### PR TITLE
TLS 1.3: PSK: Add parser/writer of pre_shared_key extension on server side.

### DIFF
--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -250,6 +250,8 @@
     ( MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL        |            \
       MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL    ) /*!< All ephemeral TLS 1.3 key exchanges */
 
+#define MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_NONE   ( 0 )
+
 /*
  * Various constants
  */

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -680,6 +680,7 @@ struct mbedtls_ssl_handshake_params
     unsigned char *psk;                 /*!<  PSK from the callback         */
     size_t psk_len;                     /*!<  Length of PSK from callback   */
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
+    uint16_t    selected_identity;
 #endif /* MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED */
 
 #if defined(MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED)

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -1349,6 +1349,10 @@ void mbedtls_ssl_add_hs_msg_to_checksum( mbedtls_ssl_context *ssl,
                                          unsigned char const *msg,
                                          size_t msg_len );
 
+void mbedtls_ssl_add_hs_hdr_to_checksum( mbedtls_ssl_context *ssl,
+                                         unsigned hs_type,
+                                         size_t total_hs_len );
+
 #if defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED)
 #if !defined(MBEDTLS_USE_PSA_CRYPTO)
 MBEDTLS_CHECK_RETURN_CRITICAL

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -532,9 +532,9 @@ void mbedtls_ssl_optimize_checksum( mbedtls_ssl_context *ssl,
     }
 }
 
-static void mbedtls_ssl_add_hs_hdr_to_checksum( mbedtls_ssl_context *ssl,
-                                                unsigned hs_type,
-                                                size_t total_hs_len )
+void mbedtls_ssl_add_hs_hdr_to_checksum( mbedtls_ssl_context *ssl,
+                                         unsigned hs_type,
+                                         size_t total_hs_len )
 {
     unsigned char hs_hdr[4];
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1710,8 +1710,12 @@ int mbedtls_ssl_set_hs_psk( mbedtls_ssl_context *ssl,
     else
         alg = PSA_ALG_TLS12_PSK_TO_MS(PSA_ALG_SHA_256);
 
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3)
     psa_set_key_usage_flags( &key_attributes,
                              PSA_KEY_USAGE_DERIVE | PSA_KEY_USAGE_EXPORT );
+#else
+    psa_set_key_usage_flags( &key_attributes, PSA_KEY_USAGE_DERIVE );
+#endif
     psa_set_key_algorithm( &key_attributes, alg );
     psa_set_key_type( &key_attributes, PSA_KEY_TYPE_DERIVE );
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1710,7 +1710,8 @@ int mbedtls_ssl_set_hs_psk( mbedtls_ssl_context *ssl,
     else
         alg = PSA_ALG_TLS12_PSK_TO_MS(PSA_ALG_SHA_256);
 
-    psa_set_key_usage_flags( &key_attributes, PSA_KEY_USAGE_DERIVE );
+    psa_set_key_usage_flags( &key_attributes,
+                             PSA_KEY_USAGE_DERIVE | PSA_KEY_USAGE_EXPORT );
     psa_set_key_algorithm( &key_attributes, alg );
     psa_set_key_type( &key_attributes, PSA_KEY_TYPE_DERIVE );
 

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -775,20 +775,13 @@ static int ssl_tls13_determine_key_exchange_mode( mbedtls_ssl_context *ssl )
      * The PSK-based key exchanges may additionally be used with 0-RTT.
      *
      * Our built-in order of preference is
-     *  1 ) Plain PSK Mode ( psk )
-     *  2 ) (EC)DHE-PSK Mode ( psk_ephemeral )
-     *  3 ) Certificate Mode ( ephemeral )
+     *  1 ) (EC)DHE-PSK Mode ( psk_ephemeral )
+     *  2 ) Certificate Mode ( ephemeral )
+     *  3 ) Plain PSK Mode ( psk )
      */
 
     ssl->handshake->key_exchange_mode = MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_NONE;
 
-    if( ssl_tls13_check_psk_key_exchange( ssl ) )
-    {
-        ssl->handshake->key_exchange_mode =
-            MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK;
-        MBEDTLS_SSL_DEBUG_MSG( 2, ( "key exchange mode: psk" ) );
-    }
-    else
     if( ssl_tls13_check_psk_ephemeral_key_exchange( ssl ) )
     {
         ssl->handshake->key_exchange_mode =
@@ -801,6 +794,13 @@ static int ssl_tls13_determine_key_exchange_mode( mbedtls_ssl_context *ssl )
         ssl->handshake->key_exchange_mode =
             MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL;
         MBEDTLS_SSL_DEBUG_MSG( 2, ( "key exchange mode: ephemeral" ) );
+    }
+    else
+    if( ssl_tls13_check_psk_key_exchange( ssl ) )
+    {
+        ssl->handshake->key_exchange_mode =
+            MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK;
+        MBEDTLS_SSL_DEBUG_MSG( 2, ( "key exchange mode: psk" ) );
     }
     else
     {

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -54,6 +54,7 @@
  *       PskKeyExchangeMode ke_modes<1..255>;
  *   } PskKeyExchangeModes;
  */
+MBEDTLS_CHECK_RETURN_CRITICAL
 static int ssl_tls13_parse_key_exchange_modes_ext( mbedtls_ssl_context *ssl,
                                                    const unsigned char *buf,
                                                    const unsigned char *end )
@@ -101,6 +102,7 @@ static int ssl_tls13_parse_key_exchange_modes_ext( mbedtls_ssl_context *ssl,
 
 #define SSL_TLS1_3_OFFERED_PSK_NOT_MATCH   0
 #define SSL_TLS1_3_OFFERED_PSK_MATCH       1
+MBEDTLS_CHECK_RETURN_CRITICAL
 static int ssl_tls13_offered_psks_check_identity_match(
                mbedtls_ssl_context *ssl,
                const unsigned char *identity,
@@ -131,6 +133,7 @@ static int ssl_tls13_offered_psks_check_identity_match(
     return( SSL_TLS1_3_OFFERED_PSK_NOT_MATCH );
 }
 
+MBEDTLS_CHECK_RETURN_CRITICAL
 static int ssl_tls13_offered_psks_check_binder_match(
                mbedtls_ssl_context *ssl,
                const unsigned char *binder,
@@ -201,6 +204,7 @@ static int ssl_tls13_offered_psks_check_binder_match(
  *        };
  *    } PreSharedKeyExtension;
  */
+MBEDTLS_CHECK_RETURN_CRITICAL
 static int ssl_tls13_parse_offered_psks_ext( mbedtls_ssl_context *ssl,
                                              const unsigned char *buf,
                                              const unsigned char *end )

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -146,14 +146,11 @@ static int ssl_tls13_offered_psks_check_binder_match(
     mbedtls_md_type_t md_alg =
         binder_len == 32 ? MBEDTLS_MD_SHA256 : MBEDTLS_MD_SHA384 ;
     psa_algorithm_t psa_md_alg = mbedtls_psa_translate_md( md_alg );
-    unsigned char transcript[MBEDTLS_MD_MAX_SIZE];
+    unsigned char transcript[PSA_HASH_MAX_SIZE];
     size_t transcript_len;
-    unsigned char server_computed_binder[MBEDTLS_MD_MAX_SIZE];
+    unsigned char server_computed_binder[PSA_HASH_MAX_SIZE];
 
-    if( ssl->handshake->resume == 1 )
-        psk_type = MBEDTLS_SSL_TLS1_3_PSK_RESUMPTION;
-    else
-        psk_type = MBEDTLS_SSL_TLS1_3_PSK_EXTERNAL;
+    psk_type = MBEDTLS_SSL_TLS1_3_PSK_EXTERNAL;
 
     /* Get current state of handshake transcript. */
     ret = mbedtls_ssl_get_handshake_transcript( ssl, md_alg,
@@ -182,6 +179,8 @@ static int ssl_tls13_offered_psks_check_binder_match(
         return( SSL_TLS1_3_OFFERED_PSK_MATCH );
     }
 
+    mbedtls_platform_zeroize( server_computed_binder,
+                              sizeof( server_computed_binder ) );
     return( SSL_TLS1_3_OFFERED_PSK_NOT_MATCH );
 }
 /* Parser for pre_shared_key extension in client hello

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -372,9 +372,9 @@ exit_failue:
  * } PreSharedKeyExtension;
  */
 static int ssl_tls13_write_selected_identity_ext( mbedtls_ssl_context *ssl,
-                                                      unsigned char *buf,
-                                                      unsigned char *end,
-                                                      size_t *olen )
+                                                  unsigned char *buf,
+                                                  unsigned char *end,
+                                                  size_t *olen )
 {
     unsigned char *p = (unsigned char*)buf;
     size_t selected_identity;
@@ -395,17 +395,12 @@ static int ssl_tls13_write_selected_identity_ext( mbedtls_ssl_context *ssl,
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "server hello, adding pre_shared_key extension" ) );
     MBEDTLS_SSL_CHK_BUF_PTR( p, end, 6 );
 
-    /* Extension Type */
     MBEDTLS_PUT_UINT16_BE( MBEDTLS_TLS_EXT_PRE_SHARED_KEY, p, 0 );
-
-    /* Extension Length */
     MBEDTLS_PUT_UINT16_BE( 2, p, 2 );
 
     /* NOTE: This will need to be adjusted once we support multiple PSKs
      *       being offered by the client. */
     selected_identity = 0;
-
-    /* Write selected_identity */
     MBEDTLS_PUT_UINT16_BE( selected_identity, p, 4 );
 
     *olen = 6;
@@ -702,9 +697,9 @@ static int ssl_tls13_client_hello_has_exts_for_ephemeral_key_exchange(
         mbedtls_ssl_context *ssl )
 {
     return( ssl_tls13_client_hello_has_exts( ssl,
-                          MBEDTLS_SSL_EXT_SUPPORTED_GROUPS |
-                          MBEDTLS_SSL_EXT_KEY_SHARE        |
-                          MBEDTLS_SSL_EXT_SIG_ALG ) );
+                                             MBEDTLS_SSL_EXT_SUPPORTED_GROUPS |
+                                             MBEDTLS_SSL_EXT_KEY_SHARE        |
+                                             MBEDTLS_SSL_EXT_SIG_ALG ) );
 }
 
 MBEDTLS_CHECK_RETURN_CRITICAL
@@ -1702,7 +1697,8 @@ static int ssl_tls13_write_server_hello_body( mbedtls_ssl_context *ssl,
     }
 
 #if defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED)
-    MBEDTLS_SSL_DEBUG_MSG( 2,( " mbedtls_ssl_tls13_some_psk_enabled %d", mbedtls_ssl_tls13_some_psk_enabled( ssl ) ) );
+    MBEDTLS_SSL_DEBUG_MSG( 2, ( " mbedtls_ssl_tls13_some_psk_enabled %d",
+                                mbedtls_ssl_tls13_some_psk_enabled( ssl ) ) );
     if( mbedtls_ssl_tls13_some_psk_enabled( ssl ) )
     {
         ret = ssl_tls13_write_selected_identity_ext( ssl, p, end, &output_len );

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -205,9 +205,9 @@ static int ssl_tls13_offered_psks_check_binder_match(
  *    } PreSharedKeyExtension;
  */
 MBEDTLS_CHECK_RETURN_CRITICAL
-static int ssl_tls13_parse_offered_psks_ext( mbedtls_ssl_context *ssl,
-                                             const unsigned char *buf,
-                                             const unsigned char *end )
+static int ssl_tls13_parse_pre_shared_key_ext( mbedtls_ssl_context *ssl,
+                                               const unsigned char *buf,
+                                               const unsigned char *end )
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     const unsigned char *p = buf;
@@ -238,6 +238,7 @@ static int ssl_tls13_parse_offered_psks_ext( mbedtls_ssl_context *ssl,
     {
         uint16_t identity_len;
         const unsigned char *identity;
+
         MBEDTLS_SSL_CHK_BUF_READ_PTR( p, identities_end, 2 );
         identity_len = MBEDTLS_GET_UINT16_BE( p, 0 );
         p += 2;
@@ -375,10 +376,10 @@ exit_failue:
  *   }
  * } PreSharedKeyExtension;
  */
-static int ssl_tls13_write_selected_identity_ext( mbedtls_ssl_context *ssl,
-                                                  unsigned char *buf,
-                                                  unsigned char *end,
-                                                  size_t *olen )
+static int ssl_tls13_write_server_pre_shared_key_ext( mbedtls_ssl_context *ssl,
+                                                      unsigned char *buf,
+                                                      unsigned char *end,
+                                                      size_t *olen )
 {
     unsigned char *p = (unsigned char*)buf;
     size_t selected_identity;
@@ -1223,12 +1224,12 @@ static int ssl_tls13_parse_client_hello( mbedtls_ssl_context *ssl,
     {
         ssl->handshake->update_checksum( ssl, buf,
                                          pre_shared_key_ext_start - buf );
-        ret = ssl_tls13_parse_offered_psks_ext( ssl,
-                                                pre_shared_key_ext_start,
-                                                pre_shared_key_ext_end );
+        ret = ssl_tls13_parse_pre_shared_key_ext( ssl,
+                                                  pre_shared_key_ext_start,
+                                                  pre_shared_key_ext_end );
         if( ret != 0 )
         {
-            MBEDTLS_SSL_DEBUG_RET( 1, ( "ssl_tls13_parse_offered_psks_ext" ),
+            MBEDTLS_SSL_DEBUG_RET( 1, ( "ssl_tls13_parse_pre_shared_key_ext" ),
                                    ret );
             return( ret );
         }
@@ -1705,10 +1706,10 @@ static int ssl_tls13_write_server_hello_body( mbedtls_ssl_context *ssl,
                                 mbedtls_ssl_tls13_some_psk_enabled( ssl ) ) );
     if( mbedtls_ssl_tls13_some_psk_enabled( ssl ) )
     {
-        ret = ssl_tls13_write_selected_identity_ext( ssl, p, end, &output_len );
+        ret = ssl_tls13_write_server_pre_shared_key_ext( ssl, p, end, &output_len );
         if( ret != 0 )
         {
-            MBEDTLS_SSL_DEBUG_RET( 1, "ssl_tls13_write_selected_identity_ext",
+            MBEDTLS_SSL_DEBUG_RET( 1, "ssl_tls13_write_server_pre_shared_key_ext",
                                    ret );
             return( ret );
         }

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1262,6 +1262,14 @@ static int ssl_tls13_parse_client_hello( mbedtls_ssl_context *ssl,
 
             case MBEDTLS_TLS_EXT_PRE_SHARED_KEY:
                 MBEDTLS_SSL_DEBUG_MSG( 3, ( "found pre_shared_key extension" ) );
+                if( ( ssl->handshake->extensions_present &
+                      MBEDTLS_SSL_EXT_PSK_KEY_EXCHANGE_MODES ) == 0 )
+                {
+                    MBEDTLS_SSL_PEND_FATAL_ALERT(
+                        MBEDTLS_SSL_ALERT_MSG_ILLEGAL_PARAMETER,
+                        MBEDTLS_ERR_SSL_HANDSHAKE_FAILURE );
+                    return( MBEDTLS_ERR_SSL_HANDSHAKE_FAILURE );
+                }
 #if defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED)
                 /* Delay processing of the PSK identity once we have
                  * found out which algorithms to use. We keep a pointer

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -2283,6 +2283,8 @@ run_test    "TLS 1.3: key exchange mode parameter passing: All" \
             "$P_CLI tls13_kex_modes=all" \
             0
 
+# FIXME: force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 should be removed in future
+#        Without it, the binder will generate wrong value.
 requires_openssl_tls1_3
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
@@ -2296,6 +2298,8 @@ run_test    "TLS 1.3: psk_key_exchange_modes: basic check, O->m" \
             -s "Found PSK_EPHEMERAL KEX MODE" \
             -s "Found PSK KEX MODE"
 
+# FIXME: force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 should be removed in future
+#        Without it, the binder will generate wrong value.
 requires_gnutls_tls1_3
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -2286,30 +2286,36 @@ run_test    "TLS 1.3: key exchange mode parameter passing: All" \
 requires_openssl_tls1_3
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
+requires_config_enabled MBEDTLS_KEY_EXCHANGE_PSK_ENABLED
 requires_config_enabled MBEDTLS_SSL_SRV_C
 requires_config_enabled MBEDTLS_DEBUG_C
-run_test    "TLS 1.3: psk_key_exchange_modes: basic check, O->m" \
-            "$P_SRV force_version=tls13 debug_level=5" \
-            "$O_NEXT_CLI -tls1_3 -psk 6162636465666768696a6b6c6d6e6f70 -allow_no_dhe_kex" \
-            0 \
+run_test    "TLS 1.3: PSK: basic check, O->m" \
+            "$P_SRV force_version=tls13 tls13_kex_modes=psk debug_level=5 psk=6162636465666768696a6b6c6d6e6f70" \
+            "$O_NEXT_CLI -tls1_3 -psk 1234 -psk 6162636465666768696a6b6c6d6e6f70 -allow_no_dhe_kex" \
+            1 \
             -s "found psk key exchange modes extension" \
+            -s "found pre_shared_key extension" \
             -s "Found PSK_EPHEMERAL KEX MODE" \
-            -s "Found PSK KEX MODE"
+            -s "Found PSK KEX MODE" \
+            -s "Pre shared key found"
 
 requires_gnutls_tls1_3
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
+requires_config_enabled MBEDTLS_KEY_EXCHANGE_PSK_ENABLED
 requires_config_enabled MBEDTLS_SSL_SRV_C
 requires_config_enabled MBEDTLS_DEBUG_C
-run_test    "TLS 1.3: psk_key_exchange_modes: basic check, G->m" \
-            "$P_SRV force_version=tls13 debug_level=5" \
-            "$G_NEXT_CLI --priority NORMAL:-VERS-ALL:+VERS-TLS1.3 \
+run_test    "TLS 1.3: PSK: basic check, G->m" \
+            "$P_SRV force_version=tls13 tls13_kex_modes=psk debug_level=5 psk=6162636465666768696a6b6c6d6e6f70" \
+            "$G_NEXT_CLI --priority NORMAL:-VERS-ALL:+KX-ALL:+PSK:+DHE-PSK:+VERS-TLS1.3 \
                          --pskusername Client_identity --pskkey=6162636465666768696a6b6c6d6e6f70 \
                          localhost" \
-            0 \
+            1 \
             -s "found psk key exchange modes extension" \
+            -s "found pre_shared_key extension" \
             -s "Found PSK_EPHEMERAL KEX MODE" \
-            -s "Found PSK KEX MODE"
+            -s "Found PSK KEX MODE" \
+            -s "Pre shared key found"
 
 # Tests for datagram packing
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -2283,8 +2283,6 @@ run_test    "TLS 1.3: key exchange mode parameter passing: All" \
             "$P_CLI tls13_kex_modes=all" \
             0
 
-# FIXME: force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 should be removed in future
-#        Without it, the binder will generate wrong value.
 requires_openssl_tls1_3
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
@@ -2298,8 +2296,6 @@ run_test    "TLS 1.3: psk_key_exchange_modes: basic check, O->m" \
             -s "Found PSK_EPHEMERAL KEX MODE" \
             -s "Found PSK KEX MODE"
 
-# FIXME: force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 should be removed in future
-#        Without it, the binder will generate wrong value.
 requires_gnutls_tls1_3
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE


### PR DESCRIPTION
## Description
fix #5564
fix #5988 

Know issues:

- [x] `mbedtls_ssl_tls13_create_psk_binder` take `handshake->psk` as input parameter and it is removed in PSA version.  PSA version should be created.
    -   Export `psk_opaque` to fix it.  
- [x] Only SHA256 ciphersuites can work with pre_shared_key extension. I am not sure the reason. 
    - Hash algorithm is selected base on binder length now.
    - https://github.com/tlswg/tls13-spec/issues/1227 , the issue is discussed .
- [x]  Add multiple psks support. 

preceding-pr: #6112 
## Status
**IN DEVELOPMENT**

