### PR TITLE
Replace references to Mbed Crypto

### DIFF
--- a/configs/config-symmetric-only.h
+++ b/configs/config-symmetric-only.h
@@ -25,7 +25,7 @@
 #define MBEDTLS_HAVE_TIME
 #define MBEDTLS_HAVE_TIME_DATE
 
-/* Mbed Crypto feature support */
+/* Mbed TLS feature support */
 #define MBEDTLS_CIPHER_MODE_CBC
 #define MBEDTLS_CIPHER_MODE_CFB
 #define MBEDTLS_CIPHER_MODE_CTR
@@ -42,7 +42,7 @@
 #define MBEDTLS_USE_PSA_CRYPTO
 #define MBEDTLS_VERSION_FEATURES
 
-/* Mbed Crypto modules */
+/* Mbed TLS modules */
 #define MBEDTLS_AES_C
 #define MBEDTLS_ASN1_PARSE_C
 #define MBEDTLS_ASN1_WRITE_C

--- a/docs/architecture/mbed-crypto-storage-specification.md
+++ b/docs/architecture/mbed-crypto-storage-specification.md
@@ -5,7 +5,7 @@ This document specifies how Mbed TLS uses storage.
 Key storage was originally introduced in a product called Mbed Crypto, which was re-distributed via Mbed TLS and has since been merged into Mbed TLS.
 This document contains historical information both from before and after this merge.
 
-Mbed TLS may be upgraded on an existing device with the storage preserved. Therefore:
+Mbed Crypto may be upgraded on an existing device with the storage preserved. Therefore:
 
 1. Any change may break existing installations and may require an upgrade path.
 1. This document retains historical information about all past released versions. Do not remove information from this document unless it has always been incorrect or it is about a version that you are sure was never released.

--- a/docs/architecture/mbed-crypto-storage-specification.md
+++ b/docs/architecture/mbed-crypto-storage-specification.md
@@ -2,6 +2,8 @@ Mbed TLS storage specification
 =================================
 
 This document specifies how Mbed TLS uses storage.
+Key storage was originally introduced in a product called Mbed Crypto, which was re-distributed via Mbed TLS and has since been merged into Mbed TLS.
+This document contains historical information both from before and after this merge.
 
 Mbed TLS may be upgraded on an existing device with the storage preserved. Therefore:
 

--- a/docs/architecture/mbed-crypto-storage-specification.md
+++ b/docs/architecture/mbed-crypto-storage-specification.md
@@ -1,9 +1,9 @@
-Mbed Crypto storage specification
+Mbed TLS storage specification
 =================================
 
-This document specifies how Mbed Crypto uses storage.
+This document specifies how Mbed TLS uses storage.
 
-Mbed Crypto may be upgraded on an existing device with the storage preserved. Therefore:
+Mbed TLS may be upgraded on an existing device with the storage preserved. Therefore:
 
 1. Any change may break existing installations and may require an upgrade path.
 1. This document retains historical information about all past released versions. Do not remove information from this document unless it has always been incorrect or it is about a version that you are sure was never released.

--- a/docs/architecture/testing/driver-interface-test-strategy.md
+++ b/docs/architecture/testing/driver-interface-test-strategy.md
@@ -1,6 +1,6 @@
-# Mbed Crypto driver interface test strategy
+# Mbed TLS driver interface test strategy
 
-This document describes the test strategy for the driver interfaces in Mbed Crypto. Mbed Crypto has interfaces for secure element drivers, accelerator drivers and entropy drivers. This document is about testing Mbed Crypto itself; testing drivers is out of scope.
+This document describes the test strategy for the driver interfaces in Mbed TLS. Mbed TLS has interfaces for secure element drivers, accelerator drivers and entropy drivers. This document is about testing Mbed TLS itself; testing drivers is out of scope.
 
 The driver interfaces are standardized through PSA Cryptography functional specifications.
 
@@ -16,9 +16,9 @@ Drivers exposing this interface need to be registered at compile time by declari
 
 #### Dynamic secure element driver interface
 
-The dynamic secure element driver interface (SE interface for short) is defined by [`psa/crypto_se_driver.h`](../../../include/psa/crypto_se_driver.h). This is an interface between Mbed Crypto and one or more third-party drivers.
+The dynamic secure element driver interface (SE interface for short) is defined by [`psa/crypto_se_driver.h`](../../../include/psa/crypto_se_driver.h). This is an interface between Mbed TLS and one or more third-party drivers.
 
-The SE interface consists of one function provided by Mbed Crypto (`psa_register_se_driver`) and many functions that drivers must implement. To make a driver usable by Mbed Crypto, the initialization code must call `psa_register_se_driver` with a structure that describes the driver. The structure mostly contains function pointers, pointing to the driver's methods. All calls to a driver function are triggered by a call to a PSA crypto API function.
+The SE interface consists of one function provided by Mbed TLS (`psa_register_se_driver`) and many functions that drivers must implement. To make a driver usable by Mbed TLS, the initialization code must call `psa_register_se_driver` with a structure that describes the driver. The structure mostly contains function pointers, pointing to the driver's methods. All calls to a driver function are triggered by a call to a PSA crypto API function.
 
 ### SE driver interface unit tests
 
@@ -57,7 +57,7 @@ For each API function that can lead to a driver call (more precisely, for each d
 
 #### SE driver outputs
 
-For each API function that leads to a driver call, call it with parameters that cause a driver to be invoked and check how Mbed Crypto handles the outputs.
+For each API function that leads to a driver call, call it with parameters that cause a driver to be invoked and check how Mbed TLS handles the outputs.
 
 * Correct outputs.
 * Incorrect outputs such as an invalid output length.

--- a/docs/architecture/testing/psa-storage-format-testing.md
+++ b/docs/architecture/testing/psa-storage-format-testing.md
@@ -47,7 +47,7 @@ The PSA subsystem provides storage on top of the PSA trusted storage interface. 
 * [Storage transaction file](#storage-transaction-resumption).
 * [Driver state files](#driver-state-files).
 
-For a more detailed description, refer to the [Mbed Crypto storage specification](../mbed-crypto-storage-specification.md).
+For a more detailed description, refer to the [Mbed TLS storage specification](../mbed-crypto-storage-specification.md).
 
 In addition, Mbed TLS includes an implementation of the PSA trusted storage interface on top of C stdio. This document addresses the test strategy for [PSA ITS over file](#psa-its-over-file) in a separate section below.
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,8 +1,8 @@
-## Getting started with Mbed Crypto
+## Getting started with Mbed TLS
 
-### What is Mbed Crypto?
+### What is Mbed TLS?
 
-Mbed Crypto is an open source cryptographic library that supports a wide range of cryptographic operations, including:
+Mbed TLS is an open source cryptographic library that supports a wide range of cryptographic operations, including:
 * Key management
 * Hashing
 * Symmetric cryptography
@@ -11,20 +11,20 @@ Mbed Crypto is an open source cryptographic library that supports a wide range o
 * Key generation and derivation
 * Authenticated encryption with associated data (AEAD)
 
-The Mbed Crypto library is a reference implementation of the cryptography interface of the Arm Platform Security Architecture (PSA). It is written in portable C.
+The Mbed TLS library is a reference implementation of the cryptography interface of the Arm Platform Security Architecture (PSA). It is written in portable C.
 
-The Mbed Crypto library is distributed under the Apache License, version 2.0.
+The Mbed TLS library is distributed under the Apache License, version 2.0.
 
 #### Platform Security Architecture (PSA)
 
 Arm's Platform Security Architecture (PSA) is a holistic set of threat models,
 security analyses, hardware and firmware architecture specifications, and an open source firmware reference implementation. PSA provides a recipe, based on industry best practice, that enables you to design security into both hardware and firmware consistently. Part of the API provided by PSA is the cryptography interface, which provides access to a set of primitives.
 
-### Using Mbed Crypto
+### Using Mbed TLS
 
-* [Getting the Mbed Crypto library](#getting-the-mbed-crypto-library)
-* [Building the Mbed Crypto library](#building-the-mbed-crypto-library)
-* [Using the Mbed Crypto library](#using-the-mbed-crypto-library)
+* [Getting the Mbed TLS library](#getting-the-mbed-tls-library)
+* [Building the Mbed TLS library](#building-the-mbed-tls-library)
+* [Using the Mbed TLS library](#using-the-mbed-tls-library)
 * [Importing a key](#importing-a-key)
 * [Signing a message using RSA](#signing-a-message-using-RSA)
 * [Encrypting or decrypting using symmetric ciphers](#encrypting-or-decrypting-using-symmetric-ciphers)
@@ -33,13 +33,13 @@ security analyses, hardware and firmware architecture specifications, and an ope
 * [Generating a random value](#generating-a-random-value)
 * [Authenticating and encrypting or decrypting a message](#authenticating-and-encrypting-or-decrypting-a-message)
 * [Generating and exporting keys](#generating-and-exporting-keys)
-* [More about the Mbed Crypto library](#more-about-the-mbed-crypto-library)
+* [More about the Mbed TLS library](#more-about-the-mbed-tls-library)
 
-### Getting the Mbed Crypto library
+### Getting the Mbed TLS library
 
-Mbed Crypto releases are available in the [public GitHub repository](https://github.com/ARMmbed/mbed-crypto).
+Mbed TLS releases are available in the [public GitHub repository](https://github.com/ARMmbed/mbedtls).
 
-### Building the Mbed Crypto library
+### Building the Mbed TLS library
 
 **Prerequisites to building the library with the provided makefiles:**
 * GNU Make.
@@ -57,13 +57,13 @@ The provided makefiles pass options to the compiler that assume a GCC-like comma
 
 To run the unit tests on the host machine, run `make test` from the top-level directory. If you are cross-compiling, copy the test executable from the `tests` directory to the target machine.
 
-### Using the Mbed Crypto library
+### Using the Mbed TLS library
 
-To use the Mbed Crypto APIs, call `psa_crypto_init()` before calling any other API. This initializes the library.
+To use the Mbed TLS APIs, call `psa_crypto_init()` before calling any other API. This initializes the library.
 
 ### Importing a key
 
-To use a key for cryptography operations in Mbed Crypto, you need to first
+To use a key for cryptography operations in Mbed TLS, you need to first
 import it. The import operation returns the identifier of the key for use
 with other function calls.
 
@@ -114,7 +114,7 @@ void import_a_key(const uint8_t *key, size_t key_len)
 
 ### Signing a message using RSA
 
-Mbed Crypto supports encrypting, decrypting, signing and verifying messages using public key signature algorithms, such as RSA or ECDSA.
+Mbed TLS supports encrypting, decrypting, signing and verifying messages using public key signature algorithms, such as RSA or ECDSA.
 
 **Prerequisites to performing asymmetric signature operations:**
 * Initialize the library with a successful call to `psa_crypto_init()`.
@@ -184,7 +184,7 @@ void sign_a_message_using_rsa(const uint8_t *key, size_t key_len)
 
 ### Using symmetric ciphers
 
-Mbed Crypto supports encrypting and decrypting messages using various symmetric cipher algorithms (both block and stream ciphers).
+Mbed TLS supports encrypting and decrypting messages using various symmetric cipher algorithms (both block and stream ciphers).
 
 **Prerequisites to working with the symmetric cipher API:**
 * Initialize the library with a successful call to `psa_crypto_init()`.
@@ -364,7 +364,7 @@ After you've initialized the operation structure with a successful call to `psa_
 
 The call to `psa_cipher_abort()` frees any resources associated with the operation, except for the operation structure itself.
 
-Mbed Crypto implicitly calls `psa_cipher_abort()` when:
+Mbed TLS implicitly calls `psa_cipher_abort()` when:
 * A call to `psa_cipher_generate_iv()`, `psa_cipher_set_iv()` or `psa_cipher_update()` fails (returning any status other than `PSA_SUCCESS`).
 * A call to `psa_cipher_finish()` succeeds or fails.
 
@@ -376,7 +376,7 @@ Making multiple sequential calls to `psa_cipher_abort()` on an operation that is
 
 ### Hashing a message
 
-Mbed Crypto lets you compute and verify hashes using various hashing
+Mbed TLS lets you compute and verify hashes using various hashing
 algorithms.
 
 **Prerequisites to working with the hash APIs:**
@@ -488,7 +488,7 @@ The API provides the macro `PSA_HASH_LENGTH`, which returns the expected hash le
 
 After a successful call to `psa_hash_setup()`, you can terminate the operation at any time by calling `psa_hash_abort()`. The call to `psa_hash_abort()` frees any resources associated with the operation, except for the operation structure itself.
 
-Mbed Crypto implicitly calls `psa_hash_abort()` when:
+Mbed TLS implicitly calls `psa_hash_abort()` when:
 1. A call to `psa_hash_update()` fails (returning any status other than `PSA_SUCCESS`).
 1. A call to `psa_hash_finish()` succeeds or fails.
 1. A call to `psa_hash_verify()` succeeds or fails.
@@ -501,7 +501,7 @@ Making multiple sequential calls to `psa_hash_abort()` on an operation that has 
 
 ### Generating a random value
 
-Mbed Crypto can generate random data.
+Mbed TLS can generate random data.
 
 **Prerequisites to generating random data:**
 * Initialize the library with a successful call to `psa_crypto_init()`.
@@ -537,7 +537,7 @@ This example shows how to generate ten bytes of random data by calling `psa_gene
 
 ### Deriving a new key from an existing key
 
-Mbed Crypto provides a key derivation API that lets you derive new keys from
+Mbed TLS provides a key derivation API that lets you derive new keys from
 existing ones. The key derivation API has functions to take inputs, including
 other keys and data, and functions to generate outputs, such as new keys or
 other data.
@@ -675,7 +675,7 @@ derived from the key, salt and info provided:
 
 ### Authenticating and encrypting or decrypting a message
 
-Mbed Crypto provides a simple way to authenticate and encrypt with associated data (AEAD), supporting the `PSA_ALG_CCM` algorithm.
+Mbed TLS provides a simple way to authenticate and encrypt with associated data (AEAD), supporting the `PSA_ALG_CCM` algorithm.
 
 **Prerequisites to working with the AEAD cipher APIs:**
 * Initialize the library with a successful call to `psa_crypto_init()`.
@@ -829,7 +829,7 @@ This example shows how to authenticate and decrypt a message:
 
 ### Generating and exporting keys
 
-Mbed Crypto provides a simple way to generate a key or key pair.
+Mbed TLS provides a simple way to generate a key or key pair.
 
 **Prerequisites to using key generation and export APIs:**
 * Initialize the library with a successful call to `psa_crypto_init()`.
@@ -891,4 +891,4 @@ Mbed Crypto provides a simple way to generate a key or key pair.
 
 ### More about the PSA Crypto API
 
-For more information about the PSA Crypto API, please see the [PSA Cryptography API Specification](https://armmbed.github.io/mbed-crypto/html/index.html).
+For more information about the PSA Crypto API, please see the [PSA Cryptography API Specification](https://armmbed.github.io/mbedtls/html/index.html).

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -2,7 +2,7 @@
 
 ### What is Mbed TLS?
 
-Mbed TLS is an open source cryptographic library that supports a wide range of cryptographic operations, including:
+Mbed TLS is an open source library that supports a wide range of cryptographic operations and functionality, including:
 * Key management
 * Hashing
 * Symmetric cryptography
@@ -10,8 +10,10 @@ Mbed TLS is an open source cryptographic library that supports a wide range of c
 * Message authentication (MAC)
 * Key generation and derivation
 * Authenticated encryption with associated data (AEAD)
+* SSL/TLS communication
+* Managing X.509 certificates
 
-The Mbed TLS library is a reference implementation of the cryptography interface of the Arm Platform Security Architecture (PSA). It is written in portable C.
+The Mbed TLS library contains a reference implementation of the cryptography interface of the Arm Platform Security Architecture (PSA). It is written in portable C.
 
 The Mbed TLS library is distributed under the Apache License, version 2.0.
 
@@ -33,6 +35,8 @@ security analyses, hardware and firmware architecture specifications, and an ope
 * [Generating a random value](#generating-a-random-value)
 * [Authenticating and encrypting or decrypting a message](#authenticating-and-encrypting-or-decrypting-a-message)
 * [Generating and exporting keys](#generating-and-exporting-keys)
+* [Reading a X.509 certificate](#reading-a-x509-certificate)
+* [Establishing a TLS connection](#establishing-a-tls-connection)
 * [More about the Mbed TLS library](#more-about-the-mbed-tls-library)
 
 ### Getting the Mbed TLS library
@@ -42,12 +46,12 @@ Mbed TLS releases are available in the [public GitHub repository](https://github
 ### Building the Mbed TLS library
 
 **Prerequisites to building the library with the provided makefiles:**
-* GNU Make.
+* CMake.
 * A C toolchain (compiler, linker, archiver).
-* Python 2 or Python 3 (either works) to generate the test code.
+* Python 3 to generate the test code.
 * Perl to run the tests.
 
-If you have a C compiler such as GCC or Clang, just run `make` in the top-level directory to build the library, a set of unit tests and some sample programs.
+If you have a C compiler such as GCC or Clang, create a new directory (eg 'build') and run `cmake <path to source>` from that directory. Run `make` from the build directory to build the library, a set of unit tests and some sample programs.
 
 To select a different compiler, set the `CC` variable to the name or path of the compiler and linker (default: `cc`) and set `AR` to a compatible archiver (default: `ar`); for example:
 ```
@@ -55,7 +59,7 @@ make CC=arm-linux-gnueabi-gcc AR=arm-linux-gnueabi-ar
 ```
 The provided makefiles pass options to the compiler that assume a GCC-like command line syntax. To use a different compiler, you may need to pass different values for `CFLAGS`, `WARNINGS_CFLAGS` and `LDFLAGS`.
 
-To run the unit tests on the host machine, run `make test` from the top-level directory. If you are cross-compiling, copy the test executable from the `tests` directory to the target machine.
+To run the unit tests on the host machine, run `make test` from the build directory. If you are cross-compiling, copy the test executable and the associated datax-file from the `tests` directory to the target machine.
 
 ### Using the Mbed TLS library
 
@@ -888,6 +892,14 @@ Mbed TLS provides a simple way to generate a key or key pair.
 
     mbedtls_psa_crypto_free();
 ```
+
+### Reading a X.509 certificate
+
+Example code is available under the programs/x509 directory.
+
+### Establishing a TLS connection
+
+Example code is available under the program/ssl directory.
 
 ### More about the PSA Crypto API
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -59,7 +59,8 @@ make CC=arm-linux-gnueabi-gcc AR=arm-linux-gnueabi-ar
 ```
 The provided makefiles pass options to the compiler that assume a GCC-like command line syntax. To use a different compiler, you may need to pass different values for `CFLAGS`, `WARNINGS_CFLAGS` and `LDFLAGS`.
 
-To run the unit tests on the host machine, run `make test` from the build directory. If you are cross-compiling, copy the test executable and the associated datax-file from the `tests` directory to the target machine.
+To build and run the unit tests on the host machine, run `make test` from the top-level directory.
+If cross-compiling, copy the `test_*` executable(s) and the associated `.datax` file(s) from the `tests` directory to the target machine.
 
 ### Using the Mbed TLS library
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -51,7 +51,7 @@ Mbed TLS releases are available in the [public GitHub repository](https://github
 * Python 3 to generate the test code.
 * Perl to run the tests.
 
-If you have a C compiler such as GCC or Clang, create a new directory (eg 'build') and run `cmake <path to source>` from that directory. Run `make` from the build directory to build the library, a set of unit tests and some sample programs.
+If you have a C compiler such as GCC or Clang, just run `make` in the top-level directory to build the library, a set of unit tests and some sample programs.
 
 To select a different compiler, set the `CC` variable to the name or path of the compiler and linker (default: `cc`) and set `AR` to a compatible archiver (default: `ar`); for example:
 ```

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -46,7 +46,7 @@ Mbed TLS releases are available in the [public GitHub repository](https://github
 ### Building the Mbed TLS library
 
 **Prerequisites to building the library with the provided makefiles:**
-* CMake.
+* GNU Make.
 * A C toolchain (compiler, linker, archiver).
 * Python 3 to generate the test code.
 * Perl to run the tests.
@@ -893,13 +893,13 @@ Mbed TLS provides a simple way to generate a key or key pair.
     mbedtls_psa_crypto_free();
 ```
 
-### Reading a X.509 certificate
+### Managing an X.509 certificate
 
 Example code is available under the programs/x509 directory.
 
 ### Establishing a TLS connection
 
-Example code is available under the program/ssl directory.
+Example code is available under the programs/ssl directory.
 
 ### More about the PSA Crypto API
 

--- a/include/psa/crypto_compat.h
+++ b/include/psa/crypto_compat.h
@@ -5,7 +5,7 @@
  *
  * This header declares alternative names for macro and functions.
  * New application code should not use these names.
- * These names may be removed in a future version of Mbed Crypto.
+ * These names may be removed in a future version of Mbed TLS.
  *
  * \note This file may not be included directly. Applications must
  * include psa/crypto.h.

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -107,7 +107,7 @@ static inline psa_algorithm_t psa_get_key_enrollment_algorithm(
  *         indicates the slot number that contains it.
  * \retval #PSA_ERROR_NOT_PERMITTED
  *         The caller is not permitted to query the slot number.
- *         Mbed Crypto currently does not return this error.
+ *         Mbed TLS currently does not return this error.
  * \retval #PSA_ERROR_INVALID_ARGUMENT
  *         The key is not located in a secure element.
  */
@@ -222,7 +222,7 @@ void mbedtls_psa_crypto_free( void );
  * resource consumption related to the PSA keystore.
  *
  * \note The content of this structure is not part of the stable API and ABI
- *       of Mbed Crypto and may change arbitrarily from version to version.
+ *       of Mbed TLS and may change arbitrarily from version to version.
  */
 typedef struct mbedtls_psa_stats_s
 {
@@ -252,7 +252,7 @@ typedef struct mbedtls_psa_stats_s
 /** \brief Get statistics about
  * resource consumption related to the PSA keystore.
  *
- * \note When Mbed Crypto is built as part of a service, with isolation
+ * \note When Mbed TLS is built as part of a service, with isolation
  *       between the application and the keystore, the service may or
  *       may not expose this function.
  */
@@ -957,7 +957,7 @@ psa_status_t mbedtls_psa_platform_get_builtin_key(
  * the official PSA Crypto API yet.
  *
  * \note The content of this section is not part of the stable API and ABI
- *       of Mbed Crypto and may change arbitrarily from version to version.
+ *       of Mbed TLS and may change arbitrarily from version to version.
  *       Same holds for the corresponding macros #PSA_ALG_CATEGORY_PAKE and
  *       #PSA_ALG_JPAKE.
  * @{

--- a/include/psa/crypto_se_driver.h
+++ b/include/psa/crypto_se_driver.h
@@ -138,7 +138,7 @@ typedef psa_status_t (*psa_drv_se_init_t)(psa_drv_se_context_t *drv_context,
                                           psa_key_location_t location);
 
 #if defined(__DOXYGEN_ONLY__) || !defined(MBEDTLS_PSA_CRYPTO_SE_C)
-/* Mbed Crypto with secure element support enabled defines this type in
+/* Mbed TLS with secure element support enabled defines this type in
  * crypto_types.h because it is also visible to applications through an
  * implementation-specific extension.
  * For the PSA Cryptography specification, this type is only visible
@@ -838,7 +838,7 @@ typedef enum
      * and #PSA_ERROR_DOES_NOT_EXIST if the driver can determine that there
      * is no key with the specified slot number.
      *
-     * This is an Mbed Crypto extension.
+     * This is an Mbed TLS extension.
      */
     PSA_KEY_CREATION_REGISTER,
 #endif

--- a/include/psa/crypto_struct.h
+++ b/include/psa/crypto_struct.h
@@ -35,8 +35,8 @@
  * GCC and Clang initialize the whole structure to 0 (at the time of writing),
  * but MSVC and CompCert don't.
  *
- * In Mbed Crypto, multipart operation structures live independently from
- * the key. This allows Mbed Crypto to free the key objects when destroying
+ * In Mbed TLS, multipart operation structures live independently from
+ * the key. This allows Mbed TLS to free the key objects when destroying
  * a key slot. If a multipart operation needs to remember the key after
  * the setup function returns, the operation structure needs to contain a
  * copy of the key.

--- a/include/psa/crypto_types.h
+++ b/include/psa/crypto_types.h
@@ -228,7 +228,7 @@ typedef uint32_t psa_key_id_t;
 typedef psa_key_id_t mbedtls_svc_key_id_t;
 
 #else /* MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER */
-/* Implementation-specific: The Mbed Cryptography library can be built as
+/* Implementation-specific: The Mbed TLS library can be built as
  * part of a multi-client service that exposes the PSA Cryptograpy API in each
  * client and encodes the client identity in the key identifier argument of
  * functions such as psa_open_key().
@@ -362,7 +362,7 @@ typedef struct psa_key_attributes_s psa_key_attributes_t;
 
 #ifndef __DOXYGEN_ONLY__
 #if defined(MBEDTLS_PSA_CRYPTO_SE_C)
-/* Mbed Crypto defines this type in crypto_types.h because it is also
+/* Mbed TLS defines this type in crypto_types.h because it is also
  * visible to applications through an implementation-specific extension.
  * For the PSA Cryptography specification, this type is only visible
  * via crypto_se_driver.h. */

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -2,7 +2,7 @@
 
 """Mbed TLS configuration file manipulation library and tool
 
-Basic usage, to read the Mbed TLS or Mbed Crypto configuration:
+Basic usage, to read the Mbed TLS configuration:
     config = ConfigFile()
     if 'MBEDTLS_RSA_C' in config: print('RSA is enabled')
 """
@@ -430,7 +430,7 @@ if __name__ == '__main__':
     def main():
         """Command line mbedtls_config.h manipulation tool."""
         parser = argparse.ArgumentParser(description="""
-        Mbed TLS and Mbed Crypto configuration file manipulation tool.
+        Mbed TLS and Mbed TLS configuration file manipulation tool.
         """)
         parser.add_argument('--file', '-f',
                             help="""File to read (and modify if requested).

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -430,7 +430,7 @@ if __name__ == '__main__':
     def main():
         """Command line mbedtls_config.h manipulation tool."""
         parser = argparse.ArgumentParser(description="""
-        Mbed TLS and Mbed TLS configuration file manipulation tool.
+        Mbed TLS configuration file manipulation tool.
         """)
         parser.add_argument('--file', '-f',
                             help="""File to read (and modify if requested).

--- a/tests/include/spe/crypto_spe.h
+++ b/tests/include/spe/crypto_spe.h
@@ -8,13 +8,13 @@
 /**
  * \file crypto_spe.h
  *
- * \brief When Mbed Crypto is built with the MBEDTLS_PSA_CRYPTO_SPM option
- *        enabled, this header is included by all .c files in Mbed Crypto that
+ * \brief When Mbed TLS is built with the MBEDTLS_PSA_CRYPTO_SPM option
+ *        enabled, this header is included by all .c files in Mbed TLS that
  *        use PSA Crypto function names. This avoids duplication of symbols
- *        between TF-M and Mbed Crypto.
+ *        between TF-M and Mbed TLS.
  *
  * \note  This file should be included before including any PSA Crypto headers
- *        from Mbed Crypto.
+ *        from Mbed TLS.
  */
 
 #ifndef CRYPTO_SPE_H

--- a/tests/scripts/psa_collect_statuses.py
+++ b/tests/scripts/psa_collect_statuses.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 """Describe the test coverage of PSA functions in terms of return statuses.
 
-1. Build Mbed Crypto with -DRECORD_PSA_STATUS_COVERAGE_LOG
+1. Build Mbed TLS with -DRECORD_PSA_STATUS_COVERAGE_LOG
 2. Run psa_collect_statuses.py
 
 The output is a series of line of the form "psa_foo PSA_ERROR_XXX". Each
 function/status combination appears only once.
 
-This script must be run from the top of an Mbed Crypto source tree.
+This script must be run from the top of an Mbed TLS source tree.
 The build command is "make -DRECORD_PSA_STATUS_COVERAGE_LOG", which is
 only supported with make (as opposed to CMake or other build methods).
 """
@@ -46,7 +46,7 @@ class Statuses:
     def collect_log(self, log_file_name):
         """Read logs from RECORD_PSA_STATUS_COVERAGE_LOG.
 
-        Read logs produced by running Mbed Crypto test suites built with
+        Read logs produced by running Mbed TLS test suites built with
         -DRECORD_PSA_STATUS_COVERAGE_LOG.
         """
         with open(log_file_name) as log:
@@ -82,7 +82,7 @@ class Statuses:
 def collect_status_logs(options):
     """Build and run unit tests and report observed function return statuses.
 
-    Build Mbed Crypto with -DRECORD_PSA_STATUS_COVERAGE_LOG, run the
+    Build Mbed TLS with -DRECORD_PSA_STATUS_COVERAGE_LOG, run the
     test suites and display information about observed return statuses.
     """
     rebuilt = False

--- a/tests/src/psa_exercise_key.c
+++ b/tests/src/psa_exercise_key.c
@@ -75,7 +75,7 @@ static int check_key_attributes_sanity( mbedtls_svc_key_id_t key )
     psa_status_t status = psa_get_key_slot_number( &attributes, &slot_number );
     if( lifetime_is_dynamic_secure_element( lifetime ) )
     {
-        /* Mbed Crypto currently always exposes the slot number to
+        /* Mbed TLS currently always exposes the slot number to
          * applications. This is not mandated by the PSA specification
          * and may change in future versions. */
         TEST_EQUAL( status, 0 );


### PR DESCRIPTION
Replace references to Mbed Crypto with Mbed TLS through-out documentation and comments.
See [#3232](https://github.com/ARMmbed/mbedtls/issues/3232)

Signed-off-by: Fredrik Hesse <fredrik@hesse.se>
