### PR TITLE
[backport 2.28] Optimize with asan

### DIFF
--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -185,6 +185,7 @@ pre_initialize_variables () {
     export CTEST_OUTPUT_ON_FAILURE=1
 
     # CFLAGS and LDFLAGS for Asan builds that don't use CMake
+    # default to -O2, use -Ox _after_ this if you want another level
     ASAN_CFLAGS='-O2 -Werror -fsanitize=address,undefined -fno-sanitize-recover=all'
 
     # Gather the list of available components. These are the functions

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -185,7 +185,7 @@ pre_initialize_variables () {
     export CTEST_OUTPUT_ON_FAILURE=1
 
     # CFLAGS and LDFLAGS for Asan builds that don't use CMake
-    ASAN_CFLAGS='-Werror -Wall -Wextra -fsanitize=address,undefined -fno-sanitize-recover=all'
+    ASAN_CFLAGS='-O2 -Werror -fsanitize=address,undefined -fno-sanitize-recover=all'
 
     # Gather the list of available components. These are the functions
     # defined in this script whose name starts with "component_".


### PR DESCRIPTION
This is the 2.28 backport of #6683 - only the part about -O2 with Asan, the rest is not applicable since the affected component is only present in development (and part of the rest was reverted anyway).
