### PR TITLE
Backport 2.28: compat.sh: Skip static ECDH cases if unsupported in openssl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,8 +55,8 @@ jobs:
         # Exclude a few test cases that are failing mysteriously.
         # https://github.com/Mbed-TLS/mbedtls/issues/6660
         - tests/ssl-opt.sh -e 'Fallback SCSV:\ .*list'
-        # Modern OpenSSL does not support fixed ECDH, null or ancient ciphers.
-        - tests/compat.sh -p OpenSSL -e 'NULL\|ECDH-\|DES\|RC4'
+        # Modern OpenSSL does not support null or ancient ciphers.
+        - tests/compat.sh -p OpenSSL -e 'NULL\|DES\|RC4'
         - tests/scripts/travis-log-failure.sh
         # GnuTLS supports CAMELLIA but compat.sh doesn't properly enable it.
         # Modern GnuTLS does not support DES.

--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -861,6 +861,16 @@ add_mbedtls_ciphersuites()
     esac
 }
 
+# o_check_ciphersuite CIPHER_SUITE_NAME
+o_check_ciphersuite()
+{
+    if [ "${O_SUPPORT_ECDH}" = "NO" ]; then
+        case "$1" in
+            *ECDH-*) SKIP_NEXT="YES"
+        esac
+    fi
+}
+
 setup_arguments()
 {
     O_MODE=""
@@ -945,6 +955,11 @@ setup_arguments()
             O_CLIENT_ARGS="$O_CLIENT_ARGS -cipher ALL@SECLEVEL=0"
             O_SERVER_ARGS="$O_SERVER_ARGS -cipher ALL@SECLEVEL=0"
             ;;
+    esac
+
+    case $($OPENSSL ciphers ALL) in
+        *ECDH-ECDSA*|*ECDH-RSA*) O_SUPPORT_ECDH="YES";;
+        *) O_SUPPORT_ECDH="NO";;
     esac
 
     if [ "X$VERIFY" = "XYES" ];
@@ -1373,6 +1388,7 @@ for MODE in $MODES; do
                     if [ "X" != "X$M_CIPHERS" ]; then
                         start_server "OpenSSL"
                         for i in $M_CIPHERS; do
+                            o_check_ciphersuite "$i"
                             run_client mbedTLS $i
                         done
                         stop_server
@@ -1381,6 +1397,7 @@ for MODE in $MODES; do
                     if [ "X" != "X$O_CIPHERS" ]; then
                         start_server "mbedTLS"
                         for i in $O_CIPHERS; do
+                            o_check_ciphersuite "$i"
                             run_client OpenSSL $i
                         done
                         stop_server

--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -1175,7 +1175,7 @@ run_client() {
             if [ $EXIT -eq 0 ]; then
                 RESULT=0
             else
-                # If ti is NULL cipher ...
+                # If it is NULL cipher ...
                 if grep 'Cipher is (NONE)' $CLI_OUT >/dev/null; then
                     RESULT=1
                 else

--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -1175,7 +1175,7 @@ run_client() {
             if [ $EXIT -eq 0 ]; then
                 RESULT=0
             else
-                # If the cipher isn't supported...
+                # If ti is NULL cipher ...
                 if grep 'Cipher is (NONE)' $CLI_OUT >/dev/null; then
                     RESULT=1
                 else


### PR DESCRIPTION
This PR is a backport of https://github.com/Mbed-TLS/mbedtls/pull/7137 to branch mbedtls-2.28.

Because `compat.sh` has changed a lot from `development` branch, the backport isn't a simple cherry-pick. The commit history has been reorganized.

