### PR TITLE
Update mbedtls_mpi_mod_sub() tests to incorporate mod_add test feedback

### DIFF
--- a/tests/suites/test_suite_bignum_mod.function
+++ b/tests/suites/test_suite_bignum_mod.function
@@ -108,7 +108,7 @@ exit:
 /* BEGIN_CASE */
 void mpi_mod_sub( char * input_N,
                   char * input_A, char * input_B,
-                  char * input_D, int oret )
+                  char * input_D, int expected_ret )
 {
     mbedtls_mpi_mod_residue a = { NULL, 0 };
     mbedtls_mpi_mod_residue b = { NULL, 0 };
@@ -125,46 +125,51 @@ void mpi_mod_sub( char * input_N,
     /* test_read_residue() normally checks that inputs have the same number of
      * limbs as the modulus. For negative testing we can ask it to skip this
      * with a non-zero final parameter. */
-    TEST_EQUAL( 0, test_read_residue( &a, &m, input_A, oret != 0 ) );
-    TEST_EQUAL( 0, test_read_residue( &b, &m, input_B, oret != 0 ) );
-    TEST_EQUAL( 0, test_read_residue( &d, &m, input_D, oret != 0 ) );
+    TEST_EQUAL( 0, test_read_residue( &a, &m, input_A, expected_ret != 0 ) );
+    TEST_EQUAL( 0, test_read_residue( &b, &m, input_B, expected_ret != 0 ) );
+    TEST_EQUAL( 0, test_read_residue( &d, &m, input_D, expected_ret != 0 ) );
 
     size_t limbs = m.limbs;
     size_t bytes = limbs * sizeof( *X_raw );
 
-    /* One spare limb for negative testing */
-    ASSERT_ALLOC( X_raw, limbs + 1 );
-
-    if( oret == 0 )
+    if( expected_ret == 0 )
     {
-        /* Sneak in a couple of negative tests on known-good data */
+        /* Negative test with too many limbs in output */
+        ASSERT_ALLOC( X_raw, limbs + 1 );
 
-        /* First, negative test with too many limbs in output */
         x.p = X_raw;
         x.limbs = limbs + 1;
         TEST_EQUAL( MBEDTLS_ERR_MPI_BAD_INPUT_DATA,
                     mbedtls_mpi_mod_sub( &x, &a, &b, &m ) );
 
-        /* Then negative test with too few limbs in output */
+        mbedtls_free( X_raw );
+        X_raw = NULL;
+
+        /* Negative test with too few limbs in output */
         if( limbs > 1 )
         {
+            ASSERT_ALLOC( X_raw, limbs - 1 );
+
             x.p = X_raw;
             x.limbs = limbs - 1;
             TEST_EQUAL( MBEDTLS_ERR_MPI_BAD_INPUT_DATA,
                         mbedtls_mpi_mod_sub( &x, &a, &b, &m ) );
+
+            mbedtls_free( X_raw );
+            X_raw = NULL;
         }
 
         /* Negative testing with too many/too few limbs in a and b is covered by
-         * manually-written test cases with oret != 0. */
-
-        /* Back to the normally-scheduled programme */
+         * manually-written test cases with expected_ret != 0. */
     }
+
+    ASSERT_ALLOC( X_raw, limbs );
 
     TEST_EQUAL( 0, mbedtls_mpi_mod_residue_setup( &x, &m, X_raw, limbs ) );
 
     /* a - b => Correct result, or expected error */
-    TEST_EQUAL( oret, mbedtls_mpi_mod_sub( &x, &a, &b, &m ) );
-    if( oret != 0 )
+    TEST_EQUAL( expected_ret, mbedtls_mpi_mod_sub( &x, &a, &b, &m ) );
+    if( expected_ret != 0 )
         goto exit;
 
     TEST_COMPARE_MPI_RESIDUES( x, d );


### PR DESCRIPTION
Update the mod_sub tests to incorporate feedback that was given to mod_add tests that were based on mod_sub:

- [rename `oret` to `expected_ret`](https://github.com/Mbed-TLS/mbedtls/pull/6732#discussion_r1047292056) and
- [don't over allocate, to allow memsan to catch overflows](https://github.com/Mbed-TLS/mbedtls/pull/6732#discussion_r1047286674)

## Gatekeeper checklist

- [ ] **changelog** not required - there will be a single bignum ChangeLog at some point
- [ ] **backport** not required - this work is not being backported
- [ ] **tests** this is an update to the tests
