### PR TITLE
TLS 1.3: EarlyData: Add early data transform computation

### DIFF
--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -986,7 +986,7 @@ struct mbedtls_ssl_handshake_params
     mbedtls_ssl_tls13_handshake_secrets tls13_hs_secrets;
 #if defined(MBEDTLS_SSL_EARLY_DATA)
     mbedtls_ssl_tls13_early_secrets tls13_early_secrets;
-    /** TLS 1.3 transform for 0-RTT application and handshake messages. */
+    /** TLS 1.3 transform for early data and handshake messages. */
     mbedtls_ssl_transform *transform_earlydata;
 #endif
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3 */

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -890,13 +890,6 @@ struct mbedtls_ssl_handshake_params
     uint16_t mtu;                       /*!<  Handshake mtu, used to fragment outgoing messages */
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
 
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3)
-    /*! TLS 1.3 transforms for 0-RTT and encrypted handshake messages.
-     *  Those pointers own the transforms they reference. */
-    mbedtls_ssl_transform *transform_handshake;
-    mbedtls_ssl_transform *transform_earlydata;
-#endif /* MBEDTLS_SSL_PROTO_TLS1_3 */
-
     /*
      * Checksum contexts
      */
@@ -981,6 +974,8 @@ struct mbedtls_ssl_handshake_params
     unsigned char *certificate_request_context;
 #endif
 
+    /** TLS 1.3 transform for encrypted handshake messages. */
+    mbedtls_ssl_transform *transform_handshake;
     union
     {
         unsigned char early    [MBEDTLS_TLS1_3_MD_MAX_SIZE];
@@ -989,6 +984,11 @@ struct mbedtls_ssl_handshake_params
     } tls13_master_secrets;
 
     mbedtls_ssl_tls13_handshake_secrets tls13_hs_secrets;
+#if defined(MBEDTLS_SSL_EARLY_DATA)
+    mbedtls_ssl_tls13_early_secrets tls13_early_secrets;
+    /** TLS 1.3 transform for 0-RTT application and handshake messages. */
+    mbedtls_ssl_transform *transform_earlydata;
+#endif
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3 */
 
 #if defined(MBEDTLS_SSL_ASYNC_PRIVATE)

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1447,9 +1447,11 @@ void mbedtls_ssl_session_reset_msg_layer( mbedtls_ssl_context *ssl,
 
     if( ssl->handshake != NULL )
     {
+#if defined(MBEDTLS_SSL_EARLY_DATA)
         mbedtls_ssl_transform_free( ssl->handshake->transform_earlydata );
         mbedtls_free( ssl->handshake->transform_earlydata );
         ssl->handshake->transform_earlydata = NULL;
+#endif
 
         mbedtls_ssl_transform_free( ssl->handshake->transform_handshake );
         mbedtls_free( ssl->handshake->transform_handshake );
@@ -4067,9 +4069,11 @@ void mbedtls_ssl_handshake_free( mbedtls_ssl_context *ssl )
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
     mbedtls_ssl_transform_free( handshake->transform_handshake );
+    mbedtls_free( handshake->transform_handshake );
+#if defined(MBEDTLS_SSL_EARLY_DATA)
     mbedtls_ssl_transform_free( handshake->transform_earlydata );
     mbedtls_free( handshake->transform_earlydata );
-    mbedtls_free( handshake->transform_handshake );
+#endif
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3 */
 
 

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -215,6 +215,7 @@ cleanup:
     return( psa_ssl_status_to_mbedtls ( status ) );
 }
 
+MBEDTLS_CHECK_RETURN_CRITICAL
 static int ssl_tls13_make_traffic_key(
                     psa_algorithm_t hash_alg,
                     const unsigned char *secret, size_t secret_len,
@@ -1123,7 +1124,7 @@ static int ssl_tls13_generate_early_key( mbedtls_ssl_context *ssl,
     if( ret != 0 )
     {
         MBEDTLS_SSL_DEBUG_RET( 1, "ssl_tls13_get_cipher_key_info", ret );
-        return ret;
+        return( ret );
     }
 
     md_type = ciphersuite_info->mac;
@@ -1179,8 +1180,8 @@ static int ssl_tls13_generate_early_key( mbedtls_ssl_context *ssl,
               traffic_keys->client_write_iv, iv_len );
     if( ret != 0 )
     {
-        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls13_make_traffic_keys", ret );
-        goto exit;
+        MBEDTLS_SSL_DEBUG_RET( 1, "ssl_tls13_make_traffic_key", ret );
+        return( 0 );
     }
     traffic_keys->key_len = key_len;
     traffic_keys->iv_len = iv_len;
@@ -1195,9 +1196,7 @@ static int ssl_tls13_generate_early_key( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= ssl_tls13_generate_early_key" ) );
 
-exit:
-
-    return( ret );
+    return( 0 );
 }
 
 int mbedtls_ssl_tls13_compute_early_transform( mbedtls_ssl_context *ssl )

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -1082,8 +1082,8 @@ static int ssl_tls13_get_cipher_key_info(
 }
 
 #if defined(MBEDTLS_SSL_EARLY_DATA)
-/* ssl_tls13_generate_early_keys() generates keys necessary for protecting
- * the early app data messages described in section 7  RFC 8446. */
+/* ssl_tls13_generate_early_keys() generates keys necessary for protecting the
+   early application and handshake messages described in section 7 RFC 8446. */
 MBEDTLS_CHECK_RETURN_CRITICAL
 static int ssl_tls13_generate_early_keys( mbedtls_ssl_context *ssl,
                                           mbedtls_ssl_key_set *traffic_keys )
@@ -1130,9 +1130,9 @@ static int ssl_tls13_generate_early_keys( mbedtls_ssl_context *ssl,
         return( ret );
     }
 
-    ret = mbedtls_ssl_tls13_derive_early_secrets( hash_alg,
-                                    handshake->tls13_master_secrets.early,
-                                    transcript, transcript_len, tls13_early_secrets );
+    ret = mbedtls_ssl_tls13_derive_early_secrets(
+              hash_alg, handshake->tls13_master_secrets.early,
+              transcript, transcript_len, tls13_early_secrets );
     if( ret != 0 )
     {
         MBEDTLS_SSL_DEBUG_RET(
@@ -1142,27 +1142,28 @@ static int ssl_tls13_generate_early_keys( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_DEBUG_BUF(
         4, "Client early traffic secret",
-                    tls13_early_secrets->client_early_traffic_secret,
-                    hash_len );
+        tls13_early_secrets->client_early_traffic_secret, hash_len );
 
     /*
      * Export client handshake traffic secret
      */
     if( ssl->f_export_keys != NULL )
     {
-        ssl->f_export_keys( ssl->p_export_keys,
-                MBEDTLS_SSL_KEY_EXPORT_TLS1_3_CLIENT_EARLY_SECRET,
-                tls13_early_secrets->client_early_traffic_secret,
-                hash_len,
-                handshake->randbytes,
-                handshake->randbytes + MBEDTLS_CLIENT_HELLO_RANDOM_LEN,
-                MBEDTLS_SSL_TLS_PRF_NONE /* TODO: FIX! */ );
+        ssl->f_export_keys(
+            ssl->p_export_keys,
+            MBEDTLS_SSL_KEY_EXPORT_TLS1_3_CLIENT_EARLY_SECRET,
+            tls13_early_secrets->client_early_traffic_secret,
+            hash_len,
+            handshake->randbytes,
+            handshake->randbytes + MBEDTLS_CLIENT_HELLO_RANDOM_LEN,
+            MBEDTLS_SSL_TLS_PRF_NONE /* TODO: FIX! */ );
     }
 
-    ret = mbedtls_ssl_tls13_make_traffic_keys( hash_alg,
-                            tls13_early_secrets->client_early_traffic_secret,
-                            tls13_early_secrets->client_early_traffic_secret,
-                            hash_len, key_len, iv_len, traffic_keys );
+    ret = mbedtls_ssl_tls13_make_traffic_keys(
+              hash_alg,
+              tls13_early_secrets->client_early_traffic_secret,
+              tls13_early_secrets->client_early_traffic_secret,
+              hash_len, key_len, iv_len, traffic_keys );
     if( ret != 0 )
     {
         MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls13_make_traffic_keys", ret );
@@ -1283,16 +1284,13 @@ int mbedtls_ssl_tls13_generate_handshake_keys( mbedtls_ssl_context *ssl,
                                                mbedtls_ssl_key_set *traffic_keys )
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
-
     mbedtls_md_type_t md_type;
-
     psa_algorithm_t hash_alg;
     size_t hash_len;
-
     unsigned char transcript[MBEDTLS_TLS1_3_MD_MAX_SIZE];
     size_t transcript_len;
-
-    size_t key_len, iv_len;
+    size_t key_len;
+    size_t iv_len;
 
     mbedtls_ssl_handshake_params *handshake = ssl->handshake;
     const mbedtls_ssl_ciphersuite_t *ciphersuite_info = handshake->ciphersuite_info;
@@ -1300,8 +1298,7 @@ int mbedtls_ssl_tls13_generate_handshake_keys( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> mbedtls_ssl_tls13_generate_handshake_keys" ) );
 
-    ret = ssl_tls13_get_cipher_key_info( ciphersuite_info,
-                                                 &key_len, &iv_len );
+    ret = ssl_tls13_get_cipher_key_info( ciphersuite_info, &key_len, &iv_len );
     if( ret != 0 )
     {
         MBEDTLS_SSL_DEBUG_RET( 1, "ssl_tls13_get_cipher_key_info", ret );
@@ -1521,7 +1518,7 @@ int mbedtls_ssl_tls13_generate_application_keys(
     /* Extract basic information about hash and ciphersuite */
 
     ret = ssl_tls13_get_cipher_key_info( handshake->ciphersuite_info,
-                                                 &key_len, &iv_len );
+                                         &key_len, &iv_len );
     if( ret != 0 )
     {
         MBEDTLS_SSL_DEBUG_RET( 1, "ssl_tls13_get_cipher_key_info", ret );

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -1090,12 +1090,12 @@ static int ssl_tls13_get_cipher_key_info(
 #if defined(MBEDTLS_SSL_EARLY_DATA)
 /*
  * ssl_tls13_generate_early_key() generates the key necessary for protecting
- * the early application data and the EndOfEarlyData handshake message
- * as described in section 7 of RFC 8446.
+ * the early application data and handshake messages as described in section 7
+ * of RFC 8446.
  *
- * NOTE: That only one key is generated, the key for the traffic from the
- * client to the server. The TLS 1.3 specification does not define a secret
- * and thus a key for server early traffic.
+ * NOTE: Only one key is generated, the key for the traffic from the client to
+ *       the server. The TLS 1.3 specification does not define a secret and thus
+ *       a key for server early traffic.
  */
 MBEDTLS_CHECK_RETURN_CRITICAL
 static int ssl_tls13_generate_early_key( mbedtls_ssl_context *ssl,

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -224,7 +224,8 @@ static int ssl_tls13_make_traffic_key(
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
 
-    ret = mbedtls_ssl_tls13_hkdf_expand_label( hash_alg,
+    ret = mbedtls_ssl_tls13_hkdf_expand_label(
+                    hash_alg,
                     secret, secret_len,
                     MBEDTLS_SSL_TLS1_3_LBL_WITH_LEN( key ),
                     NULL, 0,
@@ -232,7 +233,8 @@ static int ssl_tls13_make_traffic_key(
     if( ret != 0 )
         return( ret );
 
-    ret = mbedtls_ssl_tls13_hkdf_expand_label( hash_alg,
+    ret = mbedtls_ssl_tls13_hkdf_expand_label(
+                    hash_alg,
                     secret, secret_len,
                     MBEDTLS_SSL_TLS1_3_LBL_WITH_LEN( iv ),
                     NULL, 0,
@@ -1103,16 +1105,13 @@ static int ssl_tls13_generate_early_key( mbedtls_ssl_context *ssl,
                                          mbedtls_ssl_key_set *traffic_keys )
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
-
     mbedtls_md_type_t md_type;
-
     psa_algorithm_t hash_alg;
     size_t hash_len;
-
     unsigned char transcript[MBEDTLS_TLS1_3_MD_MAX_SIZE];
     size_t transcript_len;
-
-    size_t key_len, iv_len;
+    size_t key_len;
+    size_t iv_len;
 
     mbedtls_ssl_handshake_params *handshake = ssl->handshake;
     const mbedtls_ssl_ciphersuite_t *ciphersuite_info = handshake->ciphersuite_info;

--- a/library/ssl_tls13_keys.h
+++ b/library/ssl_tls13_keys.h
@@ -667,6 +667,23 @@ int mbedtls_ssl_tls13_calculate_verify_data( mbedtls_ssl_context *ssl,
                                              size_t *actual_len,
                                              int which );
 
+#if defined(MBEDTLS_SSL_EARLY_DATA)
+/**
+ * \brief Compute TLS 1.3 early transform
+ *
+ * \param ssl  The SSL context to operate on. The early secret must have been
+ *             computed.
+ *
+ * \returns    \c 0 on success.
+ * \returns    A negative error code on failure.
+ *
+ * \warning   `early_secrets` is not computation. Caller MUST call
+ *            mbedtls_ssl_tls13_key_schedule_stage_early() before this function.
+ */
+MBEDTLS_CHECK_RETURN_CRITICAL
+int mbedtls_ssl_tls13_compute_early_transform( mbedtls_ssl_context *ssl );
+#endif /* MBEDTLS_SSL_EARLY_DATA */
+
 /**
  * \brief Compute TLS 1.3 handshake transform
  *

--- a/library/ssl_tls13_keys.h
+++ b/library/ssl_tls13_keys.h
@@ -676,9 +676,13 @@ int mbedtls_ssl_tls13_calculate_verify_data( mbedtls_ssl_context *ssl,
  * \returns    \c 0 on success.
  * \returns    A negative error code on failure.
  *
- * \warning   `early_secrets` is not computed before this function. Call
- *            mbedtls_ssl_tls13_key_schedule_stage_early() to generate early
- *            secrets.
+ * \warning    The function does not compute the early master secret. Call
+ *             mbedtls_ssl_tls13_key_schedule_stage_early() before to
+ *             call this function to generate the early master secret.
+ * \note       For a client/server endpoint, the function computes only the
+ *             encryption/decryption part of the transform as the decryption/
+ *             encryption part is not defined by the specification (no early
+ *             traffic from the server to the client).
  */
 MBEDTLS_CHECK_RETURN_CRITICAL
 int mbedtls_ssl_tls13_compute_early_transform( mbedtls_ssl_context *ssl );

--- a/library/ssl_tls13_keys.h
+++ b/library/ssl_tls13_keys.h
@@ -671,14 +671,14 @@ int mbedtls_ssl_tls13_calculate_verify_data( mbedtls_ssl_context *ssl,
 /**
  * \brief Compute TLS 1.3 early transform
  *
- * \param ssl  The SSL context to operate on. The early secret must have been
- *             computed.
+ * \param ssl  The SSL context to operate on.
  *
  * \returns    \c 0 on success.
  * \returns    A negative error code on failure.
  *
- * \warning   `early_secrets` is not computation. Caller MUST call
- *            mbedtls_ssl_tls13_key_schedule_stage_early() before this function.
+ * \warning   `early_secrets` is not computed before this function. Call
+ *            mbedtls_ssl_tls13_key_schedule_stage_early() to generate early
+ *            secrets.
  */
 MBEDTLS_CHECK_RETURN_CRITICAL
 int mbedtls_ssl_tls13_compute_early_transform( mbedtls_ssl_context *ssl );


### PR DESCRIPTION
## Description
fix #6341 

Add needed functions for computing early keys

## Gatekeeper checklist

- [x] **changelog** provided, or not required
- [x] **backport** done, or not required
- [x] **tests** provided, or not required



## Notes for the submitter

Please refer to the [contributing guidelines](../CONTRIBUTING.md), especially the
checklist for PR contributors.

