### PR TITLE
Add changelog entry for a bug in non-PAKE code fixed during PAKE work

### DIFF
--- a/ChangeLog.d/changelog-6567-psa_key_derivation_abort-no-other_secret.txt
+++ b/ChangeLog.d/changelog-6567-psa_key_derivation_abort-no-other_secret.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix a compilation error when PSA Crypto is built with support for
+     TLS12_PRF but not TLS12_PSK_TO_MS. Reported by joerchan in #7125.


### PR DESCRIPTION
Changelog entry for a bug fixed in https://github.com/Mbed-TLS/mbedtls/pull/6567 that got lost in all the code for the new feature. The bug was originally reported [via a pull request](https://github.com/Mbed-TLS/mbedtls/pull/7125).

## Gatekeeper checklist

- [x] **changelog** yes
- [x] **backport** no (no bug in 2.28)
- [x] **tests** N/A
