### PR TITLE
Correct copyright and license in crypto_spe.h

### DIFF
--- a/tests/include/spe/crypto_spe.h
+++ b/tests/include/spe/crypto_spe.h
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2019-2021, Arm Limited. All rights reserved.
+ * Copyright The Mbed TLS Contributors
+ * SPDX-License-Identifier: Apache-2.0
  *
- * SPDX-License-Identifier: BSD-3-Clause
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 


### PR DESCRIPTION
Signed-off-by: Dave Rodgman <dave.rodgman@arm.com>
Backport: #6276 
Changelog: no