### PR TITLE
Make size of output in mpi_mul_hlp() explicit

### DIFF
--- a/library/bignum.c
+++ b/library/bignum.c
@@ -1500,8 +1500,12 @@ int mbedtls_mpi_mul_int( mbedtls_mpi *X, const mbedtls_mpi *A, mbedtls_mpi_uint 
     MPI_VALIDATE_RET( X != NULL );
     MPI_VALIDATE_RET( A != NULL );
 
+    size_t n = A->n;
+    while( n > 0 && A->p[n - 1] == 0 )
+        --n;
+
     /* The general method below doesn't work if b==0. */
-    if( b == 0 )
+    if( b == 0 || n == 0 )
         return( mbedtls_mpi_lset( X, 0 ) );
 
     /* Calculate A*b as A + A*(b-1) to take advantage of mbedtls_mpi_core_mla */
@@ -1517,9 +1521,9 @@ int mbedtls_mpi_mul_int( mbedtls_mpi *X, const mbedtls_mpi *A, mbedtls_mpi_uint 
      *
      * Note that calculating A*b as 0 + A*b doesn't work as-is because
      * A,X can be the same. */
-    MBEDTLS_MPI_CHK( mbedtls_mpi_grow( X, A->n + 1 ) );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_grow( X, n + 1 ) );
     MBEDTLS_MPI_CHK( mbedtls_mpi_copy( X, A ) );
-    mbedtls_mpi_core_mla( X->p, X->n, A->p, A->n, b - 1 );
+    mbedtls_mpi_core_mla( X->p, X->n, A->p, n, b - 1 );
 
 cleanup:
     return( ret );

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -1504,7 +1504,10 @@ int mbedtls_mpi_mul_int( mbedtls_mpi *X, const mbedtls_mpi *A, mbedtls_mpi_uint 
      * making the call to grow() unconditional causes slightly fewer
      * calls to calloc() in ECP code, presumably because it reuses the
      * same mpi for a while and this way the mpi is more likely to directly
-     * grow to its final size. */
+     * grow to its final size.
+     *
+     * Note that calculating A*b as 0 + A*b doesn't work as-is because
+     * A,X can be the same. */
     MBEDTLS_MPI_CHK( mbedtls_mpi_grow( X, A->n + 1 ) );
     MBEDTLS_MPI_CHK( mbedtls_mpi_copy( X, A ) );
     mbedtls_mpi_core_mla( X->p, X->n, A->p, A->n, b - 1 );

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -1386,14 +1386,12 @@ int mbedtls_mpi_sub_int( mbedtls_mpi *X, const mbedtls_mpi *A, mbedtls_mpi_sint 
  *
  * \return c            The carry at the end of the operation.
  */
-mbedtls_mpi_uint mbedtls_mpi_core_mla( mbedtls_mpi_uint *d, size_t d_len ,
+mbedtls_mpi_uint mbedtls_mpi_core_mla( mbedtls_mpi_uint *d, size_t d_len,
                                        const mbedtls_mpi_uint *s, size_t s_len,
                                        mbedtls_mpi_uint b )
 {
     mbedtls_mpi_uint c = 0; /* carry */
-
-    /* Remember the excess of d over s for later */
-    d_len -= s_len;
+    size_t const excess_len = d_len - s_len;
 
 #if defined(MULADDC_HUIT)
     for( ; s_len >= 8; s_len -= 8 )
@@ -1444,7 +1442,7 @@ mbedtls_mpi_uint mbedtls_mpi_core_mla( mbedtls_mpi_uint *d, size_t d_len ,
     }
 #endif /* MULADDC_HUIT */
 
-    while( d_len-- )
+    while( excess_len-- )
     {
         *d += c; c = ( *d < c ); d++;
     }

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -1391,7 +1391,7 @@ mbedtls_mpi_uint mbedtls_mpi_core_mla( mbedtls_mpi_uint *d, size_t d_len,
                                        mbedtls_mpi_uint b )
 {
     mbedtls_mpi_uint c = 0; /* carry */
-    size_t const excess_len = d_len - s_len;
+    size_t excess_len = d_len - s_len;
 
 #if defined(MULADDC_HUIT)
     for( ; s_len >= 8; s_len -= 8 )

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -1886,8 +1886,8 @@ static void mpi_montg_init( mbedtls_mpi_uint *mm, const mbedtls_mpi *N )
 static void mpi_montmul( mbedtls_mpi *A, const mbedtls_mpi *B, const mbedtls_mpi *N, mbedtls_mpi_uint mm,
                          const mbedtls_mpi *T )
 {
-    size_t i, n, m;
-    mbedtls_mpi_uint u0, u1, *d;
+    size_t n, m;
+    mbedtls_mpi_uint *d;
 
     memset( T->p, 0, T->n * ciL );
 
@@ -1895,8 +1895,10 @@ static void mpi_montmul( mbedtls_mpi *A, const mbedtls_mpi *B, const mbedtls_mpi
     n = N->n;
     m = ( B->n < n ) ? B->n : n;
 
-    for( i = 0; i < n; i++ )
+    for( size_t i = 0; i < n; i++ )
     {
+        mbedtls_mpi_uint u0, u1;
+
         /*
          * T = (T + u0*B + u1*N) / 2^biL
          */

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -1440,7 +1440,7 @@ mbedtls_mpi_uint mbedtls_mpi_core_mla( mbedtls_mpi_uint *d, size_t d_len,
 int mbedtls_mpi_mul_mpi( mbedtls_mpi *X, const mbedtls_mpi *A, const mbedtls_mpi *B )
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
-    size_t i, j, k;
+    size_t i, j;
     mbedtls_mpi TA, TB;
     int result_is_zero = 0;
     MPI_VALIDATE_RET( X != NULL );
@@ -1467,7 +1467,7 @@ int mbedtls_mpi_mul_mpi( mbedtls_mpi *X, const mbedtls_mpi *A, const mbedtls_mpi
     MBEDTLS_MPI_CHK( mbedtls_mpi_grow( X, i + j ) );
     MBEDTLS_MPI_CHK( mbedtls_mpi_lset( X, 0 ) );
 
-    for( k = 0; k < j; k++ )
+    for( size_t k = 0; k < j; k++ )
     {
         /* We know that there cannot be any carry-out since we're
          * iterating from bottom to top. */

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -1370,22 +1370,6 @@ int mbedtls_mpi_sub_int( mbedtls_mpi *X, const mbedtls_mpi *A, mbedtls_mpi_sint 
     return( mbedtls_mpi_sub_mpi( X, A, &B ) );
 }
 
-/** Helper for mbedtls_mpi multiplication.
- *
- * Add \p b * \p s to \p d.
- *
- * \param[in,out] d     The bignum to add to.
- * \param d_len         The number of limbs of \p d. This must be
- *                      at least \p s_len.
- * \param s_len         The number of limbs of \p s.
- * \param[in] s         A bignum to multiply, of size \p i.
- *                      It may overlap with \p d, but only if
- *                      \p d <= \p s.
- *                      Its leading limb must not be \c 0.
- * \param b             A scalar to multiply.
- *
- * \return c            The carry at the end of the operation.
- */
 mbedtls_mpi_uint mbedtls_mpi_core_mla( mbedtls_mpi_uint *d, size_t d_len,
                                        const mbedtls_mpi_uint *s, size_t s_len,
                                        mbedtls_mpi_uint b )

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -1440,7 +1440,9 @@ mbedtls_mpi_uint mbedtls_mpi_core_mla( mbedtls_mpi_uint *d, size_t d_len,
 int mbedtls_mpi_mul_mpi( mbedtls_mpi *X, const mbedtls_mpi *A, const mbedtls_mpi *B )
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
+    size_t i, j, k;
     mbedtls_mpi TA, TB;
+    int result_is_zero = 0;
     MPI_VALIDATE_RET( X != NULL );
     MPI_VALIDATE_RET( A != NULL );
     MPI_VALIDATE_RET( B != NULL );
@@ -1450,31 +1452,38 @@ int mbedtls_mpi_mul_mpi( mbedtls_mpi *X, const mbedtls_mpi *A, const mbedtls_mpi
     if( X == A ) { MBEDTLS_MPI_CHK( mbedtls_mpi_copy( &TA, A ) ); A = &TA; }
     if( X == B ) { MBEDTLS_MPI_CHK( mbedtls_mpi_copy( &TB, B ) ); B = &TB; }
 
-    const size_t A_len = A->n, B_len = B->n;
-    MBEDTLS_MPI_CHK( mbedtls_mpi_grow( X, A_len + B_len ) );
+    for( i = A->n; i > 0; i-- )
+        if( A->p[i - 1] != 0 )
+            break;
+    if( i == 0 )
+        result_is_zero = 1;
+
+    for( j = B->n; j > 0; j-- )
+        if( B->p[j - 1] != 0 )
+            break;
+    if( j == 0 )
+        result_is_zero = 1;
+
+    MBEDTLS_MPI_CHK( mbedtls_mpi_grow( X, i + j ) );
     MBEDTLS_MPI_CHK( mbedtls_mpi_lset( X, 0 ) );
 
-    for( size_t k = 0; k < B_len; k++ )
+    for( k = 0; k < j; k++ )
     {
         /* We know that there cannot be any carry-out since we're
          * iterating from bottom to top. */
-        (void) mbedtls_mpi_core_mla( X->p + k, A_len + 1,
-                                     A->p, A_len,
+        (void) mbedtls_mpi_core_mla( X->p + k, i + 1,
+                                     A->p, i,
                                      B->p[k] );
     }
 
-    X->s = A->s * B->s;
-
-    /* The library does not fully support a "negative zero". */
-    if( X->s == -1 )
-    {
-        size_t i;
-        for( i = X->n; i > 0; i-- )
-            if( X->p[i - 1] != 0 )
-                break;
-        if( i == 0 )
-            X->s = 1;
-    }
+    /* If the result is 0, we don't shortcut the operation, which reduces
+     * but does not eliminate side channels leaking the zero-ness. We do
+     * need to take care to set the sign bit properly since the library does
+     * not fully support an MPI object with a value of 0 and s == -1. */
+    if( result_is_zero )
+        X->s = 1;
+    else
+        X->s = A->s * B->s;
 
 cleanup:
 

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -1907,8 +1907,8 @@ static void mpi_montg_init( mbedtls_mpi_uint *mm, const mbedtls_mpi *N )
  * \param           mm  The value calculated by `mpi_montg_init(&mm, N)`.
  *                      This is -N^-1 mod 2^ciL.
  * \param[in,out]   T   A bignum for temporary storage.
- *                      It must be at least twice the limb size of N plus 2
- *                      (T->n >= 2 * (N->n + 1)).
+ *                      It must be at least twice the limb size of N plus 1
+ *                      (T->n >= 2 * N->n + 1).
  *                      Its initial content is unused and
  *                      its final content is indeterminate.
  *                      Note that unlike the usual convention in the library
@@ -1934,10 +1934,13 @@ static void mpi_montmul( mbedtls_mpi *A, const mbedtls_mpi *B, const mbedtls_mpi
         u0 = A->p[i];
         u1 = ( d[0] + u0 * B->p[0] ) * mm;
 
-        mpi_mul_hlp( m, B->p, d, u0 );
-        mpi_mul_hlp( n, N->p, d, u1 );
-
-        d++; d[n + 1] = 0;
+        (void) mpi_mul_hlp( d, n + 2,
+                            B->p, m,
+                            u0 );
+        (void) mpi_mul_hlp( d, n + 2,
+                            N->p, n,
+                            u1 );
+        d++;
     }
 
     /* At this point, d is either the desired result or the desired result

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -1465,7 +1465,7 @@ mbedtls_mpi_uint mpi_mul_hlp( mbedtls_mpi_uint *d, size_t d_len ,
 int mbedtls_mpi_mul_mpi( mbedtls_mpi *X, const mbedtls_mpi *A, const mbedtls_mpi *B )
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
-    size_t i, j;
+    size_t i, j, k;
     mbedtls_mpi TA, TB;
     int result_is_zero = 0;
     MPI_VALIDATE_RET( X != NULL );
@@ -1492,8 +1492,14 @@ int mbedtls_mpi_mul_mpi( mbedtls_mpi *X, const mbedtls_mpi *A, const mbedtls_mpi
     MBEDTLS_MPI_CHK( mbedtls_mpi_grow( X, i + j ) );
     MBEDTLS_MPI_CHK( mbedtls_mpi_lset( X, 0 ) );
 
-    for( ; j > 0; j-- )
-        mpi_mul_hlp( i, A->p, X->p + j - 1, B->p[j - 1] );
+    for( k = 0; k < j; k++ )
+    {
+        /* We know that there cannot be any carry-out since we're
+         * iterating from bottom to top. */
+        (void) mpi_mul_hlp( X->p + k, i + 1,
+                            A->p, i,
+                            B->p[k] );
+    }
 
     /* If the result is 0, we don't shortcut the operation, which reduces
      * but does not eliminate side channels leaking the zero-ness. We do

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -1525,17 +1525,9 @@ int mbedtls_mpi_mul_int( mbedtls_mpi *X, const mbedtls_mpi *A, mbedtls_mpi_uint 
     MPI_VALIDATE_RET( X != NULL );
     MPI_VALIDATE_RET( A != NULL );
 
-    /* mpi_mul_hlp can't deal with a leading 0. */
-    size_t n = A->n;
-    while( n > 0 && A->p[n - 1] == 0 )
-        --n;
-
-    /* The general method below doesn't work if n==0 or b==0. By chance
-     * calculating the result is trivial in those cases. */
-    if( b == 0 || n == 0 )
-    {
+    /* The general method below doesn't work if b==0. */
+    if( b == 0 )
         return( mbedtls_mpi_lset( X, 0 ) );
-    }
 
     /* Calculate A*b as A + A*(b-1) to take advantage of mpi_mul_hlp */
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
@@ -1547,9 +1539,9 @@ int mbedtls_mpi_mul_int( mbedtls_mpi *X, const mbedtls_mpi *A, mbedtls_mpi_uint 
      * calls to calloc() in ECP code, presumably because it reuses the
      * same mpi for a while and this way the mpi is more likely to directly
      * grow to its final size. */
-    MBEDTLS_MPI_CHK( mbedtls_mpi_grow( X, n + 1 ) );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_grow( X, A->n + 1 ) );
     MBEDTLS_MPI_CHK( mbedtls_mpi_copy( X, A ) );
-    mpi_mul_hlp( n, A->p, X->p, b - 1 );
+    mpi_mul_hlp( X->p, X->n, A->p, A->n, b - 1 );
 
 cleanup:
     return( ret );

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -1398,7 +1398,7 @@ void mpi_mul_hlp( size_t i,
                   mbedtls_mpi_uint *d,
                   mbedtls_mpi_uint b )
 {
-    mbedtls_mpi_uint c = 0, t = 0;
+    mbedtls_mpi_uint c = 0; /* carry */
 
 #if defined(MULADDC_HUIT)
     for( ; i >= 8; i -= 8 )
@@ -1448,8 +1448,6 @@ void mpi_mul_hlp( size_t i,
         MULADDC_STOP
     }
 #endif /* MULADDC_HUIT */
-
-    t++;
 
     while( c != 0 )
     {

--- a/library/bignum_internal.h
+++ b/library/bignum_internal.h
@@ -1,0 +1,49 @@
+/**
+ *  Internal bignum functions
+ *
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef MBEDTLS_BIGNUM_INTERNAL_H
+#define MBEDTLS_BIGNUM_INTERNAL_H
+
+#include "common.h"
+
+#if defined(MBEDTLS_BIGNUM_C)
+#include "mbedtls/bignum.h"
+#endif
+
+/** Helper for mbedtls_mpi multiplication.
+ *
+ * Add \p b * \p s to \p d.
+ *
+ * \param[in,out] d     The bignum to add to.
+ * \param d_len         The number of limbs of \p d. This must be
+ *                      at least \p s_len.
+ * \param s_len         The number of limbs of \p s.
+ * \param[in] s         A bignum to multiply, of size \p i.
+ *                      It may overlap with \p d, but only if
+ *                      \p d <= \p s.
+ *                      Its leading limb must not be \c 0.
+ * \param b             A scalar to multiply.
+ *
+ * \return c            The carry at the end of the operation.
+ */
+mbedtls_mpi_uint mbedtls_mpi_core_mla( mbedtls_mpi_uint *d, size_t d_len ,
+                                       const mbedtls_mpi_uint *s, size_t s_len,
+                                       mbedtls_mpi_uint b );
+
+#endif /* MBEDTLS_BIGNUM_INTERNAL_H */

--- a/library/bignum_internal.h
+++ b/library/bignum_internal.h
@@ -26,19 +26,20 @@
 #include "mbedtls/bignum.h"
 #endif
 
-/** Helper for mbedtls_mpi multiplication.
+/** Perform a known-size multiply accumulate operation
  *
  * Add \p b * \p s to \p d.
  *
- * \param[in,out] d     The bignum to add to.
+ * \param[in,out] d     The pointer to the (little-endian) array
+ *                      representing the bignum to accumulate onto.
  * \param d_len         The number of limbs of \p d. This must be
  *                      at least \p s_len.
+ * \param[in] s         The pointer to the (little-endian) array
+ *                      representing the bignum to multiply with.
+ *                      This may be the same as \p d. Otherwise,
+ *                      it must be disjoint from \p d.
  * \param s_len         The number of limbs of \p s.
- * \param[in] s         A bignum to multiply, of size \p i.
- *                      It may overlap with \p d, but only if
- *                      \p d <= \p s.
- *                      Its leading limb must not be \c 0.
- * \param b             A scalar to multiply.
+ * \param b             A scalar to multiply with.
  *
  * \return c            The carry at the end of the operation.
  */

--- a/library/bn_mul.h
+++ b/library/bn_mul.h
@@ -99,6 +99,7 @@
 #if defined(__i386__) && defined(__OPTIMIZE__)
 
 #define MULADDC_INIT                        \
+    { mbedtls_mpi_uint t;                   \
     asm(                                    \
         "movl   %%ebx, %0           \n\t"   \
         "movl   %5, %%esi           \n\t"   \
@@ -190,7 +191,8 @@
         : "=m" (t), "=m" (c), "=m" (d), "=m" (s)        \
         : "m" (t), "m" (s), "m" (d), "m" (c), "m" (b)   \
         : "eax", "ebx", "ecx", "edx", "esi", "edi"      \
-    );
+    ); }                                                \
+
 
 #else
 
@@ -202,7 +204,7 @@
         : "=m" (t), "=m" (c), "=m" (d), "=m" (s)        \
         : "m" (t), "m" (s), "m" (d), "m" (c), "m" (b)   \
         : "eax", "ebx", "ecx", "edx", "esi", "edi"      \
-    );
+    ); }
 #endif /* SSE2 */
 #endif /* i386 */
 

--- a/library/ecp_curves.c
+++ b/library/ecp_curves.c
@@ -26,6 +26,7 @@
 #include "mbedtls/error.h"
 
 #include "bn_mul.h"
+#include "bignum_internal.h"
 #include "ecp_invasive.h"
 
 #include <string.h>
@@ -5213,40 +5214,29 @@ cleanup:
 
 /*
  * Fast quasi-reduction modulo p255 = 2^255 - 19
- * Write N as A0 + 2^255 A1, return A0 + 19 * A1
+ * Write N as A0 + 2^256 A1, return A0 + 38 * A1
  */
 static int ecp_mod_p255( mbedtls_mpi *N )
 {
-    int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
-    size_t i;
-    mbedtls_mpi M;
-    mbedtls_mpi_uint Mp[P255_WIDTH + 2];
+    mbedtls_mpi_uint Mp[P255_WIDTH];
 
-    if( N->n < P255_WIDTH )
+    /* Helper references for top part of N */
+    mbedtls_mpi_uint * const NT_p = N->p + P255_WIDTH;
+    unsigned const NT_n = N->n - P255_WIDTH;
+    if( NT_n > P255_WIDTH )
         return( 0 );
 
-    /* M = A1 */
-    M.s = 1;
-    M.n = N->n - ( P255_WIDTH - 1 );
-    if( M.n > P255_WIDTH + 1 )
-        return( MBEDTLS_ERR_ECP_BAD_INPUT_DATA );
-    M.p = Mp;
-    memset( Mp, 0, sizeof Mp );
-    memcpy( Mp, N->p + P255_WIDTH - 1, M.n * sizeof( mbedtls_mpi_uint ) );
-    MBEDTLS_MPI_CHK( mbedtls_mpi_shift_r( &M, 255 % ( 8 * sizeof( mbedtls_mpi_uint ) ) ) );
-    M.n++; /* Make room for multiplication by 19 */
+    /* Split N as N + 2^256 M */
+    memset( Mp,   0,    sizeof( Mp ) );
+    memcpy( Mp,   NT_p, sizeof( mbedtls_mpi_uint ) * NT_n );
+    memset( NT_p, 0,    sizeof( mbedtls_mpi_uint ) * NT_n );
 
-    /* N = A0 */
-    MBEDTLS_MPI_CHK( mbedtls_mpi_set_bit( N, 255, 0 ) );
-    for( i = P255_WIDTH; i < N->n; i++ )
-        N->p[i] = 0;
+    /* N = A0 + 38 * A1 */
+    mbedtls_mpi_core_mla( N->p, N->n,
+                          Mp, P255_WIDTH,
+                          38 );
 
-    /* N = A0 + 19 * A1 */
-    MBEDTLS_MPI_CHK( mbedtls_mpi_mul_int( &M, &M, 19 ) );
-    MBEDTLS_MPI_CHK( mbedtls_mpi_add_abs( N, N, &M ) );
-
-cleanup:
-    return( ret );
+    return( 0 );
 }
 #endif /* MBEDTLS_ECP_DP_CURVE25519_ENABLED */
 

--- a/library/ecp_curves.c
+++ b/library/ecp_curves.c
@@ -5229,13 +5229,12 @@ static int ecp_mod_p255( mbedtls_mpi *N )
         return( MBEDTLS_ERR_ECP_BAD_INPUT_DATA );
 
     /* Split N as N + 2^256 M */
-    memset( Mp,   0,    sizeof( Mp ) );
     memcpy( Mp,   NT_p, sizeof( mbedtls_mpi_uint ) * NT_n );
     memset( NT_p, 0,    sizeof( mbedtls_mpi_uint ) * NT_n );
 
     /* N = A0 + 38 * A1 */
-    mbedtls_mpi_core_mla( N->p, N->n,
-                          Mp, P255_WIDTH,
+    mbedtls_mpi_core_mla( N->p, P255_WIDTH + 1,
+                          Mp, NT_n,
                           38 );
 
     return( 0 );

--- a/library/ecp_curves.c
+++ b/library/ecp_curves.c
@@ -5223,7 +5223,7 @@ static int ecp_mod_p255( mbedtls_mpi *N )
     /* Helper references for top part of N */
     mbedtls_mpi_uint * const NT_p = N->p + P255_WIDTH;
     const size_t NT_n = N->n - P255_WIDTH;
-    if( NT_n == 0 || NT_n > N->n )
+    if( NT_n <= P255_WIDTH )
         return( 0 );
 
     /* Split N as N + 2^256 M */

--- a/library/ecp_curves.c
+++ b/library/ecp_curves.c
@@ -5222,7 +5222,7 @@ static int ecp_mod_p255( mbedtls_mpi *N )
 
     /* Helper references for top part of N */
     mbedtls_mpi_uint * const NT_p = N->p + P255_WIDTH;
-    unsigned const NT_n = N->n - P255_WIDTH;
+    size_t const NT_n = N->n - P255_WIDTH;
     if( NT_n == 0 || NT_n > P255_WIDTH )
         return( 0 );
 

--- a/library/ecp_curves.c
+++ b/library/ecp_curves.c
@@ -5223,7 +5223,7 @@ static int ecp_mod_p255( mbedtls_mpi *N )
     /* Helper references for top part of N */
     mbedtls_mpi_uint * const NT_p = N->p + P255_WIDTH;
     unsigned const NT_n = N->n - P255_WIDTH;
-    if( NT_n > P255_WIDTH )
+    if( NT_n == 0 || NT_n > P255_WIDTH )
         return( 0 );
 
     /* Split N as N + 2^256 M */

--- a/library/ecp_curves.c
+++ b/library/ecp_curves.c
@@ -5223,7 +5223,7 @@ static int ecp_mod_p255( mbedtls_mpi *N )
     /* Helper references for top part of N */
     mbedtls_mpi_uint * const NT_p = N->p + P255_WIDTH;
     const size_t NT_n = N->n - P255_WIDTH;
-    if( NT_n == 0 || NT_n > P255_WIDTH )
+    if( NT_n == 0 || NT_n > N->n )
         return( 0 );
 
     /* Split N as N + 2^256 M */

--- a/library/ecp_curves.c
+++ b/library/ecp_curves.c
@@ -5222,7 +5222,7 @@ static int ecp_mod_p255( mbedtls_mpi *N )
 
     /* Helper references for top part of N */
     mbedtls_mpi_uint * const NT_p = N->p + P255_WIDTH;
-    size_t const NT_n = N->n - P255_WIDTH;
+    const size_t NT_n = N->n - P255_WIDTH;
     if( NT_n == 0 || NT_n > P255_WIDTH )
         return( 0 );
 

--- a/library/ecp_curves.c
+++ b/library/ecp_curves.c
@@ -5223,7 +5223,7 @@ static int ecp_mod_p255( mbedtls_mpi *N )
     /* Helper references for top part of N */
     mbedtls_mpi_uint * const NT_p = N->p + P255_WIDTH;
     const size_t NT_n = N->n - P255_WIDTH;
-    if( NT_n <= P255_WIDTH )
+    if( N->n <= P255_WIDTH )
         return( 0 );
 
     /* Split N as N + 2^256 M */

--- a/library/ecp_curves.c
+++ b/library/ecp_curves.c
@@ -5225,6 +5225,8 @@ static int ecp_mod_p255( mbedtls_mpi *N )
     const size_t NT_n = N->n - P255_WIDTH;
     if( N->n <= P255_WIDTH )
         return( 0 );
+    if( NT_n > P255_WIDTH )
+        return( MBEDTLS_ERR_ECP_BAD_INPUT_DATA );
 
     /* Split N as N + 2^256 M */
     memset( Mp,   0,    sizeof( Mp ) );


### PR DESCRIPTION
__Context:__ The helper `mpi_mul_hlp()` performs a multiply-accumulate operation `d += s * b`, where `d,b` are MPIs represented as plain integer arrays, and `b` is a scalar.

Previously, only the length of `s` was specified, while `d` was assumed to be 0-terminated of unspecified length.

This was leveraged at the end of the core multiplication steps computing the first `limb(s)` limbs of `d + s*b`: Namely, the routine would keep on adding the current carry to `d` until none was left. This can, in theory, run for an arbitrarily long time if `d` has a tail of `0xFF`s, and hence the assumption of `0`-termination.

This solution is both fragile and insecure -- the latter because the carry-loop depends on the result of the multiplication.

__Changes:__ This PR ... 
* ... changes the signature of `mpi_mul_hlp()` to receive the length of the output buffer, which must be greater or equal to the length of the input buffer. 
* ... renames the function to `mbedtls_mpi_core_mla()`, exposed in `bignum_internal.h` for internal usage
* ... adjusts the p25519 modular reduction to use `mbedtls_mpi_core_mla()` -- this was not originally intended to be done here, but turned out to be necessary since said reduction routine called `mbedtls_mpi_mul_int()` with a stack-allocated MPI which caused difficulties with re-growing.

Regarding the new signature of `mpi_mul_hlp()`, note that it is _not_ assumed that the output buffer is strictly larger than the input buffer -- instead, the routine will simply return any carry that's left. This will be useful in some applications of this function. It is the responsibility of the caller to either size the output appropriately so that no carry will be left, or to handle the carry.

__Note:__ This PR tries to be as minimal as possible. There are a number of instances where one is tempted to try to simplify call-sites of `mpi_mul_hlp()` further, such as `mbedtls_mpi_mul_int()` or the conditional subtraction after `mpi_montmul()`, but this is deliberately not tackled in this PR.