### PR TITLE
Fix so that PSA_WANT_ALG_DETERMINISTIC_ECDSA implies PSA_HAVE_FULL_EC…

### DIFF
--- a/include/mbedtls/config_psa.h
+++ b/include/mbedtls/config_psa.h
@@ -877,7 +877,8 @@ extern "C" {
 
 #endif /* MBEDTLS_PSA_CRYPTO_CONFIG */
 
-#if defined(PSA_WANT_ALG_ECDSA) && defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR) && \
+#if (defined(PSA_WANT_ALG_ECDSA) || defined(PSA_WANT_ALG_DETERMINISTIC_ECDSA)) \
+    && defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR) && \
     defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY)
 #define PSA_HAVE_FULL_ECDSA 1
 #endif


### PR DESCRIPTION
## Description

In [mbedtls/config_psa.h](https://github.com/Mbed-TLS/mbedtls/blob/development/include/mbedtls/config_psa.h#L880) `PSA_HAVE_FULL_ECDSA` is defined 

if `PSA_WANT_ALG_ECDSA` and 
`PSA_WANT_KEY_TYPE_ECC_KEY_PAIR` and `PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY` are defined. 

It should be also defined 
if `PSA_WANT_ALG_DETERMINISTIC_ECDSA` and 
`PSA_WANT_KEY_TYPE_ECC_KEY_PAIR` and `PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY`are defined.


## Gatekeeper checklist

- [ ] **changelog** provided, or not required
- [ ] **backport** done, or not required
- [ ] **tests** provided, or not required


