### PR TITLE
Fix typo in config-no-entropy.h

### DIFF
--- a/configs/config-no-entropy.h
+++ b/configs/config-no-entropy.h
@@ -21,7 +21,7 @@
  */
 /*
  * Minimal configuration of features that do not require an entropy source
- * Distinguishing reatures:
+ * Distinguishing features:
  * - no entropy module
  * - no TLS protocol implementation available due to absence of an entropy
  *   source


### PR DESCRIPTION
## Description
Fix typo, reatures -> features

## Status
READY

## Requires Backporting
NO  

## Migrations
NO