### PR TITLE
Allow building as a subdir

### DIFF
--- a/ChangeLog.d/cmake_add_subdirectory_support.txt
+++ b/ChangeLog.d/cmake_add_subdirectory_support.txt
@@ -1,0 +1,4 @@
+Changes
+   * Add aliases for libraries so that the normal MbedTLS::* targets
+     work when MbedTLS is built as a subdirectory.  Allows use of
+     CMake's FetchContent, as requested in #5688.

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -279,6 +279,7 @@ if(USE_SHARED_MBEDTLS_LIBRARY)
 endif(USE_SHARED_MBEDTLS_LIBRARY)
 
 foreach(target IN LISTS target_libraries)
+    add_library(MbedTLS::${target} ALIAS ${target})  # add_subdirectory support
     # Include public header files from /include and other directories
     # declared by /3rdparty/**/CMakeLists.txt. Include private header files
     # from /library and others declared by /3rdparty/**/CMakeLists.txt.


### PR DESCRIPTION
Allow building as a subdirectory (like with cmake FetchContent) 

Fixes #5688

Signed-off-by: Robert Shade <robert.shade@gmail.com>

## Status
**READ**

## Requires Backporting

NO  


## Migrations
If there is any API change, what's the incentive and logic for it.

 NO