### PR TITLE
Hide check_test_cases warnings on the CI

### DIFF
--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -833,7 +833,7 @@ component_check_test_cases () {
     else
         opt=''
     fi
-    tests/scripts/check_test_cases.py $opt
+    tests/scripts/check_test_cases.py -q $opt
     unset opt
 }
 


### PR DESCRIPTION
## Gatekeeper checklist

- [x] **changelog** no (test scripts only)
- [x] **backport** of https://github.com/Mbed-TLS/mbedtls/pull/6795
- [x] **tests** no (test scripts only)
