### PR TITLE
Allow caching data for AES GCM

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "C_Cpp.dimInactiveRegions": false
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "C_Cpp.dimInactiveRegions": false
-}

--- a/library/cipher.c
+++ b/library/cipher.c
@@ -744,6 +744,21 @@ int mbedtls_cipher_finish( mbedtls_cipher_context_t *ctx,
         return( 0 );
     }
 
+/*
+ * Process cache data if there is some
+ */
+#if defined(MBEDTLS_MODE_GCM)
+    if( ctx->unprocessed_len != 0 )
+    {
+        if( 0 != ( ret = mbedtls_gcm_update( (mbedtls_gcm_context *) ctx->cipher_ctx,
+                ctx->unprocessed_len, ctx->unprocessed_data, output ) ) )
+        {
+            return( ret );
+        }
+    }
+    return( 0 );
+#endif
+
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
     if( MBEDTLS_MODE_CBC == ctx->cipher_info->mode )
     {

--- a/library/cipher.c
+++ b/library/cipher.c
@@ -323,7 +323,7 @@ int mbedtls_cipher_update( mbedtls_cipher_context_t *ctx, const unsigned char *i
                     copy_len );
 
             if( 0 != ( ret = mbedtls_gcm_update( (mbedtls_gcm_context *) ctx->cipher_ctx,
-                    ilen, ctx->unprocessed_data, output ) ) )
+                    block_size, ctx->unprocessed_data, output ) ) )
             {
                 return( ret );
             }
@@ -371,7 +371,7 @@ int mbedtls_cipher_update( mbedtls_cipher_context_t *ctx, const unsigned char *i
 
         return ( 0 );
     }
-#endif
+#endif /* MBEDTLS_GCM_C */
 
     if ( 0 == block_size )
     {
@@ -745,7 +745,6 @@ int mbedtls_cipher_finish( mbedtls_cipher_context_t *ctx,
     if( MBEDTLS_MODE_GCM == ctx->cipher_info->mode )
     {
         int ret = 0;
-
         if( ctx->unprocessed_len != 0 )
         {
             if( 0 != ( ret = mbedtls_gcm_update( (mbedtls_gcm_context *) ctx->cipher_ctx,

--- a/library/cipher.c
+++ b/library/cipher.c
@@ -742,6 +742,7 @@ int mbedtls_cipher_finish( mbedtls_cipher_context_t *ctx,
     /*
     * Process cache data if there is some
     */
+#if defined(MBEDTLS_GCM_C)
     if( MBEDTLS_MODE_GCM == ctx->cipher_info->mode )
     {
         int ret = 0;
@@ -759,6 +760,7 @@ int mbedtls_cipher_finish( mbedtls_cipher_context_t *ctx,
 
         return( 0 );
     }
+#endif /* MBEDTL_GCM_C */
 
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
     if( MBEDTLS_MODE_CBC == ctx->cipher_info->mode )

--- a/tests/suites/test_suite_cipher.function
+++ b/tests/suites/test_suite_cipher.function
@@ -731,3 +731,122 @@ void check_padding( int pad_mode, char *input_str, int ret, int dlen_check )
         TEST_ASSERT( dlen == (size_t) dlen_check );
 }
 /* END_CASE */
+
+/* BEGIN_CASE */
+void enc_dec_buf_multipart_different_size( int cipher_id, int key_len, int first_length_enc_val,
+                            int second_length_enc_val, int first_length_dec_val, int second_length_dec_val, 
+                            int pad_mode, int first_encrypt_output_len, int second_encrypt_output_len,
+                            int first_decrypt_output_len, int second_decrypt_output_len )
+{
+    size_t first_length_enc = first_length_enc_val;
+    size_t second_length_enc = second_length_enc_val;
+    size_t first_length_dec = first_length_dec_val;
+    size_t second_length_dec = second_length_dec_val;
+
+    TEST_ASSERT( ( first_length_enc + second_length_enc ) == ( first_length_dec + second_length_dec ) );
+
+    size_t length = first_length_enc + second_length_enc;
+    size_t block_size;
+    unsigned char key[32];
+    unsigned char iv[16];
+
+    mbedtls_cipher_context_t ctx_dec;
+    mbedtls_cipher_context_t ctx_enc;
+    const mbedtls_cipher_info_t *cipher_info;
+
+    unsigned char inbuf[64];
+    unsigned char encbuf[64];
+    unsigned char decbuf[64];
+
+    size_t outlen = 0;
+    size_t totaloutlen = 0;
+
+    memset( key, 0, 32 );
+    memset( iv , 0, 16 );
+
+    mbedtls_cipher_init( &ctx_dec );
+    mbedtls_cipher_init( &ctx_enc );
+
+    memset( inbuf, 5, 64 );
+    memset( encbuf, 0, 64 );
+    memset( decbuf, 0, 64 );
+
+    /* Initialise enc and dec contexts */
+    cipher_info = mbedtls_cipher_info_from_type( cipher_id );
+    TEST_ASSERT( NULL != cipher_info);
+
+    TEST_ASSERT( 0 == mbedtls_cipher_setup( &ctx_dec, cipher_info ) );
+    TEST_ASSERT( 0 == mbedtls_cipher_setup( &ctx_enc, cipher_info ) );
+
+    TEST_ASSERT( 0 == mbedtls_cipher_setkey( &ctx_dec, key, key_len, MBEDTLS_DECRYPT ) );
+    TEST_ASSERT( 0 == mbedtls_cipher_setkey( &ctx_enc, key, key_len, MBEDTLS_ENCRYPT ) );
+
+#if defined(MBEDTLS_CIPHER_MODE_WITH_PADDING)
+    if( -1 != pad_mode )
+    {
+        TEST_ASSERT( 0 == mbedtls_cipher_set_padding_mode( &ctx_dec, pad_mode ) );
+        TEST_ASSERT( 0 == mbedtls_cipher_set_padding_mode( &ctx_enc, pad_mode ) );
+    }
+#else
+    (void) pad_mode;
+#endif /* MBEDTLS_CIPHER_MODE_WITH_PADDING */
+
+    TEST_ASSERT( 0 == mbedtls_cipher_set_iv( &ctx_dec, iv, 16 ) );
+    TEST_ASSERT( 0 == mbedtls_cipher_set_iv( &ctx_enc, iv, 16 ) );
+
+    TEST_ASSERT( 0 == mbedtls_cipher_reset( &ctx_dec ) );
+    TEST_ASSERT( 0 == mbedtls_cipher_reset( &ctx_enc ) );
+
+#if defined(MBEDTLS_GCM_C)
+    TEST_ASSERT( 0 == mbedtls_cipher_update_ad( &ctx_dec, NULL, 0 ) );
+    TEST_ASSERT( 0 == mbedtls_cipher_update_ad( &ctx_enc, NULL, 0 ) );
+#endif
+
+    block_size = mbedtls_cipher_get_block_size( &ctx_enc );
+    TEST_ASSERT( block_size != 0 );
+
+    /* encode length number of bytes from inbuf */
+    TEST_ASSERT( 0 == mbedtls_cipher_update( &ctx_enc, inbuf, first_length_enc, encbuf, &outlen ) );
+    TEST_ASSERT( (size_t)first_encrypt_output_len == outlen );
+    totaloutlen = outlen;
+    TEST_ASSERT( 0 == mbedtls_cipher_update( &ctx_enc, inbuf + first_length_enc, second_length_enc, encbuf + totaloutlen, &outlen ) );
+    TEST_ASSERT( (size_t)second_encrypt_output_len == outlen );
+    totaloutlen += outlen;
+    TEST_ASSERT( totaloutlen == length ||
+                 ( totaloutlen % block_size == 0 &&
+                   totaloutlen < length &&
+                   totaloutlen + block_size > length ) );
+
+    TEST_ASSERT( 0 == mbedtls_cipher_finish( &ctx_enc, encbuf + totaloutlen, &outlen ) );
+    totaloutlen += outlen;
+    TEST_ASSERT( totaloutlen == length ||
+                 ( totaloutlen % block_size == 0 &&
+                   totaloutlen > length &&
+                   totaloutlen <= length + block_size ) );
+
+    /* decode the previously encoded string */
+    second_length_dec = totaloutlen - first_length_dec;
+    TEST_ASSERT( 0 == mbedtls_cipher_update( &ctx_dec, encbuf, first_length_dec, decbuf, &outlen ) );
+    TEST_ASSERT( (size_t)first_decrypt_output_len == outlen );
+    totaloutlen = outlen;
+    TEST_ASSERT( 0 == mbedtls_cipher_update( &ctx_dec, encbuf + first_length_dec, second_length_dec, decbuf + totaloutlen, &outlen ) );
+    TEST_ASSERT( (size_t)second_decrypt_output_len == outlen );
+    totaloutlen += outlen;
+
+    TEST_ASSERT( totaloutlen == length ||
+                 ( totaloutlen % block_size == 0 &&
+                   totaloutlen < length &&
+                   totaloutlen + block_size >= length ) );
+
+    TEST_ASSERT( 0 == mbedtls_cipher_finish( &ctx_dec, decbuf + totaloutlen, &outlen ) );
+    totaloutlen += outlen;
+
+    TEST_ASSERT( totaloutlen == length );
+
+    TEST_ASSERT( 0 == memcmp(inbuf, decbuf, length) );
+
+exit:
+    mbedtls_cipher_free( &ctx_dec );
+    mbedtls_cipher_free( &ctx_enc );
+}
+/* END_CASE */

--- a/tests/suites/test_suite_cipher.function
+++ b/tests/suites/test_suite_cipher.function
@@ -738,15 +738,10 @@ void enc_dec_buf_multipart_different_size( int cipher_id, int key_len, int first
                             int pad_mode, int first_encrypt_output_len, int second_encrypt_output_len,
                             int first_decrypt_output_len, int second_decrypt_output_len )
 {
-    size_t first_length_enc = first_length_enc_val;
-    size_t second_length_enc = second_length_enc_val;
-    size_t first_length_dec = first_length_dec_val;
-    size_t second_length_dec = second_length_dec_val;
-
-    TEST_ASSERT( ( first_length_enc + second_length_enc ) == ( first_length_dec + second_length_dec ) );
-
-    size_t length = first_length_enc + second_length_enc;
     size_t block_size;
+    size_t length;
+    size_t outlen;
+    size_t totaloutlen;
     unsigned char key[32];
     unsigned char iv[16];
 
@@ -758,8 +753,16 @@ void enc_dec_buf_multipart_different_size( int cipher_id, int key_len, int first
     unsigned char encbuf[64];
     unsigned char decbuf[64];
 
-    size_t outlen = 0;
-    size_t totaloutlen = 0;
+    size_t first_length_enc = first_length_enc_val;
+    size_t second_length_enc = second_length_enc_val;
+    size_t first_length_dec = first_length_dec_val;
+    size_t second_length_dec = second_length_dec_val;
+
+    TEST_ASSERT( ( first_length_enc + second_length_enc ) == ( first_length_dec + second_length_dec ) );
+
+    length = first_length_enc + second_length_enc;
+    outlen = 0;
+    totaloutlen = 0;
 
     memset( key, 0, 32 );
     memset( iv , 0, 16 );

--- a/tests/suites/test_suite_cipher.function
+++ b/tests/suites/test_suite_cipher.function
@@ -734,7 +734,7 @@ void check_padding( int pad_mode, char *input_str, int ret, int dlen_check )
 
 /* BEGIN_CASE */
 void enc_dec_buf_multipart_different_size( int cipher_id, int key_len, int first_length_enc_val,
-                            int second_length_enc_val, int first_length_dec_val, int second_length_dec_val, 
+                            int second_length_enc_val, int first_length_dec_val, int second_length_dec_val,
                             int pad_mode, int first_encrypt_output_len, int second_encrypt_output_len,
                             int first_decrypt_output_len, int second_decrypt_output_len )
 {
@@ -757,7 +757,8 @@ void enc_dec_buf_multipart_different_size( int cipher_id, int key_len, int first
     first_length_dec = first_length_dec_val;
     second_length_dec = second_length_dec_val;
 
-    TEST_ASSERT( ( first_length_enc + second_length_enc ) == ( first_length_dec + second_length_dec ) );
+    TEST_ASSERT( ( first_length_enc + second_length_enc ) == 
+        ( first_length_dec + second_length_dec ) );
 
     length = first_length_enc + second_length_enc;
     outlen = 0;
@@ -811,7 +812,8 @@ void enc_dec_buf_multipart_different_size( int cipher_id, int key_len, int first
     TEST_ASSERT( 0 == mbedtls_cipher_update( &ctx_enc, inbuf, first_length_enc, encbuf, &outlen ) );
     TEST_ASSERT( (size_t)first_encrypt_output_len == outlen );
     totaloutlen = outlen;
-    TEST_ASSERT( 0 == mbedtls_cipher_update( &ctx_enc, inbuf + first_length_enc, second_length_enc, encbuf + totaloutlen, &outlen ) );
+    TEST_ASSERT( 0 == mbedtls_cipher_update( &ctx_enc, inbuf + first_length_enc,
+         second_length_enc, encbuf + totaloutlen, &outlen ) );
     TEST_ASSERT( (size_t)second_encrypt_output_len == outlen );
     totaloutlen += outlen;
     TEST_ASSERT( totaloutlen == length ||
@@ -831,7 +833,8 @@ void enc_dec_buf_multipart_different_size( int cipher_id, int key_len, int first
     TEST_ASSERT( 0 == mbedtls_cipher_update( &ctx_dec, encbuf, first_length_dec, decbuf, &outlen ) );
     TEST_ASSERT( (size_t)first_decrypt_output_len == outlen );
     totaloutlen = outlen;
-    TEST_ASSERT( 0 == mbedtls_cipher_update( &ctx_dec, encbuf + first_length_dec, second_length_dec, decbuf + totaloutlen, &outlen ) );
+    TEST_ASSERT( 0 == mbedtls_cipher_update( &ctx_dec, encbuf + first_length_dec, 
+        second_length_dec, decbuf + totaloutlen, &outlen ) );
     TEST_ASSERT( (size_t)second_decrypt_output_len == outlen );
     totaloutlen += outlen;
 

--- a/tests/suites/test_suite_cipher.function
+++ b/tests/suites/test_suite_cipher.function
@@ -739,9 +739,8 @@ void enc_dec_buf_multipart_different_size( int cipher_id, int key_len, int first
                             int first_decrypt_output_len, int second_decrypt_output_len )
 {
     size_t block_size;
-    size_t length;
-    size_t outlen;
-    size_t totaloutlen;
+    size_t length, outlen, totaloutlen;
+    size_t first_length_enc, second_length_enc, first_length_dec, second_length_dec;
     unsigned char key[32];
     unsigned char iv[16];
 
@@ -753,10 +752,10 @@ void enc_dec_buf_multipart_different_size( int cipher_id, int key_len, int first
     unsigned char encbuf[64];
     unsigned char decbuf[64];
 
-    size_t first_length_enc = first_length_enc_val;
-    size_t second_length_enc = second_length_enc_val;
-    size_t first_length_dec = first_length_dec_val;
-    size_t second_length_dec = second_length_dec_val;
+    first_length_enc = first_length_enc_val;
+    second_length_enc = second_length_enc_val;
+    first_length_dec = first_length_dec_val;
+    second_length_dec = second_length_dec_val;
 
     TEST_ASSERT( ( first_length_enc + second_length_enc ) == ( first_length_dec + second_length_dec ) );
 

--- a/tests/suites/test_suite_cipher.function
+++ b/tests/suites/test_suite_cipher.function
@@ -757,7 +757,7 @@ void enc_dec_buf_multipart_different_size( int cipher_id, int key_len, int first
     first_length_dec = first_length_dec_val;
     second_length_dec = second_length_dec_val;
 
-    TEST_ASSERT( ( first_length_enc + second_length_enc ) == 
+    TEST_ASSERT( ( first_length_enc + second_length_enc ) ==
         ( first_length_dec + second_length_dec ) );
 
     length = first_length_enc + second_length_enc;
@@ -833,7 +833,7 @@ void enc_dec_buf_multipart_different_size( int cipher_id, int key_len, int first
     TEST_ASSERT( 0 == mbedtls_cipher_update( &ctx_dec, encbuf, first_length_dec, decbuf, &outlen ) );
     TEST_ASSERT( (size_t)first_decrypt_output_len == outlen );
     totaloutlen = outlen;
-    TEST_ASSERT( 0 == mbedtls_cipher_update( &ctx_dec, encbuf + first_length_dec, 
+    TEST_ASSERT( 0 == mbedtls_cipher_update( &ctx_dec, encbuf + first_length_dec,
         second_length_dec, decbuf + totaloutlen, &outlen ) );
     TEST_ASSERT( (size_t)second_decrypt_output_len == outlen );
     totaloutlen += outlen;

--- a/tests/suites/test_suite_cipher.gcm.data
+++ b/tests/suites/test_suite_cipher.gcm.data
@@ -94,6 +94,14 @@ AES 128 GCM Encrypt and decrypt 32 bytes in different parts 1
 depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
 enc_dec_buf_multipart_different_size:MBEDTLS_CIPHER_AES_128_GCM:128:28:4:4:28:-1:16:16:0:32
 
+AES 128 GCM Encrypt and decrypt 22 bytes in different parts 2
+depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
+enc_dec_buf_multipart_different_size:MBEDTLS_CIPHER_AES_128_GCM:128:17:5:8:14:-1:16:0:0:16
+
+AES 128 GCM Encrypt and decrypt 60 bytes in different parts 3
+depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
+enc_dec_buf_multipart_different_size:MBEDTLS_CIPHER_AES_128_GCM:128:33:27:18:42:-1:32:16:16:32
+
 AES 128 GCM Decrypt test vector #1
 depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
 decrypt_test_vec:MBEDTLS_CIPHER_AES_128_GCM:-1:"d785dafea3e966731ef6fc6202262584":"d91a46205ee94058b3b8403997592dd2":"":"":"":"3b92a17c1b9c3578a68cffea5a5b6245":0:0
@@ -222,6 +230,18 @@ AES 192 GCM Encrypt and decrypt 32 bytes in multiple parts 1
 depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
 enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_192_GCM:192:16:16:-1:16:16:16:16
 
+AES 192 GCM Encrypt and decrypt 32 bytes in different parts 1
+depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
+enc_dec_buf_multipart_different_size:MBEDTLS_CIPHER_AES_192_GCM:192:28:4:4:28:-1:16:16:0:32
+
+AES 192 GCM Encrypt and decrypt 22 bytes in different parts 2
+depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
+enc_dec_buf_multipart_different_size:MBEDTLS_CIPHER_AES_192_GCM:192:17:5:8:14:-1:16:0:0:16
+
+AES 192 GCM Encrypt and decrypt 60 bytes in different parts 3
+depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
+enc_dec_buf_multipart_different_size:MBEDTLS_CIPHER_AES_192_GCM:192:33:27:18:42:-1:32:16:16:32
+
 AES 192 GCM Decrypt test vector #1
 depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
 decrypt_test_vec:MBEDTLS_CIPHER_AES_192_GCM:-1:"806766a4d2b6507cc4113bc0e46eebe120eacd948c24dc7f":"4f801c772395c4519ec830980c8ca5a4":"":"":"":"8fa16452b132bebc6aa521e92cb3b0ea":0:MBEDTLS_ERR_CIPHER_AUTH_FAILED
@@ -337,6 +357,18 @@ enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_256_GCM:256:0:22:-1:0:16:0:16
 AES 256 GCM Encrypt and decrypt 32 bytes in multiple parts 1
 depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
 enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_256_GCM:256:16:16:-1:16:16:16:16
+
+AES 256 GCM Encrypt and decrypt 32 bytes in different parts 1
+depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
+enc_dec_buf_multipart_different_size:MBEDTLS_CIPHER_AES_256_GCM:256:28:4:4:28:-1:16:16:0:32
+
+AES 256 GCM Encrypt and decrypt 22 bytes in different parts 2
+depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
+enc_dec_buf_multipart_different_size:MBEDTLS_CIPHER_AES_256_GCM:256:17:5:8:14:-1:16:0:0:16
+
+AES 256 GCM Encrypt and decrypt 60 bytes in different parts 3
+depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
+enc_dec_buf_multipart_different_size:MBEDTLS_CIPHER_AES_256_GCM:256:33:27:18:42:-1:32:16:16:32
 
 AES 128 GCM Decrypt test vector #0
 depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C

--- a/tests/suites/test_suite_cipher.gcm.data
+++ b/tests/suites/test_suite_cipher.gcm.data
@@ -64,11 +64,11 @@ enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_GCM:128:0:0:-1:0:0:0:0
 
 AES 128 GCM Encrypt and decrypt 1 bytes in multiple parts 1
 depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_GCM:128:1:0:-1:1:0:1:0
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_GCM:128:1:0:-1:0:0:0:0
 
 AES 128 GCM Encrypt and decrypt 1 bytes in multiple parts 2
 depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_GCM:128:0:1:-1:0:1:0:1
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_GCM:128:0:1:-1:0:0:0:0
 
 AES 128 GCM Encrypt and decrypt 16 bytes in multiple parts 1
 depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
@@ -80,11 +80,11 @@ enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_GCM:128:0:16:-1:0:16:0:16
 
 AES 128 GCM Encrypt and decrypt 22 bytes in multiple parts 1
 depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_GCM:128:16:6:-1:16:6:16:6
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_GCM:128:16:6:-1:16:0:16:0
 
 AES 128 GCM Encrypt and decrypt 22 bytes in multiple parts 2
 depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_GCM:128:0:22:-1:0:22:0:22
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_GCM:128:0:22:-1:0:16:0:16
 
 AES 128 GCM Encrypt and decrypt 32 bytes in multiple parts 1
 depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
@@ -192,11 +192,11 @@ enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_192_GCM:192:0:0:-1:0:0:0:0
 
 AES 192 GCM Encrypt and decrypt 1 bytes in multiple parts 1
 depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_192_GCM:192:1:0:-1:1:0:1:0
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_192_GCM:192:1:0:-1:0:0:0:0
 
 AES 192 GCM Encrypt and decrypt 1 bytes in multiple parts 2
 depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_192_GCM:192:0:1:-1:0:1:0:1
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_192_GCM:192:0:1:-1:0:0:0:0
 
 AES 192 GCM Encrypt and decrypt 16 bytes in multiple parts 1
 depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
@@ -208,11 +208,11 @@ enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_192_GCM:192:0:16:-1:0:16:0:16
 
 AES 192 GCM Encrypt and decrypt 22 bytes in multiple parts 1
 depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_192_GCM:192:16:6:-1:16:6:16:6
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_192_GCM:192:16:6:-1:16:0:16:0
 
 AES 192 GCM Encrypt and decrypt 22 bytes in multiple parts 2
 depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_192_GCM:192:0:22:-1:0:22:0:22
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_192_GCM:192:0:22:-1:0:16:0:16
 
 AES 192 GCM Encrypt and decrypt 32 bytes in multiple parts 1
 depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
@@ -308,11 +308,11 @@ enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_256_GCM:256:0:0:-1:0:0:0:0
 
 AES 256 GCM Encrypt and decrypt 1 bytes in multiple parts 1
 depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_256_GCM:256:1:0:-1:1:0:1:0
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_256_GCM:256:1:0:-1:0:0:0:0
 
 AES 256 GCM Encrypt and decrypt 1 bytes in multiple parts 2
 depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_256_GCM:256:0:1:-1:0:1:0:1
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_256_GCM:256:0:1:-1:0:0:0:0
 
 AES 256 GCM Encrypt and decrypt 16 bytes in multiple parts 1
 depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
@@ -324,11 +324,11 @@ enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_256_GCM:256:0:16:-1:0:16:0:16
 
 AES 256 GCM Encrypt and decrypt 22 bytes in multiple parts 1
 depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_256_GCM:256:16:6:-1:16:6:16:6
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_256_GCM:256:16:6:-1:16:0:16:0
 
 AES 256 GCM Encrypt and decrypt 22 bytes in multiple parts 2
 depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_256_GCM:256:0:22:-1:0:22:0:22
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_256_GCM:256:0:22:-1:0:16:0:16
 
 AES 256 GCM Encrypt and decrypt 32 bytes in multiple parts 1
 depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
@@ -432,11 +432,11 @@ enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_GCM:128:0:0:-1:0:0:0:0
 
 CAMELLIA 128 GCM Encrypt and decrypt 1 bytes in multiple parts 1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_GCM:128:1:0:-1:1:0:1:0
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_GCM:128:1:0:-1:0:0:0:0
 
 CAMELLIA 128 GCM Encrypt and decrypt 1 bytes in multiple parts 2
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_GCM:128:0:1:-1:0:1:0:1
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_GCM:128:0:1:-1:0:0:0:0
 
 CAMELLIA 128 GCM Encrypt and decrypt 16 bytes in multiple parts 1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_GCM_C
@@ -448,11 +448,11 @@ enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_GCM:128:0:16:-1:0:16:0:16
 
 CAMELLIA 128 GCM Encrypt and decrypt 22 bytes in multiple parts 1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_GCM:128:16:6:-1:16:6:16:6
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_GCM:128:16:6:-1:16:0:16:0
 
 CAMELLIA 128 GCM Encrypt and decrypt 22 bytes in multiple parts 2
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_GCM:128:0:22:-1:0:22:0:22
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_GCM:128:0:22:-1:0:16:0:16
 
 CAMELLIA 128 GCM Encrypt and decrypt 32 bytes in multiple parts 1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_GCM_C
@@ -544,11 +544,11 @@ enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_192_GCM:192:0:0:-1:0:0:0:0
 
 CAMELLIA 192 GCM Encrypt and decrypt 1 bytes in multiple parts 1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_192_GCM:192:1:0:-1:1:0:1:0
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_192_GCM:192:1:0:-1:0:0:0:0
 
 CAMELLIA 192 GCM Encrypt and decrypt 1 bytes in multiple parts 2
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_192_GCM:192:0:1:-1:0:1:0:1
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_192_GCM:192:0:1:-1:0:0:0:0
 
 CAMELLIA 192 GCM Encrypt and decrypt 16 bytes in multiple parts 1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_GCM_C
@@ -560,11 +560,11 @@ enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_192_GCM:192:0:16:-1:0:16:0:16
 
 CAMELLIA 192 GCM Encrypt and decrypt 22 bytes in multiple parts 1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_192_GCM:192:16:6:-1:16:6:16:6
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_192_GCM:192:16:6:-1:16:0:16:0
 
 CAMELLIA 192 GCM Encrypt and decrypt 22 bytes in multiple parts 2
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_192_GCM:192:0:22:-1:0:22:0:22
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_192_GCM:192:0:22:-1:0:16:0:16
 
 CAMELLIA 192 GCM Encrypt and decrypt 32 bytes in multiple parts 1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_GCM_C
@@ -656,11 +656,11 @@ enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_256_GCM:256:0:0:-1:0:0:0:0
 
 CAMELLIA 256 GCM Encrypt and decrypt 1 bytes in multiple parts 1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_256_GCM:256:1:0:-1:1:0:1:0
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_256_GCM:256:1:0:-1:0:0:0:0
 
 CAMELLIA 256 GCM Encrypt and decrypt 1 bytes in multiple parts 2
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_256_GCM:256:0:1:-1:0:1:0:1
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_256_GCM:256:0:1:-1:0:0:0:0
 
 CAMELLIA 256 GCM Encrypt and decrypt 16 bytes in multiple parts 1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_GCM_C
@@ -672,11 +672,11 @@ enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_256_GCM:256:0:16:-1:0:16:0:16
 
 CAMELLIA 256 GCM Encrypt and decrypt 22 bytes in multiple parts 1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_256_GCM:256:16:6:-1:16:6:16:6
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_256_GCM:256:16:6:-1:16:0:16:0
 
 CAMELLIA 256 GCM Encrypt and decrypt 22 bytes in multiple parts 2
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_256_GCM:256:0:22:-1:0:22:0:22
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_256_GCM:256:0:22:-1:0:16:0:16
 
 CAMELLIA 256 GCM Encrypt and decrypt 32 bytes in multiple parts 1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_GCM_C

--- a/tests/suites/test_suite_cipher.gcm.data
+++ b/tests/suites/test_suite_cipher.gcm.data
@@ -90,6 +90,10 @@ AES 128 GCM Encrypt and decrypt 32 bytes in multiple parts 1
 depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
 enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_GCM:128:16:16:-1:16:16:16:16
 
+AES 128 GCM Encrypt and decrypt 32 bytes in different parts 1
+depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
+enc_dec_buf_multipart_different_size:MBEDTLS_CIPHER_AES_128_GCM:128:28:4:4:28:-1:16:16:0:32
+
 AES 128 GCM Decrypt test vector #1
 depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
 decrypt_test_vec:MBEDTLS_CIPHER_AES_128_GCM:-1:"d785dafea3e966731ef6fc6202262584":"d91a46205ee94058b3b8403997592dd2":"":"":"":"3b92a17c1b9c3578a68cffea5a5b6245":0:0


### PR DESCRIPTION
## Description
Actually, if you want to update multiple buffer in AES GCM with the same context, size of input buffers must be a multiple of 16 (except for the last one). I add the possibilty to update multiple buffers with no condition on there size with the same context.

### Motivation
For work, i had to change the cryptography library used in the Cisco [libsrtp](https://github.com/cisco/libsrtp) from OpenSSL to mbedtls. I encountered difficulty with some unit tests:
One of the test was to encrypt a large buffer (1024 bytes) in multiple time and decrypt it in multiple time too. However, the size of the cutting was not the same during encryption and decryption. 

### Modification
I have used the code for the AES CBC part and modify it to be functionnal with AES GCM. I modified the mbedtls_cipher_update to cache data and mbedtls_cipher_finish to encrypted the last cached data.
I had to modify some output value in AESGCM tests because mbedtls_cipher_update return value behavior changed and added some tests case.

## Additional comments
I already made a pull request for this subject but the modification i made was not at the right level (i made them into the gcm.c function directly without using unprocessed_data provided in mbedtls_cipher_ctx structure). So i delete my old pull request and create a new one with the correct  #modification.

## Todos
- [ ] Documentation
- [ ] Changelog updated


## Steps to test or reproduce
1) Generate a 1024 bytes random buffer
2) Cut it into two buffers of different size (for example one of 24 bytes and one of 1000 bytes)
3) Encrypt the two buffer and concatenate them to have the encrypted buffer
4) Cut the encrypted into two buffers of different size but choose different size from the way you cut it for the encryption part (for example 1000 bytes for the first buffer and 24 for the second)
5) Decrypt them
6) The result of the decryption is not the initial plaintext buffer.

