### PR TITLE
Improve outcome analysis for driver-only builds

### DIFF
--- a/docs/architecture/psa-migration/outcome-analysis.sh
+++ b/docs/architecture/psa-migration/outcome-analysis.sh
@@ -147,7 +147,11 @@ compare_builds () {
             failed="$failed $suite"
         fi
     done
-    printf "suites with less coverage: %s\n" "$failed"
+    if [ -z "$failed" ]; then
+        printf "No coverage gap found.\n"
+    else
+        printf "Suites with less coverage:%s\n" "$failed"
+    fi
 }
 
 populate_suites

--- a/docs/architecture/psa-migration/outcome-analysis.sh
+++ b/docs/architecture/psa-migration/outcome-analysis.sh
@@ -48,6 +48,8 @@ IGNORE="md mdx shax" # accelerated
 IGNORE="$IGNORE entropy hmac_drbg random" # disabled (ext. RNG)
 IGNORE="$IGNORE psa_crypto_init" # needs internal RNG
 IGNORE="$IGNORE hkdf" # disabled
+# Compare only "reference vs driver" or also "before vs after"?
+BEFORE_AFTER=1 # 0 or 1
 # ----- END edit this -----
 
 set -eu
@@ -63,26 +65,28 @@ record() {
     make check
 }
 
-# save current HEAD
-HEAD=$(git branch --show-current)
+if [ "$BEFORE_AFTER" -eq 1 ]; then
+    # save current HEAD
+    HEAD=$(git branch --show-current)
 
-# get the numbers before this PR for default and full
-cleanup
-git checkout $(git merge-base HEAD development)
-record "before-default"
+    # get the numbers before this PR for default and full
+    cleanup
+    git checkout $(git merge-base HEAD development)
+    record "before-default"
 
-cleanup
-scripts/config.py full
-record "before-full"
+    cleanup
+    scripts/config.py full
+    record "before-full"
 
-# get the numbers now for default and full
-cleanup
-git checkout $HEAD
-record "after-default"
+    # get the numbers now for default and full
+    cleanup
+    git checkout $HEAD
+    record "after-default"
 
-cleanup
-scripts/config.py full
-record "after-full"
+    cleanup
+    scripts/config.py full
+    record "after-full"
+fi
 
 # get the numbers now for driver-only and reference
 cleanup
@@ -147,6 +151,8 @@ compare_builds () {
 }
 
 populate_suites
-compare_builds before-default after-default
-compare_builds before-full after-full
+if [ "$BEFORE_AFTER" -eq 1 ]; then
+    compare_builds before-default after-default
+    compare_builds before-full after-full
+fi
 compare_builds reference drivers

--- a/docs/architecture/psa-migration/outcome-analysis.sh
+++ b/docs/architecture/psa-migration/outcome-analysis.sh
@@ -95,6 +95,7 @@ record "reference"
 
 cleanup
 export MBEDTLS_TEST_OUTCOME_FILE="$PWD/outcome-drivers.csv"
+export SKIP_SSL_OPT_COMPAT_SH=1
 tests/scripts/all.sh -k test_psa_crypto_config_accel_hash_use_psa
 
 # analysis

--- a/docs/architecture/psa-migration/outcome-analysis.sh
+++ b/docs/architecture/psa-migration/outcome-analysis.sh
@@ -47,7 +47,7 @@ reference_config () {
 IGNORE="md mdx shax" # accelerated
 IGNORE="$IGNORE entropy hmac_drbg random" # disabled (ext. RNG)
 IGNORE="$IGNORE psa_crypto_init" # needs internal RNG
-IGNORE="$IGNORE hkdf" # disabled
+IGNORE="$IGNORE hkdf" # disabled in the all.sh component tested
 # Compare only "reference vs driver" or also "before vs after"?
 BEFORE_AFTER=1 # 0 or 1
 # ----- END edit this -----

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -2063,11 +2063,16 @@ component_test_psa_crypto_config_accel_hash_use_psa () {
     msg "test: MBEDTLS_PSA_CRYPTO_CONFIG with accelerated hash and USE_PSA"
     make test
 
-    msg "test: ssl-opt.sh, MBEDTLS_PSA_CRYPTO_CONFIG with accelerated hash and USE_PSA"
-    tests/ssl-opt.sh
+    # hidden option: when running outcome-analysis.sh, we can skip this
+    if [ "${SKIP_SSL_OPT_COMPAT_SH-unset}" = "unset" ]; then
+        msg "test: ssl-opt.sh, MBEDTLS_PSA_CRYPTO_CONFIG with accelerated hash and USE_PSA"
+        tests/ssl-opt.sh
 
-    msg "test: compat.sh, MBEDTLS_PSA_CRYPTO_CONFIG with accelerated hash and USE_PSA"
-    tests/compat.sh
+        msg "test: compat.sh, MBEDTLS_PSA_CRYPTO_CONFIG with accelerated hash and USE_PSA"
+        tests/compat.sh
+    else
+        echo "skip sh scripts"
+    fi
 }
 
 component_test_psa_crypto_config_accel_cipher () {

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -2043,7 +2043,7 @@ component_test_psa_crypto_config_accel_hash_use_psa () {
     # Also unset MD_C and things that depend on it;
     # see component_test_crypto_full_no_md.
     scripts/config.py unset MBEDTLS_MD_C
-    scripts/config.py unset MBEDTLS_HKDF_C
+    scripts/config.py unset MBEDTLS_HKDF_C # has independent PSA implementation
     scripts/config.py unset MBEDTLS_HMAC_DRBG_C
     scripts/config.py unset MBEDTLS_ECDSA_DETERMINISTIC
     scripts/config.py -f include/psa/crypto_config.h unset PSA_WANT_ALG_DETERMINISTIC_ECDSA
@@ -2071,7 +2071,7 @@ component_test_psa_crypto_config_accel_hash_use_psa () {
         msg "test: compat.sh, MBEDTLS_PSA_CRYPTO_CONFIG with accelerated hash and USE_PSA"
         tests/compat.sh
     else
-        echo "skip sh scripts"
+        echo "skip ssl-opt.sh and compat.sh"
     fi
 }
 


### PR DESCRIPTION
## Description

Improve outcome analysis by using an exclude list rather than an include list for test suites to compare, and making the reference configuration closer to the driver-based configuration.

## Status
**READY**

## Requires Backporting

NO  - the script is in development only, to test development-only features

## Requires ChangeLog

NO - this is a developer-only script