### PR TITLE
Allow alternative names for overridable PSA headers

### DIFF
--- a/ChangeLog.d/psa-alt-headers.txt
+++ b/ChangeLog.d/psa-alt-headers.txt
@@ -1,0 +1,4 @@
+Features
+   * The configuration macros MBEDTLS_PSA_CRYPTO_PLATFORM_FILE and
+     MBEDTLS_PSA_CRYPTO_STRUCT_FILE specify alternative locations for
+     the headers "psa/crypto_platform.h" and "psa/crypto_struct.h".

--- a/include/mbedtls/build_info.h
+++ b/include/mbedtls/build_info.h
@@ -80,6 +80,13 @@
 #include MBEDTLS_USER_CONFIG_FILE
 #endif
 
+/* If MBEDTLS_PSA_CRYPTO_C is defined, make sure MBEDTLS_PSA_CRYPTO_CLIENT
+ * is defined as well to include all PSA code.
+ */
+#if defined(MBEDTLS_PSA_CRYPTO_C)
+#define MBEDTLS_PSA_CRYPTO_CLIENT
+#endif /* MBEDTLS_PSA_CRYPTO_C */
+
 /* The PK wrappers need pk_write functions to format RSA key objects
  * when they are dispatching to the PSA API. This happens under USE_PSA_CRYPTO,
  * and also even without USE_PSA_CRYPTO for mbedtls_pk_sign_ext().

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -3537,6 +3537,53 @@
  */
 //#define MBEDTLS_PSA_CRYPTO_USER_CONFIG_FILE "/dev/null"
 
+/**
+ * \def MBEDTLS_PSA_CRYPTO_PLATFORM_FILE
+ *
+ * If defined, this is a header which will be included instead of
+ * `"psa/crypto_platform.h"`. This file should declare the same identifiers
+ * as the one in Mbed TLS, but with definitions adapted to the platform on
+ * which the library code will run.
+ *
+ * \note The required content of this header can vary from one version of
+ *       Mbed TLS to the next. Integrators who provide an alternative file
+ *       should review the changes in the original file whenever they
+ *       upgrade Mbed TLS.
+ *
+ * This macro is expanded after an <tt>\#include</tt> directive. This is a popular but
+ * non-standard feature of the C language, so this feature is only available
+ * with compilers that perform macro expansion on an <tt>\#include</tt> line.
+ *
+ * The value of this symbol is typically a path in double quotes, either
+ * absolute or relative to a directory on the include search path.
+ */
+//#define MBEDTLS_PSA_CRYPTO_PLATFORM_FILE "psa/crypto_platform_alt.h"
+
+/**
+ * \def MBEDTLS_PSA_CRYPTO_STRUCT_FILE
+ *
+ * If defined, this is a header which will be included instead of
+ * `"psa/crypto_struct.h"`. This file should declare the same identifiers
+ * as the one in Mbed TLS, but with definitions adapted to the environment
+ * in which the library code will run. The typical use for this feature
+ * is to provide alternative type definitions on the client side in
+ * client-server integrations of PSA crypto, where operation structures
+ * contain handles instead of cryptographic data.
+ *
+ * \note The required content of this header can vary from one version of
+ *       Mbed TLS to the next. Integrators who provide an alternative file
+ *       should review the changes in the original file whenever they
+ *       upgrade Mbed TLS.
+ *
+ * This macro is expanded after an <tt>\#include</tt> directive. This is a popular but
+ * non-standard feature of the C language, so this feature is only available
+ * with compilers that perform macro expansion on an <tt>\#include</tt> line.
+ *
+ * The value of this symbol is typically a path in double quotes, either
+ * absolute or relative to a directory on the include search path.
+ */
+//#define MBEDTLS_PSA_CRYPTO_STRUCT_FILE "psa/crypto_struct_alt.h"
+
 /** \} name SECTION: General configuration options */
 
 /**

--- a/include/psa/crypto.h
+++ b/include/psa/crypto.h
@@ -22,7 +22,11 @@
 #ifndef PSA_CRYPTO_H
 #define PSA_CRYPTO_H
 
+#if defined(MBEDTLS_PSA_CRYPTO_PLATFORM_FILE)
+#include MBEDTLS_PSA_CRYPTO_PLATFORM_FILE
+#else
 #include "crypto_platform.h"
+#endif
 
 #include <stddef.h>
 
@@ -4677,7 +4681,11 @@ psa_status_t psa_verify_hash_abort(
 
 /* The file "crypto_struct.h" contains definitions for
  * implementation-specific structs that are declared above. */
+#if defined(MBEDTLS_PSA_CRYPTO_STRUCT_FILE)
+#include MBEDTLS_PSA_CRYPTO_STRUCT_FILE
+#else
 #include "crypto_struct.h"
+#endif
 
 /* The file "crypto_extra.h" contains vendor-specific definitions. This
  * can include vendor-defined algorithms, extra functions, etc. */

--- a/include/psa/crypto_types.h
+++ b/include/psa/crypto_types.h
@@ -32,6 +32,10 @@
 
 #ifndef PSA_CRYPTO_TYPES_H
 #define PSA_CRYPTO_TYPES_H
+
+/* Make sure the Mbed TLS configuration is visible. */
+#include "mbedtls/build_info.h"
+/* Define the MBEDTLS_PRIVATE macro. */
 #include "mbedtls/private_access.h"
 
 #if defined(MBEDTLS_PSA_CRYPTO_PLATFORM_FILE)

--- a/include/psa/crypto_types.h
+++ b/include/psa/crypto_types.h
@@ -34,7 +34,11 @@
 #define PSA_CRYPTO_TYPES_H
 #include "mbedtls/private_access.h"
 
+#if defined(MBEDTLS_PSA_CRYPTO_PLATFORM_FILE)
+#include MBEDTLS_PSA_CRYPTO_PLATFORM_FILE
+#else
 #include "crypto_platform.h"
+#endif
 
 /* If MBEDTLS_PSA_CRYPTO_C is defined, make sure MBEDTLS_PSA_CRYPTO_CLIENT
  * is defined as well to include all PSA code.

--- a/include/psa/crypto_types.h
+++ b/include/psa/crypto_types.h
@@ -44,13 +44,6 @@
 #include "crypto_platform.h"
 #endif
 
-/* If MBEDTLS_PSA_CRYPTO_C is defined, make sure MBEDTLS_PSA_CRYPTO_CLIENT
- * is defined as well to include all PSA code.
- */
-#if defined(MBEDTLS_PSA_CRYPTO_C)
-#define MBEDTLS_PSA_CRYPTO_CLIENT
-#endif /* MBEDTLS_PSA_CRYPTO_C */
-
 #include <stdint.h>
 
 /** \defgroup error Error codes

--- a/programs/.gitignore
+++ b/programs/.gitignore
@@ -64,6 +64,7 @@ test/cpp_dummy_build.cpp
 test/dlopen
 test/ecp-bench
 test/query_compile_time_config
+test/query_included_headers
 test/selftest
 test/ssl_cert_test
 test/udp_proxy

--- a/programs/Makefile
+++ b/programs/Makefile
@@ -123,6 +123,7 @@ APPS = \
 	ssl/ssl_server2 \
 	test/benchmark \
 	test/query_compile_time_config \
+	test/query_included_headers \
 	test/selftest \
 	test/udp_proxy \
 	test/zeroize \
@@ -402,6 +403,10 @@ endif
 test/query_config.o: test/query_config.c test/query_config.h $(DEP)
 	echo "  CC    test/query_config.c"
 	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) -c test/query_config.c -o $@
+
+test/query_included_headers$(EXEXT): test/query_included_headers.c $(DEP)
+	echo "  CC    test/query_included_headers.c"
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) test/query_included_headers.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test/selftest$(EXEXT): test/selftest.c $(DEP)
 	echo "  CC    test/selftest.c"

--- a/programs/test/CMakeLists.txt
+++ b/programs/test/CMakeLists.txt
@@ -3,6 +3,7 @@ set(libs
 )
 
 set(executables_libs
+    query_included_headers
     selftest
     udp_proxy
 )

--- a/programs/test/query_included_headers.c
+++ b/programs/test/query_included_headers.c
@@ -1,0 +1,41 @@
+/* Ad hoc report on included headers. */
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <psa/crypto.h>
+#include <mbedtls/platform.h>
+
+int main(void)
+{
+
+    /* Which PSA platform header? */
+#if defined(PSA_CRYPTO_PLATFORM_H)
+    mbedtls_printf("PSA_CRYPTO_PLATFORM_H\n");
+#endif
+#if defined(PSA_CRYPTO_PLATFORM_ALT_H)
+    mbedtls_printf("PSA_CRYPTO_PLATFORM_ALT_H\n");
+#endif
+
+    /* Which PSA struct header? */
+#if defined(PSA_CRYPTO_STRUCT_H)
+    mbedtls_printf("PSA_CRYPTO_STRUCT_H\n");
+#endif
+#if defined(PSA_CRYPTO_STRUCT_ALT_H)
+    mbedtls_printf("PSA_CRYPTO_STRUCT_ALT_H\n");
+#endif
+
+}

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -13,6 +13,8 @@ data_files/hmac_drbg_seed
 data_files/ctr_drbg_seed
 data_files/entropy_seed
 
+include/alt-extra/psa/crypto_platform_alt.h
+include/alt-extra/psa/crypto_struct_alt.h
 include/test/instrument_record_status.h
 
 src/*.o

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -219,6 +219,7 @@ ifndef WINDOWS
 	rm -rf $(BINARIES) *.c *.datax
 	rm -f src/*.o src/drivers/*.o src/libmbed*
 	rm -f include/test/instrument_record_status.h
+	rm -f include/alt-extra/*/*_alt.h
 	rm -rf libtestdriver1
 	rm -f ../library/libtestdriver1.a
 else
@@ -243,6 +244,10 @@ check: $(BINARIES)
 	perl scripts/run-test-suites.pl $(TEST_FLAGS) --skip=$(SKIP_TEST_SUITES)
 
 test: check
+
+# Generate variants of some headers for testing
+include/alt-extra/%_alt.h: ../include/%.h
+	perl -p -e 's/^(# *(define|ifndef) +\w+_)H\b/$${1}ALT_H/' $< >$@
 
 # Generate test library
 

--- a/tests/include/alt-extra/psa/crypto.h
+++ b/tests/include/alt-extra/psa/crypto.h
@@ -1,0 +1,7 @@
+/* The goal of the include/alt-extra directory is to test what happens
+ * if certain files come _after_ the normal include directory.
+ * Make sure that if the alt-extra directory comes before the normal
+ * directory (so we wouldn't be achieving our test objective), the build
+ * will fail.
+ */
+#error "The normal include directory must come first in the include path"

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -3258,6 +3258,27 @@ component_build_psa_config_file () {
     rm -f psa_test_config.h psa_user_config.h
 }
 
+component_build_psa_alt_headers () {
+    msg "build: make with PSA alt headers" # ~20s
+
+    # Generate alternative versions of the substitutable headers with the
+    # same content except different include guards.
+    make -C tests include/alt-extra/psa/crypto_platform_alt.h include/alt-extra/psa/crypto_struct_alt.h
+
+    # Build the library and some programs.
+    # Don't build the fuzzers to avoid having to go through hoops to set
+    # a correct include path for programs/fuzz/Makefile.
+    make CFLAGS="-I ../tests/include/alt-extra -DMBEDTLS_PSA_CRYPTO_PLATFORM_FILE='\"psa/crypto_platform_alt.h\"' -DMBEDTLS_PSA_CRYPTO_STRUCT_FILE='\"psa/crypto_struct_alt.h\"'" lib
+    make -C programs -o fuzz CFLAGS="-I ../tests/include/alt-extra -DMBEDTLS_PSA_CRYPTO_PLATFORM_FILE='\"psa/crypto_platform_alt.h\"' -DMBEDTLS_PSA_CRYPTO_STRUCT_FILE='\"psa/crypto_struct_alt.h\"'"
+
+    # Check that we're getting the alternative include guards and not the
+    # original include guards.
+    programs/test/query_included_headers | grep -x PSA_CRYPTO_PLATFORM_ALT_H
+    programs/test/query_included_headers | grep -x PSA_CRYPTO_STRUCT_ALT_H
+    programs/test/query_included_headers | not grep -x PSA_CRYPTO_PLATFORM_H
+    programs/test/query_included_headers | not grep -x PSA_CRYPTO_STRUCT_H
+}
+
 component_test_m32_o0 () {
     # Build without optimization, so as to use portable C code (in a 32-bit
     # build) and not the i386-specific inline assembly.


### PR DESCRIPTION
Allow alternative paths for the PSA headers that integrators may override (`psa/crypto_platform.h` and `psa/crypto_struct.h`). Fixes #7145.

Also move the implication `MBEDTLS_PSA_CRYPTO_C` ⇒ `MBEDTLS_PSA_CRYPTO_CLIENT` to `build_info.h` where it belongs, in partial fulfilment of https://github.com/Mbed-TLS/mbedtls/issues/7144.

## Gatekeeper checklist

- [x] **changelog** provided
- [x] **backport** no (new feature)
- [x] **tests** provided
