### PR TITLE
Backport 2.28: Remove the dependency on MBEDTLS_TIME_H from the timing module

### DIFF
--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -128,7 +128,12 @@
  * MBEDTLS_PLATFORM_TIME_MACRO, MBEDTLS_PLATFORM_TIME_TYPE_MACRO and
  * MBEDTLS_PLATFORM_STD_TIME.
  *
- * Comment if your system does not support time functions
+ * Comment if your system does not support time functions.
+ *
+ * \note If MBEDTLS_TIMING_C is set - to enable the semi-portable timing
+ *       interface - timing.c will include time.h on suitable platforms
+ *       regardless of the setting of MBEDTLS_HAVE_TIME, unless
+ *       MBEDTLS_TIMING_ALT is used. See timing.c for more information.
  */
 #define MBEDTLS_HAVE_TIME
 
@@ -3465,6 +3470,10 @@
  * \c mbedtls_ssl_set_timer_cb() for DTLS, or leave it enabled and provide
  * your own implementation of the whole module by setting
  * \c MBEDTLS_TIMING_ALT in the current file.
+ *
+ * \note The timing module will include time.h on suitable platforms
+ *       regardless of the setting of MBEDTLS_HAVE_TIME, unless
+ *       MBEDTLS_TIMING_ALT is used. See timing.c for more information.
  *
  * \note See also our Knowledge Base article about porting to a new
  * environment:

--- a/library/timing.c
+++ b/library/timing.c
@@ -57,14 +57,14 @@ struct _hr_time
 #include <unistd.h>
 #include <sys/types.h>
 #include <signal.h>
-#if defined(MBEDTLS_HAVE_TIME)
+/* time.h should be included independently of MBEDTLS_HAVE_TIME. If the
+ * platform matches the ifdefs above, it will be used. */
 #include <time.h>
 #include <sys/time.h>
 struct _hr_time
 {
     struct timeval start;
 };
-#endif
 #endif /* _WIN32 && !EFIX64 && !EFI32 */
 
 #if !defined(HAVE_HARDCLOCK) && defined(MBEDTLS_HAVE_ASM) &&  \

--- a/library/timing.c
+++ b/library/timing.c
@@ -67,7 +67,6 @@ struct _hr_time
 #endif
 #endif /* _WIN32 && !EFIX64 && !EFI32 */
 
-#if defined(MBEDTLS_HAVE_TIME)
 #if !defined(HAVE_HARDCLOCK) && defined(MBEDTLS_HAVE_ASM) &&  \
     ( defined(_MSC_VER) && defined(_M_IX86) ) || defined(__WATCOMC__)
 
@@ -526,45 +525,5 @@ hard_test_done:
 }
 
 #endif /* MBEDTLS_SELF_TEST */
-
-#else
-volatile int mbedtls_timing_alarmed = 0;
-int mbedtls_timing_get_delay( void *data )
-{
-    (void) data;
-    return( 0 );
-}
-
-void mbedtls_timing_set_delay( void *data, uint32_t int_ms, uint32_t fin_ms )
-{
-    (void) data;
-    (void) int_ms;
-    (void) fin_ms;
-}
-
-unsigned long mbedtls_timing_get_timer( struct mbedtls_timing_hr_time *val, int reset )
-{
-    (void) val;
-    (void) reset;
-    return( 0 );
-}
-
-unsigned long mbedtls_timing_hardclock( void )
-{
-    return( 0 );
-}
-
-void mbedtls_set_alarm( int seconds )
-{
-    (void) seconds;
-}
-#if defined(MBEDTLS_SELF_TEST)
-int mbedtls_timing_self_test( int verbose )
-{
-    (void) verbose;
-    return( 0 );
-}
-#endif /* MBEDTLS_SELF_TEST */
-#endif /* MBEDTLS_HAVE_TIME */
 #endif /* !MBEDTLS_TIMING_ALT */
 #endif /* MBEDTLS_TIMING_C */

--- a/programs/test/udp_proxy.c
+++ b/programs/test/udp_proxy.c
@@ -827,7 +827,6 @@ int main( int argc, char *argv[] )
 
     get_options( argc, argv );
 
-#if defined(MBEDTLS_HAVE_TIME)
     /*
      * Decisions to drop/delay/duplicate packets are pseudo-random: dropping
      * exactly 1 in N packets would lead to problems when a flight has exactly
@@ -838,12 +837,15 @@ int main( int argc, char *argv[] )
      */
     if( opt.seed == 0 )
     {
+#if defined(MBEDTLS_HAVE_TIME)
         opt.seed = (unsigned int) mbedtls_time( NULL );
+#else
+        opt.seed = 1;
+#endif /* MBEDTLS_HAVE_TIME */
         mbedtls_printf( "  . Pseudo-random seed: %u\n", opt.seed );
     }
 
     srand( opt.seed );
-#endif /* MBEDTLS_HAVE_TIME */
 
     /*
      * 0. "Connect" to the server

--- a/tests/suites/test_suite_timing.data
+++ b/tests/suites/test_suite_timing.data
@@ -1,23 +1,17 @@
 Timing: hardclock
-depends_on:MBEDTLS_HAVE_TIME
 timing_hardclock:
 
 Timing: get timer
-depends_on:MBEDTLS_HAVE_TIME
 timing_get_timer:
 
 Timing: set alarm with no delay
-depends_on:MBEDTLS_HAVE_TIME
 timing_set_alarm:0:
 
 Timing: set alarm with 1s delay
-depends_on:MBEDTLS_HAVE_TIME
 timing_set_alarm:1:
 
 Timing: delay 0ms
-depends_on:MBEDTLS_HAVE_TIME
 timing_delay:0:
 
 Timing: delay 100ms
-depends_on:MBEDTLS_HAVE_TIME
 timing_delay:100:


### PR DESCRIPTION
Allow the timing module to include time.h if the platform is suitable, even when MBEDTLS_HAVE_TIME is disabled.
Remove the dummy timing implementation.
Backport of https://github.com/Mbed-TLS/mbedtls/pull/5708
Follow-up after https://github.com/Mbed-TLS/mbedtls/pull/5563