### PR TITLE
all.sh: test_m32_xx is not supported on arm64 host

### DIFF
--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -3265,7 +3265,7 @@ component_test_m32_o0 () {
 }
 support_test_m32_o0 () {
     case $(uname -m) in
-        *64*) true;;
+        amd64|x86_64) true;;
         *) false;;
     esac
 }


### PR DESCRIPTION
## Description

test_m32_xxx tests are x86 specific, but the support function only identifies a 64-bit system. So the tests will be run on arm64 host and cause a test failure. This change restricts those tests to amd64/x86_64 only.


## Gatekeeper checklist

- [ ] **changelog** provided, or not required
- [ ] **backport** done, or not required
- [ ] **tests** provided, or not required


