### PR TITLE
Validation remove change pk

### DIFF
--- a/library/pk.c
+++ b/library/pk.c
@@ -57,7 +57,6 @@
  */
 void mbedtls_pk_init( mbedtls_pk_context *ctx )
 {
-    PK_VALIDATE( ctx != NULL );
 
     ctx->pk_info = NULL;
     ctx->pk_ctx = NULL;
@@ -83,7 +82,6 @@ void mbedtls_pk_free( mbedtls_pk_context *ctx )
  */
 void mbedtls_pk_restart_init( mbedtls_pk_restart_ctx *ctx )
 {
-    PK_VALIDATE( ctx != NULL );
     ctx->pk_info = NULL;
     ctx->rs_ctx = NULL;
 }
@@ -137,7 +135,6 @@ const mbedtls_pk_info_t * mbedtls_pk_info_from_type( mbedtls_pk_type_t pk_type )
  */
 int mbedtls_pk_setup( mbedtls_pk_context *ctx, const mbedtls_pk_info_t *info )
 {
-    PK_VALIDATE_RET( ctx != NULL );
     if( info == NULL || ctx->pk_info != NULL )
         return( MBEDTLS_ERR_PK_BAD_INPUT_DATA );
 
@@ -200,7 +197,6 @@ int mbedtls_pk_setup_rsa_alt( mbedtls_pk_context *ctx, void * key,
     mbedtls_rsa_alt_context *rsa_alt;
     const mbedtls_pk_info_t *info = &mbedtls_rsa_alt_info;
 
-    PK_VALIDATE_RET( ctx != NULL );
     if( ctx->pk_info != NULL )
         return( MBEDTLS_ERR_PK_BAD_INPUT_DATA );
 
@@ -404,10 +400,8 @@ int mbedtls_pk_verify_restartable( mbedtls_pk_context *ctx,
                const unsigned char *sig, size_t sig_len,
                mbedtls_pk_restart_ctx *rs_ctx )
 {
-    PK_VALIDATE_RET( ctx != NULL );
     PK_VALIDATE_RET( ( md_alg == MBEDTLS_MD_NONE && hash_len == 0 ) ||
                      hash != NULL );
-    PK_VALIDATE_RET( sig != NULL );
 
     if( ctx->pk_info == NULL ||
         pk_hashlen_helper( md_alg, &hash_len ) != 0 )
@@ -462,10 +456,8 @@ int mbedtls_pk_verify_ext( mbedtls_pk_type_t type, const void *options,
                    const unsigned char *hash, size_t hash_len,
                    const unsigned char *sig, size_t sig_len )
 {
-    PK_VALIDATE_RET( ctx != NULL );
     PK_VALIDATE_RET( ( md_alg == MBEDTLS_MD_NONE && hash_len == 0 ) ||
                      hash != NULL );
-    PK_VALIDATE_RET( sig != NULL );
 
     if( ctx->pk_info == NULL )
         return( MBEDTLS_ERR_PK_BAD_INPUT_DATA );
@@ -588,10 +580,8 @@ int mbedtls_pk_sign_restartable( mbedtls_pk_context *ctx,
              int (*f_rng)(void *, unsigned char *, size_t), void *p_rng,
              mbedtls_pk_restart_ctx *rs_ctx )
 {
-    PK_VALIDATE_RET( ctx != NULL );
     PK_VALIDATE_RET( ( md_alg == MBEDTLS_MD_NONE && hash_len == 0 ) ||
                      hash != NULL );
-    PK_VALIDATE_RET( sig != NULL );
 
     if( ctx->pk_info == NULL ||
         pk_hashlen_helper( md_alg, &hash_len ) != 0 )
@@ -707,10 +697,6 @@ int mbedtls_pk_decrypt( mbedtls_pk_context *ctx,
                 unsigned char *output, size_t *olen, size_t osize,
                 int (*f_rng)(void *, unsigned char *, size_t), void *p_rng )
 {
-    PK_VALIDATE_RET( ctx != NULL );
-    PK_VALIDATE_RET( input != NULL || ilen == 0 );
-    PK_VALIDATE_RET( output != NULL || osize == 0 );
-    PK_VALIDATE_RET( olen != NULL );
 
     if( ctx->pk_info == NULL )
         return( MBEDTLS_ERR_PK_BAD_INPUT_DATA );
@@ -730,10 +716,6 @@ int mbedtls_pk_encrypt( mbedtls_pk_context *ctx,
                 unsigned char *output, size_t *olen, size_t osize,
                 int (*f_rng)(void *, unsigned char *, size_t), void *p_rng )
 {
-    PK_VALIDATE_RET( ctx != NULL );
-    PK_VALIDATE_RET( input != NULL || ilen == 0 );
-    PK_VALIDATE_RET( output != NULL || osize == 0 );
-    PK_VALIDATE_RET( olen != NULL );
 
     if( ctx->pk_info == NULL )
         return( MBEDTLS_ERR_PK_BAD_INPUT_DATA );
@@ -753,8 +735,6 @@ int mbedtls_pk_check_pair( const mbedtls_pk_context *pub,
                            int (*f_rng)(void *, unsigned char *, size_t),
                            void *p_rng )
 {
-    PK_VALIDATE_RET( pub != NULL );
-    PK_VALIDATE_RET( prv != NULL );
 
     if( pub->pk_info == NULL ||
         prv->pk_info == NULL )
@@ -800,7 +780,6 @@ size_t mbedtls_pk_get_bitlen( const mbedtls_pk_context *ctx )
  */
 int mbedtls_pk_debug( const mbedtls_pk_context *ctx, mbedtls_pk_debug_item *items )
 {
-    PK_VALIDATE_RET( ctx != NULL );
     if( ctx->pk_info == NULL )
         return( MBEDTLS_ERR_PK_BAD_INPUT_DATA );
 

--- a/library/pk.c
+++ b/library/pk.c
@@ -46,11 +46,6 @@
 #include <limits.h>
 #include <stdint.h>
 
-/* Parameter validation macros based on platform_util.h */
-#define PK_VALIDATE_RET( cond )    \
-    MBEDTLS_INTERNAL_VALIDATE_RET( cond, MBEDTLS_ERR_PK_BAD_INPUT_DATA )
-#define PK_VALIDATE( cond )        \
-    MBEDTLS_INTERNAL_VALIDATE( cond )
 
 /*
  * Initialise a mbedtls_pk_context
@@ -400,8 +395,9 @@ int mbedtls_pk_verify_restartable( mbedtls_pk_context *ctx,
                const unsigned char *sig, size_t sig_len,
                mbedtls_pk_restart_ctx *rs_ctx )
 {
-    PK_VALIDATE_RET( ( md_alg == MBEDTLS_MD_NONE && hash_len == 0 ) ||
-                     hash != NULL );
+    if( ( md_alg != MBEDTLS_MD_NONE || hash_len != 0 ) &&
+        hash == NULL )
+        return MBEDTLS_ERR_PK_BAD_INPUT_DATA;
 
     if( ctx->pk_info == NULL ||
         pk_hashlen_helper( md_alg, &hash_len ) != 0 )
@@ -456,8 +452,9 @@ int mbedtls_pk_verify_ext( mbedtls_pk_type_t type, const void *options,
                    const unsigned char *hash, size_t hash_len,
                    const unsigned char *sig, size_t sig_len )
 {
-    PK_VALIDATE_RET( ( md_alg == MBEDTLS_MD_NONE && hash_len == 0 ) ||
-                     hash != NULL );
+    if( ( md_alg != MBEDTLS_MD_NONE || hash_len != 0 ) &&
+        hash == NULL )
+        return MBEDTLS_ERR_PK_BAD_INPUT_DATA;
 
     if( ctx->pk_info == NULL )
         return( MBEDTLS_ERR_PK_BAD_INPUT_DATA );
@@ -580,8 +577,9 @@ int mbedtls_pk_sign_restartable( mbedtls_pk_context *ctx,
              int (*f_rng)(void *, unsigned char *, size_t), void *p_rng,
              mbedtls_pk_restart_ctx *rs_ctx )
 {
-    PK_VALIDATE_RET( ( md_alg == MBEDTLS_MD_NONE && hash_len == 0 ) ||
-                     hash != NULL );
+    if( ( md_alg != MBEDTLS_MD_NONE || hash_len != 0 ) &&
+        hash == NULL )
+        return MBEDTLS_ERR_PK_BAD_INPUT_DATA;
 
     if( ctx->pk_info == NULL ||
         pk_hashlen_helper( md_alg, &hash_len ) != 0 )

--- a/library/pk.c
+++ b/library/pk.c
@@ -46,13 +46,11 @@
 #include <limits.h>
 #include <stdint.h>
 
-
 /*
  * Initialise a mbedtls_pk_context
  */
 void mbedtls_pk_init( mbedtls_pk_context *ctx )
 {
-
     ctx->pk_info = NULL;
     ctx->pk_ctx = NULL;
 }
@@ -395,8 +393,7 @@ int mbedtls_pk_verify_restartable( mbedtls_pk_context *ctx,
                const unsigned char *sig, size_t sig_len,
                mbedtls_pk_restart_ctx *rs_ctx )
 {
-    if( ( md_alg != MBEDTLS_MD_NONE || hash_len != 0 ) &&
-        hash == NULL )
+    if( ( md_alg != MBEDTLS_MD_NONE || hash_len != 0 ) && hash == NULL )
         return MBEDTLS_ERR_PK_BAD_INPUT_DATA;
 
     if( ctx->pk_info == NULL ||
@@ -452,8 +449,7 @@ int mbedtls_pk_verify_ext( mbedtls_pk_type_t type, const void *options,
                    const unsigned char *hash, size_t hash_len,
                    const unsigned char *sig, size_t sig_len )
 {
-    if( ( md_alg != MBEDTLS_MD_NONE || hash_len != 0 ) &&
-        hash == NULL )
+    if( ( md_alg != MBEDTLS_MD_NONE || hash_len != 0 ) && hash == NULL )
         return MBEDTLS_ERR_PK_BAD_INPUT_DATA;
 
     if( ctx->pk_info == NULL )
@@ -577,12 +573,10 @@ int mbedtls_pk_sign_restartable( mbedtls_pk_context *ctx,
              int (*f_rng)(void *, unsigned char *, size_t), void *p_rng,
              mbedtls_pk_restart_ctx *rs_ctx )
 {
-    if( ( md_alg != MBEDTLS_MD_NONE || hash_len != 0 ) &&
-        hash == NULL )
+    if( ( md_alg != MBEDTLS_MD_NONE || hash_len != 0 ) && hash == NULL )
         return MBEDTLS_ERR_PK_BAD_INPUT_DATA;
 
-    if( ctx->pk_info == NULL ||
-        pk_hashlen_helper( md_alg, &hash_len ) != 0 )
+    if( ctx->pk_info == NULL || pk_hashlen_helper( md_alg, &hash_len ) != 0 )
         return( MBEDTLS_ERR_PK_BAD_INPUT_DATA );
 
 #if defined(MBEDTLS_ECDSA_C) && defined(MBEDTLS_ECP_RESTARTABLE)
@@ -695,7 +689,6 @@ int mbedtls_pk_decrypt( mbedtls_pk_context *ctx,
                 unsigned char *output, size_t *olen, size_t osize,
                 int (*f_rng)(void *, unsigned char *, size_t), void *p_rng )
 {
-
     if( ctx->pk_info == NULL )
         return( MBEDTLS_ERR_PK_BAD_INPUT_DATA );
 
@@ -714,7 +707,6 @@ int mbedtls_pk_encrypt( mbedtls_pk_context *ctx,
                 unsigned char *output, size_t *olen, size_t osize,
                 int (*f_rng)(void *, unsigned char *, size_t), void *p_rng )
 {
-
     if( ctx->pk_info == NULL )
         return( MBEDTLS_ERR_PK_BAD_INPUT_DATA );
 
@@ -733,7 +725,6 @@ int mbedtls_pk_check_pair( const mbedtls_pk_context *pub,
                            int (*f_rng)(void *, unsigned char *, size_t),
                            void *p_rng )
 {
-
     if( pub->pk_info == NULL ||
         prv->pk_info == NULL )
     {

--- a/library/pkparse.c
+++ b/library/pkparse.c
@@ -56,7 +56,6 @@
 #define mbedtls_free       free
 #endif
 
-
 #if defined(MBEDTLS_FS_IO)
 /*
  * Load all data from a file into a given buffer.
@@ -69,7 +68,6 @@ int mbedtls_pk_load_file( const char *path, unsigned char **buf, size_t *n )
 {
     FILE *f;
     long size;
-
 
     if( ( f = fopen( path, "rb" ) ) == NULL )
         return( MBEDTLS_ERR_PK_FILE_IO_ERROR );
@@ -125,7 +123,6 @@ int mbedtls_pk_parse_keyfile( mbedtls_pk_context *ctx,
     size_t n;
     unsigned char *buf;
 
-
     if( ( ret = mbedtls_pk_load_file( path, &buf, &n ) ) != 0 )
         return( ret );
 
@@ -149,7 +146,6 @@ int mbedtls_pk_parse_public_keyfile( mbedtls_pk_context *ctx, const char *path )
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     size_t n;
     unsigned char *buf;
-
 
     if( ( ret = mbedtls_pk_load_file( path, &buf, &n ) ) != 0 )
         return( ret );
@@ -607,7 +603,6 @@ int mbedtls_pk_parse_subpubkey( unsigned char **p, const unsigned char *end,
     mbedtls_asn1_buf alg_params;
     mbedtls_pk_type_t pk_alg = MBEDTLS_PK_NONE;
     const mbedtls_pk_info_t *pk_info;
-
 
     if( ( ret = mbedtls_asn1_get_tag( p, end, &len,
                     MBEDTLS_ASN1_CONSTRUCTED | MBEDTLS_ASN1_SEQUENCE ) ) != 0 )

--- a/library/pkparse.c
+++ b/library/pkparse.c
@@ -56,11 +56,6 @@
 #define mbedtls_free       free
 #endif
 
-/* Parameter validation macros based on platform_util.h */
-#define PK_VALIDATE_RET( cond )    \
-    MBEDTLS_INTERNAL_VALIDATE_RET( cond, MBEDTLS_ERR_PK_BAD_INPUT_DATA )
-#define PK_VALIDATE( cond )        \
-    MBEDTLS_INTERNAL_VALIDATE( cond )
 
 #if defined(MBEDTLS_FS_IO)
 /*
@@ -75,9 +70,6 @@ int mbedtls_pk_load_file( const char *path, unsigned char **buf, size_t *n )
     FILE *f;
     long size;
 
-    PK_VALIDATE_RET( path != NULL );
-    PK_VALIDATE_RET( buf != NULL );
-    PK_VALIDATE_RET( n != NULL );
 
     if( ( f = fopen( path, "rb" ) ) == NULL )
         return( MBEDTLS_ERR_PK_FILE_IO_ERROR );
@@ -133,8 +125,6 @@ int mbedtls_pk_parse_keyfile( mbedtls_pk_context *ctx,
     size_t n;
     unsigned char *buf;
 
-    PK_VALIDATE_RET( ctx != NULL );
-    PK_VALIDATE_RET( path != NULL );
 
     if( ( ret = mbedtls_pk_load_file( path, &buf, &n ) ) != 0 )
         return( ret );
@@ -160,8 +150,6 @@ int mbedtls_pk_parse_public_keyfile( mbedtls_pk_context *ctx, const char *path )
     size_t n;
     unsigned char *buf;
 
-    PK_VALIDATE_RET( ctx != NULL );
-    PK_VALIDATE_RET( path != NULL );
 
     if( ( ret = mbedtls_pk_load_file( path, &buf, &n ) ) != 0 )
         return( ret );
@@ -620,10 +608,6 @@ int mbedtls_pk_parse_subpubkey( unsigned char **p, const unsigned char *end,
     mbedtls_pk_type_t pk_alg = MBEDTLS_PK_NONE;
     const mbedtls_pk_info_t *pk_info;
 
-    PK_VALIDATE_RET( p != NULL );
-    PK_VALIDATE_RET( *p != NULL );
-    PK_VALIDATE_RET( end != NULL );
-    PK_VALIDATE_RET( pk != NULL );
 
     if( ( ret = mbedtls_asn1_get_tag( p, end, &len,
                     MBEDTLS_ASN1_CONSTRUCTED | MBEDTLS_ASN1_SEQUENCE ) ) != 0 )
@@ -1217,10 +1201,8 @@ int mbedtls_pk_parse_key( mbedtls_pk_context *pk,
     mbedtls_pem_context pem;
 #endif
 
-    PK_VALIDATE_RET( pk != NULL );
     if( keylen == 0 )
         return( MBEDTLS_ERR_PK_KEY_INVALID_FORMAT );
-    PK_VALIDATE_RET( key != NULL );
 
 #if defined(MBEDTLS_PEM_PARSE_C)
    mbedtls_pem_init( &pem );
@@ -1436,10 +1418,8 @@ int mbedtls_pk_parse_public_key( mbedtls_pk_context *ctx,
     mbedtls_pem_context pem;
 #endif
 
-    PK_VALIDATE_RET( ctx != NULL );
     if( keylen == 0 )
         return( MBEDTLS_ERR_PK_KEY_INVALID_FORMAT );
-    PK_VALIDATE_RET( key != NULL || keylen == 0 );
 
 #if defined(MBEDTLS_PEM_PARSE_C)
     mbedtls_pem_init( &pem );

--- a/library/pkwrite.c
+++ b/library/pkwrite.c
@@ -59,7 +59,6 @@
 #define mbedtls_free       free
 #endif
 
-
 #if defined(MBEDTLS_RSA_C)
 /*
  *  RSAPublicKey ::= SEQUENCE {
@@ -176,7 +175,6 @@ int mbedtls_pk_write_pubkey( unsigned char **p, unsigned char *start,
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     size_t len = 0;
-
 
 #if defined(MBEDTLS_RSA_C)
     if( mbedtls_pk_get_type( key ) == MBEDTLS_PK_RSA )
@@ -487,7 +485,6 @@ int mbedtls_pk_write_pubkey_pem( const mbedtls_pk_context *key, unsigned char *b
     unsigned char output_buf[PUB_DER_MAX_BYTES];
     size_t olen = 0;
 
-
     if( ( ret = mbedtls_pk_write_pubkey_der( key, output_buf,
                                      sizeof(output_buf) ) ) < 0 )
     {
@@ -510,7 +507,6 @@ int mbedtls_pk_write_key_pem( const mbedtls_pk_context *key, unsigned char *buf,
     unsigned char output_buf[PRV_DER_MAX_BYTES];
     const char *begin, *end;
     size_t olen = 0;
-
 
     if( ( ret = mbedtls_pk_write_key_der( key, output_buf, sizeof(output_buf) ) ) < 0 )
         return( ret );

--- a/library/pkwrite.c
+++ b/library/pkwrite.c
@@ -59,11 +59,6 @@
 #define mbedtls_free       free
 #endif
 
-/* Parameter validation macros based on platform_util.h */
-#define PK_VALIDATE_RET( cond )    \
-    MBEDTLS_INTERNAL_VALIDATE_RET( cond, MBEDTLS_ERR_PK_BAD_INPUT_DATA )
-#define PK_VALIDATE( cond )        \
-    MBEDTLS_INTERNAL_VALIDATE( cond )
 
 #if defined(MBEDTLS_RSA_C)
 /*
@@ -182,10 +177,6 @@ int mbedtls_pk_write_pubkey( unsigned char **p, unsigned char *start,
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     size_t len = 0;
 
-    PK_VALIDATE_RET( p != NULL );
-    PK_VALIDATE_RET( *p != NULL );
-    PK_VALIDATE_RET( start != NULL );
-    PK_VALIDATE_RET( key != NULL );
 
 #if defined(MBEDTLS_RSA_C)
     if( mbedtls_pk_get_type( key ) == MBEDTLS_PK_RSA )
@@ -233,10 +224,8 @@ int mbedtls_pk_write_pubkey_der( const mbedtls_pk_context *key, unsigned char *b
     mbedtls_pk_type_t pk_type;
     const char *oid;
 
-    PK_VALIDATE_RET( key != NULL );
     if( size == 0 )
         return( MBEDTLS_ERR_ASN1_BUF_TOO_SMALL );
-    PK_VALIDATE_RET( buf != NULL );
 
     c = buf + size;
 
@@ -333,10 +322,8 @@ int mbedtls_pk_write_key_der( const mbedtls_pk_context *key, unsigned char *buf,
     unsigned char *c;
     size_t len = 0;
 
-    PK_VALIDATE_RET( key != NULL );
     if( size == 0 )
         return( MBEDTLS_ERR_ASN1_BUF_TOO_SMALL );
-    PK_VALIDATE_RET( buf != NULL );
 
     c = buf + size;
 
@@ -500,8 +487,6 @@ int mbedtls_pk_write_pubkey_pem( const mbedtls_pk_context *key, unsigned char *b
     unsigned char output_buf[PUB_DER_MAX_BYTES];
     size_t olen = 0;
 
-    PK_VALIDATE_RET( key != NULL );
-    PK_VALIDATE_RET( buf != NULL || size == 0 );
 
     if( ( ret = mbedtls_pk_write_pubkey_der( key, output_buf,
                                      sizeof(output_buf) ) ) < 0 )
@@ -526,8 +511,6 @@ int mbedtls_pk_write_key_pem( const mbedtls_pk_context *key, unsigned char *buf,
     const char *begin, *end;
     size_t olen = 0;
 
-    PK_VALIDATE_RET( key != NULL );
-    PK_VALIDATE_RET( buf != NULL || size == 0 );
 
     if( ( ret = mbedtls_pk_write_key_der( key, output_buf, sizeof(output_buf) ) ) < 0 )
         return( ret );

--- a/tests/suites/test_suite_pk.data
+++ b/tests/suites/test_suite_pk.data
@@ -1,3 +1,6 @@
+PK invalid parameters
+pk_invalid_param:
+
 PK valid parameters
 valid_parameters:
 

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -299,6 +299,39 @@ exit:
 }
 /* END_CASE */
 
+
+/* BEGIN_CASE */
+void pk_invalid_param()
+{
+    mbedtls_pk_context ctx;
+    mbedtls_md_type_t md_alg_none = MBEDTLS_MD_NONE;
+    mbedtls_pk_type_t pk_type = 0;
+    unsigned char buf[] = {0x01,0x02,0x03,0x04,0x05,0x06};
+    size_t buf_size = sizeof( buf );
+
+    mbedtls_pk_init( &ctx );
+
+    TEST_EQUAL( MBEDTLS_ERR_PK_BAD_INPUT_DATA,
+                mbedtls_pk_verify_restartable( &ctx, md_alg_none,
+                                               NULL, buf_size,
+                                               buf, buf_size,
+                                               NULL ) );
+    TEST_EQUAL( MBEDTLS_ERR_PK_BAD_INPUT_DATA,
+                mbedtls_pk_verify_ext( pk_type, NULL,
+                                       &ctx, md_alg_none,
+                                       NULL, buf_size,
+                                       buf, buf_size ) );
+    TEST_EQUAL( MBEDTLS_ERR_PK_BAD_INPUT_DATA,
+                mbedtls_pk_sign_restartable( &ctx, md_alg_none,
+                                             NULL, buf_size,
+                                             buf, buf_size, &buf_size,
+                                             NULL, NULL,
+                                             NULL ) );
+exit:
+    mbedtls_pk_free( &ctx );
+}
+/* END_CASE */
+
 /* BEGIN_CASE */
 void valid_parameters( )
 {

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -303,7 +303,6 @@ exit:
 void pk_invalid_param()
 {
     mbedtls_pk_context ctx;
-    mbedtls_md_type_t md_alg_none = MBEDTLS_MD_NONE;
     mbedtls_pk_type_t pk_type = 0;
     unsigned char buf[] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06 };
     size_t buf_size = sizeof( buf );
@@ -311,18 +310,34 @@ void pk_invalid_param()
     mbedtls_pk_init( &ctx );
 
     TEST_EQUAL( MBEDTLS_ERR_PK_BAD_INPUT_DATA,
-                mbedtls_pk_verify_restartable( &ctx, md_alg_none,
+                mbedtls_pk_verify_restartable( &ctx, MBEDTLS_MD_NONE,
                                                NULL, buf_size,
                                                buf, buf_size,
                                                NULL ) );
     TEST_EQUAL( MBEDTLS_ERR_PK_BAD_INPUT_DATA,
+                mbedtls_pk_verify_restartable( &ctx, MBEDTLS_MD_SHA256,
+                                               NULL, 0,
+                                               buf, buf_size,
+                                               NULL ) );
+    TEST_EQUAL( MBEDTLS_ERR_PK_BAD_INPUT_DATA,
                 mbedtls_pk_verify_ext( pk_type, NULL,
-                                       &ctx, md_alg_none,
+                                       &ctx, MBEDTLS_MD_NONE,
                                        NULL, buf_size,
                                        buf, buf_size ) );
     TEST_EQUAL( MBEDTLS_ERR_PK_BAD_INPUT_DATA,
-                mbedtls_pk_sign_restartable( &ctx, md_alg_none,
+                mbedtls_pk_verify_ext( pk_type, NULL,
+                                       &ctx, MBEDTLS_MD_SHA256,
+                                       NULL, 0,
+                                       buf, buf_size ) );
+    TEST_EQUAL( MBEDTLS_ERR_PK_BAD_INPUT_DATA,
+                mbedtls_pk_sign_restartable( &ctx, MBEDTLS_MD_NONE,
                                              NULL, buf_size,
+                                             buf, buf_size, &buf_size,
+                                             NULL, NULL,
+                                             NULL ) );
+    TEST_EQUAL( MBEDTLS_ERR_PK_BAD_INPUT_DATA,
+                mbedtls_pk_sign_restartable( &ctx, MBEDTLS_MD_SHA256,
+                                             NULL, 0,
                                              buf, buf_size, &buf_size,
                                              NULL, NULL,
                                              NULL ) );

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -305,7 +305,7 @@ void pk_invalid_param()
     mbedtls_pk_context ctx;
     mbedtls_md_type_t md_alg_none = MBEDTLS_MD_NONE;
     mbedtls_pk_type_t pk_type = 0;
-    unsigned char buf[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06};
+    unsigned char buf[] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06 };
     size_t buf_size = sizeof( buf );
 
     mbedtls_pk_init( &ctx );

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -299,14 +299,13 @@ exit:
 }
 /* END_CASE */
 
-
 /* BEGIN_CASE */
 void pk_invalid_param()
 {
     mbedtls_pk_context ctx;
     mbedtls_md_type_t md_alg_none = MBEDTLS_MD_NONE;
     mbedtls_pk_type_t pk_type = 0;
-    unsigned char buf[] = {0x01,0x02,0x03,0x04,0x05,0x06};
+    unsigned char buf[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06};
     size_t buf_size = sizeof( buf );
 
     mbedtls_pk_init( &ctx );


### PR DESCRIPTION
## Description

This is part of #4681 
This PR re-introduce enum check in files related to public key in library.
Additionally, removes NULL pointer checks ( That is already disabled by #4313 )

## Status
**IN DEVELOPMENT**

## Requires Backporting

NO  

## Migrations

NO


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported