### PR TITLE
Revert Coverity project name change in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ addons:
     - gnutls-bin
   coverity_scan:
     project:
-      name: "Mbed-TLS/mbedtls"
+      name: "ARMmbed/mbedtls"
     notification_email: support-mbedtls@arm.com
     build_command_prepend:
     build_command: make


### PR DESCRIPTION
## Description

Although Coverity have now changed their URL to point at the newproject, they did not change the project name, it would seem.

## Status
**READY**

## Requires Backporting
Yes 
[2.28](#5186)

## Migrations
NO

## Additional comments
This cannot unfortunately be tested by CI, as only the coverity push uses this, and this is only done manually or via nightlies.

## Todos
- [ ] Tests
- [ ] Backported


## Steps to test or reproduce
See additional comments.
