### PR TITLE
Multithreaded access to PSA slots - stateful approach

### DIFF
--- a/docs/architecture/psa-thread-safety.md
+++ b/docs/architecture/psa-thread-safety.md
@@ -56,7 +56,50 @@ The following functions modify a slot's usage state:
 * `psa_close_key`: reads `slot->lock_count`; calls `psa_get_and_lock_key_slot_in_memory`, `psa_wipe_key_slot` and `psa_unlock_key_slot`.
 * `psa_purge_key`: reads `slot->lock_count`; calls `psa_get_and_lock_key_slot_in_memory`, `psa_wipe_key_slot` and `psa_unlock_key_slot`.
 
-TODO: modification of `slot->attr.id`, `slot->attr.type`.
+**slot->attr access:**
+`psa_crypto_core.h`:
+* `psa_key_slot_set_flags` - writes to attr.flags
+* `psa_key_slot_set_bits_in_flags` - writes to attr.flags
+* `psa_key_slot_clear_bits` - writes to attr.flags
+* `psa_is_key_slot_occupied` - reads attr.type
+* `psa_key_slot_get_flags` - reads attr.flags
+
+`psa_crypto_slot_management.c`:
+* `psa_get_and_lock_key_slot_in_memory` - reads attr.id
+* `psa_get_empty_key_slot` - reads attr.lifetime
+* `psa_load_persistent_key_into_slot` - passes attr pointer to psa_load_persistent_key
+* `psa_load_persistent_key` - reads attr.id and passes pointer to psa_parse_key_data_from_storage
+* `psa_parse_key_data_from_storage` - writes to many attributes
+* `psa_get_and_lock_key_slot` - writes to attr.id, attr.lifetime, and attr.policy.usage
+* `psa_purge_key` - reads attr.lifetime, calls psa_wipe_key_slot
+* `mbedtls_psa_get_stats` - reads attr.lifetime, attr.id
+
+`psa_crypto.c`:
+* `psa_get_and_lock_key_slot_with_policy` - reads attr.type, attr.policy.
+* `psa_get_and_lock_transparent_key_slot_with_policy` - reads attr.lifetime
+* `psa_destroy_key` - reads attr.lifetime, attr.id
+* `psa_get_key_attributes` - copies all publicly available attributes of a key
+* `psa_export_key` - copies attributes
+* `psa_export_public_key` - reads attr.type, copies attributes
+* `psa_start_key_creation` - writes to the whole attr structure 
+* `psa_validate_optional_attributes` - reads attr.type, attr.bits
+* `psa_import_key` - reads attr.bits
+* `psa_copy_key` - reads attr.bits, attr.type, attr.lifetime, attr.policy
+* `psa_mac_setup` - copies whole attr structure
+* `psa_mac_compute_internal` - copies whole attr structure
+* `psa_verify_internal` - copies whole attr structure
+* `psa_sign_internal` - copies whole attr structure, reads attr.type
+* `psa_assymmetric_encrypt` - reads attr.type
+* `psa_assymetric_decrypt` - reads attr.type
+* `psa_cipher_setup` - copies whole attr structure, reads attr.type
+* `psa_cipher_encrypt` - copies whole attr structure, reads attr.type
+* `psa_cipher_decrypt` - copies whole attr structure, reads attr.type
+* `psa_aead_encrypt` - copies whole attr structure
+* `psa_aead_decrypt` - copies whole attr structure
+* `psa_aead_setup` - copies whole attr structure
+* `psa_generate_derived_key_internal` - reads attr.type, writes to and reads from attr.bits, copies whole attr structure
+* `psa_key_derivation_input_key` - reads attr.type
+* `psa_key_agreement_raw_internal` - reads attr.type and attr.bits
 
 TODO: change `psa_is_key_slot_occupied` to checking the id?
 
@@ -67,6 +110,34 @@ Other than what is used to determine the [“key slot state”](#key-slot-state)
 * Modification during key creation (between `psa_start_key_creation` and `psa_finish_key_creation` or `psa_fail_key_creation`).
 * Destruction in `psa_wipe_key_slot`.
 * Read in many functions, between calls to `psa_lock_key_slot` and `psa_unlock_key_slot`.
+
+**slot->key access:** 
+* `psa_allocate_buffer_to_slot` - allocates key.data, sets key.bytes;
+* `psa_copy_key_material_into_slot` - writes to key.data
+* `psa_remove_key_data_from_memory` - writes and reads to/from key data
+* `psa_get_key_attributes` - reads from key data
+* `psa_export_key` - passes key data to psa_driver_wrapper_export_key
+* `psa_export_public_key` - passes key data to psa_driver_wrapper_export_public_key
+* `psa_finish_key_creation` - passes key data to psa_save_persistent_key
+* `psa_validate_optional_attributes` - passes key data and bytes to mbedtls_psa_rsa_load_representation
+* `psa_import_key` - passes key data to psa_driver_wrapper_import_key
+* `psa_copy_key` - passes key data to psa_driver_wrapper_copy_key, psa_copy_key_material_into_slot
+* `psa_mac_setup` - passes key data to psa_driver_wrapper_mac_sign_setup, psa_driver_wrapper_mac_verify_setup
+* `psa_mac_compute_internal` - passes key data to psa_driver_wrapper_mac_compute
+* `psa_sign_internal` - passes key data to psa_driver_wrapper_sign_message, psa_driver_wrapper_sign_hash
+* `psa_verify_internal` - passes key data to psa_driver_wrapper_verify_message, psa_driver_wrapper_verify_hash
+* `psa_asymmetric_encrypt` - passes key data to mbedtls_psa_rsa_load_representation
+* `psa_asymmetric_decrypt` - passes key data to mbedtls_psa_rsa_load_representation
+* `psa_cipher_setup ` - passes key data to psa_driver_wrapper_cipher_encrypt_setup and psa_driver_wrapper_cipher_decrypt_setup
+* `psa_cipher_encrypt` - passes key data to psa_driver_wrapper_cipher_encrypt
+* `psa_cipher_decrypt` - passes key data to psa_driver_wrapper_cipher_decrypt
+* `psa_aead_encrypt` - passes key data to psa_driver_wrapper_aead_encrypt
+* `psa_aead_decrypt` - passes key data to psa_driver_wrapper_aead_decrypt
+* `psa_aead_setup` - passes key data to psa_driver_wrapper_aead_encrypt_setup and psa_driver_wrapper_aead_decrypt_setup
+* `psa_generate_derived_key_internal` - passes key data to psa_driver_wrapper_import_key
+* `psa_key_derivation_input_key` - passes key data to psa_key_derivation_input_internal
+* `psa_key_agreement_raw_internal` - passes key data to mbedtls_psa_ecp_load_representation
+* `psa_generate_key` - passes key data to psa_driver_wrapper_generate_key
 
 ### Random generator
 

--- a/docs/architecture/psa-thread-safety.md
+++ b/docs/architecture/psa-thread-safety.md
@@ -1,0 +1,130 @@
+Thread safety of the PSA key store
+==================================
+
+Analysis of the behavior of the PSA key store as of Mbed TLS 9202ba37b19d3ea25c8451fd8597fce69eaa6867.
+
+## Resources to protect
+
+### Global variables
+
+* `psa_crypto_slot_management::global_data.key_slots[i]`: see [“Key slots”](#key-slots).
+
+* `psa_crypto_slot_management::global_data.key_slots_initialized`:
+    * `psa_initialize_key_slots`: modification.
+    * `psa_wipe_all_key_slots`: modification.
+    * `psa_get_empty_key_slot`: read.
+    * `psa_get_and_lock_key_slot`: read.
+
+* `psa_crypto::global_data.rng`: depends on the RNG implementation. See [“Random generator”](#random-generator).
+    * `psa_generate_random`: query.
+    * `mbedtls_psa_crypto_configure_entropy_sources` (only if `MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG` is enabled): setup. Only called from `psa_crypto_init` via `mbedtls_psa_random_init`, or from test code.
+    * `mbedtls_psa_crypto_free`: deinit.
+    * `psa_crypto_init`: seed (via `mbedtls_psa_random_seed`); setup via `mbedtls_psa_crypto_configure_entropy_sources.
+
+* `psa_crypto::global_data.{initialized,rng_state}`: these are bit-fields and cannot be modified independently so they must be protected by the same mutex. The following functions access these fields:
+    * `mbedtls_psa_crypto_configure_entropy_sources` [`rng_state`] (only if `MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG` is enabled): read. Only called from `psa_crypto_init` via `mbedtls_psa_random_init`, or from test code.
+    * `mbedtls_psa_crypto_free`: modification.
+    * `psa_crypto_init`: modification.
+    * Many functions via `GUARD_MODULE_INITIALIZED`: read.
+
+### Key slots
+
+#### Key slot array traversal
+
+“Occupied key slot” is determined by `psa_is_key_slot_occupied` based on `slot->attr.type`.
+
+The following functions traverse the key slot array:
+
+* `psa_get_and_lock_key_slot_in_memory`: reads `slot->attr.id`.
+* `psa_get_and_lock_key_slot_in_memory`: calls `psa_lock_key_slot` on one occupied slot.
+* `psa_get_empty_key_slot`: calls `psa_is_key_slot_occupied`.
+* `psa_get_empty_key_slot`: calls `psa_wipe_key_slot` and more modifications on one occupied slot with no active user.
+* `psa_get_empty_key_slot`: calls `psa_lock_key_slot` and more modification on one unoccupied slot.
+* `psa_wipe_all_key_slots`: writes to all slots.
+* `mbedtls_psa_get_stats`: reads from all slots.
+
+#### Key slot state
+
+The following functions modify a slot's usage state:
+
+* `psa_lock_key_slot`: writes to `slot->lock_count`.
+* `psa_unlock_key_slot`: writes to `slot->lock_count`.
+* `psa_wipe_key_slot`: writes to `slot->lock_count`.
+* `psa_destroy_key`: reads `slot->lock_count`, calls `psa_lock_key_slot`.
+* `psa_wipe_all_key_slots`: writes to all slots.
+* `psa_get_empty_key_slot`: writes to `slot->lock_count` and calls `psa_wipe_key_slot` and `psa_lock_key_slot` on one occupied slot with no active user; calls `psa_lock_key_slot` on one unoccupied slot.
+* `psa_close_key`: reads `slot->lock_count`; calls `psa_get_and_lock_key_slot_in_memory`, `psa_wipe_key_slot` and `psa_unlock_key_slot`.
+* `psa_purge_key`: reads `slot->lock_count`; calls `psa_get_and_lock_key_slot_in_memory`, `psa_wipe_key_slot` and `psa_unlock_key_slot`.
+
+TODO: modification of `slot->attr.id`, `slot->attr.type`.
+
+TODO: change `psa_is_key_slot_occupied` to checking the id?
+
+#### Key slot content
+
+Other than what is used to determine the [“key slot state”](#key-slot-state), the contents of a key slot are only accessed as follows:
+
+* Modification during key creation (between `psa_start_key_creation` and `psa_finish_key_creation` or `psa_fail_key_creation`).
+* Destruction in `psa_wipe_key_slot`.
+* Read in many functions, between calls to `psa_lock_key_slot` and `psa_unlock_key_slot`.
+
+### Random generator
+
+The PSA RNG can be accessed both from various PSA functions, and from application code via `mbedtls_psa_get_random`.
+
+With the built-in RNG implementations using `mbedtls_ctr_drbg_context` or `mbedtls_hmac_drbg_context`, querying the RNG with `mbedtls_xxx_drbg_random()` is thread-safe (protected by a mutex inside the RNG implementation), but other operations (init, free, seed) are not.
+
+When `MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG` is enabled, thread safety depends on the implementation.
+
+### Driver resources
+
+Depends on the driver. The PSA driver interface specification does not discuss whether drivers must support concurrent calls.
+
+## Simple global lock strategy
+
+Have a single mutex protecting all accesses to the key store and other global variables. In practice, this means every PSA API function needs to take the lock on entry and release on exit, except for:
+
+* Hash function.
+* Accessors for key attributes and other local structures.
+
+Note that operation functions do need to take the lock, since they need to prevent the destruction of the key.
+
+Note that this does not protect access to the RNG via `mbedtls_psa_get_random`, which is guaranteed to be thread-safe when `MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG` is disabled.
+
+This approach is conceptually simple, but requires extra instrumentation to every function and has bad performance in a multithreaded environment since a slow operation in one thread blocks unrelated operations on other threads.
+
+## Global lock excluding slot content
+
+Have a single mutex protecting all accesses to the key store and other global variables, except that it's ok to access the content of a key slot without taking the lock if one of the following conditions holds:
+
+* The key slot is in a state that guarantees that the thread has exclusive access.
+* The key slot is in a state that guarantees that no other thread can modify the slot content, and the accessing thread is only reading the slot.
+
+Note that a thread must hold the global mutex when it reads or changes a slot's state.
+
+### Slot states
+
+For concurrency purposes, a slot can be in one of three states:
+
+* UNUSED: no thread is currently accessing the slot. It may be occupied by a volatile key or a cached key.
+* WRITING: a thread has exclusive access to the slot. This can only happen in specific circumstances as detailed below.
+* READING: any thread may read from the slot.
+
+A high-level view of state transitions:
+
+* `psa_get_empty_key_slot`: UNUSED → WRITING.
+* `psa_get_and_lock_key_slot_in_memory`: UNUSED or READING → READING. This function only accepts slots in the UNUSED or READING state. A slot with the correct id but in the WRITING state is considered free.
+* `psa_unlock_key_slot`: READING → UNUSED or READING.
+* `psa_finish_key_creation`: WRITING → READING.
+* `psa_fail_key_creation`: WRITING → UNUSED.
+* `psa_wipe_key_slot`: any → UNUSED. If the slot is READING or WRITING on entry, this function must wait until the writer or all readers have finished. (By the way, the WRITING state is possible if `mbedtls_psa_crypto_free` is called while a key creation is in progress.) See [“Destruction of a key in use”](#destruction of a key in use).
+
+The current `state->lock_count` corresponds to the difference between UNUSED and READING: a slot is in use iff its lock count is nonzero, so `lock_count == 0` corresponds to UNUSED and `lock_count != 0` corresponds to READING.
+
+There is currently no indication of when a slot is in the WRITING state. This only happens between a call to `psa_start_key_creation` and a call to one of `psa_finish_key_creation` or `psa_fail_key_creation`. This new state can be conveyed by a new boolean flag, or by setting `lock_count` to `~0`.
+
+### Destruction of a key in use
+
+Problem: a key slot is destroyed (by `psa_wipe_key_slot`) while it's in use (READING or WRITING).
+
+TODO: how do we ensure that? This needs something more sophisticated than mutexes (concurrency number >2)! Even a per-slot mutex isn't enough (we'd need a reader-writer lock).

--- a/docs/architecture/psa-thread-safety.md
+++ b/docs/architecture/psa-thread-safety.md
@@ -1,9 +1,77 @@
-Thread safety of the PSA key store
+Thread safety of the PSA subsystem
 ==================================
 
-Analysis of the behavior of the PSA key store as of Mbed TLS 9202ba37b19d3ea25c8451fd8597fce69eaa6867.
+## Requirements
+
+### Backward compatibility requirement
+
+Code that is currently working must keep working. There can be an exception for code that uses features that are advertised as experimental; for example, it would be annoying but ok to add extra requirements for drivers.
+
+In particular, if you build with `MBEDTLS_PSA_CRYPTO_C` and `MBEDTLS_THREADING_C` and you either protect all PSA calls with a mutex, or only ever call PSA functions from a single thread, your application works.
+
+As a consequence, we must not add a new platform requirement beyond mutexes for the base case. It would be ok to add new platform requirements if they're only needed for PSA drivers, or if they're only performance improvements.
+
+Tempting platform requirements that we cannot add to the default `MBEDTLS_THREADING_C` include:
+
+* Releasing a mutex from a different thread than the one that acquired it. This isn't even guaranteed to work with pthreads.
+* New primitives such as semaphores or condition variables.
+
+### Correctness out of the box
+
+If you build with `MBEDTLS_PSA_CRYPTO_C` and `MBEDTLS_THREADING_C`, the code must be functionally correct: no race conditions, deadlocks or livelocks.
+
+The [PSA Crypto API specification](https://armmbed.github.io/mbed-crypto/html/overview/conventions.html#concurrent-calls) defines minimum expectations for concurrent calls. They must work as if they had been executed one at a time, except that the following cases have undefined behavior:
+
+* Destroying a key while it's in use.
+* Concurrent calls using the same operation object. (An operation object may not be used by more than one thread at a time. But it can move from one thread to another between calls.)
+* Overlap of an output buffer with an input or output of a concurrent call.
+* Modification of an input buffer during a call.
+
+Note that while the specification does not define the behavior in such cases, Mbed TLS can be used as a crypto service. It's acceptable if an application can mess itself up, but it is not acceptable if an application can mess up the crypto service. As a consequence, destroying a key while it's in use may violate the security property that all key material is erased as soon as `psa_destroy_key` returns, but it may not cause data corruption or read-after-free inside the key store.
+
+### No spinning
+
+The code must not spin on a potentially non-blocking task. For example, this is proscribed:
+```
+lock(m);
+while (!its_my_turn) {
+    unlock(m);
+    lock(m);
+}
+```
+
+Rationale: this can cause battery drain, and can even be a livelock (spinning forever), e.g. if the thread that might unblock this one has a lower priority.
+
+### Driver requirements
+
+At the time of writing, the driver interface specification does not consider multithreaded environments.
+
+We need to define clear policies so that driver implementers know what to expect. Here are two possible policies at two ends of the spectrum; what is desirable is probably somewhere in between.
+
+* Driver entry points may be called concurrently from multiple threads, even if they're using the same key, and even including destroying a key while an operation is in progress on it.
+* At most one driver entry point is active at any given time.
+
+A more reasonable policy could be:
+
+* By default, each driver only has at most one entry point active at any given time. In other words, each driver has its own exclusive lock.
+* Drivers have an optional `"thread_safe"` boolean property. If true, it allows concurrent calls to this driver.
+* Even with a thread-safe driver, the core never starts the destruction of a key while there are operations in progress on it, and never performs concurrent calls on the same multipart operation.
+
+### Long-term performance requirements
+
+In the short term, correctness is the important thing. We can start with a global lock.
+
+In the medium to long term, performing a slow or blocking operation (for example, a driver call, or an RSA decryption) should not block other threads, even if they're calling the same driver or using the same key object.
+
+We may want to go directly to a more sophisticated approach because when a system works with a global lock, it's typically hard to get rid of it to get more fine-grained concurrency.
+
+### Key destruction long-term requirements
+
+As noted above in [“Correctness out of the box”](#correctness-out-of-the-box), when a key is destroyed, it's ok if `psa_destroy_key` allows copies of the key to live until ongoing operations using the key return. In the long term, it would be good to guarantee that `psa_destroy_key` wipes all copies of the key material.
 
 ## Resources to protect
+
+Analysis of the behavior of the PSA key store as of Mbed TLS 9202ba37b19d3ea25c8451fd8597fce69eaa6867.
 
 ### Global variables
 

--- a/docs/architecture/psa-thread-safety.md
+++ b/docs/architecture/psa-thread-safety.md
@@ -7,7 +7,9 @@ Thread safety of the PSA subsystem
 
 Code that is currently working must keep working. There can be an exception for code that uses features that are advertised as experimental; for example, it would be annoying but ok to add extra requirements for drivers.
 
-In particular, if you build with `MBEDTLS_PSA_CRYPTO_C` and `MBEDTLS_THREADING_C` and you either protect all PSA calls with a mutex, or only ever call PSA functions from a single thread, your application works.
+(In this section, “currently” means Mbed TLS releases without proper concurrency management: 3.0.0, 3.1.0, and any other subsequent 3.x version.)
+
+In particular, if you either protect all PSA calls with a mutex, or only ever call PSA functions from a single thread, your application currently works and must keep working. If your application currently builds and works with `MBEDTLS_PSA_CRYPTO_C` and `MBEDTLS_THREADING_C` enabled, it must keep building and working.
 
 As a consequence, we must not add a new platform requirement beyond mutexes for the base case. It would be ok to add new platform requirements if they're only needed for PSA drivers, or if they're only performance improvements.
 

--- a/docs/architecture/psa-thread-safety.md
+++ b/docs/architecture/psa-thread-safety.md
@@ -71,20 +71,11 @@ We may want to go directly to a more sophisticated approach because when a syste
 
 As noted above in [“Correctness out of the box”](#correctness-out-of-the-box), when a key is destroyed, it's ok if `psa_destroy_key` allows copies of the key to live until ongoing operations using the key return. In the long term, it would be good to guarantee that `psa_destroy_key` wipes all copies of the key material.
 
-## Resources to protect
+## Resources left to protect
 
-Analysis of the behavior of the PSA key store as of Mbed TLS 9202ba37b19d3ea25c8451fd8597fce69eaa6867.
+Analysis of the behavior of the PSA key store as of Mbed TLS 9202ba37b19d3ea25c8451fd8597fce69eaa6867, reduced by items protected by PR https://github.com/Mbed-TLS/mbedtls/pull/5673.
 
 ### Global variables
-
-* `psa_crypto_slot_management::global_data.key_slots[i]`: see [“Key slots”](#key-slots).
-
-* `psa_crypto_slot_management::global_data.key_slots_initialized`:
-    * `psa_initialize_key_slots`: modification.
-    * `psa_wipe_all_key_slots`: modification.
-    * `psa_get_empty_key_slot`: read.
-    * `psa_get_and_lock_key_slot`: read.
-
 * `psa_crypto::global_data.rng`: depends on the RNG implementation. See [“Random generator”](#random-generator).
     * `psa_generate_random`: query.
     * `mbedtls_psa_crypto_configure_entropy_sources` (only if `MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG` is enabled): setup. Only called from `psa_crypto_init` via `mbedtls_psa_random_init`, or from test code.
@@ -96,118 +87,6 @@ Analysis of the behavior of the PSA key store as of Mbed TLS 9202ba37b19d3ea25c8
     * `mbedtls_psa_crypto_free`: modification.
     * `psa_crypto_init`: modification.
     * Many functions via `GUARD_MODULE_INITIALIZED`: read.
-
-### Key slots
-
-#### Key slot array traversal
-
-“Occupied key slot” is determined by `psa_is_key_slot_occupied` based on `slot->attr.type`.
-
-The following functions traverse the key slot array:
-
-* `psa_get_and_lock_key_slot_in_memory`: reads `slot->attr.id`.
-* `psa_get_and_lock_key_slot_in_memory`: calls `psa_lock_key_slot` on one occupied slot.
-* `psa_get_empty_key_slot`: calls `psa_is_key_slot_occupied`.
-* `psa_get_empty_key_slot`: calls `psa_wipe_key_slot` and more modifications on one occupied slot with no active user.
-* `psa_get_empty_key_slot`: calls `psa_lock_key_slot` and more modification on one unoccupied slot.
-* `psa_wipe_all_key_slots`: writes to all slots.
-* `mbedtls_psa_get_stats`: reads from all slots.
-
-#### Key slot state
-
-The following functions modify a slot's usage state:
-
-* `psa_lock_key_slot`: writes to `slot->lock_count`.
-* `psa_unlock_key_slot`: writes to `slot->lock_count`.
-* `psa_wipe_key_slot`: writes to `slot->lock_count`.
-* `psa_destroy_key`: reads `slot->lock_count`, calls `psa_lock_key_slot`.
-* `psa_wipe_all_key_slots`: writes to all slots.
-* `psa_get_empty_key_slot`: writes to `slot->lock_count` and calls `psa_wipe_key_slot` and `psa_lock_key_slot` on one occupied slot with no active user; calls `psa_lock_key_slot` on one unoccupied slot.
-* `psa_close_key`: reads `slot->lock_count`; calls `psa_get_and_lock_key_slot_in_memory`, `psa_wipe_key_slot` and `psa_unlock_key_slot`.
-* `psa_purge_key`: reads `slot->lock_count`; calls `psa_get_and_lock_key_slot_in_memory`, `psa_wipe_key_slot` and `psa_unlock_key_slot`.
-
-**slot->attr access:**
-`psa_crypto_core.h`:
-* `psa_key_slot_set_flags` - writes to attr.flags
-* `psa_key_slot_set_bits_in_flags` - writes to attr.flags
-* `psa_key_slot_clear_bits` - writes to attr.flags
-* `psa_is_key_slot_occupied` - reads attr.type
-* `psa_key_slot_get_flags` - reads attr.flags
-
-`psa_crypto_slot_management.c`:
-* `psa_get_and_lock_key_slot_in_memory` - reads attr.id
-* `psa_get_empty_key_slot` - reads attr.lifetime
-* `psa_load_persistent_key_into_slot` - passes attr pointer to psa_load_persistent_key
-* `psa_load_persistent_key` - reads attr.id and passes pointer to psa_parse_key_data_from_storage
-* `psa_parse_key_data_from_storage` - writes to many attributes
-* `psa_get_and_lock_key_slot` - writes to attr.id, attr.lifetime, and attr.policy.usage
-* `psa_purge_key` - reads attr.lifetime, calls psa_wipe_key_slot
-* `mbedtls_psa_get_stats` - reads attr.lifetime, attr.id
-
-`psa_crypto.c`:
-* `psa_get_and_lock_key_slot_with_policy` - reads attr.type, attr.policy.
-* `psa_get_and_lock_transparent_key_slot_with_policy` - reads attr.lifetime
-* `psa_destroy_key` - reads attr.lifetime, attr.id
-* `psa_get_key_attributes` - copies all publicly available attributes of a key
-* `psa_export_key` - copies attributes
-* `psa_export_public_key` - reads attr.type, copies attributes
-* `psa_start_key_creation` - writes to the whole attr structure 
-* `psa_validate_optional_attributes` - reads attr.type, attr.bits
-* `psa_import_key` - reads attr.bits
-* `psa_copy_key` - reads attr.bits, attr.type, attr.lifetime, attr.policy
-* `psa_mac_setup` - copies whole attr structure
-* `psa_mac_compute_internal` - copies whole attr structure
-* `psa_verify_internal` - copies whole attr structure
-* `psa_sign_internal` - copies whole attr structure, reads attr.type
-* `psa_assymmetric_encrypt` - reads attr.type
-* `psa_assymetric_decrypt` - reads attr.type
-* `psa_cipher_setup` - copies whole attr structure, reads attr.type
-* `psa_cipher_encrypt` - copies whole attr structure, reads attr.type
-* `psa_cipher_decrypt` - copies whole attr structure, reads attr.type
-* `psa_aead_encrypt` - copies whole attr structure
-* `psa_aead_decrypt` - copies whole attr structure
-* `psa_aead_setup` - copies whole attr structure
-* `psa_generate_derived_key_internal` - reads attr.type, writes to and reads from attr.bits, copies whole attr structure
-* `psa_key_derivation_input_key` - reads attr.type
-* `psa_key_agreement_raw_internal` - reads attr.type and attr.bits
-
-TODO: change `psa_is_key_slot_occupied` to checking the id?
-
-#### Key slot content
-
-Other than what is used to determine the [“key slot state”](#key-slot-state), the contents of a key slot are only accessed as follows:
-
-* Modification during key creation (between `psa_start_key_creation` and `psa_finish_key_creation` or `psa_fail_key_creation`).
-* Destruction in `psa_wipe_key_slot`.
-* Read in many functions, between calls to `psa_lock_key_slot` and `psa_unlock_key_slot`.
-
-**slot->key access:** 
-* `psa_allocate_buffer_to_slot` - allocates key.data, sets key.bytes;
-* `psa_copy_key_material_into_slot` - writes to key.data
-* `psa_remove_key_data_from_memory` - writes and reads to/from key data
-* `psa_get_key_attributes` - reads from key data
-* `psa_export_key` - passes key data to psa_driver_wrapper_export_key
-* `psa_export_public_key` - passes key data to psa_driver_wrapper_export_public_key
-* `psa_finish_key_creation` - passes key data to psa_save_persistent_key
-* `psa_validate_optional_attributes` - passes key data and bytes to mbedtls_psa_rsa_load_representation
-* `psa_import_key` - passes key data to psa_driver_wrapper_import_key
-* `psa_copy_key` - passes key data to psa_driver_wrapper_copy_key, psa_copy_key_material_into_slot
-* `psa_mac_setup` - passes key data to psa_driver_wrapper_mac_sign_setup, psa_driver_wrapper_mac_verify_setup
-* `psa_mac_compute_internal` - passes key data to psa_driver_wrapper_mac_compute
-* `psa_sign_internal` - passes key data to psa_driver_wrapper_sign_message, psa_driver_wrapper_sign_hash
-* `psa_verify_internal` - passes key data to psa_driver_wrapper_verify_message, psa_driver_wrapper_verify_hash
-* `psa_asymmetric_encrypt` - passes key data to mbedtls_psa_rsa_load_representation
-* `psa_asymmetric_decrypt` - passes key data to mbedtls_psa_rsa_load_representation
-* `psa_cipher_setup ` - passes key data to psa_driver_wrapper_cipher_encrypt_setup and psa_driver_wrapper_cipher_decrypt_setup
-* `psa_cipher_encrypt` - passes key data to psa_driver_wrapper_cipher_encrypt
-* `psa_cipher_decrypt` - passes key data to psa_driver_wrapper_cipher_decrypt
-* `psa_aead_encrypt` - passes key data to psa_driver_wrapper_aead_encrypt
-* `psa_aead_decrypt` - passes key data to psa_driver_wrapper_aead_decrypt
-* `psa_aead_setup` - passes key data to psa_driver_wrapper_aead_encrypt_setup and psa_driver_wrapper_aead_decrypt_setup
-* `psa_generate_derived_key_internal` - passes key data to psa_driver_wrapper_import_key
-* `psa_key_derivation_input_key` - passes key data to psa_key_derivation_input_internal
-* `psa_key_agreement_raw_internal` - passes key data to mbedtls_psa_ecp_load_representation
-* `psa_generate_key` - passes key data to psa_driver_wrapper_generate_key
 
 ### Random generator
 
@@ -221,51 +100,78 @@ When `MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG` is enabled, thread safety depends on the 
 
 Depends on the driver. The PSA driver interface specification does not discuss whether drivers must support concurrent calls.
 
-## Simple global lock strategy
-
-Have a single mutex protecting all accesses to the key store and other global variables. In practice, this means every PSA API function needs to take the lock on entry and release on exit, except for:
-
-* Hash function.
-* Accessors for key attributes and other local structures.
-
-Note that operation functions do need to take the lock, since they need to prevent the destruction of the key.
-
-Note that this does not protect access to the RNG via `mbedtls_psa_get_random`, which is guaranteed to be thread-safe when `MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG` is disabled.
-
-This approach is conceptually simple, but requires extra instrumentation to every function and has bad performance in a multithreaded environment since a slow operation in one thread blocks unrelated operations on other threads.
-
-## Global lock excluding slot content
-
-Have a single mutex protecting all accesses to the key store and other global variables, except that it's ok to access the content of a key slot without taking the lock if one of the following conditions holds:
-
-* The key slot is in a state that guarantees that the thread has exclusive access.
-* The key slot is in a state that guarantees that no other thread can modify the slot content, and the accessing thread is only reading the slot.
-
-Note that a thread must hold the global mutex when it reads or changes a slot's state.
+## Proposed strategy
 
 ### Slot states
 
-For concurrency purposes, a slot can be in one of three states:
+Each key slot can be in one of the following states:
+```
+    PSA_STATE_EMPTY,     /* No key loaded yet. */
+    PSA_STATE_CREATING,  /* Key creation has been started. */
+    PSA_STATE_UNUSED,    /* Key present, but unused. */
+    PSA_STATE_READING,   /* Key material used in an operation. */
+    PSA_STATE_WIPING,    /* Purging key data from memory in progress. */
+    PSA_STATE_DESTROYING /* Persistent and volatile key material destruction in progress. */
+```
+#### A high-level view of state transitions
+```
+           ┌──────────┐  ┌──────────┐
+      ┌────┤  EMPTY   ◄──┤DESTROYING│
+      │    └─┬────┬──▲┘  └──▲──▲────┘
+┌─────▼────┐ │ ┌──▼──┴────┐ │  │
+│ CREATING │ │ │  WIPING  ├─┘  │
+└──┬─┬─────┘ │ └──────▲───┘    │
+   │ │  ┌────▼─────┐  ├────────┘
+   │ └──►  UNUSED  ├──┤
+   │    └──▲────┬──┘  │
+   │  ┌─┬──┴────▼──┐  │
+   │  └─► READING  ├──┤
+   │    └──────────┘  │
+   └──────────────────┘
+``` 
 
-* UNUSED: no thread is currently accessing the slot. It may be occupied by a volatile key or a cached key.
-* WRITING: a thread has exclusive access to the slot. This can only happen in specific circumstances as detailed below.
-* READING: any thread may read from the slot.
+#### Details on state transitions
 
-A high-level view of state transitions:
+**State transitions from:**  
+**Empty state:**  
+-> Wiping: cleaning slots in  `psa_wipe_all_key_slots`:  `psa_crypto_init`.  
+-> Unused: importing an existing key that does not require creation:  `psa_load_persistent_key_into_slot`,  `psa_load_builtin_key_into_slot`.  
+-> Creating:  `psa_import_key`,  `psa_copy_key`,  `psa_key_derivation_output_key`,  `psa_generate_key`.
 
-* `psa_get_empty_key_slot`: UNUSED → WRITING.
-* `psa_get_and_lock_key_slot_in_memory`: UNUSED or READING → READING. This function only accepts slots in the UNUSED or READING state. A slot with the correct id but in the WRITING state is considered free.
-* `psa_unlock_key_slot`: READING → UNUSED or READING.
-* `psa_finish_key_creation`: WRITING → READING.
-* `psa_fail_key_creation`: WRITING → UNUSED.
-* `psa_wipe_key_slot`: any → UNUSED. If the slot is READING or WRITING on entry, this function must wait until the writer or all readers have finished. (By the way, the WRITING state is possible if `mbedtls_psa_crypto_free` is called while a key creation is in progress.) See [“Destruction of a key in use”](#destruction of a key in use).
+**Creating state:**  
+-> Wiping:  `psa_fail_key_creation`.  
+-> Destroying: UNUSED; TODO - could/should it happen?  
+-> Unused:  `psa_finish_key_creation`  from  `psa_import_key`,  `psa_copy_key`,  `psa_key_derivation_output_key`,  `psa_generate_key`.
 
-The current `state->lock_count` corresponds to the difference between UNUSED and READING: a slot is in use iff its lock count is nonzero, so `lock_count == 0` corresponds to UNUSED and `lock_count != 0` corresponds to READING.
+**Unused state:**  
+-> Reading: Any operation that needs to read the key material. Copying, exporting, signing, verifying, enc/dec... via  `psa_get_and_lock_key_slot_with_policy`.  
+-> Wiping:  `psa_purge_key`,  `psa_close_key`, but also  `psa_get_empty_key_slot`  if there's an unused persistent key.  
+-> Destroying:  `psa_destroy_key`.
 
-There is currently no indication of when a slot is in the WRITING state. This only happens between a call to `psa_start_key_creation` and a call to one of `psa_finish_key_creation` or `psa_fail_key_creation`. This new state can be conveyed by a new boolean flag, or by setting `lock_count` to `~0`.
+**Reading state:**  
+-> Reading: another reader added via  `psa_get_and_lock_key_slot_with_policy`.  
+-> Unused:  `psa_unlock_key_slot`  by the last reader.  
+-> Wiping:  `psa_purge_key`,  `psa_close_key`;  
+-> Destroying:  `psa_destroy_key`.
 
-### Destruction of a key in use
+**Wiping state:**  
+-> Destroying:  `psa_destroy_key`.  
+-> Empty:  `psa_wipe_key`  from  `psa_close_key`,  `psa_purge_key`, but also delayed wiping when the last reader is unlocked in  `psa_unlock_key_slot`. Failures in  `psa_get_and_lock_key_slot`,  `psa_get_empty_key_slot`.
 
-Problem: a key slot is destroyed (by `psa_wipe_key_slot`) while it's in use (READING or WRITING).
+**Destroying state:**  
+-> Empty:  `psa_finish_key_destruction`  (also calls  `psa_wipe_key`),  `psa_destroy_key`  if there are no readers, and if there was - unlocking the last one via  `psa_unlock_key_slot`.
 
-TODO: how do we ensure that? This needs something more sophisticated than mutexes (concurrency number >2)! Even a per-slot mutex isn't enough (we'd need a reader-writer lock).
+#### Implementation details
+The key slot data and metadata are protected by a single, global mutex. Each change of data/metadata and each read of a slot state requires locking it. Please note, however, that reading the key data itself does not have to be guarded by a mutex, given that `psa_get_and_lock_key_slot` is called prior to it. This function will lock the mutex, transition the key slot to the `PSA_STATE_READING` state, increase the reader counter, and release the mutex. This guarantees that the key slot data/metadata (apart from the reader counter) will not be modified until the last reader unlocks the slot by calling `psa_unlock_key_slot`.
+
+#### Intent reasoning
+To be able to atomically get a key slot and move it to a desired state (or add a reader), a new concept called `intent` was added to `psa_get_and_lock_key_slot` calls. Possible intents: 
+ - `Read` - used widely for all operations that read key slot data, moves the key to `PSA_STATE_READING` and adds a reader;
+ - `Destroy` - get key slot and move it to `PSA_STATE_DESTROYING` state;
+ - `Open` - to provide functionality for the to-be-deprecated `psa_open_key`, which gets the key handle but does not change its state.
+
+#### Destroying / wiping a key in use
+If there is a request for key destruction / wiping while the key is in use (`PSA_STATE_READING`), the state will change to `PSA_STATE_DESTROYING` or `PSA_STATE_WIPING`, but the call will return `PSA_ERROR_DELAYED`. The operation itself will be performed once the last of readers unlocks the slot. 
+
+#### Transitioning to the same state twice
+Apart from the possible transition from `PSA_STATE_READING` to itself (when adding a new reader), it is not possible to transition to the same state. The reason behind this is to prevent double calls to slot creation, destruction, or wiping. 

--- a/include/mbedtls/threading.h
+++ b/include/mbedtls/threading.h
@@ -99,6 +99,10 @@ extern int (*mbedtls_mutex_unlock)( mbedtls_threading_mutex_t *mutex );
 extern mbedtls_threading_mutex_t mbedtls_threading_readdir_mutex;
 #endif
 
+#if defined(MBEDTLS_PSA_CRYPTO_C)
+extern mbedtls_threading_mutex_t mbedtls_psa_slots_mutex;
+#endif
+
 #if defined(MBEDTLS_HAVE_TIME_DATE) && !defined(MBEDTLS_PLATFORM_GMTIME_R_ALT)
 /* This mutex may or may not be used in the default definition of
  * mbedtls_platform_gmtime_r(), but in order to determine that,
@@ -108,6 +112,27 @@ extern mbedtls_threading_mutex_t mbedtls_threading_readdir_mutex;
  * doesn't need it, but that's not a problem. */
 extern mbedtls_threading_mutex_t mbedtls_threading_gmtime_mutex;
 #endif /* MBEDTLS_HAVE_TIME_DATE && !MBEDTLS_PLATFORM_GMTIME_R_ALT */
+
+/*
+ * Helper functions
+ */
+#if defined(MBEDTLS_THREADING_C)
+#define MUTEX_LOCK_CHECK( mutex )                 \
+    do                                            \
+    {                                             \
+        if( mbedtls_mutex_lock( mutex ) != 0 )    \
+            return( PSA_ERROR_BAD_STATE );        \
+    } while( 0 )
+#define MUTEX_UNLOCK_CHECK( mutex )               \
+    do                                            \
+    {                                             \
+        if( mbedtls_mutex_unlock( mutex ) != 0 )  \
+            return( PSA_ERROR_BAD_STATE );        \
+    } while( 0 )
+#else
+#define MUTEX_LOCK_CHECK( mutex )
+#define MUTEX_UNLOCK_CHECK( mutex )
+#endif
 
 #endif /* MBEDTLS_THREADING_C */
 

--- a/include/mbedtls/threading.h
+++ b/include/mbedtls/threading.h
@@ -114,9 +114,8 @@ extern mbedtls_threading_mutex_t mbedtls_threading_gmtime_mutex;
 #endif /* MBEDTLS_HAVE_TIME_DATE && !MBEDTLS_PLATFORM_GMTIME_R_ALT */
 
 /*
- * Helper functions
+ * Helper macros for mutex handling
  */
-#if defined(MBEDTLS_THREADING_C)
 #define MUTEX_LOCK_CHECK( mutex )                 \
     do                                            \
     {                                             \
@@ -129,13 +128,10 @@ extern mbedtls_threading_mutex_t mbedtls_threading_gmtime_mutex;
         if( mbedtls_mutex_unlock( mutex ) != 0 )  \
             return( PSA_ERROR_BAD_STATE );        \
     } while( 0 )
-#else
+#else/* MBEDTLS_THREADING_C */
 #define MUTEX_LOCK_CHECK( mutex )
 #define MUTEX_UNLOCK_CHECK( mutex )
 #endif
-
-#endif /* MBEDTLS_THREADING_C */
-
 #ifdef __cplusplus
 }
 #endif

--- a/include/mbedtls/threading.h
+++ b/include/mbedtls/threading.h
@@ -116,21 +116,21 @@ extern mbedtls_threading_mutex_t mbedtls_threading_gmtime_mutex;
 /*
  * Helper macros for mutex handling
  */
-#define MUTEX_LOCK_CHECK( mutex )                 \
+#define MBEDTLS_MUTEX_LOCK_CHECK( mutex )                 \
     do                                            \
     {                                             \
         if( mbedtls_mutex_lock( mutex ) != 0 )    \
             return( PSA_ERROR_BAD_STATE );        \
     } while( 0 )
-#define MUTEX_UNLOCK_CHECK( mutex )               \
+#define MBEDTLS_MUTEX_UNLOCK_CHECK( mutex )               \
     do                                            \
     {                                             \
         if( mbedtls_mutex_unlock( mutex ) != 0 )  \
             return( PSA_ERROR_BAD_STATE );        \
     } while( 0 )
 #else/* MBEDTLS_THREADING_C */
-#define MUTEX_LOCK_CHECK( mutex )
-#define MUTEX_UNLOCK_CHECK( mutex )
+#define MBEDTLS_MUTEX_LOCK_CHECK( mutex )
+#define MBEDTLS_MUTEX_UNLOCK_CHECK( mutex )
 #endif
 #ifdef __cplusplus
 }

--- a/include/psa/crypto.h
+++ b/include/psa/crypto.h
@@ -561,7 +561,9 @@ psa_status_t psa_copy_key(mbedtls_svc_key_id_t source_key,
  *         a communication failure occurred. The cryptoprocessor may have
  *         been compromised.
  * \retval #PSA_ERROR_BAD_STATE
- *         The library has not been previously initialized by psa_crypto_init().
+ *         The library has not been previously initialized by psa_crypto_init(),
+ *         or the library was not able to move the key slot to the
+ *         PSA_STATE_DESTROYING state.
  *         It is implementation-dependent whether a failure to initialize
  *         results in this error code.
  */

--- a/include/psa/crypto_values.h
+++ b/include/psa/crypto_values.h
@@ -328,6 +328,14 @@
  */
 #define PSA_ERROR_DATA_INVALID          ((psa_status_t)-153)
 
+/** Requested operation has been delayed until the slot will be no longer in use.
+ *
+ * This error indicates that the requested operation could not be performed
+ * at the time. It is returned from psa_close_key, psa_purge_key, and
+ * psa_destroy_key for a call with a slot that is still used by a different
+ * thread. It will be performed by the thread that stops using the key last.
+ */
+#define PSA_ERROR_DELAYED               ((psa_status_t)-154)
 /**@}*/
 
 /** \defgroup crypto_types Key and algorithm types

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -1026,6 +1026,9 @@ psa_status_t psa_finish_key_destruction( psa_key_slot_t *slot )
 {
     psa_status_t status; /* status of the last operation */
     psa_status_t overall_status = PSA_SUCCESS;
+#if defined(MBEDTLS_PSA_CRYPTO_SE_C)
+    psa_se_drv_table_entry_t *driver;
+#endif /* MBEDTLS_PSA_CRYPTO_SE_C */
 
     if( slot->state != PSA_STATE_DESTROYING )
         return( PSA_ERROR_BAD_STATE );
@@ -1121,9 +1124,6 @@ psa_status_t psa_destroy_key( mbedtls_svc_key_id_t key )
 {
     psa_key_slot_t *slot;
     psa_status_t status; /* status of the last operation */
-#if defined(MBEDTLS_PSA_CRYPTO_SE_C)
-    psa_se_drv_table_entry_t *driver;
-#endif /* MBEDTLS_PSA_CRYPTO_SE_C */
 
     if( mbedtls_svc_key_id_is_null( key ) )
         return( PSA_SUCCESS );

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -85,6 +85,7 @@
 #include "mbedtls/sha1.h"
 #include "mbedtls/sha256.h"
 #include "mbedtls/sha512.h"
+#include "mbedtls/threading.h"
 
 #define ARRAY_LENGTH( array ) ( sizeof( array ) / sizeof( *( array ) ) )
 

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -1759,6 +1759,10 @@ static psa_status_t psa_finish_key_creation(
                                               slot->key.bytes );
         }
     }
+    if( status != PSA_SUCCESS )
+    {
+        return( status );
+    }
 #endif /* defined(MBEDTLS_PSA_CRYPTO_STORAGE_C) */
 
 #if defined(MBEDTLS_PSA_CRYPTO_SE_C)

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -902,7 +902,7 @@ static psa_status_t psa_get_and_lock_key_slot_with_policy(
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
     psa_key_slot_t *slot;
 
-    status = psa_get_and_lock_key_slot( key, p_slot, PSA_STATE_READING );
+    status = psa_get_and_lock_key_slot( key, p_slot, PSA_INTENT_READ );
     if( status != PSA_SUCCESS )
         return( status );
     slot = *p_slot;
@@ -1136,7 +1136,7 @@ psa_status_t psa_destroy_key( mbedtls_svc_key_id_t key )
      * the key is operated by an SE or not and this information is needed by
      * the current implementation.
      */
-    status = psa_get_and_lock_key_slot( key, &slot, PSA_STATE_DESTROYING );
+    status = psa_get_and_lock_key_slot( key, &slot, PSA_INTENT_DESTROY );
     if( status != PSA_SUCCESS )
         return( status );
 

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -1142,9 +1142,9 @@ psa_status_t psa_destroy_key( mbedtls_svc_key_id_t key )
 
     if( psa_slot_has_no_readers( slot ) )
     {
-        MUTEX_LOCK_CHECK( &mbedtls_psa_slots_mutex );
+        MBEDTLS_MUTEX_LOCK_CHECK( &mbedtls_psa_slots_mutex );
         status = psa_finish_key_destruction( slot );
-        MUTEX_UNLOCK_CHECK( &mbedtls_psa_slots_mutex );
+        MBEDTLS_MUTEX_UNLOCK_CHECK( &mbedtls_psa_slots_mutex );
     }
     else
         status = PSA_ERROR_DELAYED;
@@ -1604,11 +1604,11 @@ static psa_status_t psa_start_key_creation(
     if( status != PSA_SUCCESS )
         return( status );
 
-    MUTEX_LOCK_CHECK( &mbedtls_psa_slots_mutex );
+    MBEDTLS_MUTEX_LOCK_CHECK( &mbedtls_psa_slots_mutex );
     status = psa_get_empty_key_slot( &volatile_key_id, p_slot );
     if( status != PSA_SUCCESS )
     {
-        MUTEX_UNLOCK_CHECK( &mbedtls_psa_slots_mutex );
+        MBEDTLS_MUTEX_UNLOCK_CHECK( &mbedtls_psa_slots_mutex );
         return( status );
     }
     slot = *p_slot;
@@ -1663,7 +1663,7 @@ static psa_status_t psa_start_key_creation(
                                            &slot_number );
         if( status != PSA_SUCCESS )
         {
-            MUTEX_UNLOCK_CHECK( &mbedtls_psa_slots_mutex );
+            MBEDTLS_MUTEX_UNLOCK_CHECK( &mbedtls_psa_slots_mutex );
             return( status );
         }
 
@@ -1677,7 +1677,7 @@ static psa_status_t psa_start_key_creation(
             if( status != PSA_SUCCESS )
             {
                 (void) psa_crypto_stop_transaction( );
-                MUTEX_UNLOCK_CHECK( &mbedtls_psa_slots_mutex );
+                MBEDTLS_MUTEX_UNLOCK_CHECK( &mbedtls_psa_slots_mutex );
                 return( status );
             }
         }
@@ -1689,13 +1689,13 @@ static psa_status_t psa_start_key_creation(
     if( *p_drv == NULL && method == PSA_KEY_CREATION_REGISTER )
     {
         /* Key registration only makes sense with a secure element. */
-        MUTEX_UNLOCK_CHECK( &mbedtls_psa_slots_mutex );
+        MBEDTLS_MUTEX_UNLOCK_CHECK( &mbedtls_psa_slots_mutex );
         return( PSA_ERROR_INVALID_ARGUMENT );
     }
 #endif /* MBEDTLS_PSA_CRYPTO_SE_C */
     psa_slot_change_state( slot, PSA_STATE_CREATING );
 
-    MUTEX_UNLOCK_CHECK( &mbedtls_psa_slots_mutex );
+    MBEDTLS_MUTEX_UNLOCK_CHECK( &mbedtls_psa_slots_mutex );
     return( PSA_SUCCESS );
 }
 
@@ -1738,7 +1738,7 @@ static psa_status_t psa_finish_key_creation(
     (void) slot;
     (void) driver;
 
-    MUTEX_LOCK_CHECK( &mbedtls_psa_slots_mutex );
+    MBEDTLS_MUTEX_LOCK_CHECK( &mbedtls_psa_slots_mutex );
 #if defined(MBEDTLS_PSA_CRYPTO_STORAGE_C)
     if( ! PSA_KEY_LIFETIME_IS_VOLATILE( slot->attr.lifetime ) )
     {
@@ -1771,7 +1771,7 @@ static psa_status_t psa_finish_key_creation(
     }
     if( status != PSA_SUCCESS )
     {
-        MUTEX_UNLOCK_CHECK( &mbedtls_psa_slots_mutex );
+        MBEDTLS_MUTEX_UNLOCK_CHECK( &mbedtls_psa_slots_mutex );
         return( status );
     }
 #endif /* defined(MBEDTLS_PSA_CRYPTO_STORAGE_C) */
@@ -1789,7 +1789,7 @@ static psa_status_t psa_finish_key_creation(
         if( status != PSA_SUCCESS )
         {
             psa_destroy_persistent_key( slot->attr.id );
-            MUTEX_UNLOCK_CHECK( &mbedtls_psa_slots_mutex );
+            MBEDTLS_MUTEX_UNLOCK_CHECK( &mbedtls_psa_slots_mutex );
             return( status );
         }
         status = psa_crypto_stop_transaction( );
@@ -1804,7 +1804,7 @@ static psa_status_t psa_finish_key_creation(
             *key = MBEDTLS_SVC_KEY_ID_INIT;
     }
 
-    MUTEX_UNLOCK_CHECK( &mbedtls_psa_slots_mutex );
+    MBEDTLS_MUTEX_UNLOCK_CHECK( &mbedtls_psa_slots_mutex );
     return( status );
 }
 

--- a/library/psa_crypto_core.h
+++ b/library/psa_crypto_core.h
@@ -56,6 +56,14 @@ typedef enum
     PSA_STATE_DESTROYING /* Persistent and volatile key material destruction in progress. */
 } psa_key_slot_state_t;
 
+/** Intention behind locking a key slot */
+typedef enum
+{
+    PSA_INTENT_READ,
+    PSA_INTENT_DESTROY,
+    PSA_INTENT_OPEN /* Only used by psa_open_key, to be deprecated */
+} psa_slot_locking_intent_t;
+
 /** The data structure representing a key slot, containing key material
  * and metadata for one key.
  */

--- a/library/psa_crypto_core.h
+++ b/library/psa_crypto_core.h
@@ -555,7 +555,7 @@ psa_status_t psa_validate_unstructured_key_bit_size( psa_key_type_t type,
  * \retval 1
  *         The key slot has no active readers.
  */
-psa_status_t psa_slot_has_no_readers( psa_key_slot_t *slot );
+int psa_slot_has_no_readers( psa_key_slot_t *slot );
 
 /** Transition the slot to a given state
  *

--- a/library/psa_crypto_core.h
+++ b/library/psa_crypto_core.h
@@ -172,6 +172,9 @@ static inline psa_key_slot_number_t psa_key_slot_get_slot_number(
  *
  * Persistent storage is not affected.
  *
+ * Please note that, if MBEDTLS_THREADING_C is enabled, this function should
+ * be called with locked mbedtls_psa_slots_mutex.
+ *
  * \param[in,out] slot  The key slot to wipe.
  *
  * \retval #PSA_SUCCESS
@@ -184,6 +187,9 @@ psa_status_t psa_wipe_key_slot( psa_key_slot_t *slot );
 /** Perform key destruction in both volatile and persistent memory.
  *
  * See psa_destroy_key for information on return errors.
+ *
+ * Please note that, if MBEDTLS_THREADING_C is enabled, this function should
+ * be called with locked mbedtls_psa_slots_mutex.
  *
  * \param[in,out] slot  The key slot to wipe.
  */

--- a/library/psa_crypto_core.h
+++ b/library/psa_crypto_core.h
@@ -547,6 +547,34 @@ psa_status_t psa_verify_hash_builtin(
 psa_status_t psa_validate_unstructured_key_bit_size( psa_key_type_t type,
                                                      size_t bits );
 
+/** Test whether the number of readers of this lock is equal to 0.
+ *
+ * \param[in] slot  The key slot to test.
+ * \retval 0
+ *         The key slot has at least one active reader.
+ * \retval 1
+ *         The key slot has no active readers.
+ */
+psa_status_t psa_slot_has_no_readers( psa_key_slot_t *slot );
+
+/** Transition the slot to a given state
+ *
+ * \param[in] slot           The key slot.
+ * \param[in] target_state   The desired slot state.
+ *
+ * Please note that, if MBEDTLS_THREADING_C is enabled, this function should
+ * be called with locked mbedtls_psa_slots_mutex.
+ *
+ * \retval #PSA_ERROR_INVALID_HANDLE
+ *         \p slot is empty and a bad state change was requested.
+ * \retval #PSA_ERROR_BAD_STATE
+ *         The requested state transition could not be performed.
+ * \retval #PSA_SUCCESS
+ *         The transition succeeded and \p slot is now in \p target_state.
+ */
+psa_status_t psa_slot_change_state( psa_key_slot_t *slot,
+                                    psa_key_slot_state_t target_state );
+
 #if defined(MBEDTLS_TEST_HOOKS)
 /**
  * \brief Get a key slot from global data. Used in tests to check slot state

--- a/library/psa_crypto_slot_management.c
+++ b/library/psa_crypto_slot_management.c
@@ -680,7 +680,7 @@ psa_status_t psa_purge_key( mbedtls_svc_key_id_t key )
     psa_status_t status;
     psa_key_slot_t *slot;
 
-    if( psa_key_id_is_volatile( key ) )
+    if( psa_key_id_is_volatile( MBEDTLS_SVC_KEY_ID_GET_KEY_ID( key ) ) )
         return( PSA_SUCCESS );
 
     MBEDTLS_MUTEX_LOCK_CHECK( &mbedtls_psa_slots_mutex );

--- a/library/psa_crypto_slot_management.c
+++ b/library/psa_crypto_slot_management.c
@@ -102,8 +102,7 @@ psa_status_t psa_slot_change_state( psa_key_slot_t *slot,
                 return( PSA_ERROR_BAD_STATE );
             break;
         case PSA_STATE_DESTROYING:
-            if( target_state != PSA_STATE_EMPTY &&
-                target_state != PSA_STATE_WIPING )
+            if( target_state != PSA_STATE_EMPTY )
                 return( PSA_ERROR_BAD_STATE );
             break;
         case PSA_STATE_WIPING :

--- a/library/psa_crypto_slot_management.c
+++ b/library/psa_crypto_slot_management.c
@@ -432,7 +432,9 @@ psa_status_t psa_get_and_lock_key_slot( mbedtls_svc_key_id_t key,
 {
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
 
-    if( intent == PSA_STATE_EMPTY )
+    if( intent != PSA_STATE_DESTROYING &&
+        intent != PSA_STATE_READING &&
+        intent != PSA_STATE_UNUSED )
         return( PSA_ERROR_NOT_SUPPORTED );
     MBEDTLS_MUTEX_LOCK_CHECK( &mbedtls_psa_slots_mutex );
 

--- a/library/psa_crypto_slot_management.c
+++ b/library/psa_crypto_slot_management.c
@@ -345,7 +345,9 @@ static psa_status_t psa_load_persistent_key_into_slot( psa_key_slot_t *slot )
     {
         goto exit;
     }
-    psa_slot_change_state( slot, PSA_STATE_UNUSED );
+    status = psa_slot_change_state( slot, PSA_STATE_UNUSED );
+    if( status != PSA_SUCCESS )
+        return( status );
 
 exit:
     psa_free_persistent_key_data( key_data, key_data_length );
@@ -417,6 +419,7 @@ static psa_status_t psa_load_builtin_key_into_slot( psa_key_slot_t *slot )
     slot->key.bytes = key_buffer_length;
     slot->attr = attributes.core;
 
+    status = psa_slot_change_state( slot, PSA_STATE_UNUSED );
 exit:
     if( status != PSA_SUCCESS )
         psa_remove_key_data_from_memory( slot );

--- a/library/psa_crypto_slot_management.c
+++ b/library/psa_crypto_slot_management.c
@@ -435,12 +435,12 @@ psa_status_t psa_get_and_lock_key_slot( mbedtls_svc_key_id_t key,
 
     if( intent == PSA_STATE_EMPTY )
         return( PSA_ERROR_NOT_SUPPORTED );
-    MUTEX_LOCK_CHECK( &mbedtls_psa_slots_mutex );
+    MBEDTLS_MUTEX_LOCK_CHECK( &mbedtls_psa_slots_mutex );
 
     *p_slot = NULL;
     if( !global_data.key_slots_initialized )
     {
-        MUTEX_UNLOCK_CHECK( &mbedtls_psa_slots_mutex );
+        MBEDTLS_MUTEX_UNLOCK_CHECK( &mbedtls_psa_slots_mutex );
         return( PSA_ERROR_BAD_STATE );
     }
 
@@ -456,13 +456,13 @@ psa_status_t psa_get_and_lock_key_slot( mbedtls_svc_key_id_t key,
             status = psa_slot_change_state( *p_slot, intent );
         if( status != PSA_SUCCESS )
         {
-            MUTEX_UNLOCK_CHECK( &mbedtls_psa_slots_mutex );
+            MBEDTLS_MUTEX_UNLOCK_CHECK( &mbedtls_psa_slots_mutex );
             return( status );
         }
     }
     if( status != PSA_ERROR_DOES_NOT_EXIST )
     {
-        MUTEX_UNLOCK_CHECK( &mbedtls_psa_slots_mutex );
+        MBEDTLS_MUTEX_UNLOCK_CHECK( &mbedtls_psa_slots_mutex );
         return( status );
     }
 
@@ -474,7 +474,7 @@ psa_status_t psa_get_and_lock_key_slot( mbedtls_svc_key_id_t key,
     status = psa_get_empty_key_slot( &volatile_key_id, p_slot );
     if( status != PSA_SUCCESS )
     {
-        MUTEX_UNLOCK_CHECK( &mbedtls_psa_slots_mutex );
+        MBEDTLS_MUTEX_UNLOCK_CHECK( &mbedtls_psa_slots_mutex );
         return( status );
     }
 
@@ -509,10 +509,10 @@ psa_status_t psa_get_and_lock_key_slot( mbedtls_svc_key_id_t key,
             status = psa_slot_change_state( *p_slot, intent );
     }
 
-    MUTEX_UNLOCK_CHECK( &mbedtls_psa_slots_mutex );
+    MBEDTLS_MUTEX_UNLOCK_CHECK( &mbedtls_psa_slots_mutex );
     return( status );
 #else /* MBEDTLS_PSA_CRYPTO_STORAGE_C || MBEDTLS_PSA_CRYPTO_BUILTIN_KEYS */
-    MUTEX_UNLOCK_CHECK( &mbedtls_psa_slots_mutex );
+    MBEDTLS_MUTEX_UNLOCK_CHECK( &mbedtls_psa_slots_mutex );
     return( PSA_ERROR_INVALID_HANDLE );
 #endif /* MBEDTLS_PSA_CRYPTO_STORAGE_C || MBEDTLS_PSA_CRYPTO_BUILTIN_KEYS */
 }
@@ -523,7 +523,7 @@ psa_status_t psa_unlock_key_slot( psa_key_slot_t *slot )
     if( slot == NULL )
         return( PSA_SUCCESS );
 
-    MUTEX_LOCK_CHECK( &mbedtls_psa_slots_mutex );
+    MBEDTLS_MUTEX_LOCK_CHECK( &mbedtls_psa_slots_mutex );
 
     if( slot->state != PSA_STATE_READING &&
         slot->state != PSA_STATE_DESTROYING &&
@@ -532,14 +532,14 @@ psa_status_t psa_unlock_key_slot( psa_key_slot_t *slot )
         MBEDTLS_TEST_HOOK_TEST_ASSERT( slot->state != PSA_STATE_READING &&
             slot->state != PSA_STATE_DESTROYING &&
             slot->state != PSA_STATE_WIPING );
-        MUTEX_UNLOCK_CHECK( &mbedtls_psa_slots_mutex );
+        MBEDTLS_MUTEX_UNLOCK_CHECK( &mbedtls_psa_slots_mutex );
         return( PSA_ERROR_BAD_STATE );
     }
 
     if( slot->reader_count == 0 )
     {
         MBEDTLS_TEST_HOOK_TEST_ASSERT( slot->reader_count != 0 );
-        MUTEX_UNLOCK_CHECK( &mbedtls_psa_slots_mutex );
+        MBEDTLS_MUTEX_UNLOCK_CHECK( &mbedtls_psa_slots_mutex );
         return( PSA_ERROR_CORRUPTION_DETECTED );
     }
     slot->reader_count--;
@@ -554,7 +554,7 @@ psa_status_t psa_unlock_key_slot( psa_key_slot_t *slot )
         else
             status = psa_slot_change_state( slot, PSA_STATE_UNUSED );
     }
-    MUTEX_UNLOCK_CHECK( &mbedtls_psa_slots_mutex );
+    MBEDTLS_MUTEX_UNLOCK_CHECK( &mbedtls_psa_slots_mutex );
     return( status );
 }
 
@@ -647,14 +647,14 @@ psa_status_t psa_close_key( psa_key_handle_t handle )
     if( psa_key_handle_is_null( handle ) )
         return( PSA_SUCCESS );
 
-    MUTEX_LOCK_CHECK( &mbedtls_psa_slots_mutex );
+    MBEDTLS_MUTEX_LOCK_CHECK( &mbedtls_psa_slots_mutex );
     status = psa_get_key_slot( handle, &slot );
     if( status != PSA_SUCCESS )
     {
         if( status == PSA_ERROR_DOES_NOT_EXIST )
             status = PSA_ERROR_INVALID_HANDLE;
 
-        MUTEX_UNLOCK_CHECK( &mbedtls_psa_slots_mutex );
+        MBEDTLS_MUTEX_UNLOCK_CHECK( &mbedtls_psa_slots_mutex );
         return( status );
     }
 
@@ -662,7 +662,7 @@ psa_status_t psa_close_key( psa_key_handle_t handle )
 
     if( status != PSA_SUCCESS )
     {
-        MUTEX_UNLOCK_CHECK( &mbedtls_psa_slots_mutex );
+        MBEDTLS_MUTEX_UNLOCK_CHECK( &mbedtls_psa_slots_mutex );
         return( status );
     }
 
@@ -671,7 +671,7 @@ psa_status_t psa_close_key( psa_key_handle_t handle )
     else
         status = PSA_ERROR_DELAYED;
 
-    MUTEX_UNLOCK_CHECK( &mbedtls_psa_slots_mutex );
+    MBEDTLS_MUTEX_UNLOCK_CHECK( &mbedtls_psa_slots_mutex );
     return( status );
 }
 
@@ -683,11 +683,11 @@ psa_status_t psa_purge_key( mbedtls_svc_key_id_t key )
     if( psa_key_id_is_volatile( key ) )
         return( PSA_SUCCESS );
 
-    MUTEX_LOCK_CHECK( &mbedtls_psa_slots_mutex );
+    MBEDTLS_MUTEX_LOCK_CHECK( &mbedtls_psa_slots_mutex );
     status = psa_get_key_slot( key, &slot );
     if( status != PSA_SUCCESS )
     {
-        MUTEX_UNLOCK_CHECK( &mbedtls_psa_slots_mutex );
+        MBEDTLS_MUTEX_UNLOCK_CHECK( &mbedtls_psa_slots_mutex );
         return( status );
     }
 
@@ -695,7 +695,7 @@ psa_status_t psa_purge_key( mbedtls_svc_key_id_t key )
 
     if( status != PSA_SUCCESS )
     {
-        MUTEX_UNLOCK_CHECK( &mbedtls_psa_slots_mutex );
+        MBEDTLS_MUTEX_UNLOCK_CHECK( &mbedtls_psa_slots_mutex );
         return( status );
     }
 
@@ -704,7 +704,7 @@ psa_status_t psa_purge_key( mbedtls_svc_key_id_t key )
     else
         status = PSA_ERROR_DELAYED;
 
-    MUTEX_UNLOCK_CHECK( &mbedtls_psa_slots_mutex );
+    MBEDTLS_MUTEX_UNLOCK_CHECK( &mbedtls_psa_slots_mutex );
     return( status );
 }
 

--- a/library/psa_crypto_slot_management.c
+++ b/library/psa_crypto_slot_management.c
@@ -155,6 +155,8 @@ static psa_status_t psa_slot_add_reader( psa_key_slot_t *slot )
  * key with identifier key_id can only be stored in slot of index
  * ( key_id - #PSA_KEY_ID_VOLATILE_MIN ).
  *
+ * Please note that, if MBEDTLS_THREADING_C is enabled, this function should
+ * be called with locked mbedtls_psa_slots_mutex.
  *
  * \param key           Key identifier to query.
  * \param[out] p_slot   On success, `*p_slot` contains a pointer to the

--- a/library/psa_crypto_slot_management.c
+++ b/library/psa_crypto_slot_management.c
@@ -347,12 +347,11 @@ static psa_status_t psa_load_persistent_key_into_slot( psa_key_slot_t *slot )
     {
         goto exit;
     }
-    status = psa_slot_change_state( slot, PSA_STATE_UNUSED );
-    if( status != PSA_SUCCESS )
-        return( status );
 
 exit:
     psa_free_persistent_key_data( key_data, key_data_length );
+    if( status == PSA_SUCCESS )
+        status = psa_slot_change_state( slot, PSA_STATE_UNUSED );
     return( status );
 }
 #endif /* MBEDTLS_PSA_CRYPTO_STORAGE_C */

--- a/library/psa_crypto_slot_management.h
+++ b/library/psa_crypto_slot_management.h
@@ -128,26 +128,6 @@ psa_status_t psa_get_empty_key_slot( psa_key_id_t *volatile_key_id,
 
 /** Unlock a key slot and, if possible, perform any delayed destruction
  *  or purging.
- * This function increments the key slot lock counter by one.
- *
- * \param[in] slot  The key slot.
- *
- * \retval #PSA_SUCCESS
-               The key slot lock counter was incremented.
- * \retval #PSA_ERROR_CORRUPTION_DETECTED
- *             The lock counter already reached its maximum value and was not
- *             increased.
- */
-static inline psa_status_t psa_lock_key_slot( psa_key_slot_t *slot )
-{
-    if( slot->lock_count >= SIZE_MAX )
-        return( PSA_ERROR_CORRUPTION_DETECTED );
-
-    slot->lock_count++;
-
-    return( PSA_SUCCESS );
-}
-
  *
  * This function decrements the key slot lock counter by one.
  * If there was a key destruction or purging requested while the key was

--- a/library/psa_crypto_slot_management.h
+++ b/library/psa_crypto_slot_management.h
@@ -73,7 +73,7 @@ static inline int psa_key_id_is_volatile( psa_key_id_t key_id )
  * \param[out] p_slot   On success, `*p_slot` contains a pointer to the
  *                      key slot containing the description of the key
  *                      identified by \p key.
- *
+ * \param[in] intent    Reason for locking the key.
  * \retval #PSA_SUCCESS
  *         \p *p_slot contains a pointer to the key slot containing the
  *         description of the key identified by \p key.
@@ -94,7 +94,7 @@ static inline int psa_key_id_is_volatile( psa_key_id_t key_id )
  */
 psa_status_t psa_get_and_lock_key_slot( mbedtls_svc_key_id_t key,
                                         psa_key_slot_t **p_slot,
-                                        psa_key_slot_state_t intent );
+                                        psa_slot_locking_intent_t intent );
 
 /** Initialize the key slot structures.
  *

--- a/library/psa_crypto_slot_management.h
+++ b/library/psa_crypto_slot_management.h
@@ -115,6 +115,9 @@ void psa_wipe_all_key_slots( void );
  * the responsibility of the caller to unlock the key slot when it does not
  * access it anymore.
  *
+ * Please note that, if MBEDTLS_THREADING_C is enabled, this function should
+ * be called with locked mbedtls_psa_slots_mutex.
+ *
  * \param[out] volatile_key_id   On success, volatile key identifier
  *                               associated to the returned slot.
  * \param[out] p_slot            On success, a pointer to the slot.
@@ -163,6 +166,9 @@ psa_status_t psa_slot_has_no_readers( psa_key_slot_t *slot );
  *
  * \param[in] slot           The key slot.
  * \param[in] target_state   The desired slot state.
+ *
+ * Please note that, if MBEDTLS_THREADING_C is enabled, this function should
+ * be called with locked mbedtls_psa_slots_mutex.
  *
  * \retval #PSA_ERROR_INVALID_HANDLE
  *         \p slot is empty and a bad state change was requested.

--- a/library/psa_crypto_slot_management.h
+++ b/library/psa_crypto_slot_management.h
@@ -152,34 +152,6 @@ psa_status_t psa_get_empty_key_slot( psa_key_id_t *volatile_key_id,
  */
 psa_status_t psa_unlock_key_slot( psa_key_slot_t *slot );
 
-/** Test whether the number of readers of this lock is equal to 0.
- *
- * \param[in] slot  The key slot to test.
- * \retval 0
- *         The key slot has at least one active reader.
- * \retval 1
- *         The key slot has no active readers.
- */
-psa_status_t psa_slot_has_no_readers( psa_key_slot_t *slot );
-
-/** Transition the slot to a given state
- *
- * \param[in] slot           The key slot.
- * \param[in] target_state   The desired slot state.
- *
- * Please note that, if MBEDTLS_THREADING_C is enabled, this function should
- * be called with locked mbedtls_psa_slots_mutex.
- *
- * \retval #PSA_ERROR_INVALID_HANDLE
- *         \p slot is empty and a bad state change was requested.
- * \retval #PSA_ERROR_BAD_STATE
- *         The requested state transition could not be performed.
- * \retval #PSA_SUCCESS
- *         The transition succeeded and \p slot is now in \p target_state.
- */
-psa_status_t psa_slot_change_state( psa_key_slot_t *slot,
-                                    psa_key_slot_state_t target_state );
-
 /** Test whether a lifetime designates a key in an external cryptoprocessor.
  *
  * \param lifetime      The lifetime to test.

--- a/library/threading.c
+++ b/library/threading.c
@@ -180,6 +180,13 @@ void mbedtls_threading_free_alt( void )
 #if defined(MBEDTLS_FS_IO)
 mbedtls_threading_mutex_t mbedtls_threading_readdir_mutex MUTEX_INIT;
 #endif
+#if defined(MBEDTLS_PSA_CRYPTO_C)
+/*
+ * psa_crypto_slot_management.c global data mutex.
+ */
+mbedtls_threading_mutex_t mbedtls_psa_slots_mutex MUTEX_INIT;
+#endif
+
 #if defined(THREADING_USE_GMTIME)
 mbedtls_threading_mutex_t mbedtls_threading_gmtime_mutex MUTEX_INIT;
 #endif

--- a/tests/suites/test_suite_psa_crypto_slot_management.data
+++ b/tests/suites/test_suite_psa_crypto_slot_management.data
@@ -236,3 +236,15 @@ key_slot_eviction_to_import_new_key:PSA_KEY_LIFETIME_VOLATILE
 #   data and volatile key data being spoiled.
 Non reusable key slots integrity in case of key slot starvation
 non_reusable_key_slots_integrity_in_case_of_key_slot_starvation
+
+Slot state transitions
+slot_state_transitions:
+
+Reading and destroying volatile key slots
+slot_volatile_reading:
+
+Reading and destroying persistent key slots
+slot_persistent_reading:
+
+Locking bad states
+slot_locking_bad_states:

--- a/tests/suites/test_suite_psa_crypto_slot_management.function
+++ b/tests/suites/test_suite_psa_crypto_slot_management.function
@@ -152,7 +152,8 @@ void slot_state_transitions( )
     PSA_INIT( );
     psa_key_slot_t *slot = NULL;
     size_t slot_idx;
-    mbedtls_svc_key_id_t key_id = 0xfedcba98; // use an invalid initial ID
+    /* Use an invalid initial ID */
+    mbedtls_svc_key_id_t key_id = mbedtls_svc_key_id_make( 1, 0xfedcba98 );
 
     /* Test that all of the slots are empty */
     for( slot_idx = 0; slot_idx < MBEDTLS_PSA_KEY_SLOT_COUNT; slot_idx++ )
@@ -163,7 +164,8 @@ void slot_state_transitions( )
     /* Please note that normally, some of these calls should be protected
      * by locking the mbedtls_psa_slots_mutex, but we are performing this
      * test in a single thread, so this can be omitted. */
-    PSA_ASSERT( psa_get_empty_key_slot( &key_id, &slot ) );
+    PSA_ASSERT( psa_get_empty_key_slot( &MBEDTLS_SVC_KEY_ID_GET_KEY_ID( key_id ),
+                                        &slot ) );
 
     /* Test possible state transitions from PSA_STATE_EMPTY */
     TEST_EQUAL( psa_slot_change_state( slot, PSA_STATE_EMPTY ),
@@ -273,7 +275,8 @@ void slot_volatile_reading( )
 {
     PSA_INIT( );
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
-    mbedtls_svc_key_id_t key_id = 0xfedcba98; // use an invalid ID
+    /* Use an invalid initial ID */
+    mbedtls_svc_key_id_t key_id = mbedtls_svc_key_id_make( 1, 0xfedcba98 );
     psa_key_slot_t *slot = NULL;
 
     // key lifetime, usage flags, algorithm are irrelevant for this test
@@ -423,7 +426,8 @@ void slot_locking_bad_states( )
 {
     PSA_INIT( );
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
-    mbedtls_svc_key_id_t key_id = 0xfedcba98; // use an invalid ID
+    /* Use an invalid initial ID */
+    mbedtls_svc_key_id_t key_id = mbedtls_svc_key_id_make( 1, 0xfedcba98 );
     psa_key_slot_t *slot = NULL;
 
     // key lifetime, usage flags, algorithm are irrelevant for this test

--- a/tests/suites/test_suite_psa_crypto_slot_management.function
+++ b/tests/suites/test_suite_psa_crypto_slot_management.function
@@ -243,9 +243,13 @@ void slot_state_transitions( )
                     PSA_ERROR_BAD_STATE );
 
     PSA_ASSERT( psa_slot_change_state( slot, PSA_STATE_EMPTY ) );
-    PSA_ASSERT( psa_slot_change_state( slot, PSA_STATE_WIPING ) );
+
+    PSA_ASSERT( cycle_slot_to_state( slot, PSA_STATE_DESTROYING ) );
+    TEST_EQUAL( psa_slot_change_state( slot, PSA_STATE_WIPING ),
+                    PSA_ERROR_BAD_STATE );
 
     /* Test possible state transitions from PSA_STATE_WIPING */
+    PSA_ASSERT( cycle_slot_to_state( slot, PSA_STATE_WIPING ) );
     TEST_EQUAL( psa_slot_change_state( slot, PSA_STATE_WIPING ),
                     PSA_ERROR_BAD_STATE );
     TEST_EQUAL( psa_slot_change_state( slot, PSA_STATE_CREATING ),
@@ -296,12 +300,21 @@ void slot_volatile_reading( )
     TEST_EQUAL( slot->reader_count, 1 );
     TEST_EQUAL( slot->state, PSA_STATE_DESTROYING );
 
+    /* Test that reading is now impossible */
+    TEST_EQUAL( psa_get_and_lock_key_slot( key_id, &slot, PSA_STATE_READING ),
+                    PSA_ERROR_BAD_STATE );
+    /* Second destruction should error out */
+    TEST_EQUAL( psa_destroy_key( key_id ), PSA_ERROR_BAD_STATE );
+
+    /* Test that closing at this stage is impossible */
+    TEST_EQUAL( psa_close_key( key_id ), PSA_ERROR_BAD_STATE );
+    TEST_EQUAL( slot->state, PSA_STATE_DESTROYING );
+
     PSA_ASSERT( psa_unlock_key_slot(slot) );
     TEST_EQUAL( slot->state, PSA_STATE_EMPTY );
     TEST_EQUAL( slot->reader_count, 0 );
 
     /* Purging while reading - does nothing */
-
     PSA_ASSERT( psa_generate_key( &attributes, &key_id ) );
     TEST_EQUAL( slot->state, PSA_STATE_UNUSED );
     TEST_EQUAL( slot->reader_count, 0 );
@@ -312,12 +325,11 @@ void slot_volatile_reading( )
 
     TEST_EQUAL( psa_purge_key( key_id ), PSA_SUCCESS );
     TEST_EQUAL( slot->state, PSA_STATE_READING );
-    TEST_EQUAL( slot->reader_count,  1 );
+    TEST_EQUAL( slot->reader_count, 1 );
 
     PSA_ASSERT( psa_unlock_key_slot(slot) );
     TEST_EQUAL( slot->state, PSA_STATE_UNUSED );
     TEST_EQUAL( slot->reader_count, 0 );
-
 
     /* Closing while reading */
     PSA_ASSERT( psa_get_and_lock_key_slot( key_id, &slot, PSA_STATE_READING ) );
@@ -327,6 +339,39 @@ void slot_volatile_reading( )
     TEST_EQUAL( psa_close_key( key_id ), PSA_ERROR_DELAYED );
     TEST_EQUAL( slot->reader_count, 1 );
     TEST_EQUAL( slot->state, PSA_STATE_WIPING );
+
+    /* Test that reading is now impossible */
+    TEST_EQUAL( psa_get_and_lock_key_slot( key_id, &slot, PSA_STATE_READING ),
+                    PSA_ERROR_BAD_STATE );
+
+    /* Second call to close should error out */
+    TEST_EQUAL( psa_close_key( key_id ), PSA_ERROR_BAD_STATE );
+
+    /* Upgrading to destruction is possible */
+    TEST_EQUAL( psa_destroy_key( key_id ), PSA_ERROR_DELAYED );
+    TEST_EQUAL( slot->reader_count, 1 );
+    TEST_EQUAL( slot->state, PSA_STATE_DESTROYING );
+
+    PSA_ASSERT( psa_unlock_key_slot(slot) );
+    TEST_EQUAL( slot->state, PSA_STATE_EMPTY );
+    TEST_EQUAL( slot->reader_count, 0 );
+
+    /* Closing->destroying while reading */
+    PSA_ASSERT( psa_generate_key( &attributes, &key_id ) );
+    TEST_EQUAL( slot->state, PSA_STATE_UNUSED );
+    TEST_EQUAL( slot->reader_count, 0 );
+
+    PSA_ASSERT( psa_get_and_lock_key_slot( key_id, &slot, PSA_STATE_READING ) );
+    TEST_EQUAL( slot->state, PSA_STATE_READING );
+    TEST_EQUAL( slot->reader_count, 1 );
+
+    TEST_EQUAL( psa_close_key( key_id ), PSA_ERROR_DELAYED );
+    TEST_EQUAL( slot->reader_count, 1 );
+    TEST_EQUAL( slot->state, PSA_STATE_WIPING );
+
+    TEST_EQUAL( psa_destroy_key( key_id ), PSA_ERROR_DELAYED );
+    TEST_EQUAL( slot->reader_count, 1 );
+    TEST_EQUAL( slot->state, PSA_STATE_DESTROYING );
 
     PSA_ASSERT( psa_unlock_key_slot(slot) );
     TEST_EQUAL( slot->state, PSA_STATE_EMPTY );
@@ -372,17 +417,35 @@ void slot_persistent_reading( )
     TEST_EQUAL( slot->reader_count, 1 );
     TEST_EQUAL( slot->state, PSA_STATE_WIPING );
 
+    /* Test that reading is now impossible */
+    TEST_EQUAL( psa_get_and_lock_key_slot( key_id, &slot, PSA_STATE_READING ),
+                    PSA_ERROR_BAD_STATE );
+
+    /* Second purge should error out */
+    TEST_EQUAL( psa_purge_key( key_id ), PSA_ERROR_BAD_STATE );
+
+    /* Test that closing at this stage is impossible */
+    TEST_EQUAL( psa_close_key( key_id ), PSA_ERROR_BAD_STATE );
+    TEST_EQUAL( slot->state, PSA_STATE_WIPING );
+
     PSA_ASSERT( psa_unlock_key_slot(slot) );
     TEST_EQUAL( slot->state, PSA_STATE_EMPTY );
     TEST_EQUAL( slot->reader_count, 0 );
 
-    /* Open a purged slot, test closing while reading */
+    /* Lock a purged slot, test closing while reading */
     PSA_ASSERT( psa_get_and_lock_key_slot( key_id, &slot, PSA_STATE_READING ) );
     TEST_EQUAL( slot->state, PSA_STATE_READING );
     TEST_EQUAL( slot->reader_count, 1 );
 
     TEST_EQUAL( psa_close_key( key_id ), PSA_ERROR_DELAYED );
     TEST_EQUAL( slot->reader_count, 1 );
+    TEST_EQUAL( slot->state, PSA_STATE_WIPING );
+
+    /* Second closing should error out */
+    TEST_EQUAL( psa_close_key( key_id ), PSA_ERROR_BAD_STATE );
+
+    /* Test that purging at this stage is impossible */
+    TEST_EQUAL( psa_purge_key( key_id ), PSA_ERROR_BAD_STATE );
     TEST_EQUAL( slot->state, PSA_STATE_WIPING );
 
     PSA_ASSERT( psa_unlock_key_slot(slot) );
@@ -393,6 +456,63 @@ void slot_persistent_reading( )
     PSA_ASSERT( psa_get_and_lock_key_slot( key_id, &slot, PSA_STATE_READING ) );
     TEST_EQUAL( slot->state, PSA_STATE_READING );
     TEST_EQUAL( slot->reader_count, 1 );
+
+    TEST_EQUAL( psa_destroy_key( key_id ), PSA_ERROR_DELAYED );
+    TEST_EQUAL( slot->reader_count, 1 );
+    TEST_EQUAL( slot->state, PSA_STATE_DESTROYING );
+
+    /* Test that reading is now impossible */
+    TEST_EQUAL( psa_get_and_lock_key_slot( key_id, &slot, PSA_STATE_READING ),
+                    PSA_ERROR_BAD_STATE );
+
+    /* Second destruction should error out */
+    TEST_EQUAL( psa_destroy_key( key_id ), PSA_ERROR_BAD_STATE );
+
+    /* Test that closing at this stage is impossible */
+    TEST_EQUAL( psa_close_key( key_id ), PSA_ERROR_BAD_STATE );
+    TEST_EQUAL( slot->state, PSA_STATE_DESTROYING );
+
+    /* Test that purging at this stage is impossible */
+    TEST_EQUAL( psa_purge_key( key_id ), PSA_ERROR_BAD_STATE );
+    TEST_EQUAL( slot->state, PSA_STATE_DESTROYING );
+
+    PSA_ASSERT( psa_unlock_key_slot(slot) );
+    TEST_EQUAL( slot->state, PSA_STATE_EMPTY );
+    TEST_EQUAL( slot->reader_count, 0 );
+
+    /* Closing->destroying while reading */
+    PSA_ASSERT( psa_generate_key( &attributes, &key_id ) );
+    TEST_EQUAL( slot->state, PSA_STATE_UNUSED );
+    TEST_EQUAL( slot->reader_count, 0 );
+
+    PSA_ASSERT( psa_get_and_lock_key_slot( key_id, &slot, PSA_STATE_READING ) );
+    TEST_EQUAL( slot->state, PSA_STATE_READING );
+    TEST_EQUAL( slot->reader_count, 1 );
+
+    TEST_EQUAL( psa_close_key( key_id ), PSA_ERROR_DELAYED );
+    TEST_EQUAL( slot->reader_count, 1 );
+    TEST_EQUAL( slot->state, PSA_STATE_WIPING );
+
+    TEST_EQUAL( psa_destroy_key( key_id ), PSA_ERROR_DELAYED );
+    TEST_EQUAL( slot->reader_count, 1 );
+    TEST_EQUAL( slot->state, PSA_STATE_DESTROYING );
+
+    PSA_ASSERT( psa_unlock_key_slot(slot) );
+    TEST_EQUAL( slot->state, PSA_STATE_EMPTY );
+    TEST_EQUAL( slot->reader_count, 0 );
+
+    /* Purging->destroying while reading */
+    PSA_ASSERT( psa_generate_key( &attributes, &key_id ) );
+    TEST_EQUAL( slot->state, PSA_STATE_UNUSED );
+    TEST_EQUAL( slot->reader_count, 0 );
+
+    PSA_ASSERT( psa_get_and_lock_key_slot( key_id, &slot, PSA_STATE_READING ) );
+    TEST_EQUAL( slot->state, PSA_STATE_READING );
+    TEST_EQUAL( slot->reader_count, 1 );
+
+    TEST_EQUAL( psa_purge_key( key_id ), PSA_ERROR_DELAYED );
+    TEST_EQUAL( slot->reader_count, 1 );
+    TEST_EQUAL( slot->state, PSA_STATE_WIPING );
 
     TEST_EQUAL( psa_destroy_key( key_id ), PSA_ERROR_DELAYED );
     TEST_EQUAL( slot->reader_count, 1 );

--- a/tests/suites/test_suite_psa_crypto_slot_management.function
+++ b/tests/suites/test_suite_psa_crypto_slot_management.function
@@ -345,7 +345,7 @@ void slot_persistent_reading( )
     psa_key_lifetime_t lifetime = PSA_KEY_LIFETIME_PERSISTENT;
     mbedtls_svc_key_id_t key_id = mbedtls_svc_key_id_make( 124, PSA_KEY_ID_USER_MIN );;
     psa_key_slot_t *slot = NULL;
-    const uint8_t key_data[32];
+    const uint8_t key_data[32] = {0};
 
     // key lifetime, usage flags, algorithm are irrelevant for this test
     psa_key_type_t key_type = PSA_KEY_TYPE_AES;

--- a/tests/suites/test_suite_psa_crypto_slot_management.function
+++ b/tests/suites/test_suite_psa_crypto_slot_management.function
@@ -142,11 +142,11 @@ psa_status_t cycle_slot_to_state( psa_key_slot_t *slot,
 /* END_HEADER */
 
 /* BEGIN_DEPENDENCIES
- * depends_on:MBEDTLS_PSA_CRYPTO_C:MBEDTLS_TEST_HOOKS
+ * depends_on:MBEDTLS_PSA_CRYPTO_C
  * END_DEPENDENCIES
  */
 
-/* BEGIN_CASE */
+/* BEGIN_CASE depends_on:MBEDTLS_TEST_HOOKS */
 void slot_state_transitions( )
 {
     PSA_INIT( );
@@ -265,12 +265,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_DEPENDENCIES
- * depends_on:MBEDTLS_PSA_CRYPTO_C:MBEDTLS_TEST_HOOKS
- * END_DEPENDENCIES
- */
-
-/* BEGIN_CASE */
+/* BEGIN_CASE depends_on:MBEDTLS_TEST_HOOKS */
 void slot_volatile_reading( )
 {
     PSA_INIT( );
@@ -342,12 +337,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_DEPENDENCIES
- * depends_on:MBEDTLS_PSA_CRYPTO_C:MBEDTLS_TEST_HOOKS
- * END_DEPENDENCIES
- */
-
-/* BEGIN_CASE */
+/* BEGIN_CASE depends_on:MBEDTLS_TEST_HOOKS:MBEDTLS_PSA_CRYPTO_STORAGE_C */
 void slot_persistent_reading( )
 {
     PSA_INIT( );
@@ -416,12 +406,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_DEPENDENCIES
- * depends_on:MBEDTLS_PSA_CRYPTO_C:MBEDTLS_TEST_HOOKS
- * END_DEPENDENCIES
- */
-
-/* BEGIN_CASE */
+/* BEGIN_CASE depends_on:MBEDTLS_TEST_HOOKS */
 void slot_locking_bad_states( )
 {
     PSA_INIT( );
@@ -458,11 +443,6 @@ exit:
     PSA_DONE( );
 }
 /* END_CASE */
-
-/* BEGIN_DEPENDENCIES
- * depends_on:MBEDTLS_PSA_CRYPTO_C
- * END_DEPENDENCIES
- */
 
 /* BEGIN_CASE */
 void transient_slot_lifecycle( int owner_id_arg,

--- a/tests/suites/test_suite_psa_crypto_slot_management.function
+++ b/tests/suites/test_suite_psa_crypto_slot_management.function
@@ -103,7 +103,357 @@ exit:
     return( 0 );
 }
 
+
+/* This test uses low-level functions to validate basic requirements for slot
+ * state transitions. */
+
+psa_status_t cycle_slot_to_state( psa_key_slot_t *slot,
+                                       psa_key_slot_state_t target_state )
+{
+    psa_status_t status = PSA_SUCCESS;
+    while( slot->state != target_state && status == PSA_SUCCESS )
+    {
+        switch( slot->state )
+        {
+            case PSA_STATE_EMPTY:
+                status = psa_slot_change_state( slot, PSA_STATE_CREATING );
+                break;
+            case PSA_STATE_CREATING:
+                status = psa_slot_change_state( slot, PSA_STATE_UNUSED );
+                break;
+            case PSA_STATE_UNUSED:
+                status = psa_slot_change_state( slot, PSA_STATE_READING );
+                break;
+            case PSA_STATE_READING:
+                if( target_state == PSA_STATE_DESTROYING )
+                    status = psa_slot_change_state( slot, PSA_STATE_DESTROYING );
+                else
+                    status = psa_slot_change_state( slot, PSA_STATE_WIPING );
+                break;
+            case PSA_STATE_WIPING: // fallthrough
+            case PSA_STATE_DESTROYING:
+                status = psa_slot_change_state( slot, PSA_STATE_EMPTY );
+                break;
+        }
+    }
+    return status;
+}
+
 /* END_HEADER */
+
+/* BEGIN_DEPENDENCIES
+ * depends_on:MBEDTLS_PSA_CRYPTO_C:MBEDTLS_TEST_HOOKS
+ * END_DEPENDENCIES
+ */
+
+/* BEGIN_CASE */
+void slot_state_transitions( )
+{
+    PSA_INIT( );
+    psa_key_slot_t *slot = NULL;
+    size_t slot_idx;
+    mbedtls_svc_key_id_t key_id = 0xfedcba98; // use an invalid initial ID
+
+    /* Test that all of the slots are empty */
+    for( slot_idx = 0; slot_idx < MBEDTLS_PSA_KEY_SLOT_COUNT; slot_idx++ )
+    {
+        slot = mbedtls_psa_get_key_slot( slot_idx );
+        TEST_ASSERT( slot->state == PSA_STATE_EMPTY );
+    }
+    /* Please note that normally, some of these calls should be protected
+     * by locking the mbedtls_psa_slots_mutex, but we are performing this
+     * test in a single thread, so this can be omitted. */
+    PSA_ASSERT( psa_get_empty_key_slot( &key_id, &slot ) );
+
+    /* Test possible state transitions from PSA_STATE_EMPTY */
+    TEST_EQUAL( psa_slot_change_state( slot, PSA_STATE_EMPTY ),
+                    PSA_ERROR_INVALID_HANDLE );
+
+    TEST_EQUAL( psa_slot_change_state( slot, PSA_STATE_READING ),
+                    PSA_ERROR_INVALID_HANDLE );
+    TEST_EQUAL( psa_slot_change_state( slot, PSA_STATE_DESTROYING ),
+                    PSA_ERROR_INVALID_HANDLE );
+
+    PSA_ASSERT( psa_slot_change_state( slot, PSA_STATE_UNUSED ) );
+    PSA_ASSERT( cycle_slot_to_state( slot, PSA_STATE_EMPTY ) );
+
+    PSA_ASSERT( psa_slot_change_state( slot, PSA_STATE_WIPING ) );
+    PSA_ASSERT( cycle_slot_to_state( slot, PSA_STATE_EMPTY ) );
+
+    PSA_ASSERT( psa_slot_change_state( slot, PSA_STATE_CREATING ) );
+
+    /* Test possible state transitions from PSA_STATE_CREATING */
+    TEST_EQUAL( psa_slot_change_state( slot, PSA_STATE_CREATING ),
+                    PSA_ERROR_BAD_STATE);
+    TEST_EQUAL( psa_slot_change_state( slot, PSA_STATE_EMPTY ),
+                    PSA_ERROR_BAD_STATE );
+    TEST_EQUAL( psa_slot_change_state( slot, PSA_STATE_READING ),
+                    PSA_ERROR_BAD_STATE );
+
+    PSA_ASSERT( psa_slot_change_state( slot, PSA_STATE_WIPING ) );
+    PSA_ASSERT( cycle_slot_to_state( slot, PSA_STATE_CREATING ) );
+
+    PSA_ASSERT( psa_slot_change_state( slot, PSA_STATE_DESTROYING ) ); // TODO - check if there are such transitions possible
+    PSA_ASSERT( cycle_slot_to_state( slot, PSA_STATE_CREATING ) );
+
+    PSA_ASSERT( psa_slot_change_state( slot, PSA_STATE_UNUSED ) );
+
+    /* Test possible state transitions from PSA_STATE_UNUSED */
+    TEST_EQUAL( psa_slot_change_state( slot, PSA_STATE_UNUSED ),
+                    PSA_ERROR_BAD_STATE);
+    TEST_EQUAL( psa_slot_change_state( slot, PSA_STATE_EMPTY ),
+                    PSA_ERROR_BAD_STATE );
+    TEST_EQUAL( psa_slot_change_state( slot, PSA_STATE_CREATING ),
+                    PSA_ERROR_BAD_STATE );
+
+    PSA_ASSERT( psa_slot_change_state( slot, PSA_STATE_WIPING ) );
+    PSA_ASSERT( cycle_slot_to_state( slot, PSA_STATE_UNUSED ) );
+
+    PSA_ASSERT( psa_slot_change_state( slot, PSA_STATE_DESTROYING ) );
+    PSA_ASSERT( cycle_slot_to_state( slot, PSA_STATE_UNUSED ) );
+
+    PSA_ASSERT( psa_slot_change_state( slot, PSA_STATE_READING ) );
+
+    /* Test possible state transitions from PSA_STATE_READING */
+    PSA_ASSERT( psa_slot_change_state( slot, PSA_STATE_READING ) );
+
+    TEST_EQUAL( psa_slot_change_state( slot, PSA_STATE_EMPTY ),
+                    PSA_ERROR_BAD_STATE );
+    TEST_EQUAL( psa_slot_change_state( slot, PSA_STATE_CREATING ),
+                    PSA_ERROR_BAD_STATE );
+
+    PSA_ASSERT( psa_slot_change_state( slot, PSA_STATE_UNUSED ) );
+    PSA_ASSERT( cycle_slot_to_state( slot, PSA_STATE_READING ) );
+
+    PSA_ASSERT( psa_slot_change_state( slot, PSA_STATE_WIPING ) );
+    PSA_ASSERT( cycle_slot_to_state( slot, PSA_STATE_READING ) );
+
+    PSA_ASSERT( psa_slot_change_state( slot, PSA_STATE_DESTROYING ) );
+
+    /* Test possible state transitions from PSA_STATE_DESTROYING */
+    TEST_EQUAL( psa_slot_change_state( slot, PSA_STATE_DESTROYING ),
+                    PSA_ERROR_BAD_STATE );
+    TEST_EQUAL( psa_slot_change_state( slot, PSA_STATE_CREATING ),
+                    PSA_ERROR_BAD_STATE );
+    TEST_EQUAL( psa_slot_change_state( slot, PSA_STATE_UNUSED ),
+                    PSA_ERROR_BAD_STATE );
+    TEST_EQUAL( psa_slot_change_state( slot, PSA_STATE_READING ),
+                    PSA_ERROR_BAD_STATE );
+
+    PSA_ASSERT( psa_slot_change_state( slot, PSA_STATE_EMPTY ) );
+    PSA_ASSERT( psa_slot_change_state( slot, PSA_STATE_WIPING ) );
+
+    /* Test possible state transitions from PSA_STATE_WIPING */
+    TEST_EQUAL( psa_slot_change_state( slot, PSA_STATE_WIPING ),
+                    PSA_ERROR_BAD_STATE );
+    TEST_EQUAL( psa_slot_change_state( slot, PSA_STATE_CREATING ),
+                    PSA_ERROR_BAD_STATE );
+    TEST_EQUAL( psa_slot_change_state( slot, PSA_STATE_UNUSED ),
+                    PSA_ERROR_BAD_STATE );
+    TEST_EQUAL( psa_slot_change_state( slot, PSA_STATE_READING ),
+                    PSA_ERROR_BAD_STATE );
+
+    PSA_ASSERT( psa_slot_change_state( slot, PSA_STATE_DESTROYING ) );
+    PSA_ASSERT( cycle_slot_to_state( slot, PSA_STATE_WIPING ) );
+
+    PSA_ASSERT( psa_slot_change_state( slot, PSA_STATE_EMPTY ) );
+
+exit:
+    PSA_DONE( );
+}
+/* END_CASE */
+
+/* BEGIN_DEPENDENCIES
+ * depends_on:MBEDTLS_PSA_CRYPTO_C:MBEDTLS_TEST_HOOKS
+ * END_DEPENDENCIES
+ */
+
+/* BEGIN_CASE */
+void slot_volatile_reading( )
+{
+    PSA_INIT( );
+    psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
+    mbedtls_svc_key_id_t key_id = 0xfedcba98; // use an invalid ID
+    psa_key_slot_t *slot = NULL;
+
+    // key lifetime, usage flags, algorithm are irrelevant for this test
+    psa_key_type_t key_type = PSA_KEY_TYPE_AES;
+    size_t bits = 256;
+
+    slot = mbedtls_psa_get_key_slot( 0 );
+    psa_set_key_type( &attributes, key_type );
+    psa_set_key_bits( &attributes, bits );
+
+    /* Destruction while reading */
+    TEST_EQUAL( slot->state, PSA_STATE_EMPTY );
+    PSA_ASSERT( psa_generate_key( &attributes, &key_id ) );
+    TEST_EQUAL( slot->state, PSA_STATE_UNUSED );
+    TEST_EQUAL( slot->reader_count, 0 );
+
+    PSA_ASSERT( psa_get_and_lock_key_slot( key_id, &slot, PSA_STATE_READING ) );
+    TEST_EQUAL( slot->state, PSA_STATE_READING );
+    TEST_EQUAL( slot->reader_count, 1 );
+
+    TEST_EQUAL( psa_destroy_key( key_id ), PSA_ERROR_DELAYED );
+    TEST_EQUAL( slot->reader_count, 1 );
+    TEST_EQUAL( slot->state, PSA_STATE_DESTROYING );
+
+    PSA_ASSERT( psa_unlock_key_slot(slot) );
+    TEST_EQUAL( slot->state, PSA_STATE_EMPTY );
+    TEST_EQUAL( slot->reader_count, 0 );
+
+    /* Purging while reading - does nothing */
+
+    PSA_ASSERT( psa_generate_key( &attributes, &key_id ) );
+    TEST_EQUAL( slot->state, PSA_STATE_UNUSED );
+    TEST_EQUAL( slot->reader_count, 0 );
+
+    PSA_ASSERT( psa_get_and_lock_key_slot( key_id, &slot, PSA_STATE_READING ) );
+    TEST_EQUAL( slot->state, PSA_STATE_READING );
+    TEST_EQUAL( slot->reader_count, 1 );
+
+    TEST_EQUAL( psa_purge_key( key_id ), PSA_SUCCESS );
+    TEST_EQUAL( slot->state, PSA_STATE_READING );
+    TEST_EQUAL( slot->reader_count,  1 );
+
+    PSA_ASSERT( psa_unlock_key_slot(slot) );
+    TEST_EQUAL( slot->state, PSA_STATE_UNUSED );
+    TEST_EQUAL( slot->reader_count, 0 );
+
+
+    /* Closing while reading */
+    PSA_ASSERT( psa_get_and_lock_key_slot( key_id, &slot, PSA_STATE_READING ) );
+    TEST_EQUAL( slot->state, PSA_STATE_READING );
+    TEST_EQUAL( slot->reader_count, 1 );
+
+    TEST_EQUAL( psa_close_key( key_id ), PSA_ERROR_DELAYED );
+    TEST_EQUAL( slot->reader_count, 1 );
+    TEST_EQUAL( slot->state, PSA_STATE_WIPING );
+
+    PSA_ASSERT( psa_unlock_key_slot(slot) );
+    TEST_EQUAL( slot->state, PSA_STATE_EMPTY );
+    TEST_EQUAL( slot->reader_count, 0 );
+
+exit:
+    PSA_DONE( );
+}
+/* END_CASE */
+
+/* BEGIN_DEPENDENCIES
+ * depends_on:MBEDTLS_PSA_CRYPTO_C:MBEDTLS_TEST_HOOKS
+ * END_DEPENDENCIES
+ */
+
+/* BEGIN_CASE */
+void slot_persistent_reading( )
+{
+    PSA_INIT( );
+    psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
+    psa_key_lifetime_t lifetime = PSA_KEY_LIFETIME_PERSISTENT;
+    mbedtls_svc_key_id_t key_id = mbedtls_svc_key_id_make( 124, PSA_KEY_ID_USER_MIN );;
+    psa_key_slot_t *slot = NULL;
+    const uint8_t key_data[32];
+
+    // key lifetime, usage flags, algorithm are irrelevant for this test
+    psa_key_type_t key_type = PSA_KEY_TYPE_AES;
+    size_t bits = 256;
+
+    slot = mbedtls_psa_get_key_slot( 0 );
+    psa_set_key_type( &attributes, key_type );
+    psa_set_key_bits( &attributes, bits );
+    psa_set_key_lifetime( &attributes, lifetime );
+    psa_set_key_id( &attributes, key_id );
+
+    /* Purging while reading */
+    TEST_EQUAL( slot->state, PSA_STATE_EMPTY );
+    PSA_ASSERT( psa_import_key( &attributes, key_data, sizeof(key_data),
+                                &key_id ) );
+    TEST_EQUAL( slot->state, PSA_STATE_UNUSED );
+    TEST_EQUAL( slot->reader_count, 0 );
+
+    PSA_ASSERT( psa_get_and_lock_key_slot( key_id, &slot, PSA_STATE_READING ) );
+    TEST_EQUAL( slot->state, PSA_STATE_READING );
+    TEST_EQUAL( slot->reader_count, 1 );
+
+    TEST_EQUAL( psa_purge_key( key_id ), PSA_ERROR_DELAYED );
+    TEST_EQUAL( slot->reader_count, 1 );
+    TEST_EQUAL( slot->state, PSA_STATE_WIPING );
+
+    PSA_ASSERT( psa_unlock_key_slot(slot) );
+    TEST_EQUAL( slot->state, PSA_STATE_EMPTY );
+    TEST_EQUAL( slot->reader_count, 0 );
+
+    /* Open a purged slot, test closing while reading */
+    PSA_ASSERT( psa_get_and_lock_key_slot( key_id, &slot, PSA_STATE_READING ) );
+    TEST_EQUAL( slot->state, PSA_STATE_READING );
+    TEST_EQUAL( slot->reader_count, 1 );
+
+    TEST_EQUAL( psa_close_key( key_id ), PSA_ERROR_DELAYED );
+    TEST_EQUAL( slot->reader_count, 1 );
+    TEST_EQUAL( slot->state, PSA_STATE_WIPING );
+
+    PSA_ASSERT( psa_unlock_key_slot(slot) );
+    TEST_EQUAL( slot->state, PSA_STATE_EMPTY );
+    TEST_EQUAL( slot->reader_count, 0 );
+
+    /* Destruction while reading */
+    PSA_ASSERT( psa_get_and_lock_key_slot( key_id, &slot, PSA_STATE_READING ) );
+    TEST_EQUAL( slot->state, PSA_STATE_READING );
+    TEST_EQUAL( slot->reader_count, 1 );
+
+    TEST_EQUAL( psa_destroy_key( key_id ), PSA_ERROR_DELAYED );
+    TEST_EQUAL( slot->reader_count, 1 );
+    TEST_EQUAL( slot->state, PSA_STATE_DESTROYING );
+
+    PSA_ASSERT( psa_unlock_key_slot(slot) );
+    TEST_EQUAL( slot->state, PSA_STATE_EMPTY );
+    TEST_EQUAL( slot->reader_count, 0 );
+exit:
+    PSA_DONE( );
+}
+/* END_CASE */
+
+/* BEGIN_DEPENDENCIES
+ * depends_on:MBEDTLS_PSA_CRYPTO_C:MBEDTLS_TEST_HOOKS
+ * END_DEPENDENCIES
+ */
+
+/* BEGIN_CASE */
+void slot_locking_bad_states( )
+{
+    PSA_INIT( );
+    psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
+    mbedtls_svc_key_id_t key_id = 0xfedcba98; // use an invalid ID
+    psa_key_slot_t *slot = NULL;
+
+    // key lifetime, usage flags, algorithm are irrelevant for this test
+    psa_key_type_t key_type = PSA_KEY_TYPE_AES;
+    size_t bits = 256;
+
+    slot = mbedtls_psa_get_key_slot( 0 );
+    psa_set_key_type( &attributes, key_type );
+    psa_set_key_bits( &attributes, bits );
+
+    /* Destruction while reading */
+    TEST_EQUAL( slot->state, PSA_STATE_EMPTY );
+    PSA_ASSERT( psa_generate_key( &attributes, &key_id ) );
+    TEST_EQUAL( slot->state, PSA_STATE_UNUSED );
+    TEST_EQUAL( slot->reader_count, 0 );
+
+    TEST_EQUAL( psa_get_and_lock_key_slot( key_id, &slot, PSA_STATE_EMPTY ),
+                    PSA_ERROR_NOT_SUPPORTED );
+
+    PSA_ASSERT( psa_get_and_lock_key_slot( key_id, &slot, PSA_STATE_READING ) );
+    TEST_EQUAL( psa_slot_change_state(slot, PSA_STATE_UNUSED ), PSA_ERROR_BAD_STATE );
+    TEST_EQUAL( psa_slot_change_state(slot, PSA_STATE_EMPTY ), PSA_ERROR_BAD_STATE );
+
+    PSA_ASSERT( psa_unlock_key_slot(slot) );
+    PSA_ASSERT( psa_destroy_key( key_id ) );
+
+exit:
+    PSA_DONE( );
+}
+/* END_CASE */
 
 /* BEGIN_DEPENDENCIES
  * depends_on:MBEDTLS_PSA_CRYPTO_C

--- a/tests/suites/test_suite_psa_crypto_slot_management.function
+++ b/tests/suites/test_suite_psa_crypto_slot_management.function
@@ -292,7 +292,7 @@ void slot_volatile_reading( )
     TEST_EQUAL( slot->state, PSA_STATE_UNUSED );
     TEST_EQUAL( slot->reader_count, 0 );
 
-    PSA_ASSERT( psa_get_and_lock_key_slot( key_id, &slot, PSA_STATE_READING ) );
+    PSA_ASSERT( psa_get_and_lock_key_slot( key_id, &slot, PSA_INTENT_READ ) );
     TEST_EQUAL( slot->state, PSA_STATE_READING );
     TEST_EQUAL( slot->reader_count, 1 );
 
@@ -301,7 +301,7 @@ void slot_volatile_reading( )
     TEST_EQUAL( slot->state, PSA_STATE_DESTROYING );
 
     /* Test that reading is now impossible */
-    TEST_EQUAL( psa_get_and_lock_key_slot( key_id, &slot, PSA_STATE_READING ),
+    TEST_EQUAL( psa_get_and_lock_key_slot( key_id, &slot, PSA_INTENT_READ ),
                     PSA_ERROR_BAD_STATE );
     /* Second destruction should error out */
     TEST_EQUAL( psa_destroy_key( key_id ), PSA_ERROR_BAD_STATE );
@@ -310,7 +310,7 @@ void slot_volatile_reading( )
     TEST_EQUAL( psa_close_key( key_id ), PSA_ERROR_BAD_STATE );
     TEST_EQUAL( slot->state, PSA_STATE_DESTROYING );
 
-    PSA_ASSERT( psa_unlock_key_slot(slot) );
+    PSA_ASSERT( psa_unlock_key_slot( slot ) );
     TEST_EQUAL( slot->state, PSA_STATE_EMPTY );
     TEST_EQUAL( slot->reader_count, 0 );
 
@@ -319,7 +319,7 @@ void slot_volatile_reading( )
     TEST_EQUAL( slot->state, PSA_STATE_UNUSED );
     TEST_EQUAL( slot->reader_count, 0 );
 
-    PSA_ASSERT( psa_get_and_lock_key_slot( key_id, &slot, PSA_STATE_READING ) );
+    PSA_ASSERT( psa_get_and_lock_key_slot( key_id, &slot, PSA_INTENT_READ ) );
     TEST_EQUAL( slot->state, PSA_STATE_READING );
     TEST_EQUAL( slot->reader_count, 1 );
 
@@ -327,12 +327,12 @@ void slot_volatile_reading( )
     TEST_EQUAL( slot->state, PSA_STATE_READING );
     TEST_EQUAL( slot->reader_count, 1 );
 
-    PSA_ASSERT( psa_unlock_key_slot(slot) );
+    PSA_ASSERT( psa_unlock_key_slot( slot ) );
     TEST_EQUAL( slot->state, PSA_STATE_UNUSED );
     TEST_EQUAL( slot->reader_count, 0 );
 
     /* Closing while reading */
-    PSA_ASSERT( psa_get_and_lock_key_slot( key_id, &slot, PSA_STATE_READING ) );
+    PSA_ASSERT( psa_get_and_lock_key_slot( key_id, &slot, PSA_INTENT_READ ) );
     TEST_EQUAL( slot->state, PSA_STATE_READING );
     TEST_EQUAL( slot->reader_count, 1 );
 
@@ -341,7 +341,7 @@ void slot_volatile_reading( )
     TEST_EQUAL( slot->state, PSA_STATE_WIPING );
 
     /* Test that reading is now impossible */
-    TEST_EQUAL( psa_get_and_lock_key_slot( key_id, &slot, PSA_STATE_READING ),
+    TEST_EQUAL( psa_get_and_lock_key_slot( key_id, &slot, PSA_INTENT_READ ),
                     PSA_ERROR_BAD_STATE );
 
     /* Second call to close should error out */
@@ -352,7 +352,7 @@ void slot_volatile_reading( )
     TEST_EQUAL( slot->reader_count, 1 );
     TEST_EQUAL( slot->state, PSA_STATE_DESTROYING );
 
-    PSA_ASSERT( psa_unlock_key_slot(slot) );
+    PSA_ASSERT( psa_unlock_key_slot( slot ) );
     TEST_EQUAL( slot->state, PSA_STATE_EMPTY );
     TEST_EQUAL( slot->reader_count, 0 );
 
@@ -361,7 +361,7 @@ void slot_volatile_reading( )
     TEST_EQUAL( slot->state, PSA_STATE_UNUSED );
     TEST_EQUAL( slot->reader_count, 0 );
 
-    PSA_ASSERT( psa_get_and_lock_key_slot( key_id, &slot, PSA_STATE_READING ) );
+    PSA_ASSERT( psa_get_and_lock_key_slot( key_id, &slot, PSA_INTENT_READ ) );
     TEST_EQUAL( slot->state, PSA_STATE_READING );
     TEST_EQUAL( slot->reader_count, 1 );
 
@@ -373,7 +373,7 @@ void slot_volatile_reading( )
     TEST_EQUAL( slot->reader_count, 1 );
     TEST_EQUAL( slot->state, PSA_STATE_DESTROYING );
 
-    PSA_ASSERT( psa_unlock_key_slot(slot) );
+    PSA_ASSERT( psa_unlock_key_slot( slot ) );
     TEST_EQUAL( slot->state, PSA_STATE_EMPTY );
     TEST_EQUAL( slot->reader_count, 0 );
 
@@ -391,6 +391,7 @@ void slot_persistent_reading( )
     mbedtls_svc_key_id_t key_id = mbedtls_svc_key_id_make( 124, PSA_KEY_ID_USER_MIN );;
     psa_key_slot_t *slot = NULL;
     const uint8_t key_data[32] = {0};
+    psa_key_handle_t key_handle = PSA_KEY_HANDLE_INIT;
 
     // key lifetime, usage flags, algorithm are irrelevant for this test
     psa_key_type_t key_type = PSA_KEY_TYPE_AES;
@@ -409,7 +410,7 @@ void slot_persistent_reading( )
     TEST_EQUAL( slot->state, PSA_STATE_UNUSED );
     TEST_EQUAL( slot->reader_count, 0 );
 
-    PSA_ASSERT( psa_get_and_lock_key_slot( key_id, &slot, PSA_STATE_READING ) );
+    PSA_ASSERT( psa_get_and_lock_key_slot( key_id, &slot, PSA_INTENT_READ ) );
     TEST_EQUAL( slot->state, PSA_STATE_READING );
     TEST_EQUAL( slot->reader_count, 1 );
 
@@ -418,7 +419,7 @@ void slot_persistent_reading( )
     TEST_EQUAL( slot->state, PSA_STATE_WIPING );
 
     /* Test that reading is now impossible */
-    TEST_EQUAL( psa_get_and_lock_key_slot( key_id, &slot, PSA_STATE_READING ),
+    TEST_EQUAL( psa_get_and_lock_key_slot( key_id, &slot, PSA_INTENT_READ ),
                     PSA_ERROR_BAD_STATE );
 
     /* Second purge should error out */
@@ -428,12 +429,29 @@ void slot_persistent_reading( )
     TEST_EQUAL( psa_close_key( key_id ), PSA_ERROR_BAD_STATE );
     TEST_EQUAL( slot->state, PSA_STATE_WIPING );
 
-    PSA_ASSERT( psa_unlock_key_slot(slot) );
+    PSA_ASSERT( psa_unlock_key_slot( slot ) );
     TEST_EQUAL( slot->state, PSA_STATE_EMPTY );
     TEST_EQUAL( slot->reader_count, 0 );
 
+    /* Open a purged slot, test second open call without/with readers */
+    PSA_ASSERT( psa_open_key( key_id, &key_handle ) );
+    TEST_EQUAL( slot->state, PSA_STATE_UNUSED );
+
+    /* Test that double open works */
+    PSA_ASSERT( psa_open_key( key_id, &key_handle ) );
+    TEST_EQUAL( slot->state, PSA_STATE_UNUSED );
+
+    /* Test that opening a key slot that is already being read also works
+     * and does not change the key slot state */
+    PSA_ASSERT( psa_get_and_lock_key_slot( key_id, &slot, PSA_INTENT_READ ) );
+
+    PSA_ASSERT( psa_open_key( key_id, &key_handle ) );
+    TEST_EQUAL( slot->state, PSA_STATE_READING );
+    PSA_ASSERT( psa_unlock_key_slot( slot ) );
+    PSA_ASSERT( psa_close_key( key_id ) );
+
     /* Lock a purged slot, test closing while reading */
-    PSA_ASSERT( psa_get_and_lock_key_slot( key_id, &slot, PSA_STATE_READING ) );
+    PSA_ASSERT( psa_get_and_lock_key_slot( key_id, &slot, PSA_INTENT_READ ) );
     TEST_EQUAL( slot->state, PSA_STATE_READING );
     TEST_EQUAL( slot->reader_count, 1 );
 
@@ -448,12 +466,12 @@ void slot_persistent_reading( )
     TEST_EQUAL( psa_purge_key( key_id ), PSA_ERROR_BAD_STATE );
     TEST_EQUAL( slot->state, PSA_STATE_WIPING );
 
-    PSA_ASSERT( psa_unlock_key_slot(slot) );
+    PSA_ASSERT( psa_unlock_key_slot( slot ) );
     TEST_EQUAL( slot->state, PSA_STATE_EMPTY );
     TEST_EQUAL( slot->reader_count, 0 );
 
     /* Destruction while reading */
-    PSA_ASSERT( psa_get_and_lock_key_slot( key_id, &slot, PSA_STATE_READING ) );
+    PSA_ASSERT( psa_get_and_lock_key_slot( key_id, &slot, PSA_INTENT_READ ) );
     TEST_EQUAL( slot->state, PSA_STATE_READING );
     TEST_EQUAL( slot->reader_count, 1 );
 
@@ -462,7 +480,7 @@ void slot_persistent_reading( )
     TEST_EQUAL( slot->state, PSA_STATE_DESTROYING );
 
     /* Test that reading is now impossible */
-    TEST_EQUAL( psa_get_and_lock_key_slot( key_id, &slot, PSA_STATE_READING ),
+    TEST_EQUAL( psa_get_and_lock_key_slot( key_id, &slot, PSA_INTENT_READ ),
                     PSA_ERROR_BAD_STATE );
 
     /* Second destruction should error out */
@@ -476,7 +494,7 @@ void slot_persistent_reading( )
     TEST_EQUAL( psa_purge_key( key_id ), PSA_ERROR_BAD_STATE );
     TEST_EQUAL( slot->state, PSA_STATE_DESTROYING );
 
-    PSA_ASSERT( psa_unlock_key_slot(slot) );
+    PSA_ASSERT( psa_unlock_key_slot( slot ) );
     TEST_EQUAL( slot->state, PSA_STATE_EMPTY );
     TEST_EQUAL( slot->reader_count, 0 );
 
@@ -485,7 +503,7 @@ void slot_persistent_reading( )
     TEST_EQUAL( slot->state, PSA_STATE_UNUSED );
     TEST_EQUAL( slot->reader_count, 0 );
 
-    PSA_ASSERT( psa_get_and_lock_key_slot( key_id, &slot, PSA_STATE_READING ) );
+    PSA_ASSERT( psa_get_and_lock_key_slot( key_id, &slot, PSA_INTENT_READ ) );
     TEST_EQUAL( slot->state, PSA_STATE_READING );
     TEST_EQUAL( slot->reader_count, 1 );
 
@@ -497,7 +515,7 @@ void slot_persistent_reading( )
     TEST_EQUAL( slot->reader_count, 1 );
     TEST_EQUAL( slot->state, PSA_STATE_DESTROYING );
 
-    PSA_ASSERT( psa_unlock_key_slot(slot) );
+    PSA_ASSERT( psa_unlock_key_slot( slot ) );
     TEST_EQUAL( slot->state, PSA_STATE_EMPTY );
     TEST_EQUAL( slot->reader_count, 0 );
 
@@ -506,7 +524,7 @@ void slot_persistent_reading( )
     TEST_EQUAL( slot->state, PSA_STATE_UNUSED );
     TEST_EQUAL( slot->reader_count, 0 );
 
-    PSA_ASSERT( psa_get_and_lock_key_slot( key_id, &slot, PSA_STATE_READING ) );
+    PSA_ASSERT( psa_get_and_lock_key_slot( key_id, &slot, PSA_INTENT_READ ) );
     TEST_EQUAL( slot->state, PSA_STATE_READING );
     TEST_EQUAL( slot->reader_count, 1 );
 
@@ -518,7 +536,7 @@ void slot_persistent_reading( )
     TEST_EQUAL( slot->reader_count, 1 );
     TEST_EQUAL( slot->state, PSA_STATE_DESTROYING );
 
-    PSA_ASSERT( psa_unlock_key_slot(slot) );
+    PSA_ASSERT( psa_unlock_key_slot( slot ) );
     TEST_EQUAL( slot->state, PSA_STATE_EMPTY );
     TEST_EQUAL( slot->reader_count, 0 );
 exit:
@@ -549,14 +567,11 @@ void slot_locking_bad_states( )
     TEST_EQUAL( slot->state, PSA_STATE_UNUSED );
     TEST_EQUAL( slot->reader_count, 0 );
 
-    TEST_EQUAL( psa_get_and_lock_key_slot( key_id, &slot, PSA_STATE_EMPTY ),
-                    PSA_ERROR_NOT_SUPPORTED );
-
-    PSA_ASSERT( psa_get_and_lock_key_slot( key_id, &slot, PSA_STATE_READING ) );
+    PSA_ASSERT( psa_get_and_lock_key_slot( key_id, &slot, PSA_INTENT_READ ) );
     TEST_EQUAL( psa_slot_change_state(slot, PSA_STATE_UNUSED ), PSA_ERROR_BAD_STATE );
     TEST_EQUAL( psa_slot_change_state(slot, PSA_STATE_EMPTY ), PSA_ERROR_BAD_STATE );
 
-    PSA_ASSERT( psa_unlock_key_slot(slot) );
+    PSA_ASSERT( psa_unlock_key_slot( slot ) );
     PSA_ASSERT( psa_destroy_key( key_id ) );
 
 exit:


### PR DESCRIPTION
Protect access to key slot data & metadata by a global mutex.
Introduce a state machine to handle psa key slot states in a more robust way.
Split key destruction into two parts to be able to delay the destruction once no readers are active.

**State graph:**
```
                │
           ┌────▼─────┐  ┌──────────┐
      ┌────┤  EMPTY   ◄──┤DESTROYING│
      │    └─┬────┬──▲┘  └──▲──▲────┘
┌─────▼────┐ │ ┌──▼──┴────┐ │  │
│ CREATING │ │ │  WIPING  ├─┘  │
└──┬─┬─────┘ │ └──────▲───┘    │
   │ │  ┌────▼─────┐  ├────────┘
   │ └──►  UNUSED  ├──┤
   │    └──▲────┬──┘  │
   │    ┌──┴────▼──┐  │
   │  ┌─┤ READING  ├──┤
   │  │ └─▲────────┘  │
   │  └───┘           │
   └──────────────────┘ 
```
 **State transitions from:**
 **Empty state:**
 -> Wiping: cleaning slots in `psa_wipe_all_key_slots`: `psa_crypto_init`.
 -> Unused: importing an existing key that does not require creation: `psa_load_persistent_key_into_slot`, `psa_load_builtin_key_into_slot`.
 -> Creating: `psa_import_key`, `psa_copy_key`, `psa_key_derivation_output_key`, `psa_generate_key`.
 
 **Creating state:**
 -> Wiping: `psa_fail_key_creation`.
 -> Destroying: UNUSED; TODO - could/should it happen? 
 -> Unused: `psa_finish_key_creation` from `psa_import_key`, `psa_copy_key`, `psa_key_derivation_output_key`, `psa_generate_key`.
 
 **Unused state:**
 -> Reading: Any operation that needs to read the key material. Copying, exporting, signing, verifying, enc/dec... via `psa_get_and_lock_key_slot_with_policy`.
 -> Wiping: `psa_purge_key`, `psa_close_key`, but also `psa_get_empty_key_slot` if there's an unused persistent key.
 -> Destroying: `psa_destroy_key`.
 
 **Reading state:**
 -> Reading: another reader added via `psa_get_and_lock_key_slot_with_policy`.
 -> Unused: `psa_unlock_key_slot` by the last reader.
 -> Wiping: `psa_purge_key`, `psa_close_key`;
 -> Destroying: `psa_destroy_key`.
 
 **Wiping state:**
 -> Destroying: `psa_destroy_key`.
 -> Empty: `psa_wipe_key` from `psa_close_key`, `psa_purge_key`, but also delayed wiping when the last reader is unlocked in `psa_unlock_key_slot`. Failures in `psa_get_and_lock_key_slot`, `psa_get_empty_key_slot`.
 
 **Destroying state:**
 -> Empty: `psa_finish_key_destruction` (also calls `psa_wipe_key`), `psa_destroy_key` if there are no readers, and if there was - unlocking the last one via `psa_unlock_key_slot`.
 
Open questions:
- If a destruction is scheduled (but there are some active readers), should a second destruction call return a new error, for example `PSA_ERROR_PENDING`?
- Should calling `psa_open_key` on a key slot that has pending destruction/wiping fail?
- Is it possible to go from `PSA_STATE_CREATING` to `PSA_STATE_DESTROYING`?
- Should `psa_wipe_key_slot` not work if the key slots are in use? Currently, calling `psa_wipe_all_key_slots` will wipe all key slots once it can acquire a mutex, regardless of slot states. `psa_wipe_key_slot` is surrounded by protective logic everywhere apart from `psa_wipe_all_key_slots`.
- Should the caller be notified, that, when the key slot was unlocked, an additional delayed wiping/destruction was performed? `PSA_SUCCESS_KEY_DESTROYED`? `PSA_SUCCESS_KEY_WIPED`?
- Should `psa_get_and_lock_key_slot` be renamed? In fact this function gets the key slot and tries to transition it to a desired state.

Double, simultaneous key creation test cannot be added without multithreading in tests.

This PR supercedes https://github.com/ARMmbed/mbedtls/pull/5084 and https://github.com/ARMmbed/mbedtls/pull/5226.
Partially fixes https://github.com/ARMmbed/mbedtls/issues/3263.

Status update 2023-03-29
- informally, broadly agreed on design, but have not done formal design review (significant task)
- needs significant work to add tests (probably follow-up PR to add thorough multi-threaded tests)
- interest from multiple partners and internal team