### PR TITLE
Add missing md.h includes

### DIFF
--- a/ChangeLog.d/add-missing-md-includes.txt
+++ b/ChangeLog.d/add-missing-md-includes.txt
@@ -1,0 +1,5 @@
+Bugfix
+   * Add missing md.h includes to some of the external programs from
+     the programs directory. Without this, even though the configuration
+     was sufficient for a particular program to work, it would only print
+     a message that one of the required defines is missing.

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -40,6 +40,8 @@
 #include "mbedtls/dhm.h"
 #endif
 
+#include "mbedtls/md.h"
+
 #if defined(MBEDTLS_ECDH_C)
 #include "mbedtls/ecdh.h"
 #endif

--- a/programs/pkey/dh_client.c
+++ b/programs/pkey/dh_client.c
@@ -20,6 +20,7 @@
 #include "mbedtls/build_info.h"
 
 #include "mbedtls/platform.h"
+#include "mbedtls/md.h"
 
 #if defined(MBEDTLS_AES_C) && defined(MBEDTLS_DHM_C) && \
     defined(MBEDTLS_ENTROPY_C) && defined(MBEDTLS_NET_C) && \

--- a/programs/pkey/dh_client.c
+++ b/programs/pkey/dh_client.c
@@ -20,6 +20,7 @@
 #include "mbedtls/build_info.h"
 
 #include "mbedtls/platform.h"
+/* md.h is included this early since MD_CAN_XXX macros are defined there. */
 #include "mbedtls/md.h"
 
 #if defined(MBEDTLS_AES_C) && defined(MBEDTLS_DHM_C) && \

--- a/programs/pkey/dh_client.c
+++ b/programs/pkey/dh_client.c
@@ -46,13 +46,13 @@
     !defined(MBEDTLS_ENTROPY_C) || !defined(MBEDTLS_NET_C) ||  \
     !defined(MBEDTLS_RSA_C) || !defined(MBEDTLS_MD_CAN_SHA256) ||    \
     !defined(MBEDTLS_FS_IO) || !defined(MBEDTLS_CTR_DRBG_C) || \
-    !defined(MBEDTLS_MD_CAN_SHA1)
+    !defined(MBEDTLS_SHA1_C)
 int main(void)
 {
     mbedtls_printf("MBEDTLS_AES_C and/or MBEDTLS_DHM_C and/or MBEDTLS_ENTROPY_C "
                    "and/or MBEDTLS_NET_C and/or MBEDTLS_RSA_C and/or "
                    "MBEDTLS_MD_CAN_SHA256 and/or MBEDTLS_FS_IO and/or "
-                   "MBEDTLS_CTR_DRBG_C not defined.\n");
+                   "MBEDTLS_CTR_DRBG_C and/or MBEDTLS_SHA1_C not defined.\n");
     mbedtls_exit(0);
 }
 #else

--- a/programs/pkey/dh_server.c
+++ b/programs/pkey/dh_server.c
@@ -20,6 +20,7 @@
 #include "mbedtls/build_info.h"
 
 #include "mbedtls/platform.h"
+#include "mbedtls/md.h"
 
 #if defined(MBEDTLS_AES_C) && defined(MBEDTLS_DHM_C) && \
     defined(MBEDTLS_ENTROPY_C) && defined(MBEDTLS_NET_C) && \

--- a/programs/pkey/dh_server.c
+++ b/programs/pkey/dh_server.c
@@ -20,6 +20,7 @@
 #include "mbedtls/build_info.h"
 
 #include "mbedtls/platform.h"
+// md.h is included this early since MD_CAN_XXX macros are defined there.
 #include "mbedtls/md.h"
 
 #if defined(MBEDTLS_AES_C) && defined(MBEDTLS_DHM_C) && \

--- a/programs/pkey/dh_server.c
+++ b/programs/pkey/dh_server.c
@@ -46,13 +46,13 @@
     !defined(MBEDTLS_ENTROPY_C) || !defined(MBEDTLS_NET_C) ||  \
     !defined(MBEDTLS_RSA_C) || !defined(MBEDTLS_MD_CAN_SHA256) ||    \
     !defined(MBEDTLS_FS_IO) || !defined(MBEDTLS_CTR_DRBG_C) || \
-    !defined(MBEDTLS_MD_CAN_SHA1)
+    !defined(MBEDTLS_SHA1_C)
 int main(void)
 {
     mbedtls_printf("MBEDTLS_AES_C and/or MBEDTLS_DHM_C and/or MBEDTLS_ENTROPY_C "
                    "and/or MBEDTLS_NET_C and/or MBEDTLS_RSA_C and/or "
                    "MBEDTLS_MD_CAN_SHA256 and/or MBEDTLS_FS_IO and/or "
-                   "MBEDTLS_CTR_DRBG_C not defined.\n");
+                   "MBEDTLS_CTR_DRBG_C and/or MBEDTLS_SHA1_C not defined.\n");
     mbedtls_exit(0);
 }
 #else

--- a/programs/pkey/dh_server.c
+++ b/programs/pkey/dh_server.c
@@ -20,7 +20,7 @@
 #include "mbedtls/build_info.h"
 
 #include "mbedtls/platform.h"
-// md.h is included this early since MD_CAN_XXX macros are defined there.
+/* md.h is included this early since MD_CAN_XXX macros are defined there. */
 #include "mbedtls/md.h"
 
 #if defined(MBEDTLS_AES_C) && defined(MBEDTLS_DHM_C) && \

--- a/programs/pkey/pk_sign.c
+++ b/programs/pkey/pk_sign.c
@@ -20,6 +20,7 @@
 #include "mbedtls/build_info.h"
 
 #include "mbedtls/platform.h"
+// md.h is included this early since MD_CAN_XXX macros are defined there.
 #include "mbedtls/md.h"
 
 #if !defined(MBEDTLS_BIGNUM_C) || !defined(MBEDTLS_ENTROPY_C) ||  \

--- a/programs/pkey/pk_sign.c
+++ b/programs/pkey/pk_sign.c
@@ -20,7 +20,7 @@
 #include "mbedtls/build_info.h"
 
 #include "mbedtls/platform.h"
-// md.h is included this early since MD_CAN_XXX macros are defined there.
+/* md.h is included this early since MD_CAN_XXX macros are defined there. */
 #include "mbedtls/md.h"
 
 #if !defined(MBEDTLS_BIGNUM_C) || !defined(MBEDTLS_ENTROPY_C) ||  \

--- a/programs/pkey/pk_sign.c
+++ b/programs/pkey/pk_sign.c
@@ -39,7 +39,6 @@ int main(void)
 #include "mbedtls/error.h"
 #include "mbedtls/entropy.h"
 #include "mbedtls/ctr_drbg.h"
-#include "mbedtls/md.h"
 #include "mbedtls/pk.h"
 
 #include <stdio.h>

--- a/programs/pkey/pk_sign.c
+++ b/programs/pkey/pk_sign.c
@@ -20,6 +20,7 @@
 #include "mbedtls/build_info.h"
 
 #include "mbedtls/platform.h"
+#include "mbedtls/md.h"
 
 #if !defined(MBEDTLS_BIGNUM_C) || !defined(MBEDTLS_ENTROPY_C) ||  \
     !defined(MBEDTLS_MD_CAN_SHA256) || !defined(MBEDTLS_MD_C) || \

--- a/programs/pkey/pk_verify.c
+++ b/programs/pkey/pk_verify.c
@@ -35,7 +35,6 @@ int main(void)
 #else
 
 #include "mbedtls/error.h"
-#include "mbedtls/md.h"
 #include "mbedtls/pk.h"
 
 #include <stdio.h>

--- a/programs/pkey/pk_verify.c
+++ b/programs/pkey/pk_verify.c
@@ -20,7 +20,7 @@
 #include "mbedtls/build_info.h"
 
 #include "mbedtls/platform.h"
-// md.h is included this early since MD_CAN_XXX macros are defined there.
+/* md.h is included this early since MD_CAN_XXX macros are defined there. */
 #include "mbedtls/md.h"
 
 #if !defined(MBEDTLS_BIGNUM_C) || !defined(MBEDTLS_MD_C) || \

--- a/programs/pkey/pk_verify.c
+++ b/programs/pkey/pk_verify.c
@@ -20,6 +20,7 @@
 #include "mbedtls/build_info.h"
 
 #include "mbedtls/platform.h"
+#include "mbedtls/md.h"
 
 #if !defined(MBEDTLS_BIGNUM_C) || !defined(MBEDTLS_MD_C) || \
     !defined(MBEDTLS_MD_CAN_SHA256) || !defined(MBEDTLS_PK_PARSE_C) ||   \

--- a/programs/pkey/pk_verify.c
+++ b/programs/pkey/pk_verify.c
@@ -20,6 +20,7 @@
 #include "mbedtls/build_info.h"
 
 #include "mbedtls/platform.h"
+// md.h is included this early since MD_CAN_XXX macros are defined there.
 #include "mbedtls/md.h"
 
 #if !defined(MBEDTLS_BIGNUM_C) || !defined(MBEDTLS_MD_C) || \

--- a/programs/pkey/rsa_sign.c
+++ b/programs/pkey/rsa_sign.c
@@ -20,7 +20,7 @@
 #include "mbedtls/build_info.h"
 
 #include "mbedtls/platform.h"
-// md.h is included this early since MD_CAN_XXX macros are defined there.
+/* md.h is included this early since MD_CAN_XXX macros are defined there. */
 #include "mbedtls/md.h"
 
 #if !defined(MBEDTLS_BIGNUM_C) || !defined(MBEDTLS_RSA_C) ||  \

--- a/programs/pkey/rsa_sign.c
+++ b/programs/pkey/rsa_sign.c
@@ -20,6 +20,7 @@
 #include "mbedtls/build_info.h"
 
 #include "mbedtls/platform.h"
+#include "mbedtls/md.h"
 
 #if !defined(MBEDTLS_BIGNUM_C) || !defined(MBEDTLS_RSA_C) ||  \
     !defined(MBEDTLS_MD_CAN_SHA256) || !defined(MBEDTLS_MD_C) || \

--- a/programs/pkey/rsa_sign.c
+++ b/programs/pkey/rsa_sign.c
@@ -35,7 +35,6 @@ int main(void)
 #else
 
 #include "mbedtls/rsa.h"
-#include "mbedtls/md.h"
 
 #include <stdio.h>
 #include <string.h>

--- a/programs/pkey/rsa_sign.c
+++ b/programs/pkey/rsa_sign.c
@@ -20,6 +20,7 @@
 #include "mbedtls/build_info.h"
 
 #include "mbedtls/platform.h"
+// md.h is included this early since MD_CAN_XXX macros are defined there.
 #include "mbedtls/md.h"
 
 #if !defined(MBEDTLS_BIGNUM_C) || !defined(MBEDTLS_RSA_C) ||  \

--- a/programs/pkey/rsa_sign_pss.c
+++ b/programs/pkey/rsa_sign_pss.c
@@ -20,6 +20,7 @@
 #include "mbedtls/build_info.h"
 
 #include "mbedtls/platform.h"
+// md.h is included this early since MD_CAN_XXX macros are defined there.
 #include "mbedtls/md.h"
 
 #if !defined(MBEDTLS_MD_C) || !defined(MBEDTLS_ENTROPY_C) ||  \

--- a/programs/pkey/rsa_sign_pss.c
+++ b/programs/pkey/rsa_sign_pss.c
@@ -20,7 +20,7 @@
 #include "mbedtls/build_info.h"
 
 #include "mbedtls/platform.h"
-// md.h is included this early since MD_CAN_XXX macros are defined there.
+/* md.h is included this early since MD_CAN_XXX macros are defined there. */
 #include "mbedtls/md.h"
 
 #if !defined(MBEDTLS_MD_C) || !defined(MBEDTLS_ENTROPY_C) ||  \

--- a/programs/pkey/rsa_sign_pss.c
+++ b/programs/pkey/rsa_sign_pss.c
@@ -20,6 +20,7 @@
 #include "mbedtls/build_info.h"
 
 #include "mbedtls/platform.h"
+#include "mbedtls/md.h"
 
 #if !defined(MBEDTLS_MD_C) || !defined(MBEDTLS_ENTROPY_C) ||  \
     !defined(MBEDTLS_RSA_C) || !defined(MBEDTLS_MD_CAN_SHA256) ||        \

--- a/programs/pkey/rsa_sign_pss.c
+++ b/programs/pkey/rsa_sign_pss.c
@@ -38,7 +38,6 @@ int main(void)
 
 #include "mbedtls/entropy.h"
 #include "mbedtls/ctr_drbg.h"
-#include "mbedtls/md.h"
 #include "mbedtls/rsa.h"
 #include "mbedtls/pk.h"
 

--- a/programs/pkey/rsa_verify.c
+++ b/programs/pkey/rsa_verify.c
@@ -20,7 +20,7 @@
 #include "mbedtls/build_info.h"
 
 #include "mbedtls/platform.h"
-// md.h is included this early since MD_CAN_XXX macros are defined there.
+/* md.h is included this early since MD_CAN_XXX macros are defined there. */
 #include "mbedtls/md.h"
 
 #if !defined(MBEDTLS_BIGNUM_C) || !defined(MBEDTLS_RSA_C) ||  \

--- a/programs/pkey/rsa_verify.c
+++ b/programs/pkey/rsa_verify.c
@@ -20,6 +20,7 @@
 #include "mbedtls/build_info.h"
 
 #include "mbedtls/platform.h"
+#include "mbedtls/md.h"
 
 #if !defined(MBEDTLS_BIGNUM_C) || !defined(MBEDTLS_RSA_C) ||  \
     !defined(MBEDTLS_MD_CAN_SHA256) || !defined(MBEDTLS_MD_C) || \

--- a/programs/pkey/rsa_verify.c
+++ b/programs/pkey/rsa_verify.c
@@ -35,7 +35,6 @@ int main(void)
 #else
 
 #include "mbedtls/rsa.h"
-#include "mbedtls/md.h"
 
 #include <stdio.h>
 #include <string.h>

--- a/programs/pkey/rsa_verify.c
+++ b/programs/pkey/rsa_verify.c
@@ -20,6 +20,7 @@
 #include "mbedtls/build_info.h"
 
 #include "mbedtls/platform.h"
+// md.h is included this early since MD_CAN_XXX macros are defined there.
 #include "mbedtls/md.h"
 
 #if !defined(MBEDTLS_BIGNUM_C) || !defined(MBEDTLS_RSA_C) ||  \

--- a/programs/pkey/rsa_verify_pss.c
+++ b/programs/pkey/rsa_verify_pss.c
@@ -20,6 +20,7 @@
 #include "mbedtls/build_info.h"
 
 #include "mbedtls/platform.h"
+// md.h is included this early since MD_CAN_XXX macros are defined there.
 #include "mbedtls/md.h"
 
 #if !defined(MBEDTLS_MD_C) || !defined(MBEDTLS_ENTROPY_C) ||  \

--- a/programs/pkey/rsa_verify_pss.c
+++ b/programs/pkey/rsa_verify_pss.c
@@ -39,7 +39,6 @@ int main(void)
 #include "mbedtls/md.h"
 #include "mbedtls/pem.h"
 #include "mbedtls/pk.h"
-#include "mbedtls/md.h"
 
 #include <stdio.h>
 #include <string.h>

--- a/programs/pkey/rsa_verify_pss.c
+++ b/programs/pkey/rsa_verify_pss.c
@@ -20,7 +20,7 @@
 #include "mbedtls/build_info.h"
 
 #include "mbedtls/platform.h"
-// md.h is included this early since MD_CAN_XXX macros are defined there.
+/* md.h is included this early since MD_CAN_XXX macros are defined there. */
 #include "mbedtls/md.h"
 
 #if !defined(MBEDTLS_MD_C) || !defined(MBEDTLS_ENTROPY_C) ||  \

--- a/programs/pkey/rsa_verify_pss.c
+++ b/programs/pkey/rsa_verify_pss.c
@@ -20,6 +20,7 @@
 #include "mbedtls/build_info.h"
 
 #include "mbedtls/platform.h"
+#include "mbedtls/md.h"
 
 #if !defined(MBEDTLS_MD_C) || !defined(MBEDTLS_ENTROPY_C) ||  \
     !defined(MBEDTLS_RSA_C) || !defined(MBEDTLS_MD_CAN_SHA256) ||        \

--- a/programs/psa/key_ladder_demo.c
+++ b/programs/psa/key_ladder_demo.c
@@ -58,6 +58,7 @@
 
 #include "mbedtls/platform.h" // for mbedtls_setbuf
 #include "mbedtls/platform_util.h" // for mbedtls_platform_zeroize
+#include "mbedtls/md.h"
 
 #include <psa/crypto.h>
 

--- a/programs/psa/key_ladder_demo.c
+++ b/programs/psa/key_ladder_demo.c
@@ -58,6 +58,7 @@
 
 #include "mbedtls/platform.h" // for mbedtls_setbuf
 #include "mbedtls/platform_util.h" // for mbedtls_platform_zeroize
+// md.h is included this early since MD_CAN_XXX macros are defined there.
 #include "mbedtls/md.h"
 
 #include <psa/crypto.h>

--- a/programs/psa/key_ladder_demo.c
+++ b/programs/psa/key_ladder_demo.c
@@ -58,8 +58,6 @@
 
 #include "mbedtls/platform.h" // for mbedtls_setbuf
 #include "mbedtls/platform_util.h" // for mbedtls_platform_zeroize
-// md.h is included this early since MD_CAN_XXX macros are defined there.
-#include "mbedtls/md.h"
 
 #include <psa/crypto.h>
 

--- a/programs/x509/cert_req.c
+++ b/programs/x509/cert_req.c
@@ -20,7 +20,7 @@
 #include "mbedtls/build_info.h"
 
 #include "mbedtls/platform.h"
-// md.h is included this early since MD_CAN_XXX macros are defined there.
+/* md.h is included this early since MD_CAN_XXX macros are defined there. */
 #include "mbedtls/md.h"
 
 #if !defined(MBEDTLS_X509_CSR_WRITE_C) || !defined(MBEDTLS_FS_IO) ||  \

--- a/programs/x509/cert_req.c
+++ b/programs/x509/cert_req.c
@@ -20,6 +20,7 @@
 #include "mbedtls/build_info.h"
 
 #include "mbedtls/platform.h"
+#include "mbedtls/md.h"
 
 #if !defined(MBEDTLS_X509_CSR_WRITE_C) || !defined(MBEDTLS_FS_IO) ||  \
     !defined(MBEDTLS_PK_PARSE_C) || !defined(MBEDTLS_MD_CAN_SHA256) || \

--- a/programs/x509/cert_req.c
+++ b/programs/x509/cert_req.c
@@ -20,6 +20,7 @@
 #include "mbedtls/build_info.h"
 
 #include "mbedtls/platform.h"
+// md.h is included this early since MD_CAN_XXX macros are defined there.
 #include "mbedtls/md.h"
 
 #if !defined(MBEDTLS_X509_CSR_WRITE_C) || !defined(MBEDTLS_FS_IO) ||  \

--- a/programs/x509/cert_write.c
+++ b/programs/x509/cert_write.c
@@ -20,6 +20,7 @@
 #include "mbedtls/build_info.h"
 
 #include "mbedtls/platform.h"
+// md.h is included this early since MD_CAN_XXX macros are defined there.
 #include "mbedtls/md.h"
 
 #if !defined(MBEDTLS_X509_CRT_WRITE_C) || \

--- a/programs/x509/cert_write.c
+++ b/programs/x509/cert_write.c
@@ -20,6 +20,7 @@
 #include "mbedtls/build_info.h"
 
 #include "mbedtls/platform.h"
+#include "mbedtls/md.h"
 
 #if !defined(MBEDTLS_X509_CRT_WRITE_C) || \
     !defined(MBEDTLS_X509_CRT_PARSE_C) || !defined(MBEDTLS_FS_IO) || \

--- a/programs/x509/cert_write.c
+++ b/programs/x509/cert_write.c
@@ -20,7 +20,7 @@
 #include "mbedtls/build_info.h"
 
 #include "mbedtls/platform.h"
-// md.h is included this early since MD_CAN_XXX macros are defined there.
+/* md.h is included this early since MD_CAN_XXX macros are defined there. */
 #include "mbedtls/md.h"
 
 #if !defined(MBEDTLS_X509_CRT_WRITE_C) || \

--- a/programs/x509/cert_write.c
+++ b/programs/x509/cert_write.c
@@ -42,7 +42,6 @@ int main(void)
 #include "mbedtls/oid.h"
 #include "mbedtls/entropy.h"
 #include "mbedtls/ctr_drbg.h"
-#include "mbedtls/md.h"
 #include "mbedtls/error.h"
 #include "test/helpers.h"
 


### PR DESCRIPTION
After https://github.com/Mbed-TLS/mbedtls/commit/93302422fd146a7520ba3cdac51523dc62cdbe71 there are some guards that render programs useless, since there's no md.h include to load the required symbols.

## Gatekeeper checklist

- [x] **changelog** provided
- [x] **backport** not required - not present in 2.28.
- [x] **tests** not provided - the fact that programs are not tested is a pre-existing test gap; closing that gap is largely beyond the scope of this PR. See #2698 for a starting point.