### PR TITLE
Assume SIZE_MAX >= INT_MAX, UINT_MAX

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ Mbed TLS is mostly written in portable C99; however, it has a few platform requi
 - `int` and `size_t` must be at least 32 bits wide.
 - The types `uint8_t`, `uint16_t`, `uint32_t` and their signed equivalents must be available.
 - Mixed-endian platforms are not supported.
+- SIZE_MAX must be at least as big as INT_MAX and UINT_MAX.
 
 PSA cryptography API
 --------------------

--- a/library/ctr_drbg.c
+++ b/library/ctr_drbg.c
@@ -98,14 +98,13 @@ int mbedtls_ctr_drbg_set_nonce_len(mbedtls_ctr_drbg_context *ctx,
     if (len > MBEDTLS_CTR_DRBG_MAX_SEED_INPUT) {
         return MBEDTLS_ERR_CTR_DRBG_INPUT_TOO_BIG;
     }
-#if SIZE_MAX > INT_MAX
+
     /* This shouldn't be an issue because
      * MBEDTLS_CTR_DRBG_MAX_SEED_INPUT < INT_MAX in any sensible
      * configuration, but make sure anyway. */
     if (len > INT_MAX) {
         return MBEDTLS_ERR_CTR_DRBG_INPUT_TOO_BIG;
     }
-#endif
 
     /* For backward compatibility with Mbed TLS <= 2.19, store the
      * entropy nonce length in a field that already exists, but isn't

--- a/library/pk.c
+++ b/library/pk.c
@@ -501,11 +501,9 @@ int mbedtls_pk_verify_ext(mbedtls_pk_type_t type, const void *options,
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     const mbedtls_pk_rsassa_pss_options *pss_opts;
 
-#if SIZE_MAX > UINT_MAX
     if (md_alg == MBEDTLS_MD_NONE && UINT_MAX < hash_len) {
         return MBEDTLS_ERR_PK_BAD_INPUT_DATA;
     }
-#endif /* SIZE_MAX > UINT_MAX */
 
     if (options == NULL) {
         return MBEDTLS_ERR_PK_BAD_INPUT_DATA;

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -174,11 +174,9 @@ static int rsa_verify_wrap(void *ctx, mbedtls_md_type_t md_alg,
         PSA_ALG_RSA_PKCS1V15_SIGN(mbedtls_hash_info_psa_from_md(md_alg));
     size_t rsa_len = mbedtls_rsa_get_len(rsa);
 
-#if SIZE_MAX > UINT_MAX
     if (md_alg == MBEDTLS_MD_NONE && UINT_MAX < hash_len) {
         return MBEDTLS_ERR_PK_BAD_INPUT_DATA;
     }
-#endif /* SIZE_MAX > UINT_MAX */
 
     if (sig_len < rsa_len) {
         return MBEDTLS_ERR_RSA_VERIFY_FAILED;
@@ -230,11 +228,9 @@ static int rsa_verify_wrap(void *ctx, mbedtls_md_type_t md_alg,
     mbedtls_rsa_context *rsa = (mbedtls_rsa_context *) ctx;
     size_t rsa_len = mbedtls_rsa_get_len(rsa);
 
-#if SIZE_MAX > UINT_MAX
     if (md_alg == MBEDTLS_MD_NONE && UINT_MAX < hash_len) {
         return MBEDTLS_ERR_PK_BAD_INPUT_DATA;
     }
-#endif /* SIZE_MAX > UINT_MAX */
 
     if (sig_len < rsa_len) {
         return MBEDTLS_ERR_RSA_VERIFY_FAILED;
@@ -345,11 +341,9 @@ static int rsa_sign_wrap(void *ctx, mbedtls_md_type_t md_alg,
 {
     mbedtls_rsa_context *rsa = (mbedtls_rsa_context *) ctx;
 
-#if SIZE_MAX > UINT_MAX
     if (md_alg == MBEDTLS_MD_NONE && UINT_MAX < hash_len) {
         return MBEDTLS_ERR_PK_BAD_INPUT_DATA;
     }
-#endif /* SIZE_MAX > UINT_MAX */
 
     *sig_len = mbedtls_rsa_get_len(rsa);
     if (sig_size < *sig_len) {
@@ -1330,11 +1324,9 @@ static int rsa_alt_sign_wrap(void *ctx, mbedtls_md_type_t md_alg,
 {
     mbedtls_rsa_alt_context *rsa_alt = (mbedtls_rsa_alt_context *) ctx;
 
-#if SIZE_MAX > UINT_MAX
     if (UINT_MAX < hash_len) {
         return MBEDTLS_ERR_PK_BAD_INPUT_DATA;
     }
-#endif /* SIZE_MAX > UINT_MAX */
 
     *sig_len = rsa_alt->key_len_func(rsa_alt->key);
     if (*sig_len > MBEDTLS_PK_SIGNATURE_MAX_SIZE) {

--- a/library/psa_crypto_rsa.c
+++ b/library/psa_crypto_rsa.c
@@ -332,11 +332,9 @@ static psa_status_t psa_rsa_decode_md_type(psa_algorithm_t alg,
     /* The Mbed TLS RSA module uses an unsigned int for hash length
      * parameters. Validate that it fits so that we don't risk an
      * overflow later. */
-#if SIZE_MAX > UINT_MAX
     if (hash_length > UINT_MAX) {
         return PSA_ERROR_INVALID_ARGUMENT;
     }
-#endif
 
     /* For signatures using a hash, the hash length must be correct. */
     if (alg != PSA_ALG_RSA_PKCS1V15_SIGN_RAW) {

--- a/library/psa_crypto_se.c
+++ b/library/psa_crypto_se.c
@@ -125,12 +125,10 @@ static psa_status_t psa_get_se_driver_its_file_uid(
         return PSA_ERROR_NOT_SUPPORTED;
     }
 
-#if SIZE_MAX > UINT32_MAX
     /* ITS file sizes are limited to 32 bits. */
     if (driver->u.internal.persistent_data_size > UINT32_MAX) {
         return PSA_ERROR_NOT_SUPPORTED;
     }
-#endif
 
     /* See the documentation of PSA_CRYPTO_SE_DRIVER_ITS_UID_BASE. */
     *uid = PSA_CRYPTO_SE_DRIVER_ITS_UID_BASE + driver->location;

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -2090,7 +2090,7 @@ int mbedtls_ssl_fetch_input(mbedtls_ssl_context *ssl, size_t nb_want)
                 return ret;
             }
 
-            if ((size_t) ret > len || (INT_MAX > SIZE_MAX && ret > (int) SIZE_MAX)) {
+            if ((size_t) ret > len) {
                 MBEDTLS_SSL_DEBUG_MSG(1,
                                       ("f_recv returned %d bytes but only %" MBEDTLS_PRINTF_SIZET
                                        " were requested",
@@ -2142,7 +2142,7 @@ int mbedtls_ssl_flush_output(mbedtls_ssl_context *ssl)
             return ret;
         }
 
-        if ((size_t) ret > ssl->out_left || (INT_MAX > SIZE_MAX && ret > (int) SIZE_MAX)) {
+        if ((size_t) ret > ssl->out_left) {
             MBEDTLS_SSL_DEBUG_MSG(1,
                                   ("f_send returned %d bytes but only %" MBEDTLS_PRINTF_SIZET
                                    " bytes were sent",

--- a/programs/test/selftest.c
+++ b/programs/test/selftest.c
@@ -337,6 +337,32 @@ int main(int argc, char *argv[])
     void *pointer;
 
     /*
+     * Check some basic platform requirements as specified in README.md
+     */
+    if (SIZE_MAX < INT_MAX || SIZE_MAX < UINT_MAX) {
+        mbedtls_printf("SIZE_MAX must be at least as big as INT_MAX and UINT_MAX\n");
+        mbedtls_exit(MBEDTLS_EXIT_FAILURE);
+    }
+
+    if (sizeof(int) < 4) {
+        mbedtls_printf("int must be at least 32 bits\n");
+        mbedtls_exit(MBEDTLS_EXIT_FAILURE);
+    }
+
+    if (sizeof(size_t) < 4) {
+        mbedtls_printf("size_t must be at least 32 bits\n");
+        mbedtls_exit(MBEDTLS_EXIT_FAILURE);
+    }
+
+    uint32_t endian_test = 0x12345678;
+    char *p = (char *) &endian_test;
+    if (!(p[0] == 0x12 && p[1] == 0x34 && p[2] == 0x56 && p[3] == 0x78) &&
+        !(p[3] == 0x12 && p[2] == 0x34 && p[1] == 0x56 && p[0] == 0x78)) {
+        mbedtls_printf("Mixed-endian platforms are not supported\n");
+        mbedtls_exit(MBEDTLS_EXIT_FAILURE);
+    }
+
+    /*
      * The C standard doesn't guarantee that all-bits-0 is the representation
      * of a NULL pointer. We do however use that in our code for initializing
      * structures, which should work on every modern platform. Let's be sure.

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -1064,10 +1064,6 @@ void pk_rsa_overflow()
     size_t hash_len = SIZE_MAX, sig_len = SIZE_MAX;
     unsigned char hash[50], sig[100];
 
-    if (SIZE_MAX <= UINT_MAX) {
-        return;
-    }
-
     memset(hash, 0x2a, sizeof(hash));
     memset(sig, 0, sizeof(sig));
 
@@ -1143,12 +1139,10 @@ void pk_rsa_alt()
     TEST_ASSERT(strcmp(mbedtls_pk_get_name(&alt), "RSA-alt") == 0);
 
     /* Test signature */
-#if SIZE_MAX > UINT_MAX
     TEST_ASSERT(mbedtls_pk_sign(&alt, MBEDTLS_MD_NONE, hash, SIZE_MAX,
                                 sig, sizeof(sig), &sig_len,
                                 mbedtls_test_rnd_std_rand, NULL)
                 == MBEDTLS_ERR_PK_BAD_INPUT_DATA);
-#endif /* SIZE_MAX > UINT_MAX */
     TEST_ASSERT(mbedtls_pk_sign(&alt, MBEDTLS_MD_NONE, hash, sizeof(hash),
                                 sig, sizeof(sig), &sig_len,
                                 mbedtls_test_rnd_std_rand, NULL)

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -1139,10 +1139,12 @@ void pk_rsa_alt()
     TEST_ASSERT(strcmp(mbedtls_pk_get_name(&alt), "RSA-alt") == 0);
 
     /* Test signature */
+#if SIZE_MAX > UINT_MAX
     TEST_ASSERT(mbedtls_pk_sign(&alt, MBEDTLS_MD_NONE, hash, SIZE_MAX,
                                 sig, sizeof(sig), &sig_len,
                                 mbedtls_test_rnd_std_rand, NULL)
                 == MBEDTLS_ERR_PK_BAD_INPUT_DATA);
+#endif /* SIZE_MAX > UINT_MAX */
     TEST_ASSERT(mbedtls_pk_sign(&alt, MBEDTLS_MD_NONE, hash, sizeof(hash),
                                 sig, sizeof(sig), &sig_len,
                                 mbedtls_test_rnd_std_rand, NULL)

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -5971,6 +5971,7 @@ void aead_multipart_state_test(int key_type_arg, data_t *key_data,
 #endif
 
     /* Test for calling set lengths with a plaintext length of SIZE_MAX, after setting nonce */
+#if SIZE_MAX > UINT32_MAX
     PSA_ASSERT(psa_aead_encrypt_setup(&operation, key, alg));
 
     PSA_ASSERT(psa_aead_set_nonce(&operation, nonce->x, nonce->len));
@@ -5985,6 +5986,7 @@ void aead_multipart_state_test(int key_type_arg, data_t *key_data,
     }
 
     psa_aead_abort(&operation);
+#endif
 
     /* ------------------------------------------------------- */
 

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -5844,6 +5844,7 @@ void aead_multipart_state_test(int key_type_arg, data_t *key_data,
     psa_aead_abort(&operation);
 
     /* Test for generating nonce after calling set lengths with SIZE_MAX ad_data length */
+#if SIZE_MAX > UINT32_MAX
     PSA_ASSERT(psa_aead_encrypt_setup(&operation, key, alg));
 
     if (operation.alg == PSA_ALG_CCM || operation.alg == PSA_ALG_GCM) {
@@ -5863,6 +5864,7 @@ void aead_multipart_state_test(int key_type_arg, data_t *key_data,
     }
 
     psa_aead_abort(&operation);
+#endif
 
     /* Test for calling set lengths with a UINT32_MAX ad_data length, after generating nonce */
 

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -5916,6 +5916,7 @@ void aead_multipart_state_test(int key_type_arg, data_t *key_data,
     psa_aead_abort(&operation);
 
     /* Test for setting nonce after calling set lengths with SIZE_MAX ad_data length */
+#if SIZE_MAX > UINT32_MAX
     PSA_ASSERT(psa_aead_encrypt_setup(&operation, key, alg));
 
     if (operation.alg == PSA_ALG_CCM || operation.alg == PSA_ALG_GCM) {
@@ -5931,6 +5932,7 @@ void aead_multipart_state_test(int key_type_arg, data_t *key_data,
     }
 
     psa_aead_abort(&operation);
+#endif
 
     /* Test for calling set lengths with an ad_data length of UINT32_MAX, after setting nonce */
 

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -5844,7 +5844,6 @@ void aead_multipart_state_test(int key_type_arg, data_t *key_data,
     psa_aead_abort(&operation);
 
     /* Test for generating nonce after calling set lengths with SIZE_MAX ad_data length */
-#if SIZE_MAX > UINT32_MAX
     PSA_ASSERT(psa_aead_encrypt_setup(&operation, key, alg));
 
     if (operation.alg == PSA_ALG_CCM || operation.alg == PSA_ALG_GCM) {
@@ -5864,7 +5863,6 @@ void aead_multipart_state_test(int key_type_arg, data_t *key_data,
     }
 
     psa_aead_abort(&operation);
-#endif
 
     /* Test for calling set lengths with a UINT32_MAX ad_data length, after generating nonce */
 
@@ -5916,7 +5914,6 @@ void aead_multipart_state_test(int key_type_arg, data_t *key_data,
     psa_aead_abort(&operation);
 
     /* Test for setting nonce after calling set lengths with SIZE_MAX ad_data length */
-#if SIZE_MAX > UINT32_MAX
     PSA_ASSERT(psa_aead_encrypt_setup(&operation, key, alg));
 
     if (operation.alg == PSA_ALG_CCM || operation.alg == PSA_ALG_GCM) {
@@ -5932,7 +5929,6 @@ void aead_multipart_state_test(int key_type_arg, data_t *key_data,
     }
 
     psa_aead_abort(&operation);
-#endif
 
     /* Test for calling set lengths with an ad_data length of UINT32_MAX, after setting nonce */
 
@@ -5952,7 +5948,6 @@ void aead_multipart_state_test(int key_type_arg, data_t *key_data,
     psa_aead_abort(&operation);
 
     /* Test for setting nonce after calling set lengths with plaintext length of SIZE_MAX */
-#if SIZE_MAX > UINT32_MAX
     PSA_ASSERT(psa_aead_encrypt_setup(&operation, key, alg));
 
     if (operation.alg == PSA_ALG_GCM) {
@@ -5984,7 +5979,6 @@ void aead_multipart_state_test(int key_type_arg, data_t *key_data,
     }
 
     psa_aead_abort(&operation);
-#endif
 
     /* ------------------------------------------------------- */
 

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -5952,6 +5952,7 @@ void aead_multipart_state_test(int key_type_arg, data_t *key_data,
     psa_aead_abort(&operation);
 
     /* Test for setting nonce after calling set lengths with plaintext length of SIZE_MAX */
+#if SIZE_MAX > UINT32_MAX
     PSA_ASSERT(psa_aead_encrypt_setup(&operation, key, alg));
 
     if (operation.alg == PSA_ALG_GCM) {
@@ -5967,6 +5968,7 @@ void aead_multipart_state_test(int key_type_arg, data_t *key_data,
     }
 
     psa_aead_abort(&operation);
+#endif
 
     /* Test for calling set lengths with a plaintext length of SIZE_MAX, after setting nonce */
     PSA_ASSERT(psa_aead_encrypt_setup(&operation, key, alg));


### PR DESCRIPTION
Signed-off-by: Dave Rodgman <dave.rodgman@arm.com>

## Description

Document that SIZE_MAX >= INT_MAX and UINT_MAX; remove checks for this in the library.

Some of the checks where guards are removed are redundant where SIZE_MAX == UINT_MAX - I've removed the guards anyway on the basis that the compiler should know this and optimise them out anyway.

Added checks to selftest.c (plus a couple of extras as per `README.md`).

Fixes #3577 

## Gatekeeper checklist

- [x] **changelog** not required
- [x] **backport** not required
- [x] **tests** not required