### PR TITLE
Implement and use MBEDTLS_STATIC_ASSERT()

### DIFF
--- a/library/common.h
+++ b/library/common.h
@@ -26,6 +26,7 @@
 #include "mbedtls/build_info.h"
 #include "alignment.h"
 
+#include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stddef.h>
@@ -148,5 +149,35 @@ inline void mbedtls_xor(unsigned char *r, const unsigned char *a, const unsigned
 #define asm __asm__
 #endif
 /* *INDENT-ON* */
+
+/* Always provide a static assert macro, so it can be used unconditionally.
+ * Note that it will expand to nothing on some systems.
+ * Can be used outside functions (but don't add a trailing ';' in that case:
+ * the semicolon is included here to avoid triggering -Wextra-semi when
+ * MBEDTLS_STATIC_ASSERT() expands to nothing).
+ * Can't use the C11-style `defined(static_assert)` on FreeBSD, since it
+ * defines static_assert even with -std=c99, but then complains about it.
+ */
+#if defined(static_assert) && !defined(__FreeBSD__)
+#define MBEDTLS_STATIC_ASSERT(expr, msg)    static_assert(expr, msg);
+#elif defined(__COUNTER__)
+/* gcc will say "size of array ‘mbedtls_static_assert_failedN’ is negative"
+ * (and with -pedantic will complain further);
+ * clang will say "'mbedtls_static_assert_failedN' declared as an array with a
+ * negative size";
+ * Visual Studio will just say "error C2118: negative subscript" (without the
+ * mbedtls_static_assert_failedN part)
+ */
+#if defined(__GNUC__)
+#define MBEDTLS_UNUSED __attribute__((unused))
+#else
+#define MBEDTLS_UNUSED
+#endif
+#define MBEDTLS_STATIC_ASSERT2(expr, count) extern int MBEDTLS_UNUSED mbedtls_static_assert_failed ## count [2 * !!(expr) - 1];
+#define MBEDTLS_STATIC_ASSERT1(expr, count) MBEDTLS_STATIC_ASSERT2(expr, count)
+#define MBEDTLS_STATIC_ASSERT(expr, msg)    MBEDTLS_STATIC_ASSERT1(expr, __COUNTER__)
+#else
+#define MBEDTLS_STATIC_ASSERT(expr, msg)
+#endif
 
 #endif /* MBEDTLS_LIBRARY_COMMON_H */

--- a/library/common.h
+++ b/library/common.h
@@ -151,7 +151,7 @@ inline void mbedtls_xor(unsigned char *r, const unsigned char *a, const unsigned
 /* *INDENT-ON* */
 
 /* Always provide a static assert macro, so it can be used unconditionally.
- * Note that it will expand to nothing on some systems.
+ * It will expand to nothing on some systems.
  * Can be used outside functions (but don't add a trailing ';' in that case:
  * the semicolon is included here to avoid triggering -Wextra-semi when
  * MBEDTLS_STATIC_ASSERT() expands to nothing).
@@ -160,22 +160,6 @@ inline void mbedtls_xor(unsigned char *r, const unsigned char *a, const unsigned
  */
 #if defined(static_assert) && !defined(__FreeBSD__)
 #define MBEDTLS_STATIC_ASSERT(expr, msg)    static_assert(expr, msg);
-#elif defined(__COUNTER__)
-/* gcc will say "size of array ‘mbedtls_static_assert_failedN’ is negative"
- * (and with -pedantic will complain further);
- * clang will say "'mbedtls_static_assert_failedN' declared as an array with a
- * negative size";
- * Visual Studio will just say "error C2118: negative subscript" (without the
- * mbedtls_static_assert_failedN part)
- */
-#if defined(__GNUC__)
-#define MBEDTLS_UNUSED __attribute__((unused))
-#else
-#define MBEDTLS_UNUSED
-#endif
-#define MBEDTLS_STATIC_ASSERT2(expr, count) extern int MBEDTLS_UNUSED mbedtls_static_assert_failed ## count [2 * !!(expr) - 1];
-#define MBEDTLS_STATIC_ASSERT1(expr, count) MBEDTLS_STATIC_ASSERT2(expr, count)
-#define MBEDTLS_STATIC_ASSERT(expr, msg)    MBEDTLS_STATIC_ASSERT1(expr, __COUNTER__)
 #else
 #define MBEDTLS_STATIC_ASSERT(expr, msg)
 #endif

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -48,7 +48,6 @@
 
 #include "psa_crypto_random_impl.h"
 
-#include <assert.h>
 #include <stdlib.h>
 #include <string.h>
 #include "mbedtls/platform.h"
@@ -1471,14 +1470,15 @@ exit:
     return (status == PSA_SUCCESS) ? unlock_status : status;
 }
 
-#if defined(static_assert)
-static_assert((MBEDTLS_PSA_KA_MASK_EXTERNAL_ONLY & MBEDTLS_PSA_KA_MASK_DUAL_USE) == 0,
-              "One or more key attribute flag is listed as both external-only and dual-use");
-static_assert((PSA_KA_MASK_INTERNAL_ONLY & MBEDTLS_PSA_KA_MASK_DUAL_USE) == 0,
-              "One or more key attribute flag is listed as both internal-only and dual-use");
-static_assert((PSA_KA_MASK_INTERNAL_ONLY & MBEDTLS_PSA_KA_MASK_EXTERNAL_ONLY) == 0,
-              "One or more key attribute flag is listed as both internal-only and external-only");
-#endif
+MBEDTLS_STATIC_ASSERT(
+    (MBEDTLS_PSA_KA_MASK_EXTERNAL_ONLY & MBEDTLS_PSA_KA_MASK_DUAL_USE) == 0,
+    "One or more key attribute flag is listed as both external-only and dual-use")
+MBEDTLS_STATIC_ASSERT(
+    (PSA_KA_MASK_INTERNAL_ONLY & MBEDTLS_PSA_KA_MASK_DUAL_USE) == 0,
+    "One or more key attribute flag is listed as both internal-only and dual-use")
+MBEDTLS_STATIC_ASSERT(
+    (PSA_KA_MASK_INTERNAL_ONLY & MBEDTLS_PSA_KA_MASK_EXTERNAL_ONLY) == 0,
+    "One or more key attribute flag is listed as both internal-only and external-only")
 
 /** Validate that a key policy is internally well-formed.
  *
@@ -1742,11 +1742,10 @@ static psa_status_t psa_finish_key_creation(
             psa_key_slot_number_t slot_number =
                 psa_key_slot_get_slot_number(slot);
 
-#if defined(static_assert)
-            static_assert(sizeof(slot_number) ==
-                          sizeof(data.slot_number),
-                          "Slot number size does not match psa_se_key_data_storage_t");
-#endif
+            MBEDTLS_STATIC_ASSERT(sizeof(slot_number) ==
+                                  sizeof(data.slot_number),
+                                  "Slot number size does not match psa_se_key_data_storage_t");
+
             memcpy(&data.slot_number, &slot_number, sizeof(slot_number));
             status = psa_save_persistent_key(&slot->attr,
                                              (uint8_t *) &data,

--- a/library/psa_crypto_se.c
+++ b/library/psa_crypto_se.c
@@ -22,7 +22,6 @@
 
 #if defined(MBEDTLS_PSA_CRYPTO_SE_C)
 
-#include <assert.h>
 #include <stdint.h>
 #include <string.h>
 
@@ -313,10 +312,9 @@ psa_status_t psa_register_se_driver(
     }
     /* Driver table entries are 0-initialized. 0 is not a valid driver
      * location because it means a transparent key. */
-#if defined(static_assert)
-    static_assert(PSA_KEY_LOCATION_LOCAL_STORAGE == 0,
-                  "Secure element support requires 0 to mean a local key");
-#endif
+    MBEDTLS_STATIC_ASSERT(PSA_KEY_LOCATION_LOCAL_STORAGE == 0,
+                          "Secure element support requires 0 to mean a local key");
+
     if (location == PSA_KEY_LOCATION_LOCAL_STORAGE) {
         return PSA_ERROR_INVALID_ARGUMENT;
     }

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -25,8 +25,6 @@
 
 #if defined(MBEDTLS_SSL_TLS_C)
 
-#include <assert.h>
-
 #include "mbedtls/platform.h"
 
 #include "mbedtls/ssl.h"
@@ -1196,11 +1194,9 @@ static int ssl_handshake_init(mbedtls_ssl_context *ssl)
         size_t sig_algs_len = 0;
         uint16_t *p;
 
-#if defined(static_assert)
-        static_assert(MBEDTLS_SSL_MAX_SIG_ALG_LIST_LEN
-                      <= (SIZE_MAX - (2 * sizeof(uint16_t))),
-                      "MBEDTLS_SSL_MAX_SIG_ALG_LIST_LEN too big");
-#endif
+        MBEDTLS_STATIC_ASSERT(MBEDTLS_SSL_MAX_SIG_ALG_LIST_LEN
+                              <= (SIZE_MAX - (2 * sizeof(uint16_t))),
+                              "MBEDTLS_SSL_MAX_SIG_ALG_LIST_LEN too big");
 
         for (md = sig_hashes; *md != MBEDTLS_MD_NONE; md++) {
             if (mbedtls_ssl_hash_from_md_alg(*md) == MBEDTLS_SSL_HASH_NONE) {

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -1510,10 +1510,9 @@ read_record_header:
             MBEDTLS_TLS_SIG_NONE
         };
 
-#if defined(static_assert)
-        static_assert(sizeof(default_sig_algs) / sizeof(default_sig_algs[0]) <=
-                      MBEDTLS_RECEIVED_SIG_ALGS_SIZE, "default_sig_algs is too big");
-#endif
+        MBEDTLS_STATIC_ASSERT(sizeof(default_sig_algs) / sizeof(default_sig_algs[0])
+                              <= MBEDTLS_RECEIVED_SIG_ALGS_SIZE,
+                              "default_sig_algs is too big");
 
         memcpy(received_sig_algs, default_sig_algs, sizeof(default_sig_algs));
     }


### PR DESCRIPTION
Fixes #3693

Tested the following combinations of systems/compilers/compiler flags with assert ok/expected to fail:

OpenBSD gcc 4.2.1 assert_ok [-std=c99 [-pedantic]] -Wall -Wextra -Werror OK
OpenBSD gcc 4.2.1 assert_fails [-std=c99 [-pedantic]] -Wall -Wextra -Werror OK

clang 10.0.1 assert_ok [-std=c99 [-pedantic]] -Wall -Wextra -Werror OK
clang 10.0.1 assert_fails [-std=c99 [-pedantic]] -Wall -Wextra -Werror OK

Ubuntu gcc 12.0.1 assert_ok [-std=c99 [-pedantic]] -Wall -Wextra -Werror OK
Ubuntu gcc 12.0.1 assert_fails [-std=c99 [-pedantic]] -Wall -Wextra -Werror OK

Ubuntu clang 15.0.7 assert_ok [-std=c99 [-pedantic]] -Wall -Wextra -Werror OK
Ubuntu clang 15.0.7 assert_fails [-std=c99 [-pedantic]] -Wall -Wextra -Werror OK

macOS clang 14.0.0 assert_ok [-std=c99 [-pedantic]] -Wall -Wextra -Werror OK
macOS clang 14.0.0 assert_fails [-std=c99 [-pedantic]] -Wall -Wextra -Werror OK

Windows Visual Studio 2017 assert_ok (cmake standard build) OK
Windows Visual Studio 2017 assert_fails (cmake standard build) OK


## Gatekeeper checklist

- [ ] **changelog** not required - this is internal to the library, just enhancing existing functionality
- [ ] **backport** TO FOLLOW
- [ ] **tests** not required
