### PR TITLE
Backport 2.28: code_style.py: Support restyling only the specified files

### DIFF
--- a/scripts/code_style.py
+++ b/scripts/code_style.py
@@ -171,8 +171,8 @@ def main() -> int:
     # --files is almost useless: it only matters if there are no files
     # ('code_style.py' without arguments checks all files known to Git,
     # 'code_style.py --files' does nothing). In particular,
-    # 'code_style.py --files ...' is intended as a stable ("porcelain") way
-    # to restyle a possibly empty set of files.
+    # 'code_style.py --fix --files ...' is intended as a stable ("porcelain")
+    # way to restyle a possibly empty set of files.
     parser.add_argument('--files', action='store_true',
                         help='only check the specified files (default with non-option arguments)')
     parser.add_argument('operands', nargs='*', metavar='FILE',

--- a/scripts/code_style.py
+++ b/scripts/code_style.py
@@ -163,13 +163,25 @@ def main() -> int:
                 + uncrustify_version + "' (Note: The only supported version" \
                 "is " + UNCRUSTIFY_SUPPORTED_VERSION + ")", file=STDOUT_UTF8)
 
-    src_files = get_src_files()
-
     parser = argparse.ArgumentParser()
-    parser.add_argument('-f', '--fix', action='store_true', \
-            help='modify source files to fix the code style')
+    parser.add_argument('-f', '--fix', action='store_true',
+                        help='modify source files to fix the code style')
+    # --files is almost useless: it only matters if there are no files
+    # ('code_style.py' without arguments checks all files known to Git,
+    # 'code_style.py --files' does nothing). 'code_style.py --files ...' is
+    # intended as a stable ("porcelain") way to restyle a possibly empty
+    # set of files.
+    parser.add_argument('--files', action='store_true',
+                        help='only check the specified files (default with non-option arguments)')
+    parser.add_argument('operands', nargs='*', metavar='FILE',
+                        help='files to check (if none: check files that are known to git)')
 
     args = parser.parse_args()
+
+    if args.files or args.operands:
+        src_files = args.operands
+    else:
+        src_files = get_src_files()
 
     if args.fix:
         # Fix mode

--- a/scripts/code_style.py
+++ b/scripts/code_style.py
@@ -159,18 +159,20 @@ def main() -> int:
     """
     uncrustify_version = get_uncrustify_version().strip()
     if UNCRUSTIFY_SUPPORTED_VERSION not in uncrustify_version:
-        print("Warning: Using unsupported Uncrustify version '" \
-                + uncrustify_version + "' (Note: The only supported version" \
-                "is " + UNCRUSTIFY_SUPPORTED_VERSION + ")", file=STDOUT_UTF8)
+        print("Warning: Using unsupported Uncrustify version '" +
+              uncrustify_version + "'", file=STDOUT_UTF8)
+        print("Note: The only supported version is " +
+              UNCRUSTIFY_SUPPORTED_VERSION, file=STDOUT_UTF8)
 
     parser = argparse.ArgumentParser()
     parser.add_argument('-f', '--fix', action='store_true',
-                        help='modify source files to fix the code style')
+                        help=('modify source files to fix the code style '
+                              '(default: print diff, do not modify files)'))
     # --files is almost useless: it only matters if there are no files
     # ('code_style.py' without arguments checks all files known to Git,
-    # 'code_style.py --files' does nothing). 'code_style.py --files ...' is
-    # intended as a stable ("porcelain") way to restyle a possibly empty
-    # set of files.
+    # 'code_style.py --files' does nothing). In particular,
+    # 'code_style.py --files ...' is intended as a stable ("porcelain") way
+    # to restyle a possibly empty set of files.
     parser.add_argument('--files', action='store_true',
                         help='only check the specified files (default with non-option arguments)')
     parser.add_argument('operands', nargs='*', metavar='FILE',


### PR DESCRIPTION
## Gatekeeper checklist

- [x] **changelog** no (maintenance script only)
- [x] **backport** of https://github.com/Mbed-TLS/mbedtls/pull/6834
- [x] **tests** no (maintenance script only)
