### PR TITLE
Add PKCS8 writing support

### DIFF
--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -576,7 +576,7 @@ int mbedtls_pk_write_key_pem( mbedtls_pk_context *ctx, unsigned char *buf, size_
  *
  * \return          0 if successful, or a specific error code
  */
-int mbedtls_pkcs8_write_key_pem( mbedtls_pk_context *key, unsigned char *buf, size_t size );
+int mbedtls_pkcs8_write_key_pem( mbedtls_pk_context *ctx, unsigned char *buf, size_t size );
 #endif /* MBEDTLS_PEM_WRITE_C */
 #endif /* MBEDTLS_PK_WRITE_C */
 

--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -566,6 +566,17 @@ int mbedtls_pk_write_pubkey_pem( mbedtls_pk_context *ctx, unsigned char *buf, si
  * \return          0 if successful, or a specific error code
  */
 int mbedtls_pk_write_key_pem( mbedtls_pk_context *ctx, unsigned char *buf, size_t size );
+
+/**
+ * \brief           Write a private key to a PKCS#8 or SEC8 PEM string
+ *
+ * \param ctx       private to write away
+ * \param buf       buffer to write to
+ * \param size      size of the buffer
+ *
+ * \return          0 if successful, or a specific error code
+ */
+int mbedtls_pkcs8_write_key_pem( mbedtls_pk_context *key, unsigned char *buf, size_t size );
 #endif /* MBEDTLS_PEM_WRITE_C */
 #endif /* MBEDTLS_PK_WRITE_C */
 

--- a/programs/pkey/gen_key.c
+++ b/programs/pkey/gen_key.c
@@ -102,6 +102,7 @@ int dev_random_entropy_poll( void *data, unsigned char *output,
 
 #define FORMAT_PEM              0
 #define FORMAT_DER              1
+#define FORMAT_PEM_PKCS8        2
 
 #define DFL_TYPE                MBEDTLS_PK_RSA
 #define DFL_RSA_KEYSIZE         4096
@@ -154,10 +155,18 @@ static int write_private_key( mbedtls_pk_context *key, const char *output_file )
     size_t len = 0;
 
     memset(output_buf, 0, 16000);
-    if( opt.format == FORMAT_PEM )
+    if( opt.format == FORMAT_PEM || opt.format == FORMAT_PEM_PKCS8)
     {
-        if( ( ret = mbedtls_pk_write_key_pem( key, output_buf, 16000 ) ) != 0 )
-            return( ret );
+	if (opt.format == FORMAT_PEM_PKCS8)
+	{
+	    if( ( ret = mbedtls_pkcs8_write_key_pem( key, output_buf, 16000 ) ) != 0 )
+		return( ret );
+	}
+	else
+	{
+	    if( ( ret = mbedtls_pk_write_key_pem( key, output_buf, 16000 ) ) != 0 )
+		return( ret );
+	}
 
         len = strlen( (char *) output_buf );
     }
@@ -255,6 +264,8 @@ int main( int argc, char *argv[] )
                 opt.format = FORMAT_PEM;
             else if( strcmp( q, "der" ) == 0 )
                 opt.format = FORMAT_DER;
+            else if( strcmp( q, "pkcs8" ) == 0 )
+                opt.format = FORMAT_PEM_PKCS8;
             else
                 goto usage;
         }


### PR DESCRIPTION
## Description
Currently mbedtls can not write private keys in PKCS8 format, although it is able to parse PKCS8 format.

Since PKCS8 also supports not-yet existing key types since it is extendable it would be a future proof format for key exchange.
Another reason would be that some TLS implementations do not support PKCS1 for private key exchange (like JAVA).
Adding support for PKCS8 PEM/DER writing should be relatively simple since it is only an added envelope.

## Status
**IN DEVELOPMENT**

## Requires Backporting

NO  

## Migrations
If there is any API change, what's the incentive and logic for it.

YES

Add function to write PKCS8 PEM private key files:
int mbedtls_pkcs8_write_key_pem( mbedtls_pk_context *key, unsigned char *buf, size_t size );

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated

