### PR TITLE
Fix compilation with MinGW32

### DIFF
--- a/ChangeLog.d/mingw.txt
+++ b/ChangeLog.d/mingw.txt
@@ -1,0 +1,4 @@
+Bugfix
+   * Fix compilation error with mingw32. Fixed by Cameron Cawley in #4211.
+   * Fix compilation error when using C++ Builder on Windows. Reported by
+     Miroslav Mastny in #4015.

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -92,9 +92,11 @@ void mbedtls_platform_zeroize( void *buf, size_t len )
  * threading.h. However, this macro is not part of the Mbed TLS public API, so
  * we keep it private by only defining it in this file
  */
-#if ! ( defined(_WIN32) && !defined(EFIX64) && !defined(EFI32) )
+#if ! ( defined(_WIN32) && !defined(EFIX64) && !defined(EFI32) ) || \
+      ( defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR) )
 #define PLATFORM_UTIL_USE_GMTIME
-#endif /* ! ( defined(_WIN32) && !defined(EFIX64) && !defined(EFI32) ) */
+#endif /* ! ( defined(_WIN32) && !defined(EFIX64) && !defined(EFI32) ) || \
+             (defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR) ) */
 
 #endif /* !( ( defined(_POSIX_VERSION) && _POSIX_VERSION >= 200809L ) ||     \
              ( defined(_POSIX_THREAD_SAFE_FUNCTIONS ) &&                     \
@@ -103,7 +105,7 @@ void mbedtls_platform_zeroize( void *buf, size_t len )
 struct tm *mbedtls_platform_gmtime_r( const mbedtls_time_t *tt,
                                       struct tm *tm_buf )
 {
-#if defined(_WIN32) && !defined(EFIX64) && !defined(EFI32)
+#if defined(_WIN32) && !defined(PLATFORM_UTIL_USE_GMTIME)
     return( ( gmtime_s( tm_buf, tt ) == 0 ) ? tm_buf : NULL );
 #elif !defined(PLATFORM_UTIL_USE_GMTIME)
     return( gmtime_r( tt, tm_buf ) );

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -74,6 +74,7 @@ void mbedtls_platform_zeroize( void *buf, size_t len )
 #endif /* MBEDTLS_PLATFORM_ZEROIZE_ALT */
 
 #if defined(MBEDTLS_HAVE_TIME_DATE) && !defined(MBEDTLS_PLATFORM_GMTIME_R_ALT)
+#define __STDC_WANT_LIB_EXT1__ 1
 #include <time.h>
 #if !defined(_WIN32) && (defined(unix) || \
     defined(__unix) || defined(__unix__) || (defined(__APPLE__) && \
@@ -105,7 +106,12 @@ struct tm *mbedtls_platform_gmtime_r( const mbedtls_time_t *tt,
                                       struct tm *tm_buf )
 {
 #if defined(_WIN32) && !defined(PLATFORM_UTIL_USE_GMTIME)
+#if defined(__STDC_LIB_EXT1__)
+    return( ( gmtime_s( tt, tm_buf ) == 0 ) ? NULL : tm_buf );
+#else
+    /* MSVC and mingw64 argument order and return value are inconsistent with the C11 standard */
     return( ( gmtime_s( tm_buf, tt ) == 0 ) ? tm_buf : NULL );
+#endif
 #elif !defined(PLATFORM_UTIL_USE_GMTIME)
     return( gmtime_r( tt, tm_buf ) );
 #else

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -95,8 +95,7 @@ void mbedtls_platform_zeroize( void *buf, size_t len )
 #if ! ( defined(_WIN32) && !defined(EFIX64) && !defined(EFI32) ) || \
       ( defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR) )
 #define PLATFORM_UTIL_USE_GMTIME
-#endif /* ! ( defined(_WIN32) && !defined(EFIX64) && !defined(EFI32) ) || \
-             (defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR) ) */
+#endif
 
 #endif /* !( ( defined(_POSIX_VERSION) && _POSIX_VERSION >= 200809L ) ||     \
              ( defined(_POSIX_THREAD_SAFE_FUNCTIONS ) &&                     \

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -74,7 +74,7 @@ void mbedtls_platform_zeroize( void *buf, size_t len )
 #endif /* MBEDTLS_PLATFORM_ZEROIZE_ALT */
 
 #if defined(MBEDTLS_HAVE_TIME_DATE) && !defined(MBEDTLS_PLATFORM_GMTIME_R_ALT)
-#define __STDC_WANT_LIB_EXT1__ 1
+#define __STDC_WANT_LIB_EXT1__ 1  /* Ask for the C11 gmtime_s() if it's available */
 #include <time.h>
 #if !defined(_WIN32) && (defined(unix) || \
     defined(__unix) || defined(__unix__) || (defined(__APPLE__) && \

--- a/tests/suites/helpers.function
+++ b/tests/suites/helpers.function
@@ -44,9 +44,12 @@ typedef UINT32 uint32_t;
 
 #include <string.h>
 
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__)) || defined(__MINGW32__)
+#include <strings.h>
+#endif
+
 #if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 #include <unistd.h>
-#include <strings.h>
 #endif
 
 /* Type for Hex parameters */


### PR DESCRIPTION
## Description
Fixes #2087. MinGW-w64 should be unaffected by this change.

## Status
READY

## Requires Backporting

No - not worth backporting to an LTS

## Migrations

NO

## Todos
- [x] Tests
- [x] Changelog updated

