### PR TITLE
Fix linking of generated files in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,7 +131,7 @@ function(link_to_source base_name)
         set(target "${CMAKE_CURRENT_SOURCE_DIR}/${base_name}")
     endif()
 
-    # Linking to non-existant file is not desirable. At best you will have a
+    # Linking to non-existent file is not desirable. At best you will have a
     # dangling link, but when building in tree, this can create a symbolic link
     # to itself.
     if (EXISTS ${target} AND NOT EXISTS ${link})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,7 +131,10 @@ function(link_to_source base_name)
         set(target "${CMAKE_CURRENT_SOURCE_DIR}/${base_name}")
     endif()
 
-    if (NOT EXISTS ${link})
+    # Linking to non-existant file is not desirable. At best you will have a
+    # dangling link, but when building in tree, this can create a symbolic link
+    # to itself.
+    if (EXISTS ${target} AND NOT EXISTS ${link})
         if (CMAKE_HOST_UNIX)
             set(command ln -s ${target} ${link})
         else()

--- a/ChangeLog.d/fix_cmake_gen_files
+++ b/ChangeLog.d/fix_cmake_gen_files
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix an issue in releases with GEN_FILES turned off whereby missing
+     generated files could be turned into symlinks to themselves.


### PR DESCRIPTION
## Description

If generation of files is turned off, and a file is missing, when building in tree with cmake, you can end up with the generated file being turned into a symlink to itself. This will also break any future attempt at building with make. Fix this by testing if the file exists prior to attempting to link it.

## Status
**READY**

## Requires Backporting
NO  

## Migrations
NO

## Additional comments
This was found by (and contributed to) the breakage of the recent release.

## Todos
- [x] Tests
- [x] Changelog updated

## Steps to test or reproduce
CMake both in and out of tree should work with GEN_FILES off and although it should fail with missing files, should not create a self referential symlink.
