### PR TITLE
Use MD (not low-level hash interface) in X.509 and TLS

### DIFF
--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -905,14 +905,14 @@ struct mbedtls_ssl_handshake_params {
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     psa_hash_operation_t fin_sha256_psa;
 #else
-    mbedtls_sha256_context fin_sha256;
+    mbedtls_md_context_t fin_sha256;
 #endif
 #endif
 #if defined(MBEDTLS_HAS_ALG_SHA_384_VIA_MD_OR_PSA_BASED_ON_USE_PSA)
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     psa_hash_operation_t fin_sha384_psa;
 #else
-    mbedtls_sha512_context fin_sha384;
+    mbedtls_md_context_t fin_sha384;
 #endif
 #endif
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -5782,23 +5782,23 @@ static int ssl_get_handshake_transcript_sha384(mbedtls_ssl_context *ssl,
                                                size_t *olen)
 {
     int ret;
-    mbedtls_md_context_t sha512;
+    mbedtls_md_context_t sha384;
 
     if (dst_len < 48) {
         return MBEDTLS_ERR_SSL_INTERNAL_ERROR;
     }
 
-    mbedtls_md_init(&sha512);
-    ret = mbedtls_md_setup(&sha512, mbedtls_md_info_from_type(MBEDTLS_MD_SHA384), 0);
+    mbedtls_md_init(&sha384);
+    ret = mbedtls_md_setup(&sha384, mbedtls_md_info_from_type(MBEDTLS_MD_SHA384), 0);
     if (ret != 0) {
         goto exit;
     }
-    ret = mbedtls_md_clone(&sha512, &ssl->handshake->fin_sha384);
+    ret = mbedtls_md_clone(&sha384, &ssl->handshake->fin_sha384);
     if (ret != 0) {
         goto exit;
     }
 
-    if ((ret = mbedtls_md_finish(&sha512, dst)) != 0) {
+    if ((ret = mbedtls_md_finish(&sha384, dst)) != 0) {
         MBEDTLS_SSL_DEBUG_RET(1, "mbedtls_md_finish", ret);
         goto exit;
     }
@@ -5807,7 +5807,7 @@ static int ssl_get_handshake_transcript_sha384(mbedtls_ssl_context *ssl,
 
 exit:
 
-    mbedtls_md_free(&sha512);
+    mbedtls_md_free(&sha384);
     return ret;
 }
 #endif /* MBEDTLS_HAS_ALG_SHA_384_VIA_MD_OR_PSA_BASED_ON_USE_PSA */
@@ -6690,22 +6690,22 @@ exit:
     return mbedtls_md_error_from_psa(status);
 #else
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
-    mbedtls_md_context_t sha512;
+    mbedtls_md_context_t sha384;
 
-    mbedtls_md_init(&sha512);
+    mbedtls_md_init(&sha384);
 
     MBEDTLS_SSL_DEBUG_MSG(2, ("=> calc verify sha384"));
 
-    ret = mbedtls_md_setup(&sha512, mbedtls_md_info_from_type(MBEDTLS_MD_SHA384), 0);
+    ret = mbedtls_md_setup(&sha384, mbedtls_md_info_from_type(MBEDTLS_MD_SHA384), 0);
     if (ret != 0) {
         goto exit;
     }
-    ret = mbedtls_md_clone(&sha512, &ssl->handshake->fin_sha384);
+    ret = mbedtls_md_clone(&sha384, &ssl->handshake->fin_sha384);
     if (ret != 0) {
         goto exit;
     }
 
-    ret = mbedtls_md_finish(&sha512, hash);
+    ret = mbedtls_md_finish(&sha384, hash);
     if (ret != 0) {
         goto exit;
     }
@@ -6716,7 +6716,7 @@ exit:
     MBEDTLS_SSL_DEBUG_MSG(2, ("<= calc verify"));
 
 exit:
-    mbedtls_md_free(&sha512);
+    mbedtls_md_free(&sha384);
     return ret;
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 }
@@ -7763,7 +7763,7 @@ static int ssl_calc_finished_tls_sha384(
     psa_status_t status;
 #else
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
-    mbedtls_md_context_t sha512;
+    mbedtls_md_context_t sha384;
 #endif
 
     mbedtls_ssl_session *session = ssl->session_negotiate;
@@ -7791,15 +7791,15 @@ static int ssl_calc_finished_tls_sha384(
     }
     MBEDTLS_SSL_DEBUG_BUF(3, "PSA calculated padbuf", padbuf, 48);
 #else
-    mbedtls_md_init(&sha512);
+    mbedtls_md_init(&sha384);
 
     MBEDTLS_SSL_DEBUG_MSG(2, ("=> calc  finished tls sha384"));
 
-    ret = mbedtls_md_setup(&sha512, mbedtls_md_info_from_type(MBEDTLS_MD_SHA384), 0);
+    ret = mbedtls_md_setup(&sha384, mbedtls_md_info_from_type(MBEDTLS_MD_SHA384), 0);
     if (ret != 0) {
         goto exit;
     }
-    ret = mbedtls_md_clone(&sha512, &ssl->handshake->fin_sha384);
+    ret = mbedtls_md_clone(&sha384, &ssl->handshake->fin_sha384);
     if (ret != 0) {
         goto exit;
     }
@@ -7810,7 +7810,7 @@ static int ssl_calc_finished_tls_sha384(
      *               Hash( handshake ) )[0.11]
      */
 
-    ret = mbedtls_md_finish(&sha512, padbuf);
+    ret = mbedtls_md_finish(&sha384, padbuf);
     if (ret != 0) {
         goto exit;
     }
@@ -7832,7 +7832,7 @@ exit:
     psa_hash_abort(&sha384_psa);
     return mbedtls_md_error_from_psa(status);
 #else
-    mbedtls_md_free(&sha512);
+    mbedtls_md_free(&sha384);
     return ret;
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 }

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -7675,16 +7675,13 @@ static int ssl_calc_finished_tls_sha256(
      *               Hash( handshake ) )[0.11]
      */
 
-#if !defined(MBEDTLS_SHA256_ALT)
-    MBEDTLS_SSL_DEBUG_BUF(4, "finished sha2 state", (unsigned char *)
-                          sha256.state, sizeof(sha256.state));
-#endif
-
     ret = mbedtls_sha256_finish(&sha256, padbuf);
     if (ret != 0) {
         goto exit;
     }
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
+
+    MBEDTLS_SSL_DEBUG_BUF(4, "finished sha256 output", padbuf, 32);
 
     ssl->handshake->tls_prf(session->master, 48, sender,
                             padbuf, 32, buf, len);
@@ -7760,15 +7757,13 @@ static int ssl_calc_finished_tls_sha384(
      *               Hash( handshake ) )[0.11]
      */
 
-#if !defined(MBEDTLS_SHA512_ALT)
-    MBEDTLS_SSL_DEBUG_BUF(4, "finished sha512 state", (unsigned char *)
-                          sha512.state, sizeof(sha512.state));
-#endif
     ret = mbedtls_sha512_finish(&sha512, padbuf);
     if (ret != 0) {
         goto exit;
     }
 #endif
+
+    MBEDTLS_SSL_DEBUG_BUF(4, "finished sha384 output", padbuf, 48);
 
     ssl->handshake->tls_prf(session->master, 48, sender,
                             padbuf, 48, buf, len);

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -839,6 +839,8 @@ int mbedtls_ssl_reset_checksum(mbedtls_ssl_context *ssl)
         return mbedtls_md_error_from_psa(status);
     }
 #else
+    mbedtls_md_free(&ssl->handshake->fin_sha256);
+    mbedtls_md_init(&ssl->handshake->fin_sha256);
     ret = mbedtls_md_setup(&ssl->handshake->fin_sha256,
                            mbedtls_md_info_from_type(MBEDTLS_MD_SHA256),
                            0);
@@ -862,6 +864,8 @@ int mbedtls_ssl_reset_checksum(mbedtls_ssl_context *ssl)
         return mbedtls_md_error_from_psa(status);
     }
 #else
+    mbedtls_md_free(&ssl->handshake->fin_sha384);
+    mbedtls_md_init(&ssl->handshake->fin_sha384);
     ret = mbedtls_md_setup(&ssl->handshake->fin_sha384,
                            mbedtls_md_info_from_type(MBEDTLS_MD_SHA384), 0);
     if (ret != 0) {

--- a/library/x509write_crt.c
+++ b/library/x509write_crt.c
@@ -32,7 +32,7 @@
 #include "mbedtls/error.h"
 #include "mbedtls/oid.h"
 #include "mbedtls/platform_util.h"
-#include "mbedtls/sha1.h"
+#include "mbedtls/md.h"
 
 #include <string.h>
 
@@ -229,8 +229,9 @@ static int mbedtls_x509write_crt_set_key_identifier(mbedtls_x509write_cert *ctx,
         return MBEDTLS_ERR_PLATFORM_HW_ACCEL_FAILED;
     }
 #else
-    ret = mbedtls_sha1(buf + sizeof(buf) - len, len,
-                       buf + sizeof(buf) - 20);
+    ret = mbedtls_md(mbedtls_md_info_from_type(MBEDTLS_MD_SHA1),
+                     buf + sizeof(buf) - len, len,
+                     buf + sizeof(buf) - 20);
     if (ret != 0) {
         return ret;
     }


### PR DESCRIPTION
This is part 1 of #6989 - X.509 and TLS.

(Part 2 will address PEM and RSA (self-test) but those don't already depend on `MD_C` so they will want to auto-enable `MD_LIGHT`, which depends on #7120.)

## Gatekeeper checklist

- [x] **changelog** not required - not user-visible
- [x] **backport** not required - prep work for a new feature
- [x] **tests** not required - covered by existing tests
