### PR TITLE
TLS 1.3: EarlyData SRV: Add early data extension parser.

### DIFF
--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1840,7 +1840,7 @@ struct mbedtls_ssl_context {
                                              *   and #MBEDTLS_SSL_CID_DISABLED. */
 #endif /* MBEDTLS_SSL_DTLS_CONNECTION_ID */
 
-#if defined(MBEDTLS_SSL_EARLY_DATA) && defined(MBEDTLS_SSL_CLI_C)
+#if defined(MBEDTLS_SSL_EARLY_DATA)
     int MBEDTLS_PRIVATE(early_data_status);
 #endif /* MBEDTLS_SSL_EARLY_DATA && MBEDTLS_SSL_CLI_C */
 
@@ -5013,6 +5013,10 @@ int mbedtls_ssl_close_notify(mbedtls_ssl_context *ssl);
 
 #if defined(MBEDTLS_SSL_EARLY_DATA)
 
+#define MBEDTLS_SSL_EARLY_DATA_STATUS_NOT_SENT  0
+#define MBEDTLS_SSL_EARLY_DATA_STATUS_ACCEPTED  1
+#define MBEDTLS_SSL_EARLY_DATA_STATUS_REJECTED  2
+
 #if defined(MBEDTLS_SSL_SRV_C)
 /**
  * \brief          Read at most 'len' application data bytes while performing
@@ -5122,9 +5126,6 @@ int mbedtls_ssl_read_early_data(mbedtls_ssl_context *ssl,
 int mbedtls_ssl_write_early_data(mbedtls_ssl_context *ssl,
                                  const unsigned char *buf, size_t len);
 
-#define MBEDTLS_SSL_EARLY_DATA_STATUS_NOT_SENT  0
-#define MBEDTLS_SSL_EARLY_DATA_STATUS_ACCEPTED  1
-#define MBEDTLS_SSL_EARLY_DATA_STATUS_REJECTED  2
 /**
  * \brief Get the status of the negotiation of the use of early data.
  *

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -2129,6 +2129,12 @@ int mbedtls_ssl_tls13_write_early_data_ext(mbedtls_ssl_context *ssl,
                                            unsigned char *buf,
                                            const unsigned char *end,
                                            size_t *out_len);
+
+#if defined(MBEDTLS_SSL_SRV_C)
+#define MBEDTLS_SSL_EARLY_DATA_STATUS_NOT_RECEIVED \
+    MBEDTLS_SSL_EARLY_DATA_STATUS_NOT_SENT
+#endif /* MBEDTLS_SSL_SRV_C */
+
 #endif /* MBEDTLS_SSL_EARLY_DATA */
 
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3 */

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1749,6 +1749,40 @@ static int ssl_tls13_parse_client_hello(mbedtls_ssl_context *ssl,
     return hrr_required ? SSL_CLIENT_HELLO_HRR_REQUIRED : SSL_CLIENT_HELLO_OK;
 }
 
+#if defined(MBEDTLS_SSL_EARLY_DATA)
+static void ssl_tls13_update_early_data_status(mbedtls_ssl_context *ssl)
+{
+    mbedtls_ssl_handshake_params *handshake = ssl->handshake;
+
+    if ((handshake->received_extensions &
+         MBEDTLS_SSL_EXT_MASK(EARLY_DATA)) == 0) {
+        MBEDTLS_SSL_DEBUG_MSG(
+            1, ("EarlyData: early data extension is not received."));
+        ssl->early_data_status = MBEDTLS_SSL_EARLY_DATA_STATUS_NOT_RECEIVED;
+        return;
+    }
+
+    ssl->early_data_status = MBEDTLS_SSL_EARLY_DATA_STATUS_REJECTED;
+
+    if (ssl->conf->early_data_enabled == MBEDTLS_SSL_EARLY_DATA_DISABLED) {
+        MBEDTLS_SSL_DEBUG_MSG(
+            1, ("EarlyData: rejected. configured disabled."));
+        return;
+    }
+
+    MBEDTLS_SSL_DEBUG_MSG(
+        3, ("EarlyData: conf->max_early_data_size = %u",
+            (unsigned int) ssl->conf->max_early_data_size));
+
+    /* TODO: Add more checks here. */
+
+    MBEDTLS_SSL_DEBUG_MSG(
+        1, ("EarlyData: For time being, it should not happen."));
+    ssl->early_data_status = MBEDTLS_SSL_EARLY_DATA_STATUS_ACCEPTED;
+
+}
+#endif /* MBEDTLS_SSL_EARLY_DATA */
+
 /* Update the handshake state machine */
 
 MBEDTLS_CHECK_RETURN_CRITICAL
@@ -1774,6 +1808,12 @@ static int ssl_tls13_postprocess_client_hello(mbedtls_ssl_context *ssl)
                               "mbedtls_ssl_tls1_3_key_schedule_stage_early", ret);
         return ret;
     }
+
+#if defined(MBEDTLS_SSL_EARLY_DATA)
+    /* There is enough information, update early data state. */
+    ssl_tls13_update_early_data_status(ssl);
+
+#endif /* MBEDTLS_SSL_EARLY_DATA */
 
     return 0;
 

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1757,28 +1757,13 @@ static void ssl_tls13_update_early_data_status(mbedtls_ssl_context *ssl)
     if ((handshake->received_extensions &
          MBEDTLS_SSL_EXT_MASK(EARLY_DATA)) == 0) {
         MBEDTLS_SSL_DEBUG_MSG(
-            1, ("EarlyData: early data extension is not received."));
+            1, ("EarlyData: no early data extension received."));
         ssl->early_data_status = MBEDTLS_SSL_EARLY_DATA_STATUS_NOT_RECEIVED;
         return;
     }
 
+    /* We do not accept early data for the time being */
     ssl->early_data_status = MBEDTLS_SSL_EARLY_DATA_STATUS_REJECTED;
-
-    if (ssl->conf->early_data_enabled == MBEDTLS_SSL_EARLY_DATA_DISABLED) {
-        MBEDTLS_SSL_DEBUG_MSG(
-            1, ("EarlyData: rejected. configured disabled."));
-        return;
-    }
-
-    MBEDTLS_SSL_DEBUG_MSG(
-        3, ("EarlyData: conf->max_early_data_size = %u",
-            (unsigned int) ssl->conf->max_early_data_size));
-
-    /* TODO: Add more checks here. */
-
-    MBEDTLS_SSL_DEBUG_MSG(
-        1, ("EarlyData: For time being, it should not happen."));
-    ssl->early_data_status = MBEDTLS_SSL_EARLY_DATA_STATUS_ACCEPTED;
 
 }
 #endif /* MBEDTLS_SSL_EARLY_DATA */
@@ -1812,7 +1797,6 @@ static int ssl_tls13_postprocess_client_hello(mbedtls_ssl_context *ssl)
 #if defined(MBEDTLS_SSL_EARLY_DATA)
     /* There is enough information, update early data state. */
     ssl_tls13_update_early_data_status(ssl);
-
 #endif /* MBEDTLS_SSL_EARLY_DATA */
 
     return 0;

--- a/tests/data_files/early_data.txt
+++ b/tests/data_files/early_data.txt
@@ -1,0 +1,3 @@
+EarlyData context: line 0                                                    lf
+EarlyData context: line 1                                                    lf
+EarlyData context: If it appear, that means early_data success

--- a/tests/data_files/tls13_early_data.txt
+++ b/tests/data_files/tls13_early_data.txt
@@ -1,3 +1,3 @@
 EarlyData context: line 0                                                    lf
 EarlyData context: line 1                                                    lf
-EarlyData context: If it appear, that means early_data success
+EarlyData context: If it appears, that means early_data received.

--- a/tests/opt-testcases/tls13-misc.sh
+++ b/tests/opt-testcases/tls13-misc.sh
@@ -497,7 +497,7 @@ requires_gnutls_next
 requires_all_configs_enabled MBEDTLS_SSL_EARLY_DATA MBEDTLS_SSL_SESSION_TICKETS     \
                              MBEDTLS_SSL_SRV_C MBEDTLS_DEBUG_C MBEDTLS_HAVE_TIME    \
                              MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED \
-                             MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
+                             MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE MBEDTLS_ECP_LIGHT
 requires_any_configs_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_ENABLED \
                              MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL_ENABLED
 run_test "TLS 1.3 G->m: EarlyData: ephemeral: feature is disabled, fail." \
@@ -512,7 +512,7 @@ run_test "TLS 1.3 G->m: EarlyData: ephemeral: feature is disabled, fail." \
 requires_gnutls_next
 requires_all_configs_enabled MBEDTLS_SSL_EARLY_DATA MBEDTLS_SSL_SESSION_TICKETS     \
                              MBEDTLS_SSL_SRV_C MBEDTLS_DEBUG_C MBEDTLS_HAVE_TIME    \
-                             MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
+                             MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE MBEDTLS_ECP_LIGHT
 requires_any_configs_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_ENABLED \
                              MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL_ENABLED
 run_test "TLS 1.3 G->m: EarlyData: psk*: feature is disabled, fail." \

--- a/tests/opt-testcases/tls13-misc.sh
+++ b/tests/opt-testcases/tls13-misc.sh
@@ -501,7 +501,7 @@ requires_all_configs_enabled MBEDTLS_SSL_EARLY_DATA MBEDTLS_SSL_SESSION_TICKETS 
 requires_any_configs_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_ENABLED \
                              MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL_ENABLED
 run_test "TLS 1.3 G->m: EarlyData: feature is disabled, fail." \
-         "$P_SRV force_version=tls13 debug_level=4 max_early_data_size=-1 $(get_srv_psk_list)" \
+         "$P_SRV force_version=tls13 debug_level=4 max_early_data_size=-1" \
          "$G_NEXT_CLI localhost --priority=NORMAL:-VERS-ALL:+VERS-TLS1.3:+GROUP-ALL -d 10 -r --earlydata $EARLY_DATA_INPUT" \
          1 \
          -s "ClientHello: early_data(42) extension exists."                     \

--- a/tests/opt-testcases/tls13-misc.sh
+++ b/tests/opt-testcases/tls13-misc.sh
@@ -505,6 +505,6 @@ run_test "TLS 1.3 G->m: EarlyData: feature is disabled, fail." \
          "$G_NEXT_CLI localhost --priority=NORMAL:-VERS-ALL:+VERS-TLS1.3:+GROUP-ALL -d 10 -r --earlydata $EARLY_DATA_INPUT" \
          1 \
          -s "ClientHello: early_data(42) extension exists."                     \
-         -s "EncryptedExtensions: early_data(42) extension does not exists."    \
+         -s "EncryptedExtensions: early_data(42) extension does not exist."    \
          -s "NewSessionTicket: early_data(42) extension does not exist."        \
          -s "Last error was: -29056 - SSL - Verification of the message MAC failed"

--- a/tests/opt-testcases/tls13-misc.sh
+++ b/tests/opt-testcases/tls13-misc.sh
@@ -497,31 +497,14 @@ requires_gnutls_next
 requires_all_configs_enabled MBEDTLS_SSL_EARLY_DATA MBEDTLS_SSL_SESSION_TICKETS     \
                              MBEDTLS_SSL_SRV_C MBEDTLS_DEBUG_C MBEDTLS_HAVE_TIME    \
                              MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED \
-                             MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE MBEDTLS_ECP_LIGHT
+                             MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_any_configs_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_ENABLED \
                              MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL_ENABLED
-run_test "TLS 1.3 G->m: EarlyData: ephemeral: feature is disabled, fail." \
+run_test "TLS 1.3 G->m: EarlyData: feature is disabled, fail." \
          "$P_SRV force_version=tls13 debug_level=4 max_early_data_size=-1 $(get_srv_psk_list)" \
          "$G_NEXT_CLI localhost --priority=NORMAL:-VERS-ALL:+VERS-TLS1.3:+GROUP-ALL -d 10 -r --earlydata $EARLY_DATA_INPUT" \
          1 \
-         -c "Resume Handshake was completed"                                \
-         -s "ClientHello: early_data(42) extension exists."                 \
-         -S "EncryptedExtensions: early_data(42) extension exists."         \
-         -s "NewSessionTicket: early_data(42) extension does not exist."
-
-requires_gnutls_next
-requires_all_configs_enabled MBEDTLS_SSL_EARLY_DATA MBEDTLS_SSL_SESSION_TICKETS     \
-                             MBEDTLS_SSL_SRV_C MBEDTLS_DEBUG_C MBEDTLS_HAVE_TIME    \
-                             MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE MBEDTLS_ECP_LIGHT
-requires_any_configs_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_ENABLED \
-                             MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL_ENABLED
-run_test "TLS 1.3 G->m: EarlyData: psk*: feature is disabled, fail." \
-         "$P_SRV force_version=tls13 debug_level=4 max_early_data_size=-1 $(get_srv_psk_list)" \
-         "$G_NEXT_CLI localhost --priority=NORMAL:-VERS-ALL:+VERS-TLS1.3:+GROUP-ALL:-KX-ALL:+ECDHE-PSK:+DHE-PSK:+PSK \
-                      -d 10 -r --earlydata $EARLY_DATA_INPUT \
-                      --pskusername Client_identity --pskkey=6162636465666768696a6b6c6d6e6f70" \
-         1 \
-         -c "Resume Handshake was completed"                                \
-         -s "ClientHello: early_data(42) extension exists."                 \
-         -S "EncryptedExtensions: early_data(42) extension exists."         \
-         -s "NewSessionTicket: early_data(42) extension does not exist."
+         -s "ClientHello: early_data(42) extension exists."                     \
+         -s "EncryptedExtensions: early_data(42) extension does not exists."    \
+         -s "NewSessionTicket: early_data(42) extension does not exist."        \
+         -s "Last error was: -29056 - SSL - Verification of the message MAC failed"

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -72,6 +72,7 @@ guess_config_name() {
 : ${MBEDTLS_TEST_OUTCOME_FILE=}
 : ${MBEDTLS_TEST_CONFIGURATION:="$(guess_config_name)"}
 : ${MBEDTLS_TEST_PLATFORM:="$(uname -s | tr -c \\n0-9A-Za-z _)-$(uname -m | tr -c \\n0-9A-Za-z _)"}
+: ${EARLY_DATA_INPUT:=data_files/early_data.txt}
 
 O_SRV="$OPENSSL s_server -www -cert data_files/server5.crt -key data_files/server5.key"
 O_CLI="echo 'GET / HTTP/1.0' | $OPENSSL s_client"

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -72,7 +72,7 @@ guess_config_name() {
 : ${MBEDTLS_TEST_OUTCOME_FILE=}
 : ${MBEDTLS_TEST_CONFIGURATION:="$(guess_config_name)"}
 : ${MBEDTLS_TEST_PLATFORM:="$(uname -s | tr -c \\n0-9A-Za-z _)-$(uname -m | tr -c \\n0-9A-Za-z _)"}
-: ${EARLY_DATA_INPUT:=data_files/early_data.txt}
+: ${EARLY_DATA_INPUT:=data_files/tls13_early_data.txt}
 
 O_SRV="$OPENSSL s_server -www -cert data_files/server5.crt -key data_files/server5.key"
 O_CLI="echo 'GET / HTTP/1.0' | $OPENSSL s_client"


### PR DESCRIPTION
## Description

Fix  #6331


- [x] When `max_early_data_size` is disabled and received early data extension, ignore `decrypt error`
- [x] Relative tests.



## Gatekeeper checklist

- [x] **changelog** provided, or not required
- [x] **backport** done, or not required
- [x] **tests** provided, or not required



## Notes for the submitter

Please refer to the [contributing guidelines](../CONTRIBUTING.md), especially the
checklist for PR contributors.

