### PR TITLE
Fix test function derive_key_exercise()

### DIFF
--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -7946,7 +7946,7 @@ void derive_key_exercise( int alg_arg,
                                 &base_key ) );
 
     /* Derive a key. */
-    if ( mbedtls_test_psa_setup_key_derivation_wrap( &operation, base_key, alg,
+    if ( !mbedtls_test_psa_setup_key_derivation_wrap( &operation, base_key, alg,
                                                      input1->x, input1->len,
                                                      input2->x, input2->len,
                                                      capacity ) )


### PR DESCRIPTION
`mbedtls_test_psa_setup_key_derivation_wrap()` returns 1 for success, 0 for error, so the test here was wrong. Other uses of this function in the same file have the correct check (either `!` or `== 0`). This was causing tests using `derive_key_exercises()` to be marked as PASS even in [builds where other derive key tests fail](https://github.com/Mbed-TLS/mbedtls/issues/6839#issuecomment-1370855076) which made me notice.

## Gatekeeper checklist

- [x] **changelog** not required - test only
- [x] **backport** #6880
- [x] **tests** provided - the PR is fixing one


