### PR TITLE
Bignum: Remove diamond inheritance from bignum test generation

### DIFF
--- a/scripts/mbedtls_dev/bignum_common.py
+++ b/scripts/mbedtls_dev/bignum_common.py
@@ -20,6 +20,7 @@ import typing
 from abc import abstractmethod
 from typing import Iterator, List, Tuple, TypeVar
 
+from . import test_case
 from . import test_data_generation
 
 T = TypeVar('T') #pylint: disable=invalid-name
@@ -125,6 +126,11 @@ class OperationCommon(test_data_generation.BaseTest):
                 for b in cls.input_values
             )
         yield from cls.input_cases
+
+    @classmethod
+    def generate_function_tests(cls) -> Iterator[test_case.TestCase]:
+        for a_value, b_value in cls.get_value_pairs():
+            yield cls(a_value, b_value).create_test_case()
 
 # BEGIN MERGE SLOT 1
 

--- a/scripts/mbedtls_dev/bignum_common.py
+++ b/scripts/mbedtls_dev/bignum_common.py
@@ -101,6 +101,19 @@ class OperationCommon(test_data_generation.BaseTest):
             quote_str(self.arg_a), quote_str(self.arg_b)
         ] + self.result()
 
+    def description(self) -> str:
+        """Generate a description for the test case.
+
+        If not set, case_description uses the form A `symbol` B, where symbol
+        is used to represent the operation. Descriptions of each value are
+        generated to provide some context to the test case.
+        """
+        if not self.case_description:
+            self.case_description = "{:x} {} {:x}".format(
+                self.int_a, self.symbol, self.int_b
+            )
+        return super().description()
+
     @abstractmethod
     def result(self) -> List[str]:
         """Get the result of the operation.
@@ -131,6 +144,39 @@ class OperationCommon(test_data_generation.BaseTest):
     def generate_function_tests(cls) -> Iterator[test_case.TestCase]:
         for a_value, b_value in cls.get_value_pairs():
             yield cls(a_value, b_value).create_test_case()
+
+
+class OperationCommonArchSplit(OperationCommon):
+    #pylint: disable=abstract-method
+    """Common features for operations where the result depends on
+    the limb size."""
+
+    def __init__(self, val_a: str, val_b: str, bits_in_limb: int) -> None:
+        super().__init__(val_a, val_b)
+        bound_val = max(self.int_a, self.int_b)
+        self.bits_in_limb = bits_in_limb
+        self.bound = bound_mpi(bound_val, self.bits_in_limb)
+        limbs = limbs_mpi(bound_val, self.bits_in_limb)
+        byte_len = limbs * self.bits_in_limb // 8
+        self.hex_digits = 2 * byte_len
+        if self.bits_in_limb == 32:
+            self.dependencies = ["MBEDTLS_HAVE_INT32"]
+        elif self.bits_in_limb == 64:
+            self.dependencies = ["MBEDTLS_HAVE_INT64"]
+        else:
+            raise ValueError("Invalid number of bits in limb!")
+        self.arg_a = self.arg_a.zfill(self.hex_digits)
+        self.arg_b = self.arg_b.zfill(self.hex_digits)
+
+    def pad_to_limbs(self, val) -> str:
+        return "{:x}".format(val).zfill(self.hex_digits)
+
+    @classmethod
+    def generate_function_tests(cls) -> Iterator[test_case.TestCase]:
+        for a_value, b_value in cls.get_value_pairs():
+            yield cls(a_value, b_value, 32).create_test_case()
+            yield cls(a_value, b_value, 64).create_test_case()
+
 
 # BEGIN MERGE SLOT 1
 

--- a/scripts/mbedtls_dev/bignum_common.py
+++ b/scripts/mbedtls_dev/bignum_common.py
@@ -20,6 +20,8 @@ import typing
 from abc import abstractmethod
 from typing import Iterator, List, Tuple, TypeVar
 
+from . import test_data_generation
+
 T = TypeVar('T') #pylint: disable=invalid-name
 
 def invmod(a: int, n: int) -> int:
@@ -67,8 +69,7 @@ def combination_pairs(values: List[T]) -> List[Tuple[T, T]]:
         list(itertools.combinations_with_replacement(values, 2))
     )
 
-
-class OperationCommon:
+class OperationCommon(test_data_generation.BaseTest):
     """Common features for bignum binary operations.
 
     This adds functionality common in binary operation tests.

--- a/scripts/mbedtls_dev/bignum_core.py
+++ b/scripts/mbedtls_dev/bignum_core.py
@@ -144,11 +144,6 @@ class BignumCoreOperation(BignumCoreTarget, bignum_common.OperationCommon,
             )
         return super().description()
 
-    @classmethod
-    def generate_function_tests(cls) -> Iterator[test_case.TestCase]:
-        for a_value, b_value in cls.get_value_pairs():
-            yield cls(a_value, b_value).create_test_case()
-
 
 class BignumCoreOperationArchSplit(BignumCoreOperation):
     #pylint: disable=abstract-method

--- a/scripts/mbedtls_dev/bignum_core.py
+++ b/scripts/mbedtls_dev/bignum_core.py
@@ -16,20 +16,19 @@
 
 import random
 
-from abc import ABCMeta
 from typing import Dict, Iterator, List, Tuple
 
 from . import test_case
 from . import test_data_generation
 from . import bignum_common
 
-class BignumCoreTarget(test_data_generation.BaseTarget, metaclass=ABCMeta):
-    #pylint: disable=abstract-method
+class BignumCoreTarget(test_data_generation.BaseTarget):
+    #pylint: disable=abstract-method, too-few-public-methods
     """Target for bignum core test case generation."""
     target_basename = 'test_suite_bignum_core.generated'
 
 
-class BignumCoreShiftR(BignumCoreTarget, metaclass=ABCMeta):
+class BignumCoreShiftR(BignumCoreTarget, test_data_generation.BaseTest):
     """Test cases for mbedtls_bignum_core_shift_r()."""
     count = 0
     test_function = "mpi_core_shift_r"
@@ -69,7 +68,7 @@ class BignumCoreShiftR(BignumCoreTarget, metaclass=ABCMeta):
             for count in counts:
                 yield cls(input_hex, descr, count).create_test_case()
 
-class BignumCoreCTLookup(BignumCoreTarget, metaclass=ABCMeta):
+class BignumCoreCTLookup(BignumCoreTarget, test_data_generation.BaseTest):
     """Test cases for mbedtls_mpi_core_ct_uint_table_lookup()."""
     test_function = "mpi_core_ct_uint_table_lookup"
     test_name = "Constant time MPI table lookup"
@@ -107,7 +106,8 @@ class BignumCoreCTLookup(BignumCoreTarget, metaclass=ABCMeta):
                 yield (cls(bitsize, bitsize_description, window_size)
                        .create_test_case())
 
-class BignumCoreOperation(bignum_common.OperationCommon, BignumCoreTarget, metaclass=ABCMeta):
+class BignumCoreOperation(BignumCoreTarget, bignum_common.OperationCommon,
+                          metaclass=ABCMeta):
     #pylint: disable=abstract-method
     """Common features for bignum core operations."""
     input_values = [
@@ -297,7 +297,7 @@ class BignumCoreMLA(BignumCoreOperation):
                 yield cur_op.create_test_case()
 
 
-class BignumCoreMontmul(BignumCoreTarget):
+class BignumCoreMontmul(BignumCoreTarget, test_data_generation.BaseTest):
     """Test cases for Montgomery multiplication."""
     count = 0
     test_function = "mpi_core_montmul"

--- a/scripts/mbedtls_dev/bignum_mod.py
+++ b/scripts/mbedtls_dev/bignum_mod.py
@@ -14,12 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from abc import ABCMeta
-
 from . import test_data_generation
 
-class BignumModTarget(test_data_generation.BaseTarget, metaclass=ABCMeta):
-    #pylint: disable=abstract-method
+class BignumModTarget(test_data_generation.BaseTarget):
+    #pylint: disable=abstract-method, too-few-public-methods
     """Target for bignum mod test case generation."""
     target_basename = 'test_suite_bignum_mod.generated'
 

--- a/scripts/mbedtls_dev/bignum_mod_raw.py
+++ b/scripts/mbedtls_dev/bignum_mod_raw.py
@@ -14,12 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from abc import ABCMeta
-
 from . import test_data_generation
 
-class BignumModRawTarget(test_data_generation.BaseTarget, metaclass=ABCMeta):
-    #pylint: disable=abstract-method
+class BignumModRawTarget(test_data_generation.BaseTarget):
+    #pylint: disable=abstract-method, too-few-public-methods
     """Target for bignum mod_raw test case generation."""
     target_basename = 'test_suite_bignum_mod_raw.generated'
 

--- a/scripts/mbedtls_dev/test_data_generation.py
+++ b/scripts/mbedtls_dev/test_data_generation.py
@@ -25,6 +25,7 @@ import argparse
 import os
 import posixpath
 import re
+import inspect
 
 from abc import ABCMeta, abstractmethod
 from typing import Callable, Dict, Iterable, Iterator, List, Type, TypeVar
@@ -35,12 +36,8 @@ from . import test_case
 T = TypeVar('T') #pylint: disable=invalid-name
 
 
-class BaseTarget(metaclass=ABCMeta):
-    """Base target for test case generation.
-
-    Child classes of this class represent an output file, and can be referred
-    to as file targets. These indicate where test cases will be written to for
-    all subclasses of the file target, which is set by `target_basename`.
+class BaseTest(metaclass=ABCMeta):
+    """Base class for test case generation.
 
     Attributes:
         count: Counter for test cases from this class.
@@ -48,8 +45,6 @@ class BaseTarget(metaclass=ABCMeta):
             automatically generated using the class, or manually set.
         dependencies: A list of dependencies required for the test case.
         show_test_count: Toggle for inclusion of `count` in the test description.
-        target_basename: Basename of file to write generated tests to. This
-            should be specified in a child class of BaseTarget.
         test_function: Test function which the class generates cases for.
         test_name: A common name or description of the test function. This can
             be `test_function`, a clearer equivalent, or a short summary of the
@@ -59,7 +54,6 @@ class BaseTarget(metaclass=ABCMeta):
     case_description = ""
     dependencies = [] # type: List[str]
     show_test_count = True
-    target_basename = ""
     test_function = ""
     test_name = ""
 
@@ -121,6 +115,20 @@ class BaseTarget(metaclass=ABCMeta):
         """
         raise NotImplementedError
 
+
+class BaseTarget:
+    """Base target for test case generation.
+
+    Child classes of this class represent an output file, and can be referred
+    to as file targets. These indicate where test cases will be written to for
+    all subclasses of the file target, which is set by `target_basename`.
+
+    Attributes:
+        target_basename: Basename of file to write generated tests to. This
+            should be specified in a child class of BaseTarget.
+    """
+    target_basename = ""
+
     @classmethod
     def generate_tests(cls) -> Iterator[test_case.TestCase]:
         """Generate test cases for the class and its subclasses.
@@ -132,7 +140,7 @@ class BaseTarget(metaclass=ABCMeta):
         yield from `generate_tests()` in each. Calling this method on a class X
         will yield test cases from all classes derived from X.
         """
-        if cls.test_function:
+        if issubclass(cls, BaseTest) and not inspect.isabstract(cls):
             yield from cls.generate_function_tests()
         for subclass in sorted(cls.__subclasses__(), key=lambda c: c.__name__):
             yield from subclass.generate_tests()

--- a/scripts/mbedtls_dev/test_data_generation.py
+++ b/scripts/mbedtls_dev/test_data_generation.py
@@ -117,6 +117,7 @@ class BaseTest(metaclass=ABCMeta):
 
 
 class BaseTarget:
+    #pylint: disable=too-few-public-methods
     """Base target for test case generation.
 
     Child classes of this class represent an output file, and can be referred
@@ -141,6 +142,7 @@ class BaseTarget:
         will yield test cases from all classes derived from X.
         """
         if issubclass(cls, BaseTest) and not inspect.isabstract(cls):
+            #pylint: disable=no-member
             yield from cls.generate_function_tests()
         for subclass in sorted(cls.__subclasses__(), key=lambda c: c.__name__):
             yield from subclass.generate_tests()

--- a/tests/scripts/generate_bignum_tests.py
+++ b/tests/scripts/generate_bignum_tests.py
@@ -121,11 +121,6 @@ class BignumOperation(bignum_common.OperationCommon, BignumTarget,
             tmp = "large " + tmp
         return tmp
 
-    @classmethod
-    def generate_function_tests(cls) -> Iterator[test_case.TestCase]:
-        for a_value, b_value in cls.get_value_pairs():
-            yield cls(a_value, b_value).create_test_case()
-
 
 class BignumCmp(BignumOperation):
     """Test cases for bignum value comparison."""

--- a/tests/scripts/generate_bignum_tests.py
+++ b/tests/scripts/generate_bignum_tests.py
@@ -57,7 +57,7 @@ of BaseTarget in test_data_generation.py.
 import sys
 
 from abc import ABCMeta
-from typing import Iterator, List
+from typing import List
 
 import scripts_path # pylint: disable=unused-import
 from mbedtls_dev import test_case
@@ -69,6 +69,7 @@ from mbedtls_dev import bignum_common
 from mbedtls_dev import bignum_core # pylint: disable=unused-import
 
 class BignumTarget(test_data_generation.BaseTarget):
+    #pylint: disable=too-few-public-methods
     """Target for bignum (legacy) test case generation."""
     target_basename = 'test_suite_bignum.generated'
 

--- a/tests/scripts/generate_bignum_tests.py
+++ b/tests/scripts/generate_bignum_tests.py
@@ -68,13 +68,13 @@ from mbedtls_dev import bignum_common
 # the framework
 from mbedtls_dev import bignum_core # pylint: disable=unused-import
 
-class BignumTarget(test_data_generation.BaseTarget, metaclass=ABCMeta):
-    #pylint: disable=abstract-method
+class BignumTarget(test_data_generation.BaseTarget):
     """Target for bignum (legacy) test case generation."""
     target_basename = 'test_suite_bignum.generated'
 
 
-class BignumOperation(bignum_common.OperationCommon, BignumTarget, metaclass=ABCMeta):
+class BignumOperation(bignum_common.OperationCommon, BignumTarget,
+                      metaclass=ABCMeta):
     #pylint: disable=abstract-method
     """Common features for bignum operations in legacy tests."""
     input_values = [


### PR DESCRIPTION
## Description

The class BaseTarget served two purposes:
    
- track test cases and target files for generation
- provide an abstract base class for individual test groups
    
Splitting these allows decoupling these two and to have further common superclasses across targets.

## Gatekeeper checklist

- [ ] **changelog** not required
- [ ] **backport** not required
- [ ] **tests** not required
