### PR TITLE
Backport 2.28 - make mbedtls_ssl_send_alert_message() reentrant

### DIFF
--- a/ChangeLog.d/alert_reentrant.txt
+++ b/ChangeLog.d/alert_reentrant.txt
@@ -1,0 +1,5 @@
+Bugfix
+   * Fix bug in the alert sending function mbedtls_ssl_send_alert_message()
+     potentially leading to corrupted alert messages being sent in case
+     the function needs to be re-called after initially returning
+     MBEDTLS_SSL_WANT_WRITE.

--- a/ChangeLog.d/alert_reentrant.txt
+++ b/ChangeLog.d/alert_reentrant.txt
@@ -2,4 +2,4 @@ Bugfix
    * Fix bug in the alert sending function mbedtls_ssl_send_alert_message()
      potentially leading to corrupted alert messages being sent in case
      the function needs to be re-called after initially returning
-     MBEDTLS_SSL_WANT_WRITE.
+     MBEDTLS_SSL_WANT_WRITE. Fixes #1916.

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -4918,6 +4918,9 @@ int mbedtls_ssl_send_alert_message( mbedtls_ssl_context *ssl,
     if( ssl == NULL || ssl->conf == NULL )
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
 
+    if( ssl->out_left != 0 )
+        return( mbedtls_ssl_flush_output( ssl ) );
+
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> send alert message" ) );
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "send alert level=%u message=%u", level, message ));
 
@@ -5789,9 +5792,6 @@ int mbedtls_ssl_close_notify( mbedtls_ssl_context *ssl )
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> write close notify" ) );
-
-    if( ssl->out_left != 0 )
-        return( mbedtls_ssl_flush_output( ssl ) );
 
     if( ssl->state == MBEDTLS_SSL_HANDSHAKE_OVER )
     {


### PR DESCRIPTION
Trivial backport of #1946.