### PR TITLE
Backport 2.28: Tweak code style to be more like K&R

### DIFF
--- a/.uncrustify.cfg
+++ b/.uncrustify.cfg
@@ -187,8 +187,8 @@ sp_before_comma = remove
 # No space before the ':' in a case statement
 sp_before_case_colon = remove
 
-# No space after a cast - '(char) x' -> '(char)x'
-sp_after_cast = remove
+# Must have space after a cast - '(char)x' -> '(char) x'
+sp_after_cast = add
 
 # No space between 'sizeof' and '('
 sp_sizeof_paren = remove


### PR DESCRIPTION
## Gatekeeper checklist

- [x] **changelog** no (internal stuff)
- [x] **backport** of https://github.com/Mbed-TLS/mbedtls/pull/6836
- [x] **tests** (smoke-tested by `all.sh test_corrected_code_style`, then confirmed indirectly via [the preview branch](https://github.com/Mbed-TLS/mbedtls/pull/6758))
