### PR TITLE
Remove Cipher dependencies in TLS

### DIFF
--- a/library/ssl_ciphersuites.c
+++ b/library/ssl_ciphersuites.c
@@ -1876,7 +1876,21 @@ int mbedtls_ssl_get_ciphersuite_id( const char *ciphersuite_name )
 
 size_t mbedtls_ssl_ciphersuite_get_cipher_key_bitlen( const mbedtls_ssl_ciphersuite_t *info )
 {
-#if defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
+    psa_key_type_t key_type;
+    psa_algorithm_t alg;
+    size_t key_bits;
+
+    status = mbedtls_ssl_cipher_to_psa( info->cipher,
+                        info->flags & MBEDTLS_CIPHERSUITE_SHORT_TAG ? 8 : 16,
+                        &alg, &key_type, &key_bits );
+
+    if( status != PSA_SUCCESS )
+        return 0;
+
+    return key_bits;
+#elif defined(MBEDTLS_CIPHER_C)
     const mbedtls_cipher_info_t * const cipher_info =
       mbedtls_cipher_info_from_type( info->cipher );
 

--- a/library/ssl_ciphersuites.c
+++ b/library/ssl_ciphersuites.c
@@ -1890,15 +1890,12 @@ size_t mbedtls_ssl_ciphersuite_get_cipher_key_bitlen( const mbedtls_ssl_ciphersu
         return 0;
 
     return key_bits;
-#elif defined(MBEDTLS_CIPHER_C)
+#else
     const mbedtls_cipher_info_t * const cipher_info =
       mbedtls_cipher_info_from_type( info->cipher );
 
     return( mbedtls_cipher_info_get_key_bitlen( cipher_info ) );
-#else
-    (void)info;
-    return( 0 );
-#endif
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 }
 
 #if defined(MBEDTLS_PK_C)

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -2137,7 +2137,7 @@ static inline int mbedtls_ssl_sig_alg_is_supported(
 }
 #endif /* MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED */
 
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
+#if defined(MBEDTLS_USE_PSA_CRYPTO) || defined(MBEDTLS_SSL_PROTO_TLS1_3)
 /* Corresponding PSA algorithm for MBEDTLS_CIPHER_NULL.
  * Same value is used for PSA_ALG_CATEGORY_CIPHER, hence it is
  * guaranteed to not be a valid PSA algorithm identifier.
@@ -2167,9 +2167,7 @@ psa_status_t mbedtls_ssl_cipher_to_psa( mbedtls_cipher_type_t mbedtls_cipher_typ
                                     psa_algorithm_t *alg,
                                     psa_key_type_t *key_type,
                                     size_t *key_size );
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
-#if defined(MBEDTLS_USE_PSA_CRYPTO) || defined(MBEDTLS_SSL_PROTO_TLS1_3)
 /**
  * \brief       Convert given PSA status to mbedtls error code.
  *

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1838,7 +1838,7 @@ mbedtls_ssl_mode_t mbedtls_ssl_get_mode_from_ciphersuite(
     return( mbedtls_ssl_get_actual_mode( base_mode, encrypt_then_mac ) );
 }
 
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
+#if defined(MBEDTLS_USE_PSA_CRYPTO) || defined(MBEDTLS_SSL_PROTO_TLS1_3)
 psa_status_t mbedtls_ssl_cipher_to_psa( mbedtls_cipher_type_t mbedtls_cipher_type,
                                     size_t taglen,
                                     psa_algorithm_t *alg,
@@ -1983,7 +1983,7 @@ psa_status_t mbedtls_ssl_cipher_to_psa( mbedtls_cipher_type_t mbedtls_cipher_typ
 
     return PSA_SUCCESS;
 }
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
+#endif /* MBEDTLS_USE_PSA_CRYPTO || MBEDTLS_SSL_PROTO_TLS1_3 */
 
 #if defined(MBEDTLS_DHM_C) && defined(MBEDTLS_SSL_SRV_C)
 int mbedtls_ssl_conf_dh_param_bin( mbedtls_ssl_config *conf,

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -1203,7 +1203,15 @@ int mbedtls_ssl_tls13_generate_handshake_keys( mbedtls_ssl_context *ssl,
     unsigned char transcript[MBEDTLS_TLS1_3_MD_MAX_SIZE];
     size_t transcript_len;
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_key_type_t key_type;
+    psa_algorithm_t alg;
+    size_t key_bits;
+    size_t taglen;
+    psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
+#else
     mbedtls_cipher_info_t const *cipher_info;
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
     size_t key_len, iv_len;
 
     mbedtls_ssl_handshake_params *handshake = ssl->handshake;
@@ -1212,9 +1220,32 @@ int mbedtls_ssl_tls13_generate_handshake_keys( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> mbedtls_ssl_tls13_generate_handshake_keys" ) );
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    if( ciphersuite_info->flags & MBEDTLS_CIPHERSUITE_SHORT_TAG )
+        taglen = 8;
+    else
+        taglen = 16;
+
+    status = mbedtls_ssl_cipher_to_psa( ciphersuite_info->cipher, taglen,
+                                        &alg, &key_type, &key_bits );
+    if( status != PSA_SUCCESS )
+    {
+        ret = psa_ssl_status_to_mbedtls( status );
+        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_cipher_to_psa", ret );
+        return ret;
+    }
+
+    key_len = PSA_BITS_TO_BYTES(key_bits);
+
+    if( PSA_ALG_IS_AEAD( alg ) )
+        iv_len = 12;
+    else
+        iv_len = PSA_CIPHER_IV_LENGTH( key_type, alg );
+#else
     cipher_info = mbedtls_cipher_info_from_type( ciphersuite_info->cipher );
     key_len = cipher_info->key_bitlen >> 3;
     iv_len = cipher_info->iv_size;
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     md_type = ciphersuite_info->mac;
 
@@ -1408,17 +1439,48 @@ int mbedtls_ssl_tls13_generate_application_keys(
     size_t hash_len;
 
     /* Variables relating to the cipher for the chosen ciphersuite. */
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_key_type_t key_type;
+    psa_algorithm_t alg;
+    size_t key_bits;
+    size_t taglen;
+    psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
+#else
     mbedtls_cipher_info_t const *cipher_info;
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
     size_t key_len, iv_len;
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> derive application traffic keys" ) );
 
     /* Extract basic information about hash and ciphersuite */
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    if( handshake->ciphersuite_info->flags & MBEDTLS_CIPHERSUITE_SHORT_TAG )
+        taglen = 8;
+    else
+        taglen = 16;
+
+    status = mbedtls_ssl_cipher_to_psa( handshake->ciphersuite_info->cipher,
+                                        taglen, &alg, &key_type, &key_bits );
+    if( status != PSA_SUCCESS )
+    {
+        ret = psa_ssl_status_to_mbedtls( status );
+        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_cipher_to_psa", ret );
+        goto cleanup;
+    }
+
+    key_len = PSA_BITS_TO_BYTES(key_bits);
+
+    if( PSA_ALG_IS_AEAD( alg ) )
+        iv_len = 12;
+    else
+        iv_len = PSA_CIPHER_IV_LENGTH( key_type, alg );
+#else
     cipher_info = mbedtls_cipher_info_from_type(
                                   handshake->ciphersuite_info->cipher );
     key_len = cipher_info->key_bitlen / 8;
     iv_len = cipher_info->iv_size;
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     md_type = handshake->ciphersuite_info->mac;
 

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -1203,15 +1203,11 @@ int mbedtls_ssl_tls13_generate_handshake_keys( mbedtls_ssl_context *ssl,
     unsigned char transcript[MBEDTLS_TLS1_3_MD_MAX_SIZE];
     size_t transcript_len;
 
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
     psa_key_type_t key_type;
     psa_algorithm_t alg;
     size_t key_bits;
     size_t taglen;
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
-#else
-    mbedtls_cipher_info_t const *cipher_info;
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
     size_t key_len, iv_len;
 
     mbedtls_ssl_handshake_params *handshake = ssl->handshake;
@@ -1220,7 +1216,6 @@ int mbedtls_ssl_tls13_generate_handshake_keys( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> mbedtls_ssl_tls13_generate_handshake_keys" ) );
 
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
     if( ciphersuite_info->flags & MBEDTLS_CIPHERSUITE_SHORT_TAG )
         taglen = 8;
     else
@@ -1241,11 +1236,6 @@ int mbedtls_ssl_tls13_generate_handshake_keys( mbedtls_ssl_context *ssl,
         iv_len = 12;
     else
         iv_len = PSA_CIPHER_IV_LENGTH( key_type, alg );
-#else
-    cipher_info = mbedtls_cipher_info_from_type( ciphersuite_info->cipher );
-    key_len = cipher_info->key_bitlen >> 3;
-    iv_len = cipher_info->iv_size;
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     md_type = ciphersuite_info->mac;
 
@@ -1439,22 +1429,17 @@ int mbedtls_ssl_tls13_generate_application_keys(
     size_t hash_len;
 
     /* Variables relating to the cipher for the chosen ciphersuite. */
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
     psa_key_type_t key_type;
     psa_algorithm_t alg;
     size_t key_bits;
     size_t taglen;
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
-#else
-    mbedtls_cipher_info_t const *cipher_info;
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
     size_t key_len, iv_len;
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> derive application traffic keys" ) );
 
     /* Extract basic information about hash and ciphersuite */
 
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
     if( handshake->ciphersuite_info->flags & MBEDTLS_CIPHERSUITE_SHORT_TAG )
         taglen = 8;
     else
@@ -1475,12 +1460,6 @@ int mbedtls_ssl_tls13_generate_application_keys(
         iv_len = 12;
     else
         iv_len = PSA_CIPHER_IV_LENGTH( key_type, alg );
-#else
-    cipher_info = mbedtls_cipher_info_from_type(
-                                  handshake->ciphersuite_info->cipher );
-    key_len = cipher_info->key_bitlen / 8;
-    iv_len = cipher_info->iv_size;
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     md_type = handshake->ciphersuite_info->mac;
 

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -1210,10 +1210,8 @@ static int mbedtls_ssl_tls13_get_cipher_key_info(
 
     *key_len = PSA_BITS_TO_BYTES( key_bits );
 
-    if( PSA_ALG_IS_AEAD( alg ) )
-        *iv_len = 12;
-    else
-        *iv_len = PSA_CIPHER_IV_LENGTH( key_type, alg );
+    /* TLS 1.3 only have AEAD ciphers, IV length is unconditionally 12 bytes */
+    *iv_len = 12;
 
     return 0;
 }

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -993,8 +993,8 @@ int mbedtls_ssl_tls13_populate_transform( mbedtls_ssl_transform *transform,
 {
 #if !defined(MBEDTLS_USE_PSA_CRYPTO)
     int ret;
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
     mbedtls_cipher_info_t const *cipher_info;
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
     const mbedtls_ssl_ciphersuite_t *ciphersuite_info;
     unsigned char const *key_enc;
     unsigned char const *iv_enc;
@@ -1022,6 +1022,7 @@ int mbedtls_ssl_tls13_populate_transform( mbedtls_ssl_transform *transform,
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
     }
 
+#if !defined(MBEDTLS_USE_PSA_CRYPTO)
     cipher_info = mbedtls_cipher_info_from_type( ciphersuite_info->cipher );
     if( cipher_info == NULL )
     {
@@ -1030,7 +1031,6 @@ int mbedtls_ssl_tls13_populate_transform( mbedtls_ssl_transform *transform,
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
     }
 
-#if !defined(MBEDTLS_USE_PSA_CRYPTO)
     /*
      * Setup cipher contexts in target transform
      */
@@ -1120,7 +1120,7 @@ int mbedtls_ssl_tls13_populate_transform( mbedtls_ssl_transform *transform,
     /*
      * Setup psa keys and alg
      */
-    if( ( status = mbedtls_ssl_cipher_to_psa( cipher_info->type,
+    if( ( status = mbedtls_ssl_cipher_to_psa( ciphersuite_info->cipher,
                                  transform->taglen,
                                  &alg,
                                  &key_type,

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -1235,7 +1235,7 @@ int mbedtls_ssl_tls13_generate_handshake_keys( mbedtls_ssl_context *ssl,
         return ret;
     }
 
-    key_len = PSA_BITS_TO_BYTES(key_bits);
+    key_len = PSA_BITS_TO_BYTES( key_bits );
 
     if( PSA_ALG_IS_AEAD( alg ) )
         iv_len = 12;
@@ -1469,7 +1469,7 @@ int mbedtls_ssl_tls13_generate_application_keys(
         goto cleanup;
     }
 
-    key_len = PSA_BITS_TO_BYTES(key_bits);
+    key_len = PSA_BITS_TO_BYTES( key_bits );
 
     if( PSA_ALG_IS_AEAD( alg ) )
         iv_len = 12;


### PR DESCRIPTION
## Description
Now that all uses of Cipher for cryptographic computations have been removed from TLS when USE_PSA is enabled, it is desirable to also remove non-cryptographic uses, such as getting sizes from a cipher ID (often from a ciphersuite definition).

This task is to remove such uses and replace them with versions based on PSA or at least independent from cipher.c.

Resolves: #5797 

## Status
**READY**

## Requires Backporting
NO  

## Migrations
NO

## Additional comments
N/A

## Todos
- [x] Tests

## Steps to test or reproduce
ssl-opt.sh must run clean
