### PR TITLE
Fix LTS version in contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,10 +52,6 @@ It would be highly appreciated if contributions are backported to LTS branches i
 The list of maintained branches can be found in the [Current Branches section
 of BRANCHES.md](BRANCHES.md#current-branches).
 
-The only currently maintained LTS branch is:
-1. [mbedtls-2.16](https://github.com/Mbed-TLS/mbedtls/tree/mbedtls-2.16)
-
-
 Tests
 -----
 As mentioned, tests that show the correctness of the feature or bug fix should be added to the pull request, if no such tests exist.


### PR DESCRIPTION
The LTS branch hasn't been updated in the contributing guidelines.
Deleting it instead of updating as the information is available at the
link above and deleting prevents similar mistakes in the future.