### PR TITLE
Linux/Aarch64: support SHA acceleration detection with older libc

### DIFF
--- a/ChangeLog.d/linux-aarch64-hwcap.txt
+++ b/ChangeLog.d/linux-aarch64-hwcap.txt
@@ -1,0 +1,4 @@
+Bugfix
+   * On Linux on ARMv8, fix a build error with SHA-256 and SHA-512
+     acceleration detection when the libc headers do not define the
+     corresponding constant. Reported by valord577.

--- a/library/sha256.c
+++ b/library/sha256.c
@@ -44,6 +44,7 @@
 #      if defined(__linux__)
 /* Our preferred method of detection is getauxval() */
 #        include <sys/auxv.h>
+#        define HAVE_GETAUXVAL
 #      endif
 /* Use SIGILL on Unix, and fall back to it on Linux */
 #      include <signal.h>
@@ -64,7 +65,15 @@
  * Capability detection code comes early, so we can disable
  * MBEDTLS_SHA256_USE_A64_CRYPTO_IF_PRESENT if no detection mechanism found
  */
-#if defined(HWCAP_SHA2)
+#if defined(HAVE_GETAUXVAL)
+#if !defined(HWCAP_SHA2)
+/* The same header that declares getauxval() should provide the HWCAP_xxx
+ * constants to analyze its return value. However, the libc may be too
+ * old to have the constant that we need. So if it's missing, assume that
+ * the value is the same one used by the Linux kernel ABI.
+ */
+#define HWCAP_SHA2 (1 << 6)
+#endif
 static int mbedtls_a64_crypto_sha256_determine_support(void)
 {
     return (getauxval(AT_HWCAP) & HWCAP_SHA2) ? 1 : 0;
@@ -131,7 +140,7 @@ static int mbedtls_a64_crypto_sha256_determine_support(void)
 #else
 #warning "No mechanism to detect A64_CRYPTO found, using C code only"
 #undef MBEDTLS_SHA256_USE_A64_CRYPTO_IF_PRESENT
-#endif  /* HWCAP_SHA2, __APPLE__, __unix__ && SIG_SETMASK */
+#endif  /* HAVE_GETAUXVAL, __APPLE__, __unix__ && SIG_SETMASK */
 
 #endif  /* MBEDTLS_SHA256_USE_A64_CRYPTO_IF_PRESENT */
 


### PR DESCRIPTION
On Linux on aarch64 (64-bit ARMv8) processors, we use getauxval() to detect whether the runtime environment supports SHA-256 or SHA-512 acceleration. Some libc do not define the necessary HWCAP_xxx constants to analyze the result of getauxval(), either because they don't bother or because they're too old to recognize the values we need (for example, HWCAP_SHA2 appeared in Glibc 2.24 and HWCAP_SHA512 appeared in Glibc 2.27). In such cases, assume that the values are the same as in the kernel ABI and define the constants manually.

Fixes the issue reported in https://github.com/Mbed-TLS/mbedtls/pull/6224. Supersedes https://github.com/Mbed-TLS/mbedtls/pull/6224.

Status: I have not tested at all. @valord577 @tom-cosgrove-arm @yuhaoth Can you please try this out?

## Gatekeeper checklist

- [x] **changelog** provided
- [x] **backport** no (feature added after 3.0)
- [ ] **tests** no (to be tested manually)
