### PR TITLE
Allow isolation of EC J-PAKE password when used in TLS

### DIFF
--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -3860,6 +3860,26 @@ void mbedtls_ssl_conf_sni( mbedtls_ssl_config *conf,
 int mbedtls_ssl_set_hs_ecjpake_password( mbedtls_ssl_context *ssl,
                                          const unsigned char *pw,
                                          size_t pw_len );
+
+/**
+ * \brief          Set the EC J-PAKE opaque password for current handshake.
+ *
+ * \note           An internal copy is made, and destroyed as soon as the
+ *                 handshake is completed, or when the SSL context is reset or
+ *                 freed.
+ *
+ * \note           The SSL context needs to be already set up. The right place
+ *                 to call this function is between \c mbedtls_ssl_setup() or
+ *                 \c mbedtls_ssl_reset() and \c mbedtls_ssl_handshake().
+ *                 Password cannot be empty (see RFC 8236).
+ *
+ * \param ssl      SSL context
+ * \param pwd      EC J-PAKE opaque password
+ *
+ * \return         0 on success, or a negative error code.
+ */
+int mbedtls_ssl_set_hs_ecjpake_password_opaque( mbedtls_ssl_context *ssl,
+                                                mbedtls_svc_key_id_t pwd );
 #endif /*MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED */
 
 #if defined(MBEDTLS_SSL_ALPN)

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -3864,8 +3864,7 @@ int mbedtls_ssl_set_hs_ecjpake_password( mbedtls_ssl_context *ssl,
 /**
  * \brief          Set the EC J-PAKE opaque password for current handshake.
  *
- * \note           The input key in not copied, so the caller must not destroy
- *                 it before the handshake is over.
+ * \note           The key must remain valid until the handshake is over.
  *
  * \note           The SSL context needs to be already set up. The right place
  *                 to call this function is between \c mbedtls_ssl_setup() or

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -3864,14 +3864,12 @@ int mbedtls_ssl_set_hs_ecjpake_password( mbedtls_ssl_context *ssl,
 /**
  * \brief          Set the EC J-PAKE opaque password for current handshake.
  *
- * \note           An internal copy is made, and destroyed as soon as the
- *                 handshake is completed, or when the SSL context is reset or
- *                 freed.
+ * \note           The input key in not copied, so the caller must not destroy
+ *                 it before the handshake is over.
  *
  * \note           The SSL context needs to be already set up. The right place
  *                 to call this function is between \c mbedtls_ssl_setup() or
  *                 \c mbedtls_ssl_reset() and \c mbedtls_ssl_handshake().
- *                 Password cannot be empty (see RFC 8236).
  *
  * \param ssl      SSL context
  * \param pwd      EC J-PAKE opaque password

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1908,7 +1908,7 @@ int mbedtls_ssl_set_hs_ecjpake_password( mbedtls_ssl_context *ssl,
         return( MBEDTLS_ERR_SSL_HW_ACCEL_FAILED );
     }
 
-    psa_pake_set_password_key( &ssl->handshake->psa_pake_ctx,
+    status = psa_pake_set_password_key( &ssl->handshake->psa_pake_ctx,
                                 ssl->handshake->psa_pake_password );
     if( status != PSA_SUCCESS )
     {
@@ -1956,7 +1956,7 @@ int mbedtls_ssl_set_hs_ecjpake_password_opaque( mbedtls_ssl_context *ssl,
     if( status != PSA_SUCCESS )
         goto error;
 
-    psa_pake_set_password_key( &ssl->handshake->psa_pake_ctx,
+    status = psa_pake_set_password_key( &ssl->handshake->psa_pake_ctx,
                                 ssl->handshake->psa_pake_password );
     if( status != PSA_SUCCESS )
         goto error;

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1945,7 +1945,7 @@ int mbedtls_ssl_set_hs_ecjpake_password_opaque( mbedtls_ssl_context *ssl,
 
     status = psa_pake_setup( &ssl->handshake->psa_pake_ctx, &cipher_suite );
     if( status != PSA_SUCCESS )
-        goto error;
+        return( MBEDTLS_ERR_SSL_HW_ACCEL_FAILED );
 
     if( ssl->conf->endpoint == MBEDTLS_SSL_IS_SERVER )
         psa_role = PSA_PAKE_ROLE_SERVER;

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1991,6 +1991,10 @@ int mbedtls_ssl_set_hs_ecjpake_password( mbedtls_ssl_context *ssl,
     else
         role = MBEDTLS_ECJPAKE_CLIENT;
 
+    /* Empty password is not valid  */
+    if( ( pw == NULL) || ( pw_len == 0 ) )
+        return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
+
     return( mbedtls_ecjpake_setup( &ssl->handshake->ecjpake_ctx,
                                    role,
                                    MBEDTLS_MD_SHA256,

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1950,31 +1950,24 @@ int mbedtls_ssl_set_hs_ecjpake_password_opaque( mbedtls_ssl_context *ssl,
 
     status = psa_pake_setup( &ssl->handshake->psa_pake_ctx, &cipher_suite );
     if( status != PSA_SUCCESS )
-    {
-        psa_destroy_key( ssl->handshake->psa_pake_password );
-        return( MBEDTLS_ERR_SSL_HW_ACCEL_FAILED );
-    }
+        goto error;
 
     status = psa_pake_set_role( &ssl->handshake->psa_pake_ctx, psa_role );
     if( status != PSA_SUCCESS )
-    {
-        psa_destroy_key( ssl->handshake->psa_pake_password );
-        psa_pake_abort( &ssl->handshake->psa_pake_ctx );
-        return( MBEDTLS_ERR_SSL_HW_ACCEL_FAILED );
-    }
+        goto error;
 
     psa_pake_set_password_key( &ssl->handshake->psa_pake_ctx,
                                 ssl->handshake->psa_pake_password );
     if( status != PSA_SUCCESS )
-    {
-        psa_destroy_key( ssl->handshake->psa_pake_password );
-        psa_pake_abort( &ssl->handshake->psa_pake_ctx );
-        return( MBEDTLS_ERR_SSL_HW_ACCEL_FAILED );
-    }
+        goto error;
 
     ssl->handshake->psa_pake_ctx_is_ok = 1;
 
     return( 0 );
+
+error:
+    psa_pake_abort( &ssl->handshake->psa_pake_ctx );
+    return( MBEDTLS_ERR_SSL_HW_ACCEL_FAILED );
 }
 #else /* MBEDTLS_USE_PSA_CRYPTO */
 int mbedtls_ssl_set_hs_ecjpake_password( mbedtls_ssl_context *ssl,

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1932,11 +1932,6 @@ int mbedtls_ssl_set_hs_ecjpake_password_opaque( mbedtls_ssl_context *ssl,
     if( ssl->handshake == NULL || ssl->conf == NULL )
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
 
-    if( ssl->conf->endpoint == MBEDTLS_SSL_IS_SERVER )
-        psa_role = PSA_PAKE_ROLE_SERVER;
-    else
-        psa_role = PSA_PAKE_ROLE_CLIENT;
-
     if( mbedtls_svc_key_id_is_null( pwd ) )
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
     ssl->handshake->psa_pake_password = pwd;
@@ -1951,6 +1946,11 @@ int mbedtls_ssl_set_hs_ecjpake_password_opaque( mbedtls_ssl_context *ssl,
     status = psa_pake_setup( &ssl->handshake->psa_pake_ctx, &cipher_suite );
     if( status != PSA_SUCCESS )
         goto error;
+
+    if( ssl->conf->endpoint == MBEDTLS_SSL_IS_SERVER )
+        psa_role = PSA_PAKE_ROLE_SERVER;
+    else
+        psa_role = PSA_PAKE_ROLE_CLIENT;
 
     status = psa_pake_set_role( &ssl->handshake->psa_pake_ctx, psa_role );
     if( status != PSA_SUCCESS )
@@ -1979,14 +1979,14 @@ int mbedtls_ssl_set_hs_ecjpake_password( mbedtls_ssl_context *ssl,
     if( ssl->handshake == NULL || ssl->conf == NULL )
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
 
+    /* Empty password is not valid  */
+    if( ( pw == NULL) || ( pw_len == 0 ) )
+        return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
+
     if( ssl->conf->endpoint == MBEDTLS_SSL_IS_SERVER )
         role = MBEDTLS_ECJPAKE_SERVER;
     else
         role = MBEDTLS_ECJPAKE_CLIENT;
-
-    /* Empty password is not valid  */
-    if( ( pw == NULL) || ( pw_len == 0 ) )
-        return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
 
     return( mbedtls_ecjpake_setup( &ssl->handshake->ecjpake_ctx,
                                    role,

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -827,10 +827,10 @@ int main( int argc, char *argv[] )
         MBEDTLS_TLS_SRTP_UNSET
     };
 #endif /* MBEDTLS_SSL_DTLS_SRTP */
-#if defined( MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED ) && \
-    defined( MBEDTLS_USE_PSA_CRYPTO )
+#if defined(MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED) && \
+    defined(MBEDTLS_USE_PSA_CRYPTO)
     mbedtls_svc_key_id_t ecjpake_pw_slot = MBEDTLS_SVC_KEY_ID_INIT; /* ecjpake password key slot */
-#endif // MBEDTLS_USE_PSA_CRYPTO && MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED
+#endif /* MBEDTLS_USE_PSA_CRYPTO && MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED */
 
 #if defined(MBEDTLS_MEMORY_BUFFER_ALLOC_C)
     mbedtls_memory_buffer_alloc_init( alloc_buf, sizeof(alloc_buf) );
@@ -2176,7 +2176,7 @@ int main( int argc, char *argv[] )
 #if defined(MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED)
     if( opt.ecjpake_pw != DFL_ECJPAKE_PW )
     {
-#if defined( MBEDTLS_USE_PSA_CRIPTO )
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
         if ( opt.ecjpake_pw_opaque != DFL_ECJPAKE_PW_OPAQUE )
         {
             psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
@@ -2203,7 +2203,7 @@ int main( int argc, char *argv[] )
             }
         }
         else
-#endif  // MBEDTLS_USE_PSA_CRIPTO
+#endif  /* MBEDTLS_USE_PSA_CRYPTO */
         {
             if( ( ret = mbedtls_ssl_set_hs_ecjpake_password( &ssl,
                                         (const unsigned char *) opt.ecjpake_pw,
@@ -2214,7 +2214,7 @@ int main( int argc, char *argv[] )
             }
         }
     }
-#endif // MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED
+#endif /* MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED */
 
 #if defined(MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED)
     if( opt.context_crt_cb == 1 )
@@ -3315,13 +3315,13 @@ exit:
 #endif /* MBEDTLS_SSL_HANDSHAKE_WITH_PSK_ENABLED &&
           MBEDTLS_USE_PSA_CRYPTO */
 
-#if defined( MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED ) && \
-    defined( MBEDTLS_USE_PSA_CRYPTO )
+#if defined(MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED) && \
+    defined(MBEDTLS_USE_PSA_CRYPTO)
     if( opt.ecjpake_pw_opaque != DFL_ECJPAKE_PW_OPAQUE )
     {
         psa_destroy_key( ecjpake_pw_slot );
     }
-#endif  //   MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED && MBEDTLS_USE_PSA_CRYPTO
+#endif  /* MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED && MBEDTLS_USE_PSA_CRYPTO */
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO) || defined(MBEDTLS_SSL_PROTO_TLS1_3)
     const char* message = mbedtls_test_helper_is_psa_leaking();

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -319,12 +319,17 @@ int main( void )
 #endif
 
 #if defined(MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED)
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
 #define USAGE_ECJPAKE \
     "    ecjpake_pw=%%s           default: none (disabled)\n"   \
     "    ecjpake_pw_opaque=%%d    default: 0 (disabled)\n"
-#else
+#else /* MBEDTLS_USE_PSA_CRYPTO */
+#define USAGE_ECJPAKE \
+    "    ecjpake_pw=%%s           default: none (disabled)\n"
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
+#else /* MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED */
 #define USAGE_ECJPAKE ""
-#endif
+#endif /* MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED */
 
 #if defined(MBEDTLS_ECP_RESTARTABLE)
 #define USAGE_ECRESTART \
@@ -494,7 +499,9 @@ struct options
     const char *psk;            /* the pre-shared key                       */
     const char *psk_identity;   /* the pre-shared key identity              */
     const char *ecjpake_pw;     /* the EC J-PAKE password                   */
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     int ecjpake_pw_opaque;      /* set to 1 to use the opaque method for setting the password */
+#endif
     int ec_max_ops;             /* EC consecutive operations limit          */
     int force_ciphersuite[2];   /* protocol/ciphersuite to use, or all      */
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
@@ -926,7 +933,9 @@ int main( int argc, char *argv[] )
 #endif
     opt.psk_identity        = DFL_PSK_IDENTITY;
     opt.ecjpake_pw          = DFL_ECJPAKE_PW;
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     opt.ecjpake_pw_opaque   = DFL_ECJPAKE_PW_OPAQUE;
+#endif
     opt.ec_max_ops          = DFL_EC_MAX_OPS;
     opt.force_ciphersuite[0]= DFL_FORCE_CIPHER;
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
@@ -1102,8 +1111,10 @@ int main( int argc, char *argv[] )
             opt.psk_identity = q;
         else if( strcmp( p, "ecjpake_pw" ) == 0 )
             opt.ecjpake_pw = q;
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
         else if( strcmp( p, "ecjpake_pw_opaque" ) == 0 )
             opt.ecjpake_pw_opaque = atoi( q );
+#endif
         else if( strcmp( p, "ec_max_ops" ) == 0 )
             opt.ec_max_ops = atoi( q );
         else if( strcmp( p, "force_ciphersuite" ) == 0 )

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -2201,6 +2201,7 @@ int main( int argc, char *argv[] )
                 mbedtls_printf( " failed\n  ! mbedtls_ssl_set_hs_ecjpake_password_opaque returned %d\n\n", ret );
                 goto exit;
             }
+            mbedtls_printf( "using opaque password\n");
         }
         else
 #endif  /* MBEDTLS_USE_PSA_CRYPTO */

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -3331,7 +3331,16 @@ exit:
     defined(MBEDTLS_USE_PSA_CRYPTO)
     if( opt.ecjpake_pw_opaque != DFL_ECJPAKE_PW_OPAQUE )
     {
-        psa_destroy_key( ecjpake_pw_slot );
+        psa_key_attributes_t key_attr = PSA_KEY_ATTRIBUTES_INIT;
+
+        /* Ensure the key is still valid before destroying it */
+        status = psa_get_key_attributes( ecjpake_pw_slot, &key_attr );
+        if( status == PSA_SUCCESS &&
+            PSA_ALG_IS_PAKE( psa_get_key_algorithm( &key_attr ) ) )
+        {
+            psa_destroy_key( ecjpake_pw_slot );
+        }
+        psa_reset_key_attributes( &key_attr );
     }
 #endif  /* MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED && MBEDTLS_USE_PSA_CRYPTO */
 

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -3338,8 +3338,14 @@ exit:
         psa_key_attributes_t check_attributes = PSA_KEY_ATTRIBUTES_INIT;
 
         /* Verify that the key is still valid before destroying it */
-        if( psa_get_key_attributes( ecjpake_pw_slot, &check_attributes ) ==
+        if( psa_get_key_attributes( ecjpake_pw_slot, &check_attributes ) !=
                 PSA_SUCCESS )
+        {
+            if( ret == 0 )
+                ret = 1;
+            mbedtls_printf( "The EC J-PAKE password key has unexpectedly been already destroyed\n" );
+        }
+        else
         {
             psa_destroy_key( ecjpake_pw_slot );
         }

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -3333,10 +3333,16 @@ exit:
      * In case opaque keys it's the user responsibility to keep the key valid
      * for the duration of the handshake and destroy it at the end
      */
-    if( ( opt.ecjpake_pw_opaque != DFL_ECJPAKE_PW_OPAQUE ) &&
-        ( ! mbedtls_svc_key_id_is_null( ecjpake_pw_slot ) ) )
+    if( ( opt.ecjpake_pw_opaque != DFL_ECJPAKE_PW_OPAQUE ) )
     {
-        psa_destroy_key( ecjpake_pw_slot );
+        psa_key_attributes_t check_attributes = PSA_KEY_ATTRIBUTES_INIT;
+
+        /* Verify that the key is still valid before destroying it */
+        if( psa_get_key_attributes( ecjpake_pw_slot, &check_attributes ) ==
+                PSA_SUCCESS )
+        {
+            psa_destroy_key( ecjpake_pw_slot );
+        }
     }
 #endif  /* MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED && MBEDTLS_USE_PSA_CRYPTO */
 

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -3329,18 +3329,14 @@ exit:
 
 #if defined(MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED) && \
     defined(MBEDTLS_USE_PSA_CRYPTO)
-    if( opt.ecjpake_pw_opaque != DFL_ECJPAKE_PW_OPAQUE )
+    /*
+     * In case opaque keys it's the user responsibility to keep the key valid
+     * for the duration of the handshake and destroy it at the end
+     */
+    if( ( opt.ecjpake_pw_opaque != DFL_ECJPAKE_PW_OPAQUE ) &&
+        ( ! mbedtls_svc_key_id_is_null( ecjpake_pw_slot ) ) )
     {
-        psa_key_attributes_t key_attr = PSA_KEY_ATTRIBUTES_INIT;
-
-        /* Ensure the key is still valid before destroying it */
-        status = psa_get_key_attributes( ecjpake_pw_slot, &key_attr );
-        if( status == PSA_SUCCESS &&
-            PSA_ALG_IS_PAKE( psa_get_key_algorithm( &key_attr ) ) )
-        {
-            psa_destroy_key( ecjpake_pw_slot );
-        }
-        psa_reset_key_attributes( &key_attr );
+        psa_destroy_key( ecjpake_pw_slot );
     }
 #endif  /* MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED && MBEDTLS_USE_PSA_CRYPTO */
 

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -419,12 +419,17 @@ int main( void )
 #endif
 
 #if defined(MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED)
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
 #define USAGE_ECJPAKE \
     "    ecjpake_pw=%%s           default: none (disabled)\n"   \
     "    ecjpake_pw_opaque=%%d    default: 0 (disabled)\n"
-#else
+#else /* MBEDTLS_USE_PSA_CRYPTO */
+#define USAGE_ECJPAKE \
+    "    ecjpake_pw=%%s           default: none (disabled)\n"
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
+#else /* MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED */
 #define USAGE_ECJPAKE ""
-#endif
+#endif /* MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED */
 
 #if defined(MBEDTLS_ECP_C)
 #define USAGE_CURVES \
@@ -623,7 +628,9 @@ struct options
     const char *psk_identity;   /* the pre-shared key identity              */
     char *psk_list;             /* list of PSK id/key pairs for callback    */
     const char *ecjpake_pw;     /* the EC J-PAKE password                   */
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     int ecjpake_pw_opaque;      /* set to 1 to use the opaque method for setting the password */
+#endif
     int force_ciphersuite[2];   /* protocol/ciphersuite to use, or all      */
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
     int tls13_kex_modes;        /* supported TLS 1.3 key exchange modes     */
@@ -1668,7 +1675,9 @@ int main( int argc, char *argv[] )
     opt.psk_identity        = DFL_PSK_IDENTITY;
     opt.psk_list            = DFL_PSK_LIST;
     opt.ecjpake_pw          = DFL_ECJPAKE_PW;
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     opt.ecjpake_pw_opaque   = DFL_ECJPAKE_PW_OPAQUE;
+#endif
     opt.force_ciphersuite[0]= DFL_FORCE_CIPHER;
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
     opt.tls13_kex_modes     = DFL_TLS1_3_KEX_MODES;
@@ -1872,8 +1881,10 @@ int main( int argc, char *argv[] )
             opt.psk_list = q;
         else if( strcmp( p, "ecjpake_pw" ) == 0 )
             opt.ecjpake_pw = q;
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
         else if( strcmp( p, "ecjpake_pw_opaque" ) == 0 )
             opt.ecjpake_pw_opaque = atoi( q );
+#endif
         else if( strcmp( p, "force_ciphersuite" ) == 0 )
         {
             opt.force_ciphersuite[0] = mbedtls_ssl_get_ciphersuite_id( q );

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -98,6 +98,7 @@ int main( void )
 #define DFL_PSK_LIST_OPAQUE     0
 #define DFL_PSK_IDENTITY        "Client_identity"
 #define DFL_ECJPAKE_PW          NULL
+#define DFL_ECJPAKE_PW_OPAQUE   0
 #define DFL_PSK_LIST            NULL
 #define DFL_FORCE_CIPHER        0
 #define DFL_TLS1_3_KEX_MODES    MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_ALL
@@ -419,7 +420,8 @@ int main( void )
 
 #if defined(MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED)
 #define USAGE_ECJPAKE \
-    "    ecjpake_pw=%%s       default: none (disabled)\n"
+    "    ecjpake_pw=%%s           default: none (disabled)\n"   \
+    "    ecjpake_pw_opaque=%%d    default: 0 (disabled)\n"
 #else
 #define USAGE_ECJPAKE ""
 #endif
@@ -621,6 +623,7 @@ struct options
     const char *psk_identity;   /* the pre-shared key identity              */
     char *psk_list;             /* list of PSK id/key pairs for callback    */
     const char *ecjpake_pw;     /* the EC J-PAKE password                   */
+    int ecjpake_pw_opaque;      /* set to 1 to use the opaque method for setting the password */
     int force_ciphersuite[2];   /* protocol/ciphersuite to use, or all      */
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
     int tls13_kex_modes;        /* supported TLS 1.3 key exchange modes     */
@@ -1506,6 +1509,10 @@ int main( int argc, char *argv[] )
     unsigned char *context_buf = NULL;
     size_t context_buf_len = 0;
 #endif
+#if defined( MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED ) && \
+    defined( MBEDTLS_USE_PSA_CRYPTO )
+    mbedtls_svc_key_id_t ecjpake_pw_slot = MBEDTLS_SVC_KEY_ID_INIT; /* ecjpake password key slot */
+#endif // MBEDTLS_USE_PSA_CRYPTO && MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED
 
 #if defined(MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED)
     uint16_t sig_alg_list[SIG_ALG_LIST_SIZE];
@@ -1661,6 +1668,7 @@ int main( int argc, char *argv[] )
     opt.psk_identity        = DFL_PSK_IDENTITY;
     opt.psk_list            = DFL_PSK_LIST;
     opt.ecjpake_pw          = DFL_ECJPAKE_PW;
+    opt.ecjpake_pw_opaque   = DFL_ECJPAKE_PW_OPAQUE;
     opt.force_ciphersuite[0]= DFL_FORCE_CIPHER;
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
     opt.tls13_kex_modes     = DFL_TLS1_3_KEX_MODES;
@@ -1864,6 +1872,8 @@ int main( int argc, char *argv[] )
             opt.psk_list = q;
         else if( strcmp( p, "ecjpake_pw" ) == 0 )
             opt.ecjpake_pw = q;
+        else if( strcmp( p, "ecjpake_pw_opaque" ) == 0 )
+            opt.ecjpake_pw_opaque = atoi( q );
         else if( strcmp( p, "force_ciphersuite" ) == 0 )
         {
             opt.force_ciphersuite[0] = mbedtls_ssl_get_ciphersuite_id( q );
@@ -3488,18 +3498,48 @@ reset:
     }
 #endif /* MBEDTLS_SSL_DTLS_HELLO_VERIFY */
 
-#if defined(MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED)
+#if defined( MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED )
     if( opt.ecjpake_pw != DFL_ECJPAKE_PW )
     {
-        if( ( ret = mbedtls_ssl_set_hs_ecjpake_password( &ssl,
-                        (const unsigned char *) opt.ecjpake_pw,
-                                        strlen( opt.ecjpake_pw ) ) ) != 0 )
+#if defined( MBEDTLS_USE_PSA_CRIPTO )
+        if ( opt.ecjpake_pw_opaque != DFL_ECJPAKE_PW_OPAQUE )
         {
-            mbedtls_printf( " failed\n  ! mbedtls_ssl_set_hs_ecjpake_password returned %d\n\n", ret );
-            goto exit;
+            psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
+
+            psa_set_key_usage_flags( &attributes, PSA_KEY_USAGE_DERIVE );
+            psa_set_key_algorithm( &attributes, PSA_ALG_JPAKE );
+            psa_set_key_type( &attributes, PSA_KEY_TYPE_PASSWORD );
+
+            status = psa_import_key( &attributes,
+                                (const unsigned char *) opt.ecjpake_pw,
+                                strlen( opt.ecjpake_pw ),
+                                &ecjpake_pw_slot );
+            if( status != PSA_SUCCESS )
+            {
+                mbedtls_printf( " failed\n  ! psa_import_key returned %d\n\n",
+                            status );
+                goto exit;
+            }
+            if( ( ret = mbedtls_ssl_set_hs_ecjpake_password_opaque( &ssl,
+                                        ecjpake_pw_slot ) ) != 0 )
+            {
+                mbedtls_printf( " failed\n  ! mbedtls_ssl_set_hs_ecjpake_password_opaque returned %d\n\n", ret );
+                goto exit;
+            }
+        }
+        else
+#endif  // MBEDTLS_USE_PSA_CRIPTO
+        {
+            if( ( ret = mbedtls_ssl_set_hs_ecjpake_password( &ssl,
+                                        (const unsigned char *) opt.ecjpake_pw,
+                                        strlen( opt.ecjpake_pw ) ) ) != 0 )
+            {
+                mbedtls_printf( " failed\n  ! mbedtls_ssl_set_hs_ecjpake_password returned %d\n\n", ret );
+                goto exit;
+            }
         }
     }
-#endif
+#endif // MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED
 
 #if defined(MBEDTLS_SSL_SERVER_NAME_INDICATION)
 #if defined(MBEDTLS_KEY_EXCHANGE_CERT_REQ_ALLOWED_ENABLED)
@@ -4384,6 +4424,14 @@ exit:
     }
 #endif /* MBEDTLS_SSL_HANDSHAKE_WITH_PSK_ENABLED &&
           MBEDTLS_USE_PSA_CRYPTO */
+
+#if defined( MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED ) && \
+    defined( MBEDTLS_USE_PSA_CRYPTO )
+    if( opt.ecjpake_pw_opaque != DFL_ECJPAKE_PW_OPAQUE )
+    {
+        psa_destroy_key( ecjpake_pw_slot );
+    }
+#endif  //   MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED && MBEDTLS_USE_PSA_CRYPTO
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO) || defined(MBEDTLS_SSL_PROTO_TLS1_3)
     const char* message = mbedtls_test_helper_is_psa_leaking();

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -3526,6 +3526,7 @@ reset:
                 mbedtls_printf( " failed\n  ! mbedtls_ssl_set_hs_ecjpake_password_opaque returned %d\n\n", ret );
                 goto exit;
             }
+            mbedtls_printf( "using opaque password\n");
         }
         else
 #endif  /* MBEDTLS_USE_PSA_CRYPTO */

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -4441,7 +4441,16 @@ exit:
     defined(MBEDTLS_USE_PSA_CRYPTO)
     if( opt.ecjpake_pw_opaque != DFL_ECJPAKE_PW_OPAQUE )
     {
-        psa_destroy_key( ecjpake_pw_slot );
+        psa_key_attributes_t key_attr = PSA_KEY_ATTRIBUTES_INIT;
+
+        /* Ensure the key is still valid before destroying it */
+        status = psa_get_key_attributes( ecjpake_pw_slot, &key_attr );
+        if( status == PSA_SUCCESS &&
+            PSA_ALG_IS_PAKE( psa_get_key_algorithm( &key_attr ) ) )
+        {
+            psa_destroy_key( ecjpake_pw_slot );
+        }
+        psa_reset_key_attributes( &key_attr );
     }
 #endif  /* MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED && MBEDTLS_USE_PSA_CRYPTO */
 

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -1509,10 +1509,10 @@ int main( int argc, char *argv[] )
     unsigned char *context_buf = NULL;
     size_t context_buf_len = 0;
 #endif
-#if defined( MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED ) && \
-    defined( MBEDTLS_USE_PSA_CRYPTO )
+#if defined(MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED) && \
+    defined(MBEDTLS_USE_PSA_CRYPTO)
     mbedtls_svc_key_id_t ecjpake_pw_slot = MBEDTLS_SVC_KEY_ID_INIT; /* ecjpake password key slot */
-#endif // MBEDTLS_USE_PSA_CRYPTO && MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED
+#endif /* MBEDTLS_USE_PSA_CRYPTO && MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED */
 
 #if defined(MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED)
     uint16_t sig_alg_list[SIG_ALG_LIST_SIZE];
@@ -3498,10 +3498,10 @@ reset:
     }
 #endif /* MBEDTLS_SSL_DTLS_HELLO_VERIFY */
 
-#if defined( MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED )
+#if defined(MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED)
     if( opt.ecjpake_pw != DFL_ECJPAKE_PW )
     {
-#if defined( MBEDTLS_USE_PSA_CRIPTO )
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
         if ( opt.ecjpake_pw_opaque != DFL_ECJPAKE_PW_OPAQUE )
         {
             psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
@@ -3528,7 +3528,7 @@ reset:
             }
         }
         else
-#endif  // MBEDTLS_USE_PSA_CRIPTO
+#endif  /* MBEDTLS_USE_PSA_CRYPTO */
         {
             if( ( ret = mbedtls_ssl_set_hs_ecjpake_password( &ssl,
                                         (const unsigned char *) opt.ecjpake_pw,
@@ -3539,7 +3539,7 @@ reset:
             }
         }
     }
-#endif // MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED
+#endif /* MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED */
 
 #if defined(MBEDTLS_SSL_SERVER_NAME_INDICATION)
 #if defined(MBEDTLS_KEY_EXCHANGE_CERT_REQ_ALLOWED_ENABLED)
@@ -4425,13 +4425,13 @@ exit:
 #endif /* MBEDTLS_SSL_HANDSHAKE_WITH_PSK_ENABLED &&
           MBEDTLS_USE_PSA_CRYPTO */
 
-#if defined( MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED ) && \
-    defined( MBEDTLS_USE_PSA_CRYPTO )
+#if defined(MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED) && \
+    defined(MBEDTLS_USE_PSA_CRYPTO)
     if( opt.ecjpake_pw_opaque != DFL_ECJPAKE_PW_OPAQUE )
     {
         psa_destroy_key( ecjpake_pw_slot );
     }
-#endif  //   MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED && MBEDTLS_USE_PSA_CRYPTO
+#endif  /* MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED && MBEDTLS_USE_PSA_CRYPTO */
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO) || defined(MBEDTLS_SSL_PROTO_TLS1_3)
     const char* message = mbedtls_test_helper_is_psa_leaking();

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -4439,18 +4439,14 @@ exit:
 
 #if defined(MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED) && \
     defined(MBEDTLS_USE_PSA_CRYPTO)
-    if( opt.ecjpake_pw_opaque != DFL_ECJPAKE_PW_OPAQUE )
+    /*
+     * In case opaque keys it's the user responsibility to keep the key valid
+     * for the duration of the handshake and destroy it at the end
+     */
+    if( ( opt.ecjpake_pw_opaque != DFL_ECJPAKE_PW_OPAQUE ) &&
+        ( ! mbedtls_svc_key_id_is_null( ecjpake_pw_slot ) ) )
     {
-        psa_key_attributes_t key_attr = PSA_KEY_ATTRIBUTES_INIT;
-
-        /* Ensure the key is still valid before destroying it */
-        status = psa_get_key_attributes( ecjpake_pw_slot, &key_attr );
-        if( status == PSA_SUCCESS &&
-            PSA_ALG_IS_PAKE( psa_get_key_algorithm( &key_attr ) ) )
-        {
-            psa_destroy_key( ecjpake_pw_slot );
-        }
-        psa_reset_key_attributes( &key_attr );
+        psa_destroy_key( ecjpake_pw_slot );
     }
 #endif  /* MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED && MBEDTLS_USE_PSA_CRYPTO */
 

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -4443,10 +4443,16 @@ exit:
      * In case opaque keys it's the user responsibility to keep the key valid
      * for the duration of the handshake and destroy it at the end
      */
-    if( ( opt.ecjpake_pw_opaque != DFL_ECJPAKE_PW_OPAQUE ) &&
-        ( ! mbedtls_svc_key_id_is_null( ecjpake_pw_slot ) ) )
+    if( ( opt.ecjpake_pw_opaque != DFL_ECJPAKE_PW_OPAQUE ) )
     {
-        psa_destroy_key( ecjpake_pw_slot );
+        psa_key_attributes_t check_attributes = PSA_KEY_ATTRIBUTES_INIT;
+
+        /* Verify that the key is still valid before destroying it */
+        if( psa_get_key_attributes( ecjpake_pw_slot, &check_attributes ) ==
+                PSA_SUCCESS )
+        {
+            psa_destroy_key( ecjpake_pw_slot );
+        }
     }
 #endif  /* MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED && MBEDTLS_USE_PSA_CRYPTO */
 

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -4448,8 +4448,14 @@ exit:
         psa_key_attributes_t check_attributes = PSA_KEY_ATTRIBUTES_INIT;
 
         /* Verify that the key is still valid before destroying it */
-        if( psa_get_key_attributes( ecjpake_pw_slot, &check_attributes ) ==
+        if( psa_get_key_attributes( ecjpake_pw_slot, &check_attributes ) !=
                 PSA_SUCCESS )
+        {
+            if( ret == 0 )
+                ret = 1;
+            mbedtls_printf( "The EC J-PAKE password key has unexpectedly been already destroyed\n" );
+        }
+        else
         {
             psa_destroy_key( ecjpake_pw_slot );
         }

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1455,10 +1455,14 @@ component_test_tls1_2_ecjpake_compatibility() {
     make -C programs ssl/ssl_server2 ssl/ssl_client2
     make -C programs test/udp_proxy test/query_compile_time_config
 
-    msg "test: server w/o USE_PSA - client w/ USE_PSA"
-    P_SRV=../s2_no_use_psa tests/ssl-opt.sh -f ECJPAKE -e ECJPAKE_OPAQUE_PW
-    msg "test: client w/o USE_PSA - server w/ USE_PSA"
-    P_CLI=../c2_no_use_psa tests/ssl-opt.sh -f ECJPAKE -e ECJPAKE_OPAQUE_PW
+    msg "test: server w/o USE_PSA - client w/ USE_PSA, text password"
+    P_SRV=../s2_no_use_psa tests/ssl-opt.sh -f "ECJPAKE: working, TLS"
+    msg "test: server w/o USE_PSA - client w/ USE_PSA, opaque password"
+    P_SRV=../s2_no_use_psa tests/ssl-opt.sh -f "ECJPAKE: opaque password client only, working, TLS"
+    msg "test: client w/o USE_PSA - server w/ USE_PSA, text password"
+    P_CLI=../c2_no_use_psa tests/ssl-opt.sh -f "ECJPAKE: working, TLS"
+    msg "test: client w/o USE_PSA - server w/ USE_PSA, opaque password"
+    P_CLI=../c2_no_use_psa tests/ssl-opt.sh -f "ECJPAKE: opaque password server only, working, TLS"
 
     rm s2_no_use_psa c2_no_use_psa
 }

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1463,21 +1463,6 @@ component_test_tls1_2_ecjpake_compatibility() {
     rm s2_no_use_psa c2_no_use_psa
 }
 
-# Opaque password testing requires a separate test with repect to
-# "test_tls1_2_ecjpake_compatibility". In that case there's a mix of PSA and
-# MbedTLS based implementations of EC-JPAKE which makes it difficult to parse
-# proper strings during the test. As a consequence here we just build the
-# PSA variant for both client and server.
-component_test_tls1_2_ecjpake_opaque_password() {
-    msg "build: TLS1.2 server+client w/ opaque password support"
-    scripts/config.py set MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED
-    scripts/config.py set MBEDTLS_USE_PSA_CRYPTO
-    make -C programs ssl/ssl_server2 ssl/ssl_client2
-    make -C programs test/udp_proxy test/query_compile_time_config
-
-    tests/ssl-opt.sh -f ECJPAKE_OPAQUE_PW
-}
-
 component_test_psa_external_rng_use_psa_crypto () {
     msg "build: full + PSA_CRYPTO_EXTERNAL_RNG + USE_PSA_CRYPTO minus CTR_DRBG"
     scripts/config.py full

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1456,11 +1456,26 @@ component_test_tls1_2_ecjpake_compatibility() {
     make -C programs test/udp_proxy test/query_compile_time_config
 
     msg "test: server w/o USE_PSA - client w/ USE_PSA"
-    P_SRV=../s2_no_use_psa tests/ssl-opt.sh -f ECJPAKE
+    P_SRV=../s2_no_use_psa tests/ssl-opt.sh -f ECJPAKE -e ECJPAKE_OPAQUE_PW
     msg "test: client w/o USE_PSA - server w/ USE_PSA"
-    P_CLI=../c2_no_use_psa tests/ssl-opt.sh -f ECJPAKE
+    P_CLI=../c2_no_use_psa tests/ssl-opt.sh -f ECJPAKE -e ECJPAKE_OPAQUE_PW
 
     rm s2_no_use_psa c2_no_use_psa
+}
+
+# Opaque password testing requires a separate test with repect to
+# "test_tls1_2_ecjpake_compatibility". In that case there's a mix of PSA and
+# MbedTLS based implementations of EC-JPAKE which makes it difficult to parse
+# proper strings during the test. As a consequence here we just build the
+# PSA variant for both client and server.
+component_test_tls1_2_ecjpake_opaque_password() {
+    msg "build: TLS1.2 server+client w/ opaque password support"
+    scripts/config.py set MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED
+    scripts/config.py set MBEDTLS_USE_PSA_CRYPTO
+    make -C programs ssl/ssl_server2 ssl/ssl_client2
+    make -C programs test/udp_proxy test/query_compile_time_config
+
+    tests/ssl-opt.sh -f ECJPAKE_OPAQUE_PW
 }
 
 component_test_psa_external_rng_use_psa_crypto () {

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -7989,6 +7989,8 @@ run_test    "ECJPAKE: server not configured" \
             -C "found ecjpake_kkpp extension" \
             -s "SSL - The handshake negotiation failed"
 
+# Note: if the name of this test is changed, then please adjust the corresponding
+#       filtering label in "test_tls1_2_ecjpake_compatibility" (in "all.sh")
 requires_config_enabled MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 run_test    "ECJPAKE: working, TLS" \
@@ -8028,6 +8030,8 @@ run_test    "ECJPAKE: opaque password client+server, working, TLS" \
             -S "SSL - The handshake negotiation failed" \
             -S "SSL - Verification of the message MAC failed"
 
+# Note: if the name of this test is changed, then please adjust the corresponding
+#       filtering label in "test_tls1_2_ecjpake_compatibility" (in "all.sh")
 requires_config_enabled MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED
 requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
@@ -8049,6 +8053,8 @@ run_test    "ECJPAKE: opaque password client only, working, TLS" \
             -S "SSL - The handshake negotiation failed" \
             -S "SSL - Verification of the message MAC failed"
 
+# Note: if the name of this test is changed, then please adjust the corresponding
+#       filtering label in "test_tls1_2_ecjpake_compatibility" (in "all.sh")
 requires_config_enabled MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED
 requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -8010,7 +8010,7 @@ run_test    "ECJPAKE: working, TLS" \
 requires_config_enabled MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED
 requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-run_test    "ECJPAKE_OPAQUE_PW: working, TLS, opaque password client+server" \
+run_test    "ECJPAKE: opaque password client+server, working, TLS" \
             "$P_SRV debug_level=3 ecjpake_pw=bla ecjpake_pw_opaque=1" \
             "$P_CLI debug_level=3 ecjpake_pw=bla ecjpake_pw_opaque=1\
              force_ciphersuite=TLS-ECJPAKE-WITH-AES-128-CCM-8" \
@@ -8031,7 +8031,7 @@ run_test    "ECJPAKE_OPAQUE_PW: working, TLS, opaque password client+server" \
 requires_config_enabled MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED
 requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-run_test    "ECJPAKE_OPAQUE_PW: working, TLS, opaque password client only" \
+run_test    "ECJPAKE: opaque password client only, working, TLS" \
             "$P_SRV debug_level=3 ecjpake_pw=bla" \
             "$P_CLI debug_level=3 ecjpake_pw=bla ecjpake_pw_opaque=1\
              force_ciphersuite=TLS-ECJPAKE-WITH-AES-128-CCM-8" \
@@ -8052,7 +8052,7 @@ run_test    "ECJPAKE_OPAQUE_PW: working, TLS, opaque password client only" \
 requires_config_enabled MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED
 requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-run_test    "ECJPAKE_OPAQUE_PW: working, TLS, opaque password server only" \
+run_test    "ECJPAKE: opaque password server only, working, TLS" \
             "$P_SRV debug_level=3 ecjpake_pw=bla ecjpake_pw_opaque=1" \
             "$P_CLI debug_level=3 ecjpake_pw=bla\
              force_ciphersuite=TLS-ECJPAKE-WITH-AES-128-CCM-8" \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -8010,7 +8010,7 @@ run_test    "ECJPAKE: working, TLS" \
 requires_config_enabled MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED
 requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-run_test    "ECJPAKE_OPAQUE_PW: working, TLS, opaque password" \
+run_test    "ECJPAKE_OPAQUE_PW: working, TLS, opaque password client+server" \
             "$P_SRV debug_level=3 ecjpake_pw=bla ecjpake_pw_opaque=1" \
             "$P_CLI debug_level=3 ecjpake_pw=bla ecjpake_pw_opaque=1\
              force_ciphersuite=TLS-ECJPAKE-WITH-AES-128-CCM-8" \
@@ -8018,6 +8018,48 @@ run_test    "ECJPAKE_OPAQUE_PW: working, TLS, opaque password" \
             -c "add ciphersuite: c0ff" \
             -c "adding ecjpake_kkpp extension" \
             -c "using opaque password" \
+            -s "using opaque password" \
+            -C "re-using cached ecjpake parameters" \
+            -s "found ecjpake kkpp extension" \
+            -S "skip ecjpake kkpp extension" \
+            -S "ciphersuite mismatch: ecjpake not configured" \
+            -s "server hello, ecjpake kkpp extension" \
+            -c "found ecjpake_kkpp extension" \
+            -S "SSL - The handshake negotiation failed" \
+            -S "SSL - Verification of the message MAC failed"
+
+requires_config_enabled MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED
+requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test    "ECJPAKE_OPAQUE_PW: working, TLS, opaque password client only" \
+            "$P_SRV debug_level=3 ecjpake_pw=bla" \
+            "$P_CLI debug_level=3 ecjpake_pw=bla ecjpake_pw_opaque=1\
+             force_ciphersuite=TLS-ECJPAKE-WITH-AES-128-CCM-8" \
+            0 \
+            -c "add ciphersuite: c0ff" \
+            -c "adding ecjpake_kkpp extension" \
+            -c "using opaque password" \
+            -S "using opaque password" \
+            -C "re-using cached ecjpake parameters" \
+            -s "found ecjpake kkpp extension" \
+            -S "skip ecjpake kkpp extension" \
+            -S "ciphersuite mismatch: ecjpake not configured" \
+            -s "server hello, ecjpake kkpp extension" \
+            -c "found ecjpake_kkpp extension" \
+            -S "SSL - The handshake negotiation failed" \
+            -S "SSL - Verification of the message MAC failed"
+
+requires_config_enabled MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED
+requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test    "ECJPAKE_OPAQUE_PW: working, TLS, opaque password server only" \
+            "$P_SRV debug_level=3 ecjpake_pw=bla ecjpake_pw_opaque=1" \
+            "$P_CLI debug_level=3 ecjpake_pw=bla\
+             force_ciphersuite=TLS-ECJPAKE-WITH-AES-128-CCM-8" \
+            0 \
+            -c "add ciphersuite: c0ff" \
+            -c "adding ecjpake_kkpp extension" \
+            -C "using opaque password" \
             -s "using opaque password" \
             -C "re-using cached ecjpake parameters" \
             -s "found ecjpake kkpp extension" \
@@ -8036,6 +8078,20 @@ run_test    "ECJPAKE: password mismatch, TLS" \
             "$P_CLI debug_level=3 ecjpake_pw=bad \
              force_ciphersuite=TLS-ECJPAKE-WITH-AES-128-CCM-8" \
             1 \
+            -C "re-using cached ecjpake parameters" \
+            -s "SSL - Verification of the message MAC failed"
+
+server_needs_more_time 1
+requires_config_enabled MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED
+requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test    "ECJPAKE_OPAQUE_PW: opaque password mismatch, TLS" \
+            "$P_SRV debug_level=3 ecjpake_pw=bla ecjpake_pw_opaque=1" \
+            "$P_CLI debug_level=3 ecjpake_pw=bad ecjpake_pw_opaque=1 \
+             force_ciphersuite=TLS-ECJPAKE-WITH-AES-128-CCM-8" \
+            1 \
+            -c "using opaque password" \
+            -s "using opaque password" \
             -C "re-using cached ecjpake parameters" \
             -s "SSL - Verification of the message MAC failed"
 

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -8008,8 +8008,9 @@ run_test    "ECJPAKE: working, TLS" \
             -S "SSL - Verification of the message MAC failed"
 
 requires_config_enabled MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED
+requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-run_test    "ECJPAKE: working, TLS, opaque password" \
+run_test    "ECJPAKE_OPAQUE_PW: working, TLS, opaque password" \
             "$P_SRV debug_level=3 ecjpake_pw=bla ecjpake_pw_opaque=1" \
             "$P_CLI debug_level=3 ecjpake_pw=bla ecjpake_pw_opaque=1\
              force_ciphersuite=TLS-ECJPAKE-WITH-AES-128-CCM-8" \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -8016,6 +8016,8 @@ run_test    "ECJPAKE: working, TLS, opaque password" \
             0 \
             -c "add ciphersuite: c0ff" \
             -c "adding ecjpake_kkpp extension" \
+            -c "using opaque password" \
+            -s "using opaque password" \
             -C "re-using cached ecjpake parameters" \
             -s "found ecjpake kkpp extension" \
             -S "skip ecjpake kkpp extension" \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -8007,6 +8007,24 @@ run_test    "ECJPAKE: working, TLS" \
             -S "SSL - The handshake negotiation failed" \
             -S "SSL - Verification of the message MAC failed"
 
+requires_config_enabled MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test    "ECJPAKE: working, TLS, opaque password" \
+            "$P_SRV debug_level=3 ecjpake_pw=bla ecjpake_pw_opaque=1" \
+            "$P_CLI debug_level=3 ecjpake_pw=bla ecjpake_pw_opaque=1\
+             force_ciphersuite=TLS-ECJPAKE-WITH-AES-128-CCM-8" \
+            0 \
+            -c "add ciphersuite: c0ff" \
+            -c "adding ecjpake_kkpp extension" \
+            -C "re-using cached ecjpake parameters" \
+            -s "found ecjpake kkpp extension" \
+            -S "skip ecjpake kkpp extension" \
+            -S "ciphersuite mismatch: ecjpake not configured" \
+            -s "server hello, ecjpake kkpp extension" \
+            -c "found ecjpake_kkpp extension" \
+            -S "SSL - The handshake negotiation failed" \
+            -S "SSL - Verification of the message MAC failed"
+
 server_needs_more_time 1
 requires_config_enabled MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2

--- a/tests/suites/test_suite_ssl.data
+++ b/tests/suites/test_suite_ssl.data
@@ -3570,28 +3570,8 @@ tls13_server_certificate_msg_invalid_vector_len
 
 EC-JPAKE set password
 depends_on:MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED
-ssl_ecjpake_set_password:0:ECJPAKE_ERR_NONE:0
-
-EC-JPAKE set password - uninitiazed SSL context
-depends_on:MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED
-ssl_ecjpake_set_password:0:ECJPAKE_ERR_UNITIALIZED_SSL_CONTEXT:MBEDTLS_ERR_SSL_BAD_INPUT_DATA
-
-EC-JPAKE set password - empty password
-depends_on:MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED
-ssl_ecjpake_set_password:0:ECJPAKE_ERR_EMPTY_PASSWORD:MBEDTLS_ERR_SSL_BAD_INPUT_DATA
+ssl_ecjpake_set_password:0
 
 EC-JPAKE set opaque password
 depends_on:MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED:MBEDTLS_USE_PSA_CRYPTO
-ssl_ecjpake_set_password:1:ECJPAKE_ERR_NONE:0
-
-EC-JPAKE set opaque password - uninitiazed SSL context
-depends_on:MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED:MBEDTLS_USE_PSA_CRYPTO
-ssl_ecjpake_set_password:1:ECJPAKE_ERR_UNITIALIZED_SSL_CONTEXT:MBEDTLS_ERR_SSL_BAD_INPUT_DATA
-
-EC-JPAKE set opaque password - empty password
-depends_on:MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED:MBEDTLS_USE_PSA_CRYPTO
-ssl_ecjpake_set_password:1:ECJPAKE_ERR_EMPTY_PASSWORD:MBEDTLS_ERR_SSL_BAD_INPUT_DATA
-
-EC-JPAKE set opaque password - uninitalized password key
-depends_on:MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED:MBEDTLS_USE_PSA_CRYPTO
-ssl_ecjpake_set_password:1:ECJPAKE_ERR_UNINITIALIZED_PWD_KEY:MBEDTLS_ERR_SSL_BAD_INPUT_DATA
+ssl_ecjpake_set_password:1

--- a/tests/suites/test_suite_ssl.data
+++ b/tests/suites/test_suite_ssl.data
@@ -3567,3 +3567,31 @@ cookie_parsing:"16fefd0000000000000000002F010000de000000000000011efefd7b72727272
 
 TLS 1.3 srv Certificate msg - wrong vector lengths
 tls13_server_certificate_msg_invalid_vector_len
+
+EC-JPAKE set password
+depends_on:MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED
+ssl_ecjpake_set_password:0:ECJPAKE_ERR_NONE:0
+
+EC-JPAKE set password - uninitiazed SSL context
+depends_on:MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED
+ssl_ecjpake_set_password:0:ECJPAKE_ERR_UNITIALIZED_SSL_CONTEXT:MBEDTLS_ERR_SSL_BAD_INPUT_DATA
+
+EC-JPAKE set password - empty password
+depends_on:MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED
+ssl_ecjpake_set_password:0:ECJPAKE_ERR_EMPTY_PASSWORD:MBEDTLS_ERR_SSL_BAD_INPUT_DATA
+
+EC-JPAKE set opaque password
+depends_on:MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED:MBEDTLS_USE_PSA_CRYPTO
+ssl_ecjpake_set_password:1:ECJPAKE_ERR_NONE:0
+
+EC-JPAKE set opaque password - uninitiazed SSL context
+depends_on:MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED:MBEDTLS_USE_PSA_CRYPTO
+ssl_ecjpake_set_password:1:ECJPAKE_ERR_UNITIALIZED_SSL_CONTEXT:MBEDTLS_ERR_SSL_BAD_INPUT_DATA
+
+EC-JPAKE set opaque password - empty password
+depends_on:MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED:MBEDTLS_USE_PSA_CRYPTO
+ssl_ecjpake_set_password:1:ECJPAKE_ERR_EMPTY_PASSWORD:MBEDTLS_ERR_SSL_BAD_INPUT_DATA
+
+EC-JPAKE set opaque password - uninitalized password key
+depends_on:MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED:MBEDTLS_USE_PSA_CRYPTO
+ssl_ecjpake_set_password:1:ECJPAKE_ERR_UNINITIALIZED_PWD_KEY:MBEDTLS_ERR_SSL_BAD_INPUT_DATA

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -2590,12 +2590,12 @@ int tweak_tls13_certificate_msg_vector_len(
     ret = ( use_opaque_arg ) ?                                            \
         mbedtls_ssl_set_hs_ecjpake_password_opaque( &ssl, pwd_slot ) :    \
         mbedtls_ssl_set_hs_ecjpake_password( &ssl, pwd_string, pwd_len ); \
-    TEST_ASSERT( ret == exp_ret_val )
+    TEST_EQUAL( ret, exp_ret_val )
 #else
 #define ECJPAKE_TEST_SET_PASSWORD( exp_ret_val )                \
     ret = mbedtls_ssl_set_hs_ecjpake_password( &ssl,            \
                                         pwd_string, pwd_len );  \
-    TEST_ASSERT( ret == exp_ret_val )
+    TEST_EQUAL( ret, exp_ret_val )
 #endif
 /* END_HEADER */
 
@@ -6219,13 +6219,12 @@ void ssl_ecjpake_set_password( int use_opaque_arg )
 
     mbedtls_ssl_config_init( &conf );
 
-    TEST_ASSERT( mbedtls_ssl_config_defaults( &conf,
+    TEST_EQUAL( mbedtls_ssl_config_defaults( &conf,
                                               MBEDTLS_SSL_IS_CLIENT,
                                               MBEDTLS_SSL_TRANSPORT_STREAM,
-                                              MBEDTLS_SSL_PRESET_DEFAULT )
-                 == 0 );
+                                              MBEDTLS_SSL_PRESET_DEFAULT ), 0 );
 
-    TEST_ASSERT( mbedtls_ssl_setup( &ssl, &conf ) == 0 );
+    TEST_EQUAL( mbedtls_ssl_setup( &ssl, &conf ), 0 );
 
     /* test with empty password or unitialized password key (depending on use_opaque_arg) */
     ECJPAKE_TEST_SET_PASSWORD( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
@@ -6242,8 +6241,8 @@ void ssl_ecjpake_set_password( int use_opaque_arg )
         psa_set_key_algorithm( &attributes, PSA_ALG_JPAKE );
         psa_set_key_type( &attributes, PSA_KEY_TYPE_PASSWORD );
 
-        TEST_ASSERT( psa_import_key( &attributes, pwd_string,
-                    pwd_len, &pwd_slot ) == PSA_SUCCESS );
+        PSA_ASSERT( psa_import_key( &attributes, pwd_string,
+                    pwd_len, &pwd_slot ) );
     }
 #endif  /* MBEDTLS_USE_PSA_CRYPTO */
 

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -6264,7 +6264,10 @@ void ssl_ecjpake_set_password( int use_opaque_arg )
     ECJPAKE_TEST_SET_PASSWORD( 0 );
 
 #if defined( MBEDTLS_USE_PSA_CRYPTO )
-    psa_destroy_key( pwd_slot );
+    if( use_opaque_arg )
+    {
+        psa_destroy_key( pwd_slot );
+    }
 #endif  /* MBEDTLS_USE_PSA_CRYPTO */
     mbedtls_ssl_free( &ssl );
     mbedtls_ssl_config_free( &conf );

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -6227,7 +6227,7 @@ void ssl_ecjpake_set_password( int use_opaque_arg )
 
     TEST_ASSERT( mbedtls_ssl_setup( &ssl, &conf ) == 0 );
 
-    /* test with empty password */
+    /* test with empty password or unitialized password key (depending on use_opaque_arg) */
     ECJPAKE_TEST_SET_PASSWORD( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
 
     pwd_len = strlen( ECJPAKE_TEST_PWD );
@@ -6236,9 +6236,6 @@ void ssl_ecjpake_set_password( int use_opaque_arg )
 #if defined( MBEDTLS_USE_PSA_CRYPTO )
     if( use_opaque_arg )
     {
-        /* test with uninitialized password key */
-        ECJPAKE_TEST_SET_PASSWORD( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
-
         psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
 
         psa_set_key_usage_flags( &attributes, PSA_KEY_USAGE_DERIVE );

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -2582,6 +2582,15 @@ int tweak_tls13_certificate_msg_vector_len(
     return( 0 );
 }
 #endif /* MBEDTLS_TEST_HOOKS */
+
+typedef enum {
+    ECJPAKE_ERR_NONE,
+    ECJPAKE_ERR_UNITIALIZED_SSL_CONTEXT,
+    ECJPAKE_ERR_EMPTY_PASSWORD,
+    ECJPAKE_ERR_UNINITIALIZED_PWD_KEY,
+} ecjpake_err_inj_step_t;
+
+#define ECJPAKE_TEST_PWD        "bla"
 /* END_HEADER */
 
 /* BEGIN_DEPENDENCIES
@@ -6177,6 +6186,80 @@ exit:
     mbedtls_endpoint_free( &server_ep, NULL );
     free_handshake_options( &client_options );
     free_handshake_options( &server_options );
+    USE_PSA_DONE( );
+}
+/* END_CASE */
+
+/* BEGIN_CASE depends_on:MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED */
+void ssl_ecjpake_set_password( int use_opaque_arg,
+                               int err_injection_step_arg,
+                               int expected_error_arg )
+{
+    mbedtls_ssl_context ssl;
+    mbedtls_ssl_config conf;
+#if defined( MBEDTLS_USE_PSA_CRYPTO )
+    mbedtls_svc_key_id_t pwd_slot = MBEDTLS_SVC_KEY_ID_INIT;
+#else   /* MBEDTLS_USE_PSA_CRYPTO */
+    (void) use_opaque_arg;
+#endif  /* MBEDTLS_USE_PSA_CRYPTO */
+    const unsigned char pwd_string[ sizeof(ECJPAKE_TEST_PWD) ] = "";
+    size_t pwd_len = 0;
+    ecjpake_err_inj_step_t err_injection_step = err_injection_step_arg;
+    int ret;
+
+    USE_PSA_INIT( );
+
+    mbedtls_ssl_init( &ssl );
+
+    if( err_injection_step == ECJPAKE_ERR_UNITIALIZED_SSL_CONTEXT )
+        goto run_test;
+
+    mbedtls_ssl_config_init( &conf );
+
+    TEST_ASSERT( mbedtls_ssl_config_defaults( &conf,
+                                              MBEDTLS_SSL_IS_CLIENT,
+                                              MBEDTLS_SSL_TRANSPORT_STREAM,
+                                              MBEDTLS_SSL_PRESET_DEFAULT )
+                 == 0 );
+
+    TEST_ASSERT( mbedtls_ssl_setup( &ssl, &conf ) == 0 );
+
+    if( err_injection_step == ECJPAKE_ERR_EMPTY_PASSWORD )
+        goto run_test;
+
+    pwd_len = strlen( ECJPAKE_TEST_PWD );
+    memcpy( (void*) pwd_string, ECJPAKE_TEST_PWD, pwd_len );
+
+#if defined( MBEDTLS_USE_PSA_CRYPTO )
+    if( use_opaque_arg )
+    {
+        if( err_injection_step == ECJPAKE_ERR_UNINITIALIZED_PWD_KEY )
+            goto run_test;
+
+        psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
+
+        psa_set_key_usage_flags( &attributes, PSA_KEY_USAGE_DERIVE );
+        psa_set_key_algorithm( &attributes, PSA_ALG_JPAKE );
+        psa_set_key_type( &attributes, PSA_KEY_TYPE_PASSWORD );
+
+        TEST_ASSERT( psa_import_key( &attributes, pwd_string,
+                    pwd_len, &pwd_slot ) == PSA_SUCCESS );
+    }
+#endif  /* MBEDTLS_USE_PSA_CRYPTO */
+
+run_test:
+#if defined( MBEDTLS_USE_PSA_CRYPTO )
+    ret = ( use_opaque_arg ) ?
+            mbedtls_ssl_set_hs_ecjpake_password_opaque( &ssl, pwd_slot ) :
+            mbedtls_ssl_set_hs_ecjpake_password( &ssl, pwd_string, pwd_len );
+#else   /* MBEDTLS_USE_PSA_CRYPTO */
+    ret = mbedtls_ssl_set_hs_ecjpake_password( &ssl, pwd_string, pwd_len );
+#endif  /* MBEDTLS_USE_PSA_CRYPTO */
+    TEST_EQUAL( ret, expected_error_arg );
+
+    mbedtls_ssl_free( &ssl );
+    mbedtls_ssl_config_free( &conf );
+
     USE_PSA_DONE( );
 }
 /* END_CASE */

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -2583,14 +2583,20 @@ int tweak_tls13_certificate_msg_vector_len(
 }
 #endif /* MBEDTLS_TEST_HOOKS */
 
-typedef enum {
-    ECJPAKE_ERR_NONE,
-    ECJPAKE_ERR_UNITIALIZED_SSL_CONTEXT,
-    ECJPAKE_ERR_EMPTY_PASSWORD,
-    ECJPAKE_ERR_UNINITIALIZED_PWD_KEY,
-} ecjpake_err_inj_step_t;
-
 #define ECJPAKE_TEST_PWD        "bla"
+
+#if defined( MBEDTLS_USE_PSA_CRYPTO )
+#define ECJPAKE_TEST_SET_PASSWORD( exp_ret_val )                          \
+    ret = ( use_opaque_arg ) ?                                            \
+        mbedtls_ssl_set_hs_ecjpake_password_opaque( &ssl, pwd_slot ) :    \
+        mbedtls_ssl_set_hs_ecjpake_password( &ssl, pwd_string, pwd_len ); \
+    TEST_ASSERT( ret == exp_ret_val )
+#else
+#define ECJPAKE_TEST_SET_PASSWORD( exp_ret_val )                \
+    ret = mbedtls_ssl_set_hs_ecjpake_password( &ssl,            \
+                                        pwd_string, pwd_len );  \
+    TEST_ASSERT( ret == exp_ret_val )
+#endif
 /* END_HEADER */
 
 /* BEGIN_DEPENDENCIES
@@ -6191,9 +6197,7 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED */
-void ssl_ecjpake_set_password( int use_opaque_arg,
-                               int err_injection_step_arg,
-                               int expected_error_arg )
+void ssl_ecjpake_set_password( int use_opaque_arg )
 {
     mbedtls_ssl_context ssl;
     mbedtls_ssl_config conf;
@@ -6204,15 +6208,14 @@ void ssl_ecjpake_set_password( int use_opaque_arg,
 #endif  /* MBEDTLS_USE_PSA_CRYPTO */
     const unsigned char pwd_string[ sizeof(ECJPAKE_TEST_PWD) ] = "";
     size_t pwd_len = 0;
-    ecjpake_err_inj_step_t err_injection_step = err_injection_step_arg;
     int ret;
 
     USE_PSA_INIT( );
 
     mbedtls_ssl_init( &ssl );
 
-    if( err_injection_step == ECJPAKE_ERR_UNITIALIZED_SSL_CONTEXT )
-        goto run_test;
+    /* test with uninitalized SSL context */
+    ECJPAKE_TEST_SET_PASSWORD( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
 
     mbedtls_ssl_config_init( &conf );
 
@@ -6224,8 +6227,8 @@ void ssl_ecjpake_set_password( int use_opaque_arg,
 
     TEST_ASSERT( mbedtls_ssl_setup( &ssl, &conf ) == 0 );
 
-    if( err_injection_step == ECJPAKE_ERR_EMPTY_PASSWORD )
-        goto run_test;
+    /* test with empty password */
+    ECJPAKE_TEST_SET_PASSWORD( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
 
     pwd_len = strlen( ECJPAKE_TEST_PWD );
     memcpy( (void*) pwd_string, ECJPAKE_TEST_PWD, pwd_len );
@@ -6233,8 +6236,8 @@ void ssl_ecjpake_set_password( int use_opaque_arg,
 #if defined( MBEDTLS_USE_PSA_CRYPTO )
     if( use_opaque_arg )
     {
-        if( err_injection_step == ECJPAKE_ERR_UNINITIALIZED_PWD_KEY )
-            goto run_test;
+        /* test with uninitialized password key */
+        ECJPAKE_TEST_SET_PASSWORD( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
 
         psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
 
@@ -6247,16 +6250,12 @@ void ssl_ecjpake_set_password( int use_opaque_arg,
     }
 #endif  /* MBEDTLS_USE_PSA_CRYPTO */
 
-run_test:
-#if defined( MBEDTLS_USE_PSA_CRYPTO )
-    ret = ( use_opaque_arg ) ?
-            mbedtls_ssl_set_hs_ecjpake_password_opaque( &ssl, pwd_slot ) :
-            mbedtls_ssl_set_hs_ecjpake_password( &ssl, pwd_string, pwd_len );
-#else   /* MBEDTLS_USE_PSA_CRYPTO */
-    ret = mbedtls_ssl_set_hs_ecjpake_password( &ssl, pwd_string, pwd_len );
-#endif  /* MBEDTLS_USE_PSA_CRYPTO */
-    TEST_EQUAL( ret, expected_error_arg );
+    /* final check which should work without errors */
+    ECJPAKE_TEST_SET_PASSWORD( 0 );
 
+#if defined( MBEDTLS_USE_PSA_CRYPTO )
+    psa_destroy_key( pwd_slot );
+#endif  /* MBEDTLS_USE_PSA_CRYPTO */
     mbedtls_ssl_free( &ssl );
     mbedtls_ssl_config_free( &conf );
 

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -6206,7 +6206,7 @@ void ssl_ecjpake_set_password( int use_opaque_arg )
 #else   /* MBEDTLS_USE_PSA_CRYPTO */
     (void) use_opaque_arg;
 #endif  /* MBEDTLS_USE_PSA_CRYPTO */
-    const unsigned char pwd_string[ sizeof(ECJPAKE_TEST_PWD) ] = "";
+    unsigned char pwd_string[ sizeof(ECJPAKE_TEST_PWD) ] = "";
     size_t pwd_len = 0;
     int ret;
 
@@ -6231,7 +6231,7 @@ void ssl_ecjpake_set_password( int use_opaque_arg )
     ECJPAKE_TEST_SET_PASSWORD( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
 
     pwd_len = strlen( ECJPAKE_TEST_PWD );
-    memcpy( (void*) pwd_string, ECJPAKE_TEST_PWD, pwd_len );
+    memcpy( pwd_string, ECJPAKE_TEST_PWD, pwd_len );
 
 #if defined( MBEDTLS_USE_PSA_CRYPTO )
     if( use_opaque_arg )

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -6237,9 +6237,20 @@ void ssl_ecjpake_set_password( int use_opaque_arg )
     {
         psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
 
-        psa_set_key_usage_flags( &attributes, PSA_KEY_USAGE_DERIVE );
+        /* First try with an invalid usage */
+        psa_set_key_usage_flags( &attributes, PSA_KEY_USAGE_SIGN_HASH );
         psa_set_key_algorithm( &attributes, PSA_ALG_JPAKE );
         psa_set_key_type( &attributes, PSA_KEY_TYPE_PASSWORD );
+
+        PSA_ASSERT( psa_import_key( &attributes, pwd_string,
+                    pwd_len, &pwd_slot ) );
+
+        ECJPAKE_TEST_SET_PASSWORD( MBEDTLS_ERR_SSL_HW_ACCEL_FAILED );
+
+        psa_destroy_key( pwd_slot );
+
+        /* Then set the correct usage */
+        psa_set_key_usage_flags( &attributes, PSA_KEY_USAGE_DERIVE );
 
         PSA_ASSERT( psa_import_key( &attributes, pwd_string,
                     pwd_len, &pwd_slot ) );

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -6247,6 +6247,9 @@ void ssl_ecjpake_set_password( int use_opaque_arg )
 
         ECJPAKE_TEST_SET_PASSWORD( MBEDTLS_ERR_SSL_HW_ACCEL_FAILED );
 
+        /* check that the opaque key is still valid after failure */
+        TEST_ASSERT( ! mbedtls_svc_key_id_is_null( pwd_slot ) );
+
         psa_destroy_key( pwd_slot );
 
         /* Then set the correct usage */

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -6236,6 +6236,7 @@ void ssl_ecjpake_set_password( int use_opaque_arg )
     if( use_opaque_arg )
     {
         psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
+        psa_key_attributes_t check_attributes = PSA_KEY_ATTRIBUTES_INIT;
 
         /* First try with an invalid usage */
         psa_set_key_usage_flags( &attributes, PSA_KEY_USAGE_SIGN_HASH );
@@ -6248,7 +6249,8 @@ void ssl_ecjpake_set_password( int use_opaque_arg )
         ECJPAKE_TEST_SET_PASSWORD( MBEDTLS_ERR_SSL_HW_ACCEL_FAILED );
 
         /* check that the opaque key is still valid after failure */
-        TEST_ASSERT( ! mbedtls_svc_key_id_is_null( pwd_slot ) );
+        TEST_EQUAL( psa_get_key_attributes( pwd_slot, &check_attributes ),
+                        PSA_SUCCESS );
 
         psa_destroy_key( pwd_slot );
 


### PR DESCRIPTION
## Description

The goal of this PR is to enable the use of opaque passwords in EC-JPAKE.
Resolves #6599 



## Gatekeeper checklist

- [ ] **changelog** provided, or not required
- [ ] **backport** done, or not required
- [ ] **tests** provided, or not required
