### PR TITLE
use float for cycles/byte display in TIME_AND_TSC

### DIFF
--- a/programs/test/benchmark.c
+++ b/programs/test/benchmark.c
@@ -162,9 +162,9 @@ do {                                                                    \
     }                                                                   \
     else                                                                \
     {                                                                   \
-        mbedtls_printf( "%9lu KiB/s,  %9lu cycles/byte\n",              \
+        mbedtls_printf( "%9lu KiB/s,  %f cycles/byte\n",                \
                          ii * BUFSIZE / 1024,                           \
-                         ( mbedtls_timing_hardclock() - tsc )           \
+                         (float)( mbedtls_timing_hardclock() - tsc )    \
                          / ( jj * BUFSIZE ) );                          \
     }                                                                   \
 } while( 0 )


### PR DESCRIPTION
## Description
previously, measurements with cycles/byte < 1 would only show 0
this seems common on accelerated implementations.


## Status
READY

## Requires Backporting
NO

## Migrations
NO
