### PR TITLE
Add changelog entry for #6932 and #7203

### DIFF
--- a/ChangeLog.d/reduce-cpu-modifiers-to-file-scope.txt
+++ b/ChangeLog.d/reduce-cpu-modifiers-to-file-scope.txt
@@ -1,4 +1,12 @@
 Bugfix
-   * Fix #5758. Compilers might generate unexpected instructions when CPU
-     modifiers were specified as global flags( command line or global headers).
-     It is fixed with reducing the scope of CPU modifier flags.
+   * Fix an issue when compiling with MBEDTLS_SHA512_USE_A64_CRYPTO_IF_PRESENT
+     enabled, which required specifying compiler flags enabling SHA3 Crypto
+     Extensions, where some compilers would emit EOR3 instructions in other
+     modules, which would then fail if run on a CPU without the SHA3
+     extensions. Fixes #5758.
+
+Changes
+   * When enabling MBEDTLS_SHA256_USE_A64_CRYPTO_* or
+     MBEDTLS_SHA512_USE_A64_CRYPTO_*, it is no longer necessary to specify
+     compiler target flags on the command line; the library now sets target
+     options within the appropriate modules.

--- a/ChangeLog.d/reduce-cpu-modifiers-to-file-scope.txt
+++ b/ChangeLog.d/reduce-cpu-modifiers-to-file-scope.txt
@@ -1,0 +1,4 @@
+Bugfix
+   * Fix #5758. Compilers might generate unexpected instructions when CPU
+     modifiers were specified as global flags( command line or global headers).
+     It is fixed with reducing the scope of CPU modifier flags.


### PR DESCRIPTION
## Description

Updated version of #7323:

Add missing changelog.

#6932 and #7203 are for adding cpu modifiers into file. That is fix `illegal instruction` error when target is Arm64. 
The fail is found in Arm64. But other platforms also have same risk.

## Gatekeeper checklist

- [ ] **changelog** - this is a changelog update
- [ ] **backport** not required - arm64 CE work hasn't been backported
- [ ] **tests** not required
