### PR TITLE
Fix llvm error: variable 'default_iv_length' and other may be used uninitialized

### DIFF
--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -3997,7 +3997,7 @@ psa_status_t psa_cipher_generate_iv(psa_cipher_operation_t *operation,
 {
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
     uint8_t local_iv[PSA_CIPHER_IV_MAX_SIZE];
-    size_t default_iv_length;
+    size_t default_iv_length = 0;
 
     if (operation->id == 0) {
         status = PSA_ERROR_BAD_STATE;
@@ -4604,7 +4604,7 @@ psa_status_t psa_aead_generate_nonce(psa_aead_operation_t *operation,
 {
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
     uint8_t local_nonce[PSA_AEAD_NONCE_MAX_SIZE];
-    size_t required_nonce_size;
+    size_t required_nonce_size = 0;
 
     *nonce_length = 0;
 

--- a/library/ssl_cache.c
+++ b/library/ssl_cache.c
@@ -246,7 +246,7 @@ int mbedtls_ssl_cache_set(void *data,
     mbedtls_ssl_cache_context *cache = (mbedtls_ssl_cache_context *) data;
     mbedtls_ssl_cache_entry *cur;
 
-    size_t session_serialized_len;
+    size_t session_serialized_len = 0;
     unsigned char *session_serialized = NULL;
 
 #if defined(MBEDTLS_THREADING_C)

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -9672,7 +9672,7 @@ void persistent_key_load_key_from_storage(data_t *data,
     unsigned char *first_export = NULL;
     unsigned char *second_export = NULL;
     size_t export_size = PSA_EXPORT_KEY_OUTPUT_SIZE(type, bits);
-    size_t first_exported_length;
+    size_t first_exported_length = 0;
     size_t second_exported_length;
 
     if (usage_flags & PSA_KEY_USAGE_EXPORT) {


### PR DESCRIPTION
## Description
```
mbedtls/library/psa_crypto.c:3428:30: error: variable 'default_iv_length' may be uninitialized when used here [-Werror,-Wconditional-uninitialized]
        memcpy(iv, local_iv, default_iv_length);
                             ^~~~~~~~~~~~~~~~~
mbedtls/library/psa_crypto.c:4646:36: error: variable 'required_nonce_size' may be uninitialized when used here [-Werror,-Wconditional-uninitialized]
        memcpy(nonce, local_nonce, required_nonce_size);
                                   ^~~~~~~~~~~~~~~~~~~
mbedtls/library/ssl_cache.c:309:54: error: variable 'session_serialized_len' may be uninitialized when used here [-Werror,-Wconditional-uninitialized]
        mbedtls_platform_zeroize(session_serialized, session_serialized_len);
                                                     ^~~~~~~~~~~~~~~~~~~~~~
```
The warnings are false positive, but treated as errors and prevent compiling on Windows with LLVM Clang. 

## Gatekeeper checklist

- [x] **changelog** not required
- [x] **backport** done https://github.com/Mbed-TLS/mbedtls/pull/7211
- [x] **tests** not required

