### PR TITLE
Backport 2.28: x509_crt: handle properly broken links when looking for certificates

### DIFF
--- a/ChangeLog.d/x509-broken-symlink-handling.txt
+++ b/ChangeLog.d/x509-broken-symlink-handling.txt
@@ -1,0 +1,5 @@
+Bugfix
+   * Fix handling of broken symlinks when loading certificates using
+     mbedtls_x509_crt_parse_path(). Instead of returning an error as soon as a
+     broken link is encountered, skip the broken link and continue parsing
+     other certificate files. Contributed by Eduardo Silva in #2602.

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -1641,7 +1641,7 @@ cleanup:
         }
         else
         {
-            /* determinate if the file entry could be a link, using lstat(2)
+            /* Determine if the file entry could be a link. Using lstat(2)
              * is safer than just stat(2), otherwise a broken link will
              * give us a false positive. */
             if( lstat( entry_name, &sb ) == -1 )
@@ -1650,13 +1650,12 @@ cleanup:
                 goto cleanup;
             }
 
-            /* if the file is a symbolic link, we need to validate the real
+            /* If the file is a symbolic link, we need to validate the real
              * information using stat(2). */
             if( S_ISLNK( sb.st_mode ) )
             {
-                /* if stat(2) fails it could be a broken link or a generic
-                 * error, if the link is broken, just report it as a
-                 * certificate that could not be processed, otherwise
+                /* If stat(2) fails it could be a broken link or a generic
+                 * error. If the link is broken, ignore it, otherwise
                  * just set a MBEDTLS_ERR_X509_FILE_IO_ERROR. */
                 if( stat( entry_name, &sb ) == -1 )
                 {

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -1662,8 +1662,8 @@ cleanup:
                 {
                     if( errno == ENOENT )
                     {
-                        /* Broken link */
-                        ret++;
+                        /* Broken link - ignore this entry */
+                        continue;
                     }
                     else
                     {

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -77,6 +77,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <dirent.h>
+#include <errno.h>
 #endif /* !_WIN32 || EFIX64 || EFI32 */
 #endif
 
@@ -1638,10 +1639,39 @@ cleanup:
             ret = MBEDTLS_ERR_X509_BUFFER_TOO_SMALL;
             goto cleanup;
         }
-        else if( stat( entry_name, &sb ) == -1 )
+        else
         {
-            ret = MBEDTLS_ERR_X509_FILE_IO_ERROR;
-            goto cleanup;
+            /* determinate if the file entry could be a link, using lstat(2)
+             * is safer than just stat(2), otherwise a broken link will
+             * give us a false positive. */
+            if( lstat( entry_name, &sb ) == -1 )
+            {
+                ret = MBEDTLS_ERR_X509_FILE_IO_ERROR;
+                goto cleanup;
+            }
+
+            /* if the file is a symbolic link, we need to validate the real
+             * information using stat(2). */
+            if( S_ISLNK( sb.st_mode ) )
+            {
+                /* if stat(2) fails it could be a broken link or a generic
+                 * error, if the link is broken, just report it as a
+                 * certificate that could not be processed, otherwise
+                 * just set a MBEDTLS_ERR_X509_FILE_IO_ERROR. */
+                if( stat( entry_name, &sb ) == -1 )
+                {
+                    if( errno == ENOENT )
+                    {
+                        /* Broken link */
+                        ret++;
+                    }
+                    else
+                    {
+                        ret = MBEDTLS_ERR_X509_FILE_IO_ERROR;
+                        goto cleanup;
+                    }
+                }
+            }
         }
 
         if( !S_ISREG( sb.st_mode ) )


### PR DESCRIPTION
Almost trivial backport of #2602 