### PR TITLE
Allow x509 crt error strings to be used externally

### DIFF
--- a/include/mbedtls/x509_crt.h
+++ b/include/mbedtls/x509_crt.h
@@ -99,6 +99,16 @@ typedef struct mbedtls_x509_crt
 mbedtls_x509_crt;
 
 /**
+ * Container for x509 certificate verification error strings
+ */
+typedef struct
+{
+    int code;
+    const char *string;
+}
+mbedtls_crt_verify_string;
+
+/**
  * From RFC 5280 section 4.2.1.6:
  * OtherName ::= SEQUENCE {
  *      type-id    OBJECT IDENTIFIER,
@@ -258,6 +268,8 @@ typedef struct
 typedef void mbedtls_x509_crt_restart_ctx;
 
 #endif /* MBEDTLS_ECDSA_C && MBEDTLS_ECP_RESTARTABLE */
+
+extern const mbedtls_crt_verify_string x509_crt_verify_strings[];
 
 #if defined(MBEDTLS_X509_CRT_PARSE_C)
 /**

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -2195,12 +2195,7 @@ int mbedtls_x509_crt_info( char *buf, size_t size, const char *prefix,
     return( (int) ( size - n ) );
 }
 
-struct x509_crt_verify_string {
-    int code;
-    const char *string;
-};
-
-static const struct x509_crt_verify_string x509_crt_verify_strings[] = {
+const mbedtls_crt_verify_string x509_crt_verify_strings[] = {
     { MBEDTLS_X509_BADCERT_EXPIRED,       "The certificate validity has expired" },
     { MBEDTLS_X509_BADCERT_REVOKED,       "The certificate has been revoked (is on a CRL)" },
     { MBEDTLS_X509_BADCERT_CN_MISMATCH,   "The certificate Common Name (CN) does not match with the expected CN" },
@@ -2228,7 +2223,7 @@ int mbedtls_x509_crt_verify_info( char *buf, size_t size, const char *prefix,
                           uint32_t flags )
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
-    const struct x509_crt_verify_string *cur;
+    const mbedtls_crt_verify_string *cur;
     char *p = buf;
     size_t n = size;
 


### PR DESCRIPTION
The motivation for this patch is to allow for iteration over the
error strings against the return from mbedtls_ssl_get_verify_results
directly. Currently to report multiple errors in a linewise fashion,
I call mbedtls_x509_crt_verify_info with a dummy prefix, and then
parse out this prefix and newlines from the buffer.

Signed-off-by: Richard Robbins <mail@rcr.io>

## Requires Backporting
No

## Migrations
No
