### PR TITLE
Remove rand() from the unit test framework

### DIFF
--- a/programs/ssl/ssl_test_lib.c
+++ b/programs/ssl/ssl_test_lib.c
@@ -57,16 +57,12 @@ mbedtls_time_t dummy_constant_time( mbedtls_time_t* time )
 #if !defined(MBEDTLS_TEST_USE_PSA_CRYPTO_RNG)
 static int dummy_entropy( void *data, unsigned char *output, size_t len )
 {
-    size_t i;
     int ret;
     (void) data;
 
     ret = mbedtls_entropy_func( data, output, len );
-    for( i = 0; i < len; i++ )
-    {
-        //replace result with pseudo random
-        output[i] = (unsigned char) rand();
-    }
+    //replace result with constant data
+    memset( &output, 0x00, len );
     return( ret );
 }
 #endif
@@ -114,10 +110,6 @@ int rng_seed( rng_context_t *rng, int reproducible, const char *pers )
 #else /* !MBEDTLS_TEST_USE_PSA_CRYPTO_RNG */
     int ( *f_entropy )( void *, unsigned char *, size_t ) =
         ( reproducible ? dummy_entropy : mbedtls_entropy_func );
-
-    if ( reproducible )
-        srand( 1 );
-
 #if defined(MBEDTLS_CTR_DRBG_C)
     int ret = mbedtls_ctr_drbg_seed( &rng->drbg,
                                      f_entropy, &rng->entropy,

--- a/tests/include/test/random.h
+++ b/tests/include/test/random.h
@@ -53,13 +53,10 @@ typedef struct
 } mbedtls_test_rnd_pseudo_info;
 
 /**
- * This function just returns data from rand().
- * Although predictable and often similar on multiple
- * runs, this does not result in identical random on
- * each run. So do not use this if the results of a
- * test depend on the random data that is generated.
+ * This function just runs mbedtls_test_rnd_pseudo_rand() using the global
+ * state.
  *
- * rng_state shall be NULL.
+ * \p rng_state shall be \c NULL.
  */
 int mbedtls_test_rnd_std_rand( void *rng_state,
                                unsigned char *output,
@@ -91,12 +88,23 @@ int mbedtls_test_rnd_buffer_rand( void *rng_state,
                                   size_t len );
 
 /**
+ * This function resets the global state of the pseudo random generator.
+ *
+ * For more info see the documentation of mbedtls_test_rnd_pseudo_rand().
+ */
+void mbedtls_test_rnd_pseudo_reset_state( void );
+
+/**
  * This function returns random based on a pseudo random function.
  * This means the results should be identical on all systems.
  * Pseudo random is based on the XTEA encryption algorithm to
  * generate pseudorandom.
  *
- * \p rng_state shall be a pointer to a #mbedtls_test_rnd_pseudo_info structure.
+ * \p rng_state shall be a pointer to a #mbedtls_test_rnd_pseudo_info structure
+ *              or \c NULL to use the global state.
+ *
+ * \note When using the global state, it must be reset before the first use
+ *       with the function mbedtls_test_rnd_pseudo_reset_state().
  */
 int mbedtls_test_rnd_pseudo_rand( void *rng_state,
                                   unsigned char *output,

--- a/tests/src/random.c
+++ b/tests/src/random.c
@@ -41,22 +41,10 @@ int mbedtls_test_rnd_std_rand( void *rng_state,
                                unsigned char *output,
                                size_t len )
 {
-#if !defined(__OpenBSD__) && !defined(__NetBSD__)
-    size_t i;
-
-    if( rng_state != NULL )
-        rng_state  = NULL;
-
-    for( i = 0; i < len; ++i )
-        output[i] = rand();
-#else
     if( rng_state != NULL )
         rng_state = NULL;
 
-    arc4random_buf( output, len );
-#endif /* !OpenBSD && !NetBSD */
-
-    return( 0 );
+    return( mbedtls_test_rnd_pseudo_rand( NULL, output, len ) );
 }
 
 int mbedtls_test_rnd_zero_rand( void *rng_state,
@@ -79,7 +67,7 @@ int mbedtls_test_rnd_buffer_rand( void *rng_state,
     size_t use_len;
 
     if( rng_state == NULL )
-        return( mbedtls_test_rnd_std_rand( NULL, output, len ) );
+        return( mbedtls_test_rnd_pseudo_rand( NULL, output, len ) );
 
     use_len = len;
     if( len > info->length )
@@ -107,6 +95,13 @@ int mbedtls_test_rnd_buffer_rand( void *rng_state,
     return( 0 );
 }
 
+static mbedtls_test_rnd_pseudo_info global_info;
+
+void mbedtls_test_rnd_pseudo_reset_state( void )
+{
+    memset( &global_info, 0x00, sizeof( global_info ) );
+}
+
 int mbedtls_test_rnd_pseudo_rand( void *rng_state,
                                   unsigned char *output,
                                   size_t len )
@@ -117,7 +112,7 @@ int mbedtls_test_rnd_pseudo_rand( void *rng_state,
     unsigned char result[4], *out = output;
 
     if( rng_state == NULL )
-        return( mbedtls_test_rnd_std_rand( NULL, output, len ) );
+        info = &global_info;
 
     k = info->key;
 

--- a/tests/suites/main_test.function
+++ b/tests/suites/main_test.function
@@ -171,6 +171,8 @@ int dispatch_test( size_t func_idx, void ** params )
                 mbedtls_test_enable_insecure_external_rng( );
             #endif
 
+                mbedtls_test_rnd_pseudo_reset_state();
+
                 fp( params );
 
             #if defined(MBEDTLS_TEST_MUTEX_USAGE)

--- a/tests/suites/test_suite_mps.function
+++ b/tests/suites/test_suite_mps.function
@@ -17,6 +17,13 @@
 
 /* End of compile-time configuration. */
 
+static size_t mbedtls_mps_rand( void )
+{
+    size_t ret;
+    mbedtls_test_rnd_std_rand( NULL, (unsigned char *) &ret, sizeof( ret ) );
+    return ret;
+}
+
 /* END_HEADER */
 
 /* BEGIN_DEPENDENCIES
@@ -834,10 +841,6 @@ void mbedtls_mps_reader_random_usage( int num_out_chunks,
         ASSERT_ALLOC( acc, acc_size );
     }
 
-    /* This probably needs to be changed because we want
-     * our tests to be deterministic. */
-    //    srand( time( NULL ) );
-
     ASSERT_ALLOC( outgoing, num_out_chunks * max_chunk_size );
     ASSERT_ALLOC( incoming, num_out_chunks * max_chunk_size );
 
@@ -852,7 +855,7 @@ void mbedtls_mps_reader_random_usage( int num_out_chunks,
         if( mode == 0 )
         {
             /* Choose randomly between reclaim and feed */
-            rand_op = rand() % 2;
+            rand_op = mbedtls_mps_rand() % 2;
 
             if( rand_op == 0 )
             {
@@ -875,7 +878,7 @@ void mbedtls_mps_reader_random_usage( int num_out_chunks,
                 if( cur_out_chunk == (unsigned) num_out_chunks )
                     continue;
 
-                tmp_size = ( rand() % max_chunk_size ) + 1;
+                tmp_size = ( mbedtls_mps_rand() % max_chunk_size ) + 1;
                 ASSERT_ALLOC( tmp, tmp_size );
 
                 TEST_ASSERT( mbedtls_test_rnd_std_rand( NULL, tmp, tmp_size ) == 0 );
@@ -902,7 +905,7 @@ void mbedtls_mps_reader_random_usage( int num_out_chunks,
 
             /* Randomly switch to consumption mode if reclaim
              * was called at least once. */
-            if( reclaimed == 1 && rand() % 3 == 0 )
+            if( reclaimed == 1 && mbedtls_mps_rand() % 3 == 0 )
             {
                 in_fetch = 0;
                 mode = 1;
@@ -912,12 +915,12 @@ void mbedtls_mps_reader_random_usage( int num_out_chunks,
         {
             /* Choose randomly between get tolerating fewer data,
              * get not tolerating fewer data, and commit. */
-            rand_op = rand() % 3;
+            rand_op = mbedtls_mps_rand() % 3;
             if( rand_op == 0 || rand_op == 1 )
             {
                 mbedtls_mps_size_t get_size, real_size;
                 unsigned char *chunk_get;
-                get_size = ( rand() % max_request ) + 1;
+                get_size = ( mbedtls_mps_rand() % max_request ) + 1;
                 if( rand_op == 0 )
                 {
                     ret = mbedtls_mps_reader_get( &rd, get_size, &chunk_get,
@@ -951,7 +954,7 @@ void mbedtls_mps_reader_random_usage( int num_out_chunks,
             }
 
             /* Randomly switch back to preparation */
-            if( rand() % 3 == 0 )
+            if( mbedtls_mps_rand() % 3 == 0 )
             {
                 reclaimed = 0;
                 mode = 0;

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -32,15 +32,7 @@ typedef struct log_pattern
 } log_pattern;
 
 #if defined(MBEDTLS_X509_CRT_PARSE_C)
-static int rng_seed = 0xBEEF;
-static int rng_get( void *p_rng, unsigned char *output, size_t output_len )
-{
-    (void) p_rng;
-    for( size_t i = 0; i < output_len; i++ )
-        output[i] = rand();
-
-    return 0;
-}
+static mbedtls_test_rnd_pseudo_info rng_state;
 #endif
 
 /*
@@ -104,8 +96,7 @@ typedef struct handshake_test_options
 void init_handshake_options( handshake_test_options *opts )
 {
 #if defined(MBEDTLS_X509_CRT_PARSE_C)
-    srand( rng_seed );
-    rng_seed += 0xD0;
+    memset( &rng_state, 0x00, sizeof( rng_state ) );
 #endif
     opts->cipher = "";
     opts->client_min_version = MBEDTLS_SSL_VERSION_UNKNOWN;
@@ -991,7 +982,7 @@ int mbedtls_endpoint_init( mbedtls_endpoint *ep, int endpoint_type,
 
     mbedtls_ssl_init( &( ep->ssl ) );
     mbedtls_ssl_config_init( &( ep->conf ) );
-    mbedtls_ssl_conf_rng( &( ep->conf ), rng_get, NULL );
+    mbedtls_ssl_conf_rng( &( ep->conf ), mbedtls_test_rnd_pseudo_rand, &rng_state );
 
     TEST_ASSERT( mbedtls_ssl_conf_get_user_data_p( &ep->conf ) == NULL );
     TEST_EQUAL( mbedtls_ssl_conf_get_user_data_n( &ep->conf ), 0 );


### PR DESCRIPTION
## Description

Resolves #6250.

## Status
**READY** for review.

## Requires Backporting
**Yes** for branch `mbedtls-2.28`.

## Additional comments
I kept the function `mbedtls_test_rnd_std_rand()` and changed it to call `mbedtls_test_rnd_pseudo_rand()` instead of using `rand()`. It is possible to remove it completely by replacing all the calls to the function in the unit test to call `mbedtls_test_rnd_pseudo_rand()` directly.

## Todos
- [x] Documentation
- [ ] Changelog updated
- [ ] Backported
