### PR TITLE
Install CMake files in MbedTLS dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -355,7 +355,7 @@ if(NOT DISABLE_PACKAGE_CONFIG_AND_INSTALL)
     install(
         FILES "${CMAKE_CURRENT_BINARY_DIR}/cmake/MbedTLSConfig.cmake"
               "${CMAKE_CURRENT_BINARY_DIR}/cmake/MbedTLSConfigVersion.cmake"
-        DESTINATION "cmake")
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/MbedTLS")
 
     export(
         EXPORT MbedTLSTargets
@@ -365,7 +365,7 @@ if(NOT DISABLE_PACKAGE_CONFIG_AND_INSTALL)
     install(
         EXPORT MbedTLSTargets
         NAMESPACE MbedTLS::
-        DESTINATION "cmake"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/MbedTLS"
         FILE "MbedTLSTargets.cmake")
 
     if(CMAKE_VERSION VERSION_GREATER 3.15 OR CMAKE_VERSION VERSION_EQUAL 3.15)

--- a/ChangeLog.d/cmake-install.txt
+++ b/ChangeLog.d/cmake-install.txt
@@ -1,0 +1,3 @@
+Changes
+  * Install the .cmake files into CMAKE_INSTALL_LIBDIR/cmake/MbedTLS,
+    typically /usr/lib/cmake/MbedTLS.

--- a/programs/test/cmake_package_install/CMakeLists.txt
+++ b/programs/test/cmake_package_install/CMakeLists.txt
@@ -26,7 +26,7 @@ execute_process(
 # Locate the package.
 #
 
-set(MbedTLS_DIR "${MbedTLS_INSTALL_DIR}/cmake")
+list(INSERT CMAKE_PREFIX_PATH 0 "${MbedTLS_INSTALL_DIR}")
 find_package(MbedTLS REQUIRED)
 
 #


### PR DESCRIPTION
## Description
Right now, CMake files are installed in `<prefix>/cmake`. That being said, it gets easily bloated, and the standard is to use a directory with the same name as the project `<prefix>/lib/cmake/<name>`.

I discovered this issue with this "bug": https://github.com/termux/termux-packages/issues/12416
The issue's author claimed that MbedTLS's files were not installed in the `lib` directory. But the patch applied broke CMake's search of mbedTLS config files. So I wanted to upstream the real fix here instead.

Note that `CMAKE_INSTALL_LIBDIR` is set by `include(GNUInstallDirs)` at line 42.

Here are some examples of projects using directories:
 - https://github.com/xiph/flac/blob/1.4.2/CMakeLists.txt#L239
 - https://gitlab.freedesktop.org/dbus/dbus/-/blob/dbus-1.15.2/CMakeLists.txt#L675
 - https://github.com/catchorg/Catch2/blob/v3.2.0/CMakeLists.txt#L62
 - https://github.com/capnproto/capnproto/blob/v0.10.2/c++/CMakeLists.txt#L162


## Gatekeeper checklist
- [x] ChangeLog provided
- [x] backport not required - new feature
- [x] testing not required - covered by existing tests