### PR TITLE
Fix gettimeofday overflow

### DIFF
--- a/ChangeLog.d/fix-gettimeofday-overflow.txt
+++ b/ChangeLog.d/fix-gettimeofday-overflow.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix possible integer overflow in mbedtls_timing_hardclock(), which
+     could cause a crash in programs/test/benchmark.

--- a/programs/test/benchmark.c
+++ b/programs/test/benchmark.c
@@ -398,7 +398,7 @@ static unsigned long mbedtls_timing_hardclock( void )
     }
 
     gettimeofday( &tv_cur, NULL );
-    return( ( tv_cur.tv_sec  - tv_init.tv_sec  ) * 1000000
+    return( ( tv_cur.tv_sec  - tv_init.tv_sec  ) * 1000000U
           + ( tv_cur.tv_usec - tv_init.tv_usec ) );
 }
 #endif /* !HAVE_HARDCLOCK */


### PR DESCRIPTION
## Description

Fixes #3066. It's a (very minor) bug so probably should backport.

## Gatekeeper checklist

- [x] **changelog** provided
- [x] **backport** #6827 
- [x] **tests** not required
