### PR TITLE
Update tests to use conditional assign and swap

### DIFF
--- a/tests/suites/test_suite_bignum_core.function
+++ b/tests/suites/test_suite_bignum_core.function
@@ -371,6 +371,9 @@ void mpi_core_cond_assign( char * input_X,
 
     mbedtls_mpi_core_cond_assign( X, Y, copy_limbs, 0 );
 
+    TEST_CF_PUBLIC( X, bytes );
+    TEST_CF_PUBLIC( Y, bytes );
+
     TEST_ASSERT( memcmp( X, Y, bytes ) != 0 );
 
     /* condition is true */
@@ -379,10 +382,16 @@ void mpi_core_cond_assign( char * input_X,
 
     mbedtls_mpi_core_cond_assign( X, Y, copy_limbs, 1 );
 
+    TEST_CF_PUBLIC( X, bytes );
+    TEST_CF_PUBLIC( Y, bytes );
+
     /* Check if the given length is copied even it is smaller
        than the length of the given MPIs. */
     if( copy_limbs < limbs )
     {
+        TEST_CF_PUBLIC( X, bytes );
+        TEST_CF_PUBLIC( Y, bytes );
+
         ASSERT_COMPARE( X, copy_bytes, Y, copy_bytes );
         TEST_ASSERT( memcmp( X, Y, bytes ) != 0 );
     }
@@ -430,6 +439,9 @@ void mpi_core_cond_swap( char * input_X,
 
     mbedtls_mpi_core_cond_swap( X, Y, copy_limbs, 0 );
 
+    TEST_CF_PUBLIC( X, bytes );
+    TEST_CF_PUBLIC( Y, bytes );
+
     ASSERT_COMPARE( X, bytes, tmp_X, bytes );
     ASSERT_COMPARE( Y, bytes, tmp_Y, bytes );
 
@@ -438,6 +450,9 @@ void mpi_core_cond_swap( char * input_X,
     TEST_CF_SECRET( Y, bytes );
 
     mbedtls_mpi_core_cond_swap( X, Y, copy_limbs, 1 );
+
+    TEST_CF_PUBLIC( X, bytes );
+    TEST_CF_PUBLIC( Y, bytes );
 
     /* Check if the given length is copied even it is smaller
        than the length of the given MPIs. */

--- a/tests/suites/test_suite_bignum_core.function
+++ b/tests/suites/test_suite_bignum_core.function
@@ -345,14 +345,18 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE */
-void mpi_core_cond_assign( data_t * input_X,
-                           data_t * input_Y,
+void mpi_core_cond_assign( char * input_X,
+                           char * input_Y,
                            int input_bytes )
 {
     mbedtls_mpi_uint *X = NULL;
     mbedtls_mpi_uint *Y = NULL;
-    size_t limbs_X = CHARS_TO_LIMBS( input_X->len );
-    size_t limbs_Y = CHARS_TO_LIMBS( input_Y->len );
+    size_t limbs_X;
+    size_t limbs_Y;
+
+    TEST_EQUAL( mbedtls_test_read_mpi_core( &X, &limbs_X, input_X ), 0 );
+    TEST_EQUAL( mbedtls_test_read_mpi_core( &Y, &limbs_Y, input_Y ), 0 );
+
     size_t limbs = limbs_X;
     size_t copy_limbs = CHARS_TO_LIMBS( input_bytes );
     size_t bytes = limbs * sizeof( mbedtls_mpi_uint );
@@ -361,23 +365,11 @@ void mpi_core_cond_assign( data_t * input_X,
     TEST_EQUAL( limbs_X, limbs_Y );
     TEST_ASSERT( copy_limbs <= limbs );
 
-    ASSERT_ALLOC( X, limbs );
-    ASSERT_ALLOC( Y, limbs );
-
-    TEST_ASSERT( mbedtls_mpi_core_read_be( X, limbs, input_X->x, input_X->len )
-                 == 0 );
-
-    TEST_ASSERT( mbedtls_mpi_core_read_be( Y, limbs, input_Y->x, input_Y->len )
-                 == 0 );
-
     /* condition is false */
     TEST_CF_SECRET( X, bytes );
     TEST_CF_SECRET( Y, bytes );
 
     mbedtls_mpi_core_cond_assign( X, Y, copy_limbs, 0 );
-
-    TEST_CF_PUBLIC( X, bytes );
-    TEST_CF_PUBLIC( Y, bytes );
 
     TEST_ASSERT( memcmp( X, Y, bytes ) != 0 );
 
@@ -386,9 +378,6 @@ void mpi_core_cond_assign( data_t * input_X,
     TEST_CF_SECRET( Y, bytes );
 
     mbedtls_mpi_core_cond_assign( X, Y, copy_limbs, 1 );
-
-    TEST_CF_PUBLIC( X, bytes );
-    TEST_CF_PUBLIC( Y, bytes );
 
     /* Check if the given length is copied even it is smaller
        than the length of the given MPIs. */
@@ -407,16 +396,20 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE */
-void mpi_core_cond_swap( data_t * input_X,
-                         data_t * input_Y,
+void mpi_core_cond_swap( char * input_X,
+                         char * input_Y,
                          int input_bytes )
 {
     mbedtls_mpi_uint *tmp_X = NULL;
     mbedtls_mpi_uint *tmp_Y = NULL;
     mbedtls_mpi_uint *X = NULL;
     mbedtls_mpi_uint *Y = NULL;
-    size_t limbs_X = CHARS_TO_LIMBS( input_X->len );
-    size_t limbs_Y = CHARS_TO_LIMBS( input_Y->len );
+    size_t limbs_X;
+    size_t limbs_Y;
+
+    TEST_EQUAL( mbedtls_test_read_mpi_core( &tmp_X, &limbs_X, input_X ), 0 );
+    TEST_EQUAL( mbedtls_test_read_mpi_core( &tmp_Y, &limbs_Y, input_Y ), 0 );
+
     size_t limbs = limbs_X;
     size_t copy_limbs = CHARS_TO_LIMBS( input_bytes );
     size_t bytes = limbs * sizeof( mbedtls_mpi_uint );
@@ -425,18 +418,9 @@ void mpi_core_cond_swap( data_t * input_X,
     TEST_EQUAL( limbs_X, limbs_Y );
     TEST_ASSERT( copy_limbs <= limbs );
 
-    ASSERT_ALLOC( tmp_X, limbs );
-    ASSERT_ALLOC( tmp_Y, limbs );
-
-    TEST_ASSERT( mbedtls_mpi_core_read_be( tmp_X, limbs,
-                                           input_X->x, input_X->len )
-                 == 0 );
     ASSERT_ALLOC( X, limbs );
     memcpy( X, tmp_X, bytes );
 
-    TEST_ASSERT( mbedtls_mpi_core_read_be( tmp_Y, limbs,
-                                           input_Y->x, input_Y->len )
-                 == 0 );
     ASSERT_ALLOC( Y, limbs );
     memcpy( Y, tmp_Y, bytes );
 
@@ -446,9 +430,6 @@ void mpi_core_cond_swap( data_t * input_X,
 
     mbedtls_mpi_core_cond_swap( X, Y, copy_limbs, 0 );
 
-    TEST_CF_PUBLIC( X, bytes );
-    TEST_CF_PUBLIC( Y, bytes );
-
     ASSERT_COMPARE( X, bytes, tmp_X, bytes );
     ASSERT_COMPARE( Y, bytes, tmp_Y, bytes );
 
@@ -457,9 +438,6 @@ void mpi_core_cond_swap( data_t * input_X,
     TEST_CF_SECRET( Y, bytes );
 
     mbedtls_mpi_core_cond_swap( X, Y, copy_limbs, 1 );
-
-    TEST_CF_PUBLIC( X, bytes );
-    TEST_CF_PUBLIC( Y, bytes );
 
     /* Check if the given length is copied even it is smaller
        than the length of the given MPIs. */

--- a/tests/suites/test_suite_bignum_mod_raw.function
+++ b/tests/suites/test_suite_bignum_mod_raw.function
@@ -147,6 +147,9 @@ void mpi_mod_raw_cond_assign( char * input_X,
 
     mbedtls_mpi_mod_raw_cond_assign( X, Y, &m, 0 );
 
+    TEST_CF_PUBLIC( X, bytes );
+    TEST_CF_PUBLIC( Y, bytes );
+
     TEST_ASSERT( memcmp( X, Y, bytes ) != 0 );
 
     /* condition is true */
@@ -154,6 +157,9 @@ void mpi_mod_raw_cond_assign( char * input_X,
     TEST_CF_SECRET( Y, bytes );
 
     mbedtls_mpi_mod_raw_cond_assign( X, Y, &m, 1 );
+
+    TEST_CF_PUBLIC( X, bytes );
+    TEST_CF_PUBLIC( Y, bytes );
 
     /* Check if the given length is copied even it is smaller
        than the length of the given MPIs. */
@@ -220,6 +226,9 @@ void mpi_mod_raw_cond_swap( char * input_X,
 
     mbedtls_mpi_mod_raw_cond_swap( X, Y, &m, 0 );
 
+    TEST_CF_PUBLIC( X, bytes );
+    TEST_CF_PUBLIC( Y, bytes );
+
     ASSERT_COMPARE( X, bytes, tmp_X, bytes );
     ASSERT_COMPARE( Y, bytes, tmp_Y, bytes );
 
@@ -228,6 +237,9 @@ void mpi_mod_raw_cond_swap( char * input_X,
     TEST_CF_SECRET( Y, bytes );
 
     mbedtls_mpi_mod_raw_cond_swap( X, Y, &m, 1 );
+
+    TEST_CF_PUBLIC( X, bytes );
+    TEST_CF_PUBLIC( Y, bytes );
 
     /* Check if the given length is copied even it is smaller
        than the length of the given MPIs. */

--- a/tests/suites/test_suite_bignum_mod_raw.function
+++ b/tests/suites/test_suite_bignum_mod_raw.function
@@ -110,16 +110,20 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE */
-void mpi_mod_raw_cond_assign( data_t * input_X,
-                              data_t * input_Y,
+void mpi_mod_raw_cond_assign( char * input_X,
+                              char * input_Y,
                               int input_bytes )
 {
     mbedtls_mpi_uint *X = NULL;
     mbedtls_mpi_uint *Y = NULL;
     mbedtls_mpi_uint *buff_m = NULL;
     mbedtls_mpi_mod_modulus m;
-    size_t limbs_X = CHARS_TO_LIMBS( input_X->len );
-    size_t limbs_Y = CHARS_TO_LIMBS( input_Y->len );
+    size_t limbs_X;
+    size_t limbs_Y;
+
+    TEST_EQUAL( mbedtls_test_read_mpi_core( &X, &limbs_X, input_X ), 0 );
+    TEST_EQUAL( mbedtls_test_read_mpi_core( &Y, &limbs_Y, input_Y ), 0 );
+
     size_t limbs = limbs_X;
     size_t copy_limbs = CHARS_TO_LIMBS( input_bytes );
     size_t bytes = limbs * sizeof( mbedtls_mpi_uint );
@@ -130,33 +134,18 @@ void mpi_mod_raw_cond_assign( data_t * input_X,
     TEST_EQUAL( limbs_X, limbs_Y );
     TEST_ASSERT( copy_limbs <= limbs );
 
-    ASSERT_ALLOC( X, limbs );
-    ASSERT_ALLOC( Y, limbs );
-
-    ASSERT_ALLOC( buff_m, limbs );
-    memset( buff_m, 0xFF, copy_bytes );
-    TEST_ASSERT( mbedtls_mpi_mod_modulus_setup(
+    ASSERT_ALLOC( buff_m, copy_limbs );
+    memset( buff_m, 0xFF, copy_limbs );
+    TEST_EQUAL( mbedtls_mpi_mod_modulus_setup(
                         &m, buff_m, copy_limbs,
                         MBEDTLS_MPI_MOD_EXT_REP_BE,
-                        MBEDTLS_MPI_MOD_REP_MONTGOMERY )
-                 == 0 );
-
-    TEST_ASSERT( mbedtls_mpi_core_read_be( X, limbs,
-                                           input_X->x, input_X->len )
-                 == 0 );
-
-    TEST_ASSERT( mbedtls_mpi_core_read_be( Y, limbs,
-                                           input_Y->x, input_Y->len )
-                 == 0 );
+                        MBEDTLS_MPI_MOD_REP_MONTGOMERY ), 0 );
 
     /* condition is false */
     TEST_CF_SECRET( X, bytes );
     TEST_CF_SECRET( Y, bytes );
 
     mbedtls_mpi_mod_raw_cond_assign( X, Y, &m, 0 );
-
-    TEST_CF_PUBLIC( X, bytes );
-    TEST_CF_PUBLIC( Y, bytes );
 
     TEST_ASSERT( memcmp( X, Y, bytes ) != 0 );
 
@@ -165,9 +154,6 @@ void mpi_mod_raw_cond_assign( data_t * input_X,
     TEST_CF_SECRET( Y, bytes );
 
     mbedtls_mpi_mod_raw_cond_assign( X, Y, &m, 1 );
-
-    TEST_CF_PUBLIC( X, bytes );
-    TEST_CF_PUBLIC( Y, bytes );
 
     /* Check if the given length is copied even it is smaller
        than the length of the given MPIs. */
@@ -189,8 +175,8 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE */
-void mpi_mod_raw_cond_swap( data_t * input_X,
-                            data_t * input_Y,
+void mpi_mod_raw_cond_swap( char * input_X,
+                            char * input_Y,
                             int input_bytes )
 {
     mbedtls_mpi_uint *tmp_X = NULL;
@@ -199,8 +185,12 @@ void mpi_mod_raw_cond_swap( data_t * input_X,
     mbedtls_mpi_uint *Y = NULL;
     mbedtls_mpi_uint *buff_m = NULL;
     mbedtls_mpi_mod_modulus m;
-    size_t limbs_X = CHARS_TO_LIMBS( input_X->len );
-    size_t limbs_Y = CHARS_TO_LIMBS( input_Y->len );
+    size_t limbs_X;
+    size_t limbs_Y;
+
+    TEST_EQUAL( mbedtls_test_read_mpi_core( &tmp_X, &limbs_X, input_X ), 0 );
+    TEST_EQUAL( mbedtls_test_read_mpi_core( &tmp_Y, &limbs_Y, input_Y ), 0 );
+
     size_t limbs = limbs_X;
     size_t copy_limbs = CHARS_TO_LIMBS( input_bytes );
     size_t bytes = limbs * sizeof( mbedtls_mpi_uint );
@@ -211,24 +201,16 @@ void mpi_mod_raw_cond_swap( data_t * input_X,
     TEST_EQUAL( limbs_X, limbs_Y );
     TEST_ASSERT( copy_limbs <= limbs );
 
-    ASSERT_ALLOC( tmp_X, limbs );
-    ASSERT_ALLOC( tmp_Y, limbs );
-
     ASSERT_ALLOC( buff_m, copy_limbs );
-    memset( buff_m, 0xFF, copy_bytes );
-    TEST_ASSERT( mbedtls_mpi_mod_modulus_setup(
+    memset( buff_m, 0xFF, copy_limbs );
+    TEST_EQUAL( mbedtls_mpi_mod_modulus_setup(
                         &m, buff_m, copy_limbs,
                         MBEDTLS_MPI_MOD_EXT_REP_BE,
-                        MBEDTLS_MPI_MOD_REP_MONTGOMERY )
-                 == 0 );
+                        MBEDTLS_MPI_MOD_REP_MONTGOMERY ), 0 );
 
-    TEST_ASSERT( mbedtls_mpi_core_read_be( tmp_X, limbs, input_X->x, input_X->len )
-                 == 0 );
     ASSERT_ALLOC( X, limbs );
     memcpy( X, tmp_X, bytes );
 
-    TEST_ASSERT( mbedtls_mpi_core_read_be( tmp_Y, limbs, input_Y->x, input_Y->len )
-                 == 0 );
     ASSERT_ALLOC( Y, bytes );
     memcpy( Y, tmp_Y, bytes );
 
@@ -238,9 +220,6 @@ void mpi_mod_raw_cond_swap( data_t * input_X,
 
     mbedtls_mpi_mod_raw_cond_swap( X, Y, &m, 0 );
 
-    TEST_CF_PUBLIC( X, bytes );
-    TEST_CF_PUBLIC( Y, bytes );
-
     ASSERT_COMPARE( X, bytes, tmp_X, bytes );
     ASSERT_COMPARE( Y, bytes, tmp_Y, bytes );
 
@@ -249,9 +228,6 @@ void mpi_mod_raw_cond_swap( data_t * input_X,
     TEST_CF_SECRET( Y, bytes );
 
     mbedtls_mpi_mod_raw_cond_swap( X, Y, &m, 1 );
-
-    TEST_CF_PUBLIC( X, bytes );
-    TEST_CF_PUBLIC( Y, bytes );
 
     /* Check if the given length is copied even it is smaller
        than the length of the given MPIs. */


### PR DESCRIPTION
Follow-up PR for #6289. Use the `mbedtls_test_read_mpi_core` function, introduced in #6386 and #6398, in conditional assign and swap test functions.