### PR TITLE
Accessors to own CID within mbedtls_ssl_context

### DIFF
--- a/ChangeLog.d/add_own_cid_accessors
+++ b/ChangeLog.d/add_own_cid_accessors
@@ -1,0 +1,4 @@
+Features
+   * Add the function mbedtls_ssl_get_own_cid() to access our own connection id
+     within mbedtls_ssl_context, as requested in #5184
+

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -1317,8 +1317,9 @@
  * in the underlying transport.
  *
  * Setting this option enables the SSL APIs `mbedtls_ssl_set_cid()`,
- * `mbedtls_ssl_get_peer_cid()` and `mbedtls_ssl_conf_cid()`.
- * See the corresponding documentation for more information.
+ * mbedtls_ssl_get_own_cid()`, `mbedtls_ssl_get_peer_cid()` and
+ * `mbedtls_ssl_conf_cid()`. See the corresponding documentation for
+ * more information.
  *
  * \warning The Connection ID extension is still in draft state.
  *          We make no stability promises for the availability

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -2024,6 +2024,40 @@ int mbedtls_ssl_set_cid( mbedtls_ssl_context *ssl,
                          size_t own_cid_len );
 
 /**
+ * \brief              Get information about our request for usage of the CID
+ *                     extension in the current connection.
+ *
+ * \param ssl          The SSL context to query.
+ * \param enabled      The address at which to store whether the CID extension
+ *                     is requested to be used or not. If the CID is
+ *                     requested, `*enabled` is set to
+ *                     MBEDTLS_SSL_CID_ENABLED; otherwise, it is set to
+ *                     MBEDTLS_SSL_CID_DISABLED.
+ * \param own_cid      The address of the buffer in which to store our own
+ *                     CID (if the CID extension is requested). This may be
+ *                     \c NULL in case the value of our CID isn't needed. If
+ *                     it is not \c NULL, \p own_cid_len must not be \c NULL.
+ * \param own_cid_len  The address at which to store the size of our own CID
+ *                     (if the CID extension is requested). This is also the
+ *                     number of Bytes in \p own_cid that have been written.
+ *                     This may be \c NULL in case the length of our own CID
+ *                     isn't needed. If it is \c NULL, \p own_cid must be
+ *                     \c NULL, too.
+ *
+ *\note                If we are requesting an empty CID this function sets
+ *                     `*enabled` to #MBEDTLS_SSL_CID_DISABLED (the rationale
+ *                     for this is that the resulting outcome is the
+ *                     same as if the CID extensions wasn't requested).
+ *
+ * \return            \c 0 on success.
+ * \return            A negative error code on failure.
+ */
+int mbedtls_ssl_get_own_cid( mbedtls_ssl_context *ssl,
+                            int *enabled,
+                            unsigned char own_cid[MBEDTLS_SSL_CID_OUT_LEN_MAX],
+                            size_t *own_cid_len );
+
+/**
  * \brief              Get information about the use of the CID extension
  *                     in the current connection.
  *

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -112,6 +112,34 @@ int mbedtls_ssl_set_cid( mbedtls_ssl_context *ssl,
     return( 0 );
 }
 
+int mbedtls_ssl_get_own_cid( mbedtls_ssl_context *ssl,
+                              int *enabled,
+                              unsigned char own_cid[MBEDTLS_SSL_CID_OUT_LEN_MAX],
+                              size_t *own_cid_len )
+{
+    *enabled = MBEDTLS_SSL_CID_DISABLED;
+
+    if( ssl->conf->transport != MBEDTLS_SSL_TRANSPORT_DATAGRAM )
+        return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
+
+    /* We report MBEDTLS_SSL_CID_DISABLED in case the CID length is
+     * zero as this is indistinguishable from not requesting to use
+     * the CID extension. */
+    if( ssl->own_cid_len == 0 || ssl->negotiate_cid == MBEDTLS_SSL_CID_DISABLED )
+        return( 0 );
+
+    if( own_cid_len != NULL )
+    {
+        *own_cid_len = ssl->own_cid_len;
+        if( own_cid != NULL )
+            memcpy( own_cid, ssl->own_cid, ssl->own_cid_len );
+    }
+
+    *enabled = MBEDTLS_SSL_CID_ENABLED;
+
+    return( 0 );
+}
+
 int mbedtls_ssl_get_peer_cid( mbedtls_ssl_context *ssl,
                      int *enabled,
                      unsigned char peer_cid[ MBEDTLS_SSL_CID_OUT_LEN_MAX ],

--- a/tests/suites/test_suite_ssl.data
+++ b/tests/suites/test_suite_ssl.data
@@ -3213,3 +3213,6 @@ conf_group:
 
 Test accessor into timing_delay_context
 timing_final_delay_accessor
+
+Sanity test cid functions
+cid_sanity:

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -5452,3 +5452,86 @@ void timing_final_delay_accessor( )
     TEST_ASSERT( mbedtls_timing_get_final_delay( &delay_context ) == 100 );
 }
 /* END_CASE */
+
+/* BEGIN_CASE depends_on:MBEDTLS_SSL_DTLS_CONNECTION_ID */
+void cid_sanity( )
+{
+    mbedtls_ssl_context ssl;
+    mbedtls_ssl_config conf;
+
+    unsigned char own_cid[MBEDTLS_SSL_CID_IN_LEN_MAX];
+    unsigned char test_cid[MBEDTLS_SSL_CID_IN_LEN_MAX];
+    int cid_enabled;
+    size_t own_cid_len;
+
+    mbedtls_test_rnd_std_rand( NULL, own_cid, sizeof( own_cid ) );
+
+    mbedtls_ssl_init( &ssl );
+    mbedtls_ssl_config_init( &conf );
+
+    TEST_ASSERT( mbedtls_ssl_config_defaults( &conf,
+                                              MBEDTLS_SSL_IS_CLIENT,
+                                              MBEDTLS_SSL_TRANSPORT_STREAM,
+                                              MBEDTLS_SSL_PRESET_DEFAULT )
+                 == 0 );
+
+    TEST_ASSERT( mbedtls_ssl_setup( &ssl, &conf ) == 0 );
+
+    /* Can't use CID functions with stream transport. */
+    TEST_ASSERT( mbedtls_ssl_set_cid( &ssl, MBEDTLS_SSL_CID_ENABLED, own_cid,
+                                      sizeof( own_cid ) )
+                 == MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
+
+    TEST_ASSERT( mbedtls_ssl_get_own_cid( &ssl, &cid_enabled, test_cid,
+                                          &own_cid_len )
+                 == MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
+
+    TEST_ASSERT( mbedtls_ssl_config_defaults( &conf,
+                                              MBEDTLS_SSL_IS_CLIENT,
+                                              MBEDTLS_SSL_TRANSPORT_DATAGRAM,
+                                              MBEDTLS_SSL_PRESET_DEFAULT )
+                 == 0 );
+
+    /* Attempt to set config cid size too big. */
+    TEST_ASSERT( mbedtls_ssl_conf_cid( &conf, MBEDTLS_SSL_CID_IN_LEN_MAX + 1,
+                                       MBEDTLS_SSL_UNEXPECTED_CID_IGNORE )
+                 == MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
+
+    TEST_ASSERT( mbedtls_ssl_conf_cid( &conf, sizeof( own_cid ),
+                                       MBEDTLS_SSL_UNEXPECTED_CID_IGNORE )
+                 == 0 );
+
+    /* Attempt to set CID length not matching config. */
+    TEST_ASSERT( mbedtls_ssl_set_cid( &ssl, MBEDTLS_SSL_CID_ENABLED, own_cid,
+                                      MBEDTLS_SSL_CID_IN_LEN_MAX - 1 )
+                 == MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
+
+    TEST_ASSERT( mbedtls_ssl_set_cid( &ssl, MBEDTLS_SSL_CID_ENABLED, own_cid,
+                                      sizeof( own_cid ) )
+                 == 0 );
+
+    /* Test we get back what we put in. */
+    TEST_ASSERT( mbedtls_ssl_get_own_cid( &ssl, &cid_enabled, test_cid,
+                                          &own_cid_len )
+                 == 0 );
+
+    TEST_EQUAL( cid_enabled, MBEDTLS_SSL_CID_ENABLED );
+    ASSERT_COMPARE( own_cid, own_cid_len, test_cid, own_cid_len );
+
+    /* Test disabling works. */
+    TEST_ASSERT( mbedtls_ssl_set_cid( &ssl, MBEDTLS_SSL_CID_DISABLED, NULL,
+                                      0 )
+                 == 0 );
+
+    TEST_ASSERT( mbedtls_ssl_get_own_cid( &ssl, &cid_enabled, test_cid,
+                                          &own_cid_len )
+                 == 0 );
+
+    TEST_EQUAL( cid_enabled, MBEDTLS_SSL_CID_DISABLED );
+
+    mbedtls_ssl_free( &ssl );
+    mbedtls_ssl_config_free( &conf );
+}
+/* END_CASE */
+
+


### PR DESCRIPTION
## Description
Add accessors to own CID within mbedtls_ssl_context, as per request in #5184

Add sanity tests for all of the own CID set / get/config functions.

## Status
**READY**

## Requires Backporting
NO  

## Migrations
 NO

## Todos
- [x] Tests
- [x] Changelog updated

## Steps to test or reproduce
test_suite_ssl should run clean
