### PR TITLE
[Backport 2.28] Reduce the default MBEDTLS_ECP_WINDOW_SIZE value to 2

### DIFF
--- a/ChangeLog.d/mpi-window-perf
+++ b/ChangeLog.d/mpi-window-perf
@@ -1,0 +1,7 @@
+Changes
+   * Changed the default MBEDTLS_ECP_WINDOW_SIZE from 6 to 2.
+     As tested in issue 6790, the correlation between this define and
+     RSA decryption performance has changed lately due to security fixes.
+     To fix the performance degradation when using default values the
+     window was reduced from 6 to 2, a value that gives the best or close
+     to best results when tested on Cortex-M4 and Intel i7.

--- a/include/mbedtls/bignum.h
+++ b/include/mbedtls/bignum.h
@@ -66,7 +66,7 @@
 
 #if !defined(MBEDTLS_MPI_WINDOW_SIZE)
 /*
- * Maximum window size used for modular exponentiation. Default: 6
+ * Maximum window size used for modular exponentiation. Default: 2
  * Minimum value: 1. Maximum value: 6.
  *
  * Result is an array of ( 2 ** MBEDTLS_MPI_WINDOW_SIZE ) MPIs used
@@ -74,7 +74,7 @@
  *
  * Reduction in size, reduces speed.
  */
-#define MBEDTLS_MPI_WINDOW_SIZE                           6        /**< Maximum window size used. */
+#define MBEDTLS_MPI_WINDOW_SIZE                           2        /**< Maximum window size used. */
 #endif /* !MBEDTLS_MPI_WINDOW_SIZE */
 
 #if !defined(MBEDTLS_MPI_MAX_SIZE)

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -3749,7 +3749,7 @@
  * comment in the specific module. */
 
 /* MPI / BIGNUM options */
-//#define MBEDTLS_MPI_WINDOW_SIZE            6 /**< Maximum window size used. */
+//#define MBEDTLS_MPI_WINDOW_SIZE            2 /**< Maximum window size used. */
 //#define MBEDTLS_MPI_MAX_SIZE            1024 /**< Maximum number of bytes for usable MPIs. */
 
 /* CTR_DRBG options */


### PR DESCRIPTION
Backport of https://github.com/Mbed-TLS/mbedtls/pull/7169.
As tested in https://github.com/Mbed-TLS/mbedtls/issues/6790, after introducing side-channel counter-measures to bignum, the performance of RSA decryption in correlation to the MBEDTLS_ECP_WINDOW_SIZE has changed.
The default value of 2 has been chosen as it provides best or close-to-best results for tests on Cortex-M4 and Intel I-7.

## Gatekeeper checklist

- [x] **changelog** provided
- [x] **backport** this is the backport
- [x] **tests** not required



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

