### PR TITLE
Fix derive_ecjpake_to_pms dependency in PSA crypto test

### DIFF
--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -8906,7 +8906,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:PSA_WANT_ALG_SHA_256:MBEDTLS_PSA_BUILTIN_ALG_TLS12_PSK_TO_MS */
+/* BEGIN_CASE depends_on:PSA_WANT_ALG_SHA_256:PSA_WANT_ALG_TLS12_ECJPAKE_TO_PMS */
 void derive_ecjpake_to_pms(data_t *input, int expected_input_status_arg,
                            int derivation_step,
                            int capacity, int expected_capacity_status_arg,


### PR DESCRIPTION
## Description

Function `derive_ecjpake_to_pms` in [mbedtls/test_suite_psa_crypto.function, line 8909](https://github.com/Mbed-TLS/mbedtls/blob/development/tests/suites/test_suite_psa_crypto.function#L8909) has declared wrong dependency in comment before the function. It should be `PSA_WANT_ALG_TLS12_ECJPAKE_TO_PMS` instead of `MBEDTLS_PSA_BUILTIN_ALG_TLS12_PSK_TO_MS`. The comment is interpreted by the test suite generator.


## Gatekeeper checklist

- [ ] **changelog** provided, or not required
- [ ] **backport** done, or not required
- [ ] **tests** provided, or not required

