### PR TITLE
Enable static linking of the common runtime in MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,9 +146,7 @@ if(MSVC)
             CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE
             CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO
             CMAKE_C_FLAGS_CHECK)
-            if(${flag_var} MATCHES "/MD")
-                string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
-            endif(${flag_var} MATCHES "/MD")
+            string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
         endforeach(flag_var)
     endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,18 +139,6 @@ if(CMAKE_COMPILER_IS_MSVC)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /WX")
 endif(CMAKE_COMPILER_IS_MSVC)
 
-if(MSVC)
-    option(BUILD_WITH_STATIC_RUNTIME "Build the libraries with /MT compiler flag" OFF)
-    if(BUILD_WITH_STATIC_RUNTIME)
-        foreach(flag_var
-            CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE
-            CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO
-            CMAKE_C_FLAGS_CHECK)
-            string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
-        endforeach(flag_var)
-    endif()
-endif()
-
 if(CMAKE_BUILD_TYPE STREQUAL "Coverage")
     if(CMAKE_COMPILER_IS_GNU OR CMAKE_COMPILER_IS_CLANG)
         set(CMAKE_SHARED_LINKER_FLAGS "--coverage")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,6 +139,20 @@ if(CMAKE_COMPILER_IS_MSVC)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /WX")
 endif(CMAKE_COMPILER_IS_MSVC)
 
+if(MSVC)
+    option(BUILD_WITH_STATIC_RUNTIME "Build the libraries with /MT compiler flag" OFF)
+    if(BUILD_WITH_STATIC_RUNTIME)
+        foreach(flag_var
+            CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE
+            CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO
+            CMAKE_C_FLAGS_CHECK)
+            if(${flag_var} MATCHES "/MD")
+                string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
+            endif(${flag_var} MATCHES "/MD")
+        endforeach(flag_var)
+    endif()
+endif()
+
 if(CMAKE_BUILD_TYPE STREQUAL "Coverage")
     if(CMAKE_COMPILER_IS_GNU OR CMAKE_COMPILER_IS_CLANG)
         set(CMAKE_SHARED_LINKER_FLAGS "--coverage")

--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,8 @@ Changes
    * Close a test gap in (D)TLS between the client side and the server side:
      test the handling of large packets and small packets on the client side
      in the same way as on the server side.
+   * Add a CMake option that enables static linking of the runtime library
+     in Microsoft Visual C++ compiler. Provided by Microplankton in #674.
 
 = mbed TLS 2.13.1 branch released 2018-09-06
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -14,7 +14,7 @@ Changes
      test the handling of large packets and small packets on the client side
      in the same way as on the server side.
    * Add a CMake option that enables static linking of the runtime library
-     in Microsoft Visual C++ compiler. Provided by Microplankton in #674.
+     in Microsoft Visual C++ compiler. Contributed by Microplankton.
 
 = mbed TLS 2.13.1 branch released 2018-09-06
 

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -98,6 +98,18 @@ if(CMAKE_COMPILER_IS_CLANG)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wmissing-declarations -Wmissing-prototypes -Wdocumentation -Wno-documentation-deprecated-sync -Wunreachable-code")
 endif(CMAKE_COMPILER_IS_CLANG)
 
+if(CMAKE_COMPILER_IS_MSVC)
+    option(MSVC_STATIC_RUNTIME "Build the libraries with /MT compiler flag" OFF)
+    if(MSVC_STATIC_RUNTIME)
+        foreach(flag_var
+            CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE
+            CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO
+            CMAKE_C_FLAGS_CHECK)
+            string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
+        endforeach(flag_var)
+    endif()
+endif()
+
 if(WIN32)
     set(libs ${libs} ws2_32)
 endif(WIN32)


### PR DESCRIPTION
This PR introduces a new option in the CMake script, that enables static linking of the MSVC common runtime. It continues work started in #674.


## Status
READY

## Requires Backporting
NO  

## Migrations
NO

## Additional comments
None

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
None
