### PR TITLE
Fix a/an typos in doxygen and other comments

### DIFF
--- a/include/mbedtls/asn1write.h
+++ b/include/mbedtls/asn1write.h
@@ -86,7 +86,7 @@ int mbedtls_asn1_write_raw_buffer( unsigned char **p, const unsigned char *start
 
 #if defined(MBEDTLS_BIGNUM_C)
 /**
- * \brief           Write a arbitrary-precision number (#MBEDTLS_ASN1_INTEGER)
+ * \brief           Write an arbitrary-precision number (#MBEDTLS_ASN1_INTEGER)
  *                  in ASN.1 format.
  *
  * \note            This function works backwards in data buffer.

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -1110,7 +1110,7 @@
  * Include backtrace information with each allocated block.
  *
  * Requires: MBEDTLS_MEMORY_BUFFER_ALLOC_C
- *           GLIBC-compatible backtrace() an backtrace_symbols() support
+ *           GLIBC-compatible backtrace() and backtrace_symbols() support
  *
  * Uncomment this macro to include backtrace information
  */

--- a/include/mbedtls/md.h
+++ b/include/mbedtls/md.h
@@ -199,7 +199,7 @@ MBEDTLS_CHECK_RETURN_TYPICAL
 int mbedtls_md_setup( mbedtls_md_context_t *ctx, const mbedtls_md_info_t *md_info, int hmac );
 
 /**
- * \brief           This function clones the state of an message-digest
+ * \brief           This function clones the state of a message-digest
  *                  context.
  *
  * \note            You must call mbedtls_md_setup() on \c dst before calling

--- a/include/mbedtls/ripemd160.h
+++ b/include/mbedtls/ripemd160.h
@@ -66,7 +66,7 @@ void mbedtls_ripemd160_init( mbedtls_ripemd160_context *ctx );
 void mbedtls_ripemd160_free( mbedtls_ripemd160_context *ctx );
 
 /**
- * \brief          Clone (the state of) an RIPEMD-160 context
+ * \brief          Clone (the state of) a RIPEMD-160 context
  *
  * \param dst      The destination context
  * \param src      The context to be cloned

--- a/include/mbedtls/rsa.h
+++ b/include/mbedtls/rsa.h
@@ -479,7 +479,7 @@ int mbedtls_rsa_check_pubkey( const mbedtls_rsa_context *ctx );
  *             the current function does not have access to them,
  *             and therefore cannot check them. See mbedtls_rsa_complete().
  *             If you want to check the consistency of the entire
- *             content of an PKCS1-encoded RSA private key, for example, you
+ *             content of a PKCS1-encoded RSA private key, for example, you
  *             should use mbedtls_rsa_validate_params() before setting
  *             up the RSA context.
  *             Additionally, if the implementation performs empirical checks,

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -756,7 +756,7 @@ typedef int mbedtls_ssl_recv_timeout_t( void *ctx,
  *                 for the associated \c mbedtls_ssl_get_timer_t callback to
  *                 return correct information.
  *
- * \note           If using a event-driven style of programming, an event must
+ * \note           If using an event-driven style of programming, an event must
  *                 be generated when the final delay is passed. The event must
  *                 cause a call to \c mbedtls_ssl_handshake() with the proper
  *                 SSL context to be scheduled. Care must be taken to ensure

--- a/include/psa/crypto.h
+++ b/include/psa/crypto.h
@@ -545,7 +545,7 @@ psa_status_t psa_copy_key(mbedtls_svc_key_id_t source_key,
  * \retval #PSA_ERROR_INVALID_HANDLE
  *         \p key is not a valid identifier nor \c 0.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
- *         There was an failure in communication with the cryptoprocessor.
+ *         There was a failure in communication with the cryptoprocessor.
  *         The key material may still be present in the cryptoprocessor.
  * \retval #PSA_ERROR_DATA_INVALID
  *         This error is typically a result of either storage corruption on a

--- a/include/psa/crypto_compat.h
+++ b/include/psa/crypto_compat.h
@@ -44,7 +44,7 @@ typedef mbedtls_svc_key_id_t psa_key_handle_t;
 
 #define PSA_KEY_HANDLE_INIT MBEDTLS_SVC_KEY_ID_INIT
 
-/** Check whether an handle is null.
+/** Check whether a handle is null.
  *
  * \param handle  Handle
  *

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -359,7 +359,7 @@ psa_status_t mbedtls_psa_inject_entropy(const uint8_t *seed,
  */
 #define PSA_KEY_TYPE_DSA_KEY_PAIR                    ((psa_key_type_t)0x7002)
 
-/** Whether a key type is an DSA key (pair or public-only). */
+/** Whether a key type is a DSA key (pair or public-only). */
 #define PSA_KEY_TYPE_IS_DSA(type)                                       \
     (PSA_KEY_TYPE_PUBLIC_KEY_OF_KEY_PAIR(type) == PSA_KEY_TYPE_DSA_PUBLIC_KEY)
 
@@ -1287,7 +1287,7 @@ static void psa_pake_cs_set_hash( psa_pake_cipher_suite_t *cipher_suite,
  * Implementation details can change in future versions without notice. */
 typedef struct psa_pake_operation_s psa_pake_operation_t;
 
-/** Return an initial value for an PAKE operation object.
+/** Return an initial value for a PAKE operation object.
  */
 static psa_pake_operation_t psa_pake_operation_init( void );
 

--- a/include/psa/crypto_platform.h
+++ b/include/psa/crypto_platform.h
@@ -57,8 +57,8 @@
  *
  * The function psa_its_identifier_of_slot() in psa_crypto_storage.c that
  * translates a key identifier to a key storage file name assumes that
- * mbedtls_key_owner_id_t is an 32 bits integer. This function thus needs
- * reworking if mbedtls_key_owner_id_t is not defined as a 32 bits integer
+ * mbedtls_key_owner_id_t is a 32-bit integer. This function thus needs
+ * reworking if mbedtls_key_owner_id_t is not defined as a 32-bit integer
  * here anymore.
  */
 typedef int32_t mbedtls_key_owner_id_t;

--- a/include/psa/crypto_se_driver.h
+++ b/include/psa/crypto_se_driver.h
@@ -395,7 +395,7 @@ typedef psa_status_t (*psa_drv_se_cipher_setup_t)(psa_drv_se_context_t *drv_cont
                                                   psa_encrypt_or_decrypt_t direction);
 
 /** \brief A function that sets the initialization vector (if
- * necessary) for an secure element cipher operation
+ * necessary) for a secure element cipher operation
  *
  * Rationale: The `psa_se_cipher_*` operation in the PSA Cryptographic API has
  * two IV functions: one to set the IV, and one to generate it internally. The

--- a/include/psa/crypto_types.h
+++ b/include/psa/crypto_types.h
@@ -105,7 +105,7 @@ typedef uint8_t psa_ecc_family_t;
  * Values of this type are generally constructed by macros called
  * `PSA_DH_FAMILY_xxx`.
  *
- * The group identifier is required to create an Diffie-Hellman key using the
+ * The group identifier is required to create a Diffie-Hellman key using the
  * PSA_KEY_TYPE_DH_KEY_PAIR() or PSA_KEY_TYPE_DH_PUBLIC_KEY()
  * macros.
  *

--- a/include/psa/crypto_values.h
+++ b/include/psa/crypto_values.h
@@ -1265,7 +1265,7 @@
  */
 #define PSA_ALG_CHACHA20_POLY1305               ((psa_algorithm_t)0x05100500)
 
-/* In the encoding of a AEAD algorithm, the bits corresponding to
+/* In the encoding of an AEAD algorithm, the bits corresponding to
  * PSA_ALG_AEAD_TAG_LENGTH_MASK encode the length of the AEAD tag.
  * The constants for default lengths follow this encoding.
  */

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -2803,7 +2803,7 @@ int mbedtls_mpi_gen_prime( mbedtls_mpi *X, size_t nbits, int flags,
         else
         {
             /*
-             * An necessary condition for Y and X = 2Y + 1 to be prime
+             * A necessary condition for Y and X = 2Y + 1 to be prime
              * is X = 2 mod 3 (which is equivalent to Y = 2 mod 3).
              * Make sure it is satisfied, while keeping X = 3 mod 4
              */

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -1469,7 +1469,7 @@ static void *pk_opaque_alloc_wrap( void )
 {
     void *ctx = mbedtls_calloc( 1, sizeof( mbedtls_svc_key_id_t ) );
 
-    /* no _init() function to call, an calloc() already zeroized */
+    /* no _init() function to call, as calloc() already zeroized */
 
     return( ctx );
 }

--- a/library/ssl_tls12_client.c
+++ b/library/ssl_tls12_client.c
@@ -85,7 +85,7 @@ static int ssl_write_renegotiation_ext( mbedtls_ssl_context *ssl,
 
     *olen = 0;
 
-    /* We're always including an TLS_EMPTY_RENEGOTIATION_INFO_SCSV in the
+    /* We're always including a TLS_EMPTY_RENEGOTIATION_INFO_SCSV in the
      * initial ClientHello, in which case also adding the renegotiation
      * info extension is NOT RECOMMENDED as per RFC 5746 Section 3.4. */
     if( ssl->renego_status != MBEDTLS_SSL_RENEGOTIATION_IN_PROGRESS )

--- a/scripts/data_files/error.fmt
+++ b/scripts/data_files/error.fmt
@@ -150,7 +150,7 @@ void mbedtls_strerror( int ret, char *buf, size_t buflen )
 #else /* MBEDTLS_ERROR_C */
 
 /*
- * Provide an non-function in case MBEDTLS_ERROR_C is not defined
+ * Provide a dummy implementation when MBEDTLS_ERROR_C is not defined
  */
 void mbedtls_strerror( int ret, char *buf, size_t buflen )
 {


### PR DESCRIPTION
## Requires Backporting
**Yes** #6143 

No ChangeLog entry, as typos aren't interesting unless they impact semantics, which none of these do.
