### PR TITLE
Test TLS 1.2 builds with each encryption type

### DIFF
--- a/ChangeLog.d/fix_build_tls1_2_with_single_encryption_type.txt
+++ b/ChangeLog.d/fix_build_tls1_2_with_single_encryption_type.txt
@@ -1,0 +1,3 @@
+Bugfix
+    * Fix bugs to enable TLS 1.2 builds with
+      single encryption type + tests

--- a/ChangeLog.d/fix_build_tls1_2_with_single_encryption_type.txt
+++ b/ChangeLog.d/fix_build_tls1_2_with_single_encryption_type.txt
@@ -1,3 +1,4 @@
 Bugfix
-    * Fix bugs to enable TLS 1.2 builds with
-      single encryption type + tests
+    * Fix bugs and missing dependencies when
+      building and testing configurations with
+      only one encryption type enabled in TLS 1.2.

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -962,10 +962,6 @@
 #error "MBEDTLS_SSL_VARIABLE_BUFFER_LENGTH defined, but not all prerequisites"
 #endif
 
-#if defined(MBEDTLS_SSL_SESSION_TICKETS) && !( defined(MBEDTLS_GCM_C) || defined(MBEDTLS_CCM_C) || defined(MBEDTLS_CHACHAPOLY_C) || defined(MBEDTLS_NIST_KW_C) )
-#error "MBEDTLS_SSL_SESSION_TICKETS defined, but not all prerequisites"
-#endif
-
 #if defined(MBEDTLS_SSL_CONTEXT_SERIALIZATION) && !( defined(MBEDTLS_GCM_C) || defined(MBEDTLS_CCM_C) || defined(MBEDTLS_CHACHAPOLY_C) )
 #error "MBEDTLS_SSL_CONTEXT_SERIALIZATION defined, but not all prerequisites"
 #endif

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -962,6 +962,9 @@
 #error "MBEDTLS_SSL_VARIABLE_BUFFER_LENGTH defined, but not all prerequisites"
 #endif
 
+#if defined(MBEDTLS_SSL_SESSION_TICKETS) && !( defined(MBEDTLS_CIPHER_MODE_AEAD) || defined(MBEDTLS_NIST_KW_C) )
+#error "MBEDTLS_SSL_SESSION_TICKETS defined, but not all prerequisites"
+#endif
 
 
 /* Reject attempts to enable options that have been removed and that could

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -963,7 +963,7 @@
 #endif
 
 #if defined(MBEDTLS_SSL_SESSION_TICKETS) && \
-    !( defined(MBEDTLS_GCM_C) || defined(MBEDTLS_CCM_C) || defined(MBEDTLS_CHACHAPOLY_C) || defined(MBEDTLS_NIST_KW_C) )
+    !( defined(MBEDTLS_GCM_C) || defined(MBEDTLS_CCM_C) || defined(MBEDTLS_CHACHAPOLY_C) )
 #error "MBEDTLS_SSL_SESSION_TICKETS defined, but not all prerequisites"
 #endif
 

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -962,11 +962,11 @@
 #error "MBEDTLS_SSL_VARIABLE_BUFFER_LENGTH defined, but not all prerequisites"
 #endif
 
-#if defined(MBEDTLS_SSL_SESSION_TICKETS) && !( defined(MBEDTLS_CIPHER_MODE_AEAD) || defined(MBEDTLS_NIST_KW_C) )
+#if defined(MBEDTLS_SSL_SESSION_TICKETS) && !( defined(MBEDTLS_GCM_C) || defined(MBEDTLS_CCM_C) || defined(MBEDTLS_CHACHAPOLY_C) || defined(MBEDTLS_NIST_KW_C) )
 #error "MBEDTLS_SSL_SESSION_TICKETS defined, but not all prerequisites"
 #endif
 
-#if defined(MBEDTLS_SSL_CONTEXT_SERIALIZATION) && !defined(MBEDTLS_CIPHER_MODE_AEAD)
+#if defined(MBEDTLS_SSL_CONTEXT_SERIALIZATION) && !( defined(MBEDTLS_GCM_C) || defined(MBEDTLS_CCM_C) || defined(MBEDTLS_CHACHAPOLY_C) )
 #error "MBEDTLS_SSL_CONTEXT_SERIALIZATION defined, but not all prerequisites"
 #endif
 

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -874,6 +874,11 @@
 #error "MBEDTLS_SSL_TICKET_C defined, but not all prerequisites"
 #endif
 
+#if defined(MBEDTLS_SSL_TICKET_C) && \
+    !( defined(MBEDTLS_GCM_C) || defined(MBEDTLS_CCM_C) || defined(MBEDTLS_CHACHAPOLY_C) )
+#error "MBEDTLS_SSL_TICKET_C  defined, but not all prerequisites"
+#endif
+
 #if defined(MBEDTLS_SSL_TLS1_3_TICKET_NONCE_LENGTH) && \
     MBEDTLS_SSL_TLS1_3_TICKET_NONCE_LENGTH >= 256
 #error "MBEDTLS_SSL_TLS1_3_TICKET_NONCE_LENGTH must be less than 256"
@@ -960,11 +965,6 @@
 
 #if defined(MBEDTLS_SSL_VARIABLE_BUFFER_LENGTH) && ( !defined(MBEDTLS_SSL_MAX_FRAGMENT_LENGTH) )
 #error "MBEDTLS_SSL_VARIABLE_BUFFER_LENGTH defined, but not all prerequisites"
-#endif
-
-#if defined(MBEDTLS_SSL_SESSION_TICKETS) && \
-    !( defined(MBEDTLS_GCM_C) || defined(MBEDTLS_CCM_C) || defined(MBEDTLS_CHACHAPOLY_C) )
-#error "MBEDTLS_SSL_SESSION_TICKETS defined, but not all prerequisites"
 #endif
 
 #if defined(MBEDTLS_SSL_CONTEXT_SERIALIZATION) && !( defined(MBEDTLS_GCM_C) || defined(MBEDTLS_CCM_C) || defined(MBEDTLS_CHACHAPOLY_C) )

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -966,6 +966,9 @@
 #error "MBEDTLS_SSL_SESSION_TICKETS defined, but not all prerequisites"
 #endif
 
+#if defined(MBEDTLS_SSL_CONTEXT_SERIALIZATION) && !defined(MBEDTLS_CIPHER_MODE_AEAD)
+#error "MBEDTLS_SSL_CONTEXT_SERIALIZATION defined, but not all prerequisites"
+#endif
 
 /* Reject attempts to enable options that have been removed and that could
  * cause a build to succeed but with features removed. */

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -962,6 +962,11 @@
 #error "MBEDTLS_SSL_VARIABLE_BUFFER_LENGTH defined, but not all prerequisites"
 #endif
 
+#if defined(MBEDTLS_SSL_SESSION_TICKETS) && \
+    !( defined(MBEDTLS_GCM_C) || defined(MBEDTLS_CCM_C) || defined(MBEDTLS_CHACHAPOLY_C) || defined(MBEDTLS_NIST_KW_C) )
+#error "MBEDTLS_SSL_SESSION_TICKETS defined, but not all prerequisites"
+#endif
+
 #if defined(MBEDTLS_SSL_CONTEXT_SERIALIZATION) && !( defined(MBEDTLS_GCM_C) || defined(MBEDTLS_CCM_C) || defined(MBEDTLS_CHACHAPOLY_C) )
 #error "MBEDTLS_SSL_CONTEXT_SERIALIZATION defined, but not all prerequisites"
 #endif

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -876,7 +876,7 @@
 
 #if defined(MBEDTLS_SSL_TICKET_C) && \
     !( defined(MBEDTLS_GCM_C) || defined(MBEDTLS_CCM_C) || defined(MBEDTLS_CHACHAPOLY_C) )
-#error "MBEDTLS_SSL_TICKET_C  defined, but not all prerequisites"
+#error "MBEDTLS_SSL_TICKET_C defined, but not all prerequisites"
 #endif
 
 #if defined(MBEDTLS_SSL_TLS1_3_TICKET_NONCE_LENGTH) && \

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -1703,8 +1703,7 @@
  * tickets, including authenticated encryption and key management. Example
  * callbacks are provided by MBEDTLS_SSL_TICKET_C.
  *
- * Requires: MBEDTLS_GCM_C or MBEDTLS_CCM_C or MBEDTLS_CHACHAPOLY_C or
- *           MBEDTLS_NIST_KW_C
+ * Requires: MBEDTLS_GCM_C or MBEDTLS_CCM_C or MBEDTLS_CHACHAPOLY_C
  *
  * Comment this macro to disable support for SSL session tickets
  */

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -1703,8 +1703,6 @@
  * tickets, including authenticated encryption and key management. Example
  * callbacks are provided by MBEDTLS_SSL_TICKET_C.
  *
- * Requires: MBEDTLS_GCM_C or MBEDTLS_CCM_C or MBEDTLS_CHACHAPOLY_C
- *
  * Comment this macro to disable support for SSL session tickets
  */
 #define MBEDTLS_SSL_SESSION_TICKETS
@@ -3056,7 +3054,8 @@
  * Module:  library/ssl_ticket.c
  * Caller:
  *
- * Requires: MBEDTLS_CIPHER_C || MBEDTLS_USE_PSA_CRYPTO
+ * Requires: (MBEDTLS_CIPHER_C || MBEDTLS_USE_PSA_CRYPTO) &&
+ *           (MBEDTLS_GCM_C || MBEDTLS_CCM_C || MBEDTLS_CHACHAPOLY_C)
  */
 #define MBEDTLS_SSL_TICKET_C
 

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -1380,6 +1380,8 @@
  * saved after the handshake to allow for more efficient serialization, so if
  * you don't need this feature you'll save RAM by disabling it.
  *
+ * Requires: MBEDTLS_GCM_C or MBEDTLS_CCM_C or MBEDTLS_CHACHAPOLY_C
+ *
  * Comment to disable the context serialization APIs.
  */
 #define MBEDTLS_SSL_CONTEXT_SERIALIZATION
@@ -1700,6 +1702,9 @@
  * Server-side, you also need to provide callbacks for writing and parsing
  * tickets, including authenticated encryption and key management. Example
  * callbacks are provided by MBEDTLS_SSL_TICKET_C.
+ *
+ * Requires: MBEDTLS_GCM_C or MBEDTLS_CCM_C or MBEDTLS_CHACHAPOLY_C or
+ *           MBEDTLS_NIST_KW_C
  *
  * Comment this macro to disable support for SSL session tickets
  */

--- a/library/constant_time.c
+++ b/library/constant_time.c
@@ -81,7 +81,7 @@ unsigned mbedtls_ct_uint_mask( unsigned value )
 #endif
 }
 
-#if defined(MBEDTLS_SSL_SOME_SUITES_USE_TLS_CBC)
+#if defined(MBEDTLS_SSL_SOME_SUITES_USE_MAC)
 
 size_t mbedtls_ct_size_mask( size_t value )
 {
@@ -97,7 +97,7 @@ size_t mbedtls_ct_size_mask( size_t value )
 #endif
 }
 
-#endif /* MBEDTLS_SSL_SOME_SUITES_USE_TLS_CBC */
+#endif /* MBEDTLS_SSL_SOME_SUITES_USE_MAC */
 
 #if defined(MBEDTLS_BIGNUM_C)
 
@@ -404,7 +404,7 @@ static void mbedtls_ct_mem_move_to_left( void *start,
 
 #endif /* MBEDTLS_PKCS1_V15 && MBEDTLS_RSA_C && ! MBEDTLS_RSA_ALT */
 
-#if defined(MBEDTLS_SSL_SOME_SUITES_USE_TLS_CBC)
+#if defined(MBEDTLS_SSL_SOME_SUITES_USE_MAC)
 
 void mbedtls_ct_memcpy_if_eq( unsigned char *dest,
                               const unsigned char *src,
@@ -654,7 +654,7 @@ cleanup:
 }
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
-#endif /* MBEDTLS_SSL_SOME_SUITES_USE_TLS_CBC */
+#endif /* MBEDTLS_SSL_SOME_SUITES_USE_MAC */
 
 #if defined(MBEDTLS_BIGNUM_C)
 

--- a/library/constant_time_internal.h
+++ b/library/constant_time_internal.h
@@ -213,7 +213,7 @@ signed char mbedtls_ct_base64_dec_value( unsigned char c );
 
 #endif /* MBEDTLS_BASE64_C */
 
-#if defined(MBEDTLS_SSL_SOME_SUITES_USE_TLS_CBC)
+#if defined(MBEDTLS_SSL_SOME_SUITES_USE_MAC)
 
 /** Conditional memcpy without branches.
  *
@@ -321,7 +321,7 @@ int mbedtls_ct_hmac( mbedtls_md_context_t *ctx,
                      unsigned char *output );
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
-#endif /* MBEDTLS_SSL_SOME_SUITES_USE_TLS_CBC */
+#endif /* MBEDTLS_SSL_SOME_SUITES_USE_MAC */
 
 #if defined(MBEDTLS_PKCS1_V15) && defined(MBEDTLS_RSA_C) && !defined(MBEDTLS_RSA_ALT)
 

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -3592,6 +3592,7 @@ static psa_status_t psa_aead_check_nonce_length( psa_algorithm_t alg,
             break;
 #endif /* PSA_WANT_ALG_CHACHA20_POLY1305 */
         default:
+            (void) nonce_length;
             return( PSA_ERROR_NOT_SUPPORTED );
     }
 

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -1124,7 +1124,9 @@ int mbedtls_ssl_decrypt_buf( mbedtls_ssl_context const *ssl,
                              mbedtls_ssl_transform *transform,
                              mbedtls_record *rec )
 {
+#if defined(MBEDTLS_SSL_SOME_SUITES_USE_CBC) || defined(MBEDTLS_CIPHER_MODE_AEAD)
     size_t olen;
+#endif /* MBEDTLS_SSL_SOME_SUITES_USE_CBC || MBEDTLS_CIPHER_MODE_AEAD */
     mbedtls_ssl_mode_t ssl_mode;
     int ret;
 

--- a/library/ssl_ticket.c
+++ b/library/ssl_ticket.c
@@ -114,7 +114,6 @@ static int ssl_ticket_gen_key( mbedtls_ssl_ticket_context *ctx,
 /*
  * Rotate/generate keys if necessary
  */
-#if defined(MBEDTLS_CIPHER_MODE_AEAD) || defined(MBEDTLS_NIST_KW_C)
 MBEDTLS_CHECK_RETURN_CRITICAL
 static int ssl_ticket_update_keys( mbedtls_ssl_ticket_context *ctx )
 {
@@ -151,7 +150,6 @@ static int ssl_ticket_update_keys( mbedtls_ssl_ticket_context *ctx )
 #endif /* MBEDTLS_HAVE_TIME */
         return( 0 );
 }
-#endif
 
 /*
  * Rotate active session ticket encryption key
@@ -295,7 +293,7 @@ int mbedtls_ssl_ticket_setup( mbedtls_ssl_ticket_context *ctx,
  * The key_name, iv, and length of encrypted_state are the additional
  * authenticated data.
  */
-#if defined(MBEDTLS_CIPHER_MODE_AEAD) || defined(MBEDTLS_NIST_KW_C)
+
 int mbedtls_ssl_ticket_write( void *p_ticket,
                               const mbedtls_ssl_session *session,
                               unsigned char *start,
@@ -392,9 +390,7 @@ cleanup:
 
     return( ret );
 }
-#endif
 
-#if defined(MBEDTLS_CIPHER_MODE_AEAD) || defined(MBEDTLS_NIST_KW_C)
 /*
  * Select key based on name
  */
@@ -521,7 +517,6 @@ cleanup:
 
     return( ret );
 }
-#endif
 
 /*
  * Free context

--- a/library/ssl_ticket.c
+++ b/library/ssl_ticket.c
@@ -114,6 +114,7 @@ static int ssl_ticket_gen_key( mbedtls_ssl_ticket_context *ctx,
 /*
  * Rotate/generate keys if necessary
  */
+#if defined(MBEDTLS_CIPHER_MODE_AEAD) || defined(MBEDTLS_NIST_KW_C)
 MBEDTLS_CHECK_RETURN_CRITICAL
 static int ssl_ticket_update_keys( mbedtls_ssl_ticket_context *ctx )
 {
@@ -150,6 +151,7 @@ static int ssl_ticket_update_keys( mbedtls_ssl_ticket_context *ctx )
 #endif /* MBEDTLS_HAVE_TIME */
         return( 0 );
 }
+#endif
 
 /*
  * Rotate active session ticket encryption key
@@ -293,7 +295,7 @@ int mbedtls_ssl_ticket_setup( mbedtls_ssl_ticket_context *ctx,
  * The key_name, iv, and length of encrypted_state are the additional
  * authenticated data.
  */
-
+#if defined(MBEDTLS_CIPHER_MODE_AEAD) || defined(MBEDTLS_NIST_KW_C)
 int mbedtls_ssl_ticket_write( void *p_ticket,
                               const mbedtls_ssl_session *session,
                               unsigned char *start,
@@ -390,7 +392,9 @@ cleanup:
 
     return( ret );
 }
+#endif
 
+#if defined(MBEDTLS_CIPHER_MODE_AEAD) || defined(MBEDTLS_NIST_KW_C)
 /*
  * Select key based on name
  */
@@ -517,6 +521,7 @@ cleanup:
 
     return( ret );
 }
+#endif
 
 /*
  * Free context

--- a/programs/fuzz/fuzz_server.c
+++ b/programs/fuzz/fuzz_server.c
@@ -42,7 +42,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
     mbedtls_ssl_config conf;
     mbedtls_ctr_drbg_context ctr_drbg;
     mbedtls_entropy_context entropy;
-#if defined(MBEDTLS_SSL_SESSION_TICKETS)
+#if defined(MBEDTLS_SSL_SESSION_TICKETS) && defined(MBEDTLS_SSL_TICKET_C)
     mbedtls_ssl_ticket_context ticket_ctx;
 #endif
     unsigned char buf[4096];
@@ -89,7 +89,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
     }
     mbedtls_ssl_init( &ssl );
     mbedtls_ssl_config_init( &conf );
-#if defined(MBEDTLS_SSL_SESSION_TICKETS)
+#if defined(MBEDTLS_SSL_SESSION_TICKETS) && defined(MBEDTLS_SSL_TICKET_C)
     mbedtls_ssl_ticket_init( &ticket_ctx );
 #endif
 
@@ -114,7 +114,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
         mbedtls_ssl_conf_alpn_protocols( &conf, alpn_list );
     }
 #endif
-#if defined(MBEDTLS_SSL_SESSION_TICKETS)
+#if defined(MBEDTLS_SSL_SESSION_TICKETS) && defined(MBEDTLS_SSL_TICKET_C)
     if( options & 0x4 )
     {
         if( mbedtls_ssl_ticket_setup( &ticket_ctx,
@@ -173,7 +173,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
     }
 
 exit:
-#if defined(MBEDTLS_SSL_SESSION_TICKETS)
+#if defined(MBEDTLS_SSL_SESSION_TICKETS) && defined(MBEDTLS_SSL_TICKET_C)
     mbedtls_ssl_ticket_free( &ticket_ctx );
 #endif
     mbedtls_entropy_free( &entropy );

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -283,7 +283,7 @@ int main( void )
 #else
 #define USAGE_CA_CALLBACK ""
 #endif /* MBEDTLS_X509_TRUSTED_CERTIFICATE_CALLBACK */
-#if defined(MBEDTLS_SSL_SESSION_TICKETS)
+#if defined(MBEDTLS_SSL_SESSION_TICKETS) && defined(MBEDTLS_SSL_TICKET_C)
 #define USAGE_TICKETS                                       \
     "    tickets=%%d          default: 1 (enabled)\n"       \
     "    ticket_rotate=%%d    default: 0 (disabled)\n"      \
@@ -291,7 +291,7 @@ int main( void )
     "    ticket_aead=%%s      default: \"AES-256-GCM\"\n"
 #else
 #define USAGE_TICKETS ""
-#endif /* MBEDTLS_SSL_SESSION_TICKETS */
+#endif /* MBEDTLS_SSL_SESSION_TICKETS && MBEDTLS_SSL_TICKET_C */
 
 #define USAGE_EAP_TLS                                       \
     "    eap_tls=%%d          default: 0 (disabled)\n"
@@ -1406,7 +1406,7 @@ int main( int argc, char *argv[] )
 #endif
 #if defined(MBEDTLS_SSL_SESSION_TICKETS) && defined(MBEDTLS_SSL_TICKET_C)
     mbedtls_ssl_ticket_context ticket_ctx;
-#endif
+#endif /* MBEDTLS_SSL_SESSION_TICKETS && MBEDTLS_SSL_TICKET_C */
 #if defined(SNI_OPTION)
     sni_entry *sni_info = NULL;
 #endif

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -49,7 +49,7 @@ int main( void )
 #include "mbedtls/ssl_cache.h"
 #endif
 
-#if defined(MBEDTLS_SSL_TICKET_C)
+#if defined(MBEDTLS_SSL_SESSION_TICKETS) && defined(MBEDTLS_SSL_TICKET_C)
 #include "mbedtls/ssl_ticket.h"
 #endif
 
@@ -1404,7 +1404,7 @@ int main( int argc, char *argv[] )
 #if defined(MBEDTLS_SSL_CACHE_C)
     mbedtls_ssl_cache_context cache;
 #endif
-#if defined(MBEDTLS_SSL_SESSION_TICKETS)
+#if defined(MBEDTLS_SSL_SESSION_TICKETS) && defined(MBEDTLS_SSL_TICKET_C)
     mbedtls_ssl_ticket_context ticket_ctx;
 #endif
 #if defined(SNI_OPTION)
@@ -1495,7 +1495,7 @@ int main( int argc, char *argv[] )
 #if defined(MBEDTLS_SSL_CACHE_C)
     mbedtls_ssl_cache_init( &cache );
 #endif
-#if defined(MBEDTLS_SSL_SESSION_TICKETS)
+#if defined(MBEDTLS_SSL_SESSION_TICKETS) && defined(MBEDTLS_SSL_TICKET_C)
     mbedtls_ssl_ticket_init( &ticket_ctx );
 #endif
 #if defined(MBEDTLS_SSL_ALPN)
@@ -2914,7 +2914,7 @@ int main( int argc, char *argv[] )
                                    mbedtls_ssl_cache_set );
 #endif
 
-#if defined(MBEDTLS_SSL_SESSION_TICKETS)
+#if defined(MBEDTLS_SSL_SESSION_TICKETS) && defined(MBEDTLS_SSL_TICKET_C)
     if( opt.tickets != MBEDTLS_SSL_SESSION_TICKETS_DISABLED )
     {
         if( ( ret = mbedtls_ssl_ticket_setup( &ticket_ctx,
@@ -4210,7 +4210,7 @@ exit:
 #if defined(MBEDTLS_SSL_CACHE_C)
     mbedtls_ssl_cache_free( &cache );
 #endif
-#if defined(MBEDTLS_SSL_SESSION_TICKETS)
+#if defined(MBEDTLS_SSL_SESSION_TICKETS) && defined(MBEDTLS_SSL_TICKET_C)
     mbedtls_ssl_ticket_free( &ticket_ctx );
 #endif
 #if defined(MBEDTLS_SSL_COOKIE_C)

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1288,10 +1288,6 @@ component_test_tls1_2_default_stream_cipher_only () {
     # Enable stream (currently that's just the NULL pseudo-cipher (controlled by MBEDTLS_CIPHER_NULL_CIPHER))
     scripts/config.py set MBEDTLS_CIPHER_NULL_CIPHER
     # Indirect dependencies
-    scripts/config.py unset MBEDTLS_CTR_DRBG_C
-    scripts/config.py unset MBEDTLS_CMAC_C
-    scripts/config.py unset MBEDTLS_NIST_KW_C
-    scripts/config.py unset MBEDTLS_SSL_SESSION_TICKETS
     scripts/config.py unset MBEDTLS_SSL_CONTEXT_SERIALIZATION
 
     make
@@ -1315,10 +1311,6 @@ component_test_tls1_2_default_stream_cipher_only_use_psa () {
     # Enable stream (currently that's just the NULL pseudo-cipher (controlled by MBEDTLS_CIPHER_NULL_CIPHER))
     scripts/config.py set MBEDTLS_CIPHER_NULL_CIPHER
     # Indirect dependencies
-    scripts/config.py unset MBEDTLS_CTR_DRBG_C
-    scripts/config.py unset MBEDTLS_CMAC_C
-    scripts/config.py unset MBEDTLS_NIST_KW_C
-    scripts/config.py unset MBEDTLS_SSL_SESSION_TICKETS
     scripts/config.py unset MBEDTLS_SSL_CONTEXT_SERIALIZATION
 
     make
@@ -1341,10 +1333,6 @@ component_test_tls1_2_default_cbc_legacy_cipher_only () {
     # Disable stream (currently that's just the NULL pseudo-cipher (controlled by MBEDTLS_CIPHER_NULL_CIPHER))
     scripts/config.py unset MBEDTLS_CIPHER_NULL_CIPHER
     # Indirect dependencies
-    scripts/config.py unset MBEDTLS_CTR_DRBG_C
-    scripts/config.py unset MBEDTLS_CMAC_C
-    scripts/config.py unset MBEDTLS_NIST_KW_C
-    scripts/config.py unset MBEDTLS_SSL_SESSION_TICKETS
     scripts/config.py unset MBEDTLS_SSL_CONTEXT_SERIALIZATION
 
     make
@@ -1368,10 +1356,6 @@ component_test_tls1_2_deafult_cbc_legacy_cipher_only_use_psa () {
     # Disable stream (currently that's just the NULL pseudo-cipher (controlled by MBEDTLS_CIPHER_NULL_CIPHER))
     scripts/config.py unset MBEDTLS_CIPHER_NULL_CIPHER
     # Indirect dependencies
-    scripts/config.py unset MBEDTLS_CTR_DRBG_C
-    scripts/config.py unset MBEDTLS_CMAC_C
-    scripts/config.py unset MBEDTLS_NIST_KW_C
-    scripts/config.py unset MBEDTLS_SSL_SESSION_TICKETS
     scripts/config.py unset MBEDTLS_SSL_CONTEXT_SERIALIZATION
 
     make
@@ -1394,10 +1378,6 @@ component_test_tls1_2_default_cbc_legacy_cbc_etm_cipher_only () {
     # Disable stream (currently that's just the NULL pseudo-cipher (controlled by MBEDTLS_CIPHER_NULL_CIPHER))
     scripts/config.py unset MBEDTLS_CIPHER_NULL_CIPHER
     # Indirect dependencies
-    scripts/config.py unset MBEDTLS_CTR_DRBG_C
-    scripts/config.py unset MBEDTLS_CMAC_C
-    scripts/config.py unset MBEDTLS_NIST_KW_C
-    scripts/config.py unset MBEDTLS_SSL_SESSION_TICKETS
     scripts/config.py unset MBEDTLS_SSL_CONTEXT_SERIALIZATION
 
     make
@@ -1421,10 +1401,6 @@ component_test_tls1_2_full_cbc_legacy_cbc_etm_cipher_only_use_psa () {
     # Disable stream (currently that's just the NULL pseudo-cipher (controlled by MBEDTLS_CIPHER_NULL_CIPHER))
     scripts/config.py unset MBEDTLS_CIPHER_NULL_CIPHER
     # Indirect dependencies
-    scripts/config.py unset MBEDTLS_CTR_DRBG_C
-    scripts/config.py unset MBEDTLS_CMAC_C
-    scripts/config.py unset MBEDTLS_NIST_KW_C
-    scripts/config.py unset MBEDTLS_SSL_SESSION_TICKETS
     scripts/config.py unset MBEDTLS_SSL_CONTEXT_SERIALIZATION
 
     make

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1277,7 +1277,6 @@ component_test_crypto_full_no_cipher () {
 component_test_crypto_default_stream_cipher_only () {
     msg "build: default with only stream cipher"
 
-    scripts/config.py crypto_full
     # Disable all ciphers
     # AEAD (controlled by the presence of one of GCM_C, CCM_C, CHACHAPOLY_C
     scripts/config.py unset MBEDTLS_GCM_C
@@ -1308,9 +1307,10 @@ component_test_crypto_default_stream_cipher_only () {
     make test
 }
 
-component_test_crypto_full_stream_cipher_only () {
-    msg "build: full with only stream cipher"
+component_test_crypto_default_stream_cipher_only_use_psa () {
+    msg "build: deafult with only stream cipher use psa"
 
+    scripts/config.py set MBEDTLS_USE_PSA_CRYPTO
     # Disable all ciphers
     # AEAD (controlled by the presence of one of GCM_C, CCM_C, CHACHAPOLY_C
     scripts/config.py unset MBEDTLS_GCM_C
@@ -1337,7 +1337,7 @@ component_test_crypto_full_stream_cipher_only () {
     scripts/config.py set MBEDTLS_CIPHER_NULL_CIPHER
     make
 
-    msg "test: full with only stream cipher"
+    msg "test: deafult with only stream cipher use psa"
     make test
 }
 
@@ -1375,10 +1375,10 @@ component_test_crypto_default_cbc_legacy_cipher_only () {
     make test
 }
 
-component_test_crypto_full_cbc_legacy_cipher_only () {
-    msg "build: full with only CBC-legacy cipher"
+component_test_crypto_deafult_cbc_legacy_cipher_only_use_psa () {
+    msg "build: default with only CBC-legacy cipher use psa"
 
-    scripts/config.py crypto_full
+    scripts/config.py set MBEDTLS_USE_PSA_CRYPTO
     # Disable all ciphers
     # AEAD (controlled by the presence of one of GCM_C, CCM_C, CHACHAPOLY_C
     scripts/config.py unset MBEDTLS_GCM_C
@@ -1406,7 +1406,80 @@ component_test_crypto_full_cbc_legacy_cipher_only () {
     scripts/config.py set MBEDTLS_AES_C
     make
 
-    msg "test: full with only CBC-legacy cipher"
+    msg "test: default with only CBC-legacy cipher use psa"
+    make test
+}
+
+component_test_crypto_default_cbc_legacy_cbc_etm_cipher_only () {
+    msg "build: default with only CBC-legacy and CBC-EtM ciphers"
+
+    # Disable all ciphers
+    # AEAD (controlled by the presence of one of GCM_C, CCM_C, CHACHAPOLY_C
+    scripts/config.py unset MBEDTLS_GCM_C
+    scripts/config.py unset MBEDTLS_CCM_C
+    scripts/config.py unset MBEDTLS_CHACHAPOLY_C
+    # CBC-legacy (controlled by MBEDTLS_CIPHER_MODE_CBC plus at least one block cipher (AES, ARIA, Camellia, DES))
+    scripts/config.py unset MBEDTLS_CIPHER_MODE_CBC
+    scripts/config.py unset MBEDTLS_AES_C
+    scripts/config.py unset MBEDTLS_CAMELLIA_C
+    scripts/config.py unset MBEDTLS_ARIA_C
+    scripts/config.py unset MBEDTLS_DES_C
+    # CBC-EtM (controlled by the same as CBC-legacy plus MBEDTLS_SSL_ENCRYPT_THEN_MAC)
+    scripts/config.py unset MBEDTLS_SSL_ENCRYPT_THEN_MAC
+    # stream (currently that's just the NULL pseudo-cipher (controlled by MBEDTLS_CIPHER_NULL_CIPHER)
+    scripts/config.py unset MBEDTLS_CIPHER_NULL_CIPHER
+    # Indirect dependencies
+    scripts/config.py unset MBEDTLS_CTR_DRBG_C
+    scripts/config.py unset MBEDTLS_CMAC_C
+    scripts/config.py unset MBEDTLS_NIST_KW_C
+    scripts/config.py unset MBEDTLS_SSL_SESSION_TICKETS
+    scripts/config.py unset MBEDTLS_SSL_CONTEXT_SERIALIZATION
+
+    # Enable CBC-legacy cipher only
+    scripts/config.py set MBEDTLS_CIPHER_MODE_CBC
+    scripts/config.py set MBEDTLS_AES_C
+    scripts/config.py set MBEDTLS_SSL_ENCRYPT_THEN_MAC
+
+    make
+
+    msg "test: default with only CBC-legacy and CBC-EtM ciphers"
+    make test
+}
+
+component_test_crypto_full_cbc_legacy_cbc_etm_cipher_only_use_psa () {
+    msg "build: full with only CBC-legacy and CBC-EtM ciphers use psa"
+
+    scripts/config.py set MBEDTLS_USE_PSA_CRYPTO
+    # Disable all ciphers
+    # AEAD (controlled by the presence of one of GCM_C, CCM_C, CHACHAPOLY_C
+    scripts/config.py unset MBEDTLS_GCM_C
+    scripts/config.py unset MBEDTLS_CCM_C
+    scripts/config.py unset MBEDTLS_CHACHAPOLY_C
+    # CBC-legacy (controlled by MBEDTLS_CIPHER_MODE_CBC plus at least one block cipher (AES, ARIA, Camellia, DES))
+    scripts/config.py unset MBEDTLS_CIPHER_MODE_CBC
+    scripts/config.py unset MBEDTLS_AES_C
+    scripts/config.py unset MBEDTLS_CAMELLIA_C
+    scripts/config.py unset MBEDTLS_ARIA_C
+    scripts/config.py unset MBEDTLS_DES_C
+    # CBC-EtM (controlled by the same as CBC-legacy plus MBEDTLS_SSL_ENCRYPT_THEN_MAC)
+    scripts/config.py unset MBEDTLS_SSL_ENCRYPT_THEN_MAC
+    # stream (currently that's just the NULL pseudo-cipher (controlled by MBEDTLS_CIPHER_NULL_CIPHER)
+    scripts/config.py unset MBEDTLS_CIPHER_NULL_CIPHER
+    # Indirect dependencies
+    scripts/config.py unset MBEDTLS_CTR_DRBG_C
+    scripts/config.py unset MBEDTLS_CMAC_C
+    scripts/config.py unset MBEDTLS_NIST_KW_C
+    scripts/config.py unset MBEDTLS_SSL_SESSION_TICKETS
+    scripts/config.py unset MBEDTLS_SSL_CONTEXT_SERIALIZATION
+
+    # Enable CBC-legacy cipher only
+    scripts/config.py set MBEDTLS_CIPHER_MODE_CBC
+    scripts/config.py set MBEDTLS_AES_C
+    scripts/config.py set MBEDTLS_SSL_ENCRYPT_THEN_MAC
+
+    make
+
+    msg "test: full with only CBC-legacy and CBC-EtM ciphers use psa"
     make test
 }
 

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1289,6 +1289,7 @@ component_test_tls1_2_default_stream_cipher_only () {
     scripts/config.py set MBEDTLS_CIPHER_NULL_CIPHER
     # Indirect dependencies
     scripts/config.py unset MBEDTLS_SSL_CONTEXT_SERIALIZATION
+    scripts/config.py unset MBEDTLS_SSL_SESSION_TICKETS
 
     make
 
@@ -1312,6 +1313,7 @@ component_test_tls1_2_default_stream_cipher_only_use_psa () {
     scripts/config.py set MBEDTLS_CIPHER_NULL_CIPHER
     # Indirect dependencies
     scripts/config.py unset MBEDTLS_SSL_CONTEXT_SERIALIZATION
+    scripts/config.py unset MBEDTLS_SSL_SESSION_TICKETS
 
     make
 
@@ -1334,11 +1336,15 @@ component_test_tls1_2_default_cbc_legacy_cipher_only () {
     scripts/config.py unset MBEDTLS_CIPHER_NULL_CIPHER
     # Indirect dependencies
     scripts/config.py unset MBEDTLS_SSL_CONTEXT_SERIALIZATION
+    scripts/config.py unset MBEDTLS_SSL_SESSION_TICKETS
 
     make
 
     msg "test: default with only CBC-legacy cipher"
     make test
+
+    msg "test: default with only CBC-legacy cipher - ssl-opt.sh (subset)"
+    tests/ssl-opt.sh -f "TLS 1.2"
 }
 
 component_test_tls1_2_deafult_cbc_legacy_cipher_only_use_psa () {
@@ -1357,11 +1363,15 @@ component_test_tls1_2_deafult_cbc_legacy_cipher_only_use_psa () {
     scripts/config.py unset MBEDTLS_CIPHER_NULL_CIPHER
     # Indirect dependencies
     scripts/config.py unset MBEDTLS_SSL_CONTEXT_SERIALIZATION
+    scripts/config.py unset MBEDTLS_SSL_SESSION_TICKETS
 
     make
 
     msg "test: default with only CBC-legacy cipher use psa"
     make test
+
+    msg "test: default with only CBC-legacy cipher use psa - ssl-opt.sh (subset)"
+    tests/ssl-opt.sh -f "TLS 1.2"
 }
 
 component_test_tls1_2_default_cbc_legacy_cbc_etm_cipher_only () {
@@ -1379,15 +1389,19 @@ component_test_tls1_2_default_cbc_legacy_cbc_etm_cipher_only () {
     scripts/config.py unset MBEDTLS_CIPHER_NULL_CIPHER
     # Indirect dependencies
     scripts/config.py unset MBEDTLS_SSL_CONTEXT_SERIALIZATION
+    scripts/config.py unset MBEDTLS_SSL_SESSION_TICKETS
 
     make
 
     msg "test: default with only CBC-legacy and CBC-EtM ciphers"
     make test
+
+    msg "test: default with only CBC-legacy and CBC-EtM ciphers - ssl-opt.sh (subset)"
+    tests/ssl-opt.sh -f "TLS 1.2"
 }
 
-component_test_tls1_2_full_cbc_legacy_cbc_etm_cipher_only_use_psa () {
-    msg "build: full with only CBC-legacy and CBC-EtM ciphers use psa"
+component_test_tls1_2_default_cbc_legacy_cbc_etm_cipher_only_use_psa () {
+    msg "build: default with only CBC-legacy and CBC-EtM ciphers use psa"
 
     scripts/config.py set MBEDTLS_USE_PSA_CRYPTO
     # Disable AEAD (controlled by the presence of one of GCM_C, CCM_C, CHACHAPOLY_C)
@@ -1402,11 +1416,15 @@ component_test_tls1_2_full_cbc_legacy_cbc_etm_cipher_only_use_psa () {
     scripts/config.py unset MBEDTLS_CIPHER_NULL_CIPHER
     # Indirect dependencies
     scripts/config.py unset MBEDTLS_SSL_CONTEXT_SERIALIZATION
+    scripts/config.py unset MBEDTLS_SSL_SESSION_TICKETS
 
     make
 
-    msg "test: full with only CBC-legacy and CBC-EtM ciphers use psa"
+    msg "test: default with only CBC-legacy and CBC-EtM ciphers use psa"
     make test
+
+    msg "test: default with only CBC-legacy and CBC-EtM ciphers use psa - ssl-opt.sh (subset)"
+    tests/ssl-opt.sh -f "TLS 1.2"
 }
 
 component_test_psa_external_rng_use_psa_crypto () {

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1341,6 +1341,75 @@ component_test_crypto_full_stream_cipher_only () {
     make test
 }
 
+component_test_crypto_default_cbc_legacy_cipher_only () {
+    msg "build: default with only CBC-legacy cipher"
+
+    # Disable all ciphers
+    # AEAD (controlled by the presence of one of GCM_C, CCM_C, CHACHAPOLY_C
+    scripts/config.py unset MBEDTLS_GCM_C
+    scripts/config.py unset MBEDTLS_CCM_C
+    scripts/config.py unset MBEDTLS_CHACHAPOLY_C
+    # CBC-legacy (controlled by MBEDTLS_CIPHER_MODE_CBC plus at least one block cipher (AES, ARIA, Camellia, DES))
+    scripts/config.py unset MBEDTLS_CIPHER_MODE_CBC
+    scripts/config.py unset MBEDTLS_AES_C
+    scripts/config.py unset MBEDTLS_CAMELLIA_C
+    scripts/config.py unset MBEDTLS_ARIA_C
+    scripts/config.py unset MBEDTLS_DES_C
+    # CBC-EtM (controlled by the same as CBC-legacy plus MBEDTLS_SSL_ENCRYPT_THEN_MAC)
+    scripts/config.py unset MBEDTLS_SSL_ENCRYPT_THEN_MAC
+    # stream (currently that's just the NULL pseudo-cipher (controlled by MBEDTLS_CIPHER_NULL_CIPHER)
+    scripts/config.py unset MBEDTLS_CIPHER_NULL_CIPHER
+    # Indirect dependencies
+    scripts/config.py unset MBEDTLS_CTR_DRBG_C
+    scripts/config.py unset MBEDTLS_CMAC_C
+    scripts/config.py unset MBEDTLS_NIST_KW_C
+    scripts/config.py unset MBEDTLS_SSL_SESSION_TICKETS
+    scripts/config.py unset MBEDTLS_SSL_CONTEXT_SERIALIZATION
+
+    # Enable CBC-legacy cipher only
+    scripts/config.py set MBEDTLS_CIPHER_MODE_CBC
+    scripts/config.py set MBEDTLS_AES_C
+    make
+
+    msg "test: default with only CBC-legacy cipher"
+    make test
+}
+
+component_test_crypto_full_cbc_legacy_cipher_only () {
+    msg "build: full with only CBC-legacy cipher"
+
+    scripts/config.py crypto_full
+    # Disable all ciphers
+    # AEAD (controlled by the presence of one of GCM_C, CCM_C, CHACHAPOLY_C
+    scripts/config.py unset MBEDTLS_GCM_C
+    scripts/config.py unset MBEDTLS_CCM_C
+    scripts/config.py unset MBEDTLS_CHACHAPOLY_C
+    # CBC-legacy (controlled by MBEDTLS_CIPHER_MODE_CBC plus at least one block cipher (AES, ARIA, Camellia, DES))
+    scripts/config.py unset MBEDTLS_CIPHER_MODE_CBC
+    scripts/config.py unset MBEDTLS_AES_C
+    scripts/config.py unset MBEDTLS_CAMELLIA_C
+    scripts/config.py unset MBEDTLS_ARIA_C
+    scripts/config.py unset MBEDTLS_DES_C
+    # CBC-EtM (controlled by the same as CBC-legacy plus MBEDTLS_SSL_ENCRYPT_THEN_MAC)
+    scripts/config.py unset MBEDTLS_SSL_ENCRYPT_THEN_MAC
+    # stream (currently that's just the NULL pseudo-cipher (controlled by MBEDTLS_CIPHER_NULL_CIPHER)
+    scripts/config.py unset MBEDTLS_CIPHER_NULL_CIPHER
+    # Indirect dependencies
+    scripts/config.py unset MBEDTLS_CTR_DRBG_C
+    scripts/config.py unset MBEDTLS_CMAC_C
+    scripts/config.py unset MBEDTLS_NIST_KW_C
+    scripts/config.py unset MBEDTLS_SSL_SESSION_TICKETS
+    scripts/config.py unset MBEDTLS_SSL_CONTEXT_SERIALIZATION
+
+    # Enable CBC-legacy cipher only
+    scripts/config.py set MBEDTLS_CIPHER_MODE_CBC
+    scripts/config.py set MBEDTLS_AES_C
+    make
+
+    msg "test: full with only CBC-legacy cipher"
+    make test
+}
+
 component_test_psa_external_rng_use_psa_crypto () {
     msg "build: full + PSA_CRYPTO_EXTERNAL_RNG + USE_PSA_CRYPTO minus CTR_DRBG"
     scripts/config.py full

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1287,7 +1287,7 @@ component_test_tls1_2_default_stream_cipher_only () {
     scripts/config.py unset MBEDTLS_SSL_ENCRYPT_THEN_MAC
     # Enable stream (currently that's just the NULL pseudo-cipher (controlled by MBEDTLS_CIPHER_NULL_CIPHER))
     scripts/config.py set MBEDTLS_CIPHER_NULL_CIPHER
-    # Indirect dependencies
+    # Modules that depend on AEAD
     scripts/config.py unset MBEDTLS_SSL_CONTEXT_SERIALIZATION
     scripts/config.py unset MBEDTLS_SSL_SESSION_TICKETS
 
@@ -1295,10 +1295,12 @@ component_test_tls1_2_default_stream_cipher_only () {
 
     msg "test: default with only stream cipher"
     make test
+
+    # Not running ssl-opt.sh because most tests require a non-NULL ciphersuite.
 }
 
 component_test_tls1_2_default_stream_cipher_only_use_psa () {
-    msg "build: deafult with only stream cipher use psa"
+    msg "build: default with only stream cipher use psa"
 
     scripts/config.py set MBEDTLS_USE_PSA_CRYPTO
     # Disable AEAD (controlled by the presence of one of GCM_C, CCM_C, CHACHAPOLY_C)
@@ -1311,14 +1313,16 @@ component_test_tls1_2_default_stream_cipher_only_use_psa () {
     scripts/config.py unset MBEDTLS_SSL_ENCRYPT_THEN_MAC
     # Enable stream (currently that's just the NULL pseudo-cipher (controlled by MBEDTLS_CIPHER_NULL_CIPHER))
     scripts/config.py set MBEDTLS_CIPHER_NULL_CIPHER
-    # Indirect dependencies
+    # Modules that depend on AEAD
     scripts/config.py unset MBEDTLS_SSL_CONTEXT_SERIALIZATION
     scripts/config.py unset MBEDTLS_SSL_SESSION_TICKETS
 
     make
 
-    msg "test: deafult with only stream cipher use psa"
+    msg "test: default with only stream cipher use psa"
     make test
+
+    # Not running ssl-opt.sh because most tests require a non-NULL ciphersuite.
 }
 
 component_test_tls1_2_default_cbc_legacy_cipher_only () {
@@ -1334,7 +1338,7 @@ component_test_tls1_2_default_cbc_legacy_cipher_only () {
     scripts/config.py unset MBEDTLS_SSL_ENCRYPT_THEN_MAC
     # Disable stream (currently that's just the NULL pseudo-cipher (controlled by MBEDTLS_CIPHER_NULL_CIPHER))
     scripts/config.py unset MBEDTLS_CIPHER_NULL_CIPHER
-    # Indirect dependencies
+    # Modules that depend on AEAD
     scripts/config.py unset MBEDTLS_SSL_CONTEXT_SERIALIZATION
     scripts/config.py unset MBEDTLS_SSL_SESSION_TICKETS
 
@@ -1361,7 +1365,7 @@ component_test_tls1_2_deafult_cbc_legacy_cipher_only_use_psa () {
     scripts/config.py unset MBEDTLS_SSL_ENCRYPT_THEN_MAC
     # Disable stream (currently that's just the NULL pseudo-cipher (controlled by MBEDTLS_CIPHER_NULL_CIPHER))
     scripts/config.py unset MBEDTLS_CIPHER_NULL_CIPHER
-    # Indirect dependencies
+    # Modules that depend on AEAD
     scripts/config.py unset MBEDTLS_SSL_CONTEXT_SERIALIZATION
     scripts/config.py unset MBEDTLS_SSL_SESSION_TICKETS
 
@@ -1387,7 +1391,7 @@ component_test_tls1_2_default_cbc_legacy_cbc_etm_cipher_only () {
     scripts/config.py set MBEDTLS_SSL_ENCRYPT_THEN_MAC
     # Disable stream (currently that's just the NULL pseudo-cipher (controlled by MBEDTLS_CIPHER_NULL_CIPHER))
     scripts/config.py unset MBEDTLS_CIPHER_NULL_CIPHER
-    # Indirect dependencies
+    # Modules that depend on AEAD
     scripts/config.py unset MBEDTLS_SSL_CONTEXT_SERIALIZATION
     scripts/config.py unset MBEDTLS_SSL_SESSION_TICKETS
 
@@ -1414,7 +1418,7 @@ component_test_tls1_2_default_cbc_legacy_cbc_etm_cipher_only_use_psa () {
     scripts/config.py set MBEDTLS_SSL_ENCRYPT_THEN_MAC
     # Disable stream (currently that's just the NULL pseudo-cipher (controlled by MBEDTLS_CIPHER_NULL_CIPHER))
     scripts/config.py unset MBEDTLS_CIPHER_NULL_CIPHER
-    # Indirect dependencies
+    # Modules that depend on AEAD
     scripts/config.py unset MBEDTLS_SSL_CONTEXT_SERIALIZATION
     scripts/config.py unset MBEDTLS_SSL_SESSION_TICKETS
 

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1274,24 +1274,19 @@ component_test_crypto_full_no_cipher () {
     make test
 }
 
-component_test_crypto_default_stream_cipher_only () {
+component_test_tls1_2_default_stream_cipher_only () {
     msg "build: default with only stream cipher"
 
-    # Disable all ciphers
-    # AEAD (controlled by the presence of one of GCM_C, CCM_C, CHACHAPOLY_C
+    # Disable AEAD (controlled by the presence of one of GCM_C, CCM_C, CHACHAPOLY_C
     scripts/config.py unset MBEDTLS_GCM_C
     scripts/config.py unset MBEDTLS_CCM_C
     scripts/config.py unset MBEDTLS_CHACHAPOLY_C
-    # CBC-legacy (controlled by MBEDTLS_CIPHER_MODE_CBC plus at least one block cipher (AES, ARIA, Camellia, DES))
+    # Disable CBC-legacy (controlled by MBEDTLS_CIPHER_MODE_CBC plus at least one block cipher (AES, ARIA, Camellia, DES))
     scripts/config.py unset MBEDTLS_CIPHER_MODE_CBC
-    scripts/config.py unset MBEDTLS_AES_C
-    scripts/config.py unset MBEDTLS_CAMELLIA_C
-    scripts/config.py unset MBEDTLS_ARIA_C
-    scripts/config.py unset MBEDTLS_DES_C
-    # CBC-EtM (controlled by the same as CBC-legacy plus MBEDTLS_SSL_ENCRYPT_THEN_MAC)
+    # Disable CBC-EtM (controlled by the same as CBC-legacy plus MBEDTLS_SSL_ENCRYPT_THEN_MAC)
     scripts/config.py unset MBEDTLS_SSL_ENCRYPT_THEN_MAC
-    # stream (currently that's just the NULL pseudo-cipher (controlled by MBEDTLS_CIPHER_NULL_CIPHER)
-    scripts/config.py unset MBEDTLS_CIPHER_NULL_CIPHER
+    # Enable stream (currently that's just the NULL pseudo-cipher (controlled by MBEDTLS_CIPHER_NULL_CIPHER))
+    scripts/config.py set MBEDTLS_CIPHER_NULL_CIPHER
     # Indirect dependencies
     scripts/config.py unset MBEDTLS_CTR_DRBG_C
     scripts/config.py unset MBEDTLS_CMAC_C
@@ -1299,33 +1294,26 @@ component_test_crypto_default_stream_cipher_only () {
     scripts/config.py unset MBEDTLS_SSL_SESSION_TICKETS
     scripts/config.py unset MBEDTLS_SSL_CONTEXT_SERIALIZATION
 
-    # Enable stream(null) cipher only
-    scripts/config.py set MBEDTLS_CIPHER_NULL_CIPHER
     make
 
     msg "test: default with only stream cipher"
     make test
 }
 
-component_test_crypto_default_stream_cipher_only_use_psa () {
+component_test_tls1_2_default_stream_cipher_only_use_psa () {
     msg "build: deafult with only stream cipher use psa"
 
     scripts/config.py set MBEDTLS_USE_PSA_CRYPTO
-    # Disable all ciphers
-    # AEAD (controlled by the presence of one of GCM_C, CCM_C, CHACHAPOLY_C
+    # Disable AEAD (controlled by the presence of one of GCM_C, CCM_C, CHACHAPOLY_C)
     scripts/config.py unset MBEDTLS_GCM_C
     scripts/config.py unset MBEDTLS_CCM_C
     scripts/config.py unset MBEDTLS_CHACHAPOLY_C
-    # CBC-legacy (controlled by MBEDTLS_CIPHER_MODE_CBC plus at least one block cipher (AES, ARIA, Camellia, DES))
+    # Disable CBC-legacy (controlled by MBEDTLS_CIPHER_MODE_CBC plus at least one block cipher (AES, ARIA, Camellia, DES))
     scripts/config.py unset MBEDTLS_CIPHER_MODE_CBC
-    scripts/config.py unset MBEDTLS_AES_C
-    scripts/config.py unset MBEDTLS_CAMELLIA_C
-    scripts/config.py unset MBEDTLS_ARIA_C
-    scripts/config.py unset MBEDTLS_DES_C
-    # CBC-EtM (controlled by the same as CBC-legacy plus MBEDTLS_SSL_ENCRYPT_THEN_MAC)
+    # Disable CBC-EtM (controlled by the same as CBC-legacy plus MBEDTLS_SSL_ENCRYPT_THEN_MAC)
     scripts/config.py unset MBEDTLS_SSL_ENCRYPT_THEN_MAC
-    # stream (currently that's just the NULL pseudo-cipher (controlled by MBEDTLS_CIPHER_NULL_CIPHER)
-    scripts/config.py unset MBEDTLS_CIPHER_NULL_CIPHER
+    # Enable stream (currently that's just the NULL pseudo-cipher (controlled by MBEDTLS_CIPHER_NULL_CIPHER))
+    scripts/config.py set MBEDTLS_CIPHER_NULL_CIPHER
     # Indirect dependencies
     scripts/config.py unset MBEDTLS_CTR_DRBG_C
     scripts/config.py unset MBEDTLS_CMAC_C
@@ -1333,31 +1321,24 @@ component_test_crypto_default_stream_cipher_only_use_psa () {
     scripts/config.py unset MBEDTLS_SSL_SESSION_TICKETS
     scripts/config.py unset MBEDTLS_SSL_CONTEXT_SERIALIZATION
 
-    # Enable stream(null) cipher only
-    scripts/config.py set MBEDTLS_CIPHER_NULL_CIPHER
     make
 
     msg "test: deafult with only stream cipher use psa"
     make test
 }
 
-component_test_crypto_default_cbc_legacy_cipher_only () {
+component_test_tls1_2_default_cbc_legacy_cipher_only () {
     msg "build: default with only CBC-legacy cipher"
 
-    # Disable all ciphers
-    # AEAD (controlled by the presence of one of GCM_C, CCM_C, CHACHAPOLY_C
+    # Disable AEAD (controlled by the presence of one of GCM_C, CCM_C, CHACHAPOLY_C)
     scripts/config.py unset MBEDTLS_GCM_C
     scripts/config.py unset MBEDTLS_CCM_C
     scripts/config.py unset MBEDTLS_CHACHAPOLY_C
-    # CBC-legacy (controlled by MBEDTLS_CIPHER_MODE_CBC plus at least one block cipher (AES, ARIA, Camellia, DES))
-    scripts/config.py unset MBEDTLS_CIPHER_MODE_CBC
-    scripts/config.py unset MBEDTLS_AES_C
-    scripts/config.py unset MBEDTLS_CAMELLIA_C
-    scripts/config.py unset MBEDTLS_ARIA_C
-    scripts/config.py unset MBEDTLS_DES_C
-    # CBC-EtM (controlled by the same as CBC-legacy plus MBEDTLS_SSL_ENCRYPT_THEN_MAC)
+    # Enable CBC-legacy (controlled by MBEDTLS_CIPHER_MODE_CBC plus at least one block cipher (AES, ARIA, Camellia, DES))
+    scripts/config.py set MBEDTLS_CIPHER_MODE_CBC
+    # Disable CBC-EtM (controlled by the same as CBC-legacy plus MBEDTLS_SSL_ENCRYPT_THEN_MAC)
     scripts/config.py unset MBEDTLS_SSL_ENCRYPT_THEN_MAC
-    # stream (currently that's just the NULL pseudo-cipher (controlled by MBEDTLS_CIPHER_NULL_CIPHER)
+    # Disable stream (currently that's just the NULL pseudo-cipher (controlled by MBEDTLS_CIPHER_NULL_CIPHER))
     scripts/config.py unset MBEDTLS_CIPHER_NULL_CIPHER
     # Indirect dependencies
     scripts/config.py unset MBEDTLS_CTR_DRBG_C
@@ -1366,33 +1347,25 @@ component_test_crypto_default_cbc_legacy_cipher_only () {
     scripts/config.py unset MBEDTLS_SSL_SESSION_TICKETS
     scripts/config.py unset MBEDTLS_SSL_CONTEXT_SERIALIZATION
 
-    # Enable CBC-legacy cipher only
-    scripts/config.py set MBEDTLS_CIPHER_MODE_CBC
-    scripts/config.py set MBEDTLS_AES_C
     make
 
     msg "test: default with only CBC-legacy cipher"
     make test
 }
 
-component_test_crypto_deafult_cbc_legacy_cipher_only_use_psa () {
+component_test_tls1_2_deafult_cbc_legacy_cipher_only_use_psa () {
     msg "build: default with only CBC-legacy cipher use psa"
 
     scripts/config.py set MBEDTLS_USE_PSA_CRYPTO
-    # Disable all ciphers
-    # AEAD (controlled by the presence of one of GCM_C, CCM_C, CHACHAPOLY_C
+    # Disable AEAD (controlled by the presence of one of GCM_C, CCM_C, CHACHAPOLY_C)
     scripts/config.py unset MBEDTLS_GCM_C
     scripts/config.py unset MBEDTLS_CCM_C
     scripts/config.py unset MBEDTLS_CHACHAPOLY_C
-    # CBC-legacy (controlled by MBEDTLS_CIPHER_MODE_CBC plus at least one block cipher (AES, ARIA, Camellia, DES))
-    scripts/config.py unset MBEDTLS_CIPHER_MODE_CBC
-    scripts/config.py unset MBEDTLS_AES_C
-    scripts/config.py unset MBEDTLS_CAMELLIA_C
-    scripts/config.py unset MBEDTLS_ARIA_C
-    scripts/config.py unset MBEDTLS_DES_C
-    # CBC-EtM (controlled by the same as CBC-legacy plus MBEDTLS_SSL_ENCRYPT_THEN_MAC)
+    # Enable CBC-legacy (controlled by MBEDTLS_CIPHER_MODE_CBC plus at least one block cipher (AES, ARIA, Camellia, DES))
+    scripts/config.py set MBEDTLS_CIPHER_MODE_CBC
+    # Disable CBC-EtM (controlled by the same as CBC-legacy plus MBEDTLS_SSL_ENCRYPT_THEN_MAC)
     scripts/config.py unset MBEDTLS_SSL_ENCRYPT_THEN_MAC
-    # stream (currently that's just the NULL pseudo-cipher (controlled by MBEDTLS_CIPHER_NULL_CIPHER)
+    # Disable stream (currently that's just the NULL pseudo-cipher (controlled by MBEDTLS_CIPHER_NULL_CIPHER))
     scripts/config.py unset MBEDTLS_CIPHER_NULL_CIPHER
     # Indirect dependencies
     scripts/config.py unset MBEDTLS_CTR_DRBG_C
@@ -1401,32 +1374,24 @@ component_test_crypto_deafult_cbc_legacy_cipher_only_use_psa () {
     scripts/config.py unset MBEDTLS_SSL_SESSION_TICKETS
     scripts/config.py unset MBEDTLS_SSL_CONTEXT_SERIALIZATION
 
-    # Enable CBC-legacy cipher only
-    scripts/config.py set MBEDTLS_CIPHER_MODE_CBC
-    scripts/config.py set MBEDTLS_AES_C
     make
 
     msg "test: default with only CBC-legacy cipher use psa"
     make test
 }
 
-component_test_crypto_default_cbc_legacy_cbc_etm_cipher_only () {
+component_test_tls1_2_default_cbc_legacy_cbc_etm_cipher_only () {
     msg "build: default with only CBC-legacy and CBC-EtM ciphers"
 
-    # Disable all ciphers
-    # AEAD (controlled by the presence of one of GCM_C, CCM_C, CHACHAPOLY_C
+    # Disable AEAD (controlled by the presence of one of GCM_C, CCM_C, CHACHAPOLY_C)
     scripts/config.py unset MBEDTLS_GCM_C
     scripts/config.py unset MBEDTLS_CCM_C
     scripts/config.py unset MBEDTLS_CHACHAPOLY_C
-    # CBC-legacy (controlled by MBEDTLS_CIPHER_MODE_CBC plus at least one block cipher (AES, ARIA, Camellia, DES))
-    scripts/config.py unset MBEDTLS_CIPHER_MODE_CBC
-    scripts/config.py unset MBEDTLS_AES_C
-    scripts/config.py unset MBEDTLS_CAMELLIA_C
-    scripts/config.py unset MBEDTLS_ARIA_C
-    scripts/config.py unset MBEDTLS_DES_C
-    # CBC-EtM (controlled by the same as CBC-legacy plus MBEDTLS_SSL_ENCRYPT_THEN_MAC)
-    scripts/config.py unset MBEDTLS_SSL_ENCRYPT_THEN_MAC
-    # stream (currently that's just the NULL pseudo-cipher (controlled by MBEDTLS_CIPHER_NULL_CIPHER)
+    # Enable CBC-legacy (controlled by MBEDTLS_CIPHER_MODE_CBC plus at least one block cipher (AES, ARIA, Camellia, DES))
+    scripts/config.py set MBEDTLS_CIPHER_MODE_CBC
+    # Enable CBC-EtM (controlled by the same as CBC-legacy plus MBEDTLS_SSL_ENCRYPT_THEN_MAC)
+    scripts/config.py set MBEDTLS_SSL_ENCRYPT_THEN_MAC
+    # Disable stream (currently that's just the NULL pseudo-cipher (controlled by MBEDTLS_CIPHER_NULL_CIPHER))
     scripts/config.py unset MBEDTLS_CIPHER_NULL_CIPHER
     # Indirect dependencies
     scripts/config.py unset MBEDTLS_CTR_DRBG_C
@@ -1434,11 +1399,6 @@ component_test_crypto_default_cbc_legacy_cbc_etm_cipher_only () {
     scripts/config.py unset MBEDTLS_NIST_KW_C
     scripts/config.py unset MBEDTLS_SSL_SESSION_TICKETS
     scripts/config.py unset MBEDTLS_SSL_CONTEXT_SERIALIZATION
-
-    # Enable CBC-legacy cipher only
-    scripts/config.py set MBEDTLS_CIPHER_MODE_CBC
-    scripts/config.py set MBEDTLS_AES_C
-    scripts/config.py set MBEDTLS_SSL_ENCRYPT_THEN_MAC
 
     make
 
@@ -1446,24 +1406,19 @@ component_test_crypto_default_cbc_legacy_cbc_etm_cipher_only () {
     make test
 }
 
-component_test_crypto_full_cbc_legacy_cbc_etm_cipher_only_use_psa () {
+component_test_tls1_2_full_cbc_legacy_cbc_etm_cipher_only_use_psa () {
     msg "build: full with only CBC-legacy and CBC-EtM ciphers use psa"
 
     scripts/config.py set MBEDTLS_USE_PSA_CRYPTO
-    # Disable all ciphers
-    # AEAD (controlled by the presence of one of GCM_C, CCM_C, CHACHAPOLY_C
+    # Disable AEAD (controlled by the presence of one of GCM_C, CCM_C, CHACHAPOLY_C)
     scripts/config.py unset MBEDTLS_GCM_C
     scripts/config.py unset MBEDTLS_CCM_C
     scripts/config.py unset MBEDTLS_CHACHAPOLY_C
-    # CBC-legacy (controlled by MBEDTLS_CIPHER_MODE_CBC plus at least one block cipher (AES, ARIA, Camellia, DES))
-    scripts/config.py unset MBEDTLS_CIPHER_MODE_CBC
-    scripts/config.py unset MBEDTLS_AES_C
-    scripts/config.py unset MBEDTLS_CAMELLIA_C
-    scripts/config.py unset MBEDTLS_ARIA_C
-    scripts/config.py unset MBEDTLS_DES_C
-    # CBC-EtM (controlled by the same as CBC-legacy plus MBEDTLS_SSL_ENCRYPT_THEN_MAC)
-    scripts/config.py unset MBEDTLS_SSL_ENCRYPT_THEN_MAC
-    # stream (currently that's just the NULL pseudo-cipher (controlled by MBEDTLS_CIPHER_NULL_CIPHER)
+    # Enable CBC-legacy (controlled by MBEDTLS_CIPHER_MODE_CBC plus at least one block cipher (AES, ARIA, Camellia, DES))
+    scripts/config.py set MBEDTLS_CIPHER_MODE_CBC
+    # Enable CBC-EtM (controlled by the same as CBC-legacy plus MBEDTLS_SSL_ENCRYPT_THEN_MAC)
+    scripts/config.py set MBEDTLS_SSL_ENCRYPT_THEN_MAC
+    # Disable stream (currently that's just the NULL pseudo-cipher (controlled by MBEDTLS_CIPHER_NULL_CIPHER))
     scripts/config.py unset MBEDTLS_CIPHER_NULL_CIPHER
     # Indirect dependencies
     scripts/config.py unset MBEDTLS_CTR_DRBG_C
@@ -1471,11 +1426,6 @@ component_test_crypto_full_cbc_legacy_cbc_etm_cipher_only_use_psa () {
     scripts/config.py unset MBEDTLS_NIST_KW_C
     scripts/config.py unset MBEDTLS_SSL_SESSION_TICKETS
     scripts/config.py unset MBEDTLS_SSL_CONTEXT_SERIALIZATION
-
-    # Enable CBC-legacy cipher only
-    scripts/config.py set MBEDTLS_CIPHER_MODE_CBC
-    scripts/config.py set MBEDTLS_AES_C
-    scripts/config.py set MBEDTLS_SSL_ENCRYPT_THEN_MAC
 
     make
 

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1289,7 +1289,7 @@ component_test_tls1_2_default_stream_cipher_only () {
     scripts/config.py set MBEDTLS_CIPHER_NULL_CIPHER
     # Modules that depend on AEAD
     scripts/config.py unset MBEDTLS_SSL_CONTEXT_SERIALIZATION
-    scripts/config.py unset MBEDTLS_SSL_SESSION_TICKETS
+    scripts/config.py unset MBEDTLS_SSL_TICKET_C
 
     make
 
@@ -1315,7 +1315,7 @@ component_test_tls1_2_default_stream_cipher_only_use_psa () {
     scripts/config.py set MBEDTLS_CIPHER_NULL_CIPHER
     # Modules that depend on AEAD
     scripts/config.py unset MBEDTLS_SSL_CONTEXT_SERIALIZATION
-    scripts/config.py unset MBEDTLS_SSL_SESSION_TICKETS
+    scripts/config.py unset MBEDTLS_SSL_TICKET_C
 
     make
 
@@ -1340,7 +1340,7 @@ component_test_tls1_2_default_cbc_legacy_cipher_only () {
     scripts/config.py unset MBEDTLS_CIPHER_NULL_CIPHER
     # Modules that depend on AEAD
     scripts/config.py unset MBEDTLS_SSL_CONTEXT_SERIALIZATION
-    scripts/config.py unset MBEDTLS_SSL_SESSION_TICKETS
+    scripts/config.py unset MBEDTLS_SSL_TICKET_C
 
     make
 
@@ -1367,7 +1367,7 @@ component_test_tls1_2_deafult_cbc_legacy_cipher_only_use_psa () {
     scripts/config.py unset MBEDTLS_CIPHER_NULL_CIPHER
     # Modules that depend on AEAD
     scripts/config.py unset MBEDTLS_SSL_CONTEXT_SERIALIZATION
-    scripts/config.py unset MBEDTLS_SSL_SESSION_TICKETS
+    scripts/config.py unset MBEDTLS_SSL_TICKET_C
 
     make
 
@@ -1393,7 +1393,7 @@ component_test_tls1_2_default_cbc_legacy_cbc_etm_cipher_only () {
     scripts/config.py unset MBEDTLS_CIPHER_NULL_CIPHER
     # Modules that depend on AEAD
     scripts/config.py unset MBEDTLS_SSL_CONTEXT_SERIALIZATION
-    scripts/config.py unset MBEDTLS_SSL_SESSION_TICKETS
+    scripts/config.py unset MBEDTLS_SSL_TICKET_C
 
     make
 
@@ -1420,7 +1420,7 @@ component_test_tls1_2_default_cbc_legacy_cbc_etm_cipher_only_use_psa () {
     scripts/config.py unset MBEDTLS_CIPHER_NULL_CIPHER
     # Modules that depend on AEAD
     scripts/config.py unset MBEDTLS_SSL_CONTEXT_SERIALIZATION
-    scripts/config.py unset MBEDTLS_SSL_SESSION_TICKETS
+    scripts/config.py unset MBEDTLS_SSL_TICKET_C
 
     make
 

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1296,6 +1296,7 @@ component_test_crypto_default_stream_cipher_only () {
     scripts/config.py unset MBEDTLS_CTR_DRBG_C
     scripts/config.py unset MBEDTLS_CMAC_C
     scripts/config.py unset MBEDTLS_NIST_KW_C
+    scripts/config.py unset MBEDTLS_SSL_SESSION_TICKETS
 
     # Enable stream(null) cipher only
     scripts/config.py set MBEDTLS_CIPHER_NULL_CIPHER

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1274,6 +1274,38 @@ component_test_crypto_full_no_cipher () {
     make test
 }
 
+component_test_crypto_default_stream_cipher_only () {
+    msg "build: default with only stream cipher"
+
+    # Disable all ciphers
+    # AEAD (controlled by the presence of one of GCM_C, CCM_C, CHACHAPOLY_C
+    scripts/config.py unset MBEDTLS_GCM_C
+    scripts/config.py unset MBEDTLS_CCM_C
+    scripts/config.py unset MBEDTLS_CHACHAPOLY_C
+    # CBC-legacy (controlled by MBEDTLS_CIPHER_MODE_CBC plus at least one block cipher (AES, ARIA, Camellia, DES))
+    scripts/config.py unset MBEDTLS_CIPHER_MODE_CBC
+    scripts/config.py unset MBEDTLS_AES_C
+    scripts/config.py unset MBEDTLS_CAMELLIA_C
+    scripts/config.py unset MBEDTLS_ARIA_C
+    scripts/config.py unset MBEDTLS_DES_C
+    # CBC-EtM (controlled by the same as CBC-legacy plus MBEDTLS_SSL_ENCRYPT_THEN_MAC)
+    scripts/config.py unset MBEDTLS_SSL_ENCRYPT_THEN_MAC
+    # stream (currently that's just the NULL pseudo-cipher (controlled by MBEDTLS_CIPHER_NULL_CIPHER)
+    scripts/config.py unset MBEDTLS_CIPHER_NULL_CIPHER
+    # Indirect dependencies
+    scripts/config.py unset MBEDTLS_CTR_DRBG_C
+    scripts/config.py unset MBEDTLS_CMAC_C
+    scripts/config.py unset MBEDTLS_NIST_KW_C
+
+    # Enable stream(null) cipher only
+    scripts/config.py set MBEDTLS_CIPHER_NULL_CIPHER
+    make
+
+    msg "test: default with only stream cipher"
+    make test
+}
+
+
 component_test_psa_external_rng_use_psa_crypto () {
     msg "build: full + PSA_CRYPTO_EXTERNAL_RNG + USE_PSA_CRYPTO minus CTR_DRBG"
     scripts/config.py full

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1277,6 +1277,7 @@ component_test_crypto_full_no_cipher () {
 component_test_crypto_default_stream_cipher_only () {
     msg "build: default with only stream cipher"
 
+    scripts/config.py crypto_full
     # Disable all ciphers
     # AEAD (controlled by the presence of one of GCM_C, CCM_C, CHACHAPOLY_C
     scripts/config.py unset MBEDTLS_GCM_C
@@ -1307,6 +1308,38 @@ component_test_crypto_default_stream_cipher_only () {
     make test
 }
 
+component_test_crypto_full_stream_cipher_only () {
+    msg "build: full with only stream cipher"
+
+    # Disable all ciphers
+    # AEAD (controlled by the presence of one of GCM_C, CCM_C, CHACHAPOLY_C
+    scripts/config.py unset MBEDTLS_GCM_C
+    scripts/config.py unset MBEDTLS_CCM_C
+    scripts/config.py unset MBEDTLS_CHACHAPOLY_C
+    # CBC-legacy (controlled by MBEDTLS_CIPHER_MODE_CBC plus at least one block cipher (AES, ARIA, Camellia, DES))
+    scripts/config.py unset MBEDTLS_CIPHER_MODE_CBC
+    scripts/config.py unset MBEDTLS_AES_C
+    scripts/config.py unset MBEDTLS_CAMELLIA_C
+    scripts/config.py unset MBEDTLS_ARIA_C
+    scripts/config.py unset MBEDTLS_DES_C
+    # CBC-EtM (controlled by the same as CBC-legacy plus MBEDTLS_SSL_ENCRYPT_THEN_MAC)
+    scripts/config.py unset MBEDTLS_SSL_ENCRYPT_THEN_MAC
+    # stream (currently that's just the NULL pseudo-cipher (controlled by MBEDTLS_CIPHER_NULL_CIPHER)
+    scripts/config.py unset MBEDTLS_CIPHER_NULL_CIPHER
+    # Indirect dependencies
+    scripts/config.py unset MBEDTLS_CTR_DRBG_C
+    scripts/config.py unset MBEDTLS_CMAC_C
+    scripts/config.py unset MBEDTLS_NIST_KW_C
+    scripts/config.py unset MBEDTLS_SSL_SESSION_TICKETS
+    scripts/config.py unset MBEDTLS_SSL_CONTEXT_SERIALIZATION
+
+    # Enable stream(null) cipher only
+    scripts/config.py set MBEDTLS_CIPHER_NULL_CIPHER
+    make
+
+    msg "test: full with only stream cipher"
+    make test
+}
 
 component_test_psa_external_rng_use_psa_crypto () {
     msg "build: full + PSA_CRYPTO_EXTERNAL_RNG + USE_PSA_CRYPTO minus CTR_DRBG"

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1297,6 +1297,7 @@ component_test_crypto_default_stream_cipher_only () {
     scripts/config.py unset MBEDTLS_CMAC_C
     scripts/config.py unset MBEDTLS_NIST_KW_C
     scripts/config.py unset MBEDTLS_SSL_SESSION_TICKETS
+    scripts/config.py unset MBEDTLS_SSL_CONTEXT_SERIALIZATION
 
     # Enable stream(null) cipher only
     scripts/config.py set MBEDTLS_CIPHER_NULL_CIPHER

--- a/tests/suites/test_suite_cipher.function
+++ b/tests/suites/test_suite_cipher.function
@@ -1,9 +1,6 @@
 /* BEGIN_HEADER */
 #include "mbedtls/cipher.h"
-
-#if defined(MBEDTLS_AES_C)
 #include "mbedtls/aes.h"
-#endif
 
 #if defined(MBEDTLS_GCM_C)
 #include "mbedtls/gcm.h"

--- a/tests/suites/test_suite_cmac.data
+++ b/tests/suites/test_suite_cmac.data
@@ -22,15 +22,15 @@ mbedtls_cmac_setkey:MBEDTLS_CIPHER_DES_EDE3_ECB:192:0
 
 CMAC init #5 AES-224: bad key size
 depends_on:MBEDTLS_AES_C
-mbedtls_cmac_setkey:MBEDTLS_CIPHER_ID_AES:224:MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA
+mbedtls_cmac_setkey:MBEDTLS_CIPHER_AES_128_ECB:224:MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA
 
 CMAC init #6 AES-0: bad key size
 depends_on:MBEDTLS_AES_C
-mbedtls_cmac_setkey:MBEDTLS_CIPHER_ID_AES:0:MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA
+mbedtls_cmac_setkey:MBEDTLS_CIPHER_AES_128_ECB:0:MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA
 
 CMAC init #7 Camellia: wrong cipher
 depends_on:MBEDTLS_CAMELLIA_C
-mbedtls_cmac_setkey:MBEDTLS_CIPHER_ID_CAMELLIA:128:MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA
+mbedtls_cmac_setkey:MBEDTLS_CIPHER_CAMELLIA_192_ECB:128:MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA
 
 CMAC Single Blocks #1 - Empty block, no updates
 mbedtls_cmac_multiple_blocks:MBEDTLS_CIPHER_AES_128_ECB:"2b7e151628aed2a6abf7158809cf4f3c":128:16:"":-1:"":-1:"":-1:"":-1:"bb1d6929e95937287fa37d129b756746"


### PR DESCRIPTION
## Description
Resolves https://github.com/Mbed-TLS/mbedtls/issues/6313


## Status
**READY**

## Requires Backporting
Yes/2.28
https://github.com/Mbed-TLS/mbedtls/pull/6394

## Migrations
NO

## Additional comments
Any additional information that could be of interest

## Todos
- [X] null cipher
- [X] only CBC-legacy (no EtM)
- [X] only CBC-legacy and CBC-EtM
