### PR TITLE
Fix documentation of allowed_pks field in mbedtls_x509_crt_profile

### DIFF
--- a/ChangeLog.d/doc-x509-profile-pk.txt
+++ b/ChangeLog.d/doc-x509-profile-pk.txt
@@ -1,0 +1,5 @@
+Bugfix
+   * Fix incorrect documentation of mbedtls_x509_crt_profile. The previous
+     documentation stated that the `allowed_pks` field applies to signatures
+     only, but in fact it does apply to the public key type of the end entity
+     certificate, too. Fixes #1992.

--- a/include/mbedtls/x509_crt.h
+++ b/include/mbedtls/x509_crt.h
@@ -191,7 +191,7 @@ typedef struct mbedtls_x509_crt_profile
 {
     uint32_t allowed_mds;       /**< MDs for signatures         */
     uint32_t allowed_pks;       /**< PK algs for public keys;
-                                 *   this applies to any CRT
+                                 *   this applies to all certificates
                                  *   in the provided chain.     */
     uint32_t allowed_curves;    /**< Elliptic curves for ECDSA  */
     uint32_t rsa_min_bitlen;    /**< Minimum size for RSA keys  */

--- a/include/mbedtls/x509_crt.h
+++ b/include/mbedtls/x509_crt.h
@@ -190,7 +190,9 @@ mbedtls_x509_subject_alternative_name;
 typedef struct mbedtls_x509_crt_profile
 {
     uint32_t allowed_mds;       /**< MDs for signatures         */
-    uint32_t allowed_pks;       /**< PK algs for signatures     */
+    uint32_t allowed_pks;       /**< PK algs for public keys;
+                                 *   this applies to any CRT
+                                 *   in the provided chain.     */
     uint32_t allowed_curves;    /**< Elliptic curves for ECDSA  */
     uint32_t rsa_min_bitlen;    /**< Minimum size for RSA keys  */
 }


### PR DESCRIPTION
This PR fixes the documentation bug #1992; see there for more information.

2.28 backport: https://github.com/Mbed-TLS/mbedtls/pull/5778