### PR TITLE
Check for Uncrustify errors in `code_style.py`

### DIFF
--- a/library/bn_mul.h
+++ b/library/bn_mul.h
@@ -1005,7 +1005,6 @@
 #endif /* MSVC */
 
 #endif /* MBEDTLS_HAVE_ASM */
-/* *INDENT-ON* */
 
 #if !defined(MULADDC_X1_CORE)
 #if defined(MBEDTLS_HAVE_UDBL)
@@ -1073,4 +1072,5 @@
 #define MULADDC_X8_CORE MULADDC_X4_CORE MULADDC_X4_CORE
 #endif /* MULADDC_X8_CORE */
 
+/* *INDENT-ON* */
 #endif /* bn_mul.h */

--- a/library/bn_mul.h
+++ b/library/bn_mul.h
@@ -80,13 +80,12 @@
 
 #endif /* bits in mbedtls_mpi_uint */
 
+/* *INDENT-OFF* */
 #if defined(MBEDTLS_HAVE_ASM)
 
-/* *INDENT-OFF* */
 #ifndef asm
 #define asm __asm
 #endif
-/* *INDENT-ON* */
 
 /* armcc5 --gnu defines __GNUC__ but doesn't support GNU's extended asm */
 #if defined(__GNUC__) && \
@@ -1006,6 +1005,7 @@
 #endif /* MSVC */
 
 #endif /* MBEDTLS_HAVE_ASM */
+/* *INDENT-ON* */
 
 #if !defined(MULADDC_X1_CORE)
 #if defined(MBEDTLS_HAVE_UDBL)

--- a/scripts/code_style.py
+++ b/scripts/code_style.py
@@ -132,7 +132,7 @@ def check_style_is_correct(src_file_list: List[str]) -> bool:
 
     return style_correct
 
-def fix_style_single_pass(src_file_list: List[str]) -> None:
+def fix_style_single_pass(src_file_list: List[str]) -> bool:
     """
     Run Uncrustify once over the source files.
     """
@@ -146,6 +146,7 @@ def fix_style_single_pass(src_file_list: List[str]) -> None:
                     str(result.returncode) + " correcting file " + \
                     src_file)
             return False
+    return True
 
 def fix_style(src_file_list: List[str]) -> int:
     """

--- a/scripts/code_style.py
+++ b/scripts/code_style.py
@@ -152,9 +152,9 @@ def fix_style(src_file_list: List[str]) -> int:
     """
     Fix the code style. This takes 2 passes of Uncrustify.
     """
-    if fix_style_single_pass(src_file_list) != True:
+    if not fix_style_single_pass(src_file_list):
         return 1
-    if fix_style_single_pass(src_file_list) != True:
+    if not fix_style_single_pass(src_file_list):
         return 1
 
     # Guard against future changes that cause the codebase to require


### PR DESCRIPTION
Check the returncode of Uncrustify when fixing code style. This means that unparseable files cause checking or correction to fail.

The inline assembly defined in `bn_mul.h` confuses code style parsing, causing code style correction to fail. Disable code style correction for the whole section gated by `#if defined(MBEDTLS_HAVE_ASM)` to prevent this.

Backport 2.28: #6877

## Gatekeeper checklist

- [ ] ~**changelog** provided, or~ not required
- [x] **backport** done, or not required
- [ ] ~**tests** provided, or~ not required
