### PR TITLE
Backport 2.28 - fix gettimeofday overflow

### DIFF
--- a/ChangeLog.d/fix-gettimeofday-overflow.txt
+++ b/ChangeLog.d/fix-gettimeofday-overflow.txt
@@ -1,0 +1,4 @@
+Bugfix
+   * Fix possible integer overflow in mbedtls_timing_hardclock(), which
+     could cause a crash for certain platforms & compiler options.
+

--- a/library/timing.c
+++ b/library/timing.c
@@ -223,7 +223,7 @@ unsigned long mbedtls_timing_hardclock( void )
     }
 
     gettimeofday( &tv_cur, NULL );
-    return( ( tv_cur.tv_sec  - tv_init.tv_sec  ) * 1000000
+    return( ( tv_cur.tv_sec  - tv_init.tv_sec  ) * 1000000U
           + ( tv_cur.tv_usec - tv_init.tv_usec ) );
 }
 #endif /* !HAVE_HARDCLOCK */


### PR DESCRIPTION
## Description

Backport of #6826, fixes #3066

## Gatekeeper checklist

- [x] **changelog** provided
- [x] **backport** of #6826 
- [x] **tests** not required