### PR TITLE
[Backport 2.28] dh_genprime: Fix issue where the error code returned by mbedtls_mpi_write_file() is incorrectly reported on failure

### DIFF
--- a/ChangeLog.d/fix_dh_genprime_error_reporting.txt
+++ b/ChangeLog.d/fix_dh_genprime_error_reporting.txt
@@ -1,0 +1,4 @@
+Bugfix
+   * Fix bug in error reporting in dh_genprime.c where upon failure,
+     the error code returned by mbedtls_mpi_write_file() is overwritten
+     and therefore not printed.

--- a/programs/pkey/dh_genprime.c
+++ b/programs/pkey/dh_genprime.c
@@ -161,8 +161,8 @@ int main( int argc, char **argv )
         goto exit;
     }
 
-    if( ( ret = mbedtls_mpi_write_file( "P = ", &P, 16, fout ) != 0 ) ||
-        ( ret = mbedtls_mpi_write_file( "G = ", &G, 16, fout ) != 0 ) )
+    if( ( ( ret = mbedtls_mpi_write_file( "P = ", &P, 16, fout ) ) != 0 ) ||
+        ( ( ret = mbedtls_mpi_write_file( "G = ", &G, 16, fout ) ) != 0 ) )
     {
         mbedtls_printf( " failed\n  ! mbedtls_mpi_write_file returned %d\n\n", ret );
         fclose( fout );


### PR DESCRIPTION
Backport of #6559 