### PR TITLE
Use pointer to pass mbedtls_pk_context parameter

### DIFF
--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -138,9 +138,9 @@ typedef struct
  * \warning You must make sure the PK context actually holds an RSA context
  * before using this function!
  */
-static inline mbedtls_rsa_context *mbedtls_pk_rsa( const mbedtls_pk_context pk )
+static inline mbedtls_rsa_context *mbedtls_pk_rsa( const mbedtls_pk_context *pk )
 {
-    return( (mbedtls_rsa_context *) (pk).pk_ctx );
+    return( (mbedtls_rsa_context *) pk->pk_ctx );
 }
 #endif /* MBEDTLS_RSA_C */
 
@@ -151,9 +151,9 @@ static inline mbedtls_rsa_context *mbedtls_pk_rsa( const mbedtls_pk_context pk )
  * \warning You must make sure the PK context actually holds an EC context
  * before using this function!
  */
-static inline mbedtls_ecp_keypair *mbedtls_pk_ec( const mbedtls_pk_context pk )
+static inline mbedtls_ecp_keypair *mbedtls_pk_ec( const mbedtls_pk_context *pk )
 {
-    return( (mbedtls_ecp_keypair *) (pk).pk_ctx );
+    return( (mbedtls_ecp_keypair *) pk->pk_ctx );
 }
 #endif /* MBEDTLS_ECP_C */
 

--- a/library/pk.c
+++ b/library/pk.c
@@ -222,7 +222,7 @@ int mbedtls_pk_verify_ext( mbedtls_pk_type_t type, const void *options,
         if( sig_len < mbedtls_pk_get_len( ctx ) )
             return( MBEDTLS_ERR_RSA_VERIFY_FAILED );
 
-        ret = mbedtls_rsa_rsassa_pss_verify_ext( mbedtls_pk_rsa( *ctx ),
+        ret = mbedtls_rsa_rsassa_pss_verify_ext( mbedtls_pk_rsa( ctx ),
                 NULL, NULL, MBEDTLS_RSA_PUBLIC,
                 md_alg, (unsigned int) hash_len, hash,
                 pss_opts->mgf1_hash_id,

--- a/library/pkparse.c
+++ b/library/pkparse.c
@@ -632,15 +632,15 @@ int mbedtls_pk_parse_subpubkey( unsigned char **p, const unsigned char *end,
 #if defined(MBEDTLS_RSA_C)
     if( pk_alg == MBEDTLS_PK_RSA )
     {
-        ret = pk_get_rsapubkey( p, end, mbedtls_pk_rsa( *pk ) );
+        ret = pk_get_rsapubkey( p, end, mbedtls_pk_rsa( pk ) );
     } else
 #endif /* MBEDTLS_RSA_C */
 #if defined(MBEDTLS_ECP_C)
     if( pk_alg == MBEDTLS_PK_ECKEY_DH || pk_alg == MBEDTLS_PK_ECKEY )
     {
-        ret = pk_use_ecparams( &alg_params, &mbedtls_pk_ec( *pk )->grp );
+        ret = pk_use_ecparams( &alg_params, &mbedtls_pk_ec( pk )->grp );
         if( ret == 0 )
-            ret = pk_get_ecpubkey( p, end, mbedtls_pk_ec( *pk ) );
+            ret = pk_get_ecpubkey( p, end, mbedtls_pk_ec( pk ) );
     } else
 #endif /* MBEDTLS_ECP_C */
         ret = MBEDTLS_ERR_PK_UNKNOWN_PK_ALG;
@@ -986,7 +986,7 @@ static int pk_parse_key_pkcs8_unencrypted_der(
 #if defined(MBEDTLS_RSA_C)
     if( pk_alg == MBEDTLS_PK_RSA )
     {
-        if( ( ret = pk_parse_key_pkcs1_der( mbedtls_pk_rsa( *pk ), p, len ) ) != 0 )
+        if( ( ret = pk_parse_key_pkcs1_der( mbedtls_pk_rsa( pk ), p, len ) ) != 0 )
         {
             mbedtls_pk_free( pk );
             return( ret );
@@ -996,8 +996,8 @@ static int pk_parse_key_pkcs8_unencrypted_der(
 #if defined(MBEDTLS_ECP_C)
     if( pk_alg == MBEDTLS_PK_ECKEY || pk_alg == MBEDTLS_PK_ECKEY_DH )
     {
-        if( ( ret = pk_use_ecparams( &params, &mbedtls_pk_ec( *pk )->grp ) ) != 0 ||
-            ( ret = pk_parse_key_sec1_der( mbedtls_pk_ec( *pk ), p, len )  ) != 0 )
+        if( ( ret = pk_use_ecparams( &params, &mbedtls_pk_ec( pk )->grp ) ) != 0 ||
+            ( ret = pk_parse_key_sec1_der( mbedtls_pk_ec( pk ), p, len )  ) != 0 )
         {
             mbedtls_pk_free( pk );
             return( ret );
@@ -1166,7 +1166,7 @@ int mbedtls_pk_parse_key( mbedtls_pk_context *pk,
     {
         pk_info = mbedtls_pk_info_from_type( MBEDTLS_PK_RSA );
         if( ( ret = mbedtls_pk_setup( pk, pk_info ) ) != 0 ||
-            ( ret = pk_parse_key_pkcs1_der( mbedtls_pk_rsa( *pk ),
+            ( ret = pk_parse_key_pkcs1_der( mbedtls_pk_rsa( pk ),
                                             pem.buf, pem.buflen ) ) != 0 )
         {
             mbedtls_pk_free( pk );
@@ -1197,7 +1197,7 @@ int mbedtls_pk_parse_key( mbedtls_pk_context *pk,
         pk_info = mbedtls_pk_info_from_type( MBEDTLS_PK_ECKEY );
 
         if( ( ret = mbedtls_pk_setup( pk, pk_info ) ) != 0 ||
-            ( ret = pk_parse_key_sec1_der( mbedtls_pk_ec( *pk ),
+            ( ret = pk_parse_key_sec1_der( mbedtls_pk_ec( pk ),
                                            pem.buf, pem.buflen ) ) != 0 )
         {
             mbedtls_pk_free( pk );
@@ -1312,7 +1312,7 @@ int mbedtls_pk_parse_key( mbedtls_pk_context *pk,
 
     pk_info = mbedtls_pk_info_from_type( MBEDTLS_PK_RSA );
     if( ( ret = mbedtls_pk_setup( pk, pk_info ) ) != 0 ||
-        ( ret = pk_parse_key_pkcs1_der( mbedtls_pk_rsa( *pk ),
+        ( ret = pk_parse_key_pkcs1_der( mbedtls_pk_rsa( pk ),
                                         key, keylen ) ) != 0 )
     {
         mbedtls_pk_free( pk );
@@ -1328,7 +1328,7 @@ int mbedtls_pk_parse_key( mbedtls_pk_context *pk,
 
     pk_info = mbedtls_pk_info_from_type( MBEDTLS_PK_ECKEY );
     if( ( ret = mbedtls_pk_setup( pk, pk_info ) ) != 0 ||
-        ( ret = pk_parse_key_sec1_der( mbedtls_pk_ec( *pk ),
+        ( ret = pk_parse_key_sec1_der( mbedtls_pk_ec( pk ),
                                        key, keylen ) ) != 0 )
     {
         mbedtls_pk_free( pk );
@@ -1378,7 +1378,7 @@ int mbedtls_pk_parse_public_key( mbedtls_pk_context *ctx,
         if( ( ret = mbedtls_pk_setup( ctx, pk_info ) ) != 0 )
             return( ret );
 
-        if ( ( ret = pk_get_rsapubkey( &p, p + pem.buflen, mbedtls_pk_rsa( *ctx ) ) ) != 0 )
+        if ( ( ret = pk_get_rsapubkey( &p, p + pem.buflen, mbedtls_pk_rsa( ctx ) ) ) != 0 )
             mbedtls_pk_free( ctx );
 
         mbedtls_pem_free( &pem );
@@ -1427,7 +1427,7 @@ int mbedtls_pk_parse_public_key( mbedtls_pk_context *ctx,
         return( ret );
 
     p = (unsigned char *)key;
-    ret = pk_get_rsapubkey( &p, p + keylen, mbedtls_pk_rsa( *ctx ) );
+    ret = pk_get_rsapubkey( &p, p + keylen, mbedtls_pk_rsa( ctx ) );
     if( ret == 0 )
     {
         return( ret );

--- a/library/pkwrite.c
+++ b/library/pkwrite.c
@@ -153,12 +153,12 @@ int mbedtls_pk_write_pubkey( unsigned char **p, unsigned char *start,
 
 #if defined(MBEDTLS_RSA_C)
     if( mbedtls_pk_get_type( key ) == MBEDTLS_PK_RSA )
-        MBEDTLS_ASN1_CHK_ADD( len, pk_write_rsa_pubkey( p, start, mbedtls_pk_rsa( *key ) ) );
+        MBEDTLS_ASN1_CHK_ADD( len, pk_write_rsa_pubkey( p, start, mbedtls_pk_rsa( key ) ) );
     else
 #endif
 #if defined(MBEDTLS_ECP_C)
     if( mbedtls_pk_get_type( key ) == MBEDTLS_PK_ECKEY )
-        MBEDTLS_ASN1_CHK_ADD( len, pk_write_ec_pubkey( p, start, mbedtls_pk_ec( *key ) ) );
+        MBEDTLS_ASN1_CHK_ADD( len, pk_write_ec_pubkey( p, start, mbedtls_pk_ec( key ) ) );
     else
 #endif
         return( MBEDTLS_ERR_PK_FEATURE_UNAVAILABLE );
@@ -200,7 +200,7 @@ int mbedtls_pk_write_pubkey_der( mbedtls_pk_context *key, unsigned char *buf, si
 #if defined(MBEDTLS_ECP_C)
     if( mbedtls_pk_get_type( key ) == MBEDTLS_PK_ECKEY )
     {
-        MBEDTLS_ASN1_CHK_ADD( par_len, pk_write_ec_param( &c, buf, mbedtls_pk_ec( *key ) ) );
+        MBEDTLS_ASN1_CHK_ADD( par_len, pk_write_ec_param( &c, buf, mbedtls_pk_ec( key ) ) );
     }
 #endif
 
@@ -224,7 +224,7 @@ int mbedtls_pk_write_key_der( mbedtls_pk_context *key, unsigned char *buf, size_
     if( mbedtls_pk_get_type( key ) == MBEDTLS_PK_RSA )
     {
         mbedtls_mpi T; /* Temporary holding the exported parameters */
-        mbedtls_rsa_context *rsa = mbedtls_pk_rsa( *key );
+        mbedtls_rsa_context *rsa = mbedtls_pk_rsa( key );
 
         /*
          * Export the parameters one after another to avoid simultaneous copies.
@@ -302,7 +302,7 @@ int mbedtls_pk_write_key_der( mbedtls_pk_context *key, unsigned char *buf, size_
 #if defined(MBEDTLS_ECP_C)
     if( mbedtls_pk_get_type( key ) == MBEDTLS_PK_ECKEY )
     {
-        mbedtls_ecp_keypair *ec = mbedtls_pk_ec( *key );
+        mbedtls_ecp_keypair *ec = mbedtls_pk_ec( key );
         size_t pub_len = 0, par_len = 0;
 
         /*

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -2266,7 +2266,7 @@ static int ssl_get_ecdh_params_from_cert( mbedtls_ssl_context *ssl )
         return( MBEDTLS_ERR_SSL_PK_TYPE_MISMATCH );
     }
 
-    peer_key = mbedtls_pk_ec( ssl->session_negotiate->peer_cert->pk );
+    peer_key = mbedtls_pk_ec( &ssl->session_negotiate->peer_cert->pk );
 
     if( ( ret = mbedtls_ecdh_get_params( &ssl->handshake->ecdh_ctx, peer_key,
                                  MBEDTLS_ECDH_THEIRS ) ) != 0 )

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -661,7 +661,7 @@ static int ssl_check_key_curve( mbedtls_pk_context *pk,
                                 const mbedtls_ecp_curve_info **curves )
 {
     const mbedtls_ecp_curve_info **crv = curves;
-    mbedtls_ecp_group_id grp_id = mbedtls_pk_ec( *pk )->grp.id;
+    mbedtls_ecp_group_id grp_id = mbedtls_pk_ec( pk )->grp.id;
 
     while( *crv != NULL )
     {
@@ -2816,7 +2816,7 @@ static int ssl_get_ecdh_params_from_cert( mbedtls_ssl_context *ssl )
     }
 
     if( ( ret = mbedtls_ecdh_get_params( &ssl->handshake->ecdh_ctx,
-                                 mbedtls_pk_ec( *mbedtls_ssl_own_key( ssl ) ),
+                                 mbedtls_pk_ec( mbedtls_ssl_own_key( ssl ) ),
                                  MBEDTLS_ECDH_OURS ) ) != 0 )
     {
         MBEDTLS_SSL_DEBUG_RET( 1, ( "mbedtls_ecdh_get_params" ), ret );

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -4653,7 +4653,7 @@ int mbedtls_ssl_parse_certificate( mbedtls_ssl_context *ssl )
 
             /* If certificate uses an EC key, make sure the curve is OK */
             if( mbedtls_pk_can_do( pk, MBEDTLS_PK_ECKEY ) &&
-                mbedtls_ssl_check_curve( ssl, mbedtls_pk_ec( *pk )->grp.id ) != 0 )
+                mbedtls_ssl_check_curve( ssl, mbedtls_pk_ec( pk )->grp.id ) != 0 )
             {
                 ssl->session_negotiate->verify_result |= MBEDTLS_X509_BADCERT_BAD_KEY;
 

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -206,7 +206,7 @@ static int x509_profile_check_key( const mbedtls_x509_crt_profile *profile,
         pk_alg == MBEDTLS_PK_ECKEY ||
         pk_alg == MBEDTLS_PK_ECKEY_DH )
     {
-        const mbedtls_ecp_group_id gid = mbedtls_pk_ec( *pk )->grp.id;
+        const mbedtls_ecp_group_id gid = mbedtls_pk_ec( pk )->grp.id;
 
         if( ( profile->allowed_curves & MBEDTLS_X509_ID_FLAG( gid ) ) != 0 )
             return( 0 );

--- a/programs/pkey/gen_key.c
+++ b/programs/pkey/gen_key.c
@@ -328,7 +328,7 @@ int main( int argc, char *argv[] )
 #if defined(MBEDTLS_RSA_C) && defined(MBEDTLS_GENPRIME)
     if( opt.type == MBEDTLS_PK_RSA )
     {
-        ret = mbedtls_rsa_gen_key( mbedtls_pk_rsa( key ), mbedtls_ctr_drbg_random, &ctr_drbg,
+        ret = mbedtls_rsa_gen_key( mbedtls_pk_rsa( &key ), mbedtls_ctr_drbg_random, &ctr_drbg,
                                    opt.rsa_keysize, 65537 );
         if( ret != 0 )
         {
@@ -341,7 +341,7 @@ int main( int argc, char *argv[] )
 #if defined(MBEDTLS_ECP_C)
     if( opt.type == MBEDTLS_PK_ECKEY )
     {
-        ret = mbedtls_ecp_gen_key( opt.ec_curve, mbedtls_pk_ec( key ),
+        ret = mbedtls_ecp_gen_key( opt.ec_curve, mbedtls_pk_ec( &key ),
                                    mbedtls_ctr_drbg_random, &ctr_drbg );
         if( ret != 0 )
         {
@@ -364,7 +364,7 @@ int main( int argc, char *argv[] )
 #if defined(MBEDTLS_RSA_C)
     if( mbedtls_pk_get_type( &key ) == MBEDTLS_PK_RSA )
     {
-        mbedtls_rsa_context *rsa = mbedtls_pk_rsa( key );
+        mbedtls_rsa_context *rsa = mbedtls_pk_rsa( &key );
 
         if( ( ret = mbedtls_rsa_export    ( rsa, &N, &P, &Q, &D, &E ) ) != 0 ||
             ( ret = mbedtls_rsa_export_crt( rsa, &DP, &DQ, &QP ) )      != 0 )
@@ -387,7 +387,7 @@ int main( int argc, char *argv[] )
 #if defined(MBEDTLS_ECP_C)
     if( mbedtls_pk_get_type( &key ) == MBEDTLS_PK_ECKEY )
     {
-        mbedtls_ecp_keypair *ecp = mbedtls_pk_ec( key );
+        mbedtls_ecp_keypair *ecp = mbedtls_pk_ec( &key );
         mbedtls_printf( "curve: %s\n",
                 mbedtls_ecp_curve_info_from_grp_id( ecp->grp.id )->name );
         mbedtls_mpi_write_file( "X_Q:   ", &ecp->Q.X, 16, NULL );

--- a/programs/pkey/key_app.c
+++ b/programs/pkey/key_app.c
@@ -194,7 +194,7 @@ int main( int argc, char *argv[] )
 #if defined(MBEDTLS_RSA_C)
         if( mbedtls_pk_get_type( &pk ) == MBEDTLS_PK_RSA )
         {
-            mbedtls_rsa_context *rsa = mbedtls_pk_rsa( pk );
+            mbedtls_rsa_context *rsa = mbedtls_pk_rsa( &pk );
 
             if( ( ret = mbedtls_rsa_export    ( rsa, &N, &P, &Q, &D, &E ) ) != 0 ||
                 ( ret = mbedtls_rsa_export_crt( rsa, &DP, &DQ, &QP ) )      != 0 )
@@ -217,7 +217,7 @@ int main( int argc, char *argv[] )
 #if defined(MBEDTLS_ECP_C)
         if( mbedtls_pk_get_type( &pk ) == MBEDTLS_PK_ECKEY )
         {
-            mbedtls_ecp_keypair *ecp = mbedtls_pk_ec( pk );
+            mbedtls_ecp_keypair *ecp = mbedtls_pk_ec( &pk );
             mbedtls_mpi_write_file( "Q(X): ", &ecp->Q.X, 16, NULL );
             mbedtls_mpi_write_file( "Q(Y): ", &ecp->Q.Y, 16, NULL );
             mbedtls_mpi_write_file( "Q(Z): ", &ecp->Q.Z, 16, NULL );
@@ -252,7 +252,7 @@ int main( int argc, char *argv[] )
 #if defined(MBEDTLS_RSA_C)
         if( mbedtls_pk_get_type( &pk ) == MBEDTLS_PK_RSA )
         {
-            mbedtls_rsa_context *rsa = mbedtls_pk_rsa( pk );
+            mbedtls_rsa_context *rsa = mbedtls_pk_rsa( &pk );
 
             if( ( ret = mbedtls_rsa_export( rsa, &N, NULL, NULL,
                                             NULL, &E ) ) != 0 )
@@ -268,7 +268,7 @@ int main( int argc, char *argv[] )
 #if defined(MBEDTLS_ECP_C)
         if( mbedtls_pk_get_type( &pk ) == MBEDTLS_PK_ECKEY )
         {
-            mbedtls_ecp_keypair *ecp = mbedtls_pk_ec( pk );
+            mbedtls_ecp_keypair *ecp = mbedtls_pk_ec( &pk );
             mbedtls_mpi_write_file( "Q(X): ", &ecp->Q.X, 16, NULL );
             mbedtls_mpi_write_file( "Q(Y): ", &ecp->Q.Y, 16, NULL );
             mbedtls_mpi_write_file( "Q(Z): ", &ecp->Q.Z, 16, NULL );

--- a/programs/pkey/key_app_writer.c
+++ b/programs/pkey/key_app_writer.c
@@ -305,7 +305,7 @@ int main( int argc, char *argv[] )
 #if defined(MBEDTLS_RSA_C)
         if( mbedtls_pk_get_type( &key ) == MBEDTLS_PK_RSA )
         {
-            mbedtls_rsa_context *rsa = mbedtls_pk_rsa( key );
+            mbedtls_rsa_context *rsa = mbedtls_pk_rsa( &key );
 
             if( ( ret = mbedtls_rsa_export    ( rsa, &N, &P, &Q, &D, &E ) ) != 0 ||
                 ( ret = mbedtls_rsa_export_crt( rsa, &DP, &DQ, &QP ) )      != 0 )
@@ -328,7 +328,7 @@ int main( int argc, char *argv[] )
 #if defined(MBEDTLS_ECP_C)
         if( mbedtls_pk_get_type( &key ) == MBEDTLS_PK_ECKEY )
         {
-            mbedtls_ecp_keypair *ecp = mbedtls_pk_ec( key );
+            mbedtls_ecp_keypair *ecp = mbedtls_pk_ec( &key );
             mbedtls_mpi_write_file( "Q(X): ", &ecp->Q.X, 16, NULL );
             mbedtls_mpi_write_file( "Q(Y): ", &ecp->Q.Y, 16, NULL );
             mbedtls_mpi_write_file( "Q(Z): ", &ecp->Q.Z, 16, NULL );
@@ -366,7 +366,7 @@ int main( int argc, char *argv[] )
 #if defined(MBEDTLS_RSA_C)
         if( mbedtls_pk_get_type( &key ) == MBEDTLS_PK_RSA )
         {
-            mbedtls_rsa_context *rsa = mbedtls_pk_rsa( key );
+            mbedtls_rsa_context *rsa = mbedtls_pk_rsa( &key );
 
             if( ( ret = mbedtls_rsa_export( rsa, &N, NULL, NULL,
                                             NULL, &E ) ) != 0 )
@@ -382,7 +382,7 @@ int main( int argc, char *argv[] )
 #if defined(MBEDTLS_ECP_C)
         if( mbedtls_pk_get_type( &key ) == MBEDTLS_PK_ECKEY )
         {
-            mbedtls_ecp_keypair *ecp = mbedtls_pk_ec( key );
+            mbedtls_ecp_keypair *ecp = mbedtls_pk_ec( &key );
             mbedtls_mpi_write_file( "Q(X): ", &ecp->Q.X, 16, NULL );
             mbedtls_mpi_write_file( "Q(Y): ", &ecp->Q.Y, 16, NULL );
             mbedtls_mpi_write_file( "Q(Z): ", &ecp->Q.Z, 16, NULL );

--- a/programs/pkey/rsa_sign_pss.c
+++ b/programs/pkey/rsa_sign_pss.c
@@ -114,7 +114,7 @@ int main( int argc, char *argv[] )
         goto exit;
     }
 
-    mbedtls_rsa_set_padding( mbedtls_pk_rsa( pk ), MBEDTLS_RSA_PKCS_V21, MBEDTLS_MD_SHA256 );
+    mbedtls_rsa_set_padding( mbedtls_pk_rsa( &pk ), MBEDTLS_RSA_PKCS_V21, MBEDTLS_MD_SHA256 );
 
     /*
      * Compute the SHA-256 hash of the input file,

--- a/programs/pkey/rsa_verify_pss.c
+++ b/programs/pkey/rsa_verify_pss.c
@@ -96,7 +96,7 @@ int main( int argc, char *argv[] )
         goto exit;
     }
 
-    mbedtls_rsa_set_padding( mbedtls_pk_rsa( pk ), MBEDTLS_RSA_PKCS_V21, MBEDTLS_MD_SHA256 );
+    mbedtls_rsa_set_padding( mbedtls_pk_rsa( &pk ), MBEDTLS_RSA_PKCS_V21, MBEDTLS_MD_SHA256 );
 
     /*
      * Extract the RSA signature from the file

--- a/programs/test/ssl_cert_test.c
+++ b/programs/test/ssl_cert_test.c
@@ -214,21 +214,21 @@ int main( void )
             goto exit;
         }
 
-        ret = mbedtls_mpi_cmp_mpi(&mbedtls_pk_rsa( pk )->N, &mbedtls_pk_rsa( clicert.pk )->N);
+        ret = mbedtls_mpi_cmp_mpi(&mbedtls_pk_rsa( &pk )->N, &mbedtls_pk_rsa( &clicert.pk )->N);
         if( ret != 0 )
         {
             mbedtls_printf( " failed\n  !  mbedtls_mpi_cmp_mpi for N returned %d\n\n", ret );
             goto exit;
         }
 
-        ret = mbedtls_mpi_cmp_mpi(&mbedtls_pk_rsa( pk )->E, &mbedtls_pk_rsa( clicert.pk )->E);
+        ret = mbedtls_mpi_cmp_mpi(&mbedtls_pk_rsa( &pk )->E, &mbedtls_pk_rsa( &clicert.pk )->E);
         if( ret != 0 )
         {
             mbedtls_printf( " failed\n  !  mbedtls_mpi_cmp_mpi for E returned %d\n\n", ret );
             goto exit;
         }
 
-        ret = mbedtls_rsa_check_privkey( mbedtls_pk_rsa( pk ) );
+        ret = mbedtls_rsa_check_privkey( mbedtls_pk_rsa( &pk ) );
         if( ret != 0 )
         {
             mbedtls_printf( " failed\n  !  mbedtls_rsa_check_privkey returned %d\n\n", ret );

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -19,7 +19,7 @@ static int pk_genkey( mbedtls_pk_context *pk )
 
 #if defined(MBEDTLS_RSA_C) && defined(MBEDTLS_GENPRIME)
     if( mbedtls_pk_get_type( pk ) == MBEDTLS_PK_RSA )
-        return mbedtls_rsa_gen_key( mbedtls_pk_rsa( *pk ), rnd_std_rand, NULL, RSA_KEY_SIZE, 3 );
+        return mbedtls_rsa_gen_key( mbedtls_pk_rsa( pk ), rnd_std_rand, NULL, RSA_KEY_SIZE, 3 );
 #endif
 #if defined(MBEDTLS_ECP_C)
     if( mbedtls_pk_get_type( pk ) == MBEDTLS_PK_ECKEY ||
@@ -27,12 +27,12 @@ static int pk_genkey( mbedtls_pk_context *pk )
         mbedtls_pk_get_type( pk ) == MBEDTLS_PK_ECDSA )
     {
         int ret;
-        if( ( ret = mbedtls_ecp_group_load( &mbedtls_pk_ec( *pk )->grp,
+        if( ( ret = mbedtls_ecp_group_load( &mbedtls_pk_ec( pk )->grp,
                                       MBEDTLS_ECP_DP_SECP192R1 ) ) != 0 )
             return( ret );
 
-        return mbedtls_ecp_gen_keypair( &mbedtls_pk_ec( *pk )->grp, &mbedtls_pk_ec( *pk )->d,
-                                &mbedtls_pk_ec( *pk )->Q, rnd_std_rand, NULL );
+        return mbedtls_ecp_gen_keypair( &mbedtls_pk_ec( pk )->grp, &mbedtls_pk_ec( pk )->d,
+                                &mbedtls_pk_ec( pk )->Q, rnd_std_rand, NULL );
     }
 #endif
     return( -1 );
@@ -107,7 +107,7 @@ void mbedtls_pk_check_pair( char *pub_file, char *prv_file, int ret )
 #if defined(MBEDTLS_RSA_C) && defined(MBEDTLS_PK_RSA_ALT_SUPPORT)
     if( mbedtls_pk_get_type( &prv ) == MBEDTLS_PK_RSA )
     {
-        TEST_ASSERT( mbedtls_pk_setup_rsa_alt( &alt, mbedtls_pk_rsa( prv ),
+        TEST_ASSERT( mbedtls_pk_setup_rsa_alt( &alt, mbedtls_pk_rsa( &prv ),
                      mbedtls_rsa_decrypt_func, mbedtls_rsa_sign_func,
                      mbedtls_rsa_key_len_func ) == 0 );
         TEST_ASSERT( mbedtls_pk_check_pair( &pub, &alt ) == ret );
@@ -139,7 +139,7 @@ void pk_rsa_verify_test_vec( char *message_hex_string, int digest,
     memset( result_str, 0x00, 1000 );
 
     TEST_ASSERT( mbedtls_pk_setup( &pk, mbedtls_pk_info_from_type( MBEDTLS_PK_RSA ) ) == 0 );
-    rsa = mbedtls_pk_rsa( pk );
+    rsa = mbedtls_pk_rsa( &pk );
 
     rsa->len = mod / 8;
     TEST_ASSERT( mbedtls_mpi_read_string( &rsa->N, radix_N, input_N ) == 0 );
@@ -183,7 +183,7 @@ void pk_rsa_verify_ext_test_vec( char *message_hex_string, int digest,
     memset( result_str, 0x00, 1000 );
 
     TEST_ASSERT( mbedtls_pk_setup( &pk, mbedtls_pk_info_from_type( MBEDTLS_PK_RSA ) ) == 0 );
-    rsa = mbedtls_pk_rsa( pk );
+    rsa = mbedtls_pk_rsa( &pk );
 
     rsa->len = mod / 8;
     TEST_ASSERT( mbedtls_mpi_read_string( &rsa->N, radix_N, input_N ) == 0 );
@@ -243,7 +243,7 @@ void pk_ec_test_vec( int type, int id, char *key_str,
     TEST_ASSERT( mbedtls_pk_setup( &pk, mbedtls_pk_info_from_type( type ) ) == 0 );
 
     TEST_ASSERT( mbedtls_pk_can_do( &pk, MBEDTLS_PK_ECDSA ) );
-    eckey = mbedtls_pk_ec( pk );
+    eckey = mbedtls_pk_ec( &pk );
 
     TEST_ASSERT( mbedtls_ecp_group_load( &eckey->grp, id ) == 0 );
     TEST_ASSERT( mbedtls_ecp_point_read_binary( &eckey->grp, &eckey->Q,
@@ -307,7 +307,7 @@ void pk_rsa_encrypt_test_vec( char *message_hex, int mod,
 
     mbedtls_pk_init( &pk );
     TEST_ASSERT( mbedtls_pk_setup( &pk, mbedtls_pk_info_from_type( MBEDTLS_PK_RSA ) ) == 0 );
-    rsa = mbedtls_pk_rsa( pk );
+    rsa = mbedtls_pk_rsa( &pk );
 
     rsa->len = mod / 8;
     TEST_ASSERT( mbedtls_mpi_read_string( &rsa->N, radix_N, input_N ) == 0 );
@@ -354,7 +354,7 @@ void pk_rsa_decrypt_test_vec( char *cipher_hex, int mod,
 
     /* init pk-rsa context */
     TEST_ASSERT( mbedtls_pk_setup( &pk, mbedtls_pk_info_from_type( MBEDTLS_PK_RSA ) ) == 0 );
-    rsa = mbedtls_pk_rsa( pk );
+    rsa = mbedtls_pk_rsa( &pk );
 
     /* load public key */
     TEST_ASSERT( mbedtls_mpi_read_string( &N, radix_N, input_N ) == 0 );
@@ -483,7 +483,7 @@ void pk_rsa_alt( )
     TEST_ASSERT( pk_genkey( &rsa ) == 0 );
 
     /* Extract key to the raw rsa context */
-    TEST_ASSERT( mbedtls_rsa_copy( &raw, mbedtls_pk_rsa( rsa ) ) == 0 );
+    TEST_ASSERT( mbedtls_rsa_copy( &raw, mbedtls_pk_rsa( &rsa ) ) == 0 );
 
     /* Initialize PK RSA_ALT context */
     TEST_ASSERT( mbedtls_pk_setup_rsa_alt( &alt, (void *) &raw,

--- a/tests/suites/test_suite_pkparse.function
+++ b/tests/suites/test_suite_pkparse.function
@@ -29,7 +29,7 @@ void pk_parse_keyfile_rsa( char *key_file, char *password, int result )
     {
         mbedtls_rsa_context *rsa;
         TEST_ASSERT( mbedtls_pk_can_do( &ctx, MBEDTLS_PK_RSA ) );
-        rsa = mbedtls_pk_rsa( ctx );
+        rsa = mbedtls_pk_rsa( &ctx );
         TEST_ASSERT( mbedtls_rsa_check_privkey( rsa ) == 0 );
     }
 
@@ -54,7 +54,7 @@ void pk_parse_public_keyfile_rsa( char *key_file, int result )
     {
         mbedtls_rsa_context *rsa;
         TEST_ASSERT( mbedtls_pk_can_do( &ctx, MBEDTLS_PK_RSA ) );
-        rsa = mbedtls_pk_rsa( ctx );
+        rsa = mbedtls_pk_rsa( &ctx );
         TEST_ASSERT( mbedtls_rsa_check_pubkey( rsa ) == 0 );
     }
 
@@ -79,7 +79,7 @@ void pk_parse_public_keyfile_ec( char *key_file, int result )
     {
         mbedtls_ecp_keypair *eckey;
         TEST_ASSERT( mbedtls_pk_can_do( &ctx, MBEDTLS_PK_ECKEY ) );
-        eckey = mbedtls_pk_ec( ctx );
+        eckey = mbedtls_pk_ec( &ctx );
         TEST_ASSERT( mbedtls_ecp_check_pubkey( &eckey->grp, &eckey->Q ) == 0 );
     }
 
@@ -104,7 +104,7 @@ void pk_parse_keyfile_ec( char *key_file, char *password, int result )
     {
         mbedtls_ecp_keypair *eckey;
         TEST_ASSERT( mbedtls_pk_can_do( &ctx, MBEDTLS_PK_ECKEY ) );
-        eckey = mbedtls_pk_ec( ctx );
+        eckey = mbedtls_pk_ec( &ctx );
         TEST_ASSERT( mbedtls_ecp_check_privkey( &eckey->grp, &eckey->d ) == 0 );
     }
 

--- a/tests/suites/test_suite_x509write.function
+++ b/tests/suites/test_suite_x509write.function
@@ -135,7 +135,7 @@ void x509_crt_check( char *subject_key_file, char *subject_pwd,
     if( rsa_alt == 1 && mbedtls_pk_get_type( &issuer_key ) == MBEDTLS_PK_RSA )
     {
         TEST_ASSERT( mbedtls_pk_setup_rsa_alt( &issuer_key_alt,
-                                            mbedtls_pk_rsa( issuer_key ),
+                                            mbedtls_pk_rsa( &issuer_key ),
                                             mbedtls_rsa_decrypt_func,
                                             mbedtls_rsa_sign_func,
                                             mbedtls_rsa_key_len_func ) == 0 );

--- a/yotta/data/example-benchmark/main.cpp
+++ b/yotta/data/example-benchmark/main.cpp
@@ -698,7 +698,7 @@ int benchmark( int argc, char *argv[] )
             mbedtls_pk_init( &pk );
             mbedtls_pk_parse_key( &pk, (const unsigned char *) rsa_keys[i],
                                                        strlen( rsa_keys[i] ) + 1, NULL, 0 );
-            rsa = mbedtls_pk_rsa( pk );
+            rsa = mbedtls_pk_rsa( &pk );
 
             mbedtls_snprintf( title, sizeof( title ), "RSA-%d", mbedtls_pk_get_bitlen( &pk ) );
 


### PR DESCRIPTION
## Description
Two functions that pass context structure instead of using pointers (declared in `pk.h`).
- `static inline mbedtls_rsa_context *mbedtls_pk_rsa( const mbedtls_pk_context pk )`
- `static inline mbedtls_ecp_keypair *mbedtls_pk_ec( const mbedtls_pk_context pk )`

That is not optimal and could be improved.
The change itself is quite simple, though minor API change is required too.

## Status
**READY**

## Requires Backporting
NO  

## Which branch?
development

## Migrations
YES