### PR TITLE
TLS 1.3: EarlyData: Workaround anti replay fail from GnuTLS

### DIFF
--- a/ChangeLog.d/workaround_gnutls_anti_replay_fail.txt
+++ b/ChangeLog.d/workaround_gnutls_anti_replay_fail.txt
@@ -1,0 +1,6 @@
+Bugfix
+    * Workaround #6623. That is time unit issue. The unit of ticket age is
+      seconds in MBedTLS and milliseconds in GnuTLS. If the real age is 10ms,
+      it might be 1s(1000ms), as a result, the age of MBedTLS is greater than
+      GnuTLS server. Reduce 1 if the age is greater than 1 second to workaround
+      it.

--- a/ChangeLog.d/workaround_gnutls_anti_replay_fail.txt
+++ b/ChangeLog.d/workaround_gnutls_anti_replay_fail.txt
@@ -1,6 +1,7 @@
 Bugfix
-    * Workaround #6623. That is time unit issue. The unit of ticket age is
-      seconds in MBedTLS and milliseconds in GnuTLS. If the real age is 10ms,
-      it might be 1s(1000ms), as a result, the age of MBedTLS is greater than
-      GnuTLS server. Reduce 1 if the age is greater than 1 second to workaround
-      it.
+    * In TLS 1.3, when using a ticket for session resumption, tweak its age
+      calculation on the client side. It prevents a server with more accurate
+      ticket timestamps (typically timestamps in milliseconds) compared to the
+      Mbed TLS ticket timestamps (in seconds) to compute a ticket age smaller
+      than the age computed and transmitted by the client and thus potentially
+      reject the ticket. Fix #6623.

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -947,6 +947,16 @@ int mbedtls_ssl_tls13_write_identities_of_pre_shared_key_ext(
         uint32_t obfuscated_ticket_age =
                                 (uint32_t)( now - session->ticket_received );
 
+        /* Workaround for anti replay fail of GnuTLS server.
+         *
+         * The time unit of ticket age is milliseconds, but current unit is
+         * seconds. If the ticket was received at the end of first second and
+         * sent in next second, GnuTLS think it is replay attack.
+         *
+         */
+        if( obfuscated_ticket_age > 0 )
+            obfuscated_ticket_age -= 1;
+
         obfuscated_ticket_age *= 1000;
         obfuscated_ticket_age += session->ticket_age_add;
 

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -424,7 +424,7 @@ int main( void )
     "    reconnect=%%d        number of reconnections using session resumption\n" \
     "                        default: 0 (disabled)\n"       \
     "    reco_server_name=%%s  default: NULL\n"             \
-    "    reco_delay=%%d       default: 0 seconds\n"         \
+    "    reco_delay=%%d       default: 0 millionseconds\n"         \
     "    reco_mode=%%d        0: copy session, 1: serialize session\n" \
     "                        default: 1\n"      \
     "    reconnect_hard=%%d   default: 0 (disabled)\n"      \
@@ -3184,7 +3184,7 @@ reconnect:
 
 #if defined(MBEDTLS_TIMING_C)
         if( opt.reco_delay > 0 )
-            mbedtls_net_usleep( 1000000 * opt.reco_delay );
+            mbedtls_net_usleep( 1000 * opt.reco_delay );
 #endif
 
         mbedtls_printf( "  . Reconnecting with saved session..." );

--- a/tests/opt-testcases/tls13-misc.sh
+++ b/tests/opt-testcases/tls13-misc.sh
@@ -274,7 +274,7 @@ requires_any_configs_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL_
                              MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_ENABLED
 run_test    "TLS 1.3 m->G: EarlyData: basic check, good" \
             "$G_NEXT_SRV -d 10 --priority=NORMAL:-VERS-ALL:+VERS-TLS1.3:+CIPHER-ALL:+ECDHE-PSK:+PSK --earlydata --disable-client-cert" \
-            "$P_CLI debug_level=4 early_data=1 reco_mode=1 reconnect=1 reco_delay=2" \
+            "$P_CLI debug_level=4 early_data=1 reco_mode=1 reconnect=1 reco_delay=900" \
             1 \
             -c "Reconnecting with saved session" \
             -c "NewSessionTicket: early_data(42) extension received." \
@@ -295,7 +295,7 @@ requires_any_configs_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL_
                              MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_ENABLED
 run_test    "TLS 1.3 m->G: EarlyData: no early_data in NewSessionTicket, good" \
             "$G_NEXT_SRV -d 10 --priority=NORMAL:-VERS-ALL:+VERS-TLS1.3:+CIPHER-ALL:+ECDHE-PSK:+PSK --disable-client-cert" \
-            "$P_CLI debug_level=4 early_data=1 reco_mode=1 reconnect=1 reco_delay=2" \
+            "$P_CLI debug_level=4 early_data=1 reco_mode=1 reconnect=1" \
             0 \
             -c "Reconnecting with saved session" \
             -C "NewSessionTicket: early_data(42) extension received." \

--- a/tests/opt-testcases/tls13-misc.sh
+++ b/tests/opt-testcases/tls13-misc.sh
@@ -264,9 +264,6 @@ run_test    "TLS 1.3: G->m: PSK: configured ephemeral only, good." \
             0 \
             -s "key exchange mode: ephemeral$"
 
-# skip the basic check now cause it will randomly trigger the anti-replay protection in gnutls_server
-# Add it back once we fix the issue
-skip_next_test
 requires_gnutls_tls1_3
 requires_config_enabled MBEDTLS_DEBUG_C
 requires_config_enabled MBEDTLS_SSL_CLI_C

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -3632,7 +3632,7 @@ run_test    "Session resume using tickets: cache disabled" \
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 run_test    "Session resume using tickets: timeout" \
             "$P_SRV debug_level=3 tickets=1 cache_max=0 ticket_timeout=1" \
-            "$P_CLI debug_level=3 tickets=1 reconnect=1 reco_delay=2" \
+            "$P_CLI debug_level=3 tickets=1 reconnect=1 reco_delay=2000" \
             0 \
             -c "client hello, adding session ticket extension" \
             -s "found session ticket extension" \
@@ -3942,7 +3942,7 @@ run_test    "Session resume using tickets, DTLS: cache disabled" \
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 run_test    "Session resume using tickets, DTLS: timeout" \
             "$P_SRV debug_level=3 dtls=1 tickets=1 cache_max=0 ticket_timeout=1" \
-            "$P_CLI debug_level=3 dtls=1 tickets=1 reconnect=1 skip_close_notify=1 reco_delay=2" \
+            "$P_CLI debug_level=3 dtls=1 tickets=1 reconnect=1 skip_close_notify=1 reco_delay=2000" \
             0 \
             -c "client hello, adding session ticket extension" \
             -s "found session ticket extension" \
@@ -4066,7 +4066,7 @@ requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_CACHE_C
 run_test    "Session resume using cache: timeout < delay" \
             "$P_SRV debug_level=3 tickets=0 cache_timeout=1" \
-            "$P_CLI debug_level=3 tickets=0 reconnect=1 reco_delay=2" \
+            "$P_CLI debug_level=3 tickets=0 reconnect=1 reco_delay=2000" \
             0 \
             -S "session successfully restored from cache" \
             -S "session successfully restored from ticket" \
@@ -4077,7 +4077,7 @@ requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_CACHE_C
 run_test    "Session resume using cache: no timeout" \
             "$P_SRV debug_level=3 tickets=0 cache_timeout=0" \
-            "$P_CLI debug_level=3 tickets=0 reconnect=1 reco_delay=2" \
+            "$P_CLI debug_level=3 tickets=0 reconnect=1 reco_delay=2000" \
             0 \
             -s "session successfully restored from cache" \
             -S "session successfully restored from ticket" \
@@ -4213,7 +4213,7 @@ requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_CACHE_C
 run_test    "Session resume using cache, DTLS: timeout < delay" \
             "$P_SRV dtls=1 debug_level=3 tickets=0 cache_timeout=1" \
-            "$P_CLI dtls=1 debug_level=3 tickets=0 reconnect=1 skip_close_notify=1 reco_delay=2" \
+            "$P_CLI dtls=1 debug_level=3 tickets=0 reconnect=1 skip_close_notify=1 reco_delay=2000" \
             0 \
             -S "session successfully restored from cache" \
             -S "session successfully restored from ticket" \
@@ -4224,7 +4224,7 @@ requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_CACHE_C
 run_test    "Session resume using cache, DTLS: no timeout" \
             "$P_SRV dtls=1 debug_level=3 tickets=0 cache_timeout=0" \
-            "$P_CLI dtls=1 debug_level=3 tickets=0 reconnect=1 skip_close_notify=1 reco_delay=2" \
+            "$P_CLI dtls=1 debug_level=3 tickets=0 reconnect=1 skip_close_notify=1 reco_delay=2000" \
             0 \
             -s "session successfully restored from cache" \
             -S "session successfully restored from ticket" \
@@ -9880,7 +9880,7 @@ run_test    "DTLS fragmenting: proxy MTU, resumed handshake" \
              key_file=data_files/server8.key \
              hs_timeout=10000-60000 \
              force_ciphersuite=TLS-ECDHE-ECDSA-WITH-AES-128-GCM-SHA256 \
-             mtu=1450 reconnect=1 skip_close_notify=1 reco_delay=1" \
+             mtu=1450 reconnect=1 skip_close_notify=1 reco_delay=1000" \
             0 \
             -S "autoreduction" \
             -s "found fragmented DTLS handshake message" \


### PR DESCRIPTION
## Description

fix #6623 

anti_replay_check of GnuTLS check the ticket ages of client and server.
The restriction is in https://gitlab.com/gnutls/gnutls/-/blob/master/lib/tls13/anti_replay.c#L150

### Root cause

**TIME RESOLUTION OF TICKET AGE**

The time precision of ticket_age is milliseconds(RFC 8446). But our precision is senconds, we caculate
ticket age with (mbedtls_time( NULL ) - ticket_recived)*1000 .
If the ticket is sent/received near the end of a second and client send ticket at the beggining of
next second, ticket age of client is 1000 ms, but ticket age of server is less than it. As a result,
it offends the anit replay ruler.

Workaround solution: Add 1 second to ticket_received and do reconnect 1 second later.

The issue can be reproduce and verified with #6712 . That PR include test script and test result.

## Gatekeeper checklist

- [ ] **changelog** provided, or not required
- [ ] **backport** done, or not required
- [ ] **tests** provided, or not required



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

