### PR TITLE
Fix filtering of excluded tests in compat.sh

### DIFF
--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -170,16 +170,24 @@ filter()
 {
   LIST="$1"
   NEW_LIST=""
+  EXCLMODE=""
+  CMP=""
 
   if is_dtls "$MODE"; then
-      EXCLMODE="$EXCLUDE"'\|RC4\|ARCFOUR'
-  else
-      EXCLMODE="$EXCLUDE"
+    EXCLMODE='RC4\|ARCFOUR'
+  fi
+
+  if [ "X" != "X$EXCLUDE" ]; then
+    EXCLMODE="$EXCLUDE\|$EXCLMODE"
   fi
 
   for i in $LIST;
   do
-    NEW_LIST="$NEW_LIST $( echo "$i" | grep "$FILTER" | grep -v "$EXCLMODE" )"
+    CMP="$( echo "$i" | grep "$FILTER" )"
+    if [ "X" != "X$EXCLMODE" ]; then
+      CMP="$( echo "$CMP" | grep -v "$EXCLMODE" )"
+    fi
+    NEW_LIST="$NEW_LIST $CMP"
   done
 
   # normalize whitespace

--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -171,24 +171,30 @@ filter()
   LIST="$1"
   NEW_LIST=""
   EXCLMODE=""
-  CMP=""
 
   if is_dtls "$MODE"; then
     EXCLMODE='RC4\|ARCFOUR'
   fi
 
   if [ "X" != "X$EXCLUDE" ]; then
-    EXCLMODE="$EXCLUDE\|$EXCLMODE"
+    if [ "X" != "X$EXCLMODE" ]; then
+      EXCLMODE="$EXCLUDE"'\|'"$EXCLMODE"
+    else
+      EXCLMODE="$EXCLUDE"
+    fi
   fi
 
-  for i in $LIST;
-  do
-    CMP="$( echo "$i" | grep "$FILTER" )"
-    if [ "X" != "X$EXCLMODE" ]; then
-      CMP="$( echo "$CMP" | grep -v "$EXCLMODE" )"
-    fi
-    NEW_LIST="$NEW_LIST $CMP"
-  done
+  if [ "X" != "X$EXCLMODE" ]; then
+    for i in $LIST;
+    do
+      NEW_LIST="$NEW_LIST $( echo "$i" | grep "$FILTER" | grep -v "$EXCLMODE" )"
+    done
+  else
+    for i in $LIST;
+    do
+      NEW_LIST="$NEW_LIST $( echo "$i" | grep "$FILTER" )"
+    done
+  fi
 
   # normalize whitespace
   echo "$NEW_LIST" | sed -e 's/[[:space:]][[:space:]]*/ /g' -e 's/^ //' -e 's/ $//'

--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -55,7 +55,7 @@ fi
 MODES="tls1 tls1_1 tls1_2 dtls1 dtls1_2"
 VERIFIES="NO YES"
 TYPES="ECDSA RSA PSK"
-FILTER=""
+FILTER=".*"
 # exclude:
 # - NULL: excluded from our default config
 # - RC4, single-DES: requires legacy OpenSSL/GnuTLS versions
@@ -74,8 +74,8 @@ PEERS="OpenSSL$PEER_GNUTLS mbedTLS"
 print_usage() {
     echo "Usage: $0"
     printf "  -h|--help\tPrint this help.\n"
-    printf "  -f|--filter\tOnly matching ciphersuites are tested (Default: '$FILTER')\n"
-    printf "  -e|--exclude\tMatching ciphersuites are excluded (Default: '$EXCLUDE')\n"
+    printf "  -f|--filter\tOnly matching ciphersuites are executed (BRE; default: '$FILTER')\n"
+    printf "  -e|--exclude\tMatching ciphersuites are excluded (BRE; default: '$EXCLUDE')\n"
     printf "  -m|--modes\tWhich modes to perform (Default: '$MODES')\n"
     printf "  -t|--types\tWhich key exchange type to perform (Default: '$TYPES')\n"
     printf "  -V|--verify\tWhich verification modes to perform (Default: '$VERIFIES')\n"

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -509,6 +509,15 @@ detect_dtls() {
     fi
 }
 
+filter()
+{
+    if [ "X" != "X$EXCLUDE" ]; then
+        echo "$1" | grep "$FILTER" | grep -v "$EXCLUDE"
+    else
+        echo "$1" | grep "$FILTER"
+    fi
+}
+
 # Usage: run_test name [-p proxy_cmd] srv_cmd cli_cmd cli_exit [option [...]]
 # Options:  -s pattern  pattern that must be present in server output
 #           -c pattern  pattern that must be present in client output
@@ -522,7 +531,7 @@ run_test() {
     NAME="$1"
     shift 1
 
-    if echo "$NAME" | grep "$FILTER" | grep -v "$EXCLUDE" >/dev/null; then :
+    if filter "$NAME" >/dev/null; then :
     else
         SKIP_NEXT="NO"
         return


### PR DESCRIPTION
## Description
Currently, `./tests/compat.sh` filters the excluded tests specified with the `-e` option using the `grep -v` command. This means that all tests will be excluded if the user specifies `./tests/compat.sh -e ''` (i.e. do not exclude any tests).

This change fixes the `-e` option so that supplying an empty argument actually runs all the tests (and avoids running `grep -v`).

## Status
**READY**

## Requires Backporting
Yes