### PR TITLE
Backport 2.28 : Remove -wDocumentation from Clang builds

### DIFF
--- a/ChangeLog.d/fix-doc-warnings.txt
+++ b/ChangeLog.d/fix-doc-warnings.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Remove -Wdocumentation to fix spurious warnings with clang version 15 or
+     greater. Fixes #6960.

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -122,7 +122,16 @@ if(CMAKE_COMPILER_IS_GNUCC)
 endif(CMAKE_COMPILER_IS_GNUCC)
 
 if(CMAKE_COMPILER_IS_CLANG)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wmissing-declarations -Wmissing-prototypes -Wdocumentation -Wno-documentation-deprecated-sync -Wunreachable-code")
+    execute_process(COMMAND ${CMAKE_C_COMPILER} -dumpversion OUTPUT_VARIABLE CLANG_VERSION)
+
+    # Clang version 15 or above introduces new rules for -Wdocumentation that
+    # state that we cannot have a non-empty description after \retval VALUE, which
+    # we have lots of occurances of.
+    if(CLANG_VERSION VERSION_LESS 15.0)
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wmissing-declarations -Wmissing-prototypes -Wdocumentation -Wno-documentation-deprecated-sync -Wunreachable-code")
+    else()
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wmissing-declarations -Wmissing-prototypes -Wno-documentation-deprecated-sync -Wunreachable-code")
+    endif()
 endif(CMAKE_COMPILER_IS_CLANG)
 
 if(WIN32)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -72,7 +72,16 @@ if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANG)
 endif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANG)
 
 if(CMAKE_COMPILER_IS_CLANG)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wdocumentation -Wno-documentation-deprecated-sync -Wunreachable-code")
+    execute_process(COMMAND ${CMAKE_C_COMPILER} -dumpversion OUTPUT_VARIABLE CLANG_VERSION)
+
+    # Clang version 15 or above introduces new rules for -Wdocumentation that
+    # state that we cannot have a non-empty description after \retval VALUE, which
+    # we have lots of occurances of.
+    if(CLANG_VERSION VERSION_LESS 15.0)
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wdocumentation -Wno-documentation-deprecated-sync -Wunreachable-code")
+    else()
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-documentation-deprecated-sync -Wunreachable-code")
+    endif()
 endif(CMAKE_COMPILER_IS_CLANG)
 
 if(MSVC)


### PR DESCRIPTION
## Description

As per issue https://github.com/Mbed-TLS/mbedtls/issues/6960, Clang 15/16 seems to have introduced new rules for -Wdocumentation with respect to /return and /retval, which contradicts the rules we are using with Doxygen.

This PR removes the usage of this warning from clang builds, as Clang 15 will soon be the default on rolling release builds, and those users will be broken.

This is a backport of #6966 

## Gatekeeper checklist

- [x] **changelog** provided ~~, or not required~~
- [x] **backport** ~~done, or~~ not required
- [x] **tests** ~~provided, or~~ not required



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

