### PR TITLE
Parse an OID from a string

### DIFF
--- a/ChangeLog.d/oid-parse-from-numeric-string.txt
+++ b/ChangeLog.d/oid-parse-from-numeric-string.txt
@@ -1,3 +1,3 @@
 Features
-   * Add a function mbedtls_oid_from_numeric_string to parse an OID from a
+   * Add function mbedtls_oid_from_numeric_string() to parse an OID from a
      string to a DER-encoded mbedtls_asn1_buf.

--- a/ChangeLog.d/oid-parse-from-numeric-string.txt
+++ b/ChangeLog.d/oid-parse-from-numeric-string.txt
@@ -1,0 +1,3 @@
+Features
+   * Add a function mbedtls_oid_from_numeric_string to parse an OID from a
+     string to a DER-encoded mbedtls_asn1_buf.

--- a/include/mbedtls/oid.h
+++ b/include/mbedtls/oid.h
@@ -467,6 +467,20 @@ typedef struct mbedtls_oid_descriptor_t {
 int mbedtls_oid_get_numeric_string(char *buf, size_t size, const mbedtls_asn1_buf *oid);
 
 /**
+ * \brief           Translate a string containing a numeric representation
+ *                  of an ASN.1 OID into its encoded form
+ *                  (e.g. "1.2.840.113549" into "\x2A\x86\x48\x86\xF7\x0D")
+ *
+ * \param buf       buffer to put representation in
+ * \param size      size of the buffer
+ * \param oid       OID to translate
+ *
+ * \return          Length of the string written (excluding final NULL) or
+ *                  MBEDTLS_ERR_OID_BUF_TOO_SMALL in case of error
+ */
+int mbedtls_oid_from_numeric_string(mbedtls_asn1_buf *oid, const char *buf, size_t size);
+
+/**
  * \brief          Translate an X.509 extension OID into local values
  *
  * \param oid      OID to use

--- a/include/mbedtls/oid.h
+++ b/include/mbedtls/oid.h
@@ -479,8 +479,9 @@ int mbedtls_oid_get_numeric_string(char *buf, size_t size, const mbedtls_asn1_bu
  *                  heap. It must be freed by the caller using mbedtls_free().
  *
  * \param oid       #mbedtls_asn1_buf to populate with the DER-encoded OID
- * \param oid_str   string representation of the OID to parse
- * \param size      length of the OID string
+ * \param oid_str   string representation of the OID to parse, not
+ *                  NUL-terminated
+ * \param size      length of the OID string, not including any NUL terminator
  *
  * \return          0 if successful
  * \return          #MBEDTLS_ERR_ASN1_INVALID_DATA if \p oid_str does not

--- a/include/mbedtls/oid.h
+++ b/include/mbedtls/oid.h
@@ -471,7 +471,7 @@ int mbedtls_oid_get_numeric_string(char *buf, size_t size, const mbedtls_asn1_bu
  *                  of an ASN.1 OID into its encoded form
  *                  (e.g. "1.2.840.113549" into "\x2A\x86\x48\x86\xF7\x0D")
  *                  On success, this function allocates oid->buf from the
- *                  heap. It must be free'd by the caller.
+ *                  heap. It must be freed by the caller using mbedtls_free().
  *
  * \param oid       mbedtls_asn1_buf to populate with the DER-encoded OID
  * \param oid_str   string representation of the OID to parse

--- a/include/mbedtls/oid.h
+++ b/include/mbedtls/oid.h
@@ -478,12 +478,12 @@ int mbedtls_oid_get_numeric_string(char *buf, size_t size, const mbedtls_asn1_bu
  *                  On success, this function allocates oid->buf from the
  *                  heap. It must be freed by the caller using mbedtls_free().
  *
- * \param oid       mbedtls_asn1_buf to populate with the DER-encoded OID
+ * \param oid       #mbedtls_asn1_buf to populate with the DER-encoded OID
  * \param oid_str   string representation of the OID to parse
  * \param size      length of the OID string
  *
  * \return          0 if successful
- * \return          #MBEDTLS_ERR_ASN1_INVALID_DATA if oid_str does not
+ * \return          #MBEDTLS_ERR_ASN1_INVALID_DATA if \p oid_str does not
  *                  represent a valid OID
  * \return          #MBEDTLS_ERR_ASN1_ALLOC_FAILED if the function fails to
  *                  allocate oid->buf

--- a/include/mbedtls/oid.h
+++ b/include/mbedtls/oid.h
@@ -470,15 +470,20 @@ int mbedtls_oid_get_numeric_string(char *buf, size_t size, const mbedtls_asn1_bu
  * \brief           Translate a string containing a numeric representation
  *                  of an ASN.1 OID into its encoded form
  *                  (e.g. "1.2.840.113549" into "\x2A\x86\x48\x86\xF7\x0D")
+ *                  On success, this function allocates oid->buf from the
+ *                  heap. It must be free'd by the caller.
  *
- * \param buf       buffer to put representation in
- * \param size      size of the buffer
- * \param oid       OID to translate
+ * \param oid       mbedtls_asn1_buf to populate with the DER-encoded OID
+ * \param oid_str   string representation of the OID to parse
+ * \param size      length of the OID string
  *
- * \return          Length of the string written (excluding final NULL) or
- *                  MBEDTLS_ERR_OID_BUF_TOO_SMALL in case of error
+ * \return          0 if successful
+ * \return          #MBEDTLS_ERR_ASN1_INVALID_DATA if oid_str does not
+ *                  represent a valid OID
+ * \return          #MBEDTLS_ERR_ASN1_ALLOC_FAILED if the function fails to
+ *                  allocate oid->buf
  */
-int mbedtls_oid_from_numeric_string(mbedtls_asn1_buf *oid, const char *buf, size_t size);
+int mbedtls_oid_from_numeric_string(mbedtls_asn1_buf *oid, const char *oid_str, size_t size);
 
 /**
  * \brief          Translate an X.509 extension OID into local values

--- a/include/mbedtls/oid.h
+++ b/include/mbedtls/oid.h
@@ -479,9 +479,8 @@ int mbedtls_oid_get_numeric_string(char *buf, size_t size, const mbedtls_asn1_bu
  *                  heap. It must be freed by the caller using mbedtls_free().
  *
  * \param oid       #mbedtls_asn1_buf to populate with the DER-encoded OID
- * \param oid_str   string representation of the OID to parse, not
- *                  NUL-terminated
- * \param size      length of the OID string, not including any NUL terminator
+ * \param oid_str   string representation of the OID to parse
+ * \param size      length of the OID string, not including any null terminator
  *
  * \return          0 if successful
  * \return          #MBEDTLS_ERR_ASN1_INVALID_DATA if \p oid_str does not

--- a/include/mbedtls/oid.h
+++ b/include/mbedtls/oid.h
@@ -64,6 +64,11 @@
 #define MBEDTLS_OID_X509_EXT_NS_CERT_TYPE                (1 << 16)
 
 /*
+ * Maximum number of OID components allowed
+ */
+#define MBEDTLS_OID_MAX_COMPONENTS              128
+
+/*
  * Top level OID tuples
  */
 #define MBEDTLS_OID_ISO_MEMBER_BODIES           "\x2a"          /* {iso(1) member-body(2)} */

--- a/include/mbedtls/oid.h
+++ b/include/mbedtls/oid.h
@@ -472,9 +472,9 @@ typedef struct mbedtls_oid_descriptor_t {
 int mbedtls_oid_get_numeric_string(char *buf, size_t size, const mbedtls_asn1_buf *oid);
 
 /**
- * \brief           Translate a string containing a numeric representation
- *                  of an ASN.1 OID into its encoded form
- *                  (e.g. "1.2.840.113549" into "\x2A\x86\x48\x86\xF7\x0D")
+ * \brief           Translate a string containing a dotted-decimal
+ *                  representation of an ASN.1 OID into its encoded form
+ *                  (e.g. "1.2.840.113549" into "\x2A\x86\x48\x86\xF7\x0D").
  *                  On success, this function allocates oid->buf from the
  *                  heap. It must be freed by the caller using mbedtls_free().
  *

--- a/library/oid.c
+++ b/library/oid.c
@@ -1008,7 +1008,7 @@ int mbedtls_oid_from_numeric_string(mbedtls_asn1_buf *oid,
         encoded_len += num_bytes;
     }
 
-    oid->p = mbedtls_calloc(encoded_len, sizeof(unsigned char));
+    oid->p = mbedtls_calloc(encoded_len, 1);
     if (oid->p == NULL) {
         return MBEDTLS_ERR_ASN1_ALLOC_FAILED;
     }

--- a/library/oid.c
+++ b/library/oid.c
@@ -954,6 +954,8 @@ int mbedtls_oid_from_numeric_string(mbedtls_asn1_buf *oid,
     size_t encoded_len;
     unsigned int component1, component2;
 
+    /* First pass - parse the string to get the length of buffer required */
+
     ret = oid_parse_number(&component1, &str_ptr, str_bound);
     if (ret != 0) {
         return ret;
@@ -1014,7 +1016,9 @@ int mbedtls_oid_from_numeric_string(mbedtls_asn1_buf *oid,
     }
     oid->len = encoded_len;
 
-    /* Now that we've allocated the buffer, go back to the start and encode */
+    /* Second pass - now that we've allocated the buffer, go back to the
+     * start and encode */
+
     str_ptr = oid_str;
     unsigned char *out_ptr = oid->p;
     unsigned char *out_bound = oid->p + oid->len;

--- a/library/oid.c
+++ b/library/oid.c
@@ -957,6 +957,8 @@ int mbedtls_oid_from_numeric_string(mbedtls_asn1_buf *oid,
     unsigned int component1, component2;
     /* Count the number of dots to get a worst-case allocation size. */
     size_t num_dots = 0;
+    size_t encoded_len;
+    unsigned char *minimum_mem;
 
     for (size_t i = 0; (i < size) && (oid_str[i] != '\0'); i++) {
         if (oid_str[i] == '.') {
@@ -1040,8 +1042,8 @@ int mbedtls_oid_from_numeric_string(mbedtls_asn1_buf *oid,
         }
     }
 
-    size_t encoded_len = out_ptr - oid->p;
-    unsigned char *minimum_mem = mbedtls_calloc(encoded_len, 1);
+    encoded_len = out_ptr - oid->p;
+    minimum_mem = mbedtls_calloc(encoded_len, 1);
     if (minimum_mem == NULL) {
         ret = MBEDTLS_ERR_ASN1_ALLOC_FAILED;
         goto error;

--- a/library/oid.c
+++ b/library/oid.c
@@ -971,7 +971,14 @@ int mbedtls_oid_from_numeric_string(mbedtls_asn1_buf *oid,
     if (num_dots == 0 || (num_dots > MBEDTLS_OID_MAX_COMPONENTS - 1)) {
         return MBEDTLS_ERR_ASN1_INVALID_DATA;
     }
-    size_t max_possible_bytes = num_dots * sizeof(unsigned int);
+    /* Each byte can store 7 bits, calculate number of bytes for a
+     * subidentifier:
+     *
+     * bytes = ceil(subidentifer_size * 8 / 7)
+     */
+    size_t bytes_per_subidentifier = (((sizeof(unsigned int) * 8) - 1) / 7)
+                                     + 1;
+    size_t max_possible_bytes = num_dots * bytes_per_subidentifier;
     oid->p = mbedtls_calloc(max_possible_bytes, 1);
     if (oid->p == NULL) {
         return MBEDTLS_ERR_ASN1_ALLOC_FAILED;

--- a/library/oid.c
+++ b/library/oid.c
@@ -974,8 +974,8 @@ int mbedtls_oid_from_numeric_string(mbedtls_asn1_buf *oid,
     if (component2 < 0) {
         return component2;
     }
-    if ((component1 < 2) && (component2 > 38)) {
-        /* Root nodes 0 and 1 may have up to 39 children */
+    if ((component1 < 2) && (component2 > 39)) {
+        /* Root nodes 0 and 1 may have up to 40 children, numbered 0-39 */
         return MBEDTLS_ERR_ASN1_INVALID_DATA;
     }
     if (str_ptr < str_bound && *str_ptr != '\0') {

--- a/library/oid.c
+++ b/library/oid.c
@@ -963,7 +963,7 @@ int mbedtls_oid_from_numeric_string(mbedtls_asn1_buf *oid,
     /* Allocate maximum possible required memory:
      * There are (num_dots + 1) integer components, but the first 2 share the
      * same subidentifier, so we only need num_dots subidentifiers maximum. */
-    if (num_dots == 0 || (num_dots > SIZE_MAX / sizeof(unsigned int))) {
+    if (num_dots == 0 || (num_dots > MBEDTLS_OID_MAX_COMPONENTS - 1)) {
         return MBEDTLS_ERR_ASN1_INVALID_DATA;
     }
     size_t max_possible_bytes = num_dots * sizeof(unsigned int);

--- a/library/oid.c
+++ b/library/oid.c
@@ -956,7 +956,7 @@ int mbedtls_oid_from_numeric_string(mbedtls_asn1_buf *oid,
     unsigned int val = 0;
     unsigned int component1, component2;
     size_t encoded_len;
-    unsigned char *minimum_mem;
+    unsigned char *resized_mem;
 
     /* Count the number of dots to get a worst-case allocation size. */
     size_t num_dots = 0;
@@ -1043,14 +1043,14 @@ int mbedtls_oid_from_numeric_string(mbedtls_asn1_buf *oid,
     }
 
     encoded_len = out_ptr - oid->p;
-    minimum_mem = mbedtls_calloc(encoded_len, 1);
-    if (minimum_mem == NULL) {
+    resized_mem = mbedtls_calloc(encoded_len, 1);
+    if (resized_mem == NULL) {
         ret = MBEDTLS_ERR_ASN1_ALLOC_FAILED;
         goto error;
     }
-    memcpy(minimum_mem, oid->p, encoded_len);
+    memcpy(resized_mem, oid->p, encoded_len);
     mbedtls_free(oid->p);
-    oid->p = minimum_mem;
+    oid->p = resized_mem;
     oid->len = encoded_len;
 
     oid->tag = MBEDTLS_ASN1_OID;

--- a/library/oid.c
+++ b/library/oid.c
@@ -955,11 +955,11 @@ int mbedtls_oid_from_numeric_string(mbedtls_asn1_buf *oid,
     const char *str_bound = oid_str + size;
     unsigned int val = 0;
     unsigned int component1, component2;
-    /* Count the number of dots to get a worst-case allocation size. */
-    size_t num_dots = 0;
     size_t encoded_len;
     unsigned char *minimum_mem;
 
+    /* Count the number of dots to get a worst-case allocation size. */
+    size_t num_dots = 0;
     for (size_t i = 0; i < size; i++) {
         if (oid_str[i] == '.') {
             num_dots++;

--- a/library/oid.c
+++ b/library/oid.c
@@ -960,7 +960,7 @@ int mbedtls_oid_from_numeric_string(mbedtls_asn1_buf *oid,
     size_t encoded_len;
     unsigned char *minimum_mem;
 
-    for (size_t i = 0; (i < size) && (oid_str[i] != '\0'); i++) {
+    for (size_t i = 0; i < size; i++) {
         if (oid_str[i] == '.') {
             num_dots++;
         }
@@ -1003,7 +1003,7 @@ int mbedtls_oid_from_numeric_string(mbedtls_asn1_buf *oid,
         ret = MBEDTLS_ERR_ASN1_INVALID_DATA;
         goto error;
     }
-    if (str_ptr < str_bound && *str_ptr != '\0') {
+    if (str_ptr < str_bound) {
         if (*str_ptr == '.') {
             str_ptr++;
         } else {
@@ -1022,12 +1022,12 @@ int mbedtls_oid_from_numeric_string(mbedtls_asn1_buf *oid,
         goto error;
     }
 
-    while (str_ptr < str_bound && *str_ptr != '\0') {
+    while (str_ptr < str_bound) {
         ret = oid_parse_number(&val, &str_ptr, str_bound);
         if (ret != 0) {
             goto error;
         }
-        if (str_ptr < str_bound && *str_ptr != '\0') {
+        if (str_ptr < str_bound) {
             if (*str_ptr == '.') {
                 str_ptr++;
             } else {

--- a/library/oid.c
+++ b/library/oid.c
@@ -898,7 +898,9 @@ int mbedtls_oid_get_numeric_string(char *buf, size_t size,
 static int oid_parse_number(unsigned int *num, const char **p, const char *bound)
 {
     int ret = MBEDTLS_ERR_ASN1_INVALID_DATA;
+
     *num = 0;
+
     while (*p < bound && **p >= '0' && **p <= '9') {
         ret = 0;
         if (*num > (UINT_MAX / 10)) {
@@ -914,7 +916,9 @@ static int oid_parse_number(unsigned int *num, const char **p, const char *bound
 static size_t oid_subidentifier_num_bytes(unsigned int value)
 {
     size_t num_bytes = 1;
+
     value >>= 7;
+
     while (value != 0) {
         num_bytes++;
         value >>= 7;
@@ -927,6 +931,7 @@ static int oid_subidentifier_encode_into(unsigned char **p,
                                          unsigned int value)
 {
     size_t num_bytes = oid_subidentifier_num_bytes(value);
+
     if ((size_t) (bound - *p) < num_bytes) {
         return MBEDTLS_ERR_OID_BUF_TOO_SMALL;
     }
@@ -947,14 +952,13 @@ int mbedtls_oid_from_numeric_string(mbedtls_asn1_buf *oid,
                                     const char *oid_str, size_t size)
 {
     int ret = MBEDTLS_ERR_ASN1_INVALID_DATA;
-
     const char *str_ptr = oid_str;
     const char *str_bound = oid_str + size;
     unsigned int val = 0;
     unsigned int component1, component2;
-
     /* Count the number of dots to get a worst-case allocation size. */
     size_t num_dots = 0;
+
     for (size_t i = 0; (i < size) && (oid_str[i] != '\0'); i++) {
         if (oid_str[i] == '.') {
             num_dots++;

--- a/library/oid.c
+++ b/library/oid.c
@@ -1012,7 +1012,7 @@ int mbedtls_oid_from_numeric_string(mbedtls_asn1_buf *oid,
         }
     }
 
-    if ((UINT_MAX - component2) <= (component1 * 40)) {
+    if (component2 > (UINT_MAX - (component1 * 40))) {
         ret = MBEDTLS_ERR_ASN1_INVALID_DATA;
         goto error;
     }

--- a/library/oid.c
+++ b/library/oid.c
@@ -948,12 +948,12 @@ static int oid_subidentifier_encode_into(unsigned char **p,
 
 /* Return the OID for the given x.y.z.... style numeric string  */
 int mbedtls_oid_from_numeric_string(mbedtls_asn1_buf *oid,
-                                    const char *buf, size_t size)
+                                    const char *oid_str, size_t size)
 {
     int ret = MBEDTLS_ERR_ASN1_INVALID_DATA;
 
-    const char *str_ptr = buf;
-    const char *str_bound = buf + size;
+    const char *str_ptr = oid_str;
+    const char *str_bound = oid_str + size;
     int val = 0;
     size_t encoded_len;
 
@@ -1020,7 +1020,7 @@ int mbedtls_oid_from_numeric_string(mbedtls_asn1_buf *oid,
     oid->len = encoded_len;
 
     /* Now that we've allocated the buffer, go back to the start and encode */
-    str_ptr = buf;
+    str_ptr = oid_str;
     unsigned char *out_ptr = oid->p;
     unsigned char *out_bound = oid->p + oid->len;
 

--- a/library/oid.c
+++ b/library/oid.c
@@ -915,14 +915,13 @@ static int oid_parse_number(unsigned int *num, const char **p, const char *bound
 
 static size_t oid_subidentifier_num_bytes(unsigned int value)
 {
-    size_t num_bytes = 1;
+    size_t num_bytes = 0;
 
-    value >>= 7;
-
-    while (value != 0) {
-        num_bytes++;
+    do {
         value >>= 7;
-    }
+        num_bytes++;
+    } while (value != 0);
+
     return num_bytes;
 }
 

--- a/library/oid.c
+++ b/library/oid.c
@@ -950,7 +950,7 @@ int mbedtls_oid_from_numeric_string(mbedtls_asn1_buf *oid,
 
     const char *str_ptr = oid_str;
     const char *str_bound = oid_str + size;
-    int val = 0;
+    unsigned int val = 0;
     size_t encoded_len;
     unsigned int component1, component2;
 

--- a/library/oid.c
+++ b/library/oid.c
@@ -901,7 +901,7 @@ static int oid_parse_number(unsigned int *num, const char **p, const char *bound
     *num = 0;
     while (*p < bound && **p >= '0' && **p <= '9') {
         ret = 0;
-        if (*num > (INT_MAX / 10)) {
+        if (*num > (UINT_MAX / 10)) {
             return MBEDTLS_ERR_ASN1_INVALID_DATA;
         }
         *num *= 10;

--- a/library/oid.c
+++ b/library/oid.c
@@ -902,7 +902,7 @@ static int oid_parse_number(const char **p, const char *bound)
     while (*p < bound && **p >= '0' && **p <= '9') {
         ret = 0;
         if (num > (INT_MAX / 10)) {
-            return MBEDTLS_ERR_OID_BUF_TOO_SMALL;
+            return MBEDTLS_ERR_ASN1_INVALID_DATA;
         }
         num *= 10;
         num += **p - '0';
@@ -988,7 +988,7 @@ int mbedtls_oid_from_numeric_string(mbedtls_asn1_buf *oid,
 
     if ((UINT_MAX - (unsigned int) component2) <=
         ((unsigned int) component1 * 40)) {
-        return MBEDTLS_ERR_OID_BUF_TOO_SMALL;
+        return MBEDTLS_ERR_ASN1_INVALID_DATA;
     }
     encoded_len = oid_subidentifier_num_bytes(((unsigned int) component1 * 40)
                                               + (unsigned int) component2);
@@ -1008,7 +1008,7 @@ int mbedtls_oid_from_numeric_string(mbedtls_asn1_buf *oid,
 
         size_t num_bytes = oid_subidentifier_num_bytes(val);
         if ((SIZE_MAX - encoded_len) <= num_bytes) {
-            return MBEDTLS_ERR_OID_BUF_TOO_SMALL;
+            return MBEDTLS_ERR_ASN1_INVALID_DATA;
         }
         encoded_len += num_bytes;
     }

--- a/tests/suites/test_suite_oid.data
+++ b/tests/suites/test_suite_oid.data
@@ -119,3 +119,15 @@ oid_get_numeric_string:"8001":MBEDTLS_ERR_ASN1_INVALID_DATA:""
 
 OID get numeric string - overlong encoding, second subidentifier
 oid_get_numeric_string:"2B8001":MBEDTLS_ERR_ASN1_INVALID_DATA:""
+
+OID from numeric string - hardware module name
+oid_from_numeric_string:"1.3.6.1.5.5.7.8.4":0:"2B06010505070804"
+
+OID from numeric string - multi-byte subidentifier
+oid_from_numeric_string:"1.1.2108":0:"29903C"
+
+OID from numeric string - second component greater than 39
+oid_from_numeric_string:"2.49.0.0.826.0":0:"81010000863A00"
+
+OID from numeric string - multi-byte first subidentifier
+oid_from_numeric_string:"2.999":0:"8837"

--- a/tests/suites/test_suite_oid.data
+++ b/tests/suites/test_suite_oid.data
@@ -158,3 +158,6 @@ oid_from_numeric_string:"1.2/3.4":MBEDTLS_ERR_ASN1_INVALID_DATA:""
 
 OID from numeric string - non-'.' separator between third and fourth
 oid_from_numeric_string:"1.2.3/4":MBEDTLS_ERR_ASN1_INVALID_DATA:""
+
+OID from numeric string - OID greater than max length (129 components)
+oid_from_numeric_string:"1.2.3.4.5.6.7.8.1.2.3.4.5.6.7.8.1.2.3.4.5.6.7.8.1.2.3.4.5.6.7.8.1.2.3.4.5.6.7.8.1.2.3.4.5.6.7.8.1.2.3.4.5.6.7.8.1.2.3.4.5.6.7.8.1.2.3.4.5.6.7.8.1.2.3.4.5.6.7.8.1.2.3.4.5.6.7.8.1.2.3.4.5.6.7.8.1.2.3.4.5.6.7.8.1.2.3.4.5.6.7.8.1.2.3.4.5.6.7.8.1.2.3.4.5.6.7.8.1":MBEDTLS_ERR_ASN1_INVALID_DATA:""

--- a/tests/suites/test_suite_oid.data
+++ b/tests/suites/test_suite_oid.data
@@ -161,3 +161,9 @@ oid_from_numeric_string:"1.2.3/4":MBEDTLS_ERR_ASN1_INVALID_DATA:""
 
 OID from numeric string - OID greater than max length (129 components)
 oid_from_numeric_string:"1.2.3.4.5.6.7.8.1.2.3.4.5.6.7.8.1.2.3.4.5.6.7.8.1.2.3.4.5.6.7.8.1.2.3.4.5.6.7.8.1.2.3.4.5.6.7.8.1.2.3.4.5.6.7.8.1.2.3.4.5.6.7.8.1.2.3.4.5.6.7.8.1.2.3.4.5.6.7.8.1.2.3.4.5.6.7.8.1.2.3.4.5.6.7.8.1.2.3.4.5.6.7.8.1.2.3.4.5.6.7.8.1.2.3.4.5.6.7.8.1.2.3.4.5.6.7.8.1":MBEDTLS_ERR_ASN1_INVALID_DATA:""
+
+OID from numeric string - OID with maximum subidentifier
+oid_from_numeric_string:"2.4294967215":0:"8FFFFFFF7F"
+
+OID from numeric string - OID with overflowing subidentifier
+oid_from_numeric_string:"2.4294967216":MBEDTLS_ERR_ASN1_INVALID_DATA:""

--- a/tests/suites/test_suite_oid.data
+++ b/tests/suites/test_suite_oid.data
@@ -131,3 +131,30 @@ oid_from_numeric_string:"2.49.0.0.826.0":0:"81010000863A00"
 
 OID from numeric string - multi-byte first subidentifier
 oid_from_numeric_string:"2.999":0:"8837"
+
+OID from numeric string - empty string input
+oid_from_numeric_string:"":MBEDTLS_ERR_ASN1_INVALID_DATA:""
+
+OID from numeric string - first component not a number
+oid_from_numeric_string:"abc.1.2":MBEDTLS_ERR_ASN1_INVALID_DATA:""
+
+OID from numeric string - second component not a number
+oid_from_numeric_string:"1.abc.2":MBEDTLS_ERR_ASN1_INVALID_DATA:""
+
+OID from numeric string - first component too large
+oid_from_numeric_string:"3.1":MBEDTLS_ERR_ASN1_INVALID_DATA:""
+
+OID from numeric string - first component < 2, second > 39
+oid_from_numeric_string:"1.40":MBEDTLS_ERR_ASN1_INVALID_DATA:""
+
+OID from numeric string - third component not a number
+oid_from_numeric_string:"1.2.abc":MBEDTLS_ERR_ASN1_INVALID_DATA:""
+
+OID from numeric string - non-'.' separator between first and second
+oid_from_numeric_string:"1/2.3.4":MBEDTLS_ERR_ASN1_INVALID_DATA:""
+
+OID from numeric string - non-'.' separator between second and third
+oid_from_numeric_string:"1.2/3.4":MBEDTLS_ERR_ASN1_INVALID_DATA:""
+
+OID from numeric string - non-'.' separator between third and fourth
+oid_from_numeric_string:"1.2.3/4":MBEDTLS_ERR_ASN1_INVALID_DATA:""

--- a/tests/suites/test_suite_oid.function
+++ b/tests/suites/test_suite_oid.function
@@ -117,3 +117,29 @@ void oid_get_numeric_string(data_t *oid, int error_ret, char *result_str)
     }
 }
 /* END_CASE */
+
+/* BEGIN_CASE */
+void oid_from_numeric_string(char *oid_str, int error_ret,
+                             data_t *exp_oid_buf)
+{
+    mbedtls_asn1_buf oid = { 0, 0, NULL };
+    mbedtls_asn1_buf exp_oid = { 0, 0, NULL };
+    int ret;
+
+    exp_oid.tag = MBEDTLS_ASN1_OID;
+    exp_oid.p = exp_oid_buf->x;
+    exp_oid.len = exp_oid_buf->len;
+
+    ret = mbedtls_oid_from_numeric_string(&oid, oid_str, strlen(oid_str));
+
+    if (error_ret == 0) {
+        TEST_EQUAL(oid.len, exp_oid.len);
+        TEST_ASSERT(memcmp(oid.p, exp_oid.p, oid.len) == 0);
+        mbedtls_free(oid.p);
+        oid.p = NULL;
+        oid.len = 0;
+    } else {
+        TEST_EQUAL(ret, error_ret);
+    }
+}
+/* END_CASE */


### PR DESCRIPTION
Add a new function `mbedtls_oid_from_numeric_string()` that parses the provided OID string into an `mbedtls_asn1_buf`.


## Gatekeeper checklist

- [x] **changelog** provided
- [x] **backport** not required - New feature so no backport needed
- [x] **tests** provided

