### PR TITLE
Backport 2.28 - Fix test to check output length on PSA_SUCCESS only

### DIFF
--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -4173,7 +4173,9 @@ void asymmetric_encrypt(int key_type_arg,
                                            output, output_size,
                                            &output_length);
     TEST_EQUAL(actual_status, expected_status);
-    TEST_EQUAL(output_length, expected_output_length);
+    if (actual_status == PSA_SUCCESS) {
+        TEST_EQUAL(output_length, expected_output_length);
+    }
 
     /* If the label is empty, the test framework puts a non-null pointer
      * in label->x. Test that a null pointer works as well. */
@@ -4188,7 +4190,9 @@ void asymmetric_encrypt(int key_type_arg,
                                                output, output_size,
                                                &output_length);
         TEST_EQUAL(actual_status, expected_status);
-        TEST_EQUAL(output_length, expected_output_length);
+        if (actual_status == PSA_SUCCESS) {
+            TEST_EQUAL(output_length, expected_output_length);
+        }
     }
 
 exit:

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -4175,6 +4175,8 @@ void asymmetric_encrypt(int key_type_arg,
     TEST_EQUAL(actual_status, expected_status);
     if (actual_status == PSA_SUCCESS) {
         TEST_EQUAL(output_length, expected_output_length);
+    } else {
+        TEST_LE_U(output_length, output_size);
     }
 
     /* If the label is empty, the test framework puts a non-null pointer
@@ -4192,6 +4194,8 @@ void asymmetric_encrypt(int key_type_arg,
         TEST_EQUAL(actual_status, expected_status);
         if (actual_status == PSA_SUCCESS) {
             TEST_EQUAL(output_length, expected_output_length);
+        } else {
+            TEST_LE_U(output_length, output_size);
         }
     }
 


### PR DESCRIPTION
## Description

Trivial backport of #7124 

## Gatekeeper checklist

- [x] **changelog** provided, or not required
- [x] **backport** done, or not required
- [x] **tests** provided, or not required