### PR TITLE
Backport 2.28: Verify numerical ip SubjectAlternativeName properly

### DIFF
--- a/ChangeLog.d/verify-ip-sans-properly.txt
+++ b/ChangeLog.d/verify-ip-sans-properly.txt
@@ -1,0 +1,5 @@
+Features
+   * X.509 hostname verification now supports IPAddress Subject Alternate Names.
+     Both IPv4 (in canonical dot-decimal notation) and IPv6 (formatted according
+     to https://tools.ietf.org/html/rfc5952) are supported.
+     Contributed by Eugene Kobyakov (NetFoundry)

--- a/include/mbedtls/x509_crt.h
+++ b/include/mbedtls/x509_crt.h
@@ -586,8 +586,11 @@ int mbedtls_x509_crt_verify_info( char *buf, size_t size, const char *prefix,
  * \param cn       The expected Common Name. This will be checked to be
  *                 present in the certificate's subjectAltNames extension or,
  *                 if this extension is absent, as a CN component in its
- *                 Subject name. Currently only DNS names are supported. This
- *                 may be \c NULL if the CN need not be verified.
+ *                 Subject name. DNS names, and IP addresses are supported.
+ *                 IPv4 addresses must be in canonical dot-decimal notation.
+ *                 IPv6 addresses must be in a format specified by RFC-5952 (':'-separated hextets).
+ *                 IPv4-embedded IPv6 addresses (e.g. 64:ff9b::192.0.2.33) are not supported.
+ *                 This may be \c NULL if the CN need not be verified.
  * \param flags    The address at which to store the result of the verification.
  *                 If the verification couldn't be completed, the flag value is
  *                 set to (uint32_t) -1.

--- a/library/x509_invasive.h
+++ b/library/x509_invasive.h
@@ -1,0 +1,45 @@
+/**
+ * \file x509_invasive.h
+ *
+ * \brief x509 module: interfaces for invasive testing only.
+ *
+ * The interfaces in this file are intended for testing purposes only.
+ * They SHOULD NOT be made available in library integrations except when
+ * building the library for testing.
+ */
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+#ifndef MBEDTLS_X509_INVASIVE_H
+#define MBEDTLS_X509_INVASIVE_H
+
+#if defined(MBEDTLS_TEST_HOOKS)
+
+/*
+ * parse ipv4 address from canonical string form into bytes.
+ * return 0 if success, -1 otherwise
+ */
+int mbedtls_x509_parse_ipv4( const char *h, size_t hlen, unsigned char *addr );
+
+/*
+ * parse ipv6 address from canonical string form into bytes.
+ * return 0 if success, -1 otherwise
+ */
+int mbedtls_x509_parse_ipv6( const char *h, size_t hlen, unsigned char *addr );
+
+#endif /* MBEDTLS_TEST_HOOKS */
+
+#endif /* MBED_TLS_X509_INVASIVE_H */

--- a/tests/suites/test_suite_x509parse.data
+++ b/tests/suites/test_suite_x509parse.data
@@ -927,6 +927,59 @@ X509 CRT verification: domain identical to IPv6 in SubjectAltName
 depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECDSA_C:MBEDTLS_SHA256_C:MBEDTLS_ECP_DP_SECP256R1_ENABLED:MBEDTLS_RSA_C
 x509_verify:"data_files/server5-tricky-ip-san.crt":"data_files/server5-tricky-ip-san.crt":"data_files/crl_sha256.pem":"abcd.example.com":MBEDTLS_ERR_X509_CERT_VERIFY_FAILED:MBEDTLS_X509_BADCERT_CN_MISMATCH:"":"NULL"
 
+X509 CRT verification: matching IPv4 in SubjectAltName
+depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECDSA_C:MBEDTLS_SHA256_C:MBEDTLS_ECP_DP_SECP256R1_ENABLED:MBEDTLS_RSA_C
+x509_verify:"data_files/server5-tricky-ip-san.crt":"data_files/server5-tricky-ip-san.crt":"data_files/crl_sha256.pem":"97.98.99.100":0:0:"":"NULL"
+
+X509 CRT verification: mismatching IPv4 in SubjectAltName
+depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECDSA_C:MBEDTLS_SHA256_C:MBEDTLS_ECP_DP_SECP256R1_ENABLED:MBEDTLS_RSA_C
+x509_verify:"data_files/server5-tricky-ip-san.crt":"data_files/server5-tricky-ip-san.crt":"data_files/crl_sha256.pem":"7.8.9.10":MBEDTLS_ERR_X509_CERT_VERIFY_FAILED:MBEDTLS_X509_BADCERT_CN_MISMATCH:"":"NULL"
+
+X509 CRT verification: IPv4 with trailing data in SubjectAltName
+depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECDSA_C:MBEDTLS_SHA256_C:MBEDTLS_ECP_DP_SECP256R1_ENABLED:MBEDTLS_RSA_C
+x509_verify:"data_files/server5-tricky-ip-san.crt":"data_files/server5-tricky-ip-san.crt":"data_files/crl_sha256.pem":"97.98.99.100?":MBEDTLS_ERR_X509_CERT_VERIFY_FAILED:MBEDTLS_X509_BADCERT_CN_MISMATCH:"":"NULL"
+
+X509 CRT verification: matching IPv6 in SubjectAltName
+depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECDSA_C:MBEDTLS_SHA256_C:MBEDTLS_ECP_DP_SECP256R1_ENABLED:MBEDTLS_RSA_C
+x509_verify:"data_files/server5-tricky-ip-san.crt":"data_files/server5-tricky-ip-san.crt":"data_files/crl_sha256.pem":"6162\:6364\:2E65\:7861\:6D70\:6C65\:2E63\:6F6D":0:0:"":"NULL"
+
+X509 CRT verification: mismatching IPv6 in SubjectAltName
+depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECDSA_C:MBEDTLS_SHA256_C:MBEDTLS_ECP_DP_SECP256R1_ENABLED:MBEDTLS_RSA_C
+x509_verify:"data_files/server5-tricky-ip-san.crt":"data_files/server5-tricky-ip-san.crt":"data_files/crl_sha256.pem":"6162\:6364\:\:6F6D":MBEDTLS_ERR_X509_CERT_VERIFY_FAILED:MBEDTLS_X509_BADCERT_CN_MISMATCH:"":"NULL"
+
+IPv4 Parse: valid address
+x509_ipv4_parse:"10.10.10.10":"0A0A0A0A":0
+
+IPv4 Parse: short address
+x509_ipv4_parse:"10.10.10":"":-1
+
+IPv4 Parse: invalid char
+x509_ipv4_parse:"10.10?10.10":"":-1
+
+IPv6 Parse: valid address
+x509_ipv6_parse:"1\:2\:3\:4\:5\:6\:7\:8":"00010002000300040005000600070008":0
+
+IPv6 Parse: valid address shorthand
+x509_ipv6_parse:"6263\:\:1":"62630000000000000000000000000001":0
+
+IPv6 Parse: valid address shorthand start
+x509_ipv6_parse:"\:\:1":"00000000000000000000000000000001":0
+
+IPv6 Parse: invalid address - start single colon
+x509_ipv6_parse:"\:6263\:\:1":"":-1
+
+IPv6 Parse: short address
+x509_ipv6_parse:"\:\:":"":-1
+
+IPv6 Parse: address too long
+x509_ipv6_parse:"1\:2\:3\:4\:5\:6\:7\:8\:9":"":-1
+
+IPv6 Parse: long hextet
+x509_ipv6_parse:"12345\:\:1":"":-1
+
+IPv6 Parse: invalid char
+x509_ipv6_parse:"\:\:\:1":"":-1
+
 X509 CRT verification with ca callback: failure
 depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_SHA1_C:MBEDTLS_RSA_C:MBEDTLS_PKCS1_V15:MBEDTLS_X509_TRUSTED_CERTIFICATE_CALLBACK
 x509_verify_ca_cb_failure:"data_files/server1.crt":"data_files/test-ca.crt":"NULL":MBEDTLS_ERR_X509_FATAL_ERROR

--- a/tests/suites/test_suite_x509parse.function
+++ b/tests/suites/test_suite_x509parse.function
@@ -10,6 +10,8 @@
 #include "mbedtls/error.h"
 #include "string.h"
 
+#include <x509_invasive.h>
+
 #if MBEDTLS_X509_MAX_INTERMEDIATE_CA > 19
 #error "The value of MBEDTLS_X509_MAX_INTERMEDIATE_C is larger \
 than the current threshold 19. To test larger values, please \
@@ -399,6 +401,32 @@ int parse_crt_ext_cb( void *p_ctx, mbedtls_x509_crt const *crt, mbedtls_x509_buf
  * depends_on:MBEDTLS_BIGNUM_C
  * END_DEPENDENCIES
  */
+
+/* BEGIN_CASE depends_on:MBEDTLS_X509_CRT_PARSE_C:MBEDTLS_TEST_HOOKS */
+void x509_ipv4_parse( char * ipv4, data_t * exp, int ref_ret )
+{
+    unsigned char addr[4];
+    int ret = mbedtls_x509_parse_ipv4( ipv4, strlen(ipv4), addr  );
+    TEST_EQUAL( ret, ref_ret );
+
+    if( ret == 0 ) {
+        ASSERT_COMPARE( exp->x, exp->len, addr, sizeof( addr ) );
+    }
+}
+/* END_CASE */
+
+/* BEGIN_CASE depends_on:MBEDTLS_X509_CRT_PARSE_C:MBEDTLS_TEST_HOOKS */
+void x509_ipv6_parse( char * ipv6, data_t * exp, int ref_ret )
+{
+    unsigned char addr[16];
+    int ret = mbedtls_x509_parse_ipv6( ipv6, strlen(ipv6), addr  );
+    TEST_EQUAL( ret, ref_ret );
+
+    if( ret == 0 ) {
+        ASSERT_COMPARE( exp->x, exp->len, addr, sizeof( addr ) );
+    }
+}
+/* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_FS_IO:MBEDTLS_X509_CRT_PARSE_C */
 void x509_parse_san( char * crt_file, char * result_str )

--- a/visualc/VS2010/mbedTLS.vcxproj
+++ b/visualc/VS2010/mbedTLS.vcxproj
@@ -277,6 +277,7 @@
     <ClInclude Include="..\..\library\psa_crypto_storage.h" />
     <ClInclude Include="..\..\library\ssl_invasive.h" />
     <ClInclude Include="..\..\library\ssl_tls13_keys.h" />
+    <ClInclude Include="..\..\library\x509_invasive.h" />
     <ClInclude Include="..\..\3rdparty\everest\include\everest\everest.h" />
     <ClInclude Include="..\..\3rdparty\everest\include\everest\Hacl_Curve25519.h" />
     <ClInclude Include="..\..\3rdparty\everest\include\everest\kremlib.h" />


### PR DESCRIPTION
Trivial backport of #2906