### PR TITLE
Install .cmake files into libdir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -343,7 +343,7 @@ if(NOT DISABLE_PACKAGE_CONFIG_AND_INSTALL)
     configure_package_config_file(
         "cmake/MbedTLSConfig.cmake.in"
         "cmake/MbedTLSConfig.cmake"
-            INSTALL_DESTINATION "cmake")
+            INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/MbedTLS)
 
     write_basic_package_version_file(
         "cmake/MbedTLSConfigVersion.cmake"
@@ -353,7 +353,7 @@ if(NOT DISABLE_PACKAGE_CONFIG_AND_INSTALL)
     install(
         FILES "${CMAKE_CURRENT_BINARY_DIR}/cmake/MbedTLSConfig.cmake"
               "${CMAKE_CURRENT_BINARY_DIR}/cmake/MbedTLSConfigVersion.cmake"
-        DESTINATION "cmake")
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/MbedTLS)
 
     export(
         EXPORT MbedTLSTargets
@@ -363,7 +363,7 @@ if(NOT DISABLE_PACKAGE_CONFIG_AND_INSTALL)
     install(
         EXPORT MbedTLSTargets
         NAMESPACE MbedTLS::
-        DESTINATION "cmake"
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/MbedTLS
         FILE "MbedTLSTargets.cmake")
 
     if(CMAKE_VERSION VERSION_GREATER 3.15 OR CMAKE_VERSION VERSION_EQUAL 3.15)

--- a/ChangeLog.d/cmake-install.txt
+++ b/ChangeLog.d/cmake-install.txt
@@ -1,0 +1,3 @@
+Changes
+    * Install the .cmake files into CMAKE_INSTALL_LIBDIR/cmake/MbedTLS,
+    typically /usr/lib/cmake/MbedTLS.


### PR DESCRIPTION
Currently the .cmake files (such as MbedTLSConfig.cmake) are installed
to a 'cmake' directory under the prefix, which typically ends up as
/usr/cmake.  This isn't FHS-compliant[1] and every distribution
packaging mbedtls will need to manually move the files.

Instead install the files in a 'cmake' directory under
CMAKE_INSTALL_LIBDIR, which is also on the find_package() search path.

[1] https://refspecs.linuxfoundation.org/FHS_3.0/fhs/index.html

Signed-off-by: Ross Burton <ross.burton@arm.com>