### PR TITLE
Add ability to check if any/all configs are enabled/disabled for ssl-opt

### DIFF
--- a/programs/test/query_compile_time_config.c
+++ b/programs/test/query_compile_time_config.c
@@ -32,10 +32,10 @@
     "usage: %s [ -all | -any | -l ] <MBEDTLS_CONFIG> ...\n\n"                   \
     "This program takes command line arguments which correspond to\n"           \
     "the string representation of Mbed TLS compile time configurations.\n\n"    \
-    "If only one argument is available, the value 0 will be returned if\n"      \
-    "this configuration is defined in the Mbed TLS build and the macro\n"       \
-    "expansion of that configuration will be printed (if any). Otherwise,\n"    \
-    " 1 will be returned.\n"                                                    \
+    "If \"--all\" and \"--any\" are not used, then, if all given arguments\n"   \
+    "are defined in the Mbed TLS build, 0 is returned; otherwise 1 is\n"        \
+    "returned. If only one argument is given, the macro expansion of that\n"    \
+    "configuration will be printed (if any).\n"                                 \
     "-l\tPrint all available configuration.\n"                                  \
     "-all\tReturn 0 if all configurations are defined. Otherwise, return 1\n"   \
     "-any\tReturn 0 if any configuration is defined. Otherwise, return 1\n"     \

--- a/programs/test/query_compile_time_config.c
+++ b/programs/test/query_compile_time_config.c
@@ -34,8 +34,7 @@
     "the string representation of Mbed TLS compile time configurations.\n\n"    \
     "If \"--all\" and \"--any\" are not used, then, if all given arguments\n"   \
     "are defined in the Mbed TLS build, 0 is returned; otherwise 1 is\n"        \
-    "returned. If only one argument is given, the macro expansion of that\n"    \
-    "configuration will be printed (if any).\n"                                 \
+    "returned. Macro expansions of configurations will be printed (if any).\n"                                 \
     "-l\tPrint all available configuration.\n"                                  \
     "-all\tReturn 0 if all configurations are defined. Otherwise, return 1\n"   \
     "-any\tReturn 0 if any configuration is defined. Otherwise, return 1\n"     \

--- a/programs/test/query_compile_time_config.c
+++ b/programs/test/query_compile_time_config.c
@@ -28,20 +28,27 @@
 #define MBEDTLS_EXIT_FAILURE EXIT_FAILURE
 #endif
 
-#define USAGE                                                                \
-    "usage: %s [ <MBEDTLS_CONFIG> | -l ]\n\n"                                \
-    "This program takes one command line argument which corresponds to\n"    \
-    "the string representation of a Mbed TLS compile time configuration.\n"  \
-    "The value 0 will be returned if this configuration is defined in the\n" \
-    "Mbed TLS build and the macro expansion of that configuration will be\n" \
-    "printed (if any). Otherwise, 1 will be returned.\n"                     \
-    "-l\tPrint all available configuration.\n"
+#define USAGE                                                                   \
+    "usage: %s [ -all | -any | -l ] <MBEDTLS_CONFIG> ...\n\n"                   \
+    "This program takes command line arguments which correspond to\n"           \
+    "the string representation of Mbed TLS compile time configurations.\n\n"    \
+    "If only one argument is available, the value 0 will be returned if\n"      \
+    "this configuration is defined in the Mbed TLS build and the macro\n"       \
+    "expansion of that configuration will be printed (if any). Otherwise,\n"    \
+    " 1 will be returned.\n"                                                    \
+    "-l\tPrint all available configuration.\n"                                  \
+    "-all\tReturn 0 if all configurations are defined. Otherwise, return 1\n"   \
+    "-any\tReturn 0 if any configuration is defined. Otherwise, return 1\n"     \
+    "-h\tPrint this usage\n"
+
 #include <string.h>
 #include "query_config.h"
 
 int main( int argc, char *argv[] )
 {
-    if ( argc != 2 )
+    int i;
+
+    if ( argc == 1 || strcmp( argv[1], "-h" ) == 0 )
     {
         mbedtls_printf( USAGE, argv[0] );
         return( MBEDTLS_EXIT_FAILURE );
@@ -53,5 +60,31 @@ int main( int argc, char *argv[] )
         return( 0 );
     }
 
-    return( query_config( argv[1] ) );
+    if( strcmp( argv[1], "-all" ) == 0 )
+    {
+        for( i = 2; i < argc; i++ )
+        {
+            if( query_config( argv[i] ) != 0 )
+                return( 1 );
+        }
+        return( 0 );
+    }
+
+    if( strcmp( argv[1], "-any" ) == 0 )
+    {
+        for( i = 2; i < argc; i++ )
+        {
+            if( query_config( argv[i] ) == 0 )
+                return( 0 );
+        }
+        return( 1 );
+    }
+
+    for( i = 1; i < argc; i++ )
+    {
+        if( query_config( argv[i] ) != 0 )
+            return( 1 );
+    }
+
+    return( 0 );
 }

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -223,6 +223,34 @@ requires_config_disabled() {
     esac
 }
 
+requires_all_configs_enabled() {
+    if ! $P_QUERY -all $*
+    then
+        SKIP_NEXT="YES"
+    fi
+}
+
+requires_all_configs_disabled() {
+    if $P_QUERY -any $*
+    then
+        SKIP_NEXT="YES"
+    fi
+}
+
+requires_any_configs_enabled() {
+    if ! $P_QUERY -any $*
+    then
+        SKIP_NEXT="YES"
+    fi
+}
+
+requires_any_configs_disabled() {
+    if $P_QUERY -all $*
+    then
+        SKIP_NEXT="YES"
+    fi
+}
+
 get_config_value_or_default() {
     # This function uses the query_config command line option to query the
     # required Mbed TLS compile time configuration from the ssl_server2

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -874,12 +874,12 @@ wait_client_done() {
     ( sleep $CLI_DELAY; echo "===CLIENT_TIMEOUT===" >> $CLI_OUT; kill $CLI_PID ) &
     DOG_PID=$!
 
-    wait $CLI_PID
+    # For Ubuntu 22.04, `Terminated` message is outputed by wait command.
+    # To remove it from stdout, redirect stdout/stderr to CLI_OUT
+    wait $CLI_PID >> $CLI_OUT 2>&1
     CLI_EXIT=$?
 
     kill $DOG_PID >/dev/null 2>&1
-    # For Ubuntu 22.04, `Terminated` message is outputed by wait command.
-    # To remove it from stdout, redirect stdout/stderr to CLI_OUT
     wait $DOG_PID >> $CLI_OUT 2>&1
 
     echo "EXIT: $CLI_EXIT" >> $CLI_OUT
@@ -1230,7 +1230,9 @@ do_run_test_once() {
 
     # terminate the server (and the proxy)
     kill $SRV_PID
-    wait $SRV_PID
+    # For Ubuntu 22.04, `Terminated` message is outputed by wait command.
+    # To remove it from stdout, redirect stdout/stderr to CLI_OUT
+    wait $SRV_PID >> $SRV_OUT 2>&1
     SRV_RET=$?
 
     if [ -n "$PXY_CMD" ]; then

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -1259,7 +1259,7 @@ do_run_test_once() {
     # terminate the server (and the proxy)
     kill $SRV_PID
     # For Ubuntu 22.04, `Terminated` message is outputed by wait command.
-    # To remove it from stdout, redirect stdout/stderr to CLI_OUT
+    # To remove it from stdout, redirect stdout/stderr to SRV_OUT
     wait $SRV_PID >> $SRV_OUT 2>&1
     SRV_RET=$?
 


### PR DESCRIPTION
## Description

This is for checking `MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED` which is not defined in `mbedtls_config.h` . #6135 will use it . 

Beside that, it also includes a fix for removing output message in Ubuntu22.04.

## Status
**READY**

