### PR TITLE
Improve error injection in EC J-PAKE tests

### DIFF
--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -790,8 +790,8 @@ static void ecjpake_do_round( psa_algorithm_t alg, unsigned int primitive,
 
             if( inject_error == 1 )
             {
-                buffer0[s_x1_pk_off + 8] >>= 4;
-                buffer0[s_x2_pk_off + 7] <<= 4;
+                buffer0[s_x1_pr_off + 8] ^= 1;
+                buffer0[s_x2_pr_off + 7] ^= 1;
                 expected_status = PSA_ERROR_DATA_INVALID;
             }
 
@@ -1013,8 +1013,8 @@ static void ecjpake_do_round( psa_algorithm_t alg, unsigned int primitive,
 
             if( inject_error == 2 )
             {
-                buffer1[c_x1_pk_off + 12] >>= 4;
-                buffer1[c_x2_pk_off + 7] <<= 4;
+                buffer1[c_x1_pr_off + 12] ^= 1;
+                buffer1[c_x2_pr_off + 7] ^= 1;
                 expected_status = PSA_ERROR_DATA_INVALID;
             }
 


### PR DESCRIPTION
The problem described in https://github.com/Mbed-TLS/mbedtls/issues/6503 was caused by two bytes filled with zeros being shifted in tests:
```
buffer0[s_x1_pk_off + 8] >>= 4;
buffer0[s_x2_pk_off + 7] <<= 4;
```
The test expected an error, but with zeros in place the data doesn't change.
Fix - instead of shifting date, perform a bitflip.
Also, instead of corrupting the public key part of the message, corrupt the proof part. A proof is conceptually similar to a signature, and changing anything in it should make it invalid with a high probability (as @mpg has noted).
Fixes https://github.com/Mbed-TLS/mbedtls/issues/6503.
**Changelog not needed**, since it's a test fix, **backport not needed**, since it's a feature that's not backported.