### PR TITLE
[Backport 2.28] Workaround Uncrustify parsing of "asm"

### DIFF
--- a/include/mbedtls/bn_mul.h
+++ b/include/mbedtls/bn_mul.h
@@ -86,9 +86,11 @@
 
 #if defined(MBEDTLS_HAVE_ASM)
 
+/* *INDENT-OFF* */
 #ifndef asm
 #define asm __asm
 #endif
+/* *INDENT-ON* */
 
 /* armcc5 --gnu defines __GNUC__ but doesn't support GNU's extended asm */
 #if defined(__GNUC__) && \

--- a/library/aesni.c
+++ b/library/aesni.c
@@ -36,9 +36,11 @@
 
 #include <string.h>
 
+/* *INDENT-OFF* */
 #ifndef asm
 #define asm __asm
 #endif
+/* *INDENT-ON* */
 
 #if defined(MBEDTLS_HAVE_X86_64)
 

--- a/library/padlock.c
+++ b/library/padlock.c
@@ -31,9 +31,11 @@
 
 #include <string.h>
 
+/* *INDENT-OFF* */
 #ifndef asm
 #define asm __asm
 #endif
+/* *INDENT-ON* */
 
 #if defined(MBEDTLS_HAVE_X86)
 

--- a/library/timing.c
+++ b/library/timing.c
@@ -33,9 +33,11 @@
 #error "This module only works on Unix and Windows, see MBEDTLS_TIMING_C in config.h"
 #endif
 
+/* *INDENT-OFF* */
 #ifndef asm
 #define asm __asm
 #endif
+/* *INDENT-ON* */
 
 #if defined(_WIN32) && !defined(EFIX64) && !defined(EFI32)
 


### PR DESCRIPTION
Backport of #6868.

The following code:
```c
 #ifndef asm
 #define asm __asm
 #endif
```
causes Uncrustify to stop correcting the rest of the file. This may be due to parsing the "asm" keyword in the definition.

Work around this by wrapping the idiom in an *INDENT-OFF* comment wherever it appears.