### PR TITLE
Depends.py support for TLS 1.3 key exchange modes

### DIFF
--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1907,6 +1907,11 @@ component_test_depends_py_kex () {
     tests/scripts/depends.py kex --unset-use-psa
 }
 
+component_test_depends_py_kex13 () {
+    msg "test/build: depends.py kex13 (gcc)"
+    tests/scripts/depends.py kex13 --unset-use-psa
+}
+
 component_test_depends_py_pkalgs () {
     msg "test/build: depends.py pkalgs (gcc)"
     tests/scripts/depends.py pkalgs --unset-use-psa
@@ -1941,6 +1946,11 @@ component_test_depends_py_hashes_psa () {
 component_test_depends_py_kex_psa () {
     msg "test/build: depends.py kex (gcc) with MBEDTLS_USE_PSA_CRYPTO defined"
     tests/scripts/depends.py kex
+}
+
+component_test_depends_py_kex13_psa () {
+    msg "test/build: depends.py kex13 (gcc) with MBEDTLS_USE_PSA_CRYPTO defined"
+    tests/scripts/depends.py kex13
 }
 
 component_test_depends_py_pkalgs_psa () {

--- a/tests/scripts/depends.py
+++ b/tests/scripts/depends.py
@@ -261,7 +261,10 @@ REVERSE_DEPENDENCIES = {
                          'MBEDTLS_ENTROPY_FORCE_SHA256',
                          'MBEDTLS_SHA256_USE_A64_CRYPTO_IF_PRESENT',
                          'MBEDTLS_SHA256_USE_A64_CRYPTO_ONLY'],
-    'MBEDTLS_X509_RSASSA_PSS_SUPPORT': []
+    'MBEDTLS_X509_RSASSA_PSS_SUPPORT': [],
+    # The support for TLS 1.3 is not complete yet and in particular
+    # pre-shared keys are not supported.
+    'MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED': ['MBEDTLS_SSL_PROTO_TLS1_3']
 }
 
 # If an option is tested in an exclusive test, alter the following defines.
@@ -289,6 +292,7 @@ EXCLUSIVE_GROUPS = {
                       '-MBEDTLS_GCM_C',
                       '-MBEDTLS_SSL_TICKET_C',
                       '-MBEDTLS_SSL_CONTEXT_SERIALIZATION'],
+    'MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED': ['-MBEDTLS_SSL_EARLY_DATA'],
 }
 def handle_exclusive_groups(config_settings, symbol):
     """For every symbol tested in an exclusive group check if there are other
@@ -393,6 +397,9 @@ class DomainData:
         curve_symbols = self.config_symbols_matching(r'MBEDTLS_ECP_DP_\w+_ENABLED\Z')
         # Find key exchange enabling macros by name.
         key_exchange_symbols = self.config_symbols_matching(r'MBEDTLS_KEY_EXCHANGE_\w+_ENABLED\Z')
+        # Find TLS 1.3 key exchange enabling macros by name.
+        key_exchange_symbols_1_3 = self.config_symbols_matching(\
+                    r'MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_\w+_ENABLED\Z')
         # Find cipher IDs (block permutations and stream ciphers --- chaining
         # and padding modes are exercised separately) information by parsing
         # cipher.h, as the information is not readily available in mbedtls_config.h.
@@ -424,6 +431,8 @@ class DomainData:
             'kex': ExclusiveDomain(key_exchange_symbols,
                                    [build_command + ['lib'],
                                     build_command + ['-C', 'programs']]),
+            'kex13': ExclusiveDomain(key_exchange_symbols_1_3,
+                                     build_and_test),
             'pkalgs': ComplementaryDomain(['MBEDTLS_ECDSA_C',
                                            'MBEDTLS_ECP_C',
                                            'MBEDTLS_PKCS1_V21',


### PR DESCRIPTION
## Description

This PR extends `depends.py` adding test for TLS1.3 key exchanges.
Resolves #6848 


## Gatekeeper checklist

- [ ] **changelog** not required
- [ ] **backport** not required
- [x] **tests** provided