### PR TITLE
Fix case of Mbed TLS in assemble_changelog.py - backport 2.28

### DIFF
--- a/scripts/assemble_changelog.py
+++ b/scripts/assemble_changelog.py
@@ -122,7 +122,7 @@ class ChangelogFormat:
 class TextChangelogFormat(ChangelogFormat):
     """The traditional Mbed TLS changelog format."""
 
-    _unreleased_version_text = '= mbed TLS x.x.x branch released xxxx-xx-xx'
+    _unreleased_version_text = '= Mbed TLS x.x.x branch released xxxx-xx-xx'
     @classmethod
     def is_released_version(cls, title):
         # Look for an incomplete release date


### PR DESCRIPTION
Backport of #6081 - fixes #6080 