### PR TITLE
Cleanup: remove unused `t` in `mpi_mul_hlp()`

### DIFF
--- a/library/bignum.c
+++ b/library/bignum.c
@@ -1426,8 +1426,7 @@ void mpi_mul_hlp(size_t i,
                  mbedtls_mpi_uint *d,
                  mbedtls_mpi_uint b)
 {
-    mbedtls_mpi_uint c = 0, t = 0;
-    (void) t;                   /* Unused in some architectures */
+    mbedtls_mpi_uint c = 0;
 
 #if defined(MULADDC_HUIT)
     for (; i >= 8; i -= 8) {


### PR DESCRIPTION
## Description

I am using library/bignum.c as of Jan 13, 2023, and getting the error
```
mbedtls/library/bignum.c:1429:29: error: variable 't' set but not used [-Werror,-Wunused-but-set-variable]
    mbedtls_mpi_uint c = 0, t = 0;
                            ^
```
The error was fixed in https://github.com/Mbed-TLS/mbedtls/commit/d784833a1b83d26ea7bd3cc32d58e27d10d8f6cc on Feb 24, 2023: the variable reference was removed, but it was kept unused and the error was screened with `(void) t;`. It's very strange. I offer to remove this variable.

## Gatekeeper checklist

- [x] **changelog** not required
- [x] **backport** done, `development` does not need this change
- [x] **tests** not required
