### PR TITLE
Use GitHub C syntax highlighting on test files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Classify all '.function' files as C for syntax highlighting purposes
+*.function linguist-language=C


### PR DESCRIPTION
Backport of #6300.

Add a .gitattributes file that tells GitHub to highlight all .function files as if they were .c files. This aids in reviewing changes to tests.

## Status
**READY**

## Migrations
NO

## Additional comments
Any additional information that could be of interest