### PR TITLE
ssl_tls12_server: fix potential NULL-dereferencing if local certifica…

### DIFF
--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -3405,8 +3405,14 @@ static int ssl_decrypt_encrypted_pms( mbedtls_ssl_context *ssl,
                                       size_t peer_pmssize )
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
+
+    mbedtls_x509_crt *own_cert = mbedtls_ssl_own_cert( ssl );
+    if( own_cert == NULL ) {
+        MBEDTLS_SSL_DEBUG_MSG( 1, ( "got no local certificate" ) );
+        return( MBEDTLS_ERR_SSL_NO_CLIENT_CERTIFICATE );
+    }
+    mbedtls_pk_context *public_key = &own_cert->pk;
     mbedtls_pk_context *private_key = mbedtls_ssl_own_key( ssl );
-    mbedtls_pk_context *public_key = &mbedtls_ssl_own_cert( ssl )->pk;
     size_t len = mbedtls_pk_get_len( public_key );
 
 #if defined(MBEDTLS_SSL_ASYNC_PRIVATE)


### PR DESCRIPTION

## Description
fix potential NULL-dereferencing if local certificate was not set.

See #6183 

## Status
READY

## Requires Backporting
 NO  

## Migrations
NO

