### PR TITLE
Fixed a bug that the little-endian Microblaze does not work when MBEDTLS_HAVE_ASM is defined

### DIFF
--- a/ChangeLog.d/muladdc_microblaze.txt
+++ b/ChangeLog.d/muladdc_microblaze.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix support for little-endian Microblaze when MBEDTLS_HAVE_ASM is defined.
+     Contributed by Kazuyuki Kimura to fix #2020.

--- a/library/bn_mul.h
+++ b/library/bn_mul.h
@@ -566,10 +566,20 @@
         "andi  r7,   r6, 0xffff \n\t"   \
         "bsrli r6,   r6, 16     \n\t"
 
-#define MULADDC_X1_CORE                 \
+#if(__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+#define MULADDC_LHUI                    \
+        "lhui  r9,   r3,   0    \n\t"   \
+        "addi  r3,   r3,   2    \n\t"   \
+        "lhui  r8,   r3,   0    \n\t"
+#else
+#define MULADDC_LHUI                    \
         "lhui  r8,   r3,   0    \n\t"   \
         "addi  r3,   r3,   2    \n\t"   \
-        "lhui  r9,   r3,   0    \n\t"   \
+        "lhui  r9,   r3,   0    \n\t"
+#endif
+
+#define MULADDC_X1_CORE                    \
+        MULADDC_LHUI                    \
         "addi  r3,   r3,   2    \n\t"   \
         "mul   r10,  r9,  r6    \n\t"   \
         "mul   r11,  r8,  r7    \n\t"   \


### PR DESCRIPTION
Fixed a bug that the little-endian Microblaze does not work when MBEDTLS_HAVE_ASM is defined.

I accidentally closed #4586.... sorry.

Signed-off-by: Kazuyuki Kimura <kim@wing.ocn.ne.jp>

Fixes #2020 