### PR TITLE
ECP: Introduced a generic `ecp_mod_px_raw()` test

### DIFF
--- a/scripts/mbedtls_dev/ecp.py
+++ b/scripts/mbedtls_dev/ecp.py
@@ -79,7 +79,7 @@ class EcpP192R1Raw(bignum_common.ModOperationCommon,
 class EcpP521R1Raw(bignum_common.ModOperationCommon,
                    EcpTarget):
     """Test cases for ecp quasi_reduction()."""
-    test_function = "ecp_mod_p521_raw"
+    test_function = "ecp_mod_px_raw"
     test_name = "ecp_mod_p521_raw"
     input_style = "arch_split"
     arity = 1
@@ -162,6 +162,9 @@ class EcpP521R1Raw(bignum_common.ModOperationCommon,
     def result(self) -> List[str]:
         result = self.int_a % self.int_n
         return [self.format_result(result)]
+
+    def arguments(self) -> List[str]:
+        return ["MBEDTLS_ECP_DP_SECP521R1"] +  super().arguments()
 
     @property
     def is_valid(self) -> bool:

--- a/tests/suites/test_suite_ecp.function
+++ b/tests/suites/test_suite_ecp.function
@@ -1347,9 +1347,10 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_TEST_HOOKS */
-void ecp_mod_p521_raw(char *input_N,
-                      char *input_X,
-                      char *result)
+void ecp_mod_px_raw(int id,
+                    char *input_N,
+                    char *input_X,
+                    char *result)
 {
     mbedtls_mpi_uint *X = NULL;
     mbedtls_mpi_uint *N = NULL;
@@ -1375,7 +1376,14 @@ void ecp_mod_p521_raw(char *input_N,
                    &m, N, limbs,
                    MBEDTLS_MPI_MOD_REP_MONTGOMERY), 0);
 
-    TEST_EQUAL(mbedtls_ecp_mod_p521_raw(X, limbs_X), 0);
+    switch (id) {
+        case MBEDTLS_ECP_DP_SECP521R1:
+            TEST_EQUAL(mbedtls_ecp_mod_p521_raw(X, limbs_X), 0);
+            break;
+        default:
+            mbedtls_test_fail("Invalid ECP Curve ID", __LINE__, __FILE__);
+    }
+
     TEST_LE_U(mbedtls_mpi_core_bitlen(X, limbs_X), 522);
     mbedtls_mpi_mod_raw_fix_quasi_reduction(X, &m);
     ASSERT_COMPARE(X, bytes, res, bytes);


### PR DESCRIPTION
This patch modified `ecp_mod_pp521_raw()` to make it more generic and allow re-use with other compatible curves.

## Description

The tests for SECP521R1, SECP224R1, SECP256R1 and SECP384R1 they all seem to require the same structure. This change will allow re-using a single test, and change the tested curve by the curve `id` selector.

## Gatekeeper checklist

- [x] **changelog** Not Required
- [x] **backport** Not Required
- [x] **tests** Not Required
