### PR TITLE
Allow non-versioned library soname.

### DIFF
--- a/ChangeLog.d/nonversioned-library-soname.txt
+++ b/ChangeLog.d/nonversioned-library-soname.txt
@@ -1,0 +1,5 @@
+Features
+   * make: enable building unversioned shared library, with e.g.:
+     "SHARED=1 SOEXT_TLS=so SOEXT_X509=so SOEXT_CRYPTO=so make lib"
+     resulting in library names like "libmbedtls.so" rather than
+     "libmbedcrypto.so.11".

--- a/library/Makefile
+++ b/library/Makefile
@@ -47,9 +47,9 @@ LOCAL_CFLAGS += -fPIC -fpic
 endif
 endif
 
-SOEXT_TLS=so.18
-SOEXT_X509=so.4
-SOEXT_CRYPTO=so.12
+SOEXT_TLS?=so.18
+SOEXT_X509?=so.4
+SOEXT_CRYPTO?=so.12
 
 # Set AR_DASH= (empty string) to use an ar implementation that does not accept
 # the - prefix for command line options (e.g. llvm-ar)
@@ -219,9 +219,11 @@ libmbedtls.$(SOEXT_TLS): $(OBJS_TLS) libmbedx509.so
 	echo "  LD    $@"
 	$(CC) -shared -Wl,-soname,$@ -o $@ $(OBJS_TLS) -L. -lmbedx509 -lmbedcrypto $(LOCAL_LDFLAGS) $(LDFLAGS)
 
+ifneq ($(SOEXT_TLS),so)
 libmbedtls.so: libmbedtls.$(SOEXT_TLS)
 	echo "  LN    $@ -> $<"
 	ln -sf $< $@
+endif
 
 libmbedtls.dylib: $(OBJS_TLS) libmbedx509.dylib
 	echo "  LD    $@"
@@ -246,9 +248,11 @@ libmbedx509.$(SOEXT_X509): $(OBJS_X509) libmbedcrypto.so
 	echo "  LD    $@"
 	$(CC) -shared -Wl,-soname,$@ -o $@ $(OBJS_X509) -L. -lmbedcrypto $(LOCAL_LDFLAGS) $(LDFLAGS)
 
+ifneq ($(SOEXT_X509),so)
 libmbedx509.so: libmbedx509.$(SOEXT_X509)
 	echo "  LN    $@ -> $<"
 	ln -sf $< $@
+endif
 
 libmbedx509.dylib: $(OBJS_X509) libmbedcrypto.dylib
 	echo "  LD    $@"
@@ -273,9 +277,11 @@ libmbedcrypto.$(SOEXT_CRYPTO): $(OBJS_CRYPTO)
 	echo "  LD    $@"
 	$(CC) -shared -Wl,-soname,$@ -o $@ $(OBJS_CRYPTO) $(LOCAL_LDFLAGS) $(LDFLAGS)
 
+ifneq ($(SOEXT_CRYPTO),so)
 libmbedcrypto.so: libmbedcrypto.$(SOEXT_CRYPTO)
 	echo "  LN    $@ -> $<"
 	ln -sf $< $@
+endif
 
 libmbedcrypto.dylib: $(OBJS_CRYPTO)
 	echo "  LD    $@"

--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -96,7 +96,7 @@ then
   mv tmp library/CMakeLists.txt
 
   [ $VERBOSE ] && echo "Bumping SOVERSION for libmbedcrypto in library/Makefile"
-  sed -e "s/SOEXT_CRYPTO=so.[0-9]\{1,\}/SOEXT_CRYPTO=so.$SO_CRYPTO/g" < library/Makefile > tmp
+  sed -e "s/SOEXT_CRYPTO?=so.[0-9]\{1,\}/SOEXT_CRYPTO?=so.$SO_CRYPTO/g" < library/Makefile > tmp
   mv tmp library/Makefile
 fi
 
@@ -107,7 +107,7 @@ then
   mv tmp library/CMakeLists.txt
 
   [ $VERBOSE ] && echo "Bumping SOVERSION for libmbedx509 in library/Makefile"
-  sed -e "s/SOEXT_X509=so.[0-9]\{1,\}/SOEXT_X509=so.$SO_X509/g" < library/Makefile > tmp
+  sed -e "s/SOEXT_X509?=so.[0-9]\{1,\}/SOEXT_X509?=so.$SO_X509/g" < library/Makefile > tmp
   mv tmp library/Makefile
 fi
 
@@ -118,7 +118,7 @@ then
   mv tmp library/CMakeLists.txt
 
   [ $VERBOSE ] && echo "Bumping SOVERSION for libmbedtls in library/Makefile"
-  sed -e "s/SOEXT_TLS=so.[0-9]\{1,\}/SOEXT_TLS=so.$SO_TLS/g" < library/Makefile > tmp
+  sed -e "s/SOEXT_TLS?=so.[0-9]\{1,\}/SOEXT_TLS?=so.$SO_TLS/g" < library/Makefile > tmp
   mv tmp library/Makefile
 fi
 


### PR DESCRIPTION
On Android, you can include shared libraries by dropping them in the jniLibs directory. However, Android Studio ignores file names that don't match *.so, like libmbedtls.so.17. So developers typically build non-versioned libraries.

This patch allows me to do this:

    SOEXT_TLS=so SOEXT_X509=so SOEXT_CRYPTO=so make lib

Note that `?=` is necessary because make variables declared like this:

    SOEXT_TLS=so.17

can only be changed with an argument to make:

    make lib SOEXT_TLS=so

and these arguments are not passed on to a recursive call to make (`make -C library`), whereas `?=` allows me to use an environment variable, like so:

    SOEXT_TLS=so make lib

Signed-off-by: Mansour Moufid
