### PR TITLE
fix asm MULADDC for Microblaze in bn_mul.h

### DIFF
--- a/include/mbedtls/bn_mul.h
+++ b/include/mbedtls/bn_mul.h
@@ -568,10 +568,10 @@
         "addi  r3,   r3,   2    \n\t"   \
         "lhui  r9,   r3,   0    \n\t"   \
         "addi  r3,   r3,   2    \n\t"   \
-        "mul   r10,  r9,  r6    \n\t"   \
-        "mul   r11,  r8,  r7    \n\t"   \
-        "mul   r12,  r9,  r7    \n\t"   \
-        "mul   r13,  r8,  r6    \n\t"   \
+        "mul   r10,  r8,  r6    \n\t"   \
+        "mul   r12,  r8,  r7    \n\t"   \
+        "mul   r11,  r9,  r7    \n\t"   \
+        "mul   r13,  r9,  r6    \n\t"   \
         "bsrli  r8, r10,  16    \n\t"   \
         "bsrli  r9, r11,  16    \n\t"   \
         "add   r13, r13,  r8    \n\t"   \

--- a/include/mbedtls/bn_mul.h
+++ b/include/mbedtls/bn_mul.h
@@ -564,10 +564,10 @@
         "bsrli r6,   r6, 16     \n\t"
 
 #define MULADDC_CORE                    \
-        "lhui  r8,   r3,   0    \n\t"   \
-        "addi  r3,   r3,   2    \n\t"   \
-        "lhui  r9,   r3,   0    \n\t"   \
-        "addi  r3,   r3,   2    \n\t"   \
+        "lwi   r9,   r3,   0    \n\t"   \
+        "andi  r8,   r9, 0xffff \n\t"   \
+        "bsrli r9,   r9,  16    \n\t"   \
+        "addi  r3,   r3,   4    \n\t"   \
         "mul   r10,  r8,  r6    \n\t"   \
         "mul   r12,  r8,  r7    \n\t"   \
         "mul   r11,  r9,  r7    \n\t"   \


### PR DESCRIPTION
Fix MULADDC for Microblaze n bn_mul.h when MBEDTLS_HAVE_ASM is defined
This is a new version of #5578 with a minimal number of changes.

## Status
Ready aka "it works on my device"
It fixes #2020

## Requires Backporting
Yes, it could be backported in LTS 2.16 branch

## Steps to test or reproduce
Run MPI or ECP self test on a Microblaze with MBEDTLS_HAVE_ASM defined.

Without the patch :
```
[14:27:21:309]   MPI test #1 (mul_mpi): failed
[14:27:21:309] Unexpected error, return code = 00000001
[14:27:21:309]   ECP SW test #1 (constant op_count, base point G): Unexpected error, return code = FFFFB380
```

With patch :
```
[14:28:39:658]   MPI test #1 (mul_mpi): passed
[14:28:39:658]   MPI test #2 (div_mpi): passed
[14:28:39:768]   MPI test #3 (exp_mod): passed
[14:28:39:799]   MPI test #4 (inv_mod): passed
[14:28:39:799]   MPI test #5 (simple gcd): passed
[14:28:39:799]   ECP SW test #1 (constant op_count, base point G): passed
[14:28:40:617]   ECP SW test #2 (constant op_count, other point): passed
[14:28:41:961]   ECP Montgomery test (constant op_count): passed
```

Signed-off-by: Benjamin Silvestre <bsilvestre@eurecam.net>