### PR TITLE
6500 follow-up: enhancements to the new ssl_helpers test module

### DIFF
--- a/tests/include/test/ssl_helpers.h
+++ b/tests/include/test/ssl_helpers.h
@@ -345,7 +345,8 @@ void mbedtls_test_message_socket_init(
 int mbedtls_test_message_socket_setup(
     mbedtls_test_ssl_message_queue *queue_input,
     mbedtls_test_ssl_message_queue *queue_output,
-    size_t queue_capacity, mbedtls_test_mock_socket *socket,
+    size_t queue_capacity,
+    mbedtls_test_mock_socket *socket,
     mbedtls_test_message_socket_context *ctx);
 
 /*

--- a/tests/include/test/ssl_helpers.h
+++ b/tests/include/test/ssl_helpers.h
@@ -101,6 +101,9 @@ typedef struct mbedtls_test_handshake_test_options {
 #endif
 } mbedtls_test_handshake_test_options;
 
+/*
+ * Buffer structure for custom I/O callbacks.
+ */
 typedef struct mbedtls_test_ssl_buffer {
     size_t start;
     size_t content_length;
@@ -459,6 +462,12 @@ int mbedtls_test_move_handshake_to_state(mbedtls_ssl_context *ssl,
             goto cleanup;                       \
         }                                       \
     } while (0)
+
+#if MBEDTLS_SSL_CID_OUT_LEN_MAX > MBEDTLS_SSL_CID_IN_LEN_MAX
+#define SSL_CID_LEN_MIN MBEDTLS_SSL_CID_IN_LEN_MAX
+#else
+#define SSL_CID_LEN_MIN MBEDTLS_SSL_CID_OUT_LEN_MAX
+#endif
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_2) && \
     defined(MBEDTLS_CIPHER_MODE_CBC) && defined(MBEDTLS_AES_C)

--- a/tests/include/test/ssl_helpers.h
+++ b/tests/include/test/ssl_helpers.h
@@ -285,13 +285,13 @@ int mbedtls_test_ssl_message_queue_pop_info(
 /*
  * Setup and teardown functions for mock sockets.
  */
-void mbedtls_mock_socket_init(mbedtls_test_mock_socket *socket);
+void mbedtls_test_mock_socket_init(mbedtls_test_mock_socket *socket);
 
 /*
  * Closes the socket \p socket.
  *
  * \p socket must have been previously initialized by calling
- * mbedtls_mock_socket_init().
+ * mbedtls_test_mock_socket_init().
  *
  * This function frees all allocated resources and both sockets are aware of the
  * new connection state.
@@ -306,7 +306,7 @@ void mbedtls_test_mock_socket_close(mbedtls_test_mock_socket *socket);
  * Establishes a connection between \p peer1 and \p peer2.
  *
  * \p peer1 and \p peer2 must have been previously initialized by calling
- * mbedtls_mock_socket_init().
+ * mbedtls_test_mock_socket_init().
  *
  * The capacities of the internal buffers are set to \p bufsize. Setting this to
  * the correct value allows for simulation of MTU, sanity testing the mock

--- a/tests/include/test/ssl_helpers.h
+++ b/tests/include/test/ssl_helpers.h
@@ -386,8 +386,7 @@ int mbedtls_test_mock_tcp_send_msg(void *ctx,
  *          mbedtls_test_mock_tcp_recv_b failed.
  *
  * This function will also return any error other than
- * MBEDTLS_TEST_ERROR_MESSAGE_TRUNCATED from
- * mbedtls_test_message_queue_peek_info.
+ * MBEDTLS_TEST_ERROR_MESSAGE_TRUNCATED from test_ssl_message_queue_peek_info.
  */
 int mbedtls_test_mock_tcp_recv_msg(void *ctx,
                                    unsigned char *buf, size_t buf_len);

--- a/tests/include/test/ssl_helpers.h
+++ b/tests/include/test/ssl_helpers.h
@@ -547,7 +547,7 @@ void mbedtls_test_ssl_perform_handshake(
  *                    is expected to fail. All zeroes if no
  *                    MBEDTLS_SSL_CHK_BUF_READ_PTR failure is expected.
  */
-int tweak_tls13_certificate_msg_vector_len(
+int mbedtls_test_tweak_tls13_certificate_msg_vector_len(
     unsigned char *buf, unsigned char **end, int tweak,
     int *expected_result, mbedtls_ssl_chk_buf_ptr_args *args);
 #endif /* MBEDTLS_TEST_HOOKS */

--- a/tests/include/test/ssl_helpers.h
+++ b/tests/include/test/ssl_helpers.h
@@ -524,10 +524,11 @@ int mbedtls_test_ssl_tls13_populate_session(mbedtls_ssl_session *session,
  *
  * \retval  0 on success, otherwise error code.
  */
-int mbedtls_exchange_data(mbedtls_ssl_context *ssl_1,
-                          int msg_len_1, const int expected_fragments_1,
-                          mbedtls_ssl_context *ssl_2,
-                          int msg_len_2, const int expected_fragments_2);
+int mbedtls_test_ssl_exchange_data(
+    mbedtls_ssl_context *ssl_1,
+    int msg_len_1, const int expected_fragments_1,
+    mbedtls_ssl_context *ssl_2,
+    int msg_len_2, const int expected_fragments_2);
 
 #if defined(MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED)
 void mbedtls_test_ssl_perform_handshake(

--- a/tests/src/test_helpers/ssl_helpers.c
+++ b/tests/src/test_helpers/ssl_helpers.c
@@ -233,8 +233,8 @@ int mbedtls_test_ssl_buffer_get(mbedtls_test_ssl_buffer *buf,
     return (output_len > INT_MAX) ? INT_MAX : (int) output_len;
 }
 
-int mbedtls_test_ssl_message_queue_setup(mbedtls_test_ssl_message_queue *queue,
-                                         size_t capacity)
+int mbedtls_test_ssl_message_queue_setup(
+    mbedtls_test_ssl_message_queue *queue, size_t capacity)
 {
     queue->messages = (size_t *) mbedtls_calloc(capacity, sizeof(size_t));
     if (NULL == queue->messages) {
@@ -248,7 +248,8 @@ int mbedtls_test_ssl_message_queue_setup(mbedtls_test_ssl_message_queue *queue,
     return 0;
 }
 
-void mbedtls_test_ssl_message_queue_free(mbedtls_test_ssl_message_queue *queue)
+void mbedtls_test_ssl_message_queue_free(
+    mbedtls_test_ssl_message_queue *queue)
 {
     if (queue == NULL) {
         return;
@@ -459,7 +460,8 @@ int mbedtls_test_mock_tcp_recv_nb(void *ctx, unsigned char *buf, size_t len)
     return mbedtls_test_ssl_buffer_get(socket->input, buf, len);
 }
 
-void mbedtls_test_message_socket_init(mbedtls_test_message_socket_context *ctx)
+void mbedtls_test_message_socket_init(
+    mbedtls_test_message_socket_context *ctx)
 {
     ctx->queue_input = NULL;
     ctx->queue_output = NULL;
@@ -485,7 +487,8 @@ int mbedtls_test_message_socket_setup(
     return 0;
 }
 
-void mbedtls_test_message_socket_close(mbedtls_test_message_socket_context *ctx)
+void mbedtls_test_message_socket_close(
+    mbedtls_test_message_socket_context *ctx)
 {
     if (ctx == NULL) {
         return;

--- a/tests/src/test_helpers/ssl_helpers.c
+++ b/tests/src/test_helpers/ssl_helpers.c
@@ -124,10 +124,6 @@ static void reset_chk_buf_ptr_args(mbedtls_ssl_chk_buf_ptr_args *args)
 }
 #endif /* MBEDTLS_TEST_HOOKS */
 
-/*
- * Buffer structure for custom I/O callbacks.
- */
-
 void mbedtls_test_ssl_buffer_init(mbedtls_test_ssl_buffer *buf)
 {
     memset(buf, 0, sizeof(*buf));
@@ -1023,12 +1019,6 @@ int psk_dummy_callback(void *p_info, mbedtls_ssl_context *ssl,
     return 0;
 }
 
-#if MBEDTLS_SSL_CID_OUT_LEN_MAX > MBEDTLS_SSL_CID_IN_LEN_MAX
-#define SSL_CID_LEN_MIN MBEDTLS_SSL_CID_IN_LEN_MAX
-#else
-#define SSL_CID_LEN_MIN MBEDTLS_SSL_CID_OUT_LEN_MAX
-#endif
-
 #if defined(MBEDTLS_SSL_PROTO_TLS1_2) && \
     defined(MBEDTLS_CIPHER_MODE_CBC) && defined(MBEDTLS_AES_C)
 int mbedtls_test_psa_cipher_encrypt_helper(mbedtls_ssl_transform *transform,
@@ -1735,7 +1725,6 @@ exit:
     return 0;
 }
 #endif /* MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED */
-
 
 #if defined(MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED)
 void mbedtls_test_ssl_perform_handshake(

--- a/tests/src/test_helpers/ssl_helpers.c
+++ b/tests/src/test_helpers/ssl_helpers.c
@@ -327,7 +327,7 @@ static int test_ssl_message_queue_peek_info(
     return (*msg_len > buf_len) ? MBEDTLS_TEST_ERROR_MESSAGE_TRUNCATED : 0;
 }
 
-void mbedtls_mock_socket_init(mbedtls_test_mock_socket *socket)
+void mbedtls_test_mock_socket_init(mbedtls_test_mock_socket *socket)
 {
     memset(socket, 0, sizeof(*socket));
 }
@@ -479,7 +479,7 @@ int mbedtls_test_message_socket_setup(
     ctx->queue_input = queue_input;
     ctx->queue_output = queue_output;
     ctx->socket = socket;
-    mbedtls_mock_socket_init(socket);
+    mbedtls_test_mock_socket_init(socket);
 
     return 0;
 }
@@ -781,7 +781,7 @@ int mbedtls_test_ssl_endpoint_init(
                                                       100, &(ep->socket),
                                                       dtls_context) == 0);
     } else {
-        mbedtls_mock_socket_init(&(ep->socket));
+        mbedtls_test_mock_socket_init(&(ep->socket));
     }
 
     /* Non-blocking callbacks without timeout */

--- a/tests/src/test_helpers/ssl_helpers.c
+++ b/tests/src/test_helpers/ssl_helpers.c
@@ -981,8 +981,9 @@ exit:
     return -1;
 }
 
-void set_ciphersuite(mbedtls_ssl_config *conf, const char *cipher,
-                     int *forced_ciphersuite)
+#if defined(MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED)
+static void set_ciphersuite(mbedtls_ssl_config *conf, const char *cipher,
+                            int *forced_ciphersuite)
 {
     const mbedtls_ssl_ciphersuite_t *ciphersuite_info;
     forced_ciphersuite[0] = mbedtls_ssl_get_ciphersuite_id(cipher);
@@ -1007,9 +1008,13 @@ void set_ciphersuite(mbedtls_ssl_config *conf, const char *cipher,
 exit:
     return;
 }
+#endif /* MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED */
 
-int psk_dummy_callback(void *p_info, mbedtls_ssl_context *ssl,
-                       const unsigned char *name, size_t name_len)
+#if defined(MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED) && \
+    defined(MBEDTLS_SSL_HANDSHAKE_WITH_PSK_ENABLED)  && \
+    defined(MBEDTLS_SSL_SRV_C)
+static int psk_dummy_callback(void *p_info, mbedtls_ssl_context *ssl,
+                              const unsigned char *name, size_t name_len)
 {
     (void) p_info;
     (void) ssl;
@@ -1018,6 +1023,9 @@ int psk_dummy_callback(void *p_info, mbedtls_ssl_context *ssl,
 
     return 0;
 }
+#endif /* MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED &&
+          MBEDTLS_SSL_HANDSHAKE_WITH_PSK_ENABLED  &&
+          MBEDTLS_SSL_SRV_C */
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_2) && \
     defined(MBEDTLS_CIPHER_MODE_CBC) && defined(MBEDTLS_AES_C)
@@ -1680,12 +1688,18 @@ exit:
  *
  * \retval  0 on success, otherwise error code.
  */
-int exchange_data(mbedtls_ssl_context *ssl_1,
-                  mbedtls_ssl_context *ssl_2)
+#if defined(MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED) && \
+    (defined(MBEDTLS_SSL_RENEGOTIATION)              || \
+    defined(MBEDTLS_SSL_VARIABLE_BUFFER_LENGTH))
+static int exchange_data(mbedtls_ssl_context *ssl_1,
+                         mbedtls_ssl_context *ssl_2)
 {
     return mbedtls_exchange_data(ssl_1, 256, 1,
                                  ssl_2, 256, 1);
 }
+#endif /* MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED &&
+          (MBEDTLS_SSL_RENEGOTIATION              ||
+          MBEDTLS_SSL_VARIABLE_BUFFER_LENGTH) */
 
 #if defined(MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED)
 static int check_ssl_version(

--- a/tests/src/test_helpers/ssl_helpers.c
+++ b/tests/src/test_helpers/ssl_helpers.c
@@ -577,7 +577,7 @@ int mbedtls_test_mock_tcp_recv_msg(void *ctx,
 /*
  * Deinitializes certificates from endpoint represented by \p ep.
  */
-void mbedtls_endpoint_certificate_free(mbedtls_test_ssl_endpoint *ep)
+static void test_ssl_endpoint_certificate_free(mbedtls_test_ssl_endpoint *ep)
 {
     mbedtls_test_ssl_endpoint_certificate *cert = &(ep->cert);
     if (cert != NULL) {
@@ -729,7 +729,7 @@ int mbedtls_test_ssl_endpoint_certificate_init(mbedtls_test_ssl_endpoint *ep,
 
 exit:
     if (ret != 0) {
-        mbedtls_endpoint_certificate_free(ep);
+        test_ssl_endpoint_certificate_free(ep);
     }
 
     return ret;
@@ -845,7 +845,7 @@ void mbedtls_test_ssl_endpoint_free(
     mbedtls_test_ssl_endpoint *ep,
     mbedtls_test_message_socket_context *context)
 {
-    mbedtls_endpoint_certificate_free(ep);
+    test_ssl_endpoint_certificate_free(ep);
 
     mbedtls_ssl_free(&(ep->ssl));
     mbedtls_ssl_config_free(&(ep->conf));

--- a/tests/src/test_helpers/ssl_helpers.c
+++ b/tests/src/test_helpers/ssl_helpers.c
@@ -312,8 +312,9 @@ int mbedtls_test_ssl_message_queue_pop_info(
  *          set to the full message length so that the
  *          caller knows what portion of the message can be dropped.
  */
-int mbedtls_test_message_queue_peek_info(mbedtls_test_ssl_message_queue *queue,
-                                         size_t buf_len, size_t *msg_len)
+static int test_ssl_message_queue_peek_info(
+    mbedtls_test_ssl_message_queue *queue,
+    size_t buf_len, size_t *msg_len)
 {
     if (queue == NULL || msg_len == NULL) {
         return MBEDTLS_TEST_ERROR_ARG_NULL;
@@ -543,7 +544,7 @@ int mbedtls_test_mock_tcp_recv_msg(void *ctx,
 
     /* Peek first, so that in case of a socket error the data remains in
      * the queue. */
-    ret = mbedtls_test_message_queue_peek_info(queue, buf_len, &msg_len);
+    ret = test_ssl_message_queue_peek_info(queue, buf_len, &msg_len);
     if (ret == MBEDTLS_TEST_ERROR_MESSAGE_TRUNCATED) {
         /* Calculate how much to drop */
         drop_len = msg_len - buf_len;

--- a/tests/src/test_helpers/ssl_helpers.c
+++ b/tests/src/test_helpers/ssl_helpers.c
@@ -2131,7 +2131,7 @@ exit:
 #endif /* MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED */
 
 #if defined(MBEDTLS_TEST_HOOKS)
-int tweak_tls13_certificate_msg_vector_len(
+int mbedtls_test_tweak_tls13_certificate_msg_vector_len(
     unsigned char *buf, unsigned char **end, int tweak,
     int *expected_result, mbedtls_ssl_chk_buf_ptr_args *args)
 {

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -3085,10 +3085,11 @@ void force_bad_session_id_len()
     server.ssl.session_negotiate->id_len = 33;
     if (options.cli_msg_len != 0 || options.srv_msg_len != 0) {
         /* Start data exchanging test */
-        TEST_ASSERT(mbedtls_exchange_data(&(client.ssl), options.cli_msg_len,
-                                          options.expected_cli_fragments,
-                                          &(server.ssl), options.srv_msg_len,
-                                          options.expected_srv_fragments)
+        TEST_ASSERT(mbedtls_test_ssl_exchange_data(
+                        &(client.ssl), options.cli_msg_len,
+                        options.expected_cli_fragments,
+                        &(server.ssl), options.srv_msg_len,
+                        options.expected_srv_fragments)
                     == 0);
     }
 

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -210,17 +210,17 @@ void ssl_mock_sanity()
     unsigned char received[MSGLEN] = { 0 };
     mbedtls_test_mock_socket socket;
 
-    mbedtls_mock_socket_init(&socket);
+    mbedtls_test_mock_socket_init(&socket);
     TEST_ASSERT(mbedtls_test_mock_tcp_send_b(&socket, message, MSGLEN) < 0);
     mbedtls_test_mock_socket_close(&socket);
-    mbedtls_mock_socket_init(&socket);
+    mbedtls_test_mock_socket_init(&socket);
     TEST_ASSERT(mbedtls_test_mock_tcp_recv_b(&socket, received, MSGLEN) < 0);
     mbedtls_test_mock_socket_close(&socket);
 
-    mbedtls_mock_socket_init(&socket);
+    mbedtls_test_mock_socket_init(&socket);
     TEST_ASSERT(mbedtls_test_mock_tcp_send_nb(&socket, message, MSGLEN) < 0);
     mbedtls_test_mock_socket_close(&socket);
-    mbedtls_mock_socket_init(&socket);
+    mbedtls_test_mock_socket_init(&socket);
     TEST_ASSERT(mbedtls_test_mock_tcp_recv_nb(&socket, received, MSGLEN) < 0);
     mbedtls_test_mock_socket_close(&socket);
 
@@ -258,8 +258,8 @@ void ssl_mock_tcp(int blocking)
         recv = mbedtls_test_mock_tcp_recv_b;
     }
 
-    mbedtls_mock_socket_init(&client);
-    mbedtls_mock_socket_init(&server);
+    mbedtls_test_mock_socket_init(&client);
+    mbedtls_test_mock_socket_init(&server);
 
     /* Fill up the buffer with structured data so that unwanted changes
      * can be detected */
@@ -356,8 +356,8 @@ void ssl_mock_tcp_interleaving(int blocking)
         recv = mbedtls_test_mock_tcp_recv_b;
     }
 
-    mbedtls_mock_socket_init(&client);
-    mbedtls_mock_socket_init(&server);
+    mbedtls_test_mock_socket_init(&client);
+    mbedtls_test_mock_socket_init(&server);
 
     /* Fill up the buffers with structured data so that unwanted changes
      * can be detected */

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -3358,7 +3358,7 @@ void tls13_server_certificate_msg_invalid_vector_len()
          * Tweak server Certificate message and parse it.
          */
 
-        ret = tweak_tls13_certificate_msg_vector_len(
+        ret = mbedtls_test_tweak_tls13_certificate_msg_vector_len(
             buf, &end, step, &expected_result, &expected_chk_buf_ptr_args);
 
         if (ret != 0) {


### PR DESCRIPTION
## Description

Fix #7285
minor follow-up PR of #6500 
- [x] unify code format of function declaration between `ssl_helpers.c` and `ssl_helpers.h`
- [x] rename prefix for some functions in `ssl_helpers.c`
- [x] move some internal functions to static

## Gatekeeper checklist

- [x] **changelog** not required - internal refactoring of tests only, no user-visible changes
- [x] **backport** https://github.com/Mbed-TLS/mbedtls/pull/7332
- [x] **tests** not required