### PR TITLE
Fix incorrect use of mbedtls_ecp_group_id in test_suite_ssl.function

### DIFF
--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -5735,10 +5735,10 @@ void conf_curve()
                                           MBEDTLS_ECP_DP_SECP224R1,
                                           MBEDTLS_ECP_DP_SECP256R1,
                                           MBEDTLS_ECP_DP_NONE };
-    mbedtls_ecp_group_id iana_tls_group_list[] = { MBEDTLS_SSL_IANA_TLS_GROUP_SECP192R1,
-                                         MBEDTLS_SSL_IANA_TLS_GROUP_SECP224R1,
-                                         MBEDTLS_SSL_IANA_TLS_GROUP_SECP256R1,
-                                         MBEDTLS_SSL_IANA_TLS_GROUP_NONE };
+    uint16_t iana_tls_group_list[] = { MBEDTLS_SSL_IANA_TLS_GROUP_SECP192R1,
+                                       MBEDTLS_SSL_IANA_TLS_GROUP_SECP224R1,
+                                       MBEDTLS_SSL_IANA_TLS_GROUP_SECP256R1,
+                                       MBEDTLS_SSL_IANA_TLS_GROUP_NONE };
 
     mbedtls_ssl_config conf;
     mbedtls_ssl_config_init( &conf );


### PR DESCRIPTION
`MBEDTLS_SSL_IANA_TLS_GROUP_SECP192R1` and friends are not members of the `mbedtls_ecp_group_id` enum

Found by clang's -Wassign-enum

Signed-off-by: Tom Cosgrove <tom.cosgrove@arm.com>

## Status
**READY**

## Requires Backporting

**NO** (not applicable to 2.28)
