### PR TITLE
Fix nonstandard C++ in headers

### DIFF
--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -1823,18 +1823,6 @@ psa_status_t psa_pake_abort(psa_pake_operation_t *operation);
  */
 #define PSA_PAKE_CIPHER_SUITE_INIT { PSA_ALG_NONE, 0, 0, 0, PSA_ALG_NONE }
 
-/** Returns a suitable initializer for a PAKE operation object of type
- * psa_pake_operation_t.
- */
-#if defined(MBEDTLS_PSA_BUILTIN_PAKE)
-#define PSA_PAKE_OPERATION_INIT { PSA_ALG_NONE, 0, 0, 0, 0,              \
-                                  NULL, 0,               \
-                                  PSA_PAKE_ROLE_NONE, { 0 }, 0, 0,         \
-                                  { .dummy = 0 } }
-#else
-#define PSA_PAKE_OPERATION_INIT { PSA_ALG_NONE, 0, 0, { 0 } }
-#endif
-
 struct psa_pake_cipher_suite_s {
     psa_algorithm_t algorithm;
     psa_pake_primitive_type_t type;
@@ -1927,13 +1915,26 @@ struct psa_pake_operation_s {
     size_t MBEDTLS_PRIVATE(buffer_offset);
 #endif
     union {
+        /* A variant that's easy to initialize.
+         * Also, make the union non-empty even with no supported algorithms. */
+        uint8_t dummy;
 #if defined(MBEDTLS_PSA_BUILTIN_ALG_JPAKE)
         mbedtls_ecjpake_context ecjpake;
 #endif
-        /* Make the union non-empty even with no supported algorithms. */
-        uint8_t dummy;
     } MBEDTLS_PRIVATE(ctx);
 };
+
+/** Returns a suitable initializer for a PAKE operation object of type
+ * psa_pake_operation_t.
+ */
+#if defined(MBEDTLS_PSA_BUILTIN_PAKE)
+#define PSA_PAKE_OPERATION_INIT                 \
+    { PSA_ALG_NONE, 0, 0,                       \
+      0, 0, NULL, 0, 0, { 0 } , 0, 0,           \
+      { 0 } }
+#else
+#define PSA_PAKE_OPERATION_INIT { PSA_ALG_NONE, 0, 0, { 0 } }
+#endif
 
 static inline struct psa_pake_cipher_suite_s psa_pake_cipher_suite_init(void)
 {

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -3196,7 +3196,7 @@ component_test_cmake_shared () {
 }
 
 test_build_opt () {
-    info=$1 cc=$2; shift 2
+    info=$1 cc=$2 cxx=$3; shift 3
     for opt in "$@"; do
           msg "build/test: $cc $opt, $info" # ~ 30s
           make CC="$cc" CFLAGS="$opt -std=c99 -pedantic -Wall -Wextra -Werror"
@@ -3205,18 +3205,23 @@ test_build_opt () {
           # optimizations use inline assembly whereas runs with -O0
           # skip inline assembly.
           make test # ~30s
+          if [ -n "$cxx" ]; then
+              make TEST_CPP=1 CXX="$cxx" CFLAGS="$opt -std=c++11 -pedantic -Wall -Wextra -Werror"
+              programs/test/cpp_dummy_build
+          fi
           make clean
     done
 }
 
 component_test_clang_opt () {
     scripts/config.py full
-    test_build_opt 'full config' clang -O0 -Os -O2
+    # clang++ is not yet present on our CI images
+    test_build_opt 'full config' clang '' -O0 -Os -O2
 }
 
 component_test_gcc_opt () {
     scripts/config.py full
-    test_build_opt 'full config' gcc -O0 -Os -O2
+    test_build_opt 'full config' gcc g++ -O0 -Os -O2
 }
 
 component_build_mbedtls_config_file () {


### PR DESCRIPTION
Fix some code in header files that is standard C99, but not standard C++11.

I use C++11 as the cutoff because Mbed TLS headers have never been pedantically compliant C++98 due to the use of commas at the end of enumerator lists (and perhaps other features).

This is work in progress addressing https://github.com/Mbed-TLS/mbedtls/issues/7087. It fixes the initializers, but not the problem with linkage of functions that return structs.

## Gatekeeper checklist

- [ ] **changelog** TODO
- [ ] **backport** TODO
- [ ] **tests** provided (g++ only, we don't yet have clang++ on our CI images)
