### PR TITLE
Enable -Werror in all.sh for armclang

### DIFF
--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -3480,7 +3480,12 @@ component_build_armcc () {
     # armc[56] don't support SHA-512 intrinsics
     scripts/config.py unset MBEDTLS_SHA512_USE_A64_CRYPTO_IF_PRESENT
 
-    # stop armclang warning about feature detection for A64_CRYPTO
+    # Stop armclang warning about feature detection for A64_CRYPTO.
+    # With this enabled, the library does build correctly under armclang,
+    # but in baremetal builds (as tested here), feature detection is
+    # unavailable, and the user is notified via a #warning. So enabling
+    # this feature would prevent us from building with -Werror on
+    # armclang. Tracked in #7198.
     scripts/config.py unset MBEDTLS_SHA256_USE_A64_CRYPTO_IF_PRESENT
 
     scripts/config.py set MBEDTLS_HAVE_ASM

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -3479,6 +3479,10 @@ component_build_armcc () {
     scripts/config.py baremetal
     # armc[56] don't support SHA-512 intrinsics
     scripts/config.py unset MBEDTLS_SHA512_USE_A64_CRYPTO_IF_PRESENT
+
+    # stop armclang warning about feature detection for A64_CRYPTO
+    scripts/config.py unset MBEDTLS_SHA256_USE_A64_CRYPTO_IF_PRESENT
+
     scripts/config.py set MBEDTLS_HAVE_ASM
 
     make CC="$ARMC5_CC" AR="$ARMC5_AR" WARNING_CFLAGS='--strict --c99' lib

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -388,7 +388,7 @@ armc6_build_test()
 
     msg "build: ARM Compiler 6 ($FLAGS)"
     ARM_TOOL_VARIANT="ult" CC="$ARMC6_CC" AR="$ARMC6_AR" CFLAGS="$FLAGS" \
-                    WARNING_CFLAGS='-xc -std=c99' make lib
+                    WARNING_CFLAGS='-Werror -xc -std=c99' make lib
 
     msg "size: ARM Compiler 6 ($FLAGS)"
     "$ARMC6_FROMELF" -z library/*.o


### PR DESCRIPTION
## Description

Suppress a warning from armclang builds in all.sh. This allows all.sh to turn on -Werror for armclang builds.

Partial fix for #7186 

## Gatekeeper checklist

- [x] **changelog** not required
- [x] **backport** done: #7199 
- [x] **tests** not required