### PR TITLE
Fix key_id and owner_id accessor macros

### DIFF
--- a/include/psa/crypto_values.h
+++ b/include/psa/crypto_values.h
@@ -2269,8 +2269,8 @@ static inline int mbedtls_svc_key_id_is_null( mbedtls_svc_key_id_t key )
 #else /* MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER */
 
 #define MBEDTLS_SVC_KEY_ID_INIT ( (mbedtls_svc_key_id_t){ 0, 0 } )
-#define MBEDTLS_SVC_KEY_ID_GET_KEY_ID( id ) ( ( id ).key_id )
-#define MBEDTLS_SVC_KEY_ID_GET_OWNER_ID( id ) ( ( id ).owner )
+#define MBEDTLS_SVC_KEY_ID_GET_KEY_ID( id ) ( ( id ).MBEDTLS_PRIVATE(key_id) )
+#define MBEDTLS_SVC_KEY_ID_GET_OWNER_ID( id ) ( ( id ).MBEDTLS_PRIVATE(owner) )
 
 /** Utility to initialize a key identifier at runtime.
  *


### PR DESCRIPTION
## Description

The accessor macros for `key_id` and `owner_id` in the `mbedtls_svc_key_id_t`
type need to have the `MBEDTLS_PRIVATE()` specifier as these fields are private

Signed-off-by: Antonio de Angelis <antonio.deangelis@arm.com>

## Status
**READY**

## Requires Backporting

**NO** - `MBEDTLS_PRIVATE()` was added in 3.0

## Migrations
If there is any API change, what's the incentive and logic for it.

YES | NO

## Additional comments
Any additional information that could be of interest


## Steps to test or reproduce
Using those two macros results in build failures without this patch.
