### PR TITLE
bn_mul.h: fix x86 PIC inline ASM compilation with GCC < 5

### DIFF
--- a/ChangeLog.d/bn_mul-fix-x86-pic-compilation-for-gcc-4.txt
+++ b/ChangeLog.d/bn_mul-fix-x86-pic-compilation-for-gcc-4.txt
@@ -1,0 +1,4 @@
+Bugfix
+   * Fix a long-standing build failure when building x86 PIC code with old
+     gcc (4.x). The code will be slower, but will compile. We do however
+     recommend upgrading to a more recent compiler instead. Fixes #1910.

--- a/library/bn_mul.h
+++ b/library/bn_mul.h
@@ -91,12 +91,28 @@
     ( !defined(__ARMCC_VERSION) || __ARMCC_VERSION >= 6000000 )
 
 /*
+ * GCC < 5.0 treated the x86 ebx (which is used for the GOT) as a
+ * fixed reserved register when building as PIC, leading to errors
+ * like: bn_mul.h:46:13: error: PIC register clobbered by 'ebx' in 'asm'
+ *
+ * This is fixed by an improved register allocator in GCC 5+. From the
+ * release notes:
+ * Register allocation improvements: Reuse of the PIC hard register,
+ * instead of using a fixed register, was implemented on x86/x86-64
+ * targets. This improves generated PIC code performance as more hard
+ * registers can be used.
+ */
+#if defined(__GNUC__) && __GNUC__ < 5 && defined(__PIC__)
+#define MULADDC_CANNOT_USE_EBX
+#endif
+
+/*
  * Disable use of the i386 assembly code below if option -O0, to disable all
  * compiler optimisations, is passed, detected with __OPTIMIZE__
  * This is done as the number of registers used in the assembly code doesn't
  * work with the -O0 option.
  */
-#if defined(__i386__) && defined(__OPTIMIZE__)
+#if defined(__i386__) && defined(__OPTIMIZE__) && !defined(MULADDC_CANNOT_USE_EBX)
 
 #define MULADDC_X1_INIT                     \
     { mbedtls_mpi_uint t;                   \


### PR DESCRIPTION
Fixes #1910

With ebx added to the MULADDC_STOP clobber list to fix #1550, the inline
assembly fails to build with GCC < 5 in PIC mode with the following error:

include/mbedtls/bn_mul.h:46:13: error: PIC register clobbered by ‘ebx’ in ‘asm’

This is because older GCC versions treated the x86 ebx register (which is
used for the GOT) as a fixed reserved register when building as PIC.

This is fixed by an improved register allocator in GCC 5+.  From the release
notes:

Register allocation improvements: Reuse of the PIC hard register, instead of
using a fixed register, was implemented on x86/x86-64 targets.  This
improves generated PIC code performance as more hard registers can be used.

https://www.gnu.org/software/gcc/gcc-5/changes.html

As a workaround, detect this situation and disable the inline assembly,
similar to the MULADDC_CANNOT_USE_R7 logic.

Signed-off-by: Peter Korsgaard <peter@korsgaard.com>

## Status
**READY**

## Requires Backporting
**Yes**
Backport to 2.28 is #6096 

## Todos
- [ ] Tests
- [ ] Documentation
- [X] Changelog updated
- [X] Backported


## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.
