### PR TITLE
Backport 2.28: Fix run-test-suites.pl in out-of-tree builds

### DIFF
--- a/tests/scripts/run-test-suites.pl
+++ b/tests/scripts/run-test-suites.pl
@@ -50,10 +50,10 @@ GetOptions(
            'verbose|v:1' => \$verbose,
           ) or die;
 
-# All test suites = executable files derived from a .data file.
+# All test suites = executable files with a .datax file.
 my @suites = ();
-for my $data_file (glob 'suites/test_suite_*.data') {
-    (my $base = $data_file) =~ s#^suites/(.*)\.data$#$1#;
+for my $data_file (glob 'test_suite_*.datax') {
+    (my $base = $data_file) =~ s/\.datax$//;
     push @suites, $base if -x $base;
     push @suites, "$base.exe" if -e "$base.exe";
 }


### PR DESCRIPTION
Trivial backport of https://github.com/Mbed-TLS/mbedtls/pull/6611

## Gatekeeper checklist

- [x] **changelog** N/A
- [x] **backport** of https://github.com/Mbed-TLS/mbedtls/pull/6611
- [x] **tests** N/A



## Notes for the submitter

Please refer to the [contributing guidelines](../CONTRIBUTING.md), especially the
checklist for PR contributors.

