### PR TITLE
dh_genprime: Fix issue where the error code returned by mbedtls_mpi_write_file() is incorrectly reported on failure

### DIFF
--- a/ChangeLog.d/fix_dh_genprime_error_reporting.txt
+++ b/ChangeLog.d/fix_dh_genprime_error_reporting.txt
@@ -1,0 +1,4 @@
+Bugfix
+   * Fix bug in error reporting in dh_genprime.c where upon failure,
+     the error code returned by mbedtls_mpi_write_file() is overwritten
+     and therefore not printed.

--- a/programs/pkey/dh_genprime.c
+++ b/programs/pkey/dh_genprime.c
@@ -157,8 +157,8 @@ int main( int argc, char **argv )
         goto exit;
     }
 
-    if( ( ret = mbedtls_mpi_write_file( "P = ", &P, 16, fout ) != 0 ) ||
-        ( ret = mbedtls_mpi_write_file( "G = ", &G, 16, fout ) != 0 ) )
+    if( ( ( ret = mbedtls_mpi_write_file( "P = ", &P, 16, fout ) ) != 0 ) ||
+        ( ( ret = mbedtls_mpi_write_file( "G = ", &G, 16, fout ) ) != 0 ) )
     {
         mbedtls_printf( " failed\n  ! mbedtls_mpi_write_file returned %d\n\n", ret );
         fclose( fout );


### PR DESCRIPTION
## Description

In `dh_genprime.c`, the following condition can be found inside an `if` statement:

```
ret = mbedtls_mpi_write_file( "P = ", &P, 16, fout ) != 0 
```
As the `!=` operator binds closer than the assignment operator (`=`), the value assigned to `ret` will be the boolean result of the comparison (0 or 1) instead of the status code returned by `mbedtls_mpi_write_file`. This means that the above statement is actually equivalent to:

```
ret = ( mbedtls_mpi_write_file( "P = ", &P, 16, fout ) != 0 )
```
What we want instead is for the the status code to be assigned to `ret`. If the value assigned is non-zero, it will be 'truthy' and the `if` branch will be taken.
```
( ret = mbedtls_mpi_write_file( "P = ", &P, 16, fout ) )  != 0 
```

This PR fixes the issue by explicitly specifying the precedence of operations with parentheses.

## Gatekeeper checklist

- [x] **changelog** 
- [x] **backport** #6583 
- [ ] **tests** not required



## Notes for the submitter

Please refer to the [contributing guidelines](../CONTRIBUTING.md), especially the
checklist for PR contributors.

