### PR TITLE
Fixed memleak mbedtls_pk_parse_public_key

### DIFF
--- a/ChangeLog.d/pkparse_public_key_memleak.txt
+++ b/ChangeLog.d/pkparse_public_key_memleak.txt
@@ -1,3 +1,3 @@
 Bugfix
-   * Fix memory leak if mbedtls_pk_parse_public_key() call is repeated with the
-     same context without reseting the context first. Fixes #5492.
+   * Fix memory leak in mbedtls_pk_parse_public_key() in low memory
+     conditions

--- a/ChangeLog.d/pkparse_public_key_memleak.txt
+++ b/ChangeLog.d/pkparse_public_key_memleak.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix memory leak if mbedtls_pk_parse_public_key() call is repeated with the
+     same context without reseting the context first. Fixes #5492.

--- a/library/pkparse.c
+++ b/library/pkparse.c
@@ -1455,8 +1455,10 @@ int mbedtls_pk_parse_public_key( mbedtls_pk_context *ctx,
         if( ( pk_info = mbedtls_pk_info_from_type( MBEDTLS_PK_RSA ) ) == NULL )
             return( MBEDTLS_ERR_PK_UNKNOWN_PK_ALG );
 
-        if( ( ret = mbedtls_pk_setup( ctx, pk_info ) ) != 0 )
+        if( ( ret = mbedtls_pk_setup( ctx, pk_info ) ) != 0 ) {
+            mbedtls_pem_free( &pem );
             return( ret );
+        }
 
         if ( ( ret = pk_get_rsapubkey( &p, p + pem.buflen, mbedtls_pk_rsa( *ctx ) ) ) != 0 )
             mbedtls_pk_free( ctx );

--- a/library/pkparse.c
+++ b/library/pkparse.c
@@ -1452,16 +1452,13 @@ int mbedtls_pk_parse_public_key( mbedtls_pk_context *ctx,
     if( ret == 0 )
     {
         p = pem.buf;
-        if( ( pk_info = mbedtls_pk_info_from_type( MBEDTLS_PK_RSA ) ) == NULL )
-            return( MBEDTLS_ERR_PK_UNKNOWN_PK_ALG );
+        pk_info = mbedtls_pk_info_from_type( MBEDTLS_PK_RSA );
 
-        if( ( ret = mbedtls_pk_setup( ctx, pk_info ) ) != 0 ) {
-            mbedtls_pem_free( &pem );
-            return( ret );
+        if( ( ret = mbedtls_pk_setup( ctx, pk_info ) ) != 0 ||
+            ( ret = pk_get_rsapubkey( &p, p + pem.buflen, mbedtls_pk_rsa( *ctx ) ) ) != 0 )
+        {
+                mbedtls_pk_free( ctx );
         }
-
-        if ( ( ret = pk_get_rsapubkey( &p, p + pem.buflen, mbedtls_pk_rsa( *ctx ) ) ) != 0 )
-            mbedtls_pk_free( ctx );
 
         mbedtls_pem_free( &pem );
         return( ret );


### PR DESCRIPTION
## Description
This PR fixes a memory leak which occurs when a certain failure happens in `mbedtls_pk_parse_public_key`.
See [issue 5492](https://github.com/ARMmbed/mbedtls/issues/5492) for a detailed explanation.

## Status
**READY**

## Requires Backporting

Yes
Which branch? 2.28

## Migrations

NO

## Additional comments
See issue mentioned above.

## Todos
- [x] Tests
- [ ] Documentation
- [x] Changelog updated
- [ ] Backported


## Steps to test or reproduce
See issue mentioned above.
