### PR TITLE
[Backport 2.28] Point to docker images used in the CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,8 @@ For machines with a Unix shell and OpenSSL (and optionally GnuTLS) installed, ad
 -   `tests/scripts/depends.py` test builds in configurations with a single curve, key exchange, hash, cipher, or pkalg on.
 -   `tests/scripts/all.sh` runs a combination of the above tests, plus some more, with various build options (such as ASan, full `config.h`, etc).
 
+Instead of manually installing the required versions of all tools required for testing, it is possible to use the Docker images from our CI systems, as explained in [our testing infrastructure repository](https://github.com/Mbed-TLS/mbedtls-test/blob/master/README.md#quick-start).
+
 Porting Mbed TLS
 ----------------
 

--- a/tests/compat-in-docker.sh
+++ b/tests/compat-in-docker.sh
@@ -6,6 +6,10 @@
 # -------
 # This runs compat.sh in a Docker container.
 #
+# WARNING: the Dockerfile used by this script is no longer maintained! See
+# https://github.com/Mbed-TLS/mbedtls-test/blob/master/README.md#quick-start
+# for the set of Docker images we use on the CI.
+#
 # Notes for users
 # ---------------
 # If OPENSSL_CMD, GNUTLS_CLI, or GNUTLS_SERV are specified the path must

--- a/tests/docker/bionic/Dockerfile
+++ b/tests/docker/bionic/Dockerfile
@@ -4,6 +4,10 @@
 # -------
 # Defines a Docker container suitable to build and run all tests (all.sh),
 # except for those that use a proprietary toolchain.
+#
+# WARNING: this Dockerfile is no longer maintained! See
+# https://github.com/Mbed-TLS/mbedtls-test/blob/master/README.md#quick-start
+# for the set of Docker images we use on the CI.
 
 # Copyright The Mbed TLS Contributors
 # SPDX-License-Identifier: Apache-2.0

--- a/tests/make-in-docker.sh
+++ b/tests/make-in-docker.sh
@@ -8,6 +8,10 @@
 #
 # See also:
 # - scripts/docker_env.sh for general Docker prerequisites and other information.
+#
+# WARNING: the Dockerfile used by this script is no longer maintained! See
+# https://github.com/Mbed-TLS/mbedtls-test/blob/master/README.md#quick-start
+# for the set of Docker images we use on the CI.
 
 # Copyright The Mbed TLS Contributors
 # SPDX-License-Identifier: Apache-2.0

--- a/tests/scripts/all-in-docker.sh
+++ b/tests/scripts/all-in-docker.sh
@@ -6,6 +6,10 @@
 # -------
 # This runs all.sh (except for armcc) in a Docker container.
 #
+# WARNING: the Dockerfile used by this script is no longer maintained! See
+# https://github.com/Mbed-TLS/mbedtls-test/blob/master/README.md#quick-start
+# for the set of Docker images we use on the CI.
+#
 # Notes for users
 # ---------------
 # See docker_env.sh for prerequisites and other information.

--- a/tests/scripts/basic-in-docker.sh
+++ b/tests/scripts/basic-in-docker.sh
@@ -9,6 +9,10 @@
 # in the default configuration, partial test runs in the reference
 # configurations, and some dependency tests.
 #
+# WARNING: the Dockerfile used by this script is no longer maintained! See
+# https://github.com/Mbed-TLS/mbedtls-test/blob/master/README.md#quick-start
+# for the set of Docker images we use on the CI.
+#
 # Notes for users
 # ---------------
 # See docker_env.sh for prerequisites and other information.

--- a/tests/scripts/docker_env.sh
+++ b/tests/scripts/docker_env.sh
@@ -9,6 +9,10 @@
 # thus making it easier to get set up as well as isolating test dependencies
 # (which include legacy/insecure configurations of openssl and gnutls).
 #
+# WARNING: the Dockerfile used by this script is no longer maintained! See
+# https://github.com/Mbed-TLS/mbedtls-test/blob/master/README.md#quick-start
+# for the set of Docker images we use on the CI.
+#
 # Notes for users
 # ---------------
 # This script expects a Linux x86_64 system with a recent version of Docker

--- a/tests/ssl-opt-in-docker.sh
+++ b/tests/ssl-opt-in-docker.sh
@@ -6,6 +6,10 @@
 # -------
 # This runs ssl-opt.sh in a Docker container.
 #
+# WARNING: the Dockerfile used by this script is no longer maintained! See
+# https://github.com/Mbed-TLS/mbedtls-test/blob/master/README.md#quick-start
+# for the set of Docker images we use on the CI.
+#
 # Notes for users
 # ---------------
 # If OPENSSL_CMD, GNUTLS_CLI, or GNUTLS_SERV are specified, the path must


### PR DESCRIPTION
This is the 2.28 backport of #6789 - entirely trivial.
