### PR TITLE
Update gen_prvkey_mx paras to align with comments and c code

### DIFF
--- a/library/ecp_invasive.h
+++ b/library/ecp_invasive.h
@@ -47,7 +47,7 @@
  *                  This is the bit-size of the key minus 1:
  *                  254 for Curve25519 or 447 for Curve448.
  * \param d         The randomly generated key. This is a number of size
- *                  exactly \p n_bits + 1 bits, with the least significant bits
+ *                  exactly \p high_bit + 1 bits, with the least significant bits
  *                  masked as specified in [Curve25519] and in [RFC7748] §5.
  * \param f_rng     The RNG function.
  * \param p_rng     The RNG context to be passed to \p f_rng.
@@ -55,7 +55,7 @@
  * \return          \c 0 on success.
  * \return          \c MBEDTLS_ERR_ECP_xxx or MBEDTLS_ERR_MPI_xxx on failure.
  */
-int mbedtls_ecp_gen_privkey_mx(size_t n_bits,
+int mbedtls_ecp_gen_privkey_mx(size_t high_bit,
                                mbedtls_mpi *d,
                                int (*f_rng)(void *, unsigned char *, size_t),
                                void *p_rng);


### PR DESCRIPTION
## Description

The prototype of function mbedtls_ecp_gen_privkey_mx() doesn't allign with the implementation and the comments.
Update it to align with exist comments.

## Gatekeeper checklist

- [x] **changelog** not required - change in documentation only
- [x] **backport** required https://github.com/Mbed-TLS/mbedtls/pull/7470
- [x] **tests** not required - change in documentation only
