### PR TITLE
Add initialization for structures in test

### DIFF
--- a/tests/suites/test_suite_ecdh.function
+++ b/tests/suites/test_suite_ecdh.function
@@ -50,6 +50,8 @@ void ecdh_invalid_param( )
     mbedtls_ecp_keypair kp;
     int invalid_side = 42;
 
+    mbedtls_ecp_keypair_init( &kp );
+
     TEST_EQUAL( MBEDTLS_ERR_ECP_BAD_INPUT_DATA,
                             mbedtls_ecdh_get_params( &ctx, &kp,
                                                      invalid_side ) );

--- a/tests/suites/test_suite_ecdh.function
+++ b/tests/suites/test_suite_ecdh.function
@@ -50,6 +50,7 @@ void ecdh_invalid_param( )
     mbedtls_ecp_keypair kp;
     int invalid_side = 42;
 
+    mbedtls_ecdh_init( &ctx );
     mbedtls_ecp_keypair_init( &kp );
 
     TEST_EQUAL( MBEDTLS_ERR_ECP_BAD_INPUT_DATA,

--- a/tests/suites/test_suite_ecjpake.function
+++ b/tests/suites/test_suite_ecjpake.function
@@ -109,6 +109,8 @@ void ecjpake_invalid_param( )
     mbedtls_md_type_t valid_md = MBEDTLS_MD_SHA256;
     mbedtls_ecp_group_id valid_group = MBEDTLS_ECP_DP_SECP256R1;
 
+    mbedtls_ecjpake_init( &ctx );
+
     TEST_EQUAL( MBEDTLS_ERR_ECP_BAD_INPUT_DATA,
                             mbedtls_ecjpake_setup( &ctx,
                                                    invalid_role,

--- a/tests/suites/test_suite_ecp.function
+++ b/tests/suites/test_suite_ecp.function
@@ -72,6 +72,9 @@ void ecp_invalid_param( )
     size_t olen;
     unsigned char buf[42] = { 0 };
 
+    mbedtls_ecp_group_init( &grp );
+    mbedtls_ecp_point_init( &P );
+
     TEST_EQUAL( MBEDTLS_ERR_ECP_BAD_INPUT_DATA,
                             mbedtls_ecp_point_write_binary( &grp, &P,
                                                       invalid_fmt,


### PR DESCRIPTION
## Description

Add missing initialization that cause build error.

Fix #6308 

## Requires Backporting
- [x] [2.28](https://github.com/Mbed-TLS/mbedtls/pull/6388)