### PR TITLE
Create MBEDTLS_MAX_HASH_SIZE in hash_info.h

### DIFF
--- a/library/ecjpake.c
+++ b/library/ecjpake.c
@@ -236,7 +236,7 @@ static int ecjpake_hash( const mbedtls_md_type_t md_type,
     unsigned char *p = buf;
     const unsigned char *end = buf + sizeof( buf );
     const size_t id_len = strlen( id );
-    unsigned char hash[MBEDTLS_MD_MAX_SIZE];
+    unsigned char hash[MBEDTLS_HASH_MAX_SIZE];
 
     /* Write things to temporary buffer */
     MBEDTLS_MPI_CHK( ecjpake_write_len_point( &p, end, grp, pf, G ) );

--- a/library/hash_info.h
+++ b/library/hash_info.h
@@ -35,6 +35,20 @@
 #include "mbedtls/md.h"
 #include "psa/crypto.h"
 
+/** \def MBEDTLS_HASH_MAX_SIZE
+ *
+ * Maximum size of a hash based on configuration.
+ */
+#if defined(MBEDTLS_MD_C) && ( \
+    !defined(MBEDTLS_PSA_CRYPTO_C) || \
+    MBEDTLS_MD_MAX_SIZE >= PSA_HASH_MAX_SIZE )
+#define MBEDTLS_HASH_MAX_SIZE MBEDTLS_MD_MAX_SIZE
+#elif defined(MBEDTLS_PSA_CRYPTO_C) && ( \
+    !defined(MBEDTLS_MD_C) || \
+    PSA_HASH_MAX_SIZE >= MBEDTLS_MD_MAX_SIZE )
+#define MBEDTLS_HASH_MAX_SIZE PSA_HASH_MAX_SIZE
+#endif
+
 /** Get the output length of the given hash type from its MD type.
  *
  * \note To get the output length from the PSA alg, use \c PSA_HASH_LENGTH().

--- a/library/pkcs12.c
+++ b/library/pkcs12.c
@@ -324,7 +324,7 @@ int mbedtls_pkcs12_derivation( unsigned char *data, size_t datalen,
 
     unsigned char diversifier[128];
     unsigned char salt_block[128], pwd_block[128], hash_block[128] = {0};
-    unsigned char hash_output[64]; /* Maximal hash size for SHA512 */
+    unsigned char hash_output[MBEDTLS_HASH_MAX_SIZE];
     unsigned char *p;
     unsigned char c;
     int           use_password = 0;

--- a/library/rsa.c
+++ b/library/rsa.c
@@ -57,12 +57,9 @@
 /* We use MD first if it's available (for compatibility reasons)
  * and "fall back" to PSA otherwise (which needs psa_crypto_init()). */
 #if defined(MBEDTLS_PKCS1_V21)
-#if defined(MBEDTLS_MD_C)
-#define HASH_MAX_SIZE   MBEDTLS_MD_MAX_SIZE
-#else /* MBEDTLS_MD_C */
+#if !defined(MBEDTLS_MD_C)
 #include "psa/crypto.h"
 #include "mbedtls/psa_util.h"
-#define HASH_MAX_SIZE   PSA_HASH_MAX_SIZE
 #endif /* MBEDTLS_MD_C */
 #endif /* MBEDTLS_PKCS1_V21 */
 
@@ -1114,7 +1111,7 @@ static int mgf_mask( unsigned char *dst, size_t dlen, unsigned char *src,
     unsigned char *p;
     unsigned int hlen;
     size_t i, use_len;
-    unsigned char mask[HASH_MAX_SIZE];
+    unsigned char mask[MBEDTLS_HASH_MAX_SIZE];
 #if defined(MBEDTLS_MD_C)
     int ret = 0;
     const mbedtls_md_info_t *md_info;
@@ -1469,7 +1466,7 @@ int mbedtls_rsa_rsaes_oaep_decrypt( mbedtls_rsa_context *ctx,
     size_t ilen, i, pad_len;
     unsigned char *p, bad, pad_done;
     unsigned char buf[MBEDTLS_MPI_MAX_SIZE];
-    unsigned char lhash[HASH_MAX_SIZE];
+    unsigned char lhash[MBEDTLS_HASH_MAX_SIZE];
     unsigned int hlen;
 
     RSA_VALIDATE_RET( ctx != NULL );
@@ -2064,7 +2061,7 @@ int mbedtls_rsa_rsassa_pss_verify_ext( mbedtls_rsa_context *ctx,
     size_t siglen;
     unsigned char *p;
     unsigned char *hash_start;
-    unsigned char result[HASH_MAX_SIZE];
+    unsigned char result[MBEDTLS_HASH_MAX_SIZE];
     unsigned int hlen;
     size_t observed_salt_len, msb;
     unsigned char buf[MBEDTLS_MPI_MAX_SIZE] = {0};

--- a/library/ssl_tls12_client.c
+++ b/library/ssl_tls12_client.c
@@ -2330,11 +2330,8 @@ start_processing:
     if( mbedtls_ssl_ciphersuite_uses_server_signature( ciphersuite_info ) )
     {
         size_t sig_len, hashlen;
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
-        unsigned char hash[PSA_HASH_MAX_SIZE];
-#else
-        unsigned char hash[MBEDTLS_MD_MAX_SIZE];
-#endif
+        unsigned char hash[MBEDTLS_HASH_MAX_SIZE];
+
         mbedtls_md_type_t md_alg = MBEDTLS_MD_NONE;
         mbedtls_pk_type_t pk_alg = MBEDTLS_PK_NONE;
         unsigned char *params = ssl->in_msg + mbedtls_ssl_hs_hdr_len( ssl );

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -36,6 +36,7 @@
 #include "mbedtls/platform_util.h"
 #include "constant_time_internal.h"
 #include "mbedtls/constant_time.h"
+#include "hash_info.h"
 
 #include <string.h>
 
@@ -3059,11 +3060,8 @@ curve_matching_done:
 
         size_t dig_signed_len = ssl->out_msg + ssl->out_msglen - dig_signed;
         size_t hashlen = 0;
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
-        unsigned char hash[PSA_HASH_MAX_SIZE];
-#else
-        unsigned char hash[MBEDTLS_MD_MAX_SIZE];
-#endif
+        unsigned char hash[MBEDTLS_HASH_MAX_SIZE];
+
         int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
 
         /*

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -47,8 +47,8 @@
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
 #include "psa/crypto.h"
 #include "mbedtls/psa_util.h"
-#include "hash_info.h"
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
+#include "hash_info.h"
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"
@@ -2354,11 +2354,10 @@ static int x509_crt_verifycrl( mbedtls_x509_crt *crt, mbedtls_x509_crt *ca,
                                const mbedtls_x509_crt_profile *profile )
 {
     int flags = 0;
+    unsigned char hash[MBEDTLS_HASH_MAX_SIZE];
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
-    unsigned char hash[PSA_HASH_MAX_SIZE];
     psa_algorithm_t psa_algorithm;
 #else
-    unsigned char hash[MBEDTLS_MD_MAX_SIZE];
     const mbedtls_md_info_t *md_info;
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
     size_t hash_length;

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -2464,8 +2464,8 @@ static int x509_crt_check_signature( const mbedtls_x509_crt *child,
                                      mbedtls_x509_crt_restart_ctx *rs_ctx )
 {
     size_t hash_len;
+    unsigned char hash[MBEDTLS_HASH_MAX_SIZE];
 #if !defined(MBEDTLS_USE_PSA_CRYPTO)
-    unsigned char hash[MBEDTLS_MD_MAX_SIZE];
     const mbedtls_md_info_t *md_info;
     md_info = mbedtls_md_info_from_type( child->sig_md );
     hash_len = mbedtls_md_get_size( md_info );
@@ -2474,7 +2474,6 @@ static int x509_crt_check_signature( const mbedtls_x509_crt *child,
     if( mbedtls_md( md_info, child->tbs.p, child->tbs.len, hash ) != 0 )
         return( -1 );
 #else
-    unsigned char hash[PSA_HASH_MAX_SIZE];
     psa_algorithm_t hash_alg = mbedtls_hash_info_psa_from_md( child->sig_md );
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
 

--- a/library/x509write_crt.c
+++ b/library/x509write_crt.c
@@ -43,9 +43,9 @@
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
 #include "psa/crypto.h"
 #include "mbedtls/psa_util.h"
-#include "hash_info.h"
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
+#include "hash_info.h"
 #include "legacy_or_psa.h"
 
 void mbedtls_x509write_crt_init( mbedtls_x509write_cert *ctx )
@@ -360,12 +360,10 @@ int mbedtls_x509write_crt_der( mbedtls_x509write_cert *ctx,
     unsigned char *c, *c2;
     unsigned char sig[MBEDTLS_PK_SIGNATURE_MAX_SIZE];
     size_t hash_length = 0;
+    unsigned char hash[MBEDTLS_HASH_MAX_SIZE];
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
     psa_algorithm_t psa_algorithm;
-    unsigned char hash[PSA_HASH_MAX_SIZE];
-#else
-    unsigned char hash[64];
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     size_t sub_len = 0, pub_len = 0, sig_and_oid_len = 0, sig_len;

--- a/library/x509write_csr.c
+++ b/library/x509write_csr.c
@@ -35,8 +35,8 @@
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
 #include "psa/crypto.h"
 #include "mbedtls/psa_util.h"
-#include "hash_info.h"
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
+#include "hash_info.h"
 
 #include <string.h>
 #include <stdlib.h>
@@ -145,7 +145,7 @@ static int x509write_csr_der_internal( mbedtls_x509write_csr *ctx,
     const char *sig_oid;
     size_t sig_oid_len = 0;
     unsigned char *c, *c2;
-    unsigned char hash[64];
+    unsigned char hash[MBEDTLS_HASH_MAX_SIZE];
     size_t pub_len = 0, sig_and_oid_len = 0, sig_len;
     size_t len = 0;
     mbedtls_pk_type_t pk_alg;

--- a/tests/suites/test_suite_ecdsa.function
+++ b/tests/suites/test_suite_ecdsa.function
@@ -1,11 +1,11 @@
 /* BEGIN_HEADER */
 #include "mbedtls/ecdsa.h"
+#include "hash_info.h"
 #include "legacy_or_psa.h"
 #if ( defined(MBEDTLS_ECDSA_DETERMINISTIC) && defined(MBEDTLS_SHA256_C) ) || \
     ( !defined(MBEDTLS_ECDSA_DETERMINISTIC) && defined(MBEDTLS_HAS_ALG_SHA_256_VIA_LOWLEVEL_OR_PSA) )
 #define MBEDTLS_HAS_ALG_SHA_256_VIA_MD_IF_DETERMINISTIC
 #endif
-#define MBEDTLS_TEST_HASH_MAX_SIZE 64
 /* END_HEADER */
 
 /* BEGIN_DEPENDENCIES
@@ -20,7 +20,7 @@ void ecdsa_prim_zero( int id )
     mbedtls_ecp_point Q;
     mbedtls_mpi d, r, s;
     mbedtls_test_rnd_pseudo_info rnd_info;
-    unsigned char buf[MBEDTLS_TEST_HASH_MAX_SIZE];
+    unsigned char buf[MBEDTLS_HASH_MAX_SIZE];
 
     mbedtls_ecp_group_init( &grp );
     mbedtls_ecp_point_init( &Q );
@@ -52,7 +52,7 @@ void ecdsa_prim_random( int id )
     mbedtls_ecp_point Q;
     mbedtls_mpi d, r, s;
     mbedtls_test_rnd_pseudo_info rnd_info;
-    unsigned char buf[MBEDTLS_TEST_HASH_MAX_SIZE];
+    unsigned char buf[MBEDTLS_HASH_MAX_SIZE];
 
     mbedtls_ecp_group_init( &grp );
     mbedtls_ecp_point_init( &Q );


### PR DESCRIPTION
## Description
Create MBEDTLS_MAX_HASH_SIZE macro and use it in library and tests.

Resolves https://github.com/Mbed-TLS/mbedtls/pull/6252

## Status
**READY**

## Requires Backporting
NO  - refactoring development-only changes

## Requires ChangeLog

NO - internal refactoring


