### PR TITLE
ssl_tls13_generate_and_write_ecdh_key_exchange(): remove redundant check

### DIFF
--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -2222,6 +2222,8 @@ static inline int psa_ssl_status_to_mbedtls( psa_status_t status )
             return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
         case PSA_ERROR_BAD_STATE:
             return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+        case PSA_ERROR_BUFFER_TOO_SMALL:
+            return( MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL );
         default:
             return( MBEDTLS_ERR_PLATFORM_HW_ACCEL_FAILED );
     }

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -262,12 +262,6 @@ static int ssl_tls13_generate_and_write_ecdh_key_exchange(
 
     }
 
-    if( own_pubkey_len > (size_t)( end - buf ) )
-    {
-            MBEDTLS_SSL_DEBUG_MSG( 1, ( "No space in the buffer for ECDH public key." ) );
-        return( MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL );
-    }
-
     *out_len = own_pubkey_len;
 
     return( 0 );


### PR DESCRIPTION
## Description
This check can be removed as if the buffer is too small for the key, then export will fail.

Resolves: conversation https://github.com/Mbed-TLS/mbedtls/pull/5524#pullrequestreview-930492605 .