### PR TITLE
Backport 2.28: Update ChangeLog to make "fix" explicit

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,11 +6,11 @@ Security
    * Fix potential heap buffer overread and overwrite in DTLS if
      MBEDTLS_SSL_DTLS_CONNECTION_ID is enabled and
      MBEDTLS_SSL_CID_IN_LEN_MAX > 2 * MBEDTLS_SSL_CID_OUT_LEN_MAX.
-   * An adversary with access to precise enough information about memory
-     accesses (typically, an untrusted operating system attacking a secure
-     enclave) could recover an RSA private key after observing the victim
-     performing a single private-key operation if the window size used for the
-     exponentiation was 3 or smaller. Found and reported by Zili KOU,
+   * Fix an issue where an adversary with access to precise enough information
+     about memory accesses (typically, an untrusted operating system attacking
+     a secure enclave) could recover an RSA private key after observing the
+     victim performing a single private-key operation if the window size used
+     for the exponentiation was 3 or smaller. Found and reported by Zili KOU,
      Wenjian HE, Sharad Sinha, and Wei ZHANG. See "Cache Side-channel Attacks
      and Defenses of the Sliding Window Algorithm in TEEs" - Design, Automation
      and Test in Europe 2023.
@@ -337,16 +337,17 @@ Security
    * It was possible to configure MBEDTLS_ECP_MAX_BITS to a value that is
      too small, leading to buffer overflows in ECC operations. Fail the build
      in such a case.
-   * An adversary with access to precise enough information about memory
-     accesses (typically, an untrusted operating system attacking a secure
-     enclave) could recover an RSA private key after observing the victim
-     performing a single private-key operation. Found and reported by
+   * Fix an issue where an adversary with access to precise enough information
+     about memory accesses (typically, an untrusted operating system attacking
+     a secure enclave) could recover an RSA private key after observing the
+     victim performing a single private-key operation. Found and reported by
      Zili KOU, Wenjian HE, Sharad Sinha, and Wei ZHANG.
-   * An adversary with access to precise enough timing information (typically, a
-     co-located process) could recover a Curve25519 or Curve448 static ECDH key
-     after inputting a chosen public key and observing the victim performing the
-     corresponding private-key operation. Found and reported by Leila Batina,
-     Lukas Chmielewski, Björn Haase, Niels Samwel and Peter Schwabe.
+   * Fix an issue where an adversary with access to precise enough timing
+     information (typically, a co-located process) could recover a Curve25519
+     or Curve448 static ECDH key after inputting a chosen public key and
+     observing the victim performing the corresponding private-key operation.
+     Found and reported by Leila Batina, Lukas Chmielewski, Björn Haase, Niels
+     Samwel and Peter Schwabe.
 
 Bugfix
    * Add printf function attributes to mbedtls_debug_print_msg to ensure we


### PR DESCRIPTION
Backlport of #7231

## Gatekeeper checklist

- [ ] **changelog** not required - this is making existing ChangeLog entries clearer
- [ ] **backport** this is the backport of #7231
- [ ] **tests** not required
