### PR TITLE
Specifically assert that limbs > 0 in mpi_mod_raw_cond_assign test case

### DIFF
--- a/tests/suites/test_suite_bignum_mod_raw.function
+++ b/tests/suites/test_suite_bignum_mod_raw.function
@@ -132,6 +132,7 @@ void mpi_mod_raw_cond_assign( char * input_X,
     mbedtls_mpi_mod_modulus_init( &m );
 
     TEST_EQUAL( limbs_X, limbs_Y );
+    TEST_ASSERT( limbs_X > 0 );
     TEST_ASSERT( copy_limbs <= limbs );
 
     ASSERT_ALLOC( buff_m, copy_limbs );


### PR DESCRIPTION
Should fix Coverity issue 381872

## Gatekeeper checklist

- [ ] **changelog** not required - fix to tests in ongoing work that will have a ChangeLog done at the end
- [ ] **backport** not required - these tests are in `development` only
- [ ] **tests** not required - this is part of tests
