### PR TITLE
Allow PSA hash operations without psa_crypto_init

### DIFF
--- a/ChangeLog.d/psa_hash_without_init.txt
+++ b/ChangeLog.d/psa_hash_without_init.txt
@@ -1,0 +1,4 @@
+Features
+   * Document that PSA hash operations don't require psa_crypto_init(). This
+     has always been possible, but was not previously explicitly stated. This
+     does not necessarily apply to a PSA crypto service built on Mbed TLS.

--- a/include/psa/crypto.h
+++ b/include/psa/crypto.h
@@ -378,8 +378,6 @@ static size_t psa_get_key_bits(const psa_key_attributes_t *attributes);
  * \retval #PSA_ERROR_DATA_INVALID
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_get_key_attributes(mbedtls_svc_key_id_t key,
                                     psa_key_attributes_t *attributes);
@@ -422,8 +420,6 @@ void psa_reset_key_attributes(psa_key_attributes_t *attributes);
  *         \p key is not a valid key identifier.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_purge_key(mbedtls_svc_key_id_t key);
 
@@ -512,8 +508,6 @@ psa_status_t psa_purge_key(mbedtls_svc_key_id_t key);
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_copy_key(mbedtls_svc_key_id_t source_key,
                           const psa_key_attributes_t *attributes,
@@ -562,8 +556,6 @@ psa_status_t psa_copy_key(mbedtls_svc_key_id_t source_key,
  *         been compromised.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_destroy_key(mbedtls_svc_key_id_t key);
 
@@ -641,8 +633,6 @@ psa_status_t psa_destroy_key(mbedtls_svc_key_id_t key);
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_import_key(const psa_key_attributes_t *attributes,
                             const uint8_t *data,
@@ -736,8 +726,6 @@ psa_status_t psa_import_key(const psa_key_attributes_t *attributes,
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_export_key(mbedtls_svc_key_id_t key,
                             uint8_t *data,
@@ -811,8 +799,6 @@ psa_status_t psa_export_key(mbedtls_svc_key_id_t key,
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_export_public_key(mbedtls_svc_key_id_t key,
                                    uint8_t *data,
@@ -1179,8 +1165,6 @@ psa_status_t psa_hash_clone(const psa_hash_operation_t *source_operation,
  *         The key could not be retrieved from storage.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_mac_compute(mbedtls_svc_key_id_t key,
                              psa_algorithm_t alg,
@@ -1220,8 +1204,6 @@ psa_status_t psa_mac_compute(mbedtls_svc_key_id_t key,
  *         The key could not be retrieved from storage.
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_mac_verify(mbedtls_svc_key_id_t key,
                             psa_algorithm_t alg,
@@ -1326,8 +1308,6 @@ static psa_mac_operation_t psa_mac_operation_init(void);
  * \retval #PSA_ERROR_BAD_STATE
  *         The operation state is not valid (it must be inactive), or
  *         the library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_mac_sign_setup(psa_mac_operation_t *operation,
                                 mbedtls_svc_key_id_t key,
@@ -1388,8 +1368,6 @@ psa_status_t psa_mac_sign_setup(psa_mac_operation_t *operation,
  * \retval #PSA_ERROR_BAD_STATE
  *         The operation state is not valid (it must be inactive), or
  *         the library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_mac_verify_setup(psa_mac_operation_t *operation,
                                   mbedtls_svc_key_id_t key,
@@ -1418,8 +1396,6 @@ psa_status_t psa_mac_verify_setup(psa_mac_operation_t *operation,
  * \retval #PSA_ERROR_BAD_STATE
  *         The operation state is not valid (it must be active), or
  *         the library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_mac_update(psa_mac_operation_t *operation,
                             const uint8_t *input,
@@ -1467,8 +1443,6 @@ psa_status_t psa_mac_update(psa_mac_operation_t *operation,
  *         The operation state is not valid (it must be an active mac sign
  *         operation), or the library has not been previously initialized
  *         by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_mac_sign_finish(psa_mac_operation_t *operation,
                                  uint8_t *mac,
@@ -1510,8 +1484,6 @@ psa_status_t psa_mac_sign_finish(psa_mac_operation_t *operation,
  *         The operation state is not valid (it must be an active mac verify
  *         operation), or the library has not been previously initialized
  *         by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_mac_verify_finish(psa_mac_operation_t *operation,
                                    const uint8_t *mac,
@@ -1539,8 +1511,6 @@ psa_status_t psa_mac_verify_finish(psa_mac_operation_t *operation,
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_mac_abort(psa_mac_operation_t *operation);
 
@@ -1586,8 +1556,6 @@ psa_status_t psa_mac_abort(psa_mac_operation_t *operation);
  * \retval #PSA_ERROR_STORAGE_FAILURE
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_cipher_encrypt(mbedtls_svc_key_id_t key,
                                 psa_algorithm_t alg,
@@ -1633,8 +1601,6 @@ psa_status_t psa_cipher_encrypt(mbedtls_svc_key_id_t key,
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_cipher_decrypt(mbedtls_svc_key_id_t key,
                                 psa_algorithm_t alg,
@@ -1740,8 +1706,6 @@ static psa_cipher_operation_t psa_cipher_operation_init(void);
  * \retval #PSA_ERROR_BAD_STATE
  *         The operation state is not valid (it must be inactive), or
  *         the library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_cipher_encrypt_setup(psa_cipher_operation_t *operation,
                                       mbedtls_svc_key_id_t key,
@@ -1803,8 +1767,6 @@ psa_status_t psa_cipher_encrypt_setup(psa_cipher_operation_t *operation,
  * \retval #PSA_ERROR_BAD_STATE
  *         The operation state is not valid (it must be inactive), or
  *         the library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_cipher_decrypt_setup(psa_cipher_operation_t *operation,
                                       mbedtls_svc_key_id_t key,
@@ -1841,8 +1803,6 @@ psa_status_t psa_cipher_decrypt_setup(psa_cipher_operation_t *operation,
  *         The operation state is not valid (it must be active, with no IV set),
  *         or the library has not been previously initialized
  *         by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_cipher_generate_iv(psa_cipher_operation_t *operation,
                                     uint8_t *iv,
@@ -1882,8 +1842,6 @@ psa_status_t psa_cipher_generate_iv(psa_cipher_operation_t *operation,
  *         The operation state is not valid (it must be an active cipher
  *         encrypt operation, with no IV set), or the library has not been
  *         previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_cipher_set_iv(psa_cipher_operation_t *operation,
                                const uint8_t *iv,
@@ -1923,8 +1881,6 @@ psa_status_t psa_cipher_set_iv(psa_cipher_operation_t *operation,
  *         The operation state is not valid (it must be active, with an IV set
  *         if required for the algorithm), or the library has not been
  *         previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_cipher_update(psa_cipher_operation_t *operation,
                                const uint8_t *input,
@@ -1975,8 +1931,6 @@ psa_status_t psa_cipher_update(psa_cipher_operation_t *operation,
  *         The operation state is not valid (it must be active, with an IV set
  *         if required for the algorithm), or the library has not been
  *         previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_cipher_finish(psa_cipher_operation_t *operation,
                                uint8_t *output,
@@ -2005,8 +1959,6 @@ psa_status_t psa_cipher_finish(psa_cipher_operation_t *operation,
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_cipher_abort(psa_cipher_operation_t *operation);
 
@@ -2074,8 +2026,6 @@ psa_status_t psa_cipher_abort(psa_cipher_operation_t *operation);
  * \retval #PSA_ERROR_STORAGE_FAILURE
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_aead_encrypt(mbedtls_svc_key_id_t key,
                               psa_algorithm_t alg,
@@ -2147,8 +2097,6 @@ psa_status_t psa_aead_encrypt(mbedtls_svc_key_id_t key,
  * \retval #PSA_ERROR_STORAGE_FAILURE
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_aead_decrypt(mbedtls_svc_key_id_t key,
                               psa_algorithm_t alg,
@@ -2265,8 +2213,6 @@ static psa_aead_operation_t psa_aead_operation_init(void);
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
  * \retval #PSA_ERROR_STORAGE_FAILURE
  *         The library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_aead_encrypt_setup(psa_aead_operation_t *operation,
                                     mbedtls_svc_key_id_t key,
@@ -2331,8 +2277,6 @@ psa_status_t psa_aead_encrypt_setup(psa_aead_operation_t *operation,
  * \retval #PSA_ERROR_BAD_STATE
  *         The operation state is not valid (it must be inactive), or the
  *         library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_aead_decrypt_setup(psa_aead_operation_t *operation,
                                     mbedtls_svc_key_id_t key,
@@ -2370,8 +2314,6 @@ psa_status_t psa_aead_decrypt_setup(psa_aead_operation_t *operation,
  *         The operation state is not valid (it must be an active aead encrypt
  *         operation, with no nonce set), or the library has not been
  *         previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_aead_generate_nonce(psa_aead_operation_t *operation,
                                      uint8_t *nonce,
@@ -2410,8 +2352,6 @@ psa_status_t psa_aead_generate_nonce(psa_aead_operation_t *operation,
  *         The operation state is not valid (it must be active, with no nonce
  *         set), or the library has not been previously initialized
  *         by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_aead_set_nonce(psa_aead_operation_t *operation,
                                 const uint8_t *nonce,
@@ -2455,8 +2395,6 @@ psa_status_t psa_aead_set_nonce(psa_aead_operation_t *operation,
  *         psa_aead_update_ad() and psa_aead_update() must not have been
  *         called yet), or the library has not been previously initialized
  *         by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_aead_set_lengths(psa_aead_operation_t *operation,
                                   size_t ad_length,
@@ -2503,8 +2441,6 @@ psa_status_t psa_aead_set_lengths(psa_aead_operation_t *operation,
  *         set, have lengths set if required by the algorithm, and
  *         psa_aead_update() must not have been called yet), or the library
  *         has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_aead_update_ad(psa_aead_operation_t *operation,
                                 const uint8_t *input,
@@ -2587,8 +2523,6 @@ psa_status_t psa_aead_update_ad(psa_aead_operation_t *operation,
  *         The operation state is not valid (it must be active, have a nonce
  *         set, and have lengths set if required by the algorithm), or the
  *         library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_aead_update(psa_aead_operation_t *operation,
                              const uint8_t *input,
@@ -2673,8 +2607,6 @@ psa_status_t psa_aead_update(psa_aead_operation_t *operation,
  *         The operation state is not valid (it must be an active encryption
  *         operation with a nonce set), or the library has not been previously
  *         initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_aead_finish(psa_aead_operation_t *operation,
                              uint8_t *ciphertext,
@@ -2756,8 +2688,6 @@ psa_status_t psa_aead_finish(psa_aead_operation_t *operation,
  *         The operation state is not valid (it must be an active decryption
  *         operation with a nonce set), or the library has not been previously
  *         initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_aead_verify(psa_aead_operation_t *operation,
                              uint8_t *plaintext,
@@ -2788,8 +2718,6 @@ psa_status_t psa_aead_verify(psa_aead_operation_t *operation,
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_aead_abort(psa_aead_operation_t *operation);
 
@@ -2854,8 +2782,6 @@ psa_status_t psa_aead_abort(psa_aead_operation_t *operation);
  * \retval #PSA_ERROR_INSUFFICIENT_ENTROPY
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_sign_message( mbedtls_svc_key_id_t key,
                                psa_algorithm_t alg,
@@ -2906,8 +2832,6 @@ psa_status_t psa_sign_message( mbedtls_svc_key_id_t key,
  * \retval #PSA_ERROR_DATA_INVALID
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_verify_message( mbedtls_svc_key_id_t key,
                                  psa_algorithm_t alg,
@@ -2959,8 +2883,6 @@ psa_status_t psa_verify_message( mbedtls_svc_key_id_t key,
  * \retval #PSA_ERROR_INSUFFICIENT_ENTROPY
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_sign_hash(mbedtls_svc_key_id_t key,
                            psa_algorithm_t alg,
@@ -3010,8 +2932,6 @@ psa_status_t psa_sign_hash(mbedtls_svc_key_id_t key,
  * \retval #PSA_ERROR_STORAGE_FAILURE
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_verify_hash(mbedtls_svc_key_id_t key,
                              psa_algorithm_t alg,
@@ -3068,8 +2988,6 @@ psa_status_t psa_verify_hash(mbedtls_svc_key_id_t key,
  * \retval #PSA_ERROR_INSUFFICIENT_ENTROPY
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_asymmetric_encrypt(mbedtls_svc_key_id_t key,
                                     psa_algorithm_t alg,
@@ -3129,8 +3047,6 @@ psa_status_t psa_asymmetric_encrypt(mbedtls_svc_key_id_t key,
  * \retval #PSA_ERROR_INVALID_PADDING
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_asymmetric_decrypt(mbedtls_svc_key_id_t key,
                                     psa_algorithm_t alg,
@@ -3244,8 +3160,6 @@ static psa_key_derivation_operation_t psa_key_derivation_operation_init(void);
  * \retval #PSA_ERROR_BAD_STATE
  *         The operation state is not valid (it must be inactive), or
  *         the library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_key_derivation_setup(
     psa_key_derivation_operation_t *operation,
@@ -3267,8 +3181,6 @@ psa_status_t psa_key_derivation_setup(
  * \retval #PSA_ERROR_BAD_STATE
  *         The operation state is not valid (it must be active), or
  *         the library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_key_derivation_get_capacity(
     const psa_key_derivation_operation_t *operation,
@@ -3295,8 +3207,6 @@ psa_status_t psa_key_derivation_get_capacity(
  * \retval #PSA_ERROR_BAD_STATE
  *         The operation state is not valid (it must be active), or the
  *         library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_key_derivation_set_capacity(
     psa_key_derivation_operation_t *operation,
@@ -3348,8 +3258,6 @@ psa_status_t psa_key_derivation_set_capacity(
  * \retval #PSA_ERROR_BAD_STATE
  *         The operation state is not valid for this input \p step, or
  *         the library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_key_derivation_input_bytes(
     psa_key_derivation_operation_t *operation,
@@ -3391,8 +3299,6 @@ psa_status_t psa_key_derivation_input_bytes(
  * \retval #PSA_ERROR_BAD_STATE
  *         The operation state is not valid for this input \p step, or
  *         the library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_key_derivation_input_integer(
     psa_key_derivation_operation_t *operation,
@@ -3458,8 +3364,6 @@ psa_status_t psa_key_derivation_input_integer(
  * \retval #PSA_ERROR_BAD_STATE
  *         The operation state is not valid for this input \p step, or
  *         the library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_key_derivation_input_key(
     psa_key_derivation_operation_t *operation,
@@ -3526,8 +3430,6 @@ psa_status_t psa_key_derivation_input_key(
  * \retval #PSA_ERROR_BAD_STATE
  *         The operation state is not valid for this key agreement \p step,
  *         or the library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_key_derivation_key_agreement(
     psa_key_derivation_operation_t *operation,
@@ -3573,8 +3475,6 @@ psa_status_t psa_key_derivation_key_agreement(
  *         The operation state is not valid (it must be active and completed
  *         all required input steps), or the library has not been previously
  *         initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_key_derivation_output_bytes(
     psa_key_derivation_operation_t *operation,
@@ -3723,8 +3623,6 @@ psa_status_t psa_key_derivation_output_bytes(
  *         The operation state is not valid (it must be active and completed
  *         all required input steps), or the library has not been previously
  *         initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_key_derivation_output_key(
     const psa_key_attributes_t *attributes,
@@ -3781,8 +3679,6 @@ psa_status_t psa_key_derivation_output_key(
  *         The operation state is not valid (it must be active and completed
  *         all required input steps), or the library has not been previously
  *         initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_key_derivation_verify_bytes(
     psa_key_derivation_operation_t *operation,
@@ -3845,8 +3741,6 @@ psa_status_t psa_key_derivation_verify_bytes(
  *         The operation state is not valid (it must be active and completed
  *         all required input steps), or the library has not been previously
  *         initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_key_derivation_verify_key(
     psa_key_derivation_operation_t *operation,
@@ -3872,8 +3766,6 @@ psa_status_t psa_key_derivation_verify_key(
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_key_derivation_abort(
     psa_key_derivation_operation_t *operation);
@@ -3925,8 +3817,6 @@ psa_status_t psa_key_derivation_abort(
  * \retval #PSA_ERROR_STORAGE_FAILURE
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_raw_key_agreement(psa_algorithm_t alg,
                                    mbedtls_svc_key_id_t private_key,
@@ -3963,8 +3853,6 @@ psa_status_t psa_raw_key_agreement(psa_algorithm_t alg,
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_generate_random(uint8_t *output,
                                  size_t output_size);
@@ -4010,8 +3898,6 @@ psa_status_t psa_generate_random(uint8_t *output,
  * \retval #PSA_ERROR_STORAGE_FAILURE
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_generate_key(const psa_key_attributes_t *attributes,
                               mbedtls_svc_key_id_t *key);

--- a/include/psa/crypto.h
+++ b/include/psa/crypto.h
@@ -853,10 +853,6 @@ psa_status_t psa_export_public_key(mbedtls_svc_key_id_t key,
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
  * \retval #PSA_ERROR_HARDWARE_FAILURE
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
- * \retval #PSA_ERROR_BAD_STATE
- *         The library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_hash_compute(psa_algorithm_t alg,
                               const uint8_t *input,
@@ -888,10 +884,6 @@ psa_status_t psa_hash_compute(psa_algorithm_t alg,
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
  * \retval #PSA_ERROR_HARDWARE_FAILURE
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
- * \retval #PSA_ERROR_BAD_STATE
- *         The library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_hash_compare(psa_algorithm_t alg,
                               const uint8_t *input,
@@ -982,10 +974,7 @@ static psa_hash_operation_t psa_hash_operation_init(void);
  * \retval #PSA_ERROR_HARDWARE_FAILURE
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
  * \retval #PSA_ERROR_BAD_STATE
- *         The operation state is not valid (it must be inactive), or
- *         the library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
+ *         The operation state is not valid (it must be inactive).
  */
 psa_status_t psa_hash_setup(psa_hash_operation_t *operation,
                             psa_algorithm_t alg);
@@ -1008,10 +997,7 @@ psa_status_t psa_hash_setup(psa_hash_operation_t *operation,
  * \retval #PSA_ERROR_HARDWARE_FAILURE
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
  * \retval #PSA_ERROR_BAD_STATE
- *         The operation state is not valid (it must be active), or
- *         the library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
+ *         The operation state is not valid (it must be active).
  */
 psa_status_t psa_hash_update(psa_hash_operation_t *operation,
                              const uint8_t *input,
@@ -1054,10 +1040,7 @@ psa_status_t psa_hash_update(psa_hash_operation_t *operation,
  * \retval #PSA_ERROR_HARDWARE_FAILURE
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
  * \retval #PSA_ERROR_BAD_STATE
- *         The operation state is not valid (it must be active), or
- *         the library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
+ *         The operation state is not valid (it must be active).
  */
 psa_status_t psa_hash_finish(psa_hash_operation_t *operation,
                              uint8_t *hash,
@@ -1095,10 +1078,7 @@ psa_status_t psa_hash_finish(psa_hash_operation_t *operation,
  * \retval #PSA_ERROR_HARDWARE_FAILURE
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
  * \retval #PSA_ERROR_BAD_STATE
- *         The operation state is not valid (it must be active), or
- *         the library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
+ *         The operation state is not valid (it must be active).
  */
 psa_status_t psa_hash_verify(psa_hash_operation_t *operation,
                              const uint8_t *hash,
@@ -1124,10 +1104,6 @@ psa_status_t psa_hash_verify(psa_hash_operation_t *operation,
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
  * \retval #PSA_ERROR_HARDWARE_FAILURE
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
- * \retval #PSA_ERROR_BAD_STATE
- *         The library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_hash_abort(psa_hash_operation_t *operation);
 
@@ -1153,10 +1129,7 @@ psa_status_t psa_hash_abort(psa_hash_operation_t *operation);
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
  * \retval #PSA_ERROR_BAD_STATE
  *         The \p source_operation state is not valid (it must be active), or
- *         the \p target_operation state is not valid (it must be inactive), or
- *         the library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
+ *         the \p target_operation state is not valid (it must be inactive).
  */
 psa_status_t psa_hash_clone(const psa_hash_operation_t *source_operation,
                             psa_hash_operation_t *target_operation);

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -196,8 +196,6 @@ static inline void psa_clear_key_slot_number(
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t mbedtls_psa_register_se_key(
     const psa_key_attributes_t *attributes);
@@ -1358,8 +1356,6 @@ static psa_pake_operation_t psa_pake_operation_init( void );
  * \retval #PSA_ERROR_BAD_STATE
  *         The operation state is not valid, or
  *         the library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_pake_setup( psa_pake_operation_t *operation,
                              const psa_pake_cipher_suite_t *cipher_suite );
@@ -1406,8 +1402,6 @@ psa_status_t psa_pake_setup( psa_pake_operation_t *operation,
  * \retval #PSA_ERROR_BAD_STATE
  *         The operation state is not valid (it must have been set up.), or
  *         the library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_pake_set_password_key( psa_pake_operation_t *operation,
                                         mbedtls_svc_key_id_t password );
@@ -1446,8 +1440,6 @@ psa_status_t psa_pake_set_password_key( psa_pake_operation_t *operation,
  * \retval #PSA_ERROR_BAD_STATE
  *         The operation state is not valid, or
  *         the library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_pake_set_user( psa_pake_operation_t *operation,
                                 const uint8_t *user_id,
@@ -1488,8 +1480,6 @@ psa_status_t psa_pake_set_user( psa_pake_operation_t *operation,
  *         Calling psa_pake_set_peer() is invalid with the \p operation's
  *         algorithm, the operation state is not valid, or the library has not
  *         been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_pake_set_peer( psa_pake_operation_t *operation,
                                 const uint8_t *peer_id,
@@ -1530,8 +1520,6 @@ psa_status_t psa_pake_set_peer( psa_pake_operation_t *operation,
  * \retval #PSA_ERROR_BAD_STATE
  *         The operation state is not valid, or
  *         the library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_pake_set_role( psa_pake_operation_t *operation,
                                 psa_pake_role_t role );
@@ -1588,8 +1576,6 @@ psa_status_t psa_pake_set_role( psa_pake_operation_t *operation,
  *         up, and this call must conform to the algorithm's requirements
  *         for ordering of input and output steps), or
  *         the library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_pake_output( psa_pake_operation_t *operation,
                               psa_pake_step_t step,
@@ -1643,8 +1629,6 @@ psa_status_t psa_pake_output( psa_pake_operation_t *operation,
  *         up, and this call must conform to the algorithm's requirements
  *         for ordering of input and output steps), or
  *         the library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_pake_input( psa_pake_operation_t *operation,
                              psa_pake_step_t step,
@@ -1706,8 +1690,6 @@ psa_status_t psa_pake_input( psa_pake_operation_t *operation,
  *         the #PSA_KEY_DERIVATION_INPUT_SECRET step. This can happen if the
  *         step is out of order or the application has done this step already
  *         and it may not be repeated.
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_pake_get_implicit_key( psa_pake_operation_t *operation,
                                         psa_key_derivation_operation_t *output );
@@ -1733,8 +1715,6 @@ psa_status_t psa_pake_get_implicit_key( psa_pake_operation_t *operation,
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
- *         It is implementation-dependent whether a failure to initialize
- *         results in this error code.
  */
 psa_status_t psa_pake_abort( psa_pake_operation_t * operation );
 

--- a/tests/suites/test_suite_psa_crypto.data
+++ b/tests/suites/test_suite_psa_crypto.data
@@ -1445,8 +1445,11 @@ Copy fail: AES, across locations (unsupported) in attributes
 depends_on:PSA_WANT_ALG_CTR:PSA_WANT_KEY_TYPE_AES:PSA_CRYPTO_DRIVER_TEST
 copy_fail:PSA_KEY_USAGE_COPY | PSA_KEY_USAGE_ENCRYPT | PSA_KEY_USAGE_EXPORT:PSA_ALG_CTR:0:PSA_KEY_LIFETIME_FROM_PERSISTENCE_AND_LOCATION(PSA_KEY_PERSISTENCE_VOLATILE, TEST_DRIVER_LOCATION):PSA_KEY_TYPE_AES:"404142434445464748494a4b4c4d4e4f":PSA_KEY_TYPE_AES:0:PSA_KEY_USAGE_COPY | PSA_KEY_USAGE_ENCRYPT | PSA_KEY_USAGE_EXPORT:PSA_ALG_CTR:0:1:PSA_KEY_LIFETIME_FROM_PERSISTENCE_AND_LOCATION(PSA_KEY_PERSISTENCE_VOLATILE, 0):PSA_ERROR_NOT_SUPPORTED
 
-Hash operation object initializers zero properly
-hash_operation_init:
+Hash operation object initializers zero properly (without psa_crypto_init)
+hash_operation_init:0
+
+Hash operation object initializers zero properly (with psa_crypto_init)
+hash_operation_init:1
 
 PSA hash setup: good, SHA-1
 depends_on:PSA_WANT_ALG_SHA_1
@@ -1488,8 +1491,11 @@ PSA hash setup: bad (not a hash algorithm)
 depends_on:PSA_WANT_ALG_HMAC:PSA_WANT_ALG_SHA_256
 hash_setup:PSA_ALG_HMAC(PSA_ALG_SHA_256):PSA_ERROR_INVALID_ARGUMENT
 
-PSA hash: bad order function calls
-hash_bad_order:
+PSA hash: bad order function calls (without psa_crypto_init)
+hash_bad_order:0
+
+PSA hash: bad order function calls (with psa_crypto_init)
+hash_bad_order:1
 
 PSA hash verify: bad arguments
 hash_verify_bad_args:

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -2588,8 +2588,6 @@ void hash_setup( int alg_arg,
     psa_hash_operation_t operation = PSA_HASH_OPERATION_INIT;
     psa_status_t status;
 
-    PSA_ASSERT( psa_crypto_init( ) );
-
     /* Hash Setup, one-shot */
     output_size = PSA_HASH_LENGTH( alg );
     ASSERT_ALLOC( output, output_size );
@@ -2618,7 +2616,6 @@ void hash_setup( int alg_arg,
 
 exit:
     mbedtls_free( output );
-    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -2635,8 +2632,6 @@ void hash_compute_fail( int alg_arg, data_t *input,
     psa_status_t status;
 
     ASSERT_ALLOC( output, output_size );
-
-    PSA_ASSERT( psa_crypto_init( ) );
 
     /* Hash Compute, one-shot */
     status = psa_hash_compute( alg, input->x, input->len,
@@ -2671,7 +2666,6 @@ void hash_compute_fail( int alg_arg, data_t *input,
 exit:
     PSA_ASSERT( psa_hash_abort( &operation ) );
     mbedtls_free( output );
-    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -2684,8 +2678,6 @@ void hash_compare_fail( int alg_arg, data_t *input,
     psa_status_t expected_status = expected_status_arg;
     psa_hash_operation_t operation = PSA_HASH_OPERATION_INIT;
     psa_status_t status;
-
-    PSA_ASSERT( psa_crypto_init( ) );
 
     /* Hash Compare, one-shot */
     status = psa_hash_compare( alg, input->x, input->len,
@@ -2715,7 +2707,6 @@ void hash_compare_fail( int alg_arg, data_t *input,
 
 exit:
     PSA_ASSERT( psa_hash_abort( &operation ) );
-    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -2728,8 +2719,6 @@ void hash_compute_compare( int alg_arg, data_t *input,
     size_t output_length = INVALID_EXPORT_LENGTH;
     psa_hash_operation_t operation = PSA_HASH_OPERATION_INIT;
     size_t i;
-
-    PSA_ASSERT( psa_crypto_init( ) );
 
     /* Compute with tight buffer, one-shot */
     PSA_ASSERT( psa_hash_compute( alg, input->x, input->len,
@@ -2820,7 +2809,6 @@ void hash_compute_compare( int alg_arg, data_t *input,
 
 exit:
     PSA_ASSERT( psa_hash_abort( &operation ) );
-    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -2941,8 +2929,6 @@ void hash_verify_bad_args( )
     size_t expected_size = PSA_HASH_LENGTH( alg );
     psa_hash_operation_t operation = PSA_HASH_OPERATION_INIT;
 
-    PSA_ASSERT( psa_crypto_init( ) );
-
     /* psa_hash_verify with a smaller hash than expected */
     PSA_ASSERT( psa_hash_setup( &operation, alg ) );
     ASSERT_OPERATION_IS_ACTIVE( operation );
@@ -2961,9 +2947,6 @@ void hash_verify_bad_args( )
     PSA_ASSERT( psa_hash_setup( &operation, alg ) );
     TEST_EQUAL( psa_hash_verify( &operation, hash, sizeof( hash ) ),
                 PSA_ERROR_INVALID_SIGNATURE );
-
-exit:
-    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -2976,16 +2959,11 @@ void hash_finish_bad_args( )
     psa_hash_operation_t operation = PSA_HASH_OPERATION_INIT;
     size_t hash_len;
 
-    PSA_ASSERT( psa_crypto_init( ) );
-
     /* psa_hash_finish with a smaller hash buffer than expected */
     PSA_ASSERT( psa_hash_setup( &operation, alg ) );
     TEST_EQUAL( psa_hash_finish( &operation,
                                  hash, expected_size - 1, &hash_len ),
                 PSA_ERROR_BUFFER_TOO_SMALL );
-
-exit:
-    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -3001,7 +2979,6 @@ void hash_clone_source_state( )
     psa_hash_operation_t op_aborted = PSA_HASH_OPERATION_INIT;
     size_t hash_len;
 
-    PSA_ASSERT( psa_crypto_init( ) );
     PSA_ASSERT( psa_hash_setup( &op_source, alg ) );
 
     PSA_ASSERT( psa_hash_setup( &op_setup, alg ) );
@@ -3030,7 +3007,6 @@ exit:
     psa_hash_abort( &op_setup );
     psa_hash_abort( &op_finished );
     psa_hash_abort( &op_aborted );
-    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -3045,8 +3021,6 @@ void hash_clone_target_state( )
     psa_hash_operation_t op_aborted = PSA_HASH_OPERATION_INIT;
     psa_hash_operation_t op_target = PSA_HASH_OPERATION_INIT;
     size_t hash_len;
-
-    PSA_ASSERT( psa_crypto_init( ) );
 
     PSA_ASSERT( psa_hash_setup( &op_setup, alg ) );
     PSA_ASSERT( psa_hash_setup( &op_finished, alg ) );
@@ -3071,7 +3045,6 @@ exit:
     psa_hash_abort( &op_setup );
     psa_hash_abort( &op_finished );
     psa_hash_abort( &op_aborted );
-    PSA_DONE( );
 }
 /* END_CASE */
 

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -2548,7 +2548,7 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE */
-void hash_operation_init( )
+void hash_operation_init( int lib_init )
 {
     const uint8_t input[1] = { 0 };
     /* Test each valid way of initializing the object, except for `= {0}`, as
@@ -2558,8 +2558,10 @@ void hash_operation_init( )
     psa_hash_operation_t func = psa_hash_operation_init( );
     psa_hash_operation_t init = PSA_HASH_OPERATION_INIT;
     psa_hash_operation_t zero;
-
     memset( &zero, 0, sizeof( zero ) );
+
+    if( lib_init )
+        PSA_INIT( );
 
     /* A freshly-initialized hash operation should not be usable. */
     TEST_EQUAL( psa_hash_update( &func, input, sizeof( input ) ),
@@ -2573,6 +2575,10 @@ void hash_operation_init( )
     PSA_ASSERT( psa_hash_abort( &func ) );
     PSA_ASSERT( psa_hash_abort( &init ) );
     PSA_ASSERT( psa_hash_abort( &zero ) );
+
+exit:
+    if( lib_init )
+        PSA_DONE( );
 }
 /* END_CASE */
 
@@ -2813,7 +2819,7 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:PSA_WANT_ALG_SHA_256 */
-void hash_bad_order( )
+void hash_bad_order( int lib_init )
 {
     psa_algorithm_t alg = PSA_ALG_SHA_256;
     unsigned char input[] = "";
@@ -2826,7 +2832,8 @@ void hash_bad_order( )
     size_t hash_len;
     psa_hash_operation_t operation = PSA_HASH_OPERATION_INIT;
 
-    PSA_ASSERT( psa_crypto_init( ) );
+    if( lib_init )
+        PSA_ASSERT( psa_crypto_init( ) );
 
     /* Call setup twice in a row. */
     PSA_ASSERT( psa_hash_setup( &operation, alg ) );
@@ -2912,7 +2919,8 @@ void hash_bad_order( )
     PSA_ASSERT( psa_hash_abort( &operation ) );
 
 exit:
-    PSA_DONE( );
+    if( lib_init )
+        PSA_DONE( );
 }
 /* END_CASE */
 

--- a/tests/suites/test_suite_psa_crypto_hash.function
+++ b/tests/suites/test_suite_psa_crypto_hash.function
@@ -17,8 +17,6 @@ void hash_finish( int alg_arg, data_t *input, data_t *expected_hash )
     size_t actual_hash_length;
     psa_hash_operation_t operation = PSA_HASH_OPERATION_INIT;
 
-    PSA_ASSERT( psa_crypto_init( ) );
-
     PSA_ASSERT( psa_hash_setup( &operation, alg ) );
     PSA_ASSERT( psa_hash_update( &operation,
                                  input->x, input->len ) );
@@ -30,7 +28,6 @@ void hash_finish( int alg_arg, data_t *input, data_t *expected_hash )
 
 exit:
     psa_hash_abort( &operation );
-    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -39,8 +36,6 @@ void hash_verify( int alg_arg, data_t *input, data_t *expected_hash )
 {
     psa_algorithm_t alg = alg_arg;
     psa_hash_operation_t operation = PSA_HASH_OPERATION_INIT;
-
-    PSA_ASSERT( psa_crypto_init( ) );
 
     PSA_ASSERT( psa_hash_setup( &operation, alg ) );
     PSA_ASSERT( psa_hash_update( &operation,
@@ -52,7 +47,6 @@ void hash_verify( int alg_arg, data_t *input, data_t *expected_hash )
 
 exit:
     psa_hash_abort( &operation );
-    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -65,8 +59,6 @@ void hash_multi_part( int alg_arg, data_t *input, data_t *expected_hash )
     psa_hash_operation_t operation = PSA_HASH_OPERATION_INIT;
     psa_hash_operation_t operation2 = PSA_HASH_OPERATION_INIT;
     uint32_t len = 0;
-
-    PSA_ASSERT( psa_crypto_init( ) );
 
     do
     {
@@ -97,6 +89,5 @@ void hash_multi_part( int alg_arg, data_t *input, data_t *expected_hash )
 exit:
     psa_hash_abort( &operation );
     psa_hash_abort( &operation2 );
-    PSA_DONE( );
 }
 /* END_CASE */


### PR DESCRIPTION
Officially allow PSA hash operations (`psa_hash_compute`, `psa_hash_verify`, `psa_hash_setup`, and functions on multipart hash operations) even if the library hasn't been initialized with `psa_crypto_init`. This has always worked (with the exception of [drivers requiring initialization](https://github.com/Mbed-TLS/mbedtls/issues/6469)), but was documented as “implementation-defined” (which doesn't really make sense since we are the implementation and our documentation should be defining the implementation-defined behavior).

This is possibly on the critical path for simplifying the handling of builds where some algorithms are provided via PSA and others via legacy crypto, especially in algorithms such as RSA and deterministic ECDSA that use a hash inside.

Changelog: yes

Backport: maybe (it's technically a new feature, but the library code isn't changing)
