### PR TITLE
Validation remove and change in files related to cipher in library

### DIFF
--- a/library/aes.c
+++ b/library/aes.c
@@ -489,8 +489,6 @@ static void aes_gen_tables( void )
 
 void mbedtls_aes_init( mbedtls_aes_context *ctx )
 {
-    AES_VALIDATE( ctx != NULL );
-
     memset( ctx, 0, sizeof( mbedtls_aes_context ) );
 }
 
@@ -505,8 +503,6 @@ void mbedtls_aes_free( mbedtls_aes_context *ctx )
 #if defined(MBEDTLS_CIPHER_MODE_XTS)
 void mbedtls_aes_xts_init( mbedtls_aes_xts_context *ctx )
 {
-    AES_VALIDATE( ctx != NULL );
-
     mbedtls_aes_init( &ctx->crypt );
     mbedtls_aes_init( &ctx->tweak );
 }
@@ -530,9 +526,6 @@ int mbedtls_aes_setkey_enc( mbedtls_aes_context *ctx, const unsigned char *key,
 {
     unsigned int i;
     uint32_t *RK;
-
-    AES_VALIDATE_RET( ctx != NULL );
-    AES_VALIDATE_RET( key != NULL );
 
     switch( keybits )
     {
@@ -649,9 +642,6 @@ int mbedtls_aes_setkey_dec( mbedtls_aes_context *ctx, const unsigned char *key,
     uint32_t *RK;
     uint32_t *SK;
 
-    AES_VALIDATE_RET( ctx != NULL );
-    AES_VALIDATE_RET( key != NULL );
-
     mbedtls_aes_init( &cty );
 
     ctx->rk_offset = 0;
@@ -743,9 +733,6 @@ int mbedtls_aes_xts_setkey_enc( mbedtls_aes_xts_context *ctx,
     const unsigned char *key1, *key2;
     unsigned int key1bits, key2bits;
 
-    AES_VALIDATE_RET( ctx != NULL );
-    AES_VALIDATE_RET( key != NULL );
-
     ret = mbedtls_aes_xts_decode_keys( key, keybits, &key1, &key1bits,
                                        &key2, &key2bits );
     if( ret != 0 )
@@ -767,9 +754,6 @@ int mbedtls_aes_xts_setkey_dec( mbedtls_aes_xts_context *ctx,
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     const unsigned char *key1, *key2;
     unsigned int key1bits, key2bits;
-
-    AES_VALIDATE_RET( ctx != NULL );
-    AES_VALIDATE_RET( key != NULL );
 
     ret = mbedtls_aes_xts_decode_keys( key, keybits, &key1, &key1bits,
                                        &key2, &key2bits );
@@ -970,9 +954,6 @@ int mbedtls_aes_crypt_ecb( mbedtls_aes_context *ctx,
                            const unsigned char input[16],
                            unsigned char output[16] )
 {
-    AES_VALIDATE_RET( ctx != NULL );
-    AES_VALIDATE_RET( input != NULL );
-    AES_VALIDATE_RET( output != NULL );
     AES_VALIDATE_RET( mode == MBEDTLS_AES_ENCRYPT ||
                       mode == MBEDTLS_AES_DECRYPT );
 
@@ -1014,12 +995,8 @@ int mbedtls_aes_crypt_cbc( mbedtls_aes_context *ctx,
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     unsigned char temp[16];
 
-    AES_VALIDATE_RET( ctx != NULL );
     AES_VALIDATE_RET( mode == MBEDTLS_AES_ENCRYPT ||
                       mode == MBEDTLS_AES_DECRYPT );
-    AES_VALIDATE_RET( iv != NULL );
-    AES_VALIDATE_RET( input != NULL );
-    AES_VALIDATE_RET( output != NULL );
 
     if( length % 16 )
         return( MBEDTLS_ERR_AES_INVALID_INPUT_LENGTH );
@@ -1123,12 +1100,8 @@ int mbedtls_aes_crypt_xts( mbedtls_aes_xts_context *ctx,
     unsigned char prev_tweak[16];
     unsigned char tmp[16];
 
-    AES_VALIDATE_RET( ctx != NULL );
     AES_VALIDATE_RET( mode == MBEDTLS_AES_ENCRYPT ||
                       mode == MBEDTLS_AES_DECRYPT );
-    AES_VALIDATE_RET( data_unit != NULL );
-    AES_VALIDATE_RET( input != NULL );
-    AES_VALIDATE_RET( output != NULL );
 
     /* Data units must be at least 16 bytes long. */
     if( length < 16 )
@@ -1232,13 +1205,8 @@ int mbedtls_aes_crypt_cfb128( mbedtls_aes_context *ctx,
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     size_t n;
 
-    AES_VALIDATE_RET( ctx != NULL );
     AES_VALIDATE_RET( mode == MBEDTLS_AES_ENCRYPT ||
                       mode == MBEDTLS_AES_DECRYPT );
-    AES_VALIDATE_RET( iv_off != NULL );
-    AES_VALIDATE_RET( iv != NULL );
-    AES_VALIDATE_RET( input != NULL );
-    AES_VALIDATE_RET( output != NULL );
 
     n = *iv_off;
 
@@ -1301,12 +1269,8 @@ int mbedtls_aes_crypt_cfb8( mbedtls_aes_context *ctx,
     unsigned char c;
     unsigned char ov[17];
 
-    AES_VALIDATE_RET( ctx != NULL );
     AES_VALIDATE_RET( mode == MBEDTLS_AES_ENCRYPT ||
                       mode == MBEDTLS_AES_DECRYPT );
-    AES_VALIDATE_RET( iv != NULL );
-    AES_VALIDATE_RET( input != NULL );
-    AES_VALIDATE_RET( output != NULL );
     while( length-- )
     {
         memcpy( ov, iv, 16 );
@@ -1344,12 +1308,6 @@ int mbedtls_aes_crypt_ofb( mbedtls_aes_context *ctx,
 {
     int ret = 0;
     size_t n;
-
-    AES_VALIDATE_RET( ctx != NULL );
-    AES_VALIDATE_RET( iv_off != NULL );
-    AES_VALIDATE_RET( iv != NULL );
-    AES_VALIDATE_RET( input != NULL );
-    AES_VALIDATE_RET( output != NULL );
 
     n = *iv_off;
 
@@ -1391,13 +1349,6 @@ int mbedtls_aes_crypt_ctr( mbedtls_aes_context *ctx,
     int c, i;
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     size_t n;
-
-    AES_VALIDATE_RET( ctx != NULL );
-    AES_VALIDATE_RET( nc_off != NULL );
-    AES_VALIDATE_RET( nonce_counter != NULL );
-    AES_VALIDATE_RET( stream_block != NULL );
-    AES_VALIDATE_RET( input != NULL );
-    AES_VALIDATE_RET( output != NULL );
 
     n = *nc_off;
 

--- a/library/aes.c
+++ b/library/aes.c
@@ -51,12 +51,6 @@
 
 #if !defined(MBEDTLS_AES_ALT)
 
-/* Parameter validation macros based on platform_util.h */
-#define AES_VALIDATE_RET( cond )    \
-    MBEDTLS_INTERNAL_VALIDATE_RET( cond, MBEDTLS_ERR_AES_BAD_INPUT_DATA )
-#define AES_VALIDATE( cond )        \
-    MBEDTLS_INTERNAL_VALIDATE( cond )
-
 #if defined(MBEDTLS_PADLOCK_C) &&                      \
     ( defined(MBEDTLS_HAVE_X86) || defined(MBEDTLS_PADLOCK_ALIGN16) )
 static int aes_padlock_ace = -1;
@@ -954,8 +948,8 @@ int mbedtls_aes_crypt_ecb( mbedtls_aes_context *ctx,
                            const unsigned char input[16],
                            unsigned char output[16] )
 {
-    AES_VALIDATE_RET( mode == MBEDTLS_AES_ENCRYPT ||
-                      mode == MBEDTLS_AES_DECRYPT );
+    if( mode != MBEDTLS_AES_ENCRYPT && mode != MBEDTLS_AES_DECRYPT )
+        return MBEDTLS_ERR_AES_BAD_INPUT_DATA;
 
 #if defined(MBEDTLS_AESNI_C) && defined(MBEDTLS_HAVE_X86_64)
     if( mbedtls_aesni_has_support( MBEDTLS_AESNI_AES ) )
@@ -995,8 +989,8 @@ int mbedtls_aes_crypt_cbc( mbedtls_aes_context *ctx,
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     unsigned char temp[16];
 
-    AES_VALIDATE_RET( mode == MBEDTLS_AES_ENCRYPT ||
-                      mode == MBEDTLS_AES_DECRYPT );
+    if( mode != MBEDTLS_AES_ENCRYPT && mode != MBEDTLS_AES_DECRYPT )
+        return MBEDTLS_ERR_AES_BAD_INPUT_DATA;
 
     if( length % 16 )
         return( MBEDTLS_ERR_AES_INVALID_INPUT_LENGTH );
@@ -1100,8 +1094,8 @@ int mbedtls_aes_crypt_xts( mbedtls_aes_xts_context *ctx,
     unsigned char prev_tweak[16];
     unsigned char tmp[16];
 
-    AES_VALIDATE_RET( mode == MBEDTLS_AES_ENCRYPT ||
-                      mode == MBEDTLS_AES_DECRYPT );
+    if( mode != MBEDTLS_AES_ENCRYPT && mode != MBEDTLS_AES_DECRYPT )
+        return MBEDTLS_ERR_AES_BAD_INPUT_DATA;
 
     /* Data units must be at least 16 bytes long. */
     if( length < 16 )
@@ -1205,8 +1199,8 @@ int mbedtls_aes_crypt_cfb128( mbedtls_aes_context *ctx,
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     size_t n;
 
-    AES_VALIDATE_RET( mode == MBEDTLS_AES_ENCRYPT ||
-                      mode == MBEDTLS_AES_DECRYPT );
+    if( mode != MBEDTLS_AES_ENCRYPT && mode != MBEDTLS_AES_DECRYPT )
+        return MBEDTLS_ERR_AES_BAD_INPUT_DATA;
 
     n = *iv_off;
 
@@ -1269,8 +1263,8 @@ int mbedtls_aes_crypt_cfb8( mbedtls_aes_context *ctx,
     unsigned char c;
     unsigned char ov[17];
 
-    AES_VALIDATE_RET( mode == MBEDTLS_AES_ENCRYPT ||
-                      mode == MBEDTLS_AES_DECRYPT );
+    if( mode != MBEDTLS_AES_ENCRYPT && mode != MBEDTLS_AES_DECRYPT )
+        return MBEDTLS_ERR_AES_BAD_INPUT_DATA;
     while( length-- )
     {
         memcpy( ov, iv, 16 );

--- a/library/camellia.c
+++ b/library/camellia.c
@@ -298,7 +298,6 @@ static void camellia_feistel( const uint32_t x[2], const uint32_t k[2],
 
 void mbedtls_camellia_init( mbedtls_camellia_context *ctx )
 {
-    CAMELLIA_VALIDATE( ctx != NULL );
     memset( ctx, 0, sizeof( mbedtls_camellia_context ) );
 }
 
@@ -324,9 +323,6 @@ int mbedtls_camellia_setkey_enc( mbedtls_camellia_context *ctx,
     uint32_t SIGMA[6][2];
     uint32_t KC[16];
     uint32_t TK[20];
-
-    CAMELLIA_VALIDATE_RET( ctx != NULL );
-    CAMELLIA_VALIDATE_RET( key != NULL );
 
     RK = ctx->rk;
 
@@ -431,8 +427,6 @@ int mbedtls_camellia_setkey_dec( mbedtls_camellia_context *ctx,
     mbedtls_camellia_context cty;
     uint32_t *RK;
     uint32_t *SK;
-    CAMELLIA_VALIDATE_RET( ctx != NULL );
-    CAMELLIA_VALIDATE_RET( key != NULL );
 
     mbedtls_camellia_init( &cty );
 
@@ -480,11 +474,8 @@ int mbedtls_camellia_crypt_ecb( mbedtls_camellia_context *ctx,
 {
     int NR;
     uint32_t *RK, X[4];
-    CAMELLIA_VALIDATE_RET( ctx != NULL );
     CAMELLIA_VALIDATE_RET( mode == MBEDTLS_CAMELLIA_ENCRYPT ||
                            mode == MBEDTLS_CAMELLIA_DECRYPT );
-    CAMELLIA_VALIDATE_RET( input  != NULL );
-    CAMELLIA_VALIDATE_RET( output != NULL );
 
     ( (void) mode );
 
@@ -550,12 +541,8 @@ int mbedtls_camellia_crypt_cbc( mbedtls_camellia_context *ctx,
 {
     int i;
     unsigned char temp[16];
-    CAMELLIA_VALIDATE_RET( ctx != NULL );
     CAMELLIA_VALIDATE_RET( mode == MBEDTLS_CAMELLIA_ENCRYPT ||
                            mode == MBEDTLS_CAMELLIA_DECRYPT );
-    CAMELLIA_VALIDATE_RET( iv != NULL );
-    CAMELLIA_VALIDATE_RET( length == 0 || input  != NULL );
-    CAMELLIA_VALIDATE_RET( length == 0 || output != NULL );
 
     if( length % 16 )
         return( MBEDTLS_ERR_CAMELLIA_INVALID_INPUT_LENGTH );
@@ -611,13 +598,8 @@ int mbedtls_camellia_crypt_cfb128( mbedtls_camellia_context *ctx,
 {
     int c;
     size_t n;
-    CAMELLIA_VALIDATE_RET( ctx != NULL );
     CAMELLIA_VALIDATE_RET( mode == MBEDTLS_CAMELLIA_ENCRYPT ||
                            mode == MBEDTLS_CAMELLIA_DECRYPT );
-    CAMELLIA_VALIDATE_RET( iv     != NULL );
-    CAMELLIA_VALIDATE_RET( iv_off != NULL );
-    CAMELLIA_VALIDATE_RET( length == 0 || input  != NULL );
-    CAMELLIA_VALIDATE_RET( length == 0 || output != NULL );
 
     n = *iv_off;
     if( n >= 16 )
@@ -670,12 +652,6 @@ int mbedtls_camellia_crypt_ctr( mbedtls_camellia_context *ctx,
 {
     int c, i;
     size_t n;
-    CAMELLIA_VALIDATE_RET( ctx != NULL );
-    CAMELLIA_VALIDATE_RET( nonce_counter != NULL );
-    CAMELLIA_VALIDATE_RET( stream_block  != NULL );
-    CAMELLIA_VALIDATE_RET( nc_off != NULL );
-    CAMELLIA_VALIDATE_RET( length == 0 || input  != NULL );
-    CAMELLIA_VALIDATE_RET( length == 0 || output != NULL );
 
     n = *nc_off;
     if( n >= 16 )

--- a/library/camellia.c
+++ b/library/camellia.c
@@ -43,12 +43,6 @@
 
 #if !defined(MBEDTLS_CAMELLIA_ALT)
 
-/* Parameter validation macros */
-#define CAMELLIA_VALIDATE_RET( cond )                                       \
-    MBEDTLS_INTERNAL_VALIDATE_RET( cond, MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA )
-#define CAMELLIA_VALIDATE( cond )                                           \
-    MBEDTLS_INTERNAL_VALIDATE( cond )
-
 static const unsigned char SIGMA_CHARS[6][8] =
 {
     { 0xa0, 0x9e, 0x66, 0x7f, 0x3b, 0xcc, 0x90, 0x8b },
@@ -474,8 +468,8 @@ int mbedtls_camellia_crypt_ecb( mbedtls_camellia_context *ctx,
 {
     int NR;
     uint32_t *RK, X[4];
-    CAMELLIA_VALIDATE_RET( mode == MBEDTLS_CAMELLIA_ENCRYPT ||
-                           mode == MBEDTLS_CAMELLIA_DECRYPT );
+    if( mode != MBEDTLS_CAMELLIA_ENCRYPT && mode != MBEDTLS_CAMELLIA_DECRYPT )
+        return MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA;
 
     ( (void) mode );
 
@@ -541,8 +535,8 @@ int mbedtls_camellia_crypt_cbc( mbedtls_camellia_context *ctx,
 {
     int i;
     unsigned char temp[16];
-    CAMELLIA_VALIDATE_RET( mode == MBEDTLS_CAMELLIA_ENCRYPT ||
-                           mode == MBEDTLS_CAMELLIA_DECRYPT );
+    if( mode != MBEDTLS_CAMELLIA_ENCRYPT && mode != MBEDTLS_CAMELLIA_DECRYPT )
+        return MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA;
 
     if( length % 16 )
         return( MBEDTLS_ERR_CAMELLIA_INVALID_INPUT_LENGTH );
@@ -598,8 +592,8 @@ int mbedtls_camellia_crypt_cfb128( mbedtls_camellia_context *ctx,
 {
     int c;
     size_t n;
-    CAMELLIA_VALIDATE_RET( mode == MBEDTLS_CAMELLIA_ENCRYPT ||
-                           mode == MBEDTLS_CAMELLIA_DECRYPT );
+    if( mode != MBEDTLS_CAMELLIA_ENCRYPT && mode != MBEDTLS_CAMELLIA_DECRYPT )
+        return MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA;
 
     n = *iv_off;
     if( n >= 16 )

--- a/library/chacha20.c
+++ b/library/chacha20.c
@@ -48,12 +48,6 @@
 #define inline __inline
 #endif
 
-/* Parameter validation macros */
-#define CHACHA20_VALIDATE_RET( cond )                                       \
-    MBEDTLS_INTERNAL_VALIDATE_RET( cond, MBEDTLS_ERR_CHACHA20_BAD_INPUT_DATA )
-#define CHACHA20_VALIDATE( cond )                                           \
-    MBEDTLS_INTERNAL_VALIDATE( cond )
-
 #define ROTL32( value, amount ) \
     ( (uint32_t) ( (value) << (amount) ) | ( (value) >> ( 32 - (amount) ) ) )
 
@@ -172,8 +166,6 @@ static void chacha20_block( const uint32_t initial_state[16],
 
 void mbedtls_chacha20_init( mbedtls_chacha20_context *ctx )
 {
-    CHACHA20_VALIDATE( ctx != NULL );
-
     mbedtls_platform_zeroize( ctx->state, sizeof( ctx->state ) );
     mbedtls_platform_zeroize( ctx->keystream8, sizeof( ctx->keystream8 ) );
 
@@ -192,9 +184,6 @@ void mbedtls_chacha20_free( mbedtls_chacha20_context *ctx )
 int mbedtls_chacha20_setkey( mbedtls_chacha20_context *ctx,
                             const unsigned char key[32] )
 {
-    CHACHA20_VALIDATE_RET( ctx != NULL );
-    CHACHA20_VALIDATE_RET( key != NULL );
-
     /* ChaCha20 constants - the string "expand 32-byte k" */
     ctx->state[0] = 0x61707865;
     ctx->state[1] = 0x3320646e;
@@ -218,9 +207,6 @@ int mbedtls_chacha20_starts( mbedtls_chacha20_context* ctx,
                              const unsigned char nonce[12],
                              uint32_t counter )
 {
-    CHACHA20_VALIDATE_RET( ctx != NULL );
-    CHACHA20_VALIDATE_RET( nonce != NULL );
-
     /* Counter */
     ctx->state[12] = counter;
 
@@ -244,10 +230,6 @@ int mbedtls_chacha20_update( mbedtls_chacha20_context *ctx,
 {
     size_t offset = 0U;
     size_t i;
-
-    CHACHA20_VALIDATE_RET( ctx != NULL );
-    CHACHA20_VALIDATE_RET( size == 0 || input  != NULL );
-    CHACHA20_VALIDATE_RET( size == 0 || output != NULL );
 
     /* Use leftover keystream bytes, if available */
     while( size > 0U && ctx->keystream_bytes_used < CHACHA20_BLOCK_SIZE_BYTES )
@@ -311,11 +293,6 @@ int mbedtls_chacha20_crypt( const unsigned char key[32],
 {
     mbedtls_chacha20_context ctx;
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
-
-    CHACHA20_VALIDATE_RET( key != NULL );
-    CHACHA20_VALIDATE_RET( nonce != NULL );
-    CHACHA20_VALIDATE_RET( data_len == 0 || input  != NULL );
-    CHACHA20_VALIDATE_RET( data_len == 0 || output != NULL );
 
     mbedtls_chacha20_init( &ctx );
 

--- a/library/cipher.c
+++ b/library/cipher.c
@@ -70,11 +70,6 @@
 #define mbedtls_free   free
 #endif
 
-#define CIPHER_VALIDATE_RET( cond )    \
-    MBEDTLS_INTERNAL_VALIDATE_RET( cond, MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA )
-#define CIPHER_VALIDATE( cond )        \
-    MBEDTLS_INTERNAL_VALIDATE( cond )
-
 static int supported_init = 0;
 
 const int *mbedtls_cipher_list( void )
@@ -255,8 +250,8 @@ int mbedtls_cipher_setkey( mbedtls_cipher_context_t *ctx,
                            int key_bitlen,
                            const mbedtls_operation_t operation )
 {
-    CIPHER_VALIDATE_RET( operation == MBEDTLS_ENCRYPT ||
-                         operation == MBEDTLS_DECRYPT );
+    if( operation != MBEDTLS_ENCRYPT && operation != MBEDTLS_DECRYPT )
+        return MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA;
     if( ctx->cipher_info == NULL )
         return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
 

--- a/library/cipher.c
+++ b/library/cipher.c
@@ -143,7 +143,6 @@ const mbedtls_cipher_info_t *mbedtls_cipher_info_from_values(
 
 void mbedtls_cipher_init( mbedtls_cipher_context_t *ctx )
 {
-    CIPHER_VALIDATE( ctx != NULL );
     memset( ctx, 0, sizeof( mbedtls_cipher_context_t ) );
 }
 
@@ -193,7 +192,6 @@ void mbedtls_cipher_free( mbedtls_cipher_context_t *ctx )
 int mbedtls_cipher_setup( mbedtls_cipher_context_t *ctx,
                           const mbedtls_cipher_info_t *cipher_info )
 {
-    CIPHER_VALIDATE_RET( ctx != NULL );
     if( cipher_info == NULL )
         return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
 
@@ -257,8 +255,6 @@ int mbedtls_cipher_setkey( mbedtls_cipher_context_t *ctx,
                            int key_bitlen,
                            const mbedtls_operation_t operation )
 {
-    CIPHER_VALIDATE_RET( ctx != NULL );
-    CIPHER_VALIDATE_RET( key != NULL );
     CIPHER_VALIDATE_RET( operation == MBEDTLS_ENCRYPT ||
                          operation == MBEDTLS_DECRYPT );
     if( ctx->cipher_info == NULL )
@@ -356,8 +352,6 @@ int mbedtls_cipher_set_iv( mbedtls_cipher_context_t *ctx,
 {
     size_t actual_iv_size;
 
-    CIPHER_VALIDATE_RET( ctx != NULL );
-    CIPHER_VALIDATE_RET( iv_len == 0 || iv != NULL );
     if( ctx->cipher_info == NULL )
         return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
@@ -453,7 +447,6 @@ int mbedtls_cipher_set_iv( mbedtls_cipher_context_t *ctx,
 
 int mbedtls_cipher_reset( mbedtls_cipher_context_t *ctx )
 {
-    CIPHER_VALIDATE_RET( ctx != NULL );
     if( ctx->cipher_info == NULL )
         return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
 
@@ -475,8 +468,6 @@ int mbedtls_cipher_reset( mbedtls_cipher_context_t *ctx )
 int mbedtls_cipher_update_ad( mbedtls_cipher_context_t *ctx,
                       const unsigned char *ad, size_t ad_len )
 {
-    CIPHER_VALIDATE_RET( ctx != NULL );
-    CIPHER_VALIDATE_RET( ad_len == 0 || ad != NULL );
     if( ctx->cipher_info == NULL )
         return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
 
@@ -529,10 +520,6 @@ int mbedtls_cipher_update( mbedtls_cipher_context_t *ctx, const unsigned char *i
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     size_t block_size;
 
-    CIPHER_VALIDATE_RET( ctx != NULL );
-    CIPHER_VALIDATE_RET( ilen == 0 || input != NULL );
-    CIPHER_VALIDATE_RET( output != NULL );
-    CIPHER_VALIDATE_RET( olen != NULL );
     if( ctx->cipher_info == NULL )
         return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
 
@@ -952,9 +939,6 @@ static int get_no_padding( unsigned char *input, size_t input_len,
 int mbedtls_cipher_finish( mbedtls_cipher_context_t *ctx,
                    unsigned char *output, size_t *olen )
 {
-    CIPHER_VALIDATE_RET( ctx != NULL );
-    CIPHER_VALIDATE_RET( output != NULL );
-    CIPHER_VALIDATE_RET( olen != NULL );
     if( ctx->cipher_info == NULL )
         return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
 
@@ -1054,8 +1038,6 @@ int mbedtls_cipher_finish( mbedtls_cipher_context_t *ctx,
 int mbedtls_cipher_set_padding_mode( mbedtls_cipher_context_t *ctx,
                                      mbedtls_cipher_padding_t mode )
 {
-    CIPHER_VALIDATE_RET( ctx != NULL );
-
     if( NULL == ctx->cipher_info || MBEDTLS_MODE_CBC != ctx->cipher_info->mode )
     {
         return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
@@ -1117,8 +1099,6 @@ int mbedtls_cipher_set_padding_mode( mbedtls_cipher_context_t *ctx,
 int mbedtls_cipher_write_tag( mbedtls_cipher_context_t *ctx,
                       unsigned char *tag, size_t tag_len )
 {
-    CIPHER_VALIDATE_RET( ctx != NULL );
-    CIPHER_VALIDATE_RET( tag_len == 0 || tag != NULL );
     if( ctx->cipher_info == NULL )
         return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
 
@@ -1168,8 +1148,6 @@ int mbedtls_cipher_check_tag( mbedtls_cipher_context_t *ctx,
     unsigned char check_tag[16];
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
 
-    CIPHER_VALIDATE_RET( ctx != NULL );
-    CIPHER_VALIDATE_RET( tag_len == 0 || tag != NULL );
     if( ctx->cipher_info == NULL )
         return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
 
@@ -1260,12 +1238,6 @@ int mbedtls_cipher_crypt( mbedtls_cipher_context_t *ctx,
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     size_t finish_olen;
-
-    CIPHER_VALIDATE_RET( ctx != NULL );
-    CIPHER_VALIDATE_RET( iv_len == 0 || iv != NULL );
-    CIPHER_VALIDATE_RET( ilen == 0 || input != NULL );
-    CIPHER_VALIDATE_RET( output != NULL );
-    CIPHER_VALIDATE_RET( olen != NULL );
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     if( ctx->psa_enabled == 1 )
@@ -1542,13 +1514,6 @@ int mbedtls_cipher_auth_encrypt_ext( mbedtls_cipher_context_t *ctx,
                          unsigned char *output, size_t output_len,
                          size_t *olen, size_t tag_len )
 {
-    CIPHER_VALIDATE_RET( ctx != NULL );
-    CIPHER_VALIDATE_RET( iv_len == 0 || iv != NULL );
-    CIPHER_VALIDATE_RET( ad_len == 0 || ad != NULL );
-    CIPHER_VALIDATE_RET( ilen == 0 || input != NULL );
-    CIPHER_VALIDATE_RET( output != NULL );
-    CIPHER_VALIDATE_RET( olen != NULL );
-
 #if defined(MBEDTLS_NIST_KW_C)
     if(
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
@@ -1598,13 +1563,6 @@ int mbedtls_cipher_auth_decrypt_ext( mbedtls_cipher_context_t *ctx,
                          unsigned char *output, size_t output_len,
                          size_t *olen, size_t tag_len )
 {
-    CIPHER_VALIDATE_RET( ctx != NULL );
-    CIPHER_VALIDATE_RET( iv_len == 0 || iv != NULL );
-    CIPHER_VALIDATE_RET( ad_len == 0 || ad != NULL );
-    CIPHER_VALIDATE_RET( ilen == 0 || input != NULL );
-    CIPHER_VALIDATE_RET( output_len == 0 || output != NULL );
-    CIPHER_VALIDATE_RET( olen != NULL );
-
 #if defined(MBEDTLS_NIST_KW_C)
     if(
 #if defined(MBEDTLS_USE_PSA_CRYPTO)

--- a/library/gcm.c
+++ b/library/gcm.c
@@ -63,7 +63,6 @@
  */
 void mbedtls_gcm_init( mbedtls_gcm_context *ctx )
 {
-    GCM_VALIDATE( ctx != NULL );
     memset( ctx, 0, sizeof( mbedtls_gcm_context ) );
 }
 
@@ -143,8 +142,6 @@ int mbedtls_gcm_setkey( mbedtls_gcm_context *ctx,
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     const mbedtls_cipher_info_t *cipher_info;
 
-    GCM_VALIDATE_RET( ctx != NULL );
-    GCM_VALIDATE_RET( key != NULL );
     GCM_VALIDATE_RET( keybits == 128 || keybits == 192 || keybits == 256 );
 
     cipher_info = mbedtls_cipher_info_from_values( cipher, keybits,
@@ -256,9 +253,6 @@ int mbedtls_gcm_starts( mbedtls_gcm_context *ctx,
     size_t use_len, olen = 0;
     uint64_t iv_bits;
 
-    GCM_VALIDATE_RET( ctx != NULL );
-    GCM_VALIDATE_RET( iv != NULL );
-
     /* IV is limited to 2^64 bits, so 2^61 bytes */
     /* IV is not allowed to be zero length */
     if( iv_len == 0 || (uint64_t) iv_len >> 61 != 0 )
@@ -333,8 +327,6 @@ int mbedtls_gcm_update_ad( mbedtls_gcm_context *ctx,
 {
     const unsigned char *p;
     size_t use_len, i, offset;
-
-    GCM_VALIDATE_RET( add_len == 0 || add != NULL );
 
     /* IV is limited to 2^64 bits, so 2^61 bytes */
     if( (uint64_t) add_len >> 61 != 0 )
@@ -434,7 +426,6 @@ int mbedtls_gcm_update( mbedtls_gcm_context *ctx,
 
     if( output_size < input_length )
         return( MBEDTLS_ERR_GCM_BUFFER_TOO_SMALL );
-    GCM_VALIDATE_RET( output_length != NULL );
     *output_length = input_length;
 
     /* Exit early if input_length==0 so that we don't do any pointer arithmetic
@@ -443,10 +434,6 @@ int mbedtls_gcm_update( mbedtls_gcm_context *ctx,
      * untouched for mbedtls_gcm_finish */
     if( input_length == 0 )
         return( 0 );
-
-    GCM_VALIDATE_RET( ctx != NULL );
-    GCM_VALIDATE_RET( input != NULL );
-    GCM_VALIDATE_RET( output != NULL );
 
     if( output > input && (size_t) ( output - input ) < input_length )
         return( MBEDTLS_ERR_GCM_BAD_INPUT );
@@ -519,9 +506,6 @@ int mbedtls_gcm_finish( mbedtls_gcm_context *ctx,
     uint64_t orig_len;
     uint64_t orig_add_len;
 
-    GCM_VALIDATE_RET( ctx != NULL );
-    GCM_VALIDATE_RET( tag != NULL );
-
     /* We never pass any output in finish(). The output parameter exists only
      * for the sake of alternative implementations. */
     (void) output;
@@ -580,13 +564,6 @@ int mbedtls_gcm_crypt_and_tag( mbedtls_gcm_context *ctx,
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     size_t olen;
 
-    GCM_VALIDATE_RET( ctx != NULL );
-    GCM_VALIDATE_RET( iv != NULL );
-    GCM_VALIDATE_RET( add_len == 0 || add != NULL );
-    GCM_VALIDATE_RET( length == 0 || input != NULL );
-    GCM_VALIDATE_RET( length == 0 || output != NULL );
-    GCM_VALIDATE_RET( tag != NULL );
-
     if( ( ret = mbedtls_gcm_starts( ctx, mode, iv, iv_len ) ) != 0 )
         return( ret );
 
@@ -618,13 +595,6 @@ int mbedtls_gcm_auth_decrypt( mbedtls_gcm_context *ctx,
     unsigned char check_tag[16];
     size_t i;
     int diff;
-
-    GCM_VALIDATE_RET( ctx != NULL );
-    GCM_VALIDATE_RET( iv != NULL );
-    GCM_VALIDATE_RET( add_len == 0 || add != NULL );
-    GCM_VALIDATE_RET( tag != NULL );
-    GCM_VALIDATE_RET( length == 0 || input != NULL );
-    GCM_VALIDATE_RET( length == 0 || output != NULL );
 
     if( ( ret = mbedtls_gcm_crypt_and_tag( ctx, MBEDTLS_GCM_DECRYPT, length,
                                    iv, iv_len, add, add_len,

--- a/library/gcm.c
+++ b/library/gcm.c
@@ -52,12 +52,6 @@
 
 #if !defined(MBEDTLS_GCM_ALT)
 
-/* Parameter validation macros */
-#define GCM_VALIDATE_RET( cond ) \
-    MBEDTLS_INTERNAL_VALIDATE_RET( cond, MBEDTLS_ERR_GCM_BAD_INPUT )
-#define GCM_VALIDATE( cond ) \
-    MBEDTLS_INTERNAL_VALIDATE( cond )
-
 /*
  * Initialize a context
  */
@@ -142,7 +136,8 @@ int mbedtls_gcm_setkey( mbedtls_gcm_context *ctx,
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     const mbedtls_cipher_info_t *cipher_info;
 
-    GCM_VALIDATE_RET( keybits == 128 || keybits == 192 || keybits == 256 );
+    if( keybits != 128 && keybits != 192 && keybits != 256 )
+        return MBEDTLS_ERR_GCM_BAD_INPUT;
 
     cipher_info = mbedtls_cipher_info_from_values( cipher, keybits,
                                                    MBEDTLS_MODE_ECB );

--- a/tests/suites/test_suite_aes.function
+++ b/tests/suites/test_suite_aes.function
@@ -358,7 +358,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:NOT_DEFINED */
+/* BEGIN_CASE */
 void aes_invalid_mode( )
 {
     mbedtls_aes_context aes_ctx;

--- a/tests/suites/test_suite_camellia.function
+++ b/tests/suites/test_suite_camellia.function
@@ -7,7 +7,7 @@
  * END_DEPENDENCIES
  */
 
-/* BEGIN_CASE depends_on:NOT_DEFINED */
+/* BEGIN_CASE */
 void camellia_invalid_param( )
 {
     mbedtls_camellia_context ctx;

--- a/tests/suites/test_suite_cipher.function
+++ b/tests/suites/test_suite_cipher.function
@@ -304,7 +304,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:NOT_DEFINED */
+/* BEGIN_CASE */
 void cipher_invalid_param_conditional( )
 {
     mbedtls_cipher_context_t valid_ctx;

--- a/tests/suites/test_suite_cipher.function
+++ b/tests/suites/test_suite_cipher.function
@@ -313,8 +313,6 @@ void cipher_invalid_param_conditional( )
     unsigned char valid_buffer[] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 };
     int valid_size = sizeof(valid_buffer);
     int valid_bitlen = valid_size * 8;
-    const mbedtls_cipher_info_t *valid_info = mbedtls_cipher_info_from_type(
-        *( mbedtls_cipher_list() ) );
 
     TEST_EQUAL(
         MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA,

--- a/tests/suites/test_suite_gcm.function
+++ b/tests/suites/test_suite_gcm.function
@@ -411,7 +411,7 @@ void gcm_encrypt_and_verify_no_ad_no_cipher( int cipher_id,
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:NOT_DEFINED */
+/* BEGIN_CASE */
 void gcm_invalid_param( )
 {
     mbedtls_gcm_context ctx;


### PR DESCRIPTION
## Description

This is part of #4681 
This PR re-introduce enum check in files related to cipher in library.
Additionally, removes NULL pointer checks ( That is already disabled by #4313 )

## Status
**IN DEVELOPMENT**

## Requires Backporting

NO  

## Migrations

NO


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported
