### PR TITLE
Generate error.h automatically

### DIFF
--- a/include/mbedtls/error.h
+++ b/include/mbedtls/error.h
@@ -48,7 +48,7 @@
  * Low-level module errors (0x0002-0x007E, 0x0003-0x007F)
  *
  * Module    Nr  Codes assigned
- * BIGNUM     7  0x0002-0x0010
+ * BIGNUM     8  0x0002-0x0010
  * GCM        2  0x0012-0x0014
  * BLOWFISH   2  0x0016-0x0018
  * THREADING  3  0x001A-0x001E
@@ -56,14 +56,13 @@
  * CAMELLIA   2  0x0024-0x0026
  * XTEA       1  0x0028-0x0028
  * BASE64     2  0x002A-0x002C
- * OID        1  0x002E-0x002E   0x000B-0x000B
+ * OID        2  0x002E-0x002E   0x000B-0x000B
  * PADLOCK    1  0x0030-0x0030
  * DES        1  0x0032-0x0032
- * CTR_DBRG   4  0x0034-0x003A
- * ENTROPY    3  0x003C-0x0040   0x003D-0x003F
+ * CTR_DRBG   4  0x0034-0x003A
+ * ENTROPY    5  0x003C-0x0040   0x003D-0x003F
  * NET       11  0x0042-0x0052   0x0043-0x0045
  * ASN1       7  0x0060-0x006C
- * PBKDF2     1  0x007C-0x007C
  * HMAC_DRBG  4                  0x0003-0x0009
  * CCM        2                  0x000D-0x000F
  *
@@ -71,15 +70,15 @@
  * Name      ID  Nr of Errors
  * PEM        1  9
  * PKCS12     1  4 (Started from top)
- * X509       2  20
+ * X509       3  20
  * PKCS5      2  4 (Started from top)
  * DHM        3  9
  * PK         3  14 (Started from top)
  * RSA        4  9
  * ECP        4  8 (Started from top)
  * MD         5  4
- * CIPHER     6  6
- * SSL        6  17 (Started from top)
+ * CIPHER     6  7
+ * SSL        6  20 (Started from top)
  * SSL        7  31
  *
  * Module dependent error code (5 bits 0x.00.-0x.F8.)

--- a/include/mbedtls/error.h
+++ b/include/mbedtls/error.h
@@ -47,40 +47,40 @@
  *
  * Low-level module errors (0x0002-0x007E, 0x0003-0x007F)
  *
- * Module   Nr  Codes assigned
- * MPI       7  0x0002-0x0010
- * GCM       2  0x0012-0x0014
- * BLOWFISH  2  0x0016-0x0018
- * THREADING 3  0x001A-0x001E
- * AES       2  0x0020-0x0022
- * CAMELLIA  2  0x0024-0x0026
- * XTEA      1  0x0028-0x0028
- * BASE64    2  0x002A-0x002C
- * OID       1  0x002E-0x002E   0x000B-0x000B
- * PADLOCK   1  0x0030-0x0030
- * DES       1  0x0032-0x0032
- * CTR_DBRG  4  0x0034-0x003A
- * ENTROPY   3  0x003C-0x0040   0x003D-0x003F
- * NET      11  0x0042-0x0052   0x0043-0x0045
- * ASN1      7  0x0060-0x006C
- * PBKDF2    1  0x007C-0x007C
- * HMAC_DRBG 4  0x0003-0x0009
- * CCM       2                  0x000D-0x000F
+ * Module    Nr  Codes assigned
+ * BIGNUM     7  0x0002-0x0010
+ * GCM        2  0x0012-0x0014
+ * BLOWFISH   2  0x0016-0x0018
+ * THREADING  3  0x001A-0x001E
+ * AES        2  0x0020-0x0022
+ * CAMELLIA   2  0x0024-0x0026
+ * XTEA       1  0x0028-0x0028
+ * BASE64     2  0x002A-0x002C
+ * OID        1  0x002E-0x002E   0x000B-0x000B
+ * PADLOCK    1  0x0030-0x0030
+ * DES        1  0x0032-0x0032
+ * CTR_DBRG   4  0x0034-0x003A
+ * ENTROPY    3  0x003C-0x0040   0x003D-0x003F
+ * NET       11  0x0042-0x0052   0x0043-0x0045
+ * ASN1       7  0x0060-0x006C
+ * PBKDF2     1  0x007C-0x007C
+ * HMAC_DRBG  4                  0x0003-0x0009
+ * CCM        2                  0x000D-0x000F
  *
  * High-level module nr (3 bits - 0x0...-0x7...)
  * Name      ID  Nr of Errors
- * PEM       1   9
- * PKCS#12   1   4 (Started from top)
- * X509      2   20
- * PKCS5     2   4 (Started from top)
- * DHM       3   9
- * PK        3   14 (Started from top)
- * RSA       4   9
- * ECP       4   8 (Started from top)
- * MD        5   4
- * CIPHER    6   6
- * SSL       6   17 (Started from top)
- * SSL       7   31
+ * PEM        1  9
+ * PKCS12     1  4 (Started from top)
+ * X509       2  20
+ * PKCS5      2  4 (Started from top)
+ * DHM        3  9
+ * PK         3  14 (Started from top)
+ * RSA        4  9
+ * ECP        4  8 (Started from top)
+ * MD         5  4
+ * CIPHER     6  6
+ * SSL        6  17 (Started from top)
+ * SSL        7  31
  *
  * Module dependent error code (5 bits 0x.00.-0x.F8.)
  */

--- a/scripts/generate_errors.pl
+++ b/scripts/generate_errors.pl
@@ -3,23 +3,22 @@
 # Generate error.c
 #
 # Usage: ./generate_errors.pl or scripts/generate_errors.pl without arguments,
-# or generate_errors.pl include_dir data_dir error_file
+# or generate_errors.pl include_dir data_dir error_c [error_h]
 
+use warnings;
 use strict;
 
-my ($include_dir, $data_dir, $error_file);
+my ($include_dir, $data_dir, $error_c, $error_h) =
+  qw(include/mbedtls scripts/data_files library/error.c include/mbedtls/error.h);
 
 if( @ARGV ) {
-    die "Invalid number of arguments" if scalar @ARGV != 3;
-    ($include_dir, $data_dir, $error_file) = @ARGV;
+    die "Invalid number of arguments" if @ARGV < 3 || @ARGV > 4;
+    ($include_dir, $data_dir, $error_c) = @ARGV[1,3];
+    $error_h = @ARGV == 4 ? $ARGV[3] : "$include_dir/error.h";
 
     -d $include_dir or die "No such directory: $include_dir\n";
     -d $data_dir or die "No such directory: $data_dir\n";
 } else {
-    $include_dir = 'include/mbedtls';
-    $data_dir = 'scripts/data_files';
-    $error_file = 'library/error.c';
-
     unless( -d $include_dir && -d $data_dir ) {
         chdir '..' or die;
         -d $include_dir && -d $data_dir
@@ -46,6 +45,44 @@ close(FORMAT_FILE);
 
 $/ = $line_separator;
 
+=comment
+open(ERROR_H, "<", $error_h) or die "Opening error.h";
+my %sets;
+my $section == 0;
+while (my $line = <ERROR_H>)
+{
+    if ($line =~ /^[ *]+Module\s+Nr\s+Codes/)
+    {
+        $section = 1;
+        next;
+    }
+    elsif ($line =~ /^[ *]+High-level module/../^[ *]*$/)
+    {
+        $section = 2;
+        next;
+    }
+    elsif ($line =~ /^[ *]*$/)
+    {
+        $section = 0;
+        next;
+    }
+    if ($section == 1 &&
+        $line =~ /^[ *]+(\w+)
+                   \s+([0-9]+)
+                   ((?:\s+0x[[:xdigit:]]{4}-0x[[:xdigit:]]{4})+)/ix)
+    {
+        my ($module, $nr, $codes) = ($1, $2, $3);
+    }
+    if ($section == 2 &&
+        $line =~ /^[ *]+(\w+)\s+([0-9]+)\s+([0-9]+)\s*(.*top)?/)
+    {
+        my ($module, $id, $nr) = ($1, $2, $3);
+    }
+}
+close(ERROR_H);
+
+=cut
+
 open(GREP, "grep \"define MBEDTLS_ERR_\" $include_dir/* |") || die("Failure when calling grep: $!");
 
 my $ll_old_define = "";
@@ -62,10 +99,11 @@ while (my $line = <GREP>)
 {
     next if ($line =~ /compat-1.2.h/);
     my ($error_name, $error_code) = $line =~ /(MBEDTLS_ERR_\w+)\s+\-(0x\w+)/;
+    my $error_number = hex($error_code);
     my ($description) = $line =~ /\/\*\*< (.*?)\.? \*\//;
 
     die "Duplicated error code: $error_code ($error_name)\n"
-        if( $error_codes_seen{$error_code}++ );
+        if exists $error_codes_seen{$error_number};
 
     $description =~ s/\\/\\\\/g;
     if ($description eq "") {
@@ -79,6 +117,8 @@ while (my $line = <GREP>)
     $module_name = "BIGNUM" if ($module_name eq "MPI");
     $module_name = "CTR_DRBG" if ($module_name eq "CTR");
     $module_name = "HMAC_DRBG" if ($module_name eq "HMAC");
+
+    $error_codes_seen{$error_number} = $module_name;
 
     my $define_name = $module_name;
     $define_name = "X509_USE,X509_CREATE" if ($define_name eq "X509");
@@ -97,7 +137,7 @@ while (my $line = <GREP>)
     my $found_hl = grep $_ eq $module_name, @high_level_modules;
     if (!$found_ll && !$found_hl)
     {
-        printf("Error: Do not know how to handle: $module_name\n");
+        printf STDERR ("Error: unknown module name: $module_name\n");
         exit 1;
     }
 
@@ -108,12 +148,23 @@ while (my $line = <GREP>)
 
     if ($found_ll)
     {
+        if ($error_number < 1 || $error_number > 0x7f)
+        {
+            printf STDERR ("Error: invalid low-level error code $error_code ($error_name)\n");
+            exit 1;
+        }
         $code_check = \$ll_code_check;
         $old_define = \$ll_old_define;
         $white_space = '    ';
     }
     else
     {
+        if ($error_number == 0 || $error_number > 0x7fff ||
+            ($error_number & 0x7f) != 0)
+        {
+            printf STDERR ("Error: invalid high-level error code $error_code ($error_name)\n");
+            exit 1;
+        }
         $code_check = \$hl_code_check;
         $old_define = \$hl_old_define;
         $white_space = '        ';
@@ -164,7 +215,8 @@ while (my $line = <GREP>)
         ${$code_check} .= "${white_space}if( use_ret == -($error_name) )\n".
                           "${white_space}    mbedtls_snprintf( buf, buflen, \"$module_name - $description\" );\n"
     }
-};
+}
+close GREP or die "Error reading include files: $!";
 
 if ($ll_old_define ne "")
 {
@@ -193,6 +245,110 @@ $error_format =~ s/HEADER_INCLUDED\n/$headers/g;
 $error_format =~ s/LOW_LEVEL_CODE_CHECKS\n/$ll_code_check/g;
 $error_format =~ s/HIGH_LEVEL_CODE_CHECKS\n/$hl_code_check/g;
 
-open(ERROR_FILE, ">$error_file") or die "Opening destination file '$error_file': $!";
-print ERROR_FILE $error_format;
-close(ERROR_FILE);
+open(ERROR_FILE, ">$error_c") or die "Opening destination file '$error_c': $!";
+print ERROR_FILE $error_format or die "Writing '$error_c': $!";
+close(ERROR_FILE) or die "Closing '$error_c': $!";
+
+sub check_range
+{
+    return if @_ <= 3;
+    my $name = shift @_;
+    my $min = shift @_;
+    my $max = pop @_;
+    foreach my $x (@_)
+    {
+        if ($x < $min || $x > $max)
+        {
+            printf STDERR ("%s (0x%04x) out of range 0x%04x-0x%04x\n",
+                           $name, $x, $min, $max);
+            exit 1;
+        }
+    }
+}
+
+my %h_low_entries;
+my %h_high_entries;
+foreach my $value (keys %error_codes_seen)
+{
+    my $name = $error_codes_seen{$value};
+    if ($value <= 0x7f)
+    {
+        $h_low_entries{$name} = {nr=>0, even=>[], odd=>[]}
+            unless exists $h_low_entries{$name};
+        ++$h_low_entries{$name}{nr};
+        push @{$h_low_entries{$name}{($value & 1 ? 'odd' : 'even')}}, $value;
+    }
+    else
+    {
+        if ($name eq 'SSL' && $value >= 0x7000)
+        {
+            # Hack because SSL occupies two high-level module IDs
+            $name = 'SSL ';
+        }
+        $h_high_entries{$name} = {nr=>0, codes=>[]}
+            unless exists $h_high_entries{$name};
+        ++$h_high_entries{$name}{nr};
+        push @{$h_high_entries{$name}{codes}}, $value;
+    }
+}
+foreach my $name (keys %h_low_entries)
+{
+    my $entry = $h_low_entries{$name};
+    my @even = sort {$a <=> $b} @{$entry->{even}};
+    my @odd = sort {$a <=> $b} @{$entry->{odd}};
+    check_range($name, @even);
+    check_range($name, @odd);
+    $entry->{ranges} = (@even ?
+                        sprintf("0x%04X-0x%04X", $even[0], $even[@even-1]) :
+                        "             ");
+    $entry->{ranges} .= sprintf("   0x%04X-0x%04X", $odd[0], $odd[@odd-1])
+        if @odd;
+    $entry->{sort_key} = $entry->{ranges};
+    $entry->{sort_key} =~ s/\A /~/;
+}
+foreach my $name (keys %h_high_entries)
+{
+    my $entry = $h_high_entries{$name};
+    my @codes = sort {$a <=> $b} @{$entry->{codes}};
+    check_range($name, @codes);
+    $entry->{id} = $codes[@codes-1] >> 12;
+    $entry->{comment} = (($codes[0] & 0xf80) == 0x080 ? '' :
+                         ($codes[@codes-1] & 0xf80) == 0xf80 ?
+                         ' (Started from top)' :
+                         ' (Started from middle)');
+    $entry->{sort_key} = sprintf("%04x", $codes[0]);
+}
+my $h_low_text =
+    join('',
+         map {sprintf(" * %-9s %2d  %s\n", $_,
+                      $h_low_entries{$_}{nr},
+                      $h_low_entries{$_}{ranges})}
+         sort {$h_low_entries{$a}{sort_key} cmp $h_low_entries{$b}{sort_key}}
+         keys %h_low_entries);
+my $h_high_text =
+    join('',
+         map {sprintf(" * %-9s %2d  %d%s\n", $_,
+                      $h_high_entries{$_}{id},
+                      $h_high_entries{$_}{nr},
+                      $h_high_entries{$_}{comment})}
+         sort {$h_high_entries{$a}{sort_key} cmp $h_high_entries{$b}{sort_key}}
+         keys %h_high_entries);
+
+open(ERROR_FILE, "+<$error_h") or die "Opening destination file '$error_h': $!";
+my $h_content = do { local $/ = undef; <ERROR_FILE> };
+unless ($h_content =~ s{(\n \*\s+Module\s+Nr\s+Codes.*\n)(?: \* .*\n)*( \*\n)}
+                       {$1$h_low_text$2})
+{
+    printf STDERR ("Error: comment with low-level ranges not found in '$error_h'\n");
+    exit 1;
+}
+unless ($h_content =~ s{(\n \*\s+Name\s+ID\s+N.*\n)(?: \* .*\n)*( \*\n)}
+                       {$1$h_high_text$2})
+{
+    printf STDERR ("Error: comment with high-level ranges not found in '$error_h'\n");
+    exit 1;
+}
+seek ERROR_FILE, 0, 0 or die "Seeking in '$error_h': #$!";
+truncate ERROR_FILE, 0 or die "Truncating '$error_h': $!";
+print ERROR_FILE $h_content or die "Writing '$error_h': $!";
+close(ERROR_FILE) or die "Closing '$error_h': $!";

--- a/tests/scripts/check-generated-files.sh
+++ b/tests/scripts/check-generated-files.sh
@@ -11,14 +11,18 @@ fi
 
 check()
 {
-    FILE=$1
-    SCRIPT=$2
+    SCRIPT=$1
+    shift
 
-    cp $FILE $FILE.bak
-    $SCRIPT
-    diff $FILE $FILE.bak
-    mv $FILE.bak $FILE
+    for FILE; do
+        cp "$FILE" "$FILE.bak"
+    done
+    "$SCRIPT"
+    for FILE; do
+        diff "$FILE" "$FILE.bak"
+        mv "$FILE.bak" "$FILE"
+    done
 }
 
-check library/error.c scripts/generate_errors.pl
-check library/version_features.c scripts/generate_features.pl
+check scripts/generate_errors.pl library/error.c include/mbedtls/error.h
+check scripts/generate_features.pl library/version_features.c


### PR DESCRIPTION
There is an overview of error codes in a comment in `include/mbedtls/error.h`. This overview has been out of synch for a long time. This PR enhances `scripts/generate_errors.pl` to update `include/mbedtls/error.h` in addition to `library/error.c`.

The script contains quirks to preserve the current format of `error.h`. It could be simplified if we decide to format the information differently.

Backports: #1205 #1206
