### PR TITLE
Fixed undefined behavior in ssl_read if buf parameter is NULL.

### DIFF
--- a/ChangeLog.d/mbedtls_ssl_read_undefined_behavior.txt
+++ b/ChangeLog.d/mbedtls_ssl_read_undefined_behavior.txt
@@ -1,0 +1,2 @@
+Bugfix
+   * Fixed undefined behavior in mbedtls_ssl_read if len argument is 0

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -5431,8 +5431,11 @@ int mbedtls_ssl_read( mbedtls_ssl_context *ssl, unsigned char *buf, size_t len )
     n = ( len < ssl->in_msglen )
         ? len : ssl->in_msglen;
 
-    memcpy( buf, ssl->in_offt, n );
-    ssl->in_msglen -= n;
+    if ( buf )
+    {
+        memcpy( buf, ssl->in_offt, n );
+        ssl->in_msglen -= n;
+    }
 
     /* Zeroising the plaintext buffer to erase unused application data
        from the memory. */

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -5431,7 +5431,7 @@ int mbedtls_ssl_read( mbedtls_ssl_context *ssl, unsigned char *buf, size_t len )
     n = ( len < ssl->in_msglen )
         ? len : ssl->in_msglen;
 
-    if ( buf )
+    if ( len != 0 )
     {
         memcpy( buf, ssl->in_offt, n );
         ssl->in_msglen -= n;


### PR DESCRIPTION
Signed-off-by: Ashley Duncan <ashes.man@gmail.com>

Notes:
* Pull requests cannot be accepted until the PR follows the [contributing guidelines](../CONTRIBUTING.md). In particular, each commit must have at least one `Signed-off-by:` line from the committer to certify that the contribution is made under the terms of the [Developer Certificate of Origin](../dco.txt).
* This is just a template, so feel free to use/remove the unnecessary things
## Description
A few sentences describing the overall goals of the pull request's commits.

Fixed call of memcpy  with NULL destination pointer when mbedtls_ssl_read is called with buf parameter == NULL

Refer to issue https://github.com/ARMmbed/mbedtls/issues/3076

This situation could be unit tested by calling mbedtls_ssl_read(ctx, NULL, 0);  Unfortunately I do not have a good enough understanding of the test framework to write a good quality test.

NOTE: mbedtls_ssl_read can be called with buf == NULL to force a read from lower level buffer into tls buffers without actually returning any data.  This is useful for performing an update before asking how much data is ready to be read.

## Status
**READY/IN DEVELOPMENT/HOLD**

## Requires Backporting
When there is a bug fix, it should be backported to all maintained and supported branches.
Changes do not have to be backported if:
- This PR is a new feature\enhancement
- This PR contains changes in the API. If this is true, and there is a need for the fix to be backported, the fix should be handled differently in the legacy branch

Yes | NO  
Which branch?

## Migrations
If there is any API change, what's the incentive and logic for it.

YES | NO

## Additional comments
Any additional information that could be of interest

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.
