### PR TITLE
Backport 2.28: Fix negative zero from bignum add/subtract

### DIFF
--- a/ChangeLog.d/negative-zero-from-add.txt
+++ b/ChangeLog.d/negative-zero-from-add.txt
@@ -1,0 +1,6 @@
+Bugfix
+   * In the bignum module, operations of the form (-A) - (+A) or (-A) - (-A)
+     with A > 0 created an unintended representation of the value 0 which was
+     not processed correctly by some bignum operations. Fix this. This had no
+     consequence on cryptography code, but might affect applications that call
+     bignum directly and use negative numbers.

--- a/include/mbedtls/bignum.h
+++ b/include/mbedtls/bignum.h
@@ -191,9 +191,27 @@ extern "C" {
  */
 typedef struct mbedtls_mpi
 {
-    int s;              /*!<  Sign: -1 if the mpi is negative, 1 otherwise */
-    size_t n;           /*!<  total # of limbs  */
-    mbedtls_mpi_uint *p;          /*!<  pointer to limbs  */
+    /** Sign: -1 if the mpi is negative, 1 otherwise.
+     *
+     * The number 0 must be represented with `s = +1`. Although many library
+     * functions treat all-limbs-zero as equivalent to a valid representation
+     * of 0 regardless of the sign bit, there are exceptions, so bignum
+     * functions and external callers must always set \c s to +1 for the
+     * number zero.
+     *
+     * Note that this implies that calloc() or `... = {0}` does not create
+     * a valid MPI representation. You must call mbedtls_mpi_init().
+     */
+    int s;
+
+    /** Total number of limbs in \c p.  */
+    size_t n;
+
+    /** Pointer to limbs.
+     *
+     * This may be \c NULL if \c n is 0.
+     */
+    mbedtls_mpi_uint *p;
 }
 mbedtls_mpi;
 

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -1249,10 +1249,12 @@ cleanup:
     return( ret );
 }
 
-/*
- * Signed addition: X = A + B
+/* Common function for signed addition and subtraction.
+ * Calculate A + B * flip_B where flip_B is 1 or -1.
  */
-int mbedtls_mpi_add_mpi( mbedtls_mpi *X, const mbedtls_mpi *A, const mbedtls_mpi *B )
+static int add_sub_mpi( mbedtls_mpi *X,
+                        const mbedtls_mpi *A, const mbedtls_mpi *B,
+                        int flip_B )
 {
     int ret, s;
     MPI_VALIDATE_RET( X != NULL );
@@ -1260,7 +1262,7 @@ int mbedtls_mpi_add_mpi( mbedtls_mpi *X, const mbedtls_mpi *A, const mbedtls_mpi
     MPI_VALIDATE_RET( B != NULL );
 
     s = A->s;
-    if( A->s * B->s < 0 )
+    if( A->s * B->s * flip_B < 0 )
     {
         if( mbedtls_mpi_cmp_abs( A, B ) >= 0 )
         {
@@ -1285,38 +1287,19 @@ cleanup:
 }
 
 /*
+ * Signed addition: X = A + B
+ */
+int mbedtls_mpi_add_mpi( mbedtls_mpi *X, const mbedtls_mpi *A, const mbedtls_mpi *B )
+{
+    return( add_sub_mpi( X, A, B, 1 ) );
+}
+
+/*
  * Signed subtraction: X = A - B
  */
 int mbedtls_mpi_sub_mpi( mbedtls_mpi *X, const mbedtls_mpi *A, const mbedtls_mpi *B )
 {
-    int ret, s;
-    MPI_VALIDATE_RET( X != NULL );
-    MPI_VALIDATE_RET( A != NULL );
-    MPI_VALIDATE_RET( B != NULL );
-
-    s = A->s;
-    if( A->s * B->s > 0 )
-    {
-        if( mbedtls_mpi_cmp_abs( A, B ) >= 0 )
-        {
-            MBEDTLS_MPI_CHK( mbedtls_mpi_sub_abs( X, A, B ) );
-            X->s =  s;
-        }
-        else
-        {
-            MBEDTLS_MPI_CHK( mbedtls_mpi_sub_abs( X, B, A ) );
-            X->s = -s;
-        }
-    }
-    else
-    {
-        MBEDTLS_MPI_CHK( mbedtls_mpi_add_abs( X, A, B ) );
-        X->s = s;
-    }
-
-cleanup:
-
-    return( ret );
+    return( add_sub_mpi( X, A, B, -1 ) );
 }
 
 /*

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -1264,14 +1264,19 @@ static int add_sub_mpi( mbedtls_mpi *X,
     s = A->s;
     if( A->s * B->s * flip_B < 0 )
     {
-        if( mbedtls_mpi_cmp_abs( A, B ) >= 0 )
+        int cmp = mbedtls_mpi_cmp_abs( A, B );
+        if( cmp >= 0 )
         {
             MBEDTLS_MPI_CHK( mbedtls_mpi_sub_abs( X, A, B ) );
-            X->s =  s;
+            /* If |A| = |B|, the result is 0 and we must set the sign bit
+             * to +1 regardless of which of A or B was negative. Otherwise,
+             * since |A| > |B|, the sign is the sign of A. */
+            X->s = cmp == 0 ? 1 : s;
         }
         else
         {
             MBEDTLS_MPI_CHK( mbedtls_mpi_sub_abs( X, B, A ) );
+            /* Since |A| < |B|, the sign is the opposite of A. */
             X->s = -s;
         }
     }

--- a/tests/include/test/helpers.h
+++ b/tests/include/test/helpers.h
@@ -360,13 +360,19 @@ void mbedtls_test_err_add_check( int high, int low,
 #if defined(MBEDTLS_BIGNUM_C)
 /** Read an MPI from a hexadecimal string.
  *
- * Like mbedtls_mpi_read_string(), but size the resulting bignum based
- * on the number of digits in the string. In particular, construct a
- * bignum with 0 limbs for an empty string, and a bignum with leading 0
- * limbs if the string has sufficiently many leading 0 digits.
+ * Like mbedtls_mpi_read_string(), but with tighter guarantees around
+ * edge cases.
  *
- * This is important so that the "0 (null)" and "0 (1 limb)" and
- * "leading zeros" test cases do what they claim.
+ * - This function guarantees that if \p s begins with '-' then the sign
+ *   bit of the result will be negative, even if the value is 0.
+ *   When this function encounters such a "negative 0", it
+ *   increments #mbedtls_test_read_mpi.
+ * - The size of the result is exactly the minimum number of limbs needed
+ *   to fit the digits in the input. In particular, this function constructs
+ *   a bignum with 0 limbs for an empty string, and a bignum with leading 0
+ *   limbs if the string has sufficiently many leading 0 digits.
+ *   This is important so that the "0 (null)" and "0 (1 limb)" and
+ *   "leading zeros" test cases do what they claim.
  *
  * \param[out] X        The MPI object to populate. It must be initialized.
  * \param[in] s         The null-terminated hexadecimal string to read from.
@@ -374,6 +380,14 @@ void mbedtls_test_err_add_check( int high, int low,
  * \return \c 0 on success, an \c MBEDTLS_ERR_MPI_xxx error code otherwise.
  */
 int mbedtls_test_read_mpi( mbedtls_mpi *X, const char *s );
+
+/** Nonzero if the current test case had an input parsed with
+ * mbedtls_test_read_mpi() that is a negative 0 (`"-"`, `"-0"`, `"-00"`, etc.,
+ * constructing a result with the sign bit set to -1 and the value being
+ * all-limbs-0, which is not a valid representation in #mbedtls_mpi but is
+ * tested for robustness).
+ */
+extern unsigned mbedtls_test_case_uses_negative_0;
 #endif /* MBEDTLS_BIGNUM_C */
 
 #endif /* TEST_HELPERS_H */

--- a/tests/include/test/helpers.h
+++ b/tests/include/test/helpers.h
@@ -366,7 +366,7 @@ void mbedtls_test_err_add_check( int high, int low,
  * - This function guarantees that if \p s begins with '-' then the sign
  *   bit of the result will be negative, even if the value is 0.
  *   When this function encounters such a "negative 0", it
- *   increments #mbedtls_test_read_mpi.
+ *   increments #mbedtls_test_case_uses_negative_0.
  * - The size of the result is exactly the minimum number of limbs needed
  *   to fit the digits in the input. In particular, this function constructs
  *   a bignum with 0 limbs for an empty string, and a bignum with leading 0

--- a/tests/scripts/generate_bignum_tests.py
+++ b/tests/scripts/generate_bignum_tests.py
@@ -55,7 +55,6 @@ of BaseTarget in test_data_generation.py.
 # limitations under the License.
 
 import sys
-import typing
 
 from abc import ABCMeta, abstractmethod
 from typing import Iterator, List, Tuple, TypeVar
@@ -71,7 +70,7 @@ def hex_to_int(val: str) -> int:
 
     This is a superset of what is accepted by mbedtls_test_read_mpi_core().
     """
-    if val == '' or val == '-':
+    if val in ['', '-']:
         return 0
     return int(val, 16)
 
@@ -121,6 +120,7 @@ class BignumOperation(BignumTarget, metaclass=ABCMeta):
         return [quote_str(self.arg_a), quote_str(self.arg_b), self.result()]
 
     def description_suffix(self) -> str:
+        #pylint: disable=no-self-use # derived classes need self
         """Text to add at the end of the test case description."""
         return ""
 

--- a/tests/scripts/generate_bignum_tests.py
+++ b/tests/scripts/generate_bignum_tests.py
@@ -67,7 +67,13 @@ from mbedtls_dev import test_data_generation
 T = TypeVar('T') #pylint: disable=invalid-name
 
 def hex_to_int(val: str) -> int:
-    return int(val, 16) if val else 0
+    """Implement the syntax accepted by mbedtls_test_read_mpi().
+
+    This is a superset of what is accepted by mbedtls_test_read_mpi_core().
+    """
+    if val == '' or val == '-':
+        return 0
+    return int(val, 16)
 
 def quote_str(val) -> str:
     return "\"{}\"".format(val)
@@ -98,7 +104,8 @@ class BignumOperation(BignumTarget, metaclass=ABCMeta):
     """
     symbol = ""
     input_values = [
-        "", "0", "7b", "-7b",
+        "", "0", "-", "-0",
+        "7b", "-7b",
         "0000000000000000123", "-0000000000000000123",
         "1230000000000000000", "-1230000000000000000"
     ] # type: List[str]
@@ -113,6 +120,10 @@ class BignumOperation(BignumTarget, metaclass=ABCMeta):
     def arguments(self) -> List[str]:
         return [quote_str(self.arg_a), quote_str(self.arg_b), self.result()]
 
+    def description_suffix(self) -> str:
+        """Text to add at the end of the test case description."""
+        return ""
+
     def description(self) -> str:
         """Generate a description for the test case.
 
@@ -126,6 +137,9 @@ class BignumOperation(BignumTarget, metaclass=ABCMeta):
                 self.symbol,
                 self.value_description(self.arg_b)
             )
+            description_suffix = self.description_suffix()
+            if description_suffix:
+                self.case_description += " " + description_suffix
         return super().description()
 
     @abstractmethod
@@ -146,6 +160,8 @@ class BignumOperation(BignumTarget, metaclass=ABCMeta):
         """
         if val == "":
             return "0 (null)"
+        if val == "-":
+            return "negative 0 (null)"
         if val == "0":
             return "0 (1 limb)"
 
@@ -221,8 +237,21 @@ class BignumAdd(BignumOperation):
         ]
     )
 
+    def __init__(self, val_a: str, val_b: str) -> None:
+        super().__init__(val_a, val_b)
+        self._result = self.int_a + self.int_b
+
+    def description_suffix(self) -> str:
+        if (self.int_a >= 0 and self.int_b >= 0):
+            return "" # obviously positive result or 0
+        if (self.int_a <= 0 and self.int_b <= 0):
+            return "" # obviously negative result or 0
+        # The sign of the result is not obvious, so indicate it
+        return ", result{}0".format('>' if self._result > 0 else
+                                    '<' if self._result < 0 else '=')
+
     def result(self) -> str:
-        return quote_str("{:x}".format(self.int_a + self.int_b))
+        return quote_str("{:x}".format(self._result))
 
 if __name__ == '__main__':
     # Use the section of the docstring relevant to the CLI as description

--- a/tests/scripts/generate_bignum_tests.py
+++ b/tests/scripts/generate_bignum_tests.py
@@ -54,7 +54,6 @@ of BaseTarget in test_data_generation.py.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import itertools
 import sys
 import typing
 
@@ -75,13 +74,7 @@ def quote_str(val) -> str:
 
 def combination_pairs(values: List[T]) -> List[Tuple[T, T]]:
     """Return all pair combinations from input values."""
-    # The return value is cast, as older versions of mypy are unable to derive
-    # the specific type returned by itertools.combinations_with_replacement.
-    return typing.cast(
-        List[Tuple[T, T]],
-        list(itertools.combinations_with_replacement(values, 2))
-    )
-
+    return [(x, y) for x in values for y in values]
 
 class BignumTarget(test_data_generation.BaseTarget, metaclass=ABCMeta):
     #pylint: disable=abstract-method

--- a/tests/src/helpers.c
+++ b/tests/src/helpers.c
@@ -107,6 +107,10 @@ void mbedtls_test_set_step( unsigned long step )
     mbedtls_test_info.step = step;
 }
 
+#if defined(MBEDTLS_BIGNUM_C)
+unsigned mbedtls_test_case_uses_negative_0 = 0;
+#endif
+
 void mbedtls_test_info_reset( void )
 {
     mbedtls_test_info.result = MBEDTLS_TEST_RESULT_SUCCESS;
@@ -116,6 +120,9 @@ void mbedtls_test_info_reset( void )
     mbedtls_test_info.filename = 0;
     memset( mbedtls_test_info.line1, 0, sizeof( mbedtls_test_info.line1 ) );
     memset( mbedtls_test_info.line2, 0, sizeof( mbedtls_test_info.line2 ) );
+#if defined(MBEDTLS_BIGNUM_C)
+    mbedtls_test_case_uses_negative_0 = 0;
+#endif
 }
 
 int mbedtls_test_equal( const char *test, int line_no, const char* filename,
@@ -426,6 +433,15 @@ void mbedtls_test_err_add_check( int high, int low,
 #if defined(MBEDTLS_BIGNUM_C)
 int mbedtls_test_read_mpi( mbedtls_mpi *X, const char *s )
 {
+    int negative = 0;
+    /* Always set the sign bit to -1 if the input has a minus sign, even for 0.
+     * This creates an invalid representation, which mbedtls_mpi_read_string()
+     * avoids but we want to be able to create that in test data. */
+    if( s[0] == '-' )
+    {
+        ++s;
+        negative = 1;
+    }
     /* mbedtls_mpi_read_string() currently retains leading zeros.
      * It always allocates at least one limb for the value 0. */
     if( s[0] == 0 )
@@ -433,7 +449,15 @@ int mbedtls_test_read_mpi( mbedtls_mpi *X, const char *s )
         mbedtls_mpi_free( X );
         return( 0 );
     }
-    else
-        return( mbedtls_mpi_read_string( X, 16, s ) );
+    int ret = mbedtls_mpi_read_string( X, 16, s );
+    if( ret != 0 )
+        return( ret );
+    if( negative )
+    {
+        if( mbedtls_mpi_cmp_int( X, 0 ) == 0 )
+            ++mbedtls_test_case_uses_negative_0;
+        X->s = -1;
+    }
+    return( 0 );
 }
 #endif

--- a/tests/suites/test_suite_bignum.function
+++ b/tests/suites/test_suite_bignum.function
@@ -11,10 +11,21 @@
  * constructing the value. */
 static int sign_is_valid( const mbedtls_mpi *X )
 {
+    /* Only +1 and -1 are valid sign bits, not e.g. 0 */
     if( X->s != 1 && X->s != -1 )
-        return( 0 ); // invalid sign bit, e.g. 0
-    if( mbedtls_mpi_bitlen( X ) == 0 && X->s != 1 )
-        return( 0 ); // negative zero
+        return( 0 );
+
+    /* The value 0 must be represented with the sign +1. A "negative zero"
+     * with s=-1 is an invalid representation. Forbid that. As an exception,
+     * we sometimes test the robustness of library functions when given
+     * a negative zero input. If a test case has a negative zero as input,
+     * we don't mind if the function has a negative zero output. */
+    if( ! mbedtls_test_case_uses_negative_0 &&
+        mbedtls_mpi_bitlen( X ) == 0 && X->s != 1 )
+    {
+        return( 0 );
+    }
+
     return( 1 );
 }
 

--- a/tests/suites/test_suite_bignum.generated.data
+++ b/tests/suites/test_suite_bignum.generated.data
@@ -24,118 +24,220 @@ mbedtls_mpi_add_mpi:"":"1230000000000000000":"1230000000000000000"
 MPI add #8 0 (null) + large negative
 mbedtls_mpi_add_mpi:"":"-1230000000000000000":"-1230000000000000000"
 
-MPI add #9 0 (1 limb) + 0 (1 limb)
+MPI add #9 0 (1 limb) + 0 (null)
+mbedtls_mpi_add_mpi:"0":"":"0"
+
+MPI add #10 0 (1 limb) + 0 (1 limb)
 mbedtls_mpi_add_mpi:"0":"0":"0"
 
-MPI add #10 0 (1 limb) + positive
+MPI add #11 0 (1 limb) + positive
 mbedtls_mpi_add_mpi:"0":"7b":"7b"
 
-MPI add #11 0 (1 limb) + negative
+MPI add #12 0 (1 limb) + negative
 mbedtls_mpi_add_mpi:"0":"-7b":"-7b"
 
-MPI add #12 0 (1 limb) + positive with leading zero limb
+MPI add #13 0 (1 limb) + positive with leading zero limb
 mbedtls_mpi_add_mpi:"0":"0000000000000000123":"123"
 
-MPI add #13 0 (1 limb) + negative with leading zero limb
+MPI add #14 0 (1 limb) + negative with leading zero limb
 mbedtls_mpi_add_mpi:"0":"-0000000000000000123":"-123"
 
-MPI add #14 0 (1 limb) + large positive
+MPI add #15 0 (1 limb) + large positive
 mbedtls_mpi_add_mpi:"0":"1230000000000000000":"1230000000000000000"
 
-MPI add #15 0 (1 limb) + large negative
+MPI add #16 0 (1 limb) + large negative
 mbedtls_mpi_add_mpi:"0":"-1230000000000000000":"-1230000000000000000"
 
-MPI add #16 positive + positive
+MPI add #17 positive + 0 (null)
+mbedtls_mpi_add_mpi:"7b":"":"7b"
+
+MPI add #18 positive + 0 (1 limb)
+mbedtls_mpi_add_mpi:"7b":"0":"7b"
+
+MPI add #19 positive + positive
 mbedtls_mpi_add_mpi:"7b":"7b":"f6"
 
-MPI add #17 positive + negative
+MPI add #20 positive + negative
 mbedtls_mpi_add_mpi:"7b":"-7b":"0"
 
-MPI add #18 positive + positive with leading zero limb
+MPI add #21 positive + positive with leading zero limb
 mbedtls_mpi_add_mpi:"7b":"0000000000000000123":"19e"
 
-MPI add #19 positive + negative with leading zero limb
+MPI add #22 positive + negative with leading zero limb
 mbedtls_mpi_add_mpi:"7b":"-0000000000000000123":"-a8"
 
-MPI add #20 positive + large positive
+MPI add #23 positive + large positive
 mbedtls_mpi_add_mpi:"7b":"1230000000000000000":"123000000000000007b"
 
-MPI add #21 positive + large negative
+MPI add #24 positive + large negative
 mbedtls_mpi_add_mpi:"7b":"-1230000000000000000":"-122ffffffffffffff85"
 
-MPI add #22 negative + negative
+MPI add #25 negative + 0 (null)
+mbedtls_mpi_add_mpi:"-7b":"":"-7b"
+
+MPI add #26 negative + 0 (1 limb)
+mbedtls_mpi_add_mpi:"-7b":"0":"-7b"
+
+MPI add #27 negative + positive
+mbedtls_mpi_add_mpi:"-7b":"7b":"0"
+
+MPI add #28 negative + negative
 mbedtls_mpi_add_mpi:"-7b":"-7b":"-f6"
 
-MPI add #23 negative + positive with leading zero limb
+MPI add #29 negative + positive with leading zero limb
 mbedtls_mpi_add_mpi:"-7b":"0000000000000000123":"a8"
 
-MPI add #24 negative + negative with leading zero limb
+MPI add #30 negative + negative with leading zero limb
 mbedtls_mpi_add_mpi:"-7b":"-0000000000000000123":"-19e"
 
-MPI add #25 negative + large positive
+MPI add #31 negative + large positive
 mbedtls_mpi_add_mpi:"-7b":"1230000000000000000":"122ffffffffffffff85"
 
-MPI add #26 negative + large negative
+MPI add #32 negative + large negative
 mbedtls_mpi_add_mpi:"-7b":"-1230000000000000000":"-123000000000000007b"
 
-MPI add #27 positive with leading zero limb + positive with leading zero limb
+MPI add #33 positive with leading zero limb + 0 (null)
+mbedtls_mpi_add_mpi:"0000000000000000123":"":"123"
+
+MPI add #34 positive with leading zero limb + 0 (1 limb)
+mbedtls_mpi_add_mpi:"0000000000000000123":"0":"123"
+
+MPI add #35 positive with leading zero limb + positive
+mbedtls_mpi_add_mpi:"0000000000000000123":"7b":"19e"
+
+MPI add #36 positive with leading zero limb + negative
+mbedtls_mpi_add_mpi:"0000000000000000123":"-7b":"a8"
+
+MPI add #37 positive with leading zero limb + positive with leading zero limb
 mbedtls_mpi_add_mpi:"0000000000000000123":"0000000000000000123":"246"
 
-MPI add #28 positive with leading zero limb + negative with leading zero limb
+MPI add #38 positive with leading zero limb + negative with leading zero limb
 mbedtls_mpi_add_mpi:"0000000000000000123":"-0000000000000000123":"0"
 
-MPI add #29 positive with leading zero limb + large positive
+MPI add #39 positive with leading zero limb + large positive
 mbedtls_mpi_add_mpi:"0000000000000000123":"1230000000000000000":"1230000000000000123"
 
-MPI add #30 positive with leading zero limb + large negative
+MPI add #40 positive with leading zero limb + large negative
 mbedtls_mpi_add_mpi:"0000000000000000123":"-1230000000000000000":"-122fffffffffffffedd"
 
-MPI add #31 negative with leading zero limb + negative with leading zero limb
+MPI add #41 negative with leading zero limb + 0 (null)
+mbedtls_mpi_add_mpi:"-0000000000000000123":"":"-123"
+
+MPI add #42 negative with leading zero limb + 0 (1 limb)
+mbedtls_mpi_add_mpi:"-0000000000000000123":"0":"-123"
+
+MPI add #43 negative with leading zero limb + positive
+mbedtls_mpi_add_mpi:"-0000000000000000123":"7b":"-a8"
+
+MPI add #44 negative with leading zero limb + negative
+mbedtls_mpi_add_mpi:"-0000000000000000123":"-7b":"-19e"
+
+MPI add #45 negative with leading zero limb + positive with leading zero limb
+mbedtls_mpi_add_mpi:"-0000000000000000123":"0000000000000000123":"0"
+
+MPI add #46 negative with leading zero limb + negative with leading zero limb
 mbedtls_mpi_add_mpi:"-0000000000000000123":"-0000000000000000123":"-246"
 
-MPI add #32 negative with leading zero limb + large positive
+MPI add #47 negative with leading zero limb + large positive
 mbedtls_mpi_add_mpi:"-0000000000000000123":"1230000000000000000":"122fffffffffffffedd"
 
-MPI add #33 negative with leading zero limb + large negative
+MPI add #48 negative with leading zero limb + large negative
 mbedtls_mpi_add_mpi:"-0000000000000000123":"-1230000000000000000":"-1230000000000000123"
 
-MPI add #34 large positive + large positive
+MPI add #49 large positive + 0 (null)
+mbedtls_mpi_add_mpi:"1230000000000000000":"":"1230000000000000000"
+
+MPI add #50 large positive + 0 (1 limb)
+mbedtls_mpi_add_mpi:"1230000000000000000":"0":"1230000000000000000"
+
+MPI add #51 large positive + positive
+mbedtls_mpi_add_mpi:"1230000000000000000":"7b":"123000000000000007b"
+
+MPI add #52 large positive + negative
+mbedtls_mpi_add_mpi:"1230000000000000000":"-7b":"122ffffffffffffff85"
+
+MPI add #53 large positive + positive with leading zero limb
+mbedtls_mpi_add_mpi:"1230000000000000000":"0000000000000000123":"1230000000000000123"
+
+MPI add #54 large positive + negative with leading zero limb
+mbedtls_mpi_add_mpi:"1230000000000000000":"-0000000000000000123":"122fffffffffffffedd"
+
+MPI add #55 large positive + large positive
 mbedtls_mpi_add_mpi:"1230000000000000000":"1230000000000000000":"2460000000000000000"
 
-MPI add #35 large positive + large negative
+MPI add #56 large positive + large negative
 mbedtls_mpi_add_mpi:"1230000000000000000":"-1230000000000000000":"0"
 
-MPI add #36 large negative + large negative
+MPI add #57 large negative + 0 (null)
+mbedtls_mpi_add_mpi:"-1230000000000000000":"":"-1230000000000000000"
+
+MPI add #58 large negative + 0 (1 limb)
+mbedtls_mpi_add_mpi:"-1230000000000000000":"0":"-1230000000000000000"
+
+MPI add #59 large negative + positive
+mbedtls_mpi_add_mpi:"-1230000000000000000":"7b":"-122ffffffffffffff85"
+
+MPI add #60 large negative + negative
+mbedtls_mpi_add_mpi:"-1230000000000000000":"-7b":"-123000000000000007b"
+
+MPI add #61 large negative + positive with leading zero limb
+mbedtls_mpi_add_mpi:"-1230000000000000000":"0000000000000000123":"-122fffffffffffffedd"
+
+MPI add #62 large negative + negative with leading zero limb
+mbedtls_mpi_add_mpi:"-1230000000000000000":"-0000000000000000123":"-1230000000000000123"
+
+MPI add #63 large negative + large positive
+mbedtls_mpi_add_mpi:"-1230000000000000000":"1230000000000000000":"0"
+
+MPI add #64 large negative + large negative
 mbedtls_mpi_add_mpi:"-1230000000000000000":"-1230000000000000000":"-2460000000000000000"
 
-MPI add #37 large positive + large positive
+MPI add #65 large positive + large positive
 mbedtls_mpi_add_mpi:"1c67967269c6":"1c67967269c6":"38cf2ce4d38c"
 
-MPI add #38 large positive + positive
+MPI add #66 large positive + positive
 mbedtls_mpi_add_mpi:"1c67967269c6":"9cde3":"1c67967c37a9"
 
-MPI add #39 large positive + large negative
+MPI add #67 large positive + large negative
 mbedtls_mpi_add_mpi:"1c67967269c6":"-1c67967269c6":"0"
 
-MPI add #40 large positive + negative
+MPI add #68 large positive + negative
 mbedtls_mpi_add_mpi:"1c67967269c6":"-9cde3":"1c6796689be3"
 
-MPI add #41 positive + positive
+MPI add #69 positive + large positive
+mbedtls_mpi_add_mpi:"9cde3":"1c67967269c6":"1c67967c37a9"
+
+MPI add #70 positive + positive
 mbedtls_mpi_add_mpi:"9cde3":"9cde3":"139bc6"
 
-MPI add #42 positive + large negative
+MPI add #71 positive + large negative
 mbedtls_mpi_add_mpi:"9cde3":"-1c67967269c6":"-1c6796689be3"
 
-MPI add #43 positive + negative
+MPI add #72 positive + negative
 mbedtls_mpi_add_mpi:"9cde3":"-9cde3":"0"
 
-MPI add #44 large negative + large negative
+MPI add #73 large negative + large positive
+mbedtls_mpi_add_mpi:"-1c67967269c6":"1c67967269c6":"0"
+
+MPI add #74 large negative + positive
+mbedtls_mpi_add_mpi:"-1c67967269c6":"9cde3":"-1c6796689be3"
+
+MPI add #75 large negative + large negative
 mbedtls_mpi_add_mpi:"-1c67967269c6":"-1c67967269c6":"-38cf2ce4d38c"
 
-MPI add #45 large negative + negative
+MPI add #76 large negative + negative
 mbedtls_mpi_add_mpi:"-1c67967269c6":"-9cde3":"-1c67967c37a9"
 
-MPI add #46 negative + negative
+MPI add #77 negative + large positive
+mbedtls_mpi_add_mpi:"-9cde3":"1c67967269c6":"1c6796689be3"
+
+MPI add #78 negative + positive
+mbedtls_mpi_add_mpi:"-9cde3":"9cde3":"0"
+
+MPI add #79 negative + large negative
+mbedtls_mpi_add_mpi:"-9cde3":"-1c67967269c6":"-1c67967c37a9"
+
+MPI add #80 negative + negative
 mbedtls_mpi_add_mpi:"-9cde3":"-9cde3":"-139bc6"
 
 MPI compare #1 0 (null) == 0 (null)
@@ -162,100 +264,184 @@ mbedtls_mpi_cmp_mpi:"":"1230000000000000000":-1
 MPI compare #8 0 (null) > large negative
 mbedtls_mpi_cmp_mpi:"":"-1230000000000000000":1
 
-MPI compare #9 0 (1 limb) == 0 (1 limb)
+MPI compare #9 0 (1 limb) == 0 (null)
+mbedtls_mpi_cmp_mpi:"0":"":0
+
+MPI compare #10 0 (1 limb) == 0 (1 limb)
 mbedtls_mpi_cmp_mpi:"0":"0":0
 
-MPI compare #10 0 (1 limb) < positive
+MPI compare #11 0 (1 limb) < positive
 mbedtls_mpi_cmp_mpi:"0":"7b":-1
 
-MPI compare #11 0 (1 limb) > negative
+MPI compare #12 0 (1 limb) > negative
 mbedtls_mpi_cmp_mpi:"0":"-7b":1
 
-MPI compare #12 0 (1 limb) < positive with leading zero limb
+MPI compare #13 0 (1 limb) < positive with leading zero limb
 mbedtls_mpi_cmp_mpi:"0":"0000000000000000123":-1
 
-MPI compare #13 0 (1 limb) > negative with leading zero limb
+MPI compare #14 0 (1 limb) > negative with leading zero limb
 mbedtls_mpi_cmp_mpi:"0":"-0000000000000000123":1
 
-MPI compare #14 0 (1 limb) < large positive
+MPI compare #15 0 (1 limb) < large positive
 mbedtls_mpi_cmp_mpi:"0":"1230000000000000000":-1
 
-MPI compare #15 0 (1 limb) > large negative
+MPI compare #16 0 (1 limb) > large negative
 mbedtls_mpi_cmp_mpi:"0":"-1230000000000000000":1
 
-MPI compare #16 positive == positive
+MPI compare #17 positive > 0 (null)
+mbedtls_mpi_cmp_mpi:"7b":"":1
+
+MPI compare #18 positive > 0 (1 limb)
+mbedtls_mpi_cmp_mpi:"7b":"0":1
+
+MPI compare #19 positive == positive
 mbedtls_mpi_cmp_mpi:"7b":"7b":0
 
-MPI compare #17 positive > negative
+MPI compare #20 positive > negative
 mbedtls_mpi_cmp_mpi:"7b":"-7b":1
 
-MPI compare #18 positive < positive with leading zero limb
+MPI compare #21 positive < positive with leading zero limb
 mbedtls_mpi_cmp_mpi:"7b":"0000000000000000123":-1
 
-MPI compare #19 positive > negative with leading zero limb
+MPI compare #22 positive > negative with leading zero limb
 mbedtls_mpi_cmp_mpi:"7b":"-0000000000000000123":1
 
-MPI compare #20 positive < large positive
+MPI compare #23 positive < large positive
 mbedtls_mpi_cmp_mpi:"7b":"1230000000000000000":-1
 
-MPI compare #21 positive > large negative
+MPI compare #24 positive > large negative
 mbedtls_mpi_cmp_mpi:"7b":"-1230000000000000000":1
 
-MPI compare #22 negative == negative
+MPI compare #25 negative < 0 (null)
+mbedtls_mpi_cmp_mpi:"-7b":"":-1
+
+MPI compare #26 negative < 0 (1 limb)
+mbedtls_mpi_cmp_mpi:"-7b":"0":-1
+
+MPI compare #27 negative < positive
+mbedtls_mpi_cmp_mpi:"-7b":"7b":-1
+
+MPI compare #28 negative == negative
 mbedtls_mpi_cmp_mpi:"-7b":"-7b":0
 
-MPI compare #23 negative < positive with leading zero limb
+MPI compare #29 negative < positive with leading zero limb
 mbedtls_mpi_cmp_mpi:"-7b":"0000000000000000123":-1
 
-MPI compare #24 negative > negative with leading zero limb
+MPI compare #30 negative > negative with leading zero limb
 mbedtls_mpi_cmp_mpi:"-7b":"-0000000000000000123":1
 
-MPI compare #25 negative < large positive
+MPI compare #31 negative < large positive
 mbedtls_mpi_cmp_mpi:"-7b":"1230000000000000000":-1
 
-MPI compare #26 negative > large negative
+MPI compare #32 negative > large negative
 mbedtls_mpi_cmp_mpi:"-7b":"-1230000000000000000":1
 
-MPI compare #27 positive with leading zero limb == positive with leading zero limb
+MPI compare #33 positive with leading zero limb > 0 (null)
+mbedtls_mpi_cmp_mpi:"0000000000000000123":"":1
+
+MPI compare #34 positive with leading zero limb > 0 (1 limb)
+mbedtls_mpi_cmp_mpi:"0000000000000000123":"0":1
+
+MPI compare #35 positive with leading zero limb > positive
+mbedtls_mpi_cmp_mpi:"0000000000000000123":"7b":1
+
+MPI compare #36 positive with leading zero limb > negative
+mbedtls_mpi_cmp_mpi:"0000000000000000123":"-7b":1
+
+MPI compare #37 positive with leading zero limb == positive with leading zero limb
 mbedtls_mpi_cmp_mpi:"0000000000000000123":"0000000000000000123":0
 
-MPI compare #28 positive with leading zero limb > negative with leading zero limb
+MPI compare #38 positive with leading zero limb > negative with leading zero limb
 mbedtls_mpi_cmp_mpi:"0000000000000000123":"-0000000000000000123":1
 
-MPI compare #29 positive with leading zero limb < large positive
+MPI compare #39 positive with leading zero limb < large positive
 mbedtls_mpi_cmp_mpi:"0000000000000000123":"1230000000000000000":-1
 
-MPI compare #30 positive with leading zero limb > large negative
+MPI compare #40 positive with leading zero limb > large negative
 mbedtls_mpi_cmp_mpi:"0000000000000000123":"-1230000000000000000":1
 
-MPI compare #31 negative with leading zero limb == negative with leading zero limb
+MPI compare #41 negative with leading zero limb < 0 (null)
+mbedtls_mpi_cmp_mpi:"-0000000000000000123":"":-1
+
+MPI compare #42 negative with leading zero limb < 0 (1 limb)
+mbedtls_mpi_cmp_mpi:"-0000000000000000123":"0":-1
+
+MPI compare #43 negative with leading zero limb < positive
+mbedtls_mpi_cmp_mpi:"-0000000000000000123":"7b":-1
+
+MPI compare #44 negative with leading zero limb < negative
+mbedtls_mpi_cmp_mpi:"-0000000000000000123":"-7b":-1
+
+MPI compare #45 negative with leading zero limb < positive with leading zero limb
+mbedtls_mpi_cmp_mpi:"-0000000000000000123":"0000000000000000123":-1
+
+MPI compare #46 negative with leading zero limb == negative with leading zero limb
 mbedtls_mpi_cmp_mpi:"-0000000000000000123":"-0000000000000000123":0
 
-MPI compare #32 negative with leading zero limb < large positive
+MPI compare #47 negative with leading zero limb < large positive
 mbedtls_mpi_cmp_mpi:"-0000000000000000123":"1230000000000000000":-1
 
-MPI compare #33 negative with leading zero limb > large negative
+MPI compare #48 negative with leading zero limb > large negative
 mbedtls_mpi_cmp_mpi:"-0000000000000000123":"-1230000000000000000":1
 
-MPI compare #34 large positive == large positive
+MPI compare #49 large positive > 0 (null)
+mbedtls_mpi_cmp_mpi:"1230000000000000000":"":1
+
+MPI compare #50 large positive > 0 (1 limb)
+mbedtls_mpi_cmp_mpi:"1230000000000000000":"0":1
+
+MPI compare #51 large positive > positive
+mbedtls_mpi_cmp_mpi:"1230000000000000000":"7b":1
+
+MPI compare #52 large positive > negative
+mbedtls_mpi_cmp_mpi:"1230000000000000000":"-7b":1
+
+MPI compare #53 large positive > positive with leading zero limb
+mbedtls_mpi_cmp_mpi:"1230000000000000000":"0000000000000000123":1
+
+MPI compare #54 large positive > negative with leading zero limb
+mbedtls_mpi_cmp_mpi:"1230000000000000000":"-0000000000000000123":1
+
+MPI compare #55 large positive == large positive
 mbedtls_mpi_cmp_mpi:"1230000000000000000":"1230000000000000000":0
 
-MPI compare #35 large positive > large negative
+MPI compare #56 large positive > large negative
 mbedtls_mpi_cmp_mpi:"1230000000000000000":"-1230000000000000000":1
 
-MPI compare #36 large negative == large negative
+MPI compare #57 large negative < 0 (null)
+mbedtls_mpi_cmp_mpi:"-1230000000000000000":"":-1
+
+MPI compare #58 large negative < 0 (1 limb)
+mbedtls_mpi_cmp_mpi:"-1230000000000000000":"0":-1
+
+MPI compare #59 large negative < positive
+mbedtls_mpi_cmp_mpi:"-1230000000000000000":"7b":-1
+
+MPI compare #60 large negative < negative
+mbedtls_mpi_cmp_mpi:"-1230000000000000000":"-7b":-1
+
+MPI compare #61 large negative < positive with leading zero limb
+mbedtls_mpi_cmp_mpi:"-1230000000000000000":"0000000000000000123":-1
+
+MPI compare #62 large negative < negative with leading zero limb
+mbedtls_mpi_cmp_mpi:"-1230000000000000000":"-0000000000000000123":-1
+
+MPI compare #63 large negative < large positive
+mbedtls_mpi_cmp_mpi:"-1230000000000000000":"1230000000000000000":-1
+
+MPI compare #64 large negative == large negative
 mbedtls_mpi_cmp_mpi:"-1230000000000000000":"-1230000000000000000":0
 
-MPI compare #37 negative > negative
+MPI compare #65 negative > negative
 mbedtls_mpi_cmp_mpi:"-2":"-3":1
 
-MPI compare #38 negative == negative
+MPI compare #66 negative == negative
 mbedtls_mpi_cmp_mpi:"-2":"-2":0
 
-MPI compare #39 positive < positive
+MPI compare #67 positive < positive
 mbedtls_mpi_cmp_mpi:"2b4":"2b5":-1
 
-MPI compare #40 positive < positive
+MPI compare #68 positive < positive
 mbedtls_mpi_cmp_mpi:"2b5":"2b6":-1
 
 MPI compare (abs) #1 0 (null) == 0 (null)
@@ -282,100 +468,184 @@ mbedtls_mpi_cmp_abs:"":"1230000000000000000":-1
 MPI compare (abs) #8 0 (null) < large positive
 mbedtls_mpi_cmp_abs:"":"1230000000000000000":-1
 
-MPI compare (abs) #9 0 (1 limb) == 0 (1 limb)
-mbedtls_mpi_cmp_abs:"0":"0":0
+MPI compare (abs) #9 0 (1 limb) == 0 (null)
+mbedtls_mpi_cmp_abs:"0":"":0
 
-MPI compare (abs) #10 0 (1 limb) < positive
-mbedtls_mpi_cmp_abs:"0":"7b":-1
+MPI compare (abs) #10 0 (1 limb) == 0 (1 limb)
+mbedtls_mpi_cmp_abs:"0":"0":0
 
 MPI compare (abs) #11 0 (1 limb) < positive
 mbedtls_mpi_cmp_abs:"0":"7b":-1
 
-MPI compare (abs) #12 0 (1 limb) < positive with leading zero limb
-mbedtls_mpi_cmp_abs:"0":"0000000000000000123":-1
+MPI compare (abs) #12 0 (1 limb) < positive
+mbedtls_mpi_cmp_abs:"0":"7b":-1
 
 MPI compare (abs) #13 0 (1 limb) < positive with leading zero limb
 mbedtls_mpi_cmp_abs:"0":"0000000000000000123":-1
 
-MPI compare (abs) #14 0 (1 limb) < large positive
-mbedtls_mpi_cmp_abs:"0":"1230000000000000000":-1
+MPI compare (abs) #14 0 (1 limb) < positive with leading zero limb
+mbedtls_mpi_cmp_abs:"0":"0000000000000000123":-1
 
 MPI compare (abs) #15 0 (1 limb) < large positive
 mbedtls_mpi_cmp_abs:"0":"1230000000000000000":-1
 
-MPI compare (abs) #16 positive == positive
+MPI compare (abs) #16 0 (1 limb) < large positive
+mbedtls_mpi_cmp_abs:"0":"1230000000000000000":-1
+
+MPI compare (abs) #17 positive > 0 (null)
+mbedtls_mpi_cmp_abs:"7b":"":1
+
+MPI compare (abs) #18 positive > 0 (1 limb)
+mbedtls_mpi_cmp_abs:"7b":"0":1
+
+MPI compare (abs) #19 positive == positive
 mbedtls_mpi_cmp_abs:"7b":"7b":0
 
-MPI compare (abs) #17 positive == positive
+MPI compare (abs) #20 positive == positive
 mbedtls_mpi_cmp_abs:"7b":"7b":0
 
-MPI compare (abs) #18 positive < positive with leading zero limb
+MPI compare (abs) #21 positive < positive with leading zero limb
 mbedtls_mpi_cmp_abs:"7b":"0000000000000000123":-1
 
-MPI compare (abs) #19 positive < positive with leading zero limb
+MPI compare (abs) #22 positive < positive with leading zero limb
 mbedtls_mpi_cmp_abs:"7b":"0000000000000000123":-1
 
-MPI compare (abs) #20 positive < large positive
+MPI compare (abs) #23 positive < large positive
 mbedtls_mpi_cmp_abs:"7b":"1230000000000000000":-1
 
-MPI compare (abs) #21 positive < large positive
+MPI compare (abs) #24 positive < large positive
 mbedtls_mpi_cmp_abs:"7b":"1230000000000000000":-1
 
-MPI compare (abs) #22 positive == positive
+MPI compare (abs) #25 positive > 0 (null)
+mbedtls_mpi_cmp_abs:"7b":"":1
+
+MPI compare (abs) #26 positive > 0 (1 limb)
+mbedtls_mpi_cmp_abs:"7b":"0":1
+
+MPI compare (abs) #27 positive == positive
 mbedtls_mpi_cmp_abs:"7b":"7b":0
 
-MPI compare (abs) #23 positive < positive with leading zero limb
+MPI compare (abs) #28 positive == positive
+mbedtls_mpi_cmp_abs:"7b":"7b":0
+
+MPI compare (abs) #29 positive < positive with leading zero limb
 mbedtls_mpi_cmp_abs:"7b":"0000000000000000123":-1
 
-MPI compare (abs) #24 positive < positive with leading zero limb
+MPI compare (abs) #30 positive < positive with leading zero limb
 mbedtls_mpi_cmp_abs:"7b":"0000000000000000123":-1
 
-MPI compare (abs) #25 positive < large positive
+MPI compare (abs) #31 positive < large positive
 mbedtls_mpi_cmp_abs:"7b":"1230000000000000000":-1
 
-MPI compare (abs) #26 positive < large positive
+MPI compare (abs) #32 positive < large positive
 mbedtls_mpi_cmp_abs:"7b":"1230000000000000000":-1
 
-MPI compare (abs) #27 positive with leading zero limb == positive with leading zero limb
+MPI compare (abs) #33 positive with leading zero limb > 0 (null)
+mbedtls_mpi_cmp_abs:"0000000000000000123":"":1
+
+MPI compare (abs) #34 positive with leading zero limb > 0 (1 limb)
+mbedtls_mpi_cmp_abs:"0000000000000000123":"0":1
+
+MPI compare (abs) #35 positive with leading zero limb > positive
+mbedtls_mpi_cmp_abs:"0000000000000000123":"7b":1
+
+MPI compare (abs) #36 positive with leading zero limb > positive
+mbedtls_mpi_cmp_abs:"0000000000000000123":"7b":1
+
+MPI compare (abs) #37 positive with leading zero limb == positive with leading zero limb
 mbedtls_mpi_cmp_abs:"0000000000000000123":"0000000000000000123":0
 
-MPI compare (abs) #28 positive with leading zero limb == positive with leading zero limb
+MPI compare (abs) #38 positive with leading zero limb == positive with leading zero limb
 mbedtls_mpi_cmp_abs:"0000000000000000123":"0000000000000000123":0
 
-MPI compare (abs) #29 positive with leading zero limb < large positive
+MPI compare (abs) #39 positive with leading zero limb < large positive
 mbedtls_mpi_cmp_abs:"0000000000000000123":"1230000000000000000":-1
 
-MPI compare (abs) #30 positive with leading zero limb < large positive
+MPI compare (abs) #40 positive with leading zero limb < large positive
 mbedtls_mpi_cmp_abs:"0000000000000000123":"1230000000000000000":-1
 
-MPI compare (abs) #31 positive with leading zero limb == positive with leading zero limb
+MPI compare (abs) #41 positive with leading zero limb > 0 (null)
+mbedtls_mpi_cmp_abs:"0000000000000000123":"":1
+
+MPI compare (abs) #42 positive with leading zero limb > 0 (1 limb)
+mbedtls_mpi_cmp_abs:"0000000000000000123":"0":1
+
+MPI compare (abs) #43 positive with leading zero limb > positive
+mbedtls_mpi_cmp_abs:"0000000000000000123":"7b":1
+
+MPI compare (abs) #44 positive with leading zero limb > positive
+mbedtls_mpi_cmp_abs:"0000000000000000123":"7b":1
+
+MPI compare (abs) #45 positive with leading zero limb == positive with leading zero limb
 mbedtls_mpi_cmp_abs:"0000000000000000123":"0000000000000000123":0
 
-MPI compare (abs) #32 positive with leading zero limb < large positive
+MPI compare (abs) #46 positive with leading zero limb == positive with leading zero limb
+mbedtls_mpi_cmp_abs:"0000000000000000123":"0000000000000000123":0
+
+MPI compare (abs) #47 positive with leading zero limb < large positive
 mbedtls_mpi_cmp_abs:"0000000000000000123":"1230000000000000000":-1
 
-MPI compare (abs) #33 positive with leading zero limb < large positive
+MPI compare (abs) #48 positive with leading zero limb < large positive
 mbedtls_mpi_cmp_abs:"0000000000000000123":"1230000000000000000":-1
 
-MPI compare (abs) #34 large positive == large positive
+MPI compare (abs) #49 large positive > 0 (null)
+mbedtls_mpi_cmp_abs:"1230000000000000000":"":1
+
+MPI compare (abs) #50 large positive > 0 (1 limb)
+mbedtls_mpi_cmp_abs:"1230000000000000000":"0":1
+
+MPI compare (abs) #51 large positive > positive
+mbedtls_mpi_cmp_abs:"1230000000000000000":"7b":1
+
+MPI compare (abs) #52 large positive > positive
+mbedtls_mpi_cmp_abs:"1230000000000000000":"7b":1
+
+MPI compare (abs) #53 large positive > positive with leading zero limb
+mbedtls_mpi_cmp_abs:"1230000000000000000":"0000000000000000123":1
+
+MPI compare (abs) #54 large positive > positive with leading zero limb
+mbedtls_mpi_cmp_abs:"1230000000000000000":"0000000000000000123":1
+
+MPI compare (abs) #55 large positive == large positive
 mbedtls_mpi_cmp_abs:"1230000000000000000":"1230000000000000000":0
 
-MPI compare (abs) #35 large positive == large positive
+MPI compare (abs) #56 large positive == large positive
 mbedtls_mpi_cmp_abs:"1230000000000000000":"1230000000000000000":0
 
-MPI compare (abs) #36 large positive == large positive
+MPI compare (abs) #57 large positive > 0 (null)
+mbedtls_mpi_cmp_abs:"1230000000000000000":"":1
+
+MPI compare (abs) #58 large positive > 0 (1 limb)
+mbedtls_mpi_cmp_abs:"1230000000000000000":"0":1
+
+MPI compare (abs) #59 large positive > positive
+mbedtls_mpi_cmp_abs:"1230000000000000000":"7b":1
+
+MPI compare (abs) #60 large positive > positive
+mbedtls_mpi_cmp_abs:"1230000000000000000":"7b":1
+
+MPI compare (abs) #61 large positive > positive with leading zero limb
+mbedtls_mpi_cmp_abs:"1230000000000000000":"0000000000000000123":1
+
+MPI compare (abs) #62 large positive > positive with leading zero limb
+mbedtls_mpi_cmp_abs:"1230000000000000000":"0000000000000000123":1
+
+MPI compare (abs) #63 large positive == large positive
 mbedtls_mpi_cmp_abs:"1230000000000000000":"1230000000000000000":0
 
-MPI compare (abs) #37 positive < positive
+MPI compare (abs) #64 large positive == large positive
+mbedtls_mpi_cmp_abs:"1230000000000000000":"1230000000000000000":0
+
+MPI compare (abs) #65 positive < positive
 mbedtls_mpi_cmp_abs:"2":"3":-1
 
-MPI compare (abs) #38 positive == positive
+MPI compare (abs) #66 positive == positive
 mbedtls_mpi_cmp_abs:"2":"2":0
 
-MPI compare (abs) #39 positive < positive
+MPI compare (abs) #67 positive < positive
 mbedtls_mpi_cmp_abs:"2b4":"2b5":-1
 
-MPI compare (abs) #40 positive < positive
+MPI compare (abs) #68 positive < positive
 mbedtls_mpi_cmp_abs:"2b5":"2b6":-1
 
 # End of automatically generated file.

--- a/tests/suites/test_suite_bignum.generated.data
+++ b/tests/suites/test_suite_bignum.generated.data
@@ -6,238 +6,346 @@ mbedtls_mpi_add_mpi:"":"":"0"
 MPI add #2 0 (null) + 0 (1 limb)
 mbedtls_mpi_add_mpi:"":"0":"0"
 
-MPI add #3 0 (null) + positive
+MPI add #3 0 (null) + negative 0 (null)
+mbedtls_mpi_add_mpi:"":"-":"0"
+
+MPI add #4 0 (null) + negative with leading zero limb
+mbedtls_mpi_add_mpi:"":"-0":"0"
+
+MPI add #5 0 (null) + positive
 mbedtls_mpi_add_mpi:"":"7b":"7b"
 
-MPI add #4 0 (null) + negative
+MPI add #6 0 (null) + negative
 mbedtls_mpi_add_mpi:"":"-7b":"-7b"
 
-MPI add #5 0 (null) + positive with leading zero limb
+MPI add #7 0 (null) + positive with leading zero limb
 mbedtls_mpi_add_mpi:"":"0000000000000000123":"123"
 
-MPI add #6 0 (null) + negative with leading zero limb
+MPI add #8 0 (null) + negative with leading zero limb
 mbedtls_mpi_add_mpi:"":"-0000000000000000123":"-123"
 
-MPI add #7 0 (null) + large positive
+MPI add #9 0 (null) + large positive
 mbedtls_mpi_add_mpi:"":"1230000000000000000":"1230000000000000000"
 
-MPI add #8 0 (null) + large negative
+MPI add #10 0 (null) + large negative
 mbedtls_mpi_add_mpi:"":"-1230000000000000000":"-1230000000000000000"
 
-MPI add #9 0 (1 limb) + 0 (null)
+MPI add #11 0 (1 limb) + 0 (null)
 mbedtls_mpi_add_mpi:"0":"":"0"
 
-MPI add #10 0 (1 limb) + 0 (1 limb)
+MPI add #12 0 (1 limb) + 0 (1 limb)
 mbedtls_mpi_add_mpi:"0":"0":"0"
 
-MPI add #11 0 (1 limb) + positive
-mbedtls_mpi_add_mpi:"0":"7b":"7b"
-
-MPI add #12 0 (1 limb) + negative
-mbedtls_mpi_add_mpi:"0":"-7b":"-7b"
-
-MPI add #13 0 (1 limb) + positive with leading zero limb
-mbedtls_mpi_add_mpi:"0":"0000000000000000123":"123"
+MPI add #13 0 (1 limb) + negative 0 (null)
+mbedtls_mpi_add_mpi:"0":"-":"0"
 
 MPI add #14 0 (1 limb) + negative with leading zero limb
+mbedtls_mpi_add_mpi:"0":"-0":"0"
+
+MPI add #15 0 (1 limb) + positive
+mbedtls_mpi_add_mpi:"0":"7b":"7b"
+
+MPI add #16 0 (1 limb) + negative
+mbedtls_mpi_add_mpi:"0":"-7b":"-7b"
+
+MPI add #17 0 (1 limb) + positive with leading zero limb
+mbedtls_mpi_add_mpi:"0":"0000000000000000123":"123"
+
+MPI add #18 0 (1 limb) + negative with leading zero limb
 mbedtls_mpi_add_mpi:"0":"-0000000000000000123":"-123"
 
-MPI add #15 0 (1 limb) + large positive
+MPI add #19 0 (1 limb) + large positive
 mbedtls_mpi_add_mpi:"0":"1230000000000000000":"1230000000000000000"
 
-MPI add #16 0 (1 limb) + large negative
+MPI add #20 0 (1 limb) + large negative
 mbedtls_mpi_add_mpi:"0":"-1230000000000000000":"-1230000000000000000"
 
-MPI add #17 positive + 0 (null)
+MPI add #21 negative 0 (null) + 0 (null)
+mbedtls_mpi_add_mpi:"-":"":"0"
+
+MPI add #22 negative 0 (null) + 0 (1 limb)
+mbedtls_mpi_add_mpi:"-":"0":"0"
+
+MPI add #23 negative 0 (null) + negative 0 (null)
+mbedtls_mpi_add_mpi:"-":"-":"0"
+
+MPI add #24 negative 0 (null) + negative with leading zero limb
+mbedtls_mpi_add_mpi:"-":"-0":"0"
+
+MPI add #25 negative 0 (null) + positive
+mbedtls_mpi_add_mpi:"-":"7b":"7b"
+
+MPI add #26 negative 0 (null) + negative
+mbedtls_mpi_add_mpi:"-":"-7b":"-7b"
+
+MPI add #27 negative 0 (null) + positive with leading zero limb
+mbedtls_mpi_add_mpi:"-":"0000000000000000123":"123"
+
+MPI add #28 negative 0 (null) + negative with leading zero limb
+mbedtls_mpi_add_mpi:"-":"-0000000000000000123":"-123"
+
+MPI add #29 negative 0 (null) + large positive
+mbedtls_mpi_add_mpi:"-":"1230000000000000000":"1230000000000000000"
+
+MPI add #30 negative 0 (null) + large negative
+mbedtls_mpi_add_mpi:"-":"-1230000000000000000":"-1230000000000000000"
+
+MPI add #31 negative with leading zero limb + 0 (null)
+mbedtls_mpi_add_mpi:"-0":"":"0"
+
+MPI add #32 negative with leading zero limb + 0 (1 limb)
+mbedtls_mpi_add_mpi:"-0":"0":"0"
+
+MPI add #33 negative with leading zero limb + negative 0 (null)
+mbedtls_mpi_add_mpi:"-0":"-":"0"
+
+MPI add #34 negative with leading zero limb + negative with leading zero limb
+mbedtls_mpi_add_mpi:"-0":"-0":"0"
+
+MPI add #35 negative with leading zero limb + positive
+mbedtls_mpi_add_mpi:"-0":"7b":"7b"
+
+MPI add #36 negative with leading zero limb + negative
+mbedtls_mpi_add_mpi:"-0":"-7b":"-7b"
+
+MPI add #37 negative with leading zero limb + positive with leading zero limb
+mbedtls_mpi_add_mpi:"-0":"0000000000000000123":"123"
+
+MPI add #38 negative with leading zero limb + negative with leading zero limb
+mbedtls_mpi_add_mpi:"-0":"-0000000000000000123":"-123"
+
+MPI add #39 negative with leading zero limb + large positive
+mbedtls_mpi_add_mpi:"-0":"1230000000000000000":"1230000000000000000"
+
+MPI add #40 negative with leading zero limb + large negative
+mbedtls_mpi_add_mpi:"-0":"-1230000000000000000":"-1230000000000000000"
+
+MPI add #41 positive + 0 (null)
 mbedtls_mpi_add_mpi:"7b":"":"7b"
 
-MPI add #18 positive + 0 (1 limb)
+MPI add #42 positive + 0 (1 limb)
 mbedtls_mpi_add_mpi:"7b":"0":"7b"
 
-MPI add #19 positive + positive
+MPI add #43 positive + negative 0 (null)
+mbedtls_mpi_add_mpi:"7b":"-":"7b"
+
+MPI add #44 positive + negative with leading zero limb
+mbedtls_mpi_add_mpi:"7b":"-0":"7b"
+
+MPI add #45 positive + positive
 mbedtls_mpi_add_mpi:"7b":"7b":"f6"
 
-MPI add #20 positive + negative
+MPI add #46 positive + negative , result=0
 mbedtls_mpi_add_mpi:"7b":"-7b":"0"
 
-MPI add #21 positive + positive with leading zero limb
+MPI add #47 positive + positive with leading zero limb
 mbedtls_mpi_add_mpi:"7b":"0000000000000000123":"19e"
 
-MPI add #22 positive + negative with leading zero limb
+MPI add #48 positive + negative with leading zero limb , result<0
 mbedtls_mpi_add_mpi:"7b":"-0000000000000000123":"-a8"
 
-MPI add #23 positive + large positive
+MPI add #49 positive + large positive
 mbedtls_mpi_add_mpi:"7b":"1230000000000000000":"123000000000000007b"
 
-MPI add #24 positive + large negative
+MPI add #50 positive + large negative , result<0
 mbedtls_mpi_add_mpi:"7b":"-1230000000000000000":"-122ffffffffffffff85"
 
-MPI add #25 negative + 0 (null)
+MPI add #51 negative + 0 (null)
 mbedtls_mpi_add_mpi:"-7b":"":"-7b"
 
-MPI add #26 negative + 0 (1 limb)
+MPI add #52 negative + 0 (1 limb)
 mbedtls_mpi_add_mpi:"-7b":"0":"-7b"
 
-MPI add #27 negative + positive
+MPI add #53 negative + negative 0 (null)
+mbedtls_mpi_add_mpi:"-7b":"-":"-7b"
+
+MPI add #54 negative + negative with leading zero limb
+mbedtls_mpi_add_mpi:"-7b":"-0":"-7b"
+
+MPI add #55 negative + positive , result=0
 mbedtls_mpi_add_mpi:"-7b":"7b":"0"
 
-MPI add #28 negative + negative
+MPI add #56 negative + negative
 mbedtls_mpi_add_mpi:"-7b":"-7b":"-f6"
 
-MPI add #29 negative + positive with leading zero limb
+MPI add #57 negative + positive with leading zero limb , result>0
 mbedtls_mpi_add_mpi:"-7b":"0000000000000000123":"a8"
 
-MPI add #30 negative + negative with leading zero limb
+MPI add #58 negative + negative with leading zero limb
 mbedtls_mpi_add_mpi:"-7b":"-0000000000000000123":"-19e"
 
-MPI add #31 negative + large positive
+MPI add #59 negative + large positive , result>0
 mbedtls_mpi_add_mpi:"-7b":"1230000000000000000":"122ffffffffffffff85"
 
-MPI add #32 negative + large negative
+MPI add #60 negative + large negative
 mbedtls_mpi_add_mpi:"-7b":"-1230000000000000000":"-123000000000000007b"
 
-MPI add #33 positive with leading zero limb + 0 (null)
+MPI add #61 positive with leading zero limb + 0 (null)
 mbedtls_mpi_add_mpi:"0000000000000000123":"":"123"
 
-MPI add #34 positive with leading zero limb + 0 (1 limb)
+MPI add #62 positive with leading zero limb + 0 (1 limb)
 mbedtls_mpi_add_mpi:"0000000000000000123":"0":"123"
 
-MPI add #35 positive with leading zero limb + positive
+MPI add #63 positive with leading zero limb + negative 0 (null)
+mbedtls_mpi_add_mpi:"0000000000000000123":"-":"123"
+
+MPI add #64 positive with leading zero limb + negative with leading zero limb
+mbedtls_mpi_add_mpi:"0000000000000000123":"-0":"123"
+
+MPI add #65 positive with leading zero limb + positive
 mbedtls_mpi_add_mpi:"0000000000000000123":"7b":"19e"
 
-MPI add #36 positive with leading zero limb + negative
+MPI add #66 positive with leading zero limb + negative , result>0
 mbedtls_mpi_add_mpi:"0000000000000000123":"-7b":"a8"
 
-MPI add #37 positive with leading zero limb + positive with leading zero limb
+MPI add #67 positive with leading zero limb + positive with leading zero limb
 mbedtls_mpi_add_mpi:"0000000000000000123":"0000000000000000123":"246"
 
-MPI add #38 positive with leading zero limb + negative with leading zero limb
+MPI add #68 positive with leading zero limb + negative with leading zero limb , result=0
 mbedtls_mpi_add_mpi:"0000000000000000123":"-0000000000000000123":"0"
 
-MPI add #39 positive with leading zero limb + large positive
+MPI add #69 positive with leading zero limb + large positive
 mbedtls_mpi_add_mpi:"0000000000000000123":"1230000000000000000":"1230000000000000123"
 
-MPI add #40 positive with leading zero limb + large negative
+MPI add #70 positive with leading zero limb + large negative , result<0
 mbedtls_mpi_add_mpi:"0000000000000000123":"-1230000000000000000":"-122fffffffffffffedd"
 
-MPI add #41 negative with leading zero limb + 0 (null)
+MPI add #71 negative with leading zero limb + 0 (null)
 mbedtls_mpi_add_mpi:"-0000000000000000123":"":"-123"
 
-MPI add #42 negative with leading zero limb + 0 (1 limb)
+MPI add #72 negative with leading zero limb + 0 (1 limb)
 mbedtls_mpi_add_mpi:"-0000000000000000123":"0":"-123"
 
-MPI add #43 negative with leading zero limb + positive
+MPI add #73 negative with leading zero limb + negative 0 (null)
+mbedtls_mpi_add_mpi:"-0000000000000000123":"-":"-123"
+
+MPI add #74 negative with leading zero limb + negative with leading zero limb
+mbedtls_mpi_add_mpi:"-0000000000000000123":"-0":"-123"
+
+MPI add #75 negative with leading zero limb + positive , result<0
 mbedtls_mpi_add_mpi:"-0000000000000000123":"7b":"-a8"
 
-MPI add #44 negative with leading zero limb + negative
+MPI add #76 negative with leading zero limb + negative
 mbedtls_mpi_add_mpi:"-0000000000000000123":"-7b":"-19e"
 
-MPI add #45 negative with leading zero limb + positive with leading zero limb
+MPI add #77 negative with leading zero limb + positive with leading zero limb , result=0
 mbedtls_mpi_add_mpi:"-0000000000000000123":"0000000000000000123":"0"
 
-MPI add #46 negative with leading zero limb + negative with leading zero limb
+MPI add #78 negative with leading zero limb + negative with leading zero limb
 mbedtls_mpi_add_mpi:"-0000000000000000123":"-0000000000000000123":"-246"
 
-MPI add #47 negative with leading zero limb + large positive
+MPI add #79 negative with leading zero limb + large positive , result>0
 mbedtls_mpi_add_mpi:"-0000000000000000123":"1230000000000000000":"122fffffffffffffedd"
 
-MPI add #48 negative with leading zero limb + large negative
+MPI add #80 negative with leading zero limb + large negative
 mbedtls_mpi_add_mpi:"-0000000000000000123":"-1230000000000000000":"-1230000000000000123"
 
-MPI add #49 large positive + 0 (null)
+MPI add #81 large positive + 0 (null)
 mbedtls_mpi_add_mpi:"1230000000000000000":"":"1230000000000000000"
 
-MPI add #50 large positive + 0 (1 limb)
+MPI add #82 large positive + 0 (1 limb)
 mbedtls_mpi_add_mpi:"1230000000000000000":"0":"1230000000000000000"
 
-MPI add #51 large positive + positive
+MPI add #83 large positive + negative 0 (null)
+mbedtls_mpi_add_mpi:"1230000000000000000":"-":"1230000000000000000"
+
+MPI add #84 large positive + negative with leading zero limb
+mbedtls_mpi_add_mpi:"1230000000000000000":"-0":"1230000000000000000"
+
+MPI add #85 large positive + positive
 mbedtls_mpi_add_mpi:"1230000000000000000":"7b":"123000000000000007b"
 
-MPI add #52 large positive + negative
+MPI add #86 large positive + negative , result>0
 mbedtls_mpi_add_mpi:"1230000000000000000":"-7b":"122ffffffffffffff85"
 
-MPI add #53 large positive + positive with leading zero limb
+MPI add #87 large positive + positive with leading zero limb
 mbedtls_mpi_add_mpi:"1230000000000000000":"0000000000000000123":"1230000000000000123"
 
-MPI add #54 large positive + negative with leading zero limb
+MPI add #88 large positive + negative with leading zero limb , result>0
 mbedtls_mpi_add_mpi:"1230000000000000000":"-0000000000000000123":"122fffffffffffffedd"
 
-MPI add #55 large positive + large positive
+MPI add #89 large positive + large positive
 mbedtls_mpi_add_mpi:"1230000000000000000":"1230000000000000000":"2460000000000000000"
 
-MPI add #56 large positive + large negative
+MPI add #90 large positive + large negative , result=0
 mbedtls_mpi_add_mpi:"1230000000000000000":"-1230000000000000000":"0"
 
-MPI add #57 large negative + 0 (null)
+MPI add #91 large negative + 0 (null)
 mbedtls_mpi_add_mpi:"-1230000000000000000":"":"-1230000000000000000"
 
-MPI add #58 large negative + 0 (1 limb)
+MPI add #92 large negative + 0 (1 limb)
 mbedtls_mpi_add_mpi:"-1230000000000000000":"0":"-1230000000000000000"
 
-MPI add #59 large negative + positive
+MPI add #93 large negative + negative 0 (null)
+mbedtls_mpi_add_mpi:"-1230000000000000000":"-":"-1230000000000000000"
+
+MPI add #94 large negative + negative with leading zero limb
+mbedtls_mpi_add_mpi:"-1230000000000000000":"-0":"-1230000000000000000"
+
+MPI add #95 large negative + positive , result<0
 mbedtls_mpi_add_mpi:"-1230000000000000000":"7b":"-122ffffffffffffff85"
 
-MPI add #60 large negative + negative
+MPI add #96 large negative + negative
 mbedtls_mpi_add_mpi:"-1230000000000000000":"-7b":"-123000000000000007b"
 
-MPI add #61 large negative + positive with leading zero limb
+MPI add #97 large negative + positive with leading zero limb , result<0
 mbedtls_mpi_add_mpi:"-1230000000000000000":"0000000000000000123":"-122fffffffffffffedd"
 
-MPI add #62 large negative + negative with leading zero limb
+MPI add #98 large negative + negative with leading zero limb
 mbedtls_mpi_add_mpi:"-1230000000000000000":"-0000000000000000123":"-1230000000000000123"
 
-MPI add #63 large negative + large positive
+MPI add #99 large negative + large positive , result=0
 mbedtls_mpi_add_mpi:"-1230000000000000000":"1230000000000000000":"0"
 
-MPI add #64 large negative + large negative
+MPI add #100 large negative + large negative
 mbedtls_mpi_add_mpi:"-1230000000000000000":"-1230000000000000000":"-2460000000000000000"
 
-MPI add #65 large positive + large positive
+MPI add #101 large positive + large positive
 mbedtls_mpi_add_mpi:"1c67967269c6":"1c67967269c6":"38cf2ce4d38c"
 
-MPI add #66 large positive + positive
+MPI add #102 large positive + positive
 mbedtls_mpi_add_mpi:"1c67967269c6":"9cde3":"1c67967c37a9"
 
-MPI add #67 large positive + large negative
+MPI add #103 large positive + large negative , result=0
 mbedtls_mpi_add_mpi:"1c67967269c6":"-1c67967269c6":"0"
 
-MPI add #68 large positive + negative
+MPI add #104 large positive + negative , result>0
 mbedtls_mpi_add_mpi:"1c67967269c6":"-9cde3":"1c6796689be3"
 
-MPI add #69 positive + large positive
+MPI add #105 positive + large positive
 mbedtls_mpi_add_mpi:"9cde3":"1c67967269c6":"1c67967c37a9"
 
-MPI add #70 positive + positive
+MPI add #106 positive + positive
 mbedtls_mpi_add_mpi:"9cde3":"9cde3":"139bc6"
 
-MPI add #71 positive + large negative
+MPI add #107 positive + large negative , result<0
 mbedtls_mpi_add_mpi:"9cde3":"-1c67967269c6":"-1c6796689be3"
 
-MPI add #72 positive + negative
+MPI add #108 positive + negative , result=0
 mbedtls_mpi_add_mpi:"9cde3":"-9cde3":"0"
 
-MPI add #73 large negative + large positive
+MPI add #109 large negative + large positive , result=0
 mbedtls_mpi_add_mpi:"-1c67967269c6":"1c67967269c6":"0"
 
-MPI add #74 large negative + positive
+MPI add #110 large negative + positive , result<0
 mbedtls_mpi_add_mpi:"-1c67967269c6":"9cde3":"-1c6796689be3"
 
-MPI add #75 large negative + large negative
+MPI add #111 large negative + large negative
 mbedtls_mpi_add_mpi:"-1c67967269c6":"-1c67967269c6":"-38cf2ce4d38c"
 
-MPI add #76 large negative + negative
+MPI add #112 large negative + negative
 mbedtls_mpi_add_mpi:"-1c67967269c6":"-9cde3":"-1c67967c37a9"
 
-MPI add #77 negative + large positive
+MPI add #113 negative + large positive , result>0
 mbedtls_mpi_add_mpi:"-9cde3":"1c67967269c6":"1c6796689be3"
 
-MPI add #78 negative + positive
+MPI add #114 negative + positive , result=0
 mbedtls_mpi_add_mpi:"-9cde3":"9cde3":"0"
 
-MPI add #79 negative + large negative
+MPI add #115 negative + large negative
 mbedtls_mpi_add_mpi:"-9cde3":"-1c67967269c6":"-1c67967c37a9"
 
-MPI add #80 negative + negative
+MPI add #116 negative + negative
 mbedtls_mpi_add_mpi:"-9cde3":"-9cde3":"-139bc6"
 
 MPI compare #1 0 (null) == 0 (null)
@@ -246,202 +354,310 @@ mbedtls_mpi_cmp_mpi:"":"":0
 MPI compare #2 0 (null) == 0 (1 limb)
 mbedtls_mpi_cmp_mpi:"":"0":0
 
-MPI compare #3 0 (null) < positive
+MPI compare #3 0 (null) == negative 0 (null)
+mbedtls_mpi_cmp_mpi:"":"-":0
+
+MPI compare #4 0 (null) == negative with leading zero limb
+mbedtls_mpi_cmp_mpi:"":"-0":0
+
+MPI compare #5 0 (null) < positive
 mbedtls_mpi_cmp_mpi:"":"7b":-1
 
-MPI compare #4 0 (null) > negative
+MPI compare #6 0 (null) > negative
 mbedtls_mpi_cmp_mpi:"":"-7b":1
 
-MPI compare #5 0 (null) < positive with leading zero limb
+MPI compare #7 0 (null) < positive with leading zero limb
 mbedtls_mpi_cmp_mpi:"":"0000000000000000123":-1
 
-MPI compare #6 0 (null) > negative with leading zero limb
+MPI compare #8 0 (null) > negative with leading zero limb
 mbedtls_mpi_cmp_mpi:"":"-0000000000000000123":1
 
-MPI compare #7 0 (null) < large positive
+MPI compare #9 0 (null) < large positive
 mbedtls_mpi_cmp_mpi:"":"1230000000000000000":-1
 
-MPI compare #8 0 (null) > large negative
+MPI compare #10 0 (null) > large negative
 mbedtls_mpi_cmp_mpi:"":"-1230000000000000000":1
 
-MPI compare #9 0 (1 limb) == 0 (null)
+MPI compare #11 0 (1 limb) == 0 (null)
 mbedtls_mpi_cmp_mpi:"0":"":0
 
-MPI compare #10 0 (1 limb) == 0 (1 limb)
+MPI compare #12 0 (1 limb) == 0 (1 limb)
 mbedtls_mpi_cmp_mpi:"0":"0":0
 
-MPI compare #11 0 (1 limb) < positive
+MPI compare #13 0 (1 limb) == negative 0 (null)
+mbedtls_mpi_cmp_mpi:"0":"-":0
+
+MPI compare #14 0 (1 limb) == negative with leading zero limb
+mbedtls_mpi_cmp_mpi:"0":"-0":0
+
+MPI compare #15 0 (1 limb) < positive
 mbedtls_mpi_cmp_mpi:"0":"7b":-1
 
-MPI compare #12 0 (1 limb) > negative
+MPI compare #16 0 (1 limb) > negative
 mbedtls_mpi_cmp_mpi:"0":"-7b":1
 
-MPI compare #13 0 (1 limb) < positive with leading zero limb
+MPI compare #17 0 (1 limb) < positive with leading zero limb
 mbedtls_mpi_cmp_mpi:"0":"0000000000000000123":-1
 
-MPI compare #14 0 (1 limb) > negative with leading zero limb
+MPI compare #18 0 (1 limb) > negative with leading zero limb
 mbedtls_mpi_cmp_mpi:"0":"-0000000000000000123":1
 
-MPI compare #15 0 (1 limb) < large positive
+MPI compare #19 0 (1 limb) < large positive
 mbedtls_mpi_cmp_mpi:"0":"1230000000000000000":-1
 
-MPI compare #16 0 (1 limb) > large negative
+MPI compare #20 0 (1 limb) > large negative
 mbedtls_mpi_cmp_mpi:"0":"-1230000000000000000":1
 
-MPI compare #17 positive > 0 (null)
+MPI compare #21 negative 0 (null) == 0 (null)
+mbedtls_mpi_cmp_mpi:"-":"":0
+
+MPI compare #22 negative 0 (null) == 0 (1 limb)
+mbedtls_mpi_cmp_mpi:"-":"0":0
+
+MPI compare #23 negative 0 (null) == negative 0 (null)
+mbedtls_mpi_cmp_mpi:"-":"-":0
+
+MPI compare #24 negative 0 (null) == negative with leading zero limb
+mbedtls_mpi_cmp_mpi:"-":"-0":0
+
+MPI compare #25 negative 0 (null) < positive
+mbedtls_mpi_cmp_mpi:"-":"7b":-1
+
+MPI compare #26 negative 0 (null) > negative
+mbedtls_mpi_cmp_mpi:"-":"-7b":1
+
+MPI compare #27 negative 0 (null) < positive with leading zero limb
+mbedtls_mpi_cmp_mpi:"-":"0000000000000000123":-1
+
+MPI compare #28 negative 0 (null) > negative with leading zero limb
+mbedtls_mpi_cmp_mpi:"-":"-0000000000000000123":1
+
+MPI compare #29 negative 0 (null) < large positive
+mbedtls_mpi_cmp_mpi:"-":"1230000000000000000":-1
+
+MPI compare #30 negative 0 (null) > large negative
+mbedtls_mpi_cmp_mpi:"-":"-1230000000000000000":1
+
+MPI compare #31 negative with leading zero limb == 0 (null)
+mbedtls_mpi_cmp_mpi:"-0":"":0
+
+MPI compare #32 negative with leading zero limb == 0 (1 limb)
+mbedtls_mpi_cmp_mpi:"-0":"0":0
+
+MPI compare #33 negative with leading zero limb == negative 0 (null)
+mbedtls_mpi_cmp_mpi:"-0":"-":0
+
+MPI compare #34 negative with leading zero limb == negative with leading zero limb
+mbedtls_mpi_cmp_mpi:"-0":"-0":0
+
+MPI compare #35 negative with leading zero limb < positive
+mbedtls_mpi_cmp_mpi:"-0":"7b":-1
+
+MPI compare #36 negative with leading zero limb > negative
+mbedtls_mpi_cmp_mpi:"-0":"-7b":1
+
+MPI compare #37 negative with leading zero limb < positive with leading zero limb
+mbedtls_mpi_cmp_mpi:"-0":"0000000000000000123":-1
+
+MPI compare #38 negative with leading zero limb > negative with leading zero limb
+mbedtls_mpi_cmp_mpi:"-0":"-0000000000000000123":1
+
+MPI compare #39 negative with leading zero limb < large positive
+mbedtls_mpi_cmp_mpi:"-0":"1230000000000000000":-1
+
+MPI compare #40 negative with leading zero limb > large negative
+mbedtls_mpi_cmp_mpi:"-0":"-1230000000000000000":1
+
+MPI compare #41 positive > 0 (null)
 mbedtls_mpi_cmp_mpi:"7b":"":1
 
-MPI compare #18 positive > 0 (1 limb)
+MPI compare #42 positive > 0 (1 limb)
 mbedtls_mpi_cmp_mpi:"7b":"0":1
 
-MPI compare #19 positive == positive
+MPI compare #43 positive > negative 0 (null)
+mbedtls_mpi_cmp_mpi:"7b":"-":1
+
+MPI compare #44 positive > negative with leading zero limb
+mbedtls_mpi_cmp_mpi:"7b":"-0":1
+
+MPI compare #45 positive == positive
 mbedtls_mpi_cmp_mpi:"7b":"7b":0
 
-MPI compare #20 positive > negative
+MPI compare #46 positive > negative
 mbedtls_mpi_cmp_mpi:"7b":"-7b":1
 
-MPI compare #21 positive < positive with leading zero limb
+MPI compare #47 positive < positive with leading zero limb
 mbedtls_mpi_cmp_mpi:"7b":"0000000000000000123":-1
 
-MPI compare #22 positive > negative with leading zero limb
+MPI compare #48 positive > negative with leading zero limb
 mbedtls_mpi_cmp_mpi:"7b":"-0000000000000000123":1
 
-MPI compare #23 positive < large positive
+MPI compare #49 positive < large positive
 mbedtls_mpi_cmp_mpi:"7b":"1230000000000000000":-1
 
-MPI compare #24 positive > large negative
+MPI compare #50 positive > large negative
 mbedtls_mpi_cmp_mpi:"7b":"-1230000000000000000":1
 
-MPI compare #25 negative < 0 (null)
+MPI compare #51 negative < 0 (null)
 mbedtls_mpi_cmp_mpi:"-7b":"":-1
 
-MPI compare #26 negative < 0 (1 limb)
+MPI compare #52 negative < 0 (1 limb)
 mbedtls_mpi_cmp_mpi:"-7b":"0":-1
 
-MPI compare #27 negative < positive
+MPI compare #53 negative < negative 0 (null)
+mbedtls_mpi_cmp_mpi:"-7b":"-":-1
+
+MPI compare #54 negative < negative with leading zero limb
+mbedtls_mpi_cmp_mpi:"-7b":"-0":-1
+
+MPI compare #55 negative < positive
 mbedtls_mpi_cmp_mpi:"-7b":"7b":-1
 
-MPI compare #28 negative == negative
+MPI compare #56 negative == negative
 mbedtls_mpi_cmp_mpi:"-7b":"-7b":0
 
-MPI compare #29 negative < positive with leading zero limb
+MPI compare #57 negative < positive with leading zero limb
 mbedtls_mpi_cmp_mpi:"-7b":"0000000000000000123":-1
 
-MPI compare #30 negative > negative with leading zero limb
+MPI compare #58 negative > negative with leading zero limb
 mbedtls_mpi_cmp_mpi:"-7b":"-0000000000000000123":1
 
-MPI compare #31 negative < large positive
+MPI compare #59 negative < large positive
 mbedtls_mpi_cmp_mpi:"-7b":"1230000000000000000":-1
 
-MPI compare #32 negative > large negative
+MPI compare #60 negative > large negative
 mbedtls_mpi_cmp_mpi:"-7b":"-1230000000000000000":1
 
-MPI compare #33 positive with leading zero limb > 0 (null)
+MPI compare #61 positive with leading zero limb > 0 (null)
 mbedtls_mpi_cmp_mpi:"0000000000000000123":"":1
 
-MPI compare #34 positive with leading zero limb > 0 (1 limb)
+MPI compare #62 positive with leading zero limb > 0 (1 limb)
 mbedtls_mpi_cmp_mpi:"0000000000000000123":"0":1
 
-MPI compare #35 positive with leading zero limb > positive
+MPI compare #63 positive with leading zero limb > negative 0 (null)
+mbedtls_mpi_cmp_mpi:"0000000000000000123":"-":1
+
+MPI compare #64 positive with leading zero limb > negative with leading zero limb
+mbedtls_mpi_cmp_mpi:"0000000000000000123":"-0":1
+
+MPI compare #65 positive with leading zero limb > positive
 mbedtls_mpi_cmp_mpi:"0000000000000000123":"7b":1
 
-MPI compare #36 positive with leading zero limb > negative
+MPI compare #66 positive with leading zero limb > negative
 mbedtls_mpi_cmp_mpi:"0000000000000000123":"-7b":1
 
-MPI compare #37 positive with leading zero limb == positive with leading zero limb
+MPI compare #67 positive with leading zero limb == positive with leading zero limb
 mbedtls_mpi_cmp_mpi:"0000000000000000123":"0000000000000000123":0
 
-MPI compare #38 positive with leading zero limb > negative with leading zero limb
+MPI compare #68 positive with leading zero limb > negative with leading zero limb
 mbedtls_mpi_cmp_mpi:"0000000000000000123":"-0000000000000000123":1
 
-MPI compare #39 positive with leading zero limb < large positive
+MPI compare #69 positive with leading zero limb < large positive
 mbedtls_mpi_cmp_mpi:"0000000000000000123":"1230000000000000000":-1
 
-MPI compare #40 positive with leading zero limb > large negative
+MPI compare #70 positive with leading zero limb > large negative
 mbedtls_mpi_cmp_mpi:"0000000000000000123":"-1230000000000000000":1
 
-MPI compare #41 negative with leading zero limb < 0 (null)
+MPI compare #71 negative with leading zero limb < 0 (null)
 mbedtls_mpi_cmp_mpi:"-0000000000000000123":"":-1
 
-MPI compare #42 negative with leading zero limb < 0 (1 limb)
+MPI compare #72 negative with leading zero limb < 0 (1 limb)
 mbedtls_mpi_cmp_mpi:"-0000000000000000123":"0":-1
 
-MPI compare #43 negative with leading zero limb < positive
+MPI compare #73 negative with leading zero limb < negative 0 (null)
+mbedtls_mpi_cmp_mpi:"-0000000000000000123":"-":-1
+
+MPI compare #74 negative with leading zero limb < negative with leading zero limb
+mbedtls_mpi_cmp_mpi:"-0000000000000000123":"-0":-1
+
+MPI compare #75 negative with leading zero limb < positive
 mbedtls_mpi_cmp_mpi:"-0000000000000000123":"7b":-1
 
-MPI compare #44 negative with leading zero limb < negative
+MPI compare #76 negative with leading zero limb < negative
 mbedtls_mpi_cmp_mpi:"-0000000000000000123":"-7b":-1
 
-MPI compare #45 negative with leading zero limb < positive with leading zero limb
+MPI compare #77 negative with leading zero limb < positive with leading zero limb
 mbedtls_mpi_cmp_mpi:"-0000000000000000123":"0000000000000000123":-1
 
-MPI compare #46 negative with leading zero limb == negative with leading zero limb
+MPI compare #78 negative with leading zero limb == negative with leading zero limb
 mbedtls_mpi_cmp_mpi:"-0000000000000000123":"-0000000000000000123":0
 
-MPI compare #47 negative with leading zero limb < large positive
+MPI compare #79 negative with leading zero limb < large positive
 mbedtls_mpi_cmp_mpi:"-0000000000000000123":"1230000000000000000":-1
 
-MPI compare #48 negative with leading zero limb > large negative
+MPI compare #80 negative with leading zero limb > large negative
 mbedtls_mpi_cmp_mpi:"-0000000000000000123":"-1230000000000000000":1
 
-MPI compare #49 large positive > 0 (null)
+MPI compare #81 large positive > 0 (null)
 mbedtls_mpi_cmp_mpi:"1230000000000000000":"":1
 
-MPI compare #50 large positive > 0 (1 limb)
+MPI compare #82 large positive > 0 (1 limb)
 mbedtls_mpi_cmp_mpi:"1230000000000000000":"0":1
 
-MPI compare #51 large positive > positive
+MPI compare #83 large positive > negative 0 (null)
+mbedtls_mpi_cmp_mpi:"1230000000000000000":"-":1
+
+MPI compare #84 large positive > negative with leading zero limb
+mbedtls_mpi_cmp_mpi:"1230000000000000000":"-0":1
+
+MPI compare #85 large positive > positive
 mbedtls_mpi_cmp_mpi:"1230000000000000000":"7b":1
 
-MPI compare #52 large positive > negative
+MPI compare #86 large positive > negative
 mbedtls_mpi_cmp_mpi:"1230000000000000000":"-7b":1
 
-MPI compare #53 large positive > positive with leading zero limb
+MPI compare #87 large positive > positive with leading zero limb
 mbedtls_mpi_cmp_mpi:"1230000000000000000":"0000000000000000123":1
 
-MPI compare #54 large positive > negative with leading zero limb
+MPI compare #88 large positive > negative with leading zero limb
 mbedtls_mpi_cmp_mpi:"1230000000000000000":"-0000000000000000123":1
 
-MPI compare #55 large positive == large positive
+MPI compare #89 large positive == large positive
 mbedtls_mpi_cmp_mpi:"1230000000000000000":"1230000000000000000":0
 
-MPI compare #56 large positive > large negative
+MPI compare #90 large positive > large negative
 mbedtls_mpi_cmp_mpi:"1230000000000000000":"-1230000000000000000":1
 
-MPI compare #57 large negative < 0 (null)
+MPI compare #91 large negative < 0 (null)
 mbedtls_mpi_cmp_mpi:"-1230000000000000000":"":-1
 
-MPI compare #58 large negative < 0 (1 limb)
+MPI compare #92 large negative < 0 (1 limb)
 mbedtls_mpi_cmp_mpi:"-1230000000000000000":"0":-1
 
-MPI compare #59 large negative < positive
+MPI compare #93 large negative < negative 0 (null)
+mbedtls_mpi_cmp_mpi:"-1230000000000000000":"-":-1
+
+MPI compare #94 large negative < negative with leading zero limb
+mbedtls_mpi_cmp_mpi:"-1230000000000000000":"-0":-1
+
+MPI compare #95 large negative < positive
 mbedtls_mpi_cmp_mpi:"-1230000000000000000":"7b":-1
 
-MPI compare #60 large negative < negative
+MPI compare #96 large negative < negative
 mbedtls_mpi_cmp_mpi:"-1230000000000000000":"-7b":-1
 
-MPI compare #61 large negative < positive with leading zero limb
+MPI compare #97 large negative < positive with leading zero limb
 mbedtls_mpi_cmp_mpi:"-1230000000000000000":"0000000000000000123":-1
 
-MPI compare #62 large negative < negative with leading zero limb
+MPI compare #98 large negative < negative with leading zero limb
 mbedtls_mpi_cmp_mpi:"-1230000000000000000":"-0000000000000000123":-1
 
-MPI compare #63 large negative < large positive
+MPI compare #99 large negative < large positive
 mbedtls_mpi_cmp_mpi:"-1230000000000000000":"1230000000000000000":-1
 
-MPI compare #64 large negative == large negative
+MPI compare #100 large negative == large negative
 mbedtls_mpi_cmp_mpi:"-1230000000000000000":"-1230000000000000000":0
 
-MPI compare #65 negative > negative
+MPI compare #101 negative > negative
 mbedtls_mpi_cmp_mpi:"-2":"-3":1
 
-MPI compare #66 negative == negative
+MPI compare #102 negative == negative
 mbedtls_mpi_cmp_mpi:"-2":"-2":0
 
-MPI compare #67 positive < positive
+MPI compare #103 positive < positive
 mbedtls_mpi_cmp_mpi:"2b4":"2b5":-1
 
-MPI compare #68 positive < positive
+MPI compare #104 positive < positive
 mbedtls_mpi_cmp_mpi:"2b5":"2b6":-1
 
 MPI compare (abs) #1 0 (null) == 0 (null)
@@ -450,202 +666,310 @@ mbedtls_mpi_cmp_abs:"":"":0
 MPI compare (abs) #2 0 (null) == 0 (1 limb)
 mbedtls_mpi_cmp_abs:"":"0":0
 
-MPI compare (abs) #3 0 (null) < positive
+MPI compare (abs) #3 0 (null) == 0 (null)
+mbedtls_mpi_cmp_abs:"":"":0
+
+MPI compare (abs) #4 0 (null) == 0 (1 limb)
+mbedtls_mpi_cmp_abs:"":"0":0
+
+MPI compare (abs) #5 0 (null) < positive
 mbedtls_mpi_cmp_abs:"":"7b":-1
 
-MPI compare (abs) #4 0 (null) < positive
+MPI compare (abs) #6 0 (null) < positive
 mbedtls_mpi_cmp_abs:"":"7b":-1
 
-MPI compare (abs) #5 0 (null) < positive with leading zero limb
+MPI compare (abs) #7 0 (null) < positive with leading zero limb
 mbedtls_mpi_cmp_abs:"":"0000000000000000123":-1
 
-MPI compare (abs) #6 0 (null) < positive with leading zero limb
+MPI compare (abs) #8 0 (null) < positive with leading zero limb
 mbedtls_mpi_cmp_abs:"":"0000000000000000123":-1
 
-MPI compare (abs) #7 0 (null) < large positive
+MPI compare (abs) #9 0 (null) < large positive
 mbedtls_mpi_cmp_abs:"":"1230000000000000000":-1
 
-MPI compare (abs) #8 0 (null) < large positive
+MPI compare (abs) #10 0 (null) < large positive
 mbedtls_mpi_cmp_abs:"":"1230000000000000000":-1
 
-MPI compare (abs) #9 0 (1 limb) == 0 (null)
+MPI compare (abs) #11 0 (1 limb) == 0 (null)
 mbedtls_mpi_cmp_abs:"0":"":0
 
-MPI compare (abs) #10 0 (1 limb) == 0 (1 limb)
+MPI compare (abs) #12 0 (1 limb) == 0 (1 limb)
 mbedtls_mpi_cmp_abs:"0":"0":0
 
-MPI compare (abs) #11 0 (1 limb) < positive
+MPI compare (abs) #13 0 (1 limb) == 0 (null)
+mbedtls_mpi_cmp_abs:"0":"":0
+
+MPI compare (abs) #14 0 (1 limb) == 0 (1 limb)
+mbedtls_mpi_cmp_abs:"0":"0":0
+
+MPI compare (abs) #15 0 (1 limb) < positive
 mbedtls_mpi_cmp_abs:"0":"7b":-1
 
-MPI compare (abs) #12 0 (1 limb) < positive
+MPI compare (abs) #16 0 (1 limb) < positive
 mbedtls_mpi_cmp_abs:"0":"7b":-1
 
-MPI compare (abs) #13 0 (1 limb) < positive with leading zero limb
+MPI compare (abs) #17 0 (1 limb) < positive with leading zero limb
 mbedtls_mpi_cmp_abs:"0":"0000000000000000123":-1
 
-MPI compare (abs) #14 0 (1 limb) < positive with leading zero limb
+MPI compare (abs) #18 0 (1 limb) < positive with leading zero limb
 mbedtls_mpi_cmp_abs:"0":"0000000000000000123":-1
 
-MPI compare (abs) #15 0 (1 limb) < large positive
+MPI compare (abs) #19 0 (1 limb) < large positive
 mbedtls_mpi_cmp_abs:"0":"1230000000000000000":-1
 
-MPI compare (abs) #16 0 (1 limb) < large positive
+MPI compare (abs) #20 0 (1 limb) < large positive
 mbedtls_mpi_cmp_abs:"0":"1230000000000000000":-1
 
-MPI compare (abs) #17 positive > 0 (null)
+MPI compare (abs) #21 0 (null) == 0 (null)
+mbedtls_mpi_cmp_abs:"":"":0
+
+MPI compare (abs) #22 0 (null) == 0 (1 limb)
+mbedtls_mpi_cmp_abs:"":"0":0
+
+MPI compare (abs) #23 0 (null) == 0 (null)
+mbedtls_mpi_cmp_abs:"":"":0
+
+MPI compare (abs) #24 0 (null) == 0 (1 limb)
+mbedtls_mpi_cmp_abs:"":"0":0
+
+MPI compare (abs) #25 0 (null) < positive
+mbedtls_mpi_cmp_abs:"":"7b":-1
+
+MPI compare (abs) #26 0 (null) < positive
+mbedtls_mpi_cmp_abs:"":"7b":-1
+
+MPI compare (abs) #27 0 (null) < positive with leading zero limb
+mbedtls_mpi_cmp_abs:"":"0000000000000000123":-1
+
+MPI compare (abs) #28 0 (null) < positive with leading zero limb
+mbedtls_mpi_cmp_abs:"":"0000000000000000123":-1
+
+MPI compare (abs) #29 0 (null) < large positive
+mbedtls_mpi_cmp_abs:"":"1230000000000000000":-1
+
+MPI compare (abs) #30 0 (null) < large positive
+mbedtls_mpi_cmp_abs:"":"1230000000000000000":-1
+
+MPI compare (abs) #31 0 (1 limb) == 0 (null)
+mbedtls_mpi_cmp_abs:"0":"":0
+
+MPI compare (abs) #32 0 (1 limb) == 0 (1 limb)
+mbedtls_mpi_cmp_abs:"0":"0":0
+
+MPI compare (abs) #33 0 (1 limb) == 0 (null)
+mbedtls_mpi_cmp_abs:"0":"":0
+
+MPI compare (abs) #34 0 (1 limb) == 0 (1 limb)
+mbedtls_mpi_cmp_abs:"0":"0":0
+
+MPI compare (abs) #35 0 (1 limb) < positive
+mbedtls_mpi_cmp_abs:"0":"7b":-1
+
+MPI compare (abs) #36 0 (1 limb) < positive
+mbedtls_mpi_cmp_abs:"0":"7b":-1
+
+MPI compare (abs) #37 0 (1 limb) < positive with leading zero limb
+mbedtls_mpi_cmp_abs:"0":"0000000000000000123":-1
+
+MPI compare (abs) #38 0 (1 limb) < positive with leading zero limb
+mbedtls_mpi_cmp_abs:"0":"0000000000000000123":-1
+
+MPI compare (abs) #39 0 (1 limb) < large positive
+mbedtls_mpi_cmp_abs:"0":"1230000000000000000":-1
+
+MPI compare (abs) #40 0 (1 limb) < large positive
+mbedtls_mpi_cmp_abs:"0":"1230000000000000000":-1
+
+MPI compare (abs) #41 positive > 0 (null)
 mbedtls_mpi_cmp_abs:"7b":"":1
 
-MPI compare (abs) #18 positive > 0 (1 limb)
+MPI compare (abs) #42 positive > 0 (1 limb)
 mbedtls_mpi_cmp_abs:"7b":"0":1
 
-MPI compare (abs) #19 positive == positive
-mbedtls_mpi_cmp_abs:"7b":"7b":0
-
-MPI compare (abs) #20 positive == positive
-mbedtls_mpi_cmp_abs:"7b":"7b":0
-
-MPI compare (abs) #21 positive < positive with leading zero limb
-mbedtls_mpi_cmp_abs:"7b":"0000000000000000123":-1
-
-MPI compare (abs) #22 positive < positive with leading zero limb
-mbedtls_mpi_cmp_abs:"7b":"0000000000000000123":-1
-
-MPI compare (abs) #23 positive < large positive
-mbedtls_mpi_cmp_abs:"7b":"1230000000000000000":-1
-
-MPI compare (abs) #24 positive < large positive
-mbedtls_mpi_cmp_abs:"7b":"1230000000000000000":-1
-
-MPI compare (abs) #25 positive > 0 (null)
+MPI compare (abs) #43 positive > 0 (null)
 mbedtls_mpi_cmp_abs:"7b":"":1
 
-MPI compare (abs) #26 positive > 0 (1 limb)
+MPI compare (abs) #44 positive > 0 (1 limb)
 mbedtls_mpi_cmp_abs:"7b":"0":1
 
-MPI compare (abs) #27 positive == positive
+MPI compare (abs) #45 positive == positive
 mbedtls_mpi_cmp_abs:"7b":"7b":0
 
-MPI compare (abs) #28 positive == positive
+MPI compare (abs) #46 positive == positive
 mbedtls_mpi_cmp_abs:"7b":"7b":0
 
-MPI compare (abs) #29 positive < positive with leading zero limb
+MPI compare (abs) #47 positive < positive with leading zero limb
 mbedtls_mpi_cmp_abs:"7b":"0000000000000000123":-1
 
-MPI compare (abs) #30 positive < positive with leading zero limb
+MPI compare (abs) #48 positive < positive with leading zero limb
 mbedtls_mpi_cmp_abs:"7b":"0000000000000000123":-1
 
-MPI compare (abs) #31 positive < large positive
+MPI compare (abs) #49 positive < large positive
 mbedtls_mpi_cmp_abs:"7b":"1230000000000000000":-1
 
-MPI compare (abs) #32 positive < large positive
+MPI compare (abs) #50 positive < large positive
 mbedtls_mpi_cmp_abs:"7b":"1230000000000000000":-1
 
-MPI compare (abs) #33 positive with leading zero limb > 0 (null)
+MPI compare (abs) #51 positive > 0 (null)
+mbedtls_mpi_cmp_abs:"7b":"":1
+
+MPI compare (abs) #52 positive > 0 (1 limb)
+mbedtls_mpi_cmp_abs:"7b":"0":1
+
+MPI compare (abs) #53 positive > 0 (null)
+mbedtls_mpi_cmp_abs:"7b":"":1
+
+MPI compare (abs) #54 positive > 0 (1 limb)
+mbedtls_mpi_cmp_abs:"7b":"0":1
+
+MPI compare (abs) #55 positive == positive
+mbedtls_mpi_cmp_abs:"7b":"7b":0
+
+MPI compare (abs) #56 positive == positive
+mbedtls_mpi_cmp_abs:"7b":"7b":0
+
+MPI compare (abs) #57 positive < positive with leading zero limb
+mbedtls_mpi_cmp_abs:"7b":"0000000000000000123":-1
+
+MPI compare (abs) #58 positive < positive with leading zero limb
+mbedtls_mpi_cmp_abs:"7b":"0000000000000000123":-1
+
+MPI compare (abs) #59 positive < large positive
+mbedtls_mpi_cmp_abs:"7b":"1230000000000000000":-1
+
+MPI compare (abs) #60 positive < large positive
+mbedtls_mpi_cmp_abs:"7b":"1230000000000000000":-1
+
+MPI compare (abs) #61 positive with leading zero limb > 0 (null)
 mbedtls_mpi_cmp_abs:"0000000000000000123":"":1
 
-MPI compare (abs) #34 positive with leading zero limb > 0 (1 limb)
+MPI compare (abs) #62 positive with leading zero limb > 0 (1 limb)
 mbedtls_mpi_cmp_abs:"0000000000000000123":"0":1
 
-MPI compare (abs) #35 positive with leading zero limb > positive
-mbedtls_mpi_cmp_abs:"0000000000000000123":"7b":1
-
-MPI compare (abs) #36 positive with leading zero limb > positive
-mbedtls_mpi_cmp_abs:"0000000000000000123":"7b":1
-
-MPI compare (abs) #37 positive with leading zero limb == positive with leading zero limb
-mbedtls_mpi_cmp_abs:"0000000000000000123":"0000000000000000123":0
-
-MPI compare (abs) #38 positive with leading zero limb == positive with leading zero limb
-mbedtls_mpi_cmp_abs:"0000000000000000123":"0000000000000000123":0
-
-MPI compare (abs) #39 positive with leading zero limb < large positive
-mbedtls_mpi_cmp_abs:"0000000000000000123":"1230000000000000000":-1
-
-MPI compare (abs) #40 positive with leading zero limb < large positive
-mbedtls_mpi_cmp_abs:"0000000000000000123":"1230000000000000000":-1
-
-MPI compare (abs) #41 positive with leading zero limb > 0 (null)
+MPI compare (abs) #63 positive with leading zero limb > 0 (null)
 mbedtls_mpi_cmp_abs:"0000000000000000123":"":1
 
-MPI compare (abs) #42 positive with leading zero limb > 0 (1 limb)
+MPI compare (abs) #64 positive with leading zero limb > 0 (1 limb)
 mbedtls_mpi_cmp_abs:"0000000000000000123":"0":1
 
-MPI compare (abs) #43 positive with leading zero limb > positive
+MPI compare (abs) #65 positive with leading zero limb > positive
 mbedtls_mpi_cmp_abs:"0000000000000000123":"7b":1
 
-MPI compare (abs) #44 positive with leading zero limb > positive
+MPI compare (abs) #66 positive with leading zero limb > positive
 mbedtls_mpi_cmp_abs:"0000000000000000123":"7b":1
 
-MPI compare (abs) #45 positive with leading zero limb == positive with leading zero limb
+MPI compare (abs) #67 positive with leading zero limb == positive with leading zero limb
 mbedtls_mpi_cmp_abs:"0000000000000000123":"0000000000000000123":0
 
-MPI compare (abs) #46 positive with leading zero limb == positive with leading zero limb
+MPI compare (abs) #68 positive with leading zero limb == positive with leading zero limb
 mbedtls_mpi_cmp_abs:"0000000000000000123":"0000000000000000123":0
 
-MPI compare (abs) #47 positive with leading zero limb < large positive
+MPI compare (abs) #69 positive with leading zero limb < large positive
 mbedtls_mpi_cmp_abs:"0000000000000000123":"1230000000000000000":-1
 
-MPI compare (abs) #48 positive with leading zero limb < large positive
+MPI compare (abs) #70 positive with leading zero limb < large positive
 mbedtls_mpi_cmp_abs:"0000000000000000123":"1230000000000000000":-1
 
-MPI compare (abs) #49 large positive > 0 (null)
+MPI compare (abs) #71 positive with leading zero limb > 0 (null)
+mbedtls_mpi_cmp_abs:"0000000000000000123":"":1
+
+MPI compare (abs) #72 positive with leading zero limb > 0 (1 limb)
+mbedtls_mpi_cmp_abs:"0000000000000000123":"0":1
+
+MPI compare (abs) #73 positive with leading zero limb > 0 (null)
+mbedtls_mpi_cmp_abs:"0000000000000000123":"":1
+
+MPI compare (abs) #74 positive with leading zero limb > 0 (1 limb)
+mbedtls_mpi_cmp_abs:"0000000000000000123":"0":1
+
+MPI compare (abs) #75 positive with leading zero limb > positive
+mbedtls_mpi_cmp_abs:"0000000000000000123":"7b":1
+
+MPI compare (abs) #76 positive with leading zero limb > positive
+mbedtls_mpi_cmp_abs:"0000000000000000123":"7b":1
+
+MPI compare (abs) #77 positive with leading zero limb == positive with leading zero limb
+mbedtls_mpi_cmp_abs:"0000000000000000123":"0000000000000000123":0
+
+MPI compare (abs) #78 positive with leading zero limb == positive with leading zero limb
+mbedtls_mpi_cmp_abs:"0000000000000000123":"0000000000000000123":0
+
+MPI compare (abs) #79 positive with leading zero limb < large positive
+mbedtls_mpi_cmp_abs:"0000000000000000123":"1230000000000000000":-1
+
+MPI compare (abs) #80 positive with leading zero limb < large positive
+mbedtls_mpi_cmp_abs:"0000000000000000123":"1230000000000000000":-1
+
+MPI compare (abs) #81 large positive > 0 (null)
 mbedtls_mpi_cmp_abs:"1230000000000000000":"":1
 
-MPI compare (abs) #50 large positive > 0 (1 limb)
+MPI compare (abs) #82 large positive > 0 (1 limb)
 mbedtls_mpi_cmp_abs:"1230000000000000000":"0":1
 
-MPI compare (abs) #51 large positive > positive
-mbedtls_mpi_cmp_abs:"1230000000000000000":"7b":1
-
-MPI compare (abs) #52 large positive > positive
-mbedtls_mpi_cmp_abs:"1230000000000000000":"7b":1
-
-MPI compare (abs) #53 large positive > positive with leading zero limb
-mbedtls_mpi_cmp_abs:"1230000000000000000":"0000000000000000123":1
-
-MPI compare (abs) #54 large positive > positive with leading zero limb
-mbedtls_mpi_cmp_abs:"1230000000000000000":"0000000000000000123":1
-
-MPI compare (abs) #55 large positive == large positive
-mbedtls_mpi_cmp_abs:"1230000000000000000":"1230000000000000000":0
-
-MPI compare (abs) #56 large positive == large positive
-mbedtls_mpi_cmp_abs:"1230000000000000000":"1230000000000000000":0
-
-MPI compare (abs) #57 large positive > 0 (null)
+MPI compare (abs) #83 large positive > 0 (null)
 mbedtls_mpi_cmp_abs:"1230000000000000000":"":1
 
-MPI compare (abs) #58 large positive > 0 (1 limb)
+MPI compare (abs) #84 large positive > 0 (1 limb)
 mbedtls_mpi_cmp_abs:"1230000000000000000":"0":1
 
-MPI compare (abs) #59 large positive > positive
+MPI compare (abs) #85 large positive > positive
 mbedtls_mpi_cmp_abs:"1230000000000000000":"7b":1
 
-MPI compare (abs) #60 large positive > positive
+MPI compare (abs) #86 large positive > positive
 mbedtls_mpi_cmp_abs:"1230000000000000000":"7b":1
 
-MPI compare (abs) #61 large positive > positive with leading zero limb
+MPI compare (abs) #87 large positive > positive with leading zero limb
 mbedtls_mpi_cmp_abs:"1230000000000000000":"0000000000000000123":1
 
-MPI compare (abs) #62 large positive > positive with leading zero limb
+MPI compare (abs) #88 large positive > positive with leading zero limb
 mbedtls_mpi_cmp_abs:"1230000000000000000":"0000000000000000123":1
 
-MPI compare (abs) #63 large positive == large positive
+MPI compare (abs) #89 large positive == large positive
 mbedtls_mpi_cmp_abs:"1230000000000000000":"1230000000000000000":0
 
-MPI compare (abs) #64 large positive == large positive
+MPI compare (abs) #90 large positive == large positive
 mbedtls_mpi_cmp_abs:"1230000000000000000":"1230000000000000000":0
 
-MPI compare (abs) #65 positive < positive
+MPI compare (abs) #91 large positive > 0 (null)
+mbedtls_mpi_cmp_abs:"1230000000000000000":"":1
+
+MPI compare (abs) #92 large positive > 0 (1 limb)
+mbedtls_mpi_cmp_abs:"1230000000000000000":"0":1
+
+MPI compare (abs) #93 large positive > 0 (null)
+mbedtls_mpi_cmp_abs:"1230000000000000000":"":1
+
+MPI compare (abs) #94 large positive > 0 (1 limb)
+mbedtls_mpi_cmp_abs:"1230000000000000000":"0":1
+
+MPI compare (abs) #95 large positive > positive
+mbedtls_mpi_cmp_abs:"1230000000000000000":"7b":1
+
+MPI compare (abs) #96 large positive > positive
+mbedtls_mpi_cmp_abs:"1230000000000000000":"7b":1
+
+MPI compare (abs) #97 large positive > positive with leading zero limb
+mbedtls_mpi_cmp_abs:"1230000000000000000":"0000000000000000123":1
+
+MPI compare (abs) #98 large positive > positive with leading zero limb
+mbedtls_mpi_cmp_abs:"1230000000000000000":"0000000000000000123":1
+
+MPI compare (abs) #99 large positive == large positive
+mbedtls_mpi_cmp_abs:"1230000000000000000":"1230000000000000000":0
+
+MPI compare (abs) #100 large positive == large positive
+mbedtls_mpi_cmp_abs:"1230000000000000000":"1230000000000000000":0
+
+MPI compare (abs) #101 positive < positive
 mbedtls_mpi_cmp_abs:"2":"3":-1
 
-MPI compare (abs) #66 positive == positive
+MPI compare (abs) #102 positive == positive
 mbedtls_mpi_cmp_abs:"2":"2":0
 
-MPI compare (abs) #67 positive < positive
+MPI compare (abs) #103 positive < positive
 mbedtls_mpi_cmp_abs:"2b4":"2b5":-1
 
-MPI compare (abs) #68 positive < positive
+MPI compare (abs) #104 positive < positive
 mbedtls_mpi_cmp_abs:"2b5":"2b6":-1
 
 # End of automatically generated file.

--- a/tests/suites/test_suite_bignum.misc.data
+++ b/tests/suites/test_suite_bignum.misc.data
@@ -1141,6 +1141,18 @@ mbedtls_mpi_div_mpi:"":"1":"":"":0
 Test mbedtls_mpi_div_mpi: 0 (null) / -1
 mbedtls_mpi_div_mpi:"":"-1":"":"":0
 
+Test mbedtls_mpi_div_mpi: -0 (null) / 1
+mbedtls_mpi_div_mpi:"-":"1":"":"":0
+
+Test mbedtls_mpi_div_mpi: -0 (null) / -1
+mbedtls_mpi_div_mpi:"-":"-1":"":"":0
+
+Test mbedtls_mpi_div_mpi: -0 (null) / 42
+mbedtls_mpi_div_mpi:"-":"2a":"":"":0
+
+Test mbedtls_mpi_div_mpi: -0 (null) / -42
+mbedtls_mpi_div_mpi:"-":"-2a":"":"":0
+
 Test mbedtls_mpi_div_mpi #1
 mbedtls_mpi_div_mpi:"9e22d6da18a33d1ef28d2a82242b3f6e9c9742f63e5d440f58a190bfaf23a7866e67589adb80":"22":"4a6abf75b13dc268ea9cc8b5b6aaf0ac85ecd437a4e0987fb13cf8d2acc57c0306c738c1583":"1a":0
 
@@ -1200,6 +1212,18 @@ mbedtls_mpi_mod_mpi:"":"1":"":0
 
 Test mbedtls_mpi_mod_mpi: 0 (null) % -1
 mbedtls_mpi_mod_mpi:"":"-1":"":MBEDTLS_ERR_MPI_NEGATIVE_VALUE
+
+Test mbedtls_mpi_mod_mpi: -0 (null) % 1
+mbedtls_mpi_mod_mpi:"-":"1":"":0
+
+Test mbedtls_mpi_mod_mpi: -0 (null) % -1
+mbedtls_mpi_mod_mpi:"-":"-1":"":MBEDTLS_ERR_MPI_NEGATIVE_VALUE
+
+Test mbedtls_mpi_mod_mpi: -0 (null) % 42
+mbedtls_mpi_mod_mpi:"-":"2a":"":0
+
+Test mbedtls_mpi_mod_mpi: -0 (null) % -42
+mbedtls_mpi_mod_mpi:"-":"-2a":"":MBEDTLS_ERR_MPI_NEGATIVE_VALUE
 
 Base test mbedtls_mpi_mod_int #1
 mbedtls_mpi_mod_int:"3e8":13:12:0


### PR DESCRIPTION
In the bignum module, operations of the form (-A) - (+A) or (-A) - (-A) with A > 0 created a "negative zero" representation of the value 0. Fix this.

The negative zero was processed correctly (i.e. as if it was a valid representation of 0) by most bignum operations (in particular all variants of add, sub, mul and div, as well as `mbedtls_mpi_mod_mpi`), but not all (`mbedtls_mpi_mod_int` outputs b instead of 0 for (-X) % b when X is a multiple of b, and `mbedtls_mpi_lt_mpi_ct` treats -0 as strictly less than +0). This bug had no consequence on cryptography code.

This is the 2.28 backport. I did it before the `development` version because in `development`, this may clash with the bignum refactoring.

Contents:

* Fix the bug.
* In bignum test case generation for binary operations, test both x op y and y op x. We previously refrained from doing that because it would have triggered this bug. This way we get a non-regression test.
* Start testing functions with a negative zero input. We don't guarantee that everything will work, but since we have a history of bugs, it's better to be robust. If there's an exception we don't want to handle (for example `mbedtls_mpi_lt_mpi_ct` would be annoying), we can add an exception when we get around to generating test cases for it.

## Gatekeeper checklist

- [x] **changelog** provided
- [x] **backport** (done before the main PR)
- [x] **tests** provided
