### PR TITLE
cert_audit: Add test certificate date audit script

### DIFF
--- a/scripts/ci.requirements.txt
+++ b/scripts/ci.requirements.txt
@@ -10,3 +10,8 @@ pylint == 2.4.4
 # Use the earliest version of mypy that works with our code base.
 # See https://github.com/Mbed-TLS/mbedtls/pull/3953 .
 mypy >= 0.780
+
+# Install cryptography to avoid import-error reported by pylint.
+# What we really need is cryptography >= 35.0.0, which is only
+# available for Python >= 3.6.
+cryptography # >= 35.0.0

--- a/scripts/ci.requirements.txt
+++ b/scripts/ci.requirements.txt
@@ -14,4 +14,5 @@ mypy >= 0.780
 # Install cryptography to avoid import-error reported by pylint.
 # What we really need is cryptography >= 35.0.0, which is only
 # available for Python >= 3.6.
-cryptography # >= 35.0.0
+cryptography >= 35.0.0; sys_platform == 'linux' and python_version >= '3.6'
+cryptography;           sys_platform == 'linux' and python_version <  '3.6'

--- a/tests/scripts/audit-validity-dates.py
+++ b/tests/scripts/audit-validity-dates.py
@@ -15,11 +15,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Audit validity date of X509 crt/crl/csr
+"""Audit validity date of X509 crt/crl/csr.
 
 This script is used to audit the validity date of crt/crl/csr used for testing.
-The files are in tests/data_files/ while some data are in test suites data in
-tests/suites/*.data files.
+It prints the information of X509 data whose validity duration does not cover
+the provided validity duration. The data are collected from tests/data_files/
+and tests/suites/*.data files by default.
 """
 
 import os
@@ -362,24 +363,23 @@ def main():
     """
     Perform argument parsing.
     """
-    parser = argparse.ArgumentParser(
-        description='Audit script for X509 crt/crl/csr files.'
-    )
+    parser = argparse.ArgumentParser(description=__doc__)
 
     parser.add_argument('-a', '--all',
                         action='store_true',
-                        help='list the information of all files')
+                        help='list the information of all the files')
     parser.add_argument('-v', '--verbose',
                         action='store_true', dest='verbose',
-                        help='Show warnings')
+                        help='show warnings')
     parser.add_argument('--not-before', dest='not_before',
-                        help='not valid before this date(UTC), YYYY-MM-DD',
+                        help=('not valid before this date (UTC, YYYY-MM-DD). '
+                              'Default: today'),
                         metavar='DATE')
     parser.add_argument('--not-after', dest='not_after',
-                        help='not valid after this date(UTC), YYYY-MM-DD',
+                        help=('not valid after this date (UTC, YYYY-MM-DD). '
+                              'Default: not-before'),
                         metavar='DATE')
-    parser.add_argument('-f', '--file', dest='file',
-                        help='file to audit (Debug only)',
+    parser.add_argument('files', nargs='*', help='files to audit',
                         metavar='FILE')
 
     args = parser.parse_args()
@@ -388,9 +388,9 @@ def main():
     td_auditor = TestDataAuditor(args.verbose)
     sd_auditor = SuiteDataAuditor(args.verbose)
 
-    if args.file:
-        data_files = [args.file]
-        suite_data_files = [args.file]
+    if args.files:
+        data_files = args.files
+        suite_data_files = args.files
     else:
         data_files = td_auditor.default_files
         suite_data_files = sd_auditor.default_files
@@ -408,7 +408,7 @@ def main():
     sd_auditor.walk_all(suite_data_files)
     audit_results = td_auditor.audit_data + sd_auditor.audit_data
 
-    # we filter out the files whose validity duration covers the provide
+    # we filter out the files whose validity duration covers the provided
     # duration.
     filter_func = lambda d: (not_before_date < d.not_valid_before) or \
                             (d.not_valid_after < not_after_date)

--- a/tests/scripts/audit-validity-dates.py
+++ b/tests/scripts/audit-validity-dates.py
@@ -42,14 +42,19 @@ from cryptography import x509 #pylint: disable=import-error
 from generate_test_code import parse_test_data as parse_suite_data
 from generate_test_code import FileWrapper
 
+import scripts_path # pylint: disable=unused-import
+from mbedtls_dev import build_tree
+
 class DataType(Enum):
     CRT = 1 # Certificate
     CRL = 2 # Certificate Revocation List
     CSR = 3 # Certificate Signing Request
 
+
 class DataFormat(Enum):
     PEM = 1 # Privacy-Enhanced Mail
     DER = 2 # Distinguished Encoding Rules
+
 
 class AuditData:
     """Store data location, type and validity period of X.509 objects."""
@@ -77,6 +82,7 @@ class AuditData:
             self.not_valid_before = datetime.datetime.min
         else:
             raise ValueError("Unsupported file_type: {}".format(self.data_type))
+
 
 class X509Parser:
     """A parser class to parse crt/crl/csr file or data in PEM/DER format."""
@@ -167,6 +173,7 @@ class X509Parser:
             return False
         return True
 
+
 class Auditor:
     """A base class for audit."""
     def __init__(self, logger):
@@ -231,15 +238,8 @@ class Auditor:
     @staticmethod
     def find_test_dir():
         """Get the relative path for the MbedTLS test directory."""
-        if os.path.isdir('tests'):
-            tests_dir = 'tests'
-        elif os.path.isdir('suites'):
-            tests_dir = '.'
-        elif os.path.isdir('../suites'):
-            tests_dir = '..'
-        else:
-            raise Exception("Mbed TLS source tree not found")
-        return tests_dir
+        return os.path.relpath(build_tree.guess_mbedtls_root() + '/tests')
+
 
 class TestDataAuditor(Auditor):
     """Class for auditing files in tests/data_files/"""
@@ -254,6 +254,7 @@ class TestDataAuditor(Auditor):
         data_files = [f for f in glob.glob(test_data_glob, recursive=True)
                       if os.path.isfile(f)]
         return data_files
+
 
 class SuiteDataAuditor(Auditor):
     """Class for auditing files in tests/suites/*.data"""
@@ -293,6 +294,7 @@ class SuiteDataAuditor(Auditor):
                 audit_data_list.append(audit_data)
 
         return audit_data_list
+
 
 def list_all(audit_data: AuditData):
     print("{}\t{}\t{}\t{}".format(

--- a/tests/scripts/audit-validity-dates.py
+++ b/tests/scripts/audit-validity-dates.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+#
+# copyright the mbed tls contributors
+# spdx-license-identifier: apache-2.0
+#
+# licensed under the apache license, version 2.0 (the "license"); you may
+# not use this file except in compliance with the license.
+# you may obtain a copy of the license at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Audit validity date of X509 crt/crl/csr
+
+This script is used to audit the validity date of crt/crl/csr used for testing.
+The files are in tests/data_files/ while some data are in test suites data in
+tests/suites/*.data files.
+"""
+
+import os
+import sys
+import re
+import typing
+import types
+import argparse
+import datetime
+from enum import Enum
+
+from cryptography import x509
+
+class DataType(Enum):
+    CRT = 1 # Certificate
+    CRL = 2 # Certificate Revocation List
+    CSR = 3 # Certificate Signing Request
+
+class DataFormat(Enum):
+    PEM = 1 # Privacy-Enhanced Mail
+    DER = 2 # Distinguished Encoding Rules
+
+class AuditData:
+    """Store file, type and expiration date for audit."""
+    #pylint: disable=too-few-public-methods
+    def __init__(self, data_type: DataType):
+        self.data_type = data_type
+        self.filename = ""
+        self.not_valid_after: datetime.datetime
+        self.not_valid_before: datetime.datetime
+
+    def fill_validity_duration(self, x509_obj):
+        """Fill expiration_date field from a x509 object"""
+        # Certificate expires after "not_valid_after"
+        # Certificate is invalid before "not_valid_before"
+        if self.data_type == DataType.CRT:
+            self.not_valid_after = x509_obj.not_valid_after
+            self.not_valid_before = x509_obj.not_valid_before
+        # CertificateRevocationList expires after "next_update"
+        # CertificateRevocationList is invalid before "last_update"
+        elif self.data_type == DataType.CRL:
+            self.not_valid_after = x509_obj.next_update
+            self.not_valid_before = x509_obj.last_update
+        # CertificateSigningRequest is always valid.
+        elif self.data_type == DataType.CSR:
+            self.not_valid_after = datetime.datetime.max
+            self.not_valid_before = datetime.datetime.min
+        else:
+            raise ValueError("Unsupported file_type: {}".format(self.data_type))
+
+class X509Parser():
+    """A parser class to parse crt/crl/csr file or data in PEM/DER format."""
+    PEM_REGEX = br'-{5}BEGIN (?P<type>.*?)-{5}\n(?P<data>.*?)-{5}END (?P=type)-{5}\n'
+    PEM_TAG_REGEX = br'-{5}BEGIN (?P<type>.*?)-{5}\n'
+    PEM_TAGS = {
+        DataType.CRT: 'CERTIFICATE',
+        DataType.CRL: 'X509 CRL',
+        DataType.CSR: 'CERTIFICATE REQUEST'
+    }
+
+    def __init__(self, backends: dict):
+        self.backends = backends
+        self.__generate_parsers()
+
+    def __generate_parser(self, data_type: DataType):
+        """Parser generator for a specific DataType"""
+        tag = self.PEM_TAGS[data_type]
+        pem_loader = self.backends[data_type][DataFormat.PEM]
+        der_loader = self.backends[data_type][DataFormat.DER]
+        def wrapper(data: bytes):
+            pem_type = X509Parser.pem_data_type(data)
+            # It is in PEM format with target tag
+            if pem_type == tag:
+                return pem_loader(data)
+            # It is in PEM format without target tag
+            if pem_type:
+                return None
+            # It might be in DER format
+            try:
+                result = der_loader(data)
+            except ValueError:
+                result = None
+            return result
+        wrapper.__name__ = "{}.parser[{}]".format(type(self).__name__, tag)
+        return wrapper
+
+    def __generate_parsers(self):
+        """Generate parsers for all support DataType"""
+        self.parsers = {}
+        for data_type, _ in self.PEM_TAGS.items():
+            self.parsers[data_type] = self.__generate_parser(data_type)
+
+    def __getitem__(self, item):
+        return self.parsers[item]
+
+    @staticmethod
+    def pem_data_type(data: bytes) -> str:
+        """Get the tag from the data in PEM format
+
+        :param data: data to be checked in binary mode.
+        :return: PEM tag or "" when no tag detected.
+        """
+        m = re.search(X509Parser.PEM_TAG_REGEX, data)
+        if m is not None:
+            return m.group('type').decode('UTF-8')
+        else:
+            return ""
+
+class Auditor:
+    """A base class for audit."""
+    def __init__(self, verbose):
+        self.verbose = verbose
+        self.default_files = []
+        self.audit_data = []
+        self.parser = X509Parser({
+            DataType.CRT: {
+                DataFormat.PEM: x509.load_pem_x509_certificate,
+                DataFormat.DER: x509.load_der_x509_certificate
+            },
+            DataType.CRL: {
+                DataFormat.PEM: x509.load_pem_x509_crl,
+                DataFormat.DER: x509.load_der_x509_crl
+            },
+            DataType.CSR: {
+                DataFormat.PEM: x509.load_pem_x509_csr,
+                DataFormat.DER: x509.load_der_x509_csr
+            },
+        })
+
+    def error(self, *args):
+        #pylint: disable=no-self-use
+        print("Error: ", *args, file=sys.stderr)
+
+    def warn(self, *args):
+        if self.verbose:
+            print("Warn: ", *args, file=sys.stderr)
+
+    def parse_file(self, filename: str) -> typing.List[AuditData]:
+        """
+        Parse a list of AuditData from file.
+
+        :param filename: name of the file to parse.
+        :return list of AuditData parsed from the file.
+        """
+        with open(filename, 'rb') as f:
+            data = f.read()
+        result_list = []
+        result = self.parse_bytes(data)
+        if result is not None:
+            result.filename = filename
+            result_list.append(result)
+        return result_list
+
+    def parse_bytes(self, data: bytes):
+        """Parse AuditData from bytes."""
+        for data_type in list(DataType):
+            try:
+                result = self.parser[data_type](data)
+            except ValueError as val_error:
+                result = None
+                self.warn(val_error)
+            if result is not None:
+                audit_data = AuditData(data_type)
+                audit_data.fill_validity_duration(result)
+                return audit_data
+        return None
+
+    def walk_all(self, file_list):
+        """
+        Iterate over all the files in the list and get audit data.
+        """
+        if not file_list:
+            file_list = self.default_files
+        for filename in file_list:
+            data_list = self.parse_file(filename)
+            self.audit_data.extend(data_list)
+
+    def for_each(self, do, *args, **kwargs):
+        """
+        Sort the audit data and iterate over them.
+        """
+        if not isinstance(do, types.FunctionType):
+            return
+        for d in self.audit_data:
+            do(d, *args, **kwargs)
+
+    @staticmethod
+    def find_test_dir():
+        """Get the relative path for the MbedTLS test directory."""
+        if os.path.isdir('tests'):
+            tests_dir = 'tests'
+        elif os.path.isdir('suites'):
+            tests_dir = '.'
+        elif os.path.isdir('../suites'):
+            tests_dir = '..'
+        else:
+            raise Exception("Mbed TLS source tree not found")
+        return tests_dir
+
+class TestDataAuditor(Auditor):
+    """Class for auditing files in tests/data_files/"""
+    def __init__(self, verbose):
+        super().__init__(verbose)
+        self.default_files = self.collect_default_files()
+
+    def collect_default_files(self):
+        """collect all files in tests/data_files/"""
+        test_dir = self.find_test_dir()
+        test_data_folder = os.path.join(test_dir, 'data_files')
+        data_files = []
+        for (dir_path, _, file_names) in os.walk(test_data_folder):
+            data_files.extend(os.path.join(dir_path, file_name)
+                              for file_name in file_names)
+        return data_files
+
+
+def list_all(audit_data: AuditData):
+    print("{}\t{}\t{}\t{}".format(
+        audit_data.not_valid_before.isoformat(timespec='seconds'),
+        audit_data.not_valid_after.isoformat(timespec='seconds'),
+        audit_data.data_type.name,
+        audit_data.filename))
+
+def main():
+    """
+    Perform argument parsing.
+    """
+    parser = argparse.ArgumentParser(
+        description='Audit script for X509 crt/crl/csr files.'
+    )
+
+    parser.add_argument('-a', '--all',
+                        action='store_true',
+                        help='list the information of all files')
+    parser.add_argument('-v', '--verbose',
+                        action='store_true', dest='verbose',
+                        help='Show warnings')
+    parser.add_argument('-f', '--file', dest='file',
+                        help='file to audit (Debug only)',
+                        metavar='FILE')
+
+    args = parser.parse_args()
+
+    # start main routine
+    td_auditor = TestDataAuditor(args.verbose)
+
+    if args.file:
+        data_files = [args.file]
+    else:
+        data_files = td_auditor.default_files
+
+    td_auditor.walk_all(data_files)
+
+    if args.all:
+        td_auditor.for_each(list_all)
+
+    print("\nDone!\n")
+
+if __name__ == "__main__":
+    main()

--- a/tests/scripts/audit-validity-dates.py
+++ b/tests/scripts/audit-validity-dates.py
@@ -18,8 +18,8 @@
 """Audit validity date of X509 crt/crl/csr.
 
 This script is used to audit the validity date of crt/crl/csr used for testing.
-It would print the information about X.509 data if the validity period of the
-X.509 data didn't cover the provided validity period. The data are collected
+It prints the information about X.509 objects excluding the objects that
+are valid throughout the desired validity period. The data are collected
 from tests/data_files/ and tests/suites/*.data files by default.
 """
 
@@ -399,13 +399,13 @@ def main():
     parser.add_argument('-v', '--verbose',
                         action='store_true', dest='verbose',
                         help='show logs')
-    parser.add_argument('--not-before', dest='not_before',
-                        help=('not valid before this date (UTC, YYYY-MM-DD). '
+    parser.add_argument('--from', dest='start_date',
+                        help=('Start of desired validity period (UTC, YYYY-MM-DD). '
                               'Default: today'),
                         metavar='DATE')
-    parser.add_argument('--not-after', dest='not_after',
-                        help=('not valid after this date (UTC, YYYY-MM-DD). '
-                              'Default: not-before'),
+    parser.add_argument('--to', dest='end_date',
+                        help=('End of desired validity period (UTC, YYYY-MM-DD). '
+                              'Default: --from'),
                         metavar='DATE')
     parser.add_argument('--data-files', action='append', nargs='*',
                         help='data files to audit',
@@ -437,15 +437,15 @@ def main():
             suite_data_files = [x for l in args.suite_data_files for x in l]
 
     # validity period start date
-    if args.not_before:
-        not_before_date = datetime.datetime.fromisoformat(args.not_before)
+    if args.start_date:
+        start_date = datetime.datetime.fromisoformat(args.start_date)
     else:
-        not_before_date = datetime.datetime.today()
+        start_date = datetime.datetime.today()
     # validity period end date
-    if args.not_after:
-        not_after_date = datetime.datetime.fromisoformat(args.not_after)
+    if args.end_date:
+        end_date = datetime.datetime.fromisoformat(args.end_date)
     else:
-        not_after_date = not_before_date
+        end_date = start_date
 
     # go through all the files
     td_auditor.walk_all(data_files)
@@ -454,8 +454,8 @@ def main():
 
     # we filter out the files whose validity duration covers the provided
     # duration.
-    filter_func = lambda d: (not_before_date < d.not_valid_before) or \
-                            (d.not_valid_after < not_after_date)
+    filter_func = lambda d: (start_date < d.not_valid_before) or \
+                            (d.not_valid_after < end_date)
 
     if args.all:
         filter_func = None

--- a/tests/scripts/audit-validity-dates.py
+++ b/tests/scripts/audit-validity-dates.py
@@ -39,6 +39,7 @@ from cryptography import x509 #pylint: disable=import-error
 
 # reuse the function to parse *.data file in tests/suites/
 from generate_test_code import parse_test_data as parse_suite_data
+from generate_test_code import FileWrapper
 
 class DataType(Enum):
     CRT = 1 # Certificate
@@ -260,64 +261,6 @@ class TestDataAuditor(Auditor):
         data_files = [f for f in glob.glob(test_data_glob, recursive=True)
                       if os.path.isfile(f)]
         return data_files
-
-class FileWrapper():
-    """
-    This a stub class of generate_test_code.FileWrapper.
-
-    This class reads the whole file to memory before iterating
-    over the lines.
-    """
-
-    def __init__(self, file_name):
-        """
-        Read the file and initialize the line number to 0.
-
-        :param file_name: File path to open.
-        """
-        with open(file_name, 'rb') as f:
-            self.buf = f.read()
-        self.buf_len = len(self.buf)
-        self._line_no = 0
-        self._line_start = 0
-
-    def __iter__(self):
-        """Make the class iterable."""
-        return self
-
-    def __next__(self):
-        """
-        This method for returning a line of the file per iteration.
-
-        :return: Line read from file.
-        """
-        # If we reach the end of the file.
-        if not self._line_start < self.buf_len:
-            raise StopIteration
-
-        line_end = self.buf.find(b'\n', self._line_start) + 1
-        if line_end > 0:
-            # Find the first LF as the end of the new line.
-            line = self.buf[self._line_start:line_end]
-            self._line_start = line_end
-            self._line_no += 1
-        else:
-            # No LF found. We are at the last line without LF.
-            line = self.buf[self._line_start:]
-            self._line_start = self.buf_len
-            self._line_no += 1
-
-        # Convert byte array to string with correct encoding and
-        # strip any whitespaces added in the decoding process.
-        return line.decode(sys.getdefaultencoding()).rstrip() + '\n'
-
-    def get_line_no(self):
-        """
-        Gives current line number.
-        """
-        return self._line_no
-
-    line_no = property(get_line_no)
 
 class SuiteDataAuditor(Auditor):
     """Class for auditing files in tests/suites/*.data"""

--- a/tests/scripts/audit-validity-dates.py
+++ b/tests/scripts/audit-validity-dates.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 #
-# copyright the mbed tls contributors
-# spdx-license-identifier: apache-2.0
+# Copyright The Mbed TLS Contributors
+# SPDX-License-Identifier: Apache-2.0
 #
-# licensed under the apache license, version 2.0 (the "license"); you may
-# not use this file except in compliance with the license.
-# you may obtain a copy of the license at
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
 # http://www.apache.org/licenses/LICENSE-2.0
 #
@@ -18,9 +18,9 @@
 """Audit validity date of X509 crt/crl/csr.
 
 This script is used to audit the validity date of crt/crl/csr used for testing.
-It prints the information of X509 data whose validity duration does not cover
-the provided validity duration. The data are collected from tests/data_files/
-and tests/suites/*.data files by default.
+It would print the information about X.509 data if the validity period of the
+X.509 data didn't cover the provided validity period. The data are collected
+from tests/data_files/ and tests/suites/*.data files by default.
 """
 
 import os
@@ -50,15 +50,15 @@ class DataFormat(Enum):
     DER = 2 # Distinguished Encoding Rules
 
 class AuditData:
-    """Store file, type and expiration date for audit."""
+    """Store data location, type and validity period of X.509 objects."""
     #pylint: disable=too-few-public-methods
     def __init__(self, data_type: DataType, x509_obj):
         self.data_type = data_type
-        self.filename = ""
+        self.location = ""
         self.fill_validity_duration(x509_obj)
 
     def fill_validity_duration(self, x509_obj):
-        """Fill expiration_date field from a x509 object"""
+        """Read validity period from an X.509 object."""
         # Certificate expires after "not_valid_after"
         # Certificate is invalid before "not_valid_before"
         if self.data_type == DataType.CRT:
@@ -76,7 +76,7 @@ class AuditData:
         else:
             raise ValueError("Unsupported file_type: {}".format(self.data_type))
 
-class X509Parser():
+class X509Parser:
     """A parser class to parse crt/crl/csr file or data in PEM/DER format."""
     PEM_REGEX = br'-{5}BEGIN (?P<type>.*?)-{5}\n(?P<data>.*?)-{5}END (?P=type)-{5}\n'
     PEM_TAG_REGEX = br'-{5}BEGIN (?P<type>.*?)-{5}\n'
@@ -201,7 +201,7 @@ class Auditor:
         result_list = []
         result = self.parse_bytes(data)
         if result is not None:
-            result.filename = filename
+            result.location = filename
             result_list.append(result)
         return result_list
 
@@ -347,9 +347,9 @@ class SuiteDataAuditor(Auditor):
                 audit_data = self.parse_bytes(bytes.fromhex(match.group('data')))
                 if audit_data is None:
                     continue
-                audit_data.filename = "{}:{}:{}".format(filename,
-                                                        data_f.line_no,
-                                                        idx + 1)
+                audit_data.location = "{}:{}:#{}".format(filename,
+                                                         data_f.line_no,
+                                                         idx + 1)
                 audit_data_list.append(audit_data)
 
         return audit_data_list
@@ -359,7 +359,7 @@ def list_all(audit_data: AuditData):
         audit_data.not_valid_before.isoformat(timespec='seconds'),
         audit_data.not_valid_after.isoformat(timespec='seconds'),
         audit_data.data_type.name,
-        audit_data.filename))
+        audit_data.location))
 
 def main():
     """

--- a/tests/scripts/audit-validity-dates.py
+++ b/tests/scripts/audit-validity-dates.py
@@ -48,11 +48,10 @@ class DataFormat(Enum):
 class AuditData:
     """Store file, type and expiration date for audit."""
     #pylint: disable=too-few-public-methods
-    def __init__(self, data_type: DataType):
+    def __init__(self, data_type: DataType, x509_obj):
         self.data_type = data_type
         self.filename = ""
-        self.not_valid_after: datetime.datetime
-        self.not_valid_before: datetime.datetime
+        self.fill_validity_duration(x509_obj)
 
     def fill_validity_duration(self, x509_obj):
         """Fill expiration_date field from a x509 object"""
@@ -211,8 +210,7 @@ class Auditor:
                 result = None
                 self.warn(val_error)
             if result is not None:
-                audit_data = AuditData(data_type)
-                audit_data.fill_validity_duration(result)
+                audit_data = AuditData(data_type, result)
                 return audit_data
         return None
 

--- a/tests/scripts/audit-validity-dates.py
+++ b/tests/scripts/audit-validity-dates.py
@@ -338,7 +338,7 @@ class SuiteDataAuditor(Auditor):
         audit_data_list = []
         data_f = FileWrapper(filename)
         for _, _, _, test_args in parse_suite_data(data_f):
-            for test_arg in test_args:
+            for idx, test_arg in enumerate(test_args):
                 match = re.match(r'"(?P<data>[0-9a-fA-F]+)"', test_arg)
                 if not match:
                     continue
@@ -347,7 +347,9 @@ class SuiteDataAuditor(Auditor):
                 audit_data = self.parse_bytes(bytes.fromhex(match.group('data')))
                 if audit_data is None:
                     continue
-                audit_data.filename = filename
+                audit_data.filename = "{}:{}:{}".format(filename,
+                                                        data_f.line_no,
+                                                        idx + 1)
                 audit_data_list.append(audit_data)
 
         return audit_data_list

--- a/tests/scripts/audit-validity-dates.py
+++ b/tests/scripts/audit-validity-dates.py
@@ -31,7 +31,10 @@ import datetime
 import glob
 from enum import Enum
 
-from cryptography import x509
+# The script requires cryptography >= 35.0.0 which is only available
+# for Python >= 3.6. Disable the pylint error here until we were
+# using modern system on our CI.
+from cryptography import x509 #pylint: disable=import-error
 
 # reuse the function to parse *.data file in tests/suites/
 from generate_test_code import parse_test_data as parse_suite_data

--- a/tests/scripts/audit-validity-dates.py
+++ b/tests/scripts/audit-validity-dates.py
@@ -34,14 +34,20 @@ import logging
 from enum import Enum
 
 # The script requires cryptography >= 35.0.0 which is only available
-# for Python >= 3.6. Disable the pylint error here until we were
-# using modern system on our CI.
-from cryptography import x509 #pylint: disable=import-error
+# for Python >= 3.6.
+import cryptography
+from cryptography import x509
 
 from generate_test_code import FileWrapper
 
 import scripts_path # pylint: disable=unused-import
 from mbedtls_dev import build_tree
+
+def check_cryptography_version():
+    match = re.match(r'^[0-9]+', cryptography.__version__)
+    if match is None or int(match[0]) < 35:
+        raise Exception("audit-validity-dates requires cryptography >= 35.0.0"
+                        + "({} is too old)".format(cryptography.__version__))
 
 class DataType(Enum):
     CRT = 1 # Certificate
@@ -460,5 +466,6 @@ def main():
 
     logger.debug("Done!")
 
+check_cryptography_version()
 if __name__ == "__main__":
     main()

--- a/tests/scripts/generate_test_code.py
+++ b/tests/scripts/generate_test_code.py
@@ -163,7 +163,6 @@ __MBEDTLS_TEST_TEMPLATE__PLATFORM_CODE
 """
 
 
-import io
 import os
 import re
 import sys
@@ -208,43 +207,57 @@ class GeneratorInputError(Exception):
     pass
 
 
-class FileWrapper(io.FileIO):
+class FileWrapper:
     """
-    This class extends built-in io.FileIO class with attribute line_no,
+    This class extends the file object with attribute line_no,
     that indicates line number for the line that is read.
     """
 
-    def __init__(self, file_name):
+    def __init__(self, file_name) -> None:
         """
-        Instantiate the base class and initialize the line number to 0.
+        Instantiate the file object and initialize the line number to 0.
 
         :param file_name: File path to open.
         """
-        super().__init__(file_name, 'r')
+        # private mix-in file object
+        self._f = open(file_name, 'rb')
         self._line_no = 0
+
+    def __iter__(self):
+        return self
 
     def __next__(self):
         """
-        This method overrides base class's __next__ method and extends it
-        method to count the line numbers as each line is read.
+        This method makes FileWrapper iterable.
+        It counts the line numbers as each line is read.
 
         :return: Line read from file.
         """
-        line = super().__next__()
-        if line is not None:
-            self._line_no += 1
-            # Convert byte array to string with correct encoding and
-            # strip any whitespaces added in the decoding process.
-            return line.decode(sys.getdefaultencoding()).rstrip() + '\n'
-        return None
+        line = self._f.__next__()
+        self._line_no += 1
+        # Convert byte array to string with correct encoding and
+        # strip any whitespaces added in the decoding process.
+        return line.decode(sys.getdefaultencoding()).rstrip()+ '\n'
 
-    def get_line_no(self):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self._f.__exit__(exc_type, exc_val, exc_tb)
+
+    @property
+    def line_no(self):
         """
-        Gives current line number.
+        Property that indicates line number for the line that is read.
         """
         return self._line_no
 
-    line_no = property(get_line_no)
+    @property
+    def name(self):
+        """
+        Property that indicates name of the file that is read.
+        """
+        return self._f.name
 
 
 def split_dep(dep):


### PR DESCRIPTION
## Description
We want to introduce this script to audit the expiration date of X509 (i.e. crt/crl/csr files) files in `tests/data_files/` and data in `tests/suites/*.data`.

Fix: #7014, #7015, #7016

## Todo
- [x] Parse files in `tests/data_files/` and get their validity dates if they are crt/crl/csr files.
- [x] Option to list all parsed information.
- [x] Support for test suite data file in `tests/suites/*.data`.
- [x] Improve the speed of auditing files in `tests/suites/*.data`.
- [x] Enrich the output (e.g. line number) of auditing test suite data file.


## Gatekeeper checklist

- [x] **changelog** not required (test script only)
- [x] **backport** [no](https://github.com/Mbed-TLS/mbedtls/pull/7399#issuecomment-1523731788)
- [x] **tests** N/A
