### PR TITLE
Rename test macros `ASSERT_COMPARE()`, `ASSERT_ALLOC()` and `ASSERT_ALLOC_WEAK()`

### DIFF
--- a/tests/include/test/macros.h
+++ b/tests/include/test/macros.h
@@ -123,7 +123,7 @@
  *                  This expression may be evaluated multiple times.
  *
  */
-#define TEST_CALLOC_OR_FAIL(pointer, length)                \
+#define TEST_CALLOC(pointer, length)                        \
     do {                                                    \
         TEST_ASSERT((pointer) == NULL);                     \
         if ((length) != 0) {                                \
@@ -134,11 +134,11 @@
     } while (0)
 
 /* For backwards compatibility */
-#define ASSERT_ALLOC(pointer, length) TEST_CALLOC_OR_FAIL(pointer, length)
+#define ASSERT_ALLOC(pointer, length) TEST_CALLOC(pointer, length)
 
 /** Allocate memory dynamically. If the allocation fails, skip the test case.
  *
- * This macro behaves like #TEST_CALLOC_OR_FAIL, except that if the allocation
+ * This macro behaves like #TEST_CALLOC, except that if the allocation
  * fails, it marks the test as skipped rather than failed.
  */
 #define TEST_CALLOC_OR_SKIP(pointer, length)                \

--- a/tests/include/test/macros.h
+++ b/tests/include/test/macros.h
@@ -166,14 +166,16 @@
  * \param size2     Size of the second buffer in bytes.
  *                  This expression may be evaluated multiple times.
  */
-#define ASSERT_COMPARE(p1, size1, p2, size2)                          \
-    do                                                                  \
-    {                                                                   \
+#define TEST_BUFFERS_EQUAL(p1, size1, p2, size2)               \
+    do {                                                       \
         TEST_EQUAL((size1), (size2));                          \
-        if ((size1) != 0)                                            \
-        TEST_ASSERT(memcmp((p1), (p2), (size1)) == 0);    \
-    }                                                                   \
-    while (0)
+        if ((size1) != 0) {                                    \
+            TEST_ASSERT(memcmp((p1), (p2), (size1)) == 0);     \
+        }                                                      \
+    } while (0)
+
+/* For backwards compatibility */
+#define ASSERT_COMPARE(p1, size1, p2, size2) TEST_BUFFERS_EQUAL(p1, size1, p2, size2)
 
 /**
  * \brief   This macro tests the expression passed to it and skips the

--- a/tests/include/test/macros.h
+++ b/tests/include/test/macros.h
@@ -123,18 +123,18 @@
  *                  This expression may be evaluated multiple times.
  *
  */
-#define ASSERT_ALLOC(pointer, length)                           \
-    do                                                            \
-    {                                                             \
-        TEST_ASSERT((pointer) == NULL);                       \
-        if ((length) != 0)                                     \
-        {                                                         \
-            (pointer) = mbedtls_calloc(sizeof(*(pointer)), \
+#define TEST_CALLOC_OR_FAIL(pointer, length)                \
+    do {                                                    \
+        TEST_ASSERT((pointer) == NULL);                     \
+        if ((length) != 0) {                                \
+            (pointer) = mbedtls_calloc(sizeof(*(pointer)),  \
                                        (length));           \
-            TEST_ASSERT((pointer) != NULL);                   \
-        }                                                         \
-    }                                                             \
-    while (0)
+            TEST_ASSERT((pointer) != NULL);                 \
+        }                                                   \
+    } while (0)
+
+/* For backwards compatibility */
+#define ASSERT_ALLOC(pointer, length) TEST_CALLOC_OR_FAIL(pointer, length)
 
 /** Allocate memory dynamically. If the allocation fails, skip the test case.
  *

--- a/tests/include/test/macros.h
+++ b/tests/include/test/macros.h
@@ -138,21 +138,21 @@
 
 /** Allocate memory dynamically. If the allocation fails, skip the test case.
  *
- * This macro behaves like #ASSERT_ALLOC, except that if the allocation
+ * This macro behaves like #TEST_CALLOC_OR_FAIL, except that if the allocation
  * fails, it marks the test as skipped rather than failed.
  */
-#define ASSERT_ALLOC_WEAK(pointer, length)                      \
-    do                                                            \
-    {                                                             \
-        TEST_ASSERT((pointer) == NULL);                       \
-        if ((length) != 0)                                     \
-        {                                                         \
-            (pointer) = mbedtls_calloc(sizeof(*(pointer)), \
+#define TEST_CALLOC_OR_SKIP(pointer, length)                \
+    do {                                                    \
+        TEST_ASSERT((pointer) == NULL);                     \
+        if ((length) != 0) {                                \
+            (pointer) = mbedtls_calloc(sizeof(*(pointer)),  \
                                        (length));           \
-            TEST_ASSUME((pointer) != NULL);                   \
-        }                                                         \
-    }                                                             \
-    while (0)
+            TEST_ASSUME((pointer) != NULL);                 \
+        }                                                   \
+    } while (0)
+
+/* For backwards compatibility */
+#define ASSERT_ALLOC_WEAK(pointer, length) TEST_CALLOC_OR_SKIP(pointer, length)
 
 /** Compare two buffers and fail the test case if they differ.
  *

--- a/tests/include/test/macros.h
+++ b/tests/include/test/macros.h
@@ -107,52 +107,52 @@
  * The allocated memory will be filled with zeros.
  *
  * You must set \p pointer to \c NULL before calling this macro and
- * put `mbedtls_free( pointer )` in the test's cleanup code.
+ * put `mbedtls_free(pointer)` in the test's cleanup code.
  *
- * If \p length is zero, the resulting \p pointer will be \c NULL.
+ * If \p item_count is zero, the resulting \p pointer will be \c NULL.
  * This is usually what we want in tests since API functions are
  * supposed to accept null pointers when a buffer size is zero.
  *
  * This macro expands to an instruction, not an expression.
  * It may jump to the \c exit label.
  *
- * \param pointer   An lvalue where the address of the allocated buffer
- *                  will be stored.
- *                  This expression may be evaluated multiple times.
- * \param length    Number of elements to allocate.
- *                  This expression may be evaluated multiple times.
+ * \param pointer    An lvalue where the address of the allocated buffer
+ *                   will be stored.
+ *                   This expression may be evaluated multiple times.
+ * \param item_count Number of elements to allocate.
+ *                   This expression may be evaluated multiple times.
  *
  */
-#define TEST_CALLOC(pointer, length)                        \
+#define TEST_CALLOC(pointer, item_count)                    \
     do {                                                    \
         TEST_ASSERT((pointer) == NULL);                     \
-        if ((length) != 0) {                                \
+        if ((item_count) != 0) {                            \
             (pointer) = mbedtls_calloc(sizeof(*(pointer)),  \
-                                       (length));           \
+                                       (item_count));       \
             TEST_ASSERT((pointer) != NULL);                 \
         }                                                   \
     } while (0)
 
 /* For backwards compatibility */
-#define ASSERT_ALLOC(pointer, length) TEST_CALLOC(pointer, length)
+#define ASSERT_ALLOC(pointer, item_count) TEST_CALLOC(pointer, item_count)
 
 /** Allocate memory dynamically. If the allocation fails, skip the test case.
  *
  * This macro behaves like #TEST_CALLOC, except that if the allocation
  * fails, it marks the test as skipped rather than failed.
  */
-#define TEST_CALLOC_OR_SKIP(pointer, length)                \
+#define TEST_CALLOC_OR_SKIP(pointer, item_count)            \
     do {                                                    \
         TEST_ASSERT((pointer) == NULL);                     \
-        if ((length) != 0) {                                \
+        if ((item_count) != 0) {                            \
             (pointer) = mbedtls_calloc(sizeof(*(pointer)),  \
-                                       (length));           \
+                                       (item_count));       \
             TEST_ASSUME((pointer) != NULL);                 \
         }                                                   \
     } while (0)
 
 /* For backwards compatibility */
-#define ASSERT_ALLOC_WEAK(pointer, length) TEST_CALLOC_OR_SKIP(pointer, length)
+#define ASSERT_ALLOC_WEAK(pointer, item_count) TEST_CALLOC_OR_SKIP(pointer, item_count)
 
 /** Compare two buffers and fail the test case if they differ.
  *

--- a/tests/include/test/macros.h
+++ b/tests/include/test/macros.h
@@ -166,7 +166,7 @@
  * \param size2     Size of the second buffer in bytes.
  *                  This expression may be evaluated multiple times.
  */
-#define TEST_BUFFERS_EQUAL(p1, size1, p2, size2)               \
+#define TEST_MEMORY_COMPARE(p1, size1, p2, size2)              \
     do {                                                       \
         TEST_EQUAL((size1), (size2));                          \
         if ((size1) != 0) {                                    \
@@ -175,7 +175,7 @@
     } while (0)
 
 /* For backwards compatibility */
-#define ASSERT_COMPARE(p1, size1, p2, size2) TEST_BUFFERS_EQUAL(p1, size1, p2, size2)
+#define ASSERT_COMPARE(p1, size1, p2, size2) TEST_MEMORY_COMPARE(p1, size1, p2, size2)
 
 /**
  * \brief   This macro tests the expression passed to it and skips the

--- a/tests/src/psa_exercise_key.c
+++ b/tests/src/psa_exercise_key.c
@@ -506,7 +506,7 @@ psa_status_t mbedtls_test_psa_key_agreement_with_self(
     key_bits = psa_get_key_bits(&attributes);
     public_key_type = PSA_KEY_TYPE_PUBLIC_KEY_OF_KEY_PAIR(private_key_type);
     public_key_length = PSA_EXPORT_PUBLIC_KEY_OUTPUT_SIZE(public_key_type, key_bits);
-    ASSERT_ALLOC(public_key, public_key_length);
+    TEST_CALLOC_OR_FAIL(public_key, public_key_length);
     PSA_ASSERT(psa_export_public_key(key, public_key, public_key_length,
                                      &public_key_length));
 
@@ -548,7 +548,7 @@ psa_status_t mbedtls_test_psa_raw_key_agreement_with_self(
     key_bits = psa_get_key_bits(&attributes);
     public_key_type = PSA_KEY_TYPE_PUBLIC_KEY_OF_KEY_PAIR(private_key_type);
     public_key_length = PSA_EXPORT_PUBLIC_KEY_OUTPUT_SIZE(public_key_type, key_bits);
-    ASSERT_ALLOC(public_key, public_key_length);
+    TEST_CALLOC_OR_FAIL(public_key, public_key_length);
     PSA_ASSERT(psa_export_public_key(key,
                                      public_key, public_key_length,
                                      &public_key_length));
@@ -838,7 +838,7 @@ static int exercise_export_key(mbedtls_svc_key_id_t key,
     exported_size = PSA_EXPORT_KEY_OUTPUT_SIZE(
         psa_get_key_type(&attributes),
         psa_get_key_bits(&attributes));
-    ASSERT_ALLOC(exported, exported_size);
+    TEST_CALLOC_OR_FAIL(exported, exported_size);
 
     if ((usage & PSA_KEY_USAGE_EXPORT) == 0 &&
         !PSA_KEY_TYPE_IS_PUBLIC_KEY(psa_get_key_type(&attributes))) {
@@ -881,7 +881,7 @@ static int exercise_export_public_key(mbedtls_svc_key_id_t key)
         exported_size = PSA_EXPORT_KEY_OUTPUT_SIZE(
             psa_get_key_type(&attributes),
             psa_get_key_bits(&attributes));
-        ASSERT_ALLOC(exported, exported_size);
+        TEST_CALLOC_OR_FAIL(exported, exported_size);
 
         TEST_EQUAL(psa_export_public_key(key, exported,
                                          exported_size, &exported_length),
@@ -894,7 +894,7 @@ static int exercise_export_public_key(mbedtls_svc_key_id_t key)
         psa_get_key_type(&attributes));
     exported_size = PSA_EXPORT_PUBLIC_KEY_OUTPUT_SIZE(public_type,
                                                       psa_get_key_bits(&attributes));
-    ASSERT_ALLOC(exported, exported_size);
+    TEST_CALLOC_OR_FAIL(exported, exported_size);
 
     PSA_ASSERT(psa_export_public_key(key,
                                      exported, exported_size,

--- a/tests/src/psa_exercise_key.c
+++ b/tests/src/psa_exercise_key.c
@@ -506,7 +506,7 @@ psa_status_t mbedtls_test_psa_key_agreement_with_self(
     key_bits = psa_get_key_bits(&attributes);
     public_key_type = PSA_KEY_TYPE_PUBLIC_KEY_OF_KEY_PAIR(private_key_type);
     public_key_length = PSA_EXPORT_PUBLIC_KEY_OUTPUT_SIZE(public_key_type, key_bits);
-    TEST_CALLOC_OR_FAIL(public_key, public_key_length);
+    TEST_CALLOC(public_key, public_key_length);
     PSA_ASSERT(psa_export_public_key(key, public_key, public_key_length,
                                      &public_key_length));
 
@@ -548,7 +548,7 @@ psa_status_t mbedtls_test_psa_raw_key_agreement_with_self(
     key_bits = psa_get_key_bits(&attributes);
     public_key_type = PSA_KEY_TYPE_PUBLIC_KEY_OF_KEY_PAIR(private_key_type);
     public_key_length = PSA_EXPORT_PUBLIC_KEY_OUTPUT_SIZE(public_key_type, key_bits);
-    TEST_CALLOC_OR_FAIL(public_key, public_key_length);
+    TEST_CALLOC(public_key, public_key_length);
     PSA_ASSERT(psa_export_public_key(key,
                                      public_key, public_key_length,
                                      &public_key_length));
@@ -838,7 +838,7 @@ static int exercise_export_key(mbedtls_svc_key_id_t key,
     exported_size = PSA_EXPORT_KEY_OUTPUT_SIZE(
         psa_get_key_type(&attributes),
         psa_get_key_bits(&attributes));
-    TEST_CALLOC_OR_FAIL(exported, exported_size);
+    TEST_CALLOC(exported, exported_size);
 
     if ((usage & PSA_KEY_USAGE_EXPORT) == 0 &&
         !PSA_KEY_TYPE_IS_PUBLIC_KEY(psa_get_key_type(&attributes))) {
@@ -881,7 +881,7 @@ static int exercise_export_public_key(mbedtls_svc_key_id_t key)
         exported_size = PSA_EXPORT_KEY_OUTPUT_SIZE(
             psa_get_key_type(&attributes),
             psa_get_key_bits(&attributes));
-        TEST_CALLOC_OR_FAIL(exported, exported_size);
+        TEST_CALLOC(exported, exported_size);
 
         TEST_EQUAL(psa_export_public_key(key, exported,
                                          exported_size, &exported_length),
@@ -894,7 +894,7 @@ static int exercise_export_public_key(mbedtls_svc_key_id_t key)
         psa_get_key_type(&attributes));
     exported_size = PSA_EXPORT_PUBLIC_KEY_OUTPUT_SIZE(public_type,
                                                       psa_get_key_bits(&attributes));
-    TEST_CALLOC_OR_FAIL(exported, exported_size);
+    TEST_CALLOC(exported, exported_size);
 
     PSA_ASSERT(psa_export_public_key(key,
                                      exported, exported_size,

--- a/tests/src/test_helpers/ssl_helpers.c
+++ b/tests/src/test_helpers/ssl_helpers.c
@@ -91,7 +91,7 @@ void mbedtls_test_init_handshake_options(
     opts->resize_buffers = 1;
 #if defined(MBEDTLS_SSL_CACHE_C)
     opts->cache = NULL;
-    ASSERT_ALLOC(opts->cache, 1);
+    TEST_CALLOC_OR_FAIL(opts->cache, 1);
     mbedtls_ssl_cache_init(opts->cache);
 #if defined(MBEDTLS_HAVE_TIME)
     TEST_EQUAL(mbedtls_ssl_cache_get_timeout(opts->cache),
@@ -627,9 +627,9 @@ int mbedtls_test_ssl_endpoint_certificate_init(mbedtls_test_ssl_endpoint *ep,
     }
 
     cert = &(ep->cert);
-    ASSERT_ALLOC(cert->ca_cert, 1);
-    ASSERT_ALLOC(cert->cert, 1);
-    ASSERT_ALLOC(cert->pkey, 1);
+    TEST_CALLOC_OR_FAIL(cert->ca_cert, 1);
+    TEST_CALLOC_OR_FAIL(cert->cert, 1);
+    TEST_CALLOC_OR_FAIL(cert->pkey, 1);
 
     mbedtls_x509_crt_init(cert->ca_cert);
     mbedtls_x509_crt_init(cert->cert);

--- a/tests/src/test_helpers/ssl_helpers.c
+++ b/tests/src/test_helpers/ssl_helpers.c
@@ -91,7 +91,7 @@ void mbedtls_test_init_handshake_options(
     opts->resize_buffers = 1;
 #if defined(MBEDTLS_SSL_CACHE_C)
     opts->cache = NULL;
-    TEST_CALLOC_OR_FAIL(opts->cache, 1);
+    TEST_CALLOC(opts->cache, 1);
     mbedtls_ssl_cache_init(opts->cache);
 #if defined(MBEDTLS_HAVE_TIME)
     TEST_EQUAL(mbedtls_ssl_cache_get_timeout(opts->cache),
@@ -627,9 +627,9 @@ int mbedtls_test_ssl_endpoint_certificate_init(mbedtls_test_ssl_endpoint *ep,
     }
 
     cert = &(ep->cert);
-    TEST_CALLOC_OR_FAIL(cert->ca_cert, 1);
-    TEST_CALLOC_OR_FAIL(cert->cert, 1);
-    TEST_CALLOC_OR_FAIL(cert->pkey, 1);
+    TEST_CALLOC(cert->ca_cert, 1);
+    TEST_CALLOC(cert->cert, 1);
+    TEST_CALLOC(cert->pkey, 1);
 
     mbedtls_x509_crt_init(cert->ca_cert);
     mbedtls_x509_crt_init(cert->cert);

--- a/tests/suites/test_suite_aes.function
+++ b/tests/suites/test_suite_aes.function
@@ -38,13 +38,13 @@ static int test_copy(const data_t *key,
     // Encrypt with copied context
     TEST_ASSERT(mbedtls_aes_crypt_ecb(enc, MBEDTLS_AES_ENCRYPT,
                                       plaintext, output) == 0);
-    TEST_BUFFERS_EQUAL(ciphertext, 16, output, 16);
+    TEST_MEMORY_COMPARE(ciphertext, 16, output, 16);
     mbedtls_aes_free(enc);
 
     // Decrypt with copied context
     TEST_ASSERT(mbedtls_aes_crypt_ecb(dec, MBEDTLS_AES_DECRYPT,
                                       ciphertext, output) == 0);
-    TEST_BUFFERS_EQUAL(plaintext, 16, output, 16);
+    TEST_MEMORY_COMPARE(plaintext, 16, output, 16);
     mbedtls_aes_free(dec);
 
     return 1;

--- a/tests/suites/test_suite_aes.function
+++ b/tests/suites/test_suite_aes.function
@@ -545,9 +545,9 @@ void aes_ecb_copy_context(data_t *key)
     struct align1 *dec1 = NULL;
 
     /* All peak alignment */
-    ASSERT_ALLOC(src0, 1);
-    ASSERT_ALLOC(enc0, 1);
-    ASSERT_ALLOC(dec0, 1);
+    TEST_CALLOC_OR_FAIL(src0, 1);
+    TEST_CALLOC_OR_FAIL(enc0, 1);
+    TEST_CALLOC_OR_FAIL(dec0, 1);
     if (!test_copy(key, &src0->ctx, &enc0->ctx, &dec0->ctx)) {
         goto exit;
     }
@@ -559,9 +559,9 @@ void aes_ecb_copy_context(data_t *key)
     dec0 = NULL;
 
     /* Original shifted */
-    ASSERT_ALLOC(src1, 1);
-    ASSERT_ALLOC(enc0, 1);
-    ASSERT_ALLOC(dec0, 1);
+    TEST_CALLOC_OR_FAIL(src1, 1);
+    TEST_CALLOC_OR_FAIL(enc0, 1);
+    TEST_CALLOC_OR_FAIL(dec0, 1);
     if (!test_copy(key, &src1->ctx, &enc0->ctx, &dec0->ctx)) {
         goto exit;
     }
@@ -573,9 +573,9 @@ void aes_ecb_copy_context(data_t *key)
     dec0 = NULL;
 
     /* Copies shifted */
-    ASSERT_ALLOC(src0, 1);
-    ASSERT_ALLOC(enc1, 1);
-    ASSERT_ALLOC(dec1, 1);
+    TEST_CALLOC_OR_FAIL(src0, 1);
+    TEST_CALLOC_OR_FAIL(enc1, 1);
+    TEST_CALLOC_OR_FAIL(dec1, 1);
     if (!test_copy(key, &src0->ctx, &enc1->ctx, &dec1->ctx)) {
         goto exit;
     }
@@ -587,9 +587,9 @@ void aes_ecb_copy_context(data_t *key)
     dec1 = NULL;
 
     /* Source and copies shifted */
-    ASSERT_ALLOC(src1, 1);
-    ASSERT_ALLOC(enc1, 1);
-    ASSERT_ALLOC(dec1, 1);
+    TEST_CALLOC_OR_FAIL(src1, 1);
+    TEST_CALLOC_OR_FAIL(enc1, 1);
+    TEST_CALLOC_OR_FAIL(dec1, 1);
     if (!test_copy(key, &src1->ctx, &enc1->ctx, &dec1->ctx)) {
         goto exit;
     }

--- a/tests/suites/test_suite_aes.function
+++ b/tests/suites/test_suite_aes.function
@@ -38,13 +38,13 @@ static int test_copy(const data_t *key,
     // Encrypt with copied context
     TEST_ASSERT(mbedtls_aes_crypt_ecb(enc, MBEDTLS_AES_ENCRYPT,
                                       plaintext, output) == 0);
-    ASSERT_COMPARE(ciphertext, 16, output, 16);
+    TEST_BUFFERS_EQUAL(ciphertext, 16, output, 16);
     mbedtls_aes_free(enc);
 
     // Decrypt with copied context
     TEST_ASSERT(mbedtls_aes_crypt_ecb(dec, MBEDTLS_AES_DECRYPT,
                                       ciphertext, output) == 0);
-    ASSERT_COMPARE(plaintext, 16, output, 16);
+    TEST_BUFFERS_EQUAL(plaintext, 16, output, 16);
     mbedtls_aes_free(dec);
 
     return 1;

--- a/tests/suites/test_suite_aes.function
+++ b/tests/suites/test_suite_aes.function
@@ -545,9 +545,9 @@ void aes_ecb_copy_context(data_t *key)
     struct align1 *dec1 = NULL;
 
     /* All peak alignment */
-    TEST_CALLOC_OR_FAIL(src0, 1);
-    TEST_CALLOC_OR_FAIL(enc0, 1);
-    TEST_CALLOC_OR_FAIL(dec0, 1);
+    TEST_CALLOC(src0, 1);
+    TEST_CALLOC(enc0, 1);
+    TEST_CALLOC(dec0, 1);
     if (!test_copy(key, &src0->ctx, &enc0->ctx, &dec0->ctx)) {
         goto exit;
     }
@@ -559,9 +559,9 @@ void aes_ecb_copy_context(data_t *key)
     dec0 = NULL;
 
     /* Original shifted */
-    TEST_CALLOC_OR_FAIL(src1, 1);
-    TEST_CALLOC_OR_FAIL(enc0, 1);
-    TEST_CALLOC_OR_FAIL(dec0, 1);
+    TEST_CALLOC(src1, 1);
+    TEST_CALLOC(enc0, 1);
+    TEST_CALLOC(dec0, 1);
     if (!test_copy(key, &src1->ctx, &enc0->ctx, &dec0->ctx)) {
         goto exit;
     }
@@ -573,9 +573,9 @@ void aes_ecb_copy_context(data_t *key)
     dec0 = NULL;
 
     /* Copies shifted */
-    TEST_CALLOC_OR_FAIL(src0, 1);
-    TEST_CALLOC_OR_FAIL(enc1, 1);
-    TEST_CALLOC_OR_FAIL(dec1, 1);
+    TEST_CALLOC(src0, 1);
+    TEST_CALLOC(enc1, 1);
+    TEST_CALLOC(dec1, 1);
     if (!test_copy(key, &src0->ctx, &enc1->ctx, &dec1->ctx)) {
         goto exit;
     }
@@ -587,9 +587,9 @@ void aes_ecb_copy_context(data_t *key)
     dec1 = NULL;
 
     /* Source and copies shifted */
-    TEST_CALLOC_OR_FAIL(src1, 1);
-    TEST_CALLOC_OR_FAIL(enc1, 1);
-    TEST_CALLOC_OR_FAIL(dec1, 1);
+    TEST_CALLOC(src1, 1);
+    TEST_CALLOC(enc1, 1);
+    TEST_CALLOC(dec1, 1);
     if (!test_copy(key, &src1->ctx, &enc1->ctx, &dec1->ctx)) {
         goto exit;
     }

--- a/tests/suites/test_suite_aria.function
+++ b/tests/suites/test_suite_aria.function
@@ -77,7 +77,7 @@ void aria_encrypt_ecb(data_t *key_str, data_t *src_str,
                                                output + i) == 0);
         }
 
-        TEST_BUFFERS_EQUAL(output, expected_output->len,
+        TEST_MEMORY_COMPARE(output, expected_output->len,
                        expected_output->x, expected_output->len);
     }
 
@@ -105,7 +105,7 @@ void aria_decrypt_ecb(data_t *key_str, data_t *src_str,
                                                output + i) == 0);
         }
 
-        TEST_BUFFERS_EQUAL(output, expected_output->len,
+        TEST_MEMORY_COMPARE(output, expected_output->len,
                        expected_output->x, expected_output->len);
     }
 
@@ -130,7 +130,7 @@ void aria_encrypt_cbc(data_t *key_str, data_t *iv_str,
                                        src_str->len, iv_str->x, src_str->x,
                                        output) == cbc_result);
     if (cbc_result == 0) {
-        TEST_BUFFERS_EQUAL(output, expected_output->len,
+        TEST_MEMORY_COMPARE(output, expected_output->len,
                        expected_output->x, expected_output->len);
     }
 
@@ -155,7 +155,7 @@ void aria_decrypt_cbc(data_t *key_str, data_t *iv_str,
                                        src_str->len, iv_str->x, src_str->x,
                                        output) == cbc_result);
     if (cbc_result == 0) {
-        TEST_BUFFERS_EQUAL(output, expected_output->len,
+        TEST_MEMORY_COMPARE(output, expected_output->len,
                        expected_output->x, expected_output->len);
     }
 
@@ -182,7 +182,7 @@ void aria_encrypt_cfb128(data_t *key_str, data_t *iv_str,
                                           iv_str->x, src_str->x, output)
                 == result);
 
-    TEST_BUFFERS_EQUAL(output, expected_output->len,
+    TEST_MEMORY_COMPARE(output, expected_output->len,
                    expected_output->x, expected_output->len);
 
 exit:
@@ -208,7 +208,7 @@ void aria_decrypt_cfb128(data_t *key_str, data_t *iv_str,
                                           iv_str->x, src_str->x, output)
                 == result);
 
-    TEST_BUFFERS_EQUAL(output, expected_output->len,
+    TEST_MEMORY_COMPARE(output, expected_output->len,
                    expected_output->x, expected_output->len);
 
 exit:
@@ -234,7 +234,7 @@ void aria_encrypt_ctr(data_t *key_str, data_t *iv_str,
                                        iv_str->x, blk, src_str->x, output)
                 == result);
 
-    TEST_BUFFERS_EQUAL(output, expected_output->len,
+    TEST_MEMORY_COMPARE(output, expected_output->len,
                    expected_output->x, expected_output->len);
 
 exit:
@@ -260,7 +260,7 @@ void aria_decrypt_ctr(data_t *key_str, data_t *iv_str,
                                        iv_str->x, blk, src_str->x, output)
                 == result);
 
-    TEST_BUFFERS_EQUAL(output, expected_output->len,
+    TEST_MEMORY_COMPARE(output, expected_output->len,
                    expected_output->x, expected_output->len);
 
 exit:

--- a/tests/suites/test_suite_aria.function
+++ b/tests/suites/test_suite_aria.function
@@ -77,7 +77,7 @@ void aria_encrypt_ecb(data_t *key_str, data_t *src_str,
                                                output + i) == 0);
         }
 
-        ASSERT_COMPARE(output, expected_output->len,
+        TEST_BUFFERS_EQUAL(output, expected_output->len,
                        expected_output->x, expected_output->len);
     }
 
@@ -105,7 +105,7 @@ void aria_decrypt_ecb(data_t *key_str, data_t *src_str,
                                                output + i) == 0);
         }
 
-        ASSERT_COMPARE(output, expected_output->len,
+        TEST_BUFFERS_EQUAL(output, expected_output->len,
                        expected_output->x, expected_output->len);
     }
 
@@ -130,7 +130,7 @@ void aria_encrypt_cbc(data_t *key_str, data_t *iv_str,
                                        src_str->len, iv_str->x, src_str->x,
                                        output) == cbc_result);
     if (cbc_result == 0) {
-        ASSERT_COMPARE(output, expected_output->len,
+        TEST_BUFFERS_EQUAL(output, expected_output->len,
                        expected_output->x, expected_output->len);
     }
 
@@ -155,7 +155,7 @@ void aria_decrypt_cbc(data_t *key_str, data_t *iv_str,
                                        src_str->len, iv_str->x, src_str->x,
                                        output) == cbc_result);
     if (cbc_result == 0) {
-        ASSERT_COMPARE(output, expected_output->len,
+        TEST_BUFFERS_EQUAL(output, expected_output->len,
                        expected_output->x, expected_output->len);
     }
 
@@ -182,7 +182,7 @@ void aria_encrypt_cfb128(data_t *key_str, data_t *iv_str,
                                           iv_str->x, src_str->x, output)
                 == result);
 
-    ASSERT_COMPARE(output, expected_output->len,
+    TEST_BUFFERS_EQUAL(output, expected_output->len,
                    expected_output->x, expected_output->len);
 
 exit:
@@ -208,7 +208,7 @@ void aria_decrypt_cfb128(data_t *key_str, data_t *iv_str,
                                           iv_str->x, src_str->x, output)
                 == result);
 
-    ASSERT_COMPARE(output, expected_output->len,
+    TEST_BUFFERS_EQUAL(output, expected_output->len,
                    expected_output->x, expected_output->len);
 
 exit:
@@ -234,7 +234,7 @@ void aria_encrypt_ctr(data_t *key_str, data_t *iv_str,
                                        iv_str->x, blk, src_str->x, output)
                 == result);
 
-    ASSERT_COMPARE(output, expected_output->len,
+    TEST_BUFFERS_EQUAL(output, expected_output->len,
                    expected_output->x, expected_output->len);
 
 exit:
@@ -260,7 +260,7 @@ void aria_decrypt_ctr(data_t *key_str, data_t *iv_str,
                                        iv_str->x, blk, src_str->x, output)
                 == result);
 
-    ASSERT_COMPARE(output, expected_output->len,
+    TEST_BUFFERS_EQUAL(output, expected_output->len,
                    expected_output->x, expected_output->len);
 
 exit:

--- a/tests/suites/test_suite_aria.function
+++ b/tests/suites/test_suite_aria.function
@@ -78,7 +78,7 @@ void aria_encrypt_ecb(data_t *key_str, data_t *src_str,
         }
 
         TEST_MEMORY_COMPARE(output, expected_output->len,
-                       expected_output->x, expected_output->len);
+                            expected_output->x, expected_output->len);
     }
 
 exit:
@@ -106,7 +106,7 @@ void aria_decrypt_ecb(data_t *key_str, data_t *src_str,
         }
 
         TEST_MEMORY_COMPARE(output, expected_output->len,
-                       expected_output->x, expected_output->len);
+                            expected_output->x, expected_output->len);
     }
 
 exit:
@@ -131,7 +131,7 @@ void aria_encrypt_cbc(data_t *key_str, data_t *iv_str,
                                        output) == cbc_result);
     if (cbc_result == 0) {
         TEST_MEMORY_COMPARE(output, expected_output->len,
-                       expected_output->x, expected_output->len);
+                            expected_output->x, expected_output->len);
     }
 
 exit:
@@ -156,7 +156,7 @@ void aria_decrypt_cbc(data_t *key_str, data_t *iv_str,
                                        output) == cbc_result);
     if (cbc_result == 0) {
         TEST_MEMORY_COMPARE(output, expected_output->len,
-                       expected_output->x, expected_output->len);
+                            expected_output->x, expected_output->len);
     }
 
 exit:
@@ -183,7 +183,7 @@ void aria_encrypt_cfb128(data_t *key_str, data_t *iv_str,
                 == result);
 
     TEST_MEMORY_COMPARE(output, expected_output->len,
-                   expected_output->x, expected_output->len);
+                        expected_output->x, expected_output->len);
 
 exit:
     mbedtls_aria_free(&ctx);
@@ -209,7 +209,7 @@ void aria_decrypt_cfb128(data_t *key_str, data_t *iv_str,
                 == result);
 
     TEST_MEMORY_COMPARE(output, expected_output->len,
-                   expected_output->x, expected_output->len);
+                        expected_output->x, expected_output->len);
 
 exit:
     mbedtls_aria_free(&ctx);
@@ -235,7 +235,7 @@ void aria_encrypt_ctr(data_t *key_str, data_t *iv_str,
                 == result);
 
     TEST_MEMORY_COMPARE(output, expected_output->len,
-                   expected_output->x, expected_output->len);
+                        expected_output->x, expected_output->len);
 
 exit:
     mbedtls_aria_free(&ctx);
@@ -261,7 +261,7 @@ void aria_decrypt_ctr(data_t *key_str, data_t *iv_str,
                 == result);
 
     TEST_MEMORY_COMPARE(output, expected_output->len,
-                   expected_output->x, expected_output->len);
+                        expected_output->x, expected_output->len);
 
 exit:
     mbedtls_aria_free(&ctx);

--- a/tests/suites/test_suite_asn1parse.function
+++ b/tests/suites/test_suite_asn1parse.function
@@ -139,7 +139,7 @@ int get_len_step(const data_t *input, size_t buffer_size,
         end = buf + 1;
         p = end;
     } else {
-        ASSERT_ALLOC_WEAK(buf, buffer_size);
+        TEST_CALLOC_OR_SKIP(buf, buffer_size);
         if (buffer_size > input->len) {
             memcpy(buf, input->x, input->len);
             memset(buf + input->len, 'A', buffer_size - input->len);

--- a/tests/suites/test_suite_asn1parse.function
+++ b/tests/suites/test_suite_asn1parse.function
@@ -135,7 +135,7 @@ int get_len_step(const data_t *input, size_t buffer_size,
     /* Allocate a new buffer of exactly the length to parse each time.
      * This gives memory sanitizers a chance to catch buffer overreads. */
     if (buffer_size == 0) {
-        TEST_CALLOC_OR_FAIL(buf, 1);
+        TEST_CALLOC(buf, 1);
         end = buf + 1;
         p = end;
     } else {
@@ -247,7 +247,7 @@ void parse_prefixes(const data_t *input,
         mbedtls_test_set_step(buffer_size);
         /* Allocate a new buffer of exactly the length to parse each time.
          * This gives memory sanitizers a chance to catch buffer overreads. */
-        TEST_CALLOC_OR_FAIL(buf, buffer_size);
+        TEST_CALLOC(buf, buffer_size);
         memcpy(buf, input->x, buffer_size);
         p = buf;
         ret = nested_parse(&p, buf + buffer_size);
@@ -506,7 +506,7 @@ void get_mpi_too_large()
 
     mbedtls_mpi_init(&actual_mpi);
 
-    TEST_CALLOC_OR_FAIL(buf, size);
+    TEST_CALLOC(buf, size);
     buf[0] = 0x02; /* tag: INTEGER */
     buf[1] = 0x84; /* 4-octet length */
     buf[2] = (too_many_octets >> 24) & 0xff;
@@ -729,10 +729,10 @@ void free_named_data(int with_oid, int with_val, int with_next)
     { { 0x06, 0, NULL }, { 0, 0, NULL }, NULL, 0 };
 
     if (with_oid) {
-        TEST_CALLOC_OR_FAIL(head.oid.p, 1);
+        TEST_CALLOC(head.oid.p, 1);
     }
     if (with_val) {
-        TEST_CALLOC_OR_FAIL(head.val.p, 1);
+        TEST_CALLOC(head.val.p, 1);
     }
     if (with_next) {
         head.next = &next;
@@ -758,7 +758,7 @@ void free_named_data_list(int length)
 
     for (i = 0; i < length; i++) {
         mbedtls_asn1_named_data *new = NULL;
-        TEST_CALLOC_OR_FAIL(new, 1);
+        TEST_CALLOC(new, 1);
         new->next = head;
         head = new;
     }

--- a/tests/suites/test_suite_asn1parse.function
+++ b/tests/suites/test_suite_asn1parse.function
@@ -135,7 +135,7 @@ int get_len_step(const data_t *input, size_t buffer_size,
     /* Allocate a new buffer of exactly the length to parse each time.
      * This gives memory sanitizers a chance to catch buffer overreads. */
     if (buffer_size == 0) {
-        ASSERT_ALLOC(buf, 1);
+        TEST_CALLOC_OR_FAIL(buf, 1);
         end = buf + 1;
         p = end;
     } else {
@@ -247,7 +247,7 @@ void parse_prefixes(const data_t *input,
         mbedtls_test_set_step(buffer_size);
         /* Allocate a new buffer of exactly the length to parse each time.
          * This gives memory sanitizers a chance to catch buffer overreads. */
-        ASSERT_ALLOC(buf, buffer_size);
+        TEST_CALLOC_OR_FAIL(buf, buffer_size);
         memcpy(buf, input->x, buffer_size);
         p = buf;
         ret = nested_parse(&p, buf + buffer_size);
@@ -506,7 +506,7 @@ void get_mpi_too_large()
 
     mbedtls_mpi_init(&actual_mpi);
 
-    ASSERT_ALLOC(buf, size);
+    TEST_CALLOC_OR_FAIL(buf, size);
     buf[0] = 0x02; /* tag: INTEGER */
     buf[1] = 0x84; /* 4-octet length */
     buf[2] = (too_many_octets >> 24) & 0xff;
@@ -729,10 +729,10 @@ void free_named_data(int with_oid, int with_val, int with_next)
     { { 0x06, 0, NULL }, { 0, 0, NULL }, NULL, 0 };
 
     if (with_oid) {
-        ASSERT_ALLOC(head.oid.p, 1);
+        TEST_CALLOC_OR_FAIL(head.oid.p, 1);
     }
     if (with_val) {
-        ASSERT_ALLOC(head.val.p, 1);
+        TEST_CALLOC_OR_FAIL(head.val.p, 1);
     }
     if (with_next) {
         head.next = &next;
@@ -758,7 +758,7 @@ void free_named_data_list(int length)
 
     for (i = 0; i < length; i++) {
         mbedtls_asn1_named_data *new = NULL;
-        ASSERT_ALLOC(new, 1);
+        TEST_CALLOC_OR_FAIL(new, 1);
         new->next = head;
         head = new;
     }

--- a/tests/suites/test_suite_asn1write.function
+++ b/tests/suites/test_suite_asn1write.function
@@ -37,7 +37,7 @@ int generic_write_finish_step(generic_write_data_t *data,
         TEST_EQUAL(ret, data->end - data->p);
         TEST_ASSERT(data->p >= data->start);
         TEST_ASSERT(data->p <= data->end);
-        TEST_BUFFERS_EQUAL(data->p, (size_t) (data->end - data->p),
+        TEST_MEMORY_COMPARE(data->p, (size_t) (data->end - data->p),
                        expected->x, expected->len);
     }
     ok = 1;
@@ -322,7 +322,7 @@ void mbedtls_asn1_write_algorithm_identifier(data_t *oid,
             TEST_EQUAL(mbedtls_asn1_get_alg(&p, end_complete,
                                             &alg, &params), 0);
             TEST_EQUAL(alg.tag, MBEDTLS_ASN1_OID);
-            TEST_BUFFERS_EQUAL(alg.p, alg.len, oid->x, oid->len);
+            TEST_MEMORY_COMPARE(alg.p, alg.len, oid->x, oid->len);
             TEST_EQUAL(params.tag, expected_params_tag);
             TEST_EQUAL(params.len, expected_params_len);
             mbedtls_free(buf_complete);
@@ -440,7 +440,7 @@ void test_asn1_write_bitstrings(data_t *bitstring, int bits,
             mbedtls_asn1_bitstring read = { 0, 0, NULL };
             TEST_EQUAL(mbedtls_asn1_get_bitstring(&data.p, data.end,
                                                   &read), 0);
-            TEST_BUFFERS_EQUAL(read.p, read.len,
+            TEST_MEMORY_COMPARE(read.p, read.len,
                            masked_bitstring, byte_length);
             TEST_EQUAL(read.unused_bits, 8 * byte_length - value_bits);
         }
@@ -545,7 +545,7 @@ void store_named_data_val_found(int old_len, int new_len)
     TEST_ASSERT(found == head);
 
     if (new_val != NULL) {
-        TEST_BUFFERS_EQUAL(found->val.p, found->val.len,
+        TEST_MEMORY_COMPARE(found->val.p, found->val.len,
                        new_val, (size_t) new_len);
     }
     if (new_len == 0) {
@@ -580,14 +580,14 @@ void store_named_data_val_new(int new_len, int set_new_val)
     TEST_ASSERT(found != NULL);
     TEST_ASSERT(found == head);
     TEST_ASSERT(found->oid.p != oid);
-    TEST_BUFFERS_EQUAL(found->oid.p, found->oid.len, oid, oid_len);
+    TEST_MEMORY_COMPARE(found->oid.p, found->oid.len, oid, oid_len);
     if (new_len == 0) {
         TEST_ASSERT(found->val.p == NULL);
     } else if (new_val == NULL) {
         TEST_ASSERT(found->val.p != NULL);
     } else {
         TEST_ASSERT(found->val.p != new_val);
-        TEST_BUFFERS_EQUAL(found->val.p, found->val.len,
+        TEST_MEMORY_COMPARE(found->val.p, found->val.len,
                        new_val, (size_t) new_len);
     }
 

--- a/tests/suites/test_suite_asn1write.function
+++ b/tests/suites/test_suite_asn1write.function
@@ -37,7 +37,7 @@ int generic_write_finish_step(generic_write_data_t *data,
         TEST_EQUAL(ret, data->end - data->p);
         TEST_ASSERT(data->p >= data->start);
         TEST_ASSERT(data->p <= data->end);
-        ASSERT_COMPARE(data->p, (size_t) (data->end - data->p),
+        TEST_BUFFERS_EQUAL(data->p, (size_t) (data->end - data->p),
                        expected->x, expected->len);
     }
     ok = 1;
@@ -322,7 +322,7 @@ void mbedtls_asn1_write_algorithm_identifier(data_t *oid,
             TEST_EQUAL(mbedtls_asn1_get_alg(&p, end_complete,
                                             &alg, &params), 0);
             TEST_EQUAL(alg.tag, MBEDTLS_ASN1_OID);
-            ASSERT_COMPARE(alg.p, alg.len, oid->x, oid->len);
+            TEST_BUFFERS_EQUAL(alg.p, alg.len, oid->x, oid->len);
             TEST_EQUAL(params.tag, expected_params_tag);
             TEST_EQUAL(params.len, expected_params_len);
             mbedtls_free(buf_complete);
@@ -440,7 +440,7 @@ void test_asn1_write_bitstrings(data_t *bitstring, int bits,
             mbedtls_asn1_bitstring read = { 0, 0, NULL };
             TEST_EQUAL(mbedtls_asn1_get_bitstring(&data.p, data.end,
                                                   &read), 0);
-            ASSERT_COMPARE(read.p, read.len,
+            TEST_BUFFERS_EQUAL(read.p, read.len,
                            masked_bitstring, byte_length);
             TEST_EQUAL(read.unused_bits, 8 * byte_length - value_bits);
         }
@@ -545,7 +545,7 @@ void store_named_data_val_found(int old_len, int new_len)
     TEST_ASSERT(found == head);
 
     if (new_val != NULL) {
-        ASSERT_COMPARE(found->val.p, found->val.len,
+        TEST_BUFFERS_EQUAL(found->val.p, found->val.len,
                        new_val, (size_t) new_len);
     }
     if (new_len == 0) {
@@ -580,14 +580,14 @@ void store_named_data_val_new(int new_len, int set_new_val)
     TEST_ASSERT(found != NULL);
     TEST_ASSERT(found == head);
     TEST_ASSERT(found->oid.p != oid);
-    ASSERT_COMPARE(found->oid.p, found->oid.len, oid, oid_len);
+    TEST_BUFFERS_EQUAL(found->oid.p, found->oid.len, oid, oid_len);
     if (new_len == 0) {
         TEST_ASSERT(found->val.p == NULL);
     } else if (new_val == NULL) {
         TEST_ASSERT(found->val.p != NULL);
     } else {
         TEST_ASSERT(found->val.p != new_val);
-        ASSERT_COMPARE(found->val.p, found->val.len,
+        TEST_BUFFERS_EQUAL(found->val.p, found->val.len,
                        new_val, (size_t) new_len);
     }
 

--- a/tests/suites/test_suite_asn1write.function
+++ b/tests/suites/test_suite_asn1write.function
@@ -17,7 +17,7 @@ int generic_write_start_step(generic_write_data_t *data)
     mbedtls_test_set_step(data->size);
     mbedtls_free(data->output);
     data->output = NULL;
-    ASSERT_ALLOC(data->output, data->size == 0 ? 1 : data->size);
+    TEST_CALLOC_OR_FAIL(data->output, data->size == 0 ? 1 : data->size);
     data->end = data->output + data->size;
     data->p = data->end;
     data->start = data->end - data->size;
@@ -296,7 +296,7 @@ void mbedtls_asn1_write_algorithm_identifier(data_t *oid,
             size_t len_complete = data_len + par_len;
             unsigned char expected_params_tag;
             size_t expected_params_len;
-            ASSERT_ALLOC(buf_complete, len_complete);
+            TEST_CALLOC_OR_FAIL(buf_complete, len_complete);
             unsigned char *end_complete = buf_complete + len_complete;
             memcpy(buf_complete, data.p, data_len);
             if (par_len == 0) {
@@ -404,7 +404,7 @@ void test_asn1_write_bitstrings(data_t *bitstring, int bits,
     TEST_ASSERT(bitstring->len >= byte_length);
 
 #if defined(MBEDTLS_ASN1_PARSE_C)
-    ASSERT_ALLOC(masked_bitstring, byte_length);
+    TEST_CALLOC_OR_FAIL(masked_bitstring, byte_length);
     if (byte_length != 0) {
         memcpy(masked_bitstring, bitstring->x, byte_length);
         if (bits % 8 != 0) {
@@ -477,7 +477,7 @@ void store_named_data_find(data_t *oid0, data_t *oid1,
     }
     pointers[ARRAY_LENGTH(nd)] = NULL;
     for (i = 0; i < ARRAY_LENGTH(nd); i++) {
-        ASSERT_ALLOC(nd[i].oid.p, oid[i]->len);
+        TEST_CALLOC_OR_FAIL(nd[i].oid.p, oid[i]->len);
         memcpy(nd[i].oid.p, oid[i]->x, oid[i]->len);
         nd[i].oid.len = oid[i]->len;
         nd[i].next = pointers[i+1];
@@ -529,7 +529,7 @@ void store_named_data_val_found(int old_len, int new_len)
     unsigned char *new_val = (unsigned char *) "new value";
 
     if (old_len != 0) {
-        ASSERT_ALLOC(nd.val.p, (size_t) old_len);
+        TEST_CALLOC_OR_FAIL(nd.val.p, (size_t) old_len);
         old_val = nd.val.p;
         nd.val.len = old_len;
         memset(old_val, 'x', old_len);

--- a/tests/suites/test_suite_asn1write.function
+++ b/tests/suites/test_suite_asn1write.function
@@ -38,7 +38,7 @@ int generic_write_finish_step(generic_write_data_t *data,
         TEST_ASSERT(data->p >= data->start);
         TEST_ASSERT(data->p <= data->end);
         TEST_MEMORY_COMPARE(data->p, (size_t) (data->end - data->p),
-                       expected->x, expected->len);
+                            expected->x, expected->len);
     }
     ok = 1;
 
@@ -441,7 +441,7 @@ void test_asn1_write_bitstrings(data_t *bitstring, int bits,
             TEST_EQUAL(mbedtls_asn1_get_bitstring(&data.p, data.end,
                                                   &read), 0);
             TEST_MEMORY_COMPARE(read.p, read.len,
-                           masked_bitstring, byte_length);
+                                masked_bitstring, byte_length);
             TEST_EQUAL(read.unused_bits, 8 * byte_length - value_bits);
         }
 #endif /* MBEDTLS_ASN1_PARSE_C */
@@ -546,7 +546,7 @@ void store_named_data_val_found(int old_len, int new_len)
 
     if (new_val != NULL) {
         TEST_MEMORY_COMPARE(found->val.p, found->val.len,
-                       new_val, (size_t) new_len);
+                            new_val, (size_t) new_len);
     }
     if (new_len == 0) {
         TEST_ASSERT(found->val.p == NULL);
@@ -588,7 +588,7 @@ void store_named_data_val_new(int new_len, int set_new_val)
     } else {
         TEST_ASSERT(found->val.p != new_val);
         TEST_MEMORY_COMPARE(found->val.p, found->val.len,
-                       new_val, (size_t) new_len);
+                            new_val, (size_t) new_len);
     }
 
 exit:

--- a/tests/suites/test_suite_asn1write.function
+++ b/tests/suites/test_suite_asn1write.function
@@ -17,7 +17,7 @@ int generic_write_start_step(generic_write_data_t *data)
     mbedtls_test_set_step(data->size);
     mbedtls_free(data->output);
     data->output = NULL;
-    TEST_CALLOC_OR_FAIL(data->output, data->size == 0 ? 1 : data->size);
+    TEST_CALLOC(data->output, data->size == 0 ? 1 : data->size);
     data->end = data->output + data->size;
     data->p = data->end;
     data->start = data->end - data->size;
@@ -296,7 +296,7 @@ void mbedtls_asn1_write_algorithm_identifier(data_t *oid,
             size_t len_complete = data_len + par_len;
             unsigned char expected_params_tag;
             size_t expected_params_len;
-            TEST_CALLOC_OR_FAIL(buf_complete, len_complete);
+            TEST_CALLOC(buf_complete, len_complete);
             unsigned char *end_complete = buf_complete + len_complete;
             memcpy(buf_complete, data.p, data_len);
             if (par_len == 0) {
@@ -404,7 +404,7 @@ void test_asn1_write_bitstrings(data_t *bitstring, int bits,
     TEST_ASSERT(bitstring->len >= byte_length);
 
 #if defined(MBEDTLS_ASN1_PARSE_C)
-    TEST_CALLOC_OR_FAIL(masked_bitstring, byte_length);
+    TEST_CALLOC(masked_bitstring, byte_length);
     if (byte_length != 0) {
         memcpy(masked_bitstring, bitstring->x, byte_length);
         if (bits % 8 != 0) {
@@ -477,7 +477,7 @@ void store_named_data_find(data_t *oid0, data_t *oid1,
     }
     pointers[ARRAY_LENGTH(nd)] = NULL;
     for (i = 0; i < ARRAY_LENGTH(nd); i++) {
-        TEST_CALLOC_OR_FAIL(nd[i].oid.p, oid[i]->len);
+        TEST_CALLOC(nd[i].oid.p, oid[i]->len);
         memcpy(nd[i].oid.p, oid[i]->x, oid[i]->len);
         nd[i].oid.len = oid[i]->len;
         nd[i].next = pointers[i+1];
@@ -529,7 +529,7 @@ void store_named_data_val_found(int old_len, int new_len)
     unsigned char *new_val = (unsigned char *) "new value";
 
     if (old_len != 0) {
-        TEST_CALLOC_OR_FAIL(nd.val.p, (size_t) old_len);
+        TEST_CALLOC(nd.val.p, (size_t) old_len);
         old_val = nd.val.p;
         nd.val.len = old_len;
         memset(old_val, 'x', old_len);

--- a/tests/suites/test_suite_bignum_core.function
+++ b/tests/suites/test_suite_bignum_core.function
@@ -1047,7 +1047,7 @@ void mpi_core_ct_uint_table_lookup(int bitlen, int window_size)
         TEST_CF_PUBLIC(dest, limbs * sizeof(*dest));
         TEST_CF_PUBLIC(table, count * limbs * sizeof(*table));
         TEST_MEMORY_COMPARE(dest, limbs * sizeof(*dest),
-                       current, limbs * sizeof(*current));
+                            current, limbs * sizeof(*current));
         TEST_CF_PUBLIC(&i, sizeof(i));
     }
 
@@ -1280,7 +1280,8 @@ void mpi_core_sub_int(char *input_A, char *input_B,
     TEST_CALLOC(R, limbs);
 
 #define TEST_COMPARE_CORE_MPIS(A, B, limbs) \
-    TEST_MEMORY_COMPARE(A, (limbs) * sizeof(mbedtls_mpi_uint), B, (limbs) * sizeof(mbedtls_mpi_uint))
+    TEST_MEMORY_COMPARE(A, (limbs) * sizeof(mbedtls_mpi_uint), \
+                        B, (limbs) * sizeof(mbedtls_mpi_uint))
 
     /* 1. R = A - b. Result and borrow should be correct */
     TEST_EQUAL(mbedtls_mpi_core_sub_int(R, A, B[0], limbs), borrow);

--- a/tests/suites/test_suite_bignum_core.function
+++ b/tests/suites/test_suite_bignum_core.function
@@ -493,10 +493,10 @@ void mpi_core_cond_swap(char *input_X,
     TEST_EQUAL(limbs_X, limbs_Y);
     TEST_ASSERT(copy_limbs <= limbs);
 
-    TEST_CALLOC_OR_FAIL(X, limbs);
+    TEST_CALLOC(X, limbs);
     memcpy(X, tmp_X, bytes);
 
-    TEST_CALLOC_OR_FAIL(Y, limbs);
+    TEST_CALLOC(Y, limbs);
     memcpy(Y, tmp_Y, bytes);
 
     /* condition is false */
@@ -601,7 +601,7 @@ void mpi_core_add_and_add_if(char *input_A, char *input_B,
     TEST_EQUAL(A_limbs, S_limbs);
 
     size_t limbs = A_limbs;
-    TEST_CALLOC_OR_FAIL(X, limbs);
+    TEST_CALLOC(X, limbs);
 
     TEST_ASSERT(mpi_core_verify_add(A, B, limbs, S, carry, X));
     TEST_ASSERT(mpi_core_verify_add_if(A, B, limbs, S, carry, X));
@@ -646,15 +646,15 @@ void mpi_core_sub(char *input_A, char *input_B,
 
     /* Now let's get arrays of mbedtls_mpi_uints, rather than MPI structures */
 
-    /* TEST_CALLOC_OR_FAIL() uses calloc() under the hood, so these do get zeroed */
-    TEST_CALLOC_OR_FAIL(a, bytes);
-    TEST_CALLOC_OR_FAIL(b, bytes);
-    TEST_CALLOC_OR_FAIL(x, bytes);
-    TEST_CALLOC_OR_FAIL(r, bytes);
+    /* TEST_CALLOC() uses calloc() under the hood, so these do get zeroed */
+    TEST_CALLOC(a, bytes);
+    TEST_CALLOC(b, bytes);
+    TEST_CALLOC(x, bytes);
+    TEST_CALLOC(r, bytes);
 
     /* Populate the arrays. As the mbedtls_mpi_uint[]s in mbedtls_mpis (and as
      * processed by mbedtls_mpi_core_sub()) are little endian, we can just
-     * copy what we have as long as MSBs are 0 (which they are from TEST_CALLOC_OR_FAIL())
+     * copy what we have as long as MSBs are 0 (which they are from TEST_CALLOC())
      */
     memcpy(a, A.p, A.n * sizeof(mbedtls_mpi_uint));
     memcpy(b, B.p, B.n * sizeof(mbedtls_mpi_uint));
@@ -759,13 +759,13 @@ void mpi_core_mla(char *input_A, char *input_B, char *input_S,
 
     /* Now let's get arrays of mbedtls_mpi_uints, rather than MPI structures */
 
-    /* TEST_CALLOC_OR_FAIL() uses calloc() under the hood, so these do get zeroed */
-    TEST_CALLOC_OR_FAIL(a, bytes);
-    TEST_CALLOC_OR_FAIL(x, bytes);
+    /* TEST_CALLOC() uses calloc() under the hood, so these do get zeroed */
+    TEST_CALLOC(a, bytes);
+    TEST_CALLOC(x, bytes);
 
     /* Populate the arrays. As the mbedtls_mpi_uint[]s in mbedtls_mpis (and as
      * processed by mbedtls_mpi_core_mla()) are little endian, we can just
-     * copy what we have as long as MSBs are 0 (which they are from TEST_CALLOC_OR_FAIL()).
+     * copy what we have as long as MSBs are 0 (which they are from TEST_CALLOC()).
      */
     memcpy(a, A.p, A.n * sizeof(mbedtls_mpi_uint));
     memcpy(x, X->p, X->n * sizeof(mbedtls_mpi_uint));
@@ -1017,8 +1017,8 @@ void mpi_core_ct_uint_table_lookup(int bitlen, int window_size)
     mbedtls_mpi_uint *table = NULL;
     mbedtls_mpi_uint *dest = NULL;
 
-    TEST_CALLOC_OR_FAIL(table, limbs * count);
-    TEST_CALLOC_OR_FAIL(dest, limbs);
+    TEST_CALLOC(table, limbs * count);
+    TEST_CALLOC(dest, limbs);
 
     /*
      * Fill the table with a unique counter so that differences are easily
@@ -1070,7 +1070,7 @@ void mpi_core_fill_random(int wanted_bytes_arg, int extra_rng_bytes,
     int ret;
 
     /* Prepare an RNG with known output, limited to rng_bytes. */
-    TEST_CALLOC_OR_FAIL(rnd_data, rng_bytes);
+    TEST_CALLOC(rnd_data, rng_bytes);
     TEST_EQUAL(0, mbedtls_test_rnd_std_rand(NULL, rnd_data, rng_bytes));
     rnd_info.buf = rnd_data;
 
@@ -1078,7 +1078,7 @@ void mpi_core_fill_random(int wanted_bytes_arg, int extra_rng_bytes,
      * extra_limbs may be negative but the total limb count must be positive.
      * Fill the MPI with the byte value in before. */
     TEST_LE_U(1, X_limbs);
-    TEST_CALLOC_OR_FAIL(X, X_limbs);
+    TEST_CALLOC(X, X_limbs);
     memset(X, before, X_limbs * sizeof(*X));
 
     ret = mbedtls_mpi_core_fill_random(X, X_limbs, wanted_bytes,
@@ -1128,14 +1128,14 @@ void mpi_core_mul(char *input_A,
 
     const size_t X_limbs = A_limbs + B_limbs;
     const size_t X_bytes = X_limbs * sizeof(mbedtls_mpi_uint);
-    TEST_CALLOC_OR_FAIL(X, X_limbs);
+    TEST_CALLOC(X, X_limbs);
 
     const size_t A_bytes = A_limbs * sizeof(mbedtls_mpi_uint);
-    TEST_CALLOC_OR_FAIL(A_orig, A_limbs);
+    TEST_CALLOC(A_orig, A_limbs);
     memcpy(A_orig, A, A_bytes);
 
     const size_t B_bytes = B_limbs * sizeof(mbedtls_mpi_uint);
-    TEST_CALLOC_OR_FAIL(B_orig, B_limbs);
+    TEST_CALLOC(B_orig, B_limbs);
     memcpy(B_orig, B, B_bytes);
 
     /* Set result to something that is unlikely to be correct */
@@ -1195,7 +1195,7 @@ void mpi_core_exp_mod(char *input_N, char *input_A,
     TEST_EQUAL(0, mbedtls_test_read_mpi_core(&E, &E_limbs, input_E));
     TEST_EQUAL(0, mbedtls_test_read_mpi_core(&N, &N_limbs, input_N));
     TEST_EQUAL(0, mbedtls_test_read_mpi_core(&X, &X_limbs, input_X));
-    TEST_CALLOC_OR_FAIL(Y, N_limbs);
+    TEST_CALLOC(Y, N_limbs);
 
     TEST_EQUAL(A_limbs, N_limbs);
     TEST_EQUAL(X_limbs, N_limbs);
@@ -1227,7 +1227,7 @@ void mpi_core_exp_mod(char *input_N, char *input_A,
     TEST_LE_U(mbedtls_mpi_core_montmul_working_limbs(N_limbs),
               working_limbs);
 
-    TEST_CALLOC_OR_FAIL(T, working_limbs);
+    TEST_CALLOC(T, working_limbs);
 
     mbedtls_mpi_core_exp_mod(Y, A, N, N_limbs, E, E_limbs, R2, T);
 
@@ -1277,7 +1277,7 @@ void mpi_core_sub_int(char *input_A, char *input_B,
     TEST_EQUAL(A_limbs, X_limbs);
     size_t limbs = A_limbs;
 
-    TEST_CALLOC_OR_FAIL(R, limbs);
+    TEST_CALLOC(R, limbs);
 
 #define TEST_COMPARE_CORE_MPIS(A, B, limbs) \
     TEST_BUFFERS_EQUAL(A, (limbs) * sizeof(mbedtls_mpi_uint), B, (limbs) * sizeof(mbedtls_mpi_uint))

--- a/tests/suites/test_suite_bignum_core.function
+++ b/tests/suites/test_suite_bignum_core.function
@@ -34,45 +34,45 @@ static int mpi_core_verify_add(mbedtls_mpi_uint *A,
 
     /* A + B => correct result and carry */
     TEST_EQUAL(carry, mbedtls_mpi_core_add(X, A, B, limbs));
-    ASSERT_COMPARE(X, bytes, S, bytes);
+    TEST_BUFFERS_EQUAL(X, bytes, S, bytes);
 
     /* A + B; alias output and first operand => correct result and carry */
     memcpy(X, A, bytes);
     TEST_EQUAL(carry, mbedtls_mpi_core_add(X, X, B, limbs));
-    ASSERT_COMPARE(X, bytes, S, bytes);
+    TEST_BUFFERS_EQUAL(X, bytes, S, bytes);
 
     /* A + B; alias output and second operand => correct result and carry */
     memcpy(X, B, bytes);
     TEST_EQUAL(carry, mbedtls_mpi_core_add(X, A, X, limbs));
-    ASSERT_COMPARE(X, bytes, S, bytes);
+    TEST_BUFFERS_EQUAL(X, bytes, S, bytes);
 
     if (memcmp(A, B, bytes) == 0) {
         /* A == B, so test where A and B are aliased */
 
         /* A + A => correct result and carry */
         TEST_EQUAL(carry, mbedtls_mpi_core_add(X, A, A, limbs));
-        ASSERT_COMPARE(X, bytes, S, bytes);
+        TEST_BUFFERS_EQUAL(X, bytes, S, bytes);
 
         /* A + A, output aliased to both operands => correct result and carry */
         memcpy(X, A, bytes);
         TEST_EQUAL(carry, mbedtls_mpi_core_add(X, X, X, limbs));
-        ASSERT_COMPARE(X, bytes, S, bytes);
+        TEST_BUFFERS_EQUAL(X, bytes, S, bytes);
     } else {
         /* A != B, so test B + A */
 
         /* B + A => correct result and carry */
         TEST_EQUAL(carry, mbedtls_mpi_core_add(X, B, A, limbs));
-        ASSERT_COMPARE(X, bytes, S, bytes);
+        TEST_BUFFERS_EQUAL(X, bytes, S, bytes);
 
         /* B + A; alias output and first operand => correct result and carry */
         memcpy(X, B, bytes);
         TEST_EQUAL(carry, mbedtls_mpi_core_add(X, X, A, limbs));
-        ASSERT_COMPARE(X, bytes, S, bytes);
+        TEST_BUFFERS_EQUAL(X, bytes, S, bytes);
 
         /* B + A; alias output and second operand => correct result and carry */
         memcpy(X, A, bytes);
         TEST_EQUAL(carry, mbedtls_mpi_core_add(X, B, X, limbs));
-        ASSERT_COMPARE(X, bytes, S, bytes);
+        TEST_BUFFERS_EQUAL(X, bytes, S, bytes);
     }
 
     ret = 1;
@@ -111,11 +111,11 @@ static int mpi_core_verify_add_if(mbedtls_mpi_uint *A,
     /* cond = 0 => X unchanged, no carry */
     memcpy(X, A, bytes);
     TEST_EQUAL(0, mbedtls_mpi_core_add_if(X, B, limbs, 0));
-    ASSERT_COMPARE(X, bytes, A, bytes);
+    TEST_BUFFERS_EQUAL(X, bytes, A, bytes);
 
     /* cond = 1 => correct result and carry */
     TEST_EQUAL(carry, mbedtls_mpi_core_add_if(X, B, limbs, 1));
-    ASSERT_COMPARE(X, bytes, S, bytes);
+    TEST_BUFFERS_EQUAL(X, bytes, S, bytes);
 
     if (memcmp(A, B, bytes) == 0) {
         /* A == B, so test where A and B are aliased */
@@ -123,22 +123,22 @@ static int mpi_core_verify_add_if(mbedtls_mpi_uint *A,
         /* cond = 0 => X unchanged, no carry */
         memcpy(X, B, bytes);
         TEST_EQUAL(0, mbedtls_mpi_core_add_if(X, X, limbs, 0));
-        ASSERT_COMPARE(X, bytes, B, bytes);
+        TEST_BUFFERS_EQUAL(X, bytes, B, bytes);
 
         /* cond = 1 => correct result and carry */
         TEST_EQUAL(carry, mbedtls_mpi_core_add_if(X, X, limbs, 1));
-        ASSERT_COMPARE(X, bytes, S, bytes);
+        TEST_BUFFERS_EQUAL(X, bytes, S, bytes);
     } else {
         /* A != B, so test B + A */
 
         /* cond = 0 => d unchanged, no carry */
         memcpy(X, B, bytes);
         TEST_EQUAL(0, mbedtls_mpi_core_add_if(X, A, limbs, 0));
-        ASSERT_COMPARE(X, bytes, B, bytes);
+        TEST_BUFFERS_EQUAL(X, bytes, B, bytes);
 
         /* cond = 1 => correct result and carry */
         TEST_EQUAL(carry, mbedtls_mpi_core_add_if(X, A, limbs, 1));
-        ASSERT_COMPARE(X, bytes, S, bytes);
+        TEST_BUFFERS_EQUAL(X, bytes, S, bytes);
     }
 
     ret = 1;
@@ -458,10 +458,10 @@ void mpi_core_cond_assign(char *input_X,
         TEST_CF_PUBLIC(X, bytes);
         TEST_CF_PUBLIC(Y, bytes);
 
-        ASSERT_COMPARE(X, copy_bytes, Y, copy_bytes);
+        TEST_BUFFERS_EQUAL(X, copy_bytes, Y, copy_bytes);
         TEST_ASSERT(memcmp(X, Y, bytes) != 0);
     } else {
-        ASSERT_COMPARE(X, bytes, Y, bytes);
+        TEST_BUFFERS_EQUAL(X, bytes, Y, bytes);
     }
 
 exit:
@@ -508,8 +508,8 @@ void mpi_core_cond_swap(char *input_X,
     TEST_CF_PUBLIC(X, bytes);
     TEST_CF_PUBLIC(Y, bytes);
 
-    ASSERT_COMPARE(X, bytes, tmp_X, bytes);
-    ASSERT_COMPARE(Y, bytes, tmp_Y, bytes);
+    TEST_BUFFERS_EQUAL(X, bytes, tmp_X, bytes);
+    TEST_BUFFERS_EQUAL(Y, bytes, tmp_Y, bytes);
 
     /* condition is true */
     TEST_CF_SECRET(X, bytes);
@@ -523,15 +523,15 @@ void mpi_core_cond_swap(char *input_X,
     /* Check if the given length is copied even it is smaller
        than the length of the given MPIs. */
     if (copy_limbs < limbs) {
-        ASSERT_COMPARE(X, copy_bytes, tmp_Y, copy_bytes);
-        ASSERT_COMPARE(Y, copy_bytes, tmp_X, copy_bytes);
+        TEST_BUFFERS_EQUAL(X, copy_bytes, tmp_Y, copy_bytes);
+        TEST_BUFFERS_EQUAL(Y, copy_bytes, tmp_X, copy_bytes);
         TEST_ASSERT(memcmp(X, tmp_X, bytes) != 0);
         TEST_ASSERT(memcmp(X, tmp_Y, bytes) != 0);
         TEST_ASSERT(memcmp(Y, tmp_X, bytes) != 0);
         TEST_ASSERT(memcmp(Y, tmp_Y, bytes) != 0);
     } else {
-        ASSERT_COMPARE(X, bytes, tmp_Y, bytes);
-        ASSERT_COMPARE(Y, bytes, tmp_X, bytes);
+        TEST_BUFFERS_EQUAL(X, bytes, tmp_Y, bytes);
+        TEST_BUFFERS_EQUAL(Y, bytes, tmp_X, bytes);
     }
 
 exit:
@@ -554,7 +554,7 @@ void mpi_core_shift_r(char *input, int count, char *result)
     TEST_EQUAL(limbs, n);
 
     mbedtls_mpi_core_shift_r(X, limbs, count);
-    ASSERT_COMPARE(X, limbs * ciL, Y, limbs * ciL);
+    TEST_BUFFERS_EQUAL(X, limbs * ciL, Y, limbs * ciL);
 
 exit:
     mbedtls_free(X);
@@ -574,7 +574,7 @@ void mpi_core_shift_l(char *input, int count, char *result)
     TEST_EQUAL(limbs, n);
 
     mbedtls_mpi_core_shift_l(X, limbs, count);
-    ASSERT_COMPARE(X, limbs * ciL, Y, limbs * ciL);
+    TEST_BUFFERS_EQUAL(X, limbs * ciL, Y, limbs * ciL);
 
 exit:
     mbedtls_free(X);
@@ -664,7 +664,7 @@ void mpi_core_sub(char *input_A, char *input_B,
     TEST_EQUAL(carry, mbedtls_mpi_core_sub(r, a, b, limbs));
 
     /* 1b) r = a - b => we should get the correct result */
-    ASSERT_COMPARE(r, bytes, x, bytes);
+    TEST_BUFFERS_EQUAL(r, bytes, x, bytes);
 
     /* 2 and 3 test "r may be aliased to a or b" */
     /* 2a) r = a; r -= b => we should get the correct carry (use r to avoid clobbering a) */
@@ -672,20 +672,20 @@ void mpi_core_sub(char *input_A, char *input_B,
     TEST_EQUAL(carry, mbedtls_mpi_core_sub(r, r, b, limbs));
 
     /* 2b) r -= b => we should get the correct result */
-    ASSERT_COMPARE(r, bytes, x, bytes);
+    TEST_BUFFERS_EQUAL(r, bytes, x, bytes);
 
     /* 3a) r = b; r = a - r => we should get the correct carry (use r to avoid clobbering b) */
     memcpy(r, b, bytes);
     TEST_EQUAL(carry, mbedtls_mpi_core_sub(r, a, r, limbs));
 
     /* 3b) r = a - b => we should get the correct result */
-    ASSERT_COMPARE(r, bytes, x, bytes);
+    TEST_BUFFERS_EQUAL(r, bytes, x, bytes);
 
     /* 4 tests "r may be aliased to [...] both" */
     if (A.n == B.n && memcmp(A.p, B.p, bytes) == 0) {
         memcpy(r, b, bytes);
         TEST_EQUAL(carry, mbedtls_mpi_core_sub(r, r, r, limbs));
-        ASSERT_COMPARE(r, bytes, x, bytes);
+        TEST_BUFFERS_EQUAL(r, bytes, x, bytes);
     }
 
 exit:
@@ -774,13 +774,13 @@ void mpi_core_mla(char *input_A, char *input_B, char *input_S,
     TEST_EQUAL(mbedtls_mpi_core_mla(a, limbs, B.p, B.n, *S.p), *cy->p);
 
     /* 1b) A += B * s => we should get the correct result */
-    ASSERT_COMPARE(a, bytes, x, bytes);
+    TEST_BUFFERS_EQUAL(a, bytes, x, bytes);
 
     if (A.n == B.n && memcmp(A.p, B.p, bytes) == 0) {
         /* Check when A and B are aliased */
         memcpy(a, A.p, A.n * sizeof(mbedtls_mpi_uint));
         TEST_EQUAL(mbedtls_mpi_core_mla(a, limbs, a, limbs, *S.p), *cy->p);
-        ASSERT_COMPARE(a, bytes, x, bytes);
+        TEST_BUFFERS_EQUAL(a, bytes, x, bytes);
     }
 
 exit:
@@ -890,14 +890,14 @@ void mpi_core_montmul(int limbs_AN4, int limbs_B4,
 
     mbedtls_mpi_core_montmul(R.p, A.p, B.p, B.n, N.p, N.n, mm, T.p);
     size_t bytes = N.n * sizeof(mbedtls_mpi_uint);
-    ASSERT_COMPARE(R.p, bytes, X->p, bytes);
+    TEST_BUFFERS_EQUAL(R.p, bytes, X->p, bytes);
 
     /* The output (R, above) may be aliased to A - use R to save the value of A */
 
     memcpy(R.p, A.p, bytes);
 
     mbedtls_mpi_core_montmul(A.p, A.p, B.p, B.n, N.p, N.n, mm, T.p);
-    ASSERT_COMPARE(A.p, bytes, X->p, bytes);
+    TEST_BUFFERS_EQUAL(A.p, bytes, X->p, bytes);
 
     memcpy(A.p, R.p, bytes);    /* restore A */
 
@@ -906,7 +906,7 @@ void mpi_core_montmul(int limbs_AN4, int limbs_B4,
     memcpy(R.p, N.p, bytes);
 
     mbedtls_mpi_core_montmul(N.p, A.p, B.p, B.n, N.p, N.n, mm, T.p);
-    ASSERT_COMPARE(N.p, bytes, X->p, bytes);
+    TEST_BUFFERS_EQUAL(N.p, bytes, X->p, bytes);
 
     memcpy(N.p, R.p, bytes);
 
@@ -917,7 +917,7 @@ void mpi_core_montmul(int limbs_AN4, int limbs_B4,
              * don't bother with yet another test with only A and B aliased */
 
             mbedtls_mpi_core_montmul(B.p, B.p, B.p, B.n, N.p, N.n, mm, T.p);
-            ASSERT_COMPARE(B.p, bytes, X->p, bytes);
+            TEST_BUFFERS_EQUAL(B.p, bytes, X->p, bytes);
 
             memcpy(B.p, A.p, bytes);    /* restore B from equal value A */
         }
@@ -925,7 +925,7 @@ void mpi_core_montmul(int limbs_AN4, int limbs_B4,
         /* The output may be aliased to B - last test, so we don't save B */
 
         mbedtls_mpi_core_montmul(B.p, A.p, B.p, B.n, N.p, N.n, mm, T.p);
-        ASSERT_COMPARE(B.p, bytes, X->p, bytes);
+        TEST_BUFFERS_EQUAL(B.p, bytes, X->p, bytes);
     }
 
 exit:
@@ -1046,7 +1046,7 @@ void mpi_core_ct_uint_table_lookup(int bitlen, int window_size)
 
         TEST_CF_PUBLIC(dest, limbs * sizeof(*dest));
         TEST_CF_PUBLIC(table, count * limbs * sizeof(*table));
-        ASSERT_COMPARE(dest, limbs * sizeof(*dest),
+        TEST_BUFFERS_EQUAL(dest, limbs * sizeof(*dest),
                        current, limbs * sizeof(*current));
         TEST_CF_PUBLIC(&i, sizeof(i));
     }
@@ -1143,24 +1143,24 @@ void mpi_core_mul(char *input_A,
 
     /* 1. X = A * B - result should be correct, A and B unchanged */
     mbedtls_mpi_core_mul(X, A, A_limbs, B, B_limbs);
-    ASSERT_COMPARE(X, X_bytes, R, X_bytes);
-    ASSERT_COMPARE(A, A_bytes, A_orig, A_bytes);
-    ASSERT_COMPARE(B, B_bytes, B_orig, B_bytes);
+    TEST_BUFFERS_EQUAL(X, X_bytes, R, X_bytes);
+    TEST_BUFFERS_EQUAL(A, A_bytes, A_orig, A_bytes);
+    TEST_BUFFERS_EQUAL(B, B_bytes, B_orig, B_bytes);
 
     /* 2. A == B: alias A and B - result should be correct, A and B unchanged */
     if (A_bytes == B_bytes && memcmp(A, B, A_bytes) == 0) {
         memset(X, '!', X_bytes);
         mbedtls_mpi_core_mul(X, A, A_limbs, A, A_limbs);
-        ASSERT_COMPARE(X, X_bytes, R, X_bytes);
-        ASSERT_COMPARE(A, A_bytes, A_orig, A_bytes);
+        TEST_BUFFERS_EQUAL(X, X_bytes, R, X_bytes);
+        TEST_BUFFERS_EQUAL(A, A_bytes, A_orig, A_bytes);
     }
     /* 3. X = B * A - result should be correct, A and B unchanged */
     else {
         memset(X, '!', X_bytes);
         mbedtls_mpi_core_mul(X, B, B_limbs, A, A_limbs);
-        ASSERT_COMPARE(X, X_bytes, R, X_bytes);
-        ASSERT_COMPARE(A, A_bytes, A_orig, A_bytes);
-        ASSERT_COMPARE(B, B_bytes, B_orig, B_bytes);
+        TEST_BUFFERS_EQUAL(X, X_bytes, R, X_bytes);
+        TEST_BUFFERS_EQUAL(A, A_bytes, A_orig, A_bytes);
+        TEST_BUFFERS_EQUAL(B, B_bytes, B_orig, B_bytes);
     }
 
 exit:
@@ -1280,7 +1280,7 @@ void mpi_core_sub_int(char *input_A, char *input_B,
     ASSERT_ALLOC(R, limbs);
 
 #define TEST_COMPARE_CORE_MPIS(A, B, limbs) \
-    ASSERT_COMPARE(A, (limbs) * sizeof(mbedtls_mpi_uint), B, (limbs) * sizeof(mbedtls_mpi_uint))
+    TEST_BUFFERS_EQUAL(A, (limbs) * sizeof(mbedtls_mpi_uint), B, (limbs) * sizeof(mbedtls_mpi_uint))
 
     /* 1. R = A - b. Result and borrow should be correct */
     TEST_EQUAL(mbedtls_mpi_core_sub_int(R, A, B[0], limbs), borrow);

--- a/tests/suites/test_suite_bignum_core.function
+++ b/tests/suites/test_suite_bignum_core.function
@@ -493,10 +493,10 @@ void mpi_core_cond_swap(char *input_X,
     TEST_EQUAL(limbs_X, limbs_Y);
     TEST_ASSERT(copy_limbs <= limbs);
 
-    ASSERT_ALLOC(X, limbs);
+    TEST_CALLOC_OR_FAIL(X, limbs);
     memcpy(X, tmp_X, bytes);
 
-    ASSERT_ALLOC(Y, limbs);
+    TEST_CALLOC_OR_FAIL(Y, limbs);
     memcpy(Y, tmp_Y, bytes);
 
     /* condition is false */
@@ -601,7 +601,7 @@ void mpi_core_add_and_add_if(char *input_A, char *input_B,
     TEST_EQUAL(A_limbs, S_limbs);
 
     size_t limbs = A_limbs;
-    ASSERT_ALLOC(X, limbs);
+    TEST_CALLOC_OR_FAIL(X, limbs);
 
     TEST_ASSERT(mpi_core_verify_add(A, B, limbs, S, carry, X));
     TEST_ASSERT(mpi_core_verify_add_if(A, B, limbs, S, carry, X));
@@ -646,15 +646,15 @@ void mpi_core_sub(char *input_A, char *input_B,
 
     /* Now let's get arrays of mbedtls_mpi_uints, rather than MPI structures */
 
-    /* ASSERT_ALLOC() uses calloc() under the hood, so these do get zeroed */
-    ASSERT_ALLOC(a, bytes);
-    ASSERT_ALLOC(b, bytes);
-    ASSERT_ALLOC(x, bytes);
-    ASSERT_ALLOC(r, bytes);
+    /* TEST_CALLOC_OR_FAIL() uses calloc() under the hood, so these do get zeroed */
+    TEST_CALLOC_OR_FAIL(a, bytes);
+    TEST_CALLOC_OR_FAIL(b, bytes);
+    TEST_CALLOC_OR_FAIL(x, bytes);
+    TEST_CALLOC_OR_FAIL(r, bytes);
 
     /* Populate the arrays. As the mbedtls_mpi_uint[]s in mbedtls_mpis (and as
      * processed by mbedtls_mpi_core_sub()) are little endian, we can just
-     * copy what we have as long as MSBs are 0 (which they are from ASSERT_ALLOC())
+     * copy what we have as long as MSBs are 0 (which they are from TEST_CALLOC_OR_FAIL())
      */
     memcpy(a, A.p, A.n * sizeof(mbedtls_mpi_uint));
     memcpy(b, B.p, B.n * sizeof(mbedtls_mpi_uint));
@@ -759,13 +759,13 @@ void mpi_core_mla(char *input_A, char *input_B, char *input_S,
 
     /* Now let's get arrays of mbedtls_mpi_uints, rather than MPI structures */
 
-    /* ASSERT_ALLOC() uses calloc() under the hood, so these do get zeroed */
-    ASSERT_ALLOC(a, bytes);
-    ASSERT_ALLOC(x, bytes);
+    /* TEST_CALLOC_OR_FAIL() uses calloc() under the hood, so these do get zeroed */
+    TEST_CALLOC_OR_FAIL(a, bytes);
+    TEST_CALLOC_OR_FAIL(x, bytes);
 
     /* Populate the arrays. As the mbedtls_mpi_uint[]s in mbedtls_mpis (and as
      * processed by mbedtls_mpi_core_mla()) are little endian, we can just
-     * copy what we have as long as MSBs are 0 (which they are from ASSERT_ALLOC()).
+     * copy what we have as long as MSBs are 0 (which they are from TEST_CALLOC_OR_FAIL()).
      */
     memcpy(a, A.p, A.n * sizeof(mbedtls_mpi_uint));
     memcpy(x, X->p, X->n * sizeof(mbedtls_mpi_uint));
@@ -1017,8 +1017,8 @@ void mpi_core_ct_uint_table_lookup(int bitlen, int window_size)
     mbedtls_mpi_uint *table = NULL;
     mbedtls_mpi_uint *dest = NULL;
 
-    ASSERT_ALLOC(table, limbs * count);
-    ASSERT_ALLOC(dest, limbs);
+    TEST_CALLOC_OR_FAIL(table, limbs * count);
+    TEST_CALLOC_OR_FAIL(dest, limbs);
 
     /*
      * Fill the table with a unique counter so that differences are easily
@@ -1070,7 +1070,7 @@ void mpi_core_fill_random(int wanted_bytes_arg, int extra_rng_bytes,
     int ret;
 
     /* Prepare an RNG with known output, limited to rng_bytes. */
-    ASSERT_ALLOC(rnd_data, rng_bytes);
+    TEST_CALLOC_OR_FAIL(rnd_data, rng_bytes);
     TEST_EQUAL(0, mbedtls_test_rnd_std_rand(NULL, rnd_data, rng_bytes));
     rnd_info.buf = rnd_data;
 
@@ -1078,7 +1078,7 @@ void mpi_core_fill_random(int wanted_bytes_arg, int extra_rng_bytes,
      * extra_limbs may be negative but the total limb count must be positive.
      * Fill the MPI with the byte value in before. */
     TEST_LE_U(1, X_limbs);
-    ASSERT_ALLOC(X, X_limbs);
+    TEST_CALLOC_OR_FAIL(X, X_limbs);
     memset(X, before, X_limbs * sizeof(*X));
 
     ret = mbedtls_mpi_core_fill_random(X, X_limbs, wanted_bytes,
@@ -1128,14 +1128,14 @@ void mpi_core_mul(char *input_A,
 
     const size_t X_limbs = A_limbs + B_limbs;
     const size_t X_bytes = X_limbs * sizeof(mbedtls_mpi_uint);
-    ASSERT_ALLOC(X, X_limbs);
+    TEST_CALLOC_OR_FAIL(X, X_limbs);
 
     const size_t A_bytes = A_limbs * sizeof(mbedtls_mpi_uint);
-    ASSERT_ALLOC(A_orig, A_limbs);
+    TEST_CALLOC_OR_FAIL(A_orig, A_limbs);
     memcpy(A_orig, A, A_bytes);
 
     const size_t B_bytes = B_limbs * sizeof(mbedtls_mpi_uint);
-    ASSERT_ALLOC(B_orig, B_limbs);
+    TEST_CALLOC_OR_FAIL(B_orig, B_limbs);
     memcpy(B_orig, B, B_bytes);
 
     /* Set result to something that is unlikely to be correct */
@@ -1195,7 +1195,7 @@ void mpi_core_exp_mod(char *input_N, char *input_A,
     TEST_EQUAL(0, mbedtls_test_read_mpi_core(&E, &E_limbs, input_E));
     TEST_EQUAL(0, mbedtls_test_read_mpi_core(&N, &N_limbs, input_N));
     TEST_EQUAL(0, mbedtls_test_read_mpi_core(&X, &X_limbs, input_X));
-    ASSERT_ALLOC(Y, N_limbs);
+    TEST_CALLOC_OR_FAIL(Y, N_limbs);
 
     TEST_EQUAL(A_limbs, N_limbs);
     TEST_EQUAL(X_limbs, N_limbs);
@@ -1227,7 +1227,7 @@ void mpi_core_exp_mod(char *input_N, char *input_A,
     TEST_LE_U(mbedtls_mpi_core_montmul_working_limbs(N_limbs),
               working_limbs);
 
-    ASSERT_ALLOC(T, working_limbs);
+    TEST_CALLOC_OR_FAIL(T, working_limbs);
 
     mbedtls_mpi_core_exp_mod(Y, A, N, N_limbs, E, E_limbs, R2, T);
 
@@ -1277,7 +1277,7 @@ void mpi_core_sub_int(char *input_A, char *input_B,
     TEST_EQUAL(A_limbs, X_limbs);
     size_t limbs = A_limbs;
 
-    ASSERT_ALLOC(R, limbs);
+    TEST_CALLOC_OR_FAIL(R, limbs);
 
 #define TEST_COMPARE_CORE_MPIS(A, B, limbs) \
     TEST_BUFFERS_EQUAL(A, (limbs) * sizeof(mbedtls_mpi_uint), B, (limbs) * sizeof(mbedtls_mpi_uint))

--- a/tests/suites/test_suite_bignum_core.function
+++ b/tests/suites/test_suite_bignum_core.function
@@ -34,45 +34,45 @@ static int mpi_core_verify_add(mbedtls_mpi_uint *A,
 
     /* A + B => correct result and carry */
     TEST_EQUAL(carry, mbedtls_mpi_core_add(X, A, B, limbs));
-    TEST_BUFFERS_EQUAL(X, bytes, S, bytes);
+    TEST_MEMORY_COMPARE(X, bytes, S, bytes);
 
     /* A + B; alias output and first operand => correct result and carry */
     memcpy(X, A, bytes);
     TEST_EQUAL(carry, mbedtls_mpi_core_add(X, X, B, limbs));
-    TEST_BUFFERS_EQUAL(X, bytes, S, bytes);
+    TEST_MEMORY_COMPARE(X, bytes, S, bytes);
 
     /* A + B; alias output and second operand => correct result and carry */
     memcpy(X, B, bytes);
     TEST_EQUAL(carry, mbedtls_mpi_core_add(X, A, X, limbs));
-    TEST_BUFFERS_EQUAL(X, bytes, S, bytes);
+    TEST_MEMORY_COMPARE(X, bytes, S, bytes);
 
     if (memcmp(A, B, bytes) == 0) {
         /* A == B, so test where A and B are aliased */
 
         /* A + A => correct result and carry */
         TEST_EQUAL(carry, mbedtls_mpi_core_add(X, A, A, limbs));
-        TEST_BUFFERS_EQUAL(X, bytes, S, bytes);
+        TEST_MEMORY_COMPARE(X, bytes, S, bytes);
 
         /* A + A, output aliased to both operands => correct result and carry */
         memcpy(X, A, bytes);
         TEST_EQUAL(carry, mbedtls_mpi_core_add(X, X, X, limbs));
-        TEST_BUFFERS_EQUAL(X, bytes, S, bytes);
+        TEST_MEMORY_COMPARE(X, bytes, S, bytes);
     } else {
         /* A != B, so test B + A */
 
         /* B + A => correct result and carry */
         TEST_EQUAL(carry, mbedtls_mpi_core_add(X, B, A, limbs));
-        TEST_BUFFERS_EQUAL(X, bytes, S, bytes);
+        TEST_MEMORY_COMPARE(X, bytes, S, bytes);
 
         /* B + A; alias output and first operand => correct result and carry */
         memcpy(X, B, bytes);
         TEST_EQUAL(carry, mbedtls_mpi_core_add(X, X, A, limbs));
-        TEST_BUFFERS_EQUAL(X, bytes, S, bytes);
+        TEST_MEMORY_COMPARE(X, bytes, S, bytes);
 
         /* B + A; alias output and second operand => correct result and carry */
         memcpy(X, A, bytes);
         TEST_EQUAL(carry, mbedtls_mpi_core_add(X, B, X, limbs));
-        TEST_BUFFERS_EQUAL(X, bytes, S, bytes);
+        TEST_MEMORY_COMPARE(X, bytes, S, bytes);
     }
 
     ret = 1;
@@ -111,11 +111,11 @@ static int mpi_core_verify_add_if(mbedtls_mpi_uint *A,
     /* cond = 0 => X unchanged, no carry */
     memcpy(X, A, bytes);
     TEST_EQUAL(0, mbedtls_mpi_core_add_if(X, B, limbs, 0));
-    TEST_BUFFERS_EQUAL(X, bytes, A, bytes);
+    TEST_MEMORY_COMPARE(X, bytes, A, bytes);
 
     /* cond = 1 => correct result and carry */
     TEST_EQUAL(carry, mbedtls_mpi_core_add_if(X, B, limbs, 1));
-    TEST_BUFFERS_EQUAL(X, bytes, S, bytes);
+    TEST_MEMORY_COMPARE(X, bytes, S, bytes);
 
     if (memcmp(A, B, bytes) == 0) {
         /* A == B, so test where A and B are aliased */
@@ -123,22 +123,22 @@ static int mpi_core_verify_add_if(mbedtls_mpi_uint *A,
         /* cond = 0 => X unchanged, no carry */
         memcpy(X, B, bytes);
         TEST_EQUAL(0, mbedtls_mpi_core_add_if(X, X, limbs, 0));
-        TEST_BUFFERS_EQUAL(X, bytes, B, bytes);
+        TEST_MEMORY_COMPARE(X, bytes, B, bytes);
 
         /* cond = 1 => correct result and carry */
         TEST_EQUAL(carry, mbedtls_mpi_core_add_if(X, X, limbs, 1));
-        TEST_BUFFERS_EQUAL(X, bytes, S, bytes);
+        TEST_MEMORY_COMPARE(X, bytes, S, bytes);
     } else {
         /* A != B, so test B + A */
 
         /* cond = 0 => d unchanged, no carry */
         memcpy(X, B, bytes);
         TEST_EQUAL(0, mbedtls_mpi_core_add_if(X, A, limbs, 0));
-        TEST_BUFFERS_EQUAL(X, bytes, B, bytes);
+        TEST_MEMORY_COMPARE(X, bytes, B, bytes);
 
         /* cond = 1 => correct result and carry */
         TEST_EQUAL(carry, mbedtls_mpi_core_add_if(X, A, limbs, 1));
-        TEST_BUFFERS_EQUAL(X, bytes, S, bytes);
+        TEST_MEMORY_COMPARE(X, bytes, S, bytes);
     }
 
     ret = 1;
@@ -458,10 +458,10 @@ void mpi_core_cond_assign(char *input_X,
         TEST_CF_PUBLIC(X, bytes);
         TEST_CF_PUBLIC(Y, bytes);
 
-        TEST_BUFFERS_EQUAL(X, copy_bytes, Y, copy_bytes);
+        TEST_MEMORY_COMPARE(X, copy_bytes, Y, copy_bytes);
         TEST_ASSERT(memcmp(X, Y, bytes) != 0);
     } else {
-        TEST_BUFFERS_EQUAL(X, bytes, Y, bytes);
+        TEST_MEMORY_COMPARE(X, bytes, Y, bytes);
     }
 
 exit:
@@ -508,8 +508,8 @@ void mpi_core_cond_swap(char *input_X,
     TEST_CF_PUBLIC(X, bytes);
     TEST_CF_PUBLIC(Y, bytes);
 
-    TEST_BUFFERS_EQUAL(X, bytes, tmp_X, bytes);
-    TEST_BUFFERS_EQUAL(Y, bytes, tmp_Y, bytes);
+    TEST_MEMORY_COMPARE(X, bytes, tmp_X, bytes);
+    TEST_MEMORY_COMPARE(Y, bytes, tmp_Y, bytes);
 
     /* condition is true */
     TEST_CF_SECRET(X, bytes);
@@ -523,15 +523,15 @@ void mpi_core_cond_swap(char *input_X,
     /* Check if the given length is copied even it is smaller
        than the length of the given MPIs. */
     if (copy_limbs < limbs) {
-        TEST_BUFFERS_EQUAL(X, copy_bytes, tmp_Y, copy_bytes);
-        TEST_BUFFERS_EQUAL(Y, copy_bytes, tmp_X, copy_bytes);
+        TEST_MEMORY_COMPARE(X, copy_bytes, tmp_Y, copy_bytes);
+        TEST_MEMORY_COMPARE(Y, copy_bytes, tmp_X, copy_bytes);
         TEST_ASSERT(memcmp(X, tmp_X, bytes) != 0);
         TEST_ASSERT(memcmp(X, tmp_Y, bytes) != 0);
         TEST_ASSERT(memcmp(Y, tmp_X, bytes) != 0);
         TEST_ASSERT(memcmp(Y, tmp_Y, bytes) != 0);
     } else {
-        TEST_BUFFERS_EQUAL(X, bytes, tmp_Y, bytes);
-        TEST_BUFFERS_EQUAL(Y, bytes, tmp_X, bytes);
+        TEST_MEMORY_COMPARE(X, bytes, tmp_Y, bytes);
+        TEST_MEMORY_COMPARE(Y, bytes, tmp_X, bytes);
     }
 
 exit:
@@ -554,7 +554,7 @@ void mpi_core_shift_r(char *input, int count, char *result)
     TEST_EQUAL(limbs, n);
 
     mbedtls_mpi_core_shift_r(X, limbs, count);
-    TEST_BUFFERS_EQUAL(X, limbs * ciL, Y, limbs * ciL);
+    TEST_MEMORY_COMPARE(X, limbs * ciL, Y, limbs * ciL);
 
 exit:
     mbedtls_free(X);
@@ -574,7 +574,7 @@ void mpi_core_shift_l(char *input, int count, char *result)
     TEST_EQUAL(limbs, n);
 
     mbedtls_mpi_core_shift_l(X, limbs, count);
-    TEST_BUFFERS_EQUAL(X, limbs * ciL, Y, limbs * ciL);
+    TEST_MEMORY_COMPARE(X, limbs * ciL, Y, limbs * ciL);
 
 exit:
     mbedtls_free(X);
@@ -664,7 +664,7 @@ void mpi_core_sub(char *input_A, char *input_B,
     TEST_EQUAL(carry, mbedtls_mpi_core_sub(r, a, b, limbs));
 
     /* 1b) r = a - b => we should get the correct result */
-    TEST_BUFFERS_EQUAL(r, bytes, x, bytes);
+    TEST_MEMORY_COMPARE(r, bytes, x, bytes);
 
     /* 2 and 3 test "r may be aliased to a or b" */
     /* 2a) r = a; r -= b => we should get the correct carry (use r to avoid clobbering a) */
@@ -672,20 +672,20 @@ void mpi_core_sub(char *input_A, char *input_B,
     TEST_EQUAL(carry, mbedtls_mpi_core_sub(r, r, b, limbs));
 
     /* 2b) r -= b => we should get the correct result */
-    TEST_BUFFERS_EQUAL(r, bytes, x, bytes);
+    TEST_MEMORY_COMPARE(r, bytes, x, bytes);
 
     /* 3a) r = b; r = a - r => we should get the correct carry (use r to avoid clobbering b) */
     memcpy(r, b, bytes);
     TEST_EQUAL(carry, mbedtls_mpi_core_sub(r, a, r, limbs));
 
     /* 3b) r = a - b => we should get the correct result */
-    TEST_BUFFERS_EQUAL(r, bytes, x, bytes);
+    TEST_MEMORY_COMPARE(r, bytes, x, bytes);
 
     /* 4 tests "r may be aliased to [...] both" */
     if (A.n == B.n && memcmp(A.p, B.p, bytes) == 0) {
         memcpy(r, b, bytes);
         TEST_EQUAL(carry, mbedtls_mpi_core_sub(r, r, r, limbs));
-        TEST_BUFFERS_EQUAL(r, bytes, x, bytes);
+        TEST_MEMORY_COMPARE(r, bytes, x, bytes);
     }
 
 exit:
@@ -774,13 +774,13 @@ void mpi_core_mla(char *input_A, char *input_B, char *input_S,
     TEST_EQUAL(mbedtls_mpi_core_mla(a, limbs, B.p, B.n, *S.p), *cy->p);
 
     /* 1b) A += B * s => we should get the correct result */
-    TEST_BUFFERS_EQUAL(a, bytes, x, bytes);
+    TEST_MEMORY_COMPARE(a, bytes, x, bytes);
 
     if (A.n == B.n && memcmp(A.p, B.p, bytes) == 0) {
         /* Check when A and B are aliased */
         memcpy(a, A.p, A.n * sizeof(mbedtls_mpi_uint));
         TEST_EQUAL(mbedtls_mpi_core_mla(a, limbs, a, limbs, *S.p), *cy->p);
-        TEST_BUFFERS_EQUAL(a, bytes, x, bytes);
+        TEST_MEMORY_COMPARE(a, bytes, x, bytes);
     }
 
 exit:
@@ -890,14 +890,14 @@ void mpi_core_montmul(int limbs_AN4, int limbs_B4,
 
     mbedtls_mpi_core_montmul(R.p, A.p, B.p, B.n, N.p, N.n, mm, T.p);
     size_t bytes = N.n * sizeof(mbedtls_mpi_uint);
-    TEST_BUFFERS_EQUAL(R.p, bytes, X->p, bytes);
+    TEST_MEMORY_COMPARE(R.p, bytes, X->p, bytes);
 
     /* The output (R, above) may be aliased to A - use R to save the value of A */
 
     memcpy(R.p, A.p, bytes);
 
     mbedtls_mpi_core_montmul(A.p, A.p, B.p, B.n, N.p, N.n, mm, T.p);
-    TEST_BUFFERS_EQUAL(A.p, bytes, X->p, bytes);
+    TEST_MEMORY_COMPARE(A.p, bytes, X->p, bytes);
 
     memcpy(A.p, R.p, bytes);    /* restore A */
 
@@ -906,7 +906,7 @@ void mpi_core_montmul(int limbs_AN4, int limbs_B4,
     memcpy(R.p, N.p, bytes);
 
     mbedtls_mpi_core_montmul(N.p, A.p, B.p, B.n, N.p, N.n, mm, T.p);
-    TEST_BUFFERS_EQUAL(N.p, bytes, X->p, bytes);
+    TEST_MEMORY_COMPARE(N.p, bytes, X->p, bytes);
 
     memcpy(N.p, R.p, bytes);
 
@@ -917,7 +917,7 @@ void mpi_core_montmul(int limbs_AN4, int limbs_B4,
              * don't bother with yet another test with only A and B aliased */
 
             mbedtls_mpi_core_montmul(B.p, B.p, B.p, B.n, N.p, N.n, mm, T.p);
-            TEST_BUFFERS_EQUAL(B.p, bytes, X->p, bytes);
+            TEST_MEMORY_COMPARE(B.p, bytes, X->p, bytes);
 
             memcpy(B.p, A.p, bytes);    /* restore B from equal value A */
         }
@@ -925,7 +925,7 @@ void mpi_core_montmul(int limbs_AN4, int limbs_B4,
         /* The output may be aliased to B - last test, so we don't save B */
 
         mbedtls_mpi_core_montmul(B.p, A.p, B.p, B.n, N.p, N.n, mm, T.p);
-        TEST_BUFFERS_EQUAL(B.p, bytes, X->p, bytes);
+        TEST_MEMORY_COMPARE(B.p, bytes, X->p, bytes);
     }
 
 exit:
@@ -1046,7 +1046,7 @@ void mpi_core_ct_uint_table_lookup(int bitlen, int window_size)
 
         TEST_CF_PUBLIC(dest, limbs * sizeof(*dest));
         TEST_CF_PUBLIC(table, count * limbs * sizeof(*table));
-        TEST_BUFFERS_EQUAL(dest, limbs * sizeof(*dest),
+        TEST_MEMORY_COMPARE(dest, limbs * sizeof(*dest),
                        current, limbs * sizeof(*current));
         TEST_CF_PUBLIC(&i, sizeof(i));
     }
@@ -1143,24 +1143,24 @@ void mpi_core_mul(char *input_A,
 
     /* 1. X = A * B - result should be correct, A and B unchanged */
     mbedtls_mpi_core_mul(X, A, A_limbs, B, B_limbs);
-    TEST_BUFFERS_EQUAL(X, X_bytes, R, X_bytes);
-    TEST_BUFFERS_EQUAL(A, A_bytes, A_orig, A_bytes);
-    TEST_BUFFERS_EQUAL(B, B_bytes, B_orig, B_bytes);
+    TEST_MEMORY_COMPARE(X, X_bytes, R, X_bytes);
+    TEST_MEMORY_COMPARE(A, A_bytes, A_orig, A_bytes);
+    TEST_MEMORY_COMPARE(B, B_bytes, B_orig, B_bytes);
 
     /* 2. A == B: alias A and B - result should be correct, A and B unchanged */
     if (A_bytes == B_bytes && memcmp(A, B, A_bytes) == 0) {
         memset(X, '!', X_bytes);
         mbedtls_mpi_core_mul(X, A, A_limbs, A, A_limbs);
-        TEST_BUFFERS_EQUAL(X, X_bytes, R, X_bytes);
-        TEST_BUFFERS_EQUAL(A, A_bytes, A_orig, A_bytes);
+        TEST_MEMORY_COMPARE(X, X_bytes, R, X_bytes);
+        TEST_MEMORY_COMPARE(A, A_bytes, A_orig, A_bytes);
     }
     /* 3. X = B * A - result should be correct, A and B unchanged */
     else {
         memset(X, '!', X_bytes);
         mbedtls_mpi_core_mul(X, B, B_limbs, A, A_limbs);
-        TEST_BUFFERS_EQUAL(X, X_bytes, R, X_bytes);
-        TEST_BUFFERS_EQUAL(A, A_bytes, A_orig, A_bytes);
-        TEST_BUFFERS_EQUAL(B, B_bytes, B_orig, B_bytes);
+        TEST_MEMORY_COMPARE(X, X_bytes, R, X_bytes);
+        TEST_MEMORY_COMPARE(A, A_bytes, A_orig, A_bytes);
+        TEST_MEMORY_COMPARE(B, B_bytes, B_orig, B_bytes);
     }
 
 exit:
@@ -1280,7 +1280,7 @@ void mpi_core_sub_int(char *input_A, char *input_B,
     TEST_CALLOC(R, limbs);
 
 #define TEST_COMPARE_CORE_MPIS(A, B, limbs) \
-    TEST_BUFFERS_EQUAL(A, (limbs) * sizeof(mbedtls_mpi_uint), B, (limbs) * sizeof(mbedtls_mpi_uint))
+    TEST_MEMORY_COMPARE(A, (limbs) * sizeof(mbedtls_mpi_uint), B, (limbs) * sizeof(mbedtls_mpi_uint))
 
     /* 1. R = A - b. Result and borrow should be correct */
     TEST_EQUAL(mbedtls_mpi_core_sub_int(R, A, B[0], limbs), borrow);

--- a/tests/suites/test_suite_bignum_mod.function
+++ b/tests/suites/test_suite_bignum_mod.function
@@ -8,7 +8,7 @@
 
 #define TEST_COMPARE_MPI_RESIDUES(a, b) \
     TEST_MEMORY_COMPARE((a).p, (a).limbs * sizeof(mbedtls_mpi_uint), \
-                   (b).p, (b).limbs * sizeof(mbedtls_mpi_uint))
+                        (b).p, (b).limbs * sizeof(mbedtls_mpi_uint))
 
 static int test_read_residue(mbedtls_mpi_mod_residue *r,
                              const mbedtls_mpi_mod_modulus *m,

--- a/tests/suites/test_suite_bignum_mod.function
+++ b/tests/suites/test_suite_bignum_mod.function
@@ -7,7 +7,7 @@
 #include "test/constant_flow.h"
 
 #define TEST_COMPARE_MPI_RESIDUES(a, b) \
-    TEST_BUFFERS_EQUAL((a).p, (a).limbs * sizeof(mbedtls_mpi_uint), \
+    TEST_MEMORY_COMPARE((a).p, (a).limbs * sizeof(mbedtls_mpi_uint), \
                    (b).p, (b).limbs * sizeof(mbedtls_mpi_uint))
 
 static int test_read_residue(mbedtls_mpi_mod_residue *r,
@@ -128,42 +128,42 @@ void mpi_mod_mul(char *input_A,
     TEST_EQUAL(mbedtls_mpi_mod_residue_setup(&rX, &m, X, limbs), 0);
 
     TEST_EQUAL(mbedtls_mpi_mod_mul(&rX, &rA, &rB, &m), 0);
-    TEST_BUFFERS_EQUAL(rX.p, bytes, rR.p, bytes);
+    TEST_MEMORY_COMPARE(rX.p, bytes, rR.p, bytes);
 
     /* alias X to A */
     memcpy(rX.p, rA.p, bytes);
     TEST_EQUAL(mbedtls_mpi_mod_mul(&rX, &rX, &rB, &m), 0);
-    TEST_BUFFERS_EQUAL(rX.p, bytes, rR.p, bytes);
+    TEST_MEMORY_COMPARE(rX.p, bytes, rR.p, bytes);
 
     /* alias X to B */
     memcpy(rX.p, rB.p, bytes);
     TEST_EQUAL(mbedtls_mpi_mod_mul(&rX, &rA, &rX, &m), 0);
-    TEST_BUFFERS_EQUAL(rX.p, bytes, rR.p, bytes);
+    TEST_MEMORY_COMPARE(rX.p, bytes, rR.p, bytes);
 
     /* A == B: alias A and B */
     if (memcmp(rA.p, rB.p, bytes) == 0) {
         TEST_EQUAL(mbedtls_mpi_mod_mul(&rX, &rA, &rA, &m), 0);
-        TEST_BUFFERS_EQUAL(rX.p, bytes, rR.p, bytes);
+        TEST_MEMORY_COMPARE(rX.p, bytes, rR.p, bytes);
 
         /* X, A, B all aliased together */
         memcpy(rX.p, rA.p, bytes);
         TEST_EQUAL(mbedtls_mpi_mod_mul(&rX, &rX, &rX, &m), 0);
-        TEST_BUFFERS_EQUAL(rX.p, bytes, rR.p, bytes);
+        TEST_MEMORY_COMPARE(rX.p, bytes, rR.p, bytes);
     }
     /* A != B: test B * A */
     else {
         TEST_EQUAL(mbedtls_mpi_mod_mul(&rX, &rB, &rA, &m), 0);
-        TEST_BUFFERS_EQUAL(rX.p, bytes, rR.p, bytes);
+        TEST_MEMORY_COMPARE(rX.p, bytes, rR.p, bytes);
 
         /* B * A: alias X to A */
         memcpy(rX.p, rA.p, bytes);
         TEST_EQUAL(mbedtls_mpi_mod_mul(&rX, &rB, &rX, &m), 0);
-        TEST_BUFFERS_EQUAL(rX.p, bytes, rR.p, bytes);
+        TEST_MEMORY_COMPARE(rX.p, bytes, rR.p, bytes);
 
         /* B + A: alias X to B */
         memcpy(rX.p, rB.p, bytes);
         TEST_EQUAL(mbedtls_mpi_mod_mul(&rX, &rX, &rA, &m), 0);
-        TEST_BUFFERS_EQUAL(rX.p, bytes, rR.p, bytes);
+        TEST_MEMORY_COMPARE(rX.p, bytes, rR.p, bytes);
     }
 
 exit:
@@ -702,7 +702,7 @@ void mpi_mod_io(char *input_N, data_t *input_A, int endian)
         TEST_EQUAL(0, mbedtls_mpi_mod_write(&r, &m, obuf, obuf_sizes[i], endian));
 
         /* Make sure that writing didn't corrupt the value of r */
-        TEST_BUFFERS_EQUAL(r.p, r.limbs, r_copy.p, r_copy.limbs);
+        TEST_MEMORY_COMPARE(r.p, r.limbs, r_copy.p, r_copy.limbs);
 
         /* Set up reference output for checking the result */
         TEST_CALLOC(ref_buf, obuf_sizes[i]);
@@ -723,7 +723,7 @@ void mpi_mod_io(char *input_N, data_t *input_A, int endian)
         }
 
         /* Check the result */
-        TEST_BUFFERS_EQUAL(obuf, obuf_sizes[i], ref_buf, obuf_sizes[i]);
+        TEST_MEMORY_COMPARE(obuf, obuf_sizes[i], ref_buf, obuf_sizes[i]);
 
         mbedtls_free(ref_buf);
         ref_buf = NULL;

--- a/tests/suites/test_suite_bignum_mod.function
+++ b/tests/suites/test_suite_bignum_mod.function
@@ -7,7 +7,7 @@
 #include "test/constant_flow.h"
 
 #define TEST_COMPARE_MPI_RESIDUES(a, b) \
-    ASSERT_COMPARE((a).p, (a).limbs * sizeof(mbedtls_mpi_uint), \
+    TEST_BUFFERS_EQUAL((a).p, (a).limbs * sizeof(mbedtls_mpi_uint), \
                    (b).p, (b).limbs * sizeof(mbedtls_mpi_uint))
 
 static int test_read_residue(mbedtls_mpi_mod_residue *r,
@@ -128,42 +128,42 @@ void mpi_mod_mul(char *input_A,
     TEST_EQUAL(mbedtls_mpi_mod_residue_setup(&rX, &m, X, limbs), 0);
 
     TEST_EQUAL(mbedtls_mpi_mod_mul(&rX, &rA, &rB, &m), 0);
-    ASSERT_COMPARE(rX.p, bytes, rR.p, bytes);
+    TEST_BUFFERS_EQUAL(rX.p, bytes, rR.p, bytes);
 
     /* alias X to A */
     memcpy(rX.p, rA.p, bytes);
     TEST_EQUAL(mbedtls_mpi_mod_mul(&rX, &rX, &rB, &m), 0);
-    ASSERT_COMPARE(rX.p, bytes, rR.p, bytes);
+    TEST_BUFFERS_EQUAL(rX.p, bytes, rR.p, bytes);
 
     /* alias X to B */
     memcpy(rX.p, rB.p, bytes);
     TEST_EQUAL(mbedtls_mpi_mod_mul(&rX, &rA, &rX, &m), 0);
-    ASSERT_COMPARE(rX.p, bytes, rR.p, bytes);
+    TEST_BUFFERS_EQUAL(rX.p, bytes, rR.p, bytes);
 
     /* A == B: alias A and B */
     if (memcmp(rA.p, rB.p, bytes) == 0) {
         TEST_EQUAL(mbedtls_mpi_mod_mul(&rX, &rA, &rA, &m), 0);
-        ASSERT_COMPARE(rX.p, bytes, rR.p, bytes);
+        TEST_BUFFERS_EQUAL(rX.p, bytes, rR.p, bytes);
 
         /* X, A, B all aliased together */
         memcpy(rX.p, rA.p, bytes);
         TEST_EQUAL(mbedtls_mpi_mod_mul(&rX, &rX, &rX, &m), 0);
-        ASSERT_COMPARE(rX.p, bytes, rR.p, bytes);
+        TEST_BUFFERS_EQUAL(rX.p, bytes, rR.p, bytes);
     }
     /* A != B: test B * A */
     else {
         TEST_EQUAL(mbedtls_mpi_mod_mul(&rX, &rB, &rA, &m), 0);
-        ASSERT_COMPARE(rX.p, bytes, rR.p, bytes);
+        TEST_BUFFERS_EQUAL(rX.p, bytes, rR.p, bytes);
 
         /* B * A: alias X to A */
         memcpy(rX.p, rA.p, bytes);
         TEST_EQUAL(mbedtls_mpi_mod_mul(&rX, &rB, &rX, &m), 0);
-        ASSERT_COMPARE(rX.p, bytes, rR.p, bytes);
+        TEST_BUFFERS_EQUAL(rX.p, bytes, rR.p, bytes);
 
         /* B + A: alias X to B */
         memcpy(rX.p, rB.p, bytes);
         TEST_EQUAL(mbedtls_mpi_mod_mul(&rX, &rX, &rA, &m), 0);
-        ASSERT_COMPARE(rX.p, bytes, rR.p, bytes);
+        TEST_BUFFERS_EQUAL(rX.p, bytes, rR.p, bytes);
     }
 
 exit:
@@ -702,7 +702,7 @@ void mpi_mod_io(char *input_N, data_t *input_A, int endian)
         TEST_EQUAL(0, mbedtls_mpi_mod_write(&r, &m, obuf, obuf_sizes[i], endian));
 
         /* Make sure that writing didn't corrupt the value of r */
-        ASSERT_COMPARE(r.p, r.limbs, r_copy.p, r_copy.limbs);
+        TEST_BUFFERS_EQUAL(r.p, r.limbs, r_copy.p, r_copy.limbs);
 
         /* Set up reference output for checking the result */
         ASSERT_ALLOC(ref_buf, obuf_sizes[i]);
@@ -723,7 +723,7 @@ void mpi_mod_io(char *input_N, data_t *input_A, int endian)
         }
 
         /* Check the result */
-        ASSERT_COMPARE(obuf, obuf_sizes[i], ref_buf, obuf_sizes[i]);
+        TEST_BUFFERS_EQUAL(obuf, obuf_sizes[i], ref_buf, obuf_sizes[i]);
 
         mbedtls_free(ref_buf);
         ref_buf = NULL;

--- a/tests/suites/test_suite_bignum_mod.function
+++ b/tests/suites/test_suite_bignum_mod.function
@@ -123,7 +123,7 @@ void mpi_mod_mul(char *input_A,
     TEST_EQUAL(rB.limbs, limbs);
     TEST_EQUAL(rR.limbs, limbs);
 
-    ASSERT_ALLOC(X, limbs);
+    TEST_CALLOC_OR_FAIL(X, limbs);
 
     TEST_EQUAL(mbedtls_mpi_mod_residue_setup(&rX, &m, X, limbs), 0);
 
@@ -206,7 +206,7 @@ void mpi_mod_mul_neg(char *input_A,
 
     const size_t limbs = m.limbs;
 
-    ASSERT_ALLOC(X, limbs);
+    TEST_CALLOC_OR_FAIL(X, limbs);
 
     TEST_EQUAL(mbedtls_mpi_mod_residue_setup(&rX, &m, X, limbs), 0);
     rX.limbs = rR.limbs;
@@ -259,7 +259,7 @@ void mpi_mod_sub(char *input_N,
 
     if (expected_ret == 0) {
         /* Negative test with too many limbs in output */
-        ASSERT_ALLOC(X_raw, limbs + 1);
+        TEST_CALLOC_OR_FAIL(X_raw, limbs + 1);
 
         x.p = X_raw;
         x.limbs = limbs + 1;
@@ -271,7 +271,7 @@ void mpi_mod_sub(char *input_N,
 
         /* Negative test with too few limbs in output */
         if (limbs > 1) {
-            ASSERT_ALLOC(X_raw, limbs - 1);
+            TEST_CALLOC_OR_FAIL(X_raw, limbs - 1);
 
             x.p = X_raw;
             x.limbs = limbs - 1;
@@ -286,7 +286,7 @@ void mpi_mod_sub(char *input_N,
          * manually-written test cases with expected_ret != 0. */
     }
 
-    ASSERT_ALLOC(X_raw, limbs);
+    TEST_CALLOC_OR_FAIL(X_raw, limbs);
 
     TEST_EQUAL(0, mbedtls_mpi_mod_residue_setup(&x, &m, X_raw, limbs));
 
@@ -358,7 +358,7 @@ void mpi_mod_inv_mont(char *input_N,
     size_t limbs = N.limbs;
     size_t bytes = limbs * sizeof(*X_raw);
 
-    ASSERT_ALLOC(X_raw, limbs);
+    TEST_CALLOC_OR_FAIL(X_raw, limbs);
 
     TEST_EQUAL(0, mbedtls_mpi_mod_residue_setup(&x, &N, X_raw, limbs));
 
@@ -408,7 +408,7 @@ void mpi_mod_inv_non_mont(char *input_N,
     size_t limbs = N.limbs;
     size_t bytes = limbs * sizeof(*X_raw);
 
-    ASSERT_ALLOC(X_raw, limbs);
+    TEST_CALLOC_OR_FAIL(X_raw, limbs);
 
     TEST_EQUAL(0, mbedtls_mpi_mod_residue_setup(&x, &N, X_raw, limbs));
 
@@ -462,7 +462,7 @@ void mpi_mod_add(char *input_N,
 
     if (expected_ret == 0) {
         /* Negative test with too many limbs in output */
-        ASSERT_ALLOC(X_raw, limbs + 1);
+        TEST_CALLOC_OR_FAIL(X_raw, limbs + 1);
 
         x.p = X_raw;
         x.limbs = limbs + 1;
@@ -474,7 +474,7 @@ void mpi_mod_add(char *input_N,
 
         /* Negative test with too few limbs in output */
         if (limbs > 1) {
-            ASSERT_ALLOC(X_raw, limbs - 1);
+            TEST_CALLOC_OR_FAIL(X_raw, limbs - 1);
 
             x.p = X_raw;
             x.limbs = limbs - 1;
@@ -490,7 +490,7 @@ void mpi_mod_add(char *input_N,
     }
 
     /* Allocate correct number of limbs for X_raw */
-    ASSERT_ALLOC(X_raw, limbs);
+    TEST_CALLOC_OR_FAIL(X_raw, limbs);
 
     TEST_EQUAL(0, mbedtls_mpi_mod_residue_setup(&x, &m, X_raw, limbs));
 
@@ -582,7 +582,7 @@ void mpi_mod_io_neg(char *input_N, data_t *buf, int ret)
     size_t n_limbs;
     TEST_EQUAL(0, mbedtls_test_read_mpi_core(&N, &n_limbs, input_N));
     size_t r_limbs = n_limbs;
-    ASSERT_ALLOC(R, r_limbs);
+    TEST_CALLOC_OR_FAIL(R, r_limbs);
 
     /* modulus->p == NULL || residue->p == NULL ( m has not been set-up ) */
     TEST_EQUAL(MBEDTLS_ERR_MPI_BAD_INPUT_DATA,
@@ -658,8 +658,8 @@ void mpi_mod_io(char *input_N, data_t *input_A, int endian)
     a_bytes = input_A->len;
 
     /* Allocate the memory for intermediate data structures */
-    ASSERT_ALLOC(R, n_bytes);
-    ASSERT_ALLOC(R_COPY, n_bytes);
+    TEST_CALLOC_OR_FAIL(R, n_bytes);
+    TEST_CALLOC_OR_FAIL(R_COPY, n_bytes);
 
     /* Test that input's size is not greater to modulo's */
     TEST_LE_U(a_bytes, n_bytes);
@@ -698,14 +698,14 @@ void mpi_mod_io(char *input_N, data_t *input_A, int endian)
     obuf_sizes[2] = a_bytes + 8;
 
     for (size_t i = 0; i < obuf_sizes_len; i++) {
-        ASSERT_ALLOC(obuf, obuf_sizes[i]);
+        TEST_CALLOC_OR_FAIL(obuf, obuf_sizes[i]);
         TEST_EQUAL(0, mbedtls_mpi_mod_write(&r, &m, obuf, obuf_sizes[i], endian));
 
         /* Make sure that writing didn't corrupt the value of r */
         TEST_BUFFERS_EQUAL(r.p, r.limbs, r_copy.p, r_copy.limbs);
 
         /* Set up reference output for checking the result */
-        ASSERT_ALLOC(ref_buf, obuf_sizes[i]);
+        TEST_CALLOC_OR_FAIL(ref_buf, obuf_sizes[i]);
         switch (endian) {
             case MBEDTLS_MPI_MOD_EXT_REP_LE:
                 memcpy(ref_buf, input_A->x, a_bytes_trimmed);

--- a/tests/suites/test_suite_bignum_mod.function
+++ b/tests/suites/test_suite_bignum_mod.function
@@ -123,7 +123,7 @@ void mpi_mod_mul(char *input_A,
     TEST_EQUAL(rB.limbs, limbs);
     TEST_EQUAL(rR.limbs, limbs);
 
-    TEST_CALLOC_OR_FAIL(X, limbs);
+    TEST_CALLOC(X, limbs);
 
     TEST_EQUAL(mbedtls_mpi_mod_residue_setup(&rX, &m, X, limbs), 0);
 
@@ -206,7 +206,7 @@ void mpi_mod_mul_neg(char *input_A,
 
     const size_t limbs = m.limbs;
 
-    TEST_CALLOC_OR_FAIL(X, limbs);
+    TEST_CALLOC(X, limbs);
 
     TEST_EQUAL(mbedtls_mpi_mod_residue_setup(&rX, &m, X, limbs), 0);
     rX.limbs = rR.limbs;
@@ -259,7 +259,7 @@ void mpi_mod_sub(char *input_N,
 
     if (expected_ret == 0) {
         /* Negative test with too many limbs in output */
-        TEST_CALLOC_OR_FAIL(X_raw, limbs + 1);
+        TEST_CALLOC(X_raw, limbs + 1);
 
         x.p = X_raw;
         x.limbs = limbs + 1;
@@ -271,7 +271,7 @@ void mpi_mod_sub(char *input_N,
 
         /* Negative test with too few limbs in output */
         if (limbs > 1) {
-            TEST_CALLOC_OR_FAIL(X_raw, limbs - 1);
+            TEST_CALLOC(X_raw, limbs - 1);
 
             x.p = X_raw;
             x.limbs = limbs - 1;
@@ -286,7 +286,7 @@ void mpi_mod_sub(char *input_N,
          * manually-written test cases with expected_ret != 0. */
     }
 
-    TEST_CALLOC_OR_FAIL(X_raw, limbs);
+    TEST_CALLOC(X_raw, limbs);
 
     TEST_EQUAL(0, mbedtls_mpi_mod_residue_setup(&x, &m, X_raw, limbs));
 
@@ -358,7 +358,7 @@ void mpi_mod_inv_mont(char *input_N,
     size_t limbs = N.limbs;
     size_t bytes = limbs * sizeof(*X_raw);
 
-    TEST_CALLOC_OR_FAIL(X_raw, limbs);
+    TEST_CALLOC(X_raw, limbs);
 
     TEST_EQUAL(0, mbedtls_mpi_mod_residue_setup(&x, &N, X_raw, limbs));
 
@@ -408,7 +408,7 @@ void mpi_mod_inv_non_mont(char *input_N,
     size_t limbs = N.limbs;
     size_t bytes = limbs * sizeof(*X_raw);
 
-    TEST_CALLOC_OR_FAIL(X_raw, limbs);
+    TEST_CALLOC(X_raw, limbs);
 
     TEST_EQUAL(0, mbedtls_mpi_mod_residue_setup(&x, &N, X_raw, limbs));
 
@@ -462,7 +462,7 @@ void mpi_mod_add(char *input_N,
 
     if (expected_ret == 0) {
         /* Negative test with too many limbs in output */
-        TEST_CALLOC_OR_FAIL(X_raw, limbs + 1);
+        TEST_CALLOC(X_raw, limbs + 1);
 
         x.p = X_raw;
         x.limbs = limbs + 1;
@@ -474,7 +474,7 @@ void mpi_mod_add(char *input_N,
 
         /* Negative test with too few limbs in output */
         if (limbs > 1) {
-            TEST_CALLOC_OR_FAIL(X_raw, limbs - 1);
+            TEST_CALLOC(X_raw, limbs - 1);
 
             x.p = X_raw;
             x.limbs = limbs - 1;
@@ -490,7 +490,7 @@ void mpi_mod_add(char *input_N,
     }
 
     /* Allocate correct number of limbs for X_raw */
-    TEST_CALLOC_OR_FAIL(X_raw, limbs);
+    TEST_CALLOC(X_raw, limbs);
 
     TEST_EQUAL(0, mbedtls_mpi_mod_residue_setup(&x, &m, X_raw, limbs));
 
@@ -582,7 +582,7 @@ void mpi_mod_io_neg(char *input_N, data_t *buf, int ret)
     size_t n_limbs;
     TEST_EQUAL(0, mbedtls_test_read_mpi_core(&N, &n_limbs, input_N));
     size_t r_limbs = n_limbs;
-    TEST_CALLOC_OR_FAIL(R, r_limbs);
+    TEST_CALLOC(R, r_limbs);
 
     /* modulus->p == NULL || residue->p == NULL ( m has not been set-up ) */
     TEST_EQUAL(MBEDTLS_ERR_MPI_BAD_INPUT_DATA,
@@ -658,8 +658,8 @@ void mpi_mod_io(char *input_N, data_t *input_A, int endian)
     a_bytes = input_A->len;
 
     /* Allocate the memory for intermediate data structures */
-    TEST_CALLOC_OR_FAIL(R, n_bytes);
-    TEST_CALLOC_OR_FAIL(R_COPY, n_bytes);
+    TEST_CALLOC(R, n_bytes);
+    TEST_CALLOC(R_COPY, n_bytes);
 
     /* Test that input's size is not greater to modulo's */
     TEST_LE_U(a_bytes, n_bytes);
@@ -698,14 +698,14 @@ void mpi_mod_io(char *input_N, data_t *input_A, int endian)
     obuf_sizes[2] = a_bytes + 8;
 
     for (size_t i = 0; i < obuf_sizes_len; i++) {
-        TEST_CALLOC_OR_FAIL(obuf, obuf_sizes[i]);
+        TEST_CALLOC(obuf, obuf_sizes[i]);
         TEST_EQUAL(0, mbedtls_mpi_mod_write(&r, &m, obuf, obuf_sizes[i], endian));
 
         /* Make sure that writing didn't corrupt the value of r */
         TEST_BUFFERS_EQUAL(r.p, r.limbs, r_copy.p, r_copy.limbs);
 
         /* Set up reference output for checking the result */
-        TEST_CALLOC_OR_FAIL(ref_buf, obuf_sizes[i]);
+        TEST_CALLOC(ref_buf, obuf_sizes[i]);
         switch (endian) {
             case MBEDTLS_MPI_MOD_EXT_REP_LE:
                 memcpy(ref_buf, input_A->x, a_bytes_trimmed);

--- a/tests/suites/test_suite_bignum_mod_raw.function
+++ b/tests/suites/test_suite_bignum_mod_raw.function
@@ -161,10 +161,10 @@ void mpi_mod_raw_cond_assign(char *input_X,
     /* Check if the given length is copied even it is smaller
        than the length of the given MPIs. */
     if (copy_limbs < limbs) {
-        TEST_BUFFERS_EQUAL(X, copy_bytes, Y, copy_bytes);
+        TEST_MEMORY_COMPARE(X, copy_bytes, Y, copy_bytes);
         TEST_ASSERT(memcmp(X, Y, bytes) != 0);
     } else {
-        TEST_BUFFERS_EQUAL(X, bytes, Y, bytes);
+        TEST_MEMORY_COMPARE(X, bytes, Y, bytes);
     }
 
 exit:
@@ -223,8 +223,8 @@ void mpi_mod_raw_cond_swap(char *input_X,
     TEST_CF_PUBLIC(X, bytes);
     TEST_CF_PUBLIC(Y, bytes);
 
-    TEST_BUFFERS_EQUAL(X, bytes, tmp_X, bytes);
-    TEST_BUFFERS_EQUAL(Y, bytes, tmp_Y, bytes);
+    TEST_MEMORY_COMPARE(X, bytes, tmp_X, bytes);
+    TEST_MEMORY_COMPARE(Y, bytes, tmp_Y, bytes);
 
     /* condition is true */
     TEST_CF_SECRET(X, bytes);
@@ -238,15 +238,15 @@ void mpi_mod_raw_cond_swap(char *input_X,
     /* Check if the given length is copied even it is smaller
        than the length of the given MPIs. */
     if (copy_limbs < limbs) {
-        TEST_BUFFERS_EQUAL(X, copy_bytes, tmp_Y, copy_bytes);
-        TEST_BUFFERS_EQUAL(Y, copy_bytes, tmp_X, copy_bytes);
+        TEST_MEMORY_COMPARE(X, copy_bytes, tmp_Y, copy_bytes);
+        TEST_MEMORY_COMPARE(Y, copy_bytes, tmp_X, copy_bytes);
         TEST_ASSERT(memcmp(X, tmp_X, bytes) != 0);
         TEST_ASSERT(memcmp(X, tmp_Y, bytes) != 0);
         TEST_ASSERT(memcmp(Y, tmp_X, bytes) != 0);
         TEST_ASSERT(memcmp(Y, tmp_Y, bytes) != 0);
     } else {
-        TEST_BUFFERS_EQUAL(X, bytes, tmp_Y, bytes);
-        TEST_BUFFERS_EQUAL(Y, bytes, tmp_X, bytes);
+        TEST_MEMORY_COMPARE(X, bytes, tmp_Y, bytes);
+        TEST_MEMORY_COMPARE(Y, bytes, tmp_X, bytes);
     }
 
 exit:
@@ -297,27 +297,27 @@ void mpi_mod_raw_sub(char *input_A,
                    &m, N, limbs), 0);
 
     mbedtls_mpi_mod_raw_sub(X, A, B, &m);
-    TEST_BUFFERS_EQUAL(X, bytes, res, bytes);
+    TEST_MEMORY_COMPARE(X, bytes, res, bytes);
 
     /* alias X to A */
     memcpy(X, A, bytes);
     mbedtls_mpi_mod_raw_sub(X, X, B, &m);
-    TEST_BUFFERS_EQUAL(X, bytes, res, bytes);
+    TEST_MEMORY_COMPARE(X, bytes, res, bytes);
 
     /* alias X to B */
     memcpy(X, B, bytes);
     mbedtls_mpi_mod_raw_sub(X, A, X, &m);
-    TEST_BUFFERS_EQUAL(X, bytes, res, bytes);
+    TEST_MEMORY_COMPARE(X, bytes, res, bytes);
 
     /* A == B: alias A and B */
     if (memcmp(A, B, bytes) == 0) {
         mbedtls_mpi_mod_raw_sub(X, A, A, &m);
-        TEST_BUFFERS_EQUAL(X, bytes, res, bytes);
+        TEST_MEMORY_COMPARE(X, bytes, res, bytes);
 
         /* X, A, B all aliased together */
         memcpy(X, A, bytes);
         mbedtls_mpi_mod_raw_sub(X, X, X, &m);
-        TEST_BUFFERS_EQUAL(X, bytes, res, bytes);
+        TEST_MEMORY_COMPARE(X, bytes, res, bytes);
     }
 exit:
     mbedtls_free(A);
@@ -367,7 +367,7 @@ void mpi_mod_raw_fix_quasi_reduction(char *input_N,
                    &m, N, limbs), 0);
 
     mbedtls_mpi_mod_raw_fix_quasi_reduction(X, &m);
-    TEST_BUFFERS_EQUAL(X, bytes, res, bytes);
+    TEST_MEMORY_COMPARE(X, bytes, res, bytes);
 
 exit:
     mbedtls_free(X);
@@ -420,42 +420,42 @@ void mpi_mod_raw_mul(char *input_A,
     TEST_CALLOC(T, limbs_T);
 
     mbedtls_mpi_mod_raw_mul(X, A, B, &m, T);
-    TEST_BUFFERS_EQUAL(X, bytes, R, bytes);
+    TEST_MEMORY_COMPARE(X, bytes, R, bytes);
 
     /* alias X to A */
     memcpy(X, A, bytes);
     mbedtls_mpi_mod_raw_mul(X, X, B, &m, T);
-    TEST_BUFFERS_EQUAL(X, bytes, R, bytes);
+    TEST_MEMORY_COMPARE(X, bytes, R, bytes);
 
     /* alias X to B */
     memcpy(X, B, bytes);
     mbedtls_mpi_mod_raw_mul(X, A, X, &m, T);
-    TEST_BUFFERS_EQUAL(X, bytes, R, bytes);
+    TEST_MEMORY_COMPARE(X, bytes, R, bytes);
 
     /* A == B: alias A and B */
     if (memcmp(A, B, bytes) == 0) {
         mbedtls_mpi_mod_raw_mul(X, A, A, &m, T);
-        TEST_BUFFERS_EQUAL(X, bytes, R, bytes);
+        TEST_MEMORY_COMPARE(X, bytes, R, bytes);
 
         /* X, A, B all aliased together */
         memcpy(X, A, bytes);
         mbedtls_mpi_mod_raw_mul(X, X, X, &m, T);
-        TEST_BUFFERS_EQUAL(X, bytes, R, bytes);
+        TEST_MEMORY_COMPARE(X, bytes, R, bytes);
     }
     /* A != B: test B * A */
     else {
         mbedtls_mpi_mod_raw_mul(X, B, A, &m, T);
-        TEST_BUFFERS_EQUAL(X, bytes, R, bytes);
+        TEST_MEMORY_COMPARE(X, bytes, R, bytes);
 
         /* B * A: alias X to A */
         memcpy(X, A, bytes);
         mbedtls_mpi_mod_raw_mul(X, B, X, &m, T);
-        TEST_BUFFERS_EQUAL(X, bytes, R, bytes);
+        TEST_MEMORY_COMPARE(X, bytes, R, bytes);
 
         /* B + A: alias X to B */
         memcpy(X, B, bytes);
         mbedtls_mpi_mod_raw_mul(X, X, A, &m, T);
-        TEST_BUFFERS_EQUAL(X, bytes, R, bytes);
+        TEST_MEMORY_COMPARE(X, bytes, R, bytes);
     }
 
 exit:
@@ -578,45 +578,45 @@ void mpi_mod_raw_add(char *input_N,
 
     /* A + B => Correct result */
     mbedtls_mpi_mod_raw_add(X, A, B, &m);
-    TEST_BUFFERS_EQUAL(X, bytes, S, bytes);
+    TEST_MEMORY_COMPARE(X, bytes, S, bytes);
 
     /* A + B: alias X to A => Correct result */
     memcpy(X, A, bytes);
     mbedtls_mpi_mod_raw_add(X, X, B, &m);
-    TEST_BUFFERS_EQUAL(X, bytes, S, bytes);
+    TEST_MEMORY_COMPARE(X, bytes, S, bytes);
 
     /* A + B: alias X to B => Correct result */
     memcpy(X, B, bytes);
     mbedtls_mpi_mod_raw_add(X, A, X, &m);
-    TEST_BUFFERS_EQUAL(X, bytes, S, bytes);
+    TEST_MEMORY_COMPARE(X, bytes, S, bytes);
 
     if (memcmp(A, B, bytes) == 0) {
         /* A == B: alias A and B */
 
         /* A + A => Correct result */
         mbedtls_mpi_mod_raw_add(X, A, A, &m);
-        TEST_BUFFERS_EQUAL(X, bytes, S, bytes);
+        TEST_MEMORY_COMPARE(X, bytes, S, bytes);
 
         /* A + A: X, A, B all aliased together => Correct result */
         memcpy(X, A, bytes);
         mbedtls_mpi_mod_raw_add(X, X, X, &m);
-        TEST_BUFFERS_EQUAL(X, bytes, S, bytes);
+        TEST_MEMORY_COMPARE(X, bytes, S, bytes);
     } else {
         /* A != B: test B + A */
 
         /* B + A => Correct result */
         mbedtls_mpi_mod_raw_add(X, B, A, &m);
-        TEST_BUFFERS_EQUAL(X, bytes, S, bytes);
+        TEST_MEMORY_COMPARE(X, bytes, S, bytes);
 
         /* B + A: alias X to A => Correct result */
         memcpy(X, A, bytes);
         mbedtls_mpi_mod_raw_add(X, B, X, &m);
-        TEST_BUFFERS_EQUAL(X, bytes, S, bytes);
+        TEST_MEMORY_COMPARE(X, bytes, S, bytes);
 
         /* B + A: alias X to B => Correct result */
         memcpy(X, B, bytes);
         mbedtls_mpi_mod_raw_add(X, X, A, &m);
-        TEST_BUFFERS_EQUAL(X, bytes, S, bytes);
+        TEST_MEMORY_COMPARE(X, bytes, S, bytes);
     }
 
 exit:
@@ -647,7 +647,7 @@ void mpi_mod_raw_canonical_to_modulus_rep(const char *input_N, int rep,
     TEST_EQUAL(0, mbedtls_test_read_mpi_core(&X, &X_limbs, input_X));
 
     TEST_EQUAL(0, mbedtls_mpi_mod_raw_canonical_to_modulus_rep(A, &N));
-    TEST_BUFFERS_EQUAL(A, A_limbs * sizeof(mbedtls_mpi_uint),
+    TEST_MEMORY_COMPARE(A, A_limbs * sizeof(mbedtls_mpi_uint),
                    X, X_limbs * sizeof(mbedtls_mpi_uint));
 
 exit:
@@ -674,7 +674,7 @@ void mpi_mod_raw_modulus_to_canonical_rep(const char *input_N, int rep,
     TEST_EQUAL(0, mbedtls_test_read_mpi_core(&X, &X_limbs, input_X));
 
     TEST_EQUAL(0, mbedtls_mpi_mod_raw_modulus_to_canonical_rep(A, &N));
-    TEST_BUFFERS_EQUAL(A, A_limbs * sizeof(mbedtls_mpi_uint),
+    TEST_MEMORY_COMPARE(A, A_limbs * sizeof(mbedtls_mpi_uint),
                    X, X_limbs * sizeof(mbedtls_mpi_uint));
 
 exit:
@@ -723,20 +723,20 @@ void mpi_mod_raw_to_mont_rep(char *input_N, char *input_A, char *input_X)
     mbedtls_mpi_core_to_mont_rep(R, A, N, n_limbs,
                                  m.rep.mont.mm, m.rep.mont.rr, T);
     /* Test that the low-level function gives the required value */
-    TEST_BUFFERS_EQUAL(R, bytes, X, bytes);
+    TEST_MEMORY_COMPARE(R, bytes, X, bytes);
 
     /* Test when output is aliased to input */
     memcpy(R, A, bytes);
     mbedtls_mpi_core_to_mont_rep(R, R, N, n_limbs,
                                  m.rep.mont.mm, m.rep.mont.rr, T);
-    TEST_BUFFERS_EQUAL(R, bytes, X, bytes);
+    TEST_MEMORY_COMPARE(R, bytes, X, bytes);
 
     /* 2. Test higher-level cannonical to Montgomery conversion */
 
     TEST_EQUAL(0, mbedtls_mpi_mod_raw_to_mont_rep(A, &m));
 
     /* The result matches expected value */
-    TEST_BUFFERS_EQUAL(A, bytes, X, bytes);
+    TEST_MEMORY_COMPARE(A, bytes, X, bytes);
 
 exit:
     mbedtls_mpi_mod_modulus_free(&m);
@@ -787,20 +787,20 @@ void mpi_mod_raw_from_mont_rep(char *input_N, char *input_A, char *input_X)
     mbedtls_mpi_core_from_mont_rep(R, A, N, n_limbs,
                                    m.rep.mont.mm, T);
     /* Test that the low-level function gives the required value */
-    TEST_BUFFERS_EQUAL(R, bytes, X, bytes);
+    TEST_MEMORY_COMPARE(R, bytes, X, bytes);
 
     /* Test when output is aliased to input */
     memcpy(R, A, bytes);
     mbedtls_mpi_core_from_mont_rep(R, R, N, n_limbs,
                                    m.rep.mont.mm, T);
-    TEST_BUFFERS_EQUAL(R, bytes, X, bytes);
+    TEST_MEMORY_COMPARE(R, bytes, X, bytes);
 
     /* 2. Test higher-level Montgomery to cannonical conversion */
 
     TEST_EQUAL(0, mbedtls_mpi_mod_raw_from_mont_rep(A, &m));
 
     /* The result matches expected value */
-    TEST_BUFFERS_EQUAL(A, bytes, X, bytes);
+    TEST_MEMORY_COMPARE(A, bytes, X, bytes);
 
 exit:
     mbedtls_mpi_mod_modulus_free(&m);
@@ -841,19 +841,19 @@ void mpi_mod_raw_neg(char *input_N, char *input_A, char *input_X)
 
     /* Neg( A == 0 ) => Zero result */
     mbedtls_mpi_mod_raw_neg(R, Z, &m);
-    TEST_BUFFERS_EQUAL(R, bytes, Z, bytes);
+    TEST_MEMORY_COMPARE(R, bytes, Z, bytes);
 
     /* Neg( A == N ) => Zero result */
     mbedtls_mpi_mod_raw_neg(R, N, &m);
-    TEST_BUFFERS_EQUAL(R, bytes, Z, bytes);
+    TEST_MEMORY_COMPARE(R, bytes, Z, bytes);
 
     /* Neg( A ) => Correct result */
     mbedtls_mpi_mod_raw_neg(R, A, &m);
-    TEST_BUFFERS_EQUAL(R, bytes, X, bytes);
+    TEST_MEMORY_COMPARE(R, bytes, X, bytes);
 
     /* Neg( A ): alias A to R => Correct result */
     mbedtls_mpi_mod_raw_neg(A, A, &m);
-    TEST_BUFFERS_EQUAL(A, bytes, X, bytes);
+    TEST_MEMORY_COMPARE(A, bytes, X, bytes);
 exit:
     mbedtls_mpi_mod_modulus_free(&m);
     mbedtls_free(N);

--- a/tests/suites/test_suite_bignum_mod_raw.function
+++ b/tests/suites/test_suite_bignum_mod_raw.function
@@ -133,7 +133,7 @@ void mpi_mod_raw_cond_assign(char *input_X,
     TEST_EQUAL(limbs_X, limbs_Y);
     TEST_ASSERT(copy_limbs <= limbs);
 
-    ASSERT_ALLOC(buff_m, copy_limbs);
+    TEST_CALLOC_OR_FAIL(buff_m, copy_limbs);
     memset(buff_m, 0xFF, copy_limbs);
     TEST_EQUAL(mbedtls_mpi_mod_modulus_setup(
                    &m, buff_m, copy_limbs), 0);
@@ -203,15 +203,15 @@ void mpi_mod_raw_cond_swap(char *input_X,
     TEST_EQUAL(limbs_X, limbs_Y);
     TEST_ASSERT(copy_limbs <= limbs);
 
-    ASSERT_ALLOC(buff_m, copy_limbs);
+    TEST_CALLOC_OR_FAIL(buff_m, copy_limbs);
     memset(buff_m, 0xFF, copy_limbs);
     TEST_EQUAL(mbedtls_mpi_mod_modulus_setup(
                    &m, buff_m, copy_limbs), 0);
 
-    ASSERT_ALLOC(X, limbs);
+    TEST_CALLOC_OR_FAIL(X, limbs);
     memcpy(X, tmp_X, bytes);
 
-    ASSERT_ALLOC(Y, bytes);
+    TEST_CALLOC_OR_FAIL(Y, bytes);
     memcpy(Y, tmp_Y, bytes);
 
     /* condition is false */
@@ -291,7 +291,7 @@ void mpi_mod_raw_sub(char *input_A,
     TEST_EQUAL(limbs_B,   limbs);
     TEST_EQUAL(limbs_res, limbs);
 
-    ASSERT_ALLOC(X, limbs);
+    TEST_CALLOC_OR_FAIL(X, limbs);
 
     TEST_EQUAL(mbedtls_mpi_mod_modulus_setup(
                    &m, N, limbs), 0);
@@ -356,7 +356,7 @@ void mpi_mod_raw_fix_quasi_reduction(char *input_N,
     TEST_EQUAL(limbs_X,   limbs);
     TEST_EQUAL(limbs_res, limbs);
 
-    ASSERT_ALLOC(tmp, limbs);
+    TEST_CALLOC_OR_FAIL(tmp, limbs);
     memcpy(tmp, X, bytes);
 
     /* Check that 0 <= X < 2N */
@@ -411,13 +411,13 @@ void mpi_mod_raw_mul(char *input_A,
     TEST_EQUAL(limbs_B, limbs);
     TEST_EQUAL(limbs_R, limbs);
 
-    ASSERT_ALLOC(X, limbs);
+    TEST_CALLOC_OR_FAIL(X, limbs);
 
     TEST_EQUAL(mbedtls_mpi_mod_modulus_setup(
                    &m, N, limbs), 0);
 
     const size_t limbs_T = limbs * 2 + 1;
-    ASSERT_ALLOC(T, limbs_T);
+    TEST_CALLOC_OR_FAIL(T, limbs_T);
 
     mbedtls_mpi_mod_raw_mul(X, A, B, &m, T);
     TEST_BUFFERS_EQUAL(X, bytes, R, bytes);
@@ -489,7 +489,7 @@ void mpi_mod_raw_inv_prime(char *input_N, char *input_A, char *input_X)
     TEST_EQUAL(0, mbedtls_test_read_mpi_core(&A, &A_limbs, input_A));
     TEST_EQUAL(0, mbedtls_test_read_mpi_core(&N, &N_limbs, input_N));
     TEST_EQUAL(0, mbedtls_test_read_mpi_core(&X, &X_limbs, input_X));
-    ASSERT_ALLOC(Y, N_limbs);
+    TEST_CALLOC_OR_FAIL(Y, N_limbs);
 
     TEST_EQUAL(A_limbs, N_limbs);
     TEST_EQUAL(X_limbs, N_limbs);
@@ -519,7 +519,7 @@ void mpi_mod_raw_inv_prime(char *input_N, char *input_A, char *input_X)
     TEST_LE_U(mbedtls_mpi_core_montmul_working_limbs(N_limbs),
               working_limbs);
 
-    ASSERT_ALLOC(T, working_limbs);
+    TEST_CALLOC_OR_FAIL(T, working_limbs);
 
     mbedtls_mpi_mod_raw_inv_prime(Y, A, N, N_limbs, R2, T);
 
@@ -571,7 +571,7 @@ void mpi_mod_raw_add(char *input_N,
     TEST_EQUAL(B_limbs, limbs);
     TEST_EQUAL(S_limbs, limbs);
 
-    ASSERT_ALLOC(X, limbs);
+    TEST_CALLOC_OR_FAIL(X, limbs);
 
     TEST_EQUAL(mbedtls_mpi_mod_modulus_setup(
                    &m, N, limbs), 0);
@@ -718,8 +718,8 @@ void mpi_mod_raw_to_mont_rep(char *input_N, char *input_A, char *input_X)
 
     /* It has separate output, and requires temporary working storage */
     size_t temp_limbs = mbedtls_mpi_core_montmul_working_limbs(limbs);
-    ASSERT_ALLOC(T, temp_limbs);
-    ASSERT_ALLOC(R, limbs);
+    TEST_CALLOC_OR_FAIL(T, temp_limbs);
+    TEST_CALLOC_OR_FAIL(R, limbs);
     mbedtls_mpi_core_to_mont_rep(R, A, N, n_limbs,
                                  m.rep.mont.mm, m.rep.mont.rr, T);
     /* Test that the low-level function gives the required value */
@@ -782,8 +782,8 @@ void mpi_mod_raw_from_mont_rep(char *input_N, char *input_A, char *input_X)
 
     /* It has separate output, and requires temporary working storage */
     size_t temp_limbs = mbedtls_mpi_core_montmul_working_limbs(limbs);
-    ASSERT_ALLOC(T, temp_limbs);
-    ASSERT_ALLOC(R, limbs);
+    TEST_CALLOC_OR_FAIL(T, temp_limbs);
+    TEST_CALLOC_OR_FAIL(R, limbs);
     mbedtls_mpi_core_from_mont_rep(R, A, N, n_limbs,
                                    m.rep.mont.mm, T);
     /* Test that the low-level function gives the required value */
@@ -834,8 +834,8 @@ void mpi_mod_raw_neg(char *input_N, char *input_A, char *input_X)
     TEST_EQUAL(x_limbs, n_limbs);
     bytes = n_limbs * sizeof(mbedtls_mpi_uint);
 
-    ASSERT_ALLOC(R, n_limbs);
-    ASSERT_ALLOC(Z, n_limbs);
+    TEST_CALLOC_OR_FAIL(R, n_limbs);
+    TEST_CALLOC_OR_FAIL(Z, n_limbs);
 
     TEST_EQUAL(0, mbedtls_mpi_mod_modulus_setup(&m, N, n_limbs));
 

--- a/tests/suites/test_suite_bignum_mod_raw.function
+++ b/tests/suites/test_suite_bignum_mod_raw.function
@@ -161,10 +161,10 @@ void mpi_mod_raw_cond_assign(char *input_X,
     /* Check if the given length is copied even it is smaller
        than the length of the given MPIs. */
     if (copy_limbs < limbs) {
-        ASSERT_COMPARE(X, copy_bytes, Y, copy_bytes);
+        TEST_BUFFERS_EQUAL(X, copy_bytes, Y, copy_bytes);
         TEST_ASSERT(memcmp(X, Y, bytes) != 0);
     } else {
-        ASSERT_COMPARE(X, bytes, Y, bytes);
+        TEST_BUFFERS_EQUAL(X, bytes, Y, bytes);
     }
 
 exit:
@@ -223,8 +223,8 @@ void mpi_mod_raw_cond_swap(char *input_X,
     TEST_CF_PUBLIC(X, bytes);
     TEST_CF_PUBLIC(Y, bytes);
 
-    ASSERT_COMPARE(X, bytes, tmp_X, bytes);
-    ASSERT_COMPARE(Y, bytes, tmp_Y, bytes);
+    TEST_BUFFERS_EQUAL(X, bytes, tmp_X, bytes);
+    TEST_BUFFERS_EQUAL(Y, bytes, tmp_Y, bytes);
 
     /* condition is true */
     TEST_CF_SECRET(X, bytes);
@@ -238,15 +238,15 @@ void mpi_mod_raw_cond_swap(char *input_X,
     /* Check if the given length is copied even it is smaller
        than the length of the given MPIs. */
     if (copy_limbs < limbs) {
-        ASSERT_COMPARE(X, copy_bytes, tmp_Y, copy_bytes);
-        ASSERT_COMPARE(Y, copy_bytes, tmp_X, copy_bytes);
+        TEST_BUFFERS_EQUAL(X, copy_bytes, tmp_Y, copy_bytes);
+        TEST_BUFFERS_EQUAL(Y, copy_bytes, tmp_X, copy_bytes);
         TEST_ASSERT(memcmp(X, tmp_X, bytes) != 0);
         TEST_ASSERT(memcmp(X, tmp_Y, bytes) != 0);
         TEST_ASSERT(memcmp(Y, tmp_X, bytes) != 0);
         TEST_ASSERT(memcmp(Y, tmp_Y, bytes) != 0);
     } else {
-        ASSERT_COMPARE(X, bytes, tmp_Y, bytes);
-        ASSERT_COMPARE(Y, bytes, tmp_X, bytes);
+        TEST_BUFFERS_EQUAL(X, bytes, tmp_Y, bytes);
+        TEST_BUFFERS_EQUAL(Y, bytes, tmp_X, bytes);
     }
 
 exit:
@@ -297,27 +297,27 @@ void mpi_mod_raw_sub(char *input_A,
                    &m, N, limbs), 0);
 
     mbedtls_mpi_mod_raw_sub(X, A, B, &m);
-    ASSERT_COMPARE(X, bytes, res, bytes);
+    TEST_BUFFERS_EQUAL(X, bytes, res, bytes);
 
     /* alias X to A */
     memcpy(X, A, bytes);
     mbedtls_mpi_mod_raw_sub(X, X, B, &m);
-    ASSERT_COMPARE(X, bytes, res, bytes);
+    TEST_BUFFERS_EQUAL(X, bytes, res, bytes);
 
     /* alias X to B */
     memcpy(X, B, bytes);
     mbedtls_mpi_mod_raw_sub(X, A, X, &m);
-    ASSERT_COMPARE(X, bytes, res, bytes);
+    TEST_BUFFERS_EQUAL(X, bytes, res, bytes);
 
     /* A == B: alias A and B */
     if (memcmp(A, B, bytes) == 0) {
         mbedtls_mpi_mod_raw_sub(X, A, A, &m);
-        ASSERT_COMPARE(X, bytes, res, bytes);
+        TEST_BUFFERS_EQUAL(X, bytes, res, bytes);
 
         /* X, A, B all aliased together */
         memcpy(X, A, bytes);
         mbedtls_mpi_mod_raw_sub(X, X, X, &m);
-        ASSERT_COMPARE(X, bytes, res, bytes);
+        TEST_BUFFERS_EQUAL(X, bytes, res, bytes);
     }
 exit:
     mbedtls_free(A);
@@ -367,7 +367,7 @@ void mpi_mod_raw_fix_quasi_reduction(char *input_N,
                    &m, N, limbs), 0);
 
     mbedtls_mpi_mod_raw_fix_quasi_reduction(X, &m);
-    ASSERT_COMPARE(X, bytes, res, bytes);
+    TEST_BUFFERS_EQUAL(X, bytes, res, bytes);
 
 exit:
     mbedtls_free(X);
@@ -420,42 +420,42 @@ void mpi_mod_raw_mul(char *input_A,
     ASSERT_ALLOC(T, limbs_T);
 
     mbedtls_mpi_mod_raw_mul(X, A, B, &m, T);
-    ASSERT_COMPARE(X, bytes, R, bytes);
+    TEST_BUFFERS_EQUAL(X, bytes, R, bytes);
 
     /* alias X to A */
     memcpy(X, A, bytes);
     mbedtls_mpi_mod_raw_mul(X, X, B, &m, T);
-    ASSERT_COMPARE(X, bytes, R, bytes);
+    TEST_BUFFERS_EQUAL(X, bytes, R, bytes);
 
     /* alias X to B */
     memcpy(X, B, bytes);
     mbedtls_mpi_mod_raw_mul(X, A, X, &m, T);
-    ASSERT_COMPARE(X, bytes, R, bytes);
+    TEST_BUFFERS_EQUAL(X, bytes, R, bytes);
 
     /* A == B: alias A and B */
     if (memcmp(A, B, bytes) == 0) {
         mbedtls_mpi_mod_raw_mul(X, A, A, &m, T);
-        ASSERT_COMPARE(X, bytes, R, bytes);
+        TEST_BUFFERS_EQUAL(X, bytes, R, bytes);
 
         /* X, A, B all aliased together */
         memcpy(X, A, bytes);
         mbedtls_mpi_mod_raw_mul(X, X, X, &m, T);
-        ASSERT_COMPARE(X, bytes, R, bytes);
+        TEST_BUFFERS_EQUAL(X, bytes, R, bytes);
     }
     /* A != B: test B * A */
     else {
         mbedtls_mpi_mod_raw_mul(X, B, A, &m, T);
-        ASSERT_COMPARE(X, bytes, R, bytes);
+        TEST_BUFFERS_EQUAL(X, bytes, R, bytes);
 
         /* B * A: alias X to A */
         memcpy(X, A, bytes);
         mbedtls_mpi_mod_raw_mul(X, B, X, &m, T);
-        ASSERT_COMPARE(X, bytes, R, bytes);
+        TEST_BUFFERS_EQUAL(X, bytes, R, bytes);
 
         /* B + A: alias X to B */
         memcpy(X, B, bytes);
         mbedtls_mpi_mod_raw_mul(X, X, A, &m, T);
-        ASSERT_COMPARE(X, bytes, R, bytes);
+        TEST_BUFFERS_EQUAL(X, bytes, R, bytes);
     }
 
 exit:
@@ -578,45 +578,45 @@ void mpi_mod_raw_add(char *input_N,
 
     /* A + B => Correct result */
     mbedtls_mpi_mod_raw_add(X, A, B, &m);
-    ASSERT_COMPARE(X, bytes, S, bytes);
+    TEST_BUFFERS_EQUAL(X, bytes, S, bytes);
 
     /* A + B: alias X to A => Correct result */
     memcpy(X, A, bytes);
     mbedtls_mpi_mod_raw_add(X, X, B, &m);
-    ASSERT_COMPARE(X, bytes, S, bytes);
+    TEST_BUFFERS_EQUAL(X, bytes, S, bytes);
 
     /* A + B: alias X to B => Correct result */
     memcpy(X, B, bytes);
     mbedtls_mpi_mod_raw_add(X, A, X, &m);
-    ASSERT_COMPARE(X, bytes, S, bytes);
+    TEST_BUFFERS_EQUAL(X, bytes, S, bytes);
 
     if (memcmp(A, B, bytes) == 0) {
         /* A == B: alias A and B */
 
         /* A + A => Correct result */
         mbedtls_mpi_mod_raw_add(X, A, A, &m);
-        ASSERT_COMPARE(X, bytes, S, bytes);
+        TEST_BUFFERS_EQUAL(X, bytes, S, bytes);
 
         /* A + A: X, A, B all aliased together => Correct result */
         memcpy(X, A, bytes);
         mbedtls_mpi_mod_raw_add(X, X, X, &m);
-        ASSERT_COMPARE(X, bytes, S, bytes);
+        TEST_BUFFERS_EQUAL(X, bytes, S, bytes);
     } else {
         /* A != B: test B + A */
 
         /* B + A => Correct result */
         mbedtls_mpi_mod_raw_add(X, B, A, &m);
-        ASSERT_COMPARE(X, bytes, S, bytes);
+        TEST_BUFFERS_EQUAL(X, bytes, S, bytes);
 
         /* B + A: alias X to A => Correct result */
         memcpy(X, A, bytes);
         mbedtls_mpi_mod_raw_add(X, B, X, &m);
-        ASSERT_COMPARE(X, bytes, S, bytes);
+        TEST_BUFFERS_EQUAL(X, bytes, S, bytes);
 
         /* B + A: alias X to B => Correct result */
         memcpy(X, B, bytes);
         mbedtls_mpi_mod_raw_add(X, X, A, &m);
-        ASSERT_COMPARE(X, bytes, S, bytes);
+        TEST_BUFFERS_EQUAL(X, bytes, S, bytes);
     }
 
 exit:
@@ -647,7 +647,7 @@ void mpi_mod_raw_canonical_to_modulus_rep(const char *input_N, int rep,
     TEST_EQUAL(0, mbedtls_test_read_mpi_core(&X, &X_limbs, input_X));
 
     TEST_EQUAL(0, mbedtls_mpi_mod_raw_canonical_to_modulus_rep(A, &N));
-    ASSERT_COMPARE(A, A_limbs * sizeof(mbedtls_mpi_uint),
+    TEST_BUFFERS_EQUAL(A, A_limbs * sizeof(mbedtls_mpi_uint),
                    X, X_limbs * sizeof(mbedtls_mpi_uint));
 
 exit:
@@ -674,7 +674,7 @@ void mpi_mod_raw_modulus_to_canonical_rep(const char *input_N, int rep,
     TEST_EQUAL(0, mbedtls_test_read_mpi_core(&X, &X_limbs, input_X));
 
     TEST_EQUAL(0, mbedtls_mpi_mod_raw_modulus_to_canonical_rep(A, &N));
-    ASSERT_COMPARE(A, A_limbs * sizeof(mbedtls_mpi_uint),
+    TEST_BUFFERS_EQUAL(A, A_limbs * sizeof(mbedtls_mpi_uint),
                    X, X_limbs * sizeof(mbedtls_mpi_uint));
 
 exit:
@@ -723,20 +723,20 @@ void mpi_mod_raw_to_mont_rep(char *input_N, char *input_A, char *input_X)
     mbedtls_mpi_core_to_mont_rep(R, A, N, n_limbs,
                                  m.rep.mont.mm, m.rep.mont.rr, T);
     /* Test that the low-level function gives the required value */
-    ASSERT_COMPARE(R, bytes, X, bytes);
+    TEST_BUFFERS_EQUAL(R, bytes, X, bytes);
 
     /* Test when output is aliased to input */
     memcpy(R, A, bytes);
     mbedtls_mpi_core_to_mont_rep(R, R, N, n_limbs,
                                  m.rep.mont.mm, m.rep.mont.rr, T);
-    ASSERT_COMPARE(R, bytes, X, bytes);
+    TEST_BUFFERS_EQUAL(R, bytes, X, bytes);
 
     /* 2. Test higher-level cannonical to Montgomery conversion */
 
     TEST_EQUAL(0, mbedtls_mpi_mod_raw_to_mont_rep(A, &m));
 
     /* The result matches expected value */
-    ASSERT_COMPARE(A, bytes, X, bytes);
+    TEST_BUFFERS_EQUAL(A, bytes, X, bytes);
 
 exit:
     mbedtls_mpi_mod_modulus_free(&m);
@@ -787,20 +787,20 @@ void mpi_mod_raw_from_mont_rep(char *input_N, char *input_A, char *input_X)
     mbedtls_mpi_core_from_mont_rep(R, A, N, n_limbs,
                                    m.rep.mont.mm, T);
     /* Test that the low-level function gives the required value */
-    ASSERT_COMPARE(R, bytes, X, bytes);
+    TEST_BUFFERS_EQUAL(R, bytes, X, bytes);
 
     /* Test when output is aliased to input */
     memcpy(R, A, bytes);
     mbedtls_mpi_core_from_mont_rep(R, R, N, n_limbs,
                                    m.rep.mont.mm, T);
-    ASSERT_COMPARE(R, bytes, X, bytes);
+    TEST_BUFFERS_EQUAL(R, bytes, X, bytes);
 
     /* 2. Test higher-level Montgomery to cannonical conversion */
 
     TEST_EQUAL(0, mbedtls_mpi_mod_raw_from_mont_rep(A, &m));
 
     /* The result matches expected value */
-    ASSERT_COMPARE(A, bytes, X, bytes);
+    TEST_BUFFERS_EQUAL(A, bytes, X, bytes);
 
 exit:
     mbedtls_mpi_mod_modulus_free(&m);
@@ -841,19 +841,19 @@ void mpi_mod_raw_neg(char *input_N, char *input_A, char *input_X)
 
     /* Neg( A == 0 ) => Zero result */
     mbedtls_mpi_mod_raw_neg(R, Z, &m);
-    ASSERT_COMPARE(R, bytes, Z, bytes);
+    TEST_BUFFERS_EQUAL(R, bytes, Z, bytes);
 
     /* Neg( A == N ) => Zero result */
     mbedtls_mpi_mod_raw_neg(R, N, &m);
-    ASSERT_COMPARE(R, bytes, Z, bytes);
+    TEST_BUFFERS_EQUAL(R, bytes, Z, bytes);
 
     /* Neg( A ) => Correct result */
     mbedtls_mpi_mod_raw_neg(R, A, &m);
-    ASSERT_COMPARE(R, bytes, X, bytes);
+    TEST_BUFFERS_EQUAL(R, bytes, X, bytes);
 
     /* Neg( A ): alias A to R => Correct result */
     mbedtls_mpi_mod_raw_neg(A, A, &m);
-    ASSERT_COMPARE(A, bytes, X, bytes);
+    TEST_BUFFERS_EQUAL(A, bytes, X, bytes);
 exit:
     mbedtls_mpi_mod_modulus_free(&m);
     mbedtls_free(N);

--- a/tests/suites/test_suite_bignum_mod_raw.function
+++ b/tests/suites/test_suite_bignum_mod_raw.function
@@ -648,7 +648,7 @@ void mpi_mod_raw_canonical_to_modulus_rep(const char *input_N, int rep,
 
     TEST_EQUAL(0, mbedtls_mpi_mod_raw_canonical_to_modulus_rep(A, &N));
     TEST_MEMORY_COMPARE(A, A_limbs * sizeof(mbedtls_mpi_uint),
-                   X, X_limbs * sizeof(mbedtls_mpi_uint));
+                        X, X_limbs * sizeof(mbedtls_mpi_uint));
 
 exit:
     mbedtls_test_mpi_mod_modulus_free_with_limbs(&N);
@@ -675,7 +675,7 @@ void mpi_mod_raw_modulus_to_canonical_rep(const char *input_N, int rep,
 
     TEST_EQUAL(0, mbedtls_mpi_mod_raw_modulus_to_canonical_rep(A, &N));
     TEST_MEMORY_COMPARE(A, A_limbs * sizeof(mbedtls_mpi_uint),
-                   X, X_limbs * sizeof(mbedtls_mpi_uint));
+                        X, X_limbs * sizeof(mbedtls_mpi_uint));
 
 exit:
     mbedtls_test_mpi_mod_modulus_free_with_limbs(&N);

--- a/tests/suites/test_suite_bignum_mod_raw.function
+++ b/tests/suites/test_suite_bignum_mod_raw.function
@@ -133,7 +133,7 @@ void mpi_mod_raw_cond_assign(char *input_X,
     TEST_EQUAL(limbs_X, limbs_Y);
     TEST_ASSERT(copy_limbs <= limbs);
 
-    TEST_CALLOC_OR_FAIL(buff_m, copy_limbs);
+    TEST_CALLOC(buff_m, copy_limbs);
     memset(buff_m, 0xFF, copy_limbs);
     TEST_EQUAL(mbedtls_mpi_mod_modulus_setup(
                    &m, buff_m, copy_limbs), 0);
@@ -203,15 +203,15 @@ void mpi_mod_raw_cond_swap(char *input_X,
     TEST_EQUAL(limbs_X, limbs_Y);
     TEST_ASSERT(copy_limbs <= limbs);
 
-    TEST_CALLOC_OR_FAIL(buff_m, copy_limbs);
+    TEST_CALLOC(buff_m, copy_limbs);
     memset(buff_m, 0xFF, copy_limbs);
     TEST_EQUAL(mbedtls_mpi_mod_modulus_setup(
                    &m, buff_m, copy_limbs), 0);
 
-    TEST_CALLOC_OR_FAIL(X, limbs);
+    TEST_CALLOC(X, limbs);
     memcpy(X, tmp_X, bytes);
 
-    TEST_CALLOC_OR_FAIL(Y, bytes);
+    TEST_CALLOC(Y, bytes);
     memcpy(Y, tmp_Y, bytes);
 
     /* condition is false */
@@ -291,7 +291,7 @@ void mpi_mod_raw_sub(char *input_A,
     TEST_EQUAL(limbs_B,   limbs);
     TEST_EQUAL(limbs_res, limbs);
 
-    TEST_CALLOC_OR_FAIL(X, limbs);
+    TEST_CALLOC(X, limbs);
 
     TEST_EQUAL(mbedtls_mpi_mod_modulus_setup(
                    &m, N, limbs), 0);
@@ -356,7 +356,7 @@ void mpi_mod_raw_fix_quasi_reduction(char *input_N,
     TEST_EQUAL(limbs_X,   limbs);
     TEST_EQUAL(limbs_res, limbs);
 
-    TEST_CALLOC_OR_FAIL(tmp, limbs);
+    TEST_CALLOC(tmp, limbs);
     memcpy(tmp, X, bytes);
 
     /* Check that 0 <= X < 2N */
@@ -411,13 +411,13 @@ void mpi_mod_raw_mul(char *input_A,
     TEST_EQUAL(limbs_B, limbs);
     TEST_EQUAL(limbs_R, limbs);
 
-    TEST_CALLOC_OR_FAIL(X, limbs);
+    TEST_CALLOC(X, limbs);
 
     TEST_EQUAL(mbedtls_mpi_mod_modulus_setup(
                    &m, N, limbs), 0);
 
     const size_t limbs_T = limbs * 2 + 1;
-    TEST_CALLOC_OR_FAIL(T, limbs_T);
+    TEST_CALLOC(T, limbs_T);
 
     mbedtls_mpi_mod_raw_mul(X, A, B, &m, T);
     TEST_BUFFERS_EQUAL(X, bytes, R, bytes);
@@ -489,7 +489,7 @@ void mpi_mod_raw_inv_prime(char *input_N, char *input_A, char *input_X)
     TEST_EQUAL(0, mbedtls_test_read_mpi_core(&A, &A_limbs, input_A));
     TEST_EQUAL(0, mbedtls_test_read_mpi_core(&N, &N_limbs, input_N));
     TEST_EQUAL(0, mbedtls_test_read_mpi_core(&X, &X_limbs, input_X));
-    TEST_CALLOC_OR_FAIL(Y, N_limbs);
+    TEST_CALLOC(Y, N_limbs);
 
     TEST_EQUAL(A_limbs, N_limbs);
     TEST_EQUAL(X_limbs, N_limbs);
@@ -519,7 +519,7 @@ void mpi_mod_raw_inv_prime(char *input_N, char *input_A, char *input_X)
     TEST_LE_U(mbedtls_mpi_core_montmul_working_limbs(N_limbs),
               working_limbs);
 
-    TEST_CALLOC_OR_FAIL(T, working_limbs);
+    TEST_CALLOC(T, working_limbs);
 
     mbedtls_mpi_mod_raw_inv_prime(Y, A, N, N_limbs, R2, T);
 
@@ -571,7 +571,7 @@ void mpi_mod_raw_add(char *input_N,
     TEST_EQUAL(B_limbs, limbs);
     TEST_EQUAL(S_limbs, limbs);
 
-    TEST_CALLOC_OR_FAIL(X, limbs);
+    TEST_CALLOC(X, limbs);
 
     TEST_EQUAL(mbedtls_mpi_mod_modulus_setup(
                    &m, N, limbs), 0);
@@ -718,8 +718,8 @@ void mpi_mod_raw_to_mont_rep(char *input_N, char *input_A, char *input_X)
 
     /* It has separate output, and requires temporary working storage */
     size_t temp_limbs = mbedtls_mpi_core_montmul_working_limbs(limbs);
-    TEST_CALLOC_OR_FAIL(T, temp_limbs);
-    TEST_CALLOC_OR_FAIL(R, limbs);
+    TEST_CALLOC(T, temp_limbs);
+    TEST_CALLOC(R, limbs);
     mbedtls_mpi_core_to_mont_rep(R, A, N, n_limbs,
                                  m.rep.mont.mm, m.rep.mont.rr, T);
     /* Test that the low-level function gives the required value */
@@ -782,8 +782,8 @@ void mpi_mod_raw_from_mont_rep(char *input_N, char *input_A, char *input_X)
 
     /* It has separate output, and requires temporary working storage */
     size_t temp_limbs = mbedtls_mpi_core_montmul_working_limbs(limbs);
-    TEST_CALLOC_OR_FAIL(T, temp_limbs);
-    TEST_CALLOC_OR_FAIL(R, limbs);
+    TEST_CALLOC(T, temp_limbs);
+    TEST_CALLOC(R, limbs);
     mbedtls_mpi_core_from_mont_rep(R, A, N, n_limbs,
                                    m.rep.mont.mm, T);
     /* Test that the low-level function gives the required value */
@@ -834,8 +834,8 @@ void mpi_mod_raw_neg(char *input_N, char *input_A, char *input_X)
     TEST_EQUAL(x_limbs, n_limbs);
     bytes = n_limbs * sizeof(mbedtls_mpi_uint);
 
-    TEST_CALLOC_OR_FAIL(R, n_limbs);
-    TEST_CALLOC_OR_FAIL(Z, n_limbs);
+    TEST_CALLOC(R, n_limbs);
+    TEST_CALLOC(Z, n_limbs);
 
     TEST_EQUAL(0, mbedtls_mpi_mod_modulus_setup(&m, N, n_limbs));
 

--- a/tests/suites/test_suite_bignum_random.function
+++ b/tests/suites/test_suite_bignum_random.function
@@ -175,7 +175,7 @@ void mpi_legacy_random_values(int min, char *max_hex)
     TEST_EQUAL(core_ret, legacy_ret);
     if (core_ret == 0) {
         TEST_MEMORY_COMPARE(R_core, limbs * ciL,
-                       R_legacy.p, R_legacy.n * ciL);
+                            R_legacy.p, R_legacy.n * ciL);
     }
 
     /* Also check that they have consumed the RNG in the same way. */
@@ -183,7 +183,7 @@ void mpi_legacy_random_values(int min, char *max_hex)
      * the structure! If this is a problem in practice, change to a
      * field-by-field comparison. */
     TEST_MEMORY_COMPARE(&rnd_core, sizeof(rnd_core),
-                   &rnd_legacy, sizeof(rnd_legacy));
+                        &rnd_legacy, sizeof(rnd_legacy));
 
 exit:
     mbedtls_mpi_free(&max_legacy);
@@ -238,11 +238,11 @@ void mpi_mod_random_values(int min, char *max_hex, int rep)
         TEST_EQUAL(mbedtls_mpi_mod_raw_modulus_to_canonical_rep(R_mod_raw, &N),
                    0);
         TEST_MEMORY_COMPARE(R_core, N.limbs * ciL,
-                       R_mod_raw, N.limbs * ciL);
+                            R_mod_raw, N.limbs * ciL);
         TEST_EQUAL(mbedtls_mpi_mod_raw_modulus_to_canonical_rep(R_mod_digits, &N),
                    0);
         TEST_MEMORY_COMPARE(R_core, N.limbs * ciL,
-                       R_mod_digits, N.limbs * ciL);
+                            R_mod_digits, N.limbs * ciL);
     }
 
     /* Also check that they have consumed the RNG in the same way. */
@@ -250,9 +250,9 @@ void mpi_mod_random_values(int min, char *max_hex, int rep)
      * the structure! If this is a problem in practice, change to a
      * field-by-field comparison. */
     TEST_MEMORY_COMPARE(&rnd_core, sizeof(rnd_core),
-                   &rnd_mod_raw, sizeof(rnd_mod_raw));
+                        &rnd_mod_raw, sizeof(rnd_mod_raw));
     TEST_MEMORY_COMPARE(&rnd_core, sizeof(rnd_core),
-                   &rnd_mod, sizeof(rnd_mod));
+                        &rnd_mod, sizeof(rnd_mod));
 
 exit:
     mbedtls_test_mpi_mod_modulus_free_with_limbs(&N);

--- a/tests/suites/test_suite_bignum_random.function
+++ b/tests/suites/test_suite_bignum_random.function
@@ -124,9 +124,9 @@ void mpi_core_random_basic(int min, char *bound_bytes, int expected_ret)
 
     TEST_EQUAL(0, mbedtls_test_read_mpi_core(&upper_bound, &limbs,
                                              bound_bytes));
-    ASSERT_ALLOC(lower_bound, limbs);
+    TEST_CALLOC_OR_FAIL(lower_bound, limbs);
     lower_bound[0] = min;
-    ASSERT_ALLOC(result, limbs);
+    TEST_CALLOC_OR_FAIL(result, limbs);
 
     TEST_EQUAL(expected_ret,
                mbedtls_mpi_core_random(result, min, upper_bound, limbs,
@@ -159,7 +159,7 @@ void mpi_legacy_random_values(int min, char *max_hex)
 
     TEST_EQUAL(0, mbedtls_test_read_mpi(&max_legacy, max_hex));
     size_t limbs = max_legacy.n;
-    ASSERT_ALLOC(R_core, limbs);
+    TEST_CALLOC_OR_FAIL(R_core, limbs);
 
     /* Call the legacy function and the core function with the same random
      * stream. */
@@ -209,9 +209,9 @@ void mpi_mod_random_values(int min, char *max_hex, int rep)
     mbedtls_mpi_mod_modulus_init(&N);
 
     TEST_EQUAL(mbedtls_test_read_mpi_modulus(&N, max_hex, rep), 0);
-    ASSERT_ALLOC(R_core, N.limbs);
-    ASSERT_ALLOC(R_mod_raw, N.limbs);
-    ASSERT_ALLOC(R_mod_digits, N.limbs);
+    TEST_CALLOC_OR_FAIL(R_core, N.limbs);
+    TEST_CALLOC_OR_FAIL(R_mod_raw, N.limbs);
+    TEST_CALLOC_OR_FAIL(R_mod_digits, N.limbs);
     TEST_EQUAL(mbedtls_mpi_mod_residue_setup(&R_mod, &N,
                                              R_mod_digits, N.limbs),
                0);
@@ -287,7 +287,7 @@ void mpi_random_many(int min, char *bound_hex, int iterations)
 
     TEST_EQUAL(0, mbedtls_test_read_mpi_core(&upper_bound, &limbs,
                                              bound_hex));
-    ASSERT_ALLOC(result, limbs);
+    TEST_CALLOC_OR_FAIL(result, limbs);
 
     n_bits = mbedtls_mpi_core_bitlen(upper_bound, limbs);
     /* Consider a bound "small" if it's less than 2^5. This value is chosen
@@ -302,7 +302,7 @@ void mpi_random_many(int min, char *bound_hex, int iterations)
         full_stats = 0;
         stats_len = n_bits;
     }
-    ASSERT_ALLOC(stats, stats_len);
+    TEST_CALLOC_OR_FAIL(stats, stats_len);
 
     for (i = 0; i < (size_t) iterations; i++) {
         mbedtls_test_set_step(i);
@@ -340,7 +340,7 @@ void mpi_random_many(int min, char *bound_hex, int iterations)
         }
     } else {
         bound_bytes.len = limbs * sizeof(mbedtls_mpi_uint);
-        ASSERT_ALLOC(bound_bytes.x, bound_bytes.len);
+        TEST_CALLOC_OR_FAIL(bound_bytes.x, bound_bytes.len);
         mbedtls_mpi_core_write_be(upper_bound, limbs,
                                   bound_bytes.x, bound_bytes.len);
         int statistically_safe_all_the_way =
@@ -416,7 +416,7 @@ void mpi_mod_random_validation(int min, char *bound_hex,
                                              MBEDTLS_MPI_MOD_REP_OPT_RED),
                0);
     size_t result_limbs = N.limbs + result_limbs_delta;
-    ASSERT_ALLOC(result_digits, result_limbs);
+    TEST_CALLOC_OR_FAIL(result_digits, result_limbs);
     /* Build a reside that might not match the modulus, to test that
      * the library function rejects that as expected. */
     mbedtls_mpi_mod_residue result = { result_digits, result_limbs };

--- a/tests/suites/test_suite_bignum_random.function
+++ b/tests/suites/test_suite_bignum_random.function
@@ -124,9 +124,9 @@ void mpi_core_random_basic(int min, char *bound_bytes, int expected_ret)
 
     TEST_EQUAL(0, mbedtls_test_read_mpi_core(&upper_bound, &limbs,
                                              bound_bytes));
-    TEST_CALLOC_OR_FAIL(lower_bound, limbs);
+    TEST_CALLOC(lower_bound, limbs);
     lower_bound[0] = min;
-    TEST_CALLOC_OR_FAIL(result, limbs);
+    TEST_CALLOC(result, limbs);
 
     TEST_EQUAL(expected_ret,
                mbedtls_mpi_core_random(result, min, upper_bound, limbs,
@@ -159,7 +159,7 @@ void mpi_legacy_random_values(int min, char *max_hex)
 
     TEST_EQUAL(0, mbedtls_test_read_mpi(&max_legacy, max_hex));
     size_t limbs = max_legacy.n;
-    TEST_CALLOC_OR_FAIL(R_core, limbs);
+    TEST_CALLOC(R_core, limbs);
 
     /* Call the legacy function and the core function with the same random
      * stream. */
@@ -209,9 +209,9 @@ void mpi_mod_random_values(int min, char *max_hex, int rep)
     mbedtls_mpi_mod_modulus_init(&N);
 
     TEST_EQUAL(mbedtls_test_read_mpi_modulus(&N, max_hex, rep), 0);
-    TEST_CALLOC_OR_FAIL(R_core, N.limbs);
-    TEST_CALLOC_OR_FAIL(R_mod_raw, N.limbs);
-    TEST_CALLOC_OR_FAIL(R_mod_digits, N.limbs);
+    TEST_CALLOC(R_core, N.limbs);
+    TEST_CALLOC(R_mod_raw, N.limbs);
+    TEST_CALLOC(R_mod_digits, N.limbs);
     TEST_EQUAL(mbedtls_mpi_mod_residue_setup(&R_mod, &N,
                                              R_mod_digits, N.limbs),
                0);
@@ -287,7 +287,7 @@ void mpi_random_many(int min, char *bound_hex, int iterations)
 
     TEST_EQUAL(0, mbedtls_test_read_mpi_core(&upper_bound, &limbs,
                                              bound_hex));
-    TEST_CALLOC_OR_FAIL(result, limbs);
+    TEST_CALLOC(result, limbs);
 
     n_bits = mbedtls_mpi_core_bitlen(upper_bound, limbs);
     /* Consider a bound "small" if it's less than 2^5. This value is chosen
@@ -302,7 +302,7 @@ void mpi_random_many(int min, char *bound_hex, int iterations)
         full_stats = 0;
         stats_len = n_bits;
     }
-    TEST_CALLOC_OR_FAIL(stats, stats_len);
+    TEST_CALLOC(stats, stats_len);
 
     for (i = 0; i < (size_t) iterations; i++) {
         mbedtls_test_set_step(i);
@@ -340,7 +340,7 @@ void mpi_random_many(int min, char *bound_hex, int iterations)
         }
     } else {
         bound_bytes.len = limbs * sizeof(mbedtls_mpi_uint);
-        TEST_CALLOC_OR_FAIL(bound_bytes.x, bound_bytes.len);
+        TEST_CALLOC(bound_bytes.x, bound_bytes.len);
         mbedtls_mpi_core_write_be(upper_bound, limbs,
                                   bound_bytes.x, bound_bytes.len);
         int statistically_safe_all_the_way =
@@ -416,7 +416,7 @@ void mpi_mod_random_validation(int min, char *bound_hex,
                                              MBEDTLS_MPI_MOD_REP_OPT_RED),
                0);
     size_t result_limbs = N.limbs + result_limbs_delta;
-    TEST_CALLOC_OR_FAIL(result_digits, result_limbs);
+    TEST_CALLOC(result_digits, result_limbs);
     /* Build a reside that might not match the modulus, to test that
      * the library function rejects that as expected. */
     mbedtls_mpi_mod_residue result = { result_digits, result_limbs };

--- a/tests/suites/test_suite_bignum_random.function
+++ b/tests/suites/test_suite_bignum_random.function
@@ -174,7 +174,7 @@ void mpi_legacy_random_values(int min, char *max_hex)
      * same number, with the same limb count. */
     TEST_EQUAL(core_ret, legacy_ret);
     if (core_ret == 0) {
-        ASSERT_COMPARE(R_core, limbs * ciL,
+        TEST_BUFFERS_EQUAL(R_core, limbs * ciL,
                        R_legacy.p, R_legacy.n * ciL);
     }
 
@@ -182,7 +182,7 @@ void mpi_legacy_random_values(int min, char *max_hex)
     /* This may theoretically fail on rare platforms with padding in
      * the structure! If this is a problem in practice, change to a
      * field-by-field comparison. */
-    ASSERT_COMPARE(&rnd_core, sizeof(rnd_core),
+    TEST_BUFFERS_EQUAL(&rnd_core, sizeof(rnd_core),
                    &rnd_legacy, sizeof(rnd_legacy));
 
 exit:
@@ -237,11 +237,11 @@ void mpi_mod_random_values(int min, char *max_hex, int rep)
     if (core_ret == 0) {
         TEST_EQUAL(mbedtls_mpi_mod_raw_modulus_to_canonical_rep(R_mod_raw, &N),
                    0);
-        ASSERT_COMPARE(R_core, N.limbs * ciL,
+        TEST_BUFFERS_EQUAL(R_core, N.limbs * ciL,
                        R_mod_raw, N.limbs * ciL);
         TEST_EQUAL(mbedtls_mpi_mod_raw_modulus_to_canonical_rep(R_mod_digits, &N),
                    0);
-        ASSERT_COMPARE(R_core, N.limbs * ciL,
+        TEST_BUFFERS_EQUAL(R_core, N.limbs * ciL,
                        R_mod_digits, N.limbs * ciL);
     }
 
@@ -249,9 +249,9 @@ void mpi_mod_random_values(int min, char *max_hex, int rep)
     /* This may theoretically fail on rare platforms with padding in
      * the structure! If this is a problem in practice, change to a
      * field-by-field comparison. */
-    ASSERT_COMPARE(&rnd_core, sizeof(rnd_core),
+    TEST_BUFFERS_EQUAL(&rnd_core, sizeof(rnd_core),
                    &rnd_mod_raw, sizeof(rnd_mod_raw));
-    ASSERT_COMPARE(&rnd_core, sizeof(rnd_core),
+    TEST_BUFFERS_EQUAL(&rnd_core, sizeof(rnd_core),
                    &rnd_mod, sizeof(rnd_mod));
 
 exit:

--- a/tests/suites/test_suite_bignum_random.function
+++ b/tests/suites/test_suite_bignum_random.function
@@ -174,7 +174,7 @@ void mpi_legacy_random_values(int min, char *max_hex)
      * same number, with the same limb count. */
     TEST_EQUAL(core_ret, legacy_ret);
     if (core_ret == 0) {
-        TEST_BUFFERS_EQUAL(R_core, limbs * ciL,
+        TEST_MEMORY_COMPARE(R_core, limbs * ciL,
                        R_legacy.p, R_legacy.n * ciL);
     }
 
@@ -182,7 +182,7 @@ void mpi_legacy_random_values(int min, char *max_hex)
     /* This may theoretically fail on rare platforms with padding in
      * the structure! If this is a problem in practice, change to a
      * field-by-field comparison. */
-    TEST_BUFFERS_EQUAL(&rnd_core, sizeof(rnd_core),
+    TEST_MEMORY_COMPARE(&rnd_core, sizeof(rnd_core),
                    &rnd_legacy, sizeof(rnd_legacy));
 
 exit:
@@ -237,11 +237,11 @@ void mpi_mod_random_values(int min, char *max_hex, int rep)
     if (core_ret == 0) {
         TEST_EQUAL(mbedtls_mpi_mod_raw_modulus_to_canonical_rep(R_mod_raw, &N),
                    0);
-        TEST_BUFFERS_EQUAL(R_core, N.limbs * ciL,
+        TEST_MEMORY_COMPARE(R_core, N.limbs * ciL,
                        R_mod_raw, N.limbs * ciL);
         TEST_EQUAL(mbedtls_mpi_mod_raw_modulus_to_canonical_rep(R_mod_digits, &N),
                    0);
-        TEST_BUFFERS_EQUAL(R_core, N.limbs * ciL,
+        TEST_MEMORY_COMPARE(R_core, N.limbs * ciL,
                        R_mod_digits, N.limbs * ciL);
     }
 
@@ -249,9 +249,9 @@ void mpi_mod_random_values(int min, char *max_hex, int rep)
     /* This may theoretically fail on rare platforms with padding in
      * the structure! If this is a problem in practice, change to a
      * field-by-field comparison. */
-    TEST_BUFFERS_EQUAL(&rnd_core, sizeof(rnd_core),
+    TEST_MEMORY_COMPARE(&rnd_core, sizeof(rnd_core),
                    &rnd_mod_raw, sizeof(rnd_mod_raw));
-    TEST_BUFFERS_EQUAL(&rnd_core, sizeof(rnd_core),
+    TEST_MEMORY_COMPARE(&rnd_core, sizeof(rnd_core),
                    &rnd_mod, sizeof(rnd_mod));
 
 exit:

--- a/tests/suites/test_suite_ccm.function
+++ b/tests/suites/test_suite_ccm.function
@@ -32,7 +32,7 @@ static int check_multipart(mbedtls_ccm_context *ctx,
     /* Allocate a tight buffer for each update call. This way, if the function
      * tries to write beyond the advertised required buffer size, this will
      * count as an overflow for memory sanitizers and static checkers. */
-    ASSERT_ALLOC(output, n1);
+    TEST_CALLOC_OR_FAIL(output, n1);
     olen = 0xdeadbeef;
     TEST_EQUAL(0, mbedtls_ccm_update(ctx, input->x, n1, output, n1, &olen));
     TEST_EQUAL(n1, olen);
@@ -40,7 +40,7 @@ static int check_multipart(mbedtls_ccm_context *ctx,
     mbedtls_free(output);
     output = NULL;
 
-    ASSERT_ALLOC(output, n2);
+    TEST_CALLOC_OR_FAIL(output, n2);
     olen = 0xdeadbeef;
     TEST_EQUAL(0, mbedtls_ccm_update(ctx, input->x + n1, n2, output, n2, &olen));
     TEST_EQUAL(n2, olen);
@@ -48,7 +48,7 @@ static int check_multipart(mbedtls_ccm_context *ctx,
     mbedtls_free(output);
     output = NULL;
 
-    ASSERT_ALLOC(output, tag->len);
+    TEST_CALLOC_OR_FAIL(output, tag->len);
     TEST_EQUAL(0, mbedtls_ccm_finish(ctx, output, tag->len));
     TEST_BUFFERS_EQUAL(output, tag->len, tag->x, tag->len);
     mbedtls_free(output);
@@ -190,13 +190,13 @@ void mbedtls_ccm_encrypt_and_tag(int cipher_id, data_t *key,
     const uint8_t *expected_tag = result->x + msg->len;
 
     /* Prepare input/output message buffer */
-    ASSERT_ALLOC(io_msg_buf, msg->len);
+    TEST_CALLOC_OR_FAIL(io_msg_buf, msg->len);
     if (msg->len != 0) {
         memcpy(io_msg_buf, msg->x, msg->len);
     }
 
     /* Prepare tag buffer */
-    ASSERT_ALLOC(tag_buf, expected_tag_len);
+    TEST_CALLOC_OR_FAIL(tag_buf, expected_tag_len);
 
     mbedtls_ccm_init(&ctx);
     TEST_EQUAL(mbedtls_ccm_setkey(&ctx, cipher_id, key->x, key->len * 8), 0);
@@ -246,7 +246,7 @@ void mbedtls_ccm_star_no_tag(int cipher_id, int mode, data_t *key,
     TEST_EQUAL(0, mbedtls_ccm_starts(&ctx, mode, iv->x, iv->len));
     TEST_EQUAL(0, mbedtls_ccm_set_lengths(&ctx, 0, msg->len, 0));
 
-    ASSERT_ALLOC(output, msg->len);
+    TEST_CALLOC_OR_FAIL(output, msg->len);
     TEST_EQUAL(0, mbedtls_ccm_update(&ctx, msg->x, msg->len, output, msg->len, &olen));
     TEST_EQUAL(result->len, olen);
     TEST_BUFFERS_EQUAL(output, olen, result->x, result->len);
@@ -272,7 +272,7 @@ void mbedtls_ccm_auth_decrypt(int cipher_id, data_t *key,
 
     /* Prepare input/output message buffer */
     uint8_t *io_msg_buf = NULL;
-    ASSERT_ALLOC(io_msg_buf, expected_msg_len);
+    TEST_CALLOC_OR_FAIL(io_msg_buf, expected_msg_len);
     if (expected_msg_len) {
         memcpy(io_msg_buf, msg->x, expected_msg_len);
     }
@@ -344,16 +344,16 @@ void mbedtls_ccm_star_encrypt_and_tag(int cipher_id,
     }
 
     /* Prepare input/output message buffer */
-    ASSERT_ALLOC(io_msg_buf, msg->len);
+    TEST_CALLOC_OR_FAIL(io_msg_buf, msg->len);
     if (msg->len) {
         memcpy(io_msg_buf, msg->x, msg->len);
     }
 
     /* Prepare tag buffer */
     if (expected_tag_len == 0) {
-        ASSERT_ALLOC(tag_buf, 16);
+        TEST_CALLOC_OR_FAIL(tag_buf, 16);
     } else {
-        ASSERT_ALLOC(tag_buf, expected_tag_len);
+        TEST_CALLOC_OR_FAIL(tag_buf, expected_tag_len);
     }
 
     /* Calculate iv */
@@ -429,7 +429,7 @@ void mbedtls_ccm_star_auth_decrypt(int cipher_id,
 
     /* Prepare input/output message buffer */
     uint8_t *io_msg_buf = NULL;
-    ASSERT_ALLOC(io_msg_buf, expected_msg_len);
+    TEST_CALLOC_OR_FAIL(io_msg_buf, expected_msg_len);
     if (expected_msg_len) {
         memcpy(io_msg_buf, msg->x, expected_msg_len);
     }
@@ -500,7 +500,7 @@ void mbedtls_ccm_skip_ad(int cipher_id, int mode,
     TEST_EQUAL(0, mbedtls_ccm_starts(&ctx, mode, iv->x, iv->len));
     TEST_EQUAL(0, mbedtls_ccm_set_lengths(&ctx, 0, msg->len, tag->len));
 
-    ASSERT_ALLOC(output, result->len);
+    TEST_CALLOC_OR_FAIL(output, result->len);
     olen = 0xdeadbeef;
     TEST_EQUAL(0, mbedtls_ccm_update(&ctx, msg->x, msg->len, output, result->len, &olen));
     TEST_EQUAL(result->len, olen);
@@ -508,7 +508,7 @@ void mbedtls_ccm_skip_ad(int cipher_id, int mode,
     mbedtls_free(output);
     output = NULL;
 
-    ASSERT_ALLOC(output, tag->len);
+    TEST_CALLOC_OR_FAIL(output, tag->len);
     TEST_EQUAL(0, mbedtls_ccm_finish(&ctx, output, tag->len));
     TEST_BUFFERS_EQUAL(output, tag->len, tag->x, tag->len);
     mbedtls_free(output);
@@ -536,7 +536,7 @@ void mbedtls_ccm_skip_update(int cipher_id, int mode,
 
     TEST_EQUAL(0, mbedtls_ccm_update_ad(&ctx, add->x, add->len));
 
-    ASSERT_ALLOC(output, tag->len);
+    TEST_CALLOC_OR_FAIL(output, tag->len);
     TEST_EQUAL(0, mbedtls_ccm_finish(&ctx, output, tag->len));
     TEST_BUFFERS_EQUAL(output, tag->len, tag->x, tag->len);
     mbedtls_free(output);
@@ -607,7 +607,7 @@ void mbedtls_ccm_unexpected_text(int cipher_id, int mode,
 
     TEST_EQUAL(0, mbedtls_ccm_update_ad(&ctx, add->x, add->len));
 
-    ASSERT_ALLOC(output, msg->len);
+    TEST_CALLOC_OR_FAIL(output, msg->len);
     olen = 0xdeadbeef;
     TEST_EQUAL(MBEDTLS_ERR_CCM_BAD_INPUT,
                mbedtls_ccm_update(&ctx, msg->x, msg->len, output, msg->len, &olen));
@@ -633,7 +633,7 @@ void mbedtls_ccm_incomplete_ad(int cipher_id, int mode,
 
     TEST_EQUAL(0, mbedtls_ccm_update_ad(&ctx, add->x, add->len - 1));
 
-    ASSERT_ALLOC(output, 16);
+    TEST_CALLOC_OR_FAIL(output, 16);
     TEST_EQUAL(MBEDTLS_ERR_CCM_BAD_INPUT, mbedtls_ccm_finish(&ctx, output, 16));
 
 exit:
@@ -713,7 +713,7 @@ void mbedtls_ccm_overflow_update(int cipher_id, int mode,
 
     TEST_EQUAL(0, mbedtls_ccm_update_ad(&ctx, add->x, add->len));
 
-    ASSERT_ALLOC(output, msg->len);
+    TEST_CALLOC_OR_FAIL(output, msg->len);
     TEST_EQUAL(MBEDTLS_ERR_CCM_BAD_INPUT, \
                mbedtls_ccm_update(&ctx, msg->x, msg->len, output, msg->len, &olen));
 exit:
@@ -740,13 +740,13 @@ void mbedtls_ccm_incomplete_update(int cipher_id, int mode,
 
     TEST_EQUAL(0, mbedtls_ccm_update_ad(&ctx, add->x, add->len));
 
-    ASSERT_ALLOC(output, msg->len);
+    TEST_CALLOC_OR_FAIL(output, msg->len);
     olen = 0xdeadbeef;
     TEST_EQUAL(0, mbedtls_ccm_update(&ctx, msg->x, msg->len - 1, output, msg->len, &olen));
     mbedtls_free(output);
     output = NULL;
 
-    ASSERT_ALLOC(output, 16);
+    TEST_CALLOC_OR_FAIL(output, 16);
     TEST_EQUAL(MBEDTLS_ERR_CCM_BAD_INPUT, mbedtls_ccm_finish(&ctx, output, 16));
 
 exit:
@@ -774,7 +774,7 @@ void mbedtls_ccm_full_update_and_overflow(int cipher_id, int mode,
 
     TEST_EQUAL(0, mbedtls_ccm_update_ad(&ctx, add->x, add->len));
 
-    ASSERT_ALLOC(output, msg->len);
+    TEST_CALLOC_OR_FAIL(output, msg->len);
     // pass full text
     TEST_EQUAL(0, mbedtls_ccm_update(&ctx, msg->x, msg->len, output, msg->len, &olen));
     // pass 1 extra byte
@@ -809,7 +809,7 @@ void mbedtls_ccm_incomplete_update_overflow(int cipher_id, int mode,
 
     TEST_EQUAL(0, mbedtls_ccm_update_ad(&ctx, add->x, add->len));
 
-    ASSERT_ALLOC(output, msg->len + 1);
+    TEST_CALLOC_OR_FAIL(output, msg->len + 1);
     // pass incomplete text
     TEST_EQUAL(0, mbedtls_ccm_update(&ctx, msg->x, msg->len - 1, output, msg->len + 1, &olen));
     // pass 2 extra bytes (1 missing byte from previous incomplete pass, and 1 unexpected byte)
@@ -836,7 +836,7 @@ void mbedtls_ccm_instant_finish(int cipher_id, int mode,
     // They are not a part of this test
     TEST_EQUAL(0, mbedtls_ccm_set_lengths(&ctx, 16, 16, 16));
 
-    ASSERT_ALLOC(output, 16);
+    TEST_CALLOC_OR_FAIL(output, 16);
     TEST_EQUAL(MBEDTLS_ERR_CCM_BAD_INPUT, mbedtls_ccm_finish(&ctx, output, 16));
 
 exit:

--- a/tests/suites/test_suite_ccm.function
+++ b/tests/suites/test_suite_ccm.function
@@ -36,7 +36,7 @@ static int check_multipart(mbedtls_ccm_context *ctx,
     olen = 0xdeadbeef;
     TEST_EQUAL(0, mbedtls_ccm_update(ctx, input->x, n1, output, n1, &olen));
     TEST_EQUAL(n1, olen);
-    ASSERT_COMPARE(output, olen, expected_output->x, n1);
+    TEST_BUFFERS_EQUAL(output, olen, expected_output->x, n1);
     mbedtls_free(output);
     output = NULL;
 
@@ -44,13 +44,13 @@ static int check_multipart(mbedtls_ccm_context *ctx,
     olen = 0xdeadbeef;
     TEST_EQUAL(0, mbedtls_ccm_update(ctx, input->x + n1, n2, output, n2, &olen));
     TEST_EQUAL(n2, olen);
-    ASSERT_COMPARE(output, olen, expected_output->x + n1, n2);
+    TEST_BUFFERS_EQUAL(output, olen, expected_output->x + n1, n2);
     mbedtls_free(output);
     output = NULL;
 
     ASSERT_ALLOC(output, tag->len);
     TEST_EQUAL(0, mbedtls_ccm_finish(ctx, output, tag->len));
-    ASSERT_COMPARE(output, tag->len, tag->x, tag->len);
+    TEST_BUFFERS_EQUAL(output, tag->len, tag->x, tag->len);
     mbedtls_free(output);
     output = NULL;
 
@@ -204,8 +204,8 @@ void mbedtls_ccm_encrypt_and_tag(int cipher_id, data_t *key,
     TEST_EQUAL(mbedtls_ccm_encrypt_and_tag(&ctx, msg->len, iv->x, iv->len, add->x, add->len,
                                            io_msg_buf, io_msg_buf, tag_buf, expected_tag_len), 0);
 
-    ASSERT_COMPARE(io_msg_buf, msg->len, result->x, msg->len);
-    ASSERT_COMPARE(tag_buf, expected_tag_len, expected_tag, expected_tag_len);
+    TEST_BUFFERS_EQUAL(io_msg_buf, msg->len, result->x, msg->len);
+    TEST_BUFFERS_EQUAL(tag_buf, expected_tag_len, expected_tag, expected_tag_len);
 
     /* Prepare data_t structures for multipart testing */
     const data_t encrypted_expected = { .x = result->x,
@@ -249,7 +249,7 @@ void mbedtls_ccm_star_no_tag(int cipher_id, int mode, data_t *key,
     ASSERT_ALLOC(output, msg->len);
     TEST_EQUAL(0, mbedtls_ccm_update(&ctx, msg->x, msg->len, output, msg->len, &olen));
     TEST_EQUAL(result->len, olen);
-    ASSERT_COMPARE(output, olen, result->x, result->len);
+    TEST_BUFFERS_EQUAL(output, olen, result->x, result->len);
 
     TEST_EQUAL(0, mbedtls_ccm_finish(&ctx, NULL, 0));
 exit:
@@ -285,7 +285,7 @@ void mbedtls_ccm_auth_decrypt(int cipher_id, data_t *key,
                result);
 
     if (result == 0) {
-        ASSERT_COMPARE(io_msg_buf, expected_msg_len, expected_msg->x, expected_msg_len);
+        TEST_BUFFERS_EQUAL(io_msg_buf, expected_msg_len, expected_msg->x, expected_msg_len);
 
         /* Prepare data_t structures for multipart testing */
         const data_t encrypted = { .x = msg->x,
@@ -372,8 +372,8 @@ void mbedtls_ccm_star_encrypt_and_tag(int cipher_id,
                                                 add->x, add->len, io_msg_buf,
                                                 io_msg_buf, tag_buf, expected_tag_len), output_ret);
 
-    ASSERT_COMPARE(io_msg_buf, msg->len, expected_result->x, msg->len);
-    ASSERT_COMPARE(tag_buf, expected_tag_len, expected_tag, expected_tag_len);
+    TEST_BUFFERS_EQUAL(io_msg_buf, msg->len, expected_result->x, msg->len);
+    TEST_BUFFERS_EQUAL(tag_buf, expected_tag_len, expected_tag, expected_tag_len);
 
     if (output_ret == 0) {
         const data_t iv_data = { .x = iv,
@@ -450,7 +450,7 @@ void mbedtls_ccm_star_auth_decrypt(int cipher_id,
                                              add->x, add->len, io_msg_buf, io_msg_buf,
                                              expected_tag, expected_tag_len), output_ret);
 
-    ASSERT_COMPARE(io_msg_buf, expected_msg_len, expected_result->x, expected_msg_len);
+    TEST_BUFFERS_EQUAL(io_msg_buf, expected_msg_len, expected_result->x, expected_msg_len);
 
     if (output_ret == 0) {
         const data_t iv_data = { .x = iv,
@@ -504,13 +504,13 @@ void mbedtls_ccm_skip_ad(int cipher_id, int mode,
     olen = 0xdeadbeef;
     TEST_EQUAL(0, mbedtls_ccm_update(&ctx, msg->x, msg->len, output, result->len, &olen));
     TEST_EQUAL(result->len, olen);
-    ASSERT_COMPARE(output, olen, result->x, result->len);
+    TEST_BUFFERS_EQUAL(output, olen, result->x, result->len);
     mbedtls_free(output);
     output = NULL;
 
     ASSERT_ALLOC(output, tag->len);
     TEST_EQUAL(0, mbedtls_ccm_finish(&ctx, output, tag->len));
-    ASSERT_COMPARE(output, tag->len, tag->x, tag->len);
+    TEST_BUFFERS_EQUAL(output, tag->len, tag->x, tag->len);
     mbedtls_free(output);
     output = NULL;
 
@@ -538,7 +538,7 @@ void mbedtls_ccm_skip_update(int cipher_id, int mode,
 
     ASSERT_ALLOC(output, tag->len);
     TEST_EQUAL(0, mbedtls_ccm_finish(&ctx, output, tag->len));
-    ASSERT_COMPARE(output, tag->len, tag->x, tag->len);
+    TEST_BUFFERS_EQUAL(output, tag->len, tag->x, tag->len);
     mbedtls_free(output);
     output = NULL;
 

--- a/tests/suites/test_suite_ccm.function
+++ b/tests/suites/test_suite_ccm.function
@@ -107,7 +107,7 @@ void ccm_lengths(int msg_len, int iv_len, int add_len, int tag_len, int res)
 
     mbedtls_ccm_init(&ctx);
 
-    ASSERT_ALLOC_WEAK(add, add_len);
+    TEST_CALLOC_OR_SKIP(add, add_len);
     memset(key, 0, sizeof(key));
     memset(msg, 0, sizeof(msg));
     memset(iv, 0, sizeof(iv));

--- a/tests/suites/test_suite_ccm.function
+++ b/tests/suites/test_suite_ccm.function
@@ -36,7 +36,7 @@ static int check_multipart(mbedtls_ccm_context *ctx,
     olen = 0xdeadbeef;
     TEST_EQUAL(0, mbedtls_ccm_update(ctx, input->x, n1, output, n1, &olen));
     TEST_EQUAL(n1, olen);
-    TEST_BUFFERS_EQUAL(output, olen, expected_output->x, n1);
+    TEST_MEMORY_COMPARE(output, olen, expected_output->x, n1);
     mbedtls_free(output);
     output = NULL;
 
@@ -44,13 +44,13 @@ static int check_multipart(mbedtls_ccm_context *ctx,
     olen = 0xdeadbeef;
     TEST_EQUAL(0, mbedtls_ccm_update(ctx, input->x + n1, n2, output, n2, &olen));
     TEST_EQUAL(n2, olen);
-    TEST_BUFFERS_EQUAL(output, olen, expected_output->x + n1, n2);
+    TEST_MEMORY_COMPARE(output, olen, expected_output->x + n1, n2);
     mbedtls_free(output);
     output = NULL;
 
     TEST_CALLOC(output, tag->len);
     TEST_EQUAL(0, mbedtls_ccm_finish(ctx, output, tag->len));
-    TEST_BUFFERS_EQUAL(output, tag->len, tag->x, tag->len);
+    TEST_MEMORY_COMPARE(output, tag->len, tag->x, tag->len);
     mbedtls_free(output);
     output = NULL;
 
@@ -204,8 +204,8 @@ void mbedtls_ccm_encrypt_and_tag(int cipher_id, data_t *key,
     TEST_EQUAL(mbedtls_ccm_encrypt_and_tag(&ctx, msg->len, iv->x, iv->len, add->x, add->len,
                                            io_msg_buf, io_msg_buf, tag_buf, expected_tag_len), 0);
 
-    TEST_BUFFERS_EQUAL(io_msg_buf, msg->len, result->x, msg->len);
-    TEST_BUFFERS_EQUAL(tag_buf, expected_tag_len, expected_tag, expected_tag_len);
+    TEST_MEMORY_COMPARE(io_msg_buf, msg->len, result->x, msg->len);
+    TEST_MEMORY_COMPARE(tag_buf, expected_tag_len, expected_tag, expected_tag_len);
 
     /* Prepare data_t structures for multipart testing */
     const data_t encrypted_expected = { .x = result->x,
@@ -249,7 +249,7 @@ void mbedtls_ccm_star_no_tag(int cipher_id, int mode, data_t *key,
     TEST_CALLOC(output, msg->len);
     TEST_EQUAL(0, mbedtls_ccm_update(&ctx, msg->x, msg->len, output, msg->len, &olen));
     TEST_EQUAL(result->len, olen);
-    TEST_BUFFERS_EQUAL(output, olen, result->x, result->len);
+    TEST_MEMORY_COMPARE(output, olen, result->x, result->len);
 
     TEST_EQUAL(0, mbedtls_ccm_finish(&ctx, NULL, 0));
 exit:
@@ -285,7 +285,7 @@ void mbedtls_ccm_auth_decrypt(int cipher_id, data_t *key,
                result);
 
     if (result == 0) {
-        TEST_BUFFERS_EQUAL(io_msg_buf, expected_msg_len, expected_msg->x, expected_msg_len);
+        TEST_MEMORY_COMPARE(io_msg_buf, expected_msg_len, expected_msg->x, expected_msg_len);
 
         /* Prepare data_t structures for multipart testing */
         const data_t encrypted = { .x = msg->x,
@@ -372,8 +372,8 @@ void mbedtls_ccm_star_encrypt_and_tag(int cipher_id,
                                                 add->x, add->len, io_msg_buf,
                                                 io_msg_buf, tag_buf, expected_tag_len), output_ret);
 
-    TEST_BUFFERS_EQUAL(io_msg_buf, msg->len, expected_result->x, msg->len);
-    TEST_BUFFERS_EQUAL(tag_buf, expected_tag_len, expected_tag, expected_tag_len);
+    TEST_MEMORY_COMPARE(io_msg_buf, msg->len, expected_result->x, msg->len);
+    TEST_MEMORY_COMPARE(tag_buf, expected_tag_len, expected_tag, expected_tag_len);
 
     if (output_ret == 0) {
         const data_t iv_data = { .x = iv,
@@ -450,7 +450,7 @@ void mbedtls_ccm_star_auth_decrypt(int cipher_id,
                                              add->x, add->len, io_msg_buf, io_msg_buf,
                                              expected_tag, expected_tag_len), output_ret);
 
-    TEST_BUFFERS_EQUAL(io_msg_buf, expected_msg_len, expected_result->x, expected_msg_len);
+    TEST_MEMORY_COMPARE(io_msg_buf, expected_msg_len, expected_result->x, expected_msg_len);
 
     if (output_ret == 0) {
         const data_t iv_data = { .x = iv,
@@ -504,13 +504,13 @@ void mbedtls_ccm_skip_ad(int cipher_id, int mode,
     olen = 0xdeadbeef;
     TEST_EQUAL(0, mbedtls_ccm_update(&ctx, msg->x, msg->len, output, result->len, &olen));
     TEST_EQUAL(result->len, olen);
-    TEST_BUFFERS_EQUAL(output, olen, result->x, result->len);
+    TEST_MEMORY_COMPARE(output, olen, result->x, result->len);
     mbedtls_free(output);
     output = NULL;
 
     TEST_CALLOC(output, tag->len);
     TEST_EQUAL(0, mbedtls_ccm_finish(&ctx, output, tag->len));
-    TEST_BUFFERS_EQUAL(output, tag->len, tag->x, tag->len);
+    TEST_MEMORY_COMPARE(output, tag->len, tag->x, tag->len);
     mbedtls_free(output);
     output = NULL;
 
@@ -538,7 +538,7 @@ void mbedtls_ccm_skip_update(int cipher_id, int mode,
 
     TEST_CALLOC(output, tag->len);
     TEST_EQUAL(0, mbedtls_ccm_finish(&ctx, output, tag->len));
-    TEST_BUFFERS_EQUAL(output, tag->len, tag->x, tag->len);
+    TEST_MEMORY_COMPARE(output, tag->len, tag->x, tag->len);
     mbedtls_free(output);
     output = NULL;
 

--- a/tests/suites/test_suite_ccm.function
+++ b/tests/suites/test_suite_ccm.function
@@ -32,7 +32,7 @@ static int check_multipart(mbedtls_ccm_context *ctx,
     /* Allocate a tight buffer for each update call. This way, if the function
      * tries to write beyond the advertised required buffer size, this will
      * count as an overflow for memory sanitizers and static checkers. */
-    TEST_CALLOC_OR_FAIL(output, n1);
+    TEST_CALLOC(output, n1);
     olen = 0xdeadbeef;
     TEST_EQUAL(0, mbedtls_ccm_update(ctx, input->x, n1, output, n1, &olen));
     TEST_EQUAL(n1, olen);
@@ -40,7 +40,7 @@ static int check_multipart(mbedtls_ccm_context *ctx,
     mbedtls_free(output);
     output = NULL;
 
-    TEST_CALLOC_OR_FAIL(output, n2);
+    TEST_CALLOC(output, n2);
     olen = 0xdeadbeef;
     TEST_EQUAL(0, mbedtls_ccm_update(ctx, input->x + n1, n2, output, n2, &olen));
     TEST_EQUAL(n2, olen);
@@ -48,7 +48,7 @@ static int check_multipart(mbedtls_ccm_context *ctx,
     mbedtls_free(output);
     output = NULL;
 
-    TEST_CALLOC_OR_FAIL(output, tag->len);
+    TEST_CALLOC(output, tag->len);
     TEST_EQUAL(0, mbedtls_ccm_finish(ctx, output, tag->len));
     TEST_BUFFERS_EQUAL(output, tag->len, tag->x, tag->len);
     mbedtls_free(output);
@@ -190,13 +190,13 @@ void mbedtls_ccm_encrypt_and_tag(int cipher_id, data_t *key,
     const uint8_t *expected_tag = result->x + msg->len;
 
     /* Prepare input/output message buffer */
-    TEST_CALLOC_OR_FAIL(io_msg_buf, msg->len);
+    TEST_CALLOC(io_msg_buf, msg->len);
     if (msg->len != 0) {
         memcpy(io_msg_buf, msg->x, msg->len);
     }
 
     /* Prepare tag buffer */
-    TEST_CALLOC_OR_FAIL(tag_buf, expected_tag_len);
+    TEST_CALLOC(tag_buf, expected_tag_len);
 
     mbedtls_ccm_init(&ctx);
     TEST_EQUAL(mbedtls_ccm_setkey(&ctx, cipher_id, key->x, key->len * 8), 0);
@@ -246,7 +246,7 @@ void mbedtls_ccm_star_no_tag(int cipher_id, int mode, data_t *key,
     TEST_EQUAL(0, mbedtls_ccm_starts(&ctx, mode, iv->x, iv->len));
     TEST_EQUAL(0, mbedtls_ccm_set_lengths(&ctx, 0, msg->len, 0));
 
-    TEST_CALLOC_OR_FAIL(output, msg->len);
+    TEST_CALLOC(output, msg->len);
     TEST_EQUAL(0, mbedtls_ccm_update(&ctx, msg->x, msg->len, output, msg->len, &olen));
     TEST_EQUAL(result->len, olen);
     TEST_BUFFERS_EQUAL(output, olen, result->x, result->len);
@@ -272,7 +272,7 @@ void mbedtls_ccm_auth_decrypt(int cipher_id, data_t *key,
 
     /* Prepare input/output message buffer */
     uint8_t *io_msg_buf = NULL;
-    TEST_CALLOC_OR_FAIL(io_msg_buf, expected_msg_len);
+    TEST_CALLOC(io_msg_buf, expected_msg_len);
     if (expected_msg_len) {
         memcpy(io_msg_buf, msg->x, expected_msg_len);
     }
@@ -344,16 +344,16 @@ void mbedtls_ccm_star_encrypt_and_tag(int cipher_id,
     }
 
     /* Prepare input/output message buffer */
-    TEST_CALLOC_OR_FAIL(io_msg_buf, msg->len);
+    TEST_CALLOC(io_msg_buf, msg->len);
     if (msg->len) {
         memcpy(io_msg_buf, msg->x, msg->len);
     }
 
     /* Prepare tag buffer */
     if (expected_tag_len == 0) {
-        TEST_CALLOC_OR_FAIL(tag_buf, 16);
+        TEST_CALLOC(tag_buf, 16);
     } else {
-        TEST_CALLOC_OR_FAIL(tag_buf, expected_tag_len);
+        TEST_CALLOC(tag_buf, expected_tag_len);
     }
 
     /* Calculate iv */
@@ -429,7 +429,7 @@ void mbedtls_ccm_star_auth_decrypt(int cipher_id,
 
     /* Prepare input/output message buffer */
     uint8_t *io_msg_buf = NULL;
-    TEST_CALLOC_OR_FAIL(io_msg_buf, expected_msg_len);
+    TEST_CALLOC(io_msg_buf, expected_msg_len);
     if (expected_msg_len) {
         memcpy(io_msg_buf, msg->x, expected_msg_len);
     }
@@ -500,7 +500,7 @@ void mbedtls_ccm_skip_ad(int cipher_id, int mode,
     TEST_EQUAL(0, mbedtls_ccm_starts(&ctx, mode, iv->x, iv->len));
     TEST_EQUAL(0, mbedtls_ccm_set_lengths(&ctx, 0, msg->len, tag->len));
 
-    TEST_CALLOC_OR_FAIL(output, result->len);
+    TEST_CALLOC(output, result->len);
     olen = 0xdeadbeef;
     TEST_EQUAL(0, mbedtls_ccm_update(&ctx, msg->x, msg->len, output, result->len, &olen));
     TEST_EQUAL(result->len, olen);
@@ -508,7 +508,7 @@ void mbedtls_ccm_skip_ad(int cipher_id, int mode,
     mbedtls_free(output);
     output = NULL;
 
-    TEST_CALLOC_OR_FAIL(output, tag->len);
+    TEST_CALLOC(output, tag->len);
     TEST_EQUAL(0, mbedtls_ccm_finish(&ctx, output, tag->len));
     TEST_BUFFERS_EQUAL(output, tag->len, tag->x, tag->len);
     mbedtls_free(output);
@@ -536,7 +536,7 @@ void mbedtls_ccm_skip_update(int cipher_id, int mode,
 
     TEST_EQUAL(0, mbedtls_ccm_update_ad(&ctx, add->x, add->len));
 
-    TEST_CALLOC_OR_FAIL(output, tag->len);
+    TEST_CALLOC(output, tag->len);
     TEST_EQUAL(0, mbedtls_ccm_finish(&ctx, output, tag->len));
     TEST_BUFFERS_EQUAL(output, tag->len, tag->x, tag->len);
     mbedtls_free(output);
@@ -607,7 +607,7 @@ void mbedtls_ccm_unexpected_text(int cipher_id, int mode,
 
     TEST_EQUAL(0, mbedtls_ccm_update_ad(&ctx, add->x, add->len));
 
-    TEST_CALLOC_OR_FAIL(output, msg->len);
+    TEST_CALLOC(output, msg->len);
     olen = 0xdeadbeef;
     TEST_EQUAL(MBEDTLS_ERR_CCM_BAD_INPUT,
                mbedtls_ccm_update(&ctx, msg->x, msg->len, output, msg->len, &olen));
@@ -633,7 +633,7 @@ void mbedtls_ccm_incomplete_ad(int cipher_id, int mode,
 
     TEST_EQUAL(0, mbedtls_ccm_update_ad(&ctx, add->x, add->len - 1));
 
-    TEST_CALLOC_OR_FAIL(output, 16);
+    TEST_CALLOC(output, 16);
     TEST_EQUAL(MBEDTLS_ERR_CCM_BAD_INPUT, mbedtls_ccm_finish(&ctx, output, 16));
 
 exit:
@@ -713,7 +713,7 @@ void mbedtls_ccm_overflow_update(int cipher_id, int mode,
 
     TEST_EQUAL(0, mbedtls_ccm_update_ad(&ctx, add->x, add->len));
 
-    TEST_CALLOC_OR_FAIL(output, msg->len);
+    TEST_CALLOC(output, msg->len);
     TEST_EQUAL(MBEDTLS_ERR_CCM_BAD_INPUT, \
                mbedtls_ccm_update(&ctx, msg->x, msg->len, output, msg->len, &olen));
 exit:
@@ -740,13 +740,13 @@ void mbedtls_ccm_incomplete_update(int cipher_id, int mode,
 
     TEST_EQUAL(0, mbedtls_ccm_update_ad(&ctx, add->x, add->len));
 
-    TEST_CALLOC_OR_FAIL(output, msg->len);
+    TEST_CALLOC(output, msg->len);
     olen = 0xdeadbeef;
     TEST_EQUAL(0, mbedtls_ccm_update(&ctx, msg->x, msg->len - 1, output, msg->len, &olen));
     mbedtls_free(output);
     output = NULL;
 
-    TEST_CALLOC_OR_FAIL(output, 16);
+    TEST_CALLOC(output, 16);
     TEST_EQUAL(MBEDTLS_ERR_CCM_BAD_INPUT, mbedtls_ccm_finish(&ctx, output, 16));
 
 exit:
@@ -774,7 +774,7 @@ void mbedtls_ccm_full_update_and_overflow(int cipher_id, int mode,
 
     TEST_EQUAL(0, mbedtls_ccm_update_ad(&ctx, add->x, add->len));
 
-    TEST_CALLOC_OR_FAIL(output, msg->len);
+    TEST_CALLOC(output, msg->len);
     // pass full text
     TEST_EQUAL(0, mbedtls_ccm_update(&ctx, msg->x, msg->len, output, msg->len, &olen));
     // pass 1 extra byte
@@ -809,7 +809,7 @@ void mbedtls_ccm_incomplete_update_overflow(int cipher_id, int mode,
 
     TEST_EQUAL(0, mbedtls_ccm_update_ad(&ctx, add->x, add->len));
 
-    TEST_CALLOC_OR_FAIL(output, msg->len + 1);
+    TEST_CALLOC(output, msg->len + 1);
     // pass incomplete text
     TEST_EQUAL(0, mbedtls_ccm_update(&ctx, msg->x, msg->len - 1, output, msg->len + 1, &olen));
     // pass 2 extra bytes (1 missing byte from previous incomplete pass, and 1 unexpected byte)
@@ -836,7 +836,7 @@ void mbedtls_ccm_instant_finish(int cipher_id, int mode,
     // They are not a part of this test
     TEST_EQUAL(0, mbedtls_ccm_set_lengths(&ctx, 16, 16, 16));
 
-    TEST_CALLOC_OR_FAIL(output, 16);
+    TEST_CALLOC(output, 16);
     TEST_EQUAL(MBEDTLS_ERR_CCM_BAD_INPUT, mbedtls_ccm_finish(&ctx, output, 16));
 
 exit:

--- a/tests/suites/test_suite_chacha20.function
+++ b/tests/suites/test_suite_chacha20.function
@@ -29,7 +29,7 @@ void chacha20_crypt(data_t *key_str,
     TEST_ASSERT(mbedtls_chacha20_crypt(key_str->x, nonce_str->x, counter, src_str->len, src_str->x,
                                        output) == 0);
 
-    ASSERT_COMPARE(output, expected_output_str->len,
+    TEST_BUFFERS_EQUAL(output, expected_output_str->len,
                    expected_output_str->x, expected_output_str->len);
 
     /*
@@ -44,7 +44,7 @@ void chacha20_crypt(data_t *key_str,
     memset(output, 0x00, sizeof(output));
     TEST_ASSERT(mbedtls_chacha20_update(&ctx, src_str->len, src_str->x, output) == 0);
 
-    ASSERT_COMPARE(output, expected_output_str->len,
+    TEST_BUFFERS_EQUAL(output, expected_output_str->len,
                    expected_output_str->x, expected_output_str->len);
 
     /*
@@ -60,7 +60,7 @@ void chacha20_crypt(data_t *key_str,
     TEST_ASSERT(mbedtls_chacha20_update(&ctx, src_str->len - 1,
                                         src_str->x + 1, output + 1) == 0);
 
-    ASSERT_COMPARE(output, expected_output_str->len,
+    TEST_BUFFERS_EQUAL(output, expected_output_str->len,
                    expected_output_str->x, expected_output_str->len);
 
     mbedtls_chacha20_free(&ctx);

--- a/tests/suites/test_suite_chacha20.function
+++ b/tests/suites/test_suite_chacha20.function
@@ -29,7 +29,7 @@ void chacha20_crypt(data_t *key_str,
     TEST_ASSERT(mbedtls_chacha20_crypt(key_str->x, nonce_str->x, counter, src_str->len, src_str->x,
                                        output) == 0);
 
-    TEST_BUFFERS_EQUAL(output, expected_output_str->len,
+    TEST_MEMORY_COMPARE(output, expected_output_str->len,
                    expected_output_str->x, expected_output_str->len);
 
     /*
@@ -44,7 +44,7 @@ void chacha20_crypt(data_t *key_str,
     memset(output, 0x00, sizeof(output));
     TEST_ASSERT(mbedtls_chacha20_update(&ctx, src_str->len, src_str->x, output) == 0);
 
-    TEST_BUFFERS_EQUAL(output, expected_output_str->len,
+    TEST_MEMORY_COMPARE(output, expected_output_str->len,
                    expected_output_str->x, expected_output_str->len);
 
     /*
@@ -60,7 +60,7 @@ void chacha20_crypt(data_t *key_str,
     TEST_ASSERT(mbedtls_chacha20_update(&ctx, src_str->len - 1,
                                         src_str->x + 1, output + 1) == 0);
 
-    TEST_BUFFERS_EQUAL(output, expected_output_str->len,
+    TEST_MEMORY_COMPARE(output, expected_output_str->len,
                    expected_output_str->x, expected_output_str->len);
 
     mbedtls_chacha20_free(&ctx);

--- a/tests/suites/test_suite_chacha20.function
+++ b/tests/suites/test_suite_chacha20.function
@@ -30,7 +30,7 @@ void chacha20_crypt(data_t *key_str,
                                        output) == 0);
 
     TEST_MEMORY_COMPARE(output, expected_output_str->len,
-                   expected_output_str->x, expected_output_str->len);
+                        expected_output_str->x, expected_output_str->len);
 
     /*
      * Test the streaming API
@@ -45,7 +45,7 @@ void chacha20_crypt(data_t *key_str,
     TEST_ASSERT(mbedtls_chacha20_update(&ctx, src_str->len, src_str->x, output) == 0);
 
     TEST_MEMORY_COMPARE(output, expected_output_str->len,
-                   expected_output_str->x, expected_output_str->len);
+                        expected_output_str->x, expected_output_str->len);
 
     /*
      * Test the streaming API again, piecewise
@@ -61,7 +61,7 @@ void chacha20_crypt(data_t *key_str,
                                         src_str->x + 1, output + 1) == 0);
 
     TEST_MEMORY_COMPARE(output, expected_output_str->len,
-                   expected_output_str->x, expected_output_str->len);
+                        expected_output_str->x, expected_output_str->len);
 
     mbedtls_chacha20_free(&ctx);
 }

--- a/tests/suites/test_suite_cipher.function
+++ b/tests/suites/test_suite_cipher.function
@@ -950,7 +950,7 @@ void auth_crypt_tv(int cipher_id, data_t *key, data_t *iv,
         TEST_ASSERT(buffer_is_all_zero(decrypt_buf, decrypt_buf_len));
     } else {
         TEST_ASSERT(ret == 0);
-        ASSERT_COMPARE(decrypt_buf, outlen, clear->x, clear->len);
+        TEST_BUFFERS_EQUAL(decrypt_buf, outlen, clear->x, clear->len);
     }
 
     mbedtls_free(decrypt_buf);

--- a/tests/suites/test_suite_cipher.function
+++ b/tests/suites/test_suite_cipher.function
@@ -583,7 +583,7 @@ void dec_empty_buf(int cipher,
         iv_len = 12;
     }
 
-    TEST_CALLOC_OR_FAIL(iv, iv_len);
+    TEST_CALLOC(iv, iv_len);
     memset(iv, 0, iv_len);
 
     TEST_ASSERT(sizeof(key) * 8 >= mbedtls_cipher_info_get_key_bitlen(cipher_info));
@@ -905,7 +905,7 @@ void auth_crypt_tv(int cipher_id, data_t *key, data_t *iv,
      * (we need the tag appended to the ciphertext)
      */
     cipher_plus_tag_len = cipher->len + tag->len;
-    TEST_CALLOC_OR_FAIL(cipher_plus_tag, cipher_plus_tag_len);
+    TEST_CALLOC(cipher_plus_tag, cipher_plus_tag_len);
     memcpy(cipher_plus_tag, cipher->x, cipher->len);
     memcpy(cipher_plus_tag + cipher->len, tag->x, tag->len);
 
@@ -923,7 +923,7 @@ void auth_crypt_tv(int cipher_id, data_t *key, data_t *iv,
      * Try decrypting to a buffer that's 1B too small
      */
     if (decrypt_buf_len != 0) {
-        TEST_CALLOC_OR_FAIL(decrypt_buf, decrypt_buf_len - 1);
+        TEST_CALLOC(decrypt_buf, decrypt_buf_len - 1);
 
         outlen = 0;
         ret = mbedtls_cipher_auth_decrypt_ext(&ctx, iv->x, iv->len,
@@ -938,7 +938,7 @@ void auth_crypt_tv(int cipher_id, data_t *key, data_t *iv,
     /*
      * Authenticate and decrypt, and check result
      */
-    TEST_CALLOC_OR_FAIL(decrypt_buf, decrypt_buf_len);
+    TEST_CALLOC(decrypt_buf, decrypt_buf_len);
 
     outlen = 0;
     ret = mbedtls_cipher_auth_decrypt_ext(&ctx, iv->x, iv->len,
@@ -981,7 +981,7 @@ void auth_crypt_tv(int cipher_id, data_t *key, data_t *iv,
         /*
          * Try encrypting with an output buffer that's 1B too small
          */
-        TEST_CALLOC_OR_FAIL(encrypt_buf, encrypt_buf_len - 1);
+        TEST_CALLOC(encrypt_buf, encrypt_buf_len - 1);
 
         outlen = 0;
         ret = mbedtls_cipher_auth_encrypt_ext(&ctx, iv->x, iv->len,
@@ -995,7 +995,7 @@ void auth_crypt_tv(int cipher_id, data_t *key, data_t *iv,
         /*
          * Encrypt and check the result
          */
-        TEST_CALLOC_OR_FAIL(encrypt_buf, encrypt_buf_len);
+        TEST_CALLOC(encrypt_buf, encrypt_buf_len);
 
         outlen = 0;
         ret = mbedtls_cipher_auth_encrypt_ext(&ctx, iv->x, iv->len,

--- a/tests/suites/test_suite_cipher.function
+++ b/tests/suites/test_suite_cipher.function
@@ -950,7 +950,7 @@ void auth_crypt_tv(int cipher_id, data_t *key, data_t *iv,
         TEST_ASSERT(buffer_is_all_zero(decrypt_buf, decrypt_buf_len));
     } else {
         TEST_ASSERT(ret == 0);
-        TEST_BUFFERS_EQUAL(decrypt_buf, outlen, clear->x, clear->len);
+        TEST_MEMORY_COMPARE(decrypt_buf, outlen, clear->x, clear->len);
     }
 
     mbedtls_free(decrypt_buf);

--- a/tests/suites/test_suite_cipher.function
+++ b/tests/suites/test_suite_cipher.function
@@ -583,7 +583,7 @@ void dec_empty_buf(int cipher,
         iv_len = 12;
     }
 
-    ASSERT_ALLOC(iv, iv_len);
+    TEST_CALLOC_OR_FAIL(iv, iv_len);
     memset(iv, 0, iv_len);
 
     TEST_ASSERT(sizeof(key) * 8 >= mbedtls_cipher_info_get_key_bitlen(cipher_info));
@@ -905,7 +905,7 @@ void auth_crypt_tv(int cipher_id, data_t *key, data_t *iv,
      * (we need the tag appended to the ciphertext)
      */
     cipher_plus_tag_len = cipher->len + tag->len;
-    ASSERT_ALLOC(cipher_plus_tag, cipher_plus_tag_len);
+    TEST_CALLOC_OR_FAIL(cipher_plus_tag, cipher_plus_tag_len);
     memcpy(cipher_plus_tag, cipher->x, cipher->len);
     memcpy(cipher_plus_tag + cipher->len, tag->x, tag->len);
 
@@ -923,7 +923,7 @@ void auth_crypt_tv(int cipher_id, data_t *key, data_t *iv,
      * Try decrypting to a buffer that's 1B too small
      */
     if (decrypt_buf_len != 0) {
-        ASSERT_ALLOC(decrypt_buf, decrypt_buf_len - 1);
+        TEST_CALLOC_OR_FAIL(decrypt_buf, decrypt_buf_len - 1);
 
         outlen = 0;
         ret = mbedtls_cipher_auth_decrypt_ext(&ctx, iv->x, iv->len,
@@ -938,7 +938,7 @@ void auth_crypt_tv(int cipher_id, data_t *key, data_t *iv,
     /*
      * Authenticate and decrypt, and check result
      */
-    ASSERT_ALLOC(decrypt_buf, decrypt_buf_len);
+    TEST_CALLOC_OR_FAIL(decrypt_buf, decrypt_buf_len);
 
     outlen = 0;
     ret = mbedtls_cipher_auth_decrypt_ext(&ctx, iv->x, iv->len,
@@ -981,7 +981,7 @@ void auth_crypt_tv(int cipher_id, data_t *key, data_t *iv,
         /*
          * Try encrypting with an output buffer that's 1B too small
          */
-        ASSERT_ALLOC(encrypt_buf, encrypt_buf_len - 1);
+        TEST_CALLOC_OR_FAIL(encrypt_buf, encrypt_buf_len - 1);
 
         outlen = 0;
         ret = mbedtls_cipher_auth_encrypt_ext(&ctx, iv->x, iv->len,
@@ -995,7 +995,7 @@ void auth_crypt_tv(int cipher_id, data_t *key, data_t *iv,
         /*
          * Encrypt and check the result
          */
-        ASSERT_ALLOC(encrypt_buf, encrypt_buf_len);
+        TEST_CALLOC_OR_FAIL(encrypt_buf, encrypt_buf_len);
 
         outlen = 0;
         ret = mbedtls_cipher_auth_encrypt_ext(&ctx, iv->x, iv->len,

--- a/tests/suites/test_suite_common.function
+++ b/tests/suites/test_suite_common.function
@@ -28,7 +28,7 @@ void mbedtls_xor(int len)
         r1[i] = a[i] ^ b[i];
     }
     mbedtls_xor(r2, a, b, n);
-    TEST_BUFFERS_EQUAL(r1, n, r2, n);
+    TEST_MEMORY_COMPARE(r1, n, r2, n);
 
     /* Test r == a */
     fill_arrays(a, b, r1, r2, n);
@@ -36,7 +36,7 @@ void mbedtls_xor(int len)
         r1[i] = r1[i] ^ b[i];
     }
     mbedtls_xor(r2, r2, b, n);
-    TEST_BUFFERS_EQUAL(r1, n, r2, n);
+    TEST_MEMORY_COMPARE(r1, n, r2, n);
 
     /* Test r == b */
     fill_arrays(a, b, r1, r2, n);
@@ -44,7 +44,7 @@ void mbedtls_xor(int len)
         r1[i] = a[i] ^ r1[i];
     }
     mbedtls_xor(r2, a, r2, n);
-    TEST_BUFFERS_EQUAL(r1, n, r2, n);
+    TEST_MEMORY_COMPARE(r1, n, r2, n);
 
     /* Test a == b */
     fill_arrays(a, b, r1, r2, n);
@@ -52,7 +52,7 @@ void mbedtls_xor(int len)
         r1[i] = a[i] ^ a[i];
     }
     mbedtls_xor(r2, a, a, n);
-    TEST_BUFFERS_EQUAL(r1, n, r2, n);
+    TEST_MEMORY_COMPARE(r1, n, r2, n);
 
     /* Test a == b == r */
     fill_arrays(a, b, r1, r2, n);
@@ -60,7 +60,7 @@ void mbedtls_xor(int len)
         r1[i] = r1[i] ^ r1[i];
     }
     mbedtls_xor(r2, r2, r2, n);
-    TEST_BUFFERS_EQUAL(r1, n, r2, n);
+    TEST_MEMORY_COMPARE(r1, n, r2, n);
 
     /* Test non-word-aligned buffers, for all combinations of alignedness */
     for (int i = 0; i < 7; i++) {
@@ -71,7 +71,7 @@ void mbedtls_xor(int len)
             r1[j + r_off] = a[j + a_off] ^ b[j + b_off];
         }
         mbedtls_xor(r2 + r_off, a + a_off, b + b_off, n);
-        TEST_BUFFERS_EQUAL(r1 + r_off, n, r2 + r_off, n);
+        TEST_MEMORY_COMPARE(r1 + r_off, n, r2 + r_off, n);
     }
 exit:
     mbedtls_free(a);

--- a/tests/suites/test_suite_common.function
+++ b/tests/suites/test_suite_common.function
@@ -28,7 +28,7 @@ void mbedtls_xor(int len)
         r1[i] = a[i] ^ b[i];
     }
     mbedtls_xor(r2, a, b, n);
-    ASSERT_COMPARE(r1, n, r2, n);
+    TEST_BUFFERS_EQUAL(r1, n, r2, n);
 
     /* Test r == a */
     fill_arrays(a, b, r1, r2, n);
@@ -36,7 +36,7 @@ void mbedtls_xor(int len)
         r1[i] = r1[i] ^ b[i];
     }
     mbedtls_xor(r2, r2, b, n);
-    ASSERT_COMPARE(r1, n, r2, n);
+    TEST_BUFFERS_EQUAL(r1, n, r2, n);
 
     /* Test r == b */
     fill_arrays(a, b, r1, r2, n);
@@ -44,7 +44,7 @@ void mbedtls_xor(int len)
         r1[i] = a[i] ^ r1[i];
     }
     mbedtls_xor(r2, a, r2, n);
-    ASSERT_COMPARE(r1, n, r2, n);
+    TEST_BUFFERS_EQUAL(r1, n, r2, n);
 
     /* Test a == b */
     fill_arrays(a, b, r1, r2, n);
@@ -52,7 +52,7 @@ void mbedtls_xor(int len)
         r1[i] = a[i] ^ a[i];
     }
     mbedtls_xor(r2, a, a, n);
-    ASSERT_COMPARE(r1, n, r2, n);
+    TEST_BUFFERS_EQUAL(r1, n, r2, n);
 
     /* Test a == b == r */
     fill_arrays(a, b, r1, r2, n);
@@ -60,7 +60,7 @@ void mbedtls_xor(int len)
         r1[i] = r1[i] ^ r1[i];
     }
     mbedtls_xor(r2, r2, r2, n);
-    ASSERT_COMPARE(r1, n, r2, n);
+    TEST_BUFFERS_EQUAL(r1, n, r2, n);
 
     /* Test non-word-aligned buffers, for all combinations of alignedness */
     for (int i = 0; i < 7; i++) {
@@ -71,7 +71,7 @@ void mbedtls_xor(int len)
             r1[j + r_off] = a[j + a_off] ^ b[j + b_off];
         }
         mbedtls_xor(r2 + r_off, a + a_off, b + b_off, n);
-        ASSERT_COMPARE(r1 + r_off, n, r2 + r_off, n);
+        TEST_BUFFERS_EQUAL(r1 + r_off, n, r2 + r_off, n);
     }
 exit:
     mbedtls_free(a);

--- a/tests/suites/test_suite_common.function
+++ b/tests/suites/test_suite_common.function
@@ -17,10 +17,10 @@ void mbedtls_xor(int len)
 {
     size_t n = (size_t) len;
     unsigned char *a = NULL, *b = NULL, *r1 = NULL, *r2 = NULL;
-    TEST_CALLOC_OR_FAIL(a, n + 1);
-    TEST_CALLOC_OR_FAIL(b, n + 1);
-    TEST_CALLOC_OR_FAIL(r1, n + 1);
-    TEST_CALLOC_OR_FAIL(r2, n + 1);
+    TEST_CALLOC(a, n + 1);
+    TEST_CALLOC(b, n + 1);
+    TEST_CALLOC(r1, n + 1);
+    TEST_CALLOC(r2, n + 1);
 
     /* Test non-overlapping */
     fill_arrays(a, b, r1, r2, n);

--- a/tests/suites/test_suite_common.function
+++ b/tests/suites/test_suite_common.function
@@ -17,10 +17,10 @@ void mbedtls_xor(int len)
 {
     size_t n = (size_t) len;
     unsigned char *a = NULL, *b = NULL, *r1 = NULL, *r2 = NULL;
-    ASSERT_ALLOC(a, n + 1);
-    ASSERT_ALLOC(b, n + 1);
-    ASSERT_ALLOC(r1, n + 1);
-    ASSERT_ALLOC(r2, n + 1);
+    TEST_CALLOC_OR_FAIL(a, n + 1);
+    TEST_CALLOC_OR_FAIL(b, n + 1);
+    TEST_CALLOC_OR_FAIL(r1, n + 1);
+    TEST_CALLOC_OR_FAIL(r2, n + 1);
 
     /* Test non-overlapping */
     fill_arrays(a, b, r1, r2, n);

--- a/tests/suites/test_suite_constant_time.function
+++ b/tests/suites/test_suite_constant_time.function
@@ -91,7 +91,7 @@ void mbedtls_ct_memcpy_if_eq(int eq, int size, int offset)
     TEST_CF_PUBLIC(&one, sizeof(one));
     TEST_CF_PUBLIC(&secret_eq, sizeof(secret_eq));
 
-    ASSERT_COMPARE(expected, size, result + offset, size);
+    TEST_BUFFERS_EQUAL(expected, size, result + offset, size);
 
     for (int i = 0; i < size + offset; i++) {
         src[i]    = 1;
@@ -109,7 +109,7 @@ void mbedtls_ct_memcpy_if_eq(int eq, int size, int offset)
     TEST_CF_PUBLIC(&one, sizeof(one));
     TEST_CF_PUBLIC(&secret_eq, sizeof(secret_eq));
 
-    ASSERT_COMPARE(expected, size, result, size);
+    TEST_BUFFERS_EQUAL(expected, size, result, size);
 exit:
     mbedtls_free(src);
     mbedtls_free(result);
@@ -140,7 +140,7 @@ void ssl_cf_memcpy_offset(int offset_min, int offset_max, int len)
         TEST_CF_PUBLIC(&secret, sizeof(secret));
         TEST_CF_PUBLIC(dst, len);
 
-        ASSERT_COMPARE(dst, len, src + secret, len);
+        TEST_BUFFERS_EQUAL(dst, len, src + secret, len);
     }
 
 exit:

--- a/tests/suites/test_suite_constant_time.function
+++ b/tests/suites/test_suite_constant_time.function
@@ -29,8 +29,8 @@ void mbedtls_ct_memcmp_null()
 void mbedtls_ct_memcmp(int same, int size, int offset)
 {
     uint8_t *a = NULL, *b = NULL;
-    ASSERT_ALLOC(a, size + offset);
-    ASSERT_ALLOC(b, size + offset);
+    TEST_CALLOC_OR_FAIL(a, size + offset);
+    TEST_CALLOC_OR_FAIL(b, size + offset);
 
     TEST_CF_SECRET(a + offset, size);
     TEST_CF_SECRET(b + offset, size);
@@ -70,9 +70,9 @@ exit:
 void mbedtls_ct_memcpy_if_eq(int eq, int size, int offset)
 {
     uint8_t *src = NULL, *result = NULL, *expected = NULL;
-    ASSERT_ALLOC(src, size + offset);
-    ASSERT_ALLOC(result, size + offset);
-    ASSERT_ALLOC(expected, size + offset);
+    TEST_CALLOC_OR_FAIL(src, size + offset);
+    TEST_CALLOC_OR_FAIL(result, size + offset);
+    TEST_CALLOC_OR_FAIL(expected, size + offset);
 
     for (int i = 0; i < size + offset; i++) {
         src[i]    = 1;
@@ -125,8 +125,8 @@ void ssl_cf_memcpy_offset(int offset_min, int offset_max, int len)
     size_t src_len = offset_max + len;
     size_t secret;
 
-    ASSERT_ALLOC(dst, len);
-    ASSERT_ALLOC(src, src_len);
+    TEST_CALLOC_OR_FAIL(dst, len);
+    TEST_CALLOC_OR_FAIL(src, src_len);
 
     /* Fill src in a way that we can detect if we copied the right bytes */
     mbedtls_test_rnd_std_rand(NULL, src, src_len);

--- a/tests/suites/test_suite_constant_time.function
+++ b/tests/suites/test_suite_constant_time.function
@@ -91,7 +91,7 @@ void mbedtls_ct_memcpy_if_eq(int eq, int size, int offset)
     TEST_CF_PUBLIC(&one, sizeof(one));
     TEST_CF_PUBLIC(&secret_eq, sizeof(secret_eq));
 
-    TEST_BUFFERS_EQUAL(expected, size, result + offset, size);
+    TEST_MEMORY_COMPARE(expected, size, result + offset, size);
 
     for (int i = 0; i < size + offset; i++) {
         src[i]    = 1;
@@ -109,7 +109,7 @@ void mbedtls_ct_memcpy_if_eq(int eq, int size, int offset)
     TEST_CF_PUBLIC(&one, sizeof(one));
     TEST_CF_PUBLIC(&secret_eq, sizeof(secret_eq));
 
-    TEST_BUFFERS_EQUAL(expected, size, result, size);
+    TEST_MEMORY_COMPARE(expected, size, result, size);
 exit:
     mbedtls_free(src);
     mbedtls_free(result);
@@ -140,7 +140,7 @@ void ssl_cf_memcpy_offset(int offset_min, int offset_max, int len)
         TEST_CF_PUBLIC(&secret, sizeof(secret));
         TEST_CF_PUBLIC(dst, len);
 
-        TEST_BUFFERS_EQUAL(dst, len, src + secret, len);
+        TEST_MEMORY_COMPARE(dst, len, src + secret, len);
     }
 
 exit:

--- a/tests/suites/test_suite_constant_time.function
+++ b/tests/suites/test_suite_constant_time.function
@@ -29,8 +29,8 @@ void mbedtls_ct_memcmp_null()
 void mbedtls_ct_memcmp(int same, int size, int offset)
 {
     uint8_t *a = NULL, *b = NULL;
-    TEST_CALLOC_OR_FAIL(a, size + offset);
-    TEST_CALLOC_OR_FAIL(b, size + offset);
+    TEST_CALLOC(a, size + offset);
+    TEST_CALLOC(b, size + offset);
 
     TEST_CF_SECRET(a + offset, size);
     TEST_CF_SECRET(b + offset, size);
@@ -70,9 +70,9 @@ exit:
 void mbedtls_ct_memcpy_if_eq(int eq, int size, int offset)
 {
     uint8_t *src = NULL, *result = NULL, *expected = NULL;
-    TEST_CALLOC_OR_FAIL(src, size + offset);
-    TEST_CALLOC_OR_FAIL(result, size + offset);
-    TEST_CALLOC_OR_FAIL(expected, size + offset);
+    TEST_CALLOC(src, size + offset);
+    TEST_CALLOC(result, size + offset);
+    TEST_CALLOC(expected, size + offset);
 
     for (int i = 0; i < size + offset; i++) {
         src[i]    = 1;
@@ -125,8 +125,8 @@ void ssl_cf_memcpy_offset(int offset_min, int offset_max, int len)
     size_t src_len = offset_max + len;
     size_t secret;
 
-    TEST_CALLOC_OR_FAIL(dst, len);
-    TEST_CALLOC_OR_FAIL(src, src_len);
+    TEST_CALLOC(dst, len);
+    TEST_CALLOC(src, src_len);
 
     /* Fill src in a way that we can detect if we copied the right bytes */
     mbedtls_test_rnd_std_rand(NULL, src, src_len);

--- a/tests/suites/test_suite_constant_time_hmac.function
+++ b/tests/suites/test_suite_constant_time_hmac.function
@@ -133,7 +133,7 @@ void ssl_cf_hmac(int hash)
             TEST_EQUAL(0, mbedtls_md_hmac_reset(&ref_ctx));
 
             /* Compare */
-            TEST_BUFFERS_EQUAL(out, out_len, ref_out, out_len);
+            TEST_MEMORY_COMPARE(out, out_len, ref_out, out_len);
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
         }
 

--- a/tests/suites/test_suite_constant_time_hmac.function
+++ b/tests/suites/test_suite_constant_time_hmac.function
@@ -58,7 +58,7 @@ void ssl_cf_hmac(int hash)
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     /* Use allocated out buffer to catch overwrites */
-    TEST_CALLOC_OR_FAIL(out, out_len);
+    TEST_CALLOC(out, out_len);
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     /* Set up dummy key */
@@ -85,7 +85,7 @@ void ssl_cf_hmac(int hash)
         mbedtls_test_set_step(max_in_len * 10000);
 
         /* Use allocated in buffer to catch overreads */
-        TEST_CALLOC_OR_FAIL(data, max_in_len);
+        TEST_CALLOC(data, max_in_len);
 
         min_in_len = max_in_len > 255 ? max_in_len - 255 : 0;
         for (in_len = min_in_len; in_len <= max_in_len; in_len++) {

--- a/tests/suites/test_suite_constant_time_hmac.function
+++ b/tests/suites/test_suite_constant_time_hmac.function
@@ -133,7 +133,7 @@ void ssl_cf_hmac(int hash)
             TEST_EQUAL(0, mbedtls_md_hmac_reset(&ref_ctx));
 
             /* Compare */
-            ASSERT_COMPARE(out, out_len, ref_out, out_len);
+            TEST_BUFFERS_EQUAL(out, out_len, ref_out, out_len);
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
         }
 

--- a/tests/suites/test_suite_constant_time_hmac.function
+++ b/tests/suites/test_suite_constant_time_hmac.function
@@ -58,7 +58,7 @@ void ssl_cf_hmac(int hash)
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     /* Use allocated out buffer to catch overwrites */
-    ASSERT_ALLOC(out, out_len);
+    TEST_CALLOC_OR_FAIL(out, out_len);
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     /* Set up dummy key */
@@ -85,7 +85,7 @@ void ssl_cf_hmac(int hash)
         mbedtls_test_set_step(max_in_len * 10000);
 
         /* Use allocated in buffer to catch overreads */
-        ASSERT_ALLOC(data, max_in_len);
+        TEST_CALLOC_OR_FAIL(data, max_in_len);
 
         min_in_len = max_in_len > 255 ? max_in_len - 255 : 0;
         for (in_len = min_in_len; in_len <= max_in_len; in_len++) {

--- a/tests/suites/test_suite_ecp.function
+++ b/tests/suites/test_suite_ecp.function
@@ -1101,7 +1101,7 @@ void genkey_mx_known_answer(int bits, data_t *seed, data_t *expected)
     rnd_info.fallback_f_rng = NULL;
     rnd_info.fallback_p_rng = NULL;
 
-    TEST_CALLOC_OR_FAIL(actual, expected->len);
+    TEST_CALLOC(actual, expected->len);
 
     ret = mbedtls_ecp_gen_privkey_mx(bits, &d,
                                      mbedtls_test_rnd_buffer_rand, &rnd_info);
@@ -1456,10 +1456,10 @@ void ecp_mod_mul_inv(char *input_A, int id, int ctype)
     /* Test for limb sizes */
     TEST_EQUAL(m.limbs, limbs);
 
-    TEST_CALLOC_OR_FAIL(A_inverse, limbs);
+    TEST_CALLOC(A_inverse, limbs);
     TEST_EQUAL(0, mbedtls_mpi_mod_residue_setup(&rA_inverse, &m, A_inverse, limbs));
 
-    TEST_CALLOC_OR_FAIL(rX_raw, limbs);
+    TEST_CALLOC(rX_raw, limbs);
     TEST_EQUAL(0, mbedtls_mpi_mod_residue_setup(&rX, &m, rX_raw, limbs));
 
     /* Get inverse of A mode m, and multiply it with itself,
@@ -1467,7 +1467,7 @@ void ecp_mod_mul_inv(char *input_A, int id, int ctype)
     TEST_EQUAL(0, mbedtls_mpi_mod_inv(&rA_inverse, &rA, &m));
     TEST_EQUAL(mbedtls_mpi_mod_mul(&rX, &rA, &rA_inverse, &m), 0);
 
-    TEST_CALLOC_OR_FAIL(bufx, limbs);
+    TEST_CALLOC(bufx, limbs);
     TEST_EQUAL(mbedtls_mpi_mod_write(&rX, &m, (unsigned char *) bufx,
                                      limbs * ciL,
                                      MBEDTLS_MPI_MOD_EXT_REP_LE), 0);
@@ -1515,7 +1515,7 @@ void ecp_mod_add_sub(char *input_A, char *input_B, int id, int ctype)
     TEST_EQUAL(m.limbs, p_A_limbs);
     bytes = p_A_limbs * ciL;
 
-    TEST_CALLOC_OR_FAIL(p_S, p_A_limbs);
+    TEST_CALLOC(p_S, p_A_limbs);
 
     TEST_EQUAL(mbedtls_mpi_mod_residue_setup(&rA, &m, p_A, p_A_limbs), 0);
     TEST_EQUAL(mbedtls_mpi_mod_residue_setup(&rB, &m, p_B, p_B_limbs), 0);
@@ -1562,11 +1562,11 @@ void ecp_mod_read_write(char *input_A, int id, int ctype)
     /* Test for limb sizes */
     TEST_EQUAL(m.limbs, limbs);
 
-    TEST_CALLOC_OR_FAIL(rX_raw, limbs);
+    TEST_CALLOC(rX_raw, limbs);
     TEST_EQUAL(0, mbedtls_mpi_mod_residue_setup(&rX, &m, rX_raw, limbs));
 
     bytes = limbs * ciL;
-    TEST_CALLOC_OR_FAIL(bufx, limbs);
+    TEST_CALLOC(bufx, limbs);
     /* Write source mod residue to a buffer, then read it back to
      * the destination mod residue, compare the two mod residues.
      * Firstly test little endian write and read */
@@ -1616,7 +1616,7 @@ void ecp_mod_random(int id, int ctype)
 
     limbs = m.limbs;
 
-    TEST_CALLOC_OR_FAIL(rX_raw, limbs);
+    TEST_CALLOC(rX_raw, limbs);
     TEST_EQUAL(0, mbedtls_mpi_mod_residue_setup(&rX, &m, rX_raw, limbs));
 
     TEST_EQUAL(0, mbedtls_mpi_mod_random(&rX, 1, &m,

--- a/tests/suites/test_suite_ecp.function
+++ b/tests/suites/test_suite_ecp.function
@@ -1101,7 +1101,7 @@ void genkey_mx_known_answer(int bits, data_t *seed, data_t *expected)
     rnd_info.fallback_f_rng = NULL;
     rnd_info.fallback_p_rng = NULL;
 
-    ASSERT_ALLOC(actual, expected->len);
+    TEST_CALLOC_OR_FAIL(actual, expected->len);
 
     ret = mbedtls_ecp_gen_privkey_mx(bits, &d,
                                      mbedtls_test_rnd_buffer_rand, &rnd_info);
@@ -1456,10 +1456,10 @@ void ecp_mod_mul_inv(char *input_A, int id, int ctype)
     /* Test for limb sizes */
     TEST_EQUAL(m.limbs, limbs);
 
-    ASSERT_ALLOC(A_inverse, limbs);
+    TEST_CALLOC_OR_FAIL(A_inverse, limbs);
     TEST_EQUAL(0, mbedtls_mpi_mod_residue_setup(&rA_inverse, &m, A_inverse, limbs));
 
-    ASSERT_ALLOC(rX_raw, limbs);
+    TEST_CALLOC_OR_FAIL(rX_raw, limbs);
     TEST_EQUAL(0, mbedtls_mpi_mod_residue_setup(&rX, &m, rX_raw, limbs));
 
     /* Get inverse of A mode m, and multiply it with itself,
@@ -1467,7 +1467,7 @@ void ecp_mod_mul_inv(char *input_A, int id, int ctype)
     TEST_EQUAL(0, mbedtls_mpi_mod_inv(&rA_inverse, &rA, &m));
     TEST_EQUAL(mbedtls_mpi_mod_mul(&rX, &rA, &rA_inverse, &m), 0);
 
-    ASSERT_ALLOC(bufx, limbs);
+    TEST_CALLOC_OR_FAIL(bufx, limbs);
     TEST_EQUAL(mbedtls_mpi_mod_write(&rX, &m, (unsigned char *) bufx,
                                      limbs * ciL,
                                      MBEDTLS_MPI_MOD_EXT_REP_LE), 0);
@@ -1515,7 +1515,7 @@ void ecp_mod_add_sub(char *input_A, char *input_B, int id, int ctype)
     TEST_EQUAL(m.limbs, p_A_limbs);
     bytes = p_A_limbs * ciL;
 
-    ASSERT_ALLOC(p_S, p_A_limbs);
+    TEST_CALLOC_OR_FAIL(p_S, p_A_limbs);
 
     TEST_EQUAL(mbedtls_mpi_mod_residue_setup(&rA, &m, p_A, p_A_limbs), 0);
     TEST_EQUAL(mbedtls_mpi_mod_residue_setup(&rB, &m, p_B, p_B_limbs), 0);
@@ -1562,11 +1562,11 @@ void ecp_mod_read_write(char *input_A, int id, int ctype)
     /* Test for limb sizes */
     TEST_EQUAL(m.limbs, limbs);
 
-    ASSERT_ALLOC(rX_raw, limbs);
+    TEST_CALLOC_OR_FAIL(rX_raw, limbs);
     TEST_EQUAL(0, mbedtls_mpi_mod_residue_setup(&rX, &m, rX_raw, limbs));
 
     bytes = limbs * ciL;
-    ASSERT_ALLOC(bufx, limbs);
+    TEST_CALLOC_OR_FAIL(bufx, limbs);
     /* Write source mod residue to a buffer, then read it back to
      * the destination mod residue, compare the two mod residues.
      * Firstly test little endian write and read */
@@ -1616,7 +1616,7 @@ void ecp_mod_random(int id, int ctype)
 
     limbs = m.limbs;
 
-    ASSERT_ALLOC(rX_raw, limbs);
+    TEST_CALLOC_OR_FAIL(rX_raw, limbs);
     TEST_EQUAL(0, mbedtls_mpi_mod_residue_setup(&rX, &m, rX_raw, limbs));
 
     TEST_EQUAL(0, mbedtls_mpi_mod_random(&rX, 1, &m,

--- a/tests/suites/test_suite_ecp.function
+++ b/tests/suites/test_suite_ecp.function
@@ -538,7 +538,7 @@ void ecp_muladd(int id,
                    &len, actual_result, sizeof(actual_result)));
     TEST_ASSERT(len <= MBEDTLS_ECP_MAX_PT_LEN);
 
-    ASSERT_COMPARE(expected_result->x, expected_result->len,
+    TEST_BUFFERS_EQUAL(expected_result->x, expected_result->len,
                    actual_result, len);
 
 exit:
@@ -1061,7 +1061,7 @@ void mbedtls_ecp_read_key(int grp_id, data_t *in_key, int expected, int canonica
             ret = mbedtls_ecp_write_key(&key, buf, in_key->len);
             TEST_ASSERT(ret == 0);
 
-            ASSERT_COMPARE(in_key->x, in_key->len,
+            TEST_BUFFERS_EQUAL(in_key->x, in_key->len,
                            buf, in_key->len);
         } else {
             unsigned char export1[MBEDTLS_ECP_MAX_BYTES];
@@ -1076,7 +1076,7 @@ void mbedtls_ecp_read_key(int grp_id, data_t *in_key, int expected, int canonica
             ret = mbedtls_ecp_write_key(&key2, export2, in_key->len);
             TEST_ASSERT(ret == 0);
 
-            ASSERT_COMPARE(export1, in_key->len,
+            TEST_BUFFERS_EQUAL(export1, in_key->len,
                            export2, in_key->len);
         }
     }
@@ -1123,7 +1123,7 @@ void genkey_mx_known_answer(int bits, data_t *seed, data_t *expected)
          *   (can be enforced by checking these bits).
          * - Other bits must be random (by testing with different RNG outputs,
          *   we validate that those bits are indeed influenced by the RNG). */
-        ASSERT_COMPARE(expected->x, expected->len,
+        TEST_BUFFERS_EQUAL(expected->x, expected->len,
                        actual, expected->len);
     }
 
@@ -1379,7 +1379,7 @@ void ecp_mod_p_generic_raw(int curve_id,
 
     TEST_LE_U(mbedtls_mpi_core_bitlen(X, limbs_X), curve_bits);
     mbedtls_mpi_mod_raw_fix_quasi_reduction(X, &m);
-    ASSERT_COMPARE(X, bytes, res, bytes);
+    TEST_BUFFERS_EQUAL(X, bytes, res, bytes);
 
 exit:
     mbedtls_free(X);
@@ -1420,7 +1420,7 @@ void ecp_mod_setup(char *input_A, int id, int ctype, int iret)
         }
 
         /* Compare output byte-by-byte */
-        ASSERT_COMPARE(p, bytes, m.p, bytes);
+        TEST_BUFFERS_EQUAL(p, bytes, m.p, bytes);
 
         /* Test for user free-ing allocated memory */
         mbedtls_mpi_mod_modulus_free(&m);
@@ -1472,10 +1472,10 @@ void ecp_mod_mul_inv(char *input_A, int id, int ctype)
                                      limbs * ciL,
                                      MBEDTLS_MPI_MOD_EXT_REP_LE), 0);
 
-    ASSERT_COMPARE(bufx, ciL, one, ciL);
+    TEST_BUFFERS_EQUAL(bufx, ciL, one, ciL);
     /*Borrow the buffer of A to compare the left lims with 0 */
     memset(A, 0, limbs * ciL);
-    ASSERT_COMPARE(&bufx[1], (limbs - 1) * ciL, A, (limbs - 1) * ciL);
+    TEST_BUFFERS_EQUAL(&bufx[1], (limbs - 1) * ciL, A, (limbs - 1) * ciL);
 
 exit:
     mbedtls_mpi_mod_modulus_free(&m);
@@ -1527,7 +1527,7 @@ void ecp_mod_add_sub(char *input_A, char *input_B, int id, int ctype)
     TEST_EQUAL(0, mbedtls_mpi_mod_sub(&rS, &rS, &rB, &m));
 
     /* Compare difference with rA byte-by-byte */
-    ASSERT_COMPARE(rA.p, bytes, rS.p, bytes);
+    TEST_BUFFERS_EQUAL(rA.p, bytes, rS.p, bytes);
 
 exit:
     mbedtls_mpi_mod_modulus_free(&m);
@@ -1577,7 +1577,7 @@ void ecp_mod_read_write(char *input_A, int id, int ctype)
                                        bytes, MBEDTLS_MPI_MOD_EXT_REP_LE));
 
     TEST_EQUAL(limbs, rX.limbs);
-    ASSERT_COMPARE(rA.p, bytes, rX.p, bytes);
+    TEST_BUFFERS_EQUAL(rA.p, bytes, rX.p, bytes);
 
     memset(bufx, 0x00, bytes);
     memset(rX_raw, 0x00, bytes);
@@ -1591,7 +1591,7 @@ void ecp_mod_read_write(char *input_A, int id, int ctype)
                                        MBEDTLS_MPI_MOD_EXT_REP_BE));
 
     TEST_EQUAL(limbs, rX.limbs);
-    ASSERT_COMPARE(rA.p, bytes, rX.p, bytes);
+    TEST_BUFFERS_EQUAL(rA.p, bytes, rX.p, bytes);
 
 exit:
     mbedtls_mpi_mod_modulus_free(&m);

--- a/tests/suites/test_suite_ecp.function
+++ b/tests/suites/test_suite_ecp.function
@@ -539,7 +539,7 @@ void ecp_muladd(int id,
     TEST_ASSERT(len <= MBEDTLS_ECP_MAX_PT_LEN);
 
     TEST_MEMORY_COMPARE(expected_result->x, expected_result->len,
-                   actual_result, len);
+                        actual_result, len);
 
 exit:
     mbedtls_ecp_group_free(&grp);
@@ -1062,7 +1062,7 @@ void mbedtls_ecp_read_key(int grp_id, data_t *in_key, int expected, int canonica
             TEST_ASSERT(ret == 0);
 
             TEST_MEMORY_COMPARE(in_key->x, in_key->len,
-                           buf, in_key->len);
+                                buf, in_key->len);
         } else {
             unsigned char export1[MBEDTLS_ECP_MAX_BYTES];
             unsigned char export2[MBEDTLS_ECP_MAX_BYTES];
@@ -1077,7 +1077,7 @@ void mbedtls_ecp_read_key(int grp_id, data_t *in_key, int expected, int canonica
             TEST_ASSERT(ret == 0);
 
             TEST_MEMORY_COMPARE(export1, in_key->len,
-                           export2, in_key->len);
+                                export2, in_key->len);
         }
     }
 
@@ -1124,7 +1124,7 @@ void genkey_mx_known_answer(int bits, data_t *seed, data_t *expected)
          * - Other bits must be random (by testing with different RNG outputs,
          *   we validate that those bits are indeed influenced by the RNG). */
         TEST_MEMORY_COMPARE(expected->x, expected->len,
-                       actual, expected->len);
+                            actual, expected->len);
     }
 
 exit:

--- a/tests/suites/test_suite_ecp.function
+++ b/tests/suites/test_suite_ecp.function
@@ -538,7 +538,7 @@ void ecp_muladd(int id,
                    &len, actual_result, sizeof(actual_result)));
     TEST_ASSERT(len <= MBEDTLS_ECP_MAX_PT_LEN);
 
-    TEST_BUFFERS_EQUAL(expected_result->x, expected_result->len,
+    TEST_MEMORY_COMPARE(expected_result->x, expected_result->len,
                    actual_result, len);
 
 exit:
@@ -1061,7 +1061,7 @@ void mbedtls_ecp_read_key(int grp_id, data_t *in_key, int expected, int canonica
             ret = mbedtls_ecp_write_key(&key, buf, in_key->len);
             TEST_ASSERT(ret == 0);
 
-            TEST_BUFFERS_EQUAL(in_key->x, in_key->len,
+            TEST_MEMORY_COMPARE(in_key->x, in_key->len,
                            buf, in_key->len);
         } else {
             unsigned char export1[MBEDTLS_ECP_MAX_BYTES];
@@ -1076,7 +1076,7 @@ void mbedtls_ecp_read_key(int grp_id, data_t *in_key, int expected, int canonica
             ret = mbedtls_ecp_write_key(&key2, export2, in_key->len);
             TEST_ASSERT(ret == 0);
 
-            TEST_BUFFERS_EQUAL(export1, in_key->len,
+            TEST_MEMORY_COMPARE(export1, in_key->len,
                            export2, in_key->len);
         }
     }
@@ -1123,7 +1123,7 @@ void genkey_mx_known_answer(int bits, data_t *seed, data_t *expected)
          *   (can be enforced by checking these bits).
          * - Other bits must be random (by testing with different RNG outputs,
          *   we validate that those bits are indeed influenced by the RNG). */
-        TEST_BUFFERS_EQUAL(expected->x, expected->len,
+        TEST_MEMORY_COMPARE(expected->x, expected->len,
                        actual, expected->len);
     }
 
@@ -1379,7 +1379,7 @@ void ecp_mod_p_generic_raw(int curve_id,
 
     TEST_LE_U(mbedtls_mpi_core_bitlen(X, limbs_X), curve_bits);
     mbedtls_mpi_mod_raw_fix_quasi_reduction(X, &m);
-    TEST_BUFFERS_EQUAL(X, bytes, res, bytes);
+    TEST_MEMORY_COMPARE(X, bytes, res, bytes);
 
 exit:
     mbedtls_free(X);
@@ -1420,7 +1420,7 @@ void ecp_mod_setup(char *input_A, int id, int ctype, int iret)
         }
 
         /* Compare output byte-by-byte */
-        TEST_BUFFERS_EQUAL(p, bytes, m.p, bytes);
+        TEST_MEMORY_COMPARE(p, bytes, m.p, bytes);
 
         /* Test for user free-ing allocated memory */
         mbedtls_mpi_mod_modulus_free(&m);
@@ -1472,10 +1472,10 @@ void ecp_mod_mul_inv(char *input_A, int id, int ctype)
                                      limbs * ciL,
                                      MBEDTLS_MPI_MOD_EXT_REP_LE), 0);
 
-    TEST_BUFFERS_EQUAL(bufx, ciL, one, ciL);
+    TEST_MEMORY_COMPARE(bufx, ciL, one, ciL);
     /*Borrow the buffer of A to compare the left lims with 0 */
     memset(A, 0, limbs * ciL);
-    TEST_BUFFERS_EQUAL(&bufx[1], (limbs - 1) * ciL, A, (limbs - 1) * ciL);
+    TEST_MEMORY_COMPARE(&bufx[1], (limbs - 1) * ciL, A, (limbs - 1) * ciL);
 
 exit:
     mbedtls_mpi_mod_modulus_free(&m);
@@ -1527,7 +1527,7 @@ void ecp_mod_add_sub(char *input_A, char *input_B, int id, int ctype)
     TEST_EQUAL(0, mbedtls_mpi_mod_sub(&rS, &rS, &rB, &m));
 
     /* Compare difference with rA byte-by-byte */
-    TEST_BUFFERS_EQUAL(rA.p, bytes, rS.p, bytes);
+    TEST_MEMORY_COMPARE(rA.p, bytes, rS.p, bytes);
 
 exit:
     mbedtls_mpi_mod_modulus_free(&m);
@@ -1577,7 +1577,7 @@ void ecp_mod_read_write(char *input_A, int id, int ctype)
                                        bytes, MBEDTLS_MPI_MOD_EXT_REP_LE));
 
     TEST_EQUAL(limbs, rX.limbs);
-    TEST_BUFFERS_EQUAL(rA.p, bytes, rX.p, bytes);
+    TEST_MEMORY_COMPARE(rA.p, bytes, rX.p, bytes);
 
     memset(bufx, 0x00, bytes);
     memset(rX_raw, 0x00, bytes);
@@ -1591,7 +1591,7 @@ void ecp_mod_read_write(char *input_A, int id, int ctype)
                                        MBEDTLS_MPI_MOD_EXT_REP_BE));
 
     TEST_EQUAL(limbs, rX.limbs);
-    TEST_BUFFERS_EQUAL(rA.p, bytes, rX.p, bytes);
+    TEST_MEMORY_COMPARE(rA.p, bytes, rX.p, bytes);
 
 exit:
     mbedtls_mpi_mod_modulus_free(&m);

--- a/tests/suites/test_suite_gcm.function
+++ b/tests/suites/test_suite_gcm.function
@@ -33,7 +33,7 @@ static int check_multipart(mbedtls_gcm_context *ctx,
     /* Allocate a tight buffer for each update call. This way, if the function
      * tries to write beyond the advertised required buffer size, this will
      * count as an overflow for memory sanitizers and static checkers. */
-    ASSERT_ALLOC(output, n1);
+    TEST_CALLOC_OR_FAIL(output, n1);
     olen = 0xdeadbeef;
     TEST_EQUAL(0, mbedtls_gcm_update(ctx, input->x, n1, output, n1, &olen));
     TEST_EQUAL(n1, olen);
@@ -41,7 +41,7 @@ static int check_multipart(mbedtls_gcm_context *ctx,
     mbedtls_free(output);
     output = NULL;
 
-    ASSERT_ALLOC(output, n2);
+    TEST_CALLOC_OR_FAIL(output, n2);
     olen = 0xdeadbeef;
     TEST_EQUAL(0, mbedtls_gcm_update(ctx, input->x + n1, n2, output, n2, &olen));
     TEST_EQUAL(n2, olen);
@@ -49,7 +49,7 @@ static int check_multipart(mbedtls_gcm_context *ctx,
     mbedtls_free(output);
     output = NULL;
 
-    ASSERT_ALLOC(output, tag->len);
+    TEST_CALLOC_OR_FAIL(output, tag->len);
     TEST_EQUAL(0, mbedtls_gcm_finish(ctx, NULL, 0, &olen, output, tag->len));
     TEST_EQUAL(0, olen);
     TEST_BUFFERS_EQUAL(output, tag->len, tag->x, tag->len);
@@ -87,7 +87,7 @@ static void check_cipher_with_empty_ad(mbedtls_gcm_context *ctx,
     /* Allocate a tight buffer for each update call. This way, if the function
      * tries to write beyond the advertised required buffer size, this will
      * count as an overflow for memory sanitizers and static checkers. */
-    ASSERT_ALLOC(output, input->len);
+    TEST_CALLOC_OR_FAIL(output, input->len);
     olen = 0xdeadbeef;
     TEST_EQUAL(0, mbedtls_gcm_update(ctx, input->x, input->len, output, input->len, &olen));
     TEST_EQUAL(input->len, olen);
@@ -95,7 +95,7 @@ static void check_cipher_with_empty_ad(mbedtls_gcm_context *ctx,
     mbedtls_free(output);
     output = NULL;
 
-    ASSERT_ALLOC(output, tag->len);
+    TEST_CALLOC_OR_FAIL(output, tag->len);
     TEST_EQUAL(0, mbedtls_gcm_finish(ctx, NULL, 0, &olen, output, tag->len));
     TEST_EQUAL(0, olen);
     TEST_BUFFERS_EQUAL(output, tag->len, tag->x, tag->len);
@@ -124,7 +124,7 @@ static void check_empty_cipher_with_ad(mbedtls_gcm_context *ctx,
         TEST_EQUAL(0, olen);
     }
 
-    ASSERT_ALLOC(output_tag, tag->len);
+    TEST_CALLOC_OR_FAIL(output_tag, tag->len);
     TEST_EQUAL(0, mbedtls_gcm_finish(ctx, NULL, 0, &olen,
                                      output_tag, tag->len));
     TEST_EQUAL(0, olen);
@@ -144,7 +144,7 @@ static void check_no_cipher_no_ad(mbedtls_gcm_context *ctx,
 
     TEST_EQUAL(0, mbedtls_gcm_starts(ctx, mode,
                                      iv->x, iv->len));
-    ASSERT_ALLOC(output, tag->len);
+    TEST_CALLOC_OR_FAIL(output, tag->len);
     TEST_EQUAL(0, mbedtls_gcm_finish(ctx, NULL, 0, &olen, output, tag->len));
     TEST_EQUAL(0, olen);
     TEST_BUFFERS_EQUAL(output, tag->len, tag->x, tag->len);
@@ -448,7 +448,7 @@ void gcm_update_output_buffer_too_small(int cipher_id, int mode,
     TEST_EQUAL(mbedtls_gcm_setkey(&ctx, cipher_id, key_str->x, key_str->len * 8), 0);
     TEST_EQUAL(0, mbedtls_gcm_starts(&ctx, mode, iv->x, iv->len));
 
-    ASSERT_ALLOC(output, output_len);
+    TEST_CALLOC_OR_FAIL(output, output_len);
     TEST_EQUAL(MBEDTLS_ERR_GCM_BUFFER_TOO_SMALL,
                mbedtls_gcm_update(&ctx, input->x, input->len, output, output_len, &olen));
 

--- a/tests/suites/test_suite_gcm.function
+++ b/tests/suites/test_suite_gcm.function
@@ -37,7 +37,7 @@ static int check_multipart(mbedtls_gcm_context *ctx,
     olen = 0xdeadbeef;
     TEST_EQUAL(0, mbedtls_gcm_update(ctx, input->x, n1, output, n1, &olen));
     TEST_EQUAL(n1, olen);
-    ASSERT_COMPARE(output, olen, expected_output->x, n1);
+    TEST_BUFFERS_EQUAL(output, olen, expected_output->x, n1);
     mbedtls_free(output);
     output = NULL;
 
@@ -45,14 +45,14 @@ static int check_multipart(mbedtls_gcm_context *ctx,
     olen = 0xdeadbeef;
     TEST_EQUAL(0, mbedtls_gcm_update(ctx, input->x + n1, n2, output, n2, &olen));
     TEST_EQUAL(n2, olen);
-    ASSERT_COMPARE(output, olen, expected_output->x + n1, n2);
+    TEST_BUFFERS_EQUAL(output, olen, expected_output->x + n1, n2);
     mbedtls_free(output);
     output = NULL;
 
     ASSERT_ALLOC(output, tag->len);
     TEST_EQUAL(0, mbedtls_gcm_finish(ctx, NULL, 0, &olen, output, tag->len));
     TEST_EQUAL(0, olen);
-    ASSERT_COMPARE(output, tag->len, tag->x, tag->len);
+    TEST_BUFFERS_EQUAL(output, tag->len, tag->x, tag->len);
     mbedtls_free(output);
     output = NULL;
 
@@ -91,14 +91,14 @@ static void check_cipher_with_empty_ad(mbedtls_gcm_context *ctx,
     olen = 0xdeadbeef;
     TEST_EQUAL(0, mbedtls_gcm_update(ctx, input->x, input->len, output, input->len, &olen));
     TEST_EQUAL(input->len, olen);
-    ASSERT_COMPARE(output, olen, expected_output->x, input->len);
+    TEST_BUFFERS_EQUAL(output, olen, expected_output->x, input->len);
     mbedtls_free(output);
     output = NULL;
 
     ASSERT_ALLOC(output, tag->len);
     TEST_EQUAL(0, mbedtls_gcm_finish(ctx, NULL, 0, &olen, output, tag->len));
     TEST_EQUAL(0, olen);
-    ASSERT_COMPARE(output, tag->len, tag->x, tag->len);
+    TEST_BUFFERS_EQUAL(output, tag->len, tag->x, tag->len);
 
 exit:
     mbedtls_free(output);
@@ -128,7 +128,7 @@ static void check_empty_cipher_with_ad(mbedtls_gcm_context *ctx,
     TEST_EQUAL(0, mbedtls_gcm_finish(ctx, NULL, 0, &olen,
                                      output_tag, tag->len));
     TEST_EQUAL(0, olen);
-    ASSERT_COMPARE(output_tag, tag->len, tag->x, tag->len);
+    TEST_BUFFERS_EQUAL(output_tag, tag->len, tag->x, tag->len);
 
 exit:
     mbedtls_free(output_tag);
@@ -147,7 +147,7 @@ static void check_no_cipher_no_ad(mbedtls_gcm_context *ctx,
     ASSERT_ALLOC(output, tag->len);
     TEST_EQUAL(0, mbedtls_gcm_finish(ctx, NULL, 0, &olen, output, tag->len));
     TEST_EQUAL(0, olen);
-    ASSERT_COMPARE(output, tag->len, tag->x, tag->len);
+    TEST_BUFFERS_EQUAL(output, tag->len, tag->x, tag->len);
 
 exit:
     mbedtls_free(output);
@@ -212,8 +212,8 @@ void gcm_encrypt_and_tag(int cipher_id, data_t *key_str,
                                               iv_str->len, add_str->x, add_str->len, src_str->x,
                                               output, tag_len, tag_output) == 0);
 
-        ASSERT_COMPARE(output, src_str->len, dst->x, dst->len);
-        ASSERT_COMPARE(tag_output, tag_len, tag->x, tag->len);
+        TEST_BUFFERS_EQUAL(output, src_str->len, dst->x, dst->len);
+        TEST_BUFFERS_EQUAL(tag_output, tag_len, tag->x, tag->len);
 
         for (n1 = 0; n1 <= src_str->len; n1 += 1) {
             for (n1_add = 0; n1_add <= add_str->len; n1_add += 1) {
@@ -269,7 +269,7 @@ void gcm_decrypt_and_verify(int cipher_id, data_t *key_str,
             TEST_ASSERT(ret == MBEDTLS_ERR_GCM_AUTH_FAILED);
         } else {
             TEST_ASSERT(ret == 0);
-            ASSERT_COMPARE(output, src_str->len, pt_result->x, pt_result->len);
+            TEST_BUFFERS_EQUAL(output, src_str->len, pt_result->x, pt_result->len);
 
             for (n1 = 0; n1 <= src_str->len; n1 += 1) {
                 for (n1_add = 0; n1_add <= add_str->len; n1_add += 1) {

--- a/tests/suites/test_suite_gcm.function
+++ b/tests/suites/test_suite_gcm.function
@@ -33,7 +33,7 @@ static int check_multipart(mbedtls_gcm_context *ctx,
     /* Allocate a tight buffer for each update call. This way, if the function
      * tries to write beyond the advertised required buffer size, this will
      * count as an overflow for memory sanitizers and static checkers. */
-    TEST_CALLOC_OR_FAIL(output, n1);
+    TEST_CALLOC(output, n1);
     olen = 0xdeadbeef;
     TEST_EQUAL(0, mbedtls_gcm_update(ctx, input->x, n1, output, n1, &olen));
     TEST_EQUAL(n1, olen);
@@ -41,7 +41,7 @@ static int check_multipart(mbedtls_gcm_context *ctx,
     mbedtls_free(output);
     output = NULL;
 
-    TEST_CALLOC_OR_FAIL(output, n2);
+    TEST_CALLOC(output, n2);
     olen = 0xdeadbeef;
     TEST_EQUAL(0, mbedtls_gcm_update(ctx, input->x + n1, n2, output, n2, &olen));
     TEST_EQUAL(n2, olen);
@@ -49,7 +49,7 @@ static int check_multipart(mbedtls_gcm_context *ctx,
     mbedtls_free(output);
     output = NULL;
 
-    TEST_CALLOC_OR_FAIL(output, tag->len);
+    TEST_CALLOC(output, tag->len);
     TEST_EQUAL(0, mbedtls_gcm_finish(ctx, NULL, 0, &olen, output, tag->len));
     TEST_EQUAL(0, olen);
     TEST_BUFFERS_EQUAL(output, tag->len, tag->x, tag->len);
@@ -87,7 +87,7 @@ static void check_cipher_with_empty_ad(mbedtls_gcm_context *ctx,
     /* Allocate a tight buffer for each update call. This way, if the function
      * tries to write beyond the advertised required buffer size, this will
      * count as an overflow for memory sanitizers and static checkers. */
-    TEST_CALLOC_OR_FAIL(output, input->len);
+    TEST_CALLOC(output, input->len);
     olen = 0xdeadbeef;
     TEST_EQUAL(0, mbedtls_gcm_update(ctx, input->x, input->len, output, input->len, &olen));
     TEST_EQUAL(input->len, olen);
@@ -95,7 +95,7 @@ static void check_cipher_with_empty_ad(mbedtls_gcm_context *ctx,
     mbedtls_free(output);
     output = NULL;
 
-    TEST_CALLOC_OR_FAIL(output, tag->len);
+    TEST_CALLOC(output, tag->len);
     TEST_EQUAL(0, mbedtls_gcm_finish(ctx, NULL, 0, &olen, output, tag->len));
     TEST_EQUAL(0, olen);
     TEST_BUFFERS_EQUAL(output, tag->len, tag->x, tag->len);
@@ -124,7 +124,7 @@ static void check_empty_cipher_with_ad(mbedtls_gcm_context *ctx,
         TEST_EQUAL(0, olen);
     }
 
-    TEST_CALLOC_OR_FAIL(output_tag, tag->len);
+    TEST_CALLOC(output_tag, tag->len);
     TEST_EQUAL(0, mbedtls_gcm_finish(ctx, NULL, 0, &olen,
                                      output_tag, tag->len));
     TEST_EQUAL(0, olen);
@@ -144,7 +144,7 @@ static void check_no_cipher_no_ad(mbedtls_gcm_context *ctx,
 
     TEST_EQUAL(0, mbedtls_gcm_starts(ctx, mode,
                                      iv->x, iv->len));
-    TEST_CALLOC_OR_FAIL(output, tag->len);
+    TEST_CALLOC(output, tag->len);
     TEST_EQUAL(0, mbedtls_gcm_finish(ctx, NULL, 0, &olen, output, tag->len));
     TEST_EQUAL(0, olen);
     TEST_BUFFERS_EQUAL(output, tag->len, tag->x, tag->len);
@@ -448,7 +448,7 @@ void gcm_update_output_buffer_too_small(int cipher_id, int mode,
     TEST_EQUAL(mbedtls_gcm_setkey(&ctx, cipher_id, key_str->x, key_str->len * 8), 0);
     TEST_EQUAL(0, mbedtls_gcm_starts(&ctx, mode, iv->x, iv->len));
 
-    TEST_CALLOC_OR_FAIL(output, output_len);
+    TEST_CALLOC(output, output_len);
     TEST_EQUAL(MBEDTLS_ERR_GCM_BUFFER_TOO_SMALL,
                mbedtls_gcm_update(&ctx, input->x, input->len, output, output_len, &olen));
 

--- a/tests/suites/test_suite_gcm.function
+++ b/tests/suites/test_suite_gcm.function
@@ -37,7 +37,7 @@ static int check_multipart(mbedtls_gcm_context *ctx,
     olen = 0xdeadbeef;
     TEST_EQUAL(0, mbedtls_gcm_update(ctx, input->x, n1, output, n1, &olen));
     TEST_EQUAL(n1, olen);
-    TEST_BUFFERS_EQUAL(output, olen, expected_output->x, n1);
+    TEST_MEMORY_COMPARE(output, olen, expected_output->x, n1);
     mbedtls_free(output);
     output = NULL;
 
@@ -45,14 +45,14 @@ static int check_multipart(mbedtls_gcm_context *ctx,
     olen = 0xdeadbeef;
     TEST_EQUAL(0, mbedtls_gcm_update(ctx, input->x + n1, n2, output, n2, &olen));
     TEST_EQUAL(n2, olen);
-    TEST_BUFFERS_EQUAL(output, olen, expected_output->x + n1, n2);
+    TEST_MEMORY_COMPARE(output, olen, expected_output->x + n1, n2);
     mbedtls_free(output);
     output = NULL;
 
     TEST_CALLOC(output, tag->len);
     TEST_EQUAL(0, mbedtls_gcm_finish(ctx, NULL, 0, &olen, output, tag->len));
     TEST_EQUAL(0, olen);
-    TEST_BUFFERS_EQUAL(output, tag->len, tag->x, tag->len);
+    TEST_MEMORY_COMPARE(output, tag->len, tag->x, tag->len);
     mbedtls_free(output);
     output = NULL;
 
@@ -91,14 +91,14 @@ static void check_cipher_with_empty_ad(mbedtls_gcm_context *ctx,
     olen = 0xdeadbeef;
     TEST_EQUAL(0, mbedtls_gcm_update(ctx, input->x, input->len, output, input->len, &olen));
     TEST_EQUAL(input->len, olen);
-    TEST_BUFFERS_EQUAL(output, olen, expected_output->x, input->len);
+    TEST_MEMORY_COMPARE(output, olen, expected_output->x, input->len);
     mbedtls_free(output);
     output = NULL;
 
     TEST_CALLOC(output, tag->len);
     TEST_EQUAL(0, mbedtls_gcm_finish(ctx, NULL, 0, &olen, output, tag->len));
     TEST_EQUAL(0, olen);
-    TEST_BUFFERS_EQUAL(output, tag->len, tag->x, tag->len);
+    TEST_MEMORY_COMPARE(output, tag->len, tag->x, tag->len);
 
 exit:
     mbedtls_free(output);
@@ -128,7 +128,7 @@ static void check_empty_cipher_with_ad(mbedtls_gcm_context *ctx,
     TEST_EQUAL(0, mbedtls_gcm_finish(ctx, NULL, 0, &olen,
                                      output_tag, tag->len));
     TEST_EQUAL(0, olen);
-    TEST_BUFFERS_EQUAL(output_tag, tag->len, tag->x, tag->len);
+    TEST_MEMORY_COMPARE(output_tag, tag->len, tag->x, tag->len);
 
 exit:
     mbedtls_free(output_tag);
@@ -147,7 +147,7 @@ static void check_no_cipher_no_ad(mbedtls_gcm_context *ctx,
     TEST_CALLOC(output, tag->len);
     TEST_EQUAL(0, mbedtls_gcm_finish(ctx, NULL, 0, &olen, output, tag->len));
     TEST_EQUAL(0, olen);
-    TEST_BUFFERS_EQUAL(output, tag->len, tag->x, tag->len);
+    TEST_MEMORY_COMPARE(output, tag->len, tag->x, tag->len);
 
 exit:
     mbedtls_free(output);
@@ -212,8 +212,8 @@ void gcm_encrypt_and_tag(int cipher_id, data_t *key_str,
                                               iv_str->len, add_str->x, add_str->len, src_str->x,
                                               output, tag_len, tag_output) == 0);
 
-        TEST_BUFFERS_EQUAL(output, src_str->len, dst->x, dst->len);
-        TEST_BUFFERS_EQUAL(tag_output, tag_len, tag->x, tag->len);
+        TEST_MEMORY_COMPARE(output, src_str->len, dst->x, dst->len);
+        TEST_MEMORY_COMPARE(tag_output, tag_len, tag->x, tag->len);
 
         for (n1 = 0; n1 <= src_str->len; n1 += 1) {
             for (n1_add = 0; n1_add <= add_str->len; n1_add += 1) {
@@ -269,7 +269,7 @@ void gcm_decrypt_and_verify(int cipher_id, data_t *key_str,
             TEST_ASSERT(ret == MBEDTLS_ERR_GCM_AUTH_FAILED);
         } else {
             TEST_ASSERT(ret == 0);
-            TEST_BUFFERS_EQUAL(output, src_str->len, pt_result->x, pt_result->len);
+            TEST_MEMORY_COMPARE(output, src_str->len, pt_result->x, pt_result->len);
 
             for (n1 = 0; n1 <= src_str->len; n1 += 1) {
                 for (n1_add = 0; n1_add <= add_str->len; n1_add += 1) {

--- a/tests/suites/test_suite_hkdf.function
+++ b/tests/suites/test_suite_hkdf.function
@@ -27,7 +27,7 @@ void test_hkdf(int md_alg, data_t *ikm, data_t *salt, data_t *info,
     TEST_ASSERT(ret == 0);
 
     TEST_MEMORY_COMPARE(okm, expected_okm->len,
-                   expected_okm->x, expected_okm->len);
+                        expected_okm->x, expected_okm->len);
 
 exit:
     MD_PSA_DONE();

--- a/tests/suites/test_suite_hkdf.function
+++ b/tests/suites/test_suite_hkdf.function
@@ -50,7 +50,7 @@ void test_hkdf_extract(int md_alg,
     TEST_ASSERT(md != NULL);
 
     output_prk_len = mbedtls_md_get_size(md);
-    ASSERT_ALLOC(output_prk, output_prk_len);
+    TEST_CALLOC_OR_FAIL(output_prk, output_prk_len);
 
     ret = mbedtls_hkdf_extract(md, salt->x, salt->len,
                                ikm->x, ikm->len, output_prk);
@@ -79,7 +79,7 @@ void test_hkdf_expand(int md_alg,
     const mbedtls_md_info_t *md = mbedtls_md_info_from_type(md_alg);
     TEST_ASSERT(md != NULL);
 
-    ASSERT_ALLOC(output_okm, OKM_LEN);
+    TEST_CALLOC_OR_FAIL(output_okm, OKM_LEN);
 
     TEST_ASSERT(prk->len == mbedtls_md_get_size(md));
     TEST_ASSERT(okm->len < OKM_LEN);
@@ -110,7 +110,7 @@ void test_hkdf_extract_ret(int hash_len, int ret)
     fake_md_info.type = MBEDTLS_MD_NONE;
     fake_md_info.size = hash_len;
 
-    ASSERT_ALLOC(prk, MBEDTLS_MD_MAX_SIZE);
+    TEST_CALLOC_OR_FAIL(prk, MBEDTLS_MD_MAX_SIZE);
     salt_len = 0;
     ikm_len = 0;
 
@@ -140,11 +140,11 @@ void test_hkdf_expand_ret(int hash_len, int prk_len, int okm_len, int ret)
     info_len = 0;
 
     if (prk_len > 0) {
-        ASSERT_ALLOC(prk, prk_len);
+        TEST_CALLOC_OR_FAIL(prk, prk_len);
     }
 
     if (okm_len > 0) {
-        ASSERT_ALLOC(okm, okm_len);
+        TEST_CALLOC_OR_FAIL(okm, okm_len);
     }
 
     output_ret = mbedtls_hkdf_expand(&fake_md_info, prk, prk_len,

--- a/tests/suites/test_suite_hkdf.function
+++ b/tests/suites/test_suite_hkdf.function
@@ -50,7 +50,7 @@ void test_hkdf_extract(int md_alg,
     TEST_ASSERT(md != NULL);
 
     output_prk_len = mbedtls_md_get_size(md);
-    TEST_CALLOC_OR_FAIL(output_prk, output_prk_len);
+    TEST_CALLOC(output_prk, output_prk_len);
 
     ret = mbedtls_hkdf_extract(md, salt->x, salt->len,
                                ikm->x, ikm->len, output_prk);
@@ -79,7 +79,7 @@ void test_hkdf_expand(int md_alg,
     const mbedtls_md_info_t *md = mbedtls_md_info_from_type(md_alg);
     TEST_ASSERT(md != NULL);
 
-    TEST_CALLOC_OR_FAIL(output_okm, OKM_LEN);
+    TEST_CALLOC(output_okm, OKM_LEN);
 
     TEST_ASSERT(prk->len == mbedtls_md_get_size(md));
     TEST_ASSERT(okm->len < OKM_LEN);
@@ -110,7 +110,7 @@ void test_hkdf_extract_ret(int hash_len, int ret)
     fake_md_info.type = MBEDTLS_MD_NONE;
     fake_md_info.size = hash_len;
 
-    TEST_CALLOC_OR_FAIL(prk, MBEDTLS_MD_MAX_SIZE);
+    TEST_CALLOC(prk, MBEDTLS_MD_MAX_SIZE);
     salt_len = 0;
     ikm_len = 0;
 
@@ -140,11 +140,11 @@ void test_hkdf_expand_ret(int hash_len, int prk_len, int okm_len, int ret)
     info_len = 0;
 
     if (prk_len > 0) {
-        TEST_CALLOC_OR_FAIL(prk, prk_len);
+        TEST_CALLOC(prk, prk_len);
     }
 
     if (okm_len > 0) {
-        TEST_CALLOC_OR_FAIL(okm, okm_len);
+        TEST_CALLOC(okm, okm_len);
     }
 
     output_ret = mbedtls_hkdf_expand(&fake_md_info, prk, prk_len,

--- a/tests/suites/test_suite_hkdf.function
+++ b/tests/suites/test_suite_hkdf.function
@@ -26,7 +26,7 @@ void test_hkdf(int md_alg, data_t *ikm, data_t *salt, data_t *info,
                        info->x, info->len, okm, expected_okm->len);
     TEST_ASSERT(ret == 0);
 
-    TEST_BUFFERS_EQUAL(okm, expected_okm->len,
+    TEST_MEMORY_COMPARE(okm, expected_okm->len,
                    expected_okm->x, expected_okm->len);
 
 exit:
@@ -56,7 +56,7 @@ void test_hkdf_extract(int md_alg,
                                ikm->x, ikm->len, output_prk);
     TEST_ASSERT(ret == 0);
 
-    TEST_BUFFERS_EQUAL(output_prk, output_prk_len, prk->x, prk->len);
+    TEST_MEMORY_COMPARE(output_prk, output_prk_len, prk->x, prk->len);
 
 exit:
     mbedtls_free(output_prk);
@@ -88,7 +88,7 @@ void test_hkdf_expand(int md_alg,
                               info->x, info->len,
                               output_okm, OKM_LEN);
     TEST_ASSERT(ret == 0);
-    TEST_BUFFERS_EQUAL(output_okm, okm->len, okm->x, okm->len);
+    TEST_MEMORY_COMPARE(output_okm, okm->len, okm->x, okm->len);
 
 exit:
     mbedtls_free(output_okm);

--- a/tests/suites/test_suite_hkdf.function
+++ b/tests/suites/test_suite_hkdf.function
@@ -26,7 +26,7 @@ void test_hkdf(int md_alg, data_t *ikm, data_t *salt, data_t *info,
                        info->x, info->len, okm, expected_okm->len);
     TEST_ASSERT(ret == 0);
 
-    ASSERT_COMPARE(okm, expected_okm->len,
+    TEST_BUFFERS_EQUAL(okm, expected_okm->len,
                    expected_okm->x, expected_okm->len);
 
 exit:
@@ -56,7 +56,7 @@ void test_hkdf_extract(int md_alg,
                                ikm->x, ikm->len, output_prk);
     TEST_ASSERT(ret == 0);
 
-    ASSERT_COMPARE(output_prk, output_prk_len, prk->x, prk->len);
+    TEST_BUFFERS_EQUAL(output_prk, output_prk_len, prk->x, prk->len);
 
 exit:
     mbedtls_free(output_prk);
@@ -88,7 +88,7 @@ void test_hkdf_expand(int md_alg,
                               info->x, info->len,
                               output_okm, OKM_LEN);
     TEST_ASSERT(ret == 0);
-    ASSERT_COMPARE(output_okm, okm->len, okm->x, okm->len);
+    TEST_BUFFERS_EQUAL(output_okm, okm->len, okm->x, okm->len);
 
 exit:
     mbedtls_free(output_okm);

--- a/tests/suites/test_suite_lmots.function
+++ b/tests/suites/test_suite_lmots.function
@@ -122,7 +122,7 @@ void lmots_verify_test(data_t *msg, data_t *sig, data_t *pub_key,
                 continue;
             }
 
-            TEST_CALLOC_OR_FAIL(tmp_sig, size);
+            TEST_CALLOC(tmp_sig, size);
             if (tmp_sig != NULL) {
                 memcpy(tmp_sig, sig->x, MIN(size, sig->len));
             }
@@ -154,7 +154,7 @@ void lmots_import_export_test(data_t *pub_key, int expected_import_rc)
 
     if (expected_import_rc == 0) {
         exported_pub_key_buf_size = MBEDTLS_LMOTS_PUBLIC_KEY_LEN(MBEDTLS_LMOTS_SHA256_N32_W8);
-        TEST_CALLOC_OR_FAIL(exported_pub_key, exported_pub_key_buf_size);
+        TEST_CALLOC(exported_pub_key, exported_pub_key_buf_size);
 
         TEST_EQUAL(mbedtls_lmots_export_public_key(&ctx, exported_pub_key,
                                                    exported_pub_key_buf_size,
@@ -169,7 +169,7 @@ void lmots_import_export_test(data_t *pub_key, int expected_import_rc)
 
         /* Export into too-small buffer should fail */
         exported_pub_key_buf_size = MBEDTLS_LMOTS_PUBLIC_KEY_LEN(MBEDTLS_LMOTS_SHA256_N32_W8) - 1;
-        TEST_CALLOC_OR_FAIL(exported_pub_key, exported_pub_key_buf_size);
+        TEST_CALLOC(exported_pub_key, exported_pub_key_buf_size);
         TEST_EQUAL(mbedtls_lmots_export_public_key(&ctx, exported_pub_key,
                                                    exported_pub_key_buf_size, NULL),
                    MBEDTLS_ERR_LMS_BUFFER_TOO_SMALL);
@@ -178,7 +178,7 @@ void lmots_import_export_test(data_t *pub_key, int expected_import_rc)
 
         /* Export into too-large buffer should succeed */
         exported_pub_key_buf_size = MBEDTLS_LMOTS_PUBLIC_KEY_LEN(MBEDTLS_LMOTS_SHA256_N32_W8) + 1;
-        TEST_CALLOC_OR_FAIL(exported_pub_key, exported_pub_key_buf_size);
+        TEST_CALLOC(exported_pub_key, exported_pub_key_buf_size);
         TEST_EQUAL(mbedtls_lmots_export_public_key(&ctx, exported_pub_key,
                                                    exported_pub_key_buf_size,
                                                    &exported_pub_key_size),

--- a/tests/suites/test_suite_lmots.function
+++ b/tests/suites/test_suite_lmots.function
@@ -162,7 +162,7 @@ void lmots_import_export_test(data_t *pub_key, int expected_import_rc)
 
         TEST_EQUAL(exported_pub_key_size,
                    MBEDTLS_LMOTS_PUBLIC_KEY_LEN(MBEDTLS_LMOTS_SHA256_N32_W8));
-        ASSERT_COMPARE(pub_key->x, pub_key->len,
+        TEST_BUFFERS_EQUAL(pub_key->x, pub_key->len,
                        exported_pub_key, exported_pub_key_size);
         mbedtls_free(exported_pub_key);
         exported_pub_key = NULL;
@@ -183,7 +183,7 @@ void lmots_import_export_test(data_t *pub_key, int expected_import_rc)
                                                    exported_pub_key_buf_size,
                                                    &exported_pub_key_size),
                    0);
-        ASSERT_COMPARE(pub_key->x, pub_key->len,
+        TEST_BUFFERS_EQUAL(pub_key->x, pub_key->len,
                        exported_pub_key, exported_pub_key_size);
         mbedtls_free(exported_pub_key);
         exported_pub_key = NULL;

--- a/tests/suites/test_suite_lmots.function
+++ b/tests/suites/test_suite_lmots.function
@@ -122,7 +122,7 @@ void lmots_verify_test(data_t *msg, data_t *sig, data_t *pub_key,
                 continue;
             }
 
-            ASSERT_ALLOC(tmp_sig, size);
+            TEST_CALLOC_OR_FAIL(tmp_sig, size);
             if (tmp_sig != NULL) {
                 memcpy(tmp_sig, sig->x, MIN(size, sig->len));
             }
@@ -154,7 +154,7 @@ void lmots_import_export_test(data_t *pub_key, int expected_import_rc)
 
     if (expected_import_rc == 0) {
         exported_pub_key_buf_size = MBEDTLS_LMOTS_PUBLIC_KEY_LEN(MBEDTLS_LMOTS_SHA256_N32_W8);
-        ASSERT_ALLOC(exported_pub_key, exported_pub_key_buf_size);
+        TEST_CALLOC_OR_FAIL(exported_pub_key, exported_pub_key_buf_size);
 
         TEST_EQUAL(mbedtls_lmots_export_public_key(&ctx, exported_pub_key,
                                                    exported_pub_key_buf_size,
@@ -169,7 +169,7 @@ void lmots_import_export_test(data_t *pub_key, int expected_import_rc)
 
         /* Export into too-small buffer should fail */
         exported_pub_key_buf_size = MBEDTLS_LMOTS_PUBLIC_KEY_LEN(MBEDTLS_LMOTS_SHA256_N32_W8) - 1;
-        ASSERT_ALLOC(exported_pub_key, exported_pub_key_buf_size);
+        TEST_CALLOC_OR_FAIL(exported_pub_key, exported_pub_key_buf_size);
         TEST_EQUAL(mbedtls_lmots_export_public_key(&ctx, exported_pub_key,
                                                    exported_pub_key_buf_size, NULL),
                    MBEDTLS_ERR_LMS_BUFFER_TOO_SMALL);
@@ -178,7 +178,7 @@ void lmots_import_export_test(data_t *pub_key, int expected_import_rc)
 
         /* Export into too-large buffer should succeed */
         exported_pub_key_buf_size = MBEDTLS_LMOTS_PUBLIC_KEY_LEN(MBEDTLS_LMOTS_SHA256_N32_W8) + 1;
-        ASSERT_ALLOC(exported_pub_key, exported_pub_key_buf_size);
+        TEST_CALLOC_OR_FAIL(exported_pub_key, exported_pub_key_buf_size);
         TEST_EQUAL(mbedtls_lmots_export_public_key(&ctx, exported_pub_key,
                                                    exported_pub_key_buf_size,
                                                    &exported_pub_key_size),

--- a/tests/suites/test_suite_lmots.function
+++ b/tests/suites/test_suite_lmots.function
@@ -162,7 +162,7 @@ void lmots_import_export_test(data_t *pub_key, int expected_import_rc)
 
         TEST_EQUAL(exported_pub_key_size,
                    MBEDTLS_LMOTS_PUBLIC_KEY_LEN(MBEDTLS_LMOTS_SHA256_N32_W8));
-        TEST_BUFFERS_EQUAL(pub_key->x, pub_key->len,
+        TEST_MEMORY_COMPARE(pub_key->x, pub_key->len,
                        exported_pub_key, exported_pub_key_size);
         mbedtls_free(exported_pub_key);
         exported_pub_key = NULL;
@@ -183,7 +183,7 @@ void lmots_import_export_test(data_t *pub_key, int expected_import_rc)
                                                    exported_pub_key_buf_size,
                                                    &exported_pub_key_size),
                    0);
-        TEST_BUFFERS_EQUAL(pub_key->x, pub_key->len,
+        TEST_MEMORY_COMPARE(pub_key->x, pub_key->len,
                        exported_pub_key, exported_pub_key_size);
         mbedtls_free(exported_pub_key);
         exported_pub_key = NULL;

--- a/tests/suites/test_suite_lmots.function
+++ b/tests/suites/test_suite_lmots.function
@@ -163,7 +163,7 @@ void lmots_import_export_test(data_t *pub_key, int expected_import_rc)
         TEST_EQUAL(exported_pub_key_size,
                    MBEDTLS_LMOTS_PUBLIC_KEY_LEN(MBEDTLS_LMOTS_SHA256_N32_W8));
         TEST_MEMORY_COMPARE(pub_key->x, pub_key->len,
-                       exported_pub_key, exported_pub_key_size);
+                            exported_pub_key, exported_pub_key_size);
         mbedtls_free(exported_pub_key);
         exported_pub_key = NULL;
 
@@ -184,7 +184,7 @@ void lmots_import_export_test(data_t *pub_key, int expected_import_rc)
                                                    &exported_pub_key_size),
                    0);
         TEST_MEMORY_COMPARE(pub_key->x, pub_key->len,
-                       exported_pub_key, exported_pub_key_size);
+                            exported_pub_key, exported_pub_key_size);
         mbedtls_free(exported_pub_key);
         exported_pub_key = NULL;
     }

--- a/tests/suites/test_suite_lms.function
+++ b/tests/suites/test_suite_lms.function
@@ -164,7 +164,7 @@ void lms_import_export_test(data_t *pub_key, int expected_import_rc)
 
         TEST_EQUAL(exported_pub_key_size,
                    MBEDTLS_LMS_PUBLIC_KEY_LEN(MBEDTLS_LMS_SHA256_M32_H10));
-        TEST_BUFFERS_EQUAL(pub_key->x, pub_key->len,
+        TEST_MEMORY_COMPARE(pub_key->x, pub_key->len,
                        exported_pub_key, exported_pub_key_size);
         mbedtls_free(exported_pub_key);
         exported_pub_key = NULL;
@@ -185,7 +185,7 @@ void lms_import_export_test(data_t *pub_key, int expected_import_rc)
                                                  exported_pub_key_buf_size,
                                                  &exported_pub_key_size),
                    0);
-        TEST_BUFFERS_EQUAL(pub_key->x, pub_key->len,
+        TEST_MEMORY_COMPARE(pub_key->x, pub_key->len,
                        exported_pub_key, exported_pub_key_size);
         mbedtls_free(exported_pub_key);
         exported_pub_key = NULL;

--- a/tests/suites/test_suite_lms.function
+++ b/tests/suites/test_suite_lms.function
@@ -165,7 +165,7 @@ void lms_import_export_test(data_t *pub_key, int expected_import_rc)
         TEST_EQUAL(exported_pub_key_size,
                    MBEDTLS_LMS_PUBLIC_KEY_LEN(MBEDTLS_LMS_SHA256_M32_H10));
         TEST_MEMORY_COMPARE(pub_key->x, pub_key->len,
-                       exported_pub_key, exported_pub_key_size);
+                            exported_pub_key, exported_pub_key_size);
         mbedtls_free(exported_pub_key);
         exported_pub_key = NULL;
 
@@ -186,7 +186,7 @@ void lms_import_export_test(data_t *pub_key, int expected_import_rc)
                                                  &exported_pub_key_size),
                    0);
         TEST_MEMORY_COMPARE(pub_key->x, pub_key->len,
-                       exported_pub_key, exported_pub_key_size);
+                            exported_pub_key, exported_pub_key_size);
         mbedtls_free(exported_pub_key);
         exported_pub_key = NULL;
     }

--- a/tests/suites/test_suite_lms.function
+++ b/tests/suites/test_suite_lms.function
@@ -124,7 +124,7 @@ void lms_verify_test(data_t *msg, data_t *sig, data_t *pub_key,
                 continue;
             }
 
-            TEST_CALLOC_OR_FAIL(tmp_sig, size);
+            TEST_CALLOC(tmp_sig, size);
             if (tmp_sig != NULL) {
                 memcpy(tmp_sig, sig->x, MIN(size, sig->len));
             }
@@ -156,7 +156,7 @@ void lms_import_export_test(data_t *pub_key, int expected_import_rc)
 
     if (expected_import_rc == 0) {
         exported_pub_key_buf_size = MBEDTLS_LMS_PUBLIC_KEY_LEN(MBEDTLS_LMS_SHA256_M32_H10);
-        TEST_CALLOC_OR_FAIL(exported_pub_key, exported_pub_key_buf_size);
+        TEST_CALLOC(exported_pub_key, exported_pub_key_buf_size);
 
         TEST_EQUAL(mbedtls_lms_export_public_key(&ctx, exported_pub_key,
                                                  exported_pub_key_buf_size,
@@ -171,7 +171,7 @@ void lms_import_export_test(data_t *pub_key, int expected_import_rc)
 
         /* Export into too-small buffer should fail */
         exported_pub_key_buf_size = MBEDTLS_LMS_PUBLIC_KEY_LEN(MBEDTLS_LMS_SHA256_M32_H10) - 1;
-        TEST_CALLOC_OR_FAIL(exported_pub_key, exported_pub_key_buf_size);
+        TEST_CALLOC(exported_pub_key, exported_pub_key_buf_size);
         TEST_EQUAL(mbedtls_lms_export_public_key(&ctx, exported_pub_key,
                                                  exported_pub_key_buf_size, NULL),
                    MBEDTLS_ERR_LMS_BUFFER_TOO_SMALL);
@@ -180,7 +180,7 @@ void lms_import_export_test(data_t *pub_key, int expected_import_rc)
 
         /* Export into too-large buffer should succeed */
         exported_pub_key_buf_size = MBEDTLS_LMS_PUBLIC_KEY_LEN(MBEDTLS_LMS_SHA256_M32_H10) + 1;
-        TEST_CALLOC_OR_FAIL(exported_pub_key, exported_pub_key_buf_size);
+        TEST_CALLOC(exported_pub_key, exported_pub_key_buf_size);
         TEST_EQUAL(mbedtls_lms_export_public_key(&ctx, exported_pub_key,
                                                  exported_pub_key_buf_size,
                                                  &exported_pub_key_size),

--- a/tests/suites/test_suite_lms.function
+++ b/tests/suites/test_suite_lms.function
@@ -124,7 +124,7 @@ void lms_verify_test(data_t *msg, data_t *sig, data_t *pub_key,
                 continue;
             }
 
-            ASSERT_ALLOC(tmp_sig, size);
+            TEST_CALLOC_OR_FAIL(tmp_sig, size);
             if (tmp_sig != NULL) {
                 memcpy(tmp_sig, sig->x, MIN(size, sig->len));
             }
@@ -156,7 +156,7 @@ void lms_import_export_test(data_t *pub_key, int expected_import_rc)
 
     if (expected_import_rc == 0) {
         exported_pub_key_buf_size = MBEDTLS_LMS_PUBLIC_KEY_LEN(MBEDTLS_LMS_SHA256_M32_H10);
-        ASSERT_ALLOC(exported_pub_key, exported_pub_key_buf_size);
+        TEST_CALLOC_OR_FAIL(exported_pub_key, exported_pub_key_buf_size);
 
         TEST_EQUAL(mbedtls_lms_export_public_key(&ctx, exported_pub_key,
                                                  exported_pub_key_buf_size,
@@ -171,7 +171,7 @@ void lms_import_export_test(data_t *pub_key, int expected_import_rc)
 
         /* Export into too-small buffer should fail */
         exported_pub_key_buf_size = MBEDTLS_LMS_PUBLIC_KEY_LEN(MBEDTLS_LMS_SHA256_M32_H10) - 1;
-        ASSERT_ALLOC(exported_pub_key, exported_pub_key_buf_size);
+        TEST_CALLOC_OR_FAIL(exported_pub_key, exported_pub_key_buf_size);
         TEST_EQUAL(mbedtls_lms_export_public_key(&ctx, exported_pub_key,
                                                  exported_pub_key_buf_size, NULL),
                    MBEDTLS_ERR_LMS_BUFFER_TOO_SMALL);
@@ -180,7 +180,7 @@ void lms_import_export_test(data_t *pub_key, int expected_import_rc)
 
         /* Export into too-large buffer should succeed */
         exported_pub_key_buf_size = MBEDTLS_LMS_PUBLIC_KEY_LEN(MBEDTLS_LMS_SHA256_M32_H10) + 1;
-        ASSERT_ALLOC(exported_pub_key, exported_pub_key_buf_size);
+        TEST_CALLOC_OR_FAIL(exported_pub_key, exported_pub_key_buf_size);
         TEST_EQUAL(mbedtls_lms_export_public_key(&ctx, exported_pub_key,
                                                  exported_pub_key_buf_size,
                                                  &exported_pub_key_size),

--- a/tests/suites/test_suite_lms.function
+++ b/tests/suites/test_suite_lms.function
@@ -164,7 +164,7 @@ void lms_import_export_test(data_t *pub_key, int expected_import_rc)
 
         TEST_EQUAL(exported_pub_key_size,
                    MBEDTLS_LMS_PUBLIC_KEY_LEN(MBEDTLS_LMS_SHA256_M32_H10));
-        ASSERT_COMPARE(pub_key->x, pub_key->len,
+        TEST_BUFFERS_EQUAL(pub_key->x, pub_key->len,
                        exported_pub_key, exported_pub_key_size);
         mbedtls_free(exported_pub_key);
         exported_pub_key = NULL;
@@ -185,7 +185,7 @@ void lms_import_export_test(data_t *pub_key, int expected_import_rc)
                                                  exported_pub_key_buf_size,
                                                  &exported_pub_key_size),
                    0);
-        ASSERT_COMPARE(pub_key->x, pub_key->len,
+        TEST_BUFFERS_EQUAL(pub_key->x, pub_key->len,
                        exported_pub_key, exported_pub_key_size);
         mbedtls_free(exported_pub_key);
         exported_pub_key = NULL;

--- a/tests/suites/test_suite_md.function
+++ b/tests/suites/test_suite_md.function
@@ -185,7 +185,7 @@ void md_text(int md_type, char *text_src_string, data_t *hash)
 
     TEST_EQUAL(0, mbedtls_md(md_info, src, src_len, output));
 
-    TEST_BUFFERS_EQUAL(output, mbedtls_md_get_size(md_info), hash->x, hash->len);
+    TEST_MEMORY_COMPARE(output, mbedtls_md_get_size(md_info), hash->x, hash->len);
 
 exit:
     MD_PSA_DONE();
@@ -206,7 +206,7 @@ void md_hex(int md_type, data_t *src_str, data_t *hash)
     TEST_EQUAL(0, mbedtls_md(md_info, src_str->x, src_str->len, output));
 
 
-    TEST_BUFFERS_EQUAL(output, mbedtls_md_get_size(md_info), hash->x, hash->len);
+    TEST_MEMORY_COMPARE(output, mbedtls_md_get_size(md_info), hash->x, hash->len);
 
 exit:
     MD_PSA_DONE();
@@ -248,14 +248,14 @@ void md_text_multi(int md_type, char *text_src_string,
 
     TEST_EQUAL(0, mbedtls_md_update(&ctx, src + halfway, src_len - halfway));
     TEST_EQUAL(0, mbedtls_md_finish(&ctx, output));
-    TEST_BUFFERS_EQUAL(output, mbedtls_md_get_size(md_info), hash->x, hash->len);
+    TEST_MEMORY_COMPARE(output, mbedtls_md_get_size(md_info), hash->x, hash->len);
 
     /* Test clone */
     memset(output, 0x00, sizeof(output));
 
     TEST_EQUAL(0, mbedtls_md_update(&ctx_copy, src + halfway, src_len - halfway));
     TEST_EQUAL(0, mbedtls_md_finish(&ctx_copy, output));
-    TEST_BUFFERS_EQUAL(output, mbedtls_md_get_size(md_info), hash->x, hash->len);
+    TEST_MEMORY_COMPARE(output, mbedtls_md_get_size(md_info), hash->x, hash->len);
 
 exit:
     mbedtls_md_free(&ctx);
@@ -295,14 +295,14 @@ void md_hex_multi(int md_type, data_t *src_str, data_t *hash)
 
     TEST_EQUAL(0, mbedtls_md_update(&ctx, src_str->x + halfway, src_str->len - halfway));
     TEST_EQUAL(0, mbedtls_md_finish(&ctx, output));
-    TEST_BUFFERS_EQUAL(output, mbedtls_md_get_size(md_info), hash->x, hash->len);
+    TEST_MEMORY_COMPARE(output, mbedtls_md_get_size(md_info), hash->x, hash->len);
 
     /* Test clone */
     memset(output, 0x00, sizeof(output));
 
     TEST_EQUAL(0, mbedtls_md_update(&ctx_copy, src_str->x + halfway, src_str->len - halfway));
     TEST_EQUAL(0, mbedtls_md_finish(&ctx_copy, output));
-    TEST_BUFFERS_EQUAL(output, mbedtls_md_get_size(md_info), hash->x, hash->len);
+    TEST_MEMORY_COMPARE(output, mbedtls_md_get_size(md_info), hash->x, hash->len);
 
 exit:
     mbedtls_md_free(&ctx);
@@ -328,7 +328,7 @@ void mbedtls_md_hmac(int md_type, int trunc_size,
     TEST_EQUAL(0, mbedtls_md_hmac(md_info, key_str->x, key_str->len,
                                   src_str->x, src_str->len, output));
 
-    TEST_BUFFERS_EQUAL(output, trunc_size, hash->x, hash->len);
+    TEST_MEMORY_COMPARE(output, trunc_size, hash->x, hash->len);
 
 exit:
     MD_PSA_DONE();
@@ -363,7 +363,7 @@ void md_hmac_multi(int md_type, int trunc_size, data_t *key_str,
     TEST_EQUAL(0, mbedtls_md_hmac_update(&ctx, src_str->x + halfway, src_str->len - halfway));
     TEST_EQUAL(0, mbedtls_md_hmac_finish(&ctx, output));
 
-    TEST_BUFFERS_EQUAL(output, trunc_size, hash->x, hash->len);
+    TEST_MEMORY_COMPARE(output, trunc_size, hash->x, hash->len);
 
     /* Test again, for reset() */
     memset(output, 0x00, sizeof(output));
@@ -373,7 +373,7 @@ void md_hmac_multi(int md_type, int trunc_size, data_t *key_str,
     TEST_EQUAL(0, mbedtls_md_hmac_update(&ctx, src_str->x + halfway, src_str->len - halfway));
     TEST_EQUAL(0, mbedtls_md_hmac_finish(&ctx, output));
 
-    TEST_BUFFERS_EQUAL(output, trunc_size, hash->x, hash->len);
+    TEST_MEMORY_COMPARE(output, trunc_size, hash->x, hash->len);
 
 exit:
     mbedtls_md_free(&ctx);
@@ -395,7 +395,7 @@ void mbedtls_md_file(int md_type, char *filename,
 
     TEST_EQUAL(0, mbedtls_md_file(md_info, filename, output));
 
-    TEST_BUFFERS_EQUAL(output, mbedtls_md_get_size(md_info), hash->x, hash->len);
+    TEST_MEMORY_COMPARE(output, mbedtls_md_get_size(md_info), hash->x, hash->len);
 
 exit:
     MD_PSA_DONE();

--- a/tests/suites/test_suite_md.function
+++ b/tests/suites/test_suite_md.function
@@ -185,7 +185,7 @@ void md_text(int md_type, char *text_src_string, data_t *hash)
 
     TEST_EQUAL(0, mbedtls_md(md_info, src, src_len, output));
 
-    ASSERT_COMPARE(output, mbedtls_md_get_size(md_info), hash->x, hash->len);
+    TEST_BUFFERS_EQUAL(output, mbedtls_md_get_size(md_info), hash->x, hash->len);
 
 exit:
     MD_PSA_DONE();
@@ -206,7 +206,7 @@ void md_hex(int md_type, data_t *src_str, data_t *hash)
     TEST_EQUAL(0, mbedtls_md(md_info, src_str->x, src_str->len, output));
 
 
-    ASSERT_COMPARE(output, mbedtls_md_get_size(md_info), hash->x, hash->len);
+    TEST_BUFFERS_EQUAL(output, mbedtls_md_get_size(md_info), hash->x, hash->len);
 
 exit:
     MD_PSA_DONE();
@@ -248,14 +248,14 @@ void md_text_multi(int md_type, char *text_src_string,
 
     TEST_EQUAL(0, mbedtls_md_update(&ctx, src + halfway, src_len - halfway));
     TEST_EQUAL(0, mbedtls_md_finish(&ctx, output));
-    ASSERT_COMPARE(output, mbedtls_md_get_size(md_info), hash->x, hash->len);
+    TEST_BUFFERS_EQUAL(output, mbedtls_md_get_size(md_info), hash->x, hash->len);
 
     /* Test clone */
     memset(output, 0x00, sizeof(output));
 
     TEST_EQUAL(0, mbedtls_md_update(&ctx_copy, src + halfway, src_len - halfway));
     TEST_EQUAL(0, mbedtls_md_finish(&ctx_copy, output));
-    ASSERT_COMPARE(output, mbedtls_md_get_size(md_info), hash->x, hash->len);
+    TEST_BUFFERS_EQUAL(output, mbedtls_md_get_size(md_info), hash->x, hash->len);
 
 exit:
     mbedtls_md_free(&ctx);
@@ -295,14 +295,14 @@ void md_hex_multi(int md_type, data_t *src_str, data_t *hash)
 
     TEST_EQUAL(0, mbedtls_md_update(&ctx, src_str->x + halfway, src_str->len - halfway));
     TEST_EQUAL(0, mbedtls_md_finish(&ctx, output));
-    ASSERT_COMPARE(output, mbedtls_md_get_size(md_info), hash->x, hash->len);
+    TEST_BUFFERS_EQUAL(output, mbedtls_md_get_size(md_info), hash->x, hash->len);
 
     /* Test clone */
     memset(output, 0x00, sizeof(output));
 
     TEST_EQUAL(0, mbedtls_md_update(&ctx_copy, src_str->x + halfway, src_str->len - halfway));
     TEST_EQUAL(0, mbedtls_md_finish(&ctx_copy, output));
-    ASSERT_COMPARE(output, mbedtls_md_get_size(md_info), hash->x, hash->len);
+    TEST_BUFFERS_EQUAL(output, mbedtls_md_get_size(md_info), hash->x, hash->len);
 
 exit:
     mbedtls_md_free(&ctx);
@@ -328,7 +328,7 @@ void mbedtls_md_hmac(int md_type, int trunc_size,
     TEST_EQUAL(0, mbedtls_md_hmac(md_info, key_str->x, key_str->len,
                                   src_str->x, src_str->len, output));
 
-    ASSERT_COMPARE(output, trunc_size, hash->x, hash->len);
+    TEST_BUFFERS_EQUAL(output, trunc_size, hash->x, hash->len);
 
 exit:
     MD_PSA_DONE();
@@ -363,7 +363,7 @@ void md_hmac_multi(int md_type, int trunc_size, data_t *key_str,
     TEST_EQUAL(0, mbedtls_md_hmac_update(&ctx, src_str->x + halfway, src_str->len - halfway));
     TEST_EQUAL(0, mbedtls_md_hmac_finish(&ctx, output));
 
-    ASSERT_COMPARE(output, trunc_size, hash->x, hash->len);
+    TEST_BUFFERS_EQUAL(output, trunc_size, hash->x, hash->len);
 
     /* Test again, for reset() */
     memset(output, 0x00, sizeof(output));
@@ -373,7 +373,7 @@ void md_hmac_multi(int md_type, int trunc_size, data_t *key_str,
     TEST_EQUAL(0, mbedtls_md_hmac_update(&ctx, src_str->x + halfway, src_str->len - halfway));
     TEST_EQUAL(0, mbedtls_md_hmac_finish(&ctx, output));
 
-    ASSERT_COMPARE(output, trunc_size, hash->x, hash->len);
+    TEST_BUFFERS_EQUAL(output, trunc_size, hash->x, hash->len);
 
 exit:
     mbedtls_md_free(&ctx);
@@ -395,7 +395,7 @@ void mbedtls_md_file(int md_type, char *filename,
 
     TEST_EQUAL(0, mbedtls_md_file(md_info, filename, output));
 
-    ASSERT_COMPARE(output, mbedtls_md_get_size(md_info), hash->x, hash->len);
+    TEST_BUFFERS_EQUAL(output, mbedtls_md_get_size(md_info), hash->x, hash->len);
 
 exit:
     MD_PSA_DONE();

--- a/tests/suites/test_suite_mps.function
+++ b/tests/suites/test_suite_mps.function
@@ -60,7 +60,7 @@ void mbedtls_mps_reader_no_pausing_single_step_single_round(int with_acc)
     /* Consumption (upper layer) */
     /* Consume exactly what's available */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 100, &tmp, NULL) == 0);
-    TEST_BUFFERS_EQUAL(tmp, 100, bufA, 100);
+    TEST_MEMORY_COMPARE(tmp, 100, bufA, 100);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
     /* Wrapup (lower layer) */
     TEST_ASSERT(mbedtls_mps_reader_reclaim(&rd, &paused) == 0);
@@ -108,14 +108,14 @@ void mbedtls_mps_reader_no_pausing_single_step_multiple_rounds(int with_acc)
     /* Consumption (upper layer) */
     /* Consume exactly what's available */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 100, &tmp, NULL) == 0);
-    TEST_BUFFERS_EQUAL(tmp, 100, bufA, 100);
+    TEST_MEMORY_COMPARE(tmp, 100, bufA, 100);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
     /* Preparation */
     TEST_ASSERT(mbedtls_mps_reader_reclaim(&rd, NULL) == 0);
     TEST_ASSERT(mbedtls_mps_reader_feed(&rd, bufB, sizeof(bufB)) == 0);
     /* Consumption */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 100, &tmp, NULL) == 0);
-    TEST_BUFFERS_EQUAL(tmp, 100, bufB, 100);
+    TEST_MEMORY_COMPARE(tmp, 100, bufB, 100);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
     /* Wrapup (lower layer) */
     TEST_ASSERT(mbedtls_mps_reader_reclaim(&rd, NULL) == 0);
@@ -162,11 +162,11 @@ void mbedtls_mps_reader_no_pausing_multiple_steps_single_round(int with_acc)
     TEST_ASSERT(mbedtls_mps_reader_feed(&rd, buf, sizeof(buf)) == 0);
     /* Consumption (upper layer) */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 10, &tmp, NULL) == 0);
-    TEST_BUFFERS_EQUAL(tmp, 10, buf, 10);
+    TEST_MEMORY_COMPARE(tmp, 10, buf, 10);
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 70, &tmp, NULL) == 0);
-    TEST_BUFFERS_EQUAL(tmp, 70, buf + 10, 70);
+    TEST_MEMORY_COMPARE(tmp, 70, buf + 10, 70);
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 30, &tmp, &tmp_len) == 0);
-    TEST_BUFFERS_EQUAL(tmp, tmp_len, buf + 80, 20);
+    TEST_MEMORY_COMPARE(tmp, tmp_len, buf + 80, 20);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
     /* Wrapup (lower layer) */
     TEST_ASSERT(mbedtls_mps_reader_reclaim(&rd, NULL) == 0);
@@ -202,18 +202,18 @@ void mbedtls_mps_reader_no_pausing_multiple_steps_multiple_rounds(int with_acc)
     TEST_ASSERT(mbedtls_mps_reader_feed(&rd, bufA, sizeof(bufA)) == 0);
     /* Consumption (upper layer) */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 10, &tmp, NULL) == 0);
-    TEST_BUFFERS_EQUAL(tmp, 10, bufA, 10);
+    TEST_MEMORY_COMPARE(tmp, 10, bufA, 10);
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 70, &tmp, NULL) == 0);
-    TEST_BUFFERS_EQUAL(tmp, 70, bufA + 10, 70);
+    TEST_MEMORY_COMPARE(tmp, 70, bufA + 10, 70);
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 30, &tmp, &tmp_len) == 0);
-    TEST_BUFFERS_EQUAL(tmp, tmp_len, bufA + 80, 20);
+    TEST_MEMORY_COMPARE(tmp, tmp_len, bufA + 80, 20);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
     /* Preparation */
     TEST_ASSERT(mbedtls_mps_reader_reclaim(&rd, NULL) == 0);
     TEST_ASSERT(mbedtls_mps_reader_feed(&rd, bufB, sizeof(bufB)) == 0);
     /* Consumption */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 100, &tmp, NULL) == 0);
-    TEST_BUFFERS_EQUAL(tmp, 100, bufB, 100);
+    TEST_MEMORY_COMPARE(tmp, 100, bufB, 100);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
     /* Wrapup */
     TEST_ASSERT(mbedtls_mps_reader_reclaim(&rd, NULL) == 0);
@@ -243,7 +243,7 @@ void mbedtls_mps_reader_pausing_needed_disabled()
     TEST_ASSERT(mbedtls_mps_reader_feed(&rd, buf, sizeof(buf)) == 0);
     /* Consumption (upper layer) */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 50, &tmp, NULL) == 0);
-    TEST_BUFFERS_EQUAL(tmp, 50, buf, 50);
+    TEST_MEMORY_COMPARE(tmp, 50, buf, 50);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 100, &tmp, NULL) ==
                 MBEDTLS_ERR_MPS_READER_OUT_OF_DATA);
@@ -284,10 +284,10 @@ void mbedtls_mps_reader_pausing_needed_buffer_too_small()
     TEST_ASSERT(mbedtls_mps_reader_feed(&rd, buf, sizeof(buf)) == 0);
     /* Consumption (upper layer) */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 50, &tmp, NULL) == 0);
-    TEST_BUFFERS_EQUAL(tmp, 50, buf, 50);
+    TEST_MEMORY_COMPARE(tmp, 50, buf, 50);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 10, &tmp, NULL) == 0);
-    TEST_BUFFERS_EQUAL(tmp, 10, buf + 50, 10);
+    TEST_MEMORY_COMPARE(tmp, 10, buf + 50, 10);
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 100, &tmp, NULL) ==
                 MBEDTLS_ERR_MPS_READER_OUT_OF_DATA);
     /* Wrapup (lower layer) */
@@ -295,7 +295,7 @@ void mbedtls_mps_reader_pausing_needed_buffer_too_small()
                 MBEDTLS_ERR_MPS_READER_ACCUMULATOR_TOO_SMALL);
 
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 50, &tmp, &tmp_len) == 0);
-    TEST_BUFFERS_EQUAL(tmp, tmp_len, buf + 50, 50);
+    TEST_MEMORY_COMPARE(tmp, tmp_len, buf + 50, 50);
 
     mbedtls_mps_reader_free(&rd);
 }
@@ -325,7 +325,7 @@ void mbedtls_mps_reader_reclaim_overflow()
     TEST_ASSERT(mbedtls_mps_reader_feed(&rd, buf, sizeof(buf)) == 0);
     /* Consumption (upper layer) */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 50, &tmp, NULL) == 0);
-    TEST_BUFFERS_EQUAL(tmp, 50, buf, 50);
+    TEST_MEMORY_COMPARE(tmp, 50, buf, 50);
     /* Excess request */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, (mbedtls_mps_size_t) -1, &tmp, NULL) ==
                 MBEDTLS_ERR_MPS_READER_OUT_OF_DATA);
@@ -376,10 +376,10 @@ void mbedtls_mps_reader_pausing(int option)
     /* Consumption (upper layer) */
     /* Ask for more than what's available. */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 80, &tmp, NULL) == 0);
-    TEST_BUFFERS_EQUAL(tmp, 80, bufA, 80);
+    TEST_MEMORY_COMPARE(tmp, 80, bufA, 80);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 10, &tmp, NULL) == 0);
-    TEST_BUFFERS_EQUAL(tmp, 10, bufA + 80, 10);
+    TEST_MEMORY_COMPARE(tmp, 10, bufA + 80, 10);
     switch (option) {
         case 0:  /* Single uncommitted fetch at pausing */
         case 1:
@@ -400,50 +400,50 @@ void mbedtls_mps_reader_pausing(int option)
     switch (option) {
         case 0: /* Single fetch at pausing, re-fetch with commit. */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 20, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 90, 10);
-            TEST_BUFFERS_EQUAL(tmp + 10, 10, bufB, 10);
+            TEST_MEMORY_COMPARE(tmp, 10, bufA + 90, 10);
+            TEST_MEMORY_COMPARE(tmp + 10, 10, bufB, 10);
             TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
             break;
 
         case 1: /* Single fetch at pausing, re-fetch without commit. */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 20, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 90, 10);
-            TEST_BUFFERS_EQUAL(tmp + 10, 10, bufB, 10);
+            TEST_MEMORY_COMPARE(tmp, 10, bufA + 90, 10);
+            TEST_MEMORY_COMPARE(tmp + 10, 10, bufB, 10);
             break;
 
         case 2: /* Multiple fetches at pausing, repeat without commit. */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 10, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 80, 10);
+            TEST_MEMORY_COMPARE(tmp, 10, bufA + 80, 10);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 20, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 90, 10);
-            TEST_BUFFERS_EQUAL(tmp + 10, 10, bufB, 10);
+            TEST_MEMORY_COMPARE(tmp, 10, bufA + 90, 10);
+            TEST_MEMORY_COMPARE(tmp + 10, 10, bufB, 10);
             break;
 
         case 3: /* Multiple fetches at pausing, repeat with commit 1. */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 10, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 80, 10);
+            TEST_MEMORY_COMPARE(tmp, 10, bufA + 80, 10);
             TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 20, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 90, 10);
-            TEST_BUFFERS_EQUAL(tmp + 10, 10, bufB, 10);
+            TEST_MEMORY_COMPARE(tmp, 10, bufA + 90, 10);
+            TEST_MEMORY_COMPARE(tmp + 10, 10, bufB, 10);
             break;
 
         case 4: /* Multiple fetches at pausing, repeat with commit 2. */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 10, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 80, 10);
+            TEST_MEMORY_COMPARE(tmp, 10, bufA + 80, 10);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 20, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 90, 10);
-            TEST_BUFFERS_EQUAL(tmp + 10, 10, bufB, 10);
+            TEST_MEMORY_COMPARE(tmp, 10, bufA + 90, 10);
+            TEST_MEMORY_COMPARE(tmp + 10, 10, bufB, 10);
             TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
             break;
 
         case 5: /* Multiple fetches at pausing, repeat with commit 3. */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 10, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 80, 10);
+            TEST_MEMORY_COMPARE(tmp, 10, bufA + 80, 10);
             TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 20, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 90, 10);
-            TEST_BUFFERS_EQUAL(tmp + 10, 10, bufB, 10);
+            TEST_MEMORY_COMPARE(tmp, 10, bufA + 90, 10);
+            TEST_MEMORY_COMPARE(tmp + 10, 10, bufB, 10);
             TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
             break;
 
@@ -453,7 +453,7 @@ void mbedtls_mps_reader_pausing(int option)
 
     /* In all cases, fetch the rest of the second buffer. */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 90, &tmp, NULL) == 0);
-    TEST_BUFFERS_EQUAL(tmp, 90, bufB + 10, 90);
+    TEST_MEMORY_COMPARE(tmp, 90, bufB + 10, 90);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
 
     /* Wrapup */
@@ -498,7 +498,7 @@ void mbedtls_mps_reader_pausing_multiple_feeds(int option)
     /* Consumption (upper layer) */
     /* Ask for more than what's available. */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 80, &tmp, NULL) == 0);
-    TEST_BUFFERS_EQUAL(tmp, 80, bufA, 80);
+    TEST_MEMORY_COMPARE(tmp, 80, bufA, 80);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
     /* 20 left, ask for 70 -> 50 overhead */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 70, &tmp, NULL) ==
@@ -538,8 +538,8 @@ void mbedtls_mps_reader_pausing_multiple_feeds(int option)
 
     /* Consumption */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 70, &tmp, NULL) == 0);
-    TEST_BUFFERS_EQUAL(tmp, 20, bufA + 80, 20);
-    TEST_BUFFERS_EQUAL(tmp + 20, 50, bufB, 50);
+    TEST_MEMORY_COMPARE(tmp, 20, bufA + 80, 20);
+    TEST_MEMORY_COMPARE(tmp + 20, 50, bufB, 50);
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 1000, &tmp, &fetch_len) == 0);
     switch (option) {
         case 0:
@@ -591,14 +591,14 @@ void mbedtls_mps_reader_reclaim_data_left(int option)
             /* Fetch (but not commit) the entire buffer. */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, sizeof(buf), &tmp, NULL)
                         == 0);
-            TEST_BUFFERS_EQUAL(tmp, 100, buf, 100);
+            TEST_MEMORY_COMPARE(tmp, 100, buf, 100);
             break;
 
         case 1:
             /* Fetch (but not commit) parts of the buffer. */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, sizeof(buf) / 2,
                                                &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, sizeof(buf) / 2, buf, sizeof(buf) / 2);
+            TEST_MEMORY_COMPARE(tmp, sizeof(buf) / 2, buf, sizeof(buf) / 2);
             break;
 
         case 2:
@@ -606,11 +606,11 @@ void mbedtls_mps_reader_reclaim_data_left(int option)
              * fetch but not commit the rest of the buffer. */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, sizeof(buf) / 2,
                                                &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, sizeof(buf) / 2, buf, sizeof(buf) / 2);
+            TEST_MEMORY_COMPARE(tmp, sizeof(buf) / 2, buf, sizeof(buf) / 2);
             TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, sizeof(buf) / 2,
                                                &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, sizeof(buf) / 2,
+            TEST_MEMORY_COMPARE(tmp, sizeof(buf) / 2,
                            buf + sizeof(buf) / 2,
                            sizeof(buf) / 2);
             break;
@@ -646,16 +646,16 @@ void mbedtls_mps_reader_reclaim_data_left_retry()
     TEST_ASSERT(mbedtls_mps_reader_feed(&rd, buf, sizeof(buf)) == 0);
     /* Consumption (upper layer) */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 50, &tmp, NULL) == 0);
-    TEST_BUFFERS_EQUAL(tmp, 50, buf, 50);
+    TEST_MEMORY_COMPARE(tmp, 50, buf, 50);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 50, &tmp, NULL) == 0);
-    TEST_BUFFERS_EQUAL(tmp, 50, buf + 50, 50);
+    TEST_MEMORY_COMPARE(tmp, 50, buf + 50, 50);
     /* Preparation */
     TEST_ASSERT(mbedtls_mps_reader_reclaim(&rd, NULL) ==
                 MBEDTLS_ERR_MPS_READER_DATA_LEFT);
     /* Consumption */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 50, &tmp, NULL) == 0);
-    TEST_BUFFERS_EQUAL(tmp, 50, buf + 50, 50);
+    TEST_MEMORY_COMPARE(tmp, 50, buf + 50, 50);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
     /* Wrapup */
     TEST_ASSERT(mbedtls_mps_reader_reclaim(&rd, NULL) == 0);
@@ -699,10 +699,10 @@ void mbedtls_mps_reader_multiple_pausing(int option)
     /* Consumption (upper layer) */
     /* Ask for more than what's available. */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 80, &tmp, NULL) == 0);
-    TEST_BUFFERS_EQUAL(tmp, 80, bufA, 80);
+    TEST_MEMORY_COMPARE(tmp, 80, bufA, 80);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 10, &tmp, NULL) == 0);
-    TEST_BUFFERS_EQUAL(tmp, 10, bufA + 80, 10);
+    TEST_MEMORY_COMPARE(tmp, 10, bufA + 80, 10);
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 20, &tmp, NULL) ==
                 MBEDTLS_ERR_MPS_READER_OUT_OF_DATA);
 
@@ -717,10 +717,10 @@ void mbedtls_mps_reader_multiple_pausing(int option)
 
             /* Consume */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 10, &tmp, &tmp_len) == 0);
-            TEST_BUFFERS_EQUAL(tmp, tmp_len, bufA + 80, 10);
+            TEST_MEMORY_COMPARE(tmp, tmp_len, bufA + 80, 10);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 20, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 90, 10);
-            TEST_BUFFERS_EQUAL(tmp + 10, 10, bufB, 10);
+            TEST_MEMORY_COMPARE(tmp, 10, bufA + 90, 10);
+            TEST_MEMORY_COMPARE(tmp + 10, 10, bufB, 10);
             TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 20, &tmp, NULL) ==
                         MBEDTLS_ERR_MPS_READER_OUT_OF_DATA);
@@ -731,18 +731,18 @@ void mbedtls_mps_reader_multiple_pausing(int option)
 
             /* Consume */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 20, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 10, bufB + 10, 10);
-            TEST_BUFFERS_EQUAL(tmp + 10, 10, bufC, 10);
+            TEST_MEMORY_COMPARE(tmp, 10, bufB + 10, 10);
+            TEST_MEMORY_COMPARE(tmp + 10, 10, bufC, 10);
             break;
 
         case 1: /* Fetch same chunks, commit afterwards, and
                  * then exceed bounds of new buffer; accumulator
                  * not large enough. */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 10, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 80, 10);
+            TEST_MEMORY_COMPARE(tmp, 10, bufA + 80, 10);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 20, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 90, 10);
-            TEST_BUFFERS_EQUAL(tmp + 10, 10, bufB, 10);
+            TEST_MEMORY_COMPARE(tmp, 10, bufA + 90, 10);
+            TEST_MEMORY_COMPARE(tmp + 10, 10, bufB, 10);
             TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 51, &tmp, NULL) ==
                         MBEDTLS_ERR_MPS_READER_OUT_OF_DATA);
@@ -756,10 +756,10 @@ void mbedtls_mps_reader_multiple_pausing(int option)
                  * then exceed bounds of new buffer; accumulator
                  * large enough. */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 10, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 80, 10);
+            TEST_MEMORY_COMPARE(tmp, 10, bufA + 80, 10);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 20, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 90, 10);
-            TEST_BUFFERS_EQUAL(tmp + 10, 10, bufB, 10);
+            TEST_MEMORY_COMPARE(tmp, 10, bufA + 90, 10);
+            TEST_MEMORY_COMPARE(tmp + 10, 10, bufB, 10);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 20, &tmp, NULL) ==
                         MBEDTLS_ERR_MPS_READER_OUT_OF_DATA);
 
@@ -769,19 +769,19 @@ void mbedtls_mps_reader_multiple_pausing(int option)
 
             /* Consume */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 50, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 20, bufA + 80, 20);
-            TEST_BUFFERS_EQUAL(tmp + 20, 20, bufB, 20);
-            TEST_BUFFERS_EQUAL(tmp + 40, 10, bufC, 10);
+            TEST_MEMORY_COMPARE(tmp, 20, bufA + 80, 20);
+            TEST_MEMORY_COMPARE(tmp + 20, 20, bufB, 20);
+            TEST_MEMORY_COMPARE(tmp + 40, 10, bufC, 10);
             break;
 
         case 3: /* Fetch same chunks, don't commit afterwards, and
                  * then exceed bounds of new buffer; accumulator
                  * not large enough. */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 10, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 80, 10);
+            TEST_MEMORY_COMPARE(tmp, 10, bufA + 80, 10);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 20, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 90, 10);
-            TEST_BUFFERS_EQUAL(tmp + 10, 10, bufB, 10);
+            TEST_MEMORY_COMPARE(tmp, 10, bufA + 90, 10);
+            TEST_MEMORY_COMPARE(tmp + 10, 10, bufB, 10);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 21, &tmp, NULL) ==
                         MBEDTLS_ERR_MPS_READER_OUT_OF_DATA);
 
@@ -1005,16 +1005,16 @@ void mbedtls_reader_inconsistent_usage(int option)
         case 0:
             /* Ask for buffered data in a single chunk, no commit */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 30, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 20, bufA + 80, 20);
-            TEST_BUFFERS_EQUAL(tmp + 20, 10, bufB, 10);
+            TEST_MEMORY_COMPARE(tmp, 20, bufA + 80, 20);
+            TEST_MEMORY_COMPARE(tmp + 20, 10, bufB, 10);
             success = 1;
             break;
 
         case 1:
             /* Ask for buffered data in a single chunk, with commit */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 30, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 20, bufA + 80, 20);
-            TEST_BUFFERS_EQUAL(tmp + 20, 10, bufB, 10);
+            TEST_MEMORY_COMPARE(tmp, 20, bufA + 80, 20);
+            TEST_MEMORY_COMPARE(tmp + 20, 10, bufB, 10);
             TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
             success = 1;
             break;
@@ -1035,7 +1035,7 @@ void mbedtls_reader_inconsistent_usage(int option)
             /* Asking for buffered data in different
              * chunks than before CAN fail. */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 15, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 15, bufA + 80, 15);
+            TEST_MEMORY_COMPARE(tmp, 15, bufA + 80, 15);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 10, &tmp, NULL) ==
                         MBEDTLS_ERR_MPS_READER_INCONSISTENT_REQUESTS);
             break;
@@ -1044,10 +1044,10 @@ void mbedtls_reader_inconsistent_usage(int option)
             /* Asking for buffered data different chunks
              * than before NEED NOT fail - no commits */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 15, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 15, bufA + 80, 15);
+            TEST_MEMORY_COMPARE(tmp, 15, bufA + 80, 15);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 15, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 5, bufA + 95, 5);
-            TEST_BUFFERS_EQUAL(tmp + 5, 10, bufB, 10);
+            TEST_MEMORY_COMPARE(tmp, 5, bufA + 95, 5);
+            TEST_MEMORY_COMPARE(tmp + 5, 10, bufB, 10);
             success = 1;
             break;
 
@@ -1055,11 +1055,11 @@ void mbedtls_reader_inconsistent_usage(int option)
             /* Asking for buffered data different chunks
              * than before NEED NOT fail - intermediate commit */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 15, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 15, bufA + 80, 15);
+            TEST_MEMORY_COMPARE(tmp, 15, bufA + 80, 15);
             TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 15, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 5, bufA + 95, 5);
-            TEST_BUFFERS_EQUAL(tmp + 5, 10, bufB, 10);
+            TEST_MEMORY_COMPARE(tmp, 5, bufA + 95, 5);
+            TEST_MEMORY_COMPARE(tmp + 5, 10, bufB, 10);
             success = 1;
             break;
 
@@ -1067,10 +1067,10 @@ void mbedtls_reader_inconsistent_usage(int option)
             /* Asking for buffered data different chunks
              * than before NEED NOT fail - end commit */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 15, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 15, bufA + 80, 15);
+            TEST_MEMORY_COMPARE(tmp, 15, bufA + 80, 15);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 15, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 5, bufA + 95, 5);
-            TEST_BUFFERS_EQUAL(tmp + 5, 10, bufB, 10);
+            TEST_MEMORY_COMPARE(tmp, 5, bufA + 95, 5);
+            TEST_MEMORY_COMPARE(tmp + 5, 10, bufB, 10);
             TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
             success = 1;
             break;
@@ -1079,11 +1079,11 @@ void mbedtls_reader_inconsistent_usage(int option)
             /* Asking for buffered data different chunks
              * than before NEED NOT fail - intermediate & end commit */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 15, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 15, bufA + 80, 15);
+            TEST_MEMORY_COMPARE(tmp, 15, bufA + 80, 15);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 15, &tmp, NULL) == 0);
             TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 5, bufA + 95, 5);
-            TEST_BUFFERS_EQUAL(tmp + 5, 10, bufB, 10);
+            TEST_MEMORY_COMPARE(tmp, 5, bufA + 95, 5);
+            TEST_MEMORY_COMPARE(tmp + 5, 10, bufB, 10);
             TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
             success = 1;
             break;
@@ -1096,7 +1096,7 @@ void mbedtls_reader_inconsistent_usage(int option)
     if (success == 1) {
         /* In all succeeding cases, fetch the rest of the second buffer. */
         TEST_ASSERT(mbedtls_mps_reader_get(&rd, 90, &tmp, NULL) == 0);
-        TEST_BUFFERS_EQUAL(tmp, 90, bufB + 10, 90);
+        TEST_MEMORY_COMPARE(tmp, 90, bufB + 10, 90);
         TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
 
         /* Wrapup */
@@ -1131,7 +1131,7 @@ void mbedtls_mps_reader_feed_empty()
 
     /* Consumption (upper layer) */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 100, &tmp, NULL) == 0);
-    TEST_BUFFERS_EQUAL(tmp, 100, buf, 100);
+    TEST_MEMORY_COMPARE(tmp, 100, buf, 100);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
 
     /* Wrapup */

--- a/tests/suites/test_suite_mps.function
+++ b/tests/suites/test_suite_mps.function
@@ -844,15 +844,15 @@ void mbedtls_mps_reader_random_usage(int num_out_chunks,
     mbedtls_mps_reader rd;
 
     if (acc_size > 0) {
-        TEST_CALLOC_OR_FAIL(acc, acc_size);
+        TEST_CALLOC(acc, acc_size);
     }
 
     /* This probably needs to be changed because we want
      * our tests to be deterministic. */
     //    srand( time( NULL ) );
 
-    TEST_CALLOC_OR_FAIL(outgoing, num_out_chunks * max_chunk_size);
-    TEST_CALLOC_OR_FAIL(incoming, num_out_chunks * max_chunk_size);
+    TEST_CALLOC(outgoing, num_out_chunks * max_chunk_size);
+    TEST_CALLOC(incoming, num_out_chunks * max_chunk_size);
 
     mbedtls_mps_reader_init(&rd, acc, acc_size);
 
@@ -884,7 +884,7 @@ void mbedtls_mps_reader_random_usage(int num_out_chunks,
                 }
 
                 tmp_size = (rand() % max_chunk_size) + 1;
-                TEST_CALLOC_OR_FAIL(tmp, tmp_size);
+                TEST_CALLOC(tmp, tmp_size);
 
                 TEST_ASSERT(mbedtls_test_rnd_std_rand(NULL, tmp, tmp_size) == 0);
                 ret = mbedtls_mps_reader_feed(&rd, tmp, tmp_size);

--- a/tests/suites/test_suite_mps.function
+++ b/tests/suites/test_suite_mps.function
@@ -611,8 +611,8 @@ void mbedtls_mps_reader_reclaim_data_left(int option)
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, sizeof(buf) / 2,
                                                &tmp, NULL) == 0);
             TEST_MEMORY_COMPARE(tmp, sizeof(buf) / 2,
-                           buf + sizeof(buf) / 2,
-                           sizeof(buf) / 2);
+                                buf + sizeof(buf) / 2,
+                                sizeof(buf) / 2);
             break;
 
         default:

--- a/tests/suites/test_suite_mps.function
+++ b/tests/suites/test_suite_mps.function
@@ -60,7 +60,7 @@ void mbedtls_mps_reader_no_pausing_single_step_single_round(int with_acc)
     /* Consumption (upper layer) */
     /* Consume exactly what's available */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 100, &tmp, NULL) == 0);
-    ASSERT_COMPARE(tmp, 100, bufA, 100);
+    TEST_BUFFERS_EQUAL(tmp, 100, bufA, 100);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
     /* Wrapup (lower layer) */
     TEST_ASSERT(mbedtls_mps_reader_reclaim(&rd, &paused) == 0);
@@ -108,14 +108,14 @@ void mbedtls_mps_reader_no_pausing_single_step_multiple_rounds(int with_acc)
     /* Consumption (upper layer) */
     /* Consume exactly what's available */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 100, &tmp, NULL) == 0);
-    ASSERT_COMPARE(tmp, 100, bufA, 100);
+    TEST_BUFFERS_EQUAL(tmp, 100, bufA, 100);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
     /* Preparation */
     TEST_ASSERT(mbedtls_mps_reader_reclaim(&rd, NULL) == 0);
     TEST_ASSERT(mbedtls_mps_reader_feed(&rd, bufB, sizeof(bufB)) == 0);
     /* Consumption */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 100, &tmp, NULL) == 0);
-    ASSERT_COMPARE(tmp, 100, bufB, 100);
+    TEST_BUFFERS_EQUAL(tmp, 100, bufB, 100);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
     /* Wrapup (lower layer) */
     TEST_ASSERT(mbedtls_mps_reader_reclaim(&rd, NULL) == 0);
@@ -162,11 +162,11 @@ void mbedtls_mps_reader_no_pausing_multiple_steps_single_round(int with_acc)
     TEST_ASSERT(mbedtls_mps_reader_feed(&rd, buf, sizeof(buf)) == 0);
     /* Consumption (upper layer) */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 10, &tmp, NULL) == 0);
-    ASSERT_COMPARE(tmp, 10, buf, 10);
+    TEST_BUFFERS_EQUAL(tmp, 10, buf, 10);
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 70, &tmp, NULL) == 0);
-    ASSERT_COMPARE(tmp, 70, buf + 10, 70);
+    TEST_BUFFERS_EQUAL(tmp, 70, buf + 10, 70);
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 30, &tmp, &tmp_len) == 0);
-    ASSERT_COMPARE(tmp, tmp_len, buf + 80, 20);
+    TEST_BUFFERS_EQUAL(tmp, tmp_len, buf + 80, 20);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
     /* Wrapup (lower layer) */
     TEST_ASSERT(mbedtls_mps_reader_reclaim(&rd, NULL) == 0);
@@ -202,18 +202,18 @@ void mbedtls_mps_reader_no_pausing_multiple_steps_multiple_rounds(int with_acc)
     TEST_ASSERT(mbedtls_mps_reader_feed(&rd, bufA, sizeof(bufA)) == 0);
     /* Consumption (upper layer) */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 10, &tmp, NULL) == 0);
-    ASSERT_COMPARE(tmp, 10, bufA, 10);
+    TEST_BUFFERS_EQUAL(tmp, 10, bufA, 10);
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 70, &tmp, NULL) == 0);
-    ASSERT_COMPARE(tmp, 70, bufA + 10, 70);
+    TEST_BUFFERS_EQUAL(tmp, 70, bufA + 10, 70);
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 30, &tmp, &tmp_len) == 0);
-    ASSERT_COMPARE(tmp, tmp_len, bufA + 80, 20);
+    TEST_BUFFERS_EQUAL(tmp, tmp_len, bufA + 80, 20);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
     /* Preparation */
     TEST_ASSERT(mbedtls_mps_reader_reclaim(&rd, NULL) == 0);
     TEST_ASSERT(mbedtls_mps_reader_feed(&rd, bufB, sizeof(bufB)) == 0);
     /* Consumption */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 100, &tmp, NULL) == 0);
-    ASSERT_COMPARE(tmp, 100, bufB, 100);
+    TEST_BUFFERS_EQUAL(tmp, 100, bufB, 100);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
     /* Wrapup */
     TEST_ASSERT(mbedtls_mps_reader_reclaim(&rd, NULL) == 0);
@@ -243,7 +243,7 @@ void mbedtls_mps_reader_pausing_needed_disabled()
     TEST_ASSERT(mbedtls_mps_reader_feed(&rd, buf, sizeof(buf)) == 0);
     /* Consumption (upper layer) */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 50, &tmp, NULL) == 0);
-    ASSERT_COMPARE(tmp, 50, buf, 50);
+    TEST_BUFFERS_EQUAL(tmp, 50, buf, 50);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 100, &tmp, NULL) ==
                 MBEDTLS_ERR_MPS_READER_OUT_OF_DATA);
@@ -284,10 +284,10 @@ void mbedtls_mps_reader_pausing_needed_buffer_too_small()
     TEST_ASSERT(mbedtls_mps_reader_feed(&rd, buf, sizeof(buf)) == 0);
     /* Consumption (upper layer) */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 50, &tmp, NULL) == 0);
-    ASSERT_COMPARE(tmp, 50, buf, 50);
+    TEST_BUFFERS_EQUAL(tmp, 50, buf, 50);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 10, &tmp, NULL) == 0);
-    ASSERT_COMPARE(tmp, 10, buf + 50, 10);
+    TEST_BUFFERS_EQUAL(tmp, 10, buf + 50, 10);
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 100, &tmp, NULL) ==
                 MBEDTLS_ERR_MPS_READER_OUT_OF_DATA);
     /* Wrapup (lower layer) */
@@ -295,7 +295,7 @@ void mbedtls_mps_reader_pausing_needed_buffer_too_small()
                 MBEDTLS_ERR_MPS_READER_ACCUMULATOR_TOO_SMALL);
 
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 50, &tmp, &tmp_len) == 0);
-    ASSERT_COMPARE(tmp, tmp_len, buf + 50, 50);
+    TEST_BUFFERS_EQUAL(tmp, tmp_len, buf + 50, 50);
 
     mbedtls_mps_reader_free(&rd);
 }
@@ -325,7 +325,7 @@ void mbedtls_mps_reader_reclaim_overflow()
     TEST_ASSERT(mbedtls_mps_reader_feed(&rd, buf, sizeof(buf)) == 0);
     /* Consumption (upper layer) */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 50, &tmp, NULL) == 0);
-    ASSERT_COMPARE(tmp, 50, buf, 50);
+    TEST_BUFFERS_EQUAL(tmp, 50, buf, 50);
     /* Excess request */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, (mbedtls_mps_size_t) -1, &tmp, NULL) ==
                 MBEDTLS_ERR_MPS_READER_OUT_OF_DATA);
@@ -376,10 +376,10 @@ void mbedtls_mps_reader_pausing(int option)
     /* Consumption (upper layer) */
     /* Ask for more than what's available. */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 80, &tmp, NULL) == 0);
-    ASSERT_COMPARE(tmp, 80, bufA, 80);
+    TEST_BUFFERS_EQUAL(tmp, 80, bufA, 80);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 10, &tmp, NULL) == 0);
-    ASSERT_COMPARE(tmp, 10, bufA + 80, 10);
+    TEST_BUFFERS_EQUAL(tmp, 10, bufA + 80, 10);
     switch (option) {
         case 0:  /* Single uncommitted fetch at pausing */
         case 1:
@@ -400,50 +400,50 @@ void mbedtls_mps_reader_pausing(int option)
     switch (option) {
         case 0: /* Single fetch at pausing, re-fetch with commit. */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 20, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 10, bufA + 90, 10);
-            ASSERT_COMPARE(tmp + 10, 10, bufB, 10);
+            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 90, 10);
+            TEST_BUFFERS_EQUAL(tmp + 10, 10, bufB, 10);
             TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
             break;
 
         case 1: /* Single fetch at pausing, re-fetch without commit. */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 20, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 10, bufA + 90, 10);
-            ASSERT_COMPARE(tmp + 10, 10, bufB, 10);
+            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 90, 10);
+            TEST_BUFFERS_EQUAL(tmp + 10, 10, bufB, 10);
             break;
 
         case 2: /* Multiple fetches at pausing, repeat without commit. */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 10, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 10, bufA + 80, 10);
+            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 80, 10);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 20, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 10, bufA + 90, 10);
-            ASSERT_COMPARE(tmp + 10, 10, bufB, 10);
+            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 90, 10);
+            TEST_BUFFERS_EQUAL(tmp + 10, 10, bufB, 10);
             break;
 
         case 3: /* Multiple fetches at pausing, repeat with commit 1. */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 10, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 10, bufA + 80, 10);
+            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 80, 10);
             TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 20, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 10, bufA + 90, 10);
-            ASSERT_COMPARE(tmp + 10, 10, bufB, 10);
+            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 90, 10);
+            TEST_BUFFERS_EQUAL(tmp + 10, 10, bufB, 10);
             break;
 
         case 4: /* Multiple fetches at pausing, repeat with commit 2. */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 10, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 10, bufA + 80, 10);
+            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 80, 10);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 20, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 10, bufA + 90, 10);
-            ASSERT_COMPARE(tmp + 10, 10, bufB, 10);
+            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 90, 10);
+            TEST_BUFFERS_EQUAL(tmp + 10, 10, bufB, 10);
             TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
             break;
 
         case 5: /* Multiple fetches at pausing, repeat with commit 3. */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 10, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 10, bufA + 80, 10);
+            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 80, 10);
             TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 20, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 10, bufA + 90, 10);
-            ASSERT_COMPARE(tmp + 10, 10, bufB, 10);
+            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 90, 10);
+            TEST_BUFFERS_EQUAL(tmp + 10, 10, bufB, 10);
             TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
             break;
 
@@ -453,7 +453,7 @@ void mbedtls_mps_reader_pausing(int option)
 
     /* In all cases, fetch the rest of the second buffer. */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 90, &tmp, NULL) == 0);
-    ASSERT_COMPARE(tmp, 90, bufB + 10, 90);
+    TEST_BUFFERS_EQUAL(tmp, 90, bufB + 10, 90);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
 
     /* Wrapup */
@@ -498,7 +498,7 @@ void mbedtls_mps_reader_pausing_multiple_feeds(int option)
     /* Consumption (upper layer) */
     /* Ask for more than what's available. */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 80, &tmp, NULL) == 0);
-    ASSERT_COMPARE(tmp, 80, bufA, 80);
+    TEST_BUFFERS_EQUAL(tmp, 80, bufA, 80);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
     /* 20 left, ask for 70 -> 50 overhead */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 70, &tmp, NULL) ==
@@ -538,8 +538,8 @@ void mbedtls_mps_reader_pausing_multiple_feeds(int option)
 
     /* Consumption */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 70, &tmp, NULL) == 0);
-    ASSERT_COMPARE(tmp, 20, bufA + 80, 20);
-    ASSERT_COMPARE(tmp + 20, 50, bufB, 50);
+    TEST_BUFFERS_EQUAL(tmp, 20, bufA + 80, 20);
+    TEST_BUFFERS_EQUAL(tmp + 20, 50, bufB, 50);
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 1000, &tmp, &fetch_len) == 0);
     switch (option) {
         case 0:
@@ -591,14 +591,14 @@ void mbedtls_mps_reader_reclaim_data_left(int option)
             /* Fetch (but not commit) the entire buffer. */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, sizeof(buf), &tmp, NULL)
                         == 0);
-            ASSERT_COMPARE(tmp, 100, buf, 100);
+            TEST_BUFFERS_EQUAL(tmp, 100, buf, 100);
             break;
 
         case 1:
             /* Fetch (but not commit) parts of the buffer. */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, sizeof(buf) / 2,
                                                &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, sizeof(buf) / 2, buf, sizeof(buf) / 2);
+            TEST_BUFFERS_EQUAL(tmp, sizeof(buf) / 2, buf, sizeof(buf) / 2);
             break;
 
         case 2:
@@ -606,11 +606,11 @@ void mbedtls_mps_reader_reclaim_data_left(int option)
              * fetch but not commit the rest of the buffer. */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, sizeof(buf) / 2,
                                                &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, sizeof(buf) / 2, buf, sizeof(buf) / 2);
+            TEST_BUFFERS_EQUAL(tmp, sizeof(buf) / 2, buf, sizeof(buf) / 2);
             TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, sizeof(buf) / 2,
                                                &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, sizeof(buf) / 2,
+            TEST_BUFFERS_EQUAL(tmp, sizeof(buf) / 2,
                            buf + sizeof(buf) / 2,
                            sizeof(buf) / 2);
             break;
@@ -646,16 +646,16 @@ void mbedtls_mps_reader_reclaim_data_left_retry()
     TEST_ASSERT(mbedtls_mps_reader_feed(&rd, buf, sizeof(buf)) == 0);
     /* Consumption (upper layer) */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 50, &tmp, NULL) == 0);
-    ASSERT_COMPARE(tmp, 50, buf, 50);
+    TEST_BUFFERS_EQUAL(tmp, 50, buf, 50);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 50, &tmp, NULL) == 0);
-    ASSERT_COMPARE(tmp, 50, buf + 50, 50);
+    TEST_BUFFERS_EQUAL(tmp, 50, buf + 50, 50);
     /* Preparation */
     TEST_ASSERT(mbedtls_mps_reader_reclaim(&rd, NULL) ==
                 MBEDTLS_ERR_MPS_READER_DATA_LEFT);
     /* Consumption */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 50, &tmp, NULL) == 0);
-    ASSERT_COMPARE(tmp, 50, buf + 50, 50);
+    TEST_BUFFERS_EQUAL(tmp, 50, buf + 50, 50);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
     /* Wrapup */
     TEST_ASSERT(mbedtls_mps_reader_reclaim(&rd, NULL) == 0);
@@ -699,10 +699,10 @@ void mbedtls_mps_reader_multiple_pausing(int option)
     /* Consumption (upper layer) */
     /* Ask for more than what's available. */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 80, &tmp, NULL) == 0);
-    ASSERT_COMPARE(tmp, 80, bufA, 80);
+    TEST_BUFFERS_EQUAL(tmp, 80, bufA, 80);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 10, &tmp, NULL) == 0);
-    ASSERT_COMPARE(tmp, 10, bufA + 80, 10);
+    TEST_BUFFERS_EQUAL(tmp, 10, bufA + 80, 10);
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 20, &tmp, NULL) ==
                 MBEDTLS_ERR_MPS_READER_OUT_OF_DATA);
 
@@ -717,10 +717,10 @@ void mbedtls_mps_reader_multiple_pausing(int option)
 
             /* Consume */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 10, &tmp, &tmp_len) == 0);
-            ASSERT_COMPARE(tmp, tmp_len, bufA + 80, 10);
+            TEST_BUFFERS_EQUAL(tmp, tmp_len, bufA + 80, 10);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 20, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 10, bufA + 90, 10);
-            ASSERT_COMPARE(tmp + 10, 10, bufB, 10);
+            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 90, 10);
+            TEST_BUFFERS_EQUAL(tmp + 10, 10, bufB, 10);
             TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 20, &tmp, NULL) ==
                         MBEDTLS_ERR_MPS_READER_OUT_OF_DATA);
@@ -731,18 +731,18 @@ void mbedtls_mps_reader_multiple_pausing(int option)
 
             /* Consume */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 20, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 10, bufB + 10, 10);
-            ASSERT_COMPARE(tmp + 10, 10, bufC, 10);
+            TEST_BUFFERS_EQUAL(tmp, 10, bufB + 10, 10);
+            TEST_BUFFERS_EQUAL(tmp + 10, 10, bufC, 10);
             break;
 
         case 1: /* Fetch same chunks, commit afterwards, and
                  * then exceed bounds of new buffer; accumulator
                  * not large enough. */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 10, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 10, bufA + 80, 10);
+            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 80, 10);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 20, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 10, bufA + 90, 10);
-            ASSERT_COMPARE(tmp + 10, 10, bufB, 10);
+            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 90, 10);
+            TEST_BUFFERS_EQUAL(tmp + 10, 10, bufB, 10);
             TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 51, &tmp, NULL) ==
                         MBEDTLS_ERR_MPS_READER_OUT_OF_DATA);
@@ -756,10 +756,10 @@ void mbedtls_mps_reader_multiple_pausing(int option)
                  * then exceed bounds of new buffer; accumulator
                  * large enough. */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 10, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 10, bufA + 80, 10);
+            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 80, 10);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 20, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 10, bufA + 90, 10);
-            ASSERT_COMPARE(tmp + 10, 10, bufB, 10);
+            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 90, 10);
+            TEST_BUFFERS_EQUAL(tmp + 10, 10, bufB, 10);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 20, &tmp, NULL) ==
                         MBEDTLS_ERR_MPS_READER_OUT_OF_DATA);
 
@@ -769,19 +769,19 @@ void mbedtls_mps_reader_multiple_pausing(int option)
 
             /* Consume */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 50, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 20, bufA + 80, 20);
-            ASSERT_COMPARE(tmp + 20, 20, bufB, 20);
-            ASSERT_COMPARE(tmp + 40, 10, bufC, 10);
+            TEST_BUFFERS_EQUAL(tmp, 20, bufA + 80, 20);
+            TEST_BUFFERS_EQUAL(tmp + 20, 20, bufB, 20);
+            TEST_BUFFERS_EQUAL(tmp + 40, 10, bufC, 10);
             break;
 
         case 3: /* Fetch same chunks, don't commit afterwards, and
                  * then exceed bounds of new buffer; accumulator
                  * not large enough. */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 10, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 10, bufA + 80, 10);
+            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 80, 10);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 20, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 10, bufA + 90, 10);
-            ASSERT_COMPARE(tmp + 10, 10, bufB, 10);
+            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 90, 10);
+            TEST_BUFFERS_EQUAL(tmp + 10, 10, bufB, 10);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 21, &tmp, NULL) ==
                         MBEDTLS_ERR_MPS_READER_OUT_OF_DATA);
 
@@ -1005,16 +1005,16 @@ void mbedtls_reader_inconsistent_usage(int option)
         case 0:
             /* Ask for buffered data in a single chunk, no commit */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 30, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 20, bufA + 80, 20);
-            ASSERT_COMPARE(tmp + 20, 10, bufB, 10);
+            TEST_BUFFERS_EQUAL(tmp, 20, bufA + 80, 20);
+            TEST_BUFFERS_EQUAL(tmp + 20, 10, bufB, 10);
             success = 1;
             break;
 
         case 1:
             /* Ask for buffered data in a single chunk, with commit */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 30, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 20, bufA + 80, 20);
-            ASSERT_COMPARE(tmp + 20, 10, bufB, 10);
+            TEST_BUFFERS_EQUAL(tmp, 20, bufA + 80, 20);
+            TEST_BUFFERS_EQUAL(tmp + 20, 10, bufB, 10);
             TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
             success = 1;
             break;
@@ -1035,7 +1035,7 @@ void mbedtls_reader_inconsistent_usage(int option)
             /* Asking for buffered data in different
              * chunks than before CAN fail. */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 15, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 15, bufA + 80, 15);
+            TEST_BUFFERS_EQUAL(tmp, 15, bufA + 80, 15);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 10, &tmp, NULL) ==
                         MBEDTLS_ERR_MPS_READER_INCONSISTENT_REQUESTS);
             break;
@@ -1044,10 +1044,10 @@ void mbedtls_reader_inconsistent_usage(int option)
             /* Asking for buffered data different chunks
              * than before NEED NOT fail - no commits */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 15, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 15, bufA + 80, 15);
+            TEST_BUFFERS_EQUAL(tmp, 15, bufA + 80, 15);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 15, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 5, bufA + 95, 5);
-            ASSERT_COMPARE(tmp + 5, 10, bufB, 10);
+            TEST_BUFFERS_EQUAL(tmp, 5, bufA + 95, 5);
+            TEST_BUFFERS_EQUAL(tmp + 5, 10, bufB, 10);
             success = 1;
             break;
 
@@ -1055,11 +1055,11 @@ void mbedtls_reader_inconsistent_usage(int option)
             /* Asking for buffered data different chunks
              * than before NEED NOT fail - intermediate commit */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 15, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 15, bufA + 80, 15);
+            TEST_BUFFERS_EQUAL(tmp, 15, bufA + 80, 15);
             TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 15, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 5, bufA + 95, 5);
-            ASSERT_COMPARE(tmp + 5, 10, bufB, 10);
+            TEST_BUFFERS_EQUAL(tmp, 5, bufA + 95, 5);
+            TEST_BUFFERS_EQUAL(tmp + 5, 10, bufB, 10);
             success = 1;
             break;
 
@@ -1067,10 +1067,10 @@ void mbedtls_reader_inconsistent_usage(int option)
             /* Asking for buffered data different chunks
              * than before NEED NOT fail - end commit */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 15, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 15, bufA + 80, 15);
+            TEST_BUFFERS_EQUAL(tmp, 15, bufA + 80, 15);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 15, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 5, bufA + 95, 5);
-            ASSERT_COMPARE(tmp + 5, 10, bufB, 10);
+            TEST_BUFFERS_EQUAL(tmp, 5, bufA + 95, 5);
+            TEST_BUFFERS_EQUAL(tmp + 5, 10, bufB, 10);
             TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
             success = 1;
             break;
@@ -1079,11 +1079,11 @@ void mbedtls_reader_inconsistent_usage(int option)
             /* Asking for buffered data different chunks
              * than before NEED NOT fail - intermediate & end commit */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 15, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 15, bufA + 80, 15);
+            TEST_BUFFERS_EQUAL(tmp, 15, bufA + 80, 15);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 15, &tmp, NULL) == 0);
             TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
-            ASSERT_COMPARE(tmp, 5, bufA + 95, 5);
-            ASSERT_COMPARE(tmp + 5, 10, bufB, 10);
+            TEST_BUFFERS_EQUAL(tmp, 5, bufA + 95, 5);
+            TEST_BUFFERS_EQUAL(tmp + 5, 10, bufB, 10);
             TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
             success = 1;
             break;
@@ -1096,7 +1096,7 @@ void mbedtls_reader_inconsistent_usage(int option)
     if (success == 1) {
         /* In all succeeding cases, fetch the rest of the second buffer. */
         TEST_ASSERT(mbedtls_mps_reader_get(&rd, 90, &tmp, NULL) == 0);
-        ASSERT_COMPARE(tmp, 90, bufB + 10, 90);
+        TEST_BUFFERS_EQUAL(tmp, 90, bufB + 10, 90);
         TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
 
         /* Wrapup */
@@ -1131,7 +1131,7 @@ void mbedtls_mps_reader_feed_empty()
 
     /* Consumption (upper layer) */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 100, &tmp, NULL) == 0);
-    ASSERT_COMPARE(tmp, 100, buf, 100);
+    TEST_BUFFERS_EQUAL(tmp, 100, buf, 100);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
 
     /* Wrapup */

--- a/tests/suites/test_suite_mps.function
+++ b/tests/suites/test_suite_mps.function
@@ -844,15 +844,15 @@ void mbedtls_mps_reader_random_usage(int num_out_chunks,
     mbedtls_mps_reader rd;
 
     if (acc_size > 0) {
-        ASSERT_ALLOC(acc, acc_size);
+        TEST_CALLOC_OR_FAIL(acc, acc_size);
     }
 
     /* This probably needs to be changed because we want
      * our tests to be deterministic. */
     //    srand( time( NULL ) );
 
-    ASSERT_ALLOC(outgoing, num_out_chunks * max_chunk_size);
-    ASSERT_ALLOC(incoming, num_out_chunks * max_chunk_size);
+    TEST_CALLOC_OR_FAIL(outgoing, num_out_chunks * max_chunk_size);
+    TEST_CALLOC_OR_FAIL(incoming, num_out_chunks * max_chunk_size);
 
     mbedtls_mps_reader_init(&rd, acc, acc_size);
 
@@ -884,7 +884,7 @@ void mbedtls_mps_reader_random_usage(int num_out_chunks,
                 }
 
                 tmp_size = (rand() % max_chunk_size) + 1;
-                ASSERT_ALLOC(tmp, tmp_size);
+                TEST_CALLOC_OR_FAIL(tmp, tmp_size);
 
                 TEST_ASSERT(mbedtls_test_rnd_std_rand(NULL, tmp, tmp_size) == 0);
                 ret = mbedtls_mps_reader_feed(&rd, tmp, tmp_size);

--- a/tests/suites/test_suite_pkcs12.function
+++ b/tests/suites/test_suite_pkcs12.function
@@ -44,7 +44,7 @@ void pkcs12_derive_key(int md_type, int key_size_arg,
 
     salt_len = salt_arg->len;
 
-    ASSERT_ALLOC(output_data, key_size);
+    TEST_CALLOC_OR_FAIL(output_data, key_size);
 
     int ret = mbedtls_pkcs12_derivation(output_data,
                                         key_size,

--- a/tests/suites/test_suite_pkcs12.function
+++ b/tests/suites/test_suite_pkcs12.function
@@ -59,7 +59,7 @@ void pkcs12_derive_key(int md_type, int key_size_arg,
     TEST_EQUAL(ret, expected_status);
 
     if (expected_status == 0) {
-        ASSERT_COMPARE(expected_output->x, expected_output->len,
+        TEST_BUFFERS_EQUAL(expected_output->x, expected_output->len,
                        output_data, key_size);
     }
 

--- a/tests/suites/test_suite_pkcs12.function
+++ b/tests/suites/test_suite_pkcs12.function
@@ -59,7 +59,7 @@ void pkcs12_derive_key(int md_type, int key_size_arg,
     TEST_EQUAL(ret, expected_status);
 
     if (expected_status == 0) {
-        TEST_BUFFERS_EQUAL(expected_output->x, expected_output->len,
+        TEST_MEMORY_COMPARE(expected_output->x, expected_output->len,
                        output_data, key_size);
     }
 

--- a/tests/suites/test_suite_pkcs12.function
+++ b/tests/suites/test_suite_pkcs12.function
@@ -44,7 +44,7 @@ void pkcs12_derive_key(int md_type, int key_size_arg,
 
     salt_len = salt_arg->len;
 
-    TEST_CALLOC_OR_FAIL(output_data, key_size);
+    TEST_CALLOC(output_data, key_size);
 
     int ret = mbedtls_pkcs12_derivation(output_data,
                                         key_size,

--- a/tests/suites/test_suite_pkcs12.function
+++ b/tests/suites/test_suite_pkcs12.function
@@ -60,7 +60,7 @@ void pkcs12_derive_key(int md_type, int key_size_arg,
 
     if (expected_status == 0) {
         TEST_MEMORY_COMPARE(expected_output->x, expected_output->len,
-                       output_data, key_size);
+                            output_data, key_size);
     }
 
 exit:

--- a/tests/suites/test_suite_pkcs1_v21.function
+++ b/tests/suites/test_suite_pkcs1_v21.function
@@ -48,7 +48,7 @@ void pkcs1_rsaes_oaep_encrypt(int mod, data_t *input_N, data_t *input_E,
                                           message_str->x,
                                           output) == result);
     if (result == 0) {
-        ASSERT_COMPARE(output, ctx.len, result_str->x, result_str->len);
+        TEST_BUFFERS_EQUAL(output, ctx.len, result_str->x, result_str->len);
     }
 
 exit:
@@ -110,7 +110,7 @@ void pkcs1_rsaes_oaep_decrypt(int mod, data_t *input_P, data_t *input_Q,
                                               output,
                                               sizeof(output)) == result);
         if (result == 0) {
-            ASSERT_COMPARE(output, output_len, result_str->x, result_str->len);
+            TEST_BUFFERS_EQUAL(output, output_len, result_str->x, result_str->len);
         }
     }
 
@@ -167,7 +167,7 @@ void pkcs1_rsassa_pss_sign(int mod, data_t *input_P, data_t *input_Q,
                         &ctx, &mbedtls_test_rnd_buffer_rand, &info,
                         digest, hash_digest->len, hash_digest->x, output) == result);
         if (result == 0) {
-            ASSERT_COMPARE(output, ctx.len, result_str->x, result_str->len);
+            TEST_BUFFERS_EQUAL(output, ctx.len, result_str->x, result_str->len);
         }
 
         info.buf = rnd_buf->x;
@@ -179,7 +179,7 @@ void pkcs1_rsassa_pss_sign(int mod, data_t *input_P, data_t *input_Q,
                     digest, hash_digest->len, hash_digest->x,
                     fixed_salt_length, output) == result);
     if (result == 0) {
-        ASSERT_COMPARE(output, ctx.len, result_str->x, result_str->len);
+        TEST_BUFFERS_EQUAL(output, ctx.len, result_str->x, result_str->len);
     }
 
 exit:

--- a/tests/suites/test_suite_pkcs1_v21.function
+++ b/tests/suites/test_suite_pkcs1_v21.function
@@ -48,7 +48,7 @@ void pkcs1_rsaes_oaep_encrypt(int mod, data_t *input_N, data_t *input_E,
                                           message_str->x,
                                           output) == result);
     if (result == 0) {
-        TEST_BUFFERS_EQUAL(output, ctx.len, result_str->x, result_str->len);
+        TEST_MEMORY_COMPARE(output, ctx.len, result_str->x, result_str->len);
     }
 
 exit:
@@ -110,7 +110,7 @@ void pkcs1_rsaes_oaep_decrypt(int mod, data_t *input_P, data_t *input_Q,
                                               output,
                                               sizeof(output)) == result);
         if (result == 0) {
-            TEST_BUFFERS_EQUAL(output, output_len, result_str->x, result_str->len);
+            TEST_MEMORY_COMPARE(output, output_len, result_str->x, result_str->len);
         }
     }
 
@@ -167,7 +167,7 @@ void pkcs1_rsassa_pss_sign(int mod, data_t *input_P, data_t *input_Q,
                         &ctx, &mbedtls_test_rnd_buffer_rand, &info,
                         digest, hash_digest->len, hash_digest->x, output) == result);
         if (result == 0) {
-            TEST_BUFFERS_EQUAL(output, ctx.len, result_str->x, result_str->len);
+            TEST_MEMORY_COMPARE(output, ctx.len, result_str->x, result_str->len);
         }
 
         info.buf = rnd_buf->x;
@@ -179,7 +179,7 @@ void pkcs1_rsassa_pss_sign(int mod, data_t *input_P, data_t *input_Q,
                     digest, hash_digest->len, hash_digest->x,
                     fixed_salt_length, output) == result);
     if (result == 0) {
-        TEST_BUFFERS_EQUAL(output, ctx.len, result_str->x, result_str->len);
+        TEST_MEMORY_COMPARE(output, ctx.len, result_str->x, result_str->len);
     }
 
 exit:

--- a/tests/suites/test_suite_pkcs7.function
+++ b/tests/suites/test_suite_pkcs7.function
@@ -85,8 +85,8 @@ void pkcs7_verify(char *pkcs7_file,
         }
     }
 
-    TEST_CALLOC_OR_FAIL(crts, n_crts);
-    TEST_CALLOC_OR_FAIL(crt_files_arr, n_crts);
+    TEST_CALLOC(crts, n_crts);
+    TEST_CALLOC(crt_files_arr, n_crts);
 
     for (i = 0; i < strlen(crt_files); i++) {
         for (k = i; k < strlen(crt_files); k++) {
@@ -94,7 +94,7 @@ void pkcs7_verify(char *pkcs7_file,
                 break;
             }
         }
-        TEST_CALLOC_OR_FAIL(crt_files_arr[cnt], (k-i)+1);
+        TEST_CALLOC(crt_files_arr[cnt], (k-i)+1);
         crt_files_arr[cnt][k-i] = '\0';
         memcpy(crt_files_arr[cnt++], crt_files + i, k-i);
         i = k;
@@ -102,7 +102,7 @@ void pkcs7_verify(char *pkcs7_file,
 
     mbedtls_pkcs7_init(&pkcs7);
     for (i = 0; i < n_crts; i++) {
-        TEST_CALLOC_OR_FAIL(crts[i], 1);
+        TEST_CALLOC(crts[i], 1);
         mbedtls_x509_crt_init(crts[i]);
     }
 
@@ -127,7 +127,7 @@ void pkcs7_verify(char *pkcs7_file,
 
     datalen = st.st_size;
     /* Special-case for zero-length input so that data will be non-NULL */
-    TEST_CALLOC_OR_FAIL(data, datalen == 0 ? 1 : datalen);
+    TEST_CALLOC(data, datalen == 0 ? 1 : datalen);
     buflen = fread((void *) data, sizeof(unsigned char), datalen, file);
     TEST_EQUAL(buflen, datalen);
 
@@ -135,7 +135,7 @@ void pkcs7_verify(char *pkcs7_file,
 
     if (do_hash_alg) {
         md_info = mbedtls_md_info_from_type((mbedtls_md_type_t) do_hash_alg);
-        TEST_CALLOC_OR_FAIL(hash, mbedtls_md_get_size(md_info));
+        TEST_CALLOC(hash, mbedtls_md_get_size(md_info));
         res = mbedtls_md(md_info, data, datalen, hash);
         TEST_EQUAL(res, 0);
 

--- a/tests/suites/test_suite_pkcs7.function
+++ b/tests/suites/test_suite_pkcs7.function
@@ -85,8 +85,8 @@ void pkcs7_verify(char *pkcs7_file,
         }
     }
 
-    ASSERT_ALLOC(crts, n_crts);
-    ASSERT_ALLOC(crt_files_arr, n_crts);
+    TEST_CALLOC_OR_FAIL(crts, n_crts);
+    TEST_CALLOC_OR_FAIL(crt_files_arr, n_crts);
 
     for (i = 0; i < strlen(crt_files); i++) {
         for (k = i; k < strlen(crt_files); k++) {
@@ -94,7 +94,7 @@ void pkcs7_verify(char *pkcs7_file,
                 break;
             }
         }
-        ASSERT_ALLOC(crt_files_arr[cnt], (k-i)+1);
+        TEST_CALLOC_OR_FAIL(crt_files_arr[cnt], (k-i)+1);
         crt_files_arr[cnt][k-i] = '\0';
         memcpy(crt_files_arr[cnt++], crt_files + i, k-i);
         i = k;
@@ -102,7 +102,7 @@ void pkcs7_verify(char *pkcs7_file,
 
     mbedtls_pkcs7_init(&pkcs7);
     for (i = 0; i < n_crts; i++) {
-        ASSERT_ALLOC(crts[i], 1);
+        TEST_CALLOC_OR_FAIL(crts[i], 1);
         mbedtls_x509_crt_init(crts[i]);
     }
 
@@ -127,7 +127,7 @@ void pkcs7_verify(char *pkcs7_file,
 
     datalen = st.st_size;
     /* Special-case for zero-length input so that data will be non-NULL */
-    ASSERT_ALLOC(data, datalen == 0 ? 1 : datalen);
+    TEST_CALLOC_OR_FAIL(data, datalen == 0 ? 1 : datalen);
     buflen = fread((void *) data, sizeof(unsigned char), datalen, file);
     TEST_EQUAL(buflen, datalen);
 
@@ -135,7 +135,7 @@ void pkcs7_verify(char *pkcs7_file,
 
     if (do_hash_alg) {
         md_info = mbedtls_md_info_from_type((mbedtls_md_type_t) do_hash_alg);
-        ASSERT_ALLOC(hash, mbedtls_md_get_size(md_info));
+        TEST_CALLOC_OR_FAIL(hash, mbedtls_md_get_size(md_info));
         res = mbedtls_md(md_info, data, datalen, hash);
         TEST_EQUAL(res, 0);
 

--- a/tests/suites/test_suite_pkparse.function
+++ b/tests/suites/test_suite_pkparse.function
@@ -175,7 +175,7 @@ void pk_parse_fix_montgomery(data_t *input_key, data_t *exp_output)
     output_key_len = mbedtls_pk_write_key_der(&pk, output_key, output_key_len);
     TEST_ASSERT(output_key_len > 0);
 
-    TEST_BUFFERS_EQUAL(exp_output->x, exp_output->len, output_key, output_key_len);
+    TEST_MEMORY_COMPARE(exp_output->x, exp_output->len, output_key, output_key_len);
 
 exit:
     if (output_key != NULL) {

--- a/tests/suites/test_suite_pkparse.function
+++ b/tests/suites/test_suite_pkparse.function
@@ -169,7 +169,7 @@ void pk_parse_fix_montgomery(data_t *input_key, data_t *exp_output)
                                     mbedtls_test_rnd_std_rand, NULL), 0);
 
     output_key_len = input_key->len;
-    TEST_CALLOC_OR_FAIL(output_key, output_key_len);
+    TEST_CALLOC(output_key, output_key_len);
     /* output_key_len is updated with the real amount of data written to
      * output_key buffer. */
     output_key_len = mbedtls_pk_write_key_der(&pk, output_key, output_key_len);

--- a/tests/suites/test_suite_pkparse.function
+++ b/tests/suites/test_suite_pkparse.function
@@ -169,7 +169,7 @@ void pk_parse_fix_montgomery(data_t *input_key, data_t *exp_output)
                                     mbedtls_test_rnd_std_rand, NULL), 0);
 
     output_key_len = input_key->len;
-    ASSERT_ALLOC(output_key, output_key_len);
+    TEST_CALLOC_OR_FAIL(output_key, output_key_len);
     /* output_key_len is updated with the real amount of data written to
      * output_key buffer. */
     output_key_len = mbedtls_pk_write_key_der(&pk, output_key, output_key_len);

--- a/tests/suites/test_suite_pkparse.function
+++ b/tests/suites/test_suite_pkparse.function
@@ -175,7 +175,7 @@ void pk_parse_fix_montgomery(data_t *input_key, data_t *exp_output)
     output_key_len = mbedtls_pk_write_key_der(&pk, output_key, output_key_len);
     TEST_ASSERT(output_key_len > 0);
 
-    ASSERT_COMPARE(exp_output->x, exp_output->len, output_key, output_key_len);
+    TEST_BUFFERS_EQUAL(exp_output->x, exp_output->len, output_key, output_key_len);
 
 exit:
     if (output_key != NULL) {

--- a/tests/suites/test_suite_pkwrite.function
+++ b/tests/suites/test_suite_pkwrite.function
@@ -113,7 +113,7 @@ static void pk_write_check_common(char *key_file, int is_public_key, int is_der)
     TEST_EQUAL(pk_write_any_key(&key, &start_buf, &buf_len, is_public_key,
                                 is_der), 0);
 
-    TEST_BUFFERS_EQUAL(start_buf, buf_len, check_buf, check_buf_len);
+    TEST_MEMORY_COMPARE(start_buf, buf_len, check_buf, check_buf_len);
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     /* Verify that pk_write works also for opaque private keys */
@@ -128,7 +128,7 @@ static void pk_write_check_common(char *key_file, int is_public_key, int is_der)
         TEST_EQUAL(pk_write_any_key(&key, &start_buf, &buf_len, is_public_key,
                                     is_der), 0);
 
-        TEST_BUFFERS_EQUAL(start_buf, buf_len, check_buf, check_buf_len);
+        TEST_MEMORY_COMPARE(start_buf, buf_len, check_buf, check_buf_len);
     }
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
@@ -190,7 +190,7 @@ void pk_write_public_from_private(char *priv_key_file, char *pub_key_file)
     TEST_EQUAL(mbedtls_pk_write_pubkey_der(&priv_key, derived_key_raw,
                                            derived_key_len), pub_key_len);
 
-    TEST_BUFFERS_EQUAL(derived_key_raw, derived_key_len,
+    TEST_MEMORY_COMPARE(derived_key_raw, derived_key_len,
                    pub_key_raw, pub_key_len);
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
@@ -203,7 +203,7 @@ void pk_write_public_from_private(char *priv_key_file, char *pub_key_file)
     TEST_EQUAL(mbedtls_pk_write_pubkey_der(&priv_key, derived_key_raw,
                                            derived_key_len), pub_key_len);
 
-    TEST_BUFFERS_EQUAL(derived_key_raw, derived_key_len,
+    TEST_MEMORY_COMPARE(derived_key_raw, derived_key_len,
                    pub_key_raw, pub_key_len);
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 

--- a/tests/suites/test_suite_pkwrite.function
+++ b/tests/suites/test_suite_pkwrite.function
@@ -99,7 +99,7 @@ static void pk_write_check_common(char *key_file, int is_public_key, int is_der)
     }
     TEST_ASSERT(check_buf_len > 0);
 
-    ASSERT_ALLOC(buf, check_buf_len);
+    TEST_CALLOC_OR_FAIL(buf, check_buf_len);
 
     if (is_public_key) {
         TEST_EQUAL(mbedtls_pk_parse_public_keyfile(&key, key_file), 0);
@@ -185,7 +185,7 @@ void pk_write_public_from_private(char *priv_key_file, char *pub_key_file)
                                     &pub_key_len), 0);
 
     derived_key_len = pub_key_len;
-    ASSERT_ALLOC(derived_key_raw, derived_key_len);
+    TEST_CALLOC_OR_FAIL(derived_key_raw, derived_key_len);
 
     TEST_EQUAL(mbedtls_pk_write_pubkey_der(&priv_key, derived_key_raw,
                                            derived_key_len), pub_key_len);

--- a/tests/suites/test_suite_pkwrite.function
+++ b/tests/suites/test_suite_pkwrite.function
@@ -191,7 +191,7 @@ void pk_write_public_from_private(char *priv_key_file, char *pub_key_file)
                                            derived_key_len), pub_key_len);
 
     TEST_MEMORY_COMPARE(derived_key_raw, derived_key_len,
-                   pub_key_raw, pub_key_len);
+                        pub_key_raw, pub_key_len);
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     mbedtls_platform_zeroize(derived_key_raw, sizeof(derived_key_raw));
@@ -204,7 +204,7 @@ void pk_write_public_from_private(char *priv_key_file, char *pub_key_file)
                                            derived_key_len), pub_key_len);
 
     TEST_MEMORY_COMPARE(derived_key_raw, derived_key_len,
-                   pub_key_raw, pub_key_len);
+                        pub_key_raw, pub_key_len);
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 exit:

--- a/tests/suites/test_suite_pkwrite.function
+++ b/tests/suites/test_suite_pkwrite.function
@@ -99,7 +99,7 @@ static void pk_write_check_common(char *key_file, int is_public_key, int is_der)
     }
     TEST_ASSERT(check_buf_len > 0);
 
-    TEST_CALLOC_OR_FAIL(buf, check_buf_len);
+    TEST_CALLOC(buf, check_buf_len);
 
     if (is_public_key) {
         TEST_EQUAL(mbedtls_pk_parse_public_keyfile(&key, key_file), 0);
@@ -185,7 +185,7 @@ void pk_write_public_from_private(char *priv_key_file, char *pub_key_file)
                                     &pub_key_len), 0);
 
     derived_key_len = pub_key_len;
-    TEST_CALLOC_OR_FAIL(derived_key_raw, derived_key_len);
+    TEST_CALLOC(derived_key_raw, derived_key_len);
 
     TEST_EQUAL(mbedtls_pk_write_pubkey_der(&priv_key, derived_key_raw,
                                            derived_key_len), pub_key_len);

--- a/tests/suites/test_suite_pkwrite.function
+++ b/tests/suites/test_suite_pkwrite.function
@@ -113,7 +113,7 @@ static void pk_write_check_common(char *key_file, int is_public_key, int is_der)
     TEST_EQUAL(pk_write_any_key(&key, &start_buf, &buf_len, is_public_key,
                                 is_der), 0);
 
-    ASSERT_COMPARE(start_buf, buf_len, check_buf, check_buf_len);
+    TEST_BUFFERS_EQUAL(start_buf, buf_len, check_buf, check_buf_len);
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     /* Verify that pk_write works also for opaque private keys */
@@ -128,7 +128,7 @@ static void pk_write_check_common(char *key_file, int is_public_key, int is_der)
         TEST_EQUAL(pk_write_any_key(&key, &start_buf, &buf_len, is_public_key,
                                     is_der), 0);
 
-        ASSERT_COMPARE(start_buf, buf_len, check_buf, check_buf_len);
+        TEST_BUFFERS_EQUAL(start_buf, buf_len, check_buf, check_buf_len);
     }
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
@@ -190,7 +190,7 @@ void pk_write_public_from_private(char *priv_key_file, char *pub_key_file)
     TEST_EQUAL(mbedtls_pk_write_pubkey_der(&priv_key, derived_key_raw,
                                            derived_key_len), pub_key_len);
 
-    ASSERT_COMPARE(derived_key_raw, derived_key_len,
+    TEST_BUFFERS_EQUAL(derived_key_raw, derived_key_len,
                    pub_key_raw, pub_key_len);
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
@@ -203,7 +203,7 @@ void pk_write_public_from_private(char *priv_key_file, char *pub_key_file)
     TEST_EQUAL(mbedtls_pk_write_pubkey_der(&priv_key, derived_key_raw,
                                            derived_key_len), pub_key_len);
 
-    ASSERT_COMPARE(derived_key_raw, derived_key_len,
+    TEST_BUFFERS_EQUAL(derived_key_raw, derived_key_len,
                    pub_key_raw, pub_key_len);
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 

--- a/tests/suites/test_suite_platform_printf.function
+++ b/tests/suites/test_suite_platform_printf.function
@@ -34,7 +34,7 @@ void printf_int(char *format, /* any format expecting one int argument, e.g. "%d
     /* Nominal case: buffer just large enough */
     ASSERT_ALLOC(output, n + 1);
     TEST_EQUAL(n, mbedtls_snprintf(output, n + 1, format, x));
-    ASSERT_COMPARE(result, n + 1, output, n + 1);
+    TEST_BUFFERS_EQUAL(result, n + 1, output, n + 1);
     mbedtls_free(output);
     output = NULL;
 
@@ -59,7 +59,7 @@ void printf_long_max(const char *format, /* "%lx" or longer type */
 
     ASSERT_ALLOC(output, n + 1);
     TEST_EQUAL(n, mbedtls_snprintf(output, n + 1, format, value));
-    ASSERT_COMPARE(expected, n + 1, output, n + 1);
+    TEST_BUFFERS_EQUAL(expected, n + 1, output, n + 1);
     mbedtls_free(output);
     output = NULL;
 
@@ -79,7 +79,7 @@ void printf_char2(char *format, /* "%c%c" */
     /* Nominal case: buffer just large enough */
     ASSERT_ALLOC(output, n + 1);
     TEST_EQUAL(n, mbedtls_snprintf(output, n + 1, format, arg1, arg2));
-    ASSERT_COMPARE(result, n + 1, output, n + 1);
+    TEST_BUFFERS_EQUAL(result, n + 1, output, n + 1);
     mbedtls_free(output);
     output = NULL;
 

--- a/tests/suites/test_suite_platform_printf.function
+++ b/tests/suites/test_suite_platform_printf.function
@@ -32,7 +32,7 @@ void printf_int(char *format, /* any format expecting one int argument, e.g. "%d
     const size_t n = strlen(result);
 
     /* Nominal case: buffer just large enough */
-    TEST_CALLOC_OR_FAIL(output, n + 1);
+    TEST_CALLOC(output, n + 1);
     TEST_EQUAL(n, mbedtls_snprintf(output, n + 1, format, x));
     TEST_BUFFERS_EQUAL(result, n + 1, output, n + 1);
     mbedtls_free(output);
@@ -53,11 +53,11 @@ void printf_long_max(const char *format, /* "%lx" or longer type */
     const size_t n = sizeof(value) * 2;
 
     /* We assume that long has no padding bits! */
-    TEST_CALLOC_OR_FAIL(expected, n + 1);
+    TEST_CALLOC(expected, n + 1);
     expected[0] = '7';
     memset(expected + 1, 'f', sizeof(value) * 2 - 1);
 
-    TEST_CALLOC_OR_FAIL(output, n + 1);
+    TEST_CALLOC(output, n + 1);
     TEST_EQUAL(n, mbedtls_snprintf(output, n + 1, format, value));
     TEST_BUFFERS_EQUAL(expected, n + 1, output, n + 1);
     mbedtls_free(output);
@@ -77,7 +77,7 @@ void printf_char2(char *format, /* "%c%c" */
     const size_t n = strlen(result);
 
     /* Nominal case: buffer just large enough */
-    TEST_CALLOC_OR_FAIL(output, n + 1);
+    TEST_CALLOC(output, n + 1);
     TEST_EQUAL(n, mbedtls_snprintf(output, n + 1, format, arg1, arg2));
     TEST_BUFFERS_EQUAL(result, n + 1, output, n + 1);
     mbedtls_free(output);

--- a/tests/suites/test_suite_platform_printf.function
+++ b/tests/suites/test_suite_platform_printf.function
@@ -32,7 +32,7 @@ void printf_int(char *format, /* any format expecting one int argument, e.g. "%d
     const size_t n = strlen(result);
 
     /* Nominal case: buffer just large enough */
-    ASSERT_ALLOC(output, n + 1);
+    TEST_CALLOC_OR_FAIL(output, n + 1);
     TEST_EQUAL(n, mbedtls_snprintf(output, n + 1, format, x));
     TEST_BUFFERS_EQUAL(result, n + 1, output, n + 1);
     mbedtls_free(output);
@@ -53,11 +53,11 @@ void printf_long_max(const char *format, /* "%lx" or longer type */
     const size_t n = sizeof(value) * 2;
 
     /* We assume that long has no padding bits! */
-    ASSERT_ALLOC(expected, n + 1);
+    TEST_CALLOC_OR_FAIL(expected, n + 1);
     expected[0] = '7';
     memset(expected + 1, 'f', sizeof(value) * 2 - 1);
 
-    ASSERT_ALLOC(output, n + 1);
+    TEST_CALLOC_OR_FAIL(output, n + 1);
     TEST_EQUAL(n, mbedtls_snprintf(output, n + 1, format, value));
     TEST_BUFFERS_EQUAL(expected, n + 1, output, n + 1);
     mbedtls_free(output);
@@ -77,7 +77,7 @@ void printf_char2(char *format, /* "%c%c" */
     const size_t n = strlen(result);
 
     /* Nominal case: buffer just large enough */
-    ASSERT_ALLOC(output, n + 1);
+    TEST_CALLOC_OR_FAIL(output, n + 1);
     TEST_EQUAL(n, mbedtls_snprintf(output, n + 1, format, arg1, arg2));
     TEST_BUFFERS_EQUAL(result, n + 1, output, n + 1);
     mbedtls_free(output);

--- a/tests/suites/test_suite_platform_printf.function
+++ b/tests/suites/test_suite_platform_printf.function
@@ -34,7 +34,7 @@ void printf_int(char *format, /* any format expecting one int argument, e.g. "%d
     /* Nominal case: buffer just large enough */
     TEST_CALLOC(output, n + 1);
     TEST_EQUAL(n, mbedtls_snprintf(output, n + 1, format, x));
-    TEST_BUFFERS_EQUAL(result, n + 1, output, n + 1);
+    TEST_MEMORY_COMPARE(result, n + 1, output, n + 1);
     mbedtls_free(output);
     output = NULL;
 
@@ -59,7 +59,7 @@ void printf_long_max(const char *format, /* "%lx" or longer type */
 
     TEST_CALLOC(output, n + 1);
     TEST_EQUAL(n, mbedtls_snprintf(output, n + 1, format, value));
-    TEST_BUFFERS_EQUAL(expected, n + 1, output, n + 1);
+    TEST_MEMORY_COMPARE(expected, n + 1, output, n + 1);
     mbedtls_free(output);
     output = NULL;
 
@@ -79,7 +79,7 @@ void printf_char2(char *format, /* "%c%c" */
     /* Nominal case: buffer just large enough */
     TEST_CALLOC(output, n + 1);
     TEST_EQUAL(n, mbedtls_snprintf(output, n + 1, format, arg1, arg2));
-    TEST_BUFFERS_EQUAL(result, n + 1, output, n + 1);
+    TEST_MEMORY_COMPARE(result, n + 1, output, n + 1);
     mbedtls_free(output);
     output = NULL;
 

--- a/tests/suites/test_suite_poly1305.function
+++ b/tests/suites/test_suite_poly1305.function
@@ -22,7 +22,7 @@ void mbedtls_poly1305(data_t *key, data_t *expected_mac, data_t *src_str)
     TEST_ASSERT(mbedtls_poly1305_mac(key->x, src_str->x,
                                      src_str->len, mac) == 0);
 
-    TEST_BUFFERS_EQUAL(mac, expected_mac->len,
+    TEST_MEMORY_COMPARE(mac, expected_mac->len,
                    expected_mac->x, expected_mac->len);
 
     /*
@@ -36,7 +36,7 @@ void mbedtls_poly1305(data_t *key, data_t *expected_mac, data_t *src_str)
 
     TEST_ASSERT(mbedtls_poly1305_finish(&ctx, mac) == 0);
 
-    TEST_BUFFERS_EQUAL(mac, expected_mac->len,
+    TEST_MEMORY_COMPARE(mac, expected_mac->len,
                    expected_mac->x, expected_mac->len);
 
     /*
@@ -53,7 +53,7 @@ void mbedtls_poly1305(data_t *key, data_t *expected_mac, data_t *src_str)
 
         TEST_ASSERT(mbedtls_poly1305_finish(&ctx, mac) == 0);
 
-        TEST_BUFFERS_EQUAL(mac, expected_mac->len,
+        TEST_MEMORY_COMPARE(mac, expected_mac->len,
                        expected_mac->x, expected_mac->len);
     }
 
@@ -69,7 +69,7 @@ void mbedtls_poly1305(data_t *key, data_t *expected_mac, data_t *src_str)
 
         TEST_ASSERT(mbedtls_poly1305_finish(&ctx, mac) == 0);
 
-        TEST_BUFFERS_EQUAL(mac, expected_mac->len,
+        TEST_MEMORY_COMPARE(mac, expected_mac->len,
                        expected_mac->x, expected_mac->len);
     }
 

--- a/tests/suites/test_suite_poly1305.function
+++ b/tests/suites/test_suite_poly1305.function
@@ -22,7 +22,7 @@ void mbedtls_poly1305(data_t *key, data_t *expected_mac, data_t *src_str)
     TEST_ASSERT(mbedtls_poly1305_mac(key->x, src_str->x,
                                      src_str->len, mac) == 0);
 
-    ASSERT_COMPARE(mac, expected_mac->len,
+    TEST_BUFFERS_EQUAL(mac, expected_mac->len,
                    expected_mac->x, expected_mac->len);
 
     /*
@@ -36,7 +36,7 @@ void mbedtls_poly1305(data_t *key, data_t *expected_mac, data_t *src_str)
 
     TEST_ASSERT(mbedtls_poly1305_finish(&ctx, mac) == 0);
 
-    ASSERT_COMPARE(mac, expected_mac->len,
+    TEST_BUFFERS_EQUAL(mac, expected_mac->len,
                    expected_mac->x, expected_mac->len);
 
     /*
@@ -53,7 +53,7 @@ void mbedtls_poly1305(data_t *key, data_t *expected_mac, data_t *src_str)
 
         TEST_ASSERT(mbedtls_poly1305_finish(&ctx, mac) == 0);
 
-        ASSERT_COMPARE(mac, expected_mac->len,
+        TEST_BUFFERS_EQUAL(mac, expected_mac->len,
                        expected_mac->x, expected_mac->len);
     }
 
@@ -69,7 +69,7 @@ void mbedtls_poly1305(data_t *key, data_t *expected_mac, data_t *src_str)
 
         TEST_ASSERT(mbedtls_poly1305_finish(&ctx, mac) == 0);
 
-        ASSERT_COMPARE(mac, expected_mac->len,
+        TEST_BUFFERS_EQUAL(mac, expected_mac->len,
                        expected_mac->x, expected_mac->len);
     }
 

--- a/tests/suites/test_suite_poly1305.function
+++ b/tests/suites/test_suite_poly1305.function
@@ -23,7 +23,7 @@ void mbedtls_poly1305(data_t *key, data_t *expected_mac, data_t *src_str)
                                      src_str->len, mac) == 0);
 
     TEST_MEMORY_COMPARE(mac, expected_mac->len,
-                   expected_mac->x, expected_mac->len);
+                        expected_mac->x, expected_mac->len);
 
     /*
      * Test the streaming API
@@ -37,7 +37,7 @@ void mbedtls_poly1305(data_t *key, data_t *expected_mac, data_t *src_str)
     TEST_ASSERT(mbedtls_poly1305_finish(&ctx, mac) == 0);
 
     TEST_MEMORY_COMPARE(mac, expected_mac->len,
-                   expected_mac->x, expected_mac->len);
+                        expected_mac->x, expected_mac->len);
 
     /*
      * Test the streaming API again, piecewise
@@ -54,7 +54,7 @@ void mbedtls_poly1305(data_t *key, data_t *expected_mac, data_t *src_str)
         TEST_ASSERT(mbedtls_poly1305_finish(&ctx, mac) == 0);
 
         TEST_MEMORY_COMPARE(mac, expected_mac->len,
-                       expected_mac->x, expected_mac->len);
+                            expected_mac->x, expected_mac->len);
     }
 
     /*
@@ -70,7 +70,7 @@ void mbedtls_poly1305(data_t *key, data_t *expected_mac, data_t *src_str)
         TEST_ASSERT(mbedtls_poly1305_finish(&ctx, mac) == 0);
 
         TEST_MEMORY_COMPARE(mac, expected_mac->len,
-                       expected_mac->x, expected_mac->len);
+                            expected_mac->x, expected_mac->len);
     }
 
     mbedtls_poly1305_free(&ctx);

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -1410,7 +1410,7 @@ void import_large_key(int type_arg, int byte_size_arg,
 
     /* Skip the test case if the target running the test cannot
      * accommodate large keys due to heap size constraints */
-    ASSERT_ALLOC_WEAK(buffer, buffer_size);
+    TEST_CALLOC_OR_SKIP(buffer, buffer_size);
     memset(buffer, 'K', byte_size);
 
     PSA_ASSERT(psa_crypto_init());

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -583,7 +583,7 @@ static int aead_multipart_internal_func(int key_type_arg, data_t *key_data,
     }
 
 
-    TEST_BUFFERS_EQUAL(expected_output->x, expected_output->len,
+    TEST_MEMORY_COMPARE(expected_output->x, expected_output->len,
                    output_data, output_length);
 
 
@@ -692,7 +692,7 @@ static int mac_multipart_internal_func(int key_type_arg, data_t *key_data,
         PSA_ASSERT(psa_mac_sign_finish(&operation, mac,
                                        PSA_MAC_MAX_SIZE, &mac_len));
 
-        TEST_BUFFERS_EQUAL(expected_output->x, expected_output->len,
+        TEST_MEMORY_COMPARE(expected_output->x, expected_output->len,
                        mac, mac_len);
     }
 
@@ -1574,7 +1574,7 @@ void import_export(data_t *data,
     }
 
     if (canonical_input) {
-        TEST_BUFFERS_EQUAL(data->x, data->len, exported, exported_length);
+        TEST_MEMORY_COMPARE(data->x, data->len, exported, exported_length);
     } else {
         mbedtls_svc_key_id_t key2 = MBEDTLS_SVC_KEY_ID_INIT;
         PSA_ASSERT(psa_import_key(&attributes, exported, exported_length,
@@ -1583,7 +1583,7 @@ void import_export(data_t *data,
                                   reexported,
                                   export_size,
                                   &reexported_length));
-        TEST_BUFFERS_EQUAL(exported, exported_length,
+        TEST_MEMORY_COMPARE(exported, exported_length,
                        reexported, reexported_length);
         PSA_ASSERT(psa_destroy_key(key2));
     }
@@ -1657,7 +1657,7 @@ void import_export_public_key(data_t *data,
                   PSA_EXPORT_PUBLIC_KEY_OUTPUT_SIZE(public_type, bits));
         TEST_LE_U(expected_public_key->len,
                   PSA_EXPORT_PUBLIC_KEY_MAX_SIZE);
-        TEST_BUFFERS_EQUAL(expected_public_key->x, expected_public_key->len,
+        TEST_MEMORY_COMPARE(expected_public_key->x, expected_public_key->len,
                        exported, exported_length);
     }
 exit:
@@ -2501,7 +2501,7 @@ void copy_success(int source_usage_arg,
         TEST_CALLOC(export_buffer, material->len);
         PSA_ASSERT(psa_export_key(target_key, export_buffer,
                                   material->len, &length));
-        TEST_BUFFERS_EQUAL(material->x, material->len,
+        TEST_MEMORY_COMPARE(material->x, material->len,
                        export_buffer, length);
     }
 
@@ -2760,7 +2760,7 @@ void hash_compute_compare(int alg_arg, data_t *input,
                                 output, PSA_HASH_LENGTH(alg),
                                 &output_length));
     TEST_EQUAL(output_length, PSA_HASH_LENGTH(alg));
-    TEST_BUFFERS_EQUAL(output, output_length,
+    TEST_MEMORY_COMPARE(output, output_length,
                    expected_output->x, expected_output->len);
 
     /* Compute with tight buffer, multi-part */
@@ -2770,7 +2770,7 @@ void hash_compute_compare(int alg_arg, data_t *input,
                                PSA_HASH_LENGTH(alg),
                                &output_length));
     TEST_EQUAL(output_length, PSA_HASH_LENGTH(alg));
-    TEST_BUFFERS_EQUAL(output, output_length,
+    TEST_MEMORY_COMPARE(output, output_length,
                    expected_output->x, expected_output->len);
 
     /* Compute with larger buffer, one-shot */
@@ -2778,7 +2778,7 @@ void hash_compute_compare(int alg_arg, data_t *input,
                                 output, sizeof(output),
                                 &output_length));
     TEST_EQUAL(output_length, PSA_HASH_LENGTH(alg));
-    TEST_BUFFERS_EQUAL(output, output_length,
+    TEST_MEMORY_COMPARE(output, output_length,
                    expected_output->x, expected_output->len);
 
     /* Compute with larger buffer, multi-part */
@@ -2787,7 +2787,7 @@ void hash_compute_compare(int alg_arg, data_t *input,
     PSA_ASSERT(psa_hash_finish(&operation, output,
                                sizeof(output), &output_length));
     TEST_EQUAL(output_length, PSA_HASH_LENGTH(alg));
-    TEST_BUFFERS_EQUAL(output, output_length,
+    TEST_MEMORY_COMPARE(output, output_length,
                    expected_output->x, expected_output->len);
 
     /* Compare with correct hash, one-shot */
@@ -3392,7 +3392,7 @@ void mac_sign(int key_type_arg,
                                    actual_mac, output_size, &mac_length),
                    expected_status);
         if (expected_status == PSA_SUCCESS) {
-            TEST_BUFFERS_EQUAL(expected_mac->x, expected_mac->len,
+            TEST_MEMORY_COMPARE(expected_mac->x, expected_mac->len,
                            actual_mac, mac_length);
         }
 
@@ -3411,7 +3411,7 @@ void mac_sign(int key_type_arg,
         PSA_ASSERT(psa_mac_abort(&operation));
 
         if (expected_status == PSA_SUCCESS) {
-            TEST_BUFFERS_EQUAL(expected_mac->x, expected_mac->len,
+            TEST_MEMORY_COMPARE(expected_mac->x, expected_mac->len,
                            actual_mac, mac_length);
         }
         mbedtls_free(actual_mac);
@@ -3962,7 +3962,7 @@ void cipher_alg_without_iv(int alg_arg, int key_type_arg, data_t *key_data,
                                  output_buffer_size - output_length,
                                  &length));
     output_length += length;
-    TEST_BUFFERS_EQUAL(ciphertext->x, ciphertext->len,
+    TEST_MEMORY_COMPARE(ciphertext->x, ciphertext->len,
                    output, output_length);
 
     /* Multipart encryption */
@@ -3980,7 +3980,7 @@ void cipher_alg_without_iv(int alg_arg, int key_type_arg, data_t *key_data,
                                  output_buffer_size - output_length,
                                  &length));
     output_length += length;
-    TEST_BUFFERS_EQUAL(plaintext->x, plaintext->len,
+    TEST_MEMORY_COMPARE(plaintext->x, plaintext->len,
                    output, output_length);
 
     /* One-shot encryption */
@@ -3988,7 +3988,7 @@ void cipher_alg_without_iv(int alg_arg, int key_type_arg, data_t *key_data,
     PSA_ASSERT(psa_cipher_encrypt(key, alg, plaintext->x, plaintext->len,
                                   output, output_buffer_size,
                                   &output_length));
-    TEST_BUFFERS_EQUAL(ciphertext->x, ciphertext->len,
+    TEST_MEMORY_COMPARE(ciphertext->x, ciphertext->len,
                    output, output_length);
 
     /* One-shot decryption */
@@ -3996,7 +3996,7 @@ void cipher_alg_without_iv(int alg_arg, int key_type_arg, data_t *key_data,
     PSA_ASSERT(psa_cipher_decrypt(key, alg, ciphertext->x, ciphertext->len,
                                   output, output_buffer_size,
                                   &output_length));
-    TEST_BUFFERS_EQUAL(plaintext->x, plaintext->len,
+    TEST_MEMORY_COMPARE(plaintext->x, plaintext->len,
                    output, output_length);
 
 exit:
@@ -4116,7 +4116,7 @@ void cipher_encrypt_validation(int alg_arg,
     output2_length += function_output_length;
 
     PSA_ASSERT(psa_cipher_abort(&operation));
-    TEST_BUFFERS_EQUAL(output1 + iv_size, output1_length - iv_size,
+    TEST_MEMORY_COMPARE(output1 + iv_size, output1_length - iv_size,
                    output2, output2_length);
 
 exit:
@@ -4215,7 +4215,7 @@ void cipher_encrypt_multipart(int alg_arg, int key_type_arg,
     if (expected_status == PSA_SUCCESS) {
         PSA_ASSERT(psa_cipher_abort(&operation));
 
-        TEST_BUFFERS_EQUAL(expected_output->x, expected_output->len,
+        TEST_MEMORY_COMPARE(expected_output->x, expected_output->len,
                        output, total_output_length);
     }
 
@@ -4315,7 +4315,7 @@ void cipher_decrypt_multipart(int alg_arg, int key_type_arg,
     if (expected_status == PSA_SUCCESS) {
         PSA_ASSERT(psa_cipher_abort(&operation));
 
-        TEST_BUFFERS_EQUAL(expected_output->x, expected_output->len,
+        TEST_MEMORY_COMPARE(expected_output->x, expected_output->len,
                        output, total_output_length);
     }
 
@@ -4472,7 +4472,7 @@ void cipher_decrypt(int alg_arg,
     TEST_LE_U(output_length,
               PSA_CIPHER_DECRYPT_OUTPUT_MAX_SIZE(input_buffer_size));
 
-    TEST_BUFFERS_EQUAL(expected_output->x, expected_output->len,
+    TEST_MEMORY_COMPARE(expected_output->x, expected_output->len,
                    output, output_length);
 exit:
     mbedtls_free(input);
@@ -4529,7 +4529,7 @@ void cipher_verify_output(int alg_arg,
     TEST_LE_U(output2_length,
               PSA_CIPHER_DECRYPT_OUTPUT_MAX_SIZE(output1_length));
 
-    TEST_BUFFERS_EQUAL(input->x, input->len, output2, output2_length);
+    TEST_MEMORY_COMPARE(input->x, input->len, output2, output2_length);
 
 exit:
     mbedtls_free(output1);
@@ -4669,7 +4669,7 @@ void cipher_verify_output_multipart(int alg_arg,
 
     PSA_ASSERT(psa_cipher_abort(&operation2));
 
-    TEST_BUFFERS_EQUAL(input->x, input->len, output2, output2_length);
+    TEST_MEMORY_COMPARE(input->x, input->len, output2, output2_length);
 
 exit:
     psa_cipher_abort(&operation1);
@@ -4764,7 +4764,7 @@ void aead_encrypt_decrypt(int key_type_arg, data_t *key_data,
                                     &output_length2),
                    expected_result);
 
-        TEST_BUFFERS_EQUAL(input_data->x, input_data->len,
+        TEST_MEMORY_COMPARE(input_data->x, input_data->len,
                        output_data2, output_length2);
     }
 
@@ -4831,7 +4831,7 @@ void aead_encrypt(int key_type_arg, data_t *key_data,
     }
 
     PSA_ASSERT(status);
-    TEST_BUFFERS_EQUAL(expected_result->x, expected_result->len,
+    TEST_MEMORY_COMPARE(expected_result->x, expected_result->len,
                    output_data, output_length);
 
 exit:
@@ -4904,7 +4904,7 @@ void aead_decrypt(int key_type_arg, data_t *key_data,
     TEST_EQUAL(status, expected_result);
 
     if (expected_result == PSA_SUCCESS) {
-        TEST_BUFFERS_EQUAL(expected_data->x, expected_data->len,
+        TEST_MEMORY_COMPARE(expected_data->x, expected_data->len,
                        output_data, output_length);
     }
 
@@ -6491,7 +6491,7 @@ void sign_hash_deterministic(int key_type_arg, data_t *key_data,
                              signature, signature_size,
                              &signature_length));
     /* Verify that the signature is what is expected. */
-    TEST_BUFFERS_EQUAL(output_data->x, output_data->len,
+    TEST_MEMORY_COMPARE(output_data->x, output_data->len,
                    signature, signature_length);
 
 exit:
@@ -6614,7 +6614,7 @@ void sign_hash_interruptible(int key_type_arg, data_t *key_data,
     TEST_LE_U(num_completes, max_completes);
 
     /* Verify that the signature is what is expected. */
-    TEST_BUFFERS_EQUAL(output_data->x, output_data->len,
+    TEST_MEMORY_COMPARE(output_data->x, output_data->len,
                    signature, signature_length);
 
     PSA_ASSERT(psa_sign_hash_abort(&operation));
@@ -7912,7 +7912,7 @@ void sign_message_deterministic(int key_type_arg,
                                 signature, signature_size,
                                 &signature_length));
 
-    TEST_BUFFERS_EQUAL(output_data->x, output_data->len,
+    TEST_MEMORY_COMPARE(output_data->x, output_data->len,
                    signature, signature_length);
 
 exit:
@@ -8250,7 +8250,7 @@ void asymmetric_encrypt_decrypt(int key_type_arg,
                                       label->x, label->len,
                                       output2, output2_size,
                                       &output2_length));
-    TEST_BUFFERS_EQUAL(input_data->x, input_data->len,
+    TEST_MEMORY_COMPARE(input_data->x, input_data->len,
                    output2, output2_length);
 
 exit:
@@ -8307,7 +8307,7 @@ void asymmetric_decrypt(int key_type_arg,
                                       output,
                                       output_size,
                                       &output_length));
-    TEST_BUFFERS_EQUAL(expected_data->x, expected_data->len,
+    TEST_MEMORY_COMPARE(expected_data->x, expected_data->len,
                    output, output_length);
 
     /* If the label is empty, the test framework puts a non-null pointer
@@ -8323,7 +8323,7 @@ void asymmetric_decrypt(int key_type_arg,
                                           output,
                                           output_size,
                                           &output_length));
-        TEST_BUFFERS_EQUAL(expected_data->x, expected_data->len,
+        TEST_MEMORY_COMPARE(expected_data->x, expected_data->len,
                        output, output_length);
     }
 
@@ -8892,7 +8892,7 @@ void derive_output(int alg_arg,
             /* Success. Check the read data. */
             PSA_ASSERT(status);
             if (output_sizes[i] != 0) {
-                TEST_BUFFERS_EQUAL(output_buffer, output_sizes[i],
+                TEST_MEMORY_COMPARE(output_buffer, output_sizes[i],
                                expected_outputs[i], output_sizes[i]);
             }
             /* Check the operation status. */
@@ -9015,7 +9015,7 @@ void derive_ecjpake_to_pms(data_t *input, int expected_input_status_arg,
 
     TEST_EQUAL(status, expected_output_status);
     if (expected_output->len != 0 && expected_output_status == PSA_SUCCESS) {
-        TEST_BUFFERS_EQUAL(output_buffer, expected_output->len, expected_output->x,
+        TEST_MEMORY_COMPARE(output_buffer, expected_output->len, expected_output->x,
                        expected_output->len);
     }
 
@@ -9167,7 +9167,7 @@ void derive_key_export(int alg_arg,
     TEST_EQUAL(length, bytes2);
 
     /* Compare the outputs from the two runs. */
-    TEST_BUFFERS_EQUAL(output_buffer, bytes1 + bytes2,
+    TEST_MEMORY_COMPARE(output_buffer, bytes1 + bytes2,
                    export_buffer, capacity);
 
 exit:
@@ -9228,7 +9228,7 @@ void derive_key_type(int alg_arg,
     PSA_ASSERT(psa_export_key(derived_key,
                               export_buffer, export_buffer_size,
                               &export_length));
-    TEST_BUFFERS_EQUAL(export_buffer, export_length,
+    TEST_MEMORY_COMPARE(export_buffer, export_length,
                    expected_export->x, expected_export->len);
 
 exit:
@@ -9378,7 +9378,7 @@ void raw_key_agreement(int alg_arg,
                                      peer_key_data->x, peer_key_data->len,
                                      output, expected_output->len,
                                      &output_length));
-    TEST_BUFFERS_EQUAL(output, output_length,
+    TEST_MEMORY_COMPARE(output, output_length,
                    expected_output->x, expected_output->len);
     mbedtls_free(output);
     output = NULL;
@@ -9390,7 +9390,7 @@ void raw_key_agreement(int alg_arg,
                                      peer_key_data->x, peer_key_data->len,
                                      output, expected_output->len + 1,
                                      &output_length));
-    TEST_BUFFERS_EQUAL(output, output_length,
+    TEST_MEMORY_COMPARE(output, output_length,
                    expected_output->x, expected_output->len);
     mbedtls_free(output);
     output = NULL;
@@ -9513,13 +9513,13 @@ void key_agreement_output(int alg_arg,
     PSA_ASSERT(psa_key_derivation_output_bytes(&operation,
                                                actual_output,
                                                expected_output1->len));
-    TEST_BUFFERS_EQUAL(actual_output, expected_output1->len,
+    TEST_MEMORY_COMPARE(actual_output, expected_output1->len,
                    expected_output1->x, expected_output1->len);
     if (expected_output2->len != 0) {
         PSA_ASSERT(psa_key_derivation_output_bytes(&operation,
                                                    actual_output,
                                                    expected_output2->len));
-        TEST_BUFFERS_EQUAL(actual_output, expected_output2->len,
+        TEST_MEMORY_COMPARE(actual_output, expected_output2->len,
                        expected_output2->x, expected_output2->len);
     }
 
@@ -9688,7 +9688,7 @@ void generate_key_rsa(int bits_arg,
     if (is_default_public_exponent) {
         TEST_EQUAL(e_read_length, 0);
     } else {
-        TEST_BUFFERS_EQUAL(e_read_buffer, e_read_length, e_arg->x, e_arg->len);
+        TEST_MEMORY_COMPARE(e_read_buffer, e_read_length, e_arg->x, e_arg->len);
     }
 
     /* Do something with the key according to its type and permitted usage. */
@@ -9724,7 +9724,7 @@ void generate_key_rsa(int bits_arg,
             TEST_EQUAL(p[1], 0);
             TEST_EQUAL(p[2], 1);
         } else {
-            TEST_BUFFERS_EQUAL(p, len, e_arg->x, e_arg->len);
+            TEST_MEMORY_COMPARE(p, len, e_arg->x, e_arg->len);
         }
     }
 
@@ -9833,7 +9833,7 @@ void persistent_key_load_key_from_storage(data_t *data,
                                   first_export, export_size,
                                   &first_exported_length));
         if (generation_method == IMPORT_KEY) {
-            TEST_BUFFERS_EQUAL(data->x, data->len,
+            TEST_MEMORY_COMPARE(data->x, data->len,
                            first_export, first_exported_length);
         }
     }
@@ -9860,7 +9860,7 @@ void persistent_key_load_key_from_storage(data_t *data,
         PSA_ASSERT(psa_export_key(key,
                                   second_export, export_size,
                                   &second_exported_length));
-        TEST_BUFFERS_EQUAL(first_export, first_exported_length,
+        TEST_MEMORY_COMPARE(first_export, first_exported_length,
                        second_export, second_exported_length);
     }
 

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -429,7 +429,7 @@ static int aead_multipart_internal_func(int key_type_arg, data_t *key_data,
         data_true_size = input_data->len - tag_length;
     }
 
-    ASSERT_ALLOC(output_data, output_size);
+    TEST_CALLOC_OR_FAIL(output_data, output_size);
 
     if (is_encrypt) {
         final_output_size = PSA_AEAD_FINISH_OUTPUT_SIZE(key_type, alg);
@@ -439,7 +439,7 @@ static int aead_multipart_internal_func(int key_type_arg, data_t *key_data,
         TEST_LE_U(final_output_size, PSA_AEAD_VERIFY_OUTPUT_MAX_SIZE);
     }
 
-    ASSERT_ALLOC(final_data, final_output_size);
+    TEST_CALLOC_OR_FAIL(final_data, final_output_size);
 
     if (is_encrypt) {
         status = psa_aead_encrypt_setup(&operation, key, alg);
@@ -502,7 +502,7 @@ static int aead_multipart_internal_func(int key_type_arg, data_t *key_data,
         part_data_size = PSA_AEAD_UPDATE_OUTPUT_SIZE(key_type, alg,
                                                      (size_t) data_part_len);
 
-        ASSERT_ALLOC(part_data, part_data_size);
+        TEST_CALLOC_OR_FAIL(part_data, part_data_size);
 
         for (part_offset = 0, part_count = 0;
              part_offset < data_true_size;
@@ -744,8 +744,8 @@ static void ecjpake_do_round(psa_algorithm_t alg, unsigned int primitive,
     psa_status_t expected_status = PSA_SUCCESS;
     psa_status_t status;
 
-    ASSERT_ALLOC(buffer0, buffer_length);
-    ASSERT_ALLOC(buffer1, buffer_length);
+    TEST_CALLOC_OR_FAIL(buffer0, buffer_length);
+    TEST_CALLOC_OR_FAIL(buffer1, buffer_length);
 
     switch (round) {
         case 1:
@@ -1472,7 +1472,7 @@ void import_rsa_made_up(int bits_arg, int keypair, int expected_status_arg)
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
 
     PSA_ASSERT(psa_crypto_init());
-    ASSERT_ALLOC(buffer, buffer_size);
+    TEST_CALLOC_OR_FAIL(buffer, buffer_size);
 
     TEST_ASSERT((ret = construct_fake_rsa_key(buffer, buffer_size, &p,
                                               bits, keypair)) >= 0);
@@ -1519,9 +1519,9 @@ void import_export(data_t *data,
     psa_key_attributes_t got_attributes = PSA_KEY_ATTRIBUTES_INIT;
 
     export_size = (ptrdiff_t) data->len + export_size_delta;
-    ASSERT_ALLOC(exported, export_size);
+    TEST_CALLOC_OR_FAIL(exported, export_size);
     if (!canonical_input) {
-        ASSERT_ALLOC(reexported, export_size);
+        TEST_CALLOC_OR_FAIL(reexported, export_size);
     }
     PSA_ASSERT(psa_crypto_init());
 
@@ -1641,7 +1641,7 @@ void import_export_public_key(data_t *data,
     PSA_ASSERT(psa_import_key(&attributes, data->x, data->len, &key));
 
     /* Export the public key */
-    ASSERT_ALLOC(exported, export_size);
+    TEST_CALLOC_OR_FAIL(exported, export_size);
     status = psa_export_public_key(key,
                                    exported, export_size,
                                    &exported_length);
@@ -1938,8 +1938,8 @@ void cipher_key_policy(int policy_usage_arg,
     output_buffer_size = PSA_CIPHER_ENCRYPT_OUTPUT_SIZE(key_type, exercise_alg,
                                                         input_buffer_size);
 
-    ASSERT_ALLOC(input, input_buffer_size);
-    ASSERT_ALLOC(output, output_buffer_size);
+    TEST_CALLOC_OR_FAIL(input, input_buffer_size);
+    TEST_CALLOC_OR_FAIL(output, output_buffer_size);
 
     PSA_ASSERT(psa_crypto_init());
 
@@ -2128,7 +2128,7 @@ void asymmetric_encryption_key_policy(int policy_usage_arg,
     key_bits = psa_get_key_bits(&attributes);
     buffer_length = PSA_ASYMMETRIC_ENCRYPT_OUTPUT_SIZE(key_type, key_bits,
                                                        exercise_alg);
-    ASSERT_ALLOC(buffer, buffer_length);
+    TEST_CALLOC_OR_FAIL(buffer, buffer_length);
 
     status = psa_asymmetric_encrypt(key, exercise_alg,
                                     NULL, 0,
@@ -2498,7 +2498,7 @@ void copy_success(int source_usage_arg,
                psa_get_key_enrollment_algorithm(&target_attributes));
     if (expected_usage & PSA_KEY_USAGE_EXPORT) {
         size_t length;
-        ASSERT_ALLOC(export_buffer, material->len);
+        TEST_CALLOC_OR_FAIL(export_buffer, material->len);
         PSA_ASSERT(psa_export_key(target_key, export_buffer,
                                   material->len, &length));
         TEST_BUFFERS_EQUAL(material->x, material->len,
@@ -2626,7 +2626,7 @@ void hash_setup(int alg_arg,
 
     /* Hash Setup, one-shot */
     output_size = PSA_HASH_LENGTH(alg);
-    ASSERT_ALLOC(output, output_size);
+    TEST_CALLOC_OR_FAIL(output, output_size);
 
     status = psa_hash_compute(alg, NULL, 0,
                               output, output_size, &output_length);
@@ -2669,7 +2669,7 @@ void hash_compute_fail(int alg_arg, data_t *input,
     psa_status_t expected_status = expected_status_arg;
     psa_status_t status;
 
-    ASSERT_ALLOC(output, output_size);
+    TEST_CALLOC_OR_FAIL(output, output_size);
 
     PSA_ASSERT(psa_crypto_init());
 
@@ -3384,7 +3384,7 @@ void mac_sign(int key_type_arg,
              PSA_ERROR_BUFFER_TOO_SMALL);
 
         mbedtls_test_set_step(output_size);
-        ASSERT_ALLOC(actual_mac, output_size);
+        TEST_CALLOC_OR_FAIL(actual_mac, output_size);
 
         /* Calculate the MAC, one-shot case. */
         TEST_EQUAL(psa_mac_compute(key, alg,
@@ -3480,7 +3480,7 @@ void mac_verify(int key_type_arg,
                PSA_ERROR_INVALID_SIGNATURE);
 
     /* Test a MAC that's too long, one-shot case. */
-    ASSERT_ALLOC(perturbed_mac, expected_mac->len + 1);
+    TEST_CALLOC_OR_FAIL(perturbed_mac, expected_mac->len + 1);
     memcpy(perturbed_mac, expected_mac->x, expected_mac->len);
     TEST_EQUAL(psa_mac_verify(key, alg,
                               input->x, input->len,
@@ -3810,7 +3810,7 @@ void cipher_encrypt_fail(int alg_arg,
 
         output_buffer_size = PSA_CIPHER_ENCRYPT_OUTPUT_SIZE(key_type, alg,
                                                             input->len);
-        ASSERT_ALLOC(output, output_buffer_size);
+        TEST_CALLOC_OR_FAIL(output, output_buffer_size);
 
         PSA_ASSERT(psa_import_key(&attributes, key_data->x, key_data->len,
                                   &key));
@@ -3869,7 +3869,7 @@ void cipher_encrypt_validate_iv_length(int alg, int key_type, data_t *key_data,
     unsigned char *output = NULL;
 
     output_buffer_size = PSA_CIPHER_ENCRYPT_OUTPUT_SIZE(key_type, alg, input->len);
-    ASSERT_ALLOC(output, output_buffer_size);
+    TEST_CALLOC_OR_FAIL(output, output_buffer_size);
 
     PSA_ASSERT(psa_crypto_init());
 
@@ -3927,7 +3927,7 @@ void cipher_alg_without_iv(int alg_arg, int key_type_arg, data_t *key_data,
                               &key));
     output_buffer_size = PSA_CIPHER_ENCRYPT_OUTPUT_SIZE(key_type, alg,
                                                         plaintext->len);
-    ASSERT_ALLOC(output, output_buffer_size);
+    TEST_CALLOC_OR_FAIL(output, output_buffer_size);
 
     /* set_iv() is not allowed */
     PSA_ASSERT(psa_cipher_encrypt_setup(&operation, key, alg));
@@ -4077,8 +4077,8 @@ void cipher_encrypt_validation(int alg_arg,
     output1_buffer_size = PSA_CIPHER_ENCRYPT_OUTPUT_SIZE(key_type, alg, input->len);
     output2_buffer_size = PSA_CIPHER_UPDATE_OUTPUT_SIZE(key_type, alg, input->len) +
                           PSA_CIPHER_FINISH_OUTPUT_SIZE(key_type, alg);
-    ASSERT_ALLOC(output1, output1_buffer_size);
-    ASSERT_ALLOC(output2, output2_buffer_size);
+    TEST_CALLOC_OR_FAIL(output1, output1_buffer_size);
+    TEST_CALLOC_OR_FAIL(output2, output2_buffer_size);
 
     PSA_ASSERT(psa_import_key(&attributes, key_data->x, key_data->len,
                               &key));
@@ -4169,7 +4169,7 @@ void cipher_encrypt_multipart(int alg_arg, int key_type_arg,
 
     output_buffer_size = PSA_CIPHER_UPDATE_OUTPUT_SIZE(key_type, alg, input->len) +
                          PSA_CIPHER_FINISH_OUTPUT_SIZE(key_type, alg);
-    ASSERT_ALLOC(output, output_buffer_size);
+    TEST_CALLOC_OR_FAIL(output, output_buffer_size);
 
     TEST_LE_U(first_part_size, input->len);
     PSA_ASSERT(psa_cipher_update(&operation, input->x, first_part_size,
@@ -4268,7 +4268,7 @@ void cipher_decrypt_multipart(int alg_arg, int key_type_arg,
 
     output_buffer_size = PSA_CIPHER_UPDATE_OUTPUT_SIZE(key_type, alg, input->len) +
                          PSA_CIPHER_FINISH_OUTPUT_SIZE(key_type, alg);
-    ASSERT_ALLOC(output, output_buffer_size);
+    TEST_CALLOC_OR_FAIL(output, output_buffer_size);
 
     TEST_LE_U(first_part_size, input->len);
     PSA_ASSERT(psa_cipher_update(&operation,
@@ -4364,13 +4364,13 @@ void cipher_decrypt_fail(int alg_arg,
     /* Allocate input buffer and copy the iv and the plaintext */
     input_buffer_size = ((size_t) input_arg->len + (size_t) iv->len);
     if (input_buffer_size > 0) {
-        ASSERT_ALLOC(input, input_buffer_size);
+        TEST_CALLOC_OR_FAIL(input, input_buffer_size);
         memcpy(input, iv->x, iv->len);
         memcpy(input + iv->len, input_arg->x, input_arg->len);
     }
 
     output_buffer_size = PSA_CIPHER_DECRYPT_OUTPUT_SIZE(key_type, alg, input_buffer_size);
-    ASSERT_ALLOC(output, output_buffer_size);
+    TEST_CALLOC_OR_FAIL(output, output_buffer_size);
 
     /* Decrypt, one-short */
     status = psa_cipher_decrypt(key, alg, input, input_buffer_size, output,
@@ -4383,7 +4383,7 @@ void cipher_decrypt_fail(int alg_arg,
         output_buffer_size = PSA_CIPHER_UPDATE_OUTPUT_SIZE(key_type, alg,
                                                            input_arg->len) +
                              PSA_CIPHER_FINISH_OUTPUT_SIZE(key_type, alg);
-        ASSERT_ALLOC(output_multi, output_buffer_size);
+        TEST_CALLOC_OR_FAIL(output_multi, output_buffer_size);
 
         if (iv->len > 0) {
             status = psa_cipher_set_iv(&operation, iv->x, iv->len);
@@ -4454,13 +4454,13 @@ void cipher_decrypt(int alg_arg,
     /* Allocate input buffer and copy the iv and the plaintext */
     input_buffer_size = ((size_t) input_arg->len + (size_t) iv->len);
     if (input_buffer_size > 0) {
-        ASSERT_ALLOC(input, input_buffer_size);
+        TEST_CALLOC_OR_FAIL(input, input_buffer_size);
         memcpy(input, iv->x, iv->len);
         memcpy(input + iv->len, input_arg->x, input_arg->len);
     }
 
     output_buffer_size = PSA_CIPHER_DECRYPT_OUTPUT_SIZE(key_type, alg, input_buffer_size);
-    ASSERT_ALLOC(output, output_buffer_size);
+    TEST_CALLOC_OR_FAIL(output, output_buffer_size);
 
     PSA_ASSERT(psa_import_key(&attributes, key_data->x, key_data->len,
                               &key));
@@ -4508,7 +4508,7 @@ void cipher_verify_output(int alg_arg,
     PSA_ASSERT(psa_import_key(&attributes, key_data->x, key_data->len,
                               &key));
     output1_size = PSA_CIPHER_ENCRYPT_OUTPUT_SIZE(key_type, alg, input->len);
-    ASSERT_ALLOC(output1, output1_size);
+    TEST_CALLOC_OR_FAIL(output1, output1_size);
 
     PSA_ASSERT(psa_cipher_encrypt(key, alg, input->x, input->len,
                                   output1, output1_size,
@@ -4519,7 +4519,7 @@ void cipher_verify_output(int alg_arg,
               PSA_CIPHER_ENCRYPT_OUTPUT_MAX_SIZE(input->len));
 
     output2_size = output1_length;
-    ASSERT_ALLOC(output2, output2_size);
+    TEST_CALLOC_OR_FAIL(output2, output2_size);
 
     PSA_ASSERT(psa_cipher_decrypt(key, alg, output1, output1_length,
                                   output2, output2_size,
@@ -4585,7 +4585,7 @@ void cipher_verify_output_multipart(int alg_arg,
     output1_buffer_size = PSA_CIPHER_ENCRYPT_OUTPUT_SIZE(key_type, alg, input->len);
     TEST_LE_U(output1_buffer_size,
               PSA_CIPHER_ENCRYPT_OUTPUT_MAX_SIZE(input->len));
-    ASSERT_ALLOC(output1, output1_buffer_size);
+    TEST_CALLOC_OR_FAIL(output1, output1_buffer_size);
 
     TEST_LE_U(first_part_size, input->len);
 
@@ -4628,7 +4628,7 @@ void cipher_verify_output_multipart(int alg_arg,
               PSA_CIPHER_DECRYPT_OUTPUT_SIZE(key_type, alg, output1_length));
     TEST_LE_U(output2_buffer_size,
               PSA_CIPHER_DECRYPT_OUTPUT_MAX_SIZE(output1_length));
-    ASSERT_ALLOC(output2, output2_buffer_size);
+    TEST_CALLOC_OR_FAIL(output2, output2_buffer_size);
 
     if (iv_length > 0) {
         PSA_ASSERT(psa_cipher_set_iv(&operation2,
@@ -4724,7 +4724,7 @@ void aead_encrypt_decrypt(int key_type_arg, data_t *key_data,
         TEST_LE_U(output_size,
                   PSA_AEAD_ENCRYPT_OUTPUT_MAX_SIZE(input_data->len));
     }
-    ASSERT_ALLOC(output_data, output_size);
+    TEST_CALLOC_OR_FAIL(output_data, output_size);
 
     status = psa_aead_encrypt(key, alg,
                               nonce->x, nonce->len,
@@ -4745,7 +4745,7 @@ void aead_encrypt_decrypt(int key_type_arg, data_t *key_data,
     TEST_EQUAL(status, expected_result);
 
     if (PSA_SUCCESS == expected_result) {
-        ASSERT_ALLOC(output_data2, output_length);
+        TEST_CALLOC_OR_FAIL(output_data2, output_length);
 
         /* For all currently defined algorithms, PSA_AEAD_DECRYPT_OUTPUT_SIZE
          * should be exact. */
@@ -4813,7 +4813,7 @@ void aead_encrypt(int key_type_arg, data_t *key_data,
                PSA_AEAD_ENCRYPT_OUTPUT_SIZE(key_type, alg, input_data->len));
     TEST_LE_U(output_size,
               PSA_AEAD_ENCRYPT_OUTPUT_MAX_SIZE(input_data->len));
-    ASSERT_ALLOC(output_data, output_size);
+    TEST_CALLOC_OR_FAIL(output_data, output_size);
 
     status = psa_aead_encrypt(key, alg,
                               nonce->x, nonce->len,
@@ -4883,7 +4883,7 @@ void aead_decrypt(int key_type_arg, data_t *key_data,
         TEST_LE_U(output_size,
                   PSA_AEAD_DECRYPT_OUTPUT_MAX_SIZE(input_data->len));
     }
-    ASSERT_ALLOC(output_data, output_size);
+    TEST_CALLOC_OR_FAIL(output_data, output_size);
 
     status = psa_aead_decrypt(key, alg,
                               nonce->x, nonce->len,
@@ -5142,13 +5142,13 @@ void aead_multipart_generate_nonce(int key_type_arg, data_t *key_data,
 
     output_size = PSA_AEAD_UPDATE_OUTPUT_SIZE(key_type, alg, input_data->len);
 
-    ASSERT_ALLOC(output, output_size);
+    TEST_CALLOC_OR_FAIL(output, output_size);
 
     ciphertext_size = PSA_AEAD_FINISH_OUTPUT_SIZE(key_type, alg);
 
     TEST_LE_U(ciphertext_size, PSA_AEAD_FINISH_OUTPUT_MAX_SIZE);
 
-    ASSERT_ALLOC(ciphertext, ciphertext_size);
+    TEST_CALLOC_OR_FAIL(ciphertext, ciphertext_size);
 
     status = psa_aead_encrypt_setup(&operation, key, alg);
 
@@ -5245,13 +5245,13 @@ void aead_multipart_set_nonce(int key_type_arg, data_t *key_data,
 
     output_size = PSA_AEAD_UPDATE_OUTPUT_SIZE(key_type, alg, input_data->len);
 
-    ASSERT_ALLOC(output, output_size);
+    TEST_CALLOC_OR_FAIL(output, output_size);
 
     ciphertext_size = PSA_AEAD_FINISH_OUTPUT_SIZE(key_type, alg);
 
     TEST_LE_U(ciphertext_size, PSA_AEAD_FINISH_OUTPUT_MAX_SIZE);
 
-    ASSERT_ALLOC(ciphertext, ciphertext_size);
+    TEST_CALLOC_OR_FAIL(ciphertext, ciphertext_size);
 
     status = psa_aead_encrypt_setup(&operation, key, alg);
 
@@ -5268,12 +5268,12 @@ void aead_multipart_set_nonce(int key_type_arg, data_t *key_data,
     /* -1 == zero length and valid buffer, 0 = zero length and NULL buffer. */
     if (nonce_length_arg == -1) {
         /* Arbitrary size buffer, to test zero length valid buffer. */
-        ASSERT_ALLOC(nonce_buffer, 4);
+        TEST_CALLOC_OR_FAIL(nonce_buffer, 4);
         nonce_length = 0;
     } else {
         /* If length is zero, then this will return NULL. */
         nonce_length = (size_t) nonce_length_arg;
-        ASSERT_ALLOC(nonce_buffer, nonce_length);
+        TEST_CALLOC_OR_FAIL(nonce_buffer, nonce_length);
 
         if (nonce_buffer) {
             for (index = 0; index < nonce_length - 1; ++index) {
@@ -5362,11 +5362,11 @@ void aead_multipart_update_buffer_test(int key_type_arg, data_t *key_data,
 
     PSA_ASSERT(psa_get_key_attributes(key, &attributes));
 
-    ASSERT_ALLOC(output, output_size);
+    TEST_CALLOC_OR_FAIL(output, output_size);
 
     ciphertext_size = PSA_AEAD_FINISH_OUTPUT_SIZE(key_type, alg);
 
-    ASSERT_ALLOC(ciphertext, ciphertext_size);
+    TEST_CALLOC_OR_FAIL(ciphertext, ciphertext_size);
 
     status = psa_aead_encrypt_setup(&operation, key, alg);
 
@@ -5449,11 +5449,11 @@ void aead_multipart_finish_buffer_test(int key_type_arg, data_t *key_data,
 
     ciphertext_size = PSA_AEAD_UPDATE_OUTPUT_SIZE(key_type, alg, input_data->len);
 
-    ASSERT_ALLOC(ciphertext, ciphertext_size);
+    TEST_CALLOC_OR_FAIL(ciphertext, ciphertext_size);
 
-    ASSERT_ALLOC(finish_ciphertext, finish_ciphertext_size);
+    TEST_CALLOC_OR_FAIL(finish_ciphertext, finish_ciphertext_size);
 
-    ASSERT_ALLOC(tag_buffer, tag_size);
+    TEST_CALLOC_OR_FAIL(tag_buffer, tag_size);
 
     status = psa_aead_encrypt_setup(&operation, key, alg);
 
@@ -5538,11 +5538,11 @@ void aead_multipart_verify(int key_type_arg, data_t *key_data,
     plaintext_size = PSA_AEAD_UPDATE_OUTPUT_SIZE(key_type, alg,
                                                  input_data->len);
 
-    ASSERT_ALLOC(plaintext, plaintext_size);
+    TEST_CALLOC_OR_FAIL(plaintext, plaintext_size);
 
     verify_plaintext_size = PSA_AEAD_VERIFY_OUTPUT_SIZE(key_type, alg);
 
-    ASSERT_ALLOC(finish_plaintext, verify_plaintext_size);
+    TEST_CALLOC_OR_FAIL(finish_plaintext, verify_plaintext_size);
 
     status = psa_aead_decrypt_setup(&operation, key, alg);
 
@@ -5679,13 +5679,13 @@ void aead_multipart_state_test(int key_type_arg, data_t *key_data,
 
     output_size = PSA_AEAD_UPDATE_OUTPUT_SIZE(key_type, alg, input_data->len);
 
-    ASSERT_ALLOC(output_data, output_size);
+    TEST_CALLOC_OR_FAIL(output_data, output_size);
 
     finish_output_size = PSA_AEAD_FINISH_OUTPUT_SIZE(key_type, alg);
 
     TEST_LE_U(finish_output_size, PSA_AEAD_FINISH_OUTPUT_MAX_SIZE);
 
-    ASSERT_ALLOC(final_data, finish_output_size);
+    TEST_CALLOC_OR_FAIL(final_data, finish_output_size);
 
     /* Test all operations error without calling setup first. */
 
@@ -6483,7 +6483,7 @@ void sign_hash_deterministic(int key_type_arg, data_t *key_data,
                                           key_bits, alg);
     TEST_ASSERT(signature_size != 0);
     TEST_LE_U(signature_size, PSA_SIGNATURE_MAX_SIZE);
-    ASSERT_ALLOC(signature, signature_size);
+    TEST_CALLOC_OR_FAIL(signature, signature_size);
 
     /* Perform the signature. */
     PSA_ASSERT(psa_sign_hash(key, alg,
@@ -6566,7 +6566,7 @@ void sign_hash_interruptible(int key_type_arg, data_t *key_data,
                                           key_bits, alg);
     TEST_ASSERT(signature_size != 0);
     TEST_LE_U(signature_size, PSA_SIGNATURE_MAX_SIZE);
-    ASSERT_ALLOC(signature, signature_size);
+    TEST_CALLOC_OR_FAIL(signature, signature_size);
 
     psa_interruptible_set_max_ops(max_ops);
 
@@ -6651,7 +6651,7 @@ void sign_hash_fail(int key_type_arg, data_t *key_data,
     size_t signature_length = 0xdeadbeef;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
 
-    ASSERT_ALLOC(signature, signature_size);
+    TEST_CALLOC_OR_FAIL(signature, signature_size);
 
     PSA_ASSERT(psa_crypto_init());
 
@@ -6731,7 +6731,7 @@ void sign_hash_fail_interruptible(int key_type_arg, data_t *key_data,
     psa_sign_hash_interruptible_operation_t operation =
         psa_sign_hash_interruptible_operation_init();
 
-    ASSERT_ALLOC(signature, signature_size);
+    TEST_CALLOC_OR_FAIL(signature, signature_size);
 
     PSA_ASSERT(psa_crypto_init());
 
@@ -6859,7 +6859,7 @@ void sign_verify_hash(int key_type_arg, data_t *key_data,
                                           key_bits, alg);
     TEST_ASSERT(signature_size != 0);
     TEST_LE_U(signature_size, PSA_SIGNATURE_MAX_SIZE);
-    ASSERT_ALLOC(signature, signature_size);
+    TEST_CALLOC_OR_FAIL(signature, signature_size);
 
     /* Perform the signature. */
     PSA_ASSERT(psa_sign_hash(key, alg,
@@ -6962,7 +6962,7 @@ void sign_verify_hash_interruptible(int key_type_arg, data_t *key_data,
                                           key_bits, alg);
     TEST_ASSERT(signature_size != 0);
     TEST_LE_U(signature_size, PSA_SIGNATURE_MAX_SIZE);
-    ASSERT_ALLOC(signature, signature_size);
+    TEST_CALLOC_OR_FAIL(signature, signature_size);
 
     psa_interruptible_set_max_ops(max_ops);
 
@@ -7444,7 +7444,7 @@ void interruptible_signverify_hash_state_test(int key_type_arg,
                                           key_bits, alg);
     TEST_ASSERT(signature_size != 0);
     TEST_LE_U(signature_size, PSA_SIGNATURE_MAX_SIZE);
-    ASSERT_ALLOC(signature, signature_size);
+    TEST_CALLOC_OR_FAIL(signature, signature_size);
 
     psa_interruptible_set_max_ops(PSA_INTERRUPTIBLE_MAX_OPS_UNLIMITED);
 
@@ -7600,7 +7600,7 @@ void interruptible_signverify_hash_edgecase_tests(int key_type_arg,
                                           key_bits, alg);
     TEST_ASSERT(signature_size != 0);
     TEST_LE_U(signature_size, PSA_SIGNATURE_MAX_SIZE);
-    ASSERT_ALLOC(signature, signature_size);
+    TEST_CALLOC_OR_FAIL(signature, signature_size);
 
     /* --- Change function inputs mid run, to cause an error (sign only,
      *     verify passes all inputs to start. --- */
@@ -7731,7 +7731,7 @@ void interruptible_signverify_hash_ops_tests(int key_type_arg,
 
     TEST_ASSERT(signature_size != 0);
     TEST_LE_U(signature_size, PSA_SIGNATURE_MAX_SIZE);
-    ASSERT_ALLOC(signature, signature_size);
+    TEST_CALLOC_OR_FAIL(signature, signature_size);
 
     /* Check that default max ops gets set if we don't set it. */
     PSA_ASSERT(psa_sign_hash_start(&sign_operation, key, alg,
@@ -7905,7 +7905,7 @@ void sign_message_deterministic(int key_type_arg,
     signature_size = PSA_SIGN_OUTPUT_SIZE(key_type, key_bits, alg);
     TEST_ASSERT(signature_size != 0);
     TEST_LE_U(signature_size, PSA_SIGNATURE_MAX_SIZE);
-    ASSERT_ALLOC(signature, signature_size);
+    TEST_CALLOC_OR_FAIL(signature, signature_size);
 
     PSA_ASSERT(psa_sign_message(key, alg,
                                 input_data->x, input_data->len,
@@ -7943,7 +7943,7 @@ void sign_message_fail(int key_type_arg,
     size_t signature_length = 0xdeadbeef;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
 
-    ASSERT_ALLOC(signature, signature_size);
+    TEST_CALLOC_OR_FAIL(signature, signature_size);
 
     PSA_ASSERT(psa_crypto_init());
 
@@ -8003,7 +8003,7 @@ void sign_verify_message(int key_type_arg,
     signature_size = PSA_SIGN_OUTPUT_SIZE(key_type, key_bits, alg);
     TEST_ASSERT(signature_size != 0);
     TEST_LE_U(signature_size, PSA_SIGNATURE_MAX_SIZE);
-    ASSERT_ALLOC(signature, signature_size);
+    TEST_CALLOC_OR_FAIL(signature, signature_size);
 
     PSA_ASSERT(psa_sign_message(key, alg,
                                 input_data->x, input_data->len,
@@ -8143,7 +8143,7 @@ void asymmetric_encrypt(int key_type_arg,
 
     output_size = PSA_ASYMMETRIC_ENCRYPT_OUTPUT_SIZE(key_type, key_bits, alg);
     TEST_LE_U(output_size, PSA_ASYMMETRIC_ENCRYPT_OUTPUT_MAX_SIZE);
-    ASSERT_ALLOC(output, output_size);
+    TEST_CALLOC_OR_FAIL(output, output_size);
 
     /* Encrypt the input */
     actual_status = psa_asymmetric_encrypt(key, alg,
@@ -8225,13 +8225,13 @@ void asymmetric_encrypt_decrypt(int key_type_arg,
 
     output_size = PSA_ASYMMETRIC_ENCRYPT_OUTPUT_SIZE(key_type, key_bits, alg);
     TEST_LE_U(output_size, PSA_ASYMMETRIC_ENCRYPT_OUTPUT_MAX_SIZE);
-    ASSERT_ALLOC(output, output_size);
+    TEST_CALLOC_OR_FAIL(output, output_size);
 
     output2_size = input_data->len;
     TEST_LE_U(output2_size,
               PSA_ASYMMETRIC_DECRYPT_OUTPUT_SIZE(key_type, key_bits, alg));
     TEST_LE_U(output2_size, PSA_ASYMMETRIC_DECRYPT_OUTPUT_MAX_SIZE);
-    ASSERT_ALLOC(output2, output2_size);
+    TEST_CALLOC_OR_FAIL(output2, output2_size);
 
     /* We test encryption by checking that encrypt-then-decrypt gives back
      * the original plaintext because of the non-optional random
@@ -8299,7 +8299,7 @@ void asymmetric_decrypt(int key_type_arg,
     /* Determine the maximum ciphertext length */
     output_size = PSA_ASYMMETRIC_DECRYPT_OUTPUT_SIZE(key_type, key_bits, alg);
     TEST_LE_U(output_size, PSA_ASYMMETRIC_DECRYPT_OUTPUT_MAX_SIZE);
-    ASSERT_ALLOC(output, output_size);
+    TEST_CALLOC_OR_FAIL(output, output_size);
 
     PSA_ASSERT(psa_asymmetric_decrypt(key, alg,
                                       input_data->x, input_data->len,
@@ -8354,7 +8354,7 @@ void asymmetric_decrypt_fail(int key_type_arg,
     psa_status_t expected_status = expected_status_arg;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
 
-    ASSERT_ALLOC(output, output_size);
+    TEST_CALLOC_OR_FAIL(output, output_size);
 
     PSA_ASSERT(psa_crypto_init());
 
@@ -8722,7 +8722,7 @@ void derive_output(int alg_arg,
             expected_outputs[i] = NULL;
         }
     }
-    ASSERT_ALLOC(output_buffer, output_buffer_size);
+    TEST_CALLOC_OR_FAIL(output_buffer, output_buffer_size);
     PSA_ASSERT(psa_crypto_init());
 
     /* Extraction phase. */
@@ -8995,7 +8995,7 @@ void derive_ecjpake_to_pms(data_t *input, int expected_input_status_arg,
     psa_status_t expected_capacity_status = (psa_status_t) expected_capacity_status_arg;
     psa_status_t expected_output_status = (psa_status_t) expected_output_status_arg;
 
-    ASSERT_ALLOC(output_buffer, expected_output->len);
+    TEST_CALLOC_OR_FAIL(output_buffer, expected_output->len);
     PSA_ASSERT(psa_crypto_init());
 
     PSA_ASSERT(psa_key_derivation_setup(&operation, alg));
@@ -9116,8 +9116,8 @@ void derive_key_export(int alg_arg,
     psa_key_attributes_t derived_attributes = PSA_KEY_ATTRIBUTES_INIT;
     size_t length;
 
-    ASSERT_ALLOC(output_buffer, capacity);
-    ASSERT_ALLOC(export_buffer, capacity);
+    TEST_CALLOC_OR_FAIL(output_buffer, capacity);
+    TEST_CALLOC_OR_FAIL(export_buffer, capacity);
     PSA_ASSERT(psa_crypto_init());
 
     psa_set_key_usage_flags(&base_attributes, PSA_KEY_USAGE_DERIVE);
@@ -9201,7 +9201,7 @@ void derive_key_type(int alg_arg,
     psa_key_attributes_t derived_attributes = PSA_KEY_ATTRIBUTES_INIT;
     size_t export_length;
 
-    ASSERT_ALLOC(export_buffer, export_buffer_size);
+    TEST_CALLOC_OR_FAIL(export_buffer, export_buffer_size);
     PSA_ASSERT(psa_crypto_init());
 
     psa_set_key_usage_flags(&base_attributes, PSA_KEY_USAGE_DERIVE);
@@ -9373,7 +9373,7 @@ void raw_key_agreement(int alg_arg,
               PSA_RAW_KEY_AGREEMENT_OUTPUT_MAX_SIZE);
 
     /* Good case with exact output size */
-    ASSERT_ALLOC(output, expected_output->len);
+    TEST_CALLOC_OR_FAIL(output, expected_output->len);
     PSA_ASSERT(psa_raw_key_agreement(alg, our_key,
                                      peer_key_data->x, peer_key_data->len,
                                      output, expected_output->len,
@@ -9385,7 +9385,7 @@ void raw_key_agreement(int alg_arg,
     output_length = ~0;
 
     /* Larger buffer */
-    ASSERT_ALLOC(output, expected_output->len + 1);
+    TEST_CALLOC_OR_FAIL(output, expected_output->len + 1);
     PSA_ASSERT(psa_raw_key_agreement(alg, our_key,
                                      peer_key_data->x, peer_key_data->len,
                                      output, expected_output->len + 1,
@@ -9397,7 +9397,7 @@ void raw_key_agreement(int alg_arg,
     output_length = ~0;
 
     /* Buffer too small */
-    ASSERT_ALLOC(output, expected_output->len - 1);
+    TEST_CALLOC_OR_FAIL(output, expected_output->len - 1);
     TEST_EQUAL(psa_raw_key_agreement(alg, our_key,
                                      peer_key_data->x, peer_key_data->len,
                                      output, expected_output->len - 1,
@@ -9486,7 +9486,7 @@ void key_agreement_output(int alg_arg,
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     uint8_t *actual_output = NULL;
 
-    ASSERT_ALLOC(actual_output, MAX(expected_output1->len,
+    TEST_CALLOC_OR_FAIL(actual_output, MAX(expected_output1->len,
                                     expected_output2->len));
 
     PSA_ASSERT(psa_crypto_init());
@@ -9542,8 +9542,8 @@ void generate_random(int bytes_arg)
 
     TEST_ASSERT(bytes_arg >= 0);
 
-    ASSERT_ALLOC(output, bytes);
-    ASSERT_ALLOC(changed, bytes);
+    TEST_CALLOC_OR_FAIL(output, bytes);
+    TEST_CALLOC_OR_FAIL(changed, bytes);
 
     PSA_ASSERT(psa_crypto_init());
 
@@ -9661,8 +9661,8 @@ void generate_key_rsa(int bits_arg,
         is_default_public_exponent = 1;
         e_read_size = 0;
     }
-    ASSERT_ALLOC(e_read_buffer, e_read_size);
-    ASSERT_ALLOC(exported, exported_size);
+    TEST_CALLOC_OR_FAIL(e_read_buffer, e_read_size);
+    TEST_CALLOC_OR_FAIL(exported, exported_size);
 
     PSA_ASSERT(psa_crypto_init());
 
@@ -9764,8 +9764,8 @@ void persistent_key_load_key_from_storage(data_t *data,
     size_t second_exported_length;
 
     if (usage_flags & PSA_KEY_USAGE_EXPORT) {
-        ASSERT_ALLOC(first_export, export_size);
-        ASSERT_ALLOC(second_export, export_size);
+        TEST_CALLOC_OR_FAIL(first_export, export_size);
+        TEST_CALLOC_OR_FAIL(second_export, export_size);
     }
 
     PSA_ASSERT(psa_crypto_init());
@@ -9912,7 +9912,7 @@ void ecjpake_setup(int alg_arg, int key_type_pw_arg, int key_usage_pw_arg,
 
     size_t buf_size = PSA_PAKE_OUTPUT_SIZE(alg, primitive_arg,
                                            PSA_PAKE_STEP_KEY_SHARE);
-    ASSERT_ALLOC(output_buffer, buf_size);
+    TEST_CALLOC_OR_FAIL(output_buffer, buf_size);
 
     if (pw_data->len > 0) {
         psa_set_key_usage_flags(&attributes, key_usage_pw);

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -429,7 +429,7 @@ static int aead_multipart_internal_func(int key_type_arg, data_t *key_data,
         data_true_size = input_data->len - tag_length;
     }
 
-    TEST_CALLOC_OR_FAIL(output_data, output_size);
+    TEST_CALLOC(output_data, output_size);
 
     if (is_encrypt) {
         final_output_size = PSA_AEAD_FINISH_OUTPUT_SIZE(key_type, alg);
@@ -439,7 +439,7 @@ static int aead_multipart_internal_func(int key_type_arg, data_t *key_data,
         TEST_LE_U(final_output_size, PSA_AEAD_VERIFY_OUTPUT_MAX_SIZE);
     }
 
-    TEST_CALLOC_OR_FAIL(final_data, final_output_size);
+    TEST_CALLOC(final_data, final_output_size);
 
     if (is_encrypt) {
         status = psa_aead_encrypt_setup(&operation, key, alg);
@@ -502,7 +502,7 @@ static int aead_multipart_internal_func(int key_type_arg, data_t *key_data,
         part_data_size = PSA_AEAD_UPDATE_OUTPUT_SIZE(key_type, alg,
                                                      (size_t) data_part_len);
 
-        TEST_CALLOC_OR_FAIL(part_data, part_data_size);
+        TEST_CALLOC(part_data, part_data_size);
 
         for (part_offset = 0, part_count = 0;
              part_offset < data_true_size;
@@ -744,8 +744,8 @@ static void ecjpake_do_round(psa_algorithm_t alg, unsigned int primitive,
     psa_status_t expected_status = PSA_SUCCESS;
     psa_status_t status;
 
-    TEST_CALLOC_OR_FAIL(buffer0, buffer_length);
-    TEST_CALLOC_OR_FAIL(buffer1, buffer_length);
+    TEST_CALLOC(buffer0, buffer_length);
+    TEST_CALLOC(buffer1, buffer_length);
 
     switch (round) {
         case 1:
@@ -1472,7 +1472,7 @@ void import_rsa_made_up(int bits_arg, int keypair, int expected_status_arg)
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
 
     PSA_ASSERT(psa_crypto_init());
-    TEST_CALLOC_OR_FAIL(buffer, buffer_size);
+    TEST_CALLOC(buffer, buffer_size);
 
     TEST_ASSERT((ret = construct_fake_rsa_key(buffer, buffer_size, &p,
                                               bits, keypair)) >= 0);
@@ -1519,9 +1519,9 @@ void import_export(data_t *data,
     psa_key_attributes_t got_attributes = PSA_KEY_ATTRIBUTES_INIT;
 
     export_size = (ptrdiff_t) data->len + export_size_delta;
-    TEST_CALLOC_OR_FAIL(exported, export_size);
+    TEST_CALLOC(exported, export_size);
     if (!canonical_input) {
-        TEST_CALLOC_OR_FAIL(reexported, export_size);
+        TEST_CALLOC(reexported, export_size);
     }
     PSA_ASSERT(psa_crypto_init());
 
@@ -1641,7 +1641,7 @@ void import_export_public_key(data_t *data,
     PSA_ASSERT(psa_import_key(&attributes, data->x, data->len, &key));
 
     /* Export the public key */
-    TEST_CALLOC_OR_FAIL(exported, export_size);
+    TEST_CALLOC(exported, export_size);
     status = psa_export_public_key(key,
                                    exported, export_size,
                                    &exported_length);
@@ -1938,8 +1938,8 @@ void cipher_key_policy(int policy_usage_arg,
     output_buffer_size = PSA_CIPHER_ENCRYPT_OUTPUT_SIZE(key_type, exercise_alg,
                                                         input_buffer_size);
 
-    TEST_CALLOC_OR_FAIL(input, input_buffer_size);
-    TEST_CALLOC_OR_FAIL(output, output_buffer_size);
+    TEST_CALLOC(input, input_buffer_size);
+    TEST_CALLOC(output, output_buffer_size);
 
     PSA_ASSERT(psa_crypto_init());
 
@@ -2128,7 +2128,7 @@ void asymmetric_encryption_key_policy(int policy_usage_arg,
     key_bits = psa_get_key_bits(&attributes);
     buffer_length = PSA_ASYMMETRIC_ENCRYPT_OUTPUT_SIZE(key_type, key_bits,
                                                        exercise_alg);
-    TEST_CALLOC_OR_FAIL(buffer, buffer_length);
+    TEST_CALLOC(buffer, buffer_length);
 
     status = psa_asymmetric_encrypt(key, exercise_alg,
                                     NULL, 0,
@@ -2498,7 +2498,7 @@ void copy_success(int source_usage_arg,
                psa_get_key_enrollment_algorithm(&target_attributes));
     if (expected_usage & PSA_KEY_USAGE_EXPORT) {
         size_t length;
-        TEST_CALLOC_OR_FAIL(export_buffer, material->len);
+        TEST_CALLOC(export_buffer, material->len);
         PSA_ASSERT(psa_export_key(target_key, export_buffer,
                                   material->len, &length));
         TEST_BUFFERS_EQUAL(material->x, material->len,
@@ -2626,7 +2626,7 @@ void hash_setup(int alg_arg,
 
     /* Hash Setup, one-shot */
     output_size = PSA_HASH_LENGTH(alg);
-    TEST_CALLOC_OR_FAIL(output, output_size);
+    TEST_CALLOC(output, output_size);
 
     status = psa_hash_compute(alg, NULL, 0,
                               output, output_size, &output_length);
@@ -2669,7 +2669,7 @@ void hash_compute_fail(int alg_arg, data_t *input,
     psa_status_t expected_status = expected_status_arg;
     psa_status_t status;
 
-    TEST_CALLOC_OR_FAIL(output, output_size);
+    TEST_CALLOC(output, output_size);
 
     PSA_ASSERT(psa_crypto_init());
 
@@ -3384,7 +3384,7 @@ void mac_sign(int key_type_arg,
              PSA_ERROR_BUFFER_TOO_SMALL);
 
         mbedtls_test_set_step(output_size);
-        TEST_CALLOC_OR_FAIL(actual_mac, output_size);
+        TEST_CALLOC(actual_mac, output_size);
 
         /* Calculate the MAC, one-shot case. */
         TEST_EQUAL(psa_mac_compute(key, alg,
@@ -3480,7 +3480,7 @@ void mac_verify(int key_type_arg,
                PSA_ERROR_INVALID_SIGNATURE);
 
     /* Test a MAC that's too long, one-shot case. */
-    TEST_CALLOC_OR_FAIL(perturbed_mac, expected_mac->len + 1);
+    TEST_CALLOC(perturbed_mac, expected_mac->len + 1);
     memcpy(perturbed_mac, expected_mac->x, expected_mac->len);
     TEST_EQUAL(psa_mac_verify(key, alg,
                               input->x, input->len,
@@ -3810,7 +3810,7 @@ void cipher_encrypt_fail(int alg_arg,
 
         output_buffer_size = PSA_CIPHER_ENCRYPT_OUTPUT_SIZE(key_type, alg,
                                                             input->len);
-        TEST_CALLOC_OR_FAIL(output, output_buffer_size);
+        TEST_CALLOC(output, output_buffer_size);
 
         PSA_ASSERT(psa_import_key(&attributes, key_data->x, key_data->len,
                                   &key));
@@ -3869,7 +3869,7 @@ void cipher_encrypt_validate_iv_length(int alg, int key_type, data_t *key_data,
     unsigned char *output = NULL;
 
     output_buffer_size = PSA_CIPHER_ENCRYPT_OUTPUT_SIZE(key_type, alg, input->len);
-    TEST_CALLOC_OR_FAIL(output, output_buffer_size);
+    TEST_CALLOC(output, output_buffer_size);
 
     PSA_ASSERT(psa_crypto_init());
 
@@ -3927,7 +3927,7 @@ void cipher_alg_without_iv(int alg_arg, int key_type_arg, data_t *key_data,
                               &key));
     output_buffer_size = PSA_CIPHER_ENCRYPT_OUTPUT_SIZE(key_type, alg,
                                                         plaintext->len);
-    TEST_CALLOC_OR_FAIL(output, output_buffer_size);
+    TEST_CALLOC(output, output_buffer_size);
 
     /* set_iv() is not allowed */
     PSA_ASSERT(psa_cipher_encrypt_setup(&operation, key, alg));
@@ -4077,8 +4077,8 @@ void cipher_encrypt_validation(int alg_arg,
     output1_buffer_size = PSA_CIPHER_ENCRYPT_OUTPUT_SIZE(key_type, alg, input->len);
     output2_buffer_size = PSA_CIPHER_UPDATE_OUTPUT_SIZE(key_type, alg, input->len) +
                           PSA_CIPHER_FINISH_OUTPUT_SIZE(key_type, alg);
-    TEST_CALLOC_OR_FAIL(output1, output1_buffer_size);
-    TEST_CALLOC_OR_FAIL(output2, output2_buffer_size);
+    TEST_CALLOC(output1, output1_buffer_size);
+    TEST_CALLOC(output2, output2_buffer_size);
 
     PSA_ASSERT(psa_import_key(&attributes, key_data->x, key_data->len,
                               &key));
@@ -4169,7 +4169,7 @@ void cipher_encrypt_multipart(int alg_arg, int key_type_arg,
 
     output_buffer_size = PSA_CIPHER_UPDATE_OUTPUT_SIZE(key_type, alg, input->len) +
                          PSA_CIPHER_FINISH_OUTPUT_SIZE(key_type, alg);
-    TEST_CALLOC_OR_FAIL(output, output_buffer_size);
+    TEST_CALLOC(output, output_buffer_size);
 
     TEST_LE_U(first_part_size, input->len);
     PSA_ASSERT(psa_cipher_update(&operation, input->x, first_part_size,
@@ -4268,7 +4268,7 @@ void cipher_decrypt_multipart(int alg_arg, int key_type_arg,
 
     output_buffer_size = PSA_CIPHER_UPDATE_OUTPUT_SIZE(key_type, alg, input->len) +
                          PSA_CIPHER_FINISH_OUTPUT_SIZE(key_type, alg);
-    TEST_CALLOC_OR_FAIL(output, output_buffer_size);
+    TEST_CALLOC(output, output_buffer_size);
 
     TEST_LE_U(first_part_size, input->len);
     PSA_ASSERT(psa_cipher_update(&operation,
@@ -4364,13 +4364,13 @@ void cipher_decrypt_fail(int alg_arg,
     /* Allocate input buffer and copy the iv and the plaintext */
     input_buffer_size = ((size_t) input_arg->len + (size_t) iv->len);
     if (input_buffer_size > 0) {
-        TEST_CALLOC_OR_FAIL(input, input_buffer_size);
+        TEST_CALLOC(input, input_buffer_size);
         memcpy(input, iv->x, iv->len);
         memcpy(input + iv->len, input_arg->x, input_arg->len);
     }
 
     output_buffer_size = PSA_CIPHER_DECRYPT_OUTPUT_SIZE(key_type, alg, input_buffer_size);
-    TEST_CALLOC_OR_FAIL(output, output_buffer_size);
+    TEST_CALLOC(output, output_buffer_size);
 
     /* Decrypt, one-short */
     status = psa_cipher_decrypt(key, alg, input, input_buffer_size, output,
@@ -4383,7 +4383,7 @@ void cipher_decrypt_fail(int alg_arg,
         output_buffer_size = PSA_CIPHER_UPDATE_OUTPUT_SIZE(key_type, alg,
                                                            input_arg->len) +
                              PSA_CIPHER_FINISH_OUTPUT_SIZE(key_type, alg);
-        TEST_CALLOC_OR_FAIL(output_multi, output_buffer_size);
+        TEST_CALLOC(output_multi, output_buffer_size);
 
         if (iv->len > 0) {
             status = psa_cipher_set_iv(&operation, iv->x, iv->len);
@@ -4454,13 +4454,13 @@ void cipher_decrypt(int alg_arg,
     /* Allocate input buffer and copy the iv and the plaintext */
     input_buffer_size = ((size_t) input_arg->len + (size_t) iv->len);
     if (input_buffer_size > 0) {
-        TEST_CALLOC_OR_FAIL(input, input_buffer_size);
+        TEST_CALLOC(input, input_buffer_size);
         memcpy(input, iv->x, iv->len);
         memcpy(input + iv->len, input_arg->x, input_arg->len);
     }
 
     output_buffer_size = PSA_CIPHER_DECRYPT_OUTPUT_SIZE(key_type, alg, input_buffer_size);
-    TEST_CALLOC_OR_FAIL(output, output_buffer_size);
+    TEST_CALLOC(output, output_buffer_size);
 
     PSA_ASSERT(psa_import_key(&attributes, key_data->x, key_data->len,
                               &key));
@@ -4508,7 +4508,7 @@ void cipher_verify_output(int alg_arg,
     PSA_ASSERT(psa_import_key(&attributes, key_data->x, key_data->len,
                               &key));
     output1_size = PSA_CIPHER_ENCRYPT_OUTPUT_SIZE(key_type, alg, input->len);
-    TEST_CALLOC_OR_FAIL(output1, output1_size);
+    TEST_CALLOC(output1, output1_size);
 
     PSA_ASSERT(psa_cipher_encrypt(key, alg, input->x, input->len,
                                   output1, output1_size,
@@ -4519,7 +4519,7 @@ void cipher_verify_output(int alg_arg,
               PSA_CIPHER_ENCRYPT_OUTPUT_MAX_SIZE(input->len));
 
     output2_size = output1_length;
-    TEST_CALLOC_OR_FAIL(output2, output2_size);
+    TEST_CALLOC(output2, output2_size);
 
     PSA_ASSERT(psa_cipher_decrypt(key, alg, output1, output1_length,
                                   output2, output2_size,
@@ -4585,7 +4585,7 @@ void cipher_verify_output_multipart(int alg_arg,
     output1_buffer_size = PSA_CIPHER_ENCRYPT_OUTPUT_SIZE(key_type, alg, input->len);
     TEST_LE_U(output1_buffer_size,
               PSA_CIPHER_ENCRYPT_OUTPUT_MAX_SIZE(input->len));
-    TEST_CALLOC_OR_FAIL(output1, output1_buffer_size);
+    TEST_CALLOC(output1, output1_buffer_size);
 
     TEST_LE_U(first_part_size, input->len);
 
@@ -4628,7 +4628,7 @@ void cipher_verify_output_multipart(int alg_arg,
               PSA_CIPHER_DECRYPT_OUTPUT_SIZE(key_type, alg, output1_length));
     TEST_LE_U(output2_buffer_size,
               PSA_CIPHER_DECRYPT_OUTPUT_MAX_SIZE(output1_length));
-    TEST_CALLOC_OR_FAIL(output2, output2_buffer_size);
+    TEST_CALLOC(output2, output2_buffer_size);
 
     if (iv_length > 0) {
         PSA_ASSERT(psa_cipher_set_iv(&operation2,
@@ -4724,7 +4724,7 @@ void aead_encrypt_decrypt(int key_type_arg, data_t *key_data,
         TEST_LE_U(output_size,
                   PSA_AEAD_ENCRYPT_OUTPUT_MAX_SIZE(input_data->len));
     }
-    TEST_CALLOC_OR_FAIL(output_data, output_size);
+    TEST_CALLOC(output_data, output_size);
 
     status = psa_aead_encrypt(key, alg,
                               nonce->x, nonce->len,
@@ -4745,7 +4745,7 @@ void aead_encrypt_decrypt(int key_type_arg, data_t *key_data,
     TEST_EQUAL(status, expected_result);
 
     if (PSA_SUCCESS == expected_result) {
-        TEST_CALLOC_OR_FAIL(output_data2, output_length);
+        TEST_CALLOC(output_data2, output_length);
 
         /* For all currently defined algorithms, PSA_AEAD_DECRYPT_OUTPUT_SIZE
          * should be exact. */
@@ -4813,7 +4813,7 @@ void aead_encrypt(int key_type_arg, data_t *key_data,
                PSA_AEAD_ENCRYPT_OUTPUT_SIZE(key_type, alg, input_data->len));
     TEST_LE_U(output_size,
               PSA_AEAD_ENCRYPT_OUTPUT_MAX_SIZE(input_data->len));
-    TEST_CALLOC_OR_FAIL(output_data, output_size);
+    TEST_CALLOC(output_data, output_size);
 
     status = psa_aead_encrypt(key, alg,
                               nonce->x, nonce->len,
@@ -4883,7 +4883,7 @@ void aead_decrypt(int key_type_arg, data_t *key_data,
         TEST_LE_U(output_size,
                   PSA_AEAD_DECRYPT_OUTPUT_MAX_SIZE(input_data->len));
     }
-    TEST_CALLOC_OR_FAIL(output_data, output_size);
+    TEST_CALLOC(output_data, output_size);
 
     status = psa_aead_decrypt(key, alg,
                               nonce->x, nonce->len,
@@ -5142,13 +5142,13 @@ void aead_multipart_generate_nonce(int key_type_arg, data_t *key_data,
 
     output_size = PSA_AEAD_UPDATE_OUTPUT_SIZE(key_type, alg, input_data->len);
 
-    TEST_CALLOC_OR_FAIL(output, output_size);
+    TEST_CALLOC(output, output_size);
 
     ciphertext_size = PSA_AEAD_FINISH_OUTPUT_SIZE(key_type, alg);
 
     TEST_LE_U(ciphertext_size, PSA_AEAD_FINISH_OUTPUT_MAX_SIZE);
 
-    TEST_CALLOC_OR_FAIL(ciphertext, ciphertext_size);
+    TEST_CALLOC(ciphertext, ciphertext_size);
 
     status = psa_aead_encrypt_setup(&operation, key, alg);
 
@@ -5245,13 +5245,13 @@ void aead_multipart_set_nonce(int key_type_arg, data_t *key_data,
 
     output_size = PSA_AEAD_UPDATE_OUTPUT_SIZE(key_type, alg, input_data->len);
 
-    TEST_CALLOC_OR_FAIL(output, output_size);
+    TEST_CALLOC(output, output_size);
 
     ciphertext_size = PSA_AEAD_FINISH_OUTPUT_SIZE(key_type, alg);
 
     TEST_LE_U(ciphertext_size, PSA_AEAD_FINISH_OUTPUT_MAX_SIZE);
 
-    TEST_CALLOC_OR_FAIL(ciphertext, ciphertext_size);
+    TEST_CALLOC(ciphertext, ciphertext_size);
 
     status = psa_aead_encrypt_setup(&operation, key, alg);
 
@@ -5268,12 +5268,12 @@ void aead_multipart_set_nonce(int key_type_arg, data_t *key_data,
     /* -1 == zero length and valid buffer, 0 = zero length and NULL buffer. */
     if (nonce_length_arg == -1) {
         /* Arbitrary size buffer, to test zero length valid buffer. */
-        TEST_CALLOC_OR_FAIL(nonce_buffer, 4);
+        TEST_CALLOC(nonce_buffer, 4);
         nonce_length = 0;
     } else {
         /* If length is zero, then this will return NULL. */
         nonce_length = (size_t) nonce_length_arg;
-        TEST_CALLOC_OR_FAIL(nonce_buffer, nonce_length);
+        TEST_CALLOC(nonce_buffer, nonce_length);
 
         if (nonce_buffer) {
             for (index = 0; index < nonce_length - 1; ++index) {
@@ -5362,11 +5362,11 @@ void aead_multipart_update_buffer_test(int key_type_arg, data_t *key_data,
 
     PSA_ASSERT(psa_get_key_attributes(key, &attributes));
 
-    TEST_CALLOC_OR_FAIL(output, output_size);
+    TEST_CALLOC(output, output_size);
 
     ciphertext_size = PSA_AEAD_FINISH_OUTPUT_SIZE(key_type, alg);
 
-    TEST_CALLOC_OR_FAIL(ciphertext, ciphertext_size);
+    TEST_CALLOC(ciphertext, ciphertext_size);
 
     status = psa_aead_encrypt_setup(&operation, key, alg);
 
@@ -5449,11 +5449,11 @@ void aead_multipart_finish_buffer_test(int key_type_arg, data_t *key_data,
 
     ciphertext_size = PSA_AEAD_UPDATE_OUTPUT_SIZE(key_type, alg, input_data->len);
 
-    TEST_CALLOC_OR_FAIL(ciphertext, ciphertext_size);
+    TEST_CALLOC(ciphertext, ciphertext_size);
 
-    TEST_CALLOC_OR_FAIL(finish_ciphertext, finish_ciphertext_size);
+    TEST_CALLOC(finish_ciphertext, finish_ciphertext_size);
 
-    TEST_CALLOC_OR_FAIL(tag_buffer, tag_size);
+    TEST_CALLOC(tag_buffer, tag_size);
 
     status = psa_aead_encrypt_setup(&operation, key, alg);
 
@@ -5538,11 +5538,11 @@ void aead_multipart_verify(int key_type_arg, data_t *key_data,
     plaintext_size = PSA_AEAD_UPDATE_OUTPUT_SIZE(key_type, alg,
                                                  input_data->len);
 
-    TEST_CALLOC_OR_FAIL(plaintext, plaintext_size);
+    TEST_CALLOC(plaintext, plaintext_size);
 
     verify_plaintext_size = PSA_AEAD_VERIFY_OUTPUT_SIZE(key_type, alg);
 
-    TEST_CALLOC_OR_FAIL(finish_plaintext, verify_plaintext_size);
+    TEST_CALLOC(finish_plaintext, verify_plaintext_size);
 
     status = psa_aead_decrypt_setup(&operation, key, alg);
 
@@ -5679,13 +5679,13 @@ void aead_multipart_state_test(int key_type_arg, data_t *key_data,
 
     output_size = PSA_AEAD_UPDATE_OUTPUT_SIZE(key_type, alg, input_data->len);
 
-    TEST_CALLOC_OR_FAIL(output_data, output_size);
+    TEST_CALLOC(output_data, output_size);
 
     finish_output_size = PSA_AEAD_FINISH_OUTPUT_SIZE(key_type, alg);
 
     TEST_LE_U(finish_output_size, PSA_AEAD_FINISH_OUTPUT_MAX_SIZE);
 
-    TEST_CALLOC_OR_FAIL(final_data, finish_output_size);
+    TEST_CALLOC(final_data, finish_output_size);
 
     /* Test all operations error without calling setup first. */
 
@@ -6483,7 +6483,7 @@ void sign_hash_deterministic(int key_type_arg, data_t *key_data,
                                           key_bits, alg);
     TEST_ASSERT(signature_size != 0);
     TEST_LE_U(signature_size, PSA_SIGNATURE_MAX_SIZE);
-    TEST_CALLOC_OR_FAIL(signature, signature_size);
+    TEST_CALLOC(signature, signature_size);
 
     /* Perform the signature. */
     PSA_ASSERT(psa_sign_hash(key, alg,
@@ -6566,7 +6566,7 @@ void sign_hash_interruptible(int key_type_arg, data_t *key_data,
                                           key_bits, alg);
     TEST_ASSERT(signature_size != 0);
     TEST_LE_U(signature_size, PSA_SIGNATURE_MAX_SIZE);
-    TEST_CALLOC_OR_FAIL(signature, signature_size);
+    TEST_CALLOC(signature, signature_size);
 
     psa_interruptible_set_max_ops(max_ops);
 
@@ -6651,7 +6651,7 @@ void sign_hash_fail(int key_type_arg, data_t *key_data,
     size_t signature_length = 0xdeadbeef;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
 
-    TEST_CALLOC_OR_FAIL(signature, signature_size);
+    TEST_CALLOC(signature, signature_size);
 
     PSA_ASSERT(psa_crypto_init());
 
@@ -6731,7 +6731,7 @@ void sign_hash_fail_interruptible(int key_type_arg, data_t *key_data,
     psa_sign_hash_interruptible_operation_t operation =
         psa_sign_hash_interruptible_operation_init();
 
-    TEST_CALLOC_OR_FAIL(signature, signature_size);
+    TEST_CALLOC(signature, signature_size);
 
     PSA_ASSERT(psa_crypto_init());
 
@@ -6859,7 +6859,7 @@ void sign_verify_hash(int key_type_arg, data_t *key_data,
                                           key_bits, alg);
     TEST_ASSERT(signature_size != 0);
     TEST_LE_U(signature_size, PSA_SIGNATURE_MAX_SIZE);
-    TEST_CALLOC_OR_FAIL(signature, signature_size);
+    TEST_CALLOC(signature, signature_size);
 
     /* Perform the signature. */
     PSA_ASSERT(psa_sign_hash(key, alg,
@@ -6962,7 +6962,7 @@ void sign_verify_hash_interruptible(int key_type_arg, data_t *key_data,
                                           key_bits, alg);
     TEST_ASSERT(signature_size != 0);
     TEST_LE_U(signature_size, PSA_SIGNATURE_MAX_SIZE);
-    TEST_CALLOC_OR_FAIL(signature, signature_size);
+    TEST_CALLOC(signature, signature_size);
 
     psa_interruptible_set_max_ops(max_ops);
 
@@ -7444,7 +7444,7 @@ void interruptible_signverify_hash_state_test(int key_type_arg,
                                           key_bits, alg);
     TEST_ASSERT(signature_size != 0);
     TEST_LE_U(signature_size, PSA_SIGNATURE_MAX_SIZE);
-    TEST_CALLOC_OR_FAIL(signature, signature_size);
+    TEST_CALLOC(signature, signature_size);
 
     psa_interruptible_set_max_ops(PSA_INTERRUPTIBLE_MAX_OPS_UNLIMITED);
 
@@ -7600,7 +7600,7 @@ void interruptible_signverify_hash_edgecase_tests(int key_type_arg,
                                           key_bits, alg);
     TEST_ASSERT(signature_size != 0);
     TEST_LE_U(signature_size, PSA_SIGNATURE_MAX_SIZE);
-    TEST_CALLOC_OR_FAIL(signature, signature_size);
+    TEST_CALLOC(signature, signature_size);
 
     /* --- Change function inputs mid run, to cause an error (sign only,
      *     verify passes all inputs to start. --- */
@@ -7731,7 +7731,7 @@ void interruptible_signverify_hash_ops_tests(int key_type_arg,
 
     TEST_ASSERT(signature_size != 0);
     TEST_LE_U(signature_size, PSA_SIGNATURE_MAX_SIZE);
-    TEST_CALLOC_OR_FAIL(signature, signature_size);
+    TEST_CALLOC(signature, signature_size);
 
     /* Check that default max ops gets set if we don't set it. */
     PSA_ASSERT(psa_sign_hash_start(&sign_operation, key, alg,
@@ -7905,7 +7905,7 @@ void sign_message_deterministic(int key_type_arg,
     signature_size = PSA_SIGN_OUTPUT_SIZE(key_type, key_bits, alg);
     TEST_ASSERT(signature_size != 0);
     TEST_LE_U(signature_size, PSA_SIGNATURE_MAX_SIZE);
-    TEST_CALLOC_OR_FAIL(signature, signature_size);
+    TEST_CALLOC(signature, signature_size);
 
     PSA_ASSERT(psa_sign_message(key, alg,
                                 input_data->x, input_data->len,
@@ -7943,7 +7943,7 @@ void sign_message_fail(int key_type_arg,
     size_t signature_length = 0xdeadbeef;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
 
-    TEST_CALLOC_OR_FAIL(signature, signature_size);
+    TEST_CALLOC(signature, signature_size);
 
     PSA_ASSERT(psa_crypto_init());
 
@@ -8003,7 +8003,7 @@ void sign_verify_message(int key_type_arg,
     signature_size = PSA_SIGN_OUTPUT_SIZE(key_type, key_bits, alg);
     TEST_ASSERT(signature_size != 0);
     TEST_LE_U(signature_size, PSA_SIGNATURE_MAX_SIZE);
-    TEST_CALLOC_OR_FAIL(signature, signature_size);
+    TEST_CALLOC(signature, signature_size);
 
     PSA_ASSERT(psa_sign_message(key, alg,
                                 input_data->x, input_data->len,
@@ -8143,7 +8143,7 @@ void asymmetric_encrypt(int key_type_arg,
 
     output_size = PSA_ASYMMETRIC_ENCRYPT_OUTPUT_SIZE(key_type, key_bits, alg);
     TEST_LE_U(output_size, PSA_ASYMMETRIC_ENCRYPT_OUTPUT_MAX_SIZE);
-    TEST_CALLOC_OR_FAIL(output, output_size);
+    TEST_CALLOC(output, output_size);
 
     /* Encrypt the input */
     actual_status = psa_asymmetric_encrypt(key, alg,
@@ -8225,13 +8225,13 @@ void asymmetric_encrypt_decrypt(int key_type_arg,
 
     output_size = PSA_ASYMMETRIC_ENCRYPT_OUTPUT_SIZE(key_type, key_bits, alg);
     TEST_LE_U(output_size, PSA_ASYMMETRIC_ENCRYPT_OUTPUT_MAX_SIZE);
-    TEST_CALLOC_OR_FAIL(output, output_size);
+    TEST_CALLOC(output, output_size);
 
     output2_size = input_data->len;
     TEST_LE_U(output2_size,
               PSA_ASYMMETRIC_DECRYPT_OUTPUT_SIZE(key_type, key_bits, alg));
     TEST_LE_U(output2_size, PSA_ASYMMETRIC_DECRYPT_OUTPUT_MAX_SIZE);
-    TEST_CALLOC_OR_FAIL(output2, output2_size);
+    TEST_CALLOC(output2, output2_size);
 
     /* We test encryption by checking that encrypt-then-decrypt gives back
      * the original plaintext because of the non-optional random
@@ -8299,7 +8299,7 @@ void asymmetric_decrypt(int key_type_arg,
     /* Determine the maximum ciphertext length */
     output_size = PSA_ASYMMETRIC_DECRYPT_OUTPUT_SIZE(key_type, key_bits, alg);
     TEST_LE_U(output_size, PSA_ASYMMETRIC_DECRYPT_OUTPUT_MAX_SIZE);
-    TEST_CALLOC_OR_FAIL(output, output_size);
+    TEST_CALLOC(output, output_size);
 
     PSA_ASSERT(psa_asymmetric_decrypt(key, alg,
                                       input_data->x, input_data->len,
@@ -8354,7 +8354,7 @@ void asymmetric_decrypt_fail(int key_type_arg,
     psa_status_t expected_status = expected_status_arg;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
 
-    TEST_CALLOC_OR_FAIL(output, output_size);
+    TEST_CALLOC(output, output_size);
 
     PSA_ASSERT(psa_crypto_init());
 
@@ -8722,7 +8722,7 @@ void derive_output(int alg_arg,
             expected_outputs[i] = NULL;
         }
     }
-    TEST_CALLOC_OR_FAIL(output_buffer, output_buffer_size);
+    TEST_CALLOC(output_buffer, output_buffer_size);
     PSA_ASSERT(psa_crypto_init());
 
     /* Extraction phase. */
@@ -8995,7 +8995,7 @@ void derive_ecjpake_to_pms(data_t *input, int expected_input_status_arg,
     psa_status_t expected_capacity_status = (psa_status_t) expected_capacity_status_arg;
     psa_status_t expected_output_status = (psa_status_t) expected_output_status_arg;
 
-    TEST_CALLOC_OR_FAIL(output_buffer, expected_output->len);
+    TEST_CALLOC(output_buffer, expected_output->len);
     PSA_ASSERT(psa_crypto_init());
 
     PSA_ASSERT(psa_key_derivation_setup(&operation, alg));
@@ -9116,8 +9116,8 @@ void derive_key_export(int alg_arg,
     psa_key_attributes_t derived_attributes = PSA_KEY_ATTRIBUTES_INIT;
     size_t length;
 
-    TEST_CALLOC_OR_FAIL(output_buffer, capacity);
-    TEST_CALLOC_OR_FAIL(export_buffer, capacity);
+    TEST_CALLOC(output_buffer, capacity);
+    TEST_CALLOC(export_buffer, capacity);
     PSA_ASSERT(psa_crypto_init());
 
     psa_set_key_usage_flags(&base_attributes, PSA_KEY_USAGE_DERIVE);
@@ -9201,7 +9201,7 @@ void derive_key_type(int alg_arg,
     psa_key_attributes_t derived_attributes = PSA_KEY_ATTRIBUTES_INIT;
     size_t export_length;
 
-    TEST_CALLOC_OR_FAIL(export_buffer, export_buffer_size);
+    TEST_CALLOC(export_buffer, export_buffer_size);
     PSA_ASSERT(psa_crypto_init());
 
     psa_set_key_usage_flags(&base_attributes, PSA_KEY_USAGE_DERIVE);
@@ -9373,7 +9373,7 @@ void raw_key_agreement(int alg_arg,
               PSA_RAW_KEY_AGREEMENT_OUTPUT_MAX_SIZE);
 
     /* Good case with exact output size */
-    TEST_CALLOC_OR_FAIL(output, expected_output->len);
+    TEST_CALLOC(output, expected_output->len);
     PSA_ASSERT(psa_raw_key_agreement(alg, our_key,
                                      peer_key_data->x, peer_key_data->len,
                                      output, expected_output->len,
@@ -9385,7 +9385,7 @@ void raw_key_agreement(int alg_arg,
     output_length = ~0;
 
     /* Larger buffer */
-    TEST_CALLOC_OR_FAIL(output, expected_output->len + 1);
+    TEST_CALLOC(output, expected_output->len + 1);
     PSA_ASSERT(psa_raw_key_agreement(alg, our_key,
                                      peer_key_data->x, peer_key_data->len,
                                      output, expected_output->len + 1,
@@ -9397,7 +9397,7 @@ void raw_key_agreement(int alg_arg,
     output_length = ~0;
 
     /* Buffer too small */
-    TEST_CALLOC_OR_FAIL(output, expected_output->len - 1);
+    TEST_CALLOC(output, expected_output->len - 1);
     TEST_EQUAL(psa_raw_key_agreement(alg, our_key,
                                      peer_key_data->x, peer_key_data->len,
                                      output, expected_output->len - 1,
@@ -9486,7 +9486,7 @@ void key_agreement_output(int alg_arg,
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     uint8_t *actual_output = NULL;
 
-    TEST_CALLOC_OR_FAIL(actual_output, MAX(expected_output1->len,
+    TEST_CALLOC(actual_output, MAX(expected_output1->len,
                                     expected_output2->len));
 
     PSA_ASSERT(psa_crypto_init());
@@ -9542,8 +9542,8 @@ void generate_random(int bytes_arg)
 
     TEST_ASSERT(bytes_arg >= 0);
 
-    TEST_CALLOC_OR_FAIL(output, bytes);
-    TEST_CALLOC_OR_FAIL(changed, bytes);
+    TEST_CALLOC(output, bytes);
+    TEST_CALLOC(changed, bytes);
 
     PSA_ASSERT(psa_crypto_init());
 
@@ -9661,8 +9661,8 @@ void generate_key_rsa(int bits_arg,
         is_default_public_exponent = 1;
         e_read_size = 0;
     }
-    TEST_CALLOC_OR_FAIL(e_read_buffer, e_read_size);
-    TEST_CALLOC_OR_FAIL(exported, exported_size);
+    TEST_CALLOC(e_read_buffer, e_read_size);
+    TEST_CALLOC(exported, exported_size);
 
     PSA_ASSERT(psa_crypto_init());
 
@@ -9764,8 +9764,8 @@ void persistent_key_load_key_from_storage(data_t *data,
     size_t second_exported_length;
 
     if (usage_flags & PSA_KEY_USAGE_EXPORT) {
-        TEST_CALLOC_OR_FAIL(first_export, export_size);
-        TEST_CALLOC_OR_FAIL(second_export, export_size);
+        TEST_CALLOC(first_export, export_size);
+        TEST_CALLOC(second_export, export_size);
     }
 
     PSA_ASSERT(psa_crypto_init());
@@ -9912,7 +9912,7 @@ void ecjpake_setup(int alg_arg, int key_type_pw_arg, int key_usage_pw_arg,
 
     size_t buf_size = PSA_PAKE_OUTPUT_SIZE(alg, primitive_arg,
                                            PSA_PAKE_STEP_KEY_SHARE);
-    TEST_CALLOC_OR_FAIL(output_buffer, buf_size);
+    TEST_CALLOC(output_buffer, buf_size);
 
     if (pw_data->len > 0) {
         psa_set_key_usage_flags(&attributes, key_usage_pw);

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -584,7 +584,7 @@ static int aead_multipart_internal_func(int key_type_arg, data_t *key_data,
 
 
     TEST_MEMORY_COMPARE(expected_output->x, expected_output->len,
-                   output_data, output_length);
+                        output_data, output_length);
 
 
     test_ok = 1;
@@ -693,7 +693,7 @@ static int mac_multipart_internal_func(int key_type_arg, data_t *key_data,
                                        PSA_MAC_MAX_SIZE, &mac_len));
 
         TEST_MEMORY_COMPARE(expected_output->x, expected_output->len,
-                       mac, mac_len);
+                            mac, mac_len);
     }
 
     test_ok = 1;
@@ -1584,7 +1584,7 @@ void import_export(data_t *data,
                                   export_size,
                                   &reexported_length));
         TEST_MEMORY_COMPARE(exported, exported_length,
-                       reexported, reexported_length);
+                            reexported, reexported_length);
         PSA_ASSERT(psa_destroy_key(key2));
     }
     TEST_LE_U(exported_length,
@@ -1658,7 +1658,7 @@ void import_export_public_key(data_t *data,
         TEST_LE_U(expected_public_key->len,
                   PSA_EXPORT_PUBLIC_KEY_MAX_SIZE);
         TEST_MEMORY_COMPARE(expected_public_key->x, expected_public_key->len,
-                       exported, exported_length);
+                            exported, exported_length);
     }
 exit:
     /*
@@ -2502,7 +2502,7 @@ void copy_success(int source_usage_arg,
         PSA_ASSERT(psa_export_key(target_key, export_buffer,
                                   material->len, &length));
         TEST_MEMORY_COMPARE(material->x, material->len,
-                       export_buffer, length);
+                            export_buffer, length);
     }
 
     if (!psa_key_lifetime_is_external(target_lifetime)) {
@@ -2761,7 +2761,7 @@ void hash_compute_compare(int alg_arg, data_t *input,
                                 &output_length));
     TEST_EQUAL(output_length, PSA_HASH_LENGTH(alg));
     TEST_MEMORY_COMPARE(output, output_length,
-                   expected_output->x, expected_output->len);
+                        expected_output->x, expected_output->len);
 
     /* Compute with tight buffer, multi-part */
     PSA_ASSERT(psa_hash_setup(&operation, alg));
@@ -2771,7 +2771,7 @@ void hash_compute_compare(int alg_arg, data_t *input,
                                &output_length));
     TEST_EQUAL(output_length, PSA_HASH_LENGTH(alg));
     TEST_MEMORY_COMPARE(output, output_length,
-                   expected_output->x, expected_output->len);
+                        expected_output->x, expected_output->len);
 
     /* Compute with larger buffer, one-shot */
     PSA_ASSERT(psa_hash_compute(alg, input->x, input->len,
@@ -2779,7 +2779,7 @@ void hash_compute_compare(int alg_arg, data_t *input,
                                 &output_length));
     TEST_EQUAL(output_length, PSA_HASH_LENGTH(alg));
     TEST_MEMORY_COMPARE(output, output_length,
-                   expected_output->x, expected_output->len);
+                        expected_output->x, expected_output->len);
 
     /* Compute with larger buffer, multi-part */
     PSA_ASSERT(psa_hash_setup(&operation, alg));
@@ -2788,7 +2788,7 @@ void hash_compute_compare(int alg_arg, data_t *input,
                                sizeof(output), &output_length));
     TEST_EQUAL(output_length, PSA_HASH_LENGTH(alg));
     TEST_MEMORY_COMPARE(output, output_length,
-                   expected_output->x, expected_output->len);
+                        expected_output->x, expected_output->len);
 
     /* Compare with correct hash, one-shot */
     PSA_ASSERT(psa_hash_compare(alg, input->x, input->len,
@@ -3393,7 +3393,7 @@ void mac_sign(int key_type_arg,
                    expected_status);
         if (expected_status == PSA_SUCCESS) {
             TEST_MEMORY_COMPARE(expected_mac->x, expected_mac->len,
-                           actual_mac, mac_length);
+                                actual_mac, mac_length);
         }
 
         if (output_size > 0) {
@@ -3412,7 +3412,7 @@ void mac_sign(int key_type_arg,
 
         if (expected_status == PSA_SUCCESS) {
             TEST_MEMORY_COMPARE(expected_mac->x, expected_mac->len,
-                           actual_mac, mac_length);
+                                actual_mac, mac_length);
         }
         mbedtls_free(actual_mac);
         actual_mac = NULL;
@@ -3963,7 +3963,7 @@ void cipher_alg_without_iv(int alg_arg, int key_type_arg, data_t *key_data,
                                  &length));
     output_length += length;
     TEST_MEMORY_COMPARE(ciphertext->x, ciphertext->len,
-                   output, output_length);
+                        output, output_length);
 
     /* Multipart encryption */
     PSA_ASSERT(psa_cipher_decrypt_setup(&operation, key, alg));
@@ -3981,7 +3981,7 @@ void cipher_alg_without_iv(int alg_arg, int key_type_arg, data_t *key_data,
                                  &length));
     output_length += length;
     TEST_MEMORY_COMPARE(plaintext->x, plaintext->len,
-                   output, output_length);
+                        output, output_length);
 
     /* One-shot encryption */
     output_length = ~0;
@@ -3989,7 +3989,7 @@ void cipher_alg_without_iv(int alg_arg, int key_type_arg, data_t *key_data,
                                   output, output_buffer_size,
                                   &output_length));
     TEST_MEMORY_COMPARE(ciphertext->x, ciphertext->len,
-                   output, output_length);
+                        output, output_length);
 
     /* One-shot decryption */
     output_length = ~0;
@@ -3997,7 +3997,7 @@ void cipher_alg_without_iv(int alg_arg, int key_type_arg, data_t *key_data,
                                   output, output_buffer_size,
                                   &output_length));
     TEST_MEMORY_COMPARE(plaintext->x, plaintext->len,
-                   output, output_length);
+                        output, output_length);
 
 exit:
     PSA_ASSERT(psa_cipher_abort(&operation));
@@ -4117,7 +4117,7 @@ void cipher_encrypt_validation(int alg_arg,
 
     PSA_ASSERT(psa_cipher_abort(&operation));
     TEST_MEMORY_COMPARE(output1 + iv_size, output1_length - iv_size,
-                   output2, output2_length);
+                        output2, output2_length);
 
 exit:
     psa_cipher_abort(&operation);
@@ -4216,7 +4216,7 @@ void cipher_encrypt_multipart(int alg_arg, int key_type_arg,
         PSA_ASSERT(psa_cipher_abort(&operation));
 
         TEST_MEMORY_COMPARE(expected_output->x, expected_output->len,
-                       output, total_output_length);
+                            output, total_output_length);
     }
 
 exit:
@@ -4316,7 +4316,7 @@ void cipher_decrypt_multipart(int alg_arg, int key_type_arg,
         PSA_ASSERT(psa_cipher_abort(&operation));
 
         TEST_MEMORY_COMPARE(expected_output->x, expected_output->len,
-                       output, total_output_length);
+                            output, total_output_length);
     }
 
 exit:
@@ -4473,7 +4473,7 @@ void cipher_decrypt(int alg_arg,
               PSA_CIPHER_DECRYPT_OUTPUT_MAX_SIZE(input_buffer_size));
 
     TEST_MEMORY_COMPARE(expected_output->x, expected_output->len,
-                   output, output_length);
+                        output, output_length);
 exit:
     mbedtls_free(input);
     mbedtls_free(output);
@@ -4765,7 +4765,7 @@ void aead_encrypt_decrypt(int key_type_arg, data_t *key_data,
                    expected_result);
 
         TEST_MEMORY_COMPARE(input_data->x, input_data->len,
-                       output_data2, output_length2);
+                            output_data2, output_length2);
     }
 
 exit:
@@ -4832,7 +4832,7 @@ void aead_encrypt(int key_type_arg, data_t *key_data,
 
     PSA_ASSERT(status);
     TEST_MEMORY_COMPARE(expected_result->x, expected_result->len,
-                   output_data, output_length);
+                        output_data, output_length);
 
 exit:
     psa_destroy_key(key);
@@ -4905,7 +4905,7 @@ void aead_decrypt(int key_type_arg, data_t *key_data,
 
     if (expected_result == PSA_SUCCESS) {
         TEST_MEMORY_COMPARE(expected_data->x, expected_data->len,
-                       output_data, output_length);
+                            output_data, output_length);
     }
 
 exit:
@@ -6492,7 +6492,7 @@ void sign_hash_deterministic(int key_type_arg, data_t *key_data,
                              &signature_length));
     /* Verify that the signature is what is expected. */
     TEST_MEMORY_COMPARE(output_data->x, output_data->len,
-                   signature, signature_length);
+                        signature, signature_length);
 
 exit:
     /*
@@ -6615,7 +6615,7 @@ void sign_hash_interruptible(int key_type_arg, data_t *key_data,
 
     /* Verify that the signature is what is expected. */
     TEST_MEMORY_COMPARE(output_data->x, output_data->len,
-                   signature, signature_length);
+                        signature, signature_length);
 
     PSA_ASSERT(psa_sign_hash_abort(&operation));
 
@@ -7913,7 +7913,7 @@ void sign_message_deterministic(int key_type_arg,
                                 &signature_length));
 
     TEST_MEMORY_COMPARE(output_data->x, output_data->len,
-                   signature, signature_length);
+                        signature, signature_length);
 
 exit:
     psa_reset_key_attributes(&attributes);
@@ -8251,7 +8251,7 @@ void asymmetric_encrypt_decrypt(int key_type_arg,
                                       output2, output2_size,
                                       &output2_length));
     TEST_MEMORY_COMPARE(input_data->x, input_data->len,
-                   output2, output2_length);
+                        output2, output2_length);
 
 exit:
     /*
@@ -8308,7 +8308,7 @@ void asymmetric_decrypt(int key_type_arg,
                                       output_size,
                                       &output_length));
     TEST_MEMORY_COMPARE(expected_data->x, expected_data->len,
-                   output, output_length);
+                        output, output_length);
 
     /* If the label is empty, the test framework puts a non-null pointer
      * in label->x. Test that a null pointer works as well. */
@@ -8324,7 +8324,7 @@ void asymmetric_decrypt(int key_type_arg,
                                           output_size,
                                           &output_length));
         TEST_MEMORY_COMPARE(expected_data->x, expected_data->len,
-                       output, output_length);
+                            output, output_length);
     }
 
 exit:
@@ -8893,7 +8893,7 @@ void derive_output(int alg_arg,
             PSA_ASSERT(status);
             if (output_sizes[i] != 0) {
                 TEST_MEMORY_COMPARE(output_buffer, output_sizes[i],
-                               expected_outputs[i], output_sizes[i]);
+                                    expected_outputs[i], output_sizes[i]);
             }
             /* Check the operation status. */
             expected_capacity -= output_sizes[i];
@@ -9016,7 +9016,7 @@ void derive_ecjpake_to_pms(data_t *input, int expected_input_status_arg,
     TEST_EQUAL(status, expected_output_status);
     if (expected_output->len != 0 && expected_output_status == PSA_SUCCESS) {
         TEST_MEMORY_COMPARE(output_buffer, expected_output->len, expected_output->x,
-                       expected_output->len);
+                            expected_output->len);
     }
 
 exit:
@@ -9168,7 +9168,7 @@ void derive_key_export(int alg_arg,
 
     /* Compare the outputs from the two runs. */
     TEST_MEMORY_COMPARE(output_buffer, bytes1 + bytes2,
-                   export_buffer, capacity);
+                        export_buffer, capacity);
 
 exit:
     mbedtls_free(output_buffer);
@@ -9229,7 +9229,7 @@ void derive_key_type(int alg_arg,
                               export_buffer, export_buffer_size,
                               &export_length));
     TEST_MEMORY_COMPARE(export_buffer, export_length,
-                   expected_export->x, expected_export->len);
+                        expected_export->x, expected_export->len);
 
 exit:
     mbedtls_free(export_buffer);
@@ -9379,7 +9379,7 @@ void raw_key_agreement(int alg_arg,
                                      output, expected_output->len,
                                      &output_length));
     TEST_MEMORY_COMPARE(output, output_length,
-                   expected_output->x, expected_output->len);
+                        expected_output->x, expected_output->len);
     mbedtls_free(output);
     output = NULL;
     output_length = ~0;
@@ -9391,7 +9391,7 @@ void raw_key_agreement(int alg_arg,
                                      output, expected_output->len + 1,
                                      &output_length));
     TEST_MEMORY_COMPARE(output, output_length,
-                   expected_output->x, expected_output->len);
+                        expected_output->x, expected_output->len);
     mbedtls_free(output);
     output = NULL;
     output_length = ~0;
@@ -9487,7 +9487,7 @@ void key_agreement_output(int alg_arg,
     uint8_t *actual_output = NULL;
 
     TEST_CALLOC(actual_output, MAX(expected_output1->len,
-                                    expected_output2->len));
+                                   expected_output2->len));
 
     PSA_ASSERT(psa_crypto_init());
 
@@ -9514,13 +9514,13 @@ void key_agreement_output(int alg_arg,
                                                actual_output,
                                                expected_output1->len));
     TEST_MEMORY_COMPARE(actual_output, expected_output1->len,
-                   expected_output1->x, expected_output1->len);
+                        expected_output1->x, expected_output1->len);
     if (expected_output2->len != 0) {
         PSA_ASSERT(psa_key_derivation_output_bytes(&operation,
                                                    actual_output,
                                                    expected_output2->len));
         TEST_MEMORY_COMPARE(actual_output, expected_output2->len,
-                       expected_output2->x, expected_output2->len);
+                            expected_output2->x, expected_output2->len);
     }
 
 exit:
@@ -9834,7 +9834,7 @@ void persistent_key_load_key_from_storage(data_t *data,
                                   &first_exported_length));
         if (generation_method == IMPORT_KEY) {
             TEST_MEMORY_COMPARE(data->x, data->len,
-                           first_export, first_exported_length);
+                                first_export, first_exported_length);
         }
     }
 
@@ -9861,7 +9861,7 @@ void persistent_key_load_key_from_storage(data_t *data,
                                   second_export, export_size,
                                   &second_exported_length));
         TEST_MEMORY_COMPARE(first_export, first_exported_length,
-                       second_export, second_exported_length);
+                            second_export, second_exported_length);
     }
 
     /* Do something with the key according to its type and permitted usage. */

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -583,7 +583,7 @@ static int aead_multipart_internal_func(int key_type_arg, data_t *key_data,
     }
 
 
-    ASSERT_COMPARE(expected_output->x, expected_output->len,
+    TEST_BUFFERS_EQUAL(expected_output->x, expected_output->len,
                    output_data, output_length);
 
 
@@ -692,7 +692,7 @@ static int mac_multipart_internal_func(int key_type_arg, data_t *key_data,
         PSA_ASSERT(psa_mac_sign_finish(&operation, mac,
                                        PSA_MAC_MAX_SIZE, &mac_len));
 
-        ASSERT_COMPARE(expected_output->x, expected_output->len,
+        TEST_BUFFERS_EQUAL(expected_output->x, expected_output->len,
                        mac, mac_len);
     }
 
@@ -1574,7 +1574,7 @@ void import_export(data_t *data,
     }
 
     if (canonical_input) {
-        ASSERT_COMPARE(data->x, data->len, exported, exported_length);
+        TEST_BUFFERS_EQUAL(data->x, data->len, exported, exported_length);
     } else {
         mbedtls_svc_key_id_t key2 = MBEDTLS_SVC_KEY_ID_INIT;
         PSA_ASSERT(psa_import_key(&attributes, exported, exported_length,
@@ -1583,7 +1583,7 @@ void import_export(data_t *data,
                                   reexported,
                                   export_size,
                                   &reexported_length));
-        ASSERT_COMPARE(exported, exported_length,
+        TEST_BUFFERS_EQUAL(exported, exported_length,
                        reexported, reexported_length);
         PSA_ASSERT(psa_destroy_key(key2));
     }
@@ -1657,7 +1657,7 @@ void import_export_public_key(data_t *data,
                   PSA_EXPORT_PUBLIC_KEY_OUTPUT_SIZE(public_type, bits));
         TEST_LE_U(expected_public_key->len,
                   PSA_EXPORT_PUBLIC_KEY_MAX_SIZE);
-        ASSERT_COMPARE(expected_public_key->x, expected_public_key->len,
+        TEST_BUFFERS_EQUAL(expected_public_key->x, expected_public_key->len,
                        exported, exported_length);
     }
 exit:
@@ -2501,7 +2501,7 @@ void copy_success(int source_usage_arg,
         ASSERT_ALLOC(export_buffer, material->len);
         PSA_ASSERT(psa_export_key(target_key, export_buffer,
                                   material->len, &length));
-        ASSERT_COMPARE(material->x, material->len,
+        TEST_BUFFERS_EQUAL(material->x, material->len,
                        export_buffer, length);
     }
 
@@ -2760,7 +2760,7 @@ void hash_compute_compare(int alg_arg, data_t *input,
                                 output, PSA_HASH_LENGTH(alg),
                                 &output_length));
     TEST_EQUAL(output_length, PSA_HASH_LENGTH(alg));
-    ASSERT_COMPARE(output, output_length,
+    TEST_BUFFERS_EQUAL(output, output_length,
                    expected_output->x, expected_output->len);
 
     /* Compute with tight buffer, multi-part */
@@ -2770,7 +2770,7 @@ void hash_compute_compare(int alg_arg, data_t *input,
                                PSA_HASH_LENGTH(alg),
                                &output_length));
     TEST_EQUAL(output_length, PSA_HASH_LENGTH(alg));
-    ASSERT_COMPARE(output, output_length,
+    TEST_BUFFERS_EQUAL(output, output_length,
                    expected_output->x, expected_output->len);
 
     /* Compute with larger buffer, one-shot */
@@ -2778,7 +2778,7 @@ void hash_compute_compare(int alg_arg, data_t *input,
                                 output, sizeof(output),
                                 &output_length));
     TEST_EQUAL(output_length, PSA_HASH_LENGTH(alg));
-    ASSERT_COMPARE(output, output_length,
+    TEST_BUFFERS_EQUAL(output, output_length,
                    expected_output->x, expected_output->len);
 
     /* Compute with larger buffer, multi-part */
@@ -2787,7 +2787,7 @@ void hash_compute_compare(int alg_arg, data_t *input,
     PSA_ASSERT(psa_hash_finish(&operation, output,
                                sizeof(output), &output_length));
     TEST_EQUAL(output_length, PSA_HASH_LENGTH(alg));
-    ASSERT_COMPARE(output, output_length,
+    TEST_BUFFERS_EQUAL(output, output_length,
                    expected_output->x, expected_output->len);
 
     /* Compare with correct hash, one-shot */
@@ -3392,7 +3392,7 @@ void mac_sign(int key_type_arg,
                                    actual_mac, output_size, &mac_length),
                    expected_status);
         if (expected_status == PSA_SUCCESS) {
-            ASSERT_COMPARE(expected_mac->x, expected_mac->len,
+            TEST_BUFFERS_EQUAL(expected_mac->x, expected_mac->len,
                            actual_mac, mac_length);
         }
 
@@ -3411,7 +3411,7 @@ void mac_sign(int key_type_arg,
         PSA_ASSERT(psa_mac_abort(&operation));
 
         if (expected_status == PSA_SUCCESS) {
-            ASSERT_COMPARE(expected_mac->x, expected_mac->len,
+            TEST_BUFFERS_EQUAL(expected_mac->x, expected_mac->len,
                            actual_mac, mac_length);
         }
         mbedtls_free(actual_mac);
@@ -3962,7 +3962,7 @@ void cipher_alg_without_iv(int alg_arg, int key_type_arg, data_t *key_data,
                                  output_buffer_size - output_length,
                                  &length));
     output_length += length;
-    ASSERT_COMPARE(ciphertext->x, ciphertext->len,
+    TEST_BUFFERS_EQUAL(ciphertext->x, ciphertext->len,
                    output, output_length);
 
     /* Multipart encryption */
@@ -3980,7 +3980,7 @@ void cipher_alg_without_iv(int alg_arg, int key_type_arg, data_t *key_data,
                                  output_buffer_size - output_length,
                                  &length));
     output_length += length;
-    ASSERT_COMPARE(plaintext->x, plaintext->len,
+    TEST_BUFFERS_EQUAL(plaintext->x, plaintext->len,
                    output, output_length);
 
     /* One-shot encryption */
@@ -3988,7 +3988,7 @@ void cipher_alg_without_iv(int alg_arg, int key_type_arg, data_t *key_data,
     PSA_ASSERT(psa_cipher_encrypt(key, alg, plaintext->x, plaintext->len,
                                   output, output_buffer_size,
                                   &output_length));
-    ASSERT_COMPARE(ciphertext->x, ciphertext->len,
+    TEST_BUFFERS_EQUAL(ciphertext->x, ciphertext->len,
                    output, output_length);
 
     /* One-shot decryption */
@@ -3996,7 +3996,7 @@ void cipher_alg_without_iv(int alg_arg, int key_type_arg, data_t *key_data,
     PSA_ASSERT(psa_cipher_decrypt(key, alg, ciphertext->x, ciphertext->len,
                                   output, output_buffer_size,
                                   &output_length));
-    ASSERT_COMPARE(plaintext->x, plaintext->len,
+    TEST_BUFFERS_EQUAL(plaintext->x, plaintext->len,
                    output, output_length);
 
 exit:
@@ -4116,7 +4116,7 @@ void cipher_encrypt_validation(int alg_arg,
     output2_length += function_output_length;
 
     PSA_ASSERT(psa_cipher_abort(&operation));
-    ASSERT_COMPARE(output1 + iv_size, output1_length - iv_size,
+    TEST_BUFFERS_EQUAL(output1 + iv_size, output1_length - iv_size,
                    output2, output2_length);
 
 exit:
@@ -4215,7 +4215,7 @@ void cipher_encrypt_multipart(int alg_arg, int key_type_arg,
     if (expected_status == PSA_SUCCESS) {
         PSA_ASSERT(psa_cipher_abort(&operation));
 
-        ASSERT_COMPARE(expected_output->x, expected_output->len,
+        TEST_BUFFERS_EQUAL(expected_output->x, expected_output->len,
                        output, total_output_length);
     }
 
@@ -4315,7 +4315,7 @@ void cipher_decrypt_multipart(int alg_arg, int key_type_arg,
     if (expected_status == PSA_SUCCESS) {
         PSA_ASSERT(psa_cipher_abort(&operation));
 
-        ASSERT_COMPARE(expected_output->x, expected_output->len,
+        TEST_BUFFERS_EQUAL(expected_output->x, expected_output->len,
                        output, total_output_length);
     }
 
@@ -4472,7 +4472,7 @@ void cipher_decrypt(int alg_arg,
     TEST_LE_U(output_length,
               PSA_CIPHER_DECRYPT_OUTPUT_MAX_SIZE(input_buffer_size));
 
-    ASSERT_COMPARE(expected_output->x, expected_output->len,
+    TEST_BUFFERS_EQUAL(expected_output->x, expected_output->len,
                    output, output_length);
 exit:
     mbedtls_free(input);
@@ -4529,7 +4529,7 @@ void cipher_verify_output(int alg_arg,
     TEST_LE_U(output2_length,
               PSA_CIPHER_DECRYPT_OUTPUT_MAX_SIZE(output1_length));
 
-    ASSERT_COMPARE(input->x, input->len, output2, output2_length);
+    TEST_BUFFERS_EQUAL(input->x, input->len, output2, output2_length);
 
 exit:
     mbedtls_free(output1);
@@ -4669,7 +4669,7 @@ void cipher_verify_output_multipart(int alg_arg,
 
     PSA_ASSERT(psa_cipher_abort(&operation2));
 
-    ASSERT_COMPARE(input->x, input->len, output2, output2_length);
+    TEST_BUFFERS_EQUAL(input->x, input->len, output2, output2_length);
 
 exit:
     psa_cipher_abort(&operation1);
@@ -4764,7 +4764,7 @@ void aead_encrypt_decrypt(int key_type_arg, data_t *key_data,
                                     &output_length2),
                    expected_result);
 
-        ASSERT_COMPARE(input_data->x, input_data->len,
+        TEST_BUFFERS_EQUAL(input_data->x, input_data->len,
                        output_data2, output_length2);
     }
 
@@ -4831,7 +4831,7 @@ void aead_encrypt(int key_type_arg, data_t *key_data,
     }
 
     PSA_ASSERT(status);
-    ASSERT_COMPARE(expected_result->x, expected_result->len,
+    TEST_BUFFERS_EQUAL(expected_result->x, expected_result->len,
                    output_data, output_length);
 
 exit:
@@ -4904,7 +4904,7 @@ void aead_decrypt(int key_type_arg, data_t *key_data,
     TEST_EQUAL(status, expected_result);
 
     if (expected_result == PSA_SUCCESS) {
-        ASSERT_COMPARE(expected_data->x, expected_data->len,
+        TEST_BUFFERS_EQUAL(expected_data->x, expected_data->len,
                        output_data, output_length);
     }
 
@@ -6491,7 +6491,7 @@ void sign_hash_deterministic(int key_type_arg, data_t *key_data,
                              signature, signature_size,
                              &signature_length));
     /* Verify that the signature is what is expected. */
-    ASSERT_COMPARE(output_data->x, output_data->len,
+    TEST_BUFFERS_EQUAL(output_data->x, output_data->len,
                    signature, signature_length);
 
 exit:
@@ -6614,7 +6614,7 @@ void sign_hash_interruptible(int key_type_arg, data_t *key_data,
     TEST_LE_U(num_completes, max_completes);
 
     /* Verify that the signature is what is expected. */
-    ASSERT_COMPARE(output_data->x, output_data->len,
+    TEST_BUFFERS_EQUAL(output_data->x, output_data->len,
                    signature, signature_length);
 
     PSA_ASSERT(psa_sign_hash_abort(&operation));
@@ -7912,7 +7912,7 @@ void sign_message_deterministic(int key_type_arg,
                                 signature, signature_size,
                                 &signature_length));
 
-    ASSERT_COMPARE(output_data->x, output_data->len,
+    TEST_BUFFERS_EQUAL(output_data->x, output_data->len,
                    signature, signature_length);
 
 exit:
@@ -8250,7 +8250,7 @@ void asymmetric_encrypt_decrypt(int key_type_arg,
                                       label->x, label->len,
                                       output2, output2_size,
                                       &output2_length));
-    ASSERT_COMPARE(input_data->x, input_data->len,
+    TEST_BUFFERS_EQUAL(input_data->x, input_data->len,
                    output2, output2_length);
 
 exit:
@@ -8307,7 +8307,7 @@ void asymmetric_decrypt(int key_type_arg,
                                       output,
                                       output_size,
                                       &output_length));
-    ASSERT_COMPARE(expected_data->x, expected_data->len,
+    TEST_BUFFERS_EQUAL(expected_data->x, expected_data->len,
                    output, output_length);
 
     /* If the label is empty, the test framework puts a non-null pointer
@@ -8323,7 +8323,7 @@ void asymmetric_decrypt(int key_type_arg,
                                           output,
                                           output_size,
                                           &output_length));
-        ASSERT_COMPARE(expected_data->x, expected_data->len,
+        TEST_BUFFERS_EQUAL(expected_data->x, expected_data->len,
                        output, output_length);
     }
 
@@ -8892,7 +8892,7 @@ void derive_output(int alg_arg,
             /* Success. Check the read data. */
             PSA_ASSERT(status);
             if (output_sizes[i] != 0) {
-                ASSERT_COMPARE(output_buffer, output_sizes[i],
+                TEST_BUFFERS_EQUAL(output_buffer, output_sizes[i],
                                expected_outputs[i], output_sizes[i]);
             }
             /* Check the operation status. */
@@ -9015,7 +9015,7 @@ void derive_ecjpake_to_pms(data_t *input, int expected_input_status_arg,
 
     TEST_EQUAL(status, expected_output_status);
     if (expected_output->len != 0 && expected_output_status == PSA_SUCCESS) {
-        ASSERT_COMPARE(output_buffer, expected_output->len, expected_output->x,
+        TEST_BUFFERS_EQUAL(output_buffer, expected_output->len, expected_output->x,
                        expected_output->len);
     }
 
@@ -9167,7 +9167,7 @@ void derive_key_export(int alg_arg,
     TEST_EQUAL(length, bytes2);
 
     /* Compare the outputs from the two runs. */
-    ASSERT_COMPARE(output_buffer, bytes1 + bytes2,
+    TEST_BUFFERS_EQUAL(output_buffer, bytes1 + bytes2,
                    export_buffer, capacity);
 
 exit:
@@ -9228,7 +9228,7 @@ void derive_key_type(int alg_arg,
     PSA_ASSERT(psa_export_key(derived_key,
                               export_buffer, export_buffer_size,
                               &export_length));
-    ASSERT_COMPARE(export_buffer, export_length,
+    TEST_BUFFERS_EQUAL(export_buffer, export_length,
                    expected_export->x, expected_export->len);
 
 exit:
@@ -9378,7 +9378,7 @@ void raw_key_agreement(int alg_arg,
                                      peer_key_data->x, peer_key_data->len,
                                      output, expected_output->len,
                                      &output_length));
-    ASSERT_COMPARE(output, output_length,
+    TEST_BUFFERS_EQUAL(output, output_length,
                    expected_output->x, expected_output->len);
     mbedtls_free(output);
     output = NULL;
@@ -9390,7 +9390,7 @@ void raw_key_agreement(int alg_arg,
                                      peer_key_data->x, peer_key_data->len,
                                      output, expected_output->len + 1,
                                      &output_length));
-    ASSERT_COMPARE(output, output_length,
+    TEST_BUFFERS_EQUAL(output, output_length,
                    expected_output->x, expected_output->len);
     mbedtls_free(output);
     output = NULL;
@@ -9513,13 +9513,13 @@ void key_agreement_output(int alg_arg,
     PSA_ASSERT(psa_key_derivation_output_bytes(&operation,
                                                actual_output,
                                                expected_output1->len));
-    ASSERT_COMPARE(actual_output, expected_output1->len,
+    TEST_BUFFERS_EQUAL(actual_output, expected_output1->len,
                    expected_output1->x, expected_output1->len);
     if (expected_output2->len != 0) {
         PSA_ASSERT(psa_key_derivation_output_bytes(&operation,
                                                    actual_output,
                                                    expected_output2->len));
-        ASSERT_COMPARE(actual_output, expected_output2->len,
+        TEST_BUFFERS_EQUAL(actual_output, expected_output2->len,
                        expected_output2->x, expected_output2->len);
     }
 
@@ -9688,7 +9688,7 @@ void generate_key_rsa(int bits_arg,
     if (is_default_public_exponent) {
         TEST_EQUAL(e_read_length, 0);
     } else {
-        ASSERT_COMPARE(e_read_buffer, e_read_length, e_arg->x, e_arg->len);
+        TEST_BUFFERS_EQUAL(e_read_buffer, e_read_length, e_arg->x, e_arg->len);
     }
 
     /* Do something with the key according to its type and permitted usage. */
@@ -9724,7 +9724,7 @@ void generate_key_rsa(int bits_arg,
             TEST_EQUAL(p[1], 0);
             TEST_EQUAL(p[2], 1);
         } else {
-            ASSERT_COMPARE(p, len, e_arg->x, e_arg->len);
+            TEST_BUFFERS_EQUAL(p, len, e_arg->x, e_arg->len);
         }
     }
 
@@ -9833,7 +9833,7 @@ void persistent_key_load_key_from_storage(data_t *data,
                                   first_export, export_size,
                                   &first_exported_length));
         if (generation_method == IMPORT_KEY) {
-            ASSERT_COMPARE(data->x, data->len,
+            TEST_BUFFERS_EQUAL(data->x, data->len,
                            first_export, first_exported_length);
         }
     }
@@ -9860,7 +9860,7 @@ void persistent_key_load_key_from_storage(data_t *data,
         PSA_ASSERT(psa_export_key(key,
                                   second_export, export_size,
                                   &second_exported_length));
-        ASSERT_COMPARE(first_export, first_exported_length,
+        TEST_BUFFERS_EQUAL(first_export, first_exported_length,
                        second_export, second_exported_length);
     }
 

--- a/tests/suites/test_suite_psa_crypto_driver_wrappers.function
+++ b/tests/suites/test_suite_psa_crypto_driver_wrappers.function
@@ -460,7 +460,7 @@ static int sanity_check_rsa_encryption_result(
         TEST_EQUAL(buf[0], 0x00);
         TEST_EQUAL(buf[1], 0x02);
         TEST_EQUAL(buf[length - input_data->len - 1], 0x00);
-        TEST_BUFFERS_EQUAL(buf + length - input_data->len, input_data->len,
+        TEST_MEMORY_COMPARE(buf + length - input_data->len, input_data->len,
                        input_data->x, input_data->len);
     } else if (PSA_ALG_IS_RSA_OAEP(alg)) {
         TEST_EQUAL(buf[0], 0x00);
@@ -546,7 +546,7 @@ void sign_hash(int key_type_arg,
                                   &signature_length);
     TEST_EQUAL(actual_status, expected_status);
     if (expected_status == PSA_SUCCESS) {
-        TEST_BUFFERS_EQUAL(signature, signature_length,
+        TEST_MEMORY_COMPARE(signature, signature_length,
                        expected_output->x, expected_output->len);
     }
     TEST_EQUAL(mbedtls_test_driver_signature_sign_hooks.hits, 1);
@@ -673,7 +673,7 @@ void sign_message(int key_type_arg,
                                      &signature_length);
     TEST_EQUAL(actual_status, expected_status);
     if (expected_status == PSA_SUCCESS) {
-        TEST_BUFFERS_EQUAL(signature, signature_length,
+        TEST_MEMORY_COMPARE(signature, signature_length,
                        expected_output->x, expected_output->len);
     }
     /* In the builtin algorithm the driver is called twice. */
@@ -795,7 +795,7 @@ void generate_ec_key(int force_status_arg,
         psa_export_key(key, actual_output, sizeof(actual_output), &actual_output_length);
 
         if (fake_output->len > 0) {
-            TEST_BUFFERS_EQUAL(actual_output, actual_output_length,
+            TEST_MEMORY_COMPARE(actual_output, actual_output_length,
                            expected_output, expected_output_length);
         } else {
             size_t zeroes = 0;
@@ -927,7 +927,7 @@ void export_key(int force_status_arg,
     }
 
     if (actual_status == PSA_SUCCESS) {
-        TEST_BUFFERS_EQUAL(actual_output, actual_output_length,
+        TEST_MEMORY_COMPARE(actual_output, actual_output_length,
                        expected_output_ptr, expected_output_length);
     }
 exit:
@@ -1006,7 +1006,7 @@ void key_agreement(int alg_arg,
     TEST_EQUAL(mbedtls_test_driver_key_agreement_hooks.hits, 1);
 
     if (actual_status == PSA_SUCCESS) {
-        TEST_BUFFERS_EQUAL(actual_output, actual_output_length,
+        TEST_MEMORY_COMPARE(actual_output, actual_output_length,
                        expected_output_ptr, expected_output_length);
     }
     mbedtls_free(actual_output);
@@ -1093,7 +1093,7 @@ void cipher_encrypt_validation(int alg_arg,
     PSA_ASSERT(psa_cipher_abort(&operation));
     // driver function should've been called as part of the finish() core routine
     TEST_EQUAL(mbedtls_test_driver_cipher_hooks.hits, 0);
-    TEST_BUFFERS_EQUAL(output1 + iv_size, output1_length - iv_size,
+    TEST_MEMORY_COMPARE(output1 + iv_size, output1_length - iv_size,
                    output2, output2_length);
 
 exit:
@@ -1221,7 +1221,7 @@ void cipher_encrypt_multipart(int alg_arg,
         PSA_ASSERT(psa_cipher_abort(&operation));
         TEST_EQUAL(mbedtls_test_driver_cipher_hooks.hits, 0);
 
-        TEST_BUFFERS_EQUAL(expected_output->x, expected_output->len,
+        TEST_MEMORY_COMPARE(expected_output->x, expected_output->len,
                        output, total_output_length);
     }
 
@@ -1350,7 +1350,7 @@ void cipher_decrypt_multipart(int alg_arg,
         PSA_ASSERT(psa_cipher_abort(&operation));
         TEST_EQUAL(mbedtls_test_driver_cipher_hooks.hits, 0);
 
-        TEST_BUFFERS_EQUAL(expected_output->x, expected_output->len,
+        TEST_MEMORY_COMPARE(expected_output->x, expected_output->len,
                        output, total_output_length);
     }
 
@@ -1422,7 +1422,7 @@ void cipher_decrypt(int alg_arg,
     TEST_EQUAL(status, expected_status);
 
     if (expected_status == PSA_SUCCESS) {
-        TEST_BUFFERS_EQUAL(expected_output->x, expected_output->len,
+        TEST_MEMORY_COMPARE(expected_output->x, expected_output->len,
                        output, output_length);
     }
 
@@ -1707,7 +1707,7 @@ void aead_encrypt(int key_type_arg, data_t *key_data,
                PSA_SUCCESS : forced_status);
 
     if (status == PSA_SUCCESS) {
-        TEST_BUFFERS_EQUAL(expected_result->x, expected_result->len,
+        TEST_MEMORY_COMPARE(expected_result->x, expected_result->len,
                        output_data, output_length);
     }
 
@@ -1770,7 +1770,7 @@ void aead_decrypt(int key_type_arg, data_t *key_data,
                PSA_SUCCESS : forced_status);
 
     if (status == PSA_SUCCESS) {
-        TEST_BUFFERS_EQUAL(expected_data->x, expected_data->len,
+        TEST_MEMORY_COMPARE(expected_data->x, expected_data->len,
                        output_data, output_length);
     }
 
@@ -1839,7 +1839,7 @@ void mac_sign(int key_type_arg,
     TEST_EQUAL(mbedtls_test_driver_mac_hooks.hits, 1);
 
     if (forced_status == PSA_SUCCESS) {
-        TEST_BUFFERS_EQUAL(expected_mac->x, expected_mac->len,
+        TEST_MEMORY_COMPARE(expected_mac->x, expected_mac->len,
                        actual_mac, mac_length);
     }
 
@@ -1957,7 +1957,7 @@ void mac_sign_multipart(int key_type_arg,
     }
 
     if (forced_status == PSA_SUCCESS) {
-        TEST_BUFFERS_EQUAL(expected_mac->x, expected_mac->len,
+        TEST_MEMORY_COMPARE(expected_mac->x, expected_mac->len,
                        actual_mac, mac_length);
     }
 
@@ -2159,7 +2159,7 @@ void builtin_key_export(int builtin_key_id_arg,
     if (expected_status == PSA_SUCCESS) {
         PSA_ASSERT(actual_status);
         TEST_EQUAL(output_size, expected_output->len);
-        TEST_BUFFERS_EQUAL(output_buffer, output_size,
+        TEST_MEMORY_COMPARE(output_buffer, output_size,
                        expected_output->x, expected_output->len);
 
         PSA_ASSERT(psa_get_key_attributes(key, &attributes));
@@ -2210,7 +2210,7 @@ void builtin_pubkey_export(int builtin_key_id_arg,
     if (expected_status == PSA_SUCCESS) {
         PSA_ASSERT(actual_status);
         TEST_EQUAL(output_size, expected_output->len);
-        TEST_BUFFERS_EQUAL(output_buffer, output_size,
+        TEST_MEMORY_COMPARE(output_buffer, output_size,
                        expected_output->x, expected_output->len);
 
         PSA_ASSERT(psa_get_key_attributes(key, &attributes));
@@ -2257,7 +2257,7 @@ void hash_compute(int alg_arg,
     TEST_EQUAL(mbedtls_test_driver_hash_hooks.driver_status, forced_status);
 
     if (expected_status == PSA_SUCCESS) {
-        TEST_BUFFERS_EQUAL(output, output_length, hash->x, hash->len);
+        TEST_MEMORY_COMPARE(output, output_length, hash->x, hash->len);
     }
 
 exit:
@@ -2305,7 +2305,7 @@ void hash_multipart_setup(int alg_arg,
                    forced_status == PSA_ERROR_NOT_SUPPORTED ? 1 : 4);
         TEST_EQUAL(mbedtls_test_driver_hash_hooks.driver_status, forced_status);
 
-        TEST_BUFFERS_EQUAL(output, output_length, hash->x, hash->len);
+        TEST_MEMORY_COMPARE(output, output_length, hash->x, hash->len);
     }
 
 exit:
@@ -2362,7 +2362,7 @@ void hash_multipart_update(int alg_arg,
         TEST_EQUAL(mbedtls_test_driver_hash_hooks.hits, 2);
         TEST_EQUAL(mbedtls_test_driver_hash_hooks.driver_status, PSA_SUCCESS);
 
-        TEST_BUFFERS_EQUAL(output, output_length, hash->x, hash->len);
+        TEST_MEMORY_COMPARE(output, output_length, hash->x, hash->len);
     }
 
 exit:
@@ -2416,7 +2416,7 @@ void hash_multipart_finish(int alg_arg,
     TEST_EQUAL(mbedtls_test_driver_hash_hooks.driver_status, forced_status);
 
     if (forced_status == PSA_SUCCESS) {
-        TEST_BUFFERS_EQUAL(output, output_length, hash->x, hash->len);
+        TEST_MEMORY_COMPARE(output, output_length, hash->x, hash->len);
     }
 
 exit:
@@ -2476,7 +2476,7 @@ void hash_clone(int alg_arg,
         TEST_EQUAL(mbedtls_test_driver_hash_hooks.hits, 3);
         TEST_EQUAL(mbedtls_test_driver_hash_hooks.driver_status, PSA_SUCCESS);
 
-        TEST_BUFFERS_EQUAL(output, output_length, hash->x, hash->len);
+        TEST_MEMORY_COMPARE(output, output_length, hash->x, hash->len);
     }
 
 exit:
@@ -2560,7 +2560,7 @@ void asymmetric_encrypt_decrypt(int alg_arg,
 
     if (expected_status_encrypt == PSA_SUCCESS) {
         if (fake_output_encrypt->len > 0) {
-            TEST_BUFFERS_EQUAL(fake_output_encrypt->x, fake_output_encrypt->len,
+            TEST_MEMORY_COMPARE(fake_output_encrypt->x, fake_output_encrypt->len,
                            output, output_length);
         } else {
             mbedtls_test_driver_asymmetric_encryption_hooks.forced_status =
@@ -2587,10 +2587,10 @@ void asymmetric_encrypt_decrypt(int alg_arg,
                                               &output2_length), expected_status_decrypt);
             if (expected_status_decrypt == PSA_SUCCESS) {
                 if (fake_output_decrypt->len > 0) {
-                    TEST_BUFFERS_EQUAL(fake_output_decrypt->x, fake_output_decrypt->len,
+                    TEST_MEMORY_COMPARE(fake_output_decrypt->x, fake_output_decrypt->len,
                                    output2, output2_length);
                 } else {
-                    TEST_BUFFERS_EQUAL(input_data->x, input_data->len,
+                    TEST_MEMORY_COMPARE(input_data->x, input_data->len,
                                    output2, output2_length);
                 }
             }
@@ -2664,7 +2664,7 @@ void asymmetric_decrypt(int alg_arg,
                                       &output_length), expected_status_decrypt);
     if (expected_status_decrypt == PSA_SUCCESS) {
         TEST_EQUAL(output_length, expected_output_data->len);
-        TEST_BUFFERS_EQUAL(expected_output_data->x, expected_output_data->len,
+        TEST_MEMORY_COMPARE(expected_output_data->x, expected_output_data->len,
                        output, output_length);
     }
 exit:
@@ -2738,7 +2738,7 @@ void asymmetric_encrypt(int alg_arg,
     if (expected_status_encrypt == PSA_SUCCESS) {
         if (fake_output_encrypt->len > 0) {
             TEST_EQUAL(fake_output_encrypt->len, output_length);
-            TEST_BUFFERS_EQUAL(fake_output_encrypt->x, fake_output_encrypt->len,
+            TEST_MEMORY_COMPARE(fake_output_encrypt->x, fake_output_encrypt->len,
                            output, output_length);
         } else {
             /* Perform sanity checks on the output */
@@ -2873,11 +2873,11 @@ void aead_encrypt_setup(int key_type_arg, data_t *key_data,
                    forced_status == PSA_SUCCESS ? 1 : 0);
 
         /* Compare output_data and expected_ciphertext */
-        TEST_BUFFERS_EQUAL(expected_ciphertext->x, expected_ciphertext->len,
+        TEST_MEMORY_COMPARE(expected_ciphertext->x, expected_ciphertext->len,
                        output_data, output_length + finish_output_length);
 
         /* Compare tag and expected_tag */
-        TEST_BUFFERS_EQUAL(expected_tag->x, expected_tag->len, tag_buffer, tag_length);
+        TEST_MEMORY_COMPARE(expected_tag->x, expected_tag->len, tag_buffer, tag_length);
     }
 
 exit:
@@ -2979,7 +2979,7 @@ void aead_decrypt_setup(int key_type_arg, data_t *key_data,
         TEST_EQUAL(mbedtls_test_driver_aead_hooks.hits_abort,
                    forced_status == PSA_SUCCESS ? 1 : 0);
 
-        TEST_BUFFERS_EQUAL(expected_result->x, expected_result->len,
+        TEST_MEMORY_COMPARE(expected_result->x, expected_result->len,
                        output_data, output_length + verify_output_length);
     }
 

--- a/tests/suites/test_suite_psa_crypto_driver_wrappers.function
+++ b/tests/suites/test_suite_psa_crypto_driver_wrappers.function
@@ -49,8 +49,8 @@ static void ecjpake_do_round(psa_algorithm_t alg, unsigned int primitive,
     size_t c_x1_pr_off, c_x2_pr_off, c_x2s_pr_off;
     psa_status_t status;
 
-    TEST_CALLOC_OR_FAIL(buffer0, buffer_length);
-    TEST_CALLOC_OR_FAIL(buffer1, buffer_length);
+    TEST_CALLOC(buffer0, buffer_length);
+    TEST_CALLOC(buffer1, buffer_length);
 
     switch (round) {
         case 1:
@@ -538,7 +538,7 @@ void sign_hash(int key_type_arg,
 
     TEST_ASSERT(signature_size != 0);
     TEST_ASSERT(signature_size <= PSA_SIGNATURE_MAX_SIZE);
-    TEST_CALLOC_OR_FAIL(signature, signature_size);
+    TEST_CALLOC(signature, signature_size);
 
     actual_status = psa_sign_hash(key, alg,
                                   data_input->x, data_input->len,
@@ -665,7 +665,7 @@ void sign_message(int key_type_arg,
 
     TEST_ASSERT(signature_size != 0);
     TEST_ASSERT(signature_size <= PSA_SIGNATURE_MAX_SIZE);
-    TEST_CALLOC_OR_FAIL(signature, signature_size);
+    TEST_CALLOC(signature, signature_size);
 
     actual_status = psa_sign_message(key, alg,
                                      data_input->x, data_input->len,
@@ -997,7 +997,7 @@ void key_agreement(int alg_arg,
     mbedtls_test_driver_key_agreement_hooks.hits = 0;
     mbedtls_test_driver_key_agreement_hooks.forced_status = force_status;
 
-    TEST_CALLOC_OR_FAIL(actual_output, expected_output->len);
+    TEST_CALLOC(actual_output, expected_output->len);
     actual_status = psa_raw_key_agreement(alg, our_key,
                                           peer_key_data->x, peer_key_data->len,
                                           actual_output, expected_output->len,
@@ -1053,8 +1053,8 @@ void cipher_encrypt_validation(int alg_arg,
     output1_buffer_size = PSA_CIPHER_ENCRYPT_OUTPUT_SIZE(key_type, alg, input->len);
     output2_buffer_size = PSA_CIPHER_UPDATE_OUTPUT_SIZE(key_type, alg, input->len) +
                           PSA_CIPHER_FINISH_OUTPUT_SIZE(key_type, alg);
-    TEST_CALLOC_OR_FAIL(output1, output1_buffer_size);
-    TEST_CALLOC_OR_FAIL(output2, output2_buffer_size);
+    TEST_CALLOC(output1, output1_buffer_size);
+    TEST_CALLOC(output2, output2_buffer_size);
 
     PSA_ASSERT(psa_import_key(&attributes, key_data->x, key_data->len,
                               &key));
@@ -1171,7 +1171,7 @@ void cipher_encrypt_multipart(int alg_arg,
 
     output_buffer_size = ((size_t) input->len +
                           PSA_BLOCK_CIPHER_BLOCK_LENGTH(key_type));
-    TEST_CALLOC_OR_FAIL(output, output_buffer_size);
+    TEST_CALLOC(output, output_buffer_size);
 
     if (mock_output_arg) {
         mbedtls_test_driver_cipher_hooks.forced_output = expected_output->x;
@@ -1299,7 +1299,7 @@ void cipher_decrypt_multipart(int alg_arg,
 
     output_buffer_size = ((size_t) input->len +
                           PSA_BLOCK_CIPHER_BLOCK_LENGTH(key_type));
-    TEST_CALLOC_OR_FAIL(output, output_buffer_size);
+    TEST_CALLOC(output, output_buffer_size);
 
     if (mock_output_arg) {
         mbedtls_test_driver_cipher_hooks.forced_output = expected_output->x;
@@ -1398,13 +1398,13 @@ void cipher_decrypt(int alg_arg,
     /* Allocate input buffer and copy the iv and the plaintext */
     input_buffer_size = ((size_t) input_arg->len + (size_t) iv->len);
     if (input_buffer_size > 0) {
-        TEST_CALLOC_OR_FAIL(input, input_buffer_size);
+        TEST_CALLOC(input, input_buffer_size);
         memcpy(input, iv->x, iv->len);
         memcpy(input + iv->len, input_arg->x, input_arg->len);
     }
 
     output_buffer_size = PSA_CIPHER_DECRYPT_OUTPUT_SIZE(key_type, alg, input_buffer_size);
-    TEST_CALLOC_OR_FAIL(output, output_buffer_size);
+    TEST_CALLOC(output, output_buffer_size);
 
     PSA_ASSERT(psa_import_key(&attributes, key_data->x, key_data->len,
                               &key));
@@ -1451,7 +1451,7 @@ void cipher_entry_points(int alg_arg, int key_type_arg,
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     mbedtls_test_driver_cipher_hooks = mbedtls_test_driver_cipher_hooks_init();
 
-    TEST_CALLOC_OR_FAIL(output, input->len + 16);
+    TEST_CALLOC(output, input->len + 16);
     output_buffer_size = input->len + 16;
 
     PSA_ASSERT(psa_crypto_init());
@@ -1691,7 +1691,7 @@ void aead_encrypt(int key_type_arg, data_t *key_data,
                PSA_AEAD_ENCRYPT_OUTPUT_SIZE(key_type, alg, input_data->len));
     TEST_ASSERT(output_size <=
                 PSA_AEAD_ENCRYPT_OUTPUT_MAX_SIZE(input_data->len));
-    TEST_CALLOC_OR_FAIL(output_data, output_size);
+    TEST_CALLOC(output_data, output_size);
 
     mbedtls_test_driver_aead_hooks.forced_status = forced_status;
     status = psa_aead_encrypt(key, alg,
@@ -1753,7 +1753,7 @@ void aead_decrypt(int key_type_arg, data_t *key_data,
 
     output_size = input_data->len - PSA_AEAD_TAG_LENGTH(key_type, key_bits,
                                                         alg);
-    TEST_CALLOC_OR_FAIL(output_data, output_size);
+    TEST_CALLOC(output_data, output_size);
 
     mbedtls_test_driver_aead_hooks.forced_status = forced_status;
     status = psa_aead_decrypt(key, alg,
@@ -1816,7 +1816,7 @@ void mac_sign(int key_type_arg,
     PSA_ASSERT(psa_import_key(&attributes, key_data->x, key_data->len,
                               &key));
 
-    TEST_CALLOC_OR_FAIL(actual_mac, mac_buffer_size);
+    TEST_CALLOC(actual_mac, mac_buffer_size);
     mbedtls_test_driver_mac_hooks.forced_status = forced_status;
 
     /*
@@ -1891,7 +1891,7 @@ void mac_sign_multipart(int key_type_arg,
     PSA_ASSERT(psa_import_key(&attributes, key_data->x, key_data->len,
                               &key));
 
-    TEST_CALLOC_OR_FAIL(actual_mac, mac_buffer_size);
+    TEST_CALLOC(actual_mac, mac_buffer_size);
     mbedtls_test_driver_mac_hooks.forced_status = forced_status;
 
     /*
@@ -2152,7 +2152,7 @@ void builtin_key_export(int builtin_key_id_arg,
     psa_status_t actual_status;
 
     PSA_ASSERT(psa_crypto_init());
-    TEST_CALLOC_OR_FAIL(output_buffer, expected_output->len);
+    TEST_CALLOC(output_buffer, expected_output->len);
 
     actual_status = psa_export_key(key, output_buffer, expected_output->len, &output_size);
 
@@ -2203,7 +2203,7 @@ void builtin_pubkey_export(int builtin_key_id_arg,
     psa_status_t actual_status;
 
     PSA_ASSERT(psa_crypto_init());
-    TEST_CALLOC_OR_FAIL(output_buffer, expected_output->len);
+    TEST_CALLOC(output_buffer, expected_output->len);
 
     actual_status = psa_export_public_key(key, output_buffer, expected_output->len, &output_size);
 
@@ -2244,7 +2244,7 @@ void hash_compute(int alg_arg,
 
 
     PSA_ASSERT(psa_crypto_init());
-    TEST_CALLOC_OR_FAIL(output, PSA_HASH_LENGTH(alg));
+    TEST_CALLOC(output, PSA_HASH_LENGTH(alg));
 
     /* Do this after psa_crypto_init() which may call hash drivers */
     mbedtls_test_driver_hash_hooks = mbedtls_test_driver_hash_hooks_init();
@@ -2282,7 +2282,7 @@ void hash_multipart_setup(int alg_arg,
 
 
     PSA_ASSERT(psa_crypto_init());
-    TEST_CALLOC_OR_FAIL(output, PSA_HASH_LENGTH(alg));
+    TEST_CALLOC(output, PSA_HASH_LENGTH(alg));
 
     /* Do this after psa_crypto_init() which may call hash drivers */
     mbedtls_test_driver_hash_hooks = mbedtls_test_driver_hash_hooks_init();
@@ -2329,7 +2329,7 @@ void hash_multipart_update(int alg_arg,
 
 
     PSA_ASSERT(psa_crypto_init());
-    TEST_CALLOC_OR_FAIL(output, PSA_HASH_LENGTH(alg));
+    TEST_CALLOC(output, PSA_HASH_LENGTH(alg));
 
     /* Do this after psa_crypto_init() which may call hash drivers */
     mbedtls_test_driver_hash_hooks = mbedtls_test_driver_hash_hooks_init();
@@ -2385,7 +2385,7 @@ void hash_multipart_finish(int alg_arg,
     size_t output_length;
 
     PSA_ASSERT(psa_crypto_init());
-    TEST_CALLOC_OR_FAIL(output, PSA_HASH_LENGTH(alg));
+    TEST_CALLOC(output, PSA_HASH_LENGTH(alg));
 
     /* Do this after psa_crypto_init() which may call hash drivers */
     mbedtls_test_driver_hash_hooks = mbedtls_test_driver_hash_hooks_init();
@@ -2440,7 +2440,7 @@ void hash_clone(int alg_arg,
     size_t output_length;
 
     PSA_ASSERT(psa_crypto_init());
-    TEST_CALLOC_OR_FAIL(output, PSA_HASH_LENGTH(alg));
+    TEST_CALLOC(output, PSA_HASH_LENGTH(alg));
 
     /* Do this after psa_crypto_init() which may call hash drivers */
     mbedtls_test_driver_hash_hooks = mbedtls_test_driver_hash_hooks_init();
@@ -2539,11 +2539,11 @@ void asymmetric_encrypt_decrypt(int alg_arg,
         mbedtls_test_driver_asymmetric_encryption_hooks.forced_output_length =
             fake_output_encrypt->len;
         output_size = fake_output_encrypt->len;
-        TEST_CALLOC_OR_FAIL(output, output_size);
+        TEST_CALLOC(output, output_size);
     } else {
         output_size = PSA_ASYMMETRIC_ENCRYPT_OUTPUT_SIZE(key_type, key_bits, alg);
         TEST_ASSERT(output_size <= PSA_ASYMMETRIC_ENCRYPT_OUTPUT_MAX_SIZE);
-        TEST_CALLOC_OR_FAIL(output, output_size);
+        TEST_CALLOC(output, output_size);
     }
 
     /* We test encryption by checking that encrypt-then-decrypt gives back
@@ -2571,13 +2571,13 @@ void asymmetric_encrypt_decrypt(int alg_arg,
                 mbedtls_test_driver_asymmetric_encryption_hooks.forced_output_length =
                     fake_output_decrypt->len;
                 output2_size = fake_output_decrypt->len;
-                TEST_CALLOC_OR_FAIL(output2, output2_size);
+                TEST_CALLOC(output2, output2_size);
             } else {
                 output2_size = input_data->len;
                 TEST_ASSERT(output2_size <=
                             PSA_ASYMMETRIC_DECRYPT_OUTPUT_SIZE(key_type, key_bits, alg));
                 TEST_ASSERT(output2_size <= PSA_ASYMMETRIC_DECRYPT_OUTPUT_MAX_SIZE);
-                TEST_CALLOC_OR_FAIL(output2, output2_size);
+                TEST_CALLOC(output2, output2_size);
             }
 
             TEST_EQUAL(psa_asymmetric_decrypt(key, alg,
@@ -2651,10 +2651,10 @@ void asymmetric_decrypt(int alg_arg,
         mbedtls_test_driver_asymmetric_encryption_hooks.forced_output_length =
             fake_output_decrypt->len;
         output_size = fake_output_decrypt->len;
-        TEST_CALLOC_OR_FAIL(output, output_size);
+        TEST_CALLOC(output, output_size);
     } else {
         output_size = expected_output_data->len;
-        TEST_CALLOC_OR_FAIL(output, expected_output_data->len);
+        TEST_CALLOC(output, expected_output_data->len);
     }
 
     TEST_EQUAL(psa_asymmetric_decrypt(key, alg,
@@ -2724,10 +2724,10 @@ void asymmetric_encrypt(int alg_arg,
         mbedtls_test_driver_asymmetric_encryption_hooks.forced_output_length =
             fake_output_encrypt->len;
         output_size = fake_output_encrypt->len;
-        TEST_CALLOC_OR_FAIL(output, output_size);
+        TEST_CALLOC(output, output_size);
     } else {
         output_size = PSA_ASYMMETRIC_ENCRYPT_OUTPUT_SIZE(key_type, key_bits, alg);
-        TEST_CALLOC_OR_FAIL(output, output_size);
+        TEST_CALLOC(output, output_size);
     }
 
     TEST_EQUAL(psa_asymmetric_encrypt(key, alg,
@@ -2824,7 +2824,7 @@ void aead_encrypt_setup(int key_type_arg, data_t *key_data,
                PSA_AEAD_ENCRYPT_OUTPUT_SIZE(key_type, alg, input_data->len));
     TEST_ASSERT(output_size <=
                 PSA_AEAD_ENCRYPT_OUTPUT_MAX_SIZE(input_data->len));
-    TEST_CALLOC_OR_FAIL(output_data, output_size);
+    TEST_CALLOC(output_data, output_size);
 
     status = psa_aead_encrypt_setup(&operation, key, alg);
 
@@ -2926,7 +2926,7 @@ void aead_decrypt_setup(int key_type_arg, data_t *key_data,
 
     output_size = input_ciphertext->len;
 
-    TEST_CALLOC_OR_FAIL(output_data, output_size);
+    TEST_CALLOC(output_data, output_size);
 
     mbedtls_test_driver_aead_hooks.forced_status = forced_status;
 
@@ -3016,12 +3016,12 @@ void pake_operations(data_t *pw_data, int forced_status_setup_arg, int forced_st
                                               PSA_PAKE_STEP_KEY_SHARE);
     int in_driver = (forced_status_setup_arg == PSA_SUCCESS);
 
-    TEST_CALLOC_OR_FAIL(input_buffer,
+    TEST_CALLOC(input_buffer,
                  PSA_PAKE_INPUT_SIZE(PSA_ALG_JPAKE, primitive,
                                      PSA_PAKE_STEP_KEY_SHARE));
     memset(input_buffer, 0xAA, size_key_share);
 
-    TEST_CALLOC_OR_FAIL(output_buffer,
+    TEST_CALLOC(output_buffer,
                  PSA_PAKE_INPUT_SIZE(PSA_ALG_JPAKE, primitive,
                                      PSA_PAKE_STEP_KEY_SHARE));
     memset(output_buffer, 0x55, output_size);

--- a/tests/suites/test_suite_psa_crypto_driver_wrappers.function
+++ b/tests/suites/test_suite_psa_crypto_driver_wrappers.function
@@ -461,7 +461,7 @@ static int sanity_check_rsa_encryption_result(
         TEST_EQUAL(buf[1], 0x02);
         TEST_EQUAL(buf[length - input_data->len - 1], 0x00);
         TEST_MEMORY_COMPARE(buf + length - input_data->len, input_data->len,
-                       input_data->x, input_data->len);
+                            input_data->x, input_data->len);
     } else if (PSA_ALG_IS_RSA_OAEP(alg)) {
         TEST_EQUAL(buf[0], 0x00);
         /* The rest is too hard to check */
@@ -547,7 +547,7 @@ void sign_hash(int key_type_arg,
     TEST_EQUAL(actual_status, expected_status);
     if (expected_status == PSA_SUCCESS) {
         TEST_MEMORY_COMPARE(signature, signature_length,
-                       expected_output->x, expected_output->len);
+                            expected_output->x, expected_output->len);
     }
     TEST_EQUAL(mbedtls_test_driver_signature_sign_hooks.hits, 1);
 
@@ -674,7 +674,7 @@ void sign_message(int key_type_arg,
     TEST_EQUAL(actual_status, expected_status);
     if (expected_status == PSA_SUCCESS) {
         TEST_MEMORY_COMPARE(signature, signature_length,
-                       expected_output->x, expected_output->len);
+                            expected_output->x, expected_output->len);
     }
     /* In the builtin algorithm the driver is called twice. */
     TEST_EQUAL(mbedtls_test_driver_signature_sign_hooks.hits,
@@ -796,7 +796,7 @@ void generate_ec_key(int force_status_arg,
 
         if (fake_output->len > 0) {
             TEST_MEMORY_COMPARE(actual_output, actual_output_length,
-                           expected_output, expected_output_length);
+                                expected_output, expected_output_length);
         } else {
             size_t zeroes = 0;
             for (size_t i = 0; i < sizeof(actual_output); i++) {
@@ -928,7 +928,7 @@ void export_key(int force_status_arg,
 
     if (actual_status == PSA_SUCCESS) {
         TEST_MEMORY_COMPARE(actual_output, actual_output_length,
-                       expected_output_ptr, expected_output_length);
+                            expected_output_ptr, expected_output_length);
     }
 exit:
     psa_reset_key_attributes(&attributes);
@@ -1007,7 +1007,7 @@ void key_agreement(int alg_arg,
 
     if (actual_status == PSA_SUCCESS) {
         TEST_MEMORY_COMPARE(actual_output, actual_output_length,
-                       expected_output_ptr, expected_output_length);
+                            expected_output_ptr, expected_output_length);
     }
     mbedtls_free(actual_output);
     actual_output = NULL;
@@ -1094,7 +1094,7 @@ void cipher_encrypt_validation(int alg_arg,
     // driver function should've been called as part of the finish() core routine
     TEST_EQUAL(mbedtls_test_driver_cipher_hooks.hits, 0);
     TEST_MEMORY_COMPARE(output1 + iv_size, output1_length - iv_size,
-                   output2, output2_length);
+                        output2, output2_length);
 
 exit:
     psa_cipher_abort(&operation);
@@ -1222,7 +1222,7 @@ void cipher_encrypt_multipart(int alg_arg,
         TEST_EQUAL(mbedtls_test_driver_cipher_hooks.hits, 0);
 
         TEST_MEMORY_COMPARE(expected_output->x, expected_output->len,
-                       output, total_output_length);
+                            output, total_output_length);
     }
 
 exit:
@@ -1351,7 +1351,7 @@ void cipher_decrypt_multipart(int alg_arg,
         TEST_EQUAL(mbedtls_test_driver_cipher_hooks.hits, 0);
 
         TEST_MEMORY_COMPARE(expected_output->x, expected_output->len,
-                       output, total_output_length);
+                            output, total_output_length);
     }
 
 exit:
@@ -1423,7 +1423,7 @@ void cipher_decrypt(int alg_arg,
 
     if (expected_status == PSA_SUCCESS) {
         TEST_MEMORY_COMPARE(expected_output->x, expected_output->len,
-                       output, output_length);
+                            output, output_length);
     }
 
 exit:
@@ -1708,7 +1708,7 @@ void aead_encrypt(int key_type_arg, data_t *key_data,
 
     if (status == PSA_SUCCESS) {
         TEST_MEMORY_COMPARE(expected_result->x, expected_result->len,
-                       output_data, output_length);
+                            output_data, output_length);
     }
 
 exit:
@@ -1771,7 +1771,7 @@ void aead_decrypt(int key_type_arg, data_t *key_data,
 
     if (status == PSA_SUCCESS) {
         TEST_MEMORY_COMPARE(expected_data->x, expected_data->len,
-                       output_data, output_length);
+                            output_data, output_length);
     }
 
 exit:
@@ -1840,7 +1840,7 @@ void mac_sign(int key_type_arg,
 
     if (forced_status == PSA_SUCCESS) {
         TEST_MEMORY_COMPARE(expected_mac->x, expected_mac->len,
-                       actual_mac, mac_length);
+                            actual_mac, mac_length);
     }
 
     mbedtls_free(actual_mac);
@@ -1958,7 +1958,7 @@ void mac_sign_multipart(int key_type_arg,
 
     if (forced_status == PSA_SUCCESS) {
         TEST_MEMORY_COMPARE(expected_mac->x, expected_mac->len,
-                       actual_mac, mac_length);
+                            actual_mac, mac_length);
     }
 
     mbedtls_free(actual_mac);
@@ -2160,7 +2160,7 @@ void builtin_key_export(int builtin_key_id_arg,
         PSA_ASSERT(actual_status);
         TEST_EQUAL(output_size, expected_output->len);
         TEST_MEMORY_COMPARE(output_buffer, output_size,
-                       expected_output->x, expected_output->len);
+                            expected_output->x, expected_output->len);
 
         PSA_ASSERT(psa_get_key_attributes(key, &attributes));
         TEST_EQUAL(psa_get_key_bits(&attributes), builtin_key_bits);
@@ -2211,7 +2211,7 @@ void builtin_pubkey_export(int builtin_key_id_arg,
         PSA_ASSERT(actual_status);
         TEST_EQUAL(output_size, expected_output->len);
         TEST_MEMORY_COMPARE(output_buffer, output_size,
-                       expected_output->x, expected_output->len);
+                            expected_output->x, expected_output->len);
 
         PSA_ASSERT(psa_get_key_attributes(key, &attributes));
         TEST_EQUAL(psa_get_key_bits(&attributes), builtin_key_bits);
@@ -2561,7 +2561,7 @@ void asymmetric_encrypt_decrypt(int alg_arg,
     if (expected_status_encrypt == PSA_SUCCESS) {
         if (fake_output_encrypt->len > 0) {
             TEST_MEMORY_COMPARE(fake_output_encrypt->x, fake_output_encrypt->len,
-                           output, output_length);
+                                output, output_length);
         } else {
             mbedtls_test_driver_asymmetric_encryption_hooks.forced_status =
                 forced_status_decrypt;
@@ -2588,10 +2588,10 @@ void asymmetric_encrypt_decrypt(int alg_arg,
             if (expected_status_decrypt == PSA_SUCCESS) {
                 if (fake_output_decrypt->len > 0) {
                     TEST_MEMORY_COMPARE(fake_output_decrypt->x, fake_output_decrypt->len,
-                                   output2, output2_length);
+                                        output2, output2_length);
                 } else {
                     TEST_MEMORY_COMPARE(input_data->x, input_data->len,
-                                   output2, output2_length);
+                                        output2, output2_length);
                 }
             }
         }
@@ -2665,7 +2665,7 @@ void asymmetric_decrypt(int alg_arg,
     if (expected_status_decrypt == PSA_SUCCESS) {
         TEST_EQUAL(output_length, expected_output_data->len);
         TEST_MEMORY_COMPARE(expected_output_data->x, expected_output_data->len,
-                       output, output_length);
+                            output, output_length);
     }
 exit:
     /*
@@ -2739,7 +2739,7 @@ void asymmetric_encrypt(int alg_arg,
         if (fake_output_encrypt->len > 0) {
             TEST_EQUAL(fake_output_encrypt->len, output_length);
             TEST_MEMORY_COMPARE(fake_output_encrypt->x, fake_output_encrypt->len,
-                           output, output_length);
+                                output, output_length);
         } else {
             /* Perform sanity checks on the output */
 #if PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY
@@ -2874,7 +2874,7 @@ void aead_encrypt_setup(int key_type_arg, data_t *key_data,
 
         /* Compare output_data and expected_ciphertext */
         TEST_MEMORY_COMPARE(expected_ciphertext->x, expected_ciphertext->len,
-                       output_data, output_length + finish_output_length);
+                            output_data, output_length + finish_output_length);
 
         /* Compare tag and expected_tag */
         TEST_MEMORY_COMPARE(expected_tag->x, expected_tag->len, tag_buffer, tag_length);
@@ -2980,7 +2980,7 @@ void aead_decrypt_setup(int key_type_arg, data_t *key_data,
                    forced_status == PSA_SUCCESS ? 1 : 0);
 
         TEST_MEMORY_COMPARE(expected_result->x, expected_result->len,
-                       output_data, output_length + verify_output_length);
+                            output_data, output_length + verify_output_length);
     }
 
 exit:
@@ -3017,13 +3017,13 @@ void pake_operations(data_t *pw_data, int forced_status_setup_arg, int forced_st
     int in_driver = (forced_status_setup_arg == PSA_SUCCESS);
 
     TEST_CALLOC(input_buffer,
-                 PSA_PAKE_INPUT_SIZE(PSA_ALG_JPAKE, primitive,
-                                     PSA_PAKE_STEP_KEY_SHARE));
+                PSA_PAKE_INPUT_SIZE(PSA_ALG_JPAKE, primitive,
+                                    PSA_PAKE_STEP_KEY_SHARE));
     memset(input_buffer, 0xAA, size_key_share);
 
     TEST_CALLOC(output_buffer,
-                 PSA_PAKE_INPUT_SIZE(PSA_ALG_JPAKE, primitive,
-                                     PSA_PAKE_STEP_KEY_SHARE));
+                PSA_PAKE_INPUT_SIZE(PSA_ALG_JPAKE, primitive,
+                                    PSA_PAKE_STEP_KEY_SHARE));
     memset(output_buffer, 0x55, output_size);
 
     PSA_INIT();

--- a/tests/suites/test_suite_psa_crypto_driver_wrappers.function
+++ b/tests/suites/test_suite_psa_crypto_driver_wrappers.function
@@ -49,8 +49,8 @@ static void ecjpake_do_round(psa_algorithm_t alg, unsigned int primitive,
     size_t c_x1_pr_off, c_x2_pr_off, c_x2s_pr_off;
     psa_status_t status;
 
-    ASSERT_ALLOC(buffer0, buffer_length);
-    ASSERT_ALLOC(buffer1, buffer_length);
+    TEST_CALLOC_OR_FAIL(buffer0, buffer_length);
+    TEST_CALLOC_OR_FAIL(buffer1, buffer_length);
 
     switch (round) {
         case 1:
@@ -538,7 +538,7 @@ void sign_hash(int key_type_arg,
 
     TEST_ASSERT(signature_size != 0);
     TEST_ASSERT(signature_size <= PSA_SIGNATURE_MAX_SIZE);
-    ASSERT_ALLOC(signature, signature_size);
+    TEST_CALLOC_OR_FAIL(signature, signature_size);
 
     actual_status = psa_sign_hash(key, alg,
                                   data_input->x, data_input->len,
@@ -665,7 +665,7 @@ void sign_message(int key_type_arg,
 
     TEST_ASSERT(signature_size != 0);
     TEST_ASSERT(signature_size <= PSA_SIGNATURE_MAX_SIZE);
-    ASSERT_ALLOC(signature, signature_size);
+    TEST_CALLOC_OR_FAIL(signature, signature_size);
 
     actual_status = psa_sign_message(key, alg,
                                      data_input->x, data_input->len,
@@ -997,7 +997,7 @@ void key_agreement(int alg_arg,
     mbedtls_test_driver_key_agreement_hooks.hits = 0;
     mbedtls_test_driver_key_agreement_hooks.forced_status = force_status;
 
-    ASSERT_ALLOC(actual_output, expected_output->len);
+    TEST_CALLOC_OR_FAIL(actual_output, expected_output->len);
     actual_status = psa_raw_key_agreement(alg, our_key,
                                           peer_key_data->x, peer_key_data->len,
                                           actual_output, expected_output->len,
@@ -1053,8 +1053,8 @@ void cipher_encrypt_validation(int alg_arg,
     output1_buffer_size = PSA_CIPHER_ENCRYPT_OUTPUT_SIZE(key_type, alg, input->len);
     output2_buffer_size = PSA_CIPHER_UPDATE_OUTPUT_SIZE(key_type, alg, input->len) +
                           PSA_CIPHER_FINISH_OUTPUT_SIZE(key_type, alg);
-    ASSERT_ALLOC(output1, output1_buffer_size);
-    ASSERT_ALLOC(output2, output2_buffer_size);
+    TEST_CALLOC_OR_FAIL(output1, output1_buffer_size);
+    TEST_CALLOC_OR_FAIL(output2, output2_buffer_size);
 
     PSA_ASSERT(psa_import_key(&attributes, key_data->x, key_data->len,
                               &key));
@@ -1171,7 +1171,7 @@ void cipher_encrypt_multipart(int alg_arg,
 
     output_buffer_size = ((size_t) input->len +
                           PSA_BLOCK_CIPHER_BLOCK_LENGTH(key_type));
-    ASSERT_ALLOC(output, output_buffer_size);
+    TEST_CALLOC_OR_FAIL(output, output_buffer_size);
 
     if (mock_output_arg) {
         mbedtls_test_driver_cipher_hooks.forced_output = expected_output->x;
@@ -1299,7 +1299,7 @@ void cipher_decrypt_multipart(int alg_arg,
 
     output_buffer_size = ((size_t) input->len +
                           PSA_BLOCK_CIPHER_BLOCK_LENGTH(key_type));
-    ASSERT_ALLOC(output, output_buffer_size);
+    TEST_CALLOC_OR_FAIL(output, output_buffer_size);
 
     if (mock_output_arg) {
         mbedtls_test_driver_cipher_hooks.forced_output = expected_output->x;
@@ -1398,13 +1398,13 @@ void cipher_decrypt(int alg_arg,
     /* Allocate input buffer and copy the iv and the plaintext */
     input_buffer_size = ((size_t) input_arg->len + (size_t) iv->len);
     if (input_buffer_size > 0) {
-        ASSERT_ALLOC(input, input_buffer_size);
+        TEST_CALLOC_OR_FAIL(input, input_buffer_size);
         memcpy(input, iv->x, iv->len);
         memcpy(input + iv->len, input_arg->x, input_arg->len);
     }
 
     output_buffer_size = PSA_CIPHER_DECRYPT_OUTPUT_SIZE(key_type, alg, input_buffer_size);
-    ASSERT_ALLOC(output, output_buffer_size);
+    TEST_CALLOC_OR_FAIL(output, output_buffer_size);
 
     PSA_ASSERT(psa_import_key(&attributes, key_data->x, key_data->len,
                               &key));
@@ -1451,7 +1451,7 @@ void cipher_entry_points(int alg_arg, int key_type_arg,
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     mbedtls_test_driver_cipher_hooks = mbedtls_test_driver_cipher_hooks_init();
 
-    ASSERT_ALLOC(output, input->len + 16);
+    TEST_CALLOC_OR_FAIL(output, input->len + 16);
     output_buffer_size = input->len + 16;
 
     PSA_ASSERT(psa_crypto_init());
@@ -1691,7 +1691,7 @@ void aead_encrypt(int key_type_arg, data_t *key_data,
                PSA_AEAD_ENCRYPT_OUTPUT_SIZE(key_type, alg, input_data->len));
     TEST_ASSERT(output_size <=
                 PSA_AEAD_ENCRYPT_OUTPUT_MAX_SIZE(input_data->len));
-    ASSERT_ALLOC(output_data, output_size);
+    TEST_CALLOC_OR_FAIL(output_data, output_size);
 
     mbedtls_test_driver_aead_hooks.forced_status = forced_status;
     status = psa_aead_encrypt(key, alg,
@@ -1753,7 +1753,7 @@ void aead_decrypt(int key_type_arg, data_t *key_data,
 
     output_size = input_data->len - PSA_AEAD_TAG_LENGTH(key_type, key_bits,
                                                         alg);
-    ASSERT_ALLOC(output_data, output_size);
+    TEST_CALLOC_OR_FAIL(output_data, output_size);
 
     mbedtls_test_driver_aead_hooks.forced_status = forced_status;
     status = psa_aead_decrypt(key, alg,
@@ -1816,7 +1816,7 @@ void mac_sign(int key_type_arg,
     PSA_ASSERT(psa_import_key(&attributes, key_data->x, key_data->len,
                               &key));
 
-    ASSERT_ALLOC(actual_mac, mac_buffer_size);
+    TEST_CALLOC_OR_FAIL(actual_mac, mac_buffer_size);
     mbedtls_test_driver_mac_hooks.forced_status = forced_status;
 
     /*
@@ -1891,7 +1891,7 @@ void mac_sign_multipart(int key_type_arg,
     PSA_ASSERT(psa_import_key(&attributes, key_data->x, key_data->len,
                               &key));
 
-    ASSERT_ALLOC(actual_mac, mac_buffer_size);
+    TEST_CALLOC_OR_FAIL(actual_mac, mac_buffer_size);
     mbedtls_test_driver_mac_hooks.forced_status = forced_status;
 
     /*
@@ -2152,7 +2152,7 @@ void builtin_key_export(int builtin_key_id_arg,
     psa_status_t actual_status;
 
     PSA_ASSERT(psa_crypto_init());
-    ASSERT_ALLOC(output_buffer, expected_output->len);
+    TEST_CALLOC_OR_FAIL(output_buffer, expected_output->len);
 
     actual_status = psa_export_key(key, output_buffer, expected_output->len, &output_size);
 
@@ -2203,7 +2203,7 @@ void builtin_pubkey_export(int builtin_key_id_arg,
     psa_status_t actual_status;
 
     PSA_ASSERT(psa_crypto_init());
-    ASSERT_ALLOC(output_buffer, expected_output->len);
+    TEST_CALLOC_OR_FAIL(output_buffer, expected_output->len);
 
     actual_status = psa_export_public_key(key, output_buffer, expected_output->len, &output_size);
 
@@ -2244,7 +2244,7 @@ void hash_compute(int alg_arg,
 
 
     PSA_ASSERT(psa_crypto_init());
-    ASSERT_ALLOC(output, PSA_HASH_LENGTH(alg));
+    TEST_CALLOC_OR_FAIL(output, PSA_HASH_LENGTH(alg));
 
     /* Do this after psa_crypto_init() which may call hash drivers */
     mbedtls_test_driver_hash_hooks = mbedtls_test_driver_hash_hooks_init();
@@ -2282,7 +2282,7 @@ void hash_multipart_setup(int alg_arg,
 
 
     PSA_ASSERT(psa_crypto_init());
-    ASSERT_ALLOC(output, PSA_HASH_LENGTH(alg));
+    TEST_CALLOC_OR_FAIL(output, PSA_HASH_LENGTH(alg));
 
     /* Do this after psa_crypto_init() which may call hash drivers */
     mbedtls_test_driver_hash_hooks = mbedtls_test_driver_hash_hooks_init();
@@ -2329,7 +2329,7 @@ void hash_multipart_update(int alg_arg,
 
 
     PSA_ASSERT(psa_crypto_init());
-    ASSERT_ALLOC(output, PSA_HASH_LENGTH(alg));
+    TEST_CALLOC_OR_FAIL(output, PSA_HASH_LENGTH(alg));
 
     /* Do this after psa_crypto_init() which may call hash drivers */
     mbedtls_test_driver_hash_hooks = mbedtls_test_driver_hash_hooks_init();
@@ -2385,7 +2385,7 @@ void hash_multipart_finish(int alg_arg,
     size_t output_length;
 
     PSA_ASSERT(psa_crypto_init());
-    ASSERT_ALLOC(output, PSA_HASH_LENGTH(alg));
+    TEST_CALLOC_OR_FAIL(output, PSA_HASH_LENGTH(alg));
 
     /* Do this after psa_crypto_init() which may call hash drivers */
     mbedtls_test_driver_hash_hooks = mbedtls_test_driver_hash_hooks_init();
@@ -2440,7 +2440,7 @@ void hash_clone(int alg_arg,
     size_t output_length;
 
     PSA_ASSERT(psa_crypto_init());
-    ASSERT_ALLOC(output, PSA_HASH_LENGTH(alg));
+    TEST_CALLOC_OR_FAIL(output, PSA_HASH_LENGTH(alg));
 
     /* Do this after psa_crypto_init() which may call hash drivers */
     mbedtls_test_driver_hash_hooks = mbedtls_test_driver_hash_hooks_init();
@@ -2539,11 +2539,11 @@ void asymmetric_encrypt_decrypt(int alg_arg,
         mbedtls_test_driver_asymmetric_encryption_hooks.forced_output_length =
             fake_output_encrypt->len;
         output_size = fake_output_encrypt->len;
-        ASSERT_ALLOC(output, output_size);
+        TEST_CALLOC_OR_FAIL(output, output_size);
     } else {
         output_size = PSA_ASYMMETRIC_ENCRYPT_OUTPUT_SIZE(key_type, key_bits, alg);
         TEST_ASSERT(output_size <= PSA_ASYMMETRIC_ENCRYPT_OUTPUT_MAX_SIZE);
-        ASSERT_ALLOC(output, output_size);
+        TEST_CALLOC_OR_FAIL(output, output_size);
     }
 
     /* We test encryption by checking that encrypt-then-decrypt gives back
@@ -2571,13 +2571,13 @@ void asymmetric_encrypt_decrypt(int alg_arg,
                 mbedtls_test_driver_asymmetric_encryption_hooks.forced_output_length =
                     fake_output_decrypt->len;
                 output2_size = fake_output_decrypt->len;
-                ASSERT_ALLOC(output2, output2_size);
+                TEST_CALLOC_OR_FAIL(output2, output2_size);
             } else {
                 output2_size = input_data->len;
                 TEST_ASSERT(output2_size <=
                             PSA_ASYMMETRIC_DECRYPT_OUTPUT_SIZE(key_type, key_bits, alg));
                 TEST_ASSERT(output2_size <= PSA_ASYMMETRIC_DECRYPT_OUTPUT_MAX_SIZE);
-                ASSERT_ALLOC(output2, output2_size);
+                TEST_CALLOC_OR_FAIL(output2, output2_size);
             }
 
             TEST_EQUAL(psa_asymmetric_decrypt(key, alg,
@@ -2651,10 +2651,10 @@ void asymmetric_decrypt(int alg_arg,
         mbedtls_test_driver_asymmetric_encryption_hooks.forced_output_length =
             fake_output_decrypt->len;
         output_size = fake_output_decrypt->len;
-        ASSERT_ALLOC(output, output_size);
+        TEST_CALLOC_OR_FAIL(output, output_size);
     } else {
         output_size = expected_output_data->len;
-        ASSERT_ALLOC(output, expected_output_data->len);
+        TEST_CALLOC_OR_FAIL(output, expected_output_data->len);
     }
 
     TEST_EQUAL(psa_asymmetric_decrypt(key, alg,
@@ -2724,10 +2724,10 @@ void asymmetric_encrypt(int alg_arg,
         mbedtls_test_driver_asymmetric_encryption_hooks.forced_output_length =
             fake_output_encrypt->len;
         output_size = fake_output_encrypt->len;
-        ASSERT_ALLOC(output, output_size);
+        TEST_CALLOC_OR_FAIL(output, output_size);
     } else {
         output_size = PSA_ASYMMETRIC_ENCRYPT_OUTPUT_SIZE(key_type, key_bits, alg);
-        ASSERT_ALLOC(output, output_size);
+        TEST_CALLOC_OR_FAIL(output, output_size);
     }
 
     TEST_EQUAL(psa_asymmetric_encrypt(key, alg,
@@ -2824,7 +2824,7 @@ void aead_encrypt_setup(int key_type_arg, data_t *key_data,
                PSA_AEAD_ENCRYPT_OUTPUT_SIZE(key_type, alg, input_data->len));
     TEST_ASSERT(output_size <=
                 PSA_AEAD_ENCRYPT_OUTPUT_MAX_SIZE(input_data->len));
-    ASSERT_ALLOC(output_data, output_size);
+    TEST_CALLOC_OR_FAIL(output_data, output_size);
 
     status = psa_aead_encrypt_setup(&operation, key, alg);
 
@@ -2926,7 +2926,7 @@ void aead_decrypt_setup(int key_type_arg, data_t *key_data,
 
     output_size = input_ciphertext->len;
 
-    ASSERT_ALLOC(output_data, output_size);
+    TEST_CALLOC_OR_FAIL(output_data, output_size);
 
     mbedtls_test_driver_aead_hooks.forced_status = forced_status;
 
@@ -3016,12 +3016,12 @@ void pake_operations(data_t *pw_data, int forced_status_setup_arg, int forced_st
                                               PSA_PAKE_STEP_KEY_SHARE);
     int in_driver = (forced_status_setup_arg == PSA_SUCCESS);
 
-    ASSERT_ALLOC(input_buffer,
+    TEST_CALLOC_OR_FAIL(input_buffer,
                  PSA_PAKE_INPUT_SIZE(PSA_ALG_JPAKE, primitive,
                                      PSA_PAKE_STEP_KEY_SHARE));
     memset(input_buffer, 0xAA, size_key_share);
 
-    ASSERT_ALLOC(output_buffer,
+    TEST_CALLOC_OR_FAIL(output_buffer,
                  PSA_PAKE_INPUT_SIZE(PSA_ALG_JPAKE, primitive,
                                      PSA_PAKE_STEP_KEY_SHARE));
     memset(output_buffer, 0x55, output_size);

--- a/tests/suites/test_suite_psa_crypto_driver_wrappers.function
+++ b/tests/suites/test_suite_psa_crypto_driver_wrappers.function
@@ -460,7 +460,7 @@ static int sanity_check_rsa_encryption_result(
         TEST_EQUAL(buf[0], 0x00);
         TEST_EQUAL(buf[1], 0x02);
         TEST_EQUAL(buf[length - input_data->len - 1], 0x00);
-        ASSERT_COMPARE(buf + length - input_data->len, input_data->len,
+        TEST_BUFFERS_EQUAL(buf + length - input_data->len, input_data->len,
                        input_data->x, input_data->len);
     } else if (PSA_ALG_IS_RSA_OAEP(alg)) {
         TEST_EQUAL(buf[0], 0x00);
@@ -546,7 +546,7 @@ void sign_hash(int key_type_arg,
                                   &signature_length);
     TEST_EQUAL(actual_status, expected_status);
     if (expected_status == PSA_SUCCESS) {
-        ASSERT_COMPARE(signature, signature_length,
+        TEST_BUFFERS_EQUAL(signature, signature_length,
                        expected_output->x, expected_output->len);
     }
     TEST_EQUAL(mbedtls_test_driver_signature_sign_hooks.hits, 1);
@@ -673,7 +673,7 @@ void sign_message(int key_type_arg,
                                      &signature_length);
     TEST_EQUAL(actual_status, expected_status);
     if (expected_status == PSA_SUCCESS) {
-        ASSERT_COMPARE(signature, signature_length,
+        TEST_BUFFERS_EQUAL(signature, signature_length,
                        expected_output->x, expected_output->len);
     }
     /* In the builtin algorithm the driver is called twice. */
@@ -795,7 +795,7 @@ void generate_ec_key(int force_status_arg,
         psa_export_key(key, actual_output, sizeof(actual_output), &actual_output_length);
 
         if (fake_output->len > 0) {
-            ASSERT_COMPARE(actual_output, actual_output_length,
+            TEST_BUFFERS_EQUAL(actual_output, actual_output_length,
                            expected_output, expected_output_length);
         } else {
             size_t zeroes = 0;
@@ -927,7 +927,7 @@ void export_key(int force_status_arg,
     }
 
     if (actual_status == PSA_SUCCESS) {
-        ASSERT_COMPARE(actual_output, actual_output_length,
+        TEST_BUFFERS_EQUAL(actual_output, actual_output_length,
                        expected_output_ptr, expected_output_length);
     }
 exit:
@@ -1006,7 +1006,7 @@ void key_agreement(int alg_arg,
     TEST_EQUAL(mbedtls_test_driver_key_agreement_hooks.hits, 1);
 
     if (actual_status == PSA_SUCCESS) {
-        ASSERT_COMPARE(actual_output, actual_output_length,
+        TEST_BUFFERS_EQUAL(actual_output, actual_output_length,
                        expected_output_ptr, expected_output_length);
     }
     mbedtls_free(actual_output);
@@ -1093,7 +1093,7 @@ void cipher_encrypt_validation(int alg_arg,
     PSA_ASSERT(psa_cipher_abort(&operation));
     // driver function should've been called as part of the finish() core routine
     TEST_EQUAL(mbedtls_test_driver_cipher_hooks.hits, 0);
-    ASSERT_COMPARE(output1 + iv_size, output1_length - iv_size,
+    TEST_BUFFERS_EQUAL(output1 + iv_size, output1_length - iv_size,
                    output2, output2_length);
 
 exit:
@@ -1221,7 +1221,7 @@ void cipher_encrypt_multipart(int alg_arg,
         PSA_ASSERT(psa_cipher_abort(&operation));
         TEST_EQUAL(mbedtls_test_driver_cipher_hooks.hits, 0);
 
-        ASSERT_COMPARE(expected_output->x, expected_output->len,
+        TEST_BUFFERS_EQUAL(expected_output->x, expected_output->len,
                        output, total_output_length);
     }
 
@@ -1350,7 +1350,7 @@ void cipher_decrypt_multipart(int alg_arg,
         PSA_ASSERT(psa_cipher_abort(&operation));
         TEST_EQUAL(mbedtls_test_driver_cipher_hooks.hits, 0);
 
-        ASSERT_COMPARE(expected_output->x, expected_output->len,
+        TEST_BUFFERS_EQUAL(expected_output->x, expected_output->len,
                        output, total_output_length);
     }
 
@@ -1422,7 +1422,7 @@ void cipher_decrypt(int alg_arg,
     TEST_EQUAL(status, expected_status);
 
     if (expected_status == PSA_SUCCESS) {
-        ASSERT_COMPARE(expected_output->x, expected_output->len,
+        TEST_BUFFERS_EQUAL(expected_output->x, expected_output->len,
                        output, output_length);
     }
 
@@ -1707,7 +1707,7 @@ void aead_encrypt(int key_type_arg, data_t *key_data,
                PSA_SUCCESS : forced_status);
 
     if (status == PSA_SUCCESS) {
-        ASSERT_COMPARE(expected_result->x, expected_result->len,
+        TEST_BUFFERS_EQUAL(expected_result->x, expected_result->len,
                        output_data, output_length);
     }
 
@@ -1770,7 +1770,7 @@ void aead_decrypt(int key_type_arg, data_t *key_data,
                PSA_SUCCESS : forced_status);
 
     if (status == PSA_SUCCESS) {
-        ASSERT_COMPARE(expected_data->x, expected_data->len,
+        TEST_BUFFERS_EQUAL(expected_data->x, expected_data->len,
                        output_data, output_length);
     }
 
@@ -1839,7 +1839,7 @@ void mac_sign(int key_type_arg,
     TEST_EQUAL(mbedtls_test_driver_mac_hooks.hits, 1);
 
     if (forced_status == PSA_SUCCESS) {
-        ASSERT_COMPARE(expected_mac->x, expected_mac->len,
+        TEST_BUFFERS_EQUAL(expected_mac->x, expected_mac->len,
                        actual_mac, mac_length);
     }
 
@@ -1957,7 +1957,7 @@ void mac_sign_multipart(int key_type_arg,
     }
 
     if (forced_status == PSA_SUCCESS) {
-        ASSERT_COMPARE(expected_mac->x, expected_mac->len,
+        TEST_BUFFERS_EQUAL(expected_mac->x, expected_mac->len,
                        actual_mac, mac_length);
     }
 
@@ -2159,7 +2159,7 @@ void builtin_key_export(int builtin_key_id_arg,
     if (expected_status == PSA_SUCCESS) {
         PSA_ASSERT(actual_status);
         TEST_EQUAL(output_size, expected_output->len);
-        ASSERT_COMPARE(output_buffer, output_size,
+        TEST_BUFFERS_EQUAL(output_buffer, output_size,
                        expected_output->x, expected_output->len);
 
         PSA_ASSERT(psa_get_key_attributes(key, &attributes));
@@ -2210,7 +2210,7 @@ void builtin_pubkey_export(int builtin_key_id_arg,
     if (expected_status == PSA_SUCCESS) {
         PSA_ASSERT(actual_status);
         TEST_EQUAL(output_size, expected_output->len);
-        ASSERT_COMPARE(output_buffer, output_size,
+        TEST_BUFFERS_EQUAL(output_buffer, output_size,
                        expected_output->x, expected_output->len);
 
         PSA_ASSERT(psa_get_key_attributes(key, &attributes));
@@ -2257,7 +2257,7 @@ void hash_compute(int alg_arg,
     TEST_EQUAL(mbedtls_test_driver_hash_hooks.driver_status, forced_status);
 
     if (expected_status == PSA_SUCCESS) {
-        ASSERT_COMPARE(output, output_length, hash->x, hash->len);
+        TEST_BUFFERS_EQUAL(output, output_length, hash->x, hash->len);
     }
 
 exit:
@@ -2305,7 +2305,7 @@ void hash_multipart_setup(int alg_arg,
                    forced_status == PSA_ERROR_NOT_SUPPORTED ? 1 : 4);
         TEST_EQUAL(mbedtls_test_driver_hash_hooks.driver_status, forced_status);
 
-        ASSERT_COMPARE(output, output_length, hash->x, hash->len);
+        TEST_BUFFERS_EQUAL(output, output_length, hash->x, hash->len);
     }
 
 exit:
@@ -2362,7 +2362,7 @@ void hash_multipart_update(int alg_arg,
         TEST_EQUAL(mbedtls_test_driver_hash_hooks.hits, 2);
         TEST_EQUAL(mbedtls_test_driver_hash_hooks.driver_status, PSA_SUCCESS);
 
-        ASSERT_COMPARE(output, output_length, hash->x, hash->len);
+        TEST_BUFFERS_EQUAL(output, output_length, hash->x, hash->len);
     }
 
 exit:
@@ -2416,7 +2416,7 @@ void hash_multipart_finish(int alg_arg,
     TEST_EQUAL(mbedtls_test_driver_hash_hooks.driver_status, forced_status);
 
     if (forced_status == PSA_SUCCESS) {
-        ASSERT_COMPARE(output, output_length, hash->x, hash->len);
+        TEST_BUFFERS_EQUAL(output, output_length, hash->x, hash->len);
     }
 
 exit:
@@ -2476,7 +2476,7 @@ void hash_clone(int alg_arg,
         TEST_EQUAL(mbedtls_test_driver_hash_hooks.hits, 3);
         TEST_EQUAL(mbedtls_test_driver_hash_hooks.driver_status, PSA_SUCCESS);
 
-        ASSERT_COMPARE(output, output_length, hash->x, hash->len);
+        TEST_BUFFERS_EQUAL(output, output_length, hash->x, hash->len);
     }
 
 exit:
@@ -2560,7 +2560,7 @@ void asymmetric_encrypt_decrypt(int alg_arg,
 
     if (expected_status_encrypt == PSA_SUCCESS) {
         if (fake_output_encrypt->len > 0) {
-            ASSERT_COMPARE(fake_output_encrypt->x, fake_output_encrypt->len,
+            TEST_BUFFERS_EQUAL(fake_output_encrypt->x, fake_output_encrypt->len,
                            output, output_length);
         } else {
             mbedtls_test_driver_asymmetric_encryption_hooks.forced_status =
@@ -2587,10 +2587,10 @@ void asymmetric_encrypt_decrypt(int alg_arg,
                                               &output2_length), expected_status_decrypt);
             if (expected_status_decrypt == PSA_SUCCESS) {
                 if (fake_output_decrypt->len > 0) {
-                    ASSERT_COMPARE(fake_output_decrypt->x, fake_output_decrypt->len,
+                    TEST_BUFFERS_EQUAL(fake_output_decrypt->x, fake_output_decrypt->len,
                                    output2, output2_length);
                 } else {
-                    ASSERT_COMPARE(input_data->x, input_data->len,
+                    TEST_BUFFERS_EQUAL(input_data->x, input_data->len,
                                    output2, output2_length);
                 }
             }
@@ -2664,7 +2664,7 @@ void asymmetric_decrypt(int alg_arg,
                                       &output_length), expected_status_decrypt);
     if (expected_status_decrypt == PSA_SUCCESS) {
         TEST_EQUAL(output_length, expected_output_data->len);
-        ASSERT_COMPARE(expected_output_data->x, expected_output_data->len,
+        TEST_BUFFERS_EQUAL(expected_output_data->x, expected_output_data->len,
                        output, output_length);
     }
 exit:
@@ -2738,7 +2738,7 @@ void asymmetric_encrypt(int alg_arg,
     if (expected_status_encrypt == PSA_SUCCESS) {
         if (fake_output_encrypt->len > 0) {
             TEST_EQUAL(fake_output_encrypt->len, output_length);
-            ASSERT_COMPARE(fake_output_encrypt->x, fake_output_encrypt->len,
+            TEST_BUFFERS_EQUAL(fake_output_encrypt->x, fake_output_encrypt->len,
                            output, output_length);
         } else {
             /* Perform sanity checks on the output */
@@ -2873,11 +2873,11 @@ void aead_encrypt_setup(int key_type_arg, data_t *key_data,
                    forced_status == PSA_SUCCESS ? 1 : 0);
 
         /* Compare output_data and expected_ciphertext */
-        ASSERT_COMPARE(expected_ciphertext->x, expected_ciphertext->len,
+        TEST_BUFFERS_EQUAL(expected_ciphertext->x, expected_ciphertext->len,
                        output_data, output_length + finish_output_length);
 
         /* Compare tag and expected_tag */
-        ASSERT_COMPARE(expected_tag->x, expected_tag->len, tag_buffer, tag_length);
+        TEST_BUFFERS_EQUAL(expected_tag->x, expected_tag->len, tag_buffer, tag_length);
     }
 
 exit:
@@ -2979,7 +2979,7 @@ void aead_decrypt_setup(int key_type_arg, data_t *key_data,
         TEST_EQUAL(mbedtls_test_driver_aead_hooks.hits_abort,
                    forced_status == PSA_SUCCESS ? 1 : 0);
 
-        ASSERT_COMPARE(expected_result->x, expected_result->len,
+        TEST_BUFFERS_EQUAL(expected_result->x, expected_result->len,
                        output_data, output_length + verify_output_length);
     }
 

--- a/tests/suites/test_suite_psa_crypto_entropy.function
+++ b/tests/suites/test_suite_psa_crypto_entropy.function
@@ -86,8 +86,8 @@ void external_rng_failure_sign(int key_type, data_t *key_data, int alg,
     size_t signature_size = PSA_SIGNATURE_MAX_SIZE;
     size_t signature_length;
 
-    TEST_CALLOC_OR_FAIL(input, input_size);
-    TEST_CALLOC_OR_FAIL(signature, signature_size);
+    TEST_CALLOC(input, input_size);
+    TEST_CALLOC(signature, signature_size);
 
     PSA_ASSERT(psa_crypto_init());
     PSA_ASSERT(psa_import_key(&attributes, key_data->x, key_data->len,
@@ -135,7 +135,7 @@ void validate_entropy_seed_injection(int seed_length_a,
     } else {
         seed_size = seed_length_b;
     }
-    TEST_CALLOC_OR_FAIL(seed, seed_size);
+    TEST_CALLOC(seed, seed_size);
     /* fill seed with some data */
     for (i = 0; i < seed_size; ++i) {
         seed[i] = i;

--- a/tests/suites/test_suite_psa_crypto_entropy.function
+++ b/tests/suites/test_suite_psa_crypto_entropy.function
@@ -86,8 +86,8 @@ void external_rng_failure_sign(int key_type, data_t *key_data, int alg,
     size_t signature_size = PSA_SIGNATURE_MAX_SIZE;
     size_t signature_length;
 
-    ASSERT_ALLOC(input, input_size);
-    ASSERT_ALLOC(signature, signature_size);
+    TEST_CALLOC_OR_FAIL(input, input_size);
+    TEST_CALLOC_OR_FAIL(signature, signature_size);
 
     PSA_ASSERT(psa_crypto_init());
     PSA_ASSERT(psa_import_key(&attributes, key_data->x, key_data->len,
@@ -135,7 +135,7 @@ void validate_entropy_seed_injection(int seed_length_a,
     } else {
         seed_size = seed_length_b;
     }
-    ASSERT_ALLOC(seed, seed_size);
+    TEST_CALLOC_OR_FAIL(seed, seed_size);
     /* fill seed with some data */
     for (i = 0; i < seed_size; ++i) {
         seed[i] = i;

--- a/tests/suites/test_suite_psa_crypto_hash.function
+++ b/tests/suites/test_suite_psa_crypto_hash.function
@@ -25,7 +25,7 @@ void hash_finish(int alg_arg, data_t *input, data_t *expected_hash)
     PSA_ASSERT(psa_hash_finish(&operation,
                                actual_hash, sizeof(actual_hash),
                                &actual_hash_length));
-    TEST_BUFFERS_EQUAL(expected_hash->x, expected_hash->len,
+    TEST_MEMORY_COMPARE(expected_hash->x, expected_hash->len,
                    actual_hash, actual_hash_length);
 
 exit:
@@ -83,13 +83,13 @@ void hash_multi_part(int alg_arg, data_t *input, data_t *expected_hash)
         PSA_ASSERT(psa_hash_finish(&operation,
                                    actual_hash, sizeof(actual_hash),
                                    &actual_hash_length));
-        TEST_BUFFERS_EQUAL(expected_hash->x, expected_hash->len,
+        TEST_MEMORY_COMPARE(expected_hash->x, expected_hash->len,
                        actual_hash, actual_hash_length);
 
         PSA_ASSERT(psa_hash_finish(&operation2,
                                    actual_hash, sizeof(actual_hash),
                                    &actual_hash_length));
-        TEST_BUFFERS_EQUAL(expected_hash->x, expected_hash->len,
+        TEST_MEMORY_COMPARE(expected_hash->x, expected_hash->len,
                        actual_hash, actual_hash_length);
     } while (len++ != input->len);
 

--- a/tests/suites/test_suite_psa_crypto_hash.function
+++ b/tests/suites/test_suite_psa_crypto_hash.function
@@ -26,7 +26,7 @@ void hash_finish(int alg_arg, data_t *input, data_t *expected_hash)
                                actual_hash, sizeof(actual_hash),
                                &actual_hash_length));
     TEST_MEMORY_COMPARE(expected_hash->x, expected_hash->len,
-                   actual_hash, actual_hash_length);
+                        actual_hash, actual_hash_length);
 
 exit:
     psa_hash_abort(&operation);
@@ -84,13 +84,13 @@ void hash_multi_part(int alg_arg, data_t *input, data_t *expected_hash)
                                    actual_hash, sizeof(actual_hash),
                                    &actual_hash_length));
         TEST_MEMORY_COMPARE(expected_hash->x, expected_hash->len,
-                       actual_hash, actual_hash_length);
+                            actual_hash, actual_hash_length);
 
         PSA_ASSERT(psa_hash_finish(&operation2,
                                    actual_hash, sizeof(actual_hash),
                                    &actual_hash_length));
         TEST_MEMORY_COMPARE(expected_hash->x, expected_hash->len,
-                       actual_hash, actual_hash_length);
+                            actual_hash, actual_hash_length);
     } while (len++ != input->len);
 
 exit:

--- a/tests/suites/test_suite_psa_crypto_hash.function
+++ b/tests/suites/test_suite_psa_crypto_hash.function
@@ -25,7 +25,7 @@ void hash_finish(int alg_arg, data_t *input, data_t *expected_hash)
     PSA_ASSERT(psa_hash_finish(&operation,
                                actual_hash, sizeof(actual_hash),
                                &actual_hash_length));
-    ASSERT_COMPARE(expected_hash->x, expected_hash->len,
+    TEST_BUFFERS_EQUAL(expected_hash->x, expected_hash->len,
                    actual_hash, actual_hash_length);
 
 exit:
@@ -83,13 +83,13 @@ void hash_multi_part(int alg_arg, data_t *input, data_t *expected_hash)
         PSA_ASSERT(psa_hash_finish(&operation,
                                    actual_hash, sizeof(actual_hash),
                                    &actual_hash_length));
-        ASSERT_COMPARE(expected_hash->x, expected_hash->len,
+        TEST_BUFFERS_EQUAL(expected_hash->x, expected_hash->len,
                        actual_hash, actual_hash_length);
 
         PSA_ASSERT(psa_hash_finish(&operation2,
                                    actual_hash, sizeof(actual_hash),
                                    &actual_hash_length));
-        ASSERT_COMPARE(expected_hash->x, expected_hash->len,
+        TEST_BUFFERS_EQUAL(expected_hash->x, expected_hash->len,
                        actual_hash, actual_hash_length);
     } while (len++ != input->len);
 

--- a/tests/suites/test_suite_psa_crypto_init.function
+++ b/tests/suites/test_suite_psa_crypto_init.function
@@ -267,7 +267,7 @@ void entropy_from_nv_seed(int seed_size_arg,
     uint8_t *seed = NULL;
     size_t seed_size = seed_size_arg;
 
-    ASSERT_ALLOC(seed, seed_size);
+    TEST_CALLOC_OR_FAIL(seed, seed_size);
     TEST_ASSERT(mbedtls_nv_seed_write(seed, seed_size) >= 0);
 
     custom_entropy_sources_mask = ENTROPY_SOURCE_NV_SEED;

--- a/tests/suites/test_suite_psa_crypto_init.function
+++ b/tests/suites/test_suite_psa_crypto_init.function
@@ -267,7 +267,7 @@ void entropy_from_nv_seed(int seed_size_arg,
     uint8_t *seed = NULL;
     size_t seed_size = seed_size_arg;
 
-    TEST_CALLOC_OR_FAIL(seed, seed_size);
+    TEST_CALLOC(seed, seed_size);
     TEST_ASSERT(mbedtls_nv_seed_write(seed, seed_size) >= 0);
 
     custom_entropy_sources_mask = ENTROPY_SOURCE_NV_SEED;

--- a/tests/suites/test_suite_psa_crypto_pake.function
+++ b/tests/suites/test_suite_psa_crypto_pake.function
@@ -1031,7 +1031,7 @@ void pake_input_getters_password()
                                                    &buffer_len_ret),
                PSA_SUCCESS);
 
-    TEST_BUFFERS_EQUAL(password_ret, buffer_len_ret, password, strlen(password));
+    TEST_MEMORY_COMPARE(password_ret, buffer_len_ret, password, strlen(password));
 exit:
     PSA_ASSERT(psa_destroy_key(key));
     PSA_ASSERT(psa_pake_abort(&operation));
@@ -1064,7 +1064,7 @@ void pake_input_getters_cipher_suite()
     TEST_EQUAL(psa_crypto_driver_pake_get_cipher_suite(&operation.data.inputs, &cipher_suite_ret),
                PSA_SUCCESS);
 
-    TEST_BUFFERS_EQUAL(&cipher_suite_ret, sizeof(cipher_suite_ret),
+    TEST_MEMORY_COMPARE(&cipher_suite_ret, sizeof(cipher_suite_ret),
                    &cipher_suite, sizeof(cipher_suite));
 
 exit:
@@ -1128,7 +1128,7 @@ void pake_input_getters_user()
                                                    &buffer_len_ret),
                    PSA_SUCCESS);
 
-        TEST_BUFFERS_EQUAL(user_ret, buffer_len_ret, user, user_len);
+        TEST_MEMORY_COMPARE(user_ret, buffer_len_ret, user, user_len);
     }
 exit:
     PSA_ASSERT(psa_pake_abort(&operation));
@@ -1191,7 +1191,7 @@ void pake_input_getters_peer()
                                                    &buffer_len_ret),
                    PSA_SUCCESS);
 
-        TEST_BUFFERS_EQUAL(peer_ret, buffer_len_ret, peer, peer_len);
+        TEST_MEMORY_COMPARE(peer_ret, buffer_len_ret, peer, peer_len);
     }
 exit:
     PSA_ASSERT(psa_pake_abort(&operation));

--- a/tests/suites/test_suite_psa_crypto_pake.function
+++ b/tests/suites/test_suite_psa_crypto_pake.function
@@ -137,8 +137,8 @@ static void ecjpake_do_round(psa_algorithm_t alg, unsigned int primitive,
     size_t c_x1_pr_off, c_x2_pr_off, c_x2s_pr_off;
     psa_status_t status;
 
-    ASSERT_ALLOC(buffer0, buffer_length);
-    ASSERT_ALLOC(buffer1, buffer_length);
+    TEST_CALLOC_OR_FAIL(buffer0, buffer_length);
+    TEST_CALLOC_OR_FAIL(buffer1, buffer_length);
 
     switch (round) {
         case PAKE_ROUND_ONE:
@@ -617,7 +617,7 @@ void ecjpake_setup(int alg_arg, int key_type_pw_arg, int key_usage_pw_arg,
 
     size_t buf_size = PSA_PAKE_OUTPUT_SIZE(alg, primitive_arg,
                                            PSA_PAKE_STEP_KEY_SHARE);
-    ASSERT_ALLOC(output_buffer, buf_size);
+    TEST_CALLOC_OR_FAIL(output_buffer, buf_size);
 
     psa_set_key_usage_flags(&attributes, key_usage_pw);
     psa_set_key_algorithm(&attributes, alg);

--- a/tests/suites/test_suite_psa_crypto_pake.function
+++ b/tests/suites/test_suite_psa_crypto_pake.function
@@ -1065,7 +1065,7 @@ void pake_input_getters_cipher_suite()
                PSA_SUCCESS);
 
     TEST_MEMORY_COMPARE(&cipher_suite_ret, sizeof(cipher_suite_ret),
-                   &cipher_suite, sizeof(cipher_suite));
+                        &cipher_suite, sizeof(cipher_suite));
 
 exit:
     PSA_ASSERT(psa_pake_abort(&operation));

--- a/tests/suites/test_suite_psa_crypto_pake.function
+++ b/tests/suites/test_suite_psa_crypto_pake.function
@@ -137,8 +137,8 @@ static void ecjpake_do_round(psa_algorithm_t alg, unsigned int primitive,
     size_t c_x1_pr_off, c_x2_pr_off, c_x2s_pr_off;
     psa_status_t status;
 
-    TEST_CALLOC_OR_FAIL(buffer0, buffer_length);
-    TEST_CALLOC_OR_FAIL(buffer1, buffer_length);
+    TEST_CALLOC(buffer0, buffer_length);
+    TEST_CALLOC(buffer1, buffer_length);
 
     switch (round) {
         case PAKE_ROUND_ONE:
@@ -617,7 +617,7 @@ void ecjpake_setup(int alg_arg, int key_type_pw_arg, int key_usage_pw_arg,
 
     size_t buf_size = PSA_PAKE_OUTPUT_SIZE(alg, primitive_arg,
                                            PSA_PAKE_STEP_KEY_SHARE);
-    TEST_CALLOC_OR_FAIL(output_buffer, buf_size);
+    TEST_CALLOC(output_buffer, buf_size);
 
     psa_set_key_usage_flags(&attributes, key_usage_pw);
     psa_set_key_algorithm(&attributes, alg);

--- a/tests/suites/test_suite_psa_crypto_pake.function
+++ b/tests/suites/test_suite_psa_crypto_pake.function
@@ -1031,7 +1031,7 @@ void pake_input_getters_password()
                                                    &buffer_len_ret),
                PSA_SUCCESS);
 
-    ASSERT_COMPARE(password_ret, buffer_len_ret, password, strlen(password));
+    TEST_BUFFERS_EQUAL(password_ret, buffer_len_ret, password, strlen(password));
 exit:
     PSA_ASSERT(psa_destroy_key(key));
     PSA_ASSERT(psa_pake_abort(&operation));
@@ -1064,7 +1064,7 @@ void pake_input_getters_cipher_suite()
     TEST_EQUAL(psa_crypto_driver_pake_get_cipher_suite(&operation.data.inputs, &cipher_suite_ret),
                PSA_SUCCESS);
 
-    ASSERT_COMPARE(&cipher_suite_ret, sizeof(cipher_suite_ret),
+    TEST_BUFFERS_EQUAL(&cipher_suite_ret, sizeof(cipher_suite_ret),
                    &cipher_suite, sizeof(cipher_suite));
 
 exit:
@@ -1128,7 +1128,7 @@ void pake_input_getters_user()
                                                    &buffer_len_ret),
                    PSA_SUCCESS);
 
-        ASSERT_COMPARE(user_ret, buffer_len_ret, user, user_len);
+        TEST_BUFFERS_EQUAL(user_ret, buffer_len_ret, user, user_len);
     }
 exit:
     PSA_ASSERT(psa_pake_abort(&operation));
@@ -1191,7 +1191,7 @@ void pake_input_getters_peer()
                                                    &buffer_len_ret),
                    PSA_SUCCESS);
 
-        ASSERT_COMPARE(peer_ret, buffer_len_ret, peer, peer_len);
+        TEST_BUFFERS_EQUAL(peer_ret, buffer_len_ret, peer, peer_len);
     }
 exit:
     PSA_ASSERT(psa_pake_abort(&operation));

--- a/tests/suites/test_suite_psa_crypto_persistent_key.function
+++ b/tests/suites/test_suite_psa_crypto_persistent_key.function
@@ -61,7 +61,7 @@ void format_storage_data_check(data_t *key_data,
     psa_set_key_algorithm(&attributes, key_alg);
     psa_set_key_enrollment_algorithm(&attributes, key_alg2);
 
-    ASSERT_ALLOC(file_data, file_data_length);
+    TEST_CALLOC_OR_FAIL(file_data, file_data_length);
     psa_format_key_data_for_storage(key_data->x, key_data->len,
                                     &attributes.core,
                                     file_data);
@@ -127,7 +127,7 @@ void save_large_persistent_key(int data_length_arg, int expected_status)
     size_t data_length = data_length_arg;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
 
-    ASSERT_ALLOC(data, data_length);
+    TEST_CALLOC_OR_FAIL(data, data_length);
 
     PSA_ASSERT(psa_crypto_init());
 
@@ -267,7 +267,7 @@ void import_export_persistent_key(data_t *data, int type_arg,
     size_t exported_length;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
 
-    ASSERT_ALLOC(exported, export_size);
+    TEST_CALLOC_OR_FAIL(exported, export_size);
 
     PSA_ASSERT(psa_crypto_init());
 

--- a/tests/suites/test_suite_psa_crypto_persistent_key.function
+++ b/tests/suites/test_suite_psa_crypto_persistent_key.function
@@ -67,7 +67,7 @@ void format_storage_data_check(data_t *key_data,
                                     file_data);
 
     TEST_MEMORY_COMPARE(expected_file_data->x, expected_file_data->len,
-                   file_data, file_data_length);
+                        file_data, file_data_length);
 
 exit:
     mbedtls_free(file_data);
@@ -112,7 +112,7 @@ void parse_storage_data_check(data_t *file_data,
     TEST_EQUAL(psa_get_key_enrollment_algorithm(&attributes),
                (uint32_t) expected_key_alg2);
     TEST_MEMORY_COMPARE(expected_key_data->x, expected_key_data->len,
-                   key_data, key_data_length);
+                        key_data, key_data_length);
 
 exit:
     mbedtls_free(key_data);

--- a/tests/suites/test_suite_psa_crypto_persistent_key.function
+++ b/tests/suites/test_suite_psa_crypto_persistent_key.function
@@ -66,7 +66,7 @@ void format_storage_data_check(data_t *key_data,
                                     &attributes.core,
                                     file_data);
 
-    ASSERT_COMPARE(expected_file_data->x, expected_file_data->len,
+    TEST_BUFFERS_EQUAL(expected_file_data->x, expected_file_data->len,
                    file_data, file_data_length);
 
 exit:
@@ -111,7 +111,7 @@ void parse_storage_data_check(data_t *file_data,
                (uint32_t) expected_key_alg);
     TEST_EQUAL(psa_get_key_enrollment_algorithm(&attributes),
                (uint32_t) expected_key_alg2);
-    ASSERT_COMPARE(expected_key_data->x, expected_key_data->len,
+    TEST_BUFFERS_EQUAL(expected_key_data->x, expected_key_data->len,
                    key_data, key_data_length);
 
 exit:
@@ -307,7 +307,7 @@ void import_export_persistent_key(data_t *data, int type_arg,
     PSA_ASSERT(psa_export_key(key_id, exported, export_size,
                               &exported_length));
 
-    ASSERT_COMPARE(data->x, data->len, exported, exported_length);
+    TEST_BUFFERS_EQUAL(data->x, data->len, exported, exported_length);
 
     /* Destroy the key */
     PSA_ASSERT(psa_destroy_key(key_id));

--- a/tests/suites/test_suite_psa_crypto_persistent_key.function
+++ b/tests/suites/test_suite_psa_crypto_persistent_key.function
@@ -66,7 +66,7 @@ void format_storage_data_check(data_t *key_data,
                                     &attributes.core,
                                     file_data);
 
-    TEST_BUFFERS_EQUAL(expected_file_data->x, expected_file_data->len,
+    TEST_MEMORY_COMPARE(expected_file_data->x, expected_file_data->len,
                    file_data, file_data_length);
 
 exit:
@@ -111,7 +111,7 @@ void parse_storage_data_check(data_t *file_data,
                (uint32_t) expected_key_alg);
     TEST_EQUAL(psa_get_key_enrollment_algorithm(&attributes),
                (uint32_t) expected_key_alg2);
-    TEST_BUFFERS_EQUAL(expected_key_data->x, expected_key_data->len,
+    TEST_MEMORY_COMPARE(expected_key_data->x, expected_key_data->len,
                    key_data, key_data_length);
 
 exit:
@@ -307,7 +307,7 @@ void import_export_persistent_key(data_t *data, int type_arg,
     PSA_ASSERT(psa_export_key(key_id, exported, export_size,
                               &exported_length));
 
-    TEST_BUFFERS_EQUAL(data->x, data->len, exported, exported_length);
+    TEST_MEMORY_COMPARE(data->x, data->len, exported, exported_length);
 
     /* Destroy the key */
     PSA_ASSERT(psa_destroy_key(key_id));

--- a/tests/suites/test_suite_psa_crypto_persistent_key.function
+++ b/tests/suites/test_suite_psa_crypto_persistent_key.function
@@ -61,7 +61,7 @@ void format_storage_data_check(data_t *key_data,
     psa_set_key_algorithm(&attributes, key_alg);
     psa_set_key_enrollment_algorithm(&attributes, key_alg2);
 
-    TEST_CALLOC_OR_FAIL(file_data, file_data_length);
+    TEST_CALLOC(file_data, file_data_length);
     psa_format_key_data_for_storage(key_data->x, key_data->len,
                                     &attributes.core,
                                     file_data);
@@ -127,7 +127,7 @@ void save_large_persistent_key(int data_length_arg, int expected_status)
     size_t data_length = data_length_arg;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
 
-    TEST_CALLOC_OR_FAIL(data, data_length);
+    TEST_CALLOC(data, data_length);
 
     PSA_ASSERT(psa_crypto_init());
 
@@ -267,7 +267,7 @@ void import_export_persistent_key(data_t *data, int type_arg,
     size_t exported_length;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
 
-    TEST_CALLOC_OR_FAIL(exported, export_size);
+    TEST_CALLOC(exported, export_size);
 
     PSA_ASSERT(psa_crypto_init());
 

--- a/tests/suites/test_suite_psa_crypto_se_driver_hal.function
+++ b/tests/suites/test_suite_psa_crypto_se_driver_hal.function
@@ -607,7 +607,7 @@ static int check_persistent_data(psa_key_location_t location,
     PSA_ASSERT(psa_its_get_info(uid, &info));
     ASSERT_ALLOC(loaded, info.size);
     PSA_ASSERT(psa_its_get(uid, 0, info.size, loaded, NULL));
-    ASSERT_COMPARE(expected_data, size, loaded, info.size);
+    TEST_BUFFERS_EQUAL(expected_data, size, loaded, info.size);
     ok = 1;
 
 exit:
@@ -965,7 +965,7 @@ void key_creation_import_export(int lifetime_arg, int min_slot, int restart)
     PSA_ASSERT(psa_export_key(returned_id,
                               exported, sizeof(exported),
                               &exported_length));
-    ASSERT_COMPARE(key_material, sizeof(key_material),
+    TEST_BUFFERS_EQUAL(key_material, sizeof(key_material),
                    exported, exported_length);
 
     PSA_ASSERT(psa_destroy_key(returned_id));

--- a/tests/suites/test_suite_psa_crypto_se_driver_hal.function
+++ b/tests/suites/test_suite_psa_crypto_se_driver_hal.function
@@ -966,7 +966,7 @@ void key_creation_import_export(int lifetime_arg, int min_slot, int restart)
                               exported, sizeof(exported),
                               &exported_length));
     TEST_MEMORY_COMPARE(key_material, sizeof(key_material),
-                   exported, exported_length);
+                        exported, exported_length);
 
     PSA_ASSERT(psa_destroy_key(returned_id));
     if (!check_persistent_data(location,

--- a/tests/suites/test_suite_psa_crypto_se_driver_hal.function
+++ b/tests/suites/test_suite_psa_crypto_se_driver_hal.function
@@ -605,7 +605,7 @@ static int check_persistent_data(psa_key_location_t location,
     int ok = 0;
 
     PSA_ASSERT(psa_its_get_info(uid, &info));
-    ASSERT_ALLOC(loaded, info.size);
+    TEST_CALLOC_OR_FAIL(loaded, info.size);
     PSA_ASSERT(psa_its_get(uid, 0, info.size, loaded, NULL));
     TEST_BUFFERS_EQUAL(expected_data, size, loaded, info.size);
     ok = 1;

--- a/tests/suites/test_suite_psa_crypto_se_driver_hal.function
+++ b/tests/suites/test_suite_psa_crypto_se_driver_hal.function
@@ -605,7 +605,7 @@ static int check_persistent_data(psa_key_location_t location,
     int ok = 0;
 
     PSA_ASSERT(psa_its_get_info(uid, &info));
-    TEST_CALLOC_OR_FAIL(loaded, info.size);
+    TEST_CALLOC(loaded, info.size);
     PSA_ASSERT(psa_its_get(uid, 0, info.size, loaded, NULL));
     TEST_BUFFERS_EQUAL(expected_data, size, loaded, info.size);
     ok = 1;

--- a/tests/suites/test_suite_psa_crypto_se_driver_hal.function
+++ b/tests/suites/test_suite_psa_crypto_se_driver_hal.function
@@ -607,7 +607,7 @@ static int check_persistent_data(psa_key_location_t location,
     PSA_ASSERT(psa_its_get_info(uid, &info));
     TEST_CALLOC(loaded, info.size);
     PSA_ASSERT(psa_its_get(uid, 0, info.size, loaded, NULL));
-    TEST_BUFFERS_EQUAL(expected_data, size, loaded, info.size);
+    TEST_MEMORY_COMPARE(expected_data, size, loaded, info.size);
     ok = 1;
 
 exit:
@@ -965,7 +965,7 @@ void key_creation_import_export(int lifetime_arg, int min_slot, int restart)
     PSA_ASSERT(psa_export_key(returned_id,
                               exported, sizeof(exported),
                               &exported_length));
-    TEST_BUFFERS_EQUAL(key_material, sizeof(key_material),
+    TEST_MEMORY_COMPARE(key_material, sizeof(key_material),
                    exported, exported_length);
 
     PSA_ASSERT(psa_destroy_key(returned_id));

--- a/tests/suites/test_suite_psa_crypto_slot_management.function
+++ b/tests/suites/test_suite_psa_crypto_slot_management.function
@@ -303,7 +303,7 @@ void persistent_slot_lifecycle(int lifetime_arg, int owner_id_arg, int id_arg,
                        psa_get_key_type(&read_attributes));
             TEST_EQUAL(psa_get_key_bits(&attributes),
                        psa_get_key_bits(&read_attributes));
-            ASSERT_ALLOC(reexported, key_data->len);
+            TEST_CALLOC_OR_FAIL(reexported, key_data->len);
             if (usage_flags & PSA_KEY_USAGE_EXPORT) {
                 PSA_ASSERT(psa_export_key(id, reexported, key_data->len,
                                           &reexported_length));
@@ -575,7 +575,7 @@ void copy_across_lifetimes(int source_lifetime_arg, int source_owner_id_arg,
                psa_get_key_enrollment_algorithm(&target_attributes));
     if (expected_usage & PSA_KEY_USAGE_EXPORT) {
         size_t length;
-        ASSERT_ALLOC(export_buffer, material->len);
+        TEST_CALLOC_OR_FAIL(export_buffer, material->len);
         PSA_ASSERT(psa_export_key(returned_target_id, export_buffer,
                                   material->len, &length));
         TEST_BUFFERS_EQUAL(material->x, material->len,
@@ -689,7 +689,7 @@ void copy_to_occupied(int source_lifetime_arg, int source_id_arg,
                psa_get_key_algorithm(&attributes2));
     if (target_usage & PSA_KEY_USAGE_EXPORT) {
         size_t length;
-        ASSERT_ALLOC(export_buffer, target_material->len);
+        TEST_CALLOC_OR_FAIL(export_buffer, target_material->len);
         PSA_ASSERT(psa_export_key(returned_target_id, export_buffer,
                                   target_material->len, &length));
         TEST_BUFFERS_EQUAL(target_material->x, target_material->len,
@@ -813,7 +813,7 @@ void many_transient_keys(int max_keys_arg)
     uint8_t exported[sizeof(size_t)];
     size_t exported_length;
 
-    ASSERT_ALLOC(keys, max_keys);
+    TEST_CALLOC_OR_FAIL(keys, max_keys);
     PSA_ASSERT(psa_crypto_init());
 
     psa_set_key_usage_flags(&attributes, PSA_KEY_USAGE_EXPORT);
@@ -942,7 +942,7 @@ void non_reusable_key_slots_integrity_in_case_of_key_slot_starvation()
 
     TEST_ASSERT(MBEDTLS_PSA_KEY_SLOT_COUNT >= 1);
 
-    ASSERT_ALLOC(keys, MBEDTLS_PSA_KEY_SLOT_COUNT);
+    TEST_CALLOC_OR_FAIL(keys, MBEDTLS_PSA_KEY_SLOT_COUNT);
     PSA_ASSERT(psa_crypto_init());
 
     psa_set_key_usage_flags(&attributes,

--- a/tests/suites/test_suite_psa_crypto_slot_management.function
+++ b/tests/suites/test_suite_psa_crypto_slot_management.function
@@ -303,7 +303,7 @@ void persistent_slot_lifecycle(int lifetime_arg, int owner_id_arg, int id_arg,
                        psa_get_key_type(&read_attributes));
             TEST_EQUAL(psa_get_key_bits(&attributes),
                        psa_get_key_bits(&read_attributes));
-            TEST_CALLOC_OR_FAIL(reexported, key_data->len);
+            TEST_CALLOC(reexported, key_data->len);
             if (usage_flags & PSA_KEY_USAGE_EXPORT) {
                 PSA_ASSERT(psa_export_key(id, reexported, key_data->len,
                                           &reexported_length));
@@ -575,7 +575,7 @@ void copy_across_lifetimes(int source_lifetime_arg, int source_owner_id_arg,
                psa_get_key_enrollment_algorithm(&target_attributes));
     if (expected_usage & PSA_KEY_USAGE_EXPORT) {
         size_t length;
-        TEST_CALLOC_OR_FAIL(export_buffer, material->len);
+        TEST_CALLOC(export_buffer, material->len);
         PSA_ASSERT(psa_export_key(returned_target_id, export_buffer,
                                   material->len, &length));
         TEST_BUFFERS_EQUAL(material->x, material->len,
@@ -689,7 +689,7 @@ void copy_to_occupied(int source_lifetime_arg, int source_id_arg,
                psa_get_key_algorithm(&attributes2));
     if (target_usage & PSA_KEY_USAGE_EXPORT) {
         size_t length;
-        TEST_CALLOC_OR_FAIL(export_buffer, target_material->len);
+        TEST_CALLOC(export_buffer, target_material->len);
         PSA_ASSERT(psa_export_key(returned_target_id, export_buffer,
                                   target_material->len, &length));
         TEST_BUFFERS_EQUAL(target_material->x, target_material->len,
@@ -813,7 +813,7 @@ void many_transient_keys(int max_keys_arg)
     uint8_t exported[sizeof(size_t)];
     size_t exported_length;
 
-    TEST_CALLOC_OR_FAIL(keys, max_keys);
+    TEST_CALLOC(keys, max_keys);
     PSA_ASSERT(psa_crypto_init());
 
     psa_set_key_usage_flags(&attributes, PSA_KEY_USAGE_EXPORT);
@@ -942,7 +942,7 @@ void non_reusable_key_slots_integrity_in_case_of_key_slot_starvation()
 
     TEST_ASSERT(MBEDTLS_PSA_KEY_SLOT_COUNT >= 1);
 
-    TEST_CALLOC_OR_FAIL(keys, MBEDTLS_PSA_KEY_SLOT_COUNT);
+    TEST_CALLOC(keys, MBEDTLS_PSA_KEY_SLOT_COUNT);
     PSA_ASSERT(psa_crypto_init());
 
     psa_set_key_usage_flags(&attributes,

--- a/tests/suites/test_suite_psa_crypto_slot_management.function
+++ b/tests/suites/test_suite_psa_crypto_slot_management.function
@@ -308,7 +308,7 @@ void persistent_slot_lifecycle(int lifetime_arg, int owner_id_arg, int id_arg,
                 PSA_ASSERT(psa_export_key(id, reexported, key_data->len,
                                           &reexported_length));
                 TEST_MEMORY_COMPARE(key_data->x, key_data->len,
-                               reexported, reexported_length);
+                                    reexported, reexported_length);
             } else {
                 TEST_EQUAL(psa_export_key(id, reexported,
                                           key_data->len, &reexported_length),
@@ -403,7 +403,7 @@ void create_existent(int lifetime_arg, int owner_id_arg, int id_arg,
                               reexported, sizeof(reexported),
                               &reexported_length));
     TEST_MEMORY_COMPARE(material1, sizeof(material1),
-                   reexported, reexported_length);
+                        reexported, reexported_length);
 
     PSA_ASSERT(psa_close_key(id));
 
@@ -579,7 +579,7 @@ void copy_across_lifetimes(int source_lifetime_arg, int source_owner_id_arg,
         PSA_ASSERT(psa_export_key(returned_target_id, export_buffer,
                                   material->len, &length));
         TEST_MEMORY_COMPARE(material->x, material->len,
-                       export_buffer, length);
+                            export_buffer, length);
     } else {
         size_t length;
         /* Check that the key is actually non-exportable. */
@@ -693,7 +693,7 @@ void copy_to_occupied(int source_lifetime_arg, int source_id_arg,
         PSA_ASSERT(psa_export_key(returned_target_id, export_buffer,
                                   target_material->len, &length));
         TEST_MEMORY_COMPARE(target_material->x, target_material->len,
-                       export_buffer, length);
+                            export_buffer, length);
     }
 
     PSA_ASSERT(psa_destroy_key(returned_source_id));
@@ -841,7 +841,7 @@ void many_transient_keys(int max_keys_arg)
                                   exported, sizeof(exported),
                                   &exported_length));
         TEST_MEMORY_COMPARE(exported, exported_length,
-                       (uint8_t *) &i, sizeof(i));
+                            (uint8_t *) &i, sizeof(i));
     }
     PSA_ASSERT(psa_close_key(keys[i - 1]));
 
@@ -918,7 +918,7 @@ void key_slot_eviction_to_import_new_key(int lifetime_arg)
                                   exported, sizeof(exported),
                                   &exported_length));
         TEST_MEMORY_COMPARE(exported, exported_length,
-                       (uint8_t *) &i, sizeof(i));
+                            (uint8_t *) &i, sizeof(i));
         PSA_ASSERT(psa_destroy_key(key));
     }
 
@@ -1017,7 +1017,7 @@ void non_reusable_key_slots_integrity_in_case_of_key_slot_starvation()
                                   exported, sizeof(exported),
                                   &exported_length));
         TEST_MEMORY_COMPARE(exported, exported_length,
-                       (uint8_t *) &i, sizeof(i));
+                            (uint8_t *) &i, sizeof(i));
         PSA_ASSERT(psa_destroy_key(keys[i]));
     }
 
@@ -1029,7 +1029,7 @@ void non_reusable_key_slots_integrity_in_case_of_key_slot_starvation()
     PSA_ASSERT(psa_export_key(persistent_key, exported, sizeof(exported),
                               &exported_length));
     TEST_MEMORY_COMPARE(exported, exported_length,
-                   (uint8_t *) &persistent_key, sizeof(persistent_key));
+                        (uint8_t *) &persistent_key, sizeof(persistent_key));
 exit:
     /*
      * Key attributes may have been returned by psa_get_key_attributes()

--- a/tests/suites/test_suite_psa_crypto_slot_management.function
+++ b/tests/suites/test_suite_psa_crypto_slot_management.function
@@ -307,7 +307,7 @@ void persistent_slot_lifecycle(int lifetime_arg, int owner_id_arg, int id_arg,
             if (usage_flags & PSA_KEY_USAGE_EXPORT) {
                 PSA_ASSERT(psa_export_key(id, reexported, key_data->len,
                                           &reexported_length));
-                ASSERT_COMPARE(key_data->x, key_data->len,
+                TEST_BUFFERS_EQUAL(key_data->x, key_data->len,
                                reexported, reexported_length);
             } else {
                 TEST_EQUAL(psa_export_key(id, reexported,
@@ -402,7 +402,7 @@ void create_existent(int lifetime_arg, int owner_id_arg, int id_arg,
     PSA_ASSERT(psa_export_key(id,
                               reexported, sizeof(reexported),
                               &reexported_length));
-    ASSERT_COMPARE(material1, sizeof(material1),
+    TEST_BUFFERS_EQUAL(material1, sizeof(material1),
                    reexported, reexported_length);
 
     PSA_ASSERT(psa_close_key(id));
@@ -578,7 +578,7 @@ void copy_across_lifetimes(int source_lifetime_arg, int source_owner_id_arg,
         ASSERT_ALLOC(export_buffer, material->len);
         PSA_ASSERT(psa_export_key(returned_target_id, export_buffer,
                                   material->len, &length));
-        ASSERT_COMPARE(material->x, material->len,
+        TEST_BUFFERS_EQUAL(material->x, material->len,
                        export_buffer, length);
     } else {
         size_t length;
@@ -692,7 +692,7 @@ void copy_to_occupied(int source_lifetime_arg, int source_id_arg,
         ASSERT_ALLOC(export_buffer, target_material->len);
         PSA_ASSERT(psa_export_key(returned_target_id, export_buffer,
                                   target_material->len, &length));
-        ASSERT_COMPARE(target_material->x, target_material->len,
+        TEST_BUFFERS_EQUAL(target_material->x, target_material->len,
                        export_buffer, length);
     }
 
@@ -840,7 +840,7 @@ void many_transient_keys(int max_keys_arg)
         PSA_ASSERT(psa_export_key(keys[i],
                                   exported, sizeof(exported),
                                   &exported_length));
-        ASSERT_COMPARE(exported, exported_length,
+        TEST_BUFFERS_EQUAL(exported, exported_length,
                        (uint8_t *) &i, sizeof(i));
     }
     PSA_ASSERT(psa_close_key(keys[i - 1]));
@@ -917,7 +917,7 @@ void key_slot_eviction_to_import_new_key(int lifetime_arg)
         PSA_ASSERT(psa_export_key(key,
                                   exported, sizeof(exported),
                                   &exported_length));
-        ASSERT_COMPARE(exported, exported_length,
+        TEST_BUFFERS_EQUAL(exported, exported_length,
                        (uint8_t *) &i, sizeof(i));
         PSA_ASSERT(psa_destroy_key(key));
     }
@@ -988,7 +988,7 @@ void non_reusable_key_slots_integrity_in_case_of_key_slot_starvation()
                               exported, sizeof(exported),
                               &exported_length));
     i = MBEDTLS_PSA_KEY_SLOT_COUNT - 1;
-    ASSERT_COMPARE(exported, exported_length, (uint8_t *) &i, sizeof(i));
+    TEST_BUFFERS_EQUAL(exported, exported_length, (uint8_t *) &i, sizeof(i));
     PSA_ASSERT(psa_destroy_key(keys[MBEDTLS_PSA_KEY_SLOT_COUNT - 1]));
 
     /*
@@ -1016,7 +1016,7 @@ void non_reusable_key_slots_integrity_in_case_of_key_slot_starvation()
         PSA_ASSERT(psa_export_key(keys[i],
                                   exported, sizeof(exported),
                                   &exported_length));
-        ASSERT_COMPARE(exported, exported_length,
+        TEST_BUFFERS_EQUAL(exported, exported_length,
                        (uint8_t *) &i, sizeof(i));
         PSA_ASSERT(psa_destroy_key(keys[i]));
     }
@@ -1028,7 +1028,7 @@ void non_reusable_key_slots_integrity_in_case_of_key_slot_starvation()
 
     PSA_ASSERT(psa_export_key(persistent_key, exported, sizeof(exported),
                               &exported_length));
-    ASSERT_COMPARE(exported, exported_length,
+    TEST_BUFFERS_EQUAL(exported, exported_length,
                    (uint8_t *) &persistent_key, sizeof(persistent_key));
 exit:
     /*

--- a/tests/suites/test_suite_psa_crypto_slot_management.function
+++ b/tests/suites/test_suite_psa_crypto_slot_management.function
@@ -307,7 +307,7 @@ void persistent_slot_lifecycle(int lifetime_arg, int owner_id_arg, int id_arg,
             if (usage_flags & PSA_KEY_USAGE_EXPORT) {
                 PSA_ASSERT(psa_export_key(id, reexported, key_data->len,
                                           &reexported_length));
-                TEST_BUFFERS_EQUAL(key_data->x, key_data->len,
+                TEST_MEMORY_COMPARE(key_data->x, key_data->len,
                                reexported, reexported_length);
             } else {
                 TEST_EQUAL(psa_export_key(id, reexported,
@@ -402,7 +402,7 @@ void create_existent(int lifetime_arg, int owner_id_arg, int id_arg,
     PSA_ASSERT(psa_export_key(id,
                               reexported, sizeof(reexported),
                               &reexported_length));
-    TEST_BUFFERS_EQUAL(material1, sizeof(material1),
+    TEST_MEMORY_COMPARE(material1, sizeof(material1),
                    reexported, reexported_length);
 
     PSA_ASSERT(psa_close_key(id));
@@ -578,7 +578,7 @@ void copy_across_lifetimes(int source_lifetime_arg, int source_owner_id_arg,
         TEST_CALLOC(export_buffer, material->len);
         PSA_ASSERT(psa_export_key(returned_target_id, export_buffer,
                                   material->len, &length));
-        TEST_BUFFERS_EQUAL(material->x, material->len,
+        TEST_MEMORY_COMPARE(material->x, material->len,
                        export_buffer, length);
     } else {
         size_t length;
@@ -692,7 +692,7 @@ void copy_to_occupied(int source_lifetime_arg, int source_id_arg,
         TEST_CALLOC(export_buffer, target_material->len);
         PSA_ASSERT(psa_export_key(returned_target_id, export_buffer,
                                   target_material->len, &length));
-        TEST_BUFFERS_EQUAL(target_material->x, target_material->len,
+        TEST_MEMORY_COMPARE(target_material->x, target_material->len,
                        export_buffer, length);
     }
 
@@ -840,7 +840,7 @@ void many_transient_keys(int max_keys_arg)
         PSA_ASSERT(psa_export_key(keys[i],
                                   exported, sizeof(exported),
                                   &exported_length));
-        TEST_BUFFERS_EQUAL(exported, exported_length,
+        TEST_MEMORY_COMPARE(exported, exported_length,
                        (uint8_t *) &i, sizeof(i));
     }
     PSA_ASSERT(psa_close_key(keys[i - 1]));
@@ -917,7 +917,7 @@ void key_slot_eviction_to_import_new_key(int lifetime_arg)
         PSA_ASSERT(psa_export_key(key,
                                   exported, sizeof(exported),
                                   &exported_length));
-        TEST_BUFFERS_EQUAL(exported, exported_length,
+        TEST_MEMORY_COMPARE(exported, exported_length,
                        (uint8_t *) &i, sizeof(i));
         PSA_ASSERT(psa_destroy_key(key));
     }
@@ -988,7 +988,7 @@ void non_reusable_key_slots_integrity_in_case_of_key_slot_starvation()
                               exported, sizeof(exported),
                               &exported_length));
     i = MBEDTLS_PSA_KEY_SLOT_COUNT - 1;
-    TEST_BUFFERS_EQUAL(exported, exported_length, (uint8_t *) &i, sizeof(i));
+    TEST_MEMORY_COMPARE(exported, exported_length, (uint8_t *) &i, sizeof(i));
     PSA_ASSERT(psa_destroy_key(keys[MBEDTLS_PSA_KEY_SLOT_COUNT - 1]));
 
     /*
@@ -1016,7 +1016,7 @@ void non_reusable_key_slots_integrity_in_case_of_key_slot_starvation()
         PSA_ASSERT(psa_export_key(keys[i],
                                   exported, sizeof(exported),
                                   &exported_length));
-        TEST_BUFFERS_EQUAL(exported, exported_length,
+        TEST_MEMORY_COMPARE(exported, exported_length,
                        (uint8_t *) &i, sizeof(i));
         PSA_ASSERT(psa_destroy_key(keys[i]));
     }
@@ -1028,7 +1028,7 @@ void non_reusable_key_slots_integrity_in_case_of_key_slot_starvation()
 
     PSA_ASSERT(psa_export_key(persistent_key, exported, sizeof(exported),
                               &exported_length));
-    TEST_BUFFERS_EQUAL(exported, exported_length,
+    TEST_MEMORY_COMPARE(exported, exported_length,
                    (uint8_t *) &persistent_key, sizeof(persistent_key));
 exit:
     /*

--- a/tests/suites/test_suite_psa_crypto_storage_format.function
+++ b/tests/suites/test_suite_psa_crypto_storage_format.function
@@ -39,7 +39,7 @@ static int test_written_key(const psa_key_attributes_t *attributes,
     TEST_CALLOC(actual_representation, storage_info.size);
     PSA_ASSERT(psa_its_get(uid, 0, storage_info.size,
                            actual_representation, &length));
-    TEST_BUFFERS_EQUAL(expected_representation->x, expected_representation->len,
+    TEST_MEMORY_COMPARE(expected_representation->x, expected_representation->len,
                    actual_representation, length);
 
     ok = 1;
@@ -263,7 +263,7 @@ static int test_read_key(const psa_key_attributes_t *expected_attributes,
         PSA_ASSERT(psa_export_key(key_id,
                                   exported_material, expected_material->len,
                                   &length));
-        TEST_BUFFERS_EQUAL(expected_material->x, expected_material->len,
+        TEST_MEMORY_COMPARE(expected_material->x, expected_material->len,
                        exported_material, length);
     }
 

--- a/tests/suites/test_suite_psa_crypto_storage_format.function
+++ b/tests/suites/test_suite_psa_crypto_storage_format.function
@@ -39,7 +39,7 @@ static int test_written_key(const psa_key_attributes_t *attributes,
     ASSERT_ALLOC(actual_representation, storage_info.size);
     PSA_ASSERT(psa_its_get(uid, 0, storage_info.size,
                            actual_representation, &length));
-    ASSERT_COMPARE(expected_representation->x, expected_representation->len,
+    TEST_BUFFERS_EQUAL(expected_representation->x, expected_representation->len,
                    actual_representation, length);
 
     ok = 1;
@@ -263,7 +263,7 @@ static int test_read_key(const psa_key_attributes_t *expected_attributes,
         PSA_ASSERT(psa_export_key(key_id,
                                   exported_material, expected_material->len,
                                   &length));
-        ASSERT_COMPARE(expected_material->x, expected_material->len,
+        TEST_BUFFERS_EQUAL(expected_material->x, expected_material->len,
                        exported_material, length);
     }
 

--- a/tests/suites/test_suite_psa_crypto_storage_format.function
+++ b/tests/suites/test_suite_psa_crypto_storage_format.function
@@ -40,7 +40,7 @@ static int test_written_key(const psa_key_attributes_t *attributes,
     PSA_ASSERT(psa_its_get(uid, 0, storage_info.size,
                            actual_representation, &length));
     TEST_MEMORY_COMPARE(expected_representation->x, expected_representation->len,
-                   actual_representation, length);
+                        actual_representation, length);
 
     ok = 1;
 
@@ -264,7 +264,7 @@ static int test_read_key(const psa_key_attributes_t *expected_attributes,
                                   exported_material, expected_material->len,
                                   &length));
         TEST_MEMORY_COMPARE(expected_material->x, expected_material->len,
-                       exported_material, length);
+                            exported_material, length);
     }
 
     if ((flags & TEST_FLAG_EXERCISE) && can_exercise(&actual_attributes)) {

--- a/tests/suites/test_suite_psa_crypto_storage_format.function
+++ b/tests/suites/test_suite_psa_crypto_storage_format.function
@@ -36,7 +36,7 @@ static int test_written_key(const psa_key_attributes_t *attributes,
     /* Check that the key is represented as expected. */
     PSA_ASSERT(psa_its_get_info(uid, &storage_info));
     TEST_EQUAL(storage_info.size, expected_representation->len);
-    TEST_CALLOC_OR_FAIL(actual_representation, storage_info.size);
+    TEST_CALLOC(actual_representation, storage_info.size);
     PSA_ASSERT(psa_its_get(uid, 0, storage_info.size,
                            actual_representation, &length));
     TEST_BUFFERS_EQUAL(expected_representation->x, expected_representation->len,
@@ -259,7 +259,7 @@ static int test_read_key(const psa_key_attributes_t *expected_attributes,
     TEST_EQUAL(psa_get_key_enrollment_algorithm(expected_attributes),
                psa_get_key_enrollment_algorithm(&actual_attributes));
     if (can_export(expected_attributes)) {
-        TEST_CALLOC_OR_FAIL(exported_material, expected_material->len);
+        TEST_CALLOC(exported_material, expected_material->len);
         PSA_ASSERT(psa_export_key(key_id,
                                   exported_material, expected_material->len,
                                   &length));

--- a/tests/suites/test_suite_psa_crypto_storage_format.function
+++ b/tests/suites/test_suite_psa_crypto_storage_format.function
@@ -36,7 +36,7 @@ static int test_written_key(const psa_key_attributes_t *attributes,
     /* Check that the key is represented as expected. */
     PSA_ASSERT(psa_its_get_info(uid, &storage_info));
     TEST_EQUAL(storage_info.size, expected_representation->len);
-    ASSERT_ALLOC(actual_representation, storage_info.size);
+    TEST_CALLOC_OR_FAIL(actual_representation, storage_info.size);
     PSA_ASSERT(psa_its_get(uid, 0, storage_info.size,
                            actual_representation, &length));
     TEST_BUFFERS_EQUAL(expected_representation->x, expected_representation->len,
@@ -259,7 +259,7 @@ static int test_read_key(const psa_key_attributes_t *expected_attributes,
     TEST_EQUAL(psa_get_key_enrollment_algorithm(expected_attributes),
                psa_get_key_enrollment_algorithm(&actual_attributes));
     if (can_export(expected_attributes)) {
-        ASSERT_ALLOC(exported_material, expected_material->len);
+        TEST_CALLOC_OR_FAIL(exported_material, expected_material->len);
         PSA_ASSERT(psa_export_key(key_id,
                                   exported_material, expected_material->len,
                                   &length));

--- a/tests/suites/test_suite_psa_its.function
+++ b/tests/suites/test_suite_psa_its.function
@@ -100,7 +100,7 @@ void set_get_remove(int uid_arg, int flags_arg, data_t *data)
     TEST_ASSERT(info.size == data->len);
     TEST_ASSERT(info.flags == flags);
     PSA_ASSERT(psa_its_get(uid, 0, data->len, buffer, &ret_len));
-    TEST_BUFFERS_EQUAL(data->x, data->len, buffer, ret_len);
+    TEST_MEMORY_COMPARE(data->x, data->len, buffer, ret_len);
 
     PSA_ASSERT(psa_its_remove(uid));
 
@@ -129,7 +129,7 @@ void set_overwrite(int uid_arg,
     TEST_ASSERT(info.size == data1->len);
     TEST_ASSERT(info.flags == flags1);
     PSA_ASSERT(psa_its_get(uid, 0, data1->len, buffer, &ret_len));
-    TEST_BUFFERS_EQUAL(data1->x, data1->len, buffer, ret_len);
+    TEST_MEMORY_COMPARE(data1->x, data1->len, buffer, ret_len);
 
     PSA_ASSERT(psa_its_set_wrap(uid, data2->len, data2->x, flags2));
     PSA_ASSERT(psa_its_get_info(uid, &info));
@@ -137,7 +137,7 @@ void set_overwrite(int uid_arg,
     TEST_ASSERT(info.flags == flags2);
     ret_len = 0;
     PSA_ASSERT(psa_its_get(uid, 0, data2->len, buffer, &ret_len));
-    TEST_BUFFERS_EQUAL(data2->x, data2->len, buffer, ret_len);
+    TEST_MEMORY_COMPARE(data2->x, data2->len, buffer, ret_len);
 
     PSA_ASSERT(psa_its_remove(uid));
 
@@ -167,7 +167,7 @@ void set_multiple(int first_id, int count)
         mbedtls_snprintf(stored, sizeof(stored),
                          "Content of file 0x%08lx", (unsigned long) uid);
         PSA_ASSERT(psa_its_get(uid, 0, sizeof(stored), retrieved, &ret_len));
-        TEST_BUFFERS_EQUAL(retrieved, ret_len,
+        TEST_MEMORY_COMPARE(retrieved, ret_len,
                        stored, sizeof(stored));
         PSA_ASSERT(psa_its_remove(uid));
         TEST_ASSERT(psa_its_get(uid, 0, 0, NULL, NULL) ==
@@ -223,7 +223,7 @@ void get_at(int uid_arg, data_t *data,
     status = psa_its_get(uid, offset, length_arg, buffer, &ret_len);
     TEST_ASSERT(status == (psa_status_t) expected_status);
     if (status == PSA_SUCCESS) {
-        TEST_BUFFERS_EQUAL(data->x + offset, (size_t) length_arg,
+        TEST_MEMORY_COMPARE(data->x + offset, (size_t) length_arg,
                        buffer, ret_len);
     }
     for (i = 0; i < 16; i++) {

--- a/tests/suites/test_suite_psa_its.function
+++ b/tests/suites/test_suite_psa_its.function
@@ -168,7 +168,7 @@ void set_multiple(int first_id, int count)
                          "Content of file 0x%08lx", (unsigned long) uid);
         PSA_ASSERT(psa_its_get(uid, 0, sizeof(stored), retrieved, &ret_len));
         TEST_MEMORY_COMPARE(retrieved, ret_len,
-                       stored, sizeof(stored));
+                            stored, sizeof(stored));
         PSA_ASSERT(psa_its_remove(uid));
         TEST_ASSERT(psa_its_get(uid, 0, 0, NULL, NULL) ==
                     PSA_ERROR_DOES_NOT_EXIST);
@@ -224,7 +224,7 @@ void get_at(int uid_arg, data_t *data,
     TEST_ASSERT(status == (psa_status_t) expected_status);
     if (status == PSA_SUCCESS) {
         TEST_MEMORY_COMPARE(data->x + offset, (size_t) length_arg,
-                       buffer, ret_len);
+                            buffer, ret_len);
     }
     for (i = 0; i < 16; i++) {
         TEST_ASSERT(trailer[i] == '-');

--- a/tests/suites/test_suite_psa_its.function
+++ b/tests/suites/test_suite_psa_its.function
@@ -92,7 +92,7 @@ void set_get_remove(int uid_arg, int flags_arg, data_t *data)
     unsigned char *buffer = NULL;
     size_t ret_len = 0;
 
-    ASSERT_ALLOC(buffer, data->len);
+    TEST_CALLOC_OR_FAIL(buffer, data->len);
 
     PSA_ASSERT(psa_its_set_wrap(uid, data->len, data->x, flags));
 
@@ -122,7 +122,7 @@ void set_overwrite(int uid_arg,
     unsigned char *buffer = NULL;
     size_t ret_len = 0;
 
-    ASSERT_ALLOC(buffer, MAX(data1->len, data2->len));
+    TEST_CALLOC_OR_FAIL(buffer, MAX(data1->len, data2->len));
 
     PSA_ASSERT(psa_its_set_wrap(uid, data1->len, data1->x, flags1));
     PSA_ASSERT(psa_its_get_info(uid, &info));
@@ -214,7 +214,7 @@ void get_at(int uid_arg, data_t *data,
     size_t i;
     size_t ret_len = 0;
 
-    ASSERT_ALLOC(buffer, length + 16);
+    TEST_CALLOC_OR_FAIL(buffer, length + 16);
     trailer = buffer + length;
     memset(trailer, '-', 16);
 

--- a/tests/suites/test_suite_psa_its.function
+++ b/tests/suites/test_suite_psa_its.function
@@ -100,7 +100,7 @@ void set_get_remove(int uid_arg, int flags_arg, data_t *data)
     TEST_ASSERT(info.size == data->len);
     TEST_ASSERT(info.flags == flags);
     PSA_ASSERT(psa_its_get(uid, 0, data->len, buffer, &ret_len));
-    ASSERT_COMPARE(data->x, data->len, buffer, ret_len);
+    TEST_BUFFERS_EQUAL(data->x, data->len, buffer, ret_len);
 
     PSA_ASSERT(psa_its_remove(uid));
 
@@ -129,7 +129,7 @@ void set_overwrite(int uid_arg,
     TEST_ASSERT(info.size == data1->len);
     TEST_ASSERT(info.flags == flags1);
     PSA_ASSERT(psa_its_get(uid, 0, data1->len, buffer, &ret_len));
-    ASSERT_COMPARE(data1->x, data1->len, buffer, ret_len);
+    TEST_BUFFERS_EQUAL(data1->x, data1->len, buffer, ret_len);
 
     PSA_ASSERT(psa_its_set_wrap(uid, data2->len, data2->x, flags2));
     PSA_ASSERT(psa_its_get_info(uid, &info));
@@ -137,7 +137,7 @@ void set_overwrite(int uid_arg,
     TEST_ASSERT(info.flags == flags2);
     ret_len = 0;
     PSA_ASSERT(psa_its_get(uid, 0, data2->len, buffer, &ret_len));
-    ASSERT_COMPARE(data2->x, data2->len, buffer, ret_len);
+    TEST_BUFFERS_EQUAL(data2->x, data2->len, buffer, ret_len);
 
     PSA_ASSERT(psa_its_remove(uid));
 
@@ -167,7 +167,7 @@ void set_multiple(int first_id, int count)
         mbedtls_snprintf(stored, sizeof(stored),
                          "Content of file 0x%08lx", (unsigned long) uid);
         PSA_ASSERT(psa_its_get(uid, 0, sizeof(stored), retrieved, &ret_len));
-        ASSERT_COMPARE(retrieved, ret_len,
+        TEST_BUFFERS_EQUAL(retrieved, ret_len,
                        stored, sizeof(stored));
         PSA_ASSERT(psa_its_remove(uid));
         TEST_ASSERT(psa_its_get(uid, 0, 0, NULL, NULL) ==
@@ -223,7 +223,7 @@ void get_at(int uid_arg, data_t *data,
     status = psa_its_get(uid, offset, length_arg, buffer, &ret_len);
     TEST_ASSERT(status == (psa_status_t) expected_status);
     if (status == PSA_SUCCESS) {
-        ASSERT_COMPARE(data->x + offset, (size_t) length_arg,
+        TEST_BUFFERS_EQUAL(data->x + offset, (size_t) length_arg,
                        buffer, ret_len);
     }
     for (i = 0; i < 16; i++) {

--- a/tests/suites/test_suite_psa_its.function
+++ b/tests/suites/test_suite_psa_its.function
@@ -92,7 +92,7 @@ void set_get_remove(int uid_arg, int flags_arg, data_t *data)
     unsigned char *buffer = NULL;
     size_t ret_len = 0;
 
-    TEST_CALLOC_OR_FAIL(buffer, data->len);
+    TEST_CALLOC(buffer, data->len);
 
     PSA_ASSERT(psa_its_set_wrap(uid, data->len, data->x, flags));
 
@@ -122,7 +122,7 @@ void set_overwrite(int uid_arg,
     unsigned char *buffer = NULL;
     size_t ret_len = 0;
 
-    TEST_CALLOC_OR_FAIL(buffer, MAX(data1->len, data2->len));
+    TEST_CALLOC(buffer, MAX(data1->len, data2->len));
 
     PSA_ASSERT(psa_its_set_wrap(uid, data1->len, data1->x, flags1));
     PSA_ASSERT(psa_its_get_info(uid, &info));
@@ -214,7 +214,7 @@ void get_at(int uid_arg, data_t *data,
     size_t i;
     size_t ret_len = 0;
 
-    TEST_CALLOC_OR_FAIL(buffer, length + 16);
+    TEST_CALLOC(buffer, length + 16);
     trailer = buffer + length;
     memset(trailer, '-', 16);
 

--- a/tests/suites/test_suite_random.function
+++ b/tests/suites/test_suite_random.function
@@ -169,7 +169,7 @@ void mbedtls_psa_get_random_length(int n)
     unsigned char *output = NULL;
 
     PSA_ASSERT(psa_crypto_init());
-    ASSERT_ALLOC(output, n);
+    TEST_CALLOC_OR_FAIL(output, n);
 
     TEST_EQUAL(0, mbedtls_psa_get_random(MBEDTLS_PSA_RANDOM_STATE,
                                          output, n));

--- a/tests/suites/test_suite_random.function
+++ b/tests/suites/test_suite_random.function
@@ -169,7 +169,7 @@ void mbedtls_psa_get_random_length(int n)
     unsigned char *output = NULL;
 
     PSA_ASSERT(psa_crypto_init());
-    TEST_CALLOC_OR_FAIL(output, n);
+    TEST_CALLOC(output, n);
 
     TEST_EQUAL(0, mbedtls_psa_get_random(MBEDTLS_PSA_RANDOM_STATE,
                                          output, n));

--- a/tests/suites/test_suite_shax.function
+++ b/tests/suites/test_suite_shax.function
@@ -155,7 +155,7 @@ void mbedtls_sha3(int family, data_t *in, data_t *hash)
 {
     unsigned char *output = NULL;
 
-    TEST_CALLOC_OR_FAIL(output, hash->len);
+    TEST_CALLOC(output, hash->len);
 
     TEST_ASSERT(mbedtls_sha3(family, in->x, in->len, output, hash->len) == 0);
 
@@ -193,7 +193,7 @@ void mbedtls_sha3_multi(int family, data_t *in, data_t *hash)
     mbedtls_sha3_context ctx;
     const unsigned int block_size = 256;
 
-    TEST_CALLOC_OR_FAIL(output, hash->len);
+    TEST_CALLOC(output, hash->len);
 
     mbedtls_sha3_init(&ctx);
     mbedtls_sha3_starts(&ctx, family);

--- a/tests/suites/test_suite_shax.function
+++ b/tests/suites/test_suite_shax.function
@@ -159,7 +159,7 @@ void mbedtls_sha3(int family, data_t *in, data_t *hash)
 
     TEST_ASSERT(mbedtls_sha3(family, in->x, in->len, output, hash->len) == 0);
 
-    ASSERT_COMPARE(output, hash->len, hash->x, hash->len);
+    TEST_BUFFERS_EQUAL(output, hash->len, hash->x, hash->len);
 
 exit:
     mbedtls_free(output);
@@ -204,7 +204,7 @@ void mbedtls_sha3_multi(int family, data_t *in, data_t *hash)
 
     TEST_ASSERT(mbedtls_sha3_finish(&ctx, output, hash->len) == 0);
 
-    ASSERT_COMPARE(output, hash->len, hash->x, hash->len);
+    TEST_BUFFERS_EQUAL(output, hash->len, hash->x, hash->len);
 
 exit:
     mbedtls_free(output);
@@ -253,7 +253,7 @@ void sha3_streaming(int type, data_t *input)
         mbedtls_sha3_finish(&ctx, hash, hash_length);
         mbedtls_sha3_free(&ctx);
 
-        ASSERT_COMPARE(hash, hash_length, reference_hash, hash_length);
+        TEST_BUFFERS_EQUAL(hash, hash_length, reference_hash, hash_length);
     }
 
 exit:
@@ -289,13 +289,13 @@ void sha3_reuse(data_t *input1, data_t *hash1,
     TEST_ASSERT(mbedtls_sha3_starts(&ctx, type1) == 0);
     TEST_ASSERT(mbedtls_sha3_update(&ctx, input1->x, input1->len) == 0);
     TEST_ASSERT(mbedtls_sha3_finish(&ctx, output, sizeof(output)) == 0);
-    ASSERT_COMPARE(output, hash1->len, hash1->x, hash1->len);
+    TEST_BUFFERS_EQUAL(output, hash1->len, hash1->x, hash1->len);
 
     /* Round 2 */
     TEST_ASSERT(mbedtls_sha3_starts(&ctx, type2) == 0);
     TEST_ASSERT(mbedtls_sha3_update(&ctx, input2->x, input2->len) == 0);
     TEST_ASSERT(mbedtls_sha3_finish(&ctx, output, sizeof(output)) == 0);
-    ASSERT_COMPARE(output, hash2->len, hash2->x, hash2->len);
+    TEST_BUFFERS_EQUAL(output, hash2->len, hash2->x, hash2->len);
 
 exit:
     mbedtls_sha3_free(&ctx);

--- a/tests/suites/test_suite_shax.function
+++ b/tests/suites/test_suite_shax.function
@@ -155,7 +155,7 @@ void mbedtls_sha3(int family, data_t *in, data_t *hash)
 {
     unsigned char *output = NULL;
 
-    ASSERT_ALLOC(output, hash->len);
+    TEST_CALLOC_OR_FAIL(output, hash->len);
 
     TEST_ASSERT(mbedtls_sha3(family, in->x, in->len, output, hash->len) == 0);
 
@@ -193,7 +193,7 @@ void mbedtls_sha3_multi(int family, data_t *in, data_t *hash)
     mbedtls_sha3_context ctx;
     const unsigned int block_size = 256;
 
-    ASSERT_ALLOC(output, hash->len);
+    TEST_CALLOC_OR_FAIL(output, hash->len);
 
     mbedtls_sha3_init(&ctx);
     mbedtls_sha3_starts(&ctx, family);

--- a/tests/suites/test_suite_shax.function
+++ b/tests/suites/test_suite_shax.function
@@ -159,7 +159,7 @@ void mbedtls_sha3(int family, data_t *in, data_t *hash)
 
     TEST_ASSERT(mbedtls_sha3(family, in->x, in->len, output, hash->len) == 0);
 
-    TEST_BUFFERS_EQUAL(output, hash->len, hash->x, hash->len);
+    TEST_MEMORY_COMPARE(output, hash->len, hash->x, hash->len);
 
 exit:
     mbedtls_free(output);
@@ -204,7 +204,7 @@ void mbedtls_sha3_multi(int family, data_t *in, data_t *hash)
 
     TEST_ASSERT(mbedtls_sha3_finish(&ctx, output, hash->len) == 0);
 
-    TEST_BUFFERS_EQUAL(output, hash->len, hash->x, hash->len);
+    TEST_MEMORY_COMPARE(output, hash->len, hash->x, hash->len);
 
 exit:
     mbedtls_free(output);
@@ -253,7 +253,7 @@ void sha3_streaming(int type, data_t *input)
         mbedtls_sha3_finish(&ctx, hash, hash_length);
         mbedtls_sha3_free(&ctx);
 
-        TEST_BUFFERS_EQUAL(hash, hash_length, reference_hash, hash_length);
+        TEST_MEMORY_COMPARE(hash, hash_length, reference_hash, hash_length);
     }
 
 exit:
@@ -289,13 +289,13 @@ void sha3_reuse(data_t *input1, data_t *hash1,
     TEST_ASSERT(mbedtls_sha3_starts(&ctx, type1) == 0);
     TEST_ASSERT(mbedtls_sha3_update(&ctx, input1->x, input1->len) == 0);
     TEST_ASSERT(mbedtls_sha3_finish(&ctx, output, sizeof(output)) == 0);
-    TEST_BUFFERS_EQUAL(output, hash1->len, hash1->x, hash1->len);
+    TEST_MEMORY_COMPARE(output, hash1->len, hash1->x, hash1->len);
 
     /* Round 2 */
     TEST_ASSERT(mbedtls_sha3_starts(&ctx, type2) == 0);
     TEST_ASSERT(mbedtls_sha3_update(&ctx, input2->x, input2->len) == 0);
     TEST_ASSERT(mbedtls_sha3_finish(&ctx, output, sizeof(output)) == 0);
-    TEST_BUFFERS_EQUAL(output, hash2->len, hash2->x, hash2->len);
+    TEST_MEMORY_COMPARE(output, hash2->len, hash2->x, hash2->len);
 
 exit:
     mbedtls_sha3_free(&ctx);

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -152,7 +152,7 @@ void test_callback_buffer(int size, int put1, int put1_ret,
     if (input_len == 0) {
         input_len = 1;
     }
-    TEST_CALLOC_OR_FAIL(input, input_len);
+    TEST_CALLOC(input, input_len);
 
     output_len = 0;
     for (j = 0; j < ROUNDS; j++) {
@@ -166,7 +166,7 @@ void test_callback_buffer(int size, int put1, int put1_ret,
     if (output_len == 0) {
         output_len = 1;
     }
-    TEST_CALLOC_OR_FAIL(output, output_len);
+    TEST_CALLOC(output, output_len);
 
     /* Fill up the buffer with structured data so that unwanted changes
      * can be detected */
@@ -1543,8 +1543,8 @@ void ssl_decrypt_non_etm_cbc(int cipher_type, int hash_id, int trunc_hmac,
              + plaintext_len
              + t0.maclen
              + padlen + 1;
-    TEST_CALLOC_OR_FAIL(buf, buflen);
-    TEST_CALLOC_OR_FAIL(buf_save, buflen);
+    TEST_CALLOC(buf, buflen);
+    TEST_CALLOC(buf_save, buflen);
 
     /* Prepare a dummy record header */
     memset(rec.ctr, 0, sizeof(rec.ctr));
@@ -2064,7 +2064,7 @@ void ssl_tls13_record_protection(int ciphersuite,
     /* Make sure we have enough space in the buffer even if
      * we use more padding than the KAT. */
     buf_len = ciphertext->len + MBEDTLS_SSL_CID_TLS1_3_PADDING_GRANULARITY;
-    TEST_CALLOC_OR_FAIL(buf, buf_len);
+    TEST_CALLOC(buf, buf_len);
     rec.type   = MBEDTLS_SSL_MSG_APPLICATION_DATA;
 
     /* TLS 1.3 uses the version identifier from TLS 1.2 on the wire. */

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -152,7 +152,7 @@ void test_callback_buffer(int size, int put1, int put1_ret,
     if (input_len == 0) {
         input_len = 1;
     }
-    ASSERT_ALLOC(input, input_len);
+    TEST_CALLOC_OR_FAIL(input, input_len);
 
     output_len = 0;
     for (j = 0; j < ROUNDS; j++) {
@@ -166,7 +166,7 @@ void test_callback_buffer(int size, int put1, int put1_ret,
     if (output_len == 0) {
         output_len = 1;
     }
-    ASSERT_ALLOC(output, output_len);
+    TEST_CALLOC_OR_FAIL(output, output_len);
 
     /* Fill up the buffer with structured data so that unwanted changes
      * can be detected */
@@ -1543,8 +1543,8 @@ void ssl_decrypt_non_etm_cbc(int cipher_type, int hash_id, int trunc_hmac,
              + plaintext_len
              + t0.maclen
              + padlen + 1;
-    ASSERT_ALLOC(buf, buflen);
-    ASSERT_ALLOC(buf_save, buflen);
+    TEST_CALLOC_OR_FAIL(buf, buflen);
+    TEST_CALLOC_OR_FAIL(buf_save, buflen);
 
     /* Prepare a dummy record header */
     memset(rec.ctr, 0, sizeof(rec.ctr));
@@ -2064,7 +2064,7 @@ void ssl_tls13_record_protection(int ciphersuite,
     /* Make sure we have enough space in the buffer even if
      * we use more padding than the KAT. */
     buf_len = ciphertext->len + MBEDTLS_SSL_CID_TLS1_3_PADDING_GRANULARITY;
-    ASSERT_ALLOC(buf, buf_len);
+    TEST_CALLOC_OR_FAIL(buf, buf_len);
     rec.type   = MBEDTLS_SSL_MSG_APPLICATION_DATA;
 
     /* TLS 1.3 uses the version identifier from TLS 1.2 on the wire. */

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -1729,7 +1729,7 @@ void ssl_tls13_hkdf_expand_label(int hash_alg,
                     dst, desired_length) == 0);
 
     TEST_MEMORY_COMPARE(dst, (size_t) desired_length,
-                   expected->x, (size_t) expected->len);
+                        expected->x, (size_t) expected->len);
 
 exit:
     PSA_DONE();
@@ -1769,21 +1769,21 @@ void ssl_tls13_traffic_key_generation(int hash_alg,
                     &keys) == 0);
 
     TEST_MEMORY_COMPARE(keys.client_write_key,
-                   keys.key_len,
-                   expected_client_write_key->x,
-                   (size_t) desired_key_len);
+                        keys.key_len,
+                        expected_client_write_key->x,
+                        (size_t) desired_key_len);
     TEST_MEMORY_COMPARE(keys.server_write_key,
-                   keys.key_len,
-                   expected_server_write_key->x,
-                   (size_t) desired_key_len);
+                        keys.key_len,
+                        expected_server_write_key->x,
+                        (size_t) desired_key_len);
     TEST_MEMORY_COMPARE(keys.client_write_iv,
-                   keys.iv_len,
-                   expected_client_write_iv->x,
-                   (size_t) desired_iv_len);
+                        keys.iv_len,
+                        expected_client_write_iv->x,
+                        (size_t) desired_iv_len);
     TEST_MEMORY_COMPARE(keys.server_write_iv,
-                   keys.iv_len,
-                   expected_server_write_iv->x,
-                   (size_t) desired_iv_len);
+                        keys.iv_len,
+                        expected_server_write_iv->x,
+                        (size_t) desired_iv_len);
 
 exit:
     PSA_DONE();
@@ -1828,7 +1828,7 @@ void ssl_tls13_derive_secret(int hash_alg,
                     dst, desired_length) == 0);
 
     TEST_MEMORY_COMPARE(dst, desired_length,
-                   expected->x, desired_length);
+                        expected->x, desired_length);
 
 exit:
     PSA_DONE();
@@ -1860,9 +1860,9 @@ void ssl_tls13_derive_early_secrets(int hash_alg,
                     &secrets) == 0);
 
     TEST_MEMORY_COMPARE(secrets.client_early_traffic_secret, hash_len,
-                   traffic_expected->x, traffic_expected->len);
+                        traffic_expected->x, traffic_expected->len);
     TEST_MEMORY_COMPARE(secrets.early_exporter_master_secret, hash_len,
-                   exporter_expected->x, exporter_expected->len);
+                        exporter_expected->x, exporter_expected->len);
 
 exit:
     PSA_DONE();
@@ -1894,9 +1894,9 @@ void ssl_tls13_derive_handshake_secrets(int hash_alg,
                     &secrets) == 0);
 
     TEST_MEMORY_COMPARE(secrets.client_handshake_traffic_secret, hash_len,
-                   client_expected->x, client_expected->len);
+                        client_expected->x, client_expected->len);
     TEST_MEMORY_COMPARE(secrets.server_handshake_traffic_secret, hash_len,
-                   server_expected->x, server_expected->len);
+                        server_expected->x, server_expected->len);
 
 exit:
     PSA_DONE();
@@ -1930,11 +1930,11 @@ void ssl_tls13_derive_application_secrets(int hash_alg,
                     &secrets) == 0);
 
     TEST_MEMORY_COMPARE(secrets.client_application_traffic_secret_N, hash_len,
-                   client_expected->x, client_expected->len);
+                        client_expected->x, client_expected->len);
     TEST_MEMORY_COMPARE(secrets.server_application_traffic_secret_N, hash_len,
-                   server_expected->x, server_expected->len);
+                        server_expected->x, server_expected->len);
     TEST_MEMORY_COMPARE(secrets.exporter_master_secret, hash_len,
-                   exporter_expected->x, exporter_expected->len);
+                        exporter_expected->x, exporter_expected->len);
 
 exit:
     PSA_DONE();
@@ -1964,7 +1964,7 @@ void ssl_tls13_derive_resumption_secrets(int hash_alg,
                     &secrets) == 0);
 
     TEST_MEMORY_COMPARE(secrets.resumption_master_secret, hash_len,
-                   resumption_expected->x, resumption_expected->len);
+                        resumption_expected->x, resumption_expected->len);
 
 exit:
     PSA_DONE();
@@ -1998,7 +1998,7 @@ void ssl_tls13_create_psk_binder(int hash_alg,
                     binder) == 0);
 
     TEST_MEMORY_COMPARE(binder, hash_len,
-                   binder_expected->x, binder_expected->len);
+                        binder_expected->x, binder_expected->len);
 
 exit:
     PSA_DONE();
@@ -2091,12 +2091,12 @@ void ssl_tls13_record_protection(int ciphersuite,
 
     if (padding_used == MBEDTLS_SSL_CID_TLS1_3_PADDING_GRANULARITY) {
         TEST_MEMORY_COMPARE(rec.buf + rec.data_offset, rec.data_len,
-                       ciphertext->x, ciphertext->len);
+                            ciphertext->x, ciphertext->len);
     }
 
     TEST_ASSERT(mbedtls_ssl_decrypt_buf(NULL, &transform_recv, &rec) == 0);
     TEST_MEMORY_COMPARE(rec.buf + rec.data_offset, rec.data_len,
-                   plaintext->x, plaintext->len);
+                        plaintext->x, plaintext->len);
 
 exit:
     mbedtls_free(buf);
@@ -2123,7 +2123,7 @@ void ssl_tls13_key_evolution(int hash_alg,
                     secret_new) == 0);
 
     TEST_MEMORY_COMPARE(secret_new, (size_t) expected->len,
-                   expected->x, (size_t) expected->len);
+                        expected->x, (size_t) expected->len);
 
 exit:
     PSA_DONE();

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -1728,7 +1728,7 @@ void ssl_tls13_hkdf_expand_label(int hash_alg,
                     ctx->x, ctx->len,
                     dst, desired_length) == 0);
 
-    TEST_BUFFERS_EQUAL(dst, (size_t) desired_length,
+    TEST_MEMORY_COMPARE(dst, (size_t) desired_length,
                    expected->x, (size_t) expected->len);
 
 exit:
@@ -1768,19 +1768,19 @@ void ssl_tls13_traffic_key_generation(int hash_alg,
                     desired_key_len, desired_iv_len,
                     &keys) == 0);
 
-    TEST_BUFFERS_EQUAL(keys.client_write_key,
+    TEST_MEMORY_COMPARE(keys.client_write_key,
                    keys.key_len,
                    expected_client_write_key->x,
                    (size_t) desired_key_len);
-    TEST_BUFFERS_EQUAL(keys.server_write_key,
+    TEST_MEMORY_COMPARE(keys.server_write_key,
                    keys.key_len,
                    expected_server_write_key->x,
                    (size_t) desired_key_len);
-    TEST_BUFFERS_EQUAL(keys.client_write_iv,
+    TEST_MEMORY_COMPARE(keys.client_write_iv,
                    keys.iv_len,
                    expected_client_write_iv->x,
                    (size_t) desired_iv_len);
-    TEST_BUFFERS_EQUAL(keys.server_write_iv,
+    TEST_MEMORY_COMPARE(keys.server_write_iv,
                    keys.iv_len,
                    expected_server_write_iv->x,
                    (size_t) desired_iv_len);
@@ -1827,7 +1827,7 @@ void ssl_tls13_derive_secret(int hash_alg,
                     already_hashed,
                     dst, desired_length) == 0);
 
-    TEST_BUFFERS_EQUAL(dst, desired_length,
+    TEST_MEMORY_COMPARE(dst, desired_length,
                    expected->x, desired_length);
 
 exit:
@@ -1859,9 +1859,9 @@ void ssl_tls13_derive_early_secrets(int hash_alg,
                     alg, secret->x, transcript->x, transcript->len,
                     &secrets) == 0);
 
-    TEST_BUFFERS_EQUAL(secrets.client_early_traffic_secret, hash_len,
+    TEST_MEMORY_COMPARE(secrets.client_early_traffic_secret, hash_len,
                    traffic_expected->x, traffic_expected->len);
-    TEST_BUFFERS_EQUAL(secrets.early_exporter_master_secret, hash_len,
+    TEST_MEMORY_COMPARE(secrets.early_exporter_master_secret, hash_len,
                    exporter_expected->x, exporter_expected->len);
 
 exit:
@@ -1893,9 +1893,9 @@ void ssl_tls13_derive_handshake_secrets(int hash_alg,
                     alg, secret->x, transcript->x, transcript->len,
                     &secrets) == 0);
 
-    TEST_BUFFERS_EQUAL(secrets.client_handshake_traffic_secret, hash_len,
+    TEST_MEMORY_COMPARE(secrets.client_handshake_traffic_secret, hash_len,
                    client_expected->x, client_expected->len);
-    TEST_BUFFERS_EQUAL(secrets.server_handshake_traffic_secret, hash_len,
+    TEST_MEMORY_COMPARE(secrets.server_handshake_traffic_secret, hash_len,
                    server_expected->x, server_expected->len);
 
 exit:
@@ -1929,11 +1929,11 @@ void ssl_tls13_derive_application_secrets(int hash_alg,
                     alg, secret->x, transcript->x, transcript->len,
                     &secrets) == 0);
 
-    TEST_BUFFERS_EQUAL(secrets.client_application_traffic_secret_N, hash_len,
+    TEST_MEMORY_COMPARE(secrets.client_application_traffic_secret_N, hash_len,
                    client_expected->x, client_expected->len);
-    TEST_BUFFERS_EQUAL(secrets.server_application_traffic_secret_N, hash_len,
+    TEST_MEMORY_COMPARE(secrets.server_application_traffic_secret_N, hash_len,
                    server_expected->x, server_expected->len);
-    TEST_BUFFERS_EQUAL(secrets.exporter_master_secret, hash_len,
+    TEST_MEMORY_COMPARE(secrets.exporter_master_secret, hash_len,
                    exporter_expected->x, exporter_expected->len);
 
 exit:
@@ -1963,7 +1963,7 @@ void ssl_tls13_derive_resumption_secrets(int hash_alg,
                     alg, secret->x, transcript->x, transcript->len,
                     &secrets) == 0);
 
-    TEST_BUFFERS_EQUAL(secrets.resumption_master_secret, hash_len,
+    TEST_MEMORY_COMPARE(secrets.resumption_master_secret, hash_len,
                    resumption_expected->x, resumption_expected->len);
 
 exit:
@@ -1997,7 +1997,7 @@ void ssl_tls13_create_psk_binder(int hash_alg,
                     transcript->x,
                     binder) == 0);
 
-    TEST_BUFFERS_EQUAL(binder, hash_len,
+    TEST_MEMORY_COMPARE(binder, hash_len,
                    binder_expected->x, binder_expected->len);
 
 exit:
@@ -2090,12 +2090,12 @@ void ssl_tls13_record_protection(int ciphersuite,
                                         NULL, NULL) == 0);
 
     if (padding_used == MBEDTLS_SSL_CID_TLS1_3_PADDING_GRANULARITY) {
-        TEST_BUFFERS_EQUAL(rec.buf + rec.data_offset, rec.data_len,
+        TEST_MEMORY_COMPARE(rec.buf + rec.data_offset, rec.data_len,
                        ciphertext->x, ciphertext->len);
     }
 
     TEST_ASSERT(mbedtls_ssl_decrypt_buf(NULL, &transform_recv, &rec) == 0);
-    TEST_BUFFERS_EQUAL(rec.buf + rec.data_offset, rec.data_len,
+    TEST_MEMORY_COMPARE(rec.buf + rec.data_offset, rec.data_len,
                    plaintext->x, plaintext->len);
 
 exit:
@@ -2122,7 +2122,7 @@ void ssl_tls13_key_evolution(int hash_alg,
                     input->len ? input->x : NULL, input->len,
                     secret_new) == 0);
 
-    TEST_BUFFERS_EQUAL(secret_new, (size_t) expected->len,
+    TEST_MEMORY_COMPARE(secret_new, (size_t) expected->len,
                    expected->x, (size_t) expected->len);
 
 exit:
@@ -3326,7 +3326,7 @@ void cid_sanity()
                 == 0);
 
     TEST_EQUAL(cid_enabled, MBEDTLS_SSL_CID_ENABLED);
-    TEST_BUFFERS_EQUAL(own_cid, own_cid_len, test_cid, own_cid_len);
+    TEST_MEMORY_COMPARE(own_cid, own_cid_len, test_cid, own_cid_len);
 
     /* Test disabling works. */
     TEST_ASSERT(mbedtls_ssl_set_cid(&ssl, MBEDTLS_SSL_CID_DISABLED, NULL,

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -1728,7 +1728,7 @@ void ssl_tls13_hkdf_expand_label(int hash_alg,
                     ctx->x, ctx->len,
                     dst, desired_length) == 0);
 
-    ASSERT_COMPARE(dst, (size_t) desired_length,
+    TEST_BUFFERS_EQUAL(dst, (size_t) desired_length,
                    expected->x, (size_t) expected->len);
 
 exit:
@@ -1768,19 +1768,19 @@ void ssl_tls13_traffic_key_generation(int hash_alg,
                     desired_key_len, desired_iv_len,
                     &keys) == 0);
 
-    ASSERT_COMPARE(keys.client_write_key,
+    TEST_BUFFERS_EQUAL(keys.client_write_key,
                    keys.key_len,
                    expected_client_write_key->x,
                    (size_t) desired_key_len);
-    ASSERT_COMPARE(keys.server_write_key,
+    TEST_BUFFERS_EQUAL(keys.server_write_key,
                    keys.key_len,
                    expected_server_write_key->x,
                    (size_t) desired_key_len);
-    ASSERT_COMPARE(keys.client_write_iv,
+    TEST_BUFFERS_EQUAL(keys.client_write_iv,
                    keys.iv_len,
                    expected_client_write_iv->x,
                    (size_t) desired_iv_len);
-    ASSERT_COMPARE(keys.server_write_iv,
+    TEST_BUFFERS_EQUAL(keys.server_write_iv,
                    keys.iv_len,
                    expected_server_write_iv->x,
                    (size_t) desired_iv_len);
@@ -1827,7 +1827,7 @@ void ssl_tls13_derive_secret(int hash_alg,
                     already_hashed,
                     dst, desired_length) == 0);
 
-    ASSERT_COMPARE(dst, desired_length,
+    TEST_BUFFERS_EQUAL(dst, desired_length,
                    expected->x, desired_length);
 
 exit:
@@ -1859,9 +1859,9 @@ void ssl_tls13_derive_early_secrets(int hash_alg,
                     alg, secret->x, transcript->x, transcript->len,
                     &secrets) == 0);
 
-    ASSERT_COMPARE(secrets.client_early_traffic_secret, hash_len,
+    TEST_BUFFERS_EQUAL(secrets.client_early_traffic_secret, hash_len,
                    traffic_expected->x, traffic_expected->len);
-    ASSERT_COMPARE(secrets.early_exporter_master_secret, hash_len,
+    TEST_BUFFERS_EQUAL(secrets.early_exporter_master_secret, hash_len,
                    exporter_expected->x, exporter_expected->len);
 
 exit:
@@ -1893,9 +1893,9 @@ void ssl_tls13_derive_handshake_secrets(int hash_alg,
                     alg, secret->x, transcript->x, transcript->len,
                     &secrets) == 0);
 
-    ASSERT_COMPARE(secrets.client_handshake_traffic_secret, hash_len,
+    TEST_BUFFERS_EQUAL(secrets.client_handshake_traffic_secret, hash_len,
                    client_expected->x, client_expected->len);
-    ASSERT_COMPARE(secrets.server_handshake_traffic_secret, hash_len,
+    TEST_BUFFERS_EQUAL(secrets.server_handshake_traffic_secret, hash_len,
                    server_expected->x, server_expected->len);
 
 exit:
@@ -1929,11 +1929,11 @@ void ssl_tls13_derive_application_secrets(int hash_alg,
                     alg, secret->x, transcript->x, transcript->len,
                     &secrets) == 0);
 
-    ASSERT_COMPARE(secrets.client_application_traffic_secret_N, hash_len,
+    TEST_BUFFERS_EQUAL(secrets.client_application_traffic_secret_N, hash_len,
                    client_expected->x, client_expected->len);
-    ASSERT_COMPARE(secrets.server_application_traffic_secret_N, hash_len,
+    TEST_BUFFERS_EQUAL(secrets.server_application_traffic_secret_N, hash_len,
                    server_expected->x, server_expected->len);
-    ASSERT_COMPARE(secrets.exporter_master_secret, hash_len,
+    TEST_BUFFERS_EQUAL(secrets.exporter_master_secret, hash_len,
                    exporter_expected->x, exporter_expected->len);
 
 exit:
@@ -1963,7 +1963,7 @@ void ssl_tls13_derive_resumption_secrets(int hash_alg,
                     alg, secret->x, transcript->x, transcript->len,
                     &secrets) == 0);
 
-    ASSERT_COMPARE(secrets.resumption_master_secret, hash_len,
+    TEST_BUFFERS_EQUAL(secrets.resumption_master_secret, hash_len,
                    resumption_expected->x, resumption_expected->len);
 
 exit:
@@ -1997,7 +1997,7 @@ void ssl_tls13_create_psk_binder(int hash_alg,
                     transcript->x,
                     binder) == 0);
 
-    ASSERT_COMPARE(binder, hash_len,
+    TEST_BUFFERS_EQUAL(binder, hash_len,
                    binder_expected->x, binder_expected->len);
 
 exit:
@@ -2090,12 +2090,12 @@ void ssl_tls13_record_protection(int ciphersuite,
                                         NULL, NULL) == 0);
 
     if (padding_used == MBEDTLS_SSL_CID_TLS1_3_PADDING_GRANULARITY) {
-        ASSERT_COMPARE(rec.buf + rec.data_offset, rec.data_len,
+        TEST_BUFFERS_EQUAL(rec.buf + rec.data_offset, rec.data_len,
                        ciphertext->x, ciphertext->len);
     }
 
     TEST_ASSERT(mbedtls_ssl_decrypt_buf(NULL, &transform_recv, &rec) == 0);
-    ASSERT_COMPARE(rec.buf + rec.data_offset, rec.data_len,
+    TEST_BUFFERS_EQUAL(rec.buf + rec.data_offset, rec.data_len,
                    plaintext->x, plaintext->len);
 
 exit:
@@ -2122,7 +2122,7 @@ void ssl_tls13_key_evolution(int hash_alg,
                     input->len ? input->x : NULL, input->len,
                     secret_new) == 0);
 
-    ASSERT_COMPARE(secret_new, (size_t) expected->len,
+    TEST_BUFFERS_EQUAL(secret_new, (size_t) expected->len,
                    expected->x, (size_t) expected->len);
 
 exit:
@@ -3326,7 +3326,7 @@ void cid_sanity()
                 == 0);
 
     TEST_EQUAL(cid_enabled, MBEDTLS_SSL_CID_ENABLED);
-    ASSERT_COMPARE(own_cid, own_cid_len, test_cid, own_cid_len);
+    TEST_BUFFERS_EQUAL(own_cid, own_cid_len, test_cid, own_cid_len);
 
     /* Test disabling works. */
     TEST_ASSERT(mbedtls_ssl_set_cid(&ssl, MBEDTLS_SSL_CID_DISABLED, NULL,

--- a/tests/suites/test_suite_x509parse.function
+++ b/tests/suites/test_suite_x509parse.function
@@ -447,7 +447,7 @@ void x509_crt_parse_cn_inet_pton(const char *cn, data_t *exp, int ref_ret)
     TEST_EQUAL(addrlen, (size_t) ref_ret);
 
     if (addrlen) {
-        TEST_BUFFERS_EQUAL(exp->x, exp->len, addr, addrlen);
+        TEST_MEMORY_COMPARE(exp->x, exp->len, addr, addrlen);
     }
 }
 /* END_CASE */

--- a/tests/suites/test_suite_x509parse.function
+++ b/tests/suites/test_suite_x509parse.function
@@ -944,7 +944,7 @@ void mbedtls_x509_dn_get_next(char *name_str,
     c = buf + sizeof(buf);
     // Additional size required for trailing space
     out_size = strlen(expected_oids) + 2;
-    ASSERT_ALLOC(out, out_size);
+    TEST_CALLOC_OR_FAIL(out, out_size);
 
     TEST_EQUAL(mbedtls_x509_string_to_names(&names, name_str), 0);
 
@@ -979,7 +979,7 @@ void mbedtls_x509_dn_get_next(char *name_str,
     out = NULL;
 
     out_size = strlen(exp_dn_gets) + 1;
-    ASSERT_ALLOC(out, out_size);
+    TEST_CALLOC_OR_FAIL(out, out_size);
 
     TEST_LE_S(0, mbedtls_x509_dn_gets((char *) out, out_size, &parsed));
     TEST_EQUAL(strcmp((char *) out, exp_dn_gets), 0);

--- a/tests/suites/test_suite_x509parse.function
+++ b/tests/suites/test_suite_x509parse.function
@@ -447,7 +447,7 @@ void x509_crt_parse_cn_inet_pton(const char *cn, data_t *exp, int ref_ret)
     TEST_EQUAL(addrlen, (size_t) ref_ret);
 
     if (addrlen) {
-        ASSERT_COMPARE(exp->x, exp->len, addr, addrlen);
+        TEST_BUFFERS_EQUAL(exp->x, exp->len, addr, addrlen);
     }
 }
 /* END_CASE */

--- a/tests/suites/test_suite_x509parse.function
+++ b/tests/suites/test_suite_x509parse.function
@@ -944,7 +944,7 @@ void mbedtls_x509_dn_get_next(char *name_str,
     c = buf + sizeof(buf);
     // Additional size required for trailing space
     out_size = strlen(expected_oids) + 2;
-    TEST_CALLOC_OR_FAIL(out, out_size);
+    TEST_CALLOC(out, out_size);
 
     TEST_EQUAL(mbedtls_x509_string_to_names(&names, name_str), 0);
 
@@ -979,7 +979,7 @@ void mbedtls_x509_dn_get_next(char *name_str,
     out = NULL;
 
     out_size = strlen(exp_dn_gets) + 1;
-    TEST_CALLOC_OR_FAIL(out, out_size);
+    TEST_CALLOC(out, out_size);
 
     TEST_LE_S(0, mbedtls_x509_dn_gets((char *) out, out_size, &parsed));
     TEST_EQUAL(strcmp((char *) out, exp_dn_gets), 0);


### PR DESCRIPTION
Not much more to say :)

As discussed with Gilles in #6083 [in this comment](https://github.com/Mbed-TLS/mbedtls/pull/6083#discussion_r961656643)

Tested by building and running tests without the compatibility macro initially.

Most of the editing was done by Perl, except for `tests/include/test/macros.h`, with

```
$ find tests \( -name \*.c -o -name \*.function \) -print0 | xargs -0 perl -i -p -e 's/\bASSERT_ALLOC\b/TEST_CALLOC_OR_FAIL/g'
$ find tests \( -name \*.c -o -name \*.function \) -print0 | xargs -0 perl -i -p -e 's/\bASSERT_ALLOC_WEAK\b/TEST_CALLOC_OR_SKIP/g'
$ find tests \( -name \*.c -o -name \*.function \) -print0 | xargs -0 perl -i -p -e 's/\bASSERT_COMPARE\b/TEST_BUFFERS_EQUAL/g'
```


## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [ ] **changelog** not required as internal to tests
- [ ] **backport** will do once this has approval in principle
- [ ] **tests** these are changes to the test framework
