### PR TITLE
DO NOT MERGE - Global readers-writer lock for key slot data protection

### DIFF
--- a/include/mbedtls/threading.h
+++ b/include/mbedtls/threading.h
@@ -46,6 +46,15 @@ typedef struct mbedtls_threading_mutex_t
      * API of Mbed TLS and may change without notice. */
     char MBEDTLS_PRIVATE(is_valid);
 } mbedtls_threading_mutex_t;
+
+typedef struct mbedtls_threading_rwlock_t
+{
+    uint16_t num_readers;
+    mbedtls_threading_mutex_t readers_mutex;
+    mbedtls_threading_mutex_t writer_mutex;
+    char MBEDTLS_PRIVATE(is_valid);
+} mbedtls_threading_rwlock_t;
+
 #endif
 
 #if defined(MBEDTLS_THREADING_ALT)
@@ -92,11 +101,22 @@ extern void (*mbedtls_mutex_free)( mbedtls_threading_mutex_t *mutex );
 extern int (*mbedtls_mutex_lock)( mbedtls_threading_mutex_t *mutex );
 extern int (*mbedtls_mutex_unlock)( mbedtls_threading_mutex_t *mutex );
 
+void mbedtls_rwlock_init( mbedtls_threading_rwlock_t *lock );
+void mbedtls_rwlock_free( mbedtls_threading_rwlock_t *lock );
+int mbedtls_rwlock_lock_reader( mbedtls_threading_rwlock_t *lock );
+int mbedtls_rwlock_lock_writer( mbedtls_threading_rwlock_t *lock );
+int mbedtls_rwlock_unlock_reader( mbedtls_threading_rwlock_t *lock );
+int mbedtls_rwlock_unlock_writer( mbedtls_threading_rwlock_t *lock );
+
 /*
  * Global mutexes
  */
 #if defined(MBEDTLS_FS_IO)
 extern mbedtls_threading_mutex_t mbedtls_threading_readdir_mutex;
+#endif
+
+#if defined(MBEDTLS_PSA_CRYPTO_C)
+extern mbedtls_threading_rwlock_t mbedtls_psa_slots_lock;
 #endif
 
 #if defined(MBEDTLS_HAVE_TIME_DATE) && !defined(MBEDTLS_PLATFORM_GMTIME_R_ALT)

--- a/library/psa_crypto_slot_management.c
+++ b/library/psa_crypto_slot_management.c
@@ -34,6 +34,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include "mbedtls/threading.h"
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"
 #else
@@ -148,17 +149,27 @@ static psa_status_t psa_get_and_lock_key_slot_in_memory(
 
 psa_status_t psa_initialize_key_slots( void )
 {
+#if defined(MBEDTLS_THREADING_C)
+    if( mbedtls_rwlock_lock_writer( &mbedtls_psa_slots_lock ) != 0 )
+        return( PSA_ERROR_BAD_STATE );
+#endif
     /* Nothing to do: program startup and psa_wipe_all_key_slots() both
      * guarantee that the key slots are initialized to all-zero, which
      * means that all the key slots are in a valid, empty state. */
     global_data.key_slots_initialized = 1;
+#if defined(MBEDTLS_THREADING_C)
+    if( mbedtls_rwlock_unlock_writer( &mbedtls_psa_slots_lock ) != 0 )
+        return( PSA_ERROR_BAD_STATE );
+#endif
     return( PSA_SUCCESS );
 }
 
 void psa_wipe_all_key_slots( void )
 {
     size_t slot_idx;
-
+#if defined(MBEDTLS_THREADING_C)
+    (void) mbedtls_rwlock_lock_writer( &mbedtls_psa_slots_lock );
+#endif
     for( slot_idx = 0; slot_idx < MBEDTLS_PSA_KEY_SLOT_COUNT; slot_idx++ )
     {
         psa_key_slot_t *slot = &global_data.key_slots[ slot_idx ];
@@ -166,6 +177,9 @@ void psa_wipe_all_key_slots( void )
         (void) psa_wipe_key_slot( slot );
     }
     global_data.key_slots_initialized = 0;
+#if defined(MBEDTLS_THREADING_C)
+    (void) mbedtls_rwlock_unlock_writer( &mbedtls_psa_slots_lock );
+#endif
 }
 
 psa_status_t psa_get_empty_key_slot( psa_key_id_t *volatile_key_id,
@@ -484,20 +498,32 @@ psa_status_t psa_open_key( mbedtls_svc_key_id_t key, psa_key_handle_t *handle )
     psa_status_t status;
     psa_key_slot_t *slot;
 
+#if defined(MBEDTLS_THREADING_C)
+    if( mbedtls_rwlock_lock_reader( &mbedtls_psa_slots_lock ) != 0 )
+        return( PSA_ERROR_BAD_STATE );
+#endif
+
     status = psa_get_and_lock_key_slot( key, &slot );
     if( status != PSA_SUCCESS )
     {
         *handle = PSA_KEY_HANDLE_INIT;
         if( status == PSA_ERROR_INVALID_HANDLE )
             status = PSA_ERROR_DOES_NOT_EXIST;
-
+#if defined(MBEDTLS_THREADING_C)
+        if( mbedtls_rwlock_unlock_reader( &mbedtls_psa_slots_lock ) != 0 )
+            return( PSA_ERROR_BAD_STATE );
+#endif
         return( status );
     }
 
     *handle = key;
 
-    return( psa_unlock_key_slot( slot ) );
-
+    status = psa_unlock_key_slot( slot );
+#if defined(MBEDTLS_THREADING_C)
+    if( mbedtls_rwlock_unlock_reader( &mbedtls_psa_slots_lock ) != 0 )
+        return( PSA_ERROR_BAD_STATE );
+#endif
+    return( status );
 #else /* MBEDTLS_PSA_CRYPTO_STORAGE_C || MBEDTLS_PSA_CRYPTO_BUILTIN_KEYS */
     (void) key;
     *handle = PSA_KEY_HANDLE_INIT;
@@ -513,18 +539,34 @@ psa_status_t psa_close_key( psa_key_handle_t handle )
     if( psa_key_handle_is_null( handle ) )
         return( PSA_SUCCESS );
 
+#if defined(MBEDTLS_THREADING_C)
+    if( mbedtls_rwlock_lock_writer( &mbedtls_psa_slots_lock ) != 0 )
+        return( PSA_ERROR_BAD_STATE );
+#endif
+
     status = psa_get_and_lock_key_slot_in_memory( handle, &slot );
     if( status != PSA_SUCCESS )
     {
         if( status == PSA_ERROR_DOES_NOT_EXIST )
             status = PSA_ERROR_INVALID_HANDLE;
 
+#if defined(MBEDTLS_THREADING_C)
+        if( mbedtls_rwlock_unlock_writer( &mbedtls_psa_slots_lock ) != 0 )
+            return( PSA_ERROR_BAD_STATE );
+#endif
+
         return( status );
     }
     if( slot->lock_count <= 1 )
-        return( psa_wipe_key_slot( slot ) );
+        status = psa_wipe_key_slot( slot );
     else
-        return( psa_unlock_key_slot( slot ) );
+        status = psa_unlock_key_slot( slot );
+
+#if defined(MBEDTLS_THREADING_C)
+    if( mbedtls_rwlock_unlock_writer( &mbedtls_psa_slots_lock ) != 0 )
+        return( PSA_ERROR_BAD_STATE );
+#endif
+    return( status );
 }
 
 psa_status_t psa_purge_key( mbedtls_svc_key_id_t key )
@@ -532,15 +574,32 @@ psa_status_t psa_purge_key( mbedtls_svc_key_id_t key )
     psa_status_t status;
     psa_key_slot_t *slot;
 
+#if defined(MBEDTLS_THREADING_C)
+    if( mbedtls_rwlock_lock_writer( &mbedtls_psa_slots_lock ) != 0 )
+        return( PSA_ERROR_BAD_STATE );
+#endif
+
     status = psa_get_and_lock_key_slot_in_memory( key, &slot );
     if( status != PSA_SUCCESS )
+    {
+#if defined(MBEDTLS_THREADING_C)
+        if( mbedtls_rwlock_unlock_writer( &mbedtls_psa_slots_lock ) != 0 )
+            return( PSA_ERROR_BAD_STATE );
+#endif
         return( status );
+    }
 
     if( ( ! PSA_KEY_LIFETIME_IS_VOLATILE( slot->attr.lifetime ) ) &&
         ( slot->lock_count <= 1 ) )
-        return( psa_wipe_key_slot( slot ) );
+        status = psa_wipe_key_slot( slot );
     else
-        return( psa_unlock_key_slot( slot ) );
+        status = psa_unlock_key_slot( slot );
+
+#if defined(MBEDTLS_THREADING_C)
+    if( mbedtls_rwlock_unlock_writer( &mbedtls_psa_slots_lock ) != 0 )
+        return( PSA_ERROR_BAD_STATE );
+#endif
+    return( status );
 }
 
 void mbedtls_psa_get_stats( mbedtls_psa_stats_t *stats )


### PR DESCRIPTION
This PR presents a step further from https://github.com/ARMmbed/mbedtls/pull/5190, introducing a readers-writer lock in place of a simple mutex. 
Please note that there will be expected failures, for example with full config, test_suite_psa_crypto_se_hal - Import-sign-verify: sign in driver, ECDSA:

- psa_sign_internal locks the key slot (so the rw-lock is readers-locked before that), then the test implementation of psa_driver_wrapper_sign_hash calls psa_import_key which also tries to lock the mutex, but as a writer. Double lock ensues.
- Same case for psa_verify_internal, psa_export_public_key.

Minor todo:
- Unify psa_get_and_lock_key_slot_with_policy usage - some calls to it do not unlock the key slot after a failure is returned, and some do. It would be best to add tests that exercise the failing calls.