### PR TITLE
Validation remove change auth enc

### DIFF
--- a/library/chachapoly.c
+++ b/library/chachapoly.c
@@ -39,12 +39,6 @@
 
 #if !defined(MBEDTLS_CHACHAPOLY_ALT)
 
-/* Parameter validation macros */
-#define CHACHAPOLY_VALIDATE_RET( cond )                                       \
-    MBEDTLS_INTERNAL_VALIDATE_RET( cond, MBEDTLS_ERR_POLY1305_BAD_INPUT_DATA )
-#define CHACHAPOLY_VALIDATE( cond )                                           \
-    MBEDTLS_INTERNAL_VALIDATE( cond )
-
 #define CHACHAPOLY_STATE_INIT       ( 0 )
 #define CHACHAPOLY_STATE_AAD        ( 1 )
 #define CHACHAPOLY_STATE_CIPHERTEXT ( 2 ) /* Encrypting or decrypting */
@@ -91,8 +85,6 @@ static int chachapoly_pad_ciphertext( mbedtls_chachapoly_context *ctx )
 
 void mbedtls_chachapoly_init( mbedtls_chachapoly_context *ctx )
 {
-    CHACHAPOLY_VALIDATE( ctx != NULL );
-
     mbedtls_chacha20_init( &ctx->chacha20_ctx );
     mbedtls_poly1305_init( &ctx->poly1305_ctx );
     ctx->aad_len        = 0U;
@@ -118,8 +110,6 @@ int mbedtls_chachapoly_setkey( mbedtls_chachapoly_context *ctx,
                                const unsigned char key[32] )
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
-    CHACHAPOLY_VALIDATE_RET( ctx != NULL );
-    CHACHAPOLY_VALIDATE_RET( key != NULL );
 
     ret = mbedtls_chacha20_setkey( &ctx->chacha20_ctx, key );
 
@@ -132,8 +122,6 @@ int mbedtls_chachapoly_starts( mbedtls_chachapoly_context *ctx,
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     unsigned char poly1305_key[64];
-    CHACHAPOLY_VALIDATE_RET( ctx != NULL );
-    CHACHAPOLY_VALIDATE_RET( nonce != NULL );
 
     /* Set counter = 0, will be update to 1 when generating Poly1305 key */
     ret = mbedtls_chacha20_starts( &ctx->chacha20_ctx, nonce, 0U );
@@ -170,9 +158,6 @@ int mbedtls_chachapoly_update_aad( mbedtls_chachapoly_context *ctx,
                                    const unsigned char *aad,
                                    size_t aad_len )
 {
-    CHACHAPOLY_VALIDATE_RET( ctx != NULL );
-    CHACHAPOLY_VALIDATE_RET( aad_len == 0 || aad != NULL );
-
     if( ctx->state != CHACHAPOLY_STATE_AAD )
         return( MBEDTLS_ERR_CHACHAPOLY_BAD_STATE );
 
@@ -187,9 +172,6 @@ int mbedtls_chachapoly_update( mbedtls_chachapoly_context *ctx,
                                unsigned char *output )
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
-    CHACHAPOLY_VALIDATE_RET( ctx != NULL );
-    CHACHAPOLY_VALIDATE_RET( len == 0 || input != NULL );
-    CHACHAPOLY_VALIDATE_RET( len == 0 || output != NULL );
 
     if( ( ctx->state != CHACHAPOLY_STATE_AAD ) &&
         ( ctx->state != CHACHAPOLY_STATE_CIPHERTEXT ) )
@@ -237,8 +219,6 @@ int mbedtls_chachapoly_finish( mbedtls_chachapoly_context *ctx,
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     unsigned char len_block[16];
-    CHACHAPOLY_VALIDATE_RET( ctx != NULL );
-    CHACHAPOLY_VALIDATE_RET( mac != NULL );
 
     if( ctx->state == CHACHAPOLY_STATE_INIT )
     {
@@ -314,13 +294,6 @@ int mbedtls_chachapoly_encrypt_and_tag( mbedtls_chachapoly_context *ctx,
                                         unsigned char *output,
                                         unsigned char tag[16] )
 {
-    CHACHAPOLY_VALIDATE_RET( ctx   != NULL );
-    CHACHAPOLY_VALIDATE_RET( nonce != NULL );
-    CHACHAPOLY_VALIDATE_RET( tag   != NULL );
-    CHACHAPOLY_VALIDATE_RET( aad_len == 0 || aad    != NULL );
-    CHACHAPOLY_VALIDATE_RET( length  == 0 || input  != NULL );
-    CHACHAPOLY_VALIDATE_RET( length  == 0 || output != NULL );
-
     return( chachapoly_crypt_and_tag( ctx, MBEDTLS_CHACHAPOLY_ENCRYPT,
                                       length, nonce, aad, aad_len,
                                       input, output, tag ) );
@@ -339,12 +312,6 @@ int mbedtls_chachapoly_auth_decrypt( mbedtls_chachapoly_context *ctx,
     unsigned char check_tag[16];
     size_t i;
     int diff;
-    CHACHAPOLY_VALIDATE_RET( ctx   != NULL );
-    CHACHAPOLY_VALIDATE_RET( nonce != NULL );
-    CHACHAPOLY_VALIDATE_RET( tag   != NULL );
-    CHACHAPOLY_VALIDATE_RET( aad_len == 0 || aad    != NULL );
-    CHACHAPOLY_VALIDATE_RET( length  == 0 || input  != NULL );
-    CHACHAPOLY_VALIDATE_RET( length  == 0 || output != NULL );
 
     if( ( ret = chachapoly_crypt_and_tag( ctx,
                         MBEDTLS_CHACHAPOLY_DECRYPT, length, nonce,

--- a/library/poly1305.c
+++ b/library/poly1305.c
@@ -44,12 +44,6 @@
 #define inline __inline
 #endif
 
-/* Parameter validation macros */
-#define POLY1305_VALIDATE_RET( cond )                                       \
-    MBEDTLS_INTERNAL_VALIDATE_RET( cond, MBEDTLS_ERR_POLY1305_BAD_INPUT_DATA )
-#define POLY1305_VALIDATE( cond )                                           \
-    MBEDTLS_INTERNAL_VALIDATE( cond )
-
 #define POLY1305_BLOCK_SIZE_BYTES ( 16U )
 
 /*
@@ -258,8 +252,6 @@ static void poly1305_compute_mac( const mbedtls_poly1305_context *ctx,
 
 void mbedtls_poly1305_init( mbedtls_poly1305_context *ctx )
 {
-    POLY1305_VALIDATE( ctx != NULL );
-
     mbedtls_platform_zeroize( ctx, sizeof( mbedtls_poly1305_context ) );
 }
 
@@ -274,9 +266,6 @@ void mbedtls_poly1305_free( mbedtls_poly1305_context *ctx )
 int mbedtls_poly1305_starts( mbedtls_poly1305_context *ctx,
                              const unsigned char key[32] )
 {
-    POLY1305_VALIDATE_RET( ctx != NULL );
-    POLY1305_VALIDATE_RET( key != NULL );
-
     /* r &= 0x0ffffffc0ffffffc0ffffffc0fffffff */
     ctx->r[0] = MBEDTLS_GET_UINT32_LE( key, 0 )  & 0x0FFFFFFFU;
     ctx->r[1] = MBEDTLS_GET_UINT32_LE( key, 4 )  & 0x0FFFFFFCU;
@@ -310,8 +299,6 @@ int mbedtls_poly1305_update( mbedtls_poly1305_context *ctx,
     size_t remaining = ilen;
     size_t queue_free_len;
     size_t nblocks;
-    POLY1305_VALIDATE_RET( ctx != NULL );
-    POLY1305_VALIDATE_RET( ilen == 0 || input != NULL );
 
     if( ( remaining > 0U ) && ( ctx->queue_len > 0U ) )
     {
@@ -369,9 +356,6 @@ int mbedtls_poly1305_update( mbedtls_poly1305_context *ctx,
 int mbedtls_poly1305_finish( mbedtls_poly1305_context *ctx,
                              unsigned char mac[16] )
 {
-    POLY1305_VALIDATE_RET( ctx != NULL );
-    POLY1305_VALIDATE_RET( mac != NULL );
-
     /* Process any leftover data */
     if( ctx->queue_len > 0U )
     {
@@ -400,9 +384,6 @@ int mbedtls_poly1305_mac( const unsigned char key[32],
 {
     mbedtls_poly1305_context ctx;
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
-    POLY1305_VALIDATE_RET( key != NULL );
-    POLY1305_VALIDATE_RET( mac != NULL );
-    POLY1305_VALIDATE_RET( ilen == 0 || input != NULL );
 
     mbedtls_poly1305_init( &ctx );
 


### PR DESCRIPTION
## Description

This is part of #4681 
This PR re-introduce enum check in files related to authenticated encryption in library.
Additionally, removes NULL pointer checks ( That is already disabled by #4313 )

## Status
**IN DEVELOPMENT**

## Requires Backporting

NO  

## Migrations

NO


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported
