### PR TITLE
Don't restyle some PSA macros

### DIFF
--- a/include/psa/crypto_values.h
+++ b/include/psa/crypto_values.h
@@ -892,7 +892,9 @@
      (alg) & PSA_ALG_KEY_DERIVATION_STRETCHING_FLAG)
 
 /** An invalid algorithm identifier value. */
+/* *INDENT-OFF* (https://github.com/ARM-software/psa-arch-tests/issues/337) */
 #define PSA_ALG_NONE                            ((psa_algorithm_t)0)
+/* *INDENT-ON* */
 
 #define PSA_ALG_HASH_MASK                       ((psa_algorithm_t)0x000000ff)
 /** MD5 */
@@ -2387,7 +2389,9 @@
 
 /** The null key identifier.
  */
+/* *INDENT-OFF* (https://github.com/ARM-software/psa-arch-tests/issues/337) */
 #define PSA_KEY_ID_NULL                         ((psa_key_id_t)0)
+/* *INDENT-ON* */
 /** The minimum value for a key identifier chosen by the application.
  */
 #define PSA_KEY_ID_USER_MIN                     ((psa_key_id_t)0x00000001)

--- a/include/psa/crypto_values.h
+++ b/include/psa/crypto_values.h
@@ -58,6 +58,13 @@
  * value, check with the Arm PSA framework group to pick one that other
  * domains aren't already using. */
 
+/* Tell uncrustify not to touch the constant definitions, otherwise
+ * it might change the spacing to something that is not PSA-compliant
+ * (e.g. adding a space after casts).
+ *
+ * *INDENT-OFF*
+ */
+
 /** The action was completed successfully. */
 #define PSA_SUCCESS ((psa_status_t)0)
 
@@ -327,6 +334,8 @@
  * written by an incompatible version of the library.
  */
 #define PSA_ERROR_DATA_INVALID          ((psa_status_t)-153)
+
+/* *INDENT-ON* */
 
 /**@}*/
 


### PR DESCRIPTION
Some preprocessor macro definitions must have a specific expansion so that the same macro name can be defined in different products. The definition of having the same expansion (per the C language specification) means the same sequence of tokens, and also the same absence/presence of spacing between tokens. Don't restyle those macros (it would add a space between casts and their value, since https://github.com/Mbed-TLS/mbedtls/pull/6836). Fixes https://github.com/Mbed-TLS/mbedtls/issues/6875.

## Gatekeeper checklist

- [x] **changelog** not required (not user-visible)
- [x] **backport** https://github.com/Mbed-TLS/mbedtls/pull/6897
- [x] **tests** (will be validated by `all.sh test_psa_compliance` passing on the [preview branch](https://github.com/Mbed-TLS/mbedtls/pull/6758) once it's updated; check manually by running `scripts/code_style.py && tests/scripts/all.sh test_psa_compliance`)
