### PR TITLE
Handle errors from hash functions in TLS code

### DIFF
--- a/library/ssl_client.c
+++ b/library/ssl_client.c
@@ -945,16 +945,29 @@ int mbedtls_ssl_write_client_hello(mbedtls_ssl_context *ssl)
 #endif /* MBEDTLS_SSL_PROTO_TLS1_2 && MBEDTLS_SSL_PROTO_DTLS */
     {
 
-        mbedtls_ssl_add_hs_hdr_to_checksum(ssl, MBEDTLS_SSL_HS_CLIENT_HELLO,
-                                           msg_len);
-        ssl->handshake->update_checksum(ssl, buf, msg_len - binders_len);
+        ret = mbedtls_ssl_add_hs_hdr_to_checksum(ssl,
+                                                 MBEDTLS_SSL_HS_CLIENT_HELLO,
+                                                 msg_len);
+        if (ret != 0) {
+            MBEDTLS_SSL_DEBUG_RET(1, "mbedtls_ssl_add_hs_hdr_to_checksum", ret);
+            return ret;
+        }
+        ret = ssl->handshake->update_checksum(ssl, buf, msg_len - binders_len);
+        if (ret != 0) {
+            MBEDTLS_SSL_DEBUG_RET(1, "update_checksum", ret);
+            return ret;
+        }
 #if defined(MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_SOME_PSK_ENABLED)
         if (binders_len > 0) {
             MBEDTLS_SSL_PROC_CHK(
                 mbedtls_ssl_tls13_write_binders_of_pre_shared_key_ext(
                     ssl, buf + msg_len - binders_len, buf + msg_len));
-            ssl->handshake->update_checksum(ssl, buf + msg_len - binders_len,
+            ret = ssl->handshake->update_checksum(ssl, buf + msg_len - binders_len,
                                             binders_len);
+            if (ret != 0) {
+                MBEDTLS_SSL_DEBUG_RET(1, "update_checksum", ret);
+                return ret;
+            }
         }
 #endif /* MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_SOME_PSK_ENABLED */
 

--- a/library/ssl_client.c
+++ b/library/ssl_client.c
@@ -963,7 +963,7 @@ int mbedtls_ssl_write_client_hello(mbedtls_ssl_context *ssl)
                 mbedtls_ssl_tls13_write_binders_of_pre_shared_key_ext(
                     ssl, buf + msg_len - binders_len, buf + msg_len));
             ret = ssl->handshake->update_checksum(ssl, buf + msg_len - binders_len,
-                                            binders_len);
+                                                  binders_len);
             if (ret != 0) {
                 MBEDTLS_SSL_DEBUG_RET(1, "update_checksum", ret);
                 return ret;

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -705,8 +705,11 @@ struct mbedtls_ssl_handshake_params {
 
     mbedtls_ssl_ciphersuite_t const *ciphersuite_info;
 
+    MBEDTLS_CHECK_RETURN_CRITICAL
     int (*update_checksum)(mbedtls_ssl_context *, const unsigned char *, size_t);
+    MBEDTLS_CHECK_RETURN_CRITICAL
     int (*calc_verify)(const mbedtls_ssl_context *, unsigned char *, size_t *);
+    MBEDTLS_CHECK_RETURN_CRITICAL
     int (*calc_finished)(mbedtls_ssl_context *, unsigned char *, int);
     mbedtls_ssl_tls_prf_cb *tls_prf;
 
@@ -1317,6 +1320,7 @@ static inline void mbedtls_ssl_handshake_set_state(mbedtls_ssl_context *ssl,
 MBEDTLS_CHECK_RETURN_CRITICAL
 int mbedtls_ssl_send_fatal_handshake_failure(mbedtls_ssl_context *ssl);
 
+MBEDTLS_CHECK_RETURN_CRITICAL
 int mbedtls_ssl_reset_checksum(mbedtls_ssl_context *ssl);
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_2)
@@ -1328,7 +1332,8 @@ MBEDTLS_CHECK_RETURN_CRITICAL
 int mbedtls_ssl_handle_message_type(mbedtls_ssl_context *ssl);
 MBEDTLS_CHECK_RETURN_CRITICAL
 int mbedtls_ssl_prepare_handshake_record(mbedtls_ssl_context *ssl);
-void mbedtls_ssl_update_handshake_status(mbedtls_ssl_context *ssl);
+MBEDTLS_CHECK_RETURN_CRITICAL
+int mbedtls_ssl_update_handshake_status(mbedtls_ssl_context *ssl);
 
 /**
  * \brief       Update record layer
@@ -1461,12 +1466,14 @@ void mbedtls_ssl_optimize_checksum(mbedtls_ssl_context *ssl,
 /*
  * Update checksum of handshake messages.
  */
-void mbedtls_ssl_add_hs_msg_to_checksum(mbedtls_ssl_context *ssl,
+MBEDTLS_CHECK_RETURN_CRITICAL
+int mbedtls_ssl_add_hs_msg_to_checksum(mbedtls_ssl_context *ssl,
                                         unsigned hs_type,
                                         unsigned char const *msg,
                                         size_t msg_len);
 
-void mbedtls_ssl_add_hs_hdr_to_checksum(mbedtls_ssl_context *ssl,
+MBEDTLS_CHECK_RETURN_CRITICAL
+int mbedtls_ssl_add_hs_hdr_to_checksum(mbedtls_ssl_context *ssl,
                                         unsigned hs_type,
                                         size_t total_hs_len);
 

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -1468,14 +1468,14 @@ void mbedtls_ssl_optimize_checksum(mbedtls_ssl_context *ssl,
  */
 MBEDTLS_CHECK_RETURN_CRITICAL
 int mbedtls_ssl_add_hs_msg_to_checksum(mbedtls_ssl_context *ssl,
-                                        unsigned hs_type,
-                                        unsigned char const *msg,
-                                        size_t msg_len);
+                                       unsigned hs_type,
+                                       unsigned char const *msg,
+                                       size_t msg_len);
 
 MBEDTLS_CHECK_RETURN_CRITICAL
 int mbedtls_ssl_add_hs_hdr_to_checksum(mbedtls_ssl_context *ssl,
-                                        unsigned hs_type,
-                                        size_t total_hs_len);
+                                       unsigned hs_type,
+                                       size_t total_hs_len);
 
 #if defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED)
 #if !defined(MBEDTLS_USE_PSA_CRYPTO)

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -705,9 +705,9 @@ struct mbedtls_ssl_handshake_params {
 
     mbedtls_ssl_ciphersuite_t const *ciphersuite_info;
 
-    void (*update_checksum)(mbedtls_ssl_context *, const unsigned char *, size_t);
-    void (*calc_verify)(const mbedtls_ssl_context *, unsigned char *, size_t *);
-    void (*calc_finished)(mbedtls_ssl_context *, unsigned char *, int);
+    int (*update_checksum)(mbedtls_ssl_context *, const unsigned char *, size_t);
+    int (*calc_verify)(const mbedtls_ssl_context *, unsigned char *, size_t *);
+    int (*calc_finished)(mbedtls_ssl_context *, unsigned char *, int);
     mbedtls_ssl_tls_prf_cb *tls_prf;
 
     /*
@@ -1317,7 +1317,7 @@ static inline void mbedtls_ssl_handshake_set_state(mbedtls_ssl_context *ssl,
 MBEDTLS_CHECK_RETURN_CRITICAL
 int mbedtls_ssl_send_fatal_handshake_failure(mbedtls_ssl_context *ssl);
 
-void mbedtls_ssl_reset_checksum(mbedtls_ssl_context *ssl);
+int mbedtls_ssl_reset_checksum(mbedtls_ssl_context *ssl);
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_2)
 MBEDTLS_CHECK_RETURN_CRITICAL

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -2639,7 +2639,12 @@ int mbedtls_ssl_write_handshake_msg_ext(mbedtls_ssl_context *ssl,
 
         /* Update running hashes of handshake messages seen */
         if (hs_type != MBEDTLS_SSL_HS_HELLO_REQUEST && update_checksum != 0) {
-            ssl->handshake->update_checksum(ssl, ssl->out_msg, ssl->out_msglen);
+            ret = ssl->handshake->update_checksum(ssl, ssl->out_msg,
+                                                  ssl->out_msglen);
+            if (ret != 0) {
+                MBEDTLS_SSL_DEBUG_RET(1, "update_checksum", ret);
+                return ret;
+            }
         }
     }
 
@@ -3067,12 +3072,17 @@ int mbedtls_ssl_prepare_handshake_record(mbedtls_ssl_context *ssl)
     return 0;
 }
 
-void mbedtls_ssl_update_handshake_status(mbedtls_ssl_context *ssl)
+int mbedtls_ssl_update_handshake_status(mbedtls_ssl_context *ssl)
 {
+    int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     mbedtls_ssl_handshake_params * const hs = ssl->handshake;
 
     if (mbedtls_ssl_is_handshake_over(ssl) == 0 && hs != NULL) {
-        ssl->handshake->update_checksum(ssl, ssl->in_msg, ssl->in_hslen);
+        ret = ssl->handshake->update_checksum(ssl, ssl->in_msg, ssl->in_hslen);
+        if (ret != 0) {
+            MBEDTLS_SSL_DEBUG_RET(1, "update_checksum", ret);
+            return ret;
+        }
     }
 
     /* Handshake message is complete, increment counter */
@@ -3103,6 +3113,7 @@ void mbedtls_ssl_update_handshake_status(mbedtls_ssl_context *ssl)
         memset(hs_buf, 0, sizeof(mbedtls_ssl_hs_buffer));
     }
 #endif
+    return 0;
 }
 
 /*
@@ -3928,7 +3939,11 @@ int mbedtls_ssl_read_record(mbedtls_ssl_context *ssl,
 
         if (ssl->in_msgtype == MBEDTLS_SSL_MSG_HANDSHAKE &&
             update_hs_digest == 1) {
-            mbedtls_ssl_update_handshake_status(ssl);
+            ret = mbedtls_ssl_update_handshake_status(ssl);
+            if (0 != ret) {
+                MBEDTLS_SSL_DEBUG_RET(1, ("mbedtls_ssl_update_handshake_status"), ret);
+                return ret;
+            }
         }
     } else {
         MBEDTLS_SSL_DEBUG_MSG(2, ("reuse previously read message"));

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -893,19 +893,15 @@ static void ssl_handshake_params_init(mbedtls_ssl_handshake_params *handshake)
 #if defined(MBEDTLS_HAS_ALG_SHA_256_VIA_MD_OR_PSA_BASED_ON_USE_PSA)
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     handshake->fin_sha256_psa = psa_hash_operation_init();
-    psa_hash_setup(&handshake->fin_sha256_psa, PSA_ALG_SHA_256);
 #else
     mbedtls_sha256_init(&handshake->fin_sha256);
-    mbedtls_sha256_starts(&handshake->fin_sha256, 0);
 #endif
 #endif
 #if defined(MBEDTLS_HAS_ALG_SHA_384_VIA_MD_OR_PSA_BASED_ON_USE_PSA)
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     handshake->fin_sha384_psa = psa_hash_operation_init();
-    psa_hash_setup(&handshake->fin_sha384_psa, PSA_ALG_SHA_384);
 #else
     mbedtls_sha512_init(&handshake->fin_sha384);
-    mbedtls_sha512_starts(&handshake->fin_sha384, 1);
 #endif
 #endif
 
@@ -1041,6 +1037,9 @@ static int ssl_handshake_init(mbedtls_ssl_context *ssl)
 #if defined(MBEDTLS_SSL_PROTO_TLS1_2)
     mbedtls_ssl_transform_init(ssl->transform_negotiate);
 #endif
+
+    /* Setup handshake checksums */
+    mbedtls_ssl_reset_checksum(ssl);
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3) && \
     defined(MBEDTLS_SSL_SRV_C) && \

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -6623,8 +6623,8 @@ exit:
 
 exit:
     mbedtls_sha256_free(&sha256);
+    return ret;
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
-    return 0;
 }
 #endif /* MBEDTLS_HAS_ALG_SHA_256_VIA_MD_OR_PSA_BASED_ON_USE_PSA */
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -818,12 +818,16 @@ int mbedtls_ssl_add_hs_msg_to_checksum(mbedtls_ssl_context *ssl,
 
 int mbedtls_ssl_reset_checksum(mbedtls_ssl_context *ssl)
 {
+#if defined(MBEDTLS_HAS_ALG_SHA_256_VIA_MD_OR_PSA_BASED_ON_USE_PSA) || \
+    defined(MBEDTLS_HAS_ALG_SHA_384_VIA_MD_OR_PSA_BASED_ON_USE_PSA)
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     psa_status_t status;
 #else
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
 #endif
+#else /* SHA-256 or SHA-384 */
     ((void) ssl);
+#endif /* SHA-256 or SHA-384 */
 #if defined(MBEDTLS_HAS_ALG_SHA_256_VIA_MD_OR_PSA_BASED_ON_USE_PSA)
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     status = psa_hash_abort(&ssl->handshake->fin_sha256_psa);
@@ -864,11 +868,18 @@ int mbedtls_ssl_reset_checksum(mbedtls_ssl_context *ssl)
 static int ssl_update_checksum_start(mbedtls_ssl_context *ssl,
                                      const unsigned char *buf, size_t len)
 {
+#if defined(MBEDTLS_HAS_ALG_SHA_256_VIA_MD_OR_PSA_BASED_ON_USE_PSA) || \
+    defined(MBEDTLS_HAS_ALG_SHA_384_VIA_MD_OR_PSA_BASED_ON_USE_PSA)
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     psa_status_t status;
 #else
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
 #endif
+#else /* SHA-256 or SHA-384 */
+    ((void) ssl);
+    (void) buf;
+    (void) len;
+#endif /* SHA-256 or SHA-384 */
 #if defined(MBEDTLS_HAS_ALG_SHA_256_VIA_MD_OR_PSA_BASED_ON_USE_PSA)
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     status = psa_hash_update(&ssl->handshake->fin_sha256_psa, buf, len);
@@ -894,12 +905,6 @@ static int ssl_update_checksum_start(mbedtls_ssl_context *ssl,
         return ret;
     }
 #endif
-#endif
-#if !defined(MBEDTLS_HAS_ALG_SHA_256_VIA_MD_OR_PSA_BASED_ON_USE_PSA) && \
-    !defined(MBEDTLS_HAS_ALG_SHA_384_VIA_MD_OR_PSA_BASED_ON_USE_PSA)
-    (void) ssl;
-    (void) buf;
-    (void) len;
 #endif
     return 0;
 }

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -789,8 +789,8 @@ void mbedtls_ssl_optimize_checksum(mbedtls_ssl_context *ssl,
 }
 
 int mbedtls_ssl_add_hs_hdr_to_checksum(mbedtls_ssl_context *ssl,
-                                        unsigned hs_type,
-                                        size_t total_hs_len)
+                                       unsigned hs_type,
+                                       size_t total_hs_len)
 {
     unsigned char hs_hdr[4];
 
@@ -804,14 +804,15 @@ int mbedtls_ssl_add_hs_hdr_to_checksum(mbedtls_ssl_context *ssl,
 }
 
 int mbedtls_ssl_add_hs_msg_to_checksum(mbedtls_ssl_context *ssl,
-                                        unsigned hs_type,
-                                        unsigned char const *msg,
-                                        size_t msg_len)
+                                       unsigned hs_type,
+                                       unsigned char const *msg,
+                                       size_t msg_len)
 {
     int ret;
     ret = mbedtls_ssl_add_hs_hdr_to_checksum(ssl, hs_type, msg_len);
-    if (ret != 0)
+    if (ret != 0) {
         return ret;
+    }
     return ssl->handshake->update_checksum(ssl, msg, msg_len);
 }
 
@@ -861,7 +862,7 @@ int mbedtls_ssl_reset_checksum(mbedtls_ssl_context *ssl)
 }
 
 static int ssl_update_checksum_start(mbedtls_ssl_context *ssl,
-                                      const unsigned char *buf, size_t len)
+                                     const unsigned char *buf, size_t len)
 {
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     psa_status_t status;
@@ -905,11 +906,11 @@ static int ssl_update_checksum_start(mbedtls_ssl_context *ssl,
 
 #if defined(MBEDTLS_HAS_ALG_SHA_256_VIA_MD_OR_PSA_BASED_ON_USE_PSA)
 static int ssl_update_checksum_sha256(mbedtls_ssl_context *ssl,
-                                       const unsigned char *buf, size_t len)
+                                      const unsigned char *buf, size_t len)
 {
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     return mbedtls_md_error_from_psa(psa_hash_update(
-                             &ssl->handshake->fin_sha256_psa, buf, len));
+                                         &ssl->handshake->fin_sha256_psa, buf, len));
 #else
     return mbedtls_sha256_update(&ssl->handshake->fin_sha256, buf, len);
 #endif
@@ -918,11 +919,11 @@ static int ssl_update_checksum_sha256(mbedtls_ssl_context *ssl,
 
 #if defined(MBEDTLS_HAS_ALG_SHA_384_VIA_MD_OR_PSA_BASED_ON_USE_PSA)
 static int ssl_update_checksum_sha384(mbedtls_ssl_context *ssl,
-                                       const unsigned char *buf, size_t len)
+                                      const unsigned char *buf, size_t len)
 {
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     return mbedtls_md_error_from_psa(psa_hash_update(
-                             &ssl->handshake->fin_sha384_psa, buf, len));
+                                         &ssl->handshake->fin_sha384_psa, buf, len));
 #else
     return mbedtls_sha512_update(&ssl->handshake->fin_sha384, buf, len);
 #endif

--- a/library/ssl_tls12_client.c
+++ b/library/ssl_tls12_client.c
@@ -1090,6 +1090,7 @@ static int ssl_parse_use_srtp_ext(mbedtls_ssl_context *ssl,
 MBEDTLS_CHECK_RETURN_CRITICAL
 static int ssl_parse_hello_verify_request(mbedtls_ssl_context *ssl)
 {
+    int ret = MBEDTLS_ERR_SSL_FEATURE_UNAVAILABLE;
     const unsigned char *p = ssl->in_msg + mbedtls_ssl_hs_hdr_len(ssl);
     uint16_t dtls_legacy_version;
 
@@ -1160,7 +1161,11 @@ static int ssl_parse_hello_verify_request(mbedtls_ssl_context *ssl)
 
     /* Start over at ClientHello */
     ssl->state = MBEDTLS_SSL_CLIENT_HELLO;
-    mbedtls_ssl_reset_checksum(ssl);
+    ret = mbedtls_ssl_reset_checksum(ssl);
+    if (0 != ret) {
+        MBEDTLS_SSL_DEBUG_RET(1, ("mbedtls_ssl_reset_checksum"), ret);
+        return ret;
+    }
 
     mbedtls_ssl_recv_flight_completed(ssl);
 
@@ -3283,7 +3288,11 @@ static int ssl_write_certificate_verify(mbedtls_ssl_context *ssl)
 sign:
 #endif
 
-    ssl->handshake->calc_verify(ssl, hash, &hashlen);
+    ret = ssl->handshake->calc_verify(ssl, hash, &hashlen);
+    if (0 != ret) {
+        MBEDTLS_SSL_DEBUG_RET(1, ("calc_verify"), ret);
+        return ret;
+    }
 
     /*
      * digitally-signed struct {

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -1020,7 +1020,11 @@ read_record_header:
 
     MBEDTLS_SSL_DEBUG_BUF(4, "record contents", buf, msg_len);
 
-    ssl->handshake->update_checksum(ssl, buf, msg_len);
+    ret = ssl->handshake->update_checksum(ssl, buf, msg_len);
+    if (0 != ret) {
+        MBEDTLS_SSL_DEBUG_RET(1, ("update_checksum"), ret);
+        return ret;
+    }
 
     /*
      * Handshake layer:
@@ -4129,7 +4133,11 @@ static int ssl_parse_certificate_verify(mbedtls_ssl_context *ssl)
     /* Calculate hash and verify signature */
     {
         size_t dummy_hlen;
-        ssl->handshake->calc_verify(ssl, hash, &dummy_hlen);
+        ret = ssl->handshake->calc_verify(ssl, hash, &dummy_hlen);
+        if (0 != ret) {
+            MBEDTLS_SSL_DEBUG_RET(1, ("calc_verify"), ret);
+            return ret;
+        }
     }
 
     if ((ret = mbedtls_pk_verify(peer_pk,
@@ -4139,7 +4147,11 @@ static int ssl_parse_certificate_verify(mbedtls_ssl_context *ssl)
         return ret;
     }
 
-    mbedtls_ssl_update_handshake_status(ssl);
+    ret = mbedtls_ssl_update_handshake_status(ssl);
+    if (0 != ret) {
+        MBEDTLS_SSL_DEBUG_RET(1, ("mbedtls_ssl_update_handshake_status"), ret);
+        return ret;
+    }
 
     MBEDTLS_SSL_DEBUG_MSG(2, ("<= parse certificate verify"));
 

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -1490,8 +1490,8 @@ static int ssl_tls13_preprocess_server_hello(mbedtls_ssl_context *ssl,
         ssl->keep_current_message = 1;
         ssl->tls_version = MBEDTLS_SSL_VERSION_TLS1_2;
         MBEDTLS_SSL_PROC_CHK(mbedtls_ssl_add_hs_msg_to_checksum(ssl,
-                             MBEDTLS_SSL_HS_SERVER_HELLO,
-                             buf, (size_t) (end - buf)));
+                                                                MBEDTLS_SSL_HS_SERVER_HELLO,
+                                                                buf, (size_t) (end - buf)));
 
         if (mbedtls_ssl_conf_tls13_some_ephemeral_enabled(ssl)) {
             ret = ssl_tls13_reset_key_share(ssl);
@@ -2058,7 +2058,8 @@ static int ssl_tls13_process_server_hello(mbedtls_ssl_context *ssl)
     }
 
     MBEDTLS_SSL_PROC_CHK(mbedtls_ssl_add_hs_msg_to_checksum(ssl,
-                          MBEDTLS_SSL_HS_SERVER_HELLO, buf, buf_len));
+                                                            MBEDTLS_SSL_HS_SERVER_HELLO, buf,
+                                                            buf_len));
 
     if (is_hrr) {
         MBEDTLS_SSL_PROC_CHK(ssl_tls13_postprocess_hrr(ssl));
@@ -2216,7 +2217,8 @@ static int ssl_tls13_process_encrypted_extensions(mbedtls_ssl_context *ssl)
 #endif
 
     MBEDTLS_SSL_PROC_CHK(mbedtls_ssl_add_hs_msg_to_checksum(ssl,
-                         MBEDTLS_SSL_HS_ENCRYPTED_EXTENSIONS, buf, buf_len));
+                                                            MBEDTLS_SSL_HS_ENCRYPTED_EXTENSIONS,
+                                                            buf, buf_len));
 
 #if defined(MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED)
     if (mbedtls_ssl_tls13_key_exchange_mode_with_psk(ssl)) {
@@ -2460,7 +2462,8 @@ static int ssl_tls13_process_certificate_request(mbedtls_ssl_context *ssl)
                                                                  buf, buf + buf_len));
 
         MBEDTLS_SSL_PROC_CHK(mbedtls_ssl_add_hs_msg_to_checksum(ssl,
-                             MBEDTLS_SSL_HS_CERTIFICATE_REQUEST, buf, buf_len));
+                                                                MBEDTLS_SSL_HS_CERTIFICATE_REQUEST,
+                                                                buf, buf_len));
     } else if (ret == SSL_CERTIFICATE_REQUEST_SKIP) {
         ret = 0;
     } else {

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -2262,8 +2262,8 @@ static int ssl_tls13_write_end_of_early_data(mbedtls_ssl_context *ssl)
                              ssl, MBEDTLS_SSL_HS_END_OF_EARLY_DATA,
                              &buf, &buf_len));
 
-    mbedtls_ssl_add_hs_hdr_to_checksum(
-        ssl, MBEDTLS_SSL_HS_END_OF_EARLY_DATA, 0);
+    MBEDTLS_SSL_PROC_CHK(mbedtls_ssl_add_hs_hdr_to_checksum(
+                             ssl, MBEDTLS_SSL_HS_END_OF_EARLY_DATA, 0));
 
     MBEDTLS_SSL_PROC_CHK(
         mbedtls_ssl_finish_handshake_msg(ssl, buf_len, 0));

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -1489,8 +1489,9 @@ static int ssl_tls13_preprocess_server_hello(mbedtls_ssl_context *ssl,
 
         ssl->keep_current_message = 1;
         ssl->tls_version = MBEDTLS_SSL_VERSION_TLS1_2;
-        mbedtls_ssl_add_hs_msg_to_checksum(ssl, MBEDTLS_SSL_HS_SERVER_HELLO,
-                                           buf, (size_t) (end - buf));
+        MBEDTLS_SSL_PROC_CHK(mbedtls_ssl_add_hs_msg_to_checksum(ssl,
+                             MBEDTLS_SSL_HS_SERVER_HELLO,
+                             buf, (size_t) (end - buf)));
 
         if (mbedtls_ssl_conf_tls13_some_ephemeral_enabled(ssl)) {
             ret = ssl_tls13_reset_key_share(ssl);
@@ -2056,8 +2057,8 @@ static int ssl_tls13_process_server_hello(mbedtls_ssl_context *ssl)
         MBEDTLS_SSL_PROC_CHK(mbedtls_ssl_reset_transcript_for_hrr(ssl));
     }
 
-    mbedtls_ssl_add_hs_msg_to_checksum(ssl, MBEDTLS_SSL_HS_SERVER_HELLO,
-                                       buf, buf_len);
+    MBEDTLS_SSL_PROC_CHK(mbedtls_ssl_add_hs_msg_to_checksum(ssl,
+                          MBEDTLS_SSL_HS_SERVER_HELLO, buf, buf_len));
 
     if (is_hrr) {
         MBEDTLS_SSL_PROC_CHK(ssl_tls13_postprocess_hrr(ssl));
@@ -2214,8 +2215,8 @@ static int ssl_tls13_process_encrypted_extensions(mbedtls_ssl_context *ssl)
     }
 #endif
 
-    mbedtls_ssl_add_hs_msg_to_checksum(ssl, MBEDTLS_SSL_HS_ENCRYPTED_EXTENSIONS,
-                                       buf, buf_len);
+    MBEDTLS_SSL_PROC_CHK(mbedtls_ssl_add_hs_msg_to_checksum(ssl,
+                         MBEDTLS_SSL_HS_ENCRYPTED_EXTENSIONS, buf, buf_len));
 
 #if defined(MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED)
     if (mbedtls_ssl_tls13_key_exchange_mode_with_psk(ssl)) {
@@ -2458,8 +2459,8 @@ static int ssl_tls13_process_certificate_request(mbedtls_ssl_context *ssl)
         MBEDTLS_SSL_PROC_CHK(ssl_tls13_parse_certificate_request(ssl,
                                                                  buf, buf + buf_len));
 
-        mbedtls_ssl_add_hs_msg_to_checksum(ssl, MBEDTLS_SSL_HS_CERTIFICATE_REQUEST,
-                                           buf, buf_len);
+        MBEDTLS_SSL_PROC_CHK(mbedtls_ssl_add_hs_msg_to_checksum(ssl,
+                             MBEDTLS_SSL_HS_CERTIFICATE_REQUEST, buf, buf_len));
     } else if (ret == SSL_CERTIFICATE_REQUEST_SKIP) {
         ret = 0;
     } else {

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -1399,37 +1399,9 @@ int mbedtls_ssl_reset_transcript_for_hrr(mbedtls_ssl_context *ssl)
 
     hash_len += 4;
 
-#if defined(MBEDTLS_HAS_ALG_SHA_256_VIA_MD_OR_PSA_BASED_ON_USE_PSA)
-    if (ciphersuite_info->mac == MBEDTLS_MD_SHA256) {
-        MBEDTLS_SSL_DEBUG_BUF(4, "Truncated SHA-256 handshake transcript",
-                              hash_transcript, hash_len);
-
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
-        psa_hash_abort(&ssl->handshake->fin_sha256_psa);
-        psa_hash_setup(&ssl->handshake->fin_sha256_psa, PSA_ALG_SHA_256);
-#else
-        mbedtls_sha256_starts(&ssl->handshake->fin_sha256, 0);
-#endif
-    }
-#endif /* MBEDTLS_HAS_ALG_SHA_256_VIA_MD_OR_PSA_BASED_ON_USE_PSA */
-#if defined(MBEDTLS_HAS_ALG_SHA_384_VIA_MD_OR_PSA_BASED_ON_USE_PSA)
-    if (ciphersuite_info->mac == MBEDTLS_MD_SHA384) {
-        MBEDTLS_SSL_DEBUG_BUF(4, "Truncated SHA-384 handshake transcript",
-                              hash_transcript, hash_len);
-
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
-        psa_hash_abort(&ssl->handshake->fin_sha384_psa);
-        psa_hash_setup(&ssl->handshake->fin_sha384_psa, PSA_ALG_SHA_384);
-#else
-        mbedtls_sha512_starts(&ssl->handshake->fin_sha384, 1);
-#endif
-    }
-#endif /* MBEDTLS_HAS_ALG_SHA_384_VIA_MD_OR_PSA_BASED_ON_USE_PSA */
-#if defined(MBEDTLS_HAS_ALG_SHA_256_VIA_MD_OR_PSA_BASED_ON_USE_PSA) || \
-    defined(MBEDTLS_HAS_ALG_SHA_384_VIA_MD_OR_PSA_BASED_ON_USE_PSA)
+    /* Reset running hash and replace it with a hash of the transcript */
+    mbedtls_ssl_reset_checksum(ssl);
     ssl->handshake->update_checksum(ssl, hash_transcript, hash_len);
-#endif \
-    /* MBEDTLS_HAS_ALG_SHA_256_VIA_MD_OR_PSA_BASED_ON_USE_PSA || MBEDTLS_HAS_ALG_SHA_384_VIA_MD_OR_PSA_BASED_ON_USE_PSA */
 
     return ret;
 }

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -1392,7 +1392,7 @@ int mbedtls_ssl_reset_transcript_for_hrr(mbedtls_ssl_context *ssl)
                                                PSA_HASH_MAX_SIZE,
                                                &hash_len);
     if (ret != 0) {
-        MBEDTLS_SSL_DEBUG_RET(4, "mbedtls_ssl_get_handshake_transcript", ret);
+        MBEDTLS_SSL_DEBUG_RET(1, "mbedtls_ssl_get_handshake_transcript", ret);
         return ret;
     }
 
@@ -1402,6 +1402,9 @@ int mbedtls_ssl_reset_transcript_for_hrr(mbedtls_ssl_context *ssl)
     hash_transcript[3] = (unsigned char) hash_len;
 
     hash_len += 4;
+
+    MBEDTLS_SSL_DEBUG_BUF(4, "Truncated handshake transcript",
+                          hash_transcript, hash_len);
 
     /* Reset running hash and replace it with a hash of the transcript */
     ret = mbedtls_ssl_reset_checksum(ssl);

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -323,8 +323,8 @@ int mbedtls_ssl_tls13_process_certificate_verify(mbedtls_ssl_context *ssl)
                                                             verify_buffer_len));
 
     MBEDTLS_SSL_PROC_CHK(mbedtls_ssl_add_hs_msg_to_checksum(ssl,
-                         MBEDTLS_SSL_HS_CERTIFICATE_VERIFY,
-                         buf, buf_len));
+                                                            MBEDTLS_SSL_HS_CERTIFICATE_VERIFY,
+                                                            buf, buf_len));
 
 cleanup:
 
@@ -754,7 +754,8 @@ int mbedtls_ssl_tls13_process_certificate(mbedtls_ssl_context *ssl)
     MBEDTLS_SSL_PROC_CHK(ssl_tls13_validate_certificate(ssl));
 
     MBEDTLS_SSL_PROC_CHK(mbedtls_ssl_add_hs_msg_to_checksum(ssl,
-                         MBEDTLS_SSL_HS_CERTIFICATE, buf, buf_len));
+                                                            MBEDTLS_SSL_HS_CERTIFICATE, buf,
+                                                            buf_len));
 
 cleanup:
 #endif /* MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED */
@@ -870,7 +871,8 @@ int mbedtls_ssl_tls13_write_certificate(mbedtls_ssl_context *ssl)
                                                           &msg_len));
 
     MBEDTLS_SSL_PROC_CHK(mbedtls_ssl_add_hs_msg_to_checksum(ssl,
-                             MBEDTLS_SSL_HS_CERTIFICATE, buf, msg_len));
+                                                            MBEDTLS_SSL_HS_CERTIFICATE, buf,
+                                                            msg_len));
 
     MBEDTLS_SSL_PROC_CHK(mbedtls_ssl_finish_handshake_msg(
                              ssl, buf_len, msg_len));
@@ -1072,7 +1074,8 @@ int mbedtls_ssl_tls13_write_certificate_verify(mbedtls_ssl_context *ssl)
                              ssl, buf, buf + buf_len, &msg_len));
 
     MBEDTLS_SSL_PROC_CHK(mbedtls_ssl_add_hs_msg_to_checksum(ssl,
-                         MBEDTLS_SSL_HS_CERTIFICATE_VERIFY, buf, msg_len));
+                                                            MBEDTLS_SSL_HS_CERTIFICATE_VERIFY, buf,
+                                                            msg_len));
 
     MBEDTLS_SSL_PROC_CHK(mbedtls_ssl_finish_handshake_msg(
                              ssl, buf_len, msg_len));
@@ -1173,7 +1176,7 @@ int mbedtls_ssl_tls13_process_finished_message(mbedtls_ssl_context *ssl)
     MBEDTLS_SSL_PROC_CHK(ssl_tls13_parse_finished_message(ssl, buf, buf + buf_len));
 
     MBEDTLS_SSL_PROC_CHK(mbedtls_ssl_add_hs_msg_to_checksum(ssl,
-                         MBEDTLS_SSL_HS_FINISHED, buf, buf_len));
+                                                            MBEDTLS_SSL_HS_FINISHED, buf, buf_len));
 
 cleanup:
 
@@ -1250,7 +1253,7 @@ int mbedtls_ssl_tls13_write_finished_message(mbedtls_ssl_context *ssl)
                              ssl, buf, buf + buf_len, &msg_len));
 
     MBEDTLS_SSL_PROC_CHK(mbedtls_ssl_add_hs_msg_to_checksum(ssl,
-                         MBEDTLS_SSL_HS_FINISHED, buf, msg_len));
+                                                            MBEDTLS_SSL_HS_FINISHED, buf, msg_len));
 
     MBEDTLS_SSL_PROC_CHK(mbedtls_ssl_finish_handshake_msg(
                              ssl, buf_len, msg_len));

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -2155,7 +2155,7 @@ static int ssl_tls13_write_server_hello(mbedtls_ssl_context *ssl)
                                                            0));
 
     MBEDTLS_SSL_PROC_CHK(mbedtls_ssl_add_hs_msg_to_checksum(
-                         ssl, MBEDTLS_SSL_HS_SERVER_HELLO, buf, msg_len));
+                             ssl, MBEDTLS_SSL_HS_SERVER_HELLO, buf, msg_len));
 
     MBEDTLS_SSL_PROC_CHK(mbedtls_ssl_finish_handshake_msg(
                              ssl, buf_len, msg_len));
@@ -2228,7 +2228,7 @@ static int ssl_tls13_write_hello_retry_request(mbedtls_ssl_context *ssl)
                                                            &msg_len,
                                                            1));
     MBEDTLS_SSL_PROC_CHK(mbedtls_ssl_add_hs_msg_to_checksum(
-        ssl, MBEDTLS_SSL_HS_SERVER_HELLO, buf, msg_len));
+                             ssl, MBEDTLS_SSL_HS_SERVER_HELLO, buf, msg_len));
 
 
     MBEDTLS_SSL_PROC_CHK(mbedtls_ssl_finish_handshake_msg(ssl, buf_len,
@@ -2327,7 +2327,7 @@ static int ssl_tls13_write_encrypted_extensions(mbedtls_ssl_context *ssl)
                              ssl, buf, buf + buf_len, &msg_len));
 
     MBEDTLS_SSL_PROC_CHK(mbedtls_ssl_add_hs_msg_to_checksum(
-        ssl, MBEDTLS_SSL_HS_ENCRYPTED_EXTENSIONS, buf, msg_len));
+                             ssl, MBEDTLS_SSL_HS_ENCRYPTED_EXTENSIONS, buf, msg_len));
 
     MBEDTLS_SSL_PROC_CHK(mbedtls_ssl_finish_handshake_msg(
                              ssl, buf_len, msg_len));
@@ -2460,7 +2460,7 @@ static int ssl_tls13_write_certificate_request(mbedtls_ssl_context *ssl)
                                  ssl, buf, buf + buf_len, &msg_len));
 
         MBEDTLS_SSL_PROC_CHK(mbedtls_ssl_add_hs_msg_to_checksum(
-            ssl, MBEDTLS_SSL_HS_CERTIFICATE_REQUEST, buf, msg_len));
+                                 ssl, MBEDTLS_SSL_HS_CERTIFICATE_REQUEST, buf, msg_len));
 
         MBEDTLS_SSL_PROC_CHK(mbedtls_ssl_finish_handshake_msg(
                                  ssl, buf_len, msg_len));


### PR DESCRIPTION
## Description

Historical context: back in the Old Days, most hash functions (`mbedtls_shaxxx_yyy()`) used to return `void`, because the software implementation couldn't fail. Then we made some of them return `int` because when an `_ALT` implementation is used, the hardware might fail at any time and must be able to return an error. However, the change was only partially done in TLS, in that lots of functions that deal with hashes were not checking for error, or when checking (in the `USE_PSA` path), not propagating the error, because they were returning `void` themselves. In addition, on some error paths, some temporary contexts were not properly released.

This PR hopefully fixes all of that.

This is preparation work for #6989 - the functions in MD produce a warning when their return value is not checked, so we want the error-handling situation to be clean before we switch to MD.

## Gatekeeper checklist

- [x] **changelog** not required - not user-visible
- [x] **backport** not required - again, no visible impact
- [x] **tests** not required - we currently don't have a good framework for test that


