### PR TITLE
Minor improvements to `c_build_helper.py`

### DIFF
--- a/ChangeLog.d/c-build-helper-hostcc.txt
+++ b/ChangeLog.d/c-build-helper-hostcc.txt
@@ -1,0 +1,4 @@
+Features
+   * Use HOSTCC (if it is set) when compiling C code during generation of the
+     generated files. This allows them to be generated when CC is set for
+     cross compilation.

--- a/ChangeLog.d/c-build-helper-hostcc.txt
+++ b/ChangeLog.d/c-build-helper-hostcc.txt
@@ -1,4 +1,4 @@
 Features
    * Use HOSTCC (if it is set) when compiling C code during generation of the
-     generated files. This allows them to be generated when CC is set for
-     cross compilation.
+     configuration-independent files. This allows them to be generated when
+     CC is set for cross compilation.

--- a/scripts/mbedtls_dev/c_build_helper.py
+++ b/scripts/mbedtls_dev/c_build_helper.py
@@ -90,6 +90,13 @@ int main(void)
 ''')
 
 def compile_c_file(c_filename, exe_filename, include_dirs):
+    """Compile a C source file with the host compiler.
+
+    * ``c_filename``: the name of the source file to compile.
+    * ``exe_filename``: the name for the executable to be created.
+    * ``include_dirs``: a list of paths to include directories to be passed
+      with the -I switch.
+    """
     # Respect $HOSTCC if it is set
     cc = os.getenv('HOSTCC', None)
     if cc is None:

--- a/scripts/mbedtls_dev/c_build_helper.py
+++ b/scripts/mbedtls_dev/c_build_helper.py
@@ -90,7 +90,10 @@ int main(void)
 ''')
 
 def compile_c_file(c_filename, exe_filename, include_dirs):
-    cc = os.getenv('CC', 'cc')
+    # Respect $HOSTCC if it is set
+    cc = os.getenv('HOSTCC', None)
+    if cc is None:
+        cc = os.getenv('CC', 'cc')
     cmd = [cc]
 
     proc = subprocess.Popen(cmd,

--- a/scripts/mbedtls_dev/c_build_helper.py
+++ b/scripts/mbedtls_dev/c_build_helper.py
@@ -89,6 +89,27 @@ int main(void)
 }
 ''')
 
+def compile_c_file(c_filename, exe_filename, include_dirs):
+    cc = os.getenv('CC', 'cc')
+    cmd = [cc]
+
+    proc = subprocess.Popen(cmd,
+                            stdout=subprocess.DEVNULL,
+                            stderr=subprocess.PIPE,
+                            universal_newlines=True)
+    cc_is_msvc = 'Microsoft (R) C/C++' in proc.communicate()[1]
+
+    cmd += ['-I' + dir for dir in include_dirs]
+    if cc_is_msvc:
+        # MSVC has deprecated using -o to specify the output file,
+        # and produces an object file in the working directory by default.
+        obj_filename = exe_filename[:-4] + '.obj'
+        cmd += ['-Fe' + exe_filename, '-Fo' + obj_filename]
+    else:
+        cmd += ['-o' + exe_filename]
+
+    subprocess.check_call(cmd + [c_filename])
+
 def get_c_expression_values(
         cast_to, printf_format,
         expressions,
@@ -128,24 +149,8 @@ def get_c_expression_values(
                                                          expressions)
         )
         c_file.close()
-        cc = os.getenv('CC', 'cc')
-        cmd = [cc]
 
-        proc = subprocess.Popen(cmd,
-                                stdout=subprocess.DEVNULL,
-                                stderr=subprocess.PIPE,
-                                universal_newlines=True)
-        cc_is_msvc = 'Microsoft (R) C/C++' in proc.communicate()[1]
-
-        cmd += ['-I' + dir for dir in include_path]
-        if cc_is_msvc:
-            # MSVC has deprecated using -o to specify the output file,
-            # and produces an object file in the working directory by default.
-            obj_name = exe_name[:-4] + '.obj'
-            cmd += ['-Fe' + exe_name, '-Fo' + obj_name]
-        else:
-            cmd += ['-o' + exe_name]
-        subprocess.check_call(cmd + [c_name])
+        compile_c_file(c_name, exe_name, include_path)
         if keep_c:
             sys.stderr.write('List of {} tests kept at {}\n'
                              .format(caller, c_name))


### PR DESCRIPTION
This PR contains 2 improvements:
- Refactor `c_build_helper` to use a helper function for compilation. This allows a more flexible usage in other scripts that need to compile C code.
- Respect `$HOSTCC` for compilation if it is set, before falling back on `$CC`, allowing generated files to be generated when `$CC` is set for cross compiling.

## Gatekeeper checklist

- [x] **changelog** provided, ~or not required~
- [x] **backport** done: #6976
- [x] **tests** ~provided, or~ not required - Minor changes

