### PR TITLE
Validation remove change key agree

### DIFF
--- a/library/dhm.c
+++ b/library/dhm.c
@@ -55,11 +55,6 @@
 
 #if !defined(MBEDTLS_DHM_ALT)
 
-#define DHM_VALIDATE_RET( cond )    \
-    MBEDTLS_INTERNAL_VALIDATE_RET( cond, MBEDTLS_ERR_DHM_BAD_INPUT_DATA )
-#define DHM_VALIDATE( cond )        \
-    MBEDTLS_INTERNAL_VALIDATE( cond )
-
 /*
  * helper to validate the mbedtls_mpi size and import it
  */
@@ -120,7 +115,6 @@ cleanup:
 
 void mbedtls_dhm_init( mbedtls_dhm_context *ctx )
 {
-    DHM_VALIDATE( ctx != NULL );
     memset( ctx, 0, sizeof( mbedtls_dhm_context ) );
 }
 
@@ -173,9 +167,6 @@ int mbedtls_dhm_read_params( mbedtls_dhm_context *ctx,
                      const unsigned char *end )
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
-    DHM_VALIDATE_RET( ctx != NULL );
-    DHM_VALIDATE_RET( p != NULL && *p != NULL );
-    DHM_VALIDATE_RET( end != NULL );
 
     if( ( ret = dhm_read_bignum( &ctx->P,  p, end ) ) != 0 ||
         ( ret = dhm_read_bignum( &ctx->G,  p, end ) ) != 0 ||
@@ -252,10 +243,6 @@ int mbedtls_dhm_make_params( mbedtls_dhm_context *ctx, int x_size,
     int ret;
     size_t n1, n2, n3;
     unsigned char *p;
-    DHM_VALIDATE_RET( ctx != NULL );
-    DHM_VALIDATE_RET( output != NULL );
-    DHM_VALIDATE_RET( olen != NULL );
-    DHM_VALIDATE_RET( f_rng != NULL );
 
     ret = dhm_make_common( ctx, x_size, f_rng, p_rng );
     if( ret != 0 )
@@ -300,9 +287,6 @@ int mbedtls_dhm_set_group( mbedtls_dhm_context *ctx,
                            const mbedtls_mpi *G )
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
-    DHM_VALIDATE_RET( ctx != NULL );
-    DHM_VALIDATE_RET( P != NULL );
-    DHM_VALIDATE_RET( G != NULL );
 
     if( ( ret = mbedtls_mpi_copy( &ctx->P, P ) ) != 0 ||
         ( ret = mbedtls_mpi_copy( &ctx->G, G ) ) != 0 )
@@ -320,8 +304,6 @@ int mbedtls_dhm_read_public( mbedtls_dhm_context *ctx,
                      const unsigned char *input, size_t ilen )
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
-    DHM_VALIDATE_RET( ctx != NULL );
-    DHM_VALIDATE_RET( input != NULL );
 
     if( ilen < 1 || ilen > mbedtls_dhm_get_len( ctx ) )
         return( MBEDTLS_ERR_DHM_BAD_INPUT_DATA );
@@ -341,9 +323,6 @@ int mbedtls_dhm_make_public( mbedtls_dhm_context *ctx, int x_size,
                      void *p_rng )
 {
     int ret;
-    DHM_VALIDATE_RET( ctx != NULL );
-    DHM_VALIDATE_RET( output != NULL );
-    DHM_VALIDATE_RET( f_rng != NULL );
 
     if( olen < 1 || olen > mbedtls_dhm_get_len( ctx ) )
         return( MBEDTLS_ERR_DHM_BAD_INPUT_DATA );
@@ -440,9 +419,6 @@ int mbedtls_dhm_calc_secret( mbedtls_dhm_context *ctx,
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     mbedtls_mpi GYb;
-    DHM_VALIDATE_RET( ctx != NULL );
-    DHM_VALIDATE_RET( output != NULL );
-    DHM_VALIDATE_RET( olen != NULL );
 
     if( f_rng == NULL )
         return( MBEDTLS_ERR_DHM_BAD_INPUT_DATA );
@@ -517,9 +493,6 @@ int mbedtls_dhm_parse_dhm( mbedtls_dhm_context *dhm, const unsigned char *dhmin,
 #if defined(MBEDTLS_PEM_PARSE_C)
     mbedtls_pem_context pem;
 #endif /* MBEDTLS_PEM_PARSE_C */
-
-    DHM_VALIDATE_RET( dhm != NULL );
-    DHM_VALIDATE_RET( dhmin != NULL );
 
 #if defined(MBEDTLS_PEM_PARSE_C)
     mbedtls_pem_init( &pem );
@@ -667,8 +640,6 @@ int mbedtls_dhm_parse_dhmfile( mbedtls_dhm_context *dhm, const char *path )
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     size_t n;
     unsigned char *buf;
-    DHM_VALIDATE_RET( dhm != NULL );
-    DHM_VALIDATE_RET( path != NULL );
 
     if( ( ret = load_file( path, &buf, &n ) ) != 0 )
         return( ret );

--- a/library/rsa.c
+++ b/library/rsa.c
@@ -77,19 +77,12 @@
 
 #if !defined(MBEDTLS_RSA_ALT)
 
-/* Parameter validation macros */
-#define RSA_VALIDATE_RET( cond )                                       \
-    MBEDTLS_INTERNAL_VALIDATE_RET( cond, MBEDTLS_ERR_RSA_BAD_INPUT_DATA )
-#define RSA_VALIDATE( cond )                                           \
-    MBEDTLS_INTERNAL_VALIDATE( cond )
-
 int mbedtls_rsa_import( mbedtls_rsa_context *ctx,
                         const mbedtls_mpi *N,
                         const mbedtls_mpi *P, const mbedtls_mpi *Q,
                         const mbedtls_mpi *D, const mbedtls_mpi *E )
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
-    RSA_VALIDATE_RET( ctx != NULL );
 
     if( ( N != NULL && ( ret = mbedtls_mpi_copy( &ctx->N, N ) ) != 0 ) ||
         ( P != NULL && ( ret = mbedtls_mpi_copy( &ctx->P, P ) ) != 0 ) ||
@@ -114,7 +107,6 @@ int mbedtls_rsa_import_raw( mbedtls_rsa_context *ctx,
                             unsigned char const *E, size_t E_len )
 {
     int ret = 0;
-    RSA_VALIDATE_RET( ctx != NULL );
 
     if( N != NULL )
     {
@@ -244,8 +236,6 @@ int mbedtls_rsa_complete( mbedtls_rsa_context *ctx )
 #endif
     int n_missing, pq_missing, d_missing, is_pub, is_priv;
 
-    RSA_VALIDATE_RET( ctx != NULL );
-
     have_N = ( mbedtls_mpi_cmp_int( &ctx->N, 0 ) != 0 );
     have_P = ( mbedtls_mpi_cmp_int( &ctx->P, 0 ) != 0 );
     have_Q = ( mbedtls_mpi_cmp_int( &ctx->Q, 0 ) != 0 );
@@ -348,7 +338,6 @@ int mbedtls_rsa_export_raw( const mbedtls_rsa_context *ctx,
 {
     int ret = 0;
     int is_priv;
-    RSA_VALIDATE_RET( ctx != NULL );
 
     /* Check if key is private or public */
     is_priv =
@@ -393,7 +382,6 @@ int mbedtls_rsa_export( const mbedtls_rsa_context *ctx,
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     int is_priv;
-    RSA_VALIDATE_RET( ctx != NULL );
 
     /* Check if key is private or public */
     is_priv =
@@ -437,7 +425,6 @@ int mbedtls_rsa_export_crt( const mbedtls_rsa_context *ctx,
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     int is_priv;
-    RSA_VALIDATE_RET( ctx != NULL );
 
     /* Check if key is private or public */
     is_priv =
@@ -474,8 +461,6 @@ int mbedtls_rsa_export_crt( const mbedtls_rsa_context *ctx,
  */
 void mbedtls_rsa_init( mbedtls_rsa_context *ctx )
 {
-    RSA_VALIDATE( ctx != NULL );
-
     memset( ctx, 0, sizeof( mbedtls_rsa_context ) );
 
     ctx->padding = MBEDTLS_RSA_PKCS_V15;
@@ -552,8 +537,6 @@ int mbedtls_rsa_gen_key( mbedtls_rsa_context *ctx,
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     mbedtls_mpi H, G, L;
     int prime_quality = 0;
-    RSA_VALIDATE_RET( ctx != NULL );
-    RSA_VALIDATE_RET( f_rng != NULL );
 
     /*
      * If the modulus is 1024 bit long or shorter, then the security strength of
@@ -666,8 +649,6 @@ cleanup:
  */
 int mbedtls_rsa_check_pubkey( const mbedtls_rsa_context *ctx )
 {
-    RSA_VALIDATE_RET( ctx != NULL );
-
     if( rsa_check_context( ctx, 0 /* public */, 0 /* no blinding */ ) != 0 )
         return( MBEDTLS_ERR_RSA_KEY_CHECK_FAILED );
 
@@ -691,8 +672,6 @@ int mbedtls_rsa_check_pubkey( const mbedtls_rsa_context *ctx )
  */
 int mbedtls_rsa_check_privkey( const mbedtls_rsa_context *ctx )
 {
-    RSA_VALIDATE_RET( ctx != NULL );
-
     if( mbedtls_rsa_check_pubkey( ctx ) != 0 ||
         rsa_check_context( ctx, 1 /* private */, 1 /* blinding */ ) != 0 )
     {
@@ -722,9 +701,6 @@ int mbedtls_rsa_check_privkey( const mbedtls_rsa_context *ctx )
 int mbedtls_rsa_check_pub_priv( const mbedtls_rsa_context *pub,
                                 const mbedtls_rsa_context *prv )
 {
-    RSA_VALIDATE_RET( pub != NULL );
-    RSA_VALIDATE_RET( prv != NULL );
-
     if( mbedtls_rsa_check_pubkey( pub )  != 0 ||
         mbedtls_rsa_check_privkey( prv ) != 0 )
     {
@@ -750,9 +726,6 @@ int mbedtls_rsa_public( mbedtls_rsa_context *ctx,
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     size_t olen;
     mbedtls_mpi T;
-    RSA_VALIDATE_RET( ctx != NULL );
-    RSA_VALIDATE_RET( input != NULL );
-    RSA_VALIDATE_RET( output != NULL );
 
     if( rsa_check_context( ctx, 0 /* public */, 0 /* no blinding */ ) )
         return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
@@ -919,10 +892,6 @@ int mbedtls_rsa_private( mbedtls_rsa_context *ctx,
     /* Temporaries holding the initial input and the double
      * checked result; should be the same in the end. */
     mbedtls_mpi I, C;
-
-    RSA_VALIDATE_RET( ctx != NULL );
-    RSA_VALIDATE_RET( input  != NULL );
-    RSA_VALIDATE_RET( output != NULL );
 
     if( f_rng == NULL )
         return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
@@ -1311,11 +1280,6 @@ int mbedtls_rsa_rsaes_oaep_encrypt( mbedtls_rsa_context *ctx,
     unsigned char *p = output;
     unsigned int hlen;
 
-    RSA_VALIDATE_RET( ctx != NULL );
-    RSA_VALIDATE_RET( output != NULL );
-    RSA_VALIDATE_RET( ilen == 0 || input != NULL );
-    RSA_VALIDATE_RET( label_len == 0 || label != NULL );
-
     if( f_rng == NULL )
         return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
 
@@ -1377,10 +1341,6 @@ int mbedtls_rsa_rsaes_pkcs1_v15_encrypt( mbedtls_rsa_context *ctx,
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     unsigned char *p = output;
 
-    RSA_VALIDATE_RET( ctx != NULL );
-    RSA_VALIDATE_RET( output != NULL );
-    RSA_VALIDATE_RET( ilen == 0 || input != NULL );
-
     olen = ctx->len;
 
     /* first comparison checks for overflow */
@@ -1429,10 +1389,6 @@ int mbedtls_rsa_pkcs1_encrypt( mbedtls_rsa_context *ctx,
                        const unsigned char *input,
                        unsigned char *output )
 {
-    RSA_VALIDATE_RET( ctx != NULL );
-    RSA_VALIDATE_RET( output != NULL );
-    RSA_VALIDATE_RET( ilen == 0 || input != NULL );
-
     switch( ctx->padding )
     {
 #if defined(MBEDTLS_PKCS1_V15)
@@ -1471,12 +1427,6 @@ int mbedtls_rsa_rsaes_oaep_decrypt( mbedtls_rsa_context *ctx,
     unsigned char buf[MBEDTLS_MPI_MAX_SIZE];
     unsigned char lhash[HASH_MAX_SIZE];
     unsigned int hlen;
-
-    RSA_VALIDATE_RET( ctx != NULL );
-    RSA_VALIDATE_RET( output_max_len == 0 || output != NULL );
-    RSA_VALIDATE_RET( label_len == 0 || label != NULL );
-    RSA_VALIDATE_RET( input != NULL );
-    RSA_VALIDATE_RET( olen != NULL );
 
     /*
      * Parameters sanity checks
@@ -1598,11 +1548,6 @@ int mbedtls_rsa_rsaes_pkcs1_v15_decrypt( mbedtls_rsa_context *ctx,
     size_t ilen;
     unsigned char buf[MBEDTLS_MPI_MAX_SIZE];
 
-    RSA_VALIDATE_RET( ctx != NULL );
-    RSA_VALIDATE_RET( output_max_len == 0 || output != NULL );
-    RSA_VALIDATE_RET( input != NULL );
-    RSA_VALIDATE_RET( olen != NULL );
-
     ilen = ctx->len;
 
     if( ctx->padding != MBEDTLS_RSA_PKCS_V15 )
@@ -1637,11 +1582,6 @@ int mbedtls_rsa_pkcs1_decrypt( mbedtls_rsa_context *ctx,
                        unsigned char *output,
                        size_t output_max_len)
 {
-    RSA_VALIDATE_RET( ctx != NULL );
-    RSA_VALIDATE_RET( output_max_len == 0 || output != NULL );
-    RSA_VALIDATE_RET( input != NULL );
-    RSA_VALIDATE_RET( olen != NULL );
-
     switch( ctx->padding )
     {
 #if defined(MBEDTLS_PKCS1_V15)
@@ -1679,11 +1619,8 @@ static int rsa_rsassa_pss_sign( mbedtls_rsa_context *ctx,
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     size_t msb;
 
-    RSA_VALIDATE_RET( ctx != NULL );
-    RSA_VALIDATE_RET( ( md_alg  == MBEDTLS_MD_NONE &&
-                        hashlen == 0 ) ||
-                      hash != NULL );
-    RSA_VALIDATE_RET( sig != NULL );
+    if( ( md_alg != MBEDTLS_MD_NONE || hashlen != 0 ) && hash == NULL )
+        return MBEDTLS_ERR_RSA_BAD_INPUT_DATA;
 
     if( ctx->padding != MBEDTLS_RSA_PKCS_V21 )
         return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
@@ -1955,11 +1892,8 @@ int mbedtls_rsa_rsassa_pkcs1_v15_sign( mbedtls_rsa_context *ctx,
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     unsigned char *sig_try = NULL, *verif = NULL;
 
-    RSA_VALIDATE_RET( ctx != NULL );
-    RSA_VALIDATE_RET( ( md_alg  == MBEDTLS_MD_NONE &&
-                        hashlen == 0 ) ||
-                      hash != NULL );
-    RSA_VALIDATE_RET( sig != NULL );
+    if( ( md_alg != MBEDTLS_MD_NONE || hashlen != 0 ) && hash == NULL )
+        return MBEDTLS_ERR_RSA_BAD_INPUT_DATA;
 
     if( ctx->padding != MBEDTLS_RSA_PKCS_V15 )
         return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
@@ -2023,11 +1957,8 @@ int mbedtls_rsa_pkcs1_sign( mbedtls_rsa_context *ctx,
                     const unsigned char *hash,
                     unsigned char *sig )
 {
-    RSA_VALIDATE_RET( ctx != NULL );
-    RSA_VALIDATE_RET( ( md_alg  == MBEDTLS_MD_NONE &&
-                        hashlen == 0 ) ||
-                      hash != NULL );
-    RSA_VALIDATE_RET( sig != NULL );
+    if( ( md_alg != MBEDTLS_MD_NONE || hashlen != 0 ) && hash == NULL )
+        return MBEDTLS_ERR_RSA_BAD_INPUT_DATA;
 
     switch( ctx->padding )
     {
@@ -2069,11 +2000,8 @@ int mbedtls_rsa_rsassa_pss_verify_ext( mbedtls_rsa_context *ctx,
     size_t observed_salt_len, msb;
     unsigned char buf[MBEDTLS_MPI_MAX_SIZE] = {0};
 
-    RSA_VALIDATE_RET( ctx != NULL );
-    RSA_VALIDATE_RET( sig != NULL );
-    RSA_VALIDATE_RET( ( md_alg  == MBEDTLS_MD_NONE &&
-                        hashlen == 0 ) ||
-                      hash != NULL );
+    if( ( md_alg != MBEDTLS_MD_NONE || hashlen != 0 ) && hash == NULL )
+        return MBEDTLS_ERR_RSA_BAD_INPUT_DATA;
 
     siglen = ctx->len;
 
@@ -2168,11 +2096,8 @@ int mbedtls_rsa_rsassa_pss_verify( mbedtls_rsa_context *ctx,
                            const unsigned char *sig )
 {
     mbedtls_md_type_t mgf1_hash_id;
-    RSA_VALIDATE_RET( ctx != NULL );
-    RSA_VALIDATE_RET( sig != NULL );
-    RSA_VALIDATE_RET( ( md_alg  == MBEDTLS_MD_NONE &&
-                        hashlen == 0 ) ||
-                      hash != NULL );
+    if( ( md_alg != MBEDTLS_MD_NONE || hashlen != 0 ) && hash == NULL )
+        return MBEDTLS_ERR_RSA_BAD_INPUT_DATA;
 
     mgf1_hash_id = ( ctx->hash_id != MBEDTLS_MD_NONE )
                              ? (mbedtls_md_type_t) ctx->hash_id
@@ -2201,11 +2126,8 @@ int mbedtls_rsa_rsassa_pkcs1_v15_verify( mbedtls_rsa_context *ctx,
     size_t sig_len;
     unsigned char *encoded = NULL, *encoded_expected = NULL;
 
-    RSA_VALIDATE_RET( ctx != NULL );
-    RSA_VALIDATE_RET( sig != NULL );
-    RSA_VALIDATE_RET( ( md_alg  == MBEDTLS_MD_NONE &&
-                        hashlen == 0 ) ||
-                      hash != NULL );
+    if( ( md_alg != MBEDTLS_MD_NONE || hashlen != 0 ) && hash == NULL )
+        return MBEDTLS_ERR_RSA_BAD_INPUT_DATA;
 
     sig_len = ctx->len;
 
@@ -2270,11 +2192,8 @@ int mbedtls_rsa_pkcs1_verify( mbedtls_rsa_context *ctx,
                       const unsigned char *hash,
                       const unsigned char *sig )
 {
-    RSA_VALIDATE_RET( ctx != NULL );
-    RSA_VALIDATE_RET( sig != NULL );
-    RSA_VALIDATE_RET( ( md_alg  == MBEDTLS_MD_NONE &&
-                        hashlen == 0 ) ||
-                      hash != NULL );
+    if( ( md_alg != MBEDTLS_MD_NONE || hashlen != 0 ) && hash == NULL )
+        return MBEDTLS_ERR_RSA_BAD_INPUT_DATA;
 
     switch( ctx->padding )
     {
@@ -2301,8 +2220,6 @@ int mbedtls_rsa_pkcs1_verify( mbedtls_rsa_context *ctx,
 int mbedtls_rsa_copy( mbedtls_rsa_context *dst, const mbedtls_rsa_context *src )
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
-    RSA_VALIDATE_RET( dst != NULL );
-    RSA_VALIDATE_RET( src != NULL );
 
     dst->len = src->len;
 

--- a/tests/suites/test_suite_rsa.function
+++ b/tests/suites/test_suite_rsa.function
@@ -16,7 +16,6 @@ void rsa_invalid_param( )
     mbedtls_rsa_context ctx;
     const int invalid_padding = 42;
     const int invalid_hash_id = 0xff;
-    const mbedtls_md_type_t md_alg_none = MBEDTLS_MD_NONE;
     unsigned char buf[] = {0x00,0x01,0x02,0x03,0x04,0x05};
     size_t buf_len = sizeof( buf );
 

--- a/tests/suites/test_suite_rsa.function
+++ b/tests/suites/test_suite_rsa.function
@@ -33,13 +33,24 @@ void rsa_invalid_param( )
                 MBEDTLS_ERR_RSA_INVALID_PADDING );
 
     TEST_EQUAL( mbedtls_rsa_pkcs1_sign(&ctx, NULL,
-                                       NULL, md_alg_none,
+                                       NULL, MBEDTLS_MD_NONE,
                                        buf_len,
                                        NULL, buf),
                 MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
 
-    TEST_EQUAL( mbedtls_rsa_pkcs1_verify(&ctx, md_alg_none,
+    TEST_EQUAL( mbedtls_rsa_pkcs1_sign(&ctx, NULL,
+                                       NULL, MBEDTLS_MD_SHA256,
+                                       0,
+                                       NULL, buf),
+                MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
+
+    TEST_EQUAL( mbedtls_rsa_pkcs1_verify(&ctx, MBEDTLS_MD_NONE,
                                          buf_len,
+                                         NULL, buf),
+                MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
+
+    TEST_EQUAL( mbedtls_rsa_pkcs1_verify(&ctx, MBEDTLS_MD_SHA256,
+                                         0,
                                          NULL, buf),
                 MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
 
@@ -52,15 +63,27 @@ void rsa_invalid_param( )
 
 #if defined(MBEDTLS_PKCS1_V15)
     TEST_EQUAL( mbedtls_rsa_rsassa_pkcs1_v15_sign(&ctx, NULL,
-                                              NULL, md_alg_none,
+                                              NULL, MBEDTLS_MD_NONE,
                                               buf_len,
                                               NULL, buf),
                 MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
 
-    TEST_EQUAL( mbedtls_rsa_rsassa_pkcs1_v15_verify(&ctx, md_alg_none,
+    TEST_EQUAL( mbedtls_rsa_rsassa_pkcs1_v15_sign(&ctx, NULL,
+                                              NULL, MBEDTLS_MD_SHA256,
+                                              0,
+                                              NULL, buf),
+                MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
+
+    TEST_EQUAL( mbedtls_rsa_rsassa_pkcs1_v15_verify(&ctx, MBEDTLS_MD_NONE,
                                                 buf_len,
                                                 NULL, buf),
                 MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
+
+    TEST_EQUAL( mbedtls_rsa_rsassa_pkcs1_v15_verify(&ctx, MBEDTLS_MD_SHA256,
+                                                0,
+                                                NULL, buf),
+                MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
+
 
 #endif
 
@@ -73,22 +96,38 @@ void rsa_invalid_param( )
 
 #if defined(MBEDTLS_PKCS1_V21)
     TEST_EQUAL( mbedtls_rsa_rsassa_pss_sign_ext(&ctx, NULL, NULL,
-                                    md_alg_none, buf_len,
+                                    MBEDTLS_MD_NONE, buf_len,
                                     NULL, buf_len,
                                     buf ),
                 MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
 
-    TEST_EQUAL( mbedtls_rsa_rsassa_pss_verify_ext(&ctx, md_alg_none,
+    TEST_EQUAL( mbedtls_rsa_rsassa_pss_sign_ext(&ctx, NULL, NULL,
+                                    MBEDTLS_MD_SHA256, 0,
+                                    NULL, buf_len,
+                                    buf ),
+                MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
+
+    TEST_EQUAL( mbedtls_rsa_rsassa_pss_verify_ext(&ctx, MBEDTLS_MD_NONE,
                                                   buf_len, NULL,
-                                                  md_alg_none,
+                                                  MBEDTLS_MD_NONE,
                                                   buf_len, buf),
                 MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
 
-    TEST_EQUAL( mbedtls_rsa_rsassa_pss_verify(&ctx, md_alg_none,
+    TEST_EQUAL( mbedtls_rsa_rsassa_pss_verify_ext(&ctx, MBEDTLS_MD_SHA256,
+                                                  0, NULL,
+                                                  MBEDTLS_MD_NONE,
+                                                  buf_len, buf),
+                MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
+
+    TEST_EQUAL( mbedtls_rsa_rsassa_pss_verify(&ctx, MBEDTLS_MD_NONE,
                                               buf_len,
                                               NULL, buf),
                 MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
 
+    TEST_EQUAL( mbedtls_rsa_rsassa_pss_verify(&ctx, MBEDTLS_MD_SHA256,
+                                              0,
+                                              NULL, buf),
+                MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
 #endif
 
 exit:

--- a/tests/suites/test_suite_rsa.function
+++ b/tests/suites/test_suite_rsa.function
@@ -16,6 +16,9 @@ void rsa_invalid_param( )
     mbedtls_rsa_context ctx;
     const int invalid_padding = 42;
     const int invalid_hash_id = 0xff;
+    const mbedtls_md_type_t md_alg_none = MBEDTLS_MD_NONE;
+    unsigned char buf[] = {0x00,0x01,0x02,0x03,0x04,0x05};
+    size_t buf_len = sizeof( buf );
 
     mbedtls_rsa_init( &ctx );
 
@@ -29,6 +32,17 @@ void rsa_invalid_param( )
                                          invalid_hash_id ),
                 MBEDTLS_ERR_RSA_INVALID_PADDING );
 
+    TEST_EQUAL( mbedtls_rsa_pkcs1_sign(&ctx, NULL,
+                                       NULL, md_alg_none,
+                                       buf_len,
+                                       NULL, buf),
+                MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
+
+    TEST_EQUAL( mbedtls_rsa_pkcs1_verify(&ctx, md_alg_none,
+                                         buf_len,
+                                         NULL, buf),
+                MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
+
 #if !defined(MBEDTLS_PKCS1_V15)
     TEST_EQUAL( mbedtls_rsa_set_padding( &ctx,
                                          MBEDTLS_RSA_PKCS_V15,
@@ -36,11 +50,45 @@ void rsa_invalid_param( )
                 MBEDTLS_ERR_RSA_INVALID_PADDING );
 #endif
 
+#if defined( MBEDTLS_PKCS1_V15 )
+    TEST_EQUAL( mbedtls_rsa_rsassa_pkcs1_v15_sign(&ctx, NULL,
+                                              NULL, md_alg_none,
+                                              buf_len,
+                                              NULL, buf),
+                MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
+
+    TEST_EQUAL( mbedtls_rsa_rsassa_pkcs1_v15_verify(&ctx, md_alg_none,
+                                                buf_len,
+                                                NULL, buf),
+                MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
+
+#endif
+
 #if !defined(MBEDTLS_PKCS1_V21)
     TEST_EQUAL( mbedtls_rsa_set_padding( &ctx,
                                          MBEDTLS_RSA_PKCS_V21,
                                          MBEDTLS_MD_NONE ),
                 MBEDTLS_ERR_RSA_INVALID_PADDING );
+#endif
+
+#if defined(MBEDTLS_PKCS1_V21)
+    TEST_EQUAL( mbedtls_rsa_rsassa_pss_sign_ext(&ctx, NULL, NULL,
+                                    md_alg_none, buf_len,
+                                    NULL, buf_len,
+                                    buf ),
+                MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
+
+    TEST_EQUAL( mbedtls_rsa_rsassa_pss_verify_ext(&ctx, md_alg_none,
+                                                  buf_len, NULL,
+                                                  md_alg_none,
+                                                  buf_len, buf),
+                MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
+
+    TEST_EQUAL( mbedtls_rsa_rsassa_pss_verify(&ctx, md_alg_none,
+                                              buf_len,
+                                              NULL, buf),
+                MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
+
 #endif
 
 exit:

--- a/tests/suites/test_suite_rsa.function
+++ b/tests/suites/test_suite_rsa.function
@@ -50,7 +50,7 @@ void rsa_invalid_param( )
                 MBEDTLS_ERR_RSA_INVALID_PADDING );
 #endif
 
-#if defined( MBEDTLS_PKCS1_V15 )
+#if defined(MBEDTLS_PKCS1_V15)
     TEST_EQUAL( mbedtls_rsa_rsassa_pkcs1_v15_sign(&ctx, NULL,
                                               NULL, md_alg_none,
                                               buf_len,


### PR DESCRIPTION
## Description

This is part of #4681 
This PR re-introduce enum check in files related to key agreement in library.
Additionally, removes NULL pointer checks ( That is already disabled by #4313 )

## Status
**IN DEVELOPMENT**

## Requires Backporting

NO  

## Migrations

NO


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported
