### PR TITLE
Don't use lstrlenW() on Windows

### DIFF
--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -1449,8 +1449,8 @@ int mbedtls_x509_crt_parse_path(mbedtls_x509_crt *chain, const char *path)
         }
 
         w_ret = WideCharToMultiByte(CP_ACP, 0, file_data.cFileName,
-                                    lstrlenW(file_data.cFileName),
-                                    p, (int) len - 1,
+                                    -1,
+                                    p, (int) len,
                                     NULL, NULL);
         if (w_ret == 0) {
             ret = MBEDTLS_ERR_X509_FILE_IO_ERROR;


### PR DESCRIPTION
The lstrlenW() function isn't available to UWP apps, and isn't necessary, since when given -1, `WideCharToMultiByte()` will process the terminating null character itself (and the length returned by the function includes this character).

Resolves #2994

## Gatekeeper checklist

- [x] **changelog** not required - there will be a final one to cover this PR (addresses #2994) and the next (to fully address the rest of #1227)
- [x] **backport** to follow
- [x] **tests** not required

