### PR TITLE
Add API for Montgomery multiplication

### DIFF
--- a/include/mbedtls/bignum.h
+++ b/include/mbedtls/bignum.h
@@ -825,6 +825,70 @@ int mbedtls_mpi_mod_mpi( mbedtls_mpi *R, const mbedtls_mpi *A,
 int mbedtls_mpi_mod_int( mbedtls_mpi_uint *r, const mbedtls_mpi *A,
                          mbedtls_mpi_sint b );
 
+/** Convert to Montgomery representation: X = A * R mod N.
+ *
+ * The coefficient R depends on N and is selected by the library.
+ *
+ * \param X        The destination MPI. This must point to an initialized MPI.
+ * \param A        The MPI to convert to Montgomery representation. This must
+ *                 point to an initialized MPI.
+ * \param N        The base of the modular reduction. This must point to an
+ *                 initialized MPI.
+ * \param prec_RR  A helper MPI depending solely on \p N which is used to speed
+ *                 up multiplication by \p R mod \p N. This may be \c NULL.
+ *                 This argument behaves the same way as the argument \p
+ *                 prec_RR in mbedtls_mpi_exp_mod and is set to the same value
+ *                 for same values of \p N.
+ *
+ * \return         \c 0 if successful.
+ * \return         #MBEDTLS_ERR_MPI_ALLOC_FAILED if a memory allocation failed.
+ * \return         #MBEDTLS_ERR_MPI_BAD_INPUT_DATA if \c N is negative or
+ *                 even.
+ * \return         Another negative error code on different kinds of failure.
+ */
+int mbedtls_mpi_to_mont_mpi( mbedtls_mpi *X, const mbedtls_mpi *A,
+                             const mbedtls_mpi *N, mbedtls_mpi *prec_RR );
+
+/** Convert from Montgomery representation: X = A * R^-1 mod N.
+ *
+ * The coefficient R depends on N and is selected by the library.
+ *
+ * \param X        The destination MPI. This must point to an initialized MPI.
+ * \param A        The MPI to convert to Montgomery representation. This must
+ *                 point to an initialized MPI.
+ * \param N        The base of the modular reduction. This must point to an
+ *                 initialized MPI.
+ *
+ * \return         \c 0 if successful.
+ * \return         #MBEDTLS_ERR_MPI_ALLOC_FAILED if a memory allocation failed.
+ * \return         #MBEDTLS_ERR_MPI_BAD_INPUT_DATA if \c N is negative or
+ *                 even.
+ * \return         Another negative error code on different kinds of failure.
+ */
+int mbedtls_mpi_from_mont_mpi( mbedtls_mpi *X, const mbedtls_mpi *A,
+                               const mbedtls_mpi *N );
+
+/** Perform Montgomery multiplication: X = A * B * R^-1 mod N.
+ *
+ * The coefficient R depends on N and is selected by the library.
+ *
+ * \param X        The destination MPI. This must point to an initialized MPI.
+ * \param A        One of the numbers to multiply. This must point to an
+ *                 initialized MPI and be in range [0, N-1].
+ * \param B        One of the numbers to multiply. This must point to an
+ *                 initialized MPI and be in range [0, N-1].
+ * \param N        The base for the modular reduction. This must point to an
+ *                 initialized MPI.
+ *
+ * \return         \c 0 if successful.
+ * \return         #MBEDTLS_ERR_MPI_ALLOC_FAILED if a memory allocation failed.
+ * \return         #MBEDTLS_ERR_MPI_BAD_INPUT_DATA if \c N is negative or
+ *                 even.
+ * \return         Another negative error code on different kinds of failure.
+ */
+int mbedtls_mpi_montmul( mbedtls_mpi *X, const mbedtls_mpi *A,
+                         const mbedtls_mpi *B, const mbedtls_mpi *N );
+
 /**
  * \brief          Perform a sliding-window exponentiation: X = A^E mod N
  *

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -3477,6 +3477,34 @@ int mbedtls_mpi_self_test( int verbose )
     if( verbose != 0 )
         mbedtls_printf( "passed\n" );
 
+    MBEDTLS_MPI_CHK( mbedtls_mpi_to_mont_mpi( &X, &A, &N, NULL ) );
+
+    MBEDTLS_MPI_CHK( mbedtls_mpi_to_mont_mpi( &Y, &E, &N, NULL ) );
+
+    MBEDTLS_MPI_CHK( mbedtls_mpi_montmul( &U, &X, &Y, &N ) );
+
+    MBEDTLS_MPI_CHK( mbedtls_mpi_from_mont_mpi( &V, &U, &N ) );
+
+    MBEDTLS_MPI_CHK( mbedtls_mpi_read_string( &U, 16,
+        "4C3EAC9C60CA6D9AB4E3D16D3AEC4AEC" \
+        "52605751521CE871F2E191115B241AD1" \
+        "6B517ED785E59EEBAC973D270F3C8A" ) );
+
+    if( verbose != 0 )
+        mbedtls_printf( "  MPI test #3 (montmul): " );
+
+    if( mbedtls_mpi_cmp_mpi( &V, &U ) != 0 )
+    {
+        if( verbose != 0 )
+            mbedtls_printf( "failed\n" );
+
+        ret = 1;
+        goto cleanup;
+    }
+
+    if( verbose != 0 )
+        mbedtls_printf( "passed\n" );
+
     MBEDTLS_MPI_CHK( mbedtls_mpi_inv_mod( &X, &A, &N ) );
 
     MBEDTLS_MPI_CHK( mbedtls_mpi_read_string( &U, 16,

--- a/tests/suites/test_suite_mpi.data
+++ b/tests/suites/test_suite_mpi.data
@@ -1243,6 +1243,9 @@ mbedtls_mpi_to_from_mont:10:"37":10:"":MBEDTLS_ERR_MPI_BAD_INPUT_DATA
 Test mbedtls_mpi_to_from_mont: Very large values
 mbedtls_mpi_to_from_mont_size:10001:10000:0
 
+Test mbedtls_mpi_to_from_mont: Aliasing
+mbedtls_mpi_to_from_mont_aliasing:
+
 Base test mbedtls_mpi_exp_mod #1
 mbedtls_mpi_exp_mod:10:"23":10:"13":10:"29":10:"24":0
 

--- a/tests/suites/test_suite_mpi.data
+++ b/tests/suites/test_suite_mpi.data
@@ -1246,6 +1246,39 @@ mbedtls_mpi_to_from_mont_size:10001:10000:0
 Test mbedtls_mpi_to_from_mont: Aliasing
 mbedtls_mpi_to_from_mont_aliasing:
 
+Base test mbedtls_mpi_montmul #1
+mbedtls_mpi_montmul:10:"10":10:"10":10:"13":0
+
+Base test mbedtls_mpi_montmul #2 (Even N)
+mbedtls_mpi_montmul:10:"10":10:"10":10:"18":MBEDTLS_ERR_MPI_BAD_INPUT_DATA
+
+Base test mbedtls_mpi_montmul #2 (N = 0 (null))
+mbedtls_mpi_montmul:10:"10":10:"10":10:"":MBEDTLS_ERR_MPI_BAD_INPUT_DATA
+
+Base test mbedtls_mpi_montmul #3 (Negative N)
+mbedtls_mpi_montmul:10:"10":10:"10":10:"-13":MBEDTLS_ERR_MPI_BAD_INPUT_DATA
+
+Base test mbedtls_mpi_montmul #4 (Negative A)
+mbedtls_mpi_montmul:10:"-10":10:"10":10:"13":MBEDTLS_ERR_MPI_BAD_INPUT_DATA
+
+Base test mbedtls_mpi_montmul #4 (Negative B)
+mbedtls_mpi_montmul:10:"10":10:"-10":10:"13":MBEDTLS_ERR_MPI_BAD_INPUT_DATA
+
+Base test mbedtls_mpi_montmul #4 (A >= N)
+mbedtls_mpi_montmul:10:"13":10:"10":10:"13":MBEDTLS_ERR_MPI_BAD_INPUT_DATA
+
+Base test mbedtls_mpi_montmul #4 (B >= N)
+mbedtls_mpi_montmul:10:"10":10:"13":10:"13":MBEDTLS_ERR_MPI_BAD_INPUT_DATA
+
+Test mbedtls_mpi_montmul_chk: 0 (null) * 0 (null) mod 9
+mbedtls_mpi_montmul_chk:10:"":10:"":10:"9":10:"0"
+
+Test mbedtls_mpi_montmul_chk: 4 * 5 mod 9
+mbedtls_mpi_montmul_chk:10:"4":10:"5":10:"9":10:"2"
+
+Test mbedtls_mpi_montmul: Aliasing
+mbedtls_mpi_montmul_aliasing:
+
 Base test mbedtls_mpi_exp_mod #1
 mbedtls_mpi_exp_mod:10:"23":10:"13":10:"29":10:"24":0
 

--- a/tests/suites/test_suite_mpi.data
+++ b/tests/suites/test_suite_mpi.data
@@ -1219,6 +1219,27 @@ mbedtls_mpi_mod_int:16:"":1:0:0
 Test mbedtls_mpi_mod_int: 0 (null) % -1
 mbedtls_mpi_mod_int:16:"":-1:0:MBEDTLS_ERR_MPI_NEGATIVE_VALUE
 
+Base test mbedtls_mpi_to_from_mont #1
+mbedtls_mpi_to_from_mont:10:"15":10:"23":0
+
+Base test mbedtls_mpi_to_from_mont #2 (A = 0)
+mbedtls_mpi_to_from_mont:10:"":10:"23":0
+
+Base test mbedtls_mpi_to_from_mont #2 (Negative A)
+mbedtls_mpi_to_from_mont:10:"-15":10:"23":0
+
+Base test mbedtls_mpi_to_from_mont #2 (A larger than N)
+mbedtls_mpi_to_from_mont:10:"38":10:"23":0
+
+Base test mbedtls_mpi_to_from_mont #3 (Even N)
+mbedtls_mpi_to_from_mont:10:"37":10:"28":MBEDTLS_ERR_MPI_BAD_INPUT_DATA
+
+Base test mbedtls_mpi_to_from_mont #3 (Negative N)
+mbedtls_mpi_to_from_mont:10:"37":10:"-15":MBEDTLS_ERR_MPI_BAD_INPUT_DATA
+
+Base test mbedtls_mpi_to_from_mont #3 (N = 0 (null))
+mbedtls_mpi_to_from_mont:10:"37":10:"":MBEDTLS_ERR_MPI_BAD_INPUT_DATA
+
 Base test mbedtls_mpi_exp_mod #1
 mbedtls_mpi_exp_mod:10:"23":10:"13":10:"29":10:"24":0
 

--- a/tests/suites/test_suite_mpi.data
+++ b/tests/suites/test_suite_mpi.data
@@ -1240,6 +1240,9 @@ mbedtls_mpi_to_from_mont:10:"37":10:"-15":MBEDTLS_ERR_MPI_BAD_INPUT_DATA
 Base test mbedtls_mpi_to_from_mont #3 (N = 0 (null))
 mbedtls_mpi_to_from_mont:10:"37":10:"":MBEDTLS_ERR_MPI_BAD_INPUT_DATA
 
+Test mbedtls_mpi_to_from_mont: Very large values
+mbedtls_mpi_to_from_mont_size:10001:10000:0
+
 Base test mbedtls_mpi_exp_mod #1
 mbedtls_mpi_exp_mod:10:"23":10:"13":10:"29":10:"24":0
 

--- a/tests/suites/test_suite_mpi.function
+++ b/tests/suites/test_suite_mpi.function
@@ -1110,6 +1110,119 @@ void mbedtls_mpi_to_from_mont_aliasing()
     TEST_ASSERT( mbedtls_mpi_cmp_int ( &A, 5 ) == 0 );
 
     /* FIXME assuming we won't alias N, mpi_mod_mpi assumes so. */
+exit:
+    mbedtls_mpi_free( &A ); mbedtls_mpi_free( &N );
+}
+/* END_CASE */
+
+/* BEGIN_CASE */
+void mbedtls_mpi_montmul( int radix_A, char * input_A, int radix_B,
+                          char * input_B, int radix_N, char * input_N,
+                          int exp_result )
+{
+    mbedtls_mpi A, B, N, X;
+    int res;
+    mbedtls_mpi_init( &A ); mbedtls_mpi_init( &B ); mbedtls_mpi_init( &N );
+    mbedtls_mpi_init( &X );
+
+    TEST_ASSERT( mbedtls_test_read_mpi( &A, radix_A, input_A ) == 0 );
+    TEST_ASSERT( mbedtls_test_read_mpi( &B, radix_B, input_B ) == 0 );
+    TEST_ASSERT( mbedtls_test_read_mpi( &N, radix_N, input_N ) == 0 );
+
+    res = mbedtls_mpi_montmul( &X, &A, &B, &N );
+    TEST_ASSERT( res == exp_result );
+
+    if( res == 0 ) {
+        /* Can't check expected result without converting to/from mont */
+        TEST_ASSERT( sign_is_valid( &X ) );
+        TEST_ASSERT( mbedtls_mpi_cmp_mpi( &X, &N ) < 0 );
+        TEST_ASSERT( mbedtls_mpi_cmp_int( &X, 0 ) >= 0 );
+    }
+exit:
+    mbedtls_mpi_free( &A ); mbedtls_mpi_free( &B ); mbedtls_mpi_free( &N );
+    mbedtls_mpi_free( &X );
+}
+/* END_CASE */
+
+/* BEGIN_CASE */
+void mbedtls_mpi_montmul_aliasing()
+{
+    mbedtls_mpi A, B, N;
+
+    mbedtls_mpi_init( &A ); mbedtls_mpi_init( &B ); mbedtls_mpi_init( &N );
+
+    mbedtls_mpi_lset( &N, 9 );
+
+    /* X is A */
+    mbedtls_mpi_lset( &A, 5 );
+    TEST_ASSERT( mbedtls_mpi_to_mont_mpi( &A, &A, &N, NULL ) == 0 );
+    mbedtls_mpi_lset( &B, 4 );
+    TEST_ASSERT( mbedtls_mpi_to_mont_mpi( &B, &B, &N, NULL ) == 0 );
+
+    TEST_ASSERT( mbedtls_mpi_montmul(&A, &A, &B, &N) == 0 );
+
+    TEST_ASSERT( mbedtls_mpi_from_mont_mpi( &A, &A, &N ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_cmp_int( &A, 2) == 0 );
+
+    /* X is B */
+    mbedtls_mpi_lset( &A, 5 );
+    TEST_ASSERT( mbedtls_mpi_to_mont_mpi( &A, &A, &N, NULL ) == 0 );
+    mbedtls_mpi_lset( &B, 4 );
+    TEST_ASSERT( mbedtls_mpi_to_mont_mpi( &B, &B, &N, NULL ) == 0 );
+
+    TEST_ASSERT( mbedtls_mpi_montmul(&B, &A, &B, &N) == 0 );
+
+    TEST_ASSERT( mbedtls_mpi_from_mont_mpi( &B, &B, &N ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_cmp_int( &B, 2) == 0 );
+
+    /* A is B */
+    mbedtls_mpi_lset( &A, 5 );
+    TEST_ASSERT( mbedtls_mpi_to_mont_mpi( &A, &A, &N, NULL ) == 0 );
+
+    TEST_ASSERT( mbedtls_mpi_montmul(&B, &A, &A, &N) == 0 );
+
+    TEST_ASSERT( mbedtls_mpi_from_mont_mpi( &B, &B, &N ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_cmp_int( &B, 7) == 0 );
+
+    /* X is A is B */
+    mbedtls_mpi_lset( &A, 5 );
+    TEST_ASSERT( mbedtls_mpi_to_mont_mpi( &A, &A, &N, NULL ) == 0 );
+
+    TEST_ASSERT( mbedtls_mpi_montmul(&A, &A, &A, &N) == 0 );
+
+    TEST_ASSERT( mbedtls_mpi_from_mont_mpi( &A, &A, &N ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_cmp_int( &A, 7) == 0 );
+
+exit:
+    mbedtls_mpi_free( &A ); mbedtls_mpi_free( &B ); mbedtls_mpi_free( &N );
+}
+/* END_CASE */
+
+/* BEGIN_CASE */
+void mbedtls_mpi_montmul_chk( int radix_A, char * input_A, int radix_B,
+                              char * input_B, int radix_N, char * input_N,
+                              int radix_X, char * input_X )
+{
+    mbedtls_mpi A, B, TA, TB, N, X, Y;
+    mbedtls_mpi_init( &A  ); mbedtls_mpi_init( &B ); mbedtls_mpi_init( &N  );
+    mbedtls_mpi_init( &X  ); mbedtls_mpi_init( &Y ); mbedtls_mpi_init( &TA );
+    mbedtls_mpi_init( &TB );
+
+    TEST_ASSERT( mbedtls_test_read_mpi( &A, radix_A, input_A ) == 0 );
+    TEST_ASSERT( mbedtls_test_read_mpi( &B, radix_B, input_B ) == 0 );
+    TEST_ASSERT( mbedtls_test_read_mpi( &N, radix_N, input_N ) == 0 );
+    TEST_ASSERT( mbedtls_test_read_mpi( &X, radix_X, input_X ) == 0 );
+
+    TEST_ASSERT( mbedtls_mpi_to_mont_mpi( &TA, &A, &N, NULL ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_to_mont_mpi( &TB, &B, &N, NULL ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_montmul( &Y, &TA, &TB, &N ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_from_mont_mpi( &Y, &Y, &N ) == 0 );
+
+    TEST_ASSERT( mbedtls_mpi_cmp_mpi( &X, &Y ) == 0 );
+exit:
+    mbedtls_mpi_free( &A  ); mbedtls_mpi_free( &B ); mbedtls_mpi_free( &N  );
+    mbedtls_mpi_free( &X  ); mbedtls_mpi_free( &Y ); mbedtls_mpi_free( &TA );
+    mbedtls_mpi_free( &TB );
 }
 /* END_CASE */
 

--- a/tests/suites/test_suite_mpi.function
+++ b/tests/suites/test_suite_mpi.function
@@ -987,6 +987,86 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE */
+void mbedtls_mpi_to_from_mont( int radix_A, char * input_A, int radix_N,
+                               char * input_N, int exp_result)
+{
+    mbedtls_mpi A, RR, N, X, Y, Z;
+    int res;
+    mbedtls_mpi_init( &A ); mbedtls_mpi_init( &RR ); mbedtls_mpi_init( &N );
+    mbedtls_mpi_init( &X ); mbedtls_mpi_init( &Y  ); mbedtls_mpi_init( &Z );
+
+    TEST_ASSERT( mbedtls_test_read_mpi( &A, radix_A, input_A ) == 0 );
+    TEST_ASSERT( mbedtls_test_read_mpi( &N, radix_N, input_N ) == 0 );
+
+    res = mbedtls_mpi_to_mont_mpi( &X, &A, &N, NULL );
+    TEST_ASSERT( res == exp_result );
+    if( res == 0 )
+    {
+        TEST_ASSERT( sign_is_valid( &X ) );
+        TEST_ASSERT( mbedtls_mpi_cmp_mpi( &X, &N ) < 0 );
+        TEST_ASSERT( mbedtls_mpi_cmp_int( &X, 0 ) >= 0 );
+
+        /* Since we succeeded, verify that conversion back works. */
+        res = mbedtls_mpi_mod_mpi( &Z, &A, &N );
+        TEST_ASSERT( res == 0 );
+
+        res = mbedtls_mpi_from_mont_mpi( &Y, &X, &N );
+        TEST_ASSERT( res == 0 );
+
+        TEST_ASSERT( mbedtls_mpi_cmp_mpi (&Z, &Y) == 0 );
+    }
+
+    /* Once more, saving the speed-up parameter. */
+    res = mbedtls_mpi_to_mont_mpi( &X, &A, &N, &RR );
+    TEST_ASSERT( res == exp_result );
+    if( res == 0 )
+    {
+        TEST_ASSERT( sign_is_valid( &X ) );
+        TEST_ASSERT( mbedtls_mpi_cmp_mpi( &X, &N ) < 0 );
+        TEST_ASSERT( mbedtls_mpi_cmp_int( &X, 0 ) >= 0 );
+
+        /* Z = A mod N has already been calculated. */
+        res = mbedtls_mpi_from_mont_mpi( &Y, &X, &N );
+        TEST_ASSERT( res == 0 );
+
+        TEST_ASSERT( mbedtls_mpi_cmp_mpi (&Z, &Y) == 0 );
+    }
+
+    /* Once more, with the speed-up parameter precalculated. */
+    res = mbedtls_mpi_to_mont_mpi( &X, &A, &N, &RR );
+    TEST_ASSERT( res == exp_result );
+    if( res == 0 )
+    {
+        TEST_ASSERT( sign_is_valid( &X ) );
+        TEST_ASSERT( mbedtls_mpi_cmp_mpi( &X, &N ) < 0 );
+        TEST_ASSERT( mbedtls_mpi_cmp_int( &X, 0 ) >= 0 );
+
+        res = mbedtls_mpi_from_mont_mpi( &Y, &X, &N );
+        TEST_ASSERT( res == 0 );
+
+        TEST_ASSERT( mbedtls_mpi_cmp_mpi (&Z, &Y) == 0 );
+    }
+
+    /*
+     * Finally, check just conversion from. It should satisfy all validation
+     * checks that conversion to does.
+     */
+    res = mbedtls_mpi_from_mont_mpi( &X, &A, &N);
+    TEST_ASSERT( res == exp_result );
+    if( res == 0 )
+    {
+        TEST_ASSERT( sign_is_valid( &X ) );
+        TEST_ASSERT( mbedtls_mpi_cmp_mpi( &X, &N ) < 0 );
+        TEST_ASSERT( mbedtls_mpi_cmp_int( &X, 0 ) >= 0 );
+    }
+
+exit:
+    mbedtls_mpi_free( &A ); mbedtls_mpi_free( &RR ); mbedtls_mpi_free( &N );
+    mbedtls_mpi_free( &X ); mbedtls_mpi_free( &Y  ); mbedtls_mpi_free( &Z );
+}
+/* END_CASE */
+
+/* BEGIN_CASE */
 void mbedtls_mpi_exp_mod( int radix_A, char * input_A, int radix_E,
                           char * input_E, int radix_N, char * input_N,
                           int radix_X, char * input_X, int exp_result )

--- a/tests/suites/test_suite_mpi.function
+++ b/tests/suites/test_suite_mpi.function
@@ -1067,6 +1067,35 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE */
+void mbedtls_mpi_to_from_mont_size( int A_bytes, int N_bytes,
+                                    int exp_result )
+{
+    mbedtls_mpi A, N, RR, Z;
+    mbedtls_mpi_init( &A ); mbedtls_mpi_init( &N ); mbedtls_mpi_init( &RR );
+    mbedtls_mpi_init( &Z );
+
+    /* Set A to 2^(A_bytes - 1) + 1 */
+    TEST_ASSERT( mbedtls_mpi_lset( &A, 1 ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_shift_l( &A, ( A_bytes * 8 ) - 1 ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_set_bit( &A, 0, 1 ) == 0 );
+
+    /* Set N to 2^(N_bytes - 1) + 1 */
+    TEST_ASSERT( mbedtls_mpi_lset( &N, 1 ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_shift_l( &N, ( N_bytes * 8 ) - 1 ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_set_bit( &N, 0, 1 ) == 0 );
+
+    TEST_ASSERT( mbedtls_mpi_to_mont_mpi( &Z, &A, &N, &RR ) == exp_result );
+    /* Again with precalculated RR */
+    TEST_ASSERT( mbedtls_mpi_to_mont_mpi( &Z, &A, &N, &RR ) == exp_result );
+    TEST_ASSERT( mbedtls_mpi_from_mont_mpi( &Z, &A, &N ) == exp_result );
+
+exit:
+    mbedtls_mpi_free( &A ); mbedtls_mpi_free( &N ); mbedtls_mpi_free( &RR );
+    mbedtls_mpi_free( &Z );
+}
+/* END_CASE */
+
+/* BEGIN_CASE */
 void mbedtls_mpi_exp_mod( int radix_A, char * input_A, int radix_E,
                           char * input_E, int radix_N, char * input_N,
                           int radix_X, char * input_X, int exp_result )

--- a/tests/suites/test_suite_mpi.function
+++ b/tests/suites/test_suite_mpi.function
@@ -1096,6 +1096,24 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE */
+void mbedtls_mpi_to_from_mont_aliasing()
+{
+    mbedtls_mpi A, N;
+
+    mbedtls_mpi_init( &A ); mbedtls_mpi_init( &N );
+
+    mbedtls_mpi_lset( &A, 5 );
+    mbedtls_mpi_lset( &N, 9 );
+
+    TEST_ASSERT( mbedtls_mpi_to_mont_mpi( &A, &A, &N, NULL ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_from_mont_mpi( &A, &A, &N ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_cmp_int ( &A, 5 ) == 0 );
+
+    /* FIXME assuming we won't alias N, mpi_mod_mpi assumes so. */
+}
+/* END_CASE */
+
+/* BEGIN_CASE */
 void mbedtls_mpi_exp_mod( int radix_A, char * input_A, int radix_E,
                           char * input_E, int radix_N, char * input_N,
                           int radix_X, char * input_X, int exp_result )


### PR DESCRIPTION
## Description
Add an API for Montgomery multiplication, wrapping internal functions that are already there. New functions allow converting bignums from/to Montgomery representation and multiplication itself.


## Status
**IN DEVELOPMENT**

## Requires Backporting
No

## Migrations
No

## Additional comments
Should fix #2537. I left some FIXMEs in places where I wasn't 100% sure what to do.

## Todos
- [x] Tests
- [x] Documentation
- [ ] Changelog updated