### PR TITLE
Backport 2.28: all.sh: Do not list unsupported cases 

### DIFF
--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -3211,8 +3211,8 @@ component_build_mingw () {
     make WINDOWS_BUILD=1 clean
 }
 support_build_mingw() {
-    case $(i686-w64-mingw32-gcc -dumpversion) in
-        [0-5]*) false;;
+    case $(i686-w64-mingw32-gcc -dumpversion 2>/dev/null) in
+        [0-5]*|"") false;;
         *) true;;
     esac
 }

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -3181,6 +3181,11 @@ component_build_armcc () {
     # ARM Compiler 6 - Target ARMv8-A - AArch64
     armc6_build_test "--target=aarch64-arm-none-eabi -march=armv8.2-a"
 }
+support_build_armcc () {
+    armc5_cc="$ARMC5_BIN_DIR/armcc"
+    armc6_cc="$ARMC6_BIN_DIR/armclang"
+    (check_tools "$armc5_cc" "$armc6_cc" > /dev/null 2>&1)
+}
 
 component_build_ssl_hw_record_accel() {
     msg "build: default config with MBEDTLS_SSL_HW_RECORD_ACCEL enabled"


### PR DESCRIPTION
This PR is a backport of https://github.com/Mbed-TLS/mbedtls/pull/7163 to branch mbedtls-2.28.
