### PR TITLE
Changelog improvements before the 3.2 release

### DIFF
--- a/ChangeLog.d/add_final_delay_accessor
+++ b/ChangeLog.d/add_final_delay_accessor
@@ -1,4 +1,4 @@
 Features
    * Add the function mbedtls_timing_get_final_delay() to access the private
      final delay field in an mbedtls_timing_delay_context, as requested in
-     #5183
+     #5183.

--- a/ChangeLog.d/add_final_delay_accessor
+++ b/ChangeLog.d/add_final_delay_accessor
@@ -1,4 +1,4 @@
 Features
-   * Add the function mbedtls_timing_get_final_delay() to access the private
+   * Add function mbedtls_timing_get_final_delay() to access the private
      final delay field in an mbedtls_timing_delay_context, as requested in
      #5183.

--- a/ChangeLog.d/add_handshake_completion_accessor
+++ b/ChangeLog.d/add_handshake_completion_accessor
@@ -1,4 +1,4 @@
 Features
    * Add function mbedtls_ssl_is_handshake_over() to enable querying if the SSL
      Handshake has completed or not, and thus whether to continue calling
-     mbedtls_ssl_handshake_step(), requested in #4383
+     mbedtls_ssl_handshake_step(), requested in #4383.

--- a/ChangeLog.d/add_own_cid_accessors
+++ b/ChangeLog.d/add_own_cid_accessors
@@ -1,4 +1,4 @@
 Features
    * Add the function mbedtls_ssl_get_own_cid() to access our own connection id
-     within mbedtls_ssl_context, as requested in #5184
+     within mbedtls_ssl_context, as requested in #5184.
 

--- a/ChangeLog.d/cmake_add_subdirectory_support.txt
+++ b/ChangeLog.d/cmake_add_subdirectory_support.txt
@@ -1,4 +1,4 @@
 Changes
-   * Add aliases for libraries so that the normal MbedTLS::* targets
-     work when MbedTLS is built as a subdirectory.  Allows use of
-     CMake's FetchContent, as requested in #5688.
+   * In CMake builds, add aliases for libraries so that the normal MbedTLS::*
+     targets work when MbedTLS is built as a subdirectory. This allows the
+     use of FetchContent, as requested in #5688.

--- a/ChangeLog.d/cmake_fix_dll_install.txt
+++ b/ChangeLog.d/cmake_fix_dll_install.txt
@@ -1,3 +1,3 @@
 Changes
-   * cmake: Fix runtime library install location in mingw
-     This install DLLs in bin directory instead of lib.
+   * Fix runtime library install location when building with CMake and MinGW.
+     DLLs are now installed in the bin directory instead of lib.

--- a/ChangeLog.d/deprecate_mbedtls_cipher_setup_psa.txt
+++ b/ChangeLog.d/deprecate_mbedtls_cipher_setup_psa.txt
@@ -1,3 +1,3 @@
 New deprecations
-   * Deprecate mbedtls_cipher_setup_psa() function.
-     Use psa_aead_xxx() / psa_cipher_xxx() directly instead.
+   * Deprecate mbedtls_cipher_setup_psa(). Use psa_aead_xxx() or
+     psa_cipher_xxx() directly instead.

--- a/ChangeLog.d/fix-parllel-cmake-build-fail.txt
+++ b/ChangeLog.d/fix-parllel-cmake-build-fail.txt
@@ -1,3 +1,3 @@
 Bugfix
    * Fix a race condition in out-of-source builds with CMake when generated data
-     files are already present. Fixes #5374
+     files are already present. Fixes #5374.

--- a/ChangeLog.d/fix-windows-cmake-build-with-shared-libraries.txt
+++ b/ChangeLog.d/fix-windows-cmake-build-with-shared-libraries.txt
@@ -1,3 +1,3 @@
 Bugfix
-   * Fix compilation on Windows when building shared library, by setting
-     library search path to CMAKE_CURRENT_BINARY_DIR.
+   * Fix the library search path when building a shared library with CMake
+     on Windows.

--- a/ChangeLog.d/fix-x25519-program.txt
+++ b/ChangeLog.d/fix-x25519-program.txt
@@ -1,4 +1,4 @@
 Bugfix
-   * Fix a bug in x25519 example program where the removal of
+   * Fix a bug in the x25519 example program where the removal of
      MBEDTLS_ECDH_LEGACY_CONTEXT caused the program not to run. Fixes #4901 and
      #3191.

--- a/ChangeLog.d/mbedtls_ecp_export.txt
+++ b/ChangeLog.d/mbedtls_ecp_export.txt
@@ -1,3 +1,3 @@
 Features
-   * Add mbedtls_ecp_export() function to export ECP
-     keypair parameters. Fixes #4838.
+   * Add a function mbedtls_ecp_export() to export ECP key pair parameters.
+     Fixes #4838.

--- a/ChangeLog.d/mbedtls_ecp_export.txt
+++ b/ChangeLog.d/mbedtls_ecp_export.txt
@@ -1,3 +1,3 @@
 Features
-   * Add a function mbedtls_ecp_export() to export ECP key pair parameters.
+   * Add function mbedtls_ecp_export() to export ECP key pair parameters.
      Fixes #4838.

--- a/ChangeLog.d/mbedtls_sha256_a64_crypto_acceleration.txt
+++ b/ChangeLog.d/mbedtls_sha256_a64_crypto_acceleration.txt
@@ -1,2 +1,0 @@
-Features
-   * A64 SHA-2 crypto extension support for SHA-256

--- a/ChangeLog.d/mbedtls_sha2_a64_crypto_acceleration.txt
+++ b/ChangeLog.d/mbedtls_sha2_a64_crypto_acceleration.txt
@@ -1,0 +1,3 @@
+Features
+   * Add support for the ARMv8 SHA-2 acceleration instructions when building
+     for Aarch64.

--- a/ChangeLog.d/mbedtls_sha512_a64_crypto_acceleration.txt
+++ b/ChangeLog.d/mbedtls_sha512_a64_crypto_acceleration.txt
@@ -1,2 +1,0 @@
-Features
-   * A64 crypto extension support for SHA-512

--- a/ChangeLog.d/mbedtls_ssl_comfig_defaults-memleak.txt
+++ b/ChangeLog.d/mbedtls_ssl_comfig_defaults-memleak.txt
@@ -1,2 +1,2 @@
 Bugfix
-   * Fix memory leak if mbedtls_ssl_config_defaults() call is repeated
+   * Fix a memory leak if mbedtls_ssl_config_defaults() is called twice.

--- a/ChangeLog.d/mbedtls_ssl_tls13_client.txt
+++ b/ChangeLog.d/mbedtls_ssl_tls13_client.txt
@@ -1,4 +1,2 @@
 Features
-   * Add ALPN support in tls13 client. Client is able to write ALPN extension
-     in client hello, and able to parse the response from server encrypted
-     extension.
+   * Add ALPN support in TLS 1.3 clients.

--- a/ChangeLog.d/mbedtls_tlsver_enum.txt
+++ b/ChangeLog.d/mbedtls_tlsver_enum.txt
@@ -1,6 +1,10 @@
+New deprecations
+   * Deprecate mbedtls_ssl_conf_max_version() and
+     mbedtls_ssl_conf_min_version() in favor of
+     mbedtls_ssl_conf_max_tls_version() and
+     mbedtls_ssl_conf_min_tls_version().
+
 Features
-   * Unify internal/external TLS protocol version enums
-   * Deprecate mbedtls_ssl_conf_max_version()
-     Replaced with mbedtls_ssl_conf_max_tls_version()
-   * Deprecate mbedtls_ssl_conf_min_version()
-     Replaced with mbedtls_ssl_conf_min_tls_version()
+   * The new functions mbedtls_ssl_conf_max_tls_version() and
+     mbedtls_ssl_conf_min_tls_version() use a single value to specify
+     the protocol version.

--- a/ChangeLog.d/mbedtls_tlsver_enum.txt
+++ b/ChangeLog.d/mbedtls_tlsver_enum.txt
@@ -5,6 +5,6 @@ New deprecations
      mbedtls_ssl_conf_min_tls_version().
 
 Features
-   * The new functions mbedtls_ssl_conf_max_tls_version() and
-     mbedtls_ssl_conf_min_tls_version() use a single value to specify
+   * Add functions mbedtls_ssl_conf_max_tls_version() and
+     mbedtls_ssl_conf_min_tls_version() that use a single value to specify
      the protocol version.

--- a/ChangeLog.d/md_info_from_ctx.txt
+++ b/ChangeLog.d/md_info_from_ctx.txt
@@ -1,3 +1,3 @@
 Features
-   * Add a function to extract message digest information from a message
-     digest context.
+   * The new function mbedtls_md_info_from_ctx() recalls the message digest
+     information that was used to set up a message digest context.

--- a/ChangeLog.d/md_info_from_ctx.txt
+++ b/ChangeLog.d/md_info_from_ctx.txt
@@ -1,3 +1,3 @@
 Features
-   * The new function mbedtls_md_info_from_ctx() recalls the message digest
+   * Add function mbedtls_md_info_from_ctx() to recall the message digest
      information that was used to set up a message digest context.

--- a/ChangeLog.d/psa_aead_singleshot_error.txt
+++ b/ChangeLog.d/psa_aead_singleshot_error.txt
@@ -1,4 +1,4 @@
 Changes
-   * Return PSA_ERROR_INVALID_ARGUMENT if the algorithm passed to singleshot
+   * Return PSA_ERROR_INVALID_ARGUMENT if the algorithm passed to one-shot
      AEAD functions is not an AEAD algorithm. This aligns them with the
-     multipart functions, and the PSA Crypto API 1.1 spec.
+     multipart functions, and the PSA Crypto API 1.1 specification.

--- a/ChangeLog.d/psa_crypto_reduced_configs.txt
+++ b/ChangeLog.d/psa_crypto_reduced_configs.txt
@@ -1,5 +1,0 @@
-Changes
-   * Automatically enable MBEDTLS_PK_WRITE_C if MBEDTLS_PK_C and
-     MBEDTLS_USE_PSA_CRYPTO are enabled. This is due to ecdsa_verify_wrap
-     requirements, but will also probably be needed by RSA soon, hence the
-     broader PK_C requirement.

--- a/ChangeLog.d/psk_to_ms_mixed_psk.txt
+++ b/ChangeLog.d/psk_to_ms_mixed_psk.txt
@@ -1,4 +1,4 @@
 Features
     * Extend the existing PSA_ALG_TLS12_PSK_TO_MS() algorithm to support
-      mixed-psk. Add an optional input PSA_KEY_DERIVATION_INPUT_OTHER_SECRET
+      mixed-PSK. Add an optional input PSA_KEY_DERIVATION_INPUT_OTHER_SECRET
       holding the other secret.

--- a/ChangeLog.d/raw-agreement-destroy-missing.txt
+++ b/ChangeLog.d/raw-agreement-destroy-missing.txt
@@ -1,3 +1,0 @@
-Bugfix
-   * Add missing key slot destruction calls when a raw key agreement or
-     a public key export fails in ssl_write_client_key_exchange.

--- a/ChangeLog.d/tls13-fix-finished-fetch.txt
+++ b/ChangeLog.d/tls13-fix-finished-fetch.txt
@@ -1,5 +1,3 @@
 Bugfix
-   * Fix handshake failure when the peer Finished message has not been received
-     yet when we first try to fetch it. The fetching is moved before the
-     preprocessing computations to avoid doing them multiple times, which was
-     causing the handshake to fail.
+   * Fix a TLS 1.3 handshake failure when the peer Finished message has not
+     been received yet when we first try to fetch it.

--- a/ChangeLog.d/use-psa-ecdhe-curve.txt
+++ b/ChangeLog.d/use-psa-ecdhe-curve.txt
@@ -4,4 +4,4 @@ Bugfix
      client would fail to check that the curve selected by the server for
      ECDHE was indeed one that was offered. As a result, the client would
      accept any curve that it supported, even if that curve was not allowed
-     according to its configuration.
+     according to its configuration. Fixes #5291.

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -2813,9 +2813,9 @@
 /**
  * \def MBEDTLS_SHA256_USE_A64_CRYPTO_IF_PRESENT
  *
- * Enable acceleration of the SHA-256 cryptographic hash algorithm with the
- * Arm A64 cryptographic extensions if they are available at runtime. If not,
- * it will fall back to the C implementation.
+ * Enable acceleration of the SHA-256 and SHA-224 cryptographic hash algorithms
+ * with the ARMv8 cryptographic extensions if they are available at runtime.
+ * If not, the library will fall back to the C implementation.
  *
  * \note If MBEDTLS_SHA256_USE_A64_CRYPTO_IF_PRESENT is defined when building
  * for a non-Aarch64 build it will be silently ignored.
@@ -2838,9 +2838,9 @@
 /**
  * \def MBEDTLS_SHA256_USE_A64_CRYPTO_ONLY
  *
- * Enable acceleration of the SHA-256 cryptographic hash algorithm with the
- * Arm A64 cryptographic extensions, which must be available at runtime (or
- * an illegal instruction fault will occur).
+ * Enable acceleration of the SHA-256 and SHA-224 cryptographic hash algorithms
+ * with the ARMv8 cryptographic extensions, which must be available at runtime
+ * or else an illegal instruction fault will occur.
  *
  * \note This allows builds with a smaller code size than with
  * MBEDTLS_SHA256_USE_A64_CRYPTO_IF_PRESENT
@@ -2896,9 +2896,9 @@
 /**
  * \def MBEDTLS_SHA512_USE_A64_CRYPTO_IF_PRESENT
  *
- * Enable acceleration of the SHA-512 cryptographic hash algorithm with the
- * Arm A64 cryptographic extensions if they are available at runtime. If not,
- * it will fall back to the C implementation.
+ * Enable acceleration of the SHA-512 and SHA-384 cryptographic hash algorithms
+ * with the ARMv8 cryptographic extensions if they are available at runtime.
+ * If not, the library will fall back to the C implementation.
  *
  * \note If MBEDTLS_SHA512_USE_A64_CRYPTO_IF_PRESENT is defined when building
  * for a non-Aarch64 build it will be silently ignored.
@@ -2923,9 +2923,9 @@
 /**
  * \def MBEDTLS_SHA512_USE_A64_CRYPTO_ONLY
  *
- * Enable acceleration of the SHA-512 cryptographic hash algorithm with the
- * Arm A64 cryptographic extensions, which must be available at runtime (or
- * an illegal instruction fault will occur).
+ * Enable acceleration of the SHA-512 and SHA-384 cryptographic hash algorithms
+ * with the ARMv8 cryptographic extensions, which must be available at runtime
+ * or else an illegal instruction fault will occur.
  *
  * \note This allows builds with a smaller code size than with
  * MBEDTLS_SHA512_USE_A64_CRYPTO_IF_PRESENT


### PR DESCRIPTION
Miscellaneous improvements to changelog entries, including:

* Consolidating changelog entries from #5632 and #5547. Also update the documentation to list SHA-224 and SHA-384.
* Removing the bugfix entry added in https://github.com/Mbed-TLS/mbedtls/pull/5576, because upon further analysis there wasn't actually a bug.
* The clarification I requested in https://github.com/Mbed-TLS/mbedtls/pull/5837/files#r880337653.

I have only reviewed existing entries. I have not looked for missing entries.

Needs backport for a few entries.