### PR TITLE
Fix hash buffer size with macro derived from configuration

### DIFF
--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -6918,12 +6918,13 @@ static void ssl_calc_finished_tls_sha384(
 {
     int len = 12;
     const char *sender;
-    unsigned char padbuf[48];
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
+    unsigned char padbuf[PSA_HASH_MAX_SIZE];
     size_t hash_size;
     psa_hash_operation_t sha384_psa = PSA_HASH_OPERATION_INIT;
     psa_status_t status;
 #else
+    unsigned char padbuf[MBEDTLS_MD_MAX_SIZE];
     mbedtls_sha512_context sha512;
 #endif
 

--- a/library/ssl_tls12_client.c
+++ b/library/ssl_tls12_client.c
@@ -39,7 +39,10 @@
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
 #include "mbedtls/psa_util.h"
 #include "psa/crypto.h"
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
+#define HASH_MAX_SIZE PSA_HASH_MAX_SIZE
+#else
+#define HASH_MAX_SIZE MBEDTLS_MD_MAX_SIZE
+#endif
 
 #include <string.h>
 
@@ -2388,11 +2391,7 @@ start_processing:
     if( mbedtls_ssl_ciphersuite_uses_server_signature( ciphersuite_info ) )
     {
         size_t sig_len, hashlen;
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
-        unsigned char hash[PSA_HASH_MAX_SIZE];
-#else
-        unsigned char hash[MBEDTLS_MD_MAX_SIZE];
-#endif
+        unsigned char hash[HASH_MAX_SIZE];
         mbedtls_md_type_t md_alg = MBEDTLS_MD_NONE;
         mbedtls_pk_type_t pk_alg = MBEDTLS_PK_NONE;
         unsigned char *params = ssl->in_msg + mbedtls_ssl_hs_hdr_len( ssl );
@@ -3360,7 +3359,7 @@ static int ssl_write_certificate_verify( mbedtls_ssl_context *ssl )
     const mbedtls_ssl_ciphersuite_t *ciphersuite_info =
         ssl->handshake->ciphersuite_info;
     size_t n = 0, offset = 0;
-    unsigned char hash[48];
+    unsigned char hash[HASH_MAX_SIZE];
     unsigned char *hash_start = hash;
     mbedtls_md_type_t md_alg = MBEDTLS_MD_NONE;
     size_t hashlen;

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -37,6 +37,12 @@
 #include "constant_time_internal.h"
 #include "mbedtls/constant_time.h"
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+#define HASH_MAX_SIZE PSA_HASH_MAX_SIZE
+#else
+#define HASH_MAX_SIZE MBEDTLS_MD_MAX_SIZE
+#endif
+
 #include <string.h>
 
 #if defined(MBEDTLS_ECP_C)
@@ -3059,11 +3065,7 @@ curve_matching_done:
 
         size_t dig_signed_len = ssl->out_msg + ssl->out_msglen - dig_signed;
         size_t hashlen = 0;
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
-        unsigned char hash[PSA_HASH_MAX_SIZE];
-#else
-        unsigned char hash[MBEDTLS_MD_MAX_SIZE];
-#endif
+        unsigned char hash[HASH_MAX_SIZE];
         int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
 
         /*
@@ -4094,7 +4096,7 @@ static int ssl_parse_certificate_verify( mbedtls_ssl_context *ssl )
 {
     int ret = MBEDTLS_ERR_SSL_FEATURE_UNAVAILABLE;
     size_t i, sig_len;
-    unsigned char hash[48];
+    unsigned char hash[HASH_MAX_SIZE];
     unsigned char *hash_start = hash;
     size_t hashlen;
     mbedtls_pk_type_t pk_alg;


### PR DESCRIPTION
There are two pre-existing macros that define has buffer size
requirement: PSA_HASH_MAX_SIZE and MBEDTLS_MD_MAX_SIZE for
 PSA and legacy cyphers respectfully.  Using one of these macros
 (per configuration) instead of a hard-coded value of '48'.

Note that because SHA512 and SHA384 are co-dependent, the buffer
size will be equal 64 bytes if any of these are enabled or 32 if
the configuration only supports SHA256.

Signed-off-by: Leonid Rozenboim <leonid.rozenboim@oracle.com>

## Description
See  issue #6152 

## Status
**READY**

## Requires Backporting
Yes  

## Migrations

NO

## Additional comments
Issue detected by Coverity static code analysis.

## Todos
- [ ] Backported


## Steps to test or reproduce
Activate SHA512 algo #6152 