### PR TITLE
Improve X.509 cert writing serial number management

### DIFF
--- a/ChangeLog.d/improve_x509_cert_writing_serial_number_management.txt
+++ b/ChangeLog.d/improve_x509_cert_writing_serial_number_management.txt
@@ -1,0 +1,10 @@
+Bugfix
+   * mbedtls_x509write_crt_set_serial() now explicitly rejects serial numbers
+     whose binary representation is longer than 20 bytes. This was already
+     forbidden by the standard (RFC5280 - section 4.1.2.2) and now it's being
+     enforced also at code level.
+
+New deprecations
+   * mbedtls_x509write_crt_set_serial() is now being deprecated in favor of
+     mbedtls_x509write_crt_set_serial_new(). The goal here is to remove any
+     direct dependency of X509 from BIGNUM_C.

--- a/programs/x509/cert_write.c
+++ b/programs/x509/cert_write.c
@@ -559,6 +559,7 @@ int main( int argc, char *argv[] )
     mbedtls_printf( "  . Reading serial number..." );
     fflush( stdout );
 
+#if defined(MBEDTLS_BIGNUM_C)
     if( ( ret = mbedtls_mpi_read_string( &serial, 10, opt.serial ) ) != 0 )
     {
         mbedtls_strerror( ret, buf, sizeof(buf) );
@@ -566,6 +567,7 @@ int main( int argc, char *argv[] )
                         "returned -0x%04x - %s\n\n", (unsigned int) -ret, buf );
         goto exit;
     }
+#endif
 
     mbedtls_printf( " ok\n" );
 
@@ -721,6 +723,7 @@ int main( int argc, char *argv[] )
     mbedtls_x509write_crt_set_version( &crt, opt.version );
     mbedtls_x509write_crt_set_md_alg( &crt, opt.md );
 
+#if defined(MBEDTLS_BIGNUM_C)
     ret = mbedtls_x509write_crt_set_serial( &crt, &serial );
     if( ret != 0 )
     {
@@ -729,6 +732,17 @@ int main( int argc, char *argv[] )
                         "returned -0x%04x - %s\n\n", (unsigned int) -ret, buf );
         goto exit;
     }
+#else
+    ret = mbedtls_x509write_crt_set_serial_new( &crt, opt.serial,
+                                                strlen( opt.serial ) );
+    if( ret != 0 )
+    {
+        mbedtls_strerror( ret, buf, sizeof(buf) );
+        mbedtls_printf( " failed\n  !  mbedtls_x509write_crt_set_serial_new "
+                        "returned -0x%04x - %s\n\n", (unsigned int) -ret, buf );
+        goto exit;
+    }
+#endif
 
     ret = mbedtls_x509write_crt_set_validity( &crt, opt.not_before, opt.not_after );
     if( ret != 0 )

--- a/tests/suites/test_suite_x509write.function
+++ b/tests/suites/test_suite_x509write.function
@@ -377,12 +377,19 @@ void x509_crt_check( char *subject_key_file, char *subject_pwd,
     if( pk_wrap == 2 )
         TEST_ASSERT( mbedtls_pk_get_type( &issuer_key ) == MBEDTLS_PK_OPAQUE );
 
+#if !defined(MBEDTLS_BIGNUM_C)
     TEST_ASSERT( mbedtls_test_read_mpi( &serial, serial_str ) == 0 );
+#endif
 
     if( ver != -1 )
         mbedtls_x509write_crt_set_version( &crt, ver );
 
+#if !defined(MBEDTLS_BIGNUM_C)
     TEST_ASSERT( mbedtls_x509write_crt_set_serial( &crt, &serial ) == 0 );
+#else
+    TEST_ASSERT( mbedtls_x509write_crt_set_serial_new( &crt, serial_str,
+                                strlen( serial_str ) ) == 0 );
+#endif
     TEST_ASSERT( mbedtls_x509write_crt_set_validity( &crt, not_before,
                                                      not_after ) == 0 );
     mbedtls_x509write_crt_set_md_alg( &crt, md_type );


### PR DESCRIPTION
## Description

The goal of this PR is to remove any direct dependency of X509 certificate writing from BIGNUM_C.

Resolves #6843 

## Gatekeepe checklist

- [ ] **changelog** provided, or not required
- [ ] **backport** done, or not required
- [ ] **tests** provided, or not required