### PR TITLE
Investigation for ssl-opt timeouts on the CI

### DIFF
--- a/programs/ssl/ssl_test_lib.c
+++ b/programs/ssl/ssl_test_lib.c
@@ -41,7 +41,8 @@
  *                          This function fills it with a human-readable
  *                          time indication, terminated with a null byte.
  */
-#if defined(__unix__) && defined(MBEDTLS_PLATFORM_C)
+#if defined(__unix__) &&                        \
+    defined(MBEDTLS_PLATFORM_C) && defined(MBEDTLS_HAVE_TIME_DATE)
 #include <sys/time.h>
 #define TIMESTAMP_SIZE 13       /* "sssss.uuuuuu\0" */
 static void fill_timestamp( char *timestamp )

--- a/programs/test/udp_proxy.c
+++ b/programs/test/udp_proxy.c
@@ -509,7 +509,22 @@ typedef struct
 /* Print packet. Outgoing packets come with a reason (forward, dupl, etc.) */
 void print_packet( const packet *p, const char *why )
 {
-#if defined(MBEDTLS_TIMING_C)
+#if defined(__unix__) &&                        \
+    defined(MBEDTLS_PLATFORM_C) && defined(MBEDTLS_HAVE_TIME_DATE)
+    struct timeval tv;
+    struct tm tm;
+    (void) gettimeofday( &tv, NULL );
+    mbedtls_platform_gmtime_r( &tv.tv_sec, &tm );
+    unsigned sec = tm.tm_hour * 24 * 60 + tm.tm_min * 60 + tm.tm_sec;
+    unsigned usec = tv.tv_usec;
+
+    if( why == NULL )
+        mbedtls_printf( "  %05u.%06u dispatch %s %s (%u bytes)\n",
+                sec, usec, p->way, p->type, p->len );
+    else
+        mbedtls_printf( "  %05u.%06u dispatch %s %s (%u bytes): %s\n",
+                sec, usec, p->way, p->type, p->len, why );
+#elif defined(MBEDTLS_TIMING_C)
     if( why == NULL )
         mbedtls_printf( "  %05u dispatch %s %s (%u bytes)\n",
                 ellapsed_time(), p->way, p->type, p->len );

--- a/tests/scripts/ts.pl
+++ b/tests/scripts/ts.pl
@@ -1,0 +1,45 @@
+#!/usr/bin/env perl
+
+use Time::HiRes;
+
+if (@ARGV == 0 || $ARGV[0] eq '--help') {
+    print <<EOF;
+Usage: $0 COMMAND [ARGS...]
+Run a program and prefix timestamps to its output.
+Also print a final timestamped line with the program's exit status, and
+exit with that code (with signals wrapped to 128+signum).
+The program's stderr and stdout are merged into stdout.
+Relay common signals to the program.
+EOF
+      exit;
+}
+
+sub ts {
+    my ($t, $us) = Time::HiRes::gettimeofday();
+    my ($s, $m, $h, @_ignored) = gmtime($t);
+    printf '%05d.%06d %s', $s + $m*60 + $h*24*60, $us, $_[0];
+}
+
+local (*IN, *OUT);
+pipe IN, OUT;
+if (my $pid = fork()) {
+    $SIG{'INT'} = $SIG{'TERM'} = $SIG{'HUP'} = $SIG{'QUIT'} = sub {
+        kill($_[0], $pid);
+    };
+    close OUT;
+    $| = 1;
+    while (<IN>) {
+        ts($_);
+    }
+    wait;
+    ts(join(' ', @ARGV, "==> $?\n"));
+    exit($? & 127 ? 128 + ($? & 127) : $? >> 8);
+} else {
+    open STDOUT, '>&OUT';
+    open STDERR, '>&OUT';
+    close OUT;
+    close IN;
+    exec('stdbuf', '-o0', @ARGV);
+    print STDERR "$!\n";
+    exit 127;
+}

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -865,6 +865,9 @@ run_test() {
         return
     fi
 
+    preserve_these_logs=$PRESERVE_NEXT_LOGS
+    PRESERVE_NEXT_LOGS=$PRESERVE_LOGS
+
     # update DTLS variable
     detect_dtls "$SRV_CMD"
 
@@ -1094,14 +1097,13 @@ run_test() {
 
     # if we're here, everything is ok
     record_outcome "PASS"
-    if [ "$PRESERVE_LOGS" -gt 0 ] || [ "$PRESERVE_NEXT_LOGS" -gt 0 ]; then
+    if [ "$preserve_these_logs" -gt 0 ]; then
         mv $SRV_OUT o-srv-${TESTS}.log
         mv $CLI_OUT o-cli-${TESTS}.log
         if [ -n "$PXY_CMD" ]; then
             mv $PXY_OUT o-pxy-${TESTS}.log
         fi
     fi
-    PRESERVE_NEXT_LOGS=0
 
     rm -f $SRV_OUT $CLI_OUT $PXY_OUT
 }

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -1328,22 +1328,24 @@ SRV_DELAY_SECONDS=0
 
 # fix commands to use this port, force IPv4 while at it
 # +SRV_PORT will be replaced by either $SRV_PORT or $PXY_PORT later
+# Note: Using 'localhost' rather than 127.0.0.1 here is unwise, as on many
+# machines that will resolve to ::1, and we don't want ipv6 here.
 P_SRV="$P_SRV server_addr=127.0.0.1 server_port=$SRV_PORT"
 P_CLI="$P_CLI server_addr=127.0.0.1 server_port=+SRV_PORT"
 P_PXY="$P_PXY server_addr=127.0.0.1 server_port=$SRV_PORT listen_addr=127.0.0.1 listen_port=$PXY_PORT ${SEED:+"seed=$SEED"}"
 O_SRV="$O_SRV -accept $SRV_PORT"
-O_CLI="$O_CLI -connect localhost:+SRV_PORT"
+O_CLI="$O_CLI -connect 127.0.0.1:+SRV_PORT"
 G_SRV="$G_SRV -p $SRV_PORT"
 G_CLI="$G_CLI -p +SRV_PORT"
 
 if [ -n "${OPENSSL_LEGACY:-}" ]; then
     O_LEGACY_SRV="$O_LEGACY_SRV -accept $SRV_PORT -dhparam data_files/dhparams.pem"
-    O_LEGACY_CLI="$O_LEGACY_CLI -connect localhost:+SRV_PORT"
+    O_LEGACY_CLI="$O_LEGACY_CLI -connect 127.0.0.1:+SRV_PORT"
 fi
 
 if [ -n "${OPENSSL_NEXT:-}" ]; then
     O_NEXT_SRV="$O_NEXT_SRV -accept $SRV_PORT"
-    O_NEXT_CLI="$O_NEXT_CLI -connect localhost:+SRV_PORT"
+    O_NEXT_CLI="$O_NEXT_CLI -connect 127.0.0.1:+SRV_PORT"
 fi
 
 if [ -n "${GNUTLS_NEXT_SERV:-}" ]; then

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -2703,6 +2703,7 @@ run_test    "Session resume using tickets, DTLS: openssl server" \
             -c "parse new session ticket" \
             -c "a session has been resumed"
 
+preserve_next_logs
 server_needs_more_time 10
 run_test    "Session resume using tickets, DTLS: openssl client" \
             "$P_SRV dtls=1 debug_level=3 tickets=1" \
@@ -2904,6 +2905,7 @@ run_test    "Session resume using cache, DTLS: session copy" \
             -s "a session has been resumed" \
             -c "a session has been resumed"
 
+preserve_next_logs
 client_needs_more_time 10
 run_test    "Session resume using cache, DTLS: openssl client" \
             "$P_SRV dtls=1 debug_level=3 tickets=0" \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -2695,6 +2695,8 @@ run_test    "Session resume using tickets, DTLS: openssl server" \
             -c "parse new session ticket" \
             -c "a session has been resumed"
 
+client_needs_more_time 10
+server_needs_more_time 10
 run_test    "Session resume using tickets, DTLS: openssl client" \
             "$P_SRV dtls=1 debug_level=3 tickets=1" \
             "( $O_CLI -dtls -sess_out $SESSION; \
@@ -2791,6 +2793,8 @@ run_test    "Session resume using cache: session copy" \
             -s "a session has been resumed" \
             -c "a session has been resumed"
 
+client_needs_more_time 10
+server_needs_more_time 10
 run_test    "Session resume using cache: openssl client" \
             "$P_SRV debug_level=3 tickets=0" \
             "( $O_CLI -sess_out $SESSION; \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -769,7 +769,7 @@ wait_client_done() {
 # check if the given command uses dtls and sets global variable DTLS
 detect_dtls() {
     case "$1" in
-        *dtls=1*|-dtls|-u) DTLS=1;;
+        *dtls=1*|*-dtls*|*-u*) DTLS=1;;
         *) DTLS=0;;
     esac
 }

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -62,8 +62,16 @@ guess_config_name() {
 : ${MBEDTLS_TEST_CONFIGURATION:="$(guess_config_name)"}
 : ${MBEDTLS_TEST_PLATFORM:="$(uname -s | tr -c \\n0-9A-Za-z _)-$(uname -m | tr -c \\n0-9A-Za-z _)"}
 
+openssl_debug_options() {
+    printf '%s' '-debug'
+    case $("$1" s_client -trace 2>&1) in
+        *"unknown option -trace"*) :;;
+        *) printf ' %s' '-trace';;
+    esac
+}
+
 O_SRV="$EXT_CMD_PREFIX$OPENSSL_CMD s_server -www -cert data_files/server5.crt -key data_files/server5.key"
-O_CLI="echo 'GET / HTTP/1.0' | $EXT_CMD_PREFIX$OPENSSL_CMD s_client -debug"
+O_CLI="echo 'GET / HTTP/1.0' | $EXT_CMD_PREFIX$OPENSSL_CMD s_client $(openssl_debug_options "$OPENSSL_CMD")"
 G_SRV="$EXT_CMD_PREFIX$GNUTLS_SERV --x509certfile data_files/server5.crt --x509keyfile data_files/server5.key"
 G_CLI="echo 'GET / HTTP/1.0' | $EXT_CMD_PREFIX$GNUTLS_CLI --x509cafile data_files/test-ca_cat12.crt"
 TCP_CLIENT="$PERL scripts/tcp_client.pl"
@@ -72,7 +80,7 @@ TCP_CLIENT="$PERL scripts/tcp_client.pl"
 
 if [ -n "${OPENSSL_LEGACY:-}" ]; then
     O_LEGACY_SRV="$EXT_CMD_PREFIX$OPENSSL_LEGACY s_server -www -cert data_files/server5.crt -key data_files/server5.key"
-    O_LEGACY_CLI="echo 'GET / HTTP/1.0' | $EXT_CMD_PREFIX$OPENSSL_LEGACY s_client -debug"
+    O_LEGACY_CLI="echo 'GET / HTTP/1.0' | $EXT_CMD_PREFIX$OPENSSL_LEGACY s_client $(openssl_debug_options "$OPENSSL_LEGACY")"
 else
     O_LEGACY_SRV=false
     O_LEGACY_CLI=false
@@ -80,7 +88,7 @@ fi
 
 if [ -n "${OPENSSL_NEXT:-}" ]; then
     O_NEXT_SRV="$EXT_CMD_PREFIX$OPENSSL_NEXT s_server -www -cert data_files/server5.crt -key data_files/server5.key"
-    O_NEXT_CLI="echo 'GET / HTTP/1.0' | $EXT_CMD_PREFIX$OPENSSL_NEXT s_client -debug"
+    O_NEXT_CLI="echo 'GET / HTTP/1.0' | $EXT_CMD_PREFIX$OPENSSL_NEXT s_client $(openssl_debug_options "$OPENSSL_NEXT")"
 else
     O_NEXT_SRV=false
     O_NEXT_CLI=false

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -112,6 +112,7 @@ SHOW_TEST_NUMBER=0
 RUN_TEST_NUMBER=''
 
 PRESERVE_LOGS=0
+PRESERVE_NEXT_LOGS=0
 
 # Pick a "unique" server port in the range 10000-19999, and a proxy
 # port which is this plus 10000. Each port number may be independently
@@ -521,6 +522,12 @@ client_needs_more_time() {
 # wait for the given seconds after the client finished in the next test
 server_needs_more_time() {
     SRV_DELAY_SECONDS=$1
+}
+
+# Always keep the logs of the next test case. Not intended for production.
+# Use this temporarily when debugging a test case on the CI.
+preserve_next_logs() {
+    PRESERVE_NEXT_LOGS=1
 }
 
 # print_name <name>
@@ -1087,13 +1094,14 @@ run_test() {
 
     # if we're here, everything is ok
     record_outcome "PASS"
-    if [ "$PRESERVE_LOGS" -gt 0 ]; then
+    if [ "$PRESERVE_LOGS" -gt 0 ] || [ "$PRESERVE_NEXT_LOGS" -gt 0 ]; then
         mv $SRV_OUT o-srv-${TESTS}.log
         mv $CLI_OUT o-cli-${TESTS}.log
         if [ -n "$PXY_CMD" ]; then
             mv $PXY_OUT o-pxy-${TESTS}.log
         fi
     fi
+    PRESERVE_NEXT_LOGS=0
 
     rm -f $SRV_OUT $CLI_OUT $PXY_OUT
 }

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -2705,8 +2705,39 @@ run_test    "Session resume using tickets, DTLS: openssl server" \
 
 preserve_next_logs
 server_needs_more_time 10
+client_needs_more_time 10
 run_test    "Session resume using tickets, DTLS: openssl client" \
             "$P_SRV dtls=1 debug_level=3 tickets=1" \
+            "( $O_CLI -dtls -sess_out $SESSION; \
+               $O_CLI -dtls -sess_in $SESSION; \
+               rm -f $SESSION )" \
+            0 \
+            -s "found session ticket extension" \
+            -s "server hello, adding session ticket extension" \
+            -S "session successfully restored from cache" \
+            -s "session successfully restored from ticket" \
+            -s "a session has been resumed"
+
+preserve_next_logs
+server_needs_more_time 10
+client_needs_more_time 10
+run_test    "Session resume using tickets, DTLS: openssl client (dgram_packing=0)" \
+            "$P_SRV dtls=1 dgram_packing=0 debug_level=3 tickets=1" \
+            "( $O_CLI -dtls -sess_out $SESSION; \
+               $O_CLI -dtls -sess_in $SESSION; \
+               rm -f $SESSION )" \
+            0 \
+            -s "found session ticket extension" \
+            -s "server hello, adding session ticket extension" \
+            -S "session successfully restored from cache" \
+            -s "session successfully restored from ticket" \
+            -s "a session has been resumed"
+
+preserve_next_logs
+server_needs_more_time 10
+client_needs_more_time 10
+run_test    "Session resume using tickets, DTLS: openssl client (cookies=0)" \
+            "$P_SRV dtls=1 cookies=0 debug_level=3 tickets=1" \
             "( $O_CLI -dtls -sess_out $SESSION; \
                $O_CLI -dtls -sess_in $SESSION; \
                rm -f $SESSION )" \
@@ -2906,9 +2937,40 @@ run_test    "Session resume using cache, DTLS: session copy" \
             -c "a session has been resumed"
 
 preserve_next_logs
+server_needs_more_time 10
 client_needs_more_time 10
 run_test    "Session resume using cache, DTLS: openssl client" \
             "$P_SRV dtls=1 debug_level=3 tickets=0" \
+            "( $O_CLI -dtls -sess_out $SESSION; \
+               $O_CLI -dtls -sess_in $SESSION; \
+               rm -f $SESSION )" \
+            0 \
+            -s "found session ticket extension" \
+            -S "server hello, adding session ticket extension" \
+            -s "session successfully restored from cache" \
+            -S "session successfully restored from ticket" \
+            -s "a session has been resumed"
+
+preserve_next_logs
+server_needs_more_time 10
+client_needs_more_time 10
+run_test    "Session resume using cache, DTLS: openssl client (dgram_packing=0)" \
+            "$P_SRV dtls=1 dgram_packing=0 debug_level=3 tickets=0" \
+            "( $O_CLI -dtls -sess_out $SESSION; \
+               $O_CLI -dtls -sess_in $SESSION; \
+               rm -f $SESSION )" \
+            0 \
+            -s "found session ticket extension" \
+            -S "server hello, adding session ticket extension" \
+            -s "session successfully restored from cache" \
+            -S "session successfully restored from ticket" \
+            -s "a session has been resumed"
+
+preserve_next_logs
+server_needs_more_time 10
+client_needs_more_time 10
+run_test    "Session resume using cache, DTLS: openssl client (cookies=0)" \
+            "$P_SRV dtls=1 cookies=0 debug_level=3 tickets=0" \
             "( $O_CLI -dtls -sess_out $SESSION; \
                $O_CLI -dtls -sess_in $SESSION; \
                rm -f $SESSION )" \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -63,7 +63,7 @@ guess_config_name() {
 : ${MBEDTLS_TEST_PLATFORM:="$(uname -s | tr -c \\n0-9A-Za-z _)-$(uname -m | tr -c \\n0-9A-Za-z _)"}
 
 O_SRV="$EXT_CMD_PREFIX$OPENSSL_CMD s_server -www -cert data_files/server5.crt -key data_files/server5.key"
-O_CLI="echo 'GET / HTTP/1.0' | $EXT_CMD_PREFIX$OPENSSL_CMD s_client"
+O_CLI="echo 'GET / HTTP/1.0' | $EXT_CMD_PREFIX$OPENSSL_CMD s_client -debug"
 G_SRV="$EXT_CMD_PREFIX$GNUTLS_SERV --x509certfile data_files/server5.crt --x509keyfile data_files/server5.key"
 G_CLI="echo 'GET / HTTP/1.0' | $EXT_CMD_PREFIX$GNUTLS_CLI --x509cafile data_files/test-ca_cat12.crt"
 TCP_CLIENT="$PERL scripts/tcp_client.pl"
@@ -72,7 +72,7 @@ TCP_CLIENT="$PERL scripts/tcp_client.pl"
 
 if [ -n "${OPENSSL_LEGACY:-}" ]; then
     O_LEGACY_SRV="$EXT_CMD_PREFIX$OPENSSL_LEGACY s_server -www -cert data_files/server5.crt -key data_files/server5.key"
-    O_LEGACY_CLI="echo 'GET / HTTP/1.0' | $EXT_CMD_PREFIX$OPENSSL_LEGACY s_client"
+    O_LEGACY_CLI="echo 'GET / HTTP/1.0' | $EXT_CMD_PREFIX$OPENSSL_LEGACY s_client -debug"
 else
     O_LEGACY_SRV=false
     O_LEGACY_CLI=false
@@ -80,7 +80,7 @@ fi
 
 if [ -n "${OPENSSL_NEXT:-}" ]; then
     O_NEXT_SRV="$EXT_CMD_PREFIX$OPENSSL_NEXT s_server -www -cert data_files/server5.crt -key data_files/server5.key"
-    O_NEXT_CLI="echo 'GET / HTTP/1.0' | $EXT_CMD_PREFIX$OPENSSL_NEXT s_client"
+    O_NEXT_CLI="echo 'GET / HTTP/1.0' | $EXT_CMD_PREFIX$OPENSSL_NEXT s_client -debug"
 else
     O_NEXT_SRV=false
     O_NEXT_CLI=false

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -120,7 +120,6 @@ SHOW_TEST_NUMBER=0
 RUN_TEST_NUMBER=''
 
 PRESERVE_LOGS=0
-PRESERVE_NEXT_LOGS=0
 
 # Pick a "unique" server port in the range 10000-19999, and a proxy
 # port which is this plus 10000. Each port number may be independently
@@ -186,6 +185,7 @@ get_options() {
         esac
         shift
     done
+    PRESERVE_NEXT_LOGS=$PRESERVE_LOGS
 }
 
 # Make the outcome file path relative to the original directory, not

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -49,6 +49,7 @@ fi
 : ${GNUTLS_CLI:=gnutls-cli}
 : ${GNUTLS_SERV:=gnutls-serv}
 : ${PERL:=perl}
+: ${EXT_CMD_PREFIX:='../tests/scripts/ts.pl '}
 
 guess_config_name() {
     if git diff --quiet ../include/mbedtls/mbedtls_config.h 2>/dev/null; then
@@ -61,38 +62,38 @@ guess_config_name() {
 : ${MBEDTLS_TEST_CONFIGURATION:="$(guess_config_name)"}
 : ${MBEDTLS_TEST_PLATFORM:="$(uname -s | tr -c \\n0-9A-Za-z _)-$(uname -m | tr -c \\n0-9A-Za-z _)"}
 
-O_SRV="$OPENSSL_CMD s_server -www -cert data_files/server5.crt -key data_files/server5.key"
-O_CLI="echo 'GET / HTTP/1.0' | $OPENSSL_CMD s_client"
-G_SRV="$GNUTLS_SERV --x509certfile data_files/server5.crt --x509keyfile data_files/server5.key"
-G_CLI="echo 'GET / HTTP/1.0' | $GNUTLS_CLI --x509cafile data_files/test-ca_cat12.crt"
+O_SRV="$EXT_CMD_PREFIX$OPENSSL_CMD s_server -www -cert data_files/server5.crt -key data_files/server5.key"
+O_CLI="echo 'GET / HTTP/1.0' | $EXT_CMD_PREFIX$OPENSSL_CMD s_client"
+G_SRV="$EXT_CMD_PREFIX$GNUTLS_SERV --x509certfile data_files/server5.crt --x509keyfile data_files/server5.key"
+G_CLI="echo 'GET / HTTP/1.0' | $EXT_CMD_PREFIX$GNUTLS_CLI --x509cafile data_files/test-ca_cat12.crt"
 TCP_CLIENT="$PERL scripts/tcp_client.pl"
 
 # alternative versions of OpenSSL and GnuTLS (no default path)
 
 if [ -n "${OPENSSL_LEGACY:-}" ]; then
-    O_LEGACY_SRV="$OPENSSL_LEGACY s_server -www -cert data_files/server5.crt -key data_files/server5.key"
-    O_LEGACY_CLI="echo 'GET / HTTP/1.0' | $OPENSSL_LEGACY s_client"
+    O_LEGACY_SRV="$EXT_CMD_PREFIX$OPENSSL_LEGACY s_server -www -cert data_files/server5.crt -key data_files/server5.key"
+    O_LEGACY_CLI="echo 'GET / HTTP/1.0' | $EXT_CMD_PREFIX$OPENSSL_LEGACY s_client"
 else
     O_LEGACY_SRV=false
     O_LEGACY_CLI=false
 fi
 
 if [ -n "${OPENSSL_NEXT:-}" ]; then
-    O_NEXT_SRV="$OPENSSL_NEXT s_server -www -cert data_files/server5.crt -key data_files/server5.key"
-    O_NEXT_CLI="echo 'GET / HTTP/1.0' | $OPENSSL_NEXT s_client"
+    O_NEXT_SRV="$EXT_CMD_PREFIX$OPENSSL_NEXT s_server -www -cert data_files/server5.crt -key data_files/server5.key"
+    O_NEXT_CLI="echo 'GET / HTTP/1.0' | $EXT_CMD_PREFIX$OPENSSL_NEXT s_client"
 else
     O_NEXT_SRV=false
     O_NEXT_CLI=false
 fi
 
 if [ -n "${GNUTLS_NEXT_SERV:-}" ]; then
-    G_NEXT_SRV="$GNUTLS_NEXT_SERV --x509certfile data_files/server5.crt --x509keyfile data_files/server5.key"
+    G_NEXT_SRV="$EXT_CMD_PREFIX$GNUTLS_NEXT_SERV --x509certfile data_files/server5.crt --x509keyfile data_files/server5.key"
 else
     G_NEXT_SRV=false
 fi
 
 if [ -n "${GNUTLS_NEXT_CLI:-}" ]; then
-    G_NEXT_CLI="echo 'GET / HTTP/1.0' | $GNUTLS_NEXT_CLI --x509cafile data_files/test-ca_cat12.crt"
+    G_NEXT_CLI="echo 'GET / HTTP/1.0' | $EXT_CMD_PREFIX$GNUTLS_NEXT_CLI --x509cafile data_files/test-ca_cat12.crt"
 else
     G_NEXT_CLI=false
 fi
@@ -633,7 +634,7 @@ if type lsof >/dev/null 2>/dev/null; then
             proto=TCP
         fi
         # Make a tight loop, server normally takes less than 1s to start.
-        while ! lsof -a -n -b -i "$proto:$1" -p "$2" >/dev/null 2>/dev/null; do
+        while ! lsof -a -n -b -i "$proto:$1" >/dev/null 2>/dev/null; do
               if [ $(( $(date +%s) - $START_TIME )) -gt $DOG_DELAY ]; then
                   echo "$3 START TIMEOUT"
                   echo "$3 START TIMEOUT" >> $4

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -2695,7 +2695,6 @@ run_test    "Session resume using tickets, DTLS: openssl server" \
             -c "parse new session ticket" \
             -c "a session has been resumed"
 
-client_needs_more_time 10
 server_needs_more_time 10
 run_test    "Session resume using tickets, DTLS: openssl client" \
             "$P_SRV dtls=1 debug_level=3 tickets=1" \
@@ -2793,8 +2792,6 @@ run_test    "Session resume using cache: session copy" \
             -s "a session has been resumed" \
             -c "a session has been resumed"
 
-client_needs_more_time 10
-server_needs_more_time 10
 run_test    "Session resume using cache: openssl client" \
             "$P_SRV debug_level=3 tickets=0" \
             "( $O_CLI -sess_out $SESSION; \
@@ -2899,6 +2896,7 @@ run_test    "Session resume using cache, DTLS: session copy" \
             -s "a session has been resumed" \
             -c "a session has been resumed"
 
+client_needs_more_time 10
 run_test    "Session resume using cache, DTLS: openssl client" \
             "$P_SRV dtls=1 debug_level=3 tickets=0" \
             "( $O_CLI -dtls -sess_out $SESSION; \


### PR DESCRIPTION
Investigation for https://github.com/ARMmbed/mbedtls/issues/5012. Takes some parts from https://github.com/ARMmbed/mbedtls/pull/5057 and https://github.com/ARMmbed/mbedtls/pull/5066.

* Add microsecond timestamps on ssl_client2, ssl_server2 and udp_proxy logs.
* Try giving the client and server more time (doesn't appear to help).
* Add variants of the failing tests.
* Keep logs in successful cases as well.
* Fix DTLS detection leading to not using the proxy when intended and to some "SERVER START TIMEOUT".
* Add a lot of logging to openssl runs.

CI jobs with `openssl s_client -trace`:
* 36dac553819c44548336d1b4f48fb804bfdf0d53 → https://jenkins-mbedtls.oss.arm.com/job/mbedtls-release-ci-testing/307/
* 85a7b7cb167e7d0034ad692032aa976054664912 → https://jenkins-mbedtls.oss.arm.com/job/mbedtls-release-ci-testing/308/
