### PR TITLE
[Backport 2.28] Fix memcpy() UB in mbedtls_asn1_named_data()

### DIFF
--- a/ChangeLog.d/fix-undefined-memcpy-mbedtls_asn1_named_data.txt
+++ b/ChangeLog.d/fix-undefined-memcpy-mbedtls_asn1_named_data.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix undefined behavior in mbedtls_asn1_find_named_data(), where val is
+     not NULL and val_len is zero.

--- a/library/asn1write.c
+++ b/library/asn1write.c
@@ -472,7 +472,7 @@ mbedtls_asn1_named_data *mbedtls_asn1_store_named_data(
         cur->val.len = val_len;
     }
 
-    if( val != NULL )
+    if( val != NULL && val_len != 0 )
         memcpy( cur->val.p, val, val_len );
 
     return( cur );

--- a/tests/suites/test_suite_asn1write.data
+++ b/tests/suites/test_suite_asn1write.data
@@ -374,10 +374,13 @@ Store named data: found, larger data
 store_named_data_val_found:4:9
 
 Store named data: new, val_len=0
-store_named_data_val_new:0
+store_named_data_val_new:0:1
+
+Stored named data: new, val_len=0, val=NULL
+store_named_data_val_new:0:0
 
 Store named data: new, val_len=4
-store_named_data_val_new:4
+store_named_data_val_new:4:1
 
 Store named data: new, val_len=4, val=NULL
-store_named_data_val_new:-4
+store_named_data_val_new:4:0

--- a/tests/suites/test_suite_asn1write.function
+++ b/tests/suites/test_suite_asn1write.function
@@ -431,7 +431,7 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE */
-void store_named_data_val_new( int new_len )
+void store_named_data_val_new( int new_len, int set_new_val )
 {
     mbedtls_asn1_named_data *head = NULL;
     mbedtls_asn1_named_data *found = NULL;
@@ -439,10 +439,8 @@ void store_named_data_val_new( int new_len )
     size_t oid_len = strlen( (const char *) oid );
     const unsigned char *new_val = (unsigned char *) "new value";
 
-    if( new_len <= 0 )
+    if( set_new_val == 0 )
         new_val = NULL;
-    if( new_len < 0 )
-        new_len = - new_len;
 
     found = mbedtls_asn1_store_named_data( &head,
                                            (const char *) oid, oid_len,


### PR DESCRIPTION
Backport of #5801, tested locally with the same commands.