### PR TITLE
Test fixes for big-endian

### DIFF
--- a/tests/suites/test_suite_alignment.function
+++ b/tests/suites/test_suite_alignment.function
@@ -12,7 +12,7 @@
  */
 int parse_hex_string(char *hex_string, uint64_t *result)
 {
-    uint8_t raw[8] = {0};
+    uint8_t raw[8] = { 0 };
     size_t olen;
     if (mbedtls_test_unhexify(raw, sizeof(raw), hex_string, &olen) != 0) {
         return 0;

--- a/tests/suites/test_suite_alignment.function
+++ b/tests/suites/test_suite_alignment.function
@@ -18,19 +18,9 @@ int parse_hex_string(char *hex_string, uint64_t *result)
         return 0;
     }
 
-    /* If < 8 bytes, shift right and pad with leading zeros for big-endian */
-    if (MBEDTLS_IS_BIG_ENDIAN && olen < 8) {
-        memmove(raw + 8 - olen, raw, olen);
-        memset(raw, 0, 8 - olen);
-    }
-
     *result = 0;
     for (size_t i = 0; i < olen; i++) {
-        if (MBEDTLS_IS_BIG_ENDIAN) {
-            *result |= ((uint64_t) raw[i]) << (i * 8);
-        } else {
-            *result |= ((uint64_t) raw[i]) << ((olen - i - 1) * 8);
-        }
+        *result |= ((uint64_t) raw[i]) << ((olen - i - 1) * 8);
     }
     return 1;
 }

--- a/tests/suites/test_suite_alignment.function
+++ b/tests/suites/test_suite_alignment.function
@@ -20,13 +20,8 @@ int parse_hex_string(char *hex_string, uint64_t *result)
 
     /* If < 8 bytes, shift right and pad with leading zeros for big-endian */
     if (MBEDTLS_IS_BIG_ENDIAN && olen < 8) {
-        int offset = 8 - olen;
-        for (int i = olen - 1; i >= 0; i--) {
-            raw[i + offset] = raw[i];
-        }
-        for (int i = 0; i < offset; i++) {
-            raw[i] = 0;
-        }
+        memmove(raw + 8 - olen, raw, olen);
+        memset(raw, 0, 8 - olen);
     }
 
     *result = 0;

--- a/tests/suites/test_suite_alignment.function
+++ b/tests/suites/test_suite_alignment.function
@@ -19,15 +19,13 @@ int parse_hex_string(char *hex_string, uint64_t *result)
     }
 
     /* If < 8 bytes, shift right and pad with leading zeros for big-endian */
-    if (MBEDTLS_IS_BIG_ENDIAN) {
-        if (olen < 8) {
-            int offset = 8 - olen;
-            for (int i = olen - 1; i >= 0; i--) {
-                raw[i + offset] = raw[i];
-            }
-            for (int i = 0; i < offset; i++) {
-                raw[i] = 0;
-            }
+    if (MBEDTLS_IS_BIG_ENDIAN && olen < 8) {
+        int offset = 8 - olen;
+        for (int i = olen - 1; i >= 0; i--) {
+            raw[i + offset] = raw[i];
+        }
+        for (int i = 0; i < offset; i++) {
+            raw[i] = 0;
         }
     }
 
@@ -73,13 +71,8 @@ void mbedtls_unaligned_access(int size, int offset)
 
     /* Define expected result by manually aligning the raw bytes, and
      * reading back with a normal pointer access. */
-    uint64_t raw_aligned = 0;
-    uint8_t *e8 = (uint8_t *) &raw_aligned;
-    uint8_t *r8 = ((uint8_t *) &raw) + offset;
-    /* Make aligned copy */
-    for (int i = 0; i < size / 8; i++) {
-        e8[i] = r8[i];
-    }
+    uint64_t raw_aligned;
+    memcpy(&raw_aligned, ((uint8_t*)&raw) + offset, size / 8);
     /* Make a 16/32/64 byte read from the aligned location, and copy to expected */
     uint64_t expected = 0;
     switch (size) {
@@ -98,7 +91,7 @@ void mbedtls_unaligned_access(int size, int offset)
 
     TEST_EQUAL(r, expected);
 
-    /* Write sentinel to the part of the array we will testing writing to */
+    /* Write sentinel to the part of the array we will test writing to */
     for (size_t i = 0; i < (size_t) (size / 8); i++) {
         x[i + offset] = 0xff;
     }
@@ -319,7 +312,7 @@ void unaligned_access_endian_aware(int size, int offset, int big_endian)
     /* Verify read */
     TEST_EQUAL(read, expected);
 
-    /* Test writing back to memory. First write sentiel */
+    /* Test writing back to memory. First write sentinel */
     for (size_t i = 0; i < (size_t) (size / 8); i++) {
         x[i + offset] = 0xff;
     }

--- a/tests/suites/test_suite_alignment.function
+++ b/tests/suites/test_suite_alignment.function
@@ -71,21 +71,21 @@ void mbedtls_unaligned_access(int size, int offset)
 
     /* Define expected result by manually aligning the raw bytes, and
      * reading back with a normal pointer access. */
-    uint64_t raw_aligned;
-    memcpy(&raw_aligned, ((uint8_t*)&raw) + offset, size / 8);
+    uint64_t raw_aligned_64;
+    uint16_t *raw_aligned_16 = (uint16_t *) &raw_aligned_64;
+    uint32_t *raw_aligned_32 = (uint32_t *) &raw_aligned_64;
+    memcpy(&raw_aligned_64, ((uint8_t *) &raw) + offset, size / 8);
     /* Make a 16/32/64 byte read from the aligned location, and copy to expected */
     uint64_t expected = 0;
     switch (size) {
         case 16:
-            uint16_t *e16 = (uint16_t *) &raw_aligned;
-            expected = *e16;
+            expected = *raw_aligned_16;
             break;
         case 32:
-            uint32_t *e32 = (uint32_t *) &raw_aligned;
-            expected = *e32;
+            expected = *raw_aligned_32;
             break;
         case 64:
-            expected = raw_aligned;
+            expected = raw_aligned_64;
             break;
     }
 

--- a/tests/suites/test_suite_alignment.function
+++ b/tests/suites/test_suite_alignment.function
@@ -12,7 +12,7 @@
  */
 int parse_hex_string(char *hex_string, uint64_t *result)
 {
-    uint8_t raw[8];
+    uint8_t raw[8] = {0};
     size_t olen;
     if (mbedtls_test_unhexify(raw, sizeof(raw), hex_string, &olen) != 0) {
         return 0;
@@ -104,7 +104,7 @@ void mbedtls_unaligned_access(int size, int offset)
 /* BEGIN_CASE */
 void mbedtls_byteswap(char *input_str, int size, char *expected_str)
 {
-    uint64_t input, expected;
+    uint64_t input = 0, expected = 0;
     TEST_ASSERT(parse_hex_string(input_str, &input));
     TEST_ASSERT(parse_hex_string(expected_str, &expected));
 

--- a/tests/suites/test_suite_alignment.function
+++ b/tests/suites/test_suite_alignment.function
@@ -17,6 +17,20 @@ int parse_hex_string(char *hex_string, uint64_t *result)
     if (mbedtls_test_unhexify(raw, sizeof(raw), hex_string, &olen) != 0) {
         return 0;
     }
+
+    /* If < 8 bytes, shift right and pad with leading zeros for big-endian */
+    if (MBEDTLS_IS_BIG_ENDIAN) {
+        if (olen < 8) {
+            int offset = 8 - olen;
+            for (int i = olen - 1; i >= 0; i--) {
+                raw[i + offset] = raw[i];
+            }
+            for (int i = 0; i < offset; i++) {
+                raw[i] = 0;
+            }
+        }
+    }
+
     *result = 0;
     for (size_t i = 0; i < olen; i++) {
         if (MBEDTLS_IS_BIG_ENDIAN) {
@@ -57,38 +71,28 @@ void mbedtls_unaligned_access(int size, int offset)
             break;
     }
 
-    /* Generate expected result */
-    uint64_t expected = 0;
-    for (uint8_t i = 0; i < 8; i++) {
-        uint8_t shift;
-        if (MBEDTLS_IS_BIG_ENDIAN) {
-            /*
-             * Similar to little-endian case described below, but the shift needs
-             * to be inverted
-             */
-            shift = 7 - (i * 8);
-        } else {
-            /* example for offset == 1:
-             * expected = (( 1 + 0 ) << (0 * 8)) | (( 1 + 1 ) << (1 * 8)) | (( 1 + 2 ) << (2 * 8)))
-             *          = (1 << 0) | (2 << 8) | (3 << 16) ...
-             *          = 0x0807060504030201
-             * x = { 0, 1, 2, 3, ... }
-             * ie expected is the value that would be read from x on a LE system, when
-             * byte swapping is not performed
-             */
-            shift = i * 8;
-        }
-        uint64_t b = offset + i;
-        expected |= b << shift;
+    /* Define expected result by manually aligning the raw bytes, and
+     * reading back with a normal pointer access. */
+    uint64_t raw_aligned = 0;
+    uint8_t *e8 = (uint8_t *) &raw_aligned;
+    uint8_t *r8 = ((uint8_t *) &raw) + offset;
+    /* Make aligned copy */
+    for (int i = 0; i < size / 8; i++) {
+        e8[i] = r8[i];
     }
-
-    /* Mask out excess bits from expected result */
+    /* Make a 16/32/64 byte read from the aligned location, and copy to expected */
+    uint64_t expected = 0;
     switch (size) {
         case 16:
-            expected &= 0xffff;
+            uint16_t *e16 = (uint16_t *) &raw_aligned;
+            expected = *e16;
             break;
         case 32:
-            expected &= 0xffffffff;
+            uint32_t *e32 = (uint32_t *) &raw_aligned;
+            expected = *e32;
+            break;
+        case 64:
+            expected = raw_aligned;
             break;
     }
 


### PR DESCRIPTION
## Description

Improve alignment tests, which fixes big-endian failures.

Fixes #7428 

## Gatekeeper checklist

- [x] **changelog** not required
- [x] **backport** not required - not in 2.28
- [x] **tests** these are test fixes


