### PR TITLE
Rename modulus input argument from m to N

### DIFF
--- a/library/bignum_mod.c
+++ b/library/bignum_mod.c
@@ -351,30 +351,30 @@ int mbedtls_mpi_mod_random(mbedtls_mpi_mod_residue *X,
 /* END MERGE SLOT 6 */
 
 /* BEGIN MERGE SLOT 7 */
-int mbedtls_mpi_mod_read(mbedtls_mpi_mod_residue *r,
-                         const mbedtls_mpi_mod_modulus *m,
-                         const unsigned char *buf,
-                         size_t buflen,
-                         mbedtls_mpi_mod_ext_rep ext_rep)
+int mbedtls_mpi_mod_read( mbedtls_mpi_mod_residue *r,
+                          const mbedtls_mpi_mod_modulus *N,
+                          const unsigned char *buf,
+                          size_t buflen,
+                          mbedtls_mpi_mod_ext_rep ext_rep )
 {
     int ret = MBEDTLS_ERR_MPI_BAD_INPUT_DATA;
 
     /* Do our best to check if r and m have been set up */
-    if (r->limbs == 0 || m->limbs == 0) {
+    if (r->limbs == 0 || N->limbs == 0) {
         goto cleanup;
     }
-    if (r->limbs != m->limbs) {
+    if (r->limbs != N->limbs) {
         goto cleanup;
     }
 
-    ret = mbedtls_mpi_mod_raw_read(r->p, m, buf, buflen, ext_rep);
+    ret = mbedtls_mpi_mod_raw_read(r->p, N, buf, buflen, ext_rep);
     if (ret != 0) {
         goto cleanup;
     }
 
-    r->limbs = m->limbs;
+    r->limbs = N->limbs;
 
-    ret = mbedtls_mpi_mod_raw_canonical_to_modulus_rep(r->p, m);
+    ret = mbedtls_mpi_mod_raw_canonical_to_modulus_rep( r->p, N );
 
 cleanup:
     return ret;

--- a/library/bignum_mod.c
+++ b/library/bignum_mod.c
@@ -380,37 +380,38 @@ cleanup:
     return ret;
 }
 
-int mbedtls_mpi_mod_write(const mbedtls_mpi_mod_residue *r,
-                          const mbedtls_mpi_mod_modulus *m,
-                          unsigned char *buf,
-                          size_t buflen,
-                          mbedtls_mpi_mod_ext_rep ext_rep)
+int mbedtls_mpi_mod_write( const mbedtls_mpi_mod_residue *r,
+                           const mbedtls_mpi_mod_modulus *N,
+                           unsigned char *buf,
+                           size_t buflen,
+                           mbedtls_mpi_mod_ext_rep ext_rep )
 {
     int ret = MBEDTLS_ERR_MPI_BAD_INPUT_DATA;
 
     /* Do our best to check if r and m have been set up */
-    if (r->limbs == 0 || m->limbs == 0) {
+    if (r->limbs == 0 || N->limbs == 0) {
         goto cleanup;
     }
-    if (r->limbs != m->limbs) {
+    if (r->limbs != N->limbs) {
         goto cleanup;
     }
 
-    if (m->int_rep == MBEDTLS_MPI_MOD_REP_MONTGOMERY) {
-        ret = mbedtls_mpi_mod_raw_from_mont_rep(r->p, m);
+    if (N->int_rep == MBEDTLS_MPI_MOD_REP_MONTGOMERY) {
+        ret = mbedtls_mpi_mod_raw_from_mont_rep(r->p, N);
         if (ret != 0) {
             goto cleanup;
         }
     }
 
-    ret = mbedtls_mpi_mod_raw_write(r->p, m, buf, buflen, ext_rep);
+    ret = mbedtls_mpi_mod_raw_write( r->p, N, buf, buflen, ext_rep );
 
-    if (m->int_rep == MBEDTLS_MPI_MOD_REP_MONTGOMERY) {
+    if( N->int_rep == MBEDTLS_MPI_MOD_REP_MONTGOMERY )
+    {
         /* If this fails, the value of r is corrupted and we want to return
          * this error (as opposed to the error code from the write above) to
          * let the caller know. If it succeeds, we want to return the error
          * code from write above. */
-        int conv_ret = mbedtls_mpi_mod_raw_to_mont_rep(r->p, m);
+        int conv_ret = mbedtls_mpi_mod_raw_to_mont_rep(r->p, N);
         if (ret == 0) {
             ret = conv_ret;
         }

--- a/library/bignum_mod.c
+++ b/library/bignum_mod.c
@@ -34,16 +34,16 @@
 #include "bignum_mod_raw.h"
 #include "constant_time_internal.h"
 
-int mbedtls_mpi_mod_residue_setup(mbedtls_mpi_mod_residue *r,
-                                  const mbedtls_mpi_mod_modulus *m,
-                                  mbedtls_mpi_uint *p,
-                                  size_t p_limbs)
+int mbedtls_mpi_mod_residue_setup( mbedtls_mpi_mod_residue *r,
+                                   const mbedtls_mpi_mod_modulus *N,
+                                   mbedtls_mpi_uint *p,
+                                   size_t p_limbs )
 {
-    if (p_limbs != m->limbs || !mbedtls_mpi_core_lt_ct(p, m->p, m->limbs)) {
+    if (p_limbs != N->limbs || !mbedtls_mpi_core_lt_ct(p, N->p, N->limbs)) {
         return MBEDTLS_ERR_MPI_BAD_INPUT_DATA;
     }
 
-    r->limbs = m->limbs;
+    r->limbs = N->limbs;
     r->p = p;
 
     return 0;

--- a/library/bignum_mod.c
+++ b/library/bignum_mod.c
@@ -136,26 +136,26 @@ cleanup:
     return ret;
 }
 
-int mbedtls_mpi_mod_modulus_setup(mbedtls_mpi_mod_modulus *m,
-                                  const mbedtls_mpi_uint *p,
-                                  size_t p_limbs,
-                                  mbedtls_mpi_mod_rep_selector int_rep)
+int mbedtls_mpi_mod_modulus_setup( mbedtls_mpi_mod_modulus *N,
+                                   const mbedtls_mpi_uint *p,
+                                   size_t p_limbs,
+                                   mbedtls_mpi_mod_rep_selector int_rep )
 {
     int ret = 0;
 
-    m->p = p;
-    m->limbs = p_limbs;
-    m->bits = mbedtls_mpi_core_bitlen(p, p_limbs);
+    N->p = p;
+    N->limbs = p_limbs;
+    N->bits = mbedtls_mpi_core_bitlen( p, p_limbs );
 
     switch (int_rep) {
         case MBEDTLS_MPI_MOD_REP_MONTGOMERY:
-            m->int_rep = int_rep;
-            m->rep.mont.mm = mbedtls_mpi_core_montmul_init(m->p);
-            ret = set_mont_const_square(&m->rep.mont.rr, m->p, m->limbs);
+            N->int_rep = int_rep;
+            N->rep.mont.mm = mbedtls_mpi_core_montmul_init( N->p );
+            ret = set_mont_const_square( &N->rep.mont.rr, N->p, N->limbs );
             break;
         case MBEDTLS_MPI_MOD_REP_OPT_RED:
-            m->int_rep = int_rep;
-            m->rep.ored = NULL;
+            N->int_rep = int_rep;
+            N->rep.ored = NULL;
             break;
         default:
             ret = MBEDTLS_ERR_MPI_BAD_INPUT_DATA;
@@ -164,8 +164,9 @@ int mbedtls_mpi_mod_modulus_setup(mbedtls_mpi_mod_modulus *m,
 
 exit:
 
-    if (ret != 0) {
-        mbedtls_mpi_mod_modulus_free(m);
+    if( ret != 0 )
+    {
+        mbedtls_mpi_mod_modulus_free( N );
     }
 
     return ret;

--- a/library/bignum_mod.c
+++ b/library/bignum_mod.c
@@ -71,33 +71,35 @@ void mbedtls_mpi_mod_modulus_init( mbedtls_mpi_mod_modulus *N )
     N->int_rep = MBEDTLS_MPI_MOD_REP_INVALID;
 }
 
-void mbedtls_mpi_mod_modulus_free(mbedtls_mpi_mod_modulus *m)
+void mbedtls_mpi_mod_modulus_free( mbedtls_mpi_mod_modulus *N )
 {
-    if (m == NULL) {
+    if (N == NULL) {
         return;
     }
 
-    switch (m->int_rep) {
+    switch( N->int_rep )
+    {
         case MBEDTLS_MPI_MOD_REP_MONTGOMERY:
-            if (m->rep.mont.rr != NULL) {
-                mbedtls_platform_zeroize((mbedtls_mpi_uint *) m->rep.mont.rr,
-                                         m->limbs * sizeof(mbedtls_mpi_uint));
-                mbedtls_free((mbedtls_mpi_uint *) m->rep.mont.rr);
-                m->rep.mont.rr = NULL;
+            if (N->rep.mont.rr != NULL)
+            {
+                mbedtls_platform_zeroize( (mbedtls_mpi_uint *) N->rep.mont.rr,
+                                           N->limbs * sizeof(mbedtls_mpi_uint) );
+                mbedtls_free( (mbedtls_mpi_uint *)N->rep.mont.rr );
+                N->rep.mont.rr = NULL;
             }
-            m->rep.mont.mm = 0;
+            N->rep.mont.mm = 0;
             break;
         case MBEDTLS_MPI_MOD_REP_OPT_RED:
-            mbedtls_free(m->rep.ored);
+            mbedtls_free( N->rep.ored );
             break;
         case MBEDTLS_MPI_MOD_REP_INVALID:
             break;
     }
 
-    m->p = NULL;
-    m->limbs = 0;
-    m->bits = 0;
-    m->int_rep = MBEDTLS_MPI_MOD_REP_INVALID;
+    N->p = NULL;
+    N->limbs = 0;
+    N->bits = 0;
+    N->int_rep = MBEDTLS_MPI_MOD_REP_INVALID;
 }
 
 static int set_mont_const_square(const mbedtls_mpi_uint **X,

--- a/library/bignum_mod.c
+++ b/library/bignum_mod.c
@@ -59,16 +59,16 @@ void mbedtls_mpi_mod_residue_release(mbedtls_mpi_mod_residue *r)
     r->p = NULL;
 }
 
-void mbedtls_mpi_mod_modulus_init(mbedtls_mpi_mod_modulus *m)
+void mbedtls_mpi_mod_modulus_init( mbedtls_mpi_mod_modulus *N )
 {
-    if (m == NULL) {
+    if (N == NULL) {
         return;
     }
 
-    m->p = NULL;
-    m->limbs = 0;
-    m->bits = 0;
-    m->int_rep = MBEDTLS_MPI_MOD_REP_INVALID;
+    N->p = NULL;
+    N->limbs = 0;
+    N->bits = 0;
+    N->int_rep = MBEDTLS_MPI_MOD_REP_INVALID;
 }
 
 void mbedtls_mpi_mod_modulus_free(mbedtls_mpi_mod_modulus *m)

--- a/library/bignum_mod.c
+++ b/library/bignum_mod.c
@@ -34,10 +34,10 @@
 #include "bignum_mod_raw.h"
 #include "constant_time_internal.h"
 
-int mbedtls_mpi_mod_residue_setup( mbedtls_mpi_mod_residue *r,
-                                   const mbedtls_mpi_mod_modulus *N,
-                                   mbedtls_mpi_uint *p,
-                                   size_t p_limbs )
+int mbedtls_mpi_mod_residue_setup(mbedtls_mpi_mod_residue *r,
+                                  const mbedtls_mpi_mod_modulus *N,
+                                  mbedtls_mpi_uint *p,
+                                  size_t p_limbs)
 {
     if (p_limbs != N->limbs || !mbedtls_mpi_core_lt_ct(p, N->p, N->limbs)) {
         return MBEDTLS_ERR_MPI_BAD_INPUT_DATA;
@@ -59,7 +59,7 @@ void mbedtls_mpi_mod_residue_release(mbedtls_mpi_mod_residue *r)
     r->p = NULL;
 }
 
-void mbedtls_mpi_mod_modulus_init( mbedtls_mpi_mod_modulus *N )
+void mbedtls_mpi_mod_modulus_init(mbedtls_mpi_mod_modulus *N)
 {
     if (N == NULL) {
         return;
@@ -71,26 +71,24 @@ void mbedtls_mpi_mod_modulus_init( mbedtls_mpi_mod_modulus *N )
     N->int_rep = MBEDTLS_MPI_MOD_REP_INVALID;
 }
 
-void mbedtls_mpi_mod_modulus_free( mbedtls_mpi_mod_modulus *N )
+void mbedtls_mpi_mod_modulus_free(mbedtls_mpi_mod_modulus *N)
 {
     if (N == NULL) {
         return;
     }
 
-    switch( N->int_rep )
-    {
+    switch (N->int_rep) {
         case MBEDTLS_MPI_MOD_REP_MONTGOMERY:
-            if (N->rep.mont.rr != NULL)
-            {
-                mbedtls_platform_zeroize( (mbedtls_mpi_uint *) N->rep.mont.rr,
-                                           N->limbs * sizeof(mbedtls_mpi_uint) );
-                mbedtls_free( (mbedtls_mpi_uint *)N->rep.mont.rr );
+            if (N->rep.mont.rr != NULL) {
+                mbedtls_platform_zeroize((mbedtls_mpi_uint *) N->rep.mont.rr,
+                                         N->limbs * sizeof(mbedtls_mpi_uint));
+                mbedtls_free((mbedtls_mpi_uint *) N->rep.mont.rr);
                 N->rep.mont.rr = NULL;
             }
             N->rep.mont.mm = 0;
             break;
         case MBEDTLS_MPI_MOD_REP_OPT_RED:
-            mbedtls_free( N->rep.ored );
+            mbedtls_free(N->rep.ored);
             break;
         case MBEDTLS_MPI_MOD_REP_INVALID:
             break;
@@ -138,22 +136,22 @@ cleanup:
     return ret;
 }
 
-int mbedtls_mpi_mod_modulus_setup( mbedtls_mpi_mod_modulus *N,
-                                   const mbedtls_mpi_uint *p,
-                                   size_t p_limbs,
-                                   mbedtls_mpi_mod_rep_selector int_rep )
+int mbedtls_mpi_mod_modulus_setup(mbedtls_mpi_mod_modulus *N,
+                                  const mbedtls_mpi_uint *p,
+                                  size_t p_limbs,
+                                  mbedtls_mpi_mod_rep_selector int_rep)
 {
     int ret = 0;
 
     N->p = p;
     N->limbs = p_limbs;
-    N->bits = mbedtls_mpi_core_bitlen( p, p_limbs );
+    N->bits = mbedtls_mpi_core_bitlen(p, p_limbs);
 
     switch (int_rep) {
         case MBEDTLS_MPI_MOD_REP_MONTGOMERY:
             N->int_rep = int_rep;
-            N->rep.mont.mm = mbedtls_mpi_core_montmul_init( N->p );
-            ret = set_mont_const_square( &N->rep.mont.rr, N->p, N->limbs );
+            N->rep.mont.mm = mbedtls_mpi_core_montmul_init(N->p);
+            ret = set_mont_const_square(&N->rep.mont.rr, N->p, N->limbs);
             break;
         case MBEDTLS_MPI_MOD_REP_OPT_RED:
             N->int_rep = int_rep;
@@ -166,9 +164,8 @@ int mbedtls_mpi_mod_modulus_setup( mbedtls_mpi_mod_modulus *N,
 
 exit:
 
-    if( ret != 0 )
-    {
-        mbedtls_mpi_mod_modulus_free( N );
+    if (ret != 0) {
+        mbedtls_mpi_mod_modulus_free(N);
     }
 
     return ret;
@@ -351,11 +348,11 @@ int mbedtls_mpi_mod_random(mbedtls_mpi_mod_residue *X,
 /* END MERGE SLOT 6 */
 
 /* BEGIN MERGE SLOT 7 */
-int mbedtls_mpi_mod_read( mbedtls_mpi_mod_residue *r,
-                          const mbedtls_mpi_mod_modulus *N,
-                          const unsigned char *buf,
-                          size_t buflen,
-                          mbedtls_mpi_mod_ext_rep ext_rep )
+int mbedtls_mpi_mod_read(mbedtls_mpi_mod_residue *r,
+                         const mbedtls_mpi_mod_modulus *N,
+                         const unsigned char *buf,
+                         size_t buflen,
+                         mbedtls_mpi_mod_ext_rep ext_rep)
 {
     int ret = MBEDTLS_ERR_MPI_BAD_INPUT_DATA;
 
@@ -374,17 +371,17 @@ int mbedtls_mpi_mod_read( mbedtls_mpi_mod_residue *r,
 
     r->limbs = N->limbs;
 
-    ret = mbedtls_mpi_mod_raw_canonical_to_modulus_rep( r->p, N );
+    ret = mbedtls_mpi_mod_raw_canonical_to_modulus_rep(r->p, N);
 
 cleanup:
     return ret;
 }
 
-int mbedtls_mpi_mod_write( const mbedtls_mpi_mod_residue *r,
-                           const mbedtls_mpi_mod_modulus *N,
-                           unsigned char *buf,
-                           size_t buflen,
-                           mbedtls_mpi_mod_ext_rep ext_rep )
+int mbedtls_mpi_mod_write(const mbedtls_mpi_mod_residue *r,
+                          const mbedtls_mpi_mod_modulus *N,
+                          unsigned char *buf,
+                          size_t buflen,
+                          mbedtls_mpi_mod_ext_rep ext_rep)
 {
     int ret = MBEDTLS_ERR_MPI_BAD_INPUT_DATA;
 
@@ -403,10 +400,9 @@ int mbedtls_mpi_mod_write( const mbedtls_mpi_mod_residue *r,
         }
     }
 
-    ret = mbedtls_mpi_mod_raw_write( r->p, N, buf, buflen, ext_rep );
+    ret = mbedtls_mpi_mod_raw_write(r->p, N, buf, buflen, ext_rep);
 
-    if( N->int_rep == MBEDTLS_MPI_MOD_REP_MONTGOMERY )
-    {
+    if (N->int_rep == MBEDTLS_MPI_MOD_REP_MONTGOMERY) {
         /* If this fails, the value of r is corrupted and we want to return
          * this error (as opposed to the error code from the write above) to
          * let the caller know. If it succeeds, we want to return the error

--- a/library/bignum_mod.h
+++ b/library/bignum_mod.h
@@ -429,22 +429,22 @@ int mbedtls_mpi_mod_read( mbedtls_mpi_mod_residue *r,
 
 /** Write a residue into a byte buffer.
  *
- * The modulus \p m must be the modulus associated with \p r (see
+ * The modulus \p N must be the modulus associated with \p r (see
  * mbedtls_mpi_mod_residue_setup() and mbedtls_mpi_mod_read()).
  *
  * The residue will be automatically converted from the internal representation
- * based on the value of `m->int_rep` field.
+ * based on the value of `N->int_rep` field.
  *
- * \warning     If the buffer is smaller than `m->bits`, the number of
+ * \warning     If the buffer is smaller than `N->bits`, the number of
  *              leading zeroes is leaked through timing. If \p r is
  *              secret, the caller must ensure that \p buflen is at least
- *              (`m->bits`+7)/8.
+ *              (`N->bits`+7)/8.
  *
  * \param[in] r     The address of the residue. It must have the same number of
- *                  limbs as the modulus \p m. (\p r is an input parameter, but
+ *                  limbs as the modulus \p N. (\p r is an input parameter, but
  *                  its value will be modified during execution and restored
  *                  before the function returns.)
- * \param[in] m     The address of the modulus associated with \r.
+ * \param[in] N     The address of the modulus associated with \r.
  * \param[out] buf  The output buffer to export to.
  * \param buflen    The length in bytes of \p buf.
  * \param ext_rep   The endianness in which the number should be written into
@@ -459,11 +459,11 @@ int mbedtls_mpi_mod_read( mbedtls_mpi_mod_residue *r,
  *               memory for conversion. Can occur only for moduli with
  *               MBEDTLS_MPI_MOD_REP_MONTGOMERY.
  */
-int mbedtls_mpi_mod_write(const mbedtls_mpi_mod_residue *r,
-                          const mbedtls_mpi_mod_modulus *m,
-                          unsigned char *buf,
-                          size_t buflen,
-                          mbedtls_mpi_mod_ext_rep ext_rep);
+int mbedtls_mpi_mod_write( const mbedtls_mpi_mod_residue *r,
+                           const mbedtls_mpi_mod_modulus *N,
+                           unsigned char *buf,
+                           size_t buflen,
+                           mbedtls_mpi_mod_ext_rep ext_rep );
 /* END MERGE SLOT 7 */
 
 /* BEGIN MERGE SLOT 8 */

--- a/library/bignum_mod.h
+++ b/library/bignum_mod.h
@@ -185,20 +185,20 @@ void mbedtls_mpi_mod_residue_release(mbedtls_mpi_mod_residue *r);
 
 /** Initialize a modulus structure.
  *
- * \param[out] m     The address of the modulus structure to initialize.
+ * \param[out] N     The address of the modulus structure to initialize.
  */
-void mbedtls_mpi_mod_modulus_init(mbedtls_mpi_mod_modulus *m);
+void mbedtls_mpi_mod_modulus_init( mbedtls_mpi_mod_modulus *N );
 
 /** Setup a modulus structure.
  *
- * \param[out] m    The address of the modulus structure to populate.
- * \param[in] p     The address of the limb array storing the value of \p m.
- *                  The memory pointed to by \p p will be used by \p m and must
+ * \param[out] N    The address of the modulus structure to populate.
+ * \param[in] p     The address of the limb array storing the value of \p N.
+ *                  The memory pointed to by \p p will be used by \p N and must
  *                  not be modified in any way until after
  *                  mbedtls_mpi_mod_modulus_free() is called.
  * \param p_limbs   The number of limbs of \p p.
  * \param int_rep   The internal representation to be used for residues
- *                  associated with \p m (see #mbedtls_mpi_mod_rep_selector).
+ *                  associated with \p N (see #mbedtls_mpi_mod_rep_selector).
  *
  * \return      \c 0 if successful.
  * \return      #MBEDTLS_ERR_MPI_BAD_INPUT_DATA if \p int_rep is invalid.

--- a/library/bignum_mod.h
+++ b/library/bignum_mod.h
@@ -203,10 +203,10 @@ void mbedtls_mpi_mod_modulus_init( mbedtls_mpi_mod_modulus *N );
  * \return      \c 0 if successful.
  * \return      #MBEDTLS_ERR_MPI_BAD_INPUT_DATA if \p int_rep is invalid.
  */
-int mbedtls_mpi_mod_modulus_setup(mbedtls_mpi_mod_modulus *m,
-                                  const mbedtls_mpi_uint *p,
-                                  size_t p_limbs,
-                                  mbedtls_mpi_mod_rep_selector int_rep);
+int mbedtls_mpi_mod_modulus_setup( mbedtls_mpi_mod_modulus *N,
+                                   const mbedtls_mpi_uint *p,
+                                   size_t p_limbs,
+                                   mbedtls_mpi_mod_rep_selector int_rep );
 
 /** Free elements of a modulus structure.
  *

--- a/library/bignum_mod.h
+++ b/library/bignum_mod.h
@@ -216,9 +216,9 @@ int mbedtls_mpi_mod_modulus_setup( mbedtls_mpi_mod_modulus *N,
  *          mbedtls_mpi_mod_modulus_setup() only removes the reference to it,
  *          making it safe to free or to use it again.
  *
- * \param[in,out] m     The address of the modulus structure to free.
+ * \param[in,out] N     The address of the modulus structure to free.
  */
-void mbedtls_mpi_mod_modulus_free(mbedtls_mpi_mod_modulus *m);
+void mbedtls_mpi_mod_modulus_free( mbedtls_mpi_mod_modulus *N );
 
 /* BEGIN MERGE SLOT 1 */
 

--- a/library/bignum_mod.h
+++ b/library/bignum_mod.h
@@ -140,36 +140,36 @@ typedef struct {
 
 /** Setup a residue structure.
  *
- * The residue will be set up with the buffer \p p and modulus \p m.
+ * The residue will be set up with the buffer \p p and modulus \p N.
  *
  * The memory pointed to by \p p will be used by the resulting residue structure.
  * The value at the pointed-to memory will be the initial value of \p r and must
  * hold a value that is less than the modulus. This value will be used as-is
- * and interpreted according to the value of the `m->int_rep` field.
+ * and interpreted according to the value of the `N->int_rep` field.
  *
- * The modulus \p m will be the modulus associated with \p r. The residue \p r
- * should only be used in operations where the modulus is \p m.
+ * The modulus \p N will be the modulus associated with \p r. The residue \p r
+ * should only be used in operations where the modulus is \p N.
  *
  * \param[out] r    The address of the residue to setup.
- * \param[in] m     The address of the modulus related to \p r.
+ * \param[in] N     The address of the modulus related to \p r.
  * \param[in] p     The address of the limb array containing the value of \p r.
  *                  The memory pointed to by \p p will be used by \p r and must
  *                  not be modified in any way until after
  *                  mbedtls_mpi_mod_residue_release() is called. The data
  *                  pointed to by \p p must be less than the modulus (the value
- *                  pointed to by `m->p`) and already in the representation
- *                  indicated by `m->int_rep`.
+ *                  pointed to by `N->p`) and already in the representation
+ *                  indicated by `N->int_rep`.
  * \param p_limbs   The number of limbs of \p p. Must be the same as the number
- *                  of limbs in the modulus \p m.
+ *                  of limbs in the modulus \p N.
  *
  * \return      \c 0 if successful.
  * \return      #MBEDTLS_ERR_MPI_BAD_INPUT_DATA if \p p_limbs is less than the
- *              limbs in \p m or if \p p is not less than \p m.
+ *              limbs in \p N or if \p p is not less than \p N.
  */
-int mbedtls_mpi_mod_residue_setup(mbedtls_mpi_mod_residue *r,
-                                  const mbedtls_mpi_mod_modulus *m,
-                                  mbedtls_mpi_uint *p,
-                                  size_t p_limbs);
+int mbedtls_mpi_mod_residue_setup( mbedtls_mpi_mod_residue *r,
+                                   const mbedtls_mpi_mod_modulus *N,
+                                   mbedtls_mpi_uint *p,
+                                   size_t p_limbs );
 
 /** Unbind elements of a residue structure.
  *

--- a/library/bignum_mod.h
+++ b/library/bignum_mod.h
@@ -401,16 +401,16 @@ int mbedtls_mpi_mod_random(mbedtls_mpi_mod_residue *X,
 /** Read a residue from a byte buffer.
  *
  * The residue will be automatically converted to the internal representation
- * based on the value of the `m->int_rep` field.
+ * based on the value of the `N->int_rep` field.
  *
- * The modulus \p m will be the modulus associated with \p r. The residue \p r
- * should only be used in operations where the modulus is \p m or a modulus
- * equivalent to \p m (in the sense that all their fields or memory pointed by
+ * The modulus \p N will be the modulus associated with \p r. The residue \p r
+ * should only be used in operations where the modulus is \p N or a modulus
+ * equivalent to \p N (in the sense that all their fields or memory pointed by
  * their fields hold the same value).
  *
  * \param[out] r    The address of the residue. It must have exactly the same
- *                  number of limbs as the modulus \p m.
- * \param[in] m     The address of the modulus.
+ *                  number of limbs as the modulus \p N.
+ * \param[in] N     The address of the modulus.
  * \param[in] buf   The input buffer to import from.
  * \param buflen    The length in bytes of \p buf.
  * \param ext_rep   The endianness of the number in the input buffer.
@@ -419,13 +419,13 @@ int mbedtls_mpi_mod_random(mbedtls_mpi_mod_residue *X,
  * \return       #MBEDTLS_ERR_MPI_BUFFER_TOO_SMALL if \p r isn't
  *               large enough to hold the value in \p buf.
  * \return       #MBEDTLS_ERR_MPI_BAD_INPUT_DATA if \p ext_rep
- *               is invalid or the value in the buffer is not less than \p m.
+ *               is invalid or the value in the buffer is not less than \p N.
  */
-int mbedtls_mpi_mod_read(mbedtls_mpi_mod_residue *r,
-                         const mbedtls_mpi_mod_modulus *m,
-                         const unsigned char *buf,
-                         size_t buflen,
-                         mbedtls_mpi_mod_ext_rep ext_rep);
+int mbedtls_mpi_mod_read( mbedtls_mpi_mod_residue *r,
+                          const mbedtls_mpi_mod_modulus *N,
+                          const unsigned char *buf,
+                          size_t buflen,
+                          mbedtls_mpi_mod_ext_rep ext_rep );
 
 /** Write a residue into a byte buffer.
  *

--- a/library/bignum_mod.h
+++ b/library/bignum_mod.h
@@ -166,10 +166,10 @@ typedef struct {
  * \return      #MBEDTLS_ERR_MPI_BAD_INPUT_DATA if \p p_limbs is less than the
  *              limbs in \p N or if \p p is not less than \p N.
  */
-int mbedtls_mpi_mod_residue_setup( mbedtls_mpi_mod_residue *r,
-                                   const mbedtls_mpi_mod_modulus *N,
-                                   mbedtls_mpi_uint *p,
-                                   size_t p_limbs );
+int mbedtls_mpi_mod_residue_setup(mbedtls_mpi_mod_residue *r,
+                                  const mbedtls_mpi_mod_modulus *N,
+                                  mbedtls_mpi_uint *p,
+                                  size_t p_limbs);
 
 /** Unbind elements of a residue structure.
  *
@@ -187,7 +187,7 @@ void mbedtls_mpi_mod_residue_release(mbedtls_mpi_mod_residue *r);
  *
  * \param[out] N     The address of the modulus structure to initialize.
  */
-void mbedtls_mpi_mod_modulus_init( mbedtls_mpi_mod_modulus *N );
+void mbedtls_mpi_mod_modulus_init(mbedtls_mpi_mod_modulus *N);
 
 /** Setup a modulus structure.
  *
@@ -203,10 +203,10 @@ void mbedtls_mpi_mod_modulus_init( mbedtls_mpi_mod_modulus *N );
  * \return      \c 0 if successful.
  * \return      #MBEDTLS_ERR_MPI_BAD_INPUT_DATA if \p int_rep is invalid.
  */
-int mbedtls_mpi_mod_modulus_setup( mbedtls_mpi_mod_modulus *N,
-                                   const mbedtls_mpi_uint *p,
-                                   size_t p_limbs,
-                                   mbedtls_mpi_mod_rep_selector int_rep );
+int mbedtls_mpi_mod_modulus_setup(mbedtls_mpi_mod_modulus *N,
+                                  const mbedtls_mpi_uint *p,
+                                  size_t p_limbs,
+                                  mbedtls_mpi_mod_rep_selector int_rep);
 
 /** Free elements of a modulus structure.
  *
@@ -218,7 +218,7 @@ int mbedtls_mpi_mod_modulus_setup( mbedtls_mpi_mod_modulus *N,
  *
  * \param[in,out] N     The address of the modulus structure to free.
  */
-void mbedtls_mpi_mod_modulus_free( mbedtls_mpi_mod_modulus *N );
+void mbedtls_mpi_mod_modulus_free(mbedtls_mpi_mod_modulus *N);
 
 /* BEGIN MERGE SLOT 1 */
 
@@ -421,11 +421,11 @@ int mbedtls_mpi_mod_random(mbedtls_mpi_mod_residue *X,
  * \return       #MBEDTLS_ERR_MPI_BAD_INPUT_DATA if \p ext_rep
  *               is invalid or the value in the buffer is not less than \p N.
  */
-int mbedtls_mpi_mod_read( mbedtls_mpi_mod_residue *r,
-                          const mbedtls_mpi_mod_modulus *N,
-                          const unsigned char *buf,
-                          size_t buflen,
-                          mbedtls_mpi_mod_ext_rep ext_rep );
+int mbedtls_mpi_mod_read(mbedtls_mpi_mod_residue *r,
+                         const mbedtls_mpi_mod_modulus *N,
+                         const unsigned char *buf,
+                         size_t buflen,
+                         mbedtls_mpi_mod_ext_rep ext_rep);
 
 /** Write a residue into a byte buffer.
  *
@@ -459,11 +459,11 @@ int mbedtls_mpi_mod_read( mbedtls_mpi_mod_residue *r,
  *               memory for conversion. Can occur only for moduli with
  *               MBEDTLS_MPI_MOD_REP_MONTGOMERY.
  */
-int mbedtls_mpi_mod_write( const mbedtls_mpi_mod_residue *r,
-                           const mbedtls_mpi_mod_modulus *N,
-                           unsigned char *buf,
-                           size_t buflen,
-                           mbedtls_mpi_mod_ext_rep ext_rep );
+int mbedtls_mpi_mod_write(const mbedtls_mpi_mod_residue *r,
+                          const mbedtls_mpi_mod_modulus *N,
+                          unsigned char *buf,
+                          size_t buflen,
+                          mbedtls_mpi_mod_ext_rep ext_rep);
 /* END MERGE SLOT 7 */
 
 /* BEGIN MERGE SLOT 8 */

--- a/library/bignum_mod_raw.c
+++ b/library/bignum_mod_raw.c
@@ -85,19 +85,19 @@ cleanup:
     return ret;
 }
 
-int mbedtls_mpi_mod_raw_write(const mbedtls_mpi_uint *A,
-                              const mbedtls_mpi_mod_modulus *m,
-                              unsigned char *output,
-                              size_t output_length,
-                              mbedtls_mpi_mod_ext_rep ext_rep)
+int mbedtls_mpi_mod_raw_write( const mbedtls_mpi_uint *A,
+                               const mbedtls_mpi_mod_modulus *N,
+                               unsigned char *output,
+                               size_t output_length,
+                               mbedtls_mpi_mod_ext_rep ext_rep )
 {
     switch (ext_rep) {
         case MBEDTLS_MPI_MOD_EXT_REP_LE:
-            return mbedtls_mpi_core_write_le(A, m->limbs,
-                                             output, output_length);
+            return( mbedtls_mpi_core_write_le( A, N->limbs,
+                                               output, output_length ) );
         case MBEDTLS_MPI_MOD_EXT_REP_BE:
-            return mbedtls_mpi_core_write_be(A, m->limbs,
-                                             output, output_length);
+            return( mbedtls_mpi_core_write_be( A, N->limbs,
+                                               output, output_length ) );
         default:
             return MBEDTLS_ERR_MPI_BAD_INPUT_DATA;
     }

--- a/library/bignum_mod_raw.c
+++ b/library/bignum_mod_raw.c
@@ -229,18 +229,18 @@ int mbedtls_mpi_mod_raw_random(mbedtls_mpi_uint *X,
 /* END MERGE SLOT 6 */
 
 /* BEGIN MERGE SLOT 7 */
-int mbedtls_mpi_mod_raw_to_mont_rep(mbedtls_mpi_uint *X,
-                                    const mbedtls_mpi_mod_modulus *m)
+int mbedtls_mpi_mod_raw_to_mont_rep( mbedtls_mpi_uint *X,
+                                     const mbedtls_mpi_mod_modulus *N )
 {
     mbedtls_mpi_uint *T;
-    const size_t t_limbs = mbedtls_mpi_core_montmul_working_limbs(m->limbs);
+    const size_t t_limbs = mbedtls_mpi_core_montmul_working_limbs( N->limbs );
 
     if ((T = (mbedtls_mpi_uint *) mbedtls_calloc(t_limbs, ciL)) == NULL) {
         return MBEDTLS_ERR_MPI_ALLOC_FAILED;
     }
 
-    mbedtls_mpi_core_to_mont_rep(X, X, m->p, m->limbs,
-                                 m->rep.mont.mm, m->rep.mont.rr, T);
+    mbedtls_mpi_core_to_mont_rep( X, X, N->p, N->limbs,
+                                  N->rep.mont.mm, N->rep.mont.rr, T );
 
     mbedtls_platform_zeroize(T, t_limbs * ciL);
     mbedtls_free(T);

--- a/library/bignum_mod_raw.c
+++ b/library/bignum_mod_raw.c
@@ -49,22 +49,22 @@ void mbedtls_mpi_mod_raw_cond_swap(mbedtls_mpi_uint *X,
     mbedtls_mpi_core_cond_swap(X, Y, N->limbs, swap);
 }
 
-int mbedtls_mpi_mod_raw_read(mbedtls_mpi_uint *X,
-                             const mbedtls_mpi_mod_modulus *m,
-                             const unsigned char *input,
-                             size_t input_length,
-                             mbedtls_mpi_mod_ext_rep ext_rep)
+int mbedtls_mpi_mod_raw_read( mbedtls_mpi_uint *X,
+                              const mbedtls_mpi_mod_modulus *N,
+                              const unsigned char *input,
+                              size_t input_length,
+                              mbedtls_mpi_mod_ext_rep ext_rep )
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
 
     switch (ext_rep) {
         case MBEDTLS_MPI_MOD_EXT_REP_LE:
-            ret = mbedtls_mpi_core_read_le(X, m->limbs,
-                                           input, input_length);
+            ret = mbedtls_mpi_core_read_le( X, N->limbs,
+                                            input, input_length );
             break;
         case MBEDTLS_MPI_MOD_EXT_REP_BE:
-            ret = mbedtls_mpi_core_read_be(X, m->limbs,
-                                           input, input_length);
+            ret = mbedtls_mpi_core_read_be( X, N->limbs,
+                                            input, input_length );
             break;
         default:
             return MBEDTLS_ERR_MPI_BAD_INPUT_DATA;
@@ -74,7 +74,8 @@ int mbedtls_mpi_mod_raw_read(mbedtls_mpi_uint *X,
         goto cleanup;
     }
 
-    if (!mbedtls_mpi_core_lt_ct(X, m->p, m->limbs)) {
+    if( !mbedtls_mpi_core_lt_ct( X, N->p, N->limbs ) )
+    {
         ret = MBEDTLS_ERR_MPI_BAD_INPUT_DATA;
         goto cleanup;
     }

--- a/library/bignum_mod_raw.c
+++ b/library/bignum_mod_raw.c
@@ -49,22 +49,22 @@ void mbedtls_mpi_mod_raw_cond_swap(mbedtls_mpi_uint *X,
     mbedtls_mpi_core_cond_swap(X, Y, N->limbs, swap);
 }
 
-int mbedtls_mpi_mod_raw_read( mbedtls_mpi_uint *X,
-                              const mbedtls_mpi_mod_modulus *N,
-                              const unsigned char *input,
-                              size_t input_length,
-                              mbedtls_mpi_mod_ext_rep ext_rep )
+int mbedtls_mpi_mod_raw_read(mbedtls_mpi_uint *X,
+                             const mbedtls_mpi_mod_modulus *N,
+                             const unsigned char *input,
+                             size_t input_length,
+                             mbedtls_mpi_mod_ext_rep ext_rep)
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
 
     switch (ext_rep) {
         case MBEDTLS_MPI_MOD_EXT_REP_LE:
-            ret = mbedtls_mpi_core_read_le( X, N->limbs,
-                                            input, input_length );
+            ret = mbedtls_mpi_core_read_le(X, N->limbs,
+                                           input, input_length);
             break;
         case MBEDTLS_MPI_MOD_EXT_REP_BE:
-            ret = mbedtls_mpi_core_read_be( X, N->limbs,
-                                            input, input_length );
+            ret = mbedtls_mpi_core_read_be(X, N->limbs,
+                                           input, input_length);
             break;
         default:
             return MBEDTLS_ERR_MPI_BAD_INPUT_DATA;
@@ -74,8 +74,7 @@ int mbedtls_mpi_mod_raw_read( mbedtls_mpi_uint *X,
         goto cleanup;
     }
 
-    if( !mbedtls_mpi_core_lt_ct( X, N->p, N->limbs ) )
-    {
+    if (!mbedtls_mpi_core_lt_ct(X, N->p, N->limbs)) {
         ret = MBEDTLS_ERR_MPI_BAD_INPUT_DATA;
         goto cleanup;
     }
@@ -85,19 +84,19 @@ cleanup:
     return ret;
 }
 
-int mbedtls_mpi_mod_raw_write( const mbedtls_mpi_uint *A,
-                               const mbedtls_mpi_mod_modulus *N,
-                               unsigned char *output,
-                               size_t output_length,
-                               mbedtls_mpi_mod_ext_rep ext_rep )
+int mbedtls_mpi_mod_raw_write(const mbedtls_mpi_uint *A,
+                              const mbedtls_mpi_mod_modulus *N,
+                              unsigned char *output,
+                              size_t output_length,
+                              mbedtls_mpi_mod_ext_rep ext_rep)
 {
     switch (ext_rep) {
         case MBEDTLS_MPI_MOD_EXT_REP_LE:
-            return( mbedtls_mpi_core_write_le( A, N->limbs,
-                                               output, output_length ) );
+            return mbedtls_mpi_core_write_le(A, N->limbs,
+                                             output, output_length);
         case MBEDTLS_MPI_MOD_EXT_REP_BE:
-            return( mbedtls_mpi_core_write_be( A, N->limbs,
-                                               output, output_length ) );
+            return mbedtls_mpi_core_write_be(A, N->limbs,
+                                             output, output_length);
         default:
             return MBEDTLS_ERR_MPI_BAD_INPUT_DATA;
     }
@@ -229,35 +228,35 @@ int mbedtls_mpi_mod_raw_random(mbedtls_mpi_uint *X,
 /* END MERGE SLOT 6 */
 
 /* BEGIN MERGE SLOT 7 */
-int mbedtls_mpi_mod_raw_to_mont_rep( mbedtls_mpi_uint *X,
-                                     const mbedtls_mpi_mod_modulus *N )
+int mbedtls_mpi_mod_raw_to_mont_rep(mbedtls_mpi_uint *X,
+                                    const mbedtls_mpi_mod_modulus *N)
 {
     mbedtls_mpi_uint *T;
-    const size_t t_limbs = mbedtls_mpi_core_montmul_working_limbs( N->limbs );
+    const size_t t_limbs = mbedtls_mpi_core_montmul_working_limbs(N->limbs);
 
     if ((T = (mbedtls_mpi_uint *) mbedtls_calloc(t_limbs, ciL)) == NULL) {
         return MBEDTLS_ERR_MPI_ALLOC_FAILED;
     }
 
-    mbedtls_mpi_core_to_mont_rep( X, X, N->p, N->limbs,
-                                  N->rep.mont.mm, N->rep.mont.rr, T );
+    mbedtls_mpi_core_to_mont_rep(X, X, N->p, N->limbs,
+                                 N->rep.mont.mm, N->rep.mont.rr, T);
 
     mbedtls_platform_zeroize(T, t_limbs * ciL);
     mbedtls_free(T);
     return 0;
 }
 
-int mbedtls_mpi_mod_raw_from_mont_rep( mbedtls_mpi_uint *X,
-                                       const mbedtls_mpi_mod_modulus *N )
+int mbedtls_mpi_mod_raw_from_mont_rep(mbedtls_mpi_uint *X,
+                                      const mbedtls_mpi_mod_modulus *N)
 {
-    const size_t t_limbs = mbedtls_mpi_core_montmul_working_limbs( N->limbs );
+    const size_t t_limbs = mbedtls_mpi_core_montmul_working_limbs(N->limbs);
     mbedtls_mpi_uint *T;
 
     if ((T = (mbedtls_mpi_uint *) mbedtls_calloc(t_limbs, ciL)) == NULL) {
         return MBEDTLS_ERR_MPI_ALLOC_FAILED;
     }
 
-    mbedtls_mpi_core_from_mont_rep( X, X, N->p, N->limbs, N->rep.mont.mm, T );
+    mbedtls_mpi_core_from_mont_rep(X, X, N->p, N->limbs, N->rep.mont.mm, T);
 
     mbedtls_platform_zeroize(T, t_limbs * ciL);
     mbedtls_free(T);
@@ -266,14 +265,14 @@ int mbedtls_mpi_mod_raw_from_mont_rep( mbedtls_mpi_uint *X,
 
 void mbedtls_mpi_mod_raw_neg(mbedtls_mpi_uint *X,
                              const mbedtls_mpi_uint *A,
-                             const mbedtls_mpi_mod_modulus *m)
+                             const mbedtls_mpi_mod_modulus *N)
 {
-    mbedtls_mpi_core_sub(X, m->p, A, m->limbs);
+    mbedtls_mpi_core_sub(X, N->p, A, N->limbs);
 
     /* If A=0 initially, then X=N now. Detect this by
      * subtracting N and catching the carry. */
-    mbedtls_mpi_uint borrow = mbedtls_mpi_core_sub(X, X, m->p, m->limbs);
-    (void) mbedtls_mpi_core_add_if(X, m->p, m->limbs, (unsigned) borrow);
+    mbedtls_mpi_uint borrow = mbedtls_mpi_core_sub(X, X, N->p, N->limbs);
+    (void) mbedtls_mpi_core_add_if(X, N->p, N->limbs, (unsigned) borrow);
 }
 /* END MERGE SLOT 7 */
 

--- a/library/bignum_mod_raw.c
+++ b/library/bignum_mod_raw.c
@@ -247,17 +247,17 @@ int mbedtls_mpi_mod_raw_to_mont_rep( mbedtls_mpi_uint *X,
     return 0;
 }
 
-int mbedtls_mpi_mod_raw_from_mont_rep(mbedtls_mpi_uint *X,
-                                      const mbedtls_mpi_mod_modulus *m)
+int mbedtls_mpi_mod_raw_from_mont_rep( mbedtls_mpi_uint *X,
+                                       const mbedtls_mpi_mod_modulus *N )
 {
-    const size_t t_limbs = mbedtls_mpi_core_montmul_working_limbs(m->limbs);
+    const size_t t_limbs = mbedtls_mpi_core_montmul_working_limbs( N->limbs );
     mbedtls_mpi_uint *T;
 
     if ((T = (mbedtls_mpi_uint *) mbedtls_calloc(t_limbs, ciL)) == NULL) {
         return MBEDTLS_ERR_MPI_ALLOC_FAILED;
     }
 
-    mbedtls_mpi_core_from_mont_rep(X, X, m->p, m->limbs, m->rep.mont.mm, T);
+    mbedtls_mpi_core_from_mont_rep( X, X, N->p, N->limbs, N->rep.mont.mm, T );
 
     mbedtls_platform_zeroize(T, t_limbs * ciL);
     mbedtls_free(T);

--- a/library/bignum_mod_raw.h
+++ b/library/bignum_mod_raw.h
@@ -410,14 +410,14 @@ int mbedtls_mpi_mod_raw_random(mbedtls_mpi_uint *X,
 /** Convert an MPI into Montgomery form.
  *
  * \param X      The address of the MPI.
- *               Must have the same number of limbs as \p m.
- * \param m      The address of the modulus, which gives the size of
- *               the base `R` = 2^(biL*m->limbs).
+ *               Must have the same number of limbs as \p N.
+ * \param N      The address of the modulus, which gives the size of
+ *               the base `R` = 2^(biL*N->limbs).
  *
  * \return       \c 0 if successful.
  */
-int mbedtls_mpi_mod_raw_to_mont_rep(mbedtls_mpi_uint *X,
-                                    const mbedtls_mpi_mod_modulus *m);
+int mbedtls_mpi_mod_raw_to_mont_rep( mbedtls_mpi_uint *X,
+                                     const mbedtls_mpi_mod_modulus *N );
 
 /** Convert an MPI back from Montgomery representation.
  *

--- a/library/bignum_mod_raw.h
+++ b/library/bignum_mod_raw.h
@@ -422,14 +422,14 @@ int mbedtls_mpi_mod_raw_to_mont_rep( mbedtls_mpi_uint *X,
 /** Convert an MPI back from Montgomery representation.
  *
  * \param X      The address of the MPI.
- *               Must have the same number of limbs as \p m.
- * \param m      The address of the modulus, which gives the size of
- *               the base `R`= 2^(biL*m->limbs).
+ *               Must have the same number of limbs as \p N.
+ * \param N      The address of the modulus, which gives the size of
+ *               the base `R`= 2^(biL*N->limbs).
  *
  * \return       \c 0 if successful.
  */
-int mbedtls_mpi_mod_raw_from_mont_rep(mbedtls_mpi_uint *X,
-                                      const mbedtls_mpi_mod_modulus *m);
+int mbedtls_mpi_mod_raw_from_mont_rep( mbedtls_mpi_uint *X,
+                                       const mbedtls_mpi_mod_modulus *N );
 
 /** \brief  Perform fixed width modular negation.
  *

--- a/library/bignum_mod_raw.h
+++ b/library/bignum_mod_raw.h
@@ -159,11 +159,11 @@ void mbedtls_mpi_mod_raw_cond_swap(mbedtls_mpi_uint *X,
  * \return       #MBEDTLS_ERR_MPI_BAD_INPUT_DATA if the external representation
  *               of \p N is invalid or \p X is not less than \p N.
  */
-int mbedtls_mpi_mod_raw_read( mbedtls_mpi_uint *X,
-                              const mbedtls_mpi_mod_modulus *N,
-                              const unsigned char *input,
-                              size_t input_length,
-                              mbedtls_mpi_mod_ext_rep ext_rep );
+int mbedtls_mpi_mod_raw_read(mbedtls_mpi_uint *X,
+                             const mbedtls_mpi_mod_modulus *N,
+                             const unsigned char *input,
+                             size_t input_length,
+                             mbedtls_mpi_mod_ext_rep ext_rep);
 
 /** Export A into unsigned binary data.
  *
@@ -181,11 +181,11 @@ int mbedtls_mpi_mod_raw_read( mbedtls_mpi_uint *X,
  * \return       #MBEDTLS_ERR_MPI_BAD_INPUT_DATA if the external representation
  *               of \p N is invalid.
  */
-int mbedtls_mpi_mod_raw_write( const mbedtls_mpi_uint *A,
-                               const mbedtls_mpi_mod_modulus *N,
-                               unsigned char *output,
-                               size_t output_length,
-                               mbedtls_mpi_mod_ext_rep ext_rep );
+int mbedtls_mpi_mod_raw_write(const mbedtls_mpi_uint *A,
+                              const mbedtls_mpi_mod_modulus *N,
+                              unsigned char *output,
+                              size_t output_length,
+                              mbedtls_mpi_mod_ext_rep ext_rep);
 
 /* BEGIN MERGE SLOT 1 */
 
@@ -416,8 +416,8 @@ int mbedtls_mpi_mod_raw_random(mbedtls_mpi_uint *X,
  *
  * \return       \c 0 if successful.
  */
-int mbedtls_mpi_mod_raw_to_mont_rep( mbedtls_mpi_uint *X,
-                                     const mbedtls_mpi_mod_modulus *N );
+int mbedtls_mpi_mod_raw_to_mont_rep(mbedtls_mpi_uint *X,
+                                    const mbedtls_mpi_mod_modulus *N);
 
 /** Convert an MPI back from Montgomery representation.
  *
@@ -428,25 +428,25 @@ int mbedtls_mpi_mod_raw_to_mont_rep( mbedtls_mpi_uint *X,
  *
  * \return       \c 0 if successful.
  */
-int mbedtls_mpi_mod_raw_from_mont_rep( mbedtls_mpi_uint *X,
-                                       const mbedtls_mpi_mod_modulus *N );
+int mbedtls_mpi_mod_raw_from_mont_rep(mbedtls_mpi_uint *X,
+                                      const mbedtls_mpi_mod_modulus *N);
 
 /** \brief  Perform fixed width modular negation.
  *
- * The size of the operation is determined by \p m. \p A must have
- * the same number of limbs as \p m.
+ * The size of the operation is determined by \p N. \p A must have
+ * the same number of limbs as \p N.
  *
  * \p X may be aliased to \p A.
  *
  * \param[out] X        The result of the modular negation.
  *                      This must be initialized.
  * \param[in] A         Little-endian presentation of the input operand. This
- *                      must be less than or equal to \p m.
- * \param[in] m         The modulus to use.
+ *                      must be less than or equal to \p N.
+ * \param[in] N         The modulus to use.
  */
 void mbedtls_mpi_mod_raw_neg(mbedtls_mpi_uint *X,
                              const mbedtls_mpi_uint *A,
-                             const mbedtls_mpi_mod_modulus *m);
+                             const mbedtls_mpi_mod_modulus *N);
 /* END MERGE SLOT 7 */
 
 /* BEGIN MERGE SLOT 8 */

--- a/library/bignum_mod_raw.h
+++ b/library/bignum_mod_raw.h
@@ -145,10 +145,10 @@ void mbedtls_mpi_mod_raw_cond_swap(mbedtls_mpi_uint *X,
  * The MPI needs to have enough limbs to store the full value (including any
  * most significant zero bytes in the input).
  *
- * \param[out] X        The address of the MPI. The size is determined by \p m.
+ * \param[out] X        The address of the MPI. The size is determined by \p N.
  *                      (In particular, it must have at least as many limbs as
- *                      the modulus \p m.)
- * \param[in] m         The address of the modulus related to \p X.
+ *                      the modulus \p N.)
+ * \param[in] N         The address of the modulus related to \p X.
  * \param[in] input     The input buffer to import from.
  * \param input_length  The length in bytes of \p input.
  * \param ext_rep       The endianness of the number in the input buffer.
@@ -157,13 +157,13 @@ void mbedtls_mpi_mod_raw_cond_swap(mbedtls_mpi_uint *X,
  * \return       #MBEDTLS_ERR_MPI_BUFFER_TOO_SMALL if \p X isn't
  *               large enough to hold the value in \p input.
  * \return       #MBEDTLS_ERR_MPI_BAD_INPUT_DATA if the external representation
- *               of \p m is invalid or \p X is not less than \p m.
+ *               of \p N is invalid or \p X is not less than \p N.
  */
-int mbedtls_mpi_mod_raw_read(mbedtls_mpi_uint *X,
-                             const mbedtls_mpi_mod_modulus *m,
-                             const unsigned char *input,
-                             size_t input_length,
-                             mbedtls_mpi_mod_ext_rep ext_rep);
+int mbedtls_mpi_mod_raw_read( mbedtls_mpi_uint *X,
+                              const mbedtls_mpi_mod_modulus *N,
+                              const unsigned char *input,
+                              size_t input_length,
+                              mbedtls_mpi_mod_ext_rep ext_rep );
 
 /** Export A into unsigned binary data.
  *

--- a/library/bignum_mod_raw.h
+++ b/library/bignum_mod_raw.h
@@ -167,10 +167,10 @@ int mbedtls_mpi_mod_raw_read( mbedtls_mpi_uint *X,
 
 /** Export A into unsigned binary data.
  *
- * \param[in] A         The address of the MPI. The size is determined by \p m.
+ * \param[in] A         The address of the MPI. The size is determined by \p N.
  *                      (In particular, it must have at least as many limbs as
- *                      the modulus \p m.)
- * \param[in] m         The address of the modulus related to \p A.
+ *                      the modulus \p N.)
+ * \param[in] N         The address of the modulus related to \p A.
  * \param[out] output   The output buffer to export to.
  * \param output_length The length in bytes of \p output.
  * \param ext_rep       The endianness in which the number should be written into the output buffer.
@@ -179,13 +179,13 @@ int mbedtls_mpi_mod_raw_read( mbedtls_mpi_uint *X,
  * \return       #MBEDTLS_ERR_MPI_BUFFER_TOO_SMALL if \p output isn't
  *               large enough to hold the value of \p A.
  * \return       #MBEDTLS_ERR_MPI_BAD_INPUT_DATA if the external representation
- *               of \p m is invalid.
+ *               of \p N is invalid.
  */
-int mbedtls_mpi_mod_raw_write(const mbedtls_mpi_uint *A,
-                              const mbedtls_mpi_mod_modulus *m,
-                              unsigned char *output,
-                              size_t output_length,
-                              mbedtls_mpi_mod_ext_rep ext_rep);
+int mbedtls_mpi_mod_raw_write( const mbedtls_mpi_uint *A,
+                               const mbedtls_mpi_mod_modulus *N,
+                               unsigned char *output,
+                               size_t output_length,
+                               mbedtls_mpi_mod_ext_rep ext_rep );
 
 /* BEGIN MERGE SLOT 1 */
 


### PR DESCRIPTION
#### Files : 

bignum_mod.c
 bignum_mod.h
 bignum_mod_raw.c
 bignum_mod_raw.h
 test_suite_bignum_mod.function



## Description

Rename modulus input argument from m to N in above mentioned files.



## Gatekeeper checklist

- [x] **changelog**  not required
- [x] **backport** not required
- [x]  Run Ctest ( All test passed successfully)
- [x]  Run check_files.py (File system are correct)
- [x]  Signed the commit





## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

