### PR TITLE
[Backport 2.28] Check for Uncrustify errors in `code_style.py`

### DIFF
--- a/include/mbedtls/bn_mul.h
+++ b/include/mbedtls/bn_mul.h
@@ -954,7 +954,6 @@
 #endif /* MSVC */
 
 #endif /* MBEDTLS_HAVE_ASM */
-/* *INDENT-ON* */
 
 #if !defined(MULADDC_CORE)
 #if defined(MBEDTLS_HAVE_UDBL)
@@ -1003,4 +1002,5 @@
 #endif /* C (generic)  */
 #endif /* C (longlong) */
 
+/* *INDENT-ON* */
 #endif /* bn_mul.h */

--- a/include/mbedtls/bn_mul.h
+++ b/include/mbedtls/bn_mul.h
@@ -84,13 +84,12 @@
 
 #endif /* bits in mbedtls_mpi_uint */
 
+/* *INDENT-OFF* */
 #if defined(MBEDTLS_HAVE_ASM)
 
-/* *INDENT-OFF* */
 #ifndef asm
 #define asm __asm
 #endif
-/* *INDENT-ON* */
 
 /* armcc5 --gnu defines __GNUC__ but doesn't support GNU's extended asm */
 #if defined(__GNUC__) && \
@@ -955,6 +954,7 @@
 #endif /* MSVC */
 
 #endif /* MBEDTLS_HAVE_ASM */
+/* *INDENT-ON* */
 
 #if !defined(MULADDC_CORE)
 #if defined(MBEDTLS_HAVE_UDBL)

--- a/scripts/code_style.py
+++ b/scripts/code_style.py
@@ -132,7 +132,7 @@ def check_style_is_correct(src_file_list: List[str]) -> bool:
 
     return style_correct
 
-def fix_style_single_pass(src_file_list: List[str]) -> None:
+def fix_style_single_pass(src_file_list: List[str]) -> bool:
     """
     Run Uncrustify once over the source files.
     """
@@ -146,6 +146,7 @@ def fix_style_single_pass(src_file_list: List[str]) -> None:
                     str(result.returncode) + " correcting file " + \
                     src_file)
             return False
+    return True
 
 def fix_style(src_file_list: List[str]) -> int:
     """

--- a/scripts/code_style.py
+++ b/scripts/code_style.py
@@ -152,9 +152,9 @@ def fix_style(src_file_list: List[str]) -> int:
     """
     Fix the code style. This takes 2 passes of Uncrustify.
     """
-    if fix_style_single_pass(src_file_list) != True:
+    if not fix_style_single_pass(src_file_list):
         return 1
-    if fix_style_single_pass(src_file_list) != True:
+    if not fix_style_single_pass(src_file_list):
         return 1
 
     # Guard against future changes that cause the codebase to require


### PR DESCRIPTION
Trivial backport of #6876.

Check the returncode of Uncrustify when fixing code style. This means that unparseable files cause checking or correction to fail.

The inline assembly defined in `bn_mul.h` confuses code style parsing, causing code style correction to fail. Disable code style correction for the whole section gated by `#if defined(MBEDTLS_HAVE_ASM)` to prevent this.

