### PR TITLE
Fix typos in doxygen commands in new bignum modules

### DIFF
--- a/library/bignum_core.h
+++ b/library/bignum_core.h
@@ -222,7 +222,7 @@ int mbedtls_mpi_core_read_le(mbedtls_mpi_uint *X,
  * most significant zero bytes in the input).
  *
  * \param[out] X        The address of the MPI.
- *                      May only be #NULL if \X_limbs is 0 and \p input_length
+ *                      May only be #NULL if \p X_limbs is 0 and \p input_length
  *                      is 0.
  * \param X_limbs       The number of limbs of \p X.
  * \param[in] input     The input buffer to import from.

--- a/library/bignum_mod.h
+++ b/library/bignum_mod.h
@@ -444,7 +444,7 @@ int mbedtls_mpi_mod_read(mbedtls_mpi_mod_residue *r,
  *                  limbs as the modulus \p N. (\p r is an input parameter, but
  *                  its value will be modified during execution and restored
  *                  before the function returns.)
- * \param[in] N     The address of the modulus associated with \r.
+ * \param[in] N     The address of the modulus associated with \p r.
  * \param[out] buf  The output buffer to export to.
  * \param buflen    The length in bytes of \p buf.
  * \param ext_rep   The endianness in which the number should be written into


### PR DESCRIPTION
## Gatekeeper checklist

- [ ] **changelog** not required - bignum work hasn't had its own changelog yet
- [ ] **backport** not required - this is in new bignum, which is on `development only`
- [ ] **tests** not required - this is documentation
