### PR TITLE
Remove duplicate test macros

### DIFF
--- a/tests/include/test/macros.h
+++ b/tests/include/test/macros.h
@@ -253,27 +253,4 @@
  */
 #define MAX(x, y) ((x) > (y) ? (x) : (y))
 
-/*
- * 32-bit integer manipulation macros (big endian)
- */
-#ifndef GET_UINT32_BE
-#define GET_UINT32_BE(n, b, i)                            \
-    {                                                       \
-        (n) = ((uint32_t) (b)[(i)] << 24)             \
-              | ((uint32_t) (b)[(i) + 1] << 16)             \
-              | ((uint32_t) (b)[(i) + 2] <<  8)             \
-              | ((uint32_t) (b)[(i) + 3]);            \
-    }
-#endif
-
-#ifndef PUT_UINT32_BE
-#define PUT_UINT32_BE(n, b, i)                            \
-    {                                                       \
-        (b)[(i)] = (unsigned char) ((n) >> 24);       \
-        (b)[(i) + 1] = (unsigned char) ((n) >> 16);       \
-        (b)[(i) + 2] = (unsigned char) ((n) >>  8);       \
-        (b)[(i) + 3] = (unsigned char) ((n));       \
-    }
-#endif
-
 #endif /* TEST_MACROS_H */

--- a/tests/src/random.c
+++ b/tests/src/random.c
@@ -36,6 +36,7 @@
 #include <string.h>
 
 #include <mbedtls/entropy.h>
+#include "../../library/alignment.h"
 
 int mbedtls_test_rnd_std_rand(void *rng_state,
                               unsigned char *output,
@@ -137,7 +138,7 @@ int mbedtls_test_rnd_pseudo_rand(void *rng_state,
                          + info->v0) ^ (sum + k[(sum>>11) & 3]);
         }
 
-        PUT_UINT32_BE(info->v0, result, 0);
+        MBEDTLS_PUT_UINT32_BE(info->v0, result, 0);
         memcpy(out, result, use_len);
         len -= use_len;
         out += 4;


### PR DESCRIPTION
## Description

Minor cleanup - some test macros are just a duplicate of macros from the main library.

## Gatekeeper checklist

- [x] **changelog** not required
- [x] **backport** not required
- [x] **tests** not required
