### PR TITLE
Backport 2.28: programs/fuzz: set sensible default CFLAGS

### DIFF
--- a/programs/fuzz/Makefile
+++ b/programs/fuzz/Makefile
@@ -1,7 +1,9 @@
 MBEDTLS_TEST_PATH:=../../tests/src
 MBEDTLS_TEST_OBJS:=$(patsubst %.c,%.o,$(wildcard ${MBEDTLS_TEST_PATH}/*.c ${MBEDTLS_TEST_PATH}/drivers/*.c))
 
-LOCAL_CFLAGS = -I../../tests/include -I../../include -D_FILE_OFFSET_BITS=64
+CFLAGS ?= -O2
+WARNING_CFLAGS ?= -Wall -Wextra
+LOCAL_CFLAGS = $(WARNING_CFLAGS) -I../../tests/include -I../../include -D_FILE_OFFSET_BITS=64
 LOCAL_LDFLAGS = ${MBEDTLS_TEST_OBJS}		\
 		-L../../library			\
 		-lmbedtls$(SHARED_SUFFIX)	\


### PR DESCRIPTION
Trivial backport of https://github.com/Mbed-TLS/mbedtls/pull/6687

## Gatekeeper checklist

- [x] **changelog** no (no impact on generated code)
- [x] **backport** of https://github.com/Mbed-TLS/mbedtls/pull/6687
- [x] **tests** N/A (build scripts only)
