### PR TITLE
Fix a timing leak in ecp_mul_mxz() - 2.28 backport

### DIFF
--- a/library/ecp.c
+++ b/library/ecp.c
@@ -2594,7 +2594,7 @@ static int ecp_mul_mxz( mbedtls_ecp_group *grp, mbedtls_ecp_point *R,
         MBEDTLS_MPI_CHK( ecp_randomize_mxz( grp, &RP, f_rng, p_rng ) );
 
     /* Loop invariant: R = result so far, RP = R + P */
-    i = mbedtls_mpi_bitlen( m ); /* one past the (zero-based) most significant bit */
+    i = grp->nbits + 1; /* one past the (zero-based) required msb for private keys */
     while( i-- > 0 )
     {
         b = mbedtls_mpi_get_bit( m, i );


### PR DESCRIPTION
Trivial backport of #5841 
Changelog: Not needed