### PR TITLE
Backport 2.28: Fix typographical errors in .md files found by cspell

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,4 +1,4 @@
-## Reporting Vulneratibilities
+## Reporting Vulnerabilities
 
 If you think you have found an Mbed TLS security vulnerability, then please
 send an email to the security team at

--- a/docs/architecture/psa-crypto-implementation-structure.md
+++ b/docs/architecture/psa-crypto-implementation-structure.md
@@ -1,4 +1,4 @@
-PSA Cryptograpy API implementation and PSA driver interface
+PSA Cryptography API implementation and PSA driver interface
 ===========================================================
 
 ## Introduction

--- a/docs/proposed/psa-driver-interface.md
+++ b/docs/proposed/psa-driver-interface.md
@@ -237,7 +237,7 @@ The entry points that implement each step of a multi-part operation are grouped 
 1. The core calls the `xxx_setup` entry point for this operation family. If this fails, the core destroys the operation context object without calling any other driver entry point on it.
 1. The core calls other entry points that manipulate the operation context object, respecting the constraints.
 1. If any entry point fails, the core calls the driver's `xxx_abort` entry point for this operation family, then destroys the operation context object without calling any other driver entry point on it.
-1. If a “finish” entry point fails, the core destroys the operation context object without calling any other driver entry point on it. The finish entry points are: *prefix*`_mac_sign_finish`, *prefix*`_mac_verify_finish`, *prefix*`_cipher_fnish`, *prefix*`_aead_finish`, *prefix*`_aead_verify`.
+1. If a “finish” entry point fails, the core destroys the operation context object without calling any other driver entry point on it. The finish entry points are: *prefix*`_mac_sign_finish`, *prefix*`_mac_verify_finish`, *prefix*`_cipher_finish`, *prefix*`_aead_finish`, *prefix*`_aead_verify`.
 
 If a driver implements a multi-part operation but not the corresponding single-part operation, the core calls the driver's multipart operation entry points to perform the single-part operation.
 

--- a/tests/git-scripts/README.md
+++ b/tests/git-scripts/README.md
@@ -1,16 +1,16 @@
 README for git hooks script
 ===========================
 git has a way to run scripts, which are invoked by specific git commands.
-The git hooks are located in `<mbed TLS root>/.git/hooks`, and as such are not under version control
+The git hooks are located in `<Mbed TLS root>/.git/hooks`, and as such are not under version control
 for more information, see the [git documentation](https://git-scm.com/docs/githooks).
 
-The mbed TLS git hooks are located in `<mbed TLS root>/tests/git-scripts` directory, and one must create a soft link from `<mbed TLS root>/.git/hooks` to `<mbed TLS root>/tesst/git-scripts`, in order to make the hook scripts successfully work.
+The Mbed TLS git hooks are located in `<Mbed TLS root>/tests/git-scripts` directory, and one must create a soft link from `<Mbed TLS root>/.git/hooks` to `<Mbed TLS root>/tests/git-scripts`, in order to make the hook scripts successfully work.
 
 Example:
 
-Execute the following command to create a link on linux from the mbed TLS `.git/hooks` directory:  
+Execute the following command to create a link on Linux from the Mbed TLS `.git/hooks` directory:  
 `ln -s ../../tests/git-scripts/pre-push.sh pre-push`
 
-**Note: Currently the mbed TLS git hooks work only on a GNU platform. If using a non-GNU platform, don't enable these hooks!**
+**Note: Currently the Mbed TLS git hooks work only on a GNU platform. If using a non-GNU platform, don't enable these hooks!**
 
 These scripts can also be used independently.


### PR DESCRIPTION
Backport of #6159
