### PR TITLE
Update references to old Github organisation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ addons:
     - gnutls-bin
   coverity_scan:
     project:
-      name: "ARMmbed/mbedtls"
+      name: "Mbed-TLS/mbedtls"
     notification_email: support-mbedtls@arm.com
     build_command_prepend:
     build_command: make

--- a/BRANCHES.md
+++ b/BRANCHES.md
@@ -2,24 +2,24 @@
 
 At any point in time, we have a number of maintained branches, currently consisting of:
 
-- The [`master`](https://github.com/ARMmbed/mbedtls/tree/master) branch:
+- The [`master`](https://github.com/Mbed-TLS/mbedtls/tree/master) branch:
   this always contains the latest release, including all publicly available
   security fixes.
-- The [`development`](https://github.com/ARMmbed/mbedtls/tree/development) branch:
+- The [`development`](https://github.com/Mbed-TLS/mbedtls/tree/development) branch:
   this is where the current major version of Mbed TLS (version 3.x) is being
   prepared. It has API changes that make it incompatible with Mbed TLS 2.x,
   as well as all the new features and bug fixes and security fixes.
 - One or more long-time support (LTS) branches: these only get bug fixes and
   security fixes. Currently, the only supported LTS branch is:
-  [`mbedtls-2.28`](https://github.com/ARMmbed/mbedtls/tree/mbedtls-2.28).
+  [`mbedtls-2.28`](https://github.com/Mbed-TLS/mbedtls/tree/mbedtls-2.28).
 - For a short time we also have the previous LTS, which has recently ended its
   support period,
-  [`mbedtls-2.16`](https://github.com/ARMmbed/mbedtls/tree/mbedtls-2.16).
+  [`mbedtls-2.16`](https://github.com/Mbed-TLS/mbedtls/tree/mbedtls-2.16).
   This branch will move into the `archive` namespace around the time of
   the next release.
 
 We retain a number of historical branches, whose names are prefixed by `archive/`,
-such as [`archive/mbedtls-2.7`](https://github.com/ARMmbed/mbedtls/tree/archive/mbedtls-2.7).
+such as [`archive/mbedtls-2.7`](https://github.com/Mbed-TLS/mbedtls/tree/archive/mbedtls-2.7).
 These branches will not receive any changes or updates.
 
 We use [Semantic Versioning](https://semver.org/). In particular, we maintain
@@ -75,10 +75,10 @@ CONTRIBUTING](CONTRIBUTING.md#backwards-compatibility).
 
 The following branches are currently maintained:
 
-- [master](https://github.com/ARMmbed/mbedtls/tree/master)
-- [`development`](https://github.com/ARMmbed/mbedtls/)
-- [`mbedtls-2.28`](https://github.com/ARMmbed/mbedtls/tree/mbedtls-2.28)
+- [master](https://github.com/Mbed-TLS/mbedtls/tree/master)
+- [`development`](https://github.com/Mbed-TLS/mbedtls/)
+- [`mbedtls-2.28`](https://github.com/Mbed-TLS/mbedtls/tree/mbedtls-2.28)
  maintained until at least the end of 2024, see
-  <https://github.com/ARMmbed/mbedtls/releases/tag/v2.28.0>.
+  <https://github.com/Mbed-TLS/mbedtls/releases/tag/v2.28.0>.
 
 Users are urged to always use the latest version of a maintained branch.

--- a/BUGS.md
+++ b/BUGS.md
@@ -1,6 +1,6 @@
 ## Known issues
 
-Known issues in Mbed TLS are [tracked on GitHub](https://github.com/ARMmbed/mbedtls/issues).
+Known issues in Mbed TLS are [tracked on GitHub](https://github.com/Mbed-TLS/mbedtls/issues).
 
 ## Reporting a bug
 
@@ -9,12 +9,12 @@ If you think you've found a bug in Mbed TLS, please follow these steps:
 1. Make sure you're using the latest version of a
    [maintained branch](BRANCHES.md): `master`, `development`,
    or a long-time support branch.
-2. Check [GitHub](https://github.com/ARMmbed/mbedtls/issues) to see if
+2. Check [GitHub](https://github.com/Mbed-TLS/mbedtls/issues) to see if
    your issue has already been reported. If not, …
 3. If the issue is a security risk (for example: buffer overflow,
    data leak), please report it confidentially as described in
    [`SECURITY.md`](SECURITY.md). If not, …
-4. Please [create an issue on on GitHub](https://github.com/ARMmbed/mbedtls/issues).
+4. Please [create an issue on on GitHub](https://github.com/Mbed-TLS/mbedtls/issues).
 
 Please do not use GitHub for support questions. If you want to know
 how to do something with Mbed TLS, please see [`SUPPORT.md`](SUPPORT.md) for available documentation and support channels.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,8 +14,8 @@ Coding Standards
 
 Making a Contribution
 ---------------------
-1. [Check for open issues](https://github.com/ARMmbed/mbedtls/issues) or [start a discussion](https://lists.trustedfirmware.org/mailman3/lists/mbed-tls.lists.trustedfirmware.org) around a feature idea or a bug.
-1. Fork the [Mbed TLS repository on GitHub](https://github.com/ARMmbed/mbedtls) to start making your changes. As a general rule, you should use the ["development" branch](https://github.com/ARMmbed/mbedtls/tree/development) as a basis.
+1. [Check for open issues](https://github.com/Mbed-TLS/mbedtls/issues) or [start a discussion](https://lists.trustedfirmware.org/mailman3/lists/mbed-tls.lists.trustedfirmware.org) around a feature idea or a bug.
+1. Fork the [Mbed TLS repository on GitHub](https://github.com/Mbed-TLS/mbedtls) to start making your changes. As a general rule, you should use the ["development" branch](https://github.com/Mbed-TLS/mbedtls/tree/development) as a basis.
 1. Write a test which shows that the bug was fixed or that the feature works as expected.
 1. Send a pull request (PR) and work with us until it gets merged and published. Contributions may need some modifications, so a few rounds of review and fixing may be necessary. We will include your name in the ChangeLog :)
 1. For quick merging, the contribution should be short, and concentrated on a single feature or topic. The larger the contribution is, the longer it would take to review it and merge it.
@@ -47,13 +47,13 @@ When backporting to these branches please observe the following rules:
 1. All bug fixes that correct a defect that is also present in an LTS branch must be backported to that LTS branch. If a bug fix introduces a change to the API such as a new function, the fix should be reworked to avoid the API change. API changes without very strong justification are unlikely to be accepted.
 1. If a contribution is a new feature or enhancement, no backporting is required. Exceptions to this may be additional test cases or quality improvements such as changes to build or test scripts.
 
-It would be highly appreciated if contributions are backported to LTS branches in addition to the [development branch](https://github.com/ARMmbed/mbedtls/tree/development) by contributors.
+It would be highly appreciated if contributions are backported to LTS branches in addition to the [development branch](https://github.com/Mbed-TLS/mbedtls/tree/development) by contributors.
 
 The list of maintained branches can be found in the [Current Branches section
 of BRANCHES.md](BRANCHES.md#current-branches).
 
 The only currently maintained LTS branch is:
-1. [mbedtls-2.16](https://github.com/ARMmbed/mbedtls/tree/mbedtls-2.16)
+1. [mbedtls-2.16](https://github.com/Mbed-TLS/mbedtls/tree/mbedtls-2.16)
 
 
 Tests
@@ -72,7 +72,7 @@ Continuous Integration Tests
 ----------------------------
 Once a PR has been made, the Continuous Integration (CI) tests are triggered and run. You should follow the result of the CI tests, and fix failures.
 
-It is advised to enable the [githooks scripts](https://github.com/ARMmbed/mbedtls/tree/development/tests/git-scripts) prior to pushing your changes, for catching some of the issues as early as possible.
+It is advised to enable the [githooks scripts](https://github.com/Mbed-TLS/mbedtls/tree/development/tests/git-scripts) prior to pushing your changes, for catching some of the issues as early as possible.
 
 Documentation
 -------------
@@ -82,4 +82,4 @@ Mbed TLS is well documented, but if you think documentation is needed, speak out
 1. Complex parts in the code should include comments.
 1. If needed, a Readme file is advised.
 1. If a [Knowledge Base (KB)](https://tls.mbed.org/kb) article should be added, write this as a comment in the PR description.
-1. A [ChangeLog](https://github.com/ARMmbed/mbedtls/blob/development/ChangeLog.d/00README.md) entry should be added for this contribution.
+1. A [ChangeLog](https://github.com/Mbed-TLS/mbedtls/blob/development/ChangeLog.d/00README.md) entry should be added for this contribution.

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ This implementation is not yet as mature as the rest of the library. Some parts 
 
 The X.509 and TLS code can use PSA cryptography for a limited subset of operations. To enable this support, activate the compilation option `MBEDTLS_USE_PSA_CRYPTO` in `mbedtls_config.h`.
 
-There are currently a few deviations where the library does not yet implement the latest version of the specification. Please refer to the [compliance issues on Github](https://github.com/ARMmbed/mbed-crypto/labels/compliance) for an up-to-date list.
+There are currently a few deviations where the library does not yet implement the latest version of the specification. Please refer to the [compliance issues on Github](https://github.com/Mbed-TLS/mbedtls/labels/compliance) for an up-to-date list.
 
 ### Upcoming features
 
@@ -315,5 +315,5 @@ Contact
 -------
 
 * To report a security vulnerability in Mbed TLS, please email <mbed-tls-security@lists.trustedfirmware.org>. For more information, see [`SECURITY.md`](SECURITY.md).
-* To report a bug or request a feature in Mbed TLS, please [file an issue on GitHub](https://github.com/ARMmbed/mbedtls/issues/new/choose).
+* To report a bug or request a feature in Mbed TLS, please [file an issue on GitHub](https://github.com/Mbed-TLS/mbedtls/issues/new/choose).
 * Please see [`SUPPORT.md`](SUPPORT.md) for other channels for discussion and support about Mbed TLS.

--- a/docs/3.0-migration-guide.md
+++ b/docs/3.0-migration-guide.md
@@ -48,7 +48,7 @@ Attempting to access a private field directly will result in a compilation error
 
 If you were accessing structure fields directly, and these fields are not documented as public, you need to change your code. If an accessor (getter/setter) function exists, use that. Direct accessor functions are usually called `mbedtls_<MODULE>_{get,set}_<FIELD>` or `mbedtls_<MODULE>_<STRUCTURE>_{get,set}_<FIELD>`. Accessor functions that change the format may use different verbs, for example `read`/`write` for functions that import/export data from/to a text or byte string.
 
-If no accessor function exists, please open an [enhancement request against Mbed TLS](https://github.com/ARMmbed/mbedtls/issues/new?template=feature_request.md) and describe your use case. The Mbed TLS development team is aware that some useful accessor functions are missing in the 3.0 release, and we expect to add them to the first minor release(s) (3.1, etc.).
+If no accessor function exists, please open an [enhancement request against Mbed TLS](https://github.com/Mbed-TLS/mbedtls/issues/new?template=feature_request.md) and describe your use case. The Mbed TLS development team is aware that some useful accessor functions are missing in the 3.0 release, and we expect to add them to the first minor release(s) (3.1, etc.).
 
 As a last resort, you can access the field `foo` of a structure `bar` by writing `bar.MBEDTLS_PRIVATE(foo)`. Note that you do so at your own risk, since such code is likely to break in a future minor version of Mbed TLS.
 

--- a/docs/architecture/psa-migration/psa-limitations.md
+++ b/docs/architecture/psa-migration/psa-limitations.md
@@ -27,12 +27,12 @@ PSA Crypto has an API for FFDH, but it's not implemented in Mbed TLS yet.
 (Regarding FFDH, see the next section as well.) See issue [3261][ffdh] on
 github.
 
-[ffdh]: https://github.com/ARMmbed/mbedtls/issues/3261
+[ffdh]: https://github.com/Mbed-TLS/mbedtls/issues/3261
 
 PSA Crypto has an experimental API for EC J-PAKE, but it's not implemented in
 Mbed TLS yet. See the [EC J-PAKE follow-up EPIC][ecjp] on github.
 
-[ecjp]: https://github.com/orgs/ARMmbed/projects/18#column-15836385
+[ecjp]: https://github.com/orgs/Mbed-TLS/projects/1#column-17950140
 
 Arbitrary parameters for FFDH
 -----------------------------

--- a/docs/architecture/psa-migration/strategy.md
+++ b/docs/architecture/psa-migration/strategy.md
@@ -42,7 +42,7 @@ are:
 - it's incompatible with `MBEDTLS_ECP_RESTARTABLE`;
 - historical: used to be incompatible
   `MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER` (fixed early 2022, see
-    <https://github.com/ARMmbed/mbedtls/issues/5259>);
+    <https://github.com/Mbed-TLS/mbedtls/issues/5259>);
 - it does not work well with `MBEDTLS_PSA_CRYPTO_CONFIG` (could compile with
   both of them, but then `MBEDTLS_PSA_CRYPTO_CONFIG` won't have the desired
 effect)
@@ -99,8 +99,8 @@ an algorithm through a PSA driver only, without building the software
 implementation of that algorithm. But then the TLS code would consider the
 algorithm unavailable.
 
-This is tracked in https://github.com/ARMmbed/mbedtls/issues/3674 and
-https://github.com/ARMmbed/mbedtls/issues/3677. But now that I look at it with
+This is tracked in https://github.com/Mbed-TLS/mbedtls/issues/3674 and
+https://github.com/Mbed-TLS/mbedtls/issues/3677. But now that I look at it with
 fresh eyes, I don't think the approach we were planning to use would actually
 works. This needs more design effort.
 
@@ -138,7 +138,7 @@ available in entropy-less builds. (Then code using those functions still needs
 to have one version using it, for entropy-less builds, and one version using
 the standard function, for driver support in build with entropy.)
 
-See https://github.com/ARMmbed/mbedtls/issues/5156
+See https://github.com/Mbed-TLS/mbedtls/issues/5156
 
 Taking advantage of the existing abstractions layers - or not
 =============================================================

--- a/docs/architecture/tls13-support.md
+++ b/docs/architecture/tls13-support.md
@@ -324,7 +324,7 @@ TLS 1.3 specific coding rules:
     ```
 
   - To mitigate what happened here
-    (https://github.com/ARMmbed/mbedtls/pull/4882#discussion_r701704527) from
+    (https://github.com/Mbed-TLS/mbedtls/pull/4882#discussion_r701704527) from
     happening again, use always a local variable named `p` for the reading
     pointer in functions parsing TLS 1.3 data, and for the writing pointer in
     functions writing data into an output buffer and only that variable. The

--- a/docs/proposed/psa-driver-wrappers-codegen-migration-guide.md
+++ b/docs/proposed/psa-driver-wrappers-codegen-migration-guide.md
@@ -1,5 +1,5 @@
-Migrating to an auto genrated psa_crypto_driver_wrappers.c file
-===============================================================
+Migrating to an auto generated psa_crypto_driver_wrappers.c file
+================================================================
 
 **This is a specification of work in progress. The implementation is not yet merged into Mbed TLS.**
 
@@ -8,7 +8,7 @@ It is meant to give the library user migration guidelines while the Mbed TLS pro
 
 ## Introduction
 
-The design of the Driver Wrappers code generation is based on the design proposal https://github.com/ARMmbed/mbedtls/pull/5067
+The design of the Driver Wrappers code generation is based on the design proposal https://github.com/Mbed-TLS/mbedtls/pull/5067
 During the process of implementation there might be minor variations wrt versioning and broader implementation specific ideas, but the design remains the same.
 
 ## Prerequisites

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -879,23 +879,23 @@
  * cause a build to succeed but with features removed. */
 
 #if defined(MBEDTLS_HAVEGE_C) //no-check-names
-#error "MBEDTLS_HAVEGE_C was removed in Mbed TLS 3.0. See https://github.com/ARMmbed/mbedtls/issues/2599"
+#error "MBEDTLS_HAVEGE_C was removed in Mbed TLS 3.0. See https://github.com/Mbed-TLS/mbedtls/issues/2599"
 #endif
 
 #if defined(MBEDTLS_SSL_HW_RECORD_ACCEL) //no-check-names
-#error "MBEDTLS_SSL_HW_RECORD_ACCEL was removed in Mbed TLS 3.0. See https://github.com/ARMmbed/mbedtls/issues/4031"
+#error "MBEDTLS_SSL_HW_RECORD_ACCEL was removed in Mbed TLS 3.0. See https://github.com/Mbed-TLS/mbedtls/issues/4031"
 #endif
 
 #if defined(MBEDTLS_SSL_PROTO_SSL3) //no-check-names
-#error "MBEDTLS_SSL_PROTO_SSL3 (SSL v3.0 support) was removed in Mbed TLS 3.0. See https://github.com/ARMmbed/mbedtls/issues/4031"
+#error "MBEDTLS_SSL_PROTO_SSL3 (SSL v3.0 support) was removed in Mbed TLS 3.0. See https://github.com/Mbed-TLS/mbedtls/issues/4031"
 #endif
 
 #if defined(MBEDTLS_SSL_SRV_SUPPORT_SSLV2_CLIENT_HELLO) //no-check-names
-#error "MBEDTLS_SSL_SRV_SUPPORT_SSLV2_CLIENT_HELLO (SSL v2 ClientHello support) was removed in Mbed TLS 3.0. See https://github.com/ARMmbed/mbedtls/issues/4031"
+#error "MBEDTLS_SSL_SRV_SUPPORT_SSLV2_CLIENT_HELLO (SSL v2 ClientHello support) was removed in Mbed TLS 3.0. See https://github.com/Mbed-TLS/mbedtls/issues/4031"
 #endif
 
 #if defined(MBEDTLS_SSL_TRUNCATED_HMAC_COMPAT) //no-check-names
-#error "MBEDTLS_SSL_TRUNCATED_HMAC_COMPAT (compatibility with the buggy implementation of truncated HMAC in Mbed TLS up to 2.7) was removed in Mbed TLS 3.0. See https://github.com/ARMmbed/mbedtls/issues/4031"
+#error "MBEDTLS_SSL_TRUNCATED_HMAC_COMPAT (compatibility with the buggy implementation of truncated HMAC in Mbed TLS up to 2.7) was removed in Mbed TLS 3.0. See https://github.com/Mbed-TLS/mbedtls/issues/4031"
 #endif
 
 #if defined(MBEDTLS_TLS_DEFAULT_ALLOW_SHA1_IN_CERTIFICATES) //no-check-names
@@ -903,23 +903,23 @@
 #endif
 
 #if defined(MBEDTLS_ZLIB_SUPPORT) //no-check-names
-#error "MBEDTLS_ZLIB_SUPPORT was removed in Mbed TLS 3.0. See https://github.com/ARMmbed/mbedtls/issues/4031"
+#error "MBEDTLS_ZLIB_SUPPORT was removed in Mbed TLS 3.0. See https://github.com/Mbed-TLS/mbedtls/issues/4031"
 #endif
 
 #if defined(MBEDTLS_CHECK_PARAMS) //no-check-names
-#error "MBEDTLS_CHECK_PARAMS was removed in Mbed TLS 3.0. See https://github.com/ARMmbed/mbedtls/issues/4313"
+#error "MBEDTLS_CHECK_PARAMS was removed in Mbed TLS 3.0. See https://github.com/Mbed-TLS/mbedtls/issues/4313"
 #endif
 
 #if defined(MBEDTLS_SSL_CID_PADDING_GRANULARITY) //no-check-names
-#error "MBEDTLS_SSL_CID_PADDING_GRANULARITY was removed in Mbed TLS 3.0. See https://github.com/ARMmbed/mbedtls/issues/4335"
+#error "MBEDTLS_SSL_CID_PADDING_GRANULARITY was removed in Mbed TLS 3.0. See https://github.com/Mbed-TLS/mbedtls/issues/4335"
 #endif
 
 #if defined(MBEDTLS_SSL_TLS1_3_PADDING_GRANULARITY) //no-check-names
-#error "MBEDTLS_SSL_TLS1_3_PADDING_GRANULARITY was removed in Mbed TLS 3.0. See https://github.com/ARMmbed/mbedtls/issues/4335"
+#error "MBEDTLS_SSL_TLS1_3_PADDING_GRANULARITY was removed in Mbed TLS 3.0. See https://github.com/Mbed-TLS/mbedtls/issues/4335"
 #endif
 
 #if defined(MBEDTLS_SSL_TRUNCATED_HMAC) //no-check-names
-#error "MBEDTLS_SSL_TRUNCATED_HMAC was removed in Mbed TLS 3.0. See https://github.com/ARMmbed/mbedtls/issues/4341"
+#error "MBEDTLS_SSL_TRUNCATED_HMAC was removed in Mbed TLS 3.0. See https://github.com/Mbed-TLS/mbedtls/issues/4341"
 #endif
 
 /*

--- a/include/mbedtls/config_psa.h
+++ b/include/mbedtls/config_psa.h
@@ -515,7 +515,7 @@ extern "C" {
 #if !defined(MBEDTLS_PSA_ACCEL_ECC_SECP_K1_224)
 /*
  * SECP224K1 is buggy via the PSA API in Mbed TLS
- * (https://github.com/ARMmbed/mbedtls/issues/3541).
+ * (https://github.com/Mbed-TLS/mbedtls/issues/3541).
  */
 #error "SECP224K1 is buggy via the PSA API in Mbed TLS."
 #define MBEDTLS_ECP_DP_SECP224K1_ENABLED
@@ -776,7 +776,7 @@ extern "C" {
 #define PSA_WANT_ECC_SECP_K1_192
 #endif
 
-/* SECP224K1 is buggy via the PSA API (https://github.com/ARMmbed/mbedtls/issues/3541) */
+/* SECP224K1 is buggy via the PSA API (https://github.com/Mbed-TLS/mbedtls/issues/3541) */
 #if 0 && defined(MBEDTLS_ECP_DP_SECP224K1_ENABLED)
 #define MBEDTLS_PSA_BUILTIN_ECC_SECP_K1_224 1
 #define PSA_WANT_ECC_SECP_K1_224

--- a/include/psa/crypto_config.h
+++ b/include/psa/crypto_config.h
@@ -97,7 +97,7 @@
 #define PSA_WANT_ECC_SECP_K1_192                1
 /*
  * SECP224K1 is buggy via the PSA API in Mbed TLS
- * (https://github.com/ARMmbed/mbedtls/issues/3541). Thus, do not enable it by
+ * (https://github.com/Mbed-TLS/mbedtls/issues/3541). Thus, do not enable it by
  * default.
  */
 //#define PSA_WANT_ECC_SECP_K1_224                1

--- a/programs/psa/hmac_demo.c
+++ b/programs/psa/hmac_demo.c
@@ -107,7 +107,7 @@ psa_status_t hmac_demo(void)
     const psa_algorithm_t alg = PSA_ALG_HMAC(PSA_ALG_SHA_256);
     uint8_t out[PSA_MAC_MAX_SIZE]; // safe but not optimal
     /* PSA_MAC_LENGTH(PSA_KEY_TYPE_HMAC, 8 * sizeof( key_bytes ), alg)
-     * should work but see https://github.com/ARMmbed/mbedtls/issues/4320 */
+     * should work but see https://github.com/Mbed-TLS/mbedtls/issues/4320 */
 
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     psa_key_id_t key = 0;

--- a/scripts/ci.requirements.txt
+++ b/scripts/ci.requirements.txt
@@ -8,5 +8,5 @@
 pylint == 2.4.4
 
 # Use the earliest version of mypy that works with our code base.
-# See https://github.com/ARMmbed/mbedtls/pull/3953 .
+# See https://github.com/Mbed-TLS/mbedtls/pull/3953 .
 mypy >= 0.780

--- a/scripts/driver.requirements.txt
+++ b/scripts/driver.requirements.txt
@@ -7,7 +7,7 @@
 markupsafe < 2.1
 
 # Use the version of Jinja that's in Ubuntu 20.04.
-# See https://github.com/ARMmbed/mbedtls/pull/5067#discussion_r738794607 .
+# See https://github.com/Mbed-TLS/mbedtls/pull/5067#discussion_r738794607 .
 # Note that Jinja 3.0 drops support for Python 3.5, so we need to support
 # Jinja 2.x as long as we're still using Python 3.5 anywhere.
 Jinja2 >= 2.10.1

--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -337,7 +337,7 @@ add_common_ciphersuites()
 #
 # NOTE: for some reason RSA-PSK doesn't work with OpenSSL,
 # so RSA-PSK ciphersuites need to go in other sections, see
-# https://github.com/ARMmbed/mbedtls/issues/1419
+# https://github.com/Mbed-TLS/mbedtls/issues/1419
 #
 # ChachaPoly suites are here rather than in "common", as they were added in
 # GnuTLS in 3.5.0 and the CI only has 3.4.x so far.

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -2691,9 +2691,9 @@ component_build_arm_linux_gnueabi_gcc_arm5vte () {
     scripts/config.py baremetal
     # Build for a target platform that's close to what Debian uses
     # for its "armel" distribution (https://wiki.debian.org/ArmEabiPort).
-    # See https://github.com/ARMmbed/mbedtls/pull/2169 and comments.
+    # See https://github.com/Mbed-TLS/mbedtls/pull/2169 and comments.
     # Build everything including programs, see for example
-    # https://github.com/ARMmbed/mbedtls/pull/3449#issuecomment-675313720
+    # https://github.com/Mbed-TLS/mbedtls/pull/3449#issuecomment-675313720
     make CC="${ARM_LINUX_GNUEABI_GCC_PREFIX}gcc" AR="${ARM_LINUX_GNUEABI_GCC_PREFIX}ar" CFLAGS='-Werror -Wall -Wextra -march=armv5te -O1' LDFLAGS='-march=armv5te'
 
     msg "size: ${ARM_LINUX_GNUEABI_GCC_PREFIX}gcc -march=armv5te -O1"

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -1633,7 +1633,7 @@ run_test_psa_force_curve "brainpoolP256r1"
 requires_config_enabled MBEDTLS_ECP_DP_SECP224R1_ENABLED
 run_test_psa_force_curve "secp224r1"
 ## SECP224K1 is buggy via the PSA API
-## (https://github.com/ARMmbed/mbedtls/issues/3541),
+## (https://github.com/Mbed-TLS/mbedtls/issues/3541),
 ## so it is disabled in PSA even when it's enabled in Mbed TLS.
 ## The proper dependency would be on PSA_WANT_ECC_SECP_K1_224 but
 ## dependencies on PSA symbols in ssl-opt.sh are not implemented yet.

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -12,7 +12,7 @@
 
 /* Needed only for test case data under #if defined(MBEDTLS_USE_PSA_CRYPTO),
  * but the test code generator requires test case data to be valid C code
- * unconditionally (https://github.com/ARMmbed/mbedtls/issues/2023). */
+ * unconditionally (https://github.com/Mbed-TLS/mbedtls/issues/2023). */
 #include "psa/crypto.h"
 
 #define RSA_KEY_SIZE 512


### PR DESCRIPTION
Replace references to ARMmbed organisation with the new
org, Mbed-TLS, following project migration.

Signed-off-by: Dave Rodgman <dave.rodgman@arm.com>