### PR TITLE
x509_crt: handle properly broken links when looking for certificates

### DIFF
--- a/ChangeLog.d/x509-broken-symlink-handling.txt
+++ b/ChangeLog.d/x509-broken-symlink-handling.txt
@@ -1,0 +1,5 @@
+Bugfix
+   * Fix handling of broken symlinks when loading certificates using
+     mbedtls_x509_crt_parse_path(). Instead of returning an error as soon as a
+     broken link is encountered, skip the broken link and continue parsing
+     other certificate files. Contributed by Eduardo Silva in #2602.

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -1679,8 +1679,8 @@ cleanup:
                 {
                     if( errno == ENOENT )
                     {
-                        /* Broken link */
-                        ret++;
+                        /* Broken link - ignore this entry */
+                        continue;
                     }
                     else
                     {

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -1656,37 +1656,23 @@ cleanup:
             ret = MBEDTLS_ERR_X509_BUFFER_TOO_SMALL;
             goto cleanup;
         }
-        else
+        else if( stat( entry_name, &sb ) == -1 )
         {
-            /* Determine if the file entry could be a link. Using lstat(2)
-             * is safer than just stat(2), otherwise a broken link will
-             * give us a false positive. */
-            if( lstat( entry_name, &sb ) == -1 )
+            if( errno == ENOENT )
             {
+                /* Broken symbolic link - ignore this entry.
+                    stat(2) will return this error for either (a) a dangling
+                    symlink or (b) a missing file.
+                    Given that we have just obtained the filename from readdir,
+                    assume that it does exist and therefore treat this as a
+                    dangling symlink. */
+                continue;
+            }
+            else
+            {
+                /* Some other file error; report the error. */
                 ret = MBEDTLS_ERR_X509_FILE_IO_ERROR;
                 goto cleanup;
-            }
-
-            /* If the file is a symbolic link, we need to validate the real
-             * information using stat(2). */
-            if( S_ISLNK( sb.st_mode ) )
-            {
-                /* If stat(2) fails it could be a broken link or a generic
-                 * error. If the link is broken, ignore it, otherwise
-                 * just set a MBEDTLS_ERR_X509_FILE_IO_ERROR. */
-                if( stat( entry_name, &sb ) == -1 )
-                {
-                    if( errno == ENOENT )
-                    {
-                        /* Broken link - ignore this entry */
-                        continue;
-                    }
-                    else
-                    {
-                        ret = MBEDTLS_ERR_X509_FILE_IO_ERROR;
-                        goto cleanup;
-                    }
-                }
             }
         }
 

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -1658,7 +1658,7 @@ cleanup:
         }
         else
         {
-            /* determinate if the file entry could be a link, using lstat(2)
+            /* Determine if the file entry could be a link. Using lstat(2)
              * is safer than just stat(2), otherwise a broken link will
              * give us a false positive. */
             if( lstat( entry_name, &sb ) == -1 )
@@ -1667,13 +1667,12 @@ cleanup:
                 goto cleanup;
             }
 
-            /* if the file is a symbolic link, we need to validate the real
+            /* If the file is a symbolic link, we need to validate the real
              * information using stat(2). */
             if( S_ISLNK( sb.st_mode ) )
             {
-                /* if stat(2) fails it could be a broken link or a generic
-                 * error, if the link is broken, just report it as a
-                 * certificate that could not be processed, otherwise
+                /* If stat(2) fails it could be a broken link or a generic
+                 * error. If the link is broken, ignore it, otherwise
                  * just set a MBEDTLS_ERR_X509_FILE_IO_ERROR. */
                 if( stat( entry_name, &sb ) == -1 )
                 {


### PR DESCRIPTION
## Description

On non-windows environments, when loading certificates from a given
path through mbedtls_x509_crt_parse_path() function, if a symbolic
link is found and is broken (meaning the target file don't exists),
the function is returning MBEDTLS_ERR_X509_FILE_IO_ERROR which is
not honoring the default behavior of just skip the bad certificate file
and increase the counter of wrong files.

The problem have been raised many times in our open source project
called Fluent Bit which depends on MbedTLS:

https://github.com/fluent/fluent-bit/issues/843#issuecomment-486388209

The expected behavior is that if a simple certificate cannot be processed,
it should just be skipped.

This patch implements a workaround with lstat(2) and stat(2) to determinate
first, if the entry found in the directory is a symbolic link or not, if is
a symbolic link, do a proper stat(2) for the target file, otherwise process
normally. Upon finding a broken symbolic link it will increase the counter of
not processed certificates.

## Status
**READY**

Backport in #6161 