### PR TITLE
Update test_suite_ecp,function for making the comparison with call by value instead of call by reference,

### DIFF
--- a/tests/suites/test_suite_ecp.function
+++ b/tests/suites/test_suite_ecp.function
@@ -50,7 +50,7 @@ inline static int mbedtls_ecp_group_cmp( mbedtls_ecp_group *grp1,
         return 1;
     if( grp1->T_size != grp2->T_size )
         return 1;
-    if( grp1->T != grp2->T )
+    if( grp1->&T != grp2->&T )
         return 1;
 
     return 0;


### PR DESCRIPTION
## Description

updated mbedtls_ecp_group_cmp function for making the comparison for the value of T by call by value instead of call by reference.


## Gatekeeper checklist

- [ ] **changelog** provided, or not required
- [ ] **backport** done, or not required
- [ ] **tests** provided, or not required



## Notes for the submitter

Please refer to the [contributing guidelines](../CONTRIBUTING.md), especially the
checklist for PR contributors.

