### PR TITLE
Add getters for some fields

### DIFF
--- a/ChangeLog.d/add-getters-for-some-fields.txt
+++ b/ChangeLog.d/add-getters-for-some-fields.txt
@@ -1,0 +1,7 @@
+Features
+   * Add getter (mbedtls_ssl_cache_get_timeout()) to access
+     `mbedtls_ssl_cache_context.timeout`.
+   * Add getter (mbedtls_ssl_get_hostname()) to access
+     `mbedtls_ssl_context.hostname`.
+   * Add getter (mbedtls_ssl_conf_get_endpoint()) to access
+     `mbedtls_ssl_config.endpoint`.

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1926,7 +1926,7 @@ void mbedtls_ssl_conf_endpoint(mbedtls_ssl_config *conf, int endpoint);
  * \return         Endpoint type, either MBEDTLS_SSL_IS_CLIENT
  *                 or MBEDTLS_SSL_IS_SERVER
  */
-static inline int mbedtls_ssl_conf_get_endpoint(mbedtls_ssl_config *conf)
+static inline int mbedtls_ssl_conf_get_endpoint(const mbedtls_ssl_config *conf)
 {
     return conf->MBEDTLS_PRIVATE(endpoint);
 }

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -3777,6 +3777,21 @@ void mbedtls_ssl_conf_sig_algs(mbedtls_ssl_config *conf,
  *                 On too long input failure, old hostname is unchanged.
  */
 int mbedtls_ssl_set_hostname(mbedtls_ssl_context *ssl, const char *hostname);
+
+/**
+ * \brief          Get the hostname that checked against the received
+ *                 server certificate. It is used to set the ServerName
+ *                 TLS extension, too, if that extension is enabled.
+ *                 (client-side only)
+ *
+ * \param ssl      SSL context
+ *
+ * \return         const pointer to the hostname value
+ */
+static inline const char *mbedtls_ssl_get_hostname(mbedtls_ssl_context *ssl)
+{
+    return ssl->MBEDTLS_PRIVATE(hostname);
+}
 #endif /* MBEDTLS_X509_CRT_PARSE_C */
 
 #if defined(MBEDTLS_SSL_SERVER_NAME_INDICATION)

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1919,6 +1919,19 @@ int mbedtls_ssl_session_reset(mbedtls_ssl_context *ssl);
 void mbedtls_ssl_conf_endpoint(mbedtls_ssl_config *conf, int endpoint);
 
 /**
+ * \brief          Get the current endpoint type
+ *
+ * \param conf     SSL configuration
+ *
+ * \return         Endpoint type, either MBEDTLS_SSL_IS_CLIENT
+ *                 or MBEDTLS_SSL_IS_SERVER
+ */
+static inline int mbedtls_ssl_conf_get_endpoint(mbedtls_ssl_config *conf)
+{
+    return conf->MBEDTLS_PRIVATE(endpoint);
+}
+
+/**
  * \brief           Set the transport type (TLS or DTLS).
  *                  Default: TLS
  *

--- a/include/mbedtls/ssl_cache.h
+++ b/include/mbedtls/ssl_cache.h
@@ -160,6 +160,20 @@ int mbedtls_ssl_cache_remove(void *data,
  * \param timeout  cache entry timeout in seconds
  */
 void mbedtls_ssl_cache_set_timeout(mbedtls_ssl_cache_context *cache, int timeout);
+
+/**
+ * \brief          Get the cache timeout
+ *
+ *                 A timeout of 0 indicates no timeout.
+ *
+ * \param cache    SSL cache context
+ *
+ * \return         cache entry timeout in seconds
+ */
+static inline int mbedtls_ssl_cache_get_timeout(mbedtls_ssl_cache_context *cache)
+{
+    return cache->MBEDTLS_PRIVATE(timeout);
+}
 #endif /* MBEDTLS_HAVE_TIME */
 
 /**

--- a/tests/src/test_helpers/ssl_helpers.c
+++ b/tests/src/test_helpers/ssl_helpers.c
@@ -93,6 +93,10 @@ void mbedtls_test_init_handshake_options(
     opts->cache = NULL;
     ASSERT_ALLOC(opts->cache, 1);
     mbedtls_ssl_cache_init(opts->cache);
+#if defined(MBEDTLS_HAVE_TIME)
+    TEST_EQUAL(mbedtls_ssl_cache_get_timeout(opts->cache),
+               MBEDTLS_SSL_CACHE_DEFAULT_TIMEOUT);
+#endif
 exit:
     return;
 #endif

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -3051,6 +3051,8 @@ void conf_version(int endpoint, int transport,
     mbedtls_ssl_conf_max_tls_version(&conf, max_tls_version);
 
     TEST_ASSERT(mbedtls_ssl_setup(&ssl, &conf) == expected_ssl_setup_result);
+    TEST_EQUAL(mbedtls_ssl_conf_get_endpoint(
+                   mbedtls_ssl_context_get_config(&ssl)), endpoint);
 
     mbedtls_ssl_free(&ssl);
     mbedtls_ssl_config_free(&conf);

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -1148,13 +1148,19 @@ exit:
 /* BEGIN_CASE depends_on:MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED */
 void ssl_set_hostname_twice(char *hostname0, char *hostname1)
 {
+    const char *hostname;
     mbedtls_ssl_context ssl;
 
     mbedtls_ssl_init(&ssl);
     USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_ssl_set_hostname(&ssl, hostname0) == 0);
+    hostname = mbedtls_ssl_get_hostname(&ssl);
+    TEST_ASSERT(strcmp(hostname0, hostname) == 0);
+
     TEST_ASSERT(mbedtls_ssl_set_hostname(&ssl, hostname1) == 0);
+    hostname = mbedtls_ssl_get_hostname(&ssl);
+    TEST_ASSERT(strcmp(hostname1, hostname) == 0);
 
 exit:
     mbedtls_ssl_free(&ssl);


### PR DESCRIPTION
## Description

Partially Fix: https://github.com/Mbed-TLS/mbedtls/issues/6840

The getters are added for the convenience of application usage.



## Gatekeeper checklist

- [x] **changelog** provided
- [x] **backport** not required
- [x] **tests** provided


