### PR TITLE
DRAFT: Support double-granularity for Montgomery multiplication

### DIFF
--- a/include/mbedtls/bignum.h
+++ b/include/mbedtls/bignum.h
@@ -1011,6 +1011,9 @@ int mbedtls_mpi_gen_prime( mbedtls_mpi *X, size_t nbits, int flags,
                    int (*f_rng)(void *, unsigned char *, size_t),
                    void *p_rng );
 
+void mbedtls_mpi_montmul_set( unsigned var );
+const char * mbedtls_mpi_montmul_varname( unsigned var );
+
 #if defined(MBEDTLS_SELF_TEST)
 
 /**

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -1386,14 +1386,12 @@ int mbedtls_mpi_sub_int( mbedtls_mpi *X, const mbedtls_mpi *A, mbedtls_mpi_sint 
  *
  * \return c            The carry at the end of the operation.
  */
-mbedtls_mpi_uint mbedtls_mpi_core_mla( mbedtls_mpi_uint *d, size_t d_len ,
+mbedtls_mpi_uint mbedtls_mpi_core_mla( mbedtls_mpi_uint *d, size_t d_len,
                                        const mbedtls_mpi_uint *s, size_t s_len,
                                        mbedtls_mpi_uint b )
 {
     mbedtls_mpi_uint c = 0; /* carry */
-
-    /* Remember the excess of d over s for later */
-    d_len -= s_len;
+    size_t const excess_len = d_len - s_len;
 
 #if defined(MULADDC_HUIT)
     for( ; s_len >= 8; s_len -= 8 )
@@ -1444,7 +1442,7 @@ mbedtls_mpi_uint mbedtls_mpi_core_mla( mbedtls_mpi_uint *d, size_t d_len ,
     }
 #endif /* MULADDC_HUIT */
 
-    while( d_len-- )
+    while( excess_len-- )
     {
         *d += c; c = ( *d < c ); d++;
     }

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -1391,7 +1391,7 @@ mbedtls_mpi_uint mbedtls_mpi_core_mla( mbedtls_mpi_uint *d, size_t d_len,
                                        mbedtls_mpi_uint b )
 {
     mbedtls_mpi_uint c = 0; /* carry */
-    size_t const excess_len = d_len - s_len;
+    size_t excess_len = d_len - s_len;
 
 #if defined(MULADDC_HUIT)
     for( ; s_len >= 8; s_len -= 8 )

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -1377,54 +1377,19 @@ mbedtls_mpi_uint mbedtls_mpi_core_mla( mbedtls_mpi_uint *d, size_t d_len,
     mbedtls_mpi_uint c = 0; /* carry */
     size_t excess_len = d_len - s_len;
 
-#if defined(MULADDC_HUIT)
     for( ; s_len >= 8; s_len -= 8 )
     {
-        MULADDC_INIT
-        MULADDC_HUIT
-        MULADDC_STOP
+        MULADDC_X8_INIT
+        MULADDC_X8_CORE
+        MULADDC_X8_STOP
     }
 
     for( ; s_len > 0; s_len-- )
     {
-        MULADDC_INIT
-        MULADDC_CORE
-        MULADDC_STOP
+        MULADDC_X1_INIT
+        MULADDC_X1_CORE
+        MULADDC_X1_STOP
     }
-#else /* MULADDC_HUIT */
-    for( ; s_len >= 16; s_len -= 16 )
-    {
-        MULADDC_INIT
-        MULADDC_CORE   MULADDC_CORE
-        MULADDC_CORE   MULADDC_CORE
-        MULADDC_CORE   MULADDC_CORE
-        MULADDC_CORE   MULADDC_CORE
-
-        MULADDC_CORE   MULADDC_CORE
-        MULADDC_CORE   MULADDC_CORE
-        MULADDC_CORE   MULADDC_CORE
-        MULADDC_CORE   MULADDC_CORE
-        MULADDC_STOP
-    }
-
-    for( ; s_len >= 8; s_len -= 8 )
-    {
-        MULADDC_INIT
-        MULADDC_CORE   MULADDC_CORE
-        MULADDC_CORE   MULADDC_CORE
-
-        MULADDC_CORE   MULADDC_CORE
-        MULADDC_CORE   MULADDC_CORE
-        MULADDC_STOP
-    }
-
-    for( ; s_len > 0; s_len-- )
-    {
-        MULADDC_INIT
-        MULADDC_CORE
-        MULADDC_STOP
-    }
-#endif /* MULADDC_HUIT */
 
     while( excess_len-- )
     {

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -1377,14 +1377,17 @@ mbedtls_mpi_uint mbedtls_mpi_core_mla( mbedtls_mpi_uint *d, size_t d_len,
     mbedtls_mpi_uint c = 0; /* carry */
     size_t excess_len = d_len - s_len;
 
-    for( ; s_len >= 8; s_len -= 8 )
+    size_t steps_x8 = s_len / 8;
+    size_t steps_x1 = s_len & 7;
+
+    while( steps_x8-- )
     {
         MULADDC_X8_INIT
         MULADDC_X8_CORE
         MULADDC_X8_STOP
     }
 
-    for( ; s_len > 0; s_len-- )
+    while( steps_x1-- )
     {
         MULADDC_X1_INIT
         MULADDC_X1_CORE

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -1370,22 +1370,6 @@ int mbedtls_mpi_sub_int( mbedtls_mpi *X, const mbedtls_mpi *A, mbedtls_mpi_sint 
     return( mbedtls_mpi_sub_mpi( X, A, &B ) );
 }
 
-/** Helper for mbedtls_mpi multiplication.
- *
- * Add \p b * \p s to \p d.
- *
- * \param[in,out] d     The bignum to add to.
- * \param d_len         The number of limbs of \p d. This must be
- *                      at least \p s_len.
- * \param s_len         The number of limbs of \p s.
- * \param[in] s         A bignum to multiply, of size \p i.
- *                      It may overlap with \p d, but only if
- *                      \p d <= \p s.
- *                      Its leading limb must not be \c 0.
- * \param b             A scalar to multiply.
- *
- * \return c            The carry at the end of the operation.
- */
 mbedtls_mpi_uint mbedtls_mpi_core_mla( mbedtls_mpi_uint *d, size_t d_len,
                                        const mbedtls_mpi_uint *s, size_t s_len,
                                        mbedtls_mpi_uint b )

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -1820,19 +1820,31 @@ int mbedtls_mpi_mod_int( mbedtls_mpi_uint *r, const mbedtls_mpi *A, mbedtls_mpi_
 
 /*
  * Fast Montgomery initialization (thanks to Tom St Denis)
+ *
+ * This computes the negative modular inverse of m in mbedtls_mpi_uint.
  */
-static void mpi_montg_init( mbedtls_mpi_uint *mm, const mbedtls_mpi *N )
+static void mpi_montg_init( mbedtls_mpi_uint *m_inv,
+                            mbedtls_mpi_uint const *m )
 {
-    mbedtls_mpi_uint x, m0 = N->p[0];
-    unsigned int i;
-
-    x  = m0;
-    x += ( ( m0 + 2 ) & 4 ) << 1;
-
-    for( i = biL; i >= 8; i /= 2 )
-        x *= ( 2 - ( m0 * x ) );
-
-    *mm = ~x + 1;
+    /* The basic principle is the following:
+     * If R=2^k and we already know that m_inv is the negative
+     * modular inverse of m w.r.t. R -- that is,
+     *   m_inv*m + 1 == 0 mod R,
+     * then
+     *  (m_inv*m + 1)^2 == 0 mod R^2.
+     * Expanding yields that
+     *  2 m_inv + m_inv^2 * m = m_inv * (2 + m_inv*m)
+     * is the modular inverse of -m w.r.t. R^2 = 2^{2k}
+     *
+     * Below, we iterate this procedure, starting at the bitlevel (k=1)
+     * where m_inv = m = 1 (m must be odd). We compute in mbedtls_mpi_uint
+     * throughout, which is higher precision than necessary for most of
+     * the iterations, but yields the simplest and fastest code.
+     */
+    mbedtls_mpi_uint m0 = m[0], mi0 = m0;
+    for( unsigned i = biL; i > 1; i /= 2 )
+        mi0 *= ( 2 + ( m0 * mi0 ) );
+    *m_inv = mi0;
 }
 
 /** Montgomery multiplication: A = A * B * R^-1 mod N  (HAC 14.36)
@@ -1986,7 +1998,7 @@ int mbedtls_mpi_exp_mod( mbedtls_mpi *X, const mbedtls_mpi *A,
     /*
      * Init temps and window size
      */
-    mpi_montg_init( &mm, N );
+    mpi_montg_init( &mm, N->p );
     mbedtls_mpi_init( &RR ); mbedtls_mpi_init( &T );
     mbedtls_mpi_init( &Apos );
     mbedtls_mpi_init( &WW );

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -1907,8 +1907,8 @@ static void mpi_montg_init( mbedtls_mpi_uint *mm, const mbedtls_mpi *N )
  * \param           mm  The value calculated by `mpi_montg_init(&mm, N)`.
  *                      This is -N^-1 mod 2^ciL.
  * \param[in,out]   T   A bignum for temporary storage.
- *                      It must be at least twice the limb size of N plus 2
- *                      (T->n >= 2 * (N->n + 1)).
+ *                      It must be at least twice the limb size of N plus 1
+ *                      (T->n >= 2 * N->n + 1).
  *                      Its initial content is unused and
  *                      its final content is indeterminate.
  *                      Note that unlike the usual convention in the library
@@ -1934,10 +1934,13 @@ static void mpi_montmul( mbedtls_mpi *A, const mbedtls_mpi *B, const mbedtls_mpi
         u0 = A->p[i];
         u1 = ( d[0] + u0 * B->p[0] ) * mm;
 
-        mpi_mul_hlp( m, B->p, d, u0 );
-        mpi_mul_hlp( n, N->p, d, u1 );
-
-        d++; d[n + 1] = 0;
+        (void) mpi_mul_hlp( d, n + 2,
+                            B->p, m,
+                            u0 );
+        (void) mpi_mul_hlp( d, n + 2,
+                            N->p, n,
+                            u1 );
+        d++;
     }
 
     /* At this point, d is either the desired result or the desired result

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -1465,7 +1465,7 @@ mbedtls_mpi_uint mpi_mul_hlp( mbedtls_mpi_uint *d, size_t d_len ,
 int mbedtls_mpi_mul_mpi( mbedtls_mpi *X, const mbedtls_mpi *A, const mbedtls_mpi *B )
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
-    size_t i, j;
+    size_t i, j, k;
     mbedtls_mpi TA, TB;
     int result_is_zero = 0;
     MPI_VALIDATE_RET( X != NULL );
@@ -1492,8 +1492,14 @@ int mbedtls_mpi_mul_mpi( mbedtls_mpi *X, const mbedtls_mpi *A, const mbedtls_mpi
     MBEDTLS_MPI_CHK( mbedtls_mpi_grow( X, i + j ) );
     MBEDTLS_MPI_CHK( mbedtls_mpi_lset( X, 0 ) );
 
-    for( ; j > 0; j-- )
-        mpi_mul_hlp( i, A->p, X->p + j - 1, B->p[j - 1] );
+    for( k = 0; k < j; k++ )
+    {
+        /* We know that there cannot be any carry-out since we're
+         * iterating from bottom to top. */
+        (void) mpi_mul_hlp( X->p + k, i + 1,
+                            A->p, i,
+                            B->p[k] );
+    }
 
     /* If the result is 0, we don't shortcut the operation, which reduces
      * but does not eliminate side channels leaking the zero-ness. We do

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -1525,17 +1525,9 @@ int mbedtls_mpi_mul_int( mbedtls_mpi *X, const mbedtls_mpi *A, mbedtls_mpi_uint 
     MPI_VALIDATE_RET( X != NULL );
     MPI_VALIDATE_RET( A != NULL );
 
-    /* mpi_mul_hlp can't deal with a leading 0. */
-    size_t n = A->n;
-    while( n > 0 && A->p[n - 1] == 0 )
-        --n;
-
-    /* The general method below doesn't work if n==0 or b==0. By chance
-     * calculating the result is trivial in those cases. */
-    if( b == 0 || n == 0 )
-    {
+    /* The general method below doesn't work if b==0. */
+    if( b == 0 )
         return( mbedtls_mpi_lset( X, 0 ) );
-    }
 
     /* Calculate A*b as A + A*(b-1) to take advantage of mpi_mul_hlp */
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
@@ -1547,9 +1539,9 @@ int mbedtls_mpi_mul_int( mbedtls_mpi *X, const mbedtls_mpi *A, mbedtls_mpi_uint 
      * calls to calloc() in ECP code, presumably because it reuses the
      * same mpi for a while and this way the mpi is more likely to directly
      * grow to its final size. */
-    MBEDTLS_MPI_CHK( mbedtls_mpi_grow( X, n + 1 ) );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_grow( X, A->n + 1 ) );
     MBEDTLS_MPI_CHK( mbedtls_mpi_copy( X, A ) );
-    mpi_mul_hlp( n, A->p, X->p, b - 1 );
+    mpi_mul_hlp( X->p, X->n, A->p, A->n, b - 1 );
 
 cleanup:
     return( ret );

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -1398,7 +1398,7 @@ void mpi_mul_hlp( size_t i,
                   mbedtls_mpi_uint *d,
                   mbedtls_mpi_uint b )
 {
-    mbedtls_mpi_uint c = 0, t = 0;
+    mbedtls_mpi_uint c = 0; /* carry */
 
 #if defined(MULADDC_HUIT)
     for( ; i >= 8; i -= 8 )
@@ -1448,8 +1448,6 @@ void mpi_mul_hlp( size_t i,
         MULADDC_STOP
     }
 #endif /* MULADDC_HUIT */
-
-    t++;
 
     while( c != 0 )
     {

--- a/library/bignum_internal.h
+++ b/library/bignum_internal.h
@@ -1,0 +1,49 @@
+/**
+ *  Internal bignum functions
+ *
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef MBEDTLS_BIGNUM_INTERNAL_H
+#define MBEDTLS_BIGNUM_INTERNAL_H
+
+#include "common.h"
+
+#if defined(MBEDTLS_BIGNUM_C)
+#include "mbedtls/bignum.h"
+#endif
+
+/** Helper for mbedtls_mpi multiplication.
+ *
+ * Add \p b * \p s to \p d.
+ *
+ * \param[in,out] d     The bignum to add to.
+ * \param d_len         The number of limbs of \p d. This must be
+ *                      at least \p s_len.
+ * \param s_len         The number of limbs of \p s.
+ * \param[in] s         A bignum to multiply, of size \p i.
+ *                      It may overlap with \p d, but only if
+ *                      \p d <= \p s.
+ *                      Its leading limb must not be \c 0.
+ * \param b             A scalar to multiply.
+ *
+ * \return c            The carry at the end of the operation.
+ */
+mbedtls_mpi_uint mbedtls_mpi_core_mla( mbedtls_mpi_uint *d, size_t d_len ,
+                                       const mbedtls_mpi_uint *s, size_t s_len,
+                                       mbedtls_mpi_uint b );
+
+#endif /* MBEDTLS_BIGNUM_INTERNAL_H */

--- a/library/bignum_internal.h
+++ b/library/bignum_internal.h
@@ -26,19 +26,20 @@
 #include "mbedtls/bignum.h"
 #endif
 
-/** Helper for mbedtls_mpi multiplication.
+/** Perform a known-size multiply accumulate operation
  *
  * Add \p b * \p s to \p d.
  *
- * \param[in,out] d     The bignum to add to.
+ * \param[in,out] d     The pointer to the (little-endian) array
+ *                      representing the bignum to accumulate onto.
  * \param d_len         The number of limbs of \p d. This must be
  *                      at least \p s_len.
+ * \param[in] s         The pointer to the (little-endian) array
+ *                      representing the bignum to multiply with.
+ *                      This may be the same as \p d. Otherwise,
+ *                      it must be disjoint from \p d.
  * \param s_len         The number of limbs of \p s.
- * \param[in] s         A bignum to multiply, of size \p i.
- *                      It may overlap with \p d, but only if
- *                      \p d <= \p s.
- *                      Its leading limb must not be \c 0.
- * \param b             A scalar to multiply.
+ * \param b             A scalar to multiply with.
  *
  * \return c            The carry at the end of the operation.
  */

--- a/library/bignum_internal.h
+++ b/library/bignum_internal.h
@@ -47,4 +47,14 @@ mbedtls_mpi_uint mbedtls_mpi_core_mla( mbedtls_mpi_uint *d, size_t d_len ,
                                        const mbedtls_mpi_uint *s, size_t s_len,
                                        mbedtls_mpi_uint b );
 
+mbedtls_mpi_uint mbedtls_mpi_core_mla_x2( const mbedtls_mpi_uint *s, size_t s_len,
+                                          mbedtls_mpi_uint *d, size_t d_len,
+                                          mbedtls_mpi_uint b0, mbedtls_mpi_uint b1 );
+
+mbedtls_mpi_uint mbedtls_mpi_core_mla_x2_dbl(
+    mbedtls_mpi_uint *d, size_t d_len,
+    const mbedtls_mpi_uint *s, const mbedtls_mpi_uint *t, size_t st_len,
+    mbedtls_mpi_uint b0, mbedtls_mpi_uint b1,
+    mbedtls_mpi_uint a0, mbedtls_mpi_uint a1 );
+
 #endif /* MBEDTLS_BIGNUM_INTERNAL_H */

--- a/library/bignum_internal.h
+++ b/library/bignum_internal.h
@@ -43,18 +43,31 @@
  *
  * \return c            The carry at the end of the operation.
  */
-mbedtls_mpi_uint mbedtls_mpi_core_mla( mbedtls_mpi_uint *d, size_t d_len ,
-                                       const mbedtls_mpi_uint *s, size_t s_len,
-                                       mbedtls_mpi_uint b );
+mbedtls_mpi_uint mbedtls_mpi_core_mla(
+    mbedtls_mpi_uint *d, size_t d_len ,
+    const mbedtls_mpi_uint *s, size_t s_len,
+    mbedtls_mpi_uint b );
 
-mbedtls_mpi_uint mbedtls_mpi_core_mla_x2( const mbedtls_mpi_uint *s, size_t s_len,
-                                          mbedtls_mpi_uint *d, size_t d_len,
-                                          mbedtls_mpi_uint b0, mbedtls_mpi_uint b1 );
+mbedtls_mpi_uint mbedtls_mpi_core_mla_x1(
+    mbedtls_mpi_uint *d, size_t d_len,
+    const mbedtls_mpi_uint *s, size_t s_len,
+    mbedtls_mpi_uint b );
 
-mbedtls_mpi_uint mbedtls_mpi_core_mla_x2_dbl(
+mbedtls_mpi_uint mbedtls_mpi_core_mmla_x1(
+    mbedtls_mpi_uint *d, size_t d_len,
+    const mbedtls_mpi_uint *s, const mbedtls_mpi_uint *t, size_t st_len,
+    mbedtls_mpi_uint b, mbedtls_mpi_uint a );
+
+mbedtls_mpi_uint mbedtls_mpi_core_mla_x2(
+    mbedtls_mpi_uint *d, size_t d_len,
+    const mbedtls_mpi_uint *s, size_t s_len,
+    mbedtls_mpi_uint b0, mbedtls_mpi_uint b1 );
+
+mbedtls_mpi_uint mbedtls_mpi_core_mmla_x2(
     mbedtls_mpi_uint *d, size_t d_len,
     const mbedtls_mpi_uint *s, const mbedtls_mpi_uint *t, size_t st_len,
     mbedtls_mpi_uint b0, mbedtls_mpi_uint b1,
     mbedtls_mpi_uint a0, mbedtls_mpi_uint a1 );
+
 
 #endif /* MBEDTLS_BIGNUM_INTERNAL_H */

--- a/library/bn_mul.h
+++ b/library/bn_mul.h
@@ -98,7 +98,7 @@
  */
 #if defined(__i386__) && defined(__OPTIMIZE__)
 
-#define MULADDC_INIT                        \
+#define MULADDC_X1_INIT                     \
     { mbedtls_mpi_uint t;                   \
     asm(                                    \
         "movl   %%ebx, %0           \n\t"   \
@@ -107,7 +107,7 @@
         "movl   %7, %%ecx           \n\t"   \
         "movl   %8, %%ebx           \n\t"
 
-#define MULADDC_CORE                        \
+#define MULADDC_X1_CORE                     \
         "lodsl                      \n\t"   \
         "mull   %%ebx               \n\t"   \
         "addl   %%ecx,   %%eax      \n\t"   \
@@ -117,9 +117,21 @@
         "movl   %%edx,   %%ecx      \n\t"   \
         "stosl                      \n\t"
 
+#define MULADDC_X1_STOP                                 \
+        "movl   %4, %%ebx       \n\t"                   \
+        "movl   %%ecx, %1       \n\t"                   \
+        "movl   %%edi, %2       \n\t"                   \
+        "movl   %%esi, %3       \n\t"                   \
+        : "=m" (t), "=m" (c), "=m" (d), "=m" (s)        \
+        : "m" (t), "m" (s), "m" (d), "m" (c), "m" (b)   \
+        : "eax", "ebx", "ecx", "edx", "esi", "edi"      \
+    ); }
+
 #if defined(MBEDTLS_HAVE_SSE2)
 
-#define MULADDC_HUIT                            \
+#define MULADDC_X8_INIT MULADDC_X1_INIT
+
+#define MULADDC_X8_CORE                         \
         "movd     %%ecx,     %%mm1      \n\t"   \
         "movd     %%ebx,     %%mm0      \n\t"   \
         "movd     (%%edi),   %%mm3      \n\t"   \
@@ -182,7 +194,7 @@
         "psrlq    $32,       %%mm1      \n\t"   \
         "movd     %%mm1,     %%ecx      \n\t"
 
-#define MULADDC_STOP                    \
+#define MULADDC_X8_STOP                 \
         "emms                   \n\t"   \
         "movl   %4, %%ebx       \n\t"   \
         "movl   %%ecx, %1       \n\t"   \
@@ -193,28 +205,17 @@
         : "eax", "ebx", "ecx", "edx", "esi", "edi"      \
     ); }                                                \
 
-
-#else
-
-#define MULADDC_STOP                    \
-        "movl   %4, %%ebx       \n\t"   \
-        "movl   %%ecx, %1       \n\t"   \
-        "movl   %%edi, %2       \n\t"   \
-        "movl   %%esi, %3       \n\t"   \
-        : "=m" (t), "=m" (c), "=m" (d), "=m" (s)        \
-        : "m" (t), "m" (s), "m" (d), "m" (c), "m" (b)   \
-        : "eax", "ebx", "ecx", "edx", "esi", "edi"      \
-    ); }
 #endif /* SSE2 */
+
 #endif /* i386 */
 
 #if defined(__amd64__) || defined (__x86_64__)
 
-#define MULADDC_INIT                        \
+#define MULADDC_X1_INIT                        \
     asm(                                    \
         "xorq   %%r8, %%r8\n"
 
-#define MULADDC_CORE                        \
+#define MULADDC_X1_CORE                        \
         "movq   (%%rsi), %%rax\n"           \
         "mulq   %%rbx\n"                    \
         "addq   $8, %%rsi\n"                \
@@ -226,7 +227,7 @@
         "adcq   %%rdx, %%rcx\n"             \
         "addq   $8, %%rdi\n"
 
-#define MULADDC_STOP                                                 \
+#define MULADDC_X1_STOP                                              \
         : "+c" (c), "+D" (d), "+S" (s), "+m" (*(uint64_t (*)[16]) d) \
         : "b" (b), "m" (*(const uint64_t (*)[16]) s)                 \
         : "rax", "rdx", "r8"                                         \
@@ -236,10 +237,10 @@
 
 #if defined(__aarch64__)
 
-#define MULADDC_INIT                \
+#define MULADDC_X1_INIT             \
     asm(
 
-#define MULADDC_CORE                \
+#define MULADDC_X1_CORE             \
         "ldr x4, [%2], #8   \n\t"   \
         "ldr x5, [%1]       \n\t"   \
         "mul x6, x4, %4     \n\t"   \
@@ -250,7 +251,7 @@
         "adc %0, x7, xzr    \n\t"   \
         "str x5, [%1], #8   \n\t"
 
-#define MULADDC_STOP                                                    \
+#define MULADDC_X1_STOP                                                 \
          : "+r" (c),  "+r" (d), "+r" (s), "+m" (*(uint64_t (*)[16]) d)  \
          : "r" (b), "m" (*(const uint64_t (*)[16]) s)                   \
          : "x4", "x5", "x6", "x7", "cc"                                 \
@@ -260,7 +261,7 @@
 
 #if defined(__mc68020__) || defined(__mcpu32__)
 
-#define MULADDC_INIT                    \
+#define MULADDC_X1_INIT                 \
     asm(                                \
         "movl   %3, %%a2        \n\t"   \
         "movl   %4, %%a3        \n\t"   \
@@ -268,7 +269,7 @@
         "movl   %6, %%d2        \n\t"   \
         "moveq  #0, %%d0        \n\t"
 
-#define MULADDC_CORE                    \
+#define MULADDC_X1_CORE                 \
         "movel  %%a2@+, %%d1    \n\t"   \
         "mulul  %%d2, %%d4:%%d1 \n\t"   \
         "addl   %%d3, %%d1      \n\t"   \
@@ -277,7 +278,7 @@
         "addl   %%d1, %%a3@+    \n\t"   \
         "addxl  %%d4, %%d3      \n\t"
 
-#define MULADDC_STOP                    \
+#define MULADDC_X1_STOP                 \
         "movl   %%d3, %0        \n\t"   \
         "movl   %%a3, %1        \n\t"   \
         "movl   %%a2, %2        \n\t"   \
@@ -286,7 +287,9 @@
         : "d0", "d1", "d2", "d3", "d4", "a2", "a3"  \
     );
 
-#define MULADDC_HUIT                        \
+#define MULADDC_X8_INIT MULADDC_X1_INIT
+
+#define MULADDC_X8_CORE                     \
         "movel  %%a2@+,  %%d1       \n\t"   \
         "mulul  %%d2,    %%d4:%%d1  \n\t"   \
         "addxl  %%d3,    %%d1       \n\t"   \
@@ -329,13 +332,15 @@
         "addl   %%d1,    %%a3@+     \n\t"   \
         "addxl  %%d0,    %%d3       \n\t"
 
+#define MULADDC_X8_STOP MULADDC_X1_STOP
+
 #endif /* MC68000 */
 
 #if defined(__powerpc64__) || defined(__ppc64__)
 
 #if defined(__MACH__) && defined(__APPLE__)
 
-#define MULADDC_INIT                        \
+#define MULADDC_X1_INIT                     \
     asm(                                    \
         "ld     r3, %3              \n\t"   \
         "ld     r4, %4              \n\t"   \
@@ -345,7 +350,7 @@
         "addi   r4, r4, -8          \n\t"   \
         "addic  r5, r5,  0          \n\t"
 
-#define MULADDC_CORE                        \
+#define MULADDC_X1_CORE                     \
         "ldu    r7, 8(r3)           \n\t"   \
         "mulld  r8, r7, r6          \n\t"   \
         "mulhdu r9, r7, r6          \n\t"   \
@@ -355,7 +360,7 @@
         "addc   r8, r8, r7          \n\t"   \
         "stdu   r8, 8(r4)           \n\t"
 
-#define MULADDC_STOP                        \
+#define MULADDC_X1_STOP                     \
         "addze  r5, r5              \n\t"   \
         "addi   r4, r4, 8           \n\t"   \
         "addi   r3, r3, 8           \n\t"   \
@@ -370,7 +375,7 @@
 
 #else /* __MACH__ && __APPLE__ */
 
-#define MULADDC_INIT                        \
+#define MULADDC_X1_INIT                     \
     asm(                                    \
         "ld     %%r3, %3            \n\t"   \
         "ld     %%r4, %4            \n\t"   \
@@ -380,7 +385,7 @@
         "addi   %%r4, %%r4, -8      \n\t"   \
         "addic  %%r5, %%r5,  0      \n\t"
 
-#define MULADDC_CORE                        \
+#define MULADDC_X1_CORE                     \
         "ldu    %%r7, 8(%%r3)       \n\t"   \
         "mulld  %%r8, %%r7, %%r6    \n\t"   \
         "mulhdu %%r9, %%r7, %%r6    \n\t"   \
@@ -390,7 +395,7 @@
         "addc   %%r8, %%r8, %%r7    \n\t"   \
         "stdu   %%r8, 8(%%r4)       \n\t"
 
-#define MULADDC_STOP                        \
+#define MULADDC_X1_STOP                     \
         "addze  %%r5, %%r5          \n\t"   \
         "addi   %%r4, %%r4, 8       \n\t"   \
         "addi   %%r3, %%r3, 8       \n\t"   \
@@ -408,7 +413,7 @@
 
 #if defined(__MACH__) && defined(__APPLE__)
 
-#define MULADDC_INIT                    \
+#define MULADDC_X1_INIT                 \
     asm(                                \
         "lwz    r3, %3          \n\t"   \
         "lwz    r4, %4          \n\t"   \
@@ -418,7 +423,7 @@
         "addi   r4, r4, -4      \n\t"   \
         "addic  r5, r5,  0      \n\t"
 
-#define MULADDC_CORE                    \
+#define MULADDC_X1_CORE                 \
         "lwzu   r7, 4(r3)       \n\t"   \
         "mullw  r8, r7, r6      \n\t"   \
         "mulhwu r9, r7, r6      \n\t"   \
@@ -428,7 +433,7 @@
         "addc   r8, r8, r7      \n\t"   \
         "stwu   r8, 4(r4)       \n\t"
 
-#define MULADDC_STOP                    \
+#define MULADDC_X1_STOP                 \
         "addze  r5, r5          \n\t"   \
         "addi   r4, r4, 4       \n\t"   \
         "addi   r3, r3, 4       \n\t"   \
@@ -442,7 +447,7 @@
 
 #else /* __MACH__ && __APPLE__ */
 
-#define MULADDC_INIT                        \
+#define MULADDC_X1_INIT                     \
     asm(                                    \
         "lwz    %%r3, %3            \n\t"   \
         "lwz    %%r4, %4            \n\t"   \
@@ -452,7 +457,7 @@
         "addi   %%r4, %%r4, -4      \n\t"   \
         "addic  %%r5, %%r5,  0      \n\t"
 
-#define MULADDC_CORE                        \
+#define MULADDC_X1_CORE                     \
         "lwzu   %%r7, 4(%%r3)       \n\t"   \
         "mullw  %%r8, %%r7, %%r6    \n\t"   \
         "mulhwu %%r9, %%r7, %%r6    \n\t"   \
@@ -462,7 +467,7 @@
         "addc   %%r8, %%r8, %%r7    \n\t"   \
         "stwu   %%r8, 4(%%r4)       \n\t"
 
-#define MULADDC_STOP                        \
+#define MULADDC_X1_STOP                     \
         "addze  %%r5, %%r5          \n\t"   \
         "addi   %%r4, %%r4, 4       \n\t"   \
         "addi   %%r3, %%r3, 4       \n\t"   \
@@ -485,14 +490,14 @@
 #if 0 && defined(__sparc__)
 #if defined(__sparc64__)
 
-#define MULADDC_INIT                                    \
+#define MULADDC_X1_INIT                                 \
     asm(                                                \
                 "ldx     %3, %%o0               \n\t"   \
                 "ldx     %4, %%o1               \n\t"   \
                 "ld      %5, %%o2               \n\t"   \
                 "ld      %6, %%o3               \n\t"
 
-#define MULADDC_CORE                                    \
+#define MULADDC_X1_CORE                                 \
                 "ld      [%%o0], %%o4           \n\t"   \
                 "inc     4, %%o0                \n\t"   \
                 "ld      [%%o1], %%o5           \n\t"   \
@@ -505,7 +510,7 @@
                 "addx    %%g1, 0, %%o2          \n\t"   \
                 "inc     4, %%o1                \n\t"
 
-        #define MULADDC_STOP                            \
+#define MULADDC_X1_STOP                                 \
                 "st      %%o2, %0               \n\t"   \
                 "stx     %%o1, %1               \n\t"   \
                 "stx     %%o0, %2               \n\t"   \
@@ -517,14 +522,14 @@
 
 #else /* __sparc64__ */
 
-#define MULADDC_INIT                                    \
+#define MULADDC_X1_INIT                                 \
     asm(                                                \
                 "ld      %3, %%o0               \n\t"   \
                 "ld      %4, %%o1               \n\t"   \
                 "ld      %5, %%o2               \n\t"   \
                 "ld      %6, %%o3               \n\t"
 
-#define MULADDC_CORE                                    \
+#define MULADDC_X1_CORE                                 \
                 "ld      [%%o0], %%o4           \n\t"   \
                 "inc     4, %%o0                \n\t"   \
                 "ld      [%%o1], %%o5           \n\t"   \
@@ -537,7 +542,7 @@
                 "addx    %%g1, 0, %%o2          \n\t"   \
                 "inc     4, %%o1                \n\t"
 
-#define MULADDC_STOP                                    \
+#define MULADDC_X1_STOP                                 \
                 "st      %%o2, %0               \n\t"   \
                 "st      %%o1, %1               \n\t"   \
                 "st      %%o0, %2               \n\t"   \
@@ -552,7 +557,7 @@
 
 #if defined(__microblaze__) || defined(microblaze)
 
-#define MULADDC_INIT                    \
+#define MULADDC_X1_INIT                 \
     asm(                                \
         "lwi   r3,   %3         \n\t"   \
         "lwi   r4,   %4         \n\t"   \
@@ -561,7 +566,7 @@
         "andi  r7,   r6, 0xffff \n\t"   \
         "bsrli r6,   r6, 16     \n\t"
 
-#define MULADDC_CORE                    \
+#define MULADDC_X1_CORE                 \
         "lhui  r8,   r3,   0    \n\t"   \
         "addi  r3,   r3,   2    \n\t"   \
         "lhui  r9,   r3,   0    \n\t"   \
@@ -588,7 +593,7 @@
         "swi   r12,  r4,   0    \n\t"   \
         "addi   r4,  r4,   4    \n\t"
 
-#define MULADDC_STOP                    \
+#define MULADDC_X1_STOP                 \
         "swi   r5,   %0         \n\t"   \
         "swi   r4,   %1         \n\t"   \
         "swi   r3,   %2         \n\t"   \
@@ -602,7 +607,7 @@
 
 #if defined(__tricore__)
 
-#define MULADDC_INIT                            \
+#define MULADDC_X1_INIT                         \
     asm(                                        \
         "ld.a   %%a2, %3                \n\t"   \
         "ld.a   %%a3, %4                \n\t"   \
@@ -610,7 +615,7 @@
         "ld.w   %%d1, %6                \n\t"   \
         "xor    %%d5, %%d5              \n\t"
 
-#define MULADDC_CORE                            \
+#define MULADDC_X1_CORE                         \
         "ld.w   %%d0,   [%%a2+]         \n\t"   \
         "madd.u %%e2, %%e4, %%d0, %%d1  \n\t"   \
         "ld.w   %%d0,   [%%a3]          \n\t"   \
@@ -619,7 +624,7 @@
         "mov    %%d4,    %%d3           \n\t"   \
         "st.w  [%%a3+],  %%d2           \n\t"
 
-#define MULADDC_STOP                            \
+#define MULADDC_X1_STOP                         \
         "st.w   %0, %%d4                \n\t"   \
         "st.a   %1, %%a3                \n\t"   \
         "st.a   %2, %%a2                \n\t"   \
@@ -649,7 +654,7 @@
 
 #if defined(__thumb__) && !defined(__thumb2__)
 
-#define MULADDC_INIT                                    \
+#define MULADDC_X1_INIT                                 \
     asm(                                                \
             "ldr    r0, %3                      \n\t"   \
             "ldr    r1, %4                      \n\t"   \
@@ -661,7 +666,7 @@
             "lsr    r7, r7, #16                 \n\t"   \
             "mov    r8, r7                      \n\t"
 
-#define MULADDC_CORE                                    \
+#define MULADDC_X1_CORE                                 \
             "ldmia  r0!, {r6}                   \n\t"   \
             "lsr    r7, r6, #16                 \n\t"   \
             "lsl    r6, r6, #16                 \n\t"   \
@@ -692,7 +697,7 @@
             "adc    r2, r5                      \n\t"   \
             "stmia  r1!, {r4}                   \n\t"
 
-#define MULADDC_STOP                                    \
+#define MULADDC_X1_STOP                                 \
             "str    r2, %0                      \n\t"   \
             "str    r1, %1                      \n\t"   \
             "str    r0, %2                      \n\t"   \
@@ -705,16 +710,16 @@
 #elif (__ARM_ARCH >= 6) && \
     defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1)
 
-#define MULADDC_INIT                            \
+#define MULADDC_X1_INIT                            \
     asm(
 
-#define MULADDC_CORE                            \
+#define MULADDC_X1_CORE                         \
             "ldr    r0, [%0], #4        \n\t"   \
             "ldr    r1, [%1]            \n\t"   \
             "umaal  r1, %2, %3, r0      \n\t"   \
             "str    r1, [%1], #4        \n\t"
 
-#define MULADDC_STOP                            \
+#define MULADDC_X1_STOP                         \
          : "=r" (s),  "=r" (d), "=r" (c)        \
          : "r" (b), "0" (s), "1" (d), "2" (c)   \
          : "r0", "r1", "memory"                 \
@@ -722,14 +727,14 @@
 
 #else
 
-#define MULADDC_INIT                                    \
+#define MULADDC_X1_INIT                                 \
     asm(                                                \
             "ldr    r0, %3                      \n\t"   \
             "ldr    r1, %4                      \n\t"   \
             "ldr    r2, %5                      \n\t"   \
             "ldr    r3, %6                      \n\t"
 
-#define MULADDC_CORE                                    \
+#define MULADDC_X1_CORE                                 \
             "ldr    r4, [r0], #4                \n\t"   \
             "mov    r5, #0                      \n\t"   \
             "ldr    r6, [r1]                    \n\t"   \
@@ -738,7 +743,7 @@
             "adc    r2, r5, #0                  \n\t"   \
             "str    r7, [r1], #4                \n\t"
 
-#define MULADDC_STOP                                    \
+#define MULADDC_X1_STOP                                 \
             "str    r2, %0                      \n\t"   \
             "str    r1, %1                      \n\t"   \
             "str    r0, %2                      \n\t"   \
@@ -754,14 +759,14 @@
 
 #if defined(__alpha__)
 
-#define MULADDC_INIT                    \
+#define MULADDC_X1_INIT                 \
     asm(                                \
         "ldq    $1, %3          \n\t"   \
         "ldq    $2, %4          \n\t"   \
         "ldq    $3, %5          \n\t"   \
         "ldq    $4, %6          \n\t"
 
-#define MULADDC_CORE                    \
+#define MULADDC_X1_CORE                 \
         "ldq    $6,  0($1)      \n\t"   \
         "addq   $1,  8, $1      \n\t"   \
         "mulq   $6, $4, $7      \n\t"   \
@@ -776,7 +781,7 @@
         "addq   $6, $3, $3      \n\t"   \
         "addq   $5, $3, $3      \n\t"
 
-#define MULADDC_STOP                                    \
+#define MULADDC_X1_STOP                 \
         "stq    $3, %0          \n\t"   \
         "stq    $2, %1          \n\t"   \
         "stq    $1, %2          \n\t"   \
@@ -788,14 +793,14 @@
 
 #if defined(__mips__) && !defined(__mips64)
 
-#define MULADDC_INIT                    \
+#define MULADDC_X1_INIT                 \
     asm(                                \
         "lw     $10, %3         \n\t"   \
         "lw     $11, %4         \n\t"   \
         "lw     $12, %5         \n\t"   \
         "lw     $13, %6         \n\t"
 
-#define MULADDC_CORE                    \
+#define MULADDC_X1_CORE                 \
         "lw     $14, 0($10)     \n\t"   \
         "multu  $13, $14        \n\t"   \
         "addi   $10, $10, 4     \n\t"   \
@@ -811,7 +816,7 @@
         "addu   $12, $12, $14   \n\t"   \
         "addi   $11, $11, 4     \n\t"
 
-#define MULADDC_STOP                    \
+#define MULADDC_X1_STOP                 \
         "sw     $12, %0         \n\t"   \
         "sw     $11, %1         \n\t"   \
         "sw     $10, %2         \n\t"   \
@@ -825,13 +830,13 @@
 
 #if (defined(_MSC_VER) && defined(_M_IX86)) || defined(__WATCOMC__)
 
-#define MULADDC_INIT                            \
+#define MULADDC_X1_INIT                         \
     __asm   mov     esi, s                      \
     __asm   mov     edi, d                      \
     __asm   mov     ecx, c                      \
     __asm   mov     ebx, b
 
-#define MULADDC_CORE                            \
+#define MULADDC_X1_CORE                         \
     __asm   lodsd                               \
     __asm   mul     ebx                         \
     __asm   add     eax, ecx                    \
@@ -841,11 +846,18 @@
     __asm   mov     ecx, edx                    \
     __asm   stosd
 
+#define MULADDC_X1_STOP                         \
+    __asm   mov     c, ecx                      \
+    __asm   mov     d, edi                      \
+    __asm   mov     s, esi
+
 #if defined(MBEDTLS_HAVE_SSE2)
 
 #define EMIT __asm _emit
 
-#define MULADDC_HUIT                            \
+#define MULADDC_X8_INIT MULADDC_X1_INIT
+
+#define MULADDC_X8_CORE                         \
     EMIT 0x0F  EMIT 0x6E  EMIT 0xC9             \
     EMIT 0x0F  EMIT 0x6E  EMIT 0xC3             \
     EMIT 0x0F  EMIT 0x6E  EMIT 0x1F             \
@@ -908,33 +920,26 @@
     EMIT 0x0F  EMIT 0x73  EMIT 0xD1  EMIT 0x20  \
     EMIT 0x0F  EMIT 0x7E  EMIT 0xC9
 
-#define MULADDC_STOP                            \
+#define MULADDC_X8_STOP                         \
     EMIT 0x0F  EMIT 0x77                        \
     __asm   mov     c, ecx                      \
     __asm   mov     d, edi                      \
-    __asm   mov     s, esi                      \
-
-#else
-
-#define MULADDC_STOP                            \
-    __asm   mov     c, ecx                      \
-    __asm   mov     d, edi                      \
-    __asm   mov     s, esi                      \
+    __asm   mov     s, esi
 
 #endif /* SSE2 */
 #endif /* MSVC */
 
 #endif /* MBEDTLS_HAVE_ASM */
 
-#if !defined(MULADDC_CORE)
+#if !defined(MULADDC_X1_CORE)
 #if defined(MBEDTLS_HAVE_UDBL)
 
-#define MULADDC_INIT                    \
+#define MULADDC_X1_INIT                 \
 {                                       \
     mbedtls_t_udbl r;                           \
     mbedtls_mpi_uint r0, r1;
 
-#define MULADDC_CORE                    \
+#define MULADDC_X1_CORE                 \
     r   = *(s++) * (mbedtls_t_udbl) b;          \
     r0  = (mbedtls_mpi_uint) r;                   \
     r1  = (mbedtls_mpi_uint)( r >> biL );         \
@@ -942,18 +947,19 @@
     r0 += *d; r1 += (r0 < *d);          \
     c = r1; *(d++) = r0;
 
-#define MULADDC_STOP                    \
+#define MULADDC_X1_STOP                 \
 }
 
-#else
-#define MULADDC_INIT                    \
+#else /* MBEDTLS_HAVE_UDBL */
+
+#define MULADDC_X1_INIT                 \
 {                                       \
     mbedtls_mpi_uint s0, s1, b0, b1;              \
     mbedtls_mpi_uint r0, r1, rx, ry;              \
     b0 = ( b << biH ) >> biH;           \
     b1 = ( b >> biH );
 
-#define MULADDC_CORE                    \
+#define MULADDC_X1_CORE                 \
     s0 = ( *s << biH ) >> biH;          \
     s1 = ( *s >> biH ); s++;            \
     rx = s0 * b1; r0 = s0 * b0;         \
@@ -967,10 +973,28 @@
     r0 += *d; r1 += (r0 < *d);          \
     c = r1; *(d++) = r0;
 
-#define MULADDC_STOP                    \
+#define MULADDC_X1_STOP                 \
 }
 
-#endif /* C (generic)  */
 #endif /* C (longlong) */
+#endif /* C (generic)  */
+
+#if !defined(MULADDC_X2_CORE)
+#define MULADDC_X2_INIT MULADDC_X1_INIT
+#define MULADDC_X2_STOP MULADDC_X1_STOP
+#define MULADDC_X2_CORE MULADDC_X1_CORE MULADDC_X1_CORE
+#endif /* MULADDC_X2_CORE */
+
+#if !defined(MULADDC_X4_CORE)
+#define MULADDC_X4_INIT MULADDC_X2_INIT
+#define MULADDC_X4_STOP MULADDC_X2_STOP
+#define MULADDC_X4_CORE MULADDC_X2_CORE MULADDC_X2_CORE
+#endif /* MULADDC_X4_CORE */
+
+#if !defined(MULADDC_X8_CORE)
+#define MULADDC_X8_INIT MULADDC_X4_INIT
+#define MULADDC_X8_STOP MULADDC_X4_STOP
+#define MULADDC_X8_CORE MULADDC_X4_CORE MULADDC_X4_CORE
+#endif /* MULADDC_X8_CORE */
 
 #endif /* bn_mul.h */

--- a/library/bn_mul.h
+++ b/library/bn_mul.h
@@ -99,6 +99,7 @@
 #if defined(__i386__) && defined(__OPTIMIZE__)
 
 #define MULADDC_INIT                        \
+    { mbedtls_mpi_uint t;                   \
     asm(                                    \
         "movl   %%ebx, %0           \n\t"   \
         "movl   %5, %%esi           \n\t"   \
@@ -190,7 +191,8 @@
         : "=m" (t), "=m" (c), "=m" (d), "=m" (s)        \
         : "m" (t), "m" (s), "m" (d), "m" (c), "m" (b)   \
         : "eax", "ebx", "ecx", "edx", "esi", "edi"      \
-    );
+    ); }                                                \
+
 
 #else
 
@@ -202,7 +204,7 @@
         : "=m" (t), "=m" (c), "=m" (d), "=m" (s)        \
         : "m" (t), "m" (s), "m" (d), "m" (c), "m" (b)   \
         : "eax", "ebx", "ecx", "edx", "esi", "edi"      \
-    );
+    ); }
 #endif /* SSE2 */
 #endif /* i386 */
 

--- a/library/bn_mul.h
+++ b/library/bn_mul.h
@@ -1075,4 +1075,12 @@
 #define MULADDC_X8_CORE MULADDC_X4_CORE MULADDC_X4_CORE
 #endif /* MULADDC_X8_CORE */
 
+#if !defined(MPI_UINT_VMAAL_X4)
+#define MPI_UINT_VMAAL_X4(d0,d1,d2,d3,c,s0,s1,s2,s3,b)     \
+    MPI_UINT_UMAAL(d0, c, s0, b );                         \
+    MPI_UINT_UMAAL(d1, c, s1, b );                         \
+    MPI_UINT_UMAAL(d2, c, s2, b );                         \
+    MPI_UINT_UMAAL(d3, c, s3, b );
+#endif /* MPI_UINT_VMAAL_X4 */
+
 #endif /* bn_mul.h */

--- a/library/bn_mul.h
+++ b/library/bn_mul.h
@@ -711,19 +711,27 @@
     defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1)
 
 #define MULADDC_X1_INIT                            \
-    asm(
+    {                                              \
+        mbedtls_mpi_uint tmp_a, tmp_b;             \
+        asm volatile (
 
-#define MULADDC_X1_CORE                         \
-            "ldr    r0, [%0], #4        \n\t"   \
-            "ldr    r1, [%1]            \n\t"   \
-            "umaal  r1, %2, %3, r0      \n\t"   \
-            "str    r1, [%1], #4        \n\t"
+#define MULADDC_X1_CORE                                         \
+           ".p2align  2                                 \n\t"   \
+            "ldr.w    %[a], [%[in]], #4                 \n\t"   \
+            "ldr.w    %[b], [%[acc]]                    \n\t"   \
+            "umaal    %[b], %[carry], %[scalar], %[a]   \n\t"   \
+            "str.w    %[b], [%[acc]], #4                \n\t"
 
-#define MULADDC_X1_STOP                         \
-         : "=r" (s),  "=r" (d), "=r" (c)        \
-         : "r" (b), "0" (s), "1" (d), "2" (c)   \
-         : "r0", "r1", "memory"                 \
-         );
+#define MULADDC_X1_STOP                                      \
+            : [a]      "=&r" (tmp_a),                        \
+              [b]      "=&r" (tmp_b),                        \
+              [in]     "+r"  (s),                            \
+              [acc]    "+r"  (d),                            \
+              [carry]  "+l"  (c)                             \
+            : [scalar] "r"   (b)                             \
+            : "memory"                                       \
+        );                                                   \
+    }
 
 #define MULADDC_X2_INIT                              \
     {                                                \

--- a/library/bn_mul.h
+++ b/library/bn_mul.h
@@ -1006,6 +1006,44 @@
 #endif /* MBEDTLS_HAVE_UDBL */
 #endif /* MPI_UINT_UMAAL */
 
+#define MPI_UINT_DBL_MUL_SGL(out0,out1,a0,a1,b0)  \
+    {                                             \
+        mbedtls_mpi_uint carry = 0;               \
+        mbedtls_mpi_uint tmp0 = 0, tmp1 = 0;      \
+        MPI_UINT_UMAAL(tmp0,tmp1,a0,b0);          \
+        MPI_UINT_UMAAL(tmp1,carry,a1,b0);         \
+        out0 = tmp0; out1 = tmp1;                 \
+    }
+
+#define MPI_UINT_DBL_MUL_SGL_ACC(acc0,acc1,a0,a1,b0)     \
+    {                                                    \
+        mbedtls_mpi_uint carry;                          \
+        mbedtls_mpi_uint tmp0 = acc0, tmp1 = 0;          \
+        MPI_UINT_UMAAL(tmp0,tmp1,a0,b0);                 \
+        carry = acc1; MPI_UINT_UMAAL(tmp1,carry,a1,b0);  \
+        acc0 = tmp0; acc1 = tmp1;                        \
+    }
+
+#define MPI_UINT_DBL_MUL_DBL_ACC(acc0,acc1,a0,a1,b0,b1)  \
+    {                                                    \
+        mbedtls_mpi_uint carry;                          \
+        mbedtls_mpi_uint tmp0 = acc0, tmp1 = 0;          \
+        MPI_UINT_UMAAL(tmp0,tmp1,a0,b0);                 \
+        carry = acc1; MPI_UINT_UMAAL(tmp1,carry,a1,b0);  \
+        carry = 0;    MPI_UINT_UMAAL(tmp1,carry,a0,b1);  \
+        acc0 = tmp0; acc1 = tmp1;                        \
+    }
+
+#define MPI_UINT_DBL_MUL_DBL(out0,out1,a0,a1,b0,b1)  \
+    {                                                \
+        mbedtls_mpi_uint carry;                      \
+        mbedtls_mpi_uint tmp0 = 0, tmp1 = 0;         \
+        MPI_UINT_UMAAL(tmp0,tmp1,a0,b0);             \
+        carry = 0; MPI_UINT_UMAAL(tmp1,carry,a1,b0); \
+        carry = 0; MPI_UINT_UMAAL(tmp1,carry,a0,b1); \
+        out0 = tmp0; out1 = tmp1;                    \
+    }
+
 #if !defined(MULADDC_X1_CORE)
 #define MULADDC_X1_INIT                         \
     {                                           \

--- a/library/bn_mul.h
+++ b/library/bn_mul.h
@@ -725,6 +725,36 @@
          : "r0", "r1", "memory"                 \
          );
 
+#define MULADDC_X2_INIT                              \
+    {                                                \
+        mbedtls_mpi_uint tmp_a0, tmp_b0;             \
+        mbedtls_mpi_uint tmp_a1, tmp_b1;             \
+        asm volatile (
+
+#define MULADDC_X2_CORE                                           \
+           ".p2align  2                                   \n\t"   \
+            "ldr.w    %[a0], [%[in]],  #+8                \n\t"   \
+            "ldr.w    %[b0], [%[acc]], #+8                \n\t"   \
+            "ldr.w    %[a1], [%[in],  #-4]                \n\t"   \
+            "ldr.w    %[b1], [%[acc], #-4]                \n\t"   \
+            "umaal    %[b0], %[carry], %[scalar], %[a0]   \n\t"   \
+            "umaal    %[b1], %[carry], %[scalar], %[a1]   \n\t"   \
+            "str.w    %[b0], [%[acc], #-8]                \n\t"   \
+            "str.w    %[b1], [%[acc], #-4]                \n\t"
+
+#define MULADDC_X2_STOP                                      \
+            : [a0]     "=&r" (tmp_a0),                       \
+              [b0]     "=&r" (tmp_b0),                       \
+              [a1]     "=&r" (tmp_a1),                       \
+              [b1]     "=&r" (tmp_b1),                       \
+              [in]     "+r"  (s),                            \
+              [acc]    "+r"  (d),                            \
+              [carry]  "+l"  (c)                             \
+            : [scalar] "r"   (b)                             \
+            : "memory"                                       \
+        );                                                   \
+    }
+
 #else
 
 #define MULADDC_X1_INIT                                 \

--- a/library/ecp_curves.c
+++ b/library/ecp_curves.c
@@ -26,6 +26,7 @@
 #include "mbedtls/error.h"
 
 #include "bn_mul.h"
+#include "bignum_internal.h"
 #include "ecp_invasive.h"
 
 #include <string.h>
@@ -5213,40 +5214,29 @@ cleanup:
 
 /*
  * Fast quasi-reduction modulo p255 = 2^255 - 19
- * Write N as A0 + 2^255 A1, return A0 + 19 * A1
+ * Write N as A0 + 2^256 A1, return A0 + 38 * A1
  */
 static int ecp_mod_p255( mbedtls_mpi *N )
 {
-    int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
-    size_t i;
-    mbedtls_mpi M;
-    mbedtls_mpi_uint Mp[P255_WIDTH + 2];
+    mbedtls_mpi_uint Mp[P255_WIDTH];
 
-    if( N->n < P255_WIDTH )
+    /* Helper references for top part of N */
+    mbedtls_mpi_uint * const NT_p = N->p + P255_WIDTH;
+    unsigned const NT_n = N->n - P255_WIDTH;
+    if( NT_n > P255_WIDTH )
         return( 0 );
 
-    /* M = A1 */
-    M.s = 1;
-    M.n = N->n - ( P255_WIDTH - 1 );
-    if( M.n > P255_WIDTH + 1 )
-        return( MBEDTLS_ERR_ECP_BAD_INPUT_DATA );
-    M.p = Mp;
-    memset( Mp, 0, sizeof Mp );
-    memcpy( Mp, N->p + P255_WIDTH - 1, M.n * sizeof( mbedtls_mpi_uint ) );
-    MBEDTLS_MPI_CHK( mbedtls_mpi_shift_r( &M, 255 % ( 8 * sizeof( mbedtls_mpi_uint ) ) ) );
-    M.n++; /* Make room for multiplication by 19 */
+    /* Split N as N + 2^256 M */
+    memset( Mp,   0,    sizeof( Mp ) );
+    memcpy( Mp,   NT_p, sizeof( mbedtls_mpi_uint ) * NT_n );
+    memset( NT_p, 0,    sizeof( mbedtls_mpi_uint ) * NT_n );
 
-    /* N = A0 */
-    MBEDTLS_MPI_CHK( mbedtls_mpi_set_bit( N, 255, 0 ) );
-    for( i = P255_WIDTH; i < N->n; i++ )
-        N->p[i] = 0;
+    /* N = A0 + 38 * A1 */
+    mbedtls_mpi_core_mla( N->p, N->n,
+                          Mp, P255_WIDTH,
+                          38 );
 
-    /* N = A0 + 19 * A1 */
-    MBEDTLS_MPI_CHK( mbedtls_mpi_mul_int( &M, &M, 19 ) );
-    MBEDTLS_MPI_CHK( mbedtls_mpi_add_abs( N, N, &M ) );
-
-cleanup:
-    return( ret );
+    return( 0 );
 }
 #endif /* MBEDTLS_ECP_DP_CURVE25519_ENABLED */
 

--- a/library/ecp_curves.c
+++ b/library/ecp_curves.c
@@ -5222,7 +5222,7 @@ static int ecp_mod_p255( mbedtls_mpi *N )
 
     /* Helper references for top part of N */
     mbedtls_mpi_uint * const NT_p = N->p + P255_WIDTH;
-    unsigned const NT_n = N->n - P255_WIDTH;
+    size_t const NT_n = N->n - P255_WIDTH;
     if( NT_n == 0 || NT_n > P255_WIDTH )
         return( 0 );
 

--- a/library/ecp_curves.c
+++ b/library/ecp_curves.c
@@ -5223,7 +5223,7 @@ static int ecp_mod_p255( mbedtls_mpi *N )
     /* Helper references for top part of N */
     mbedtls_mpi_uint * const NT_p = N->p + P255_WIDTH;
     unsigned const NT_n = N->n - P255_WIDTH;
-    if( NT_n > P255_WIDTH )
+    if( NT_n == 0 || NT_n > P255_WIDTH )
         return( 0 );
 
     /* Split N as N + 2^256 M */

--- a/library/ecp_curves.c
+++ b/library/ecp_curves.c
@@ -5222,7 +5222,7 @@ static int ecp_mod_p255( mbedtls_mpi *N )
 
     /* Helper references for top part of N */
     mbedtls_mpi_uint * const NT_p = N->p + P255_WIDTH;
-    size_t const NT_n = N->n - P255_WIDTH;
+    const size_t NT_n = N->n - P255_WIDTH;
     if( NT_n == 0 || NT_n > P255_WIDTH )
         return( 0 );
 


### PR DESCRIPTION
__Dependencies:__ 
* Based on #5722 
* Should be based on #5701 (TODO)

__Summary:__ This PR experiments with two optimizations previously noted for RSA. These optimizations retain the basic quadratic-time Montgomery multiplication approach, but change two details:
* Single-width vs Double-width granularity for Montgomery multiplication (see below).
* "Coarsely integrated operand scanning" (CIOS) vs. "Finely integrated operand scanning" (FIOS) (initially suggested in #5666).

__Why:__ There are multiple reasons why the above changes can be beneficial, depending on the target platform.

* Both optimizations save memory operations, which _may_ improve performance. To put it in numbers:
  * The present Montgomery multiplication strategy has a 3/1 ratio of load/store to UMAAL arithmetic blocks (which for MCUs with DSP extension are in fact single instructions, but generally need multiple instructions)
  * Replacing CIOS by FIOS reduces the ratio to 2/1
  * Double-width granularity reduces the CIOS ratio from 3/1 to 1.5/1, and the FIOS ratio from 2/1 to 1/1
* Both optimizations increase the instruction-level parallelism (ILP), which makes it likely that high-end CPUs see a performance bump. This is particularly interesting since we're dealing with carry chains, which are inherently sequential.

__Architecture-specific considerations:__ TODO -- will discuss MCUs with DSP extension, and high-end v8-A CPUs. 

__Results:__ TODO

### Background: Montgomery multiplication granularity

Iterative Montgomery multiplication computes the modular product `a*b` of two `n`-limb integers `(a_i), (b_i)` by computing one big x small product `a * b_i` a time followed by an (n+1)-to-n limb Montgomery reduction.

Here, by "granularity" of the Montgomery multiplication I mean the size of the limbs. Mbed TLS picks `mbedtls_mpi_uint`, which is most suitable type to compute with on the target machine; typically `uint64_t` on high-end CPUs, and `uint32_t` on MCUs. 

This PR double the granularity of Montgomery multiplication in the sense that the "Montgomery-limbs" are now _pairs_ of two `mbedtls_mpi_uint` values, while the structure of the Montgomery multiplication stays the same. In terms of `mbedtls_mpi_uint`s, this means that we compute one product `a * (b_{2i}, b_{2i+1})` a time, followed by an `(n+2)-to-n` limb reduction. 
