### PR TITLE
mbedtls_mpi_sub_abs: Skip memcpy when redundant (#6701).

### DIFF
--- a/ChangeLog.d/conditionalize-mbedtls_mpi_sub_abs-memcpy.txt
+++ b/ChangeLog.d/conditionalize-mbedtls_mpi_sub_abs-memcpy.txt
@@ -1,5 +1,4 @@
 Bugfix
-   * Fix mbedtls_mpi_sub_abs() to account for the possibility that the output
-     pointer could equal the first input pointer and if so to skip a memcpy()
-     call that would be redundant.  Reported by Pascal Cuoq using TrustInSoft
-     Analyzer in #6701; observed independently by Aaron Ucko under Valgrind.
+   * Fix potential undefined behavior in mbedtls_mpi_sub_abs().  Reported by
+     Pascal Cuoq using TrustInSoft Analyzer in #6701; observed independently by
+     Aaron Ucko under Valgrind.

--- a/ChangeLog.d/conditionalize-mbedtls_mpi_sub_abs-memcpy.txt
+++ b/ChangeLog.d/conditionalize-mbedtls_mpi_sub_abs-memcpy.txt
@@ -1,0 +1,5 @@
+Bugfix
+   * Fix mbedtls_mpi_sub_abs() to account for the possibility that the output
+     pointer could equal the first input pointer and if so to skip a memcpy()
+     call that would be redundant.  Reported by Pascal Cuoq using TrustInSoft
+     Analyzer in #6701; observed independently by Aaron Ucko under Valgrind.

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -1009,7 +1009,7 @@ int mbedtls_mpi_sub_abs(mbedtls_mpi *X, const mbedtls_mpi *A, const mbedtls_mpi 
     /* Set the high limbs of X to match A. Don't touch the lower limbs
      * because X might be aliased to B, and we must not overwrite the
      * significant digits of B. */
-    if (A->n > n) {
+    if (A->n > n && A != X) {
         memcpy(X->p + n, A->p + n, (A->n - n) * ciL);
     }
     if (X->n > A->n) {


### PR DESCRIPTION
## Description

In some contexts, the output pointer may equal the first input pointer, in which case copying is not only superfluous but results in "Source and destination overlap in memcpy" errors from Valgrind (as I observed in the context of ecp_double_jac) and a diagnostic message from TrustInSoft Analyzer (as Pascal Cuoq reported in the context of other ECP functions called by cert-app with a suitable certificate).

I will be happy to supply a corresponding LTS PR in due course, particularly given that I'm using that branch myself.

(Split from #6930.)

## Gatekeeper checklist

- [x] **changelog** provided
- [x] **backport** #7001
- [x] **tests** not required



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

