### PR TITLE
Tls13 parse early data indication ee

### DIFF
--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -2063,14 +2063,6 @@ static int ssl_tls13_parse_encrypted_extensions( mbedtls_ssl_context *ssl,
 
 #if defined(MBEDTLS_SSL_EARLY_DATA)
             case MBEDTLS_TLS_EXT_EARLY_DATA:
-                if( ssl->early_data_status != MBEDTLS_SSL_EARLY_DATA_STATUS_INDICATION_SENT )
-                {
-                    /* The server must not send the EarlyDataIndication if the
-                    * client hasn't indicated the use of early data. */
-                    MBEDTLS_SSL_PEND_FATAL_ALERT( MBEDTLS_SSL_ALERT_MSG_ILLEGAL_PARAMETER,
-                                                  MBEDTLS_ERR_SSL_ILLEGAL_PARAMETER );
-                    return( MBEDTLS_ERR_SSL_ILLEGAL_PARAMETER );
-                }
 
                 if( extension_data_len != 0 )
                 {
@@ -2080,7 +2072,7 @@ static int ssl_tls13_parse_encrypted_extensions( mbedtls_ssl_context *ssl,
                     return( MBEDTLS_ERR_SSL_DECODE_ERROR );
                 }
 
-	            ssl->early_data_status = MBEDTLS_SSL_EARLY_DATA_STATUS_ACCEPTED;
+                ssl->early_data_status = MBEDTLS_SSL_EARLY_DATA_STATUS_ACCEPTED;
 
                 break;
 #endif /* MBEDTLS_SSL_EARLY_DATA */

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -2072,8 +2072,6 @@ static int ssl_tls13_parse_encrypted_extensions( mbedtls_ssl_context *ssl,
                     return( MBEDTLS_ERR_SSL_DECODE_ERROR );
                 }
 
-                ssl->early_data_status = MBEDTLS_SSL_EARLY_DATA_STATUS_ACCEPTED;
-
                 break;
 #endif /* MBEDTLS_SSL_EARLY_DATA */
 
@@ -2118,6 +2116,14 @@ static int ssl_tls13_process_encrypted_extensions( mbedtls_ssl_context *ssl )
     /* Process the message contents */
     MBEDTLS_SSL_PROC_CHK(
         ssl_tls13_parse_encrypted_extensions( ssl, buf, buf + buf_len ) );
+
+#if defined(MBEDTLS_SSL_EARLY_DATA)
+    if( ssl->handshake->received_extensions &
+        MBEDTLS_SSL_EXT_MASK( EARLY_DATA ) )
+    {
+        ssl->early_data_status = MBEDTLS_SSL_EARLY_DATA_STATUS_ACCEPTED;
+    }
+#endif
 
     mbedtls_ssl_add_hs_msg_to_checksum( ssl, MBEDTLS_SSL_HS_ENCRYPTED_EXTENSIONS,
                                         buf, buf_len );

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -1335,6 +1335,53 @@ static int ssl_tls13_is_downgrade_negotiation( mbedtls_ssl_context *ssl,
     return( 0 );
 }
 
+#if defined(MBEDTLS_SSL_EARLY_DATA)
+/*
+ * ssl_tls13_parse_ee_early_data_ext()
+ *      Parse early data indication extension in EncryptedExtensions.
+ *
+ * struct {} Empty;
+ *
+ * struct {
+ *   select (Handshake.msg_type) {
+ *     ...
+ *     case client_hello:         Empty;
+ *     case encrypted_extensions: Empty;
+ *   };
+ * } EarlyDataIndication;
+ *
+ */
+
+MBEDTLS_CHECK_RETURN_CRITICAL
+static int ssl_tls13_parse_ee_early_data_ext( mbedtls_ssl_context *ssl,
+                                              const unsigned char *buf,
+                                              size_t len )
+{
+    if( ssl->early_data_status < MBEDTLS_SSL_EARLY_DATA_STATUS_INDICATION_SENT )
+    {
+        /* The server must not send the EarlyDataIndication if the
+         * client hasn't indicated the use of early data. */
+        MBEDTLS_SSL_PEND_FATAL_ALERT( MBEDTLS_SSL_ALERT_MSG_ILLEGAL_PARAMETER,
+                                      MBEDTLS_ERR_SSL_ILLEGAL_PARAMETER );
+        return( MBEDTLS_ERR_SSL_ILLEGAL_PARAMETER );
+    }
+
+    if( len != 0 )
+    {
+        /* The message must be empty. */
+        MBEDTLS_SSL_PEND_FATAL_ALERT( MBEDTLS_SSL_ALERT_MSG_DECODE_ERROR,
+                                      MBEDTLS_ERR_SSL_DECODE_ERROR );
+        return( MBEDTLS_ERR_SSL_DECODE_ERROR );
+    }
+
+    /* Nothing to parse */
+    ((void) buf);
+
+    ssl->early_data_status = MBEDTLS_SSL_EARLY_DATA_STATUS_ACCEPTED;
+    return( 0 );
+}
+#endif /* MBEDTLS_SSL_EARLY_DATA */
+
 /* Returns a negative value on failure, and otherwise
  * - SSL_SERVER_HELLO or
  * - SSL_SERVER_HELLO_HRR
@@ -2060,6 +2107,22 @@ static int ssl_tls13_parse_encrypted_extensions( mbedtls_ssl_context *ssl,
 
                 break;
 #endif /* MBEDTLS_SSL_ALPN */
+
+#if defined(MBEDTLS_SSL_EARLY_DATA)
+            case MBEDTLS_TLS_EXT_EARLY_DATA:
+                ret = ssl_tls13_parse_ee_early_data_ext(
+                            ssl, p, (size_t)extension_data_len );
+                if( ret != 0 )
+                {
+                    ssl->early_data_status =
+                            MBEDTLS_SSL_EARLY_DATA_STATUS_REJECTED;
+                    MBEDTLS_SSL_DEBUG_RET(
+                            1, "ssl_tls13_parse_ee_early_data_ext", ret );
+                    return( ret );
+                }
+                break;
+#endif /* MBEDTLS_SSL_EARLY_DATA */
+
             default:
                 MBEDTLS_SSL_PRINT_EXT(
                     3, MBEDTLS_SSL_HS_ENCRYPTED_EXTENSIONS,

--- a/tests/opt-testcases/tls13-misc.sh
+++ b/tests/opt-testcases/tls13-misc.sh
@@ -301,7 +301,7 @@ run_test    "TLS 1.3 m->G: EarlyData: basic check, good" \
             -c "NewSessionTicket: early_data(42) extension received." \
             -c "ClientHello: early_data(42) extension exists." \
             -c "EncryptedExtensions: early_data(42) extension received." \
-            -c "EncryptedExtensions: early_data(42) extension ( ignored )." \
+            -c "EncryptedExtensions: early_data(42) extension exists." \
             -s "Parsing extension 'Early Data/42' (0 bytes)" \
             -s "Sending extension Early Data/42 (0 bytes)" \
             -s "early data accepted"
@@ -322,7 +322,7 @@ run_test    "TLS 1.3 m->G: EarlyData: no early_data in NewSessionTicket, good" \
             -C "NewSessionTicket: early_data(42) extension received." \
             -c "ClientHello: early_data(42) extension does not exist." \
             -C "EncryptedExtensions: early_data(42) extension received." \
-            -C "EncryptedExtensions: early_data(42) extension ( ignored )."
+            -C "EncryptedExtensions: early_data(42) extension exists."
 
 #TODO: OpenSSL tests don't work now. It might be openssl options issue, cause GnuTLS has worked.
 skip_next_test


### PR DESCRIPTION
Parse early data indication in encrypted extentions.
Empty to indicate that early data supported by server side.
