### PR TITLE
Backport 2.28: check_names: extend typo check to PSA macro/enum names

### DIFF
--- a/include/psa/crypto.h
+++ b/include/psa/crypto.h
@@ -2861,7 +2861,7 @@ psa_status_t psa_aead_abort(psa_aead_operation_t *operation);
  *
  * \note To perform a multi-part hash-and-sign signature algorithm, first use
  *       a multi-part hash operation and then pass the resulting hash to
- *       psa_sign_hash(). PSA_ALG_GET_HASH(\p alg) can be used to determine the
+ *       psa_sign_hash(). PSA_ALG_SIGN_GET_HASH(\p alg) can be used to determine the
  *       hash algorithm to use.
  *
  * \param[in]  key              Identifier of the key to use for the operation.
@@ -2927,7 +2927,7 @@ psa_status_t psa_sign_message( mbedtls_svc_key_id_t key,
  * \note To perform a multi-part hash-and-sign signature verification
  *       algorithm, first use a multi-part hash operation to hash the message
  *       and then pass the resulting hash to psa_verify_hash().
- *       PSA_ALG_GET_HASH(\p alg) can be used to determine the hash algorithm
+ *       PSA_ALG_SIGN_GET_HASH(\p alg) can be used to determine the hash algorithm
  *       to use.
  *
  * \param[in]  key              Identifier of the key to use for the operation.

--- a/include/psa/crypto_values.h
+++ b/include/psa/crypto_values.h
@@ -1688,7 +1688,7 @@
 #define PSA_ALG_HKDF_BASE                       ((psa_algorithm_t)0x08000100)
 /** Macro to build an HKDF algorithm.
  *
- * For example, `PSA_ALG_HKDF(PSA_ALG_SHA256)` is HKDF using HMAC-SHA-256.
+ * For example, `PSA_ALG_HKDF(PSA_ALG_SHA_256)` is HKDF using HMAC-SHA-256.
  *
  * This key derivation algorithm uses the following inputs:
  * - #PSA_KEY_DERIVATION_INPUT_SALT is the salt used in the "extract" step.
@@ -1741,7 +1741,7 @@
  * concatenation of ServerHello.Random + ClientHello.Random,
  * and the label is "key expansion".
  *
- * For example, `PSA_ALG_TLS12_PRF(PSA_ALG_SHA256)` represents the
+ * For example, `PSA_ALG_TLS12_PRF(PSA_ALG_SHA_256)` represents the
  * TLS 1.2 PRF using HMAC-SHA-256.
  *
  * \param hash_alg      A hash algorithm (\c PSA_ALG_XXX value such that
@@ -1787,7 +1787,7 @@
  * ClientHello.Random + ServerHello.Random,
  * and the label is "master secret" or "extended master secret".
  *
- * For example, `PSA_ALG_TLS12_PSK_TO_MS(PSA_ALG_SHA256)` represents the
+ * For example, `PSA_ALG_TLS12_PSK_TO_MS(PSA_ALG_SHA_256)` represents the
  * TLS-1.2 PSK to MasterSecret derivation PRF using HMAC-SHA-256.
  *
  * \param hash_alg      A hash algorithm (\c PSA_ALG_XXX value such that

--- a/library/psa_crypto_aead.h
+++ b/library/psa_crypto_aead.h
@@ -148,4 +148,4 @@ psa_status_t mbedtls_psa_aead_decrypt(
     const uint8_t *ciphertext, size_t ciphertext_length,
     uint8_t *plaintext, size_t plaintext_size, size_t *plaintext_length );
 
-#endif /* PSA_CRYPTO_AEAD */
+#endif /* PSA_CRYPTO_AEAD_H */

--- a/library/psa_crypto_driver_wrappers.c
+++ b/library/psa_crypto_driver_wrappers.c
@@ -275,7 +275,7 @@ psa_status_t psa_driver_wrapper_sign_hash(
                     alg, hash, hash_length,
                     signature, signature_size, signature_length ) );
     }
-#endif /* PSA_CRYPTO_SE_C */
+#endif /* MBEDTLS_PSA_CRYPTO_SE_C */
 
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
     psa_key_location_t location =
@@ -359,7 +359,7 @@ psa_status_t psa_driver_wrapper_verify_hash(
                     alg, hash, hash_length,
                     signature, signature_length ) );
     }
-#endif /* PSA_CRYPTO_SE_C */
+#endif /* MBEDTLS_PSA_CRYPTO_SE_C */
 
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
     psa_key_location_t location =
@@ -579,7 +579,7 @@ psa_status_t psa_driver_wrapper_import_key(
 
         return( PSA_SUCCESS );
     }
-#endif /* PSA_CRYPTO_SE_C */
+#endif /* MBEDTLS_PSA_CRYPTO_SE_C */
 
     switch( location )
     {
@@ -641,7 +641,7 @@ psa_status_t psa_driver_wrapper_export_key(
                      *( (psa_key_slot_number_t *)key_buffer ),
                      data, data_size, data_length ) );
     }
-#endif /* PSA_CRYPTO_SE_C */
+#endif /* MBEDTLS_PSA_CRYPTO_SE_C */
 
     switch( location )
     {

--- a/library/psa_crypto_its.h
+++ b/library/psa_crypto_its.h
@@ -73,7 +73,7 @@ struct psa_storage_info_t
  * \return      A status indicating the success/failure of the operation
  *
  * \retval      #PSA_SUCCESS                     The operation completed successfully
- * \retval      #PSA_ERROR_NOT_PERMITTED         The operation failed because the provided `uid` value was already created with PSA_STORAGE_WRITE_ONCE_FLAG
+ * \retval      #PSA_ERROR_NOT_PERMITTED         The operation failed because the provided `uid` value was already created with PSA_STORAGE_FLAG_WRITE_ONCE
  * \retval      #PSA_ERROR_NOT_SUPPORTED         The operation failed because one or more of the flags provided in `create_flags` is not supported or is not valid
  * \retval      #PSA_ERROR_INSUFFICIENT_STORAGE  The operation failed because there was insufficient space on the storage medium
  * \retval      #PSA_ERROR_STORAGE_FAILURE       The operation failed because the physical storage has failed (Fatal error)
@@ -137,7 +137,7 @@ psa_status_t psa_its_get_info(psa_storage_uid_t uid,
  *
  * \retval      #PSA_SUCCESS                  The operation completed successfully
  * \retval      #PSA_ERROR_DOES_NOT_EXIST     The operation failed because the provided key value was not found in the storage
- * \retval      #PSA_ERROR_NOT_PERMITTED      The operation failed because the provided key value was created with PSA_STORAGE_WRITE_ONCE_FLAG
+ * \retval      #PSA_ERROR_NOT_PERMITTED      The operation failed because the provided key value was created with PSA_STORAGE_FLAG_WRITE_ONCE
  * \retval      #PSA_ERROR_STORAGE_FAILURE    The operation failed because the physical storage has failed (Fatal error)
  */
 psa_status_t psa_its_remove(psa_storage_uid_t uid);

--- a/tests/scripts/check_names.py
+++ b/tests/scripts/check_names.py
@@ -835,7 +835,8 @@ class NameChecker():
             self.parse_result["enum_consts"]
         }
         typo_exclusion = re.compile(r"XXX|__|_$|^MBEDTLS_.*CONFIG_FILE$|"
-                                    r"MBEDTLS_TEST_LIBTESTDRIVER*")
+                                    r"MBEDTLS_TEST_LIBTESTDRIVER*|"
+                                    r"PSA_CRYPTO_DRIVER_TEST")
 
         for name_match in self.parse_result["mbed_psa_words"]:
             found = name_match.name in all_caps_names


### PR DESCRIPTION
## Description
This PR is a backport of #6558 to branch mbedtls-2.28 which resolves the issue #6416.