### PR TITLE
Hide check_test_cases warnings on the CI

### DIFF
--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -870,7 +870,7 @@ component_check_test_cases () {
     else
         opt=''
     fi
-    tests/scripts/check_test_cases.py $opt
+    tests/scripts/check_test_cases.py -q $opt
     unset opt
 
     # Check that no tests are explicitely disabled when USE_PSA_CRYPTO is set


### PR DESCRIPTION
We aren't paying attention to the warnings ("Test description too long"). So hide them and save log size. Errors (which cause the test to fail) are still shown.

## Gatekeeper checklist

- [x] **changelog** no (test scripts only)
- [x] **backport** https://github.com/Mbed-TLS/mbedtls/pull/6798
- [x] **tests** no (test scripts only)
