### PR TITLE
Update documentation of PSA_ALG_RSA_PSS

### DIFF
--- a/include/psa/crypto_values.h
+++ b/include/psa/crypto_values.h
@@ -1372,9 +1372,11 @@
  * This is the signature scheme defined by RFC 8017
  * (PKCS#1: RSA Cryptography Specifications) under the name
  * RSASSA-PSS, with the message generation function MGF1, and with
- * a salt length equal to the length of the hash. The specified
- * hash algorithm is used to hash the input message, to create the
- * salted hash, and for the mask generation.
+ * a salt length equal to the length of the hash, or the largest
+ * possible salt length for the algorithm and key size if that is
+ * smaller than the hash length. The specified hash algorithm is
+ * used to hash the input message, to create the salted hash, and
+ * for the mask generation.
  *
  * \param hash_alg      A hash algorithm (\c PSA_ALG_XXX value such that
  *                      #PSA_ALG_IS_HASH(\p hash_alg) is true).


### PR DESCRIPTION
## Description

Currently documenation of PSA_ALG_RSA_PSS doesn't reflect the change in code.
This closes #5856 

## Status
**IN REVIEW**

## Requires Backporting

Yes 

Which branch?

2.28

## Migrations

NO

## Additional comments

Note regarding issue #5856, positive test case already exist in test_suite_psa_crypto.

PSA verify hash: RSA-1024 PSS SHA-512, slen=62

Thus, no need to add new positive test case

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce

See documentation for PSA_ALG_RSA_PSS in include/psa/crypto_values.h file.
