### PR TITLE
Fix outdated reference in debug message

### DIFF
--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -1797,8 +1797,7 @@ int mbedtls_ssl_fetch_input( mbedtls_ssl_context *ssl, size_t nb_want )
 
     if( ssl->f_recv == NULL && ssl->f_recv_timeout == NULL )
     {
-        MBEDTLS_SSL_DEBUG_MSG( 1, ( "Bad usage of mbedtls_ssl_set_bio() "
-                            "or mbedtls_ssl_set_bio()" ) );
+        MBEDTLS_SSL_DEBUG_MSG( 1, ( "Bad usage of mbedtls_ssl_set_bio() " ) );
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
     }
 
@@ -2013,8 +2012,7 @@ int mbedtls_ssl_flush_output( mbedtls_ssl_context *ssl )
 
     if( ssl->f_send == NULL )
     {
-        MBEDTLS_SSL_DEBUG_MSG( 1, ( "Bad usage of mbedtls_ssl_set_bio() "
-                            "or mbedtls_ssl_set_bio()" ) );
+        MBEDTLS_SSL_DEBUG_MSG( 1, ( "Bad usage of mbedtls_ssl_set_bio() " ) );
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
     }
 


### PR DESCRIPTION
The debug message was incorrectly adapted when `mbedtls_ssl_set_bio_timeout()` was renamed to `mbedtls_ssl_set_bio()` in:
https://github.com/Mbed-TLS/mbedtls/commit/1b511f93c6353db39da0ae7534fb8c7a884f9f47#diff-76b73bf2a8157ee95fdd3b688384812654c63878be4ecce6ee56402eb52b1f4fL2188-L2376

Backport: #6554 