### PR TITLE
Interruptible {sign|verify} hash - Call complete() after start() failure.

### DIFF
--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -6662,6 +6662,12 @@ exit:
  * 3. Test that the number of ops done prior to start and after abort is zero
  *    and that each successful stage completes some ops (this is not mandated by
  *    the PSA specification, but is currently the case).
+ *
+ * 4. Check that calling complete() when start() fails and complete()
+ *    after completion results in a BAD_STATE error.
+ *
+ * 5. Check that calling start() again after start fails results in a BAD_STATE
+ *    error.
  */
 void sign_hash_fail_interruptible(int key_type_arg, data_t *key_data,
                                   int alg_arg, data_t *input_data,
@@ -6718,6 +6724,15 @@ void sign_hash_fail_interruptible(int key_type_arg, data_t *key_data,
     TEST_EQUAL(actual_status, expected_start_status);
 
     if (expected_start_status != PSA_SUCCESS) {
+        /* Emulate poor implementation, and call complete anyway, even though
+         * start failed. */
+        actual_status = psa_sign_hash_complete(&operation, signature,
+                                               signature_size,
+                                               &signature_length);
+
+        TEST_EQUAL(actual_status, PSA_ERROR_BAD_STATE);
+
+        /* Test that calling start again after failure also causes BAD_STATE. */
         actual_status = psa_sign_hash_start(&operation, key, alg,
                                             input_data->x, input_data->len);
 
@@ -7183,6 +7198,12 @@ exit:
  * 3. Test that the number of ops done prior to start and after abort is zero
  *    and that each successful stage completes some ops (this is not mandated by
  *    the PSA specification, but is currently the case).
+ *
+ * 4. Check that calling complete() when start() fails and complete()
+ *    after completion results in a BAD_STATE error.
+ *
+ * 5. Check that calling start() again after start fails results in a BAD_STATE
+ *    error.
  */
 void verify_hash_fail_interruptible(int key_type_arg, data_t *key_data,
                                     int alg_arg, data_t *hash_data,
@@ -7235,6 +7256,13 @@ void verify_hash_fail_interruptible(int key_type_arg, data_t *key_data,
     TEST_EQUAL(actual_status, expected_start_status);
 
     if (expected_start_status != PSA_SUCCESS) {
+        /* Emulate poor implementation, and call complete anyway, even though
+         * start failed. */
+        actual_status = psa_verify_hash_complete(&operation);
+
+        TEST_EQUAL(actual_status, PSA_ERROR_BAD_STATE);
+
+        /* Test that calling start again after failure also causes BAD_STATE. */
         actual_status = psa_verify_hash_start(&operation, key, alg,
                                               hash_data->x, hash_data->len,
                                               signature_data->x,

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -6724,7 +6724,7 @@ void sign_hash_fail_interruptible(int key_type_arg, data_t *key_data,
     TEST_EQUAL(actual_status, expected_start_status);
 
     if (expected_start_status != PSA_SUCCESS) {
-        /* Emulate poor implementation, and call complete anyway, even though
+        /* Emulate poor application code, and call complete anyway, even though
          * start failed. */
         actual_status = psa_sign_hash_complete(&operation, signature,
                                                signature_size,
@@ -7256,7 +7256,7 @@ void verify_hash_fail_interruptible(int key_type_arg, data_t *key_data,
     TEST_EQUAL(actual_status, expected_start_status);
 
     if (expected_start_status != PSA_SUCCESS) {
-        /* Emulate poor implementation, and call complete anyway, even though
+        /* Emulate poor application code, and call complete anyway, even though
          * start failed. */
         actual_status = psa_verify_hash_complete(&operation);
 


### PR DESCRIPTION
## Description

Add tests to check `{sign|verify}_complete()` will fail with `BAD_STATE` after a failing call to `{sign|verify}_start()`, to emulate a bad implementation that doesn't check its return values.

I was in the process of writing a separate test to test calling `{sign|verify}_start()` fails with `BAD_STATE` after a failing call to `{sign|verify}_start()`, but during this process this felt like more and more of a waste of time as its basically a complete duplicate of the current sign and verify failure tests (and I'm very conscious about adding new tests right now).

My reasoning is as follows: Calling `{sign|verify}_complete()` should not change the internal state in any way shape or form, if we are in a bad state. It should just report this fact and return, therefore it should not matter whether we have called `{sign|verify}_complete()` first or not, the test should still be valid to call `{sign|verify}_start()` again, and expect BAD_STATE. If you disagree with this, this is the place to argue about it.

## Gatekeeper checklist

- [x] **changelog** ~~provided, or~~ not required
- [x] **backport** ~~done, or~~ not required
- [x] **tests** ~~provided, or~~ not required
