### PR TITLE
Make legacy_or_psa.h private

### DIFF
--- a/include/mbedtls/constant_time.h
+++ b/include/mbedtls/constant_time.h
@@ -1,6 +1,7 @@
 /**
  *  Constant-time functions
- *
+ */
+/*
  *  Copyright The Mbed TLS Contributors
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/legacy_or_psa.h
+++ b/include/mbedtls/legacy_or_psa.h
@@ -1,7 +1,8 @@
 /**
  *  Macros to express dependencies for code and tests that may use either the
- *  legacy API or PSA in various builds; mostly for internal use.
- *
+ *  legacy API or PSA in various builds. This whole header file is currently
+ *  for internal use only and both the header file and the macros it defines
+ *  may change or be removed without notice.
  */
 /*
  *  Copyright The Mbed TLS Contributors

--- a/include/mbedtls/legacy_or_psa.h
+++ b/include/mbedtls/legacy_or_psa.h
@@ -2,6 +2,8 @@
  *  Macros to express dependencies for code and tests that may use either the
  *  legacy API or PSA in various builds; mostly for internal use.
  *
+ */
+/*
  *  Copyright The Mbed TLS Contributors
  *  SPDX-License-Identifier: Apache-2.0
  *


### PR DESCRIPTION
Exclude `mbedtls/legacy_or_psa.h` and its contents from the official API. We're [seriously considering reworking it](https://github.com/Mbed-TLS/mbedtls/issues/6471) but still discussing how, so do the minimum change so that it doesn't create an obligation on us.

I've reviewed the [changelog entry](https://github.com/Mbed-TLS/mbedtls/pull/6283/files#diff-e5017d84507d81c322dcf6dc95244d96a0e2673b53083c1d2dc1c33a91af00c1) from the [pull request that introduced `legacy_or_psa.h`](https://github.com/Mbed-TLS/mbedtls/pull/6283) and the related [changes in `mbedtls_config.h`](https://github.com/Mbed-TLS/mbedtls/pull/6283/files#diff-0279e5915ac49daea5fd9ed14934a074d1a88e9b35c674d7d1a0d0e0688f60bb), and I'm ok with preserving what is promised there (quite possibly, in some edge cases, by forcibly enabling `MBEDTLS_MD_C` in `build_info.h`).

Changelog: no (we didn't announce it as a feature)

Backport: no (not applicable)
