### PR TITLE
Backport 2.28 - Timing alignment

### DIFF
--- a/include/mbedtls/timing.h
+++ b/include/mbedtls/timing.h
@@ -42,7 +42,7 @@ extern "C" {
  * \brief          timer structure
  */
 struct mbedtls_timing_hr_time {
-    uint64_t opaque[4];
+    unsigned char opaque[32];
 };
 
 /**

--- a/include/mbedtls/timing.h
+++ b/include/mbedtls/timing.h
@@ -42,7 +42,7 @@ extern "C" {
  * \brief          timer structure
  */
 struct mbedtls_timing_hr_time {
-    unsigned char opaque[32];
+    uint64_t opaque[4];
 };
 
 /**

--- a/library/timing.c
+++ b/library/timing.c
@@ -234,12 +234,13 @@ volatile int mbedtls_timing_alarmed = 0;
 unsigned long mbedtls_timing_get_timer(struct mbedtls_timing_hr_time *val, int reset)
 {
     /* Copy val to an 8-byte-aligned address, so that we can safely cast it */
-    uint64_t val_aligned[(sizeof(struct mbedtls_timing_hr_time) + 7) / 8];
-    memcpy(val_aligned, val, sizeof(struct _hr_time));
+    uint64_t val_aligned[(sizeof(struct mbedtls_timing_hr_time) + sizeof(uint64_t) - 1) / sizeof(uint64_t)];
+    memcpy(val_aligned, val, sizeof(struct mbedtls_timing_hr_time));
     struct _hr_time *t = (struct _hr_time *)val_aligned;
 
     if (reset) {
         QueryPerformanceCounter(&t->start);
+        memcpy(val, t, sizeof(struct _hr_time));
         return 0;
     } else {
         unsigned long delta;
@@ -283,12 +284,13 @@ void mbedtls_set_alarm(int seconds)
 unsigned long mbedtls_timing_get_timer(struct mbedtls_timing_hr_time *val, int reset)
 {
     /* Copy val to an 8-byte-aligned address, so that we can safely cast it */
-    uint64_t val_aligned[(sizeof(struct mbedtls_timing_hr_time) + 7) / 8];
-    memcpy(val_aligned, val, sizeof(struct _hr_time));
+    uint64_t val_aligned[(sizeof(struct mbedtls_timing_hr_time) + sizeof(uint64_t) - 1) / sizeof(uint64_t)];
+    memcpy(val_aligned, val, sizeof(struct mbedtls_timing_hr_time));
     struct _hr_time *t = (struct _hr_time *)val_aligned;
 
     if (reset) {
         gettimeofday(&t->start, NULL);
+        memcpy(val, t, sizeof(struct _hr_time));
         return 0;
     } else {
         unsigned long delta;

--- a/library/timing.c
+++ b/library/timing.c
@@ -291,7 +291,7 @@ unsigned long mbedtls_timing_get_timer(struct mbedtls_timing_hr_time *val, int r
     } else {
         unsigned long delta;
         struct timeval now;
-        /* We can't safely cast val because it may not be aligned, so use memcpy */ 
+        /* We can't safely cast val because it may not be aligned, so use memcpy */
         memcpy(&t, val, sizeof(struct _hr_time));
         gettimeofday(&now, NULL);
         delta = (now.tv_sec  - t.start.tv_sec) * 1000ul

--- a/library/timing.c
+++ b/library/timing.c
@@ -233,9 +233,7 @@ volatile int mbedtls_timing_alarmed = 0;
 
 unsigned long mbedtls_timing_get_timer(struct mbedtls_timing_hr_time *val, int reset)
 {
-    /* We can't safely cast val because it may not be aligned, so use memcpy */
     struct _hr_time t;
-    memcpy(&t, val, sizeof(struct _hr_time));
 
     if (reset) {
         QueryPerformanceCounter(&t.start);
@@ -244,6 +242,8 @@ unsigned long mbedtls_timing_get_timer(struct mbedtls_timing_hr_time *val, int r
     } else {
         unsigned long delta;
         LARGE_INTEGER now, hfreq;
+        /* We can't safely cast val because it may not be aligned, so use memcpy */
+        memcpy(&t, val, sizeof(struct _hr_time));
         QueryPerformanceCounter(&now);
         QueryPerformanceFrequency(&hfreq);
         delta = (unsigned long) ((now.QuadPart - t.start.QuadPart) * 1000ul
@@ -282,9 +282,7 @@ void mbedtls_set_alarm(int seconds)
 
 unsigned long mbedtls_timing_get_timer(struct mbedtls_timing_hr_time *val, int reset)
 {
-    /* We can't safely cast val because it may not be aligned, so use memcpy */
     struct _hr_time t;
-    memcpy(&t, val, sizeof(struct _hr_time));
 
     if (reset) {
         gettimeofday(&t.start, NULL);
@@ -293,6 +291,8 @@ unsigned long mbedtls_timing_get_timer(struct mbedtls_timing_hr_time *val, int r
     } else {
         unsigned long delta;
         struct timeval now;
+        /* We can't safely cast val because it may not be aligned, so use memcpy */ 
+        memcpy(&t, val, sizeof(struct _hr_time));
         gettimeofday(&now, NULL);
         delta = (now.tv_sec  - t.start.tv_sec) * 1000ul
                 + (now.tv_usec - t.start.tv_usec) / 1000;

--- a/library/timing.c
+++ b/library/timing.c
@@ -240,7 +240,7 @@ unsigned long mbedtls_timing_get_timer(struct mbedtls_timing_hr_time *val, int r
 
     if (reset) {
         QueryPerformanceCounter(&t->start);
-        memcpy(val, t, sizeof(struct _hr_time));
+        memcpy(val, val_aligned, sizeof(struct mbedtls_timing_hr_time));
         return 0;
     } else {
         unsigned long delta;
@@ -290,7 +290,7 @@ unsigned long mbedtls_timing_get_timer(struct mbedtls_timing_hr_time *val, int r
 
     if (reset) {
         gettimeofday(&t->start, NULL);
-        memcpy(val, t, sizeof(struct _hr_time));
+        memcpy(val, val_aligned, sizeof(struct mbedtls_timing_hr_time));
         return 0;
     } else {
         unsigned long delta;

--- a/library/timing.c
+++ b/library/timing.c
@@ -17,6 +17,8 @@
  *  limitations under the License.
  */
 
+#include <string.h>
+
 #include "common.h"
 
 #include "mbedtls/platform.h"
@@ -231,7 +233,10 @@ volatile int mbedtls_timing_alarmed = 0;
 
 unsigned long mbedtls_timing_get_timer(struct mbedtls_timing_hr_time *val, int reset)
 {
-    struct _hr_time *t = (struct _hr_time *) val;
+    /* Copy val to an 8-byte-aligned address, so that we can safely cast it */
+    uint64_t val_aligned[(sizeof(struct mbedtls_timing_hr_time) + 7) / 8];
+    memcpy(val_aligned, val, sizeof(struct _hr_time));
+    struct _hr_time *t = (struct _hr_time *)val_aligned;
 
     if (reset) {
         QueryPerformanceCounter(&t->start);
@@ -277,7 +282,10 @@ void mbedtls_set_alarm(int seconds)
 
 unsigned long mbedtls_timing_get_timer(struct mbedtls_timing_hr_time *val, int reset)
 {
-    struct _hr_time *t = (struct _hr_time *) val;
+    /* Copy val to an 8-byte-aligned address, so that we can safely cast it */
+    uint64_t val_aligned[(sizeof(struct mbedtls_timing_hr_time) + 7) / 8];
+    memcpy(val_aligned, val, sizeof(struct _hr_time));
+    struct _hr_time *t = (struct _hr_time *)val_aligned;
 
     if (reset) {
         gettimeofday(&t->start, NULL);

--- a/tests/suites/test_suite_timing.function
+++ b/tests/suites/test_suite_timing.function
@@ -37,7 +37,7 @@ void timing_get_timer()
     /* Check that a non-zero time was written back */
     int all_zero = 1;
     for (size_t i = 0; i < sizeof(time); i++) {
-        all_zero &= ((unsigned char *)&time)[i] == 0;
+        all_zero &= ((unsigned char *) &time)[i] == 0;
     }
     TEST_ASSERT(!all_zero);
 

--- a/tests/suites/test_suite_timing.function
+++ b/tests/suites/test_suite_timing.function
@@ -29,8 +29,20 @@ void timing_hardclock()
 void timing_get_timer()
 {
     struct mbedtls_timing_hr_time time;
+
+    memset(&time, 0, sizeof(time));
+
     (void) mbedtls_timing_get_timer(&time, 1);
+
+    /* Check that a non-zero time was written back */
+    int all_zero = 1;
+    for (size_t i = 0; i < sizeof(time); i++) {
+        all_zero &= ((unsigned char *)&time)[i] == 0;
+    }
+    TEST_ASSERT(!all_zero);
+
     (void) mbedtls_timing_get_timer(&time, 0);
+
     /* This goto is added to avoid warnings from the generated code. */
     goto exit;
 }


### PR DESCRIPTION
## Description

Backport of #7385 

The ABI check failure is because the type of a field has changed (but its size remains the same). Since the only useful thing a user could do with the field is cast it to `struct timeval` (or WIndows equivalent), and its not supposed to be accessed by the user, this seems reasonable.

Alternatives AFAICT:
- use non-portable compiler attributes to align without changing the type
- copy the struct when using it to ensure alignment
- accept the nominal ABI break

## Gatekeeper checklist

- [x] **changelog** not required
- [x] **backport** done
- [x] **tests** not required
