### PR TITLE
mbedtls_x509_time performance and reduce memory use

### DIFF
--- a/ChangeLog.d/mbedtls_x509_time.txt
+++ b/ChangeLog.d/mbedtls_x509_time.txt
@@ -1,2 +1,3 @@
 Features
    * Improve mbedtls_x509_time performance and reduce memory use.
+   * Reduce syscalls to time() during certificate verification.

--- a/ChangeLog.d/mbedtls_x509_time.txt
+++ b/ChangeLog.d/mbedtls_x509_time.txt
@@ -1,0 +1,2 @@
+Features
+   * Improve mbedtls_x509_time performance and reduce memory use.

--- a/include/mbedtls/x509.h
+++ b/include/mbedtls/x509.h
@@ -367,6 +367,18 @@ static inline mbedtls_x509_name *mbedtls_x509_dn_get_next(
 int mbedtls_x509_serial_gets(char *buf, size_t size, const mbedtls_x509_buf *serial);
 
 /**
+ * \brief          Compare pair of mbedtls_x509_time.
+ *
+ * \param t1       mbedtls_x509_time to compare
+ * \param t2       mbedtls_x509_time to compare
+ *
+ * \return         < 0 if t1 is before t2
+ *                   0 if t1 equals t2
+ *                 > 0 if t1 is after t2
+ */
+int mbedtls_x509_time_cmp(const mbedtls_x509_time *t1, const mbedtls_x509_time *t2);
+
+/**
  * \brief          Check a given mbedtls_x509_time against the system time
  *                 and tell if it's in the past.
  *

--- a/include/mbedtls/x509.h
+++ b/include/mbedtls/x509.h
@@ -378,6 +378,19 @@ int mbedtls_x509_serial_gets(char *buf, size_t size, const mbedtls_x509_buf *ser
  */
 int mbedtls_x509_time_cmp(const mbedtls_x509_time *t1, const mbedtls_x509_time *t2);
 
+#if defined(MBEDTLS_HAVE_TIME_DATE)
+/**
+ * \brief          Fill mbedtls_x509_time with provided mbedtls_time_t.
+ *
+ * \param tt       mbedtls_time_t to convert
+ * \param now      mbedtls_x509_time to fill with converted mbedtls_time_t
+ *
+ * \return         \c 0 on success
+ * \return         A non-zero return value on failure.
+ */
+int mbedtls_x509_time_gmtime(mbedtls_time_t tt, mbedtls_x509_time *now);
+#endif /* MBEDTLS_HAVE_TIME_DATE */
+
 /**
  * \brief          Check a given mbedtls_x509_time against the system time
  *                 and tell if it's in the past.

--- a/library/x509.c
+++ b/library/x509.c
@@ -587,7 +587,7 @@ static int x509_date_is_valid(const mbedtls_x509_time *t)
     }
 
     if ((unsigned int) (t->day - 1) >= month_days ||      /* (1 - days in month) */
-        /* (unsigned int)( t->mon - 1 ) >= 12 || */ /* (1 - 12) checked above */
+        /* (unsigned int) (t->mon - 1) >= 12 || */  /* (1 - 12) checked above */
         (unsigned int) t->year > 9999 ||         /* (0 - 9999) */
         (unsigned int) t->hour > 23 ||           /* (0 - 23) */
         (unsigned int) t->min  > 59 ||           /* (0 - 59) */

--- a/library/x509.c
+++ b/library/x509.c
@@ -586,12 +586,12 @@ static int x509_date_is_valid(const mbedtls_x509_time *t)
             return MBEDTLS_ERR_X509_INVALID_DATE;
     }
 
-    if ((unsigned int) (t->day - 1) >= month_days ||      /*(1 - days in month)*/
-        /*(unsigned int)( t->mon - 1 ) >= 12 ||*//*(1 - 12) checked above*/
-        (unsigned int) t->year > 9999 ||         /*(0 - 9999)*/
-        (unsigned int) t->hour > 23 ||           /*(0 - 23)*/
-        (unsigned int) t->min  > 59 ||           /*(0 - 59)*/
-        (unsigned int) t->sec  > 59) {           /*(0 - 59)*/
+    if ((unsigned int) (t->day - 1) >= month_days ||      /* (1 - days in month) */
+        /* (unsigned int)( t->mon - 1 ) >= 12 || */ /* (1 - 12) checked above */
+        (unsigned int) t->year > 9999 ||         /* (0 - 9999) */
+        (unsigned int) t->hour > 23 ||           /* (0 - 23) */
+        (unsigned int) t->min  > 59 ||           /* (0 - 59) */
+        (unsigned int) t->sec  > 59) {           /* (0 - 59) */
         return MBEDTLS_ERR_X509_INVALID_DATE;
     }
 

--- a/library/x509.c
+++ b/library/x509.c
@@ -1011,17 +1011,11 @@ int mbedtls_x509_time_cmp(const mbedtls_x509_time *t1,
 }
 
 #if defined(MBEDTLS_HAVE_TIME_DATE)
-/*
- * Set the time structure to the current time.
- * Return 0 on success, non-zero on failure.
- */
-static int x509_get_current_time(mbedtls_x509_time *now)
+int mbedtls_x509_time_gmtime(mbedtls_time_t tt, mbedtls_x509_time *now)
 {
     struct tm *lt, tm_buf;
-    mbedtls_time_t tt;
     int ret = 0;
 
-    tt = mbedtls_time(NULL);
     lt = mbedtls_platform_gmtime_r(&tt, &tm_buf);
 
     if (lt == NULL) {
@@ -1036,6 +1030,11 @@ static int x509_get_current_time(mbedtls_x509_time *now)
     }
 
     return ret;
+}
+
+static int x509_get_current_time(mbedtls_x509_time *now)
+{
+    return mbedtls_x509_time_gmtime(mbedtls_time(NULL), now);
 }
 
 int mbedtls_x509_time_is_past(const mbedtls_x509_time *to)

--- a/library/x509.c
+++ b/library/x509.c
@@ -1013,23 +1013,19 @@ int mbedtls_x509_time_cmp(const mbedtls_x509_time *t1,
 #if defined(MBEDTLS_HAVE_TIME_DATE)
 int mbedtls_x509_time_gmtime(mbedtls_time_t tt, mbedtls_x509_time *now)
 {
-    struct tm *lt, tm_buf;
-    int ret = 0;
+    struct tm tm;
 
-    lt = mbedtls_platform_gmtime_r(&tt, &tm_buf);
-
-    if (lt == NULL) {
-        ret = -1;
-    } else {
-        now->year = lt->tm_year + 1900;
-        now->mon  = lt->tm_mon  + 1;
-        now->day  = lt->tm_mday;
-        now->hour = lt->tm_hour;
-        now->min  = lt->tm_min;
-        now->sec  = lt->tm_sec;
+    if (mbedtls_platform_gmtime_r(&tt, &tm) == NULL) {
+        return -1;
     }
 
-    return ret;
+    now->year = tm.tm_year + 1900;
+    now->mon  = tm.tm_mon  + 1;
+    now->day  = tm.tm_mday;
+    now->hour = tm.tm_hour;
+    now->min  = tm.tm_min;
+    now->sec  = tm.tm_sec;
+    return 0;
 }
 
 static int x509_get_current_time(mbedtls_x509_time *now)

--- a/library/x509.c
+++ b/library/x509.c
@@ -567,23 +567,26 @@ error:
 
 static int x509_date_is_valid(const mbedtls_x509_time *t)
 {
-    unsigned int d;
+    unsigned int month_days;
+    unsigned int year;
     switch (t->mon) {
         case 1: case 3: case 5: case 7: case 8: case 10: case 12:
-            d = 31;
+            month_days = 31;
             break;
         case 4: case 6: case 9: case 11:
-            d = 30;
+            month_days = 30;
             break;
         case 2:
-            d = (unsigned int) t->year;
-            d = ((d & 3) || (!(d % 100) && (d % 400))) ? 28 : 29;
+            year = (unsigned int) t->year;
+            month_days = ((year & 3) || (!(year % 100)
+                                         && (year % 400)))
+                          ? 28 : 29;
             break;
         default:
             return MBEDTLS_ERR_X509_INVALID_DATE;
     }
 
-    if ((unsigned int) (t->day - 1) >= d ||      /*(1 - days in month)*/
+    if ((unsigned int) (t->day - 1) >= month_days ||      /*(1 - days in month)*/
         /*(unsigned int)( t->mon - 1 ) >= 12 ||*//*(1 - 12) checked above*/
         (unsigned int) t->year > 9999 ||         /*(0 - 9999)*/
         (unsigned int) t->hour > 23 ||           /*(0 - 23)*/

--- a/library/x509.c
+++ b/library/x509.c
@@ -997,27 +997,17 @@ int mbedtls_x509_key_size_helper(char *buf, size_t buf_size, const char *name)
 int mbedtls_x509_time_cmp(const mbedtls_x509_time *t1,
                           const mbedtls_x509_time *t2)
 {
-    if (t1->year != t2->year) {
-        return t1->year - t2->year;
+    int x;
+
+    x = (((t1->year << 9) | (t1->mon << 5) | (t1->day)) -
+         ((t2->year << 9) | (t2->mon << 5) | (t2->day)));
+    if (x != 0) {
+        return x;
     }
 
-    if (t1->mon  != t2->mon) {
-        return t1->mon  - t2->mon;
-    }
-
-    if (t1->day  != t2->day) {
-        return t1->day  - t2->day;
-    }
-
-    if (t1->hour != t2->hour) {
-        return t1->hour - t2->hour;
-    }
-
-    if (t1->min  != t2->min) {
-        return t1->min  - t2->min;
-    }
-
-    return t1->sec  - t2->sec;
+    x = (((t1->hour << 12) | (t1->min << 6) | (t1->sec)) -
+         ((t2->hour << 12) | (t2->min << 6) | (t2->sec)));
+    return x;
 }
 
 #if defined(MBEDTLS_HAVE_TIME_DATE)

--- a/library/x509.c
+++ b/library/x509.c
@@ -994,6 +994,32 @@ int mbedtls_x509_key_size_helper(char *buf, size_t buf_size, const char *name)
     return 0;
 }
 
+int mbedtls_x509_time_cmp(const mbedtls_x509_time *t1,
+                          const mbedtls_x509_time *t2)
+{
+    if (t1->year != t2->year) {
+        return t1->year - t2->year;
+    }
+
+    if (t1->mon  != t2->mon) {
+        return t1->mon  - t2->mon;
+    }
+
+    if (t1->day  != t2->day) {
+        return t1->day  - t2->day;
+    }
+
+    if (t1->hour != t2->hour) {
+        return t1->hour - t2->hour;
+    }
+
+    if (t1->min  != t2->min) {
+        return t1->min  - t2->min;
+    }
+
+    return t1->sec  - t2->sec;
+}
+
 #if defined(MBEDTLS_HAVE_TIME_DATE)
 /*
  * Set the time structure to the current time.
@@ -1022,53 +1048,6 @@ static int x509_get_current_time(mbedtls_x509_time *now)
     return ret;
 }
 
-/*
- * Return 0 if before <= after, 1 otherwise
- */
-static int x509_check_time(const mbedtls_x509_time *before, const mbedtls_x509_time *after)
-{
-    if (before->year  > after->year) {
-        return 1;
-    }
-
-    if (before->year == after->year &&
-        before->mon   > after->mon) {
-        return 1;
-    }
-
-    if (before->year == after->year &&
-        before->mon  == after->mon  &&
-        before->day   > after->day) {
-        return 1;
-    }
-
-    if (before->year == after->year &&
-        before->mon  == after->mon  &&
-        before->day  == after->day  &&
-        before->hour  > after->hour) {
-        return 1;
-    }
-
-    if (before->year == after->year &&
-        before->mon  == after->mon  &&
-        before->day  == after->day  &&
-        before->hour == after->hour &&
-        before->min   > after->min) {
-        return 1;
-    }
-
-    if (before->year == after->year &&
-        before->mon  == after->mon  &&
-        before->day  == after->day  &&
-        before->hour == after->hour &&
-        before->min  == after->min  &&
-        before->sec   > after->sec) {
-        return 1;
-    }
-
-    return 0;
-}
-
 int mbedtls_x509_time_is_past(const mbedtls_x509_time *to)
 {
     mbedtls_x509_time now;
@@ -1077,7 +1056,7 @@ int mbedtls_x509_time_is_past(const mbedtls_x509_time *to)
         return 1;
     }
 
-    return x509_check_time(&now, to);
+    return mbedtls_x509_time_cmp(to, &now) < 0;
 }
 
 int mbedtls_x509_time_is_future(const mbedtls_x509_time *from)
@@ -1088,7 +1067,7 @@ int mbedtls_x509_time_is_future(const mbedtls_x509_time *from)
         return 1;
     }
 
-    return x509_check_time(from, &now);
+    return mbedtls_x509_time_cmp(from, &now) > 0;
 }
 
 #else  /* MBEDTLS_HAVE_TIME_DATE */

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -2021,7 +2021,8 @@ int mbedtls_x509_crt_is_revoked(const mbedtls_x509_crt *crt, const mbedtls_x509_
  */
 static int x509_crt_verifycrl(mbedtls_x509_crt *crt, mbedtls_x509_crt *ca,
                               mbedtls_x509_crl *crl_list,
-                              const mbedtls_x509_crt_profile *profile)
+                              const mbedtls_x509_crt_profile *profile,
+                              const mbedtls_x509_time *now)
 {
     int flags = 0;
     unsigned char hash[MBEDTLS_MD_MAX_SIZE];
@@ -2099,16 +2100,20 @@ static int x509_crt_verifycrl(mbedtls_x509_crt *crt, mbedtls_x509_crt *ca,
             break;
         }
 
+#if defined(MBEDTLS_HAVE_TIME_DATE)
         /*
          * Check for validity of CRL (Do not drop out)
          */
-        if (mbedtls_x509_time_is_past(&crl_list->next_update)) {
+        if (mbedtls_x509_time_cmp(&crl_list->next_update, now) < 0) {
             flags |= MBEDTLS_X509_BADCRL_EXPIRED;
         }
 
-        if (mbedtls_x509_time_is_future(&crl_list->this_update)) {
+        if (mbedtls_x509_time_cmp(&crl_list->this_update, now) > 0) {
             flags |= MBEDTLS_X509_BADCRL_FUTURE;
         }
+#else
+        ((void) now);
+#endif
 
         /*
          * Check if certificate is revoked
@@ -2266,7 +2271,8 @@ static int x509_crt_find_parent_in(
     int top,
     unsigned path_cnt,
     unsigned self_cnt,
-    mbedtls_x509_crt_restart_ctx *rs_ctx)
+    mbedtls_x509_crt_restart_ctx *rs_ctx,
+    const mbedtls_x509_time *now)
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     mbedtls_x509_crt *parent, *fallback_parent;
@@ -2329,9 +2335,10 @@ check_signature:
             continue;
         }
 
+#if defined(MBEDTLS_HAVE_TIME_DATE)
         /* optional time check */
-        if (mbedtls_x509_time_is_past(&parent->valid_to) ||
-            mbedtls_x509_time_is_future(&parent->valid_from)) {
+        if (mbedtls_x509_time_cmp(&parent->valid_to, now) < 0 ||    /* past */
+            mbedtls_x509_time_cmp(&parent->valid_from, now) > 0) {  /* future */
             if (fallback_parent == NULL) {
                 fallback_parent = parent;
                 fallback_signature_is_good = signature_is_good;
@@ -2339,6 +2346,9 @@ check_signature:
 
             continue;
         }
+#else
+        ((void) now);
+#endif
 
         *r_parent = parent;
         *r_signature_is_good = signature_is_good;
@@ -2384,7 +2394,8 @@ static int x509_crt_find_parent(
     int *signature_is_good,
     unsigned path_cnt,
     unsigned self_cnt,
-    mbedtls_x509_crt_restart_ctx *rs_ctx)
+    mbedtls_x509_crt_restart_ctx *rs_ctx,
+    const mbedtls_x509_time *now)
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     mbedtls_x509_crt *search_list;
@@ -2405,7 +2416,7 @@ static int x509_crt_find_parent(
         ret = x509_crt_find_parent_in(child, search_list,
                                       parent, signature_is_good,
                                       *parent_is_trusted,
-                                      path_cnt, self_cnt, rs_ctx);
+                                      path_cnt, self_cnt, rs_ctx, now);
 
 #if defined(MBEDTLS_ECDSA_C) && defined(MBEDTLS_ECP_RESTARTABLE)
         if (rs_ctx != NULL && ret == MBEDTLS_ERR_ECP_IN_PROGRESS) {
@@ -2526,6 +2537,13 @@ static int x509_crt_verify_chain(
     int signature_is_good;
     unsigned self_cnt;
     mbedtls_x509_crt *cur_trust_ca = NULL;
+    mbedtls_x509_time now;
+
+#if defined(MBEDTLS_HAVE_TIME_DATE)
+    if (mbedtls_x509_time_gmtime(mbedtls_time(NULL), &now) != 0) {
+        return MBEDTLS_ERR_X509_FATAL_ERROR;
+    }
+#endif
 
 #if defined(MBEDTLS_ECDSA_C) && defined(MBEDTLS_ECP_RESTARTABLE)
     /* resume if we had an operation in progress */
@@ -2556,14 +2574,16 @@ static int x509_crt_verify_chain(
         ver_chain->len++;
         flags = &cur->flags;
 
+#if defined(MBEDTLS_HAVE_TIME_DATE)
         /* Check time-validity (all certificates) */
-        if (mbedtls_x509_time_is_past(&child->valid_to)) {
+        if (mbedtls_x509_time_cmp(&child->valid_to, &now) < 0) {
             *flags |= MBEDTLS_X509_BADCERT_EXPIRED;
         }
 
-        if (mbedtls_x509_time_is_future(&child->valid_from)) {
+        if (mbedtls_x509_time_cmp(&child->valid_from, &now) > 0) {
             *flags |= MBEDTLS_X509_BADCERT_FUTURE;
         }
+#endif
 
         /* Stop here for trusted roots (but not for trusted EE certs) */
         if (child_is_trusted) {
@@ -2614,7 +2634,8 @@ find_parent:
         /* Look for a parent in trusted CAs or up the chain */
         ret = x509_crt_find_parent(child, cur_trust_ca, &parent,
                                    &parent_is_trusted, &signature_is_good,
-                                   ver_chain->len - 1, self_cnt, rs_ctx);
+                                   ver_chain->len - 1, self_cnt, rs_ctx,
+                                   &now);
 
 #if defined(MBEDTLS_ECDSA_C) && defined(MBEDTLS_ECP_RESTARTABLE)
         if (rs_ctx != NULL && ret == MBEDTLS_ERR_ECP_IN_PROGRESS) {
@@ -2663,7 +2684,7 @@ find_parent:
 
 #if defined(MBEDTLS_X509_CRL_PARSE_C)
         /* Check trusted CA's CRL for the given crt */
-        *flags |= x509_crt_verifycrl(child, parent, ca_crl, profile);
+        *flags |= x509_crt_verifycrl(child, parent, ca_crl, profile, &now);
 #else
         (void) ca_crl;
 #endif


### PR DESCRIPTION
## Description

Features
   * Improve mbedtls_x509_time performance and reduce memory use.
   * Reduce syscalls to time() during certificate verification.

Please consider reviewing commit-by-commit to step through the code transformations.

## Status
**READY**

## Requires Backporting
NO  

## Migrations
NO

## Todos
- [x] Tests
- [x] Documentation
- [x] Changelog updated