### PR TITLE
Crash in test suite x509write config full no seedfile

### DIFF
--- a/tests/suites/test_suite_x509write.function
+++ b/tests/suites/test_suite_x509write.function
@@ -101,13 +101,14 @@ void x509_csr_check( char * key_file, char * cert_req_check_file, int md_type,
 
     memset( &rnd_info, 0x2a, sizeof( mbedtls_test_rnd_pseudo_info ) );
 
+    mbedtls_x509write_csr_init( &req );
+
     USE_PSA_INIT( );
 
     mbedtls_pk_init( &key );
     TEST_ASSERT( mbedtls_pk_parse_keyfile( &key, key_file, NULL,
                         mbedtls_test_rnd_std_rand, NULL ) == 0 );
 
-    mbedtls_x509write_csr_init( &req );
     mbedtls_x509write_csr_set_md_alg( &req, md_type );
     mbedtls_x509write_csr_set_key( &req, &key );
     TEST_ASSERT( mbedtls_x509write_csr_set_subject_name( &req, subject_name ) == 0 );
@@ -183,8 +184,11 @@ void x509_csr_check_opaque( char *key_file, int md_type, int key_usage,
     const char *subject_name = "C=NL,O=PolarSSL,CN=PolarSSL Server 1";
     mbedtls_test_rnd_pseudo_info rnd_info;
 
-    PSA_INIT( );
     memset( &rnd_info, 0x2a, sizeof( mbedtls_test_rnd_pseudo_info ) );
+
+    mbedtls_x509write_csr_init( &req );
+
+    USE_PSA_INIT( );
 
     md_alg_psa = mbedtls_hash_info_psa_from_md( (mbedtls_md_type_t) md_type );
     TEST_ASSERT( md_alg_psa != MBEDTLS_MD_NONE );
@@ -204,7 +208,6 @@ void x509_csr_check_opaque( char *key_file, int md_type, int key_usage,
                                             PSA_KEY_USAGE_SIGN_HASH,
                                             PSA_ALG_NONE ) == 0 );
 
-    mbedtls_x509write_csr_init( &req );
     mbedtls_x509write_csr_set_md_alg( &req, md_type );
     mbedtls_x509write_csr_set_key( &req, &key );
     TEST_ASSERT( mbedtls_x509write_csr_set_subject_name( &req, subject_name ) == 0 );


### PR DESCRIPTION
## Description
Steps to reproduce:
```
find . -name seedfile -exec rm {} +
scripts/config.py config full
(cd tests && make test_suite_x509write && ./test_suite_x509write)
```
Observed behaviour: the first few tests fail, then eventually there's a bus error and a core dump is produced. If we just add the seedfile again (`dd if=/dev/urandom of=./tests/seedfile bs=64 count=1`) everything passes and there is no crash.

Cause:
When USE_PSA_INIT() failed because lack of seedfile, `mbedtls_x509write_csr_free()`
crashed when called on an unitialized `mbedtls_x509write_csr` struct.

This moves `mbedtls_x509write_csr_init` before calling USE_PSA_INIT(),
which could probably fail, and use the same flow in `x509_csr_check()`
and `x509_csr_check_opaque()`.

Resolves #6100 

**Gatekeeping note:** I (mpg) think this should be backported to 2.28, but does not deserve a ChangeLog entry, as the bug is only in test code.

## Status
**READY**

## Requires Backporting
Yes 2.28 #6246 

## Migrations
NO

## Additional comments
N/A

## Todos
- [x] Tests

## Steps to test or reproduce
test_suite_x509write must not crash without a seedfile