### PR TITLE
TLS 1.3: Key Generation: Change tls13_early_secrets to local variable

### DIFF
--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -986,7 +986,6 @@ struct mbedtls_ssl_handshake_params {
 
     mbedtls_ssl_tls13_handshake_secrets tls13_hs_secrets;
 #if defined(MBEDTLS_SSL_EARLY_DATA)
-    mbedtls_ssl_tls13_early_secrets tls13_early_secrets;
     /** TLS 1.3 transform for early data and handshake messages. */
     mbedtls_ssl_transform *transform_earlydata;
 #endif

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -1110,10 +1110,10 @@ static int ssl_tls13_generate_early_key(mbedtls_ssl_context *ssl,
     size_t transcript_len;
     size_t key_len;
     size_t iv_len;
+    mbedtls_ssl_tls13_early_secrets tls13_early_secrets;
 
     mbedtls_ssl_handshake_params *handshake = ssl->handshake;
     const mbedtls_ssl_ciphersuite_t *ciphersuite_info = handshake->ciphersuite_info;
-    mbedtls_ssl_tls13_early_secrets tls13_early_secrets;
 
     MBEDTLS_SSL_DEBUG_MSG(2, ("=> ssl_tls13_generate_early_key"));
 
@@ -1178,6 +1178,10 @@ static int ssl_tls13_generate_early_key(mbedtls_ssl_context *ssl,
     traffic_keys->key_len = key_len;
     traffic_keys->iv_len = iv_len;
 
+    /* Erase early secrets */
+    mbedtls_platform_zeroize(
+        &tls13_early_secrets, sizeof(mbedtls_ssl_tls13_early_secrets));
+
     MBEDTLS_SSL_DEBUG_BUF(4, "client early write_key",
                           traffic_keys->client_write_key,
                           traffic_keys->key_len);
@@ -1189,7 +1193,7 @@ static int ssl_tls13_generate_early_key(mbedtls_ssl_context *ssl,
     MBEDTLS_SSL_DEBUG_MSG(2, ("<= ssl_tls13_generate_early_key"));
 
 cleanup:
-    /* Erase secret and transcript */
+    /* Erase early secrets and transcript */
     mbedtls_platform_zeroize(
         &tls13_early_secrets, sizeof(mbedtls_ssl_tls13_early_secrets));
     mbedtls_platform_zeroize(transcript, sizeof(transcript));

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -1178,10 +1178,6 @@ static int ssl_tls13_generate_early_key(mbedtls_ssl_context *ssl,
     traffic_keys->key_len = key_len;
     traffic_keys->iv_len = iv_len;
 
-    /* Erase early secrets */
-    mbedtls_platform_zeroize(
-        &tls13_early_secrets, sizeof(mbedtls_ssl_tls13_early_secrets));
-
     MBEDTLS_SSL_DEBUG_BUF(4, "client early write_key",
                           traffic_keys->client_write_key,
                           traffic_keys->key_len);

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -1113,7 +1113,7 @@ static int ssl_tls13_generate_early_key(mbedtls_ssl_context *ssl,
 
     mbedtls_ssl_handshake_params *handshake = ssl->handshake;
     const mbedtls_ssl_ciphersuite_t *ciphersuite_info = handshake->ciphersuite_info;
-    mbedtls_ssl_tls13_early_secrets *tls13_early_secrets = &handshake->tls13_early_secrets;
+    mbedtls_ssl_tls13_early_secrets tls13_early_secrets;
 
     MBEDTLS_SSL_DEBUG_MSG(2, ("=> ssl_tls13_generate_early_key"));
 
@@ -1141,7 +1141,7 @@ static int ssl_tls13_generate_early_key(mbedtls_ssl_context *ssl,
 
     ret = mbedtls_ssl_tls13_derive_early_secrets(
         hash_alg, handshake->tls13_master_secrets.early,
-        transcript, transcript_len, tls13_early_secrets);
+        transcript, transcript_len, &tls13_early_secrets);
     if (ret != 0) {
         MBEDTLS_SSL_DEBUG_RET(
             1, "mbedtls_ssl_tls13_derive_early_secrets", ret);
@@ -1150,7 +1150,7 @@ static int ssl_tls13_generate_early_key(mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_DEBUG_BUF(
         4, "Client early traffic secret",
-        tls13_early_secrets->client_early_traffic_secret, hash_len);
+        tls13_early_secrets.client_early_traffic_secret, hash_len);
 
     /*
      * Export client handshake traffic secret
@@ -1159,7 +1159,7 @@ static int ssl_tls13_generate_early_key(mbedtls_ssl_context *ssl,
         ssl->f_export_keys(
             ssl->p_export_keys,
             MBEDTLS_SSL_KEY_EXPORT_TLS1_3_CLIENT_EARLY_SECRET,
-            tls13_early_secrets->client_early_traffic_secret,
+            tls13_early_secrets.client_early_traffic_secret,
             hash_len,
             handshake->randbytes,
             handshake->randbytes + MBEDTLS_CLIENT_HELLO_RANDOM_LEN,
@@ -1168,7 +1168,7 @@ static int ssl_tls13_generate_early_key(mbedtls_ssl_context *ssl,
 
     ret = ssl_tls13_make_traffic_key(
         hash_alg,
-        tls13_early_secrets->client_early_traffic_secret,
+        tls13_early_secrets.client_early_traffic_secret,
         hash_len, traffic_keys->client_write_key, key_len,
         traffic_keys->client_write_iv, iv_len);
     if (ret != 0) {
@@ -1191,7 +1191,7 @@ static int ssl_tls13_generate_early_key(mbedtls_ssl_context *ssl,
 cleanup:
     /* Erase secret and transcript */
     mbedtls_platform_zeroize(
-        tls13_early_secrets, sizeof(mbedtls_ssl_tls13_early_secrets));
+        &tls13_early_secrets, sizeof(mbedtls_ssl_tls13_early_secrets));
     mbedtls_platform_zeroize(transcript, sizeof(transcript));
     return ret;
 }


### PR DESCRIPTION
## Description

Fix sub-issue for: #6675 

## Gatekeeper checklist

- [x] **changelog** not required, part of enhancing key generation in TLS 1.3.
- [x] **backport** not required
- [x] **tests** not required

## Comments

This PR only fixes one issue listed in #6675. 