### PR TITLE
Backport 2.28: all.sh: test_m32_xx is not supported on arm64 host 

### DIFF
--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -2956,7 +2956,7 @@ component_test_m32_o0 () {
 }
 support_test_m32_o0 () {
     case $(uname -m) in
-        *64*) true;;
+        amd64|x86_64) true;;
         *) false;;
     esac
 }


### PR DESCRIPTION
## Description

This PR is a backport of #7003  to branch mbedtls-2.28.




