### PR TITLE
Adjust log level for "got supported group" message.

### DIFF
--- a/library/ssl_client.c
+++ b/library/ssl_client.c
@@ -255,7 +255,7 @@ static int ssl_write_supported_groups_ext(mbedtls_ssl_context *ssl,
     }
 
     for (; *group_list != 0; group_list++) {
-        MBEDTLS_SSL_DEBUG_MSG(1, ("got supported group(%04x)", *group_list));
+        MBEDTLS_SSL_DEBUG_MSG(3, ("got supported group(%04x)", *group_list));
 
 #if defined(MBEDTLS_ECP_C)
         if ((mbedtls_ssl_conf_is_tls13_enabled(ssl->conf) &&


### PR DESCRIPTION
## Description
This PR resolve #6765 issue. During one successful DTLS handshake, user seeing many message caused by wrong log level.

## Gatekeeper checklist

- [ ] **changelog** not required
- [ ] **backport** not required
- [ ] **tests** not required
