### PR TITLE
TLS 1.3 EarlyData: add `max_early_data_size` field for ticket

### DIFF
--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1253,7 +1253,7 @@ struct mbedtls_ssl_session {
 #endif /*  MBEDTLS_SSL_PROTO_TLS1_3 && MBEDTLS_SSL_SESSION_TICKETS */
 
 #if defined(MBEDTLS_SSL_EARLY_DATA)
-    uint32_t MBEDTLS_PRIVATE(max_early_data_size);          /*!< max_early_data_size of ticket */
+    uint32_t MBEDTLS_PRIVATE(max_early_data_size);          /*!< maximum amount of early data in tickets */
 #endif
 
 #if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC)
@@ -2041,6 +2041,10 @@ void mbedtls_ssl_tls13_conf_early_data(mbedtls_ssl_config *conf,
  * \param[in] max_early_data_size   The maximum amount of 0-RTT data.
  *
  * \warning This interface is experimental and may change without notice.
+ *
+ * \warning This interface DOES NOT influence/limit the amount of early data
+ *          that can be received with tickets that were previously created and
+ *          emitted and that clients may have stored.
  *
  */
 void mbedtls_ssl_tls13_conf_max_early_data_size(

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -2043,8 +2043,8 @@ void mbedtls_ssl_tls13_conf_early_data(mbedtls_ssl_config *conf,
  * \warning This interface is experimental and may change without notice.
  *
  * \warning This interface DOES NOT influence/limit the amount of early data
- *          that can be received with tickets that were previously created and
- *          emitted and that clients may have stored.
+ *          that can be received through previously created and issued tickets,
+ *          which clients may have stored.
  *
  */
 void mbedtls_ssl_tls13_conf_max_early_data_size(

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1252,6 +1252,10 @@ struct mbedtls_ssl_session {
 
 #endif /*  MBEDTLS_SSL_PROTO_TLS1_3 && MBEDTLS_SSL_SESSION_TICKETS */
 
+#if defined(MBEDTLS_SSL_EARLY_DATA)
+    uint32_t MBEDTLS_PRIVATE(max_early_data_size);          /*!< max_early_data_size of ticket */
+#endif
+
 #if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC)
     int MBEDTLS_PRIVATE(encrypt_then_mac);       /*!< flag for EtM activation                */
 #endif

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -2466,6 +2466,7 @@ mbedtls_ssl_mode_t mbedtls_ssl_get_mode_from_ciphersuite(
  *       uint32 ticket_age_add;
  *       uint8 ticket_flags;
  *       opaque resumption_key<0..255>;
+ *       uint32 max_early_data_size;
  *       select ( endpoint ) {
  *            case client: ClientOnlyData;
  *            case server: uint64 start_time;
@@ -2497,6 +2498,10 @@ static int ssl_tls13_session_save(const mbedtls_ssl_session *session,
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
     needed += session->resumption_key_len;  /* resumption_key */
+
+#if defined(MBEDTLS_SSL_EARLY_DATA)
+    needed += 4;                            /* max_early_data_size */
+#endif
 
 #if defined(MBEDTLS_HAVE_TIME)
     needed += 8; /* start_time or ticket_received */
@@ -2536,6 +2541,11 @@ static int ssl_tls13_session_save(const mbedtls_ssl_session *session,
     p += 9;
     memcpy(p, session->resumption_key, session->resumption_key_len);
     p += session->resumption_key_len;
+
+#if defined(MBEDTLS_SSL_EARLY_DATA)
+    MBEDTLS_PUT_UINT32_BE(session->max_early_data_size, p, 0);
+    p += 4;
+#endif
 
 #if defined(MBEDTLS_HAVE_TIME) && defined(MBEDTLS_SSL_SRV_C)
     if (session->endpoint == MBEDTLS_SSL_IS_SERVER) {
@@ -2604,6 +2614,14 @@ static int ssl_tls13_session_load(mbedtls_ssl_session *session,
     }
     memcpy(session->resumption_key, p, session->resumption_key_len);
     p += session->resumption_key_len;
+
+#if defined(MBEDTLS_SSL_EARLY_DATA)
+    if (end - p < 4) {
+        return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
+    }
+    session->max_early_data_size = MBEDTLS_GET_UINT32_BE(p, 0);
+    p += 4;
+#endif
 
 #if defined(MBEDTLS_HAVE_TIME) && defined(MBEDTLS_SSL_SRV_C)
     if (session->endpoint == MBEDTLS_SSL_IS_SERVER) {

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -467,6 +467,10 @@ static int ssl_tls13_session_copy_ticket(mbedtls_ssl_session *dst,
     }
     memcpy(dst->resumption_key, src->resumption_key, src->resumption_key_len);
 
+#if defined(MBEDTLS_SSL_EARLY_DATA)
+    dst->max_early_data_size = src->max_early_data_size;
+#endif
+
     return 0;
 }
 #endif /* MBEDTLS_SSL_SESSION_TICKETS */

--- a/tests/src/test_helpers/ssl_helpers.c
+++ b/tests/src/test_helpers/ssl_helpers.c
@@ -1638,6 +1638,10 @@ int mbedtls_test_ssl_tls13_populate_session(mbedtls_ssl_session *session,
     session->resumption_key_len = 32;
     memset(session->resumption_key, 0x99, sizeof(session->resumption_key));
 
+#if defined(MBEDTLS_SSL_EARLY_DATA)
+    session->max_early_data_size = 0x87654321;
+#endif
+
 #if defined(MBEDTLS_HAVE_TIME)
     if (session->endpoint == MBEDTLS_SSL_IS_SERVER) {
         session->start = mbedtls_time(NULL) - 42;

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -2042,6 +2042,12 @@ void ssl_serialize_session_save_load(int ticket_len, char *crt_file,
                                restored.resumption_key,
                                original.resumption_key_len) == 0);
         }
+
+#if defined(MBEDTLS_SSL_EARLY_DATA)
+        TEST_ASSERT(
+            original.max_early_data_size == restored.max_early_data_size);
+#endif
+
 #if defined(MBEDTLS_HAVE_TIME) && defined(MBEDTLS_SSL_SRV_C)
         if (endpoint_type == MBEDTLS_SSL_IS_SERVER) {
             TEST_ASSERT(original.start == restored.start);


### PR DESCRIPTION
## Description

fix #6347 



## Gatekeeper checklist

- [x] **changelog** ~~provided, or~~ not required( That's part of early data feature)
- [x] **backport** ~~done, or~~ not required( That's part of tls 1.3 early data feature)
- [x] **tests** provided



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

