### PR TITLE
all.sh --list-all-groups

### DIFF
--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -211,7 +211,7 @@ pre_initialize_variables () {
 # * GROUP_NAME=_PREFIX_MISC to group some components with the same prefix.
 add_to_group ()
 {
-    if [[ -v groups["$1"] ]]; then
+    if [[ -n "${groups["$1"]-}" ]]; then
         groups["$1"]="${groups["$1"]} $2"
     else
         groups["$1"]="$2"

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1280,7 +1280,7 @@ component_test_crypto_full_no_cipher () {
     make test
 }
 
-component_test_tls1_2_default_stream_cipher_only () {
+component_test_tls12_default_stream_cipher_only () {
     msg "build: default with only stream cipher"
 
     # Disable AEAD (controlled by the presence of one of GCM_C, CCM_C, CHACHAPOLY_C
@@ -1305,7 +1305,7 @@ component_test_tls1_2_default_stream_cipher_only () {
     # Not running ssl-opt.sh because most tests require a non-NULL ciphersuite.
 }
 
-component_test_tls1_2_default_stream_cipher_only_use_psa () {
+component_test_tls12_default_stream_cipher_only_use_psa () {
     msg "build: default with only stream cipher use psa"
 
     scripts/config.py set MBEDTLS_USE_PSA_CRYPTO
@@ -1331,7 +1331,7 @@ component_test_tls1_2_default_stream_cipher_only_use_psa () {
     # Not running ssl-opt.sh because most tests require a non-NULL ciphersuite.
 }
 
-component_test_tls1_2_default_cbc_legacy_cipher_only () {
+component_test_tls12_default_cbc_legacy_cipher_only () {
     msg "build: default with only CBC-legacy cipher"
 
     # Disable AEAD (controlled by the presence of one of GCM_C, CCM_C, CHACHAPOLY_C)
@@ -1357,7 +1357,7 @@ component_test_tls1_2_default_cbc_legacy_cipher_only () {
     tests/ssl-opt.sh -f "TLS 1.2"
 }
 
-component_test_tls1_2_deafult_cbc_legacy_cipher_only_use_psa () {
+component_test_tls12_deafult_cbc_legacy_cipher_only_use_psa () {
     msg "build: default with only CBC-legacy cipher use psa"
 
     scripts/config.py set MBEDTLS_USE_PSA_CRYPTO
@@ -1384,7 +1384,7 @@ component_test_tls1_2_deafult_cbc_legacy_cipher_only_use_psa () {
     tests/ssl-opt.sh -f "TLS 1.2"
 }
 
-component_test_tls1_2_default_cbc_legacy_cbc_etm_cipher_only () {
+component_test_tls12_default_cbc_legacy_cbc_etm_cipher_only () {
     msg "build: default with only CBC-legacy and CBC-EtM ciphers"
 
     # Disable AEAD (controlled by the presence of one of GCM_C, CCM_C, CHACHAPOLY_C)
@@ -1410,7 +1410,7 @@ component_test_tls1_2_default_cbc_legacy_cbc_etm_cipher_only () {
     tests/ssl-opt.sh -f "TLS 1.2"
 }
 
-component_test_tls1_2_default_cbc_legacy_cbc_etm_cipher_only_use_psa () {
+component_test_tls12_default_cbc_legacy_cbc_etm_cipher_only_use_psa () {
     msg "build: default with only CBC-legacy and CBC-EtM ciphers use psa"
 
     scripts/config.py set MBEDTLS_USE_PSA_CRYPTO


### PR DESCRIPTION
Run `all.sh --list-all-groups` to list all available components, grouped in such a way that running all the components in a group shouldn't last longer than the slowest component.

This is meant to be used on a continuous integration environment that instantiates a separate runtime environment for each component, and where instantiating a runtime environment is costly. The CI system can now instantiate a runtime environment per group, saving on instantiation costs.

This is the mbedtls repository side of an implementation of https://github.com/Mbed-TLS/mbedtls-test/issues/69.

### Gatekeeper notes

* **Do not merge until this has been tested with the Groovy side of the feature**
* Changelog: N/A (just test stuff)
* Backport: yes, but no need to wait for it to be done
