### PR TITLE
Replace CPU modifier check with file scope target cpu modifiers

### DIFF
--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -708,41 +708,6 @@
 #if defined(MBEDTLS_SHA512_ALT) || defined(MBEDTLS_SHA512_PROCESS_ALT)
 #error "MBEDTLS_SHA512_*ALT can't be used with MBEDTLS_SHA512_USE_A64_CRYPTO_*"
 #endif
-/*
- * Best performance comes from most recent compilers, with intrinsics and -O3.
- * Must compile with -march=armv8.2-a+sha3, but we can't detect armv8.2-a, and
- * can't always detect __ARM_FEATURE_SHA512 (notably clang 7-12).
- *
- * GCC < 8 won't work at all (lacks the sha512 instructions)
- * GCC >= 8 uses intrinsics, sets __ARM_FEATURE_SHA512
- *
- * Clang < 7 won't work at all (lacks the sha512 instructions)
- * Clang 7-12 don't have intrinsics (but we work around that with inline
- *            assembler) or __ARM_FEATURE_SHA512
- * Clang == 13.0.0 same as clang 12 (only seen on macOS)
- * Clang >= 13.0.1 has __ARM_FEATURE_SHA512 and intrinsics
- */
-#if defined(__aarch64__) && !defined(__ARM_FEATURE_SHA512)
-   /* Test Clang first, as it defines __GNUC__ */
-#  if defined(__clang__)
-#    if __clang_major__ < 7
-#      error "A more recent Clang is required for MBEDTLS_SHA512_USE_A64_CRYPTO_*"
-#    elif __clang_major__ < 13 || \
-         (__clang_major__ == 13 && __clang_minor__ == 0 && __clang_patchlevel__ == 0)
-       /* We implement the intrinsics with inline assembler, so don't error */
-#    else
-#      error "Must use minimum -march=armv8.2-a+sha3 for MBEDTLS_SHA512_USE_A64_CRYPTO_*"
-#    endif
-#  elif defined(__GNUC__)
-#    if __GNUC__ < 8
-#      error "A more recent GCC is required for MBEDTLS_SHA512_USE_A64_CRYPTO_*"
-#    else
-#      error "Must use minimum -march=armv8.2-a+sha3 for MBEDTLS_SHA512_USE_A64_CRYPTO_*"
-#    endif
-#  else
-#    error "Only GCC and Clang supported for MBEDTLS_SHA512_USE_A64_CRYPTO_*"
-#  endif
-#endif
 
 #endif /* MBEDTLS_SHA512_USE_A64_CRYPTO_IF_PRESENT || MBEDTLS_SHA512_USE_A64_CRYPTO_ONLY */
 
@@ -763,9 +728,7 @@
 #if defined(MBEDTLS_SHA256_ALT) || defined(MBEDTLS_SHA256_PROCESS_ALT)
 #error "MBEDTLS_SHA256_*ALT can't be used with MBEDTLS_SHA256_USE_A64_CRYPTO_*"
 #endif
-#if defined(__aarch64__) && !defined(__ARM_FEATURE_CRYPTO)
-#error "Must use minimum -march=armv8-a+crypto for MBEDTLS_SHA256_USE_A64_CRYPTO_*"
-#endif
+
 #endif
 
 #if defined(MBEDTLS_SHA256_USE_A64_CRYPTO_ONLY) && \

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -3087,9 +3087,6 @@
  * \note If MBEDTLS_SHA256_USE_A64_CRYPTO_IF_PRESENT is defined when building
  * for a non-Aarch64 build it will be silently ignored.
  *
- * \note The code uses Neon intrinsics, so \c CFLAGS must be set to a minimum
- * of \c -march=armv8-a+crypto.
- *
  * \warning MBEDTLS_SHA256_USE_A64_CRYPTO_IF_PRESENT cannot be defined at the
  * same time as MBEDTLS_SHA256_USE_A64_CRYPTO_ONLY.
  *
@@ -3111,9 +3108,6 @@
  *
  * \note This allows builds with a smaller code size than with
  * MBEDTLS_SHA256_USE_A64_CRYPTO_IF_PRESENT
- *
- * \note The code uses Neon intrinsics, so \c CFLAGS must be set to a minimum
- * of \c -march=armv8-a+crypto.
  *
  * \warning MBEDTLS_SHA256_USE_A64_CRYPTO_ONLY cannot be defined at the same
  * time as MBEDTLS_SHA256_USE_A64_CRYPTO_IF_PRESENT.
@@ -3169,9 +3163,7 @@
  * for a non-Aarch64 build it will be silently ignored.
  *
  * \note The code uses the SHA-512 Neon intrinsics, so requires GCC >= 8 or
- * Clang >= 7, and \c CFLAGS must be set to a minimum of
- * \c -march=armv8.2-a+sha3. An optimisation level of \c -O3 generates the
- * fastest code.
+ * Clang >= 7.
  *
  * \warning MBEDTLS_SHA512_USE_A64_CRYPTO_IF_PRESENT cannot be defined at the
  * same time as MBEDTLS_SHA512_USE_A64_CRYPTO_ONLY.
@@ -3196,9 +3188,7 @@
  * MBEDTLS_SHA512_USE_A64_CRYPTO_IF_PRESENT
  *
  * \note The code uses the SHA-512 Neon intrinsics, so requires GCC >= 8 or
- * Clang >= 7, and \c CFLAGS must be set to a minimum of
- * \c -march=armv8.2-a+sha3. An optimisation level of \c -O3 generates the
- * fastest code.
+ * Clang >= 7.
  *
  * \warning MBEDTLS_SHA512_USE_A64_CRYPTO_ONLY cannot be defined at the same
  * time as MBEDTLS_SHA512_USE_A64_CRYPTO_IF_PRESENT.

--- a/library/sha256.c
+++ b/library/sha256.c
@@ -37,6 +37,11 @@
 #if defined(__aarch64__)
 #  if defined(MBEDTLS_SHA256_USE_A64_CRYPTO_IF_PRESENT) || \
     defined(MBEDTLS_SHA256_USE_A64_CRYPTO_ONLY)
+/* *INDENT-OFF* */
+#    if !defined(__ARM_FEATURE_CRYPTO)
+#       error "Must use minimum -march=armv8-a+crypto for MBEDTLS_SHA256_USE_A64_CRYPTO_*"
+#    endif
+/* *INDENT-ON* */
 #    include <arm_neon.h>
 #  endif
 #  if defined(MBEDTLS_SHA256_USE_A64_CRYPTO_IF_PRESENT)

--- a/library/sha256.c
+++ b/library/sha256.c
@@ -54,7 +54,10 @@
 #        pragma clang attribute push (__attribute__((target("crypto"))), apply_to=function)
 #        define MBEDTLS_POP_TARGET_PRAGMA
 #      elif defined(__GNUC__)
-#        if __GNUC__ < 6 /* TODO: check sha256 compatible for GCC */
+         /* FIXME: GCC-5 annouce crypto extension, but some intrinsic are missed.
+          *        Known miss intrinsic can be workaround.
+          */
+#        if __GNUC__ < 6
 #          error "A more recent GCC is required for MBEDTLS_SHA256_USE_A64_CRYPTO_*"
 #        else
 #          pragma GCC push_options

--- a/library/sha256.c
+++ b/library/sha256.c
@@ -34,13 +34,13 @@
 #pragma clang attribute push (__attribute__((target("crypto"))), apply_to=function)
 #define MBEDTLS_POP_TARGET_PRAGMA
 #endif /* __aarch64__ && __clang__ &&
-         !__ARM_FEATURE_CRYPTO && __clang_major__ < 18 && __clang_major__ > 3 */
+          !__ARM_FEATURE_CRYPTO && __clang_major__ < 18 && __clang_major__ > 3 */
 
 #include "common.h"
 
 #if defined(MBEDTLS_POP_TARGET_PRAGMA) && \
     !(defined(MBEDTLS_SHA256_USE_A64_CRYPTO_IF_PRESENT) || \
-      defined(MBEDTLS_SHA256_USE_A64_CRYPTO_ONLY))
+    defined(MBEDTLS_SHA256_USE_A64_CRYPTO_ONLY))
 #if defined(__clang__)
 #pragma clang attribute pop
 #endif

--- a/library/sha256.c
+++ b/library/sha256.c
@@ -29,23 +29,16 @@
  * The intrinsic declaration are guarded with ACLE predefined macros in clang,
  * and those macros are only enabled with command line. Define the macros can
  * enable those declaration and avoid compile error on it.
+ *
+ * `arm_neon.h` might be included in any head files. On the top of this file, we
+ * can guarantee this workaround always work.
  */
 #define __ARM_FEATURE_CRYPTO 1
-#pragma clang attribute push (__attribute__((target("crypto"))), apply_to=function)
-#define MBEDTLS_POP_TARGET_PRAGMA
+#define NEED_TARGET_OPTIONS
 #endif /* __aarch64__ && __clang__ &&
           !__ARM_FEATURE_CRYPTO && __clang_major__ < 18 && __clang_major__ > 3 */
 
 #include "common.h"
-
-#if defined(MBEDTLS_POP_TARGET_PRAGMA) && \
-    !(defined(MBEDTLS_SHA256_USE_A64_CRYPTO_IF_PRESENT) || \
-    defined(MBEDTLS_SHA256_USE_A64_CRYPTO_ONLY))
-#if defined(__clang__)
-#pragma clang attribute pop
-#endif
-#undef MBEDTLS_POP_TARGET_PRAGMA
-#endif
 
 #if defined(MBEDTLS_SHA256_C) || defined(MBEDTLS_SHA224_C)
 
@@ -61,7 +54,7 @@
 #  if defined(MBEDTLS_SHA256_USE_A64_CRYPTO_IF_PRESENT) || \
     defined(MBEDTLS_SHA256_USE_A64_CRYPTO_ONLY)
 /* *INDENT-OFF* */
-#    if !defined(__ARM_FEATURE_CRYPTO)
+#    if !defined(__ARM_FEATURE_CRYPTO) || defined(NEED_TARGET_OPTIONS)
 #      if defined(__clang__)
 #        if __clang_major__ < 4
 #          error "A more recent Clang is required for MBEDTLS_SHA256_USE_A64_CRYPTO_*"

--- a/library/sha256.c
+++ b/library/sha256.c
@@ -380,6 +380,11 @@ int mbedtls_internal_sha256_process_a64_crypto(mbedtls_sha256_context *ctx,
             SHA256_BLOCK_SIZE) ? 0 : -1;
 }
 
+#if defined(MBEDTLS_POP_TARGET_PRAGMA)
+#pragma clang attribute pop
+#undef MBEDTLS_POP_TARGET_PRAGMA
+#endif
+
 #endif /* MBEDTLS_SHA256_USE_A64_CRYPTO_IF_PRESENT || MBEDTLS_SHA256_USE_A64_CRYPTO_ONLY */
 
 

--- a/library/sha256.c
+++ b/library/sha256.c
@@ -40,7 +40,9 @@
 /* *INDENT-OFF* */
 #    if !defined(__ARM_FEATURE_CRYPTO)
 #      if defined(__clang__)
-#        if __clang_major__ < 18
+#        if __clang_major__ < 4
+#          error "A more recent Clang is required for MBEDTLS_SHA256_USE_A64_CRYPTO_*"
+#        elif __clang_major__ < 18
            /* TODO: Re-consider above after https://reviews.llvm.org/D131064
             *       merged.
             *

--- a/library/sha256.c
+++ b/library/sha256.c
@@ -57,7 +57,9 @@
 #        if __GNUC__ < 6 /* TODO: check sha256 compatible for GCC */
 #          error "A more recent GCC is required for MBEDTLS_SHA256_USE_A64_CRYPTO_*"
 #        else
+#          pragma GCC push_options
 #          pragma GCC target ("arch=armv8-a+crypto")
+#          define MBEDTLS_POP_TARGET_PRAGMA
 #        endif
 #      else
 #        error "Only GCC and Clang supported for MBEDTLS_SHA256_USE_A64_CRYPTO_*"
@@ -381,7 +383,11 @@ int mbedtls_internal_sha256_process_a64_crypto(mbedtls_sha256_context *ctx,
 }
 
 #if defined(MBEDTLS_POP_TARGET_PRAGMA)
+#if defined(__clang__)
 #pragma clang attribute pop
+#elif defined(__GNUC__)
+#pragma GCC pop_options
+#endif
 #undef MBEDTLS_POP_TARGET_PRAGMA
 #endif
 

--- a/library/sha256.c
+++ b/library/sha256.c
@@ -26,12 +26,13 @@
     defined(__clang__) &&  __clang_major__ < 18 && __clang_major__ > 3
 /* TODO: Re-consider above after https://reviews.llvm.org/D131064 merged.
  *
- * The intrinsic declaration are guarded with ACLE predefined macros in clang,
- * and those macros are only enabled with command line. Define the macros can
- * enable those declaration and avoid compile error on it.
+ * The intrinsic declaration are guarded by predefined ACLE macros in clang:
+ * these are normally only enabled by the -march option on the command line.
+ * By defining the macros ourselves we gain access to those declarations without
+ * requiring -march on the command line.
  *
- * `arm_neon.h` might be included in any head files. On the top of this file, we
- * can guarantee this workaround always work.
+ * `arm_neon.h` could be included by any header file, so we put these defines
+ * at the top of this file, before any includes.
  */
 #define __ARM_FEATURE_CRYPTO 1
 #define NEED_TARGET_OPTIONS

--- a/library/sha512.c
+++ b/library/sha512.c
@@ -30,10 +30,12 @@
  * The intrinsic declaration are guarded with ACLE predefined macros in clang,
  * and those macros are only enabled with command line. Define the macros can
  * enable those declaration and avoid compile error on it.
+ *
+ * `arm_neon.h` might be included in any head files. On the top of this file, we
+ * can guarantee this workaround always work.
  */
 #define __ARM_FEATURE_SHA512 1
-#pragma clang attribute push (__attribute__((target("crypto"))), apply_to=function)
-#define MBEDTLS_POP_TARGET_PRAGMA
+#define NEED_TARGET_OPTIONS
 #endif /* __aarch64__ && __clang__ &&
           !__ARM_FEATURE_SHA512 && __clang_major__ < 18 &&
           __clang_major__ >= 13 && __clang_minor__ > 0 &&
@@ -84,7 +86,7 @@
  * Clang == 13.0.0 same as clang 12 (only seen on macOS)
  * Clang >= 13.0.1 has __ARM_FEATURE_SHA512 and intrinsics
  */
-#    if !defined(__ARM_FEATURE_SHA512)
+#    if !defined(__ARM_FEATURE_SHA512) || defined(NEED_TARGET_OPTIONS)
        /* Test Clang first, as it defines __GNUC__ */
 #      if defined(__clang__)
 #        if __clang_major__ < 7

--- a/library/sha512.c
+++ b/library/sha512.c
@@ -27,12 +27,13 @@
     __clang_major__ >= 13 && __clang_minor__ > 0 && __clang_patchlevel__ > 0
 /* TODO: Re-consider above after https://reviews.llvm.org/D131064 merged.
  *
- * The intrinsic declaration are guarded with ACLE predefined macros in clang,
- * and those macros are only enabled with command line. Define the macros can
- * enable those declaration and avoid compile error on it.
+ * The intrinsic declaration are guarded by predefined ACLE macros in clang:
+ * these are normally only enabled by the -march option on the command line.
+ * By defining the macros ourselves we gain access to those declarations without
+ * requiring -march on the command line.
  *
- * `arm_neon.h` might be included in any head files. On the top of this file, we
- * can guarantee this workaround always work.
+ * `arm_neon.h` could be included by any header file, so we put these defines
+ * at the top of this file, before any includes.
  */
 #define __ARM_FEATURE_SHA512 1
 #define NEED_TARGET_OPTIONS
@@ -42,15 +43,6 @@
           __clang_patchlevel__ > 0 */
 
 #include "common.h"
-
-#if defined(MBEDTLS_POP_TARGET_PRAGMA) && \
-    !(defined(MBEDTLS_SHA512_USE_A64_CRYPTO_IF_PRESENT) || \
-    defined(MBEDTLS_SHA512_USE_A64_CRYPTO_ONLY))
-#if defined(__clang__)
-#pragma clang attribute pop
-#endif
-#undef MBEDTLS_POP_TARGET_PRAGMA
-#endif
 
 #if defined(MBEDTLS_SHA512_C) || defined(MBEDTLS_SHA384_C)
 

--- a/library/sha512.c
+++ b/library/sha512.c
@@ -43,6 +43,44 @@
 #if defined(__aarch64__)
 #  if defined(MBEDTLS_SHA512_USE_A64_CRYPTO_IF_PRESENT) || \
     defined(MBEDTLS_SHA512_USE_A64_CRYPTO_ONLY)
+/* *INDENT-OFF* */
+/*
+ * Best performance comes from most recent compilers, with intrinsics and -O3.
+ * Must compile with -march=armv8.2-a+sha3, but we can't detect armv8.2-a, and
+ * can't always detect __ARM_FEATURE_SHA512 (notably clang 7-12).
+ *
+ * GCC < 8 won't work at all (lacks the sha512 instructions)
+ * GCC >= 8 uses intrinsics, sets __ARM_FEATURE_SHA512
+ *
+ * Clang < 7 won't work at all (lacks the sha512 instructions)
+ * Clang 7-12 don't have intrinsics (but we work around that with inline
+ *            assembler) or __ARM_FEATURE_SHA512
+ * Clang == 13.0.0 same as clang 12 (only seen on macOS)
+ * Clang >= 13.0.1 has __ARM_FEATURE_SHA512 and intrinsics
+ */
+#if !defined(__ARM_FEATURE_SHA512)
+   /* Test Clang first, as it defines __GNUC__ */
+#  if defined(__clang__)
+#    if __clang_major__ < 7
+#      error "A more recent Clang is required for MBEDTLS_SHA512_USE_A64_CRYPTO_*"
+#    elif __clang_major__ < 13 || \
+         (__clang_major__ == 13 && __clang_minor__ == 0 && __clang_patchlevel__ == 0)
+       /* We implement the intrinsics with inline assembler, so don't error */
+#    else
+#      error "Must use minimum -march=armv8.2-a+sha3 for MBEDTLS_SHA512_USE_A64_CRYPTO_*"
+#    endif
+#  elif defined(__GNUC__)
+#    if __GNUC__ < 8
+#      error "A more recent GCC is required for MBEDTLS_SHA512_USE_A64_CRYPTO_*"
+#    else
+#      error "Must use minimum -march=armv8.2-a+sha3 for MBEDTLS_SHA512_USE_A64_CRYPTO_*"
+#    endif
+#  else
+#    error "Only GCC and Clang supported for MBEDTLS_SHA512_USE_A64_CRYPTO_*"
+#  endif
+#endif
+/* *INDENT-ON* */
+
 #    include <arm_neon.h>
 #  endif
 #  if defined(MBEDTLS_SHA512_USE_A64_CRYPTO_IF_PRESENT)

--- a/library/sha512.c
+++ b/library/sha512.c
@@ -86,7 +86,9 @@
 #        if __GNUC__ < 8
 #          error "A more recent GCC is required for MBEDTLS_SHA512_USE_A64_CRYPTO_*"
 #        else
+#          pragma GCC push_options
 #          pragma GCC target ("arch=armv8.2-a+sha3")
+#          define MBEDTLS_POP_TARGET_PRAGMA
 #        endif
 #      else
 #        error "Only GCC and Clang supported for MBEDTLS_SHA512_USE_A64_CRYPTO_*"
@@ -567,7 +569,11 @@ int mbedtls_internal_sha512_process_a64_crypto(mbedtls_sha512_context *ctx,
 }
 
 #if defined(MBEDTLS_POP_TARGET_PRAGMA)
+#if defined(__clang__)
 #pragma clang attribute pop
+#elif defined(__GNUC__)
+#pragma GCC pop_options
+#endif
 #undef MBEDTLS_POP_TARGET_PRAGMA
 #endif
 

--- a/library/sha512.c
+++ b/library/sha512.c
@@ -566,6 +566,11 @@ int mbedtls_internal_sha512_process_a64_crypto(mbedtls_sha512_context *ctx,
             SHA512_BLOCK_SIZE) ? 0 : -1;
 }
 
+#if defined(MBEDTLS_POP_TARGET_PRAGMA)
+#pragma clang attribute pop
+#undef MBEDTLS_POP_TARGET_PRAGMA
+#endif
+
 #endif /* MBEDTLS_SHA512_USE_A64_CRYPTO_IF_PRESENT || MBEDTLS_SHA512_USE_A64_CRYPTO_ONLY */
 
 

--- a/library/sha512.c
+++ b/library/sha512.c
@@ -35,15 +35,15 @@
 #pragma clang attribute push (__attribute__((target("crypto"))), apply_to=function)
 #define MBEDTLS_POP_TARGET_PRAGMA
 #endif /* __aarch64__ && __clang__ &&
-         !__ARM_FEATURE_SHA512 && __clang_major__ < 18 &&
-         __clang_major__ >= 13 && __clang_minor__ > 0 &&
-         __clang_patchlevel__ > 0 */
+          !__ARM_FEATURE_SHA512 && __clang_major__ < 18 &&
+          __clang_major__ >= 13 && __clang_minor__ > 0 &&
+          __clang_patchlevel__ > 0 */
 
 #include "common.h"
 
 #if defined(MBEDTLS_POP_TARGET_PRAGMA) && \
     !(defined(MBEDTLS_SHA512_USE_A64_CRYPTO_IF_PRESENT) || \
-      defined(MBEDTLS_SHA512_USE_A64_CRYPTO_ONLY))
+    defined(MBEDTLS_SHA512_USE_A64_CRYPTO_ONLY))
 #if defined(__clang__)
 #pragma clang attribute pop
 #endif


### PR DESCRIPTION
## Description

Fix #5758 .

This PR changed the rule of CPU feature modifier cflags for building with hardware acceleration. The flags is checked in global header file and report error if they are not set in global `CFLAGS`. This commit suggests set the cflags per file with compiler extension( `#pragma GCC target` or target attributes ).

That is more readable to resolve with compiler extension than cflags of compiler command line. The cpu feature modifier is just near the code which needs them.

Script issue raised in [Mbed-TLS/mbedtls#5758](https://github.com/Mbed-TLS/mbedtls/issues/5758) can be resolved with this solution.

`illegal instruction` error was found in #6918 . When MBedTLS is build with optimization flag and `-march=armv8.2-a+sha3-crypto` which is requested by `MBEDTLS_SHA512_USE_A64_CRYPTO_*`, an unexpected instruction `eor3` is generated in assembly code. `eor3` is provided by sha3 extension.

- Build with `-O2 -march=armv8-a+crypto`, assembly code is [here](https://godbolt.org/#z:OYLghAFBqd5QCxAYwPYBMCmBRdBLAF1QCcAaPECAMzwBtMA7AQwFtMQByARg9KtQYEAysib0QXACx8BBAKoBnTAAUAHpwAMvAFYTStJg1AB9U8lJL6yAngGVG6AMKpaAVxYMQAJgBspBwAyeAyYAHLuAEaYxCCSXKQADqgKhLYMzm4e3n5JKTYCQSHhLFExcRaYVvkMQgRMxAQZ7p6%2BFVVptfUEhWGR0bHxCnUNTVmtQ109xaUDAJQWqK7EyOwcAKQaAIJrXgDMwchuWADUa7uO9SzGIQIAdAhn2BvbWxM2yMfBtMGYx67BBAAHKouD5jARjgkWK5aLRjLRUAB3CB/AHA0Hg45MUiowTosEQiLHWbPNYAdgAQs9jjTjsRMAQlgwUQA3ekA6IJekEACOxlcgOMCS4XkBEGptMlUtpLOhsKFPkk4q20tVqogSVoAE9FeDZizgAz4UiFUrjmzMBziFyGXyErqBSimMTiaQJWqPccNS4dZI9QajQjEabWezBJzuXaHWLjkTZi744mzlStuSACLPN54D5fH64oEggmQuVwhB4YAICD/PGFzHY/P4zEREmpynuukMpmhy3h62R/mC4Wi5WbT3S2Uw0vlhAh81hggR22mgdO13tscbqUWq023nLx2xhMJ5OkskZ151d6fBjfEINwuqLyYitMBQzuUEYwimPVgsYiEAOIABI4r%2BjYQkBADSxKnimo60mBtYQsQGg4sQ8RYjiEQ4gQqHHAQXAniqCFog%2BT7IQyREvPBNJoAwQz3v%2BxwAF6nLsabmugrgJHyDArscGgwbscGSs6ZwccBVGSkS4nHFBVHtihbEcVCk7GsimGHiSwmKVwynFmpZYVk6WFCSJtK4fpLKYKoe4HthsY4oCZntgR%2BmqfKQYmfhgnaeZNKWbJHlTsZmmWX5rmCbJ1kkHyB64ThekRcRAV6dFNl2TGzE4XhznJTRdJRex5qYLF/EoYlLkpfhaXFdZtlxTGCUsU5VUFehVmlcQjUouhlX5ZK3K3CyYhrAArBSGjjRxskoVJtJDSNtDjRShFjTNxXofNNLcl2HYQvl6aklsiFMS%2Bb7GB%2BxjEOgyAoqdPiPpiwQwa2/mMUWTB4UwGHNQRCnVXRDEPZiCRWfOi6ZfyiqslxPHXNDZoaKogJkseOmAwIwOkUxzHRKgVlw7x/G%2BdtWJFRxwTDaNE1TetZM/fpVNLSta0Zhj1GSgA9AAVDzkI%2BgwqAsHgYgdlx1hpMcPNc5F7klsYRmVliGFgwNFm1Rx9WZSizV48QqCterNKM%2BlZUHj9/Vk256UNfx%2BuGz5RsMxTJXmzGX1WxzkqBcVwXqU6qttYpnbEMybvdfxns%2BejcFHVsHDzLQnBjbwngcFopCoJwjjHAoizLL8Oy7DwpAEJoifzAA1rEACcty7LXteSGSZKAhoPht4CY1ePonCSGnFdZ5wvAKCAqHlxniekHAsBIGgLAJHQ0TkJQC9L/QMSXCygIALTIIchjAFwY0aKhWAstmmAAGp4JgiIAPIJIwnClzQtALsQY8QBEQ8RME9QtSv14P/ZgxAtQPwiNoTA1hgGkAXmwQQD8bxAKnqQLALAj7iDQfgekktrJjzQTZGBrgFxwI5MnNB3wIjEEAc4LAQ8CDEDwCwYB8wqAGGAAoW%2B98n4v24LwfgggRBiHYFIGQghFAqHUGg3Q8QDBGBAKYYw5hqFj0gPMVACRqiEN3g/Lwxxd6YOWA8di2895MB2BSZA4DtGoFHpUGB1R7AMCcC4ZoIBG7%2BFcVMPoMQRSJGSKkAQoxPBeNyMEhgviSj9ACZYJxHRhiNHcVkLx8TJYCE6A0aJMw4lJNCZ42uFgkk5NiV4eY%2BclgrAkEnFOg80HZw4FiYgLAd672dIfIwxwT63A0L0r0uBCAkFOHsLgsxeCTy0LMauIBT63B8GfHuXguC112Msk%2BfcOAD1IOnTOjTR7jzLhXaZmyvD1L2SPI5U8TnWS/mkWIQA%3D%3D%3D)
- Build with `-O2 -march=armv8.2-a+sha3+crypto`, assembly code is [here](https://godbolt.org/#z:OYLghAFBqd5QCxAYwPYBMCmBRdBLAF1QCcAaPECAMzwBtMA7AQwFtMQByARg9KtQYEAysib0QXACx8BBAKoBnTAAUAHpwAMvAFYTStJg1AB9U8lJL6yAngGVG6AMKpaAVxYMQAJgBspBwAyeAyYAHLuAEaYxCCSXKQADqgKhLYMzm4e3n5JKTYCQSHhLFExcRaYVvkMQgRMxAQZ7p6%2BFVVptfUEhWGR0bHxCnUNTVmtQ109xaUDAJQWqK7EyOwcAKQaAIJrXgDMwchuWADUa7uO9SzGIQIAdAhn2BvbWxM2yMfBtMGYx67BBAAHKouD5jARjgkWK5aLRjLRUAB3CB/AHA0Hg45MUiowTosEQiLHWbPNYAdgAQs9jjTjsRMAQlgwUQA3ekA6IJekEACOxlcgOMCS4XkBEGptMlUtpLOhsKFPkk4q20tVqogSVoAE9FeDZizgAz4UiFUrjmzMBziFyGXyErqBSimMTiaQJWqPccNS4dZI9QajQjEabWezBJzuXaHWLjkTZi744mzlStuSACLPN54D5fH64oEggmQuVwhB4YAICD/PGFzHY/P4zEREmpynuukMpmhy3h62R/mC4Wi5WbT3S2Uw0vlhAh81hggR22mgdO13tscbqUWq023nLx2xhMJ5OkskZ151d6fBjfEINwuqLyYitMBQzuUEYwimPVgsYiEAOIABI4r%2BjYQkBADSxKnimo60mBtYQsQGg4sQ8RYjiEQ4gQqHHAQXAniqCFog%2BT7IQyREvPBNJoAwQz3v%2BxwAF6nLsabmugrgJHyDArscGgwbscGSs6ZwccBVGSkS4nHFBVHtihbEcVCk7GsimGHiSwmKVwynFmpZYVk6WFCSJtK4fpLKYKoe4HthsY4oCZntgR%2BmqfKQYmfhgnaeZNKWbJHlTsZmmWX5rmCbJ1kkHyB64ThekRcRAV6dFNl2TGzE4XhznJTRdJRex5qYLF/EoYlLkpfhaXFdZtlxTGCUsU5VUFehVmlcQjUouhlX5ZK3K3CyYhrAArBSGjjRxskoVJtJDSNtDjRShFjTNxXofNNLcl2HYQvl6aklsiFMS%2Bb7GB%2BxjEOgyAoqdPiPpiwQwa2/mMUWTB4UwGHNQRCnVXRDEPZiCRWfOi6ZfyiqslxPHXNDZoaKogJkseOmAwIwOkUxzHRKgVlw7x/G%2BdtWJFRxwTDaNE1TetZM/fpVNLSta0Zhj1GSgA9AAVDzkI%2BgwqAsHgYgdlx1hpMcPNc5F7klsYRmVliGFgwNFm1Rx9WZSizV48QqCterNKM%2BlZUHj9/Vk256UNfx%2BuGz5RsMxTJXmzGX1WxzkqBcVwXqU6qttYpnbEMybvdfxns%2BejcFHVsHDzLQnBjbwngcFopCoJwjjHAoizLL8Oy7DwpAEJoifzAA1rEACcty7LXteSGSZKAhoPht4CY1ePonCSGnFdZ5wvAKCAqHlxniekHAsBIGgLAJHQ0TkJQC9L/QMSXCygIALTIIchjAFwY0aKhWAstmmAAGp4JgiIAPIJIwnClzQtALsQY8QBEQ8RME9QtSv14P/ZgxAtQPwiNoTA1hgGkAXmwQQD8bxAKnqQLALAj7iDQfgekktrJjzQTZGBrgFxwI5MnNB3wIjEEAc4LAQ8CDEDwCwYB8wqAGGAAoW%2B98n4v24LwfgggRBiHYFIGQghFAqHUGg3Q8QDBGBAKYYw5hqFj0gPMVACRqiEN3g/Lwxxd6YOWA8di29AS3C8LvJgOwKRviYLsWxyBwHaNQKPSoMDqj2AYE4FwzQQC7DGv4HxUw%2BgxBFIkZIqQBCjE8IEyJeQ0ihJKP0CJlhPEdGGI0PxWR4npMlgIToDRkkzDSVk2JASgkTGKT8aYqSvDzHzksFYEgk4p0Hmg7OHAsTEBYDvaxxxD5GGOCfW4GgxlelwIQEgpw9hcFmLwSeWhZjVxAKfW4Pgz49y8FwWuuwdknz7hwAepB06Zy6aPceZcK4rKOV4Dp5yR7XKnrc6yX80ixCAA%3D%3D)



- [x] Re-enable clang and add version checks
- [x] Fix armcc build fails


## Gatekeeper checklist

- [ ] **changelog** provided, or not required
- [ ] **backport** done, or not required
- [ ] **tests** provided, or not required



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

