### PR TITLE
Add support for VITASDK

### DIFF
--- a/library/net_sockets.c
+++ b/library/net_sockets.c
@@ -33,7 +33,8 @@
 
 #if !defined(unix) && !defined(__unix__) && !defined(__unix) && \
     !defined(__APPLE__) && !defined(_WIN32) && !defined(__QNXNTO__) && \
-    !defined(__HAIKU__) && !defined(__midipix__)
+    !defined(__HAIKU__) && !defined(__midipix__) && \
+    !defined(__vita__)
 #error "This module only works on Unix and Windows, see MBEDTLS_NET_C in mbedtls_config.h"
 #endif
 

--- a/library/timing.c
+++ b/library/timing.c
@@ -27,7 +27,8 @@
 
 #if !defined(unix) && !defined(__unix__) && !defined(__unix) && \
     !defined(__APPLE__) && !defined(_WIN32) && !defined(__QNXNTO__) && \
-    !defined(__HAIKU__) && !defined(__midipix__)
+    !defined(__HAIKU__) && !defined(__midipix__) && \
+    !defined(__vita__)
 #error "This module only works on Unix and Windows, see MBEDTLS_TIMING_C in mbedtls_config.h"
 #endif
 


### PR DESCRIPTION
## Description
This small change allows mbedtls to work on the Playstation Vita when building with the VITASDK homebrew development kit. It uses the getentropy function offered by the Vita SDK.

Credit goes to @isage for the changes. See: https://github.com/vitasdk/packages/pull/242

## Status
**READY**

## Requires Backporting
NO  

## Migrations
NO
