### PR TITLE
Add a note that config.py must remain compatible with Python 3.4

### DIFF
--- a/scripts/config.py
+++ b/scripts/config.py
@@ -7,6 +7,11 @@ Basic usage, to read the Mbed TLS or Mbed Crypto configuration:
     if 'MBEDTLS_RSA_C' in config: print('RSA is enabled')
 """
 
+# Note that as long as Mbed TLS 2.28 LTS is maintained, the version of
+# this script in the mbedtls-2.28 branch must remain compatible with
+# Python 3.4. The version in development may only use more recent features
+# in parts that are not backported to 2.28.
+
 ## Copyright The Mbed TLS Contributors
 ## SPDX-License-Identifier: Apache-2.0
 ##


### PR DESCRIPTION
See https://github.com/Mbed-TLS/mbedtls-docs/pull/51#discussion_r972217817

Changelog: no (comment only)
Backport: https://github.com/Mbed-TLS/mbedtls/pull/6402