### PR TITLE
PSA partial initialization

### DIFF
--- a/include/psa/crypto.h
+++ b/include/psa/crypto.h
@@ -75,18 +75,12 @@ extern "C" {
  * \brief Library initialization.
  *
  * Applications must call this function before calling any other
- * function in this module.
+ * function in this module, except as otherwise indicated.
  *
  * Applications may call this function more than once. Once a call
  * succeeds, subsequent calls are guaranteed to succeed.
  *
- * If the application calls other functions before calling psa_crypto_init(),
- * the behavior is undefined. Implementations are encouraged to either perform
- * the operation as if the library had been initialized or to return
- * #PSA_ERROR_BAD_STATE or some other applicable error. In particular,
- * implementations should not return a success status if the lack of
- * initialization may have security implications, for example due to improper
- * seeding of the random number generator.
+ * For finer control over initialization, see psa_crypto_init_subsystem().
  *
  * \retval #PSA_SUCCESS
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
@@ -100,6 +94,44 @@ extern "C" {
  * \retval #PSA_ERROR_DATA_CORRUPT
  */
 psa_status_t psa_crypto_init(void);
+
+/**
+ * \brief Partial library initialization.
+ *
+ * Applications may call this function on the same subsystem more than once.
+ * Once a call succeeds, subsequent calls with the same subsystem are
+ * guaranteed to succeed.
+ *
+ * Initializing a subsystem may initialize other subsystems if the
+ * implementations needs them internally. For example, in a typical
+ * client-server implementation, #PSA_CRYPTO_SUBSYSTEM_COMMUNICATION is
+ * required for all other subsystems, and therefore initializing any other
+ * subsystem also initializes #PSA_CRYPTO_SUBSYSTEM_COMMUNICATION.
+ *
+ * Calling psa_crypto_init() is equivalent to calling
+ * psa_crypto_init_subsystem() on all the available subsystems.
+ *
+ * \note This function is part of a draft API specification and may change
+ *       as the API evolves.
+ *
+ * \note You can initialize multiple subsystems in the same call by passing
+ *       a bitwise-or of \c PSA_CRYPTO_SUBSYSTEM_xxx values. This ability
+ *       is experimental and may change without notice. If the initialization
+ *       of one subsystem fails, it is unspecified whether other requested
+ *       subsystems are initialized or not.
+ *
+ * \retval #PSA_SUCCESS
+ * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ * \retval #PSA_ERROR_INSUFFICIENT_STORAGE
+ * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ * \retval #PSA_ERROR_HARDWARE_FAILURE
+ * \retval #PSA_ERROR_CORRUPTION_DETECTED
+ * \retval #PSA_ERROR_INSUFFICIENT_ENTROPY
+ * \retval #PSA_ERROR_STORAGE_FAILURE
+ * \retval #PSA_ERROR_DATA_INVALID
+ * \retval #PSA_ERROR_DATA_CORRUPT
+ */
+psa_status_t psa_crypto_init_subsystem(psa_crypto_subsystem_t subsystem);
 
 /**@}*/
 

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -216,6 +216,26 @@ psa_status_t mbedtls_psa_register_se_key(
  */
 void mbedtls_psa_crypto_free( void );
 
+/**
+ * \brief Query the library initialization state.
+ *
+ * This is an Mbed TLS extension.
+ *
+ * \note This function is experimental and may change or be removed
+ *       without notice.
+ *
+ * \note You can pass a mask of subsystems as \p subsystem, and this
+ *       function returns 1 if and only if all the given subsystems are
+ *       initialized. This ability is experimental and may be removed
+ *       without notice.
+ *
+ * \param subsystem     The subsystem to query.
+ *
+ * \return 1 if the given subsysem is already initialized, otherwise 0.
+ */
+int mbedtls_psa_crypto_is_subsystem_initialized(
+    psa_crypto_subsystem_t subsystem );
+
 /** \brief Statistics about
  * resource consumption related to the PSA keystore.
  *

--- a/include/psa/crypto_types.h
+++ b/include/psa/crypto_types.h
@@ -473,6 +473,7 @@ typedef enum {
     MBEDTLS_PSA_CRYPTO_SUBSYSTEM_STORAGE_INDEX,
     MBEDTLS_PSA_CRYPTO_SUBSYSTEM_ACCELERATORS_INDEX,
     MBEDTLS_PSA_CRYPTO_SUBSYSTEM_SECURE_ELEMENTS_INDEX,
+    MBEDTLS_PSA_CRYPTO_SUBSYSTEM_RANDOM_INDEX,
     /* Must come last. Value equal to the number of preceding elements. */
     MBEDTLS_PSA_CRYPTO_SUBSYSTEM_COUNT
 } mbedtls_psa_crypto_subsystem_index_t;
@@ -546,6 +547,27 @@ typedef uint32_t psa_crypto_subsystem_t;
 #define PSA_CRYPTO_SUBSYSTEM_SECURE_ELEMENTS \
     ((psa_crypto_subsystem_t)1 << MBEDTLS_PSA_CRYPTO_SUBSYSTEM_SECURE_ELEMENTS_INDEX)
 
+/** Initialize the random generator.
+ *
+ * Initializing this subsystem initializes all registered entropy drivers
+ * and accesses the registered entropy sources.
+ *
+ * Initializing this subsystem is necessary for psa_generate_random(),
+ * psa_generate_key(), as well as some operations using private or
+ * secret keys. Only the following operations are guaranteed not to
+ * require this subsystem:
+ *
+ * - hash operations;
+ * - signature verification operations.
+ *
+ * \note Currently, symmetric decryption (authenticated or not) and
+ *       MAC operations do not require the random generator.
+ *       This may change in future versions of the library
+ *       or when the operations are performed by a driver.
+ */
+#define PSA_CRYPTO_SUBSYSTEM_RANDOM \
+    ((psa_crypto_subsystem_t)1 << MBEDTLS_PSA_CRYPTO_SUBSYSTEM_RANDOM_INDEX)
+
 /* A mask of all the subsystems recognized by Mbed TLS. */
 #define MBEDTLS_PSA_CRYPTO_ALL_SUBSYSTEMS (     \
         PSA_CRYPTO_SUBSYSTEM_COMMUNICATION |    \
@@ -553,6 +575,7 @@ typedef uint32_t psa_crypto_subsystem_t;
         PSA_CRYPTO_SUBSYSTEM_STORAGE |          \
         PSA_CRYPTO_SUBSYSTEM_ACCELERATORS |     \
         PSA_CRYPTO_SUBSYSTEM_SECURE_ELEMENTS |  \
+        PSA_CRYPTO_SUBSYSTEM_RANDOM |           \
         0 )
 
 /**@}*/

--- a/include/psa/crypto_types.h
+++ b/include/psa/crypto_types.h
@@ -474,6 +474,7 @@ typedef enum {
     MBEDTLS_PSA_CRYPTO_SUBSYSTEM_ACCELERATORS_INDEX,
     MBEDTLS_PSA_CRYPTO_SUBSYSTEM_SECURE_ELEMENTS_INDEX,
     MBEDTLS_PSA_CRYPTO_SUBSYSTEM_RANDOM_INDEX,
+    MBEDTLS_PSA_CRYPTO_SUBSYSTEM_BUILTIN_KEYS_INDEX,
     /* Must come last. Value equal to the number of preceding elements. */
     MBEDTLS_PSA_CRYPTO_SUBSYSTEM_COUNT
 } mbedtls_psa_crypto_subsystem_index_t;
@@ -568,6 +569,14 @@ typedef uint32_t psa_crypto_subsystem_t;
 #define PSA_CRYPTO_SUBSYSTEM_RANDOM \
     ((psa_crypto_subsystem_t)1 << MBEDTLS_PSA_CRYPTO_SUBSYSTEM_RANDOM_INDEX)
 
+/** Access to built-in keys.
+ *
+ * Initializing this subsystem as well as #PSA_CRYPTO_SUBSYSTEM_KEYS
+ * allows access to built-in keys.
+ */
+#define PSA_CRYPTO_SUBSYSTEM_BUILTIN_KEYS \
+    ((psa_crypto_subsystem_t)1 << MBEDTLS_PSA_CRYPTO_SUBSYSTEM_BUILTIN_KEYS_INDEX)
+
 /* A mask of all the subsystems recognized by Mbed TLS. */
 #define MBEDTLS_PSA_CRYPTO_ALL_SUBSYSTEMS (     \
         PSA_CRYPTO_SUBSYSTEM_COMMUNICATION |    \
@@ -576,6 +585,7 @@ typedef uint32_t psa_crypto_subsystem_t;
         PSA_CRYPTO_SUBSYSTEM_ACCELERATORS |     \
         PSA_CRYPTO_SUBSYSTEM_SECURE_ELEMENTS |  \
         PSA_CRYPTO_SUBSYSTEM_RANDOM |           \
+        PSA_CRYPTO_SUBSYSTEM_BUILTIN_KEYS |     \
         0 )
 
 /**@}*/

--- a/include/psa/crypto_types.h
+++ b/include/psa/crypto_types.h
@@ -462,4 +462,45 @@ typedef uint16_t psa_key_derivation_step_t;
 
 /**@}*/
 
+/** \addtogroup initialization
+ * @{
+ */
+
+/* Auxiliary type for values of type psa_crypto_subsystem_index_t */
+typedef enum {
+    MBEDTLS_PSA_CRYPTO_SUBSYSTEM_COMMUNICATION_INDEX,
+    /* Must come last. Value equal to the number of preceding elements. */
+    MBEDTLS_PSA_CRYPTO_SUBSYSTEM_COUNT
+} mbedtls_psa_crypto_subsystem_index_t;
+
+/** \brief The designation of a subsystem of the PSA Crypto implementation.
+ *
+ * Value of this type are masks of \c PSA_CRYPTO_SUBSYSTEM_xxx constants.
+ *
+ * \note This type is experimental and may change without notice.
+ */
+typedef uint32_t psa_crypto_subsystem_t;
+
+/** Communication with the server, if this is a client that communicates
+ * with a server where the key store is located.
+ *
+ * In a client-server implementation, this subsystem is necessary
+ * before any API function other than library initialization,
+ * deinitialization and functions accessing local data structures
+ * such as key attributes.
+ *
+ * In a library implementation, initializing this subsystem does nothing
+ * and succeeds.
+ */
+#define PSA_CRYPTO_SUBSYSTEM_COMMUNICATION \
+    ((psa_crypto_subsystem_t)1 << MBEDTLS_PSA_CRYPTO_SUBSYSTEM_COMMUNICATION_INDEX)
+
+
+/* A mask of all the subsystems recognized by Mbed TLS. */
+#define MBEDTLS_PSA_CRYPTO_ALL_SUBSYSTEMS (     \
+        PSA_CRYPTO_SUBSYSTEM_COMMUNICATION |    \
+        0 )
+
+/**@}*/
+
 #endif /* PSA_CRYPTO_TYPES_H */

--- a/include/psa/crypto_types.h
+++ b/include/psa/crypto_types.h
@@ -469,6 +469,8 @@ typedef uint16_t psa_key_derivation_step_t;
 /* Auxiliary type for values of type psa_crypto_subsystem_index_t */
 typedef enum {
     MBEDTLS_PSA_CRYPTO_SUBSYSTEM_COMMUNICATION_INDEX,
+    MBEDTLS_PSA_CRYPTO_SUBSYSTEM_KEYS_INDEX,
+    MBEDTLS_PSA_CRYPTO_SUBSYSTEM_STORAGE_INDEX,
     /* Must come last. Value equal to the number of preceding elements. */
     MBEDTLS_PSA_CRYPTO_SUBSYSTEM_COUNT
 } mbedtls_psa_crypto_subsystem_index_t;
@@ -495,10 +497,35 @@ typedef uint32_t psa_crypto_subsystem_t;
 #define PSA_CRYPTO_SUBSYSTEM_COMMUNICATION \
     ((psa_crypto_subsystem_t)1 << MBEDTLS_PSA_CRYPTO_SUBSYSTEM_COMMUNICATION_INDEX)
 
+/** The key store in memory.
+ *
+ * Initializing this subsystem allows creating, accessing and destroying
+ * volatile keys in the default location, i.e.  keys with the lifetime
+ * #PSA_KEY_LIFETIME_VOLATILE.
+ *
+ * Persistent keys also require #PSA_CRYPTO_SUBSYSTEM_STORAGE.
+ * Keys in other locations also require
+ * #PSA_CRYPTO_SUBSYSTEM_SECURE_ELEMENTS.
+ */
+#define PSA_CRYPTO_SUBSYSTEM_KEYS \
+    ((psa_crypto_subsystem_t)1 << MBEDTLS_PSA_CRYPTO_SUBSYSTEM_KEYS_INDEX)
+
+/** Access to keys in storage.
+ *
+ * Initializing this subsystem as well as #PSA_CRYPTO_SUBSYSTEM_KEYS
+ * allows creating, accessing and destroying persistent keys.
+ *
+ * Oersistent keys in secure elements also require
+ * #PSA_CRYPTO_SUBSYSTEM_SECURE_ELEMENTS.
+ */
+#define PSA_CRYPTO_SUBSYSTEM_STORAGE \
+    ((psa_crypto_subsystem_t)1 << MBEDTLS_PSA_CRYPTO_SUBSYSTEM_STORAGE_INDEX)
 
 /* A mask of all the subsystems recognized by Mbed TLS. */
 #define MBEDTLS_PSA_CRYPTO_ALL_SUBSYSTEMS (     \
         PSA_CRYPTO_SUBSYSTEM_COMMUNICATION |    \
+        PSA_CRYPTO_SUBSYSTEM_KEYS |             \
+        PSA_CRYPTO_SUBSYSTEM_STORAGE |          \
         0 )
 
 /**@}*/

--- a/include/psa/crypto_types.h
+++ b/include/psa/crypto_types.h
@@ -471,6 +471,8 @@ typedef enum {
     MBEDTLS_PSA_CRYPTO_SUBSYSTEM_COMMUNICATION_INDEX,
     MBEDTLS_PSA_CRYPTO_SUBSYSTEM_KEYS_INDEX,
     MBEDTLS_PSA_CRYPTO_SUBSYSTEM_STORAGE_INDEX,
+    MBEDTLS_PSA_CRYPTO_SUBSYSTEM_ACCELERATORS_INDEX,
+    MBEDTLS_PSA_CRYPTO_SUBSYSTEM_SECURE_ELEMENTS_INDEX,
     /* Must come last. Value equal to the number of preceding elements. */
     MBEDTLS_PSA_CRYPTO_SUBSYSTEM_COUNT
 } mbedtls_psa_crypto_subsystem_index_t;
@@ -521,11 +523,36 @@ typedef uint32_t psa_crypto_subsystem_t;
 #define PSA_CRYPTO_SUBSYSTEM_STORAGE \
     ((psa_crypto_subsystem_t)1 << MBEDTLS_PSA_CRYPTO_SUBSYSTEM_STORAGE_INDEX)
 
+/** Accelerator drivers.
+ *
+ * Initializing this subsystem calls the initialization entry points
+ * of all registered accelerator drivers.
+ *
+ * Initializing this subsystem allows cryptographic operations that
+ * are implemented via an accelerator driver.
+ */
+#define PSA_CRYPTO_SUBSYSTEM_ACCELERATORS \
+    ((psa_crypto_subsystem_t)1 << MBEDTLS_PSA_CRYPTO_SUBSYSTEM_ACCELERATORS_INDEX)
+
+/** Secure element drivers.
+ *
+ * Initializing this subsystem calls the initialization entry points
+ * of all registered secure element drivers.
+ *
+ * Initializing this subsystem as well as #PSA_CRYPTO_SUBSYSTEM_KEYS
+ * allows creating, accessing and destroying keys in a secure element
+ * (i.e. keys whose location is not #PSA_KEY_LOCATION_LOCAL_STORAGE).
+ */
+#define PSA_CRYPTO_SUBSYSTEM_SECURE_ELEMENTS \
+    ((psa_crypto_subsystem_t)1 << MBEDTLS_PSA_CRYPTO_SUBSYSTEM_SECURE_ELEMENTS_INDEX)
+
 /* A mask of all the subsystems recognized by Mbed TLS. */
 #define MBEDTLS_PSA_CRYPTO_ALL_SUBSYSTEMS (     \
         PSA_CRYPTO_SUBSYSTEM_COMMUNICATION |    \
         PSA_CRYPTO_SUBSYSTEM_KEYS |             \
         PSA_CRYPTO_SUBSYSTEM_STORAGE |          \
+        PSA_CRYPTO_SUBSYSTEM_ACCELERATORS |     \
+        PSA_CRYPTO_SUBSYSTEM_SECURE_ELEMENTS |  \
         0 )
 
 /**@}*/

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -99,16 +99,9 @@ static int key_type_is_raw_bytes( psa_key_type_t type )
     return( PSA_KEY_TYPE_IS_UNSTRUCTURED( type ) );
 }
 
-
-/* Values for psa_global_data_t::rng_state */
-#define RNG_NOT_INITIALIZED 0
-#define RNG_INITIALIZED 1
-#define RNG_SEEDED 2
-
 typedef struct
 {
     psa_crypto_subsystem_t active_subsystems;
-    unsigned rng_state : 2;
     mbedtls_psa_random_context_t rng;
 } psa_global_data_t;
 
@@ -6359,7 +6352,8 @@ psa_status_t mbedtls_psa_crypto_configure_entropy_sources(
     void (* entropy_init )( mbedtls_entropy_context *ctx ),
     void (* entropy_free )( mbedtls_entropy_context *ctx ) )
 {
-    if( global_data.rng_state != RNG_NOT_INITIALIZED )
+    if( mbedtls_psa_crypto_is_subsystem_initialized(
+            PSA_CRYPTO_SUBSYSTEM_RANDOM ) )
         return( PSA_ERROR_BAD_STATE );
     global_data.rng.entropy_init = entropy_init;
     global_data.rng.entropy_free = entropy_free;
@@ -6370,14 +6364,11 @@ psa_status_t mbedtls_psa_crypto_configure_entropy_sources(
 void mbedtls_psa_crypto_free( void )
 {
     psa_wipe_all_key_slots( );
-    if( global_data.rng_state != RNG_NOT_INITIALIZED )
+    if( mbedtls_psa_crypto_is_subsystem_initialized(
+            PSA_CRYPTO_SUBSYSTEM_RANDOM ) )
     {
         mbedtls_psa_random_free( &global_data.rng );
     }
-    /* Wipe all remaining data, including configuration.
-     * In particular, this sets all state indicator to the value
-     * indicating "uninitialized". */
-    mbedtls_platform_zeroize( &global_data, sizeof( global_data ) );
 
     if( mbedtls_psa_crypto_is_subsystem_initialized(
             PSA_CRYPTO_SUBSYSTEM_SECURE_ELEMENTS ) )
@@ -6514,11 +6505,9 @@ psa_status_t psa_crypto_init_subsystem( psa_crypto_subsystem_t subsystems )
     if( subsystems & PSA_CRYPTO_SUBSYSTEM_RANDOM )
     {
         mbedtls_psa_random_init( &global_data.rng );
-        global_data.rng_state = RNG_INITIALIZED;
         status = mbedtls_psa_random_seed( &global_data.rng );
         if( status != PSA_SUCCESS )
             return( status );
-        global_data.rng_state = RNG_SEEDED;
         global_data.active_subsystems |= PSA_CRYPTO_SUBSYSTEM_RANDOM;
     }
 

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -6418,12 +6418,11 @@ psa_status_t psa_crypto_init( void )
         goto exit;
     global_data.rng_state = RNG_SEEDED;
 
-    status = psa_initialize_key_slots( );
+    /* Init drivers */
+    status = psa_driver_wrapper_init_accelerators( );
     if( status != PSA_SUCCESS )
         goto exit;
-
-    /* Init drivers */
-    status = psa_driver_wrapper_init( );
+    status = psa_driver_wrapper_init_secure_elements( );
     if( status != PSA_SUCCESS )
         goto exit;
 

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -6376,7 +6376,7 @@ psa_status_t psa_crypto_init_subsystem( psa_crypto_subsystem_t subsystems )
     /* If a subsystem is already initialized, skip it. */
     subsystems &= ~global_data.active_subsystems;
 
-    psa_status_t status = PSA_SUCCESS;
+    psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
 
     if( subsystems & PSA_CRYPTO_SUBSYSTEM_COMMUNICATION )
     {
@@ -6385,7 +6385,17 @@ psa_status_t psa_crypto_init_subsystem( psa_crypto_subsystem_t subsystems )
         global_data.active_subsystems |= PSA_CRYPTO_SUBSYSTEM_COMMUNICATION;
     }
 
-    return( status );
+    if( subsystems & ( PSA_CRYPTO_SUBSYSTEM_KEYS |
+                       PSA_CRYPTO_SUBSYSTEM_STORAGE ) )
+    {
+        status = psa_initialize_key_slots( );
+        if( status != PSA_SUCCESS )
+            return( status );
+        global_data.active_subsystems |= ( PSA_CRYPTO_SUBSYSTEM_KEYS |
+                                           PSA_CRYPTO_SUBSYSTEM_STORAGE );
+    }
+
+    return( PSA_SUCCESS );
 }
 
 psa_status_t psa_crypto_init( void )

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -6424,7 +6424,8 @@ psa_status_t psa_crypto_init_subsystem( psa_crypto_subsystem_t subsystems )
     }
 
     if( subsystems & ( PSA_CRYPTO_SUBSYSTEM_KEYS |
-                       PSA_CRYPTO_SUBSYSTEM_STORAGE ) )
+                       PSA_CRYPTO_SUBSYSTEM_STORAGE |
+                       PSA_CRYPTO_SUBSYSTEM_BUILTIN_KEYS ) )
     {
         status = psa_initialize_key_slots( );
         if( status != PSA_SUCCESS )
@@ -6439,7 +6440,8 @@ psa_status_t psa_crypto_init_subsystem( psa_crypto_subsystem_t subsystems )
         }
 #endif /* PSA_CRYPTO_STORAGE_HAS_TRANSACTIONS */
         global_data.active_subsystems |= ( PSA_CRYPTO_SUBSYSTEM_KEYS |
-                                           PSA_CRYPTO_SUBSYSTEM_STORAGE );
+                                           PSA_CRYPTO_SUBSYSTEM_STORAGE |
+                                           PSA_CRYPTO_SUBSYSTEM_BUILTIN_KEYS );
     }
 
     if( subsystems & PSA_CRYPTO_SUBSYSTEM_ACCELERATORS )

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -6360,6 +6360,23 @@ static psa_status_t psa_crypto_recover_transaction(
             return( PSA_ERROR_DATA_INVALID );
     }
 }
+
+static psa_crypto_init_transactions( void )
+{
+    psa_status_t status = psa_crypto_load_transaction( );
+    if( status == PSA_ERROR_DOES_NOT_EXIST )
+    {
+        /* There's no transaction to complete. It's all good. */
+        return( PSA_SUCCESS );
+    }
+    else if( status != PSA_SUCCESS )
+        return( status );
+
+    status = psa_crypto_recover_transaction( &psa_crypto_transaction );
+    if( status != PSA_SUCCESS )
+        return( status );
+    return( psa_crypto_stop_transaction( ) );
+}
 #endif /* PSA_CRYPTO_STORAGE_HAS_TRANSACTIONS */
 
 int mbedtls_psa_crypto_is_subsystem_initialized(
@@ -6427,19 +6444,9 @@ psa_status_t psa_crypto_init( void )
         goto exit;
 
 #if defined(PSA_CRYPTO_STORAGE_HAS_TRANSACTIONS)
-    status = psa_crypto_load_transaction( );
-    if( status == PSA_SUCCESS )
-    {
-        status = psa_crypto_recover_transaction( &psa_crypto_transaction );
-        if( status != PSA_SUCCESS )
-            goto exit;
-        status = psa_crypto_stop_transaction( );
-    }
-    else if( status == PSA_ERROR_DOES_NOT_EXIST )
-    {
-        /* There's no transaction to complete. It's all good. */
-        status = PSA_SUCCESS;
-    }
+    status = psa_crypto_init_transactions( );
+    if( status != PSA_SUCCESS )
+        goto exit;
 #endif /* PSA_CRYPTO_STORAGE_HAS_TRANSACTIONS */
 
     /* All done. */

--- a/library/psa_crypto_driver_wrappers.h
+++ b/library/psa_crypto_driver_wrappers.h
@@ -29,7 +29,8 @@
  */
 psa_status_t psa_driver_wrapper_init_accelerators( void );
 psa_status_t psa_driver_wrapper_init_secure_elements( void );
-void psa_driver_wrapper_free( void );
+void psa_driver_wrapper_free_accelerators( void );
+void psa_driver_wrapper_free_secure_elements( void );
 
 /*
  * Signature functions

--- a/library/psa_crypto_driver_wrappers.h
+++ b/library/psa_crypto_driver_wrappers.h
@@ -27,7 +27,8 @@
 /*
  * Initialization and termination functions
  */
-psa_status_t psa_driver_wrapper_init( void );
+psa_status_t psa_driver_wrapper_init_accelerators( void );
+psa_status_t psa_driver_wrapper_init_secure_elements( void );
 void psa_driver_wrapper_free( void );
 
 /*

--- a/scripts/data_files/driver_templates/psa_crypto_driver_wrappers.c.jinja
+++ b/scripts/data_files/driver_templates/psa_crypto_driver_wrappers.c.jinja
@@ -116,7 +116,14 @@ psa_status_t psa_driver_wrapper_init_secure_elements( void )
     return( PSA_SUCCESS );
 }
 
-void psa_driver_wrapper_free( void )
+void psa_driver_wrapper_free_accelerators( void )
+{
+#if defined(PSA_CRYPTO_DRIVER_TEST)
+    mbedtls_test_transparent_free( );
+#endif
+}
+
+void psa_driver_wrapper_free_secure_elements( void )
 {
 #if defined(MBEDTLS_PSA_CRYPTO_SE_C)
     /* Unregister all secure element drivers, so that we restart from
@@ -125,7 +132,6 @@ void psa_driver_wrapper_free( void )
 #endif /* MBEDTLS_PSA_CRYPTO_SE_C */
 
 #if defined(PSA_CRYPTO_DRIVER_TEST)
-    mbedtls_test_transparent_free( );
     mbedtls_test_opaque_free( );
 #endif
 }

--- a/scripts/data_files/driver_templates/psa_crypto_driver_wrappers.c.jinja
+++ b/scripts/data_files/driver_templates/psa_crypto_driver_wrappers.c.jinja
@@ -82,7 +82,21 @@
 #include "psa_crypto_se.h"
 #endif
 
-psa_status_t psa_driver_wrapper_init( void )
+psa_status_t psa_driver_wrapper_init_accelerators( void )
+{
+    psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
+
+#if defined(PSA_CRYPTO_DRIVER_TEST)
+    status = mbedtls_test_transparent_init( );
+    if( status != PSA_SUCCESS )
+        return( status );
+#endif
+
+    (void) status;
+    return( PSA_SUCCESS );
+}
+
+psa_status_t psa_driver_wrapper_init_secure_elements( void )
 {
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
 
@@ -93,10 +107,6 @@ psa_status_t psa_driver_wrapper_init( void )
 #endif
 
 #if defined(PSA_CRYPTO_DRIVER_TEST)
-    status = mbedtls_test_transparent_init( );
-    if( status != PSA_SUCCESS )
-        return( status );
-
     status = mbedtls_test_opaque_init( );
     if( status != PSA_SUCCESS )
         return( status );

--- a/tests/suites/test_suite_psa_crypto_init.data
+++ b/tests/suites/test_suite_psa_crypto_init.data
@@ -10,6 +10,15 @@ deinit_without_init:0
 PSA deinit twice
 deinit_without_init:1
 
+Subsystem init: none
+subsystem_init:0
+
+Subsystem init: communication
+subsystem_init:PSA_CRYPTO_SUBSYSTEM_COMMUNICATION
+
+Subsystem init: invalid
+subsystem_init_invalid:1 << MBEDTLS_PSA_CRYPTO_SUBSYSTEM_COUNT
+
 No random without init
 validate_module_init_generate_random:0
 

--- a/tests/suites/test_suite_psa_crypto_init.data
+++ b/tests/suites/test_suite_psa_crypto_init.data
@@ -22,6 +22,12 @@ subsystem_init:PSA_CRYPTO_SUBSYSTEM_KEYS
 Subsystem init: storage
 subsystem_init:PSA_CRYPTO_SUBSYSTEM_STORAGE
 
+Subsystem init: accelerators
+subsystem_init:PSA_CRYPTO_SUBSYSTEM_ACCELERATORS
+
+Subsystem init: secure elements
+subsystem_init:PSA_CRYPTO_SUBSYSTEM_SECURE_ELEMENTS
+
 Subsystem init: invalid
 subsystem_init_invalid:1 << MBEDTLS_PSA_CRYPTO_SUBSYSTEM_COUNT
 

--- a/tests/suites/test_suite_psa_crypto_init.data
+++ b/tests/suites/test_suite_psa_crypto_init.data
@@ -34,6 +34,9 @@ subsystem_init:PSA_CRYPTO_SUBSYSTEM_RANDOM
 Subsystem init: all except random generator
 subsystem_init:MBEDTLS_PSA_CRYPTO_ALL_SUBSYSTEMS & ~PSA_CRYPTO_SUBSYSTEM_RANDOM
 
+Subsystem init: built-in keys
+subsystem_init:PSA_CRYPTO_SUBSYSTEM_BUILTIN_KEYS
+
 Subsystem init: invalid
 subsystem_init_invalid:1 << MBEDTLS_PSA_CRYPTO_SUBSYSTEM_COUNT
 

--- a/tests/suites/test_suite_psa_crypto_init.data
+++ b/tests/suites/test_suite_psa_crypto_init.data
@@ -16,6 +16,12 @@ subsystem_init:0
 Subsystem init: communication
 subsystem_init:PSA_CRYPTO_SUBSYSTEM_COMMUNICATION
 
+Subsystem init: keys
+subsystem_init:PSA_CRYPTO_SUBSYSTEM_KEYS
+
+Subsystem init: storage
+subsystem_init:PSA_CRYPTO_SUBSYSTEM_STORAGE
+
 Subsystem init: invalid
 subsystem_init_invalid:1 << MBEDTLS_PSA_CRYPTO_SUBSYSTEM_COUNT
 

--- a/tests/suites/test_suite_psa_crypto_init.data
+++ b/tests/suites/test_suite_psa_crypto_init.data
@@ -28,6 +28,12 @@ subsystem_init:PSA_CRYPTO_SUBSYSTEM_ACCELERATORS
 Subsystem init: secure elements
 subsystem_init:PSA_CRYPTO_SUBSYSTEM_SECURE_ELEMENTS
 
+Subsystem init: random generator
+subsystem_init:PSA_CRYPTO_SUBSYSTEM_RANDOM
+
+Subsystem init: all except random generator
+subsystem_init:MBEDTLS_PSA_CRYPTO_ALL_SUBSYSTEMS & ~PSA_CRYPTO_SUBSYSTEM_RANDOM
+
 Subsystem init: invalid
 subsystem_init_invalid:1 << MBEDTLS_PSA_CRYPTO_SUBSYSTEM_COUNT
 

--- a/tests/suites/test_suite_psa_crypto_init.function
+++ b/tests/suites/test_suite_psa_crypto_init.function
@@ -20,6 +20,82 @@ exit:
     return( 0 );
 }
 
+/* Assume that the key store is initialized, but the random generator is not.
+ * Check that a cipher mechanism with IV behaves as expected. */
+static int test_symmetric_key_without_random( psa_key_type_t key_type,
+                                              psa_algorithm_t alg )
+{
+    psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
+    mbedtls_svc_key_id_t key = MBEDTLS_SVC_KEY_ID_INIT;
+    int ok = 0;
+
+    psa_set_key_type( &attributes, key_type );
+    psa_set_key_algorithm( &attributes, alg );
+    psa_set_key_usage_flags( &attributes,
+                             PSA_KEY_USAGE_ENCRYPT |
+                             PSA_KEY_USAGE_DECRYPT );
+    const uint8_t key_data[32] = "KKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKK";
+    PSA_ASSERT( psa_import_key( &attributes,
+                                key_data, sizeof( key_data ),
+                                &key ) );
+
+    uint8_t plaintext[16] = "This is a sample";
+    uint8_t ciphertext[32] = "[[[[IV  here]]]]CIPHERTEXT!";
+    size_t length;
+    PSA_ASSERT( psa_cipher_decrypt( key, alg,
+                                    ciphertext, sizeof( ciphertext ),
+                                    plaintext, sizeof( plaintext ),
+                                    &length ) );
+
+    /* Should fail to generate an IV */
+    TEST_EQUAL( PSA_ERROR_BAD_STATE,
+                psa_cipher_encrypt( key, alg,
+                                    plaintext, sizeof( plaintext ),
+                                    ciphertext, sizeof( ciphertext ),
+                                    &length ) );
+
+    PSA_ASSERT( psa_destroy_key( key ) );
+    psa_reset_key_attributes( &attributes );
+
+    ok = 1;
+
+exit:
+    psa_reset_key_attributes( &attributes );
+    psa_destroy_key( key );
+    return( ok );
+}
+
+/* Assume that the key store is initialized, but the random generator is not.
+ * Check that various cryptographic operations behave as expected.
+ *
+ * This function currently covers a representative set of algorithms.
+ * It does not attempt systematic coverage.
+ */
+static int test_with_keys_without_random( void )
+{
+    /* IV generation requires random, but decryption doesn't. */
+#if defined(PSA_WANT_KEY_TYPE_AES) && defined(PSA_WANT_ALG_CTR)
+    if( ! test_symmetric_key_without_random( PSA_KEY_TYPE_AES,
+                                             PSA_ALG_CTR ) )
+        return( 0 );
+#endif
+#if defined(PSA_WANT_KEY_TYPE_CAMELLIA) && defined(PSA_WANT_ALG_CTR)
+    if( ! test_symmetric_key_without_random( PSA_KEY_TYPE_CAMELLIA,
+                                             PSA_ALG_CTR ) )
+        return( 0 );
+#endif
+    /* Don't bother figuring out exactly in which configurations the function
+     * is unused. */
+    (void) test_symmetric_key_without_random;
+
+    /* TODO: check that signature verification is possible. */
+    /* TODO: check that signing with a built-in implementation that uses
+     * blinding is rejected. */
+    /* TODO: check that asymmetric encryption is rejected. */
+
+    return( 1 );
+}
+
 /* Check that the availability of API functions is coherent with
  * the claims from mbedtls_psa_crypto_is_subsystem_initialized(). */
 static int subsystems_are_coherent( void )
@@ -90,8 +166,14 @@ static int subsystems_are_coherent( void )
     {
         TEST_EQUAL( psa_generate_random( rnd1, sizeof( rnd1 ) ),
                     PSA_ERROR_BAD_STATE );
-        TEST_EQUAL( psa_generate_key( &attributes, &key ),
-                    PSA_ERROR_BAD_STATE );
+        if( mbedtls_psa_crypto_is_subsystem_initialized(
+                PSA_CRYPTO_SUBSYSTEM_KEYS ) )
+        {
+            TEST_EQUAL( psa_generate_key( &attributes, &key ),
+                        PSA_ERROR_BAD_STATE );
+            if( ! test_with_keys_without_random( ) )
+                goto exit;
+        }
     }
     psa_reset_key_attributes( &attributes );
 

--- a/tests/suites/test_suite_psa_crypto_init.function
+++ b/tests/suites/test_suite_psa_crypto_init.function
@@ -24,10 +24,47 @@ exit:
  * the claims from mbedtls_psa_crypto_is_subsystem_initialized(). */
 static int subsystems_are_coherent( void )
 {
+    int ok = 0;
+    psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
+    mbedtls_svc_key_id_t key = MBEDTLS_SVC_KEY_ID_INIT;
+    const uint8_t key_material[1] = {'K'};
+
     /* Communication: nothing to check since the tests are calling the library
      * directly. */
 
-    return( 1 );
+    psa_set_key_type( &attributes, PSA_KEY_TYPE_RAW_DATA );
+    if( mbedtls_psa_crypto_is_subsystem_initialized(
+            PSA_CRYPTO_SUBSYSTEM_KEYS ) )
+    {
+        PSA_ASSERT( psa_import_key( &attributes, key_material, 1, &key ) );
+        psa_reset_key_attributes( &attributes );
+        PSA_ASSERT( psa_get_key_attributes( key, &attributes ) );
+        TEST_EQUAL( psa_get_key_type( &attributes ), PSA_KEY_TYPE_RAW_DATA );
+        TEST_EQUAL( psa_get_key_bits( &attributes ), 8 );
+        PSA_ASSERT( psa_destroy_key( key ) );
+        key = MBEDTLS_SVC_KEY_ID_INIT;
+    }
+    else
+    {
+        TEST_EQUAL( psa_import_key( &attributes, key_material, 1, &key ),
+                    PSA_ERROR_BAD_STATE );
+        TEST_EQUAL( psa_get_key_attributes( key, &attributes ),
+                    PSA_ERROR_BAD_STATE );
+    }
+
+    /* Gray box testing: Mbed TLS currently initializes storage access
+     * together with the key store in memory. */
+    TEST_EQUAL( mbedtls_psa_crypto_is_subsystem_initialized(
+                    PSA_CRYPTO_SUBSYSTEM_KEYS ),
+                mbedtls_psa_crypto_is_subsystem_initialized(
+                    PSA_CRYPTO_SUBSYSTEM_STORAGE ) );
+
+    ok = 1;
+
+exit:
+    psa_reset_key_attributes( &attributes );
+    psa_destroy_key( key );
+    return( ok );
 }
 
 /* Some tests in this module configure entropy sources. */

--- a/tests/suites/test_suite_psa_crypto_init.function
+++ b/tests/suites/test_suite_psa_crypto_init.function
@@ -95,6 +95,13 @@ static int subsystems_are_coherent( void )
     }
     psa_reset_key_attributes( &attributes );
 
+    /* Gray box testing: Mbed TLS currently initializes built-in keys
+     * together with the key store in memory. */
+    TEST_EQUAL( mbedtls_psa_crypto_is_subsystem_initialized(
+                    PSA_CRYPTO_SUBSYSTEM_KEYS ),
+                mbedtls_psa_crypto_is_subsystem_initialized(
+                    PSA_CRYPTO_SUBSYSTEM_BUILTIN_KEYS ) );
+
     ok = 1;
 
 exit:

--- a/tests/suites/test_suite_psa_crypto_init.function
+++ b/tests/suites/test_suite_psa_crypto_init.function
@@ -59,6 +59,14 @@ static int subsystems_are_coherent( void )
                 mbedtls_psa_crypto_is_subsystem_initialized(
                     PSA_CRYPTO_SUBSYSTEM_STORAGE ) );
 
+    /* TODO: PSA_CRYPTO_SUBSYSTEM_ACCELERATORS */
+    /* Need to find an accelerated algorithm and try to use it. */
+    /* Also arrange a white-box check when using a test driver. */
+
+    /* TODO: PSA_CRYPTO_SUBSYSTEM_SECURE_ELEMENTS */
+    /* Need to find a secure element location and try to use it. */
+    /* Also arrange a white-box check when using a test driver. */
+
     ok = 1;
 
 exit:

--- a/tests/suites/test_suite_psa_crypto_init.function
+++ b/tests/suites/test_suite_psa_crypto_init.function
@@ -1,6 +1,35 @@
 /* BEGIN_HEADER */
 #include <stdint.h>
 
+static int all_subsystems_are_initialized( void )
+{
+    return( mbedtls_psa_crypto_is_subsystem_initialized(
+                MBEDTLS_PSA_CRYPTO_ALL_SUBSYSTEMS ) );
+}
+
+static int no_subsystems_are_initialized( void )
+{
+    mbedtls_psa_crypto_subsystem_index_t i;
+    for( i = 0; i < MBEDTLS_PSA_CRYPTO_SUBSYSTEM_COUNT; i++ )
+    {
+        TEST_ASSERT( ! mbedtls_psa_crypto_is_subsystem_initialized( 1 << i ) );
+    }
+    return( 1) ;
+
+exit:
+    return( 0 );
+}
+
+/* Check that the availability of API functions is coherent with
+ * the claims from mbedtls_psa_crypto_is_subsystem_initialized(). */
+static int subsystems_are_coherent( void )
+{
+    /* Communication: nothing to check since the tests are calling the library
+     * directly. */
+
+    return( 1 );
+}
+
 /* Some tests in this module configure entropy sources. */
 #include "psa_crypto_invasive.h"
 
@@ -139,9 +168,17 @@ void init_deinit( int count )
     {
         status = psa_crypto_init( );
         PSA_ASSERT( status );
+        TEST_ASSERT( all_subsystems_are_initialized( ) );
+        TEST_ASSERT( subsystems_are_coherent( ) );
+
         status = psa_crypto_init( );
         PSA_ASSERT( status );
+        TEST_ASSERT( all_subsystems_are_initialized( ) );
+        TEST_ASSERT( subsystems_are_coherent( ) );
+
         PSA_DONE( );
+        TEST_ASSERT( no_subsystems_are_initialized( ) );
+        TEST_ASSERT( subsystems_are_coherent( ) );
     }
 }
 /* END_CASE */
@@ -153,9 +190,55 @@ void deinit_without_init( int count )
     for( i = 0; i < count; i++ )
     {
         PSA_ASSERT( psa_crypto_init( ) );
+        TEST_ASSERT( all_subsystems_are_initialized( ) );
+        TEST_ASSERT( subsystems_are_coherent( ) );
+
         PSA_DONE( );
+        TEST_ASSERT( subsystems_are_coherent( ) );
+        TEST_ASSERT( no_subsystems_are_initialized( ) );
     }
+
     PSA_DONE( );
+    TEST_ASSERT( subsystems_are_coherent( ) );
+    TEST_ASSERT( no_subsystems_are_initialized( ) );
+}
+/* END_CASE */
+
+/* BEGIN_CASE */
+void subsystem_init( int subsystems )
+{
+    TEST_EQUAL( subsystems == 0,
+                mbedtls_psa_crypto_is_subsystem_initialized( subsystems ) );
+
+    mbedtls_test_set_step( 1 );
+    PSA_ASSERT( psa_crypto_init_subsystem( subsystems ) );
+    TEST_EQUAL( 1, mbedtls_psa_crypto_is_subsystem_initialized( subsystems ) );
+    TEST_ASSERT( subsystems_are_coherent( ) );
+
+    /* A second initialization should be a no-op */
+    mbedtls_test_set_step( 2 );
+    PSA_ASSERT( psa_crypto_init_subsystem( subsystems ) );
+    TEST_EQUAL( 1, mbedtls_psa_crypto_is_subsystem_initialized( subsystems ) );
+    TEST_ASSERT( subsystems_are_coherent( ) );
+
+    mbedtls_test_set_step( 3 );
+    PSA_DONE( );
+    TEST_ASSERT( no_subsystems_are_initialized( ) );
+    TEST_EQUAL( subsystems == 0,
+                mbedtls_psa_crypto_is_subsystem_initialized( subsystems ) );
+    TEST_ASSERT( subsystems_are_coherent( ) );
+}
+/* END_CASE */
+
+/* BEGIN_CASE */
+void subsystem_init_invalid( int subsystem )
+{
+    TEST_EQUAL( 0, mbedtls_psa_crypto_is_subsystem_initialized( subsystem ) );
+    TEST_EQUAL( psa_crypto_init_subsystem( subsystem ),
+                PSA_ERROR_INVALID_ARGUMENT );
+    TEST_EQUAL( 0, mbedtls_psa_crypto_is_subsystem_initialized( subsystem ) );
+    TEST_ASSERT( no_subsystems_are_initialized( ) );
+    TEST_ASSERT( subsystems_are_coherent( ) );
 }
 /* END_CASE */
 

--- a/tests/suites/test_suite_psa_crypto_init.function
+++ b/tests/suites/test_suite_psa_crypto_init.function
@@ -28,6 +28,7 @@ static int subsystems_are_coherent( void )
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     mbedtls_svc_key_id_t key = MBEDTLS_SVC_KEY_ID_INIT;
     const uint8_t key_material[1] = {'K'};
+    uint8_t rnd1[16] = {0}, rnd2[16] = {0};
 
     /* Communication: nothing to check since the tests are calling the library
      * directly. */
@@ -51,6 +52,7 @@ static int subsystems_are_coherent( void )
         TEST_EQUAL( psa_get_key_attributes( key, &attributes ),
                     PSA_ERROR_BAD_STATE );
     }
+    psa_reset_key_attributes( &attributes );
 
     /* Gray box testing: Mbed TLS currently initializes storage access
      * together with the key store in memory. */
@@ -66,6 +68,32 @@ static int subsystems_are_coherent( void )
     /* TODO: PSA_CRYPTO_SUBSYSTEM_SECURE_ELEMENTS */
     /* Need to find a secure element location and try to use it. */
     /* Also arrange a white-box check when using a test driver. */
+
+    psa_set_key_type( &attributes, PSA_KEY_TYPE_RAW_DATA );
+    psa_set_key_bits( &attributes, 8 );
+    if( mbedtls_psa_crypto_is_subsystem_initialized(
+            PSA_CRYPTO_SUBSYSTEM_RANDOM ) )
+    {
+        PSA_ASSERT( psa_generate_random( rnd1, sizeof( rnd1 ) ) );
+        PSA_ASSERT( psa_generate_random( rnd2, sizeof( rnd2 ) ) );
+        /* If the random generator is working properly, the chances of
+         * getting the same 16 bytes twice are negligible. */
+        TEST_ASSERT( memcmp( rnd1, rnd2, sizeof( rnd1 ) ) != 0 );
+
+        if( mbedtls_psa_crypto_is_subsystem_initialized(
+                PSA_CRYPTO_SUBSYSTEM_KEYS ) )
+        {
+            PSA_ASSERT( psa_generate_key( &attributes, &key ) );
+        }
+    }
+    else
+    {
+        TEST_EQUAL( psa_generate_random( rnd1, sizeof( rnd1 ) ),
+                    PSA_ERROR_BAD_STATE );
+        TEST_EQUAL( psa_generate_key( &attributes, &key ),
+                    PSA_ERROR_BAD_STATE );
+    }
+    psa_reset_key_attributes( &attributes );
 
     ok = 1;
 


### PR DESCRIPTION
Implement the upcoming PSA feature `psa_crypto_init_subsystem`, allowing partial initialization of PSA crypto. For example, you can start calculating hashes and verifying signatures without seeding the random generator.

Status: work in progress. The feature is fully implemented, but there are known bugs and test gaps. Out there for design review.

* The code may attempt to use accelerator drivers before they're initialized.
* Need tests involving drivers.
* Need tests where a subsystem's initialization fails.

## Gatekeeper checklist

- [ ] **changelog** TODO
- [ ] **backport** no (new feature)
- [ ] **tests** work in progress
