### PR TITLE
mbedtls: fix possible false success in mbedtls_cipher_check_tag()

### DIFF
--- a/ChangeLog.d/fix-possible-false-success-in-mbedtls_cipher_check_tag.txt
+++ b/ChangeLog.d/fix-possible-false-success-in-mbedtls_cipher_check_tag.txt
@@ -1,0 +1,4 @@
+Changes
+   * Calling AEAD tag-specific functions for non-AEAD algorithms (which should not
+     be done - they are documented for use only by AES-GCM and ChaCha20+Poly1305)
+     now returns MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE instead of success (0).

--- a/ChangeLog.d/fix-possible-false-success-in-mbedtls_cipher_check_tag.txt
+++ b/ChangeLog.d/fix-possible-false-success-in-mbedtls_cipher_check_tag.txt
@@ -1,4 +1,5 @@
 Changes
-   * Calling AEAD tag-specific functions for non-AEAD algorithms (which should not
-     be done - they are documented for use only by AES-GCM and ChaCha20+Poly1305)
-     now returns MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE instead of success (0).
+   * Calling AEAD tag-specific functions for non-AEAD algorithms (which
+     should not be done - they are documented for use only by AES-GCM and
+     ChaCha20+Poly1305) now returns MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE
+     instead of success (0).

--- a/library/cipher.c
+++ b/library/cipher.c
@@ -505,7 +505,7 @@ int mbedtls_cipher_update_ad( mbedtls_cipher_context_t *ctx,
     }
 #endif
 
-    return( 0 );
+    return( MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE );
 }
 #endif /* MBEDTLS_GCM_C || MBEDTLS_CHACHAPOLY_C */
 
@@ -1134,7 +1134,7 @@ int mbedtls_cipher_write_tag( mbedtls_cipher_context_t *ctx,
     }
 #endif
 
-    return( 0 );
+    return( MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE );
 }
 
 int mbedtls_cipher_check_tag( mbedtls_cipher_context_t *ctx,
@@ -1161,11 +1161,8 @@ int mbedtls_cipher_check_tag( mbedtls_cipher_context_t *ctx,
     }
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
-    /* Status to return on a non-authenticated algorithm. It would make sense
-     * to return MBEDTLS_ERR_CIPHER_INVALID_CONTEXT or perhaps
-     * MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA, but at the time I write this our
-     * unit tests assume 0. */
-    ret = 0;
+    /* Status to return on a non-authenticated algorithm. */
+    ret = MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE;
 
 #if defined(MBEDTLS_GCM_C)
     if( MBEDTLS_MODE_GCM == ctx->cipher_info->mode )

--- a/tests/suites/test_suite_cipher.function
+++ b/tests/suites/test_suite_cipher.function
@@ -454,7 +454,7 @@ void enc_dec_buf( int cipher_id, char * cipher_string, int key_len,
 
 #if defined(MBEDTLS_GCM_C) || defined(MBEDTLS_CHACHAPOLY_C)
     int expected = ( cipher_info->mode == MBEDTLS_MODE_GCM ||
-                     cipher_info->mode == MBEDTLS_CIPHER_CHACHA20_POLY1305 ) ?
+                     cipher_info->type == MBEDTLS_CIPHER_CHACHA20_POLY1305 ) ?
                    0 : MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE;
 
     TEST_EQUAL( expected, mbedtls_cipher_update_ad( &ctx_dec, ad, sizeof(ad) - i ) );
@@ -555,7 +555,7 @@ void enc_fail( int cipher_id, int pad_mode, int key_len, int length_val,
     TEST_ASSERT( 0 == mbedtls_cipher_reset( &ctx ) );
 #if defined(MBEDTLS_GCM_C) || defined(MBEDTLS_CHACHAPOLY_C)
     int expected = ( cipher_info->mode == MBEDTLS_MODE_GCM ||
-                     cipher_info->mode == MBEDTLS_CIPHER_CHACHA20_POLY1305 ) ?
+                     cipher_info->type == MBEDTLS_CIPHER_CHACHA20_POLY1305 ) ?
                    0 : MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE;
 
     TEST_EQUAL( expected, mbedtls_cipher_update_ad( &ctx, NULL, 0 ) );
@@ -621,7 +621,7 @@ void dec_empty_buf( int cipher,
 
 #if defined(MBEDTLS_GCM_C) || defined(MBEDTLS_CHACHAPOLY_C)
     int expected = ( cipher_info->mode == MBEDTLS_MODE_GCM ||
-                     cipher_info->mode == MBEDTLS_CIPHER_CHACHA20_POLY1305 ) ?
+                     cipher_info->type == MBEDTLS_CIPHER_CHACHA20_POLY1305 ) ?
                    0 : MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE;
 
     TEST_EQUAL( expected, mbedtls_cipher_update_ad( &ctx_dec, NULL, 0 ) );
@@ -726,7 +726,7 @@ void enc_dec_buf_multipart( int cipher_id, int key_len, int first_length_val,
 
 #if defined(MBEDTLS_GCM_C) || defined(MBEDTLS_CHACHAPOLY_C)
     int expected = ( cipher_info->mode == MBEDTLS_MODE_GCM ||
-                     cipher_info->mode == MBEDTLS_CIPHER_CHACHA20_POLY1305 ) ?
+                     cipher_info->type == MBEDTLS_CIPHER_CHACHA20_POLY1305 ) ?
                    0 : MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE;
 
     TEST_EQUAL( expected, mbedtls_cipher_update_ad( &ctx_dec, NULL, 0 ) );
@@ -815,7 +815,7 @@ void decrypt_test_vec( int cipher_id, int pad_mode, data_t * key,
     TEST_ASSERT( 0 == mbedtls_cipher_reset( &ctx ) );
 #if defined(MBEDTLS_GCM_C) || defined(MBEDTLS_CHACHAPOLY_C)
     int expected = ( ctx.cipher_info->mode == MBEDTLS_MODE_GCM ||
-                     ctx.cipher_info->mode == MBEDTLS_CIPHER_CHACHA20_POLY1305 ) ?
+                     ctx.cipher_info->type == MBEDTLS_CIPHER_CHACHA20_POLY1305 ) ?
                    0 : MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE;
 
     TEST_EQUAL( expected, mbedtls_cipher_update_ad( &ctx, ad->x, ad->len ) );
@@ -830,7 +830,7 @@ void decrypt_test_vec( int cipher_id, int pad_mode, data_t * key,
     total_len += outlen;
 #if defined(MBEDTLS_GCM_C) || defined(MBEDTLS_CHACHAPOLY_C)
     int tag_expected = ( ctx.cipher_info->mode == MBEDTLS_MODE_GCM ||
-                         ctx.cipher_info->mode == MBEDTLS_CIPHER_CHACHA20_POLY1305 ) ?
+                         ctx.cipher_info->type == MBEDTLS_CIPHER_CHACHA20_POLY1305 ) ?
                        tag_result : MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE;
 
     TEST_EQUAL( tag_expected, mbedtls_cipher_check_tag( &ctx, tag->x, tag->len ) );

--- a/tests/suites/test_suite_cipher.function
+++ b/tests/suites/test_suite_cipher.function
@@ -453,8 +453,12 @@ void enc_dec_buf( int cipher_id, char * cipher_string, int key_len,
     TEST_ASSERT( 0 == mbedtls_cipher_reset( &ctx_enc ) );
 
 #if defined(MBEDTLS_GCM_C) || defined(MBEDTLS_CHACHAPOLY_C)
-    TEST_ASSERT( 0 == mbedtls_cipher_update_ad( &ctx_dec, ad, sizeof( ad ) - i ) );
-    TEST_ASSERT( 0 == mbedtls_cipher_update_ad( &ctx_enc, ad, sizeof( ad ) - i ) );
+    int expected = ( cipher_info->mode == MBEDTLS_MODE_GCM ||
+                     cipher_info->mode == MBEDTLS_CIPHER_CHACHA20_POLY1305 ) ?
+                   0 : MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE;
+
+    TEST_EQUAL( expected, mbedtls_cipher_update_ad( &ctx_dec, ad, sizeof(ad) - i ) );
+    TEST_EQUAL( expected, mbedtls_cipher_update_ad( &ctx_enc, ad, sizeof(ad) - i ) );
 #endif
 
     block_size = mbedtls_cipher_get_block_size( &ctx_enc );
@@ -473,7 +477,7 @@ void enc_dec_buf( int cipher_id, char * cipher_string, int key_len,
     total_len += outlen;
 
 #if defined(MBEDTLS_GCM_C) || defined(MBEDTLS_CHACHAPOLY_C)
-    TEST_ASSERT( 0 == mbedtls_cipher_write_tag( &ctx_enc, tag, sizeof( tag ) ) );
+    TEST_EQUAL( expected, mbedtls_cipher_write_tag( &ctx_enc, tag, sizeof(tag) ) );
 #endif
 
     TEST_ASSERT( total_len == length ||
@@ -494,7 +498,7 @@ void enc_dec_buf( int cipher_id, char * cipher_string, int key_len,
     total_len += outlen;
 
 #if defined(MBEDTLS_GCM_C) || defined(MBEDTLS_CHACHAPOLY_C)
-    TEST_ASSERT( 0 == mbedtls_cipher_check_tag( &ctx_dec, tag, sizeof( tag ) ) );
+    TEST_EQUAL( expected, mbedtls_cipher_check_tag( &ctx_dec, tag, sizeof(tag) ) );
 #endif
 
     /* check result */
@@ -550,7 +554,11 @@ void enc_fail( int cipher_id, int pad_mode, int key_len, int length_val,
     TEST_ASSERT( 0 == mbedtls_cipher_set_iv( &ctx, iv, 16 ) );
     TEST_ASSERT( 0 == mbedtls_cipher_reset( &ctx ) );
 #if defined(MBEDTLS_GCM_C) || defined(MBEDTLS_CHACHAPOLY_C)
-    TEST_ASSERT( 0 == mbedtls_cipher_update_ad( &ctx, NULL, 0 ) );
+    int expected = ( cipher_info->mode == MBEDTLS_MODE_GCM ||
+                     cipher_info->mode == MBEDTLS_CIPHER_CHACHA20_POLY1305 ) ?
+                   0 : MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE;
+
+    TEST_EQUAL( expected, mbedtls_cipher_update_ad( &ctx, NULL, 0 ) );
 #endif
 
     /* encode length number of bytes from inbuf */
@@ -612,7 +620,11 @@ void dec_empty_buf( int cipher,
     TEST_ASSERT( 0 == mbedtls_cipher_reset( &ctx_dec ) );
 
 #if defined(MBEDTLS_GCM_C) || defined(MBEDTLS_CHACHAPOLY_C)
-    TEST_ASSERT( 0 == mbedtls_cipher_update_ad( &ctx_dec, NULL, 0 ) );
+    int expected = ( cipher_info->mode == MBEDTLS_MODE_GCM ||
+                     cipher_info->mode == MBEDTLS_CIPHER_CHACHA20_POLY1305 ) ?
+                   0 : MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE;
+
+    TEST_EQUAL( expected, mbedtls_cipher_update_ad( &ctx_dec, NULL, 0 ) );
 #endif
 
     /* decode 0-byte string */
@@ -713,8 +725,12 @@ void enc_dec_buf_multipart( int cipher_id, int key_len, int first_length_val,
     TEST_ASSERT( 0 == mbedtls_cipher_reset( &ctx_enc ) );
 
 #if defined(MBEDTLS_GCM_C) || defined(MBEDTLS_CHACHAPOLY_C)
-    TEST_ASSERT( 0 == mbedtls_cipher_update_ad( &ctx_dec, NULL, 0 ) );
-    TEST_ASSERT( 0 == mbedtls_cipher_update_ad( &ctx_enc, NULL, 0 ) );
+    int expected = ( cipher_info->mode == MBEDTLS_MODE_GCM ||
+                     cipher_info->mode == MBEDTLS_CIPHER_CHACHA20_POLY1305 ) ?
+                   0 : MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE;
+
+    TEST_EQUAL( expected, mbedtls_cipher_update_ad( &ctx_dec, NULL, 0 ) );
+    TEST_EQUAL( expected, mbedtls_cipher_update_ad( &ctx_enc, NULL, 0 ) );
 #endif
 
     block_size = mbedtls_cipher_get_block_size( &ctx_enc );
@@ -798,7 +814,11 @@ void decrypt_test_vec( int cipher_id, int pad_mode, data_t * key,
     TEST_ASSERT( 0 == mbedtls_cipher_set_iv( &ctx, iv->x, iv->len ) );
     TEST_ASSERT( 0 == mbedtls_cipher_reset( &ctx ) );
 #if defined(MBEDTLS_GCM_C) || defined(MBEDTLS_CHACHAPOLY_C)
-    TEST_ASSERT( 0 == mbedtls_cipher_update_ad( &ctx, ad->x, ad->len ) );
+    int expected = ( ctx.cipher_info->mode == MBEDTLS_MODE_GCM ||
+                     ctx.cipher_info->mode == MBEDTLS_CIPHER_CHACHA20_POLY1305 ) ?
+                   0 : MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE;
+
+    TEST_EQUAL( expected, mbedtls_cipher_update_ad( &ctx, ad->x, ad->len ) );
 #endif
 
     /* decode buffer and check tag->x */
@@ -809,7 +829,11 @@ void decrypt_test_vec( int cipher_id, int pad_mode, data_t * key,
                                                  &outlen ) );
     total_len += outlen;
 #if defined(MBEDTLS_GCM_C) || defined(MBEDTLS_CHACHAPOLY_C)
-    TEST_ASSERT( tag_result == mbedtls_cipher_check_tag( &ctx, tag->x, tag->len ) );
+    int tag_expected = ( ctx.cipher_info->mode == MBEDTLS_MODE_GCM ||
+                         ctx.cipher_info->mode == MBEDTLS_CIPHER_CHACHA20_POLY1305 ) ?
+                       tag_result : MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE;
+
+    TEST_EQUAL( tag_expected, mbedtls_cipher_check_tag( &ctx, tag->x, tag->len ) );
 #endif
 
     /* check plaintext only if everything went fine */


### PR DESCRIPTION
Originally this was PR #2164 - creating a new PR as that was based off user's `development` branch

I've taken the commit in the original PR, fixed the conflict, and updated the tests to reflect the new return values in the "you shouldn't call these functions in this mode" cases.

This is not a bug fix - calling AEAD-specific functions on non-AEAD algorithms is misuse of the library - rather, this is a change of library behaviour to help badly-written calling code fail safe. Both the previous behaviour and this new behaviour comply with the documentation of these functions. Accordingly I don't think it needs a backport.

Original description:

We should report a error when the security check of the security
tag was not made. In the other case false success is possible and
is not observable by the software.

Technically this could lead to a security flaw.

Signed-off-by: Denis V. Lunev <den@openvz.org>

## Gatekeeper checklist
- [X] Tests
- [X] ChangeLog.d entry
- [X] Backport: not required
