### PR TITLE
Avoid using post-ansi language feature - variable definition in for-loop

### DIFF
--- a/library/bignum.c
+++ b/library/bignum.c
@@ -1996,8 +1996,8 @@ static void mpi_montred( mbedtls_mpi *A, const mbedtls_mpi *N,
 static int mpi_select( mbedtls_mpi *R, const mbedtls_mpi *T, size_t T_size, size_t idx )
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
-
-    for( size_t i = 0; i < T_size; i++ )
+    size_t i;
+    for( i = 0; i < T_size; i++ )
     {
         MBEDTLS_MPI_CHK( mbedtls_mpi_safe_cond_assign( R, &T[i],
                         (unsigned char) mbedtls_ct_size_bool_eq( i, idx ) ) );

--- a/library/constant_time.c
+++ b/library/constant_time.c
@@ -415,9 +415,10 @@ void mbedtls_ct_memcpy_if_eq( unsigned char *dest,
     /* mask = c1 == c2 ? 0xff : 0x00 */
     const size_t equal = mbedtls_ct_size_bool_eq( c1, c2 );
     const unsigned char mask = (unsigned char) mbedtls_ct_size_mask( equal );
+    size_t i;
 
     /* dest[i] = c1 == c2 ? src[i] : dest[i] */
-    for( size_t i = 0; i < len; i++ )
+    for( i = 0; i < len; i++ )
         dest[i] = ( src[i] & mask ) | ( dest[i] & ~mask );
 }
 

--- a/library/ecjpake.c
+++ b/library/ecjpake.c
@@ -967,10 +967,10 @@ static const unsigned char ecjpake_test_pms[] = {
 static int self_test_rng( void *ctx, unsigned char *out, size_t len )
 {
     static uint32_t state = 42;
-
+    size_t i;
     (void) ctx;
 
-    for( size_t i = 0; i < len; i++ )
+    for( i = 0; i < len; i++ )
     {
         state = state * 1664525u + 1013904223u;
         out[i] = (unsigned char) state;

--- a/library/ecp.c
+++ b/library/ecp.c
@@ -3388,10 +3388,10 @@ int mbedtls_ecp_export(const mbedtls_ecp_keypair *key, mbedtls_ecp_group *grp,
 static int self_test_rng( void *ctx, unsigned char *out, size_t len )
 {
     static uint32_t state = 42;
-
+    size_t i;
     (void) ctx;
 
-    for( size_t i = 0; i < len; i++ )
+    for( i = 0; i < len; i++ )
     {
         state = state * 1664525u + 1013904223u;
         out[i] = (unsigned char) state;

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -761,7 +761,7 @@ static int ssl_handshake_init( mbedtls_ssl_context *ssl )
     /* Heap allocate and translate curve_list from internal to IANA group ids */
     if ( ssl->conf->curve_list != NULL )
     {
-        size_t length;
+        size_t length, i;
         const mbedtls_ecp_group_id *curve_list = ssl->conf->curve_list;
 
         for( length = 0;  ( curve_list[length] != MBEDTLS_ECP_DP_NONE ) &&
@@ -772,7 +772,7 @@ static int ssl_handshake_init( mbedtls_ssl_context *ssl )
         if ( group_list == NULL )
             return( MBEDTLS_ERR_SSL_ALLOC_FAILED );
 
-        for( size_t i = 0; i < length; i++ )
+        for( i = 0; i < length; i++ )
         {
             const mbedtls_ecp_curve_info *info =
                         mbedtls_ecp_curve_info_from_grp_id( curve_list[i] );


### PR DESCRIPTION
## Description
Defining an iterator variable inside a for-loop statement
is not tolerated by some compilers which do not support the C99
standard extension by default (ex. KEIL/ARM C compiler).

## Status
READY

## Requires Backporting
NO  

## Migrations
If there is any API change, what's the incentive and logic for it.

NO

## Additional comments
Any additional information that could be of interest

## Steps to test or reproduce
Compile with strict-ansi (pre-C99) language option

Signed-off-by: Leonid Rozenboim <leonid.rozenboim@oracle.com>