### PR TITLE
Make ChangeLog more visible in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,6 +17,10 @@ Changes do not have to be backported if:
 Yes | NO  
 Which branch?
 
+## Requires ChangeLog entry
+
+YES | NO - if no, why not?
+
 ## Migrations
 If there is any API change, what's the incentive and logic for it.
 


### PR DESCRIPTION
While waiting for us to implement a more automated solution to avoid forgotten ChangeLog entries, we should at least try to document explicitly when a PR doesn't need an entry, to helpthe pour soul that will have to double-check all PRs for missing entries when preparing the next release.

This is a small step in encouraging that. I'm aware that no everyone uses the PR template (case in point), but some contributors do, so while this is far from a complete solution, this is a simple step with non-zero usefulness.

Needs backports: should check if the template is always taken from the default branch, or from the target branch.
Needs ChangeLog entry: nope, not a user-visible change in the product.
