### PR TITLE
Bugfix: Fix the usage of ssl context after it's nullified

### DIFF
--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -865,7 +865,8 @@ static int ssl_populate_transform( mbedtls_ssl_transform *transform,
 
 #if !defined(MBEDTLS_SSL_HW_RECORD_ACCEL) && \
     !defined(MBEDTLS_SSL_EXPORT_KEYS) && \
-    !defined(MBEDTLS_DEBUG_C)
+    !defined(MBEDTLS_DEBUG_C) && \
+    !defined(MBEDTLS_SSL_DTLS_CONNECTION_ID)
     ssl = NULL; /* make sure we don't use it except for those cases */
     (void) ssl;
 #endif


### PR DESCRIPTION
When not using `MBEDTLS_SSL_HW_RECORD_ACCEL`, `MBEDTLS_SSL_EXPORT_KEYS` and `MBEDTLS_DEBUG_C`, but using the DTLS CID feature - a null pointer was accessed in line 917.
This is a very specific set of defines, and given that the same combination is probably not used anywhere else - I didn't bother adding a test for it, nor a changelog entry. Let me know if that's acceptable.
