### PR TITLE
Backport 2.28: Support alternative MBEDTLS_PSA_CRYPTO_CONFIG_FILE

### DIFF
--- a/ChangeLog.d/psa_crypto_config_file.txt
+++ b/ChangeLog.d/psa_crypto_config_file.txt
@@ -1,0 +1,6 @@
+Features
+   * When MBEDTLS_PSA_CRYPTO_CONFIG is enabled, you may list the PSA crypto
+     requirements in the file named by the new macro
+     MBEDTLS_PSA_CRYPTO_CONFIG_FILE instead of the default psa/crypto_config.h.
+     Furthermore you may name an additional file to include after the main
+     file with the macro MBEDTLS_PSA_CRYPTO_USER_CONFIG_FILE.

--- a/ChangeLog.d/psa_crypto_config_file.txt
+++ b/ChangeLog.d/psa_crypto_config_file.txt
@@ -1,6 +1,6 @@
 Features
    * When MBEDTLS_PSA_CRYPTO_CONFIG is enabled, you may list the PSA crypto
-     requirements in the file named by the new macro
+     feature requirements in the file named by the new macro
      MBEDTLS_PSA_CRYPTO_CONFIG_FILE instead of the default psa/crypto_config.h.
      Furthermore you may name an additional file to include after the main
      file with the macro MBEDTLS_PSA_CRYPTO_USER_CONFIG_FILE.

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -3624,6 +3624,38 @@
  * \{
  */
 
+/* Meta configuration */
+/**
+ * \def MBEDTLS_CONFIG_FILE
+ *
+ * If defined, this is a header which will be included instead of
+ * `"mbedtls/mbedtls_config.h"`.
+ * This header file specifies the compile-time configuration of Mbed TLS.
+ *
+ * This macro is expanded after an `#include` directive. This is a popular but
+ * non-standard feature of the C language, so this feature is only available
+ * with compilers that perform macro expansion on an `#include` line.
+ *
+ * The value of this symbol is typically a path in double quotes, relative
+ * to a directory on the include search pah.
+ */
+//#define MBEDTLS_CONFIG_FILE "mbedtls/mbedtls_config.h"
+
+/**
+ * \def MBEDTLS_USER_CONFIG_FILE
+ *
+ * If defined, this is a header which will be included after
+ * `"mbedtls/mbedtls_config.h"` or #MBEDTLS_CONFIG_FILE.
+ *
+ * This macro is expanded after an `#include` directive. This is a popular but
+ * non-standard feature of the C language, so this feature is only available
+ * with compilers that perform macro expansion on an `#include` line.
+ *
+ * The value of this symbol is typically a path in double quotes, relative
+ * to a directory on the include search pah.
+ */
+//#define MBEDTLS_USER_CONFIG_FILE "/dev/null"
+
 /* MPI / BIGNUM options */
 //#define MBEDTLS_MPI_WINDOW_SIZE            6 /**< Maximum window size used. */
 //#define MBEDTLS_MPI_MAX_SIZE            1024 /**< Maximum number of bytes for usable MPIs. */

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -3640,8 +3640,8 @@
  * non-standard feature of the C language, so this feature is only available
  * with compilers that perform macro expansion on an <tt>\#include</tt> line.
  *
- * The value of this symbol is typically a path in double quotes, relative
- * to a directory on the include search pah.
+ * The value of this symbol is typically a path in double quotes, either
+ * absolute or relative to a directory on the include search path.
  */
 //#define MBEDTLS_CONFIG_FILE "mbedtls/mbedtls_config.h"
 
@@ -3657,8 +3657,8 @@
  * non-standard feature of the C language, so this feature is only available
  * with compilers that perform macro expansion on an <tt>\#include</tt> line.
  *
- * The value of this symbol is typically a path in double quotes, relative
- * to a directory on the include search pah.
+ * The value of this symbol is typically a path in double quotes, either
+ * absolute or relative to a directory on the include search path.
  */
 //#define MBEDTLS_USER_CONFIG_FILE "/dev/null"
 
@@ -3675,8 +3675,8 @@
  * non-standard feature of the C language, so this feature is only available
  * with compilers that perform macro expansion on an <tt>\#include</tt> line.
  *
- * The value of this symbol is typically a path in double quotes, relative
- * to a directory on the include search pah.
+ * The value of this symbol is typically a path in double quotes, either
+ * absolute or relative to a directory on the include search path.
  */
 //#define MBEDTLS_PSA_CRYPTO_CONFIG_FILE "psa/crypto_config.h"
 
@@ -3692,8 +3692,8 @@
  * non-standard feature of the C language, so this feature is only available
  * with compilers that perform macro expansion on an <tt>\#include</tt> line.
  *
- * The value of this symbol is typically a path in double quotes, relative
- * to a directory on the include search pah.
+ * The value of this symbol is typically a path in double quotes, either
+ * absolute or relative to a directory on the include search path.
  */
 //#define MBEDTLS_PSA_CRYPTO_USER_CONFIG_FILE "/dev/null"
 

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -4102,7 +4102,7 @@
  */
 //#define MBEDTLS_ECDH_VARIANT_EVEREST_ENABLED
 
-/** \} name SECTION: Customisation configuration options */
+/** \} name SECTION: Module configuration options */
 
 /* Target and application specific configurations
  *

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -3620,7 +3620,7 @@
 /** \} name SECTION: mbed TLS modules */
 
 /**
- * \name SECTION: Module configuration options
+ * \name SECTION: General configuration options
  *
  * This section allows for the setting of module specific sizes and
  * configuration options. The default values are already present in the
@@ -3634,7 +3634,6 @@
  * \{
  */
 
-/* Meta configuration */
 /**
  * \def MBEDTLS_CONFIG_FILE
  *
@@ -3698,6 +3697,23 @@
  * to a directory on the include search pah.
  */
 //#define MBEDTLS_PSA_CRYPTO_USER_CONFIG_FILE "/dev/null"
+
+/** \} name SECTION: General configuration options */
+
+/**
+ * \name SECTION: Module configuration options
+ *
+ * This section allows for the setting of module specific sizes and
+ * configuration options. The default values are already present in the
+ * relevant header files and should suffice for the regular use cases.
+ *
+ * Our advice is to enable options and change their values here
+ * only if you have a good reason and know the consequences.
+ *
+ * Please check the respective header file for documentation on these
+ * parameters (to prevent duplicate documentation).
+ * \{
+ */
 
 /* MPI / BIGNUM options */
 //#define MBEDTLS_MPI_WINDOW_SIZE            6 /**< Maximum window size used. */

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -3649,6 +3649,8 @@
  *
  * If defined, this is a header which will be included after
  * `"mbedtls/mbedtls_config.h"` or #MBEDTLS_CONFIG_FILE.
+ * This allows you to modify the default configuration, including the ability
+ * to undefine options that are enabled by default.
  *
  * This macro is expanded after an <tt>\#include</tt> directive. This is a popular but
  * non-standard feature of the C language, so this feature is only available
@@ -3682,6 +3684,8 @@
  *
  * If defined, this is a header which will be included after
  * `"psa/crypto_config.h"` or #MBEDTLS_PSA_CRYPTO_CONFIG_FILE.
+ * This allows you to modify the default configuration, including the ability
+ * to undefine options that are enabled by default.
  *
  * This macro is expanded after an <tt>\#include</tt> directive. This is a popular but
  * non-standard feature of the C language, so this feature is only available

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -2177,6 +2177,9 @@
  * mechanism). You may still freely enable additional `MBEDTLS_XXX` symbols
  * in mbedtls_config.h.
  *
+ * If the symbol #MBEDTLS_PSA_CRYPTO_CONFIG_FILE is defined, it specifies
+ * an alternative location to use instead of include/psa/crypto_config.h.
+ *
  * If you enable this option and write your own configuration file, you must
  * include mbedtls/config_psa.h in your configuration file. The default
  * provided mbedtls/config.h contains the necessary inclusion.
@@ -3662,6 +3665,39 @@
  * to a directory on the include search pah.
  */
 //#define MBEDTLS_USER_CONFIG_FILE "/dev/null"
+
+/**
+ * \def MBEDTLS_PSA_CRYPTO_CONFIG_FILE
+ *
+ * If defined, this is a header which will be included instead of
+ * `"psa/crypto_config.h"`.
+ * This header file specifies which cryptographic mechanisms are available
+ * through the PSA API when #MBEDTLS_PSA_CRYPTO_CONFIG is enabled, and
+ * is not used when #MBEDTLS_PSA_CRYPTO_CONFIG is disabled.
+ *
+ * This macro is expanded after an `#include` directive. This is a popular but
+ * non-standard feature of the C language, so this feature is only available
+ * with compilers that perform macro expansion on an `#include` line.
+ *
+ * The value of this symbol is typically a path in double quotes, relative
+ * to a directory on the include search pah.
+ */
+//#define MBEDTLS_PSA_CRYPTO_CONFIG_FILE "psa/crypto_config.h"
+
+/**
+ * \def MBEDTLS_PSA_CRYPTO_USER_CONFIG_FILE
+ *
+ * If defined, this is a header which will be included after
+ * `"psa/crypto_config.h"` or #MBEDTLS_PSA_CRYPTO_CONFIG_FILE.
+ *
+ * This macro is expanded after an `#include` directive. This is a popular but
+ * non-standard feature of the C language, so this feature is only available
+ * with compilers that perform macro expansion on an `#include` line.
+ *
+ * The value of this symbol is typically a path in double quotes, relative
+ * to a directory on the include search pah.
+ */
+//#define MBEDTLS_PSA_CRYPTO_USER_CONFIG_FILE "/dev/null"
 
 /* MPI / BIGNUM options */
 //#define MBEDTLS_MPI_WINDOW_SIZE            6 /**< Maximum window size used. */

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -3622,15 +3622,9 @@
 /**
  * \name SECTION: General configuration options
  *
- * This section allows for the setting of module specific sizes and
- * configuration options. The default values are already present in the
- * relevant header files and should suffice for the regular use cases.
+ * This section contains Mbed TLS build settings that are not associated
+ * with a particular module.
  *
- * Our advice is to enable options and change their values here
- * only if you have a good reason and know the consequences.
- *
- * Please check the respective header file for documentation on these
- * parameters (to prevent duplicate documentation).
  * \{
  */
 

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -2179,7 +2179,7 @@
  * in mbedtls_config.h.
  *
  * If the symbol #MBEDTLS_PSA_CRYPTO_CONFIG_FILE is defined, it specifies
- * an alternative location to use instead of include/psa/crypto_config.h.
+ * an alternative header to include instead of include/psa/crypto_config.h.
  *
  * If you enable this option and write your own configuration file, you must
  * include mbedtls/config_psa.h in your configuration file. The default

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -2167,8 +2167,15 @@
  * This setting allows support for cryptographic mechanisms through the PSA
  * API to be configured separately from support through the mbedtls API.
  *
- * Uncomment this to enable use of PSA Crypto configuration settings which
- * can be found in include/psa/crypto_config.h.
+ * When this option is disabled, the PSA API exposes the same cryptographic
+ * mechanism as the `mbedtls_xxx` API configured with `MBEDTLS_XXX` symbols.
+ *
+ * When this option is enabled, the PSA API exposes the cryptographic
+ * mechanisms requested by the `PSA_WANT_XXX` symbols defined in
+ * include/psa/crypto_config.h. The corresponding `MBEDTLS_XXX` settings are
+ * automatically enabled if required (i.e. if no PSA driver provides the
+ * mechanism). You may still freely enable additional `MBEDTLS_XXX` symbols
+ * in mbedtls_config.h.
  *
  * If you enable this option and write your own configuration file, you must
  * include mbedtls/config_psa.h in your configuration file. The default

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -3635,6 +3635,8 @@
  * If defined, this is a header which will be included instead of
  * `"mbedtls/config.h"`.
  * This header file specifies the compile-time configuration of Mbed TLS.
+ * Unlike other configuration options, this one must be defined on the
+ * compiler command line: a definition in `config.h` would have no effect.
  *
  * This macro is expanded after an <tt>\#include</tt> directive. This is a popular but
  * non-standard feature of the C language, so this feature is only available

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -3641,9 +3641,9 @@
  * `"mbedtls/mbedtls_config.h"`.
  * This header file specifies the compile-time configuration of Mbed TLS.
  *
- * This macro is expanded after an `#include` directive. This is a popular but
+ * This macro is expanded after an <tt>\#include</tt> directive. This is a popular but
  * non-standard feature of the C language, so this feature is only available
- * with compilers that perform macro expansion on an `#include` line.
+ * with compilers that perform macro expansion on an <tt>\#include</tt> line.
  *
  * The value of this symbol is typically a path in double quotes, relative
  * to a directory on the include search pah.
@@ -3656,9 +3656,9 @@
  * If defined, this is a header which will be included after
  * `"mbedtls/mbedtls_config.h"` or #MBEDTLS_CONFIG_FILE.
  *
- * This macro is expanded after an `#include` directive. This is a popular but
+ * This macro is expanded after an <tt>\#include</tt> directive. This is a popular but
  * non-standard feature of the C language, so this feature is only available
- * with compilers that perform macro expansion on an `#include` line.
+ * with compilers that perform macro expansion on an <tt>\#include</tt> line.
  *
  * The value of this symbol is typically a path in double quotes, relative
  * to a directory on the include search pah.
@@ -3674,9 +3674,9 @@
  * through the PSA API when #MBEDTLS_PSA_CRYPTO_CONFIG is enabled, and
  * is not used when #MBEDTLS_PSA_CRYPTO_CONFIG is disabled.
  *
- * This macro is expanded after an `#include` directive. This is a popular but
+ * This macro is expanded after an <tt>\#include</tt> directive. This is a popular but
  * non-standard feature of the C language, so this feature is only available
- * with compilers that perform macro expansion on an `#include` line.
+ * with compilers that perform macro expansion on an <tt>\#include</tt> line.
  *
  * The value of this symbol is typically a path in double quotes, relative
  * to a directory on the include search pah.
@@ -3689,9 +3689,9 @@
  * If defined, this is a header which will be included after
  * `"psa/crypto_config.h"` or #MBEDTLS_PSA_CRYPTO_CONFIG_FILE.
  *
- * This macro is expanded after an `#include` directive. This is a popular but
+ * This macro is expanded after an <tt>\#include</tt> directive. This is a popular but
  * non-standard feature of the C language, so this feature is only available
- * with compilers that perform macro expansion on an `#include` line.
+ * with compilers that perform macro expansion on an <tt>\#include</tt> line.
  *
  * The value of this symbol is typically a path in double quotes, relative
  * to a directory on the include search pah.

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -2176,7 +2176,7 @@
  * include/psa/crypto_config.h. The corresponding `MBEDTLS_XXX` settings are
  * automatically enabled if required (i.e. if no PSA driver provides the
  * mechanism). You may still freely enable additional `MBEDTLS_XXX` symbols
- * in mbedtls_config.h.
+ * in config.h.
  *
  * If the symbol #MBEDTLS_PSA_CRYPTO_CONFIG_FILE is defined, it specifies
  * an alternative header to include instead of include/psa/crypto_config.h.
@@ -3633,7 +3633,7 @@
  * \def MBEDTLS_CONFIG_FILE
  *
  * If defined, this is a header which will be included instead of
- * `"mbedtls/mbedtls_config.h"`.
+ * `"mbedtls/config.h"`.
  * This header file specifies the compile-time configuration of Mbed TLS.
  *
  * This macro is expanded after an <tt>\#include</tt> directive. This is a popular but
@@ -3643,13 +3643,13 @@
  * The value of this symbol is typically a path in double quotes, either
  * absolute or relative to a directory on the include search path.
  */
-//#define MBEDTLS_CONFIG_FILE "mbedtls/mbedtls_config.h"
+//#define MBEDTLS_CONFIG_FILE "mbedtls/config.h"
 
 /**
  * \def MBEDTLS_USER_CONFIG_FILE
  *
  * If defined, this is a header which will be included after
- * `"mbedtls/mbedtls_config.h"` or #MBEDTLS_CONFIG_FILE.
+ * `"mbedtls/config.h"` or #MBEDTLS_CONFIG_FILE.
  * This allows you to modify the default configuration, including the ability
  * to undefine options that are enabled by default.
  *

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -3703,11 +3703,15 @@
  *
  * Our advice is to enable options and change their values here
  * only if you have a good reason and know the consequences.
- *
- * Please check the respective header file for documentation on these
- * parameters (to prevent duplicate documentation).
  * \{
  */
+/* The Doxygen documentation here is used when a user comments out a
+ * setting and runs doxygen themselves. On the other hand, when we typeset
+ * the full documentation including disabled settings, the documentation
+ * in specific modules' header files is used if present. When editing this
+ * file, make sure that each option is documented in exactly one place,
+ * plus optionally a same-line Doxygen comment here if there is a Doxygen
+ * comment in the specific module. */
 
 /* MPI / BIGNUM options */
 //#define MBEDTLS_MPI_WINDOW_SIZE            6 /**< Maximum window size used. */

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -2167,8 +2167,9 @@
  * This setting allows support for cryptographic mechanisms through the PSA
  * API to be configured separately from support through the mbedtls API.
  *
- * When this option is disabled, the PSA API exposes the same cryptographic
- * mechanism as the `mbedtls_xxx` API configured with `MBEDTLS_XXX` symbols.
+ * When this option is disabled, the PSA API exposes the cryptographic
+ * mechanisms that can be implemented on top of the `mbedtls_xxx` API
+ * configured with `MBEDTLS_XXX` symbols.
  *
  * When this option is enabled, the PSA API exposes the cryptographic
  * mechanisms requested by the `PSA_WANT_XXX` symbols defined in

--- a/include/mbedtls/config_psa.h
+++ b/include/mbedtls/config_psa.h
@@ -31,8 +31,16 @@
 #define MBEDTLS_CONFIG_PSA_H
 
 #if defined(MBEDTLS_PSA_CRYPTO_CONFIG)
+#if defined(MBEDTLS_PSA_CRYPTO_CONFIG_FILE)
+#include MBEDTLS_PSA_CRYPTO_CONFIG_FILE
+#else
 #include "psa/crypto_config.h"
+#endif
 #endif /* defined(MBEDTLS_PSA_CRYPTO_CONFIG) */
+
+#if defined(MBEDTLS_PSA_CRYPTO_USER_CONFIG_FILE)
+#include MBEDTLS_PSA_CRYPTO_USER_CONFIG_FILE
+#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/programs/test/query_config.c
+++ b/programs/test/query_config.c
@@ -2320,6 +2320,38 @@ int query_config( const char *config )
     }
 #endif /* MBEDTLS_XTEA_C */
 
+#if defined(MBEDTLS_CONFIG_FILE)
+    if( strcmp( "MBEDTLS_CONFIG_FILE", config ) == 0 )
+    {
+        MACRO_EXPANSION_TO_STR( MBEDTLS_CONFIG_FILE );
+        return( 0 );
+    }
+#endif /* MBEDTLS_CONFIG_FILE */
+
+#if defined(MBEDTLS_USER_CONFIG_FILE)
+    if( strcmp( "MBEDTLS_USER_CONFIG_FILE", config ) == 0 )
+    {
+        MACRO_EXPANSION_TO_STR( MBEDTLS_USER_CONFIG_FILE );
+        return( 0 );
+    }
+#endif /* MBEDTLS_USER_CONFIG_FILE */
+
+#if defined(MBEDTLS_PSA_CRYPTO_CONFIG_FILE)
+    if( strcmp( "MBEDTLS_PSA_CRYPTO_CONFIG_FILE", config ) == 0 )
+    {
+        MACRO_EXPANSION_TO_STR( MBEDTLS_PSA_CRYPTO_CONFIG_FILE );
+        return( 0 );
+    }
+#endif /* MBEDTLS_PSA_CRYPTO_CONFIG_FILE */
+
+#if defined(MBEDTLS_PSA_CRYPTO_USER_CONFIG_FILE)
+    if( strcmp( "MBEDTLS_PSA_CRYPTO_USER_CONFIG_FILE", config ) == 0 )
+    {
+        MACRO_EXPANSION_TO_STR( MBEDTLS_PSA_CRYPTO_USER_CONFIG_FILE );
+        return( 0 );
+    }
+#endif /* MBEDTLS_PSA_CRYPTO_USER_CONFIG_FILE */
+
 #if defined(MBEDTLS_MPI_WINDOW_SIZE)
     if( strcmp( "MBEDTLS_MPI_WINDOW_SIZE", config ) == 0 )
     {
@@ -3945,6 +3977,22 @@ void list_config( void )
 #if defined(MBEDTLS_XTEA_C)
     OUTPUT_MACRO_NAME_VALUE(MBEDTLS_XTEA_C);
 #endif /* MBEDTLS_XTEA_C */
+
+#if defined(MBEDTLS_CONFIG_FILE)
+    OUTPUT_MACRO_NAME_VALUE(MBEDTLS_CONFIG_FILE);
+#endif /* MBEDTLS_CONFIG_FILE */
+
+#if defined(MBEDTLS_USER_CONFIG_FILE)
+    OUTPUT_MACRO_NAME_VALUE(MBEDTLS_USER_CONFIG_FILE);
+#endif /* MBEDTLS_USER_CONFIG_FILE */
+
+#if defined(MBEDTLS_PSA_CRYPTO_CONFIG_FILE)
+    OUTPUT_MACRO_NAME_VALUE(MBEDTLS_PSA_CRYPTO_CONFIG_FILE);
+#endif /* MBEDTLS_PSA_CRYPTO_CONFIG_FILE */
+
+#if defined(MBEDTLS_PSA_CRYPTO_USER_CONFIG_FILE)
+    OUTPUT_MACRO_NAME_VALUE(MBEDTLS_PSA_CRYPTO_USER_CONFIG_FILE);
+#endif /* MBEDTLS_PSA_CRYPTO_USER_CONFIG_FILE */
 
 #if defined(MBEDTLS_MPI_WINDOW_SIZE)
     OUTPUT_MACRO_NAME_VALUE(MBEDTLS_MPI_WINDOW_SIZE);

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -152,8 +152,16 @@ def is_full_section(section):
     return section.endswith('support') or section.endswith('modules')
 
 def realfull_adapter(_name, active, section):
-    """Activate all symbols found in the system and feature sections."""
-    if not is_full_section(section):
+    """Activate all symbols found in the global and boolean feature sections.
+
+    This is intended for building the documentation, including the
+    documentation of settings that are activated by defining an optional
+    preprocessor macro.
+
+    Do not activate definitions in the section containing symbols that are
+    supposed to be defined and documented in their own module.
+    """
+    if section == 'Module configuration options':
         return active
     return True
 

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -2622,8 +2622,6 @@ component_test_gcc_opt () {
 
 component_build_mbedtls_config_file () {
     msg "build: make with MBEDTLS_CONFIG_FILE" # ~40s
-    # Use the full config so as to catch a maximum of places where
-    # the check of MBEDTLS_CONFIG_FILE might be missing.
     scripts/config.py -w full_config.h full
     echo '#error "MBEDTLS_CONFIG_FILE is not working"' >"$CONFIG_H"
     make CFLAGS="-I '$PWD' -DMBEDTLS_CONFIG_FILE='\"full_config.h\"'"

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -2625,6 +2625,7 @@ component_build_mbedtls_config_file () {
     scripts/config.py -w full_config.h full
     echo '#error "MBEDTLS_CONFIG_FILE is not working"' >"$CONFIG_H"
     make CFLAGS="-I '$PWD' -DMBEDTLS_CONFIG_FILE='\"full_config.h\"'"
+    # Make sure this feature is enabled. We'll disable it in the next phase.
     programs/test/query_compile_time_config MBEDTLS_NIST_KW_C
     make clean
 
@@ -2644,6 +2645,7 @@ component_build_psa_config_file () {
     cp "$CRYPTO_CONFIG_H" psa_test_config.h
     echo '#error "MBEDTLS_PSA_CRYPTO_CONFIG_FILE is not working"' >"$CRYPTO_CONFIG_H"
     make CFLAGS="-I '$PWD' -DMBEDTLS_PSA_CRYPTO_CONFIG_FILE='\"psa_test_config.h\"'"
+    # Make sure this feature is enabled. We'll disable it in the next phase.
     programs/test/query_compile_time_config MBEDTLS_CMAC_C
     make clean
 

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -2638,6 +2638,26 @@ component_build_mbedtls_config_file () {
     rm -f user_config.h full_config.h
 }
 
+component_build_psa_config_file () {
+    msg "build: make with MBEDTLS_PSA_CRYPTO_CONFIG_FILE" # ~40s
+    scripts/config.py set MBEDTLS_PSA_CRYPTO_CONFIG
+    cp "$CRYPTO_CONFIG_H" psa_test_config.h
+    echo '#error "MBEDTLS_PSA_CRYPTO_CONFIG_FILE is not working"' >"$CRYPTO_CONFIG_H"
+    make CFLAGS="-I '$PWD' -DMBEDTLS_PSA_CRYPTO_CONFIG_FILE='\"psa_test_config.h\"'"
+    programs/test/query_compile_time_config MBEDTLS_CMAC_C
+    make clean
+
+    msg "build: make with MBEDTLS_PSA_CRYPTO_CONFIG_FILE + MBEDTLS_PSA_CRYPTO_USER_CONFIG_FILE" # ~40s
+    # In the user config, disable one feature, which will reflect on the
+    # mbedtls configuration so we can query it with query_compile_time_config.
+    echo '#undef PSA_WANT_ALG_CMAC' >psa_user_config.h
+    scripts/config.py unset MBEDTLS_CMAC_C
+    make CFLAGS="-I '$PWD' -DMBEDTLS_PSA_CRYPTO_CONFIG_FILE='\"psa_test_config.h\"' -DMBEDTLS_PSA_CRYPTO_USER_CONFIG_FILE='\"psa_user_config.h\"'"
+    not programs/test/query_compile_time_config MBEDTLS_CMAC_C
+
+    rm -f psa_test_config.h psa_user_config.h
+}
+
 component_test_m32_o0 () {
     # Build without optimization, so as to use portable C code (in a 32-bit
     # build) and not the i386-specific inline assembly.

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -2624,8 +2624,7 @@ component_build_mbedtls_config_file () {
     msg "build: make with MBEDTLS_CONFIG_FILE" # ~40s
     # Use the full config so as to catch a maximum of places where
     # the check of MBEDTLS_CONFIG_FILE might be missing.
-    scripts/config.py full
-    sed 's!"check_config.h"!"mbedtls/check_config.h"!' <"$CONFIG_H" >full_config.h
+    scripts/config.py -w full_config.h full
     echo '#error "MBEDTLS_CONFIG_FILE is not working"' >"$CONFIG_H"
     make CFLAGS="-I '$PWD' -DMBEDTLS_CONFIG_FILE='\"full_config.h\"'"
     rm -f full_config.h

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -2625,7 +2625,17 @@ component_build_mbedtls_config_file () {
     scripts/config.py -w full_config.h full
     echo '#error "MBEDTLS_CONFIG_FILE is not working"' >"$CONFIG_H"
     make CFLAGS="-I '$PWD' -DMBEDTLS_CONFIG_FILE='\"full_config.h\"'"
-    rm -f full_config.h
+    programs/test/query_compile_time_config MBEDTLS_NIST_KW_C
+    make clean
+
+    msg "build: make with MBEDTLS_CONFIG_FILE + MBEDTLS_USER_CONFIG_FILE"
+    # In the user config, disable one feature (for simplicity, pick a feature
+    # that nothing else depends on).
+    echo '#undef MBEDTLS_NIST_KW_C' >user_config.h
+    make CFLAGS="-I '$PWD' -DMBEDTLS_CONFIG_FILE='\"full_config.h\"' -DMBEDTLS_USER_CONFIG_FILE='\"user_config.h\"'"
+    not programs/test/query_compile_time_config MBEDTLS_NIST_KW_C
+
+    rm -f user_config.h full_config.h
 }
 
 component_test_m32_o0 () {


### PR DESCRIPTION
Complete backport of https://github.com/Mbed-TLS/mbedtls/pull/5654 with the new PSA config file macros as well as the documentation and test improvements.

We don't normally backport new features, but this one has no impact on users who don't use it (e.g. no impact on code size) and minimal risk of bugs (unlikely to cause a bug if you don't use it). In maintenance terms, it's an additional thing, but we want to use it to simplify testing in a way that applies to both 3.x and 2.28, so it's easier on balance to have the feature in 2.28.
