### PR TITLE
Fix incorrect dispatch to USAGE in example programs, which causes uninitialized memory to be used

### DIFF
--- a/ChangeLog.d/fix-example-programs-no-args.txt
+++ b/ChangeLog.d/fix-example-programs-no-args.txt
@@ -1,0 +1,7 @@
+Bugfix
+   * Fix a bug present in multiple example programs where running the program
+     from the shell without any command line argument results argv[1] being
+     accessed. The above was fixed for the following: pem2der.c, cert_req.c, 
+     cert_app.c, cert_write.c, req_app.c, crl_app.c, dh_genprime.c, key_app.c,
+     gen_key.c, key_app_writer.c, ssl_client2.c, ssl_server2.c, 
+     ssl_mail_client.c.

--- a/ChangeLog.d/fix-example-programs-no-args.txt
+++ b/ChangeLog.d/fix-example-programs-no-args.txt
@@ -1,7 +1,4 @@
 Bugfix
-   * Fix a bug present in multiple example programs where running the program
-     from the shell without any command line argument results argv[1] being
-     accessed. The above was fixed for the following: pem2der.c, cert_req.c, 
-     cert_app.c, cert_write.c, req_app.c, crl_app.c, dh_genprime.c, key_app.c,
-     gen_key.c, key_app_writer.c, ssl_client2.c, ssl_server2.c, 
-     ssl_mail_client.c.
+   * Fix behavior of certain sample programs which could, when run with no
+     arguments, access uninitialized memory in some cases. Fixes #6700 (which
+     was found by TrustInSoft Analyzer during REDOCS'22) and #1120.

--- a/programs/hash/generic_sum.c
+++ b/programs/hash/generic_sum.c
@@ -169,7 +169,7 @@ int main(int argc, char *argv[])
 
     mbedtls_md_init(&md_ctx);
 
-    if (argc == 1) {
+    if (argc < 2) {
         const int *list;
 
         mbedtls_printf("print mode:  generic_sum <mbedtls_md> <file> <file> ...\n");

--- a/programs/pkey/dh_genprime.c
+++ b/programs/pkey/dh_genprime.c
@@ -71,7 +71,7 @@ int main(int argc, char **argv)
     mbedtls_ctr_drbg_init(&ctr_drbg);
     mbedtls_entropy_init(&entropy);
 
-    if (argc == 0) {
+    if (argc < 2) {
 usage:
         mbedtls_printf(USAGE);
         goto exit;

--- a/programs/pkey/gen_key.c
+++ b/programs/pkey/gen_key.c
@@ -200,7 +200,7 @@ int main(int argc, char *argv[])
     mbedtls_ctr_drbg_init(&ctr_drbg);
     memset(buf, 0, sizeof(buf));
 
-    if (argc == 0) {
+    if (argc < 2) {
 usage:
         mbedtls_printf(USAGE);
 #if defined(MBEDTLS_ECP_C)

--- a/programs/pkey/key_app.c
+++ b/programs/pkey/key_app.c
@@ -103,7 +103,7 @@ int main(int argc, char *argv[])
     mbedtls_mpi_init(&D); mbedtls_mpi_init(&E); mbedtls_mpi_init(&DP);
     mbedtls_mpi_init(&DQ); mbedtls_mpi_init(&QP);
 
-    if (argc == 0) {
+    if (argc < 2) {
 usage:
         mbedtls_printf(USAGE);
         goto cleanup;

--- a/programs/pkey/key_app_writer.c
+++ b/programs/pkey/key_app_writer.c
@@ -220,7 +220,7 @@ int main(int argc, char *argv[])
     mbedtls_mpi_init(&D); mbedtls_mpi_init(&E); mbedtls_mpi_init(&DP);
     mbedtls_mpi_init(&DQ); mbedtls_mpi_init(&QP);
 
-    if (argc == 0) {
+    if (argc < 2) {
 usage:
         mbedtls_printf(USAGE);
         goto exit;

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -867,7 +867,7 @@ int main(int argc, char *argv[])
     mbedtls_test_enable_insecure_external_rng();
 #endif  /* MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG */
 
-    if (argc == 0) {
+    if (argc < 2) {
 usage:
         if (ret == 0) {
             ret = 1;

--- a/programs/ssl/ssl_mail_client.c
+++ b/programs/ssl/ssl_mail_client.c
@@ -370,7 +370,7 @@ int main(int argc, char *argv[])
     mbedtls_pk_init(&pkey);
     mbedtls_ctr_drbg_init(&ctr_drbg);
 
-    if (argc == 0) {
+    if (argc < 2) {
 usage:
         mbedtls_printf(USAGE);
 

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -1633,7 +1633,7 @@ int main(int argc, char *argv[])
     signal(SIGINT, term_handler);
 #endif
 
-    if (argc == 0) {
+    if (argc < 2) {
 usage:
         if (ret == 0) {
             ret = 1;

--- a/programs/test/query_compile_time_config.c
+++ b/programs/test/query_compile_time_config.c
@@ -40,7 +40,7 @@ int main(int argc, char *argv[])
 {
     int i;
 
-    if (argc == 1 || strcmp(argv[1], "-h") == 0) {
+    if (argc < 2 || strcmp(argv[1], "-h") == 0) {
         mbedtls_printf(USAGE, argv[0]);
         return MBEDTLS_EXIT_FAILURE;
     }

--- a/programs/util/pem2der.c
+++ b/programs/util/pem2der.c
@@ -189,7 +189,7 @@ int main(int argc, char *argv[])
     memset(buf, 0, sizeof(buf));
     memset(der_buffer, 0, sizeof(der_buffer));
 
-    if (argc == 0) {
+    if (argc < 2) {
 usage:
         mbedtls_printf(USAGE);
         goto exit;

--- a/programs/x509/cert_app.c
+++ b/programs/x509/cert_app.c
@@ -161,7 +161,7 @@ int main(int argc, char *argv[])
     memset(&cacrl, 0, sizeof(mbedtls_x509_crl));
 #endif
 
-    if (argc == 0) {
+    if (argc < 2) {
 usage:
         mbedtls_printf(USAGE);
         goto exit;

--- a/programs/x509/cert_req.c
+++ b/programs/x509/cert_req.c
@@ -159,7 +159,7 @@ int main(int argc, char *argv[])
     mbedtls_ctr_drbg_init(&ctr_drbg);
     memset(buf, 0, sizeof(buf));
 
-    if (argc == 0) {
+    if (argc < 2) {
 usage:
         mbedtls_printf(USAGE);
         goto exit;

--- a/programs/x509/cert_write.c
+++ b/programs/x509/cert_write.c
@@ -273,7 +273,7 @@ int main(int argc, char *argv[])
     mbedtls_x509_crt_init(&issuer_crt);
     memset(buf, 0, sizeof(buf));
 
-    if (argc == 0) {
+    if (argc < 2) {
 usage:
         mbedtls_printf(USAGE);
         goto exit;

--- a/programs/x509/crl_app.c
+++ b/programs/x509/crl_app.c
@@ -70,7 +70,7 @@ int main(int argc, char *argv[])
      */
     mbedtls_x509_crl_init(&crl);
 
-    if (argc == 0) {
+    if (argc < 2) {
 usage:
         mbedtls_printf(USAGE);
         goto exit;

--- a/programs/x509/req_app.c
+++ b/programs/x509/req_app.c
@@ -70,7 +70,7 @@ int main(int argc, char *argv[])
      */
     mbedtls_x509_csr_init(&csr);
 
-    if (argc == 0) {
+    if (argc < 2) {
 usage:
         mbedtls_printf(USAGE);
         goto exit;


### PR DESCRIPTION
## Description

Fixes issues #1120 and #6700.

Numerous example programs contain the following:
```
if (argc == 0) {
    goto USAGE;
}

// later in program
p = argv[1];
```
If a program is called from the shell then`argc = 1`, so the program will not go to USAGE due to the check. The access to `argv[1]` is accessing undefined memory. This PR changes the check to `if (argc < 2)`.


## Gatekeeper checklist

- [x] **changelog** provided
- [x] **backport** #7026 
- [x] **tests** not required, example programs

