### PR TITLE
Add changelog entry for #6932 and #7203

### DIFF
--- a/ChangeLog.d/reduce-cpu-modifiers-to-file-scope.txt
+++ b/ChangeLog.d/reduce-cpu-modifiers-to-file-scope.txt
@@ -1,0 +1,4 @@
+Bugfix
+   * Fix #5758. Compilers might generate unexpected instructions when CPU
+     modifiers were specified as global flags( command line or global headers).
+     It is fixed with reducing the scope of CPU modifier flags.


### PR DESCRIPTION
## Description

Add missing changelog.

#6932 and #7203 are for adding cpu modifiers into file. That is fix `illegal instruction` error when target is Arm64. 
The fail is found in Arm64. But other platforms also have same risk.




## Gatekeeper checklist

- [ ] **changelog** provided, or not required
- [ ] **backport** done, or not required
- [ ] **tests** provided, or not required



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

