### PR TITLE
Backport 2.28: Fix name of basic build test.sh 2.28

### DIFF
--- a/tests/scripts/basic-build-test.sh
+++ b/tests/scripts/basic-build-test.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# basic-build-tests.sh
+# basic-build-test.sh
 #
 # Copyright The Mbed TLS Contributors
 # SPDX-License-Identifier: Apache-2.0
@@ -36,7 +36,7 @@
 #
 # This script has been written to be generic and should work on any shell.
 #
-# Usage: basic-build-tests.sh
+# Usage: basic-build-test.sh
 #
 
 # Abort on errors (and uninitiliased variables)


### PR DESCRIPTION
`basic-build-test.sh` calls itself `basic-build-tests.sh` internally, which is wrong, so fix it.

## Gatekeeper checklist

- [ ] **changelog** not required
- [ ] **backport** of https://github.com/Mbed-TLS/mbedtls/pull/6694
- [ ] **tests** not required