### PR TITLE
Fix an incorrect regex in check_names.py

### DIFF
--- a/tests/scripts/check_names.py
+++ b/tests/scripts/check_names.py
@@ -444,8 +444,11 @@ class CodeParser():
                     # Match typedefs and brackets only when they are at the
                     # beginning of the line -- if they are indented, they might
                     # be sub-structures within structs, etc.
+                    optional_c_identifier = r"([_a-zA-Z][_a-zA-Z0-9]*)?"
                     if (state == states.OUTSIDE_KEYWORD and
-                            re.search(r"^(typedef +)?enum +{", line)):
+                            re.search(r"^(typedef +)?enum " + \
+                                    optional_c_identifier + \
+                                    r" *{", line)):
                         state = states.IN_BRACES
                     elif (state == states.OUTSIDE_KEYWORD and
                           re.search(r"^(typedef +)?enum", line)):


### PR DESCRIPTION
This PR fixes nightly CI failures in the code-style preview branches.

Allow check_names.py to detect declarations of the form:

`enum some_enum_name {`

This pattern has only just appeared due to code style correction, which explains why the issue was not previously noticed.

## Gatekeeper checklist

- [ ] ~**changelog** provided, or~ not required - internal tooling, so not user facing.
- [x] **backport** done, or not required
- [ ] ~**tests** provided, or~ not required

Backport: #6811