### PR TITLE
Rewrite x25519 example program

### DIFF
--- a/ChangeLog.d/fix-x25519-program.txt
+++ b/ChangeLog.d/fix-x25519-program.txt
@@ -1,0 +1,4 @@
+Bugfix
+   * Fix a bug in x25519 example program where the removal of
+     MBEDTLS_ECDH_LEGACY_CONTEXT caused the program not to run. Fixes #4901 and
+     #3191.

--- a/programs/pkey/ecdh_curve25519.c
+++ b/programs/pkey/ecdh_curve25519.c
@@ -79,9 +79,9 @@ int main( int argc, char *argv[] )
 
     mbedtls_entropy_init( &entropy );
     if( ( ret = mbedtls_ctr_drbg_seed( &ctr_drbg, mbedtls_entropy_func,
-                                &entropy,
-                                (const unsigned char *) pers,
-                                sizeof pers ) ) != 0 )
+                                       &entropy,
+                                       (const unsigned char *) pers,
+                                       sizeof pers ) ) != 0 )
     {
         mbedtls_printf( " failed\n  ! mbedtls_ctr_drbg_seed returned %d\n",
                         ret );

--- a/programs/pkey/ecdh_curve25519.c
+++ b/programs/pkey/ecdh_curve25519.c
@@ -30,12 +30,12 @@
 #define MBEDTLS_EXIT_FAILURE    EXIT_FAILURE
 #endif /* MBEDTLS_PLATFORM_C */
 
-#if !defined(MBEDTLS_ECDH_C) || !defined(MBEDTLS_ECDH_LEGACY_CONTEXT) || \
+#if !defined(MBEDTLS_ECDH_C) || \
     !defined(MBEDTLS_ECP_DP_CURVE25519_ENABLED) || \
     !defined(MBEDTLS_ENTROPY_C) || !defined(MBEDTLS_CTR_DRBG_C)
 int main( void )
 {
-    mbedtls_printf( "MBEDTLS_ECDH_C and/or MBEDTLS_ECDH_LEGACY_CONTEXT and/or "
+    mbedtls_printf( "MBEDTLS_ECDH_C and/or "
                     "MBEDTLS_ECP_DP_CURVE25519_ENABLED and/or "
                     "MBEDTLS_ENTROPY_C and/or MBEDTLS_CTR_DRBG_C "
                     "not defined\n" );
@@ -47,6 +47,8 @@ int main( void )
 #include "mbedtls/ctr_drbg.h"
 #include "mbedtls/ecdh.h"
 
+#include <string.h>
+
 
 int main( int argc, char *argv[] )
 {
@@ -55,8 +57,13 @@ int main( int argc, char *argv[] )
     mbedtls_ecdh_context ctx_cli, ctx_srv;
     mbedtls_entropy_context entropy;
     mbedtls_ctr_drbg_context ctr_drbg;
-    unsigned char cli_to_srv[32], srv_to_cli[32];
+    unsigned char cli_to_srv[36], srv_to_cli[33];
     const char pers[] = "ecdh";
+
+    size_t olen;
+    unsigned char secret_cli[32], secret_srv[32];
+    const unsigned char *p_cli_to_srv = cli_to_srv;
+
     ((void) argc);
     ((void) argv);
 
@@ -67,15 +74,17 @@ int main( int argc, char *argv[] )
     /*
      * Initialize random number generation
      */
-    mbedtls_printf( "  . Seeding the random number generator..." );
+    mbedtls_printf( "  . Seed the random number generator..." );
     fflush( stdout );
 
     mbedtls_entropy_init( &entropy );
-    if( ( ret = mbedtls_ctr_drbg_seed( &ctr_drbg, mbedtls_entropy_func, &entropy,
-                               (const unsigned char *) pers,
-                               sizeof pers ) ) != 0 )
+    if( ( ret = mbedtls_ctr_drbg_seed( &ctr_drbg, mbedtls_entropy_func,
+                                &entropy,
+                                (const unsigned char *) pers,
+                                sizeof pers ) ) != 0 )
     {
-        mbedtls_printf( " failed\n  ! mbedtls_ctr_drbg_seed returned %d\n", ret );
+        mbedtls_printf( " failed\n  ! mbedtls_ctr_drbg_seed returned %d\n",
+                        ret );
         goto exit;
     }
 
@@ -84,28 +93,23 @@ int main( int argc, char *argv[] )
     /*
      * Client: initialize context and generate keypair
      */
-    mbedtls_printf( "  . Setting up client context..." );
+    mbedtls_printf( "  . Set up client context, generate EC key pair..." );
     fflush( stdout );
 
-    ret = mbedtls_ecp_group_load( &ctx_cli.MBEDTLS_PRIVATE(grp), MBEDTLS_ECP_DP_CURVE25519 );
+    ret = mbedtls_ecdh_setup( &ctx_cli, MBEDTLS_ECP_DP_CURVE25519 );
     if( ret != 0 )
     {
-        mbedtls_printf( " failed\n  ! mbedtls_ecp_group_load returned %d\n", ret );
+        mbedtls_printf( " failed\n  ! mbedtls_ecdh_setup returned %d\n", ret );
         goto exit;
     }
 
-    ret = mbedtls_ecdh_gen_public( &ctx_cli.MBEDTLS_PRIVATE(grp), &ctx_cli.MBEDTLS_PRIVATE(d), &ctx_cli.MBEDTLS_PRIVATE(Q),
-                                   mbedtls_ctr_drbg_random, &ctr_drbg );
+    ret = mbedtls_ecdh_make_params( &ctx_cli, &olen, cli_to_srv,
+                                    sizeof( cli_to_srv ),
+                                    mbedtls_ctr_drbg_random, &ctr_drbg );
     if( ret != 0 )
     {
-        mbedtls_printf( " failed\n  ! mbedtls_ecdh_gen_public returned %d\n", ret );
-        goto exit;
-    }
-
-    ret = mbedtls_mpi_write_binary( &ctx_cli.MBEDTLS_PRIVATE(Q).MBEDTLS_PRIVATE(X), cli_to_srv, 32 );
-    if( ret != 0 )
-    {
-        mbedtls_printf( " failed\n  ! mbedtls_mpi_write_binary returned %d\n", ret );
+        mbedtls_printf( " failed\n  ! mbedtls_ecdh_make_params returned %d\n",
+                        ret );
         goto exit;
     }
 
@@ -114,90 +118,70 @@ int main( int argc, char *argv[] )
     /*
      * Server: initialize context and generate keypair
      */
-    mbedtls_printf( "  . Setting up server context..." );
+    mbedtls_printf( "  . Server: read params, generate public key..." );
     fflush( stdout );
 
-    ret = mbedtls_ecp_group_load( &ctx_srv.MBEDTLS_PRIVATE(grp), MBEDTLS_ECP_DP_CURVE25519 );
+    ret = mbedtls_ecdh_read_params( &ctx_srv, &p_cli_to_srv,
+                                    p_cli_to_srv + sizeof( cli_to_srv ) );
     if( ret != 0 )
     {
-        mbedtls_printf( " failed\n  ! mbedtls_ecp_group_load returned %d\n", ret );
+        mbedtls_printf( " failed\n  ! mbedtls_ecdh_read_params returned %d\n",
+                        ret );
         goto exit;
     }
 
-    ret = mbedtls_ecdh_gen_public( &ctx_srv.MBEDTLS_PRIVATE(grp), &ctx_srv.MBEDTLS_PRIVATE(d), &ctx_srv.MBEDTLS_PRIVATE(Q),
-                                   mbedtls_ctr_drbg_random, &ctr_drbg );
+    ret = mbedtls_ecdh_make_public( &ctx_srv, &olen, srv_to_cli,
+                                    sizeof( srv_to_cli ),
+                                    mbedtls_ctr_drbg_random, &ctr_drbg );
     if( ret != 0 )
     {
-        mbedtls_printf( " failed\n  ! mbedtls_ecdh_gen_public returned %d\n", ret );
-        goto exit;
-    }
-
-    ret = mbedtls_mpi_write_binary( &ctx_srv.MBEDTLS_PRIVATE(Q).MBEDTLS_PRIVATE(X), srv_to_cli, 32 );
-    if( ret != 0 )
-    {
-        mbedtls_printf( " failed\n  ! mbedtls_mpi_write_binary returned %d\n", ret );
+        mbedtls_printf( " failed\n  ! mbedtls_ecdh_make_params returned %d\n",
+                        ret );
         goto exit;
     }
 
     mbedtls_printf( " ok\n" );
 
     /*
-     * Server: read peer's key and generate shared secret
+     * Client: read public key
      */
-    mbedtls_printf( "  . Server reading client key and computing secret..." );
+    mbedtls_printf( "  . Client: read public key..." );
     fflush( stdout );
 
-    ret = mbedtls_mpi_lset( &ctx_srv.MBEDTLS_PRIVATE(Qp).MBEDTLS_PRIVATE(Z), 1 );
+    ret = mbedtls_ecdh_read_public( &ctx_cli, srv_to_cli,
+                                    sizeof( srv_to_cli ) );
     if( ret != 0 )
     {
-        mbedtls_printf( " failed\n  ! mbedtls_mpi_lset returned %d\n", ret );
-        goto exit;
-    }
-
-    ret = mbedtls_mpi_read_binary( &ctx_srv.MBEDTLS_PRIVATE(Qp).MBEDTLS_PRIVATE(X), cli_to_srv, 32 );
-    if( ret != 0 )
-    {
-        mbedtls_printf( " failed\n  ! mbedtls_mpi_read_binary returned %d\n", ret );
-        goto exit;
-    }
-
-    ret = mbedtls_ecdh_compute_shared( &ctx_srv.MBEDTLS_PRIVATE(grp), &ctx_srv.MBEDTLS_PRIVATE(z),
-                                       &ctx_srv.MBEDTLS_PRIVATE(Qp), &ctx_srv.MBEDTLS_PRIVATE(d),
-                                       mbedtls_ctr_drbg_random, &ctr_drbg );
-    if( ret != 0 )
-    {
-        mbedtls_printf( " failed\n  ! mbedtls_ecdh_compute_shared returned %d\n", ret );
+        mbedtls_printf( " failed\n  ! mbedtls_ecdh_read_public returned %d\n",
+                        ret );
         goto exit;
     }
 
     mbedtls_printf( " ok\n" );
 
     /*
-     * Client: read peer's key and generate shared secret
+     * Calculate secrets
      */
-    mbedtls_printf( "  . Client reading server key and computing secret..." );
+    mbedtls_printf( "  . Calculate secrets..." );
     fflush( stdout );
 
-    ret = mbedtls_mpi_lset( &ctx_cli.MBEDTLS_PRIVATE(Qp).MBEDTLS_PRIVATE(Z), 1 );
+    ret = mbedtls_ecdh_calc_secret( &ctx_cli, &olen, secret_cli,
+                                    sizeof( secret_cli ),
+                                    mbedtls_ctr_drbg_random, &ctr_drbg );
     if( ret != 0 )
     {
-        mbedtls_printf( " failed\n  ! mbedtls_mpi_lset returned %d\n", ret );
+        mbedtls_printf( " failed\n  ! mbedtls_ecdh_calc_secret returned %d\n",
+                        ret );
         goto exit;
     }
 
-    ret = mbedtls_mpi_read_binary( &ctx_cli.MBEDTLS_PRIVATE(Qp).MBEDTLS_PRIVATE(X), srv_to_cli, 32 );
+    ret = mbedtls_ecdh_calc_secret( &ctx_srv, &olen, secret_srv,
+                                    sizeof( secret_srv ),
+                                    mbedtls_ctr_drbg_random, &ctr_drbg );
     if( ret != 0 )
     {
-        mbedtls_printf( " failed\n  ! mbedtls_mpi_read_binary returned %d\n", ret );
-        goto exit;
-    }
-
-    ret = mbedtls_ecdh_compute_shared( &ctx_cli.MBEDTLS_PRIVATE(grp), &ctx_cli.MBEDTLS_PRIVATE(z),
-                                       &ctx_cli.MBEDTLS_PRIVATE(Qp), &ctx_cli.MBEDTLS_PRIVATE(d),
-                                       mbedtls_ctr_drbg_random, &ctr_drbg );
-    if( ret != 0 )
-    {
-        mbedtls_printf( " failed\n  ! mbedtls_ecdh_compute_shared returned %d\n", ret );
+        mbedtls_printf( " failed\n  ! mbedtls_ecdh_calc_secret returned %d\n",
+                        ret );
         goto exit;
     }
 
@@ -206,13 +190,13 @@ int main( int argc, char *argv[] )
     /*
      * Verification: are the computed secrets equal?
      */
-    mbedtls_printf( "  . Checking if both computed secrets are equal..." );
+    mbedtls_printf( "  . Check if both calculated secrets are equal..." );
     fflush( stdout );
 
-    ret = mbedtls_mpi_cmp_mpi( &ctx_cli.MBEDTLS_PRIVATE(z), &ctx_srv.MBEDTLS_PRIVATE(z) );
+    ret = memcmp( secret_srv, secret_cli, sizeof( secret_srv ) );
     if( ret != 0 )
     {
-        mbedtls_printf( " failed\n  ! mbedtls_ecdh_compute_shared returned %d\n", ret );
+        mbedtls_printf( " failed\n  ! Shared secrets not equal.\n" );
         goto exit;
     }
 

--- a/programs/pkey/ecdh_curve25519.c
+++ b/programs/pkey/ecdh_curve25519.c
@@ -135,7 +135,7 @@ int main( int argc, char *argv[] )
                                     mbedtls_ctr_drbg_random, &ctr_drbg );
     if( ret != 0 )
     {
-        mbedtls_printf( " failed\n  ! mbedtls_ecdh_make_params returned %d\n",
+        mbedtls_printf( " failed\n  ! mbedtls_ecdh_make_public returned %d\n",
                         ret );
         goto exit;
     }

--- a/programs/pkey/ecdh_curve25519.c
+++ b/programs/pkey/ecdh_curve25519.c
@@ -60,7 +60,8 @@ int main( int argc, char *argv[] )
     unsigned char cli_to_srv[36], srv_to_cli[33];
     const char pers[] = "ecdh";
 
-    size_t olen;
+    size_t srv_olen;
+    size_t cli_olen;
     unsigned char secret_cli[32] = { 0 };
     unsigned char secret_srv[32] = { 0 };
     const unsigned char *p_cli_to_srv = cli_to_srv;
@@ -104,7 +105,7 @@ int main( int argc, char *argv[] )
         goto exit;
     }
 
-    ret = mbedtls_ecdh_make_params( &ctx_cli, &olen, cli_to_srv,
+    ret = mbedtls_ecdh_make_params( &ctx_cli, &cli_olen, cli_to_srv,
                                     sizeof( cli_to_srv ),
                                     mbedtls_ctr_drbg_random, &ctr_drbg );
     if( ret != 0 )
@@ -131,7 +132,7 @@ int main( int argc, char *argv[] )
         goto exit;
     }
 
-    ret = mbedtls_ecdh_make_public( &ctx_srv, &olen, srv_to_cli,
+    ret = mbedtls_ecdh_make_public( &ctx_srv, &srv_olen, srv_to_cli,
                                     sizeof( srv_to_cli ),
                                     mbedtls_ctr_drbg_random, &ctr_drbg );
     if( ret != 0 )
@@ -166,7 +167,7 @@ int main( int argc, char *argv[] )
     mbedtls_printf( "  . Calculate secrets..." );
     fflush( stdout );
 
-    ret = mbedtls_ecdh_calc_secret( &ctx_cli, &olen, secret_cli,
+    ret = mbedtls_ecdh_calc_secret( &ctx_cli, &cli_olen, secret_cli,
                                     sizeof( secret_cli ),
                                     mbedtls_ctr_drbg_random, &ctr_drbg );
     if( ret != 0 )
@@ -176,9 +177,7 @@ int main( int argc, char *argv[] )
         goto exit;
     }
 
-    size_t secret_cli_olen = olen;
-
-    ret = mbedtls_ecdh_calc_secret( &ctx_srv, &olen, secret_srv,
+    ret = mbedtls_ecdh_calc_secret( &ctx_srv, &srv_olen, secret_srv,
                                     sizeof( secret_srv ),
                                     mbedtls_ctr_drbg_random, &ctr_drbg );
     if( ret != 0 )
@@ -188,8 +187,6 @@ int main( int argc, char *argv[] )
         goto exit;
     }
 
-    size_t secret_srv_olen = olen;
-
     mbedtls_printf( " ok\n" );
 
     /*
@@ -198,8 +195,8 @@ int main( int argc, char *argv[] )
     mbedtls_printf( "  . Check if both calculated secrets are equal..." );
     fflush( stdout );
 
-    ret = memcmp( secret_srv, secret_cli, sizeof( secret_srv_olen ) );
-    if( ret != 0 || ( secret_cli_olen != secret_srv_olen ) )
+    ret = memcmp( secret_srv, secret_cli, sizeof( srv_olen ) );
+    if( ret != 0 || ( cli_olen != srv_olen ) )
     {
         mbedtls_printf( " failed\n  ! Shared secrets not equal.\n" );
         goto exit;

--- a/programs/pkey/ecdh_curve25519.c
+++ b/programs/pkey/ecdh_curve25519.c
@@ -61,7 +61,8 @@ int main( int argc, char *argv[] )
     const char pers[] = "ecdh";
 
     size_t olen;
-    unsigned char secret_cli[32], secret_srv[32];
+    unsigned char secret_cli[32] = { 0 };
+    unsigned char secret_srv[32] = { 0 };
     const unsigned char *p_cli_to_srv = cli_to_srv;
 
     ((void) argc);
@@ -175,6 +176,8 @@ int main( int argc, char *argv[] )
         goto exit;
     }
 
+    size_t secret_cli_olen = olen;
+
     ret = mbedtls_ecdh_calc_secret( &ctx_srv, &olen, secret_srv,
                                     sizeof( secret_srv ),
                                     mbedtls_ctr_drbg_random, &ctr_drbg );
@@ -185,6 +188,8 @@ int main( int argc, char *argv[] )
         goto exit;
     }
 
+    size_t secret_srv_olen = olen;
+
     mbedtls_printf( " ok\n" );
 
     /*
@@ -193,8 +198,8 @@ int main( int argc, char *argv[] )
     mbedtls_printf( "  . Check if both calculated secrets are equal..." );
     fflush( stdout );
 
-    ret = memcmp( secret_srv, secret_cli, sizeof( secret_srv ) );
-    if( ret != 0 )
+    ret = memcmp( secret_srv, secret_cli, sizeof( secret_srv_olen ) );
+    if( ret != 0 || ( secret_cli_olen != secret_srv_olen ) )
     {
         mbedtls_printf( " failed\n  ! Shared secrets not equal.\n" );
         goto exit;

--- a/programs/pkey/ecdh_curve25519.c
+++ b/programs/pkey/ecdh_curve25519.c
@@ -195,7 +195,7 @@ int main( int argc, char *argv[] )
     mbedtls_printf( "  . Check if both calculated secrets are equal..." );
     fflush( stdout );
 
-    ret = memcmp( secret_srv, secret_cli, sizeof( srv_olen ) );
+    ret = memcmp( secret_srv, secret_cli, srv_olen );
     if( ret != 0 || ( cli_olen != srv_olen ) )
     {
         mbedtls_printf( " failed\n  ! Shared secrets not equal.\n" );


### PR DESCRIPTION
Resolves #4901 and #3191

2.28 Backport available: #5848 

## Description
This PR rewrites the ecdh_curve25519 using the high-level ECDH API. This is both to fix the issue mentioned in the above issue and also to demonstrate best practices when using the ECDH API.


## Status
*READY*