### PR TITLE
Fix test to check output length on PSA_SUCCESS only

### DIFF
--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -7855,6 +7855,8 @@ void asymmetric_encrypt(int key_type_arg,
     TEST_EQUAL(actual_status, expected_status);
     if (actual_status == PSA_SUCCESS) {
         TEST_EQUAL(output_length, expected_output_length);
+    } else {
+        TEST_LE_U(output_length, output_size);
     }
 
     /* If the label is empty, the test framework puts a non-null pointer
@@ -7872,6 +7874,8 @@ void asymmetric_encrypt(int key_type_arg,
         TEST_EQUAL(actual_status, expected_status);
         if (actual_status == PSA_SUCCESS) {
             TEST_EQUAL(output_length, expected_output_length);
+        } else {
+            TEST_LE_U(output_length, output_size);
         }
     }
 

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -7853,7 +7853,9 @@ void asymmetric_encrypt(int key_type_arg,
                                            output, output_size,
                                            &output_length);
     TEST_EQUAL(actual_status, expected_status);
-    TEST_EQUAL(output_length, expected_output_length);
+    if (actual_status == PSA_SUCCESS) {
+        TEST_EQUAL(output_length, expected_output_length);
+    }
 
     /* If the label is empty, the test framework puts a non-null pointer
      * in label->x. Test that a null pointer works as well. */
@@ -7868,7 +7870,9 @@ void asymmetric_encrypt(int key_type_arg,
                                                output, output_size,
                                                &output_length);
         TEST_EQUAL(actual_status, expected_status);
-        TEST_EQUAL(output_length, expected_output_length);
+        if (actual_status == PSA_SUCCESS) {
+            TEST_EQUAL(output_length, expected_output_length);
+        }
     }
 
 exit:


### PR DESCRIPTION
## Description

Fix `asymmetric_encrypt ` in `test_suite_psa_crypto.function` so that it only expects a defined `output_length` if `psa_asymmetric_encrypt` returns `PSA_SUCCESS`. 

## Gatekeeper checklist

- [x] **changelog** not required
- [x] **backport** see #7139
- [x] **tests** not required

Signed-off-by: Oberon microsystems AG, Zürich