### PR TITLE
Backport 2.28: Don't restyle some PSA macros

### DIFF
--- a/include/psa/crypto_values.h
+++ b/include/psa/crypto_values.h
@@ -828,7 +828,9 @@
     (((alg) & PSA_ALG_CATEGORY_MASK) == PSA_ALG_CATEGORY_KEY_DERIVATION)
 
 /** An invalid algorithm identifier value. */
+/* *INDENT-OFF* (https://github.com/ARM-software/psa-arch-tests/issues/337) */
 #define PSA_ALG_NONE                            ((psa_algorithm_t)0)
+/* *INDENT-ON* */
 
 #define PSA_ALG_HASH_MASK                       ((psa_algorithm_t)0x000000ff)
 /** MD2 */
@@ -2094,7 +2096,9 @@
 
 /** The null key identifier.
  */
+/* *INDENT-OFF* (https://github.com/ARM-software/psa-arch-tests/issues/337) */
 #define PSA_KEY_ID_NULL                         ((psa_key_id_t)0)
+/* *INDENT-ON* */
 /** The minimum value for a key identifier chosen by the application.
  */
 #define PSA_KEY_ID_USER_MIN                     ((psa_key_id_t)0x00000001)

--- a/include/psa/crypto_values.h
+++ b/include/psa/crypto_values.h
@@ -57,6 +57,13 @@
  * value, check with the Arm PSA framework group to pick one that other
  * domains aren't already using. */
 
+/* Tell uncrustify not to touch the constant definitions, otherwise
+ * it might change the spacing to something that is not PSA-compliant
+ * (e.g. adding a space after casts).
+ *
+ * *INDENT-OFF*
+ */
+
 /** The action was completed successfully. */
 #define PSA_SUCCESS ((psa_status_t)0)
 
@@ -326,6 +333,8 @@
  * written by an incompatible version of the library.
  */
 #define PSA_ERROR_DATA_INVALID          ((psa_status_t)-153)
+
+/* *INDENT-ON* */
 
 /**@}*/
 


### PR DESCRIPTION
Trivial backport of https://github.com/Mbed-TLS/mbedtls/pull/6878

## Gatekeeper checklist

- [x] **changelog** not required (not user-visible)
- [x] **backport** of https://github.com/Mbed-TLS/mbedtls/pull/6878
- [x] **tests** will be validated by `all.sh test_psa_compliance` passing on the [preview branch](https://github.com/Mbed-TLS/mbedtls/pull/6758) once it's updated; check manually by running `scripts/code_style.py && tests/scripts/all.sh test_psa_compliance`)
