### PR TITLE
Fix CRL with critical extension can't be loaded

### DIFF
--- a/include/mbedtls/x509_crl.h
+++ b/include/mbedtls/x509_crl.h
@@ -163,13 +163,16 @@ typedef int (*mbedtls_x509_crl_ext_cb_t)( void *p_ctx,
  * \param buf      buffer holding the CRL data in PEM or DER format
  * \param buflen   size of the buffer
  *                 (including the terminating null byte for PEM data)
+ * \param cb       A callback invoked for every unsupported certificate
+ *                 extension.
+ * \param p_ctx    An opaque context passed to the callback.
  *
  * \return         0 if successful, or a specific X509 or PEM error code
  */
-int mbedtls_x509_crl_parse_with_cb_ext( mbedtls_x509_crl *chain, 
-                                        const unsigned char *buf, 
-                                        size_t buflen, 
-                                        mbedtls_x509_crl_ext_cb_t cb, 
+int mbedtls_x509_crl_parse_with_cb_ext( mbedtls_x509_crl *chain,
+                                        const unsigned char *buf,
+                                        size_t buflen,
+                                        mbedtls_x509_crl_ext_cb_t cb,
                                         void* p_ctx);
 
 /**

--- a/include/mbedtls/x509_crl.h
+++ b/include/mbedtls/x509_crl.h
@@ -148,7 +148,7 @@ int mbedtls_x509_crl_parse_der( mbedtls_x509_crl *chain,
  * \return         A negative error code on failure.
  */
 typedef int (*mbedtls_x509_crl_ext_cb_t)( void *p_ctx,
-                                          mbedtls_x509_crl const *crt,
+                                          mbedtls_x509_crl const *crl,
                                           mbedtls_x509_buf const *oid,
                                           int critical,
                                           const unsigned char *p,

--- a/include/mbedtls/x509_crl.h
+++ b/include/mbedtls/x509_crl.h
@@ -118,6 +118,60 @@ mbedtls_x509_crl;
  */
 int mbedtls_x509_crl_parse_der( mbedtls_x509_crl *chain,
                         const unsigned char *buf, size_t buflen );
+
+/**
+ * \brief          The type of CRL extension callbacks.
+ *
+ *                 Callbacks of this type are passed to and used by the
+ *                 mbedtls_x509_crl_parse_der_with_ext_cb() routine when
+ *                 it encounters either an unsupported extension.
+ *                 Future versions of the library may invoke the callback
+ *                 in other cases, if and when the need arises.
+ *
+ * \param p_ctx    An opaque context passed to the callback.
+ * \param crl      The CRL being parsed.
+ * \param oid      The OID of the extension.
+ * \param critical Whether the extension is critical.
+ * \param p        Pointer to the start of the extension value
+ *                 (the content of the OCTET STRING).
+ * \param end      End of extension value.
+ *
+ * \note           The callback must fail and return a negative error code
+ *                 if it can not parse or does not support the extension.
+ *                 When the callback fails to parse a critical extension
+ *                 mbedtls_x509_crl_parse_der_with_ext_cb() also fails.
+ *                 When the callback fails to parse a non critical extension
+ *                 mbedtls_x509_crl_parse_der_with_ext_cb() simply skips
+ *                 the extension and continues parsing.
+ *
+ * \return         \c 0 on success.
+ * \return         A negative error code on failure.
+ */
+typedef int (*mbedtls_x509_crl_ext_cb_t)( void *p_ctx,
+                                          mbedtls_x509_crl const *crt,
+                                          mbedtls_x509_buf const *oid,
+                                          int critical,
+                                          const unsigned char *p,
+                                          const unsigned char *end );
+
+/**
+ * \brief          Parse one or more CRLs and append them to the chained list
+ *
+ * \note           Multiple CRLs are accepted only if using PEM format
+ *
+ * \param chain    points to the start of the chain
+ * \param buf      buffer holding the CRL data in PEM or DER format
+ * \param buflen   size of the buffer
+ *                 (including the terminating null byte for PEM data)
+ *
+ * \return         0 if successful, or a specific X509 or PEM error code
+ */
+int mbedtls_x509_crl_parse_with_cb_ext( mbedtls_x509_crl *chain, 
+                                        const unsigned char *buf, 
+                                        size_t buflen, 
+                                        mbedtls_x509_crl_ext_cb_t cb, 
+                                        void* p_ctx);
+
 /**
  * \brief          Parse one or more CRLs and append them to the chained list
  *

--- a/library/x509_crl.c
+++ b/library/x509_crl.c
@@ -311,9 +311,9 @@ static int x509_get_entries( unsigned char **p,
  * Parse one  CRLs in DER format and append it to the chained list
  */
 static int mbedtls_x509_crl_parse_der_internal( mbedtls_x509_crl *chain,
-                                                const unsigned char *buf, 
-                                                size_t buflen, 
-                                                mbedtls_x509_crl_ext_cb_t cb, 
+                                                const unsigned char *buf,
+                                                size_t buflen,
+                                                mbedtls_x509_crl_ext_cb_t cb,
                                                 void* p_ctx)
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
@@ -562,10 +562,10 @@ int mbedtls_x509_crl_parse_der(mbedtls_x509_crl *chain,
  * Parse one or more CRLs and add them to the chained list
  * support callback
  */
-int mbedtls_x509_crl_parse_with_cb_ext( mbedtls_x509_crl *chain, 
-                                        const unsigned char *buf, 
+int mbedtls_x509_crl_parse_with_cb_ext( mbedtls_x509_crl *chain,
+                                        const unsigned char *buf,
                                         size_t buflen,
-                                        mbedtls_x509_crl_ext_cb_t cb, 
+                                        mbedtls_x509_crl_ext_cb_t cb,
                                         void* p_ctx)
 {
 #if defined(MBEDTLS_PEM_PARSE_C)

--- a/programs/x509/crl_app.c
+++ b/programs/x509/crl_app.c
@@ -57,6 +57,33 @@ int main( void )
     "    filename=%%s         default: crl.pem\n"      \
     "\n"
 
+int app_mbedtls_x509_crl_ext_cb(void* p_ctx,
+    mbedtls_x509_crl const* crl,
+    mbedtls_x509_buf const* oid,
+    int critical,
+    const unsigned char* p,
+    const unsigned char* end)
+{
+    return 0;
+}
+
+int app_x509_crl_parse_file(mbedtls_x509_crl* chain, const char* path)
+{
+    int ret;
+    size_t n;
+    unsigned char* buf;
+
+    if ((ret = mbedtls_pk_load_file(path, &buf, &n)) != 0)
+        return(ret);
+
+    ret = mbedtls_x509_crl_parse_with_cb_ext(chain, buf, n, app_mbedtls_x509_crl_ext_cb, NULL);
+
+    mbedtls_platform_zeroize(buf, n);
+    mbedtls_free(buf);
+
+    return(ret);
+}
+
 
 /*
  * global options
@@ -108,15 +135,23 @@ int main( int argc, char *argv[] )
     mbedtls_printf( "\n  . Loading the CRL ..." );
     fflush( stdout );
 
+#if 0
     ret = mbedtls_x509_crl_parse_file( &crl, opt.filename );
-
     if( ret != 0 )
     {
         mbedtls_printf( " failed\n  !  mbedtls_x509_crl_parse_file returned %d\n\n", ret );
         mbedtls_x509_crl_free( &crl );
         goto exit;
     }
-
+#else
+    ret = app_x509_crl_parse_file( &crl, opt.filename );
+    if( ret != 0 )
+    {
+        mbedtls_printf( " failed\n  !  app_x509_crl_parse_file returned %d\n\n", ret );
+        mbedtls_x509_crl_free( &crl );
+        goto exit;
+    }
+#endif
     mbedtls_printf( " ok\n" );
 
     /*

--- a/programs/x509/crl_app.c
+++ b/programs/x509/crl_app.c
@@ -64,6 +64,12 @@ int app_mbedtls_x509_crl_ext_cb(void* p_ctx,
     const unsigned char* p,
     const unsigned char* end)
 {
+    ((void) p_ctx);
+    ((void) crl);
+    ((void) oid);
+    ((void) critical);
+    ((void) p);
+    ((void) end);
     return 0;
 }
 

--- a/tests/suites/test_suite_x509parse.data
+++ b/tests/suites/test_suite_x509parse.data
@@ -266,6 +266,14 @@ X509 CRL Unsupported critical extension (issuingDistributionPoint)
 depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_RSA_C:MBEDTLS_SHA256_C
 mbedtls_x509_crl_parse:"data_files/crl-idp.pem":MBEDTLS_ERR_X509_INVALID_EXTENSIONS + MBEDTLS_ERR_ASN1_UNEXPECTED_TAG
 
+X509 CRL Unsupported critical extension recognized by callback (issuingDistributionPoint)
+depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_RSA_C:MBEDTLS_SHA256_C
+mbedtls_x509_crl_parse_cb_recognized:"data_files/crl-idp.pem":0
+
+X509 CRL Unsupported critical extension not recognized by callback (issuingDistributionPoint)
+depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_RSA_C:MBEDTLS_SHA256_C
+mbedtls_x509_crl_parse_cb_not_recognized:"data_files/crl-idp.pem":MBEDTLS_ERR_X509_INVALID_EXTENSIONS + MBEDTLS_ERR_ASN1_UNEXPECTED_TAG
+
 X509 CRL Unsupported non-critical extension (issuingDistributionPoint)
 depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_RSA_C:MBEDTLS_SHA256_C
 mbedtls_x509_crl_parse:"data_files/crl-idpnc.pem":0

--- a/tests/suites/test_suite_x509parse.function
+++ b/tests/suites/test_suite_x509parse.function
@@ -393,6 +393,27 @@ int parse_crt_ext_cb( void *p_ctx, mbedtls_x509_crt const *crt, mbedtls_x509_buf
         return( MBEDTLS_ERROR_ADD( MBEDTLS_ERR_X509_INVALID_EXTENSIONS,
                                    MBEDTLS_ERR_ASN1_UNEXPECTED_TAG ) );
 }
+
+int parse_crl_ext_cb_recognized(void* p_ctx,
+    mbedtls_x509_crl const* crl,
+    mbedtls_x509_buf const* oid,
+    int critical,
+    const unsigned char* p,
+    const unsigned char* end)
+{
+    return 0;
+}
+
+int parse_crl_ext_cb_not_recognized(void* p_ctx,
+    mbedtls_x509_crl const* crl,
+    mbedtls_x509_buf const* oid,
+    int critical,
+    const unsigned char* p,
+    const unsigned char* end)
+{
+    return MBEDTLS_ERR_X509_INVALID_EXTENSIONS + MBEDTLS_ERR_ASN1_UNEXPECTED_TAG;
+}
+
 #endif /* MBEDTLS_X509_CRT_PARSE_C */
 /* END_HEADER */
 
@@ -516,6 +537,46 @@ void mbedtls_x509_crl_parse( char * crl_file, int result )
 
 exit:
     mbedtls_x509_crl_free( &crl );
+}
+/* END_CASE */
+
+/* BEGIN_CASE depends_on:MBEDTLS_FS_IO:MBEDTLS_X509_CRL_PARSE_C */
+void mbedtls_x509_crl_parse_cb_recognized( char * crl_file, int result )
+{
+    mbedtls_x509_crl   crl;
+    size_t n;
+    char *buf = NULL;
+
+    mbedtls_x509_crl_init( &crl );
+
+    TEST_ASSERT( mbedtls_pk_load_file(crl_file, &buf, &n) == 0 );
+
+    TEST_ASSERT( mbedtls_x509_crl_parse_with_cb_ext( &crl, buf, n, parse_crl_ext_cb_recognized, NULL ) == result );
+
+exit:
+    mbedtls_x509_crl_free( &crl );
+    if (buf)
+        mbedtls_free(buf);
+}
+/* END_CASE */
+
+/* BEGIN_CASE depends_on:MBEDTLS_FS_IO:MBEDTLS_X509_CRL_PARSE_C */
+void mbedtls_x509_crl_parse_cb_not_recognized( char * crl_file, int result )
+{
+    mbedtls_x509_crl   crl;
+    size_t n;
+    char *buf = NULL;
+
+    mbedtls_x509_crl_init( &crl );
+
+    TEST_ASSERT( mbedtls_pk_load_file(crl_file, &buf, &n) == 0 );
+
+    TEST_ASSERT( mbedtls_x509_crl_parse_with_cb_ext( &crl, buf, n, parse_crl_ext_cb_not_recognized, NULL ) == result );
+
+exit:
+    mbedtls_x509_crl_free( &crl );
+    if (buf)
+        mbedtls_free(buf);
 }
 /* END_CASE */
 

--- a/tests/suites/test_suite_x509parse.function
+++ b/tests/suites/test_suite_x509parse.function
@@ -401,6 +401,12 @@ int parse_crl_ext_cb_recognized(void* p_ctx,
     const unsigned char* p,
     const unsigned char* end)
 {
+    ((void) p_ctx);
+    ((void) crl);
+    ((void) oid);
+    ((void) critical);
+    ((void) p);
+    ((void) end);
     return 0;
 }
 
@@ -411,6 +417,12 @@ int parse_crl_ext_cb_not_recognized(void* p_ctx,
     const unsigned char* p,
     const unsigned char* end)
 {
+    ((void) p_ctx);
+    ((void) crl);
+    ((void) oid);
+    ((void) critical);
+    ((void) p);
+    ((void) end);
     return MBEDTLS_ERR_X509_INVALID_EXTENSIONS + MBEDTLS_ERR_ASN1_UNEXPECTED_TAG;
 }
 
@@ -545,7 +557,7 @@ void mbedtls_x509_crl_parse_cb_recognized( char * crl_file, int result )
 {
     mbedtls_x509_crl   crl;
     size_t n;
-    char *buf = NULL;
+    unsigned char *buf = NULL;
 
     mbedtls_x509_crl_init( &crl );
 
@@ -565,7 +577,7 @@ void mbedtls_x509_crl_parse_cb_not_recognized( char * crl_file, int result )
 {
     mbedtls_x509_crl   crl;
     size_t n;
-    char *buf = NULL;
+    unsigned char *buf = NULL;
 
     mbedtls_x509_crl_init( &crl );
 


### PR DESCRIPTION
## Description
**Ticket #6175**
I added the function mbedtls_x509_crl_parse_with_cb_ext() that uses a mbedtls_x509_crl_ext_cb_t type callback to parse the CRL extensions.
The principle and the integration are similar to the CRT version.

## Status
**READY**

## Requires Backporting
No current API changed.
Full backward compatible.

## Migrations
No current API changed.
Full backward compatible.

## Additional comments
Based on the master branch because need to have an improvement of a stable version of mbedtls.

## Todos
- [ ] Tests
- [ ] Documentation
- [x] Changelog updated
- [ ] Backported

## Steps to test or reproduce
Load a CRL with critical extension like *tests/data_files/crl-idp.pem*.
