### PR TITLE
Backport 2.28: fix: ignore *.o under tests/src/test_helpers

### DIFF
--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -11,6 +11,7 @@ data_files/entropy_seed
 include/test/instrument_record_status.h
 
 src/*.o
+src/test_helpers/*.o
 src/drivers/*.o
 src/libmbed*
 


### PR DESCRIPTION
## Description

ignore `*.o` under `tests/src/test_helpers`

Small fix for #6500

## Gatekeeper checklist

- [x] **changelog** not required - fix to `.gitignore` so not really significant for users
- [x] **backport** of #7336 
- [x] **tests** not required