### PR TITLE
compat.sh: Skip static ECDH cases if unsupported in openssl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ jobs:
         - tests/scripts/test_psa_constant_names.py
         - tests/ssl-opt.sh
         # Modern OpenSSL does not support fixed ECDH or null ciphers.
-        - tests/compat.sh -p OpenSSL -e 'NULL\|ECDH_'
+        - tests/compat.sh -p OpenSSL -e 'NULL'
         - tests/scripts/travis-log-failure.sh
         # GnuTLS supports CAMELLIA but compat.sh doesn't properly enable it.
         - tests/compat.sh -p GnuTLS -e 'CAMELLIA'

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ jobs:
         - programs/test/selftest
         - tests/scripts/test_psa_constant_names.py
         - tests/ssl-opt.sh
-        # Modern OpenSSL does not support fixed ECDH or null ciphers.
+        # Modern OpenSSL does not support null ciphers.
         - tests/compat.sh -p OpenSSL -e 'NULL'
         - tests/scripts/travis-log-failure.sh
         # GnuTLS supports CAMELLIA but compat.sh doesn't properly enable it.

--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -534,6 +534,15 @@ add_mbedtls_ciphersuites()
     esac
 }
 
+# o_check_ciphersuite STANDARD_CIPHER_SUITE
+o_check_ciphersuite()
+{
+    if [ "${1#*ECDH_ECDSA*}" != "$1" ] && \
+       [ "X${O_SUPPORT_ECDH}" = "XNO" ]; then
+            SKIP_NEXT="YES"
+    fi
+}
+
 setup_arguments()
 {
     O_MODE=""
@@ -601,6 +610,11 @@ setup_arguments()
             O_CLIENT_ARGS="$O_CLIENT_ARGS -cipher ALL@SECLEVEL=0"
             O_SERVER_ARGS="$O_SERVER_ARGS -cipher ALL@SECLEVEL=0"
             ;;
+    esac
+
+    case $($OPENSSL ciphers ALL) in
+        *ECDH-ECDSA*) O_SUPPORT_ECDH="YES";;
+        *)O_SUPPORT_ECDH="NO";;
     esac
 
     if [ "X$VERIFY" = "XYES" ];
@@ -1033,6 +1047,7 @@ for MODE in $MODES; do
                         start_server "OpenSSL"
                         translate_ciphers m $M_CIPHERS
                         for i in $ciphers; do
+                            o_check_ciphersuite "$i"
                             run_client mbedTLS ${i%%=*} ${i#*=}
                         done
                         stop_server

--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -1047,7 +1047,7 @@ for MODE in $MODES; do
                         start_server "OpenSSL"
                         translate_ciphers m $M_CIPHERS
                         for i in $ciphers; do
-                            o_check_ciphersuite "$i"
+                            o_check_ciphersuite "${i%%=*}"
                             run_client mbedTLS ${i%%=*} ${i#*=}
                         done
                         stop_server

--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -614,7 +614,7 @@ setup_arguments()
     esac
 
     case $($OPENSSL ciphers ALL) in
-        *ECDH-ECDSA*) O_SUPPORT_ECDH="YES";;
+        *ECDH-ECDSA*|*ECDH-RSA*) O_SUPPORT_ECDH="YES";;
         *) O_SUPPORT_ECDH="NO";;
     esac
 
@@ -834,7 +834,7 @@ run_client() {
             if [ $EXIT -eq 0 ]; then
                 RESULT=0
             else
-                # If the cipher isn't supported...
+                # If it is NULL cipher ...
                 if grep 'Cipher is (NONE)' $CLI_OUT >/dev/null; then
                     RESULT=1
                 else

--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -537,9 +537,10 @@ add_mbedtls_ciphersuites()
 # o_check_ciphersuite STANDARD_CIPHER_SUITE
 o_check_ciphersuite()
 {
-    if [ "${1#*ECDH_ECDSA*}" != "$1" ] && \
-       [ "X${O_SUPPORT_ECDH}" = "XNO" ]; then
-            SKIP_NEXT="YES"
+    if [ "${O_SUPPORT_ECDH}" = "NO" ]; then
+        case "$1" in
+            *ECDH_*) SKIP_NEXT="YES"
+        esac
     fi
 }
 
@@ -614,7 +615,7 @@ setup_arguments()
 
     case $($OPENSSL ciphers ALL) in
         *ECDH-ECDSA*) O_SUPPORT_ECDH="YES";;
-        *)O_SUPPORT_ECDH="NO";;
+        *) O_SUPPORT_ECDH="NO";;
     esac
 
     if [ "X$VERIFY" = "XYES" ];

--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -1058,6 +1058,7 @@ for MODE in $MODES; do
                         start_server "mbedTLS"
                         translate_ciphers o $O_CIPHERS
                         for i in $ciphers; do
+                            o_check_ciphersuite "${i%%=*}"
                             run_client OpenSSL ${i%%=*} ${i#*=}
                         done
                         stop_server


### PR DESCRIPTION
## Description

Fix: https://github.com/Mbed-TLS/mbedtls/issues/1785

This PR add the ability in `compat.sh` to check if the under testing `openssl` program supports static ECDH (i.e. `ECDH_ECDSA`) key exchange methods. The cases for `TLS_ECDH_ECDSA_xxx` ciphersuites will be skipped if `openssl` doesn't support so.

This PR would like to cover all out of box failures of ssl-opt.sh and compat.sh on modern systems (e.g Ubuntu 18.04 and newer).

## Gatekeeper checklist

- [ ] **changelog** provided, or not required
- [ ] **backport**  https://github.com/Mbed-TLS/mbedtls/pull/7153
- [ ] **tests** provided, or not required


