### PR TITLE
Allow MPIs with external/fixed-size/read-only buffers

### DIFF
--- a/include/mbedtls/bignum.h
+++ b/include/mbedtls/bignum.h
@@ -188,9 +188,17 @@ extern "C" {
  */
 typedef struct mbedtls_mpi
 {
-    int MBEDTLS_PRIVATE(s);              /*!<  Sign: -1 if the mpi is negative, 1 otherwise */
-    size_t MBEDTLS_PRIVATE(n);           /*!<  total # of limbs  */
-    mbedtls_mpi_uint *MBEDTLS_PRIVATE(p);          /*!<  pointer to limbs  */
+    signed   char MBEDTLS_PRIVATE(s);         /*!<  Sign: -1 if the mpi is negative, 1 otherwise        */
+    unsigned char MBEDTLS_PRIVATE(external);  /*!< Indicates whether p was allocated by the MPI module. */
+    unsigned char MBEDTLS_PRIVATE(keepdata);  /*!< Indicates whether the data buffer should be zeroized
+                                               *   when freeing the MPI. Set to \c 1 if the data buffer
+                                               *   is read-only, or when the data is stilll used after
+                                               *   the MPI has been freed.                               */
+    unsigned char MBEDTLS_PRIVATE(fixedbuf);   /*!< Indicates whether \p p may be resized.               */
+                                               /* Invariants:
+                                                * - keepdata ==> external ==> fixedbuf */
+    size_t MBEDTLS_PRIVATE(n);            /*!<  total # of limbs  */
+    mbedtls_mpi_uint *MBEDTLS_PRIVATE(p); /*!<  pointer to limbs  */
 }
 mbedtls_mpi;
 

--- a/library/ecp.c
+++ b/library/ecp.c
@@ -535,7 +535,6 @@ void mbedtls_ecp_group_init( mbedtls_ecp_group *grp )
     mbedtls_mpi_init( &grp->N );
     grp->pbits = 0;
     grp->nbits = 0;
-    grp->h = 0;
     grp->modp = NULL;
     grp->t_pre = NULL;
     grp->t_post = NULL;
@@ -591,14 +590,11 @@ void mbedtls_ecp_group_free( mbedtls_ecp_group *grp )
     if( grp == NULL )
         return;
 
-    if( grp->h != 1 )
-    {
-        mbedtls_mpi_free( &grp->P );
-        mbedtls_mpi_free( &grp->A );
-        mbedtls_mpi_free( &grp->B );
-        mbedtls_ecp_point_free( &grp->G );
-        mbedtls_mpi_free( &grp->N );
-    }
+    mbedtls_mpi_free( &grp->P );
+    mbedtls_mpi_free( &grp->A );
+    mbedtls_mpi_free( &grp->B );
+    mbedtls_ecp_point_free( &grp->G );
+    mbedtls_mpi_free( &grp->N );
 
     if( !ecp_group_is_static_comb_table(grp) && grp->T != NULL )
     {
@@ -785,6 +781,7 @@ int mbedtls_ecp_point_write_binary( const mbedtls_ecp_group *grp,
         }
     }
 #endif
+
 
 cleanup:
     return( ret );
@@ -2747,9 +2744,19 @@ int mbedtls_ecp_muladd( mbedtls_ecp_group *grp, mbedtls_ecp_point *R,
 
 #if defined(MBEDTLS_ECP_MONTGOMERY_ENABLED)
 #if defined(MBEDTLS_ECP_DP_CURVE25519_ENABLED)
-#define ECP_MPI_INIT(s, n, p) {s, (n), (mbedtls_mpi_uint *)(p)}
-#define ECP_MPI_INIT_ARRAY(x)   \
-    ECP_MPI_INIT(1, sizeof(x) / sizeof(mbedtls_mpi_uint), x)
+
+#define ECP_MPI_INIT(N, P)                        \
+     {                                            \
+        .s = 1,                                   \
+        .p = (mbedtls_mpi_uint*) (P),             \
+        .n = (N),                                 \
+        .external = 1,                            \
+        .keepdata = 1,                            \
+        .fixedbuf = 1,                            \
+     }
+
+#define ECP_MPI_INIT_STATIC(x)   \
+    ECP_MPI_INIT(sizeof(x) / sizeof(mbedtls_mpi_uint), x)
 /*
  * Constants for the two points other than 0, 1, -1 (mod p) in
  * https://cr.yp.to/ecdh.html#validate
@@ -2767,10 +2774,10 @@ static const mbedtls_mpi_uint x25519_bad_point_2[] = {
     MBEDTLS_BYTES_TO_T_UINT_8( 0x04, 0x44, 0x5c, 0xc4, 0x58, 0x1c, 0x8e, 0x86 ),
     MBEDTLS_BYTES_TO_T_UINT_8( 0xd8, 0x22, 0x4e, 0xdd, 0xd0, 0x9f, 0x11, 0x57 ),
 };
-static const mbedtls_mpi ecp_x25519_bad_point_1 = ECP_MPI_INIT_ARRAY(
-        x25519_bad_point_1 );
-static const mbedtls_mpi ecp_x25519_bad_point_2 = ECP_MPI_INIT_ARRAY(
-        x25519_bad_point_2 );
+static const mbedtls_mpi ecp_x25519_bad_point_1 =
+    ECP_MPI_INIT_STATIC( x25519_bad_point_1 );
+static const mbedtls_mpi ecp_x25519_bad_point_2 =
+    ECP_MPI_INIT_STATIC( x25519_bad_point_2 );
 #endif /* MBEDTLS_ECP_DP_CURVE25519_ENABLED */
 
 /*


### PR DESCRIPTION
When used solely through its public MPI, the data buffer underlying
an `mbedtls_mpi` is always heap allocated. While this makes up for the
majority of MPIs used by the library, there are a few exceptions where
the library bypasses the MPI API to construct and operate on MPIs
with externally provided data buffer:

- MPIs for some but not all ECP group constants are setup from ROM.
- Curve-specific modular reduction routines hand-craft an MPI with
  stack-allocated data buffer

If the data buffer is not heap allocated, there is great danger
of shooting yourself in the foot when using the MPI API, as
numerous APIs assume that the data buffer is heap allocated:
For example, mbedtls_mpi_free() attempts to free the data buffer,
and mbedtls_mpi_grow/shrink() may attempt to reallocate it.

The above cases where the library bypasses the public API to operate
on MPIs with static buffers are therefore easy to get wrong. An example
is in fact the stack-allocated MPI in the case of the modular reduction
routines: Since mbedts_mpi_free() must not be called on it, the buffer
is also not zeroized (which would normally also be done as part of
mbedtls_mpi_free()), and so sensitive data is leaked on the stack.
In the case of ECP group constants in ROM, calling e.g.
mbedtls_ecp_point_free() on grp->G would lead to heap corruption,
which is prevented via a dedicated variable `h` in the EC group struct.

This PR introduces three new private flags to `mbedtls_mpi`:
- `fixedbuf`, which indicates that the MPI's data buffer must not
  be resized. If calls to `mbedtls_mpi_{shrink,grow}()` lead to a
  an attempted reallocation, they fail gracefully.
- `external`, which implies `fixedbuf`, and which in addition
  indicates that the data buffer is not allocated
  by the MPI module and which thus need not be freed in
  `mbedtls_mpi_free()`.
- `keepdata`, which implies `external`, and which indicates that
  the data buffer should not be zeroized when the MPI is freed.
  This may be used both for read-only data buffers, or for data
  buffers that are still used after the MPI structure has been
  freed.

This is used as follows:
- The stack-allocated MPI buffers in the ECP modular reduction
  routines are marked as external, and mbedtls_mpi_free() is
  called at the end of the reduction. This zeroizes the buffer
  but does not attempt to free it.
- ECP groups with ROM constants mark the corresponding MPIs as
  `keepdata`, which skips over zeroization and freeing when
  mbedtls_ecp_group_free() is called. The `h` variable in the
  ECP group structure can be removed.
