### PR TITLE
Shrink Montgomery curve point for fast quasi-reduction

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -144,8 +144,6 @@ Bugfix
      operations psa_mac_compute() and psa_mac_sign_setup().
    * The key usage flags PSA_KEY_USAGE_VERIFY_MESSAGE now allows the MAC
      operations psa_mac_verify() and psa_mac_verify_setup().
-   * Fix a bug that ECP multiplication is wrongly rejecting valid input that is
-     used to store result. The rejected input is with many limbs. Fixes #5965.
 
 Changes
     * Explicitly mark the fields mbedtls_ssl_session.exported and

--- a/ChangeLog
+++ b/ChangeLog
@@ -144,6 +144,8 @@ Bugfix
      operations psa_mac_compute() and psa_mac_sign_setup().
    * The key usage flags PSA_KEY_USAGE_VERIFY_MESSAGE now allows the MAC
      operations psa_mac_verify() and psa_mac_verify_setup().
+   * Fix a bug that ECP multiplication is wrongly rejecting valid input that is
+     used to store result. The rejected input is with many limbs. Fixes #5965.
 
 Changes
     * Explicitly mark the fields mbedtls_ssl_session.exported and

--- a/ChangeLog.d/fix-montgomery-curve-mul-rejecting-input.txt
+++ b/ChangeLog.d/fix-montgomery-curve-mul-rejecting-input.txt
@@ -1,0 +1,4 @@
+Bugfix
+   * Fix a bug that ECP multiplication on Montgomery curve is wrongly rejecting
+     valid input that is used to store result. The rejected input is with many
+     limbs. Fixes #5965.

--- a/library/ecp.c
+++ b/library/ecp.c
@@ -2517,6 +2517,9 @@ static int ecp_mul_mxz( mbedtls_ecp_group *grp, mbedtls_ecp_point *R,
     /* Set R to zero in modified x/z coordinates */
     MPI_ECP_LSET( &R->X, 1 );
     MPI_ECP_LSET( &R->Z, 0 );
+    /* Shrink for fast quasi-reduction */
+    MBEDTLS_MPI_CHK( mbedtls_mpi_shrink( &R->X, 1 ) );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_shrink( &R->Z, 1 ) );
     mbedtls_mpi_free( &R->Y );
 
     /* RP.X might be slightly larger than P, so reduce it */

--- a/library/ecp.c
+++ b/library/ecp.c
@@ -2514,12 +2514,15 @@ static int ecp_mul_mxz( mbedtls_ecp_group *grp, mbedtls_ecp_point *R,
     MPI_ECP_MOV( &PX, &P->X );
     MBEDTLS_MPI_CHK( mbedtls_ecp_copy( &RP, P ) );
 
-    /* Set R to zero in modified x/z coordinates */
+    /*
+     * Set R to zero in modified x/z coordinates.
+     * Free first to make sure R does not have too many limbs
+     * as required by fast quasi-reduction.
+     */
+    mbedtls_mpi_free( &R->X );
+    mbedtls_mpi_free( &R->Z );
     MPI_ECP_LSET( &R->X, 1 );
     MPI_ECP_LSET( &R->Z, 0 );
-    /* Shrink for fast quasi-reduction */
-    MBEDTLS_MPI_CHK( mbedtls_mpi_shrink( &R->X, 1 ) );
-    MBEDTLS_MPI_CHK( mbedtls_mpi_shrink( &R->Z, 1 ) );
     mbedtls_mpi_free( &R->Y );
 
     /* RP.X might be slightly larger than P, so reduce it */

--- a/tests/suites/test_suite_ecp.function
+++ b/tests/suites/test_suite_ecp.function
@@ -424,6 +424,7 @@ void ecp_test_mul( int id, data_t * n_hex,
     mbedtls_ecp_point P, nP, R;
     mbedtls_mpi n;
     mbedtls_test_rnd_pseudo_info rnd_info;
+    int rounds = 0;
 
     mbedtls_ecp_group_init( &grp ); mbedtls_ecp_point_init( &R );
     mbedtls_ecp_point_init( &P ); mbedtls_ecp_point_init( &nP );
@@ -446,15 +447,30 @@ void ecp_test_mul( int id, data_t * n_hex,
     TEST_ASSERT( mbedtls_mpi_read_binary( &nP.Z, nPz_hex->x, nPz_hex->len )
                  == 0 );
 
-    TEST_ASSERT( mbedtls_ecp_mul( &grp, &R, &n, &P,
-                                  &mbedtls_test_rnd_pseudo_rand, &rnd_info )
-                 == expected_ret );
-
-    if( expected_ret == 0 )
+    for( rounds = 0; rounds < 2; ++rounds )
     {
-        TEST_ASSERT( mbedtls_mpi_cmp_mpi( &nP.X, &R.X ) == 0 );
-        TEST_ASSERT( mbedtls_mpi_cmp_mpi( &nP.Y, &R.Y ) == 0 );
-        TEST_ASSERT( mbedtls_mpi_cmp_mpi( &nP.Z, &R.Z ) == 0 );
+        /* Second round, make inputs to mbedtls_ecp_mul() carry many limbs */
+        if( rounds == 1 )
+        {
+            TEST_ASSERT( mbedtls_mpi_grow(&R.X, MBEDTLS_MPI_MAX_LIMBS) == 0);
+            TEST_ASSERT( mbedtls_mpi_grow(&R.Y, MBEDTLS_MPI_MAX_LIMBS) == 0);
+            TEST_ASSERT( mbedtls_mpi_grow(&R.Z, MBEDTLS_MPI_MAX_LIMBS) == 0);
+            TEST_ASSERT( mbedtls_mpi_grow(&n, MBEDTLS_MPI_MAX_LIMBS) == 0);
+            TEST_ASSERT( mbedtls_mpi_grow(&P.X, MBEDTLS_MPI_MAX_LIMBS) == 0);
+            TEST_ASSERT( mbedtls_mpi_grow(&P.Y, MBEDTLS_MPI_MAX_LIMBS) == 0);
+            TEST_ASSERT( mbedtls_mpi_grow(&P.Z, MBEDTLS_MPI_MAX_LIMBS) == 0);
+        }
+
+        TEST_ASSERT( mbedtls_ecp_mul( &grp, &R, &n, &P,
+                                      &mbedtls_test_rnd_pseudo_rand, &rnd_info )
+                     == expected_ret );
+
+        if( expected_ret == 0 )
+        {
+            TEST_ASSERT( mbedtls_mpi_cmp_mpi( &nP.X, &R.X ) == 0 );
+            TEST_ASSERT( mbedtls_mpi_cmp_mpi( &nP.Y, &R.Y ) == 0 );
+            TEST_ASSERT( mbedtls_mpi_cmp_mpi( &nP.Z, &R.Z ) == 0 );
+        }
     }
 
 exit:

--- a/tests/suites/test_suite_ecp.function
+++ b/tests/suites/test_suite_ecp.function
@@ -452,13 +452,13 @@ void ecp_test_mul( int id, data_t * n_hex,
         /* Second round, make inputs to mbedtls_ecp_mul() carry many limbs */
         if( rounds == 1 )
         {
-            TEST_ASSERT( mbedtls_mpi_grow(&R.X, MBEDTLS_MPI_MAX_LIMBS) == 0);
-            TEST_ASSERT( mbedtls_mpi_grow(&R.Y, MBEDTLS_MPI_MAX_LIMBS) == 0);
-            TEST_ASSERT( mbedtls_mpi_grow(&R.Z, MBEDTLS_MPI_MAX_LIMBS) == 0);
-            TEST_ASSERT( mbedtls_mpi_grow(&n, MBEDTLS_MPI_MAX_LIMBS) == 0);
-            TEST_ASSERT( mbedtls_mpi_grow(&P.X, MBEDTLS_MPI_MAX_LIMBS) == 0);
-            TEST_ASSERT( mbedtls_mpi_grow(&P.Y, MBEDTLS_MPI_MAX_LIMBS) == 0);
-            TEST_ASSERT( mbedtls_mpi_grow(&P.Z, MBEDTLS_MPI_MAX_LIMBS) == 0);
+            TEST_ASSERT( mbedtls_mpi_grow( &R.X, MBEDTLS_MPI_MAX_LIMBS ) == 0);
+            TEST_ASSERT( mbedtls_mpi_grow( &R.Y, MBEDTLS_MPI_MAX_LIMBS ) == 0);
+            TEST_ASSERT( mbedtls_mpi_grow( &R.Z, MBEDTLS_MPI_MAX_LIMBS ) == 0);
+            TEST_ASSERT( mbedtls_mpi_grow( &n, MBEDTLS_MPI_MAX_LIMBS ) == 0);
+            TEST_ASSERT( mbedtls_mpi_grow( &P.X, MBEDTLS_MPI_MAX_LIMBS ) == 0);
+            TEST_ASSERT( mbedtls_mpi_grow( &P.Y, MBEDTLS_MPI_MAX_LIMBS ) == 0);
+            TEST_ASSERT( mbedtls_mpi_grow( &P.Z, MBEDTLS_MPI_MAX_LIMBS ) == 0);
         }
 
         TEST_ASSERT( mbedtls_ecp_mul( &grp, &R, &n, &P,

--- a/tests/suites/test_suite_ecp.function
+++ b/tests/suites/test_suite_ecp.function
@@ -452,13 +452,13 @@ void ecp_test_mul( int id, data_t * n_hex,
         /* Second round, make inputs to mbedtls_ecp_mul() carry many limbs */
         if( rounds == 1 )
         {
-            TEST_ASSERT( mbedtls_mpi_grow( &R.X, MBEDTLS_MPI_MAX_LIMBS ) == 0);
-            TEST_ASSERT( mbedtls_mpi_grow( &R.Y, MBEDTLS_MPI_MAX_LIMBS ) == 0);
-            TEST_ASSERT( mbedtls_mpi_grow( &R.Z, MBEDTLS_MPI_MAX_LIMBS ) == 0);
-            TEST_ASSERT( mbedtls_mpi_grow( &n, MBEDTLS_MPI_MAX_LIMBS ) == 0);
-            TEST_ASSERT( mbedtls_mpi_grow( &P.X, MBEDTLS_MPI_MAX_LIMBS ) == 0);
-            TEST_ASSERT( mbedtls_mpi_grow( &P.Y, MBEDTLS_MPI_MAX_LIMBS ) == 0);
-            TEST_ASSERT( mbedtls_mpi_grow( &P.Z, MBEDTLS_MPI_MAX_LIMBS ) == 0);
+            TEST_ASSERT( mbedtls_mpi_grow( &R.X, MBEDTLS_MPI_MAX_LIMBS ) == 0 );
+            TEST_ASSERT( mbedtls_mpi_grow( &R.Y, MBEDTLS_MPI_MAX_LIMBS ) == 0 );
+            TEST_ASSERT( mbedtls_mpi_grow( &R.Z, MBEDTLS_MPI_MAX_LIMBS ) == 0 );
+            TEST_ASSERT( mbedtls_mpi_grow( &n, MBEDTLS_MPI_MAX_LIMBS ) == 0 );
+            TEST_ASSERT( mbedtls_mpi_grow( &P.X, MBEDTLS_MPI_MAX_LIMBS ) == 0 );
+            TEST_ASSERT( mbedtls_mpi_grow( &P.Y, MBEDTLS_MPI_MAX_LIMBS ) == 0 );
+            TEST_ASSERT( mbedtls_mpi_grow( &P.Z, MBEDTLS_MPI_MAX_LIMBS ) == 0 );
         }
 
         TEST_ASSERT( mbedtls_ecp_mul( &grp, &R, &n, &P,


### PR DESCRIPTION
## Description
Fixes issue https://github.com/Mbed-TLS/mbedtls/issues/5965.


## Status
**READY**

## Requires Backporting

Yes. To all maintained branches.

## Migrations

NO

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported
