### PR TITLE
check_names: extend typo check to PSA macro/enum names

### DIFF
--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -327,7 +327,7 @@
 
 /* Use of EC J-PAKE in TLS requires SHA-256.
  * This will be taken from MD if it is present, or from PSA if MD is absent.
- * Note: ECJPAKE_C depends on MD_C || PSA_CRYPTO_C. */
+ * Note: MBEDTLS_ECJPAKE_C depends on MBEDTLS_MD_C || MBEDTLS_PSA_CRYPTO_C. */
 #if defined(MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED) &&                    \
     !( defined(MBEDTLS_MD_C) && defined(MBEDTLS_SHA256_C) ) &&          \
     !( !defined(MBEDTLS_MD_C) && defined(PSA_WANT_ALG_SHA_256) )

--- a/include/mbedtls/legacy_or_psa.h
+++ b/include/mbedtls/legacy_or_psa.h
@@ -64,7 +64,7 @@
  * The naming scheme for these macros is:
  *      MBEDTLS_HAS_feature_VIA_legacy_OR_PSA(_condition)
  * where:
- * - feature is expressed the same way as in PSA_WANT macros, for example:
+ * - feature is expressed the same way as in PSA_WANT_xxx macros, for example:
  *   KEY_TYPE_AES, ALG_SHA_256, ECC_SECP_R1_256;
  * - legacy is either LOWLEVEL or the name of the layer: MD, CIPHER;
  * - condition is omitted if it's based on availability, else it's

--- a/include/psa/crypto_values.h
+++ b/include/psa/crypto_values.h
@@ -1760,7 +1760,7 @@
 #define PSA_ALG_HKDF_BASE                       ((psa_algorithm_t)0x08000100)
 /** Macro to build an HKDF algorithm.
  *
- * For example, `PSA_ALG_HKDF(PSA_ALG_SHA256)` is HKDF using HMAC-SHA-256.
+ * For example, `PSA_ALG_HKDF(PSA_ALG_SHA_256)` is HKDF using HMAC-SHA-256.
  *
  * This key derivation algorithm uses the following inputs:
  * - #PSA_KEY_DERIVATION_INPUT_SALT is the salt used in the "extract" step.
@@ -1805,7 +1805,7 @@
 #define PSA_ALG_HKDF_EXTRACT_BASE                       ((psa_algorithm_t)0x08000400)
 /** Macro to build an HKDF-Extract algorithm.
  *
- * For example, `PSA_ALG_HKDF_EXTRACT(PSA_ALG_SHA256)` is
+ * For example, `PSA_ALG_HKDF_EXTRACT(PSA_ALG_SHA_256)` is
  * HKDF-Extract using HMAC-SHA-256.
  *
  * This key derivation algorithm uses the following inputs:
@@ -1854,7 +1854,7 @@
 #define PSA_ALG_HKDF_EXPAND_BASE                       ((psa_algorithm_t)0x08000500)
 /** Macro to build an HKDF-Expand algorithm.
  *
- * For example, `PSA_ALG_HKDF_EXPAND(PSA_ALG_SHA256)` is
+ * For example, `PSA_ALG_HKDF_EXPAND(PSA_ALG_SHA_256)` is
  * HKDF-Expand using HMAC-SHA-256.
  *
  * This key derivation algorithm uses the following inputs:
@@ -1925,7 +1925,7 @@
  * concatenation of ServerHello.Random + ClientHello.Random,
  * and the label is "key expansion".
  *
- * For example, `PSA_ALG_TLS12_PRF(PSA_ALG_SHA256)` represents the
+ * For example, `PSA_ALG_TLS12_PRF(PSA_ALG_SHA_256)` represents the
  * TLS 1.2 PRF using HMAC-SHA-256.
  *
  * \param hash_alg      A hash algorithm (\c PSA_ALG_XXX value such that
@@ -1995,7 +1995,7 @@
  *   PSA_ALG_RSA_PKCS1V15_CRYPT, passed to the key derivation operation
  *   with `psa_key_derivation_input_bytes()`.
  *
- * For example, `PSA_ALG_TLS12_PSK_TO_MS(PSA_ALG_SHA256)` represents the
+ * For example, `PSA_ALG_TLS12_PSK_TO_MS(PSA_ALG_SHA_256)` represents the
  * TLS-1.2 PSK to MasterSecret derivation PRF using HMAC-SHA-256.
  *
  * \param hash_alg      A hash algorithm (\c PSA_ALG_XXX value such that
@@ -2050,7 +2050,7 @@
  * PBKDF2 is defined by PKCS#5, republished as RFC 8018 (section 5.2).
  * This macro specifies the PBKDF2 algorithm constructed using a PRF based on
  * HMAC with the specified hash.
- * For example, `PSA_ALG_PBKDF2_HMAC(PSA_ALG_SHA256)` specifies PBKDF2
+ * For example, `PSA_ALG_PBKDF2_HMAC(PSA_ALG_SHA_256)` specifies PBKDF2
  * using the PRF HMAC-SHA-256.
  *
  * This key derivation algorithm uses the following inputs, which must be

--- a/library/psa_crypto_aead.h
+++ b/library/psa_crypto_aead.h
@@ -508,4 +508,4 @@ psa_status_t mbedtls_psa_aead_finish(
 psa_status_t mbedtls_psa_aead_abort(
     mbedtls_psa_aead_operation_t *operation );
 
-#endif /* PSA_CRYPTO_AEAD */
+#endif /* PSA_CRYPTO_AEAD_H */

--- a/library/psa_crypto_its.h
+++ b/library/psa_crypto_its.h
@@ -73,7 +73,7 @@ struct psa_storage_info_t
  * \return      A status indicating the success/failure of the operation
  *
  * \retval      #PSA_SUCCESS                     The operation completed successfully
- * \retval      #PSA_ERROR_NOT_PERMITTED         The operation failed because the provided `uid` value was already created with PSA_STORAGE_WRITE_ONCE_FLAG
+ * \retval      #PSA_ERROR_NOT_PERMITTED         The operation failed because the provided `uid` value was already created with PSA_STORAGE_FLAG_WRITE_ONCE
  * \retval      #PSA_ERROR_NOT_SUPPORTED         The operation failed because one or more of the flags provided in `create_flags` is not supported or is not valid
  * \retval      #PSA_ERROR_INSUFFICIENT_STORAGE  The operation failed because there was insufficient space on the storage medium
  * \retval      #PSA_ERROR_STORAGE_FAILURE       The operation failed because the physical storage has failed (Fatal error)
@@ -137,7 +137,7 @@ psa_status_t psa_its_get_info(psa_storage_uid_t uid,
  *
  * \retval      #PSA_SUCCESS                  The operation completed successfully
  * \retval      #PSA_ERROR_DOES_NOT_EXIST     The operation failed because the provided key value was not found in the storage
- * \retval      #PSA_ERROR_NOT_PERMITTED      The operation failed because the provided key value was created with PSA_STORAGE_WRITE_ONCE_FLAG
+ * \retval      #PSA_ERROR_NOT_PERMITTED      The operation failed because the provided key value was created with PSA_STORAGE_FLAG_WRITE_ONCE
  * \retval      #PSA_ERROR_STORAGE_FAILURE    The operation failed because the physical storage has failed (Fatal error)
  */
 psa_status_t psa_its_remove(psa_storage_uid_t uid);

--- a/library/psa_crypto_rsa.h
+++ b/library/psa_crypto_rsa.h
@@ -249,7 +249,7 @@ psa_status_t mbedtls_psa_rsa_verify_hash(
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
  * \retval #PSA_ERROR_HARDWARE_FAILURE
- * \retval #PSA_ERROR_TAMPERING_DETECTED
+ * \retval #PSA_ERROR_CORRUPTION_DETECTED
  * \retval #PSA_ERROR_INSUFFICIENT_ENTROPY
  * \retval #PSA_ERROR_BAD_STATE
  *         The library has not been previously initialized by psa_crypto_init().
@@ -306,7 +306,7 @@ psa_status_t mbedtls_psa_asymmetric_encrypt( const psa_key_attributes_t *attribu
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
  * \retval #PSA_ERROR_HARDWARE_FAILURE
- * \retval #PSA_ERROR_TAMPERING_DETECTED
+ * \retval #PSA_ERROR_CORRUPTION_DETECTED
  * \retval #PSA_ERROR_INSUFFICIENT_ENTROPY
  * \retval #PSA_ERROR_INVALID_PADDING
  * \retval #PSA_ERROR_BAD_STATE

--- a/scripts/data_files/driver_templates/psa_crypto_driver_wrappers.c.jinja
+++ b/scripts/data_files/driver_templates/psa_crypto_driver_wrappers.c.jinja
@@ -291,7 +291,7 @@ psa_status_t psa_driver_wrapper_sign_hash(
                     alg, hash, hash_length,
                     signature, signature_size, signature_length ) );
     }
-#endif /* PSA_CRYPTO_SE_C */
+#endif /* MBEDTLS_PSA_CRYPTO_SE_C */
 
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
     psa_key_location_t location =
@@ -375,7 +375,7 @@ psa_status_t psa_driver_wrapper_verify_hash(
                     alg, hash, hash_length,
                     signature, signature_length ) );
     }
-#endif /* PSA_CRYPTO_SE_C */
+#endif /* MBEDTLS_PSA_CRYPTO_SE_C */
 
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
     psa_key_location_t location =
@@ -647,7 +647,7 @@ bits
 
         return( PSA_SUCCESS );
     }
-#endif /* PSA_CRYPTO_SE_C */
+#endif /* MBEDTLS_PSA_CRYPTO_SE_C */
 
     switch( location )
     {
@@ -715,7 +715,7 @@ data_length
                      *( (psa_key_slot_number_t *)key_buffer ),
                      data, data_size, data_length ) );
     }
-#endif /* PSA_CRYPTO_SE_C */
+#endif /* MBEDTLS_PSA_CRYPTO_SE_C */
 
     switch( location )
     {

--- a/tests/scripts/check_names.py
+++ b/tests/scripts/check_names.py
@@ -846,7 +846,8 @@ class NameChecker():
             self.parse_result["enum_consts"]
             }
         typo_exclusion = re.compile(r"XXX|__|_$|^MBEDTLS_.*CONFIG_FILE$|"
-                                    r"MBEDTLS_TEST_LIBTESTDRIVER*")
+                                    r"MBEDTLS_TEST_LIBTESTDRIVER*|"
+                                    r"PSA_CRYPTO_DRIVER_TEST")
 
         for name_match in self.parse_result["mbed_psa_words"]:
             found = name_match.name in all_caps_names

--- a/tests/scripts/check_names.py
+++ b/tests/scripts/check_names.py
@@ -36,7 +36,7 @@ NameChecker performs the following checks:
   declared in the header files. This uses the nm command.
 - All macros, constants, and identifiers (function names, struct names, etc)
   follow the required regex pattern.
-- Typo checking: All words that begin with MBED exist as macros or constants.
+- Typo checking: All words that begin with MBED|PSA exist as macros or constants.
 
 The script returns 0 on success, 1 on test failure, and 2 if there is a script
 error. It must be run from Mbed TLS root.
@@ -191,11 +191,12 @@ class PatternMismatch(Problem): # pylint: disable=too-few-public-methods
 
 class Typo(Problem): # pylint: disable=too-few-public-methods
     """
-    A problem that occurs when a word using MBED doesn't appear to be defined as
-    constants nor enum values. Created with NameCheck.check_for_typos()
+    A problem that occurs when a word using MBED or PSA doesn't
+    appear to be defined as constants nor enum values. Created with
+    NameCheck.check_for_typos()
 
     Fields:
-    * match: the Match object of the MBED name in question.
+    * match: the Match object of the MBED|PSA name in question.
     """
     def __init__(self, match):
         self.match = match
@@ -245,7 +246,7 @@ class CodeParser():
             .format(str(self.excluded_files))
         )
 
-        all_macros = {"public": [], "internal": []}
+        all_macros = {"public": [], "internal": [], "private":[]}
         all_macros["public"] = self.parse_macros([
             "include/mbedtls/*.h",
             "include/psa/*.h",
@@ -256,9 +257,14 @@ class CodeParser():
             "library/*.h",
             "tests/include/test/drivers/*.h",
         ])
+        all_macros["private"] = self.parse_macros([
+            "library/*.c",
+        ])
         enum_consts = self.parse_enum_consts([
             "include/mbedtls/*.h",
+            "include/psa/*.h",
             "library/*.h",
+            "library/*.c",
             "3rdparty/everest/include/everest/everest.h",
             "3rdparty/everest/include/everest/x25519.h"
         ])
@@ -269,7 +275,7 @@ class CodeParser():
             "3rdparty/everest/include/everest/everest.h",
             "3rdparty/everest/include/everest/x25519.h"
         ])
-        mbed_words = self.parse_mbed_words([
+        mbed_psa_words = self.parse_mbed_psa_words([
             "include/mbedtls/*.h",
             "include/psa/*.h",
             "library/*.h",
@@ -302,10 +308,11 @@ class CodeParser():
         return {
             "public_macros": actual_macros["public"],
             "internal_macros": actual_macros["internal"],
+            "private_macros": all_macros["private"],
             "enum_consts": enum_consts,
             "identifiers": identifiers,
             "symbols": symbols,
-            "mbed_words": mbed_words
+            "mbed_psa_words": mbed_psa_words
         }
 
     def is_file_excluded(self, path, exclude_wildcards):
@@ -373,25 +380,28 @@ class CodeParser():
 
         return macros
 
-    def parse_mbed_words(self, include, exclude=None):
+    def parse_mbed_psa_words(self, include, exclude=None):
         """
-        Parse all words in the file that begin with MBED, in and out of macros,
-        comments, anything.
+        Parse all words in the file that begin with MBED|PSA, in and out of
+        macros, comments, anything.
 
         Args:
         * include: A List of glob expressions to look for files through.
         * exclude: A List of glob expressions for excluding files.
 
-        Returns a List of Match objects for words beginning with MBED.
+        Returns a List of Match objects for words beginning with MBED|PSA.
         """
         # Typos of TLS are common, hence the broader check below than MBEDTLS.
-        mbed_regex = re.compile(r"\bMBED.+?_[A-Z0-9_]*")
+        mbed_regex = re.compile(r"\b(MBED.+?|PSA)_[A-Z0-9_]*")
         exclusions = re.compile(r"// *no-check-names|#error")
 
         files = self.get_files(include, exclude)
-        self.log.debug("Looking for MBED words in {} files".format(len(files)))
+        self.log.debug(
+            "Looking for MBED|PSA words in {} files"
+            .format(len(files))
+        )
 
-        mbed_words = []
+        mbed_psa_words = []
         for filename in files:
             with open(filename, "r", encoding="utf-8") as fp:
                 for line_no, line in enumerate(fp):
@@ -399,14 +409,14 @@ class CodeParser():
                         continue
 
                     for name in mbed_regex.finditer(line):
-                        mbed_words.append(Match(
+                        mbed_psa_words.append(Match(
                             filename,
                             line,
                             line_no,
                             name.span(0),
                             name.group(0)))
 
-        return mbed_words
+        return mbed_psa_words
 
     def parse_enum_consts(self, include, exclude=None):
         """
@@ -832,12 +842,13 @@ class NameChecker():
             for match
             in self.parse_result["public_macros"] +
             self.parse_result["internal_macros"] +
+            self.parse_result["private_macros"] +
             self.parse_result["enum_consts"]
             }
         typo_exclusion = re.compile(r"XXX|__|_$|^MBEDTLS_.*CONFIG_FILE$|"
                                     r"MBEDTLS_TEST_LIBTESTDRIVER*")
 
-        for name_match in self.parse_result["mbed_words"]:
+        for name_match in self.parse_result["mbed_psa_words"]:
             found = name_match.name in all_caps_names
 
             # Since MBEDTLS_PSA_ACCEL_XXX defines are defined by the

--- a/tests/scripts/check_names.py
+++ b/tests/scripts/check_names.py
@@ -847,7 +847,8 @@ class NameChecker():
             }
         typo_exclusion = re.compile(r"XXX|__|_$|^MBEDTLS_.*CONFIG_FILE$|"
                                     r"MBEDTLS_TEST_LIBTESTDRIVER*|"
-                                    r"PSA_CRYPTO_DRIVER_TEST")
+                                    r"PSA_CRYPTO_DRIVER_TEST|"
+                                    r"PSA_CRYPTO_C")
 
         for name_match in self.parse_result["mbed_psa_words"]:
             found = name_match.name in all_caps_names

--- a/tests/scripts/check_names.py
+++ b/tests/scripts/check_names.py
@@ -847,8 +847,7 @@ class NameChecker():
             }
         typo_exclusion = re.compile(r"XXX|__|_$|^MBEDTLS_.*CONFIG_FILE$|"
                                     r"MBEDTLS_TEST_LIBTESTDRIVER*|"
-                                    r"PSA_CRYPTO_DRIVER_TEST|"
-                                    r"PSA_CRYPTO_C")
+                                    r"PSA_CRYPTO_DRIVER_TEST")
 
         for name_match in self.parse_result["mbed_psa_words"]:
             found = name_match.name in all_caps_names


### PR DESCRIPTION
## Description
This PR extends typo checks of `check_names.py` to include PSA macro/enum names.
Resolve: #6416


## Status
**READY**


## Todos
- [x] Extend `check_names.py` to check typos of PSA macro/enum names
- [x] Check and fix the newly reported typos
- [x] Check and fix the false negative reports
- [x] Backport to 2.28 branch: https://github.com/Mbed-TLS/mbedtls/pull/6586

