### PR TITLE
Add msvc support for AESCE

### DIFF
--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -66,13 +66,6 @@
 #error "MBEDTLS_HAVE_TIME_DATE without MBEDTLS_HAVE_TIME does not make sense"
 #endif
 
-#if defined(__aarch64__) && defined(__GNUC__)
-/* We don't do anything with MBEDTLS_AESCE_C on systems without ^ these two */
-#if defined(MBEDTLS_AESCE_C) && !defined(MBEDTLS_HAVE_ASM)
-#error "MBEDTLS_AESCE_C defined, but not all prerequisites"
-#endif
-#endif
-
 #if defined(MBEDTLS_CTR_DRBG_C) && !defined(MBEDTLS_AES_C)
 #error "MBEDTLS_CTR_DRBG_C defined, but not all prerequisites"
 #endif

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -2082,8 +2082,8 @@
  *          system, Armv8-A Cryptographic Extensions must be supported by
  *          the CPU when this option is enabled.
  *
- * \note    The minimum version of MSVC for building this module is "Visual
- *          Studio 2019 version 16.11.2"(`_MSC_VER >= 1929`)
+ * \note    Minimum compiler versions for this feature are Clang 4.0,
+ *          GCC 6.0 or MSVC 2019 version 16.11.2.
  *
  * This module adds support for the AES Armv8-A Cryptographic Extensions on Aarch64 systems.
  */

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -2076,11 +2076,14 @@
  * Module:  library/aesce.c
  * Caller:  library/aes.c
  *
- * Requires: MBEDTLS_HAVE_ASM, MBEDTLS_AES_C
+ * Requires: MBEDTLS_AES_C
  *
  * \warning Runtime detection only works on Linux. For non-Linux operating
  *          system, Armv8-A Cryptographic Extensions must be supported by
  *          the CPU when this option is enabled.
+ *
+ * \note    The minimum version of MSVC for building this module is "Visual
+ *          Studio 2019 version 16.11.2"(`_MSC_VER >= 1929`)
  *
  * This module adds support for the AES Armv8-A Cryptographic Extensions on Aarch64 systems.
  */

--- a/library/aesce.c
+++ b/library/aesce.c
@@ -62,8 +62,9 @@
 #       pragma GCC push_options
 #       pragma GCC target ("arch=armv8-a+crypto")
 #       define MBEDTLS_POP_TARGET_PRAGMA
+#   elif defined(_MSC_VER)
 #   else
-#       error "Only GCC and Clang supported for MBEDTLS_AESCE_C"
+#       error "Only MSVC, GCC and Clang supported for MBEDTLS_AESCE_C"
 #   endif
 #endif /* !__ARM_FEATURE_AES || MBEDTLS_ENABLE_ARM_CRYPTO_EXTENSIONS_COMPILER_FLAG */
 

--- a/library/aesce.c
+++ b/library/aesce.c
@@ -375,9 +375,14 @@ static inline uint8x16x3_t poly_mult_128(uint8x16_t a, uint8x16_t b)
 static inline uint8x16_t poly_mult_reduce(uint8x16x3_t input)
 {
     uint8x16_t const ZERO = vdupq_n_u8(0);
-    /* use 'asm' as an optimisation barrier to prevent loading MODULO from memory */
+
     uint64x2_t r = vreinterpretq_u64_u8(vdupq_n_u8(0x87));
+#if defined(__GNUC__)
+    /* use 'asm' as an optimisation barrier to prevent loading MODULO from
+     * memory. It is for GNUC compatible compilers.
+     */
     asm ("" : "+w" (r));
+#endif
     uint8x16_t const MODULO = vreinterpretq_u8_u64(vshrq_n_u64(r, 64 - 8));
     uint8x16_t h, m, l; /* input high/middle/low 128b */
     uint8x16_t c, d, e, f, g, n, o;

--- a/library/aesce.c
+++ b/library/aesce.c
@@ -48,23 +48,28 @@
 
 #if defined(MBEDTLS_HAVE_ARM64)
 
+/* Compiler version checks. */
+#if defined(__clang__) && (__clang_major__ < 4)
+#   error "Minimum version of Clang for MBEDTLS_AESCE_C is 4.0."
+#elif defined(__GNUC__) && (__GNUC__ < 6)
+#   error "Minimum version of GCC for MBEDTLS_AESCE_C is 6.0."
+#elif defined(_MSC_VER) && (_MSC_VER < 1929)
+/* TODO: We haven't verified MSVC from 1920 to 1928. If someone verified that,
+ *       please update this and document of `MBEDTLS_AESCE_C` in
+ *       `mbedtls_config.h`. */
+#   error "Minimum version of MSVC for MBEDTLS_AESCE_C is 2019 version 16.11.2."
+#endif
+
 #if !defined(__ARM_FEATURE_AES) || defined(MBEDTLS_ENABLE_ARM_CRYPTO_EXTENSIONS_COMPILER_FLAG)
 #   if defined(__clang__)
-#       if __clang_major__ < 4
-#           error "A more recent Clang is required for MBEDTLS_AESCE_C"
-#       endif
 #       pragma clang attribute push (__attribute__((target("crypto"))), apply_to=function)
 #       define MBEDTLS_POP_TARGET_PRAGMA
 #   elif defined(__GNUC__)
-#       if __GNUC__ < 6
-#           error "A more recent GCC is required for MBEDTLS_AESCE_C"
-#       endif
 #       pragma GCC push_options
 #       pragma GCC target ("arch=armv8-a+crypto")
 #       define MBEDTLS_POP_TARGET_PRAGMA
 #   elif defined(_MSC_VER)
-#   else
-#       error "Only MSVC, GCC and Clang supported for MBEDTLS_AESCE_C"
+#       error "Required feature(__ARM_FEATURE_AES) is not enabled."
 #   endif
 #endif /* !__ARM_FEATURE_AES || MBEDTLS_ENABLE_ARM_CRYPTO_EXTENSIONS_COMPILER_FLAG */
 

--- a/library/aesce.c
+++ b/library/aesce.c
@@ -49,15 +49,21 @@
 #if defined(MBEDTLS_HAVE_ARM64)
 
 /* Compiler version checks. */
-#if defined(__clang__) && (__clang_major__ < 4)
-#   error "Minimum version of Clang for MBEDTLS_AESCE_C is 4.0."
-#elif defined(__GNUC__) && (__GNUC__ < 6)
-#   error "Minimum version of GCC for MBEDTLS_AESCE_C is 6.0."
-#elif defined(_MSC_VER) && (_MSC_VER < 1929)
+#if defined(__clang__)
+#   if __clang_major__ < 4
+#       error "Minimum version of Clang for MBEDTLS_AESCE_C is 4.0."
+#   endif
+#elif defined(__GNUC__)
+#   if __GNUC__ < 6
+#       error "Minimum version of GCC for MBEDTLS_AESCE_C is 6.0."
+#   endif
+#elif defined(_MSC_VER)
 /* TODO: We haven't verified MSVC from 1920 to 1928. If someone verified that,
  *       please update this and document of `MBEDTLS_AESCE_C` in
  *       `mbedtls_config.h`. */
-#   error "Minimum version of MSVC for MBEDTLS_AESCE_C is 2019 version 16.11.2."
+#   if _MSC_VER < 1929
+#       error "Minimum version of MSVC for MBEDTLS_AESCE_C is 2019 version 16.11.2."
+#   endif
 #endif
 
 #if !defined(__ARM_FEATURE_AES) || defined(MBEDTLS_ENABLE_ARM_CRYPTO_EXTENSIONS_COMPILER_FLAG)

--- a/library/aesce.h
+++ b/library/aesce.h
@@ -30,11 +30,18 @@
 
 #include "mbedtls/aes.h"
 
-
+#if !defined(MBEDTLS_HAVE_ARM64)
 #if defined(MBEDTLS_HAVE_ASM) && defined(__GNUC__) && \
-    defined(__aarch64__) && !defined(MBEDTLS_HAVE_ARM64)
+    defined(__aarch64__)
 #define MBEDTLS_HAVE_ARM64
 #endif
+
+/* MSVC */
+#if defined(_M_ARM64) || defined(_M_ARM64EC)
+#define MBEDTLS_HAVE_ARM64
+#endif
+#endif
+
 
 #if defined(MBEDTLS_HAVE_ARM64)
 

--- a/library/aesce.h
+++ b/library/aesce.h
@@ -31,13 +31,13 @@
 #include "mbedtls/aes.h"
 
 #if !defined(MBEDTLS_HAVE_ARM64)
-#if defined(MBEDTLS_HAVE_ASM) && defined(__GNUC__) && \
-    defined(__aarch64__)
+#if defined(__GNUC__) && defined(__aarch64__)
 #define MBEDTLS_HAVE_ARM64
 #endif
 
 /* MSVC */
-#if defined(_M_ARM64) || defined(_M_ARM64EC)
+#if defined(_MSC_VER) && _MSC_VER >=1929 && \
+    (defined(_M_ARM64) || defined(_M_ARM64EC))
 #define MBEDTLS_HAVE_ARM64
 #endif
 #endif

--- a/library/aesce.h
+++ b/library/aesce.h
@@ -31,21 +31,10 @@
 #include "mbedtls/aes.h"
 
 #if !defined(MBEDTLS_HAVE_ARM64)
-#if defined(__GNUC__) && defined(__aarch64__)
-#define MBEDTLS_HAVE_ARM64
-#endif
-
-/* MSVC
- * TODO: We haven't verified msvc from 1920 to 1928. If someone verified that,
- *       please update this and document of `MBEDTLS_AESCE_C` in
- *       `mbedtls_config.h`
- */
-#if defined(_MSC_VER) && _MSC_VER >=1929 && \
-    (defined(_M_ARM64) || defined(_M_ARM64EC))
+#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
 #define MBEDTLS_HAVE_ARM64
 #endif
 #endif
-
 
 #if defined(MBEDTLS_HAVE_ARM64)
 

--- a/library/aesce.h
+++ b/library/aesce.h
@@ -35,7 +35,11 @@
 #define MBEDTLS_HAVE_ARM64
 #endif
 
-/* MSVC */
+/* MSVC
+ * TODO: We haven't verified msvc from 1920 to 1928. If someone verified that,
+ *       please update this and document of `MBEDTLS_AESCE_C` in
+ *       `mbedtls_config.h`
+ */
 #if defined(_MSC_VER) && _MSC_VER >=1929 && \
     (defined(_M_ARM64) || defined(_M_ARM64EC))
 #define MBEDTLS_HAVE_ARM64


### PR DESCRIPTION
## Description

Fixes #6920 

This PR is enable MSVC support for AESCE module. 

The code is verified under below condition.
- Build with VS2022 and `platformtoolsetversion=v143`
   - With VS2022, platformtoolsetversion=v141 build fail. `arm_neon.h` reports ARM64 not supported
- Test on Windows 10 with `selftest` 

> NOTE:  Build command `msbuild /nodeReuse:false /t:Rebuild /p:Configuration=Debug,Platform=ARM64,PlatformToolset=v143  "mbedTLS.sln"`


## Gatekeeper checklist

- [x] **changelog** not required - covered by #7313
- [x] **backport** not in 2.28
- [x] **tests** provided, or not required

