### PR TITLE
Bignum: Updated the modulus lifecyle

### DIFF
--- a/library/bignum_mod.c
+++ b/library/bignum_mod.c
@@ -77,6 +77,9 @@ void mbedtls_mpi_mod_modulus_free( mbedtls_mpi_mod_modulus *m )
     switch( m->int_rep )
     {
         case MBEDTLS_MPI_MOD_REP_MONTGOMERY:
+            mbedtls_platform_zeroize( (mbedtls_mpi_uint *) m->rep.mont.rr,
+                                      m->limbs );
+            mbedtls_free( (mbedtls_mpi_uint *)m->rep.mont.rr );
             m->rep.mont.rr = NULL;
             m->rep.mont.mm = 0; break;
         case MBEDTLS_MPI_MOD_REP_OPT_RED:
@@ -91,6 +94,38 @@ void mbedtls_mpi_mod_modulus_free( mbedtls_mpi_mod_modulus *m )
     m->bits = 0;
     m->ext_rep = MBEDTLS_MPI_MOD_EXT_REP_INVALID;
     m->int_rep = MBEDTLS_MPI_MOD_REP_INVALID;
+}
+
+static int set_mont_const_square( const mbedtls_mpi_uint **X,
+                                  const mbedtls_mpi_uint *A,
+                                  size_t limbs )
+{
+    int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
+    mbedtls_mpi N;
+    mbedtls_mpi RR;
+
+    mbedtls_mpi_init( &N );
+    mbedtls_mpi_init( &RR );
+
+    if ( A == NULL || limbs == 0 || limbs >= ( MBEDTLS_MPI_MAX_LIMBS / 2 ) - 2 )
+        goto cleanup;
+
+    if ( !mbedtls_mpi_grow( &N,  limbs ))
+        memcpy( N.p, A, sizeof(mbedtls_mpi_uint) *  limbs );
+    else
+        goto cleanup;
+
+    mbedtls_mpi_core_get_mont_r2_unsafe(&RR, &N);
+
+    *X = RR.p;
+    RR.p = NULL;
+    ret = 0;
+
+cleanup:
+    mbedtls_mpi_free(&N);
+    mbedtls_mpi_free(&RR);
+    ret = ( ret != 0 ) ? MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED : 0;
+    return( ret );
 }
 
 int mbedtls_mpi_mod_modulus_setup( mbedtls_mpi_mod_modulus *m,
@@ -120,8 +155,9 @@ int mbedtls_mpi_mod_modulus_setup( mbedtls_mpi_mod_modulus *m,
     {
         case MBEDTLS_MPI_MOD_REP_MONTGOMERY:
             m->int_rep = int_rep;
-            m->rep.mont.rr = NULL;
-            m->rep.mont.mm = 0; break;
+            m->rep.mont.mm = mbedtls_mpi_core_montmul_init( m->p );
+            set_mont_const_square( &m->rep.mont.rr, m->p, m->limbs );
+            break;
         case MBEDTLS_MPI_MOD_REP_OPT_RED:
             m->int_rep = int_rep;
             m->rep.ored = NULL;

--- a/library/bignum_mod.c
+++ b/library/bignum_mod.c
@@ -77,8 +77,8 @@ void mbedtls_mpi_mod_modulus_free( mbedtls_mpi_mod_modulus *m )
     switch( m->int_rep )
     {
         case MBEDTLS_MPI_MOD_REP_MONTGOMERY:
-            mbedtls_free( m->rep.mont );
-            break;
+            m->rep.mont.rr = NULL;
+            m->rep.mont.mm = 0; break;
         case MBEDTLS_MPI_MOD_REP_OPT_RED:
             mbedtls_free( m->rep.ored );
             break;
@@ -120,8 +120,8 @@ int mbedtls_mpi_mod_modulus_setup( mbedtls_mpi_mod_modulus *m,
     {
         case MBEDTLS_MPI_MOD_REP_MONTGOMERY:
             m->int_rep = int_rep;
-            m->rep.mont = NULL;
-            break;
+            m->rep.mont.rr = NULL;
+            m->rep.mont.mm = 0; break;
         case MBEDTLS_MPI_MOD_REP_OPT_RED:
             m->int_rep = int_rep;
             m->rep.ored = NULL;

--- a/library/bignum_mod.c
+++ b/library/bignum_mod.c
@@ -81,7 +81,8 @@ void mbedtls_mpi_mod_modulus_free( mbedtls_mpi_mod_modulus *m )
                                       m->limbs );
             mbedtls_free( (mbedtls_mpi_uint *)m->rep.mont.rr );
             m->rep.mont.rr = NULL;
-            m->rep.mont.mm = 0; break;
+            m->rep.mont.mm = 0;
+            break;
         case MBEDTLS_MPI_MOD_REP_OPT_RED:
             mbedtls_free( m->rep.ored );
             break;
@@ -110,10 +111,10 @@ static int set_mont_const_square( const mbedtls_mpi_uint **X,
     if ( A == NULL || limbs == 0 || limbs >= ( MBEDTLS_MPI_MAX_LIMBS / 2 ) - 2 )
         goto cleanup;
 
-    if ( !mbedtls_mpi_grow( &N,  limbs ))
-        memcpy( N.p, A, sizeof(mbedtls_mpi_uint) *  limbs );
-    else
+    if ( mbedtls_mpi_grow( &N,  limbs ))
         goto cleanup;
+
+    memcpy( N.p, A, sizeof(mbedtls_mpi_uint) *  limbs );
 
     mbedtls_mpi_core_get_mont_r2_unsafe(&RR, &N);
 

--- a/library/bignum_mod.h
+++ b/library/bignum_mod.h
@@ -53,7 +53,11 @@ typedef struct
     size_t limbs;
 } mbedtls_mpi_mod_residue;
 
-typedef void *mbedtls_mpi_mont_struct;
+typedef struct {
+    mbedtls_mpi_uint const *rr;  /* The residue for 2^{2*n*biL} mod N */
+    mbedtls_mpi_uint mm;         /* Montgomery const for -N^{-1} mod 2^{ciL} */
+} mbedtls_mpi_mont_struct;
+
 typedef void *mbedtls_mpi_opt_red_struct;
 
 typedef struct {

--- a/tests/suites/test_suite_bignum_mod.function
+++ b/tests/suites/test_suite_bignum_mod.function
@@ -17,10 +17,9 @@ void mpi_mod_setup( int ext_rep, int int_rep, int iret )
     #define MLIMBS 8
     mbedtls_mpi_uint mp[MLIMBS];
     mbedtls_mpi_mod_modulus m;
-    const size_t mp_size = sizeof(mbedtls_mpi_uint);
     int ret;
 
-    memset( mp, 0xFF, mp_size );
+    memset( mp, 0xFF, sizeof(mp) );
 
     mbedtls_mpi_mod_modulus_init( &m );
     ret = mbedtls_mpi_mod_modulus_setup( &m, mp, MLIMBS, ext_rep, int_rep );
@@ -44,13 +43,9 @@ void mpi_mod_setup( int ext_rep, int int_rep, int iret )
     /* Only test if the constants have been set-up  */
     if ( ret == 0 && int_rep == MBEDTLS_MPI_MOD_REP_MONTGOMERY )
     {
-        /* Reuse the allocated buffer for a zeroization check */
-        memset( mp, 0x00, mp_size );
-
         /* Verify the data and pointers allocated have been properly wiped */
         TEST_ASSERT( m.rep.mont.rr == NULL );
         TEST_ASSERT( m.rep.mont.mm == 0 );
-
     }
 exit:
     /* It should be safe to call an mbedtls free several times */

--- a/tests/suites/test_suite_bignum_mod.function
+++ b/tests/suites/test_suite_bignum_mod.function
@@ -18,7 +18,6 @@ void mpi_mod_setup( int ext_rep, int int_rep, int iret )
     mbedtls_mpi_uint mp[MLIMBS];
     mbedtls_mpi_mod_modulus m;
     const size_t mp_size = sizeof(mbedtls_mpi_uint);
-    mbedtls_mpi_uint * rr;
     int ret;
 
     memset( mp, 0xFF, mp_size );
@@ -34,8 +33,6 @@ void mpi_mod_setup( int ext_rep, int int_rep, int iret )
         TEST_ASSERT( m.rep.mont.rr != NULL );
         TEST_ASSERT( m.rep.mont.mm != 0 );
 
-        /* Keep a copy of the memory location used to store Montgomery const */
-        rr = (mbedtls_mpi_uint *)m.rep.mont.rr;
     }
 
     /* Address sanitiser should catch if we try to free mp */
@@ -54,10 +51,6 @@ void mpi_mod_setup( int ext_rep, int int_rep, int iret )
         TEST_ASSERT( m.rep.mont.rr == NULL );
         TEST_ASSERT( m.rep.mont.mm == 0 );
 
-        /* mbedtls_mpi_mod_modulus_free() has set the
-         * (mbedtls_mpi_uint *)m.rep.mont.rr -> NULL.
-         * Verify that the actual data have been zeroed */
-        ASSERT_COMPARE( rr, mp_size, &mp, mp_size );
     }
 exit:
     /* It should be safe to call an mbedtls free several times */

--- a/tests/suites/test_suite_bignum_mod.function
+++ b/tests/suites/test_suite_bignum_mod.function
@@ -17,13 +17,26 @@ void mpi_mod_setup( int ext_rep, int int_rep, int iret )
     #define MLIMBS 8
     mbedtls_mpi_uint mp[MLIMBS];
     mbedtls_mpi_mod_modulus m;
+    const size_t mp_size = sizeof(mbedtls_mpi_uint);
+    mbedtls_mpi_uint * rr;
     int ret;
 
-    memset( mp, 0xFF, sizeof(mp) );
+    memset( mp, 0xFF, mp_size );
 
     mbedtls_mpi_mod_modulus_init( &m );
     ret = mbedtls_mpi_mod_modulus_setup( &m, mp, MLIMBS, ext_rep, int_rep );
     TEST_EQUAL( ret, iret );
+
+    /* Only test if the constants have been set-up  */
+    if ( ret == 0 && int_rep == MBEDTLS_MPI_MOD_REP_MONTGOMERY )
+    {
+        /* Test that the consts have been calculated */
+        TEST_ASSERT( m.rep.mont.rr != NULL );
+        TEST_ASSERT( m.rep.mont.mm != 0 );
+
+        /* Keep a copy of the memory location used to store Montgomery const */
+        rr = (mbedtls_mpi_uint *)m.rep.mont.rr;
+    }
 
     /* Address sanitiser should catch if we try to free mp */
     mbedtls_mpi_mod_modulus_free( &m );
@@ -31,6 +44,21 @@ void mpi_mod_setup( int ext_rep, int int_rep, int iret )
     /* Make sure that the modulus doesn't have reference to mp anymore */
     TEST_ASSERT( m.p != mp );
 
+    /* Only test if the constants have been set-up  */
+    if ( ret == 0 && int_rep == MBEDTLS_MPI_MOD_REP_MONTGOMERY )
+    {
+        /* Reuse the allocated buffer for a zeroization check */
+        memset( mp, 0x00, mp_size );
+
+        /* Verify the data and pointers allocated have been properly wiped */
+        TEST_ASSERT( m.rep.mont.rr == NULL );
+        TEST_ASSERT( m.rep.mont.mm == 0 );
+
+        /* mbedtls_mpi_mod_modulus_free() has set the
+         * (mbedtls_mpi_uint *)m.rep.mont.rr -> NULL.
+         * Verify that the actual data have been zeroed */
+        ASSERT_COMPARE( rr, mp_size, &mp, mp_size );
+    }
 exit:
     /* It should be safe to call an mbedtls free several times */
     mbedtls_mpi_mod_modulus_free( &m );

--- a/tests/suites/test_suite_bignum_mod_raw.function
+++ b/tests/suites/test_suite_bignum_mod_raw.function
@@ -134,6 +134,7 @@ void mpi_mod_raw_cond_assign( data_t * input_X,
     ASSERT_ALLOC( Y, limbs );
 
     ASSERT_ALLOC( buff_m, limbs );
+    memset( buff_m, 0xFF, copy_bytes );
     TEST_ASSERT( mbedtls_mpi_mod_modulus_setup(
                         &m, buff_m, copy_limbs,
                         MBEDTLS_MPI_MOD_EXT_REP_BE,
@@ -214,6 +215,7 @@ void mpi_mod_raw_cond_swap( data_t * input_X,
     ASSERT_ALLOC( tmp_Y, limbs );
 
     ASSERT_ALLOC( buff_m, copy_limbs );
+    memset( buff_m, 0xFF, copy_bytes );
     TEST_ASSERT( mbedtls_mpi_mod_modulus_setup(
                         &m, buff_m, copy_limbs,
                         MBEDTLS_MPI_MOD_EXT_REP_BE,


### PR DESCRIPTION
Notes:
This pr expands the new bignum interface as follows:
* Adds a new struct `mbedtls_mpi_mont_struct` to store the inverse mod and Montgomery constant
* Updates `mbedtls_mpi_mod_modulus_setup/free()` to properly precacacluate and store, zeroise said fields.
* Adds tests

## Status
**READY**

## Requires Backporting
 NO  

## Migrations
If there is any API change, what's the incentive and logic for it.
NO