### PR TITLE
Feature psec-3207 move TLS13 hashing and hmac to psa

### DIFF
--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -923,7 +923,7 @@ static int ssl_tls13_write_certificate_verify_body( mbedtls_ssl_context *ssl,
     unsigned char verify_hash[ MBEDTLS_MD_MAX_SIZE ];
     size_t verify_hash_len;
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
-    
+
     *out_len = 0;
 
     own_key = mbedtls_ssl_own_key( ssl );
@@ -984,7 +984,6 @@ static int ssl_tls13_write_certificate_verify_body( mbedtls_ssl_context *ssl,
 
     /* Hash verify buffer with indicated hash function */
     psa_algorithm = mbedtls_psa_translate_md( md_alg );
-
     status = psa_hash_compute( psa_algorithm,
                                verify_buffer,
                                verify_buffer_len,

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -253,7 +253,6 @@ static int ssl_tls13_parse_certificate_verify( mbedtls_ssl_context *ssl,
     }
 
     MBEDTLS_SSL_DEBUG_BUF( 3, "verify hash", verify_hash, verify_hash_len );
-
 #if defined(MBEDTLS_X509_RSASSA_PSS_SUPPORT)
     if( sig_alg == MBEDTLS_PK_RSASSA_PSS )
     {
@@ -990,7 +989,7 @@ static int ssl_tls13_write_certificate_verify_body( mbedtls_ssl_context *ssl,
                           verify_buffer_len,
                           verify_hash,sizeof( verify_hash ),
                           &verify_hash_len ) != PSA_SUCCESS )
-        return( ret );
+        return( psa_ssl_status_to_mbedtls( status ) );
 
     MBEDTLS_SSL_DEBUG_BUF( 3, "verify hash", verify_hash, verify_hash_len );
 

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -922,7 +922,8 @@ static int ssl_tls13_write_certificate_verify_body( mbedtls_ssl_context *ssl,
     size_t signature_len = 0;
     unsigned char verify_hash[ MBEDTLS_MD_MAX_SIZE ];
     size_t verify_hash_len;
-
+    psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
+    
     *out_len = 0;
 
     own_key = mbedtls_ssl_own_key( ssl );
@@ -984,11 +985,12 @@ static int ssl_tls13_write_certificate_verify_body( mbedtls_ssl_context *ssl,
     /* Hash verify buffer with indicated hash function */
     psa_algorithm = mbedtls_psa_translate_md( md_alg );
 
-    if( psa_hash_compute( psa_algorithm,
-                          verify_buffer,
-                          verify_buffer_len,
-                          verify_hash,sizeof( verify_hash ),
-                          &verify_hash_len ) != PSA_SUCCESS )
+    status = psa_hash_compute( psa_algorithm,
+                               verify_buffer,
+                               verify_buffer_len,
+                               verify_hash,sizeof( verify_hash ),
+                               &verify_hash_len );
+    if( status != PSA_SUCCESS )
         return( psa_ssl_status_to_mbedtls( status ) );
 
     MBEDTLS_SSL_DEBUG_BUF( 3, "verify hash", verify_hash, verify_hash_len );


### PR DESCRIPTION
## Description
There are a number of places in the TLS 1.3 handshake where hashes/HMACs are computed. This should be done using psa_hash_/psa_mac_ functions rather than mbedtls_md_ or mbedtls_shaNNN functions. (Regardless of the value of MBEDTLS_USE_PSA_CRYPTO, which only affects 1.2, as 1.3 should always use PSA.) this PR addresses:

- In `ssl_tls13_parse_certificate_verify()`: use `psa_hash_compute()` instead of `mbedtls_shaNNN()`.
- In `mbedtls_ssl_tls13_derive_secret()`: use `psa_mac_compute()` instead of `mbedtls_md_hmac()`.

## Status
**READY**

## Requires Backporting
NO  

Fixes #5326