### PR TITLE
mbedtls_mpi_div_mpi allow outputs to alias inputs

### DIFF
--- a/include/mbedtls/bignum.h
+++ b/include/mbedtls/bignum.h
@@ -758,10 +758,10 @@ int mbedtls_mpi_mul_int( mbedtls_mpi *X, const mbedtls_mpi *A,
  *
  * \param Q        The destination MPI for the quotient.
  *                 This may be \c NULL if the value of the
- *                 quotient is not needed. This must not alias A or B.
+ *                 quotient is not needed.
  * \param R        The destination MPI for the remainder value.
  *                 This may be \c NULL if the value of the
- *                 remainder is not needed. This must not alias A or B.
+ *                 remainder is not needed.
  * \param A        The dividend. This must point to an initialized MPI.
  * \param B        The divisor. This must point to an initialized MPI.
  *
@@ -779,10 +779,10 @@ int mbedtls_mpi_div_mpi( mbedtls_mpi *Q, mbedtls_mpi *R, const mbedtls_mpi *A,
  *
  * \param Q        The destination MPI for the quotient.
  *                 This may be \c NULL if the value of the
- *                 quotient is not needed.  This must not alias A.
+ *                 quotient is not needed.
  * \param R        The destination MPI for the remainder value.
  *                 This may be \c NULL if the value of the
- *                 remainder is not needed.  This must not alias A.
+ *                 remainder is not needed.
  * \param A        The dividend. This must point to an initialized MPi.
  * \param b        The divisor.
  *

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -1300,8 +1300,8 @@ int mbedtls_mpi_div_mpi( mbedtls_mpi *Q, mbedtls_mpi *R, const mbedtls_mpi *A,
 
     if( mbedtls_mpi_cmp_abs( A, B ) < 0 )
     {
-        if( Q != NULL ) MBEDTLS_MPI_CHK( mbedtls_mpi_lset( Q, 0 ) );
         if( R != NULL ) MBEDTLS_MPI_CHK( mbedtls_mpi_copy( R, A ) );
+        if( Q != NULL ) MBEDTLS_MPI_CHK( mbedtls_mpi_lset( Q, 0 ) );
         return( 0 );
     }
 
@@ -1372,16 +1372,19 @@ int mbedtls_mpi_div_mpi( mbedtls_mpi *Q, mbedtls_mpi *R, const mbedtls_mpi *A,
         }
     }
 
+    T1.s = A->s; /* save sign value in case outputs alias inputs */
+
     if( Q != NULL )
     {
+        T2.s = B->s; /* save sign value in case outputs alias inputs */
         MBEDTLS_MPI_CHK( mbedtls_mpi_copy( Q, &Z ) );
-        Q->s = A->s * B->s;
+        Q->s = T1.s * T2.s;
     }
 
     if( R != NULL )
     {
         MBEDTLS_MPI_CHK( mbedtls_mpi_shift_r( &X, k ) );
-        X.s = A->s;
+        X.s = T1.s;
         MBEDTLS_MPI_CHK( mbedtls_mpi_copy( R, &X ) );
 
         if( mbedtls_mpi_cmp_int( R, 0 ) == 0 )

--- a/tests/suites/test_suite_bignum.function
+++ b/tests/suites/test_suite_bignum.function
@@ -906,6 +906,76 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE */
+void mpi_div_mpi_aliasing( int result )
+{
+    mbedtls_mpi Q, R, A, B, X;
+    mbedtls_mpi_init( &Q ); mbedtls_mpi_init( &R ); mbedtls_mpi_init( &A ); mbedtls_mpi_init( &B );
+    mbedtls_mpi_init( &X );
+    (void)result;
+
+    TEST_ASSERT( mbedtls_mpi_lset( &R, 2 ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_div_mpi( NULL, &R, &R, &R ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_lset( &X, 0 ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_cmp_mpi( &R, &X ) == 0 );
+
+    TEST_ASSERT( mbedtls_mpi_lset( &Q, 2 ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_div_mpi( &Q, NULL, &Q, &Q ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_lset( &X, 1 ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_cmp_mpi( &Q, &X ) == 0 );
+
+    TEST_ASSERT( mbedtls_mpi_lset( &R, 2 ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_div_mpi( &Q, &R, &R, &R ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_lset( &X, 0 ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_cmp_mpi( &R, &X ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_lset( &X, 1 ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_cmp_mpi( &Q, &X ) == 0 );
+
+    TEST_ASSERT( mbedtls_mpi_lset( &Q, 2 ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_div_mpi( &Q, &R, &Q, &Q ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_lset( &X, 1 ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_cmp_mpi( &Q, &X ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_lset( &X, 0 ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_cmp_mpi( &R, &X ) == 0 );
+
+    TEST_ASSERT( mbedtls_mpi_lset( &Q, 6 ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_lset( &R, 3 ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_div_mpi( &Q, &R, &Q, &R ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_lset( &X, 2 ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_cmp_mpi( &Q, &X ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_lset( &X, 0 ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_cmp_mpi( &R, &X ) == 0 );
+
+    TEST_ASSERT( mbedtls_mpi_lset( &R, 6 ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_lset( &Q, 3 ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_div_mpi( &Q, &R, &R, &Q ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_lset( &X, 2 ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_cmp_mpi( &Q, &X ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_lset( &X, 0 ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_cmp_mpi( &R, &X ) == 0 );
+
+    /* test specific implementation internals */
+    TEST_ASSERT( mbedtls_mpi_lset( &Q, 1 ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_lset( &B, 2 ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_div_mpi( &Q, &R, &Q, &B ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_lset( &X, 1 ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_cmp_mpi( &R, &X ) == 0 );
+
+    /* test specific implementation internals */
+    TEST_ASSERT( mbedtls_mpi_lset( &Q, 5 ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_lset( &B, -2 ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_div_mpi( &Q, &R, &Q, &B ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_lset( &X, -2 ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_cmp_mpi( &Q, &X ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_lset( &X, 1 ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_cmp_mpi( &R, &X ) == 0 );
+
+exit:
+    mbedtls_mpi_free( &Q ); mbedtls_mpi_free( &R ); mbedtls_mpi_free( &A ); mbedtls_mpi_free( &B );
+    mbedtls_mpi_free( &X );
+}
+/* END_CASE */
+
+/* BEGIN_CASE */
 void mpi_div_int( char * input_X, int input_Y,
                   char * input_A, char * input_B,
                   int div_result )

--- a/tests/suites/test_suite_bignum.misc.data
+++ b/tests/suites/test_suite_bignum.misc.data
@@ -1156,6 +1156,9 @@ mpi_div_mpi:"3e8":"7":"8e":"6":0
 Test mbedtls_mpi_div_mpi #4
 mpi_div_mpi:"309":"7":"6f":"0":0
 
+Test mbedtls_mpi_div_mpi output argument aliasing inputs
+mpi_div_mpi_aliasing:0
+
 Base test mbedtls_mpi_div_int #1
 mpi_div_int:"3e8":13:"4c":"c":0
 


### PR DESCRIPTION
mbedtls_mpi_div_mpi allow outputs to alias inputs

follow-up to [#6552](https://github.com/Mbed-TLS/mbedtls/pull/6552)

While it was previously possible to alias some outputs to inputs if one of the outputs was NULL, instead of documenting the exceptions, it is more useful to remove the aliasing restrictions.  It happens to turn out to be simple to remove the aliasing restrictions.

(The two outputs Q and R must still not alias one another.  It makes no sense to do so, anyway.)

## Gatekeeper checklist

- [ ] **changelog** provided, or not required
- [ ] **backport** done, or not required
- [ ] **tests** provided, or not required