### PR TITLE
Use getrandom() on Linux even if libc isn't Glibc

### DIFF
--- a/ChangeLog.d/_GNU_SOURCE-redefined.txt
+++ b/ChangeLog.d/_GNU_SOURCE-redefined.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix the build when the macro _GNU_SOURCE is defined to a non-empty value.
+     Fix #3432.

--- a/ChangeLog.d/getrandom.txt
+++ b/ChangeLog.d/getrandom.txt
@@ -1,0 +1,7 @@
+Changes
+   * On Linux, use the getrandom() system call if available, even when
+     building with a libc that does not define __GLIBC__. This
+     requires the libc to provide <sys/syscall.h> and a syscall()
+     function. As before, getrandom() is only used if SYS_getrandom is
+     defined during the build and there is a runtime fallback to
+     /dev/urandom if the getrandom() system call fails.

--- a/ChangeLog.d/getrandom.txt
+++ b/ChangeLog.d/getrandom.txt
@@ -1,2 +1,0 @@
-Changes
-   Use glibc's getrandom() instead of syscall when glibc > 2.25.

--- a/library/entropy_poll.c
+++ b/library/entropy_poll.c
@@ -85,11 +85,10 @@ int mbedtls_platform_entropy_poll( void *data, unsigned char *output, size_t len
 #else /* _WIN32 && !EFIX64 && !EFI32 */
 
 /*
- * Test for Linux getrandom() support.
- * Since there is no wrapper in the libc yet, use the generic syscall wrapper
- * available in GNU libc and compatible libc's (eg uClibc).
+ * Test for Linux getrandom() support. Since many libc implementations on
+ * Linux don't have a wrapper for getrandom(), issue the system call directly.
  */
-#if ((defined(__linux__) && defined(__GLIBC__)) || defined(__midipix__))
+#if defined(__linux__) || defined(__midipix__)
 #include <unistd.h>
 #include <sys/syscall.h>
 #if defined(SYS_getrandom)

--- a/library/entropy_poll.c
+++ b/library/entropy_poll.c
@@ -17,7 +17,7 @@
  *  limitations under the License.
  */
 
-#if defined(__linux__)
+#if defined(__linux__) && !defined(_GNU_SOURCE)
 /* Ensure that syscall() is available even when compiling with -std=c99 */
 #define _GNU_SOURCE
 #endif

--- a/library/entropy_poll.c
+++ b/library/entropy_poll.c
@@ -91,8 +91,16 @@ int mbedtls_platform_entropy_poll( void *data, unsigned char *output, size_t len
 #if defined(__linux__) || defined(__midipix__)
 #include <unistd.h>
 #include <sys/syscall.h>
+
 #if defined(SYS_getrandom)
 #define HAVE_GETRANDOM
+#elif defined(__NR_getrandom)
+#define HAVE_GETRANDOM
+#define SYS_getrandom __NR_getrandom
+#endif
+#endif /* __linux__ || __midipix__ */
+
+#if defined(HAVE_GETRANDOM)
 #include <errno.h>
 
 static int getrandom_wrapper( void *buf, size_t buflen, unsigned int flags )
@@ -105,8 +113,7 @@ static int getrandom_wrapper( void *buf, size_t buflen, unsigned int flags )
 #endif
     return( syscall( SYS_getrandom, buf, buflen, flags ) );
 }
-#endif /* SYS_getrandom */
-#endif /* __linux__ || __midipix__ */
+#endif /* HAVE_GETRANDOM */
 
 /*
  * Some BSD systems provide KERN_ARND.


### PR DESCRIPTION
As discussed in https://github.com/ARMmbed/mbedtls/issues/3432, improve support for non-glibc libc on Linux. Now getrandom() should be used with all major libc.

I tested locally with the libc that I had readily available:

* Compile with glibc 2.31 (Ubuntu 20.04), run on glibc 2.23 (Ubuntu 16.04), both amd64. This worked before #3642, broke with #3642, works again with my PR.
* Compile and run with musl (`make CC='musl-gcc'`).
* Compile and run with dietlibc (`make CC='diet gcc' LDFLAGS='-lcompat'`). Now that dietlibc will be using `getrandom_wrapper`, linking with `-lcompat` has become necessary. Dietlibc actually defines a `getrandom()` function, but I don't know how to declare its availability.

I checked the source of [uClibc](https://git.uclibc.org/uClibc/tree/include/sys/syscall.h) and [bionic](https://android.googlesource.com/platform/bionic/+/refs/heads/master/libc/include/sys/syscall.h) and both have `<sys/syscall.h>` and `syscall()`. It would be good to test them. Are there other libc that we should check?

Depends on https://github.com/ARMmbed/mbedtls/pull/3734.
