### PR TITLE
Add explicit rule for ssl_server

### DIFF
--- a/programs/Makefile
+++ b/programs/Makefile
@@ -358,6 +358,10 @@ ssl/ssl_server2$(EXEXT): ssl/ssl_server2.c $(SSL_TEST_DEPS)
 	echo "  CC    ssl/ssl_server2.c"
 	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) ssl/ssl_server2.c $(SSL_TEST_OBJECTS) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
+ssl/ssl_server$(EXEXT): ssl/ssl_server.c $(SSL_TEST_DEPS)
+	echo "  CC    ssl/ssl_server.c"
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) ssl/ssl_server.c $(SSL_TEST_OBJECTS) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+
 ssl/ssl_context_info$(EXEXT): ssl/ssl_context_info.c test/query_config.o test/query_config.h $(DEP)
 	echo "  CC    ssl/ssl_context_info.c"
 	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) ssl/ssl_context_info.c test/query_config.o $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@


### PR DESCRIPTION
The Makefile for programs/Makefile is missing a rule for
ssl/ssl_server.c, and it ends up being built with defalut rules.  At
least in one CI environment, this causes this file to be compiled with
a missing include path, and the build fails trying to find build_info.h.

Fix this by adding an explicit rule for the target.

Signed-off-by: David Brown <david.brown@linaro.org>
