### PR TITLE
Backport 2.28: compat.sh: remove VERIFY and duplicate test cases for PSK

### DIFF
--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -231,7 +231,7 @@ filter_ciphersuites()
 
     # For GnuTLS client -> mbed TLS server,
     # we need to force IPv4 by connecting to 127.0.0.1 but then auth fails
-    if is_dtls "$MODE" && [ "X$VERIFY" = "XYES" ] && [ "$TYPE" != "PSK" ]; then
+    if is_dtls "$MODE" && [ "X$VERIFY" = "XYES" ]; then
         G_CIPHERS=""
     fi
 }
@@ -947,7 +947,7 @@ setup_arguments()
             ;;
     esac
 
-    if [ "X$VERIFY" = "XYES" ] && [ "$TYPE" != "PSK" ];
+    if [ "X$VERIFY" = "XYES" ];
     then
         M_SERVER_ARGS="$M_SERVER_ARGS ca_file=data_files/test-ca_cat12.crt auth_mode=required"
         O_SERVER_ARGS="$O_SERVER_ARGS -CAfile data_files/test-ca_cat12.crt -Verify 10"
@@ -1134,7 +1134,6 @@ wait_client_done() {
 run_client() {
     # announce what we're going to do
     TESTS=$(( $TESTS + 1 ))
-    VERIF=$(echo $VERIFY | tr '[:upper:]' '[:lower:]')
     TITLE="`echo $1 | head -c1`->`echo $SERVER_NAME | head -c1`"
     TITLE="$TITLE $MODE,$VERIF $2"
     printf "%s " "$TITLE"
@@ -1332,20 +1331,19 @@ SKIP_NEXT="NO"
 trap cleanup INT TERM HUP
 
 for MODE in $MODES; do
-    PSK_TESTS=""
-    for VERIFY in $VERIFIES; do
-        VERIF=$(echo $VERIFY | tr '[:upper:]' '[:lower:]')
-        for TYPE in $TYPES; do
+    for TYPE in $TYPES; do
 
-            if [ "$TYPE" = "PSK" ]; then
-                if [ -z "$PSK_TESTS" ]; then
-                    PSK_TESTS="FINISHED"
-                    VERIF="no"
-                else
-                    continue;
-                fi
-            fi
+        # PSK cipher suites do not allow client certificate verification.
+        # This means PSK test cases with VERIFY=YES should be replaced by
+        # VERIFY=NO or be ignored. SUB_VERIFIES variable is used to constrain
+        # verification option for PSK test cases.
+        SUB_VERIFIES=$VERIFIES
+        if [ "$TYPE" = "PSK" ]; then
+            SUB_VERIFIES="NO"
+        fi
 
+        for VERIFY in $SUB_VERIFIES; do
+            VERIF=$(echo $VERIFY | tr '[:upper:]' '[:lower:]')
             for PEER in $PEERS; do
 
             setup_arguments

--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -932,7 +932,6 @@ setup_arguments()
     M_CLIENT_ARGS="server_port=$PORT server_addr=127.0.0.1 force_version=$MODE"
     O_CLIENT_ARGS="-connect localhost:$PORT -$O_MODE"
     G_CLIENT_ARGS="-p $PORT --debug 3 $G_MODE"
-    G_CLIENT_PRIO="NONE:$G_PRIO_MODE:+COMP-NULL:+CURVE-ALL:+SIGN-ALL"
 
     # Newer versions of OpenSSL have a syntax to enable all "ciphers", even
     # low-security ones. This covers not just cipher suites but also protocol

--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -959,7 +959,7 @@ setup_arguments()
             ;;
     esac
 
-    if [ "X$VERIFY" = "XYES" ];
+    if [ "X$VERIFY" = "XYES" ] && [ "$TYPE" != "PSK" ];
     then
         M_SERVER_ARGS="$M_SERVER_ARGS ca_file=data_files/test-ca_cat12.crt auth_mode=required"
         O_SERVER_ARGS="$O_SERVER_ARGS -CAfile data_files/test-ca_cat12.crt -Verify 10"

--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -215,17 +215,6 @@ filter()
   echo "$NEW_LIST" | sed -e 's/[[:space:]][[:space:]]*/ /g' -e 's/^ //' -e 's/ $//'
 }
 
-# OpenSSL 1.0.1h with -Verify wants a ClientCertificate message even for
-# PSK ciphersuites with DTLS, which is incorrect, so disable them for now
-check_openssl_server_bug()
-{
-    if test "X$VERIFY" = "XYES" && is_dtls "$MODE" && \
-        echo "$1" | grep "^TLS-PSK" >/dev/null;
-    then
-        SKIP_NEXT="YES"
-    fi
-}
-
 filter_ciphersuites()
 {
     if [ "X" != "X$FILTER" -o "X" != "X$EXCLUDE" ];
@@ -1386,7 +1375,6 @@ for MODE in $MODES; do
                     if [ "X" != "X$M_CIPHERS" ]; then
                         start_server "OpenSSL"
                         for i in $M_CIPHERS; do
-                            check_openssl_server_bug $i
                             run_client mbedTLS $i
                         done
                         stop_server

--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -1341,6 +1341,7 @@ for MODE in $MODES; do
             if [ "$TYPE" = "PSK" ]; then
                 if [ -z "$PSK_TESTS" ]; then
                     PSK_TESTS="FINISHED"
+                    VERIF="no"
                 else
                     continue;
                 fi

--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -1343,9 +1343,20 @@ SKIP_NEXT="NO"
 
 trap cleanup INT TERM HUP
 
-for VERIFY in $VERIFIES; do
-    for MODE in $MODES; do
+for MODE in $MODES; do
+    PSK_TESTS=""
+    for VERIFY in $VERIFIES; do
+        VERIF=$(echo $VERIFY | tr '[:upper:]' '[:lower:]')
         for TYPE in $TYPES; do
+
+            if [ "$TYPE" = "PSK" ]; then
+                if [ -z "$PSK_TESTS" ]; then
+                    PSK_TESTS="FINISHED"
+                else
+                    continue;
+                fi
+            fi
+
             for PEER in $PEERS; do
 
             setup_arguments

--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -231,7 +231,7 @@ filter_ciphersuites()
 
     # For GnuTLS client -> mbed TLS server,
     # we need to force IPv4 by connecting to 127.0.0.1 but then auth fails
-    if [ "X$VERIFY" = "XYES" ] && is_dtls "$MODE"; then
+    if is_dtls "$MODE" && [ "X$VERIFY" = "XYES" ] && [ "$TYPE" != "PSK" ]; then
         G_CIPHERS=""
     fi
 }


### PR DESCRIPTION
## Description
Backport of #7052 

## Gatekeeper checklist

- [x] **changelog** not required
- [x] **backport** required https://github.com/Mbed-TLS/mbedtls/pull/7070
- [x] **tests** not required
