### PR TITLE
Fix formatting of generate_ssl_debug_helpers.py

### DIFF
--- a/scripts/generate_ssl_debug_helpers.py
+++ b/scripts/generate_ssl_debug_helpers.py
@@ -276,10 +276,9 @@ class SignatureAlgorithmDefinition:
         translation_table = []
         for m in self._definitions:
             name = m.groupdict()['name']
+            return_val = name[len('MBEDTLS_TLS1_3_SIG_'):].lower()
             translation_table.append(
-                '    case {}:\n        return "{}";'.format(name,
-                                                        name[len('MBEDTLS_TLS1_3_SIG_'):].lower())
-            )
+                '    case {}:\n        return "{}";'.format(name, return_val))
 
         body = textwrap.dedent('''\
             const char *mbedtls_ssl_sig_alg_to_str( uint16_t in )


### PR DESCRIPTION
## Description

The emergency fix of  `generate_ssl_debug_helpers.py` to fix the release build ( https://github.com/Mbed-TLS/mbedtls/pull/6076 ) unfortunately fell foul of pylint on the CI, this fixes that. 

In order to fix the second line too long issue I had to split out the second part into another variable.

## Status
**READY**

## Requires Backporting
NO  

## Migrations
NO

## Todos
- [ ] Tests

## Steps to test or reproduce
CI (check_python_files.py) should pass.
