### PR TITLE
config.py: Allow disabling of features incompatible with baremetal builds while keeping the existing config

### DIFF
--- a/scripts/config.py
+++ b/scripts/config.py
@@ -286,6 +286,9 @@ def baremetal_adapter(name, active, section):
         return True
     return include_in_full(name) and keep_in_baremetal(name)
 
+def baremetal_compatible_adapter(name, active, section):
+    return active and keep_in_baremetal(name)
+
 # This set contains options that are mostly for debugging or test purposes,
 # and therefore should be excluded when doing code size measurements.
 # Options that are their own module (such as MBEDTLS_ERROR_C) are not listed
@@ -522,6 +525,9 @@ if __name__ == '__main__':
         add_adapter('baremetal_size', baremetal_size_adapter,
                     """Like baremetal, but exclude debugging features.
                     Useful for code size measurements.""")
+        add_adapter('baremetal_compatible', baremetal_compatible_adapter,
+                    """Use the existing configuration, but disable any features
+                    (e.g. file IO) that are not compatible with a baremetal build.""")
         add_adapter('full', full_adapter,
                     """Uncomment most features.
                     Exclude alternative implementations and platform support

--- a/scripts/footprint.sh
+++ b/scripts/footprint.sh
@@ -73,9 +73,8 @@ doit()
     fi
 
     {
-        scripts/config.py unset MBEDTLS_NET_C || true
-        scripts/config.py unset MBEDTLS_TIMING_C || true
-        scripts/config.py unset MBEDTLS_FS_IO || true
+        # Remove any features that are incompatible with baremetal builds
+        scripts/config.py baremetal_compatible
         scripts/config.py --force set MBEDTLS_NO_PLATFORM_ENTROPY || true
     } >/dev/null 2>&1
 


### PR DESCRIPTION
## Description
Resolves #7235 

The current `baremetal` config option in `config.py` is the full config minus anything not compatible with baremetal builds. This does not cover the use case where a user may wish to disable features that are incompatible with baremetal builds while keeping their existing configuration. 

An example of this is `footprint.sh`. Currently it attempts to manually disable incompatible features, but this is now outdated, rendering the script unusable (see issue #7235). This PR adds a `baremetal_compatible` option to `config.py`; using this gives the existing config minus any options incompatible with baremetal. `footprint.sh` has been changed to use this option.


## Gatekeeper checklist

- [x] **changelog** not required: scripts only
- [ ] **backport** TODO
- [x] **tests** not required: scripts only

