### PR TITLE
Add minimum requirements for Python 3.10 support

### DIFF
--- a/scripts/driver.requirements.txt
+++ b/scripts/driver.requirements.txt
@@ -10,7 +10,9 @@ markupsafe < 2.1
 # See https://github.com/Mbed-TLS/mbedtls/pull/5067#discussion_r738794607 .
 # Note that Jinja 3.0 drops support for Python 3.5, so we need to support
 # Jinja 2.x as long as we're still using Python 3.5 anywhere.
-Jinja2 >= 2.10.1
+# Jinja 2.10.1 doesn't support Python 3.10+
+Jinja2 >= 2.10.1; python_version <  '3.10'
+Jinja2 >= 2.10.3; python_version >= '3.10'
 # Jinja2 >=2.10, <3.0 needs a separate package for type annotations
 types-Jinja2
 

--- a/scripts/min_requirements.py
+++ b/scripts/min_requirements.py
@@ -44,8 +44,9 @@ class Requirements:
         """Adjust a requirement to the minimum specified version."""
         # allow inheritance #pylint: disable=no-self-use
         # If a requirement specifies a minimum version, impose that version.
-        req = re.sub(r'>=|~=', r'==', req)
-        return req
+        split_req = req.split(';', 1)
+        split_req[0] = re.sub(r'>=|~=', r'==', split_req[0])
+        return ';'.join(split_req)
 
     def add_file(self, filename: str) -> None:
         """Add requirements from the specified file.


### PR DESCRIPTION
Add minimum requirements, so that `min_requirements.py` installs a working version of `jinja2` on Python 3.10+.

## Status
**READY**

## Requires Backporting
No, Jinja 2 is not required by mbedtls 2.28  

## Migrations
No