### PR TITLE
Bignum: add mod_raw_add

### DIFF
--- a/library/bignum_mod_raw.c
+++ b/library/bignum_mod_raw.c
@@ -119,7 +119,18 @@ int mbedtls_mpi_mod_raw_write( const mbedtls_mpi_uint *A,
 /* END MERGE SLOT 4 */
 
 /* BEGIN MERGE SLOT 5 */
-
+void MPI_CORE(add_mod)( mbedtls_mpi_uint *X,
+                        mbedtls_mpi_uint const *A,
+                        mbedtls_mpi_uint const *B,
+                        const mbedtls_mpi_uint *N,
+                        size_t n )
+{
+    size_t carry, borrow = 0, fixup;
+    carry  = mbedtls_mpi_core_add( X, A, B, n );
+    borrow = mbedtls_mpi_core_sub( X, X, N, n);
+    fixup  = ( carry < borrow );
+    (void) mbedtls_mpi_core_add_if( X, N, n, fixup );
+}
 /* END MERGE SLOT 5 */
 
 /* BEGIN MERGE SLOT 6 */

--- a/library/bignum_mod_raw.c
+++ b/library/bignum_mod_raw.c
@@ -122,13 +122,12 @@ int mbedtls_mpi_mod_raw_write( const mbedtls_mpi_uint *A,
 void mbedtls_mpi_mod_raw_add( mbedtls_mpi_uint *X,
                               mbedtls_mpi_uint const *A,
                               mbedtls_mpi_uint const *B,
-                              const mbedtls_mpi_uint *N,
-                              size_t limbs )
+                              const mbedtls_mpi_mod_modulus *N )
 {
     size_t carry, borrow = 0;
-    carry  = mbedtls_mpi_core_add( X, A, B, limbs );
-    borrow = mbedtls_mpi_core_sub( X, X, N, limbs);
-    (void) mbedtls_mpi_core_add_if( X, N, limbs, ( carry < borrow ) );
+    carry  = mbedtls_mpi_core_add( X, A, B, N->limbs );
+    borrow = mbedtls_mpi_core_sub( X, X, N->p, N->limbs );
+    (void) mbedtls_mpi_core_add_if( X, N->p, N->limbs, ( carry < borrow ) );
 }
 /* END MERGE SLOT 5 */
 

--- a/library/bignum_mod_raw.c
+++ b/library/bignum_mod_raw.c
@@ -127,7 +127,7 @@ void mbedtls_mpi_mod_raw_add( mbedtls_mpi_uint *X,
     mbedtls_mpi_uint carry, borrow;
     carry  = mbedtls_mpi_core_add( X, A, B, N->limbs );
     borrow = mbedtls_mpi_core_sub( X, X, N->p, N->limbs );
-    (void) mbedtls_mpi_core_add_if( X, N->p, N->limbs, (unsigned char) ( carry ^ borrow ) );
+    (void) mbedtls_mpi_core_add_if( X, N->p, N->limbs, (unsigned) ( carry ^ borrow ) );
 }
 /* END MERGE SLOT 5 */
 

--- a/library/bignum_mod_raw.c
+++ b/library/bignum_mod_raw.c
@@ -120,11 +120,11 @@ int mbedtls_mpi_mod_raw_write( const mbedtls_mpi_uint *A,
 
 /* BEGIN MERGE SLOT 5 */
 void mbedtls_mpi_mod_raw_add( mbedtls_mpi_uint *X,
-                              mbedtls_mpi_uint const *A,
-                              mbedtls_mpi_uint const *B,
+                              const mbedtls_mpi_uint *A,
+                              const mbedtls_mpi_uint *B,
                               const mbedtls_mpi_mod_modulus *N )
 {
-    size_t carry, borrow = 0;
+    mbedtls_mpi_uint carry, borrow;
     carry  = mbedtls_mpi_core_add( X, A, B, N->limbs );
     borrow = mbedtls_mpi_core_sub( X, X, N->p, N->limbs );
     (void) mbedtls_mpi_core_add_if( X, N->p, N->limbs, ( carry < borrow ) );

--- a/library/bignum_mod_raw.c
+++ b/library/bignum_mod_raw.c
@@ -127,7 +127,7 @@ void mbedtls_mpi_mod_raw_add( mbedtls_mpi_uint *X,
     mbedtls_mpi_uint carry, borrow;
     carry  = mbedtls_mpi_core_add( X, A, B, N->limbs );
     borrow = mbedtls_mpi_core_sub( X, X, N->p, N->limbs );
-    (void) mbedtls_mpi_core_add_if( X, N->p, N->limbs, ( carry < borrow ) );
+    (void) mbedtls_mpi_core_add_if( X, N->p, N->limbs, (unsigned char) ( carry ^ borrow ) );
 }
 /* END MERGE SLOT 5 */
 

--- a/library/bignum_mod_raw.c
+++ b/library/bignum_mod_raw.c
@@ -119,17 +119,16 @@ int mbedtls_mpi_mod_raw_write( const mbedtls_mpi_uint *A,
 /* END MERGE SLOT 4 */
 
 /* BEGIN MERGE SLOT 5 */
-void MPI_CORE(add_mod)( mbedtls_mpi_uint *X,
-                        mbedtls_mpi_uint const *A,
-                        mbedtls_mpi_uint const *B,
-                        const mbedtls_mpi_uint *N,
-                        size_t n )
+void mbedtls_mpi_mod_raw_add( mbedtls_mpi_uint *X,
+                              mbedtls_mpi_uint const *A,
+                              mbedtls_mpi_uint const *B,
+                              const mbedtls_mpi_uint *N,
+                              size_t limbs )
 {
-    size_t carry, borrow = 0, fixup;
-    carry  = mbedtls_mpi_core_add( X, A, B, n );
-    borrow = mbedtls_mpi_core_sub( X, X, N, n);
-    fixup  = ( carry < borrow );
-    (void) mbedtls_mpi_core_add_if( X, N, n, fixup );
+    size_t carry, borrow = 0;
+    carry  = mbedtls_mpi_core_add( X, A, B, limbs );
+    borrow = mbedtls_mpi_core_sub( X, X, N, limbs);
+    (void) mbedtls_mpi_core_add_if( X, N, limbs, ( carry < borrow ) );
 }
 /* END MERGE SLOT 5 */
 

--- a/library/bignum_mod_raw.h
+++ b/library/bignum_mod_raw.h
@@ -158,15 +158,19 @@ int mbedtls_mpi_mod_raw_write( const mbedtls_mpi_uint *A,
 /**
  * \brief Perform a known-size modular addition.
  *
- * Calculate `A + B modulo N` where \p A, \p B, and \p N have the same size.
+ * Calculate `A + B modulo N`.
+ *
+ * The number of limbs in each operand, and the result, is given by the
+ * modulus \p N.
+ *
+ * \p X may be aliased to \p A or \p B, or even both, but may not overlap
+ * either otherwise.
  *
  * \param[out] X    The result of the modular addition.
  * \param[in] A     Little-endian presentation of the left operand. This
- *                  must be smaller than \p N, and have the same number of
- *                  limbs.
+ *                  must be smaller than \p N.
  * \param[in] B     Little-endian presentation of the right operand. This
- *                  must be smaller than \p N, and have the same number of
- *                  limbs.
+ *                  must be smaller than \p N.
  * \param[in] N     The address of the modulus.
  */
 void mbedtls_mpi_mod_raw_add( mbedtls_mpi_uint *X,

--- a/library/bignum_mod_raw.h
+++ b/library/bignum_mod_raw.h
@@ -158,17 +158,21 @@ int mbedtls_mpi_mod_raw_write( const mbedtls_mpi_uint *A,
 /**
  * \brief Perform a known-size modular addition.
  *
- * Calculate A + B mod N.
+ * Calculate `A + B modulo N` where \p A, \p B, and \p N have the same size.
  *
- * \param[out] X        The result of the modular addition.
- * \param[in] A         The left operand. This must be smaller than \p N.
- * \param[in] B         The right operand. This must be smaller than \p N.
- * \param[in] N         The modulus.
- * \param n             Number of limbs of \p X, \p A, \p B and \p N.
+ * \param[out] X    The result of the modular addition.
+ * \param[in] A     Little-endian presentation of the left operand. This
+ *                  must be smaller than \p N.
+ * \param[in] B     Little-endian presentation of the right operand. This
+ *                  must be smaller than \p N.
+ * \param[in] N     Little-endian presentation of the modulus.
+ * \param limbs     Number of limbs of \p X, \p A, \p B and \p N.
  */
-void MPI_CORE(add_mod)( mbedtls_mpi_uint *X, mbedtls_mpi_uint const *A,
-                        mbedtls_mpi_uint const *B, const mbedtls_mpi_uint *N,
-                        size_t n );
+void mbedtls_mpi_mod_raw_add( mbedtls_mpi_uint *X,
+                              mbedtls_mpi_uint const *A,
+                              mbedtls_mpi_uint const *B,
+                              const mbedtls_mpi_uint *N,
+                              size_t limbs );
 /* END MERGE SLOT 5 */
 
 /* BEGIN MERGE SLOT 6 */

--- a/library/bignum_mod_raw.h
+++ b/library/bignum_mod_raw.h
@@ -155,7 +155,20 @@ int mbedtls_mpi_mod_raw_write( const mbedtls_mpi_uint *A,
 /* END MERGE SLOT 4 */
 
 /* BEGIN MERGE SLOT 5 */
-
+/**
+ * \brief Perform a known-size modular addition.
+ *
+ * Calculate A + B mod N.
+ *
+ * \param[out] X        The result of the modular addition.
+ * \param[in] A         The left operand. This must be smaller than \p N.
+ * \param[in] B         The right operand. This must be smaller than \p N.
+ * \param[in] N         The modulus.
+ * \param n             Number of limbs of \p X, \p A, \p B and \p N.
+ */
+void MPI_CORE(add_mod)( mbedtls_mpi_uint *X, mbedtls_mpi_uint const *A,
+                        mbedtls_mpi_uint const *B, const mbedtls_mpi_uint *N,
+                        size_t n );
 /* END MERGE SLOT 5 */
 
 /* BEGIN MERGE SLOT 6 */

--- a/library/bignum_mod_raw.h
+++ b/library/bignum_mod_raw.h
@@ -162,17 +162,17 @@ int mbedtls_mpi_mod_raw_write( const mbedtls_mpi_uint *A,
  *
  * \param[out] X    The result of the modular addition.
  * \param[in] A     Little-endian presentation of the left operand. This
- *                  must be smaller than \p N.
+ *                  must be smaller than \p N, and have the same number of
+ *                  limbs.
  * \param[in] B     Little-endian presentation of the right operand. This
- *                  must be smaller than \p N.
- * \param[in] N     Little-endian presentation of the modulus.
- * \param limbs     Number of limbs of \p X, \p A, \p B and \p N.
+ *                  must be smaller than \p N, and have the same number of
+ *                  limbs.
+ * \param[in] N     The address of the modulus.
  */
 void mbedtls_mpi_mod_raw_add( mbedtls_mpi_uint *X,
                               mbedtls_mpi_uint const *A,
                               mbedtls_mpi_uint const *B,
-                              const mbedtls_mpi_uint *N,
-                              size_t limbs );
+                              const mbedtls_mpi_mod_modulus *N );
 /* END MERGE SLOT 5 */
 
 /* BEGIN MERGE SLOT 6 */

--- a/library/bignum_mod_raw.h
+++ b/library/bignum_mod_raw.h
@@ -170,8 +170,8 @@ int mbedtls_mpi_mod_raw_write( const mbedtls_mpi_uint *A,
  * \param[in] N     The address of the modulus.
  */
 void mbedtls_mpi_mod_raw_add( mbedtls_mpi_uint *X,
-                              mbedtls_mpi_uint const *A,
-                              mbedtls_mpi_uint const *B,
+                              const mbedtls_mpi_uint *A,
+                              const mbedtls_mpi_uint *B,
                               const mbedtls_mpi_mod_modulus *N );
 /* END MERGE SLOT 5 */
 

--- a/scripts/mbedtls_dev/bignum_mod_raw.py
+++ b/scripts/mbedtls_dev/bignum_mod_raw.py
@@ -42,6 +42,25 @@ class BignumModRawTarget(test_data_generation.BaseTarget):
 
 # BEGIN MERGE SLOT 5
 
+class BignumModRawAdd(bignum_common.ModOperationCommon,
+                      BignumModRawTarget):
+    """Test cases for bignum mpi_mod_raw_add()."""
+    symbol = "+"
+    test_function = "mpi_mod_raw_add"
+    test_name = "mbedtls_mpi_mod_raw_add"
+    input_style = "fixed"
+    arity = 2
+
+    def arguments(self) -> List[str]:
+        return [bignum_common.quote_str(n) for n in [self.arg_a,
+                                                     self.arg_b,
+                                                     self.arg_n]
+               ] + self.result()
+
+    def result(self) -> List[str]:
+        result = (self.int_a + self.int_b) % self.int_n
+        return [self.format_result(result)]
+
 # END MERGE SLOT 5
 
 # BEGIN MERGE SLOT 6

--- a/scripts/mbedtls_dev/bignum_mod_raw.py
+++ b/scripts/mbedtls_dev/bignum_mod_raw.py
@@ -51,12 +51,6 @@ class BignumModRawAdd(bignum_common.ModOperationCommon,
     input_style = "fixed"
     arity = 2
 
-    def arguments(self) -> List[str]:
-        return [bignum_common.quote_str(n) for n in [self.arg_a,
-                                                     self.arg_b,
-                                                     self.arg_n]
-               ] + self.result()
-
     def result(self) -> List[str]:
         result = (self.int_a + self.int_b) % self.int_n
         return [self.format_result(result)]

--- a/tests/suites/test_suite_bignum_mod_raw.function
+++ b/tests/suites/test_suite_bignum_mod_raw.function
@@ -288,8 +288,9 @@ exit:
 /* BEGIN MERGE SLOT 5 */
 
 /* BEGIN_CASE */
-void mpi_mod_raw_add( char * input_A, char * input_B,
-                      char * input_N, char * input_S )
+void mpi_mod_raw_add( char * input_N,
+                      char * input_A, char * input_B,
+                      char * input_S )
 {
     mbedtls_mpi_uint *A = NULL;
     mbedtls_mpi_uint *B = NULL;

--- a/tests/suites/test_suite_bignum_mod_raw.function
+++ b/tests/suites/test_suite_bignum_mod_raw.function
@@ -287,6 +287,97 @@ exit:
 
 /* BEGIN MERGE SLOT 5 */
 
+/* BEGIN_CASE */
+void mpi_mod_raw_add( char * input_A, char * input_B,
+                      char * input_N, char * input_S )
+{
+    mbedtls_mpi_uint *A = NULL;
+    mbedtls_mpi_uint *B = NULL;
+    mbedtls_mpi_uint *S = NULL;
+    mbedtls_mpi_uint *N = NULL;
+    mbedtls_mpi_uint *X = NULL;
+    mbedtls_mpi_mod_modulus m;
+    size_t A_limbs, B_limbs, N_limbs, S_limbs;
+
+    mbedtls_mpi_mod_modulus_init( &m );
+
+    TEST_EQUAL( 0, mbedtls_test_read_mpi_core( &A, &A_limbs, input_A ) );
+    TEST_EQUAL( 0, mbedtls_test_read_mpi_core( &B, &B_limbs, input_B ) );
+    TEST_EQUAL( 0, mbedtls_test_read_mpi_core( &N, &N_limbs, input_N ) );
+    TEST_EQUAL( 0, mbedtls_test_read_mpi_core( &S, &S_limbs, input_S ) );
+
+    /* All inputs must have have the same number of limbs. */
+    TEST_EQUAL( A_limbs, B_limbs );
+    TEST_EQUAL( S_limbs, N_limbs );
+    TEST_EQUAL( A_limbs, S_limbs );
+
+    size_t limbs = A_limbs;
+    size_t bytes = limbs * sizeof( *A );
+
+    ASSERT_ALLOC( X, limbs );
+
+    TEST_EQUAL( mbedtls_mpi_mod_modulus_setup(
+                        &m, N, limbs,
+                        MBEDTLS_MPI_MOD_EXT_REP_BE,
+                        MBEDTLS_MPI_MOD_REP_MONTGOMERY
+                ), 0 );
+
+    /* A + B => Correct result */
+    mbedtls_mpi_mod_raw_add( X, A, B, &m );
+    ASSERT_COMPARE( X, bytes, S, bytes );
+
+    /* A + B: alias X to A => Correct result */
+    memcpy( X, A, bytes );
+    mbedtls_mpi_mod_raw_add( X, X, B, &m );
+    ASSERT_COMPARE( X, bytes, S, bytes );
+
+    /* A + B: alias X to B => Correct result */
+    memcpy( X, B, bytes );
+    mbedtls_mpi_mod_raw_add( X, A, X, &m );
+    ASSERT_COMPARE( X, bytes, S, bytes );
+
+    if ( memcmp(A, B, bytes ) == 0 )
+    {
+        /* A == B: alias A and B */
+
+        /* A + A => Correct result */
+        mbedtls_mpi_mod_raw_add( X, A, A, &m );
+        ASSERT_COMPARE( X, bytes, S, bytes );
+
+        /* A + A, alias X to A => Correct result */
+        memcpy( X, A, bytes );
+        mbedtls_mpi_mod_raw_add( X, A, A, &m );
+        ASSERT_COMPARE( X, bytes, S, bytes );
+    }
+    else
+    {
+        /* A != B: test B + A */
+
+        /* B + A => Correct result */
+        mbedtls_mpi_mod_raw_add( X, B, A, &m );
+        ASSERT_COMPARE( X, bytes, S, bytes );
+
+        /* B + A: alias X to A => Correct result */
+        memcpy( X, A, bytes );
+        mbedtls_mpi_mod_raw_add( X, B, X, &m );
+        ASSERT_COMPARE( X, bytes, S, bytes );
+
+        /* B + A: alias X to B => Correct result */
+        memcpy( X, B, bytes );
+        mbedtls_mpi_mod_raw_add( X, X, A, &m );
+        ASSERT_COMPARE( X, bytes, S, bytes );
+    }
+
+exit:
+    mbedtls_free( A );
+    mbedtls_free( B );
+    mbedtls_free( S );
+    mbedtls_free( N );
+    mbedtls_free( X );
+
+    mbedtls_mpi_mod_modulus_free( &m );
+}
+/* END_CASE */
 /* END MERGE SLOT 5 */
 
 /* BEGIN MERGE SLOT 6 */

--- a/tests/suites/test_suite_bignum_mod_raw.function
+++ b/tests/suites/test_suite_bignum_mod_raw.function
@@ -370,13 +370,13 @@ void mpi_mod_raw_add( char * input_N,
     }
 
 exit:
+    mbedtls_mpi_mod_modulus_free( &m );
+
     mbedtls_free( A );
     mbedtls_free( B );
     mbedtls_free( S );
     mbedtls_free( N );
     mbedtls_free( X );
-
-    mbedtls_mpi_mod_modulus_free( &m );
 }
 /* END_CASE */
 /* END MERGE SLOT 5 */

--- a/tests/suites/test_suite_bignum_mod_raw.function
+++ b/tests/suites/test_suite_bignum_mod_raw.function
@@ -296,9 +296,9 @@ void mpi_mod_raw_add( char * input_A, char * input_B,
     mbedtls_mpi_uint *S = NULL;
     mbedtls_mpi_uint *N = NULL;
     mbedtls_mpi_uint *X = NULL;
-    mbedtls_mpi_mod_modulus m;
     size_t A_limbs, B_limbs, N_limbs, S_limbs;
 
+    mbedtls_mpi_mod_modulus m;
     mbedtls_mpi_mod_modulus_init( &m );
 
     TEST_EQUAL( 0, mbedtls_test_read_mpi_core( &A, &A_limbs, input_A ) );
@@ -306,13 +306,13 @@ void mpi_mod_raw_add( char * input_A, char * input_B,
     TEST_EQUAL( 0, mbedtls_test_read_mpi_core( &N, &N_limbs, input_N ) );
     TEST_EQUAL( 0, mbedtls_test_read_mpi_core( &S, &S_limbs, input_S ) );
 
-    /* All inputs must have have the same number of limbs. */
-    TEST_EQUAL( A_limbs, B_limbs );
-    TEST_EQUAL( S_limbs, N_limbs );
-    TEST_EQUAL( A_limbs, S_limbs );
-
-    size_t limbs = A_limbs;
+    /* Modulus gives the number of limbs; all inputs must have the same. */
+    size_t limbs = N_limbs;
     size_t bytes = limbs * sizeof( *A );
+
+    TEST_EQUAL( A_limbs, limbs );
+    TEST_EQUAL( B_limbs, limbs );
+    TEST_EQUAL( S_limbs, limbs );
 
     ASSERT_ALLOC( X, limbs );
 

--- a/tests/suites/test_suite_bignum_mod_raw.function
+++ b/tests/suites/test_suite_bignum_mod_raw.function
@@ -344,9 +344,9 @@ void mpi_mod_raw_add( char * input_A, char * input_B,
         mbedtls_mpi_mod_raw_add( X, A, A, &m );
         ASSERT_COMPARE( X, bytes, S, bytes );
 
-        /* A + A, alias X to A => Correct result */
+        /* A + A: X, A, B all aliased together => Correct result */
         memcpy( X, A, bytes );
-        mbedtls_mpi_mod_raw_add( X, A, A, &m );
+        mbedtls_mpi_mod_raw_add( X, X, X, &m );
         ASSERT_COMPARE( X, bytes, S, bytes );
     }
     else


### PR DESCRIPTION
## Description

Resolves #6225 

Adds `mbedtls_mpi_mod_raw_add()`, with implementation from [prototype](https://github.com/hanno-becker/mbedtls/blob/ecp_prototype/library/bignum_core.c#L415-L426).
This is modified to take a modulus structure in place of the modulus mpi and limbs parameters.

Test cases are generated for a variety of moduli using the python test framework.

**Most of this work is from Werner's PR #6546, with minor changes to comments by me, and completely different python test generation, using the new framework**

## Gatekeeper checklist

- [x] **changelog** not required
- [x] **backport** not required
- [x] **tests** provided

