### PR TITLE
[Backport 2.28] Clarify LTS lifetime

### DIFF
--- a/BRANCHES.md
+++ b/BRANCHES.md
@@ -19,7 +19,7 @@ details.
 Every major version will become an LTS branch when the next major version is
 released. We may occasionally create LTS branches from other releases at our
 discretion.
-After a new LTS branch is created, it remains supported for at least 3 years.
+When a new LTS branch is created, it usually remains supported for three years.
 
 ## Backwards Compatibility for application code
 

--- a/BRANCHES.md
+++ b/BRANCHES.md
@@ -16,7 +16,9 @@ API compatibility in the `master` branch between major version changes. We
 also maintain ABI compatibility within LTS branches; see the next section for
 details.
 
-New LTS branches are usually created around the time of a new major version.
+Every major version will become an LTS branch when the next major version is
+released. We may occasionally create LTS branches from other releases at our
+discretion.
 After a new LTS branch is created, it remains supported for at least 3 years.
 
 ## Backwards Compatibility for application code

--- a/BRANCHES.md
+++ b/BRANCHES.md
@@ -16,6 +16,9 @@ API compatibility in the `master` branch between major version changes. We
 also maintain ABI compatibility within LTS branches; see the next section for
 details.
 
+New LTS branches are usually created around the time of a new major version.
+After a new LTS branch is created, it remains supported for at least 3 years.
+
 ## Backwards Compatibility for application code
 
 We maintain API compatibility in released versions of Mbed TLS. If you have


### PR DESCRIPTION
## Description

Backport of https://github.com/Mbed-TLS/mbedtls/pull/7383.

Users can get more value out of our LTS releases and plan transition between versions better if the documentation is more clear about the lifetime of LTS branches.

## Gatekeeper checklist

- [x] **changelog** not required
- [x] **backport** this is the backport
- [x] **tests** not required

