### PR TITLE
Fix memory allocations in pkcs7_verify test

### DIFF
--- a/tests/suites/test_suite_pkcs7.function
+++ b/tests/suites/test_suite_pkcs7.function
@@ -84,8 +84,8 @@ void pkcs7_verify(char *pkcs7_file,
         }
     }
 
-    ASSERT_ALLOC(crts, sizeof(*crts)*n_crts);
-    ASSERT_ALLOC(crt_files_arr, sizeof(*crt_files_arr)*n_crts);
+    ASSERT_ALLOC(crts, n_crts);
+    ASSERT_ALLOC(crt_files_arr, n_crts);
 
     for (i = 0; i < strlen(crt_files); i++) {
         for (k = i; k < strlen(crt_files); k++) {
@@ -101,7 +101,7 @@ void pkcs7_verify(char *pkcs7_file,
 
     mbedtls_pkcs7_init(&pkcs7);
     for (i = 0; i < n_crts; i++) {
-        ASSERT_ALLOC(crts[i], sizeof(*crts[i]));
+        ASSERT_ALLOC(crts[i], 1);
         mbedtls_x509_crt_init(crts[i]);
     }
 


### PR DESCRIPTION
## Description

While working on support for parsing `SubjectKeyId` and `AuthorityKeyId` x509 V3 extensions I encountered a test failure in `test_suite_pkcs7` (configuration with enabled `MBEDTLS_MEMORY_BUFFER_ALLOC_C` and `MBEDTLS_PLATFORM_MEMORY`).
The following allocation is failing:
https://github.com/Mbed-TLS/mbedtls/blob/development/tests/suites/test_suite_pkcs7.function#L102-L106

This PR fixes memory allocation in test as `ASSERT_ALLOC` is incorrectly used. 

## Gatekeeper checklist

- [x] **changelog** not required
- [x] **backport** not required -  not in 2.28
- [x] **tests** not required



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

