### PR TITLE
Bignum: Add BignumModRaw Operation base classes

### DIFF
--- a/scripts/mbedtls_dev/bignum_mod_raw.py
+++ b/scripts/mbedtls_dev/bignum_mod_raw.py
@@ -15,8 +15,11 @@
 # limitations under the License.
 
 from abc import ABCMeta
+from typing import Dict, Iterator, List
 
+from . import test_case
 from . import test_data_generation
+from . import bignum_common
 
 class BignumModRawTarget(test_data_generation.BaseTarget, metaclass=ABCMeta):
     #pylint: disable=abstract-method
@@ -48,7 +51,42 @@ class BignumModRawTarget(test_data_generation.BaseTarget, metaclass=ABCMeta):
 # END MERGE SLOT 6
 
 # BEGIN MERGE SLOT 7
+class BignumModRawOperation(bignum_common.OperationCommon, BignumModRawTarget, metaclass=ABCMeta):
+    #pylint: disable=abstract-method
+    pass
 
+class BignumModRawOperationArchSplit(BignumModRawOperation):
+    #pylint: disable=abstract-method
+    """Common features for bignum core operations where the result depends on
+    the limb size."""
+
+    def __init__(self, val_a: str, val_b: str, bits_in_limb: int) -> None:
+        super().__init__(val_a, val_b)
+        bound_val = max(self.int_a, self.int_b)
+        self.bits_in_limb = bits_in_limb
+        self.bound = bignum_common.bound_mpi(bound_val, self.bits_in_limb)
+        limbs = bignum_common.limbs_mpi(bound_val, self.bits_in_limb)
+        byte_len = limbs * self.bits_in_limb // 8
+        self.hex_digits = 2 * byte_len
+        if self.bits_in_limb == 32:
+            self.dependencies = ["MBEDTLS_HAVE_INT32"]
+        elif self.bits_in_limb == 64:
+            self.dependencies = ["MBEDTLS_HAVE_INT64"]
+        else:
+            raise ValueError("Invalid number of bits in limb!")
+        self.arg_a = self.arg_a.zfill(self.hex_digits)
+        self.arg_b = self.arg_b.zfill(self.hex_digits)
+        self.arg_a_int = bignum_common.hex_to_int(self.arg_a)
+        self.arg_b_int = bignum_common.hex_to_int(self.arg_b)
+
+    def pad_to_limbs(self, val) -> str:
+        return "{:x}".format(val).zfill(self.hex_digits)
+
+    @classmethod
+    def generate_function_tests(cls) -> Iterator[test_case.TestCase]:
+        for a_value, b_value in cls.get_value_pairs():
+            yield cls(a_value, b_value, 32).create_test_case()
+            yield cls(a_value, b_value, 64).create_test_case()
 # END MERGE SLOT 7
 
 # BEGIN MERGE SLOT 8

--- a/scripts/mbedtls_dev/bignum_mod_raw.py
+++ b/scripts/mbedtls_dev/bignum_mod_raw.py
@@ -26,31 +26,6 @@ class BignumModRawTarget(test_data_generation.BaseTarget, metaclass=ABCMeta):
     """Target for bignum mod_raw test case generation."""
     target_basename = 'test_suite_bignum_mod_raw.generated'
 
-# BEGIN MERGE SLOT 1
-
-# END MERGE SLOT 1
-
-# BEGIN MERGE SLOT 2
-
-# END MERGE SLOT 2
-
-# BEGIN MERGE SLOT 3
-
-# END MERGE SLOT 3
-
-# BEGIN MERGE SLOT 4
-
-# END MERGE SLOT 4
-
-# BEGIN MERGE SLOT 5
-
-# END MERGE SLOT 5
-
-# BEGIN MERGE SLOT 6
-
-# END MERGE SLOT 6
-
-# BEGIN MERGE SLOT 7
 class BignumModRawOperation(bignum_common.OperationCommon, BignumModRawTarget, metaclass=ABCMeta):
     #pylint: disable=abstract-method
     """Target for bignum mod_raw test case generation."""
@@ -99,7 +74,7 @@ class BignumModRawOperation(bignum_common.OperationCommon, BignumModRawTarget, m
         return bignum_common.invmod(self.r, self.int_n)
 
     @property
-    def r_sqrt(self) -> int: # pylint: disable=invalid-name
+    def r2(self) -> int: # pylint: disable=invalid-name
         return pow(self.r, 2)
 
 class BignumModRawOperationArchSplit(BignumModRawOperation):
@@ -122,6 +97,32 @@ class BignumModRawOperationArchSplit(BignumModRawOperation):
         for a_value, b_value in cls.get_value_pairs():
             for bil in cls.limb_sizes:
                 yield cls(a_value, b_value, bits_in_limb=bil).create_test_case()
+# BEGIN MERGE SLOT 1
+
+# END MERGE SLOT 1
+
+# BEGIN MERGE SLOT 2
+
+# END MERGE SLOT 2
+
+# BEGIN MERGE SLOT 3
+
+# END MERGE SLOT 3
+
+# BEGIN MERGE SLOT 4
+
+# END MERGE SLOT 4
+
+# BEGIN MERGE SLOT 5
+
+# END MERGE SLOT 5
+
+# BEGIN MERGE SLOT 6
+
+# END MERGE SLOT 6
+
+# BEGIN MERGE SLOT 7
+
 # END MERGE SLOT 7
 
 # BEGIN MERGE SLOT 8

--- a/scripts/mbedtls_dev/bignum_mod_raw.py
+++ b/scripts/mbedtls_dev/bignum_mod_raw.py
@@ -53,40 +53,75 @@ class BignumModRawTarget(test_data_generation.BaseTarget, metaclass=ABCMeta):
 # BEGIN MERGE SLOT 7
 class BignumModRawOperation(bignum_common.OperationCommon, BignumModRawTarget, metaclass=ABCMeta):
     #pylint: disable=abstract-method
-    pass
+    """Target for bignum mod_raw test case generation."""
+
+    def __init__(self, val_n: str, val_a: str, val_b: str = "0", bits_in_limb: int = 64) -> None:
+        super().__init__(val_a=val_a, val_b=val_b)
+        self.val_n = val_n
+        self.bits_in_limb = bits_in_limb
+
+    @property
+    def int_n(self) -> int:
+        return bignum_common.hex_to_int(self.val_n)
+
+    @property
+    def boundary(self) -> int:
+        data_in = [self.int_a, self.int_b, self.int_n]
+        return max([n for n in data_in if n is not None])
+
+    @property
+    def limbs(self) -> int:
+        return bignum_common.limbs_mpi(self.boundary, self.bits_in_limb)
+
+    @property
+    def hex_digits(self) -> int:
+        return 2 * (self.limbs * self.bits_in_limb // 8)
+
+    @property
+    def hex_n(self) -> str:
+        return "{:x}".format(self.int_n).zfill(self.hex_digits)
+
+    @property
+    def hex_a(self) -> str:
+        return "{:x}".format(self.int_a).zfill(self.hex_digits)
+
+    @property
+    def hex_b(self) -> str:
+        return "{:x}".format(self.int_b).zfill(self.hex_digits)
+
+    @property
+    def r(self) -> int: # pylint: disable=invalid-name
+        l = bignum_common.limbs_mpi(self.int_n, self.bits_in_limb)
+        return bignum_common.bound_mpi_limbs(l, self.bits_in_limb)
+
+    @property
+    def r_inv(self) -> int:
+        return bignum_common.invmod(self.r, self.int_n)
+
+    @property
+    def r_sqrt(self) -> int: # pylint: disable=invalid-name
+        return pow(self.r, 2)
 
 class BignumModRawOperationArchSplit(BignumModRawOperation):
     #pylint: disable=abstract-method
-    """Common features for bignum core operations where the result depends on
+    """Common features for bignum mod raw operations where the result depends on
     the limb size."""
 
-    def __init__(self, val_a: str, val_b: str, bits_in_limb: int) -> None:
-        super().__init__(val_a, val_b)
-        bound_val = max(self.int_a, self.int_b)
-        self.bits_in_limb = bits_in_limb
-        self.bound = bignum_common.bound_mpi(bound_val, self.bits_in_limb)
-        limbs = bignum_common.limbs_mpi(bound_val, self.bits_in_limb)
-        byte_len = limbs * self.bits_in_limb // 8
-        self.hex_digits = 2 * byte_len
-        if self.bits_in_limb == 32:
-            self.dependencies = ["MBEDTLS_HAVE_INT32"]
-        elif self.bits_in_limb == 64:
-            self.dependencies = ["MBEDTLS_HAVE_INT64"]
-        else:
-            raise ValueError("Invalid number of bits in limb!")
-        self.arg_a = self.arg_a.zfill(self.hex_digits)
-        self.arg_b = self.arg_b.zfill(self.hex_digits)
-        self.arg_a_int = bignum_common.hex_to_int(self.arg_a)
-        self.arg_b_int = bignum_common.hex_to_int(self.arg_b)
+    limb_sizes = [32, 64] # type: List[int]
 
-    def pad_to_limbs(self, val) -> str:
-        return "{:x}".format(val).zfill(self.hex_digits)
+    def __init__(self, val_n: str, val_a: str, val_b: str = "0", bits_in_limb: int = 64) -> None:
+        super().__init__(val_n=val_n, val_a=val_a, val_b=val_b, bits_in_limb=bits_in_limb)
+
+        if bits_in_limb not in self.limb_sizes:
+            raise ValueError("Invalid number of bits in limb!")
+
+        self.dependencies = ["MBEDTLS_HAVE_INT{:d}".format(bits_in_limb)]
 
     @classmethod
     def generate_function_tests(cls) -> Iterator[test_case.TestCase]:
         for a_value, b_value in cls.get_value_pairs():
-            yield cls(a_value, b_value, 32).create_test_case()
-            yield cls(a_value, b_value, 64).create_test_case()
+            for bil in cls.limb_sizes:
+                yield cls(a_value, b_value, bits_in_limb=bil).create_test_case()
 # END MERGE SLOT 7
 
 # BEGIN MERGE SLOT 8

--- a/tests/scripts/generate_bignum_tests.py
+++ b/tests/scripts/generate_bignum_tests.py
@@ -66,7 +66,7 @@ from mbedtls_dev import bignum_common
 # Import modules containing additional test classes
 # Test function classes in these modules will be registered by
 # the framework
-from mbedtls_dev import bignum_core # pylint: disable=unused-import
+from mbedtls_dev import bignum_core, bignum_mod_raw # pylint: disable=unused-import
 
 class BignumTarget(test_data_generation.BaseTarget, metaclass=ABCMeta):
     #pylint: disable=abstract-method


### PR DESCRIPTION
## Description

This pr is implementing some required base classes ( **BignumModRawOperation**, **BignumModRawOperationArchSplit** )for `bignum_mod_raw.py module`.  

The class structure is configured in order to make is simpler for test classes to inherit from it.

* Adds new optional parameters, which dynamically calculate or convert members if requested.
* Adjusts the expected input variable pair from `(val_a, val_b)` to `(val_n, val_a, val_b(optional)`)
* Added the optional `bits_to_limbs` argument which allows generation of 32 and 64 bit tests cases.
* Added zeropadded string hex representations of all input arguments.

## Gatekeeper checklist

- [x] **changelog** not needed
- [x] **backport** not required
- [x] **tests** not required


## Notes for the submitter

Please refer to the [contributing guidelines](../CONTRIBUTING.md), especially the
checklist for PR contributors.

