### PR TITLE
Make the fields of mbedtls_pk_rsassa_pss_options public

### DIFF
--- a/ChangeLog.d/pk_ext-pss_options-public.txt
+++ b/ChangeLog.d/pk_ext-pss_options-public.txt
@@ -1,0 +1,4 @@
+Bugfix
+   * Make the fields of mbedtls_pk_rsassa_pss_options public. This makes it
+     possible to verify RSA PSS signatures with the pk module, which was
+     inadvertently broken since Mbed TLS 3.0.

--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -98,8 +98,24 @@ typedef enum {
  *                  See \c mbedtls_rsa_rsassa_pss_verify_ext()
  */
 typedef struct mbedtls_pk_rsassa_pss_options {
-    mbedtls_md_type_t MBEDTLS_PRIVATE(mgf1_hash_id);
-    int MBEDTLS_PRIVATE(expected_salt_len);
+    /** The digest to use for MGF1 in PSS.
+     *
+     * \note When #MBEDTLS_USE_PSA_CRYPTO is enabled and #MBEDTLS_RSA_C is
+     *       disabled, this must be equal to the \c md_alg argument passed
+     *       to mbedtls_pk_verify_ext(). In a future version of the library,
+     *       this constraint may apply whenever #MBEDTLS_USE_PSA_CRYPTO is
+     *       enabled regardless of the status of #MBEDTLS_RSA_C.
+     */
+    mbedtls_md_type_t mgf1_hash_id;
+
+    /** The expected length of the salt, in bytes. This may be
+     * #MBEDTLS_RSA_SALT_LEN_ANY to accept any salt length.
+     *
+     * \note When #MBEDTLS_USE_PSA_CRYPTO is enabled, only
+     *       #MBEDTLS_RSA_SALT_LEN_ANY is valid. Any other value may be
+     *       ignored (allowing any salt length).
+     */
+    int expected_salt_len;
 
 } mbedtls_pk_rsassa_pss_options;
 


### PR DESCRIPTION
This makes it possible to verify RSA PSS signatures with the pk module, which was inadvertently broken since Mbed TLS 3.0. Fixes #7040.

## Gatekeeper checklist

- [x] **changelog** provided
- [x] **backport** N/A
- [x] **tests** no (no new behavior; we already test the use of the structure, and we don't have a way to test that the fields are public)
