### PR TITLE
Bignum: Implement fixed width raw modular multiplication

### DIFF
--- a/library/bignum_mod_raw.c
+++ b/library/bignum_mod_raw.c
@@ -120,6 +120,16 @@ void mbedtls_mpi_mod_raw_sub( mbedtls_mpi_uint *X,
     (void) mbedtls_mpi_core_add_if( X, N->p, N->limbs, (unsigned) c );
 }
 
+void mbedtls_mpi_mod_raw_mul( mbedtls_mpi_uint *X,
+                              const mbedtls_mpi_uint *A,
+                              const mbedtls_mpi_uint *B,
+                              const mbedtls_mpi_mod_modulus *N,
+                              mbedtls_mpi_uint *T )
+{
+    mbedtls_mpi_core_montmul( X, A, B, N->limbs, N->p, N->limbs,
+                              N->rep.mont.mm, T );
+}
+
 /* END MERGE SLOT 2 */
 
 /* BEGIN MERGE SLOT 3 */

--- a/library/bignum_mod_raw.h
+++ b/library/bignum_mod_raw.h
@@ -173,7 +173,7 @@ void mbedtls_mpi_mod_raw_sub( mbedtls_mpi_uint *X,
 /** \brief  Multiply two MPIs, returning the residue modulo the specified
  *          modulus.
  *
- * \note Currently handles the case when `m->int_rep` is
+ * \note Currently handles the case when `N->int_rep` is
  * MBEDTLS_MPI_MOD_REP_MONTGOMERY.
  *
  * The size of the operation is determined by \p N. \p A, \p B and \p X must
@@ -193,7 +193,7 @@ void mbedtls_mpi_mod_raw_sub( mbedtls_mpi_uint *X,
  * \param[in]  B        The address of the second MPI.
  * \param[in]  N        The address of the modulus. Used to perform a modulo
  *                      operation on the result of the multiplication.
- * \param[in,out] T     Temporary storage of size at least 2 * AN_limbs + 1
+ * \param[in,out] T     Temporary storage of size at least 2 * N->limbs + 1
  *                      limbs. Its initial content is unused and
  *                      its final content is indeterminate.
  *                      It must not alias or otherwise overlap any of the

--- a/library/bignum_mod_raw.h
+++ b/library/bignum_mod_raw.h
@@ -170,6 +170,31 @@ void mbedtls_mpi_mod_raw_sub( mbedtls_mpi_uint *X,
                               const mbedtls_mpi_uint *B,
                               const mbedtls_mpi_mod_modulus *N );
 
+/** \brief  Multiply two MPIs, returning the residue modulo the specified
+ *          modulus.
+ *
+ * The size of the operation is determined by \p N. \p A and \p B must have
+ * the same number of limbs as \p N.
+ *
+ * \p X may be aliased to \p A or \p B, or even both, but may not overlap
+ * either otherwise.
+ *
+ * \param[out] X        The address of the result MPI.
+ *                      This must be initialized. Must have enough limbs to
+ *                      store the full value of the result.
+ * \param[in]  A        The address of the first MPI. This must be initialized.
+ * \param[in]  B        The address of the second MPI. This must be initialized.
+ * \param[in]  N        The address of the modulus. Used to perform a modulo
+ *                      operation on the result of the subtraction.
+ * \param[in]  T        The address of an MPI used by the multiplication
+ *                      as a temp variable.
+ */
+void mbedtls_mpi_mod_raw_mul( mbedtls_mpi_uint *X,
+                              const mbedtls_mpi_uint *A,
+                              const mbedtls_mpi_uint *B,
+                              const mbedtls_mpi_mod_modulus *N,
+                              mbedtls_mpi_uint *T );
+
 /* END MERGE SLOT 2 */
 
 /* BEGIN MERGE SLOT 3 */

--- a/library/bignum_mod_raw.h
+++ b/library/bignum_mod_raw.h
@@ -173,21 +173,31 @@ void mbedtls_mpi_mod_raw_sub( mbedtls_mpi_uint *X,
 /** \brief  Multiply two MPIs, returning the residue modulo the specified
  *          modulus.
  *
- * The size of the operation is determined by \p N. \p A and \p B must have
- * the same number of limbs as \p N.
+ * \note Currently handles the case when `m->int_rep` is
+ * MBEDTLS_MPI_MOD_REP_MONTGOMERY.
+ *
+ * The size of the operation is determined by \p N. \p A, \p B and \p X must
+ * all be associated with the modulus \p N and must all have the same number
+ * of limbs as \p N.
  *
  * \p X may be aliased to \p A or \p B, or even both, but may not overlap
- * either otherwise.
+ * either otherwise. They may not alias \p N (since they must be in canonical
+ * form, they cannot == \p N).
  *
- * \param[out] X        The address of the result MPI.
- *                      This must be initialized. Must have enough limbs to
- *                      store the full value of the result.
- * \param[in]  A        The address of the first MPI. This must be initialized.
- * \param[in]  B        The address of the second MPI. This must be initialized.
+ * \param[out] X        The address of the result MPI. Must have the same
+ *                      number of limbs as \p N.
+ *                      On successful completion, \p X contains the result of
+ *                      the multiplication `A * B * R^-1` mod N where
+ *                      `R = 2^(biL * N->limbs)`.
+ * \param[in]  A        The address of the first MPI.
+ * \param[in]  B        The address of the second MPI.
  * \param[in]  N        The address of the modulus. Used to perform a modulo
- *                      operation on the result of the subtraction.
- * \param[in]  T        The address of an MPI used by the multiplication
- *                      as a temp variable.
+ *                      operation on the result of the multiplication.
+ * \param[in,out] T     Temporary storage of size at least 2 * AN_limbs + 1
+ *                      limbs. Its initial content is unused and
+ *                      its final content is indeterminate.
+ *                      It must not alias or otherwise overlap any of the
+ *                      other parameters.
  */
 void mbedtls_mpi_mod_raw_mul( mbedtls_mpi_uint *X,
                               const mbedtls_mpi_uint *A,

--- a/scripts/mbedtls_dev/bignum_mod_raw.py
+++ b/scripts/mbedtls_dev/bignum_mod_raw.py
@@ -60,14 +60,14 @@ class BignumModRawMul(bignum_common.ModOperationCommon,
     arity = 2
 
     def arguments(self) -> List[str]:
-        return [bignum_common.quote_str(n) for n in [self.arg_a,
-                                                     self.arg_b,
-                                                     self.arg_n]
+        return [self.format_result(self.to_montgomery(self.int_a)),
+                self.format_result(self.to_montgomery(self.int_b)),
+                bignum_common.quote_str(self.arg_n)
                ] + self.result()
 
     def result(self) -> List[str]:
         result = (self.int_a * self.int_b) % self.int_n
-        return [self.format_result(result)]
+        return [self.format_result(self.to_montgomery(result))]
 
 # END MERGE SLOT 2
 

--- a/scripts/mbedtls_dev/bignum_mod_raw.py
+++ b/scripts/mbedtls_dev/bignum_mod_raw.py
@@ -50,6 +50,25 @@ class BignumModRawSub(bignum_common.ModOperationCommon,
         result = (self.int_a - self.int_b) % self.int_n
         return [self.format_result(result)]
 
+class BignumModRawMul(bignum_common.ModOperationCommon,
+                      BignumModRawTarget):
+    """Test cases for bignum mpi_mod_raw_mul()."""
+    symbol = "*"
+    test_function = "mpi_mod_raw_mul"
+    test_name = "mbedtls_mpi_mod_raw_mul"
+    input_style = "arch_split"
+    arity = 2
+
+    def arguments(self) -> List[str]:
+        return [bignum_common.quote_str(n) for n in [self.arg_a,
+                                                     self.arg_b,
+                                                     self.arg_n]
+               ] + self.result()
+
+    def result(self) -> List[str]:
+        result = (self.int_a * self.int_b) % self.int_n
+        return [self.format_result(result)]
+
 # END MERGE SLOT 2
 
 # BEGIN MERGE SLOT 3

--- a/tests/suites/test_suite_bignum_mod_raw.function
+++ b/tests/suites/test_suite_bignum_mod_raw.function
@@ -386,37 +386,28 @@ void mpi_mod_raw_mul( char * input_A,
     const size_t limbs_T = limbs * 2 + 1;
     ASSERT_ALLOC( T, limbs_T );
 
-    /* Convert to Montgomery representation */
-    TEST_EQUAL( mbedtls_mpi_mod_raw_to_mont_rep( A, &m ), 0 );
-    TEST_EQUAL( mbedtls_mpi_mod_raw_to_mont_rep( B, &m ), 0 );
-
     mbedtls_mpi_mod_raw_mul( X, A, B, &m, T );
-    TEST_EQUAL( mbedtls_mpi_mod_raw_from_mont_rep( X, &m ), 0 );
     ASSERT_COMPARE( X, bytes, R, bytes );
 
     /* alias X to A */
     memcpy( X, A, bytes );
     mbedtls_mpi_mod_raw_mul( X, X, B, &m, T );
-    TEST_EQUAL( mbedtls_mpi_mod_raw_from_mont_rep( X, &m ), 0 );
     ASSERT_COMPARE( X, bytes, R, bytes );
 
     /* alias X to B */
     memcpy( X, B, bytes );
     mbedtls_mpi_mod_raw_mul( X, A, X, &m, T );
-    TEST_EQUAL( mbedtls_mpi_mod_raw_from_mont_rep( X, &m ), 0 );
     ASSERT_COMPARE( X, bytes, R, bytes );
 
     /* A == B: alias A and B */
     if( memcmp( A, B, bytes ) == 0 )
     {
         mbedtls_mpi_mod_raw_mul( X, A, A, &m, T );
-        TEST_EQUAL( mbedtls_mpi_mod_raw_from_mont_rep( X, &m ), 0 );
         ASSERT_COMPARE( X, bytes, R, bytes );
 
         /* X, A, B all aliased together */
         memcpy( X, A, bytes );
         mbedtls_mpi_mod_raw_mul( X, X, X, &m, T );
-        TEST_EQUAL( mbedtls_mpi_mod_raw_from_mont_rep( X, &m ), 0 );
         ASSERT_COMPARE( X, bytes, R, bytes );
     }
 
@@ -424,19 +415,16 @@ void mpi_mod_raw_mul( char * input_A,
     else
     {
         mbedtls_mpi_mod_raw_mul( X, B, A, &m, T );
-        TEST_EQUAL( mbedtls_mpi_mod_raw_from_mont_rep( X, &m ), 0 );
         ASSERT_COMPARE( X, bytes, R, bytes );
 
         /* B * A: alias X to A */
         memcpy( X, A, bytes );
         mbedtls_mpi_mod_raw_mul( X, B, X, &m, T );
-        TEST_EQUAL( mbedtls_mpi_mod_raw_from_mont_rep( X, &m ), 0 );
         ASSERT_COMPARE( X, bytes, R, bytes );
 
         /* B + A: alias X to B */
         memcpy( X, B, bytes );
         mbedtls_mpi_mod_raw_mul( X, X, A, &m, T );
-        TEST_EQUAL( mbedtls_mpi_mod_raw_from_mont_rep( X, &m ), 0 );
         ASSERT_COMPARE( X, bytes, R, bytes );
     }
 

--- a/tests/suites/test_suite_bignum_mod_raw.function
+++ b/tests/suites/test_suite_bignum_mod_raw.function
@@ -345,6 +345,113 @@ exit:
 }
 /* END_CASE */
 
+/* BEGIN_CASE */
+void mpi_mod_raw_mul( char * input_A,
+                      char * input_B,
+                      char * input_N,
+                      char * result )
+{
+    mbedtls_mpi_uint *A = NULL;
+    mbedtls_mpi_uint *B = NULL;
+    mbedtls_mpi_uint *N = NULL;
+    mbedtls_mpi_uint *X = NULL;
+    mbedtls_mpi_uint *R = NULL;
+    mbedtls_mpi_uint *T = NULL;
+    size_t limbs_A;
+    size_t limbs_B;
+    size_t limbs_N;
+    size_t limbs_R;
+
+    mbedtls_mpi_mod_modulus m;
+    mbedtls_mpi_mod_modulus_init( &m );
+
+    TEST_EQUAL( mbedtls_test_read_mpi_core( &A, &limbs_A, input_A ), 0 );
+    TEST_EQUAL( mbedtls_test_read_mpi_core( &B, &limbs_B, input_B ), 0 );
+    TEST_EQUAL( mbedtls_test_read_mpi_core( &N, &limbs_N, input_N ), 0 );
+    TEST_EQUAL( mbedtls_test_read_mpi_core( &R, &limbs_R, result  ), 0 );
+
+    const size_t limbs = limbs_N;
+    const size_t bytes = limbs * sizeof( mbedtls_mpi_uint );
+
+    TEST_EQUAL( limbs_A, limbs );
+    TEST_EQUAL( limbs_B, limbs );
+    TEST_EQUAL( limbs_R, limbs );
+
+    ASSERT_ALLOC( X, limbs );
+
+    TEST_EQUAL( mbedtls_mpi_mod_modulus_setup(
+                        &m, N, limbs,
+                        MBEDTLS_MPI_MOD_REP_MONTGOMERY ), 0 );
+
+    const size_t limbs_T = limbs * 2 + 1;
+    ASSERT_ALLOC( T, limbs_T );
+
+    /* Convert to Montgomery representation */
+    TEST_EQUAL( mbedtls_mpi_mod_raw_to_mont_rep( A, &m ), 0 );
+    TEST_EQUAL( mbedtls_mpi_mod_raw_to_mont_rep( B, &m ), 0 );
+
+    mbedtls_mpi_mod_raw_mul( X, A, B, &m, T );
+    TEST_EQUAL( mbedtls_mpi_mod_raw_from_mont_rep( X, &m ), 0 );
+    ASSERT_COMPARE( X, bytes, R, bytes );
+
+    /* alias X to A */
+    memcpy( X, A, bytes );
+    mbedtls_mpi_mod_raw_mul( X, X, B, &m, T );
+    TEST_EQUAL( mbedtls_mpi_mod_raw_from_mont_rep( X, &m ), 0 );
+    ASSERT_COMPARE( X, bytes, R, bytes );
+
+    /* alias X to B */
+    memcpy( X, B, bytes );
+    mbedtls_mpi_mod_raw_mul( X, A, X, &m, T );
+    TEST_EQUAL( mbedtls_mpi_mod_raw_from_mont_rep( X, &m ), 0 );
+    ASSERT_COMPARE( X, bytes, R, bytes );
+
+    /* A == B: alias A and B */
+    if( memcmp( A, B, bytes ) == 0 )
+    {
+        mbedtls_mpi_mod_raw_mul( X, A, A, &m, T );
+        TEST_EQUAL( mbedtls_mpi_mod_raw_from_mont_rep( X, &m ), 0 );
+        ASSERT_COMPARE( X, bytes, R, bytes );
+
+        /* X, A, B all aliased together */
+        memcpy( X, A, bytes );
+        mbedtls_mpi_mod_raw_mul( X, X, X, &m, T );
+        TEST_EQUAL( mbedtls_mpi_mod_raw_from_mont_rep( X, &m ), 0 );
+        ASSERT_COMPARE( X, bytes, R, bytes );
+    }
+
+    /* A != B: test B * A */
+    else
+    {
+        mbedtls_mpi_mod_raw_mul( X, B, A, &m, T );
+        TEST_EQUAL( mbedtls_mpi_mod_raw_from_mont_rep( X, &m ), 0 );
+        ASSERT_COMPARE( X, bytes, R, bytes );
+
+        /* B * A: alias X to A */
+        memcpy( X, A, bytes );
+        mbedtls_mpi_mod_raw_mul( X, B, X, &m, T );
+        TEST_EQUAL( mbedtls_mpi_mod_raw_from_mont_rep( X, &m ), 0 );
+        ASSERT_COMPARE( X, bytes, R, bytes );
+
+        /* B + A: alias X to B */
+        memcpy( X, B, bytes );
+        mbedtls_mpi_mod_raw_mul( X, X, A, &m, T );
+        TEST_EQUAL( mbedtls_mpi_mod_raw_from_mont_rep( X, &m ), 0 );
+        ASSERT_COMPARE( X, bytes, R, bytes );
+    }
+
+exit:
+    mbedtls_free( A );
+    mbedtls_free( B );
+    mbedtls_free( X );
+    mbedtls_free( R );
+    mbedtls_free( T );
+
+    mbedtls_mpi_mod_modulus_free( &m );
+    mbedtls_free( N );
+}
+/* END_CASE */
+
 /* END MERGE SLOT 2 */
 
 /* BEGIN MERGE SLOT 3 */


### PR DESCRIPTION
## Description

Implement fixed width modular multiplication. The `_mod_raw` version should take a caller-managed buffer for the temporary buffer. 

Resolve #6022 

## Gatekeeper checklist

- [x] **tests** provided, or not required
