### PR TITLE
Copy files instead of hard-linking on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,37 +120,32 @@ endif()
 
 # Create a symbolic link from ${base_name} in the binary directory
 # to the corresponding path in the source directory.
+# Note: Copies the file(s) on Windows.
 function(link_to_source base_name)
-    # Get OS dependent path to use in `execute_process`
-    if (CMAKE_HOST_WIN32)
-        #mklink is an internal command of cmd.exe it can only work with \
-        string(REPLACE "/" "\\" link "${CMAKE_CURRENT_BINARY_DIR}/${base_name}")
-        string(REPLACE "/" "\\" target "${CMAKE_CURRENT_SOURCE_DIR}/${base_name}")
-    else()
-        set(link "${CMAKE_CURRENT_BINARY_DIR}/${base_name}")
-        set(target "${CMAKE_CURRENT_SOURCE_DIR}/${base_name}")
-    endif()
+    set(link "${CMAKE_CURRENT_BINARY_DIR}/${base_name}")
+    set(target "${CMAKE_CURRENT_SOURCE_DIR}/${base_name}")
 
     # Linking to non-existent file is not desirable. At best you will have a
     # dangling link, but when building in tree, this can create a symbolic link
     # to itself.
     if (EXISTS ${target} AND NOT EXISTS ${link})
         if (CMAKE_HOST_UNIX)
-            set(command ln -s ${target} ${link})
+            execute_process(COMMAND ln -s ${target} ${link}
+                RESULT_VARIABLE result
+                ERROR_VARIABLE output)
+
+            if (NOT ${result} EQUAL 0)
+                message(FATAL_ERROR "Could not create symbolic link for: ${target} --> ${output}")
+            endif()
         else()
             if (IS_DIRECTORY ${target})
-                set(command cmd.exe /c mklink /j ${link} ${target})
+                file(GLOB_RECURSE files FOLLOW_SYMLINKS LIST_DIRECTORIES false RELATIVE ${target} "${target}/*")
+                foreach(file IN LISTS files)
+                    configure_file("${target}/${file}" "${link}/${file}" COPYONLY)
+                endforeach(file)
             else()
-                set(command cmd.exe /c mklink /h ${link} ${target})
+                configure_file(${target} ${link} COPYONLY)
             endif()
-        endif()
-
-        execute_process(COMMAND ${command}
-            RESULT_VARIABLE result
-            ERROR_VARIABLE output)
-
-        if (NOT ${result} EQUAL 0)
-            message(FATAL_ERROR "Could not create symbolic link for: ${target} --> ${output}")
         endif()
     endif()
 endfunction(link_to_source)

--- a/ChangeLog.d/fix_hard_link_across_drives
+++ b/ChangeLog.d/fix_hard_link_across_drives
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix a build issue on Windows where the source and build directory could not be on
+     different drives (#5751).


### PR DESCRIPTION
## Description

Fixes an issue on Windows where when the source and build directory are on different drives hard-linking to files or directory fails as it doesn't work across filesystem boundaries. 
Note also that symlinking is also not possible because it requires administrator privileges on Windows.

~~The solution copies the files using the built-in cmake `file(COPY)` command.~~
The solution copies the files using the built-in cmake `configure_file(src dest COPYONLY)` command.
As this command only operates on files, if a directory is specified the files will be globbed recursively
and through symlinks.

## Status

**READY**

## Additional comments

Fixes #5751

## Todos

- [x] Changelog updated
