### PR TITLE
Add CPU modifier for AESCE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,8 +89,11 @@ jobs:
           packages:
           - gcc
       script:
-        # Do a manual build+test sequence rather than using all.sh, because
-        # there's no all.sh component that does what we want.
+        # Do a manual build+test sequence rather than using all.sh.
+        #
+        # On Arm64 host of Travis CI, the time of `test_full_cmake_*` exceeds
+        # limitation of Travis CI. Base on `test_full_cmake_*`, we removed
+        # `ssl-opt.sh` and GnuTLS compat.sh here to meet the time limitation.
         - scripts/config.py full
         - make generated_files
         - make CFLAGS='-O3 -Werror -fsanitize=address,undefined -fno-sanitize-recover=all' LDFLAGS='-Werror -fsanitize=address,undefined -fno-sanitize-recover=all'
@@ -112,8 +115,11 @@ jobs:
           - clang
           - gnutls-bin
       script:
-        # Do a manual build+test sequence rather than using all.sh, because
-        # there's no all.sh component that does what we want.
+        # Do a manual build+test sequence rather than using all.sh.
+        #
+        # On Arm64 host of Travis CI, the time of `test_full_cmake_*` exceeds
+        # limitation of Travis CI. Base on `test_full_cmake_*`, we removed
+        # `ssl-opt.sh` and OpenSSl compat.sh here to meet the time limitation.
         - scripts/config.py full
         - make generated_files
         - make CC=clang CFLAGS='-O3 -Werror -fsanitize=address,undefined -fno-sanitize-recover=all' LDFLAGS='-Werror -fsanitize=address,undefined -fno-sanitize-recover=all'

--- a/.travis.yml
+++ b/.travis.yml
@@ -90,15 +90,10 @@ jobs:
           - gcc
       script:
         # Do a manual build+test sequence rather than using all.sh, because
-        # there's no all.sh component that does what we want. We should set
-        # CFLAGS for arm64 host CC.
+        # there's no all.sh component that does what we want.
         - scripts/config.py full
-        - scripts/config.py unset MBEDTLS_SHA512_USE_A64_CRYPTO_IF_PRESENT
-        - scripts/config.py unset MBEDTLS_SHA512_USE_A64_CRYPTO_ONLY
-        - scripts/config.py unset MBEDTLS_SHA256_USE_A64_CRYPTO_IF_PRESENT
-        - scripts/config.py unset MBEDTLS_SHA256_USE_A64_CRYPTO_ONLY
         - make generated_files
-        - make CFLAGS='-march=armv8-a+crypto -O3 -Werror -fsanitize=address,undefined -fno-sanitize-recover=all' LDFLAGS='-Werror -fsanitize=address,undefined -fno-sanitize-recover=all'
+        - make CFLAGS='-O3 -Werror -fsanitize=address,undefined -fno-sanitize-recover=all' LDFLAGS='-Werror -fsanitize=address,undefined -fno-sanitize-recover=all'
         - make test
         - programs/test/selftest
         - tests/scripts/test_psa_constant_names.py
@@ -118,15 +113,10 @@ jobs:
           - gnutls-bin
       script:
         # Do a manual build+test sequence rather than using all.sh, because
-        # there's no all.sh component that does what we want. We should set
-        # CFLAGS for arm64 host CC.
+        # there's no all.sh component that does what we want.
         - scripts/config.py full
-        - scripts/config.py unset MBEDTLS_SHA512_USE_A64_CRYPTO_IF_PRESENT
-        - scripts/config.py unset MBEDTLS_SHA512_USE_A64_CRYPTO_ONLY
-        - scripts/config.py unset MBEDTLS_SHA256_USE_A64_CRYPTO_IF_PRESENT
-        - scripts/config.py unset MBEDTLS_SHA256_USE_A64_CRYPTO_ONLY
         - make generated_files
-        - make CC=clang CFLAGS='-march=armv8-a+crypto -O3 -Werror -fsanitize=address,undefined -fno-sanitize-recover=all' LDFLAGS='-Werror -fsanitize=address,undefined -fno-sanitize-recover=all'
+        - make CC=clang CFLAGS='-O3 -Werror -fsanitize=address,undefined -fno-sanitize-recover=all' LDFLAGS='-Werror -fsanitize=address,undefined -fno-sanitize-recover=all'
         # GnuTLS supports CAMELLIA but compat.sh doesn't properly enable it.
         - tests/compat.sh -p GnuTLS -e 'CAMELLIA'
         - tests/scripts/travis-log-failure.sh

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -2039,17 +2039,6 @@
  *
  * Requires: MBEDTLS_HAVE_ASM, MBEDTLS_AES_C
  *
- * \note The code uses Neon intrinsics, so \c CFLAGS must be set to a minimum
- * of \c -march=armv8-a+crypto .
- *
- * \warning If the target architecture is set to something that includes the
- *          SHA3 feature (e.g. `-march=armv8.2-a+sha3`), for example because
- *          `MBEDTLS_SHA512_USE_A64_CRYPTO_IF_PRESENT` is desired, compilers
- *          generate code for `MBEDTLS_AESCE_C` that includes instructions
- *          only present with the (optional) SHA3 feature. This will lead to an
- *          undefined instruction exception if the code is run on a CPU without
- *          that feature.
- *
  * \warning Runtime detection only works on linux. For non-linux operation
  *          system, crypto extension MUST be supported by CPU.
  *

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -2042,9 +2042,6 @@
  * \warning Runtime detection only works on linux. For non-linux operation
  *          system, crypto extension MUST be supported by CPU.
  *
- * \warning This option is experimental. For time being, we can not guarantee
- *          it with CI tests.
- *
  * This module adds support for the AES crypto instructions on Arm64
  */
 #define MBEDTLS_AESCE_C
@@ -3074,9 +3071,6 @@
  * \warning MBEDTLS_SHA256_USE_A64_CRYPTO_IF_PRESENT cannot be defined at the
  * same time as MBEDTLS_SHA256_USE_A64_CRYPTO_ONLY.
  *
- * \warning This option is experimental. For time being, we can not guarantee
- *          it with CI tests.
- *
  * Requires: MBEDTLS_SHA256_C.
  *
  * Module:  library/sha256.c
@@ -3098,9 +3092,6 @@
  *
  * \warning MBEDTLS_SHA256_USE_A64_CRYPTO_ONLY cannot be defined at the same
  * time as MBEDTLS_SHA256_USE_A64_CRYPTO_IF_PRESENT.
- *
- * \warning This option is experimental. For time being, we can not guarantee
- *          it with CI tests.
  *
  * Requires: MBEDTLS_SHA256_C.
  *
@@ -3158,9 +3149,6 @@
  * \warning MBEDTLS_SHA512_USE_A64_CRYPTO_IF_PRESENT cannot be defined at the
  * same time as MBEDTLS_SHA512_USE_A64_CRYPTO_ONLY.
  *
- * \warning This option is experimental. For time being, we can not guarantee
- *          it with CI tests.
- *
  * Requires: MBEDTLS_SHA512_C.
  *
  * Module:  library/sha512.c
@@ -3185,9 +3173,6 @@
  *
  * \warning MBEDTLS_SHA512_USE_A64_CRYPTO_ONLY cannot be defined at the same
  * time as MBEDTLS_SHA512_USE_A64_CRYPTO_IF_PRESENT.
- *
- * \warning This option is experimental. For time being, we can not guarantee
- *          it with CI tests.
  *
  * Requires: MBEDTLS_SHA512_C.
  *

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -2042,6 +2042,9 @@
  * \warning Runtime detection only works on linux. For non-linux operation
  *          system, crypto extension MUST be supported by CPU.
  *
+ * \warning This option is experimental. For time being, we can not guarantee
+ *          it with CI tests.
+ *
  * This module adds support for the AES crypto instructions on Arm64
  */
 #define MBEDTLS_AESCE_C
@@ -3071,6 +3074,9 @@
  * \warning MBEDTLS_SHA256_USE_A64_CRYPTO_IF_PRESENT cannot be defined at the
  * same time as MBEDTLS_SHA256_USE_A64_CRYPTO_ONLY.
  *
+ * \warning This option is experimental. For time being, we can not guarantee
+ *          it with CI tests.
+ *
  * Requires: MBEDTLS_SHA256_C.
  *
  * Module:  library/sha256.c
@@ -3092,6 +3098,9 @@
  *
  * \warning MBEDTLS_SHA256_USE_A64_CRYPTO_ONLY cannot be defined at the same
  * time as MBEDTLS_SHA256_USE_A64_CRYPTO_IF_PRESENT.
+ *
+ * \warning This option is experimental. For time being, we can not guarantee
+ *          it with CI tests.
  *
  * Requires: MBEDTLS_SHA256_C.
  *
@@ -3149,6 +3158,9 @@
  * \warning MBEDTLS_SHA512_USE_A64_CRYPTO_IF_PRESENT cannot be defined at the
  * same time as MBEDTLS_SHA512_USE_A64_CRYPTO_ONLY.
  *
+ * \warning This option is experimental. For time being, we can not guarantee
+ *          it with CI tests.
+ *
  * Requires: MBEDTLS_SHA512_C.
  *
  * Module:  library/sha512.c
@@ -3173,6 +3185,9 @@
  *
  * \warning MBEDTLS_SHA512_USE_A64_CRYPTO_ONLY cannot be defined at the same
  * time as MBEDTLS_SHA512_USE_A64_CRYPTO_IF_PRESENT.
+ *
+ * \warning This option is experimental. For time being, we can not guarantee
+ *          it with CI tests.
  *
  * Requires: MBEDTLS_SHA512_C.
  *

--- a/library/aesce.c
+++ b/library/aesce.c
@@ -36,7 +36,7 @@
  * for older compilers.
  */
 #define __ARM_FEATURE_AES    1
-#define MBEDTLS_NEED_TAGET_OPTIONS
+#define MBEDTLS_NEED_TARGET_OPTIONS
 #endif
 
 #include <string.h>
@@ -58,9 +58,9 @@
 #   if __GNUC__ < 6
 #       error "A more recent GCC is required for MBEDTLS_AESCE_C"
 #   endif
-#          pragma GCC push_options
-#          pragma GCC target ("arch=armv8-a+crypto")
-#          define MBEDTLS_POP_TARGET_PRAGMA
+#   pragma GCC push_options
+#   pragma GCC target ("arch=armv8-a+crypto")
+#   define MBEDTLS_POP_TARGET_PRAGMA
 #else
 #    error "Only GCC and Clang supported for MBEDTLS_AESCE_C"
 #endif

--- a/library/aesce.c
+++ b/library/aesce.c
@@ -48,22 +48,24 @@
 
 #if defined(MBEDTLS_HAVE_ARM64)
 
-#if defined(__clang__)
-#   if __clang_major__ < 4
-#       error "A more recent Clang is required for MBEDTLS_AESCE_C"
+#if !defined(__ARM_FEATURE_AES) || defined(MBEDTLS_NEED_TARGET_OPTIONS)
+#   if defined(__clang__)
+#       if __clang_major__ < 4
+#           error "A more recent Clang is required for MBEDTLS_AESCE_C"
+#       endif
+#       pragma clang attribute push (__attribute__((target("crypto"))), apply_to=function)
+#       define MBEDTLS_POP_TARGET_PRAGMA
+#   elif defined(__GNUC__)
+#       if __GNUC__ < 6
+#           error "A more recent GCC is required for MBEDTLS_AESCE_C"
+#       endif
+#       pragma GCC push_options
+#       pragma GCC target ("arch=armv8-a+crypto")
+#       define MBEDTLS_POP_TARGET_PRAGMA
+#   else
+#       error "Only GCC and Clang supported for MBEDTLS_AESCE_C"
 #   endif
-#        pragma clang attribute push (__attribute__((target("crypto"))), apply_to=function)
-#        define MBEDTLS_POP_TARGET_PRAGMA
-#elif defined(__GNUC__)
-#   if __GNUC__ < 6
-#       error "A more recent GCC is required for MBEDTLS_AESCE_C"
-#   endif
-#   pragma GCC push_options
-#   pragma GCC target ("arch=armv8-a+crypto")
-#   define MBEDTLS_POP_TARGET_PRAGMA
-#else
-#    error "Only GCC and Clang supported for MBEDTLS_AESCE_C"
-#endif
+#endif /* !__ARM_FEATURE_AES || MBEDTLS_NEED_TARGET_OPTIONS */
 
 #include <arm_neon.h>
 

--- a/library/aesce.c
+++ b/library/aesce.c
@@ -30,6 +30,11 @@
  * at the top of this file, before any includes.
  */
 #define __ARM_FEATURE_CRYPTO 1
+/* See: https://arm-software.github.io/acle/main/acle.html#cryptographic-extensions
+ *
+ * `__ARM_FEATURE_CRYPTO` is deprecated. Reserve it for older compilers.
+ */
+#define __ARM_FEATURE_AES    1
 #define NEED_TARGET_OPTIONS
 #endif /* __aarch64__ && __clang__ &&
           !__ARM_FEATURE_CRYPTO && __clang_major__ < 18 && __clang_major__ > 3 */

--- a/library/aesce.c
+++ b/library/aesce.c
@@ -18,7 +18,7 @@
  */
 
 #if defined(__aarch64__) && !defined(__ARM_FEATURE_CRYPTO) && \
-    defined(__clang__) && __clang_major__ > 3
+    defined(__clang__) && __clang_major__ >= 4
 /* TODO: Re-consider above after https://reviews.llvm.org/D131064 merged.
  *
  * The intrinsic declaration are guarded by predefined ACLE macros in clang:

--- a/library/aesce.c
+++ b/library/aesce.c
@@ -18,7 +18,7 @@
  */
 
 #if defined(__aarch64__) && !defined(__ARM_FEATURE_CRYPTO) && \
-    defined(__clang__) &&  __clang_major__ < 18 && __clang_major__ > 3
+    defined(__clang__) && __clang_major__ > 3
 /* TODO: Re-consider above after https://reviews.llvm.org/D131064 merged.
  *
  * The intrinsic declaration are guarded by predefined ACLE macros in clang:

--- a/library/aesce.c
+++ b/library/aesce.c
@@ -36,7 +36,7 @@
  * for older compilers.
  */
 #define __ARM_FEATURE_AES    1
-#define NEED_TARGET_OPTIONS
+#define MBEDTLS_NEED_TAGET_OPTIONS
 #endif
 
 #include <string.h>

--- a/library/aesce.c
+++ b/library/aesce.c
@@ -32,12 +32,12 @@
 #define __ARM_FEATURE_CRYPTO 1
 /* See: https://arm-software.github.io/acle/main/acle.html#cryptographic-extensions
  *
- * `__ARM_FEATURE_CRYPTO` is deprecated. Reserve it for older compilers.
+ * `__ARM_FEATURE_CRYPTO` is deprecated, but we need to continue to specify it
+ * for older compilers.
  */
 #define __ARM_FEATURE_AES    1
 #define NEED_TARGET_OPTIONS
-#endif /* __aarch64__ && __clang__ &&
-          !__ARM_FEATURE_CRYPTO && __clang_major__ < 18 && __clang_major__ > 3 */
+#endif
 
 #include <string.h>
 #include "common.h"

--- a/library/sha256.c
+++ b/library/sha256.c
@@ -23,7 +23,7 @@
  */
 
 #if defined(__aarch64__) && !defined(__ARM_FEATURE_CRYPTO) && \
-    defined(__clang__) &&  __clang_major__ < 18 && __clang_major__ > 3
+    defined(__clang__) && __clang_major__ > 3
 /* TODO: Re-consider above after https://reviews.llvm.org/D131064 merged.
  *
  * The intrinsic declaration are guarded by predefined ACLE macros in clang:

--- a/library/sha256.c
+++ b/library/sha256.c
@@ -41,7 +41,7 @@
  * for older compilers.
  */
 #define __ARM_FEATURE_SHA2   1
-#define MBEDTLS_NEED_TAGET_OPTIONS
+#define MBEDTLS_NEED_TARGET_OPTIONS
 #endif
 
 #include "common.h"
@@ -60,7 +60,7 @@
 #  if defined(MBEDTLS_SHA256_USE_A64_CRYPTO_IF_PRESENT) || \
     defined(MBEDTLS_SHA256_USE_A64_CRYPTO_ONLY)
 /* *INDENT-OFF* */
-#    if !defined(__ARM_FEATURE_CRYPTO) || defined(MBEDTLS_NEED_TAGET_OPTIONS)
+#    if !defined(__ARM_FEATURE_CRYPTO) || defined(MBEDTLS_NEED_TARGET_OPTIONS)
 #      if defined(__clang__)
 #        if __clang_major__ < 4
 #          error "A more recent Clang is required for MBEDTLS_SHA256_USE_A64_CRYPTO_*"

--- a/library/sha256.c
+++ b/library/sha256.c
@@ -35,6 +35,11 @@
  * at the top of this file, before any includes.
  */
 #define __ARM_FEATURE_CRYPTO 1
+/* See: https://arm-software.github.io/acle/main/acle.html#cryptographic-extensions
+ *
+ * `__ARM_FEATURE_CRYPTO` is deprecated. Reserve it for older compilers.
+ */
+#define __ARM_FEATURE_SHA2   1
 #define NEED_TARGET_OPTIONS
 #endif /* __aarch64__ && __clang__ &&
           !__ARM_FEATURE_CRYPTO && __clang_major__ < 18 && __clang_major__ > 3 */

--- a/library/sha256.c
+++ b/library/sha256.c
@@ -37,12 +37,12 @@
 #define __ARM_FEATURE_CRYPTO 1
 /* See: https://arm-software.github.io/acle/main/acle.html#cryptographic-extensions
  *
- * `__ARM_FEATURE_CRYPTO` is deprecated. Reserve it for older compilers.
+ * `__ARM_FEATURE_CRYPTO` is deprecated, but we need to continue to specify it
+ * for older compilers.
  */
 #define __ARM_FEATURE_SHA2   1
 #define NEED_TARGET_OPTIONS
-#endif /* __aarch64__ && __clang__ &&
-          !__ARM_FEATURE_CRYPTO && __clang_major__ < 18 && __clang_major__ > 3 */
+#endif
 
 #include "common.h"
 

--- a/library/sha256.c
+++ b/library/sha256.c
@@ -23,7 +23,7 @@
  */
 
 #if defined(__aarch64__) && !defined(__ARM_FEATURE_CRYPTO) && \
-    defined(__clang__) && __clang_major__ > 3
+    defined(__clang__) && __clang_major__ >= 4
 /* TODO: Re-consider above after https://reviews.llvm.org/D131064 merged.
  *
  * The intrinsic declaration are guarded by predefined ACLE macros in clang:

--- a/library/sha256.c
+++ b/library/sha256.c
@@ -41,7 +41,7 @@
  * for older compilers.
  */
 #define __ARM_FEATURE_SHA2   1
-#define NEED_TARGET_OPTIONS
+#define MBEDTLS_NEED_TAGET_OPTIONS
 #endif
 
 #include "common.h"
@@ -60,7 +60,7 @@
 #  if defined(MBEDTLS_SHA256_USE_A64_CRYPTO_IF_PRESENT) || \
     defined(MBEDTLS_SHA256_USE_A64_CRYPTO_ONLY)
 /* *INDENT-OFF* */
-#    if !defined(__ARM_FEATURE_CRYPTO) || defined(NEED_TARGET_OPTIONS)
+#    if !defined(__ARM_FEATURE_CRYPTO) || defined(MBEDTLS_NEED_TAGET_OPTIONS)
 #      if defined(__clang__)
 #        if __clang_major__ < 4
 #          error "A more recent Clang is required for MBEDTLS_SHA256_USE_A64_CRYPTO_*"

--- a/library/sha512.c
+++ b/library/sha512.c
@@ -36,8 +36,7 @@
  */
 #define __ARM_FEATURE_SHA512 1
 #define NEED_TARGET_OPTIONS
-#endif /* __aarch64__ &&  !__ARM_FEATURE_SHA512 &&
-          __clang__ && __clang_major__ < 18 && __clang_major__ > 7 */
+#endif
 
 #include "common.h"
 

--- a/library/sha512.c
+++ b/library/sha512.c
@@ -35,7 +35,7 @@
  * at the top of this file, before any includes.
  */
 #define __ARM_FEATURE_SHA512 1
-#define MBEDTLS_NEED_TAGET_OPTIONS
+#define MBEDTLS_NEED_TARGET_OPTIONS
 #endif
 
 #include "common.h"
@@ -74,7 +74,7 @@
  * Clang == 13.0.0 same as clang 12 (only seen on macOS)
  * Clang >= 13.0.1 has __ARM_FEATURE_SHA512 and intrinsics
  */
-#    if !defined(__ARM_FEATURE_SHA512) || defined(MBEDTLS_NEED_TAGET_OPTIONS)
+#    if !defined(__ARM_FEATURE_SHA512) || defined(MBEDTLS_NEED_TARGET_OPTIONS)
        /* Test Clang first, as it defines __GNUC__ */
 #      if defined(__clang__)
 #        if __clang_major__ < 7

--- a/library/sha512.c
+++ b/library/sha512.c
@@ -23,8 +23,7 @@
  */
 
 #if defined(__aarch64__) && !defined(__ARM_FEATURE_SHA512) && \
-    defined(__clang__) &&  __clang_major__ < 18 && \
-    __clang_major__ >= 13 && __clang_minor__ > 0 && __clang_patchlevel__ > 0
+    defined(__clang__) &&  __clang_major__ < 18 && __clang_major__ > 7
 /* TODO: Re-consider above after https://reviews.llvm.org/D131064 merged.
  *
  * The intrinsic declaration are guarded by predefined ACLE macros in clang:
@@ -37,10 +36,8 @@
  */
 #define __ARM_FEATURE_SHA512 1
 #define NEED_TARGET_OPTIONS
-#endif /* __aarch64__ && __clang__ &&
-          !__ARM_FEATURE_SHA512 && __clang_major__ < 18 &&
-          __clang_major__ >= 13 && __clang_minor__ > 0 &&
-          __clang_patchlevel__ > 0 */
+#endif /* __aarch64__ &&  !__ARM_FEATURE_SHA512 &&
+          __clang__ && __clang_major__ < 18 && __clang_major__ > 7 */
 
 #include "common.h"
 
@@ -83,10 +80,6 @@
 #      if defined(__clang__)
 #        if __clang_major__ < 7
 #          error "A more recent Clang is required for MBEDTLS_SHA512_USE_A64_CRYPTO_*"
-#        elif __clang_major__ < 13 || \
-              (__clang_major__ == 13 && __clang_minor__ == 0 && \
-               __clang_patchlevel__ == 0)
-           /* We implement the intrinsics with inline assembler, so don't error */
 #        else
 #          pragma clang attribute push (__attribute__((target("sha3"))), apply_to=function)
 #          define MBEDTLS_POP_TARGET_PRAGMA

--- a/library/sha512.c
+++ b/library/sha512.c
@@ -35,7 +35,7 @@
  * at the top of this file, before any includes.
  */
 #define __ARM_FEATURE_SHA512 1
-#define NEED_TARGET_OPTIONS
+#define MBEDTLS_NEED_TAGET_OPTIONS
 #endif
 
 #include "common.h"
@@ -74,7 +74,7 @@
  * Clang == 13.0.0 same as clang 12 (only seen on macOS)
  * Clang >= 13.0.1 has __ARM_FEATURE_SHA512 and intrinsics
  */
-#    if !defined(__ARM_FEATURE_SHA512) || defined(NEED_TARGET_OPTIONS)
+#    if !defined(__ARM_FEATURE_SHA512) || defined(MBEDTLS_NEED_TAGET_OPTIONS)
        /* Test Clang first, as it defines __GNUC__ */
 #      if defined(__clang__)
 #        if __clang_major__ < 7

--- a/library/sha512.c
+++ b/library/sha512.c
@@ -23,7 +23,7 @@
  */
 
 #if defined(__aarch64__) && !defined(__ARM_FEATURE_SHA512) && \
-    defined(__clang__) &&  __clang_major__ < 18 && __clang_major__ > 7
+    defined(__clang__) && __clang_major__ > 7
 /* TODO: Re-consider above after https://reviews.llvm.org/D131064 merged.
  *
  * The intrinsic declaration are guarded by predefined ACLE macros in clang:

--- a/library/sha512.c
+++ b/library/sha512.c
@@ -23,7 +23,7 @@
  */
 
 #if defined(__aarch64__) && !defined(__ARM_FEATURE_SHA512) && \
-    defined(__clang__) && __clang_major__ > 7
+    defined(__clang__) && __clang_major__ >= 7
 /* TODO: Re-consider above after https://reviews.llvm.org/D131064 merged.
  *
  * The intrinsic declaration are guarded by predefined ACLE macros in clang:


### PR DESCRIPTION
## Description

The library does not build out-of-the-box on Arm (the user needs to set compiler flags). This fixes it.

Fix #5758 

#6932 fixed Arm64 host build fail before #6895 merged.

Without `-march=armv8-a+crypto` , AESCE module still reports fail after #6895. This PR add similar pragmas to fix it.

Beside that, Travis CI is updated, for we have resolved conflict issue between SHA512 and AESCE. 




## Gatekeeper checklist

- [x] **changelog** not required
- [x] **backport** not required
- [x] **tests** not required



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

