### PR TITLE
LMS: Fix memory leak if unit test fails

### DIFF
--- a/tests/suites/test_suite_lmots.function
+++ b/tests/suites/test_suite_lmots.function
@@ -193,6 +193,7 @@ void lmots_import_export_test (  data_t * pub_key, int expected_import_rc )
 
 exit:
     mbedtls_lmots_public_free( &ctx );
+    mbedtls_free( exported_pub_key );
 }
 /* END_CASE */
 


### PR DESCRIPTION
Fixes https://github.com/Mbed-TLS/mbedtls/issues/6428

Note to reviewers: approving not only means that the patch is correct, but also that it handles all the [issues reported by Coverity](https://scan4.scan.coverity.com/reports.htm#v27693/p10660). That is, approvers must confirm that my Coverity triaging is correct.

* [381498](https://scan4.scan.coverity.com/reports.htm#v27693/p10660/fileInstanceId=122899021&defectInstanceId=14522571&mergedDefectId=381498): intentional
* [381499](https://scan4.scan.coverity.com/reports.htm#v27693/p10660/fileInstanceId=122899021&defectInstanceId=14522571&mergedDefectId=381499): fixed here
* [381500](https://scan4.scan.coverity.com/reports.htm#v27693/p10660/fileInstanceId=122899019&defectInstanceId=14522560&mergedDefectId=381500): false positive
* [381501](https://scan4.scan.coverity.com/reports.htm#v27693/p10660/fileInstanceId=122899019&defectInstanceId=14522560&mergedDefectId=381501): false positive

Changelog: no (not yet released)

Backport: no (feature not in LTS)
