### PR TITLE
Implemented mbedtls_net_connect_timeout

### DIFF
--- a/ChangeLog.d/mbedtls_net_connect_timeout.txt
+++ b/ChangeLog.d/mbedtls_net_connect_timeout.txt
@@ -1,0 +1,3 @@
+Features
+    * Add mbedtls_net_connect_timeout() function which behaves the same as
+      mbedtls_net_connect() but allows specifying a connect timeout.

--- a/include/mbedtls/net_sockets.h
+++ b/include/mbedtls/net_sockets.h
@@ -124,6 +124,24 @@ void mbedtls_net_init( mbedtls_net_context *ctx );
 int mbedtls_net_connect( mbedtls_net_context *ctx, const char *host, const char *port, int proto );
 
 /**
+ * \brief          Initiate a connection with host:port in the given protocol with a timeout
+ *
+ * \param ctx      Socket to use
+ * \param host     Host to connect to
+ * \param port     Port to connect to
+ * \param proto    Protocol: MBEDTLS_NET_PROTO_TCP or MBEDTLS_NET_PROTO_UDP
+ * \param timeout  The timeout in milliseconds
+ *
+ * \return         0 if successful, or one of:
+ *                      MBEDTLS_ERR_NET_SOCKET_FAILED,
+ *                      MBEDTLS_ERR_NET_UNKNOWN_HOST,
+ *                      MBEDTLS_ERR_NET_CONNECT_FAILED
+ *
+ * \note           Sets the socket in connected mode even with UDP.
+ */
+int mbedtls_net_connect_timeout( mbedtls_net_context *ctx, const char *host, const char *port, int proto, int timeout );
+
+/**
  * \brief          Create a receiving socket on bind_ip:port in the chosen
  *                 protocol. If bind_ip == NULL, all interfaces are bound.
  *

--- a/include/mbedtls/net_sockets.h
+++ b/include/mbedtls/net_sockets.h
@@ -130,7 +130,8 @@ int mbedtls_net_connect( mbedtls_net_context *ctx, const char *host, const char 
  * \param host     Host to connect to
  * \param port     Port to connect to
  * \param proto    Protocol: MBEDTLS_NET_PROTO_TCP or MBEDTLS_NET_PROTO_UDP
- * \param timeout  The timeout in milliseconds
+ * \param timeout  Maximum number of milliseconds to wait for a connection
+ *                 0 means no timeout (wait forever)
  *
  * \return         0 if successful, or one of:
  *                      MBEDTLS_ERR_NET_SOCKET_FAILED,
@@ -139,7 +140,8 @@ int mbedtls_net_connect( mbedtls_net_context *ctx, const char *host, const char 
  *
  * \note           Sets the socket in connected mode even with UDP.
  */
-int mbedtls_net_connect_timeout( mbedtls_net_context *ctx, const char *host, const char *port, int proto, int timeout );
+int mbedtls_net_connect_timeout( mbedtls_net_context *ctx, const char *host, const char *port, int proto,
+						uint32_t timeout );
 
 /**
  * \brief          Create a receiving socket on bind_ip:port in the chosen

--- a/library/net_sockets.c
+++ b/library/net_sockets.c
@@ -217,6 +217,128 @@ int mbedtls_net_connect( mbedtls_net_context *ctx, const char *host,
 }
 
 /*
+ * Initiate a TCP connection with host:port and the given protocol with a timeout (ms)
+ */
+int mbedtls_net_connect_timeout( mbedtls_net_context *ctx, const char *host,
+                         const char *port, int proto, int timeout )
+{
+    int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
+    struct addrinfo hints, *addr_list, *cur;
+	int last_error;
+
+    if( ( ret = net_prepare() ) != 0 )
+        return( ret );
+
+    /* Do name resolution with both IPv6 and IPv4 */
+    memset( &hints, 0, sizeof( hints ) );
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = proto == MBEDTLS_NET_PROTO_UDP ? SOCK_DGRAM : SOCK_STREAM;
+    hints.ai_protocol = proto == MBEDTLS_NET_PROTO_UDP ? IPPROTO_UDP : IPPROTO_TCP;
+
+    if( getaddrinfo( host, port, &hints, &addr_list ) != 0 )
+        return( MBEDTLS_ERR_NET_UNKNOWN_HOST );
+
+    /* Try the sockaddrs until a connection succeeds */
+    ret = MBEDTLS_ERR_NET_UNKNOWN_HOST;
+    for( cur = addr_list; cur != NULL; cur = cur->ai_next )
+    {
+        ctx->fd = (int) socket( cur->ai_family, cur->ai_socktype,
+                            cur->ai_protocol );
+        if( ctx->fd < 0 )
+        {
+            ret = MBEDTLS_ERR_NET_SOCKET_FAILED;
+            continue;
+        }
+
+		if( mbedtls_net_set_nonblock( ctx ) < 0 )
+		{
+			close( ctx->fd );
+			ret = MBEDTLS_ERR_NET_CONNECT_FAILED;
+			break;
+		}
+
+        if( connect( ctx->fd, cur->ai_addr, MSVC_INT_CAST cur->ai_addrlen ) == 0 )
+        {
+            ret = 0;
+            break;
+        }
+
+#if _WIN32
+		last_error = WSAGetLastError();
+		if( last_error == WSAEWOULDBLOCK )
+		{
+			last_error = EINPROGRESS;
+		}
+#else
+		last_error = errno;
+#endif
+		if( last_error == EINPROGRESS )
+		{
+			int            fd = (int)ctx->fd;
+			int            opt;
+			socklen_t      slen;
+			struct timeval tv;
+			fd_set         write_fds;
+			fd_set         error_fds;
+
+			while( 1 )
+			{
+				FD_ZERO( &write_fds );
+				FD_ZERO( &error_fds );
+				FD_SET( fd, &write_fds );
+				FD_SET( fd, &error_fds );
+
+				tv.tv_sec = timeout / 1000;
+				tv.tv_usec = (timeout % 1000) * 1000;
+
+				ret = select( fd + 1, NULL, &write_fds, &error_fds, timeout == 0 ? NULL : &tv );
+				if( ret == -1 )
+				{
+#if _WIN32
+					if( WSAGetLastError() == WSAEINTR )
+						continue;
+#else
+					if( errno == EINTR )
+						continue;
+#endif
+				}
+				else if( ret == 0 )
+				{
+					close(fd);
+					ret = MBEDTLS_ERR_NET_CONNECT_FAILED;
+				}
+				else
+				{
+					ret = 0;
+
+					slen = sizeof(int);
+					if( ( getsockopt( fd, SOL_SOCKET, SO_ERROR, (void *) &opt, &slen ) == 0 ) && ( opt > 0 ) )
+					{
+						close(fd);
+						ret = MBEDTLS_ERR_NET_CONNECT_FAILED;
+					}
+				}
+				break;
+			}
+			break;
+		}
+
+        close( ctx->fd );
+        ret = MBEDTLS_ERR_NET_CONNECT_FAILED;
+    }
+
+    freeaddrinfo( addr_list );
+
+	if( ret == 0 && mbedtls_net_set_block( ctx ) < 0 )
+	{
+		close(ctx->fd);
+		ret = MBEDTLS_ERR_NET_CONNECT_FAILED;
+	}
+
+    return( ret );
+}
+
+/*
  * Create a listening socket on bind_ip:port
  */
 int mbedtls_net_bind( mbedtls_net_context *ctx, const char *bind_ip, const char *port, int proto )

--- a/library/net_sockets.c
+++ b/library/net_sockets.c
@@ -174,53 +174,14 @@ void mbedtls_net_init( mbedtls_net_context *ctx )
 int mbedtls_net_connect( mbedtls_net_context *ctx, const char *host,
                          const char *port, int proto )
 {
-    int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
-    struct addrinfo hints, *addr_list, *cur;
-
-    if( ( ret = net_prepare() ) != 0 )
-        return( ret );
-
-    /* Do name resolution with both IPv6 and IPv4 */
-    memset( &hints, 0, sizeof( hints ) );
-    hints.ai_family = AF_UNSPEC;
-    hints.ai_socktype = proto == MBEDTLS_NET_PROTO_UDP ? SOCK_DGRAM : SOCK_STREAM;
-    hints.ai_protocol = proto == MBEDTLS_NET_PROTO_UDP ? IPPROTO_UDP : IPPROTO_TCP;
-
-    if( getaddrinfo( host, port, &hints, &addr_list ) != 0 )
-        return( MBEDTLS_ERR_NET_UNKNOWN_HOST );
-
-    /* Try the sockaddrs until a connection succeeds */
-    ret = MBEDTLS_ERR_NET_UNKNOWN_HOST;
-    for( cur = addr_list; cur != NULL; cur = cur->ai_next )
-    {
-        ctx->fd = (int) socket( cur->ai_family, cur->ai_socktype,
-                            cur->ai_protocol );
-        if( ctx->fd < 0 )
-        {
-            ret = MBEDTLS_ERR_NET_SOCKET_FAILED;
-            continue;
-        }
-
-        if( connect( ctx->fd, cur->ai_addr, MSVC_INT_CAST cur->ai_addrlen ) == 0 )
-        {
-            ret = 0;
-            break;
-        }
-
-        close( ctx->fd );
-        ret = MBEDTLS_ERR_NET_CONNECT_FAILED;
-    }
-
-    freeaddrinfo( addr_list );
-
-    return( ret );
+	return mbedtls_net_connect_timeout( ctx, host, port, proto, 0 );
 }
 
 /*
- * Initiate a TCP connection with host:port and the given protocol with a timeout (ms)
+ * Initiate a TCP connection with host:port and the given protocol blocking for at most 'timeout' ms
  */
 int mbedtls_net_connect_timeout( mbedtls_net_context *ctx, const char *host,
-                         const char *port, int proto, int timeout )
+                         const char *port, int proto, uint32_t timeout )
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     struct addrinfo hints, *addr_list, *cur;


### PR DESCRIPTION
Implemented an alternative form of mbedtls_net_connect which takes a timeout
argument.

Signed-off-by: Micah N Gorrell <micah.gorrell@venafi.com>

Notes:
* Pull requests cannot be accepted until the PR follows the [contributing guidelines](../CONTRIBUTING.md). In particular, each commit must have at least one `Signed-off-by:` line from the committer to certify that the contribution is made under the terms of the [Developer Certificate of Origin](../dco.txt).
* This is just a template, so feel free to use/remove the unnecessary things
## Description
A few sentences describing the overall goals of the pull request's commits.


## Status
**READY**

## Requires Backporting
NO

## Migrations
If there is any API change, what's the incentive and logic for it.

NO

## Additional comments

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.
