### PR TITLE
TLS ECDH 3a: ECDHE-PSK (both sides, 1.2)

### DIFF
--- a/library/ssl_tls12_client.c
+++ b/library/ssl_tls12_client.c
@@ -3130,10 +3130,6 @@ ecdh_calc_secret:
         MBEDTLS_PUT_UINT16_BE( zlen, pms, 0 );
         pms += zlen_size + zlen;
 
-        /* opaque psk<0..2^16-1>; */
-        if( pms_end - pms < 2 )
-            return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
-
         const unsigned char *psk = NULL;
         size_t psk_len = 0;
 
@@ -3145,12 +3141,13 @@ ecdh_calc_secret:
              */
             return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
 
+        /* opaque psk<0..2^16-1>; */
+        if( (size_t)( pms_end - pms ) < ( 2 + psk_len ) )
+            return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
+
         /* Write the PSK length as uint16 */
         MBEDTLS_PUT_UINT16_BE( psk_len, pms, 0 );
         pms += 2;
-
-        if( pms_end < pms || (size_t)( pms_end - pms ) < psk_len )
-            return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
 
         /* Write the PSK itself */
         memcpy( pms, psk, psk_len );

--- a/library/ssl_tls12_client.c
+++ b/library/ssl_tls12_client.c
@@ -3066,7 +3066,7 @@ ecdh_calc_secret:
         status = psa_generate_key( &key_attributes,
                                    &handshake->ecdh_psa_privkey );
         if( status != PSA_SUCCESS )
-            return( MBEDTLS_ERR_SSL_HW_ACCEL_FAILED );
+            return( psa_ssl_status_to_mbedtls( status ) );
 
         /* Export the public part of the ECDH private key from PSA.
          * The export format is an ECPoint structure as expected by TLS,
@@ -3083,7 +3083,7 @@ ecdh_calc_secret:
         {
             psa_destroy_key( handshake->ecdh_psa_privkey );
             handshake->ecdh_psa_privkey = MBEDTLS_SVC_KEY_ID_INIT;
-            return( MBEDTLS_ERR_SSL_HW_ACCEL_FAILED );
+            return( psa_ssl_status_to_mbedtls( status ) );
         }
 
         ssl->out_msg[header_len] = (unsigned char) own_pubkey_len;
@@ -3111,8 +3111,10 @@ ecdh_calc_secret:
         destruction_status = psa_destroy_key( handshake->ecdh_psa_privkey );
         handshake->ecdh_psa_privkey = MBEDTLS_SVC_KEY_ID_INIT;
 
-        if( status != PSA_SUCCESS || destruction_status != PSA_SUCCESS )
-            return( MBEDTLS_ERR_SSL_HW_ACCEL_FAILED );
+        if( status != PSA_SUCCESS )
+            return( psa_ssl_status_to_mbedtls( status ) );
+        else if( destruction_status != PSA_SUCCESS )
+            return( psa_ssl_status_to_mbedtls( destruction_status ) );
 
         /* Write the ECDH computation length before the ECDH computation */
         MBEDTLS_PUT_UINT16_BE( zlen, p, 0 );

--- a/library/ssl_tls12_client.c
+++ b/library/ssl_tls12_client.c
@@ -3025,10 +3025,14 @@ ecdh_calc_secret:
         if( ssl_conf_has_static_raw_psk( ssl->conf ) == 0 )
             return( MBEDTLS_ERR_SSL_FEATURE_UNAVAILABLE );
 
+        /* uint16 to store content length */
+        const size_t content_len_size = 2;
+
         header_len = 4;
         content_len = ssl->conf->psk_identity_len;
 
-        if( header_len + 2 + content_len > MBEDTLS_SSL_OUT_CONTENT_LEN )
+        if( header_len + content_len_size + content_len
+                    > MBEDTLS_SSL_OUT_CONTENT_LEN )
         {
             MBEDTLS_SSL_DEBUG_MSG( 1,
                 ( "psk identity too long or SSL buffer too short" ) );

--- a/library/ssl_tls12_client.c
+++ b/library/ssl_tls12_client.c
@@ -3076,7 +3076,7 @@ ecdh_calc_secret:
         unsigned char *own_pubkey = ssl->out_msg + header_len + 1;
         unsigned char *end = ssl->out_msg + MBEDTLS_SSL_OUT_CONTENT_LEN;
         size_t own_pubkey_max_len = (size_t)( end - own_pubkey );
-        size_t own_pubkey_len;
+        size_t own_pubkey_len = 0;
 
         status = psa_export_public_key( handshake->ecdh_psa_privkey,
                                         own_pubkey, own_pubkey_max_len,
@@ -3094,7 +3094,7 @@ ecdh_calc_secret:
         /* The ECDH secret is the premaster secret used for key derivation. */
         unsigned char *p = ssl->handshake->premaster;
         unsigned char *p_end = p + sizeof( ssl->handshake->premaster );
-        size_t zlen;
+        size_t zlen = 0;
 
         /* Compute ECDH shared secret. */
         status = psa_raw_key_agreement( PSA_ALG_ECDH,

--- a/library/ssl_tls12_client.c
+++ b/library/ssl_tls12_client.c
@@ -3096,7 +3096,8 @@ ecdh_calc_secret:
          * - the PSK itself
          */
         unsigned char *p = ssl->handshake->premaster;
-        unsigned char *p_end = p + sizeof( ssl->handshake->premaster );
+        const unsigned char* const p_end = p +
+                                sizeof( ssl->handshake->premaster );
         size_t zlen = 0;
 
         /* Perform ECDH computation after the uint16 reserved for the length */

--- a/library/ssl_tls12_client.c
+++ b/library/ssl_tls12_client.c
@@ -3016,12 +3016,10 @@ ecdh_calc_secret:
          * opaque psk_identity<0..2^16-1>;
          */
         if( mbedtls_ssl_conf_has_static_psk( ssl->conf ) == 0 )
-        {
             /* We don't offer PSK suites if we don't have a PSK,
              * and we check that the server's choice is among the
              * ciphersuites we offered, so this should never happen. */
             return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
-        }
 
         /* Opaque PSKs are currently only supported for PSK-only suites. */
         if( ssl_conf_has_static_raw_psk( ssl->conf ) == 0 )
@@ -3129,13 +3127,11 @@ ecdh_calc_secret:
 
         if( mbedtls_ssl_get_psk( ssl, &psk, &psk_len )
                 == MBEDTLS_ERR_SSL_PRIVATE_KEY_REQUIRED )
-        {
             /*
              * This should never happen because the existence of a PSK is always
              * checked before calling this function
              */
             return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
-        }
 
         /* Write the PSK length as uint16 */
         MBEDTLS_PUT_UINT16_BE( psk_len, p, 0 );

--- a/library/ssl_tls12_client.c
+++ b/library/ssl_tls12_client.c
@@ -3098,6 +3098,8 @@ ecdh_calc_secret:
         unsigned char *p = ssl->handshake->premaster;
         const unsigned char* const p_end = p +
                                 sizeof( ssl->handshake->premaster );
+        /* uint16 to store length (in octets) of the ECDH computation */
+        const size_t zlen_size = 2;
         size_t zlen = 0;
 
         /* Perform ECDH computation after the uint16 reserved for the length */
@@ -3105,8 +3107,8 @@ ecdh_calc_secret:
                                         handshake->ecdh_psa_privkey,
                                         handshake->ecdh_psa_peerkey,
                                         handshake->ecdh_psa_peerkey_len,
-                                        p + 2,
-                                        p_end - ( p + 2 ),
+                                        p + zlen_size,
+                                        p_end - ( p + zlen_size ),
                                         &zlen );
 
         destruction_status = psa_destroy_key( handshake->ecdh_psa_privkey );
@@ -3119,7 +3121,7 @@ ecdh_calc_secret:
 
         /* Write the ECDH computation length before the ECDH computation */
         MBEDTLS_PUT_UINT16_BE( zlen, p, 0 );
-        p += 2 + zlen;
+        p += zlen_size + zlen;
 
         /* opaque psk<0..2^16-1>; */
         if( p_end - p < 2 )

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -4057,8 +4057,15 @@ static int ssl_parse_client_key_exchange( mbedtls_ssl_context *ssl )
         }
 
         /* Keep a copy of the peer's public key */
+        if( p >= end )
+        {
+            psa_destroy_key( handshake->ecdh_psa_privkey );
+            handshake->ecdh_psa_privkey = MBEDTLS_SVC_KEY_ID_INIT;
+            return( MBEDTLS_ERR_SSL_DECODE_ERROR );
+        }
+
         ecpoint_len = *(p++);
-        if( (size_t)( end - *p ) < ecpoint_len ) {
+        if( (size_t)( end - p ) < ecpoint_len ) {
             psa_destroy_key( handshake->ecdh_psa_privkey );
             handshake->ecdh_psa_privkey = MBEDTLS_SVC_KEY_ID_INIT;
             return( MBEDTLS_ERR_SSL_DECODE_ERROR );

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -4081,7 +4081,8 @@ static int ssl_parse_client_key_exchange( mbedtls_ssl_context *ssl )
 ￼         * - the PSK itself
 ￼         */
         unsigned char *psm = ssl->handshake->premaster;
-        unsigned char *psm_end = psm + sizeof( ssl->handshake->premaster );
+        const unsigned char* const psm_end =
+                    psm + sizeof( ssl->handshake->premaster );
         size_t zlen = 0;
 
         /* Compute ECDH shared secret. */

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -4083,6 +4083,8 @@ static int ssl_parse_client_key_exchange( mbedtls_ssl_context *ssl )
         unsigned char *psm = ssl->handshake->premaster;
         const unsigned char* const psm_end =
                     psm + sizeof( ssl->handshake->premaster );
+        /* uint16 to store length (in octets) of the ECDH computation */
+        const size_t zlen_size = 2;
         size_t zlen = 0;
 
         /* Compute ECDH shared secret. */
@@ -4090,8 +4092,8 @@ static int ssl_parse_client_key_exchange( mbedtls_ssl_context *ssl )
                                         handshake->ecdh_psa_privkey,
                                         handshake->ecdh_psa_peerkey,
                                         handshake->ecdh_psa_peerkey_len,
-                                        psm + 2,
-                                        psm_end - ( psm + 2 ),
+                                        psm + zlen_size,
+                                        psm_end - ( psm + zlen_size ),
                                         &zlen );
 
         destruction_status = psa_destroy_key( handshake->ecdh_psa_privkey );
@@ -4104,7 +4106,7 @@ static int ssl_parse_client_key_exchange( mbedtls_ssl_context *ssl )
 
         /* Write the ECDH computation length before the ECDH computation */
         MBEDTLS_PUT_UINT16_BE( zlen, psm, 0 );
-        psm += 2 + zlen;
+        psm += zlen_size + zlen;
 
         /* opaque psk<0..2^16-1>; */
         if( psm_end - psm < 2 )

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -4112,13 +4112,11 @@ static int ssl_parse_client_key_exchange( mbedtls_ssl_context *ssl )
 
         if( mbedtls_ssl_get_psk( ssl, &psk, &psk_len )
                 == MBEDTLS_ERR_SSL_PRIVATE_KEY_REQUIRED )
-        {
             /*
              * This should never happen because the existence of a PSK is always
              * checked before calling this function
              */
             return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
-        }
 
         /* Write the PSK length as uint16 */
         MBEDTLS_PUT_UINT16_BE( psk_len, psm, 0 );

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -4096,8 +4096,10 @@ static int ssl_parse_client_key_exchange( mbedtls_ssl_context *ssl )
         destruction_status = psa_destroy_key( handshake->ecdh_psa_privkey );
         handshake->ecdh_psa_privkey = MBEDTLS_SVC_KEY_ID_INIT;
 
-        if( status != PSA_SUCCESS || destruction_status != PSA_SUCCESS )
-            return( MBEDTLS_ERR_SSL_HW_ACCEL_FAILED );
+        if( status != PSA_SUCCESS )
+            return( psa_ssl_status_to_mbedtls( status ) );
+        else if( destruction_status != PSA_SUCCESS )
+            return( psa_ssl_status_to_mbedtls( destruction_status ) );
 
         /* Write the ECDH computation length before the ECDH computation */
         MBEDTLS_PUT_UINT16_BE( zlen, psm, 0 );

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -4075,11 +4075,11 @@ static int ssl_parse_client_key_exchange( mbedtls_ssl_context *ssl )
         p += ecpoint_len;
 
         /* As RFC 5489 section 2, the premaster secret is formed as follows:
-￼         * - a uint16 containing the length (in octets) of the ECDH computation
-￼         * - the octet string produced by the ECDH computation
-￼         * - a uint16 containing the length (in octets) of the PSK
-￼         * - the PSK itself
-￼         */
+         * - a uint16 containing the length (in octets) of the ECDH computation
+         * - the octet string produced by the ECDH computation
+         * - a uint16 containing the length (in octets) of the PSK
+         * - the PSK itself
+         */
         unsigned char *psm = ssl->handshake->premaster;
         const unsigned char* const psm_end =
                     psm + sizeof( ssl->handshake->premaster );

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -4046,6 +4046,10 @@ static int ssl_parse_client_key_exchange( mbedtls_ssl_context *ssl )
         psa_status_t destruction_status = PSA_ERROR_CORRUPTION_DETECTED;
         uint8_t ecpoint_len;
 
+        /* Opaque PSKs are currently only supported for PSK-only. */
+        if( ssl_use_opaque_psk( ssl ) == 1 )
+            return( MBEDTLS_ERR_SSL_FEATURE_UNAVAILABLE );
+
         mbedtls_ssl_handshake_params *handshake = ssl->handshake;
 
         if( ( ret = ssl_parse_client_psk_identity( ssl, &p, end ) ) != 0 )

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -4115,10 +4115,6 @@ static int ssl_parse_client_key_exchange( mbedtls_ssl_context *ssl )
         MBEDTLS_PUT_UINT16_BE( zlen, psm, 0 );
         psm += zlen_size + zlen;
 
-        /* opaque psk<0..2^16-1>; */
-        if( psm_end - psm < 2 )
-            return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
-
         const unsigned char *psk = NULL;
         size_t psk_len = 0;
 
@@ -4130,12 +4126,13 @@ static int ssl_parse_client_key_exchange( mbedtls_ssl_context *ssl )
              */
             return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
 
+        /* opaque psk<0..2^16-1>; */
+        if( (size_t)( psm_end - psm ) < ( 2 + psk_len ) )
+            return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
+
         /* Write the PSK length as uint16 */
         MBEDTLS_PUT_UINT16_BE( psk_len, psm, 0 );
         psm += 2;
-
-        if( psm_end < psm || (size_t)( psm_end - psm ) < psk_len )
-            return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
 
         /* Write the PSK itself */
         memcpy( psm, psk, psk_len );

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -4077,7 +4077,7 @@ static int ssl_parse_client_key_exchange( mbedtls_ssl_context *ssl )
         /* The ECDH secret is the premaster secret used for key derivation. */
         unsigned char *psm = ssl->handshake->premaster;
         unsigned char *psm_end = psm + sizeof( ssl->handshake->premaster );
-        size_t zlen;
+        size_t zlen = 0;
 
         /* Compute ECDH shared secret. */
         status = psa_raw_key_agreement( PSA_ALG_ECDH,


### PR DESCRIPTION
## Description
This task is to implement (both client-side and server-side) the ECDHE part of the ECDHE-PSK key exchange in (D)TLS 1.2 based on PSA when `MBEDTLS_USE_PSA_CRYPTO` is defined.

Resolves: #5318

## Status
**IN DEVELOPMENT**

## Requires Backporting
NO 

## Migrations
NO

## Additional comments
Depends on #5613 to be merged first, will need to be rebased on top

## Todos
- [x] Implementation
- [x] Tests


## Steps to test or reproduce
tests/ssl-opt.sh must run clean
