### PR TITLE
Fix typos in documentation and constants with typo finding tool

### DIFF
--- a/3rdparty/everest/include/everest/everest.h
+++ b/3rdparty/everest/include/everest/everest.h
@@ -96,7 +96,7 @@ int mbedtls_everest_make_params( mbedtls_ecdh_context_everest *ctx, size_t *olen
                                  void *p_rng );
 
 /**
- * \brief           This function parses and processes a TLS ServerKeyExhange
+ * \brief           This function parses and processes a TLS ServerKeyExchange
  *                  payload.
  *
  *                  This is the first function used by a TLS client for ECDHE
@@ -116,7 +116,7 @@ int mbedtls_everest_read_params( mbedtls_ecdh_context_everest *ctx,
                                  const unsigned char **buf, const unsigned char *end );
 
 /**
- * \brief           This function parses and processes a TLS ServerKeyExhange
+ * \brief           This function parses and processes a TLS ServerKeyExchange
  *                  payload.
  *
  *                  This is the first function used by a TLS client for ECDHE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 #     that targets are built using the proper list of include directories.
 #   + Use the PUBLIC and PRIVATE keywords to specify the scope of include
 #     directories. That way, a target linking to a library (using the
-#     target_link_librairies command) inherits from the library PUBLIC include
+#     target_link_libraries command) inherits from the library PUBLIC include
 #     directories and not from the PRIVATE ones.
 # - MBEDTLS_TARGET_PREFIX: CMake targets are designed to be alterable by calling
 #   CMake in order to avoid target name clashes, via the use of

--- a/docs/architecture/psa-migration/strategy.md
+++ b/docs/architecture/psa-migration/strategy.md
@@ -360,7 +360,7 @@ would need a way to easily extract the PSA key ID from the PK context.
 
 2. APIs the accept list of identifiers: for example
    `mbedtls_ssl_conf_curves()` taking a list of `mbedtls_ecp_group_id`s. This
-could be changed to accept a list of pairs (`psa_ecc_familiy_t`, size) but we
+could be changed to accept a list of pairs (`psa_ecc_family_t`, size) but we
 should probably take this opportunity to move to a identifier independent from
 the underlying crypto implementation and use TLS-specific identifiers instead
 (based on IANA values or custom enums), as is currently done in the new

--- a/docs/architecture/testing/driver-interface-test-strategy.md
+++ b/docs/architecture/testing/driver-interface-test-strategy.md
@@ -87,7 +87,7 @@ Creating or removing a key in a secure element involves multiple storage modific
 * This must be done for each possible flow, including error cases (e.g. a key creation that fails midway due to `OUT_OF_MEMORY`).
 * The recovery during `psa_crypto_init` can itself be interrupted. Test those interruptions too.
 * Two things need to be tested: the key that is being created or destroyed, and the driver's persistent storage.
-* Check both that the storage has the expected content (this can be done by e.g. using a key that is supposed to be present) and does not have any unexpected content (for keys, this can be done by checking that `psa_open_key` fails with `PSA_ERRROR_DOES_NOT_EXIST`).
+* Check both that the storage has the expected content (this can be done by e.g. using a key that is supposed to be present) and does not have any unexpected content (for keys, this can be done by checking that `psa_open_key` fails with `PSA_ERROR_DOES_NOT_EXIST`).
 
 This requires instrumenting the storage implementation, either to force it to fail at each point or to record successive storage states and replay each of them. Each `psa_its_xxx` function call is assumed to be atomic.
 

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -150,24 +150,24 @@
 #endif
 
 #if defined(MBEDTLS_PKCS12_C) && !defined(MBEDTLS_CIPHER_C)
-#error "MBEDTLS_PKCS12_C defined, but not all prerequesites"
+#error "MBEDTLS_PKCS12_C defined, but not all prerequisites"
 #endif
 
 #if defined(MBEDTLS_PKCS5_C) && (!defined(MBEDTLS_MD_C) || \
                                  !defined(MBEDTLS_CIPHER_C))
-#error "MBEDTLS_PKCS5_C defined, but not all prerequesites"
+#error "MBEDTLS_PKCS5_C defined, but not all prerequisites"
 #endif
 
 #if defined(MBEDTLS_PKCS12_C) && !defined(MBEDTLS_MD_C)
-#error "MBEDTLS_PKCS12_C defined, but not all prerequesites"
+#error "MBEDTLS_PKCS12_C defined, but not all prerequisites"
 #endif
 
 #if defined(MBEDTLS_PKCS1_V15) && !defined(MBEDTLS_MD_C)
-#error "MBEDTLS_PKCS1_V15 defined, but not all prerequesites"
+#error "MBEDTLS_PKCS1_V15 defined, but not all prerequisites"
 #endif
 
 #if defined(MBEDTLS_PKCS1_V21) && !defined(MBEDTLS_MD_C)
-#error "MBEDTLS_PKCS1_V21 defined, but not all prerequesites"
+#error "MBEDTLS_PKCS1_V21 defined, but not all prerequisites"
 #endif
 
 #if defined(MBEDTLS_ENTROPY_C) && (!defined(MBEDTLS_SHA512_C) &&      \

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1938,7 +1938,7 @@ static inline const mbedtls_ssl_config *mbedtls_ssl_context_get_config(
  *
  * \note           The two most common use cases are:
  *                 - non-blocking I/O, f_recv != NULL, f_recv_timeout == NULL
- *                 - blocking I/O, f_recv == NULL, f_recv_timout != NULL
+ *                 - blocking I/O, f_recv == NULL, f_recv_timeout != NULL
  *
  * \note           For DTLS, you need to provide either a non-NULL
  *                 f_recv_timeout callback, or a f_recv that doesn't block.
@@ -3203,7 +3203,7 @@ void mbedtls_ssl_conf_ca_cb( mbedtls_ssl_config *conf,
  *
  * \note           On client, only the first call has any effect. That is,
  *                 only one client certificate can be provisioned. The
- *                 server's preferences in its CertficateRequest message will
+ *                 server's preferences in its CertificateRequest message will
  *                 be ignored and our only cert will be sent regardless of
  *                 whether it matches those preferences - the server can then
  *                 decide what it wants to do with it.

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -448,9 +448,9 @@ psa_status_t mbedtls_psa_inject_entropy(const uint8_t *seed,
  *   As an exception, the public exponent 65537 is represented by an empty
  *   byte string.
  * - For DSA keys (#PSA_KEY_TYPE_DSA_PUBLIC_KEY or #PSA_KEY_TYPE_DSA_KEY_PAIR),
- *   the `Dss-Parms` format as defined by RFC 3279 &sect;2.3.2.
+ *   the `Dss-Params` format as defined by RFC 3279 &sect;2.3.2.
  *   ```
- *   Dss-Parms ::= SEQUENCE  {
+ *   Dss-Params ::= SEQUENCE  {
  *      p       INTEGER,
  *      q       INTEGER,
  *      g       INTEGER
@@ -466,9 +466,9 @@ psa_status_t mbedtls_psa_inject_entropy(const uint8_t *seed,
  *      g               INTEGER,                    -- generator, g
  *      q               INTEGER,                    -- factor of p-1
  *      j               INTEGER OPTIONAL,           -- subgroup factor
- *      validationParms ValidationParms OPTIONAL
+ *      validationParams ValidationParams OPTIONAL
  *   }
- *   ValidationParms ::= SEQUENCE {
+ *   ValidationParams ::= SEQUENCE {
  *      seed            BIT STRING,
  *      pgenCounter     INTEGER
  *   }

--- a/include/psa/crypto_sizes.h
+++ b/include/psa/crypto_sizes.h
@@ -739,7 +739,7 @@
  *      subjectPublicKey     BIT STRING  } -- contains DSAPublicKey
  * AlgorithmIdentifier  ::=  SEQUENCE  {
  *      algorithm               OBJECT IDENTIFIER,
- *      parameters              Dss-Parms  } -- SEQUENCE of 3 INTEGERs
+ *      parameters              Dss-Params  } -- SEQUENCE of 3 INTEGERs
  * DSAPublicKey  ::=  INTEGER -- public key, Y
  *
  * - 3 * 4 bytes of SEQUENCE overhead;

--- a/library/ccm.c
+++ b/library/ccm.c
@@ -99,7 +99,7 @@ void mbedtls_ccm_free( mbedtls_ccm_context *ctx )
 
 #define CCM_STATE__CLEAR                0
 #define CCM_STATE__STARTED              (1 << 0)
-#define CCM_STATE__LENGHTS_SET          (1 << 1)
+#define CCM_STATE__LENGTHS_SET          (1 << 1)
 #define CCM_STATE__AUTH_DATA_STARTED    (1 << 2)
 #define CCM_STATE__AUTH_DATA_FINISHED   (1 << 3)
 #define CCM_STATE__ERROR                (1 << 4)
@@ -147,7 +147,7 @@ static int ccm_calculate_first_block_if_ready(mbedtls_ccm_context *ctx)
     /* length calulcation can be done only after both
      * mbedtls_ccm_starts() and mbedtls_ccm_set_lengths() have been executed
      */
-    if( !(ctx->state & CCM_STATE__STARTED) || !(ctx->state & CCM_STATE__LENGHTS_SET) )
+    if( !(ctx->state & CCM_STATE__STARTED) || !(ctx->state & CCM_STATE__LENGTHS_SET) )
         return 0;
 
     /* CCM expects non-empty tag.
@@ -260,7 +260,7 @@ int mbedtls_ccm_set_lengths( mbedtls_ccm_context *ctx,
     ctx->tag_len = tag_len;
     ctx->processed = 0;
 
-    ctx->state |= CCM_STATE__LENGHTS_SET;
+    ctx->state |= CCM_STATE__LENGTHS_SET;
     return ccm_calculate_first_block_if_ready(ctx);
 }
 

--- a/library/ctr_drbg.c
+++ b/library/ctr_drbg.c
@@ -815,7 +815,7 @@ static int ctr_drbg_self_test_entropy( void *data, unsigned char *buf,
                         return( 1 );                        \
                     }
 
-#define SELF_TEST_OUPUT_DISCARD_LENGTH 64
+#define SELF_TEST_OUTPUT_DISCARD_LENGTH 64
 
 /*
  * Checkup routine
@@ -841,7 +841,7 @@ int mbedtls_ctr_drbg_self_test( int verbose )
                                 (void *) entropy_source_pr,
                                 pers_pr, MBEDTLS_CTR_DRBG_KEYSIZE ) );
     mbedtls_ctr_drbg_set_prediction_resistance( &ctx, MBEDTLS_CTR_DRBG_PR_ON );
-    CHK( mbedtls_ctr_drbg_random( &ctx, buf, SELF_TEST_OUPUT_DISCARD_LENGTH ) );
+    CHK( mbedtls_ctr_drbg_random( &ctx, buf, SELF_TEST_OUTPUT_DISCARD_LENGTH ) );
     CHK( mbedtls_ctr_drbg_random( &ctx, buf, sizeof( result_pr ) ) );
     CHK( memcmp( buf, result_pr, sizeof( result_pr ) ) );
 
@@ -866,7 +866,7 @@ int mbedtls_ctr_drbg_self_test( int verbose )
                                 (void *) entropy_source_nopr,
                                 pers_nopr, MBEDTLS_CTR_DRBG_KEYSIZE ) );
     CHK( mbedtls_ctr_drbg_reseed( &ctx, NULL, 0 ) );
-    CHK( mbedtls_ctr_drbg_random( &ctx, buf, SELF_TEST_OUPUT_DISCARD_LENGTH ) );
+    CHK( mbedtls_ctr_drbg_random( &ctx, buf, SELF_TEST_OUTPUT_DISCARD_LENGTH ) );
     CHK( mbedtls_ctr_drbg_random( &ctx, buf, sizeof( result_nopr ) ) );
     CHK( memcmp( buf, result_nopr, sizeof( result_nopr ) ) );
 

--- a/library/ecdh.c
+++ b/library/ecdh.c
@@ -399,7 +399,7 @@ static int ecdh_read_params_internal( mbedtls_ecdh_context_mbed *ctx,
 }
 
 /*
- * Read the ServerKeyExhange parameters (RFC 4492)
+ * Read the ServerKeyExchange parameters (RFC 4492)
  *      struct {
  *          ECParameters    curve_params;
  *          ECPoint         public;

--- a/library/mps_common.h
+++ b/library/mps_common.h
@@ -51,7 +51,7 @@
  *  the function's behavior is entirely undefined.
  *  In addition to state integrity, all MPS structures have a more refined
  *  notion of abstract state that the API operates on. For example, all layers
- *  have a notion of 'abtract read state' which indicates if incoming data has
+ *  have a notion of 'abstract read state' which indicates if incoming data has
  *  been passed to the user, e.g. through mps_l2_read_start() for Layer 2
  *  or mps_l3_read() in Layer 3. After such a call, it doesn't make sense to
  *  call these reading functions again until the incoming data has been

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -412,7 +412,7 @@ static int ssl_tls13_parse_client_hello( mbedtls_ssl_context *ssl,
      */
 
     /*
-     * Minimal length ( with everything empty and extensions ommitted ) is
+     * Minimal length ( with everything empty and extensions omitted ) is
      * 2 + 32 + 1 + 2 + 1 = 38 bytes. Check that first, so that we can
      * read at least up to session id length without worrying.
      */

--- a/programs/ssl/ssl_test_lib.h
+++ b/programs/ssl/ssl_test_lib.h
@@ -241,7 +241,7 @@ int rng_get( void *p_rng, unsigned char *output, size_t output_len );
 int key_opaque_alg_parse( const char *arg, const char **alg1, const char **alg2 );
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
-/** Parse given opaque key algoritms to obtain psa algs and usage
+/** Parse given opaque key algorithms to obtain psa algs and usage
  *  that will be passed to mbedtls_pk_wrap_as_opaque().
  *
  *


### PR DESCRIPTION
I used an [automated typo-finding tool](https://github.com/crate-ci/typos) to locate several typos in constants and documentation in various files in mbedtls. (I accidentally found these in mbedtls after a [library that depended on it](https://github.com/Infineon/optiga-trust-m) tripped a CI step.)