### PR TITLE
fix asn1 integer functions

### DIFF
--- a/include/mbedtls/asn1.h
+++ b/include/mbedtls/asn1.h
@@ -351,6 +351,34 @@ void mbedtls_asn1_free_named_data( mbedtls_asn1_named_data *entry );
  */
 void mbedtls_asn1_free_named_data_list( mbedtls_asn1_named_data **head );
 
+/**
+ * \brief       Verify that the integer is the smallest possible number
+ *              of octets
+ *
+ * \param p     The position in the ASN.1 data
+ * \param len   ASN1 length, in octets.
+ */
+static inline int mbedtls_check_shortest_asn1_integer( unsigned char *p, size_t len )
+{
+    if( len < 2 )
+        return 0;
+
+    if( *(p+1) & 0x80 )
+    {
+        if( *p == 0xff )
+        {
+            return ( MBEDTLS_ERR_ASN1_INVALID_DATA );
+        }
+    }
+    else
+    {
+        if( *p == 0 )
+        {
+            return ( MBEDTLS_ERR_ASN1_INVALID_DATA );
+        }
+    }
+    return 0;
+}
 #ifdef __cplusplus
 }
 #endif

--- a/include/mbedtls/asn1.h
+++ b/include/mbedtls/asn1.h
@@ -353,31 +353,37 @@ void mbedtls_asn1_free_named_data_list( mbedtls_asn1_named_data **head );
 
 /**
  * \brief       Verify that the integer is the smallest possible number
- *              of octets
+ *              of octets.
  *
- * \param p     The position in the ASN.1 data
- * \param len   ASN1 length, in octets.
+ * \param p     The start of the buffer which is encoded by ASN1
+ * \param len   The length of the buffer
  */
 static inline int mbedtls_check_shortest_asn1_integer( unsigned char *p, size_t len )
 {
     if( len < 2 )
-        return 0;
+    {
+        return( 0 );
+    }
 
-    if( *(p+1) & 0x80 )
+    /*
+     * If the contents octets of an integer value encoding consist of
+     * more than one octet,
+     * then the bits of the first octet and bit 8 of the second octet:
+     *  a) shall not all be ones and
+     *  b) shall not all be zero.
+     * These rules ensure that an integer value is always encoded in
+     * the smallest possible number of octets.
+     */
+    if( *p == 0x00 && ( *(p+1) & 0x80 ) == 0 )
     {
-        if( *p == 0xff )
-        {
-            return ( MBEDTLS_ERR_ASN1_INVALID_DATA );
-        }
+        return( MBEDTLS_ERR_ASN1_INVALID_DATA );
     }
-    else
+    else if( *p == 0xff && ( *(p+1) & 0x80 ) != 0 )
     {
-        if( *p == 0 )
-        {
-            return ( MBEDTLS_ERR_ASN1_INVALID_DATA );
-        }
+        return( MBEDTLS_ERR_ASN1_INVALID_DATA );
     }
-    return 0;
+
+    return( 0 );
 }
 #ifdef __cplusplus
 }

--- a/library/asn1parse.c
+++ b/library/asn1parse.c
@@ -149,10 +149,16 @@ int mbedtls_asn1_get_int( unsigned char **p,
     if( ( ret = mbedtls_asn1_get_tag( p, end, &len, MBEDTLS_ASN1_INTEGER ) ) != 0 )
         return( ret );
 
-    if( len == 0 || len > sizeof( int ) || ( **p & 0x80 ) != 0 )
+    if( len == 0 || len > sizeof( int ) )
         return( MBEDTLS_ERR_ASN1_INVALID_LENGTH );
 
-    *val = 0;
+    if( ( ret = mbedtls_check_shortest_asn1_integer( *p, len ) ) != 0 )
+        return( ret );
+
+    if( **p & 0x80 )
+        *val = -1; // all bits set to 1
+    else
+        *val = 0;
 
     while( len-- > 0 )
     {
@@ -172,6 +178,9 @@ int mbedtls_asn1_get_mpi( unsigned char **p,
     size_t len;
 
     if( ( ret = mbedtls_asn1_get_tag( p, end, &len, MBEDTLS_ASN1_INTEGER ) ) != 0 )
+        return( ret );
+
+    if( ( ret = mbedtls_check_shortest_asn1_integer( *p, len ) ) != 0 )
         return( ret );
 
     ret = mbedtls_mpi_read_binary( X, *p, len );

--- a/library/asn1parse.c
+++ b/library/asn1parse.c
@@ -149,16 +149,13 @@ int mbedtls_asn1_get_int( unsigned char **p,
     if( ( ret = mbedtls_asn1_get_tag( p, end, &len, MBEDTLS_ASN1_INTEGER ) ) != 0 )
         return( ret );
 
-    if( len == 0 || len > sizeof( int ) )
+    if( len == 0 || len > sizeof( int ) || ( **p & 0x80 ) != 0 )
         return( MBEDTLS_ERR_ASN1_INVALID_LENGTH );
 
     if( ( ret = mbedtls_check_shortest_asn1_integer( *p, len ) ) != 0 )
         return( ret );
 
-    if( **p & 0x80 )
-        *val = -1; // all bits set to 1
-    else
-        *val = 0;
+    *val = 0;
 
     while( len-- > 0 )
     {

--- a/library/asn1write.c
+++ b/library/asn1write.c
@@ -234,30 +234,33 @@ int mbedtls_asn1_write_bool( unsigned char **p, unsigned char *start, int boolea
 int mbedtls_asn1_write_int( unsigned char **p, unsigned char *start, int val )
 {
     int ret;
+    size_t len;
+#if __BYTE_ORDER == __LITTLE_ENDIAN
     unsigned i;
     unsigned char *c;
-    size_t len = 0;
+#endif
 
-    if( *p - start < 1 )
+    if( *p - start < (unsigned)sizeof(int) )
         return( MBEDTLS_ERR_ASN1_BUF_TOO_SMALL );
 
+#if __BYTE_ORDER == __LITTLE_ENDIAN
     c = (unsigned char *)&val;
-
-    // assume that little-endian
     for( i = 0 ; i < sizeof(int) ; i++ )
     {
         *--(*p) = c[i];
-        len += 1;
     }
+#else
+    (*p) -= sizeof(int);
+    *((int *)(*p)) = val;
+#endif
 
-    for( i = 0; i < sizeof(int)-1 ; i++ )
+    for( len = sizeof(int) ; len > 0 ; len-- )
     {
        if( mbedtls_check_shortest_asn1_integer( *p, len ) == 0 )
        {
            break;
        }
        ++(*p);
-       len -= 1;
     }
 
     MBEDTLS_ASN1_CHK_ADD( len, mbedtls_asn1_write_len( p, start, len ) );

--- a/library/asn1write.c
+++ b/library/asn1write.c
@@ -240,7 +240,7 @@ int mbedtls_asn1_write_int( unsigned char **p, unsigned char *start, int val )
     unsigned char *c;
 #endif
 
-    if( *p - start < (unsigned)sizeof(int) )
+    if( *p < start || (size_t)( *p - start ) < sizeof(int) )
         return( MBEDTLS_ERR_ASN1_BUF_TOO_SMALL );
 
 #if __BYTE_ORDER == __LITTLE_ENDIAN

--- a/library/asn1write.c
+++ b/library/asn1write.c
@@ -254,7 +254,7 @@ int mbedtls_asn1_write_int( unsigned char **p, unsigned char *start, int val )
         len += 1;
     }
 
-    for( i = 0; i < len ; i++ )
+    for( i = 0; i < sizeof(int) ; i++ )
     {
        if( mbedtls_check_shortest_asn1_integer( *p, len ) == 0 )
        {


### PR DESCRIPTION
According to the integer encodings of x.690,
the shortest possible length encoding must be used.

issue: https://github.com/ARMmbed/mbedtls/issues/2099

the following functions are modified.
mbedtls_asn1_write_int
mbedtls_asn1_get_int
mbedtls_asn1_get_mpi
