### PR TITLE
Backport 2.28: Rotate coverity secret token in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ after_failure:
 env:
   global:
     - SEED=1
-    - secure: "FrI5d2s+ckckC17T66c8jm2jV6i2DkBPU5nyWzwbedjmEBeocREfQLd/x8yKpPzLDz7ghOvr+/GQvsPPn0dVkGlNzm3Q+hGHc/ujnASuUtGrcuMM+0ALnJ3k4rFr9xEvjJeWb4SmhJO5UCAZYvTItW4k7+bj9L+R6lt3TzQbXzg="
+    - secure: "JECCru6HASpKZ0OLfHh8f/KXhKkdrCwjquZghd/qbA4ksxsWImjR7KEPERcaPndXEilzhDbKwuFvJiQX2duVgTGoq745YGhLZIjzo1i8tySkceCVd48P8WceYGz+F/bmY7r+m6fFNuxDSoGGSVeA4Lnjvmm8PFUP45YodDV9no4="
 
 addons:
   apt:


### PR DESCRIPTION
## Description
Travis stopped being able to push builds to coverity due to the token apparently being no longer valid (could have to do with either the project rename or other apps rotating their travis tokens)

This PR rotates our coverity token to see if that fixes things.

This is a backport to 2.28 of #5803

## Status
**READY**

## Migrations
NO

## Additional comments
Note that travis secrets are encrypted using a project-based public key encryption - this is not the bare token. See https://docs.travis-ci.com/user/encryption-keys/

Note also that this secret is *only* used for pushes to coverity from Travis, therefore nothing in the CI run will test this functionality before it is merged. However, the push is currently already broken, so this won't make anything worse.

## Todos
- [ ] Tests

## Steps to test or reproduce
See Additional comments. Testing will have to take place after merge.