### PR TITLE
Fix macro redefinition warning from armclang

### DIFF
--- a/library/alignment.h
+++ b/library/alignment.h
@@ -130,7 +130,7 @@ inline void mbedtls_put_unaligned_uint64(void *p, uint64_t x)
  * byte from x, where byte 0 is the least significant byte.
  */
 #define MBEDTLS_BYTE_0(x) ((uint8_t) ((x)         & 0xff))
-#define MBEDTLS_BYTE_1(x) ((uint8_t) (((x) >> 8) & 0xff))
+#define MBEDTLS_BYTE_1(x) ((uint8_t) (((x) >>  8) & 0xff))
 #define MBEDTLS_BYTE_2(x) ((uint8_t) (((x) >> 16) & 0xff))
 #define MBEDTLS_BYTE_3(x) ((uint8_t) (((x) >> 24) & 0xff))
 #define MBEDTLS_BYTE_4(x) ((uint8_t) (((x) >> 32) & 0xff))
@@ -245,8 +245,8 @@ static const uint16_t mbedtls_byte_order_detector = { 0x100 };
  *                  byte of the four bytes to build the 32 bits unsigned
  *                  integer from.
  */
-#define MBEDTLS_GET_UINT32_BE(data, offset)                              \
-    ((MBEDTLS_IS_BIG_ENDIAN)                                            \
+#define MBEDTLS_GET_UINT32_BE(data, offset)                                \
+    ((MBEDTLS_IS_BIG_ENDIAN)                                               \
         ? mbedtls_get_unaligned_uint32((data) + (offset))                  \
         : MBEDTLS_BSWAP32(mbedtls_get_unaligned_uint32((data) + (offset))) \
     )
@@ -260,11 +260,11 @@ static const uint16_t mbedtls_byte_order_detector = { 0x100 };
  * \param   offset  Offset from \p data where to put the most significant
  *                  byte of the 32 bits unsigned integer \p n.
  */
-#define MBEDTLS_PUT_UINT32_BE(n, data, offset)                             \
+#define MBEDTLS_PUT_UINT32_BE(n, data, offset)                                   \
     {                                                                            \
-        if (MBEDTLS_IS_BIG_ENDIAN)                                             \
+        if (MBEDTLS_IS_BIG_ENDIAN)                                               \
         {                                                                        \
-            mbedtls_put_unaligned_uint32((data) + (offset), (uint32_t) (n));      \
+            mbedtls_put_unaligned_uint32((data) + (offset), (uint32_t) (n));     \
         }                                                                        \
         else                                                                     \
         {                                                                        \
@@ -281,8 +281,8 @@ static const uint16_t mbedtls_byte_order_detector = { 0x100 };
  *                  byte of the four bytes to build the 32 bits unsigned
  *                  integer from.
  */
-#define MBEDTLS_GET_UINT32_LE(data, offset)                              \
-    ((MBEDTLS_IS_BIG_ENDIAN)                                            \
+#define MBEDTLS_GET_UINT32_LE(data, offset)                                \
+    ((MBEDTLS_IS_BIG_ENDIAN)                                               \
         ? MBEDTLS_BSWAP32(mbedtls_get_unaligned_uint32((data) + (offset))) \
         : mbedtls_get_unaligned_uint32((data) + (offset))                  \
     )
@@ -297,15 +297,15 @@ static const uint16_t mbedtls_byte_order_detector = { 0x100 };
  * \param   offset  Offset from \p data where to put the least significant
  *                  byte of the 32 bits unsigned integer \p n.
  */
-#define MBEDTLS_PUT_UINT32_LE(n, data, offset)                             \
+#define MBEDTLS_PUT_UINT32_LE(n, data, offset)                                   \
     {                                                                            \
-        if (MBEDTLS_IS_BIG_ENDIAN)                                             \
+        if (MBEDTLS_IS_BIG_ENDIAN)                                               \
         {                                                                        \
             mbedtls_put_unaligned_uint32((data) + (offset), MBEDTLS_BSWAP32((uint32_t) (n))); \
         }                                                                        \
         else                                                                     \
         {                                                                        \
-            mbedtls_put_unaligned_uint32((data) + (offset), ((uint32_t) (n)));      \
+            mbedtls_put_unaligned_uint32((data) + (offset), ((uint32_t) (n)));   \
         }                                                                        \
     }
 
@@ -318,8 +318,8 @@ static const uint16_t mbedtls_byte_order_detector = { 0x100 };
  *                  byte of the two bytes to build the 16 bits unsigned
  *                  integer from.
  */
-#define MBEDTLS_GET_UINT16_LE(data, offset)                              \
-    ((MBEDTLS_IS_BIG_ENDIAN)                                            \
+#define MBEDTLS_GET_UINT16_LE(data, offset)                                \
+    ((MBEDTLS_IS_BIG_ENDIAN)                                               \
         ? MBEDTLS_BSWAP16(mbedtls_get_unaligned_uint16((data) + (offset))) \
         : mbedtls_get_unaligned_uint16((data) + (offset))                  \
     )
@@ -333,15 +333,15 @@ static const uint16_t mbedtls_byte_order_detector = { 0x100 };
  * \param   offset  Offset from \p data where to put the least significant
  *                  byte of the 16 bits unsigned integer \p n.
  */
-#define MBEDTLS_PUT_UINT16_LE(n, data, offset)                             \
+#define MBEDTLS_PUT_UINT16_LE(n, data, offset)                                   \
     {                                                                            \
-        if (MBEDTLS_IS_BIG_ENDIAN)                                             \
+        if (MBEDTLS_IS_BIG_ENDIAN)                                               \
         {                                                                        \
             mbedtls_put_unaligned_uint16((data) + (offset), MBEDTLS_BSWAP16((uint16_t) (n))); \
         }                                                                        \
         else                                                                     \
         {                                                                        \
-            mbedtls_put_unaligned_uint16((data) + (offset), (uint16_t) (n));      \
+            mbedtls_put_unaligned_uint16((data) + (offset), (uint16_t) (n));     \
         }                                                                        \
     }
 
@@ -354,8 +354,8 @@ static const uint16_t mbedtls_byte_order_detector = { 0x100 };
  *                  byte of the two bytes to build the 16 bits unsigned
  *                  integer from.
  */
-#define MBEDTLS_GET_UINT16_BE(data, offset)                              \
-    ((MBEDTLS_IS_BIG_ENDIAN)                                            \
+#define MBEDTLS_GET_UINT16_BE(data, offset)                                \
+    ((MBEDTLS_IS_BIG_ENDIAN)                                               \
         ? mbedtls_get_unaligned_uint16((data) + (offset))                  \
         : MBEDTLS_BSWAP16(mbedtls_get_unaligned_uint16((data) + (offset))) \
     )
@@ -369,11 +369,11 @@ static const uint16_t mbedtls_byte_order_detector = { 0x100 };
  * \param   offset  Offset from \p data where to put the most significant
  *                  byte of the 16 bits unsigned integer \p n.
  */
-#define MBEDTLS_PUT_UINT16_BE(n, data, offset)                             \
+#define MBEDTLS_PUT_UINT16_BE(n, data, offset)                                   \
     {                                                                            \
-        if (MBEDTLS_IS_BIG_ENDIAN)                                             \
+        if (MBEDTLS_IS_BIG_ENDIAN)                                               \
         {                                                                        \
-            mbedtls_put_unaligned_uint16((data) + (offset), (uint16_t) (n));      \
+            mbedtls_put_unaligned_uint16((data) + (offset), (uint16_t) (n));     \
         }                                                                        \
         else                                                                     \
         {                                                                        \
@@ -390,11 +390,11 @@ static const uint16_t mbedtls_byte_order_detector = { 0x100 };
  *                  byte of the three bytes to build the 24 bits unsigned
  *                  integer from.
  */
-#define MBEDTLS_GET_UINT24_BE(data, offset)                  \
-    (                                                           \
-        ((uint32_t) (data)[(offset)] << 16)         \
-        | ((uint32_t) (data)[(offset) + 1] << 8)         \
-        | ((uint32_t) (data)[(offset) + 2])         \
+#define MBEDTLS_GET_UINT24_BE(data, offset)        \
+    (                                              \
+        ((uint32_t) (data)[(offset)] << 16)        \
+        | ((uint32_t) (data)[(offset) + 1] << 8)   \
+        | ((uint32_t) (data)[(offset) + 2])        \
     )
 
 /**
@@ -407,8 +407,8 @@ static const uint16_t mbedtls_byte_order_detector = { 0x100 };
  *                  byte of the 24 bits unsigned integer \p n.
  */
 #define MBEDTLS_PUT_UINT24_BE(n, data, offset)                \
-    {                                                               \
-        (data)[(offset)] = MBEDTLS_BYTE_2(n);             \
+    {                                                         \
+        (data)[(offset)] = MBEDTLS_BYTE_2(n);                 \
         (data)[(offset) + 1] = MBEDTLS_BYTE_1(n);             \
         (data)[(offset) + 2] = MBEDTLS_BYTE_0(n);             \
     }
@@ -422,9 +422,9 @@ static const uint16_t mbedtls_byte_order_detector = { 0x100 };
  *                  byte of the three bytes to build the 24 bits unsigned
  *                  integer from.
  */
-#define MBEDTLS_GET_UINT24_LE(data, offset)                   \
-    (                                                           \
-        ((uint32_t) (data)[(offset)])         \
+#define MBEDTLS_GET_UINT24_LE(data, offset)               \
+    (                                                     \
+        ((uint32_t) (data)[(offset)])                     \
         | ((uint32_t) (data)[(offset) + 1] <<  8)         \
         | ((uint32_t) (data)[(offset) + 2] << 16)         \
     )
@@ -439,8 +439,8 @@ static const uint16_t mbedtls_byte_order_detector = { 0x100 };
  *                  byte of the 24 bits unsigned integer \p n.
  */
 #define MBEDTLS_PUT_UINT24_LE(n, data, offset)                \
-    {                                                               \
-        (data)[(offset)] = MBEDTLS_BYTE_0(n);             \
+    {                                                         \
+        (data)[(offset)] = MBEDTLS_BYTE_0(n);                 \
         (data)[(offset) + 1] = MBEDTLS_BYTE_1(n);             \
         (data)[(offset) + 2] = MBEDTLS_BYTE_2(n);             \
     }
@@ -454,8 +454,8 @@ static const uint16_t mbedtls_byte_order_detector = { 0x100 };
  *                  byte of the eight bytes to build the 64 bits unsigned
  *                  integer from.
  */
-#define MBEDTLS_GET_UINT64_BE(data, offset)                              \
-    ((MBEDTLS_IS_BIG_ENDIAN)                                            \
+#define MBEDTLS_GET_UINT64_BE(data, offset)                                \
+    ((MBEDTLS_IS_BIG_ENDIAN)                                               \
         ? mbedtls_get_unaligned_uint64((data) + (offset))                  \
         : MBEDTLS_BSWAP64(mbedtls_get_unaligned_uint64((data) + (offset))) \
     )
@@ -469,11 +469,11 @@ static const uint16_t mbedtls_byte_order_detector = { 0x100 };
  * \param   offset  Offset from \p data where to put the most significant
  *                  byte of the 64 bits unsigned integer \p n.
  */
-#define MBEDTLS_PUT_UINT64_BE(n, data, offset)                             \
+#define MBEDTLS_PUT_UINT64_BE(n, data, offset)                                   \
     {                                                                            \
-        if (MBEDTLS_IS_BIG_ENDIAN)                                             \
+        if (MBEDTLS_IS_BIG_ENDIAN)                                               \
         {                                                                        \
-            mbedtls_put_unaligned_uint64((data) + (offset), (uint64_t) (n));      \
+            mbedtls_put_unaligned_uint64((data) + (offset), (uint64_t) (n));     \
         }                                                                        \
         else                                                                     \
         {                                                                        \
@@ -490,8 +490,8 @@ static const uint16_t mbedtls_byte_order_detector = { 0x100 };
  *                  byte of the eight bytes to build the 64 bits unsigned
  *                  integer from.
  */
-#define MBEDTLS_GET_UINT64_LE(data, offset)                              \
-    ((MBEDTLS_IS_BIG_ENDIAN)                                            \
+#define MBEDTLS_GET_UINT64_LE(data, offset)                                \
+    ((MBEDTLS_IS_BIG_ENDIAN)                                               \
         ? MBEDTLS_BSWAP64(mbedtls_get_unaligned_uint64((data) + (offset))) \
         : mbedtls_get_unaligned_uint64((data) + (offset))                  \
     )
@@ -505,15 +505,15 @@ static const uint16_t mbedtls_byte_order_detector = { 0x100 };
  * \param   offset  Offset from \p data where to put the least significant
  *                  byte of the 64 bits unsigned integer \p n.
  */
-#define MBEDTLS_PUT_UINT64_LE(n, data, offset)                             \
+#define MBEDTLS_PUT_UINT64_LE(n, data, offset)                                   \
     {                                                                            \
-        if (MBEDTLS_IS_BIG_ENDIAN)                                             \
+        if (MBEDTLS_IS_BIG_ENDIAN)                                               \
         {                                                                        \
             mbedtls_put_unaligned_uint64((data) + (offset), MBEDTLS_BSWAP64((uint64_t) (n))); \
         }                                                                        \
         else                                                                     \
         {                                                                        \
-            mbedtls_put_unaligned_uint64((data) + (offset), (uint64_t) (n));      \
+            mbedtls_put_unaligned_uint64((data) + (offset), (uint64_t) (n));     \
         }                                                                        \
     }
 

--- a/library/alignment.h
+++ b/library/alignment.h
@@ -155,13 +155,13 @@ inline void mbedtls_put_unaligned_uint64(void *p, uint64_t x)
  * Detect Clang built-in byteswap routines
  */
 #if defined(__clang__) && defined(__has_builtin)
-#if __has_builtin(__builtin_bswap16)
+#if __has_builtin(__builtin_bswap16) && !defined(MBEDTLS_BSWAP16)
 #define MBEDTLS_BSWAP16 __builtin_bswap16
 #endif /* __has_builtin(__builtin_bswap16) */
-#if __has_builtin(__builtin_bswap32)
+#if __has_builtin(__builtin_bswap32) && !defined(MBEDTLS_BSWAP32)
 #define MBEDTLS_BSWAP32 __builtin_bswap32
 #endif /* __has_builtin(__builtin_bswap32) */
-#if __has_builtin(__builtin_bswap64)
+#if __has_builtin(__builtin_bswap64) && !defined(MBEDTLS_BSWAP64)
 #define MBEDTLS_BSWAP64 __builtin_bswap64
 #endif /* __has_builtin(__builtin_bswap64) */
 #endif /* defined(__clang__) && defined(__has_builtin) */
@@ -170,13 +170,19 @@ inline void mbedtls_put_unaligned_uint64(void *p, uint64_t x)
  * Detect MSVC built-in byteswap routines
  */
 #if defined(_MSC_VER)
+#if !defined(MBEDTLS_BSWAP16)
 #define MBEDTLS_BSWAP16 _byteswap_ushort
+#endif
+#if !defined(MBEDTLS_BSWAP32)
 #define MBEDTLS_BSWAP32 _byteswap_ulong
+#endif
+#if !defined(MBEDTLS_BSWAP64)
 #define MBEDTLS_BSWAP64 _byteswap_uint64
+#endif
 #endif /* defined(_MSC_VER) */
 
 /* Detect armcc built-in byteswap routine */
-#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 410000)
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 410000) && !defined(MBEDTLS_BSWAP32)
 #define MBEDTLS_BSWAP32 __rev
 #endif
 


### PR DESCRIPTION
## Description

Avoid redefining the MBEDTLS_BSWAPxx macros for compilers which support multiple options, such as armclang.

Fixes some of #7186 

## Gatekeeper checklist

- [x] **changelog** not required (not previously released)
- [x] **backport** not required - not in 2.28
- [x] **tests** not required

