### PR TITLE
Improve efficiency of some constant time functions

### DIFF
--- a/include/mbedtls/build_info.h
+++ b/include/mbedtls/build_info.h
@@ -59,6 +59,13 @@
 #define inline __inline
 #endif
 
+/* Define `asm` for compilers which don't define it. */
+/* *INDENT-OFF* */
+#ifndef asm
+#define asm __asm__
+#endif
+/* *INDENT-ON* */
+
 #if !defined(MBEDTLS_CONFIG_FILE)
 #include "mbedtls/mbedtls_config.h"
 #else

--- a/include/mbedtls/build_info.h
+++ b/include/mbedtls/build_info.h
@@ -59,13 +59,6 @@
 #define inline __inline
 #endif
 
-/* Define `asm` for compilers which don't define it. */
-/* *INDENT-OFF* */
-#ifndef asm
-#define asm __asm__
-#endif
-/* *INDENT-ON* */
-
 #if !defined(MBEDTLS_CONFIG_FILE)
 #include "mbedtls/mbedtls_config.h"
 #else

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -48,8 +48,11 @@
  * Requires support for asm() in compiler.
  *
  * Used in:
+ *      library/aesni.h
  *      library/aria.c
  *      library/bn_mul.h
+ *      library/constant_time.c
+ *      library/padlock.h
  *
  * Required by:
  *      MBEDTLS_AESNI_C

--- a/library/aesni.c
+++ b/library/aesni.c
@@ -37,12 +37,6 @@
 
 #include <string.h>
 
-/* *INDENT-OFF* */
-#ifndef asm
-#define asm __asm
-#endif
-/* *INDENT-ON* */
-
 #if defined(MBEDTLS_HAVE_X86_64)
 
 /*

--- a/library/alignment.h
+++ b/library/alignment.h
@@ -29,6 +29,19 @@
 
 #include "mbedtls/build_info.h"
 
+/*
+ * Define MBEDTLS_EFFICIENT_UNALIGNED_ACCESS for architectures where unaligned memory
+ * accesses are known to be safe and efficient.
+ */
+#if defined(__ARM_FEATURE_UNALIGNED) \
+    || defined(__i386__) || defined(__amd64__) || defined(__x86_64__)
+/*
+ * __ARM_FEATURE_UNALIGNED is defined where appropriate by armcc, gcc 7, clang 9
+ * (and later versions); all x86 platforms should have efficient unaligned access.
+ */
+#define MBEDTLS_EFFICIENT_UNALIGNED_ACCESS
+#endif
+
 /**
  * Read the unsigned 16 bits integer from the given address, which need not
  * be aligned.

--- a/library/alignment.h
+++ b/library/alignment.h
@@ -31,13 +31,17 @@
 
 /*
  * Define MBEDTLS_EFFICIENT_UNALIGNED_ACCESS for architectures where unaligned memory
- * accesses are known to be safe and efficient.
+ * accesses are known to be efficient.
+ *
+ * All functions defined here will behave correctly regardless, but might be less
+ * efficient when this is not defined.
  */
 #if defined(__ARM_FEATURE_UNALIGNED) \
     || defined(__i386__) || defined(__amd64__) || defined(__x86_64__)
 /*
  * __ARM_FEATURE_UNALIGNED is defined where appropriate by armcc, gcc 7, clang 9
- * (and later versions); all x86 platforms should have efficient unaligned access.
+ * (and later versions) for Arm v7 and later; all x86 platforms should have
+ * efficient unaligned access.
  */
 #define MBEDTLS_EFFICIENT_UNALIGNED_ACCESS
 #endif

--- a/library/bn_mul.h
+++ b/library/bn_mul.h
@@ -83,10 +83,6 @@
 /* *INDENT-OFF* */
 #if defined(MBEDTLS_HAVE_ASM)
 
-#ifndef asm
-#define asm __asm
-#endif
-
 /* armcc5 --gnu defines __GNUC__ but doesn't support GNU's extended asm */
 #if defined(__GNUC__) && \
     ( !defined(__ARMCC_VERSION) || __ARMCC_VERSION >= 6000000 )

--- a/library/common.h
+++ b/library/common.h
@@ -122,11 +122,13 @@ static inline const unsigned char *mbedtls_buffer_offset_const(
  */
 inline void mbedtls_xor(unsigned char *r, const unsigned char *a, const unsigned char *b, size_t n)
 {
-    size_t i;
-    for (i = 0; (i + 4) <= n; i += 4) {
+    size_t i = 0;
+#if defined(MBEDTLS_EFFICIENT_UNALIGNED_ACCESS)
+    for (; (i + 4) <= n; i += 4) {
         uint32_t x = mbedtls_get_unaligned_uint32(a + i) ^ mbedtls_get_unaligned_uint32(b + i);
         mbedtls_put_unaligned_uint32(r + i, x);
     }
+#endif
     for (; i < n; i++) {
         r[i] = a[i] ^ b[i];
     }

--- a/library/common.h
+++ b/library/common.h
@@ -142,4 +142,11 @@ inline void mbedtls_xor(unsigned char *r, const unsigned char *a, const unsigned
 #define /*no-check-names*/ __func__ __FUNCTION__
 #endif
 
+/* Define `asm` for compilers which don't define it. */
+/* *INDENT-OFF* */
+#ifndef asm
+#define asm __asm__
+#endif
+/* *INDENT-ON* */
+
 #endif /* MBEDTLS_LIBRARY_COMMON_H */

--- a/library/constant_time.c
+++ b/library/constant_time.c
@@ -48,15 +48,6 @@
 #include <string.h>
 
 /*
- * Define MBEDTLS_EFFICIENT_UNALIGNED_ACCESS for architectures where unaligned memory
- * accesses are known to be safe and efficient.
- */
-#if defined(__ARM_FEATURE_UNALIGNED)
-/* __ARM_FEATURE_UNALIGNED is defined by armcc, gcc 7, clang 9 and later versions */
-#define MBEDTLS_EFFICIENT_UNALIGNED_ACCESS
-#endif
-
-/*
  * Define MBEDTLS_EFFICIENT_UNALIGNED_VOLATILE_ACCESS where assembly is present to
  * perform fast unaligned access to volatile data.
  *

--- a/library/constant_time.c
+++ b/library/constant_time.c
@@ -85,9 +85,15 @@ int mbedtls_ct_memcmp(const void *a,
                       size_t n)
 {
     size_t i = 0;
+    /*
+     * `A` and `B` are cast to volatile to ensure that the compiler
+     * generates code that always fully reads both buffers.
+     * Otherwise it could generate a test to exit early if `diff` has all
+     * bits set early in the loop.
+     */
     volatile const unsigned char *A = (volatile const unsigned char *) a;
     volatile const unsigned char *B = (volatile const unsigned char *) b;
-    volatile uint32_t diff = 0;
+    uint32_t diff = 0;
 
 #if defined(MBEDTLS_EFFICIENT_UNALIGNED_VOLATILE_ACCESS)
     for (; (i + 4) <= n; i += 4) {

--- a/library/padlock.c
+++ b/library/padlock.c
@@ -31,12 +31,6 @@
 
 #include <string.h>
 
-/* *INDENT-OFF* */
-#ifndef asm
-#define asm __asm
-#endif
-/* *INDENT-ON* */
-
 #if defined(MBEDTLS_HAVE_X86)
 
 /*

--- a/library/sha256.c
+++ b/library/sha256.c
@@ -89,12 +89,6 @@ static int mbedtls_a64_crypto_sha256_determine_support(void)
 #include <signal.h>
 #include <setjmp.h>
 
-/* *INDENT-OFF* */
-#ifndef asm
-#define asm __asm__
-#endif
-/* *INDENT-ON* */
-
 static jmp_buf return_from_sigill;
 
 /*

--- a/library/sha512.c
+++ b/library/sha512.c
@@ -104,12 +104,6 @@ static int mbedtls_a64_crypto_sha512_determine_support(void)
 #include <signal.h>
 #include <setjmp.h>
 
-/* *INDENT-OFF* */
-#ifndef asm
-#define asm __asm__
-#endif
-/* *INDENT-ON* */
-
 static jmp_buf return_from_sigill;
 
 /*
@@ -299,12 +293,6 @@ static const uint64_t K[80] =
 #  define mbedtls_internal_sha512_process_many_a64_crypto mbedtls_internal_sha512_process_many
 #  define mbedtls_internal_sha512_process_a64_crypto      mbedtls_internal_sha512_process
 #endif
-
-/* *INDENT-OFF* */
-#ifndef asm
-#define asm __asm__
-#endif
-/* *INDENT-ON* */
 
 /* Accelerated SHA-512 implementation originally written by Simon Tatham for PuTTY,
  * under the MIT licence; dual-licensed as Apache 2 with his kind permission.

--- a/tests/suites/test_suite_alignment.function
+++ b/tests/suites/test_suite_alignment.function
@@ -6,7 +6,6 @@
 #if defined(__clang__)
 #pragma clang diagnostic ignored "-Wunreachable-code"
 #endif
-#include <stdio.h>
 
 /*
  * Convert a string of the form "abcd" (case-insensitive) to a uint64_t.

--- a/tests/suites/test_suite_constant_time.data
+++ b/tests/suites/test_suite_constant_time.data
@@ -9,3 +9,111 @@ ssl_cf_memcpy_offset:0:255:32
 # we could get this with 255-bytes plaintext and untruncated SHA-384
 Constant-flow memcpy from offset: large
 ssl_cf_memcpy_offset:100:339:48
+
+mbedtls_ct_memcmp NULL
+mbedtls_ct_memcmp_null
+
+mbedtls_ct_memcmp len 1
+mbedtls_ct_memcmp:1:1:0
+
+mbedtls_ct_memcmp len 3
+mbedtls_ct_memcmp:1:3:0
+
+mbedtls_ct_memcmp len 4
+mbedtls_ct_memcmp:1:4:0
+
+mbedtls_ct_memcmp len 5
+mbedtls_ct_memcmp:1:5:0
+
+mbedtls_ct_memcmp len 15
+mbedtls_ct_memcmp:1:15:0
+
+mbedtls_ct_memcmp len 16
+mbedtls_ct_memcmp:1:16:0
+
+mbedtls_ct_memcmp len 17
+mbedtls_ct_memcmp:1:17:0
+
+mbedtls_ct_memcmp len 1 different
+mbedtls_ct_memcmp:0:1:0
+
+mbedtls_ct_memcmp len 17 different
+mbedtls_ct_memcmp:0:17:0
+
+mbedtls_ct_memcmp len 1 offset 1 different
+mbedtls_ct_memcmp:0:1:1
+
+mbedtls_ct_memcmp len 17 offset 1 different
+mbedtls_ct_memcmp:0:17:1
+
+mbedtls_ct_memcmp len 1 offset 1
+mbedtls_ct_memcmp:1:1:1
+
+mbedtls_ct_memcmp len 1 offset 2
+mbedtls_ct_memcmp:1:1:2
+
+mbedtls_ct_memcmp len 1 offset 3
+mbedtls_ct_memcmp:1:1:3
+
+mbedtls_ct_memcmp len 5 offset 1
+mbedtls_ct_memcmp:1:5:1
+
+mbedtls_ct_memcmp len 5 offset 2
+mbedtls_ct_memcmp:1:5:2
+
+mbedtls_ct_memcmp len 5 offset 3
+mbedtls_ct_memcmp:1:5:3
+
+mbedtls_ct_memcmp len 17 offset 1
+mbedtls_ct_memcmp:1:17:1
+
+mbedtls_ct_memcmp len 17 offset 2
+mbedtls_ct_memcmp:1:17:2
+
+mbedtls_ct_memcmp len 17 offset 3
+mbedtls_ct_memcmp:1:17:3
+
+mbedtls_ct_memcpy_if_eq len 1 offset 0
+mbedtls_ct_memcpy_if_eq:1:1:0
+
+mbedtls_ct_memcpy_if_eq len 1 offset 1
+mbedtls_ct_memcpy_if_eq:1:1:1
+
+mbedtls_ct_memcpy_if_eq len 4 offset 0
+mbedtls_ct_memcpy_if_eq:1:1:0
+
+mbedtls_ct_memcpy_if_eq len 4 offset 1
+mbedtls_ct_memcpy_if_eq:1:1:1
+
+mbedtls_ct_memcpy_if_eq len 4 offset 2
+mbedtls_ct_memcpy_if_eq:1:1:2
+
+mbedtls_ct_memcpy_if_eq len 4 offset 3
+mbedtls_ct_memcpy_if_eq:1:1:3
+
+mbedtls_ct_memcpy_if_eq len 15 offset 0
+mbedtls_ct_memcpy_if_eq:1:15:0
+
+mbedtls_ct_memcpy_if_eq len 15 offset 1
+mbedtls_ct_memcpy_if_eq:1:15:1
+
+mbedtls_ct_memcpy_if_eq len 16 offset 0
+mbedtls_ct_memcpy_if_eq:1:16:0
+
+mbedtls_ct_memcpy_if_eq len 16 offset 1
+mbedtls_ct_memcpy_if_eq:1:16:1
+
+mbedtls_ct_memcpy_if_eq len 17 offset 0
+mbedtls_ct_memcpy_if_eq:1:17:0
+
+mbedtls_ct_memcpy_if_eq len 17 offset 1
+mbedtls_ct_memcpy_if_eq:1:17:1
+
+mbedtls_ct_memcpy_if_eq len 0 not eq
+mbedtls_ct_memcpy_if_eq:0:17:0
+
+mbedtls_ct_memcpy_if_eq len 5 offset 1 not eq
+mbedtls_ct_memcpy_if_eq:0:5:1
+
+mbedtls_ct_memcpy_if_eq len 17 offset 3 not eq
+mbedtls_ct_memcpy_if_eq:0:17:3

--- a/tests/suites/test_suite_constant_time.data
+++ b/tests/suites/test_suite_constant_time.data
@@ -14,25 +14,25 @@ mbedtls_ct_memcmp NULL
 mbedtls_ct_memcmp_null
 
 mbedtls_ct_memcmp len 1
-mbedtls_ct_memcmp:1:1:0
+mbedtls_ct_memcmp:-1:1:0
 
 mbedtls_ct_memcmp len 3
-mbedtls_ct_memcmp:1:3:0
+mbedtls_ct_memcmp:-1:3:0
 
 mbedtls_ct_memcmp len 4
-mbedtls_ct_memcmp:1:4:0
+mbedtls_ct_memcmp:-1:4:0
 
 mbedtls_ct_memcmp len 5
-mbedtls_ct_memcmp:1:5:0
+mbedtls_ct_memcmp:-1:5:0
 
 mbedtls_ct_memcmp len 15
-mbedtls_ct_memcmp:1:15:0
+mbedtls_ct_memcmp:-1:15:0
 
 mbedtls_ct_memcmp len 16
-mbedtls_ct_memcmp:1:16:0
+mbedtls_ct_memcmp:-1:16:0
 
 mbedtls_ct_memcmp len 17
-mbedtls_ct_memcmp:1:17:0
+mbedtls_ct_memcmp:-1:17:0
 
 mbedtls_ct_memcmp len 1 different
 mbedtls_ct_memcmp:0:1:0
@@ -40,38 +40,56 @@ mbedtls_ct_memcmp:0:1:0
 mbedtls_ct_memcmp len 17 different
 mbedtls_ct_memcmp:0:17:0
 
+mbedtls_ct_memcmp len 17 different 1
+mbedtls_ct_memcmp:1:17:0
+
+mbedtls_ct_memcmp len 17 different 4
+mbedtls_ct_memcmp:4:17:0
+
+mbedtls_ct_memcmp len 17 different 10
+mbedtls_ct_memcmp:10:17:0
+
+mbedtls_ct_memcmp len 17 different 16
+mbedtls_ct_memcmp:16:17:0
+
 mbedtls_ct_memcmp len 1 offset 1 different
 mbedtls_ct_memcmp:0:1:1
 
 mbedtls_ct_memcmp len 17 offset 1 different
 mbedtls_ct_memcmp:0:17:1
 
-mbedtls_ct_memcmp len 1 offset 1
-mbedtls_ct_memcmp:1:1:1
-
-mbedtls_ct_memcmp len 1 offset 2
-mbedtls_ct_memcmp:1:1:2
-
-mbedtls_ct_memcmp len 1 offset 3
-mbedtls_ct_memcmp:1:1:3
-
-mbedtls_ct_memcmp len 5 offset 1
-mbedtls_ct_memcmp:1:5:1
-
-mbedtls_ct_memcmp len 5 offset 2
-mbedtls_ct_memcmp:1:5:2
-
-mbedtls_ct_memcmp len 5 offset 3
-mbedtls_ct_memcmp:1:5:3
-
-mbedtls_ct_memcmp len 17 offset 1
+mbedtls_ct_memcmp len 17 offset 1 different 1
 mbedtls_ct_memcmp:1:17:1
 
+mbedtls_ct_memcmp len 17 offset 1 different 5
+mbedtls_ct_memcmp:5:17:1
+
+mbedtls_ct_memcmp len 1 offset 1
+mbedtls_ct_memcmp:-1:1:1
+
+mbedtls_ct_memcmp len 1 offset 2
+mbedtls_ct_memcmp:-1:1:2
+
+mbedtls_ct_memcmp len 1 offset 3
+mbedtls_ct_memcmp:-1:1:3
+
+mbedtls_ct_memcmp len 5 offset 1
+mbedtls_ct_memcmp:-1:5:1
+
+mbedtls_ct_memcmp len 5 offset 2
+mbedtls_ct_memcmp:-1:5:2
+
+mbedtls_ct_memcmp len 5 offset 3
+mbedtls_ct_memcmp:-1:5:3
+
+mbedtls_ct_memcmp len 17 offset 1
+mbedtls_ct_memcmp:-1:17:1
+
 mbedtls_ct_memcmp len 17 offset 2
-mbedtls_ct_memcmp:1:17:2
+mbedtls_ct_memcmp:-1:17:2
 
 mbedtls_ct_memcmp len 17 offset 3
-mbedtls_ct_memcmp:1:17:3
+mbedtls_ct_memcmp:-1:17:3
 
 mbedtls_ct_memcpy_if_eq len 1 offset 0
 mbedtls_ct_memcpy_if_eq:1:1:0

--- a/tests/suites/test_suite_constant_time.function
+++ b/tests/suites/test_suite_constant_time.function
@@ -80,7 +80,17 @@ void mbedtls_ct_memcpy_if_eq(int eq, int size, int offset)
         expected[i] = eq ? 1 : 0xff;
     }
 
-    mbedtls_ct_memcpy_if_eq(result + offset, src, size, eq, 1);
+    int one, secret_eq;
+    TEST_CF_SECRET(&one, sizeof(one));
+    TEST_CF_SECRET(&secret_eq,  sizeof(secret_eq));
+    one = 1;
+    secret_eq = eq;
+
+    mbedtls_ct_memcpy_if_eq(result + offset, src, size, secret_eq, one);
+
+    TEST_CF_PUBLIC(&one, sizeof(one));
+    TEST_CF_PUBLIC(&secret_eq, sizeof(secret_eq));
+
     ASSERT_COMPARE(expected, size, result + offset, size);
 
     for (int i = 0; i < size + offset; i++) {
@@ -88,9 +98,18 @@ void mbedtls_ct_memcpy_if_eq(int eq, int size, int offset)
         result[i] = 0xff;
         expected[i] = eq ? 1 : 0xff;
     }
-    mbedtls_ct_memcpy_if_eq(result, src + offset, size, eq, 1);
-    ASSERT_COMPARE(expected, size, result, size);
 
+    TEST_CF_SECRET(&one, sizeof(one));
+    TEST_CF_SECRET(&secret_eq,  sizeof(secret_eq));
+    one = 1;
+    secret_eq = eq;
+
+    mbedtls_ct_memcpy_if_eq(result, src + offset, size, secret_eq, one);
+
+    TEST_CF_PUBLIC(&one, sizeof(one));
+    TEST_CF_PUBLIC(&secret_eq, sizeof(secret_eq));
+
+    ASSERT_COMPARE(expected, size, result, size);
 exit:
     mbedtls_free(src);
     mbedtls_free(result);

--- a/tests/suites/test_suite_constant_time.function
+++ b/tests/suites/test_suite_constant_time.function
@@ -35,9 +35,17 @@ void mbedtls_ct_memcmp(int same, int size, int offset)
     TEST_CF_SECRET(a + offset, size);
     TEST_CF_SECRET(b + offset, size);
 
+    /* Construct data that matches, if same == -1, otherwise
+     * same gives the number of bytes (after the initial offset)
+     * that will match; after that it will differ.
+     */
     for (int i = 0; i < size + offset; i++) {
         a[i] = i & 0xff;
-        b[i] = (i & 0xff) + (same ? 0 : 1);
+        if (same == -1 || (i - offset) < same) {
+            b[i] = a[i];
+        } else {
+            b[i] = (i + 1) & 0xff;
+        }
     }
 
     int reference = memcmp(a + offset, b + offset, size);
@@ -45,7 +53,7 @@ void mbedtls_ct_memcmp(int same, int size, int offset)
     TEST_CF_PUBLIC(a + offset, size);
     TEST_CF_PUBLIC(b + offset, size);
 
-    if (same != 0) {
+    if (same == -1 || same >= size) {
         TEST_ASSERT(reference == 0);
         TEST_ASSERT(actual == 0);
     } else {

--- a/tests/suites/test_suite_constant_time.function
+++ b/tests/suites/test_suite_constant_time.function
@@ -15,6 +15,83 @@
 #include <test/constant_flow.h>
 /* END_HEADER */
 
+#include <stdio.h>
+
+/* BEGIN_CASE */
+void mbedtls_ct_memcmp_null()
+{
+    uint32_t x;
+    TEST_ASSERT(mbedtls_ct_memcmp(&x, NULL, 0) == 0);
+    TEST_ASSERT(mbedtls_ct_memcmp(NULL, &x, 0) == 0);
+    TEST_ASSERT(mbedtls_ct_memcmp(NULL, NULL, 0) == 0);
+}
+/* END_CASE */
+
+/* BEGIN_CASE */
+void mbedtls_ct_memcmp(int same, int size, int offset)
+{
+    uint8_t *a = NULL, *b = NULL;
+    ASSERT_ALLOC(a, size + offset);
+    ASSERT_ALLOC(b, size + offset);
+
+    TEST_CF_SECRET(a + offset, size);
+    TEST_CF_SECRET(b + offset, size);
+
+    for (int i = 0; i < size + offset; i++) {
+        a[i] = i & 0xff;
+        b[i] = (i & 0xff) + (same ? 0 : 1);
+    }
+
+    int reference = memcmp(a + offset, b + offset, size);
+    int actual = mbedtls_ct_memcmp(a + offset, b + offset, size);
+    TEST_CF_PUBLIC(a + offset, size);
+    TEST_CF_PUBLIC(b + offset, size);
+
+    if (same != 0) {
+        TEST_ASSERT(reference == 0);
+        TEST_ASSERT(actual == 0);
+    } else {
+        TEST_ASSERT(reference != 0);
+        TEST_ASSERT(actual != 0);
+    }
+exit:
+    mbedtls_free(a);
+    mbedtls_free(b);
+}
+/* END_CASE */
+
+/* BEGIN_CASE depends_on:MBEDTLS_SSL_SOME_SUITES_USE_MAC */
+void mbedtls_ct_memcpy_if_eq(int eq, int size, int offset)
+{
+    uint8_t *src = NULL, *result = NULL, *expected = NULL;
+    ASSERT_ALLOC(src, size + offset);
+    ASSERT_ALLOC(result, size + offset);
+    ASSERT_ALLOC(expected, size + offset);
+
+    for (int i = 0; i < size + offset; i++) {
+        src[i]    = 1;
+        result[i] = 0xff;
+        expected[i] = eq ? 1 : 0xff;
+    }
+
+    mbedtls_ct_memcpy_if_eq(result + offset, src, size, eq, 1);
+    ASSERT_COMPARE(expected, size, result + offset, size);
+
+    for (int i = 0; i < size + offset; i++) {
+        src[i]    = 1;
+        result[i] = 0xff;
+        expected[i] = eq ? 1 : 0xff;
+    }
+    mbedtls_ct_memcpy_if_eq(result, src + offset, size, eq, 1);
+    ASSERT_COMPARE(expected, size, result, size);
+
+exit:
+    mbedtls_free(src);
+    mbedtls_free(result);
+    mbedtls_free(expected);
+}
+/* END_CASE */
+
 /* BEGIN_CASE depends_on:MBEDTLS_SSL_SOME_SUITES_USE_TLS_CBC:MBEDTLS_TEST_HOOKS */
 void ssl_cf_memcpy_offset(int offset_min, int offset_max, int len)
 {

--- a/tests/suites/test_suite_constant_time.function
+++ b/tests/suites/test_suite_constant_time.function
@@ -15,8 +15,6 @@
 #include <test/constant_flow.h>
 /* END_HEADER */
 
-#include <stdio.h>
-
 /* BEGIN_CASE */
 void mbedtls_ct_memcmp_null()
 {


### PR DESCRIPTION
Follow-up to #6666 - improve efficiency of our constant time memcmp and memcpy implementations.

## Gatekeeper checklist

- [x] **changelog** not required (covered by changelog entry from #6666)
- [x] **backport** not required
- [x] **tests** added tests for these functions