### PR TITLE
Avoid parse/unparse private ECC keys in PK with USE_PSA when !ECP_C

### DIFF
--- a/library/pk.c
+++ b/library/pk.c
@@ -912,7 +912,6 @@ int mbedtls_pk_wrap_as_opaque(mbedtls_pk_context *pk,
 #else /* !MBEDTLS_ECP_LIGHT && !MBEDTLS_RSA_C */
 #if defined(MBEDTLS_ECP_LIGHT)
     if (mbedtls_pk_get_type(pk) == MBEDTLS_PK_ECKEY) {
-        unsigned char d[MBEDTLS_ECP_MAX_BYTES];
         size_t d_len;
         psa_ecc_family_t curve_id;
         psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
@@ -922,6 +921,7 @@ int mbedtls_pk_wrap_as_opaque(mbedtls_pk_context *pk,
 
         /* export the private key material in the format PSA wants */
 #if defined(MBEDTLS_PK_USE_PSA_EC_DATA)
+        unsigned char d[MBEDTLS_PSA_MAX_EC_KEY_PAIR_LENGTH];
         status = psa_export_key(pk->priv_id, d, sizeof(d), &d_len);
         if (status != PSA_SUCCESS) {
             return psa_pk_status_to_mbedtls(status);
@@ -930,6 +930,7 @@ int mbedtls_pk_wrap_as_opaque(mbedtls_pk_context *pk,
         curve_id = pk->ec_family;
         bits = pk->ec_bits;
 #else /* MBEDTLS_PK_USE_PSA_EC_DATA */
+        unsigned char d[MBEDTLS_ECP_MAX_BYTES];
         mbedtls_ecp_keypair *ec = mbedtls_pk_ec_rw(*pk);
         int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
 

--- a/library/pk.c
+++ b/library/pk.c
@@ -42,13 +42,6 @@
 
 #if defined(MBEDTLS_PSA_CRYPTO_C)
 #include "mbedtls/psa_util.h"
-#define PSA_PK_TO_MBEDTLS_ERR(status) psa_pk_status_to_mbedtls(status)
-#define PSA_PK_RSA_TO_MBEDTLS_ERR(status) PSA_TO_MBEDTLS_ERR_LIST(status,     \
-                                                                  psa_to_pk_rsa_errors,            \
-                                                                  psa_pk_status_to_mbedtls)
-#define PSA_PK_ECDSA_TO_MBEDTLS_ERR(status) PSA_TO_MBEDTLS_ERR_LIST(status,   \
-                                                                    psa_to_pk_ecdsa_errors,        \
-                                                                    psa_pk_status_to_mbedtls)
 #endif
 
 #include <limits.h>

--- a/library/pk_internal.h
+++ b/library/pk_internal.h
@@ -81,24 +81,20 @@ static inline mbedtls_ecp_keypair *mbedtls_pk_ec_rw(const mbedtls_pk_context pk)
     }
 }
 
-/* Helpers for Montgomery curves */
+static inline mbedtls_ecp_group_id mbedtls_pk_get_group_id(const mbedtls_pk_context *pk)
+{
+    mbedtls_ecp_group_id id;
+#if defined(MBEDTLS_PK_USE_PSA_EC_DATA)
+    id = mbedtls_ecc_group_of_psa(pk->ec_family, pk->ec_bits, 0);
+#else /* MBEDTLS_PK_USE_PSA_EC_DATA */
+    id = mbedtls_pk_ec_ro(*pk)->grp.id;
+#endif /* MBEDTLS_PK_USE_PSA_EC_DATA */
+    return id;
+}
+
+/* Helper for Montgomery curves */
 #if defined(MBEDTLS_ECP_DP_CURVE25519_ENABLED) || defined(MBEDTLS_ECP_DP_CURVE448_ENABLED)
 #define MBEDTLS_PK_HAVE_RFC8410_CURVES
-
-static inline int mbedtls_pk_is_rfc8410_curve(mbedtls_ecp_group_id id)
-{
-#if defined(MBEDTLS_ECP_DP_CURVE25519_ENABLED)
-    if (id == MBEDTLS_ECP_DP_CURVE25519) {
-        return 1;
-    }
-#endif
-#if defined(MBEDTLS_ECP_DP_CURVE448_ENABLED)
-    if (id == MBEDTLS_ECP_DP_CURVE448) {
-        return 1;
-    }
-#endif
-    return 0;
-}
 #endif /* MBEDTLS_ECP_DP_CURVE25519_ENABLED || MBEDTLS_ECP_DP_CURVE448_ENABLED */
 #endif /* MBEDTLS_ECP_LIGHT */
 

--- a/library/pk_internal.h
+++ b/library/pk_internal.h
@@ -33,6 +33,17 @@
 #include "psa/crypto.h"
 #endif
 
+#if defined(MBEDTLS_PSA_CRYPTO_C)
+#include "mbedtls/psa_util.h"
+#define PSA_PK_TO_MBEDTLS_ERR(status) psa_pk_status_to_mbedtls(status)
+#define PSA_PK_RSA_TO_MBEDTLS_ERR(status) PSA_TO_MBEDTLS_ERR_LIST(status,     \
+                                                                  psa_to_pk_rsa_errors,            \
+                                                                  psa_pk_status_to_mbedtls)
+#define PSA_PK_ECDSA_TO_MBEDTLS_ERR(status) PSA_TO_MBEDTLS_ERR_LIST(status,   \
+                                                                    psa_to_pk_ecdsa_errors,        \
+                                                                    psa_pk_status_to_mbedtls)
+#endif
+
 #if defined(MBEDTLS_ECP_LIGHT)
 /**
  * Public function mbedtls_pk_ec() can be used to get direct access to the

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -43,13 +43,6 @@
 
 #if defined(MBEDTLS_PSA_CRYPTO_C)
 #include "mbedtls/psa_util.h"
-#define PSA_PK_TO_MBEDTLS_ERR(status) psa_pk_status_to_mbedtls(status)
-#define PSA_PK_RSA_TO_MBEDTLS_ERR(status) PSA_TO_MBEDTLS_ERR_LIST(status,     \
-                                                                  psa_to_pk_rsa_errors,            \
-                                                                  psa_pk_status_to_mbedtls)
-#define PSA_PK_ECDSA_TO_MBEDTLS_ERR(status) PSA_TO_MBEDTLS_ERR_LIST(status,   \
-                                                                    psa_to_pk_ecdsa_errors,        \
-                                                                    psa_pk_status_to_mbedtls)
 #endif
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -1214,6 +1214,7 @@ static int eckey_check_pair(mbedtls_pk_context *pub, mbedtls_pk_context *prv,
 #endif
 }
 
+#if !defined(MBEDTLS_PK_USE_PSA_EC_DATA)
 static void *eckey_alloc_wrap(void)
 {
     void *ctx = mbedtls_calloc(1, sizeof(mbedtls_ecp_keypair));
@@ -1230,6 +1231,7 @@ static void eckey_free_wrap(void *ctx)
     mbedtls_ecp_keypair_free((mbedtls_ecp_keypair *) ctx);
     mbedtls_free(ctx);
 }
+#endif /* MBEDTLS_PK_USE_PSA_EC_DATA */
 
 static void eckey_debug(mbedtls_pk_context *pk, mbedtls_pk_debug_item *items)
 {
@@ -1267,8 +1269,13 @@ const mbedtls_pk_info_t mbedtls_eckey_info = {
     NULL,
     NULL,
     eckey_check_pair,
+#if defined(MBEDTLS_PK_USE_PSA_EC_DATA)
+    NULL,
+    NULL,
+#else /* MBEDTLS_PK_USE_PSA_EC_DATA */
     eckey_alloc_wrap,
     eckey_free_wrap,
+#endif /* MBEDTLS_PK_USE_PSA_EC_DATA */
 #if defined(MBEDTLS_ECDSA_C) && defined(MBEDTLS_ECP_RESTARTABLE)
     eckey_rs_alloc,
     eckey_rs_free,
@@ -1299,8 +1306,13 @@ const mbedtls_pk_info_t mbedtls_eckeydh_info = {
     NULL,
     NULL,
     eckey_check_pair,
-    eckey_alloc_wrap,       /* Same underlying key structure */
-    eckey_free_wrap,        /* Same underlying key structure */
+#if defined(MBEDTLS_PK_USE_PSA_EC_DATA)
+    NULL,
+    NULL,
+#else /* MBEDTLS_PK_USE_PSA_EC_DATA */
+    eckey_alloc_wrap,   /* Same underlying key structure */
+    eckey_free_wrap,    /* Same underlying key structure */
+#endif /* MBEDTLS_PK_USE_PSA_EC_DATA */
 #if defined(MBEDTLS_ECDSA_C) && defined(MBEDTLS_ECP_RESTARTABLE)
     NULL,
     NULL,
@@ -1389,8 +1401,13 @@ const mbedtls_pk_info_t mbedtls_ecdsa_info = {
     NULL,
     NULL,
     eckey_check_pair,   /* Compatible key structures */
+#if defined(MBEDTLS_PK_USE_PSA_EC_DATA)
+    NULL,
+    NULL,
+#else /* MBEDTLS_PK_USE_PSA_EC_DATA */
     eckey_alloc_wrap,   /* Compatible key structures */
     eckey_free_wrap,   /* Compatible key structures */
+#endif /* MBEDTLS_PK_USE_PSA_EC_DATA */
 #if defined(MBEDTLS_ECDSA_C) && defined(MBEDTLS_ECP_RESTARTABLE)
     ecdsa_rs_alloc,
     ecdsa_rs_free,

--- a/library/pkparse.c
+++ b/library/pkparse.c
@@ -642,16 +642,9 @@ static int pk_parse_key_rfc8410_der(mbedtls_pk_context *pk,
     psa_status_t status;
 
     psa_set_key_type(&attributes, PSA_KEY_TYPE_ECC_KEY_PAIR(pk->ec_family));
-    /* Setting largest masks for usage and key algorithms */
-    psa_set_key_usage_flags(&attributes, PSA_KEY_USAGE_SIGN_HASH |
-                            PSA_KEY_USAGE_SIGN_MESSAGE |
-                            PSA_KEY_USAGE_EXPORT);
-#if defined(MBEDTLS_ECDSA_DETERMINISTIC)
-    psa_set_key_algorithm(&attributes,
-                          PSA_ALG_DETERMINISTIC_ECDSA(PSA_ALG_ANY_HASH));
-#else
-    psa_set_key_algorithm(&attributes, PSA_ALG_ECDSA(PSA_ALG_ANY_HASH));
-#endif
+    psa_set_key_usage_flags(&attributes, PSA_KEY_USAGE_EXPORT |
+                            PSA_KEY_USAGE_DERIVE);
+    psa_set_key_algorithm(&attributes, PSA_ALG_ECDH);
 
     status = psa_import_key(&attributes, key, len, &pk->priv_id);
     if (status != PSA_SUCCESS) {
@@ -1304,13 +1297,14 @@ static int pk_parse_key_sec1_der(mbedtls_pk_context *pk,
     /* Setting largest masks for usage and key algorithms */
     psa_set_key_usage_flags(&attributes, PSA_KEY_USAGE_SIGN_HASH |
                             PSA_KEY_USAGE_SIGN_MESSAGE |
-                            PSA_KEY_USAGE_EXPORT);
+                            PSA_KEY_USAGE_EXPORT | PSA_KEY_USAGE_DERIVE);
 #if defined(MBEDTLS_ECDSA_DETERMINISTIC)
     psa_set_key_algorithm(&attributes,
                           PSA_ALG_DETERMINISTIC_ECDSA(PSA_ALG_ANY_HASH));
 #else
     psa_set_key_algorithm(&attributes, PSA_ALG_ECDSA(PSA_ALG_ANY_HASH));
 #endif
+    psa_set_key_enrollment_algorithm(&attributes, PSA_ALG_ECDH);
 
     status = psa_import_key(&attributes, priv_key_raw, priv_key_len,
                             &pk->priv_id);

--- a/library/pkparse.c
+++ b/library/pkparse.c
@@ -63,6 +63,12 @@
 
 #include "mbedtls/platform.h"
 
+/* Helper for Montgomery curves */
+#if defined(MBEDTLS_ECP_LIGHT) && defined(MBEDTLS_PK_HAVE_RFC8410_CURVES)
+#define MBEDTLS_PK_IS_RFC8410_GROUP_ID(id)  \
+    ((id == MBEDTLS_ECP_DP_CURVE25519) || (id == MBEDTLS_ECP_DP_CURVE448))
+#endif /* MBEDTLS_ECP_LIGHT && MBEDTLS_PK_HAVE_RFC8410_CURVES */
+
 #if defined(MBEDTLS_FS_IO)
 /*
  * Load all data from a file into a given buffer.

--- a/library/pkparse.c
+++ b/library/pkparse.c
@@ -514,6 +514,9 @@ static int pk_use_ecparams(const mbedtls_asn1_buf *params, mbedtls_pk_context *p
 #endif
     }
 
+#if defined(MBEDTLS_PK_USE_PSA_EC_DATA)
+    ret = pk_update_psa_ecparams(pk, grp_id);
+#else
     /* grp may already be initialized; if so, make sure IDs match */
     if (mbedtls_pk_ec_ro(*pk)->grp.id != MBEDTLS_ECP_DP_NONE &&
         mbedtls_pk_ec_ro(*pk)->grp.id != grp_id) {
@@ -524,8 +527,6 @@ static int pk_use_ecparams(const mbedtls_asn1_buf *params, mbedtls_pk_context *p
                                       grp_id)) != 0) {
         return ret;
     }
-#if defined(MBEDTLS_PK_USE_PSA_EC_DATA)
-    ret = pk_update_psa_ecparams(pk, grp_id);
 #endif /* MBEDTLS_PK_USE_PSA_EC_DATA */
 
     return ret;
@@ -539,20 +540,26 @@ static int pk_derive_public_key(mbedtls_pk_context *pk,
                                 int (*f_rng)(void *, unsigned char *, size_t), void *p_rng)
 {
     int ret;
-    mbedtls_ecp_keypair *eck = (mbedtls_ecp_keypair *) pk->pk_ctx;
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
-    psa_status_t status, destruction_status;
+    psa_status_t status;
+    (void) f_rng;
+    (void) p_rng;
+#if defined(MBEDTLS_PK_USE_PSA_EC_DATA)
+    (void) d;
+    (void) d_len;
+
+    status = psa_export_public_key(pk->priv_id, pk->pub_raw, sizeof(pk->pub_raw),
+                                   &pk->pub_raw_len);
+    ret = psa_pk_status_to_mbedtls(status);
+#else /* MBEDTLS_PK_USE_PSA_EC_DATA */
+    mbedtls_ecp_keypair *eck = (mbedtls_ecp_keypair *) pk->pk_ctx;
+    unsigned char key_buf[MBEDTLS_PSA_MAX_EC_PUBKEY_LENGTH];
+    size_t key_len;
+    mbedtls_svc_key_id_t key_id = MBEDTLS_SVC_KEY_ID_INIT;
     psa_key_attributes_t key_attr = PSA_KEY_ATTRIBUTES_INIT;
     size_t curve_bits;
     psa_ecc_family_t curve = mbedtls_ecc_group_to_psa(eck->grp.id, &curve_bits);
-#if !defined(MBEDTLS_PK_USE_PSA_EC_DATA)
-    unsigned char key_buf[MBEDTLS_PSA_MAX_EC_PUBKEY_LENGTH];
-    size_t key_len;
-#endif /* !MBEDTLS_PK_USE_PSA_EC_DATA */
-    mbedtls_svc_key_id_t key_id = MBEDTLS_SVC_KEY_ID_INIT;
-
-    (void) f_rng;
-    (void) p_rng;
+    psa_status_t destruction_status;
 
     psa_set_key_type(&key_attr, PSA_KEY_TYPE_ECC_KEY_PAIR(curve));
     psa_set_key_usage_flags(&key_attr, PSA_KEY_USAGE_EXPORT);
@@ -563,12 +570,7 @@ static int pk_derive_public_key(mbedtls_pk_context *pk,
         return ret;
     }
 
-#if defined(MBEDTLS_PK_USE_PSA_EC_DATA)
-    status = psa_export_public_key(key_id, pk->pub_raw, sizeof(pk->pub_raw),
-                                   &pk->pub_raw_len);
-#else /* MBEDTLS_PK_USE_PSA_EC_DATA */
     status = psa_export_public_key(key_id, key_buf, sizeof(key_buf), &key_len);
-#endif /* MBEDTLS_PK_USE_PSA_EC_DATA */
     ret = psa_pk_status_to_mbedtls(status);
     destruction_status = psa_destroy_key(key_id);
     if (ret != 0) {
@@ -576,10 +578,10 @@ static int pk_derive_public_key(mbedtls_pk_context *pk,
     } else if (destruction_status != PSA_SUCCESS) {
         return psa_pk_status_to_mbedtls(destruction_status);
     }
-#if !defined(MBEDTLS_PK_USE_PSA_EC_DATA)
     ret = mbedtls_ecp_point_read_binary(&eck->grp, &eck->Q, key_buf, key_len);
-#endif /* !MBEDTLS_PK_USE_PSA_EC_DATA */
+#endif /* MBEDTLS_PK_USE_PSA_EC_DATA */
 #else /* MBEDTLS_USE_PSA_CRYPTO */
+    mbedtls_ecp_keypair *eck = (mbedtls_ecp_keypair *) pk->pk_ctx;
     (void) d;
     (void) d_len;
 
@@ -597,21 +599,21 @@ static int pk_use_ecparams_rfc8410(const mbedtls_asn1_buf *params,
                                    mbedtls_ecp_group_id grp_id,
                                    mbedtls_pk_context *pk)
 {
-    mbedtls_ecp_keypair *ecp = mbedtls_pk_ec_rw(*pk);
     int ret;
 
     if (params->tag != 0 || params->len != 0) {
         return MBEDTLS_ERR_PK_KEY_INVALID_FORMAT;
     }
 
+#if defined(MBEDTLS_PK_USE_PSA_EC_DATA)
+    ret = pk_update_psa_ecparams(pk, grp_id);
+#else
+    mbedtls_ecp_keypair *ecp = mbedtls_pk_ec_rw(*pk);
     ret = mbedtls_ecp_group_load(&(ecp->grp), grp_id);
     if (ret != 0) {
         return ret;
     }
-
-#if defined(MBEDTLS_PK_USE_PSA_EC_DATA)
-    ret = pk_update_psa_ecparams(pk, grp_id);
-#endif /* MBEDTLS_PK_USE_PSA_EC_DATA */
+#endif
     return ret;
 }
 
@@ -624,7 +626,6 @@ static int pk_parse_key_rfc8410_der(mbedtls_pk_context *pk,
                                     unsigned char *key, size_t keylen, const unsigned char *end,
                                     int (*f_rng)(void *, unsigned char *, size_t), void *p_rng)
 {
-    mbedtls_ecp_keypair *eck = mbedtls_pk_ec_rw(*pk);
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     size_t len;
 
@@ -636,23 +637,54 @@ static int pk_parse_key_rfc8410_der(mbedtls_pk_context *pk,
         return MBEDTLS_ERR_PK_KEY_INVALID_FORMAT;
     }
 
+#if defined(MBEDTLS_PK_USE_PSA_EC_DATA)
+    psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
+    psa_status_t status;
+
+    psa_set_key_type(&attributes, PSA_KEY_TYPE_ECC_KEY_PAIR(pk->ec_family));
+    /* Setting largest masks for usage and key algorithms */
+    psa_set_key_usage_flags(&attributes, PSA_KEY_USAGE_SIGN_HASH |
+                            PSA_KEY_USAGE_SIGN_MESSAGE |
+                            PSA_KEY_USAGE_EXPORT);
+#if defined(MBEDTLS_ECDSA_DETERMINISTIC)
+    psa_set_key_algorithm(&attributes,
+                          PSA_ALG_DETERMINISTIC_ECDSA(PSA_ALG_ANY_HASH));
+#else
+    psa_set_key_algorithm(&attributes, PSA_ALG_ECDSA(PSA_ALG_ANY_HASH));
+#endif
+
+    status = psa_import_key(&attributes, key, len, &pk->priv_id);
+    if (status != PSA_SUCCESS) {
+        ret = psa_pk_status_to_mbedtls(status);
+        return ret;
+    }
+#else /* MBEDTLS_PK_USE_PSA_EC_DATA */
+    mbedtls_ecp_keypair *eck = mbedtls_pk_ec_rw(*pk);
+
     if ((ret = mbedtls_mpi_read_binary_le(&eck->d, key, len)) != 0) {
         mbedtls_ecp_keypair_free(eck);
         return MBEDTLS_ERROR_ADD(MBEDTLS_ERR_PK_KEY_INVALID_FORMAT, ret);
     }
+#endif /* MBEDTLS_PK_USE_PSA_EC_DATA */
 
     /* pk_parse_key_pkcs8_unencrypted_der() only supports version 1 PKCS8 keys,
      * which never contain a public key. As such, derive the public key
      * unconditionally. */
     if ((ret = pk_derive_public_key(pk, key, len, f_rng, p_rng)) != 0) {
+#if !defined(MBEDTLS_PK_USE_PSA_EC_DATA)
         mbedtls_ecp_keypair_free(eck);
+#endif /* !MBEDTLS_PK_USE_PSA_EC_DATA */
         return ret;
     }
 
+    /* When MBEDTLS_PK_USE_PSA_EC_DATA the key is checked while importing it
+     * into PSA. */
+#if !defined(MBEDTLS_PK_USE_PSA_EC_DATA)
     if ((ret = mbedtls_ecp_check_privkey(&eck->grp, &eck->d)) != 0) {
         mbedtls_ecp_keypair_free(eck);
         return ret;
     }
+#endif /* !MBEDTLS_PK_USE_PSA_EC_DATA */
 
     return 0;
 }
@@ -926,7 +958,7 @@ int mbedtls_pk_parse_subpubkey(unsigned char **p, const unsigned char *end,
 #if defined(MBEDTLS_ECP_LIGHT)
     if (pk_alg == MBEDTLS_PK_ECKEY_DH || pk_alg == MBEDTLS_PK_ECKEY) {
 #if defined(MBEDTLS_PK_HAVE_RFC8410_CURVES)
-        if (mbedtls_pk_is_rfc8410_curve(ec_grp_id)) {
+        if (MBEDTLS_PK_IS_RFC8410_GROUP_ID(ec_grp_id)) {
             ret = pk_use_ecparams_rfc8410(&alg_params, ec_grp_id, pk);
         } else
 #endif
@@ -1158,6 +1190,12 @@ static int pk_parse_key_sec1_der(mbedtls_pk_context *pk,
     unsigned char *end = p + keylen;
     unsigned char *end2;
     mbedtls_ecp_keypair *eck = mbedtls_pk_ec_rw(*pk);
+#if defined(MBEDTLS_PK_USE_PSA_EC_DATA)
+    psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
+    psa_status_t status;
+    uint8_t priv_key_raw[MBEDTLS_PSA_MAX_EC_KEY_PAIR_LENGTH];
+    size_t priv_key_len;
+#endif /* MBEDTLS_PK_USE_PSA_EC_DATA */
 
     /*
      * RFC 5915, or SEC1 Appendix C.4
@@ -1190,10 +1228,19 @@ static int pk_parse_key_sec1_der(mbedtls_pk_context *pk,
 
     d = p;
     d_len = len;
+
+#if defined(MBEDTLS_PK_USE_PSA_EC_DATA)
+    if (len > MBEDTLS_PSA_MAX_EC_KEY_PAIR_LENGTH) {
+        return MBEDTLS_ERR_PK_BAD_INPUT_DATA;
+    }
+    memcpy(priv_key_raw, p, len);
+    priv_key_len = len;
+#else
     if ((ret = mbedtls_mpi_read_binary(&eck->d, p, len)) != 0) {
         mbedtls_ecp_keypair_free(eck);
         return MBEDTLS_ERROR_ADD(MBEDTLS_ERR_PK_KEY_INVALID_FORMAT, ret);
     }
+#endif
 
     p += len;
 
@@ -1252,6 +1299,27 @@ static int pk_parse_key_sec1_der(mbedtls_pk_context *pk,
         }
     }
 
+#if defined(MBEDTLS_PK_USE_PSA_EC_DATA)
+    psa_set_key_type(&attributes, PSA_KEY_TYPE_ECC_KEY_PAIR(pk->ec_family));
+    /* Setting largest masks for usage and key algorithms */
+    psa_set_key_usage_flags(&attributes, PSA_KEY_USAGE_SIGN_HASH |
+                            PSA_KEY_USAGE_SIGN_MESSAGE |
+                            PSA_KEY_USAGE_EXPORT);
+#if defined(MBEDTLS_ECDSA_DETERMINISTIC)
+    psa_set_key_algorithm(&attributes,
+                          PSA_ALG_DETERMINISTIC_ECDSA(PSA_ALG_ANY_HASH));
+#else
+    psa_set_key_algorithm(&attributes, PSA_ALG_ECDSA(PSA_ALG_ANY_HASH));
+#endif
+
+    status = psa_import_key(&attributes, priv_key_raw, priv_key_len,
+                            &pk->priv_id);
+    if (status != PSA_SUCCESS) {
+        ret = psa_pk_status_to_mbedtls(status);
+        return ret;
+    }
+#endif /* MBEDTLS_PK_USE_PSA_EC_DATA */
+
     if (!pubkey_done) {
         if ((ret = pk_derive_public_key(pk, d, d_len, f_rng, p_rng)) != 0) {
             mbedtls_ecp_keypair_free(eck);
@@ -1259,10 +1327,12 @@ static int pk_parse_key_sec1_der(mbedtls_pk_context *pk,
         }
     }
 
+#if !defined(MBEDTLS_PK_USE_PSA_EC_DATA)
     if ((ret = mbedtls_ecp_check_privkey(&eck->grp, &eck->d)) != 0) {
         mbedtls_ecp_keypair_free(eck);
         return ret;
     }
+#endif /* !MBEDTLS_PK_USE_PSA_EC_DATA */
 
     return 0;
 }
@@ -1363,7 +1433,7 @@ static int pk_parse_key_pkcs8_unencrypted_der(
 #if defined(MBEDTLS_ECP_LIGHT)
     if (pk_alg == MBEDTLS_PK_ECKEY || pk_alg == MBEDTLS_PK_ECKEY_DH) {
 #if defined(MBEDTLS_PK_HAVE_RFC8410_CURVES)
-        if (mbedtls_pk_is_rfc8410_curve(ec_grp_id)) {
+        if (MBEDTLS_PK_IS_RFC8410_GROUP_ID(ec_grp_id)) {
             if ((ret =
                      pk_use_ecparams_rfc8410(&params, ec_grp_id, pk)) != 0 ||
                 (ret =

--- a/library/pkwrite.c
+++ b/library/pkwrite.c
@@ -57,6 +57,26 @@
 #endif
 #include "mbedtls/platform.h"
 
+/* Helper for Montgomery curves */
+#if defined(MBEDTLS_ECP_LIGHT) && defined(MBEDTLS_PK_HAVE_RFC8410_CURVES)
+static inline int mbedtls_pk_is_rfc8410(const mbedtls_pk_context *pk)
+{
+    mbedtls_ecp_group_id id = mbedtls_pk_get_group_id(pk);
+
+#if defined(MBEDTLS_ECP_DP_CURVE25519_ENABLED)
+    if (id == MBEDTLS_ECP_DP_CURVE25519) {
+        return 1;
+    }
+#endif
+#if defined(MBEDTLS_ECP_DP_CURVE448_ENABLED)
+    if (id == MBEDTLS_ECP_DP_CURVE448) {
+        return 1;
+    }
+#endif
+    return 0;
+}
+#endif /* MBEDTLS_ECP_LIGHT && MBEDTLS_PK_HAVE_RFC8410_CURVES */
+
 #if defined(MBEDTLS_RSA_C)
 /*
  *  RSAPublicKey ::= SEQUENCE {

--- a/library/pkwrite.c
+++ b/library/pkwrite.c
@@ -185,20 +185,33 @@ static int pk_write_ec_param(unsigned char **p, unsigned char *start,
  * privateKey  OCTET STRING -- always of length ceil(log2(n)/8)
  */
 static int pk_write_ec_private(unsigned char **p, unsigned char *start,
-                               mbedtls_ecp_keypair *ec)
+                               const mbedtls_pk_context *pk)
 {
+    size_t byte_length;
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
-    size_t byte_length = (ec->grp.pbits + 7) / 8;
+
+#if defined(MBEDTLS_PK_USE_PSA_EC_DATA)
+    unsigned char tmp[MBEDTLS_PSA_MAX_EC_KEY_PAIR_LENGTH];
+    psa_status_t status;
+
+    status = psa_export_key(pk->priv_id, tmp, sizeof(tmp), &byte_length);
+    if (status != PSA_SUCCESS) {
+        ret = PSA_PK_ECDSA_TO_MBEDTLS_ERR(status);
+        goto exit;
+    }
+#else /* MBEDTLS_PK_USE_PSA_EC_DATA */
     unsigned char tmp[MBEDTLS_ECP_MAX_BYTES];
+    mbedtls_ecp_keypair *ec = mbedtls_pk_ec_rw(*pk);
+    byte_length = (ec->grp.pbits + 7) / 8;
 
     ret = mbedtls_ecp_write_key(ec, tmp, byte_length);
     if (ret != 0) {
         goto exit;
     }
+#endif /* MBEDTLS_PK_USE_PSA_EC_DATA */
     ret = mbedtls_asn1_write_octet_string(p, start, tmp, byte_length);
-
 exit:
-    mbedtls_platform_zeroize(tmp, byte_length);
+    mbedtls_platform_zeroize(tmp, sizeof(tmp));
     return ret;
 }
 #endif /* MBEDTLS_ECP_LIGHT */
@@ -280,7 +293,11 @@ int mbedtls_pk_write_pubkey_der(const mbedtls_pk_context *key, unsigned char *bu
     pk_type = mbedtls_pk_get_type(key);
 #if defined(MBEDTLS_ECP_LIGHT)
     if (pk_type == MBEDTLS_PK_ECKEY) {
+#if defined(MBEDTLS_ECP_C)
         ec_grp_id = mbedtls_pk_ec_ro(*key)->grp.id;
+#else /* MBEDTLS_ECP_C */
+        ec_grp_id = mbedtls_ecc_group_of_psa(key->ec_family, key->ec_bits, 0);
+#endif /* MBEDTLS_ECP_C */
     }
 #endif /* MBEDTLS_ECP_LIGHT */
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
@@ -372,7 +389,7 @@ int mbedtls_pk_write_pubkey_der(const mbedtls_pk_context *key, unsigned char *bu
  * CurvePrivateKey ::= OCTET STRING
  */
 static int pk_write_ec_rfc8410_der(unsigned char **p, unsigned char *buf,
-                                   mbedtls_ecp_keypair *ec)
+                                   const mbedtls_pk_context *pk)
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     size_t len = 0;
@@ -380,14 +397,23 @@ static int pk_write_ec_rfc8410_der(unsigned char **p, unsigned char *buf,
     const char *oid;
 
     /* privateKey */
-    MBEDTLS_ASN1_CHK_ADD(len, pk_write_ec_private(p, buf, ec));
+    MBEDTLS_ASN1_CHK_ADD(len, pk_write_ec_private(p, buf, pk));
     MBEDTLS_ASN1_CHK_ADD(len, mbedtls_asn1_write_len(p, buf, len));
     MBEDTLS_ASN1_CHK_ADD(len, mbedtls_asn1_write_tag(p, buf, MBEDTLS_ASN1_OCTET_STRING));
 
     /* privateKeyAlgorithm */
+#if defined(MBEDTLS_PK_USE_PSA_EC_DATA)
+    mbedtls_ecp_group_id grp_id = mbedtls_ecc_group_of_psa(pk->ec_family,
+                                                           pk->ec_bits, 0);
+    if ((ret = mbedtls_oid_get_oid_by_ec_grp_algid(grp_id, &oid, &oid_len)) != 0) {
+        return ret;
+    }
+#else /* MBEDTLS_PK_USE_PSA_EC_DATA */
+    mbedtls_ecp_keypair *ec = mbedtls_pk_ec_rw(*pk);
     if ((ret = mbedtls_oid_get_oid_by_ec_grp_algid(ec->grp.id, &oid, &oid_len)) != 0) {
         return ret;
     }
+#endif /* MBEDTLS_PK_USE_PSA_EC_DATA */
     MBEDTLS_ASN1_CHK_ADD(len,
                          mbedtls_asn1_write_algorithm_identifier_ext(p, buf, oid, oid_len, 0, 0));
 
@@ -408,6 +434,9 @@ int mbedtls_pk_write_key_der(const mbedtls_pk_context *key, unsigned char *buf, 
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     unsigned char *c;
     size_t len = 0;
+#if defined(MBEDTLS_ECP_LIGHT)
+    mbedtls_ecp_group_id grp_id;
+#endif
 
     if (size == 0) {
         return MBEDTLS_ERR_ASN1_BUF_TOO_SMALL;
@@ -503,12 +532,11 @@ end_of_export:
 #endif /* MBEDTLS_RSA_C */
 #if defined(MBEDTLS_ECP_LIGHT)
     if (mbedtls_pk_get_type(key) == MBEDTLS_PK_ECKEY) {
-        mbedtls_ecp_keypair *ec = mbedtls_pk_ec_rw(*key);
         size_t pub_len = 0, par_len = 0;
 
 #if defined(MBEDTLS_PK_HAVE_RFC8410_CURVES)
-        if (mbedtls_pk_is_rfc8410_curve(ec->grp.id)) {
-            return pk_write_ec_rfc8410_der(&c, buf, ec);
+        if (mbedtls_pk_is_rfc8410(key)) {
+            return pk_write_ec_rfc8410_der(&c, buf, key);
         }
 #endif
 
@@ -542,7 +570,8 @@ end_of_export:
         len += pub_len;
 
         /* parameters */
-        MBEDTLS_ASN1_CHK_ADD(par_len, pk_write_ec_param(&c, buf, ec->grp.id));
+        grp_id = mbedtls_pk_get_group_id(key);
+        MBEDTLS_ASN1_CHK_ADD(par_len, pk_write_ec_param(&c, buf, grp_id));
 
         MBEDTLS_ASN1_CHK_ADD(par_len, mbedtls_asn1_write_len(&c, buf, par_len));
         MBEDTLS_ASN1_CHK_ADD(par_len, mbedtls_asn1_write_tag(&c, buf,
@@ -551,7 +580,7 @@ end_of_export:
         len += par_len;
 
         /* privateKey */
-        MBEDTLS_ASN1_CHK_ADD(len, pk_write_ec_private(&c, buf, ec));
+        MBEDTLS_ASN1_CHK_ADD(len, pk_write_ec_private(&c, buf, key));
 
         /* version */
         MBEDTLS_ASN1_CHK_ADD(len, mbedtls_asn1_write_int(&c, buf, 1));
@@ -625,7 +654,7 @@ int mbedtls_pk_write_key_pem(const mbedtls_pk_context *key, unsigned char *buf, 
 #if defined(MBEDTLS_ECP_LIGHT)
     if (mbedtls_pk_get_type(key) == MBEDTLS_PK_ECKEY) {
 #if defined(MBEDTLS_PK_HAVE_RFC8410_CURVES)
-        if (mbedtls_pk_is_rfc8410_curve(mbedtls_pk_ec_ro(*key)->grp.id)) {
+        if (mbedtls_pk_is_rfc8410(key)) {
             begin = PEM_BEGIN_PRIVATE_KEY_PKCS8;
             end = PEM_END_PRIVATE_KEY_PKCS8;
         } else

--- a/library/pkwrite.c
+++ b/library/pkwrite.c
@@ -404,15 +404,9 @@ static int pk_write_ec_rfc8410_der(unsigned char **p, unsigned char *buf,
 
     grp_id = mbedtls_pk_get_group_id(pk);
     /* privateKeyAlgorithm */
-#if defined(MBEDTLS_PK_USE_PSA_EC_DATA)
     if ((ret = mbedtls_oid_get_oid_by_ec_grp_algid(grp_id, &oid, &oid_len)) != 0) {
         return ret;
     }
-#else /* MBEDTLS_PK_USE_PSA_EC_DATA */
-    if ((ret = mbedtls_oid_get_oid_by_ec_grp_algid(grp_id, &oid, &oid_len)) != 0) {
-        return ret;
-    }
-#endif /* MBEDTLS_PK_USE_PSA_EC_DATA */
     MBEDTLS_ASN1_CHK_ADD(len,
                          mbedtls_asn1_write_algorithm_identifier_ext(p, buf, oid, oid_len, 0, 0));
 

--- a/library/pkwrite.c
+++ b/library/pkwrite.c
@@ -395,22 +395,21 @@ static int pk_write_ec_rfc8410_der(unsigned char **p, unsigned char *buf,
     size_t len = 0;
     size_t oid_len = 0;
     const char *oid;
+    mbedtls_ecp_group_id grp_id;
 
     /* privateKey */
     MBEDTLS_ASN1_CHK_ADD(len, pk_write_ec_private(p, buf, pk));
     MBEDTLS_ASN1_CHK_ADD(len, mbedtls_asn1_write_len(p, buf, len));
     MBEDTLS_ASN1_CHK_ADD(len, mbedtls_asn1_write_tag(p, buf, MBEDTLS_ASN1_OCTET_STRING));
 
+    grp_id = mbedtls_pk_get_group_id(pk);
     /* privateKeyAlgorithm */
 #if defined(MBEDTLS_PK_USE_PSA_EC_DATA)
-    mbedtls_ecp_group_id grp_id = mbedtls_ecc_group_of_psa(pk->ec_family,
-                                                           pk->ec_bits, 0);
     if ((ret = mbedtls_oid_get_oid_by_ec_grp_algid(grp_id, &oid, &oid_len)) != 0) {
         return ret;
     }
 #else /* MBEDTLS_PK_USE_PSA_EC_DATA */
-    mbedtls_ecp_keypair *ec = mbedtls_pk_ec_rw(*pk);
-    if ((ret = mbedtls_oid_get_oid_by_ec_grp_algid(ec->grp.id, &oid, &oid_len)) != 0) {
+    if ((ret = mbedtls_oid_get_oid_by_ec_grp_algid(grp_id, &oid, &oid_len)) != 0) {
         return ret;
     }
 #endif /* MBEDTLS_PK_USE_PSA_EC_DATA */

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -7388,17 +7388,11 @@ static int ssl_parse_certificate_verify(mbedtls_ssl_context *ssl,
             /* and in the unlikely case the above assumption no longer holds
              * we are making sure that pk_ec() here does not return a NULL
              */
-            mbedtls_ecp_group_id grp_id;
-#if defined(MBEDTLS_PK_USE_PSA_EC_DATA)
-            grp_id = mbedtls_ecc_group_of_psa(pk->ec_family, pk->ec_bits, 0);
-#else /* MBEDTLS_PK_USE_PSA_EC_DATA */
-            const mbedtls_ecp_keypair *ec = mbedtls_pk_ec_ro(*pk);
-            if (ec == NULL) {
-                MBEDTLS_SSL_DEBUG_MSG(1, ("mbedtls_pk_ec_ro() returned NULL"));
+            mbedtls_ecp_group_id grp_id = mbedtls_pk_get_group_id(pk);
+            if (grp_id == MBEDTLS_ECP_DP_NONE) {
+                MBEDTLS_SSL_DEBUG_MSG(1, ("invalid group ID"));
                 return MBEDTLS_ERR_SSL_INTERNAL_ERROR;
             }
-            grp_id = ec->grp.id;
-#endif /* MBEDTLS_PK_USE_PSA_EC_DATA */
             if (mbedtls_ssl_check_curve(ssl, grp_id) != 0) {
                 ssl->session_negotiate->verify_result |=
                     MBEDTLS_X509_BADCERT_BAD_KEY;

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -2600,7 +2600,10 @@ static int ssl_get_ecdh_params_from_cert(mbedtls_ssl_context *ssl)
     psa_ecc_family_t ecc_family;
     size_t key_len;
     mbedtls_pk_context *pk;
+    mbedtls_ecp_group_id grp_id;
+#if !defined(MBEDTLS_PK_USE_PSA_EC_DATA)
     mbedtls_ecp_keypair *key;
+#endif /* !MBEDTLS_PK_USE_PSA_EC_DATA */
 
     pk = mbedtls_ssl_own_key(ssl);
 
@@ -2636,12 +2639,16 @@ static int ssl_get_ecdh_params_from_cert(mbedtls_ssl_context *ssl)
         case MBEDTLS_PK_ECKEY:
         case MBEDTLS_PK_ECKEY_DH:
         case MBEDTLS_PK_ECDSA:
+#if defined(MBEDTLS_PK_USE_PSA_EC_DATA)
+            grp_id = mbedtls_ecc_group_of_psa(pk->ec_family, pk->ec_bits, 0);
+#else /* MBEDTLS_PK_USE_PSA_EC_DATA */
             key = mbedtls_pk_ec_rw(*pk);
             if (key == NULL) {
                 return MBEDTLS_ERR_ECP_BAD_INPUT_DATA;
             }
-
-            tls_id = mbedtls_ssl_get_tls_id_from_ecp_group_id(key->grp.id);
+            grp_id = key->grp.id;
+#endif /* MBEDTLS_PK_USE_PSA_EC_DATA */
+            tls_id = mbedtls_ssl_get_tls_id_from_ecp_group_id(grp_id);
             if (tls_id == 0) {
                 /* This elliptic curve is not supported */
                 return MBEDTLS_ERR_SSL_HANDSHAKE_FAILURE;
@@ -2661,11 +2668,19 @@ static int ssl_get_ecdh_params_from_cert(mbedtls_ssl_context *ssl)
                              PSA_KEY_TYPE_ECC_KEY_PAIR(ssl->handshake->ecdh_psa_type));
             psa_set_key_bits(&key_attributes, ssl->handshake->ecdh_bits);
 
+#if defined(MBEDTLS_PK_USE_PSA_EC_DATA)
+            status = psa_export_key(pk->priv_id, buf, sizeof(buf), &key_len);
+            if (status != PSA_SUCCESS) {
+                ret = PSA_TO_MBEDTLS_ERR(status);
+                goto cleanup;
+            }
+#else /* MBEDTLS_PK_USE_PSA_EC_DATA */
             key_len = PSA_BITS_TO_BYTES(key->grp.pbits);
             ret = mbedtls_ecp_write_key(key, buf, key_len);
             if (ret != 0) {
                 goto cleanup;
             }
+#endif /* MBEDTLS_PK_USE_PSA_EC_DATA */
 
             status = psa_import_key(&key_attributes, buf, key_len,
                                     &ssl->handshake->ecdh_psa_privkey);

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -238,7 +238,7 @@ static int x509_profile_check_key(const mbedtls_x509_crt_profile *profile,
     if (pk_alg == MBEDTLS_PK_ECDSA ||
         pk_alg == MBEDTLS_PK_ECKEY ||
         pk_alg == MBEDTLS_PK_ECKEY_DH) {
-        const mbedtls_ecp_group_id gid = mbedtls_pk_ec_ro(*pk)->grp.id;
+        const mbedtls_ecp_group_id gid = mbedtls_pk_get_group_id(pk);
 
         if (gid == MBEDTLS_ECP_DP_NONE) {
             return -1;

--- a/tests/scripts/analyze_outcomes.py
+++ b/tests/scripts/analyze_outcomes.py
@@ -247,7 +247,21 @@ TASKS = {
                     'ECP test vectors secp256r1 rfc 5114',
                     'ECP test vectors secp384r1 rfc 5114',
                     'ECP test vectors secp521r1 rfc 5114',
-                ]
+                ],
+                'test_suite_pkparse': [
+                    # This is a known difference for Montgomery curves: in
+                    # reference component private keys are parsed using
+                    # mbedtls_mpi_read_binary_le(), while in driver version they
+                    # they are imported in PSA and there the parsing is done
+                    # through mbedtls_ecp_read_key(). Unfortunately the latter
+                    # fixes the errors which are intentionally set on the parsed
+                    # key and therefore the following test case is not failing
+                    # as expected.
+                    # This cause the following test to be guarded by ECP_C and
+                    # not being executed on the driver version.
+                    ('Key ASN1 (OneAsymmetricKey X25519, doesn\'t match masking '
+                     'requirements, from RFC8410 Appendix A but made into version 0)'),
+                ],
             }
         }
     },

--- a/tests/suites/test_suite_ecp.function
+++ b/tests/suites/test_suite_ecp.function
@@ -1086,7 +1086,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_TEST_HOOKS:MBEDTLS_ECP_MONTGOMERY_ENABLED:MBBEDTLS_ECP_C */
+/* BEGIN_CASE depends_on:MBEDTLS_TEST_HOOKS:MBEDTLS_ECP_MONTGOMERY_ENABLED:MBEDTLS_ECP_LIGHT */
 void genkey_mx_known_answer(int bits, data_t *seed, data_t *expected)
 {
     mbedtls_test_rnd_buf_info rnd_info;

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -29,13 +29,9 @@
 static int pk_genkey_ec(mbedtls_pk_context *pk, mbedtls_ecp_group_id grp_id)
 {
     psa_status_t status;
-    mbedtls_ecp_keypair *eck = mbedtls_pk_ec_rw(*pk);
     psa_key_attributes_t key_attr = PSA_KEY_ATTRIBUTES_INIT;
-    mbedtls_svc_key_id_t key_id = MBEDTLS_SVC_KEY_ID_INIT;
     size_t curve_bits;
     psa_ecc_family_t curve = mbedtls_ecc_group_to_psa(grp_id, &curve_bits);
-    unsigned char key_buf[MBEDTLS_PSA_MAX_EC_PUBKEY_LENGTH];
-    size_t key_len;
     int ret;
 
     if (curve == 0) {
@@ -44,25 +40,21 @@ static int pk_genkey_ec(mbedtls_pk_context *pk, mbedtls_ecp_group_id grp_id)
 
     psa_set_key_type(&key_attr, PSA_KEY_TYPE_ECC_KEY_PAIR(curve));
     psa_set_key_bits(&key_attr, curve_bits);
-    psa_set_key_usage_flags(&key_attr, PSA_KEY_USAGE_EXPORT);
+    psa_set_key_usage_flags(&key_attr, PSA_KEY_USAGE_EXPORT |
+                            PSA_KEY_USAGE_SIGN_HASH |
+                            PSA_KEY_USAGE_SIGN_MESSAGE);
+#if defined(MBEDTLS_ECDSA_DETERMINISTIC)
+    psa_set_key_algorithm(&key_attr, PSA_ALG_DETERMINISTIC_ECDSA(PSA_ALG_ANY_HASH));
+#else
+    psa_set_key_algorithm(&key_attr, PSA_ALG_ECDSA(PSA_ALG_ANY_HASH));
+#endif
 
-    status = psa_generate_key(&key_attr, &key_id);
+    status = psa_generate_key(&key_attr, &pk->priv_id);
     if (status != PSA_SUCCESS) {
         return MBEDTLS_ERR_PK_FEATURE_UNAVAILABLE;
     }
 
-    status = psa_export_key(key_id, key_buf, sizeof(key_buf), &key_len);
-    if (status != PSA_SUCCESS) {
-        ret = MBEDTLS_ERR_PK_FEATURE_UNAVAILABLE;
-        goto exit;
-    }
-
-    ret = mbedtls_mpi_read_binary(&eck->d, key_buf, key_len);
-    if (ret != 0) {
-        goto exit;
-    }
-
-    status = psa_export_public_key(key_id, pk->pub_raw, sizeof(pk->pub_raw),
+    status = psa_export_public_key(pk->priv_id, pk->pub_raw, sizeof(pk->pub_raw),
                                    &pk->pub_raw_len);
     if (status != PSA_SUCCESS) {
         ret = MBEDTLS_ERR_PK_FEATURE_UNAVAILABLE;
@@ -72,15 +64,10 @@ static int pk_genkey_ec(mbedtls_pk_context *pk, mbedtls_ecp_group_id grp_id)
     pk->ec_family = curve;
     pk->ec_bits = curve_bits;
 
-    status = psa_destroy_key(key_id);
-    if (status != PSA_SUCCESS) {
-        return psa_pk_status_to_mbedtls(status);
-    }
-
     return 0;
 
 exit:
-    status = psa_destroy_key(key_id);
+    status = psa_destroy_key(pk->priv_id);
     return (ret != 0) ? ret : psa_pk_status_to_mbedtls(status);
 }
 #endif /* MBEDTLS_PK_USE_PSA_EC_DATA */
@@ -114,10 +101,16 @@ static int pk_genkey(mbedtls_pk_context *pk, int parameter)
         mbedtls_pk_get_type(pk) == MBEDTLS_PK_ECDSA) {
         int ret;
 
+#if defined(MBEDTLS_ECP_C)
         ret = mbedtls_ecp_group_load(&mbedtls_pk_ec_rw(*pk)->grp, parameter);
         if (ret != 0) {
             return ret;
         }
+        return mbedtls_ecp_gen_keypair(&mbedtls_pk_ec_rw(*pk)->grp,
+                                       &mbedtls_pk_ec_rw(*pk)->d,
+                                       &mbedtls_pk_ec_rw(*pk)->Q,
+                                       mbedtls_test_rnd_std_rand, NULL);
+#endif /* MBEDTLS_ECP_C */
 
 #if defined(MBEDTLS_PK_USE_PSA_EC_DATA)
         mbedtls_ecp_group grp;
@@ -136,12 +129,6 @@ static int pk_genkey(mbedtls_pk_context *pk, int parameter)
 
         return 0;
 #endif /* MBEDTLS_PK_USE_PSA_EC_DATA */
-#if defined(MBEDTLS_ECP_C)
-        return mbedtls_ecp_gen_keypair(&mbedtls_pk_ec_rw(*pk)->grp,
-                                       &mbedtls_pk_ec_rw(*pk)->d,
-                                       &mbedtls_pk_ec_rw(*pk)->Q,
-                                       mbedtls_test_rnd_std_rand, NULL);
-#endif /* MBEDTLS_ECP_C */
 
     }
 #endif /* MBEDTLS_ECP_LIGHT */

--- a/tests/suites/test_suite_pkparse.data
+++ b/tests/suites/test_suite_pkparse.data
@@ -1197,7 +1197,7 @@ depends_on:MBEDTLS_ECP_LIGHT
 pk_parse_key:"30070201010400a000":MBEDTLS_ERR_PK_KEY_INVALID_FORMAT
 
 Key ASN1 (OneAsymmetricKey X25519, doesn't match masking requirements, from RFC8410 Appendix A but made into version 0)
-depends_on:MBEDTLS_ECP_LIGHT
+depends_on:MBEDTLS_ECP_C
 pk_parse_key:"302e020100300506032b656e04220420f8ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff3f":MBEDTLS_ERR_PK_KEY_INVALID_FORMAT
 
 Key ASN1 (OneAsymmetricKey X25519, with invalid optional AlgorithIdentifier parameters)

--- a/tests/suites/test_suite_pkparse.function
+++ b/tests/suites/test_suite_pkparse.function
@@ -117,10 +117,13 @@ void pk_parse_keyfile_ec(char *key_file, char *password, int result)
     TEST_ASSERT(res == result);
 
     if (res == 0) {
-        const mbedtls_ecp_keypair *eckey;
         TEST_ASSERT(mbedtls_pk_can_do(&ctx, MBEDTLS_PK_ECKEY));
-        eckey = mbedtls_pk_ec_ro(ctx);
+#if defined(MBEDTLS_ECP_C)
+        const mbedtls_ecp_keypair *eckey = mbedtls_pk_ec_ro(ctx);
         TEST_ASSERT(mbedtls_ecp_check_privkey(&eckey->grp, &eckey->d) == 0);
+#else
+        /* PSA keys are already checked on import so nothing to do here. */
+#endif
     }
 
 exit:


### PR DESCRIPTION
The goal of this PR is to continue the work started with #7202 (related issue #7073) allowing to get rid of the `ecp_keypair` structure also for the public key. However, differently from #7202, in this case the content of the public key is not kept in clear in `pk_context` structure, but it is instead imported into PSA and only its ID is kept.

~Depends on #7554~
Resolves #7074

## Gatekeeper checklist

- [ ] **changelog** not provided - will be added in #7452
- [ ] **backport** not required: it is a new feature
- [ ] **tests** not required: using already existing tests