### PR TITLE
Fix can_exercise() for RSA and hashes

### DIFF
--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -1130,7 +1130,7 @@
  *
  * Enable support for PKCS#1 v1.5 encoding.
  *
- * Requires: MBEDTLS_MD_C, MBEDTLS_RSA_C
+ * Requires: MBEDTLS_RSA_C
  *
  * This enables support for PKCS#1 v1.5 operations.
  */

--- a/tests/suites/test_suite_psa_crypto_storage_format.function
+++ b/tests/suites/test_suite_psa_crypto_storage_format.function
@@ -84,10 +84,6 @@ static int is_accelerated_rsa( psa_algorithm_t alg )
  * also be built-in. */
 static int is_builtin_calling_md( psa_algorithm_t alg )
 {
-#if defined(MBEDTLS_PSA_BUILTIN_ALG_RSA_PKCS1V15_SIGN)
-    if( PSA_ALG_IS_RSA_PKCS1V15_SIGN( alg ) )
-        return( 1 );
-#endif
 #if defined(MBEDTLS_PSA_BUILTIN_ALG_RSA_PSS)
     if( PSA_ALG_IS_RSA_PSS( alg ) )
         return( 1 );

--- a/tests/suites/test_suite_psa_crypto_storage_format.function
+++ b/tests/suites/test_suite_psa_crypto_storage_format.function
@@ -86,11 +86,19 @@ static int is_builtin_calling_md( psa_algorithm_t alg )
 {
 #if defined(MBEDTLS_PSA_BUILTIN_ALG_RSA_PSS)
     if( PSA_ALG_IS_RSA_PSS( alg ) )
+#if defined(MBEDTLS_MD_C)
         return( 1 );
+#else
+        return( 0 );
+#endif
 #endif
 #if defined(MBEDTLS_PSA_BUILTIN_ALG_RSA_OAEP)
     if( PSA_ALG_IS_RSA_OAEP( alg ) )
+#if defined(MBEDTLS_MD_C)
         return( 1 );
+#else
+        return( 0 );
+#endif
 #endif
 #if defined(MBEDTLS_PSA_BUILTIN_ALG_DETERMINISTIC_ECDSA)
     if( PSA_ALG_IS_DETERMINISTIC_ECDSA( alg ) )


### PR DESCRIPTION
The storage format tests (`test_suite_psa_crypto_storage_format.function`) try to exercise keys after loading them, in order to make sure everything is OK. However, this part is skipped if the configuration doesn't have what it takes to exercise that key. This is done with `can_exercised()` which in turn calls `is_builtin_calling_md()` in order to determine if we are using a built-in algorithm like RSA that's itself calling MD, hence requiring the hash used to also be built-in.

The conditions under which RSA is calling MD changed recently, but `is_builtin_calling_md()` wasn't updated. This PR fixes that.

- No backport (fix in a new feature).
- No ChangeLog entry (tests only, and also hasn't been in a release yet anyway).
