### PR TITLE
Have compat.sh and ssl-opt.sh not return success for > 255 errors

### DIFF
--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -1106,8 +1106,7 @@ done
 
 echo "------------------------------------------------------------------------"
 
-if [ $FAILED -ne 0 -o $SRVMEM -ne 0 ];
-then
+if [ $FAILED -ne 0 -o $SRVMEM -ne 0 ]; then
     printf "FAILED"
 else
     printf "PASSED"
@@ -1123,4 +1122,9 @@ PASSED=$(( $TESTS - $FAILED ))
 echo " ($PASSED / $TESTS tests ($SKIPPED skipped$MEMREPORT))"
 
 FAILED=$(( $FAILED + $SRVMEM ))
+if [ $FAILED -gt 255 ]; then
+    # Clamp at 255 as caller gets exit code & 0xFF
+    # (so 256 would be 0, or success, etc)
+    FAILED=255
+fi
 exit $FAILED

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -13312,4 +13312,9 @@ fi
 PASSES=$(( $TESTS - $FAILS ))
 echo " ($PASSES / $TESTS tests ($SKIPS skipped))"
 
+if [ $FAILS -gt 255 ]; then
+    # Clamp at 255 as caller gets exit code & 0xFF
+    # (so 256 would be 0, or success, etc)
+    FAILS=255
+fi
 exit $FAILS


### PR DESCRIPTION
Fixes #2068

## Gatekeeper checklist

- [x] **changelog** not required - this isn't a user-facing change
- [x] **backport** done (#6928)
- [x] **tests** not required - these are minor fixes to test scripts
