### PR TITLE
2.28 compat.sh: Restore testing against OpenSSL for pre 1.2 TLS versions

### DIFF
--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -867,12 +867,15 @@ setup_arguments()
     G_MODE=""
     case "$MODE" in
         "ssl3")
+            O_MODE="ssl3"
             G_PRIO_MODE="+VERS-SSL3.0"
             ;;
         "tls1")
+            O_MODE="tls1"
             G_PRIO_MODE="+VERS-TLS1.0"
             ;;
         "tls1_1")
+            O_MODE="tls1_1"
             G_PRIO_MODE="+VERS-TLS1.1"
             ;;
         "tls12")
@@ -880,6 +883,7 @@ setup_arguments()
             G_PRIO_MODE="+VERS-TLS1.2"
             ;;
         "dtls1")
+            O_MODE="dtls1"
             G_PRIO_MODE="+VERS-DTLS1.0"
             G_MODE="-u"
             ;;


### PR DESCRIPTION
## Description
Fix #6650

I've done some checks of the number of tests: full configuration + OpenSSL 1.0.2g.

./tests/compat.sh -p OpenSSL -m "ssl3 tls1 tls1_1 dtls1":
. mbedtls-2.28 + this PR: 232 tests 2 skipped
. mbedtls-2.28.0: 232 test 2 skipped

./tests/compat.sh
. mbedtls-2.28 + this PR: 1984 tests 4 skipped
. mbedtls-2.28.0: 856 tests 2 skipped
Much more tests now because of #5660 I think.

## Gatekeeper checklist
- [x] **changelog** not required
- [x] **backport** not required
- [x] **tests** not required