### PR TITLE
Backport 2.28: Remove duplicated PSA_WANT_ALG_CMAC in crypto_config.h

### DIFF
--- a/include/psa/crypto_config.h
+++ b/include/psa/crypto_config.h
@@ -60,7 +60,6 @@
 #define PSA_WANT_ALG_CMAC                       1
 #define PSA_WANT_ALG_CFB                        1
 #define PSA_WANT_ALG_CHACHA20_POLY1305          1
-#define PSA_WANT_ALG_CMAC                       1
 #define PSA_WANT_ALG_CTR                        1
 #define PSA_WANT_ALG_DETERMINISTIC_ECDSA        1
 #define PSA_WANT_ALG_ECB_NO_PADDING             1


### PR DESCRIPTION
Signed-off-by: Summer Qin <summer.qin@arm.com>

Notes:
PSA_WANT_ALG_CMAC is defined twice in crypto_config.h

Backport of #5875


## Status
**READY**

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported



