### PR TITLE
Backport: Fix typo in `library/entropy.c`

### DIFF
--- a/library/entropy.c
+++ b/library/entropy.c
@@ -590,7 +590,7 @@ static int mbedtls_entropy_source_self_test_check_bits( const unsigned char *buf
 }
 
 /*
- * A test to ensure hat the entropy sources are functioning correctly
+ * A test to ensure that the entropy sources are functioning correctly
  * and there is no obvious failure. The test performs the following checks:
  *  - The entropy source is not providing only 0s (all bits unset) or 1s (all
  *    bits set).


### PR DESCRIPTION
## Description

Fix typo in `library/entropy.c`. Specifically 'hat' to 'that' on line 593



## Gatekeeper checklist

- [x] **changelog** provided, or not required
- [x] **backport** done, or not required
- [x] **tests** provided, or not required



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

