### PR TITLE
An attempt to use pycparser for check-names.

### DIFF
--- a/library/.gitignore
+++ b/library/.gitignore
@@ -1,4 +1,6 @@
 *.o
+*.i
+*.im
 libmbed*
 *.sln
 *.vcxproj

--- a/library/Makefile
+++ b/library/Makefile
@@ -267,6 +267,9 @@ libmbedcrypto.dll: $(OBJS_CRYPTO)
 .c.o:
 	echo "  CC    $<"
 	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) -o $@ -c $<
+	echo "  CC -E    $<"
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) -I/home/mtst/pycparser/utils/fake_libc_include -E $< -o $*.i
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) -I/home/mtst/pycparser/utils/fake_libc_include -E -dM $< -o $*.im
 
 .PHONY: generated_files
 GENERATED_FILES = error.c version_features.c
@@ -293,10 +296,12 @@ version_features.c:
 
 clean:
 ifndef WINDOWS
-	rm -f *.o libmbed*
+	rm -f *.o *.i *.im libmbed*
 	rm -f $(THIRDPARTY_CRYPTO_OBJECTS)
 else
 	if exist *.o del /Q /F *.o
+	if exist *.i del /Q /F *.i
+	if exist *.im del /Q /F *.im
 	if exist libmbed* del /Q /F libmbed*
 	del /Q /F del_errors_out_if_the_file_list_is_empty_but_not_if_a_file_does_not_exist $(subst /,\,$(THIRDPARTY_CRYPTO_OBJECTS))
 endif

--- a/parse.py
+++ b/parse.py
@@ -1,0 +1,24 @@
+from __future__ import print_function
+import sys
+
+from pycparser import c_parser, c_ast
+
+#sys.path.extend(['.', '..'])
+
+# A simple visitor for FuncDef nodes that prints the names and
+# locations of function definitions.
+class FuncDefVisitor(c_ast.NodeVisitor):
+    def visit_FuncDef(self, node):
+        print('%s at %s' % (node.decl.name, node.decl.coord))
+
+
+def show_func_defs(preprocessed_file):
+    parser = c_parser.CParser()
+    with open(preprocessed_file) as f:
+        ast = parser.parse(text=f.read())
+        v = FuncDefVisitor()
+        v.visit(ast)
+
+
+if __name__ == "__main__":
+    show_func_defs(sys.argv[1])


### PR DESCRIPTION
This is a proof of concept for my proposal of using the `pycparser` in new refactoring of check-names script: #1638

# Setup

1. Install pycparser package `pip3 install pycparser`
2. Clone repository (we need the `utils` directory) `cd ~ && git clone git@github.com:eliben/pycparser.git`
3. Edit the fake definitions file`gedit ~/pycparser/utils/fake_libc_include/_fake_defines.h`.
 Add `#define CHAR_BIT 8` line to `_fake_defines.h` <- it's necessary to preprocess the library (I don't know why it's missing in the pycparser repo)
4. Adjust `-I` path in the library Makefile to correctly point to `utils/fake_libc_include` directory (See my comment in review)

# Launch preprocessing

From mbedtls repo root:
`make clean && make`
This will generate `.i` and `.im` files.

## Preprocessed files

`.i` are preprocessor output which we can use use pass to `pycparser`.

`python3 ./parse.py library/aes.i`

Sample output:
```
mtst@PL007366:~/mbedtls/mbedtls$ python3 ./parse.py library/aes.i
mbedtls_error_add at ../include/mbedtls/error.h:156:19
aes_gen_tables at aes.c:399:13
mbedtls_aes_init at aes.c:513:6
mbedtls_aes_free at aes.c:520:6
mbedtls_aes_xts_init at aes.c:529:6
mbedtls_aes_xts_free at aes.c:537:6
mbedtls_aes_setkey_enc at aes.c:551:5
mbedtls_aes_setkey_dec at aes.c:667:5
mbedtls_aes_xts_decode_keys at aes.c:736:12
mbedtls_aes_xts_setkey_enc at aes.c:761:5
mbedtls_aes_xts_setkey_dec at aes.c:786:5
mbedtls_internal_aes_encrypt at aes.c:864:5
mbedtls_internal_aes_decrypt at aes.c:928:5
mbedtls_aes_crypt_ecb at aes.c:991:5
mbedtls_aes_crypt_cbc at aes.c:1029:5
mbedtls_gf128mul_x_ble at aes.c:1139:13
mbedtls_aes_crypt_xts at aes.c:1157:5
mbedtls_aes_crypt_cfb128 at aes.c:1268:5
mbedtls_aes_crypt_cfb8 at aes.c:1327:5
mbedtls_aes_crypt_ofb at aes.c:1367:5
mbedtls_aes_crypt_ctr at aes.c:1412:5
mbedtls_aes_self_test at aes.c:1772:5
```

This should be enough to check function declaration names.
To investigate: **what about structure names?**

## Defines

`.im` files contain all defines generated for particular files. From these we can easily extract necessary data for macro names checking.
Sample `.im` file:

```
#define MBEDTLS_HAVE_ASM 
#define PRIXFAST32 "X"
#define __SSP_STRONG__ 3
#define __DBL_MIN_EXP__ (-1021)
#define __FLT32X_MAX_EXP__ 1024
#define __UINT_LEAST16_MAX__ 0xffff
#define __ATOMIC_ACQUIRE 2
#define __FLT128_MAX_10_EXP__ 4932
#define MBEDTLS_MAX_IV_LENGTH 16
#define PRIXFAST64 "X"
#define __FLT_MIN__ 1.17549435082228750796873653722224568e-38F
#define __GCC_IEC_559_COMPLEX 2
#define MBEDTLS_SSL_ENCRYPT_THEN_MAC 
#define __UINT_LEAST8_TYPE__ unsigned char
#define __SIZEOF_FLOAT80__ 16
#define MBEDTLS_DES_C 
#define PRIuPTR "u"
#define __INTMAX_C(c) c ## L
#define __CHAR_BIT__ 8
#define __m256_u int
#define MBEDTLS_KEY_EXCHANGE_ECDH_ECDSA_ENABLED 
#define SHRT_MAX 32767
#define __UINT8_MAX__ 0xff
#define __WINT_MAX__ 0xffffffffU
#define MBEDTLS_HAVE_TIME 
#define __FLT32_MIN_EXP__ (-125)
#define __m512i_u int
#define va_start(_ap,_type) __builtin_va_start((_ap))
#define MBEDTLS_SHA1_C 
#define __ORDER_LITTLE_ENDIAN__ 1234
#define __SIZE_MAX__ 0xffffffffffffffffUL
#define PRIdMAX "d"
#define __WCHAR_MAX__ 0x7fffffff
#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_1 1
#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_2 1
#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_4 1
#define __DBL_DENORM_MIN__ ((double)4.94065645841246544176568792868221372e-324L)
#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_8 1
#define __GCC_ATOMIC_CHAR_LOCK_FREE 2
#define __GCC_IEC_559 2
#define __FLT32X_DECIMAL_DIG__ 17
#define __FLT_EVAL_METHOD__ 0
#define SHRT_MIN -32768
#define MBEDTLS_CMAC_C 
```
