### PR TITLE
Backport 2.28: Remove largely useless bit of test log to silence GCC 12

### DIFF
--- a/ChangeLog.d/selftest-gcc12.txt
+++ b/ChangeLog.d/selftest-gcc12.txt
@@ -1,0 +1,2 @@
+Bugfix
+   * Silence a warning from GCC 12 in the selftest program. Fixes #5974.

--- a/programs/test/selftest.c
+++ b/programs/test/selftest.c
@@ -89,7 +89,6 @@ static int calloc_self_test( int verbose )
     void *empty2 = mbedtls_calloc( 0, 1 );
     void *buffer1 = mbedtls_calloc( 1, 1 );
     void *buffer2 = mbedtls_calloc( 1, 1 );
-    uintptr_t old_buffer1;
 
     if( empty1 == NULL && empty2 == NULL )
     {
@@ -131,7 +130,6 @@ static int calloc_self_test( int verbose )
             mbedtls_printf( "  CALLOC(1): passed\n" );
     }
 
-    old_buffer1 = (uintptr_t) buffer1;
     mbedtls_free( buffer1 );
     buffer1 = mbedtls_calloc( 1, 1 );
     if( buffer1 == NULL )
@@ -143,9 +141,7 @@ static int calloc_self_test( int verbose )
     else
     {
         if( verbose )
-            mbedtls_printf( "  CALLOC(1 again): passed (%s address)\n",
-                            (uintptr_t) old_buffer1 == (uintptr_t) buffer1 ?
-                            "same" : "different" );
+            mbedtls_printf( "  CALLOC(1 again): passed\n" );
     }
 
     if( verbose )


### PR DESCRIPTION
Backport of https://github.com/Mbed-TLS/mbedtls/pull/5976. Fixes https://github.com/Mbed-TLS/mbedtls/issues/5974.