### PR TITLE
Driver only EC JPAKE: re-enable the EC J-PAKE key exchange and get test parity

### DIFF
--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -290,6 +290,17 @@
 #endif
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
+/* Helper for JPAKE dependencies, will be undefined at the end of the file */
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+#if defined(PSA_HAVE_FULL_JPAKE)
+#define MBEDTLS_PK_HAVE_JPAKE
+#endif
+#else /* MBEDTLS_USE_PSA_CRYPTO */
+#if defined(MBEDTLS_ECJPAKE_C)
+#define MBEDTLS_PK_HAVE_JPAKE
+#endif
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
+
 #if defined(MBEDTLS_KEY_EXCHANGE_ECDH_ECDSA_ENABLED) &&                 \
     ( !defined(MBEDTLS_ECDH_C) ||                                       \
       !defined(MBEDTLS_PK_HAVE_ECDSA) ||                                \
@@ -344,7 +355,7 @@
 #endif
 
 #if defined(MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED) &&                    \
-    ( !defined(MBEDTLS_ECJPAKE_C) ||                                    \
+    ( !defined(MBEDTLS_PK_HAVE_JPAKE) ||                                    \
       !defined(MBEDTLS_ECP_DP_SECP256R1_ENABLED) )
 #error "MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED defined, but not all prerequisites"
 #endif
@@ -1081,6 +1092,7 @@
 
 /* Undefine helper symbols */
 #undef MBEDTLS_PK_HAVE_ECDSA
+#undef MBEDTLS_PK_HAVE_JPAKE
 
 /*
  * Avoid warning from -pedantic. This is a convenient place for this

--- a/include/mbedtls/config_psa.h
+++ b/include/mbedtls/config_psa.h
@@ -848,6 +848,11 @@ extern "C" {
 #define PSA_HAVE_FULL_ECDSA 1
 #endif
 
+#if defined(PSA_WANT_ALG_JPAKE) && defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR) && \
+    defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY)
+#define PSA_HAVE_FULL_JPAKE 1
+#endif
+
 /* These features are always enabled. */
 #define PSA_WANT_KEY_TYPE_DERIVE 1
 #define PSA_WANT_KEY_TYPE_PASSWORD 1

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -2352,8 +2352,6 @@ config_psa_crypto_config_ecjpake_use_psa () {
         # Disable the module that's accelerated
         scripts/config.py unset MBEDTLS_ECJPAKE_C
     fi
-    # Disable things that depend on it (regardless of driver or built-in)
-    scripts/config.py unset MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED
 
     # Dynamic secure element support is a deprecated feature and needs to be disabled here.
     # This is done to have the same form of psa_key_attributes_s for libdriver and library.

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -2398,8 +2398,8 @@ component_test_psa_crypto_config_accel_ecjpake_use_psa () {
     msg "test: MBEDTLS_PSA_CRYPTO_CONFIG with accelerated JPAKE + USE_PSA"
     make test
 
-    # ssl-opt will be added later. Please check issue 7255 for a list of
-    # follow up activities
+    msg "test: ssl-opt.sh"
+    tests/ssl-opt.sh
 }
 
 # Keep in sync with component_test_psa_crypto_config_accel_ecjpake_use_psa.
@@ -2418,8 +2418,8 @@ component_test_psa_crypto_config_reference_ecjpake_use_psa () {
     msg "test: MBEDTLS_PSA_CRYPTO_CONFIG with reference ECJPAKE + USE_PSA"
     make test
 
-    # ssl-opt will be added later. Please check issue 7255 for a list of
-    # follow up activities
+    msg "test: ssl-opt.sh"
+    tests/ssl-opt.sh
 }
 
 component_test_psa_crypto_config_accel_rsa_signature () {


### PR DESCRIPTION
This PR addresses issue #7281 by re-enabling EC JPAKE key exchanges and getting test parity in driver coverage analysis.

Depends on #7299
Resolves #7281 

## Gatekeeper checklist

- [x] **changelog** TODO in a follow-up
- [x] **backport** not required
- [X] **tests** provided