### PR TITLE
Changelog and terminology tidy-up for AESCE

### DIFF
--- a/ChangeLog.d/armv8-aes.txt
+++ b/ChangeLog.d/armv8-aes.txt
@@ -1,0 +1,5 @@
+Features
+   * Add support for the Armv8-A Cryptographic Extension in AES on
+     64-bit Arm. A new configuration option, MBEDTLS_AESCE_C, can
+     be used to enable this feature. Run-time detection is supported
+     under Linux only.

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -2039,24 +2039,25 @@
  *
  * Requires: MBEDTLS_HAVE_ASM
  *
- * This modules adds support for the AES-NI instructions on x86-64
+ * This module adds support for the AES-NI instructions on x86-64
  */
 #define MBEDTLS_AESNI_C
 
 /**
  * \def MBEDTLS_AESCE_C
  *
- * Enable AES crypto extension support on Arm64.
+ * Enable AES cryptographic extension support on 64-bit Arm.
  *
  * Module:  library/aesce.c
  * Caller:  library/aes.c
  *
  * Requires: MBEDTLS_HAVE_ASM, MBEDTLS_AES_C
  *
- * \warning Runtime detection only works on linux. For non-linux operation
- *          system, crypto extension MUST be supported by CPU.
+ * \warning Runtime detection only works on Linux. For non-Linux operating
+ *          system, Armv8-A Cryptographic Extensions must be supported by
+ *          the CPU when this option is enabled.
  *
- * This module adds support for the AES crypto instructions on Arm64
+ * This module adds support for the AES Armv8-A Cryptographic Extensions on Aarch64 systems.
  */
 #define MBEDTLS_AESCE_C
 

--- a/library/aesce.c
+++ b/library/aesce.c
@@ -1,5 +1,5 @@
 /*
- *  Arm64 crypto extension support functions
+ *  Armv8-A Cryptographic Extension support functions for Aarch64
  *
  *  Copyright The Mbed TLS Contributors
  *  SPDX-License-Identifier: Apache-2.0

--- a/library/aesce.h
+++ b/library/aesce.h
@@ -1,8 +1,8 @@
 /**
  * \file aesce.h
  *
- * \brief AES-CE for hardware AES acceleration on ARMv8 processors with crypto
- *        extension.
+ * \brief Support hardware AES acceleration on Armv8-A processors with
+ *        the Armv8-A Cryptographic Extension in AArch64 execution state.
  *
  * \warning These functions are only for internal use by other library
  *          functions; you must not call them directly.


### PR DESCRIPTION
## Description

Add missing changelog for #6918 and #6915; tidy-up use of terminology in source files.

## Gatekeeper checklist

- [x] **changelog** provided
- [x] **backport** not required
- [x] **tests** not required
