### PR TITLE
Extend query_compile_time_config to PSA_WANT_xxx macros

### DIFF
--- a/ChangeLog.d/extend-query_compile_time_config-to-psa_want.txt
+++ b/ChangeLog.d/extend-query_compile_time_config-to-psa_want.txt
@@ -1,0 +1,2 @@
+Changes
+   * Add the ability to query PSA_WANT_xxx macros to query_compile_time_config

--- a/scripts/data_files/query_config.fmt
+++ b/scripts/data_files/query_config.fmt
@@ -30,8 +30,12 @@
 
 /*
  * Include all the headers with public APIs in case they define a macro to its
- * default value when that configuration is not set in the mbedtls_config.h.
+ * default value when that configuration is not set in mbedtls_config.h, or
+ * for PSA_WANT macros, in case they're auto-defined based on mbedtls_config.h
+ * rather than defined directly in crypto_config.h.
  */
+#include "psa/crypto.h"
+
 #include "mbedtls/aes.h"
 #include "mbedtls/aria.h"
 #include "mbedtls/asn1.h"
@@ -89,8 +93,6 @@
 #include "mbedtls/x509_crl.h"
 #include "mbedtls/x509_crt.h"
 #include "mbedtls/x509_csr.h"
-
-#include "psa/crypto_config.h"
 
 #include <string.h>
 

--- a/scripts/data_files/query_config.fmt
+++ b/scripts/data_files/query_config.fmt
@@ -90,6 +90,8 @@
 #include "mbedtls/x509_crt.h"
 #include "mbedtls/x509_csr.h"
 
+#include "psa/crypto_config.h"
+
 #include <string.h>
 
 /*

--- a/scripts/generate_query_config.pl
+++ b/scripts/generate_query_config.pl
@@ -50,7 +50,7 @@ if( @ARGV ) {
     if (defined($psa_crypto_config_file) && length($psa_crypto_config_file)) {
         -f $psa_crypto_config_file or die "No such file: $psa_crypto_config_file";
     } else {
-        $psa_crypto_config_file = (-d $default_psa_crypto_config_file) ? $default_psa_crypto_config_file : undef;
+        $psa_crypto_config_file = (-f $default_psa_crypto_config_file) ? $default_psa_crypto_config_file : undef;
     }
 } else {
     $mbedtls_config_file = $default_mbedtls_config_file;
@@ -89,7 +89,7 @@ for my $config_file ($mbedtls_config_file, $psa_crypto_config_file) {
         if ($line =~ /^(\/\/)?\s*#\s*define\s+(MBEDTLS_\w+|PSA_WANT_\w+).*/) {
             my $name = $2;
 
-            # Skip over the macro if it is in the ecluded list
+            # Skip over the macro if it is in the excluded list
             next if $name =~ /$excluded_re/;
 
             $config_check .= <<EOT;

--- a/scripts/generate_query_config.pl
+++ b/scripts/generate_query_config.pl
@@ -15,7 +15,7 @@
 # function by using the template in scripts/data_files/query_config.fmt.
 #
 # Usage: scripts/generate_query_config.pl without arguments, or
-# generate_query_config.pl config_file template_file output_file
+# generate_query_config.pl mbedtls_config_file template_file output_file
 #
 # Copyright The Mbed TLS Contributors
 # SPDX-License-Identifier: Apache-2.0
@@ -34,22 +34,26 @@
 
 use strict;
 
-my ($config_file, $query_config_format_file, $query_config_file);
+my ($mbedtls_config_file, $query_config_format_file, $query_config_file);
+
+my $default_mbedtls_config_file = "./include/mbedtls/mbedtls_config.h";
+my $default_query_config_format_file = "./scripts/data_files/query_config.fmt";
+my $default_query_config_file = "./programs/test/query_config.c";
 
 if( @ARGV ) {
     die "Invalid number of arguments - usage: $0 [CONFIG_FILE TEMPLATE_FILE OUTPUT_FILE]" if scalar @ARGV != 3;
-    ($config_file, $query_config_format_file, $query_config_file) = @ARGV;
+    ($mbedtls_config_file, $query_config_format_file, $query_config_file) = @ARGV;
 
-    -f $config_file or die "No such file: $config_file";
+    -f $mbedtls_config_file or die "No such file: $mbedtls_config_file";
     -f $query_config_format_file or die "No such file: $query_config_format_file";
 } else {
-    $config_file = "./include/mbedtls/mbedtls_config.h";
-    $query_config_format_file = "./scripts/data_files/query_config.fmt";
-    $query_config_file = "./programs/test/query_config.c";
+    $mbedtls_config_file = $default_mbedtls_config_file;
+    $query_config_format_file = $default_query_config_format_file;
+    $query_config_file = $default_query_config_file;
 
-    unless( -f $config_file && -f $query_config_format_file ) {
+    unless( -f $mbedtls_config_file && -f $query_config_format_file ) {
         chdir '..' or die;
-        -f $config_file && -f $query_config_format_file
+        -f $mbedtls_config_file && -f $query_config_format_file
           or die "No arguments supplied, must be run from project root or a first-level subdirectory\n";
     }
 }
@@ -63,12 +67,12 @@ MBEDTLS_SSL_CIPHERSUITES
 );
 my $excluded_re = join '|', @excluded;
 
-open(CONFIG_FILE, "$config_file") or die "Opening config file '$config_file': $!";
-
 # This variable will contain the string to replace in the CHECK_CONFIG of the
 # format file
 my $config_check = "";
 my $list_config = "";
+
+open(CONFIG_FILE, "<", $mbedtls_config_file) or die "Opening config file '$mbedtls_config_file': $!";
 
 while (my $line = <CONFIG_FILE>) {
     if ($line =~ /^(\/\/)?\s*#\s*define\s+(MBEDTLS_\w+).*/) {
@@ -77,25 +81,31 @@ while (my $line = <CONFIG_FILE>) {
         # Skip over the macro if it is in the ecluded list
         next if $name =~ /$excluded_re/;
 
-        $config_check .= "#if defined($name)\n";
-        $config_check .= "    if( strcmp( \"$name\", config ) == 0 )\n";
-        $config_check .= "    {\n";
-        $config_check .= "        MACRO_EXPANSION_TO_STR( $name );\n";
-        $config_check .= "        return( 0 );\n";
-        $config_check .= "    }\n";
-        $config_check .= "#endif /* $name */\n";
-        $config_check .= "\n";
+        $config_check .= <<EOT;
+#if defined($name)
+    if( strcmp( "$name", config ) == 0 )
+    {
+        MACRO_EXPANSION_TO_STR( $name );
+        return( 0 );
+    }
+#endif /* $name */
 
-        $list_config .= "#if defined($name)\n";
-        $list_config .= "    OUTPUT_MACRO_NAME_VALUE($name);\n";
-        $list_config .= "#endif /* $name */\n";
-        $list_config .= "\n";
+EOT
+
+        $list_config .= <<EOT;
+#if defined($name)
+    OUTPUT_MACRO_NAME_VALUE($name);
+#endif /* $name */
+
+EOT
     }
 }
 
+close(CONFIG_FILE);
+
 # Read the full format file into a string
 local $/;
-open(FORMAT_FILE, "$query_config_format_file") or die "Opening query config format file '$query_config_format_file': $!";
+open(FORMAT_FILE, "<", $query_config_format_file) or die "Opening query config format file '$query_config_format_file': $!";
 my $query_config_format = <FORMAT_FILE>;
 close(FORMAT_FILE);
 
@@ -104,6 +114,6 @@ $query_config_format =~ s/CHECK_CONFIG/$config_check/g;
 $query_config_format =~ s/LIST_CONFIG/$list_config/g;
 
 # Rewrite the query_config.c file
-open(QUERY_CONFIG_FILE, ">$query_config_file") or die "Opening destination file '$query_config_file': $!";
+open(QUERY_CONFIG_FILE, ">", $query_config_file) or die "Opening destination file '$query_config_file': $!";
 print QUERY_CONFIG_FILE $query_config_format;
 close(QUERY_CONFIG_FILE);


### PR DESCRIPTION
## Status
**READY**

## Requires Backporting
**NO** - this is an enhancement 

## Migrations

Note that if `query_compile_time_config` is run with files specified, the PSA config file is an optional additional argument. This will allow existing scripts to continue to function.

## Future Enhancements

Future enhancements could have us using `MBEDTLS_PSA_CRYPTO_CONFIG` and `MBEDTLS_PSA_CRYPTO_CONFIG_FILE`, but let's only add those if found to be necessary.