### PR TITLE
Use `grep -E` instead of `egrep`

### DIFF
--- a/tests/scripts/doxygen.sh
+++ b/tests/scripts/doxygen.sh
@@ -35,7 +35,7 @@ cat doc.out doc.err | \
     grep -v "warning: ignoring unsupported tag" \
     > doc.filtered
 
-if egrep "(warning|error):" doc.filtered; then
+if grep -E "(warning|error):" doc.filtered; then
     echo "FAIL" >&2
     exit 1;
 fi


### PR DESCRIPTION
Trivial backport of #6865 

## Gatekeeper checklist

- [ ] **changelog** not required
- [ ] **backport** done, this is it
- [ ] **tests** not required