### PR TITLE
Return an error from mbedtls_ssl_handshake_step() if neither client nor server

### DIFF
--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -3243,6 +3243,10 @@ int mbedtls_ssl_handshake_step( mbedtls_ssl_context *ssl )
     if( ret != 0 )
         goto cleanup;
 
+    /* If ssl->conf->endpoint is not one of MBEDTLS_SSL_IS_CLIENT or
+     * MBEDTLS_SSL_IS_SERVER, this is the return code we give */
+    ret = MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
+
 #if defined(MBEDTLS_SSL_CLI_C)
     if( ssl->conf->endpoint == MBEDTLS_SSL_IS_CLIENT )
     {

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -3257,6 +3257,7 @@ int mbedtls_ssl_handshake_step( mbedtls_ssl_context *ssl )
         {
             case MBEDTLS_SSL_HELLO_REQUEST:
                 ssl->state = MBEDTLS_SSL_CLIENT_HELLO;
+                ret = 0;
                 break;
 
             case MBEDTLS_SSL_CLIENT_HELLO:


### PR DESCRIPTION
`mbedtls_ssl_handshake_step()` shouldn't return `0` (success) if an invalid context is passed in, in this easy-to-detect way.

Doesn't need a ChangeLog entry, as this isn't something that is really visible to the user of the library, it is "just" better representing what a function finds of its inputs (in the same way we have `MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED`)

Fixes #6305

## Status
**READY**

## Requires Backporting
**NO** - 2.28-LTS already returns an error (specifically `MBEDTLS_ERR_SSL_FEATURE_UNAVAILABLE`) in this case, so this could be considered to be a regression.