### PR TITLE
Add missing break

### DIFF
--- a/tests/suites/host_test.function
+++ b/tests/suites/host_test.function
@@ -590,6 +590,7 @@ int execute_tests( int argc , const char ** argv )
              */
             test_files = &argv[ arg_index ];
             testfile_count = argc - arg_index;
+            break;
         }
 
         arg_index++;


### PR DESCRIPTION
## Description

In ''int execute_tests( int argc , const char ** argv )'' function, switch case is missing break statement.

The issue was, there was missing break statement in switch case. Result of this mistake, if you provide list of data files to test executable, it will only use last data file for test
 

## Status
*IN DEVELOPMENT*

## Requires Backporting

Yes
  
Which branch?

2.28

## Migrations

NO

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce

Run any test executable with multiple data files, it will use all data files for testing.