### PR TITLE
ssl_tls: avoid the appearance of a potential NULL dereferencing

### DIFF
--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -7282,7 +7282,7 @@ static tls_prf_fn ssl_tls12prf_from_cs( int ciphersuite_id )
     const mbedtls_ssl_ciphersuite_t * const ciphersuite_info =
          mbedtls_ssl_ciphersuite_from_id( ciphersuite_id );
 
-    if( ciphersuite_info->mac == MBEDTLS_MD_SHA384 )
+    if( ciphersuite_info != NULL && ciphersuite_info->mac == MBEDTLS_MD_SHA384 )
         return( tls_prf_sha384 );
 #else
     (void) ciphersuite_id;


### PR DESCRIPTION
Looking at the bigger picture it is clear that if `ssl->session` is NULL,
there will be a failure much earlier, and that is well protected from,
however, the practice of dereferencing a pointer which has not been
verified in prior for validity goes against secure coding practices.

## Description
See #6183 

## Status
READY

## Requires Backporting
NO  

## Migrations
 NO