### PR TITLE
[Backport 2.28]Crash in test suite x509write config full no seedfile

### DIFF
--- a/tests/suites/test_suite_x509write.function
+++ b/tests/suites/test_suite_x509write.function
@@ -93,10 +93,11 @@ void x509_csr_check( char * key_file, char * cert_req_check_file, int md_type,
 
     memset( &rnd_info, 0x2a, sizeof( mbedtls_test_rnd_pseudo_info ) );
 
+    mbedtls_x509write_csr_init( &req );
+
     mbedtls_pk_init( &key );
     TEST_ASSERT( mbedtls_pk_parse_keyfile( &key, key_file, NULL ) == 0 );
 
-    mbedtls_x509write_csr_init( &req );
     mbedtls_x509write_csr_set_md_alg( &req, md_type );
     mbedtls_x509write_csr_set_key( &req, &key );
     TEST_ASSERT( mbedtls_x509write_csr_set_subject_name( &req, subject_name ) == 0 );
@@ -156,8 +157,11 @@ void x509_csr_check_opaque( char *key_file, int md_type, int key_usage,
     const char *subject_name = "C=NL,O=PolarSSL,CN=PolarSSL Server 1";
     mbedtls_test_rnd_pseudo_info rnd_info;
 
-    PSA_INIT( );
     memset( &rnd_info, 0x2a, sizeof( mbedtls_test_rnd_pseudo_info ) );
+
+    mbedtls_x509write_csr_init( &req );
+
+    USE_PSA_INIT( );
 
     md_alg_psa = mbedtls_psa_translate_md( (mbedtls_md_type_t) md_type );
     TEST_ASSERT( md_alg_psa != MBEDTLS_MD_NONE );
@@ -166,7 +170,6 @@ void x509_csr_check_opaque( char *key_file, int md_type, int key_usage,
     TEST_ASSERT( mbedtls_pk_parse_keyfile( &key, key_file, NULL ) == 0 );
     TEST_ASSERT( mbedtls_pk_wrap_as_opaque( &key, &key_id, md_alg_psa ) == 0 );
 
-    mbedtls_x509write_csr_init( &req );
     mbedtls_x509write_csr_set_md_alg( &req, md_type );
     mbedtls_x509write_csr_set_key( &req, &key );
     TEST_ASSERT( mbedtls_x509write_csr_set_subject_name( &req, subject_name ) == 0 );


### PR DESCRIPTION
## Description
Backport of #6109:
Steps to reproduce:
```
find . -name seedfile -exec rm {} +
scripts/config.py config full
(cd tests && make test_suite_x509write && ./test_suite_x509write)
```
Observed behaviour: the first few tests fail, then eventually there's a bus error and a core dump is produced. If we just add the seedfile again (`dd if=/dev/urandom of=./tests/seedfile bs=64 count=1`) everything passes and there is no crash.

Cause:
When USE_PSA_INIT() failed because lack of seedfile, `mbedtls_x509write_csr_free()`
crashed when called on an unitialized `mbedtls_x509write_csr` struct.

This moves `mbedtls_x509write_csr_init` before calling USE_PSA_INIT(),
which could probably fail, and use the same flow in `x509_csr_check()`
and `x509_csr_check_opaque()`.

## Status
**READY**

## Requires Backporting
NO  

## Migrations
NO

## Additional comments
N/A