### PR TITLE
Avoid use of MD in X.509 write test suite

### DIFF
--- a/tests/suites/test_suite_x509write.function
+++ b/tests/suites/test_suite_x509write.function
@@ -34,8 +34,7 @@ size_t mbedtls_rsa_key_len_func( void *ctx )
     defined(MBEDTLS_PEM_WRITE_C) && defined(MBEDTLS_X509_CSR_WRITE_C)
 static int x509_crt_verifycsr( const unsigned char *buf, size_t buflen )
 {
-    unsigned char hash[MBEDTLS_MD_MAX_SIZE];
-    const mbedtls_md_info_t *md_info;
+    unsigned char hash[PSA_HASH_MAX_SIZE];
     mbedtls_x509_csr csr;
     int ret = 0;
 
@@ -47,8 +46,12 @@ static int x509_crt_verifycsr( const unsigned char *buf, size_t buflen )
         goto cleanup;
     }
 
-    md_info = mbedtls_md_info_from_type( csr.sig_md );
-    if( mbedtls_md( md_info, csr.cri.p, csr.cri.len, hash ) != 0 )
+    psa_algorithm_t psa_alg = mbedtls_hash_info_psa_from_md( csr.sig_md );
+    size_t hash_size = 0;
+    psa_status_t status = psa_hash_compute( psa_alg, csr.cri.p, csr.cri.len,
+                                            hash, PSA_HASH_MAX_SIZE, &hash_size );
+
+    if( status != PSA_SUCCESS )
     {
         /* Note: this can't happen except after an internal error */
         ret = MBEDTLS_ERR_X509_BAD_INPUT_DATA;
@@ -56,7 +59,7 @@ static int x509_crt_verifycsr( const unsigned char *buf, size_t buflen )
     }
 
     if( mbedtls_pk_verify_ext( csr.sig_pk, csr.sig_opts, &csr.pk,
-                       csr.sig_md, hash, mbedtls_md_get_size( md_info ),
+                       csr.sig_md, hash, mbedtls_hash_info_get_size( csr.sig_md ),
                        csr.sig.p, csr.sig.len ) != 0 )
     {
         ret = MBEDTLS_ERR_X509_CERT_VERIFY_FAILED;


### PR DESCRIPTION
## Description
test_suite_x509write: use psa_hash_compute() instead mbedtls_md().

## Status
**READY**

## Requires Backporting
NO  
## Migrations
NO
