### PR TITLE
[Backport 2.28]  Add initialization for structures in test

### DIFF
--- a/tests/suites/test_suite_ecdh.function
+++ b/tests/suites/test_suite_ecdh.function
@@ -65,6 +65,8 @@ void ecdh_invalid_param( )
     int invalid_side = 42;
     mbedtls_ecp_group_id valid_grp = MBEDTLS_ECP_DP_SECP192R1;
 
+    mbedtls_ecp_keypair_init( &kp );
+    mbedtls_ecdh_init( &ctx );
     TEST_INVALID_PARAM( mbedtls_ecdh_init( NULL ) );
 
 #if defined(MBEDTLS_ECP_RESTARTABLE)

--- a/tests/suites/test_suite_ecdsa.function
+++ b/tests/suites/test_suite_ecdsa.function
@@ -20,6 +20,12 @@ void ecdsa_invalid_param( )
     size_t slen;
     unsigned char buf[42] = { 0 };
 
+    mbedtls_ecdsa_init( &ctx );
+    mbedtls_ecp_keypair_init( &key );
+    mbedtls_ecp_group_init( &grp );
+    mbedtls_ecp_point_init( &P );
+    mbedtls_mpi_init( &m );
+
     TEST_INVALID_PARAM( mbedtls_ecdsa_init( NULL ) );
     TEST_VALID_PARAM( mbedtls_ecdsa_free( NULL ) );
 
@@ -200,6 +206,12 @@ void ecdsa_invalid_param( )
                        mbedtls_ecdsa_from_keypair( &ctx, NULL ) );
 
 exit:
+    mbedtls_ecdsa_free( &ctx );
+    mbedtls_ecp_keypair_free( &key );
+    mbedtls_ecp_group_free( &grp );
+    mbedtls_ecp_point_free( &P );
+    mbedtls_mpi_free( &m );
+
     return;
 }
 /* END_CASE */

--- a/tests/suites/test_suite_ecjpake.function
+++ b/tests/suites/test_suite_ecjpake.function
@@ -110,6 +110,8 @@ void ecjpake_invalid_param( )
     mbedtls_md_type_t valid_md = MBEDTLS_MD_SHA256;
     mbedtls_ecp_group_id valid_group = MBEDTLS_ECP_DP_SECP256R1;
 
+    mbedtls_ecjpake_init( &ctx );
+
     TEST_INVALID_PARAM( mbedtls_ecjpake_init( NULL ) );
     TEST_VALID_PARAM( mbedtls_ecjpake_free( NULL ) );
 

--- a/tests/suites/test_suite_ecp.function
+++ b/tests/suites/test_suite_ecp.function
@@ -57,6 +57,9 @@ void ecp_invalid_param( )
     mbedtls_ecp_restart_ctx restart_ctx;
 #endif /* MBEDTLS_ECP_RESTARTABLE */
 
+    mbedtls_ecp_group_init( &grp );
+    mbedtls_ecp_point_init( &P );
+
     TEST_INVALID_PARAM( mbedtls_ecp_point_init( NULL ) );
     TEST_INVALID_PARAM( mbedtls_ecp_keypair_init( NULL ) );
     TEST_INVALID_PARAM( mbedtls_ecp_group_init( NULL ) );


### PR DESCRIPTION
Straightforward backport of #6325 with an addition of initialization in ecdsa_invalid_param function in test_suite_ecdsa.function.

Resolve #6308.