### PR TITLE
Use GitHub C syntax highlighting on test files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Classify all '.function' files as C for syntax highlighting purposes
+*.function linguist-language=C


### PR DESCRIPTION
Backport: #6302

Add a .gitattributes file that tells GitHub to highlight all `.function` files as if they were `.c` files. This aids in reviewing changes to tests.

To see the effect in GitHub, see [a function file in this branch](https://github.com/davidhorstmann-arm/mbedtls/blob/syntax-highlighting-function-files/tests/suites/helpers.function).

## Status
**READY**

## Requires Backporting
 NO although it can be backported if desired

## Migrations
NO
