### PR TITLE
Tweak code style to be more like K&R

### DIFF
--- a/.uncrustify.cfg
+++ b/.uncrustify.cfg
@@ -187,8 +187,8 @@ sp_before_comma = remove
 # No space before the ':' in a case statement
 sp_before_case_colon = remove
 
-# No space after a cast - '(char) x' -> '(char)x'
-sp_after_cast = remove
+# Must have space after a cast - '(char)x' -> '(char) x'
+sp_after_cast = add
 
 # No space between 'sizeof' and '('
 sp_sizeof_paren = remove


### PR DESCRIPTION
* Require a space after a cast.

## Gatekeeper checklist

- [x] **changelog** no (internal stuff)
- [x] **backport** https://github.com/Mbed-TLS/mbedtls/pull/6837
- [x] **tests** (smoke-tested by `all.sh test_corrected_code_style`, then confirmed indirectly via [the preview branch](https://github.com/Mbed-TLS/mbedtls/pull/6758))
