### PR TITLE
Backport 2.28: Fix iar warning bignum backport

### DIFF
--- a/ChangeLog.d/fix-iar-warnings.txt
+++ b/ChangeLog.d/fix-iar-warnings.txt
@@ -1,0 +1,2 @@
+Bugfix
+   * Fix IAR compiler warnings. Contributed by Glenn Strauss in #3835.

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -1559,9 +1559,9 @@ static mbedtls_mpi_uint mbedtls_int_div_int( mbedtls_mpi_uint u1,
      */
     if( 0 == d || u1 >= d )
     {
-        if (r != NULL) *r = ~0;
+        if (r != NULL) *r = ~(mbedtls_mpi_uint)0u;
 
-        return ( ~0 );
+        return ( ~(mbedtls_mpi_uint)0u );
     }
 
 #if defined(MBEDTLS_HAVE_UDBL)
@@ -1700,7 +1700,7 @@ int mbedtls_mpi_div_mpi( mbedtls_mpi *Q, mbedtls_mpi *R, const mbedtls_mpi *A,
     for( i = n; i > t ; i-- )
     {
         if( X.p[i] >= Y.p[t] )
-            Z.p[i - t - 1] = ~0;
+            Z.p[i - t - 1] = ~(mbedtls_mpi_uint)0u;
         else
         {
             Z.p[i - t - 1] = mbedtls_int_div_int( X.p[i], X.p[i - 1],


### PR DESCRIPTION
## Gatekeeper checklist

- [x] **changelog** provided
- [x] **backport** of #6888
- [x] **tests** not required