### PR TITLE
Remove MD dependencies from mbedtls_x509_sig_alg_gets(), ssl_tls13_parse_certificate_verify()

### DIFF
--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -256,13 +256,14 @@ static int ssl_tls13_parse_certificate_verify( mbedtls_ssl_context *ssl,
 #if defined(MBEDTLS_X509_RSASSA_PSS_SUPPORT)
     if( sig_alg == MBEDTLS_PK_RSASSA_PSS )
     {
-        const mbedtls_md_info_t* md_info;
         rsassa_pss_options.mgf1_hash_id = md_alg;
-        if( ( md_info = mbedtls_md_info_from_type( md_alg ) ) == NULL )
+        psa_algorithm_t psa_alg = mbedtls_psa_translate_md( md_alg );
+
+        if( psa_alg == 0 )
         {
             return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
         }
-        rsassa_pss_options.expected_salt_len = mbedtls_md_get_size( md_info );
+        rsassa_pss_options.expected_salt_len = PSA_HASH_LENGTH( psa_alg );
         options = (const void*) &rsassa_pss_options;
     }
 #endif /* MBEDTLS_X509_RSASSA_PSS_SUPPORT */

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -257,13 +257,8 @@ static int ssl_tls13_parse_certificate_verify( mbedtls_ssl_context *ssl,
     if( sig_alg == MBEDTLS_PK_RSASSA_PSS )
     {
         rsassa_pss_options.mgf1_hash_id = md_alg;
-        psa_algorithm_t psa_alg = mbedtls_psa_translate_md( md_alg );
 
-        if( psa_alg == 0 )
-        {
-            return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
-        }
-        rsassa_pss_options.expected_salt_len = PSA_HASH_LENGTH( psa_alg );
+        rsassa_pss_options.expected_salt_len = PSA_HASH_LENGTH( hash_alg );
         options = (const void*) &rsassa_pss_options;
     }
 #endif /* MBEDTLS_X509_RSASSA_PSS_SUPPORT */

--- a/library/x509.c
+++ b/library/x509.c
@@ -909,8 +909,8 @@ int mbedtls_x509_sig_alg_gets( char *buf, size_t size, const mbedtls_x509_buf *s
 
         pss_opts = (const mbedtls_pk_rsassa_pss_options *) sig_opts;
 
-        const char *name = md_type_to_string ( md_alg );
-        const char *mgf_name = md_type_to_string ( pss_opts->mgf1_hash_id );
+        const char *name = md_type_to_string( md_alg );
+        const char *mgf_name = md_type_to_string( pss_opts->mgf1_hash_id );
 
         ret = mbedtls_snprintf( p, n, " (%s, MGF1-%s, 0x%02X)",
                               name ? name : "???",

--- a/library/x509.c
+++ b/library/x509.c
@@ -131,6 +131,48 @@ int mbedtls_x509_get_alg( unsigned char **p, const unsigned char *end,
     return( 0 );
 }
 
+/*
+ * Convert md type to string
+ */
+static inline const char* md_type_to_string( mbedtls_md_type_t md_alg )
+{
+    switch( md_alg )
+    {
+#if defined(MBEDTLS_MD5_C)
+    case MBEDTLS_MD_MD5:
+        return( "MD5" );
+#endif
+#if defined(MBEDTLS_SHA1_C)
+    case MBEDTLS_MD_SHA1:
+        return( "SHA1" );
+#endif
+#if defined(MBEDTLS_SHA224_C)
+    case MBEDTLS_MD_SHA224:
+        return( "SHA224" );
+#endif
+#if defined(MBEDTLS_SHA256_C)
+    case MBEDTLS_MD_SHA256:
+        return( "SHA256" );
+#endif
+#if defined(MBEDTLS_SHA384_C)
+    case MBEDTLS_MD_SHA384:
+        return( "SHA384" );
+#endif
+#if defined(MBEDTLS_SHA512_C)
+    case MBEDTLS_MD_SHA512:
+        return( "SHA512" );
+#endif
+#if defined(MBEDTLS_RIPEMD160_C)
+    case MBEDTLS_MD_RIPEMD160:
+        return( "RIPEMD160" );
+#endif
+    case MBEDTLS_MD_NONE:
+        return( NULL );
+    default:
+        return( NULL );
+    }
+}
+
 #if defined(MBEDTLS_X509_RSASSA_PSS_SUPPORT)
 /*
  * HashAlgorithm ::= AlgorithmIdentifier
@@ -864,16 +906,15 @@ int mbedtls_x509_sig_alg_gets( char *buf, size_t size, const mbedtls_x509_buf *s
     if( pk_alg == MBEDTLS_PK_RSASSA_PSS )
     {
         const mbedtls_pk_rsassa_pss_options *pss_opts;
-        const mbedtls_md_info_t *md_info, *mgf_md_info;
 
         pss_opts = (const mbedtls_pk_rsassa_pss_options *) sig_opts;
 
-        md_info = mbedtls_md_info_from_type( md_alg );
-        mgf_md_info = mbedtls_md_info_from_type( pss_opts->mgf1_hash_id );
+        const char *name = md_type_to_string ( md_alg );
+        const char *mgf_name = md_type_to_string ( pss_opts->mgf1_hash_id );
 
         ret = mbedtls_snprintf( p, n, " (%s, MGF1-%s, 0x%02X)",
-                              md_info ? mbedtls_md_get_name( md_info ) : "???",
-                              mgf_md_info ? mbedtls_md_get_name( mgf_md_info ) : "???",
+                              name ? name : "???",
+                              mgf_name ? mgf_name : "???",
                               (unsigned int) pss_opts->expected_salt_len );
         MBEDTLS_X509_SAFE_SNPRINTF;
     }


### PR DESCRIPTION
## Description

Remove MD dependencies from `mbedtls_x509_sig_alg_gets(), ssl_tls13_parse_certificate_verify()`.
Resolves https://github.com/Mbed-TLS/mbedtls/issues/5795 and resolves https://github.com/Mbed-TLS/mbedtls/issues/5796


## Status
**READY**

## Requires Backporting
NO  

## Migrations
NO
