### PR TITLE
Improve test suite detection in run-test-suites.pl

### DIFF
--- a/tests/scripts/run-test-suites.pl
+++ b/tests/scripts/run-test-suites.pl
@@ -50,11 +50,13 @@ GetOptions(
            'verbose|v:1' => \$verbose,
           ) or die;
 
-# All test suites = executable files, excluding source files, debug
-# and profiling information, etc. We can't just grep {! /\./} because
-# some of our test cases' base names contain a dot.
-my @suites = grep { -x $_ || /\.exe$/ } glob 'test_suite_*';
-@suites = grep { !/\.c$/ && !/\.data$/ && -f } @suites;
+# All test suites = executable files derived from a .data file.
+my @suites = ();
+for my $data_file (glob 'suites/test_suite_*.data') {
+    (my $base = $data_file) =~ s#^suites/(.*)\.data$#$1#;
+    push @suites, $base if -x $base;
+    push @suites, "$base.exe" if -e "$base.exe";
+}
 die "$0: no test suite found\n" unless @suites;
 
 # "foo" as a skip pattern skips "test_suite_foo" and "test_suite_foo.bar"


### PR DESCRIPTION
Looking for executables causes problems with leftover compiled test suites from other branches when we forget to run make clean before switching branches. Using the .data files is more robust as most of them are tracked, so will be removed when switching branches.

**Testing:**
- tested locally on Linux, both that it ignores extra executables (see steps below), and that it runs the expected number of suites;
- checked in CI logs that it executes the expected number of suites in `Windows-mingw` (`win32-msvc12_{64,32}` are not running the test suites, and `Windows-2013` and `win32-mingw` use cmake which doesn't use this script).

Steps to reproduce:
```
make tests
(cd tests && cp /bin/false test_suite_00leftover)
make test
```
Before: runs `test_suite_00leftover` and fails. After: correctly ignores it.

## Gatekeeper checklist

- [ ] **changelog** not required - test tooling improvement
- [ ] **backport** done: #6572
- [ ] **tests** not required - test tooling improvement