### PR TITLE
Remove redundant error code definitions

### DIFF
--- a/library/psa_crypto_its.h
+++ b/library/psa_crypto_its.h
@@ -54,11 +54,6 @@ struct psa_storage_info_t
 /** Flag indicating that \ref psa_storage_create and \ref psa_storage_set_extended are supported */
 #define PSA_STORAGE_SUPPORT_SET_EXTENDED (1 << 0)
 
-/** \brief PSA storage specific error codes
- */
-#define PSA_ERROR_INVALID_SIGNATURE     ((psa_status_t)-149)
-#define PSA_ERROR_DATA_CORRUPT          ((psa_status_t)-152)
-
 #define PSA_ITS_API_VERSION_MAJOR  1  /**< The major version number of the PSA ITS API. It will be incremented on significant updates that may include breaking changes */
 #define PSA_ITS_API_VERSION_MINOR  1  /**< The minor version number of the PSA ITS API. It will be incremented in small updates that are unlikely to include breaking changes */
 


### PR DESCRIPTION
We're including psa/crypto_values.h, which defines the necessary error codes. Remove redundant definitions, which hurt because they need to be styled in exactly the same way (same presence/absence of spaces between tokens).

This completes the fix of https://github.com/Mbed-TLS/mbedtls/issues/6875, following https://github.com/Mbed-TLS/mbedtls/pull/6878 which [broke the restyled code](https://jenkins-mbedtls.oss.arm.com/job/mbed-tls-nightly-tests/3147/).

## Gatekeeper checklist

- [x] **changelog** no (internal change)
- [x] **backport** https://github.com/Mbed-TLS/mbedtls/pull/6906
- [x] **tests** test locally: a build after restyling should not emit any warnings (`scripts/code_style.py --fix && make CFLAGS="-O -Werror"`)
