### PR TITLE
Bignum Test Generation: Refactoring BigNumCommon

### DIFF
--- a/scripts/mbedtls_dev/bignum_common.py
+++ b/scripts/mbedtls_dev/bignum_common.py
@@ -185,6 +185,15 @@ class OperationCommonArchSplit(OperationCommon):
             raise ValueError("Invalid number of bits in limb!")
 
         self.dependencies = ["MBEDTLS_HAVE_INT{:d}".format(bits_in_limb)]
+
+    @classmethod
+    def get_bil_value_pairs(cls) -> Iterator[Tuple[str, str]]:
+    # Note: Instead of overriding get_value_pairs we invoke it and prefix it with the bil
+        yield from ( 
+            (a, b, c)
+            for a in cls.limb_sizes
+            for b, c in cls.get_value_pairs()
+        )
 # BEGIN MERGE SLOT 1
 
 # END MERGE SLOT 1

--- a/scripts/mbedtls_dev/bignum_common.py
+++ b/scripts/mbedtls_dev/bignum_common.py
@@ -85,12 +85,6 @@ class OperationCommon:
     unique_combinations_only = True
 
     def __init__(self, val_n: str, val_a: str, val_b: str = "0", bits_in_limb: int = 64) -> None:
-        super().__init__(val_a=val_a, val_b=val_b)
-        self.val_n = val_n
-        self.bits_in_limb = bits_in_limb
-
-
-    def __init__(self, val_n: str, val_a: str, val_b: str = "0", bits_in_limb: int = 64) -> None:
         self.val_n = val_n
         self.arg_a = val_a
         self.arg_b = val_b
@@ -189,7 +183,7 @@ class OperationCommonArchSplit(OperationCommon):
     @classmethod
     def get_bil_value_pairs(cls) -> Iterator[Tuple[str, str]]:
     # Note: Instead of overriding get_value_pairs we invoke it and prefix it with the bil
-        yield from ( 
+        yield from (
             (a, b, c)
             for a in cls.limb_sizes
             for b, c in cls.get_value_pairs()

--- a/scripts/mbedtls_dev/bignum_core.py
+++ b/scripts/mbedtls_dev/bignum_core.py
@@ -150,36 +150,43 @@ class BignumCoreOperation(bignum_common.OperationCommon, BignumCoreTarget, metac
             yield cls(a_value, b_value).create_test_case()
 
 
-class BignumCoreOperationArchSplit(BignumCoreOperation):
+class BignumCoreOperationArchSplit(bignum_common.OperationCommonArchSplit, BignumCoreTarget, metaclass=ABCMeta):
     #pylint: disable=abstract-method
     """Common features for bignum core operations where the result depends on
     the limb size."""
 
+    input_values = [
+        "0", "1", "3", "f", "fe", "ff", "100", "ff00", "fffe", "ffff", "10000",
+        "fffffffe", "ffffffff", "100000000", "1f7f7f7f7f7f7f",
+        "8000000000000000", "fefefefefefefefe", "fffffffffffffffe",
+        "ffffffffffffffff", "10000000000000000", "1234567890abcdef0",
+        "fffffffffffffffffefefefefefefefe", "fffffffffffffffffffffffffffffffe",
+        "ffffffffffffffffffffffffffffffff", "100000000000000000000000000000000",
+        "1234567890abcdef01234567890abcdef0",
+        "fffffffffffffffffffffffffffffffffffffffffffffffffefefefefefefefe",
+        "fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe",
+        "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "10000000000000000000000000000000000000000000000000000000000000000",
+        "1234567890abcdef01234567890abcdef01234567890abcdef01234567890abcdef0",
+        (
+            "4df72d07b4b71c8dacb6cffa954f8d88254b6277099308baf003fab73227f34029"
+            "643b5a263f66e0d3c3fa297ef71755efd53b8fb6cb812c6bbf7bcf179298bd9947"
+            "c4c8b14324140a2c0f5fad7958a69050a987a6096e9f055fb38edf0c5889eca4a0"
+            "cfa99b45fbdeee4c696b328ddceae4723945901ec025076b12b"
+        )
+    ]
+
+
     def __init__(self, val_a: str, val_b: str, bits_in_limb: int) -> None:
-        super().__init__(val_a, val_b)
-        bound_val = max(self.int_a, self.int_b)
-        self.bits_in_limb = bits_in_limb
-        self.bound = bignum_common.bound_mpi(bound_val, self.bits_in_limb)
-        limbs = bignum_common.limbs_mpi(bound_val, self.bits_in_limb)
-        byte_len = limbs * self.bits_in_limb // 8
-        self.hex_digits = 2 * byte_len
-        if self.bits_in_limb == 32:
-            self.dependencies = ["MBEDTLS_HAVE_INT32"]
-        elif self.bits_in_limb == 64:
-            self.dependencies = ["MBEDTLS_HAVE_INT64"]
-        else:
-            raise ValueError("Invalid number of bits in limb!")
-        self.arg_a = self.arg_a.zfill(self.hex_digits)
-        self.arg_b = self.arg_b.zfill(self.hex_digits)
+        super().__init__(val_n="0", val_a=val_a, val_b=val_b, bits_in_limb=bits_in_limb)
 
     def pad_to_limbs(self, val) -> str:
         return "{:x}".format(val).zfill(self.hex_digits)
 
     @classmethod
-    def generate_function_tests(cls) -> Iterator[test_case.TestCase]:
-        for a_value, b_value in cls.get_value_pairs():
-            yield cls(a_value, b_value, 32).create_test_case()
-            yield cls(a_value, b_value, 64).create_test_case()
+    def generate_function_tests(cls) -> Iterator[test_case.TestCase]:      
+        for bil, a_value, b_value in cls.get_bil_value_pairs():
+            yield cls(a_value, b_value, bil).create_test_case()
 
 class BignumCoreAddAndAddIf(BignumCoreOperationArchSplit):
     """Test cases for bignum core add and add-if."""
@@ -191,7 +198,8 @@ class BignumCoreAddAndAddIf(BignumCoreOperationArchSplit):
     def result(self) -> List[str]:
         result = self.int_a + self.int_b
 
-        carry, result = divmod(result, self.bound)
+        carry, result = divmod(result, self.r)
+        print("Result", )
 
         return [
             bignum_common.quote_str(self.pad_to_limbs(result)),

--- a/scripts/mbedtls_dev/bignum_core.py
+++ b/scripts/mbedtls_dev/bignum_core.py
@@ -74,6 +74,10 @@ class BignumCoreTarget(test_data_generation.BaseTarget, metaclass=ABCMeta):
             )
         return super().description()
 
+    def arguments(self) -> List[str]:
+        return [
+            bignum_common.quote_str(self.arg_a), bignum_common.quote_str(self.arg_b)
+        ] + self.result()
 
 class BignumCoreShiftR(BignumCoreTarget, metaclass=ABCMeta):
     """Test cases for mbedtls_bignum_core_shift_r()."""
@@ -153,11 +157,9 @@ class BignumCoreCTLookup(BignumCoreTarget, metaclass=ABCMeta):
                 yield (cls(bitsize, bitsize_description, window_size)
                        .create_test_case())
 
-class BignumCoreOperation(bignum_common.OperationCommon, BignumCoreTarget, metaclass=ABCMeta):
+class BignumCoreOperation(BignumCoreTarget, bignum_common.OperationCommon, metaclass=ABCMeta):
     #pylint: disable=abstract-method
     """Common features for bignum core operations."""
-
-    input_values = input_values
 
     def description(self) -> str:
         """Generate a description for the test case.
@@ -178,12 +180,10 @@ class BignumCoreOperation(bignum_common.OperationCommon, BignumCoreTarget, metac
             yield cls(a_value, b_value).create_test_case()
 
 
-class BignumCoreOperationArchSplit(bignum_common.OperationCommonArchSplit, BignumCoreTarget, metaclass=ABCMeta):
+class BignumCoreOperationArchSplit(BignumCoreTarget, bignum_common.OperationCommonArchSplit, metaclass=ABCMeta):
     #pylint: disable=abstract-method
     """Common features for bignum core operations where the result depends on
     the limb size."""
-
-    input_values = input_values
 
     def __init__(self, val_a: str, val_b: str, bits_in_limb: int) -> None:
         super().__init__(val_n="0", val_a=val_a, val_b=val_b, bits_in_limb=bits_in_limb)

--- a/scripts/mbedtls_dev/bignum_core.py
+++ b/scripts/mbedtls_dev/bignum_core.py
@@ -23,10 +23,56 @@ from . import test_case
 from . import test_data_generation
 from . import bignum_common
 
+# Note: Setting the input values on a module level, allows access
+# from other modules such as
+# import bignum_core
+# core_values = bignum_core.input_values
+# or
+# from bignum_core import input_values as core_values
+# Ideally we should have a collection of input values for A and Modulo in
+#  bignum_common
+
+input_values = [
+    "0", "1", "3", "f", "fe", "ff", "100", "ff00", "fffe", "ffff", "10000",
+    "fffffffe", "ffffffff", "100000000", "1f7f7f7f7f7f7f",
+    "8000000000000000", "fefefefefefefefe", "fffffffffffffffe",
+    "ffffffffffffffff", "10000000000000000", "1234567890abcdef0",
+    "fffffffffffffffffefefefefefefefe", "fffffffffffffffffffffffffffffffe",
+    "ffffffffffffffffffffffffffffffff", "100000000000000000000000000000000",
+    "1234567890abcdef01234567890abcdef0",
+    "fffffffffffffffffffffffffffffffffffffffffffffffffefefefefefefefe",
+    "fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe",
+    "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    "10000000000000000000000000000000000000000000000000000000000000000",
+    "1234567890abcdef01234567890abcdef01234567890abcdef01234567890abcdef0",
+    (
+        "4df72d07b4b71c8dacb6cffa954f8d88254b6277099308baf003fab73227f34029"
+        "643b5a263f66e0d3c3fa297ef71755efd53b8fb6cb812c6bbf7bcf179298bd9947"
+        "c4c8b14324140a2c0f5fad7958a69050a987a6096e9f055fb38edf0c5889eca4a0"
+        "cfa99b45fbdeee4c696b328ddceae4723945901ec025076b12b"
+    )
+]
+
+# Note: Description, file target name and standard values are set here
 class BignumCoreTarget(test_data_generation.BaseTarget, metaclass=ABCMeta):
     #pylint: disable=abstract-method
     """Target for bignum core test case generation."""
     target_basename = 'test_suite_bignum_core.generated'
+
+    input_values = input_values
+
+    def description(self) -> str:
+        """Generate a description for the test case.
+
+        If not set, case_description uses the form A `symbol` B, where symbol
+        is used to represent the operation. Descriptions of each value are
+        generated to provide some context to the test case.
+        """
+        if not self.case_description:
+            self.case_description = "{:x} {} {:x}".format(
+                self.int_a, self.symbol, self.int_b
+            )
+        return super().description()
 
 
 class BignumCoreShiftR(BignumCoreTarget, metaclass=ABCMeta):
@@ -110,26 +156,8 @@ class BignumCoreCTLookup(BignumCoreTarget, metaclass=ABCMeta):
 class BignumCoreOperation(bignum_common.OperationCommon, BignumCoreTarget, metaclass=ABCMeta):
     #pylint: disable=abstract-method
     """Common features for bignum core operations."""
-    input_values = [
-        "0", "1", "3", "f", "fe", "ff", "100", "ff00", "fffe", "ffff", "10000",
-        "fffffffe", "ffffffff", "100000000", "1f7f7f7f7f7f7f",
-        "8000000000000000", "fefefefefefefefe", "fffffffffffffffe",
-        "ffffffffffffffff", "10000000000000000", "1234567890abcdef0",
-        "fffffffffffffffffefefefefefefefe", "fffffffffffffffffffffffffffffffe",
-        "ffffffffffffffffffffffffffffffff", "100000000000000000000000000000000",
-        "1234567890abcdef01234567890abcdef0",
-        "fffffffffffffffffffffffffffffffffffffffffffffffffefefefefefefefe",
-        "fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe",
-        "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-        "10000000000000000000000000000000000000000000000000000000000000000",
-        "1234567890abcdef01234567890abcdef01234567890abcdef01234567890abcdef0",
-        (
-            "4df72d07b4b71c8dacb6cffa954f8d88254b6277099308baf003fab73227f34029"
-            "643b5a263f66e0d3c3fa297ef71755efd53b8fb6cb812c6bbf7bcf179298bd9947"
-            "c4c8b14324140a2c0f5fad7958a69050a987a6096e9f055fb38edf0c5889eca4a0"
-            "cfa99b45fbdeee4c696b328ddceae4723945901ec025076b12b"
-        )
-    ]
+
+    input_values = input_values
 
     def description(self) -> str:
         """Generate a description for the test case.
@@ -155,27 +183,7 @@ class BignumCoreOperationArchSplit(bignum_common.OperationCommonArchSplit, Bignu
     """Common features for bignum core operations where the result depends on
     the limb size."""
 
-    input_values = [
-        "0", "1", "3", "f", "fe", "ff", "100", "ff00", "fffe", "ffff", "10000",
-        "fffffffe", "ffffffff", "100000000", "1f7f7f7f7f7f7f",
-        "8000000000000000", "fefefefefefefefe", "fffffffffffffffe",
-        "ffffffffffffffff", "10000000000000000", "1234567890abcdef0",
-        "fffffffffffffffffefefefefefefefe", "fffffffffffffffffffffffffffffffe",
-        "ffffffffffffffffffffffffffffffff", "100000000000000000000000000000000",
-        "1234567890abcdef01234567890abcdef0",
-        "fffffffffffffffffffffffffffffffffffffffffffffffffefefefefefefefe",
-        "fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe",
-        "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-        "10000000000000000000000000000000000000000000000000000000000000000",
-        "1234567890abcdef01234567890abcdef01234567890abcdef01234567890abcdef0",
-        (
-            "4df72d07b4b71c8dacb6cffa954f8d88254b6277099308baf003fab73227f34029"
-            "643b5a263f66e0d3c3fa297ef71755efd53b8fb6cb812c6bbf7bcf179298bd9947"
-            "c4c8b14324140a2c0f5fad7958a69050a987a6096e9f055fb38edf0c5889eca4a0"
-            "cfa99b45fbdeee4c696b328ddceae4723945901ec025076b12b"
-        )
-    ]
-
+    input_values = input_values
 
     def __init__(self, val_a: str, val_b: str, bits_in_limb: int) -> None:
         super().__init__(val_n="0", val_a=val_a, val_b=val_b, bits_in_limb=bits_in_limb)
@@ -184,7 +192,7 @@ class BignumCoreOperationArchSplit(bignum_common.OperationCommonArchSplit, Bignu
         return "{:x}".format(val).zfill(self.hex_digits)
 
     @classmethod
-    def generate_function_tests(cls) -> Iterator[test_case.TestCase]:      
+    def generate_function_tests(cls) -> Iterator[test_case.TestCase]:
         for bil, a_value, b_value in cls.get_bil_value_pairs():
             yield cls(a_value, b_value, bil).create_test_case()
 
@@ -199,7 +207,6 @@ class BignumCoreAddAndAddIf(BignumCoreOperationArchSplit):
         result = self.int_a + self.int_b
 
         carry, result = divmod(result, self.r)
-        print("Result", )
 
         return [
             bignum_common.quote_str(self.pad_to_limbs(result)),

--- a/scripts/mbedtls_dev/bignum_mod_raw.py
+++ b/scripts/mbedtls_dev/bignum_mod_raw.py
@@ -30,73 +30,19 @@ class BignumModRawOperation(bignum_common.OperationCommon, BignumModRawTarget, m
     #pylint: disable=abstract-method
     """Target for bignum mod_raw test case generation."""
 
+    # Note: This can be replaced by a simple pass statement
     def __init__(self, val_n: str, val_a: str, val_b: str = "0", bits_in_limb: int = 64) -> None:
-        super().__init__(val_a=val_a, val_b=val_b)
-        self.val_n = val_n
-        self.bits_in_limb = bits_in_limb
+        super().__init__(val_n=val_n, val_a=val_a, val_b=val_b, bits_in_limb=bits_in_limb)
 
-    @property
-    def int_n(self) -> int:
-        return bignum_common.hex_to_int(self.val_n)
-
-    @property
-    def boundary(self) -> int:
-        data_in = [self.int_a, self.int_b, self.int_n]
-        return max([n for n in data_in if n is not None])
-
-    @property
-    def limbs(self) -> int:
-        return bignum_common.limbs_mpi(self.boundary, self.bits_in_limb)
-
-    @property
-    def hex_digits(self) -> int:
-        return 2 * (self.limbs * self.bits_in_limb // 8)
-
-    @property
-    def hex_n(self) -> str:
-        return "{:x}".format(self.int_n).zfill(self.hex_digits)
-
-    @property
-    def hex_a(self) -> str:
-        return "{:x}".format(self.int_a).zfill(self.hex_digits)
-
-    @property
-    def hex_b(self) -> str:
-        return "{:x}".format(self.int_b).zfill(self.hex_digits)
-
-    @property
-    def r(self) -> int: # pylint: disable=invalid-name
-        l = bignum_common.limbs_mpi(self.int_n, self.bits_in_limb)
-        return bignum_common.bound_mpi_limbs(l, self.bits_in_limb)
-
-    @property
-    def r_inv(self) -> int:
-        return bignum_common.invmod(self.r, self.int_n)
-
-    @property
-    def r2(self) -> int: # pylint: disable=invalid-name
-        return pow(self.r, 2)
-
-class BignumModRawOperationArchSplit(BignumModRawOperation):
+class BignumModRawOperationArchSplit(bignum_common.OperationCommonArchSplit, BignumModRawTarget, metaclass=ABCMeta):
     #pylint: disable=abstract-method
     """Common features for bignum mod raw operations where the result depends on
     the limb size."""
 
-    limb_sizes = [32, 64] # type: List[int]
-
+    # Note: This can be replaced by a simple pass statement
     def __init__(self, val_n: str, val_a: str, val_b: str = "0", bits_in_limb: int = 64) -> None:
         super().__init__(val_n=val_n, val_a=val_a, val_b=val_b, bits_in_limb=bits_in_limb)
 
-        if bits_in_limb not in self.limb_sizes:
-            raise ValueError("Invalid number of bits in limb!")
-
-        self.dependencies = ["MBEDTLS_HAVE_INT{:d}".format(bits_in_limb)]
-
-    @classmethod
-    def generate_function_tests(cls) -> Iterator[test_case.TestCase]:
-        for a_value, b_value in cls.get_value_pairs():
-            for bil in cls.limb_sizes:
-                yield cls(a_value, b_value, bits_in_limb=bil).create_test_case()
 # BEGIN MERGE SLOT 1
 
 # END MERGE SLOT 1

--- a/scripts/mbedtls_dev/bignum_mod_raw.py
+++ b/scripts/mbedtls_dev/bignum_mod_raw.py
@@ -142,6 +142,9 @@ class BignumModRawConvertToMont(BignumModRawOperationArchSplit):
 
     @classmethod
     def generate_function_tests(cls) -> Iterator[test_case.TestCase]:
+
+        #Note This could be similarly accessed by
+        # bil, a, n BignumModRawConvertToMont.get_bil_value_pairs()
         for bil in [32, 64]:
             for n in cls.test_data_moduli:
                 for i in cls.test_input_numbers:


### PR DESCRIPTION
## Description

This PR is a design proposal on how to restructure the test generators inheritance model, with using the `@properties` and with minimal disruption to the existing test code.

It provides also example on how to refactor bignum_core and use the new design with simply modifying the
`BignumCoreOperation`, `BignumCoreOperationArchSplit`, `BignumCoreTarget` classes to use the new design.

The inheritance model proposed by this approach is 

~~~~~~
                          BignumCoreTarget                BignumModRawTarget                  BignumModTarget
                              |      |                         |                                |       |
                              |      V                         |                                |       |
CommonOperation               | BignumCoreOperation            |                                |       |
     |------------------------------------------------------------> BignumModRawOperation       |       V
     |------------------------|--------------------------------|------------------------------------> BignumModOperation        
     |                        |                                |                                |
     V                        V                                |                                |
CommonOperationArchSplit --> BignumCoreOperationArchSplit      V                                |  
                         |-----------------------------------> BignumModRawOperationArchSplit   V
                         |--------------------------------------------------------------------> BignumModOperationArchSplit
~~~~~~

The Target classes offer a per module template for decription, module related standard input_values and a standard override for the `arguments()` property which is invoking the `result()` method.

All the standard formatting operations, for storing and converting (e.g `sting-> int-> hex`) the input parameters are now contained in the `OperationCommon` which is in the bottom of the method resolution order:

~~~~~~
<class 'mbedtls_dev.bignum_core.BignumCoreAddAndAddIf'>,
<class 'mbedtls_dev.bignum_core.BignumCoreOperationArchSplit'>,
<class 'mbedtls_dev.bignum_core.BignumCoreTarget'>,
<class 'mbedtls_dev.test_data_generation.BaseTarget'>,
<class 'mbedtls_dev.bignum_common.OperationCommonArchSplit'>,
<class 'mbedtls_dev.bignum_common.OperationCommon'>,
<class 'object'>
~~~~~~

## Gatekeeper checklist

- [x] **changelog** Not required
- [x] **backport** Not required
- [ ] **tests** Not required



## Notes for the submitter

This is a design review PR and shall not be merged. It is also not expected to pass our current CI.

