### PR TITLE
Tell cmake to get SKIP_TEST_SUITES from ENV

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -107,6 +107,10 @@ endif()
 # the risk of a race.
 add_custom_target(test_suite_bignum_generated_data DEPENDS ${bignum_generated_data_files})
 add_custom_target(test_suite_psa_generated_data DEPENDS ${psa_generated_data_files})
+# If SKIP_TEST_SUITES is not defined with -D, get it from the environment.
+if((NOT DEFINED SKIP_TEST_SUITES) AND (DEFINED ENV{SKIP_TEST_SUITES}))
+    set(SKIP_TEST_SUITES $ENV{SKIP_TEST_SUITES})
+endif()
 # Test suites caught by SKIP_TEST_SUITES are built but not executed.
 # "foo" as a skip pattern skips "test_suite_foo" and "test_suite_foo.bar"
 # but not "test_suite_foobar".


### PR DESCRIPTION
If the variable SKIP_TEST_SUITES is not defined with -D, but is defined in an environment variable, tell cmake to get it from there.

This should allow #6665 to work.

## Gatekeeper checklist

- [x] **changelog** provided, or not required
- [x] **backport** done, or not required
- [x] **tests** provided, or not required

