### PR TITLE
Prevent free of uninitialised MPI  variables

### DIFF
--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -723,6 +723,8 @@ void pk_rsa_encrypt_decrypt_test( data_t * message, int mod, int radix_P,
     size_t olen, rlen;
 
     mbedtls_pk_init( &pk );
+    mbedtls_mpi_init( &N ); mbedtls_mpi_init( &P );
+    mbedtls_mpi_init( &Q ); mbedtls_mpi_init( &E );
 
     memset( &rnd_info,  0, sizeof( mbedtls_test_rnd_pseudo_info ) );
     memset( output,     0, sizeof( output ) );


### PR DESCRIPTION
## Description
In one of the Pk RSA tests, it was possible (in an unlikely error case) for some `mbedtls_mpi` variables to be free'd without first being initialised, which could potentially cause an uninitialised pointer to used (for clearing memory) and/or heap damage.

Found by coverity.

## Status
**READY**

## Requires Backporting
NO  

## Migrations
NO

## Todos
- [x] Tests

## Steps to test or reproduce
test_suite_pk should run clean.
