### PR TITLE
mbedtls_test_read_mpi_core: support an odd number of hex digits

### DIFF
--- a/tests/include/test/helpers.h
+++ b/tests/include/test/helpers.h
@@ -298,12 +298,13 @@ void mbedtls_test_err_add_check( int high, int low,
  *                      of limbs is 0.
  * \param[out] plimbs   The address where the number of limbs will be stored.
  * \param[in] input     The test argument to read.
- *                      It is interpreted as a big-endian integer in base 256.
+ *                      It is interpreted as a hexadecimal representation
+ *                      of a non-negative integer.
  *
  * \return \c 0 on success, an \c MBEDTLS_ERR_MPI_xxx error code otherwise.
  */
 int mbedtls_test_read_mpi_core( mbedtls_mpi_uint **pX, size_t *plimbs,
-                                const data_t *input );
+                                const char *input );
 
 /** Read an MPI from a hexadecimal string.
  *

--- a/tests/suites/test_suite_mpi.data
+++ b/tests/suites/test_suite_mpi.data
@@ -447,6 +447,12 @@ mpi_bitlen:"941379d00fed1491fe15df284dfde4a142f68aa8d412023195cee66883e6290ffe70
 Test mbedtls_mpi_bitlen 0x18
 mpi_bitlen:"18":5
 
+Test mbedtls_mpi_bitlen 0x18 with leading 0 limb(s)
+mpi_bitlen:"00000000000000018":5
+
+Test mbedtls_mpi_bitlen 0x18 << 64
+mpi_bitlen:"180000000000000000":69
+
 Test mbedtls_mpi_bitlen 0x01
 mpi_bitlen:"1":1
 
@@ -464,6 +470,9 @@ mpi_bitlen:"":0
 
 Test mbedtls_mpi_bitlen: 0 (1 limb)
 mpi_bitlen:"0":0
+
+Test mbedtls_mpi_bitlen: -0x18
+mpi_bitlen:"-18":5
 
 Base test mbedtls_mpi_cmp_int #1
 mpi_cmp_int:693:693:0

--- a/tests/suites/test_suite_mpi.data
+++ b/tests/suites/test_suite_mpi.data
@@ -595,13 +595,13 @@ Test mbedtls_mpi_cmp_mpi: large negative < 0 (1 limb)
 mpi_cmp_mpi:"-1230000000000000000":"0":-1
 
 mbedtls_mpi_core_lt_ct: x=y (1 limb)
-mpi_core_lt_ct:"02B5":"02B5":0
+mpi_core_lt_ct:"2B5":"2B5":0
 
 mbedtls_mpi_core_lt_ct: x>y (1 limb)
-mpi_core_lt_ct:"02B5":"02B4":0
+mpi_core_lt_ct:"2B5":"2B4":0
 
 mbedtls_mpi_core_lt_ct: x<y (1 limb)
-mpi_core_lt_ct:"02B5":"02B6":1
+mpi_core_lt_ct:"2B5":"2B6":1
 
 mbedtls_mpi_core_lt_ct: x=y (0 limbs)
 mpi_core_lt_ct:"":"":0
@@ -667,7 +667,7 @@ mbedtls_mpi_core_lt_ct: x<y (32 bit y, first bytes equal)
 mpi_core_lt_ct:"000000FF":"FFFFFFFF":1
 
 mbedtls_mpi_core_lt_ct: x<y, zero vs non-zero MS limb
-mpi_core_lt_ct:"00FFFFFFFFFFFFFFFF":"01FFFFFFFFFFFFFFFF":1
+mpi_core_lt_ct:"0FFFFFFFFFFFFFFFF":"1FFFFFFFFFFFFFFFF":1
 
 mbedtls_mpi_core_lt_ct: x>y, equal MS limbs
 mpi_core_lt_ct:"EEFFFFFFFFFFFFFFFF":"EEFFFFFFFFFFFFFFF1":0

--- a/tests/suites/test_suite_mpi.data
+++ b/tests/suites/test_suite_mpi.data
@@ -441,28 +441,28 @@ mpi_lsb:"24":2
 Base test mbedtls_mpi_lsb #4
 mpi_lsb:"2000":13
 
-Base test mbedtls_mpi_bitlen #1
+Test mbedtls_mpi_bitlen 764-bit
 mpi_bitlen:"941379d00fed1491fe15df284dfde4a142f68aa8d412023195cee66883e6290ffe703f4ea5963bf212713cee46b107c09182b5edcd955adac418bf4918e2889af48e1099d513830cec85c26ac1e158b52620e33ba8692f893efbb2f958b4424":764
 
-Base test mbedtls_mpi_bitlen #2
+Test mbedtls_mpi_bitlen 0x18
 mpi_bitlen:"18":5
 
-Base test mbedtls_mpi_bitlen #3
+Test mbedtls_mpi_bitlen 0x01
 mpi_bitlen:"1":1
 
-Base test mbedtls_mpi_bitlen #4
+Test mbedtls_mpi_bitlen 0x0f
 mpi_bitlen:"f":4
 
-Base test mbedtls_mpi_bitlen #5
+Test mbedtls_mpi_bitlen 0x10
 mpi_bitlen:"10":5
 
-Base test mbedtls_mpi_bitlen #6
+Test mbedtls_mpi_bitlen 0x0a
 mpi_bitlen:"a":4
 
-Base test mbedtls_mpi_bitlen: 0 (null)
+Test mbedtls_mpi_bitlen: 0 (null)
 mpi_bitlen:"":0
 
-Base test mbedtls_mpi_bitlen: 0 (1 limb)
+Test mbedtls_mpi_bitlen: 0 (1 limb)
 mpi_bitlen:"0":0
 
 Base test mbedtls_mpi_cmp_int #1

--- a/tests/suites/test_suite_mpi.data
+++ b/tests/suites/test_suite_mpi.data
@@ -441,6 +441,33 @@ mpi_lsb:"24":2
 Base test mbedtls_mpi_lsb #4
 mpi_lsb:"2000":13
 
+Test mbedtls_mpi_core_bitlen 764-bit
+mpi_core_bitlen:"941379d00fed1491fe15df284dfde4a142f68aa8d412023195cee66883e6290ffe703f4ea5963bf212713cee46b107c09182b5edcd955adac418bf4918e2889af48e1099d513830cec85c26ac1e158b52620e33ba8692f893efbb2f958b4424":764
+
+Test mbedtls_mpi_core_bitlen 0x18
+mpi_core_bitlen:"18":5
+
+Test mbedtls_mpi_core_bitlen 0x18 with leading 0 limb(s)
+mpi_core_bitlen:"00000000000000018":5
+
+Test mbedtls_mpi_core_bitlen 0x18 << 64
+mpi_core_bitlen:"180000000000000000":69
+
+Test mbedtls_mpi_core_bitlen 0x01
+mpi_core_bitlen:"1":1
+
+Test mbedtls_mpi_core_bitlen 0x0f
+mpi_core_bitlen:"f":4
+
+Test mbedtls_mpi_core_bitlen 0x10
+mpi_core_bitlen:"10":5
+
+Test mbedtls_mpi_core_bitlen 0x0a
+mpi_core_bitlen:"a":4
+
+Test mbedtls_mpi_core_bitlen: 0 (1 limb)
+mpi_core_bitlen:"0":0
+
 Test mbedtls_mpi_bitlen 764-bit
 mpi_bitlen:"941379d00fed1491fe15df284dfde4a142f68aa8d412023195cee66883e6290ffe703f4ea5963bf212713cee46b107c09182b5edcd955adac418bf4918e2889af48e1099d513830cec85c26ac1e158b52620e33ba8692f893efbb2f958b4424":764
 

--- a/tests/suites/test_suite_mpi.function
+++ b/tests/suites/test_suite_mpi.function
@@ -665,6 +665,20 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE */
+void mpi_core_bitlen( char *input_X, int nr_bits )
+{
+    mbedtls_mpi_uint *X = NULL;
+    size_t limbs;
+
+    TEST_EQUAL( mbedtls_test_read_mpi_core( &X, &limbs, input_X ), 0 );
+    TEST_EQUAL( mbedtls_mpi_core_bitlen( X, limbs ), nr_bits );
+
+exit:
+    mbedtls_free( X );
+}
+/* END_CASE */
+
+/* BEGIN_CASE */
 void mpi_bitlen( char * input_X, int nr_bits )
 {
     mbedtls_mpi X;

--- a/tests/suites/test_suite_mpi.function
+++ b/tests/suites/test_suite_mpi.function
@@ -728,7 +728,7 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE */
-void mpi_core_lt_ct( data_t * input_X, data_t * input_Y, int exp_ret )
+void mpi_core_lt_ct( char *input_X, char *input_Y, int exp_ret )
 {
     mbedtls_mpi_uint *X = NULL;
     size_t X_limbs;


### PR DESCRIPTION
This is a continuation of https://github.com/Mbed-TLS/mbedtls/pull/6386 which allows bignum-core inputs to have an odd number of hex digits. (This is allowed for legacy bignums.) This is backward compatible for test data, but test functions now need to take a `char*` input instead of `data_t*`.

This pull request also adds tests for `mbedtls_mpi_core_bitlen` (I wanted a little more validation of the new auxiliary function). If we decide to merge https://github.com/Mbed-TLS/mbedtls/pull/6386, these commits are still useful.

Changelog: no (test only)

Backport: no (test framework, but only related to a new library feature)
