### PR TITLE
[Backport 2.28] check_files.py: Allow specific Box Drawings characters to be used

### DIFF
--- a/tests/scripts/check_files.py
+++ b/tests/scripts/check_files.py
@@ -285,6 +285,7 @@ class UnicodeIssueTracker(LineIssueTracker):
         '\u2070\u2071\u2074-\u208E\u2090-\u209C', # Superscripts and Subscripts
         '\u2190-\u21FF', # Arrows
         '\u2200-\u22FF', # Mathematical Symbols
+        '\u2500 \u2514 \u251C' # Box Drawings characters used in markdown trees
     ])
     # Allow any of the characters and ranges above, and anything classified
     # as a word constituent.

--- a/tests/scripts/check_files.py
+++ b/tests/scripts/check_files.py
@@ -285,7 +285,7 @@ class UnicodeIssueTracker(LineIssueTracker):
         '\u2070\u2071\u2074-\u208E\u2090-\u209C', # Superscripts and Subscripts
         '\u2190-\u21FF', # Arrows
         '\u2200-\u22FF', # Mathematical Symbols
-        '\u2500 \u2514 \u251C' # Box Drawings characters used in markdown trees
+        '\u2500-\u257F' # Box Drawings characters used in markdown trees
     ])
     # Allow any of the characters and ranges above, and anything classified
     # as a word constituent.

--- a/tests/scripts/check_files.py
+++ b/tests/scripts/check_files.py
@@ -268,7 +268,7 @@ class UnicodeIssueTracker(LineIssueTracker):
 
     heading = "Invalid UTF-8 or forbidden character:"
 
-    # Only allow valid UTF-8, and only white-listed characters.
+    # Only allow valid UTF-8, and only other explicitly allowed characters.
     # We deliberately exclude all characters that aren't a simple non-blank,
     # non-zero-width glyph, apart from a very small set (tab, ordinary space,
     # line breaks, "basic" no-break space and soft hyphen). In particular,


### PR DESCRIPTION
## Description

Currently, `check_files.py` enforces that Mbed TLS uses only valid UTF-8 and only other explicitly allowed characters. This PR adds three characters from the Box Drawings range to the list of allowed characters:

- `u\2500`: “─”
- `u\2514`: “└”
- `u\251C`: “├”

These characters are used to construct file trees in Markdown, like the one below. These can serve as useful visual aids.
```
├── src
│   ├── dir1
│   │   ├── file1.c
│   ├── file2.c
│   ├── file3.c
│   ├── file4.c
├── include
│   ├── head1.h
│   ├── head2.h
│   ├── head3.h
├── Makefile
└── .gitignore
```
This PR also changes the wording of how the allowed characters are explained using inclusive terminology.

## Gatekeeper checklist

- [x] **changelog** not required: changes to test scripts only here
- [x] **backport** of #6982 
- [x] **tests** not required