### PR TITLE
Workaround random `test_suite_platform` fail in time test

### DIFF
--- a/tests/suites/test_suite_platform.data
+++ b/tests/suites/test_suite_platform.data
@@ -4,9 +4,3 @@ time_get_milliseconds:
 
 Time: get seconds
 time_get_seconds:
-
-Time: delay milliseconds
-time_delay_milliseconds:1000
-
-Time: delay seconds
-time_delay_seconds:1

--- a/tests/suites/test_suite_platform.data
+++ b/tests/suites/test_suite_platform.data
@@ -4,3 +4,6 @@ time_get_milliseconds:
 
 Time: get seconds
 time_get_seconds:
+
+Time: delay milliseconds
+time_delay_milliseconds:1000

--- a/tests/suites/test_suite_platform.function
+++ b/tests/suites/test_suite_platform.function
@@ -86,8 +86,11 @@ void time_delay_seconds(int delay_secs)
     elapsed_secs = mbedtls_time(NULL) - current;
 
     /* Built-in mbedtls_time function returns the number of seconds since the
-     * Epoch. That is affected by discontinuous jumps and cause test fail.
-     * Workaround it with 1 seconds tollerance.
+     * Epoch. That is affected by discontinuous jumps. And `nanosleep` use
+     * CLOCK_MONOTONIC(monotonically-increasing time source), That will cause
+     * negative elapsed time difference.
+     *
+     * Workaround it with 1 second tolerance.
      */
     TEST_ASSERT(elapsed_secs >= delay_secs - 1);
     TEST_ASSERT(elapsed_secs < 4 + delay_secs);

--- a/tests/suites/test_suite_platform.function
+++ b/tests/suites/test_suite_platform.function
@@ -76,7 +76,8 @@ void time_delay_milliseconds(int delay_ms)
 /* BEGIN_CASE depends_on:MBEDTLS_HAVE_TIME */
 
 /*
- * WARNING: DONOT ENABLE THIS TEST. RESERVE IT HERE TO KEEP THE REASON.
+ * WARNING: DO NOT ENABLE THIS TEST. We keep the code here to document the
+ *          reason.
  *
  *          The test often failed on the CI. See #1517. CI failures cannot be
  *          completely avoided due to out-of-sync clock sources.
@@ -98,7 +99,7 @@ void time_delay_seconds(int delay_secs)
      * CLOCK_REALTIME should not affect `nanosleep()`.
      *
      * If discontinuous changes occur during `nanosleep()`, we will get
-     * `elapsed_secs < delay_secs` for backward and `elapsed_secs > delay_secs`
+     * `elapsed_secs < delay_secs` for backward or `elapsed_secs > delay_secs`
      * for forward.
      *
      * The following tolerance windows cannot be guaranteed.

--- a/tests/suites/test_suite_platform.function
+++ b/tests/suites/test_suite_platform.function
@@ -84,7 +84,8 @@ void time_delay_seconds(int delay_secs)
     sleep_ms(delay_secs * 1000);
 
     elapsed_secs = mbedtls_time(NULL) - current;
-    TEST_ASSERT(elapsed_secs >= delay_secs && elapsed_secs < 4 + delay_secs);
+    TEST_ASSERT(elapsed_secs >= delay_secs);
+    TEST_ASSERT(elapsed_secs < 4 + delay_secs);
     /* This goto is added to avoid warnings from the generated code. */
     goto exit;
 }

--- a/tests/suites/test_suite_platform.function
+++ b/tests/suites/test_suite_platform.function
@@ -10,13 +10,33 @@
 #if defined(MBEDTLS_HAVE_TIME)
 #include "mbedtls/platform_time.h"
 
+#ifdef WIN32
+#include <windows.h>
+#elif _POSIX_C_SOURCE >= 199309L
+#include <time.h>
+#else
+#include <unistd.h>
+#endif
+void sleep_ms(int milliseconds)
+{
+#ifdef WIN32
+    Sleep(milliseconds);
+#elif _POSIX_C_SOURCE >= 199309L
+    struct timespec ts;
+    ts.tv_sec = milliseconds / 1000;
+    ts.tv_nsec = (milliseconds % 1000) * 1000000;
+    nanosleep(&ts, NULL);
+#else
+    usleep(milliseconds * 1000);
+#endif
+}
+#endif
+
 /* END_HEADER */
 
 /* BEGIN_DEPENDENCIES */
 
 /* END_DEPENDENCIES */
-
-
 
 /* BEGIN_CASE depends_on:MBEDTLS_HAVE_TIME */
 void time_get_milliseconds()
@@ -33,6 +53,51 @@ void time_get_seconds()
 {
     mbedtls_time_t current = mbedtls_time(NULL);
     (void) current;
+    /* This goto is added to avoid warnings from the generated code. */
+    goto exit;
+}
+/* END_CASE */
+
+/* BEGIN_CASE depends_on:MBEDTLS_HAVE_TIME */
+void time_delay_milliseconds(int delay_ms)
+{
+    mbedtls_ms_time_t current = mbedtls_ms_time();
+    mbedtls_ms_time_t elapsed_ms;
+
+    sleep_ms(delay_ms);
+
+    elapsed_ms = mbedtls_ms_time() - current;
+    TEST_ASSERT(elapsed_ms >= delay_ms && elapsed_ms < 4000 + delay_ms);
+    /* This goto is added to avoid warnings from the generated code. */
+    goto exit;
+}
+/* END_CASE */
+
+/* BEGIN_CASE depends_on:MBEDTLS_HAVE_TIME */
+void time_delay_seconds(int delay_secs)
+{
+    mbedtls_time_t current = mbedtls_time(NULL);
+    mbedtls_time_t elapsed_secs;
+
+    sleep_ms(delay_secs * 1000);
+
+    elapsed_secs = mbedtls_time(NULL) - current;
+
+    /*
+     * `mbedtls_time` was defined as c99 function `time`, it uses
+     * CLOCK_REALTIME and returns the number of seconds since the Epoch. And
+     * `nanosleep` uses CLOCK_MONOTONIC. The time sources are out of sync.
+     *
+     * If CLOCK_MONOTONIC is faster than CLOCK_REALTIME and `nanosleep` exits at
+     * the end of a second, `elapsed_secs` will be less than `delay_secs`.
+     *
+     * Workaround it with 1 second tolerance.
+     */
+    TEST_ASSERT(elapsed_secs >= delay_secs - 1);
+    /* If CLOCK_MONOTONIC is slower than CLOCK_REALTIME or nanosleep does not
+     * exit on time.
+     */
+    TEST_ASSERT(elapsed_secs < 4 + delay_secs);
     /* This goto is added to avoid warnings from the generated code. */
     goto exit;
 }

--- a/tests/suites/test_suite_platform.function
+++ b/tests/suites/test_suite_platform.function
@@ -74,6 +74,13 @@ void time_delay_milliseconds(int delay_ms)
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_HAVE_TIME */
+
+/*
+ * WARNING: DONOT ENABLE THIS TEST. RESERVE IT HERE TO KEEP THE REASON.
+ *
+ *          The test often failed on the CI. See #1517. CI failures cannot be
+ *          completely avoided due to out-of-sync clock sources.
+ */
 void time_delay_seconds(int delay_secs)
 {
     mbedtls_time_t current = mbedtls_time(NULL);

--- a/tests/suites/test_suite_platform.function
+++ b/tests/suites/test_suite_platform.function
@@ -10,28 +10,6 @@
 #if defined(MBEDTLS_HAVE_TIME)
 #include "mbedtls/platform_time.h"
 
-#ifdef WIN32
-#include <windows.h>
-#elif _POSIX_C_SOURCE >= 199309L
-#include <time.h>
-#else
-#include <unistd.h>
-#endif
-void sleep_ms(int milliseconds)
-{
-#ifdef WIN32
-    Sleep(milliseconds);
-#elif _POSIX_C_SOURCE >= 199309L
-    struct timespec ts;
-    ts.tv_sec = milliseconds / 1000;
-    ts.tv_nsec = (milliseconds % 1000) * 1000000;
-    nanosleep(&ts, NULL);
-#else
-    usleep(milliseconds * 1000);
-#endif
-}
-#endif
-
 /* END_HEADER */
 
 /* BEGIN_DEPENDENCIES */
@@ -55,45 +33,6 @@ void time_get_seconds()
 {
     mbedtls_time_t current = mbedtls_time(NULL);
     (void) current;
-    /* This goto is added to avoid warnings from the generated code. */
-    goto exit;
-}
-/* END_CASE */
-
-/* BEGIN_CASE depends_on:MBEDTLS_HAVE_TIME */
-void time_delay_milliseconds(int delay_ms)
-{
-    mbedtls_ms_time_t current = mbedtls_ms_time();
-    mbedtls_ms_time_t elapsed_ms;
-
-    sleep_ms(delay_ms);
-
-    elapsed_ms = mbedtls_ms_time() - current;
-    TEST_ASSERT(elapsed_ms >= delay_ms && elapsed_ms < 4000 + delay_ms);
-    /* This goto is added to avoid warnings from the generated code. */
-    goto exit;
-}
-/* END_CASE */
-
-/* BEGIN_CASE depends_on:MBEDTLS_HAVE_TIME */
-void time_delay_seconds(int delay_secs)
-{
-    mbedtls_time_t current = mbedtls_time(NULL);
-    mbedtls_time_t elapsed_secs;
-
-    sleep_ms(delay_secs * 1000);
-
-    elapsed_secs = mbedtls_time(NULL) - current;
-
-    /* Built-in mbedtls_time function returns the number of seconds since the
-     * Epoch. That is affected by discontinuous jumps. And `nanosleep` use
-     * CLOCK_MONOTONIC(monotonically-increasing time source), That will cause
-     * negative elapsed time difference.
-     *
-     * Workaround it with 1 second tolerance.
-     */
-    TEST_ASSERT(elapsed_secs >= delay_secs - 1);
-    TEST_ASSERT(elapsed_secs < 4 + delay_secs);
     /* This goto is added to avoid warnings from the generated code. */
     goto exit;
 }

--- a/tests/suites/test_suite_platform.function
+++ b/tests/suites/test_suite_platform.function
@@ -84,7 +84,12 @@ void time_delay_seconds(int delay_secs)
     sleep_ms(delay_secs * 1000);
 
     elapsed_secs = mbedtls_time(NULL) - current;
-    TEST_ASSERT(elapsed_secs >= delay_secs);
+
+    /* Built-in mbedtls_time function returns the number of seconds since the
+     * Epoch. That is affected by discontinuous jumps and cause test fail.
+     * Workaround it with 1 seconds tollerance.
+     */
+    TEST_ASSERT(elapsed_secs >= delay_secs - 1);
     TEST_ASSERT(elapsed_secs < 4 + delay_secs);
     /* This goto is added to avoid warnings from the generated code. */
     goto exit;

--- a/tests/suites/test_suite_platform.function
+++ b/tests/suites/test_suite_platform.function
@@ -91,20 +91,21 @@ void time_delay_seconds(int delay_secs)
     elapsed_secs = mbedtls_time(NULL) - current;
 
     /*
-     * `mbedtls_time` was defined as c99 function `time`, it uses
-     * CLOCK_REALTIME and returns the number of seconds since the Epoch. And
-     * `nanosleep` uses CLOCK_MONOTONIC. The time sources are out of sync.
+     * `mbedtls_time()` was defined as c99 function `time()`, returns the number
+     * of seconds since the Epoch. And it is affected by discontinuous changes
+     * from automatic drift adjustment or time setting system call. The POSIX.1
+     * specification for clock_settime says that discontinuous changes in
+     * CLOCK_REALTIME should not affect `nanosleep()`.
      *
-     * If CLOCK_MONOTONIC is faster than CLOCK_REALTIME and `nanosleep` exits at
-     * the end of a second, `elapsed_secs` will be less than `delay_secs`.
+     * If discontinuous changes occur during `nanosleep()`, we will get
+     * `elapsed_secs < delay_secs` for backward and `elapsed_secs > delay_secs`
+     * for forward.
      *
-     * Workaround it with 1 second tolerance.
+     * The following tolerance windows cannot be guaranteed.
+     * PLEASE DO NOT ENABLE IT IN CI TEST.
      */
-    TEST_ASSERT(elapsed_secs >= delay_secs - 1);
-    /* If CLOCK_MONOTONIC is slower than CLOCK_REALTIME or nanosleep does not
-     * exit on time.
-     */
-    TEST_ASSERT(elapsed_secs < 4 + delay_secs);
+    TEST_ASSERT(elapsed_secs - delay_secs >= -1 &&
+                elapsed_secs - delay_secs <   4);
     /* This goto is added to avoid warnings from the generated code. */
     goto exit;
 }


### PR DESCRIPTION
## Description

We got random `test_suite_platform` fails in CI tests
The CI reports with this PR
```
Time: delay seconds ............................................... FAILED
  elapsed_secs >= delay_secs
  at line 87, /var/lib/build/tests/suites/test_suite_platform.function
```

I think it is due to `time(time_t*)` returns Epoch time which is discontinuous. 



## Gatekeeper checklist

- [ ] **changelog** provided, or not required
- [ ] **backport** done, or not required
- [ ] **tests** provided, or not required



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

