### PR TITLE
Backport: Improve X.509 cert writing serial number management

### DIFF
--- a/ChangeLog.d/improve_x509_cert_writing_serial_number_management.txt
+++ b/ChangeLog.d/improve_x509_cert_writing_serial_number_management.txt
@@ -1,0 +1,5 @@
+Bugfix
+   * mbedtls_x509write_crt_set_serial() now explicitly rejects serial numbers
+     whose binary representation is longer than 20 bytes. This was already
+     forbidden by the standard (RFC5280 - section 4.1.2.2) and now it's being
+     enforced also at code level.

--- a/library/x509write_crt.c
+++ b/library/x509write_crt.c
@@ -100,6 +100,10 @@ int mbedtls_x509write_crt_set_serial(mbedtls_x509write_cert *ctx,
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
 
+    if (mbedtls_mpi_size(serial) > MBEDTLS_X509_RFC5280_MAX_SERIAL_LEN) {
+        return MBEDTLS_ERR_X509_BAD_INPUT_DATA;
+    }
+
     if ((ret = mbedtls_mpi_copy(&ctx->serial, serial)) != 0) {
         return ret;
     }

--- a/tests/suites/test_suite_x509write.data
+++ b/tests/suites/test_suite_x509write.data
@@ -132,3 +132,6 @@ mbedtls_x509_string_to_names:"C=NL, O=Offspark\a Inc., OU=PolarSSL":"":MBEDTLS_E
 
 X509 String to Names #6 (Escape at end)
 mbedtls_x509_string_to_names:"C=NL, O=Offspark\":"":MBEDTLS_ERR_X509_INVALID_NAME
+
+Check max serial length
+x509_set_serial_check:

--- a/tests/suites/test_suite_x509write.function
+++ b/tests/suites/test_suite_x509write.function
@@ -425,6 +425,24 @@ exit:
 }
 /* END_CASE */
 
+/* BEGIN_CASE depends_on:MBEDTLS_X509_CRT_WRITE_C */
+void x509_set_serial_check()
+{
+    mbedtls_x509write_cert ctx;
+    mbedtls_mpi serial_mpi;
+    uint8_t invalid_serial[MBEDTLS_X509_RFC5280_MAX_SERIAL_LEN + 1];
+
+    memset(invalid_serial, 0x01, sizeof(invalid_serial));
+
+    mbedtls_mpi_init(&serial_mpi);
+    TEST_EQUAL(mbedtls_mpi_read_binary(&serial_mpi, invalid_serial,
+                                       sizeof(invalid_serial)), 0);
+    TEST_EQUAL(mbedtls_x509write_crt_set_serial(&ctx, &serial_mpi),
+               MBEDTLS_ERR_X509_BAD_INPUT_DATA);
+    mbedtls_mpi_free(&serial_mpi);
+}
+/* END_CASE */
+
 /* BEGIN_CASE depends_on:MBEDTLS_X509_CREATE_C:MBEDTLS_X509_USE_C */
 void mbedtls_x509_string_to_names(char *name, char *parsed_name, int result
                                   )


### PR DESCRIPTION
## Description

This PR backports a bugfix introduced into `development` during PR #6843, i.e. `x509write_crt` rejects serials longer than X509_RFC5280_MAX_SERIAL_LEN.

## Gatekeeper checklist

- [x] **changelog** provided
- [ ] **backport** not required - this is already a backport
- [x] **tests** provided, or not required
