### PR TITLE
Remove useless debug log of pk type from test cases

### DIFF
--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -11727,8 +11727,7 @@ run_test    "TLS 1.3: Client authentication, client alg not in server list - ope
             -c "got a certificate request" \
             -c "client state: MBEDTLS_SSL_CLIENT_CERTIFICATE" \
             -c "client state: MBEDTLS_SSL_CLIENT_CERTIFICATE_VERIFY" \
-            -c "no suitable signature algorithm" \
-            -C "unknown pk type"
+            -c "no suitable signature algorithm"
 
 requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
@@ -11745,8 +11744,7 @@ run_test    "TLS 1.3: Client authentication, client alg not in server list - gnu
             -c "got a certificate request" \
             -c "client state: MBEDTLS_SSL_CLIENT_CERTIFICATE" \
             -c "client state: MBEDTLS_SSL_CLIENT_CERTIFICATE_VERIFY" \
-            -c "no suitable signature algorithm" \
-            -C "unknown pk type"
+            -c "no suitable signature algorithm"
 
 # Test using an opaque private key for client authentication
 requires_openssl_tls1_3
@@ -11999,8 +11997,7 @@ run_test    "TLS 1.3: Client authentication - opaque key, client alg not in serv
             -c "got a certificate request" \
             -c "client state: MBEDTLS_SSL_CLIENT_CERTIFICATE" \
             -c "client state: MBEDTLS_SSL_CLIENT_CERTIFICATE_VERIFY" \
-            -c "no suitable signature algorithm" \
-            -C "unkown pk type"
+            -c "no suitable signature algorithm"
 
 requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
@@ -12018,8 +12015,7 @@ run_test    "TLS 1.3: Client authentication - opaque key, client alg not in serv
             -c "got a certificate request" \
             -c "client state: MBEDTLS_SSL_CLIENT_CERTIFICATE" \
             -c "client state: MBEDTLS_SSL_CLIENT_CERTIFICATE_VERIFY" \
-            -c "no suitable signature algorithm" \
-            -C "unkown pk type"
+            -c "no suitable signature algorithm"
 
 requires_openssl_tls1_3
 requires_config_enabled MBEDTLS_DEBUG_C


### PR DESCRIPTION
The debug log "unkown pk type" doesn't exist in our code, instead we use another log: "no suitable signature algorithm". 
In some cases, we still have the message "unkown pk type" or "unknown pk type", which is useless, remove them.

