### PR TITLE
Fix a timing leak in ecp_mul_mxz()

### DIFF
--- a/library/ecp.c
+++ b/library/ecp.c
@@ -2526,7 +2526,7 @@ static int ecp_mul_mxz( mbedtls_ecp_group *grp, mbedtls_ecp_point *R,
     MBEDTLS_MPI_CHK( ecp_randomize_mxz( grp, &RP, f_rng, p_rng ) );
 
     /* Loop invariant: R = result so far, RP = R + P */
-    i = mbedtls_mpi_bitlen( m ); /* one past the (zero-based) most significant bit */
+    i = grp->nbits + 1; /* one past the (zero-based) required msb for private keys */
     while( i-- > 0 )
     {
         b = mbedtls_mpi_get_bit( m, i );


### PR DESCRIPTION
## Description
The bit length of m is leaked through through timing in ecp_mul_mxz().
Initially found by Manuel Pégourié-Gonnard on ecp_mul_edxyz(), which has
been inspired from ecp_mul_mxz(), during initial review of the EdDSA PR.
See: https://github.com/Mbed-TLS/mbedtls/pull/3245#discussion_r490827996

Fix that by using grp->pbits instead, which anyway is very close to the
length of m, which means there is no significant performance impact.

## Status
**READY**

## Requires Backporting
Yes to maintained branches: development and mbedtls-2.28 - see #6492 

## Migrations
NO

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated - no, @daverodgman & @mpg agree not needed
- [x] Backported