### PR TITLE
mbedtls-2.28: Fix llvm error: variable 'default_iv_length' may be used uninitialized

### DIFF
--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -3392,7 +3392,7 @@ psa_status_t psa_cipher_generate_iv(psa_cipher_operation_t *operation,
 {
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
     uint8_t local_iv[PSA_CIPHER_IV_MAX_SIZE];
-    size_t default_iv_length;
+    size_t default_iv_length = 0;
 
     if (operation->id == 0) {
         status = PSA_ERROR_BAD_STATE;


### PR DESCRIPTION
## Description

Backport of https://github.com/Mbed-TLS/mbedtls/pull/7210
```
mbedtls/library/psa_crypto.c:3428:30: error: variable 'default_iv_length' may be uninitialized when used here [-Werror,-Wconditional-uninitialized]
        memcpy(iv, local_iv, default_iv_length);
                             ^~~~~~~~~~~~~~~~~
```
The warning is false positive, but treated as error and prevents compiling on Windows with LLVM Clang. 

## Gatekeeper checklist

- [x] **changelog** not required
- [x] **backport** done
- [x] **tests**  not required
