### PR TITLE
Fix test conditions because PURE_EDDSA does not support sign_hash

### DIFF
--- a/tests/src/psa_exercise_key.c
+++ b/tests/src/psa_exercise_key.c
@@ -295,7 +295,8 @@ static int exercise_signature_key(mbedtls_svc_key_id_t key,
                                   psa_key_usage_t usage,
                                   psa_algorithm_t alg)
 {
-    if (usage & (PSA_KEY_USAGE_SIGN_HASH | PSA_KEY_USAGE_VERIFY_HASH)) {
+    if (usage & (PSA_KEY_USAGE_SIGN_HASH | PSA_KEY_USAGE_VERIFY_HASH) &&
+        PSA_ALG_IS_SIGN_HASH(alg)) {
         unsigned char payload[PSA_HASH_MAX_SIZE] = { 1 };
         size_t payload_length = 16;
         unsigned char signature[PSA_SIGNATURE_MAX_SIZE] = { 0 };


### PR DESCRIPTION
## Description

If test function `key_storage_read()` in `test_suite_psa_crypto_storage_format.function` is called with algorithm `PSA_ALG_PURE_EDDSA`, this leads to a call of `psa_sign_hash()` in `psa_exercise_key.c`. Pure EDDSA can only be used with `psa_sign_message()`.

## Gatekeeper checklist

- [ ] **changelog** provided, or not required
- [ ] **backport** done, or not required
- [ ] **tests** provided, or not required

Signed-off-by: Oberon microsystems AG, Zürich