### PR TITLE
Add support for opaque key derivation #3718

### DIFF
--- a/ChangeLog.d/support_opaque_key_derivation_3718.txt
+++ b/ChangeLog.d/support_opaque_key_derivation_3718.txt
@@ -1,0 +1,4 @@
+Features:
+   * Add support for key derivation with opaque keys, as described in #3718.
+     A new driver entry point is required for this operation. Note: only
+     HKDF is currently supported.

--- a/ChangeLog.d/support_opaque_key_derivation_3718.txt
+++ b/ChangeLog.d/support_opaque_key_derivation_3718.txt
@@ -1,4 +1,4 @@
-Features:
+Features
    * Add support for key derivation with opaque keys, as described in #3718.
      A new driver entry point is required for this operation. Note: only
      HKDF is currently supported.

--- a/docs/proposed/psa-driver-interface.md
+++ b/docs/proposed/psa-driver-interface.md
@@ -304,10 +304,23 @@ This family requires the following type and entry points:
 * `"key_derivation_output_bytes"`: called by `psa_key_derivation_output_bytes()`; also by `psa_key_derivation_output_key()` for transparent drivers.
 * `"key_derivation_output_key"`: called by `psa_key_derivation_output_key()` for transparent drivers when deriving an asymmetric key pair, and also for opaque drivers.
 * `"key_derivation_abort"`: called by all key derivation functions of the PSA Cryptography API.
+* `"key_derivation_oneshot"`: called by `psa_key_derivation_output_bytes()` and `psa_key_derivation_output_key()` when the output is derived from an opaque secret. Note: HKDF is currently the only algorithm that is supported for opaque key derivation.
+
+A `"key_derivation_oneshot"` entry point for a driver with the prefix `"acme_opaque"`must have the following signature (assuming the `"names"` property is not used):
+```
+psa_status_t acme_opaque_key_derivation_oneshot(psa_algorithm_t alg,
+                                                const psa_key_attributes_t *secret_key_attributes,
+                                                const uint8_t *secret_key_buffer,
+                                                size_t secret_key_size,
+                                                const psa_key_derivation_input_buffer_t *input_array,
+                                                size_t input_count,
+                                                const psa_key_attributes_t *output_key_attributes,
+                                                uint8_t *output_key_buffer,
+                                                size_t output_key_size,
+                                                size_t *output_key_length);
+```
 
 TODO: key input and output for opaque drivers; deterministic key generation for transparent drivers
-
-TODO
 
 ### Driver entry points for key management
 

--- a/include/psa/crypto_struct.h
+++ b/include/psa/crypto_struct.h
@@ -262,11 +262,31 @@ typedef struct psa_tls12_prf_key_derivation_s
 } psa_tls12_prf_key_derivation_t;
 #endif /* MBEDTLS_MD_C */
 
+typedef struct {
+    const uint8_t *data;
+    size_t length;
+    psa_key_derivation_step_t step;
+} psa_key_derivation_input_buffer_t;
+
+typedef struct psa_opaque_key_derivation_s {
+    psa_key_handle_t key;
+    uint8_t *salt;
+    size_t salt_length;
+    uint8_t *label;
+    size_t label_length;
+    uint8_t *info;
+    size_t info_length;
+    uint8_t *seed;
+    size_t seed_length;
+} psa_opaque_key_derivation_t;
+
 struct psa_key_derivation_s
 {
     psa_algorithm_t alg;
     unsigned int can_output_key : 1;
+    unsigned int storing_references : 1; /* Indicates input is just stored */
     size_t capacity;
+    psa_key_derivation_input_buffer_t stored_input;
     union
     {
         /* Make the union non-empty even with no supported algorithms. */
@@ -275,11 +295,12 @@ struct psa_key_derivation_s
         psa_hkdf_key_derivation_t hkdf;
         psa_tls12_prf_key_derivation_t tls12_prf;
 #endif
+        psa_opaque_key_derivation_t opaque_kdf;
     } ctx;
 };
 
 /* This only zeroes out the first byte in the union, the rest is unspecified. */
-#define PSA_KEY_DERIVATION_OPERATION_INIT {0, 0, 0, {0}}
+#define PSA_KEY_DERIVATION_OPERATION_INIT {0, 0, 0, 0, {0}, {0}}
 static inline struct psa_key_derivation_s psa_key_derivation_operation_init( void )
 {
     const struct psa_key_derivation_s v = PSA_KEY_DERIVATION_OPERATION_INIT;

--- a/include/psa/crypto_struct.h
+++ b/include/psa/crypto_struct.h
@@ -262,13 +262,15 @@ typedef struct psa_tls12_prf_key_derivation_s
 } psa_tls12_prf_key_derivation_t;
 #endif /* MBEDTLS_MD_C */
 
-typedef struct {
+typedef struct psa_key_derivation_input_buffer_s
+{
     const uint8_t *data;
     size_t length;
     psa_key_derivation_step_t step;
 } psa_key_derivation_input_buffer_t;
 
-typedef struct psa_opaque_key_derivation_s {
+typedef struct psa_opaque_key_derivation_s
+{
     psa_key_handle_t key;
     uint8_t *salt;
     size_t salt_length;

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -5843,11 +5843,18 @@ psa_status_t psa_key_derivation_input_bytes(
         && operation->can_output_key == 0 )
     {
         /* Copy salt to hmac struct for opaque support */
-        uint8_t *salt_ptr = mbedtls_calloc( 1, data_length );
-        if( salt_ptr == NULL )
-            return( PSA_ERROR_INSUFFICIENT_MEMORY );
-        memcpy( salt_ptr, data, data_length );
-        operation->stored_input.data = salt_ptr;
+        if( data_length > 0)
+        {
+            uint8_t *salt_ptr = mbedtls_calloc( 1, data_length );
+            if( salt_ptr == NULL )
+                return( PSA_ERROR_INSUFFICIENT_MEMORY );
+            memcpy( salt_ptr, data, data_length );
+            operation->stored_input.data = salt_ptr;
+        }
+        else
+        {
+            operation->stored_input.data = NULL;
+        }
         operation->stored_input.length = data_length;
         operation->stored_input.step = PSA_KEY_DERIVATION_INPUT_SALT;
     }

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -5843,7 +5843,7 @@ psa_status_t psa_key_derivation_input_bytes(
         && operation->can_output_key == 0 )
     {
         /* Copy salt to hmac struct for opaque support */
-        if( data_length > 0)
+        if( data_length > 0 )
         {
             uint8_t *salt_ptr = mbedtls_calloc( 1, data_length );
             if( salt_ptr == NULL )

--- a/library/psa_crypto_driver_wrappers.c
+++ b/library/psa_crypto_driver_wrappers.c
@@ -909,4 +909,45 @@ psa_status_t psa_driver_wrapper_cipher_abort(
 #endif /* PSA_CRYPTO_DRIVER_PRESENT */
 }
 
+psa_status_t psa_driver_wrapper_opaque_key_derivation_oneshot(
+    psa_algorithm_t alg,
+    psa_key_slot_t *secret_key_slot,
+    psa_key_derivation_input_buffer_t *input_array,
+    size_t input_count,
+    const psa_key_attributes_t *output_key_attributes,
+    psa_key_slot_t *output_key_slot )
+{
+#if defined(PSA_CRYPTO_DRIVER_PRESENT) && defined(PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT)
+    psa_key_location_t location = PSA_KEY_LIFETIME_GET_LOCATION(
+        secret_key_slot->attr.lifetime );
+
+    switch( location )
+    {
+        case PSA_KEY_LOCATION_LOCAL_STORAGE:
+            /* This is a dedicated opaque wrapper. Should never be called for
+             * transparent keys */
+            return( PSA_ERROR_NOT_SUPPORTED );
+#if defined(PSA_CRYPTO_DRIVER_TEST)
+        /* TODO: Add test driver case here */
+#endif /* PSA_CRYPTO_DRIVER_TEST */
+        default:
+            return( PSA_ERROR_INVALID_ARGUMENT );
+    }
+    (void)alg;
+    (void)input_array;
+    (void)input_count;
+    (void)output_key_attributes;
+    (void)output_key_slot;
+    return( PSA_ERROR_NOT_SUPPORTED );
+#else
+    (void)alg;
+    (void)secret_key_slot;
+    (void)input_array;
+    (void)input_count;
+    (void)output_key_attributes;
+    (void)output_key_slot;
+    return( PSA_ERROR_NOT_SUPPORTED );
+#endif /* PSA_CRYPTO_DRIVER_PRESENT && PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
+}
+
 /* End of automatically generated file. */

--- a/library/psa_crypto_driver_wrappers.h
+++ b/library/psa_crypto_driver_wrappers.h
@@ -105,6 +105,17 @@ psa_status_t psa_driver_wrapper_cipher_finish(
 psa_status_t psa_driver_wrapper_cipher_abort(
     psa_operation_driver_context_t *operation );
 
+/*
+ * Key derivation functions
+ */
+psa_status_t psa_driver_wrapper_opaque_key_derivation_oneshot(
+    psa_algorithm_t alg,
+    psa_key_slot_t *secret_key_slot,
+    psa_key_derivation_input_buffer_t *input_array,
+    size_t input_count,
+    const psa_key_attributes_t *output_key_attributes,
+    psa_key_slot_t *output_key_slot );
+
 #endif /* PSA_CRYPTO_DRIVER_WRAPPERS_H */
 
 /* End of automatically generated file. */


### PR DESCRIPTION
## Description
Opaque key derivation cannot be supported with the previously outlined key derivation entry points, so a new dedicated opaque driver entry point is proposed in #3718.  This PR implements support for that entry point. Note: HKDF is the only algorithm that is currently supported for opaque key derivation.

## Status
**IN DEVELOPMENT**
Note: Status is set to IN DEVELOPMENT since new tests have not been added that specifically cover the changes in this PR. For that to be done, the test system would have to be expanded with opaque key handling and test drivers.

## Requires Backporting
NO  

## Migrations
NO

## Additional comments
None

## Todos
- [ ] Tests
- [x] Documentation
- [x] Changelog updated
