### PR TITLE
Improve code/perf trade-off in bignum multiplication

### DIFF
--- a/library/bignum.c
+++ b/library/bignum.c
@@ -1405,26 +1405,33 @@ void mpi_mul_hlp( size_t i,
      *
      * Also, on 32-bit platforms, 256-bit numbers are 8 limbs, and this is a
      * common size for ECC, widely used on constrained platforms.
+     *
+     * Use optimized 8/4/2-times version if available.
      */
-#if defined(MULADDC_FAST8)
-    for( ; i >= 8; i -= 8 )
-    {
-        MULADDC_INIT
-        MULADDC_FAST8
-        MULADDC_STOP
-    }
-#else /* MULADDC_FAST8 */
-    for( ; i >= 8; i -= 8 )
-    {
-        MULADDC_INIT
-        MULADDC_CORE   MULADDC_CORE
-        MULADDC_CORE   MULADDC_CORE
+#if defined(MULADDC_FAST2)
+#define MULADDC_2   MULADDC_FAST2
+#else
+#define MULADDC_2   MULADDC_CORE MULADDC_CORE
+#endif
 
-        MULADDC_CORE   MULADDC_CORE
-        MULADDC_CORE   MULADDC_CORE
+#if defined(MULADDC_FAST4)
+#define MULADDC_4   MULADDC_FAST4
+#else
+#define MULADDC_4   MULADDC_2 MULADDC_2
+#endif
+
+#if defined(MULADDC_FAST8)
+#define MULADDC_8   MULADDC_FAST8
+#else
+#define MULADDC_8   MULADDC_4 MULADDC_4
+#endif
+
+    for( ; i >= 8; i -= 8 )
+    {
+        MULADDC_INIT
+        MULADDC_8
         MULADDC_STOP
     }
-#endif /* MULADDC_FAST8 */
 
     for( ; i > 0; i-- )
     {

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -1406,14 +1406,14 @@ void mpi_mul_hlp( size_t i,
      * Also, on 32-bit platforms, 256-bit numbers are 8 limbs, and this is a
      * common size for ECC, widely used on constrained platforms.
      */
-#if defined(MULADDC_HUIT)
+#if defined(MULADDC_FAST8)
     for( ; i >= 8; i -= 8 )
     {
         MULADDC_INIT
-        MULADDC_HUIT
+        MULADDC_FAST8
         MULADDC_STOP
     }
-#else /* MULADDC_HUIT */
+#else /* MULADDC_FAST8 */
     for( ; i >= 8; i -= 8 )
     {
         MULADDC_INIT
@@ -1424,7 +1424,7 @@ void mpi_mul_hlp( size_t i,
         MULADDC_CORE   MULADDC_CORE
         MULADDC_STOP
     }
-#endif /* MULADDC_HUIT */
+#endif /* MULADDC_FAST8 */
 
     for( ; i > 0; i-- )
     {

--- a/library/bn_mul.h
+++ b/library/bn_mul.h
@@ -118,7 +118,7 @@
 
 #if defined(MBEDTLS_HAVE_SSE2)
 
-#define MULADDC_HUIT                            \
+#define MULADDC_FAST8                            \
         "movd     %%ecx,     %%mm1      \n\t"   \
         "movd     %%ebx,     %%mm0      \n\t"   \
         "movd     (%%edi),   %%mm3      \n\t"   \
@@ -284,7 +284,7 @@
         : "d0", "d1", "d2", "d3", "d4", "a2", "a3"  \
     );
 
-#define MULADDC_HUIT                        \
+#define MULADDC_FAST8                        \
         "movel  %%a2@+,  %%d1       \n\t"   \
         "mulul  %%d2,    %%d4:%%d1  \n\t"   \
         "addxl  %%d3,    %%d1       \n\t"   \
@@ -843,7 +843,7 @@
 
 #define EMIT __asm _emit
 
-#define MULADDC_HUIT                            \
+#define MULADDC_FAST8                            \
     EMIT 0x0F  EMIT 0x6E  EMIT 0xC9             \
     EMIT 0x0F  EMIT 0x6E  EMIT 0xC3             \
     EMIT 0x0F  EMIT 0x6E  EMIT 0x1F             \


### PR DESCRIPTION
## Description

See https://github.com/ARMmbed/mbedtls/issues/5360#issuecomment-1002086595 - this PR saves code by removing loop unrolling which turned out not to be useful, and paves the way fore the main improvement suggested in #5360.

## Status
**READY**

## Requires Backporting

NO  (improvement)

## Migrations

NO - but introducing new internal APIs between `bn_mul.h` and `bignum.c`.

## Notes

Does this need a ChangeLog entry for the code size improvement? (988 bytes on Cortex-M0)
