### PR TITLE
TLS 1.3: Fix anti replay fail from GnuTLS

### DIFF
--- a/ChangeLog.d/gnutls_anti_replay_fail.txt
+++ b/ChangeLog.d/gnutls_anti_replay_fail.txt
@@ -1,0 +1,4 @@
+Bugfix
+    * Fixes #6623. That is time unit issue. The unit of ticket age is seconds in
+      MBedTLS and milliseconds in GnuTLS. If the real age is 10ms, it might be
+      1s(1000ms), as a result, the age of MBedTLS is bigger than GnuTLS server.

--- a/ChangeLog.d/gnutls_anti_replay_fail.txt
+++ b/ChangeLog.d/gnutls_anti_replay_fail.txt
@@ -1,4 +1,5 @@
 Bugfix
-    * Fixes #6623. That is time unit issue. The unit of ticket age is seconds in
-      MBedTLS and milliseconds in GnuTLS. If the real age is 10ms, it might be
-      1s(1000ms), as a result, the age of MBedTLS is bigger than GnuTLS server.
+    * Switch to milliseconds as the unit for ticket creation and reception time
+      instead of seconds. That avoids rounding errors when computing the age of
+      tickets compared to peer using a millisecond clock (observed with GnuTLS).
+      Fixes #6623.

--- a/include/mbedtls/debug.h
+++ b/include/mbedtls/debug.h
@@ -120,7 +120,12 @@
     /* (defined(__MINGW32__)  && __USE_MINGW_ANSI_STDIO == 0) || (defined(_MSC_VER) && _MSC_VER < 1800) */
 
 #if !defined(MBEDTLS_PRINTF_MS_TIME)
+#include <inttypes.h>
+#if !defined(PRId64)
+#define MBEDTLS_PRINTF_MS_TIME MBEDTLS_PRINTF_LONGLONG
+#else
 #define MBEDTLS_PRINTF_MS_TIME PRId64
+#endif
 #endif /* MBEDTLS_PRINTF_MS_TIME */
 
 #ifdef __cplusplus

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -4115,6 +4115,7 @@
  * 6s, thus in the worst case clients and servers must sync up their system time
  * every 6000/360/2~=8 hours.
  *
+ * See section 8.3 of the TLS 1.3 specification(RFC 8446) for more information.
  */
 //#define MBEDTLS_SSL_TLS1_3_TICKET_AGE_TOLERANCE 6000
 

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -4099,19 +4099,21 @@
 /**
  * \def MBEDTLS_SSL_TLS1_3_TICKET_AGE_TOLERANCE
  *
- * Maximum time difference in milliseconds tolerated between the age of a
- * ticket from the server and client point of view.
- * From the client point of view, the age of a ticket is the time difference
- * between the time when the client proposes to the server to use the ticket
- * (time of writing of the Pre-Shared Key Extension including the ticket) and
- * the time the client received the ticket from the server.
- * From the server point of view, the age of a ticket is the time difference
- * between the time when the server receives a proposition from the client
- * to use the ticket and the time when the ticket was created by the server.
- * The server age is expected to be always greater than the client one and
- * MBEDTLS_SSL_TLS1_3_TICKET_AGE_TOLERANCE defines the
- * maximum difference tolerated for the server to accept the ticket.
- * This is not used in TLS 1.2.
+ * Maximum allowd ticket age difference in milliseconds tolerated between
+ * server and client. Default value is 6000. This is not used in TLS 1.2.
+ *
+ * - The client ticket age is the time difference between the time when the
+ *   client proposes to the server to use the ticket and the time the client
+ *   received the ticket from the server.
+ * - The server ticket age is the time difference between the time when the
+ *   server receives a proposition from the client to use the ticket and the
+ *   time when the ticket was created by the server.
+ *
+ * The ages might be different due to accuracy of RTC crypstal. The typical
+ * accuracy of an RTC crystal is ±100 to ±20 parts per million (360 to 72
+ * milliseconds per hour). Default tolerance windows is 6s, thus in the worst
+ * case client and servers must sync up their system time every 6000/360/2~=8
+ * hours.
  *
  */
 //#define MBEDTLS_SSL_TLS1_3_TICKET_AGE_TOLERANCE 6000

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -4099,7 +4099,7 @@
 /**
  * \def MBEDTLS_SSL_TLS1_3_TICKET_AGE_TOLERANCE
  *
- * Maximum allowd ticket age difference in milliseconds tolerated between
+ * Maximum allowed ticket age difference in milliseconds tolerated between
  * server and client. Default value is 6000. This is not used in TLS 1.2.
  *
  * - The client ticket age is the time difference between the time when the
@@ -4109,11 +4109,11 @@
  *   server receives a proposition from the client to use the ticket and the
  *   time when the ticket was created by the server.
  *
- * The ages might be different due to accuracy of RTC crypstal. The typical
- * accuracy of an RTC crystal is ±100 to ±20 parts per million (360 to 72
- * milliseconds per hour). Default tolerance windows is 6s, thus in the worst
- * case client and servers must sync up their system time every 6000/360/2~=8
- * hours.
+ * The ages might be different due to the client and server clocks not running
+ * at the same pace. The typical accuracy of an RTC crystal is ±100 to ±20 parts
+ * per million (360 to 72 milliseconds per hour). Default tolerance window is
+ * 6s, thus in the worst case clients and servers must sync up their system time
+ * every 6000/360/2~=8 hours.
  *
  */
 //#define MBEDTLS_SSL_TLS1_3_TICKET_AGE_TOLERANCE 6000

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1256,7 +1256,7 @@ struct mbedtls_ssl_session {
 
 #if defined(MBEDTLS_HAVE_TIME)
 #if defined(MBEDTLS_SSL_CLI_C)
-    mbedtls_ms_time_t MBEDTLS_PRIVATE(ticket_received);        /*!< time that ticket was received */
+    mbedtls_ms_time_t MBEDTLS_PRIVATE(ticket_reception_time);        /*!< time that ticket was received */
 #endif
 #if defined(MBEDTLS_SSL_SRV_C)
     mbedtls_ms_time_t MBEDTLS_PRIVATE(ticket_creation_time);     /*!< create time of ticket */

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1248,18 +1248,20 @@ struct mbedtls_ssl_session {
     uint8_t MBEDTLS_PRIVATE(ticket_flags);      /*!< Ticket flags */
     uint32_t MBEDTLS_PRIVATE(ticket_age_add);               /*!< Randomly generated value used to obscure the age of the ticket */
     uint8_t MBEDTLS_PRIVATE(resumption_key_len);            /*!< resumption_key length */
-#if defined(MBEDTLS_HAVE_TIME)
-    mbedtls_ms_time_t MBEDTLS_PRIVATE(ticket_creation);     /*!< create time of ticket */
-#endif
     unsigned char MBEDTLS_PRIVATE(resumption_key)[MBEDTLS_SSL_TLS1_3_TICKET_RESUMPTION_KEY_LEN];
 
 #if defined(MBEDTLS_SSL_SERVER_NAME_INDICATION) && defined(MBEDTLS_SSL_CLI_C)
     char *MBEDTLS_PRIVATE(hostname);             /*!< host name binded with tickets */
 #endif /* MBEDTLS_SSL_SERVER_NAME_INDICATION && MBEDTLS_SSL_CLI_C */
 
-#if defined(MBEDTLS_HAVE_TIME) && defined(MBEDTLS_SSL_CLI_C)
-    mbedtls_ms_time_t MBEDTLS_PRIVATE(ticket_received);        /*!< time ticket was received */
-#endif /* MBEDTLS_HAVE_TIME && MBEDTLS_SSL_CLI_C */
+#if defined(MBEDTLS_HAVE_TIME)
+#if defined(MBEDTLS_SSL_CLI_C)
+    mbedtls_ms_time_t MBEDTLS_PRIVATE(ticket_received);        /*!< time that ticket was received */
+#endif
+#if defined(MBEDTLS_SSL_SRV_C)
+    mbedtls_ms_time_t MBEDTLS_PRIVATE(ticket_creation_time);     /*!< create time of ticket */
+#endif
+#endif /* MBEDTLS_HAVE_TIME */
 
 #endif /*  MBEDTLS_SSL_PROTO_TLS1_3 && MBEDTLS_SSL_SESSION_TICKETS */
 

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1248,7 +1248,9 @@ struct mbedtls_ssl_session {
     uint8_t MBEDTLS_PRIVATE(ticket_flags);      /*!< Ticket flags */
     uint32_t MBEDTLS_PRIVATE(ticket_age_add);               /*!< Randomly generated value used to obscure the age of the ticket */
     uint8_t MBEDTLS_PRIVATE(resumption_key_len);            /*!< resumption_key length */
+#if defined(MBEDTLS_HAVE_TIME)
     mbedtls_ms_time_t MBEDTLS_PRIVATE(ticket_creation);     /*!< create time of ticket */
+#endif
     unsigned char MBEDTLS_PRIVATE(resumption_key)[MBEDTLS_SSL_TLS1_3_TICKET_RESUMPTION_KEY_LEN];
 
 #if defined(MBEDTLS_SSL_SERVER_NAME_INDICATION) && defined(MBEDTLS_SSL_CLI_C)

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1217,7 +1217,7 @@ struct mbedtls_ssl_session {
     mbedtls_ssl_protocol_version MBEDTLS_PRIVATE(tls_version);
 
 #if defined(MBEDTLS_HAVE_TIME)
-    mbedtls_time_t MBEDTLS_PRIVATE(start);       /*!< starting time      */
+    mbedtls_ms_time_t MBEDTLS_PRIVATE(start);    /*!< starting time      */
 #endif
     int MBEDTLS_PRIVATE(ciphersuite);            /*!< chosen ciphersuite */
     size_t MBEDTLS_PRIVATE(id_len);              /*!< session id length  */
@@ -1255,7 +1255,7 @@ struct mbedtls_ssl_session {
 #endif /* MBEDTLS_SSL_SERVER_NAME_INDICATION && MBEDTLS_SSL_CLI_C */
 
 #if defined(MBEDTLS_HAVE_TIME) && defined(MBEDTLS_SSL_CLI_C)
-    mbedtls_time_t MBEDTLS_PRIVATE(ticket_received);        /*!< time ticket was received */
+    mbedtls_ms_time_t MBEDTLS_PRIVATE(ticket_received);        /*!< time ticket was received */
 #endif /* MBEDTLS_HAVE_TIME && MBEDTLS_SSL_CLI_C */
 
 #endif /*  MBEDTLS_SSL_PROTO_TLS1_3 && MBEDTLS_SSL_SESSION_TICKETS */

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1256,10 +1256,10 @@ struct mbedtls_ssl_session {
 
 #if defined(MBEDTLS_HAVE_TIME)
 #if defined(MBEDTLS_SSL_CLI_C)
-    mbedtls_ms_time_t MBEDTLS_PRIVATE(ticket_reception_time);        /*!< time that ticket was received */
+    mbedtls_ms_time_t MBEDTLS_PRIVATE(ticket_reception_time);   /*!< time when ticket was received. */
 #endif
 #if defined(MBEDTLS_SSL_SRV_C)
-    mbedtls_ms_time_t MBEDTLS_PRIVATE(ticket_creation_time);     /*!< create time of ticket */
+    mbedtls_ms_time_t MBEDTLS_PRIVATE(ticket_creation_time);    /*!< time when ticket was created. */
 #endif
 #endif /* MBEDTLS_HAVE_TIME */
 

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1217,7 +1217,7 @@ struct mbedtls_ssl_session {
     mbedtls_ssl_protocol_version MBEDTLS_PRIVATE(tls_version);
 
 #if defined(MBEDTLS_HAVE_TIME)
-    mbedtls_ms_time_t MBEDTLS_PRIVATE(start);    /*!< starting time      */
+    mbedtls_time_t MBEDTLS_PRIVATE(start);       /*!< start time of current session */
 #endif
     int MBEDTLS_PRIVATE(ciphersuite);            /*!< chosen ciphersuite */
     size_t MBEDTLS_PRIVATE(id_len);              /*!< session id length  */
@@ -1248,6 +1248,7 @@ struct mbedtls_ssl_session {
     uint8_t MBEDTLS_PRIVATE(ticket_flags);      /*!< Ticket flags */
     uint32_t MBEDTLS_PRIVATE(ticket_age_add);               /*!< Randomly generated value used to obscure the age of the ticket */
     uint8_t MBEDTLS_PRIVATE(resumption_key_len);            /*!< resumption_key length */
+    mbedtls_ms_time_t MBEDTLS_PRIVATE(ticket_creation);     /*!< create time of ticket */
     unsigned char MBEDTLS_PRIVATE(resumption_key)[MBEDTLS_SSL_TLS1_3_TICKET_RESUMPTION_KEY_LEN];
 
 #if defined(MBEDTLS_SSL_SERVER_NAME_INDICATION) && defined(MBEDTLS_SSL_CLI_C)

--- a/library/ssl_client.c
+++ b/library/ssl_client.c
@@ -756,10 +756,9 @@ static int ssl_prepare_client_hello(mbedtls_ssl_context *ssl)
     if (ssl->handshake->resume != 0 &&
         session_negotiate->tls_version == MBEDTLS_SSL_VERSION_TLS1_3 &&
         session_negotiate->ticket != NULL) {
-        mbedtls_time_t now = mbedtls_time(NULL);
-        uint64_t age = (uint64_t) (now - session_negotiate->ticket_received);
-        if (session_negotiate->ticket_received > now ||
-            age > session_negotiate->ticket_lifetime) {
+        mbedtls_ms_time_t now = mbedtls_ms_time();
+        mbedtls_ms_time_t age = now - session_negotiate->ticket_received;
+        if (age < 0 || age > session_negotiate->ticket_lifetime * 1000) {
             /* Without valid ticket, disable session resumption.*/
             MBEDTLS_SSL_DEBUG_MSG(
                 3, ("Ticket expired, disable session resumption"));

--- a/library/ssl_client.c
+++ b/library/ssl_client.c
@@ -757,7 +757,7 @@ static int ssl_prepare_client_hello(mbedtls_ssl_context *ssl)
         session_negotiate->tls_version == MBEDTLS_SSL_VERSION_TLS1_3 &&
         session_negotiate->ticket != NULL) {
         mbedtls_ms_time_t now = mbedtls_ms_time();
-        mbedtls_ms_time_t age = now - session_negotiate->ticket_received;
+        mbedtls_ms_time_t age = now - session_negotiate->ticket_reception_time;
         if (age < 0 || age > session_negotiate->ticket_lifetime * 1000) {
             /* Without valid ticket, disable session resumption.*/
             MBEDTLS_SSL_DEBUG_MSG(

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -2765,6 +2765,9 @@ int mbedtls_ssl_session_set_hostname(mbedtls_ssl_session *session,
 #endif
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3) && defined(MBEDTLS_SSL_SESSION_TICKETS)
+
+#define MBEDTLS_SSL_TLS1_3_MAX_ALLOWED_TICKET_LIFETIME (604800)
+
 static inline unsigned int mbedtls_ssl_session_get_ticket_flags(
     mbedtls_ssl_session *session, unsigned int flags)
 {

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -2766,6 +2766,8 @@ int mbedtls_ssl_session_set_hostname(mbedtls_ssl_session *session,
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3) && defined(MBEDTLS_SSL_SESSION_TICKETS)
 
+#define MBEDTLS_SSL_TLS1_3_MAX_ALLOWED_TICKET_LIFETIME (604800)
+
 static inline unsigned int mbedtls_ssl_session_get_ticket_flags(
     mbedtls_ssl_session *session, unsigned int flags)
 {

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -2766,8 +2766,6 @@ int mbedtls_ssl_session_set_hostname(mbedtls_ssl_session *session,
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3) && defined(MBEDTLS_SSL_SESSION_TICKETS)
 
-#define MBEDTLS_SSL_TLS1_3_MAX_ALLOWED_TICKET_LIFETIME (604800)
-
 static inline unsigned int mbedtls_ssl_session_get_ticket_flags(
     mbedtls_ssl_session *session, unsigned int flags)
 {

--- a/library/ssl_ticket.c
+++ b/library/ssl_ticket.c
@@ -498,16 +498,17 @@ int mbedtls_ssl_ticket_parse(void *p_ticket,
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
     if (session->tls_version == MBEDTLS_SSL_VERSION_TLS1_3) {
         /* Check for expiration */
-        mbedtls_ms_time_t ticket_age = mbedtls_ms_time() - session->start;
+        mbedtls_ms_time_t ticket_age = mbedtls_ms_time() - session->ticket_creation;
         mbedtls_ms_time_t ticket_lifetime = ctx->ticket_lifetime * 1000;
 
         if (ticket_age < 0 || ticket_age > ticket_lifetime) {
             ret = MBEDTLS_ERR_SSL_SESSION_TICKET_EXPIRED;
             goto cleanup;
         }
-    } else
+    }
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3 */
-    {
+#if defined(MBEDTLS_SSL_PROTO_TLS1_2)
+    if (session->tls_version == MBEDTLS_SSL_VERSION_TLS1_2) {
         /* Check for expiration */
         mbedtls_time_t current_time = mbedtls_time(NULL);
 
@@ -517,6 +518,7 @@ int mbedtls_ssl_ticket_parse(void *p_ticket,
             goto cleanup;
         }
     }
+#endif
 #endif /* MBEDTLS_HAVE_TIME */
 
 cleanup:

--- a/library/ssl_ticket.c
+++ b/library/ssl_ticket.c
@@ -498,7 +498,7 @@ int mbedtls_ssl_ticket_parse(void *p_ticket,
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
     if (session->tls_version == MBEDTLS_SSL_VERSION_TLS1_3) {
         /* Check for expiration */
-        mbedtls_ms_time_t ticket_age = mbedtls_ms_time() - session->ticket_creation;
+        mbedtls_ms_time_t ticket_age = mbedtls_ms_time() - session->ticket_creation_time;
         mbedtls_ms_time_t ticket_lifetime = ctx->ticket_lifetime * 1000;
 
         if (ticket_age < 0 || ticket_age > ticket_lifetime) {

--- a/library/ssl_ticket.c
+++ b/library/ssl_ticket.c
@@ -495,6 +495,18 @@ int mbedtls_ssl_ticket_parse(void *p_ticket,
     }
 
 #if defined(MBEDTLS_HAVE_TIME)
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3)
+    if (session->tls_version == MBEDTLS_SSL_VERSION_TLS1_3) {
+        /* Check for expiration */
+        mbedtls_ms_time_t ticket_age = mbedtls_ms_time() - session->start;
+        mbedtls_ms_time_t ticket_lifetime = ctx->ticket_lifetime * 1000;
+
+        if (ticket_age < 0 || ticket_age > ticket_lifetime) {
+            ret = MBEDTLS_ERR_SSL_SESSION_TICKET_EXPIRED;
+            goto cleanup;
+        }
+    } else
+#endif /* MBEDTLS_SSL_PROTO_TLS1_3 */
     {
         /* Check for expiration */
         mbedtls_time_t current_time = mbedtls_time(NULL);
@@ -505,7 +517,7 @@ int mbedtls_ssl_ticket_parse(void *p_ticket,
             goto cleanup;
         }
     }
-#endif
+#endif /* MBEDTLS_HAVE_TIME */
 
 cleanup:
 #if defined(MBEDTLS_THREADING_C)

--- a/library/ssl_ticket.c
+++ b/library/ssl_ticket.c
@@ -498,7 +498,18 @@ int mbedtls_ssl_ticket_parse(void *p_ticket,
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
     if (session->tls_version == MBEDTLS_SSL_VERSION_TLS1_3) {
         /* Check for expiration */
-        mbedtls_ms_time_t ticket_age = mbedtls_ms_time() - session->ticket_creation_time;
+        mbedtls_ms_time_t ticket_age = -1;
+#if defined(MBEDTLS_SSL_SRV_C)
+        if (session->endpoint == MBEDTLS_SSL_IS_SERVER) {
+            ticket_age = mbedtls_ms_time() - session->ticket_creation_time;
+        }
+#endif
+#if defined(MBEDTLS_SSL_CLI_C)
+        if (session->endpoint == MBEDTLS_SSL_IS_CLIENT) {
+            ticket_age = mbedtls_ms_time() - session->ticket_reception_time;
+        }
+#endif
+
         mbedtls_ms_time_t ticket_lifetime = ctx->ticket_lifetime * 1000;
 
         if (ticket_age < 0 || ticket_age > ticket_lifetime) {

--- a/library/ssl_ticket.c
+++ b/library/ssl_ticket.c
@@ -518,7 +518,7 @@ int mbedtls_ssl_ticket_parse(void *p_ticket,
             goto cleanup;
         }
     }
-#endif
+#endif /* MBEDTLS_SSL_PROTO_TLS1_2 */
 #endif /* MBEDTLS_HAVE_TIME */
 
 cleanup:

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -2457,7 +2457,7 @@ mbedtls_ssl_mode_t mbedtls_ssl_get_mode_from_ciphersuite(
  *       uint32 max_early_data_size;
  *       select ( endpoint ) {
  *            case client: ClientOnlyData;
- *            case server: uint64 ticket_creation_time_time;
+ *            case server: uint64 ticket_creation_time;
  *        };
  *     } serialized_session_tls13;
  *
@@ -2492,7 +2492,7 @@ static int ssl_tls13_session_save(const mbedtls_ssl_session *session,
 #endif
 
 #if defined(MBEDTLS_HAVE_TIME)
-    needed += 8; /* start_time or ticket_reception_time */
+    needed += 8; /* ticket_creation_time or ticket_reception_time */
 #endif
 
 #if defined(MBEDTLS_SSL_CLI_C)

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -2537,7 +2537,7 @@ static int ssl_tls13_session_save(const mbedtls_ssl_session *session,
 
 #if defined(MBEDTLS_HAVE_TIME) && defined(MBEDTLS_SSL_SRV_C)
     if (session->endpoint == MBEDTLS_SSL_IS_SERVER) {
-        MBEDTLS_PUT_UINT64_BE((uint64_t) session->start, p, 0);
+        MBEDTLS_PUT_UINT64_BE((uint64_t) session->ticket_creation, p, 0);
         p += 8;
     }
 #endif /* MBEDTLS_HAVE_TIME */
@@ -2616,7 +2616,7 @@ static int ssl_tls13_session_load(mbedtls_ssl_session *session,
         if (end - p < 8) {
             return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
         }
-        session->start = MBEDTLS_GET_UINT64_BE(p, 0);
+        session->ticket_creation = MBEDTLS_GET_UINT64_BE(p, 0);
         p += 8;
     }
 #endif /* MBEDTLS_HAVE_TIME */

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -2443,7 +2443,7 @@ mbedtls_ssl_mode_t mbedtls_ssl_get_mode_from_ciphersuite(
  *
  *     struct {
  *       opaque hostname<0..2^16-1>;
- *       uint64 ticket_received;
+ *       uint64 ticket_reception_time;
  *       uint32 ticket_lifetime;
  *       opaque ticket<1..2^16-1>;
  *     } ClientOnlyData;
@@ -2492,7 +2492,7 @@ static int ssl_tls13_session_save(const mbedtls_ssl_session *session,
 #endif
 
 #if defined(MBEDTLS_HAVE_TIME)
-    needed += 8; /* start_time or ticket_received */
+    needed += 8; /* start_time or ticket_reception_time */
 #endif
 
 #if defined(MBEDTLS_SSL_CLI_C)
@@ -2555,7 +2555,7 @@ static int ssl_tls13_session_save(const mbedtls_ssl_session *session,
 #endif /* MBEDTLS_SSL_SERVER_NAME_INDICATION */
 
 #if defined(MBEDTLS_HAVE_TIME)
-        MBEDTLS_PUT_UINT64_BE((uint64_t) session->ticket_received, p, 0);
+        MBEDTLS_PUT_UINT64_BE((uint64_t) session->ticket_reception_time, p, 0);
         p += 8;
 #endif
         MBEDTLS_PUT_UINT32_BE(session->ticket_lifetime, p, 0);
@@ -2651,7 +2651,7 @@ static int ssl_tls13_session_load(mbedtls_ssl_session *session,
         if (end - p < 8) {
             return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
         }
-        session->ticket_received = MBEDTLS_GET_UINT64_BE(p, 0);
+        session->ticket_reception_time = MBEDTLS_GET_UINT64_BE(p, 0);
         p += 8;
 #endif
         if (end - p < 4) {

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -2457,7 +2457,7 @@ mbedtls_ssl_mode_t mbedtls_ssl_get_mode_from_ciphersuite(
  *       uint32 max_early_data_size;
  *       select ( endpoint ) {
  *            case client: ClientOnlyData;
- *            case server: uint64 start_time;
+ *            case server: uint64 ticket_creation_time_time;
  *        };
  *     } serialized_session_tls13;
  *
@@ -2537,7 +2537,7 @@ static int ssl_tls13_session_save(const mbedtls_ssl_session *session,
 
 #if defined(MBEDTLS_HAVE_TIME) && defined(MBEDTLS_SSL_SRV_C)
     if (session->endpoint == MBEDTLS_SSL_IS_SERVER) {
-        MBEDTLS_PUT_UINT64_BE((uint64_t) session->ticket_creation, p, 0);
+        MBEDTLS_PUT_UINT64_BE((uint64_t) session->ticket_creation_time, p, 0);
         p += 8;
     }
 #endif /* MBEDTLS_HAVE_TIME */
@@ -2616,7 +2616,7 @@ static int ssl_tls13_session_load(mbedtls_ssl_session *session,
         if (end - p < 8) {
             return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
         }
-        session->ticket_creation = MBEDTLS_GET_UINT64_BE(p, 0);
+        session->ticket_creation_time = MBEDTLS_GET_UINT64_BE(p, 0);
         p += 8;
     }
 #endif /* MBEDTLS_HAVE_TIME */

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -938,7 +938,7 @@ int mbedtls_ssl_tls13_write_identities_of_pre_shared_key_ext(
          * 7 days (enforced in ssl_tls13_parse_new_session_ticket()) . Thus the
          * cast to `uint32_t` of the ticket age is safe. */
         uint32_t obfuscated_ticket_age =
-            (uint32_t) (now - session->ticket_received);
+            (uint32_t) (now - session->ticket_reception_time);
         obfuscated_ticket_age += session->ticket_age_add;
 
         ret = ssl_tls13_write_identity(ssl, p, end,
@@ -2829,7 +2829,7 @@ static int ssl_tls13_postprocess_new_session_ticket(mbedtls_ssl_context *ssl,
 
 #if defined(MBEDTLS_HAVE_TIME)
     /* Store ticket creation time */
-    session->ticket_received = mbedtls_ms_time();
+    session->ticket_reception_time = mbedtls_ms_time();
 #endif
 
     ciphersuite_info = mbedtls_ssl_ciphersuite_from_id(session->ciphersuite);

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -2748,7 +2748,8 @@ static int ssl_tls13_parse_new_session_ticket(mbedtls_ssl_context *ssl,
     MBEDTLS_SSL_DEBUG_MSG(3,
                           ("ticket_lifetime: %u",
                            (unsigned int) session->ticket_lifetime));
-    if (session->ticket_lifetime > 604800) {
+    if (session->ticket_lifetime >
+        MBEDTLS_SSL_TLS1_3_MAX_ALLOWED_TICKET_LIFETIME) {
         MBEDTLS_SSL_DEBUG_MSG(3, ("ticket_lifetime exceeds 7 days."));
         return MBEDTLS_ERR_SSL_ILLEGAL_PARAMETER;
     }

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -933,7 +933,7 @@ int mbedtls_ssl_tls13_write_identities_of_pre_shared_key_ext(
 #if defined(MBEDTLS_HAVE_TIME)
         mbedtls_ms_time_t now = mbedtls_ms_time();
         mbedtls_ssl_session *session = ssl->session_negotiate;
-        /* The ticket age has been checked to be smaller that the
+        /* The ticket age has been checked to be smaller than the
          * `ticket_lifetime` in ssl_prepare_client_hello() which is smaller than
          * 7 days (enforced in ssl_tls13_parse_new_session_ticket()) . Thus the
          * cast to `uint32_t` of the ticket age is safe. */
@@ -2748,11 +2748,9 @@ static int ssl_tls13_parse_new_session_ticket(mbedtls_ssl_context *ssl,
     MBEDTLS_SSL_DEBUG_MSG(3,
                           ("ticket_lifetime: %u",
                            (unsigned int) session->ticket_lifetime));
-    if (session->ticket_lifetime >
-        MBEDTLS_SSL_TLS1_3_MAX_ALLOWED_TICKET_LIFETIME) {
-        /* TODO: Add new return value here? */
+    if (session->ticket_lifetime > 604800) {
         MBEDTLS_SSL_DEBUG_MSG(3, ("ticket_lifetime exceeds 7 days."));
-        return MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
+        return MBEDTLS_ERR_SSL_ILLEGAL_PARAMETER;
     }
 
     session->ticket_age_add = MBEDTLS_GET_UINT32_BE(p, 4);

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -193,15 +193,15 @@ static int ssl_tls13_offered_psks_check_identity_match_ticket(
 #if defined(MBEDTLS_HAVE_TIME)
     now = mbedtls_ms_time();
 
-    if (now < session->ticket_creation) {
+    if (now < session->ticket_creation_time) {
         MBEDTLS_SSL_DEBUG_MSG(
             3, ("Invalid ticket start time ( now = %" MBEDTLS_PRINTF_MS_TIME
                 ", start = %" MBEDTLS_PRINTF_MS_TIME " )",
-                now, session->ticket_creation));
+                now, session->ticket_creation_time));
         goto exit;
     }
 
-    server_age = now - session->ticket_creation;
+    server_age = now - session->ticket_creation_time;
 
     /* RFC 8446 section 4.6.1
      *
@@ -2878,7 +2878,7 @@ static int ssl_tls13_prepare_new_session_ticket(mbedtls_ssl_context *ssl,
     MBEDTLS_SSL_DEBUG_MSG(2, ("=> prepare NewSessionTicket msg"));
 
 #if defined(MBEDTLS_HAVE_TIME)
-    session->ticket_creation = mbedtls_ms_time();
+    session->ticket_creation_time = mbedtls_ms_time();
 #endif
 
     /* Set ticket_flags depends on the advertised psk key exchange mode */

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -195,8 +195,9 @@ static int ssl_tls13_offered_psks_check_identity_match_ticket(
 
     if (now < session->start) {
         MBEDTLS_SSL_DEBUG_MSG(
-            3, ("Invalid ticket start time ( now=%" MBEDTLS_PRINTF_MS_TIME
-                ", start=%" MBEDTLS_PRINTF_MS_TIME " )", now, session->start));
+            3, ("Invalid ticket start time ( now = %" MBEDTLS_PRINTF_MS_TIME
+                ", start = %" MBEDTLS_PRINTF_MS_TIME " )",
+                now, session->start));
         goto exit;
     }
 
@@ -213,7 +214,7 @@ static int ssl_tls13_offered_psks_check_identity_match_ticket(
      *
      * For time being, the age MUST be less than 604800 seconds (7 days).
      */
-    if (server_age > 604800*1000) {
+    if (server_age > 604800 * 1000) {
         MBEDTLS_SSL_DEBUG_MSG(
             3, ("Ticket age exceeds limitation ticket_age=%" MBEDTLS_PRINTF_MS_TIME,
                 server_age));
@@ -238,7 +239,8 @@ static int ssl_tls13_offered_psks_check_identity_match_ticket(
     if (age_diff < -1000 ||
         age_diff > MBEDTLS_SSL_TLS1_3_TICKET_AGE_TOLERANCE) {
         MBEDTLS_SSL_DEBUG_MSG(
-            3, ("Ticket age outside tolerance window ( diff=%" MBEDTLS_PRINTF_MS_TIME ")",
+            3, ("Ticket age outside tolerance window ( diff = %"
+                MBEDTLS_PRINTF_MS_TIME ")",
                 age_diff));
         goto exit;
     }

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -3025,8 +3025,8 @@ static int ssl_tls13_write_new_session_ticket_body(mbedtls_ssl_context *ssl,
      *      MAY treat a ticket as valid for a shorter period of time than what
      *      is stated in the ticket_lifetime.
      */
-    if (ticket_lifetime > 604800) {
-        ticket_lifetime = 604800;
+    if (ticket_lifetime > MBEDTLS_SSL_TLS1_3_MAX_ALLOWED_TICKET_LIFETIME) {
+        ticket_lifetime = MBEDTLS_SSL_TLS1_3_MAX_ALLOWED_TICKET_LIFETIME;
     }
     MBEDTLS_PUT_UINT32_BE(ticket_lifetime, p, 0);
     MBEDTLS_SSL_DEBUG_MSG(3, ("ticket_lifetime: %u",

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -113,7 +113,7 @@ static int ssl_tls13_offered_psks_check_identity_match_ticket(
 #if defined(MBEDTLS_HAVE_TIME)
     mbedtls_ms_time_t now;
     mbedtls_ms_time_t server_age;
-    mbedtls_ms_time_t client_age;
+    uint32_t client_age;
     mbedtls_ms_time_t age_diff;
 #endif
 
@@ -195,8 +195,8 @@ static int ssl_tls13_offered_psks_check_identity_match_ticket(
 
     if (now < session->ticket_creation_time) {
         MBEDTLS_SSL_DEBUG_MSG(
-            3, ("Invalid ticket start time ( now = %" MBEDTLS_PRINTF_MS_TIME
-                ", start = %" MBEDTLS_PRINTF_MS_TIME " )",
+            3, ("Invalid ticket creation time ( now = %" MBEDTLS_PRINTF_MS_TIME
+                ", creation_time = %" MBEDTLS_PRINTF_MS_TIME " )",
                 now, session->ticket_creation_time));
         goto exit;
     }
@@ -233,7 +233,7 @@ static int ssl_tls13_offered_psks_check_identity_match_ticket(
      *       sync up their system time every 6000/360/2~=8 hours.
      */
     client_age = obfuscated_ticket_age - session->ticket_age_add;
-    age_diff = server_age - client_age;
+    age_diff = server_age - (mbedtls_ms_time_t)client_age;
     if (age_diff < -MBEDTLS_SSL_TLS1_3_TICKET_AGE_TOLERANCE ||
         age_diff > MBEDTLS_SSL_TLS1_3_TICKET_AGE_TOLERANCE) {
         MBEDTLS_SSL_DEBUG_MSG(

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -213,7 +213,7 @@ static int ssl_tls13_offered_psks_check_identity_match_ticket(
      * the "ticket_lifetime" value which was provided with the ticket.
      *
      */
-    if (server_age > 604800 * 1000) {
+    if (server_age > MBEDTLS_SSL_TLS1_3_MAX_ALLOWED_TICKET_LIFETIME * 1000) {
         MBEDTLS_SSL_DEBUG_MSG(
             3, ("Ticket age exceeds limitation ticket_age=%" MBEDTLS_PRINTF_MS_TIME,
                 server_age));
@@ -3025,8 +3025,8 @@ static int ssl_tls13_write_new_session_ticket_body(mbedtls_ssl_context *ssl,
      *      MAY treat a ticket as valid for a shorter period of time than what
      *      is stated in the ticket_lifetime.
      */
-    if (ticket_lifetime > 604800) {
-        ticket_lifetime = 604800;
+    if (ticket_lifetime > MBEDTLS_SSL_TLS1_3_MAX_ALLOWED_TICKET_LIFETIME) {
+        ticket_lifetime = MBEDTLS_SSL_TLS1_3_MAX_ALLOWED_TICKET_LIFETIME;
     }
     MBEDTLS_PUT_UINT32_BE(ticket_lifetime, p, 0);
     MBEDTLS_SSL_DEBUG_MSG(3, ("ticket_lifetime: %u",

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -233,7 +233,7 @@ static int ssl_tls13_offered_psks_check_identity_match_ticket(
      *       sync up their system time every 6000/360/2~=8 hours.
      */
     client_age = obfuscated_ticket_age - session->ticket_age_add;
-    age_diff = server_age - (mbedtls_ms_time_t)client_age;
+    age_diff = server_age - (mbedtls_ms_time_t) client_age;
     if (age_diff < -MBEDTLS_SSL_TLS1_3_TICKET_AGE_TOLERANCE ||
         age_diff > MBEDTLS_SSL_TLS1_3_TICKET_AGE_TOLERANCE) {
         MBEDTLS_SSL_DEBUG_MSG(

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -229,7 +229,7 @@ static int ssl_tls13_offered_psks_check_identity_match_ticket(
      *
      * NOTE: The typical accuracy of an RTC crystal is ±100 to ±20 parts per
      *       million (360 to 72 milliseconds per hour). Default tolerance
-     *       windows is 6s, thus in the worst case client and servers must
+     *       window is 6s, thus in the worst case clients and servers must
      *       sync up their system time every 6000/360/2~=8 hours.
      */
     client_age = obfuscated_ticket_age - session->ticket_age_add;

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -3025,8 +3025,8 @@ static int ssl_tls13_write_new_session_ticket_body(mbedtls_ssl_context *ssl,
      *      MAY treat a ticket as valid for a shorter period of time than what
      *      is stated in the ticket_lifetime.
      */
-    if (ticket_lifetime > MBEDTLS_SSL_TLS1_3_MAX_ALLOWED_TICKET_LIFETIME) {
-        ticket_lifetime = MBEDTLS_SSL_TLS1_3_MAX_ALLOWED_TICKET_LIFETIME;
+    if (ticket_lifetime > 604800) {
+        ticket_lifetime = 604800;
     }
     MBEDTLS_PUT_UINT32_BE(ticket_lifetime, p, 0);
     MBEDTLS_SSL_DEBUG_MSG(3, ("ticket_lifetime: %u",

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -212,7 +212,6 @@ static int ssl_tls13_offered_psks_check_identity_match_ticket(
      * Clients MUST NOT attempt to use tickets which have ages greater than
      * the "ticket_lifetime" value which was provided with the ticket.
      *
-     * For time being, the age MUST be less than 604800 seconds (7 days).
      */
     if (server_age > 604800 * 1000) {
         MBEDTLS_SSL_DEBUG_MSG(
@@ -228,11 +227,10 @@ static int ssl_tls13_offered_psks_check_identity_match_ticket(
      * ticket_age_add from PskIdentity.obfuscated_ticket_age modulo 2^32) is
      * within a small tolerance of the time since the ticket was issued.
      *
-     * NOTE: Typical crystal RTC accuracy specifications are from ±100 to ±20
-     *       parts per million (360 to 72 million seconds per hour). Defualt
-     *       tolerance windows is 6000 millionsections, that means client host
-     *       MUST sync up system time every 16 hours. Otherwise, the ticket will
-     *       be invalid.
+     * NOTE: The typical accuracy of an RTC crystal is ±100 to ±20 parts per
+     *       million (360 to 72 milliseconds per hour). Default tolerance
+     *       windows is 6s, thus in the worst case client and servers must
+     *       sync up their system time every 6000/360/2~=8 hours.
      */
     client_age = obfuscated_ticket_age - session->ticket_age_add;
     age_diff = server_age - client_age;

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -215,7 +215,7 @@ static int ssl_tls13_offered_psks_check_identity_match_ticket(
      */
     if (server_age > MBEDTLS_SSL_TLS1_3_MAX_ALLOWED_TICKET_LIFETIME * 1000) {
         MBEDTLS_SSL_DEBUG_MSG(
-            3, ("Ticket age exceeds limitation ticket_age=%" MBEDTLS_PRINTF_MS_TIME,
+            3, ("Ticket age exceeds limitation ticket_age = %" MBEDTLS_PRINTF_MS_TIME,
                 server_age));
         goto exit;
     }

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -193,15 +193,15 @@ static int ssl_tls13_offered_psks_check_identity_match_ticket(
 #if defined(MBEDTLS_HAVE_TIME)
     now = mbedtls_ms_time();
 
-    if (now < session->start) {
+    if (now < session->ticket_creation) {
         MBEDTLS_SSL_DEBUG_MSG(
             3, ("Invalid ticket start time ( now = %" MBEDTLS_PRINTF_MS_TIME
                 ", start = %" MBEDTLS_PRINTF_MS_TIME " )",
-                now, session->start));
+                now, session->ticket_creation));
         goto exit;
     }
 
-    server_age = now - session->start;
+    server_age = now - session->ticket_creation;
 
     /* RFC 8446 section 4.6.1
      *
@@ -2880,7 +2880,7 @@ static int ssl_tls13_prepare_new_session_ticket(mbedtls_ssl_context *ssl,
     MBEDTLS_SSL_DEBUG_MSG(2, ("=> prepare NewSessionTicket msg"));
 
 #if defined(MBEDTLS_HAVE_TIME)
-    session->start = mbedtls_ms_time();
+    session->ticket_creation = mbedtls_ms_time();
 #endif
 
     /* Set ticket_flags depends on the advertised psk key exchange mode */

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -234,7 +234,7 @@ static int ssl_tls13_offered_psks_check_identity_match_ticket(
      */
     client_age = obfuscated_ticket_age - session->ticket_age_add;
     age_diff = server_age - client_age;
-    if (age_diff < -1000 ||
+    if (age_diff < -MBEDTLS_SSL_TLS1_3_TICKET_AGE_TOLERANCE ||
         age_diff > MBEDTLS_SSL_TLS1_3_TICKET_AGE_TOLERANCE) {
         MBEDTLS_SSL_DEBUG_MSG(
             3, ("Ticket age outside tolerance window ( diff = %"

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -1422,28 +1422,28 @@ int dummy_ticket_parse(void *p_ticket, mbedtls_ssl_session *session,
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
         case 3:
             /* Creation time in the future. */
-            session->ticket_creation = mbedtls_ms_time() +
-                                       MBEDTLS_SSL_TLS1_3_TICKET_AGE_TOLERANCE +
-                                       4 * 1000;
+            session->ticket_creation_time = mbedtls_ms_time() +
+                                            MBEDTLS_SSL_TLS1_3_TICKET_AGE_TOLERANCE +
+                                            4 * 1000;
             break;
         case 4:
             /* Ticket reaches the end of lifetime. */
-            session->ticket_creation = mbedtls_ms_time() - session->ticket_lifetime -
-                                       MBEDTLS_SSL_TLS1_3_TICKET_AGE_TOLERANCE - 4 * 1000;
+            session->ticket_creation_time = mbedtls_ms_time() - session->ticket_lifetime -
+                                            MBEDTLS_SSL_TLS1_3_TICKET_AGE_TOLERANCE - 4 * 1000;
             break;
         case 5:
             /* Ticket is valid, but client age is beyond the upper bound of tolerance window. */
 
             session->ticket_age_add += MBEDTLS_SSL_TLS1_3_TICKET_AGE_TOLERANCE + 4 * 1000;
             /* Make sure the execution time does not affect the result */
-            session->ticket_creation = mbedtls_ms_time();
+            session->ticket_creation_time = mbedtls_ms_time();
             break;
 
         case 6:
             /* Ticket is valid, but client age is beyond the lower bound of tolerance window. */
             session->ticket_age_add -= MBEDTLS_SSL_TLS1_3_TICKET_AGE_TOLERANCE + 4 * 1000;
             /* Make sure the execution time does not affect the result */
-            session->ticket_creation = mbedtls_ms_time();
+            session->ticket_creation_time = mbedtls_ms_time();
             break;
         case 7:
             session->ticket_flags = MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_NONE;

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -1430,14 +1430,14 @@ int dummy_ticket_parse(void *p_ticket, mbedtls_ssl_session *session,
                                             (7 * 24 * 3600 * 1000 + 1000);
             break;
         case 5:
-            /* Ticket is valid, but client age is below the upper bound of tolerance window. */
+            /* Ticket is valid, but client age is below the lower bound of the tolerance window. */
             session->ticket_age_add += MBEDTLS_SSL_TLS1_3_TICKET_AGE_TOLERANCE + 4 * 1000;
             /* Make sure the execution time does not affect the result */
             session->ticket_creation_time = mbedtls_ms_time();
             break;
 
         case 6:
-            /* Ticket is valid, but client age is beyond the lower bound of tolerance window. */
+            /* Ticket is valid, but client age is beyond the upper bound of the tolerance window. */
             session->ticket_age_add -= MBEDTLS_SSL_TLS1_3_TICKET_AGE_TOLERANCE + 4 * 1000;
             /* Make sure the execution time does not affect the result */
             session->ticket_creation_time = mbedtls_ms_time();

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -1422,18 +1422,15 @@ int dummy_ticket_parse(void *p_ticket, mbedtls_ssl_session *session,
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
         case 3:
             /* Creation time in the future. */
-            session->ticket_creation_time = mbedtls_ms_time() +
-                                            MBEDTLS_SSL_TLS1_3_TICKET_AGE_TOLERANCE +
-                                            4 * 1000;
+            session->ticket_creation_time = mbedtls_ms_time() + 1000;
             break;
         case 4:
-            /* Ticket reaches the end of lifetime. */
-            session->ticket_creation_time = mbedtls_ms_time() - session->ticket_lifetime -
-                                            MBEDTLS_SSL_TLS1_3_TICKET_AGE_TOLERANCE - 4 * 1000;
+            /* Ticket has reached the end of lifetime. */
+            session->ticket_creation_time = mbedtls_ms_time() -
+                                            (7 * 24 * 3600 * 1000 + 1000);
             break;
         case 5:
-            /* Ticket is valid, but client age is beyond the upper bound of tolerance window. */
-
+            /* Ticket is valid, but client age is below the upper bound of tolerance window. */
             session->ticket_age_add += MBEDTLS_SSL_TLS1_3_TICKET_AGE_TOLERANCE + 4 * 1000;
             /* Make sure the execution time does not affect the result */
             session->ticket_creation_time = mbedtls_ms_time();

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -1420,16 +1420,16 @@ int dummy_ticket_parse(void *p_ticket, mbedtls_ssl_session *session,
         case 2:
             return MBEDTLS_ERR_SSL_SESSION_TICKET_EXPIRED;
         case 3:
-            session->start = mbedtls_time(NULL) + 10;
+            session->start = mbedtls_ms_time() + 10 * 1000;
             break;
         case 4:
-            session->start = mbedtls_time(NULL) - 10 - 7 * 24 * 3600;
+            session->start = mbedtls_ms_time() - 10 * 1000 - 7 * 24 * 3600 * 1000;
             break;
         case 5:
-            session->start = mbedtls_time(NULL) - 10;
+            session->start = mbedtls_ms_time() - 10 * 1000;
             break;
         case 6:
-            session->start = mbedtls_time(NULL);
+            session->start = mbedtls_ms_time();
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
             session->ticket_age_add -= 1000;
 #endif

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -1416,35 +1416,43 @@ int dummy_ticket_parse(void *p_ticket, mbedtls_ssl_session *session,
 
     switch (opt.dummy_ticket % 11) {
         case 1:
+            /* Callback function return INVALID_MAC */
             return MBEDTLS_ERR_SSL_INVALID_MAC;
         case 2:
+            /* Callback function return ticket expired */
             return MBEDTLS_ERR_SSL_SESSION_TICKET_EXPIRED;
         case 3:
+            /* Built-in check, the start time is in future. */
             session->start = mbedtls_ms_time() + 10 * 1000;
             break;
         case 4:
+            /* Built-in check, ticket expired due to too old. */
             session->start = mbedtls_ms_time() - 10 * 1000 - 7 * 24 * 3600 * 1000;
             break;
         case 5:
+            /* Built-in check, age outside tolerance window, too young. */
             session->start = mbedtls_ms_time() - 10 * 1000;
             break;
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3)
         case 6:
+            /* Built-in check, age outside tolerance window, too old. */
             session->start = mbedtls_ms_time();
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3)
             session->ticket_age_add -= 1000;
-#endif
             break;
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3)
         case 7:
+            /* Built-in check, ticket permission check. */
             session->ticket_flags = MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_NONE;
             break;
         case 8:
+            /* Built-in check, ticket permission check. */
             session->ticket_flags = MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK;
             break;
         case 9:
+            /* Built-in check, ticket permission check. */
             session->ticket_flags = MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL;
             break;
         case 10:
+            /* Built-in check, ticket permission check. */
             session->ticket_flags = MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_ALL;
             break;
 #endif

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -1421,22 +1421,23 @@ int dummy_ticket_parse(void *p_ticket, mbedtls_ssl_session *session,
         case 2:
             /* Callback function return ticket expired */
             return MBEDTLS_ERR_SSL_SESSION_TICKET_EXPIRED;
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3)
         case 3:
             /* Built-in check, the start time is in future. */
-            session->start = mbedtls_ms_time() + 10 * 1000;
+            session->ticket_creation = mbedtls_ms_time() + 10 * 1000;
             break;
         case 4:
             /* Built-in check, ticket expired due to too old. */
-            session->start = mbedtls_ms_time() - 10 * 1000 - 7 * 24 * 3600 * 1000;
+            session->ticket_creation = mbedtls_ms_time() - 10 * 1000 - 7 * 24 * 3600 * 1000;
             break;
         case 5:
             /* Built-in check, age outside tolerance window, too young. */
-            session->start = mbedtls_ms_time() - 10 * 1000;
+            session->ticket_creation = mbedtls_ms_time() - 10 * 1000;
             break;
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3)
+
         case 6:
             /* Built-in check, age outside tolerance window, too old. */
-            session->start = mbedtls_ms_time();
+            session->ticket_creation = mbedtls_ms_time();
             session->ticket_age_add -= 1000;
             break;
         case 7:

--- a/tests/opt-testcases/tls13-misc.sh
+++ b/tests/opt-testcases/tls13-misc.sh
@@ -86,7 +86,7 @@ run_test "TLS 1.3 m->m: Session resumption failure, ticket authentication failed
          -S "key exchange mode: psk$" \
          -s "ticket is not authentic" \
          -S "ticket is expired" \
-         -S "Invalid ticket start time" \
+         -S "Invalid ticket creation time" \
          -S "Ticket age exceeds limitation" \
          -S "Ticket age outside tolerance window"
 
@@ -105,7 +105,7 @@ run_test "TLS 1.3 m->m: Session resumption failure, ticket expired." \
          -S "key exchange mode: psk$" \
          -S "ticket is not authentic" \
          -s "ticket is expired" \
-         -S "Invalid ticket start time" \
+         -S "Invalid ticket creation time" \
          -S "Ticket age exceeds limitation" \
          -S "Ticket age outside tolerance window"
 
@@ -124,7 +124,7 @@ run_test "TLS 1.3 m->m: Session resumption failure, invalid start time." \
          -S "key exchange mode: psk$" \
          -S "ticket is not authentic" \
          -S "ticket is expired" \
-         -s "Invalid ticket start time" \
+         -s "Invalid ticket creation time" \
          -S "Ticket age exceeds limitation" \
          -S "Ticket age outside tolerance window"
 
@@ -143,7 +143,7 @@ run_test "TLS 1.3 m->m: Session resumption failure, ticket expired. too old" \
          -S "key exchange mode: psk$" \
          -S "ticket is not authentic" \
          -S "ticket is expired" \
-         -S "Invalid ticket start time" \
+         -S "Invalid ticket creation time" \
          -s "Ticket age exceeds limitation" \
          -S "Ticket age outside tolerance window"
 
@@ -162,7 +162,7 @@ run_test "TLS 1.3 m->m: Session resumption failure, age outside tolerance window
          -S "key exchange mode: psk$" \
          -S "ticket is not authentic" \
          -S "ticket is expired" \
-         -S "Invalid ticket start time" \
+         -S "Invalid ticket creation time" \
          -S "Ticket age exceeds limitation" \
          -s "Ticket age outside tolerance window"
 
@@ -181,7 +181,7 @@ run_test "TLS 1.3 m->m: Session resumption failure, age outside tolerance window
          -S "key exchange mode: psk$" \
          -S "ticket is not authentic" \
          -S "ticket is expired" \
-         -S "Invalid ticket start time" \
+         -S "Invalid ticket creation time" \
          -S "Ticket age exceeds limitation" \
          -s "Ticket age outside tolerance window"
 

--- a/tests/src/test_helpers/ssl_helpers.c
+++ b/tests/src/test_helpers/ssl_helpers.c
@@ -1633,6 +1633,7 @@ exit:
 }
 #endif /* MBEDTLS_SSL_SOME_SUITES_USE_MAC */
 
+#if defined(MBEDTLS_SSL_PROTO_TLS1_2)
 int mbedtls_test_ssl_tls12_populate_session(mbedtls_ssl_session *session,
                                             int ticket_len,
                                             const char *crt_file)
@@ -1729,6 +1730,7 @@ int mbedtls_test_ssl_tls12_populate_session(mbedtls_ssl_session *session,
 
     return 0;
 }
+#endif /* MBEDTLS_SSL_PROTO_TLS1_2 */
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
 int mbedtls_test_ssl_tls13_populate_session(mbedtls_ssl_session *session,
@@ -1752,14 +1754,14 @@ int mbedtls_test_ssl_tls13_populate_session(mbedtls_ssl_session *session,
 
 #if defined(MBEDTLS_HAVE_TIME)
     if (session->endpoint == MBEDTLS_SSL_IS_SERVER) {
-        session->start = mbedtls_time(NULL) - 42;
+        session->ticket_creation = mbedtls_ms_time() - 42;
     }
 #endif
 
 #if defined(MBEDTLS_SSL_CLI_C)
     if (session->endpoint == MBEDTLS_SSL_IS_CLIENT) {
 #if defined(MBEDTLS_HAVE_TIME)
-        session->ticket_received = mbedtls_time(NULL) - 40;
+        session->ticket_received = mbedtls_ms_time() - 40;
 #endif
         session->ticket_lifetime = 0xfedcba98;
 

--- a/tests/src/test_helpers/ssl_helpers.c
+++ b/tests/src/test_helpers/ssl_helpers.c
@@ -1754,7 +1754,7 @@ int mbedtls_test_ssl_tls13_populate_session(mbedtls_ssl_session *session,
 
 #if defined(MBEDTLS_HAVE_TIME)
     if (session->endpoint == MBEDTLS_SSL_IS_SERVER) {
-        session->ticket_creation = mbedtls_ms_time() - 42;
+        session->ticket_creation_time = mbedtls_ms_time() - 42;
     }
 #endif
 

--- a/tests/src/test_helpers/ssl_helpers.c
+++ b/tests/src/test_helpers/ssl_helpers.c
@@ -1752,7 +1752,7 @@ int mbedtls_test_ssl_tls13_populate_session(mbedtls_ssl_session *session,
     session->max_early_data_size = 0x87654321;
 #endif
 
-#if defined(MBEDTLS_HAVE_TIME)
+#if defined(MBEDTLS_HAVE_TIME) && defined(MBEDTLS_SSL_SRV_C)
     if (session->endpoint == MBEDTLS_SSL_IS_SERVER) {
         session->ticket_creation_time = mbedtls_ms_time() - 42;
     }

--- a/tests/src/test_helpers/ssl_helpers.c
+++ b/tests/src/test_helpers/ssl_helpers.c
@@ -1761,7 +1761,7 @@ int mbedtls_test_ssl_tls13_populate_session(mbedtls_ssl_session *session,
 #if defined(MBEDTLS_SSL_CLI_C)
     if (session->endpoint == MBEDTLS_SSL_IS_CLIENT) {
 #if defined(MBEDTLS_HAVE_TIME)
-        session->ticket_received = mbedtls_ms_time() - 40;
+        session->ticket_reception_time = mbedtls_ms_time() - 40;
 #endif
         session->ticket_lifetime = 0xfedcba98;
 

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -2120,23 +2120,28 @@ void ssl_serialize_session_load_save(int ticket_len, char *crt_file,
 
     /* Prepare a dummy session to work on */
     ((void) endpoint_type);
-    ((void) tls_version);
     ((void) ticket_len);
     ((void) crt_file);
+
+    switch (tls_version) {
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
-    if (tls_version == MBEDTLS_SSL_VERSION_TLS1_3) {
-        TEST_ASSERT(mbedtls_test_ssl_tls13_populate_session(
-                        &session, 0, endpoint_type) == 0);
-    }
+        case MBEDTLS_SSL_VERSION_TLS1_3:
+            TEST_ASSERT(mbedtls_test_ssl_tls13_populate_session(
+                            &session, 0, endpoint_type) == 0);
+            break;
 #endif
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_2)
-    if (tls_version == MBEDTLS_SSL_VERSION_TLS1_2) {
-
-        TEST_ASSERT(mbedtls_test_ssl_tls12_populate_session(
-                        &session, ticket_len, crt_file) == 0);
-    }
+        case MBEDTLS_SSL_VERSION_TLS1_2:
+            TEST_ASSERT(mbedtls_test_ssl_tls12_populate_session(
+                            &session, ticket_len, crt_file) == 0);
+            break;
 #endif
+        default:
+            /* should never happen */
+            TEST_ASSERT(0);
+            break;
+    }
 
     /* Get desired buffer size for serializing */
     TEST_ASSERT(mbedtls_ssl_session_save(&session, NULL, 0, &len0)

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -2185,19 +2185,25 @@ void ssl_serialize_session_save_buf_size(int ticket_len, char *crt_file,
     ((void) tls_version);
     ((void) ticket_len);
     ((void) crt_file);
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3)
-    if (tls_version == MBEDTLS_SSL_VERSION_TLS1_3) {
-        TEST_ASSERT(mbedtls_test_ssl_tls13_populate_session(
-                        &session, 0, endpoint_type) == 0);
-    }
-#endif
 
-#if defined(MBEDTLS_SSL_PROTO_TLS1_2)
-    if (tls_version == MBEDTLS_SSL_VERSION_TLS1_2) {
-        TEST_ASSERT(mbedtls_test_ssl_tls12_populate_session(
-                        &session, ticket_len, crt_file) == 0);
-    }
+    switch (tls_version) {
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3)
+        case MBEDTLS_SSL_VERSION_TLS1_3:
+            TEST_ASSERT(mbedtls_test_ssl_tls13_populate_session(
+                            &session, 0, endpoint_type) == 0);
+            break;
 #endif
+#if defined(MBEDTLS_SSL_PROTO_TLS1_2)
+        case MBEDTLS_SSL_VERSION_TLS1_2:
+            TEST_ASSERT(mbedtls_test_ssl_tls12_populate_session(
+                            &session, ticket_len, crt_file) == 0);
+            break;
+#endif
+        default:
+            /* should never happen */
+            TEST_ASSERT(0);
+            break;
+    }
 
     TEST_ASSERT(mbedtls_ssl_session_save(&session, NULL, 0, &good_len)
                 == MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL);
@@ -2303,19 +2309,25 @@ void ssl_session_serialize_version_check(int corrupt_major,
     USE_PSA_INIT();
     ((void) endpoint_type);
     ((void) tls_version);
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3)
-    if (tls_version == MBEDTLS_SSL_VERSION_TLS1_3) {
-        TEST_ASSERT(mbedtls_test_ssl_tls13_populate_session(
-                        &session, 0, endpoint_type) == 0);
-    }
-#endif
 
-#if defined(MBEDTLS_SSL_PROTO_TLS1_2)
-    if (tls_version == MBEDTLS_SSL_VERSION_TLS1_2) {
-        TEST_ASSERT(mbedtls_test_ssl_tls12_populate_session(
-                        &session, 0, NULL) == 0);
-    }
+    switch (tls_version) {
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3)
+        case MBEDTLS_SSL_VERSION_TLS1_3:
+            TEST_ASSERT(mbedtls_test_ssl_tls13_populate_session(
+                            &session, 0, endpoint_type) == 0);
+            break;
 #endif
+#if defined(MBEDTLS_SSL_PROTO_TLS1_2)
+        case MBEDTLS_SSL_VERSION_TLS1_2:
+            TEST_ASSERT(mbedtls_test_ssl_tls12_populate_session(
+                            &session, 0, NULL) == 0);
+            break;
+#endif
+        default:
+            /* should never happen */
+            TEST_ASSERT(0);
+            break;
+    }
 
     /* Infer length of serialized session. */
     TEST_ASSERT(mbedtls_ssl_session_save(&session,

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -1973,7 +1973,7 @@ void ssl_serialize_session_save_load(int ticket_len, char *crt_file,
      * Make sure both session structures are identical
      */
 #if defined(MBEDTLS_HAVE_TIME)
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3)
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3) && defined(MBEDTLS_SSL_SRV_C)
     if (tls_version == MBEDTLS_SSL_VERSION_TLS1_3) {
         TEST_ASSERT(original.ticket_creation_time == restored.ticket_creation_time);
     }

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -1943,16 +1943,21 @@ void ssl_serialize_session_save_load(int ticket_len, char *crt_file,
     /* Prepare a dummy session to work on */
     ((void) endpoint_type);
     ((void) tls_version);
+    ((void) ticket_len);
+    ((void) crt_file);
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
     if (tls_version == MBEDTLS_SSL_VERSION_TLS1_3) {
         TEST_ASSERT(mbedtls_test_ssl_tls13_populate_session(
                         &original, 0, endpoint_type) == 0);
-    } else
+    }
 #endif
-    {
+
+#if defined(MBEDTLS_SSL_PROTO_TLS1_2)
+    if (tls_version == MBEDTLS_SSL_VERSION_TLS1_2) {
         TEST_ASSERT(mbedtls_test_ssl_tls12_populate_session(
                         &original, ticket_len, crt_file) == 0);
     }
+#endif
 
     /* Serialize it */
     TEST_ASSERT(mbedtls_ssl_session_save(&original, NULL, 0, &len)
@@ -1968,8 +1973,20 @@ void ssl_serialize_session_save_load(int ticket_len, char *crt_file,
      * Make sure both session structures are identical
      */
 #if defined(MBEDTLS_HAVE_TIME)
-    TEST_ASSERT(original.start == restored.start);
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3)
+    if (tls_version == MBEDTLS_SSL_VERSION_TLS1_3) {
+        TEST_ASSERT(original.ticket_creation == restored.ticket_creation);
+    }
 #endif
+
+#if defined(MBEDTLS_SSL_PROTO_TLS1_2)
+    if (tls_version == MBEDTLS_SSL_VERSION_TLS1_2) {
+        TEST_ASSERT(original.start == restored.start);
+    }
+#endif
+
+#endif
+
     TEST_ASSERT(original.tls_version == restored.tls_version);
     TEST_ASSERT(original.ciphersuite == restored.ciphersuite);
 #if defined(MBEDTLS_SSL_PROTO_TLS1_2)
@@ -2049,7 +2066,7 @@ void ssl_serialize_session_save_load(int ticket_len, char *crt_file,
 
 #if defined(MBEDTLS_HAVE_TIME) && defined(MBEDTLS_SSL_SRV_C)
         if (endpoint_type == MBEDTLS_SSL_IS_SERVER) {
-            TEST_ASSERT(original.start == restored.start);
+            TEST_ASSERT(original.ticket_creation == restored.ticket_creation);
         }
 #endif
 #if defined(MBEDTLS_SSL_SESSION_TICKETS) && defined(MBEDTLS_SSL_CLI_C)
@@ -2097,16 +2114,22 @@ void ssl_serialize_session_load_save(int ticket_len, char *crt_file,
     /* Prepare a dummy session to work on */
     ((void) endpoint_type);
     ((void) tls_version);
+    ((void) ticket_len);
+    ((void) crt_file);
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
     if (tls_version == MBEDTLS_SSL_VERSION_TLS1_3) {
         TEST_ASSERT(mbedtls_test_ssl_tls13_populate_session(
                         &session, 0, endpoint_type) == 0);
-    } else
+    }
 #endif
-    {
+
+#if defined(MBEDTLS_SSL_PROTO_TLS1_2)
+    if (tls_version == MBEDTLS_SSL_VERSION_TLS1_2) {
+
         TEST_ASSERT(mbedtls_test_ssl_tls12_populate_session(
                         &session, ticket_len, crt_file) == 0);
     }
+#endif
 
     /* Get desired buffer size for serializing */
     TEST_ASSERT(mbedtls_ssl_session_save(&session, NULL, 0, &len0)
@@ -2160,16 +2183,22 @@ void ssl_serialize_session_save_buf_size(int ticket_len, char *crt_file,
     /* Prepare dummy session and get serialized size */
     ((void) endpoint_type);
     ((void) tls_version);
+    ((void) ticket_len);
+    ((void) crt_file);
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
     if (tls_version == MBEDTLS_SSL_VERSION_TLS1_3) {
         TEST_ASSERT(mbedtls_test_ssl_tls13_populate_session(
                         &session, 0, endpoint_type) == 0);
-    } else
+    }
 #endif
-    {
+
+#if defined(MBEDTLS_SSL_PROTO_TLS1_2)
+    if (tls_version == MBEDTLS_SSL_VERSION_TLS1_2) {
         TEST_ASSERT(mbedtls_test_ssl_tls12_populate_session(
                         &session, ticket_len, crt_file) == 0);
     }
+#endif
+
     TEST_ASSERT(mbedtls_ssl_session_save(&session, NULL, 0, &good_len)
                 == MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL);
 
@@ -2209,16 +2238,22 @@ void ssl_serialize_session_load_buf_size(int ticket_len, char *crt_file,
     /* Prepare serialized session data */
     ((void) endpoint_type);
     ((void) tls_version);
+    ((void) ticket_len);
+    ((void) crt_file);
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
     if (tls_version == MBEDTLS_SSL_VERSION_TLS1_3) {
         TEST_ASSERT(mbedtls_test_ssl_tls13_populate_session(
                         &session, 0, endpoint_type) == 0);
-    } else
+    }
 #endif
-    {
+
+#if defined(MBEDTLS_SSL_PROTO_TLS1_2)
+    if (tls_version == MBEDTLS_SSL_VERSION_TLS1_2) {
         TEST_ASSERT(mbedtls_test_ssl_tls12_populate_session(
                         &session, ticket_len, crt_file) == 0);
     }
+#endif
+
     TEST_ASSERT(mbedtls_ssl_session_save(&session, NULL, 0, &good_len)
                 == MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL);
     TEST_CALLOC(good_buf, good_len);
@@ -2272,11 +2307,15 @@ void ssl_session_serialize_version_check(int corrupt_major,
     if (tls_version == MBEDTLS_SSL_VERSION_TLS1_3) {
         TEST_ASSERT(mbedtls_test_ssl_tls13_populate_session(
                         &session, 0, endpoint_type) == 0);
-    } else
+    }
 #endif
-    TEST_ASSERT(mbedtls_test_ssl_tls12_populate_session(
-                    &session, 0, NULL) == 0);
 
+#if defined(MBEDTLS_SSL_PROTO_TLS1_2)
+    if (tls_version == MBEDTLS_SSL_VERSION_TLS1_2) {
+        TEST_ASSERT(mbedtls_test_ssl_tls12_populate_session(
+                        &session, 0, NULL) == 0);
+    }
+#endif
 
     /* Infer length of serialized session. */
     TEST_ASSERT(mbedtls_ssl_session_save(&session,

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -1973,17 +1973,24 @@ void ssl_serialize_session_save_load(int ticket_len, char *crt_file,
      * Make sure both session structures are identical
      */
 #if defined(MBEDTLS_HAVE_TIME)
+    switch (tls_version) {
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3) && defined(MBEDTLS_SSL_SRV_C)
-    if (tls_version == MBEDTLS_SSL_VERSION_TLS1_3) {
-        TEST_ASSERT(original.ticket_creation_time == restored.ticket_creation_time);
-    }
+        case MBEDTLS_SSL_VERSION_TLS1_3:
+            TEST_ASSERT(original.ticket_creation_time == restored.ticket_creation_time);
+            break;
+#endif
+#if defined(MBEDTLS_SSL_PROTO_TLS1_2)
+        case MBEDTLS_SSL_VERSION_TLS1_2:
+            TEST_ASSERT(original.start == restored.start);
+            break;
 #endif
 
-#if defined(MBEDTLS_SSL_PROTO_TLS1_2)
-    if (tls_version == MBEDTLS_SSL_VERSION_TLS1_2) {
-        TEST_ASSERT(original.start == restored.start);
+        default:
+            /* should never happen */
+            TEST_ASSERT(0);
+            break;
     }
-#endif
+
 
 #endif
 
@@ -2246,19 +2253,27 @@ void ssl_serialize_session_load_buf_size(int ticket_len, char *crt_file,
     ((void) tls_version);
     ((void) ticket_len);
     ((void) crt_file);
+
+    switch (tls_version) {
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
-    if (tls_version == MBEDTLS_SSL_VERSION_TLS1_3) {
-        TEST_ASSERT(mbedtls_test_ssl_tls13_populate_session(
-                        &session, 0, endpoint_type) == 0);
-    }
+        case MBEDTLS_SSL_VERSION_TLS1_3:
+            TEST_ASSERT(mbedtls_test_ssl_tls13_populate_session(
+                            &session, 0, endpoint_type) == 0);
+            break;
 #endif
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_2)
-    if (tls_version == MBEDTLS_SSL_VERSION_TLS1_2) {
-        TEST_ASSERT(mbedtls_test_ssl_tls12_populate_session(
-                        &session, ticket_len, crt_file) == 0);
-    }
+        case MBEDTLS_SSL_VERSION_TLS1_2:
+            TEST_ASSERT(mbedtls_test_ssl_tls12_populate_session(
+                            &session, ticket_len, crt_file) == 0);
+            break;
 #endif
+
+        default:
+            /* should never happen */
+            TEST_ASSERT(0);
+            break;
+    }
 
     TEST_ASSERT(mbedtls_ssl_session_save(&session, NULL, 0, &good_len)
                 == MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL);
@@ -2321,6 +2336,7 @@ void ssl_session_serialize_version_check(int corrupt_major,
         case MBEDTLS_SSL_VERSION_TLS1_2:
             TEST_ASSERT(mbedtls_test_ssl_tls12_populate_session(
                             &session, 0, NULL) == 0);
+
             break;
 #endif
         default:

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -1975,7 +1975,7 @@ void ssl_serialize_session_save_load(int ticket_len, char *crt_file,
 #if defined(MBEDTLS_HAVE_TIME)
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
     if (tls_version == MBEDTLS_SSL_VERSION_TLS1_3) {
-        TEST_ASSERT(original.ticket_creation == restored.ticket_creation);
+        TEST_ASSERT(original.ticket_creation_time == restored.ticket_creation_time);
     }
 #endif
 
@@ -2066,7 +2066,7 @@ void ssl_serialize_session_save_load(int ticket_len, char *crt_file,
 
 #if defined(MBEDTLS_HAVE_TIME) && defined(MBEDTLS_SSL_SRV_C)
         if (endpoint_type == MBEDTLS_SSL_IS_SERVER) {
-            TEST_ASSERT(original.ticket_creation == restored.ticket_creation);
+            TEST_ASSERT(original.ticket_creation_time == restored.ticket_creation_time);
         }
 #endif
 #if defined(MBEDTLS_SSL_SESSION_TICKETS) && defined(MBEDTLS_SSL_CLI_C)

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -2189,7 +2189,6 @@ void ssl_serialize_session_save_buf_size(int ticket_len, char *crt_file,
 
     /* Prepare dummy session and get serialized size */
     ((void) endpoint_type);
-    ((void) tls_version);
     ((void) ticket_len);
     ((void) crt_file);
 
@@ -2250,7 +2249,6 @@ void ssl_serialize_session_load_buf_size(int ticket_len, char *crt_file,
 
     /* Prepare serialized session data */
     ((void) endpoint_type);
-    ((void) tls_version);
     ((void) ticket_len);
     ((void) crt_file);
 
@@ -2323,7 +2321,6 @@ void ssl_session_serialize_version_check(int corrupt_major,
     mbedtls_ssl_session_init(&session);
     USE_PSA_INIT();
     ((void) endpoint_type);
-    ((void) tls_version);
 
     switch (tls_version) {
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -2072,7 +2072,7 @@ void ssl_serialize_session_save_load(int ticket_len, char *crt_file,
 #if defined(MBEDTLS_SSL_SESSION_TICKETS) && defined(MBEDTLS_SSL_CLI_C)
         if (endpoint_type == MBEDTLS_SSL_IS_CLIENT) {
 #if defined(MBEDTLS_HAVE_TIME)
-            TEST_ASSERT(original.ticket_received == restored.ticket_received);
+            TEST_ASSERT(original.ticket_reception_time == restored.ticket_reception_time);
 #endif
             TEST_ASSERT(original.ticket_lifetime == restored.ticket_lifetime);
             TEST_ASSERT(original.ticket_len == restored.ticket_len);


### PR DESCRIPTION
## Description

fix #6623 

preceding-pr: #6891 

### ROOT CAUSE

TIME RESOLUTION OF TICKET AGE

The time precision of ticket_age is milliseconds(RFC 8446). But our precision is senconds, we caculate
ticket age with (mbedtls_time( NULL ) - ticket_recived)*1000 .
If the ticket is sent/received near the end of a second and client send ticket at the beggining of
next second, ticket age of client is 1000 ms, but ticket age of server is less than it. As a result,
it offends the anit replay ruler.

Workaround solution: Add 1 second to ticket_received and do reconnect 1 second later.

The issue can be reproduce and verified with https://github.com/Mbed-TLS/mbedtls/pull/6712 . That PR include test script and test result.
This PR is to fix that.

- [x] Add platform time function with milliseconds.
- [x] Change the time resolution from seconds to milliseconds for `ticket->start` and `ticket->ticket_received`

The commit is come from #6712 and verified in that PR

## Gatekeeper checklist

I am not sure if it needs backport.

- [ ] **changelog** provided, or not required
- [ ] **backport** done, or not required
- [ ] **tests** provided, or not required



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

