### PR TITLE
TLS ECDH 3b: server-side static ECDH (1.2)

### DIFF
--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -923,7 +923,8 @@ int mbedtls_pk_load_file( const char *path, unsigned char **buf, size_t *n );
  *                  change or be removed at any time without notice.
  *
  * \note            Only ECDSA keys are supported so far. Signing with the
- *                  specified hash is the only allowed use of that key.
+ *                  specified hash & ECDH key agreement derivation operation
+ *                  are the only allowed use of that key.
  *
  * \param pk        Input: the EC key to import to a PSA key.
  *                  Output: a PK context wrapping that PSA key.

--- a/library/pk.c
+++ b/library/pk.c
@@ -735,8 +735,10 @@ int mbedtls_pk_wrap_as_opaque( mbedtls_pk_context *pk,
     /* prepare the key attributes */
     psa_set_key_type( &attributes, key_type );
     psa_set_key_bits( &attributes, bits );
-    psa_set_key_usage_flags( &attributes, PSA_KEY_USAGE_SIGN_HASH );
+    psa_set_key_usage_flags( &attributes, PSA_KEY_USAGE_SIGN_HASH |
+                                          PSA_KEY_USAGE_DERIVE);
     psa_set_key_algorithm( &attributes, PSA_ALG_ECDSA(hash_alg) );
+    psa_set_key_enrollment_algorithm( &attributes, PSA_ALG_ECDH );
 
     /* import private key into PSA */
     if( PSA_SUCCESS != psa_import_key( &attributes, d, d_len, key ) )

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -632,6 +632,7 @@ struct mbedtls_ssl_handshake_params
     psa_key_type_t ecdh_psa_type;
     uint16_t ecdh_bits;
     mbedtls_svc_key_id_t ecdh_psa_privkey;
+    uint8_t ecdh_psa_shared_key;
     unsigned char ecdh_psa_peerkey[MBEDTLS_PSA_MAX_EC_PUBKEY_LENGTH];
     size_t ecdh_psa_peerkey_len;
 #endif /* MBEDTLS_USE_PSA_CRYPTO || MBEDTLS_SSL_PROTO_TLS1_3 */

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -630,7 +630,7 @@ struct mbedtls_ssl_handshake_params
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO) || defined(MBEDTLS_SSL_PROTO_TLS1_3)
     psa_key_type_t ecdh_psa_type;
-    uint16_t ecdh_bits;
+    size_t ecdh_bits;
     mbedtls_svc_key_id_t ecdh_psa_privkey;
     uint8_t ecdh_psa_shared_key;
     unsigned char ecdh_psa_peerkey[MBEDTLS_PSA_MAX_EC_PUBKEY_LENGTH];

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -632,7 +632,7 @@ struct mbedtls_ssl_handshake_params
     psa_key_type_t ecdh_psa_type;
     size_t ecdh_bits;
     mbedtls_svc_key_id_t ecdh_psa_privkey;
-    uint8_t ecdh_psa_shared_key;
+    uint8_t ecdh_psa_privkey_is_external;
     unsigned char ecdh_psa_peerkey[MBEDTLS_PSA_MAX_EC_PUBKEY_LENGTH];
     size_t ecdh_psa_peerkey_len;
 #endif /* MBEDTLS_USE_PSA_CRYPTO || MBEDTLS_SSL_PROTO_TLS1_3 */

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -3146,7 +3146,7 @@ void mbedtls_ssl_handshake_free( mbedtls_ssl_context *ssl )
 
 #if defined(MBEDTLS_ECDH_C) && \
     ( defined(MBEDTLS_USE_PSA_CRYPTO) || defined(MBEDTLS_SSL_PROTO_TLS1_3) )
-    if( handshake->ecdh_psa_shared_key == 0 )
+    if( handshake->ecdh_psa_privkey_is_external == 0 )
         psa_destroy_key( handshake->ecdh_psa_privkey );
 #endif /* MBEDTLS_ECDH_C && MBEDTLS_USE_PSA_CRYPTO */
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -3146,7 +3146,8 @@ void mbedtls_ssl_handshake_free( mbedtls_ssl_context *ssl )
 
 #if defined(MBEDTLS_ECDH_C) && \
     ( defined(MBEDTLS_USE_PSA_CRYPTO) || defined(MBEDTLS_SSL_PROTO_TLS1_3) )
-    psa_destroy_key( handshake->ecdh_psa_privkey );
+    if( handshake->ecdh_psa_shared_key == 0 )
+        psa_destroy_key( handshake->ecdh_psa_privkey );
 #endif /* MBEDTLS_ECDH_C && MBEDTLS_USE_PSA_CRYPTO */
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)

--- a/library/ssl_tls12_client.c
+++ b/library/ssl_tls12_client.c
@@ -2352,9 +2352,7 @@ static int ssl_parse_server_ecdh_params_psa( mbedtls_ssl_context *ssl,
     {
         return( MBEDTLS_ERR_SSL_HANDSHAKE_FAILURE );
     }
-    if( ecdh_bits > 0xffff )
-        return( MBEDTLS_ERR_SSL_ILLEGAL_PARAMETER );
-    handshake->ecdh_bits = (uint16_t) ecdh_bits;
+    handshake->ecdh_bits = ecdh_bits;
 
     /* Keep a copy of the peer's public key */
     ecpoint_len = *(*p)++;

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -2883,18 +2883,21 @@ static int ssl_get_ecdh_params_from_cert( mbedtls_ssl_context *ssl )
         ssl->handshake->ecdh_psa_privkey =
                 *( (mbedtls_svc_key_id_t*) pk->pk_ctx );
 
+        /* Key should not be destroyed in the TLS library */
+        ssl->handshake->ecdh_psa_privkey_is_external = 1;
+
         status = psa_get_key_attributes( ssl->handshake->ecdh_psa_privkey,
                                          &key_attributes );
         if( status != PSA_SUCCESS)
+        {
+            ssl->handshake->ecdh_psa_privkey = MBEDTLS_SVC_KEY_ID_INIT;
             return( psa_ssl_status_to_mbedtls( status ) );
+        }
 
         ssl->handshake->ecdh_psa_type = psa_get_key_type( &key_attributes );
         ssl->handshake->ecdh_bits = psa_get_key_bits( &key_attributes );
 
         psa_reset_key_attributes( &key_attributes );
-
-        /* Key should not be destroyed in the TLS library */
-        ssl->handshake->ecdh_psa_privkey_is_external = 1;
 
         ret = 0;
         break;

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -2914,7 +2914,7 @@ static int ssl_get_ecdh_params_from_cert( mbedtls_ssl_context *ssl )
     ret = 0;
 
 cleanup:
-    memset( buf, 0, sizeof( buf ) );
+    mbedtls_platform_zeroize( buf, sizeof( buf ) );
 
     return( ret );
 }

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -2886,7 +2886,7 @@ static int ssl_get_ecdh_params_from_cert( mbedtls_ssl_context *ssl )
         status = psa_get_key_attributes( ssl->handshake->ecdh_psa_privkey,
                                          &key_attributes );
         if( status != PSA_SUCCESS)
-            return( MBEDTLS_ERR_PK_BAD_INPUT_DATA );
+            return( psa_ssl_status_to_mbedtls( status ) );
 
         ssl->handshake->ecdh_psa_type = psa_get_key_type( &key_attributes );
         ssl->handshake->ecdh_bits = psa_get_key_bits( &key_attributes );

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -2861,7 +2861,8 @@ static int ssl_get_ecdh_params_from_cert( mbedtls_ssl_context *ssl )
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
-    unsigned char buf[MBEDTLS_ECP_MAX_BYTES];
+    unsigned char buf[
+        PSA_KEY_EXPORT_ECC_KEY_PAIR_MAX_SIZE(PSA_VENDOR_ECC_MAX_CURVE_BITS)];
     psa_key_attributes_t key_attributes;
     size_t ecdh_bits = 0;
     size_t key_len;

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -2893,7 +2893,7 @@ static int ssl_get_ecdh_params_from_cert( mbedtls_ssl_context *ssl )
 
         psa_reset_key_attributes( &key_attributes );
 
-        /* Key should no be destroyed in the TLS library */
+        /* Key should not be destroyed in the TLS library */
         ssl->handshake->ecdh_psa_shared_key = 1;
 
         ret = 0;

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -2897,7 +2897,7 @@ static int ssl_get_ecdh_params_from_cert( mbedtls_ssl_context *ssl )
             PSA_KEY_TYPE_ECC_KEY_PAIR( ssl->handshake->ecdh_psa_type ) );
     psa_set_key_bits( &key_attributes, ssl->handshake->ecdh_bits );
 
-    key_len = ( key->grp.pbits + 7 ) / 8;
+    key_len = PSA_BITS_TO_BYTES( key->grp.pbits );
     ret = mbedtls_ecp_write_key( key, buf, key_len );
     if( ret != 0 )
         goto cleanup;

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -2913,10 +2913,7 @@ static int ssl_get_ecdh_params_from_cert( mbedtls_ssl_context *ssl )
             return( MBEDTLS_ERR_SSL_HANDSHAKE_FAILURE );
         }
 
-        if( ecdh_bits > 0xffff )
-            return( MBEDTLS_ERR_SSL_ILLEGAL_PARAMETER );
-
-        ssl->handshake->ecdh_bits = (uint16_t) ecdh_bits;
+        ssl->handshake->ecdh_bits = ecdh_bits;
 
         key_attributes = psa_key_attributes_init();
         psa_set_key_usage_flags( &key_attributes, PSA_KEY_USAGE_DERIVE );
@@ -3186,12 +3183,12 @@ curve_matching_done:
             handshake->ecdh_psa_type = mbedtls_psa_parse_tls_ecc_group(
                         (*curve)->tls_id, &ecdh_bits );
 
-            if( handshake->ecdh_psa_type == 0 || ecdh_bits > 0xffff )
+            if( handshake->ecdh_psa_type == 0 )
             {
                 MBEDTLS_SSL_DEBUG_MSG( 1, ( "Invalid ecc group parse." ) );
                 return( MBEDTLS_ERR_SSL_ILLEGAL_PARAMETER );
             }
-            handshake->ecdh_bits = (uint16_t) ecdh_bits;
+            handshake->ecdh_bits = ecdh_bits;
 
             key_attributes = psa_key_attributes_init();
             psa_set_key_usage_flags( &key_attributes, PSA_KEY_USAGE_DERIVE );

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -3946,18 +3946,22 @@ static int ssl_parse_client_key_exchange( mbedtls_ssl_context *ssl )
         {
             ret = psa_ssl_status_to_mbedtls( status );
             MBEDTLS_SSL_DEBUG_RET( 1, "psa_raw_key_agreement", ret );
-            (void) psa_destroy_key( handshake->ecdh_psa_privkey );
+            if( handshake->ecdh_psa_shared_key == 0 )
+                (void) psa_destroy_key( handshake->ecdh_psa_privkey );
             handshake->ecdh_psa_privkey = MBEDTLS_SVC_KEY_ID_INIT;
             return( ret );
         }
 
-        status = psa_destroy_key( handshake->ecdh_psa_privkey );
-
-        if( status != PSA_SUCCESS )
+        if( handshake->ecdh_psa_shared_key == 0 )
         {
-            ret = psa_ssl_status_to_mbedtls( status );
-            MBEDTLS_SSL_DEBUG_RET( 1, "psa_destroy_key", ret );
-            return( ret );
+            status = psa_destroy_key( handshake->ecdh_psa_privkey );
+
+            if( status != PSA_SUCCESS )
+            {
+                ret = psa_ssl_status_to_mbedtls( status );
+                MBEDTLS_SSL_DEBUG_RET( 1, "psa_destroy_key", ret );
+                return( ret );
+            }
         }
         handshake->ecdh_psa_privkey = MBEDTLS_SVC_KEY_ID_INIT;
     }

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -2904,7 +2904,8 @@ static int ssl_get_ecdh_params_from_cert( mbedtls_ssl_context *ssl )
 
     status = psa_import_key( &key_attributes, buf, key_len,
                              &ssl->handshake->ecdh_psa_privkey );
-    if( status != PSA_SUCCESS ) {
+    if( status != PSA_SUCCESS )
+    {
         ret = psa_ssl_status_to_mbedtls( status );
         goto cleanup;
     }

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -2894,7 +2894,7 @@ static int ssl_get_ecdh_params_from_cert( mbedtls_ssl_context *ssl )
         psa_reset_key_attributes( &key_attributes );
 
         /* Key should not be destroyed in the TLS library */
-        ssl->handshake->ecdh_psa_shared_key = 1;
+        ssl->handshake->ecdh_psa_privkey_is_external = 1;
 
         ret = 0;
         break;
@@ -3974,13 +3974,13 @@ static int ssl_parse_client_key_exchange( mbedtls_ssl_context *ssl )
         {
             ret = psa_ssl_status_to_mbedtls( status );
             MBEDTLS_SSL_DEBUG_RET( 1, "psa_raw_key_agreement", ret );
-            if( handshake->ecdh_psa_shared_key == 0 )
+            if( handshake->ecdh_psa_privkey_is_external == 0 )
                 (void) psa_destroy_key( handshake->ecdh_psa_privkey );
             handshake->ecdh_psa_privkey = MBEDTLS_SVC_KEY_ID_INIT;
             return( ret );
         }
 
-        if( handshake->ecdh_psa_shared_key == 0 )
+        if( handshake->ecdh_psa_privkey_is_external == 0 )
         {
             status = psa_destroy_key( handshake->ecdh_psa_privkey );
 

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -288,9 +288,7 @@ static int ssl_tls13_generate_and_write_ecdh_key_exchange(
         mbedtls_psa_parse_tls_ecc_group( named_group, &ecdh_bits ) ) == 0 )
             return( MBEDTLS_ERR_SSL_HANDSHAKE_FAILURE );
 
-    if( ecdh_bits > 0xffff )
-        return( MBEDTLS_ERR_SSL_ILLEGAL_PARAMETER );
-    ssl->handshake->ecdh_bits = (uint16_t) ecdh_bits;
+    ssl->handshake->ecdh_bits = ecdh_bits;
 
     key_attributes = psa_key_attributes_init();
     psa_set_key_usage_flags( &key_attributes, PSA_KEY_USAGE_DERIVE );

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -1589,7 +1589,8 @@ requires_config_enabled MBEDTLS_X509_CRT_PARSE_C
 requires_config_enabled MBEDTLS_ECDSA_C
 requires_config_enabled MBEDTLS_SHA256_C
 run_test    "Opaque key for server authentication (ECDH-)" \
-            "$P_SRV auth_mode=required key_opaque=1 crt_file=data_files/server5.ku-ka.crt \
+            "$P_SRV force_version=tls12 auth_mode=required key_opaque=1\
+             crt_file=data_files/server5.ku-ka.crt\
              key_file=data_files/server5.key" \
             "$P_CLI" \
             0 \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -1583,6 +1583,23 @@ run_test    "Opaque key for server authentication" \
             -S "error" \
             -C "error"
 
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
+requires_config_enabled MBEDTLS_X509_CRT_PARSE_C
+requires_config_enabled MBEDTLS_ECDSA_C
+requires_config_enabled MBEDTLS_SHA256_C
+run_test    "Opaque key for server authentication (ECDH-)" \
+            "$P_SRV auth_mode=required key_opaque=1 crt_file=data_files/server5.ku-ka.crt \
+             key_file=data_files/server5.key" \
+            "$P_CLI" \
+            0 \
+            -c "Verifying peer X.509 certificate... ok" \
+            -c "Ciphersuite is TLS-ECDH-" \
+            -s "key types: Opaque, none" \
+            -s "Ciphersuite is TLS-ECDH-" \
+            -S "error" \
+            -C "error"
+
 # Test using an opaque private key for client/server authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_USE_PSA_CRYPTO


### PR DESCRIPTION
## Description
This task is to implement server-side the ECDH part of the ECDH-ECDSA and ECDH-RSA key exchange(s) in (D)TLS 1.2 based on PSA when `MBEDTLS_USE_PSA_CRYPTO` is defined.

Resolves: #5320 

## Status
**READY**

## Requires Backporting
NO 

## Migrations
NO

## Additional comments
~Depends on #5613 to be merged first, will need to be rebased on top~ done

## Todos
- [x] Implementation
- [x] Tests

## Steps to test or reproduce
tests/ssl-opt.sh must run clean
