### PR TITLE
Inhibit compiler from optimising out const-time asm

### DIFF
--- a/library/constant_time.c
+++ b/library/constant_time.c
@@ -72,9 +72,9 @@ static inline uint32_t mbedtls_get_unaligned_volatile_uint32(volatile const unsi
      */
     uint32_t r;
 #if defined(__arm__) || defined(__thumb__) || defined(__thumb2__)
-    asm ("ldr %0, [%1]" : "=r" (r) : "r" (p) :);
+    asm volatile ("ldr %0, [%1]" : "=r" (r) : "r" (p) :);
 #elif defined(__aarch64__)
-    asm ("ldr %w0, [%1]" : "=r" (r) : "r" (p) :);
+    asm volatile ("ldr %w0, [%1]" : "=r" (r) : "r" (p) :);
 #endif
     return r;
 }


### PR DESCRIPTION
Follow-up to the discussion here: https://github.com/Mbed-TLS/mbedtls/pull/6832#discussion_r1066969858

Adding volatile prevents the compile from optimising the assembly line out, without the overhead of making `diff` volatile as suggested in that discussion. From a usability point of view, it also seems cleaner that `mbedtls_get_unaligned_volatile_uint32()` does the right thing without requiring the caller to do anything special with volatile.

## Gatekeeper checklist

- [x] **changelog** not required - no user visible impact
- [x] **backport** not required - not present in 2.28
- [x] **tests** covered by existing tests
