### PR TITLE
Fix generation of ssl_debug_helpers

### DIFF
--- a/scripts/generate_ssl_debug_helpers.py
+++ b/scripts/generate_ssl_debug_helpers.py
@@ -277,7 +277,7 @@ class SignatureAlgorithmDefinition:
         for m in self._definitions:
             name = m.groupdict()['name']
             translation_table.append(
-                '\tcase {}:\n\t    return "{}";'.format(name,
+                '    case {}:\n        return "{}";'.format(name,
                                                         name[len('MBEDTLS_TLS1_3_SIG_'):].lower())
             )
 
@@ -337,7 +337,7 @@ class NamedGroupDefinition:
         for m in self._definitions:
             name = m.groupdict()['name']
             iana_name = name[len('MBEDTLS_SSL_IANA_TLS_GROUP_'):].lower()
-            translation_table.append('\tcase {}:\n\t    return "{}";'.format(name, iana_name))
+            translation_table.append('    case {}:\n        return "{}";'.format(name, iana_name))
 
         body = textwrap.dedent('''\
             const char *mbedtls_ssl_named_group_to_str( uint16_t in )


### PR DESCRIPTION
## Description
The file 'ssl_debug_helpers_generated.c' was being generated using tabs rather than spaces, which breaks release builds. This problem is normally hidden, as this file is referenced as part of the .gitignore, however in a release build it gets checked in.

Resolves https://github.com/Mbed-TLS/mbedtls/issues/6075

## Status
**READY**

## Requires Backporting
NO  
(This script was only added in 3.0)

## Migrations
NO

## Todos
- [ ] Tests

## Steps to test or reproduce
Release build should not complain about check_files failing on 'ssl_debug_helpers_generated.c'
