### PR TITLE
add support for MBEDTLS_SSL_VERIFY_EXTERNAL authmode

### DIFF
--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -166,6 +166,7 @@
 #define MBEDTLS_SSL_VERIFY_OPTIONAL             1
 #define MBEDTLS_SSL_VERIFY_REQUIRED             2
 #define MBEDTLS_SSL_VERIFY_UNSET                3 /* Used only for sni_authmode */
+#define MBEDTLS_SSL_VERIFY_EXTERNAL             4
 
 #define MBEDTLS_SSL_LEGACY_RENEGOTIATION        0
 #define MBEDTLS_SSL_SECURE_RENEGOTIATION        1
@@ -979,7 +980,7 @@ struct mbedtls_ssl_config
 
     unsigned int endpoint : 1;      /*!< 0: client, 1: server               */
     unsigned int transport : 1;     /*!< stream (TLS) or datagram (DTLS)    */
-    unsigned int authmode : 2;      /*!< MBEDTLS_SSL_VERIFY_XXX             */
+    unsigned int authmode : 3;      /*!< MBEDTLS_SSL_VERIFY_XXX             */
     /* needed even with renego disabled for LEGACY_BREAK_HANDSHAKE          */
     unsigned int allow_legacy_renegotiation : 2 ; /*!< MBEDTLS_LEGACY_XXX   */
 #if defined(MBEDTLS_ARC4_C)

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -5744,13 +5744,24 @@ crt_verify:
         /*
          * Main check: verify certificate
          */
-        ret = mbedtls_x509_crt_verify_restartable(
+
+        if( authmode == MBEDTLS_SSL_VERIFY_EXTERNAL )
+        {
+            if( NULL != ssl->conf->f_vrfy )
+            {
+                ret = ssl->conf->f_vrfy( ssl->conf->p_vrfy, ssl->session_negotiate->peer_cert, -1, &ssl->session_negotiate->verify_result );
+            }
+        }
+        else
+        {
+            ret = mbedtls_x509_crt_verify_restartable(
                                 ssl->session_negotiate->peer_cert,
                                 ca_chain, ca_crl,
                                 ssl->conf->cert_profile,
                                 ssl->hostname,
                                &ssl->session_negotiate->verify_result,
                                 ssl->conf->f_vrfy, ssl->conf->p_vrfy, rs_ctx );
+        }
 
         if( ret != 0 )
         {


### PR DESCRIPTION
This pull request adds a new "external" certificate verification mode that makes it possible for an application to override the certificate validation logic with much more flexibility and simplicity. I took special care in adding the new mode in a way that would make it easy to detect at compilation time and would not cause an API or ABI breakage.

Here is the list of changes:

1. New MBEDTLS_SSL_VERIFY_EXTERNAL (4) definition, can be used for compile-time detection
2. unsigned int autmode : 2 was changed to : 3 because the value 4 did not fit in 2 bits.
3. When the external mode is used, the verification callback is called with the certificate chain sent by the server and a depth of -1 to indicate that the entire chain, not a single certificate, is passed.

I have set the depth to -1 because in this case it should not mean anything, since we're passing the chain and not one certificate at a time like what I understood happens with some other modes.

The rationale for exposing the certificate chain sent by the server more directly to the application is that some cases cannot be easily covered without "polluting" the core library with too much application-specific or platform-specific logic. In the simplest case, one can just call the mbedtls APIs again with what has been passed in the callback to validate the certificate chain, and then handle validation failure in a custom way.

I see two major use cases for external certificate validation:

1) Application-specific handling of certificate exceptions. If automatic validation fails, the application can then present the certificate chain to the user for manual validation. The application may also save a hash of certificates that were marked as exceptions by the user, and add the exception list to the validation logic. This does not prevent the application by trying to validate the certificate chain with the same mbed TLS APIs used for automatic certificate validation, but it makes it easy to insert additional logic without touching the mbed TLS core libraries.

2) Validation against platform-specific certificate stores, the most notable one being the Windows certificate store that is not exposed in the form of a directory with PEM files. The mbed TLS API works well with file-based certificate stores and certificate bundles, but it does not support platform-specific certificate APIs, and as far as I know, it is not the goal of the project to do so. By exposing the certificate chain more directly to the application, it becomes easier to call platform-specific APIs to perform the validation against the system trusted certificates.

I have an mbed account with the same email used for the commit in this PR and I have accepted the contribution agreement. Please let me know what you think, I am open to making changes but I really think mbed TLS needs to allow external certificate validation logic in one way or another.

