### PR TITLE
Show line numbers in unit test logs

### DIFF
--- a/tests/scripts/generate_test_code.py
+++ b/tests/scripts/generate_test_code.py
@@ -689,8 +689,8 @@ def parse_test_data(data_f):
             continue
 
         if state == __state_read_name:
-            # Read test name
-            name = line
+            # Read test name and prepend source line number for easy lookup
+            name = '%05u %s' % (data_f.line_no, line)
             state = __state_read_args
         elif state == __state_read_args:
             # Check dependencies

--- a/tests/suites/host_test.function
+++ b/tests/suites/host_test.function
@@ -640,11 +640,11 @@ int execute_tests( int argc , const char ** argv )
 
             if( ( ret = get_line( file, buf, sizeof(buf) ) ) != 0 )
                 break;
-            mbedtls_fprintf( stdout, "%s%.66s",
+            mbedtls_fprintf( stdout, "%s%.72s",
                     mbedtls_test_info.result == MBEDTLS_TEST_RESULT_FAILED ?
                     "\n" : "", buf );
             mbedtls_fprintf( stdout, " " );
-            for( i = strlen( buf ) + 1; i < 67; i++ )
+            for( i = strlen( buf ) + 1; i <= 72; i++ )
                 mbedtls_fprintf( stdout, "." );
             mbedtls_fprintf( stdout, " " );
             fflush( stdout );


### PR DESCRIPTION
In the verbose output from unit tests, show the line number for each test case (specifically the line number in the `.data` file where the test case description is). This helps quickly look up a test case from the logs, without having to compare the whole line (and hope that the 66-character truncation isn't ambiguous).

It would be just as easy to use consecutive test case numbers (1 for the first test case, 2 for the second one, etc.). I used line numbers because they make it easier to locate a test case, without having any editor automation. [I don't personally mind editor automation though](https://github.com/Mbed-TLS/mbedtls-docs/blob/main/tools/emacs/mbedtls-test-data-mode.el).

For `ssl-opt.sh`, it's impossible to do something similar for two reasons: there's no portable way to find the source line from which a function was invoked in portable sh (but we could do it if we switched to bash); and some test cases are invoked from the same source location of a `run_test` call, called in a loop or via an auxiliary function. But you can already run `ssl-opt.sh -s` to show test case numbers, in order of execution, with excluded test cases skipped in the numbering.

This is a proposed solution for https://github.com/Mbed-TLS/mbedtls/issues/6227.
