### PR TITLE
Code Size: Add the TFM Medium Profile config files and the option to track code size changes

### DIFF
--- a/configs/crypto_config_profile_medium.h
+++ b/configs/crypto_config_profile_medium.h
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2018-2022, Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+/**
+ * \file psa/crypto_config.h
+ * \brief PSA crypto configuration options (set of defines)
+ *
+ */
+#if defined(MBEDTLS_PSA_CRYPTO_CONFIG)
+/**
+ * When #MBEDTLS_PSA_CRYPTO_CONFIG is enabled in mbedtls_config.h,
+ * this file determines which cryptographic mechanisms are enabled
+ * through the PSA Cryptography API (\c psa_xxx() functions).
+ *
+ * To enable a cryptographic mechanism, uncomment the definition of
+ * the corresponding \c PSA_WANT_xxx preprocessor symbol.
+ * To disable a cryptographic mechanism, comment out the definition of
+ * the corresponding \c PSA_WANT_xxx preprocessor symbol.
+ * The names of cryptographic mechanisms correspond to values
+ * defined in psa/crypto_values.h, with the prefix \c PSA_WANT_ instead
+ * of \c PSA_.
+ *
+ * Note that many cryptographic mechanisms involve two symbols: one for
+ * the key type (\c PSA_WANT_KEY_TYPE_xxx) and one for the algorithm
+ * (\c PSA_WANT_ALG_xxx). Mechanisms with additional parameters may involve
+ * additional symbols.
+ */
+#else
+/**
+ * When \c MBEDTLS_PSA_CRYPTO_CONFIG is disabled in mbedtls_config.h,
+ * this file is not used, and cryptographic mechanisms are supported
+ * through the PSA API if and only if they are supported through the
+ * mbedtls_xxx API.
+ */
+#endif
+
+#ifndef PROFILE_M_PSA_CRYPTO_CONFIG_H
+#define PROFILE_M_PSA_CRYPTO_CONFIG_H
+
+/*
+ * CBC-MAC is not yet supported via the PSA API in Mbed TLS.
+ */
+//#define PSA_WANT_ALG_CBC_MAC                    1
+//#define PSA_WANT_ALG_CBC_NO_PADDING             1
+//#define PSA_WANT_ALG_CBC_PKCS7                  1
+#define PSA_WANT_ALG_CCM                        1
+//#define PSA_WANT_ALG_CMAC                       1
+//#define PSA_WANT_ALG_CFB                        1
+//#define PSA_WANT_ALG_CHACHA20_POLY1305          1
+//#define PSA_WANT_ALG_CTR                        1
+#define PSA_WANT_ALG_DETERMINISTIC_ECDSA        1
+//#define PSA_WANT_ALG_ECB_NO_PADDING             1
+#define PSA_WANT_ALG_ECDH                       1
+#define PSA_WANT_ALG_ECDSA                      1
+//#define PSA_WANT_ALG_GCM                        1
+#define PSA_WANT_ALG_HKDF                       1
+#define PSA_WANT_ALG_HMAC                       1
+//#define PSA_WANT_ALG_MD5                        1
+//#define PSA_WANT_ALG_OFB                        1
+/* PBKDF2-HMAC is not yet supported via the PSA API in Mbed TLS.
+ * Note: when adding support, also adjust include/mbedtls/config_psa.h */
+//#define PSA_WANT_ALG_PBKDF2_HMAC                1
+//#define PSA_WANT_ALG_RIPEMD160                  1
+//#define PSA_WANT_ALG_RSA_OAEP                   1
+//#define PSA_WANT_ALG_RSA_PKCS1V15_CRYPT         1
+//#define PSA_WANT_ALG_RSA_PKCS1V15_SIGN          1
+//#define PSA_WANT_ALG_RSA_PSS                    1
+//#define PSA_WANT_ALG_SHA_1                      1
+#define PSA_WANT_ALG_SHA_224                    1
+#define PSA_WANT_ALG_SHA_256                    1
+//#define PSA_WANT_ALG_SHA_384                    1
+//#define PSA_WANT_ALG_SHA_512                    1
+//#define PSA_WANT_ALG_STREAM_CIPHER              1
+#define PSA_WANT_ALG_TLS12_PRF                  1
+#define PSA_WANT_ALG_TLS12_PSK_TO_MS            1
+/* PBKDF2-HMAC is not yet supported via the PSA API in Mbed TLS.
+ * Note: when adding support, also adjust include/mbedtls/config_psa.h */
+//#define PSA_WANT_ALG_XTS                        1
+
+//#define PSA_WANT_ECC_BRAINPOOL_P_R1_256         1
+//#define PSA_WANT_ECC_BRAINPOOL_P_R1_384         1
+//#define PSA_WANT_ECC_BRAINPOOL_P_R1_512         1
+//#define PSA_WANT_ECC_MONTGOMERY_255             1
+//#define PSA_WANT_ECC_MONTGOMERY_448             1
+//#define PSA_WANT_ECC_SECP_K1_192                1
+/*
+ * SECP224K1 is buggy via the PSA API in Mbed TLS
+ * (https://github.com/Mbed-TLS/mbedtls/issues/3541). Thus, do not enable it by
+ * default.
+ */
+//#define PSA_WANT_ECC_SECP_K1_224                1
+//#define PSA_WANT_ECC_SECP_K1_256                1
+//#define PSA_WANT_ECC_SECP_R1_192                1
+//#define PSA_WANT_ECC_SECP_R1_224                1
+#define PSA_WANT_ECC_SECP_R1_256                1
+//#define PSA_WANT_ECC_SECP_R1_384                1
+//#define PSA_WANT_ECC_SECP_R1_521                1
+
+#define PSA_WANT_KEY_TYPE_DERIVE                1
+#define PSA_WANT_KEY_TYPE_HMAC                  1
+#define PSA_WANT_KEY_TYPE_AES                   1
+//#define PSA_WANT_KEY_TYPE_ARIA                  1
+//#define PSA_WANT_KEY_TYPE_CAMELLIA              1
+//#define PSA_WANT_KEY_TYPE_CHACHA20              1
+//#define PSA_WANT_KEY_TYPE_DES                   1
+#define PSA_WANT_KEY_TYPE_ECC_KEY_PAIR          1
+#define PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY        1
+#define PSA_WANT_KEY_TYPE_RAW_DATA              1
+//#define PSA_WANT_KEY_TYPE_RSA_KEY_PAIR          1
+//#define PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY        1
+
+#endif /* PROFILE_M_PSA_CRYPTO_CONFIG_H */

--- a/configs/tfm_mbedcrypto_config_profile_medium.h
+++ b/configs/tfm_mbedcrypto_config_profile_medium.h
@@ -1,0 +1,634 @@
+/**
+ * \file config.h
+ *
+ * \brief Configuration options (set of defines)
+ *
+ *  This set of compile-time options may be used to enable
+ *  or disable features selectively, and reduce the global
+ *  memory footprint.
+ */
+/*
+ *  Copyright (C) 2006-2022, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
+ */
+
+#ifndef PROFILE_M_MBEDTLS_CONFIG_H
+#define PROFILE_M_MBEDTLS_CONFIG_H
+
+#include "config_tfm.h"
+
+#if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_DEPRECATE)
+#define _CRT_SECURE_NO_DEPRECATE 1
+#endif
+
+/**
+ * \name SECTION: System support
+ *
+ * This section sets system specific settings.
+ * \{
+ */
+
+/**
+ * \def MBEDTLS_HAVE_ASM
+ *
+ * The compiler has support for asm().
+ *
+ * Requires support for asm() in compiler.
+ *
+ * Used in:
+ *      library/aria.c
+ *      library/timing.c
+ *      include/mbedtls/bn_mul.h
+ *
+ * Required by:
+ *      MBEDTLS_AESNI_C
+ *      MBEDTLS_PADLOCK_C
+ *
+ * Comment to disable the use of assembly code.
+ */
+#define MBEDTLS_HAVE_ASM
+
+/**
+ * \def MBEDTLS_PLATFORM_MEMORY
+ *
+ * Enable the memory allocation layer.
+ *
+ * By default mbed TLS uses the system-provided calloc() and free().
+ * This allows different allocators (self-implemented or provided) to be
+ * provided to the platform abstraction layer.
+ *
+ * Enabling MBEDTLS_PLATFORM_MEMORY without the
+ * MBEDTLS_PLATFORM_{FREE,CALLOC}_MACROs will provide
+ * "mbedtls_platform_set_calloc_free()" allowing you to set an alternative calloc() and
+ * free() function pointer at runtime.
+ *
+ * Enabling MBEDTLS_PLATFORM_MEMORY and specifying
+ * MBEDTLS_PLATFORM_{CALLOC,FREE}_MACROs will allow you to specify the
+ * alternate function at compile time.
+ *
+ * Requires: MBEDTLS_PLATFORM_C
+ *
+ * Enable this layer to allow use of alternative memory allocators.
+ */
+#define MBEDTLS_PLATFORM_MEMORY
+
+/* \} name SECTION: System support */
+
+/**
+ * \name SECTION: mbed TLS feature support
+ *
+ * This section sets support for features that are or are not needed
+ * within the modules that are enabled.
+ * \{
+ */
+
+/**
+ * \def MBEDTLS_MD2_PROCESS_ALT
+ *
+ * MBEDTLS__FUNCTION_NAME__ALT: Uncomment a macro to let mbed TLS use you
+ * alternate core implementation of symmetric crypto or hash function. Keep in
+ * mind that function prototypes should remain the same.
+ *
+ * This replaces only one function. The header file from mbed TLS is still
+ * used, in contrast to the MBEDTLS__MODULE_NAME__ALT flags.
+ *
+ * Example: In case you uncomment MBEDTLS_SHA256_PROCESS_ALT, mbed TLS will
+ * no longer provide the mbedtls_sha1_process() function, but it will still provide
+ * the other function (using your mbedtls_sha1_process() function) and the definition
+ * of mbedtls_sha1_context, so your implementation of mbedtls_sha1_process must be compatible
+ * with this definition.
+ *
+ * \note Because of a signature change, the core AES encryption and decryption routines are
+ *       currently named mbedtls_aes_internal_encrypt and mbedtls_aes_internal_decrypt,
+ *       respectively. When setting up alternative implementations, these functions should
+ *       be overridden, but the wrapper functions mbedtls_aes_decrypt and mbedtls_aes_encrypt
+ *       must stay untouched.
+ *
+ * \note If you use the AES_xxx_ALT macros, then is is recommended to also set
+ *       MBEDTLS_AES_ROM_TABLES in order to help the linker garbage-collect the AES
+ *       tables.
+ *
+ * Uncomment a macro to enable alternate implementation of the corresponding
+ * function.
+ *
+ * \warning   MD2, MD4, MD5, DES and SHA-1 are considered weak and their use
+ *            constitutes a security risk. If possible, we recommend avoiding
+ *            dependencies on them, and considering stronger message digests
+ *            and ciphers instead.
+ *
+ */
+#define MBEDTLS_AES_SETKEY_DEC_ALT
+#define MBEDTLS_AES_DECRYPT_ALT
+
+/**
+ * \def MBEDTLS_AES_ROM_TABLES
+ *
+ * Use precomputed AES tables stored in ROM.
+ *
+ * Uncomment this macro to use precomputed AES tables stored in ROM.
+ * Comment this macro to generate AES tables in RAM at runtime.
+ *
+ * Tradeoff: Using precomputed ROM tables reduces RAM usage by ~8kb
+ * (or ~2kb if \c MBEDTLS_AES_FEWER_TABLES is used) and reduces the
+ * initialization time before the first AES operation can be performed.
+ * It comes at the cost of additional ~8kb ROM use (resp. ~2kb if \c
+ * MBEDTLS_AES_FEWER_TABLES below is used), and potentially degraded
+ * performance if ROM access is slower than RAM access.
+ *
+ * This option is independent of \c MBEDTLS_AES_FEWER_TABLES.
+ *
+ */
+#define MBEDTLS_AES_ROM_TABLES
+
+/**
+ * \def MBEDTLS_AES_FEWER_TABLES
+ *
+ * Use less ROM/RAM for AES tables.
+ *
+ * Uncommenting this macro omits 75% of the AES tables from
+ * ROM / RAM (depending on the value of \c MBEDTLS_AES_ROM_TABLES)
+ * by computing their values on the fly during operations
+ * (the tables are entry-wise rotations of one another).
+ *
+ * Tradeoff: Uncommenting this reduces the RAM / ROM footprint
+ * by ~6kb but at the cost of more arithmetic operations during
+ * runtime. Specifically, one has to compare 4 accesses within
+ * different tables to 4 accesses with additional arithmetic
+ * operations within the same table. The performance gain/loss
+ * depends on the system and memory details.
+ *
+ * This option is independent of \c MBEDTLS_AES_ROM_TABLES.
+ *
+ */
+#define MBEDTLS_AES_FEWER_TABLES
+
+/**
+ * \def MBEDTLS_ECP_NIST_OPTIM
+ *
+ * Enable specific 'modulo p' routines for each NIST prime.
+ * Depending on the prime and architecture, makes operations 4 to 8 times
+ * faster on the corresponding curve.
+ *
+ * Comment this macro to disable NIST curves optimisation.
+ */
+#define MBEDTLS_ECP_NIST_OPTIM
+
+/**
+ * \def MBEDTLS_ERROR_STRERROR_DUMMY
+ *
+ * Enable a dummy error function to make use of mbedtls_strerror() in
+ * third party libraries easier when MBEDTLS_ERROR_C is disabled
+ * (no effect when MBEDTLS_ERROR_C is enabled).
+ *
+ * You can safely disable this if MBEDTLS_ERROR_C is enabled, or if you're
+ * not using mbedtls_strerror() or error_strerror() in your application.
+ *
+ * Disable if you run into name conflicts and want to really remove the
+ * mbedtls_strerror()
+ */
+#define MBEDTLS_ERROR_STRERROR_DUMMY
+
+/**
+ * \def MBEDTLS_NO_PLATFORM_ENTROPY
+ *
+ * Do not use built-in platform entropy functions.
+ * This is useful if your platform does not support
+ * standards like the /dev/urandom or Windows CryptoAPI.
+ *
+ * Uncomment this macro to disable the built-in platform entropy functions.
+ */
+#define MBEDTLS_NO_PLATFORM_ENTROPY
+
+/**
+ * \def MBEDTLS_ENTROPY_NV_SEED
+ *
+ * Enable the non-volatile (NV) seed file-based entropy source.
+ * (Also enables the NV seed read/write functions in the platform layer)
+ *
+ * This is crucial (if not required) on systems that do not have a
+ * cryptographic entropy source (in hardware or kernel) available.
+ *
+ * Requires: MBEDTLS_ENTROPY_C, MBEDTLS_PLATFORM_C
+ *
+ * \note The read/write functions that are used by the entropy source are
+ *       determined in the platform layer, and can be modified at runtime and/or
+ *       compile-time depending on the flags (MBEDTLS_PLATFORM_NV_SEED_*) used.
+ *
+ * \note If you use the default implementation functions that read a seedfile
+ *       with regular fopen(), please make sure you make a seedfile with the
+ *       proper name (defined in MBEDTLS_PLATFORM_STD_NV_SEED_FILE) and at
+ *       least MBEDTLS_ENTROPY_BLOCK_SIZE bytes in size that can be read from
+ *       and written to or you will get an entropy source error! The default
+ *       implementation will only use the first MBEDTLS_ENTROPY_BLOCK_SIZE
+ *       bytes from the file.
+ *
+ * \note The entropy collector will write to the seed file before entropy is
+ *       given to an external source, to update it.
+ */
+#define MBEDTLS_ENTROPY_NV_SEED
+
+/* MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER
+ *
+ * Enable key identifiers that encode a key owner identifier.
+ *
+ * This is only meaningful when building the library as part of a
+ * multi-client service. When you activate this option, you must provide an
+ * implementation of the type mbedtls_key_owner_id_t and a translation from
+ * mbedtls_svc_key_id_t to file name in all the storage backends that you
+ * you wish to support.
+ *
+ * Note that this option is meant for internal use only and may be removed
+ * without notice.
+ */
+#define MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER
+
+/**
+ * \def MBEDTLS_PSA_CRYPTO_SPM
+ *
+ * When MBEDTLS_PSA_CRYPTO_SPM is defined, the code is built for SPM (Secure
+ * Partition Manager) integration which separates the code into two parts: a
+ * NSPE (Non-Secure Process Environment) and an SPE (Secure Process
+ * Environment).
+ *
+ * Module:  library/psa_crypto.c
+ * Requires: MBEDTLS_PSA_CRYPTO_C
+ *
+ */
+#define MBEDTLS_PSA_CRYPTO_SPM
+
+/**
+ * \def MBEDTLS_SHA256_SMALLER
+ *
+ * Enable an implementation of SHA-256 that has lower ROM footprint but also
+ * lower performance.
+ *
+ * The default implementation is meant to be a reasonnable compromise between
+ * performance and size. This version optimizes more aggressively for size at
+ * the expense of performance. Eg on Cortex-M4 it reduces the size of
+ * mbedtls_sha256_process() from ~2KB to ~0.5KB for a performance hit of about
+ * 30%.
+ *
+ * Uncomment to enable the smaller implementation of SHA256.
+ */
+#define MBEDTLS_SHA256_SMALLER
+
+/**
+ * \def MBEDTLS_PSA_CRYPTO_CONFIG
+ *
+ * This setting allows support for cryptographic mechanisms through the PSA
+ * API to be configured separately from support through the mbedtls API.
+ *
+ * When this option is disabled, the PSA API exposes the cryptographic
+ * mechanisms that can be implemented on top of the `mbedtls_xxx` API
+ * configured with `MBEDTLS_XXX` symbols.
+ *
+ * When this option is enabled, the PSA API exposes the cryptographic
+ * mechanisms requested by the `PSA_WANT_XXX` symbols defined in
+ * include/psa/crypto_config.h. The corresponding `MBEDTLS_XXX` settings are
+ * automatically enabled if required (i.e. if no PSA driver provides the
+ * mechanism). You may still freely enable additional `MBEDTLS_XXX` symbols
+ * in mbedtls_config.h.
+ *
+ * If the symbol #MBEDTLS_PSA_CRYPTO_CONFIG_FILE is defined, it specifies
+ * an alternative header to include instead of include/psa/crypto_config.h.
+ *
+ * This feature is still experimental and is not ready for production since
+ * it is not completed.
+ */
+#define MBEDTLS_PSA_CRYPTO_CONFIG
+
+/* \} name SECTION: mbed TLS feature support */
+
+/**
+ * \name SECTION: mbed TLS modules
+ *
+ * This section enables or disables entire modules in mbed TLS
+ * \{
+ */
+
+/**
+ * \def MBEDTLS_AES_C
+ *
+ * Enable the AES block cipher.
+ *
+ * Module:  library/aes.c
+ * Caller:  library/cipher.c
+ *          library/pem.c
+ *          library/ctr_drbg.c
+ *
+ * This module is required to support the TLS ciphersuites that use the AES
+ * cipher.
+ *
+ * PEM_PARSE uses AES for decrypting encrypted keys.
+ */
+#define MBEDTLS_AES_C
+
+/**
+ * \def MBEDTLS_CIPHER_C
+ *
+ * Enable the generic cipher layer.
+ *
+ * Module:  library/cipher.c
+ *
+ * Uncomment to enable generic cipher wrappers.
+ */
+#define MBEDTLS_CIPHER_C
+
+/**
+ * \def MBEDTLS_CTR_DRBG_C
+ *
+ * Enable the CTR_DRBG AES-based random generator.
+ * The CTR_DRBG generator uses AES-256 by default.
+ * To use AES-128 instead, enable MBEDTLS_CTR_DRBG_USE_128_BIT_KEY below.
+ *
+ * Module:  library/ctr_drbg.c
+ * Caller:
+ *
+ * Requires: MBEDTLS_AES_C
+ *
+ * This module provides the CTR_DRBG AES random number generator.
+ */
+#define MBEDTLS_CTR_DRBG_C
+
+/**
+ * \def MBEDTLS_ENTROPY_C
+ *
+ * Enable the platform-specific entropy code.
+ *
+ * Module:  library/entropy.c
+ * Caller:
+ *
+ * Requires: MBEDTLS_SHA512_C or MBEDTLS_SHA256_C
+ *
+ * This module provides a generic entropy pool
+ */
+#define MBEDTLS_ENTROPY_C
+
+/**
+ * \def MBEDTLS_ERROR_C
+ *
+ * Enable error code to error string conversion.
+ *
+ * Module:  library/error.c
+ * Caller:
+ *
+ * This module enables mbedtls_strerror().
+ */
+#define MBEDTLS_ERROR_C
+
+/**
+ * \def MBEDTLS_HKDF_C
+ *
+ * Enable the HKDF algorithm (RFC 5869).
+ *
+ * Module:  library/hkdf.c
+ * Caller:
+ *
+ * Requires: MBEDTLS_MD_C
+ *
+ * This module adds support for the Hashed Message Authentication Code
+ * (HMAC)-based key derivation function (HKDF).
+ */
+#define MBEDTLS_HKDF_C /* Used for HUK deriviation */
+
+/**
+ * \def MBEDTLS_MEMORY_BUFFER_ALLOC_C
+ *
+ * Enable the buffer allocator implementation that makes use of a (stack)
+ * based buffer to 'allocate' dynamic memory. (replaces calloc() and free()
+ * calls)
+ *
+ * Module:  library/memory_buffer_alloc.c
+ *
+ * Requires: MBEDTLS_PLATFORM_C
+ *           MBEDTLS_PLATFORM_MEMORY (to use it within mbed TLS)
+ *
+ * Enable this module to enable the buffer memory allocator.
+ */
+#define MBEDTLS_MEMORY_BUFFER_ALLOC_C
+
+/**
+ * \def MBEDTLS_PK_C
+ *
+ * Enable the generic public (asymetric) key layer.
+ *
+ * Module:  library/pk.c
+ *
+ * Requires: MBEDTLS_RSA_C or MBEDTLS_ECP_C
+ *
+ * Uncomment to enable generic public key wrappers.
+ */
+#define MBEDTLS_PK_C
+
+/**
+ * \def MBEDTLS_PK_PARSE_C
+ *
+ * Enable the generic public (asymetric) key parser.
+ *
+ * Module:  library/pkparse.c
+ *
+ * Requires: MBEDTLS_PK_C
+ *
+ * Uncomment to enable generic public key parse functions.
+ */
+#define MBEDTLS_PK_PARSE_C
+
+/**
+ * \def MBEDTLS_PK_WRITE_C
+ *
+ * Enable the generic public (asymetric) key writer.
+ *
+ * Module:  library/pkwrite.c
+ *
+ * Requires: MBEDTLS_PK_C
+ *
+ * Uncomment to enable generic public key write functions.
+ */
+#define MBEDTLS_PK_WRITE_C
+
+/**
+ * \def MBEDTLS_PLATFORM_C
+ *
+ * Enable the platform abstraction layer that allows you to re-assign
+ * functions like calloc(), free(), snprintf(), printf(), fprintf(), exit().
+ *
+ * Enabling MBEDTLS_PLATFORM_C enables to use of MBEDTLS_PLATFORM_XXX_ALT
+ * or MBEDTLS_PLATFORM_XXX_MACRO directives, allowing the functions mentioned
+ * above to be specified at runtime or compile time respectively.
+ *
+ * \note This abstraction layer must be enabled on Windows (including MSYS2)
+ * as other module rely on it for a fixed snprintf implementation.
+ *
+ * Module:  library/platform.c
+ * Caller:  Most other .c files
+ *
+ * This module enables abstraction of common (libc) functions.
+ */
+#define MBEDTLS_PLATFORM_C
+
+#define MBEDTLS_PLATFORM_NO_STD_FUNCTIONS
+#define MBEDTLS_PLATFORM_STD_MEM_HDR   <stdlib.h>
+
+#include <stdio.h>
+
+#define MBEDTLS_PLATFORM_SNPRINTF_MACRO      snprintf
+#define MBEDTLS_PLATFORM_PRINTF_ALT
+#define MBEDTLS_PLATFORM_STD_EXIT_SUCCESS  EXIT_SUCCESS
+#define MBEDTLS_PLATFORM_STD_EXIT_FAILURE  EXIT_FAILURE
+
+/**
+ * \def MBEDTLS_PSA_CRYPTO_C
+ *
+ * Enable the Platform Security Architecture cryptography API.
+ *
+ * Module:  library/psa_crypto.c
+ *
+ * Requires: MBEDTLS_CTR_DRBG_C, MBEDTLS_ENTROPY_C
+ *
+ */
+#define MBEDTLS_PSA_CRYPTO_C
+
+/**
+ * \def MBEDTLS_PSA_CRYPTO_STORAGE_C
+ *
+ * Enable the Platform Security Architecture persistent key storage.
+ *
+ * Module:  library/psa_crypto_storage.c
+ *
+ * Requires: MBEDTLS_PSA_CRYPTO_C,
+ *           either MBEDTLS_PSA_ITS_FILE_C or a native implementation of
+ *           the PSA ITS interface
+ */
+#define MBEDTLS_PSA_CRYPTO_STORAGE_C
+
+/* \} name SECTION: mbed TLS modules */
+
+/**
+ * \name SECTION: General configuration options
+ *
+ * This section contains Mbed TLS build settings that are not associated
+ * with a particular module.
+ *
+ * \{
+ */
+
+/**
+ * \def MBEDTLS_CONFIG_FILE
+ *
+ * If defined, this is a header which will be included instead of
+ * `"mbedtls/mbedtls_config.h"`.
+ * This header file specifies the compile-time configuration of Mbed TLS.
+ * Unlike other configuration options, this one must be defined on the
+ * compiler command line: a definition in `mbedtls_config.h` would have
+ * no effect.
+ *
+ * This macro is expanded after an <tt>\#include</tt> directive. This is a popular but
+ * non-standard feature of the C language, so this feature is only available
+ * with compilers that perform macro expansion on an <tt>\#include</tt> line.
+ *
+ * The value of this symbol is typically a path in double quotes, either
+ * absolute or relative to a directory on the include search path.
+ */
+//#define MBEDTLS_CONFIG_FILE "mbedtls/mbedtls_config.h"
+
+/**
+ * \def MBEDTLS_USER_CONFIG_FILE
+ *
+ * If defined, this is a header which will be included after
+ * `"mbedtls/mbedtls_config.h"` or #MBEDTLS_CONFIG_FILE.
+ * This allows you to modify the default configuration, including the ability
+ * to undefine options that are enabled by default.
+ *
+ * This macro is expanded after an <tt>\#include</tt> directive. This is a popular but
+ * non-standard feature of the C language, so this feature is only available
+ * with compilers that perform macro expansion on an <tt>\#include</tt> line.
+ *
+ * The value of this symbol is typically a path in double quotes, either
+ * absolute or relative to a directory on the include search path.
+ */
+//#define MBEDTLS_USER_CONFIG_FILE "/dev/null"
+
+/**
+ * \def MBEDTLS_PSA_CRYPTO_CONFIG_FILE
+ *
+ * If defined, this is a header which will be included instead of
+ * `"psa/crypto_config.h"`.
+ * This header file specifies which cryptographic mechanisms are available
+ * through the PSA API when #MBEDTLS_PSA_CRYPTO_CONFIG is enabled, and
+ * is not used when #MBEDTLS_PSA_CRYPTO_CONFIG is disabled.
+ *
+ * This macro is expanded after an <tt>\#include</tt> directive. This is a popular but
+ * non-standard feature of the C language, so this feature is only available
+ * with compilers that perform macro expansion on an <tt>\#include</tt> line.
+ *
+ * The value of this symbol is typically a path in double quotes, either
+ * absolute or relative to a directory on the include search path.
+ */
+//#define MBEDTLS_PSA_CRYPTO_CONFIG_FILE "psa/crypto_config.h"
+
+/**
+ * \def MBEDTLS_PSA_CRYPTO_USER_CONFIG_FILE
+ *
+ * If defined, this is a header which will be included after
+ * `"psa/crypto_config.h"` or #MBEDTLS_PSA_CRYPTO_CONFIG_FILE.
+ * This allows you to modify the default configuration, including the ability
+ * to undefine options that are enabled by default.
+ *
+ * This macro is expanded after an <tt>\#include</tt> directive. This is a popular but
+ * non-standard feature of the C language, so this feature is only available
+ * with compilers that perform macro expansion on an <tt>\#include</tt> line.
+ *
+ * The value of this symbol is typically a path in double quotes, either
+ * absolute or relative to a directory on the include search path.
+ */
+//#define MBEDTLS_PSA_CRYPTO_USER_CONFIG_FILE "/dev/null"
+
+/** \} name SECTION: General configuration options */
+
+/**
+ * \name SECTION: Module configuration options
+ *
+ * This section allows for the setting of module specific sizes and
+ * configuration options. The default values are already present in the
+ * relevant header files and should suffice for the regular use cases.
+ *
+ * Our advice is to enable options and change their values here
+ * only if you have a good reason and know the consequences.
+ *
+ * Please check the respective header file for documentation on these
+ * parameters (to prevent duplicate documentation).
+ * \{
+ */
+
+/* ECP options */
+#define MBEDTLS_ECP_FIXED_POINT_OPTIM        0 /**< Disable fixed-point speed-up */
+
+/* \} name SECTION: Customisation configuration options */
+
+#if CRYPTO_NV_SEED
+#include "tfm_mbedcrypto_config_extra_nv_seed.h"
+#endif /* CRYPTO_NV_SEED */
+
+#if !defined(CRYPTO_HW_ACCELERATOR) && defined(MBEDTLS_ENTROPY_NV_SEED)
+#include "mbedtls_entropy_nv_seed_config.h"
+#endif
+
+#ifdef CRYPTO_HW_ACCELERATOR
+#include "mbedtls_accelerator_config.h"
+#endif
+
+#endif /* PROFILE_M_MBEDTLS_CONFIG_H */

--- a/configs/tfm_mbedcrypto_config_profile_medium.h
+++ b/configs/tfm_mbedcrypto_config_profile_medium.h
@@ -29,8 +29,6 @@
 #ifndef PROFILE_M_MBEDTLS_CONFIG_H
 #define PROFILE_M_MBEDTLS_CONFIG_H
 
-#include "config_tfm.h"
-
 #if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_DEPRECATE)
 #define _CRT_SECURE_NO_DEPRECATE 1
 #endif
@@ -239,7 +237,9 @@
  * \note The entropy collector will write to the seed file before entropy is
  *       given to an external source, to update it.
  */
-#define MBEDTLS_ENTROPY_NV_SEED
+// This macro is enabled in TFM Medium but is disabled here because it is
+// incompatible with baremetal builds in Mbed TLS.
+//#define MBEDTLS_ENTROPY_NV_SEED
 
 /* MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER
  *
@@ -251,8 +251,10 @@
  * mbedtls_svc_key_id_t to file name in all the storage backends that you
  * you wish to support.
  *
- * Note that this option is meant for internal use only and may be removed
- * without notice.
+ * Note that while this define has been removed from TF-M's copy of this config
+ * file, TF-M still passes this option to Mbed TLS during the build via CMake.
+ * Therefore we keep it in our copy. See discussion on PR #7426 for more info.
+ *
  */
 #define MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER
 
@@ -480,15 +482,6 @@
  */
 #define MBEDTLS_PLATFORM_C
 
-#define MBEDTLS_PLATFORM_NO_STD_FUNCTIONS
-#define MBEDTLS_PLATFORM_STD_MEM_HDR   <stdlib.h>
-
-#include <stdio.h>
-
-#define MBEDTLS_PLATFORM_SNPRINTF_MACRO      snprintf
-#define MBEDTLS_PLATFORM_PRINTF_ALT
-#define MBEDTLS_PLATFORM_STD_EXIT_SUCCESS  EXIT_SUCCESS
-#define MBEDTLS_PLATFORM_STD_EXIT_FAILURE  EXIT_FAILURE
 
 /**
  * \def MBEDTLS_PSA_CRYPTO_C
@@ -513,7 +506,9 @@
  *           either MBEDTLS_PSA_ITS_FILE_C or a native implementation of
  *           the PSA ITS interface
  */
-#define MBEDTLS_PSA_CRYPTO_STORAGE_C
+// This macro is enabled in TFM Medium but is disabled here because it is
+// incompatible with baremetal builds in Mbed TLS.
+//#define MBEDTLS_PSA_CRYPTO_STORAGE_C
 
 /* \} name SECTION: mbed TLS modules */
 

--- a/include/psa/crypto_platform.h
+++ b/include/psa/crypto_platform.h
@@ -83,7 +83,7 @@ static inline int mbedtls_key_owner_id_equal(mbedtls_key_owner_id_t id1,
  */
 #if defined(MBEDTLS_PSA_CRYPTO_SPM)
 #define PSA_CRYPTO_SECURE 1
-#include "crypto_spe.h"
+#include "../tests/include/spe/crypto_spe.h"
 #endif // MBEDTLS_PSA_CRYPTO_SPM
 
 #if defined(MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG)

--- a/scripts/code_size_compare.py
+++ b/scripts/code_size_compare.py
@@ -169,7 +169,7 @@ class CodeSizeComparison:
             git_worktree_path = os.path.join(self.repo_path, "temp-" + revision)
             subprocess.check_output(
                 [self.git_command, "worktree", "add", "--detach",
-                git_worktree_path, revision], cwd=self.repo_path,
+                 git_worktree_path, revision], cwd=self.repo_path,
                 stderr=subprocess.STDOUT
             )
 

--- a/scripts/code_size_compare.py
+++ b/scripts/code_size_compare.py
@@ -100,6 +100,7 @@ class CodeSizeComparison:
 
         self.old_rev = old_revision
         self.new_rev = new_revision
+        self.config = config
         self.git_command = "git"
         self.pre_build_commands, self.make_command = CONFIG_CMDS[config]
 
@@ -192,7 +193,7 @@ class CodeSizeComparison:
     def _gen_code_size_csv(self, revision, git_worktree_path):
         """Generate code size csv file."""
 
-        csv_fname = revision + ".csv"
+        csv_fname = revision + "-" + self.config + ".csv"
         if revision == "current":
             print("Measuring code size in current work directory.")
         else:
@@ -240,8 +241,8 @@ class CodeSizeComparison:
         old and new. Measured code size results of these two revisions
         must be available."""
 
-        res_file = open(os.path.join(self.result_dir, "compare-" + self.old_rev
-                                     + "-" + self.new_rev + ".csv"), "w")
+        res_file = open(os.path.join(self.result_dir, "compare-" + self.config + "-" +
+                                     self.old_rev + "-" + self.new_rev + ".csv"), "w")
         def write_dict_to_csv(old_d, new_d):
             tot_change_pct = ""
             for (f,s) in new_d.items():

--- a/scripts/code_size_compare.py
+++ b/scripts/code_size_compare.py
@@ -157,11 +157,12 @@ class CodeSizeComparison:
             return \
                  'make -j lib CC=armclang \
                   CFLAGS=\'--target=arm-arm-none-eabi -mcpu=cortex-m33 -Os \
-                      -DMBEDTLS_CONFIG_FILE=\\\"../configs/tfm_mbedcrypto_config_profile_medium.h\\\" \
-                      -DMBEDTLS_PSA_CRYPTO_CONFIG_FILE=\\\"../configs/crypto_config_profile_medium.h\\\" \' '
+            -DMBEDTLS_CONFIG_FILE=\\\"../configs/tfm_mbedcrypto_config_profile_medium.h\\\" \
+            -DMBEDTLS_PSA_CRYPTO_CONFIG_FILE=\\\"../configs/crypto_config_profile_medium.h\\\" \' '
 
         # Any remaining supported combinations are incompatible with each other
-        print('Config option {} is incompatble with architecture {}'.format(self.config, self.arch))
+        print('Config option {} is incompatble with architecture {}'
+              .format(self.config, self.arch))
         sys.exit(-1)
 
     def _create_git_worktree(self, revision):
@@ -201,7 +202,7 @@ class CodeSizeComparison:
             try:
                 subprocess.check_output(
                     self.pre_build_commands, env=my_environment, shell=True,
-                    cwd=git_worktree_path, stderr=subprocess.STDOUT,
+                    cwd=git_worktree_path, stderr=subprocess.STDOUT
                 )
             except subprocess.CalledProcessError as e:
                 self._handle_called_process_error(e, git_worktree_path)
@@ -212,7 +213,7 @@ class CodeSizeComparison:
         try:
             subprocess.check_output(
                 self.make_command, env=my_environment, shell=True,
-                cwd=git_worktree_path, stderr=subprocess.STDOUT,
+                cwd=git_worktree_path, stderr=subprocess.STDOUT
             )
         except subprocess.CalledProcessError as e:
             self._handle_called_process_error(e, git_worktree_path)
@@ -224,7 +225,8 @@ class CodeSizeComparison:
         # Size for libmbedcrypto.a
         try:
             result = subprocess.check_output(
-                ["size -t library/libmbedcrypto.a"], cwd=git_worktree_path, shell=True
+                ["size -t library/libmbedcrypto.a"],
+                cwd=git_worktree_path, shell=True
             )
         except subprocess.CalledProcessError as e:
             self._handle_called_process_error(e, git_worktree_path)
@@ -232,7 +234,8 @@ class CodeSizeComparison:
         # Size for libmbedx509.a
         try:
             result = subprocess.check_output(
-                ["size -t library/libmbedx509.a"], cwd=git_worktree_path, shell=True
+                ["size -t library/libmbedx509.a"],
+                cwd=git_worktree_path, shell=True
             )
         except subprocess.CalledProcessError as e:
             self._handle_called_process_error(e, git_worktree_path)
@@ -240,7 +243,8 @@ class CodeSizeComparison:
         # Size for libmbedtls.a
         try:
             result = subprocess.check_output(
-                ["size -t library/libmbedtls.a"], cwd=git_worktree_path, shell=True
+                ["size -t library/libmbedtls.a"],
+                cwd=git_worktree_path, shell=True
             )
         except subprocess.CalledProcessError as e:
             self._handle_called_process_error(e, git_worktree_path)
@@ -293,7 +297,6 @@ class CodeSizeComparison:
             write_dict_to_csv(d)
             csv_file.write('\n')
 
-
     def _remove_worktree(self, git_worktree_path):
         """Remove temporary worktree."""
         if git_worktree_path != self.repo_path:
@@ -318,7 +321,8 @@ class CodeSizeComparison:
 
         res_file = open(os.path.join(self.result_dir, "compare-" + self.config +
                                      "-" + self.arch + "-" + self.old_rev + "-"
-                                     + self.new_rev + ".csv"), "w", encoding='utf-8')
+                                     + self.new_rev + ".csv"),
+                        "w", encoding='utf-8')
         def write_dict_to_csv(old_d, new_d):
             for (f, s) in new_d.items():
                 new_size = int(s.total)
@@ -352,9 +356,10 @@ class CodeSizeComparison:
         self._get_code_size_for_rev(self.new_rev)
         return self.compare_code_size()
 
-    def _handle_called_process_error(self, e: subprocess.CalledProcessError, git_worktree_path):
-        """Handle a CalledProcessError and quit the program gracefully. Remove any
-        extra worktrees so that the script may be called again."""
+    def _handle_called_process_error(self, e: subprocess.CalledProcessError,
+                                     git_worktree_path):
+        """Handle a CalledProcessError and quit the program gracefully.
+        Remove any extra worktrees so that the script may be called again."""
 
         # Tell the user what went wrong
         print("The following command: {} failed and exited with code {}"\

--- a/scripts/code_size_compare.py
+++ b/scripts/code_size_compare.py
@@ -106,8 +106,7 @@ class CodeSizeComparison:
         self.config = config
         self.git_command = "git"
         self.pre_build_commands = PRE_BUILD_CMDS[config]
-        self.make_command = ''
-        self._set_make_command()
+        self.make_command = self._set_make_command()
 
         self.old_sizes = {}
         self.new_sizes = {}
@@ -121,10 +120,10 @@ class CodeSizeComparison:
     def _set_make_command(self):
         """Use the config and arch options passed to the object to determine
            and set the correct build command."""
+
         if self.arch == 'x86' and (self.config in {'default', 'full',\
                                                    'baremetal'}):
-            self.make_command = 'make -j lib'
-            return
+            return 'make -j lib'
 
         # Default just takes the current config, which may or may not work
         # with baremetal targets. Warn the user.
@@ -134,27 +133,24 @@ class CodeSizeComparison:
 
         if self.config in {'default', 'baremetal'}:
             if self.arch == 'aarch32':
-                self.make_command = 'make -j lib CC=armclang\
-                                    CFLAGS=\"--target=arm-arm-none-eabi \
-                                    -mcpu=cortex-m33 -Os\"'
+                return 'make -j lib CC=armclang \
+                        CFLAGS=\"--target=arm-arm-none-eabi \
+                            -mcpu=cortex-m33 -Os\" '
             if self.arch == 'aarch64':
-                self.make_command = 'make -j lib CC=armclang\
-                                    CFLAGS=\"--target=aarch64-arm-none-eabi\"'
-            return
+                return 'make -j lib CC=armclang \
+                        CFLAGS=\"--target=aarch64-arm-none-eabi\" '
 
         if self.arch == 'aarch32' and self.config == 'tfm-medium':
             # pylint: disable=C0301
-            self.make_command = \
-                 'make -j lib CC=armclang CFLAGS=\'--target=arm-arm-none-eabi \
-                 -mcpu=cortex-m33 -Os \
-                 -DMBEDTLS_CONFIG_FILE=\\\"../configs/tfm_mbedcrypto_config_profile_medium.h\\\" \
-                 -DMBEDTLS_PSA_CRYPTO_CONFIG_FILE=\\\"../configs/crypto_config_profile_medium.h\\\" \''
-            return
+            return \
+                 'make -j lib CC=armclang \
+                  CFLAGS=\'--target=arm-arm-none-eabi -mcpu=cortex-m33 -Os \
+                      -DMBEDTLS_CONFIG_FILE=\\\"../configs/tfm_mbedcrypto_config_profile_medium.h\\\" \
+                      -DMBEDTLS_PSA_CRYPTO_CONFIG_FILE=\\\"../configs/crypto_config_profile_medium.h\\\" \' '
 
         # Any remaining supported combinations are incompatible with each other
         print('Config option {} is incompatble with architecture {}'.format(self.config, self.arch))
         sys.exit(-1)
-
 
     def _create_git_worktree(self, revision):
         """Make a separate worktree for revision.

--- a/scripts/code_size_compare.py
+++ b/scripts/code_size_compare.py
@@ -111,7 +111,6 @@ class CodeSizeComparison:
 
         self.old_sizes = {}
         self.new_sizes = {}
-        self.change_pcts = {}
 
     @staticmethod
     def validate_revision(revision):
@@ -298,7 +297,6 @@ class CodeSizeComparison:
                                      "-" + self.arch + "-" + self.old_rev + "-"
                                      + self.new_rev + ".csv"), "w", encoding='utf-8')
         def write_dict_to_csv(old_d, new_d):
-            tot_change_pct = ""
             for (f, s) in new_d.items():
                 new_size = int(s.total)
                 if f in old_d:
@@ -310,20 +308,16 @@ class CodeSizeComparison:
                         change_pct = 0
                     res_file.write("{}, {}, {}, {}, {:.2%}\n".format(f, \
                                new_size, old_size, change, float(change_pct)))
-                    if f == "(TOTALS)":
-                        tot_change_pct = str(change_pct)
                 else:
                     res_file.write("{}, {}\n".format(f, new_size))
-            return tot_change_pct
 
         res_file.write("file_name, this_size, old_size, change, change %\n")
         print("Generating comparison results.")
 
         for exe in self.new_sizes:
             res_file.write(exe + '\n')
-            tot = write_dict_to_csv(self.old_sizes[exe], self.new_sizes[exe])
+            write_dict_to_csv(self.old_sizes[exe], self.new_sizes[exe])
             res_file.write('\n')
-            self.change_pcts[exe] = tot
 
         return 0
 

--- a/scripts/code_size_compare.py
+++ b/scripts/code_size_compare.py
@@ -284,17 +284,10 @@ class CodeSizeComparison:
 
     def _get_code_size_for_rev(self, revision):
         """Generate code size csv file for the specified git revision."""
-
-        # Check if the corresponding record exists
-        csv_fname = revision + ".csv"
-        if (revision != "current") and \
-           os.path.exists(os.path.join(self.csv_dir, csv_fname)):
-            print("Code size csv file for", revision, "already exists.")
-        else:
-            git_worktree_path = self._create_git_worktree(revision)
-            self._build_libraries(git_worktree_path)
-            self._gen_code_size_csv(revision, git_worktree_path)
-            self._remove_worktree(git_worktree_path)
+        git_worktree_path = self._create_git_worktree(revision)
+        self._build_libraries(git_worktree_path)
+        self._gen_code_size_csv(revision, git_worktree_path)
+        self._remove_worktree(git_worktree_path)
 
     def compare_code_size(self):
         """Generate results of the size changes between two revisions,

--- a/scripts/code_size_compare.py
+++ b/scripts/code_size_compare.py
@@ -32,11 +32,60 @@ import sys
 
 from mbedtls_dev import build_tree
 
+class Size:
+    def __init__(self, text: int, data: int, bss: int, total: int):
+        self.text = text
+        self.data = data
+        self.bss = bss
+        self.total = total
+    def __eq__(self, __o: object) -> bool:
+        return (self.text == __o.text) and \
+               (self.data == __o.data) and \
+               (self.bss == __o.bss)
+
+    def __ne__(self, __o: object) -> bool:
+        return not self.__eq__(__o)
+
+    def __lt__(self, __o: object) -> bool:
+        return self.total < __o.total
+
+    def __le__(self, __o: object) -> bool:
+        return self.__lt__(__o) or self.__eq__(__o)
+
+    def __gt__(self, __o: object) -> bool:
+        return self.total > __o.total
+
+    def __ge__(self, __o: object) -> bool:
+        return self.__gt__(__o) or self.__eq__(__o)
+
+    def __add__(self, __o: object) -> object:
+        text = self.text + __o.text
+        data = self.data + __o.data
+        bss = self.bss + __o.bss
+        total = self.total + __o.total
+        return Size(text,data,bss,total)
+
+    def __sub__(self, __o: object) -> object:
+        text = self.text - __o.text
+        data = self.data - __o.data
+        bss = self.bss - __o.bss
+        total = self.total - __o.total
+        return Size(text,data,bss,total)
+
+CONFIG_CMDS = {
+    'default': ('','make -j lib'),
+    'full': ('scripts/config.py full', 'make -j lib'),
+    'baremetal': ('scripts/config.py baremetal', 'make -j lib'),
+    'tfm': ('', 'make lib CC=armclang CFLAGS=\"--target=arm-arm-none-eabi \
+                 -mcpu=cortex-m33 \
+                 -DMBEDTLS_CONFIG_FILE=\\\\\\"../configs/tfm_mbedcrypto_config_profile_medium.h\\\\\\" \
+                 -DMBEDTLS_PSA_CRYPTO_CONFIG_FILE=\\\\\\"../configs/crypto_config_profile_medium.h\\\\\\" \"')
+}
 
 class CodeSizeComparison:
     """Compare code size between two Git revisions."""
 
-    def __init__(self, old_revision, new_revision, result_dir):
+    def __init__(self, old_revision, new_revision, result_dir, config):
         """
         old_revision: revision to compare against
         new_revision:
@@ -52,7 +101,11 @@ class CodeSizeComparison:
         self.old_rev = old_revision
         self.new_rev = new_revision
         self.git_command = "git"
-        self.make_command = "make"
+        self.pre_build_commands, self.make_command = CONFIG_CMDS[config]
+
+        self.old_sizes = {}
+        self.new_sizes = {}
+        self.change_pcts = {}
 
     @staticmethod
     def validate_revision(revision):
@@ -81,10 +134,60 @@ class CodeSizeComparison:
         """Build libraries in the specified worktree."""
 
         my_environment = os.environ.copy()
+        if self.pre_build_commands != '':
+            subprocess.check_output(
+                self.pre_build_commands, env=my_environment, shell=True,
+                cwd=git_worktree_path, stderr=subprocess.STDOUT,
+        )
+
         subprocess.check_output(
-            [self.make_command, "-j", "lib"], env=my_environment,
+            self.make_command, env=my_environment, shell=True,
             cwd=git_worktree_path, stderr=subprocess.STDOUT,
         )
+
+    def _gen_code_size_report(self, revision, git_worktree_path):
+        """Generate a code size report for each executable and store them
+        in a dictionary"""
+
+        # Size for libmbedcrypto.a
+        result = subprocess.check_output(
+            ["size -t library/libmbedcrypto.a"], cwd=git_worktree_path, shell=True
+        )
+        crypto_text = result.decode()
+        # Size for libmbedx509.a
+        result = subprocess.check_output(
+            ["size -t library/libmbedx509.a"], cwd=git_worktree_path, shell=True
+        )
+        x509_text = result.decode()
+        # Size for libmbedtls.a
+        result = subprocess.check_output(
+            ["size -t library/libmbedtls.a"], cwd=git_worktree_path, shell=True
+        )
+        tls_text = result.decode()
+
+        def size_text_to_dict(txt):
+            """Helper function: Converts 'size' command output to dictionary"""
+            size_dict = {}
+            for line in txt.splitlines()[1:]:
+                data = line.split()
+                exe_size = Size(data[0], data[1], data[2], data[3])
+                size_dict[f'{data[5]}'] = exe_size
+            return size_dict
+
+        lst = [(crypto_text),(x509_text),(tls_text)]
+        size_lst = [size_text_to_dict(t) for t in lst]
+        size_dicts = {
+            'crypto': size_lst[0],
+            'x509': size_lst[1],
+            'tls': size_lst[2]
+        }
+
+        if revision == self.old_rev:
+            self.old_sizes = size_dicts
+        if revision == self.new_rev:
+            self.new_sizes = size_dicts
+
+        return size_dicts
 
     def _gen_code_size_csv(self, revision, git_worktree_path):
         """Generate code size csv file."""
@@ -94,14 +197,19 @@ class CodeSizeComparison:
             print("Measuring code size in current work directory.")
         else:
             print("Measuring code size for", revision)
-        result = subprocess.check_output(
-            ["size library/*.o"], cwd=git_worktree_path, shell=True
-        )
-        size_text = result.decode()
+        sizes_dict = self._gen_code_size_report(revision, git_worktree_path)
+
+        def write_dict_to_csv(d):
+            for (f,s) in d.items():
+                csv_file.write(f'{f}, {s.text}, {s.data}, {s.bss}, {s.total}\n')
+
         csv_file = open(os.path.join(self.csv_dir, csv_fname), "w")
-        for line in size_text.splitlines()[1:]:
-            data = line.split()
-            csv_file.write("{}, {}\n".format(data[5], data[3]))
+        csv_file.write('file, text, data, bss, TOTAL\n')
+        for (n,d) in sizes_dict.items():
+            csv_file.write(f'{n}\n')
+            write_dict_to_csv(d)
+            csv_file.write('\n')
+
 
     def _remove_worktree(self, git_worktree_path):
         """Remove temporary worktree."""
@@ -132,39 +240,36 @@ class CodeSizeComparison:
         old and new. Measured code size results of these two revisions
         must be available."""
 
-        old_file = open(os.path.join(self.csv_dir, self.old_rev + ".csv"), "r")
-        new_file = open(os.path.join(self.csv_dir, self.new_rev + ".csv"), "r")
         res_file = open(os.path.join(self.result_dir, "compare-" + self.old_rev
                                      + "-" + self.new_rev + ".csv"), "w")
+        def write_dict_to_csv(old_d, new_d):
+            tot_change_pct = ""
+            for (f,s) in new_d.items():
+                new_size = int(s.total)
+                if f in old_d:
+                    old_size = int(old_d[f].total)
+                    change = new_size - old_size
+                    if change != 0:
+                        change_pct = change / old_size
+                    else:
+                        change_pct = 0
+                    res_file.write("{}, {}, {}, {}, {:.2%}\n".format(f, \
+                               new_size, old_size, change, float(change_pct)))
+                    if f == "(TOTALS)":
+                        tot_change_pct = str(change_pct)
+                else:
+                    res_file.write("{}, {}\n".format(f, new_size))
+            return tot_change_pct
 
         res_file.write("file_name, this_size, old_size, change, change %\n")
         print("Generating comparison results.")
 
-        old_ds = {}
-        for line in old_file.readlines()[1:]:
-            cols = line.split(", ")
-            fname = cols[0]
-            size = int(cols[1])
-            if size != 0:
-                old_ds[fname] = size
+        for exe in self.new_sizes:
+            res_file.write(f"{exe}\n")
+            tot = write_dict_to_csv(self.old_sizes[f'{exe}'], self.new_sizes[f'{exe}'])
+            res_file.write('\n')
+            self.change_pcts[f'{exe}'] = tot
 
-        new_ds = {}
-        for line in new_file.readlines()[1:]:
-            cols = line.split(", ")
-            fname = cols[0]
-            size = int(cols[1])
-            new_ds[fname] = size
-
-        for fname in new_ds:
-            this_size = new_ds[fname]
-            if fname in old_ds:
-                old_size = old_ds[fname]
-                change = this_size - old_size
-                change_pct = change / old_size
-                res_file.write("{}, {}, {}, {}, {:.2%}\n".format(fname, \
-                               this_size, old_size, change, float(change_pct)))
-            else:
-                res_file.write("{}, {}\n".format(fname, this_size))
         return 0
 
     def get_comparision_results(self):
@@ -199,6 +304,11 @@ def main():
         help="new revision for comparison, default is the current work \
               directory, including uncommitted changes."
     )
+    parser.add_argument(
+        "-c", "--config", type=str, default="default",
+        help="optional configuration for Mbed TLS. Default uses current \
+              config. Options: full, baremetal, tfm."
+    )
     comp_args = parser.parse_args()
 
     if os.path.isfile(comp_args.result_dir):
@@ -215,7 +325,8 @@ def main():
         new_revision = "current"
 
     result_dir = comp_args.result_dir
-    size_compare = CodeSizeComparison(old_revision, new_revision, result_dir)
+    size_compare = CodeSizeComparison(old_revision, new_revision, result_dir,
+                                      comp_args.config)
     return_code = size_compare.get_comparision_results()
     sys.exit(return_code)
 


### PR DESCRIPTION
## Description

This PR:
1. Adds slightly modified versions of both regular and PSA-style config header files from TFM under `configs/`.
2. Modifies `code_size_compare.py` so that it separates the sizes of `crypto`, `x509`, and `tls` in the csv report and allows for the use of alternative configurations (like the TFM Baremetal one).

Should resolve #7360. Will also lay the foundations for addressing #7361 and #7359.

## Gatekeeper checklist

- [x] **changelog** not required: scripts only (unless we feel adding a new configuration warrants one)
- [x] **backport** not required: scripts only
- [x] **tests**  not required: scripts only

