### PR TITLE
Add a missing guard in an example program

### DIFF
--- a/programs/ssl/ssl_context_info.c
+++ b/programs/ssl/ssl_context_info.c
@@ -631,7 +631,9 @@ void print_deserialized_ssl_session( const uint8_t *ssl, uint32_t len,
     else
     {
         const mbedtls_cipher_info_t *cipher_info;
+#if defined(MBEDTLS_MD_C)
         const mbedtls_md_info_t *md_info;
+#endif
 
         printf( "\tciphersuite    : %s\n", ciphersuite_info->name );
         printf( "\tcipher flags   : 0x%02X\n", ciphersuite_info->flags );


### PR DESCRIPTION
An `mbedtls_md_info_t` variable is not used in builds without MD.
This PR fixes a test failure introduced in the combination of https://github.com/Mbed-TLS/mbedtls/pull/6111 and https://github.com/Mbed-TLS/mbedtls/pull/6208.