### PR TITLE
Use PSA EC-JPAKE in TLS (1.2)

### DIFF
--- a/docs/use-psa-crypto.md
+++ b/docs/use-psa-crypto.md
@@ -86,7 +86,6 @@ is enabled, no change required on the application side.
 
 Current exceptions:
 
-- EC J-PAKE (when `MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED` is defined)
 - finite-field (non-EC) Diffie-Hellman (used in key exchanges: DHE-RSA,
   DHE-PSK)
 

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -50,7 +50,8 @@
 #include "mbedtls/sha512.h"
 #endif
 
-#if defined(MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED)
+#if defined(MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED) && \
+    !defined(MBEDTLS_USE_PSA_CRYPTO)
 #include "mbedtls/ecjpake.h"
 #endif
 
@@ -665,7 +666,13 @@ struct mbedtls_ssl_handshake_params
 #endif /* MBEDTLS_ECDH_C || MBEDTLS_ECDSA_C */
 
 #if defined(MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED)
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_pake_operation_t psa_pake_ctx;        /*!< EC J-PAKE key exchange */
+    mbedtls_svc_key_id_t psa_pake_password;
+    uint8_t psa_pake_ctx_is_ok;
+#else
     mbedtls_ecjpake_context ecjpake_ctx;        /*!< EC J-PAKE key exchange */
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 #if defined(MBEDTLS_SSL_CLI_C)
     unsigned char *ecjpake_cache;               /*!< Cache for ClientHello ext */
     size_t ecjpake_cache_len;                   /*!< Length of cached data */

--- a/library/ssl_tls12_client.c
+++ b/library/ssl_tls12_client.c
@@ -157,15 +157,24 @@ static int ssl_write_ecjpake_kkpp_ext( mbedtls_ssl_context *ssl,
                                        const unsigned char *end,
                                        size_t *olen )
 {
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_status_t status;
+#else
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
     unsigned char *p = buf;
     size_t kkpp_len;
 
     *olen = 0;
 
     /* Skip costly extension if we can't use EC J-PAKE anyway */
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    if( ssl->handshake->psa_pake_ctx_is_ok != 1 )
+        return( 0 );
+#else
     if( mbedtls_ecjpake_check( &ssl->handshake->ecjpake_ctx ) != 0 )
         return( 0 );
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     MBEDTLS_SSL_DEBUG_MSG( 3,
         ( "client hello, adding ecjpake_kkpp extension" ) );
@@ -185,6 +194,35 @@ static int ssl_write_ecjpake_kkpp_ext( mbedtls_ssl_context *ssl,
     {
         MBEDTLS_SSL_DEBUG_MSG( 3, ( "generating new ecjpake parameters" ) );
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+        size_t output_offset = 0;
+        size_t output_len;
+
+        /* Repeat the KEY_SHARE, ZK_PUBLIC & ZF_PROOF twice */
+        for( unsigned int x = 1 ; x <= 2 ; ++x )
+        {
+            for( psa_pake_step_t step = PSA_PAKE_STEP_KEY_SHARE ;
+                 step <= PSA_PAKE_STEP_ZK_PROOF ;
+                 ++step )
+            {
+                status = psa_pake_output( &ssl->handshake->psa_pake_ctx,
+                                          step, p + 2 + output_offset,
+                                          end - p - output_offset - 2,
+                                          &output_len );
+                if( status != PSA_SUCCESS )
+                {
+                    psa_destroy_key( ssl->handshake->psa_pake_password );
+                    psa_pake_abort( &ssl->handshake->psa_pake_ctx );
+                    MBEDTLS_SSL_DEBUG_RET( 1 , "psa_pake_output", status );
+                    return( psa_ssl_status_to_mbedtls( status ) );
+                }
+
+                output_offset += output_len;
+            }
+        }
+
+        kkpp_len = output_offset + output_len;
+#else
         ret = mbedtls_ecjpake_write_round_one( &ssl->handshake->ecjpake_ctx,
                                                p + 2, end - p - 2, &kkpp_len,
                                                ssl->conf->f_rng, ssl->conf->p_rng );
@@ -194,6 +232,7 @@ static int ssl_write_ecjpake_kkpp_ext( mbedtls_ssl_context *ssl,
                 "mbedtls_ecjpake_write_round_one", ret );
             return( ret );
         }
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
         ssl->handshake->ecjpake_cache = mbedtls_calloc( 1, kkpp_len );
         if( ssl->handshake->ecjpake_cache == NULL )
@@ -876,10 +915,11 @@ static int ssl_parse_supported_point_formats_ext( mbedtls_ssl_context *ssl,
             ssl->handshake->ecdh_ctx.point_format = p[0];
 #endif /* !MBEDTLS_USE_PSA_CRYPTO &&
           ( MBEDTLS_ECDH_C || MBEDTLS_ECDSA_C ) */
-#if defined(MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED)
+#if !defined(MBEDTLS_USE_PSA_CRYPTO) &&                             \
+    defined(MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED)
             mbedtls_ecjpake_set_point_format( &ssl->handshake->ecjpake_ctx,
                                               p[0] );
-#endif
+#endif /* !MBEDTLS_USE_PSA_CRYPTO && MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED */
             MBEDTLS_SSL_DEBUG_MSG( 4, ( "point format selected: %d", p[0] ) );
             return( 0 );
         }
@@ -903,6 +943,9 @@ static int ssl_parse_ecjpake_kkpp( mbedtls_ssl_context *ssl,
                                    size_t len )
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_status_t status;
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     if( ssl->handshake->ciphersuite_info->key_exchange !=
         MBEDTLS_KEY_EXCHANGE_ECJPAKE )
@@ -916,6 +959,51 @@ static int ssl_parse_ecjpake_kkpp( mbedtls_ssl_context *ssl,
     ssl->handshake->ecjpake_cache = NULL;
     ssl->handshake->ecjpake_cache_len = 0;
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    size_t input_offset = 0;
+
+    /* Repeat the KEY_SHARE, ZK_PUBLIC & ZF_PROOF twice */
+    for( unsigned int x = 1 ; x <= 2 ; ++x )
+    {
+        for( psa_pake_step_t step = PSA_PAKE_STEP_KEY_SHARE ;
+             step <= PSA_PAKE_STEP_ZK_PROOF ;
+             ++step )
+        {
+            /* Length is stored at the first byte */
+            size_t length = buf[input_offset] + 1;
+
+            if( input_offset + length > len )
+            {
+                ret = MBEDTLS_ERR_SSL_HANDSHAKE_FAILURE;
+                goto psa_pake_error;
+            }
+
+            status = psa_pake_input( &ssl->handshake->psa_pake_ctx, step,
+                                     buf + input_offset, length );
+            if( status != PSA_SUCCESS)
+            {
+                ret = psa_ssl_status_to_mbedtls( status );
+                goto psa_pake_error;
+            }
+
+            input_offset += length;
+        }
+    }
+
+    return( 0 );
+
+psa_pake_error:
+    psa_destroy_key( ssl->handshake->psa_pake_password );
+    psa_pake_abort( &ssl->handshake->psa_pake_ctx );
+
+    MBEDTLS_SSL_DEBUG_RET( 1, "psa_pake_input round one", ret );
+    mbedtls_ssl_send_alert_message(
+            ssl,
+            MBEDTLS_SSL_ALERT_LEVEL_FATAL,
+            MBEDTLS_SSL_ALERT_MSG_HANDSHAKE_FAILURE );
+
+    return( ret );
+#else
     if( ( ret = mbedtls_ecjpake_read_round_one( &ssl->handshake->ecjpake_ctx,
                                                 buf, len ) ) != 0 )
     {
@@ -928,6 +1016,7 @@ static int ssl_parse_ecjpake_kkpp( mbedtls_ssl_context *ssl,
     }
 
     return( 0 );
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 }
 #endif /* MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED */
 
@@ -2307,6 +2396,59 @@ start_processing:
 #if defined(MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED)
     if( ciphersuite_info->key_exchange == MBEDTLS_KEY_EXCHANGE_ECJPAKE )
     {
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+        psa_status_t status;
+        size_t len = end - p;
+        size_t input_offset = 0;
+
+        for( psa_pake_step_t step = PSA_PAKE_STEP_KEY_SHARE ;
+             step <= PSA_PAKE_STEP_ZK_PROOF ;
+             ++step )
+        {
+            size_t length;
+
+            if( step == PSA_PAKE_STEP_KEY_SHARE )
+            {
+                /* Length is stored after 3bytes curve */
+                length = 3 + p[input_offset + 3] + 1;
+            }
+            else
+            {
+                /* Length is stored at the first byte */
+                length = p[input_offset] + 1;
+            }
+
+            if( input_offset + length > len )
+            {
+                ret = MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
+                goto psa_pake_out;
+            }
+
+            status = psa_pake_input( &ssl->handshake->psa_pake_ctx, step,
+                                     p + input_offset, length );
+            if( status != PSA_SUCCESS)
+            {
+                ret = psa_ssl_status_to_mbedtls( status );
+                goto psa_pake_out;
+            }
+
+            input_offset += length;
+        }
+
+psa_pake_out:
+        if( ret != 0 )
+        {
+            psa_destroy_key( ssl->handshake->psa_pake_password );
+            psa_pake_abort( &ssl->handshake->psa_pake_ctx );
+
+            MBEDTLS_SSL_DEBUG_RET( 1, "psa_pake_input round two", ret );
+            mbedtls_ssl_send_alert_message(
+                ssl,
+                MBEDTLS_SSL_ALERT_LEVEL_FATAL,
+                MBEDTLS_SSL_ALERT_MSG_HANDSHAKE_FAILURE );
+            return( MBEDTLS_ERR_SSL_HANDSHAKE_FAILURE );
+        }
+#else
         ret = mbedtls_ecjpake_read_round_two( &ssl->handshake->ecjpake_ctx,
                                               p, end - p );
         if( ret != 0 )
@@ -2318,6 +2460,7 @@ start_processing:
                 MBEDTLS_SSL_ALERT_MSG_HANDSHAKE_FAILURE );
             return( MBEDTLS_ERR_SSL_HANDSHAKE_FAILURE );
         }
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
     }
     else
 #endif /* MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED */
@@ -3244,6 +3387,35 @@ ecdh_calc_secret:
     {
         header_len = 4;
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+        unsigned char *out_p = ssl->out_msg + header_len;
+        unsigned char *end_p = ssl->out_msg + MBEDTLS_SSL_OUT_CONTENT_LEN -
+                               header_len;
+        psa_status_t status;
+        size_t output_offset = 0;
+        size_t output_len;
+
+        for( psa_pake_step_t step = PSA_PAKE_STEP_KEY_SHARE ;
+             step <= PSA_PAKE_STEP_ZK_PROOF ;
+             ++step )
+        {
+            status = psa_pake_output( &ssl->handshake->psa_pake_ctx,
+                                      step, out_p + output_offset,
+                                      end_p - out_p - output_offset,
+                                      &output_len );
+            if( status != PSA_SUCCESS )
+            {
+                psa_destroy_key( ssl->handshake->psa_pake_password );
+                psa_pake_abort( &ssl->handshake->psa_pake_ctx );
+                MBEDTLS_SSL_DEBUG_RET( 1 , "psa_pake_output", status );
+                return( psa_ssl_status_to_mbedtls( status ) );
+            }
+
+            output_offset += output_len;
+        }
+
+        content_len = output_offset;
+#else
         ret = mbedtls_ecjpake_write_round_two( &ssl->handshake->ecjpake_ctx,
                 ssl->out_msg + header_len,
                 MBEDTLS_SSL_OUT_CONTENT_LEN - header_len,
@@ -3263,6 +3435,7 @@ ecdh_calc_secret:
             MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ecjpake_derive_secret", ret );
             return( ret );
         }
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
     }
     else
 #endif /* MBEDTLS_KEY_EXCHANGE_RSA_ENABLED */

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -274,10 +274,11 @@ static int ssl_parse_supported_point_formats( mbedtls_ssl_context *ssl,
             ssl->handshake->ecdh_ctx.point_format = p[0];
 #endif /* !MBEDTLS_USE_PSA_CRYPTO &&
           ( MBEDTLS_ECDH_C || MBEDTLS_ECDSA_C ) */
-#if defined(MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED)
+#if !defined(MBEDTLS_USE_PSA_CRYPTO) &&                             \
+    defined(MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED)
             mbedtls_ecjpake_set_point_format( &ssl->handshake->ecjpake_ctx,
                                               p[0] );
-#endif
+#endif /* !MBEDTLS_USE_PSA_CRYPTO && MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED */
             MBEDTLS_SSL_DEBUG_MSG( 4, ( "point format selected: %d", p[0] ) );
             return( 0 );
         }
@@ -298,13 +299,51 @@ static int ssl_parse_ecjpake_kkpp( mbedtls_ssl_context *ssl,
                                    size_t len )
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_status_t status;
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    if( ssl->handshake->psa_pake_ctx_is_ok != 1 )
+#else
     if( mbedtls_ecjpake_check( &ssl->handshake->ecjpake_ctx ) != 0 )
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
     {
         MBEDTLS_SSL_DEBUG_MSG( 3, ( "skip ecjpake kkpp extension" ) );
         return( 0 );
     }
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    size_t input_offset = 0;
+
+    /* Repeat the KEY_SHARE, ZK_PUBLIC & ZF_PROOF twice */
+    for( unsigned int x = 1 ; x <= 2 ; ++x )
+    {
+        for( psa_pake_step_t step = PSA_PAKE_STEP_KEY_SHARE ;
+             step <= PSA_PAKE_STEP_ZK_PROOF ;
+             ++step )
+        {
+            /* Length is stored at the first byte */
+            size_t length = buf[input_offset] + 1;
+
+            if( input_offset + length > len )
+            {
+                ret = MBEDTLS_ERR_SSL_HANDSHAKE_FAILURE;
+                goto psa_pake_error;
+            }
+
+            status = psa_pake_input( &ssl->handshake->psa_pake_ctx, step,
+                                     buf + input_offset, length );
+            if( status != PSA_SUCCESS)
+            {
+                ret = psa_ssl_status_to_mbedtls( status );
+                goto psa_pake_error;
+            }
+
+            input_offset += length;
+        }
+    }
+#else
     if( ( ret = mbedtls_ecjpake_read_round_one( &ssl->handshake->ecjpake_ctx,
                                                 buf, len ) ) != 0 )
     {
@@ -313,11 +352,26 @@ static int ssl_parse_ecjpake_kkpp( mbedtls_ssl_context *ssl,
                                         MBEDTLS_SSL_ALERT_MSG_ILLEGAL_PARAMETER );
         return( ret );
     }
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     /* Only mark the extension as OK when we're sure it is */
     ssl->handshake->cli_exts |= MBEDTLS_TLS_EXT_ECJPAKE_KKPP_OK;
 
     return( 0 );
+
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+psa_pake_error:
+    psa_destroy_key( ssl->handshake->psa_pake_password );
+    psa_pake_abort( &ssl->handshake->psa_pake_ctx );
+
+    MBEDTLS_SSL_DEBUG_RET( 1, "psa_pake_input round one", ret );
+    mbedtls_ssl_send_alert_message(
+            ssl,
+            MBEDTLS_SSL_ALERT_LEVEL_FATAL,
+            MBEDTLS_SSL_ALERT_MSG_HANDSHAKE_FAILURE );
+
+    return( ret );
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 }
 #endif /* MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED */
 
@@ -1970,7 +2024,11 @@ static void ssl_write_ecjpake_kkpp_ext( mbedtls_ssl_context *ssl,
                                         unsigned char *buf,
                                         size_t *olen )
 {
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_status_t status;
+#else
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
     unsigned char *p = buf;
     const unsigned char *end = ssl->out_msg + MBEDTLS_SSL_OUT_CONTENT_LEN;
     size_t kkpp_len;
@@ -1993,6 +2051,35 @@ static void ssl_write_ecjpake_kkpp_ext( mbedtls_ssl_context *ssl,
     MBEDTLS_PUT_UINT16_BE( MBEDTLS_TLS_EXT_ECJPAKE_KKPP, p, 0 );
     p += 2;
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    size_t output_offset = 0;
+    size_t output_len;
+
+    /* Repeat the KEY_SHARE, ZK_PUBLIC & ZF_PROOF twice */
+    for( unsigned int x = 1 ; x <= 2 ; ++x )
+    {
+        for( psa_pake_step_t step = PSA_PAKE_STEP_KEY_SHARE ;
+             step <= PSA_PAKE_STEP_ZK_PROOF ;
+             ++step )
+        {
+            status = psa_pake_output( &ssl->handshake->psa_pake_ctx,
+                                      step, p + 2 + output_offset,
+                                      end - p - output_offset - 2,
+                                      &output_len );
+            if( status != PSA_SUCCESS )
+            {
+                psa_destroy_key( ssl->handshake->psa_pake_password );
+                psa_pake_abort( &ssl->handshake->psa_pake_ctx );
+                MBEDTLS_SSL_DEBUG_RET( 1 , "psa_pake_output", status );
+                return;
+            }
+
+            output_offset += output_len;
+        }
+    }
+
+    kkpp_len = output_offset;
+#else
     ret = mbedtls_ecjpake_write_round_one( &ssl->handshake->ecjpake_ctx,
                                         p + 2, end - p - 2, &kkpp_len,
                                         ssl->conf->f_rng, ssl->conf->p_rng );
@@ -2001,6 +2088,7 @@ static void ssl_write_ecjpake_kkpp_ext( mbedtls_ssl_context *ssl,
         MBEDTLS_SSL_DEBUG_RET( 1 , "mbedtls_ecjpake_write_round_one", ret );
         return;
     }
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     MBEDTLS_PUT_UINT16_BE( kkpp_len, p, 0 );
     p += 2;
@@ -2804,6 +2892,35 @@ static int ssl_prepare_server_key_exchange( mbedtls_ssl_context *ssl,
 #if defined(MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED)
     if( ciphersuite_info->key_exchange == MBEDTLS_KEY_EXCHANGE_ECJPAKE )
     {
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+        unsigned char *out_p = ssl->out_msg + ssl->out_msglen;
+        unsigned char *end_p = ssl->out_msg + MBEDTLS_SSL_OUT_CONTENT_LEN -
+                               ssl->out_msglen;
+        psa_status_t status;
+        size_t output_offset = 0;
+        size_t output_len;
+
+        for( psa_pake_step_t step = PSA_PAKE_STEP_KEY_SHARE ;
+             step <= PSA_PAKE_STEP_ZK_PROOF ;
+             ++step )
+        {
+            status = psa_pake_output( &ssl->handshake->psa_pake_ctx,
+                                      step, out_p + output_offset,
+                                      end_p - out_p - output_offset,
+                                      &output_len );
+            if( status != PSA_SUCCESS )
+            {
+                psa_destroy_key( ssl->handshake->psa_pake_password );
+                psa_pake_abort( &ssl->handshake->psa_pake_ctx );
+                MBEDTLS_SSL_DEBUG_RET( 1 , "psa_pake_output", status );
+                return( psa_ssl_status_to_mbedtls( status ) );
+            }
+
+            output_offset += output_len;
+        }
+
+        ssl->out_msglen += output_offset;
+#else
         int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
         size_t len = 0;
 
@@ -2819,6 +2936,7 @@ static int ssl_prepare_server_key_exchange( mbedtls_ssl_context *ssl,
         }
 
         ssl->out_msglen += len;
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
     }
 #endif /* MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED */
 
@@ -4036,6 +4154,45 @@ static int ssl_parse_client_key_exchange( mbedtls_ssl_context *ssl )
 #if defined(MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED)
     if( ciphersuite_info->key_exchange == MBEDTLS_KEY_EXCHANGE_ECJPAKE )
     {
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+        size_t len = end - p;
+        psa_status_t status;
+        size_t input_offset = 0;
+
+        for( psa_pake_step_t step = PSA_PAKE_STEP_KEY_SHARE ;
+             step <= PSA_PAKE_STEP_ZK_PROOF ;
+             ++step )
+        {
+            /* Length is stored at the first byte */
+            size_t length = p[input_offset] + 1;
+
+            if( input_offset + length > len )
+            {
+                ret = MBEDTLS_ERR_SSL_HANDSHAKE_FAILURE;
+                goto psa_pake_out;
+            }
+
+            status = psa_pake_input( &ssl->handshake->psa_pake_ctx, step,
+                                     p + input_offset, length );
+            if( status != PSA_SUCCESS)
+            {
+                ret = psa_ssl_status_to_mbedtls( status );
+                goto psa_pake_out;
+            }
+
+            input_offset += length;
+        }
+
+psa_pake_out:
+        if( ret != 0 )
+        {
+            psa_destroy_key( ssl->handshake->psa_pake_password );
+            psa_pake_abort( &ssl->handshake->psa_pake_ctx );
+
+            MBEDTLS_SSL_DEBUG_RET( 1, "psa_pake_input round two", ret );
+            return( ret );
+        }
+#else
         ret = mbedtls_ecjpake_read_round_two( &ssl->handshake->ecjpake_ctx,
                                               p, end - p );
         if( ret != 0 )
@@ -4052,6 +4209,7 @@ static int ssl_parse_client_key_exchange( mbedtls_ssl_context *ssl )
             MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ecjpake_derive_secret", ret );
             return( ret );
         }
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
     }
     else
 #endif /* MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED */


### PR DESCRIPTION
## Description
TLS 1.2 has optional support for a key exchange based on EC J-PAKE, defined as part of the [Thread standard](https://www.threadgroup.org/ThreadSpec), see MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED. Currently the implementation always uses the mbedtls_ecjpake API regardless of whether MBEDTLS_USE_PSA_CRYPTO is enabled.

This task it to make it use the PSA API when MBEDTLS_USE_PSA_CRYPTO is enabled.

Resolves #5847 

## Status
**IN DEVELOPMENT**

## Requires Backporting
NO 

## Migrations
NO

## Additional comments
Depends on #6115 to be merged

## Todos
- [ ] Tests

## Steps to test or reproduce
ssl-opt.sh must run clean