### PR TITLE
Avoid potentially passing NULL arguments

### DIFF
--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -3203,6 +3203,12 @@ curve_matching_done:
 #if defined(MBEDTLS_KEY_EXCHANGE_WITH_SERVER_SIGNATURE_ENABLED)
     if( mbedtls_ssl_ciphersuite_uses_server_signature( ciphersuite_info ) )
     {
+        if( dig_signed == NULL )
+        {
+            MBEDTLS_SSL_DEBUG_MSG( 1, ( "should never happen" ) );
+            return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+        }
+
         size_t dig_signed_len = ssl->out_msg + ssl->out_msglen - dig_signed;
         size_t hashlen = 0;
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
@@ -3241,12 +3247,6 @@ curve_matching_done:
          */
         if( md_alg != MBEDTLS_MD_NONE )
         {
-            if( dig_signed == NULL )
-            {
-                MBEDTLS_SSL_DEBUG_MSG( 1, ( "should never happen" ) );
-                return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
-            }
-
             ret = mbedtls_ssl_get_key_exchange_md_tls1_2( ssl, hash, &hashlen,
                                                           dig_signed,
                                                           dig_signed_len,

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -2858,7 +2858,7 @@ static int ssl_get_ecdh_params_from_cert( mbedtls_ssl_context *ssl )
     const mbedtls_pk_context *private_key = mbedtls_ssl_own_key( ssl );
     if( private_key == NULL)
     {
-        MBEDTLS_SSL_DEBUG_MSG( 1, ( "got no ECDH private key" ) );
+        MBEDTLS_SSL_DEBUG_MSG( 1, ( "got no server private key" ) );
         return( MBEDTLS_ERR_SSL_PRIVATE_KEY_REQUIRED );
     }
 


### PR DESCRIPTION
Several call sites flagged by Coverity that may potentially cause
a pointer argument to be NULL.

In two cases the issue is using a function call as a parameter to
a second function, where the first function may return NULL, while
the second function does not check for the NULL argument value.

Remaining case is when static configuration is mixed with run-time
decision, that could result in a data buffer argument being NULL.

Partially continuing from https://github.com/Mbed-TLS/mbedtls/pull/5700.