### PR TITLE
Fix cast alignment warning in timing.c

### DIFF
--- a/include/mbedtls/timing.h
+++ b/include/mbedtls/timing.h
@@ -39,7 +39,7 @@ extern "C" {
  * \brief          timer structure
  */
 struct mbedtls_timing_hr_time {
-    unsigned char MBEDTLS_PRIVATE(opaque)[32];
+    uint64_t MBEDTLS_PRIVATE(opaque)[4];
 };
 
 /**

--- a/tests/suites/test_suite_timing.function
+++ b/tests/suites/test_suite_timing.function
@@ -28,7 +28,7 @@ void timing_get_timer()
     /* Check that a non-zero time was written back */
     int all_zero = 1;
     for (size_t i = 0; i < sizeof(time); i++) {
-        all_zero &= ((unsigned char *)&time)[i] == 0;
+        all_zero &= ((unsigned char *) &time)[i] == 0;
     }
     TEST_ASSERT(!all_zero);
 

--- a/tests/suites/test_suite_timing.function
+++ b/tests/suites/test_suite_timing.function
@@ -20,8 +20,20 @@
 void timing_get_timer()
 {
     struct mbedtls_timing_hr_time time;
+
+    memset(&time, 0, sizeof(time));
+
     (void) mbedtls_timing_get_timer(&time, 1);
+
+    /* Check that a non-zero time was written back */
+    int all_zero = 1;
+    for (size_t i = 0; i < sizeof(time); i++) {
+        all_zero &= ((unsigned char *)&time)[i] == 0;
+    }
+    TEST_ASSERT(!all_zero);
+
     (void) mbedtls_timing_get_timer(&time, 0);
+
     /* This goto is added to avoid warnings from the generated code. */
     goto exit;
 }


### PR DESCRIPTION
## Description

Fix #5633 cast alignment warning in timing.c.

## Gatekeeper checklist

- [x] **changelog** not required
- [x] **backport** #7386 
- [x] **tests** not required

