### PR TITLE
Abstraction of threading primitives API 

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,11 @@ mbed TLS ChangeLog (Sorted per branch, date)
 Features
    * Allow comments in test data files.
 
+API Changes
+   * Extended threading API to allow static definition of threading primitives
+     at link time, to avoid calls to mbedtls_threading_set_alt() to initialise
+     threading.
+
 Bugfix
    * Fix memory leak in mbedtls_ssl_set_hostname() when called multiple times.
      Found by projectgus and jethrogb, #836.

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -595,24 +595,17 @@
 #error "MBEDTLS_SSL_SERVER_NAME_INDICATION defined, but not all prerequisites"
 #endif
 
-#if defined(MBEDTLS_THREADING_PTHREAD)
-#if !defined(MBEDTLS_THREADING_C) || defined(MBEDTLS_THREADING_IMPL)
+#if defined(MBEDTLS_THREADING_PTHREAD) && !defined(MBEDTLS_THREADING_C)
 #error "MBEDTLS_THREADING_PTHREAD defined, but not all prerequisites"
 #endif
-#define MBEDTLS_THREADING_IMPL
-#endif
 
-#if defined(MBEDTLS_THREADING_ALT)
-#if !defined(MBEDTLS_THREADING_C) || defined(MBEDTLS_THREADING_IMPL)
+#if defined(MBEDTLS_THREADING_ALT) && !defined(MBEDTLS_THREADING_C)
 #error "MBEDTLS_THREADING_ALT defined, but not all prerequisites"
 #endif
-#define MBEDTLS_THREADING_IMPL
-#endif
 
-#if defined(MBEDTLS_THREADING_C) && !defined(MBEDTLS_THREADING_IMPL)
-#error "MBEDTLS_THREADING_C defined, single threading implementation required"
+#if defined(MBEDTLS_THREADING_ALT) && defined(MBEDTLS_THREADING_PTHREAD)
+#error "MBEDTLS_THREADING_ALT and MBEDTLS_THREADING_PTHREAD cannot be defined simultaneously"
 #endif
-#undef MBEDTLS_THREADING_IMPL
 
 #if defined(MBEDTLS_VERSION_FEATURES) && !defined(MBEDTLS_VERSION_C)
 #error "MBEDTLS_VERSION_FEATURES defined, but not all prerequisites"

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -2231,7 +2231,7 @@
  * Enable the platform abstraction layer that allows you to re-assign
  * functions like calloc(), free(), snprintf(), printf(), fprintf(), exit().
  *
- * Enabling MBEDTLS_PLATFORM_C enables to use of MBEDTLS_PLATFORM_XXX_ALT
+ * Enabling MBEDTLS_PLATFORM_C enables use of MBEDTLS_PLATFORM_XXX_ALT
  * or MBEDTLS_PLATFORM_XXX_MACRO directives, allowing the functions mentioned
  * above to be specified at runtime or compile time respectively.
  *
@@ -2404,22 +2404,26 @@
 /**
  * \def MBEDTLS_THREADING_C
  *
- * Enable the threading abstraction layer.
+ * Enable the threading abstraction layer, to enable use of mutexes within
+ * mbed TLS.
+ *
  * By default mbed TLS assumes it is used in a non-threaded environment or that
  * contexts are not shared between threads. If you do intend to use contexts
  * between threads, you will need to enable this layer to prevent race
- * conditions. See also our Knowledge Base article about threading:
+ * conditions.
+ *
+ * See also our Knowledge Base article about threading:
  * https://tls.mbed.org/kb/development/thread-safety-and-multi-threading
  *
  * Module:  library/threading.c
  *
- * This allows different threading implementations (self-implemented or
- * provided).
+ * Enabling MBEDTLS_THREADING_C enables use of MBEDTLS_THREADING_PTHREAD,
+ * MBEDTLS_THREADING_ALT and MBEDTLS_MUTEX_XXX_MACRO directives, allowing the
+ * mutex functions to be specified at runtime or compile time.
  *
- * You will have to enable either MBEDTLS_THREADING_ALT or
- * MBEDTLS_THREADING_PTHREAD.
+ * You will have to enable either MBEDTLS_THREADING_ALT/MBEDTLS_MUTEX_XXX_MACRO
+ * or MBEDTLS_THREADING_PTHREAD.
  *
- * Enable this layer to allow use of mutexes within mbed TLS
  */
 //#define MBEDTLS_THREADING_C
 
@@ -2626,6 +2630,8 @@
 //#define MBEDTLS_PLATFORM_STD_SNPRINTF    snprintf /**< Default snprintf to use, can be undefined */
 //#define MBEDTLS_PLATFORM_STD_EXIT_SUCCESS       0 /**< Default exit value to use, can be undefined */
 //#define MBEDTLS_PLATFORM_STD_EXIT_FAILURE       1 /**< Default exit value to use, can be undefined */
+
+/* NV Seed platform operations */
 //#define MBEDTLS_PLATFORM_STD_NV_SEED_READ   mbedtls_platform_std_nv_seed_read /**< Default nv_seed_read function to use, can be undefined */
 //#define MBEDTLS_PLATFORM_STD_NV_SEED_WRITE  mbedtls_platform_std_nv_seed_write /**< Default nv_seed_write function to use, can be undefined */
 //#define MBEDTLS_PLATFORM_STD_NV_SEED_FILE  "seedfile" /**< Seed file to read/write with default implementation */
@@ -2643,6 +2649,15 @@
 //#define MBEDTLS_PLATFORM_SNPRINTF_MACRO    snprintf /**< Default snprintf macro to use, can be undefined */
 //#define MBEDTLS_PLATFORM_NV_SEED_READ_MACRO   mbedtls_platform_std_nv_seed_read /**< Default nv_seed_read function to use, can be undefined */
 //#define MBEDTLS_PLATFORM_NV_SEED_WRITE_MACRO  mbedtls_platform_std_nv_seed_write /**< Default nv_seed_write function to use, can be undefined */
+
+/* Threading/mutex operations */
+/* To use threading operations MBEDTLS_THREADING_C must be defined */
+//#define MBEDTLS_MUTEX_INIT_MACRO        mbedtls_mutex_init
+//#define MBEDTLS_MUTEX_FREE_MACRO        mbedtls_mutex_free
+//#define MBEDTLS_MUTEX_LOCK_MACRO        mbedtls_mutex_lock
+//#define MBEDTLS_MUTEX_UNLOCK_MACRO      mbedtls_mutex_unlock
+
+//#define MBEDTLS_MUTEX_INITIALIZER       { NULL }
 
 /* SSL Cache options */
 //#define MBEDTLS_SSL_CACHE_DEFAULT_TIMEOUT       86400 /**< 1 day  */

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -2231,7 +2231,7 @@
  * Enable the platform abstraction layer that allows you to re-assign
  * functions like calloc(), free(), snprintf(), printf(), fprintf(), exit().
  *
- * Enabling MBEDTLS_PLATFORM_C enables use of MBEDTLS_PLATFORM_XXX_ALT
+ * Defining MBEDTLS_PLATFORM_C enables use of MBEDTLS_PLATFORM_XXX_ALT
  * or MBEDTLS_PLATFORM_XXX_MACRO directives, allowing the functions mentioned
  * above to be specified at runtime or compile time respectively.
  *
@@ -2404,8 +2404,8 @@
 /**
  * \def MBEDTLS_THREADING_C
  *
- * Enable the threading abstraction layer, to enable use of mutexes within
- * mbed TLS.
+ * Enable the threading abstraction layer, to use mbed TLS thread-safe
+ * features.
  *
  * By default mbed TLS assumes it is used in a non-threaded environment or that
  * contexts are not shared between threads. If you do intend to use contexts
@@ -2658,6 +2658,9 @@
 //#define MBEDTLS_MUTEX_UNLOCK_MACRO      mbedtls_mutex_unlock
 
 //#define MBEDTLS_MUTEX_INITIALIZER       { NULL }
+				/**< Default static initialisation value for
+				 * each declared mbedtls_threading_mutex_t
+				 * structure used by the library. */
 
 /* SSL Cache options */
 //#define MBEDTLS_SSL_CACHE_DEFAULT_TIMEOUT       86400 /**< 1 day  */

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -2651,16 +2651,17 @@
 //#define MBEDTLS_PLATFORM_NV_SEED_WRITE_MACRO  mbedtls_platform_std_nv_seed_write /**< Default nv_seed_write function to use, can be undefined */
 
 /* Threading/mutex operations */
-/* To use threading operations MBEDTLS_THREADING_C must be defined */
+/* To define the threading operations with these macros, MBEDTLS_THREADING_C
+ * and MBEDTLS_THREADING_ALT must be defined. */
 //#define MBEDTLS_MUTEX_INIT_MACRO        mbedtls_mutex_init
 //#define MBEDTLS_MUTEX_FREE_MACRO        mbedtls_mutex_free
 //#define MBEDTLS_MUTEX_LOCK_MACRO        mbedtls_mutex_lock
 //#define MBEDTLS_MUTEX_UNLOCK_MACRO      mbedtls_mutex_unlock
 
 //#define MBEDTLS_MUTEX_INITIALIZER       { NULL }
-				/**< Default static initialisation value for
-				 * each declared mbedtls_threading_mutex_t
-				 * structure used by the library. */
+                                /**< Default static initialisation value for
+                                 * each declared mbedtls_threading_mutex_t
+                                 * structure used by the library. */
 
 /* SSL Cache options */
 //#define MBEDTLS_SSL_CACHE_DEFAULT_TIMEOUT       86400 /**< 1 day  */

--- a/include/mbedtls/threading.h
+++ b/include/mbedtls/threading.h
@@ -37,9 +37,9 @@ extern "C" {
 
 #if defined(MBEDTLS_THREADING_C)
 
-#define MBEDTLS_ERR_THREADING_FEATURE_UNAVAILABLE   0x001A
+#define MBEDTLS_ERR_THREADING_FEATURE_UNAVAILABLE   -0x001A
                             /**< The selected feature is not available. */
-#define MBEDTLS_ERR_THREADING_BAD_INPUT_DATA        0x001C
+#define MBEDTLS_ERR_THREADING_BAD_INPUT_DATA        -0x001C
                             /**< Bad input parameters to function. */
 #define MBEDTLS_ERR_THREADING_MUTEX_ERROR           -0x001E
                             /**< Locking / unlocking / free failed with
@@ -69,7 +69,7 @@ typedef struct _mbedtls_threading_mutex_t
     void* mutex;
 } mbedtls_threading_mutex_t;
 
-#endif
+#endif /* !MBEDTLS_THREADING_ALT && !MBEDTLS_THREADING_PTHREAD */
 
 #if !defined(MBEDTLS_THREADING_ALT)
 

--- a/library/threading.c
+++ b/library/threading.c
@@ -69,19 +69,13 @@ int mbedtls_mutex_unlock( mbedtls_threading_mutex_t *mutex )
     return( 0 );
 }
 
-#define MBEDTLS_MUTEX_INIT_MACRO       threading_mutex_init_pthread
-#define MBEDTLS_MUTEX_FREE_MACRO       threading_mutex_free_pthread
-#define MBEDTLS_MUTEX_LOCK_MACRO       threading_mutex_lock_pthread
-#define MBEDTLS_MUTEX_UNLOCK_MACRO     threading_mutex_unlock_pthread
-
 /*
  * With pthreads we can statically initialize mutexes
  */
 #define MBEDTLS_MUTEX_INITIALIZER      { PTHREAD_MUTEX_INITIALIZER, 1 }
 
-#endif /* MBEDTLS_THREADING_PTHREAD */
 
-#if defined(MBEDTLS_THREADING_ALT)
+#elif defined(MBEDTLS_THREADING_ALT)
 
 #if !defined(MBEDTLS_MUTEX_INIT_MACRO) && \
     !defined(MBEDTLS_MUTEX_FREE_MACRO) && \
@@ -103,7 +97,7 @@ static void threading_mutex_dummy( mbedtls_threading_mutex_t *mutex )
 #define MBEDTLS_MUTEX_INIT_MACRO      threading_mutex_dummy
 #define MBEDTLS_MUTEX_FREE_MACRO      threading_mutex_dummy
 #define MBEDTLS_MUTEX_LOCK_MACRO      threading_mutex_fail
-#define MBEDTLS_UNLOCK_FREE_MACRO     threading_mutex_fail
+#define MBEDTLS_MUTEX_UNLOCK_MACRO    threading_mutex_fail
 
 #endif /* !MBEDTLS_MUTEX_INIT_MACRO && !MBEDTLS_MUTEX_FREE_MACRO &&
         * !MBEDTLS_MUTEX_LOCK_MACRO && !MBEDTLS_UNLOCK_FREE_MACRO */
@@ -145,20 +139,20 @@ void mbedtls_threading_free_alt( void )
 }
 
 mbedtls_mutex_init_t* mbedtls_mutex_init =
-                            ( mbedtls_mutex_init_t* )MBEDTLS_MUTEX_INIT_MACRO;
+                            (mbedtls_mutex_init_t*)MBEDTLS_MUTEX_INIT_MACRO;
 mbedtls_mutex_free_t* mbedtls_mutex_free =
-                            ( mbedtls_mutex_free_t* )MBEDTLS_MUTEX_FREE_MACRO;
+                            (mbedtls_mutex_free_t*)MBEDTLS_MUTEX_FREE_MACRO;
 mbedtls_mutex_lock_t* mbedtls_mutex_lock =
-                            ( mbedtls_mutex_lock_t* )MBEDTLS_MUTEX_LOCK_MACRO;
+                            (mbedtls_mutex_lock_t*)MBEDTLS_MUTEX_LOCK_MACRO;
 mbedtls_mutex_unlock_t* mbedtls_mutex_unlock =
-                        ( mbedtls_mutex_unlock_t* )MBEDTLS_MUTEX_UNLOCK_MACRO;
+                            (mbedtls_mutex_unlock_t*)MBEDTLS_MUTEX_UNLOCK_MACRO;
 
 #endif /* MBEDTLS_THREADING_ALT */
 
 /*
  * Define global mutexes
  */
-#ifdef MBEDTLS_MUTEX_INITIALIZER
+#if defined(MBEDTLS_MUTEX_INITIALIZER)
 
 #if defined(MBEDTLS_FS_IO)
 mbedtls_threading_mutex_t mbedtls_threading_readdir_mutex = MBEDTLS_MUTEX_INITIALIZER;

--- a/library/threading.c
+++ b/library/threading.c
@@ -30,7 +30,7 @@
 #include "mbedtls/threading.h"
 
 #if defined(MBEDTLS_THREADING_PTHREAD)
-static void threading_mutex_init_pthread( mbedtls_threading_mutex_t *mutex )
+void mbedtls_mutex_init( mbedtls_threading_mutex_t *mutex )
 {
     if( mutex == NULL )
         return;
@@ -38,7 +38,7 @@ static void threading_mutex_init_pthread( mbedtls_threading_mutex_t *mutex )
     mutex->is_valid = pthread_mutex_init( &mutex->mutex, NULL ) == 0;
 }
 
-static void threading_mutex_free_pthread( mbedtls_threading_mutex_t *mutex )
+void mbedtls_mutex_free( mbedtls_threading_mutex_t *mutex )
 {
     if( mutex == NULL || !mutex->is_valid )
         return;
@@ -47,7 +47,7 @@ static void threading_mutex_free_pthread( mbedtls_threading_mutex_t *mutex )
     mutex->is_valid = 0;
 }
 
-static int threading_mutex_lock_pthread( mbedtls_threading_mutex_t *mutex )
+int mbedtls_mutex_lock( mbedtls_threading_mutex_t *mutex )
 {
     if( mutex == NULL || ! mutex->is_valid )
         return( MBEDTLS_ERR_THREADING_BAD_INPUT_DATA );
@@ -58,7 +58,7 @@ static int threading_mutex_lock_pthread( mbedtls_threading_mutex_t *mutex )
     return( 0 );
 }
 
-static int threading_mutex_unlock_pthread( mbedtls_threading_mutex_t *mutex )
+int mbedtls_mutex_unlock( mbedtls_threading_mutex_t *mutex )
 {
     if( mutex == NULL || ! mutex->is_valid )
         return( MBEDTLS_ERR_THREADING_BAD_INPUT_DATA );
@@ -75,7 +75,7 @@ static int threading_mutex_unlock_pthread( mbedtls_threading_mutex_t *mutex )
 #define MBEDTLS_MUTEX_UNLOCK_MACRO     threading_mutex_unlock_pthread
 
 /*
- * With phtreads we can statically initialize mutexes
+ * With pthreads we can statically initialize mutexes
  */
 #define MBEDTLS_MUTEX_INITIALIZER      { PTHREAD_MUTEX_INITIALIZER, 1 }
 
@@ -144,8 +144,6 @@ void mbedtls_threading_free_alt( void )
 #endif /* MBEDTLS_HAVE_TIME_DATE */
 }
 
-#endif /* MBEDTLS_THREADING_ALT */
-
 mbedtls_mutex_init_t* mbedtls_mutex_init =
                             ( mbedtls_mutex_init_t* )MBEDTLS_MUTEX_INIT_MACRO;
 mbedtls_mutex_free_t* mbedtls_mutex_free =
@@ -154,6 +152,8 @@ mbedtls_mutex_lock_t* mbedtls_mutex_lock =
                             ( mbedtls_mutex_lock_t* )MBEDTLS_MUTEX_LOCK_MACRO;
 mbedtls_mutex_unlock_t* mbedtls_mutex_unlock =
                         ( mbedtls_mutex_unlock_t* )MBEDTLS_MUTEX_UNLOCK_MACRO;
+
+#endif /* MBEDTLS_THREADING_ALT */
 
 /*
  * Define global mutexes

--- a/library/threading.c
+++ b/library/threading.c
@@ -1,5 +1,5 @@
 /*
- *  Threading abstraction layer
+ *  Threading abstraction layer - pthreads implementation
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
@@ -69,50 +69,65 @@ static int threading_mutex_unlock_pthread( mbedtls_threading_mutex_t *mutex )
     return( 0 );
 }
 
-void (*mbedtls_mutex_init)( mbedtls_threading_mutex_t * ) = threading_mutex_init_pthread;
-void (*mbedtls_mutex_free)( mbedtls_threading_mutex_t * ) = threading_mutex_free_pthread;
-int (*mbedtls_mutex_lock)( mbedtls_threading_mutex_t * ) = threading_mutex_lock_pthread;
-int (*mbedtls_mutex_unlock)( mbedtls_threading_mutex_t * ) = threading_mutex_unlock_pthread;
+#define MBEDTLS_MUTEX_INIT_MACRO       threading_mutex_init_pthread
+#define MBEDTLS_MUTEX_FREE_MACRO       threading_mutex_free_pthread
+#define MBEDTLS_MUTEX_LOCK_MACRO       threading_mutex_lock_pthread
+#define MBEDTLS_MUTEX_UNLOCK_MACRO     threading_mutex_unlock_pthread
 
 /*
  * With phtreads we can statically initialize mutexes
  */
-#define MUTEX_INIT  = { PTHREAD_MUTEX_INITIALIZER, 1 }
+#define MBEDTLS_MUTEX_INITIALIZER      { PTHREAD_MUTEX_INITIALIZER, 1 }
 
 #endif /* MBEDTLS_THREADING_PTHREAD */
 
 #if defined(MBEDTLS_THREADING_ALT)
+
+#if !defined(MBEDTLS_MUTEX_INIT_MACRO) && \
+    !defined(MBEDTLS_MUTEX_FREE_MACRO) && \
+    !defined(MBEDTLS_MUTEX_LOCK_MACRO) && \
+    !defined(MBEDTLS_UNLOCK_FREE_MACRO)
+
 static int threading_mutex_fail( mbedtls_threading_mutex_t *mutex )
 {
     ((void) mutex );
     return( MBEDTLS_ERR_THREADING_BAD_INPUT_DATA );
 }
+
 static void threading_mutex_dummy( mbedtls_threading_mutex_t *mutex )
 {
     ((void) mutex );
     return;
 }
 
-void (*mbedtls_mutex_init)( mbedtls_threading_mutex_t * ) = threading_mutex_dummy;
-void (*mbedtls_mutex_free)( mbedtls_threading_mutex_t * ) = threading_mutex_dummy;
-int (*mbedtls_mutex_lock)( mbedtls_threading_mutex_t * ) = threading_mutex_fail;
-int (*mbedtls_mutex_unlock)( mbedtls_threading_mutex_t * ) = threading_mutex_fail;
+#define MBEDTLS_MUTEX_INIT_MACRO      threading_mutex_dummy
+#define MBEDTLS_MUTEX_FREE_MACRO      threading_mutex_dummy
+#define MBEDTLS_MUTEX_LOCK_MACRO      threading_mutex_fail
+#define MBEDTLS_UNLOCK_FREE_MACRO     threading_mutex_fail
+
+#endif /* !MBEDTLS_MUTEX_INIT_MACRO && !MBEDTLS_MUTEX_FREE_MACRO &&
+        * !MBEDTLS_MUTEX_LOCK_MACRO && !MBEDTLS_UNLOCK_FREE_MACRO */
 
 /*
  * Set functions pointers and initialize global mutexes
  */
-void mbedtls_threading_set_alt( void (*mutex_init)( mbedtls_threading_mutex_t * ),
-                       void (*mutex_free)( mbedtls_threading_mutex_t * ),
-                       int (*mutex_lock)( mbedtls_threading_mutex_t * ),
-                       int (*mutex_unlock)( mbedtls_threading_mutex_t * ) )
+void mbedtls_threading_set_alt( mbedtls_mutex_init_t* mutex_init,
+                                mbedtls_mutex_free_t* mutex_free,
+                                mbedtls_mutex_lock_t* mutex_lock,
+                                mbedtls_mutex_unlock_t* mutex_unlock )
 {
     mbedtls_mutex_init = mutex_init;
     mbedtls_mutex_free = mutex_free;
     mbedtls_mutex_lock = mutex_lock;
     mbedtls_mutex_unlock = mutex_unlock;
 
+#if defined(MBEDTLS_FS_IO)
     mbedtls_mutex_init( &mbedtls_threading_readdir_mutex );
+#endif /* MBEDTLS_FS_IO */
+
+#if defined(MBEDTLS_HAVE_TIME_DATE)
     mbedtls_mutex_init( &mbedtls_threading_gmtime_mutex );
+#endif /* MBEDTLS_HAVE_TIME_DATE */
 }
 
 /*
@@ -120,18 +135,49 @@ void mbedtls_threading_set_alt( void (*mutex_init)( mbedtls_threading_mutex_t * 
  */
 void mbedtls_threading_free_alt( void )
 {
+#if defined(MBEDTLS_FS_IO)
     mbedtls_mutex_free( &mbedtls_threading_readdir_mutex );
+#endif /* MBEDTLS_FS_IO */
+
+#if defined(MBEDTLS_HAVE_TIME_DATE)
     mbedtls_mutex_free( &mbedtls_threading_gmtime_mutex );
+#endif /* MBEDTLS_HAVE_TIME_DATE */
 }
+
 #endif /* MBEDTLS_THREADING_ALT */
+
+mbedtls_mutex_init_t* mbedtls_mutex_init =
+                            ( mbedtls_mutex_init_t* )MBEDTLS_MUTEX_INIT_MACRO;
+mbedtls_mutex_free_t* mbedtls_mutex_free =
+                            ( mbedtls_mutex_free_t* )MBEDTLS_MUTEX_FREE_MACRO;
+mbedtls_mutex_lock_t* mbedtls_mutex_lock =
+                            ( mbedtls_mutex_lock_t* )MBEDTLS_MUTEX_LOCK_MACRO;
+mbedtls_mutex_unlock_t* mbedtls_mutex_unlock =
+                        ( mbedtls_mutex_unlock_t* )MBEDTLS_MUTEX_UNLOCK_MACRO;
 
 /*
  * Define global mutexes
  */
-#ifndef MUTEX_INIT
-#define MUTEX_INIT
-#endif
-mbedtls_threading_mutex_t mbedtls_threading_readdir_mutex MUTEX_INIT;
-mbedtls_threading_mutex_t mbedtls_threading_gmtime_mutex MUTEX_INIT;
+#ifdef MBEDTLS_MUTEX_INITIALIZER
+
+#if defined(MBEDTLS_FS_IO)
+mbedtls_threading_mutex_t mbedtls_threading_readdir_mutex = MBEDTLS_MUTEX_INITIALIZER;
+#endif /* MBEDTLS_FS_IO */
+
+#if defined(MBEDTLS_HAVE_TIME_DATE)
+mbedtls_threading_mutex_t mbedtls_threading_gmtime_mutex = MBEDTLS_MUTEX_INITIALIZER;
+#endif /* MBEDTLS_HAVE_TIME_DATE */
+
+#else
+
+#if defined(MBEDTLS_FS_IO)
+mbedtls_threading_mutex_t mbedtls_threading_readdir_mutex;
+#endif /* MBEDTLS_FS_IO */
+
+#if defined(MBEDTLS_HAVE_TIME_DATE)
+mbedtls_threading_mutex_t mbedtls_threading_gmtime_mutex;
+#endif /* MBEDTLS_HAVE_TIME_DATE */
+
+#endif /* MBEDTLS_MUTEX_INITIALIZER */
 
 #endif /* MBEDTLS_THREADING_C */


### PR DESCRIPTION
## Description

This PR makes several changes to improve the platform abstraction of the threading primitives:

 * allows threading functions to be defined at link time so it's not necessary to call the function `mbedtls_threading_set_alt()` to set them
 * tidies up some comments in the threading abstraction layer, removing obsolete checks in `check_config.h` 
 * changes the model of how threading primitive functions are accessed, thereby they are statically linked with `MBEDTLS_THREADING_PTHREAD` and dynamically determined for `MBEDTLS_THREADING_ALT`. This can now be extended for other implementations of the threading for other platforms.

## Status
**READY**

## Requires Backporting
 NO  

This is a functional enhancement to the API and is not appropriate to backport.

## Migrations
YES

## Additional comments
This PR replaces #697, and takes into all review feedback on that PR.

## Todos
- [ n/a] Tests
- [ n/a] Documentation
- [ DONE] Changelog updated
- [ n/a] Backported
