### PR TITLE
Make psa_raw_key_agreement return BUFFER_TOO_SMALL

### DIFF
--- a/ChangeLog.d/psa_raw_key_agreement-buffer_too_small.txt
+++ b/ChangeLog.d/psa_raw_key_agreement-buffer_too_small.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * psa_raw_key_agreement() now returns PSA_ERROR_BUFFER_TOO_SMALL when
+     applicable. Fixes #5735.

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -5640,6 +5640,22 @@ psa_status_t psa_raw_key_agreement( psa_algorithm_t alg,
     if( status != PSA_SUCCESS )
         goto exit;
 
+    /* PSA_RAW_KEY_AGREEMENT_OUTPUT_SIZE() is in general an upper bound
+     * for the output size. The PSA specification only guarantees that this
+     * function works if output_size >= PSA_RAW_KEY_AGREEMENT_OUTPUT_SIZE(...),
+     * but it might be nice to allow smaller buffers if the output fits.
+     * At the time of writing this comment, with only ECDH implemented,
+     * PSA_RAW_KEY_AGREEMENT_OUTPUT_SIZE() is exact so the point is moot.
+     * If FFDH is implemented, PSA_RAW_KEY_AGREEMENT_OUTPUT_SIZE() can easily
+     * be exact for it as well. */
+    size_t expected_length =
+        PSA_RAW_KEY_AGREEMENT_OUTPUT_SIZE( slot->attr.type, slot->attr.bits );
+    if( output_size < expected_length )
+    {
+        status = PSA_ERROR_BUFFER_TOO_SMALL;
+        goto exit;
+    }
+
     status = psa_key_agreement_raw_internal( alg, slot,
                                              peer_key, peer_key_length,
                                              output, output_size,

--- a/tests/include/test/helpers.h
+++ b/tests/include/test/helpers.h
@@ -155,6 +155,48 @@ int mbedtls_test_equal( const char *test, int line_no, const char* filename,
                         unsigned long long value1, unsigned long long value2 );
 
 /**
+ * \brief           Record the current test case as a failure based
+ *                  on comparing two unsigned integers.
+ *
+ *                  This function is usually called via the macro
+ *                  #TEST_LE_U.
+ *
+ * \param test      Description of the failure or assertion that failed. This
+ *                  MUST be a string literal. This normally has the form
+ *                  "EXPR1 <= EXPR2" where EXPR1 has the value \p value1
+ *                  and EXPR2 has the value \p value2.
+ * \param line_no   Line number where the failure originated.
+ * \param filename  Filename where the failure originated.
+ * \param value1    The first value to compare.
+ * \param value2    The second value to compare.
+ *
+ * \return          \c 1 if \p value1 <= \p value2, otherwise \c 0.
+ */
+int mbedtls_test_le_u( const char *test, int line_no, const char* filename,
+                       unsigned long long value1, unsigned long long value2 );
+
+/**
+ * \brief           Record the current test case as a failure based
+ *                  on comparing two signed integers.
+ *
+ *                  This function is usually called via the macro
+ *                  #TEST_LE_S.
+ *
+ * \param test      Description of the failure or assertion that failed. This
+ *                  MUST be a string literal. This normally has the form
+ *                  "EXPR1 <= EXPR2" where EXPR1 has the value \p value1
+ *                  and EXPR2 has the value \p value2.
+ * \param line_no   Line number where the failure originated.
+ * \param filename  Filename where the failure originated.
+ * \param value1    The first value to compare.
+ * \param value2    The second value to compare.
+ *
+ * \return          \c 1 if \p value1 <= \p value2, otherwise \c 0.
+ */
+int mbedtls_test_le_s( const char *test, int line_no, const char* filename,
+                       long long value1, long long value2 );
+
+/**
  * \brief          This function decodes the hexadecimal representation of
  *                 data.
  *

--- a/tests/include/test/macros.h
+++ b/tests/include/test/macros.h
@@ -89,6 +89,32 @@
             goto exit;                                                  \
     } while( 0 )
 
+/** Evaluate two unsigned integer expressions and fail the test case
+ * if they are not in increasing order (left <= right).
+ *
+ * \param expr1     An integral-typed expression to evaluate.
+ * \param expr2     Another integral-typed expression to evaluate.
+ */
+#define TEST_LE_U( expr1, expr2 )                                       \
+    do {                                                                \
+        if( ! mbedtls_test_le_u( #expr1 " <= " #expr2, __LINE__, __FILE__, \
+                                 expr1, expr2 ) )                      \
+            goto exit;                                                  \
+    } while( 0 )
+
+/** Evaluate two signed integer expressions and fail the test case
+ * if they are not in increasing order (left <= right).
+ *
+ * \param expr1     An integral-typed expression to evaluate.
+ * \param expr2     Another integral-typed expression to evaluate.
+ */
+#define TEST_LE_S( expr1, expr2 )                                       \
+    do {                                                                \
+        if( ! mbedtls_test_le_s( #expr1 " <= " #expr2, __LINE__, __FILE__, \
+                                 expr1, expr2 ) )                      \
+            goto exit;                                                  \
+    } while( 0 )
+
 /** Allocate memory dynamically and fail the test case if this fails.
  * The allocated memory will be filled with zeros.
  *

--- a/tests/src/helpers.c
+++ b/tests/src/helpers.c
@@ -122,6 +122,52 @@ int mbedtls_test_equal( const char *test, int line_no, const char* filename,
     return( 0 );
 }
 
+int mbedtls_test_le_u( const char *test, int line_no, const char* filename,
+                       unsigned long long value1, unsigned long long value2 )
+{
+    if( value1 <= value2 )
+        return( 1 );
+    if( mbedtls_test_info.result == MBEDTLS_TEST_RESULT_FAILED )
+    {
+        /* We've already recorded the test as having failed. Don't
+         * overwrite any previous information about the failure. */
+        return( 0 );
+    }
+    mbedtls_test_fail( test, line_no, filename );
+    (void) mbedtls_snprintf( mbedtls_test_info.line1,
+                             sizeof( mbedtls_test_info.line1 ),
+                             "lhs = 0x%016llx = %llu",
+                             value1, value1 );
+    (void) mbedtls_snprintf( mbedtls_test_info.line2,
+                             sizeof( mbedtls_test_info.line2 ),
+                             "rhs = 0x%016llx = %llu",
+                             value2, value2 );
+    return( 0 );
+}
+
+int mbedtls_test_le_s( const char *test, int line_no, const char* filename,
+                       long long value1, long long value2 )
+{
+    if( value1 <= value2 )
+        return( 1 );
+    if( mbedtls_test_info.result == MBEDTLS_TEST_RESULT_FAILED )
+    {
+        /* We've already recorded the test as having failed. Don't
+         * overwrite any previous information about the failure. */
+        return( 0 );
+    }
+    mbedtls_test_fail( test, line_no, filename );
+    (void) mbedtls_snprintf( mbedtls_test_info.line1,
+                             sizeof( mbedtls_test_info.line1 ),
+                             "lhs = 0x%016llx = %lld",
+                             (unsigned long long) value1, value1 );
+    (void) mbedtls_snprintf( mbedtls_test_info.line2,
+                             sizeof( mbedtls_test_info.line2 ),
+                             "rhs = 0x%016llx = %lld",
+                             (unsigned long long) value2, value2 );
+    return( 0 );
+}
+
 int mbedtls_test_unhexify( unsigned char *obuf,
                            size_t obufmax,
                            const char *ibuf,

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -7430,7 +7430,7 @@ void raw_key_agreement( int alg_arg,
                     expected_output->x, expected_output->len );
     TEST_ASSERT( output_length <=
                  PSA_RAW_KEY_AGREEMENT_OUTPUT_SIZE( our_key_type, key_bits ) );
-    TEST_ASSERT( output_length <=
+    TEST_ASSERT( PSA_RAW_KEY_AGREEMENT_OUTPUT_SIZE( our_key_type, key_bits ) <=
                  PSA_RAW_KEY_AGREEMENT_OUTPUT_MAX_SIZE );
     mbedtls_free( output );
     output = NULL;

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -396,12 +396,12 @@ static int aead_multipart_internal_func( int key_type_arg, data_t *key_data,
     if( is_encrypt )
     {
         final_output_size = PSA_AEAD_FINISH_OUTPUT_SIZE( key_type, alg );
-        TEST_ASSERT( final_output_size <= PSA_AEAD_FINISH_OUTPUT_MAX_SIZE );
+        TEST_LE_U( final_output_size, PSA_AEAD_FINISH_OUTPUT_MAX_SIZE );
     }
     else
     {
         final_output_size = PSA_AEAD_VERIFY_OUTPUT_SIZE( key_type, alg );
-        TEST_ASSERT( final_output_size <= PSA_AEAD_VERIFY_OUTPUT_MAX_SIZE );
+        TEST_LE_U( final_output_size, PSA_AEAD_VERIFY_OUTPUT_MAX_SIZE );
     }
 
     ASSERT_ALLOC( final_data, final_output_size );
@@ -557,18 +557,18 @@ static int aead_multipart_internal_func( int key_type_arg, data_t *key_data,
         output_length += tag_length;
 
         TEST_EQUAL( output_length,
-                      PSA_AEAD_ENCRYPT_OUTPUT_SIZE( key_type, alg,
-                                                    input_data->len ) );
-        TEST_ASSERT( output_length <=
-                      PSA_AEAD_ENCRYPT_OUTPUT_MAX_SIZE( input_data->len ) );
+                    PSA_AEAD_ENCRYPT_OUTPUT_SIZE( key_type, alg,
+                                                  input_data->len ) );
+        TEST_LE_U( output_length,
+                   PSA_AEAD_ENCRYPT_OUTPUT_MAX_SIZE( input_data->len ) );
     }
     else
     {
        TEST_EQUAL( output_length,
                       PSA_AEAD_DECRYPT_OUTPUT_SIZE( key_type, alg,
                                                     input_data->len ) );
-       TEST_ASSERT( output_length <=
-                      PSA_AEAD_DECRYPT_OUTPUT_MAX_SIZE( input_data->len ) );
+       TEST_LE_U( output_length,
+                  PSA_AEAD_DECRYPT_OUTPUT_MAX_SIZE( input_data->len ) );
     }
 
 
@@ -721,7 +721,7 @@ void static_checks( )
     /* Check that the length for a truncated MAC always fits in the algorithm
      * encoding. The shifted mask is the maximum truncated value. The
      * untruncated algorithm may be one byte larger. */
-    TEST_ASSERT( PSA_MAC_MAX_SIZE <= 1 + max_truncated_mac_size );
+    TEST_LE_U( PSA_MAC_MAX_SIZE, 1 + max_truncated_mac_size );
 }
 /* END_CASE */
 
@@ -965,7 +965,7 @@ void import_export( data_t *data,
      * and export_size. On errors, the exported length must be 0. */
     TEST_ASSERT( exported_length != INVALID_EXPORT_LENGTH );
     TEST_ASSERT( status == PSA_SUCCESS || exported_length == 0 );
-    TEST_ASSERT( exported_length <= export_size );
+    TEST_LE_U( exported_length, export_size );
 
     TEST_ASSERT( mem_is_char( exported + exported_length, 0,
                               export_size - exported_length ) );
@@ -1000,10 +1000,10 @@ void import_export( data_t *data,
                          reexported, reexported_length );
         PSA_ASSERT( psa_destroy_key( key2 ) );
     }
-    TEST_ASSERT( exported_length <=
+    TEST_LE_U( exported_length,
              PSA_EXPORT_KEY_OUTPUT_SIZE( type,
                                          psa_get_key_bits( &got_attributes ) ) );
-    TEST_ASSERT( exported_length <= PSA_EXPORT_KEY_PAIR_MAX_SIZE );
+    TEST_LE_U( exported_length, PSA_EXPORT_KEY_PAIR_MAX_SIZE );
 
 destroy:
     /* Destroy the key */
@@ -1065,12 +1065,12 @@ void import_export_public_key( data_t *data,
         size_t bits;
         PSA_ASSERT( psa_get_key_attributes( key, &attributes ) );
         bits = psa_get_key_bits( &attributes );
-        TEST_ASSERT( expected_public_key->len <=
-                     PSA_EXPORT_KEY_OUTPUT_SIZE( public_type, bits ) );
-        TEST_ASSERT( expected_public_key->len <=
-                     PSA_EXPORT_PUBLIC_KEY_OUTPUT_SIZE( public_type, bits ) );
-        TEST_ASSERT( expected_public_key->len <=
-                     PSA_EXPORT_PUBLIC_KEY_MAX_SIZE );
+        TEST_LE_U( expected_public_key->len,
+                   PSA_EXPORT_KEY_OUTPUT_SIZE( public_type, bits ) );
+        TEST_LE_U( expected_public_key->len,
+                   PSA_EXPORT_PUBLIC_KEY_OUTPUT_SIZE( public_type, bits ) );
+        TEST_LE_U( expected_public_key->len,
+                   PSA_EXPORT_PUBLIC_KEY_MAX_SIZE );
         ASSERT_COMPARE( expected_public_key->x, expected_public_key->len,
                         exported, exported_length );
     }
@@ -1441,8 +1441,8 @@ void aead_key_policy( int policy_usage_arg,
     size_t tag_length = tag_length_arg;
     size_t output_length;
 
-    TEST_ASSERT( nonce_length <= sizeof( nonce ) );
-    TEST_ASSERT( tag_length <= sizeof( tag ) );
+    TEST_LE_U( nonce_length, sizeof( nonce ) );
+    TEST_LE_U( tag_length, sizeof( tag ) );
 
     PSA_ASSERT( psa_crypto_init( ) );
 
@@ -2077,7 +2077,7 @@ void hash_compute_fail( int alg_arg, data_t *input,
     status = psa_hash_compute( alg, input->x, input->len,
                                output, output_size, &output_length );
     TEST_EQUAL( status, expected_status );
-    TEST_ASSERT( output_length <= output_size );
+    TEST_LE_U( output_length, output_size );
 
     /* Hash Compute, multi-part */
     status = psa_hash_setup( &operation, alg );
@@ -2089,7 +2089,7 @@ void hash_compute_fail( int alg_arg, data_t *input,
             status = psa_hash_finish( &operation, output, output_size,
                                       &output_length );
             if( status == PSA_SUCCESS )
-                TEST_ASSERT( output_length <= output_size );
+                TEST_LE_U( output_length, output_size );
             else
                 TEST_EQUAL( status, expected_status );
         }
@@ -2769,7 +2769,7 @@ void mac_sign( int key_type_arg,
         expected_mac->len + 1,
     };
 
-    TEST_ASSERT( mac_buffer_size <= PSA_MAC_MAX_SIZE );
+    TEST_LE_U( mac_buffer_size, PSA_MAC_MAX_SIZE );
     /* We expect PSA_MAC_LENGTH to be exact. */
     TEST_ASSERT( expected_mac->len == mac_buffer_size );
 
@@ -2847,7 +2847,7 @@ void mac_verify( int key_type_arg,
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     uint8_t *perturbed_mac = NULL;
 
-    TEST_ASSERT( expected_mac->len <= PSA_MAC_MAX_SIZE );
+    TEST_LE_U( expected_mac->len, PSA_MAC_MAX_SIZE );
 
     PSA_ASSERT( psa_crypto_init( ) );
 
@@ -3344,10 +3344,10 @@ void cipher_encrypt_alg_without_iv( int alg_arg,
     /* Encrypt, one-shot */
     PSA_ASSERT( psa_cipher_encrypt( key, alg, input->x, input->len, output,
                                     output_buffer_size, &output_length ) );
-    TEST_ASSERT( output_length <=
-                 PSA_CIPHER_ENCRYPT_OUTPUT_SIZE( key_type, alg, input->len ) );
-    TEST_ASSERT( output_length <=
-                 PSA_CIPHER_ENCRYPT_OUTPUT_MAX_SIZE( input->len ) );
+    TEST_LE_U( output_length,
+               PSA_CIPHER_ENCRYPT_OUTPUT_SIZE( key_type, alg, input->len ) );
+    TEST_LE_U( output_length,
+               PSA_CIPHER_ENCRYPT_OUTPUT_MAX_SIZE( input->len ) );
 
     ASSERT_COMPARE( expected_output->x, expected_output->len,
                     output, output_length );
@@ -3359,10 +3359,10 @@ void cipher_encrypt_alg_without_iv( int alg_arg,
     PSA_ASSERT( psa_cipher_update( &operation, input->x, input->len,
                                    output, output_buffer_size,
                                    &output_length) );
-    TEST_ASSERT( output_length <=
-                 PSA_CIPHER_ENCRYPT_OUTPUT_SIZE( key_type, alg, input->len ) );
-    TEST_ASSERT( output_length <=
-                 PSA_CIPHER_ENCRYPT_OUTPUT_MAX_SIZE( input->len ) );
+    TEST_LE_U( output_length,
+               PSA_CIPHER_ENCRYPT_OUTPUT_SIZE( key_type, alg, input->len ) );
+    TEST_LE_U( output_length,
+               PSA_CIPHER_ENCRYPT_OUTPUT_MAX_SIZE( input->len ) );
 
     ASSERT_COMPARE( expected_output->x, expected_output->len,
                     output, output_length );
@@ -3454,10 +3454,10 @@ void cipher_encrypt_validation( int alg_arg,
        the output is not possible. Validating with multipart encryption. */
     PSA_ASSERT( psa_cipher_encrypt( key, alg, input->x, input->len, output1,
                                     output1_buffer_size, &output1_length ) );
-    TEST_ASSERT( output1_length <=
-                 PSA_CIPHER_ENCRYPT_OUTPUT_SIZE( key_type, alg, input->len ) );
-    TEST_ASSERT( output1_length <=
-                 PSA_CIPHER_ENCRYPT_OUTPUT_MAX_SIZE( input->len ) );
+    TEST_LE_U( output1_length,
+               PSA_CIPHER_ENCRYPT_OUTPUT_SIZE( key_type, alg, input->len ) );
+    TEST_LE_U( output1_length,
+               PSA_CIPHER_ENCRYPT_OUTPUT_MAX_SIZE( input->len ) );
 
     PSA_ASSERT( psa_cipher_encrypt_setup( &operation, key, alg ) );
     PSA_ASSERT( psa_cipher_set_iv( &operation, output1, iv_size ) );
@@ -3466,20 +3466,20 @@ void cipher_encrypt_validation( int alg_arg,
                                    input->x, input->len,
                                    output2, output2_buffer_size,
                                    &function_output_length ) );
-    TEST_ASSERT( function_output_length <=
-                 PSA_CIPHER_UPDATE_OUTPUT_SIZE( key_type, alg, input->len ) );
-    TEST_ASSERT( function_output_length <=
-                 PSA_CIPHER_UPDATE_OUTPUT_MAX_SIZE( input->len ) );
+    TEST_LE_U( function_output_length,
+               PSA_CIPHER_UPDATE_OUTPUT_SIZE( key_type, alg, input->len ) );
+    TEST_LE_U( function_output_length,
+               PSA_CIPHER_UPDATE_OUTPUT_MAX_SIZE( input->len ) );
     output2_length += function_output_length;
 
     PSA_ASSERT( psa_cipher_finish( &operation,
                                    output2 + output2_length,
                                    output2_buffer_size - output2_length,
                                    &function_output_length ) );
-    TEST_ASSERT( function_output_length <=
-                 PSA_CIPHER_FINISH_OUTPUT_SIZE( key_type, alg ) );
-    TEST_ASSERT( function_output_length <=
-                 PSA_CIPHER_FINISH_OUTPUT_MAX_SIZE );
+    TEST_LE_U( function_output_length,
+               PSA_CIPHER_FINISH_OUTPUT_SIZE( key_type, alg ) );
+    TEST_LE_U( function_output_length,
+               PSA_CIPHER_FINISH_OUTPUT_MAX_SIZE );
     output2_length += function_output_length;
 
     PSA_ASSERT( psa_cipher_abort( &operation ) );
@@ -3539,15 +3539,15 @@ void cipher_encrypt_multipart( int alg_arg, int key_type_arg,
                          PSA_CIPHER_FINISH_OUTPUT_SIZE( key_type, alg );
     ASSERT_ALLOC( output, output_buffer_size );
 
-    TEST_ASSERT( first_part_size <= input->len );
+    TEST_LE_U( first_part_size, input->len );
     PSA_ASSERT( psa_cipher_update( &operation, input->x, first_part_size,
                                    output, output_buffer_size,
                                    &function_output_length ) );
     TEST_ASSERT( function_output_length == output1_length );
-    TEST_ASSERT( function_output_length <=
-                 PSA_CIPHER_UPDATE_OUTPUT_SIZE( key_type, alg, first_part_size ) );
-    TEST_ASSERT( function_output_length <=
-                 PSA_CIPHER_UPDATE_OUTPUT_MAX_SIZE( first_part_size) );
+    TEST_LE_U( function_output_length,
+               PSA_CIPHER_UPDATE_OUTPUT_SIZE( key_type, alg, first_part_size ) );
+    TEST_LE_U( function_output_length,
+               PSA_CIPHER_UPDATE_OUTPUT_MAX_SIZE( first_part_size) );
     total_output_length += function_output_length;
 
     if( first_part_size < input->len )
@@ -3560,12 +3560,12 @@ void cipher_encrypt_multipart( int alg_arg, int key_type_arg,
                                        output_buffer_size - total_output_length,
                                        &function_output_length ) );
         TEST_ASSERT( function_output_length == output2_length );
-        TEST_ASSERT( function_output_length <=
-                     PSA_CIPHER_UPDATE_OUTPUT_SIZE( key_type,
-                                                    alg,
-                                                    input->len - first_part_size ) );
-        TEST_ASSERT( function_output_length <=
-                     PSA_CIPHER_UPDATE_OUTPUT_MAX_SIZE( input->len ) );
+        TEST_LE_U( function_output_length,
+                   PSA_CIPHER_UPDATE_OUTPUT_SIZE( key_type,
+                                                  alg,
+                                                  input->len - first_part_size ) );
+        TEST_LE_U( function_output_length,
+                   PSA_CIPHER_UPDATE_OUTPUT_MAX_SIZE( input->len ) );
         total_output_length += function_output_length;
     }
 
@@ -3574,10 +3574,10 @@ void cipher_encrypt_multipart( int alg_arg, int key_type_arg,
                                   output + total_output_length ),
                                 output_buffer_size - total_output_length,
                                 &function_output_length );
-    TEST_ASSERT( function_output_length <=
-                 PSA_CIPHER_FINISH_OUTPUT_SIZE( key_type, alg ) );
-    TEST_ASSERT( function_output_length <=
-                 PSA_CIPHER_FINISH_OUTPUT_MAX_SIZE );
+    TEST_LE_U( function_output_length,
+               PSA_CIPHER_FINISH_OUTPUT_SIZE( key_type, alg ) );
+    TEST_LE_U( function_output_length,
+               PSA_CIPHER_FINISH_OUTPUT_MAX_SIZE );
     total_output_length += function_output_length;
     TEST_EQUAL( status, expected_status );
 
@@ -3641,16 +3641,16 @@ void cipher_decrypt_multipart( int alg_arg, int key_type_arg,
                          PSA_CIPHER_FINISH_OUTPUT_SIZE( key_type, alg );
     ASSERT_ALLOC( output, output_buffer_size );
 
-    TEST_ASSERT( first_part_size <= input->len );
+    TEST_LE_U( first_part_size, input->len );
     PSA_ASSERT( psa_cipher_update( &operation,
                                    input->x, first_part_size,
                                    output, output_buffer_size,
                                    &function_output_length ) );
     TEST_ASSERT( function_output_length == output1_length );
-    TEST_ASSERT( function_output_length <=
-                 PSA_CIPHER_UPDATE_OUTPUT_SIZE( key_type, alg, first_part_size ) );
-    TEST_ASSERT( function_output_length <=
-                 PSA_CIPHER_UPDATE_OUTPUT_MAX_SIZE( first_part_size ) );
+    TEST_LE_U( function_output_length,
+               PSA_CIPHER_UPDATE_OUTPUT_SIZE( key_type, alg, first_part_size ) );
+    TEST_LE_U( function_output_length,
+               PSA_CIPHER_UPDATE_OUTPUT_MAX_SIZE( first_part_size ) );
     total_output_length += function_output_length;
 
     if( first_part_size < input->len )
@@ -3663,12 +3663,12 @@ void cipher_decrypt_multipart( int alg_arg, int key_type_arg,
                                        output_buffer_size - total_output_length,
                                        &function_output_length ) );
         TEST_ASSERT( function_output_length == output2_length );
-        TEST_ASSERT( function_output_length <=
-                     PSA_CIPHER_UPDATE_OUTPUT_SIZE( key_type,
-                                                    alg,
-                                                    input->len - first_part_size ) );
-        TEST_ASSERT( function_output_length <=
-                     PSA_CIPHER_UPDATE_OUTPUT_MAX_SIZE( input->len ) );
+        TEST_LE_U( function_output_length,
+                   PSA_CIPHER_UPDATE_OUTPUT_SIZE( key_type,
+                                                  alg,
+                                                  input->len - first_part_size ) );
+        TEST_LE_U( function_output_length,
+                   PSA_CIPHER_UPDATE_OUTPUT_MAX_SIZE( input->len ) );
         total_output_length += function_output_length;
     }
 
@@ -3677,10 +3677,10 @@ void cipher_decrypt_multipart( int alg_arg, int key_type_arg,
                                   output + total_output_length ),
                                 output_buffer_size - total_output_length,
                                 &function_output_length );
-    TEST_ASSERT( function_output_length <=
-                 PSA_CIPHER_FINISH_OUTPUT_SIZE( key_type, alg ) );
-    TEST_ASSERT( function_output_length <=
-                 PSA_CIPHER_FINISH_OUTPUT_MAX_SIZE );
+    TEST_LE_U( function_output_length,
+               PSA_CIPHER_FINISH_OUTPUT_SIZE( key_type, alg ) );
+    TEST_LE_U( function_output_length,
+               PSA_CIPHER_FINISH_OUTPUT_MAX_SIZE );
     total_output_length += function_output_length;
     TEST_EQUAL( status, expected_status );
 
@@ -3852,10 +3852,10 @@ void cipher_decrypt( int alg_arg,
 
     PSA_ASSERT( psa_cipher_decrypt( key, alg, input, input_buffer_size, output,
                                     output_buffer_size, &output_length ) );
-    TEST_ASSERT( output_length <=
-                 PSA_CIPHER_DECRYPT_OUTPUT_SIZE( key_type, alg, input_buffer_size ) );
-    TEST_ASSERT( output_length <=
-                 PSA_CIPHER_DECRYPT_OUTPUT_MAX_SIZE( input_buffer_size ) );
+    TEST_LE_U( output_length,
+               PSA_CIPHER_DECRYPT_OUTPUT_SIZE( key_type, alg, input_buffer_size ) );
+    TEST_LE_U( output_length,
+               PSA_CIPHER_DECRYPT_OUTPUT_MAX_SIZE( input_buffer_size ) );
 
     ASSERT_COMPARE( expected_output->x, expected_output->len,
                     output, output_length );
@@ -3898,10 +3898,10 @@ void cipher_verify_output( int alg_arg,
     PSA_ASSERT( psa_cipher_encrypt( key, alg, input->x, input->len,
                                     output1, output1_size,
                                     &output1_length ) );
-    TEST_ASSERT( output1_length <=
-                 PSA_CIPHER_ENCRYPT_OUTPUT_SIZE( key_type, alg, input->len ) );
-    TEST_ASSERT( output1_length <=
-                 PSA_CIPHER_ENCRYPT_OUTPUT_MAX_SIZE( input->len ) );
+    TEST_LE_U( output1_length,
+               PSA_CIPHER_ENCRYPT_OUTPUT_SIZE( key_type, alg, input->len ) );
+    TEST_LE_U( output1_length,
+               PSA_CIPHER_ENCRYPT_OUTPUT_MAX_SIZE( input->len ) );
 
     output2_size = output1_length;
     ASSERT_ALLOC( output2, output2_size );
@@ -3909,10 +3909,10 @@ void cipher_verify_output( int alg_arg,
     PSA_ASSERT( psa_cipher_decrypt( key, alg, output1, output1_length,
                                     output2, output2_size,
                                     &output2_length ) );
-    TEST_ASSERT( output2_length <=
-                 PSA_CIPHER_DECRYPT_OUTPUT_SIZE( key_type, alg, output1_length ) );
-    TEST_ASSERT( output2_length <=
-                 PSA_CIPHER_DECRYPT_OUTPUT_MAX_SIZE( output1_length ) );
+    TEST_LE_U( output2_length,
+               PSA_CIPHER_DECRYPT_OUTPUT_SIZE( key_type, alg, output1_length ) );
+    TEST_LE_U( output2_length,
+               PSA_CIPHER_DECRYPT_OUTPUT_MAX_SIZE( output1_length ) );
 
     ASSERT_COMPARE( input->x, input->len, output2, output2_length );
 
@@ -3969,19 +3969,19 @@ void cipher_verify_output_multipart( int alg_arg,
     }
 
     output1_buffer_size = PSA_CIPHER_ENCRYPT_OUTPUT_SIZE( key_type, alg, input->len );
-    TEST_ASSERT( output1_buffer_size <=
-                 PSA_CIPHER_ENCRYPT_OUTPUT_MAX_SIZE( input->len ) );
+    TEST_LE_U( output1_buffer_size,
+               PSA_CIPHER_ENCRYPT_OUTPUT_MAX_SIZE( input->len ) );
     ASSERT_ALLOC( output1, output1_buffer_size );
 
-    TEST_ASSERT( first_part_size <= input->len );
+    TEST_LE_U( first_part_size, input->len );
 
     PSA_ASSERT( psa_cipher_update( &operation1, input->x, first_part_size,
                                    output1, output1_buffer_size,
                                    &function_output_length ) );
-    TEST_ASSERT( function_output_length <=
-                 PSA_CIPHER_UPDATE_OUTPUT_SIZE( key_type, alg, first_part_size ) );
-    TEST_ASSERT( function_output_length <=
-                 PSA_CIPHER_UPDATE_OUTPUT_MAX_SIZE( first_part_size ) );
+    TEST_LE_U( function_output_length,
+               PSA_CIPHER_UPDATE_OUTPUT_SIZE( key_type, alg, first_part_size ) );
+    TEST_LE_U( function_output_length,
+               PSA_CIPHER_UPDATE_OUTPUT_MAX_SIZE( first_part_size ) );
     output1_length += function_output_length;
 
     PSA_ASSERT( psa_cipher_update( &operation1,
@@ -3989,31 +3989,31 @@ void cipher_verify_output_multipart( int alg_arg,
                                    input->len - first_part_size,
                                    output1, output1_buffer_size,
                                    &function_output_length ) );
-    TEST_ASSERT( function_output_length <=
-                 PSA_CIPHER_UPDATE_OUTPUT_SIZE( key_type,
-                                                alg,
-                                                input->len - first_part_size ) );
-    TEST_ASSERT( function_output_length <=
-                 PSA_CIPHER_UPDATE_OUTPUT_MAX_SIZE( input->len - first_part_size ) );
+    TEST_LE_U( function_output_length,
+               PSA_CIPHER_UPDATE_OUTPUT_SIZE( key_type,
+                                              alg,
+                                              input->len - first_part_size ) );
+    TEST_LE_U( function_output_length,
+               PSA_CIPHER_UPDATE_OUTPUT_MAX_SIZE( input->len - first_part_size ) );
     output1_length += function_output_length;
 
     PSA_ASSERT( psa_cipher_finish( &operation1,
                                    output1 + output1_length,
                                    output1_buffer_size - output1_length,
                                    &function_output_length ) );
-    TEST_ASSERT( function_output_length <=
-                 PSA_CIPHER_FINISH_OUTPUT_SIZE( key_type, alg ) );
-    TEST_ASSERT( function_output_length <=
-                 PSA_CIPHER_FINISH_OUTPUT_MAX_SIZE );
+    TEST_LE_U( function_output_length,
+               PSA_CIPHER_FINISH_OUTPUT_SIZE( key_type, alg ) );
+    TEST_LE_U( function_output_length,
+               PSA_CIPHER_FINISH_OUTPUT_MAX_SIZE );
     output1_length += function_output_length;
 
     PSA_ASSERT( psa_cipher_abort( &operation1 ) );
 
     output2_buffer_size = output1_length;
-    TEST_ASSERT( output2_buffer_size <=
-                 PSA_CIPHER_DECRYPT_OUTPUT_SIZE( key_type, alg, output1_length ) );
-    TEST_ASSERT( output2_buffer_size <=
-                 PSA_CIPHER_DECRYPT_OUTPUT_MAX_SIZE( output1_length ) );
+    TEST_LE_U( output2_buffer_size,
+               PSA_CIPHER_DECRYPT_OUTPUT_SIZE( key_type, alg, output1_length ) );
+    TEST_LE_U( output2_buffer_size,
+               PSA_CIPHER_DECRYPT_OUTPUT_MAX_SIZE( output1_length ) );
     ASSERT_ALLOC( output2, output2_buffer_size );
 
     if( iv_length > 0 )
@@ -4025,10 +4025,10 @@ void cipher_verify_output_multipart( int alg_arg,
     PSA_ASSERT( psa_cipher_update( &operation2, output1, first_part_size,
                                    output2, output2_buffer_size,
                                    &function_output_length ) );
-    TEST_ASSERT( function_output_length <=
-                 PSA_CIPHER_UPDATE_OUTPUT_SIZE( key_type, alg, first_part_size ) );
-    TEST_ASSERT( function_output_length <=
-                 PSA_CIPHER_UPDATE_OUTPUT_MAX_SIZE( first_part_size ) );
+    TEST_LE_U( function_output_length,
+               PSA_CIPHER_UPDATE_OUTPUT_SIZE( key_type, alg, first_part_size ) );
+    TEST_LE_U( function_output_length,
+               PSA_CIPHER_UPDATE_OUTPUT_MAX_SIZE( first_part_size ) );
     output2_length += function_output_length;
 
     PSA_ASSERT( psa_cipher_update( &operation2,
@@ -4036,22 +4036,22 @@ void cipher_verify_output_multipart( int alg_arg,
                                    output1_length - first_part_size,
                                    output2, output2_buffer_size,
                                    &function_output_length ) );
-    TEST_ASSERT( function_output_length <=
-                 PSA_CIPHER_UPDATE_OUTPUT_SIZE( key_type,
-                                                alg,
-                                                output1_length - first_part_size ) );
-    TEST_ASSERT( function_output_length <=
-                 PSA_CIPHER_UPDATE_OUTPUT_MAX_SIZE( output1_length - first_part_size ) );
+    TEST_LE_U( function_output_length,
+               PSA_CIPHER_UPDATE_OUTPUT_SIZE( key_type,
+                                              alg,
+                                              output1_length - first_part_size ) );
+    TEST_LE_U( function_output_length,
+               PSA_CIPHER_UPDATE_OUTPUT_MAX_SIZE( output1_length - first_part_size ) );
     output2_length += function_output_length;
 
     PSA_ASSERT( psa_cipher_finish( &operation2,
                                    output2 + output2_length,
                                    output2_buffer_size - output2_length,
                                    &function_output_length ) );
-    TEST_ASSERT( function_output_length <=
-                 PSA_CIPHER_FINISH_OUTPUT_SIZE( key_type, alg ) );
-    TEST_ASSERT( function_output_length <=
-                 PSA_CIPHER_FINISH_OUTPUT_MAX_SIZE );
+    TEST_LE_U( function_output_length,
+               PSA_CIPHER_FINISH_OUTPUT_SIZE( key_type, alg ) );
+    TEST_LE_U( function_output_length,
+               PSA_CIPHER_FINISH_OUTPUT_MAX_SIZE );
     output2_length += function_output_length;
 
     PSA_ASSERT( psa_cipher_abort( &operation2 ) );
@@ -4109,8 +4109,8 @@ void aead_encrypt_decrypt( int key_type_arg, data_t *key_data,
     {
         TEST_EQUAL( output_size,
                     PSA_AEAD_ENCRYPT_OUTPUT_SIZE( key_type, alg, input_data->len ) );
-        TEST_ASSERT( output_size <=
-                     PSA_AEAD_ENCRYPT_OUTPUT_MAX_SIZE( input_data->len ) );
+        TEST_LE_U( output_size,
+                   PSA_AEAD_ENCRYPT_OUTPUT_MAX_SIZE( input_data->len ) );
     }
     ASSERT_ALLOC( output_data, output_size );
 
@@ -4142,8 +4142,8 @@ void aead_encrypt_decrypt( int key_type_arg, data_t *key_data,
         TEST_EQUAL( input_data->len,
                     PSA_AEAD_DECRYPT_OUTPUT_SIZE( key_type, alg, output_length ) );
 
-        TEST_ASSERT( input_data->len <=
-                     PSA_AEAD_DECRYPT_OUTPUT_MAX_SIZE( output_length ) );
+        TEST_LE_U( input_data->len,
+                   PSA_AEAD_DECRYPT_OUTPUT_MAX_SIZE( output_length ) );
 
         TEST_EQUAL( psa_aead_decrypt( key, alg,
                                       nonce->x, nonce->len,
@@ -4201,8 +4201,8 @@ void aead_encrypt( int key_type_arg, data_t *key_data,
      * should be exact. */
     TEST_EQUAL( output_size,
                 PSA_AEAD_ENCRYPT_OUTPUT_SIZE( key_type, alg, input_data->len ) );
-    TEST_ASSERT( output_size <=
-                 PSA_AEAD_ENCRYPT_OUTPUT_MAX_SIZE( input_data->len ) );
+    TEST_LE_U( output_size,
+               PSA_AEAD_ENCRYPT_OUTPUT_MAX_SIZE( input_data->len ) );
     ASSERT_ALLOC( output_data, output_size );
 
     status = psa_aead_encrypt( key, alg,
@@ -4272,8 +4272,8 @@ void aead_decrypt( int key_type_arg, data_t *key_data,
          * should be exact. */
         TEST_EQUAL( output_size,
                     PSA_AEAD_DECRYPT_OUTPUT_SIZE( key_type, alg, input_data->len ) );
-        TEST_ASSERT( output_size <=
-                     PSA_AEAD_DECRYPT_OUTPUT_MAX_SIZE( input_data->len ) );
+        TEST_LE_U( output_size,
+                   PSA_AEAD_DECRYPT_OUTPUT_MAX_SIZE( input_data->len ) );
     }
     ASSERT_ALLOC( output_data, output_size );
 
@@ -4534,7 +4534,7 @@ void aead_multipart_generate_nonce( int key_type_arg, data_t *key_data,
 
     ciphertext_size = PSA_AEAD_FINISH_OUTPUT_SIZE( key_type, alg );
 
-    TEST_ASSERT( ciphertext_size <= PSA_AEAD_FINISH_OUTPUT_MAX_SIZE );
+    TEST_LE_U( ciphertext_size, PSA_AEAD_FINISH_OUTPUT_MAX_SIZE );
 
     ASSERT_ALLOC( ciphertext, ciphertext_size );
 
@@ -4563,7 +4563,7 @@ void aead_multipart_generate_nonce( int key_type_arg, data_t *key_data,
         TEST_EQUAL( actual_nonce_length, PSA_AEAD_NONCE_LENGTH( key_type,
                                                                 alg ) );
 
-    TEST_ASSERT( actual_nonce_length <= PSA_AEAD_NONCE_MAX_SIZE );
+    TEST_LE_U( actual_nonce_length, PSA_AEAD_NONCE_MAX_SIZE );
 
     if( expected_status == PSA_SUCCESS )
     {
@@ -4638,7 +4638,7 @@ void aead_multipart_set_nonce( int key_type_arg, data_t *key_data,
 
     ciphertext_size = PSA_AEAD_FINISH_OUTPUT_SIZE( key_type, alg );
 
-    TEST_ASSERT( ciphertext_size <= PSA_AEAD_FINISH_OUTPUT_MAX_SIZE );
+    TEST_LE_U( ciphertext_size, PSA_AEAD_FINISH_OUTPUT_MAX_SIZE );
 
     ASSERT_ALLOC( ciphertext, ciphertext_size );
 
@@ -5076,7 +5076,7 @@ void aead_multipart_state_test( int key_type_arg, data_t *key_data,
 
     tag_length = PSA_AEAD_TAG_LENGTH( key_type, key_bits, alg );
 
-    TEST_ASSERT( tag_length <= PSA_AEAD_TAG_MAX_SIZE );
+    TEST_LE_U( tag_length, PSA_AEAD_TAG_MAX_SIZE );
 
     output_size = PSA_AEAD_UPDATE_OUTPUT_SIZE( key_type, alg, input_data->len );
 
@@ -5084,7 +5084,7 @@ void aead_multipart_state_test( int key_type_arg, data_t *key_data,
 
     finish_output_size = PSA_AEAD_FINISH_OUTPUT_SIZE( key_type, alg );
 
-    TEST_ASSERT( finish_output_size <= PSA_AEAD_FINISH_OUTPUT_MAX_SIZE );
+    TEST_LE_U( finish_output_size, PSA_AEAD_FINISH_OUTPUT_MAX_SIZE );
 
     ASSERT_ALLOC( final_data, finish_output_size );
 
@@ -5924,7 +5924,7 @@ void sign_hash_deterministic( int key_type_arg, data_t *key_data,
     signature_size = PSA_SIGN_OUTPUT_SIZE( key_type,
                                                       key_bits, alg );
     TEST_ASSERT( signature_size != 0 );
-    TEST_ASSERT( signature_size <= PSA_SIGNATURE_MAX_SIZE );
+    TEST_LE_U( signature_size, PSA_SIGNATURE_MAX_SIZE );
     ASSERT_ALLOC( signature, signature_size );
 
     /* Perform the signature. */
@@ -5984,7 +5984,7 @@ void sign_hash_fail( int key_type_arg, data_t *key_data,
      * whatever it is, it should be less than signature_size, so that
      * if the caller tries to read *signature_length bytes without
      * checking the error code then they don't overflow a buffer. */
-    TEST_ASSERT( signature_length <= signature_size );
+    TEST_LE_U( signature_length, signature_size );
 
 exit:
     psa_reset_key_attributes( &attributes );
@@ -6023,7 +6023,7 @@ void sign_verify_hash( int key_type_arg, data_t *key_data,
     signature_size = PSA_SIGN_OUTPUT_SIZE( key_type,
                                                       key_bits, alg );
     TEST_ASSERT( signature_size != 0 );
-    TEST_ASSERT( signature_size <= PSA_SIGNATURE_MAX_SIZE );
+    TEST_LE_U( signature_size, PSA_SIGNATURE_MAX_SIZE );
     ASSERT_ALLOC( signature, signature_size );
 
     /* Perform the signature. */
@@ -6032,7 +6032,7 @@ void sign_verify_hash( int key_type_arg, data_t *key_data,
                                signature, signature_size,
                                &signature_length ) );
     /* Check that the signature length looks sensible. */
-    TEST_ASSERT( signature_length <= signature_size );
+    TEST_LE_U( signature_length, signature_size );
     TEST_ASSERT( signature_length > 0 );
 
     /* Use the library to verify that the signature is correct. */
@@ -6075,7 +6075,7 @@ void verify_hash( int key_type_arg, data_t *key_data,
     psa_algorithm_t alg = alg_arg;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
 
-    TEST_ASSERT( signature_data->len <= PSA_SIGNATURE_MAX_SIZE );
+    TEST_LE_U( signature_data->len, PSA_SIGNATURE_MAX_SIZE );
 
     PSA_ASSERT( psa_crypto_init( ) );
 
@@ -6160,7 +6160,7 @@ void sign_message_deterministic( int key_type_arg,
 
     signature_size = PSA_SIGN_OUTPUT_SIZE( key_type, key_bits, alg );
     TEST_ASSERT( signature_size != 0 );
-    TEST_ASSERT( signature_size <= PSA_SIGNATURE_MAX_SIZE );
+    TEST_LE_U( signature_size, PSA_SIGNATURE_MAX_SIZE );
     ASSERT_ALLOC( signature, signature_size );
 
     PSA_ASSERT( psa_sign_message( key, alg,
@@ -6219,7 +6219,7 @@ void sign_message_fail( int key_type_arg,
      * whatever it is, it should be less than signature_size, so that
      * if the caller tries to read *signature_length bytes without
      * checking the error code then they don't overflow a buffer. */
-    TEST_ASSERT( signature_length <= signature_size );
+    TEST_LE_U( signature_length, signature_size );
 
 exit:
     psa_reset_key_attributes( &attributes );
@@ -6258,14 +6258,14 @@ void sign_verify_message( int key_type_arg,
 
     signature_size = PSA_SIGN_OUTPUT_SIZE( key_type, key_bits, alg );
     TEST_ASSERT( signature_size != 0 );
-    TEST_ASSERT( signature_size <= PSA_SIGNATURE_MAX_SIZE );
+    TEST_LE_U( signature_size, PSA_SIGNATURE_MAX_SIZE );
     ASSERT_ALLOC( signature, signature_size );
 
     PSA_ASSERT( psa_sign_message( key, alg,
                                   input_data->x, input_data->len,
                                   signature, signature_size,
                                   &signature_length ) );
-    TEST_ASSERT( signature_length <= signature_size );
+    TEST_LE_U( signature_length, signature_size );
     TEST_ASSERT( signature_length > 0 );
 
     PSA_ASSERT( psa_verify_message( key, alg,
@@ -6305,7 +6305,7 @@ void verify_message( int key_type_arg,
     psa_algorithm_t alg = alg_arg;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
 
-    TEST_ASSERT( signature_data->len <= PSA_SIGNATURE_MAX_SIZE );
+    TEST_LE_U( signature_data->len, PSA_SIGNATURE_MAX_SIZE );
 
     PSA_ASSERT( psa_crypto_init( ) );
 
@@ -6399,7 +6399,7 @@ void asymmetric_encrypt( int key_type_arg,
     key_bits = psa_get_key_bits( &attributes );
 
     output_size = PSA_ASYMMETRIC_ENCRYPT_OUTPUT_SIZE( key_type, key_bits, alg );
-    TEST_ASSERT( output_size <= PSA_ASYMMETRIC_ENCRYPT_OUTPUT_MAX_SIZE );
+    TEST_LE_U( output_size, PSA_ASYMMETRIC_ENCRYPT_OUTPUT_MAX_SIZE );
     ASSERT_ALLOC( output, output_size );
 
     /* Encrypt the input */
@@ -6473,13 +6473,13 @@ void asymmetric_encrypt_decrypt( int key_type_arg,
     key_bits = psa_get_key_bits( &attributes );
 
     output_size = PSA_ASYMMETRIC_ENCRYPT_OUTPUT_SIZE( key_type, key_bits, alg );
-    TEST_ASSERT( output_size <= PSA_ASYMMETRIC_ENCRYPT_OUTPUT_MAX_SIZE );
+    TEST_LE_U( output_size, PSA_ASYMMETRIC_ENCRYPT_OUTPUT_MAX_SIZE );
     ASSERT_ALLOC( output, output_size );
 
     output2_size = input_data->len;
-    TEST_ASSERT( output2_size <=
-                 PSA_ASYMMETRIC_DECRYPT_OUTPUT_SIZE( key_type, key_bits, alg ) );
-    TEST_ASSERT( output2_size <= PSA_ASYMMETRIC_DECRYPT_OUTPUT_MAX_SIZE );
+    TEST_LE_U( output2_size,
+               PSA_ASYMMETRIC_DECRYPT_OUTPUT_SIZE( key_type, key_bits, alg ) );
+    TEST_LE_U( output2_size, PSA_ASYMMETRIC_DECRYPT_OUTPUT_MAX_SIZE );
     ASSERT_ALLOC( output2, output2_size );
 
     /* We test encryption by checking that encrypt-then-decrypt gives back
@@ -6492,7 +6492,7 @@ void asymmetric_encrypt_decrypt( int key_type_arg,
                                         &output_length ) );
     /* We don't know what ciphertext length to expect, but check that
      * it looks sensible. */
-    TEST_ASSERT( output_length <= output_size );
+    TEST_LE_U( output_length, output_size );
 
     PSA_ASSERT( psa_asymmetric_decrypt( key, alg,
                                         output, output_length,
@@ -6547,7 +6547,7 @@ void asymmetric_decrypt( int key_type_arg,
 
     /* Determine the maximum ciphertext length */
     output_size = PSA_ASYMMETRIC_DECRYPT_OUTPUT_SIZE( key_type, key_bits, alg );
-    TEST_ASSERT( output_size <= PSA_ASYMMETRIC_DECRYPT_OUTPUT_MAX_SIZE );
+    TEST_LE_U( output_size, PSA_ASYMMETRIC_DECRYPT_OUTPUT_MAX_SIZE );
     ASSERT_ALLOC( output, output_size );
 
     PSA_ASSERT( psa_asymmetric_decrypt( key, alg,
@@ -6620,7 +6620,7 @@ void asymmetric_decrypt_fail( int key_type_arg,
                                             output, output_size,
                                             &output_length );
     TEST_EQUAL( actual_status, expected_status );
-    TEST_ASSERT( output_length <= output_size );
+    TEST_LE_U( output_length, output_size );
 
     /* If the label is empty, the test framework puts a non-null pointer
      * in label->x. Test that a null pointer works as well. */
@@ -6635,7 +6635,7 @@ void asymmetric_decrypt_fail( int key_type_arg,
                                                 output, output_size,
                                                 &output_length );
         TEST_EQUAL( actual_status, expected_status );
-        TEST_ASSERT( output_length <= output_size );
+        TEST_LE_U( output_length, output_size );
     }
 
 exit:
@@ -6956,8 +6956,8 @@ void derive_output( int alg_arg,
                 if ( PSA_ALG_IS_TLS12_PSK_TO_MS( alg ) )
                 {
                     PSA_ASSERT( psa_get_key_attributes( keys[i], &attributes ) );
-                    TEST_ASSERT( PSA_BITS_TO_BYTES( psa_get_key_bits( &attributes ) ) <=
-                                 PSA_TLS12_PSK_TO_MS_PSK_MAX_SIZE );
+                    TEST_LE_U( PSA_BITS_TO_BYTES( psa_get_key_bits( &attributes ) ),
+                               PSA_TLS12_PSK_TO_MS_PSK_MAX_SIZE );
                 }
 
                 PSA_ASSERT( psa_key_derivation_input_key(
@@ -7419,10 +7419,10 @@ void raw_key_agreement( int alg_arg,
     key_bits = psa_get_key_bits( &attributes );
 
     /* Validate size macros */
-    TEST_ASSERT( expected_output->len <=
-                 PSA_RAW_KEY_AGREEMENT_OUTPUT_SIZE( our_key_type, key_bits ) );
-    TEST_ASSERT( PSA_RAW_KEY_AGREEMENT_OUTPUT_SIZE( our_key_type, key_bits ) <=
-                 PSA_RAW_KEY_AGREEMENT_OUTPUT_MAX_SIZE );
+    TEST_LE_U( expected_output->len,
+               PSA_RAW_KEY_AGREEMENT_OUTPUT_SIZE( our_key_type, key_bits ) );
+    TEST_LE_U( PSA_RAW_KEY_AGREEMENT_OUTPUT_SIZE( our_key_type, key_bits ),
+               PSA_RAW_KEY_AGREEMENT_OUTPUT_MAX_SIZE );
 
     /* Good case with exact output size */
     ASSERT_ALLOC( output, expected_output->len );
@@ -7456,7 +7456,7 @@ void raw_key_agreement( int alg_arg,
                                        &output_length ),
                 PSA_ERROR_BUFFER_TOO_SMALL );
     /* Not required by the spec, but good robustness */
-    TEST_ASSERT( output_length <= expected_output->len - 1 );
+    TEST_LE_U( output_length, expected_output->len - 1 );
     mbedtls_free( output );
     output = NULL;
 

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -7419,6 +7419,10 @@ void raw_key_agreement( int alg_arg,
     key_bits = psa_get_key_bits( &attributes );
 
     /* Validate size macros */
+    TEST_ASSERT( expected_output->len <=
+                 PSA_RAW_KEY_AGREEMENT_OUTPUT_SIZE( our_key_type, key_bits ) );
+    TEST_ASSERT( PSA_RAW_KEY_AGREEMENT_OUTPUT_SIZE( our_key_type, key_bits ) <=
+                 PSA_RAW_KEY_AGREEMENT_OUTPUT_MAX_SIZE );
 
     /* Good case with exact output size */
     ASSERT_ALLOC( output, expected_output->len );
@@ -7428,10 +7432,6 @@ void raw_key_agreement( int alg_arg,
                                        &output_length ) );
     ASSERT_COMPARE( output, output_length,
                     expected_output->x, expected_output->len );
-    TEST_ASSERT( output_length <=
-                 PSA_RAW_KEY_AGREEMENT_OUTPUT_SIZE( our_key_type, key_bits ) );
-    TEST_ASSERT( PSA_RAW_KEY_AGREEMENT_OUTPUT_SIZE( our_key_type, key_bits ) <=
-                 PSA_RAW_KEY_AGREEMENT_OUTPUT_MAX_SIZE );
     mbedtls_free( output );
     output = NULL;
     output_length = ~0;

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -7406,7 +7406,6 @@ void raw_key_agreement( int alg_arg,
     size_t output_length = ~0;
     size_t key_bits;
 
-    ASSERT_ALLOC( output, expected_output->len );
     PSA_ASSERT( psa_crypto_init( ) );
 
     psa_set_key_usage_flags( &attributes, PSA_KEY_USAGE_DERIVE );
@@ -7419,6 +7418,10 @@ void raw_key_agreement( int alg_arg,
     PSA_ASSERT( psa_get_key_attributes( our_key, &attributes ) );
     key_bits = psa_get_key_bits( &attributes );
 
+    /* Validate size macros */
+
+    /* Good case with exact output size */
+    ASSERT_ALLOC( output, expected_output->len );
     PSA_ASSERT( psa_raw_key_agreement( alg, our_key,
                                        peer_key_data->x, peer_key_data->len,
                                        output, expected_output->len,
@@ -7429,6 +7432,33 @@ void raw_key_agreement( int alg_arg,
                  PSA_RAW_KEY_AGREEMENT_OUTPUT_SIZE( our_key_type, key_bits ) );
     TEST_ASSERT( output_length <=
                  PSA_RAW_KEY_AGREEMENT_OUTPUT_MAX_SIZE );
+    mbedtls_free( output );
+    output = NULL;
+    output_length = ~0;
+
+    /* Larger buffer */
+    ASSERT_ALLOC( output, expected_output->len + 1 );
+    PSA_ASSERT( psa_raw_key_agreement( alg, our_key,
+                                       peer_key_data->x, peer_key_data->len,
+                                       output, expected_output->len + 1,
+                                       &output_length ) );
+    ASSERT_COMPARE( output, output_length,
+                    expected_output->x, expected_output->len );
+    mbedtls_free( output );
+    output = NULL;
+    output_length = ~0;
+
+    /* Buffer too small */
+    ASSERT_ALLOC( output, expected_output->len - 1 );
+    TEST_EQUAL( psa_raw_key_agreement( alg, our_key,
+                                       peer_key_data->x, peer_key_data->len,
+                                       output, expected_output->len - 1,
+                                       &output_length ),
+                PSA_ERROR_BUFFER_TOO_SMALL );
+    /* Not required by the spec, but good robustness */
+    TEST_ASSERT( output_length <= expected_output->len - 1 );
+    mbedtls_free( output );
+    output = NULL;
 
 exit:
     mbedtls_free( output );


### PR DESCRIPTION
Fix https://github.com/Mbed-TLS/mbedtls/issues/5735

Needs backport