### PR TITLE
Update PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,40 +1,28 @@
-Notes:
-* Pull requests cannot be accepted until the PR follows the [contributing guidelines](../CONTRIBUTING.md). In particular, each commit must have at least one `Signed-off-by:` line from the committer to certify that the contribution is made under the terms of the [Developer Certificate of Origin](../dco.txt).
-* This is just a template, so feel free to use/remove the unnecessary things
 ## Description
-A few sentences describing the overall goals of the pull request's commits.
+
+Please write a few sentences describing the overall goals of the pull request's commits.
 
 
-## Status
-**READY/IN DEVELOPMENT/HOLD**
 
-## Requires Backporting
+## Gatekeeper checklist
+
+- [ ] **changelog** provided, or not required
+- [ ] **backport** done, or not required
+- [ ] **tests** provided, or not required
+
+
+
+## Notes for the submitter
+
+Pull requests cannot be accepted until the PR follows the [contributing guidelines](../CONTRIBUTING.md). In particular, each commit must have at least one `Signed-off-by:` line from the committer to certify that the contribution is made under the terms of the [Developer Certificate of Origin](../dco.txt).
+
+#### Backporting
+
 When there is a bug fix, it should be backported to all maintained and supported branches.
 Changes do not have to be backported if:
-- This PR is a new feature\enhancement
+
+- This PR is a new feature / enhancement
 - This PR contains changes in the API. If this is true, and there is a need for the fix to be backported, the fix should be handled differently in the legacy branch
 
-Yes | NO  
-Which branch?
+It is fine to defer providing a backport until the main PR is approved.
 
-## Requires ChangeLog entry
-
-YES | NO - if no, why not?
-
-## Migrations
-If there is any API change, what's the incentive and logic for it.
-
-YES | NO
-
-## Additional comments
-Any additional information that could be of interest
-
-## Todos
-- [ ] Tests
-- [ ] Documentation
-- [ ] Changelog updated
-- [ ] Backported
-
-
-## Steps to test or reproduce
-Outline the steps to test or reproduce the PR here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,15 +14,6 @@ Please write a few sentences describing the overall goals of the pull request's 
 
 ## Notes for the submitter
 
-Pull requests cannot be accepted until the PR follows the [contributing guidelines](../CONTRIBUTING.md). In particular, each commit must have at least one `Signed-off-by:` line from the committer to certify that the contribution is made under the terms of the [Developer Certificate of Origin](../dco.txt).
-
-#### Backporting
-
-When there is a bug fix, it should be backported to all maintained and supported branches.
-Changes do not have to be backported if:
-
-- This PR is a new feature / enhancement
-- This PR contains changes in the API. If this is true, and there is a need for the fix to be backported, the fix should be handled differently in the legacy branch
-
-It is fine to defer providing a backport until the main PR is approved.
+Please refer to the [contributing guidelines](../CONTRIBUTING.md), especially the
+checklist for PR contributors.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,15 @@
 Contributing
 ============
-We gratefully accept bug reports and contributions from the community. There are some requirements we need to fulfill in order to be able to integrate contributions:
+We gratefully accept bug reports and contributions from the community.
 
- - As with any open source project, contributions will be reviewed by the project team and community and may need some modifications to be accepted.
- - The contribution should not break API or ABI, unless there is a real justification for that. If there is an API change, the contribution, if accepted, will be merged only when there will be a major release.
+Quick Checklist for PR contributors
+-----------------------------------
+More details on all of these points may be found in the sections below.
+
+- [Sign-off](#license-and-copyright): all commits must be signed off
+- [Tests](#tests): please ensure the PR includes adequate tests
+- [Changelog](#documentation): if needed, please provide a changelog entry
+- [Backports](#long-term-support-branches): provide a backport if needed (it's fine to wait until the main PR is accepted)
 
 Coding Standards
 ----------------
@@ -25,7 +31,7 @@ Backwards Compatibility
 
 The project aims to minimise the impact on users upgrading to newer versions of the library and it should not be necessary for a user to make any changes to their own code to work with a newer version of the library. Unless the user has made an active decision to use newer features, a newer generation of the library or a change has been necessary due to a security issue or other significant software defect, no modifications to their own code should be necessary. To achieve this, API compatibility is maintained between different versions of Mbed TLS on the main development branch and in LTS (Long Term Support) branches, as described in [BRANCHES.md](BRANCHES.md).
 
-To minimise such disruption to users, where a change to the interface is required, all changes to the ABI or API, even on the main development branch where new features are added, need to be justifiable by either being a significant enhancement, new feature or bug fix which is best resolved by an interface change.
+To minimise such disruption to users, where a change to the interface is required, all changes to the ABI or API, even on the main development branch where new features are added, need to be justifiable by either being a significant enhancement, new feature or bug fix which is best resolved by an interface change. If there is an API change, the contribution, if accepted, will be merged only when there will be a major release.
 
 Where changes to an existing interface are necessary, functions in the public interface which need to be changed, are marked as 'deprecated'. This is done with the preprocessor symbols `MBEDTLS_DEPRECATED_WARNING` and `MBEDTLS_DEPRECATED_REMOVED`. Then, a new function with a new name but similar if not identical behaviour to the original function containing the necessary changes should be created alongside the existing deprecated function.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,10 +7,10 @@ Quick Checklist for PR contributors
 -----------------------------------
 More details on all of these points may be found in the sections below.
 
-- [Sign-off](#license-and-copyright): all commits must be signed off
-- [Tests](#tests): please ensure the PR includes adequate tests
-- [Changelog](#documentation): if needed, please provide a changelog entry
-- [Backports](#long-term-support-branches): provide a backport if needed (it's fine to wait until the main PR is accepted)
+- [Sign-off](#license-and-copyright): all commits must be signed off.
+- [Tests](#tests): please ensure the PR includes adequate tests.
+- [Changelog](#documentation): if needed, please provide a changelog entry.
+- [Backports](#long-term-support-branches): provide a backport if needed (it's fine to wait until the main PR is accepted).
 
 Coding Standards
 ----------------

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,7 @@
 Contributing
 ============
-We gratefully accept bug reports and contributions from the community.
+We gratefully accept bug reports and contributions from the community. All PRs are reviewed by the project team / community, and may need some modifications to
+be accepted.
 
 Quick Checklist for PR contributors
 -----------------------------------


### PR DESCRIPTION
Aim is to simplify the template, and provide gatekeepers / release-leads with a quick checklist of the things that are often missed.

Backport: #6527 
Changelog: not needed