### PR TITLE
all.sh: support build & test on ARM64 Host

### DIFF
--- a/scripts/mbedtls_dev/c_build_helper.py
+++ b/scripts/mbedtls_dev/c_build_helper.py
@@ -137,7 +137,7 @@ def get_c_expression_values(
                                 universal_newlines=True)
         cc_is_msvc = 'Microsoft (R) C/C++' in proc.communicate()[1]
 
-        cflags = os.getenv('CFLAGS', '')
+        cflags = os.getenv('CFLAGS', None)
         cmd += [cflags] if cflags else []
 
         cmd += ['-I' + dir for dir in include_path]

--- a/scripts/mbedtls_dev/c_build_helper.py
+++ b/scripts/mbedtls_dev/c_build_helper.py
@@ -137,6 +137,9 @@ def get_c_expression_values(
                                 universal_newlines=True)
         cc_is_msvc = 'Microsoft (R) C/C++' in proc.communicate()[1]
 
+        cflags = os.getenv('CFLAGS', '')
+        cmd += [cflags] if cflags else []
+
         cmd += ['-I' + dir for dir in include_path]
         if cc_is_msvc:
             # MSVC has deprecated using -o to specify the output file,

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -981,7 +981,11 @@ component_check_changelog () {
 
 component_check_names () {
     msg "Check: declared and exported names (builds the library)" # < 3s
-    tests/scripts/check_names.py -v
+    SHA_CFLAGS=$(get_cc_march_sha256_512)
+    CFLAGS="$SHA_CFLAGS" tests/scripts/check_names.py -v
+}
+support_check_names () {
+    ! is_cc_target_aarch64 || is_cc_support_sha512_a64
 }
 
 component_check_test_cases () {

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -3170,6 +3170,7 @@ component_test_m32_o0 () {
 }
 support_test_m32_o0 () {
     case $(uname -m) in
+        aarch64) false;;
         *64*) true;;
         *) false;;
     esac

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1664,7 +1664,7 @@ component_test_full_cmake_clang () {
     programs/test/cpp_dummy_build
 
     msg "test: psa_constant_names (full config, clang)" # ~ 1s
-    tests/scripts/test_psa_constant_names.py
+    CC=clang CFLAGS="$SHA_CFLAGS" tests/scripts/test_psa_constant_names.py
 
     msg "test: ssl-opt.sh default, ECJPAKE, SSL async (full config)" # ~ 1s
     tests/ssl-opt.sh -f 'Default\|ECJPAKE\|SSL async private'

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -793,6 +793,15 @@ pre_generate_files() {
     fi
 }
 
+is_cc_target_aarch64() {
+    local cc=${1:-cc}
+    local target=$(${cc} -dumpmachine)
+    case ${target} in
+        *aarch64*) true;;
+        *) false;;
+    esac
+}
+
 
 
 ################################################################

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1921,75 +1921,162 @@ support_build_baremetal () {
 }
 
 # depends.py family of tests
+support_test_depends_py_test(){
+    ! is_cc_target_aarch64 || is_cc_support_sha512_a64
+}
 component_test_depends_py_cipher_id () {
     msg "test/build: depends.py cipher_id (gcc)"
+    if is_cc_target_aarch64; then
+        export CFLAGS="$(get_cc_march_sha256_512)"
+    fi
     tests/scripts/depends.py cipher_id --unset-use-psa
+}
+support_test_depends_py_cipher_id (){
+    support_test_depends_py_test
 }
 
 component_test_depends_py_cipher_chaining () {
     msg "test/build: depends.py cipher_chaining (gcc)"
+    if is_cc_target_aarch64; then
+        export CFLAGS="$(get_cc_march_sha256_512)"
+    fi
     tests/scripts/depends.py cipher_chaining --unset-use-psa
+}
+support_test_depends_py_cipher_chaining (){
+    support_test_depends_py_test
 }
 
 component_test_depends_py_cipher_padding () {
     msg "test/build: depends.py cipher_padding (gcc)"
+    if is_cc_target_aarch64; then
+        export CFLAGS="$(get_cc_march_sha256_512)"
+    fi
     tests/scripts/depends.py cipher_padding --unset-use-psa
+}
+support_test_depends_py_cipher_padding (){
+    support_test_depends_py_test
 }
 
 component_test_depends_py_curves () {
     msg "test/build: depends.py curves (gcc)"
+    if is_cc_target_aarch64; then
+        export CFLAGS="$(get_cc_march_sha256_512)"
+    fi
     tests/scripts/depends.py curves --unset-use-psa
+}
+support_test_depends_py_curves (){
+    support_test_depends_py_test
 }
 
 component_test_depends_py_hashes () {
     msg "test/build: depends.py hashes (gcc)"
+    if is_cc_target_aarch64; then
+        export CFLAGS="$(get_cc_march_sha256_512)"
+    fi
     tests/scripts/depends.py hashes --unset-use-psa
+}
+support_test_depends_py_hashes (){
+    support_test_depends_py_test
 }
 
 component_test_depends_py_kex () {
     msg "test/build: depends.py kex (gcc)"
+    if is_cc_target_aarch64; then
+        export CFLAGS="$(get_cc_march_sha256_512)"
+    fi
     tests/scripts/depends.py kex --unset-use-psa
+}
+support_test_depends_py_kex (){
+    support_test_depends_py_test
 }
 
 component_test_depends_py_pkalgs () {
     msg "test/build: depends.py pkalgs (gcc)"
+    if is_cc_target_aarch64; then
+        export CFLAGS="$(get_cc_march_sha256_512)"
+    fi
     tests/scripts/depends.py pkalgs --unset-use-psa
+}
+support_test_depends_py_pkalgs (){
+    support_test_depends_py_test
 }
 
 # PSA equivalents of the depends.py tests
 component_test_depends_py_cipher_id_psa () {
     msg "test/build: depends.py cipher_id (gcc) with MBEDTLS_USE_PSA_CRYPTO defined"
+    if is_cc_target_aarch64; then
+        export CFLAGS="$(get_cc_march_sha256_512)"
+    fi
     tests/scripts/depends.py cipher_id
+}
+support_test_depends_py_cipher_id_psa (){
+    support_test_depends_py_test
 }
 
 component_test_depends_py_cipher_chaining_psa () {
     msg "test/build: depends.py cipher_chaining (gcc) with MBEDTLS_USE_PSA_CRYPTO defined"
+    if is_cc_target_aarch64; then
+        export CFLAGS="$(get_cc_march_sha256_512)"
+    fi
     tests/scripts/depends.py cipher_chaining
+}
+support_test_depends_py_cipher_chaining_psa (){
+    support_test_depends_py_test
 }
 
 component_test_depends_py_cipher_padding_psa () {
     msg "test/build: depends.py cipher_padding (gcc) with MBEDTLS_USE_PSA_CRYPTO defined"
+    if is_cc_target_aarch64; then
+        export CFLAGS="$(get_cc_march_sha256_512)"
+    fi
     tests/scripts/depends.py cipher_padding
+}
+support_test_depends_py_cipher_padding_psa (){
+    support_test_depends_py_test
 }
 
 component_test_depends_py_curves_psa () {
     msg "test/build: depends.py curves (gcc) with MBEDTLS_USE_PSA_CRYPTO defined"
+    if is_cc_target_aarch64; then
+        export CFLAGS="$(get_cc_march_sha256_512)"
+    fi
     tests/scripts/depends.py curves
+}
+support_test_depends_py_curves_psa (){
+    support_test_depends_py_test
 }
 
 component_test_depends_py_hashes_psa () {
     msg "test/build: depends.py hashes (gcc) with MBEDTLS_USE_PSA_CRYPTO defined"
+    if is_cc_target_aarch64; then
+        export CFLAGS="$(get_cc_march_sha256_512)"
+    fi
     tests/scripts/depends.py hashes
+}
+support_test_depends_py_hashes_psa (){
+    support_test_depends_py_test
 }
 
 component_test_depends_py_kex_psa () {
     msg "test/build: depends.py kex (gcc) with MBEDTLS_USE_PSA_CRYPTO defined"
+    if is_cc_target_aarch64; then
+        export CFLAGS="$(get_cc_march_sha256_512)"
+    fi
     tests/scripts/depends.py kex
+}
+support_test_depends_py_kex_psa (){
+    support_test_depends_py_test
 }
 
 component_test_depends_py_pkalgs_psa () {
     msg "test/build: depends.py pkalgs (gcc) with MBEDTLS_USE_PSA_CRYPTO defined"
+    if is_cc_target_aarch64; then
+        export CFLAGS="$(get_cc_march_sha256_512)"
+    fi
     tests/scripts/depends.py pkalgs
+}
+support_test_depends_py_pkalgs_psa (){
+    support_test_depends_py_test
 }
 
 component_build_module_alt () {

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -907,7 +907,7 @@ prebuild_get_extra_cflags() {
         cflags+=("$march")
     fi
 
-    echo "${cflags[@]}"
+    echo "${cflags[@]:-}"
 }
 
 

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -863,25 +863,6 @@ check_cc_version() {
     fi
 }
 
-# Version compare based on 'sort -V'
-# In:
-#   * $1 first version
-#   * $2 second version
-# Out:
-#   'eq' if $1 and $2 are equal
-#   'lt' if $1 is less than $2
-#   'gt' if $1 is greater than $2
-version_compare() {
-    local v1=${1}
-    local v2=${2}
-
-    if [ "${v1}" = "${v2}" ]; then
-        echo "eq"
-    else
-        [[ $(echo -e "${v1}\n${v2}" | sort -V | head -n1) == "${v1}" ]] && echo "lt" || echo "gt"
-    fi
-}
-
 # Get the -march switch for sha256/512 acceleration
 get_cc_march_sha256_512 () {
     local cc=${1:-cc}
@@ -889,17 +870,7 @@ get_cc_march_sha256_512 () {
 
     # check if sha3 feature should be enabled
     if is_cc_support_sha512_a64 ${cc}; then
-        case $(${cc} --version 2>&1) in
-            *clang*)
-                local v1="$(${cc} -dumpversion)"
-                local v2="13.0.0"
-                [ "$(version_compare ${v1} ${v2})" == "gt" ] && \
-                    cflag="-march=armv8.2-a+sha3"
-                ;;
-            *gcc*|*cc*)
-                cflag="-march=armv8.2-a+sha3"
-                ;;
-        esac
+        cflag="-march=armv8.2-a+sha3"
     fi
 
     # check if crypto feature should be enabled

--- a/tests/scripts/check_names.py
+++ b/tests/scripts/check_names.py
@@ -644,6 +644,7 @@ class CodeParser():
             )
             my_environment = os.environ.copy()
             my_environment["CFLAGS"] = "-fno-asynchronous-unwind-tables"
+            my_environment["CFLAGS"] += " " + (os.environ.get('CFLAGS') or "")
             # Run make clean separately to lib to prevent unwanted behavior when
             # make is invoked with parallelism.
             subprocess.run(

--- a/tests/scripts/depends.py
+++ b/tests/scripts/depends.py
@@ -394,7 +394,7 @@ class DomainData:
 
     def __init__(self, options):
         """Gather data about the library and establish a list of domains to test."""
-        build_command = [options.make_command, 'CFLAGS=-Werror']
+        build_command = [options.make_command, 'CFLAGS+=-Werror']
         build_and_test = [build_command, [options.make_command, 'test']]
         self.all_config_symbols = set(collect_config_symbols(options))
         # Find hash modules by name.


### PR DESCRIPTION
## Description
fix  #5758
Resovles: Build on Arm64 HOST Fail

Add functions in `test/scripts/all.sh`:


- [x] Identify the `aarch64` target of the compiler on the host
- [x] Check if the compiler supports A64 SHA512 instructions based on its version
- [x] Generate the `-march` switch for SHA{512/256} acceleration
- [x] Check the compiler version and add `-march` switch for each components that enables `MBEDTLS_SHA{512/256}_USE_A64_CRYPTO_*`
- [x] Check and list issues for default compiler( clang, gcc)  issues of ubuntu16.04, ubuntu18.04, ubuntu20.04, ubuntu22.04)


## Status
**READY**


## Additional comments
This issue is related to incorrect `-march` settings when building with `MBEDTLS_SHA{512/256}_USE_A64_CRYPTO_*` enabled in `test/scripts/all.sh`. Since most components failed to build the lib with the similar reason, I chose two component tests (`check_names` and `test_full_cmake_clang`) to verify this change, which uses GCC and Clang for construction respectively.
Tested in Ubuntu 16.04/18.04/20.04/22.04 container on local ARM64 host.


### Ubuntu 16.04
- GCC version: 5.4.0
- Clang version: 4.2.1

Error:
- `check_names`:
  ```
  ../include/mbedtls/check_config.h:735:8: error: #error "A more recent GCC is required for MBEDTLS_SHA512_USE_A64_CRYPTO_*"
  ../include/mbedtls/check_config.h:772:2: error: #error "Must use minimum -march=armv8-a+crypto for MBEDTLS_SHA256_USE_A64_CRYPTO_*"
  ```
- `test_full_cmake_clang`:
  ```
  /var/lib/ws/include/mbedtls/check_config.h:726:8: error: "A more recent Clang is required for MBEDTLS_SHA512_USE_A64_CRYPTO_*"
  /var/lib/ws/include/mbedtls/check_config.h:772:2: error: "Must use minimum -march=armv8-a+crypto for MBEDTLS_SHA256_USE_A64_CRYPTO_*"
  ```

Fix:
- `check_names`: not supported
- `test_full_cmake_clang`: not supported


### Ubuntu 18.04
 - GCC version: 7.5.0
 - Clang version: 4.2.1

Error:
- `check_names`:
  ```
  ../include/mbedtls/check_config.h:735:8: error: #error "A more recent GCC is required for MBEDTLS_SHA512_USE_A64_CRYPTO_*"
  ../include/mbedtls/check_config.h:772:2: error: #error "Must use minimum -march=armv8-a+crypto for MBEDTLS_SHA256_USE_A64_CRYPTO_*"
  ```
- `test_full_cmake_clang`:
  ```
  /var/lib/ws/include/mbedtls/check_config.h:726:8: error: "A more recent Clang is required for MBEDTLS_SHA512_USE_A64_CRYPTO_*"
  /var/lib/ws/include/mbedtls/check_config.h:772:2: error: "Must use minimum -march=armv8-a+crypto for MBEDTLS_SHA256_USE_A64_CRYPTO_*"
  ```

Fix:
- `check_names`: not supported
- `test_full_cmake_clang`: not supported


### Ubuntu 20.04
- GCC version: 9.4.0
- Clang version: 10.0.0

Error:
- `check_names`:
  ```
  ../include/mbedtls/check_config.h:737:8: error: #error "Must use minimum -march=armv8.2-a+sha3 for MBEDTLS_SHA512_USE_A64_CRYPTO_*"
  ../include/mbedtls/check_config.h:772:2: error: #error "Must use minimum -march=armv8-a+crypto for MBEDTLS_SHA256_USE_A64_CRYPTO_*"
  ```
- `test_full_cmake_clang`:
  ```
  /var/lib/ws/include/mbedtls/check_config.h:772:2: error: "Must use minimum -march=armv8-a+crypto for MBEDTLS_SHA256_USE_A64_CRYPTO_*"
  ```

Fix:
- `check_names`: Pass
- `test_full_cmake_clang`: Build failed with new error
  ```
  /var/lib/ws/library/sha512.c:322:10: error: instruction requires: sha3
      asm( "sha512h %0,%1,%2.2D" : "+w" (x) : "w" (y), "w" (z) );
           ^

  <inline asm>:1:2: note: instantiated into assembly here                                                                                 
          sha512h v30,v28,v29.2D         
          ^
  ```

### Ubuntu 22.04
- GCC version: 11.2.0
- Clang version: 14.0.0

Error:
- `check_names`:
  ```
  ../include/mbedtls/check_config.h:737:8: error: #error "Must use minimum -march=armv8.2-a+sha3 for MBEDTLS_SHA512_USE_A64_CRYPTO_*"
  ../include/mbedtls/check_config.h:772:2: error: #error "Must use minimum -march=armv8-a+crypto for MBEDTLS_SHA256_USE_A64_CRYPTO_*"
  ```
- `test_full_cmake_clang`:
  ```
  /var/lib/ws/include/mbedtls/check_config.h:731:8: error: "Must use minimum -march=armv8.2-a+sha3 for MBEDTLS_SHA512_USE_A64_CRYPTO_*"
  /var/lib/ws/include/mbedtls/check_config.h:772:2: error: "Must use minimum -march=armv8-a+crypto for MBEDTLS_SHA256_USE_A64_CRYPTO_*"
  ```

Fix:
- `check_names`: Pass
- `test_full_cmake_clang`: Build successed, tests with failures
  ```
  96% tests passed, 4 tests failed out of 98

  Total Test time (real) = 164.42 sec

  The following tests FAILED:
            7 - aria-suite (ILLEGAL)
           16 - cipher.aria-suite (ILLEGAL)
           89 - psa_crypto_storage_format.v0-suite (ILLEGAL)
           94 - ssl-suite (ILLEGAL)
  ```
  Seems to be out of the scope of this PR, have raised a new issue #6480