### PR TITLE
TLS 1.3: EarlyData: workaround gnutls anti replay fail.

### DIFF
--- a/tests/opt-testcases/tls13-misc.sh
+++ b/tests/opt-testcases/tls13-misc.sh
@@ -282,9 +282,6 @@ run_test    "TLS 1.3: G->m: PSK: configured ephemeral only, good." \
             0 \
             -s "key exchange mode: ephemeral$"
 
-# skip the basic check now cause it will randomly trigger the anti-replay protection in gnutls_server
-# Add it back once we fix the issue
-skip_next_test
 requires_gnutls_tls1_3
 requires_config_enabled MBEDTLS_DEBUG_C
 requires_config_enabled MBEDTLS_SSL_CLI_C


### PR DESCRIPTION
## Description

`anti_replay_check` of GnuTLS check the ticket ages of client and server.
The restriction is in https://gitlab.com/gnutls/gnutls/-/blob/master/lib/tls13/anti_replay.c#L150

Root cause: That is due to time precision.
The time precision of ticket_age is milliseconds(RFC 8446). But our precision is senconds, we caculate
ticket age with `(mbedtls_time( NULL ) - ticket_recived)*1000` .
If the ticket is sent/received near the end of a second and client send ticket at the beggining of
next second, ticket age of client is 1000 ms, but ticket age of server is less than it. As a result,
it offends the anit replay ruler.

Workaround solution: Add 1 second to ticket_received and do reconnect 1 second later.
This commit implement it.


## Gatekeeper checklist

- [ ] **changelog** provided, or not required
- [ ] **backport** done, or not required
- [ ] **tests** provided, or not required



## Notes for the submitter

Please refer to the [contributing guidelines](../CONTRIBUTING.md), especially the
checklist for PR contributors.

