### PR TITLE
AES: Add accelerator only mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -151,7 +151,6 @@ jobs:
         - make generated_files
         - make
         - programs/test/selftest
-        - tests/scripts/travis-log-failure.sh
         - tests/context-info.sh
 
 after_failure:

--- a/.travis.yml
+++ b/.travis.yml
@@ -147,7 +147,7 @@ jobs:
         - scripts/config.py unset MBEDTLS_AESNI_C
         - scripts/config.py unset MBEDTLS_PADLOCK_C
         - scripts/config.py set MBEDTLS_AESCE_C
-        - scripts/config.py set MBEDTLS_AES_DONT_USE_SOFTWARE_CRYPTO
+        - scripts/config.py set MBEDTLS_AES_USE_HARDWARE_ONLY
         - make generated_files
         - make
         - programs/test/selftest

--- a/.travis.yml
+++ b/.travis.yml
@@ -150,7 +150,7 @@ jobs:
         - scripts/config.py set MBEDTLS_AES_USE_HARDWARE_ONLY
         - make generated_files
         - make
-        - programs/test/selftest
+        - programs/test/selftest aes | grep "using AESCE"
         - tests/context-info.sh
 
 after_failure:

--- a/.travis.yml
+++ b/.travis.yml
@@ -147,7 +147,7 @@ jobs:
         - scripts/config.py unset MBEDTLS_AESNI_C
         - scripts/config.py unset MBEDTLS_PADLOCK_C
         - scripts/config.py set MBEDTLS_AESCE_C
-        - scripts/config.py set MBEDTLS_AES_HAS_NO_BUILTIN
+        - scripts/config.py set MBEDTLS_AES_HAS_NO_PLAIN_C
         - make generated_files
         - make
         - programs/test/selftest

--- a/.travis.yml
+++ b/.travis.yml
@@ -147,7 +147,7 @@ jobs:
         - scripts/config.py unset MBEDTLS_AESNI_C
         - scripts/config.py unset MBEDTLS_PADLOCK_C
         - scripts/config.py set MBEDTLS_AESCE_C
-        - scripts/config.py set MBEDTLS_AES_HAS_NO_PLAIN_C
+        - scripts/config.py set MBEDTLS_AES_DONT_USE_SOFTWARE_CRYPTO
         - make generated_files
         - make
         - programs/test/selftest

--- a/.travis.yml
+++ b/.travis.yml
@@ -129,6 +129,31 @@ jobs:
         - tests/scripts/travis-log-failure.sh
         - tests/context-info.sh
 
+    - name: Arm64 accelerators tests on arm64 host
+      os: linux
+      dist: focal
+      arch: arm64
+      addons:
+        apt:
+          packages:
+          - gcc
+      script:
+        # Do a manual build+test sequence rather than using all.sh.
+        #
+        # This is arm64 host only test for no runtime detection case. Internal
+        # and Open CI do not include Arm64 host, and they check if components
+        # are be tested. As result, it will always fail on `pre-test-check` in
+        # them.
+        - scripts/config.py unset MBEDTLS_AESNI_C
+        - scripts/config.py unset MBEDTLS_PADLOCK_C
+        - scripts/config.py set MBEDTLS_AESCE_C
+        - scripts/config.py set MBEDTLS_AES_HAS_NO_BUILTIN
+        - make generated_files
+        - make
+        - programs/test/selftest
+        - tests/scripts/travis-log-failure.sh
+        - tests/context-info.sh
+
 after_failure:
 - tests/scripts/travis-log-failure.sh
 

--- a/ChangeLog.d/add-aes-hardware-only-option.txt
+++ b/ChangeLog.d/add-aes-hardware-only-option.txt
@@ -1,6 +1,6 @@
 Features
-   * New configuration option MBEDTLS_AES_USE_HARDWARE_ONLY introduced. When using
-     CPU-accelerated AES (e.g., Arm Crypto Extensions), this option disables
-     the plain C implementation and the run-time detection for the CPU feature,
-     which reduces code size and avoid the vulnerability of the plain C
-     implementation.
+   * New configuration option MBEDTLS_AES_USE_HARDWARE_ONLY introduced. When
+     using CPU-accelerated AES (e.g., Arm Crypto Extensions), this option
+     disables the plain C implementation and the run-time detection for the
+     CPU feature, which reduces code size and avoid the vulnerability of the
+     plain C implementation.

--- a/ChangeLog.d/add-aes-hardware-only-option.txt
+++ b/ChangeLog.d/add-aes-hardware-only-option.txt
@@ -1,0 +1,6 @@
+Features
+   * New configuration option MBEDTLS_AES_USE_HARDWARE_ONLY introduced. When using
+     CPU-accelerated AES (e.g., Arm Crypto Extensions), this option disables
+     the plain C implementation and the run-time detection for the CPU feature,
+     which reduces code size and avoid the vulnerability of the plain C
+     implementation.

--- a/ChangeLog.d/add-aes-hardware-only-option.txt
+++ b/ChangeLog.d/add-aes-hardware-only-option.txt
@@ -2,5 +2,5 @@ Features
    * New configuration option MBEDTLS_AES_USE_HARDWARE_ONLY introduced. When
      using CPU-accelerated AES (e.g., Arm Crypto Extensions), this option
      disables the plain C implementation and the run-time detection for the
-     CPU feature, which reduces code size and avoid the vulnerability of the
+     CPU feature, which reduces code size and avoids the vulnerability of the
      plain C implementation.

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -412,10 +412,6 @@
 #error "MBEDTLS_MEMORY_DEBUG defined, but not all prerequisites"
 #endif
 
-#if defined(MBEDTLS_PADLOCK_C) && !defined(MBEDTLS_HAVE_ASM)
-#error "MBEDTLS_PADLOCK_C defined, but not all prerequisites"
-#endif
-
 #if defined(MBEDTLS_PEM_PARSE_C) && !defined(MBEDTLS_BASE64_C)
 #error "MBEDTLS_PEM_PARSE_C defined, but not all prerequisites"
 #endif

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -4015,6 +4015,7 @@
  * detection will be used to select between them.
  *
  * If only one implementation is present, runtime detection will not be used.
+ * This configuration will crash if running on the CPU without needed features.
  */
 //#define MBEDTLS_AES_USE_HARDWARE_ONLY
 

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -4008,8 +4008,14 @@
 
 /*
  * Platform independent implementation for crypto algorithms.
- * Disable plain c implementation for AES.
+ * Disable plain C implementation for AES.
+ *
+ * If the plain C implementation is enabled, and an implementation using a
+ * special CPU feature (such as MBEDTLS_AESCE_C) is also enabled, runtime
+ * detection will be used to select between them.
+ *
+ * If only one implementation is present, runtime detection will not be used.
  */
-//#define MBEDTLS_AES_DONT_USE_SOFTWARE_CRYPTO /* Uncomment to disable plain c implementation of AES */
+//#define MBEDTLS_AES_USE_HARDWARE_ONLY
 
 /** \} name SECTION: Module configuration options */

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -4008,7 +4008,8 @@
 
 /*
  * Platform independent implementation for crypto algorithms.
+ * Disable plain c implementation for AES.
  */
-//#define MBEDTLS_AES_HAS_NO_PLAIN_C /* Uncomment to disable built-in platform independent code of AES */
+//#define MBEDTLS_AES_HAS_NO_PLAIN_C /* Uncomment to disable plain c implementation of AES */
 
 /** \} name SECTION: Module configuration options */

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -4015,7 +4015,9 @@
  * detection will be used to select between them.
  *
  * If only one implementation is present, runtime detection will not be used.
- * This configuration will crash if running on the CPU without needed features.
+ * This configuration will crash at runtime if running on a CPU without the
+ * necessary features. It will not build unless at least one of MBEDTLS_AESCE_C,
+ * MBEDTLS_AESNI_C and/or MBEDTLS_PADLOCK_C is enabled & present in the build.
  */
 //#define MBEDTLS_AES_USE_HARDWARE_ONLY
 

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -4015,8 +4015,8 @@
  *
  * If only one implementation is present, runtime detection will not be used.
  * This configuration will crash at runtime if running on a CPU without the
- * necessary features. It will not build unless at least one of MBEDTLS_AESCE_C,
- * MBEDTLS_AESNI_C and/or MBEDTLS_PADLOCK_C is enabled & present in the build.
+ * necessary features. It will not build unless at least one of MBEDTLS_AESCE_C
+ * and/or MBEDTLS_AESNI_C is enabled & present in the build.
  */
 //#define MBEDTLS_AES_USE_HARDWARE_ONLY
 

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -4006,4 +4006,9 @@
  */
 //#define MBEDTLS_ECP_WITH_MPI_UINT
 
+/*
+ * Platform independent implementation for crypto algorithms.
+ */
+//#define MBEDTLS_AES_HAS_NO_BUILTIN /* Uncomment to disable built-in platform independent code of AES */
+
 /** \} name SECTION: Module configuration options */

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -4009,6 +4009,6 @@
 /*
  * Platform independent implementation for crypto algorithms.
  */
-//#define MBEDTLS_AES_HAS_NO_BUILTIN /* Uncomment to disable built-in platform independent code of AES */
+//#define MBEDTLS_AES_HAS_NO_PLAIN_C /* Uncomment to disable built-in platform independent code of AES */
 
 /** \} name SECTION: Module configuration options */

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -4007,10 +4007,9 @@
 //#define MBEDTLS_ECP_WITH_MPI_UINT
 
 /*
- * Platform independent implementation for crypto algorithms.
  * Disable plain C implementation for AES.
  *
- * If the plain C implementation is enabled, and an implementation using a
+ * When the plain C implementation is enabled, and an implementation using a
  * special CPU feature (such as MBEDTLS_AESCE_C) is also enabled, runtime
  * detection will be used to select between them.
  *

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -4010,6 +4010,6 @@
  * Platform independent implementation for crypto algorithms.
  * Disable plain c implementation for AES.
  */
-//#define MBEDTLS_AES_HAS_NO_PLAIN_C /* Uncomment to disable plain c implementation of AES */
+//#define MBEDTLS_AES_DONT_USE_SOFTWARE_CRYPTO /* Uncomment to disable plain c implementation of AES */
 
 /** \} name SECTION: Module configuration options */

--- a/library/aes.c
+++ b/library/aes.c
@@ -1900,11 +1900,6 @@ int mbedtls_aes_self_test(int verbose)
 #if defined(MBEDTLS_AES_ALT)
         mbedtls_printf("  AES note: alternative implementation.\n");
 #else /* MBEDTLS_AES_ALT */
-#if defined(MBEDTLS_PADLOCK_C) && defined(MBEDTLS_HAVE_X86) && defined(__GNUC__)
-        if (mbedtls_padlock_has_support(MBEDTLS_PADLOCK_ACE)) {
-            mbedtls_printf("  AES note: using VIA Padlock.\n");
-        } else
-#endif
 #if defined(MBEDTLS_AESNI_HAVE_CODE)
 #if MBEDTLS_AESNI_HAVE_CODE == 1
         mbedtls_printf("  AES note: AESNI code present (assembly implementation).\n");
@@ -1915,6 +1910,11 @@ int mbedtls_aes_self_test(int verbose)
 #endif
         if (mbedtls_aesni_has_support(MBEDTLS_AESNI_AES)) {
             mbedtls_printf("  AES note: using AESNI.\n");
+        } else
+#endif
+#if defined(MBEDTLS_PADLOCK_C) && defined(MBEDTLS_HAVE_X86) && defined(__GNUC__)
+        if (mbedtls_padlock_has_support(MBEDTLS_PADLOCK_ACE)) {
+            mbedtls_printf("  AES note: using VIA Padlock.\n");
         } else
 #endif
 #if defined(MBEDTLS_AESCE_C) && defined(MBEDTLS_HAVE_ARM64)

--- a/library/aes.c
+++ b/library/aes.c
@@ -567,7 +567,7 @@ void mbedtls_aes_xts_free(mbedtls_aes_xts_context *ctx)
  * Note that the offset is in units of elements of buf, i.e. 32-bit words,
  * i.e. an offset of 1 means 4 bytes and so on.
  */
-#if (defined(MBEDTLS_PADLOCK_C) && defined(MBEDTLS_HAVE_X86)) ||        \
+#if (defined(MBEDTLS_VIA_PADLOCK_HAVE_CODE)) ||        \
     (defined(MBEDTLS_AESNI_C) && MBEDTLS_AESNI_HAVE_CODE == 2)
 #define MAY_NEED_TO_ALIGN
 #endif

--- a/library/aes.c
+++ b/library/aes.c
@@ -38,7 +38,7 @@
     defined(__aarch64__) && !defined(MBEDTLS_HAVE_ARM64)
 #define MBEDTLS_HAVE_ARM64
 #if !defined(MBEDTLS_AESCE_C) && defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
-#error "MBEDTLS_AES_C defined, but not all prerequisites"
+#error "MBEDTLS_AES_USE_HARDWARE_ONLY defined, but not all prerequisites"
 #endif
 #endif
 
@@ -47,7 +47,7 @@
     !defined(MBEDTLS_HAVE_X86_64)
 #define MBEDTLS_HAVE_X86_64
 #if !defined(MBEDTLS_AESNI_C) && defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
-#error "MBEDTLS_AES_C defined, but not all prerequisites"
+#error "MBEDTLS_AES_USE_HARDWARE_ONLY defined, but not all prerequisites"
 #endif
 #endif
 
@@ -56,7 +56,7 @@
 #define MBEDTLS_HAVE_X86
 
 #if !defined(MBEDTLS_PADLOCK_C) && defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
-#error "MBEDTLS_AES_C defined, but not all prerequisites"
+#error "MBEDTLS_AES_USE_HARDWARE_ONLY defined, but not all prerequisites"
 #endif
 #endif
 

--- a/library/aes.c
+++ b/library/aes.c
@@ -33,6 +33,33 @@
 #include "mbedtls/platform.h"
 #include "mbedtls/platform_util.h"
 #include "mbedtls/error.h"
+
+#if defined(MBEDTLS_HAVE_ASM) && defined(__GNUC__) && \
+    defined(__aarch64__) && !defined(MBEDTLS_HAVE_ARM64)
+#define MBEDTLS_HAVE_ARM64
+#if !defined(MBEDTLS_AESCE_C) && defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
+#error "MBEDTLS_AES_C defined, but not all prerequisites"
+#endif
+#endif
+
+#if defined(MBEDTLS_HAVE_ASM) && defined(__GNUC__) && \
+    (defined(__amd64__) || defined(__x86_64__))   &&  \
+    !defined(MBEDTLS_HAVE_X86_64)
+#define MBEDTLS_HAVE_X86_64
+#if !defined(MBEDTLS_AESNI_C) && defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
+#error "MBEDTLS_AES_C defined, but not all prerequisites"
+#endif
+#endif
+
+#if defined(MBEDTLS_HAVE_ASM) && defined(__GNUC__) && defined(__i386__) && \
+    !defined(MBEDTLS_HAVE_ASAN)
+#define MBEDTLS_HAVE_X86
+
+#if !defined(MBEDTLS_PADLOCK_C) && defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
+#error "MBEDTLS_AES_C defined, but not all prerequisites"
+#endif
+#endif
+
 #if defined(MBEDTLS_PADLOCK_C)
 #include "padlock.h"
 #endif

--- a/library/aes.c
+++ b/library/aes.c
@@ -52,7 +52,8 @@
 #error "MBEDTLS_AES_USE_HARDWARE_ONLY defined, but not all prerequisites"
 #endif
 
-#if defined(MBEDTLS_PADLOCK_C) && !defined(MBEDTLS_HAVE_ASM)
+#if defined(MBEDTLS_PADLOCK_C) && \
+    (!defined(MBEDTLS_HAVE_ASM) || defined(MBEDTLS_AES_USE_HARDWARE_ONLY))
 #error "MBEDTLS_PADLOCK_C defined, but not all prerequisites"
 #endif
 #endif

--- a/library/aes.c
+++ b/library/aes.c
@@ -41,7 +41,7 @@
 #endif
 
 #if defined(__amd64__) || defined(__x86_64__) || \
-    defined(_M_X64) || defined(_M_AMD64)
+    ((defined(_M_X64) || defined(_M_AMD64)) && !defined(_M_ARM64EC))
 #if !defined(MBEDTLS_AESNI_C) && defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
 #error "MBEDTLS_AES_USE_HARDWARE_ONLY defined, but not all prerequisites"
 #endif

--- a/library/aes.c
+++ b/library/aes.c
@@ -655,6 +655,13 @@ int mbedtls_aes_setkey_enc(mbedtls_aes_context *ctx, const unsigned char *key,
     }
 #endif
 
+/* When runtime detection enabled and plain C is disabled, compiler
+   reports `-Werror=return-type`. */
+#if defined(MBEDTLS_HAVE_X86) && defined(MBEDTLS_AES_USE_HARDWARE_ONLY) && \
+    defined(MBEDTLS_PADLOCK_C) && defined(MBEDTLS_AESNI_HAVE_CODE)
+    return MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED;
+#endif
+
 #if !defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
     for (i = 0; i < (keybits >> 5); i++) {
         RK[i] = MBEDTLS_GET_UINT32_LE(key, i << 2);
@@ -1099,6 +1106,13 @@ int mbedtls_aes_crypt_ecb(mbedtls_aes_context *ctx,
     if (aes_padlock_ace > 0) {
         return mbedtls_padlock_xcryptecb(ctx, mode, input, output);
     }
+#endif
+
+/* When runtime detection enabled and plain C is disabled, compiler
+   reports `-Werror=return-type`. */
+#if defined(MBEDTLS_HAVE_X86) && defined(MBEDTLS_AES_USE_HARDWARE_ONLY) && \
+    defined(MBEDTLS_PADLOCK_C) && defined(MBEDTLS_AESNI_HAVE_CODE)
+    return MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED;
 #endif
 
 #if !defined(MBEDTLS_AES_USE_HARDWARE_ONLY)

--- a/library/aes.c
+++ b/library/aes.c
@@ -52,9 +52,14 @@
 #error "MBEDTLS_AES_USE_HARDWARE_ONLY defined, but not all prerequisites"
 #endif
 
-#if defined(MBEDTLS_PADLOCK_C) && \
-    (!defined(MBEDTLS_HAVE_ASM) || defined(MBEDTLS_AES_USE_HARDWARE_ONLY))
+#if defined(MBEDTLS_PADLOCK_C)
+#if !defined(MBEDTLS_HAVE_ASM)
 #error "MBEDTLS_PADLOCK_C defined, but not all prerequisites"
+#endif
+#if defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
+#error "MBEDTLS_AES_USE_HARDWARE_ONLY cannot be defined when " \
+    "MBEDTLS_PADLOCK_C is set"
+#endif
 #endif
 #endif
 

--- a/library/aes.c
+++ b/library/aes.c
@@ -620,9 +620,6 @@ static unsigned mbedtls_aes_rk_offset(uint32_t *buf)
 int mbedtls_aes_setkey_enc(mbedtls_aes_context *ctx, const unsigned char *key,
                            unsigned int keybits)
 {
-#if !defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
-    unsigned int i;
-#endif
     uint32_t *RK;
 
     switch (keybits) {
@@ -657,14 +654,14 @@ int mbedtls_aes_setkey_enc(mbedtls_aes_context *ctx, const unsigned char *key,
 #endif
 
 #if !defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
-    for (i = 0; i < (keybits >> 5); i++) {
+    for (unsigned int i = 0; i < (keybits >> 5); i++) {
         RK[i] = MBEDTLS_GET_UINT32_LE(key, i << 2);
     }
 
     switch (ctx->nr) {
         case 10:
 
-            for (i = 0; i < 10; i++, RK += 4) {
+            for (unsigned int i = 0; i < 10; i++, RK += 4) {
                 RK[4]  = RK[0] ^ RCON[i] ^
                          ((uint32_t) FSb[MBEDTLS_BYTE_1(RK[3])]) ^
                          ((uint32_t) FSb[MBEDTLS_BYTE_2(RK[3])] <<  8) ^
@@ -680,7 +677,7 @@ int mbedtls_aes_setkey_enc(mbedtls_aes_context *ctx, const unsigned char *key,
 #if !defined(MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH)
         case 12:
 
-            for (i = 0; i < 8; i++, RK += 6) {
+            for (unsigned int i = 0; i < 8; i++, RK += 6) {
                 RK[6]  = RK[0] ^ RCON[i] ^
                          ((uint32_t) FSb[MBEDTLS_BYTE_1(RK[5])]) ^
                          ((uint32_t) FSb[MBEDTLS_BYTE_2(RK[5])] <<  8) ^
@@ -697,7 +694,7 @@ int mbedtls_aes_setkey_enc(mbedtls_aes_context *ctx, const unsigned char *key,
 
         case 14:
 
-            for (i = 0; i < 7; i++, RK += 8) {
+            for (unsigned int i = 0; i < 7; i++, RK += 8) {
                 RK[8]  = RK[0] ^ RCON[i] ^
                          ((uint32_t) FSb[MBEDTLS_BYTE_1(RK[7])]) ^
                          ((uint32_t) FSb[MBEDTLS_BYTE_2(RK[7])] <<  8) ^
@@ -735,7 +732,6 @@ int mbedtls_aes_setkey_dec(mbedtls_aes_context *ctx, const unsigned char *key,
                            unsigned int keybits)
 {
 #if !defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
-    int i, j;
     uint32_t *SK;
 #endif
     int ret;
@@ -780,9 +776,9 @@ int mbedtls_aes_setkey_dec(mbedtls_aes_context *ctx, const unsigned char *key,
     *RK++ = *SK++;
     *RK++ = *SK++;
     *RK++ = *SK++;
-
-    for (i = ctx->nr - 1, SK -= 8; i > 0; i--, SK -= 8) {
-        for (j = 0; j < 4; j++, SK++) {
+    SK -= 8;
+    for (int i = ctx->nr - 1; i > 0; i--, SK -= 8) {
+        for (int j = 0; j < 4; j++, SK++) {
             *RK++ = AES_RT0(FSb[MBEDTLS_BYTE_0(*SK)]) ^
                     AES_RT1(FSb[MBEDTLS_BYTE_1(*SK)]) ^
                     AES_RT2(FSb[MBEDTLS_BYTE_2(*SK)]) ^

--- a/library/aes.c
+++ b/library/aes.c
@@ -49,8 +49,8 @@
 
 #if defined(MBEDTLS_HAVE_ASM) && defined(__i386__) && \
     !defined(MBEDTLS_HAVE_ASAN)
-#if !defined(MBEDTLS_PADLOCK_C) && defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
-#error "MBEDTLS_AES_USE_HARDWARE_ONLY defined, but not all prerequisites"
+#if defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
+#error "MBEDTLS_AES_USE_HARDWARE_ONLY not supported yet for i386."
 #endif
 #endif
 

--- a/library/aes.c
+++ b/library/aes.c
@@ -47,10 +47,13 @@
 #endif
 #endif
 
-#if defined(MBEDTLS_HAVE_ASM) && defined(__i386__) && \
-    !defined(MBEDTLS_HAVE_ASAN)
+#if defined(__i386__)
 #if defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
 #error "MBEDTLS_AES_USE_HARDWARE_ONLY not supported yet for i386."
+#endif
+
+#if defined(MBEDTLS_PADLOCK_C) && !defined(MBEDTLS_HAVE_ASM)
+#error "MBEDTLS_PADLOCK_C defined, but not all prerequisites"
 #endif
 #endif
 

--- a/library/aes.c
+++ b/library/aes.c
@@ -71,7 +71,7 @@
 
 #if !defined(MBEDTLS_AES_ALT)
 
-#if defined(MBEDTLS_PADLOCK_C) && defined(MBEDTLS_HAVE_X86) && defined(__GNUC__)
+#if defined(MBEDTLS_VIA_PADLOCK_HAVE_CODE)
 static int aes_padlock_ace = -1;
 #endif
 
@@ -578,7 +578,7 @@ static unsigned mbedtls_aes_rk_offset(uint32_t *buf)
 #if defined(MAY_NEED_TO_ALIGN)
     int align_16_bytes = 0;
 
-#if defined(MBEDTLS_PADLOCK_C) && defined(MBEDTLS_HAVE_X86) && defined(__GNUC__)
+#if defined(MBEDTLS_VIA_PADLOCK_HAVE_CODE)
     if (aes_padlock_ace == -1) {
         aes_padlock_ace = mbedtls_padlock_has_support(MBEDTLS_PADLOCK_ACE);
     }
@@ -1102,7 +1102,7 @@ int mbedtls_aes_crypt_ecb(mbedtls_aes_context *ctx,
     }
 #endif
 
-#if defined(MBEDTLS_PADLOCK_C) && defined(MBEDTLS_HAVE_X86) && defined(__GNUC__)
+#if defined(MBEDTLS_VIA_PADLOCK_HAVE_CODE)
     if (aes_padlock_ace > 0) {
         return mbedtls_padlock_xcryptecb(ctx, mode, input, output);
     }
@@ -1110,8 +1110,8 @@ int mbedtls_aes_crypt_ecb(mbedtls_aes_context *ctx,
 
 /* When runtime detection enabled and plain C is disabled, compiler
    reports `-Werror=return-type`. */
-#if defined(MBEDTLS_HAVE_X86) && defined(MBEDTLS_AES_USE_HARDWARE_ONLY) && \
-    defined(MBEDTLS_PADLOCK_C) && defined(MBEDTLS_AESNI_HAVE_CODE)
+#if defined(MBEDTLS_AES_USE_HARDWARE_ONLY) && \
+    defined(MBEDTLS_VIA_PADLOCK_HAVE_CODE) && defined(MBEDTLS_AESNI_HAVE_CODE)
     return MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED;
 #endif
 
@@ -1148,7 +1148,7 @@ int mbedtls_aes_crypt_cbc(mbedtls_aes_context *ctx,
         return MBEDTLS_ERR_AES_INVALID_INPUT_LENGTH;
     }
 
-#if defined(MBEDTLS_PADLOCK_C) && defined(MBEDTLS_HAVE_X86) && defined(__GNUC__)
+#if defined(MBEDTLS_VIA_PADLOCK_HAVE_CODE)
     if (aes_padlock_ace > 0) {
         if (mbedtls_padlock_xcryptcbc(ctx, mode, length, iv, input, output) == 0) {
             return 0;
@@ -1912,7 +1912,7 @@ int mbedtls_aes_self_test(int verbose)
             mbedtls_printf("  AES note: using AESNI.\n");
         } else
 #endif
-#if defined(MBEDTLS_PADLOCK_C) && defined(MBEDTLS_HAVE_X86) && defined(__GNUC__)
+#if defined(MBEDTLS_VIA_PADLOCK_HAVE_CODE)
         if (mbedtls_padlock_has_support(MBEDTLS_PADLOCK_ACE)) {
             mbedtls_printf("  AES note: using VIA Padlock.\n");
         } else

--- a/library/aes.c
+++ b/library/aes.c
@@ -656,13 +656,6 @@ int mbedtls_aes_setkey_enc(mbedtls_aes_context *ctx, const unsigned char *key,
     }
 #endif
 
-/* When runtime detection enabled and plain C is disabled, compiler
-   reports `-Werror=return-type`. */
-#if defined(MBEDTLS_HAVE_X86) && defined(MBEDTLS_AES_USE_HARDWARE_ONLY) && \
-    defined(MBEDTLS_PADLOCK_C) && defined(MBEDTLS_AESNI_HAVE_CODE)
-    return MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED;
-#endif
-
 #if !defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
     for (i = 0; i < (keybits >> 5); i++) {
         RK[i] = MBEDTLS_GET_UINT32_LE(key, i << 2);
@@ -1107,13 +1100,6 @@ int mbedtls_aes_crypt_ecb(mbedtls_aes_context *ctx,
     if (aes_padlock_ace > 0) {
         return mbedtls_padlock_xcryptecb(ctx, mode, input, output);
     }
-#endif
-
-/* When runtime detection enabled and plain C is disabled, compiler
-   reports `-Werror=return-type`. */
-#if defined(MBEDTLS_AES_USE_HARDWARE_ONLY) && \
-    defined(MBEDTLS_VIA_PADLOCK_HAVE_CODE) && defined(MBEDTLS_AESNI_HAVE_CODE)
-    return MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED;
 #endif
 
 #if !defined(MBEDTLS_AES_USE_HARDWARE_ONLY)

--- a/library/aes.c
+++ b/library/aes.c
@@ -34,7 +34,7 @@
 #include "mbedtls/platform_util.h"
 #include "mbedtls/error.h"
 
-#if defined(MBEDTLS_HAVE_ASM) && defined(__aarch64__)
+#if defined(__aarch64__)
 #if !defined(MBEDTLS_AESCE_C) && defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
 #error "MBEDTLS_AES_USE_HARDWARE_ONLY defined, but not all prerequisites"
 #endif

--- a/library/aes.c
+++ b/library/aes.c
@@ -40,15 +40,16 @@
 #endif
 #endif
 
-#if defined(__amd64__) || defined(__x86_64__)
+#if defined(__amd64__) || defined(__x86_64__) || \
+    defined(_M_X64) || defined(_M_AMD64)
 #if !defined(MBEDTLS_AESNI_C) && defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
 #error "MBEDTLS_AES_USE_HARDWARE_ONLY defined, but not all prerequisites"
 #endif
 #endif
 
-#if defined(__i386__)
-#if defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
-#error "MBEDTLS_AES_USE_HARDWARE_ONLY not supported yet for i386."
+#if defined(__i386__) || defined(_M_IX86)
+#if defined(MBEDTLS_AES_USE_HARDWARE_ONLY) && !defined(MBEDTLS_AESNI_C)
+#error "MBEDTLS_AES_USE_HARDWARE_ONLY defined, but not all prerequisites"
 #endif
 
 #if defined(MBEDTLS_PADLOCK_C) && !defined(MBEDTLS_HAVE_ASM)

--- a/library/aes.c
+++ b/library/aes.c
@@ -40,8 +40,7 @@
 #endif
 #endif
 
-#if defined(MBEDTLS_HAVE_ASM) && \
-    (defined(__amd64__) || defined(__x86_64__))
+#if defined(__amd64__) || defined(__x86_64__)
 #if !defined(MBEDTLS_AESNI_C) && defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
 #error "MBEDTLS_AES_USE_HARDWARE_ONLY defined, but not all prerequisites"
 #endif

--- a/library/aes.c
+++ b/library/aes.c
@@ -34,16 +34,14 @@
 #include "mbedtls/platform_util.h"
 #include "mbedtls/error.h"
 
-#if defined(MBEDTLS_HAVE_ASM) && \
-    defined(__aarch64__) && !defined(MBEDTLS_HAVE_ARM64)
+#if defined(MBEDTLS_HAVE_ASM) && defined(__aarch64__)
 #if !defined(MBEDTLS_AESCE_C) && defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
 #error "MBEDTLS_AES_USE_HARDWARE_ONLY defined, but not all prerequisites"
 #endif
 #endif
 
 #if defined(MBEDTLS_HAVE_ASM) && \
-    (defined(__amd64__) || defined(__x86_64__))   &&  \
-    !defined(MBEDTLS_HAVE_X86_64)
+    (defined(__amd64__) || defined(__x86_64__))
 #if !defined(MBEDTLS_AESNI_C) && defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
 #error "MBEDTLS_AES_USE_HARDWARE_ONLY defined, but not all prerequisites"
 #endif

--- a/library/aes.c
+++ b/library/aes.c
@@ -71,7 +71,7 @@
 
 #if !defined(MBEDTLS_AES_ALT)
 
-#if defined(MBEDTLS_PADLOCK_C) && defined(MBEDTLS_HAVE_X86)
+#if defined(MBEDTLS_PADLOCK_C) && defined(MBEDTLS_HAVE_X86) && defined(__GNUC__)
 static int aes_padlock_ace = -1;
 #endif
 
@@ -578,7 +578,7 @@ static unsigned mbedtls_aes_rk_offset(uint32_t *buf)
 #if defined(MAY_NEED_TO_ALIGN)
     int align_16_bytes = 0;
 
-#if defined(MBEDTLS_PADLOCK_C) && defined(MBEDTLS_HAVE_X86)
+#if defined(MBEDTLS_PADLOCK_C) && defined(MBEDTLS_HAVE_X86) && defined(__GNUC__)
     if (aes_padlock_ace == -1) {
         aes_padlock_ace = mbedtls_padlock_has_support(MBEDTLS_PADLOCK_ACE);
     }
@@ -1102,7 +1102,7 @@ int mbedtls_aes_crypt_ecb(mbedtls_aes_context *ctx,
     }
 #endif
 
-#if defined(MBEDTLS_PADLOCK_C) && defined(MBEDTLS_HAVE_X86)
+#if defined(MBEDTLS_PADLOCK_C) && defined(MBEDTLS_HAVE_X86) && defined(__GNUC__)
     if (aes_padlock_ace > 0) {
         return mbedtls_padlock_xcryptecb(ctx, mode, input, output);
     }
@@ -1148,7 +1148,7 @@ int mbedtls_aes_crypt_cbc(mbedtls_aes_context *ctx,
         return MBEDTLS_ERR_AES_INVALID_INPUT_LENGTH;
     }
 
-#if defined(MBEDTLS_PADLOCK_C) && defined(MBEDTLS_HAVE_X86)
+#if defined(MBEDTLS_PADLOCK_C) && defined(MBEDTLS_HAVE_X86) && defined(__GNUC__)
     if (aes_padlock_ace > 0) {
         if (mbedtls_padlock_xcryptcbc(ctx, mode, length, iv, input, output) == 0) {
             return 0;
@@ -1900,7 +1900,7 @@ int mbedtls_aes_self_test(int verbose)
 #if defined(MBEDTLS_AES_ALT)
         mbedtls_printf("  AES note: alternative implementation.\n");
 #else /* MBEDTLS_AES_ALT */
-#if defined(MBEDTLS_PADLOCK_C) && defined(MBEDTLS_HAVE_X86)
+#if defined(MBEDTLS_PADLOCK_C) && defined(MBEDTLS_HAVE_X86) && defined(__GNUC__)
         if (mbedtls_padlock_has_support(MBEDTLS_PADLOCK_ACE)) {
             mbedtls_printf("  AES note: using VIA Padlock.\n");
         } else

--- a/library/aes.c
+++ b/library/aes.c
@@ -622,7 +622,9 @@ static unsigned mbedtls_aes_rk_offset(uint32_t *buf)
 int mbedtls_aes_setkey_enc(mbedtls_aes_context *ctx, const unsigned char *key,
                            unsigned int keybits)
 {
+#if !defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
     unsigned int i;
+#endif
     uint32_t *RK;
 
     switch (keybits) {
@@ -656,6 +658,7 @@ int mbedtls_aes_setkey_enc(mbedtls_aes_context *ctx, const unsigned char *key,
     }
 #endif
 
+#if !defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
     for (i = 0; i < (keybits >> 5); i++) {
         RK[i] = MBEDTLS_GET_UINT32_LE(key, i << 2);
     }
@@ -722,6 +725,7 @@ int mbedtls_aes_setkey_enc(mbedtls_aes_context *ctx, const unsigned char *key,
     }
 
     return 0;
+#endif /* !MBEDTLS_AES_USE_HARDWARE_ONLY */
 }
 #endif /* !MBEDTLS_AES_SETKEY_ENC_ALT */
 
@@ -732,10 +736,14 @@ int mbedtls_aes_setkey_enc(mbedtls_aes_context *ctx, const unsigned char *key,
 int mbedtls_aes_setkey_dec(mbedtls_aes_context *ctx, const unsigned char *key,
                            unsigned int keybits)
 {
-    int i, j, ret;
+#if !defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
+    int i, j;
+    uint32_t *SK;
+#endif
+    int ret;
     mbedtls_aes_context cty;
     uint32_t *RK;
-    uint32_t *SK;
+
 
     mbedtls_aes_init(&cty);
 
@@ -767,6 +775,7 @@ int mbedtls_aes_setkey_dec(mbedtls_aes_context *ctx, const unsigned char *key,
     }
 #endif
 
+#if !defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
     SK = cty.buf + cty.rk_offset + cty.nr * 4;
 
     *RK++ = *SK++;
@@ -787,7 +796,7 @@ int mbedtls_aes_setkey_dec(mbedtls_aes_context *ctx, const unsigned char *key,
     *RK++ = *SK++;
     *RK++ = *SK++;
     *RK++ = *SK++;
-
+#endif /* !MBEDTLS_AES_USE_HARDWARE_ONLY */
 exit:
     mbedtls_aes_free(&cty);
 
@@ -1095,11 +1104,14 @@ int mbedtls_aes_crypt_ecb(mbedtls_aes_context *ctx,
     }
 #endif
 
+#if !defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
     if (mode == MBEDTLS_AES_ENCRYPT) {
         return mbedtls_internal_aes_encrypt(ctx, input, output);
     } else {
         return mbedtls_internal_aes_decrypt(ctx, input, output);
     }
+#endif
+
 }
 
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
@@ -1899,7 +1911,11 @@ int mbedtls_aes_self_test(int verbose)
             mbedtls_printf("  AES note: using AESCE.\n");
         } else
 #endif
-        mbedtls_printf("  AES note: built-in implementation.\n");
+        {
+#if !defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
+            mbedtls_printf("  AES note: built-in implementation.\n");
+#endif
+        }
 #endif /* MBEDTLS_AES_ALT */
     }
 

--- a/library/aes.c
+++ b/library/aes.c
@@ -34,27 +34,23 @@
 #include "mbedtls/platform_util.h"
 #include "mbedtls/error.h"
 
-#if defined(MBEDTLS_HAVE_ASM) && defined(__GNUC__) && \
+#if defined(MBEDTLS_HAVE_ASM) && \
     defined(__aarch64__) && !defined(MBEDTLS_HAVE_ARM64)
-#define MBEDTLS_HAVE_ARM64
 #if !defined(MBEDTLS_AESCE_C) && defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
 #error "MBEDTLS_AES_USE_HARDWARE_ONLY defined, but not all prerequisites"
 #endif
 #endif
 
-#if defined(MBEDTLS_HAVE_ASM) && defined(__GNUC__) && \
+#if defined(MBEDTLS_HAVE_ASM) && \
     (defined(__amd64__) || defined(__x86_64__))   &&  \
     !defined(MBEDTLS_HAVE_X86_64)
-#define MBEDTLS_HAVE_X86_64
 #if !defined(MBEDTLS_AESNI_C) && defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
 #error "MBEDTLS_AES_USE_HARDWARE_ONLY defined, but not all prerequisites"
 #endif
 #endif
 
-#if defined(MBEDTLS_HAVE_ASM) && defined(__GNUC__) && defined(__i386__) && \
+#if defined(MBEDTLS_HAVE_ASM) && defined(__i386__) && \
     !defined(MBEDTLS_HAVE_ASAN)
-#define MBEDTLS_HAVE_X86
-
 #if !defined(MBEDTLS_PADLOCK_C) && defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
 #error "MBEDTLS_AES_USE_HARDWARE_ONLY defined, but not all prerequisites"
 #endif

--- a/library/aesce.c
+++ b/library/aesce.c
@@ -99,7 +99,7 @@
 #include <sys/auxv.h>
 #endif
 
-#if !defined(MBEDTLS_AES_HAS_NO_PLAIN_C)
+#if !defined(MBEDTLS_AES_DONT_USE_SOFTWARE_CRYPTO)
 /*
  * AES instruction support detection routine
  */

--- a/library/aesce.c
+++ b/library/aesce.c
@@ -99,7 +99,7 @@
 #include <sys/auxv.h>
 #endif
 
-#if !defined(MBEDTLS_AES_DONT_USE_SOFTWARE_CRYPTO)
+#if !defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
 /*
  * AES instruction support detection routine
  */

--- a/library/aesce.c
+++ b/library/aesce.c
@@ -99,7 +99,7 @@
 #include <sys/auxv.h>
 #endif
 
-#if !defined(MBEDTLS_AES_HAS_NO_BUILTIN)
+#if !defined(MBEDTLS_AES_HAS_NO_PLAIN_C)
 /*
  * AES instruction support detection routine
  */

--- a/library/aesce.c
+++ b/library/aesce.c
@@ -99,6 +99,7 @@
 #include <sys/auxv.h>
 #endif
 
+#if !defined(MBEDTLS_AES_HAS_NO_BUILTIN)
 /*
  * AES instruction support detection routine
  */
@@ -113,6 +114,7 @@ int mbedtls_aesce_has_support(void)
     return 1;
 #endif
 }
+#endif
 
 /* Single round of AESCE encryption */
 #define AESCE_ENCRYPT_ROUND                   \

--- a/library/aesce.h
+++ b/library/aesce.h
@@ -33,7 +33,7 @@
 #if !defined(MBEDTLS_HAVE_ARM64)
 #if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
 #define MBEDTLS_HAVE_ARM64
-#if !defined(MBEDTLS_AESCE_C) && defined(MBEDTLS_AES_DONT_USE_SOFTWARE_CRYPTO)
+#if !defined(MBEDTLS_AESCE_C) && defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
 #error "MBEDTLS_AES_C defined, but not all prerequisites"
 #endif
 #endif
@@ -50,7 +50,7 @@ extern "C" {
  *
  * \return         1 if CPU has support for the feature, 0 otherwise
  */
-#if !defined(MBEDTLS_AES_DONT_USE_SOFTWARE_CRYPTO)
+#if !defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
 int mbedtls_aesce_has_support(void);
 #else
 #define /* no-check-names */ mbedtls_aesce_has_support() 1

--- a/library/aesce.h
+++ b/library/aesce.h
@@ -33,6 +33,9 @@
 #if !defined(MBEDTLS_HAVE_ARM64)
 #if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
 #define MBEDTLS_HAVE_ARM64
+#if !defined(MBEDTLS_AESCE_C) && !defined(MBEDTLS_AES_HAS_NO_PLAIN_C)
+#error "MBEDTLS_AESCE_C defined, but not all prerequisites"
+#endif
 #endif
 #endif
 

--- a/library/aesce.h
+++ b/library/aesce.h
@@ -47,7 +47,7 @@ extern "C" {
  *
  * \return         1 if CPU has support for the feature, 0 otherwise
  */
-#if !defined(MBEDTLS_AES_HAS_NO_BUILTIN)
+#if !defined(MBEDTLS_AES_HAS_NO_PLAIN_C)
 int mbedtls_aesce_has_support(void);
 #else
 #define /* no-check-names */ mbedtls_aesce_has_support() 1

--- a/library/aesce.h
+++ b/library/aesce.h
@@ -33,9 +33,6 @@
 #if !defined(MBEDTLS_HAVE_ARM64)
 #if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
 #define MBEDTLS_HAVE_ARM64
-#if !defined(MBEDTLS_AESCE_C) && defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
-#error "MBEDTLS_AES_C defined, but not all prerequisites"
-#endif
 #endif
 #endif
 

--- a/library/aesce.h
+++ b/library/aesce.h
@@ -33,8 +33,8 @@
 #if !defined(MBEDTLS_HAVE_ARM64)
 #if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
 #define MBEDTLS_HAVE_ARM64
-#if !defined(MBEDTLS_AESCE_C) && !defined(MBEDTLS_AES_DONT_USE_SOFTWARE_CRYPTO)
-#error "MBEDTLS_AESCE_C defined, but not all prerequisites"
+#if !defined(MBEDTLS_AESCE_C) && defined(MBEDTLS_AES_DONT_USE_SOFTWARE_CRYPTO)
+#error "MBEDTLS_AES_C defined, but not all prerequisites"
 #endif
 #endif
 #endif

--- a/library/aesce.h
+++ b/library/aesce.h
@@ -47,7 +47,12 @@ extern "C" {
  *
  * \return         1 if CPU has support for the feature, 0 otherwise
  */
+#if !defined(MBEDTLS_AES_HAS_NO_BUILTIN)
 int mbedtls_aesce_has_support(void);
+#else
+#define /* no-check-names */ mbedtls_aesce_has_support() 1
+#endif
+
 
 /**
  * \brief          Internal AES-ECB block encryption and decryption

--- a/library/aesce.h
+++ b/library/aesce.h
@@ -33,7 +33,7 @@
 #if !defined(MBEDTLS_HAVE_ARM64)
 #if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
 #define MBEDTLS_HAVE_ARM64
-#if !defined(MBEDTLS_AESCE_C) && !defined(MBEDTLS_AES_HAS_NO_PLAIN_C)
+#if !defined(MBEDTLS_AESCE_C) && !defined(MBEDTLS_AES_DONT_USE_SOFTWARE_CRYPTO)
 #error "MBEDTLS_AESCE_C defined, but not all prerequisites"
 #endif
 #endif
@@ -50,7 +50,7 @@ extern "C" {
  *
  * \return         1 if CPU has support for the feature, 0 otherwise
  */
-#if !defined(MBEDTLS_AES_HAS_NO_PLAIN_C)
+#if !defined(MBEDTLS_AES_DONT_USE_SOFTWARE_CRYPTO)
 int mbedtls_aesce_has_support(void);
 #else
 #define /* no-check-names */ mbedtls_aesce_has_support() 1

--- a/library/aesce.h
+++ b/library/aesce.h
@@ -50,7 +50,7 @@ extern "C" {
 #if !defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
 int mbedtls_aesce_has_support(void);
 #else
-#define /* no-check-names */ mbedtls_aesce_has_support() 1
+#define mbedtls_aesce_has_support() 1
 #endif
 
 

--- a/library/aesni.c
+++ b/library/aesni.c
@@ -39,8 +39,7 @@
 #include <immintrin.h>
 #endif
 
-#if !defined(MBEDTLS_AES_USE_HARDWARE_ONLY) || \
-    (defined(MBEDTLS_HAVE_X86) && defined(MBEDTLS_PADLOCK_C))
+#if !defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
 /*
  * AES-NI support detection routine
  */

--- a/library/aesni.c
+++ b/library/aesni.c
@@ -39,7 +39,8 @@
 #include <immintrin.h>
 #endif
 
-#if !defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
+#if !defined(MBEDTLS_AES_USE_HARDWARE_ONLY) || \
+    (defined(MBEDTLS_HAVE_X86) && defined(MBEDTLS_PADLOCK_C))
 /*
  * AES-NI support detection routine
  */

--- a/library/aesni.c
+++ b/library/aesni.c
@@ -39,6 +39,7 @@
 #include <immintrin.h>
 #endif
 
+#if !defined(MBEDTLS_AES_HAS_NO_BUILTIN)
 /*
  * AES-NI support detection routine
  */
@@ -68,6 +69,7 @@ int mbedtls_aesni_has_support(unsigned int what)
 
     return (c & what) != 0;
 }
+#endif /* !MBEDTLS_AES_HAS_NO_BUILTIN */
 
 #if MBEDTLS_AESNI_HAVE_CODE == 2
 

--- a/library/aesni.c
+++ b/library/aesni.c
@@ -39,7 +39,7 @@
 #include <immintrin.h>
 #endif
 
-#if !defined(MBEDTLS_AES_DONT_USE_SOFTWARE_CRYPTO)
+#if !defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
 /*
  * AES-NI support detection routine
  */
@@ -69,7 +69,7 @@ int mbedtls_aesni_has_support(unsigned int what)
 
     return (c & what) != 0;
 }
-#endif /* !MBEDTLS_AES_DONT_USE_SOFTWARE_CRYPTO */
+#endif /* !MBEDTLS_AES_USE_HARDWARE_ONLY */
 
 #if MBEDTLS_AESNI_HAVE_CODE == 2
 

--- a/library/aesni.c
+++ b/library/aesni.c
@@ -39,7 +39,7 @@
 #include <immintrin.h>
 #endif
 
-#if !defined(MBEDTLS_AES_HAS_NO_PLAIN_C)
+#if !defined(MBEDTLS_AES_DONT_USE_SOFTWARE_CRYPTO)
 /*
  * AES-NI support detection routine
  */
@@ -69,7 +69,7 @@ int mbedtls_aesni_has_support(unsigned int what)
 
     return (c & what) != 0;
 }
-#endif /* !MBEDTLS_AES_HAS_NO_PLAIN_C */
+#endif /* !MBEDTLS_AES_DONT_USE_SOFTWARE_CRYPTO */
 
 #if MBEDTLS_AESNI_HAVE_CODE == 2
 

--- a/library/aesni.c
+++ b/library/aesni.c
@@ -39,7 +39,7 @@
 #include <immintrin.h>
 #endif
 
-#if !defined(MBEDTLS_AES_HAS_NO_BUILTIN)
+#if !defined(MBEDTLS_AES_HAS_NO_PLAIN_C)
 /*
  * AES-NI support detection routine
  */
@@ -69,7 +69,7 @@ int mbedtls_aesni_has_support(unsigned int what)
 
     return (c & what) != 0;
 }
-#endif /* !MBEDTLS_AES_HAS_NO_BUILTIN */
+#endif /* !MBEDTLS_AES_HAS_NO_PLAIN_C */
 
 #if MBEDTLS_AESNI_HAVE_CODE == 2
 

--- a/library/aesni.h
+++ b/library/aesni.h
@@ -39,7 +39,7 @@
     (defined(__amd64__) || defined(__x86_64__))   &&  \
     !defined(MBEDTLS_HAVE_X86_64)
 #define MBEDTLS_HAVE_X86_64
-#if !defined(MBEDTLS_AESNI_C) && !defined(MBEDTLS_AES_HAS_NO_PLAIN_C)
+#if !defined(MBEDTLS_AESNI_C) && !defined(MBEDTLS_AES_DONT_USE_SOFTWARE_CRYPTO)
 #error "MBEDTLS_AESCE_C defined, but not all prerequisites"
 #endif
 #endif
@@ -91,7 +91,7 @@ extern "C" {
  *
  * \return         1 if CPU has support for the feature, 0 otherwise
  */
-#if !defined(MBEDTLS_AES_HAS_NO_PLAIN_C)
+#if !defined(MBEDTLS_AES_DONT_USE_SOFTWARE_CRYPTO)
 int mbedtls_aesni_has_support(unsigned int what);
 #else
 #define /* no-check-names */ mbedtls_aesni_has_support(what) 1

--- a/library/aesni.h
+++ b/library/aesni.h
@@ -39,9 +39,6 @@
     (defined(__amd64__) || defined(__x86_64__))   &&  \
     !defined(MBEDTLS_HAVE_X86_64)
 #define MBEDTLS_HAVE_X86_64
-#if !defined(MBEDTLS_AESNI_C) && defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
-#error "MBEDTLS_AES_C defined, but not all prerequisites"
-#endif
 #endif
 
 #if defined(MBEDTLS_AESNI_C)

--- a/library/aesni.h
+++ b/library/aesni.h
@@ -76,6 +76,8 @@
 #elif defined(MBEDTLS_HAVE_ASM) && \
     defined(__GNUC__) && defined(MBEDTLS_HAVE_X86_64)
 #define MBEDTLS_AESNI_HAVE_CODE 1 // via assembly
+#elif defined(__GNUC__)
+#   error "Must use `-mpclmul -msse2 -maes` for MBEDTLS_AESNI_C"
 #else
 #error "MBEDTLS_AESNI_C defined, but neither intrinsics nor assembly available"
 #endif

--- a/library/aesni.h
+++ b/library/aesni.h
@@ -35,13 +35,13 @@
 /* Can we do AESNI with inline assembly?
  * (Only implemented with gas syntax, only for 64-bit.)
  */
-#if defined(MBEDTLS_HAVE_ASM) && defined(__GNUC__) && \
-    (defined(__amd64__) || defined(__x86_64__))   &&  \
-    !defined(MBEDTLS_HAVE_X86_64)
+#if !defined(MBEDTLS_HAVE_X86_64) && \
+    (defined(__amd64__) || defined(__x86_64__) || \
+    defined(_M_X64) || defined(_M_AMD64))
 #define MBEDTLS_HAVE_X86_64
 #endif
 
-#if defined(MBEDTLS_AESNI_C)
+#if defined(MBEDTLS_AESNI_C) && defined(MBEDTLS_HAVE_X86_64)
 
 /* Can we do AESNI with intrinsics?
  * (Only implemented with certain compilers, only for certain targets.)
@@ -67,8 +67,10 @@
  * In the long run, we will likely remove the assembly implementation. */
 #if defined(MBEDTLS_AESNI_HAVE_INTRINSICS)
 #define MBEDTLS_AESNI_HAVE_CODE 2 // via intrinsics
-#elif defined(MBEDTLS_HAVE_X86_64)
+#elif defined(MBEDTLS_HAVE_ASM)
 #define MBEDTLS_AESNI_HAVE_CODE 1 // via assembly
+#else
+#error "MBEDTLS_AESNI_C defined, but neither intrinsics nor assembly available"
 #endif
 
 #if defined(MBEDTLS_AESNI_HAVE_CODE)

--- a/library/aesni.h
+++ b/library/aesni.h
@@ -39,8 +39,8 @@
     (defined(__amd64__) || defined(__x86_64__))   &&  \
     !defined(MBEDTLS_HAVE_X86_64)
 #define MBEDTLS_HAVE_X86_64
-#if !defined(MBEDTLS_AESNI_C) && !defined(MBEDTLS_AES_DONT_USE_SOFTWARE_CRYPTO)
-#error "MBEDTLS_AESCE_C defined, but not all prerequisites"
+#if !defined(MBEDTLS_AESNI_C) && defined(MBEDTLS_AES_DONT_USE_SOFTWARE_CRYPTO)
+#error "MBEDTLS_AES_C defined, but not all prerequisites"
 #endif
 #endif
 

--- a/library/aesni.h
+++ b/library/aesni.h
@@ -67,7 +67,7 @@
  * In the long run, we will likely remove the assembly implementation. */
 #if defined(MBEDTLS_AESNI_HAVE_INTRINSICS)
 #define MBEDTLS_AESNI_HAVE_CODE 2 // via intrinsics
-#elif defined(MBEDTLS_HAVE_ASM)
+#elif defined(MBEDTLS_HAVE_ASM) && defined(__GNUC__)
 #define MBEDTLS_AESNI_HAVE_CODE 1 // via assembly
 #else
 #error "MBEDTLS_AESNI_C defined, but neither intrinsics nor assembly available"

--- a/library/aesni.h
+++ b/library/aesni.h
@@ -39,7 +39,7 @@
     (defined(__amd64__) || defined(__x86_64__))   &&  \
     !defined(MBEDTLS_HAVE_X86_64)
 #define MBEDTLS_HAVE_X86_64
-#if !defined(MBEDTLS_AESNI_C) && defined(MBEDTLS_AES_DONT_USE_SOFTWARE_CRYPTO)
+#if !defined(MBEDTLS_AESNI_C) && defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
 #error "MBEDTLS_AES_C defined, but not all prerequisites"
 #endif
 #endif
@@ -91,7 +91,7 @@ extern "C" {
  *
  * \return         1 if CPU has support for the feature, 0 otherwise
  */
-#if !defined(MBEDTLS_AES_DONT_USE_SOFTWARE_CRYPTO)
+#if !defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
 int mbedtls_aesni_has_support(unsigned int what);
 #else
 #define /* no-check-names */ mbedtls_aesni_has_support(what) 1

--- a/library/aesni.h
+++ b/library/aesni.h
@@ -88,7 +88,11 @@ extern "C" {
  *
  * \return         1 if CPU has support for the feature, 0 otherwise
  */
+#if !defined(MBEDTLS_AES_HAS_NO_BUILTIN)
 int mbedtls_aesni_has_support(unsigned int what);
+#else
+#define /* no-check-names */ mbedtls_aesni_has_support(what) 1
+#endif
 
 /**
  * \brief          Internal AES-NI AES-ECB block encryption and decryption

--- a/library/aesni.h
+++ b/library/aesni.h
@@ -97,7 +97,8 @@ extern "C" {
  *
  * \return         1 if CPU has support for the feature, 0 otherwise
  */
-#if !defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
+#if !defined(MBEDTLS_AES_USE_HARDWARE_ONLY) || \
+    (defined(MBEDTLS_HAVE_X86) && defined(MBEDTLS_PADLOCK_C))
 int mbedtls_aesni_has_support(unsigned int what);
 #else
 #define mbedtls_aesni_has_support(what) 1

--- a/library/aesni.h
+++ b/library/aesni.h
@@ -37,7 +37,8 @@
  */
 #if !defined(MBEDTLS_HAVE_X86_64) && \
     (defined(__amd64__) || defined(__x86_64__) || \
-    defined(_M_X64) || defined(_M_AMD64))
+    defined(_M_X64) || defined(_M_AMD64)) && \
+    !defined(_M_ARM64EC)
 #define MBEDTLS_HAVE_X86_64
 #endif
 

--- a/library/aesni.h
+++ b/library/aesni.h
@@ -91,7 +91,7 @@ extern "C" {
 #if !defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
 int mbedtls_aesni_has_support(unsigned int what);
 #else
-#define /* no-check-names */ mbedtls_aesni_has_support(what) 1
+#define mbedtls_aesni_has_support(what) 1
 #endif
 
 /**

--- a/library/aesni.h
+++ b/library/aesni.h
@@ -39,6 +39,9 @@
     (defined(__amd64__) || defined(__x86_64__))   &&  \
     !defined(MBEDTLS_HAVE_X86_64)
 #define MBEDTLS_HAVE_X86_64
+#if !defined(MBEDTLS_AESNI_C) && !defined(MBEDTLS_AES_HAS_NO_PLAIN_C)
+#error "MBEDTLS_AESCE_C defined, but not all prerequisites"
+#endif
 #endif
 
 #if defined(MBEDTLS_AESNI_C)

--- a/library/aesni.h
+++ b/library/aesni.h
@@ -41,7 +41,13 @@
 #define MBEDTLS_HAVE_X86_64
 #endif
 
-#if defined(MBEDTLS_AESNI_C) && defined(MBEDTLS_HAVE_X86_64)
+#if !defined(MBEDTLS_HAVE_X86) && \
+    (defined(__i386__) || defined(_M_IX86))
+#define MBEDTLS_HAVE_X86
+#endif
+
+#if defined(MBEDTLS_AESNI_C) && \
+    (defined(MBEDTLS_HAVE_X86_64) || defined(MBEDTLS_HAVE_X86))
 
 /* Can we do AESNI with intrinsics?
  * (Only implemented with certain compilers, only for certain targets.)
@@ -67,7 +73,8 @@
  * In the long run, we will likely remove the assembly implementation. */
 #if defined(MBEDTLS_AESNI_HAVE_INTRINSICS)
 #define MBEDTLS_AESNI_HAVE_CODE 2 // via intrinsics
-#elif defined(MBEDTLS_HAVE_ASM) && defined(__GNUC__)
+#elif defined(MBEDTLS_HAVE_ASM) && \
+    defined(__GNUC__) && defined(MBEDTLS_HAVE_X86_64)
 #define MBEDTLS_AESNI_HAVE_CODE 1 // via assembly
 #else
 #error "MBEDTLS_AESNI_C defined, but neither intrinsics nor assembly available"

--- a/library/aesni.h
+++ b/library/aesni.h
@@ -100,8 +100,7 @@ extern "C" {
  *
  * \return         1 if CPU has support for the feature, 0 otherwise
  */
-#if !defined(MBEDTLS_AES_USE_HARDWARE_ONLY) || \
-    (defined(MBEDTLS_HAVE_X86) && defined(MBEDTLS_PADLOCK_C))
+#if !defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
 int mbedtls_aesni_has_support(unsigned int what);
 #else
 #define mbedtls_aesni_has_support(what) 1

--- a/library/aesni.h
+++ b/library/aesni.h
@@ -88,7 +88,7 @@ extern "C" {
  *
  * \return         1 if CPU has support for the feature, 0 otherwise
  */
-#if !defined(MBEDTLS_AES_HAS_NO_BUILTIN)
+#if !defined(MBEDTLS_AES_HAS_NO_PLAIN_C)
 int mbedtls_aesni_has_support(unsigned int what);
 #else
 #define /* no-check-names */ mbedtls_aesni_has_support(what) 1

--- a/library/gcm.c
+++ b/library/gcm.c
@@ -884,6 +884,13 @@ int mbedtls_gcm_self_test(int verbose)
             mbedtls_printf("  GCM note: using AESNI.\n");
         } else
 #endif
+
+#if defined(MBEDTLS_AESCE_C) && defined(MBEDTLS_HAVE_ARM64)
+        if (mbedtls_aesce_has_support()) {
+            mbedtls_printf("  GCM note: using AESCE.\n");
+        } else
+#endif
+
         mbedtls_printf("  GCM note: built-in implementation.\n");
 #endif /* MBEDTLS_GCM_ALT */
     }

--- a/library/padlock.c
+++ b/library/padlock.c
@@ -33,7 +33,7 @@
 
 #if defined(MBEDTLS_HAVE_X86)
 
-#if !defined(MBEDTLS_AES_DONT_USE_SOFTWARE_CRYPTO)
+#if !defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
 /*
  * PadLock detection routine
  */

--- a/library/padlock.c
+++ b/library/padlock.c
@@ -33,7 +33,7 @@
 
 #if defined(MBEDTLS_HAVE_X86)
 
-#if !defined(MBEDTLS_AES_HAS_NO_BUILTIN)
+#if !defined(MBEDTLS_AES_HAS_NO_PLAIN_C)
 /*
  * PadLock detection routine
  */

--- a/library/padlock.c
+++ b/library/padlock.c
@@ -33,6 +33,7 @@
 
 #if defined(MBEDTLS_HAVE_X86)
 
+#if !defined(MBEDTLS_AES_HAS_NO_BUILTIN)
 /*
  * PadLock detection routine
  */
@@ -62,6 +63,7 @@ int mbedtls_padlock_has_support(int feature)
 
     return flags & feature;
 }
+#endif
 
 /*
  * PadLock AES-ECB block en(de)cryption

--- a/library/padlock.c
+++ b/library/padlock.c
@@ -33,7 +33,10 @@
 
 #if defined(MBEDTLS_HAVE_X86)
 
-#if !defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
+#if defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
+#error "MBEDTLS_PADLOCK_C defined, but not all prerequisites"
+#endif
+
 /*
  * PadLock detection routine
  */
@@ -63,7 +66,6 @@ int mbedtls_padlock_has_support(int feature)
 
     return flags & feature;
 }
-#endif
 
 /*
  * PadLock AES-ECB block en(de)cryption

--- a/library/padlock.c
+++ b/library/padlock.c
@@ -33,10 +33,6 @@
 
 #if defined(MBEDTLS_HAVE_X86)
 
-#if defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
-#error "MBEDTLS_PADLOCK_C defined, but not all prerequisites"
-#endif
-
 /*
  * PadLock detection routine
  */

--- a/library/padlock.c
+++ b/library/padlock.c
@@ -33,7 +33,7 @@
 
 #if defined(MBEDTLS_HAVE_X86)
 
-#if !defined(MBEDTLS_AES_HAS_NO_PLAIN_C)
+#if !defined(MBEDTLS_AES_DONT_USE_SOFTWARE_CRYPTO)
 /*
  * PadLock detection routine
  */

--- a/library/padlock.h
+++ b/library/padlock.h
@@ -42,6 +42,8 @@
 #if defined(MBEDTLS_HAVE_ASM) && defined(__GNUC__) && defined(__i386__) && \
     !defined(MBEDTLS_HAVE_ASAN)
 
+#define MBEDTLS_VIA_PADLOCK_HAVE_CODE
+
 #ifndef MBEDTLS_HAVE_X86
 #define MBEDTLS_HAVE_X86
 #endif

--- a/library/padlock.h
+++ b/library/padlock.h
@@ -41,7 +41,6 @@
 /* Some versions of ASan result in errors about not enough registers */
 #if defined(MBEDTLS_HAVE_ASM) && defined(__GNUC__) && defined(__i386__) && \
     !defined(MBEDTLS_HAVE_ASAN)
-
 #ifndef MBEDTLS_HAVE_X86
 #define MBEDTLS_HAVE_X86
 #endif
@@ -69,7 +68,11 @@ extern "C" {
  *
  * \return         non-zero if CPU has support for the feature, 0 otherwise
  */
+#if !defined(MBEDTLS_AES_HAS_NO_BUILTIN)
 int mbedtls_padlock_has_support(int feature);
+#else
+#define /* no-check-names */ mbedtls_padlock_has_support(feature) 1
+#endif
 
 /**
  * \brief          Internal PadLock AES-ECB block en(de)cryption

--- a/library/padlock.h
+++ b/library/padlock.h
@@ -47,7 +47,7 @@
 
 #include <stdint.h>
 
-#if !defined(MBEDTLS_PADLOCK_C) && defined(MBEDTLS_AES_DONT_USE_SOFTWARE_CRYPTO)
+#if !defined(MBEDTLS_PADLOCK_C) && defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
 #error "MBEDTLS_AES_C defined, but not all prerequisites"
 #endif
 
@@ -72,7 +72,7 @@ extern "C" {
  *
  * \return         non-zero if CPU has support for the feature, 0 otherwise
  */
-#if !defined(MBEDTLS_AES_DONT_USE_SOFTWARE_CRYPTO)
+#if !defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
 int mbedtls_padlock_has_support(int feature);
 #else
 #define /* no-check-names */ mbedtls_padlock_has_support(feature) 1

--- a/library/padlock.h
+++ b/library/padlock.h
@@ -47,7 +47,7 @@
 
 #include <stdint.h>
 
-#if !defined(MBEDTLS_PADLOCK_C) && !defined(MBEDTLS_AES_HAS_NO_PLAIN_C)
+#if !defined(MBEDTLS_PADLOCK_C) && !defined(MBEDTLS_AES_DONT_USE_SOFTWARE_CRYPTO)
 #error "MBEDTLS_AESCE_C defined, but not all prerequisites"
 #endif
 
@@ -72,7 +72,7 @@ extern "C" {
  *
  * \return         non-zero if CPU has support for the feature, 0 otherwise
  */
-#if !defined(MBEDTLS_AES_HAS_NO_PLAIN_C)
+#if !defined(MBEDTLS_AES_DONT_USE_SOFTWARE_CRYPTO)
 int mbedtls_padlock_has_support(int feature);
 #else
 #define /* no-check-names */ mbedtls_padlock_has_support(feature) 1

--- a/library/padlock.h
+++ b/library/padlock.h
@@ -68,7 +68,7 @@ extern "C" {
  *
  * \return         non-zero if CPU has support for the feature, 0 otherwise
  */
-#if !defined(MBEDTLS_AES_HAS_NO_BUILTIN)
+#if !defined(MBEDTLS_AES_HAS_NO_PLAIN_C)
 int mbedtls_padlock_has_support(int feature);
 #else
 #define /* no-check-names */ mbedtls_padlock_has_support(feature) 1

--- a/library/padlock.h
+++ b/library/padlock.h
@@ -69,11 +69,7 @@ extern "C" {
  *
  * \return         non-zero if CPU has support for the feature, 0 otherwise
  */
-#if !defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
 int mbedtls_padlock_has_support(int feature);
-#else
-#define /* no-check-names */ mbedtls_padlock_has_support(feature) 1
-#endif
 
 /**
  * \brief          Internal PadLock AES-ECB block en(de)cryption

--- a/library/padlock.h
+++ b/library/padlock.h
@@ -48,10 +48,6 @@
 
 #include <stdint.h>
 
-#if !defined(MBEDTLS_PADLOCK_C) && defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
-#error "MBEDTLS_AES_C defined, but not all prerequisites"
-#endif
-
 #define MBEDTLS_PADLOCK_RNG 0x000C
 #define MBEDTLS_PADLOCK_ACE 0x00C0
 #define MBEDTLS_PADLOCK_PHE 0x0C00

--- a/library/padlock.h
+++ b/library/padlock.h
@@ -41,6 +41,7 @@
 /* Some versions of ASan result in errors about not enough registers */
 #if defined(MBEDTLS_HAVE_ASM) && defined(__GNUC__) && defined(__i386__) && \
     !defined(MBEDTLS_HAVE_ASAN)
+
 #ifndef MBEDTLS_HAVE_X86
 #define MBEDTLS_HAVE_X86
 #endif

--- a/library/padlock.h
+++ b/library/padlock.h
@@ -47,6 +47,10 @@
 
 #include <stdint.h>
 
+#if !defined(MBEDTLS_PADLOCK_C) && !defined(MBEDTLS_AES_HAS_NO_PLAIN_C)
+#error "MBEDTLS_AESCE_C defined, but not all prerequisites"
+#endif
+
 #define MBEDTLS_PADLOCK_RNG 0x000C
 #define MBEDTLS_PADLOCK_ACE 0x00C0
 #define MBEDTLS_PADLOCK_PHE 0x0C00

--- a/library/padlock.h
+++ b/library/padlock.h
@@ -47,8 +47,8 @@
 
 #include <stdint.h>
 
-#if !defined(MBEDTLS_PADLOCK_C) && !defined(MBEDTLS_AES_DONT_USE_SOFTWARE_CRYPTO)
-#error "MBEDTLS_AESCE_C defined, but not all prerequisites"
+#if !defined(MBEDTLS_PADLOCK_C) && defined(MBEDTLS_AES_DONT_USE_SOFTWARE_CRYPTO)
+#error "MBEDTLS_AES_C defined, but not all prerequisites"
 #endif
 
 #define MBEDTLS_PADLOCK_RNG 0x000C

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -3896,6 +3896,7 @@ component_test_aesni () { # ~ 60s
     make test programs/test/selftest CC=gcc CFLAGS='-Werror -Wall -Wextra -mpclmul -msse2 -maes'
     # check that we built intrinsics - this should be used by default when supported by the compiler
     ./programs/test/selftest aes | grep "AES note: using AESNI"
+    ./programs/test/selftest aes | grep -v "AES note: built-in implementation."
 }
 
 

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -4941,6 +4941,43 @@ component_check_test_helpers () {
     python3 -m unittest tests/scripts/translate_ciphers.py 2>&1
 }
 
+component_test_aes_builtin_only () {
+    msg "Test: AES builtin only"
+    scripts/config.py unset MBEDTLS_AESNI_C
+    scripts/config.py unset MBEDTLS_PADLOCK_C
+    scripts/config.py unset MBEDTLS_AESCE_C
+    scripts/config.py unset MBEDTLS_AES_HAS_NO_BUILTIN
+    msg "build: make, AES built-in only" # ~10s
+    make
+
+    msg "selftest: AES built-in only" # ~10s
+    programs/test/selftest
+}
+
+component_test_aes_aesni_only () {
+    msg "Test: AESNI only"
+    scripts/config.py set MBEDTLS_AESNI_C
+    scripts/config.py unset MBEDTLS_PADLOCK_C
+    scripts/config.py unset MBEDTLS_AESCE_C
+    scripts/config.py set MBEDTLS_AES_HAS_NO_BUILTIN
+    msg "build:  AESNI only" # ~10s
+    make
+
+    msg "selftest:  AESNI only" # ~10s
+    programs/test/selftest
+}
+
+component_test_aes_padlock_only () {
+    msg "Test: AES, VIA padlock only"
+    scripts/config.py unset MBEDTLS_AESNI_C
+    scripts/config.py set MBEDTLS_PADLOCK_C
+    scripts/config.py unset MBEDTLS_AESCE_C
+    scripts/config.py set MBEDTLS_AES_HAS_NO_BUILTIN
+    msg "build: AES, VIA padlock only" # ~10s
+    make CC=gcc CFLAGS="$ASAN_CFLAGS -m32 -O2" LDFLAGS="-m32 $ASAN_CFLAGS"
+
+}
+
 ################################################################
 #### Termination
 ################################################################

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -4941,41 +4941,6 @@ component_check_test_helpers () {
     python3 -m unittest tests/scripts/translate_ciphers.py 2>&1
 }
 
-component_test_aes_donot_use_hardware () {
-    msg "Test: AES builtin only"
-    scripts/config.py unset MBEDTLS_AESNI_C
-    scripts/config.py unset MBEDTLS_PADLOCK_C
-    scripts/config.py unset MBEDTLS_AESCE_C
-    scripts/config.py unset MBEDTLS_AES_USE_HARDWARE_ONLY
-    msg "build: make, AES built-in only" # ~10s
-    make
-
-    msg "selftest: AES built-in only" # ~10s
-    programs/test/selftest
-}
-
-component_test_aes_aesni_only () {
-    msg "Test: AESNI only"
-    scripts/config.py set MBEDTLS_AESNI_C
-    scripts/config.py unset MBEDTLS_PADLOCK_C
-    scripts/config.py unset MBEDTLS_AESCE_C
-    scripts/config.py set MBEDTLS_AES_USE_HARDWARE_ONLY
-    msg "build: AESNI only" # ~10s
-    make
-
-    msg "selftest: AESNI only" # ~10s
-    programs/test/selftest
-}
-
-component_test_aes_padlock_only () {
-    msg "Test: AES, VIA padlock only"
-    scripts/config.py unset MBEDTLS_AESNI_C
-    scripts/config.py set MBEDTLS_PADLOCK_C
-    scripts/config.py unset MBEDTLS_AESCE_C
-    scripts/config.py set MBEDTLS_AES_USE_HARDWARE_ONLY
-    msg "build: AES, VIA padlock only" # ~10s
-    make CC=gcc CFLAGS="$ASAN_CFLAGS -m32 -O2" LDFLAGS="-m32 $ASAN_CFLAGS"
-}
 
 ################################################################
 #### Termination

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -4272,6 +4272,7 @@ component_test_m32_o0 () {
     # build) and not the i386-specific inline assembly.
     msg "build: i386, make, gcc -O0 (ASan build)" # ~ 30s
     scripts/config.py full
+    scripts/config.py unset MBEDTLS_AESNI_C # AESNI depends on cpu modifiers
     make CC=gcc CFLAGS="$ASAN_CFLAGS -m32 -O0" LDFLAGS="-m32 $ASAN_CFLAGS"
 
     msg "test: i386, make, gcc -O0 (ASan build)"
@@ -4289,6 +4290,7 @@ component_test_m32_o2 () {
     # and go faster for tests.
     msg "build: i386, make, gcc -O2 (ASan build)" # ~ 30s
     scripts/config.py full
+    scripts/config.py unset MBEDTLS_AESNI_C # AESNI depends on cpu modifiers
     make CC=gcc CFLAGS="$ASAN_CFLAGS -m32 -O2" LDFLAGS="-m32 $ASAN_CFLAGS"
 
     msg "test: i386, make, gcc -O2 (ASan build)"
@@ -4304,6 +4306,7 @@ support_test_m32_o2 () {
 component_test_m32_everest () {
     msg "build: i386, Everest ECDH context (ASan build)" # ~ 6 min
     scripts/config.py set MBEDTLS_ECDH_VARIANT_EVEREST_ENABLED
+    scripts/config.py unset MBEDTLS_AESNI_C # AESNI depends on cpu modifiers
     make CC=gcc CFLAGS="$ASAN_CFLAGS -m32 -O2" LDFLAGS="-m32 $ASAN_CFLAGS"
 
     msg "test: i386, Everest ECDH context - main suites (inc. selftests) (ASan build)" # ~ 50s
@@ -4757,6 +4760,7 @@ component_test_tls13_only_record_size_limit () {
 
 component_build_mingw () {
     msg "build: Windows cross build - mingw64, make (Link Library)" # ~ 30s
+    scripts/config.py unset MBEDTLS_AESNI_C # AESNI depends on cpu modifiers
     make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -Wall -Wextra' WINDOWS_BUILD=1 lib programs
 
     # note Make tests only builds the tests, but doesn't run them

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -3931,19 +3931,6 @@ component_test_aesni_m32 () { # ~ 60s
     grep -q mbedtls_aesni_has_support ./programs/test/selftest
 
     scripts/config.py set MBEDTLS_AESNI_C
-    scripts/config.py set MBEDTLS_PADLOCK_C
-    scripts/config.py set MBEDTLS_AES_USE_HARDWARE_ONLY
-    msg "AES tests, test AESNI and VIA Padlock enabled"
-    make clean
-    make CC=gcc CFLAGS='-m32 -Werror -Wall -Wextra -mpclmul -msse2 -maes' LDFLAGS='-m32'
-    ./programs/test/selftest aes | grep -q "AES note: using AESNI"
-    ./programs/test/selftest aes | not grep -q "AES note: built-in implementation."
-    grep -q "AES note: using AESNI" ./programs/test/selftest
-    not grep -q "AES note: built-in implementation." ./programs/test/selftest
-    grep -q "AES note: using VIA Padlock" ./programs/test/selftest
-    grep -q mbedtls_aesni_has_support ./programs/test/selftest
-
-    scripts/config.py set MBEDTLS_AESNI_C
     scripts/config.py unset MBEDTLS_PADLOCK_C
     scripts/config.py set MBEDTLS_AES_USE_HARDWARE_ONLY
     msg "AES tests, test AESNI only"

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -3989,9 +3989,11 @@ component_build_aes_aesce_armcc () {
 component_build_aes_via_padlock () {
 
     msg "AES:VIA PadLock, build with default configuration."
+    scripts/config.py unset MBEDTLS_AESNI_C
     scripts/config.py set MBEDTLS_PADLOCK_C
     scripts/config.py unset MBEDTLS_AES_USE_HARDWARE_ONLY
     make CC=gcc CFLAGS="$ASAN_CFLAGS -m32 -O2" LDFLAGS="-m32 $ASAN_CFLAGS"
+    grep -q mbedtls_padlock_has_support ./programs/test/selftest
 
 }
 

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -3887,6 +3887,15 @@ component_test_aesni () { # ~ 60s
     make test programs/test/selftest CC=gcc CFLAGS='-O2 -Werror'
     # check that there is no AESNI code present
     ./programs/test/selftest aes | not grep -q "AESNI code"
+
+    # test the intrinsics implementation
+    scripts/config.py set MBEDTLS_AESNI_C
+    scripts/config.py set MBEDTLS_AES_USE_HARDWARE_ONLY
+    msg "AES tests, test AESNI only"
+    make clean
+    make test programs/test/selftest CC=gcc CFLAGS='-Werror -Wall -Wextra -mpclmul -msse2 -maes'
+    # check that we built intrinsics - this should be used by default when supported by the compiler
+    ./programs/test/selftest aes | grep "AES note: using AESNI"
 }
 
 component_test_aes_only_128_bit_keys () {

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -3869,14 +3869,14 @@ component_test_aesni () { # ~ 60s
     make clean
     make test programs/test/selftest CC=gcc CFLAGS='-Werror -Wall -Wextra -mpclmul -msse2 -maes'
     # check that we built intrinsics - this should be used by default when supported by the compiler
-    ./programs/test/selftest | grep "AESNI code" | grep -q "intrinsics"
+    ./programs/test/selftest aes | grep "AESNI code" | grep -q "intrinsics"
 
     # test the asm implementation
     msg "AES tests, test assembly"
     make clean
     make test programs/test/selftest CC=gcc CFLAGS='-Werror -Wall -Wextra -mno-pclmul -mno-sse2 -mno-aes'
     # check that we built assembly - this should be built if the compiler does not support intrinsics
-    ./programs/test/selftest | grep "AESNI code" | grep -q "assembly"
+    ./programs/test/selftest aes | grep "AESNI code" | grep -q "assembly"
 
     # test the plain C implementation
     scripts/config.py unset MBEDTLS_AESNI_C
@@ -3884,7 +3884,7 @@ component_test_aesni () { # ~ 60s
     make clean
     make test programs/test/selftest CC=gcc CFLAGS='-O2 -Werror'
     # check that there is no AESNI code present
-    ./programs/test/selftest | not grep -q "AESNI code"
+    ./programs/test/selftest aes | not grep -q "AESNI code"
 }
 
 component_test_aes_only_128_bit_keys () {

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -4941,12 +4941,12 @@ component_check_test_helpers () {
     python3 -m unittest tests/scripts/translate_ciphers.py 2>&1
 }
 
-component_test_aes_builtin_only () {
+component_test_aes_donot_use_hardware () {
     msg "Test: AES builtin only"
     scripts/config.py unset MBEDTLS_AESNI_C
     scripts/config.py unset MBEDTLS_PADLOCK_C
     scripts/config.py unset MBEDTLS_AESCE_C
-    scripts/config.py unset MBEDTLS_AES_DONT_USE_SOFTWARE_CRYPTO
+    scripts/config.py unset MBEDTLS_AES_USE_HARDWARE_ONLY
     msg "build: make, AES built-in only" # ~10s
     make
 
@@ -4959,7 +4959,7 @@ component_test_aes_aesni_only () {
     scripts/config.py set MBEDTLS_AESNI_C
     scripts/config.py unset MBEDTLS_PADLOCK_C
     scripts/config.py unset MBEDTLS_AESCE_C
-    scripts/config.py set MBEDTLS_AES_DONT_USE_SOFTWARE_CRYPTO
+    scripts/config.py set MBEDTLS_AES_USE_HARDWARE_ONLY
     msg "build:  AESNI only" # ~10s
     make
 
@@ -4972,7 +4972,7 @@ component_test_aes_padlock_only () {
     scripts/config.py unset MBEDTLS_AESNI_C
     scripts/config.py set MBEDTLS_PADLOCK_C
     scripts/config.py unset MBEDTLS_AESCE_C
-    scripts/config.py set MBEDTLS_AES_DONT_USE_SOFTWARE_CRYPTO
+    scripts/config.py set MBEDTLS_AES_USE_HARDWARE_ONLY
     msg "build: AES, VIA padlock only" # ~10s
     make CC=gcc CFLAGS="$ASAN_CFLAGS -m32 -O2" LDFLAGS="-m32 $ASAN_CFLAGS"
 

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -3927,6 +3927,22 @@ component_build_aes_aesce_armcc () {
     armc6_build_test "-O1 --target=aarch64-arm-none-eabi -march=armv8-a+crypto"
 }
 
+# For timebeing, no VIA Padlock platform available.
+component_build_aes_via_padlock () {
+
+    msg "AES:VIA PadLock, build with default configuration."
+    scripts/config.py set MBEDTLS_PADLOCK_C
+    scripts/config.py unset MBEDTLS_AES_USE_HARDWARE_ONLY
+    make CC=gcc CFLAGS="$ASAN_CFLAGS -m32 -O2" LDFLAGS="-m32 $ASAN_CFLAGS"
+
+}
+
+support_build_aes_via_padlock_only () {
+    ( [ "$MBEDTLS_TEST_PLATFORM" == "Linux-x86_64" ] || \
+        [ "$MBEDTLS_TEST_PLATFORM" == "Linux-amd64" ] ) && \
+    [ "`dpkg --print-foreign-architectures`" == "i386" ]
+}
+
 support_build_aes_aesce_armcc () {
     support_build_armcc
 }

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -4946,7 +4946,7 @@ component_test_aes_builtin_only () {
     scripts/config.py unset MBEDTLS_AESNI_C
     scripts/config.py unset MBEDTLS_PADLOCK_C
     scripts/config.py unset MBEDTLS_AESCE_C
-    scripts/config.py unset MBEDTLS_AES_HAS_NO_BUILTIN
+    scripts/config.py unset MBEDTLS_AES_HAS_NO_PLAIN_C
     msg "build: make, AES built-in only" # ~10s
     make
 
@@ -4959,7 +4959,7 @@ component_test_aes_aesni_only () {
     scripts/config.py set MBEDTLS_AESNI_C
     scripts/config.py unset MBEDTLS_PADLOCK_C
     scripts/config.py unset MBEDTLS_AESCE_C
-    scripts/config.py set MBEDTLS_AES_HAS_NO_BUILTIN
+    scripts/config.py set MBEDTLS_AES_HAS_NO_PLAIN_C
     msg "build:  AESNI only" # ~10s
     make
 
@@ -4972,7 +4972,7 @@ component_test_aes_padlock_only () {
     scripts/config.py unset MBEDTLS_AESNI_C
     scripts/config.py set MBEDTLS_PADLOCK_C
     scripts/config.py unset MBEDTLS_AESCE_C
-    scripts/config.py set MBEDTLS_AES_HAS_NO_BUILTIN
+    scripts/config.py set MBEDTLS_AES_HAS_NO_PLAIN_C
     msg "build: AES, VIA padlock only" # ~10s
     make CC=gcc CFLAGS="$ASAN_CFLAGS -m32 -O2" LDFLAGS="-m32 $ASAN_CFLAGS"
 

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -4960,10 +4960,10 @@ component_test_aes_aesni_only () {
     scripts/config.py unset MBEDTLS_PADLOCK_C
     scripts/config.py unset MBEDTLS_AESCE_C
     scripts/config.py set MBEDTLS_AES_USE_HARDWARE_ONLY
-    msg "build:  AESNI only" # ~10s
+    msg "build: AESNI only" # ~10s
     make
 
-    msg "selftest:  AESNI only" # ~10s
+    msg "selftest: AESNI only" # ~10s
     programs/test/selftest
 }
 
@@ -4975,7 +4975,6 @@ component_test_aes_padlock_only () {
     scripts/config.py set MBEDTLS_AES_USE_HARDWARE_ONLY
     msg "build: AES, VIA padlock only" # ~10s
     make CC=gcc CFLAGS="$ASAN_CFLAGS -m32 -O2" LDFLAGS="-m32 $ASAN_CFLAGS"
-
 }
 
 ################################################################

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -3862,6 +3862,7 @@ component_test_aesni () { # ~ 60s
 
     msg "build: default config with different AES implementations"
     scripts/config.py set MBEDTLS_AESNI_C
+    scripts/config.py unset MBEDTLS_AES_USE_HARDWARE_ONLY
     scripts/config.py set MBEDTLS_HAVE_ASM
 
     # test the intrinsics implementation
@@ -3880,6 +3881,7 @@ component_test_aesni () { # ~ 60s
 
     # test the plain C implementation
     scripts/config.py unset MBEDTLS_AESNI_C
+    scripts/config.py unset MBEDTLS_AES_USE_HARDWARE_ONLY
     msg "AES tests, plain C"
     make clean
     make test programs/test/selftest CC=gcc CFLAGS='-O2 -Werror'

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -3887,8 +3887,8 @@ component_test_aesni () { # ~ 60s
     make CC=gcc CFLAGS='-O2 -Werror'
     # check that there is no AESNI code present
     ./programs/test/selftest aes | not grep -q "AESNI code"
-    strings ./programs/test/selftest | not grep -q "AES note: using AESNI"
-    strings ./programs/test/selftest | grep -q "AES note: built-in implementation."
+    not grep -q "AES note: using AESNI" ./programs/test/selftest
+    grep -q "AES note: built-in implementation." ./programs/test/selftest
 
     # test the intrinsics implementation
     scripts/config.py set MBEDTLS_AESNI_C
@@ -3896,10 +3896,11 @@ component_test_aesni () { # ~ 60s
     msg "AES tests, test AESNI only"
     make clean
     make CC=gcc CFLAGS='-Werror -Wall -Wextra -mpclmul -msse2 -maes'
-    strings ./programs/test/selftest | grep -q "AES note: using AESNI"
-    strings ./programs/test/selftest | not grep -q "AES note: built-in implementation."
     ./programs/test/selftest aes | grep -q "AES note: using AESNI"
     ./programs/test/selftest aes | not grep -q "AES note: built-in implementation."
+    grep -q "AES note: using AESNI" ./programs/test/selftest
+    not grep -q "AES note: built-in implementation." ./programs/test/selftest
+
 
 }
 

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -4946,7 +4946,7 @@ component_test_aes_builtin_only () {
     scripts/config.py unset MBEDTLS_AESNI_C
     scripts/config.py unset MBEDTLS_PADLOCK_C
     scripts/config.py unset MBEDTLS_AESCE_C
-    scripts/config.py unset MBEDTLS_AES_HAS_NO_PLAIN_C
+    scripts/config.py unset MBEDTLS_AES_DONT_USE_SOFTWARE_CRYPTO
     msg "build: make, AES built-in only" # ~10s
     make
 
@@ -4959,7 +4959,7 @@ component_test_aes_aesni_only () {
     scripts/config.py set MBEDTLS_AESNI_C
     scripts/config.py unset MBEDTLS_PADLOCK_C
     scripts/config.py unset MBEDTLS_AESCE_C
-    scripts/config.py set MBEDTLS_AES_HAS_NO_PLAIN_C
+    scripts/config.py set MBEDTLS_AES_DONT_USE_SOFTWARE_CRYPTO
     msg "build:  AESNI only" # ~10s
     make
 
@@ -4972,7 +4972,7 @@ component_test_aes_padlock_only () {
     scripts/config.py unset MBEDTLS_AESNI_C
     scripts/config.py set MBEDTLS_PADLOCK_C
     scripts/config.py unset MBEDTLS_AESCE_C
-    scripts/config.py set MBEDTLS_AES_HAS_NO_PLAIN_C
+    scripts/config.py set MBEDTLS_AES_DONT_USE_SOFTWARE_CRYPTO
     msg "build: AES, VIA padlock only" # ~10s
     make CC=gcc CFLAGS="$ASAN_CFLAGS -m32 -O2" LDFLAGS="-m32 $ASAN_CFLAGS"
 


### PR DESCRIPTION
## Description

Add new option(`MBEDTLS_AES_USE_HARDWARE_ONLY `) to disable built-in AES implementation.

For time being, there are only two implementations in each known architecture. This PR just disable runtime detection to meet the requirement. When runtime detection was disabled and accelerator is enabled, built-in implementation become dead code, compiler will remove those dead code.

Fixes #7141 

## Gatekeeper checklist

- [x] **changelog** present
- [x] **backport** no, not in 2.28
- [x] **tests** provided



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

