### PR TITLE
Driver-only ecdsa wrapup

### DIFF
--- a/ChangeLog.d/driver-only-ecdsa.txt
+++ b/ChangeLog.d/driver-only-ecdsa.txt
@@ -1,0 +1,7 @@
+Features
+   * When a PSA driver for ECDSA is present, it is now possible to disable
+     MBEDTLS_ECDSA_C in the build in order to save code size. For PK, X.509
+     and TLS to fully work, this requires MBEDTLS_USE_PSA_CRYPTO to be enabled.
+     Restartable/interruptible ECDSA operations in PK, X.509 and TLS are not
+     supported in those builds yet, as driver support for interruptible ECDSA
+     operations is not present yet.

--- a/docs/use-psa-crypto.md
+++ b/docs/use-psa-crypto.md
@@ -11,12 +11,15 @@ General considerations
 `psa_crypto_init()` before calling any function from the SSL/TLS, X.509 or PK
 module.
 
-**Scope:** `MBEDTLS_USE_PSA_CRYPTO` has no effect on the parts of the code that
-are specific to TLS 1.3; those parts always use PSA Crypto. The parts of the
-TLS 1.3 code that are common with TLS 1.2, however, follow this option;
-currently this is the record protection code, computation of the running
-handshake hash, and X.509. You need to enable `MBEDTLS_USE_PSA_CRYPTO` if you
-want TLS 1.3 to use PSA everywhere.
+**Scope:** `MBEDTLS_USE_PSA_CRYPTO` has no effect on the most of the TLS 1.3
+code, which always uses PSA crypto. The parts of the TLS 1.3 code that will
+use PSA Crypto or not depending on the value of this option are:
+- record protection;
+- running handshake hash;
+- asymmetric signature verification & generation;
+- X.509 certificate chain verification.
+You need to enable `MBEDTLS_USE_PSA_CRYPTO` if you want TLS 1.3 to use PSA
+everywhere.
 
 New APIs / API extensions
 -------------------------

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -783,7 +783,7 @@
 
 #if defined(MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED)
 #if !( defined(MBEDTLS_ECDH_C) && defined(MBEDTLS_X509_CRT_PARSE_C) && \
-       ( defined(MBEDTLS_ECDSA_C) || defined(MBEDTLS_PKCS1_V21) ) )
+       ( defined(MBEDTLS_PK_HAVE_ECDSA) || defined(MBEDTLS_PKCS1_V21) ) )
 #error "MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED defined, but not all prerequisites"
 #endif
 #endif

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -279,9 +279,20 @@
 #error "MBEDTLS_HMAC_DRBG_C defined, but not all prerequisites"
 #endif
 
+/* Helper for ECDSA dependencies, will be undefined at the end of the file */
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+#if defined(PSA_HAVE_FULL_ECDSA)
+#define MBEDTLS_PK_HAVE_ECDSA
+#endif
+#else /* MBEDTLS_USE_PSA_CRYPTO */
+#if defined(MBEDTLS_ECDSA_C)
+#define MBEDTLS_PK_HAVE_ECDSA
+#endif
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
+
 #if defined(MBEDTLS_KEY_EXCHANGE_ECDH_ECDSA_ENABLED) &&                 \
     ( !defined(MBEDTLS_ECDH_C) ||                                       \
-      !(defined(MBEDTLS_ECDSA_C) || defined(PSA_HAVE_FULL_ECDSA)) ||     \
+      !defined(MBEDTLS_PK_HAVE_ECDSA) ||                                \
       !defined(MBEDTLS_X509_CRT_PARSE_C) )
 #error "MBEDTLS_KEY_EXCHANGE_ECDH_ECDSA_ENABLED defined, but not all prerequisites"
 #endif
@@ -313,9 +324,9 @@
 #error "MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED defined, but not all prerequisites"
 #endif
 
-#if defined(MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED) &&                 \
+#if defined(MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED) &&                \
     ( !defined(MBEDTLS_ECDH_C) ||                                       \
-      !(defined(MBEDTLS_ECDSA_C) || defined(PSA_HAVE_FULL_ECDSA)) ||     \
+      !defined(MBEDTLS_PK_HAVE_ECDSA) ||                                \
       !defined(MBEDTLS_X509_CRT_PARSE_C) )
 #error "MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED defined, but not all prerequisites"
 #endif
@@ -1067,6 +1078,9 @@
     ( !defined(MBEDTLS_MD_C) ) )
 #error  "MBEDTLS_PKCS7_C is defined, but not all prerequisites"
 #endif
+
+/* Undefine helper symbols */
+#undef MBEDTLS_PK_HAVE_ECDSA
 
 /*
  * Avoid warning from -pedantic. This is a convenient place for this

--- a/include/mbedtls/config_psa.h
+++ b/include/mbedtls/config_psa.h
@@ -310,11 +310,6 @@ extern "C" {
 #define PSA_HAVE_SOFT_BLOCK_AEAD 1
 #endif
 
-#if defined(PSA_WANT_ALG_ECDSA) && defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR) && \
-    defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY)
-#define PSA_HAVE_FULL_ECDSA 1
-#endif
-
 #if defined(PSA_WANT_KEY_TYPE_AES)
 #if !defined(MBEDTLS_PSA_ACCEL_KEY_TYPE_AES)
 #define PSA_HAVE_SOFT_KEY_TYPE_AES 1
@@ -847,6 +842,11 @@ extern "C" {
 #endif
 
 #endif /* MBEDTLS_PSA_CRYPTO_CONFIG */
+
+#if defined(PSA_WANT_ALG_ECDSA) && defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR) && \
+    defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY)
+#define PSA_HAVE_FULL_ECDSA 1
+#endif
 
 /* These features are always enabled. */
 #define PSA_WANT_KEY_TYPE_DERIVE 1


### PR DESCRIPTION
## Description

This PR:
- fixes the issue found here: https://github.com/Mbed-TLS/mbedtls/pull/7117#discussion_r1131360315
- fixes a related issue that I noticed while looking at this
- adds a ChangeLog entry for the driver-only ECDSA work.

## Gatekeeper checklist

- [x] **changelog** provided - for the entire driver-only ECDSA series
- [x] **backport** not required - new feature
- [x] **tests** not required for `check_config.h` and ChangeLog



