### PR TITLE
Remove a few redundancies from all.sh

### DIFF
--- a/tests/configs/tls13-only.h
+++ b/tests/configs/tls13-only.h
@@ -22,9 +22,11 @@
  *  limitations under the License.
  */
 
+/* Enable TLS 1.3 and core 1.3 features */
 #define MBEDTLS_SSL_PROTO_TLS1_3
 #define MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 
+/* Disable TLS 1.2 and 1.2-specific features */
 #undef MBEDTLS_SSL_ENCRYPT_THEN_MAC
 #undef MBEDTLS_SSL_EXTENDED_MASTER_SECRET
 #undef MBEDTLS_SSL_PROTO_TLS1_2
@@ -32,3 +34,6 @@
 #undef MBEDTLS_SSL_DTLS_ANTI_REPLAY
 #undef MBEDTLS_SSL_DTLS_HELLO_VERIFY
 #undef MBEDTLS_SSL_DTLS_CLIENT_PORT_REUSE
+
+/* Enable some invasive tests */
+#define MBEDTLS_TEST_HOOKS

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -3341,46 +3341,6 @@ component_test_tls13_no_compatibility_mode () {
     tests/ssl-opt.sh
 }
 
-component_test_tls13_with_padding () {
-    msg "build: default config with MBEDTLS_SSL_PROTO_TLS1_3 enabled, with padding"
-    scripts/config.py set MBEDTLS_SSL_PROTO_TLS1_3
-    scripts/config.py set MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
-    scripts/config.py set MBEDTLS_SSL_CID_TLS1_3_PADDING_GRANULARITY 16
-    CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
-    make
-    msg "test: default config with MBEDTLS_SSL_PROTO_TLS1_3 enabled, with padding"
-    make test
-    msg "ssl-opt.sh (TLS 1.3 with padding)"
-    tests/ssl-opt.sh
-}
-
-component_test_tls13_with_ecp_restartable () {
-    msg "build: default config with MBEDTLS_SSL_PROTO_TLS1_3 enabled, with ecp_restartable"
-    scripts/config.py set MBEDTLS_SSL_PROTO_TLS1_3
-    scripts/config.py set MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
-    scripts/config.py set MBEDTLS_ECP_RESTARTABLE
-    CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
-    make
-    msg "test: default config with MBEDTLS_SSL_PROTO_TLS1_3 enabled, with ecp_restartable"
-    make test
-    msg "ssl-opt.sh (TLS 1.3 with ecp_restartable)"
-    tests/ssl-opt.sh
-}
-
-component_test_tls13_with_everest () {
-    msg "build: default config with MBEDTLS_SSL_PROTO_TLS1_3 enabled, with Everest"
-    scripts/config.py set MBEDTLS_SSL_PROTO_TLS1_3
-    scripts/config.py set MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
-    scripts/config.py set MBEDTLS_ECDH_VARIANT_EVEREST_ENABLED
-    scripts/config.py unset MBEDTLS_ECP_RESTARTABLE
-    CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
-    make
-    msg "test: default config with MBEDTLS_SSL_PROTO_TLS1_3 enabled, with Everest"
-    make test
-    msg "ssl-opt.sh (TLS 1.3 with everest)"
-    tests/ssl-opt.sh
-}
-
 component_build_mingw () {
     msg "build: Windows cross build - mingw64, make (Link Library)" # ~ 30s
     make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -Wall -Wextra' WINDOWS_BUILD=1 lib programs

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -2238,25 +2238,6 @@ component_test_psa_crypto_config_chachapoly_disabled() {
     make test
 }
 
-# This should be renamed to test and updated once the accelerator ECDSA code is in place and ready to test.
-component_build_psa_accel_alg_ecdsa() {
-    # full plus MBEDTLS_PSA_CRYPTO_CONFIG with PSA_WANT_ALG_ECDSA
-    # without MBEDTLS_ECDSA_C
-    # PSA_WANT_ALG_ECDSA and PSA_WANT_ALG_DETERMINISTIC_ECDSA are already
-    # set in include/psa/crypto_config.h
-    msg "build: full + MBEDTLS_PSA_CRYPTO_CONFIG + PSA_WANT_ALG_ECDSA without MBEDTLS_ECDSA_C"
-    scripts/config.py full
-    scripts/config.py set MBEDTLS_PSA_CRYPTO_CONFIG
-    scripts/config.py set MBEDTLS_PSA_CRYPTO_DRIVERS
-    scripts/config.py unset MBEDTLS_USE_PSA_CRYPTO
-    scripts/config.py unset MBEDTLS_SSL_PROTO_TLS1_3
-    scripts/config.py unset MBEDTLS_ECDSA_C
-    scripts/config.py unset MBEDTLS_KEY_EXCHANGE_ECDH_ECDSA_ENABLED
-    scripts/config.py unset MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
-    # Need to define the correct symbol and include the test driver header path in order to build with the test driver
-    make CC=gcc CFLAGS="$ASAN_CFLAGS -DPSA_CRYPTO_DRIVER_TEST -DMBEDTLS_PSA_ACCEL_ALG_ECDSA -DMBEDTLS_PSA_ACCEL_ALG_DETERMINISTIC_ECDSA -I../tests/include -O2" LDFLAGS="$ASAN_CFLAGS"
-}
-
 # This should be renamed to test and updated once the accelerator ECDH code is in place and ready to test.
 component_build_psa_accel_alg_ecdh() {
     # full plus MBEDTLS_PSA_CRYPTO_CONFIG with PSA_WANT_ALG_ECDH

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1542,11 +1542,14 @@ component_test_psa_collect_statuses () {
 component_test_full_cmake_clang () {
     msg "build: cmake, full config, clang" # ~ 50s
     scripts/config.py full
-    CC=clang cmake -D CMAKE_BUILD_TYPE:String=Release -D ENABLE_TESTING=On .
+    CC=clang CXX=clang cmake -D CMAKE_BUILD_TYPE:String=Release -D ENABLE_TESTING=On -D TEST_CPP=1 .
     make
 
     msg "test: main suites (full config, clang)" # ~ 5s
     make test
+
+    msg "test: cpp_dummy_build (full config, clang)" # ~ 1s
+    programs/test/cpp_dummy_build
 
     msg "test: psa_constant_names (full config, clang)" # ~ 1s
     tests/scripts/test_psa_constant_names.py
@@ -1840,15 +1843,6 @@ component_test_depends_py_kex_psa () {
 component_test_depends_py_pkalgs_psa () {
     msg "test/build: depends.py pkalgs (gcc) with MBEDTLS_USE_PSA_CRYPTO defined"
     tests/scripts/depends.py pkalgs
-}
-
-component_test_make_cxx () {
-    msg "build: Unix make, full, gcc + g++"
-    scripts/config.py full
-    make TEST_CPP=1 lib programs
-
-    msg "test: cpp_dummy_build"
-    programs/test/cpp_dummy_build
 }
 
 component_build_module_alt () {

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -3248,8 +3248,8 @@ component_test_tls13_only () {
     msg "build: default config with MBEDTLS_SSL_PROTO_TLS1_3, without MBEDTLS_SSL_PROTO_TLS1_2"
     make CFLAGS="'-DMBEDTLS_USER_CONFIG_FILE=\"../tests/configs/tls13-only.h\"'"
 
-    msg "test_suite_ssl: TLS 1.3 only, all key exchange modes enabled"
-    cd tests; ./test_suite_ssl; cd ..
+    msg "test: TLS 1.3 only, all key exchange modes enabled"
+    make test
 
     msg "ssl-opt.sh: TLS 1.3 only, all key exchange modes enabled"
     tests/ssl-opt.sh
@@ -3332,18 +3332,6 @@ component_test_tls13_only_ephemeral_all () {
 
     msg "ssl-opt.sh: TLS 1.3 only, ephemeral and PSK ephemeral key exchange modes"
     tests/ssl-opt.sh
-}
-
-component_test_tls13_only_with_hooks () {
-    msg "build: default config with MBEDTLS_SSL_PROTO_TLS1_3 and MBEDTLS_TEST_HOOKS, without MBEDTLS_SSL_PROTO_TLS1_2"
-    scripts/config.py set MBEDTLS_TEST_HOOKS
-    make CFLAGS="'-DMBEDTLS_USER_CONFIG_FILE=\"../tests/configs/tls13-only.h\"'"
-
-    msg "test: default config with MBEDTLS_SSL_PROTO_TLS1_3 enabled, without MBEDTLS_SSL_PROTO_TLS1_2"
-    if_build_succeeded make test
-
-    msg "ssl-opt.sh (TLS 1.3)"
-    if_build_succeeded tests/ssl-opt.sh
 }
 
 component_test_tls13 () {


### PR DESCRIPTION
Remove 5 components from `all.sh` that were fully or almost fully redundant with other components.

We've talked about removing the `build_psa_accel_*` components that build with drivers for a specific feature because they don't do much: there are now tests `test_psa_crypto_config_accel_` that test with drivers. But the build components do something that the test components don't do yet, which is to validate that the correct `#ifdef` guards are in place for specific features. Until we have a `depends.py`-style script that tests with one algorithm accelerated at a time (or something like this), the cookie-cutter `build_psa_accel_*` have some utility, so I think they should stay.

I looked for opportunities to group components together, which would improve CI performance because we sometimes spend several minutes instantiating a node, doing a checkout, downloading and spinning up a Docker image, only to run a script that only takes a couple of seconds. I even started [writing some auxiliary scripts for that purpose](https://github.com/gilles-peskine-arm/mbedtls/tree/all.sh-auxiliary_scripts-20221028-development). But the effort spent to make each grouping viable (so we have proper reporting, the failure of one early part doesn't cause subsequent parts not to run, and can still run one specific part easily) felt out of proportion, compared to the effort of having the Groovy code do some kind of grouping without having to get into the specifics of what the components do. So I push for [having grouping in Groovy instead](https://github.com/Mbed-TLS/mbedtls-test/issues/69).

Changelog: no (test script only)

Backport: partial (the changes other than TLS 1.3 apply, and there may be other similar things in 2.28 only)
