### PR TITLE
Backport 2.28 - Fix RSA ALT test guards

### DIFF
--- a/ChangeLog.d/fix-rsaalt-test-guards.txt
+++ b/ChangeLog.d/fix-rsaalt-test-guards.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix compile error where MBEDTLS_RSA_C and MBEDTLS_X509_CRT_WRITE_C are
+     defined, but MBEDTLS_PK_RSA_ALT_SUPPORT is not defined. Fixes #3174.

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1806,6 +1806,18 @@ component_test_depends_py_pkalgs_psa () {
     tests/scripts/depends.py pkalgs
 }
 
+component_build_no_pk_rsa_alt_support () {
+    msg "build: !MBEDTLS_PK_RSA_ALT_SUPPORT" # ~30s
+
+    scripts/config.py full
+    scripts/config.py unset MBEDTLS_PK_RSA_ALT_SUPPORT
+    scripts/config.py set MBEDTLS_RSA_C
+    scripts/config.py set MBEDTLS_X509_CRT_WRITE_C
+
+    # Only compile - this is primarily to test for compile issues
+    make CC=gcc CFLAGS='-Werror -Wall -Wextra -I../tests/include/alt-dummy'
+}
+
 component_test_no_use_psa_crypto_full_cmake_asan() {
     # full minus MBEDTLS_USE_PSA_CRYPTO: run the same set of tests as basic-build-test.sh
     msg "build: cmake, full config minus MBEDTLS_USE_PSA_CRYPTO, ASan"

--- a/tests/suites/test_suite_x509write.function
+++ b/tests/suites/test_suite_x509write.function
@@ -294,7 +294,7 @@ void x509_crt_check(char *subject_key_file, char *subject_pwd,
     TEST_ASSERT(mbedtls_pk_parse_keyfile(&issuer_key, issuer_key_file,
                                          issuer_pwd) == 0);
 
-#if defined(MBEDTLS_RSA_C)
+#if defined(MBEDTLS_RSA_C) && defined(MBEDTLS_PK_RSA_ALT_SUPPORT)
     /* For RSA PK contexts, create a copy as an alternative RSA context. */
     if (rsa_alt == 1 && mbedtls_pk_get_type(&issuer_key) == MBEDTLS_PK_RSA) {
         TEST_ASSERT(mbedtls_pk_setup_rsa_alt(&issuer_key_alt,


### PR DESCRIPTION
## Description

Trivial backport of #6950 

## Gatekeeper checklist

- [x] **changelog** provided
- [x] **backport** this is it
- [x] **tests**  not required

