### PR TITLE
Reorder crypto.h includes

### DIFF
--- a/include/psa/crypto.h
+++ b/include/psa/crypto.h
@@ -43,15 +43,15 @@
  * algorithms, key types, policies, etc. */
 #include "crypto_types.h"
 
- /* The file "crypto_values.h" declares macros to build and analyze values
+/* The file "crypto_values.h" declares macros to build and analyze values
  * of integral types defined in "crypto_types.h". */
 #include "crypto_values.h"
 
- /* The file "crypto_sizes.h" contains definitions for size calculation
+/* The file "crypto_sizes.h" contains definitions for size calculation
  * macros whose definitions are implementation-specific. */
 #include "crypto_sizes.h"
 
- /* The file "crypto_struct.h" contains definitions for
+/* The file "crypto_struct.h" contains definitions for
  * implementation-specific structs that are declared below. */
 #include "crypto_struct.h"
 

--- a/include/psa/crypto.h
+++ b/include/psa/crypto.h
@@ -39,13 +39,21 @@
 /**@}*/
 #endif /* __DOXYGEN_ONLY__ */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /* The file "crypto_types.h" declares types that encode errors,
  * algorithms, key types, policies, etc. */
 #include "crypto_types.h"
+
+ /* The file "crypto_values.h" declares macros to build and analyze values
+ * of integral types defined in "crypto_types.h". */
+#include "crypto_values.h"
+
+ /* The file "crypto_sizes.h" contains definitions for size calculation
+ * macros whose definitions are implementation-specific. */
+#include "crypto_sizes.h"
+
+ /* The file "crypto_struct.h" contains definitions for
+ * implementation-specific structs that are declared below. */
+#include "crypto_struct.h"
 
 /** \defgroup version API version
  * @{
@@ -63,9 +71,9 @@ extern "C" {
 
 /**@}*/
 
-/* The file "crypto_values.h" declares macros to build and analyze values
- * of integral types defined in "crypto_types.h". */
-#include "crypto_values.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /** \defgroup initialization Library initialization
  * @{
@@ -4670,14 +4678,6 @@ psa_status_t psa_verify_hash_abort(
 #ifdef __cplusplus
 }
 #endif
-
-/* The file "crypto_sizes.h" contains definitions for size calculation
- * macros whose definitions are implementation-specific. */
-#include "crypto_sizes.h"
-
-/* The file "crypto_struct.h" contains definitions for
- * implementation-specific structs that are declared above. */
-#include "crypto_struct.h"
 
 /* The file "crypto_extra.h" contains vendor-specific definitions. This
  * can include vendor-defined algorithms, extra functions, etc. */


### PR DESCRIPTION
## Description

The issue here was including crypto.h from C++ with MSVC gave errors

```
Error	C2526	'psa_aead_operation_init': C linkage function cannot return C++ class 'psa_aead_operation_s' 
   mbedtls\include\psa\crypto.h	2231
Error	C2371	'psa_aead_operation_init': redefinition; different basic types    mbedtls\include\psa\crypto_struct.h	204	
Error	C2556	'psa_aead_operation_s psa_aead_operation_init(void)': overloaded function differs only by return type from 'void psa_aead_operation_init(void)'    mbedtls\include\psa\crypto_struct.h	205	
```

The `C linkage function cannot return C++ class` error is misleading; I think it's more 'C linkage cannot return incomplete structure'. Moving the structure definitions in crypto_structs.h to before the function declarations fixes this. Note this only seems to be an issue with MSVC.


## Gatekeeper checklist

- [ ] **changelog** not required
- [ ] **backport** not required
- [ ] **tests** not required



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

