### PR TITLE
TLS 1.3: EarlyData: SRV: Implement `mbedtls_ssl_read_early_data`

### DIFF
--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -90,8 +90,10 @@
 #define MBEDTLS_ERR_SSL_RECEIVED_NEW_SESSION_TICKET       -0x7B00
 /** Not possible to read early data */
 #define MBEDTLS_ERR_SSL_CANNOT_READ_EARLY_DATA            -0x7B80
+/** Has early data to be read. */
+#define MBEDTLS_ERR_SSL_HAS_EARLY_DATA                    -0x7C00
 /** Not possible to write early data */
-#define MBEDTLS_ERR_SSL_CANNOT_WRITE_EARLY_DATA           -0x7C00
+#define MBEDTLS_ERR_SSL_CANNOT_WRITE_EARLY_DATA           -0x7C80
 /* Error space gap */
 /* Error space gap */
 /* Error space gap */

--- a/library/ssl_debug_helpers.h
+++ b/library/ssl_debug_helpers.h
@@ -18,6 +18,15 @@
 #include "mbedtls/ssl.h"
 #include "ssl_misc.h"
 
+#undef MBEDTLS_SSL_ASSERT
+
+#define MBEDTLS_SSL_ASSERT(cond)                                    \
+    do {                                                            \
+        if (!(cond)) {                                              \
+            MBEDTLS_SSL_DEBUG_MSG(1, ("`" #cond "` mismatch"));      \
+            return -1;                                              \
+        }                                                           \
+    } while (0)
 
 const char *mbedtls_ssl_states_str(mbedtls_ssl_states in);
 
@@ -64,6 +73,8 @@ void mbedtls_ssl_print_ticket_flags(const mbedtls_ssl_context *ssl,
 #endif
 
 #else
+
+#define MBEDTLS_SSL_ASSERT(cond)
 
 #define MBEDTLS_SSL_PRINT_EXTS(level, hs_msg_type, extension_mask)
 

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -1311,6 +1311,11 @@ int mbedtls_ssl_send_fatal_handshake_failure(mbedtls_ssl_context *ssl);
 MBEDTLS_CHECK_RETURN_CRITICAL
 int mbedtls_ssl_reset_checksum(mbedtls_ssl_context *ssl);
 
+/* Read message from ssl->in_msg. */
+MBEDTLS_CHECK_RETURN_CRITICAL
+int mbedtls_ssl_read_inmsg(
+    mbedtls_ssl_context *ssl, unsigned char *buf, size_t len);
+
 #if defined(MBEDTLS_SSL_PROTO_TLS1_2)
 MBEDTLS_CHECK_RETURN_CRITICAL
 int mbedtls_ssl_derive_keys(mbedtls_ssl_context *ssl);

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -5647,13 +5647,38 @@ static int ssl_handle_hs_message_post_handshake(mbedtls_ssl_context *ssl)
     return MBEDTLS_ERR_SSL_INTERNAL_ERROR;
 }
 
+int mbedtls_ssl_read_inmsg(
+    mbedtls_ssl_context *ssl, unsigned char *buf, size_t len)
+{
+    size_t n = (len < ssl->in_msglen) ? len : ssl->in_msglen;
+
+    if (len != 0) {
+        memcpy(buf, ssl->in_offt, n);
+        ssl->in_msglen -= n;
+    }
+
+    /* Zeroising the plaintext buffer to erase unused application data
+       from the memory. */
+    mbedtls_platform_zeroize(ssl->in_offt, n);
+
+    if (ssl->in_msglen == 0) {
+        /* all bytes consumed */
+        ssl->in_offt = NULL;
+        ssl->keep_current_message = 0;
+    } else {
+        /* more data available */
+        ssl->in_offt += n;
+    }
+
+    return (int) n;
+}
+
 /*
  * Receive application data decrypted from the SSL layer
  */
 int mbedtls_ssl_read(mbedtls_ssl_context *ssl, unsigned char *buf, size_t len)
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
-    size_t n;
 
     if (ssl == NULL || ssl->conf == NULL) {
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
@@ -5817,30 +5842,11 @@ int mbedtls_ssl_read(mbedtls_ssl_context *ssl, unsigned char *buf, size_t len)
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
     }
 
-    n = (len < ssl->in_msglen)
-        ? len : ssl->in_msglen;
-
-    if (len != 0) {
-        memcpy(buf, ssl->in_offt, n);
-        ssl->in_msglen -= n;
-    }
-
-    /* Zeroising the plaintext buffer to erase unused application data
-       from the memory. */
-    mbedtls_platform_zeroize(ssl->in_offt, n);
-
-    if (ssl->in_msglen == 0) {
-        /* all bytes consumed */
-        ssl->in_offt = NULL;
-        ssl->keep_current_message = 0;
-    } else {
-        /* more data available */
-        ssl->in_offt += n;
-    }
+    ret = mbedtls_ssl_read_inmsg(ssl, buf, len);
 
     MBEDTLS_SSL_DEBUG_MSG(2, ("<= read"));
 
-    return (int) n;
+    return ret;
 }
 
 /*

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -2893,6 +2893,20 @@ static int ssl_tls13_end_of_early_data_coordinate(mbedtls_ssl_context *ssl)
 
     if (ssl->in_msgtype == MBEDTLS_SSL_MSG_APPLICATION_DATA) {
         MBEDTLS_SSL_DEBUG_MSG(3, ("Received early data"));
+        /* RFC 8446 section 4.6.1
+         *
+         * A server receiving more than max_early_data_size bytes of 0-RTT data
+         * SHOULD terminate the connection with an "unexpected_message" alert.
+         *
+         * TODO: Add received data size check here.
+         *
+         * suggestion:
+         * ```
+         * if(ssl->in_offt == NULL) early_data_size += ssl->in_msglen;
+         * if(early_data_size > max_early_data_size) { send alert and return;}
+         * ```
+         *
+         */
         return SSL_GOT_EARLY_DATA;
     }
 
@@ -2937,14 +2951,6 @@ static int ssl_tls13_process_early_application_data(mbedtls_ssl_context *ssl)
      */
     ssl->in_msg[ssl->in_msglen] = 0;
     MBEDTLS_SSL_DEBUG_MSG(3, ("\n%s", ssl->in_msg));
-
-    /* RFC 8446 section 4.6.1
-     *
-     * A server receiving more than max_early_data_size bytes of 0-RTT data
-     * SHOULD terminate the connection with an "unexpected_message" alert.
-     *
-     * TODO: Add received data size check here.
-     */
 
     return 0;
 }

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -1073,7 +1073,8 @@ static int mbedtls_status_is_ssl_in_progress(int ret)
 {
     return ret == MBEDTLS_ERR_SSL_WANT_READ ||
            ret == MBEDTLS_ERR_SSL_WANT_WRITE ||
-           ret == MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS;
+           ret == MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS ||
+           ret == MBEDTLS_ERR_SSL_HAS_EARLY_DATA;
 }
 
 #if defined(MBEDTLS_SSL_ASYNC_PRIVATE)

--- a/tests/opt-testcases/tls13-misc.sh
+++ b/tests/opt-testcases/tls13-misc.sh
@@ -506,4 +506,5 @@ run_test "TLS 1.3 G->m: EarlyData: feature is enabled, good." \
          -s "Sent max_early_data_size=$EARLY_DATA_INPUT_LEN"                \
          -s "ClientHello: early_data(42) extension exists."                 \
          -s "EncryptedExtensions: early_data(42) extension exists."         \
-         -s "$( tail -1 $EARLY_DATA_INPUT )"
+         -s "$( tail -1 $EARLY_DATA_INPUT )"                                \
+         -s "[ Received 0-RTT data size is $EARLY_DATA_INPUT_LEN ]"


### PR DESCRIPTION
## Description

fix #6341 

- [x] Implement `mbedtls_ssl_read_early_data` 
- [x] Add tests for read early_data


## Gatekeeper checklist

- [x] **changelog** not required( That part of tls13 early data)
- [x] **backport** not required( That part of tls13 early data)
- [x] **tests** provided(That has been covered by exist tests)



## Notes for the submitter

Please refer to the [contributing guidelines](../CONTRIBUTING.md), especially the
checklist for PR contributors.

