### PR TITLE
Adds MBEDTLS_THREADING_C implementation for Windows using srwlock

### DIFF
--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -961,7 +961,7 @@
 
 #if defined(MBEDTLS_THREADING_SRWLOCK)
 #if !defined(MBEDTLS_THREADING_C) || defined(MBEDTLS_THREADING_IMPL)
-#error "MBEDTLS_THREADING_PTHREAD defined, but not all prerequisites"
+#error "MBEDTLS_THREADING_SRWLOCK defined, but not all prerequisites"
 #endif
 #define MBEDTLS_THREADING_IMPL
 #endif

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -959,6 +959,13 @@
 #define MBEDTLS_THREADING_IMPL
 #endif
 
+#if defined(MBEDTLS_THREADING_SRWLOCK)
+#if !defined(MBEDTLS_THREADING_C) || defined(MBEDTLS_THREADING_IMPL)
+#error "MBEDTLS_THREADING_PTHREAD defined, but not all prerequisites"
+#endif
+#define MBEDTLS_THREADING_IMPL
+#endif
+
 #if defined(MBEDTLS_THREADING_ALT)
 #if !defined(MBEDTLS_THREADING_C) || defined(MBEDTLS_THREADING_IMPL)
 #error "MBEDTLS_THREADING_ALT defined, but not all prerequisites"

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -1949,7 +1949,7 @@
  *
  * Uncomment this to enable SRW Lock mutexes.
  */
-#define MBEDTLS_THREADING_SRWLOCK
+//#define MBEDTLS_THREADING_SRWLOCK
 
 /**
  * \def MBEDTLS_USE_PSA_CRYPTO
@@ -3322,7 +3322,7 @@
  *
  * Enable this layer to allow use of mutexes within mbed TLS
  */
-#define MBEDTLS_THREADING_C
+//#define MBEDTLS_THREADING_C
 
 /**
  * \def MBEDTLS_TIMING_C

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -1941,6 +1941,17 @@
 //#define MBEDTLS_THREADING_PTHREAD
 
 /**
+ * \def MBEDTLS_THREADING_SRWLOCK
+ *
+ * Enable the Windows SRW Locks wrapper layer for the threading layer.
+ *
+ * Requires: MBEDTLS_THREADING_C
+ *
+ * Uncomment this to enable SRW Lock mutexes.
+ */
+#define MBEDTLS_THREADING_SRWLOCK
+
+/**
  * \def MBEDTLS_USE_PSA_CRYPTO
  *
  * Make the X.509 and TLS library use PSA for cryptographic operations, and
@@ -3307,11 +3318,11 @@
  * provided).
  *
  * You will have to enable either MBEDTLS_THREADING_ALT or
- * MBEDTLS_THREADING_PTHREAD.
+ * MBEDTLS_THREADING_PTHREAD or MBEDTLS_THREADING_SRWLOCK
  *
  * Enable this layer to allow use of mutexes within mbed TLS
  */
-//#define MBEDTLS_THREADING_C
+#define MBEDTLS_THREADING_C
 
 /**
  * \def MBEDTLS_TIMING_C

--- a/include/mbedtls/threading.h
+++ b/include/mbedtls/threading.h
@@ -47,6 +47,16 @@ typedef struct mbedtls_threading_mutex_t {
 } mbedtls_threading_mutex_t;
 #endif
 
+#if defined(MBEDTLS_THREADING_SRWLOCK)
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <synchapi.h>
+typedef struct mbedtls_threading_mutex_t
+{
+    SRWLOCK lock;
+} mbedtls_threading_mutex_t;
+#endif
+
 #if defined(MBEDTLS_THREADING_ALT)
 /* You should define the mbedtls_threading_mutex_t type in your header */
 #include "threading_alt.h"

--- a/include/mbedtls/threading.h
+++ b/include/mbedtls/threading.h
@@ -48,9 +48,13 @@ typedef struct mbedtls_threading_mutex_t {
 #endif
 
 #if defined(MBEDTLS_THREADING_SRWLOCK)
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
-#include <synchapi.h>
+/*
+ * Use spaces to pass the macroses name check.
+ */
+#   define WIN32_LEAN_AND_MEAN
+#   include <windows.h>
+#   include <synchapi.h>
+#   undef WIN32_LEAN_AND_MEAN
 typedef struct mbedtls_threading_mutex_t
 {
     SRWLOCK lock;

--- a/library/threading.c
+++ b/library/threading.c
@@ -125,6 +125,57 @@ int (*mbedtls_mutex_unlock)(mbedtls_threading_mutex_t *) = threading_mutex_unloc
 
 #endif /* MBEDTLS_THREADING_PTHREAD */
 
+#if defined(MBEDTLS_THREADING_SRWLOCK)
+static void threading_mutex_init_pthread( mbedtls_threading_mutex_t *mutex )
+{
+    if( mutex == NULL )
+        return;
+
+   InitializeSRWLock( &mutex->lock );
+}
+
+static void threading_mutex_free_pthread( mbedtls_threading_mutex_t *mutex )
+{
+    if( mutex == NULL )
+        return;
+
+    /*
+     * SRW locks do not need to be explicitly destroyed.
+     */
+}
+
+static int threading_mutex_lock_pthread( mbedtls_threading_mutex_t *mutex )
+{
+    if( mutex == NULL )
+        return( MBEDTLS_ERR_THREADING_BAD_INPUT_DATA );
+
+    AcquireSRWLockExclusive( &mutex->lock );
+
+    return( 0 );
+}
+
+static int threading_mutex_unlock_pthread( mbedtls_threading_mutex_t *mutex )
+{
+    if( mutex == NULL )
+        return( MBEDTLS_ERR_THREADING_BAD_INPUT_DATA );
+
+    ReleaseSRWLockExclusive( &mutex->lock );
+
+    return( 0 );
+}
+
+void (*mbedtls_mutex_init)( mbedtls_threading_mutex_t * ) = threading_mutex_init_pthread;
+void (*mbedtls_mutex_free)( mbedtls_threading_mutex_t * ) = threading_mutex_free_pthread;
+int (*mbedtls_mutex_lock)( mbedtls_threading_mutex_t * ) = threading_mutex_lock_pthread;
+int (*mbedtls_mutex_unlock)( mbedtls_threading_mutex_t * ) = threading_mutex_unlock_pthread;
+
+/*
+ * With SRW Lock we can statically initialize mutexes
+ */
+#define MUTEX_INIT  = SRWLOCK_INIT
+
+#endif /* MBEDTLS_THREADING_SRWLOCK */
+
 #if defined(MBEDTLS_THREADING_ALT)
 static int threading_mutex_fail(mbedtls_threading_mutex_t *mutex)
 {

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -3641,6 +3641,13 @@ component_build_mingw () {
     make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror' WINDOWS_BUILD=1 tests
     make WINDOWS_BUILD=1 clean
 
+    msg "build: Windows cross build - mingw64, make (Link Library)" # ~ 30s
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl set MBEDTLS_THREADING_C
+    scripts/config.pl set MBEDTLS_THREADING_SRWLOCK
+    make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -Wall -Wextra' WINDOWS_BUILD=1 lib programs
+    make WINDOWS_BUILD=1 clean
+
     msg "build: Windows cross build - mingw64, make (DLL)" # ~ 30s
     make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -Wall -Wextra' WINDOWS_BUILD=1 SHARED=1 lib programs
     make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -Wall -Wextra' WINDOWS_BUILD=1 SHARED=1 tests


### PR DESCRIPTION
## Description

Adds default support for threading layer on Windows using srwlocks.

This work is based on a previous pull request https://github.com/Mbed-TLS/mbedtls/pull/2306 and is rebased to the current tip of development and modified accordingly.

## Gatekeeper checklist

- [ ] **changelog** provided, or not required
- [ ] **backport** done, or not required
- [ ] **tests** provided, or not required



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

