### PR TITLE
Use QueryPerformanceCounter as fallback timer on non-x86 mingw

### DIFF
--- a/programs/test/benchmark.c
+++ b/programs/test/benchmark.c
@@ -362,7 +362,7 @@ static unsigned long mbedtls_timing_hardclock( void )
 #endif /* !HAVE_HARDCLOCK && MBEDTLS_HAVE_ASM &&
           __GNUC__ && __ia64__ */
 
-#if !defined(HAVE_HARDCLOCK) && defined(_MSC_VER) && \
+#if !defined(HAVE_HARDCLOCK) && defined(_WIN32) && \
     !defined(EFIX64) && !defined(EFI32)
 
 #define HAVE_HARDCLOCK
@@ -375,7 +375,7 @@ static unsigned long mbedtls_timing_hardclock( void )
 
     return( (unsigned long)( offset.QuadPart ) );
 }
-#endif /* !HAVE_HARDCLOCK && _MSC_VER && !EFIX64 && !EFI32 */
+#endif /* !HAVE_HARDCLOCK && _WIN32 && !EFIX64 && !EFI32 */
 
 #if !defined(HAVE_HARDCLOCK)
 


### PR DESCRIPTION
The `QueryPerformanceCounter` implementation previously was within `defined(_MSC_VER)`, but it works just as well on other Windows toolchains, like mingw.

For most common mingw x86 build configurations, one of the earlier inline assembly implementations would end up used, but for non-x86 (arm, aarch64), it would end up falling back on the `gettimeofday` implementation.

This implementation did build successfully (as mingw toolchains do provide `gettimeofday`, contrary to MSVC), but the header providing gettimeofday, `<sys/time.h>`, wasn't ever included when building targeting Windows - thus the function was called without a proper declaration.

Clang 15 changes such implicit function declarations into a hard error by default, when building in C99 mode (or newer) [1]. (While Clang 15 still is under development, this may still change before it's released, but it's a valid issue in any case.)

[1] https://github.com/llvm/llvm-project/commit/7d644e1215b376ec5e915df9ea2eeb56e2d94626

