### PR TITLE
Improve mutex validity checking

### DIFF
--- a/library/threading.c
+++ b/library/threading.c
@@ -27,6 +27,7 @@
 
 #if defined(MBEDTLS_THREADING_C)
 
+#include <stdbool.h>
 #include "mbedtls/threading.h"
 
 #if defined(MBEDTLS_THREADING_PTHREAD)
@@ -35,12 +36,17 @@ static void threading_mutex_init_pthread( mbedtls_threading_mutex_t *mutex )
     if( mutex == NULL )
         return;
 
-    mutex->is_valid = pthread_mutex_init( &mutex->mutex, NULL ) == 0;
+    mutex->is_valid = (pthread_mutex_init( &mutex->mutex, NULL ) == 0) ? 1 : 0;
+}
+
+static bool is_mutex_valid(mbedtls_threading_mutex_t *mutex)
+{
+    return (mutex->is_valid == 1);
 }
 
 static void threading_mutex_free_pthread( mbedtls_threading_mutex_t *mutex )
 {
-    if( mutex == NULL || !mutex->is_valid )
+    if( mutex == NULL || !is_mutex_valid(mutex) )
         return;
 
     (void) pthread_mutex_destroy( &mutex->mutex );
@@ -49,7 +55,7 @@ static void threading_mutex_free_pthread( mbedtls_threading_mutex_t *mutex )
 
 static int threading_mutex_lock_pthread( mbedtls_threading_mutex_t *mutex )
 {
-    if( mutex == NULL || ! mutex->is_valid )
+    if( mutex == NULL || !is_mutex_valid(mutex) )
         return( MBEDTLS_ERR_THREADING_BAD_INPUT_DATA );
 
     if( pthread_mutex_lock( &mutex->mutex ) != 0 )
@@ -60,7 +66,7 @@ static int threading_mutex_lock_pthread( mbedtls_threading_mutex_t *mutex )
 
 static int threading_mutex_unlock_pthread( mbedtls_threading_mutex_t *mutex )
 {
-    if( mutex == NULL || ! mutex->is_valid )
+    if( mutex == NULL || !is_mutex_valid(mutex) )
         return( MBEDTLS_ERR_THREADING_BAD_INPUT_DATA );
 
     if( pthread_mutex_unlock( &mutex->mutex ) != 0 )

--- a/library/threading.c
+++ b/library/threading.c
@@ -36,17 +36,18 @@ static void threading_mutex_init_pthread( mbedtls_threading_mutex_t *mutex )
     if( mutex == NULL )
         return;
 
-    mutex->is_valid = (pthread_mutex_init( &mutex->mutex, NULL ) == 0) ? 1 : 0;
+    mutex->is_valid =
+        ( pthread_mutex_init( &mutex->mutex, NULL ) == 0 ) ? 1 : 0;
 }
 
-static bool is_mutex_valid(mbedtls_threading_mutex_t *mutex)
+static int mutex_is_valid( mbedtls_threading_mutex_t *mutex )
 {
-    return (mutex->is_valid == 1);
+    return( mutex->is_valid == 1 );
 }
 
 static void threading_mutex_free_pthread( mbedtls_threading_mutex_t *mutex )
 {
-    if( mutex == NULL || !is_mutex_valid(mutex) )
+    if( mutex == NULL || !mutex_is_valid( mutex ) )
         return;
 
     (void) pthread_mutex_destroy( &mutex->mutex );
@@ -55,7 +56,7 @@ static void threading_mutex_free_pthread( mbedtls_threading_mutex_t *mutex )
 
 static int threading_mutex_lock_pthread( mbedtls_threading_mutex_t *mutex )
 {
-    if( mutex == NULL || !is_mutex_valid(mutex) )
+    if( mutex == NULL || !mutex_is_valid( mutex ) )
         return( MBEDTLS_ERR_THREADING_BAD_INPUT_DATA );
 
     if( pthread_mutex_lock( &mutex->mutex ) != 0 )
@@ -66,7 +67,7 @@ static int threading_mutex_lock_pthread( mbedtls_threading_mutex_t *mutex )
 
 static int threading_mutex_unlock_pthread( mbedtls_threading_mutex_t *mutex )
 {
-    if( mutex == NULL || !is_mutex_valid(mutex) )
+    if( mutex == NULL || !mutex_is_valid( mutex ) )
         return( MBEDTLS_ERR_THREADING_BAD_INPUT_DATA );
 
     if( pthread_mutex_unlock( &mutex->mutex ) != 0 )

--- a/library/threading.c
+++ b/library/threading.c
@@ -27,7 +27,6 @@
 
 #if defined(MBEDTLS_THREADING_C)
 
-#include <stdbool.h>
 #include "mbedtls/threading.h"
 
 #if defined(MBEDTLS_THREADING_PTHREAD)


### PR DESCRIPTION
While debugging an issue with a mismatch in header file config and the library I ran into an issue where the mutex memory was being corrupted, the is_valid field was corrupted but not being detected. This change makes the is_valid check more explicit to make it easier to catch issues like this.