### PR TITLE
Change implementation of zeroize() function

### DIFF
--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -25,6 +25,33 @@
 #ifndef MBEDTLS_PLATFORM_UTIL_H
 #define MBEDTLS_PLATFORM_UTIL_H
 
+#ifdef mbedtls_platform_zeroize
+#error "'mbedtls_platform_zeroize' as macro should be defined in platform_util.h file"
+#endif
+
+#ifndef MBEDTLS_PLATFORM_ZEROIZE_ALT
+// Standard macros
+#ifdef _WIN32
+#include <windows.h>
+#define mbedtls_platform_zeroize RtlSecureZeroMemory
+#endif
+// Other possible implementations
+/* C11/C++11
+ *#include <strings.h>
+ *#define mbedtls_platform_zeroize( buf, len ) memset_s( (buf), (len), 0, (len) )
+ */
+/* FreeBSD
+ * #include <strings.h>
+ * #define mbedtls_platform_zeroize explicit_bzero
+ */
+#else
+/*
+ * User-defined alternative macro definition for mbedtls_platform_zeroize
+ */
+#undef mbedtls_platform_zeroize //Ensure error message in platform_util.c
+#endif /* MBEDTLS_PLATFORM_ZEROIZE_ALT */
+
+#if defined(MBEDTLS_PLATFORM_ZEROIZE_ALT) && !defined(mbedtls_platform_zeroize)
 #include <stddef.h>
 
 #ifdef __cplusplus
@@ -58,5 +85,6 @@ void mbedtls_platform_zeroize( void *buf, size_t len );
 #ifdef __cplusplus
 }
 #endif
+#endif /* defined(MBEDTLS_PLATFORM_ZEROIZE_ALT) && !defined(mbedtls_platform_zeroize) */
 
 #endif /* MBEDTLS_PLATFORM_UTIL_H */

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -48,10 +48,10 @@
 /*
  * User-defined alternative macro definition for mbedtls_platform_zeroize
  */
-#undef mbedtls_platform_zeroize //Ensure error message in platform_util.c
+#undef mbedtls_platform_zeroize //No macro, ensure error message in platform_util.c
 #endif /* MBEDTLS_PLATFORM_ZEROIZE_ALT */
 
-#if defined(MBEDTLS_PLATFORM_ZEROIZE_ALT) && !defined(mbedtls_platform_zeroize)
+#if !defined(mbedtls_platform_zeroize)
 #include <stddef.h>
 
 #ifdef __cplusplus

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -25,13 +25,13 @@
 #ifndef MBEDTLS_PLATFORM_UTIL_H
 #define MBEDTLS_PLATFORM_UTIL_H
 
-#ifdef mbedtls_platform_zeroize
+#if defined(mbedtls_platform_zeroize)
 #error "'mbedtls_platform_zeroize' as macro should be defined in platform_util.h file"
 #endif
 
-#ifndef MBEDTLS_PLATFORM_ZEROIZE_ALT
+#if !defined(MBEDTLS_PLATFORM_ZEROIZE_ALT)
 // Standard macros
-#ifdef _WIN32
+#if defined(_WIN32)
 #include <windows.h>
 #define mbedtls_platform_zeroize RtlSecureZeroMemory
 #endif
@@ -48,7 +48,7 @@
 /*
  * User-defined alternative macro definition for mbedtls_platform_zeroize
  */
-#undef mbedtls_platform_zeroize //No macro, ensure error message in platform_util.c
+#undef mbedtls_platform_zeroize //This will trigger an error if no implementation has been provided
 #endif /* MBEDTLS_PLATFORM_ZEROIZE_ALT */
 
 #if !defined(mbedtls_platform_zeroize)
@@ -85,6 +85,6 @@ void mbedtls_platform_zeroize( void *buf, size_t len );
 #ifdef __cplusplus
 }
 #endif
-#endif /* !defined(mbedtls_platform_zeroize) */
+#endif /* mbedtls_platform_zeroize */
 
 #endif /* MBEDTLS_PLATFORM_UTIL_H */

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -85,6 +85,6 @@ void mbedtls_platform_zeroize( void *buf, size_t len );
 #ifdef __cplusplus
 }
 #endif
-#endif /* defined(MBEDTLS_PLATFORM_ZEROIZE_ALT) && !defined(mbedtls_platform_zeroize) */
+#endif /* !defined(mbedtls_platform_zeroize) */
 
 #endif /* MBEDTLS_PLATFORM_UTIL_H */

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -35,34 +35,34 @@
 void mbedtls_platform_zeroize(void *buf, size_t len)
 {
 #ifndef MBEDTLS_PLATFORM_ZEROIZE_ALT
-	/*
-	* This implementation should never be optimized out by the compiler
-	*
-	* This implementation for mbedtls_platform_zeroize() was inspired from Colin
-	* Percival's blog article at:
-	*
-	* http://www.daemonology.net/blog/2014-09-04-how-to-zero-a-buffer.html
-	*
-	* It uses a volatile function pointer to the standard memset(). Because the
-	* pointer is volatile the compiler expects it to change at
-	* any time and will not optimize out the call that could potentially perform
-	* other operations on the input buffer instead of just setting it to 0.
-	* Nevertheless, as pointed out by davidtgoldblatt on Hacker News
-	* (refer to http://www.daemonology.net/blog/2014-09-05-erratum.html for
-	* details), optimizations of the following form are still possible:
-	*
-	* if( memset_func != memset )
-	*     memset_func( buf, 0, len );
-	*
-	* Note that it is extremely difficult to guarantee that
-	* mbedtls_platform_zeroize() will not be optimized out by aggressive compilers
-	* in a portable way. For this reason, Mbed TLS also provides the configuration
-	* option MBEDTLS_PLATFORM_ZEROIZE_ALT, which allows users to configure
-	* mbedtls_platform_zeroize() to use a suitable implementation for their
-	* platform and needs.
-	*/
-	static const void * (*const volatile memset_func)(void *, int, size_t) = memset;
-	memset_func(buf, 0, len);
+/*
+ * This implementation should never be optimized out by the compiler
+ *
+ * This implementation for mbedtls_platform_zeroize() was inspired from Colin
+ * Percival's blog article at:
+ *
+ * http://www.daemonology.net/blog/2014-09-04-how-to-zero-a-buffer.html
+ *
+ * It uses a volatile function pointer to the standard memset(). Because the
+ * pointer is volatile the compiler expects it to change at
+ * any time and will not optimize out the call that could potentially perform
+ * other operations on the input buffer instead of just setting it to 0.
+ * Nevertheless, as pointed out by davidtgoldblatt on Hacker News
+ * (refer to http://www.daemonology.net/blog/2014-09-05-erratum.html for
+ * details), optimizations of the following form are still possible:
+ *
+ * if( memset_func != memset )
+ *     memset_func( buf, 0, len );
+ *
+ * Note that it is extremely difficult to guarantee that
+ * mbedtls_platform_zeroize() will not be optimized out by aggressive compilers
+ * in a portable way. For this reason, Mbed TLS also provides the configuration
+ * option MBEDTLS_PLATFORM_ZEROIZE_ALT, which allows users to configure
+ * mbedtls_platform_zeroize() to use a suitable implementation for their
+ * platform and needs.
+*/
+    static const void * (*const volatile memset_func)(void *, int, size_t) = memset;
+    memset_func(buf, 0, len);
 #else
 #error "MBEDTLS_PLATFORM_ZEROIZE_ALT was defined, but neither function nor macro were provided for 'mbedtls_platform_zeroize'."
 #endif /* MBEDTLS_PLATFORM_ZEROIZE_ALT */

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -28,40 +28,43 @@
 
 #include "mbedtls/platform_util.h"
 
-#include <stddef.h>
+#ifndef mbedtls_platform_zeroize
+#ifndef MBEDTLS_PLATFORM_ZEROIZE_ALT
 #include <string.h>
-
-#if !defined(MBEDTLS_PLATFORM_ZEROIZE_ALT)
-/*
- * This implementation should never be optimized out by the compiler
- *
- * This implementation for mbedtls_platform_zeroize() was inspired from Colin
- * Percival's blog article at:
- *
- * http://www.daemonology.net/blog/2014-09-04-how-to-zero-a-buffer.html
- *
- * It uses a volatile function pointer to the standard memset(). Because the
- * pointer is volatile the compiler expects it to change at
- * any time and will not optimize out the call that could potentially perform
- * other operations on the input buffer instead of just setting it to 0.
- * Nevertheless, as pointed out by davidtgoldblatt on Hacker News
- * (refer to http://www.daemonology.net/blog/2014-09-05-erratum.html for
- * details), optimizations of the following form are still possible:
- *
- * if( memset_func != memset )
- *     memset_func( buf, 0, len );
- *
- * Note that it is extremely difficult to guarantee that
- * mbedtls_platform_zeroize() will not be optimized out by aggressive compilers
- * in a portable way. For this reason, Mbed TLS also provides the configuration
- * option MBEDTLS_PLATFORM_ZEROIZE_ALT, which allows users to configure
- * mbedtls_platform_zeroize() to use a suitable implementation for their
- * platform and needs.
- */
-static void * (* const volatile memset_func)( void *, int, size_t ) = memset;
-
-void mbedtls_platform_zeroize( void *buf, size_t len )
+#endif
+void mbedtls_platform_zeroize(void *buf, size_t len)
 {
-    memset_func( buf, 0, len );
-}
+#ifndef MBEDTLS_PLATFORM_ZEROIZE_ALT
+	/*
+	* This implementation should never be optimized out by the compiler
+	*
+	* This implementation for mbedtls_platform_zeroize() was inspired from Colin
+	* Percival's blog article at:
+	*
+	* http://www.daemonology.net/blog/2014-09-04-how-to-zero-a-buffer.html
+	*
+	* It uses a volatile function pointer to the standard memset(). Because the
+	* pointer is volatile the compiler expects it to change at
+	* any time and will not optimize out the call that could potentially perform
+	* other operations on the input buffer instead of just setting it to 0.
+	* Nevertheless, as pointed out by davidtgoldblatt on Hacker News
+	* (refer to http://www.daemonology.net/blog/2014-09-05-erratum.html for
+	* details), optimizations of the following form are still possible:
+	*
+	* if( memset_func != memset )
+	*     memset_func( buf, 0, len );
+	*
+	* Note that it is extremely difficult to guarantee that
+	* mbedtls_platform_zeroize() will not be optimized out by aggressive compilers
+	* in a portable way. For this reason, Mbed TLS also provides the configuration
+	* option MBEDTLS_PLATFORM_ZEROIZE_ALT, which allows users to configure
+	* mbedtls_platform_zeroize() to use a suitable implementation for their
+	* platform and needs.
+	*/
+	static const void * (*const volatile memset_func)(void *, int, size_t) = memset;
+	memset_func(buf, 0, len);
+#else
+#error "MBEDTLS_PLATFORM_ZEROIZE_ALT was defined, but neither function nor macro were provided for 'mbedtls_platform_zeroize'."
 #endif /* MBEDTLS_PLATFORM_ZEROIZE_ALT */
+}
+#endif /* mbedtls_platform_zeroize */

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -28,13 +28,13 @@
 
 #include "mbedtls/platform_util.h"
 
-#ifndef mbedtls_platform_zeroize
-#ifndef MBEDTLS_PLATFORM_ZEROIZE_ALT
+#if !defined(mbedtls_platform_zeroize)
+#if !defined(MBEDTLS_PLATFORM_ZEROIZE_ALT)
 #include <string.h>
 #endif
-void mbedtls_platform_zeroize(void *buf, size_t len)
+void mbedtls_platform_zeroize( void *buf, size_t len )
 {
-#ifndef MBEDTLS_PLATFORM_ZEROIZE_ALT
+#if !defined(MBEDTLS_PLATFORM_ZEROIZE_ALT)
 /*
  * This implementation should never be optimized out by the compiler
  *
@@ -61,8 +61,8 @@ void mbedtls_platform_zeroize(void *buf, size_t len)
  * mbedtls_platform_zeroize() to use a suitable implementation for their
  * platform and needs.
 */
-    static const void * (*const volatile memset_func)(void *, int, size_t) = memset;
-    memset_func(buf, 0, len);
+    static void * (* const volatile memset_func)( void *, int, size_t ) = memset;
+    memset_func( buf, 0, len );
 #else
 #error "MBEDTLS_PLATFORM_ZEROIZE_ALT was defined, but neither function nor macro were provided for 'mbedtls_platform_zeroize'."
 #endif /* MBEDTLS_PLATFORM_ZEROIZE_ALT */


### PR DESCRIPTION
## Description
Based on PR #1644
The goals were:
- Simplify and make the logic more straightforward
- Automatically define macros only if no alternative implemntations were expected.
- All platform should be treated uniformly
- Alternative implementation could be either macro-based, or defining function body. Error message should be printed if no definition was provided.

## Status
**IN DEVELOPMENT**

## Requires Backporting
 NO  

## Additional comments
Removed one macro definition and repeated include file (stddef.h)