### PR TITLE
Re-enable the early data test cases with gnutls server

### DIFF
--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -817,6 +817,8 @@ static int ssl_tls13_write_identity( mbedtls_ssl_context *ssl,
      * - identity               (psk_identity_len bytes)
      * - obfuscated_ticket_age  (4 bytes)
      */
+    MBEDTLS_SSL_DEBUG_MSG( 4, ( "after add, obfuscated_ticket_age = %ud",
+                                (unsigned int)obfuscated_ticket_age ) );
     MBEDTLS_SSL_CHK_BUF_PTR( buf, end, 6 + identity_len );
 
     MBEDTLS_PUT_UINT16_BE( identity_len, buf, 0 );
@@ -947,6 +949,10 @@ int mbedtls_ssl_tls13_write_identities_of_pre_shared_key_ext(
         uint32_t obfuscated_ticket_age =
                                 (uint32_t)( now - session->ticket_received );
 
+        MBEDTLS_SSL_DEBUG_MSG( 4, ( "HAVE_TIME,  obfuscated_ticket_age = %ud",
+                                    (unsigned int)obfuscated_ticket_age ) );
+        MBEDTLS_SSL_DEBUG_MSG( 4, ( "HAVE_TIME,  session->ticket_age_add = %ud",
+                                    (unsigned int)session->ticket_age_add ) );
         obfuscated_ticket_age *= 1000;
         obfuscated_ticket_age += session->ticket_age_add;
 
@@ -955,6 +961,7 @@ int mbedtls_ssl_tls13_write_identities_of_pre_shared_key_ext(
                                         obfuscated_ticket_age,
                                         &output_len );
 #else
+        MBEDTLS_SSL_DEBUG_MSG( 4, ( "Not HAVE_TIME, write 0" ) );
         ret = ssl_tls13_write_identity( ssl, p, end, identity, identity_len,
                                         0, &output_len );
 #endif /* MBEDTLS_HAVE_TIME */

--- a/tests/opt-testcases/tls13-misc.sh
+++ b/tests/opt-testcases/tls13-misc.sh
@@ -282,12 +282,10 @@ run_test    "TLS 1.3: G->m: PSK: configured ephemeral only, good." \
             0 \
             -s "key exchange mode: ephemeral$"
 
-# skip the basic check now cause it will randomly trigger the anti-replay protection in gnutls_server
-# Add it back once we fix the issue
-skip_next_test
 requires_gnutls_tls1_3
 requires_config_enabled MBEDTLS_DEBUG_C
 requires_config_enabled MBEDTLS_SSL_CLI_C
+requires_config_enabled MBEDTLS_HAVE_TIME
 requires_all_configs_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE \
                              MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED \
                              MBEDTLS_SSL_EARLY_DATA


### PR DESCRIPTION

Session tickets need time to check the ticket_age.
Disable the test case if platform doesn't support MBEDTLS_HAVE_TIME