### PR TITLE
Fix build error due to  missing prototype warning when `MBEDTLS_DEPRECATED_REMOVED` is enabled

### DIFF
--- a/ChangeLog.d/fix_build_error_for_mbedtls_deprecated_removed.txt
+++ b/ChangeLog.d/fix_build_error_for_mbedtls_deprecated_removed.txt
@@ -1,0 +1,3 @@
+Bugfix
+    * Fix build error due to missing prototype
+      warning when MBEDTLS_DEPRECATED_REMOVED is enabled

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -2502,6 +2502,7 @@ void mbedtls_ssl_get_dtls_srtp_negotiation_result( const mbedtls_ssl_context *ss
 }
 #endif /* MBEDTLS_SSL_DTLS_SRTP */
 
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
 void mbedtls_ssl_conf_max_version( mbedtls_ssl_config *conf, int major, int minor )
 {
     conf->max_tls_version = (major << 8) | minor;
@@ -2511,6 +2512,7 @@ void mbedtls_ssl_conf_min_version( mbedtls_ssl_config *conf, int major, int mino
 {
     conf->min_tls_version = (major << 8) | minor;
 }
+#endif /* MBEDTLS_DEPRECATED_REMOVED */
 
 #if defined(MBEDTLS_SSL_SRV_C)
 void mbedtls_ssl_conf_cert_req_ca_list( mbedtls_ssl_config *conf,


### PR DESCRIPTION
## Description
Currently mbedtls fails to build when `MBEDTLS_DEPRECATED_REMOVED` config option is enabled.
Reason: In latest version the function prototypes `mbedtls_ssl_conf_max_version` and `mbedtls_ssl_conf_min_version` from `ssl.h` file were deprecated and added under `MBEDTLS_DEPRECATED_REMOVED` config option. But their respective function declarations were not added under the same config option. While building, `mbedtls/CMakeLists.txt` enables `-Wmissing-prototypes` compile option and thus the build currently fails with following error:

`/Users/flying_raijin/espressif/mbedtls/library/ssl_tls.c:2505:6: error: no previous prototype for function 'mbedtls_ssl_conf_max_version' [-Werror,-Wmissing-prototypes]`

This MR adds those function declarations under respective macro
## Status
**READY**

## Requires Backporting
NO - the bug was introduced in 3.2 and is not present in 2.28.x

## Migrations
If there is any API change, what's the incentive and logic for it.

NO

## Additional comments
Any additional information that could be of interest

## Steps to test or reproduce
This can be reproduced by enabling `MBEDTLS_DEPRECATED_REMOVED` option and trying to build mbedtls.
