### PR TITLE
ecp: Unify test cases

### DIFF
--- a/scripts/mbedtls_dev/bignum_common.py
+++ b/scripts/mbedtls_dev/bignum_common.py
@@ -17,6 +17,7 @@
 from abc import abstractmethod
 import enum
 from typing import Iterator, List, Tuple, TypeVar, Any
+from copy import deepcopy
 from itertools import chain
 
 from . import test_case
@@ -104,6 +105,7 @@ class OperationCommon(test_data_generation.BaseTest):
     symbol = ""
     input_values = INPUTS_DEFAULT # type: List[str]
     input_cases = [] # type: List[Any]
+    dependencies = [] # type: List[Any]
     unique_combinations_only = False
     input_styles = ["variable", "fixed", "arch_split"] # type: List[str]
     input_style = "variable" # type: str
@@ -119,10 +121,11 @@ class OperationCommon(test_data_generation.BaseTest):
         # provides earlier/more robust input validation.
         self.int_a = hex_to_int(val_a)
         self.int_b = hex_to_int(val_b)
+        self.dependencies = deepcopy(self.dependencies)
         if bits_in_limb not in self.limb_sizes:
             raise ValueError("Invalid number of bits in limb!")
         if self.input_style == "arch_split":
-            self.dependencies = ["MBEDTLS_HAVE_INT{:d}".format(bits_in_limb)]
+            self.dependencies.append("MBEDTLS_HAVE_INT{:d}".format(bits_in_limb))
         self.bits_in_limb = bits_in_limb
 
     @property

--- a/scripts/mbedtls_dev/ecp.py
+++ b/scripts/mbedtls_dev/ecp.py
@@ -30,7 +30,7 @@ class EcpP192R1Raw(bignum_common.ModOperationCommon,
                    EcpTarget):
     """Test cases for ECP P192 fast reduction."""
     symbol = "-"
-    test_function = "ecp_mod_p192_raw"
+    test_function = "ecp_mod_p_generic_raw"
     test_name = "ecp_mod_p192_raw"
     input_style = "fixed"
     arity = 1
@@ -96,12 +96,16 @@ class EcpP192R1Raw(bignum_common.ModOperationCommon,
     def is_valid(self) -> bool:
         return True
 
+    def arguments(self):
+        args = super().arguments()
+        return  ["MBEDTLS_ECP_DP_SECP192R1"] + args
+
 
 class EcpP224R1Raw(bignum_common.ModOperationCommon,
                    EcpTarget):
     """Test cases for ECP P224 fast reduction."""
     symbol = "-"
-    test_function = "ecp_mod_p224_raw"
+    test_function = "ecp_mod_p_generic_raw"
     test_name = "ecp_mod_p224_raw"
     input_style = "arch_split"
     arity = 1
@@ -168,12 +172,16 @@ class EcpP224R1Raw(bignum_common.ModOperationCommon,
     def is_valid(self) -> bool:
         return True
 
+    def arguments(self):
+        args = super().arguments()
+        return  ["MBEDTLS_ECP_DP_SECP224R1"] + args
+
 
 class EcpP256R1Raw(bignum_common.ModOperationCommon,
                    EcpTarget):
     """Test cases for ECP P256 fast reduction."""
     symbol = "-"
-    test_function = "ecp_mod_p256_raw"
+    test_function = "ecp_mod_p_generic_raw"
     test_name = "ecp_mod_p256_raw"
     input_style = "fixed"
     arity = 1
@@ -247,11 +255,15 @@ class EcpP256R1Raw(bignum_common.ModOperationCommon,
     def is_valid(self) -> bool:
         return True
 
+    def arguments(self):
+        args = super().arguments()
+        return  ["MBEDTLS_ECP_DP_SECP256R1"] + args
+
 
 class EcpP384R1Raw(bignum_common.ModOperationCommon,
                    EcpTarget):
     """Test cases for ECP P384 fast reduction."""
-    test_function = "ecp_mod_p384_raw"
+    test_function = "ecp_mod_p_generic_raw"
     test_name = "ecp_mod_p384_raw"
     input_style = "fixed"
     arity = 1
@@ -364,10 +376,15 @@ class EcpP384R1Raw(bignum_common.ModOperationCommon,
     def is_valid(self) -> bool:
         return True
 
+    def arguments(self):
+        args = super().arguments()
+        return  ["MBEDTLS_ECP_DP_SECP384R1"] + args
+
+
 class EcpP521R1Raw(bignum_common.ModOperationCommon,
                    EcpTarget):
     """Test cases for ECP P521 fast reduction."""
-    test_function = "ecp_mod_p521_raw"
+    test_function = "ecp_mod_p_generic_raw"
     test_name = "ecp_mod_p521_raw"
     input_style = "arch_split"
     arity = 1
@@ -462,3 +479,7 @@ class EcpP521R1Raw(bignum_common.ModOperationCommon,
     @property
     def is_valid(self) -> bool:
         return True
+
+    def arguments(self):
+        args = super().arguments()
+        return  ["MBEDTLS_ECP_DP_SECP521R1"] + args

--- a/scripts/mbedtls_dev/ecp.py
+++ b/scripts/mbedtls_dev/ecp.py
@@ -34,6 +34,7 @@ class EcpP192R1Raw(bignum_common.ModOperationCommon,
     test_name = "ecp_mod_p192_raw"
     input_style = "fixed"
     arity = 1
+    dependencies = ["MBEDTLS_ECP_DP_SECP192R1_ENABLED"]
 
     moduli = ["fffffffffffffffffffffffffffffffeffffffffffffffff"] # type: List[str]
 
@@ -109,6 +110,7 @@ class EcpP224R1Raw(bignum_common.ModOperationCommon,
     test_name = "ecp_mod_p224_raw"
     input_style = "arch_split"
     arity = 1
+    dependencies = ["MBEDTLS_ECP_DP_SECP224R1_ENABLED"]
 
     moduli = ["ffffffffffffffffffffffffffffffff000000000000000000000001"] # type: List[str]
 
@@ -185,6 +187,7 @@ class EcpP256R1Raw(bignum_common.ModOperationCommon,
     test_name = "ecp_mod_p256_raw"
     input_style = "fixed"
     arity = 1
+    dependencies = ["MBEDTLS_ECP_DP_SECP256R1_ENABLED"]
 
     moduli = ["ffffffff00000001000000000000000000000000ffffffffffffffffffffffff"] # type: List[str]
 
@@ -267,6 +270,7 @@ class EcpP384R1Raw(bignum_common.ModOperationCommon,
     test_name = "ecp_mod_p384_raw"
     input_style = "fixed"
     arity = 1
+    dependencies = ["MBEDTLS_ECP_DP_SECP384R1_ENABLED"]
 
     moduli = [("ffffffffffffffffffffffffffffffffffffffffffffffff"
                "fffffffffffffffeffffffff0000000000000000ffffffff")
@@ -388,6 +392,7 @@ class EcpP521R1Raw(bignum_common.ModOperationCommon,
     test_name = "ecp_mod_p521_raw"
     input_style = "arch_split"
     arity = 1
+    dependencies = ["MBEDTLS_ECP_DP_SECP521R1_ENABLED"]
 
     moduli = [("01ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
                "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")

--- a/tests/suites/test_suite_ecp.function
+++ b/tests/suites/test_suite_ecp.function
@@ -67,6 +67,15 @@ inline static int mbedtls_ecp_group_cmp(mbedtls_ecp_group *grp1,
     return 0;
 }
 
+#if defined(MBEDTLS_TEST_HOOKS) && \
+    (defined(MBEDTLS_ECP_DP_SECP192R1_ENABLED) || \
+    defined(MBEDTLS_ECP_DP_SECP224R1_ENABLED) || \
+    defined(MBEDTLS_ECP_DP_SECP256R1_ENABLED) || \
+    defined(MBEDTLS_ECP_DP_SECP384R1_ENABLED) || \
+    defined(MBEDTLS_ECP_DP_SECP521R1_ENABLED))
+#define MBEDTLS_ECP_DP_SECP_GENERIC_ENABLED
+#endif
+
 /* END_HEADER */
 
 /* BEGIN_DEPENDENCIES
@@ -1266,7 +1275,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_TEST_HOOKS */
+/* BEGIN_CASE depends_on:MBEDTLS_TEST_HOOKS:MBEDTLS_ECP_DP_SECP_GENERIC_ENABLED */
 void ecp_mod_p_generic_raw(int curve_id,
                            char *input_N,
                            char *input_X,

--- a/tests/suites/test_suite_ecp.function
+++ b/tests/suites/test_suite_ecp.function
@@ -67,15 +67,6 @@ inline static int mbedtls_ecp_group_cmp(mbedtls_ecp_group *grp1,
     return 0;
 }
 
-#if defined(MBEDTLS_TEST_HOOKS) && \
-    (defined(MBEDTLS_ECP_DP_SECP192R1_ENABLED) || \
-    defined(MBEDTLS_ECP_DP_SECP224R1_ENABLED) || \
-    defined(MBEDTLS_ECP_DP_SECP256R1_ENABLED) || \
-    defined(MBEDTLS_ECP_DP_SECP384R1_ENABLED) || \
-    defined(MBEDTLS_ECP_DP_SECP521R1_ENABLED))
-#define MBEDTLS_ECP_DP_SECP_GENERIC_ENABLED
-#endif
-
 /* END_HEADER */
 
 /* BEGIN_DEPENDENCIES
@@ -1275,7 +1266,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_TEST_HOOKS:MBEDTLS_ECP_DP_SECP_GENERIC_ENABLED */
+/* BEGIN_CASE depends_on:MBEDTLS_TEST_HOOKS */
 void ecp_mod_p_generic_raw(int curve_id,
                            char *input_N,
                            char *input_X,
@@ -1347,7 +1338,7 @@ void ecp_mod_p_generic_raw(int curve_id,
 
     TEST_EQUAL(mbedtls_mpi_mod_modulus_setup(
                    &m, N, limbs_N,
-                   MBEDTLS_MPI_MOD_REP_MONTGOMERY), 0);
+                   MBEDTLS_MPI_MOD_REP_OPT_RED), 0);
 
     TEST_EQUAL((*curve_func)(X, limbs_X), 0);
 

--- a/tests/suites/test_suite_ecp.function
+++ b/tests/suites/test_suite_ecp.function
@@ -1266,10 +1266,11 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_TEST_HOOKS:MBEDTLS_ECP_DP_SECP192R1_ENABLED */
-void ecp_mod_p192_raw(char *input_N,
-                      char *input_X,
-                      char *result)
+/* BEGIN_CASE depends_on:MBEDTLS_TEST_HOOKS */
+void ecp_mod_p_generic_raw(int curve_id,
+                           char *input_N,
+                           char *input_X,
+                           char *result)
 {
     mbedtls_mpi_uint *X = NULL;
     mbedtls_mpi_uint *N = NULL;
@@ -1278,48 +1279,10 @@ void ecp_mod_p192_raw(char *input_N,
     size_t limbs_N;
     size_t limbs_res;
 
-    mbedtls_mpi_mod_modulus m;
-    mbedtls_mpi_mod_modulus_init(&m);
-
-    TEST_EQUAL(mbedtls_test_read_mpi_core(&X,   &limbs_X,   input_X), 0);
-    TEST_EQUAL(mbedtls_test_read_mpi_core(&N,   &limbs_N,   input_N), 0);
-    TEST_EQUAL(mbedtls_test_read_mpi_core(&res, &limbs_res, result),  0);
-
-    size_t limbs = limbs_N;
-    size_t bytes = limbs * sizeof(mbedtls_mpi_uint);
-
-    TEST_EQUAL(limbs_X, 2 * limbs);
-    TEST_EQUAL(limbs_res, limbs);
-
-    TEST_EQUAL(mbedtls_mpi_mod_modulus_setup(
-                   &m, N, limbs,
-                   MBEDTLS_MPI_MOD_REP_MONTGOMERY), 0);
-
-    TEST_EQUAL(mbedtls_ecp_mod_p192_raw(X, limbs_X), 0);
-    TEST_LE_U(mbedtls_mpi_core_bitlen(X, limbs_X), 192);
-    mbedtls_mpi_mod_raw_fix_quasi_reduction(X, &m);
-    ASSERT_COMPARE(X, bytes, res, bytes);
-
-exit:
-    mbedtls_free(X);
-    mbedtls_free(res);
-
-    mbedtls_mpi_mod_modulus_free(&m);
-    mbedtls_free(N);
-}
-/* END_CASE */
-
-/* BEGIN_CASE depends_on:MBEDTLS_TEST_HOOKS:MBEDTLS_ECP_DP_SECP224R1_ENABLED */
-void ecp_mod_p224_raw(char *input_N,
-                      char *input_X,
-                      char *result)
-{
-    mbedtls_mpi_uint *X = NULL;
-    mbedtls_mpi_uint *N = NULL;
-    mbedtls_mpi_uint *res = NULL;
-    size_t limbs_X;
-    size_t limbs_N;
-    size_t limbs_res;
+    size_t bytes;
+    size_t limbs;
+    size_t curve_bits;
+    int (*curve_func)(mbedtls_mpi_uint *X, size_t X_limbs);
 
     mbedtls_mpi_mod_modulus m;
     mbedtls_mpi_mod_modulus_init(&m);
@@ -1327,148 +1290,59 @@ void ecp_mod_p224_raw(char *input_N,
     TEST_EQUAL(mbedtls_test_read_mpi_core(&X,   &limbs_X,   input_X), 0);
     TEST_EQUAL(mbedtls_test_read_mpi_core(&N,   &limbs_N,   input_N), 0);
     TEST_EQUAL(mbedtls_test_read_mpi_core(&res, &limbs_res, result),  0);
+    bytes = limbs_N * sizeof(mbedtls_mpi_uint);
 
-    size_t limbs = limbs_N;
-    size_t bytes = limbs * sizeof(mbedtls_mpi_uint);
+    switch (curve_id) {
+#if defined(MBEDTLS_ECP_DP_SECP192R1_ENABLED)
+        case MBEDTLS_ECP_DP_SECP192R1:
+            limbs = 2 * limbs_N;
+            curve_bits = 192;
+            curve_func = &mbedtls_ecp_mod_p192_raw;
+            break;
+#endif
+#if defined(MBEDTLS_ECP_DP_SECP224R1_ENABLED)
+        case MBEDTLS_ECP_DP_SECP224R1:
+            limbs = 448 / biL;
+            curve_bits = 224;
+            curve_func = &mbedtls_ecp_mod_p224_raw;
+            break;
+#endif
+#if defined(MBEDTLS_ECP_DP_SECP256R1_ENABLED)
+        case MBEDTLS_ECP_DP_SECP256R1:
+            limbs = 2 * limbs_N;
+            curve_bits = 256;
+            curve_func = &mbedtls_ecp_mod_p256_raw;
+            break;
+#endif
+#if defined(MBEDTLS_ECP_DP_SECP384R1_ENABLED)
+        case MBEDTLS_ECP_DP_SECP384R1:
+            limbs = 2 * limbs_N;
+            curve_bits = 384;
+            curve_func = &mbedtls_ecp_mod_p384_raw;
+            break;
+#endif
+#if defined(MBEDTLS_ECP_DP_SECP521R1_ENABLED)
+        case MBEDTLS_ECP_DP_SECP521R1:
+            limbs = 2 * limbs_N;
+            curve_bits = 522;
+            curve_func = &mbedtls_ecp_mod_p521_raw;
+            break;
+#endif
+        default:
+            mbedtls_test_fail("Unsupported curve_id", __LINE__, __FILE__);
+            goto exit;
+    }
 
-    TEST_EQUAL(limbs_X, 448 / biL);
-    TEST_EQUAL(limbs_res, limbs);
-
-    TEST_EQUAL(mbedtls_mpi_mod_modulus_setup(
-                   &m, N, limbs,
-                   MBEDTLS_MPI_MOD_REP_MONTGOMERY), 0);
-
-    TEST_EQUAL(mbedtls_ecp_mod_p224_raw(X, limbs_X), 0);
-    TEST_LE_U(mbedtls_mpi_core_bitlen(X, limbs_X), 224);
-    mbedtls_mpi_mod_raw_fix_quasi_reduction(X, &m);
-    ASSERT_COMPARE(X, bytes, res, bytes);
-
-exit:
-    mbedtls_free(X);
-    mbedtls_free(res);
-
-    mbedtls_mpi_mod_modulus_free(&m);
-    mbedtls_free(N);
-}
-/* END_CASE */
-
-/* BEGIN_CASE depends_on:MBEDTLS_TEST_HOOKS:MBEDTLS_ECP_DP_SECP256R1_ENABLED */
-void ecp_mod_p256_raw(char *input_N,
-                      char *input_X,
-                      char *result)
-{
-    mbedtls_mpi_uint *X = NULL;
-    mbedtls_mpi_uint *N = NULL;
-    mbedtls_mpi_uint *res = NULL;
-    size_t limbs_X;
-    size_t limbs_N;
-    size_t limbs_res;
-
-    mbedtls_mpi_mod_modulus m;
-    mbedtls_mpi_mod_modulus_init(&m);
-
-    TEST_EQUAL(mbedtls_test_read_mpi_core(&X,   &limbs_X,   input_X), 0);
-    TEST_EQUAL(mbedtls_test_read_mpi_core(&N,   &limbs_N,   input_N), 0);
-    TEST_EQUAL(mbedtls_test_read_mpi_core(&res, &limbs_res, result),  0);
-
-    size_t limbs = limbs_N;
-    size_t bytes = limbs * sizeof(mbedtls_mpi_uint);
-
-    TEST_EQUAL(limbs_X, 2 * limbs);
-    TEST_EQUAL(limbs_res, limbs);
+    TEST_EQUAL(limbs_X, limbs);
+    TEST_EQUAL(limbs_res, limbs_N);
 
     TEST_EQUAL(mbedtls_mpi_mod_modulus_setup(
-                   &m, N, limbs,
+                   &m, N, limbs_N,
                    MBEDTLS_MPI_MOD_REP_MONTGOMERY), 0);
 
-    TEST_EQUAL(mbedtls_ecp_mod_p256_raw(X, limbs_X), 0);
-    TEST_LE_U(mbedtls_mpi_core_bitlen(X, limbs_X), 256);
-    mbedtls_mpi_mod_raw_fix_quasi_reduction(X, &m);
-    ASSERT_COMPARE(X, bytes, res, bytes);
+    TEST_EQUAL((*curve_func)(X, limbs_X), 0);
 
-exit:
-    mbedtls_free(X);
-    mbedtls_free(res);
-
-    mbedtls_mpi_mod_modulus_free(&m);
-    mbedtls_free(N);
-}
-/* END_CASE */
-
-/* BEGIN_CASE depends_on:MBEDTLS_TEST_HOOKS:MBEDTLS_ECP_DP_SECP384R1_ENABLED */
-void ecp_mod_p384_raw(char *input_N,
-                      char *input_X,
-                      char *result)
-{
-    mbedtls_mpi_uint *X = NULL;
-    mbedtls_mpi_uint *N = NULL;
-    mbedtls_mpi_uint *res = NULL;
-    size_t limbs_X;
-    size_t limbs_N;
-    size_t limbs_res;
-
-    mbedtls_mpi_mod_modulus m;
-    mbedtls_mpi_mod_modulus_init(&m);
-
-    TEST_EQUAL(mbedtls_test_read_mpi_core(&X,   &limbs_X,   input_X), 0);
-    TEST_EQUAL(mbedtls_test_read_mpi_core(&N,   &limbs_N,   input_N), 0);
-    TEST_EQUAL(mbedtls_test_read_mpi_core(&res, &limbs_res, result),  0);
-
-    size_t limbs = limbs_N;
-    size_t bytes = limbs * sizeof(mbedtls_mpi_uint);
-
-    TEST_EQUAL(limbs_X, 2 * limbs);
-    TEST_EQUAL(limbs_res, limbs);
-
-    TEST_EQUAL(mbedtls_mpi_mod_modulus_setup(
-                   &m, N, limbs,
-                   MBEDTLS_MPI_MOD_REP_MONTGOMERY), 0);
-
-    TEST_EQUAL(mbedtls_ecp_mod_p384_raw(X, limbs_X), 0);
-    TEST_LE_U(mbedtls_mpi_core_bitlen(X, limbs_X), 384);
-    mbedtls_mpi_mod_raw_fix_quasi_reduction(X, &m);
-    ASSERT_COMPARE(X, bytes, res, bytes);
-
-exit:
-    mbedtls_free(X);
-    mbedtls_free(res);
-
-    mbedtls_mpi_mod_modulus_free(&m);
-    mbedtls_free(N);
-}
-/* END_CASE */
-
-/* BEGIN_CASE depends_on:MBEDTLS_TEST_HOOKS:MBEDTLS_ECP_DP_SECP521R1_ENABLED */
-void ecp_mod_p521_raw(char *input_N,
-                      char *input_X,
-                      char *result)
-{
-    mbedtls_mpi_uint *X = NULL;
-    mbedtls_mpi_uint *N = NULL;
-    mbedtls_mpi_uint *res = NULL;
-    size_t limbs_X;
-    size_t limbs_N;
-    size_t limbs_res;
-
-    mbedtls_mpi_mod_modulus m;
-    mbedtls_mpi_mod_modulus_init(&m);
-
-    TEST_EQUAL(mbedtls_test_read_mpi_core(&X,   &limbs_X,   input_X), 0);
-    TEST_EQUAL(mbedtls_test_read_mpi_core(&N,   &limbs_N,   input_N), 0);
-    TEST_EQUAL(mbedtls_test_read_mpi_core(&res, &limbs_res, result),  0);
-
-    size_t limbs = limbs_N;
-    size_t bytes = limbs * sizeof(mbedtls_mpi_uint);
-
-    TEST_EQUAL(limbs_X, 2 * limbs);
-    TEST_EQUAL(limbs_res, limbs);
-
-    TEST_EQUAL(mbedtls_mpi_mod_modulus_setup(
-                   &m, N, limbs,
-                   MBEDTLS_MPI_MOD_REP_MONTGOMERY), 0);
-
-    TEST_EQUAL(mbedtls_ecp_mod_p521_raw(X, limbs_X), 0);
-    TEST_LE_U(mbedtls_mpi_core_bitlen(X, limbs_X), 522);
+    TEST_LE_U(mbedtls_mpi_core_bitlen(X, limbs_X), curve_bits);
     mbedtls_mpi_mod_raw_fix_quasi_reduction(X, &m);
     ASSERT_COMPARE(X, bytes, res, bytes);
 


### PR DESCRIPTION
## Description

Resolves #7306 .

This patch replaces the test functions for the following curves:

- MBEDTLS_ECP_DP_SECP192R1
- MBEDTLS_ECP_DP_SECP224R1
- MBEDTLS_ECP_DP_BP256R1
- MBEDTLS_ECP_DP_BP512R1
- MBEDTLS_ECP_DP_BP384R1

Instead of invoking a functionally similar curve specific method, 
`ecp_mod_pXXX_raw(char *input_N, char *input_X, char *result)` ,
                          
the new generic implementation is accepting a curve_id, 
`
ecp_mod_p_generic_raw(int curve_id, char *input_N, char *input_X, char *result)` 

which is defined in the [ecp interface](https://github.com/Mbed-TLS/mbedtls/blob/development/include/mbedtls/ecp.h#L66-L76).

Then the curve specific parameters are switch-gated, greatly simplifying the test code.

## Gatekeeper checklist

- [x] **changelog** Not required since that is a new interface, and are not changing behaviour or logs.
- [x] **backport** Not required since that is a new interface not ported to 2.28
- [x] **tests** Provided

