### PR TITLE
PSA J-PAKE API has missing elements and confusing documentation

### DIFF
--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -1162,7 +1162,7 @@ typedef struct psa_pake_cipher_suite_s psa_pake_cipher_suite_t;
 
 /** Return an initial value for a PAKE cipher suite object.
  */
-static psa_pake_cipher_suite_t psa_pake_cipher_suite_init(void);
+static psa_pake_cipher_suite_t psa_pake_cipher_suite_init( void );
 
 /** Retrieve the PAKE algorithm from a PAKE cipher suite.
  *
@@ -1175,8 +1175,7 @@ static psa_pake_cipher_suite_t psa_pake_cipher_suite_init(void);
  * \return The PAKE algorithm stored in the cipher suite structure.
  */
 static psa_algorithm_t psa_pake_cs_get_algorithm(
-                           const psa_pake_cipher_suite_t* cipher_suite
-                           );
+                           const psa_pake_cipher_suite_t *cipher_suite );
 
 /** Declare the PAKE algorithm for the cipher suite.
  *
@@ -1194,10 +1193,8 @@ static psa_algorithm_t psa_pake_cs_get_algorithm(
  *                             If this is 0, the PAKE algorithm in
  *                             \p cipher_suite becomes unspecified.
  */
-static void psa_pake_cs_set_algorithm(
-                           psa_pake_cipher_suite_t* cipher_suite,
-                           psa_algorithm_t algorithm
-                           );
+static void psa_pake_cs_set_algorithm( psa_pake_cipher_suite_t *cipher_suite,
+                                       psa_algorithm_t algorithm );
 
 /** Retrieve the primitive from a PAKE cipher suite.
  *
@@ -1210,8 +1207,7 @@ static void psa_pake_cs_set_algorithm(
  * \return The primitive stored in the cipher suite structure.
  */
 static psa_pake_primitive_t psa_pake_cs_get_primitive(
-                           const psa_pake_cipher_suite_t* cipher_suite
-                           );
+                           const psa_pake_cipher_suite_t *cipher_suite );
 
 /** Declare the primitive for a PAKE cipher suite.
  *
@@ -1226,10 +1222,8 @@ static psa_pake_primitive_t psa_pake_cs_get_primitive(
  *                             primitive type in \p cipher_suite becomes
  *                             unspecified.
  */
-static void psa_pake_cs_set_primitive(
-                           psa_pake_cipher_suite_t* cipher_suite,
-                           psa_pake_primitive_t primitive
-                           );
+static void psa_pake_cs_set_primitive( psa_pake_cipher_suite_t *cipher_suite,
+                                       psa_pake_primitive_t primitive );
 
 /** Retrieve the PAKE family from a PAKE cipher suite.
  *
@@ -1242,8 +1236,7 @@ static void psa_pake_cs_set_primitive(
  * \return The PAKE family stored in the cipher suite structure.
  */
 static psa_pake_family_t psa_pake_cs_get_family(
-                           const psa_pake_cipher_suite_t* cipher_suite
-                           );
+                           const psa_pake_cipher_suite_t *cipher_suite );
 
 /** Retrieve the PAKE primitive bit-size from a PAKE cipher suite.
  *
@@ -1256,8 +1249,7 @@ static psa_pake_family_t psa_pake_cs_get_family(
  * \return The PAKE primitive bit-size stored in the cipher suite structure.
  */
 static uint16_t psa_pake_cs_get_bits(
-                           const psa_pake_cipher_suite_t* cipher_suite
-                           );
+                           const psa_pake_cipher_suite_t *cipher_suite );
 
 /** Retrieve the hash algorithm from a PAKE cipher suite.
  *
@@ -1272,8 +1264,7 @@ static uint16_t psa_pake_cs_get_bits(
  *         the hash algorithm is not set.
  */
 static psa_algorithm_t psa_pake_cs_get_hash(
-                           const psa_pake_cipher_suite_t* cipher_suite
-                           );
+                           const psa_pake_cipher_suite_t *cipher_suite );
 
 /** Declare the hash algorithm for a PAKE cipher suite.
  *
@@ -1295,10 +1286,8 @@ static psa_algorithm_t psa_pake_cs_get_hash(
  *                              If this is 0, the hash algorithm in
  *                              \p cipher_suite becomes unspecified.
  */
-static void psa_pake_cs_set_hash(
-                           psa_pake_cipher_suite_t* cipher_suite,
-                           psa_algorithm_t hash
-                           );
+static void psa_pake_cs_set_hash( psa_pake_cipher_suite_t *cipher_suite,
+                                  psa_algorithm_t hash );
 
 /** The type of the state data structure for PAKE operations.
  *
@@ -1332,7 +1321,7 @@ typedef struct psa_pake_operation_s psa_pake_operation_t;
 
 /** Return an initial value for an PAKE operation object.
  */
-static psa_pake_operation_t psa_pake_operation_init(void);
+static psa_pake_operation_t psa_pake_operation_init( void );
 
 /** Set the session information for a password-authenticated key exchange.
  *
@@ -1404,8 +1393,8 @@ static psa_pake_operation_t psa_pake_operation_init(void);
  *         It is implementation-dependent whether a failure to initialize
  *         results in this error code.
  */
-psa_status_t psa_pake_setup(psa_pake_operation_t *operation,
-                            const psa_pake_cipher_suite_t *cipher_suite);
+psa_status_t psa_pake_setup( psa_pake_operation_t *operation,
+                             const psa_pake_cipher_suite_t *cipher_suite );
 
 /** Set the password for a password-authenticated key exchange from key ID.
  *
@@ -1452,8 +1441,8 @@ psa_status_t psa_pake_setup(psa_pake_operation_t *operation,
  *         It is implementation-dependent whether a failure to initialize
  *         results in this error code.
  */
-psa_status_t psa_pake_set_password_key(psa_pake_operation_t *operation,
-                                       mbedtls_svc_key_id_t password);
+psa_status_t psa_pake_set_password_key( psa_pake_operation_t *operation,
+                                        mbedtls_svc_key_id_t password );
 
 /** Set the user ID for a password-authenticated key exchange.
  *
@@ -1492,9 +1481,9 @@ psa_status_t psa_pake_set_password_key(psa_pake_operation_t *operation,
  *         It is implementation-dependent whether a failure to initialize
  *         results in this error code.
  */
-psa_status_t psa_pake_set_user(psa_pake_operation_t *operation,
-                               const uint8_t *user_id,
-                               size_t user_id_len);
+psa_status_t psa_pake_set_user( psa_pake_operation_t *operation,
+                                const uint8_t *user_id,
+                                size_t user_id_len );
 
 /** Set the peer ID for a password-authenticated key exchange.
  *
@@ -1534,9 +1523,9 @@ psa_status_t psa_pake_set_user(psa_pake_operation_t *operation,
  *         It is implementation-dependent whether a failure to initialize
  *         results in this error code.
  */
-psa_status_t psa_pake_set_peer(psa_pake_operation_t *operation,
-                               const uint8_t *peer_id,
-                               size_t peer_id_len);
+psa_status_t psa_pake_set_peer( psa_pake_operation_t *operation,
+                                const uint8_t *peer_id,
+                                size_t peer_id_len );
 
 /** Set the application role for a password-authenticated key exchange.
  *
@@ -1576,8 +1565,8 @@ psa_status_t psa_pake_set_peer(psa_pake_operation_t *operation,
  *         It is implementation-dependent whether a failure to initialize
  *         results in this error code.
  */
-psa_status_t psa_pake_set_role(psa_pake_operation_t *operation,
-                               psa_pake_role_t role);
+psa_status_t psa_pake_set_role( psa_pake_operation_t *operation,
+                                psa_pake_role_t role );
 
 /** Get output for a step of a password-authenticated key exchange.
  *
@@ -1634,11 +1623,11 @@ psa_status_t psa_pake_set_role(psa_pake_operation_t *operation,
  *         It is implementation-dependent whether a failure to initialize
  *         results in this error code.
  */
-psa_status_t psa_pake_output(psa_pake_operation_t *operation,
-                             psa_pake_step_t step,
-                             uint8_t *output,
-                             size_t output_size,
-                             size_t *output_length);
+psa_status_t psa_pake_output( psa_pake_operation_t *operation,
+                              psa_pake_step_t step,
+                              uint8_t *output,
+                              size_t output_size,
+                              size_t *output_length );
 
 /** Provide input for a step of a password-authenticated key exchange.
  *
@@ -1689,10 +1678,10 @@ psa_status_t psa_pake_output(psa_pake_operation_t *operation,
  *         It is implementation-dependent whether a failure to initialize
  *         results in this error code.
  */
-psa_status_t psa_pake_input(psa_pake_operation_t *operation,
-                            psa_pake_step_t step,
-                            const uint8_t *input,
-                            size_t input_length);
+psa_status_t psa_pake_input( psa_pake_operation_t *operation,
+                             psa_pake_step_t step,
+                             const uint8_t *input,
+                             size_t input_length );
 
 /** Get implicitly confirmed shared secret from a PAKE.
  *
@@ -1752,8 +1741,8 @@ psa_status_t psa_pake_input(psa_pake_operation_t *operation,
  *         It is implementation-dependent whether a failure to initialize
  *         results in this error code.
  */
-psa_status_t psa_pake_get_implicit_key(psa_pake_operation_t *operation,
-                                       psa_key_derivation_operation_t *output);
+psa_status_t psa_pake_get_implicit_key( psa_pake_operation_t *operation,
+                                        psa_key_derivation_operation_t *output );
 
 /** Abort a PAKE operation.
  *
@@ -1779,7 +1768,7 @@ psa_status_t psa_pake_get_implicit_key(psa_pake_operation_t *operation,
  *         It is implementation-dependent whether a failure to initialize
  *         results in this error code.
  */
-psa_status_t psa_pake_abort(psa_pake_operation_t * operation);
+psa_status_t psa_pake_abort( psa_pake_operation_t * operation );
 
 /**@}*/
 
@@ -1864,31 +1853,31 @@ struct psa_pake_cipher_suite_s
 };
 
 static inline psa_algorithm_t psa_pake_cs_get_algorithm(
-    const psa_pake_cipher_suite_t *cipher_suite)
+                        const psa_pake_cipher_suite_t *cipher_suite )
 {
-    return(cipher_suite->algorithm);
+    return( cipher_suite->algorithm );
 }
 
 static inline void psa_pake_cs_set_algorithm(
     psa_pake_cipher_suite_t *cipher_suite,
     psa_algorithm_t algorithm)
 {
-    if(!PSA_ALG_IS_PAKE(algorithm))
+    if( !PSA_ALG_IS_PAKE(algorithm) )
         cipher_suite->algorithm = 0;
     else
         cipher_suite->algorithm = algorithm;
 }
 
 static inline psa_pake_primitive_t psa_pake_cs_get_primitive(
-    const psa_pake_cipher_suite_t *cipher_suite)
+                        const psa_pake_cipher_suite_t *cipher_suite )
 {
-    return(PSA_PAKE_PRIMITIVE(cipher_suite->type, cipher_suite->family,
-                cipher_suite->bits));
+    return( PSA_PAKE_PRIMITIVE(cipher_suite->type, cipher_suite->family,
+                               cipher_suite->bits) );
 }
 
 static inline void psa_pake_cs_set_primitive(
-    psa_pake_cipher_suite_t *cipher_suite,
-    psa_pake_primitive_t primitive)
+                        psa_pake_cipher_suite_t *cipher_suite,
+                        psa_pake_primitive_t primitive )
 {
     cipher_suite->type = (psa_pake_primitive_type_t) (primitive >> 24);
     cipher_suite->family = (psa_pake_family_t) (0xFF & (primitive >> 16));
@@ -1896,28 +1885,27 @@ static inline void psa_pake_cs_set_primitive(
 }
 
 static inline psa_pake_family_t psa_pake_cs_get_family(
-    const psa_pake_cipher_suite_t *cipher_suite)
+                        const psa_pake_cipher_suite_t *cipher_suite )
 {
-    return(cipher_suite->family);
+    return( cipher_suite->family );
 }
 
 static inline uint16_t psa_pake_cs_get_bits(
-    const psa_pake_cipher_suite_t *cipher_suite)
+                        const psa_pake_cipher_suite_t *cipher_suite )
 {
-    return(cipher_suite->bits);
+    return( cipher_suite->bits );
 }
 
 static inline psa_algorithm_t psa_pake_cs_get_hash(
-    const psa_pake_cipher_suite_t *cipher_suite)
+                        const psa_pake_cipher_suite_t *cipher_suite )
 {
-    return(cipher_suite->hash);
+    return( cipher_suite->hash );
 }
 
-static inline void psa_pake_cs_set_hash(
-    psa_pake_cipher_suite_t *cipher_suite,
-    psa_algorithm_t hash)
+static inline void psa_pake_cs_set_hash( psa_pake_cipher_suite_t *cipher_suite,
+                                         psa_algorithm_t hash )
 {
-    if(!PSA_ALG_IS_HASH(hash))
+    if( !PSA_ALG_IS_HASH(hash) )
         cipher_suite->hash = 0;
     else
         cipher_suite->hash = hash;
@@ -1933,16 +1921,16 @@ struct psa_pake_operation_s
     } ctx;
 };
 
-static inline struct psa_pake_cipher_suite_s psa_pake_cipher_suite_init(void)
+static inline struct psa_pake_cipher_suite_s psa_pake_cipher_suite_init( void )
 {
     const struct psa_pake_cipher_suite_s v = PSA_PAKE_CIPHER_SUITE_INIT;
-    return(v);
+    return( v );
 }
 
-static inline struct psa_pake_operation_s psa_pake_operation_init(void)
+static inline struct psa_pake_operation_s psa_pake_operation_init( void )
 {
     const struct psa_pake_operation_s v = PSA_PAKE_OPERATION_INIT;
-    return(v);
+    return( v );
 }
 
 #ifdef __cplusplus

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -1224,6 +1224,20 @@ static void psa_pake_cs_set_primitive(
                            psa_pake_primitive_t primitive
                            );
 
+/** Retrieve the PAKE family from a PAKE cipher suite.
+ *
+ * This function may be declared as `static` (i.e. without external
+ * linkage). This function may be provided as a function-like macro,
+ * but in this case it must evaluate its argument exactly once.
+ *
+ * \param[in] cipher_suite     The cipher suite structure to query.
+ *
+ * \return The PAKE family stored in the cipher suite structure.
+ */
+static psa_pake_family_t psa_pake_cs_get_family(
+                           const psa_pake_cipher_suite_t* cipher_suite
+                           );
+
 /** Retrieve the hash algorithm from a PAKE cipher suite.
  *
  * This function may be declared as `static` (i.e. without external
@@ -1809,6 +1823,12 @@ static inline void psa_pake_cs_set_primitive(
     cipher_suite->type = (psa_pake_primitive_type_t) (primitive >> 24);
     cipher_suite->family = (psa_pake_family_t) (0xFF & (primitive >> 16));
     cipher_suite->bits = (uint16_t) (0xFFFF & primitive);
+}
+
+static inline psa_pake_family_t psa_pake_cs_get_family(
+    const psa_pake_cipher_suite_t *cipher_suite)
+{
+    return(cipher_suite->family);
 }
 
 static inline psa_algorithm_t psa_pake_cs_get_hash(

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -1153,6 +1153,10 @@ typedef uint32_t psa_pake_primitive_t;
  */
 typedef struct psa_pake_cipher_suite_s psa_pake_cipher_suite_t;
 
+/** Return an initial value for a PAKE cipher suite object.
+ */
+static psa_pake_cipher_suite_t psa_pake_cipher_suite_init(void);
+
 /** Retrieve the PAKE algorithm from a PAKE cipher suite.
  *
  * This function may be declared as `static` (i.e. without external
@@ -1802,6 +1806,12 @@ struct psa_pake_operation_s
         uint8_t dummy;
     } ctx;
 };
+
+static inline struct psa_pake_cipher_suite_s psa_pake_cipher_suite_init(void)
+{
+    const struct psa_pake_cipher_suite_s v = PSA_PAKE_CIPHER_SUITE_INIT;
+    return(v);
+}
 
 /* This only zeroes out the first byte in the union, the rest is unspecified. */
 #define PSA_PAKE_OPERATION_INIT {0, {0}}

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -1572,8 +1572,11 @@ psa_status_t psa_pake_set_side(psa_pake_operation_t *operation,
  *                             \c PSA_PAKE_STEP_XXX constants for more
  *                             information.
  * \param output_size          Size of the \p output buffer in bytes. This must
- *                             be at least #PSA_PAKE_OUTPUT_SIZE(\p alg, \c
- *                             cipher_suite, \p type).
+ *                             be at least #PSA_PAKE_OUTPUT_SIZE(\p alg, \p
+ *                             primitive, \p step) where \p alg and
+ *                             \p primitive are the PAKE algorithm and primitive
+ *                             in the operation's cipher suite, and \p step is
+ *                             the output step.
  *
  * \param[out] output_length   On success, the number of bytes of the returned
  *                             output.

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -1627,8 +1627,9 @@ psa_status_t psa_pake_set_role(psa_pake_operation_t *operation,
  * \retval #PSA_ERROR_DATA_CORRUPT
  * \retval #PSA_ERROR_DATA_INVALID
  * \retval #PSA_ERROR_BAD_STATE
- *         The operation state is not valid (it must be active, but beyond that
- *         validity is specific to the algorithm), or
+ *         The operation state is not valid (it must be active, and fully set
+ *         up, and this call must conform to the algorithm's requirements
+ *         for ordering of input and output steps), or
  *         the library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
  *         results in this error code.
@@ -1681,8 +1682,9 @@ psa_status_t psa_pake_output(psa_pake_operation_t *operation,
  * \retval #PSA_ERROR_DATA_CORRUPT
  * \retval #PSA_ERROR_DATA_INVALID
  * \retval #PSA_ERROR_BAD_STATE
- *         The operation state is not valid (it must be active, but beyond that
- *         validity is specific to the algorithm), or
+ *         The operation state is not valid (it must be active, and fully set
+ *         up, and this call must conform to the algorithm's requirements
+ *         for ordering of input and output steps), or
  *         the library has not been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
  *         results in this error code.

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -1344,7 +1344,7 @@ static psa_pake_operation_t psa_pake_operation_init(void);
  *
  * \param[in,out] operation     The operation object to set up. It must have
  *                              been initialized but not set up yet.
- * \param cipher_suite          The cipher suite to use. (A cipher suite fully
+ * \param[in] cipher_suite      The cipher suite to use. (A cipher suite fully
  *                              characterizes a PAKE algorithm and determines
  *                              the algorithm as well.)
  *
@@ -1362,7 +1362,7 @@ static psa_pake_operation_t psa_pake_operation_init(void);
  *         results in this error code.
  */
 psa_status_t psa_pake_setup(psa_pake_operation_t *operation,
-                            psa_pake_cipher_suite_t cipher_suite);
+                            const psa_pake_cipher_suite_t *cipher_suite);
 
 /** Set the password for a password-authenticated key exchange from key ID.
  *
@@ -1818,7 +1818,6 @@ static inline struct psa_pake_cipher_suite_s psa_pake_cipher_suite_init(void)
     return(v);
 }
 
-/* This only zeroes out the first byte in the union, the rest is unspecified. */
 static inline struct psa_pake_operation_s psa_pake_operation_init(void)
 {
     const struct psa_pake_operation_s v = PSA_PAKE_OPERATION_INIT;

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -1512,13 +1512,13 @@ psa_status_t psa_pake_set_user(psa_pake_operation_t *operation,
  *
  * \retval #PSA_SUCCESS
  *         Success.
+ * \retval #PSA_ERROR_INVALID_ARGUMENT
+ *         \p user_id is not valid for the \p operation's algorithm and cipher
+ *         suite.
  * \retval #PSA_ERROR_NOT_SUPPORTED
  *         The algorithm doesn't associate a second identity with the session.
- * \retval #PSA_ERROR_INVALID_ARGUMENT
- *         \p user_id is NULL.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
- * \retval #PSA_ERROR_HARDWARE_FAILURE
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
  * \retval #PSA_ERROR_BAD_STATE
  *         The operation state is not valid, or the library has not

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -1768,6 +1768,7 @@ psa_status_t psa_pake_get_implicit_key(psa_pake_operation_t *operation,
  * \param[in,out] operation    The operation to abort.
  *
  * \retval #PSA_SUCCESS
+ *         Success.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
  * \retval #PSA_ERROR_BAD_STATE

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -1727,13 +1727,17 @@ psa_status_t psa_pake_input(psa_pake_operation_t *operation,
  * \retval #PSA_SUCCESS
  *         Success.
  * \retval #PSA_ERROR_INVALID_ARGUMENT
- *         #PSA_KEY_DERIVATION_INPUT_SECRET is not compatible with the output’s
- *         algorithm.
+ *         #PSA_KEY_DERIVATION_INPUT_SECRET is not compatible with the
+ *         algorithm in the \p output key derivation operation.
+ * \retval #PSA_ERROR_NOT_SUPPORTED
+ *         Input from a PAKE is not supported by the algorithm in the \p output
+ *         key derivation operation.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
- * \retval #PSA_ERROR_HARDWARE_FAILURE
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ * \retval #PSA_ERROR_DATA_CORRUPT
+ * \retval #PSA_ERROR_DATA_INVALID
  * \retval #PSA_ERROR_BAD_STATE
  *         The PAKE operation state is not valid (it must be active, but beyond
  *         that validity is specific to the algorithm), or

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -870,7 +870,7 @@ psa_status_t mbedtls_psa_platform_get_builtin_key(
  * Section 2.3.8 of _SEC 1: Elliptic Curve Cryptography_
  * (https://www.secg.org/sec1-v2.pdf), before reducing it modulo \c q. Here
  * \c q is order of the group defined by the primitive set in the cipher suite.
- * The \c psa_pake_set_password() functions return an error if the result
+ * The \c psa_pake_set_password() function returns an error if the result
  * of the reduction is 0.)
  *
  * The key exchange flow for J-PAKE is as follows:
@@ -1538,7 +1538,7 @@ psa_status_t psa_pake_set_peer( psa_pake_operation_t *operation,
  * values of type ::psa_algorithm_t such that #PSA_ALG_IS_PAKE(\c alg) is true)
  * for more information.
  *
- * \param[in,out] operation     The operation object to specificy the
+ * \param[in,out] operation     The operation object to specify the
  *                              application's role for. It must have been set up
  *                              by psa_pake_setup() and not yet in use (neither
  *                              psa_pake_output() nor psa_pake_input() has been

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -1673,6 +1673,31 @@ psa_status_t psa_pake_input(psa_pake_operation_t *operation,
 psa_status_t psa_pake_get_implicit_key(psa_pake_operation_t *operation,
                                        psa_key_derivation_operation_t *output);
 
+/** Abort a PAKE operation.
+ *
+ * Aborting an operation frees all associated resources except for the \c
+ * operation structure itself. Once aborted, the operation object can be reused
+ * for another operation by calling psa_pake_setup() again.
+ *
+ * This function may be called at any time after the operation
+ * object has been initialized as described in #psa_pake_operation_t.
+ *
+ * In particular, calling psa_pake_abort() after the operation has been
+ * terminated by a call to psa_pake_abort() or psa_pake_get_implicit_key()
+ * is safe and has no effect.
+ *
+ * \param[in,out] operation    The operation to abort.
+ *
+ * \retval #PSA_SUCCESS
+ * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ * \retval #PSA_ERROR_BAD_STATE
+ *         The library has not been previously initialized by psa_crypto_init().
+ *         It is implementation-dependent whether a failure to initialize
+ *         results in this error code.
+ */
+psa_status_t psa_pake_abort(psa_pake_operation_t * operation);
+
 /**@}*/
 
 /** A sufficient output buffer size for psa_pake_output().

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -1743,9 +1743,10 @@ psa_status_t psa_pake_abort(psa_pake_operation_t * operation);
  * \param output_step   A value of type ::psa_pake_step_t that is valid for the
  *                      algorithm \p alg.
  * \return              A sufficient output buffer size for the specified
- *                      output, cipher suite and algorithm. If the cipher suite,
- *                      the output type or PAKE algorithm is not recognized, or
- *                      the parameters are incompatible, return 0.
+ *                      PAKE algorithm, primitive, and output step. If the
+ *                      PAKE algorithm, primitive, or output step is not
+ *                      recognized, or the parameters are incompatible,
+ *                      return 0.
  */
 #define PSA_PAKE_OUTPUT_SIZE(alg, primitive, output_step) 0
 

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -1472,10 +1472,12 @@ psa_status_t psa_pake_set_password_key(psa_pake_operation_t *operation,
  * \retval #PSA_SUCCESS
  *         Success.
  * \retval #PSA_ERROR_INVALID_ARGUMENT
- *         \p user_id is NULL.
+ *         \p user_id is not valid for the \p operation's algorithm and cipher
+ *         suite.
+ * \retval #PSA_ERROR_NOT_SUPPORTED
+ *         The value of \p user_id is not supported by the implementation.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
- * \retval #PSA_ERROR_HARDWARE_FAILURE
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
  * \retval #PSA_ERROR_BAD_STATE
  *         The operation state is not valid, or

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -1238,6 +1238,20 @@ static psa_pake_family_t psa_pake_cs_get_family(
                            const psa_pake_cipher_suite_t* cipher_suite
                            );
 
+/** Retrieve the PAKE primitive bit-size from a PAKE cipher suite.
+ *
+ * This function may be declared as `static` (i.e. without external
+ * linkage). This function may be provided as a function-like macro,
+ * but in this case it must evaluate its argument exactly once.
+ *
+ * \param[in] cipher_suite     The cipher suite structure to query.
+ *
+ * \return The PAKE primitive bit-size stored in the cipher suite structure.
+ */
+static uint16_t psa_pake_cs_get_bits(
+                           const psa_pake_cipher_suite_t* cipher_suite
+                           );
+
 /** Retrieve the hash algorithm from a PAKE cipher suite.
  *
  * This function may be declared as `static` (i.e. without external
@@ -1829,6 +1843,12 @@ static inline psa_pake_family_t psa_pake_cs_get_family(
     const psa_pake_cipher_suite_t *cipher_suite)
 {
     return(cipher_suite->family);
+}
+
+static inline uint16_t psa_pake_cs_get_bits(
+    const psa_pake_cipher_suite_t *cipher_suite)
+{
+    return(cipher_suite->bits);
 }
 
 static inline psa_algorithm_t psa_pake_cs_get_hash(

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -1378,10 +1378,18 @@ static psa_pake_operation_t psa_pake_operation_init(void);
  *
  * \retval #PSA_SUCCESS
  *         Success.
+ * \retval #PSA_ERROR_INVALID_ARGUMENT
+ *         The algorithm in \p cipher_suite is not a PAKE algorithm, or the
+ *         PAKE primitive in \p cipher_suite is not compatible with the
+ *         PAKE algorithm, or the hash algorithm in \p cipher_suite is invalid
+ *         or not compatible with the PAKE algorithm and primitive.
  * \retval #PSA_ERROR_NOT_SUPPORTED
- *         The \p cipher_suite is not supported or is not valid.
+ *         The algorithm in \p cipher_suite is not a supported PAKE algorithm,
+ *         or the PAKE primitive in \p cipher_suite is not supported or not
+ *         compatible with the PAKE algorithm, or the hash algorithm in
+ *         \p cipher_suite is not supported or not compatible with the PAKE
+ *         algorithm and primitive.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
- * \retval #PSA_ERROR_HARDWARE_FAILURE
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
  * \retval #PSA_ERROR_BAD_STATE
  *         The operation state is not valid, or

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -1166,10 +1166,6 @@ static psa_pake_cipher_suite_t psa_pake_cipher_suite_init( void );
 
 /** Retrieve the PAKE algorithm from a PAKE cipher suite.
  *
- * This function may be declared as `static` (i.e. without external
- * linkage). This function may be provided as a function-like macro,
- * but in this case it must evaluate its argument exactly once.
- *
  * \param[in] cipher_suite     The cipher suite structure to query.
  *
  * \return The PAKE algorithm stored in the cipher suite structure.
@@ -1181,10 +1177,6 @@ static psa_algorithm_t psa_pake_cs_get_algorithm(
  *
  * This function overwrites any PAKE algorithm
  * previously set in \p cipher_suite.
- *
- * This function may be declared as `static` (i.e. without external
- * linkage). This function may be provided as a function-like macro,
- * but in this case it must evaluate each of its arguments exactly once.
  *
  * \param[out] cipher_suite    The cipher suite structure to write to.
  * \param algorithm            The PAKE algorithm to write.
@@ -1198,10 +1190,6 @@ static void psa_pake_cs_set_algorithm( psa_pake_cipher_suite_t *cipher_suite,
 
 /** Retrieve the primitive from a PAKE cipher suite.
  *
- * This function may be declared as `static` (i.e. without external linkage).
- * This function may be provided as a function-like macro, but in this case it
- * must evaluate its argument exactly once.
- *
  * \param[in] cipher_suite     The cipher suite structure to query.
  *
  * \return The primitive stored in the cipher suite structure.
@@ -1213,10 +1201,6 @@ static psa_pake_primitive_t psa_pake_cs_get_primitive(
  *
  * This function overwrites any primitive previously set in \p cipher_suite.
  *
- * This function may be declared as `static` (i.e. without external
- * linkage). This function may be provided as a function-like macro,
- * but in this case it must evaluate each of its arguments exactly once.
- *
  * \param[out] cipher_suite    The cipher suite structure to write to.
  * \param primitive            The primitive to write. If this is 0, the
  *                             primitive type in \p cipher_suite becomes
@@ -1227,10 +1211,6 @@ static void psa_pake_cs_set_primitive( psa_pake_cipher_suite_t *cipher_suite,
 
 /** Retrieve the PAKE family from a PAKE cipher suite.
  *
- * This function may be declared as `static` (i.e. without external
- * linkage). This function may be provided as a function-like macro,
- * but in this case it must evaluate its argument exactly once.
- *
  * \param[in] cipher_suite     The cipher suite structure to query.
  *
  * \return The PAKE family stored in the cipher suite structure.
@@ -1240,10 +1220,6 @@ static psa_pake_family_t psa_pake_cs_get_family(
 
 /** Retrieve the PAKE primitive bit-size from a PAKE cipher suite.
  *
- * This function may be declared as `static` (i.e. without external
- * linkage). This function may be provided as a function-like macro,
- * but in this case it must evaluate its argument exactly once.
- *
  * \param[in] cipher_suite     The cipher suite structure to query.
  *
  * \return The PAKE primitive bit-size stored in the cipher suite structure.
@@ -1252,10 +1228,6 @@ static uint16_t psa_pake_cs_get_bits(
                            const psa_pake_cipher_suite_t *cipher_suite );
 
 /** Retrieve the hash algorithm from a PAKE cipher suite.
- *
- * This function may be declared as `static` (i.e. without external
- * linkage). This function may be provided as a function-like macro,
- * but in this case it must evaluate its argument exactly once.
  *
  * \param[in] cipher_suite      The cipher suite structure to query.
  *
@@ -1270,10 +1242,6 @@ static psa_algorithm_t psa_pake_cs_get_hash(
  *
  * This function overwrites any hash algorithm
  * previously set in \p cipher_suite.
- *
- * This function may be declared as `static` (i.e. without external
- * linkage). This function may be provided as a function-like macro,
- * but in this case it must evaluate each of its arguments exactly once.
  *
  * Refer to the documentation of individual PAKE algorithm types (`PSA_ALG_XXX`
  * values of type ::psa_algorithm_t such that #PSA_ALG_IS_PAKE(\c alg) is true)

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -1731,6 +1731,11 @@ psa_status_t psa_pake_get_implicit_key(psa_pake_operation_t *operation,
  */
 #define PSA_PAKE_INPUT_MAX_SIZE 0
 
+/** Returns a suitable initializer for a PAKE cipher suite object of type
+ * psa_pake_cipher_suite_t.
+ */
+#define PSA_PAKE_CIPHER_SUITE_INIT {PSA_ALG_NONE, 0, 0, 0, PSA_ALG_NONE}
+
 struct psa_pake_cipher_suite_s
 {
     psa_algorithm_t algorithm;

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -1422,14 +1422,23 @@ psa_status_t psa_pake_setup(psa_pake_operation_t *operation,
  *
  * \retval #PSA_SUCCESS
  *         Success.
- * \retval #PSA_ERROR_INVALID_ARGUMENT
- *         \p key is not compatible with the algorithm or the cipher suite.
- * \retval #PSA_ERROR_CORRUPTION_DETECTED
  * \retval #PSA_ERROR_INVALID_HANDLE
- * \retval #PSA_ERROR_COMMUNICATION_FAILURE
- * \retval #PSA_ERROR_HARDWARE_FAILURE
- * \retval #PSA_ERROR_STORAGE_FAILURE
+ *         \p password is not a valid key identifier.
  * \retval #PSA_ERROR_NOT_PERMITTED
+ *         The key does not have the #PSA_KEY_USAGE_DERIVE flag, or it does not
+ *         permit the \p operation's algorithm.
+ * \retval #PSA_ERROR_INVALID_ARGUMENT
+ *         The key type for \p password is not #PSA_KEY_TYPE_PASSWORD or
+ *         #PSA_KEY_TYPE_PASSWORD_HASH, or \p password is not compatible with
+ *         the \p operation's cipher suite.
+ * \retval #PSA_ERROR_NOT_SUPPORTED
+ *         The key type or key size of \p password is not supported with the
+ *         \p operation's cipher suite.
+ * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ * \retval #PSA_ERROR_STORAGE_FAILURE
+ * \retval #PSA_ERROR_DATA_CORRUPT
+ * \retval #PSA_ERROR_DATA_INVALID
  * \retval #PSA_ERROR_BAD_STATE
  *         The operation state is not valid (it must have been set up.), or
  *         the library has not been previously initialized by psa_crypto_init().

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -870,7 +870,7 @@ psa_status_t mbedtls_psa_platform_get_builtin_key(
  * Section 2.3.8 of _SEC 1: Elliptic Curve Cryptography_
  * (https://www.secg.org/sec1-v2.pdf), before reducing it modulo \c q. Here
  * \c q is order of the group defined by the primitive set in the cipher suite.
- * The \c psa_pake_set_password() function returns an error if the result
+ * The \c psa_pake_set_password_key() function returns an error if the result
  * of the reduction is 0.)
  *
  * The key exchange flow for J-PAKE is as follows:

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -1614,11 +1614,17 @@ psa_status_t psa_pake_set_role(psa_pake_operation_t *operation,
  *         Success.
  * \retval #PSA_ERROR_BUFFER_TOO_SMALL
  *         The size of the \p output buffer is too small.
+ * \retval #PSA_ERROR_INVALID_ARGUMENT
+ *         \p step is not compatible with the operation's algorithm.
+ * \retval #PSA_ERROR_NOT_SUPPORTED
+ *         \p step is not supported with the operation's algorithm.
+ * \retval #PSA_ERROR_INSUFFICIENT_ENTROPY
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
- * \retval #PSA_ERROR_HARDWARE_FAILURE
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ * \retval #PSA_ERROR_DATA_CORRUPT
+ * \retval #PSA_ERROR_DATA_INVALID
  * \retval #PSA_ERROR_BAD_STATE
  *         The operation state is not valid (it must be active, but beyond that
  *         validity is specific to the algorithm), or

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -862,15 +862,15 @@ psa_status_t mbedtls_psa_platform_get_builtin_key(
  * psa_pake_set_password_key(operation, ...);
  * \endcode
  *
- * The password is read as a byte array and must be non-empty. This can be the
- * password itself (in some pre-defined character encoding) or some value
- * derived from the password as mandated by some higher level protocol.
+ * The password is provided as a key. This can be the password text itself,
+ * in an agreed character encoding, or some value derived from the password
+ * as required by a higher level protocol.
  *
- * (The implementation converts this byte array to a number as described in
+ * (The implementation converts the key material to a number as described in
  * Section 2.3.8 of _SEC 1: Elliptic Curve Cryptography_
  * (https://www.secg.org/sec1-v2.pdf), before reducing it modulo \c q. Here
  * \c q is order of the group defined by the primitive set in the cipher suite.
- * The \c psa_pake_set_password_xxx() functions return an error if the result
+ * The \c psa_pake_set_password() functions return an error if the result
  * of the reduction is 0.)
  *
  * The key exchange flow for J-PAKE is as follows:

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -1588,12 +1588,12 @@ psa_status_t psa_pake_output(psa_pake_operation_t *operation,
  *
  * \param[in,out] operation    Active PAKE operation.
  * \param step                 The step for which the input is provided.
- * \param[out] input           Buffer containing the input in the format
+ * \param[in] input            Buffer containing the input in the format
  *                             appropriate for this \p step. Refer to the
  *                             documentation of the individual
  *                             \c PSA_PAKE_STEP_XXX constants for more
  *                             information.
- * \param[out] input_length    Size of the \p input buffer in bytes.
+ * \param input_length         Size of the \p input buffer in bytes.
  *
  * \retval #PSA_SUCCESS
  *         Success.
@@ -1613,7 +1613,7 @@ psa_status_t psa_pake_output(psa_pake_operation_t *operation,
  */
 psa_status_t psa_pake_input(psa_pake_operation_t *operation,
                             psa_pake_step_t step,
-                            uint8_t *input,
+                            const uint8_t *input,
                             size_t input_length);
 
 /** Get implicitly confirmed shared secret from a PAKE.

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -1862,7 +1862,7 @@ static inline void psa_pake_cs_set_algorithm(
     psa_pake_cipher_suite_t *cipher_suite,
     psa_algorithm_t algorithm)
 {
-    if( !PSA_ALG_IS_PAKE(algorithm) )
+    if( !PSA_ALG_IS_PAKE( algorithm ) )
         cipher_suite->algorithm = 0;
     else
         cipher_suite->algorithm = algorithm;
@@ -1871,8 +1871,8 @@ static inline void psa_pake_cs_set_algorithm(
 static inline psa_pake_primitive_t psa_pake_cs_get_primitive(
                         const psa_pake_cipher_suite_t *cipher_suite )
 {
-    return( PSA_PAKE_PRIMITIVE(cipher_suite->type, cipher_suite->family,
-                               cipher_suite->bits) );
+    return( PSA_PAKE_PRIMITIVE( cipher_suite->type, cipher_suite->family,
+                                cipher_suite->bits ) );
 }
 
 static inline void psa_pake_cs_set_primitive(
@@ -1905,7 +1905,7 @@ static inline psa_algorithm_t psa_pake_cs_get_hash(
 static inline void psa_pake_cs_set_hash( psa_pake_cipher_suite_t *cipher_suite,
                                          psa_algorithm_t hash )
 {
-    if( !PSA_ALG_IS_HASH(hash) )
+    if( !PSA_ALG_IS_HASH( hash ) )
         cipher_suite->hash = 0;
     else
         cipher_suite->hash = hash;

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -1663,13 +1663,22 @@ psa_status_t psa_pake_output(psa_pake_operation_t *operation,
  *
  * \retval #PSA_SUCCESS
  *         Success.
+ * \retval #PSA_ERROR_INVALID_SIGNATURE
+ *         The verification fails for a #PSA_PAKE_STEP_ZK_PROOF input step.
  * \retval #PSA_ERROR_INVALID_ARGUMENT
- *         The input is not valid for the algorithm, ciphersuite or \p step.
+ *         \p is not compatible with the \p operation’s algorithm, or the
+ *         \p input is not valid for the \p operation's algorithm, cipher suite
+ *         or \p step.
+ * \retval #PSA_ERROR_NOT_SUPPORTED
+ *         \p step p is not supported with the \p operation's algorithm, or the
+ *         \p input is not supported for the \p operation's algorithm, cipher
+ *         suite or \p step.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
- * \retval #PSA_ERROR_HARDWARE_FAILURE
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
  * \retval #PSA_ERROR_STORAGE_FAILURE
+ * \retval #PSA_ERROR_DATA_CORRUPT
+ * \retval #PSA_ERROR_DATA_INVALID
  * \retval #PSA_ERROR_BAD_STATE
  *         The operation state is not valid (it must be active, but beyond that
  *         validity is specific to the algorithm), or

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -1740,6 +1740,11 @@ psa_status_t psa_pake_get_implicit_key(psa_pake_operation_t *operation,
  */
 #define PSA_PAKE_CIPHER_SUITE_INIT {PSA_ALG_NONE, 0, 0, 0, PSA_ALG_NONE}
 
+/** Returns a suitable initializer for a PAKE operation object of type
+ * psa_pake_operation_t.
+ */
+#define PSA_PAKE_OPERATION_INIT {0, {0}}
+
 struct psa_pake_cipher_suite_s
 {
     psa_algorithm_t algorithm;
@@ -1814,7 +1819,6 @@ static inline struct psa_pake_cipher_suite_s psa_pake_cipher_suite_init(void)
 }
 
 /* This only zeroes out the first byte in the union, the rest is unspecified. */
-#define PSA_PAKE_OPERATION_INIT {0, {0}}
 static inline struct psa_pake_operation_s psa_pake_operation_init(void)
 {
     const struct psa_pake_operation_s v = PSA_PAKE_OPERATION_INIT;

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -1528,7 +1528,8 @@ psa_status_t psa_pake_set_user(psa_pake_operation_t *operation,
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
  * \retval #PSA_ERROR_BAD_STATE
- *         The operation state is not valid, or the library has not
+ *         Calling psa_pake_set_peer() is invalid with the \p operation's
+ *         algorithm, the operation state is not valid, or the library has not
  *         been previously initialized by psa_crypto_init().
  *         It is implementation-dependent whether a failure to initialize
  *         results in this error code.

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -1852,7 +1852,7 @@ psa_status_t psa_pake_abort(psa_pake_operation_t * operation);
 /** Returns a suitable initializer for a PAKE operation object of type
  * psa_pake_operation_t.
  */
-#define PSA_PAKE_OPERATION_INIT {0, {0}}
+#define PSA_PAKE_OPERATION_INIT {PSA_ALG_NONE, {0}}
 
 struct psa_pake_cipher_suite_s
 {

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -1826,21 +1826,21 @@ psa_status_t psa_pake_abort(psa_pake_operation_t * operation);
  */
 #define PSA_PAKE_INPUT_SIZE(alg, primitive, input_step) 0
 
-/** Output buffer size for psa_pake_output() for any of the supported cipher
- * suites and PAKE algorithms.
+/** Output buffer size for psa_pake_output() for any of the supported PAKE
+ * algorithm and primitive suites and output step.
  *
  * This macro must expand to a compile-time constant integer.
  *
- * See also #PSA_PAKE_OUTPUT_SIZE(\p alg, \p cipher_suite, \p output).
+ * See also #PSA_PAKE_OUTPUT_SIZE(\p alg, \p primitive, \p step).
  */
 #define PSA_PAKE_OUTPUT_MAX_SIZE 0
 
-/** Input buffer size for psa_pake_input() for any of the supported cipher
- * suites and PAKE algorithms.
+/** Input buffer size for psa_pake_input() for any of the supported PAKE
+ * algorithm and primitive suites and input step.
  *
  * This macro must expand to a compile-time constant integer.
  *
- * See also #PSA_PAKE_INPUT_SIZE(\p alg, \p cipher_suite, \p input).
+ * See also #PSA_PAKE_INPUT_SIZE(\p alg, \p primitive, \p step).
  */
 #define PSA_PAKE_INPUT_MAX_SIZE 0
 


### PR DESCRIPTION
## Description
Fixup PSA J-PAKE API against PSA Cryptography API 1.1 PAKE Extension.

Resolves https://github.com/Mbed-TLS/mbedtls/issues/4745

## Status
**IN DEVELOPMENT**

## Requires Backporting
NO  

## Migrations
NO

## Additional comments
N/A

## Todos
- [x] `PSA_PAKE_CIPHER_SUITE_INIT` not provided by Mbed TLS.
- [x] `psa_pake_cipher_suite_init()` not provided by Mbed TLS.
- [x] `PSA_PAKE_OPERATION_INIT` not documented by Mbed TLS
- [x] The `cipher_suite` parameter to `psa_pake_setup()` should be passed by reference as const `psa_pake_cipher_suite_t *`, instead of by value as `psa_pake_cipher_suite_t`.
- [x] The `input` parameter to `psa_pake_input()` should be const `uint8_t *`, instead of `uint8_t *`.
- [x] The `input` and `input_length` parameters to `psa_pake_input()` are documented as [out] parameters in the doxygen comments in Mbed TLS.
- [x] `psa_pake_abort()` is not defined (but referenced) in Mbed TLS.
- [x] In Mbed TLS, `psa_pake_cs_get_family()` and `psa_pake_cs_get_bits()` are referenced by `PSA_PAKE_PRIMITIVE_TYPE_DH` and `PSA_PAKE_PRIMITIVE_TYPE_ECC`, but not defined.
- [x] In the buffer size macro `PSA_PAKE_OUTPUT_SIZE()` , the return value description still talks about 'cipher suite' and 'output type', instead of the 'primitive' and 'output step'.
- [x] The same holds for `PSA_PAKE_INPUT_SIZE()`
- [x] The `output_size` parameter for `psa_pake_output()` refers to `PSA_PAKE_OUTPUT_SIZE(alg, cipher_suite, type)` to calculate the buffer size. Clearly this should be `PSA_PAKE_OUTPUT_SIZE(alg, primitive, step)`. The spec documentation also defines alg and primitive as these are not local to the function being called (in the cipher-suite used to set up the operation).
- [x] PSA_ALG_JPAKE itself, the description of how the password is processed has not been properly updated to reflect that only way to input a password is via a key. e.g.:
   - "the password is read as a byte array" - might be better to describe the 'key material' or 'key content'.
   - ".. must be non-empty" - redundant, keys cannot have size zero.
   - "The psa_pake_set_password_xxx() functions - there is only one for now, psa_pake_set_password_key(). 
- [x] The error documentation in the specification is more complete, aligning it with the latest changes in the main API document.
psa_pake_set_peer() results in PSA_ERROR_BAD_STATE instead of PSA_ERROR_NOT_SUPPORTED if the algorithm does not use peer identities.
- [x] The handling of invalid roles, and algorithms without roles, for psa_pake_set_side() is tightened: PSA_PAKE_SIDE_NONE is introduced
- [x] Values that are not valid for the algorithm result in PSA_ERROR_INVALID_ARGUMENT.
- [x] Mandate the ordering of inputs and outputs for J-PAKE.
- [x] Clarify where and how an algorithm/verification failure will be reported in the API.
- [x] Verification failure is reported by `psa_pake_input()` using `PSA_ERROR_INVALID_SIGNATURE` instead of `PSA_ERROR_INVALID_ARGUMENT`.
- [x] Change from 'side' to 'role' in the API:
    -   `psa_pake_side_t` -> `psa_pake_role_t`
    -   `psa_pake_set_side()` -> `psa_pake_set_role()`
    -   `PSA_PAKE_SIDE_XXX` -> `PSA_PAKE_ROLE_XXX`

## Steps to test or reproduce
N/A