### PR TITLE
library: psa_crypto: Fix compilation error in psa_key_derivation_abort

### DIFF
--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -4289,11 +4289,13 @@ psa_status_t psa_key_derivation_abort(psa_key_derivation_operation_t *operation)
             mbedtls_free(operation->ctx.tls12_prf.label);
         }
 
+#if defined(MBEDTLS_PSA_BUILTIN_ALG_TLS12_PSK_TO_MS)
         if (operation->ctx.tls12_prf.other_secret != NULL) {
             mbedtls_platform_zeroize(operation->ctx.tls12_prf.other_secret,
                                      operation->ctx.tls12_prf.other_secret_length);
             mbedtls_free(operation->ctx.tls12_prf.other_secret);
         }
+#endif
 
         status = PSA_SUCCESS;
 


### PR DESCRIPTION
## Description

Fix compilation error in psa_key_derivation_abort when MBEDTLS_PSA_BUILTIN_ALG_TLS12_PRF is defined, but
MBEDTLS_PSA_BUILTIN_ALG_TLS12_PSK_TO_MS is not defined.

In function 'psa_key_derivation_abort':
error: 'psa_tls12_prf_key_derivation_t'
{aka 'struct psa_tls12_prf_key_derivation_s'} has no member named 'other_secret'

## Gatekeeper checklist

- [ ] **changelog** missing
- [x] **backport** not required
- [x] **tests** excused



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

