### PR TITLE
Note that MBEDTLS_HAVE_ASM is required by MBEDTLS_AESCE_C

### DIFF
--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -55,6 +55,7 @@
  *      library/padlock.h
  *
  * Required by:
+ *      MBEDTLS_AESCE_C
  *      MBEDTLS_AESNI_C
  *      MBEDTLS_PADLOCK_C
  *


### PR DESCRIPTION
## Gatekeeper checklist

- [ ] **changelog** not required - this is just to tidy up following \6918
- [ ] **backport** not required - this is development only
- [ ] **tests** not required - this is config file documentation



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

