### PR TITLE
Private RSA Montgomery Ladder Implementation

### DIFF
--- a/include/mbedtls/bignum.h
+++ b/include/mbedtls/bignum.h
@@ -795,6 +795,27 @@ int mbedtls_mpi_exp_mod( mbedtls_mpi *X, const mbedtls_mpi *A,
                          mbedtls_mpi *_RR );
 
 /**
+ * \brief          Montgomery Ladder Exponentiation: X = A^E mod N
+ *
+ * \param X        Destination MPI
+ * \param A        Left-hand MPI
+ * \param E        Exponent MPI
+ * \param N        Modular MPI
+ * \param _RR      Speed-up MPI used for recalculations
+ *
+ * \return         0 if successful,
+ *                 MBEDTLS_ERR_MPI_ALLOC_FAILED if memory allocation failed,
+ *                 MBEDTLS_ERR_MPI_BAD_INPUT_DATA if N is negative or even or
+ *                 if E is negative
+ *
+ * \note           _RR is used to avoid re-computing R*R mod N across
+ *                 multiple calls, which speeds up things a bit. It can
+ *                 be set to NULL if the extra performance is unneeded.
+ */
+int mbedtls_mpi_exp_mod_montladder( mbedtls_mpi *X, const mbedtls_mpi *A, const mbedtls_mpi *E, const mbedtls_mpi *N, mbedtls_mpi *_RR );
+
+
+/**
  * \brief          Fill an MPI with a number of random bytes.
  *
  * \param X        The destination MPI. This must point to an initialized MPI.

--- a/include/mbedtls/rsa.h
+++ b/include/mbedtls/rsa.h
@@ -66,8 +66,8 @@
 /*
  * RSA constants
  */
-#define MBEDTLS_RSA_PUBLIC      0 /**< Request private key operation. */
-#define MBEDTLS_RSA_PRIVATE     1 /**< Request public key operation. */
+#define MBEDTLS_RSA_PUBLIC      0 /**< Request public key operation. */
+#define MBEDTLS_RSA_PRIVATE     1 /**< Request private key operation. */
 
 #define MBEDTLS_RSA_PKCS_V15    0 /**< Use PKCS#1 v1.5 encoding. */
 #define MBEDTLS_RSA_PKCS_V21    1 /**< Use PKCS#1 v2.1 encoding. */
@@ -76,6 +76,9 @@
 #define MBEDTLS_RSA_CRYPT       2 /**< Identifier for RSA encryption and decryption operations. */
 
 #define MBEDTLS_RSA_SALT_LEN_ANY    -1
+
+#define MBEDTLS_RSA_CONSTANT_TIME 1
+
 
 /*
  * The above constants may be used even if the RSA module is compile out,

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -2058,6 +2058,10 @@ int mbedtls_mpi_exp_mod_montladder( mbedtls_mpi *X, const mbedtls_mpi * A, const
     mbedtls_mpi RR, T, L0, L1, Apos;
     int neg;
 
+    MPI_VALIDATE_RET( X != NULL );
+    MPI_VALIDATE_RET( A != NULL );
+    MPI_VALIDATE_RET( E != NULL );
+    MPI_VALIDATE_RET( N != NULL );
 
     if( mbedtls_mpi_cmp_int( N, 0 ) <= 0 || ( N->p[0] & 1 ) == 0 )
         return( MBEDTLS_ERR_MPI_BAD_INPUT_DATA );


### PR DESCRIPTION
Notes:
* Pull requests cannot be accepted until:
-  The submitter has [accepted the online agreement here with a click through](https://developer.mbed.org/contributor_agreement/) 
   or for companies or those that do not wish to create an mbed account, a slightly different agreement can be found [here](https://www.mbed.com/en/about-mbed/contributor-license-agreements/)
- The PR follows the [mbed TLS coding standards](https://tls.mbed.org/kb/development/mbedtls-coding-standards)
* This is just a template, so feel free to use/remove the unnecessary things
## Description
This PR implements Montgomery ladder exponentiation (applied to private RSA operations) as a constant time improvement for mbedTLS.

A brief description has been attached.
[montgomeryEnhancement.docx](https://github.com/ARMmbed/mbedtls/files/2880863/montgomeryEnhancement.docx)



## Status
**READY**

## Requires Backporting
When there is a bug fix, it should be backported to all maintained and supported branches.
Changes do not have to be backported if:
- This PR is a new feature\enhancement
- This PR contains changes in the API. If this is true, and there is a need for the fix to be backported, the fix should be handled differently in the legacy branch

NO  

## Migrations
If there is any API change, what's the incentive and logic for it.

NO

## Additional comments
Any additional information that could be of interest

## Todos
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.
