### PR TITLE
Bignum: extract core_sub_int from the prototype

### DIFF
--- a/library/bignum.c
+++ b/library/bignum.c
@@ -968,17 +968,15 @@ int mbedtls_mpi_sub_abs( mbedtls_mpi *X, const mbedtls_mpi *A, const mbedtls_mpi
     carry = mbedtls_mpi_core_sub( X->p, A->p, B->p, n );
     if( carry != 0 )
     {
-        /* Propagate the carry to the first nonzero limb of X. */
-        for( ; n < X->n && X->p[n] == 0; n++ )
-            --X->p[n];
-        /* If we ran out of space for the carry, it means that the result
-         * is negative. */
-        if( n == X->n )
+        /* Propagate the carry through the rest of X. */
+        carry = mbedtls_mpi_core_sub_int( X->p + n, X->p + n, carry, X->n - n );
+
+        /* If we have further carry/borrow, the result is negative. */
+        if( carry != 0 )
         {
             ret = MBEDTLS_ERR_MPI_NEGATIVE_VALUE;
             goto cleanup;
         }
-        --X->p[n];
     }
 
     /* X should always be positive as a result of unsigned subtractions. */

--- a/library/bignum_core.c
+++ b/library/bignum_core.c
@@ -590,16 +590,17 @@ cleanup:
 
 /* BEGIN MERGE SLOT 3 */
 
-mbedtls_mpi_uint MPI_CORE(sub_int)( mbedtls_mpi_uint *d,
-                                    const mbedtls_mpi_uint *l,
-                                    mbedtls_mpi_uint c, size_t n )
+mbedtls_mpi_uint mbedtls_mpi_core_sub_int( mbedtls_mpi_uint *X,
+                                           const mbedtls_mpi_uint *A,
+                                           mbedtls_mpi_uint c, /* doubles as carry */
+                                           size_t limbs )
 {
-    for( size_t i = 0; i < n; i++ )
+    for( size_t i = 0; i < limbs; i++ )
     {
-        mbedtls_mpi_uint s, t;
-        s = l[i];
-        t = s - c; c = ( t > s );
-        d[i] = t;
+        mbedtls_mpi_uint s = A[i];
+        mbedtls_mpi_uint t = s - c;
+        c = ( t > s );
+        X[i] = t;
     }
 
     return( c );

--- a/library/bignum_core.c
+++ b/library/bignum_core.c
@@ -590,6 +590,21 @@ cleanup:
 
 /* BEGIN MERGE SLOT 3 */
 
+mbedtls_mpi_uint MPI_CORE(sub_int)( mbedtls_mpi_uint *d,
+                                    const mbedtls_mpi_uint *l,
+                                    mbedtls_mpi_uint c, size_t n )
+{
+    for( size_t i = 0; i < n; i++ )
+    {
+        mbedtls_mpi_uint s, t;
+        s = l[i];
+        t = s - c; c = ( t > s );
+        d[i] = t;
+    }
+
+    return( c );
+}
+
 /* END MERGE SLOT 3 */
 
 /* BEGIN MERGE SLOT 4 */

--- a/library/bignum_core.h
+++ b/library/bignum_core.h
@@ -504,23 +504,22 @@ int mbedtls_mpi_core_fill_random( mbedtls_mpi_uint *X, size_t X_limbs,
 
 /* BEGIN MERGE SLOT 3 */
 
-#define MPI_CORE(func) mbedtls_mpi_core_ ## func ## _minimal
-
 /**
  * \brief Subtract unsigned integer from known-size large unsigned integers.
  *        Return the borrow.
  *
- * \param[out] d        The result of the subtraction.
- * \param[in] l         The left operand.
- * \param[in] r         The unsigned scalar to subtract.
- * \param n             Number of limbs of \p d and \p l.
+ * \param[out] X    The result of the subtraction.
+ * \param[in] A     The left operand.
+ * \param b         The unsigned scalar to subtract.
+ * \param limbs     Number of limbs of \p X and \p A.
  *
- * \return              1 if `l < r`.
- *                      0 if `l >= r`.
+ * \return          1 if `A < b`.
+ *                  0 if `A >= b`.
  */
-mbedtls_mpi_uint MPI_CORE(sub_int)( mbedtls_mpi_uint *d,
-                                    const mbedtls_mpi_uint *l,
-                                    mbedtls_mpi_uint r, size_t n );
+mbedtls_mpi_uint mbedtls_mpi_core_sub_int( mbedtls_mpi_uint *X,
+                                           const mbedtls_mpi_uint *A,
+                                           mbedtls_mpi_uint b,
+                                           size_t limbs );
 
 /* END MERGE SLOT 3 */
 

--- a/library/bignum_core.h
+++ b/library/bignum_core.h
@@ -504,6 +504,24 @@ int mbedtls_mpi_core_fill_random( mbedtls_mpi_uint *X, size_t X_limbs,
 
 /* BEGIN MERGE SLOT 3 */
 
+#define MPI_CORE(func) mbedtls_mpi_core_ ## func ## _minimal
+
+/**
+ * \brief Subtract unsigned integer from known-size large unsigned integers.
+ *        Return the borrow.
+ *
+ * \param[out] d        The result of the subtraction.
+ * \param[in] l         The left operand.
+ * \param[in] r         The unsigned scalar to subtract.
+ * \param n             Number of limbs of \p d and \p l.
+ *
+ * \return              1 if `l < r`.
+ *                      0 if `l >= r`.
+ */
+mbedtls_mpi_uint MPI_CORE(sub_int)( mbedtls_mpi_uint *d,
+                                    const mbedtls_mpi_uint *l,
+                                    mbedtls_mpi_uint r, size_t n );
+
 /* END MERGE SLOT 3 */
 
 /* BEGIN MERGE SLOT 4 */

--- a/scripts/mbedtls_dev/bignum_core.py
+++ b/scripts/mbedtls_dev/bignum_core.py
@@ -763,6 +763,37 @@ def mpi_modmul_case_generate() -> None:
 
 # BEGIN MERGE SLOT 3
 
+class BignumCoreSubInt(BignumCoreTarget, bignum_common.OperationCommon):
+    """Test cases for bignum core sub int."""
+    count = 0
+    symbol = "-"
+    test_function = "mpi_core_sub_int"
+    test_name = "mpi_core_sub_int"
+    input_style = "arch_split"
+
+    @property
+    def is_valid(self) -> bool:
+        # This is "sub int", so b is only one limb
+        if bignum_common.limbs_mpi(self.int_b, self.bits_in_limb) > 1:
+            return False
+        return True
+
+    # Overriding because we don't want leading zeros on b
+    @property
+    def arg_b(self) -> str:
+        return self.val_b
+
+    def result(self) -> List[str]:
+        result = self.int_a - self.int_b
+
+        borrow, result = divmod(result, self.limb_boundary)
+
+        # Borrow will be -1 if non-zero, but we want it to be 1 in the test data
+        return [
+            self.format_result(result),
+            str(-borrow)
+        ]
+
 # END MERGE SLOT 3
 
 # BEGIN MERGE SLOT 4

--- a/tests/suites/test_suite_bignum_core.function
+++ b/tests/suites/test_suite_bignum_core.function
@@ -1049,6 +1049,52 @@ exit:
 
 /* BEGIN MERGE SLOT 3 */
 
+/* BEGIN_CASE */
+void mpi_core_sub_int( char * input_A, char * input_B,
+                       char * input_X, int borrow )
+{
+    /* We are testing A - b, where A is an MPI and b is a scalar, expecting
+     * result X with borrow borrow.  However, for ease of handling we encode b
+     * as a 1-limb MPI (B) in the .data file. */
+
+    mbedtls_mpi_uint *A = NULL;
+    mbedtls_mpi_uint *B = NULL;
+    mbedtls_mpi_uint *X = NULL;
+    mbedtls_mpi_uint *R = NULL;
+    size_t A_limbs, B_limbs, X_limbs;
+
+    TEST_EQUAL( 0, mbedtls_test_read_mpi_core( &A, &A_limbs, input_A ) );
+    TEST_EQUAL( 0, mbedtls_test_read_mpi_core( &B, &B_limbs, input_B ) );
+    TEST_EQUAL( 0, mbedtls_test_read_mpi_core( &X, &X_limbs, input_X ) );
+
+    /* The MPI encoding of scalar b must be only 1 limb */
+    TEST_EQUAL( B_limbs, 1 );
+
+    /* The subtraction is fixed-width, so A and X must have the same number of limbs */
+    TEST_EQUAL( A_limbs, X_limbs );
+    size_t limbs = A_limbs;
+
+    ASSERT_ALLOC( R, limbs );
+
+#define TEST_COMPARE_CORE_MPIS( A, B, limbs ) \
+                ASSERT_COMPARE( A, (limbs) * sizeof(mbedtls_mpi_uint), B, (limbs) * sizeof(mbedtls_mpi_uint) )
+
+    /* 1. R = A - b. Result and borrow should be correct */
+    TEST_EQUAL( mbedtls_mpi_core_sub_int( R, A, B[0], limbs ), borrow );
+    TEST_COMPARE_CORE_MPIS( R, X, limbs );
+
+    /* 2. A = A - b. Result and borrow should be correct */
+    TEST_EQUAL( mbedtls_mpi_core_sub_int( A, A, B[0], limbs ), borrow );
+    TEST_COMPARE_CORE_MPIS( A, X, limbs );
+
+exit:
+    mbedtls_free( A );
+    mbedtls_free( B );
+    mbedtls_free( X );
+    mbedtls_free( R );
+}
+/* END_CASE */
+
 /* END MERGE SLOT 3 */
 
 /* BEGIN MERGE SLOT 4 */


### PR DESCRIPTION
## Description
Extract MPI_CORE(sub_int) from the [prototype](https://github.com/hanno-arm/mbedtls/blob/ecp_prototype/library/bignum_core.c#L214-L227). Fixes #6231

## Status
**READY**

## Requires Backporting
**NO**

## Todos
- [x] The `MPI_CORE(sub_int)` and its dependencies are taken from the prototype and credit is given to Hanno
- [x] New macros are expanded/removed
- [x] The legacy functions in `bignum.c` are calling the new function wherever possible
- [x] Extensive unit tests are added for all new functions
