### PR TITLE
Inline mbedtls_x509_dn_get_next() in x509.h

### DIFF
--- a/include/mbedtls/x509.h
+++ b/include/mbedtls/x509.h
@@ -269,12 +269,21 @@ int mbedtls_x509_dn_gets( char *buf, size_t size, const mbedtls_x509_name *dn );
 /**
  * \brief          Return the next relative DN in an X509 name.
  *
+ * \note           Intended use is to compare function result to dn->next
+ *                 in order to detect boundaries of multi-valued RDNs.
+ *
  * \param dn       Current node in the X509 name
  *
  * \return         Pointer to the first attribute-value pair of the
  *                 next RDN in sequence, or NULL if end is reached.
  */
-mbedtls_x509_name * mbedtls_x509_dn_get_next( mbedtls_x509_name *dn );
+static inline mbedtls_x509_name * mbedtls_x509_dn_get_next(
+    mbedtls_x509_name * dn )
+{
+    while( dn->MBEDTLS_PRIVATE(next_merged) && dn->next != NULL )
+        dn = dn->next;
+    return( dn->next );
+}
 
 /**
  * \brief          Store the certificate serial in printable form into buf;

--- a/library/x509.c
+++ b/library/x509.c
@@ -797,15 +797,6 @@ int mbedtls_x509_dn_gets( char *buf, size_t size, const mbedtls_x509_name *dn )
 }
 
 /*
- * Return the next relative DN in an X509 name.
- */
-mbedtls_x509_name * mbedtls_x509_dn_get_next( mbedtls_x509_name * dn )
-{
-    for( ; dn->next != NULL && dn->next_merged; dn = dn->next );
-    return( dn->next );
-}
-
-/*
  * Store the serial in printable form into buf; no more
  * than size characters will be written
  */


### PR DESCRIPTION
## Description

Inline mbedtls_x509_dn_get_next() in x509.h and improve header documentation
for new interface (#5954) added for now-private member.

## Status
**READY**

## Requires Backporting
NO  

## Migrations
NO

## Todos
- [x] Documentation