### PR TITLE
Fix Shared Library compilation issue with Cmake

### DIFF
--- a/ChangeLog.d/fix-windows-cmake-build-with-shared-libraries.txt
+++ b/ChangeLog.d/fix-windows-cmake-build-with-shared-libraries.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix compilation on Windows when building shared library, by setting
+     library search path to CMAKE_CURRENT_BINARY_DIR.

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -259,6 +259,7 @@ if(USE_STATIC_MBEDTLS_LIBRARY)
 endif(USE_STATIC_MBEDTLS_LIBRARY)
 
 if(USE_SHARED_MBEDTLS_LIBRARY)
+    set(CMAKE_LIBRARY_PATH ${CMAKE_CURRENT_BINARY_DIR})
     add_library(${mbedcrypto_target} SHARED ${src_crypto})
     set_target_properties(${mbedcrypto_target} PROPERTIES VERSION 3.1.0 SOVERSION 11)
     target_link_libraries(${mbedcrypto_target} PUBLIC ${libs})


### PR DESCRIPTION
## Description
Fix link error on windows using cmake, when building a shared
Set the Library path as the current Binary Dir
This PR relates to #1130
The issue reporter notes this doesn't fix the said issue. This PR fixes an issue with similar symptom

## Status
**READY**

## Requires Backporting
??


## Additional comments
CMake biuld error
Checked on linux as well

## Todos
- [ ] Tests
- [ ] Documentation
- [x] Changelog updated
- [ ] Backported


## Steps to test or reproduce
~~~
mkdir build
cd build
cmake -DENABLE_TESTING=Off -DUSE_SHARED_MBEDTLS_LIBRARY=On ..
cmake --build .
~~~
