### PR TITLE
include: mbedtls: Add missing private_access header

### DIFF
--- a/include/mbedtls/lms.h
+++ b/include/mbedtls/lms.h
@@ -30,6 +30,7 @@
 #include <stdint.h>
 #include <stddef.h>
 
+#include "mbedtls/private_access.h"
 #include "mbedtls/build_info.h"
 
 #define MBEDTLS_ERR_LMS_BAD_INPUT_DATA   -0x0011 /**< Bad data has been input to an LMS function */


### PR DESCRIPTION
This adds a missing private access header.

Signed-off-by: Moritz Fischer <moritzf@google.com>

## Description

Fix compile errors.



## Gatekeeper checklist

- [x] **changelog** provided, or not required
- [x] **backport** done, or not required
- [x] **tests** provided, or not required



## Notes for the submitter

Should be fairly non-controversial.

