### PR TITLE
Fix unreachable code compiler warning in psa_crypto_driver_wrappers.c

### DIFF
--- a/scripts/data_files/driver_templates/psa_crypto_driver_wrappers.c.jinja
+++ b/scripts/data_files/driver_templates/psa_crypto_driver_wrappers.c.jinja
@@ -1182,8 +1182,9 @@ psa_status_t psa_driver_wrapper_cipher_decrypt_setup(
                 operation->id = PSA_CRYPTO_MBED_TLS_DRIVER_ID;
 
             return( status );
-#endif /* MBEDTLS_PSA_BUILTIN_CIPHER */
+#else /* MBEDTLS_PSA_BUILTIN_CIPHER */
             return( PSA_ERROR_NOT_SUPPORTED );
+#endif /* MBEDTLS_PSA_BUILTIN_CIPHER */
 
         /* Add cases for opaque driver here */
 #if defined(PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT)


### PR DESCRIPTION
Signed-off-by: Sergey <sergio_nsk@yahoo.de>

If the macro `MBEDTLS_PSA_BUILTIN_CIPHER` is defined, there are 2 sequential `return` statements:
```c
            return(( status );
#endif /* MBEDTLS_PSA_BUILTIN_CIPHER */
            return( PSA_ERROR_NOT_SUPPORTED );
```
The second `return` is unreachable and should be enclosed in `#else` block.