### PR TITLE
Use `config.py` as a module in `depends.py`

### DIFF
--- a/tests/scripts/depends.py
+++ b/tests/scripts/depends.py
@@ -138,9 +138,7 @@ Remove the backup file if it was saved earlier."""
         shutil.copy(options.config_backup, options.config)
 
 def option_exists(conf, option):
-    if option not in conf.settings:
-        return False
-    return True
+    return option in conf.settings
 
 def set_config_option_value(conf, option, colors, value: Union[bool, str]):
     """Set/unset a configuration option, optionally specifying a value.

--- a/tests/scripts/depends.py
+++ b/tests/scripts/depends.py
@@ -71,6 +71,8 @@ import shutil
 import subprocess
 import sys
 import traceback
+from typing import Union
+
 # Add the Mbed TLS Python library directory to the module search path
 import scripts_path # pylint: disable=unused-import
 import config
@@ -140,8 +142,10 @@ def option_exists(conf, option):
         return False
     return True
 
-def set_config_option_value(conf, option, colors, value):
-    """Set/unset a configuration option, optionally specifying a value"""
+def set_config_option_value(conf, option, colors, value: Union[bool, str]):
+    """Set/unset a configuration option, optionally specifying a value.
+value can be either True/False (set/unset config option), or a string,
+which will make a symbol defined with a certain value."""
     if not option_exists(conf, option):
         log_line('Symbol {} was not found in {}'.format(option, conf.filename), color=colors.red)
         return False

--- a/tests/scripts/depends.py
+++ b/tests/scripts/depends.py
@@ -151,13 +151,12 @@ which will make a symbol defined with a certain value."""
     if value is False:
         log_command(['config.py', 'unset', option])
         conf.unset(option)
+    elif value is True:
+        log_command(['config.py', 'set', option])
+        conf.set(option)
     else:
-        if value is True:
-            log_command(['config.py', 'set', option])
-            conf.set(option)
-        else:
-            log_command(['config.py', 'set', option, value])
-            conf.set(option, value)
+        log_command(['config.py', 'set', option, value])
+        conf.set(option, value)
     return True
 
 def set_reference_config(conf, options, colors):

--- a/tests/scripts/depends.py
+++ b/tests/scripts/depends.py
@@ -23,7 +23,7 @@ Test Mbed TLS with a subset of algorithms.
 This script can be divided into several steps:
 
 First, include/mbedtls/mbedtls_config.h or a different config file passed
-in the arguments is parsed to extract any configuration options (collect_config_symbols).
+in the arguments is parsed to extract any configuration options (using config.py).
 
 Then, test domains (groups of jobs, tests) are built based on predefined data
 collected in the DomainData class. Here, each domain has five major traits:
@@ -72,6 +72,9 @@ import subprocess
 import sys
 import traceback
 
+import scripts_path # pylint: disable=unused-import
+import config
+
 class Colors: # pylint: disable=too-few-public-methods
     """Minimalistic support for colored output.
 Each field of an object of this class is either None if colored output
@@ -80,6 +83,7 @@ that outputting start switches the text color to the desired color and
 stop switches the text color back to the default."""
     red = None
     green = None
+    cyan = None
     bold_red = None
     bold_green = None
     def __init__(self, options=None):
@@ -95,6 +99,7 @@ stop switches the text color back to the default."""
             normal = '\033[0m'
             self.red = ('\033[31m', normal)
             self.green = ('\033[32m', normal)
+            self.cyan = ('\033[36m', normal)
             self.bold_red = ('\033[1;31m', normal)
             self.bold_green = ('\033[1;32m', normal)
 NO_COLORS = Colors(None)
@@ -130,34 +135,39 @@ Remove the backup file if it was saved earlier."""
     else:
         shutil.copy(options.config_backup, options.config)
 
-def run_config_py(options, args):
-    """Run scripts/config.py with the specified arguments."""
-    cmd = ['scripts/config.py']
-    if options.config != 'include/mbedtls/mbedtls_config.h':
-        cmd += ['--file', options.config]
-    cmd += args
-    log_command(cmd)
-    subprocess.check_call(cmd)
+def option_exists(conf, option):
+    if option not in conf.settings:
+        return False
+    return True
 
-def set_reference_config(options):
+def set_config_option(conf, option, colors, value=None):
+    """Set configuration option, optionally specifying a value"""
+    if not option_exists(conf, option):
+        log_line('Symbol {} was not found in {}'.format(option, conf.filename), color=colors.red)
+        return False
+    log_command(['config.py', 'set', option])
+    conf.set(option, value)
+    return True
+
+def unset_config_option(conf, option, colors):
+    """Unset configuration option if it exists"""
+    if not option_exists(conf, option):
+        log_line('Symbol {} was not found in {}'.format(option, conf.filename), color=colors.red)
+        return False
+    log_command(['config.py', 'unset', option])
+    conf.unset(option)
+    return True
+
+def set_reference_config(conf, options, colors):
     """Change the library configuration file (mbedtls_config.h) to the reference state.
 The reference state is the one from which the tested configurations are
 derived."""
     # Turn off options that are not relevant to the tests and slow them down.
-    run_config_py(options, ['full'])
-    run_config_py(options, ['unset', 'MBEDTLS_TEST_HOOKS'])
+    log_command(['config.py', 'full'])
+    conf.adapt(config.full_adapter)
+    unset_config_option(conf, 'MBEDTLS_TEST_HOOKS', colors)
     if options.unset_use_psa:
-        run_config_py(options, ['unset', 'MBEDTLS_USE_PSA_CRYPTO'])
-
-def collect_config_symbols(options):
-    """Read the list of settings from mbedtls_config.h.
-Return them in a generator."""
-    with open(options.config, encoding="utf-8") as config_file:
-        rx = re.compile(r'\s*(?://\s*)?#define\s+(\w+)\s*(?:$|/[/*])')
-        for line in config_file:
-            m = re.match(rx, line)
-            if m:
-                yield m.group(1)
+        unset_config_option(conf, 'MBEDTLS_USE_PSA_CRYPTO', colors)
 
 class Job:
     """A job builds the library in a specific configuration and runs some tests."""
@@ -185,19 +195,22 @@ If what is False, announce that the job has failed.'''
         elif what is False:
             log_line(self.name + ' FAILED', color=colors.red)
         else:
-            log_line('starting ' + self.name)
+            log_line('starting ' + self.name, color=colors.cyan)
 
-    def configure(self, options):
+    def configure(self, conf, options, colors):
         '''Set library configuration options as required for the job.'''
-        set_reference_config(options)
+        set_reference_config(conf, options, colors)
         for key, value in sorted(self.config_settings.items()):
+            ret = False
             if value is True:
-                args = ['set', key]
+                ret = set_config_option(conf, key, colors)
             elif value is False:
-                args = ['unset', key]
+                ret = unset_config_option(conf, key, colors)
             else:
-                args = ['set', key, value]
-            run_config_py(options, args)
+                ret = set_config_option(conf, key, colors, value)
+            if ret is False:
+                return False
+        return True
 
     def test(self, options):
         '''Run the job's build and test commands.
@@ -392,11 +405,11 @@ class DomainData:
         return [symbol for symbol in self.all_config_symbols
                 if re.match(regexp, symbol)]
 
-    def __init__(self, options):
+    def __init__(self, options, conf):
         """Gather data about the library and establish a list of domains to test."""
         build_command = [options.make_command, 'CFLAGS=-Werror']
         build_and_test = [build_command, [options.make_command, 'test']]
-        self.all_config_symbols = set(collect_config_symbols(options))
+        self.all_config_symbols = set(conf.settings.keys())
         # Find hash modules by name.
         hash_symbols = self.config_symbols_matching(r'MBEDTLS_(MD|RIPEMD|SHA)[0-9]+_C\Z')
         # Find elliptic curve enabling macros by name.
@@ -455,16 +468,19 @@ A name can either be the name of a domain or the name of one specific job."""
         else:
             return [self.jobs[name]]
 
-def run(options, job, colors=NO_COLORS):
+def run(options, job, conf, colors=NO_COLORS):
     """Run the specified job (a Job instance)."""
     subprocess.check_call([options.make_command, 'clean'])
     job.announce(colors, None)
-    job.configure(options)
+    if not job.configure(conf, options, colors):
+        job.announce(colors, False)
+        return False
+    conf.write()
     success = job.test(options)
     job.announce(colors, success)
     return success
 
-def run_tests(options, domain_data):
+def run_tests(options, domain_data, conf):
     """Run the desired jobs.
 domain_data should be a DomainData instance that describes the available
 domains and jobs.
@@ -480,7 +496,7 @@ Run the jobs listed in options.tasks."""
     backup_config(options)
     try:
         for job in jobs:
-            success = run(options, job, colors=colors)
+            success = run(options, job, conf, colors=colors)
             if not success:
                 if options.keep_going:
                     failures.append(job.name)
@@ -546,7 +562,9 @@ def main():
                             default=True)
         options = parser.parse_args()
         os.chdir(options.directory)
-        domain_data = DomainData(options)
+        conf = config.ConfigFile(options.config)
+        domain_data = DomainData(options, conf)
+
         if options.tasks is True:
             options.tasks = sorted(domain_data.domains.keys())
         if options.list:
@@ -555,7 +573,7 @@ def main():
                     print(domain_name)
             sys.exit(0)
         else:
-            sys.exit(0 if run_tests(options, domain_data) else 1)
+            sys.exit(0 if run_tests(options, domain_data, conf) else 1)
     except Exception: # pylint: disable=broad-except
         traceback.print_exc()
         sys.exit(3)


### PR DESCRIPTION
`depends.py` now uses `config.py` to get the available configuration options as well as manipulate the config file.
Fixes https://github.com/Mbed-TLS/mbedtls/issues/6440.
[Backport here](https://github.com/Mbed-TLS/mbedtls/pull/7104)
