### PR TITLE
Driver only hashes wrap-up

### DIFF
--- a/ChangeLog.d/driver-only-hashes.txt
+++ b/ChangeLog.d/driver-only-hashes.txt
@@ -1,0 +1,20 @@
+Features
+   * Some crypto modules that previously depended on MD or a low-level hash
+     module, either unconditionally (RSA, PK, PKCS5, PKCS12, EC J-PAKE), or
+     for some features (PEM for encrypted files), are now able to use PSA
+     Crypto instead when the legacy API is not available. This means it is
+     now possible to use all features from those modules in configurations
+     where the built-in implementations of hashes are excluded and the hashes
+     are only provided by PSA drivers. In these configurations, you need to
+     call `psa_crypto_init()` before you call any function from those
+     modules; this is not required in configurations where the built-in
+     implementation is still available. Note that some crypto modules and
+     features still depend on the built-in implementation of hashes:
+     MBEDTLS_HKDF_C (but the PSA HKDF function do not depend on it),
+     MBEDTLS_ENTROPY_C, MBEDTLS_HMAC_DRBG_C and MBEDTLS_ECDSA_DETERMINISTIC.
+     In particular, for now, compiling without built-in hashes requires use
+     of MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG.
+   * When MBEDTLS_USE_PSA_CRYPTO is enabled, X.509, TLS 1.2 and TLS 1.3 no
+     longer depend on MD. This means it is now possible to use them in
+     configurations where the built-in implementations of hashes are excluded
+     and the hashes are only provided by PSA drivers.

--- a/docs/architecture/psa-migration/psa-limitations.md
+++ b/docs/architecture/psa-migration/psa-limitations.md
@@ -29,11 +29,6 @@ github.
 
 [ffdh]: https://github.com/Mbed-TLS/mbedtls/issues/3261
 
-PSA Crypto has an experimental API for EC J-PAKE, but it's not implemented in
-Mbed TLS yet. See the [EC J-PAKE follow-up EPIC][ecjp] on github.
-
-[ecjp]: https://github.com/orgs/Mbed-TLS/projects/1#column-17950140
-
 Arbitrary parameters for FFDH
 -----------------------------
 

--- a/docs/architecture/psa-migration/strategy.md
+++ b/docs/architecture/psa-migration/strategy.md
@@ -351,7 +351,7 @@ It should be noted that there are currently:
 - too many different ways of computing a hash (low-level, MD, PSA);
 - too many different ways to configure the library that influence which of
   these ways is available and will be used (`MBEDTLS_USE_PSA_CRYPTO`,
-`MBEDTLS_PSA_CRYPTO_CONFIG`, `mbedtls_config.h` + `psa/crypto_config.h`).
+  `MBEDTLS_PSA_CRYPTO_CONFIG`, `mbedtls_config.h` + `psa/crypto_config.h`).
 
 As a result, we need more families of dependency macros than we'd like to.
 This is a temporary situation until we move to a place where everything is
@@ -361,12 +361,12 @@ the new macros in the hope of avoiding confusion.
 Note: the new macros supplement but do not replace the existing macros:
 - code that always uses PSA Crypto (for example, code specific to TLS 1.3)
   should use `PSA_WANT_xxx`;
-- code that always uses the legacy API (for exmaple, crypto modules that have
+- code that always uses the legacy API (for example, crypto modules that have
   not undergone step 1 yet) should use `MBEDTLS_xxx_C`;
 - code that may use one of the two APIs, either based on
   `MBEDTLS_USE_PSA_CRYPTO` (X.509, TLS 1.2, shared between TLS 1.2 and 1.3),
-or based on availability (crypto modules after step 1), should use one of the
-new macros from `legacy_or_psa.h`.
+  or based on availability (crypto modules after step 1), should use one of
+  the new macros from `legacy_or_psa.h`.
 
 Executing step 3 will mostly consist of using the right dependency macros in
 the right places (once the previous steps are done).

--- a/docs/architecture/psa-migration/strategy.md
+++ b/docs/architecture/psa-migration/strategy.md
@@ -345,7 +345,7 @@ available. Data related to a certain hash (OID, sizes, translations) should
 only be included in the build if it is possible to use that hash in some way.
 
 In order to cater to these new needs, new families of macros are introduced in
-`library/legacy_or_psa.h`, see its documentation for details.
+`legacy_or_psa.h`, see its documentation for details.
 
 It should be noted that there are currently:
 - too many different ways of computing a hash (low-level, MD, PSA);
@@ -357,6 +357,16 @@ As a result, we need more families of dependency macros than we'd like to.
 This is a temporary situation until we move to a place where everything is
 based on PSA Crypto. In the meantime, long and explicit names where chosen for
 the new macros in the hope of avoiding confusion.
+
+Note: the new macros supplement but do not replace the existing macros:
+- code that always uses PSA Crypto (for example, code specific to TLS 1.3)
+  should use `PSA_WANT_xxx`;
+- code that always uses the legacy API (for exmaple, crypto modules that have
+  not undergone step 1 yet) should use `MBEDTLS_xxx_C`;
+- code that may use one of the two APIs, either based on
+  `MBEDTLS_USE_PSA_CRYPTO` (X.509, TLS 1.2, shared between TLS 1.2 and 1.3),
+or based on availability (crypto modules after step 1), should use one of the
+new macros from `legacy_or_psa.h`.
 
 Executing step 3 will mostly consist of using the right dependency macros in
 the right places (once the previous steps are done).

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -320,8 +320,17 @@
 #endif
 
 #if defined(MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED) &&                    \
-    ( !defined(MBEDTLS_ECJPAKE_C) || !defined(MBEDTLS_SHA256_C) ||      \
+    ( !defined(MBEDTLS_ECJPAKE_C) ||                                    \
       !defined(MBEDTLS_ECP_DP_SECP256R1_ENABLED) )
+#error "MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED defined, but not all prerequisites"
+#endif
+
+/* Use of EC J-PAKE in TLS requires SHA-256.
+ * This will be taken from MD is present, or from PSA if MD is absent.
+ * Note: ECJPAKE_C depends on MD_C || PSA_CRYPTO_C. */
+#if defined(MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED) &&                    \
+    !( defined(MBEDTLS_MD_C) && defined(MBEDTLS_SHA256_C) ) &&          \
+    !( !defined(MBEDTLS_MD_C) && defined(PSA_WANT_ALG_SHA_256) )
 #error "MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED defined, but not all prerequisites"
 #endif
 

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -326,7 +326,7 @@
 #endif
 
 /* Use of EC J-PAKE in TLS requires SHA-256.
- * This will be taken from MD is present, or from PSA if MD is absent.
+ * This will be taken from MD if it is present, or from PSA if MD is absent.
  * Note: ECJPAKE_C depends on MD_C || PSA_CRYPTO_C. */
 #if defined(MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED) &&                    \
     !( defined(MBEDTLS_MD_C) && defined(MBEDTLS_SHA256_C) ) &&          \

--- a/include/mbedtls/legacy_or_psa.h
+++ b/include/mbedtls/legacy_or_psa.h
@@ -19,7 +19,7 @@
  */
 
 /*
- * Note: applications who are targetting a specific configurations do not need
+ * Note: applications that are targeting a specific configuration do not need
  * to use these macros; instead they should directly use the functions they
  * know are available in their configuration.
  *
@@ -29,7 +29,7 @@
  *
  * Note: code that is purely based on the legacy crypto APIs (mbedtls_xxx())
  * does not need to use these macros; instead it should use the relevant
- * MBEDTLS_xxx_ macros.
+ * MBEDTLS_xxx macros.
  *
  * These macros are for code that wants to use <crypto feature> and will do so
  * using <legacy API> or PSA depending on <condition>, where:

--- a/include/mbedtls/legacy_or_psa.h
+++ b/include/mbedtls/legacy_or_psa.h
@@ -96,7 +96,7 @@
 #ifndef MBEDTLS_OR_PSA_HELPERS_H
 #define MBEDTLS_OR_PSA_HELPERS_H
 
-#include "common.h"
+#include "mbedtls/build_info.h"
 #if defined(MBEDTLS_PSA_CRYPTO_C)
 #include "psa/crypto.h"
 #endif /* MBEDTLS_PSA_CRYPTO_C */

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -958,7 +958,7 @@
  * might still happen. For this reason, this is disabled by default.
  *
  * Requires: MBEDTLS_ECJPAKE_C
- *           SHA-256 (via MD is present, or via PSA, see MBEDTLS_ECJPAKE_C)
+ *           SHA-256 (via MD if present, or via PSA, see MBEDTLS_ECJPAKE_C)
  *           MBEDTLS_ECP_DP_SECP256R1_ENABLED
  *
  * This enables the following ciphersuites (if other requisites are

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -1492,13 +1492,14 @@
  *
  * Enable support for TLS 1.2 (and DTLS 1.2 if DTLS is enabled).
  *
- * Requires: MBEDTLS_SHA1_C or MBEDTLS_SHA256_C or MBEDTLS_SHA512_C
- *           (Depends on ciphersuites) when MBEDTLS_USE_PSA_CRYPTO
- *           is not defined, PSA_WANT_ALG_SHA_1 or PSA_WANT_ALG_SHA_256 or
- *           PSA_WANT_ALG_SHA_512 when MBEDTLS_USE_PSA_CRYPTO is defined.
+ * Requires: Without MBEDTLS_USE_PSA_CRYPTO: MBEDTLS_MD_C and
+ *              (MBEDTLS_SHA1_C or MBEDTLS_SHA256_C or MBEDTLS_SHA512_C)
+ *           With MBEDTLS_USE_PSA_CRYPTO:
+ *              PSA_WANT_ALG_SHA_1 or PSA_WANT_ALG_SHA_256 or
+ *              PSA_WANT_ALG_SHA_512
  *
- * \warning If building without MBEDTLS_MD_C, you must call psa_crypto_init()
- * before doing any TLS operation.
+ * \warning If building with MBEDTLS_USE_PSA_CRYPTO, you must call
+ * psa_crypto_init() before doing any TLS operations.
  *
  * Comment this macro to disable support for TLS 1.2 / DTLS 1.2
  */
@@ -1517,11 +1518,11 @@
  * Requires: MBEDTLS_SSL_KEEP_PEER_CERTIFICATE
  * Requires: MBEDTLS_PSA_CRYPTO_C
  *
- * Note: even though TLS 1.3 depends on PSA Crypto, if you want it to only use
- * PSA for all crypto operations, you need to also enable
- * MBEDTLS_USE_PSA_CRYPTO; otherwise X.509 operations, and functions that are
- * common with TLS 1.2 (record protection, running handshake hash) will still
- * use non-PSA crypto.
+ * Note: even though TLS 1.3 depends on PSA Crypto, and uses it unconditonally
+ * for most operations, if you want it to only use PSA for all crypto
+ * operations, you need to also enable MBEDTLS_USE_PSA_CRYPTO; otherwise X.509
+ * operations, and functions that are common with TLS 1.2 (record protection,
+ * running handshake hash) will still use non-PSA crypto.
  *
  * Uncomment this macro to enable the support for TLS 1.3.
  */
@@ -2337,7 +2338,7 @@
  * This module is used by the following key exchanges:
  *      ECJPAKE
  *
- * Requires: MBEDTLS_ECP_C, MBEDTLS_MD_C
+ * Requires: MBEDTLS_ECP_C and either MBEDTLS_MD_C or MBEDTLS_PSA_CRYPTO_C
  *
  * \warning If building without MBEDTLS_MD_C, you must call psa_crypto_init()
  * before doing any EC J-PAKE operations.
@@ -2654,7 +2655,10 @@
  *
  * Module:  library/pkcs5.c
  *
- * Requires: MBEDTLS_CIPHER_C, MBEDTLS_MD_C
+ * Requires: MBEDTLS_CIPHER_C and either MBEDTLS_MD_C or MBEDTLS_PSA_CRYPTO_C.
+ *
+ * \warning If building without MBEDTLS_MD_C, you must call psa_crypto_init()
+ * before doing any PKCS5 operation.
  *
  * This module adds support for the PKCS#5 functions.
  */
@@ -3136,8 +3140,8 @@
  * Requires: MBEDTLS_ASN1_PARSE_C, MBEDTLS_BIGNUM_C, MBEDTLS_OID_C, MBEDTLS_PK_PARSE_C,
  *           (MBEDTLS_MD_C or MBEDTLS_USE_PSA_CRYPTO)
  *
- * \warning If building without MBEDTLS_MD_C, you must call psa_crypto_init()
- * before doing any X.509 operation.
+ * \warning If building with MBEDTLS_USE_PSA_CRYPTO, you must call
+ * psa_crypto_init() before doing any X.509 operation.
  *
  * This module is required for the X.509 parsing modules.
  */
@@ -3197,8 +3201,8 @@
  * Requires: MBEDTLS_BIGNUM_C, MBEDTLS_OID_C, MBEDTLS_PK_PARSE_C,
  *           (MBEDTLS_MD_C or MBEDTLS_USE_PSA_CRYPTO)
  *
- * \warning If building without MBEDTLS_MD_C, you must call psa_crypto_init()
- * before doing any X.509 create operation.
+ * \warning If building with MBEDTLS_USE_PSA_CRYPTO, you must call
+ * psa_crypto_init() before doing any X.509 create operation.
  *
  * This module is the basis for creating X.509 certificates and CSRs.
  */

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -958,7 +958,7 @@
  * might still happen. For this reason, this is disabled by default.
  *
  * Requires: MBEDTLS_ECJPAKE_C
- *           MBEDTLS_SHA256_C
+ *           SHA-256 (via MD is present, or via PSA, see MBEDTLS_ECJPAKE_C)
  *           MBEDTLS_ECP_DP_SECP256R1_ENABLED
  *
  * This enables the following ciphersuites (if other requisites are

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -629,11 +629,7 @@ union mbedtls_ssl_premaster_secret
 
 #define MBEDTLS_PREMASTER_SIZE     sizeof( union mbedtls_ssl_premaster_secret )
 
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
 #define MBEDTLS_TLS1_3_MD_MAX_SIZE         PSA_HASH_MAX_SIZE
-#else
-#define MBEDTLS_TLS1_3_MD_MAX_SIZE         MBEDTLS_MD_MAX_SIZE
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 
 /* Length in number of bytes of the TLS sequence number */

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -52,9 +52,7 @@
 #include "mbedtls/platform_time.h"
 #endif
 
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
 #include "psa/crypto.h"
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 /*
  * SSL Error codes

--- a/include/mbedtls/x509_crt.h
+++ b/include/mbedtls/x509_crt.h
@@ -24,6 +24,7 @@
 #include "mbedtls/private_access.h"
 
 #include "mbedtls/build_info.h"
+#include "mbedtls/legacy_or_psa.h"
 
 #include "mbedtls/x509.h"
 #include "mbedtls/x509_crl.h"
@@ -1108,7 +1109,7 @@ int mbedtls_x509write_crt_set_extension( mbedtls_x509write_cert *ctx,
 int mbedtls_x509write_crt_set_basic_constraints( mbedtls_x509write_cert *ctx,
                                          int is_ca, int max_pathlen );
 
-#if defined(MBEDTLS_SHA1_C) || ( defined(MBEDTLS_PSA_CRYPTO_C) && defined(PSA_WANT_ALG_SHA_1) )
+#if defined(MBEDTLS_HAS_ALG_SHA_1_VIA_LOWLEVEL_OR_PSA)
 /**
  * \brief           Set the subjectKeyIdentifier extension for a CRT
  *                  Requires that mbedtls_x509write_crt_set_subject_key() has been
@@ -1130,7 +1131,7 @@ int mbedtls_x509write_crt_set_subject_key_identifier( mbedtls_x509write_cert *ct
  * \return          0 if successful, or a MBEDTLS_ERR_X509_ALLOC_FAILED
  */
 int mbedtls_x509write_crt_set_authority_key_identifier( mbedtls_x509write_cert *ctx );
-#endif /* MBEDTLS_SHA1_C || (MBEDTLS_PSA_CRYPTO_C && PSA_WANT_ALG_SHA_1)*/
+#endif /* MBEDTLS_HAS_ALG_SHA_1_VIA_LOWLEVEL_OR_PSA */
 
 /**
  * \brief           Set the Key Usage Extension flags

--- a/library/hash_info.c
+++ b/library/hash_info.c
@@ -21,7 +21,7 @@
  */
 
 #include "hash_info.h"
-#include "legacy_or_psa.h"
+#include "mbedtls/legacy_or_psa.h"
 #include "mbedtls/error.h"
 
 typedef struct

--- a/library/legacy_or_psa.h
+++ b/library/legacy_or_psa.h
@@ -1,6 +1,6 @@
 /**
- *  Internal macros to express dependencies for code and tests
- *  that may use either the legacy API or PSA in various builds.
+ *  Macros to express dependencies for code and tests that may use either the
+ *  legacy API or PSA in various builds; mostly for internal use.
  *
  *  Copyright The Mbed TLS Contributors
  *  SPDX-License-Identifier: Apache-2.0
@@ -19,6 +19,18 @@
  */
 
 /*
+ * Note: applications who are targetting a specific configurations do not need
+ * to use these macros; instead they should directly use the functions they
+ * know are available in their configuration.
+ *
+ * Note: code that is purely based on PSA Crypto (psa_xxx() functions)
+ * does not need to use these macros; instead it should use the relevant
+ * PSA_WANT_xxx macros.
+ *
+ * Note: code that is purely based on the legacy crypto APIs (mbedtls_xxx())
+ * does not need to use these macros; instead it should use the relevant
+ * MBEDTLS_xxx_ macros.
+ *
  * These macros are for code that wants to use <crypto feature> and will do so
  * using <legacy API> or PSA depending on <condition>, where:
  * - <crypto feature> will generally be an algorithm (SHA-256, ECDH) but may
@@ -36,15 +48,10 @@
  * - TLS 1.2 will compute hashes using either mbedtls_md_xxx() (and
  *   mbedtls_sha256_xxx()) or psa_aead_xxx() depending on whether
  *   MBEDTLS_USE_PSA_CRYPTO is defined;
- * - RSA PKCS#1 v2.1 will, in the near future*, compute hashes (for padding)
- *   using either `mbedtls_md()` if it's available, or `psa_hash_compute()`
- *   otherwise;
- * - PEM decoding of PEM-encrypted keys will, in the near future*, compute MD5
- *   hashes using either `mbedtls_md5_xxx()` if it's available, or
- *   `psa_hash_xxx()` otherwise.
- * *See docs/architecture/psa-migration/strategy.md, section "Supporting
- * builds with drivers without the software implementation", strategy for step
- * 1 (libmbedcrypto except the RNG subsystem).
+ * - RSA PKCS#1 v2.1 will compute hashes (for padding) using either
+ *   `mbedtls_md()` if it's available, or `psa_hash_compute()` otherwise;
+ * - PEM decoding of PEM-encrypted keys will compute MD5 hashes using either
+ *   `mbedtls_md5_xxx()` if it's available, or `psa_hash_xxx()` otherwise.
  *
  * Note: the macros are essential to express test dependencies. Inside code,
  * we could instead just use the equivalent pre-processor condition, but
@@ -70,9 +77,9 @@
  *      MBEDTLS_HAS_ALG_MD5_VIA_LOWLEVEL_OR_PSA
  *
  * Note: every time it's possible to use, say SHA-256, via the MD API, then
- * it's also possible to used it via the low-level API. So, code that wants to
+ * it's also possible to use it via the low-level API. So, code that wants to
  * use SHA-256 via both APIs only needs to depend on the MD macro. Also, it
- * just so happens that all the choosing which API to use based on
+ * just so happens that all the code choosing which API to use based on
  * MBEDTLS_USE_PSA_CRYPTO (X.509, TLS 1.2/shared), always uses the abstraction
  * layer (sometimes in addition to the low-level API), so we don't need the
  * MBEDTLS_HAS_feature_VIA_LOWLEVEL_OR_PSA_BASED_ON_USE_PSA macros.

--- a/library/oid.c
+++ b/library/oid.c
@@ -27,7 +27,7 @@
 #include "mbedtls/rsa.h"
 #include "mbedtls/error.h"
 
-#include "legacy_or_psa.h"
+#include "mbedtls/legacy_or_psa.h"
 
 #include <stdio.h>
 #include <string.h>

--- a/library/pem.c
+++ b/library/pem.c
@@ -47,10 +47,12 @@
 
 #include "legacy_or_psa.h"
 
-#if defined(MBEDTLS_HAS_ALG_MD5_VIA_MD_OR_PSA_BASED_ON_USE_PSA) && defined(MBEDTLS_CIPHER_MODE_CBC) &&         \
+#if defined(MBEDTLS_HAS_ALG_MD5_VIA_MD_OR_PSA_BASED_ON_USE_PSA) &&  \
+    defined(MBEDTLS_CIPHER_MODE_CBC) &&                             \
     ( defined(MBEDTLS_DES_C) || defined(MBEDTLS_AES_C) )
 #define PEM_RFC1421
-#endif /* MBEDTLS_HAS_ALG_MD5_VIA_MD_OR_PSA_BASED_ON_USE_PSA && MBEDTLS_CIPHER_MODE_CBC &&
+#endif /* MBEDTLS_HAS_ALG_MD5_VIA_MD_OR_PSA_BASED_ON_USE_PSA &&
+          MBEDTLS_CIPHER_MODE_CBC &&
           ( MBEDTLS_AES_C || MBEDTLS_DES_C ) */
 
 #if defined(MBEDTLS_PEM_PARSE_C)

--- a/library/pem.c
+++ b/library/pem.c
@@ -45,7 +45,7 @@
 #include "psa/crypto.h"
 #endif
 
-#include "legacy_or_psa.h"
+#include "mbedtls/legacy_or_psa.h"
 
 #if defined(MBEDTLS_HAS_ALG_MD5_VIA_MD_OR_PSA_BASED_ON_USE_PSA) &&  \
     defined(MBEDTLS_CIPHER_MODE_CBC) &&                             \

--- a/library/ssl_ciphersuites.c
+++ b/library/ssl_ciphersuites.c
@@ -33,7 +33,7 @@
 #include "mbedtls/ssl.h"
 #include "ssl_misc.h"
 
-#include "legacy_or_psa.h"
+#include "mbedtls/legacy_or_psa.h"
 
 #include <string.h>
 

--- a/library/ssl_cookie.c
+++ b/library/ssl_cookie.c
@@ -38,7 +38,7 @@
 #include "mbedtls/platform_util.h"
 #include "mbedtls/constant_time.h"
 
-#include "legacy_or_psa.h"
+#include "mbedtls/legacy_or_psa.h"
 
 #include <string.h>
 

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -32,7 +32,7 @@
 #include "mbedtls/psa_util.h"
 #include "hash_info.h"
 #endif
-#include "legacy_or_psa.h"
+#include "mbedtls/legacy_or_psa.h"
 
 #if defined(MBEDTLS_MD5_C)
 #include "mbedtls/md5.h"

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -54,7 +54,7 @@
 #include "mbedtls/psa_util.h"
 #include "psa/crypto.h"
 #endif
-#include "legacy_or_psa.h"
+#include "mbedtls/legacy_or_psa.h"
 
 #if defined(MBEDTLS_X509_CRT_PARSE_C)
 #include "mbedtls/oid.h"

--- a/library/x509.c
+++ b/library/x509.c
@@ -62,7 +62,7 @@
 #include <time.h>
 #endif
 
-#include "legacy_or_psa.h"
+#include "mbedtls/legacy_or_psa.h"
 
 #define CHECK(code) if( ( ret = ( code ) ) != 0 ){ return( ret ); }
 #define CHECK_RANGE(min, max, val)                      \

--- a/library/x509write_crt.c
+++ b/library/x509write_crt.c
@@ -46,7 +46,7 @@
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 #include "hash_info.h"
-#include "legacy_or_psa.h"
+#include "mbedtls/legacy_or_psa.h"
 
 void mbedtls_x509write_crt_init( mbedtls_x509write_cert *ctx )
 {

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -1426,11 +1426,11 @@ int main( int argc, char *argv[] )
         if( opt.psk_opaque != 0 )
         {
             /* Determine KDF algorithm the opaque PSK will be used in. */
-#if defined(HAS_ALG_SHA_384_VIA_MD_OR_PSA_BASED_ON_USE_PSA)
+#if defined(MBEDTLS_HAS_ALG_SHA_384_VIA_MD_OR_PSA_BASED_ON_USE_PSA)
             if( ciphersuite_info->mac == MBEDTLS_MD_SHA384 )
                 alg = PSA_ALG_TLS12_PSK_TO_MS(PSA_ALG_SHA_384);
             else
-#endif /* HAS_ALG_SHA_384_VIA_MD_OR_PSA_BASED_ON_USE_PSA */
+#endif /* MBEDTLS_HAS_ALG_SHA_384_VIA_MD_OR_PSA_BASED_ON_USE_PSA */
                 alg = PSA_ALG_TLS12_PSK_TO_MS(PSA_ALG_SHA_256);
         }
 #endif /* MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED */

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -2261,11 +2261,11 @@ int main( int argc, char *argv[] )
         if( opt.psk_opaque != 0 || opt.psk_list_opaque != 0 )
         {
             /* Determine KDF algorithm the opaque PSK will be used in. */
-#if defined(HAS_ALG_SHA_384_VIA_MD_OR_PSA_BASED_ON_USE_PSA)
+#if defined(MBEDTLS_HAS_ALG_SHA_384_VIA_MD_OR_PSA_BASED_ON_USE_PSA)
             if( ciphersuite_info->mac == MBEDTLS_MD_SHA384 )
                 alg = PSA_ALG_TLS12_PSK_TO_MS(PSA_ALG_SHA_384);
             else
-#endif /* HAS_ALG_SHA_384_VIA_MD_OR_PSA_BASED_ON_USE_PSA */
+#endif /* MBEDTLS_HAS_ALG_SHA_384_VIA_MD_OR_PSA_BASED_ON_USE_PSA */
                 alg = PSA_ALG_TLS12_PSK_TO_MS(PSA_ALG_SHA_256);
         }
 #endif /* MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED */

--- a/programs/ssl/ssl_test_common_source.c
+++ b/programs/ssl/ssl_test_common_source.c
@@ -297,49 +297,23 @@ int send_cb( void *ctx, unsigned char const *buf, size_t len )
 #define MBEDTLS_SSL_SIG_ALG( hash )
 #endif
 
-#if ( !defined(MBEDTLS_USE_PSA_CRYPTO) && \
-        defined(MBEDTLS_MD_C) && defined(MBEDTLS_SHA1_C) ) || \
-    ( defined(MBEDTLS_USE_PSA_CRYPTO) && defined(PSA_WANT_ALG_SHA_1) )
-#define HAS_ALG_SHA_1_VIA_MD_OR_PSA_BASED_ON_USE_PSA
-#endif
-#if ( !defined(MBEDTLS_USE_PSA_CRYPTO) && \
-        defined(MBEDTLS_MD_C) && defined(MBEDTLS_SHA224_C) ) || \
-    ( defined(MBEDTLS_USE_PSA_CRYPTO) && defined(PSA_WANT_ALG_SHA_224) )
-#define HAS_ALG_SHA_224_VIA_MD_OR_PSA_BASED_ON_USE_PSA
-#endif
-#if ( !defined(MBEDTLS_USE_PSA_CRYPTO) && \
-        defined(MBEDTLS_MD_C) && defined(MBEDTLS_SHA256_C) ) || \
-    ( defined(MBEDTLS_USE_PSA_CRYPTO) && defined(PSA_WANT_ALG_SHA_256) )
-#define HAS_ALG_SHA_256_VIA_MD_OR_PSA_BASED_ON_USE_PSA
-#endif
-#if ( !defined(MBEDTLS_USE_PSA_CRYPTO) && \
-        defined(MBEDTLS_MD_C) && defined(MBEDTLS_SHA384_C) ) || \
-    ( defined(MBEDTLS_USE_PSA_CRYPTO) && defined(PSA_WANT_ALG_SHA_384) )
-#define HAS_ALG_SHA_384_VIA_MD_OR_PSA_BASED_ON_USE_PSA
-#endif
-#if ( !defined(MBEDTLS_USE_PSA_CRYPTO) && \
-        defined(MBEDTLS_MD_C) && defined(MBEDTLS_SHA512_C) ) || \
-    ( defined(MBEDTLS_USE_PSA_CRYPTO) && defined(PSA_WANT_ALG_SHA_512) )
-#define HAS_ALG_SHA_512_VIA_MD_OR_PSA_BASED_ON_USE_PSA
-#endif
-
 uint16_t ssl_sig_algs_for_test[] = {
-#if defined(HAS_ALG_SHA_512_VIA_MD_OR_PSA_BASED_ON_USE_PSA)
+#if defined(MBEDTLS_HAS_ALG_SHA_512_VIA_MD_OR_PSA_BASED_ON_USE_PSA)
     MBEDTLS_SSL_SIG_ALG( MBEDTLS_SSL_HASH_SHA512 )
 #endif
-#if defined(HAS_ALG_SHA_384_VIA_MD_OR_PSA_BASED_ON_USE_PSA)
+#if defined(MBEDTLS_HAS_ALG_SHA_384_VIA_MD_OR_PSA_BASED_ON_USE_PSA)
     MBEDTLS_SSL_SIG_ALG( MBEDTLS_SSL_HASH_SHA384 )
 #endif
-#if defined(HAS_ALG_SHA_256_VIA_MD_OR_PSA_BASED_ON_USE_PSA)
+#if defined(MBEDTLS_HAS_ALG_SHA_256_VIA_MD_OR_PSA_BASED_ON_USE_PSA)
     MBEDTLS_SSL_SIG_ALG( MBEDTLS_SSL_HASH_SHA256 )
 #endif
-#if defined(HAS_ALG_SHA_224_VIA_MD_OR_PSA_BASED_ON_USE_PSA)
+#if defined(MBEDTLS_HAS_ALG_SHA_224_VIA_MD_OR_PSA_BASED_ON_USE_PSA)
     MBEDTLS_SSL_SIG_ALG( MBEDTLS_SSL_HASH_SHA224 )
 #endif
-#if defined(MBEDTLS_RSA_C) && defined(HAS_ALG_SHA_256_VIA_MD_OR_PSA_BASED_ON_USE_PSA)
+#if defined(MBEDTLS_RSA_C) && defined(MBEDTLS_HAS_ALG_SHA_256_VIA_MD_OR_PSA_BASED_ON_USE_PSA)
     MBEDTLS_TLS1_3_SIG_RSA_PSS_RSAE_SHA256,
 #endif /* MBEDTLS_RSA_C && MBEDTLS_SHA256_C */
-#if defined(HAS_ALG_SHA_1_VIA_MD_OR_PSA_BASED_ON_USE_PSA)
+#if defined(MBEDTLS_HAS_ALG_SHA_1_VIA_MD_OR_PSA_BASED_ON_USE_PSA)
     /* Allow SHA-1 as we use it extensively in tests. */
     MBEDTLS_SSL_SIG_ALG( MBEDTLS_SSL_HASH_SHA1 )
 #endif

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1715,7 +1715,7 @@ component_test_psa_crypto_config_accel_ecdsa () {
     scripts/config.py unset MBEDTLS_KEY_EXCHANGE_ECDH_ECDSA_ENABLED
 
     loc_accel_flags="$loc_accel_flags $( echo "$loc_accel_list" | sed 's/[^ ]* */-DMBEDTLS_PSA_ACCEL_&/g' )"
-    make CFLAGS="$ASAN_CFLAGS -O -Werror -I../tests/include -I../tests -DPSA_CRYPTO_DRIVER_TEST -DMBEDTLS_TEST_LIBTESTDRIVER1 $loc_accel_flags" LDFLAGS="-ltestdriver1 $ASAN_CFLAGS"
+    make CFLAGS="$ASAN_CFLAGS -O -Werror -I../tests/include -I../tests -I../../tests -DPSA_CRYPTO_DRIVER_TEST -DMBEDTLS_TEST_LIBTESTDRIVER1 $loc_accel_flags" LDFLAGS="-ltestdriver1 $ASAN_CFLAGS"
 
     not grep mbedtls_ecdsa_ library/ecdsa.o
 
@@ -1797,7 +1797,7 @@ component_test_psa_crypto_config_accel_rsa_signature () {
     scripts/config.py unset MBEDTLS_SSL_CBC_RECORD_SPLITTING
 
     loc_accel_flags="$loc_accel_flags $( echo "$loc_accel_list" | sed 's/[^ ]* */-DMBEDTLS_PSA_ACCEL_&/g' )"
-    make CFLAGS="$ASAN_CFLAGS -Werror -I../tests/include -I../tests -DPSA_CRYPTO_DRIVER_TEST -DMBEDTLS_TEST_LIBTESTDRIVER1 $loc_accel_flags" LDFLAGS="-ltestdriver1 $ASAN_CFLAGS"
+    make CFLAGS="$ASAN_CFLAGS -Werror -I../tests/include -I../tests -I../../tests -DPSA_CRYPTO_DRIVER_TEST -DMBEDTLS_TEST_LIBTESTDRIVER1 $loc_accel_flags" LDFLAGS="-ltestdriver1 $ASAN_CFLAGS"
 
     not grep mbedtls_rsa_rsassa_pkcs1_v15_sign library/rsa.o
     not grep mbedtls_rsa_rsassa_pss_sign_ext library/rsa.o
@@ -1827,7 +1827,7 @@ component_test_psa_crypto_config_accel_hash () {
     scripts/config.py unset MBEDTLS_SHA384_C
     scripts/config.py unset MBEDTLS_SHA512_C
     loc_accel_flags="$loc_accel_flags $( echo "$loc_accel_list" | sed 's/[^ ]* */-DMBEDTLS_PSA_ACCEL_&/g' )"
-    make CFLAGS="$ASAN_CFLAGS -Werror -I../tests/include -I../tests -DPSA_CRYPTO_DRIVER_TEST -DMBEDTLS_TEST_LIBTESTDRIVER1 $loc_accel_flags" LDFLAGS="-ltestdriver1 $ASAN_CFLAGS"
+    make CFLAGS="$ASAN_CFLAGS -Werror -I../tests/include -I../tests -I../../tests -DPSA_CRYPTO_DRIVER_TEST -DMBEDTLS_TEST_LIBTESTDRIVER1 $loc_accel_flags" LDFLAGS="-ltestdriver1 $ASAN_CFLAGS"
 
     not grep mbedtls_sha512_init library/sha512.o
     not grep mbedtls_sha1_init library/sha1.o
@@ -1925,7 +1925,7 @@ component_test_psa_crypto_config_accel_cipher () {
     scripts/config.py unset MBEDTLS_DES_C
 
     loc_accel_flags="$loc_accel_flags $( echo "$loc_accel_list" | sed 's/[^ ]* */-DMBEDTLS_PSA_ACCEL_&/g' )"
-    make CFLAGS="$ASAN_CFLAGS -Werror -I../tests/include -I../tests -DPSA_CRYPTO_DRIVER_TEST -DMBEDTLS_TEST_LIBTESTDRIVER1 $loc_accel_flags" LDFLAGS="-ltestdriver1 $ASAN_CFLAGS"
+    make CFLAGS="$ASAN_CFLAGS -Werror -I../tests/include -I../tests -I../../tests -DPSA_CRYPTO_DRIVER_TEST -DMBEDTLS_TEST_LIBTESTDRIVER1 $loc_accel_flags" LDFLAGS="-ltestdriver1 $ASAN_CFLAGS"
 
     not grep mbedtls_des* library/des.o
 

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1848,21 +1848,28 @@ component_test_psa_crypto_config_accel_hash_use_psa () {
     loc_accel_flags=$( echo "$loc_accel_list" | sed 's/[^ ]* */-DLIBTESTDRIVER1_MBEDTLS_PSA_ACCEL_&/g' )
     make -C tests libtestdriver1.a CFLAGS="$ASAN_CFLAGS $loc_accel_flags" LDFLAGS="$ASAN_CFLAGS"
 
+    # start with config full for maximum coverage (also enables USE_PSA)
+    scripts/config.py full
+    # enable support for drivers and configuring PSA-only algorithms
     scripts/config.py set MBEDTLS_PSA_CRYPTO_DRIVERS
     scripts/config.py set MBEDTLS_PSA_CRYPTO_CONFIG
-    scripts/config.py set MBEDTLS_USE_PSA_CRYPTO
+    # disable the built-in implementation of hashes
     scripts/config.py unset MBEDTLS_MD5_C
     scripts/config.py unset MBEDTLS_RIPEMD160_C
     scripts/config.py unset MBEDTLS_SHA1_C
     scripts/config.py unset MBEDTLS_SHA224_C
     scripts/config.py unset MBEDTLS_SHA256_C # see external RNG below
+    scripts/config.py unset MBEDTLS_SHA256_USE_A64_CRYPTO_IF_PRESENT
     scripts/config.py unset MBEDTLS_SHA384_C
     scripts/config.py unset MBEDTLS_SHA512_C
+    scripts/config.py unset MBEDTLS_SHA512_USE_A64_CRYPTO_IF_PRESENT
     # Use an external RNG as currently internal RNGs depend on entropy.c
     # which in turn hard-depends on SHA256_C (or SHA512_C).
     # See component_test_psa_external_rng_no_drbg_use_psa.
     scripts/config.py set MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG
     scripts/config.py unset MBEDTLS_ENTROPY_C
+    scripts/config.py unset MBEDTLS_ENTROPY_NV_SEED # depends on ENTROPY_C
+    scripts/config.py unset MBEDTLS_PLATFORM_NV_SEED_ALT # depends on former
     # Also unset MD_C and things that depend on it;
     # see component_test_crypto_full_no_md.
     scripts/config.py unset MBEDTLS_MD_C
@@ -1870,10 +1877,6 @@ component_test_psa_crypto_config_accel_hash_use_psa () {
     scripts/config.py unset MBEDTLS_HMAC_DRBG_C
     scripts/config.py unset MBEDTLS_ECDSA_DETERMINISTIC
     scripts/config.py -f include/psa/crypto_config.h unset PSA_WANT_ALG_DETERMINISTIC_ECDSA
-    # Enable TLS 1.3: use PSA implementation for hashes
-    scripts/config.py set MBEDTLS_SSL_PROTO_TLS1_3
-    scripts/config.py set MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
-    scripts/config.py set MBEDTLS_SSL_CID_TLS1_3_PADDING_GRANULARITY 1
 
     loc_accel_flags="$loc_accel_flags $( echo "$loc_accel_list" | sed 's/[^ ]* */-DMBEDTLS_PSA_ACCEL_&/g' )"
     make CFLAGS="$ASAN_CFLAGS -Werror -I../tests/include -I../tests -I../../tests -DPSA_CRYPTO_DRIVER_TEST -DMBEDTLS_TEST_LIBTESTDRIVER1 $loc_accel_flags" LDFLAGS="-ltestdriver1 $ASAN_CFLAGS" all

--- a/tests/src/certs.c
+++ b/tests/src/certs.c
@@ -23,7 +23,7 @@
 
 #include "mbedtls/build_info.h"
 
-#include "legacy_or_psa.h"
+#include "mbedtls/legacy_or_psa.h"
 
 /*
  * Test CA Certificates

--- a/tests/suites/test_suite_ecdsa.function
+++ b/tests/suites/test_suite_ecdsa.function
@@ -1,7 +1,7 @@
 /* BEGIN_HEADER */
 #include "mbedtls/ecdsa.h"
 #include "hash_info.h"
-#include "legacy_or_psa.h"
+#include "mbedtls/legacy_or_psa.h"
 #if ( defined(MBEDTLS_ECDSA_DETERMINISTIC) && defined(MBEDTLS_SHA256_C) ) || \
     ( !defined(MBEDTLS_ECDSA_DETERMINISTIC) && defined(MBEDTLS_HAS_ALG_SHA_256_VIA_LOWLEVEL_OR_PSA) )
 #define MBEDTLS_HAS_ALG_SHA_256_VIA_MD_IF_DETERMINISTIC

--- a/tests/suites/test_suite_ecjpake.function
+++ b/tests/suites/test_suite_ecjpake.function
@@ -1,6 +1,6 @@
 /* BEGIN_HEADER */
 #include "mbedtls/ecjpake.h"
-#include "legacy_or_psa.h"
+#include "mbedtls/legacy_or_psa.h"
 
 #if defined(MBEDTLS_ECP_DP_SECP256R1_ENABLED) && defined(MBEDTLS_HAS_ALG_SHA_256_VIA_MD_OR_PSA)
 static const unsigned char ecjpake_test_x1[] = {

--- a/tests/suites/test_suite_oid.function
+++ b/tests/suites/test_suite_oid.function
@@ -3,7 +3,7 @@
 #include "mbedtls/asn1.h"
 #include "mbedtls/asn1write.h"
 #include "string.h"
-#include "legacy_or_psa.h"
+#include "mbedtls/legacy_or_psa.h"
 /* END_HEADER */
 
 /* BEGIN_DEPENDENCIES

--- a/tests/suites/test_suite_pem.function
+++ b/tests/suites/test_suite_pem.function
@@ -3,7 +3,7 @@
 #include "mbedtls/pem.h"
 #include "mbedtls/des.h"
 #include "mbedtls/aes.h"
-#include "legacy_or_psa.h"
+#include "mbedtls/legacy_or_psa.h"
 
 /* END_HEADER */
 

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -8,7 +8,7 @@
 #include "mbedtls/rsa.h"
 
 #include "hash_info.h"
-#include "legacy_or_psa.h"
+#include "mbedtls/legacy_or_psa.h"
 
 #include <limits.h>
 #include <stdint.h>

--- a/tests/suites/test_suite_pkcs12.function
+++ b/tests/suites/test_suite_pkcs12.function
@@ -2,7 +2,7 @@
 #include "mbedtls/pkcs12.h"
 #include "common.h"
 
-#include "legacy_or_psa.h"
+#include "mbedtls/legacy_or_psa.h"
 
 typedef enum
 {

--- a/tests/suites/test_suite_pkcs1_v15.function
+++ b/tests/suites/test_suite_pkcs1_v15.function
@@ -2,7 +2,7 @@
 #include "mbedtls/rsa.h"
 #include "mbedtls/md.h"
 
-#include "legacy_or_psa.h"
+#include "mbedtls/legacy_or_psa.h"
 /* END_HEADER */
 
 /* BEGIN_DEPENDENCIES

--- a/tests/suites/test_suite_pkcs1_v21.function
+++ b/tests/suites/test_suite_pkcs1_v21.function
@@ -1,6 +1,6 @@
 /* BEGIN_HEADER */
 #include "mbedtls/rsa.h"
-#include "legacy_or_psa.h"
+#include "mbedtls/legacy_or_psa.h"
 /* END_HEADER */
 
 /* BEGIN_DEPENDENCIES

--- a/tests/suites/test_suite_pkcs5.function
+++ b/tests/suites/test_suite_pkcs5.function
@@ -1,6 +1,6 @@
 /* BEGIN_HEADER */
 #include "mbedtls/pkcs5.h"
-#include "legacy_or_psa.h"
+#include "mbedtls/legacy_or_psa.h"
 /* END_HEADER */
 
 /* BEGIN_DEPENDENCIES

--- a/tests/suites/test_suite_pkparse.function
+++ b/tests/suites/test_suite_pkparse.function
@@ -2,7 +2,7 @@
 #include "mbedtls/pk.h"
 #include "mbedtls/pem.h"
 #include "mbedtls/oid.h"
-#include "legacy_or_psa.h"
+#include "mbedtls/legacy_or_psa.h"
 /* END_HEADER */
 
 /* BEGIN_DEPENDENCIES

--- a/tests/suites/test_suite_rsa.function
+++ b/tests/suites/test_suite_rsa.function
@@ -2,7 +2,7 @@
 #include "mbedtls/rsa.h"
 #include "rsa_alt_helpers.h"
 
-#include "legacy_or_psa.h"
+#include "mbedtls/legacy_or_psa.h"
 /* END_HEADER */
 
 /* BEGIN_DEPENDENCIES

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -5439,7 +5439,7 @@ void ssl_cf_hmac( int hash )
     size_t min_in_len, in_len, max_in_len, i;
     /* TLS additional data is 13 bytes (hence the "lucky 13" name) */
     unsigned char add_data[13];
-    unsigned char ref_out[MBEDTLS_MD_MAX_SIZE];
+    unsigned char ref_out[MBEDTLS_HASH_MAX_SIZE];
     unsigned char *data = NULL;
     unsigned char *out = NULL;
     unsigned char rec_num = 0;

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -11,7 +11,7 @@
 #include "mbedtls/ssl_cache.h"
 #endif
 
-#include <legacy_or_psa.h>
+#include <mbedtls/legacy_or_psa.h>
 #include "hash_info.h"
 
 #include <constant_time_internal.h>

--- a/tests/suites/test_suite_x509parse.function
+++ b/tests/suites/test_suite_x509parse.function
@@ -10,7 +10,7 @@
 #include "mbedtls/error.h"
 #include "string.h"
 
-#include "legacy_or_psa.h"
+#include "mbedtls/legacy_or_psa.h"
 
 #if MBEDTLS_X509_MAX_INTERMEDIATE_CA > 19
 #error "The value of MBEDTLS_X509_MAX_INTERMEDIATE_C is larger \

--- a/tests/suites/test_suite_x509write.function
+++ b/tests/suites/test_suite_x509write.function
@@ -7,7 +7,7 @@
 #include "mbedtls/rsa.h"
 
 #include "hash_info.h"
-#include "legacy_or_psa.h"
+#include "mbedtls/legacy_or_psa.h"
 
 #if defined(MBEDTLS_RSA_C)
 int mbedtls_rsa_decrypt_func( void *ctx, size_t *olen,


### PR DESCRIPTION
This is a wrap-up PR for the "driver-only: 1a hashes" EPIC, adding a ChangeLog entry, updating the documentation and doing misc. clean-ups that we discussed in previous PRs but left as follow-ups.

This implements part of #6146 but does not close it - we want that issue to remain open in the release EPIC so that we remember to update again for work that's going to happen between now and the next release.

## Requires Backporting
NO  - new features
