### PR TITLE
compat.sh: report and filter cipher suite names consistently

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ jobs:
         - tests/scripts/test_psa_constant_names.py
         - tests/ssl-opt.sh
         # Modern OpenSSL does not support fixed ECDH or null ciphers.
-        - tests/compat.sh -p OpenSSL -e 'NULL\|ECDH-'
+        - tests/compat.sh -p OpenSSL -e 'NULL\|ECDH_'
         - tests/scripts/travis-log-failure.sh
         # GnuTLS supports CAMELLIA but compat.sh doesn't properly enable it.
         - tests/compat.sh -p GnuTLS -e 'CAMELLIA'

--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -234,6 +234,7 @@ filter_ciphersuites()
 
 reset_ciphersuites()
 {
+    S_CIPHERS=""
     M_CIPHERS=""
     O_CIPHERS=""
     G_CIPHERS=""
@@ -258,56 +259,60 @@ add_common_ciphersuites()
 
         "ECDSA")
             CIPHERS="$CIPHERS                           \
-                TLS-ECDHE-ECDSA-WITH-AES-128-CBC-SHA    \
-                TLS-ECDHE-ECDSA-WITH-AES-128-CBC-SHA256 \
-                TLS-ECDHE-ECDSA-WITH-AES-128-GCM-SHA256 \
-                TLS-ECDHE-ECDSA-WITH-AES-256-CBC-SHA    \
-                TLS-ECDHE-ECDSA-WITH-AES-256-CBC-SHA384 \
-                TLS-ECDHE-ECDSA-WITH-AES-256-GCM-SHA384 \
-                TLS-ECDHE-ECDSA-WITH-NULL-SHA           \
+                TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA    \
+                TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256 \
+                TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 \
+                TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA    \
+                TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384 \
+                TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 \
+                TLS_ECDHE_ECDSA_WITH_NULL_SHA           \
                 "
             ;;
 
         "RSA")
             CIPHERS="$CIPHERS                           \
-                TLS-DHE-RSA-WITH-AES-128-CBC-SHA        \
-                TLS-DHE-RSA-WITH-AES-128-CBC-SHA256     \
-                TLS-DHE-RSA-WITH-AES-128-GCM-SHA256     \
-                TLS-DHE-RSA-WITH-AES-256-CBC-SHA        \
-                TLS-DHE-RSA-WITH-AES-256-CBC-SHA256     \
-                TLS-DHE-RSA-WITH-AES-256-GCM-SHA384     \
-                TLS-DHE-RSA-WITH-CAMELLIA-128-CBC-SHA   \
-                TLS-DHE-RSA-WITH-CAMELLIA-256-CBC-SHA   \
-                TLS-ECDHE-RSA-WITH-AES-128-CBC-SHA      \
-                TLS-ECDHE-RSA-WITH-AES-128-CBC-SHA256   \
-                TLS-ECDHE-RSA-WITH-AES-128-GCM-SHA256   \
-                TLS-ECDHE-RSA-WITH-AES-256-CBC-SHA      \
-                TLS-ECDHE-RSA-WITH-AES-256-CBC-SHA384   \
-                TLS-ECDHE-RSA-WITH-AES-256-GCM-SHA384   \
-                TLS-ECDHE-RSA-WITH-NULL-SHA             \
-                TLS-RSA-WITH-AES-128-CBC-SHA            \
-                TLS-RSA-WITH-AES-128-CBC-SHA256         \
-                TLS-RSA-WITH-AES-128-GCM-SHA256         \
-                TLS-RSA-WITH-AES-256-CBC-SHA            \
-                TLS-RSA-WITH-AES-256-CBC-SHA256         \
-                TLS-RSA-WITH-AES-256-GCM-SHA384         \
-                TLS-RSA-WITH-CAMELLIA-128-CBC-SHA       \
-                TLS-RSA-WITH-CAMELLIA-256-CBC-SHA       \
-                TLS-RSA-WITH-NULL-MD5                   \
-                TLS-RSA-WITH-NULL-SHA                   \
-                TLS-RSA-WITH-NULL-SHA256                \
+                TLS_DHE_RSA_WITH_AES_128_CBC_SHA        \
+                TLS_DHE_RSA_WITH_AES_128_CBC_SHA256     \
+                TLS_DHE_RSA_WITH_AES_128_GCM_SHA256     \
+                TLS_DHE_RSA_WITH_AES_256_CBC_SHA        \
+                TLS_DHE_RSA_WITH_AES_256_CBC_SHA256     \
+                TLS_DHE_RSA_WITH_AES_256_GCM_SHA384     \
+                TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA   \
+                TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA   \
+                TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA      \
+                TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256   \
+                TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256   \
+                TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA      \
+                TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384   \
+                TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384   \
+                TLS_ECDHE_RSA_WITH_NULL_SHA             \
+                TLS_RSA_WITH_AES_128_CBC_SHA            \
+                TLS_RSA_WITH_AES_128_CBC_SHA256         \
+                TLS_RSA_WITH_AES_128_GCM_SHA256         \
+                TLS_RSA_WITH_AES_256_CBC_SHA            \
+                TLS_RSA_WITH_AES_256_CBC_SHA256         \
+                TLS_RSA_WITH_AES_256_GCM_SHA384         \
+                TLS_RSA_WITH_CAMELLIA_128_CBC_SHA       \
+                TLS_RSA_WITH_CAMELLIA_256_CBC_SHA       \
+                TLS_RSA_WITH_NULL_MD5                   \
+                TLS_RSA_WITH_NULL_SHA                   \
+                TLS_RSA_WITH_NULL_SHA256                \
                 "
             ;;
 
         "PSK")
             CIPHERS="$CIPHERS                           \
-                TLS-PSK-WITH-AES-128-CBC-SHA            \
-                TLS-PSK-WITH-AES-256-CBC-SHA            \
+                TLS_PSK_WITH_AES_128_CBC_SHA            \
+                TLS_PSK_WITH_AES_256_CBC_SHA            \
                 "
             ;;
     esac
 
-    M_CIPHERS="$M_CIPHERS $CIPHERS"
+    S_CIPHERS="$S_CIPHERS $CIPHERS"
+
+    T=$(./scripts/translate_ciphers.py m $CIPHERS)
+    check_translation $? "$T"
+    M_CIPHERS="$M_CIPHERS $T"
 
     T=$(./scripts/translate_ciphers.py g $CIPHERS)
     check_translation $? "$T"
@@ -337,46 +342,50 @@ add_openssl_ciphersuites()
 
         "ECDSA")
             CIPHERS="$CIPHERS                                   \
-                TLS-ECDH-ECDSA-WITH-AES-128-CBC-SHA             \
-                TLS-ECDH-ECDSA-WITH-AES-128-CBC-SHA256          \
-                TLS-ECDH-ECDSA-WITH-AES-128-GCM-SHA256          \
-                TLS-ECDH-ECDSA-WITH-AES-256-CBC-SHA             \
-                TLS-ECDH-ECDSA-WITH-AES-256-CBC-SHA384          \
-                TLS-ECDH-ECDSA-WITH-AES-256-GCM-SHA384          \
-                TLS-ECDH-ECDSA-WITH-NULL-SHA                    \
-                TLS-ECDHE-ECDSA-WITH-ARIA-128-GCM-SHA256        \
-                TLS-ECDHE-ECDSA-WITH-ARIA-256-GCM-SHA384        \
-                TLS-ECDHE-ECDSA-WITH-CHACHA20-POLY1305-SHA256   \
+                TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA             \
+                TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256          \
+                TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256          \
+                TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA             \
+                TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384          \
+                TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384          \
+                TLS_ECDH_ECDSA_WITH_NULL_SHA                    \
+                TLS_ECDHE_ECDSA_WITH_ARIA_128_GCM_SHA256        \
+                TLS_ECDHE_ECDSA_WITH_ARIA_256_GCM_SHA384        \
+                TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256   \
                 "
             ;;
 
         "RSA")
             CIPHERS="$CIPHERS                                   \
-                TLS-DHE-RSA-WITH-ARIA-128-GCM-SHA256            \
-                TLS-DHE-RSA-WITH-ARIA-256-GCM-SHA384            \
-                TLS-DHE-RSA-WITH-CHACHA20-POLY1305-SHA256       \
-                TLS-ECDHE-RSA-WITH-ARIA-128-GCM-SHA256          \
-                TLS-ECDHE-RSA-WITH-ARIA-256-GCM-SHA384          \
-                TLS-ECDHE-RSA-WITH-CHACHA20-POLY1305-SHA256     \
-                TLS-RSA-WITH-ARIA-128-GCM-SHA256                \
-                TLS-RSA-WITH-ARIA-256-GCM-SHA384                \
+                TLS_DHE_RSA_WITH_ARIA_128_GCM_SHA256            \
+                TLS_DHE_RSA_WITH_ARIA_256_GCM_SHA384            \
+                TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256       \
+                TLS_ECDHE_RSA_WITH_ARIA_128_GCM_SHA256          \
+                TLS_ECDHE_RSA_WITH_ARIA_256_GCM_SHA384          \
+                TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256     \
+                TLS_RSA_WITH_ARIA_128_GCM_SHA256                \
+                TLS_RSA_WITH_ARIA_256_GCM_SHA384                \
                 "
             ;;
 
         "PSK")
             CIPHERS="$CIPHERS                                   \
-                TLS-DHE-PSK-WITH-ARIA-128-GCM-SHA256            \
-                TLS-DHE-PSK-WITH-ARIA-256-GCM-SHA384            \
-                TLS-DHE-PSK-WITH-CHACHA20-POLY1305-SHA256       \
-                TLS-ECDHE-PSK-WITH-CHACHA20-POLY1305-SHA256     \
-                TLS-PSK-WITH-ARIA-128-GCM-SHA256                \
-                TLS-PSK-WITH-ARIA-256-GCM-SHA384                \
-                TLS-PSK-WITH-CHACHA20-POLY1305-SHA256           \
+                TLS_DHE_PSK_WITH_ARIA_128_GCM_SHA256            \
+                TLS_DHE_PSK_WITH_ARIA_256_GCM_SHA384            \
+                TLS_DHE_PSK_WITH_CHACHA20_POLY1305_SHA256       \
+                TLS_ECDHE_PSK_WITH_CHACHA20_POLY1305_SHA256     \
+                TLS_PSK_WITH_ARIA_128_GCM_SHA256                \
+                TLS_PSK_WITH_ARIA_256_GCM_SHA384                \
+                TLS_PSK_WITH_CHACHA20_POLY1305_SHA256           \
                 "
             ;;
     esac
 
-    M_CIPHERS="$M_CIPHERS $CIPHERS"
+    S_CIPHERS="$S_CIPHERS $CIPHERS"
+
+    T=$(./scripts/translate_ciphers.py m $CIPHERS)
+    check_translation $? "$T"
+    M_CIPHERS="$M_CIPHERS $T"
 
     T=$(./scripts/translate_ciphers.py o $CIPHERS)
     check_translation $? "$T"
@@ -395,99 +404,103 @@ add_gnutls_ciphersuites()
 
         "ECDSA")
             CIPHERS="$CIPHERS                                       \
-                TLS-ECDHE-ECDSA-WITH-AES-128-CCM                    \
-                TLS-ECDHE-ECDSA-WITH-AES-128-CCM-8                  \
-                TLS-ECDHE-ECDSA-WITH-AES-256-CCM                    \
-                TLS-ECDHE-ECDSA-WITH-AES-256-CCM-8                  \
-                TLS-ECDHE-ECDSA-WITH-CAMELLIA-128-CBC-SHA256        \
-                TLS-ECDHE-ECDSA-WITH-CAMELLIA-128-GCM-SHA256        \
-                TLS-ECDHE-ECDSA-WITH-CAMELLIA-256-CBC-SHA384        \
-                TLS-ECDHE-ECDSA-WITH-CAMELLIA-256-GCM-SHA384        \
+                TLS_ECDHE_ECDSA_WITH_AES_128_CCM                    \
+                TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8                  \
+                TLS_ECDHE_ECDSA_WITH_AES_256_CCM                    \
+                TLS_ECDHE_ECDSA_WITH_AES_256_CCM_8                  \
+                TLS_ECDHE_ECDSA_WITH_CAMELLIA_128_CBC_SHA256        \
+                TLS_ECDHE_ECDSA_WITH_CAMELLIA_128_GCM_SHA256        \
+                TLS_ECDHE_ECDSA_WITH_CAMELLIA_256_CBC_SHA384        \
+                TLS_ECDHE_ECDSA_WITH_CAMELLIA_256_GCM_SHA384        \
                 "
             ;;
 
         "RSA")
             CIPHERS="$CIPHERS                               \
-                TLS-DHE-RSA-WITH-AES-128-CCM                \
-                TLS-DHE-RSA-WITH-AES-128-CCM-8              \
-                TLS-DHE-RSA-WITH-AES-256-CCM                \
-                TLS-DHE-RSA-WITH-AES-256-CCM-8              \
-                TLS-DHE-RSA-WITH-CAMELLIA-128-CBC-SHA256    \
-                TLS-DHE-RSA-WITH-CAMELLIA-128-GCM-SHA256    \
-                TLS-DHE-RSA-WITH-CAMELLIA-256-CBC-SHA256    \
-                TLS-DHE-RSA-WITH-CAMELLIA-256-GCM-SHA384    \
-                TLS-ECDHE-RSA-WITH-CAMELLIA-128-CBC-SHA256  \
-                TLS-ECDHE-RSA-WITH-CAMELLIA-128-GCM-SHA256  \
-                TLS-ECDHE-RSA-WITH-CAMELLIA-256-CBC-SHA384  \
-                TLS-ECDHE-RSA-WITH-CAMELLIA-256-GCM-SHA384  \
-                TLS-RSA-WITH-AES-128-CCM                    \
-                TLS-RSA-WITH-AES-128-CCM-8                  \
-                TLS-RSA-WITH-AES-256-CCM                    \
-                TLS-RSA-WITH-AES-256-CCM-8                  \
-                TLS-RSA-WITH-CAMELLIA-128-CBC-SHA256        \
-                TLS-RSA-WITH-CAMELLIA-128-GCM-SHA256        \
-                TLS-RSA-WITH-CAMELLIA-256-CBC-SHA256        \
-                TLS-RSA-WITH-CAMELLIA-256-GCM-SHA384        \
+                TLS_DHE_RSA_WITH_AES_128_CCM                \
+                TLS_DHE_RSA_WITH_AES_128_CCM_8              \
+                TLS_DHE_RSA_WITH_AES_256_CCM                \
+                TLS_DHE_RSA_WITH_AES_256_CCM_8              \
+                TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA256    \
+                TLS_DHE_RSA_WITH_CAMELLIA_128_GCM_SHA256    \
+                TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA256    \
+                TLS_DHE_RSA_WITH_CAMELLIA_256_GCM_SHA384    \
+                TLS_ECDHE_RSA_WITH_CAMELLIA_128_CBC_SHA256  \
+                TLS_ECDHE_RSA_WITH_CAMELLIA_128_GCM_SHA256  \
+                TLS_ECDHE_RSA_WITH_CAMELLIA_256_CBC_SHA384  \
+                TLS_ECDHE_RSA_WITH_CAMELLIA_256_GCM_SHA384  \
+                TLS_RSA_WITH_AES_128_CCM                    \
+                TLS_RSA_WITH_AES_128_CCM_8                  \
+                TLS_RSA_WITH_AES_256_CCM                    \
+                TLS_RSA_WITH_AES_256_CCM_8                  \
+                TLS_RSA_WITH_CAMELLIA_128_CBC_SHA256        \
+                TLS_RSA_WITH_CAMELLIA_128_GCM_SHA256        \
+                TLS_RSA_WITH_CAMELLIA_256_CBC_SHA256        \
+                TLS_RSA_WITH_CAMELLIA_256_GCM_SHA384        \
                 "
             ;;
 
         "PSK")
             CIPHERS="$CIPHERS                               \
-                TLS-DHE-PSK-WITH-AES-128-CBC-SHA            \
-                TLS-DHE-PSK-WITH-AES-128-CBC-SHA256         \
-                TLS-DHE-PSK-WITH-AES-128-CCM                \
-                TLS-DHE-PSK-WITH-AES-128-CCM-8              \
-                TLS-DHE-PSK-WITH-AES-128-GCM-SHA256         \
-                TLS-DHE-PSK-WITH-AES-256-CBC-SHA            \
-                TLS-DHE-PSK-WITH-AES-256-CBC-SHA384         \
-                TLS-DHE-PSK-WITH-AES-256-CCM                \
-                TLS-DHE-PSK-WITH-AES-256-CCM-8              \
-                TLS-DHE-PSK-WITH-AES-256-GCM-SHA384         \
-                TLS-DHE-PSK-WITH-CAMELLIA-128-CBC-SHA256    \
-                TLS-DHE-PSK-WITH-CAMELLIA-128-GCM-SHA256    \
-                TLS-DHE-PSK-WITH-CAMELLIA-256-CBC-SHA384    \
-                TLS-DHE-PSK-WITH-CAMELLIA-256-GCM-SHA384    \
-                TLS-DHE-PSK-WITH-NULL-SHA256                \
-                TLS-DHE-PSK-WITH-NULL-SHA384                \
-                TLS-ECDHE-PSK-WITH-AES-128-CBC-SHA          \
-                TLS-ECDHE-PSK-WITH-AES-128-CBC-SHA256       \
-                TLS-ECDHE-PSK-WITH-AES-256-CBC-SHA          \
-                TLS-ECDHE-PSK-WITH-AES-256-CBC-SHA384       \
-                TLS-ECDHE-PSK-WITH-CAMELLIA-128-CBC-SHA256  \
-                TLS-ECDHE-PSK-WITH-CAMELLIA-256-CBC-SHA384  \
-                TLS-ECDHE-PSK-WITH-NULL-SHA256              \
-                TLS-ECDHE-PSK-WITH-NULL-SHA384              \
-                TLS-PSK-WITH-AES-128-CBC-SHA256             \
-                TLS-PSK-WITH-AES-128-CCM                    \
-                TLS-PSK-WITH-AES-128-CCM-8                  \
-                TLS-PSK-WITH-AES-128-GCM-SHA256             \
-                TLS-PSK-WITH-AES-256-CBC-SHA384             \
-                TLS-PSK-WITH-AES-256-CCM                    \
-                TLS-PSK-WITH-AES-256-CCM-8                  \
-                TLS-PSK-WITH-AES-256-GCM-SHA384             \
-                TLS-PSK-WITH-CAMELLIA-128-CBC-SHA256        \
-                TLS-PSK-WITH-CAMELLIA-128-GCM-SHA256        \
-                TLS-PSK-WITH-CAMELLIA-256-CBC-SHA384        \
-                TLS-PSK-WITH-CAMELLIA-256-GCM-SHA384        \
-                TLS-PSK-WITH-NULL-SHA256                    \
-                TLS-PSK-WITH-NULL-SHA384                    \
-                TLS-RSA-PSK-WITH-AES-128-CBC-SHA            \
-                TLS-RSA-PSK-WITH-AES-128-CBC-SHA256         \
-                TLS-RSA-PSK-WITH-AES-128-GCM-SHA256         \
-                TLS-RSA-PSK-WITH-AES-256-CBC-SHA            \
-                TLS-RSA-PSK-WITH-AES-256-CBC-SHA384         \
-                TLS-RSA-PSK-WITH-AES-256-GCM-SHA384         \
-                TLS-RSA-PSK-WITH-CAMELLIA-128-CBC-SHA256    \
-                TLS-RSA-PSK-WITH-CAMELLIA-128-GCM-SHA256    \
-                TLS-RSA-PSK-WITH-CAMELLIA-256-CBC-SHA384    \
-                TLS-RSA-PSK-WITH-CAMELLIA-256-GCM-SHA384    \
-                TLS-RSA-PSK-WITH-NULL-SHA256                \
-                TLS-RSA-PSK-WITH-NULL-SHA384                \
+                TLS_DHE_PSK_WITH_AES_128_CBC_SHA            \
+                TLS_DHE_PSK_WITH_AES_128_CBC_SHA256         \
+                TLS_DHE_PSK_WITH_AES_128_CCM                \
+                TLS_DHE_PSK_WITH_AES_128_CCM_8              \
+                TLS_DHE_PSK_WITH_AES_128_GCM_SHA256         \
+                TLS_DHE_PSK_WITH_AES_256_CBC_SHA            \
+                TLS_DHE_PSK_WITH_AES_256_CBC_SHA384         \
+                TLS_DHE_PSK_WITH_AES_256_CCM                \
+                TLS_DHE_PSK_WITH_AES_256_CCM_8              \
+                TLS_DHE_PSK_WITH_AES_256_GCM_SHA384         \
+                TLS_DHE_PSK_WITH_CAMELLIA_128_CBC_SHA256    \
+                TLS_DHE_PSK_WITH_CAMELLIA_128_GCM_SHA256    \
+                TLS_DHE_PSK_WITH_CAMELLIA_256_CBC_SHA384    \
+                TLS_DHE_PSK_WITH_CAMELLIA_256_GCM_SHA384    \
+                TLS_DHE_PSK_WITH_NULL_SHA256                \
+                TLS_DHE_PSK_WITH_NULL_SHA384                \
+                TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA          \
+                TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA256       \
+                TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA          \
+                TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA384       \
+                TLS_ECDHE_PSK_WITH_CAMELLIA_128_CBC_SHA256  \
+                TLS_ECDHE_PSK_WITH_CAMELLIA_256_CBC_SHA384  \
+                TLS_ECDHE_PSK_WITH_NULL_SHA256              \
+                TLS_ECDHE_PSK_WITH_NULL_SHA384              \
+                TLS_PSK_WITH_AES_128_CBC_SHA256             \
+                TLS_PSK_WITH_AES_128_CCM                    \
+                TLS_PSK_WITH_AES_128_CCM_8                  \
+                TLS_PSK_WITH_AES_128_GCM_SHA256             \
+                TLS_PSK_WITH_AES_256_CBC_SHA384             \
+                TLS_PSK_WITH_AES_256_CCM                    \
+                TLS_PSK_WITH_AES_256_CCM_8                  \
+                TLS_PSK_WITH_AES_256_GCM_SHA384             \
+                TLS_PSK_WITH_CAMELLIA_128_CBC_SHA256        \
+                TLS_PSK_WITH_CAMELLIA_128_GCM_SHA256        \
+                TLS_PSK_WITH_CAMELLIA_256_CBC_SHA384        \
+                TLS_PSK_WITH_CAMELLIA_256_GCM_SHA384        \
+                TLS_PSK_WITH_NULL_SHA256                    \
+                TLS_PSK_WITH_NULL_SHA384                    \
+                TLS_RSA_PSK_WITH_AES_128_CBC_SHA            \
+                TLS_RSA_PSK_WITH_AES_128_CBC_SHA256         \
+                TLS_RSA_PSK_WITH_AES_128_GCM_SHA256         \
+                TLS_RSA_PSK_WITH_AES_256_CBC_SHA            \
+                TLS_RSA_PSK_WITH_AES_256_CBC_SHA384         \
+                TLS_RSA_PSK_WITH_AES_256_GCM_SHA384         \
+                TLS_RSA_PSK_WITH_CAMELLIA_128_CBC_SHA256    \
+                TLS_RSA_PSK_WITH_CAMELLIA_128_GCM_SHA256    \
+                TLS_RSA_PSK_WITH_CAMELLIA_256_CBC_SHA384    \
+                TLS_RSA_PSK_WITH_CAMELLIA_256_GCM_SHA384    \
+                TLS_RSA_PSK_WITH_NULL_SHA256                \
+                TLS_RSA_PSK_WITH_NULL_SHA384                \
                 "
             ;;
     esac
 
-    M_CIPHERS="$M_CIPHERS $CIPHERS"
+    S_CIPHERS="$S_CIPHERS $CIPHERS"
+
+    T=$(./scripts/translate_ciphers.py m $CIPHERS)
+    check_translation $? "$T"
+    M_CIPHERS="$M_CIPHERS $T"
 
     T=$(./scripts/translate_ciphers.py g $CIPHERS)
     check_translation $? "$T"
@@ -503,51 +516,57 @@ add_mbedtls_ciphersuites()
 
         "ECDSA")
             M_CIPHERS="$M_CIPHERS                               \
-                TLS-ECDH-ECDSA-WITH-ARIA-128-CBC-SHA256         \
-                TLS-ECDH-ECDSA-WITH-ARIA-128-GCM-SHA256         \
-                TLS-ECDH-ECDSA-WITH-ARIA-256-CBC-SHA384         \
-                TLS-ECDH-ECDSA-WITH-ARIA-256-GCM-SHA384         \
-                TLS-ECDH-ECDSA-WITH-CAMELLIA-128-CBC-SHA256     \
-                TLS-ECDH-ECDSA-WITH-CAMELLIA-128-GCM-SHA256     \
-                TLS-ECDH-ECDSA-WITH-CAMELLIA-256-CBC-SHA384     \
-                TLS-ECDH-ECDSA-WITH-CAMELLIA-256-GCM-SHA384     \
-                TLS-ECDHE-ECDSA-WITH-ARIA-128-CBC-SHA256        \
-                TLS-ECDHE-ECDSA-WITH-ARIA-256-CBC-SHA384        \
+                TLS_ECDH_ECDSA_WITH_ARIA_128_CBC_SHA256         \
+                TLS_ECDH_ECDSA_WITH_ARIA_128_GCM_SHA256         \
+                TLS_ECDH_ECDSA_WITH_ARIA_256_CBC_SHA384         \
+                TLS_ECDH_ECDSA_WITH_ARIA_256_GCM_SHA384         \
+                TLS_ECDH_ECDSA_WITH_CAMELLIA_128_CBC_SHA256     \
+                TLS_ECDH_ECDSA_WITH_CAMELLIA_128_GCM_SHA256     \
+                TLS_ECDH_ECDSA_WITH_CAMELLIA_256_CBC_SHA384     \
+                TLS_ECDH_ECDSA_WITH_CAMELLIA_256_GCM_SHA384     \
+                TLS_ECDHE_ECDSA_WITH_ARIA_128_CBC_SHA256        \
+                TLS_ECDHE_ECDSA_WITH_ARIA_256_CBC_SHA384        \
                 "
             ;;
 
         "RSA")
             M_CIPHERS="$M_CIPHERS                               \
-                TLS-DHE-RSA-WITH-ARIA-128-CBC-SHA256            \
-                TLS-DHE-RSA-WITH-ARIA-256-CBC-SHA384            \
-                TLS-ECDHE-RSA-WITH-ARIA-128-CBC-SHA256          \
-                TLS-ECDHE-RSA-WITH-ARIA-256-CBC-SHA384          \
-                TLS-RSA-WITH-ARIA-128-CBC-SHA256                \
-                TLS-RSA-WITH-ARIA-256-CBC-SHA384                \
+                TLS_DHE_RSA_WITH_ARIA_128_CBC_SHA256            \
+                TLS_DHE_RSA_WITH_ARIA_256_CBC_SHA384            \
+                TLS_ECDHE_RSA_WITH_ARIA_128_CBC_SHA256          \
+                TLS_ECDHE_RSA_WITH_ARIA_256_CBC_SHA384          \
+                TLS_RSA_WITH_ARIA_128_CBC_SHA256                \
+                TLS_RSA_WITH_ARIA_256_CBC_SHA384                \
                 "
             ;;
 
         "PSK")
-            # *PSK-NULL-SHA suites supported by GnuTLS 3.3.5 but not 3.2.15
+            # *PSK_NULL_SHA suites supported by GnuTLS 3.3.5 but not 3.2.15
             M_CIPHERS="$M_CIPHERS                               \
-                TLS-DHE-PSK-WITH-ARIA-128-CBC-SHA256            \
-                TLS-DHE-PSK-WITH-ARIA-256-CBC-SHA384            \
-                TLS-DHE-PSK-WITH-NULL-SHA                       \
-                TLS-ECDHE-PSK-WITH-ARIA-128-CBC-SHA256          \
-                TLS-ECDHE-PSK-WITH-ARIA-256-CBC-SHA384          \
-                TLS-ECDHE-PSK-WITH-NULL-SHA                     \
-                TLS-PSK-WITH-ARIA-128-CBC-SHA256                \
-                TLS-PSK-WITH-ARIA-256-CBC-SHA384                \
-                TLS-PSK-WITH-NULL-SHA                           \
-                TLS-RSA-PSK-WITH-ARIA-128-CBC-SHA256            \
-                TLS-RSA-PSK-WITH-ARIA-128-GCM-SHA256            \
-                TLS-RSA-PSK-WITH-ARIA-256-CBC-SHA384            \
-                TLS-RSA-PSK-WITH-ARIA-256-GCM-SHA384            \
-                TLS-RSA-PSK-WITH-CHACHA20-POLY1305-SHA256       \
-                TLS-RSA-PSK-WITH-NULL-SHA                       \
+                TLS_DHE_PSK_WITH_ARIA_128_CBC_SHA256            \
+                TLS_DHE_PSK_WITH_ARIA_256_CBC_SHA384            \
+                TLS_DHE_PSK_WITH_NULL_SHA                       \
+                TLS_ECDHE_PSK_WITH_ARIA_128_CBC_SHA256          \
+                TLS_ECDHE_PSK_WITH_ARIA_256_CBC_SHA384          \
+                TLS_ECDHE_PSK_WITH_NULL_SHA                     \
+                TLS_PSK_WITH_ARIA_128_CBC_SHA256                \
+                TLS_PSK_WITH_ARIA_256_CBC_SHA384                \
+                TLS_PSK_WITH_NULL_SHA                           \
+                TLS_RSA_PSK_WITH_ARIA_128_CBC_SHA256            \
+                TLS_RSA_PSK_WITH_ARIA_128_GCM_SHA256            \
+                TLS_RSA_PSK_WITH_ARIA_256_CBC_SHA384            \
+                TLS_RSA_PSK_WITH_ARIA_256_GCM_SHA384            \
+                TLS_RSA_PSK_WITH_CHACHA20_POLY1305_SHA256       \
+                TLS_RSA_PSK_WITH_NULL_SHA                       \
                 "
             ;;
     esac
+
+    S_CIPHERS="$S_CIPHERS $CIPHERS"
+
+    T=$(./scripts/translate_ciphers.py m $CIPHERS)
+    check_translation $? "$T"
+    M_CIPHERS="$M_CIPHERS $T"
 }
 
 setup_arguments()

--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -800,8 +800,11 @@ run_client() {
     LEN=$(( 72 - `echo "$TITLE" | wc -c` ))
     for i in `seq 1 $LEN`; do printf '.'; done; printf ' '
 
+    # Calculate the argument $c to pass to translate_ciphers.py
+    client=$(echo $1 | head -c1)
+    c=$(echo $client | tr '[:upper:]' '[:lower:]')
     # Translate ciphersuite names based on client's naming convention
-    t_cipher=$(./scripts/translate_ciphers.py $3 $2)
+    t_cipher=$(./scripts/translate_ciphers.py $c $2)
     check_translation $? "$t_cipher"
 
     # should we skip?
@@ -1027,7 +1030,7 @@ for VERIFY in $VERIFIES; do
                         start_server "OpenSSL"
                         for i in $M_CIPHERS; do
                             check_openssl_server_bug $i
-                            run_client mbedTLS $i m
+                            run_client mbedTLS $i
                         done
                         stop_server
                     fi
@@ -1035,7 +1038,7 @@ for VERIFY in $VERIFIES; do
                     if [ "X" != "X$O_CIPHERS" ]; then
                         start_server "mbedTLS"
                         for i in $O_CIPHERS; do
-                            run_client OpenSSL $i o
+                            run_client OpenSSL $i
                         done
                         stop_server
                     fi
@@ -1052,7 +1055,7 @@ for VERIFY in $VERIFIES; do
                     if [ "X" != "X$M_CIPHERS" ]; then
                         start_server "GnuTLS"
                         for i in $M_CIPHERS; do
-                            run_client mbedTLS $i m
+                            run_client mbedTLS $i
                         done
                         stop_server
                     fi
@@ -1060,7 +1063,7 @@ for VERIFY in $VERIFIES; do
                     if [ "X" != "X$G_CIPHERS" ]; then
                         start_server "mbedTLS"
                         for i in $G_CIPHERS; do
-                            run_client GnuTLS $i g
+                            run_client GnuTLS $i
                         done
                         stop_server
                     fi
@@ -1079,7 +1082,7 @@ for VERIFY in $VERIFIES; do
                     if [ "X" != "X$M_CIPHERS" ]; then
                         start_server "mbedTLS"
                         for i in $M_CIPHERS; do
-                            run_client mbedTLS $i m
+                            run_client mbedTLS $i
                         done
                         stop_server
                     fi

--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -205,7 +205,7 @@ filter()
 check_openssl_server_bug()
 {
     if test "X$VERIFY" = "XYES" && is_dtls "$MODE" && \
-        echo "$1" | grep "^TLS_PSK" >/dev/null;
+        test "$TYPE" = "PSK";
     then
         SKIP_NEXT="YES"
     fi
@@ -1029,7 +1029,7 @@ for VERIFY in $VERIFIES; do
                     if [ "X" != "X$M_CIPHERS" ]; then
                         start_server "OpenSSL"
                         for i in $M_CIPHERS; do
-                            check_openssl_server_bug $i
+                            check_openssl_server_bug
                             run_client mbedTLS $i
                         done
                         stop_server

--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -804,7 +804,8 @@ run_client() {
     TESTS=$(( $TESTS + 1 ))
     TITLE="${1%"${1#?}"}->${SERVER_NAME%"${SERVER_NAME#?}"}"
     TITLE="$TITLE $MODE,$VERIF $2"
-    printf "%s %.*s " "$TITLE" "$((72 - ${#TITLE}))" ........................................................................
+    DOTS72="........................................................................"
+    printf "%s %.*s " "$TITLE" "$((71 - ${#TITLE}))" "$DOTS72"
 
     # should we skip?
     if [ "X$SKIP_NEXT" = "XYES" ]; then

--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -679,7 +679,11 @@ setup_arguments()
 
 # is_mbedtls <cmd_line>
 is_mbedtls() {
-    echo "$1" | grep 'ssl_server2\|ssl_client2' > /dev/null
+    case $1 in
+        *ssl_client2*) true;;
+        *ssl_server2*) true;;
+        *) false;;
+    esac
 }
 
 # has_mem_err <log_file_name>
@@ -798,12 +802,9 @@ wait_client_done() {
 run_client() {
     # announce what we're going to do
     TESTS=$(( $TESTS + 1 ))
-    VERIF=$(echo $VERIFY | tr '[:upper:]' '[:lower:]')
-    TITLE="`echo $1 | head -c1`->`echo $SERVER_NAME | head -c1`"
+    TITLE="${1%"${1#?}"}->${SERVER_NAME%"${SERVER_NAME#?}"}"
     TITLE="$TITLE $MODE,$VERIF $2"
-    printf "%s " "$TITLE"
-    LEN=$(( 72 - `echo "$TITLE" | wc -c` ))
-    for i in `seq 1 $LEN`; do printf '.'; done; printf ' '
+    printf "%s %.*s " "$TITLE" "$((72 - ${#TITLE}))" ........................................................................
 
     # should we skip?
     if [ "X$SKIP_NEXT" = "XYES" ]; then
@@ -996,6 +997,7 @@ SKIP_NEXT="NO"
 trap cleanup INT TERM HUP
 
 for VERIFY in $VERIFIES; do
+    VERIF=$(echo $VERIFY | tr '[:upper:]' '[:lower:]')
     for MODE in $MODES; do
         for TYPE in $TYPES; do
             for PEER in $PEERS; do

--- a/tests/scripts/translate_ciphers.py
+++ b/tests/scripts/translate_ciphers.py
@@ -179,7 +179,7 @@ def format_ciphersuite_names(mode, names):
          "o": translate_ossl,
          "m": translate_mbedtls
         }[mode]
-    return " ".join(t(c) for c in names)
+    return " ".join(c + '=' + t(c) for c in names)
 
 def main(target, names):
     print(format_ciphersuite_names(target, names))

--- a/tests/scripts/translate_ciphers.py
+++ b/tests/scripts/translate_ciphers.py
@@ -18,8 +18,7 @@
 # limitations under the License.
 
 """
-Translate ciphersuite names in Mbed TLS format to OpenSSL and GNUTLS
-standards.
+Translate standard ciphersuite names to GnuTLS, OpenSSL and Mbed TLS standards.
 
 To test the translation functions run:
 python3 -m unittest translate_cipher.py
@@ -36,116 +35,150 @@ class TestTranslateCiphers(unittest.TestCase):
     """
     def test_translate_all_cipher_names(self):
         """
-        Translate MbedTLS ciphersuite names to their OpenSSL and
-        GnuTLS counterpart. Use only a small subset of ciphers
-        that exercise each step of the translate functions
+        Translate standard ciphersuite names to GnuTLS, OpenSSL and
+        Mbed TLS counterpart. Use only a small subset of ciphers
+        that exercise each step of the translation functions
         """
         ciphers = [
-            ("TLS-ECDHE-ECDSA-WITH-NULL-SHA",
+            ("TLS_ECDHE_ECDSA_WITH_NULL_SHA",
              "+ECDHE-ECDSA:+NULL:+SHA1",
-             "ECDHE-ECDSA-NULL-SHA"),
-            ("TLS-ECDHE-ECDSA-WITH-AES-128-GCM-SHA256",
+             "ECDHE-ECDSA-NULL-SHA",
+             "TLS-ECDHE-ECDSA-WITH-NULL-SHA"),
+            ("TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
              "+ECDHE-ECDSA:+AES-128-GCM:+AEAD",
-             "ECDHE-ECDSA-AES128-GCM-SHA256"),
-            ("TLS-DHE-RSA-WITH-3DES-EDE-CBC-SHA",
+             "ECDHE-ECDSA-AES128-GCM-SHA256",
+             "TLS-ECDHE-ECDSA-WITH-AES-128-GCM-SHA256"),
+            ("TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA",
              "+DHE-RSA:+3DES-CBC:+SHA1",
-             "EDH-RSA-DES-CBC3-SHA"),
-            ("TLS-RSA-WITH-AES-256-CBC-SHA",
+             "EDH-RSA-DES-CBC3-SHA",
+             "TLS-DHE-RSA-WITH-3DES-EDE-CBC-SHA"),
+            ("TLS_RSA_WITH_AES_256_CBC_SHA",
              "+RSA:+AES-256-CBC:+SHA1",
-             "AES256-SHA"),
-            ("TLS-PSK-WITH-3DES-EDE-CBC-SHA",
+             "AES256-SHA",
+             "TLS-RSA-WITH-AES-256-CBC-SHA"),
+            ("TLS_PSK_WITH_3DES_EDE_CBC_SHA",
              "+PSK:+3DES-CBC:+SHA1",
-             "PSK-3DES-EDE-CBC-SHA"),
-            ("TLS-ECDHE-ECDSA-WITH-CHACHA20-POLY1305-SHA256",
+             "PSK-3DES-EDE-CBC-SHA",
+             "TLS-PSK-WITH-3DES-EDE-CBC-SHA"),
+            ("TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
              None,
-             "ECDHE-ECDSA-CHACHA20-POLY1305"),
-            ("TLS-ECDHE-ECDSA-WITH-AES-128-CCM",
+             "ECDHE-ECDSA-CHACHA20-POLY1305",
+             "TLS-ECDHE-ECDSA-WITH-CHACHA20-POLY1305-SHA256"),
+            ("TLS_ECDHE_ECDSA_WITH_AES_128_CCM",
              "+ECDHE-ECDSA:+AES-128-CCM:+AEAD",
-             None),
-            ("TLS-ECDHE-RSA-WITH-ARIA-256-GCM-SHA384",
              None,
-             "ECDHE-ARIA256-GCM-SHA384"),
+             "TLS-ECDHE-ECDSA-WITH-AES-128-CCM"),
+            ("TLS_ECDHE_RSA_WITH_ARIA_256_GCM_SHA384",
+             None,
+             "ECDHE-ARIA256-GCM-SHA384",
+             "TLS-ECDHE-RSA-WITH-ARIA-256-GCM-SHA384"),
         ]
 
-        for m, g_exp, o_exp in ciphers:
+        for s, g_exp, o_exp, m_exp in ciphers:
 
             if g_exp is not None:
-                g = translate_gnutls(m)
+                g = translate_gnutls(s)
                 self.assertEqual(g, g_exp)
 
             if o_exp is not None:
-                o = translate_ossl(m)
+                o = translate_ossl(s)
                 self.assertEqual(o, o_exp)
 
-def translate_gnutls(m_cipher):
+            if m_exp is not None:
+                m = translate_mbedtls(s)
+                self.assertEqual(m, m_exp)
+
+def translate_gnutls(s_cipher):
     """
-    Translate m_cipher from Mbed TLS ciphersuite naming convention
+    Translate s_cipher from standard ciphersuite naming convention
     and return the GnuTLS naming convention
     """
 
-    m_cipher = re.sub(r'\ATLS-', '+', m_cipher)
-    m_cipher = m_cipher.replace("-WITH-", ":+")
-    m_cipher = m_cipher.replace("-EDE", "")
+    # Replace "_" with "-" to handle ciphersuite names based on Mbed TLS
+    # naming convention
+    s_cipher = s_cipher.replace("_", "-")
+
+    s_cipher = re.sub(r'\ATLS-', '+', s_cipher)
+    s_cipher = s_cipher.replace("-WITH-", ":+")
+    s_cipher = s_cipher.replace("-EDE", "")
 
     # SHA in Mbed TLS == SHA1 GnuTLS,
     # if the last 3 chars are SHA append 1
-    if m_cipher[-3:] == "SHA":
-        m_cipher = m_cipher+"1"
+    if s_cipher[-3:] == "SHA":
+        s_cipher = s_cipher+"1"
 
     # CCM or CCM-8 should be followed by ":+AEAD"
     # Replace "GCM:+SHAxyz" with "GCM:+AEAD"
-    if "CCM" in m_cipher or "GCM" in m_cipher:
-        m_cipher = re.sub(r"GCM-SHA\d\d\d", "GCM", m_cipher)
-        m_cipher = m_cipher+":+AEAD"
+    if "CCM" in s_cipher or "GCM" in s_cipher:
+        s_cipher = re.sub(r"GCM-SHA\d\d\d", "GCM", s_cipher)
+        s_cipher = s_cipher+":+AEAD"
 
     # Replace the last "-" with ":+"
     else:
-        index = m_cipher.rindex("-")
-        m_cipher = m_cipher[:index] + ":+" + m_cipher[index+1:]
+        index = s_cipher.rindex("-")
+        s_cipher = s_cipher[:index] + ":+" + s_cipher[index+1:]
 
-    return m_cipher
+    return s_cipher
 
-def translate_ossl(m_cipher):
+def translate_ossl(s_cipher):
     """
-    Translate m_cipher from Mbed TLS ciphersuite naming convention
+    Translate s_cipher from standard ciphersuite naming convention
     and return the OpenSSL naming convention
     """
 
-    m_cipher = re.sub(r'^TLS-', '', m_cipher)
-    m_cipher = m_cipher.replace("-WITH", "")
+    # Replace "_" with "-" to handle ciphersuite names based on Mbed TLS
+    # naming convention
+    s_cipher = s_cipher.replace("_", "-")
+
+    s_cipher = re.sub(r'^TLS-', '', s_cipher)
+    s_cipher = s_cipher.replace("-WITH", "")
 
     # Remove the "-" from "ABC-xyz"
-    m_cipher = m_cipher.replace("AES-", "AES")
-    m_cipher = m_cipher.replace("CAMELLIA-", "CAMELLIA")
-    m_cipher = m_cipher.replace("ARIA-", "ARIA")
+    s_cipher = s_cipher.replace("AES-", "AES")
+    s_cipher = s_cipher.replace("CAMELLIA-", "CAMELLIA")
+    s_cipher = s_cipher.replace("ARIA-", "ARIA")
 
     # Remove "RSA" if it is at the beginning
-    m_cipher = re.sub(r'^RSA-', r'', m_cipher)
+    s_cipher = re.sub(r'^RSA-', r'', s_cipher)
 
     # For all circumstances outside of PSK
-    if "PSK" not in m_cipher:
-        m_cipher = m_cipher.replace("-EDE", "")
-        m_cipher = m_cipher.replace("3DES-CBC", "DES-CBC3")
+    if "PSK" not in s_cipher:
+        s_cipher = s_cipher.replace("-EDE", "")
+        s_cipher = s_cipher.replace("3DES-CBC", "DES-CBC3")
 
         # Remove "CBC" if it is not prefixed by DES
-        m_cipher = re.sub(r'(?<!DES-)CBC-', r'', m_cipher)
+        s_cipher = re.sub(r'(?<!DES-)CBC-', r'', s_cipher)
 
     # ECDHE-RSA-ARIA does not exist in OpenSSL
-    m_cipher = m_cipher.replace("ECDHE-RSA-ARIA", "ECDHE-ARIA")
+    s_cipher = s_cipher.replace("ECDHE-RSA-ARIA", "ECDHE-ARIA")
 
     # POLY1305 should not be followed by anything
-    if "POLY1305" in m_cipher:
-        index = m_cipher.rindex("POLY1305")
-        m_cipher = m_cipher[:index+8]
+    if "POLY1305" in s_cipher:
+        index = s_cipher.rindex("POLY1305")
+        s_cipher = s_cipher[:index+8]
 
     # If DES is being used, Replace DHE with EDH
-    if "DES" in m_cipher and "DHE" in m_cipher and "ECDHE" not in m_cipher:
-        m_cipher = m_cipher.replace("DHE", "EDH")
+    if "DES" in s_cipher and "DHE" in s_cipher and "ECDHE" not in s_cipher:
+        s_cipher = s_cipher.replace("DHE", "EDH")
 
-    return m_cipher
+    return s_cipher
+
+def translate_mbedtls(s_cipher):
+    """
+    Translate s_cipher from standard ciphersuite naming convention
+    and return Mbed TLS ciphersuite naming convention
+    """
+
+    # Replace "_" with "-"
+    s_cipher = s_cipher.replace("_", "-")
+
+    return s_cipher
 
 def format_ciphersuite_names(mode, names):
-    t = {"g": translate_gnutls, "o": translate_ossl}[mode]
+    t = {"g": translate_gnutls,
+         "o": translate_ossl,
+         "m": translate_mbedtls
+        }[mode]
     return " ".join(t(c) for c in names)
 
 def main(target, names):
@@ -153,7 +186,7 @@ def main(target, names):
 
 if __name__ == "__main__":
     PARSER = argparse.ArgumentParser()
-    PARSER.add_argument('target', metavar='TARGET', choices=['o', 'g'])
+    PARSER.add_argument('target', metavar='TARGET', choices=['o', 'g', 'm'])
     PARSER.add_argument('names', metavar='NAMES', nargs='+')
     ARGS = PARSER.parse_args()
     main(ARGS.target, ARGS.names)


### PR DESCRIPTION
## Description

Fix: #6651

## Comments

This PR is not finished yet, just to back up all the modifications. We need further dicussion to consider if we should put more effort on this PR since we may rewrite `compat.sh` in Python.

## Gatekeeper checklist

- [x] **changelog** not required
- [x] **backport** not required
- [x] **tests** not required
