### PR TITLE
TLS 1.3: EarlyData SRV: Write `early_data` extension of NewSessionTicket

### DIFF
--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -2115,7 +2115,8 @@ int mbedtls_ssl_tls13_generate_and_write_xxdh_key_exchange(
 int mbedtls_ssl_tls13_write_early_data_ext(mbedtls_ssl_context *ssl,
                                            unsigned char *buf,
                                            const unsigned char *end,
-                                           size_t *out_len);
+                                           size_t *out_len,
+                                           const mbedtls_ssl_session *session);
 
 #if defined(MBEDTLS_SSL_SRV_C)
 #define MBEDTLS_SSL_EARLY_DATA_STATUS_NOT_RECEIVED \

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -2113,10 +2113,10 @@ int mbedtls_ssl_tls13_generate_and_write_xxdh_key_exchange(
 
 #if defined(MBEDTLS_SSL_EARLY_DATA)
 int mbedtls_ssl_tls13_write_early_data_ext(mbedtls_ssl_context *ssl,
+                                           int in_new_session_ticket,
                                            unsigned char *buf,
                                            const unsigned char *end,
-                                           size_t *out_len,
-                                           const mbedtls_ssl_session *session);
+                                           size_t *out_len);
 
 #if defined(MBEDTLS_SSL_SRV_C)
 #define MBEDTLS_SSL_EARLY_DATA_STATUS_NOT_RECEIVED \

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -2795,6 +2795,13 @@ static inline unsigned int mbedtls_ssl_session_ticket_allow_psk_ephemeral(
                                                    MBEDTLS_SSL_TLS1_3_TICKET_ALLOW_PSK_EPHEMERAL_RESUMPTION);
 }
 
+static inline unsigned int mbedtls_ssl_session_ticket_allow_early_data(
+    mbedtls_ssl_session *session)
+{
+    return !mbedtls_ssl_session_check_ticket_flags(session,
+                                                   MBEDTLS_SSL_TLS1_3_TICKET_ALLOW_EARLY_DATA);
+}
+
 static inline void mbedtls_ssl_session_set_ticket_flags(
     mbedtls_ssl_session *session, unsigned int flags)
 {

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1100,6 +1100,9 @@ static int ssl_handshake_init(mbedtls_ssl_context *ssl)
     /* Initialize structures */
     mbedtls_ssl_session_init(ssl->session_negotiate);
     ssl_handshake_params_init(ssl->handshake);
+#if defined(MBEDTLS_SSL_EARLY_DATA) && defined(MBEDTLS_SSL_SRV_C)
+    ssl->session_negotiate->max_early_data_size = ssl->conf->max_early_data_size;
+#endif
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_2)
     mbedtls_ssl_transform_init(ssl->transform_negotiate);

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1100,9 +1100,6 @@ static int ssl_handshake_init(mbedtls_ssl_context *ssl)
     /* Initialize structures */
     mbedtls_ssl_session_init(ssl->session_negotiate);
     ssl_handshake_params_init(ssl->handshake);
-#if defined(MBEDTLS_SSL_EARLY_DATA) && defined(MBEDTLS_SSL_SRV_C)
-    ssl->session_negotiate->max_early_data_size = ssl->conf->max_early_data_size;
-#endif
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_2)
     mbedtls_ssl_transform_init(ssl->transform_negotiate);

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -1174,7 +1174,9 @@ int mbedtls_ssl_tls13_write_client_hello_exts(mbedtls_ssl_context *ssl,
     if (mbedtls_ssl_conf_tls13_some_psk_enabled(ssl) &&
         ssl_tls13_early_data_has_valid_ticket(ssl) &&
         ssl->conf->early_data_enabled == MBEDTLS_SSL_EARLY_DATA_ENABLED) {
-        ret = mbedtls_ssl_tls13_write_early_data_ext(ssl, p, end, &ext_len);
+
+        ret = mbedtls_ssl_tls13_write_early_data_ext(
+            ssl, p, end, &ext_len, NULL);
         if (ret != 0) {
             return ret;
         }

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -695,10 +695,8 @@ static int ssl_tls13_early_data_has_valid_ticket(mbedtls_ssl_context *ssl)
     mbedtls_ssl_session *session = ssl->session_negotiate;
     return ssl->handshake->resume &&
            session->tls_version == MBEDTLS_SSL_VERSION_TLS1_3 &&
-           (session->ticket_flags &
-            MBEDTLS_SSL_TLS1_3_TICKET_ALLOW_EARLY_DATA) &&
-           mbedtls_ssl_tls13_cipher_suite_is_offered(
-        ssl, session->ciphersuite);
+           mbedtls_ssl_session_ticket_allow_early_data(session) &&
+           mbedtls_ssl_tls13_cipher_suite_is_offered(ssl, session->ciphersuite);
 }
 #endif
 

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -1176,7 +1176,7 @@ int mbedtls_ssl_tls13_write_client_hello_exts(mbedtls_ssl_context *ssl,
         ssl->conf->early_data_enabled == MBEDTLS_SSL_EARLY_DATA_ENABLED) {
 
         ret = mbedtls_ssl_tls13_write_early_data_ext(
-            ssl, p, end, &ext_len, NULL);
+            ssl, 0, p, end, &ext_len);
         if (ret != 0) {
             return ret;
         }

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -1407,9 +1407,6 @@ cleanup:
  *     case encrypted_extensions: Empty;
  *   };
  * } EarlyDataIndication;
- *
- * We use `mbedtls_ssl_is_handshake_over()` to decide if `max_early_data_size`
- * should be sent for `new_session_ticket` is post-handshake message.
  */
 #if defined(MBEDTLS_SSL_EARLY_DATA)
 int mbedtls_ssl_tls13_write_early_data_ext(mbedtls_ssl_context *ssl,

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -1410,18 +1410,18 @@ cleanup:
  */
 #if defined(MBEDTLS_SSL_EARLY_DATA)
 int mbedtls_ssl_tls13_write_early_data_ext(mbedtls_ssl_context *ssl,
+                                           int in_new_session_ticket,
                                            unsigned char *buf,
                                            const unsigned char *end,
-                                           size_t *out_len,
-                                           const mbedtls_ssl_session *session)
+                                           size_t *out_len)
 {
     unsigned char *p = buf;
 
 #if defined(MBEDTLS_SSL_SRV_C)
-    const size_t needed = session != NULL ? 8 : 4;
+    const size_t needed = in_new_session_ticket ? 8 : 4;
 #else
     const size_t needed = 4;
-    ((void) session);
+    ((void) in_new_session_ticket);
 #endif
 
     *out_len = 0;
@@ -1432,11 +1432,11 @@ int mbedtls_ssl_tls13_write_early_data_ext(mbedtls_ssl_context *ssl,
     MBEDTLS_PUT_UINT16_BE(needed - 4, p, 2);
 
 #if defined(MBEDTLS_SSL_SRV_C)
-    if (session != NULL) {
-        MBEDTLS_PUT_UINT32_BE(session->max_early_data_size, p, 4);
+    if (in_new_session_ticket) {
+        MBEDTLS_PUT_UINT32_BE(ssl->conf->max_early_data_size, p, 4);
         MBEDTLS_SSL_DEBUG_MSG(
             4, ("Sent max_early_data_size=%u",
-                (unsigned int) session->max_early_data_size));
+                (unsigned int) ssl->conf->max_early_data_size));
     }
 #endif
 

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -3295,6 +3295,9 @@ static int ssl_tls13_write_new_session_ticket_body(mbedtls_ssl_context *ssl,
         ssl->conf->max_early_data_size > 0) {
         mbedtls_ssl_session_set_ticket_flags(
             session, MBEDTLS_SSL_TLS1_3_TICKET_ALLOW_EARLY_DATA);
+        /* In resumption connection, server get `max_early_data_size` from
+         * ticket. */
+        session->max_early_data_size = ssl->conf->max_early_data_size;
     }
 #endif /* MBEDTLS_SSL_EARLY_DATA */
 

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -3206,10 +3206,10 @@ static int ssl_tls13_prepare_new_session_ticket(mbedtls_ssl_context *ssl,
 /* RFC 8446 section 4.2.10
  *
  * struct {
- *   select ( Handshake.msg_type ) {
- *     case new_session_ticket:   uint32 max_early_data_size;
- *     ...
- *   };
+ *     select (Handshake.msg_type) {
+ *         case new_session_ticket:   uint32 max_early_data_size;
+ *         ...
+ *     };
  * } EarlyDataIndication;
  */
 MBEDTLS_CHECK_RETURN_CRITICAL

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1845,6 +1845,14 @@ static void ssl_tls13_update_early_data_status(mbedtls_ssl_context *ssl)
 
     }
 
+    if (mbedtls_ssl_session_get_ticket_flags(
+            ssl->session_negotiate,
+            MBEDTLS_SSL_TLS1_3_TICKET_ALLOW_EARLY_DATA) == 0) {
+        MBEDTLS_SSL_DEBUG_MSG(
+            1,
+            ("EarlyData: rejected, denied by ticket permission bits."));
+        return;
+    }
 
     ssl->early_data_status = MBEDTLS_SSL_EARLY_DATA_STATUS_ACCEPTED;
 

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -3232,10 +3232,10 @@ static int ssl_tls13_write_nst_early_data_ext(mbedtls_ssl_context *ssl,
 
     MBEDTLS_PUT_UINT16_BE(MBEDTLS_TLS_EXT_EARLY_DATA, p, 0);
     MBEDTLS_PUT_UINT16_BE(4, p, 2);
-    MBEDTLS_PUT_UINT32_BE(ssl->session->max_early_data_size, p, 4);
+    MBEDTLS_PUT_UINT32_BE(ssl->conf->max_early_data_size, p, 4);
     MBEDTLS_SSL_DEBUG_MSG(
         4, ("Sent max_early_data_size=%u",
-            (unsigned int) ssl->session->max_early_data_size));
+            (unsigned int) ssl->conf->max_early_data_size));
 
     *out_len = 8;
 

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -247,6 +247,11 @@ static int ssl_tls13_offered_psks_check_identity_match_ticket(
 
 #endif /* MBEDTLS_HAVE_TIME */
 
+#if defined(MBEDTLS_SSL_EARLY_DATA)
+    MBEDTLS_SSL_DEBUG_MSG(2, ("ticket->max_early_data_size=%u",
+                              (unsigned int) session->max_early_data_size));
+#endif
+
 exit:
     if (ret != 0) {
         mbedtls_ssl_session_free(session);

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1850,7 +1850,8 @@ static void ssl_tls13_update_early_data_status(mbedtls_ssl_context *ssl)
             MBEDTLS_SSL_TLS1_3_TICKET_ALLOW_EARLY_DATA) == 0) {
         MBEDTLS_SSL_DEBUG_MSG(
             1,
-            ("EarlyData: rejected, denied by ticket permission bits."));
+            ("EarlyData: rejected, early_data not allowed in ticket "
+             "permission bits."));
         return;
     }
 
@@ -3222,10 +3223,11 @@ static int ssl_tls13_write_nst_early_data_ext(mbedtls_ssl_context *ssl,
     unsigned char *p = buf;
     *out_len = 0;
 
-    if ((ssl->session->ticket_flags &
-         MBEDTLS_SSL_TLS1_3_TICKET_ALLOW_EARLY_DATA) == 0) {
+    if (mbedtls_ssl_session_get_ticket_flags(
+            ssl->session, MBEDTLS_SSL_TLS1_3_TICKET_ALLOW_EARLY_DATA) == 0) {
         MBEDTLS_SSL_DEBUG_MSG(
-            4, ("Skip early_data extension in NST for it is not allowed."));
+            4, ("early_data not allowed, skip early_data extension in "
+                "NewSessionTicket"));
         return 0;
     }
 

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -3235,10 +3235,10 @@ static int ssl_tls13_write_nst_early_data_ext(mbedtls_ssl_context *ssl,
 
     MBEDTLS_PUT_UINT16_BE(MBEDTLS_TLS_EXT_EARLY_DATA, p, 0);
     MBEDTLS_PUT_UINT16_BE(4, p, 2);
-    MBEDTLS_PUT_UINT32_BE(ssl->conf->max_early_data_size, p, 4);
+    MBEDTLS_PUT_UINT32_BE(ssl->session->max_early_data_size, p, 4);
     MBEDTLS_SSL_DEBUG_MSG(
         4, ("Sent max_early_data_size=%u",
-            (unsigned int) ssl->conf->max_early_data_size));
+            (unsigned int) ssl->session->max_early_data_size));
 
     *out_len = 8;
 

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -3214,10 +3214,10 @@ static int ssl_tls13_prepare_new_session_ticket(mbedtls_ssl_context *ssl,
  * } EarlyDataIndication;
  */
 MBEDTLS_CHECK_RETURN_CRITICAL
-static int ssl_tls13_write_early_data_ext_of_nst(mbedtls_ssl_context *ssl,
-                                                 unsigned char *buf,
-                                                 const unsigned char *end,
-                                                 size_t *out_len)
+static int ssl_tls13_write_nst_early_data_ext(mbedtls_ssl_context *ssl,
+                                              unsigned char *buf,
+                                              const unsigned char *end,
+                                              size_t *out_len)
 {
     unsigned char *p = buf;
     *out_len = 0;
@@ -3363,9 +3363,9 @@ static int ssl_tls13_write_new_session_ticket_body(mbedtls_ssl_context *ssl,
     p += 2;
 
 #if defined(MBEDTLS_SSL_EARLY_DATA)
-    if ((ret = ssl_tls13_write_early_data_ext_of_nst(
+    if ((ret = ssl_tls13_write_nst_early_data_ext(
              ssl, p, end, &output_len)) != 0) {
-        MBEDTLS_SSL_DEBUG_RET(1, "ssl_tls13_write_early_data_ext_of_nst", ret);
+        MBEDTLS_SSL_DEBUG_RET(1, "ssl_tls13_write_nst_early_data_ext", ret);
         return ret;
     }
     p += output_len;

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -3292,7 +3292,8 @@ static int ssl_tls13_write_new_session_ticket_body(mbedtls_ssl_context *ssl,
 
 #if defined(MBEDTLS_SSL_EARLY_DATA)
     if (ssl->conf->early_data_enabled == MBEDTLS_SSL_EARLY_DATA_ENABLED) {
-        session->ticket_flags |= MBEDTLS_SSL_TLS1_3_TICKET_ALLOW_EARLY_DATA;
+        mbedtls_ssl_session_set_ticket_flags(
+            session, MBEDTLS_SSL_TLS1_3_TICKET_ALLOW_EARLY_DATA);
     }
 #endif /* MBEDTLS_SSL_EARLY_DATA */
 

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -564,9 +564,6 @@ static int ssl_tls13_parse_pre_shared_key_ext(
 #if defined(MBEDTLS_SSL_SESSION_TICKETS)
         mbedtls_ssl_session session;
         mbedtls_ssl_session_init(&session);
-#if defined(MBEDTLS_SSL_EARLY_DATA)
-        session.max_early_data_size = ssl->conf->max_early_data_size;
-#endif
 #endif
 
         MBEDTLS_SSL_CHK_BUF_READ_PTR(p_identity_len, identities_end, 2 + 1 + 4);

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -2525,7 +2525,7 @@ static int ssl_tls13_write_encrypted_extensions_body(mbedtls_ssl_context *ssl,
 #if defined(MBEDTLS_SSL_EARLY_DATA)
     if (ssl->early_data_status == MBEDTLS_SSL_EARLY_DATA_STATUS_ACCEPTED) {
         ret = mbedtls_ssl_tls13_write_early_data_ext(
-            ssl, p, end, &output_len, NULL);
+            ssl, 0, p, end, &output_len);
         if (ret != 0) {
             return ret;
         }
@@ -3326,7 +3326,7 @@ static int ssl_tls13_write_new_session_ticket_body(mbedtls_ssl_context *ssl,
     if (ssl->conf->early_data_enabled == MBEDTLS_SSL_EARLY_DATA_ENABLED &&
         ssl->conf->max_early_data_size > 0) {
         if ((ret = mbedtls_ssl_tls13_write_early_data_ext(
-                 ssl, p, end, &output_len, session)) != 0) {
+                 ssl, 1, p, end, &output_len)) != 0) {
             MBEDTLS_SSL_DEBUG_RET(
                 1, "mbedtls_ssl_tls13_write_early_data_ext", ret);
             return ret;

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1845,9 +1845,7 @@ static void ssl_tls13_update_early_data_status(mbedtls_ssl_context *ssl)
 
     }
 
-    if (mbedtls_ssl_session_get_ticket_flags(
-            ssl->session_negotiate,
-            MBEDTLS_SSL_TLS1_3_TICKET_ALLOW_EARLY_DATA) == 0) {
+    if (!mbedtls_ssl_session_ticket_allow_early_data(ssl->session_negotiate)) {
         MBEDTLS_SSL_DEBUG_MSG(
             1,
             ("EarlyData: rejected, early_data not allowed in ticket "
@@ -3223,8 +3221,7 @@ static int ssl_tls13_write_nst_early_data_ext(mbedtls_ssl_context *ssl,
     unsigned char *p = buf;
     *out_len = 0;
 
-    if (mbedtls_ssl_session_get_ticket_flags(
-            ssl->session, MBEDTLS_SSL_TLS1_3_TICKET_ALLOW_EARLY_DATA) == 0) {
+    if (!mbedtls_ssl_session_ticket_allow_early_data(ssl->session)) {
         MBEDTLS_SSL_DEBUG_MSG(
             4, ("early_data not allowed, skip early_data extension in "
                 "NewSessionTicket"));

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -564,6 +564,9 @@ static int ssl_tls13_parse_pre_shared_key_ext(
 #if defined(MBEDTLS_SSL_SESSION_TICKETS)
         mbedtls_ssl_session session;
         mbedtls_ssl_session_init(&session);
+#if defined(MBEDTLS_SSL_EARLY_DATA)
+        session.max_early_data_size = ssl->conf->max_early_data_size;
+#endif
 #endif
 
         MBEDTLS_SSL_CHK_BUF_READ_PTR(p_identity_len, identities_end, 2 + 1 + 4);

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -3340,6 +3340,10 @@ static int ssl_tls13_write_new_session_ticket_body(mbedtls_ssl_context *ssl,
             return ret;
         }
         p += output_len;
+    } else {
+        MBEDTLS_SSL_DEBUG_MSG(
+            4, ("early_data not allowed, "
+                "skip early_data extension in NewSessionTicket"));
     }
 
 #endif /* MBEDTLS_SSL_EARLY_DATA */

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -247,11 +247,6 @@ static int ssl_tls13_offered_psks_check_identity_match_ticket(
 
 #endif /* MBEDTLS_HAVE_TIME */
 
-#if defined(MBEDTLS_SSL_EARLY_DATA)
-    MBEDTLS_SSL_DEBUG_MSG(2, ("ticket->max_early_data_size=%u",
-                              (unsigned int) session->max_early_data_size));
-#endif
-
 exit:
     if (ret != 0) {
         mbedtls_ssl_session_free(session);
@@ -3259,9 +3254,6 @@ static int ssl_tls13_write_new_session_ticket_body(mbedtls_ssl_context *ssl,
         ssl->conf->max_early_data_size > 0) {
         mbedtls_ssl_session_set_ticket_flags(
             session, MBEDTLS_SSL_TLS1_3_TICKET_ALLOW_EARLY_DATA);
-        /* In resumption connection, server get `max_early_data_size` from
-         * ticket. */
-        session->max_early_data_size = ssl->conf->max_early_data_size;
     }
 #endif /* MBEDTLS_SSL_EARLY_DATA */
 

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -3262,12 +3262,13 @@ static int ssl_tls13_write_nst_early_data_ext(mbedtls_ssl_context *ssl,
  * The following fields are placed inside the ticket by the
  * f_ticket_write() function:
  *
- *  - creation time (start)
- *  - flags (flags)
+ *  - creation time (ticket_creation_time)
+ *  - flags (ticket_flags)
  *  - age add (ticket_age_add)
- *  - key (key)
- *  - key length (key_len)
+ *  - key (resumption_key)
+ *  - key length (resumption_key_len)
  *  - ciphersuite (ciphersuite)
+ *  - max_early_data_size (max_early_data_size)
  */
 MBEDTLS_CHECK_RETURN_CRITICAL
 static int ssl_tls13_write_new_session_ticket_body(mbedtls_ssl_context *ssl,

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -435,7 +435,9 @@ int main(void)
     "                            The max amount of 0-RTT data for 1st and 2nd connection\n" \
     "                            format:  1st_connection_value[,2nd_connection_value]\n" \
     "                            available values:  < 0 (disabled), >= 0 (enabled).\n"             \
-    "                                               The absolute value is the max amount of 0-RTT data.\n"
+    "                                               The absolute value is the max amount of 0-RTT data \n" \
+    "                                               up to UINT32_MAX. \n"
+
 #else
 #define USAGE_EARLY_DATA ""
 #endif /* MBEDTLS_SSL_EARLY_DATA */

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -122,7 +122,7 @@ int main(void)
 #define DFL_SNI                 NULL
 #define DFL_ALPN_STRING         NULL
 #define DFL_GROUPS              NULL
-#define DFL_MAX_EARLY_DATA_SIZE 0
+#define DFL_MAX_EARLY_DATA_SIZE NULL
 #define DFL_SIG_ALGS            NULL
 #define DFL_DHM_FILE            NULL
 #define DFL_TRANSPORT           MBEDTLS_SSL_TRANSPORT_STREAM
@@ -427,11 +427,15 @@ int main(void)
 #define USAGE_ECJPAKE ""
 #endif /* MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED */
 
+#define ARRAY_LENGTH(a) (sizeof(a)/sizeof(a[0]))
 #if defined(MBEDTLS_SSL_EARLY_DATA)
+
 #define USAGE_EARLY_DATA \
-    "    max_early_data_size=%%d default: -1 (disabled)\n"             \
-    "                            options: -1 (disabled), "           \
-    "                                     >= 0 (enabled, max amount of early data )\n"
+    "    max_early_data_size=%%d default: -1 (disabled)\n"              \
+    "                            The max amount of 0-RTT data for 1st and 2nd connection\n" \
+    "                            format:  1st_connection_value[,2nd_connection_value]\n" \
+    "                            available values:  < 0 (disabled), >= 0 (enabled).\n"             \
+    "                                               The absolute value is the max amount of 0-RTT data.\n"
 #else
 #define USAGE_EARLY_DATA ""
 #endif /* MBEDTLS_SSL_EARLY_DATA */
@@ -556,6 +560,7 @@ int main(void)
     USAGE_GROUPS                                            \
     USAGE_SIG_ALGS                                          \
     USAGE_KEY_OPAQUE_ALGS                                   \
+    USAGE_EARLY_DATA                                        \
     "\n"
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
@@ -693,7 +698,7 @@ struct options {
     const char *cid_val_renego; /* the CID to use for incoming messages
                                  * after renegotiation                      */
     int reproducible;           /* make communication reproducible          */
-    uint32_t max_early_data_size; /* max amount of early data               */
+    const char *max_early_data_size; /* max amount list of early data         */
     int query_config_mode;      /* whether to read config                   */
     int use_srtp;               /* Support SRTP                             */
     int force_srtp_profile;     /* SRTP protection profile to use or all    */
@@ -1609,7 +1614,9 @@ int main(int argc, char *argv[])
 #endif /* MBEDTLS_SSL_DTLS_SRTP */
 
 #if defined(MBEDTLS_SSL_EARLY_DATA)
-    int tls13_early_data_enabled = MBEDTLS_SSL_EARLY_DATA_DISABLED;
+    long long max_early_data_size_list[2];
+    size_t max_early_data_size_count = 0;
+    size_t tls13_connection_counter = 0;
 #endif
 #if defined(MBEDTLS_MEMORY_BUFFER_ALLOC_C)
     mbedtls_memory_buffer_alloc_init(alloc_buf, sizeof(alloc_buf));
@@ -1979,12 +1986,23 @@ usage:
 #endif
 #if defined(MBEDTLS_SSL_EARLY_DATA)
         else if (strcmp(p, "max_early_data_size") == 0) {
-            long long value = atoll(q);
-            tls13_early_data_enabled =
-                value >= 0 ? MBEDTLS_SSL_EARLY_DATA_ENABLED :
-                MBEDTLS_SSL_EARLY_DATA_DISABLED;
-            if (tls13_early_data_enabled) {
-                opt.max_early_data_size = atoi(q);
+            char *endptr, *str;
+            opt.max_early_data_size = q;
+            str = endptr = q;
+            for (size_t early_data_size_iter = 0;
+                 early_data_size_iter < ARRAY_LENGTH(max_early_data_size_list);
+                 early_data_size_iter++) {
+                long long value = strtoll(str, &endptr, 0);
+                if (str == endptr || (*endptr != ',' && *endptr != '\0')) {
+                    mbedtls_printf("fail\n illegal digital number for max_early_data_size %s\n",
+                                   endptr);
+                    goto exit;
+                }
+                max_early_data_size_list[max_early_data_size_count++] = value;
+                if (*endptr == '\0') {
+                    break;
+                }
+                str = endptr + 1;
             }
         }
 #endif /* MBEDTLS_SSL_EARLY_DATA */
@@ -2806,14 +2824,6 @@ usage:
         mbedtls_ssl_conf_cert_req_ca_list(&conf, opt.cert_req_ca_list);
     }
 
-#if defined(MBEDTLS_SSL_EARLY_DATA)
-    mbedtls_ssl_conf_early_data(&conf, tls13_early_data_enabled);
-    if (tls13_early_data_enabled == MBEDTLS_SSL_EARLY_DATA_ENABLED) {
-        mbedtls_ssl_conf_max_early_data_size(
-            &conf, opt.max_early_data_size);
-    }
-#endif /* MBEDTLS_SSL_EARLY_DATA */
-
 #if defined(MBEDTLS_KEY_EXCHANGE_CERT_REQ_ALLOWED_ENABLED)
     /* exercise setting DN hints for server certificate request
      * (Intended for use where the client cert expected has been signed by
@@ -3311,6 +3321,17 @@ usage:
     mbedtls_printf(" ok\n");
 
 reset:
+
+#if defined(MBEDTLS_SSL_EARLY_DATA)
+    if (tls13_connection_counter < max_early_data_size_count) {
+        long long max_early_data_size = max_early_data_size_list[tls13_connection_counter];
+        mbedtls_ssl_conf_early_data(
+            &conf, max_early_data_size < 0 ? MBEDTLS_SSL_EARLY_DATA_DISABLED :
+            MBEDTLS_SSL_EARLY_DATA_ENABLED);
+        mbedtls_ssl_conf_max_early_data_size(&conf, (uint32_t) llabs(max_early_data_size));
+    }
+    tls13_connection_counter++;
+#endif /* MBEDTLS_SSL_EARLY_DATA */
 #if !defined(_WIN32)
     if (received_sigterm) {
         mbedtls_printf(" interrupted by SIGTERM (not in net_accept())\n");

--- a/tests/opt-testcases/tls13-misc.sh
+++ b/tests/opt-testcases/tls13-misc.sh
@@ -491,22 +491,6 @@ EARLY_DATA_INPUT_LEN_BLOCKS=$(( ( $( cat $EARLY_DATA_INPUT | wc -c ) + 31 ) / 32
 EARLY_DATA_INPUT_LEN=$(( $EARLY_DATA_INPUT_LEN_BLOCKS * 32 ))
 
 requires_gnutls_next
-requires_all_configs_enabled MBEDTLS_SSL_EARLY_DATA MBEDTLS_SSL_SESSION_TICKETS     \
-                             MBEDTLS_SSL_SRV_C MBEDTLS_DEBUG_C MBEDTLS_HAVE_TIME    \
-                             MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED \
-                             MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
-requires_any_configs_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_ENABLED \
-                             MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL_ENABLED
-run_test "TLS 1.3 G->m: EarlyData: feature is disabled, fail." \
-         "$P_SRV force_version=tls13 debug_level=4 max_early_data_size=-1" \
-         "$G_NEXT_CLI localhost --priority=NORMAL:-VERS-ALL:+VERS-TLS1.3:+GROUP-ALL -d 10 -r --earlydata $EARLY_DATA_INPUT" \
-         1 \
-         -s "ClientHello: early_data(42) extension exists."                     \
-         -s "EncryptedExtensions: early_data(42) extension does not exist."     \
-         -s "NewSessionTicket: early_data(42) extension does not exist."        \
-         -s "Last error was: -29056 - SSL - Verification of the message MAC failed"
-
-requires_gnutls_next
 requires_all_configs_enabled MBEDTLS_SSL_EARLY_DATA MBEDTLS_SSL_SESSION_TICKETS \
                              MBEDTLS_SSL_SRV_C MBEDTLS_DEBUG_C MBEDTLS_HAVE_TIME \
                              MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED \

--- a/tests/opt-testcases/tls13-misc.sh
+++ b/tests/opt-testcases/tls13-misc.sh
@@ -523,5 +523,3 @@ run_test "TLS 1.3 G->m: EarlyData: feature is enabled, good." \
          -s "ClientHello: early_data(42) extension exists."                 \
          -s "EncryptedExtensions: early_data(42) extension exists."         \
          -s "$( tail -1 $EARLY_DATA_INPUT )"
-
-

--- a/tests/opt-testcases/tls13-misc.sh
+++ b/tests/opt-testcases/tls13-misc.sh
@@ -502,7 +502,7 @@ run_test "TLS 1.3 G->m: EarlyData: feature is disabled, fail." \
          "$G_NEXT_CLI localhost --priority=NORMAL:-VERS-ALL:+VERS-TLS1.3:+GROUP-ALL -d 10 -r --earlydata $EARLY_DATA_INPUT" \
          1 \
          -s "ClientHello: early_data(42) extension exists."                     \
-         -s "EncryptedExtensions: early_data(42) extension does not exist."    \
+         -s "EncryptedExtensions: early_data(42) extension does not exist."     \
          -s "NewSessionTicket: early_data(42) extension does not exist."        \
          -s "Last error was: -29056 - SSL - Verification of the message MAC failed"
 
@@ -518,7 +518,10 @@ run_test "TLS 1.3 G->m: EarlyData: feature is enabled, good." \
          "$G_NEXT_CLI localhost --priority=NORMAL:-VERS-ALL:+VERS-TLS1.3:+GROUP-ALL:+KX-ALL \
                       -d 10 -r --earlydata $EARLY_DATA_INPUT " \
          0 \
+         -s "NewSessionTicket: early_data(42) extension exists."            \
+         -s "Sent max_early_data_size=$EARLY_DATA_INPUT_LEN"                \
          -s "ClientHello: early_data(42) extension exists."                 \
          -s "EncryptedExtensions: early_data(42) extension exists."         \
-         -s "NewSessionTicket: early_data(42) extension does not exist."    \
          -s "$( tail -1 $EARLY_DATA_INPUT )"
+
+


### PR DESCRIPTION
## Description

fix #6347 

This PR write early_data extension of NST message. `max_early_data_field` is come from configured value. Next PRs will fix that.

## Gatekeeper checklist

- [x] **changelog** provided, or not required
- [x] **backport** done, or not required
- [x] **tests** provided, or not required



## Notes for the submitter

Please refer to the [contributing guidelines](../CONTRIBUTING.md), especially the
checklist for PR contributors.

