### PR TITLE
ssl_cache: Add cache entry removal api

### DIFF
--- a/ChangeLog.d/add-cache-remove-api.txt
+++ b/ChangeLog.d/add-cache-remove-api.txt
@@ -1,0 +1,5 @@
+Features
+   * Add new API mbedtls_ssl_cache_remove for cache entry removal by
+     its session id.
+Security
+   * Zeroize SSL cache entries when they are freed.

--- a/include/mbedtls/ssl_cache.h
+++ b/include/mbedtls/ssl_cache.h
@@ -123,6 +123,23 @@ int mbedtls_ssl_cache_set(void *data,
                           size_t session_id_len,
                           const mbedtls_ssl_session *session);
 
+/**
+ * \brief          Remove the cache entry by the session ID
+ *                 (Thread-safe if MBEDTLS_THREADING_C is enabled)
+ *
+ * \param data            The SSL cache context to use.
+ * \param session_id      The pointer to the buffer holding the session ID
+ *                        associated to \p session.
+ * \param session_id_len  The length of \p session_id in bytes.
+ *
+ * \return                0: The cache entry for session with provided ID
+ *                           is removed or does not exist.
+ *                        1: Internal error.
+ */
+int mbedtls_ssl_cache_remove(void *data,
+                             unsigned char const *session_id,
+                             size_t session_id_len);
+
 #if defined(MBEDTLS_HAVE_TIME)
 /**
  * \brief          Set the cache timeout

--- a/include/mbedtls/ssl_cache.h
+++ b/include/mbedtls/ssl_cache.h
@@ -134,7 +134,7 @@ int mbedtls_ssl_cache_set(void *data,
  *
  * \return                0: The cache entry for session with provided ID
  *                           is removed or does not exist.
- *                        1: Internal error.
+ *                        Otherwise: fail.
  */
 int mbedtls_ssl_cache_remove(void *data,
                              unsigned char const *session_id,

--- a/library/ssl_cache.c
+++ b/library/ssl_cache.c
@@ -92,8 +92,8 @@ int mbedtls_ssl_cache_get(void *data,
     mbedtls_ssl_cache_entry *entry;
 
 #if defined(MBEDTLS_THREADING_C)
-    if (mbedtls_mutex_lock(&cache->mutex) != 0) {
-        return 1;
+    if ((ret = mbedtls_mutex_lock(&cache->mutex)) != 0) {
+        return ret;
     }
 #endif
 
@@ -114,7 +114,7 @@ int mbedtls_ssl_cache_get(void *data,
 exit:
 #if defined(MBEDTLS_THREADING_C)
     if (mbedtls_mutex_unlock(&cache->mutex) != 0) {
-        ret = 1;
+        ret = MBEDTLS_ERR_THREADING_MUTEX_ERROR;
     }
 #endif
 
@@ -318,7 +318,7 @@ int mbedtls_ssl_cache_set(void *data,
 exit:
 #if defined(MBEDTLS_THREADING_C)
     if (mbedtls_mutex_unlock(&cache->mutex) != 0) {
-        ret = 1;
+        ret = MBEDTLS_ERR_THREADING_MUTEX_ERROR;
     }
 #endif
 
@@ -341,8 +341,8 @@ int mbedtls_ssl_cache_remove(void *data,
     mbedtls_ssl_cache_entry *prev;
 
 #if defined(MBEDTLS_THREADING_C)
-    if (mbedtls_mutex_lock(&cache->mutex) != 0) {
-        return 1;
+    if ((ret = mbedtls_mutex_lock(&cache->mutex)) != 0) {
+        return ret;
     }
 #endif
 
@@ -373,7 +373,7 @@ free:
 exit:
 #if defined(MBEDTLS_THREADING_C)
     if (mbedtls_mutex_unlock(&cache->mutex) != 0) {
-        ret = 1;
+        ret = MBEDTLS_ERR_THREADING_MUTEX_ERROR;
     }
 #endif
 

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -320,19 +320,17 @@ int main(void)
 
 #if defined(MBEDTLS_SSL_CACHE_C)
 #define USAGE_CACHE                                             \
-    "    cache_max=%%d        default: cache default (50)\n"
+    "    cache_max=%%d        default: cache default (50)\n"    \
+    "    cache_remove=%%d     default: 0 (don't remove)\n"
 #if defined(MBEDTLS_HAVE_TIME)
 #define USAGE_CACHE_TIME \
     "    cache_timeout=%%d    default: cache default (1d)\n"
 #else
 #define USAGE_CACHE_TIME ""
 #endif
-#define USAGE_CACHE_REMOVE                                      \
-    "    cache_remove=%%d     default: 0 (disabled)\n"
 #else
 #define USAGE_CACHE ""
 #define USAGE_CACHE_TIME ""
-#define USAGE_CACHE_REMOVE ""
 #endif /* MBEDTLS_SSL_CACHE_C */
 
 #if defined(SNI_OPTION)
@@ -553,7 +551,6 @@ int main(void)
     USAGE_NSS_KEYLOG_FILE                                   \
     USAGE_CACHE                                             \
     USAGE_CACHE_TIME                                        \
-    USAGE_CACHE_REMOVE                                      \
     USAGE_MAX_FRAG_LEN                                      \
     USAGE_ALPN                                              \
     USAGE_EMS                                               \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -4077,6 +4077,22 @@ run_test    "Session resume using cache: cache_max=1" \
 
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_CACHE_C
+run_test    "Session resume using cache: cache removed" \
+            "$P_SRV debug_level=3 tickets=0 cache_remove=1" \
+            "$P_CLI debug_level=3 tickets=0 reconnect=1" \
+            0 \
+            -C "client hello, adding session ticket extension" \
+            -S "found session ticket extension" \
+            -S "server hello, adding session ticket extension" \
+            -C "found session_ticket extension" \
+            -C "parse new session ticket" \
+            -S "session successfully restored from cache" \
+            -S "session successfully restored from ticket" \
+            -S "a session has been resumed" \
+            -C "a session has been resumed"
+
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+requires_config_enabled MBEDTLS_SSL_CACHE_C
 run_test    "Session resume using cache: timeout > delay" \
             "$P_SRV debug_level=3 tickets=0" \
             "$P_CLI debug_level=3 tickets=0 reconnect=1 reco_delay=0" \


### PR DESCRIPTION
## Description

Partially Fix: https://github.com/Mbed-TLS/mbedtls/issues/6840

Add a new interface in `ssl_cache.c` to support the removal of cache entry be the session id. The test is provided as well.


## Gatekeeper checklist

- [x] **changelog** provided
- [x] **backport** no (new feature, plus a fix for a bug that isn't present in 2.28)
- [x] **tests** provided


