### PR TITLE
Fix expected export length for Edwards curves in test suite.

### DIFF
--- a/tests/src/psa_exercise_key.c
+++ b/tests/src/psa_exercise_key.c
@@ -778,10 +778,10 @@ int mbedtls_test_psa_exported_key_sanity_check(
             /* The representation of an ECC Montgomery public key is
              * the raw compressed point */
             TEST_EQUAL(PSA_BITS_TO_BYTES(bits), exported_length);
-        } else if(PSA_KEY_TYPE_ECC_GET_FAMILY(type) == PSA_ECC_FAMILY_TWISTED_EDWARDS) {
+        } else if (PSA_KEY_TYPE_ECC_GET_FAMILY(type) == PSA_ECC_FAMILY_TWISTED_EDWARDS) {
             /* The representation of an ECC Edwards public key is
              * the raw compressed point */
-             TEST_EQUAL(PSA_BITS_TO_BYTES(bits + 1), exported_length);
+            TEST_EQUAL(PSA_BITS_TO_BYTES(bits + 1), exported_length);
         } else {
             /* The representation of an ECC Weierstrass public key is:
              *      - The byte 0x04;

--- a/tests/src/psa_exercise_key.c
+++ b/tests/src/psa_exercise_key.c
@@ -778,6 +778,10 @@ int mbedtls_test_psa_exported_key_sanity_check(
             /* The representation of an ECC Montgomery public key is
              * the raw compressed point */
             TEST_EQUAL(PSA_BITS_TO_BYTES(bits), exported_length);
+        } else if(PSA_KEY_TYPE_ECC_GET_FAMILY(type) == PSA_ECC_FAMILY_TWISTED_EDWARDS) {
+            /* The representation of an ECC Edwards public key is
+             * the raw compressed point */
+             TEST_EQUAL(PSA_BITS_TO_BYTES(bits + 1), exported_length);
         } else {
             /* The representation of an ECC Weierstrass public key is:
              *      - The byte 0x04;


### PR DESCRIPTION
## Description

The `mbedtls_test_psa_exported_key_sanity_check` required by `test_suite_psa_crypto_storage` expects a `size of 2 * keysize + 1` for all elliptic curve public keys except Montgomery type curves where the expected size is keysize. This PR adds another case for Edwards curves where the expected size is key size plus one extra bit.

## Gatekeeper checklist

- [ ] **changelog** provided, or not required
- [ ] **backport** done, or not required
- [ ] **tests** provided, or not required

Signed-off-by: Oberon microsystems AG, Zürich