### PR TITLE
Backport 2.28: enable -Werror for armclang

### DIFF
--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -376,7 +376,7 @@ armc6_build_test()
 
     msg "build: ARM Compiler 6 ($FLAGS)"
     ARM_TOOL_VARIANT="ult" CC="$ARMC6_CC" AR="$ARMC6_AR" CFLAGS="$FLAGS" \
-                    WARNING_CFLAGS='-xc -std=c99' make lib
+                    WARNING_CFLAGS='-Werror -xc -std=c99' make lib
 
     msg "size: ARM Compiler 6 ($FLAGS)"
     "$ARMC6_FROMELF" -z library/*.o


### PR DESCRIPTION
## Description

Backport of #7197  (the only relevant part is enabling -Werror)

## Gatekeeper checklist

- [x] **changelog** not required
- [x] **backport** done
- [x] **tests** not required


