### PR TITLE
Update references to old Github organisation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ addons:
     - gnutls-bin
   coverity_scan:
     project:
-      name: "ARMmbed/mbedtls"
+      name: "Mbed-TLS/mbedtls"
     notification_email: support-mbedtls@arm.com
     build_command_prepend:
     build_command: make

--- a/BRANCHES.md
+++ b/BRANCHES.md
@@ -2,10 +2,10 @@
 
 At any point in time, we have a number of maintained branches consisting of:
 
-- The [`master`](https://github.com/ARMmbed/mbedtls/tree/master) branch:
+- The [`master`](https://github.com/Mbed-TLS/mbedtls/tree/master) branch:
   this always contains the latest release, including all publicly available
   security fixes.
-- The [`development`](https://github.com/ARMmbed/mbedtls/tree/development) branch:
+- The [`development`](https://github.com/Mbed-TLS/mbedtls/tree/development) branch:
   this is where new features land,
   as well as bug fixes and security fixes.
 - One or more long-time support (LTS) branches:
@@ -40,15 +40,15 @@ had to break ABI compatibility in an LTS branch, but we occasionally had to
 increase code size for a security fix.)
 
 For contributors, see the [Backwards Compatibility section of
-CONTRIBUTING](CONTRIBUTING.md#cackwords-compatibility).
+CONTRIBUTING](CONTRIBUTING.md#backwards-compatibility).
 
 ## Current Branches
 
 The following branches are currently maintained:
 
-- [master](https://github.com/ARMmbed/mbedtls/tree/master)
-- [`development`](https://github.com/ARMmbed/mbedtls/)
-- [`mbedtls-2.28`](https://github.com/ARMmbed/mbedtls/tree/mbedtls-2.28)
+- [master](https://github.com/Mbed-TLS/mbedtls/tree/master)
+- [`development`](https://github.com/Mbed-TLS/mbedtls/)
+- [`mbedtls-2.28`](https://github.com/Mbed-TLS/mbedtls/tree/mbedtls-2.28)
  maintained until at least the end of 2024.
 
 Users are urged to always use the latest version of a maintained branch.

--- a/BUGS.md
+++ b/BUGS.md
@@ -1,6 +1,6 @@
 ## Known issues
 
-Known issues in Mbed TLS are [tracked on GitHub](https://github.com/ARMmbed/mbedtls/issues).
+Known issues in Mbed TLS are [tracked on GitHub](https://github.com/Mbed-TLS/mbedtls/issues).
 
 ## Reporting a bug
 
@@ -9,12 +9,12 @@ If you think you've found a bug in Mbed TLS, please follow these steps:
 1. Make sure you're using the latest version of a
    [maintained branch](BRANCHES.md): `master`, `development`,
    or a long-time support branch.
-2. Check [GitHub](https://github.com/ARMmbed/mbedtls/issues) to see if
+2. Check [GitHub](https://github.com/Mbed-TLS/mbedtls/issues) to see if
    your issue has already been reported. If not, …
 3. If the issue is a security risk (for example: buffer overflow,
    data leak), please report it confidentially as described in
    [`SECURITY.md`](SECURITY.md). If not, …
-4. Please [create an issue on on GitHub](https://github.com/ARMmbed/mbedtls/issues).
+4. Please [create an issue on on GitHub](https://github.com/Mbed-TLS/mbedtls/issues).
 
 Please do not use GitHub for support questions. If you want to know
 how to do something with Mbed TLS, please see [`SUPPORT.md`](SUPPORT.md) for available documentation and support channels.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,8 +14,8 @@ Coding Standards
 
 Making a Contribution
 ---------------------
-1. [Check for open issues](https://github.com/ARMmbed/mbedtls/issues) or [start a discussion](https://lists.trustedfirmware.org/mailman3/lists/mbed-tls.lists.trustedfirmware.org) around a feature idea or a bug.
-1. Fork the [Mbed TLS repository on GitHub](https://github.com/ARMmbed/mbedtls) to start making your changes. As a general rule, you should use the ["development" branch](https://github.com/ARMmbed/mbedtls/tree/development) as a basis.
+1. [Check for open issues](https://github.com/Mbed-TLS/mbedtls/issues) or [start a discussion](https://lists.trustedfirmware.org/mailman3/lists/mbed-tls.lists.trustedfirmware.org) around a feature idea or a bug.
+1. Fork the [Mbed TLS repository on GitHub](https://github.com/Mbed-TLS/mbedtls) to start making your changes. As a general rule, you should use the ["development" branch](https://github.com/Mbed-TLS/mbedtls/tree/development) as a basis.
 1. Write a test which shows that the bug was fixed or that the feature works as expected.
 1. Send a pull request (PR) and work with us until it gets merged and published. Contributions may need some modifications, so a few rounds of review and fixing may be necessary. We will include your name in the ChangeLog :)
 1. For quick merging, the contribution should be short, and concentrated on a single feature or topic. The larger the contribution is, the longer it would take to review it and merge it.
@@ -47,14 +47,14 @@ When backporting to these branches please observe the following rules:
 1. All bug fixes that correct a defect that is also present in an LTS branch must be backported to that LTS branch. If a bug fix introduces a change to the API such as a new function, the fix should be reworked to avoid the API change. API changes without very strong justification are unlikely to be accepted.
 1. If a contribution is a new feature or enhancement, no backporting is required. Exceptions to this may be additional test cases or quality improvements such as changes to build or test scripts.
 
-It would be highly appreciated if contributions are backported to LTS branches in addition to the [development branch](https://github.com/ARMmbed/mbedtls/tree/development) by contributors.
+It would be highly appreciated if contributions are backported to LTS branches in addition to the [development branch](https://github.com/Mbed-TLS/mbedtls/tree/development) by contributors.
 
 The list of maintained branches can be found in the [Current Branches section
 of BRANCHES.md](BRANCHES.md#current-branches).
 
 Currently maintained LTS branches are:
-1. [mbedtls-2.7](https://github.com/ARMmbed/mbedtls/tree/mbedtls-2.7)
-1. [mbedtls-2.16](https://github.com/ARMmbed/mbedtls/tree/mbedtls-2.16)
+1. [mbedtls-2.7](https://github.com/Mbed-TLS/mbedtls/tree/mbedtls-2.7)
+1. [mbedtls-2.16](https://github.com/Mbed-TLS/mbedtls/tree/mbedtls-2.16)
 
 
 Tests
@@ -73,7 +73,7 @@ Continuous Integration Tests
 ----------------------------
 Once a PR has been made, the Continuous Integration (CI) tests are triggered and run. You should follow the result of the CI tests, and fix failures.
 
-It is advised to enable the [githooks scripts](https://github.com/ARMmbed/mbedtls/tree/development/tests/git-scripts) prior to pushing your changes, for catching some of the issues as early as possible.
+It is advised to enable the [githooks scripts](https://github.com/Mbed-TLS/mbedtls/tree/development/tests/git-scripts) prior to pushing your changes, for catching some of the issues as early as possible.
 
 Documentation
 -------------
@@ -83,4 +83,4 @@ Mbed TLS is well documented, but if you think documentation is needed, speak out
 1. Complex parts in the code should include comments.
 1. If needed, a Readme file is advised.
 1. If a [Knowledge Base (KB)](https://tls.mbed.org/kb) article should be added, write this as a comment in the PR description.
-1. A [ChangeLog](https://github.com/ARMmbed/mbedtls/blob/development/ChangeLog.d/00README.md) entry should be added for this contribution.
+1. A [ChangeLog](https://github.com/Mbed-TLS/mbedtls/blob/development/ChangeLog.d/00README.md) entry should be added for this contribution.

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ This implementation is not yet as mature as the rest of the library. Some parts 
 
 The X.509 and TLS code can use PSA cryptography for a limited subset of operations. To enable this support, activate the compilation option `MBEDTLS_USE_PSA_CRYPTO` in `config.h`.
 
-There are currently a few deviations where the library does not yet implement the latest version of the specification. Please refer to the [compliance issues on Github](https://github.com/ARMmbed/mbed-crypto/labels/compliance) for an up-to-date list.
+There are currently a few deviations where the library does not yet implement the latest version of the specification. Please refer to the [compliance issues on Github](https://github.com/Mbed-TLS/mbed-crypto/labels/compliance) for an up-to-date list.
 
 ### Upcoming features
 
@@ -260,5 +260,5 @@ Contact
 -------
 
 * To report a security vulnerability in Mbed TLS, please email <mbed-tls-security@lists.trustedfirmware.org>. For more information, see [`SECURITY.md`](SECURITY.md).
-* To report a bug or request a feature in Mbed TLS, please [file an issue on GitHub](https://github.com/ARMmbed/mbedtls/issues/new/choose).
+* To report a bug or request a feature in Mbed TLS, please [file an issue on GitHub](https://github.com/Mbed-TLS/mbedtls/issues/new/choose).
 * Please see [`SUPPORT.md`](SUPPORT.md) for other channels for discussion and support about Mbed TLS.

--- a/include/mbedtls/config_psa.h
+++ b/include/mbedtls/config_psa.h
@@ -483,7 +483,7 @@ extern "C" {
 #if !defined(MBEDTLS_PSA_ACCEL_ECC_MONTGOMERY_448)
 /*
  * Curve448 is not yet supported via the PSA API in Mbed TLS
- * (https://github.com/ARMmbed/mbedtls/issues/4249).
+ * (https://github.com/Mbed-TLS/mbedtls/issues/4249).
  */
 #error "Curve448 is not yet supported via the PSA API in Mbed TLS."
 #define MBEDTLS_ECP_DP_CURVE448_ENABLED
@@ -537,7 +537,7 @@ extern "C" {
 #if !defined(MBEDTLS_PSA_ACCEL_ECC_SECP_K1_224)
 /*
  * SECP224K1 is buggy via the PSA API in Mbed TLS
- * (https://github.com/ARMmbed/mbedtls/issues/3541).
+ * (https://github.com/Mbed-TLS/mbedtls/issues/3541).
  */
 #error "SECP224K1 is buggy via the PSA API in Mbed TLS."
 #define MBEDTLS_ECP_DP_SECP224K1_ENABLED
@@ -776,7 +776,7 @@ extern "C" {
 #define PSA_WANT_ECC_MONTGOMERY_255
 #endif
 
-/* Curve448 is not yet supported via the PSA API (https://github.com/ARMmbed/mbedtls/issues/4249) */
+/* Curve448 is not yet supported via the PSA API (https://github.com/Mbed-TLS/mbedtls/issues/4249) */
 #if 0 && defined(MBEDTLS_ECP_DP_CURVE448_ENABLED)
 #define MBEDTLS_PSA_BUILTIN_ECC_MONTGOMERY_448 1
 #define PSA_WANT_ECC_MONTGOMERY_448
@@ -812,7 +812,7 @@ extern "C" {
 #define PSA_WANT_ECC_SECP_K1_192
 #endif
 
-/* SECP224K1 is buggy via the PSA API (https://github.com/ARMmbed/mbedtls/issues/3541) */
+/* SECP224K1 is buggy via the PSA API (https://github.com/Mbed-TLS/mbedtls/issues/3541) */
 #if 0 && defined(MBEDTLS_ECP_DP_SECP224K1_ENABLED)
 #define MBEDTLS_PSA_BUILTIN_ECC_SECP_K1_224 1
 #define PSA_WANT_ECC_SECP_K1_224

--- a/include/psa/crypto_config.h
+++ b/include/psa/crypto_config.h
@@ -94,14 +94,14 @@
 #define PSA_WANT_ECC_MONTGOMERY_255             1
 /*
  * Curve448 is not yet supported via the PSA API in Mbed TLS
- * (https://github.com/ARMmbed/mbedtls/issues/4249). Thus, do not enable it by
+ * (https://github.com/Mbed-TLS/mbedtls/issues/4249). Thus, do not enable it by
  * default.
  */
 //#define PSA_WANT_ECC_MONTGOMERY_448             1
 #define PSA_WANT_ECC_SECP_K1_192                1
 /*
  * SECP224K1 is buggy via the PSA API in Mbed TLS
- * (https://github.com/ARMmbed/mbedtls/issues/3541). Thus, do not enable it by
+ * (https://github.com/Mbed-TLS/mbedtls/issues/3541). Thus, do not enable it by
  * default.
  */
 //#define PSA_WANT_ECC_SECP_K1_224                1

--- a/scripts/ci.requirements.txt
+++ b/scripts/ci.requirements.txt
@@ -10,5 +10,5 @@
 pylint == 2.4.4
 
 # Use the earliest version of mypy that works with our code base.
-# See https://github.com/ARMmbed/mbedtls/pull/3953 .
+# See https://github.com/Mbed-TLS/mbedtls/pull/3953 .
 mypy >= 0.780

--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -446,7 +446,7 @@ add_common_ciphersuites()
 #
 # NOTE: for some reason RSA-PSK doesn't work with OpenSSL,
 # so RSA-PSK ciphersuites need to go in other sections, see
-# https://github.com/ARMmbed/mbedtls/issues/1419
+# https://github.com/Mbed-TLS/mbedtls/issues/1419
 #
 # ChachaPoly suites are here rather than in "common", as they were added in
 # GnuTLS in 3.5.0 and the CI only has 3.4.x so far.

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -2780,9 +2780,9 @@ component_build_arm_linux_gnueabi_gcc_arm5vte () {
     scripts/config.py baremetal
     # Build for a target platform that's close to what Debian uses
     # for its "armel" distribution (https://wiki.debian.org/ArmEabiPort).
-    # See https://github.com/ARMmbed/mbedtls/pull/2169 and comments.
+    # See https://github.com/Mbed-TLS/mbedtls/pull/2169 and comments.
     # Build everything including programs, see for example
-    # https://github.com/ARMmbed/mbedtls/pull/3449#issuecomment-675313720
+    # https://github.com/Mbed-TLS/mbedtls/pull/3449#issuecomment-675313720
     make CC="${ARM_LINUX_GNUEABI_GCC_PREFIX}gcc" AR="${ARM_LINUX_GNUEABI_GCC_PREFIX}ar" CFLAGS='-Werror -Wall -Wextra -march=armv5te -O1' LDFLAGS='-march=armv5te'
 
     msg "size: ${ARM_LINUX_GNUEABI_GCC_PREFIX}gcc -march=armv5te -O1"

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -1499,7 +1499,7 @@ run_test_psa_force_curve "brainpoolP256r1"
 requires_config_enabled MBEDTLS_ECP_DP_SECP224R1_ENABLED
 run_test_psa_force_curve "secp224r1"
 ## SECP224K1 is buggy via the PSA API
-## (https://github.com/ARMmbed/mbedtls/issues/3541),
+## (https://github.com/Mbed-TLS/mbedtls/issues/3541),
 ## so it is disabled in PSA even when it's enabled in Mbed TLS.
 ## The proper dependency would be on PSA_WANT_ECC_SECP_K1_224 but
 ## dependencies on PSA symbols in ssl-opt.sh are not implemented yet.

--- a/tests/suites/test_suite_pk.data
+++ b/tests/suites/test_suite_pk.data
@@ -287,7 +287,7 @@ PSA wrapped sign: SECP192K1
 depends_on:MBEDTLS_ECP_DP_SECP192K1_ENABLED
 pk_psa_sign:MBEDTLS_ECP_DP_SECP192K1:PSA_ECC_FAMILY_SECP_K1:192
 
-## Currently buggy: https://github.com/ARMmbed/mbed-crypto/issues/336
+## Currently buggy: https://github.com/Mbed-TLS/mbed-crypto/issues/336
 # PSA wrapped sign: SECP224K1
 # depends_on:MBEDTLS_ECP_DP_SECP224K1_ENABLED
 # pk_psa_sign:MBEDTLS_ECP_DP_SECP224K1:PSA_ECC_FAMILY_SECP_K1:224

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -12,7 +12,7 @@
 
 /* Needed only for test case data under #if defined(MBEDTLS_USE_PSA_CRYPTO),
  * but the test code generator requires test case data to be valid C code
- * unconditionally (https://github.com/ARMmbed/mbedtls/issues/2023). */
+ * unconditionally (https://github.com/Mbed-TLS/mbedtls/issues/2023). */
 #include "psa/crypto.h"
 
 #define RSA_KEY_SIZE 512


### PR DESCRIPTION
Replace references to ARMmbed organisation with the new
org, Mbed-TLS, following project migration.

Backport of #5681 