### PR TITLE
Optimize with asan

### DIFF
--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -185,6 +185,7 @@ pre_initialize_variables () {
     export CTEST_OUTPUT_ON_FAILURE=1
 
     # CFLAGS and LDFLAGS for Asan builds that don't use CMake
+    # default to -O2, use -Ox _after_ this if you want another level
     ASAN_CFLAGS='-O2 -Werror -fsanitize=address,undefined -fno-sanitize-recover=all'
 
     # Gather the list of available components. These are the functions

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -185,7 +185,7 @@ pre_initialize_variables () {
     export CTEST_OUTPUT_ON_FAILURE=1
 
     # CFLAGS and LDFLAGS for Asan builds that don't use CMake
-    ASAN_CFLAGS='-Werror -Wall -Wextra -fsanitize=address,undefined -fno-sanitize-recover=all'
+    ASAN_CFLAGS='-O2 -Werror -fsanitize=address,undefined -fno-sanitize-recover=all'
 
     # Gather the list of available components. These are the functions
     # defined in this script whose name starts with "component_".

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -2162,11 +2162,16 @@ component_test_psa_crypto_config_accel_hash_use_psa () {
     msg "test: MBEDTLS_PSA_CRYPTO_CONFIG with accelerated hash and USE_PSA"
     make test
 
+    # This is mostly useful so that we can later compare outcome files with
+    # the reference config in analyze_outcomes.py, to check that the
+    # dependency declarations in ssl-opt.sh and in TLS code are correct.
     msg "test: ssl-opt.sh, MBEDTLS_PSA_CRYPTO_CONFIG with accelerated hash and USE_PSA"
     tests/ssl-opt.sh
 
-    msg "test: compat.sh, MBEDTLS_PSA_CRYPTO_CONFIG without accelerated hash and USE_PSA"
-    tests/compat.sh
+    # This is to make sure all ciphersuites are exercised, but we don't need
+    # interop testing (besides, we already got some from ssl-opt.sh).
+    msg "test: compat.sh, MBEDTLS_PSA_CRYPTO_CONFIG with accelerated hash and USE_PSA"
+    tests/compat.sh -p mbedTLS -V YES
 }
 
 # This component provides reference configuration for test_psa_crypto_config_accel_hash_use_psa


### PR DESCRIPTION
This is an attempt at resolving https://github.com/Mbed-TLS/mbedtls/issues/6662, see [this comment](https://github.com/Mbed-TLS/mbedtls/issues/6662#issuecomment-1330347859) and the next one in particular.

Running time of this component on my laptop (which ccache disabled):

- Before: 26:17
- After first commit: 20:51 (-20%)
- ~After second commit 19:18 (-8% from previous commit, -26% total)~ reverted
- After third commit 14:43 (-24% from previous commit, -40% total)

~Note: the second commit only addresses `test_psa_crypto_config_accel_hash_use_psa` but could be applicable to other components that build with libtestdriver1. However I wanted to wait for review feedback before applying it everywhere. (Note that it's also the change with the least impact.)~ (Edit: reverted.)

## Gatekeeper checklist

- [x] **changelog** not required - just optimizing tests
- [x] **backport** #6693
- [x] **tests** not required





