### PR TITLE
Don't touch the style of generated files

### DIFF
--- a/scripts/code_style.py
+++ b/scripts/code_style.py
@@ -22,9 +22,10 @@ change of code style.
 import argparse
 import io
 import os
+import re
 import subprocess
 import sys
-from typing import List
+from typing import FrozenSet, List
 
 UNCRUSTIFY_SUPPORTED_VERSION = "0.75.1"
 CONFIG_FILE = ".uncrustify.cfg"
@@ -32,9 +33,32 @@ UNCRUSTIFY_EXE = "uncrustify"
 UNCRUSTIFY_ARGS = ["-c", CONFIG_FILE]
 STDOUT_UTF8 = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
 STDERR_UTF8 = io.TextIOWrapper(sys.stderr.buffer, encoding='utf-8')
+CHECK_GENERATED_FILES = "tests/scripts/check-generated-files.sh"
 
 def print_err(*args):
     print("Error: ", *args, file=STDERR_UTF8)
+
+# Match FILENAME(s) in "check SCRIPT (FILENAME...)"
+CHECK_CALL_RE = re.compile(r"\n\s*check\s+[^\s#$&*?;|]+([^\n#$&*?;|]+)",
+                           re.ASCII)
+def list_generated_files() -> FrozenSet[str]:
+    """Return the names of generated files.
+
+    We don't reformat generated files, since the result might be different
+    from the output of the generator. Ideally the result of the generator
+    would conform to the code style, but this would be difficult, especially
+    with respect to the placement of line breaks in long logical lines.
+    """
+    # Parse check-generated-files.sh to get an up-to-date list of
+    # generated files. Read the file rather than calling it so that
+    # this script only depends on Git, Python and uncrustify, and not other
+    # tools such as sh or grep which might not be available on Windows.
+    # This introduces a limitation: check-generated-files.sh must have
+    # the expected format and must list the files explicitly, not through
+    # wildcards or command substitution.
+    content = open(CHECK_GENERATED_FILES, encoding="utf-8").read()
+    checks = re.findall(CHECK_CALL_RE, content)
+    return frozenset(word for s in checks for word in s.split())
 
 def get_src_files() -> List[str]:
     """
@@ -52,11 +76,14 @@ def get_src_files() -> List[str]:
         print_err("git ls-files returned: " + str(result.returncode))
         return []
     else:
+        generated_files = list_generated_files()
         src_files = str(result.stdout, "utf-8").split()
-        # Don't correct style for files in 3rdparty/
-        src_files = list(filter( \
-                lambda filename: not filename.startswith("3rdparty/"), \
-                src_files))
+        # Don't correct style for third-party files (and, for simplicity,
+        # companion files in the same subtree), or for automatically
+        # generated files (we're correcting the templates instead).
+        src_files = [filename for filename in src_files
+                     if not (filename.startswith("3rdparty/") or
+                             filename in generated_files)]
         return src_files
 
 def get_uncrustify_version() -> str:

--- a/tests/scripts/check-generated-files.sh
+++ b/tests/scripts/check-generated-files.sh
@@ -116,6 +116,11 @@ check()
     fi
 }
 
+# Note: if the format of calls to the "check" function changes, update
+# scripts/code_style.py accordingly. For generated C source files (*.h or *.c),
+# the format must be "check SCRIPT FILENAME...". For other source files,
+# any shell syntax is permitted (including e.g. command substitution).
+
 check scripts/generate_errors.pl library/error.c
 check scripts/generate_query_config.pl programs/test/query_config.c
 check scripts/generate_driver_wrappers.py library/psa_crypto_driver_wrappers.c

--- a/tests/scripts/check-generated-files.sh
+++ b/tests/scripts/check-generated-files.sh
@@ -121,6 +121,11 @@ check()
 # the format must be "check SCRIPT FILENAME...". For other source files,
 # any shell syntax is permitted (including e.g. command substitution).
 
+# Note: Instructions to generate those files are replicated in:
+#   - **/Makefile (to (re)build them with make)
+#   - **/CMakeLists.txt (to (re)build them with cmake)
+#   - scripts/make_generated_files.bat (to generate them under Windows)
+
 check scripts/generate_errors.pl library/error.c
 check scripts/generate_query_config.pl programs/test/query_config.c
 check scripts/generate_driver_wrappers.py library/psa_crypto_driver_wrappers.c


### PR DESCRIPTION
Ideally the result of the generator would conform to the code style, but this would be difficult, especially with respect to the placement of line breaks in long logical lines. So, to avoid surprises when checking the style of generated files (which happens in releases and in long-time support branches), systematically skip generated files.

`code_style.py` reformats the templates, so the generated files are mostly ok. Preferably the parts that are constructed by Perl or Python code should respect the new code style (I've started on that and will make a PR later). However, generating code that conforms to the line length limit would be very difficult, and I don't propose to do that.

In development, this will prevent `check-generated-files.sh` from failing when we make a release and commit the generated files into Git, then run the CI. In 2.28, this will prevent `check-generated-files.sh` failing on the CI once the branch is built properly (regenerating files after the code style change).

There are other possible approaches. I think it would be realistic to insist on the code style of the generated files apart from the line lengths. But we'd need to test that adequately, because in the `development` branch the problem would only manifest at release time when we check the generated files into Git.

## Gatekeeper checklist

- [x] **changelog** no (not a user-visible feature)
- [x] **backport** 
- [x] **tests** manually: `scripts/code_style.py -f && tests/scripts/check-generated-files.sh -u && scripts/code_style.py >/dev/null` must succeed (no restyling after regeneration)
