### PR TITLE
clean up compat.sh

### DIFF
--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -246,47 +246,43 @@ add_common_ciphersuites()
 
         "ECDSA")
             CIPHERS="$CIPHERS                           \
-                TLS-ECDHE-ECDSA-WITH-NULL-SHA           \
                 TLS-ECDHE-ECDSA-WITH-AES-128-CBC-SHA    \
+                TLS-ECDHE-ECDSA-WITH-AES-128-CBC-SHA256 \
+                TLS-ECDHE-ECDSA-WITH-AES-128-GCM-SHA256 \
                 TLS-ECDHE-ECDSA-WITH-AES-256-CBC-SHA    \
-
-                TLS-ECDHE-ECDSA-WITH-AES-128-CBC-SHA256         \
-                TLS-ECDHE-ECDSA-WITH-AES-256-CBC-SHA384         \
-                TLS-ECDHE-ECDSA-WITH-AES-128-GCM-SHA256         \
-                TLS-ECDHE-ECDSA-WITH-AES-256-GCM-SHA384         \
+                TLS-ECDHE-ECDSA-WITH-AES-256-CBC-SHA384 \
+                TLS-ECDHE-ECDSA-WITH-AES-256-GCM-SHA384 \
+                TLS-ECDHE-ECDSA-WITH-NULL-SHA           \
                 "
             ;;
 
         "RSA")
             CIPHERS="$CIPHERS                           \
                 TLS-DHE-RSA-WITH-AES-128-CBC-SHA        \
+                TLS-DHE-RSA-WITH-AES-128-CBC-SHA256     \
+                TLS-DHE-RSA-WITH-AES-128-GCM-SHA256     \
                 TLS-DHE-RSA-WITH-AES-256-CBC-SHA        \
+                TLS-DHE-RSA-WITH-AES-256-CBC-SHA256     \
+                TLS-DHE-RSA-WITH-AES-256-GCM-SHA384     \
                 TLS-DHE-RSA-WITH-CAMELLIA-128-CBC-SHA   \
                 TLS-DHE-RSA-WITH-CAMELLIA-256-CBC-SHA   \
-                TLS-RSA-WITH-AES-256-CBC-SHA            \
-                TLS-RSA-WITH-CAMELLIA-256-CBC-SHA       \
+                TLS-ECDHE-RSA-WITH-AES-128-CBC-SHA      \
+                TLS-ECDHE-RSA-WITH-AES-128-CBC-SHA256   \
+                TLS-ECDHE-RSA-WITH-AES-128-GCM-SHA256   \
+                TLS-ECDHE-RSA-WITH-AES-256-CBC-SHA      \
+                TLS-ECDHE-RSA-WITH-AES-256-CBC-SHA384   \
+                TLS-ECDHE-RSA-WITH-AES-256-GCM-SHA384   \
+                TLS-ECDHE-RSA-WITH-NULL-SHA             \
                 TLS-RSA-WITH-AES-128-CBC-SHA            \
+                TLS-RSA-WITH-AES-128-CBC-SHA256         \
+                TLS-RSA-WITH-AES-128-GCM-SHA256         \
+                TLS-RSA-WITH-AES-256-CBC-SHA            \
+                TLS-RSA-WITH-AES-256-CBC-SHA256         \
+                TLS-RSA-WITH-AES-256-GCM-SHA384         \
                 TLS-RSA-WITH-CAMELLIA-128-CBC-SHA       \
+                TLS-RSA-WITH-CAMELLIA-256-CBC-SHA       \
                 TLS-RSA-WITH-NULL-MD5                   \
                 TLS-RSA-WITH-NULL-SHA                   \
-
-                TLS-ECDHE-RSA-WITH-AES-128-CBC-SHA      \
-                TLS-ECDHE-RSA-WITH-AES-256-CBC-SHA      \
-                TLS-ECDHE-RSA-WITH-NULL-SHA             \
-
-                TLS-RSA-WITH-AES-128-CBC-SHA256         \
-                TLS-DHE-RSA-WITH-AES-128-CBC-SHA256     \
-                TLS-RSA-WITH-AES-256-CBC-SHA256         \
-                TLS-DHE-RSA-WITH-AES-256-CBC-SHA256     \
-                TLS-ECDHE-RSA-WITH-AES-128-CBC-SHA256   \
-                TLS-ECDHE-RSA-WITH-AES-256-CBC-SHA384   \
-                TLS-RSA-WITH-AES-128-GCM-SHA256         \
-                TLS-RSA-WITH-AES-256-GCM-SHA384         \
-                TLS-DHE-RSA-WITH-AES-128-GCM-SHA256     \
-                TLS-DHE-RSA-WITH-AES-256-GCM-SHA384     \
-                TLS-ECDHE-RSA-WITH-AES-128-GCM-SHA256   \
-                TLS-ECDHE-RSA-WITH-AES-256-GCM-SHA384   \
-
                 TLS-RSA-WITH-NULL-SHA256                \
                 "
             ;;
@@ -328,43 +324,42 @@ add_openssl_ciphersuites()
     case $TYPE in
 
         "ECDSA")
-            CIPHERS="$CIPHERS                           \
-                TLS-ECDH-ECDSA-WITH-NULL-SHA            \
-                TLS-ECDH-ECDSA-WITH-AES-128-CBC-SHA     \
-                TLS-ECDH-ECDSA-WITH-AES-256-CBC-SHA     \
-
+            CIPHERS="$CIPHERS                                   \
+                TLS-ECDH-ECDSA-WITH-AES-128-CBC-SHA             \
                 TLS-ECDH-ECDSA-WITH-AES-128-CBC-SHA256          \
-                TLS-ECDH-ECDSA-WITH-AES-256-CBC-SHA384          \
                 TLS-ECDH-ECDSA-WITH-AES-128-GCM-SHA256          \
+                TLS-ECDH-ECDSA-WITH-AES-256-CBC-SHA             \
+                TLS-ECDH-ECDSA-WITH-AES-256-CBC-SHA384          \
                 TLS-ECDH-ECDSA-WITH-AES-256-GCM-SHA384          \
-                TLS-ECDHE-ECDSA-WITH-ARIA-256-GCM-SHA384        \
+                TLS-ECDH-ECDSA-WITH-NULL-SHA                    \
                 TLS-ECDHE-ECDSA-WITH-ARIA-128-GCM-SHA256        \
+                TLS-ECDHE-ECDSA-WITH-ARIA-256-GCM-SHA384        \
                 TLS-ECDHE-ECDSA-WITH-CHACHA20-POLY1305-SHA256   \
                 "
             ;;
 
         "RSA")
-            CIPHERS="$CIPHERS                           \
-                TLS-ECDHE-RSA-WITH-ARIA-256-GCM-SHA384          \
-                TLS-DHE-RSA-WITH-ARIA-256-GCM-SHA384            \
-                TLS-RSA-WITH-ARIA-256-GCM-SHA384                \
-                TLS-ECDHE-RSA-WITH-ARIA-128-GCM-SHA256          \
+            CIPHERS="$CIPHERS                                   \
                 TLS-DHE-RSA-WITH-ARIA-128-GCM-SHA256            \
-                TLS-RSA-WITH-ARIA-128-GCM-SHA256                \
+                TLS-DHE-RSA-WITH-ARIA-256-GCM-SHA384            \
                 TLS-DHE-RSA-WITH-CHACHA20-POLY1305-SHA256       \
+                TLS-ECDHE-RSA-WITH-ARIA-128-GCM-SHA256          \
+                TLS-ECDHE-RSA-WITH-ARIA-256-GCM-SHA384          \
                 TLS-ECDHE-RSA-WITH-CHACHA20-POLY1305-SHA256     \
+                TLS-RSA-WITH-ARIA-128-GCM-SHA256                \
+                TLS-RSA-WITH-ARIA-256-GCM-SHA384                \
                 "
             ;;
 
         "PSK")
             CIPHERS="$CIPHERS                                   \
-                TLS-DHE-PSK-WITH-ARIA-256-GCM-SHA384            \
                 TLS-DHE-PSK-WITH-ARIA-128-GCM-SHA256            \
-                TLS-PSK-WITH-ARIA-256-GCM-SHA384                \
-                TLS-PSK-WITH-ARIA-128-GCM-SHA256                \
-                TLS-PSK-WITH-CHACHA20-POLY1305-SHA256           \
-                TLS-ECDHE-PSK-WITH-CHACHA20-POLY1305-SHA256     \
+                TLS-DHE-PSK-WITH-ARIA-256-GCM-SHA384            \
                 TLS-DHE-PSK-WITH-CHACHA20-POLY1305-SHA256       \
+                TLS-ECDHE-PSK-WITH-CHACHA20-POLY1305-SHA256     \
+                TLS-PSK-WITH-ARIA-128-GCM-SHA256                \
+                TLS-PSK-WITH-ARIA-256-GCM-SHA384                \
+                TLS-PSK-WITH-CHACHA20-POLY1305-SHA256           \
                 "
             ;;
     esac
@@ -388,96 +383,94 @@ add_gnutls_ciphersuites()
 
         "ECDSA")
             CIPHERS="$CIPHERS                                       \
-                TLS-ECDHE-ECDSA-WITH-CAMELLIA-128-CBC-SHA256        \
-                TLS-ECDHE-ECDSA-WITH-CAMELLIA-256-CBC-SHA384        \
-                TLS-ECDHE-ECDSA-WITH-CAMELLIA-128-GCM-SHA256        \
-                TLS-ECDHE-ECDSA-WITH-CAMELLIA-256-GCM-SHA384        \
                 TLS-ECDHE-ECDSA-WITH-AES-128-CCM                    \
-                TLS-ECDHE-ECDSA-WITH-AES-256-CCM                    \
                 TLS-ECDHE-ECDSA-WITH-AES-128-CCM-8                  \
+                TLS-ECDHE-ECDSA-WITH-AES-256-CCM                    \
                 TLS-ECDHE-ECDSA-WITH-AES-256-CCM-8                  \
+                TLS-ECDHE-ECDSA-WITH-CAMELLIA-128-CBC-SHA256        \
+                TLS-ECDHE-ECDSA-WITH-CAMELLIA-128-GCM-SHA256        \
+                TLS-ECDHE-ECDSA-WITH-CAMELLIA-256-CBC-SHA384        \
+                TLS-ECDHE-ECDSA-WITH-CAMELLIA-256-GCM-SHA384        \
                 "
             ;;
 
         "RSA")
             CIPHERS="$CIPHERS                               \
-                TLS-ECDHE-RSA-WITH-CAMELLIA-128-CBC-SHA256  \
-                TLS-ECDHE-RSA-WITH-CAMELLIA-256-CBC-SHA384  \
-                TLS-RSA-WITH-CAMELLIA-128-CBC-SHA256        \
-                TLS-RSA-WITH-CAMELLIA-256-CBC-SHA256        \
-                TLS-DHE-RSA-WITH-CAMELLIA-128-CBC-SHA256    \
-                TLS-DHE-RSA-WITH-CAMELLIA-256-CBC-SHA256    \
-                TLS-ECDHE-RSA-WITH-CAMELLIA-128-GCM-SHA256  \
-                TLS-ECDHE-RSA-WITH-CAMELLIA-256-GCM-SHA384  \
-                TLS-DHE-RSA-WITH-CAMELLIA-128-GCM-SHA256    \
-                TLS-DHE-RSA-WITH-CAMELLIA-256-GCM-SHA384    \
-                TLS-RSA-WITH-CAMELLIA-128-GCM-SHA256        \
-                TLS-RSA-WITH-CAMELLIA-256-GCM-SHA384        \
-                TLS-RSA-WITH-AES-128-CCM                    \
-                TLS-RSA-WITH-AES-256-CCM                    \
                 TLS-DHE-RSA-WITH-AES-128-CCM                \
-                TLS-DHE-RSA-WITH-AES-256-CCM                \
-                TLS-RSA-WITH-AES-128-CCM-8                  \
-                TLS-RSA-WITH-AES-256-CCM-8                  \
                 TLS-DHE-RSA-WITH-AES-128-CCM-8              \
+                TLS-DHE-RSA-WITH-AES-256-CCM                \
                 TLS-DHE-RSA-WITH-AES-256-CCM-8              \
+                TLS-DHE-RSA-WITH-CAMELLIA-128-CBC-SHA256    \
+                TLS-DHE-RSA-WITH-CAMELLIA-128-GCM-SHA256    \
+                TLS-DHE-RSA-WITH-CAMELLIA-256-CBC-SHA256    \
+                TLS-DHE-RSA-WITH-CAMELLIA-256-GCM-SHA384    \
+                TLS-ECDHE-RSA-WITH-CAMELLIA-128-CBC-SHA256  \
+                TLS-ECDHE-RSA-WITH-CAMELLIA-128-GCM-SHA256  \
+                TLS-ECDHE-RSA-WITH-CAMELLIA-256-CBC-SHA384  \
+                TLS-ECDHE-RSA-WITH-CAMELLIA-256-GCM-SHA384  \
+                TLS-RSA-WITH-AES-128-CCM                    \
+                TLS-RSA-WITH-AES-128-CCM-8                  \
+                TLS-RSA-WITH-AES-256-CCM                    \
+                TLS-RSA-WITH-AES-256-CCM-8                  \
+                TLS-RSA-WITH-CAMELLIA-128-CBC-SHA256        \
+                TLS-RSA-WITH-CAMELLIA-128-GCM-SHA256        \
+                TLS-RSA-WITH-CAMELLIA-256-CBC-SHA256        \
+                TLS-RSA-WITH-CAMELLIA-256-GCM-SHA384        \
                 "
             ;;
 
         "PSK")
             CIPHERS="$CIPHERS                               \
                 TLS-DHE-PSK-WITH-AES-128-CBC-SHA            \
-                TLS-DHE-PSK-WITH-AES-256-CBC-SHA            \
-
-                TLS-ECDHE-PSK-WITH-AES-256-CBC-SHA          \
-                TLS-ECDHE-PSK-WITH-AES-128-CBC-SHA          \
-                TLS-RSA-PSK-WITH-AES-256-CBC-SHA            \
-                TLS-RSA-PSK-WITH-AES-128-CBC-SHA            \
-
-                TLS-ECDHE-PSK-WITH-AES-256-CBC-SHA384       \
-                TLS-ECDHE-PSK-WITH-CAMELLIA-256-CBC-SHA384  \
-                TLS-ECDHE-PSK-WITH-AES-128-CBC-SHA256       \
-                TLS-ECDHE-PSK-WITH-CAMELLIA-128-CBC-SHA256  \
-                TLS-ECDHE-PSK-WITH-NULL-SHA384              \
-                TLS-ECDHE-PSK-WITH-NULL-SHA256              \
-                TLS-PSK-WITH-AES-128-CBC-SHA256             \
-                TLS-PSK-WITH-AES-256-CBC-SHA384             \
                 TLS-DHE-PSK-WITH-AES-128-CBC-SHA256         \
+                TLS-DHE-PSK-WITH-AES-128-CCM                \
+                TLS-DHE-PSK-WITH-AES-128-CCM-8              \
+                TLS-DHE-PSK-WITH-AES-128-GCM-SHA256         \
+                TLS-DHE-PSK-WITH-AES-256-CBC-SHA            \
                 TLS-DHE-PSK-WITH-AES-256-CBC-SHA384         \
-                TLS-PSK-WITH-NULL-SHA256                    \
-                TLS-PSK-WITH-NULL-SHA384                    \
+                TLS-DHE-PSK-WITH-AES-256-CCM                \
+                TLS-DHE-PSK-WITH-AES-256-CCM-8              \
+                TLS-DHE-PSK-WITH-AES-256-GCM-SHA384         \
+                TLS-DHE-PSK-WITH-CAMELLIA-128-CBC-SHA256    \
+                TLS-DHE-PSK-WITH-CAMELLIA-128-GCM-SHA256    \
+                TLS-DHE-PSK-WITH-CAMELLIA-256-CBC-SHA384    \
+                TLS-DHE-PSK-WITH-CAMELLIA-256-GCM-SHA384    \
                 TLS-DHE-PSK-WITH-NULL-SHA256                \
                 TLS-DHE-PSK-WITH-NULL-SHA384                \
-                TLS-RSA-PSK-WITH-AES-256-CBC-SHA384         \
+                TLS-ECDHE-PSK-WITH-AES-128-CBC-SHA          \
+                TLS-ECDHE-PSK-WITH-AES-128-CBC-SHA256       \
+                TLS-ECDHE-PSK-WITH-AES-256-CBC-SHA          \
+                TLS-ECDHE-PSK-WITH-AES-256-CBC-SHA384       \
+                TLS-ECDHE-PSK-WITH-CAMELLIA-128-CBC-SHA256  \
+                TLS-ECDHE-PSK-WITH-CAMELLIA-256-CBC-SHA384  \
+                TLS-ECDHE-PSK-WITH-NULL-SHA256              \
+                TLS-ECDHE-PSK-WITH-NULL-SHA384              \
+                TLS-PSK-WITH-AES-128-CBC-SHA256             \
+                TLS-PSK-WITH-AES-128-CCM                    \
+                TLS-PSK-WITH-AES-128-CCM-8                  \
+                TLS-PSK-WITH-AES-128-GCM-SHA256             \
+                TLS-PSK-WITH-AES-256-CBC-SHA384             \
+                TLS-PSK-WITH-AES-256-CCM                    \
+                TLS-PSK-WITH-AES-256-CCM-8                  \
+                TLS-PSK-WITH-AES-256-GCM-SHA384             \
+                TLS-PSK-WITH-CAMELLIA-128-CBC-SHA256        \
+                TLS-PSK-WITH-CAMELLIA-128-GCM-SHA256        \
+                TLS-PSK-WITH-CAMELLIA-256-CBC-SHA384        \
+                TLS-PSK-WITH-CAMELLIA-256-GCM-SHA384        \
+                TLS-PSK-WITH-NULL-SHA256                    \
+                TLS-PSK-WITH-NULL-SHA384                    \
+                TLS-RSA-PSK-WITH-AES-128-CBC-SHA            \
                 TLS-RSA-PSK-WITH-AES-128-CBC-SHA256         \
+                TLS-RSA-PSK-WITH-AES-128-GCM-SHA256         \
+                TLS-RSA-PSK-WITH-AES-256-CBC-SHA            \
+                TLS-RSA-PSK-WITH-AES-256-CBC-SHA384         \
+                TLS-RSA-PSK-WITH-AES-256-GCM-SHA384         \
+                TLS-RSA-PSK-WITH-CAMELLIA-128-CBC-SHA256    \
+                TLS-RSA-PSK-WITH-CAMELLIA-128-GCM-SHA256    \
+                TLS-RSA-PSK-WITH-CAMELLIA-256-CBC-SHA384    \
+                TLS-RSA-PSK-WITH-CAMELLIA-256-GCM-SHA384    \
                 TLS-RSA-PSK-WITH-NULL-SHA256                \
                 TLS-RSA-PSK-WITH-NULL-SHA384                \
-                TLS-DHE-PSK-WITH-CAMELLIA-128-CBC-SHA256    \
-                TLS-DHE-PSK-WITH-CAMELLIA-256-CBC-SHA384    \
-                TLS-PSK-WITH-CAMELLIA-128-CBC-SHA256        \
-                TLS-PSK-WITH-CAMELLIA-256-CBC-SHA384        \
-                TLS-RSA-PSK-WITH-CAMELLIA-256-CBC-SHA384    \
-                TLS-RSA-PSK-WITH-CAMELLIA-128-CBC-SHA256    \
-                TLS-PSK-WITH-AES-128-GCM-SHA256             \
-                TLS-PSK-WITH-AES-256-GCM-SHA384             \
-                TLS-DHE-PSK-WITH-AES-128-GCM-SHA256         \
-                TLS-DHE-PSK-WITH-AES-256-GCM-SHA384         \
-                TLS-PSK-WITH-AES-128-CCM                    \
-                TLS-PSK-WITH-AES-256-CCM                    \
-                TLS-DHE-PSK-WITH-AES-128-CCM                \
-                TLS-DHE-PSK-WITH-AES-256-CCM                \
-                TLS-PSK-WITH-AES-128-CCM-8                  \
-                TLS-PSK-WITH-AES-256-CCM-8                  \
-                TLS-DHE-PSK-WITH-AES-128-CCM-8              \
-                TLS-DHE-PSK-WITH-AES-256-CCM-8              \
-                TLS-RSA-PSK-WITH-CAMELLIA-128-GCM-SHA256    \
-                TLS-RSA-PSK-WITH-CAMELLIA-256-GCM-SHA384    \
-                TLS-PSK-WITH-CAMELLIA-128-GCM-SHA256        \
-                TLS-PSK-WITH-CAMELLIA-256-GCM-SHA384        \
-                TLS-DHE-PSK-WITH-CAMELLIA-128-GCM-SHA256    \
-                TLS-DHE-PSK-WITH-CAMELLIA-256-GCM-SHA384    \
-                TLS-RSA-PSK-WITH-AES-256-GCM-SHA384         \
-                TLS-RSA-PSK-WITH-AES-128-GCM-SHA256         \
                 "
             ;;
     esac
@@ -498,51 +491,48 @@ add_mbedtls_ciphersuites()
 
         "ECDSA")
             M_CIPHERS="$M_CIPHERS                               \
-                TLS-ECDH-ECDSA-WITH-CAMELLIA-128-CBC-SHA256     \
-                TLS-ECDH-ECDSA-WITH-CAMELLIA-256-CBC-SHA384     \
-
-                TLS-ECDH-ECDSA-WITH-CAMELLIA-128-GCM-SHA256     \
-                TLS-ECDH-ECDSA-WITH-CAMELLIA-256-GCM-SHA384     \
-                TLS-ECDHE-ECDSA-WITH-ARIA-256-CBC-SHA384        \
-                TLS-ECDHE-ECDSA-WITH-ARIA-128-CBC-SHA256        \
-                TLS-ECDH-ECDSA-WITH-ARIA-256-GCM-SHA384         \
+                TLS-ECDH-ECDSA-WITH-ARIA-128-CBC-SHA256         \
                 TLS-ECDH-ECDSA-WITH-ARIA-128-GCM-SHA256         \
                 TLS-ECDH-ECDSA-WITH-ARIA-256-CBC-SHA384         \
-                TLS-ECDH-ECDSA-WITH-ARIA-128-CBC-SHA256         \
+                TLS-ECDH-ECDSA-WITH-ARIA-256-GCM-SHA384         \
+                TLS-ECDH-ECDSA-WITH-CAMELLIA-128-CBC-SHA256     \
+                TLS-ECDH-ECDSA-WITH-CAMELLIA-128-GCM-SHA256     \
+                TLS-ECDH-ECDSA-WITH-CAMELLIA-256-CBC-SHA384     \
+                TLS-ECDH-ECDSA-WITH-CAMELLIA-256-GCM-SHA384     \
+                TLS-ECDHE-ECDSA-WITH-ARIA-128-CBC-SHA256        \
+                TLS-ECDHE-ECDSA-WITH-ARIA-256-CBC-SHA384        \
                 "
             ;;
 
         "RSA")
             M_CIPHERS="$M_CIPHERS                               \
-                TLS-ECDHE-RSA-WITH-ARIA-256-CBC-SHA384          \
+                TLS-DHE-RSA-WITH-ARIA-128-CBC-SHA256            \
                 TLS-DHE-RSA-WITH-ARIA-256-CBC-SHA384            \
                 TLS-ECDHE-RSA-WITH-ARIA-128-CBC-SHA256          \
-                TLS-DHE-RSA-WITH-ARIA-128-CBC-SHA256            \
-                TLS-RSA-WITH-ARIA-256-CBC-SHA384                \
+                TLS-ECDHE-RSA-WITH-ARIA-256-CBC-SHA384          \
                 TLS-RSA-WITH-ARIA-128-CBC-SHA256                \
+                TLS-RSA-WITH-ARIA-256-CBC-SHA384                \
                 "
             ;;
 
         "PSK")
             # *PSK-NULL-SHA suites supported by GnuTLS 3.3.5 but not 3.2.15
             M_CIPHERS="$M_CIPHERS                               \
-                TLS-PSK-WITH-NULL-SHA                           \
-                TLS-DHE-PSK-WITH-NULL-SHA                       \
-
-                TLS-ECDHE-PSK-WITH-NULL-SHA                     \
-                TLS-RSA-PSK-WITH-NULL-SHA                       \
-
-                TLS-RSA-PSK-WITH-ARIA-256-CBC-SHA384            \
-                TLS-RSA-PSK-WITH-ARIA-128-CBC-SHA256            \
-                TLS-PSK-WITH-ARIA-256-CBC-SHA384                \
-                TLS-PSK-WITH-ARIA-128-CBC-SHA256                \
-                TLS-RSA-PSK-WITH-ARIA-256-GCM-SHA384            \
-                TLS-RSA-PSK-WITH-ARIA-128-GCM-SHA256            \
-                TLS-ECDHE-PSK-WITH-ARIA-256-CBC-SHA384          \
-                TLS-ECDHE-PSK-WITH-ARIA-128-CBC-SHA256          \
-                TLS-DHE-PSK-WITH-ARIA-256-CBC-SHA384            \
                 TLS-DHE-PSK-WITH-ARIA-128-CBC-SHA256            \
+                TLS-DHE-PSK-WITH-ARIA-256-CBC-SHA384            \
+                TLS-DHE-PSK-WITH-NULL-SHA                       \
+                TLS-ECDHE-PSK-WITH-ARIA-128-CBC-SHA256          \
+                TLS-ECDHE-PSK-WITH-ARIA-256-CBC-SHA384          \
+                TLS-ECDHE-PSK-WITH-NULL-SHA                     \
+                TLS-PSK-WITH-ARIA-128-CBC-SHA256                \
+                TLS-PSK-WITH-ARIA-256-CBC-SHA384                \
+                TLS-PSK-WITH-NULL-SHA                           \
+                TLS-RSA-PSK-WITH-ARIA-128-CBC-SHA256            \
+                TLS-RSA-PSK-WITH-ARIA-128-GCM-SHA256            \
+                TLS-RSA-PSK-WITH-ARIA-256-CBC-SHA384            \
+                TLS-RSA-PSK-WITH-ARIA-256-GCM-SHA384            \
                 TLS-RSA-PSK-WITH-CHACHA20-POLY1305-SHA256       \
+                TLS-RSA-PSK-WITH-NULL-SHA                       \
                 "
             ;;
     esac

--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -245,24 +245,17 @@ add_common_ciphersuites()
     case $TYPE in
 
         "ECDSA")
-            if [ `minor_ver "$MODE"` -gt 0 ]
-            then
-                CIPHERS="$CIPHERS                           \
-                    TLS-ECDHE-ECDSA-WITH-NULL-SHA           \
-                    TLS-ECDHE-ECDSA-WITH-3DES-EDE-CBC-SHA   \
-                    TLS-ECDHE-ECDSA-WITH-AES-128-CBC-SHA    \
-                    TLS-ECDHE-ECDSA-WITH-AES-256-CBC-SHA    \
-                    "
-            fi
-            if [ `minor_ver "$MODE"` -ge 3 ]
-            then
-                CIPHERS="$CIPHERS                                   \
-                    TLS-ECDHE-ECDSA-WITH-AES-128-CBC-SHA256         \
-                    TLS-ECDHE-ECDSA-WITH-AES-256-CBC-SHA384         \
-                    TLS-ECDHE-ECDSA-WITH-AES-128-GCM-SHA256         \
-                    TLS-ECDHE-ECDSA-WITH-AES-256-GCM-SHA384         \
-                    "
-            fi
+            CIPHERS="$CIPHERS                           \
+                TLS-ECDHE-ECDSA-WITH-NULL-SHA           \
+                TLS-ECDHE-ECDSA-WITH-3DES-EDE-CBC-SHA   \
+                TLS-ECDHE-ECDSA-WITH-AES-128-CBC-SHA    \
+                TLS-ECDHE-ECDSA-WITH-AES-256-CBC-SHA    \
+
+                TLS-ECDHE-ECDSA-WITH-AES-128-CBC-SHA256         \
+                TLS-ECDHE-ECDSA-WITH-AES-256-CBC-SHA384         \
+                TLS-ECDHE-ECDSA-WITH-AES-128-GCM-SHA256         \
+                TLS-ECDHE-ECDSA-WITH-AES-256-GCM-SHA384         \
+                "
             ;;
 
         "RSA")
@@ -279,34 +272,27 @@ add_common_ciphersuites()
                 TLS-RSA-WITH-3DES-EDE-CBC-SHA           \
                 TLS-RSA-WITH-NULL-MD5                   \
                 TLS-RSA-WITH-NULL-SHA                   \
+
+                TLS-ECDHE-RSA-WITH-AES-128-CBC-SHA      \
+                TLS-ECDHE-RSA-WITH-AES-256-CBC-SHA      \
+                TLS-ECDHE-RSA-WITH-3DES-EDE-CBC-SHA     \
+                TLS-ECDHE-RSA-WITH-NULL-SHA             \
+
+                TLS-RSA-WITH-AES-128-CBC-SHA256         \
+                TLS-DHE-RSA-WITH-AES-128-CBC-SHA256     \
+                TLS-RSA-WITH-AES-256-CBC-SHA256         \
+                TLS-DHE-RSA-WITH-AES-256-CBC-SHA256     \
+                TLS-ECDHE-RSA-WITH-AES-128-CBC-SHA256   \
+                TLS-ECDHE-RSA-WITH-AES-256-CBC-SHA384   \
+                TLS-RSA-WITH-AES-128-GCM-SHA256         \
+                TLS-RSA-WITH-AES-256-GCM-SHA384         \
+                TLS-DHE-RSA-WITH-AES-128-GCM-SHA256     \
+                TLS-DHE-RSA-WITH-AES-256-GCM-SHA384     \
+                TLS-ECDHE-RSA-WITH-AES-128-GCM-SHA256   \
+                TLS-ECDHE-RSA-WITH-AES-256-GCM-SHA384   \
+
+                TLS-RSA-WITH-NULL-SHA256                \
                 "
-            if [ `minor_ver "$MODE"` -gt 0 ]
-            then
-                CIPHERS="$CIPHERS                           \
-                    TLS-ECDHE-RSA-WITH-AES-128-CBC-SHA      \
-                    TLS-ECDHE-RSA-WITH-AES-256-CBC-SHA      \
-                    TLS-ECDHE-RSA-WITH-3DES-EDE-CBC-SHA     \
-                    TLS-ECDHE-RSA-WITH-NULL-SHA             \
-                    "
-            fi
-            if [ `minor_ver "$MODE"` -ge 3 ]
-            then
-                CIPHERS="$CIPHERS                           \
-                    TLS-RSA-WITH-AES-128-CBC-SHA256         \
-                    TLS-DHE-RSA-WITH-AES-128-CBC-SHA256     \
-                    TLS-RSA-WITH-AES-256-CBC-SHA256         \
-                    TLS-DHE-RSA-WITH-AES-256-CBC-SHA256     \
-                    TLS-ECDHE-RSA-WITH-AES-128-CBC-SHA256   \
-                    TLS-ECDHE-RSA-WITH-AES-256-CBC-SHA384   \
-                    TLS-RSA-WITH-AES-128-GCM-SHA256         \
-                    TLS-RSA-WITH-AES-256-GCM-SHA384         \
-                    TLS-DHE-RSA-WITH-AES-128-GCM-SHA256     \
-                    TLS-DHE-RSA-WITH-AES-256-GCM-SHA384     \
-                    TLS-ECDHE-RSA-WITH-AES-128-GCM-SHA256   \
-                    TLS-ECDHE-RSA-WITH-AES-256-GCM-SHA384   \
-                    TLS-RSA-WITH-NULL-SHA256                \
-                    "
-            fi
             ;;
 
         "PSK")
@@ -347,62 +333,48 @@ add_openssl_ciphersuites()
     case $TYPE in
 
         "ECDSA")
-            if [ `minor_ver "$MODE"` -gt 0 ]
-            then
-                CIPHERS="$CIPHERS                           \
-                    TLS-ECDH-ECDSA-WITH-NULL-SHA       \
-                    TLS-ECDH-ECDSA-WITH-3DES-EDE-CBC-SHA    \
-                    TLS-ECDH-ECDSA-WITH-AES-128-CBC-SHA     \
-                    TLS-ECDH-ECDSA-WITH-AES-256-CBC-SHA     \
-                    "
-            fi
-            if [ `minor_ver "$MODE"` -ge 3 ]
-            then
-                CIPHERS="$CIPHERS                           \
-                    TLS-ECDH-ECDSA-WITH-AES-128-CBC-SHA256     \
-                    TLS-ECDH-ECDSA-WITH-AES-256-CBC-SHA384          \
-                    TLS-ECDH-ECDSA-WITH-AES-128-GCM-SHA256          \
-                    TLS-ECDH-ECDSA-WITH-AES-256-GCM-SHA384          \
-                    TLS-ECDHE-ECDSA-WITH-ARIA-256-GCM-SHA384        \
-                    TLS-ECDHE-ECDSA-WITH-ARIA-128-GCM-SHA256        \
-                    TLS-ECDHE-ECDSA-WITH-CHACHA20-POLY1305-SHA256   \
-                    "
-            fi
+            CIPHERS="$CIPHERS                           \
+                TLS-ECDH-ECDSA-WITH-NULL-SHA            \
+                TLS-ECDH-ECDSA-WITH-3DES-EDE-CBC-SHA    \
+                TLS-ECDH-ECDSA-WITH-AES-128-CBC-SHA     \
+                TLS-ECDH-ECDSA-WITH-AES-256-CBC-SHA     \
+
+                TLS-ECDH-ECDSA-WITH-AES-128-CBC-SHA256          \
+                TLS-ECDH-ECDSA-WITH-AES-256-CBC-SHA384          \
+                TLS-ECDH-ECDSA-WITH-AES-128-GCM-SHA256          \
+                TLS-ECDH-ECDSA-WITH-AES-256-GCM-SHA384          \
+                TLS-ECDHE-ECDSA-WITH-ARIA-256-GCM-SHA384        \
+                TLS-ECDHE-ECDSA-WITH-ARIA-128-GCM-SHA256        \
+                TLS-ECDHE-ECDSA-WITH-CHACHA20-POLY1305-SHA256   \
+                "
             ;;
 
         "RSA")
             CIPHERS="$CIPHERS                           \
-                TLS-RSA-WITH-DES-CBC-SHA           \
+                TLS-RSA-WITH-DES-CBC-SHA                \
                 TLS-DHE-RSA-WITH-DES-CBC-SHA            \
+
+                TLS-ECDHE-RSA-WITH-ARIA-256-GCM-SHA384          \
+                TLS-DHE-RSA-WITH-ARIA-256-GCM-SHA384            \
+                TLS-RSA-WITH-ARIA-256-GCM-SHA384                \
+                TLS-ECDHE-RSA-WITH-ARIA-128-GCM-SHA256          \
+                TLS-DHE-RSA-WITH-ARIA-128-GCM-SHA256            \
+                TLS-RSA-WITH-ARIA-128-GCM-SHA256                \
+                TLS-DHE-RSA-WITH-CHACHA20-POLY1305-SHA256       \
+                TLS-ECDHE-RSA-WITH-CHACHA20-POLY1305-SHA256     \
                 "
-            if [ `minor_ver "$MODE"` -ge 3 ]
-            then
-                CIPHERS="$CIPHERS                           \
-                    TLS-ECDHE-RSA-WITH-ARIA-256-GCM-SHA384     \
-                    TLS-DHE-RSA-WITH-ARIA-256-GCM-SHA384            \
-                    TLS-RSA-WITH-ARIA-256-GCM-SHA384                \
-                    TLS-ECDHE-RSA-WITH-ARIA-128-GCM-SHA256          \
-                    TLS-DHE-RSA-WITH-ARIA-128-GCM-SHA256            \
-                    TLS-RSA-WITH-ARIA-128-GCM-SHA256                \
-                    TLS-DHE-RSA-WITH-CHACHA20-POLY1305-SHA256       \
-                    TLS-ECDHE-RSA-WITH-CHACHA20-POLY1305-SHA256     \
-                    "
-            fi
             ;;
 
         "PSK")
-            if [ `minor_ver "$MODE"` -ge 3 ]
-            then
-                CIPHERS="$CIPHERS                           \
-                    TLS-DHE-PSK-WITH-ARIA-256-GCM-SHA384       \
-                    TLS-DHE-PSK-WITH-ARIA-128-GCM-SHA256            \
-                    TLS-PSK-WITH-ARIA-256-GCM-SHA384                \
-                    TLS-PSK-WITH-ARIA-128-GCM-SHA256                \
-                    TLS-PSK-WITH-CHACHA20-POLY1305-SHA256           \
-                    TLS-ECDHE-PSK-WITH-CHACHA20-POLY1305-SHA256     \
-                    TLS-DHE-PSK-WITH-CHACHA20-POLY1305-SHA256       \
-                    "
-            fi
+            CIPHERS="$CIPHERS                                   \
+                TLS-DHE-PSK-WITH-ARIA-256-GCM-SHA384            \
+                TLS-DHE-PSK-WITH-ARIA-128-GCM-SHA256            \
+                TLS-PSK-WITH-ARIA-256-GCM-SHA384                \
+                TLS-PSK-WITH-ARIA-128-GCM-SHA256                \
+                TLS-PSK-WITH-CHACHA20-POLY1305-SHA256           \
+                TLS-ECDHE-PSK-WITH-CHACHA20-POLY1305-SHA256     \
+                TLS-DHE-PSK-WITH-CHACHA20-POLY1305-SHA256       \
+                "
             ;;
     esac
 
@@ -424,115 +396,101 @@ add_gnutls_ciphersuites()
     case $TYPE in
 
         "ECDSA")
-            if [ `minor_ver "$MODE"` -ge 3 ]
-            then
-                CIPHERS="$CIPHERS                           \
-                    TLS-ECDHE-ECDSA-WITH-CAMELLIA-128-CBC-SHA256   \
-                    TLS-ECDHE-ECDSA-WITH-CAMELLIA-256-CBC-SHA384        \
-                    TLS-ECDHE-ECDSA-WITH-CAMELLIA-128-GCM-SHA256        \
-                    TLS-ECDHE-ECDSA-WITH-CAMELLIA-256-GCM-SHA384        \
-                    TLS-ECDHE-ECDSA-WITH-AES-128-CCM                    \
-                    TLS-ECDHE-ECDSA-WITH-AES-256-CCM                    \
-                    TLS-ECDHE-ECDSA-WITH-AES-128-CCM-8                  \
-                    TLS-ECDHE-ECDSA-WITH-AES-256-CCM-8                  \
-                   "
-            fi
+            CIPHERS="$CIPHERS                                       \
+                TLS-ECDHE-ECDSA-WITH-CAMELLIA-128-CBC-SHA256        \
+                TLS-ECDHE-ECDSA-WITH-CAMELLIA-256-CBC-SHA384        \
+                TLS-ECDHE-ECDSA-WITH-CAMELLIA-128-GCM-SHA256        \
+                TLS-ECDHE-ECDSA-WITH-CAMELLIA-256-GCM-SHA384        \
+                TLS-ECDHE-ECDSA-WITH-AES-128-CCM                    \
+                TLS-ECDHE-ECDSA-WITH-AES-256-CCM                    \
+                TLS-ECDHE-ECDSA-WITH-AES-128-CCM-8                  \
+                TLS-ECDHE-ECDSA-WITH-AES-256-CCM-8                  \
+                "
             ;;
 
         "RSA")
-            if [ `minor_ver "$MODE"` -ge 3 ]
-            then
-                CIPHERS="$CIPHERS                               \
-                    TLS-ECDHE-RSA-WITH-CAMELLIA-128-CBC-SHA256  \
-                    TLS-ECDHE-RSA-WITH-CAMELLIA-256-CBC-SHA384  \
-                    TLS-RSA-WITH-CAMELLIA-128-CBC-SHA256        \
-                    TLS-RSA-WITH-CAMELLIA-256-CBC-SHA256        \
-                    TLS-DHE-RSA-WITH-CAMELLIA-128-CBC-SHA256    \
-                    TLS-DHE-RSA-WITH-CAMELLIA-256-CBC-SHA256    \
-                    TLS-ECDHE-RSA-WITH-CAMELLIA-128-GCM-SHA256  \
-                    TLS-ECDHE-RSA-WITH-CAMELLIA-256-GCM-SHA384  \
-                    TLS-DHE-RSA-WITH-CAMELLIA-128-GCM-SHA256    \
-                    TLS-DHE-RSA-WITH-CAMELLIA-256-GCM-SHA384    \
-                    TLS-RSA-WITH-CAMELLIA-128-GCM-SHA256        \
-                    TLS-RSA-WITH-CAMELLIA-256-GCM-SHA384        \
-                    TLS-RSA-WITH-AES-128-CCM                    \
-                    TLS-RSA-WITH-AES-256-CCM                    \
-                    TLS-DHE-RSA-WITH-AES-128-CCM                \
-                    TLS-DHE-RSA-WITH-AES-256-CCM                \
-                    TLS-RSA-WITH-AES-128-CCM-8                  \
-                    TLS-RSA-WITH-AES-256-CCM-8                  \
-                    TLS-DHE-RSA-WITH-AES-128-CCM-8              \
-                    TLS-DHE-RSA-WITH-AES-256-CCM-8              \
-                    "
-            fi
+            CIPHERS="$CIPHERS                               \
+                TLS-ECDHE-RSA-WITH-CAMELLIA-128-CBC-SHA256  \
+                TLS-ECDHE-RSA-WITH-CAMELLIA-256-CBC-SHA384  \
+                TLS-RSA-WITH-CAMELLIA-128-CBC-SHA256        \
+                TLS-RSA-WITH-CAMELLIA-256-CBC-SHA256        \
+                TLS-DHE-RSA-WITH-CAMELLIA-128-CBC-SHA256    \
+                TLS-DHE-RSA-WITH-CAMELLIA-256-CBC-SHA256    \
+                TLS-ECDHE-RSA-WITH-CAMELLIA-128-GCM-SHA256  \
+                TLS-ECDHE-RSA-WITH-CAMELLIA-256-GCM-SHA384  \
+                TLS-DHE-RSA-WITH-CAMELLIA-128-GCM-SHA256    \
+                TLS-DHE-RSA-WITH-CAMELLIA-256-GCM-SHA384    \
+                TLS-RSA-WITH-CAMELLIA-128-GCM-SHA256        \
+                TLS-RSA-WITH-CAMELLIA-256-GCM-SHA384        \
+                TLS-RSA-WITH-AES-128-CCM                    \
+                TLS-RSA-WITH-AES-256-CCM                    \
+                TLS-DHE-RSA-WITH-AES-128-CCM                \
+                TLS-DHE-RSA-WITH-AES-256-CCM                \
+                TLS-RSA-WITH-AES-128-CCM-8                  \
+                TLS-RSA-WITH-AES-256-CCM-8                  \
+                TLS-DHE-RSA-WITH-AES-128-CCM-8              \
+                TLS-DHE-RSA-WITH-AES-256-CCM-8              \
+                "
             ;;
 
         "PSK")
-            CIPHERS="$CIPHERS                                 \
-                TLS-DHE-PSK-WITH-3DES-EDE-CBC-SHA             \
-                TLS-DHE-PSK-WITH-AES-128-CBC-SHA              \
-                TLS-DHE-PSK-WITH-AES-256-CBC-SHA              \
+            CIPHERS="$CIPHERS                               \
+                TLS-DHE-PSK-WITH-3DES-EDE-CBC-SHA           \
+                TLS-DHE-PSK-WITH-AES-128-CBC-SHA            \
+                TLS-DHE-PSK-WITH-AES-256-CBC-SHA            \
+
+                TLS-ECDHE-PSK-WITH-AES-256-CBC-SHA          \
+                TLS-ECDHE-PSK-WITH-AES-128-CBC-SHA          \
+                TLS-ECDHE-PSK-WITH-3DES-EDE-CBC-SHA         \
+                TLS-RSA-PSK-WITH-3DES-EDE-CBC-SHA           \
+                TLS-RSA-PSK-WITH-AES-256-CBC-SHA            \
+                TLS-RSA-PSK-WITH-AES-128-CBC-SHA            \
+
+                TLS-ECDHE-PSK-WITH-AES-256-CBC-SHA384       \
+                TLS-ECDHE-PSK-WITH-CAMELLIA-256-CBC-SHA384  \
+                TLS-ECDHE-PSK-WITH-AES-128-CBC-SHA256       \
+                TLS-ECDHE-PSK-WITH-CAMELLIA-128-CBC-SHA256  \
+                TLS-ECDHE-PSK-WITH-NULL-SHA384              \
+                TLS-ECDHE-PSK-WITH-NULL-SHA256              \
+                TLS-PSK-WITH-AES-128-CBC-SHA256             \
+                TLS-PSK-WITH-AES-256-CBC-SHA384             \
+                TLS-DHE-PSK-WITH-AES-128-CBC-SHA256         \
+                TLS-DHE-PSK-WITH-AES-256-CBC-SHA384         \
+                TLS-PSK-WITH-NULL-SHA256                    \
+                TLS-PSK-WITH-NULL-SHA384                    \
+                TLS-DHE-PSK-WITH-NULL-SHA256                \
+                TLS-DHE-PSK-WITH-NULL-SHA384                \
+                TLS-RSA-PSK-WITH-AES-256-CBC-SHA384         \
+                TLS-RSA-PSK-WITH-AES-128-CBC-SHA256         \
+                TLS-RSA-PSK-WITH-NULL-SHA256                \
+                TLS-RSA-PSK-WITH-NULL-SHA384                \
+                TLS-DHE-PSK-WITH-CAMELLIA-128-CBC-SHA256    \
+                TLS-DHE-PSK-WITH-CAMELLIA-256-CBC-SHA384    \
+                TLS-PSK-WITH-CAMELLIA-128-CBC-SHA256        \
+                TLS-PSK-WITH-CAMELLIA-256-CBC-SHA384        \
+                TLS-RSA-PSK-WITH-CAMELLIA-256-CBC-SHA384    \
+                TLS-RSA-PSK-WITH-CAMELLIA-128-CBC-SHA256    \
+                TLS-PSK-WITH-AES-128-GCM-SHA256             \
+                TLS-PSK-WITH-AES-256-GCM-SHA384             \
+                TLS-DHE-PSK-WITH-AES-128-GCM-SHA256         \
+                TLS-DHE-PSK-WITH-AES-256-GCM-SHA384         \
+                TLS-PSK-WITH-AES-128-CCM                    \
+                TLS-PSK-WITH-AES-256-CCM                    \
+                TLS-DHE-PSK-WITH-AES-128-CCM                \
+                TLS-DHE-PSK-WITH-AES-256-CCM                \
+                TLS-PSK-WITH-AES-128-CCM-8                  \
+                TLS-PSK-WITH-AES-256-CCM-8                  \
+                TLS-DHE-PSK-WITH-AES-128-CCM-8              \
+                TLS-DHE-PSK-WITH-AES-256-CCM-8              \
+                TLS-RSA-PSK-WITH-CAMELLIA-128-GCM-SHA256    \
+                TLS-RSA-PSK-WITH-CAMELLIA-256-GCM-SHA384    \
+                TLS-PSK-WITH-CAMELLIA-128-GCM-SHA256        \
+                TLS-PSK-WITH-CAMELLIA-256-GCM-SHA384        \
+                TLS-DHE-PSK-WITH-CAMELLIA-128-GCM-SHA256    \
+                TLS-DHE-PSK-WITH-CAMELLIA-256-GCM-SHA384    \
+                TLS-RSA-PSK-WITH-AES-256-GCM-SHA384         \
+                TLS-RSA-PSK-WITH-AES-128-GCM-SHA256         \
                 "
-            if [ `minor_ver "$MODE"` -gt 0 ]
-            then
-                CIPHERS="$CIPHERS                               \
-                    TLS-ECDHE-PSK-WITH-AES-256-CBC-SHA          \
-                    TLS-ECDHE-PSK-WITH-AES-128-CBC-SHA          \
-                    TLS-ECDHE-PSK-WITH-3DES-EDE-CBC-SHA         \
-                    TLS-RSA-PSK-WITH-3DES-EDE-CBC-SHA           \
-                    TLS-RSA-PSK-WITH-AES-256-CBC-SHA            \
-                    TLS-RSA-PSK-WITH-AES-128-CBC-SHA            \
-                    "
-            fi
-            if [ `minor_ver "$MODE"` -ge 3 ]
-            then
-                CIPHERS="$CIPHERS                               \
-                    TLS-ECDHE-PSK-WITH-AES-256-CBC-SHA384       \
-                    TLS-ECDHE-PSK-WITH-CAMELLIA-256-CBC-SHA384  \
-                    TLS-ECDHE-PSK-WITH-AES-128-CBC-SHA256       \
-                    TLS-ECDHE-PSK-WITH-CAMELLIA-128-CBC-SHA256  \
-                    TLS-ECDHE-PSK-WITH-NULL-SHA384              \
-                    TLS-ECDHE-PSK-WITH-NULL-SHA256              \
-                    TLS-PSK-WITH-AES-128-CBC-SHA256             \
-                    TLS-PSK-WITH-AES-256-CBC-SHA384             \
-                    TLS-DHE-PSK-WITH-AES-128-CBC-SHA256         \
-                    TLS-DHE-PSK-WITH-AES-256-CBC-SHA384         \
-                    TLS-PSK-WITH-NULL-SHA256                    \
-                    TLS-PSK-WITH-NULL-SHA384                    \
-                    TLS-DHE-PSK-WITH-NULL-SHA256                \
-                    TLS-DHE-PSK-WITH-NULL-SHA384                \
-                    TLS-RSA-PSK-WITH-AES-256-CBC-SHA384         \
-                    TLS-RSA-PSK-WITH-AES-128-CBC-SHA256         \
-                    TLS-RSA-PSK-WITH-NULL-SHA256                \
-                    TLS-RSA-PSK-WITH-NULL-SHA384                \
-                    TLS-DHE-PSK-WITH-CAMELLIA-128-CBC-SHA256    \
-                    TLS-DHE-PSK-WITH-CAMELLIA-256-CBC-SHA384    \
-                    TLS-PSK-WITH-CAMELLIA-128-CBC-SHA256        \
-                    TLS-PSK-WITH-CAMELLIA-256-CBC-SHA384        \
-                    TLS-RSA-PSK-WITH-CAMELLIA-256-CBC-SHA384    \
-                    TLS-RSA-PSK-WITH-CAMELLIA-128-CBC-SHA256    \
-                    TLS-PSK-WITH-AES-128-GCM-SHA256             \
-                    TLS-PSK-WITH-AES-256-GCM-SHA384             \
-                    TLS-DHE-PSK-WITH-AES-128-GCM-SHA256         \
-                    TLS-DHE-PSK-WITH-AES-256-GCM-SHA384         \
-                    TLS-PSK-WITH-AES-128-CCM                    \
-                    TLS-PSK-WITH-AES-256-CCM                    \
-                    TLS-DHE-PSK-WITH-AES-128-CCM                \
-                    TLS-DHE-PSK-WITH-AES-256-CCM                \
-                    TLS-PSK-WITH-AES-128-CCM-8                  \
-                    TLS-PSK-WITH-AES-256-CCM-8                  \
-                    TLS-DHE-PSK-WITH-AES-128-CCM-8              \
-                    TLS-DHE-PSK-WITH-AES-256-CCM-8              \
-                    TLS-RSA-PSK-WITH-CAMELLIA-128-GCM-SHA256    \
-                    TLS-RSA-PSK-WITH-CAMELLIA-256-GCM-SHA384    \
-                    TLS-PSK-WITH-CAMELLIA-128-GCM-SHA256        \
-                    TLS-PSK-WITH-CAMELLIA-256-GCM-SHA384        \
-                    TLS-DHE-PSK-WITH-CAMELLIA-128-GCM-SHA256    \
-                    TLS-DHE-PSK-WITH-CAMELLIA-256-GCM-SHA384    \
-                    TLS-RSA-PSK-WITH-AES-256-GCM-SHA384         \
-                    TLS-RSA-PSK-WITH-AES-128-GCM-SHA256         \
-                    "
-            fi
             ;;
     esac
 
@@ -551,71 +509,53 @@ add_mbedtls_ciphersuites()
     case $TYPE in
 
         "ECDSA")
-            if [ `minor_ver "$MODE"` -gt 0 ]
-            then
-                M_CIPHERS="$M_CIPHERS                               \
-                    TLS-ECDH-ECDSA-WITH-CAMELLIA-128-CBC-SHA256     \
-                    TLS-ECDH-ECDSA-WITH-CAMELLIA-256-CBC-SHA384     \
-                    "
-            fi
-            if [ `minor_ver "$MODE"` -ge 3 ]
-            then
-                M_CIPHERS="$M_CIPHERS                               \
-                    TLS-ECDH-ECDSA-WITH-CAMELLIA-128-GCM-SHA256     \
-                    TLS-ECDH-ECDSA-WITH-CAMELLIA-256-GCM-SHA384     \
-                    TLS-ECDHE-ECDSA-WITH-ARIA-256-CBC-SHA384        \
-                    TLS-ECDHE-ECDSA-WITH-ARIA-128-CBC-SHA256        \
-                    TLS-ECDH-ECDSA-WITH-ARIA-256-GCM-SHA384         \
-                    TLS-ECDH-ECDSA-WITH-ARIA-128-GCM-SHA256         \
-                    TLS-ECDH-ECDSA-WITH-ARIA-256-CBC-SHA384         \
-                    TLS-ECDH-ECDSA-WITH-ARIA-128-CBC-SHA256         \
-                    "
-            fi
+            M_CIPHERS="$M_CIPHERS                               \
+                TLS-ECDH-ECDSA-WITH-CAMELLIA-128-CBC-SHA256     \
+                TLS-ECDH-ECDSA-WITH-CAMELLIA-256-CBC-SHA384     \
+
+                TLS-ECDH-ECDSA-WITH-CAMELLIA-128-GCM-SHA256     \
+                TLS-ECDH-ECDSA-WITH-CAMELLIA-256-GCM-SHA384     \
+                TLS-ECDHE-ECDSA-WITH-ARIA-256-CBC-SHA384        \
+                TLS-ECDHE-ECDSA-WITH-ARIA-128-CBC-SHA256        \
+                TLS-ECDH-ECDSA-WITH-ARIA-256-GCM-SHA384         \
+                TLS-ECDH-ECDSA-WITH-ARIA-128-GCM-SHA256         \
+                TLS-ECDH-ECDSA-WITH-ARIA-256-CBC-SHA384         \
+                TLS-ECDH-ECDSA-WITH-ARIA-128-CBC-SHA256         \
+                "
             ;;
 
         "RSA")
-            if [ `minor_ver "$MODE"` -ge 3 ]
-            then
-                M_CIPHERS="$M_CIPHERS                               \
-                    TLS-ECDHE-RSA-WITH-ARIA-256-CBC-SHA384          \
-                    TLS-DHE-RSA-WITH-ARIA-256-CBC-SHA384            \
-                    TLS-ECDHE-RSA-WITH-ARIA-128-CBC-SHA256          \
-                    TLS-DHE-RSA-WITH-ARIA-128-CBC-SHA256            \
-                    TLS-RSA-WITH-ARIA-256-CBC-SHA384                \
-                    TLS-RSA-WITH-ARIA-128-CBC-SHA256                \
-                    "
-            fi
+            M_CIPHERS="$M_CIPHERS                               \
+                TLS-ECDHE-RSA-WITH-ARIA-256-CBC-SHA384          \
+                TLS-DHE-RSA-WITH-ARIA-256-CBC-SHA384            \
+                TLS-ECDHE-RSA-WITH-ARIA-128-CBC-SHA256          \
+                TLS-DHE-RSA-WITH-ARIA-128-CBC-SHA256            \
+                TLS-RSA-WITH-ARIA-256-CBC-SHA384                \
+                TLS-RSA-WITH-ARIA-128-CBC-SHA256                \
+                "
             ;;
 
         "PSK")
             # *PSK-NULL-SHA suites supported by GnuTLS 3.3.5 but not 3.2.15
-            M_CIPHERS="$M_CIPHERS                        \
-                TLS-PSK-WITH-NULL-SHA                    \
-                TLS-DHE-PSK-WITH-NULL-SHA                \
+            M_CIPHERS="$M_CIPHERS                               \
+                TLS-PSK-WITH-NULL-SHA                           \
+                TLS-DHE-PSK-WITH-NULL-SHA                       \
+
+                TLS-ECDHE-PSK-WITH-NULL-SHA                     \
+                TLS-RSA-PSK-WITH-NULL-SHA                       \
+
+                TLS-RSA-PSK-WITH-ARIA-256-CBC-SHA384            \
+                TLS-RSA-PSK-WITH-ARIA-128-CBC-SHA256            \
+                TLS-PSK-WITH-ARIA-256-CBC-SHA384                \
+                TLS-PSK-WITH-ARIA-128-CBC-SHA256                \
+                TLS-RSA-PSK-WITH-ARIA-256-GCM-SHA384            \
+                TLS-RSA-PSK-WITH-ARIA-128-GCM-SHA256            \
+                TLS-ECDHE-PSK-WITH-ARIA-256-CBC-SHA384          \
+                TLS-ECDHE-PSK-WITH-ARIA-128-CBC-SHA256          \
+                TLS-DHE-PSK-WITH-ARIA-256-CBC-SHA384            \
+                TLS-DHE-PSK-WITH-ARIA-128-CBC-SHA256            \
+                TLS-RSA-PSK-WITH-CHACHA20-POLY1305-SHA256       \
                 "
-            if [ `minor_ver "$MODE"` -gt 0 ]
-            then
-                M_CIPHERS="$M_CIPHERS                    \
-                    TLS-ECDHE-PSK-WITH-NULL-SHA          \
-                    TLS-RSA-PSK-WITH-NULL-SHA            \
-                    "
-            fi
-            if [ `minor_ver "$MODE"` -ge 3 ]
-            then
-                M_CIPHERS="$M_CIPHERS                               \
-                    TLS-RSA-PSK-WITH-ARIA-256-CBC-SHA384            \
-                    TLS-RSA-PSK-WITH-ARIA-128-CBC-SHA256            \
-                    TLS-PSK-WITH-ARIA-256-CBC-SHA384                \
-                    TLS-PSK-WITH-ARIA-128-CBC-SHA256                \
-                    TLS-RSA-PSK-WITH-ARIA-256-GCM-SHA384            \
-                    TLS-RSA-PSK-WITH-ARIA-128-GCM-SHA256            \
-                    TLS-ECDHE-PSK-WITH-ARIA-256-CBC-SHA384          \
-                    TLS-ECDHE-PSK-WITH-ARIA-128-CBC-SHA256          \
-                    TLS-DHE-PSK-WITH-ARIA-256-CBC-SHA384            \
-                    TLS-DHE-PSK-WITH-ARIA-128-CBC-SHA256            \
-                    TLS-RSA-PSK-WITH-CHACHA20-POLY1305-SHA256       \
-                    "
-            fi
             ;;
     esac
 }

--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -247,7 +247,6 @@ add_common_ciphersuites()
         "ECDSA")
             CIPHERS="$CIPHERS                           \
                 TLS-ECDHE-ECDSA-WITH-NULL-SHA           \
-                TLS-ECDHE-ECDSA-WITH-3DES-EDE-CBC-SHA   \
                 TLS-ECDHE-ECDSA-WITH-AES-128-CBC-SHA    \
                 TLS-ECDHE-ECDSA-WITH-AES-256-CBC-SHA    \
 
@@ -264,18 +263,15 @@ add_common_ciphersuites()
                 TLS-DHE-RSA-WITH-AES-256-CBC-SHA        \
                 TLS-DHE-RSA-WITH-CAMELLIA-128-CBC-SHA   \
                 TLS-DHE-RSA-WITH-CAMELLIA-256-CBC-SHA   \
-                TLS-DHE-RSA-WITH-3DES-EDE-CBC-SHA       \
                 TLS-RSA-WITH-AES-256-CBC-SHA            \
                 TLS-RSA-WITH-CAMELLIA-256-CBC-SHA       \
                 TLS-RSA-WITH-AES-128-CBC-SHA            \
                 TLS-RSA-WITH-CAMELLIA-128-CBC-SHA       \
-                TLS-RSA-WITH-3DES-EDE-CBC-SHA           \
                 TLS-RSA-WITH-NULL-MD5                   \
                 TLS-RSA-WITH-NULL-SHA                   \
 
                 TLS-ECDHE-RSA-WITH-AES-128-CBC-SHA      \
                 TLS-ECDHE-RSA-WITH-AES-256-CBC-SHA      \
-                TLS-ECDHE-RSA-WITH-3DES-EDE-CBC-SHA     \
                 TLS-ECDHE-RSA-WITH-NULL-SHA             \
 
                 TLS-RSA-WITH-AES-128-CBC-SHA256         \
@@ -297,7 +293,6 @@ add_common_ciphersuites()
 
         "PSK")
             CIPHERS="$CIPHERS                           \
-                TLS-PSK-WITH-3DES-EDE-CBC-SHA           \
                 TLS-PSK-WITH-AES-128-CBC-SHA            \
                 TLS-PSK-WITH-AES-256-CBC-SHA            \
                 "
@@ -335,7 +330,6 @@ add_openssl_ciphersuites()
         "ECDSA")
             CIPHERS="$CIPHERS                           \
                 TLS-ECDH-ECDSA-WITH-NULL-SHA            \
-                TLS-ECDH-ECDSA-WITH-3DES-EDE-CBC-SHA    \
                 TLS-ECDH-ECDSA-WITH-AES-128-CBC-SHA     \
                 TLS-ECDH-ECDSA-WITH-AES-256-CBC-SHA     \
 
@@ -351,9 +345,6 @@ add_openssl_ciphersuites()
 
         "RSA")
             CIPHERS="$CIPHERS                           \
-                TLS-RSA-WITH-DES-CBC-SHA                \
-                TLS-DHE-RSA-WITH-DES-CBC-SHA            \
-
                 TLS-ECDHE-RSA-WITH-ARIA-256-GCM-SHA384          \
                 TLS-DHE-RSA-WITH-ARIA-256-GCM-SHA384            \
                 TLS-RSA-WITH-ARIA-256-GCM-SHA384                \
@@ -435,14 +426,11 @@ add_gnutls_ciphersuites()
 
         "PSK")
             CIPHERS="$CIPHERS                               \
-                TLS-DHE-PSK-WITH-3DES-EDE-CBC-SHA           \
                 TLS-DHE-PSK-WITH-AES-128-CBC-SHA            \
                 TLS-DHE-PSK-WITH-AES-256-CBC-SHA            \
 
                 TLS-ECDHE-PSK-WITH-AES-256-CBC-SHA          \
                 TLS-ECDHE-PSK-WITH-AES-128-CBC-SHA          \
-                TLS-ECDHE-PSK-WITH-3DES-EDE-CBC-SHA         \
-                TLS-RSA-PSK-WITH-3DES-EDE-CBC-SHA           \
                 TLS-RSA-PSK-WITH-AES-256-CBC-SHA            \
                 TLS-RSA-PSK-WITH-AES-128-CBC-SHA            \
 

--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -73,11 +73,9 @@ TYPES="ECDSA RSA PSK"
 FILTER=""
 # exclude:
 # - NULL: excluded from our default config
-#   avoid plain DES but keep 3DES-EDE-CBC (mbedTLS), DES-CBC3 (OpenSSL)
-# - ARIA: not in default mbedtls_config.h + requires OpenSSL >= 1.1.1
+# - ARIA: requires OpenSSL >= 1.1.1
 # - ChachaPoly: requires OpenSSL >= 1.1.0
-# - 3DES: not in default config
-EXCLUDE='NULL\|DES\|ARIA\|CHACHA20-POLY1305'
+EXCLUDE='NULL\|ARIA\|CHACHA20-POLY1305'
 VERBOSE=""
 MEMCHECK=0
 PEERS="OpenSSL$PEER_GNUTLS mbedTLS"

--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -67,12 +67,15 @@ else
 fi
 
 # default values for options
+# /!\ keep this synchronised with:
+# - basic-build-test.sh
+# - all.sh (multiple components)
 MODES="tls12 dtls12"
 VERIFIES="NO YES"
 TYPES="ECDSA RSA PSK"
 FILTER=""
-# exclude:
-# - NULL: excluded from our default config
+# By default, exclude:
+# - NULL: excluded from our default config + requires OpenSSL legacy
 # - ARIA: requires OpenSSL >= 1.1.1
 # - ChachaPoly: requires OpenSSL >= 1.1.0
 EXCLUDE='NULL\|ARIA\|CHACHA20-POLY1305'

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1226,7 +1226,7 @@ component_test_everest () {
 
     msg "test: Everest ECDH context - compat.sh with some ECDH ciphersuites (ASan build)" # ~ 3 min
     # Exclude some symmetric ciphers that are redundant here to gain time.
-    tests/compat.sh -f ECDH -V NO -e 'ARIA\|CAMELLIA\|CHACHA\|DES'
+    tests/compat.sh -f ECDH -V NO -e 'ARIA\|CAMELLIA\|CHACHA'
 }
 
 component_test_everest_curve25519_only () {
@@ -1314,8 +1314,8 @@ component_test_full_cmake_clang () {
     msg "test: ssl-opt.sh default, ECJPAKE, SSL async (full config)" # ~ 1s
     tests/ssl-opt.sh -f 'Default\|ECJPAKE\|SSL async private'
 
-    msg "test: compat.sh DES, 3DES & NULL (full config)" # ~ 2 min
-    env OPENSSL_CMD="$OPENSSL_LEGACY" GNUTLS_CLI="$GNUTLS_LEGACY_CLI" GNUTLS_SERV="$GNUTLS_LEGACY_SERV" tests/compat.sh -e '^$' -f 'NULL\|DES'
+    msg "test: compat.sh NULL (full config)" # ~ 2 min
+    env OPENSSL_CMD="$OPENSSL_LEGACY" GNUTLS_CLI="$GNUTLS_LEGACY_CLI" GNUTLS_SERV="$GNUTLS_LEGACY_SERV" tests/compat.sh -e '^$' -f 'NULL'
 
     msg "test: compat.sh ARIA + ChachaPoly"
     env OPENSSL_CMD="$OPENSSL_NEXT" tests/compat.sh -e '^$' -f 'ARIA\|CHACHA'
@@ -1607,8 +1607,8 @@ component_test_no_use_psa_crypto_full_cmake_asan() {
     msg "test: compat.sh default (full minus MBEDTLS_USE_PSA_CRYPTO)"
     tests/compat.sh
 
-    msg "test: compat.sh DES & NULL (full minus MBEDTLS_USE_PSA_CRYPTO)"
-    env OPENSSL_CMD="$OPENSSL_LEGACY" GNUTLS_CLI="$GNUTLS_LEGACY_CLI" GNUTLS_SERV="$GNUTLS_LEGACY_SERV" tests/compat.sh -e '3DES\|DES-CBC3' -f 'NULL\|DES'
+    msg "test: compat.sh NULL (full minus MBEDTLS_USE_PSA_CRYPTO)"
+    env OPENSSL_CMD="$OPENSSL_LEGACY" GNUTLS_CLI="$GNUTLS_LEGACY_CLI" GNUTLS_SERV="$GNUTLS_LEGACY_SERV" tests/compat.sh -f 'NULL'
 
     msg "test: compat.sh ARIA + ChachaPoly (full minus MBEDTLS_USE_PSA_CRYPTO)"
     env OPENSSL_CMD="$OPENSSL_NEXT" tests/compat.sh -e '^$' -f 'ARIA\|CHACHA'
@@ -2600,7 +2600,7 @@ component_test_m32_everest () {
 
     msg "test: i386, Everest ECDH context - compat.sh with some ECDH ciphersuites (ASan build)" # ~ 3 min
     # Exclude some symmetric ciphers that are redundant here to gain time.
-    tests/compat.sh -f ECDH -V NO -e 'ARIA\|CAMELLIA\|CHACHA\|DES'
+    tests/compat.sh -f ECDH -V NO -e 'ARIA\|CAMELLIA\|CHACHA'
 }
 support_test_m32_everest () {
     support_test_m32_o0 "$@"

--- a/tests/scripts/basic-build-test.sh
+++ b/tests/scripts/basic-build-test.sh
@@ -124,10 +124,10 @@ echo '################ compat.sh ################'
     sh compat.sh -m 'tls1_2 dtls1_2'
     echo
 
-    echo '#### compat.sh: legacy (null, DES)'
+    echo '#### compat.sh: legacy (null)'
     OPENSSL_CMD="$OPENSSL_LEGACY" \
     GNUTLS_CLI="$GNUTLS_LEGACY_CLI" GNUTLS_SERV="$GNUTLS_LEGACY_SERV" \
-    sh compat.sh -e '^$' -f 'NULL\|DES'
+    sh compat.sh -e '^$' -f 'NULL'
     echo
 
     echo '#### compat.sh: next (ARIA, ChaCha)'

--- a/tests/scripts/basic-build-test.sh
+++ b/tests/scripts/basic-build-test.sh
@@ -121,7 +121,7 @@ echo
 echo '################ compat.sh ################'
 {
     echo '#### compat.sh: Default versions'
-    sh compat.sh -m 'tls1_2 dtls1_2'
+    sh compat.sh
     echo
 
     echo '#### compat.sh: legacy (null)'


### PR DESCRIPTION
## Description
Clean up tests/compat.sh to improve maintainability by:

removing cipher suites we no longer support
remove checks on which cipher suites to use, now that we don't support anything lower than (D)TLS 1.2

Closes #4818

## Status
**READY**

## Requires Backporting
Partial - https://github.com/Mbed-TLS/mbedtls/pull/5737

## Migrations
NO

## Additional comments
This is a redo of #4863 as the branch it was based off evolved quite a bit and made rebasing or merging unecessarily complicated. This PR just cherry-picked the relevant commits.

## Steps to test or reproduce
- with config full: `tests/compat.sh -e '^$' -p mbedtls` no longer skips any test
- with config full: `tests/compat.sh` has the same output (modulo ordering) before and after