### PR TITLE
Add missing local variable initialization

### DIFF
--- a/library/ecp.c
+++ b/library/ecp.c
@@ -1817,7 +1817,7 @@ static int ecp_precompute_comb( const mbedtls_ecp_group *grp,
     unsigned char i;
     size_t j = 0;
     const unsigned char T_size = 1U << ( w - 1 );
-    mbedtls_ecp_point *cur, *TT[COMB_MAX_PRE - 1];
+    mbedtls_ecp_point *cur, *TT[COMB_MAX_PRE - 1] = {NULL};
 
     mbedtls_mpi tmp[4];
 

--- a/library/gcm.c
+++ b/library/gcm.c
@@ -430,7 +430,7 @@ int mbedtls_gcm_update( mbedtls_gcm_context *ctx,
     const unsigned char *p = input;
     unsigned char *out_p = output;
     size_t offset;
-    unsigned char ectr[16];
+    unsigned char ectr[16] = {0};
 
     if( output_size < input_length )
         return( MBEDTLS_ERR_GCM_BUFFER_TOO_SMALL );

--- a/library/pkcs12.c
+++ b/library/pkcs12.c
@@ -218,7 +218,7 @@ int mbedtls_pkcs12_derivation( unsigned char *data, size_t datalen,
     unsigned int j;
 
     unsigned char diversifier[128];
-    unsigned char salt_block[128], pwd_block[128], hash_block[128];
+    unsigned char salt_block[128], pwd_block[128], hash_block[128] = {0};
     unsigned char hash_output[MBEDTLS_MD_MAX_SIZE];
     unsigned char *p;
     unsigned char c;

--- a/library/pkparse.c
+++ b/library/pkparse.c
@@ -866,7 +866,7 @@ static int pk_parse_key_sec1_der( mbedtls_ecp_keypair *eck,
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     int version, pubkey_done;
     size_t len;
-    mbedtls_asn1_buf params;
+    mbedtls_asn1_buf params = { 0, 0, NULL };
     unsigned char *p = (unsigned char *) key;
     unsigned char *end = p + keylen;
     unsigned char *end2;

--- a/library/rsa.c
+++ b/library/rsa.c
@@ -1965,7 +1965,7 @@ int mbedtls_rsa_rsassa_pss_verify_ext( mbedtls_rsa_context *ctx,
     size_t observed_salt_len, msb;
     const mbedtls_md_info_t *md_info;
     mbedtls_md_context_t md_ctx;
-    unsigned char buf[MBEDTLS_MPI_MAX_SIZE];
+    unsigned char buf[MBEDTLS_MPI_MAX_SIZE] = {0};
 
     RSA_VALIDATE_RET( ctx != NULL );
     RSA_VALIDATE_RET( sig != NULL );

--- a/library/ssl_ticket.c
+++ b/library/ssl_ticket.c
@@ -70,7 +70,7 @@ static int ssl_ticket_gen_key( mbedtls_ssl_ticket_context *ctx,
                                unsigned char index )
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
-    unsigned char buf[MAX_KEY_BYTES];
+    unsigned char buf[MAX_KEY_BYTES] = {0};
     mbedtls_ssl_ticket_key *key = ctx->keys + index;
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)


### PR DESCRIPTION
These issues were flagged by Coverity static code analyzer for
instances that a local variable may be used prior to being initialized.

Partially continuing from https://github.com/Mbed-TLS/mbedtls/pull/5700.