### PR TITLE
Make generate_errors.pl handle directory names containing spaces when opening files

### DIFF
--- a/ChangeLog.d/fix_build_for_directory_names_containing_spaces.txt
+++ b/ChangeLog.d/fix_build_for_directory_names_containing_spaces.txt
@@ -1,0 +1,4 @@
+Bugfix
+   * Fix a bug in the build where directory names containing spaces were
+     causing generate_errors.pl to error out resulting in a build failure.
+     Fixes issue #6879.

--- a/scripts/generate_errors.pl
+++ b/scripts/generate_errors.pl
@@ -60,11 +60,11 @@ open(FORMAT_FILE, '<:crlf', "$error_format_file") or die "Opening error format f
 my $error_format = <FORMAT_FILE>;
 close(FORMAT_FILE);
 
-my @files = <$include_dir/*.h>;
+my @files = glob qq("$include_dir/*.h");
 my @necessary_include_files;
 my @matches;
 foreach my $file (@files) {
-    open(FILE, '<:crlf', "$file");
+    open(FILE, '<:crlf', $file) or die("$0: $file: $!");
     my $content = <FILE>;
     close FILE;
     my $found = 0;


### PR DESCRIPTION
Fixes #6879 

## Description

Modify generate_errors.pl such that it can now handle opening files where the file path includes a directory name containing spaces.

Fix provided by
@tom-cosgrove-arm in aforementioned issue.

2.28 backport: #6894 

## Gatekeeper checklist

- [ ] **changelog** provided
- [ ] **backport** done PR #6894
- [ ] **tests** not required - this is a robustness improvement to parts of the build system



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

