### PR TITLE
Cipher cleanup: abstract TLS mode

### DIFF
--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -173,6 +173,12 @@
 #define MBEDTLS_SSL_SOME_SUITES_USE_MAC
 #endif
 
+/* This macro determines whether a ciphersuite uses Encrypt-then-MAC with CBC */
+#if defined(MBEDTLS_SSL_SOME_SUITES_USE_CBC) && \
+    defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC)
+#define MBEDTLS_SSL_SOME_SUITES_USE_CBC_ETM
+#endif
+
 #endif /* MBEDTLS_SSL_PROTO_TLS1_2 */
 
 #if defined(MBEDTLS_SSL_SOME_SUITES_USE_MAC)
@@ -2223,16 +2229,14 @@ typedef enum {
 mbedtls_ssl_mode_t mbedtls_ssl_get_mode_from_transform(
         const mbedtls_ssl_transform *transform );
 
-#if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC) && \
-    defined(MBEDTLS_SSL_SOME_SUITES_USE_MAC)
+#if defined(MBEDTLS_SSL_SOME_SUITES_USE_CBC_ETM)
 mbedtls_ssl_mode_t mbedtls_ssl_get_mode_from_ciphersuite(
         int encrypt_then_mac,
         const mbedtls_ssl_ciphersuite_t *suite );
 #else
 mbedtls_ssl_mode_t mbedtls_ssl_get_mode_from_ciphersuite(
         const mbedtls_ssl_ciphersuite_t *suite );
-#endif /* MBEDTLS_SSL_ENCRYPT_THEN_MAC &&
-          MBEDTLS_SSL_SOME_SUITES_USE_MAC */
+#endif /* MBEDTLS_SSL_SOME_SUITES_USE_CBC_ETM */
 
 #if defined(MBEDTLS_ECDH_C)
 

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -2223,14 +2223,16 @@ typedef enum {
 mbedtls_ssl_mode_t mbedtls_ssl_get_mode_from_transform(
         const mbedtls_ssl_transform *transform );
 
-#if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC)
+#if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC) && \
+    defined(MBEDTLS_SSL_SOME_SUITES_USE_MAC)
 mbedtls_ssl_mode_t mbedtls_ssl_get_mode_from_ciphersuite(
         int encrypt_then_mac,
         const mbedtls_ssl_ciphersuite_t *suite );
 #else
 mbedtls_ssl_mode_t mbedtls_ssl_get_mode_from_ciphersuite(
         const mbedtls_ssl_ciphersuite_t *suite );
-#endif /* MBEDTLS_SSL_ENCRYPT_THEN_MAC */
+#endif /* MBEDTLS_SSL_ENCRYPT_THEN_MAC &&
+          MBEDTLS_SSL_SOME_SUITES_USE_MAC */
 
 #if defined(MBEDTLS_ECDH_C)
 

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -2220,15 +2220,15 @@ typedef enum {
     MBEDTLS_SSL_MODE_AEAD
 } mbedtls_ssl_mode_t;
 
-mbedtls_ssl_mode_t mbedtls_get_mode_from_transform(
+mbedtls_ssl_mode_t mbedtls_ssl_get_mode_from_transform(
         const mbedtls_ssl_transform *transform );
 
 #if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC)
-mbedtls_ssl_mode_t mbedtls_get_mode_from_ciphersuite(
+mbedtls_ssl_mode_t mbedtls_ssl_get_mode_from_ciphersuite(
         int encrypt_then_mac,
         const mbedtls_ssl_ciphersuite_t *suite );
 #else
-mbedtls_ssl_mode_t mbedtls_get_mode_from_ciphersuite(
+mbedtls_ssl_mode_t mbedtls_ssl_get_mode_from_ciphersuite(
         const mbedtls_ssl_ciphersuite_t *suite );
 #endif /* MBEDTLS_SSL_ENCRYPT_THEN_MAC */
 

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -2223,6 +2223,15 @@ typedef enum {
 mbedtls_ssl_mode_t mbedtls_get_mode_from_transform(
         const mbedtls_ssl_transform *transform );
 
+#if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC)
+mbedtls_ssl_mode_t mbedtls_get_mode_from_ciphersuite(
+        int encrypt_then_mac,
+        const mbedtls_ssl_ciphersuite_t *suite );
+#else
+mbedtls_ssl_mode_t mbedtls_get_mode_from_ciphersuite(
+        const mbedtls_ssl_ciphersuite_t *suite );
+#endif /* MBEDTLS_SSL_ENCRYPT_THEN_MAC */
+
 #if defined(MBEDTLS_ECDH_C)
 
 int mbedtls_ssl_tls13_read_public_ecdhe_share( mbedtls_ssl_context *ssl,

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -2210,6 +2210,19 @@ static inline int psa_ssl_status_to_mbedtls( psa_status_t status )
 }
 #endif /* MBEDTLS_USE_PSA_CRYPTO || MBEDTLS_SSL_PROTO_TLS1_3 */
 
+/**
+ * \brief       TLS record protection modes
+ */
+typedef enum {
+    MBEDTLS_SSL_MODE_STREAM = 0,
+    MBEDTLS_SSL_MODE_CBC,
+    MBEDTLS_SSL_MODE_CBC_ETM,
+    MBEDTLS_SSL_MODE_AEAD
+} mbedtls_ssl_mode_t;
+
+mbedtls_ssl_mode_t mbedtls_get_mode_from_transform(
+        const mbedtls_ssl_transform *transform );
+
 #if defined(MBEDTLS_ECDH_C)
 
 int mbedtls_ssl_tls13_read_public_ecdhe_share( mbedtls_ssl_context *ssl,

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -564,7 +564,7 @@ int mbedtls_ssl_encrypt_buf( mbedtls_ssl_context *ssl,
         return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
     }
 
-    ssl_mode = mbedtls_get_mode_from_transform( transform );
+    ssl_mode = mbedtls_ssl_get_mode_from_transform( transform );
 
     data = rec->buf + rec->data_offset;
     post_avail = rec->buf_len - ( rec->data_len + rec->data_offset );
@@ -1140,7 +1140,7 @@ int mbedtls_ssl_decrypt_buf( mbedtls_ssl_context const *ssl,
     }
 
     data = rec->buf + rec->data_offset;
-    ssl_mode = mbedtls_get_mode_from_transform( transform );
+    ssl_mode = mbedtls_ssl_get_mode_from_transform( transform );
 
 #if defined(MBEDTLS_SSL_DTLS_CONNECTION_ID)
     /*

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -523,9 +523,7 @@ int mbedtls_ssl_encrypt_buf( mbedtls_ssl_context *ssl,
                              int (*f_rng)(void *, unsigned char *, size_t),
                              void *p_rng )
 {
-#if !defined(MBEDTLS_USE_PSA_CRYPTO)
-    mbedtls_cipher_mode_t mode;
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
+    mbedtls_ssl_mode_t ssl_mode;
     int auth_done = 0;
     unsigned char * data;
     unsigned char add_data[13 + 1 + MBEDTLS_SSL_CID_OUT_LEN_MAX ];
@@ -566,14 +564,12 @@ int mbedtls_ssl_encrypt_buf( mbedtls_ssl_context *ssl,
         return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
     }
 
+    ssl_mode = mbedtls_get_mode_from_transform( transform );
+
     data = rec->buf + rec->data_offset;
     post_avail = rec->buf_len - ( rec->data_len + rec->data_offset );
     MBEDTLS_SSL_DEBUG_BUF( 4, "before encrypt: output payload",
                            data, rec->data_len );
-
-#if !defined(MBEDTLS_USE_PSA_CRYPTO)
-    mode = mbedtls_cipher_get_cipher_mode( &transform->cipher_ctx_enc );
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     if( rec->data_len > MBEDTLS_SSL_OUT_CONTENT_LEN )
     {
@@ -654,17 +650,8 @@ int mbedtls_ssl_encrypt_buf( mbedtls_ssl_context *ssl,
      * Add MAC before if needed
      */
 #if defined(MBEDTLS_SSL_SOME_SUITES_USE_MAC)
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
-    if ( transform->psa_alg == MBEDTLS_SSL_NULL_CIPHER  ||
-            ( transform->psa_alg == PSA_ALG_CBC_NO_PADDING
-#else
-    if( mode == MBEDTLS_MODE_STREAM ||
-        ( mode == MBEDTLS_MODE_CBC
-#endif
-#if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC)
-          && transform->encrypt_then_mac == MBEDTLS_SSL_ETM_DISABLED
-#endif
-        ) )
+    if( ssl_mode == MBEDTLS_SSL_MODE_STREAM ||
+        ssl_mode == MBEDTLS_SSL_MODE_CBC )
     {
         if( post_avail < transform->maclen )
         {
@@ -748,11 +735,7 @@ int mbedtls_ssl_encrypt_buf( mbedtls_ssl_context *ssl,
      * Encrypt
      */
 #if defined(MBEDTLS_SSL_SOME_SUITES_USE_STREAM)
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
-    if ( transform->psa_alg == MBEDTLS_SSL_NULL_CIPHER )
-#else
-    if( mode == MBEDTLS_MODE_STREAM )
-#endif
+    if( ssl_mode == MBEDTLS_SSL_MODE_STREAM )
     {
         MBEDTLS_SSL_DEBUG_MSG( 3, ( "before encrypt: msglen = %" MBEDTLS_PRINTF_SIZET ", "
                                     "including %d bytes of padding",
@@ -767,13 +750,7 @@ int mbedtls_ssl_encrypt_buf( mbedtls_ssl_context *ssl,
 #if defined(MBEDTLS_GCM_C) || \
     defined(MBEDTLS_CCM_C) || \
     defined(MBEDTLS_CHACHAPOLY_C)
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
-    if ( PSA_ALG_IS_AEAD( transform->psa_alg ) )
-#else
-    if( mode == MBEDTLS_MODE_GCM ||
-        mode == MBEDTLS_MODE_CCM ||
-        mode == MBEDTLS_MODE_CHACHAPOLY )
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
+    if( ssl_mode == MBEDTLS_SSL_MODE_AEAD )
     {
         unsigned char iv[12];
         unsigned char *dynamic_iv;
@@ -891,11 +868,8 @@ int mbedtls_ssl_encrypt_buf( mbedtls_ssl_context *ssl,
     else
 #endif /* MBEDTLS_GCM_C || MBEDTLS_CCM_C || MBEDTLS_CHACHAPOLY_C */
 #if defined(MBEDTLS_SSL_SOME_SUITES_USE_CBC)
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
-    if ( transform->psa_alg == PSA_ALG_CBC_NO_PADDING )
-#else
-    if( mode == MBEDTLS_MODE_CBC )
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
+    if( ssl_mode == MBEDTLS_SSL_MODE_CBC ||
+        ssl_mode == MBEDTLS_SSL_MODE_CBC_ETM )
     {
         int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
         size_t padlen, i;
@@ -1139,13 +1113,8 @@ int mbedtls_ssl_decrypt_buf( mbedtls_ssl_context const *ssl,
                              mbedtls_record *rec )
 {
     size_t olen;
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    mbedtls_ssl_mode_t ssl_mode;
     int ret;
-
-#else
-    mbedtls_cipher_mode_t mode;
-    int ret;
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     int auth_done = 0;
 #if defined(MBEDTLS_SSL_SOME_SUITES_USE_MAC)
@@ -1171,9 +1140,7 @@ int mbedtls_ssl_decrypt_buf( mbedtls_ssl_context const *ssl,
     }
 
     data = rec->buf + rec->data_offset;
-#if !defined(MBEDTLS_USE_PSA_CRYPTO)
-    mode = mbedtls_cipher_get_cipher_mode( &transform->cipher_ctx_dec );
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
+    ssl_mode = mbedtls_get_mode_from_transform( transform );
 
 #if defined(MBEDTLS_SSL_DTLS_CONNECTION_ID)
     /*
@@ -1187,11 +1154,7 @@ int mbedtls_ssl_decrypt_buf( mbedtls_ssl_context const *ssl,
 #endif /* MBEDTLS_SSL_DTLS_CONNECTION_ID */
 
 #if defined(MBEDTLS_SSL_SOME_SUITES_USE_STREAM)
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
-    if ( transform->psa_alg == MBEDTLS_SSL_NULL_CIPHER )
-#else
-    if( mode == MBEDTLS_MODE_STREAM )
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
+    if( ssl_mode == MBEDTLS_SSL_MODE_STREAM )
     {
         /* The only supported stream cipher is "NULL",
          * so there's nothing to do here.*/
@@ -1201,13 +1164,7 @@ int mbedtls_ssl_decrypt_buf( mbedtls_ssl_context const *ssl,
 #if defined(MBEDTLS_GCM_C) || \
     defined(MBEDTLS_CCM_C) || \
     defined(MBEDTLS_CHACHAPOLY_C)
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
-    if ( PSA_ALG_IS_AEAD( transform->psa_alg ) )
-#else
-    if( mode == MBEDTLS_MODE_GCM ||
-        mode == MBEDTLS_MODE_CCM ||
-        mode == MBEDTLS_MODE_CHACHAPOLY )
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
+    if( ssl_mode == MBEDTLS_SSL_MODE_AEAD )
     {
         unsigned char iv[12];
         unsigned char *dynamic_iv;
@@ -1333,11 +1290,8 @@ int mbedtls_ssl_decrypt_buf( mbedtls_ssl_context const *ssl,
     else
 #endif /* MBEDTLS_GCM_C || MBEDTLS_CCM_C */
 #if defined(MBEDTLS_SSL_SOME_SUITES_USE_CBC)
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
-    if ( transform->psa_alg == PSA_ALG_CBC_NO_PADDING )
-#else
-    if( mode == MBEDTLS_MODE_CBC )
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
+    if( ssl_mode == MBEDTLS_SSL_MODE_CBC ||
+        ssl_mode == MBEDTLS_SSL_MODE_CBC_ETM )
     {
         size_t minlen = 0;
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
@@ -1391,7 +1345,7 @@ int mbedtls_ssl_decrypt_buf( mbedtls_ssl_context const *ssl,
          * Authenticate before decrypt if enabled
          */
 #if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC)
-        if( transform->encrypt_then_mac == MBEDTLS_SSL_ETM_ENABLED )
+        if( ssl_mode == MBEDTLS_SSL_MODE_CBC_ETM )
         {
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
             psa_mac_operation_t operation = PSA_MAC_OPERATION_INIT;

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1713,28 +1713,29 @@ void mbedtls_ssl_conf_psk_cb( mbedtls_ssl_config *conf,
 }
 #endif /* MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED */
 
-static mbedtls_ssl_mode_t mbedtls_ssl_get_base_mode(
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
-        psa_algorithm_t alg
-#else
-        mbedtls_cipher_mode_t mode
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
-        )
+static mbedtls_ssl_mode_t mbedtls_ssl_get_base_mode(
+        psa_algorithm_t alg )
 {
 #if defined(MBEDTLS_SSL_SOME_SUITES_USE_MAC)
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
     if( alg == PSA_ALG_CBC_NO_PADDING )
         return( MBEDTLS_SSL_MODE_CBC );
-#else
-    if( mode == MBEDTLS_MODE_CBC )
-        return( MBEDTLS_SSL_MODE_CBC );
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
 #endif /* MBEDTLS_SSL_SOME_SUITES_USE_MAC */
-
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
     if( PSA_ALG_IS_AEAD( alg ) )
         return( MBEDTLS_SSL_MODE_AEAD );
-#else
+    return( MBEDTLS_SSL_MODE_STREAM );
+}
+
+#else /* MBEDTLS_USE_PSA_CRYPTO */
+
+static mbedtls_ssl_mode_t mbedtls_ssl_get_base_mode(
+        mbedtls_cipher_mode_t mode )
+{
+#if defined(MBEDTLS_SSL_SOME_SUITES_USE_MAC)
+    if( mode == MBEDTLS_MODE_CBC )
+        return( MBEDTLS_SSL_MODE_CBC );
+#endif /* MBEDTLS_SSL_SOME_SUITES_USE_MAC */
+
 #if defined(MBEDTLS_GCM_C) || \
     defined(MBEDTLS_CCM_C) || \
     defined(MBEDTLS_CHACHAPOLY_C)
@@ -1743,10 +1744,10 @@ static mbedtls_ssl_mode_t mbedtls_ssl_get_base_mode(
         mode == MBEDTLS_MODE_CHACHAPOLY )
         return( MBEDTLS_SSL_MODE_AEAD );
 #endif /* MBEDTLS_GCM_C || MBEDTLS_CCM_C || MBEDTLS_CHACHAPOLY_C */
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     return( MBEDTLS_SSL_MODE_STREAM );
 }
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 static mbedtls_ssl_mode_t mbedtls_ssl_get_actual_mode(
     mbedtls_ssl_mode_t base_mode,

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1716,9 +1716,11 @@ void mbedtls_ssl_conf_psk_cb( mbedtls_ssl_config *conf,
 #endif /* MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED */
 
 static inline mbedtls_ssl_mode_t mbedtls_ssl_get_mode(
-#if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC)
+#if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC) && \
+    defined(MBEDTLS_SSL_SOME_SUITES_USE_MAC)
         int encrypt_then_mac,
-#endif /* MBEDTLS_SSL_ENCRYPT_THEN_MAC */
+#endif /* MBEDTLS_SSL_ENCRYPT_THEN_MAC &&
+          MBEDTLS_SSL_SOME_SUITES_USE_MAC */
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
         psa_algorithm_t alg
 #else
@@ -1772,26 +1774,32 @@ mbedtls_ssl_mode_t mbedtls_ssl_get_mode_from_transform(
 {
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     return mbedtls_ssl_get_mode(
-#if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC)
+#if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC) && \
+    defined(MBEDTLS_SSL_SOME_SUITES_USE_MAC)
             transform->encrypt_then_mac,
-#endif /* MBEDTLS_SSL_ENCRYPT_THEN_MAC */
+#endif /* MBEDTLS_SSL_ENCRYPT_THEN_MAC &&
+          MBEDTLS_SSL_SOME_SUITES_USE_MAC */
             transform->psa_alg );
 #else
     mbedtls_cipher_mode_t mode =
         mbedtls_cipher_get_cipher_mode( &transform->cipher_ctx_enc );
 
     return mbedtls_ssl_get_mode(
-#if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC)
+#if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC) && \
+    defined(MBEDTLS_SSL_SOME_SUITES_USE_MAC)
             transform->encrypt_then_mac,
-#endif /* MBEDTLS_SSL_ENCRYPT_THEN_MAC */
+#endif /* MBEDTLS_SSL_ENCRYPT_THEN_MAC &&
+          MBEDTLS_SSL_SOME_SUITES_USE_MAC */
             mode );
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 }
 
 mbedtls_ssl_mode_t mbedtls_ssl_get_mode_from_ciphersuite(
-#if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC)
+#if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC) && \
+    defined(MBEDTLS_SSL_SOME_SUITES_USE_MAC)
         int encrypt_then_mac,
-#endif /* MBEDTLS_SSL_ENCRYPT_THEN_MAC */
+#endif /* MBEDTLS_SSL_ENCRYPT_THEN_MAC &&
+          MBEDTLS_SSL_SOME_SUITES_USE_MAC */
         const mbedtls_ssl_ciphersuite_t *suite )
 {
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
@@ -1803,9 +1811,11 @@ mbedtls_ssl_mode_t mbedtls_ssl_get_mode_from_ciphersuite(
     status = mbedtls_ssl_cipher_to_psa( suite->cipher, 0, &alg, &type, &size );
     if( status == PSA_SUCCESS )
         return mbedtls_ssl_get_mode(
-#if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC)
+#if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC) && \
+    defined(MBEDTLS_SSL_SOME_SUITES_USE_MAC)
             encrypt_then_mac,
-#endif /* MBEDTLS_SSL_ENCRYPT_THEN_MAC */
+#endif /* MBEDTLS_SSL_ENCRYPT_THEN_MAC &&
+          MBEDTLS_SSL_SOME_SUITES_USE_MAC */
             alg );
 #else
     const mbedtls_cipher_info_t *cipher =
@@ -1813,9 +1823,11 @@ mbedtls_ssl_mode_t mbedtls_ssl_get_mode_from_ciphersuite(
 
     if( cipher != NULL )
         return mbedtls_ssl_get_mode(
-#if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC)
+#if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC) && \
+    defined(MBEDTLS_SSL_SOME_SUITES_USE_MAC)
             encrypt_then_mac,
-#endif /* MBEDTLS_SSL_ENCRYPT_THEN_MAC */
+#endif /* MBEDTLS_SSL_ENCRYPT_THEN_MAC &&
+          MBEDTLS_SSL_SOME_SUITES_USE_MAC */
             mbedtls_cipher_info_get_mode( cipher ) );
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
@@ -6969,9 +6981,11 @@ static int ssl_tls12_populate_transform( mbedtls_ssl_transform *transform,
     }
 
     ssl_mode = mbedtls_ssl_get_mode_from_ciphersuite(
-#if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC)
+#if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC) && \
+    defined(MBEDTLS_SSL_SOME_SUITES_USE_MAC)
                                         encrypt_then_mac,
-#endif /* MBEDTLS_SSL_ENCRYPT_THEN_MAC */
+#endif /* MBEDTLS_SSL_ENCRYPT_THEN_MAC &&
+          MBEDTLS_SSL_SOME_SUITES_USE_MAC */
                                         ciphersuite_info );
 
     if( ssl_mode == MBEDTLS_SSL_MODE_AEAD )

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1715,7 +1715,7 @@ void mbedtls_ssl_conf_psk_cb( mbedtls_ssl_config *conf,
 }
 #endif /* MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED */
 
-static inline mbedtls_ssl_mode_t mbedtls_get_mode(
+static inline mbedtls_ssl_mode_t mbedtls_ssl_get_mode(
 #if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC)
         int encrypt_then_mac,
 #endif /* MBEDTLS_SSL_ENCRYPT_THEN_MAC */
@@ -1771,7 +1771,7 @@ mbedtls_ssl_mode_t mbedtls_ssl_get_mode_from_transform(
                     const mbedtls_ssl_transform *transform )
 {
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
-    return mbedtls_get_mode(
+    return mbedtls_ssl_get_mode(
 #if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC)
             transform->encrypt_then_mac,
 #endif /* MBEDTLS_SSL_ENCRYPT_THEN_MAC */
@@ -1780,7 +1780,7 @@ mbedtls_ssl_mode_t mbedtls_ssl_get_mode_from_transform(
     mbedtls_cipher_mode_t mode =
         mbedtls_cipher_get_cipher_mode( &transform->cipher_ctx_enc );
 
-    return mbedtls_get_mode(
+    return mbedtls_ssl_get_mode(
 #if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC)
             transform->encrypt_then_mac,
 #endif /* MBEDTLS_SSL_ENCRYPT_THEN_MAC */
@@ -1802,7 +1802,7 @@ mbedtls_ssl_mode_t mbedtls_ssl_get_mode_from_ciphersuite(
 
     status = mbedtls_ssl_cipher_to_psa( suite->cipher, 0, &alg, &type, &size );
     if( status == PSA_SUCCESS )
-        return mbedtls_get_mode(
+        return mbedtls_ssl_get_mode(
 #if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC)
             encrypt_then_mac,
 #endif /* MBEDTLS_SSL_ENCRYPT_THEN_MAC */
@@ -1812,7 +1812,7 @@ mbedtls_ssl_mode_t mbedtls_ssl_get_mode_from_ciphersuite(
             mbedtls_cipher_info_from_type( suite->cipher );
 
     if( cipher != NULL )
-        return mbedtls_get_mode(
+        return mbedtls_ssl_get_mode(
 #if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC)
             encrypt_then_mac,
 #endif /* MBEDTLS_SSL_ENCRYPT_THEN_MAC */

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -7114,10 +7114,7 @@ static int ssl_tls12_populate_transform( mbedtls_ssl_transform *transform,
 
         /* IV length */
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
-        if( ssl_mode == MBEDTLS_SSL_MODE_STREAM )
-            transform->ivlen = 0;
-        else
-            transform->ivlen = PSA_CIPHER_IV_LENGTH( key_type, alg );
+        transform->ivlen = PSA_CIPHER_IV_LENGTH( key_type, alg );
 #else
         transform->ivlen = cipher_info->iv_size;
 #endif /* MBEDTLS_USE_PSA_CRYPTO */

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -383,11 +383,9 @@ typedef int ssl_tls_prf_t(const unsigned char *, size_t, const char *,
 static int ssl_tls12_populate_transform( mbedtls_ssl_transform *transform,
                                    int ciphersuite,
                                    const unsigned char master[48],
-#if defined(MBEDTLS_SSL_SOME_SUITES_USE_MAC) && \
-    defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC)
+#if defined(MBEDTLS_SSL_SOME_SUITES_USE_CBC_ETM)
                                    int encrypt_then_mac,
-#endif /* MBEDTLS_SSL_ENCRYPT_THEN_MAC &&
-          MBEDTLS_SSL_SOME_SUITES_USE_MAC */
+#endif /* MBEDTLS_SSL_SOME_SUITES_USE_CBC_ETM */
                                    ssl_tls_prf_t tls_prf,
                                    const unsigned char randbytes[64],
                                    mbedtls_ssl_protocol_version tls_version,
@@ -1716,11 +1714,9 @@ void mbedtls_ssl_conf_psk_cb( mbedtls_ssl_config *conf,
 #endif /* MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED */
 
 static inline mbedtls_ssl_mode_t mbedtls_ssl_get_mode(
-#if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC) && \
-    defined(MBEDTLS_SSL_SOME_SUITES_USE_MAC)
+#if defined(MBEDTLS_SSL_SOME_SUITES_USE_CBC_ETM)
         int encrypt_then_mac,
-#endif /* MBEDTLS_SSL_ENCRYPT_THEN_MAC &&
-          MBEDTLS_SSL_SOME_SUITES_USE_MAC */
+#endif /* MBEDTLS_SSL_SOME_SUITES_USE_CBC_ETM */
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
         psa_algorithm_t alg
 #else
@@ -1774,32 +1770,26 @@ mbedtls_ssl_mode_t mbedtls_ssl_get_mode_from_transform(
 {
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     return mbedtls_ssl_get_mode(
-#if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC) && \
-    defined(MBEDTLS_SSL_SOME_SUITES_USE_MAC)
+#if defined(MBEDTLS_SSL_SOME_SUITES_USE_CBC_ETM)
             transform->encrypt_then_mac,
-#endif /* MBEDTLS_SSL_ENCRYPT_THEN_MAC &&
-          MBEDTLS_SSL_SOME_SUITES_USE_MAC */
+#endif /* MBEDTLS_SSL_SOME_SUITES_USE_CBC_ETM */
             transform->psa_alg );
 #else
     mbedtls_cipher_mode_t mode =
         mbedtls_cipher_get_cipher_mode( &transform->cipher_ctx_enc );
 
     return mbedtls_ssl_get_mode(
-#if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC) && \
-    defined(MBEDTLS_SSL_SOME_SUITES_USE_MAC)
+#if defined(MBEDTLS_SSL_SOME_SUITES_USE_CBC_ETM)
             transform->encrypt_then_mac,
-#endif /* MBEDTLS_SSL_ENCRYPT_THEN_MAC &&
-          MBEDTLS_SSL_SOME_SUITES_USE_MAC */
+#endif /* MBEDTLS_SSL_SOME_SUITES_USE_CBC_ETM */
             mode );
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 }
 
 mbedtls_ssl_mode_t mbedtls_ssl_get_mode_from_ciphersuite(
-#if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC) && \
-    defined(MBEDTLS_SSL_SOME_SUITES_USE_MAC)
+#if defined(MBEDTLS_SSL_SOME_SUITES_USE_CBC_ETM)
         int encrypt_then_mac,
-#endif /* MBEDTLS_SSL_ENCRYPT_THEN_MAC &&
-          MBEDTLS_SSL_SOME_SUITES_USE_MAC */
+#endif /* MBEDTLS_SSL_SOME_SUITES_USE_CBC_ETM */
         const mbedtls_ssl_ciphersuite_t *suite )
 {
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
@@ -1811,11 +1801,9 @@ mbedtls_ssl_mode_t mbedtls_ssl_get_mode_from_ciphersuite(
     status = mbedtls_ssl_cipher_to_psa( suite->cipher, 0, &alg, &type, &size );
     if( status == PSA_SUCCESS )
         return mbedtls_ssl_get_mode(
-#if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC) && \
-    defined(MBEDTLS_SSL_SOME_SUITES_USE_MAC)
+#if defined(MBEDTLS_SSL_SOME_SUITES_USE_CBC_ETM)
             encrypt_then_mac,
-#endif /* MBEDTLS_SSL_ENCRYPT_THEN_MAC &&
-          MBEDTLS_SSL_SOME_SUITES_USE_MAC */
+#endif /* MBEDTLS_SSL_SOME_SUITES_USE_CBC_ETM */
             alg );
 #else
     const mbedtls_cipher_info_t *cipher =
@@ -1823,11 +1811,9 @@ mbedtls_ssl_mode_t mbedtls_ssl_get_mode_from_ciphersuite(
 
     if( cipher != NULL )
         return mbedtls_ssl_get_mode(
-#if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC) && \
-    defined(MBEDTLS_SSL_SOME_SUITES_USE_MAC)
+#if defined(MBEDTLS_SSL_SOME_SUITES_USE_CBC_ETM)
             encrypt_then_mac,
-#endif /* MBEDTLS_SSL_ENCRYPT_THEN_MAC &&
-          MBEDTLS_SSL_SOME_SUITES_USE_MAC */
+#endif /* MBEDTLS_SSL_SOME_SUITES_USE_CBC_ETM */
             mbedtls_cipher_info_get_mode( cipher ) );
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
@@ -3734,11 +3720,9 @@ static int ssl_context_load( mbedtls_ssl_context *ssl,
     ret = ssl_tls12_populate_transform( ssl->transform,
                   ssl->session->ciphersuite,
                   ssl->session->master,
-#if defined(MBEDTLS_SSL_SOME_SUITES_USE_MAC) && \
-    defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC)
+#if defined(MBEDTLS_SSL_SOME_SUITES_USE_CBC_ETM)
                   ssl->session->encrypt_then_mac,
-#endif /* MBEDTLS_SSL_ENCRYPT_THEN_MAC &&
-          MBEDTLS_SSL_SOME_SUITES_USE_MAC */
+#endif /* MBEDTLS_SSL_SOME_SUITES_USE_CBC_ETM */
                   ssl_tls12prf_from_cs( ssl->session->ciphersuite ),
                   p, /* currently pointing to randbytes */
                   MBEDTLS_SSL_VERSION_TLS1_2, /* (D)TLS 1.2 is forced */
@@ -5312,11 +5296,9 @@ int mbedtls_ssl_derive_keys( mbedtls_ssl_context *ssl )
     ret = ssl_tls12_populate_transform( ssl->transform_negotiate,
                                         ssl->session_negotiate->ciphersuite,
                                         ssl->session_negotiate->master,
-#if defined(MBEDTLS_SSL_SOME_SUITES_USE_MAC) && \
-    defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC)
+#if defined(MBEDTLS_SSL_SOME_SUITES_USE_CBC_ETM)
                                         ssl->session_negotiate->encrypt_then_mac,
-#endif /* MBEDTLS_SSL_ENCRYPT_THEN_MAC &&
-          MBEDTLS_SSL_SOME_SUITES_USE_MAC */
+#endif /* MBEDTLS_SSL_SOME_SUITES_USE_CBC_ETM */
                                         ssl->handshake->tls_prf,
                                         ssl->handshake->randbytes,
                                         ssl->tls_version,
@@ -6902,11 +6884,9 @@ static mbedtls_tls_prf_types tls_prf_get_type( mbedtls_ssl_tls_prf_cb *tls_prf )
 static int ssl_tls12_populate_transform( mbedtls_ssl_transform *transform,
                                    int ciphersuite,
                                    const unsigned char master[48],
-#if defined(MBEDTLS_SSL_SOME_SUITES_USE_MAC) && \
-    defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC)
+#if defined(MBEDTLS_SSL_SOME_SUITES_USE_CBC_ETM)
                                    int encrypt_then_mac,
-#endif /* MBEDTLS_SSL_ENCRYPT_THEN_MAC &&
-          MBEDTLS_SSL_SOME_SUITES_USE_MAC */
+#endif /* MBEDTLS_SSL_SOME_SUITES_USE_CBC_ETM */
                                    ssl_tls_prf_t tls_prf,
                                    const unsigned char randbytes[64],
                                    mbedtls_ssl_protocol_version tls_version,
@@ -6950,10 +6930,9 @@ static int ssl_tls12_populate_transform( mbedtls_ssl_transform *transform,
     /*
      * Some data just needs copying into the structure
      */
-#if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC) && \
-    defined(MBEDTLS_SSL_SOME_SUITES_USE_MAC)
+#if defined(MBEDTLS_SSL_SOME_SUITES_USE_CBC_ETM)
     transform->encrypt_then_mac = encrypt_then_mac;
-#endif
+#endif /* MBEDTLS_SSL_SOME_SUITES_USE_CBC_ETM */
     transform->tls_version = tls_version;
 
 #if defined(MBEDTLS_SSL_CONTEXT_SERIALIZATION)
@@ -6981,11 +6960,9 @@ static int ssl_tls12_populate_transform( mbedtls_ssl_transform *transform,
     }
 
     ssl_mode = mbedtls_ssl_get_mode_from_ciphersuite(
-#if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC) && \
-    defined(MBEDTLS_SSL_SOME_SUITES_USE_MAC)
+#if defined(MBEDTLS_SSL_SOME_SUITES_USE_CBC_ETM)
                                         encrypt_then_mac,
-#endif /* MBEDTLS_SSL_ENCRYPT_THEN_MAC &&
-          MBEDTLS_SSL_SOME_SUITES_USE_MAC */
+#endif /* MBEDTLS_SSL_SOME_SUITES_USE_CBC_ETM */
                                         ciphersuite_info );
 
     if( ssl_mode == MBEDTLS_SSL_MODE_AEAD )

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -7103,7 +7103,7 @@ static int ssl_tls12_populate_transform( mbedtls_ssl_transform *transform,
         ssl_mode == MBEDTLS_SSL_MODE_CBC_ETM )
     {
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
-        size_t block_size = PSA_BLOCK_CIPHER_BLOCK_MAX_SIZE;
+        size_t block_size = PSA_BLOCK_CIPHER_BLOCK_LENGTH( key_type );
 #else
         size_t block_size = cipher_info->block_size;
 #endif /* MBEDTLS_USE_PSA_CRYPTO */

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1767,7 +1767,7 @@ static inline mbedtls_ssl_mode_t mbedtls_get_mode(
     return( MBEDTLS_SSL_MODE_STREAM );
 }
 
-mbedtls_ssl_mode_t mbedtls_get_mode_from_transform(
+mbedtls_ssl_mode_t mbedtls_ssl_get_mode_from_transform(
                     const mbedtls_ssl_transform *transform )
 {
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
@@ -1788,7 +1788,7 @@ mbedtls_ssl_mode_t mbedtls_get_mode_from_transform(
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 }
 
-mbedtls_ssl_mode_t mbedtls_get_mode_from_ciphersuite(
+mbedtls_ssl_mode_t mbedtls_ssl_get_mode_from_ciphersuite(
 #if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC)
         int encrypt_then_mac,
 #endif /* MBEDTLS_SSL_ENCRYPT_THEN_MAC */
@@ -6968,7 +6968,7 @@ static int ssl_tls12_populate_transform( mbedtls_ssl_transform *transform,
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
     }
 
-    ssl_mode = mbedtls_get_mode_from_ciphersuite(
+    ssl_mode = mbedtls_ssl_get_mode_from_ciphersuite(
 #if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC)
                                         encrypt_then_mac,
 #endif /* MBEDTLS_SSL_ENCRYPT_THEN_MAC */

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -1992,7 +1992,7 @@ static void ssl_write_encrypt_then_mac_ext( mbedtls_ssl_context *ssl,
     else
     {
         mbedtls_ssl_mode_t ssl_mode =
-            mbedtls_get_mode_from_ciphersuite(
+            mbedtls_ssl_get_mode_from_ciphersuite(
                 ssl->session_negotiate->encrypt_then_mac,
                 suite );
 

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -1978,13 +1978,6 @@ static void ssl_write_encrypt_then_mac_ext( mbedtls_ssl_context *ssl,
 {
     unsigned char *p = buf;
     const mbedtls_ssl_ciphersuite_t *suite = NULL;
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
-    psa_key_type_t key_type;
-    psa_algorithm_t alg;
-    size_t key_bits;
-#else
-    const mbedtls_cipher_info_t *cipher = NULL;
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     /*
      * RFC 7366: "If a server receives an encrypt-then-MAC request extension
@@ -1992,18 +1985,19 @@ static void ssl_write_encrypt_then_mac_ext( mbedtls_ssl_context *ssl,
      * with Associated Data (AEAD) ciphersuite, it MUST NOT send an
      * encrypt-then-MAC response extension back to the client."
      */
-    if( ( suite = mbedtls_ssl_ciphersuite_from_id(
-                    ssl->session_negotiate->ciphersuite ) ) == NULL ||
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
-        ( mbedtls_ssl_cipher_to_psa( suite->cipher, 0, &alg,
-                            &key_type, &key_bits ) != PSA_SUCCESS ) ||
-        alg != PSA_ALG_CBC_NO_PADDING )
-#else
-        ( cipher = mbedtls_cipher_info_from_type( suite->cipher ) ) == NULL ||
-        cipher->mode != MBEDTLS_MODE_CBC )
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
-    {
+    suite = mbedtls_ssl_ciphersuite_from_id(
+                    ssl->session_negotiate->ciphersuite );
+    if( suite == NULL )
         ssl->session_negotiate->encrypt_then_mac = MBEDTLS_SSL_ETM_DISABLED;
+    else
+    {
+        mbedtls_ssl_mode_t ssl_mode =
+            mbedtls_get_mode_from_ciphersuite(
+                ssl->session_negotiate->encrypt_then_mac,
+                suite );
+
+        if( ssl_mode != MBEDTLS_SSL_MODE_CBC_ETM )
+            ssl->session_negotiate->encrypt_then_mac = MBEDTLS_SSL_ETM_DISABLED;
     }
 
     if( ssl->session_negotiate->encrypt_then_mac == MBEDTLS_SSL_ETM_DISABLED )

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -1971,7 +1971,7 @@ static void ssl_write_cid_ext( mbedtls_ssl_context *ssl,
 }
 #endif /* MBEDTLS_SSL_DTLS_CONNECTION_ID */
 
-#if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC)
+#if defined(MBEDTLS_SSL_SOME_SUITES_USE_CBC_ETM)
 static void ssl_write_encrypt_then_mac_ext( mbedtls_ssl_context *ssl,
                                             unsigned char *buf,
                                             size_t *olen )
@@ -2016,7 +2016,7 @@ static void ssl_write_encrypt_then_mac_ext( mbedtls_ssl_context *ssl,
 
     *olen = 4;
 }
-#endif /* MBEDTLS_SSL_ENCRYPT_THEN_MAC */
+#endif /* MBEDTLS_SSL_SOME_SUITES_USE_CBC_ETM */
 
 #if defined(MBEDTLS_SSL_EXTENDED_MASTER_SECRET)
 static void ssl_write_extended_ms_ext( mbedtls_ssl_context *ssl,
@@ -2585,7 +2585,7 @@ static int ssl_write_server_hello( mbedtls_ssl_context *ssl )
     ext_len += olen;
 #endif
 
-#if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC)
+#if defined(MBEDTLS_SSL_SOME_SUITES_USE_CBC_ETM)
     ssl_write_encrypt_then_mac_ext( ssl, p + 2 + ext_len, &olen );
     ext_len += olen;
 #endif


### PR DESCRIPTION
## Description
This task is to create that enum and any helper function that's useful, and using them to simplify all the places in the code that currently use `MBEDTLS_MODE_xxx` / `cipher_get_mode()`.

Resolves #5668 

## Status
**READY**

## Requires Backporting
NO 

## Migrations
NO

## Additional comments
Any additional information that could be of interest

## Todos
- [x] Tests


## Steps to test or reproduce
test_suite_ssl & ssl-opt.sh must run clean