### PR TITLE
Fix undeclared dependencies: MD

### DIFF
--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -153,6 +153,18 @@
 #error "MBEDTLS_PKCS5_C defined, but not all prerequesites"
 #endif
 
+#if defined(MBEDTLS_PKCS12_C) && !defined(MBEDTLS_MD_C)
+#error "MBEDTLS_PKCS12_C defined, but not all prerequesites"
+#endif
+
+#if defined(MBEDTLS_PKCS1_V15) && !defined(MBEDTLS_MD_C)
+#error "MBEDTLS_PKCS1_V15 defined, but not all prerequesites"
+#endif
+
+#if defined(MBEDTLS_PKCS1_V21) && !defined(MBEDTLS_MD_C)
+#error "MBEDTLS_PKCS1_V21 defined, but not all prerequesites"
+#endif
+
 #if defined(MBEDTLS_ENTROPY_C) && (!defined(MBEDTLS_SHA512_C) &&      \
                                     !defined(MBEDTLS_SHA256_C))
 #error "MBEDTLS_ENTROPY_C defined, but not all prerequisites"
@@ -342,7 +354,7 @@
 #endif
 
 #if defined(MBEDTLS_PK_C) && \
-    ( !defined(MBEDTLS_RSA_C) && !defined(MBEDTLS_ECP_C) )
+    ( !defined(MBEDTLS_MD_C) || ( !defined(MBEDTLS_RSA_C) && !defined(MBEDTLS_ECP_C) ) )
 #error "MBEDTLS_PK_C defined, but not all prerequisites"
 #endif
 

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -1129,7 +1129,7 @@
  *
  * Enable support for PKCS#1 v1.5 encoding.
  *
- * Requires: MBEDTLS_RSA_C
+ * Requires: MBEDTLS_MD_C, MBEDTLS_RSA_C
  *
  * This enables support for PKCS#1 v1.5 operations.
  */
@@ -2390,7 +2390,24 @@
  * Enable the generic message digest layer.
  *
  * Module:  library/md.c
- * Caller:
+ * Caller:  library/constant_time.c
+ *          library/ecdsa.c
+ *          library/ecjpake.c
+ *          library/hkdf.c
+ *          library/hmac_drbg.c
+ *          library/oid.c
+ *          library/pk.c
+ *          library/pkcs5.c
+ *          library/pkcs12.c
+ *          library/psa_crypto_ecp.c
+ *          library/psa_crypto_rsa.c
+ *          library/rsa.c
+ *          library/ssl_cookie.c
+ *          library/ssl_msg.c
+ *          library/ssl_tls.c
+ *          library/x509_crt.c
+ *          library/x509write_crt.c
+ *          library/x509write_csr.c
  *
  * Uncomment to enable generic message digest wrappers.
  */
@@ -2535,7 +2552,7 @@
  *          library/ssl*_server.c
  *          library/x509.c
  *
- * Requires: MBEDTLS_RSA_C or MBEDTLS_ECP_C
+ * Requires: MBEDTLS_MD_C, MBEDTLS_RSA_C or MBEDTLS_ECP_C
  *
  * Uncomment to enable generic public key wrappers.
  */

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -2395,7 +2395,6 @@
  *          library/ecjpake.c
  *          library/hkdf.c
  *          library/hmac_drbg.c
- *          library/oid.c
  *          library/pk.c
  *          library/pkcs5.c
  *          library/pkcs12.c
@@ -2405,6 +2404,7 @@
  *          library/ssl_cookie.c
  *          library/ssl_msg.c
  *          library/ssl_tls.c
+ *          library/x509.c
  *          library/x509_crt.c
  *          library/x509write_crt.c
  *          library/x509write_csr.c

--- a/library/rsa.c
+++ b/library/rsa.c
@@ -49,10 +49,6 @@
 
 #include <string.h>
 
-#if defined(MBEDTLS_PKCS1_V21)
-#include "mbedtls/md.h"
-#endif
-
 #if defined(MBEDTLS_PKCS1_V15) && !defined(__OpenBSD__) && !defined(__NetBSD__)
 #include <stdlib.h>
 #endif

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1197,6 +1197,28 @@ component_test_psa_external_rng_no_drbg_use_psa () {
     tests/ssl-opt.sh -f 'Default\|opaque'
 }
 
+component_test_crypto_full_no_md () {
+    msg "build: crypto_full minus MD"
+    scripts/config.py crypto_full
+    scripts/config.py unset MBEDTLS_MD_C
+    scripts/config.py unset MBEDTLS_ECJPAKE_C
+    scripts/config.py unset MBEDTLS_PKCS5_C
+    scripts/config.py unset MBEDTLS_PKCS12_C
+    scripts/config.py unset MBEDTLS_PKCS1_V15
+    scripts/config.py unset MBEDTLS_PKCS1_V21
+    scripts/config.py unset MBEDTLS_HKDF_C
+    scripts/config.py unset MBEDTLS_HMAC_DRBG_C
+    scripts/config.py unset MBEDTLS_PK_C
+    scripts/config.py unset MBEDTLS_ECDSA_DETERMINISTIC
+    scripts/config.py unset MBEDTLS_PK_PARSE_C
+    scripts/config.py unset MBEDTLS_PK_WRITE_C
+    scripts/config.py unset MBEDTLS_RSA_C
+    make
+
+    msg "test: crypto_full minus MD"
+    make test
+}
+
 component_test_psa_external_rng_use_psa_crypto () {
     msg "build: full + PSA_CRYPTO_EXTERNAL_RNG + USE_PSA_CRYPTO minus CTR_DRBG"
     scripts/config.py full

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1201,14 +1201,16 @@ component_test_crypto_full_no_md () {
     msg "build: crypto_full minus MD"
     scripts/config.py crypto_full
     scripts/config.py unset MBEDTLS_MD_C
+    # Direct dependencies
     scripts/config.py unset MBEDTLS_ECJPAKE_C
-    scripts/config.py unset MBEDTLS_PKCS5_C
-    scripts/config.py unset MBEDTLS_PKCS12_C
-    scripts/config.py unset MBEDTLS_PKCS1_V15
-    scripts/config.py unset MBEDTLS_PKCS1_V21
     scripts/config.py unset MBEDTLS_HKDF_C
     scripts/config.py unset MBEDTLS_HMAC_DRBG_C
     scripts/config.py unset MBEDTLS_PK_C
+    scripts/config.py unset MBEDTLS_PKCS1_V15
+    scripts/config.py unset MBEDTLS_PKCS1_V21
+    scripts/config.py unset MBEDTLS_PKCS5_C
+    scripts/config.py unset MBEDTLS_PKCS12_C
+    # Indirect dependencies
     scripts/config.py unset MBEDTLS_ECDSA_DETERMINISTIC
     scripts/config.py unset MBEDTLS_PK_PARSE_C
     scripts/config.py unset MBEDTLS_PK_WRITE_C

--- a/tests/scripts/generate_psa_tests.py
+++ b/tests/scripts/generate_psa_tests.py
@@ -165,6 +165,7 @@ class NotSupported:
     ALWAYS_SUPPORTED = frozenset([
         'PSA_KEY_TYPE_DERIVE',
         'PSA_KEY_TYPE_RAW_DATA',
+        'PSA_KEY_TYPE_HMAC'
     ])
     def test_cases_for_key_type_not_supported(
             self,

--- a/tests/suites/test_suite_oid.function
+++ b/tests/suites/test_suite_oid.function
@@ -82,7 +82,7 @@ void oid_get_x509_extension( data_t *oid, int exp_type )
 }
 /* END_CASE */
 
-/* BEGIN_CASE */
+/* BEGIN_CASE depends_on:MBEDTLS_MD_C */
 void oid_get_md_alg_id( data_t *oid, int exp_md_id )
 {
     mbedtls_asn1_buf md_oid = { 0, 0, NULL };

--- a/tests/suites/test_suite_psa_crypto_se_driver_hal.function
+++ b/tests/suites/test_suite_psa_crypto_se_driver_hal.function
@@ -170,6 +170,7 @@ static psa_status_t counter_allocate( psa_drv_se_context_t *context,
 }
 
 /* Null import: do nothing, but pretend it worked. */
+#if defined(AT_LEAST_ONE_BUILTIN_KDF)
 static psa_status_t null_import( psa_drv_se_context_t *context,
                                  psa_key_slot_number_t slot_number,
                                  const psa_key_attributes_t *attributes,
@@ -186,8 +187,10 @@ static psa_status_t null_import( psa_drv_se_context_t *context,
     *bits = PSA_BYTES_TO_BITS( data_length );
     return( PSA_SUCCESS );
 }
+#endif /* AT_LEAST_ONE_BUILTIN_KDF */
 
 /* Null generate: do nothing, but pretend it worked. */
+#if defined(AT_LEAST_ONE_BUILTIN_KDF)
 static psa_status_t null_generate( psa_drv_se_context_t *context,
                                    psa_key_slot_number_t slot_number,
                                    const psa_key_attributes_t *attributes,
@@ -208,6 +211,7 @@ static psa_status_t null_generate( psa_drv_se_context_t *context,
 
     return( PSA_SUCCESS );
 }
+#endif /* AT_LEAST_ONE_BUILTIN_KDF */
 
 /* Null destroy: do nothing, but pretend it worked. */
 static psa_status_t null_destroy( psa_drv_se_context_t *context,
@@ -635,6 +639,7 @@ exit:
 /* Check that a function's return status is "smoke-free", i.e. that
  * it's an acceptable error code when calling an API function that operates
  * on a key with potentially bogus parameters. */
+#if defined(AT_LEAST_ONE_BUILTIN_KDF)
 static int is_status_smoke_free( psa_status_t status )
 {
     switch( status )
@@ -651,6 +656,8 @@ static int is_status_smoke_free( psa_status_t status )
             return( 0 );
     }
 }
+#endif /* AT_LEAST_ONE_BUILTIN_KDF */
+
 #define SMOKE_ASSERT( expr )                    \
     TEST_ASSERT( is_status_smoke_free( expr ) )
 
@@ -658,6 +665,7 @@ static int is_status_smoke_free( psa_status_t status )
  * mostly bogus parameters: the goal is to ensure that there is no memory
  * corruption or crash. This test function is most useful when run under
  * an environment with sanity checks such as ASan or MSan. */
+#if defined(AT_LEAST_ONE_BUILTIN_KDF)
 static int smoke_test_key( mbedtls_svc_key_id_t key )
 {
     int ok = 0;
@@ -766,6 +774,7 @@ exit:
 
     return( ok );
 }
+#endif /* AT_LEAST_ONE_BUILTIN_KDF */
 
 static void psa_purge_storage( void )
 {
@@ -1073,7 +1082,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE */
+/* BEGIN_CASE depends_on:AT_LEAST_ONE_BUILTIN_KDF */
 void import_key_smoke( int type_arg, int alg_arg,
                        data_t *key_material )
 {
@@ -1186,7 +1195,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE */
+/* BEGIN_CASE depends_on:AT_LEAST_ONE_BUILTIN_KDF */
 void generate_key_smoke( int type_arg, int bits_arg, int alg_arg )
 {
     psa_key_type_t type = type_arg;

--- a/tests/suites/test_suite_x509parse.function
+++ b/tests/suites/test_suite_x509parse.function
@@ -87,7 +87,7 @@ int ca_callback_fail( void *data, mbedtls_x509_crt const *child, mbedtls_x509_cr
 
     return -1;
 }
-
+#if defined(MBEDTLS_X509_CRT_PARSE_C)
 int ca_callback( void *data, mbedtls_x509_crt const *child,
                  mbedtls_x509_crt **candidates )
 {
@@ -141,6 +141,7 @@ exit:
     *candidates = first;
     return( ret );
 }
+#endif /* MBEDTLS_X509_CRT_PARSE_C */
 #endif /* MBEDTLS_X509_TRUSTED_CERTIFICATE_CALLBACK */
 
 int verify_fatal( void *data, mbedtls_x509_crt *crt, int certificate_depth, uint32_t *flags )


### PR DESCRIPTION
## Description

Adapt dependencies on `MBEDTLS_MD_C`.
Resolves: https://github.com/Mbed-TLS/mbedtls/issues/5715

Starting from full config to disable `MBEDTLS_MD_C` we need to disable the following dependent features:
- `[MBEDTLS_MD_C]`
- `['MBEDTLS_ECJPAKE_C', 'MBEDTLS_PKCS5_C', 'MBEDTLS_PKCS12_C', 'MBEDTLS_PKCS1_V15', 'MBEDTLS_PKCS1_V21', 'MBEDTLS_HKDF_C', 'MBEDTLS_HMAC_DRBG_C', 'MBEDTLS_PK_C', 'MBEDTLS_SSL_TLS_C']`
- `['MBEDTLS_ECDSA_DETERMINISTIC', 'MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED', 'MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED', 'MBEDTLS_KEY_EXCHANGE_RSA_PSK_ENABLED', 'MBEDTLS_KEY_EXCHANGE_RSA_ENABLED', 'MBEDTLS_PK_PARSE_C', 'MBEDTLS_PK_WRITE_C', 'MBEDTLS_RSA_C', 'MBEDTLS_X509_RSASSA_PSS_SUPPORT', 'MBEDTLS_SSL_CLI_C', 'MBEDTLS_SSL_SRV_C', 'MBEDTLS_SSL_DTLS_ANTI_REPLAY']`
- `['MBEDTLS_KEY_EXCHANGE_ECDH_RSA_ENABLED', 'MBEDTLS_X509_USE_C', 'MBEDTLS_X509_CREATE_C']`
- `['MBEDTLS_X509_CRT_PARSE_C', 'MBEDTLS_X509_CRL_PARSE_C', 'MBEDTLS_X509_CSR_PARSE_C', 'MBEDTLS_X509_CRT_WRITE_C', 'MBEDTLS_X509_CSR_WRITE_C']`
- `['MBEDTLS_KEY_EXCHANGE_ECDH_ECDSA_ENABLED', 'MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED', 'MBEDTLS_SSL_SERVER_NAME_INDICATION']`

Now with few additional fixes in code (see changes) we are able to build library and tests.

Also fixed dependencies in few tests and with these changes all are passing, but one (`test_suite_psa_crypto_not_supported.generated`):

Need to take closer look. 
`psa_import/generate_key` is expected to fail with `PSA_ERROR_NOT_SUPPORTED`, but passes somehow.
Tests depend on `!PSA_WANT_KEY_TYPE_HMAC`.

```
PSA import HMAC 128-bit not supported ............................. FAILED
  psa_import_key( &attributes, key_material->x, key_material->len, &key_id ) == PSA_ERROR_NOT_SUPPORTED
  at line 233, test_suite_psa_crypto_not_supported.generated.c
  lhs = 0x0000000000000000 = 0
  rhs = 0xffffffffffffff7a = -134
PSA generate HMAC 128-bit not supported ........................... FAILED
  psa_generate_key( &attributes, &key_id ) == PSA_ERROR_NOT_SUPPORTED
  at line 259, test_suite_psa_crypto_not_supported.generated.c
  lhs = 0x0000000000000000 = 0
  rhs = 0xffffffffffffff7a = -134
PSA import HMAC 160-bit not supported ............................. FAILED
  psa_import_key( &attributes, key_material->x, key_material->len, &key_id ) == PSA_ERROR_NOT_SUPPORTED
  at line 233, test_suite_psa_crypto_not_supported.generated.c
  lhs = 0x0000000000000000 = 0
  rhs = 0xffffffffffffff7a = -134
PSA generate HMAC 160-bit not supported ........................... FAILED
  psa_generate_key( &attributes, &key_id ) == PSA_ERROR_NOT_SUPPORTED
  at line 259, test_suite_psa_crypto_not_supported.generated.c
  lhs = 0x0000000000000000 = 0
  rhs = 0xffffffffffffff7a = -134
PSA import HMAC 224-bit not supported ............................. FAILED
  psa_import_key( &attributes, key_material->x, key_material->len, &key_id ) == PSA_ERROR_NOT_SUPPORTED
  at line 233, test_suite_psa_crypto_not_supported.generated.c
  lhs = 0x0000000000000000 = 0
  rhs = 0xffffffffffffff7a = -134
PSA generate HMAC 224-bit not supported ........................... FAILED
  psa_generate_key( &attributes, &key_id ) == PSA_ERROR_NOT_SUPPORTED
  at line 259, test_suite_psa_crypto_not_supported.generated.c
  lhs = 0x0000000000000000 = 0
  rhs = 0xffffffffffffff7a = -134
PSA import HMAC 256-bit not supported ............................. FAILED
  psa_import_key( &attributes, key_material->x, key_material->len, &key_id ) == PSA_ERROR_NOT_SUPPORTED
  at line 233, test_suite_psa_crypto_not_supported.generated.c
  lhs = 0x0000000000000000 = 0
  rhs = 0xffffffffffffff7a = -134
PSA generate HMAC 256-bit not supported ........................... FAILED
  psa_generate_key( &attributes, &key_id ) == PSA_ERROR_NOT_SUPPORTED
  at line 259, test_suite_psa_crypto_not_supported.generated.c
  lhs = 0x0000000000000000 = 0
  rhs = 0xffffffffffffff7a = -134
PSA import HMAC 384-bit not supported ............................. FAILED
  psa_import_key( &attributes, key_material->x, key_material->len, &key_id ) == PSA_ERROR_NOT_SUPPORTED
  at line 233, test_suite_psa_crypto_not_supported.generated.c
  lhs = 0x0000000000000000 = 0
  rhs = 0xffffffffffffff7a = -134
PSA generate HMAC 384-bit not supported ........................... FAILED
  psa_generate_key( &attributes, &key_id ) == PSA_ERROR_NOT_SUPPORTED
  at line 259, test_suite_psa_crypto_not_supported.generated.c
  lhs = 0x0000000000000000 = 0
  rhs = 0xffffffffffffff7a = -134
PSA import HMAC 512-bit not supported ............................. FAILED
  psa_import_key( &attributes, key_material->x, key_material->len, &key_id ) == PSA_ERROR_NOT_SUPPORTED
  at line 233, test_suite_psa_crypto_not_supported.generated.c
  lhs = 0x0000000000000000 = 0
  rhs = 0xffffffffffffff7a = -134
PSA generate HMAC 512-bit not supported ........................... FAILED
  psa_generate_key( &attributes, &key_id ) == PSA_ERROR_NOT_SUPPORTED
  at line 259, test_suite_psa_crypto_not_supported.generated.c
  lhs = 0x0000000000000000 = 0
  rhs = 0xffffffffffffff7a = -134
```

## Status
**IN DEVELOPMENT**

## Requires Backporting
Yes 
2.28

## Additional comments
Any additional information that could be of interest

## Todos
- [x] Tests
- [x] Documentation
- [x] Changelog updated
- [ ] Backported
- [x] Component in all.sh
