### PR TITLE
Add option for user psa crypto config file

### DIFF
--- a/include/mbedtls/config_psa.h
+++ b/include/mbedtls/config_psa.h
@@ -31,7 +31,11 @@
 #define MBEDTLS_CONFIG_PSA_H
 
 #if defined(MBEDTLS_PSA_CRYPTO_CONFIG)
+#if !defined(MBEDTLS_PSA_CRYPTO_CONFIG_FILE)
 #include "psa/crypto_config.h"
+#else
+#include MBEDTLS_PSA_CRYPTO_CONFIG_FILE
+#endif
 #endif /* defined(MBEDTLS_PSA_CRYPTO_CONFIG) */
 
 #ifdef __cplusplus

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -2485,6 +2485,18 @@ component_build_mbedtls_config_file () {
     rm -f full_config.h
 }
 
+component_build_mbedtls_psa_crypto_config_file () {
+    msg "build: make with MBEDTLS_PSA_CRYPTO_CONFIG_FILE" # ~40s
+    # Use the full config so as to catch a maximum of places where
+    # the check of MBEDTLS_PSA_CRYPTO_CONFIG_FILE might be missing.
+    scripts/config.py full
+    scripts/config.py set MBEDTLS_PSA_CRYPTO_CONFIG
+    sed 's!"check_config.h"!"mbedtls/check_config.h"!' <"$CRYPTO_CONFIG_H" >full_config.h
+    echo '#error "MBEDTLS_PSA_CRYPTO_CONFIG_FILE is not working"' >"$CRYPTO_CONFIG_H"
+    make CFLAGS="-I '$PWD' -DMBEDTLS_PSA_CRYPTO_CONFIG_FILE='\"full_config.h\"'"
+    rm -f full_config.h
+}
+
 component_test_m32_o0 () {
     # Build without optimization, so as to use portable C code (in a 32-bit
     # build) and not the i386-specific inline assembly.


### PR DESCRIPTION
Add MBEDTLS_PSA_CRYPTO_CONFIG_FILE to use custom specific
psa crypto config file.

Signed-off-by: Summer Qin <summer.qin@arm.com>

Notes:
Give users to use their specific PSA crypto configuration when use new style PSA config.

## Status
READY

## Todos
- [x] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


