### PR TITLE
all.sh: Do not list unsupported cases

### DIFF
--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -3506,9 +3506,9 @@ component_build_armcc () {
     armc6_build_test "-O1 --target=aarch64-arm-none-eabi -march=armv8.2-a+crypto"
 }
 support_build_armcc () {
-    arm5_cc="$ARMC5_BIN_DIR/armcc"
-    arm6_cc="$ARMC6_BIN_DIR/armclang"
-    `check_tools "$arm5_cc" "$arm6_cc" > /dev/null 2>&1`
+    armc5_cc="$ARMC5_BIN_DIR/armcc"
+    armc6_cc="$ARMC6_BIN_DIR/armclang"
+    (check_tools "$armc5_cc" "$armc6_cc" > /dev/null 2>&1)
 }
 
 component_test_tls13_only () {

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -3506,9 +3506,11 @@ component_build_armcc () {
     armc6_build_test "-O1 --target=aarch64-arm-none-eabi -march=armv8.2-a+crypto"
 }
 support_build_armcc () {
-    arm5_cc="$ARMC5_BIN_DIR/armcc"
-    arm6_cc="$ARMC6_BIN_DIR/armclang"
-    `check_tools "$arm5_cc" "$arm6_cc" > /dev/null 2>&1`
+    armc5_cc="$ARMC5_BIN_DIR/armcc"
+    armc6_cc="$ARMC6_BIN_DIR/armclang"
+    # check if Arm Compiler is installed and license server is available.
+    ("$armc5_cc" --help > /dev/null 2>&1) && \
+    ("$armc6_cc" --help > /dev/null 2>&1)
 }
 
 component_test_tls13_only () {

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -3505,6 +3505,11 @@ component_build_armcc () {
     # ARM Compiler 6 - Target ARMv8.2-A - AArch64
     armc6_build_test "-O1 --target=aarch64-arm-none-eabi -march=armv8.2-a+crypto"
 }
+support_build_armcc () {
+    arm5_cc="$ARMC5_BIN_DIR/armcc"
+    arm6_cc="$ARMC6_BIN_DIR/armclang"
+    `check_tools "$arm5_cc" "$arm6_cc" > /dev/null 2>&1`
+}
 
 component_test_tls13_only () {
     msg "build: default config with MBEDTLS_SSL_PROTO_TLS1_3, without MBEDTLS_SSL_PROTO_TLS1_2"

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -3506,11 +3506,9 @@ component_build_armcc () {
     armc6_build_test "-O1 --target=aarch64-arm-none-eabi -march=armv8.2-a+crypto"
 }
 support_build_armcc () {
-    armc5_cc="$ARMC5_BIN_DIR/armcc"
-    armc6_cc="$ARMC6_BIN_DIR/armclang"
-    # check if Arm Compiler is installed and license server is available.
-    ("$armc5_cc" --help > /dev/null 2>&1) && \
-    ("$armc6_cc" --help > /dev/null 2>&1)
+    arm5_cc="$ARMC5_BIN_DIR/armcc"
+    arm6_cc="$ARMC6_BIN_DIR/armclang"
+    `check_tools "$arm5_cc" "$arm6_cc" > /dev/null 2>&1`
 }
 
 component_test_tls13_only () {

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -3647,8 +3647,8 @@ component_build_mingw () {
     make WINDOWS_BUILD=1 clean
 }
 support_build_mingw() {
-    case $(i686-w64-mingw32-gcc -dumpversion) in
-        [0-5]*) false;;
+    case $(i686-w64-mingw32-gcc -dumpversion 2>/dev/null) in
+        [0-5]*|"") false;;
         *) true;;
     esac
 }


### PR DESCRIPTION
## Description
We are going to sperate the Arm Compiler docker image from the main docker images in CI: https://github.com/Mbed-TLS/mbedtls-test/pull/96. 
The CI depends on `all.sh --list-components` for list of available case on a specific platform. However, `build_armcc` is always listed no metter if there are Arm Compilers or not. That causes the CI generate a job which runs `build_armcc` on a platform that is not installed with the tools.

This PR add support functions for `build_armcc` case, so that it would not be listed if there is no Arm Compiler detected.



## Gatekeeper checklist

- [x] **changelog** not required (test scripts only)
- [x] **backport** https://github.com/Mbed-TLS/mbedtls/pull/7204
- [x] **tests** N/A (test scripts only)

