### PR TITLE
Adjust hash dependencies in `test_suite_ecdsa`

### DIFF
--- a/tests/suites/test_suite_ecdsa.function
+++ b/tests/suites/test_suite_ecdsa.function
@@ -1,5 +1,10 @@
 /* BEGIN_HEADER */
 #include "mbedtls/ecdsa.h"
+#include "legacy_or_psa.h"
+#if ( defined(MBEDTLS_ECDSA_DETERMINISTIC) && defined(MBEDTLS_SHA256_C) ) || \
+    ( !defined(MBEDTLS_ECDSA_DETERMINISTIC) && defined(MBEDTLS_HAS_ALG_SHA_256_VIA_LOWLEVEL_OR_PSA) )
+#define MBEDTLS_HAS_ALG_SHA_256_VIA_MD_IF_DETERMINISTIC
+#endif
 /* END_HEADER */
 
 /* BEGIN_DEPENDENCIES
@@ -224,7 +229,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_SHA256_C */
+/* BEGIN_CASE depends_on:MBEDTLS_HAS_ALG_SHA_256_VIA_MD_IF_DETERMINISTIC */
 void ecdsa_write_read_zero( int id )
 {
     mbedtls_ecdsa_context ctx;
@@ -284,7 +289,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_SHA256_C */
+/* BEGIN_CASE depends_on:MBEDTLS_HAS_ALG_SHA_256_VIA_MD_IF_DETERMINISTIC */
 void ecdsa_write_read_random( int id )
 {
     mbedtls_ecdsa_context ctx;

--- a/tests/suites/test_suite_ecdsa.function
+++ b/tests/suites/test_suite_ecdsa.function
@@ -5,6 +5,7 @@
     ( !defined(MBEDTLS_ECDSA_DETERMINISTIC) && defined(MBEDTLS_HAS_ALG_SHA_256_VIA_LOWLEVEL_OR_PSA) )
 #define MBEDTLS_HAS_ALG_SHA_256_VIA_MD_IF_DETERMINISTIC
 #endif
+#define MBEDTLS_TEST_HASH_MAX_SIZE 64
 /* END_HEADER */
 
 /* BEGIN_DEPENDENCIES
@@ -19,7 +20,7 @@ void ecdsa_prim_zero( int id )
     mbedtls_ecp_point Q;
     mbedtls_mpi d, r, s;
     mbedtls_test_rnd_pseudo_info rnd_info;
-    unsigned char buf[MBEDTLS_MD_MAX_SIZE];
+    unsigned char buf[MBEDTLS_TEST_HASH_MAX_SIZE];
 
     mbedtls_ecp_group_init( &grp );
     mbedtls_ecp_point_init( &Q );
@@ -51,7 +52,7 @@ void ecdsa_prim_random( int id )
     mbedtls_ecp_point Q;
     mbedtls_mpi d, r, s;
     mbedtls_test_rnd_pseudo_info rnd_info;
-    unsigned char buf[MBEDTLS_MD_MAX_SIZE];
+    unsigned char buf[MBEDTLS_TEST_HASH_MAX_SIZE];
 
     mbedtls_ecp_group_init( &grp );
     mbedtls_ecp_point_init( &Q );


### PR DESCRIPTION
Only deterministic tests require SHA256 now.
Fixes https://github.com/Mbed-TLS/mbedtls/issues/6126