### PR TITLE
TLS without MD - compat.sh addition to all.sh hash acceleration tests

### DIFF
--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1889,6 +1889,7 @@ component_test_psa_crypto_config_accel_hash_use_psa () {
 
     msg "test: MBEDTLS_PSA_CRYPTO_CONFIG with accelerated hash and USE_PSA"
     make test
+    tests/compat.sh
 }
 
 component_test_psa_crypto_config_accel_cipher () {


### PR DESCRIPTION
**Gatekeeping notes:**
- no backport - this is a new feature
- no ChangeLog entry - a grouped one will be added later, see #6146 

This PR is a follow-up for https://github.com/Mbed-TLS/mbedtls/pull/6208 and should report any issues from compat.sh.
An additional component was temporarily added to all.sh:
```
    scripts/config.py -f include/psa/crypto_config.h unset PSA_WANT_ALG_STREAM_CIPHER
    scripts/config.py -f include/psa/crypto_config.h unset PSA_WANT_ALG_ECB_NO_PADDING

    scripts/config.py set MBEDTLS_PSA_CRYPTO_CONFIG
    scripts/config.py set MBEDTLS_USE_PSA_CRYPTO
 
    # Also unset MD_C and things that depend on it;
    # see component_test_crypto_full_no_md.
    scripts/config.py unset MBEDTLS_HKDF_C
    scripts/config.py unset MBEDTLS_HMAC_DRBG_C
    scripts/config.py unset MBEDTLS_ECDSA_DETERMINISTIC
    scripts/config.py -f include/psa/crypto_config.h unset PSA_WANT_ALG_DETERMINISTIC_ECDSA
    # TLS 1.3 currently depends on SHA256_C || SHA384_C
    # but is already disabled in the default config
  
    make CFLAGS="$ASAN_CFLAGS -Werror" LDFLAGS="$ASAN_CFLAGS" all

    msg "test: MBEDTLS_PSA_CRYPTO_CONFIG with USE_PSA for comparison"
    make test
    tests/compat.sh
```
The `compat.sh` results were the same for this component and `psa_crypto_config_accel_hash_use_psa`:
`PASSED (1428 / 1428 tests (2 skipped))`.
Skipped:
```
[2022-09-03T11:37:28.459Z] m->O dtls12,yes TLS-PSK-WITH-AES-128-CBC-SHA ........................... SKIP
[2022-09-03T11:37:28.459Z] m->O dtls12,yes TLS-PSK-WITH-AES-256-CBC-SHA ........................... SKIP
```
Logs can be accessed [here ](https://ci.trustedfirmware.org/blue/organizations/jenkins/mbed-tls-pr-merge/detail/PR-6216-merge/6/pipeline/329) and [here](https://ci.trustedfirmware.org/blue/organizations/jenkins/mbed-tls-pr-merge/detail/PR-6216-merge/6/pipeline/328/).
Fixes https://github.com/Mbed-TLS/mbedtls/issues/6129.