### PR TITLE
Backport 2.28: Changelog improvements for 3.3

### DIFF
--- a/ChangeLog.d/fix_build_tls1_2_with_single_encryption_type.txt
+++ b/ChangeLog.d/fix_build_tls1_2_with_single_encryption_type.txt
@@ -1,4 +1,3 @@
 Bugfix
-    * Fix bugs and missing dependencies when
-      building and testing configurations with
-      only one encryption type enabled in TLS 1.2.
+    * Fix bugs and missing dependencies when building and testing
+      configurations with only one encryption type enabled in TLS 1.2.

--- a/ChangeLog.d/fix_cmake_using_iar_toolchain.txt
+++ b/ChangeLog.d/fix_cmake_using_iar_toolchain.txt
@@ -1,3 +1,3 @@
 Bugfix
-   * Fixed an issue that cause compile error using CMake IAR toolchain.
+   * Fix a compilation error when using CMake with an IAR toolchain.
      Fixes #5964.

--- a/ChangeLog.d/fix_zeroization.txt
+++ b/ChangeLog.d/fix_zeroization.txt
@@ -1,3 +1,3 @@
 Bugfix
-   * Fix possible crash in TLS PRF code, if a failure to allocate memory occurs.
-     Reported by Michael Madsen in #6516.
+   * Fix a possible null pointer dereference if a memory allocation fails
+     in TLS PRF code. Reported by Michael Madsen in #6516.


### PR DESCRIPTION
Backport of https://github.com/Mbed-TLS/mbedtls/pull/6689. Only a few changes were in bugfixes with backports. `ChangeLog.d` is identical here and in https://github.com/Mbed-TLS/mbedtls/pull/6689 except for files that are only present in 3.3 and for `psa_rsa_needs_pk.txt` where 2.28 and 3.3 had different problems in the same area.

## Gatekeeper checklist

- [x] **changelog** N/A
- [x] **backport** of https://github.com/Mbed-TLS/mbedtls/pull/6689
- [x] **tests** N/A
