### PR TITLE
Fix potential memcpy() UB in mbedtls_asn1_store_named_data() 

### DIFF
--- a/library/asn1write.c
+++ b/library/asn1write.c
@@ -472,7 +472,7 @@ mbedtls_asn1_named_data *mbedtls_asn1_store_named_data(
         cur->val.len = val_len;
     }
 
-    if( val != NULL )
+    if( val != NULL && val_len != 0 )
         memcpy( cur->val.p, val, val_len );
 
     return( cur );

--- a/library/asn1write.c
+++ b/library/asn1write.c
@@ -472,7 +472,7 @@ mbedtls_asn1_named_data *mbedtls_asn1_store_named_data(
         cur->val.len = val_len;
     }
 
-    if( val != NULL && val_len != 0 )
+    if( val != NULL )
         memcpy( cur->val.p, val, val_len );
 
     return( cur );

--- a/tests/suites/test_suite_asn1write.data
+++ b/tests/suites/test_suite_asn1write.data
@@ -373,11 +373,14 @@ store_named_data_val_found:9:9
 Store named data: found, larger data
 store_named_data_val_found:4:9
 
-Store named data: new, val_len=0
-store_named_data_val_new:0
+Store named data: new, val_len=0, val=NULL
+store_named_data_val_new:0:1
 
-Store named data: new, val_len=4
-store_named_data_val_new:4
+Store named data: new, val_len=0, val=non-NULL
+store_named_data_val_new:0:0
+
+Store named data: new, val_len=4, val=non-NULL
+store_named_data_val_new:4:0
 
 Store named data: new, val_len=4, val=NULL
-store_named_data_val_new:-4
+store_named_data_val_new:4:1

--- a/tests/suites/test_suite_asn1write.function
+++ b/tests/suites/test_suite_asn1write.function
@@ -431,18 +431,16 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE */
-void store_named_data_val_new( int new_len )
+void store_named_data_val_new( int new_len, int new_val_is_null )
 {
     mbedtls_asn1_named_data *head = NULL;
     mbedtls_asn1_named_data *found = NULL;
     const unsigned char *oid = (unsigned char *) "OID";
     size_t oid_len = strlen( (const char *) oid );
-    const unsigned char *new_val = (unsigned char *) "new value";
+    unsigned char * new_val = (unsigned char *) "new value";
 
-    if( new_len <= 0 )
+    if( new_val_is_null )
         new_val = NULL;
-    if( new_len < 0 )
-        new_len = - new_len;
 
     found = mbedtls_asn1_store_named_data( &head,
                                            (const char *) oid, oid_len,


### PR DESCRIPTION
## Description
There was a potential case in mbedtls_asn1_store_named_data where
memcpy() could be called with a null pointer and length 0, which is
undefined behaviour.
Only calling the memcpy where the length is not zero removes this case,
and scan-build no longer flags this as undefined behaviour with this fix
applied.

This issue was originally flagged by PR #3710, however this fix differs slightly and omits some zero-initialisations that are unnecessary and incur a performance cost.

The original report generated by clang's scan-build was as follows:
![Screenshot from 2022-03-07 16-25-24](https://user-images.githubusercontent.com/66637160/157076305-46bce6ef-ad40-4f00-bbcc-ec047651e13f.png)


## Status
**READY**

## Requires Backporting
**YES** 2.28

## Migrations
NO

## Additional comments
N/A

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
Build mbedtls with scan-build:
```scan-build make -j```
