### PR TITLE
TLS 1.3: SessionTicket: Change time precision

### DIFF
--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -873,6 +873,13 @@
 #error "MBEDTLS_SSL_PROTO_DTLS defined, but not all prerequisites"
 #endif
 
+#if defined(MBEDTLS_SSL_SESSION_TICKETS)    && \
+    defined(MBEDTLS_SSL_PROTO_TLS1_3)       && \
+    !defined(MBEDTLS_HAVE_CLOCK_GETTIME)
+#error "MBEDTLS_SSL_SESSION_TICKETS and MBEDTLS_SSL_PROTO_TLS1_3 defined, " \
+       "but MBEDTLS_HAVE_CLOCK_GETTIME not defined."
+#endif
+
 #if defined(MBEDTLS_SSL_CLI_C) && !defined(MBEDTLS_SSL_TLS_C)
 #error "MBEDTLS_SSL_CLI_C defined, but not all prerequisites"
 #endif

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -459,6 +459,25 @@
 #error "MBEDTLS_PLATFORM_TIME_TYPE_MACRO and MBEDTLS_PLATFORM_STD_TIME/MBEDTLS_PLATFORM_TIME_ALT cannot be defined simultaneously"
 #endif
 
+#if defined(MBEDTLS_HAVE_CLOCK_GETTIME) && !defined(MBEDTLS_HAVE_TIME)
+#error "MBEDTLS_HAVE_CLOCK_GETTIME defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_PLATFORM_CLOCK_GETTIME_MACRO) && \
+    !defined(MBEDTLS_HAVE_CLOCK_GETTIME)
+#error "MBEDTLS_PLATFORM_CLOCK_GETTIME_MACRO defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_PLATFORM_CLOCK_GETTIME_TYPE_MACRO) && \
+    !defined(MBEDTLS_HAVE_CLOCK_GETTIME)
+#error "MBEDTLS_PLATFORM_CLOCK_GETTIME_TYPE_MACRO defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_PLATFORM_CLOCK_REALTIME_MACRO) && \
+    !defined(MBEDTLS_HAVE_CLOCK_GETTIME)
+#error "MBEDTLS_PLATFORM_CLOCK_REALTIME_MACRO defined, but not all prerequisites"
+#endif
+
 #if defined(MBEDTLS_PLATFORM_FPRINTF_ALT) && !defined(MBEDTLS_PLATFORM_C)
 #error "MBEDTLS_PLATFORM_FPRINTF_ALT defined, but not all prerequisites"
 #endif

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -159,6 +159,24 @@
  */
 #define MBEDTLS_HAVE_TIME_DATE
 
+
+/**
+ * \def MBEDTLS_HAVE_CLOCK_GETTIME
+ *
+ * System has POSIX clock_gettime().
+ * The time does not need to be correct, only time differences are used,
+ * by contrast with MBEDTLS_HAVE_TIME_DATE
+ *
+ * Defining MBEDTLS_HAVE_CLOCK_GETTIME allows you to specify,
+ * MBEDTLS_PLATFORM_CLOCK_GETTIME_MACRO, MBEDTLS_CLOCK_REALTIME
+ * and MBEDTLS_PLATFORM_CLOCK_GETTIME_TYPE_MACRO.
+ *
+ * requires: MBEDTLS_HAVE_TIME
+ *
+ * Comment if your system does not support clock_gettime functions.
+ */
+#define MBEDTLS_HAVE_CLOCK_GETTIME
+
 /**
  * \def MBEDTLS_PLATFORM_MEMORY
  *
@@ -3509,6 +3527,9 @@
 //#define MBEDTLS_PLATFORM_SETBUF_MACRO      setbuf /**< Default setbuf macro to use, can be undefined */
 //#define MBEDTLS_PLATFORM_TIME_MACRO            time /**< Default time macro to use, can be undefined. MBEDTLS_HAVE_TIME must be enabled */
 //#define MBEDTLS_PLATFORM_TIME_TYPE_MACRO       time_t /**< Default time macro to use, can be undefined. MBEDTLS_HAVE_TIME must be enabled */
+//#define MBEDTLS_PLATFORM_CLOCK_GETTIME_MACRO   clock_gettime /**< Default time macro to use, can be undefined. MBEDTLS_HAVE_CLOCK_GETTIME must be enabled */
+//#define MBEDTLS_PLATFORM_CLOCK_GETTIME_TYPE_MACRO       struct timespec /**< Default time macro to use, can be undefined. MBEDTLS_HAVE_CLOCK_GETTIME must be enabled */
+//#define MBEDTLS_PLATFORM_CLOCK_REALTIME_MACRO       CLOCK_REALTIME /**< Default time macro to use, can be undefined. MBEDTLS_HAVE_CLOCK_GETTIME must be enabled */
 //#define MBEDTLS_PLATFORM_FPRINTF_MACRO      fprintf /**< Default fprintf macro to use, can be undefined */
 //#define MBEDTLS_PLATFORM_PRINTF_MACRO        printf /**< Default printf macro to use, can be undefined */
 /* Note: your snprintf must correctly zero-terminate the buffer! */

--- a/include/mbedtls/platform.h
+++ b/include/mbedtls/platform.h
@@ -45,6 +45,10 @@
 #include "mbedtls/platform_time.h"
 #endif
 
+#if defined(MBEDTLS_HAVE_CLOCK_GETTIME)
+#include "mbedtls/platform_clock_gettime.h"
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/mbedtls/platform_clock_gettime.h
+++ b/include/mbedtls/platform_clock_gettime.h
@@ -1,0 +1,58 @@
+/**
+ * \file platform_clock_gettime.h
+ *
+ * \brief mbed TLS Platform clock_gettime abstraction
+ */
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+#ifndef MBEDTLS_PLATFORM_CLOCK_GETTIME_H
+#define MBEDTLS_PLATFORM_CLOCK_GETTIME_H
+
+#include "mbedtls/build_info.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * The time_t datatype
+ */
+#if defined(MBEDTLS_PLATFORM_CLOCK_GETTIME_TYPE_MACRO)
+typedef MBEDTLS_PLATFORM_CLOCK_GETTIME_TYPE_MACRO mbedtls_timespec_t;
+#else
+/* For time_t */
+#include <time.h>
+typedef struct timespec mbedtls_timespec_t;
+#endif /* MBEDTLS_PLATFORM_CLOCK_GETTIME_TYPE_MACRO */
+
+#if defined(MBEDTLS_PLATFORM_CLOCK_GETTIME_MACRO)
+#define mbedtls_clock_gettime   MBEDTLS_PLATFORM_CLOCK_GETTIME_MACRO
+#else
+#define mbedtls_clock_gettime   clock_gettime
+#endif /* MBEDTLS_PLATFORM_CLOCK_GETTIME_MACRO */
+
+#if defined(MBEDTLS_PLATFORM_CLOCK_REALTIME_MACRO)
+#define MBEDTLS_CLOCK_REALTIME   MBEDTLS_PLATFORM_CLOCK_REALTIME_MACRO
+#else
+#define MBEDTLS_CLOCK_REALTIME   CLOCK_REALTIME
+#endif /* MBEDTLS_PLATFORM_CLOCK_GETTIME_MACRO */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* platform_clock_gettime.h */

--- a/include/mbedtls/platform_clock_gettime.h
+++ b/include/mbedtls/platform_clock_gettime.h
@@ -40,9 +40,10 @@ typedef struct timespec mbedtls_timespec_t;
 #endif /* MBEDTLS_PLATFORM_CLOCK_GETTIME_TYPE_MACRO */
 
 #if defined(MBEDTLS_PLATFORM_CLOCK_GETTIME_MACRO)
-#define mbedtls_clock_gettime   MBEDTLS_PLATFORM_CLOCK_GETTIME_MACRO
+#define /* no-check-names */ mbedtls_clock_gettime   \
+                                 MBEDTLS_PLATFORM_CLOCK_GETTIME_MACRO
 #else
-#define mbedtls_clock_gettime   clock_gettime
+#define /* no-check-names */ mbedtls_clock_gettime   clock_gettime
 #endif /* MBEDTLS_PLATFORM_CLOCK_GETTIME_MACRO */
 
 #if defined(MBEDTLS_PLATFORM_CLOCK_REALTIME_MACRO)

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1148,6 +1148,10 @@ mbedtls_dtls_srtp_info;
 
 #endif /* MBEDTLS_SSL_DTLS_SRTP */
 
+#if defined(MBEDTLS_HAVE_CLOCK_GETTIME)
+typedef int64_t mbedtls_ms_time_t;
+#endif /* MBEDTLS_HAVE_CLOCK_GETTIME */
+
 /** Human-friendly representation of the (D)TLS protocol version. */
 typedef enum
 {
@@ -1179,8 +1183,9 @@ struct mbedtls_ssl_session
      *  or resuming a session instead of the configured minor TLS version.
      */
     mbedtls_ssl_protocol_version MBEDTLS_PRIVATE(tls_version);
-
-#if defined(MBEDTLS_HAVE_TIME)
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3) && defined(MBEDTLS_HAVE_CLOCK_GETTIME)
+    mbedtls_ms_time_t MBEDTLS_PRIVATE(start);       /*!< starting time      */
+#elif defined(MBEDTLS_HAVE_TIME)
     mbedtls_time_t MBEDTLS_PRIVATE(start);       /*!< starting time      */
 #endif
     int MBEDTLS_PRIVATE(ciphersuite);            /*!< chosen ciphersuite */
@@ -1219,7 +1224,11 @@ struct mbedtls_ssl_session
 #endif /* MBEDTLS_SSL_SERVER_NAME_INDICATION && MBEDTLS_SSL_CLI_C */
 
 #if defined(MBEDTLS_HAVE_TIME) && defined(MBEDTLS_SSL_CLI_C)
+#if defined(MBEDTLS_HAVE_CLOCK_GETTIME)
+    mbedtls_ms_time_t MBEDTLS_PRIVATE(ticket_received);        /*!< time ticket was received */
+#else
     mbedtls_time_t MBEDTLS_PRIVATE(ticket_received);        /*!< time ticket was received */
+#endif
 #endif /* MBEDTLS_HAVE_TIME && MBEDTLS_SSL_CLI_C */
 
 #endif /*  MBEDTLS_SSL_PROTO_TLS1_3 && MBEDTLS_SSL_SESSION_TICKETS */

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -2634,4 +2634,9 @@ int mbedtls_ssl_session_set_hostname( mbedtls_ssl_session *session,
                                       const char *hostname );
 #endif
 
+#if defined(MBEDTLS_HAVE_CLOCK_GETTIME)
+MBEDTLS_CHECK_RETURN_CRITICAL
+mbedtls_ms_time_t mbedtls_ms_time(void);
+#endif /* MBEDTLS_HAVE_CLOCK_GETTIME */
+
 #endif /* ssl_misc.h */

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -941,23 +941,17 @@ int mbedtls_ssl_tls13_write_identities_of_pre_shared_key_ext(
     if( ssl_tls13_ticket_get_identity(
             ssl, &hash_alg, &identity, &identity_len ) == 0 )
     {
-#if defined(MBEDTLS_HAVE_TIME)
-        mbedtls_time_t now = mbedtls_time( NULL );
+        mbedtls_ms_time_t now = mbedtls_ms_time();
         mbedtls_ssl_session *session = ssl->session_negotiate;
         uint32_t obfuscated_ticket_age =
                                 (uint32_t)( now - session->ticket_received );
 
-        obfuscated_ticket_age *= 1000;
         obfuscated_ticket_age += session->ticket_age_add;
 
         ret = ssl_tls13_write_identity( ssl, p, end,
                                         identity, identity_len,
                                         obfuscated_ticket_age,
                                         &output_len );
-#else
-        ret = ssl_tls13_write_identity( ssl, p, end, identity, identity_len,
-                                        0, &output_len );
-#endif /* MBEDTLS_HAVE_TIME */
         if( ret != 0 )
             return( ret );
 
@@ -1650,10 +1644,6 @@ static int ssl_tls13_parse_server_hello( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "server hello, chosen ciphersuite: ( %04x ) - %s",
                                  cipher_suite, ciphersuite_info->name ) );
-
-#if defined(MBEDTLS_HAVE_TIME)
-    ssl->session_negotiate->start = time( NULL );
-#endif /* MBEDTLS_HAVE_TIME */
 
     /* ...
      * uint8 legacy_compression_method = 0;
@@ -2685,10 +2675,8 @@ static int ssl_tls13_postprocess_new_session_ticket( mbedtls_ssl_context *ssl,
     psa_algorithm_t psa_hash_alg;
     int hash_length;
 
-#if defined(MBEDTLS_HAVE_TIME)
-    /* Store ticket creation time */
-    session->ticket_received = mbedtls_time( NULL );
-#endif
+    /* Store ticket received time */
+    session->ticket_received = mbedtls_ms_time();
 
     ciphersuite_info = mbedtls_ssl_ciphersuite_from_id( session->ciphersuite );
     if( ciphersuite_info == NULL )

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -1620,5 +1620,18 @@ int mbedtls_ssl_tls13_check_received_extension(
     return( MBEDTLS_ERR_SSL_UNSUPPORTED_EXTENSION );
 }
 
+#if defined(MBEDTLS_HAVE_CLOCK_GETTIME)
+/* TODO: move to right place */
+mbedtls_ms_time_t mbedtls_ms_time(void)
+{
+    int ret;
+    mbedtls_timespec_t tv;
+    ret = mbedtls_clock_gettime( MBEDTLS_CLOCK_REALTIME, &tv );
+    if( ret )
+        return( 0 );
+    return (tv.tv_sec*1000 + (tv.tv_nsec % 1000000)/1000 );
+}
+#endif /* MBEDTLS_HAVE_CLOCK_GETTIME */
+
 #endif /* MBEDTLS_SSL_TLS_C && MBEDTLS_SSL_PROTO_TLS1_3 */
 

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -260,6 +260,7 @@ EXCLUDE_FROM_BAREMETAL = frozenset([
     'MBEDTLS_FS_IO', # requires a filesystem
     'MBEDTLS_HAVE_TIME', # requires a clock
     'MBEDTLS_HAVE_TIME_DATE', # requires a clock
+    'MBEDTLS_HAVE_CLOCK_GETTIME', # requires a clock
     'MBEDTLS_NET_C', # requires POSIX-like networking
     'MBEDTLS_PLATFORM_FPRINTF_ALT', # requires FILE* from stdio.h
     'MBEDTLS_PLATFORM_NV_SEED_ALT', # requires a filesystem and ENTROPY_NV_SEED

--- a/tests/opt-testcases/tls13-misc.sh
+++ b/tests/opt-testcases/tls13-misc.sh
@@ -282,9 +282,6 @@ run_test    "TLS 1.3: G->m: PSK: configured ephemeral only, good." \
             0 \
             -s "key exchange mode: ephemeral$"
 
-# skip the basic check now cause it will randomly trigger the anti-replay protection in gnutls_server
-# Add it back once we fix the issue
-skip_next_test
 requires_gnutls_tls1_3
 requires_config_enabled MBEDTLS_DEBUG_C
 requires_config_enabled MBEDTLS_SSL_CLI_C


### PR DESCRIPTION
## Description

Preceding PR: #6630 

As description in #6630 , the root cause of `anti_replay_check` is time precision. 

This PR is to fix that.

- [ ] Add platform time function with milliseconds precision.
      - `clock()` from C99(N1256 section 7.23) https://www.open-std.org/JTC1/SC22/WG14/www/docs/n1256.pdf
      - `clock_gettime()` from POSIX.1-2008 ( `man clock_gettime` ) ***this is selected***
      - `gettimeofday()` NOT recommend, POSIX.1-2008 marks gettimeofday() as obsolete ( `man gettimeofday` )
- [ ] Change the time precision from seconds to milliseconds.
- [ ] Force enable MBEDTL_HAVE_TIME when TLS1.3 session ticket is enabled.
       - This should be revert. NOT DONE
- [ ] Remove negative tollerance window?? Consider this point again. In embed world, the negative tollerance might be appear.
- [ ] Add `mbedtls_ms_time_t` and `mbedtls_ms_time` for internal usage.

$\color{#58A6FF}\textsf{\Large\&#x24D8;\kern{0.2cm}\normalsize FOR TIME BEING, It is not ready for review}$
## Gatekeeper checklist

- [ ] **changelog** provided, or not required
- [ ] **backport** done, or not required
- [ ] **tests** provided, or not required



## Notes for the submitter

Please refer to the [contributing guidelines](../CONTRIBUTING.md), especially the
checklist for PR contributors.

