### PR TITLE
Add check for subject/authority key identifier

### DIFF
--- a/ChangeLog.d/fix-cert-key-id.txt
+++ b/ChangeLog.d/fix-cert-key-id.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Add verification of key identifier field of the certificate
+     authority key identifier extension.


### PR DESCRIPTION
## Description

Resolves https://github.com/Mbed-TLS/mbedtls/issues/2954 (partially)
Needs: PR https://github.com/Mbed-TLS/mbedtls/pull/6866

Verify key identifiers only if `AuthorityKeyIdentifier` extension is available and critical. This is done to keep backward compatibility with certificates that don't have this extension.

After discussion that started from https://github.com/Mbed-TLS/mbedtls/issues/2954#issuecomment-1370647079 I added missing check, but with limitation, for now, to keep backward compatibility with certificates generated without `AuthorityKeyIdentifier` extension.

The problem of this solution is that the certificate chain provided in the issue is still not rejected. It could be if we would remove _is extension critical_ condition and leave only to check if certificate has AuthorityKeyIdentifier extension.
This way the provided certificate chain would be rejected and our tests still passing.

Do we need extra tests for this?

## Gatekeeper checklist

- [ ] **changelog** provided, or not required
- [ ] **backport** done, or not required
- [ ] **tests** provided, or not required



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

