### PR TITLE
Don't insist on MBEDTLS_HAVE_ASM for MBEDTLS_AESCE_C on non-Arm64 systems

### DIFF
--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -70,8 +70,11 @@
 #error "MBEDTLS_AESNI_C defined, but not all prerequisites"
 #endif
 
+#if defined(__aarch64__) && defined(__GNUC__)
+/* We don't do anything with MBEDTLS_AESCE_C on systems without ^ these two */
 #if defined(MBEDTLS_AESCE_C) && !defined(MBEDTLS_HAVE_ASM)
 #error "MBEDTLS_AESCE_C defined, but not all prerequisites"
+#endif
 #endif
 
 #if defined(MBEDTLS_CTR_DRBG_C) && !defined(MBEDTLS_AES_C)


### PR DESCRIPTION
Fixes #7234

Tested using the reproducer in the issue:
- fails to build without this fix on x86_64
- builds successfully with this fix on x86_64
- fails to build without this fix on aarch64
- builds successfully with this fix on aarch64

Simplest fix for an actual regression on non-aarch64; we can worry about tidy-up after release.

~~This is the “lowest impact fix” - it just moves the definition of `MBEDTLS_HAVE_ARM64` and then uses it in the `check_config.h` test.~~

~~The consequence on Armv8 builds is that, although to get AES CE on Armv8 you still need both `MBEDTLS_AESCE_C` and `MBEDTLS_HAVE_ASM`, the library will allow you to build with `MBEDTLS_AESCE_C` but not `MBEDTLS_HAVE_ASM`, and then just not use AES CE (which seems fair, because you clearly said "no asssembler" by disabling `MBEDTLS_HAVE_ASM`, which is enabled by default).~~

~~However, it clearly leads to two alternatives, which are smaller:~~

~~1) only do the check_config.h test if `defined(__aarch64__) && defined(__GNUC__)`
(which is NOT equivalent to this change - it's equivalent to this change on x86, but on Armv8 builds it keeps the existing behaviour, which we might prefer)~~

~~-or-~~

~~2) remove the test in check_config.h altogether (which IS equivalent to this change)~~

~~And that leads to a potentially nicer fix:~~

~~3) In `build_info.h`, undef `MBEDTLS_AESCE_C` if we don't have `MBEDTLS_HAVE_ASM` - which makes it all very obvious (and I like obvious; it goes nicely with "simple")!~~

## Gatekeeper checklist

- [x] **changelog** not required - this is a regression fix for a feature that isn't released yet, but which will already have a ChangeLog entry in the release notes
- [x] **backport** not required - AESCE is `development`-only
- [x] **tests** not required (build test could be added to all.sh if we want?)
