### PR TITLE
Fix type used for capturing TLS ticket generation time

### DIFF
--- a/include/mbedtls/ssl_ticket.h
+++ b/include/mbedtls/ssl_ticket.h
@@ -33,7 +33,10 @@
 
 #include "mbedtls/ssl.h"
 #include "mbedtls/cipher.h"
+
+#if defined(MBEDTLS_HAVE_TIME)
 #include "mbedtls/platform_time.h"
+#endif
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
 #include "psa/crypto.h"
@@ -57,7 +60,9 @@ typedef struct mbedtls_ssl_ticket_key
 {
     unsigned char MBEDTLS_PRIVATE(name)[MBEDTLS_SSL_TICKET_KEY_NAME_BYTES];
                                                      /*!< random key identifier              */
+#if defined(MBEDTLS_HAVE_TIME)
     mbedtls_time_t MBEDTLS_PRIVATE(generation_time); /*!< key generation timestamp (seconds) */
+#endif
 #if !defined(MBEDTLS_USE_PSA_CRYPTO)
     mbedtls_cipher_context_t MBEDTLS_PRIVATE(ctx);   /*!< context for auth enc/decryption    */
 #else

--- a/include/mbedtls/ssl_ticket.h
+++ b/include/mbedtls/ssl_ticket.h
@@ -33,6 +33,7 @@
 
 #include "mbedtls/ssl.h"
 #include "mbedtls/cipher.h"
+#include "mbedtls/platform_time.h"
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
 #include "psa/crypto.h"
@@ -56,7 +57,7 @@ typedef struct mbedtls_ssl_ticket_key
 {
     unsigned char MBEDTLS_PRIVATE(name)[MBEDTLS_SSL_TICKET_KEY_NAME_BYTES];
                                                      /*!< random key identifier              */
-    uint32_t MBEDTLS_PRIVATE(generation_time);       /*!< key generation timestamp (seconds) */
+    mbedtls_time_t MBEDTLS_PRIVATE(generation_time); /*!< key generation timestamp (seconds) */
 #if !defined(MBEDTLS_USE_PSA_CRYPTO)
     mbedtls_cipher_context_t MBEDTLS_PRIVATE(ctx);   /*!< context for auth enc/decryption    */
 #else

--- a/library/ssl_ticket.c
+++ b/library/ssl_ticket.c
@@ -130,7 +130,7 @@ static int ssl_ticket_update_keys( mbedtls_ssl_ticket_context *ctx )
 #endif
 
         if( current_time >= key_time &&
-            current_time - key_time < ctx->ticket_lifetime )
+            (uint64_t) ( current_time - key_time ) < ctx->ticket_lifetime )
         {
             return( 0 );
         }

--- a/library/ssl_ticket.c
+++ b/library/ssl_ticket.c
@@ -79,7 +79,7 @@ static int ssl_ticket_gen_key( mbedtls_ssl_ticket_context *ctx,
 #endif
 
 #if defined(MBEDTLS_HAVE_TIME)
-    key->generation_time = (uint32_t) mbedtls_time( NULL );
+    key->generation_time = mbedtls_time( NULL );
 #endif
 
     if( ( ret = ctx->f_rng( ctx->p_rng, key->name, sizeof( key->name ) ) ) != 0 )
@@ -122,8 +122,8 @@ static int ssl_ticket_update_keys( mbedtls_ssl_ticket_context *ctx )
 #else
     if( ctx->ticket_lifetime != 0 )
     {
-        uint32_t current_time = (uint32_t) mbedtls_time( NULL );
-        uint32_t key_time = ctx->keys[ctx->active].generation_time;
+        mbedtls_time_t current_time = mbedtls_time( NULL );
+        mbedtls_time_t key_time = ctx->keys[ctx->active].generation_time;
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
         psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
@@ -204,7 +204,7 @@ int mbedtls_ssl_ticket_rotate( mbedtls_ssl_ticket_context *ctx,
     ctx->ticket_lifetime = lifetime;
     memcpy( key->name, name, TICKET_KEY_NAME_BYTES );
 #if defined(MBEDTLS_HAVE_TIME)
-    key->generation_time = (uint32_t) mbedtls_time( NULL );
+    key->generation_time = mbedtls_time( NULL );
 #endif
     return 0;
 }


### PR DESCRIPTION
Address Coverity warnings

Changelog not required IMO - the bug is a non-issue until 2038.

Backport not required: 2.28 will be out of support in 2038, and the fix is an API break.