### PR TITLE
Fix memcpy of null pointer found by Clang static analyzer

### DIFF
--- a/library/aes.c
+++ b/library/aes.c
@@ -1198,7 +1198,7 @@ int mbedtls_aes_crypt_xts( mbedtls_aes_xts_context *ctx,
     size_t blocks = length / 16;
     size_t leftover = length % 16;
     unsigned char tweak[16];
-    unsigned char prev_tweak[16];
+    unsigned char prev_tweak[16] = {0};
     unsigned char tmp[16];
 
     AES_VALIDATE_RET( ctx != NULL );

--- a/library/asn1write.c
+++ b/library/asn1write.c
@@ -472,7 +472,7 @@ mbedtls_asn1_named_data *mbedtls_asn1_store_named_data(
         cur->val.len = val_len;
     }
 
-    if( val != NULL )
+    if( val != NULL && cur->val.p != NULL )
         memcpy( cur->val.p, val, val_len );
 
     return( cur );

--- a/library/rsa.c
+++ b/library/rsa.c
@@ -2191,7 +2191,7 @@ int mbedtls_rsa_rsassa_pss_verify_ext( mbedtls_rsa_context *ctx,
     size_t observed_salt_len, msb;
     const mbedtls_md_info_t *md_info;
     mbedtls_md_context_t md_ctx;
-    unsigned char buf[MBEDTLS_MPI_MAX_SIZE];
+    unsigned char buf[MBEDTLS_MPI_MAX_SIZE] = {0};
 
     RSA_VALIDATE_RET( ctx != NULL );
     RSA_VALIDATE_RET( mode == MBEDTLS_RSA_PRIVATE ||


### PR DESCRIPTION
## Description
Fixes a few issues found by clang static analyzer.

## Status
**READY**

## Requires Backporting
Yes

## Steps to test or reproduce
Build with `scan-build`.
