### PR TITLE
Remove the dependency on MBEDTLS_TIME_H from the timing module

### DIFF
--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -129,7 +129,12 @@
  * MBEDTLS_PLATFORM_TIME_MACRO, MBEDTLS_PLATFORM_TIME_TYPE_MACRO and
  * MBEDTLS_PLATFORM_STD_TIME.
  *
- * Comment if your system does not support time functions
+ * Comment if your system does not support time functions.
+ *
+ * \note If MBEDTLS_TIMING_C is set - to enable the semi-portable timing
+ *       interface - timing.c will include time.h on suitable platforms
+ *       regardless of the setting of MBEDTLS_HAVE_TIME, unless
+ *       MBEDTLS_TIMING_ALT is used. See timing.c for more information.
  */
 #define MBEDTLS_HAVE_TIME
 
@@ -3012,6 +3017,10 @@
  * \c mbedtls_ssl_set_timer_cb() for DTLS, or leave it enabled and provide
  * your own implementation of the whole module by setting
  * \c MBEDTLS_TIMING_ALT in the current file.
+ *
+ * \note The timing module will include time.h on suitable platforms
+ *       regardless of the setting of MBEDTLS_HAVE_TIME, unless
+ *       MBEDTLS_TIMING_ALT is used. See timing.c for more information.
  *
  * \note See also our Knowledge Base article about porting to a new
  * environment:

--- a/library/timing.c
+++ b/library/timing.c
@@ -167,33 +167,6 @@ uint32_t mbedtls_timing_get_final_delay(
 {
     return( data->fin_ms );
 }
-#else /* MBEDTLS_HAVE_TIME */
-uint32_t mbedtls_timing_get_final_delay(
-                                      const mbedtls_timing_delay_context *data )
-{
-    (void) data;
-    return( 0 );
-}
-
-int mbedtls_timing_get_delay( void *data )
-{
-    (void) data;
-    return( 0 );
-}
-void mbedtls_timing_set_delay( void *data, uint32_t int_ms, uint32_t fin_ms )
-{
-    (void) data;
-    (void) int_ms;
-    (void) fin_ms;
-}
-
-unsigned long mbedtls_timing_get_timer( struct mbedtls_timing_hr_time *val, int reset )
-{
-    (void) val;
-    (void) reset;
-    return( 0 );
-}
-
 #endif /* MBEDTLS_HAVE_TIME */
 #endif /* !MBEDTLS_TIMING_ALT */
 #endif /* MBEDTLS_TIMING_C */

--- a/library/timing.c
+++ b/library/timing.c
@@ -46,14 +46,14 @@ struct _hr_time
 #include <unistd.h>
 #include <sys/types.h>
 #include <signal.h>
-#if defined(MBEDTLS_HAVE_TIME)
+/* time.h should be included independently of MBEDTLS_HAVE_TIME. If the
+ * platform matches the ifdefs above, it will be used. */
 #include <time.h>
 #include <sys/time.h>
 struct _hr_time
 {
     struct timeval start;
 };
-#endif
 #endif /* _WIN32 && !EFIX64 && !EFI32 */
 
 /**
@@ -75,7 +75,6 @@ struct _hr_time
  *                 get_timer(0) }` the value time1+time2 is only approximately
  *                 the delay since the first reset.
  */
-#if defined(MBEDTLS_HAVE_TIME)
 #if defined(_WIN32) && !defined(EFIX64) && !defined(EFI32)
 
 unsigned long mbedtls_timing_get_timer( struct mbedtls_timing_hr_time *val, int reset )
@@ -167,6 +166,5 @@ uint32_t mbedtls_timing_get_final_delay(
 {
     return( data->fin_ms );
 }
-#endif /* MBEDTLS_HAVE_TIME */
 #endif /* !MBEDTLS_TIMING_ALT */
 #endif /* MBEDTLS_TIMING_C */

--- a/programs/test/udp_proxy.c
+++ b/programs/test/udp_proxy.c
@@ -825,7 +825,6 @@ int main( int argc, char *argv[] )
 
     get_options( argc, argv );
 
-#if defined(MBEDTLS_HAVE_TIME)
     /*
      * Decisions to drop/delay/duplicate packets are pseudo-random: dropping
      * exactly 1 in N packets would lead to problems when a flight has exactly
@@ -836,12 +835,15 @@ int main( int argc, char *argv[] )
      */
     if( opt.seed == 0 )
     {
+#if defined(MBEDTLS_HAVE_TIME)
         opt.seed = (unsigned int) mbedtls_time( NULL );
+#else
+        opt.seed = 1;
+#endif /* MBEDTLS_HAVE_TIME */
         mbedtls_printf( "  . Pseudo-random seed: %u\n", opt.seed );
     }
 
     srand( opt.seed );
-#endif /* MBEDTLS_HAVE_TIME */
 
     /*
      * 0. "Connect" to the server

--- a/tests/suites/test_suite_timing.data
+++ b/tests/suites/test_suite_timing.data
@@ -1,11 +1,8 @@
 Timing: get timer
-depends_on:MBEDTLS_HAVE_TIME
 timing_get_timer:
 
 Timing: delay 0ms
-depends_on:MBEDTLS_HAVE_TIME
 timing_delay:0:
 
 Timing: delay 100ms
-depends_on:MBEDTLS_HAVE_TIME
 timing_delay:100:


### PR DESCRIPTION
Allow the timing module to include `time.h` if the platform is suitable, even when MBEDTLS_HAVE_TIME is disabled.
Remove the dummy timing implementation.
Follow-up after https://github.com/Mbed-TLS/mbedtls/pull/3624.