### PR TITLE
Add a changelog entry explaining usage of PSA in TLS 1.2 EC J-PAKE

### DIFF
--- a/ChangeLog.d/ecjpake-in-tls.txt
+++ b/ChangeLog.d/ecjpake-in-tls.txt
@@ -1,0 +1,5 @@
+Features
+   * The TLS 1.2 EC J-PAKE key exchange can now use the PSA Crypto API.
+     Additional PSA key slots will be allocated in the process of such key
+     exchange for builds that enable MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED and
+     MBEDTLS_USE_PSA_CRYPTO.


### PR DESCRIPTION
Missing changelog entry after https://github.com/Mbed-TLS/mbedtls/pull/6533 was merged.
Fixes https://github.com/Mbed-TLS/mbedtls/issues/6653.