### PR TITLE
pylint: Set a minimum duplicate match to 10 lines.

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,5 +1,6 @@
 [MASTER]
 init-hook='import sys; sys.path.append("scripts")'
+min-similarity-lines=10
 
 [BASIC]
 # We're ok with short funtion argument names.


### PR DESCRIPTION
This patch adjusts pylint to disregard duplicate matches for up to 10 lines.

The number is chosen to permit overriding with up to 3 identical lines for `def arguments(self)` and
`def result(self)` while two more lines for `arity` and `input_style` in the bignum test suite.

## Gatekeeper checklist

- [x] **changelog** not required
- [x] **backport** not required since it is a new feature. 
- [x] **tests** not required since the code does not change, just the tools checking it.

