### PR TITLE
Permissions 2b: TLS 1.3 sigalg selection

### DIFF
--- a/ChangeLog.d/tls13_sig_alg_selection.txt
+++ b/ChangeLog.d/tls13_sig_alg_selection.txt
@@ -1,0 +1,3 @@
+Features
+   * Add support for opaque keys as the private keys associated to certificates
+     for authentication in TLS 1.3.

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -906,12 +906,8 @@ int mbedtls_ssl_tls13_check_sig_alg_cert_key_match( uint16_t sig_alg,
         case MBEDTLS_SSL_SIG_RSA:
             switch( sig_alg )
             {
-                case MBEDTLS_TLS1_3_SIG_RSA_PSS_RSAE_SHA256:
-                    return( key_size <= 3072 );
-
-                case MBEDTLS_TLS1_3_SIG_RSA_PSS_RSAE_SHA384:
-                    return( key_size <= 7680 );
-
+                case MBEDTLS_TLS1_3_SIG_RSA_PSS_RSAE_SHA256: /* Intentional fallthrough */
+                case MBEDTLS_TLS1_3_SIG_RSA_PSS_RSAE_SHA384: /* Intentional fallthrough */
                 case MBEDTLS_TLS1_3_SIG_RSA_PSS_RSAE_SHA512:
                     return( 1 );
 

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -930,36 +930,27 @@ int mbedtls_ssl_tls13_check_sig_alg_cert_key_match( uint16_t sig_alg,
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
 static psa_algorithm_t ssl_tls13_select_sig_alg_to_psa_alg( uint16_t sig_alg )
 {
-    psa_algorithm_t psa_alg = 0;
     switch( sig_alg )
     {
         case MBEDTLS_TLS1_3_SIG_ECDSA_SECP256R1_SHA256:
-            psa_alg = PSA_ALG_ECDSA( PSA_ALG_SHA_256 );
-            break;
+            return( PSA_ALG_ECDSA( PSA_ALG_SHA_256 ) );
         case MBEDTLS_TLS1_3_SIG_ECDSA_SECP384R1_SHA384:
-            psa_alg = PSA_ALG_ECDSA( PSA_ALG_SHA_384 );
-            break;
+            return( PSA_ALG_ECDSA( PSA_ALG_SHA_384 ) );
         case MBEDTLS_TLS1_3_SIG_ECDSA_SECP521R1_SHA512:
-            psa_alg = PSA_ALG_ECDSA( PSA_ALG_SHA_512 );
-            break;
+            return( PSA_ALG_ECDSA( PSA_ALG_SHA_512 ) );
         case MBEDTLS_TLS1_3_SIG_RSA_PSS_RSAE_SHA256:
-            psa_alg = PSA_ALG_RSA_PSS( PSA_ALG_SHA_256 );
-            break;
+            return( PSA_ALG_RSA_PSS( PSA_ALG_SHA_256 ) );
         case MBEDTLS_TLS1_3_SIG_RSA_PSS_RSAE_SHA384:
-            psa_alg = PSA_ALG_RSA_PSS( PSA_ALG_SHA_384 );
-            break;
+            return( PSA_ALG_RSA_PSS( PSA_ALG_SHA_384 ) );
         case MBEDTLS_TLS1_3_SIG_RSA_PSS_RSAE_SHA512:
-            psa_alg = PSA_ALG_RSA_PSS( PSA_ALG_SHA_512 );
-            break;
+            return( PSA_ALG_RSA_PSS( PSA_ALG_SHA_512 ) );
         case MBEDTLS_TLS1_3_SIG_RSA_PKCS1_SHA256:
         case MBEDTLS_TLS1_3_SIG_RSA_PKCS1_SHA384:
         case MBEDTLS_TLS1_3_SIG_RSA_PKCS1_SHA512:
-            psa_alg = PSA_ALG_RSA_PKCS1V15_CRYPT;
-            break;
+            return( PSA_ALG_RSA_PKCS1V15_CRYPT );
         default:
-            break;
+            return( 0 );
     }
-    return( psa_alg );
 }
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -1021,6 +1021,12 @@ static int ssl_tls13_write_certificate_verify_body( mbedtls_ssl_context *ssl,
              MBEDTLS_SSL_DEBUG_MSG( 2, ( "CertificateVerify signature failed with %s",
                                     mbedtls_ssl_sig_alg_to_str( *sig_alg ) ) );
              MBEDTLS_SSL_DEBUG_RET( 2, "mbedtls_pk_sign_ext", ret );
+
+             /* The signature failed. This is possible if the private key
+              * was not suitable for the signature operation as purposely we
+              * did not check its suitability completely. Let's try with
+              * another signature algorithm.
+              */
              continue;
         }
 

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -923,83 +923,13 @@ int mbedtls_ssl_tls13_check_sig_alg_cert_key_match( uint16_t sig_alg,
     return( 0 );
 }
 
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
-static psa_algorithm_t ssl_tls13_select_sig_alg_to_psa_alg( uint16_t sig_alg )
-{
-    switch( sig_alg )
-    {
-        case MBEDTLS_TLS1_3_SIG_ECDSA_SECP256R1_SHA256:
-            return( PSA_ALG_ECDSA( PSA_ALG_SHA_256 ) );
-        case MBEDTLS_TLS1_3_SIG_ECDSA_SECP384R1_SHA384:
-            return( PSA_ALG_ECDSA( PSA_ALG_SHA_384 ) );
-        case MBEDTLS_TLS1_3_SIG_ECDSA_SECP521R1_SHA512:
-            return( PSA_ALG_ECDSA( PSA_ALG_SHA_512 ) );
-        case MBEDTLS_TLS1_3_SIG_RSA_PSS_RSAE_SHA256:
-            return( PSA_ALG_RSA_PSS( PSA_ALG_SHA_256 ) );
-        case MBEDTLS_TLS1_3_SIG_RSA_PSS_RSAE_SHA384:
-            return( PSA_ALG_RSA_PSS( PSA_ALG_SHA_384 ) );
-        case MBEDTLS_TLS1_3_SIG_RSA_PSS_RSAE_SHA512:
-            return( PSA_ALG_RSA_PSS( PSA_ALG_SHA_512 ) );
-        case MBEDTLS_TLS1_3_SIG_RSA_PKCS1_SHA256:
-        case MBEDTLS_TLS1_3_SIG_RSA_PKCS1_SHA384:
-        case MBEDTLS_TLS1_3_SIG_RSA_PKCS1_SHA512:
-            return( PSA_ALG_RSA_PKCS1V15_CRYPT );
-        default:
-            return( 0 );
-    }
-}
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
-
-MBEDTLS_CHECK_RETURN_CRITICAL
-static int ssl_tls13_select_sig_alg_for_certificate_verify(
-                                          mbedtls_ssl_context *ssl,
-                                          mbedtls_pk_context *own_key,
-                                          uint16_t *algorithm )
-{
-    uint16_t *sig_alg = ssl->handshake->received_sig_algs;
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
-    psa_algorithm_t psa_alg = 0;
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
-
-    *algorithm = MBEDTLS_TLS1_3_SIG_NONE;
-    for( ; *sig_alg != MBEDTLS_TLS1_3_SIG_NONE ; sig_alg++ )
-    {
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
-        psa_alg = ssl_tls13_select_sig_alg_to_psa_alg( *sig_alg );
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
-
-        if( mbedtls_ssl_sig_alg_is_offered( ssl, *sig_alg ) &&
-            mbedtls_ssl_tls13_sig_alg_for_cert_verify_is_supported( *sig_alg ) &&
-            mbedtls_ssl_tls13_check_sig_alg_cert_key_match( *sig_alg, own_key )
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
-            && psa_alg != 0 &&
-            mbedtls_pk_can_do_ext( own_key, psa_alg,
-                                   PSA_KEY_USAGE_SIGN_HASH ) == 1
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
-            )
-        {
-            MBEDTLS_SSL_DEBUG_MSG( 3,
-                                   ( "select_sig_alg_for_certificate_verify:"
-                                     "selected signature algorithm %s [%04x]",
-                                     mbedtls_ssl_sig_alg_to_str( *sig_alg ),
-                                     *sig_alg ) );
-            *algorithm = *sig_alg;
-            return( 0 );
-        }
-    }
-    MBEDTLS_SSL_DEBUG_MSG( 2,
-                           ( "select_sig_alg_for_certificate_verify:"
-                             "no suitable signature algorithm found" ) );
-    return( -1 );
-}
-
 MBEDTLS_CHECK_RETURN_CRITICAL
 static int ssl_tls13_write_certificate_verify_body( mbedtls_ssl_context *ssl,
                                                     unsigned char *buf,
                                                     unsigned char *end,
                                                     size_t *out_len )
 {
-    int ret;
+    int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     unsigned char *p = buf;
     mbedtls_pk_context *own_key;
 
@@ -1007,14 +937,9 @@ static int ssl_tls13_write_certificate_verify_body( mbedtls_ssl_context *ssl,
     size_t handshake_hash_len;
     unsigned char verify_buffer[ SSL_VERIFY_STRUCT_MAX_SIZE ];
     size_t verify_buffer_len;
-    mbedtls_pk_type_t pk_type = MBEDTLS_PK_NONE;
-    mbedtls_md_type_t md_alg = MBEDTLS_MD_NONE;
-    psa_algorithm_t psa_algorithm = PSA_ALG_NONE;
-    uint16_t algorithm = MBEDTLS_TLS1_3_SIG_NONE;
+
+    uint16_t *sig_alg = ssl->handshake->received_sig_algs;
     size_t signature_len = 0;
-    unsigned char verify_hash[PSA_HASH_MAX_SIZE];
-    size_t verify_hash_len;
-    psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
 
     *out_len = 0;
 
@@ -1047,64 +972,78 @@ static int ssl_tls13_write_certificate_verify_body( mbedtls_ssl_context *ssl,
      *    opaque signature<0..2^16-1>;
      *  } CertificateVerify;
      */
-    ret = ssl_tls13_select_sig_alg_for_certificate_verify( ssl, own_key,
-                                                           &algorithm );
-    if( ret != 0 )
+    /* Check there is space for the algorithm identifier (2 bytes) and the
+     * signature length (2 bytes).
+     */
+    MBEDTLS_SSL_CHK_BUF_PTR( p, end, 4 );
+
+    for( ; *sig_alg != MBEDTLS_TLS1_3_SIG_NONE ; sig_alg++ )
     {
-        MBEDTLS_SSL_DEBUG_MSG( 1,
-                    ( "signature algorithm not in received or offered list." ) );
+        psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
+        mbedtls_pk_type_t pk_type = MBEDTLS_PK_NONE;
+        mbedtls_md_type_t md_alg = MBEDTLS_MD_NONE;
+        psa_algorithm_t psa_algorithm = PSA_ALG_NONE;
+        unsigned char verify_hash[PSA_HASH_MAX_SIZE];
+        size_t verify_hash_len;
 
-        MBEDTLS_SSL_DEBUG_MSG( 1, ( "Signature algorithm is %s",
-                                    mbedtls_ssl_sig_alg_to_str( algorithm ) ) );
+        if( !mbedtls_ssl_sig_alg_is_offered( ssl, *sig_alg ) )
+            continue;
 
+        if( !mbedtls_ssl_tls13_sig_alg_for_cert_verify_is_supported( *sig_alg ) )
+            continue;
+
+        if( !mbedtls_ssl_tls13_check_sig_alg_cert_key_match( *sig_alg, own_key ) )
+            continue;
+
+        if( mbedtls_ssl_get_pk_type_and_md_alg_from_sig_alg(
+                                        *sig_alg, &pk_type, &md_alg ) != 0 )
+        {
+             return( MBEDTLS_ERR_SSL_INTERNAL_ERROR  );
+        }
+
+        /* Hash verify buffer with indicated hash function */
+        psa_algorithm = mbedtls_hash_info_psa_from_md( md_alg );
+        status = psa_hash_compute( psa_algorithm,
+                                   verify_buffer,
+                                   verify_buffer_len,
+                                   verify_hash, sizeof( verify_hash ),
+                                   &verify_hash_len );
+        if( status != PSA_SUCCESS )
+            return( psa_ssl_status_to_mbedtls( status ) );
+
+        MBEDTLS_SSL_DEBUG_BUF( 3, "verify hash", verify_hash, verify_hash_len );
+
+        if( ( ret = mbedtls_pk_sign_ext( pk_type, own_key,
+                        md_alg, verify_hash, verify_hash_len,
+                        p + 4, (size_t)( end - ( p + 4 ) ), &signature_len,
+                        ssl->conf->f_rng, ssl->conf->p_rng ) ) != 0 )
+        {
+             MBEDTLS_SSL_DEBUG_MSG( 2, ( "CertificateVerify signature failed with %s",
+                                    mbedtls_ssl_sig_alg_to_str( *sig_alg ) ) );
+             MBEDTLS_SSL_DEBUG_RET( 2, "mbedtls_pk_sign_ext", ret );
+             continue;
+        }
+
+        MBEDTLS_SSL_DEBUG_MSG( 2, ( "CertificateVerify signature with %s",
+                                    mbedtls_ssl_sig_alg_to_str( *sig_alg ) ) );
+
+        break;
+    }
+
+    if( *sig_alg == MBEDTLS_TLS1_3_SIG_NONE )
+    {
+        MBEDTLS_SSL_DEBUG_MSG( 1, ( "no suitable signature algorithm" ) );
         MBEDTLS_SSL_PEND_FATAL_ALERT( MBEDTLS_SSL_ALERT_MSG_HANDSHAKE_FAILURE,
                                       MBEDTLS_ERR_SSL_HANDSHAKE_FAILURE );
         return( MBEDTLS_ERR_SSL_HANDSHAKE_FAILURE );
     }
 
-    MBEDTLS_SSL_DEBUG_MSG( 2, ( "CertificateVerify with %s",
-                                mbedtls_ssl_sig_alg_to_str( algorithm )) );
+    MBEDTLS_PUT_UINT16_BE( *sig_alg, p, 0 );
+    MBEDTLS_PUT_UINT16_BE( signature_len, p, 2 );
 
-    if( mbedtls_ssl_get_pk_type_and_md_alg_from_sig_alg(
-                                        algorithm, &pk_type, &md_alg ) != 0 )
-    {
-        return( MBEDTLS_ERR_SSL_INTERNAL_ERROR  );
-    }
+    *out_len = 4 + signature_len;
 
-    /* Check there is space for the algorithm identifier (2 bytes) and the
-     * signature length (2 bytes).
-     */
-    MBEDTLS_SSL_CHK_BUF_PTR( p, end, 4 );
-    MBEDTLS_PUT_UINT16_BE( algorithm, p, 0 );
-    p += 2;
-
-    /* Hash verify buffer with indicated hash function */
-    psa_algorithm = mbedtls_hash_info_psa_from_md( md_alg );
-    status = psa_hash_compute( psa_algorithm,
-                               verify_buffer,
-                               verify_buffer_len,
-                               verify_hash,sizeof( verify_hash ),
-                               &verify_hash_len );
-    if( status != PSA_SUCCESS )
-        return( psa_ssl_status_to_mbedtls( status ) );
-
-    MBEDTLS_SSL_DEBUG_BUF( 3, "verify hash", verify_hash, verify_hash_len );
-
-    if( ( ret = mbedtls_pk_sign_ext( pk_type, own_key,
-                        md_alg, verify_hash, verify_hash_len,
-                        p + 2, (size_t)( end - ( p + 2 ) ), &signature_len,
-                        ssl->conf->f_rng, ssl->conf->p_rng ) ) != 0 )
-    {
-        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_pk_sign", ret );
-        return( ret );
-    }
-
-    MBEDTLS_PUT_UINT16_BE( signature_len, p, 0 );
-    p += 2 + signature_len;
-
-    *out_len = (size_t)( p - buf );
-
-    return( ret );
+    return( 0 );
 }
 
 int mbedtls_ssl_tls13_write_certificate_verify( mbedtls_ssl_context *ssl )

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -917,9 +917,11 @@ static psa_algorithm_t ssl_tls13_iana_sig_alg_to_psa_alg( uint16_t sig_alg )
         case MBEDTLS_TLS1_3_SIG_RSA_PSS_RSAE_SHA512:
             return( PSA_ALG_RSA_PSS( PSA_ALG_SHA_512 ) );
         case MBEDTLS_TLS1_3_SIG_RSA_PKCS1_SHA256:
+            return( PSA_ALG_RSA_PKCS1V15_SIGN( PSA_ALG_SHA_256 ) );
         case MBEDTLS_TLS1_3_SIG_RSA_PKCS1_SHA384:
+            return( PSA_ALG_RSA_PKCS1V15_SIGN( PSA_ALG_SHA_384 ) );
         case MBEDTLS_TLS1_3_SIG_RSA_PKCS1_SHA512:
-            return( PSA_ALG_RSA_PKCS1V15_CRYPT );
+            return( PSA_ALG_RSA_PKCS1V15_SIGN( PSA_ALG_SHA_512 ) );
         default:
             return( PSA_ALG_NONE );
     }

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -898,6 +898,34 @@ static int ssl_tls13_determine_key_exchange_mode( mbedtls_ssl_context *ssl )
 
 #if defined(MBEDTLS_X509_CRT_PARSE_C) && \
     defined(MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED)
+
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+static psa_algorithm_t ssl_tls13_iana_sig_alg_to_psa_alg( uint16_t sig_alg )
+{
+    switch( sig_alg )
+    {
+        case MBEDTLS_TLS1_3_SIG_ECDSA_SECP256R1_SHA256:
+            return( PSA_ALG_ECDSA( PSA_ALG_SHA_256 ) );
+        case MBEDTLS_TLS1_3_SIG_ECDSA_SECP384R1_SHA384:
+            return( PSA_ALG_ECDSA( PSA_ALG_SHA_384 ) );
+        case MBEDTLS_TLS1_3_SIG_ECDSA_SECP521R1_SHA512:
+            return( PSA_ALG_ECDSA( PSA_ALG_SHA_512 ) );
+        case MBEDTLS_TLS1_3_SIG_RSA_PSS_RSAE_SHA256:
+            return( PSA_ALG_RSA_PSS( PSA_ALG_SHA_256 ) );
+        case MBEDTLS_TLS1_3_SIG_RSA_PSS_RSAE_SHA384:
+            return( PSA_ALG_RSA_PSS( PSA_ALG_SHA_384 ) );
+        case MBEDTLS_TLS1_3_SIG_RSA_PSS_RSAE_SHA512:
+            return( PSA_ALG_RSA_PSS( PSA_ALG_SHA_512 ) );
+        case MBEDTLS_TLS1_3_SIG_RSA_PKCS1_SHA256:
+        case MBEDTLS_TLS1_3_SIG_RSA_PKCS1_SHA384:
+        case MBEDTLS_TLS1_3_SIG_RSA_PKCS1_SHA512:
+            return( PSA_ALG_RSA_PKCS1V15_CRYPT );
+        default:
+            return( PSA_ALG_NONE );
+    }
+}
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
+
 /*
  * Pick best ( private key, certificate chain ) pair based on the signature
  * algorithms supported by the client.
@@ -923,9 +951,19 @@ static int ssl_tls13_pick_key_cert( mbedtls_ssl_context *ssl )
 
     for( ; *sig_alg != MBEDTLS_TLS1_3_SIG_NONE; sig_alg++ )
     {
+        if( !mbedtls_ssl_sig_alg_is_offered( ssl, *sig_alg ) )
+            continue;
+
+        if( !mbedtls_ssl_tls13_sig_alg_for_cert_verify_is_supported( *sig_alg ) )
+            continue;
+
         for( key_cert = key_cert_list; key_cert != NULL;
              key_cert = key_cert->next )
         {
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+            psa_algorithm_t psa_alg = PSA_ALG_NONE;
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
+
             MBEDTLS_SSL_DEBUG_CRT( 3, "certificate (chain) candidate",
                                    key_cert->cert );
 
@@ -949,8 +987,18 @@ static int ssl_tls13_pick_key_cert( mbedtls_ssl_context *ssl )
                                      "check signature algorithm %s [%04x]",
                                      mbedtls_ssl_sig_alg_to_str( *sig_alg ),
                                      *sig_alg ) );
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+            psa_alg = ssl_tls13_iana_sig_alg_to_psa_alg( *sig_alg );
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
+
             if( mbedtls_ssl_tls13_check_sig_alg_cert_key_match(
-                                            *sig_alg, &key_cert->cert->pk ) )
+                                            *sig_alg, &key_cert->cert->pk )
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+                && psa_alg != PSA_ALG_NONE &&
+                mbedtls_pk_can_do_ext( &key_cert->cert->pk, psa_alg,
+                                       PSA_KEY_USAGE_SIGN_HASH ) == 1
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
+                )
             {
                 ssl->handshake->key_cert = key_cert;
                 MBEDTLS_SSL_DEBUG_MSG( 3,

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -1769,7 +1769,8 @@ int main( int argc, char *argv[] )
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     mbedtls_printf( " ok (key type: %s)\n",
-                    strlen( opt.key_file ) ? mbedtls_pk_get_name( &pkey ) : "none" );
+                    strlen( opt.key_file ) || strlen( opt.key_opaque_alg1 ) ?
+                            mbedtls_pk_get_name( &pkey ) : "none" );
 #endif /* MBEDTLS_X509_CRT_PARSE_C */
 
     /*

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -346,10 +346,11 @@ int main( void )
 
 #define USAGE_KEY_OPAQUE_ALGS \
     "    key_opaque_algs=%%s  Allowed opaque key algorithms.\n"                      \
-    "                        comma-separated pair of values among the following:\n"   \
-    "                        rsa-sign-pkcs1, rsa-sign-pss, rsa-decrypt,\n"           \
-    "                        ecdsa-sign, ecdh, none (only acceptable for\n"          \
-    "                        the second value).\n"                                   \
+    "                        comma-separated pair of values among the following:\n"    \
+    "                        rsa-sign-pkcs1, rsa-sign-pss, rsa-sign-pss-sha256,\n"     \
+    "                        rsa-sign-pss-sha384, rsa-sign-pss-sha512, rsa-decrypt,\n" \
+    "                        ecdsa-sign, ecdh, none (only acceptable for\n"            \
+    "                        the second value).\n"                                     \
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
 #define USAGE_TLS1_3_KEY_EXCHANGE_MODES \

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -458,15 +458,17 @@ int main( void )
 #endif
 
 #define USAGE_KEY_OPAQUE_ALGS \
-    "    key_opaque_algs=%%s  Allowed opaque key 1 algorithms.\n"                    \
-    "                        comma-separated pair of values among the following:\n"  \
-    "                        rsa-sign-pkcs1, rsa-sign-pss, rsa-decrypt,\n"           \
-    "                        ecdsa-sign, ecdh, none (only acceptable for\n"          \
-    "                        the second value).\n"                                   \
-    "    key_opaque_algs2=%%s Allowed opaque key 2 algorithms.\n"                    \
-    "                        comma-separated pair of values among the following:\n"  \
-    "                        rsa-sign-pkcs1, rsa-sign-pss, rsa-decrypt,\n"           \
-    "                        ecdsa-sign, ecdh, none (only acceptable for\n"          \
+    "    key_opaque_algs=%%s  Allowed opaque key 1 algorithms.\n"                      \
+    "                        comma-separated pair of values among the following:\n"    \
+    "                        rsa-sign-pkcs1, rsa-sign-pss, rsa-sign-pss-sha256,\n"     \
+    "                        rsa-sign-pss-sha384, rsa-sign-pss-sha512, rsa-decrypt,\n" \
+    "                        ecdsa-sign, ecdh, none (only acceptable for\n"            \
+    "                        the second value).\n"                                     \
+    "    key_opaque_algs2=%%s Allowed opaque key 2 algorithms.\n"                      \
+    "                        comma-separated pair of values among the following:\n"    \
+    "                        rsa-sign-pkcs1, rsa-sign-pss, rsa-sign-pss-sha256,\n"     \
+    "                        rsa-sign-pss-sha384, rsa-sign-pss-sha512, rsa-decrypt,\n" \
+    "                        ecdsa-sign, ecdh, none (only acceptable for\n"            \
     "                        the second value).\n"
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
 #define USAGE_TLS1_3_KEY_EXCHANGE_MODES \

--- a/programs/ssl/ssl_test_lib.c
+++ b/programs/ssl/ssl_test_lib.c
@@ -205,6 +205,9 @@ int key_opaque_alg_parse( const char *arg, const char **alg1, const char **alg2 
 
     if( strcmp( *alg1, "rsa-sign-pkcs1" ) != 0 &&
         strcmp( *alg1, "rsa-sign-pss" ) != 0 &&
+        strcmp( *alg1, "rsa-sign-pss-sha256" ) != 0 &&
+        strcmp( *alg1, "rsa-sign-pss-sha384" ) != 0 &&
+        strcmp( *alg1, "rsa-sign-pss-sha512" ) != 0 &&
         strcmp( *alg1, "rsa-decrypt" ) != 0 &&
         strcmp( *alg1, "ecdsa-sign" ) != 0 &&
         strcmp( *alg1, "ecdh" ) != 0 )
@@ -212,6 +215,9 @@ int key_opaque_alg_parse( const char *arg, const char **alg1, const char **alg2 
 
     if( strcmp( *alg2, "rsa-sign-pkcs1" ) != 0 &&
         strcmp( *alg2, "rsa-sign-pss" ) != 0 &&
+        strcmp( *alg1, "rsa-sign-pss-sha256" ) != 0 &&
+        strcmp( *alg1, "rsa-sign-pss-sha384" ) != 0 &&
+        strcmp( *alg1, "rsa-sign-pss-sha512" ) != 0 &&
         strcmp( *alg2, "rsa-decrypt" ) != 0 &&
         strcmp( *alg2, "ecdsa-sign" ) != 0 &&
         strcmp( *alg2, "ecdh" ) != 0 &&
@@ -243,6 +249,21 @@ int key_opaque_set_alg_usage( const char *alg1, const char *alg2,
             else if( strcmp( algs[i], "rsa-sign-pss" ) == 0 )
             {
                 *psa_algs[i] = PSA_ALG_RSA_PSS( PSA_ALG_ANY_HASH );
+                *usage |= PSA_KEY_USAGE_SIGN_HASH;
+            }
+            else if( strcmp( algs[i], "rsa-sign-pss-sha256" ) == 0 )
+            {
+                *psa_algs[i] = PSA_ALG_RSA_PSS( PSA_ALG_SHA_256 );
+                *usage |= PSA_KEY_USAGE_SIGN_HASH;
+            }
+            else if( strcmp( algs[i], "rsa-sign-pss-sha384" ) == 0 )
+            {
+                *psa_algs[i] = PSA_ALG_RSA_PSS( PSA_ALG_SHA_384 );
+                *usage |= PSA_KEY_USAGE_SIGN_HASH;
+            }
+            else if( strcmp( algs[i], "rsa-sign-pss-sha512" ) == 0 )
+            {
+                *psa_algs[i] = PSA_ALG_RSA_PSS( PSA_ALG_SHA_512 );
                 *usage |= PSA_KEY_USAGE_SIGN_HASH;
             }
             else if( strcmp( algs[i], "rsa-decrypt" ) == 0 )

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -2045,7 +2045,7 @@ run_test    "Opaque keys for server authentication: EC + RSA, force ECDHE-ECDSA"
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
 requires_config_enabled MBEDTLS_RSA_C
-run_test    "TLS1.3 opaque key: no suitable algorithm found" \
+run_test    "TLS 1.3 opaque key: no suitable algorithm found" \
             "$P_SRV debug_level=4 force_version=tls13 key_opaque=1 key_opaque_algs=rsa-decrypt,none" \
             "$P_CLI debug_level=4 force_version=tls13 key_opaque=1 key_opaque_algs=rsa-decrypt,rsa-sign-pss" \
             1 \
@@ -2059,7 +2059,7 @@ run_test    "TLS1.3 opaque key: no suitable algorithm found" \
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
 requires_config_enabled MBEDTLS_RSA_C
-run_test    "TLS1.3 opaque key: suitable algorithm found" \
+run_test    "TLS 1.3 opaque key: suitable algorithm found" \
             "$P_SRV debug_level=4 force_version=tls13 key_opaque=1 key_opaque_algs=rsa-decrypt,rsa-sign-pss" \
             "$P_CLI debug_level=4 force_version=tls13 key_opaque=1 key_opaque_algs=rsa-decrypt,rsa-sign-pss" \
             0 \
@@ -2073,7 +2073,7 @@ run_test    "TLS1.3 opaque key: suitable algorithm found" \
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
 requires_config_enabled MBEDTLS_RSA_C
-run_test    "TLS1.3 opaque key: 2 keys on server, suitable algorithm found" \
+run_test    "TLS 1.3 opaque key: 2 keys on server, suitable algorithm found" \
             "$P_SRV debug_level=4 force_version=tls13 key_opaque=1 key_opaque_algs2=ecdsa-sign,none key_opaque_algs=rsa-decrypt,rsa-sign-pss" \
             "$P_CLI debug_level=4 force_version=tls13 key_opaque=1 key_opaque_algs=rsa-decrypt,rsa-sign-pss" \
             0 \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -2046,7 +2046,7 @@ requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
 requires_config_enabled MBEDTLS_RSA_C
 run_test    "TLS 1.3 opaque key: no suitable algorithm found" \
-            "$P_SRV debug_level=4 force_version=tls13 key_opaque=1 key_opaque_algs=rsa-decrypt,none" \
+            "$P_SRV debug_level=4 force_version=tls13 auth_mode=required key_opaque=1 key_opaque_algs=rsa-decrypt,none" \
             "$P_CLI debug_level=4 key_opaque=1 key_opaque_algs=rsa-decrypt,rsa-sign-pss" \
             1 \
             -s "The SSL configuration is tls13 only" \
@@ -2059,7 +2059,7 @@ requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
 requires_config_enabled MBEDTLS_RSA_C
 run_test    "TLS 1.3 opaque key: suitable algorithm found" \
-            "$P_SRV debug_level=4 force_version=tls13 key_opaque=1 key_opaque_algs=rsa-decrypt,rsa-sign-pss" \
+            "$P_SRV debug_level=4 force_version=tls13 auth_mode=required key_opaque=1 key_opaque_algs=rsa-decrypt,rsa-sign-pss" \
             "$P_CLI debug_level=4 key_opaque=1 key_opaque_algs=rsa-decrypt,rsa-sign-pss" \
             0 \
             -s "The SSL configuration is tls13 only" \
@@ -2072,7 +2072,7 @@ requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
 requires_config_enabled MBEDTLS_RSA_C
 run_test    "TLS 1.3 opaque key: 2 keys on server, suitable algorithm found" \
-            "$P_SRV debug_level=4 force_version=tls13 key_opaque=1 key_opaque_algs2=ecdsa-sign,none key_opaque_algs=rsa-decrypt,rsa-sign-pss" \
+            "$P_SRV debug_level=4 force_version=tls13 auth_mode=required key_opaque=1 key_opaque_algs2=ecdsa-sign,none key_opaque_algs=rsa-decrypt,rsa-sign-pss" \
             "$P_CLI debug_level=4 key_opaque=1 key_opaque_algs=rsa-decrypt,rsa-sign-pss" \
             0 \
             -s "The SSL configuration is tls13 only" \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -2047,9 +2047,8 @@ requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
 requires_config_enabled MBEDTLS_RSA_C
 run_test    "TLS 1.3 opaque key: no suitable algorithm found" \
             "$P_SRV debug_level=4 force_version=tls13 key_opaque=1 key_opaque_algs=rsa-decrypt,none" \
-            "$P_CLI debug_level=4 force_version=tls13 key_opaque=1 key_opaque_algs=rsa-decrypt,rsa-sign-pss" \
+            "$P_CLI debug_level=4 key_opaque=1 key_opaque_algs=rsa-decrypt,rsa-sign-pss" \
             1 \
-            -c "The SSL configuration is tls13 only" \
             -s "The SSL configuration is tls13 only" \
             -c "key type: Opaque" \
             -s "key types: Opaque, Opaque" \
@@ -2061,9 +2060,8 @@ requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
 requires_config_enabled MBEDTLS_RSA_C
 run_test    "TLS 1.3 opaque key: suitable algorithm found" \
             "$P_SRV debug_level=4 force_version=tls13 key_opaque=1 key_opaque_algs=rsa-decrypt,rsa-sign-pss" \
-            "$P_CLI debug_level=4 force_version=tls13 key_opaque=1 key_opaque_algs=rsa-decrypt,rsa-sign-pss" \
+            "$P_CLI debug_level=4 key_opaque=1 key_opaque_algs=rsa-decrypt,rsa-sign-pss" \
             0 \
-            -c "The SSL configuration is tls13 only" \
             -s "The SSL configuration is tls13 only" \
             -c "key type: Opaque" \
             -s "key types: Opaque, Opaque" \
@@ -2075,9 +2073,8 @@ requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
 requires_config_enabled MBEDTLS_RSA_C
 run_test    "TLS 1.3 opaque key: 2 keys on server, suitable algorithm found" \
             "$P_SRV debug_level=4 force_version=tls13 key_opaque=1 key_opaque_algs2=ecdsa-sign,none key_opaque_algs=rsa-decrypt,rsa-sign-pss" \
-            "$P_CLI debug_level=4 force_version=tls13 key_opaque=1 key_opaque_algs=rsa-decrypt,rsa-sign-pss" \
+            "$P_CLI debug_level=4 key_opaque=1 key_opaque_algs=rsa-decrypt,rsa-sign-pss" \
             0 \
-            -c "The SSL configuration is tls13 only" \
             -s "The SSL configuration is tls13 only" \
             -c "key type: Opaque" \
             -s "key types: Opaque, Opaque" \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -2071,6 +2071,20 @@ run_test    "TLS 1.3 opaque key: suitable algorithm found" \
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
 requires_config_enabled MBEDTLS_RSA_C
+run_test    "TLS 1.3 opaque key: first client sig alg not suitable" \
+            "$P_SRV debug_level=4 force_version=tls13 auth_mode=required key_opaque=1 key_opaque_algs=rsa-sign-pss-sha512,none" \
+            "$P_CLI debug_level=4 sig_algs=rsa_pss_rsae_sha256,rsa_pss_rsae_sha512" \
+            0 \
+            -s "The SSL configuration is tls13 only" \
+            -s "key types: Opaque, Opaque" \
+            -s "CertificateVerify signature failed with rsa_pss_rsae_sha256" \
+            -s "CertificateVerify signature with rsa_pss_rsae_sha512" \
+            -C "error" \
+            -S "error" \
+
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
+requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
+requires_config_enabled MBEDTLS_RSA_C
 run_test    "TLS 1.3 opaque key: 2 keys on server, suitable algorithm found" \
             "$P_SRV debug_level=4 force_version=tls13 auth_mode=required key_opaque=1 key_opaque_algs2=ecdsa-sign,none key_opaque_algs=rsa-decrypt,rsa-sign-pss" \
             "$P_CLI debug_level=4 key_opaque=1 key_opaque_algs=rsa-decrypt,rsa-sign-pss" \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -2042,6 +2042,48 @@ run_test    "Opaque keys for server authentication: EC + RSA, force ECDHE-ECDSA"
             -S "error" \
             -C "error"
 
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
+requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
+requires_config_enabled MBEDTLS_RSA_C
+run_test    "TLS1.3 opaque key: no suitable algorithm found" \
+            "$P_SRV debug_level=4 force_version=tls13 key_opaque=1 key_opaque_algs=rsa-decrypt,none" \
+            "$P_CLI debug_level=4 force_version=tls13 key_opaque=1 key_opaque_algs=rsa-decrypt,rsa-sign-pss" \
+            1 \
+            -c "The SSL configuration is tls13 only" \
+            -s "The SSL configuration is tls13 only" \
+            -c "key type: Opaque" \
+            -s "key types: Opaque, Opaque" \
+            -c "error" \
+            -s "select_sig_alg_for_certificate_verify:no suitable signature algorithm found" \
+
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
+requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
+requires_config_enabled MBEDTLS_RSA_C
+run_test    "TLS1.3 opaque key: suitable algorithm found" \
+            "$P_SRV debug_level=4 force_version=tls13 key_opaque=1 key_opaque_algs=rsa-decrypt,rsa-sign-pss" \
+            "$P_CLI debug_level=4 force_version=tls13 key_opaque=1 key_opaque_algs=rsa-decrypt,rsa-sign-pss" \
+            0 \
+            -c "The SSL configuration is tls13 only" \
+            -s "The SSL configuration is tls13 only" \
+            -c "key type: Opaque" \
+            -s "key types: Opaque, Opaque" \
+            -C "error" \
+            -S "error" \
+
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
+requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
+requires_config_enabled MBEDTLS_RSA_C
+run_test    "TLS1.3 opaque key: 2 keys on server, suitable algorithm found" \
+            "$P_SRV debug_level=4 force_version=tls13 key_opaque=1 key_opaque_algs2=ecdsa-sign,none key_opaque_algs=rsa-decrypt,rsa-sign-pss" \
+            "$P_CLI debug_level=4 force_version=tls13 key_opaque=1 key_opaque_algs=rsa-decrypt,rsa-sign-pss" \
+            0 \
+            -c "The SSL configuration is tls13 only" \
+            -s "The SSL configuration is tls13 only" \
+            -c "key type: Opaque" \
+            -s "key types: Opaque, Opaque" \
+            -C "error" \
+            -S "error" \
+
 # Test using a RSA opaque private key for server authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_USE_PSA_CRYPTO

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -12671,8 +12671,7 @@ run_test    "TLS 1.3: Check server no suitable signature algorithm, G->m" \
                                  --x509certfile data_files/server2-sha256.crt --x509keyfile data_files/server2.key \
                                  --priority=NORMAL:-SIGN-ALL:+SIGN-RSA-SHA512:+SIGN-RSA-PSS-RSAE-SHA512:+SIGN-ECDSA-SECP521R1-SHA512"  \
             1 \
-            -s "ssl_tls13_pick_key_cert:selected signature algorithm rsa_pss_rsae_sha512" \
-            -s "select_sig_alg_for_certificate_verify:no suitable signature algorithm found"
+            -S "ssl_tls13_pick_key_cert:check signature algorithm"
 
 requires_openssl_tls1_3
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -12688,8 +12687,7 @@ run_test    "TLS 1.3: Check server no suitable signature algorithm, O->m" \
                                  -cert data_files/server2-sha256.crt -key data_files/server2.key \
                                  -sigalgs rsa_pkcs1_sha512:rsa_pss_rsae_sha512:ecdsa_secp521r1_sha512"  \
             1 \
-            -s "ssl_tls13_pick_key_cert:selected signature algorithm rsa_pss_rsae_sha512" \
-            -s "select_sig_alg_for_certificate_verify:no suitable signature algorithm found"
+            -S "ssl_tls13_pick_key_cert:check signature algorithm"
 
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
@@ -12704,8 +12702,7 @@ run_test    "TLS 1.3: Check server no suitable signature algorithm, m->m" \
             "$P_CLI allow_sha1=0 debug_level=4 crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key \
                     sig_algs=rsa_pkcs1_sha512,rsa_pss_rsae_sha512,ecdsa_secp521r1_sha512" \
             1 \
-            -s "ssl_tls13_pick_key_cert:selected signature algorithm rsa_pss_rsae_sha512" \
-            -s "select_sig_alg_for_certificate_verify:no suitable signature algorithm found"
+            -S "ssl_tls13_pick_key_cert:check signature algorithm"
 
 requires_gnutls_tls1_3
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -2054,7 +2054,7 @@ run_test    "TLS1.3 opaque key: no suitable algorithm found" \
             -c "key type: Opaque" \
             -s "key types: Opaque, Opaque" \
             -c "error" \
-            -s "select_sig_alg_for_certificate_verify:no suitable signature algorithm found" \
+            -s "no suitable signature algorithm"
 
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
@@ -11562,7 +11562,7 @@ run_test    "TLS 1.3: Client authentication, client alg not in server list - ope
             -c "got a certificate request" \
             -c "client state: MBEDTLS_SSL_CLIENT_CERTIFICATE" \
             -c "client state: MBEDTLS_SSL_CLIENT_CERTIFICATE_VERIFY" \
-            -c "signature algorithm not in received or offered list." \
+            -c "no suitable signature algorithm" \
             -C "unknown pk type"
 
 requires_gnutls_tls1_3
@@ -11580,7 +11580,7 @@ run_test    "TLS 1.3: Client authentication, client alg not in server list - gnu
             -c "got a certificate request" \
             -c "client state: MBEDTLS_SSL_CLIENT_CERTIFICATE" \
             -c "client state: MBEDTLS_SSL_CLIENT_CERTIFICATE_VERIFY" \
-            -c "signature algorithm not in received or offered list." \
+            -c "no suitable signature algorithm" \
             -C "unknown pk type"
 
 # Test using an opaque private key for client authentication
@@ -11834,7 +11834,7 @@ run_test    "TLS 1.3: Client authentication - opaque key, client alg not in serv
             -c "got a certificate request" \
             -c "client state: MBEDTLS_SSL_CLIENT_CERTIFICATE" \
             -c "client state: MBEDTLS_SSL_CLIENT_CERTIFICATE_VERIFY" \
-            -c "signature algorithm not in received or offered list." \
+            -c "no suitable signature algorithm" \
             -C "unkown pk type"
 
 requires_gnutls_tls1_3
@@ -11853,7 +11853,7 @@ run_test    "TLS 1.3: Client authentication - opaque key, client alg not in serv
             -c "got a certificate request" \
             -c "client state: MBEDTLS_SSL_CLIENT_CERTIFICATE" \
             -c "client state: MBEDTLS_SSL_CLIENT_CERTIFICATE_VERIFY" \
-            -c "signature algorithm not in received or offered list." \
+            -c "no suitable signature algorithm" \
             -C "unkown pk type"
 
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -12582,7 +12582,7 @@ run_test    "TLS 1.3: Check signature algorithm order, m->O" \
                     sig_algs=rsa_pkcs1_sha512,rsa_pss_rsae_sha512,rsa_pss_rsae_sha384,ecdsa_secp256r1_sha256" \
             0 \
             -c "Protocol is TLSv1.3" \
-            -c "select_sig_alg_for_certificate_verify:selected signature algorithm rsa_pss_rsae_sha512" \
+            -c "CertificateVerify signature with rsa_pss_rsae_sha512" \
             -c "HTTP/1.0 200 [Oo][Kk]"
 
 requires_gnutls_tls1_3
@@ -12598,7 +12598,7 @@ run_test    "TLS 1.3: Check signature algorithm order, m->G" \
                     sig_algs=rsa_pkcs1_sha512,rsa_pss_rsae_sha512,rsa_pss_rsae_sha384,ecdsa_secp256r1_sha256" \
             0 \
             -c "Protocol is TLSv1.3" \
-            -c "select_sig_alg_for_certificate_verify:selected signature algorithm rsa_pss_rsae_sha512" \
+            -c "CertificateVerify signature with rsa_pss_rsae_sha512" \
             -c "HTTP/1.0 200 [Oo][Kk]"
 
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -12615,8 +12615,8 @@ run_test    "TLS 1.3: Check signature algorithm order, m->m" \
                     sig_algs=rsa_pkcs1_sha512,rsa_pss_rsae_sha512,rsa_pss_rsae_sha384,ecdsa_secp256r1_sha256" \
             0 \
             -c "Protocol is TLSv1.3" \
-            -c "select_sig_alg_for_certificate_verify:selected signature algorithm rsa_pss_rsae_sha512" \
-            -s "select_sig_alg_for_certificate_verify:selected signature algorithm rsa_pss_rsae_sha512" \
+            -c "CertificateVerify signature with rsa_pss_rsae_sha512" \
+            -s "CertificateVerify signature with rsa_pss_rsae_sha512" \
             -s "ssl_tls13_pick_key_cert:selected signature algorithm rsa_pss_rsae_sha512" \
             -c "HTTP/1.0 200 [Oo][Kk]"
 
@@ -12635,7 +12635,7 @@ run_test    "TLS 1.3: Check signature algorithm order, O->m" \
                                  -sigalgs rsa_pkcs1_sha512:rsa_pss_rsae_sha512:rsa_pss_rsae_sha384:ecdsa_secp256r1_sha256"  \
             0 \
             -c "TLSv1.3" \
-            -s "select_sig_alg_for_certificate_verify:selected signature algorithm rsa_pss_rsae_sha512" \
+            -s "CertificateVerify signature with rsa_pss_rsae_sha512" \
             -s "ssl_tls13_pick_key_cert:selected signature algorithm rsa_pss_rsae_sha512"
 
 requires_gnutls_tls1_3
@@ -12654,7 +12654,7 @@ run_test    "TLS 1.3: Check signature algorithm order, G->m" \
             0 \
             -c "Negotiated version: 3.4" \
             -c "HTTP/1.0 200 [Oo][Kk]" \
-            -s "select_sig_alg_for_certificate_verify:selected signature algorithm rsa_pss_rsae_sha512" \
+            -s "CertificateVerify signature with rsa_pss_rsae_sha512" \
             -s "ssl_tls13_pick_key_cert:selected signature algorithm rsa_pss_rsae_sha512"
 
 requires_gnutls_tls1_3
@@ -12758,7 +12758,7 @@ run_test    "TLS 1.3: Check client no signature algorithm, m->O" \
             "$P_CLI debug_level=4 crt_file=data_files/server5.crt key_file=data_files/server5.key \
                     sig_algs=rsa_pkcs1_sha512,rsa_pss_rsae_sha512,rsa_pss_rsae_sha384,ecdsa_secp256r1_sha256" \
             1 \
-            -c "select_sig_alg_for_certificate_verify:no suitable signature algorithm found"
+            -c "no suitable signature algorithm"
 
 requires_gnutls_tls1_3
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -12772,7 +12772,7 @@ run_test    "TLS 1.3: Check client no signature algorithm, m->G" \
             "$P_CLI debug_level=4 crt_file=data_files/server5.crt key_file=data_files/server5.key \
                     sig_algs=rsa_pkcs1_sha512,rsa_pss_rsae_sha512,rsa_pss_rsae_sha384,ecdsa_secp256r1_sha256" \
             1 \
-            -c "select_sig_alg_for_certificate_verify:no suitable signature algorithm found"
+            -c "no suitable signature algorithm"
 
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
@@ -12787,7 +12787,7 @@ run_test    "TLS 1.3: Check client no signature algorithm, m->m" \
             "$P_CLI debug_level=4 crt_file=data_files/server5.crt key_file=data_files/server5.key \
                     sig_algs=rsa_pkcs1_sha512,rsa_pss_rsae_sha512,rsa_pss_rsae_sha384,ecdsa_secp256r1_sha256" \
             1 \
-            -c "select_sig_alg_for_certificate_verify:no suitable signature algorithm found"
+            -c "no suitable signature algorithm"
 
 requires_openssl_tls1_3
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3


### PR DESCRIPTION
## Description
TLS 1.3: Take into account key policy while picking a signature algorithm.
Resolves https://github.com/Mbed-TLS/mbedtls/issues/5844

@mpg @ronald-cron-arm Do we need extra tests for this change?


## Status
**IN DEVELOPMENT**

## Requires Backporting
NO  

## Migrations
NO

## Todos
- [ ] Tests ???

