### PR TITLE
PK: RSA verification

### DIFF
--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -215,9 +215,9 @@ static int rsa_verify_wrap( void *ctx, mbedtls_md_type_t md_alg,
                               sig, sig_len );
     if( status != PSA_SUCCESS )
     {
-        if ( status == PSA_ERROR_INVALID_PADDING )
+        if ( status == PSA_ERROR_INVALID_SIGNATURE )
         {
-            ret = MBEDTLS_ERR_RSA_INVALID_PADDING;
+            ret = MBEDTLS_ERR_RSA_VERIFY_FAILED;
         }
         else
         {

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -177,7 +177,6 @@ static int rsa_verify_wrap( void *ctx, mbedtls_md_type_t md_alg,
     mbedtls_pk_context key;
     int key_len;
     unsigned char buf[MBEDTLS_PK_RSA_PUB_DER_MAX_BYTES];
-    mbedtls_pk_info_t pk_info = mbedtls_rsa_info;
     psa_algorithm_t psa_alg_md =
         PSA_ALG_RSA_PKCS1V15_SIGN( mbedtls_psa_translate_md( md_alg ) );
     size_t rsa_len = mbedtls_rsa_get_len( rsa );
@@ -192,7 +191,7 @@ static int rsa_verify_wrap( void *ctx, mbedtls_md_type_t md_alg,
 
     /* mbedtls_pk_write_pubkey_der() expects a full PK context;
      * re-construct one to make it happy */
-    key.pk_info = &pk_info;
+    key.pk_info = &mbedtls_rsa_info;
     key.pk_ctx = ctx;
     key_len = mbedtls_pk_write_pubkey_der( &key, buf, sizeof( buf ) );
     if( key_len <= 0 )

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -176,8 +176,7 @@ static int rsa_verify_wrap( void *ctx, mbedtls_md_type_t md_alg,
     psa_status_t status;
     mbedtls_pk_context key;
     int key_len;
-    /* see RSA_PUR_DER_MAX_BYTES in pkwrite.c */
-    unsigned char buf[38 + 2 * MBEDTLS_MPI_MAX_SIZE];
+    unsigned char buf[MBEDTLS_PK_RSA_PUB_DER_MAX_BYTES];
     mbedtls_pk_info_t pk_info = mbedtls_rsa_info;
     psa_algorithm_t psa_alg_md = PSA_ALG_RSA_PKCS1V15_SIGN( mbedtls_psa_translate_md( md_alg ) );
     size_t rsa_len = mbedtls_rsa_get_len( rsa );

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -190,7 +190,7 @@ static int rsa_verify_wrap( void *ctx, mbedtls_md_type_t md_alg,
     if( sig_len < rsa_len )
         return( MBEDTLS_ERR_RSA_VERIFY_FAILED );
 
-    /* mbedtls_pk_write_pubkey() expects a full PK context;
+    /* mbedtls_pk_write_pubkey_der() expects a full PK context;
      * re-construct one to make it happy */
     key.pk_info = &pk_info;
     key.pk_ctx = ctx;

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -164,9 +164,70 @@ static size_t rsa_get_bitlen( const void *ctx )
     return( 8 * mbedtls_rsa_get_len( rsa ) );
 }
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
 static int rsa_verify_wrap( void *ctx, mbedtls_md_type_t md_alg,
                    const unsigned char *hash, size_t hash_len,
                    const unsigned char *sig, size_t sig_len )
+{
+    mbedtls_rsa_context * rsa = (mbedtls_rsa_context *) ctx;
+    int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
+    psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
+    mbedtls_svc_key_id_t key_id = MBEDTLS_SVC_KEY_ID_INIT;
+    psa_status_t status;
+    mbedtls_pk_context key;
+    int key_len;
+    /* see RSA_PUR_DER_MAX_BYTES in pkwrite.c */
+    unsigned char buf[38 + 2 * MBEDTLS_MPI_MAX_SIZE];
+    mbedtls_pk_info_t pk_info = mbedtls_rsa_info;
+    psa_algorithm_t psa_alg_md = PSA_ALG_RSA_PKCS1V15_SIGN( mbedtls_psa_translate_md( md_alg ) );
+    size_t rsa_len = mbedtls_rsa_get_len( rsa );
+
+#if SIZE_MAX > UINT_MAX
+    if( md_alg == MBEDTLS_MD_NONE && UINT_MAX < hash_len )
+        return( MBEDTLS_ERR_PK_BAD_INPUT_DATA );
+#endif /* SIZE_MAX > UINT_MAX */
+
+    if( sig_len < rsa_len )
+        return( MBEDTLS_ERR_RSA_VERIFY_FAILED );
+
+    /* mbedtls_pk_write_pubkey() expects a full PK context;
+     * re-construct one to make it happy */
+    key.pk_info = &pk_info;
+    key.pk_ctx = ctx;
+    key_len = mbedtls_pk_write_pubkey_der( &key, buf, sizeof( buf ) );
+    if( key_len <= 0 )
+        return( MBEDTLS_ERR_PK_BAD_INPUT_DATA );
+
+    psa_set_key_usage_flags( &attributes, PSA_KEY_USAGE_VERIFY_HASH );
+    psa_set_key_algorithm( &attributes, psa_alg_md );
+    psa_set_key_type( &attributes, PSA_KEY_TYPE_RSA_PUBLIC_KEY );
+
+    status = psa_import_key( &attributes,
+                             buf + sizeof( buf ) - key_len, key_len,
+                             &key_id );
+    if( status != PSA_SUCCESS )
+    {
+        ret = mbedtls_psa_err_translate_pk( status );
+        goto cleanup;
+    }
+
+    status = psa_verify_hash( key_id, psa_alg_md, hash, hash_len,
+                              sig, sig_len );
+    if( status != PSA_SUCCESS )
+    {
+        ret = mbedtls_psa_err_translate_pk( status );
+        goto cleanup;
+    }
+    ret = 0;
+
+cleanup:
+    psa_destroy_key( key_id );
+    return( ret );
+}
+#else
+static int rsa_verify_wrap( void *ctx, mbedtls_md_type_t md_alg,
+        const unsigned char *hash, size_t hash_len,
+        const unsigned char *sig, size_t sig_len )
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     mbedtls_rsa_context * rsa = (mbedtls_rsa_context *) ctx;
@@ -195,6 +256,7 @@ static int rsa_verify_wrap( void *ctx, mbedtls_md_type_t md_alg,
 
     return( 0 );
 }
+#endif
 
 #if defined(MBEDTLS_PSA_CRYPTO_C)
 int  mbedtls_pk_psa_rsa_sign_ext( psa_algorithm_t alg,

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -228,7 +228,10 @@ static int rsa_verify_wrap( void *ctx, mbedtls_md_type_t md_alg,
     ret = 0;
 
 cleanup:
-    psa_destroy_key( key_id );
+    status = psa_destroy_key( key_id );
+    if( ret == 0 && status != PSA_SUCCESS )
+        ret = mbedtls_psa_err_translate_pk( status );
+
     return( ret );
 }
 #else

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -215,7 +215,14 @@ static int rsa_verify_wrap( void *ctx, mbedtls_md_type_t md_alg,
                               sig, sig_len );
     if( status != PSA_SUCCESS )
     {
-        ret = mbedtls_psa_err_translate_pk( status );
+        if ( status == PSA_ERROR_INVALID_PADDING )
+        {
+            ret = MBEDTLS_ERR_RSA_INVALID_PADDING;
+        }
+        else
+        {
+            ret = mbedtls_psa_err_translate_pk( status );
+        }
         goto cleanup;
     }
     ret = 0;

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -207,7 +207,7 @@ static int rsa_verify_wrap( void *ctx, mbedtls_md_type_t md_alg,
                              &key_id );
     if( status != PSA_SUCCESS )
     {
-        ret = mbedtls_psa_err_translate_pk( status );
+        ret = mbedtls_pk_error_from_psa( status );
         goto cleanup;
     }
 
@@ -215,14 +215,7 @@ static int rsa_verify_wrap( void *ctx, mbedtls_md_type_t md_alg,
                               sig, sig_len );
     if( status != PSA_SUCCESS )
     {
-        if ( status == PSA_ERROR_INVALID_SIGNATURE )
-        {
-            ret = MBEDTLS_ERR_RSA_VERIFY_FAILED;
-        }
-        else
-        {
-            ret = mbedtls_psa_err_translate_pk( status );
-        }
+        ret = mbedtls_pk_error_from_psa_rsa( status );
         goto cleanup;
     }
     ret = 0;
@@ -230,7 +223,7 @@ static int rsa_verify_wrap( void *ctx, mbedtls_md_type_t md_alg,
 cleanup:
     status = psa_destroy_key( key_id );
     if( ret == 0 && status != PSA_SUCCESS )
-        ret = mbedtls_psa_err_translate_pk( status );
+        ret = mbedtls_pk_error_from_psa( status );
 
     return( ret );
 }

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -178,7 +178,8 @@ static int rsa_verify_wrap( void *ctx, mbedtls_md_type_t md_alg,
     int key_len;
     unsigned char buf[MBEDTLS_PK_RSA_PUB_DER_MAX_BYTES];
     mbedtls_pk_info_t pk_info = mbedtls_rsa_info;
-    psa_algorithm_t psa_alg_md = PSA_ALG_RSA_PKCS1V15_SIGN( mbedtls_psa_translate_md( md_alg ) );
+    psa_algorithm_t psa_alg_md =
+        PSA_ALG_RSA_PKCS1V15_SIGN( mbedtls_psa_translate_md( md_alg ) );
     size_t rsa_len = mbedtls_rsa_get_len( rsa );
 
 #if SIZE_MAX > UINT_MAX

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -345,6 +345,8 @@ void mbedtls_pk_check_pair( char * pub_file, char * prv_file, int ret )
 {
     mbedtls_pk_context pub, prv, alt;
 
+    USE_PSA_INIT();
+
     mbedtls_pk_init( &pub );
     mbedtls_pk_init( &prv );
     mbedtls_pk_init( &alt );
@@ -373,6 +375,7 @@ void mbedtls_pk_check_pair( char * pub_file, char * prv_file, int ret )
     mbedtls_pk_free( &pub );
     mbedtls_pk_free( &prv );
     mbedtls_pk_free( &alt );
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -394,6 +397,8 @@ void pk_rsa_verify_test_vec( data_t * message_str, int digest, int mod,
     // this setting would ensure restart would happen if ECC was used
     mbedtls_ecp_set_max_ops( 1 );
 #endif
+
+    USE_PSA_INIT();
 
     mbedtls_pk_init( &pk );
 
@@ -421,6 +426,7 @@ exit:
     mbedtls_pk_restart_free( rs_ctx );
 #endif
     mbedtls_pk_free( &pk );
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -530,6 +536,8 @@ void pk_sign_verify_restart( int pk_type, int grp_id, char *d_str,
     size_t hlen, slen;
     const mbedtls_md_info_t *md_info;
 
+    USE_PSA_INIT();
+
     mbedtls_pk_restart_init( &rs_ctx );
     mbedtls_pk_init( &prv );
     mbedtls_pk_init( &pub );
@@ -617,6 +625,7 @@ exit:
     mbedtls_pk_restart_free( &rs_ctx );
     mbedtls_pk_free( &prv );
     mbedtls_pk_free( &pub );
+    USE_PSA_DONE();
 }
 /* END_CASE */
 


### PR DESCRIPTION
## Description
In `library/pk_wrap.c`, provide an implementation of `rsa_verify_wrap` to use `psa_verify_hash()` instead of `mbedtls_rsa_pkcs1_verify()` when `MBEDTLS_USE_PSA_CRYPTO` is enabled.

Resolves #5159 

## Status
**READY**

## Requires Backporting
NO  

## Migrations
NO

## Todos
- [X] Implementation
- [X] Tests

## Steps to test or reproduce
test_suite_pk should run clean
