### PR TITLE
programs/fuzz: set sensible default CFLAGS

### DIFF
--- a/programs/fuzz/Makefile
+++ b/programs/fuzz/Makefile
@@ -1,7 +1,9 @@
 MBEDTLS_TEST_PATH:=../../tests/src
 MBEDTLS_TEST_OBJS:=$(patsubst %.c,%.o,$(wildcard ${MBEDTLS_TEST_PATH}/*.c ${MBEDTLS_TEST_PATH}/drivers/*.c))
 
-LOCAL_CFLAGS = -I../../tests/include -I../../include -D_FILE_OFFSET_BITS=64
+CFLAGS ?= -O2
+WARNING_CFLAGS ?= -Wall -Wextra
+LOCAL_CFLAGS = $(WARNING_CFLAGS) -I../../tests/include -I../../include -D_FILE_OFFSET_BITS=64
 LOCAL_LDFLAGS = ${MBEDTLS_TEST_OBJS}		\
 		-L../../library			\
 		-lmbedtls$(SHARED_SUFFIX)	\


### PR DESCRIPTION
Running make from programs/fuzz didn't set any optimization flags (running make from programs or from the root inherited the parent's optimization flags). Default to -O2.

There were no -W flags. Default to -Wall -Wextra, but not -Werror in line with the other makefiles.

## Gatekeeper checklist

- [x] **changelog** no (no impact on generated code)
- [x] **backport** https://github.com/Mbed-TLS/mbedtls/pull/6696
- [x] **tests** N/A (build scripts only)
