### PR TITLE
Driver-only hashes: TLS 1.3

### DIFF
--- a/include/mbedtls/build_info.h
+++ b/include/mbedtls/build_info.h
@@ -77,7 +77,11 @@
 #if defined(MBEDTLS_PK_C) && defined(MBEDTLS_USE_PSA_CRYPTO)
 #define MBEDTLS_PK_WRITE_C
 #endif
-#if defined(MBEDTLS_PSA_CRYPTO_CONFIG)
+
+/* Make sure all configuration symbols are set before including check_config.h,
+ * even the ones that are calculated programmatically. */
+#if defined(MBEDTLS_PSA_CRYPTO_CONFIG) /* PSA_WANT_xxx influences MBEDTLS_xxx */ || \
+    defined(MBEDTLS_PSA_CRYPTO_C) /* MBEDTLS_xxx influences PSA_WANT_xxx */
 #include "mbedtls/config_psa.h"
 #endif
 

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -260,7 +260,7 @@
 #error "MBEDTLS_ECP_NO_FALLBACK defined, but no alternative implementation enabled"
 #endif
 
-#if defined(MBEDTLS_HKDF_C) && !( defined(MBEDTLS_MD_C) || defined(MBEDTLS_PSA_CRYPTO_C) )
+#if defined(MBEDTLS_HKDF_C) && !defined(MBEDTLS_MD_C)
 #error "MBEDTLS_HKDF_C defined, but not all prerequisites"
 #endif
 

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -750,11 +750,13 @@
 #error "MBEDTLS_SSL_PROTO_TLS1_2 defined, but not all prerequisites"
 #endif
 
-/*
- * HKDF is mandatory for TLS 1.3.
- * Otherwise support for at least one ciphersuite mandates either SHA_256 or
- * SHA_384.
- */
+/* TLS 1.3 requires separate HKDF parts from PSA */
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3) && \
+        !( defined(MBEDTLS_PSA_CRYPTO_C) && defined(PSA_WANT_ALG_HKDF_EXTRACT) && defined(PSA_WANT_ALG_HKDF_EXPAND) )
+#error "MBEDTLS_SSL_PROTO_TLS1_3 defined, but not all prerequisites"
+#endif
+
+/* TLS 1.3 requires at least one ciphersuite, so at least SHA-256 or SHA-384 */
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3) &&                   \
     !( ( defined(PSA_WANT_ALG_SHA_256) || defined(PSA_WANT_ALG_SHA_348) ) && \
         ( defined(MBEDTLS_USE_PSA_CRYPTO) || ( defined(MBEDTLS_MD_C) && ( defined(MBEDTLS_SHA256_C) || defined(MBEDTLS_SHA384_C) ) ) ) )

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -260,7 +260,7 @@
 #error "MBEDTLS_ECP_NO_FALLBACK defined, but no alternative implementation enabled"
 #endif
 
-#if defined(MBEDTLS_HKDF_C) && !defined(MBEDTLS_MD_C)
+#if defined(MBEDTLS_HKDF_C) && !( defined(MBEDTLS_MD_C) || defined(MBEDTLS_PSA_CRYPTO_C) )
 #error "MBEDTLS_HKDF_C defined, but not all prerequisites"
 #endif
 
@@ -755,10 +755,9 @@
  * Otherwise support for at least one ciphersuite mandates either SHA_256 or
  * SHA_384.
  */
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3) && \
-    ( ( !defined(MBEDTLS_HKDF_C) ) || \
-      ( !defined(MBEDTLS_SHA256_C) && !defined(MBEDTLS_SHA384_C) ) || \
-      ( !defined(MBEDTLS_PSA_CRYPTO_C) ) )
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3) &&                   \
+    !( ( defined(PSA_WANT_ALG_SHA_256) || defined(PSA_WANT_ALG_SHA_348) ) && \
+        ( defined(MBEDTLS_USE_PSA_CRYPTO) || ( defined(MBEDTLS_MD_C) && ( defined(MBEDTLS_SHA256_C) || defined(MBEDTLS_SHA384_C) ) ) ) )
 #error "MBEDTLS_SSL_PROTO_TLS1_3 defined, but not all prerequisites"
 #endif
 

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -629,7 +629,12 @@ union mbedtls_ssl_premaster_secret
 
 #define MBEDTLS_PREMASTER_SIZE     sizeof( union mbedtls_ssl_premaster_secret )
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+#define MBEDTLS_TLS1_3_MD_MAX_SIZE         PSA_HASH_MAX_SIZE
+#else
 #define MBEDTLS_TLS1_3_MD_MAX_SIZE         MBEDTLS_MD_MAX_SIZE
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
+
 
 /* Length in number of bytes of the TLS sequence number */
 #define MBEDTLS_SSL_SEQUENCE_NUMBER_LEN 8

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -338,11 +338,15 @@
 #define MBEDTLS_SSL_SRV_CIPHERSUITE_ORDER_SERVER  0
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3) && defined(MBEDTLS_SSL_SESSION_TICKETS)
-#if defined(MBEDTLS_SHA384_C)
+#if ( !defined(MBEDTLS_USE_PSA_CRYPTO) && \
+        defined(MBEDTLS_MD_C) && defined(MBEDTLS_SHA256_C) ) || \
+    ( defined(MBEDTLS_USE_PSA_CRYPTO) && defined(PSA_WANT_ALG_SHA_256) )
 #define MBEDTLS_SSL_TLS1_3_TICKET_RESUMPTION_KEY_LEN        48
-#elif defined(MBEDTLS_SHA256_C)
+#elif ( !defined(MBEDTLS_USE_PSA_CRYPTO) && \
+        defined(MBEDTLS_MD_C) && defined(MBEDTLS_SHA384_C) ) || \
+    ( defined(MBEDTLS_USE_PSA_CRYPTO) && defined(PSA_WANT_ALG_SHA_384) )
 #define MBEDTLS_SSL_TLS1_3_TICKET_RESUMPTION_KEY_LEN        32
-#endif /* MBEDTLS_SHA256_C  */
+#endif
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3 && MBEDTLS_SSL_SESSION_TICKETS */
 /*
  * Default range for DTLS retransmission timer value, in milliseconds.

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -338,13 +338,9 @@
 #define MBEDTLS_SSL_SRV_CIPHERSUITE_ORDER_SERVER  0
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3) && defined(MBEDTLS_SSL_SESSION_TICKETS)
-#if ( !defined(MBEDTLS_USE_PSA_CRYPTO) && \
-        defined(MBEDTLS_MD_C) && defined(MBEDTLS_SHA256_C) ) || \
-    ( defined(MBEDTLS_USE_PSA_CRYPTO) && defined(PSA_WANT_ALG_SHA_256) )
+#if defined(PSA_WANT_ALG_SHA_384)
 #define MBEDTLS_SSL_TLS1_3_TICKET_RESUMPTION_KEY_LEN        48
-#elif ( !defined(MBEDTLS_USE_PSA_CRYPTO) && \
-        defined(MBEDTLS_MD_C) && defined(MBEDTLS_SHA384_C) ) || \
-    ( defined(MBEDTLS_USE_PSA_CRYPTO) && defined(PSA_WANT_ALG_SHA_384) )
+#elif defined(PSA_WANT_ALG_SHA_256)
 #define MBEDTLS_SSL_TLS1_3_TICKET_RESUMPTION_KEY_LEN        32
 #endif
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3 && MBEDTLS_SSL_SESSION_TICKETS */

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -2137,33 +2137,33 @@ static inline int mbedtls_ssl_tls13_sig_alg_for_cert_verify_is_supported(
     switch( sig_alg )
     {
 #if defined(MBEDTLS_ECDSA_C)
-#if defined(MBEDTLS_SHA256_C) && defined(MBEDTLS_ECP_DP_SECP256R1_ENABLED)
+#if defined(PSA_WANT_ALG_SHA_256) && defined(MBEDTLS_ECP_DP_SECP256R1_ENABLED)
         case MBEDTLS_TLS1_3_SIG_ECDSA_SECP256R1_SHA256:
             break;
-#endif /* MBEDTLS_SHA256_C && MBEDTLS_ECP_DP_SECP256R1_ENABLED */
-#if defined(MBEDTLS_SHA384_C) && defined(MBEDTLS_ECP_DP_SECP384R1_ENABLED)
+#endif /* PSA_WANT_ALG_SHA_256 && MBEDTLS_ECP_DP_SECP256R1_ENABLED */
+#if defined(PSA_WANT_ALG_SHA_384) && defined(MBEDTLS_ECP_DP_SECP384R1_ENABLED)
         case MBEDTLS_TLS1_3_SIG_ECDSA_SECP384R1_SHA384:
             break;
-#endif /* MBEDTLS_SHA384_C && MBEDTLS_ECP_DP_SECP384R1_ENABLED */
-#if defined(MBEDTLS_SHA512_C) && defined(MBEDTLS_ECP_DP_SECP521R1_ENABLED)
+#endif /* PSA_WANT_ALG_SHA_384 && MBEDTLS_ECP_DP_SECP384R1_ENABLED */
+#if defined(PSA_WANT_ALG_SHA_512) && defined(MBEDTLS_ECP_DP_SECP521R1_ENABLED)
         case MBEDTLS_TLS1_3_SIG_ECDSA_SECP521R1_SHA512:
             break;
-#endif /* MBEDTLS_SHA512_C && MBEDTLS_ECP_DP_SECP521R1_ENABLED */
+#endif /* PSA_WANT_ALG_SHA_512 && MBEDTLS_ECP_DP_SECP521R1_ENABLED */
 #endif /* MBEDTLS_ECDSA_C */
 
 #if defined(MBEDTLS_PKCS1_V21)
-#if defined(MBEDTLS_SHA256_C)
+#if defined(PSA_WANT_ALG_SHA_256)
         case MBEDTLS_TLS1_3_SIG_RSA_PSS_RSAE_SHA256:
             break;
-#endif /* MBEDTLS_SHA256_C  */
-#if defined(MBEDTLS_SHA384_C)
+#endif /* PSA_WANT_ALG_SHA_256  */
+#if defined(PSA_WANT_ALG_SHA_384)
         case MBEDTLS_TLS1_3_SIG_RSA_PSS_RSAE_SHA384:
             break;
-#endif /* MBEDTLS_SHA384_C */
-#if defined(MBEDTLS_SHA512_C)
+#endif /* PSA_WANT_ALG_SHA_384 */
+#if defined(PSA_WANT_ALG_SHA_512)
         case MBEDTLS_TLS1_3_SIG_RSA_PSS_RSAE_SHA512:
             break;
-#endif /* MBEDTLS_SHA512_C */
+#endif /* PSA_WANT_ALG_SHA_512 */
 #endif /* MBEDTLS_PKCS1_V21 */
         default:
             return( 0 );

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -2178,18 +2178,18 @@ static inline int mbedtls_ssl_tls13_sig_alg_is_supported(
     switch( sig_alg )
     {
 #if defined(MBEDTLS_PKCS1_V15)
-#if defined(MBEDTLS_SHA256_C)
+#if defined(MBEDTLS_HAS_ALG_SHA_256_VIA_MD_OR_PSA_BASED_ON_USE_PSA)
         case MBEDTLS_TLS1_3_SIG_RSA_PKCS1_SHA256:
             break;
-#endif /* MBEDTLS_SHA256_C */
-#if defined(MBEDTLS_SHA384_C)
+#endif /* MBEDTLS_HAS_ALG_SHA_256_VIA_MD_OR_PSA_BASED_ON_USE_PSA */
+#if defined(MBEDTLS_HAS_ALG_SHA_384_VIA_MD_OR_PSA_BASED_ON_USE_PSA)
         case MBEDTLS_TLS1_3_SIG_RSA_PKCS1_SHA384:
             break;
-#endif /* MBEDTLS_SHA384_C */
-#if defined(MBEDTLS_SHA512_C)
+#endif /* MBEDTLS_HAS_ALG_SHA_384_VIA_MD_OR_PSA_BASED_ON_USE_PSA */
+#if defined(MBEDTLS_HAS_ALG_SHA_512_VIA_MD_OR_PSA_BASED_ON_USE_PSA)
         case MBEDTLS_TLS1_3_SIG_RSA_PKCS1_SHA512:
             break;
-#endif /* MBEDTLS_SHA512_C */
+#endif /* MBEDTLS_HAS_ALG_SHA_512_VIA_MD_OR_PSA_BASED_ON_USE_PSA */
 #endif /* MBEDTLS_PKCS1_V15 */
         default:
             return( mbedtls_ssl_tls13_sig_alg_for_cert_verify_is_supported(

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -1401,7 +1401,7 @@ int mbedtls_ssl_reset_transcript_for_hrr( mbedtls_ssl_context *ssl )
     }
 #endif /* MBEDTLS_HAS_ALG_SHA_256_VIA_MD_OR_PSA_BASED_ON_USE_PSA */
 #if defined(MBEDTLS_HAS_ALG_SHA_384_VIA_MD_OR_PSA_BASED_ON_USE_PSA)
-    else if( ciphersuite_info->mac == MBEDTLS_MD_SHA384 )
+    if( ciphersuite_info->mac == MBEDTLS_MD_SHA384 )
     {
         MBEDTLS_SSL_DEBUG_BUF( 4, "Truncated SHA-384 handshake transcript",
                                hash_transcript, hash_len );

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -976,7 +976,7 @@ static int ssl_tls13_write_certificate_verify_body( mbedtls_ssl_context *ssl,
     psa_algorithm_t psa_algorithm = PSA_ALG_NONE;
     uint16_t algorithm = MBEDTLS_TLS1_3_SIG_NONE;
     size_t signature_len = 0;
-    unsigned char verify_hash[ MBEDTLS_MD_MAX_SIZE ];
+    unsigned char verify_hash[PSA_HASH_MAX_SIZE];
     size_t verify_hash_len;
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
 
@@ -1361,7 +1361,7 @@ cleanup:
 int mbedtls_ssl_reset_transcript_for_hrr( mbedtls_ssl_context *ssl )
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
-    unsigned char hash_transcript[ MBEDTLS_MD_MAX_SIZE + 4 ];
+    unsigned char hash_transcript[PSA_HASH_MAX_SIZE + 4];
     size_t hash_len;
     const mbedtls_ssl_ciphersuite_t *ciphersuite_info;
     uint16_t cipher_suite = ssl->session_negotiate->ciphersuite;
@@ -1371,7 +1371,7 @@ int mbedtls_ssl_reset_transcript_for_hrr( mbedtls_ssl_context *ssl )
 
     ret = mbedtls_ssl_get_handshake_transcript( ssl, ciphersuite_info->mac,
                                                 hash_transcript + 4,
-                                                MBEDTLS_MD_MAX_SIZE,
+                                                PSA_HASH_MAX_SIZE,
                                                 &hash_len );
     if( ret != 0 )
     {

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -1386,9 +1386,9 @@ int mbedtls_ssl_reset_transcript_for_hrr( mbedtls_ssl_context *ssl )
 
     hash_len += 4;
 
+#if defined(MBEDTLS_HAS_ALG_SHA_256_VIA_MD_OR_PSA_BASED_ON_USE_PSA)
     if( ciphersuite_info->mac == MBEDTLS_MD_SHA256 )
     {
-#if defined(MBEDTLS_HAS_ALG_SHA_256_VIA_MD_OR_PSA_BASED_ON_USE_PSA)
         MBEDTLS_SSL_DEBUG_BUF( 4, "Truncated SHA-256 handshake transcript",
                                hash_transcript, hash_len );
 
@@ -1398,11 +1398,11 @@ int mbedtls_ssl_reset_transcript_for_hrr( mbedtls_ssl_context *ssl )
 #else
         mbedtls_sha256_starts( &ssl->handshake->fin_sha256, 0 );
 #endif
-#endif /* MBEDTLS_HAS_ALG_SHA_256_VIA_MD_OR_PSA_BASED_ON_USE_PSA */
     }
+#endif /* MBEDTLS_HAS_ALG_SHA_256_VIA_MD_OR_PSA_BASED_ON_USE_PSA */
+#if defined(MBEDTLS_HAS_ALG_SHA_384_VIA_MD_OR_PSA_BASED_ON_USE_PSA)
     else if( ciphersuite_info->mac == MBEDTLS_MD_SHA384 )
     {
-#if defined(MBEDTLS_HAS_ALG_SHA_384_VIA_MD_OR_PSA_BASED_ON_USE_PSA)
         MBEDTLS_SSL_DEBUG_BUF( 4, "Truncated SHA-384 handshake transcript",
                                hash_transcript, hash_len );
 
@@ -1412,9 +1412,8 @@ int mbedtls_ssl_reset_transcript_for_hrr( mbedtls_ssl_context *ssl )
 #else
         mbedtls_sha512_starts( &ssl->handshake->fin_sha384, 1 );
 #endif
-#endif /* MBEDTLS_HAS_ALG_SHA_384_VIA_MD_OR_PSA_BASED_ON_USE_PSA */
     }
-
+#endif /* MBEDTLS_HAS_ALG_SHA_384_VIA_MD_OR_PSA_BASED_ON_USE_PSA */
 #if defined(MBEDTLS_HAS_ALG_SHA_256_VIA_MD_OR_PSA_BASED_ON_USE_PSA) || defined(MBEDTLS_HAS_ALG_SHA_384_VIA_MD_OR_PSA_BASED_ON_USE_PSA)
     ssl->handshake->update_checksum( ssl, hash_transcript, hash_len );
 #endif /* MBEDTLS_HAS_ALG_SHA_256_VIA_MD_OR_PSA_BASED_ON_USE_PSA || MBEDTLS_HAS_ALG_SHA_384_VIA_MD_OR_PSA_BASED_ON_USE_PSA */

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -1388,7 +1388,7 @@ int mbedtls_ssl_reset_transcript_for_hrr( mbedtls_ssl_context *ssl )
 
     if( ciphersuite_info->mac == MBEDTLS_MD_SHA256 )
     {
-#if defined(MBEDTLS_SHA256_C)
+#if defined(MBEDTLS_HAS_ALG_SHA_256_VIA_MD_OR_PSA_BASED_ON_USE_PSA)
         MBEDTLS_SSL_DEBUG_BUF( 4, "Truncated SHA-256 handshake transcript",
                                hash_transcript, hash_len );
 
@@ -1398,11 +1398,11 @@ int mbedtls_ssl_reset_transcript_for_hrr( mbedtls_ssl_context *ssl )
 #else
         mbedtls_sha256_starts( &ssl->handshake->fin_sha256, 0 );
 #endif
-#endif /* MBEDTLS_SHA256_C */
+#endif /* MBEDTLS_HAS_ALG_SHA_256_VIA_MD_OR_PSA_BASED_ON_USE_PSA */
     }
     else if( ciphersuite_info->mac == MBEDTLS_MD_SHA384 )
     {
-#if defined(MBEDTLS_SHA384_C)
+#if defined(MBEDTLS_HAS_ALG_SHA_384_VIA_MD_OR_PSA_BASED_ON_USE_PSA)
         MBEDTLS_SSL_DEBUG_BUF( 4, "Truncated SHA-384 handshake transcript",
                                hash_transcript, hash_len );
 
@@ -1412,12 +1412,12 @@ int mbedtls_ssl_reset_transcript_for_hrr( mbedtls_ssl_context *ssl )
 #else
         mbedtls_sha512_starts( &ssl->handshake->fin_sha384, 1 );
 #endif
-#endif /* MBEDTLS_SHA384_C */
+#endif /* MBEDTLS_HAS_ALG_SHA_384_VIA_MD_OR_PSA_BASED_ON_USE_PSA */
     }
 
-#if defined(MBEDTLS_SHA256_C) || defined(MBEDTLS_SHA384_C)
+#if defined(MBEDTLS_HAS_ALG_SHA_256_VIA_MD_OR_PSA_BASED_ON_USE_PSA) || defined(MBEDTLS_HAS_ALG_SHA_384_VIA_MD_OR_PSA_BASED_ON_USE_PSA)
     ssl->handshake->update_checksum( ssl, hash_transcript, hash_len );
-#endif /* MBEDTLS_SHA256_C || MBEDTLS_SHA384_C */
+#endif /* MBEDTLS_HAS_ALG_SHA_256_VIA_MD_OR_PSA_BASED_ON_USE_PSA || MBEDTLS_HAS_ALG_SHA_384_VIA_MD_OR_PSA_BASED_ON_USE_PSA */
 
     return( ret );
 }

--- a/library/ssl_tls13_keys.h
+++ b/library/ssl_tls13_keys.h
@@ -81,7 +81,7 @@ extern const struct mbedtls_ssl_tls13_labels_struct mbedtls_ssl_tls13_labels;
  * Since contexts are always hashes of message transcripts, this can
  * be approximated from above by the maximum hash size. */
 #define MBEDTLS_SSL_TLS1_3_KEY_SCHEDULE_MAX_CONTEXT_LEN  \
-    MBEDTLS_MD_MAX_SIZE
+    PSA_HASH_MAX_SIZE
 
 /* Maximum desired length for expanded key material generated
  * by HKDF-Expand-Label.

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1851,9 +1851,6 @@ component_test_psa_crypto_config_accel_hash_use_psa () {
     scripts/config.py set MBEDTLS_PSA_CRYPTO_DRIVERS
     scripts/config.py set MBEDTLS_PSA_CRYPTO_CONFIG
     scripts/config.py set MBEDTLS_USE_PSA_CRYPTO
-    scripts/config.py set MBEDTLS_SSL_PROTO_TLS1_3
-    scripts/config.py set MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
-    scripts/config.py set MBEDTLS_SSL_CID_TLS1_3_PADDING_GRANULARITY 1
     scripts/config.py unset MBEDTLS_MD5_C
     scripts/config.py unset MBEDTLS_RIPEMD160_C
     scripts/config.py unset MBEDTLS_SHA1_C
@@ -1873,8 +1870,10 @@ component_test_psa_crypto_config_accel_hash_use_psa () {
     scripts/config.py unset MBEDTLS_HMAC_DRBG_C
     scripts/config.py unset MBEDTLS_ECDSA_DETERMINISTIC
     scripts/config.py -f include/psa/crypto_config.h unset PSA_WANT_ALG_DETERMINISTIC_ECDSA
-    # TLS 1.3 currently depends on SHA256_C || SHA384_C
-    # but is already disabled in the default config
+    # Enable TLS 1.3: use PSA implementation for hashes
+    scripts/config.py set MBEDTLS_SSL_PROTO_TLS1_3
+    scripts/config.py set MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
+    scripts/config.py set MBEDTLS_SSL_CID_TLS1_3_PADDING_GRANULARITY 1
 
     loc_accel_flags="$loc_accel_flags $( echo "$loc_accel_list" | sed 's/[^ ]* */-DMBEDTLS_PSA_ACCEL_&/g' )"
     make CFLAGS="$ASAN_CFLAGS -Werror -I../tests/include -I../tests -I../../tests -DPSA_CRYPTO_DRIVER_TEST -DMBEDTLS_TEST_LIBTESTDRIVER1 $loc_accel_flags" LDFLAGS="-ltestdriver1 $ASAN_CFLAGS" all

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1851,6 +1851,9 @@ component_test_psa_crypto_config_accel_hash_use_psa () {
     scripts/config.py set MBEDTLS_PSA_CRYPTO_DRIVERS
     scripts/config.py set MBEDTLS_PSA_CRYPTO_CONFIG
     scripts/config.py set MBEDTLS_USE_PSA_CRYPTO
+    scripts/config.py set MBEDTLS_SSL_PROTO_TLS1_3
+    scripts/config.py set MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
+    scripts/config.py set MBEDTLS_SSL_CID_TLS1_3_PADDING_GRANULARITY 1
     scripts/config.py unset MBEDTLS_MD5_C
     scripts/config.py unset MBEDTLS_RIPEMD160_C
     scripts/config.py unset MBEDTLS_SHA1_C


### PR DESCRIPTION
## Description
Build and run TLS 1.3 in a configuration where all hashes are provided by drivers.

Resolves: https://github.com/Mbed-TLS/mbedtls/issues/6132

```
*** Comparing before-default -> after-default ***
         ssl: total 892; skipped 478 -> 478
         mps: total  42; skipped  42 ->  42

*** Comparing before-full -> after-full ***
         ssl: total 892; skipped  96 ->  96
         mps: total  42; skipped   0 ->   0

*** Comparing reference -> drivers ***
         ssl: total 892; skipped 445 -> 392
> Test mbedtls_endpoint sanity for the client                           : !MBEDTLS_SSL_PROTO_TLS1_3
> Test mbedtls_endpoint sanity for the server                           : !MBEDTLS_SSL_PROTO_TLS1_3
> DTLS Handshake with serialization, tls1_2                             : !MBEDTLS_SSL_PROTO_TLS1_3
> DTLS Handshake fragmentation, MFL=512                                 : !MBEDTLS_SSL_PROTO_TLS1_3
> DTLS Handshake fragmentation, MFL=1024                                : !MBEDTLS_SSL_PROTO_TLS1_3
> Sending app data via DTLS, MFL=512 without fragmentation              : !MBEDTLS_SSL_PROTO_TLS1_3
> Sending app data via DTLS, MFL=512 with fragmentation                 : !MBEDTLS_SSL_PROTO_TLS1_3
> Sending app data via DTLS, MFL=1024 without fragmentation             : !MBEDTLS_SSL_PROTO_TLS1_3
> Sending app data via DTLS, MFL=1024 with fragmentation                : !MBEDTLS_SSL_PROTO_TLS1_3
> Sending app data via DTLS, MFL=2048 without fragmentation             : !MBEDTLS_SSL_PROTO_TLS1_3
> Sending app data via DTLS, MFL=2048 with fragmentation                : !MBEDTLS_SSL_PROTO_TLS1_3
> Sending app data via DTLS, MFL=4096 without fragmentation             : !MBEDTLS_SSL_PROTO_TLS1_3
> Sending app data via DTLS, MFL=4096 with fragmentation                : !MBEDTLS_SSL_PROTO_TLS1_3
> Sending app data via DTLS, without MFL and without fragmentation      : !MBEDTLS_SSL_PROTO_TLS1_3
> Sending app data via DTLS, without MFL and with fragmentation         : !MBEDTLS_SSL_PROTO_TLS1_3
> DTLS renegotiation: no legacy renegotiation                           : !MBEDTLS_SSL_PROTO_TLS1_3
> DTLS renegotiation: legacy renegotiation                              : !MBEDTLS_SSL_PROTO_TLS1_3
> DTLS renegotiation: legacy break handshake                            : !MBEDTLS_SSL_PROTO_TLS1_3
> Version config: invalid client TLS 1.3 only                           : !MBEDTLS_SSL_PROTO_TLS1_3
> Version config: invalid client DTLS 1.3 only                          : !MBEDTLS_SSL_PROTO_TLS1_3
> Version config: invalid server TLS 1.3 only                           : !MBEDTLS_SSL_PROTO_TLS1_3
> Version config: invalid server DTLS 1.3 only                          : !MBEDTLS_SSL_PROTO_TLS1_3
> Version config: valid client hybrid TLS 1.2/3, no TLS 1.3             : !MBEDTLS_SSL_PROTO_TLS1_3
> Version config: unsupported client hybrid DTLS 1.2/3, no TLS 1.3      : !MBEDTLS_SSL_PROTO_TLS1_3
> Version config: unsupported server hybrid TLS 1.2/3, no TLS 1.3       : !MBEDTLS_SSL_PROTO_TLS1_3
> Version config: unsupported server hybrid DTLS 1.2/3, no TLS 1.3      : !MBEDTLS_SSL_PROTO_TLS1_3
> Force a bad session id length
         mps: total  42; skipped  42 ->   0
```

TLS.1.3 ssl tests are now executed (`skipped 445 -> 392`). Additional tests that are skipped now (after these changes) depend on `!MBEDTLS_SSL_PROTO_TLS1_3`.

## Status
**READY**

## Requires Backporting
NO  - new feature

## Needs ChangeLog

NO - will be added in #6146
