### PR TITLE
Fix warning with GCC 12

### DIFF
--- a/tests/suites/test_suite_constant_time.function
+++ b/tests/suites/test_suite_constant_time.function
@@ -18,7 +18,7 @@
 /* BEGIN_CASE */
 void mbedtls_ct_memcmp_null()
 {
-    uint32_t x;
+    uint32_t x = 0;
     TEST_ASSERT(mbedtls_ct_memcmp(&x, NULL, 0) == 0);
     TEST_ASSERT(mbedtls_ct_memcmp(NULL, &x, 0) == 0);
     TEST_ASSERT(mbedtls_ct_memcmp(NULL, NULL, 0) == 0);


### PR DESCRIPTION
## Description

Fix a warning with GCC 12 about variable being used uninitialised which has been annoying me greatlyof late. Only GCC finds this, Clang does not.

## Gatekeeper checklist

- [ ] **changelog** ~~provided~~, not required - this is a trivial change in test code
- [ ] **backport** ~~done, or~~ not required - `mbedtls_ct_memcmp_null()` is `development` only
- [ ] **tests** ~~provided, or~~ not required
