### PR TITLE
Script to update the GitHub preview branches

### DIFF
--- a/scripts/update-code-style-preview-branches.sh
+++ b/scripts/update-code-style-preview-branches.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-ENFORCEMENT_COMMIT=6ed34c672d4f9298a90a17f149211b69ea97d190
+ENFORCEMENT_COMMIT=features/new-code-style/switch-to-enforcement
 REMOTE_URL=git@github.com:Mbed-TLS/mbedtls.git
 
 help () {

--- a/scripts/update-code-style-preview-branches.sh
+++ b/scripts/update-code-style-preview-branches.sh
@@ -1,0 +1,93 @@
+#!/bin/sh
+
+ENFORCEMENT_COMMIT=7a88ce312a516cb2fe9c30cfe365ff3fa64c17b7
+REMOTE_URL=git@github.com:Mbed-TLS/mbedtls.git
+
+help () {
+    cat <<EOF
+Usage: $0 [OPTION]... BRANCH_NAME...
+Update and force-push the given preview branches with the new code style.
+
+You must run this from a Git worktree with a remote pointing to the official
+Mbed TLS repository.
+This script will fetch and push to that remote but will not modify the
+Git worktree or local branches.
+
+If something goes wrong, a Git worktree may be left in
+../update-code-style-preview-*
+
+Options:
+  -c SHA        Commit that switches all.sh to code style enforcement mode
+                (default: $ENFORCEMENT_COMMIT)
+  -r REMOTE     Git remote name (default: autodetected from REMOTE_URL)
+  -u REMOTE_URL Git remote URL (default: $REMOTE_URL)
+EOF
+}
+
+set -eu
+
+remote=
+
+# update_branch BRANCH_NAME
+update_branch () {
+    worktree_name="update-code-style-preview-$1-$$"
+    git worktree add "../$worktree_name" "$remote/$1"
+    cd "../$worktree_name"
+    # Hide diffs, keep errors (and uncrustify's progress output)
+    ./scripts/code_style.py --fix >/dev/null
+    git commit -a --signoff -m 'Switch to the new code style'
+    git cherry-pick "$ENFORCEMENT_COMMIT"
+    git push --force-with-lease "$REMOTE_URL" "HEAD:refs/heads/features/new-code-style/$1"
+    cd "$OLDPWD"
+    git worktree remove "../$worktree_name"
+}
+
+find_remote () {
+    if ! root=$(git rev-parse --show-toplevel); then
+        echo >&2 "Fatal: not a git worktree?"
+        echo >&2 "Please run this script from a Git checkout of mbedtls."
+        exit 2
+    fi
+    cd "$root"
+
+    if [ -z "$remote" ]; then
+        remote=$(git remote -v |
+                     awk -v REMOTE_URL="$REMOTE_URL" '$2 == REMOTE_URL && $3 == "(push)" {print $1; exit}')
+        if [ -z "$remote" ]; then
+            echo >&2 "Fatal: o pushable Git remote found for $REMOTE_URL"
+            echo >&2 "Please run this script from a Git checkout of mbedtls."
+            exit 2
+        fi
+    fi
+    git fetch "$remote"
+
+    if [ "$(git cat-file -t "$ENFORCEMENT_COMMIT")" != "commit" ]; then
+        echo >&2 "Fatal: code style enforcement commit not found."
+        exit 2
+    fi
+}
+
+if [ "${1-}" = "--help" ]; then
+    help
+    exit
+fi
+while getopts c:r:u: OPTLET; do
+    case $OPTLET in
+        c) ENFORCEMENT_COMMIT=$OPTARG;;
+        r) remote=$OPTARG;;
+        u) REMOTE_URL=$OPTARG;;
+        \?) help >&2; exit 3;;
+    esac
+done
+shift $((OPTIND - 1))
+
+find_remote
+
+if [ $# -eq 0 ]; then
+    echo "$0: worktree OK. No branches specified."
+    exit
+fi
+
+for branch in "$@"; do
+    update_branch "$branch"
+done

--- a/scripts/update-code-style-preview-branches.sh
+++ b/scripts/update-code-style-preview-branches.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-ENFORCEMENT_COMMIT=7a88ce312a516cb2fe9c30cfe365ff3fa64c17b7
+ENFORCEMENT_COMMIT=6ed34c672d4f9298a90a17f149211b69ea97d190
 REMOTE_URL=git@github.com:Mbed-TLS/mbedtls.git
 
 help () {


### PR DESCRIPTION
This pull request is not intended to be merged, I'm just putting it out for visibility and to open comments.

The goal of this pull request is to share the script `scripts/update-code-style-preview-branches.sh`, which we can use to keep preview branches up to date for the [new code style](https://github.com/Mbed-TLS/mbedtls/issues/6346). We'll be doing this on an informal schedule until the [switch to the new code style](https://github.com/Mbed-TLS/mbedtls/issues/6359), which we intend to make in the first week of January 2023.

Basic usage:
```
scripts/update-code-style-preview-branches.sh development mbedtls-2.28
```

Script quality: it's worked for me once. Caveat utor. I think it should work for others but I suggest first running `sh -x scripts/update-code-style-preview-branches.sh` which will fetch the resources it needs but not do anything destructive.

The script relies on a commit which is located in [a branch on the main repository](https://github.com/Mbed-TLS/mbedtls/tree/dev/gilles-peskine-arm/coding-style-switch-to-enforcement), with the tag [`features/new-code-style/switch-to-enforcement`](https://github.com/Mbed-TLS/mbedtls/tree/features/new-code-style/switch-to-enforcement). Past versions of that commit are in https://github.com/gilles-peskine-arm/mbedtls/tree/coding-style-switch-to-enforcement-1 etc.

This makes two branches available on the main Mbed TLS repository:
* [`features/new-code-style/development`](https://github.com/Mbed-TLS/mbedtls/tree/features/new-code-style/development)
* [`features/new-code-style/mbedtls-2.28`](https://github.com/Mbed-TLS/mbedtls/tree/features/new-code-style/mbedtls-2.28)
