### PR TITLE
Reduce RAM - move some variables to .rodata

### DIFF
--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -4348,7 +4348,7 @@ static uint16_t ssl_preset_default_groups[] = {
     MBEDTLS_SSL_IANA_TLS_GROUP_NONE
 };
 
-static int ssl_preset_suiteb_ciphersuites[] = {
+static const int ssl_preset_suiteb_ciphersuites[] = {
     MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
     MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
     0


### PR DESCRIPTION
Add const to move variables to .rodata section

Signed-off-by: Xeenych <xeenych@gmail.com>

Fix #5891 
