### PR TITLE
ctr_drbg: fix free uninitialized aes context

### DIFF
--- a/ChangeLog.d/fix-ctr-drbg-may-free-invalid-aes-context.txt
+++ b/ChangeLog.d/fix-ctr-drbg-may-free-invalid-aes-context.txt
@@ -1,0 +1,4 @@
+Bugfix
+    * Fix mbedtls_ctr_drbg_free() on an initialized but unseeded context. When
+      MBEDTLS_AES_ALT is enabled, it could call mbedtls_aes_free() on an
+      uninitialized context.

--- a/library/ctr_drbg.c
+++ b/library/ctr_drbg.c
@@ -51,6 +51,7 @@
 void mbedtls_ctr_drbg_init( mbedtls_ctr_drbg_context *ctx )
 {
     memset( ctx, 0, sizeof( mbedtls_ctr_drbg_context ) );
+    mbedtls_aes_init( &ctx->aes_ctx );
     /* Indicate that the entropy nonce length is not set explicitly.
      * See mbedtls_ctr_drbg_set_nonce_len(). */
     ctx->reseed_counter = -1;

--- a/library/ctr_drbg.c
+++ b/library/ctr_drbg.c
@@ -449,8 +449,6 @@ int mbedtls_ctr_drbg_seed( mbedtls_ctr_drbg_context *ctx,
     mbedtls_mutex_init( &ctx->mutex );
 #endif
 
-    mbedtls_aes_init( &ctx->aes_ctx );
-
     ctx->f_entropy = f_entropy;
     ctx->p_entropy = p_entropy;
 


### PR DESCRIPTION
## Description
Application may enabled `AES_ALT` and define `mbedtls_aes_context` by its own.
The initial state of user-defined `mbedtls_aes_context` may not all byte zero.

In `mbedtls_ctr_drbg_init`, the code set all byte to zero, including the AES
context nested in the ctr_drbg context.

And in `mbedtls_ctr_drbg_free`, the code calls `mbedtls_aes_free` on an AES
context without calling `mbedtls_aes_init`.

If user-defined AES context requires an non-zero init, the `mbedtls_aes_free`
call in `mbedtls_ctr_drbg_free` is illegal.

This patch fix this issue by add `mbedtls_aes_init` in `mbedtls_ctr_drbg_init`.

So aes context will always be initialized to correct state.


## Status
READY

## Requires Backporting
Yes  
mbedtls-2.28

## Migrations
NO

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
1. Define `AES_ALT` in `config.h`
2. implement AES byself:
   *  Adding a `fd` field to aes context
   * in mbedtls_aes_init, set fd to `-1`
   * in mbedtls_aes_free, if `fd >= 0` close fd
3. call mbedtls_ctr_drbg_init to initialize a ctr_drbg context.
4. call mbedtls_ctr_drbg_free to free the context.
5. Standard input (fd = 0) is closed unexpectedly.