### PR TITLE
Backport 2.28: 6500 follow-up: enhancements to the new ssl_helpers test module #7287

### DIFF
--- a/tests/include/test/ssl_helpers.h
+++ b/tests/include/test/ssl_helpers.h
@@ -277,13 +277,13 @@ int mbedtls_test_ssl_message_queue_pop_info(
 /*
  * Setup and teardown functions for mock sockets.
  */
-void mbedtls_mock_socket_init(mbedtls_test_mock_socket *socket);
+void mbedtls_test_mock_socket_init(mbedtls_test_mock_socket *socket);
 
 /*
  * Closes the socket \p socket.
  *
  * \p socket must have been previously initialized by calling
- * mbedtls_mock_socket_init().
+ * mbedtls_test_mock_socket_init().
  *
  * This function frees all allocated resources and both sockets are aware of the
  * new connection state.
@@ -298,7 +298,7 @@ void mbedtls_test_mock_socket_close(mbedtls_test_mock_socket *socket);
  * Establishes a connection between \p peer1 and \p peer2.
  *
  * \p peer1 and \p peer2 must have been previously initialized by calling
- * mbedtls_mock_socket_init().
+ * mbedtls_test_mock_socket_init().
  *
  * The capacities of the internal buffers are set to \p bufsize. Setting this to
  * the correct value allows for simulation of MTU, sanity testing the mock

--- a/tests/include/test/ssl_helpers.h
+++ b/tests/include/test/ssl_helpers.h
@@ -498,10 +498,11 @@ int mbedtls_test_ssl_populate_session(mbedtls_ssl_session *session,
  *
  * \retval  0 on success, otherwise error code.
  */
-int mbedtls_exchange_data(mbedtls_ssl_context *ssl_1,
-                          int msg_len_1, const int expected_fragments_1,
-                          mbedtls_ssl_context *ssl_2,
-                          int msg_len_2, const int expected_fragments_2);
+int mbedtls_test_ssl_exchange_data(
+    mbedtls_ssl_context *ssl_1,
+    int msg_len_1, const int expected_fragments_1,
+    mbedtls_ssl_context *ssl_2,
+    int msg_len_2, const int expected_fragments_2);
 
 #if defined(MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED) && \
     defined(MBEDTLS_CERTS_C) && \

--- a/tests/include/test/ssl_helpers.h
+++ b/tests/include/test/ssl_helpers.h
@@ -377,8 +377,7 @@ int mbedtls_test_mock_tcp_send_msg(void *ctx,
  *          mbedtls_test_mock_tcp_recv_b failed.
  *
  * This function will also return any error other than
- * MBEDTLS_TEST_ERROR_MESSAGE_TRUNCATED from
- * mbedtls_test_message_queue_peek_info.
+ * MBEDTLS_TEST_ERROR_MESSAGE_TRUNCATED from test_ssl_message_queue_peek_info.
  */
 int mbedtls_test_mock_tcp_recv_msg(void *ctx,
                                    unsigned char *buf, size_t buf_len);

--- a/tests/include/test/ssl_helpers.h
+++ b/tests/include/test/ssl_helpers.h
@@ -456,6 +456,12 @@ int mbedtls_test_move_handshake_to_state(mbedtls_ssl_context *ssl,
         }                                       \
     } while (0)
 
+#if MBEDTLS_SSL_CID_OUT_LEN_MAX > MBEDTLS_SSL_CID_IN_LEN_MAX
+#define SSL_CID_LEN_MIN MBEDTLS_SSL_CID_IN_LEN_MAX
+#else
+#define SSL_CID_LEN_MIN MBEDTLS_SSL_CID_OUT_LEN_MAX
+#endif
+
 int mbedtls_test_ssl_build_transforms(mbedtls_ssl_transform *t_in,
                                       mbedtls_ssl_transform *t_out,
                                       int cipher_type, int hash_id,

--- a/tests/src/test_helpers/ssl_helpers.c
+++ b/tests/src/test_helpers/ssl_helpers.c
@@ -257,8 +257,9 @@ int mbedtls_test_ssl_message_queue_pop_info(
  *          set to the full message length so that the
  *          caller knows what portion of the message can be dropped.
  */
-int mbedtls_test_message_queue_peek_info(mbedtls_test_ssl_message_queue *queue,
-                                         size_t buf_len, size_t *msg_len)
+static int test_ssl_message_queue_peek_info(
+    mbedtls_test_ssl_message_queue *queue,
+    size_t buf_len, size_t *msg_len)
 {
     if (queue == NULL || msg_len == NULL) {
         return MBEDTLS_TEST_ERROR_ARG_NULL;
@@ -488,7 +489,7 @@ int mbedtls_test_mock_tcp_recv_msg(void *ctx,
 
     /* Peek first, so that in case of a socket error the data remains in
      * the queue. */
-    ret = mbedtls_test_message_queue_peek_info(queue, buf_len, &msg_len);
+    ret = test_ssl_message_queue_peek_info(queue, buf_len, &msg_len);
     if (ret == MBEDTLS_TEST_ERROR_MESSAGE_TRUNCATED) {
         /* Calculate how much to drop */
         drop_len = msg_len - buf_len;

--- a/tests/src/test_helpers/ssl_helpers.c
+++ b/tests/src/test_helpers/ssl_helpers.c
@@ -525,7 +525,7 @@ int mbedtls_test_mock_tcp_recv_msg(void *ctx,
 /*
  * Deinitializes certificates from endpoint represented by \p ep.
  */
-void mbedtls_endpoint_certificate_free(mbedtls_test_ssl_endpoint *ep)
+static void test_ssl_endpoint_certificate_free(mbedtls_test_ssl_endpoint *ep)
 {
     mbedtls_test_ssl_endpoint_certificate *cert = &(ep->cert);
     if (cert != NULL) {
@@ -647,7 +647,7 @@ int mbedtls_test_ssl_endpoint_certificate_init(mbedtls_test_ssl_endpoint *ep,
 
 exit:
     if (ret != 0) {
-        mbedtls_endpoint_certificate_free(ep);
+        test_ssl_endpoint_certificate_free(ep);
     }
 
     return ret;
@@ -744,7 +744,7 @@ void mbedtls_test_ssl_endpoint_free(
     mbedtls_test_ssl_endpoint *ep,
     mbedtls_test_message_socket_context *context)
 {
-    mbedtls_endpoint_certificate_free(ep);
+    test_ssl_endpoint_certificate_free(ep);
 
     mbedtls_ssl_free(&(ep->ssl));
     mbedtls_ssl_config_free(&(ep->conf));

--- a/tests/src/test_helpers/ssl_helpers.c
+++ b/tests/src/test_helpers/ssl_helpers.c
@@ -272,7 +272,7 @@ static int test_ssl_message_queue_peek_info(
     return (*msg_len > buf_len) ? MBEDTLS_TEST_ERROR_MESSAGE_TRUNCATED : 0;
 }
 
-void mbedtls_mock_socket_init(mbedtls_test_mock_socket *socket)
+void mbedtls_test_mock_socket_init(mbedtls_test_mock_socket *socket)
 {
     memset(socket, 0, sizeof(*socket));
 }
@@ -424,7 +424,7 @@ int mbedtls_test_message_socket_setup(
     ctx->queue_input = queue_input;
     ctx->queue_output = queue_output;
     ctx->socket = socket;
-    mbedtls_mock_socket_init(socket);
+    mbedtls_test_mock_socket_init(socket);
 
     return 0;
 }
@@ -688,7 +688,7 @@ int mbedtls_test_ssl_endpoint_init(
                                                       100, &(ep->socket),
                                                       dtls_context) == 0);
     } else {
-        mbedtls_mock_socket_init(&(ep->socket));
+        mbedtls_test_mock_socket_init(&(ep->socket));
     }
 
     ret = mbedtls_ctr_drbg_seed(&(ep->ctr_drbg), mbedtls_entropy_func,

--- a/tests/src/test_helpers/ssl_helpers.c
+++ b/tests/src/test_helpers/ssl_helpers.c
@@ -883,8 +883,12 @@ exit:
     return -1;
 }
 
-void set_ciphersuite(mbedtls_ssl_config *conf, const char *cipher,
-                     int *forced_ciphersuite)
+#if defined(MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED) && \
+    defined(MBEDTLS_CERTS_C)                        && \
+    defined(MBEDTLS_ENTROPY_C)                      && \
+    defined(MBEDTLS_CTR_DRBG_C)
+static void set_ciphersuite(mbedtls_ssl_config *conf, const char *cipher,
+                            int *forced_ciphersuite)
 {
     const mbedtls_ssl_ciphersuite_t *ciphersuite_info;
     forced_ciphersuite[0] = mbedtls_ssl_get_ciphersuite_id(cipher);
@@ -909,9 +913,16 @@ void set_ciphersuite(mbedtls_ssl_config *conf, const char *cipher,
 exit:
     return;
 }
+#endif /* MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED && MBEDTLS_CERTS_C &&
+          MBEDTLS_ENTROPY_C && MBEDTLS_CTR_DRBG_C */
 
-int psk_dummy_callback(void *p_info, mbedtls_ssl_context *ssl,
-                       const unsigned char *name, size_t name_len)
+#if defined(MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED) && \
+    defined(MBEDTLS_CERTS_C)                        && \
+    defined(MBEDTLS_ENTROPY_C)                      && \
+    defined(MBEDTLS_CTR_DRBG_C)                     && \
+    defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED)
+static int psk_dummy_callback(void *p_info, mbedtls_ssl_context *ssl,
+                              const unsigned char *name, size_t name_len)
 {
     (void) p_info;
     (void) ssl;
@@ -920,6 +931,9 @@ int psk_dummy_callback(void *p_info, mbedtls_ssl_context *ssl,
 
     return 0;
 }
+#endif /* MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED && MBEDTLS_CERTS_C &&
+          MBEDTLS_ENTROPY_C && MBEDTLS_CTR_DRBG_C &&
+          MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED */
 
 int mbedtls_test_ssl_build_transforms(mbedtls_ssl_transform *t_in,
                                       mbedtls_ssl_transform *t_out,
@@ -1373,16 +1387,26 @@ exit:
  *
  * \retval  0 on success, otherwise error code.
  */
-int exchange_data(mbedtls_ssl_context *ssl_1,
-                  mbedtls_ssl_context *ssl_2)
+#if defined(MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED) && \
+    defined(MBEDTLS_CERTS_C)                        && \
+    defined(MBEDTLS_ENTROPY_C)                      && \
+    defined(MBEDTLS_CTR_DRBG_C)                     && \
+    (defined(MBEDTLS_SSL_RENEGOTIATION)             || \
+    defined(MBEDTLS_SSL_VARIABLE_BUFFER_LENGTH))
+static int exchange_data(mbedtls_ssl_context *ssl_1,
+                         mbedtls_ssl_context *ssl_2)
 {
     return mbedtls_exchange_data(ssl_1, 256, 1,
                                  ssl_2, 256, 1);
 }
+#endif /* MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED && MBEDTLS_CERTS_C &&
+          MBEDTLS_ENTROPY_C && MBEDTLS_CTR_DRBG_C &&
+          (MBEDTLS_SSL_RENEGOTIATION              ||
+          MBEDTLS_SSL_VARIABLE_BUFFER_LENGTH) */
 
 #if defined(MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED) && \
-    defined(MBEDTLS_CERTS_C) && \
-    defined(MBEDTLS_ENTROPY_C) && \
+    defined(MBEDTLS_CERTS_C)                        && \
+    defined(MBEDTLS_ENTROPY_C)                      && \
     defined(MBEDTLS_CTR_DRBG_C)
 void mbedtls_test_ssl_perform_handshake(
     mbedtls_test_handshake_test_options *options)

--- a/tests/src/test_helpers/ssl_helpers.c
+++ b/tests/src/test_helpers/ssl_helpers.c
@@ -921,12 +921,6 @@ int psk_dummy_callback(void *p_info, mbedtls_ssl_context *ssl,
     return 0;
 }
 
-#if MBEDTLS_SSL_CID_OUT_LEN_MAX > MBEDTLS_SSL_CID_IN_LEN_MAX
-#define SSL_CID_LEN_MIN MBEDTLS_SSL_CID_IN_LEN_MAX
-#else
-#define SSL_CID_LEN_MIN MBEDTLS_SSL_CID_OUT_LEN_MAX
-#endif
-
 int mbedtls_test_ssl_build_transforms(mbedtls_ssl_transform *t_in,
                                       mbedtls_ssl_transform *t_out,
                                       int cipher_type, int hash_id,

--- a/tests/src/test_helpers/ssl_helpers.c
+++ b/tests/src/test_helpers/ssl_helpers.c
@@ -821,7 +821,7 @@ int mbedtls_ssl_write_fragment(mbedtls_ssl_context *ssl,
         /* Used for DTLS and the message size larger than MFL. In that case
          * the message can not be fragmented and the library should return
          * MBEDTLS_ERR_SSL_BAD_INPUT_DATA error. This error must be returned
-         * to prevent a dead loop inside mbedtls_exchange_data(). */
+         * to prevent a dead loop inside mbedtls_test_ssl_exchange_data(). */
         return ret;
     } else if (expected_fragments == 1) {
         /* Used for TLS/DTLS and the message size lower than MFL */
@@ -1279,10 +1279,11 @@ int mbedtls_test_ssl_populate_session(mbedtls_ssl_session *session,
     return 0;
 }
 
-int mbedtls_exchange_data(mbedtls_ssl_context *ssl_1,
-                          int msg_len_1, const int expected_fragments_1,
-                          mbedtls_ssl_context *ssl_2,
-                          int msg_len_2, const int expected_fragments_2)
+int mbedtls_test_ssl_exchange_data(
+    mbedtls_ssl_context *ssl_1,
+    int msg_len_1, const int expected_fragments_1,
+    mbedtls_ssl_context *ssl_2,
+    int msg_len_2, const int expected_fragments_2)
 {
     unsigned char *msg_buf_1 = malloc(msg_len_1);
     unsigned char *msg_buf_2 = malloc(msg_len_2);
@@ -1397,8 +1398,8 @@ exit:
 static int exchange_data(mbedtls_ssl_context *ssl_1,
                          mbedtls_ssl_context *ssl_2)
 {
-    return mbedtls_exchange_data(ssl_1, 256, 1,
-                                 ssl_2, 256, 1);
+    return mbedtls_test_ssl_exchange_data(ssl_1, 256, 1,
+                                          ssl_2, 256, 1);
 }
 #endif /* MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED && MBEDTLS_CERTS_C &&
           MBEDTLS_ENTROPY_C && MBEDTLS_CTR_DRBG_C &&
@@ -1622,10 +1623,11 @@ void mbedtls_test_ssl_perform_handshake(
 
     if (options->cli_msg_len != 0 || options->srv_msg_len != 0) {
         /* Start data exchanging test */
-        TEST_ASSERT(mbedtls_exchange_data(&(client.ssl), options->cli_msg_len,
-                                          options->expected_cli_fragments,
-                                          &(server.ssl), options->srv_msg_len,
-                                          options->expected_srv_fragments)
+        TEST_ASSERT(mbedtls_test_ssl_exchange_data(
+                        &(client.ssl), options->cli_msg_len,
+                        options->expected_cli_fragments,
+                        &(server.ssl), options->srv_msg_len,
+                        options->expected_srv_fragments)
                     == 0);
     }
 #if defined(MBEDTLS_SSL_CONTEXT_SERIALIZATION)
@@ -1680,12 +1682,10 @@ void mbedtls_test_ssl_perform_handshake(
 #endif
         /* Retest writing/reading */
         if (options->cli_msg_len != 0 || options->srv_msg_len != 0) {
-            TEST_ASSERT(mbedtls_exchange_data(
-                            &(client.ssl),
-                            options->cli_msg_len,
+            TEST_ASSERT(mbedtls_test_ssl_exchange_data(
+                            &(client.ssl), options->cli_msg_len,
                             options->expected_cli_fragments,
-                            &(server.ssl),
-                            options->srv_msg_len,
+                            &(server.ssl), options->srv_msg_len,
                             options->expected_srv_fragments)
                         == 0);
         }

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -202,17 +202,17 @@ void ssl_mock_sanity()
     unsigned char received[MSGLEN] = { 0 };
     mbedtls_test_mock_socket socket;
 
-    mbedtls_mock_socket_init(&socket);
+    mbedtls_test_mock_socket_init(&socket);
     TEST_ASSERT(mbedtls_test_mock_tcp_send_b(&socket, message, MSGLEN) < 0);
     mbedtls_test_mock_socket_close(&socket);
-    mbedtls_mock_socket_init(&socket);
+    mbedtls_test_mock_socket_init(&socket);
     TEST_ASSERT(mbedtls_test_mock_tcp_recv_b(&socket, received, MSGLEN) < 0);
     mbedtls_test_mock_socket_close(&socket);
 
-    mbedtls_mock_socket_init(&socket);
+    mbedtls_test_mock_socket_init(&socket);
     TEST_ASSERT(mbedtls_test_mock_tcp_send_nb(&socket, message, MSGLEN) < 0);
     mbedtls_test_mock_socket_close(&socket);
-    mbedtls_mock_socket_init(&socket);
+    mbedtls_test_mock_socket_init(&socket);
     TEST_ASSERT(mbedtls_test_mock_tcp_recv_nb(&socket, received, MSGLEN) < 0);
     mbedtls_test_mock_socket_close(&socket);
 
@@ -250,8 +250,8 @@ void ssl_mock_tcp(int blocking)
         recv = mbedtls_test_mock_tcp_recv_b;
     }
 
-    mbedtls_mock_socket_init(&client);
-    mbedtls_mock_socket_init(&server);
+    mbedtls_test_mock_socket_init(&client);
+    mbedtls_test_mock_socket_init(&server);
 
     /* Fill up the buffer with structured data so that unwanted changes
      * can be detected */
@@ -347,8 +347,8 @@ void ssl_mock_tcp_interleaving(int blocking)
         recv = mbedtls_test_mock_tcp_recv_b;
     }
 
-    mbedtls_mock_socket_init(&client);
-    mbedtls_mock_socket_init(&server);
+    mbedtls_test_mock_socket_init(&client);
+    mbedtls_test_mock_socket_init(&server);
 
     /* Fill up the buffers with structured data so that unwanted changes
      * can be detected */


### PR DESCRIPTION
## Description

Backport of #7287 

- [x] unify code format of function declaration between `ssl_helpers.c` and `ssl_helpers.h`
- [x] rename prefix for some functions in `ssl_helpers.c`
- [x] move some internal functions to static

Since there are some differences between `development` and `mbedtls-2.28`. The backport is not identical with original PR.

## Gatekeeper checklist

- [x] **changelog** not required - internal refactoring of tests only, no user-visible changes
- [x] **backport** https://github.com/Mbed-TLS/mbedtls/pull/7332
- [x] **tests** not required