### PR TITLE
Workaround Uncrustify parsing of "asm"

### DIFF
--- a/library/aesni.c
+++ b/library/aesni.c
@@ -36,9 +36,11 @@
 
 #include <string.h>
 
+/* *INDENT-OFF* */
 #ifndef asm
 #define asm __asm
 #endif
+/* *INDENT-ON* */
 
 #if defined(MBEDTLS_HAVE_X86_64)
 

--- a/library/bn_mul.h
+++ b/library/bn_mul.h
@@ -82,9 +82,11 @@
 
 #if defined(MBEDTLS_HAVE_ASM)
 
+/* *INDENT-OFF* */
 #ifndef asm
 #define asm __asm
 #endif
+/* *INDENT-ON* */
 
 /* armcc5 --gnu defines __GNUC__ but doesn't support GNU's extended asm */
 #if defined(__GNUC__) && \

--- a/library/padlock.c
+++ b/library/padlock.c
@@ -31,9 +31,11 @@
 
 #include <string.h>
 
+/* *INDENT-OFF* */
 #ifndef asm
 #define asm __asm
 #endif
+/* *INDENT-ON* */
 
 #if defined(MBEDTLS_HAVE_X86)
 

--- a/library/sha256.c
+++ b/library/sha256.c
@@ -89,9 +89,11 @@ static int mbedtls_a64_crypto_sha256_determine_support( void )
 #include <signal.h>
 #include <setjmp.h>
 
+/* *INDENT-OFF* */
 #ifndef asm
 #define asm __asm__
 #endif
+/* *INDENT-ON* */
 
 static jmp_buf return_from_sigill;
 

--- a/library/sha512.c
+++ b/library/sha512.c
@@ -104,9 +104,11 @@ static int mbedtls_a64_crypto_sha512_determine_support( void )
 #include <signal.h>
 #include <setjmp.h>
 
+/* *INDENT-OFF* */
 #ifndef asm
 #define asm __asm__
 #endif
+/* *INDENT-ON* */
 
 static jmp_buf return_from_sigill;
 
@@ -297,9 +299,11 @@ static const uint64_t K[80] =
 #  define mbedtls_internal_sha512_process_a64_crypto      mbedtls_internal_sha512_process
 #endif
 
+/* *INDENT-OFF* */
 #ifndef asm
 #define asm __asm__
 #endif
+/* *INDENT-ON* */
 
 /* Accelerated SHA-512 implementation originally written by Simon Tatham for PuTTY,
  * under the MIT licence; dual-licensed as Apache 2 with his kind permission.

--- a/programs/test/benchmark.c
+++ b/programs/test/benchmark.c
@@ -61,9 +61,11 @@ int main( void )
 
 #include "mbedtls/error.h"
 
+/* *INDENT-OFF* */
 #ifndef asm
 #define asm __asm
 #endif
+/* *INDENT-ON* */
 
 #if defined(_WIN32) && !defined(EFIX64) && !defined(EFI32)
 


### PR DESCRIPTION
Fixes #6845.

Backport: #6869

The following code:

 ```c
 #ifndef asm
 #define asm __asm
 #endif
```

causes Uncrustify to stop correcting the rest of the file. This may be due to parsing the "asm" keyword in the definition.

Work around this by wrapping the idiom in an *INDENT-OFF* comment wherever it appears.

## Gatekeeper checklist

- [ ] ~**changelog** provided, or~ not required (developer-facing)
- [x] **backport** done, or not required
- [ ] ~**tests** provided, or~ not required
