### PR TITLE
Update links to references in bignum

### DIFF
--- a/library/ecdh.c
+++ b/library/ecdh.c
@@ -20,7 +20,7 @@
 /*
  * References:
  *
- * SEC1 http://www.secg.org/index.php?action=secg,docs_secg
+ * SEC1 https://www.secg.org/sec1-v2.pdf
  * RFC 4492
  */
 

--- a/library/ecdsa.c
+++ b/library/ecdsa.c
@@ -20,7 +20,7 @@
 /*
  * References:
  *
- * SEC1 http://www.secg.org/index.php?action=secg,docs_secg
+ * SEC1 https://www.secg.org/sec1-v2.pdf 
  */
 
 #include "common.h"

--- a/library/ecdsa.c
+++ b/library/ecdsa.c
@@ -20,7 +20,7 @@
 /*
  * References:
  *
- * SEC1 https://www.secg.org/sec1-v2.pdf 
+ * SEC1 https://www.secg.org/sec1-v2.pdf
  */
 
 #include "common.h"

--- a/library/ecp.c
+++ b/library/ecp.c
@@ -24,9 +24,11 @@
  * GECC = Guide to Elliptic Curve Cryptography - Hankerson, Menezes, Vanstone
  * FIPS 186-3 http://csrc.nist.gov/publications/fips/fips186-3/fips_186-3.pdf
  * RFC 4492 for the related TLS structures and constants
+ * - https://www.rfc-editor.org/rfc/rfc4492
  * RFC 7748 for the Curve448 and Curve25519 curve definitions
+ * - https://www.rfc-editor.org/rfc/rfc7748
  *
- * [Curve25519] http://cr.yp.to/ecdh/curve25519-20060209.pdf
+ * [Curve25519] https://cr.yp.to/ecdh/curve25519-20060209.pdf
  *
  * [2] CORON, Jean-S'ebastien. Resistance against differential power analysis
  *     for elliptic curve cryptosystems. In : Cryptographic Hardware and


### PR DESCRIPTION
## Description

The links of SEC1 is out-dated, update them to version 2.
Some RFC missed the links, add them.

- [x] **changelog** not required - change in documentation only
- [x] **backport** required https://github.com/Mbed-TLS/mbedtls/pull/7469
- [x] **tests** not required - change in documentation only
