### PR TITLE
Fix `mbedtls_pk_parse_public_key` resource leaks

### DIFF
--- a/ChangeLog.d/fix_some_resource_leaks.txt
+++ b/ChangeLog.d/fix_some_resource_leaks.txt
@@ -1,0 +1,4 @@
+Bugfix
+   * Fix resource leaks in mbedtls_pk_parse_public_key() in low
+     memory conditions.
+

--- a/library/pkparse.c
+++ b/library/pkparse.c
@@ -1465,8 +1465,10 @@ int mbedtls_pk_parse_public_key( mbedtls_pk_context *ctx,
         if( ( pk_info = mbedtls_pk_info_from_type( MBEDTLS_PK_RSA ) ) == NULL )
             return( MBEDTLS_ERR_PK_UNKNOWN_PK_ALG );
 
-        if( ( ret = mbedtls_pk_setup( ctx, pk_info ) ) != 0 )
+        if( ( ret = mbedtls_pk_setup( ctx, pk_info ) ) != 0 ) {
+            mbedtls_pem_free( &pem );
             return( ret );
+        }
 
         if ( ( ret = pk_get_rsapubkey( &p, p + pem.buflen, mbedtls_pk_rsa( *ctx ) ) ) != 0 )
             mbedtls_pk_free( ctx );

--- a/library/pkparse.c
+++ b/library/pkparse.c
@@ -1462,7 +1462,7 @@ int mbedtls_pk_parse_public_key( mbedtls_pk_context *ctx,
     if( ret == 0 )
     {
         p = pem.buf;
-        if( ( pk_info = mbedtls_pk_info_from_type( MBEDTLS_PK_RSA )) == NULL )
+        if( ( pk_info = mbedtls_pk_info_from_type( MBEDTLS_PK_RSA ) ) == NULL )
         {
             mbedtls_pem_free( &pem );
             return( MBEDTLS_ERR_PK_UNKNOWN_PK_ALG );

--- a/library/pkparse.c
+++ b/library/pkparse.c
@@ -1462,10 +1462,14 @@ int mbedtls_pk_parse_public_key( mbedtls_pk_context *ctx,
     if( ret == 0 )
     {
         p = pem.buf;
-        if( ( pk_info = mbedtls_pk_info_from_type( MBEDTLS_PK_RSA ) ) == NULL )
+        if( ( pk_info = mbedtls_pk_info_from_type( MBEDTLS_PK_RSA )) == NULL )
+        {
+            mbedtls_pem_free( &pem );
             return( MBEDTLS_ERR_PK_UNKNOWN_PK_ALG );
+        }
 
-        if( ( ret = mbedtls_pk_setup( ctx, pk_info ) ) != 0 ) {
+        if( ( ret = mbedtls_pk_setup( ctx, pk_info ) ) != 0 )
+        {
             mbedtls_pem_free( &pem );
             return( ret );
         }


### PR DESCRIPTION
Partial backport of https://github.com/Mbed-TLS/mbedtls/pull/5765 - only the `mbedtls_pk_parse_public_key` part applies.