### PR TITLE
Refactor/tidy after fixing unusual macros

### DIFF
--- a/library/ecp.c
+++ b/library/ecp.c
@@ -2051,7 +2051,7 @@ static int ecp_mul_comb_core( const mbedtls_ecp_group *grp, mbedtls_ecp_point *R
 
         int have_rng = 1;
 #if defined(MBEDTLS_ECP_NO_INTERNAL_RNG)
-        if( f_rng == 0 )
+        if( f_rng == NULL )
             have_rng = 0;
 #endif
         if( have_rng )
@@ -2190,7 +2190,7 @@ final_norm:
      */
     int have_rng = 1;
 #if defined(MBEDTLS_ECP_NO_INTERNAL_RNG)
-    if( f_rng == 0 )
+    if( f_rng == NULL )
         have_rng = 0;
 #endif
     if( have_rng )

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -3454,20 +3454,18 @@ start_processing:
         if( ( ret = mbedtls_pk_verify_restartable( peer_pk,
                         md_alg, hash, hashlen, p, sig_len, rs_ctx ) ) != 0 )
         {
-            int send_alert_msg = 1;
-#if defined(MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED)
-            send_alert_msg = ( ret != MBEDTLS_ERR_ECP_IN_PROGRESS );
-#endif
-            if( send_alert_msg )
-                mbedtls_ssl_send_alert_message(
-                    ssl,
-                    MBEDTLS_SSL_ALERT_LEVEL_FATAL,
-                    MBEDTLS_SSL_ALERT_MSG_DECRYPT_ERROR );
-            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_pk_verify", ret );
 #if defined(MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED)
             if( ret == MBEDTLS_ERR_ECP_IN_PROGRESS )
-                ret = MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS;
+            {
+                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_pk_verify", ret );
+                return( MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS );
+            }
 #endif
+            mbedtls_ssl_send_alert_message(
+                ssl,
+                MBEDTLS_SSL_ALERT_LEVEL_FATAL,
+                MBEDTLS_SSL_ALERT_MSG_DECRYPT_ERROR );
+            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_pk_verify", ret );
             return( ret );
         }
 

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -2060,7 +2060,7 @@ static int is_compression_ok( mbedtls_ssl_context *ssl, unsigned char comp )
     int accept_comp = 1;
 
     /* Suppress warnings in some configurations */
-    ( void )ssl;
+    (void) ssl;
 #if defined(MBEDTLS_ZLIB_SUPPORT)
     /* See comments in ssl_write_client_hello() */
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
@@ -2254,7 +2254,7 @@ static int ssl_parse_server_hello( mbedtls_ssl_context *ssl )
      */
     comp = buf[37 + n];
 
-    if( !is_compression_ok(ssl, comp) )
+    if( !is_compression_ok( ssl, comp ) )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1,
             ( "server hello, bad compression: %d", comp ) );

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -2694,17 +2694,14 @@ static int ssl_check_server_ecdh_params( const mbedtls_ssl_context *ssl )
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "ECDH curve: %s", curve_info->name ) );
 
-    int bad_params = 0;
 #if defined(MBEDTLS_ECP_C)
     if( mbedtls_ssl_check_curve( ssl, grp_id ) != 0 )
-        bad_params = 1;
+        return( -1 );
 #else
     if( ssl->handshake->ecdh_ctx.grp.nbits < 163 ||
         ssl->handshake->ecdh_ctx.grp.nbits > 521 )
-        bad_params = 1;
-#endif
-    if( bad_params )
         return( -1 );
+#endif
 
     MBEDTLS_SSL_DEBUG_ECDH( 3, &ssl->handshake->ecdh_ctx,
                             MBEDTLS_DEBUG_ECDH_QP );

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -2687,7 +2687,7 @@ static int ssl_check_server_ecdh_params( const mbedtls_ssl_context *ssl )
     grp_id = ssl->handshake->ecdh_ctx.grp.id;
 #else
     grp_id = ssl->handshake->ecdh_ctx.grp_id;
-#endif
+#endif /* MBEDTLS_ECDH_LEGACY_CONTEXT */
 
     curve_info = mbedtls_ecp_curve_info_from_grp_id( grp_id );
     if( curve_info == NULL )
@@ -2705,7 +2705,7 @@ static int ssl_check_server_ecdh_params( const mbedtls_ssl_context *ssl )
     if( ssl->handshake->ecdh_ctx.grp.nbits < 163 ||
         ssl->handshake->ecdh_ctx.grp.nbits > 521 )
         return( -1 );
-#endif
+#endif /* MBEDTLS_ECP_C */
 
     MBEDTLS_SSL_DEBUG_ECDH( 3, &ssl->handshake->ecdh_ctx,
                             MBEDTLS_DEBUG_ECDH_QP );
@@ -3453,7 +3453,7 @@ start_processing:
 #if defined(MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED)
         if( ssl->handshake->ecrs_enabled )
             rs_ctx = &ssl->handshake->ecrs_ctx.pk;
-#endif
+#endif /* MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED */
 
         if( ( ret = mbedtls_pk_verify_restartable( peer_pk,
                         md_alg, hash, hashlen, p, sig_len, rs_ctx ) ) != 0 )
@@ -3464,7 +3464,7 @@ start_processing:
                 MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_pk_verify", ret );
                 return( MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS );
             }
-#endif
+#endif /* MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED */
             mbedtls_ssl_send_alert_message(
                 ssl,
                 MBEDTLS_SSL_ALERT_LEVEL_FATAL,

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -2055,9 +2055,9 @@ static int ssl_parse_hello_verify_request( mbedtls_ssl_context *ssl )
 }
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
 
-static int is_compression_ok( mbedtls_ssl_context *ssl, unsigned char comp )
+static int is_compression_bad( mbedtls_ssl_context *ssl, unsigned char comp )
 {
-    int accept_comp = 1;
+    int bad_comp = 0;
 
     /* Suppress warnings in some configurations */
     (void) ssl;
@@ -2065,17 +2065,17 @@ static int is_compression_ok( mbedtls_ssl_context *ssl, unsigned char comp )
     /* See comments in ssl_write_client_hello() */
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
     if( ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM )
-        accept_comp = 0;
+        bad_comp = 1;
 #endif
 
     if( comp != MBEDTLS_SSL_COMPRESS_NULL &&
         comp != MBEDTLS_SSL_COMPRESS_DEFLATE )
-        accept_comp = 0;
+        bad_comp = 1;
 #else /* MBEDTLS_ZLIB_SUPPORT */
     if( comp != MBEDTLS_SSL_COMPRESS_NULL )
-        accept_comp = 0;
+        bad_comp = 1;
 #endif/* MBEDTLS_ZLIB_SUPPORT */
-    return accept_comp;
+    return bad_comp;
 }
 
 MBEDTLS_CHECK_RETURN_CRITICAL
@@ -2254,7 +2254,7 @@ static int ssl_parse_server_hello( mbedtls_ssl_context *ssl )
      */
     comp = buf[37 + n];
 
-    if( !is_compression_ok( ssl, comp ) )
+    if( is_compression_bad( ssl, comp ) )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1,
             ( "server hello, bad compression: %d", comp ) );

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -2064,7 +2064,8 @@ static int is_compression_bad( mbedtls_ssl_context *ssl, unsigned char comp )
 #if defined(MBEDTLS_ZLIB_SUPPORT)
     /* See comments in ssl_write_client_hello() */
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
-    if( ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM )
+    if( ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM &&
+        comp != MBEDTLS_SSL_COMPRESS_NULL )
         bad_comp = 1;
 #endif
 

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -1089,11 +1089,6 @@ static int ssl_write_client_hello( mbedtls_ssl_context *ssl )
      * RFC 5077 section 3.4: "When presenting a ticket, the client MAY
      * generate and include a Session ID in the TLS ClientHello."
      */
-    renegotiating = 0;
-#if defined(MBEDTLS_SSL_RENEGOTIATION)
-    if( ssl->renego_status != MBEDTLS_SSL_INITIAL_HANDSHAKE )
-        renegotiating = 1;
-#endif
     if( !renegotiating )
     {
         if( ssl->session_negotiate->ticket != NULL &&
@@ -1209,11 +1204,6 @@ static int ssl_write_client_hello( mbedtls_ssl_context *ssl )
     /*
      * Add TLS_EMPTY_RENEGOTIATION_INFO_SCSV
      */
-    renegotiating = 0;
-#if defined(MBEDTLS_SSL_RENEGOTIATION)
-    if( ssl->renego_status != MBEDTLS_SSL_INITIAL_HANDSHAKE )
-        renegotiating = 1;
-#endif
     if( !renegotiating )
     {
         MBEDTLS_SSL_DEBUG_MSG( 3, ( "adding EMPTY_RENEGOTIATION_INFO_SCSV" ) );


### PR DESCRIPTION
Do a small amount of refactoring as a followup on #6491, to ensure we don't increase the complexity of the refactored areas too much.

## Gatekeeper checklist

- [x] ~**changelog** provided, or~ not required
- [x] ~**backport** done, or~ not required
- [x] ~**tests** provided, or~ not required