### PR TITLE
Don't correct the style of error.c

### DIFF
--- a/scripts/code_style.py
+++ b/scripts/code_style.py
@@ -55,7 +55,8 @@ def get_src_files() -> List[str]:
         src_files = str(result.stdout, "utf-8").split()
         # Don't correct style for files in 3rdparty/
         src_files = list(filter( \
-                lambda filename: not filename.startswith("3rdparty/"), \
+                lambda filename: (not filename.startswith("3rdparty/") \
+                                  and not "error.c" in filename), \
                 src_files))
         return src_files
 


### PR DESCRIPTION
In Mbed TLS 2.28, `error.c` is listed by `git ls-files` so must be explicitly removed from the list of files to correct style of, since it is generated by a script.

This solves a failure of `check-generated-files.sh` in the code style preview nightly. Currently `error.c` is corrected by the code style script, so `check-generated-files` complains that it is not up-to-date. Fix this by not correcting `error.c`.

After this PR is merged, when the 2.28 code style preview is next updated, `error.c` will not be style-corrected and so `check-generated-files.sh` will succeed.

## Gatekeeper checklist

- [ ] ~**changelog** provided, or~ not required - internal / not user facing
- [ ] ~**backport** done, or~ not required - affects 2.28 only
- [ ] ~**tests** provided, or~ not required