### PR TITLE
Move SSL modules out of libmbedcrypto

### DIFF
--- a/ChangeLog.d/move-ssl-modules.txt
+++ b/ChangeLog.d/move-ssl-modules.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Move some SSL-specific code out of libmbedcrypto where it had been placed
+     accidentally.

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -49,8 +49,6 @@ set(src_crypto
     md.c
     md5.c
     memory_buffer_alloc.c
-    mps_reader.c
-    mps_trace.c
     nist_kw.c
     oid.c
     padlock.c
@@ -103,6 +101,8 @@ set(src_x509
 
 set(src_tls
     debug.c
+    mps_reader.c
+    mps_trace.c
     net_sockets.c
     ssl_cache.c
     ssl_ciphersuites.c

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -84,7 +84,6 @@ set(src_crypto
     sha1.c
     sha256.c
     sha512.c
-    ssl_debug_helpers_generated.c
     threading.c
     timing.c
     version.c
@@ -109,6 +108,7 @@ set(src_tls
     ssl_ciphersuites.c
     ssl_client.c
     ssl_cookie.c
+    ssl_debug_helpers_generated.c
     ssl_msg.c
     ssl_ticket.c
     ssl_tls.c

--- a/library/Makefile
+++ b/library/Makefile
@@ -149,7 +149,6 @@ OBJS_CRYPTO= \
 	     sha1.o \
 	     sha256.o \
 	     sha512.o \
-	     ssl_debug_helpers_generated.o \
 	     threading.o \
 	     timing.o \
 	     version.o \
@@ -178,6 +177,7 @@ OBJS_TLS= \
 	  ssl_ciphersuites.o \
 	  ssl_client.o \
 	  ssl_cookie.o \
+	  ssl_debug_helpers_generated.o \
 	  ssl_msg.o \
 	  ssl_ticket.o \
 	  ssl_tls.o \

--- a/library/Makefile
+++ b/library/Makefile
@@ -114,8 +114,6 @@ OBJS_CRYPTO= \
 	     md.o \
 	     md5.o \
 	     memory_buffer_alloc.o \
-	     mps_reader.o \
-	     mps_trace.o \
 	     nist_kw.o \
 	     oid.o \
 	     padlock.o \
@@ -172,6 +170,8 @@ OBJS_X509= \
 
 OBJS_TLS= \
 	  debug.o \
+	  mps_reader.o \
+	  mps_trace.o \
 	  net_sockets.o \
 	  ssl_cache.o \
 	  ssl_ciphersuites.o \


### PR DESCRIPTION
`ssl_debug_helpers_generated` was accidentally added to libmbedcrypto instead of libmbedtls in 3.1. The MPS modules were accidentally added to libmbedcrypto instead of libmbedtls in 2.27. Move them to the correct library.

This is an ABI change for libmbedcrypto (a new libmbedtls wouldn't work with the old libmbedcrypto since it's missing those functions). It isn't an API change since none of those modules implement any functions that are part of the API.

The bug is also present in 2.28, but this only concerns TLS 1.3 (the only feature that uses MPS) and in 2.28 it's a work in progress that isn't really usable for anything. So it's not worth breaking the ABI in 2.28 LTS.

## Gatekeeper checklist

- [x] **changelog** provided
- [x] **backport** no
- [x] **tests** not applicable
