### PR TITLE
Document that MBEDTLS_SSL_KEEP_PEER_CERTIFICATE is required by MBEDTLS_SSL_PROTO_TLS1_3

### DIFF
--- a/ChangeLog.d/tls13_and_keep_certificates.txt
+++ b/ChangeLog.d/tls13_and_keep_certificates.txt
@@ -1,0 +1,4 @@
+Bugfix
+   * Fix check_config.h to check that we have MBEDTLS_SSL_KEEP_PEER_CERTIFICATE
+     when MBEDTLS_SSL_PROTO_TLS1_3 is specified, and make this explicit in the
+     documentation. Fixes #5610.

--- a/ChangeLog.d/tls13_and_keep_certificates.txt
+++ b/ChangeLog.d/tls13_and_keep_certificates.txt
@@ -1,4 +1,4 @@
 Bugfix
    * Fix check_config.h to check that we have MBEDTLS_SSL_KEEP_PEER_CERTIFICATE
-     when MBEDTLS_SSL_PROTO_TLS1_3 is specified, and make this explicit in the
-     documentation. Fixes #5610.
+     when MBEDTLS_SSL_PROTO_TLS1_3 is specified, and make this and other
+     dependencies explicit in the documentation. Fixes #5610.

--- a/docs/architecture/tls13-support.md
+++ b/docs/architecture/tls13-support.md
@@ -136,10 +136,16 @@ MVP definition
 
 - Compatibility with existing SSL/TLS build options:
 
-  The TLS 1.3 MVP is compatible with all TLS 1.2 configuration options in the
-  sense that when enabling the TLS 1.3 MVP in the library there is no need to
-  modify the configuration for TLS 1.2. The MBEDTLS_USE_PSA_CRYPTO configuration
-  option is an exception though, the TLS 1.3 MVP is not compatible with it.
+  The TLS 1.3 MVP is compatible with nearly all TLS 1.2 configuration options
+  in the sense that when enabling the TLS 1.3 MVP in the library there is rarely
+  any need to modify the configuration from that used for TLS 1.2.
+
+  The two exceptions to this are:
+
+  - The TLS 1.3 MVP is not compatible with MBEDTLS_USE_PSA_CRYPTO, so this option
+    must be disabled.
+  - The TLS 1.3 MVP requires MBEDTLS_SSL_KEEP_PEER_CERTIFICATE, so this option
+    must be enabled.
 
   Mbed TLS SSL/TLS related features are not supported or not applicable to the
   TLS 1.3 MVP:
@@ -152,12 +158,11 @@ MVP definition
   | MBEDTLS_SSL_DEBUG_ALL                    | no      |
   | MBEDTLS_SSL_ENCRYPT_THEN_MAC             | n/a     |
   | MBEDTLS_SSL_EXTENDED_MASTER_SECRET       | n/a     |
-  | MBEDTLS_SSL_KEEP_PEER_CERTIFICATE        | no      |
+  | MBEDTLS_SSL_KEEP_PEER_CERTIFICATE        | no (1)  |
   | MBEDTLS_SSL_RENEGOTIATION                | n/a     |
   | MBEDTLS_SSL_MAX_FRAGMENT_LENGTH          | no      |
   |                                          |         |
   | MBEDTLS_SSL_SESSION_TICKETS              | no      |
-  | MBEDTLS_SSL_EXPORT_KEYS                  | no (1)  |
   | MBEDTLS_SSL_SERVER_NAME_INDICATION       | no      |
   | MBEDTLS_SSL_VARIABLE_BUFFER_LENGTH       | no      |
   |                                          |         |
@@ -178,7 +183,7 @@ MVP definition
   |                                          |         |
   | MBEDTLS_USE_PSA_CRYPTO                   | no      |
 
-  (1) Some support has already been upstreamed but it is incomplete.
+  (1) This option must remain in its default state of enabled.
   (2) Key exchange configuration options for TLS 1.3 will likely to be
       organized around the notion of key exchange mode along the line
       of the MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_NONE/PSK/PSK_EPHEMERAL/EPHEMERAL

--- a/docs/architecture/tls13-support.md
+++ b/docs/architecture/tls13-support.md
@@ -140,12 +140,12 @@ MVP definition
   in the sense that when enabling the TLS 1.3 MVP in the library there is rarely
   any need to modify the configuration from that used for TLS 1.2.
 
-  The two exceptions to this are:
+  The exceptions to this are:
 
   - The TLS 1.3 MVP is not compatible with MBEDTLS_USE_PSA_CRYPTO, so this option
     must be disabled.
-  - The TLS 1.3 MVP requires MBEDTLS_SSL_KEEP_PEER_CERTIFICATE, so this option
-    must be enabled.
+  - The TLS 1.3 MVP requires MBEDTLS_PSA_CRYPTO_C and MBEDTLS_SSL_KEEP_PEER_CERTIFICATE,
+    so these options must be enabled.
 
   Mbed TLS SSL/TLS related features are not supported or not applicable to the
   TLS 1.3 MVP:
@@ -181,9 +181,10 @@ MVP definition
   | MBEDTLS_KEY_EXCHANGE_ECDH_RSA_ENABLED    | n/a     |
   | MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED     | n/a     |
   |                                          |         |
+  | MBEDTLS_PSA_CRYPTO_C                     | no (1)  |
   | MBEDTLS_USE_PSA_CRYPTO                   | no      |
 
-  (1) This option must remain in its default state of enabled.
+  (1) These options must remain in their default state of enabled.
   (2) Key exchange configuration options for TLS 1.3 will likely to be
       organized around the notion of key exchange mode along the line
       of the MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_NONE/PSK/PSK_EPHEMERAL/EPHEMERAL

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -729,6 +729,13 @@
 #error "MBEDTLS_SSL_PROTO_TLS1_3 defined, but not all prerequisites"
 #endif
 
+/*
+ * The current implementation of TLS 1.3 requires MBEDTLS_SSL_KEEP_PEER_CERTIFICATE.
+ */
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3) && !defined(MBEDTLS_SSL_KEEP_PEER_CERTIFICATE)
+#error "MBEDTLS_SSL_PROTO_TLS1_3 defined without MBEDTLS_SSL_KEEP_PEER_CERTIFICATE"
+#endif
+
 #if defined(MBEDTLS_SSL_PROTO_TLS1_2) &&                                    \
     !(defined(MBEDTLS_KEY_EXCHANGE_RSA_ENABLED) ||                          \
       defined(MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED) ||                      \

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -1444,6 +1444,8 @@
  *       still ensure that certificates do not change during renegotiation,
  *       for example by keeping a hash of the peer's certificate.
  *
+ * \note This option is required if MBEDTLS_SSL_PROTO_TLS1_3 is set.
+ *
  * Comment this macro to disable storing the peer's certificate
  * after the handshake.
  */
@@ -1501,6 +1503,8 @@
  *       pre-shared keys are not supported.
  *       See docs/architecture/tls13-support.md for a description of the TLS
  *       1.3 support that this option enables.
+ *
+ * Requires: MBEDTLS_SSL_KEEP_PEER_CERTIFICATE
  *
  * Uncomment this macro to enable the support for TLS 1.3.
  *


### PR DESCRIPTION
And have check_config.h enforce it

Fixes #5610 

## Status
**READY**

## Requires Backporting

NO - TLS 1.3 doesn't get backported to 2.x