### PR TITLE
Remove encoding width suffix from Arm bignum assembly

### DIFF
--- a/library/bn_mul.h
+++ b/library/bn_mul.h
@@ -717,10 +717,10 @@
 
 #define MULADDC_X1_CORE                                         \
            ".p2align  2                                 \n\t"   \
-            "ldr.w    %[a], [%[in]], #4                 \n\t"   \
-            "ldr.w    %[b], [%[acc]]                    \n\t"   \
+            "ldr      %[a], [%[in]], #4                 \n\t"   \
+            "ldr      %[b], [%[acc]]                    \n\t"   \
             "umaal    %[b], %[carry], %[scalar], %[a]   \n\t"   \
-            "str.w    %[b], [%[acc]], #4                \n\t"
+            "str      %[b], [%[acc]], #4                \n\t"
 
 #define MULADDC_X1_STOP                                      \
             : [a]      "=&r" (tmp_a),                        \
@@ -751,14 +751,14 @@
              *   2 cycles, while subsequent loads/stores are single-cycle. */
 #define MULADDC_X2_CORE                                           \
            ".p2align  2                                   \n\t"   \
-            "ldr.w    %[a0], [%[in]],  #+8                \n\t"   \
-            "ldr.w    %[b0], [%[acc]], #+8                \n\t"   \
-            "ldr.w    %[a1], [%[in],  #-4]                \n\t"   \
-            "ldr.w    %[b1], [%[acc], #-4]                \n\t"   \
+            "ldr      %[a0], [%[in]],  #+8                \n\t"   \
+            "ldr      %[b0], [%[acc]], #+8                \n\t"   \
+            "ldr      %[a1], [%[in],  #-4]                \n\t"   \
+            "ldr      %[b1], [%[acc], #-4]                \n\t"   \
             "umaal    %[b0], %[carry], %[scalar], %[a0]   \n\t"   \
             "umaal    %[b1], %[carry], %[scalar], %[a1]   \n\t"   \
-            "str.w    %[b0], [%[acc], #-8]                \n\t"   \
-            "str.w    %[b1], [%[acc], #-4]                \n\t"
+            "str      %[b0], [%[acc], #-8]                \n\t"   \
+            "str      %[b1], [%[acc], #-4]                \n\t"
 
 #define MULADDC_X2_STOP                                      \
             : [a0]     "=&r" (tmp_a0),                       \

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -2870,6 +2870,7 @@ component_build_armcc () {
     scripts/config.py baremetal
     # armc[56] don't support SHA-512 intrinsics
     scripts/config.py unset MBEDTLS_SHA512_USE_A64_CRYPTO_IF_PRESENT
+    scripts/config.py set MBEDTLS_HAVE_ASM
 
     make CC="$ARMC5_CC" AR="$ARMC5_AR" WARNING_CFLAGS='--strict --c99' lib
 
@@ -2878,20 +2879,22 @@ component_build_armcc () {
 
     make clean
 
+    # Compile with -O1 since some Arm inline assembly is disabled for -O0.
+
     # ARM Compiler 6 - Target ARMv7-A
-    armc6_build_test "--target=arm-arm-none-eabi -march=armv7-a"
+    armc6_build_test "--target=arm-arm-none-eabi -O1 -march=armv7-a"
 
     # ARM Compiler 6 - Target ARMv7-M
-    armc6_build_test "--target=arm-arm-none-eabi -march=armv7-m"
+    armc6_build_test "--target=arm-arm-none-eabi -O1 -march=armv7-m+dsp"
 
     # ARM Compiler 6 - Target ARMv8-A - AArch32
-    armc6_build_test "--target=arm-arm-none-eabi -march=armv8.2-a"
+    armc6_build_test "--target=arm-arm-none-eabi -O1 -march=armv8.2-a"
 
     # ARM Compiler 6 - Target ARMv8-M
-    armc6_build_test "--target=arm-arm-none-eabi -march=armv8-m.main"
+    armc6_build_test "--target=arm-arm-none-eabi -O1 -march=armv8-m.main"
 
     # ARM Compiler 6 - Target ARMv8.2-A - AArch64
-    armc6_build_test "--target=aarch64-arm-none-eabi -march=armv8.2-a+crypto"
+    armc6_build_test "--target=aarch64-arm-none-eabi -O1 -march=armv8.2-a+crypto"
 }
 
 component_test_tls13_only () {

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -2882,19 +2882,22 @@ component_build_armcc () {
     # Compile with -O1 since some Arm inline assembly is disabled for -O0.
 
     # ARM Compiler 6 - Target ARMv7-A
-    armc6_build_test "--target=arm-arm-none-eabi -O1 -march=armv7-a"
+    armc6_build_test "-O1 --target=arm-arm-none-eabi -march=armv7-a"
 
     # ARM Compiler 6 - Target ARMv7-M
-    armc6_build_test "--target=arm-arm-none-eabi -O1 -march=armv7-m+dsp"
+    armc6_build_test "-O1 --target=arm-arm-none-eabi -march=armv7-m"
+
+    # ARM Compiler 6 - Target ARMv7-M+DSP
+    armc6_build_test "-O1 --target=arm-arm-none-eabi -march=armv7-m+dsp"
 
     # ARM Compiler 6 - Target ARMv8-A - AArch32
-    armc6_build_test "--target=arm-arm-none-eabi -O1 -march=armv8.2-a"
+    armc6_build_test "-O1 --target=arm-arm-none-eabi -march=armv8.2-a"
 
     # ARM Compiler 6 - Target ARMv8-M
-    armc6_build_test "--target=arm-arm-none-eabi -O1 -march=armv8-m.main"
+    armc6_build_test "-O1 --target=arm-arm-none-eabi -march=armv8-m.main"
 
     # ARM Compiler 6 - Target ARMv8.2-A - AArch64
-    armc6_build_test "--target=aarch64-arm-none-eabi -O1 -march=armv8.2-a+crypto"
+    armc6_build_test "-O1 --target=aarch64-arm-none-eabi -march=armv8.2-a+crypto"
 }
 
 component_test_tls13_only () {


### PR DESCRIPTION
Within the M-profile of the Arm architecture, some instructions admit both a 16-bit and a 32-bit encoding. For those instructions,
some assemblers support the use of the .n (narrow) and .w (wide) suffixes to force a choice of instruction encoding width.
Forcing the size of encodings may be useful to ensure alignment of code, which can have a significant performance impact on some microarchitectures.

It is for this reason that a previous commit introduced explicit .w suffixes into what was believed to be M-profile only assembly
in library/bn_mul.h.

This change, however, introduced two issues:
- First, the assembly block in question is used also for Armv7-A systems, on which the .n/.w distinction is not meaningful (all instructions are 32-bit). This was reported in #6089.
- Second, compiler support for .n/.w suffixes appears patchy in the first place, leading to compilation failures even when building for M-profile targets that don't appear trivial to resolve.

This PR removes the .w annotations in order to restore working code, deferring controlled re-introduction for the sake of performance.

It also modifies all.sh to make sure that Arm inline assembly is at least built.

Fixes #6089.