### PR TITLE
Protect operations on keys with mutexes if MBEDTLS_THREADING_C is enabled

### DIFF
--- a/ChangeLog.d/psa-key-slot-mutexes.txt
+++ b/ChangeLog.d/psa-key-slot-mutexes.txt
@@ -1,0 +1,4 @@
+Changes
+   * Introduce key slot mutexes and a global key slot data mutex when using
+   MBEDTLS_THREADING_C. For additional requirements regarding mutex locking
+   order, please see psa_key_slot_t in psa_crypto_core.h.

--- a/include/mbedtls/threading.h
+++ b/include/mbedtls/threading.h
@@ -98,7 +98,9 @@ extern int (*mbedtls_mutex_unlock)( mbedtls_threading_mutex_t *mutex );
 #if defined(MBEDTLS_FS_IO)
 extern mbedtls_threading_mutex_t mbedtls_threading_readdir_mutex;
 #endif
-
+#if defined(MBEDTLS_PSA_CRYPTO_C)
+extern mbedtls_threading_mutex_t mbedtls_psa_slots_mutex;
+#endif
 #if defined(MBEDTLS_HAVE_TIME_DATE) && !defined(MBEDTLS_PLATFORM_GMTIME_R_ALT)
 /* This mutex may or may not be used in the default definition of
  * mbedtls_platform_gmtime_r(), but in order to determine that,

--- a/library/psa_crypto_core.h
+++ b/library/psa_crypto_core.h
@@ -83,18 +83,6 @@ typedef struct
     size_t lock_count;
 #if defined(MBEDTLS_THREADING_C)
     /* This mutex guards the access to key slot data.
-     * Please note that the global slots mutex, mbedtls_psa_slots_mutex,
-     * should not be locked after a key slot lock is locked, as it might
-     * lead to deadlocks:
-     * the call patterns used by the psa code involve locking
-     * mbedtls_psa_slots_mutex before (if at all) locking a particular
-     * slot mutex.
-     * The slot mutexes are used as follows:
-     *     - Initialized in psa_initialize_key_slots.
-     *     - Locked in psa_lock_key_slot( ) and before each call
-     *       to psa_wipe_key_slot( ).
-     *     - Unlocked in psa_unlock_key_slot( ) and in psa_wipe_key_slot( ).
-     *     - Freed in psa_wipe_all_key_slots.
      */
     mbedtls_threading_mutex_t mutex;
 #endif

--- a/library/psa_crypto_core.h
+++ b/library/psa_crypto_core.h
@@ -116,6 +116,8 @@ typedef struct
  *
  * A key slot is occupied iff the key type is nonzero. This works because
  * no valid key can have 0 as its key type.
+ * Please note that, when using MBEDTLS_THREADING_C, the key slot mutex
+ * should be locked to perform this operation.
  *
  * \param[in] slot      The key slot to test.
  *
@@ -129,6 +131,8 @@ static inline int psa_is_key_slot_occupied( const psa_key_slot_t *slot )
 /** Test whether a key slot is locked.
  *
  * A key slot is locked iff its lock counter is strictly greater than 0.
+ * Please note that, when using MBEDTLS_THREADING_C, the key slot mutex
+ * should be locked to perform this operation.
  *
  * \param[in] slot  The key slot to test.
  *
@@ -140,6 +144,9 @@ static inline int psa_is_key_slot_locked( const psa_key_slot_t *slot )
 }
 
 /** Retrieve flags from psa_key_slot_t::attr::core::flags.
+ *
+ * Please note that, when using MBEDTLS_THREADING_C, the key slot mutex
+ * should be locked to perform this operation.
  *
  * \param[in] slot      The key slot to query.
  * \param mask          The mask of bits to extract.
@@ -155,6 +162,9 @@ static inline uint16_t psa_key_slot_get_flags( const psa_key_slot_t *slot,
 
 /** Set flags in psa_key_slot_t::attr::core::flags.
  *
+ * Please note that, when using MBEDTLS_THREADING_C, the key slot mutex
+ * should be locked to perform this operation.
+ *
  * \param[in,out] slot  The key slot to modify.
  * \param mask          The mask of bits to modify.
  * \param value         The new value of the selected bits.
@@ -169,6 +179,8 @@ static inline void psa_key_slot_set_flags( psa_key_slot_t *slot,
 
 /** Turn on flags in psa_key_slot_t::attr::core::flags.
  *
+ * Please note that, when using MBEDTLS_THREADING_C, the key slot mutex
+ * should be locked to perform this operation.
  * \param[in,out] slot  The key slot to modify.
  * \param mask          The mask of bits to set.
  */
@@ -179,6 +191,9 @@ static inline void psa_key_slot_set_bits_in_flags( psa_key_slot_t *slot,
 }
 
 /** Turn off flags in psa_key_slot_t::attr::core::flags.
+ *
+ * Please note that, when using MBEDTLS_THREADING_C, the key slot mutex
+ * should be locked to perform this operation.
  *
  * \param[in,out] slot  The key slot to modify.
  * \param mask          The mask of bits to clear.

--- a/library/threading.c
+++ b/library/threading.c
@@ -152,6 +152,9 @@ void mbedtls_threading_set_alt( void (*mutex_init)( mbedtls_threading_mutex_t * 
 #if defined(MBEDTLS_FS_IO)
     mbedtls_mutex_init( &mbedtls_threading_readdir_mutex );
 #endif
+#if defined(MBEDTLS_PSA_CRYPTO_C)
+    mbedtls_mutex_init( &mbedtls_psa_slots_mutex );
+#endif
 #if defined(THREADING_USE_GMTIME)
     mbedtls_mutex_init( &mbedtls_threading_gmtime_mutex );
 #endif
@@ -164,6 +167,9 @@ void mbedtls_threading_free_alt( void )
 {
 #if defined(MBEDTLS_FS_IO)
     mbedtls_mutex_free( &mbedtls_threading_readdir_mutex );
+#endif
+#if defined(MBEDTLS_PSA_CRYPTO_C)
+    mbedtls_mutex_free( &mbedtls_psa_slots_mutex );
 #endif
 #if defined(THREADING_USE_GMTIME)
     mbedtls_mutex_free( &mbedtls_threading_gmtime_mutex );
@@ -179,6 +185,16 @@ void mbedtls_threading_free_alt( void )
 #endif
 #if defined(MBEDTLS_FS_IO)
 mbedtls_threading_mutex_t mbedtls_threading_readdir_mutex MUTEX_INIT;
+#endif
+#if defined(MBEDTLS_PSA_CRYPTO_C)
+/*
+ * psa_crypto_slot_management.c global data mutex.
+ * this mutex  should not be locked after a key slot lock is locked, as it
+ * might lead to deadlocks:
+ * the call patterns used by the psa code involve locking
+ * mbedtls_psa_slots_mutex before (if at all) locking a particular slot mutex.
+ */
+mbedtls_threading_mutex_t mbedtls_psa_slots_mutex MUTEX_INIT;
 #endif
 #if defined(THREADING_USE_GMTIME)
 mbedtls_threading_mutex_t mbedtls_threading_gmtime_mutex MUTEX_INIT;

--- a/library/threading.c
+++ b/library/threading.c
@@ -189,10 +189,6 @@ mbedtls_threading_mutex_t mbedtls_threading_readdir_mutex MUTEX_INIT;
 #if defined(MBEDTLS_PSA_CRYPTO_C)
 /*
  * psa_crypto_slot_management.c global data mutex.
- * this mutex  should not be locked after a key slot lock is locked, as it
- * might lead to deadlocks:
- * the call patterns used by the psa code involve locking
- * mbedtls_psa_slots_mutex before (if at all) locking a particular slot mutex.
  */
 mbedtls_threading_mutex_t mbedtls_psa_slots_mutex MUTEX_INIT;
 #endif


### PR DESCRIPTION
This PR introduces a global data mutex, as well as a mutex per each key slot.
Currently the global mutex aims to protect the global "key_slots_initialized" variable, and only it; 
The main weight of the job is on the key slot mutexes, as this simplifies many situations.
These mutexes should be changed to a readers-writer lock, to enable multiple threads reading from a slot mutex;
There are two things that are currently unhandled in this PR:

- get_and_lock_key_slot_in_memory, get_empty_key_slot, psa_wipe_all_key_slots, and mbedtls_psa_get_stats iterate through key slots and read from them. This means that, before reading from a given slot, they lock the respective key mutex. The problem is that if a given thread locks a key mutex (after, for example, starting key creation) and then the same thread calls any of the functions mentioned above - a double lock will happen. 
- psa_copy_key problem: it locks one key slot, and then calls `psa_start_key_creation()`, which in turn iterates over the key array. Since it's reading key attributes - if it hits the first, locked slot, a double lock will occur. A simple implementation of a RW-lock will not prevent this, so we might need more abstraction (tracking threads vs mutexes locked), or a different solution. Please note that when locking a non-volatile key via `psa_get_and_lock_key_slot_with_policy()`, the code also iterates over the key slots, so simply changing the order of functions (`psa_start_key_creation` and `psa_get_and_lock_key_slot_with_policy`) won't work. Current state of the PR contains a hotfix that has implemented such temporary hack, but one test still fails because of this reason: `Non reusable key slots integrity in case of key slot starvation`.
- Reading any slot data (or attributes) requires a slot lock to be locked. Thus, psa_is_key_slot_locked is obsolete with current design and assumption of a simple (not readers-writer) mutex:
    - The key slot might be either locked, so the caller has to wait for a mutex before calling psa_is_key_slot_locked. When the mutex is unlocked, the caller is free to lock it and find out that the key slot is not locked.
    - The key slot is not locked, so the caller locks the slot mutex and finds out that the key slot is not locked.
Please note that with a readers-writer lock this will no longer be a problem. It's only used by mbedtls_psa_get_stats() this way though.

Other considerations:
- Slot states, as suggested here: https://github.com/AndrzejKurek/mbedtls/blob/psa-thread_safety-doc/docs/architecture/psa-thread-safety.md - I'm not sure what the advantage of having certain slot states would be. If we decide to use a readers-writer lock, the implemented priority of locking will take care of acting as the state the slot is in. 
- Global vs local lock responsibilities
psa_get_empty_key_slot iterates over key slots and reads their attributes - it should lock respective slot mutexes before doing so. If not, and we consider the global mutex to be enough - there might be problems with other functions like psa_import_key: it calls psa_start_key_creation, so only the local lock is locked after that, and then psa_driver_wrapper_import_key which is slot agnostic. There's no way to lock the global lock for the entirety of the function, unless we add abstraction that will prevent double locking.
- Multipart operations and key destruction
After the introduction of key UID's this should not be a problem: at the beginning of each multipart operation the key slot mutex is locked and its UID is checked against the one stored in the operation object. If there's a mismatch, the operation is aborted.

- It was mentioned, for a global lock approach, that:
>Have a single mutex protecting all accesses to the key store and other global variables. In practice, this means every PSA API function needs to take the lock on entry and release on exit, except for:
> - Hash function.
> - Accessors for key attributes and other local structures.

I'm not sure why accessors for key attributes and hash functions would not require a mutex to be locked, unless we're talking about low level functions that already act under a mutex locked, and operating on local variables that were copied from a slot under a mutex.

Major todo:
- Change the simple mutex to a readers-writer lock.

Minor todos:
- Renaming key lock counter to "open" counter;
- Unify `psa_get_and_lock_key_slot_with_policy` usage - some calls to it do not unlock the key slot after a failure is returned, and some do. It would be best to add tests that exercise the failing calls.
