### PR TITLE
Don't use cast-assignment in ssl_server.c

### DIFF
--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -1374,6 +1374,11 @@ int report_cid_usage(mbedtls_ssl_context *ssl,
 #endif /* MBEDTLS_SSL_DTLS_CONNECTION_ID */
 
 #if defined(MBEDTLS_SSL_SESSION_TICKETS) && defined(MBEDTLS_HAVE_TIME)
+static inline void put_unaligned_uint32(void *p, uint32_t x)
+{
+    memcpy(p, &x, sizeof(x));
+}
+
 /* Functions for session ticket tests */
 int dummy_ticket_write(void *p_ticket, const mbedtls_ssl_session *session,
                        unsigned char *start, const unsigned char *end,
@@ -1387,7 +1392,7 @@ int dummy_ticket_write(void *p_ticket, const mbedtls_ssl_session *session,
     if (end - p < 4) {
         return MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL;
     }
-    *((uint32_t *) p) = 7 * 24 * 3600;
+    put_unaligned_uint32(p, 7 * 24 * 3600);
     *ticket_lifetime = 7 * 24 * 3600;
     p += 4;
 


### PR DESCRIPTION
Would have used `mbedtls_put_unaligned_uint32()`, but `alignment.h` is in `library/`.

## Gatekeeper checklist

- [x] **changelog** not required - minor change (to best practice) in a sample program
- [x] **backport** not required - dummy_ticket_write() is development-only - this code doesn't seem to appear in any form in mbedtls-2.28
- [x] **tests** not required - this is a sample program



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

