### PR TITLE
Backport 2.28: Fix uninitialised memory access in constant time functions

### DIFF
--- a/library/constant_time.c
+++ b/library/constant_time.c
@@ -489,6 +489,12 @@ int mbedtls_ct_hmac( mbedtls_md_context_t *ctx,
     MD_CHK( mbedtls_md_update( ctx, add_data, add_data_len ) );
     MD_CHK( mbedtls_md_update( ctx, data, min_data_len ) );
 
+    /* Fill the hash buffer in advance with something that is
+     * not a valid hash (barring an attack on the hash and
+     * deliberately-crafted input), in case the caller doesn't
+     * check the return status properly. */
+    memset( output, '!', hash_size );
+
     /* For each possible length, compute the hash up to that point */
     for( offset = min_data_len; offset <= max_data_len; offset++ )
     {

--- a/library/constant_time_internal.h
+++ b/library/constant_time_internal.h
@@ -221,6 +221,13 @@ void mbedtls_ct_memcpy_if_eq( unsigned char *dest,
  * offset_secret, but only on \p offset_min, \p offset_max and \p len.
  * Functionally equivalent to `memcpy(dst, src + offset_secret, len)`.
  *
+ * \note                This function reads from \p dest, but the value that
+ *                      is read does not influence the result and this
+ *                      function's behavior is well-defined regardless of the
+ *                      contents of the buffers. This may result in false
+ *                      positives from static or dynamic analyzers, especially
+ *                      if \p dest is not initialized.
+ *
  * \param dest          The destination buffer. This must point to a writable
  *                      buffer of at least \p len bytes.
  * \param src           The base of the source buffer. This must point to a

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -1590,8 +1590,8 @@ int mbedtls_ssl_decrypt_buf( mbedtls_ssl_context const *ssl,
 #if defined(MBEDTLS_SSL_SOME_MODES_USE_MAC)
     if( auth_done == 0 )
     {
-        unsigned char mac_expect[MBEDTLS_SSL_MAC_ADD];
-        unsigned char mac_peer[MBEDTLS_SSL_MAC_ADD];
+        unsigned char mac_expect[MBEDTLS_SSL_MAC_ADD] = { 0 };
+        unsigned char mac_peer[MBEDTLS_SSL_MAC_ADD] = { 0 };
 
         /* If the initial value of padlen was such that
          * data_len < maclen + padlen + 1, then padlen


### PR DESCRIPTION
## Description
Fix an issue reported by Coverity whereby some constant time functions called from the ssl decrypt code could potentially access uninitialised memory, by zeroing memory in two of the places where this function is used.

Add a note to mbedtls_ct_memcpy_if_eq() documentation to warn that it reads from the buffer as well as writing to it. Note that no decisions are taken as a result of the uninitialised data, but obviously its still not best practice.

This is a backport of #5829 

## Status
**READY**

## Migrations
NO

## Additional comments
As we are not trying to hide the length that will be copied, I used memset to zero the target buffers. I hope this is not too out of place in constant_time.c, and will re-write if people feel that it is.

## Todos
- [ ] Tests
- [ ] Documentation
- [x] Changelog updated

## Steps to test or reproduce
test_suite_ssl should run clean.
