### PR TITLE
Fix typos

### DIFF
--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -4542,7 +4542,7 @@ int mbedtls_ssl_get_max_out_record_payload(const mbedtls_ssl_context *ssl);
 /**
  * \brief          Return the current maximum incoming record payload in bytes.
  *
- * \note           The logic to determine the maximum outgoing record payload is
+ * \note           The logic to determine the maximum incoming record payload is
  *                 version-specific. It takes into account various factors, such as
  *                 the mbedtls_config.h setting \c MBEDTLS_SSL_IN_CONTENT_LEN, extensions
  *                 such as the max fragment length extension or record size limit
@@ -4554,7 +4554,7 @@ int mbedtls_ssl_get_max_out_record_payload(const mbedtls_ssl_context *ssl);
  *
  * \param ssl      SSL context
  *
- * \return         Current maximum payload for an outgoing record,
+ * \return         Current maximum payload for an incoming record,
  *                 or a negative error code.
  */
 int mbedtls_ssl_get_max_in_record_payload(const mbedtls_ssl_context *ssl);

--- a/tests/scripts/doxygen.sh
+++ b/tests/scripts/doxygen.sh
@@ -17,7 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Abort on errors (and uninitiliased variables)
+# Abort on errors (and uninitialised variables)
 set -eu
 
 if [ -d library -a -d include -a -d tests ]; then :; else


### PR DESCRIPTION
Simple typo fixes.

## Gatekeeper checklist

- [x] **changelog** not required
- [x] **backport** #7053 
- [x] **tests** not required
