### PR TITLE
pkcs7 - add support for signed attributes

### DIFF
--- a/include/mbedtls/oid.h
+++ b/include/mbedtls/oid.h
@@ -316,6 +316,7 @@
 #define MBEDTLS_OID_PKCS7_SIGNED_AND_ENVELOPED_DATA   MBEDTLS_OID_PKCS7 "\x04" /**< Content type is Signed and Enveloped Data OBJECT IDENTIFIER ::= {pkcs-7 4} */
 #define MBEDTLS_OID_PKCS7_DIGESTED_DATA               MBEDTLS_OID_PKCS7 "\x05" /**< Content type is Digested Data OBJECT IDENTIFIER ::= {pkcs-7 5} */
 #define MBEDTLS_OID_PKCS7_ENCRYPTED_DATA              MBEDTLS_OID_PKCS7 "\x06" /**< Content type is Encrypted Data OBJECT IDENTIFIER ::= {pkcs-7 6} */
+#define MBEDTLS_OID_PKCS9_MESSAGE_DIGEST              MBEDTLS_OID_PKCS9 "\x04" /**< id-messageDigest OCTET STRING ::= {pkcs-9 4} */
 
 /*
  * PKCS#8 OIDs

--- a/include/mbedtls/pkcs7.h
+++ b/include/mbedtls/pkcs7.h
@@ -127,6 +127,8 @@ typedef struct mbedtls_pkcs7_signer_info {
     mbedtls_x509_name MBEDTLS_PRIVATE(issuer);
     mbedtls_x509_buf MBEDTLS_PRIVATE(issuer_raw);
     mbedtls_x509_buf MBEDTLS_PRIVATE(alg_identifier);
+    mbedtls_asn1_named_data MBEDTLS_PRIVATE(signed_attrs);
+    mbedtls_x509_buf MBEDTLS_PRIVATE(signed_attrs_raw);
     mbedtls_x509_buf MBEDTLS_PRIVATE(sig_alg_identifier);
     mbedtls_x509_buf MBEDTLS_PRIVATE(sig);
     struct mbedtls_pkcs7_signer_info *MBEDTLS_PRIVATE(next);


### PR DESCRIPTION
Contributed by Joakim Sindholt <opensource@zhasha.com> under the terms of the DCO, so I've signed it off: see https://lists.trustedfirmware.org/archives/list/mbed-tls@lists.trustedfirmware.org/thread/WKW5ODIOQKM6FKLFOAEZEFAO47GOTMWU/

I have verified that this doesn't break the existing tests, but haven't done any other checking. It does conflict with the latest version so will need some work to update it, as well as to add tests.


## Gatekeeper checklist

- [ ] **changelog** TODO
- [ ] **backport** not required - not in 2.28
- [ ] **tests** TODO
