### PR TITLE
Bignum: Refactor mpi_core_sub tests to use arch_split

### DIFF
--- a/scripts/mbedtls_dev/bignum_core.py
+++ b/scripts/mbedtls_dev/bignum_core.py
@@ -130,24 +130,20 @@ class BignumCoreAddAndAddIf(BignumCoreTarget, bignum_common.OperationCommon):
 class BignumCoreSub(BignumCoreTarget, bignum_common.OperationCommon):
     """Test cases for bignum core sub."""
     count = 0
+    input_style = "arch_split"
     symbol = "-"
     test_function = "mpi_core_sub"
     test_name = "mbedtls_mpi_core_sub"
 
     def result(self) -> List[str]:
         if self.int_a >= self.int_b:
-            result_4 = result_8 = self.int_a - self.int_b
+            result = self.int_a - self.int_b
             carry = 0
         else:
-            bound_val = max(self.int_a, self.int_b)
-            bound_4 = bignum_common.bound_mpi(bound_val, 32)
-            result_4 = bound_4 + self.int_a - self.int_b
-            bound_8 = bignum_common.bound_mpi(bound_val, 64)
-            result_8 = bound_8 + self.int_a - self.int_b
+            result = self.limb_boundary + self.int_a - self.int_b
             carry = 1
         return [
-            "\"{:x}\"".format(result_4),
-            "\"{:x}\"".format(result_8),
+            self.format_result(result),
             str(carry)
         ]
 

--- a/tests/suites/test_suite_bignum_core.function
+++ b/tests/suites/test_suite_bignum_core.function
@@ -533,10 +533,9 @@ exit:
 
 /* BEGIN_CASE */
 void mpi_core_sub( char * input_A, char * input_B,
-                   char * input_X4, char * input_X8,
-                   int carry )
+                   char * input_X, int carry )
 {
-    mbedtls_mpi A, B, X4, X8;
+    mbedtls_mpi A, B, X;
     mbedtls_mpi_uint *a = NULL;
     mbedtls_mpi_uint *b = NULL;
     mbedtls_mpi_uint *x = NULL; /* expected */
@@ -544,29 +543,23 @@ void mpi_core_sub( char * input_A, char * input_B,
 
     mbedtls_mpi_init( &A );
     mbedtls_mpi_init( &B );
-    mbedtls_mpi_init( &X4 );
-    mbedtls_mpi_init( &X8 );
+    mbedtls_mpi_init( &X );
 
     TEST_EQUAL( 0, mbedtls_test_read_mpi( &A, input_A ) );
     TEST_EQUAL( 0, mbedtls_test_read_mpi( &B, input_B ) );
-    TEST_EQUAL( 0, mbedtls_test_read_mpi( &X4, input_X4 ) );
-    TEST_EQUAL( 0, mbedtls_test_read_mpi( &X8, input_X8 ) );
+    TEST_EQUAL( 0, mbedtls_test_read_mpi( &X, input_X ) );
 
     /* All of the inputs are +ve (or zero) */
     TEST_EQUAL( 1, A.s );
     TEST_EQUAL( 1, B.s );
-    TEST_EQUAL( 1, X4.s );
-    TEST_EQUAL( 1, X8.s );
+    TEST_EQUAL( 1, X.s );
 
     /* Get the number of limbs we will need */
     size_t limbs = MAX( A.n, B.n );
     size_t bytes = limbs * sizeof(mbedtls_mpi_uint);
 
-    /* We only need to work with X4 or X8, depending on sizeof(mbedtls_mpi_uint) */
-    mbedtls_mpi *X = ( sizeof(mbedtls_mpi_uint) == 4 ) ? &X4 : &X8;
-
     /* The result shouldn't have more limbs than the longest input */
-    TEST_LE_U( X->n, limbs );
+    TEST_LE_U( X.n, limbs );
 
     /* Now let's get arrays of mbedtls_mpi_uints, rather than MPI structures */
 
@@ -582,7 +575,7 @@ void mpi_core_sub( char * input_A, char * input_B,
      */
     memcpy( a, A.p, A.n * sizeof(mbedtls_mpi_uint) );
     memcpy( b, B.p, B.n * sizeof(mbedtls_mpi_uint) );
-    memcpy( x, X->p, X->n * sizeof(mbedtls_mpi_uint) );
+    memcpy( x, X.p, X.n * sizeof(mbedtls_mpi_uint) );
 
     /* 1a) r = a - b => we should get the correct carry */
     TEST_EQUAL( carry, mbedtls_mpi_core_sub( r, a, b, limbs ) );
@@ -621,8 +614,7 @@ exit:
 
     mbedtls_mpi_free( &A );
     mbedtls_mpi_free( &B );
-    mbedtls_mpi_free( &X4 );
-    mbedtls_mpi_free( &X8 );
+    mbedtls_mpi_free( &X );
 }
 /* END_CASE */
 


### PR DESCRIPTION
## Description

Tests are refactored to generate separate cases for 32-bit and 64-bit limbs using `arch_split`. Duplicate arguments and branching in the test function is removed.

Resolves #6725.

## Gatekeeper checklist

- [x] **changelog** not required
- [x] **backport** not required
- [x] **tests** provided

