### PR TITLE
Two warning fixes for GCC12.1

### DIFF
--- a/tests/suites/test_suite_ecdh.function
+++ b/tests/suites/test_suite_ecdh.function
@@ -50,6 +50,8 @@ void ecdh_invalid_param( )
     mbedtls_ecp_keypair kp;
     int invalid_side = 42;
 
+    mbedtls_ecp_keypair_init( &kp );
+
     TEST_EQUAL( MBEDTLS_ERR_ECP_BAD_INPUT_DATA,
                             mbedtls_ecdh_get_params( &ctx, &kp,
                                                      invalid_side ) );

--- a/tests/suites/test_suite_ecp.function
+++ b/tests/suites/test_suite_ecp.function
@@ -70,6 +70,9 @@ void ecp_invalid_param( )
     size_t olen;
     unsigned char buf[42] = { 0 };
 
+    mbedtls_ecp_group_init( &grp );
+    mbedtls_ecp_point_init( &P );
+
     TEST_EQUAL( MBEDTLS_ERR_ECP_BAD_INPUT_DATA,
                             mbedtls_ecp_point_write_binary( &grp, &P,
                                                       invalid_fmt,


### PR DESCRIPTION


Signed-off-by: Paul Elliott <paul.elliott@arm.com>

Notes:
* Pull requests cannot be accepted until the PR follows the [contributing guidelines](../CONTRIBUTING.md). In particular, each commit must have at least one `Signed-off-by:` line from the committer to certify that the contribution is made under the terms of the [Developer Certificate of Origin](../dco.txt).
* This is just a template, so feel free to use/remove the unnecessary things
## Description
Latest GCC was warning (again) about uninitialised variables, and although the two tests are for invalid parameters, I don't think initialising these variables impacts the intent of these tests.

## Status
**READY**

## Requires Backporting
NO  

## Migrations
NO

## Todos
- [ ] Tests

## Steps to test or reproduce

test_suite_ecdh and test_suite_ecp should both (still) run clean.
