### PR TITLE
fix: ignore *.o under tests/src/test_helpers

### DIFF
--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -18,6 +18,7 @@ include/alt-extra/psa/crypto_struct_alt.h
 include/test/instrument_record_status.h
 
 src/*.o
+src/test_helpers/*.o
 src/drivers/*.o
 src/libmbed*
 


### PR DESCRIPTION
## Description

ignore `*.o` under `tests/src/test_helpers`

Small fix for #6500

## Gatekeeper checklist

- [x] **changelog** not required - fix to `.gitignore` so not really significant for users
- [x] **backport**  https://github.com/Mbed-TLS/mbedtls/pull/7338
- [x] **tests** not required