### PR TITLE
Introduce mbedtls_ssl_hs_cb_t typedef

### DIFF
--- a/ChangeLog.d/mbedtls_ssl_hs_cb_t.txt
+++ b/ChangeLog.d/mbedtls_ssl_hs_cb_t.txt
@@ -1,0 +1,4 @@
+Features
+   * Introduce mbedtls_ssl_hs_cb_t typedef for use with
+     mbedtls_ssl_conf_cert_cb() and perhaps future callbacks
+     during TLS handshake.

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1313,14 +1313,6 @@ void mbedtls_ssl_set_timer_cb( mbedtls_ssl_context *ssl,
 }
 
 #if defined(MBEDTLS_SSL_SRV_C)
-void mbedtls_ssl_conf_cert_cb( mbedtls_ssl_config *conf,
-                               int (*f_cert_cb)(mbedtls_ssl_context *) )
-{
-    conf->f_cert_cb = f_cert_cb;
-}
-#endif /* MBEDTLS_SSL_SRV_C */
-
-#if defined(MBEDTLS_SSL_SRV_C)
 void mbedtls_ssl_conf_session_cache( mbedtls_ssl_config *conf,
                                      void *p_cache,
                                      mbedtls_ssl_cache_get_t *f_get_cache,


### PR DESCRIPTION
## Description
* Introduce mbedtls_ssl_hs_cb_t typedef
* Inline func for mbedtls_ssl_conf_cert_cb()

Follow-up PR from discussion with @mpg in #5454.
https://github.com/ARMmbed/mbedtls/pull/5454#discussion_r823488484
https://github.com/ARMmbed/mbedtls/pull/5454#discussion_r823549312
This PR aims to slightly improve the interface.  This PR is lower priority as this is not a fix to anything.

Related question: should all *new* interfaces which are simple getter/setter functions be inlined in the header when struct definition is visible, even if the inline func uses MBEDTLS_PRIVATE?  (e.g. setter/getter for `mbedtls_ssl_config` and `mbedtls_ssl_context` are available, but `struct mbedtls_ssl_handshake_params` (library/ssl_misc.h) is not visible.)  Note: This should not be done for older interfaces (until possibly after a major version bump) since compiled application code might hold references to the symbols.

## Status
**READY**

## Requires Backporting
NO  

## Migrations
NO

## Todos
- [x] Documentation
- [x] Changelog updated