### PR TITLE
Fix typo 'unsupoported' -> 'unsupported'

### DIFF
--- a/tests/data_files/Makefile
+++ b/tests/data_files/Makefile
@@ -280,7 +280,7 @@ server5-nonprintable_othername.crt: server5.key
 	$(OPENSSL) req -x509 -new -subj "/C=UK/O=Mbed TLS/CN=Mbed TLS non-printable othername SAN" -set_serial 77 -config $(test_ca_config_file) -extensions nonprintable_othername_san -days 3650 -sha256 -key $< -out $@
 
 server5-unsupported_othername.crt: server5.key
-	$(OPENSSL) req -x509 -new -subj "/C=UK/O=Mbed TLS/CN=Mbed TLS unsupported othername SAN" -set_serial 77 -config $(test_ca_config_file) -extensions unsupoported_othername_san -days 3650 -sha256 -key $< -out $@
+	$(OPENSSL) req -x509 -new -subj "/C=UK/O=Mbed TLS/CN=Mbed TLS unsupported othername SAN" -set_serial 77 -config $(test_ca_config_file) -extensions unsupported_othername_san -days 3650 -sha256 -key $< -out $@
 
 server5-fan.crt: server5.key
 	$(OPENSSL) req -x509 -new -subj "/C=UK/O=Mbed TLS/CN=Mbed TLS FAN" -set_serial 77 -config $(test_ca_config_file) -extensions fan_cert -days 3650 -sha256 -key server5.key -out $@

--- a/tests/data_files/test-ca.opensslconf
+++ b/tests/data_files/test-ca.opensslconf
@@ -18,7 +18,7 @@ subjectAltName=otherName:1.3.6.1.5.5.7.8.4;SEQ:hw_module_name
 [nonprintable_othername_san]
 subjectAltName=otherName:1.3.6.1.5.5.7.8.4;SEQ:nonprintable_hw_module_name
 
-[unsupoported_othername_san]
+[unsupported_othername_san]
 subjectAltName=otherName:1.2.3.4;UTF8:some other identifier
 
 [dns_alt_names]


### PR DESCRIPTION
Fix a typo in test files: "unsupoported" is not a word.


## Gatekeeper checklist

- [ ] ~**changelog** provided, or~ not required
- [x] **backport** done, or not required #6664 
- [ ] ~**tests** provided, or~ not required