### PR TITLE
Use platform-provided secure zeroization

### DIFF
--- a/ChangeLog.d/platform-zeroization.txt
+++ b/ChangeLog.d/platform-zeroization.txt
@@ -1,0 +1,3 @@
+Security
+  * Use platform-provided secure zeroization function where possible, such as
+    explicit_bzero().

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -88,7 +88,7 @@
  * mbedtls_platform_zeroize() to use a suitable implementation for their
  * platform and needs.
  */
- #if !defined(MBEDTLS_PLATFORM_HAS_EXPLICIT_BZERO) && !defined(__STDC_LIB_EXT1__) \
+#if !defined(MBEDTLS_PLATFORM_HAS_EXPLICIT_BZERO) && !defined(__STDC_LIB_EXT1__) \
     && !defined(_WIN32)
 static void *(*const volatile memset_func)(void *, int, size_t) = memset;
 #endif

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -35,7 +35,7 @@
 #include <stddef.h>
 
 #ifndef __STDC_WANT_LIB_EXT1__
-#define __STDC_WANT_LIB_EXT1__ 1
+#define __STDC_WANT_LIB_EXT1__ 1 /* Ask for the C11 gmtime_s() and memset_s() if available */
 #endif
 #include <string.h>
 
@@ -107,7 +107,6 @@ void mbedtls_platform_zeroize(void *buf, size_t len)
 #endif /* MBEDTLS_PLATFORM_ZEROIZE_ALT */
 
 #if defined(MBEDTLS_HAVE_TIME_DATE) && !defined(MBEDTLS_PLATFORM_GMTIME_R_ALT)
-#define __STDC_WANT_LIB_EXT1__ 1  /* Ask for the C11 gmtime_s() if it's available */
 #include <time.h>
 #if !defined(_WIN32) && (defined(unix) || \
     defined(__unix) || defined(__unix__) || (defined(__APPLE__) && \

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -48,7 +48,7 @@
     && !defined(__ARM_EABI__)
 #define MBEDTLS_PLATFORM_HAS_EXPLICIT_BZERO 1
 #endif
-#if defined(__FreeBSD__) && __FreeBSD_version >= 1100037
+#if defined(__FreeBSD__) && (__FreeBSD_version >= 1100037)
 #define MBEDTLS_PLATFORM_HAS_EXPLICIT_BZERO 1
 #endif
 #if defined(__NEWLIB__)

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -51,9 +51,6 @@
 #if defined(__FreeBSD__) && (__FreeBSD_version >= 1100037)
 #define MBEDTLS_PLATFORM_HAS_EXPLICIT_BZERO 1
 #endif
-#if defined(__NEWLIB__)
-#define MBEDTLS_PLATFORM_HAS_EXPLICIT_BZERO 1
-#endif
 
 #if !defined(MBEDTLS_PLATFORM_ZEROIZE_ALT)
 /*

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -76,7 +76,7 @@
  * (refer to http://www.daemonology.net/blog/2014-09-05-erratum.html for
  * details), optimizations of the following form are still possible:
  *
- * if(memset_func != memset)
+ * if (memset_func != memset)
  *     memset_func(buf, 0, len);
  *
  * Note that it is extremely difficult to guarantee that

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -44,7 +44,8 @@
 #endif
 
 // Detect platforms known to support explicit_bzero()
-#if defined(__GLIBC__) && (__GLIBC__ >= 2) && (__GLIBC_MINOR__ >= 25) && defined(__unix__)
+#if defined(__GLIBC__) && (__GLIBC__ >= 2) && (__GLIBC_MINOR__ >= 25) \
+    && !defined(__ARM_EABI__)
 #define MBEDTLS_PLATFORM_HAS_EXPLICIT_BZERO 1
 #endif
 #if defined(__FreeBSD__) && __FreeBSD_version >= 1100037

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -52,8 +52,7 @@
 #if defined(__GLIBC__) && (__GLIBC__ >= 2) && (__GLIBC_MINOR__ >= 25) \
     && !defined(__ARM_EABI__)
 #define MBEDTLS_PLATFORM_HAS_EXPLICIT_BZERO 1
-#endif
-#if defined(__FreeBSD__) && (__FreeBSD_version >= 1100037)
+#elif defined(__FreeBSD__) && (__FreeBSD_version >= 1100037)
 #define MBEDTLS_PLATFORM_HAS_EXPLICIT_BZERO 1
 #endif
 

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -95,7 +95,7 @@ void mbedtls_platform_zeroize(void *buf, size_t len)
     if (len > 0) {
 #if defined(MBEDTLS_PLATFORM_HAS_EXPLICIT_BZERO)
         explicit_bzero(buf, len);
-#elif(__STDC_LIB_EXT1__)
+#elif defined(__STDC_LIB_EXT1__)
         memset_s(buf, len, 0, len);
 #elif defined(_WIN32)
         SecureZeroMemory(buf, len);

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -49,8 +49,7 @@
 #endif
 
 // Detect platforms known to support explicit_bzero()
-#if defined(__GLIBC__) && (__GLIBC__ >= 2) && (__GLIBC_MINOR__ >= 25) \
-    && !defined(__ARM_EABI__)
+#if defined(__GLIBC__) && (__GLIBC__ >= 2) && (__GLIBC_MINOR__ >= 25)
 #define MBEDTLS_PLATFORM_HAS_EXPLICIT_BZERO 1
 #elif defined(__FreeBSD__) && (__FreeBSD_version >= 1100037)
 #define MBEDTLS_PLATFORM_HAS_EXPLICIT_BZERO 1

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -26,6 +26,11 @@
 #define _POSIX_C_SOURCE 200112L
 #endif
 
+#if !defined (_GNU_SOURCE)
+/* Clang requires this to get support for explicit_bzero */
+#define _GNU_SOURCE
+#endif
+
 #include "common.h"
 
 #include "mbedtls/platform_util.h"
@@ -84,7 +89,10 @@
  * mbedtls_platform_zeroize() to use a suitable implementation for their
  * platform and needs.
  */
+ #if !defined(MBEDTLS_PLATFORM_HAS_EXPLICIT_BZERO) && !defined(__STDC_LIB_EXT1__) \
+    && !defined(_WIN32)
 static void *(*const volatile memset_func)(void *, int, size_t) = memset;
+#endif
 
 void mbedtls_platform_zeroize(void *buf, size_t len)
 {

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -26,7 +26,7 @@
 #define _POSIX_C_SOURCE 200112L
 #endif
 
-#if !defined (_GNU_SOURCE)
+#if !defined(_GNU_SOURCE)
 /* Clang requires this to get support for explicit_bzero */
 #define _GNU_SOURCE
 #endif

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -45,7 +45,7 @@
 #include <string.h>
 
 #if defined(_WIN32)
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 // Detect platforms known to support explicit_bzero()

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -44,7 +44,7 @@
 #endif
 
 // Detect platforms known to support explicit_bzero()
-#if defined(__GLIBC__) && (__GLIBC__ >= 2) && (__GLIBC_MINOR__ >= 25)
+#if defined(__GLIBC__) && (__GLIBC__ >= 2) && (__GLIBC_MINOR__ >= 25) && defined(__unix__)
 #define MBEDTLS_PLATFORM_HAS_EXPLICIT_BZERO 1
 #endif
 #if defined(__FreeBSD__) && __FreeBSD_version >= 1100037

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -56,7 +56,12 @@
 
 #if !defined(MBEDTLS_PLATFORM_ZEROIZE_ALT)
 /*
- * This implementation should never be optimized out by the compiler
+ * Where possible, we try to detect the presence of a platform-provided
+ * secure memset, such as explicit_bzero(), that is safe against being optimized
+ * out, and use that.
+ *
+ * For other platforms, we provide an implementation that aims not to be
+ * optimized out by the compiler.
  *
  * This implementation for mbedtls_platform_zeroize() was inspired from Colin
  * Percival's blog article at:
@@ -71,11 +76,11 @@
  * (refer to http://www.daemonology.net/blog/2014-09-05-erratum.html for
  * details), optimizations of the following form are still possible:
  *
- * if( memset_func != memset )
- *     memset_func( buf, 0, len );
+ * if(memset_func != memset)
+ *     memset_func(buf, 0, len);
  *
  * Note that it is extremely difficult to guarantee that
- * mbedtls_platform_zeroize() will not be optimized out by aggressive compilers
+ * the memset() call will not be optimized out by aggressive compilers
  * in a portable way. For this reason, Mbed TLS also provides the configuration
  * option MBEDTLS_PLATFORM_ZEROIZE_ALT, which allows users to configure
  * mbedtls_platform_zeroize() to use a suitable implementation for their

--- a/tests/suites/test_suite_platform_util.data
+++ b/tests/suites/test_suite_platform_util.data
@@ -1,0 +1,23 @@
+Zeroize len 0, null
+mbedtls_platform_zeroize:0:1
+
+Zeroize len 0, non-null
+mbedtls_platform_zeroize:0:0
+
+Zeroize len 1
+mbedtls_platform_zeroize:1:0
+
+Zeroize len 4
+mbedtls_platform_zeroize:1:0
+
+Zeroize len 5
+mbedtls_platform_zeroize:1:0
+
+Zeroize len 32
+mbedtls_platform_zeroize:32:0
+
+Zeroize len 127
+mbedtls_platform_zeroize:127:0
+
+Zeroize len 128
+mbedtls_platform_zeroize:128:0

--- a/tests/suites/test_suite_platform_util.function
+++ b/tests/suites/test_suite_platform_util.function
@@ -1,0 +1,41 @@
+/* BEGIN_HEADER */
+#include "mbedtls/platform_util.h"
+/* END_HEADER */
+
+/* BEGIN_CASE */
+void mbedtls_platform_zeroize(int len, int null)
+{
+    char buf[130];
+    char *p = NULL;
+
+    TEST_ASSERT(len <= 128);
+
+    /* Write sentinel values */
+    buf[0] = 2;
+    buf[len + 1] = 2;
+
+    /* Write non-zero content */
+    if (!null) {
+        p = &buf[1];
+        for (int i = 0; i < len; i++) {
+            p[i] = 1;
+        }
+    }
+
+    /* Check content is non-zero */
+    TEST_EQUAL(buf[0], 2);
+    for (int i = 0; i < len; i++) {
+        TEST_ASSERT(p[i] == 1);
+    }
+    TEST_EQUAL(buf[len + 1], 2);
+
+    mbedtls_platform_zeroize(p, len);
+
+    /* Check content is zero and sentinels un-changed */
+    TEST_EQUAL(buf[0], 2);
+    for (int i = 0; i < len; i++) {
+        TEST_ASSERT(p[i] == 0);
+    }
+    TEST_EQUAL(buf[len + 1], 2);
+}
+/* END_CASE */


### PR DESCRIPTION
## Description

Use `explicit_bzero`, `memset_s`, or `SecureZeroMemory` where provided.

Fixes #1584 

## Gatekeeper checklist

- [x] **changelog** done
- [x] **backport** No, it's an enhancement, not a bug-fix
- [x] **tests** done (functional tests only, nothing to test that it can't be optimised away - this is hard as per #6229)


