### PR TITLE
[Backport 2.28] Pass `MBEDTLS_CONFIG_FILE` defines through cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,13 +135,9 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
         FORCE)
 endif()
 
-# If set, make MBEDTLS_CONFIG_FILE and MBEDTLS_USER_CONFIG_FILE into PATHs
-if(DEFINED MBEDTLS_CONFIG_FILE)
-    set(MBEDTLS_CONFIG_FILE "" CACHE PATH "Mbed TLS config file (overrides default).")
-endif()
-if(DEFINED MBEDTLS_USER_CONFIG_FILE)
-    set(MBEDTLS_USER_CONFIG_FILE "" CACHE PATH "Mbed TLS user config file (appended to default).")
-endif()
+# Make MBEDTLS_CONFIG_FILE and MBEDTLS_USER_CONFIG_FILE into PATHs
+set(MBEDTLS_CONFIG_FILE "" CACHE FILEPATH "Mbed TLS config file (overrides default).")
+set(MBEDTLS_USER_CONFIG_FILE "" CACHE FILEPATH "Mbed TLS user config file (appended to default).")
 
 # Create a symbolic link from ${base_name} in the binary directory
 # to the corresponding path in the source directory.
@@ -314,13 +310,13 @@ if(ENABLE_TESTING OR ENABLE_PROGRAMS)
         PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/everest/include)
 
     # Pass-through MBEDTLS_CONFIG_FILE and MBEDTLS_USER_CONFIG_FILE
-    if(DEFINED MBEDTLS_CONFIG_FILE)
+    if(MBEDTLS_CONFIG_FILE)
         target_compile_definitions(mbedtls_test
             PUBLIC MBEDTLS_CONFIG_FILE="${MBEDTLS_CONFIG_FILE}")
         target_compile_definitions(mbedtls_test_helpers
             PUBLIC MBEDTLS_CONFIG_FILE="${MBEDTLS_CONFIG_FILE}")
     endif()
-    if(DEFINED MBEDTLS_USER_CONFIG_FILE)
+    if(MBEDTLS_USER_CONFIG_FILE)
         target_compile_definitions(mbedtls_test
             PUBLIC MBEDTLS_USER_CONFIG_FILE="${MBEDTLS_USER_CONFIG_FILE}")
         target_compile_definitions(mbedtls_test_helpers

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,14 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
         FORCE)
 endif()
 
+# If set, make MBEDTLS_CONFIG_FILE and MBEDTLS_USER_CONFIG_FILE into PATHs
+if(DEFINED MBEDTLS_CONFIG_FILE)
+    set(MBEDTLS_CONFIG_FILE "" CACHE PATH "Mbed TLS config file (overrides default).")
+endif()
+if(DEFINED MBEDTLS_USER_CONFIG_FILE)
+    set(MBEDTLS_USER_CONFIG_FILE "" CACHE PATH "Mbed TLS user config file (appended to default).")
+endif()
+
 # Create a symbolic link from ${base_name} in the binary directory
 # to the corresponding path in the source directory.
 # Note: Copies the file(s) on Windows.
@@ -304,6 +312,20 @@ if(ENABLE_TESTING OR ENABLE_PROGRAMS)
         PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
         PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/library
         PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/everest/include)
+
+    # Pass-through MBEDTLS_CONFIG_FILE and MBEDTLS_USER_CONFIG_FILE
+    if(DEFINED MBEDTLS_CONFIG_FILE)
+        target_compile_definitions(mbedtls_test
+            PUBLIC MBEDTLS_CONFIG_FILE="${MBEDTLS_CONFIG_FILE}")
+        target_compile_definitions(mbedtls_test_helpers
+            PUBLIC MBEDTLS_CONFIG_FILE="${MBEDTLS_CONFIG_FILE}")
+    endif()
+    if(DEFINED MBEDTLS_USER_CONFIG_FILE)
+        target_compile_definitions(mbedtls_test
+            PUBLIC MBEDTLS_USER_CONFIG_FILE="${MBEDTLS_USER_CONFIG_FILE}")
+        target_compile_definitions(mbedtls_test_helpers
+            PUBLIC MBEDTLS_USER_CONFIG_FILE="${MBEDTLS_USER_CONFIG_FILE}")
+    endif()
 endif()
 
 if(ENABLE_PROGRAMS)

--- a/ChangeLog.d/cmake-pass-through-config-defines.txt
+++ b/ChangeLog.d/cmake-pass-through-config-defines.txt
@@ -1,0 +1,3 @@
+Features
+   * Allow MBEDTLS_CONFIG_FILE and MBEDTLS_USER_CONFIG_FILE to be set by
+     setting the CMake variable of the same name at configuration time.

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -10,6 +10,14 @@ if(NOT DEFINED MBEDTLS_DIR)
     set(MBEDTLS_DIR ${CMAKE_SOURCE_DIR})
 endif()
 
+# If set, make MBEDTLS_CONFIG_FILE and MBEDTLS_USER_CONFIG_FILE into PATHs
+if(DEFINED MBEDTLS_CONFIG_FILE)
+    set(MBEDTLS_CONFIG_FILE "" CACHE PATH "Mbed TLS config file (overrides default).")
+endif()
+if(DEFINED MBEDTLS_USER_CONFIG_FILE)
+    set(MBEDTLS_USER_CONFIG_FILE "" CACHE PATH "Mbed TLS user config file (appended to default).")
+endif()
+
 set(src_crypto
     aes.c
     aesni.c
@@ -229,6 +237,15 @@ foreach(target IN LISTS target_libraries)
         PRIVATE ${thirdparty_inc})
     target_compile_definitions(${target}
         PRIVATE ${thirdparty_def})
+    # Pass-through MBEDTLS_CONFIG_FILE and MBEDTLS_USER_CONFIG_FILE
+    if(DEFINED MBEDTLS_CONFIG_FILE)
+        target_compile_definitions(${target}
+            PUBLIC MBEDTLS_CONFIG_FILE="${MBEDTLS_CONFIG_FILE}")
+    endif()
+    if(DEFINED MBEDTLS_USER_CONFIG_FILE)
+        target_compile_definitions(${target}
+            PUBLIC MBEDTLS_USER_CONFIG_FILE="${MBEDTLS_USER_CONFIG_FILE}")
+    endif()
     install(TARGETS ${target}
             DESTINATION ${LIB_INSTALL_DIR}
             PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -230,11 +230,11 @@ foreach(target IN LISTS target_libraries)
     target_compile_definitions(${target}
         PRIVATE ${thirdparty_def})
     # Pass-through MBEDTLS_CONFIG_FILE and MBEDTLS_USER_CONFIG_FILE
-    if(DEFINED MBEDTLS_CONFIG_FILE)
+    if(MBEDTLS_CONFIG_FILE)
         target_compile_definitions(${target}
             PUBLIC MBEDTLS_CONFIG_FILE="${MBEDTLS_CONFIG_FILE}")
     endif()
-    if(DEFINED MBEDTLS_USER_CONFIG_FILE)
+    if(MBEDTLS_USER_CONFIG_FILE)
         target_compile_definitions(${target}
             PUBLIC MBEDTLS_USER_CONFIG_FILE="${MBEDTLS_USER_CONFIG_FILE}")
     endif()

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -10,14 +10,6 @@ if(NOT DEFINED MBEDTLS_DIR)
     set(MBEDTLS_DIR ${CMAKE_SOURCE_DIR})
 endif()
 
-# If set, make MBEDTLS_CONFIG_FILE and MBEDTLS_USER_CONFIG_FILE into PATHs
-if(DEFINED MBEDTLS_CONFIG_FILE)
-    set(MBEDTLS_CONFIG_FILE "" CACHE PATH "Mbed TLS config file (overrides default).")
-endif()
-if(DEFINED MBEDTLS_USER_CONFIG_FILE)
-    set(MBEDTLS_USER_CONFIG_FILE "" CACHE PATH "Mbed TLS user config file (appended to default).")
-endif()
-
 set(src_crypto
     aes.c
     aesni.c

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -3413,20 +3413,20 @@ support_test_cmake_as_subdirectory () {
 }
 
 component_build_cmake_custom_config_file () {
-    # Make a copy of mbedtls_config.h to use for the in-tree test
-    cp include/mbedtls/mbedtls_config.h include/mbedtls_config_in_tree_copy.h
+    # Make a copy of config file to use for the in-tree test
+    cp "$CONFIG_H" include/mbedtls_config_in_tree_copy.h
 
     MBEDTLS_ROOT_DIR="$PWD"
     mkdir "$OUT_OF_SOURCE_DIR"
     cd "$OUT_OF_SOURCE_DIR"
 
-    # Build once to get the generated files (which need an intact mbedtls_config.h)
+    # Build once to get the generated files (which need an intact config file)
     cmake "$MBEDTLS_ROOT_DIR"
     make
 
     msg "build: cmake with -DMBEDTLS_CONFIG_FILE"
     scripts/config.py -w full_config.h full
-    echo '#error "cmake -DMBEDTLS_CONFIG_FILE is not working."' > "$MBEDTLS_ROOT_DIR/include/mbedtls/mbedtls_config.h"
+    echo '#error "cmake -DMBEDTLS_CONFIG_FILE is not working."' > "$MBEDTLS_ROOT_DIR/$CONFIG_H"
     cmake -DGEN_FILES=OFF -DMBEDTLS_CONFIG_FILE=full_config.h "$MBEDTLS_ROOT_DIR"
     make
 
@@ -3446,16 +3446,16 @@ component_build_cmake_custom_config_file () {
 
     # Now repeat the test for an in-tree build:
 
-    # Restore mbedtls_config.h for the in-tree test
-    mv include/mbedtls_config_in_tree_copy.h include/mbedtls/mbedtls_config.h
+    # Restore config for the in-tree test
+    mv include/mbedtls_config_in_tree_copy.h "$CONFIG_H"
 
-    # Build once to get the generated files (which need an intact mbedtls_config.h)
+    # Build once to get the generated files (which need an intact config)
     cmake .
     make
 
     msg "build: cmake (in-tree) with -DMBEDTLS_CONFIG_FILE"
     scripts/config.py -w full_config.h full
-    echo '#error "cmake -DMBEDTLS_CONFIG_FILE is not working."' > "$MBEDTLS_ROOT_DIR/include/mbedtls/mbedtls_config.h"
+    echo '#error "cmake -DMBEDTLS_CONFIG_FILE is not working."' > "$MBEDTLS_ROOT_DIR/$CONFIG_H"
     cmake -DGEN_FILES=OFF -DMBEDTLS_CONFIG_FILE=full_config.h .
     make
 

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -3412,6 +3412,69 @@ support_test_cmake_as_subdirectory () {
     support_test_cmake_out_of_source
 }
 
+component_build_cmake_custom_config_file () {
+    # Make a copy of mbedtls_config.h to use for the in-tree test
+    cp include/mbedtls/mbedtls_config.h include/mbedtls_config_in_tree_copy.h
+
+    MBEDTLS_ROOT_DIR="$PWD"
+    mkdir "$OUT_OF_SOURCE_DIR"
+    cd "$OUT_OF_SOURCE_DIR"
+
+    # Build once to get the generated files (which need an intact mbedtls_config.h)
+    cmake "$MBEDTLS_ROOT_DIR"
+    make
+
+    msg "build: cmake with -DMBEDTLS_CONFIG_FILE"
+    scripts/config.py -w full_config.h full
+    echo '#error "cmake -DMBEDTLS_CONFIG_FILE is not working."' > "$MBEDTLS_ROOT_DIR/include/mbedtls/mbedtls_config.h"
+    cmake -DGEN_FILES=OFF -DMBEDTLS_CONFIG_FILE=full_config.h "$MBEDTLS_ROOT_DIR"
+    make
+
+    msg "build: cmake with -DMBEDTLS_CONFIG_FILE + -DMBEDTLS_USER_CONFIG_FILE"
+    # In the user config, disable one feature (for simplicity, pick a feature
+    # that nothing else depends on).
+    echo '#undef MBEDTLS_NIST_KW_C' >user_config.h
+
+    cmake -DGEN_FILES=OFF -DMBEDTLS_CONFIG_FILE=full_config.h -DMBEDTLS_USER_CONFIG_FILE=user_config.h "$MBEDTLS_ROOT_DIR"
+    make
+    not programs/test/query_compile_time_config MBEDTLS_NIST_KW_C
+
+    rm -f user_config.h full_config.h
+
+    cd "$MBEDTLS_ROOT_DIR"
+    rm -rf "$OUT_OF_SOURCE_DIR"
+
+    # Now repeat the test for an in-tree build:
+
+    # Restore mbedtls_config.h for the in-tree test
+    mv include/mbedtls_config_in_tree_copy.h include/mbedtls/mbedtls_config.h
+
+    # Build once to get the generated files (which need an intact mbedtls_config.h)
+    cmake .
+    make
+
+    msg "build: cmake (in-tree) with -DMBEDTLS_CONFIG_FILE"
+    scripts/config.py -w full_config.h full
+    echo '#error "cmake -DMBEDTLS_CONFIG_FILE is not working."' > "$MBEDTLS_ROOT_DIR/include/mbedtls/mbedtls_config.h"
+    cmake -DGEN_FILES=OFF -DMBEDTLS_CONFIG_FILE=full_config.h .
+    make
+
+    msg "build: cmake (in-tree) with -DMBEDTLS_CONFIG_FILE + -DMBEDTLS_USER_CONFIG_FILE"
+    # In the user config, disable one feature (for simplicity, pick a feature
+    # that nothing else depends on).
+    echo '#undef MBEDTLS_NIST_KW_C' >user_config.h
+
+    cmake -DGEN_FILES=OFF -DMBEDTLS_CONFIG_FILE=full_config.h -DMBEDTLS_USER_CONFIG_FILE=user_config.h .
+    make
+    not programs/test/query_compile_time_config MBEDTLS_NIST_KW_C
+
+    rm -f user_config.h full_config.h
+}
+support_build_cmake_custom_config_file () {
+    support_test_cmake_out_of_source
+}
+
+
 component_test_zeroize () {
     # Test that the function mbedtls_platform_zeroize() is not optimized away by
     # different combinations of compilers and optimization flags by using an


### PR DESCRIPTION
Backport of #6914.

Conflicts:
 - `library/CMakeLists.txt` - the code that adds include directories and definitions has changed between 2.28 and development.
 - `all.sh` - 2.28 does not have the CMake as-package and as-package install tests.


## Gatekeeper checklist

- [x] **changelog** provided
- [x] **backport** of #6914
- [x] **tests** provided
