### PR TITLE
Fix typos in documentation and constants with typo finding tool

### DIFF
--- a/3rdparty/everest/include/everest/everest.h
+++ b/3rdparty/everest/include/everest/everest.h
@@ -96,7 +96,7 @@ int mbedtls_everest_make_params( mbedtls_ecdh_context_everest *ctx, size_t *olen
                                  void *p_rng );
 
 /**
- * \brief           This function parses and processes a TLS ServerKeyExhange
+ * \brief           This function parses and processes a TLS ServerKeyExchange
  *                  payload.
  *
  *                  This is the first function used by a TLS client for ECDHE
@@ -116,7 +116,7 @@ int mbedtls_everest_read_params( mbedtls_ecdh_context_everest *ctx,
                                  const unsigned char **buf, const unsigned char *end );
 
 /**
- * \brief           This function parses and processes a TLS ServerKeyExhange
+ * \brief           This function parses and processes a TLS ServerKeyExchange
  *                  payload.
  *
  *                  This is the first function used by a TLS client for ECDHE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 #     that targets are built using the proper list of include directories.
 #   + Use the PUBLIC and PRIVATE keywords to specify the scope of include
 #     directories. That way, a target linking to a library (using the
-#     target_link_librairies command) inherits from the library PUBLIC include
+#     target_link_libraries command) inherits from the library PUBLIC include
 #     directories and not from the PRIVATE ones.
 #   + Note: there is currently one remaining include_directories command in the
 #     CMake files. It is related to ZLIB support which is planned to be removed.

--- a/docs/architecture/testing/driver-interface-test-strategy.md
+++ b/docs/architecture/testing/driver-interface-test-strategy.md
@@ -87,7 +87,7 @@ Creating or removing a key in a secure element involves multiple storage modific
 * This must be done for each possible flow, including error cases (e.g. a key creation that fails midway due to `OUT_OF_MEMORY`).
 * The recovery during `psa_crypto_init` can itself be interrupted. Test those interruptions too.
 * Two things need to be tested: the key that is being created or destroyed, and the driver's persistent storage.
-* Check both that the storage has the expected content (this can be done by e.g. using a key that is supposed to be present) and does not have any unexpected content (for keys, this can be done by checking that `psa_open_key` fails with `PSA_ERRROR_DOES_NOT_EXIST`).
+* Check both that the storage has the expected content (this can be done by e.g. using a key that is supposed to be present) and does not have any unexpected content (for keys, this can be done by checking that `psa_open_key` fails with `PSA_ERROR_DOES_NOT_EXIST`).
 
 This requires instrumenting the storage implementation, either to force it to fail at each point or to record successive storage states and replay each of them. Each `psa_its_xxx` function call is assumed to be atomic.
 

--- a/include/mbedtls/blowfish.h
+++ b/include/mbedtls/blowfish.h
@@ -185,7 +185,7 @@ int mbedtls_blowfish_crypt_cbc( mbedtls_blowfish_context *ctx,
  *                 #MBEDTLS_BLOWFISH_ENCRYPT for encryption, or
  *                 #MBEDTLS_BLOWFISH_DECRYPT for decryption.
  * \param length   The length of the input data in Bytes.
- * \param iv_off   The offset in the initialiation vector.
+ * \param iv_off   The offset in the initialization vector.
  *                 The value pointed to must be smaller than \c 8 Bytes.
  *                 It is updated by this function to support the aforementioned
  *                 streaming usage.

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -67,7 +67,7 @@ extern "C" {
  * \brief       User supplied callback function for parameter validation failure.
  *              See #MBEDTLS_CHECK_PARAMS for context.
  *
- *              This function will be called unless an alternative treatement
+ *              This function will be called unless an alternative treatment
  *              is defined through the #MBEDTLS_PARAM_FAILED macro.
  *
  *              This function can return, and the operation will be aborted, or

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1405,7 +1405,7 @@ struct mbedtls_ssl_context
     unsigned char *compress_buf;        /*!<  zlib data buffer        */
 #endif /* MBEDTLS_ZLIB_SUPPORT */
 #if defined(MBEDTLS_SSL_CBC_RECORD_SPLITTING)
-    signed char split_done;     /*!< current record already splitted? */
+    signed char split_done;     /*!< current record already split? */
 #endif /* MBEDTLS_SSL_CBC_RECORD_SPLITTING */
 
     /*
@@ -1688,7 +1688,7 @@ void mbedtls_ssl_conf_dbg( mbedtls_ssl_config *conf,
  *
  * \note           The two most common use cases are:
  *                 - non-blocking I/O, f_recv != NULL, f_recv_timeout == NULL
- *                 - blocking I/O, f_recv == NULL, f_recv_timout != NULL
+ *                 - blocking I/O, f_recv == NULL, f_recv_timeout != NULL
  *
  * \note           For DTLS, you need to provide either a non-NULL
  *                 f_recv_timeout callback, or a f_recv that doesn't block.
@@ -2793,7 +2793,7 @@ void mbedtls_ssl_conf_ca_cb( mbedtls_ssl_config *conf,
  *
  * \note           On client, only the first call has any effect. That is,
  *                 only one client certificate can be provisioned. The
- *                 server's preferences in its CertficateRequest message will
+ *                 server's preferences in its CertificateRequest message will
  *                 be ignored and our only cert will be sent regardless of
  *                 whether it matches those preferences - the server can then
  *                 decide what it wants to do with it.

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -445,9 +445,9 @@ psa_status_t mbedtls_psa_inject_entropy(const uint8_t *seed,
  *   As an exception, the public exponent 65537 is represented by an empty
  *   byte string.
  * - For DSA keys (#PSA_KEY_TYPE_DSA_PUBLIC_KEY or #PSA_KEY_TYPE_DSA_KEY_PAIR),
- *   the `Dss-Parms` format as defined by RFC 3279 &sect;2.3.2.
+ *   the `Dss-Params` format as defined by RFC 3279 &sect;2.3.2.
  *   ```
- *   Dss-Parms ::= SEQUENCE  {
+ *   Dss-Params ::= SEQUENCE  {
  *      p       INTEGER,
  *      q       INTEGER,
  *      g       INTEGER
@@ -463,9 +463,9 @@ psa_status_t mbedtls_psa_inject_entropy(const uint8_t *seed,
  *      g               INTEGER,                    -- generator, g
  *      q               INTEGER,                    -- factor of p-1
  *      j               INTEGER OPTIONAL,           -- subgroup factor
- *      validationParms ValidationParms OPTIONAL
+ *      validationParams ValidationParams OPTIONAL
  *   }
- *   ValidationParms ::= SEQUENCE {
+ *   ValidationParams ::= SEQUENCE {
  *      seed            BIT STRING,
  *      pgenCounter     INTEGER
  *   }

--- a/include/psa/crypto_sizes.h
+++ b/include/psa/crypto_sizes.h
@@ -747,7 +747,7 @@
  *      subjectPublicKey     BIT STRING  } -- contains DSAPublicKey
  * AlgorithmIdentifier  ::=  SEQUENCE  {
  *      algorithm               OBJECT IDENTIFIER,
- *      parameters              Dss-Parms  } -- SEQUENCE of 3 INTEGERs
+ *      parameters              Dss-Params  } -- SEQUENCE of 3 INTEGERs
  * DSAPublicKey  ::=  INTEGER -- public key, Y
  *
  * - 3 * 4 bytes of SEQUENCE overhead;

--- a/library/ctr_drbg.c
+++ b/library/ctr_drbg.c
@@ -828,7 +828,7 @@ static int ctr_drbg_self_test_entropy( void *data, unsigned char *buf,
                         return( 1 );                        \
                     }
 
-#define SELF_TEST_OUPUT_DISCARD_LENGTH 64
+#define SELF_TEST_OUTPUT_DISCARD_LENGTH 64
 
 /*
  * Checkup routine
@@ -854,7 +854,7 @@ int mbedtls_ctr_drbg_self_test( int verbose )
                                 (void *) entropy_source_pr,
                                 pers_pr, MBEDTLS_CTR_DRBG_KEYSIZE ) );
     mbedtls_ctr_drbg_set_prediction_resistance( &ctx, MBEDTLS_CTR_DRBG_PR_ON );
-    CHK( mbedtls_ctr_drbg_random( &ctx, buf, SELF_TEST_OUPUT_DISCARD_LENGTH ) );
+    CHK( mbedtls_ctr_drbg_random( &ctx, buf, SELF_TEST_OUTPUT_DISCARD_LENGTH ) );
     CHK( mbedtls_ctr_drbg_random( &ctx, buf, sizeof( result_pr ) ) );
     CHK( memcmp( buf, result_pr, sizeof( result_pr ) ) );
 
@@ -879,7 +879,7 @@ int mbedtls_ctr_drbg_self_test( int verbose )
                                 (void *) entropy_source_nopr,
                                 pers_nopr, MBEDTLS_CTR_DRBG_KEYSIZE ) );
     CHK( mbedtls_ctr_drbg_reseed( &ctx, NULL, 0 ) );
-    CHK( mbedtls_ctr_drbg_random( &ctx, buf, SELF_TEST_OUPUT_DISCARD_LENGTH ) );
+    CHK( mbedtls_ctr_drbg_random( &ctx, buf, SELF_TEST_OUTPUT_DISCARD_LENGTH ) );
     CHK( mbedtls_ctr_drbg_random( &ctx, buf, sizeof( result_nopr ) ) );
     CHK( memcmp( buf, result_nopr, sizeof( result_nopr ) ) );
 

--- a/library/ecdh.c
+++ b/library/ecdh.c
@@ -399,7 +399,7 @@ static int ecdh_read_params_internal( mbedtls_ecdh_context_mbed *ctx,
 }
 
 /*
- * Read the ServerKeyExhange parameters (RFC 4492)
+ * Read the ServerKeyExchange parameters (RFC 4492)
  *      struct {
  *          ECParameters    curve_params;
  *          ECPoint         public;

--- a/library/mps_common.h
+++ b/library/mps_common.h
@@ -51,7 +51,7 @@
  *  the function's behavior is entirely undefined.
  *  In addition to state integrity, all MPS structures have a more refined
  *  notion of abstract state that the API operates on. For example, all layers
- *  have a notion of 'abtract read state' which indicates if incoming data has
+ *  have a notion of 'abstract read state' which indicates if incoming data has
  *  been passed to the user, e.g. through mps_l2_read_start() for Layer 2
  *  or mps_l3_read() in Layer 3. After such a call, it doesn't make sense to
  *  call these reading functions again until the incoming data has been


### PR DESCRIPTION
related to #5846. I used an [automated typo-finding tool](https://github.com/crate-ci/typos) to locate several typos in constants and documentation in various files in mbedtls. backported to mbedtls-2.28.