### PR TITLE
Fixing USE_PSA_INIT/DONE in SSL/X509/PK test suites

### DIFF
--- a/docs/use-psa-crypto.md
+++ b/docs/use-psa-crypto.md
@@ -13,7 +13,8 @@ General considerations
 
 **Application code:** when this option is enabled, you need to call
 `psa_crypto_init()` before calling any function from the SSL/TLS, X.509 or PK
-module.
+modules, except for the various mbedtls_xxx_init() functions which can be called
+at any time.
 
 **Why enable this option:** to fully take advantage of PSA drivers in PK,
 X.509 and TLS. For example, enabling this option is what allows use of drivers

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -1931,7 +1931,8 @@
  * break backwards compatibility.
  *
  * \warning If you enable this option, you need to call `psa_crypto_init()`
- * before calling any function from the SSL/TLS, X.509 or PK modules.
+ * before calling any function from the SSL/TLS, X.509 or PK modules, except
+ * for the various mbedtls_xxx_init() functions which can be called at any time.
  *
  * \note An important and desirable effect of this option is that it allows
  * PK, X.509 and TLS to take advantage of PSA drivers. For example, enabling

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -216,7 +216,7 @@ void pk_psa_utils(int key_is_rsa)
     size_t len;
     mbedtls_pk_debug_item dbg;
 
-    PSA_ASSERT(psa_crypto_init());
+    USE_PSA_INIT();
 
     mbedtls_pk_init(&pk);
     mbedtls_pk_init(&pk2);
@@ -314,7 +314,7 @@ void pk_can_do_ext(int opaque_key, int key_type, int key_usage, int key_alg,
     mbedtls_svc_key_id_t key = MBEDTLS_SVC_KEY_ID_INIT;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
 
-    PSA_ASSERT(psa_crypto_init());
+    USE_PSA_INIT();
 
     mbedtls_pk_init(&pk);
 
@@ -361,6 +361,8 @@ void pk_invalid_param()
     unsigned char buf[] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06 };
     size_t buf_size = sizeof(buf);
 
+    USE_PSA_INIT();
+
     mbedtls_pk_init(&ctx);
 
     TEST_EQUAL(MBEDTLS_ERR_PK_BAD_INPUT_DATA,
@@ -397,6 +399,7 @@ void pk_invalid_param()
                                            NULL));
 exit:
     mbedtls_pk_free(&ctx);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -408,6 +411,7 @@ void valid_parameters()
     size_t len;
     void *options = NULL;
 
+    USE_PSA_INIT();
     mbedtls_pk_init(&pk);
 
     TEST_ASSERT(mbedtls_pk_setup(&pk, NULL) ==
@@ -484,6 +488,7 @@ void valid_parameters()
     TEST_ASSERT(mbedtls_pk_parse_public_key(&pk, NULL, 0) ==
                 MBEDTLS_ERR_PK_KEY_INVALID_FORMAT);
 #endif /* MBEDTLS_PK_PARSE_C */
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -492,6 +497,7 @@ void valid_parameters_pkwrite(data_t *key_data)
 {
     mbedtls_pk_context pk;
 
+    USE_PSA_INIT();
     /* For the write tests to be effective, we need a valid key pair. */
     mbedtls_pk_init(&pk);
     TEST_ASSERT(mbedtls_pk_parse_key(&pk,
@@ -514,6 +520,7 @@ void valid_parameters_pkwrite(data_t *key_data)
 
 exit:
     mbedtls_pk_free(&pk);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -701,8 +708,8 @@ void pk_ec_test_vec(int type, int id, data_t *key, data_t *hash,
     mbedtls_pk_context pk;
     mbedtls_ecp_keypair *eckey;
 
-    mbedtls_pk_init(&pk);
     USE_PSA_INIT();
+    mbedtls_pk_init(&pk);
 
     TEST_ASSERT(mbedtls_pk_setup(&pk, mbedtls_pk_info_from_type(type)) == 0);
 
@@ -830,8 +837,8 @@ void pk_sign_verify(int type, int parameter, int sign_ret, int verify_ret)
     mbedtls_ecp_set_max_ops(42000);
 #endif
 
-    mbedtls_pk_init(&pk);
     MD_OR_USE_PSA_INIT();
+    mbedtls_pk_init(&pk);
 
     memset(hash, 0x2a, sizeof(hash));
     memset(sig, 0, sizeof(sig));
@@ -912,14 +919,14 @@ void pk_rsa_encrypt_decrypt_test(data_t *message, int mod,
     mbedtls_pk_context pk;
     size_t olen, rlen;
 
+    USE_PSA_INIT();
+
     mbedtls_pk_init(&pk);
     mbedtls_mpi_init(&N); mbedtls_mpi_init(&P);
     mbedtls_mpi_init(&Q); mbedtls_mpi_init(&E);
 
     memset(&rnd_info,  0, sizeof(mbedtls_test_rnd_pseudo_info));
     memset(output,     0, sizeof(output));
-
-    USE_PSA_INIT();
 
     /* encryption test */
 
@@ -1106,6 +1113,7 @@ void pk_ec_nocrypt(int type)
     size_t olen = 0;
     int ret = MBEDTLS_ERR_PK_TYPE_MISMATCH;
 
+    USE_PSA_INIT();
     mbedtls_pk_init(&pk);
 
     memset(&rnd_info,  0, sizeof(mbedtls_test_rnd_pseudo_info));
@@ -1124,6 +1132,7 @@ void pk_ec_nocrypt(int type)
 
 exit:
     mbedtls_pk_free(&pk);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -1134,6 +1143,7 @@ void pk_rsa_overflow()
     size_t hash_len = SIZE_MAX, sig_len = SIZE_MAX;
     unsigned char hash[50], sig[100];
 
+    USE_PSA_INIT();
     memset(hash, 0x2a, sizeof(hash));
     memset(sig, 0, sizeof(sig));
 
@@ -1158,6 +1168,7 @@ void pk_rsa_overflow()
 
 exit:
     mbedtls_pk_free(&pk);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -1274,7 +1285,7 @@ void pk_psa_sign(int parameter_arg,
      * - parse it to a PK context and verify the signature this way
      */
 
-    PSA_ASSERT(psa_crypto_init());
+    USE_PSA_INIT();
 
 #if defined(MBEDTLS_RSA_C) && defined(MBEDTLS_GENPRIME)
     if (PSA_KEY_TYPE_IS_RSA(psa_type_arg)) {
@@ -1413,8 +1424,8 @@ void pk_psa_sign_ext(int pk_type, int parameter, int key_pk_type, int md_alg)
     memset(hash, 0x2a, sizeof(hash));
     memset(sig, 0, sizeof(sig));
 
-    mbedtls_pk_init(&pk);
     PSA_INIT();
+    mbedtls_pk_init(&pk);
 
     TEST_ASSERT(mbedtls_pk_setup(&pk,
                                  mbedtls_pk_info_from_type(pk_type)) == 0);
@@ -1434,8 +1445,8 @@ void pk_psa_sign_ext(int pk_type, int parameter, int key_pk_type, int md_alg)
     TEST_ASSERT(mbedtls_pk_verify_ext(key_pk_type, options, &pk, md_alg,
                                       hash, hash_len, sig, sig_len) == 0);
 exit:
-    PSA_DONE();
     mbedtls_pk_free(&pk);
+    PSA_DONE();
 }
 /* END_CASE */
 
@@ -1457,8 +1468,8 @@ void pk_psa_wrap_sign_ext(int pk_type, int parameter, int key_pk_type, int md_al
     mbedtls_pk_rsassa_pss_options rsassa_pss_options;
     int ret;
 
-    mbedtls_pk_init(&pk);
     PSA_INIT();
+    mbedtls_pk_init(&pk);
 
     /* Create legacy RSA public/private key in PK context. */
     mbedtls_pk_init(&pk);

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -1131,7 +1131,7 @@ exit:
 void pk_rsa_overflow()
 {
     mbedtls_pk_context pk;
-    size_t hash_len = SIZE_MAX, sig_len = SIZE_MAX;
+    size_t hash_len = UINT_MAX + 1, sig_len = UINT_MAX + 1;
     unsigned char hash[50], sig[100];
 
     mbedtls_pk_init(&pk);

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -216,10 +216,9 @@ void pk_psa_utils(int key_is_rsa)
     size_t len;
     mbedtls_pk_debug_item dbg;
 
-    USE_PSA_INIT();
-
     mbedtls_pk_init(&pk);
     mbedtls_pk_init(&pk2);
+    USE_PSA_INIT();
 
     TEST_ASSERT(psa_crypto_init() == PSA_SUCCESS);
 
@@ -314,9 +313,8 @@ void pk_can_do_ext(int opaque_key, int key_type, int key_usage, int key_alg,
     mbedtls_svc_key_id_t key = MBEDTLS_SVC_KEY_ID_INIT;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
 
-    USE_PSA_INIT();
-
     mbedtls_pk_init(&pk);
+    USE_PSA_INIT();
 
     if (opaque_key == 1) {
         psa_set_key_usage_flags(&attributes, key_usage);
@@ -361,9 +359,8 @@ void pk_invalid_param()
     unsigned char buf[] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06 };
     size_t buf_size = sizeof(buf);
 
-    USE_PSA_INIT();
-
     mbedtls_pk_init(&ctx);
+    USE_PSA_INIT();
 
     TEST_EQUAL(MBEDTLS_ERR_PK_BAD_INPUT_DATA,
                mbedtls_pk_verify_restartable(&ctx, MBEDTLS_MD_NONE,
@@ -411,8 +408,8 @@ void valid_parameters()
     size_t len;
     void *options = NULL;
 
-    USE_PSA_INIT();
     mbedtls_pk_init(&pk);
+    USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_pk_setup(&pk, NULL) ==
                 MBEDTLS_ERR_PK_BAD_INPUT_DATA);
@@ -497,9 +494,10 @@ void valid_parameters_pkwrite(data_t *key_data)
 {
     mbedtls_pk_context pk;
 
-    USE_PSA_INIT();
     /* For the write tests to be effective, we need a valid key pair. */
     mbedtls_pk_init(&pk);
+    USE_PSA_INIT();
+
     TEST_ASSERT(mbedtls_pk_parse_key(&pk,
                                      key_data->x, key_data->len, NULL, 0,
                                      mbedtls_test_rnd_std_rand, NULL) == 0);
@@ -529,8 +527,8 @@ void pk_utils(int type, int parameter, int bitlen, int len, char *name)
 {
     mbedtls_pk_context pk;
 
-    USE_PSA_INIT();
     mbedtls_pk_init(&pk);
+    USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_pk_setup(&pk, mbedtls_pk_info_from_type(type)) == 0);
     TEST_ASSERT(pk_genkey(&pk, parameter) == 0);
@@ -552,11 +550,10 @@ void mbedtls_pk_check_pair(char *pub_file, char *prv_file, int ret)
 {
     mbedtls_pk_context pub, prv, alt;
 
-    USE_PSA_INIT();
-
     mbedtls_pk_init(&pub);
     mbedtls_pk_init(&prv);
     mbedtls_pk_init(&alt);
+    USE_PSA_INIT();
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     /* mbedtls_pk_check_pair() returns either PK or ECP error codes depending
@@ -611,10 +608,8 @@ void pk_rsa_verify_test_vec(data_t *message_str, int digest, int mod,
     mbedtls_ecp_set_max_ops(1);
 #endif
 
-    USE_PSA_INIT();
-
     mbedtls_pk_init(&pk);
-
+    USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_pk_setup(&pk, mbedtls_pk_info_from_type(MBEDTLS_PK_RSA)) == 0);
     rsa = mbedtls_pk_rsa(pk);
@@ -653,8 +648,8 @@ void pk_rsa_verify_ext_test_vec(data_t *message_str, int digest,
     void *options;
     int ret;
 
-    MD_OR_USE_PSA_INIT();
     mbedtls_pk_init(&pk);
+    MD_OR_USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_pk_setup(&pk, mbedtls_pk_info_from_type(MBEDTLS_PK_RSA)) == 0);
     rsa = mbedtls_pk_rsa(pk);
@@ -708,8 +703,8 @@ void pk_ec_test_vec(int type, int id, data_t *key, data_t *hash,
     mbedtls_pk_context pk;
     mbedtls_ecp_keypair *eckey;
 
-    USE_PSA_INIT();
     mbedtls_pk_init(&pk);
+    USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_pk_setup(&pk, mbedtls_pk_info_from_type(type)) == 0);
 
@@ -742,11 +737,11 @@ void pk_sign_verify_restart(int pk_type, int grp_id, char *d_str,
     unsigned char sig[MBEDTLS_ECDSA_MAX_LEN];
     size_t slen;
 
-    USE_PSA_INIT();
-
     mbedtls_pk_restart_init(&rs_ctx);
     mbedtls_pk_init(&prv);
     mbedtls_pk_init(&pub);
+    USE_PSA_INIT();
+
     memset(sig, 0, sizeof(sig));
 
     TEST_ASSERT(mbedtls_pk_setup(&prv, mbedtls_pk_info_from_type(pk_type)) == 0);
@@ -837,8 +832,8 @@ void pk_sign_verify(int type, int parameter, int sign_ret, int verify_ret)
     mbedtls_ecp_set_max_ops(42000);
 #endif
 
-    MD_OR_USE_PSA_INIT();
     mbedtls_pk_init(&pk);
+    MD_OR_USE_PSA_INIT();
 
     memset(hash, 0x2a, sizeof(hash));
     memset(sig, 0, sizeof(sig));
@@ -919,11 +914,10 @@ void pk_rsa_encrypt_decrypt_test(data_t *message, int mod,
     mbedtls_pk_context pk;
     size_t olen, rlen;
 
-    USE_PSA_INIT();
-
     mbedtls_pk_init(&pk);
     mbedtls_mpi_init(&N); mbedtls_mpi_init(&P);
     mbedtls_mpi_init(&Q); mbedtls_mpi_init(&E);
+    USE_PSA_INIT();
 
     memset(&rnd_info,  0, sizeof(mbedtls_test_rnd_pseudo_info));
     memset(output,     0, sizeof(output));
@@ -995,14 +989,12 @@ void pk_rsa_decrypt_test_vec(data_t *cipher, int mod,
     mbedtls_pk_context pk;
     size_t olen;
 
-    USE_PSA_INIT();
-
     mbedtls_pk_init(&pk);
     mbedtls_mpi_init(&N); mbedtls_mpi_init(&P);
     mbedtls_mpi_init(&Q); mbedtls_mpi_init(&E);
+    USE_PSA_INIT();
 
     memset(&rnd_info,  0, sizeof(mbedtls_test_rnd_pseudo_info));
-
 
     /* init pk-rsa context */
     TEST_ASSERT(mbedtls_pk_setup(&pk, mbedtls_pk_info_from_type(MBEDTLS_PK_RSA)) == 0);
@@ -1052,11 +1044,10 @@ void pk_wrap_rsa_decrypt_test_vec(data_t *cipher, int mod,
     mbedtls_svc_key_id_t key_id;
     size_t olen;
 
-    USE_PSA_INIT();
-
     mbedtls_pk_init(&pk);
     mbedtls_mpi_init(&N); mbedtls_mpi_init(&P);
     mbedtls_mpi_init(&Q); mbedtls_mpi_init(&E);
+    USE_PSA_INIT();
 
     memset(&rnd_info,  0, sizeof(mbedtls_test_rnd_pseudo_info));
 
@@ -1113,8 +1104,8 @@ void pk_ec_nocrypt(int type)
     size_t olen = 0;
     int ret = MBEDTLS_ERR_PK_TYPE_MISMATCH;
 
-    USE_PSA_INIT();
     mbedtls_pk_init(&pk);
+    USE_PSA_INIT();
 
     memset(&rnd_info,  0, sizeof(mbedtls_test_rnd_pseudo_info));
     memset(output,     0, sizeof(output));
@@ -1143,11 +1134,11 @@ void pk_rsa_overflow()
     size_t hash_len = SIZE_MAX, sig_len = SIZE_MAX;
     unsigned char hash[50], sig[100];
 
+    mbedtls_pk_init(&pk);
     USE_PSA_INIT();
+
     memset(hash, 0x2a, sizeof(hash));
     memset(sig, 0, sizeof(sig));
-
-    mbedtls_pk_init(&pk);
 
     TEST_ASSERT(mbedtls_pk_setup(&pk,
                                  mbedtls_pk_info_from_type(MBEDTLS_PK_RSA)) == 0);
@@ -1188,10 +1179,10 @@ void pk_rsa_alt()
     size_t sig_len, ciph_len, test_len;
     int ret = MBEDTLS_ERR_PK_TYPE_MISMATCH;
 
-    USE_PSA_INIT();
-
     mbedtls_rsa_init(&raw);
-    mbedtls_pk_init(&rsa); mbedtls_pk_init(&alt);
+    mbedtls_pk_init(&rsa);
+    mbedtls_pk_init(&alt);
+    USE_PSA_INIT();
 
     memset(hash, 0x2a, sizeof(hash));
     memset(sig, 0, sizeof(sig));
@@ -1285,12 +1276,12 @@ void pk_psa_sign(int parameter_arg,
      * - parse it to a PK context and verify the signature this way
      */
 
+    mbedtls_pk_init(&pk);
     USE_PSA_INIT();
 
 #if defined(MBEDTLS_RSA_C) && defined(MBEDTLS_GENPRIME)
     if (PSA_KEY_TYPE_IS_RSA(psa_type_arg)) {
         /* Create legacy RSA public/private key in PK context. */
-        mbedtls_pk_init(&pk);
         TEST_ASSERT(mbedtls_pk_setup(&pk,
                                      mbedtls_pk_info_from_type(MBEDTLS_PK_RSA)) == 0);
         TEST_ASSERT(mbedtls_rsa_gen_key(mbedtls_pk_rsa(pk),
@@ -1304,7 +1295,6 @@ void pk_psa_sign(int parameter_arg,
         mbedtls_ecp_group_id grpid = parameter_arg;
 
         /* Create legacy EC public/private key in PK context. */
-        mbedtls_pk_init(&pk);
         TEST_ASSERT(mbedtls_pk_setup(&pk,
                                      mbedtls_pk_info_from_type(MBEDTLS_PK_ECKEY)) == 0);
         TEST_ASSERT(pk_genkey(&pk, grpid) == 0);
@@ -1424,8 +1414,8 @@ void pk_psa_sign_ext(int pk_type, int parameter, int key_pk_type, int md_alg)
     memset(hash, 0x2a, sizeof(hash));
     memset(sig, 0, sizeof(sig));
 
-    PSA_INIT();
     mbedtls_pk_init(&pk);
+    PSA_INIT();
 
     TEST_ASSERT(mbedtls_pk_setup(&pk,
                                  mbedtls_pk_info_from_type(pk_type)) == 0);
@@ -1468,8 +1458,8 @@ void pk_psa_wrap_sign_ext(int pk_type, int parameter, int key_pk_type, int md_al
     mbedtls_pk_rsassa_pss_options rsassa_pss_options;
     int ret;
 
-    PSA_INIT();
     mbedtls_pk_init(&pk);
+    PSA_INIT();
 
     /* Create legacy RSA public/private key in PK context. */
     mbedtls_pk_init(&pk);

--- a/tests/suites/test_suite_pkparse.function
+++ b/tests/suites/test_suite_pkparse.function
@@ -17,9 +17,8 @@ void pk_parse_keyfile_rsa(char *key_file, char *password, int result)
     int res;
     char *pwd = password;
 
-    MD_PSA_INIT();
-
     mbedtls_pk_init(&ctx);
+    MD_PSA_INIT();
 
     if (strcmp(pwd, "NULL") == 0) {
         pwd = NULL;
@@ -50,9 +49,8 @@ void pk_parse_public_keyfile_rsa(char *key_file, int result)
     mbedtls_pk_context ctx;
     int res;
 
-    MD_PSA_INIT();
-
     mbedtls_pk_init(&ctx);
+    MD_PSA_INIT();
 
     res = mbedtls_pk_parse_public_keyfile(&ctx, key_file);
 
@@ -78,6 +76,7 @@ void pk_parse_public_keyfile_ec(char *key_file, int result)
     int res;
 
     mbedtls_pk_init(&ctx);
+    USE_PSA_INIT();
 
     res = mbedtls_pk_parse_public_keyfile(&ctx, key_file);
 
@@ -92,6 +91,7 @@ void pk_parse_public_keyfile_ec(char *key_file, int result)
 
 exit:
     mbedtls_pk_free(&ctx);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -101,8 +101,8 @@ void pk_parse_keyfile_ec(char *key_file, char *password, int result)
     mbedtls_pk_context ctx;
     int res;
 
-    USE_PSA_INIT();
     mbedtls_pk_init(&ctx);
+    USE_PSA_INIT();
 
     res = mbedtls_pk_parse_keyfile(&ctx, key_file, password,
                                    mbedtls_test_rnd_std_rand, NULL);
@@ -128,11 +128,13 @@ void pk_parse_key(data_t *buf, int result)
     mbedtls_pk_context pk;
 
     mbedtls_pk_init(&pk);
+    USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_pk_parse_key(&pk, buf->x, buf->len, NULL, 0,
                                      mbedtls_test_rnd_std_rand, NULL) == result);
 
 exit:
     mbedtls_pk_free(&pk);
+    USE_PSA_DONE();
 }
 /* END_CASE */

--- a/tests/suites/test_suite_pkwrite.function
+++ b/tests/suites/test_suite_pkwrite.function
@@ -36,6 +36,9 @@ static void pk_write_check_common(char *key_file, int is_public_key, int is_der)
     size_t buf_len, check_buf_len;
     int ret;
 
+    mbedtls_pk_init(&key);
+    USE_PSA_INIT();
+
     /* Note: if mbedtls_pk_load_file() successfully reads the file, then
        it also allocates check_buf, which should be freed on exit */
     TEST_EQUAL(mbedtls_pk_load_file(key_file, &check_buf, &check_buf_len), 0);
@@ -56,7 +59,6 @@ static void pk_write_check_common(char *key_file, int is_public_key, int is_der)
 
     ASSERT_ALLOC(buf, check_buf_len);
 
-    mbedtls_pk_init(&key);
     if (is_public_key) {
         TEST_EQUAL(mbedtls_pk_parse_public_keyfile(&key, key_file), 0);
         if (is_der) {
@@ -98,6 +100,7 @@ exit:
     mbedtls_free(buf);
     mbedtls_free(check_buf);
     mbedtls_pk_free(&key);
+    USE_PSA_DONE();
 }
 /* END_HEADER */
 

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -12,6 +12,8 @@
 #include <constant_time_internal.h>
 #include <test/constant_flow.h>
 
+#define SSL_MESSAGE_QUEUE_INIT      { NULL, 0, 0, 0 }
+
 /* END_HEADER */
 
 /* BEGIN_DEPENDENCIES
@@ -459,7 +461,7 @@ exit:
 /* BEGIN_CASE */
 void ssl_message_queue_sanity()
 {
-    mbedtls_test_ssl_message_queue queue = {NULL, 0, 0, 0};
+    mbedtls_test_ssl_message_queue queue = SSL_MESSAGE_QUEUE_INIT;
 
     USE_PSA_INIT();
     /* Trying to push/pull to an empty queue */
@@ -481,7 +483,7 @@ exit:
 /* BEGIN_CASE */
 void ssl_message_queue_basic()
 {
-    mbedtls_test_ssl_message_queue queue = {NULL, 0, 0, 0};
+    mbedtls_test_ssl_message_queue queue = SSL_MESSAGE_QUEUE_INIT;
 
     USE_PSA_INIT();
     TEST_ASSERT(mbedtls_test_ssl_message_queue_setup(&queue, 3) == 0);
@@ -510,7 +512,7 @@ exit:
 /* BEGIN_CASE */
 void ssl_message_queue_overflow_underflow()
 {
-    mbedtls_test_ssl_message_queue queue = {NULL, 0, 0, 0};
+    mbedtls_test_ssl_message_queue queue = SSL_MESSAGE_QUEUE_INIT;
 
     USE_PSA_INIT();
     TEST_ASSERT(mbedtls_test_ssl_message_queue_setup(&queue, 3) == 0);
@@ -538,7 +540,7 @@ exit:
 /* BEGIN_CASE */
 void ssl_message_queue_interleaved()
 {
-    mbedtls_test_ssl_message_queue queue = {NULL, 0, 0, 0};
+    mbedtls_test_ssl_message_queue queue = SSL_MESSAGE_QUEUE_INIT;
 
     USE_PSA_INIT();
     TEST_ASSERT(mbedtls_test_ssl_message_queue_setup(&queue, 3) == 0);
@@ -574,7 +576,7 @@ exit:
 /* BEGIN_CASE */
 void ssl_message_queue_insufficient_buffer()
 {
-    mbedtls_test_ssl_message_queue queue = {NULL, 0, 0, 0};
+    mbedtls_test_ssl_message_queue queue = SSL_MESSAGE_QUEUE_INIT;
     size_t message_len = 10;
     size_t buffer_len = 5;
 

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -27,6 +27,7 @@ void test_callback_buffer_sanity()
     unsigned char input[MSGLEN];
     unsigned char output[MSGLEN];
 
+    USE_PSA_INIT();
     memset(input, 0, sizeof(input));
 
     /* Make sure calling put and get on NULL buffer results in error. */
@@ -79,8 +80,8 @@ void test_callback_buffer_sanity()
 
 
 exit:
-
     mbedtls_test_ssl_buffer_free(&buf);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -114,6 +115,7 @@ void test_callback_buffer(int size, int put1, int put1_ret,
     size_t output_len;
     size_t i, j, written, read;
 
+    USE_PSA_INIT();
     mbedtls_test_ssl_buffer_init(&buf);
     TEST_ASSERT(mbedtls_test_ssl_buffer_setup(&buf, size) == 0);
 
@@ -189,10 +191,10 @@ void test_callback_buffer(int size, int put1, int put1_ret,
     }
 
 exit:
-
     mbedtls_free(input);
     mbedtls_free(output);
     mbedtls_test_ssl_buffer_free(&buf);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -209,6 +211,7 @@ void ssl_mock_sanity()
     unsigned char received[MSGLEN] = { 0 };
     mbedtls_test_mock_socket socket;
 
+    USE_PSA_INIT();
     mbedtls_test_mock_socket_init(&socket);
     TEST_ASSERT(mbedtls_test_mock_tcp_send_b(&socket, message, MSGLEN) < 0);
     mbedtls_test_mock_socket_close(&socket);
@@ -224,8 +227,8 @@ void ssl_mock_sanity()
     mbedtls_test_mock_socket_close(&socket);
 
 exit:
-
     mbedtls_test_mock_socket_close(&socket);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -249,6 +252,7 @@ void ssl_mock_tcp(int blocking)
     mbedtls_ssl_recv_t *recv;
     unsigned i;
 
+    USE_PSA_INIT();
     if (blocking == 0) {
         send = mbedtls_test_mock_tcp_send_nb;
         recv = mbedtls_test_mock_tcp_recv_nb;
@@ -317,9 +321,9 @@ void ssl_mock_tcp(int blocking)
     TEST_ASSERT(memcmp(message, received, MSGLEN) == 0);
 
 exit:
-
     mbedtls_test_mock_socket_close(&client);
     mbedtls_test_mock_socket_close(&server);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -347,6 +351,7 @@ void ssl_mock_tcp_interleaving(int blocking)
     mbedtls_ssl_send_t *send;
     mbedtls_ssl_recv_t *recv;
 
+    USE_PSA_INIT();
     if (blocking == 0) {
         send = mbedtls_test_mock_tcp_send_nb;
         recv = mbedtls_test_mock_tcp_recv_nb;
@@ -445,9 +450,9 @@ void ssl_mock_tcp_interleaving(int blocking)
     }
 
 exit:
-
     mbedtls_test_mock_socket_close(&client);
     mbedtls_test_mock_socket_close(&server);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -456,6 +461,7 @@ void ssl_message_queue_sanity()
 {
     mbedtls_test_ssl_message_queue queue;
 
+    USE_PSA_INIT();
     /* Trying to push/pull to an empty queue */
     TEST_ASSERT(mbedtls_test_ssl_message_queue_push_info(NULL, 1)
                 == MBEDTLS_TEST_ERROR_ARG_NULL);
@@ -468,6 +474,7 @@ void ssl_message_queue_sanity()
 
 exit:
     mbedtls_test_ssl_message_queue_free(&queue);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -476,6 +483,7 @@ void ssl_message_queue_basic()
 {
     mbedtls_test_ssl_message_queue queue;
 
+    USE_PSA_INIT();
     TEST_ASSERT(mbedtls_test_ssl_message_queue_setup(&queue, 3) == 0);
 
     /* Sanity test - 3 pushes and 3 pops with sufficient space */
@@ -495,6 +503,7 @@ void ssl_message_queue_basic()
 
 exit:
     mbedtls_test_ssl_message_queue_free(&queue);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -503,6 +512,7 @@ void ssl_message_queue_overflow_underflow()
 {
     mbedtls_test_ssl_message_queue queue;
 
+    USE_PSA_INIT();
     TEST_ASSERT(mbedtls_test_ssl_message_queue_setup(&queue, 3) == 0);
 
     /* 4 pushes (last one with an error), 4 pops (last one with an error) */
@@ -521,6 +531,7 @@ void ssl_message_queue_overflow_underflow()
 
 exit:
     mbedtls_test_ssl_message_queue_free(&queue);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -529,6 +540,7 @@ void ssl_message_queue_interleaved()
 {
     mbedtls_test_ssl_message_queue queue;
 
+    USE_PSA_INIT();
     TEST_ASSERT(mbedtls_test_ssl_message_queue_setup(&queue, 3) == 0);
 
     /* Interleaved test - [2 pushes, 1 pop] twice, and then two pops
@@ -555,6 +567,7 @@ void ssl_message_queue_interleaved()
 
 exit:
     mbedtls_test_ssl_message_queue_free(&queue);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -565,6 +578,7 @@ void ssl_message_queue_insufficient_buffer()
     size_t message_len = 10;
     size_t buffer_len = 5;
 
+    USE_PSA_INIT();
     TEST_ASSERT(mbedtls_test_ssl_message_queue_setup(&queue, 1) == 0);
 
     /* Popping without a sufficient buffer */
@@ -574,6 +588,7 @@ void ssl_message_queue_insufficient_buffer()
                 == (int) buffer_len);
 exit:
     mbedtls_test_ssl_message_queue_free(&queue);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -588,6 +603,7 @@ void ssl_message_mock_uninitialized()
     mbedtls_test_message_socket_init(&server_context);
     mbedtls_test_message_socket_init(&client_context);
 
+    USE_PSA_INIT();
     /* Send with a NULL context */
     TEST_ASSERT(mbedtls_test_mock_tcp_send_msg(NULL, message, MSGLEN)
                 == MBEDTLS_TEST_ERROR_CONTEXT_ERROR);
@@ -626,6 +642,7 @@ void ssl_message_mock_uninitialized()
 exit:
     mbedtls_test_message_socket_close(&server_context);
     mbedtls_test_message_socket_close(&client_context);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -638,6 +655,8 @@ void ssl_message_mock_basic()
     unsigned i;
     mbedtls_test_ssl_message_queue server_queue, client_queue;
     mbedtls_test_message_socket_context server_context, client_context;
+
+    USE_PSA_INIT();
     mbedtls_test_message_socket_init(&server_context);
     mbedtls_test_message_socket_init(&client_context);
 
@@ -685,6 +704,7 @@ void ssl_message_mock_basic()
 exit:
     mbedtls_test_message_socket_close(&server_context);
     mbedtls_test_message_socket_close(&client_context);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -697,6 +717,8 @@ void ssl_message_mock_queue_overflow_underflow()
     unsigned i;
     mbedtls_test_ssl_message_queue server_queue, client_queue;
     mbedtls_test_message_socket_context server_context, client_context;
+
+    USE_PSA_INIT();
     mbedtls_test_message_socket_init(&server_context);
     mbedtls_test_message_socket_init(&client_context);
 
@@ -749,6 +771,7 @@ void ssl_message_mock_queue_overflow_underflow()
 exit:
     mbedtls_test_message_socket_close(&server_context);
     mbedtls_test_message_socket_close(&client_context);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -761,6 +784,8 @@ void ssl_message_mock_socket_overflow()
     unsigned i;
     mbedtls_test_ssl_message_queue server_queue, client_queue;
     mbedtls_test_message_socket_context server_context, client_context;
+
+    USE_PSA_INIT();
     mbedtls_test_message_socket_init(&server_context);
     mbedtls_test_message_socket_init(&client_context);
 
@@ -801,6 +826,7 @@ void ssl_message_mock_socket_overflow()
 exit:
     mbedtls_test_message_socket_close(&server_context);
     mbedtls_test_message_socket_close(&client_context);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -813,6 +839,8 @@ void ssl_message_mock_truncated()
     unsigned i;
     mbedtls_test_ssl_message_queue server_queue, client_queue;
     mbedtls_test_message_socket_context server_context, client_context;
+
+    USE_PSA_INIT();
     mbedtls_test_message_socket_init(&server_context);
     mbedtls_test_message_socket_init(&client_context);
 
@@ -865,6 +893,7 @@ void ssl_message_mock_truncated()
 exit:
     mbedtls_test_message_socket_close(&server_context);
     mbedtls_test_message_socket_close(&client_context);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -877,6 +906,8 @@ void ssl_message_mock_socket_read_error()
     unsigned i;
     mbedtls_test_ssl_message_queue server_queue, client_queue;
     mbedtls_test_message_socket_context server_context, client_context;
+
+    USE_PSA_INIT();
     mbedtls_test_message_socket_init(&server_context);
     mbedtls_test_message_socket_init(&client_context);
 
@@ -923,6 +954,7 @@ void ssl_message_mock_socket_read_error()
 exit:
     mbedtls_test_message_socket_close(&server_context);
     mbedtls_test_message_socket_close(&client_context);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -935,6 +967,8 @@ void ssl_message_mock_interleaved_one_way()
     unsigned i;
     mbedtls_test_ssl_message_queue server_queue, client_queue;
     mbedtls_test_message_socket_context server_context, client_context;
+
+    USE_PSA_INIT();
     mbedtls_test_message_socket_init(&server_context);
     mbedtls_test_message_socket_init(&client_context);
 
@@ -983,6 +1017,7 @@ void ssl_message_mock_interleaved_one_way()
 exit:
     mbedtls_test_message_socket_close(&server_context);
     mbedtls_test_message_socket_close(&client_context);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -995,6 +1030,8 @@ void ssl_message_mock_interleaved_two_ways()
     unsigned i;
     mbedtls_test_ssl_message_queue server_queue, client_queue;
     mbedtls_test_message_socket_context server_context, client_context;
+
+    USE_PSA_INIT();
     mbedtls_test_message_socket_init(&server_context);
     mbedtls_test_message_socket_init(&client_context);
 
@@ -1070,6 +1107,7 @@ void ssl_message_mock_interleaved_two_ways()
 exit:
     mbedtls_test_message_socket_close(&server_context);
     mbedtls_test_message_socket_close(&client_context);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -1112,12 +1150,15 @@ exit:
 void ssl_set_hostname_twice(char *hostname0, char *hostname1)
 {
     mbedtls_ssl_context ssl;
+
+    USE_PSA_INIT();
     mbedtls_ssl_init(&ssl);
 
     TEST_ASSERT(mbedtls_ssl_set_hostname(&ssl, hostname0) == 0);
     TEST_ASSERT(mbedtls_ssl_set_hostname(&ssl, hostname1) == 0);
 
     mbedtls_ssl_free(&ssl);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -2114,7 +2155,7 @@ void ssl_serialize_session_save_load(int ticket_len, char *crt_file,
     /*
      * Test that a save-load pair is the identity
      */
-
+    USE_PSA_INIT();
     mbedtls_ssl_session_init(&original);
     mbedtls_ssl_session_init(&restored);
 
@@ -2248,6 +2289,7 @@ exit:
     mbedtls_ssl_session_free(&original);
     mbedtls_ssl_session_free(&restored);
     mbedtls_free(buf);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -2262,7 +2304,7 @@ void ssl_serialize_session_load_save(int ticket_len, char *crt_file,
     /*
      * Test that a load-save pair is the identity
      */
-
+    USE_PSA_INIT();
     mbedtls_ssl_session_init(&session);
 
     /* Prepare a dummy session to work on */
@@ -2310,6 +2352,7 @@ exit:
     mbedtls_ssl_session_free(&session);
     mbedtls_free(buf1);
     mbedtls_free(buf2);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -2324,7 +2367,7 @@ void ssl_serialize_session_save_buf_size(int ticket_len, char *crt_file,
     /*
      * Test that session_save() fails cleanly on small buffers
      */
-
+    USE_PSA_INIT();
     mbedtls_ssl_session_init(&session);
 
     /* Prepare dummy session and get serialized size */
@@ -2357,6 +2400,7 @@ void ssl_serialize_session_save_buf_size(int ticket_len, char *crt_file,
 exit:
     mbedtls_ssl_session_free(&session);
     mbedtls_free(buf);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -2371,7 +2415,7 @@ void ssl_serialize_session_load_buf_size(int ticket_len, char *crt_file,
     /*
      * Test that session_load() fails cleanly on small buffers
      */
-
+    USE_PSA_INIT();
     mbedtls_ssl_session_init(&session);
 
     /* Prepare serialized session data */
@@ -2410,6 +2454,7 @@ exit:
     mbedtls_ssl_session_free(&session);
     mbedtls_free(good_buf);
     mbedtls_free(bad_buf);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -2431,6 +2476,7 @@ void ssl_session_serialize_version_check(int corrupt_major,
                                       corrupt_config == 1,
                                       corrupt_config == 1 };
 
+    USE_PSA_INIT();
     mbedtls_ssl_session_init(&session);
     ((void) endpoint_type);
     ((void) tls_version);
@@ -2484,7 +2530,7 @@ void ssl_session_serialize_version_check(int corrupt_major,
             *byte ^= corrupted_bit;
         }
     }
-
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -2857,9 +2903,10 @@ exit:
 /* BEGIN_CASE depends_on:MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED:!MBEDTLS_SSL_PROTO_TLS1_3:MBEDTLS_PKCS1_V15:MBEDTLS_SSL_VARIABLE_BUFFER_LENGTH:MBEDTLS_SSL_CONTEXT_SERIALIZATION:MBEDTLS_SSL_PROTO_TLS1_2:MBEDTLS_RSA_C:MBEDTLS_ECP_DP_SECP384R1_ENABLED:MBEDTLS_SSL_PROTO_DTLS:MBEDTLS_MD_CAN_SHA256:MBEDTLS_CAN_HANDLE_RSA_TEST_KEY */
 void resize_buffers_serialize_mfl(int mfl)
 {
+    USE_PSA_INIT();
     test_resize_buffers(mfl, 0, MBEDTLS_SSL_LEGACY_NO_RENEGOTIATION, 1, 1,
                         (char *) "");
-
+    USE_PSA_DONE();
     /* The goto below is used to avoid an "unused label" warning.*/
     goto exit;
 }
@@ -2869,8 +2916,9 @@ void resize_buffers_serialize_mfl(int mfl)
 void resize_buffers_renegotiate_mfl(int mfl, int legacy_renegotiation,
                                     char *cipher)
 {
+    USE_PSA_INIT();
     test_resize_buffers(mfl, 1, legacy_renegotiation, 0, 1, cipher);
-
+    USE_PSA_DONE();
     /* The goto below is used to avoid an "unused label" warning.*/
     goto exit;
 }
@@ -3179,6 +3227,7 @@ void cookie_parsing(data_t *cookie, int exp_ret)
     mbedtls_ssl_config conf;
     size_t len;
 
+    USE_PSA_INIT();
     mbedtls_ssl_init(&ssl);
     mbedtls_ssl_config_init(&conf);
     TEST_EQUAL(mbedtls_ssl_config_defaults(&conf, MBEDTLS_SSL_IS_SERVER,
@@ -3197,6 +3246,7 @@ void cookie_parsing(data_t *cookie, int exp_ret)
 
     mbedtls_ssl_free(&ssl);
     mbedtls_ssl_config_free(&conf);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -3205,9 +3255,11 @@ void timing_final_delay_accessor()
 {
     mbedtls_timing_delay_context    delay_context;
 
+    USE_PSA_INIT();
     mbedtls_timing_set_delay(&delay_context, 50, 100);
 
     TEST_ASSERT(mbedtls_timing_get_final_delay(&delay_context) == 100);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -115,8 +115,8 @@ void test_callback_buffer(int size, int put1, int put1_ret,
     size_t output_len;
     size_t i, j, written, read;
 
-    USE_PSA_INIT();
     mbedtls_test_ssl_buffer_init(&buf);
+    USE_PSA_INIT();
     TEST_ASSERT(mbedtls_test_ssl_buffer_setup(&buf, size) == 0);
 
     /* Check the sanity of input parameters and initialise local variables. That
@@ -211,8 +211,8 @@ void ssl_mock_sanity()
     unsigned char received[MSGLEN] = { 0 };
     mbedtls_test_mock_socket socket;
 
-    USE_PSA_INIT();
     mbedtls_test_mock_socket_init(&socket);
+    USE_PSA_INIT();
     TEST_ASSERT(mbedtls_test_mock_tcp_send_b(&socket, message, MSGLEN) < 0);
     mbedtls_test_mock_socket_close(&socket);
     mbedtls_test_mock_socket_init(&socket);
@@ -252,7 +252,6 @@ void ssl_mock_tcp(int blocking)
     mbedtls_ssl_recv_t *recv;
     unsigned i;
 
-    USE_PSA_INIT();
     if (blocking == 0) {
         send = mbedtls_test_mock_tcp_send_nb;
         recv = mbedtls_test_mock_tcp_recv_nb;
@@ -263,6 +262,7 @@ void ssl_mock_tcp(int blocking)
 
     mbedtls_test_mock_socket_init(&client);
     mbedtls_test_mock_socket_init(&server);
+    USE_PSA_INIT();
 
     /* Fill up the buffer with structured data so that unwanted changes
      * can be detected */
@@ -351,7 +351,6 @@ void ssl_mock_tcp_interleaving(int blocking)
     mbedtls_ssl_send_t *send;
     mbedtls_ssl_recv_t *recv;
 
-    USE_PSA_INIT();
     if (blocking == 0) {
         send = mbedtls_test_mock_tcp_send_nb;
         recv = mbedtls_test_mock_tcp_recv_nb;
@@ -362,6 +361,7 @@ void ssl_mock_tcp_interleaving(int blocking)
 
     mbedtls_test_mock_socket_init(&client);
     mbedtls_test_mock_socket_init(&server);
+    USE_PSA_INIT();
 
     /* Fill up the buffers with structured data so that unwanted changes
      * can be detected */
@@ -459,7 +459,7 @@ exit:
 /* BEGIN_CASE */
 void ssl_message_queue_sanity()
 {
-    mbedtls_test_ssl_message_queue queue;
+    mbedtls_test_ssl_message_queue queue = {NULL, 0, 0, 0};
 
     USE_PSA_INIT();
     /* Trying to push/pull to an empty queue */
@@ -481,7 +481,7 @@ exit:
 /* BEGIN_CASE */
 void ssl_message_queue_basic()
 {
-    mbedtls_test_ssl_message_queue queue;
+    mbedtls_test_ssl_message_queue queue = {NULL, 0, 0, 0};
 
     USE_PSA_INIT();
     TEST_ASSERT(mbedtls_test_ssl_message_queue_setup(&queue, 3) == 0);
@@ -510,7 +510,7 @@ exit:
 /* BEGIN_CASE */
 void ssl_message_queue_overflow_underflow()
 {
-    mbedtls_test_ssl_message_queue queue;
+    mbedtls_test_ssl_message_queue queue = {NULL, 0, 0, 0};
 
     USE_PSA_INIT();
     TEST_ASSERT(mbedtls_test_ssl_message_queue_setup(&queue, 3) == 0);
@@ -538,7 +538,7 @@ exit:
 /* BEGIN_CASE */
 void ssl_message_queue_interleaved()
 {
-    mbedtls_test_ssl_message_queue queue;
+    mbedtls_test_ssl_message_queue queue = {NULL, 0, 0, 0};
 
     USE_PSA_INIT();
     TEST_ASSERT(mbedtls_test_ssl_message_queue_setup(&queue, 3) == 0);
@@ -574,7 +574,7 @@ exit:
 /* BEGIN_CASE */
 void ssl_message_queue_insufficient_buffer()
 {
-    mbedtls_test_ssl_message_queue queue;
+    mbedtls_test_ssl_message_queue queue = {NULL, 0, 0, 0};
     size_t message_len = 10;
     size_t buffer_len = 5;
 
@@ -656,9 +656,9 @@ void ssl_message_mock_basic()
     mbedtls_test_ssl_message_queue server_queue, client_queue;
     mbedtls_test_message_socket_context server_context, client_context;
 
-    USE_PSA_INIT();
     mbedtls_test_message_socket_init(&server_context);
     mbedtls_test_message_socket_init(&client_context);
+    USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_test_message_socket_setup(&server_queue,
                                                   &client_queue, 1,
@@ -718,9 +718,9 @@ void ssl_message_mock_queue_overflow_underflow()
     mbedtls_test_ssl_message_queue server_queue, client_queue;
     mbedtls_test_message_socket_context server_context, client_context;
 
-    USE_PSA_INIT();
     mbedtls_test_message_socket_init(&server_context);
     mbedtls_test_message_socket_init(&client_context);
+    USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_test_message_socket_setup(&server_queue,
                                                   &client_queue, 2,
@@ -785,9 +785,9 @@ void ssl_message_mock_socket_overflow()
     mbedtls_test_ssl_message_queue server_queue, client_queue;
     mbedtls_test_message_socket_context server_context, client_context;
 
-    USE_PSA_INIT();
     mbedtls_test_message_socket_init(&server_context);
     mbedtls_test_message_socket_init(&client_context);
+    USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_test_message_socket_setup(&server_queue,
                                                   &client_queue, 2,
@@ -840,9 +840,9 @@ void ssl_message_mock_truncated()
     mbedtls_test_ssl_message_queue server_queue, client_queue;
     mbedtls_test_message_socket_context server_context, client_context;
 
-    USE_PSA_INIT();
     mbedtls_test_message_socket_init(&server_context);
     mbedtls_test_message_socket_init(&client_context);
+    USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_test_message_socket_setup(&server_queue,
                                                   &client_queue, 2,
@@ -907,9 +907,9 @@ void ssl_message_mock_socket_read_error()
     mbedtls_test_ssl_message_queue server_queue, client_queue;
     mbedtls_test_message_socket_context server_context, client_context;
 
-    USE_PSA_INIT();
     mbedtls_test_message_socket_init(&server_context);
     mbedtls_test_message_socket_init(&client_context);
+    USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_test_message_socket_setup(&server_queue,
                                                   &client_queue, 1,
@@ -968,9 +968,9 @@ void ssl_message_mock_interleaved_one_way()
     mbedtls_test_ssl_message_queue server_queue, client_queue;
     mbedtls_test_message_socket_context server_context, client_context;
 
-    USE_PSA_INIT();
     mbedtls_test_message_socket_init(&server_context);
     mbedtls_test_message_socket_init(&client_context);
+    USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_test_message_socket_setup(&server_queue,
                                                   &client_queue, 3,
@@ -1031,9 +1031,9 @@ void ssl_message_mock_interleaved_two_ways()
     mbedtls_test_ssl_message_queue server_queue, client_queue;
     mbedtls_test_message_socket_context server_context, client_context;
 
-    USE_PSA_INIT();
     mbedtls_test_message_socket_init(&server_context);
     mbedtls_test_message_socket_init(&client_context);
+    USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_test_message_socket_setup(&server_queue,
                                                   &client_queue, 3,
@@ -2019,8 +2019,6 @@ void ssl_tls13_record_protection(int ciphersuite,
     size_t buf_len;
     int other_endpoint;
 
-    MD_OR_USE_PSA_INIT();
-
     TEST_ASSERT(endpoint == MBEDTLS_SSL_IS_CLIENT ||
                 endpoint == MBEDTLS_SSL_IS_SERVER);
 
@@ -2048,6 +2046,7 @@ void ssl_tls13_record_protection(int ciphersuite,
 
     mbedtls_ssl_transform_init(&transform_recv);
     mbedtls_ssl_transform_init(&transform_send);
+    MD_OR_USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_ssl_tls13_populate_transform(
                     &transform_send, endpoint,
@@ -2701,15 +2700,10 @@ exit:
 /* BEGIN_CASE depends_on:MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED:MBEDTLS_PKCS1_V15:MBEDTLS_SSL_PROTO_TLS1_2:MBEDTLS_MD_CAN_SHA256 */
 void handshake_cipher(char *cipher, int pk_alg, int dtls)
 {
-    MD_OR_USE_PSA_INIT();
-
     test_handshake_psk_cipher(cipher, pk_alg, NULL, dtls);
 
     /* The goto below is used to avoid an "unused label" warning.*/
     goto exit;
-
-exit:
-    MD_OR_USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -2779,15 +2773,10 @@ void app_data_tls(int mfl, int cli_msg_len, int srv_msg_len,
                   int expected_cli_fragments,
                   int expected_srv_fragments)
 {
-    MD_OR_USE_PSA_INIT();
-
     test_app_data(mfl, cli_msg_len, srv_msg_len, expected_cli_fragments,
                   expected_srv_fragments, 0);
     /* The goto below is used to avoid an "unused label" warning.*/
     goto exit;
-
-exit:
-    MD_OR_USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -2796,15 +2785,10 @@ void app_data_dtls(int mfl, int cli_msg_len, int srv_msg_len,
                    int expected_cli_fragments,
                    int expected_srv_fragments)
 {
-    MD_OR_USE_PSA_INIT();
-
     test_app_data(mfl, cli_msg_len, srv_msg_len, expected_cli_fragments,
                   expected_srv_fragments, 1);
     /* The goto below is used to avoid an "unused label" warning.*/
     goto exit;
-
-exit:
-    MD_OR_USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -2915,14 +2899,10 @@ exit:
 /* BEGIN_CASE depends_on:MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED:!MBEDTLS_SSL_PROTO_TLS1_3:MBEDTLS_PKCS1_V15:MBEDTLS_SSL_VARIABLE_BUFFER_LENGTH:MBEDTLS_SSL_CONTEXT_SERIALIZATION:MBEDTLS_SSL_PROTO_TLS1_2:MBEDTLS_RSA_C:MBEDTLS_ECP_DP_SECP384R1_ENABLED:MBEDTLS_SSL_PROTO_DTLS:MBEDTLS_MD_CAN_SHA256:MBEDTLS_CAN_HANDLE_RSA_TEST_KEY */
 void resize_buffers_serialize_mfl(int mfl)
 {
-    USE_PSA_INIT();
     test_resize_buffers(mfl, 0, MBEDTLS_SSL_LEGACY_NO_RENEGOTIATION, 1, 1,
                         (char *) "");
     /* The goto below is used to avoid an "unused label" warning.*/
     goto exit;
-
-exit:
-    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -2930,13 +2910,9 @@ exit:
 void resize_buffers_renegotiate_mfl(int mfl, int legacy_renegotiation,
                                     char *cipher)
 {
-    USE_PSA_INIT();
     test_resize_buffers(mfl, 1, legacy_renegotiation, 0, 1, cipher);
     /* The goto below is used to avoid an "unused label" warning.*/
     goto exit;
-
-exit:
-    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -3181,12 +3157,12 @@ void force_bad_session_id_len()
     options.srv_log_obj = &srv_pattern;
     options.srv_log_fun = mbedtls_test_ssl_log_analyzer;
 
-    MD_OR_USE_PSA_INIT();
     mbedtls_platform_zeroize(&client, sizeof(client));
     mbedtls_platform_zeroize(&server, sizeof(server));
 
     mbedtls_test_message_socket_init(&server_context);
     mbedtls_test_message_socket_init(&client_context);
+    MD_OR_USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_test_ssl_endpoint_init(&client, MBEDTLS_SSL_IS_CLIENT,
                                                &options, NULL, NULL,

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -1118,10 +1118,9 @@ void ssl_dtls_replay(data_t *prevs, data_t *new, int ret)
     mbedtls_ssl_context ssl;
     mbedtls_ssl_config conf;
 
-    MD_OR_USE_PSA_INIT();
-
     mbedtls_ssl_init(&ssl);
     mbedtls_ssl_config_init(&conf);
+    MD_OR_USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_ssl_config_defaults(&conf,
                                             MBEDTLS_SSL_IS_CLIENT,
@@ -1151,12 +1150,13 @@ void ssl_set_hostname_twice(char *hostname0, char *hostname1)
 {
     mbedtls_ssl_context ssl;
 
-    USE_PSA_INIT();
     mbedtls_ssl_init(&ssl);
+    USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_ssl_set_hostname(&ssl, hostname0) == 0);
     TEST_ASSERT(mbedtls_ssl_set_hostname(&ssl, hostname1) == 0);
 
+exit:
     mbedtls_ssl_free(&ssl);
     USE_PSA_DONE();
 }
@@ -1182,11 +1182,11 @@ void ssl_crypt_record(int cipher_type, int hash_id,
     size_t const buflen = 512;
     mbedtls_record rec, rec_backup;
 
-    MD_OR_USE_PSA_INIT();
-
     mbedtls_ssl_init(&ssl);
     mbedtls_ssl_transform_init(&t0);
     mbedtls_ssl_transform_init(&t1);
+    MD_OR_USE_PSA_INIT();
+
     ret = mbedtls_test_ssl_build_transforms(&t0, &t1, cipher_type, hash_id,
                                             etm, tag_mode, ver,
                                             (size_t) cid0_len,
@@ -1336,11 +1336,11 @@ void ssl_crypt_record_small(int cipher_type, int hash_id,
     int seen_success; /* Indicates if in the current mode we've
                        * already seen a successful test. */
 
-    MD_OR_USE_PSA_INIT();
-
     mbedtls_ssl_init(&ssl);
     mbedtls_ssl_transform_init(&t0);
     mbedtls_ssl_transform_init(&t1);
+    MD_OR_USE_PSA_INIT();
+
     ret = mbedtls_test_ssl_build_transforms(&t0, &t1, cipher_type, hash_id,
                                             etm, tag_mode, ver,
                                             (size_t) cid0_len,
@@ -1497,11 +1497,10 @@ void ssl_decrypt_non_etm_cbc(int cipher_type, int hash_id, int trunc_hmac,
     int ret;
     const unsigned char pad_max_len = 255; /* Per the standard */
 
-    MD_OR_USE_PSA_INIT();
-
     mbedtls_ssl_init(&ssl);
     mbedtls_ssl_transform_init(&t0);
     mbedtls_ssl_transform_init(&t1);
+    MD_OR_USE_PSA_INIT();
 
     /* Set up transforms with dummy keys */
     ret = mbedtls_test_ssl_build_transforms(&t0, &t1, cipher_type, hash_id,
@@ -1726,6 +1725,7 @@ void ssl_tls13_hkdf_expand_label(int hash_alg,
     ASSERT_COMPARE(dst, (size_t) desired_length,
                    expected->x, (size_t) expected->len);
 
+exit:
     PSA_DONE();
 }
 /* END_CASE */
@@ -1779,6 +1779,7 @@ void ssl_tls13_traffic_key_generation(int hash_alg,
                    expected_server_write_iv->x,
                    (size_t) desired_iv_len);
 
+exit:
     PSA_DONE();
 }
 /* END_CASE */
@@ -1823,6 +1824,7 @@ void ssl_tls13_derive_secret(int hash_alg,
     ASSERT_COMPARE(dst, desired_length,
                    expected->x, desired_length);
 
+exit:
     PSA_DONE();
 }
 /* END_CASE */
@@ -1856,6 +1858,7 @@ void ssl_tls13_derive_early_secrets(int hash_alg,
     ASSERT_COMPARE(secrets.early_exporter_master_secret, hash_len,
                    exporter_expected->x, exporter_expected->len);
 
+exit:
     PSA_DONE();
 }
 /* END_CASE */
@@ -1889,6 +1892,7 @@ void ssl_tls13_derive_handshake_secrets(int hash_alg,
     ASSERT_COMPARE(secrets.server_handshake_traffic_secret, hash_len,
                    server_expected->x, server_expected->len);
 
+exit:
     PSA_DONE();
 }
 /* END_CASE */
@@ -1926,6 +1930,7 @@ void ssl_tls13_derive_application_secrets(int hash_alg,
     ASSERT_COMPARE(secrets.exporter_master_secret, hash_len,
                    exporter_expected->x, exporter_expected->len);
 
+exit:
     PSA_DONE();
 }
 /* END_CASE */
@@ -1955,6 +1960,7 @@ void ssl_tls13_derive_resumption_secrets(int hash_alg,
     ASSERT_COMPARE(secrets.resumption_master_secret, hash_len,
                    resumption_expected->x, resumption_expected->len);
 
+exit:
     PSA_DONE();
 }
 /* END_CASE */
@@ -1988,6 +1994,7 @@ void ssl_tls13_create_psk_binder(int hash_alg,
     ASSERT_COMPARE(binder, hash_len,
                    binder_expected->x, binder_expected->len);
 
+exit:
     PSA_DONE();
 }
 /* END_CASE */
@@ -2086,6 +2093,7 @@ void ssl_tls13_record_protection(int ciphersuite,
     ASSERT_COMPARE(rec.buf + rec.data_offset, rec.data_len,
                    plaintext->x, plaintext->len);
 
+exit:
     mbedtls_free(buf);
     mbedtls_ssl_transform_free(&transform_send);
     mbedtls_ssl_transform_free(&transform_recv);
@@ -2112,6 +2120,7 @@ void ssl_tls13_key_evolution(int hash_alg,
     ASSERT_COMPARE(secret_new, (size_t) expected->len,
                    expected->x, (size_t) expected->len);
 
+exit:
     PSA_DONE();
 }
 /* END_CASE */
@@ -2155,9 +2164,9 @@ void ssl_serialize_session_save_load(int ticket_len, char *crt_file,
     /*
      * Test that a save-load pair is the identity
      */
-    USE_PSA_INIT();
     mbedtls_ssl_session_init(&original);
     mbedtls_ssl_session_init(&restored);
+    USE_PSA_INIT();
 
     /* Prepare a dummy session to work on */
     ((void) endpoint_type);
@@ -2304,8 +2313,8 @@ void ssl_serialize_session_load_save(int ticket_len, char *crt_file,
     /*
      * Test that a load-save pair is the identity
      */
-    USE_PSA_INIT();
     mbedtls_ssl_session_init(&session);
+    USE_PSA_INIT();
 
     /* Prepare a dummy session to work on */
     ((void) endpoint_type);
@@ -2367,8 +2376,8 @@ void ssl_serialize_session_save_buf_size(int ticket_len, char *crt_file,
     /*
      * Test that session_save() fails cleanly on small buffers
      */
-    USE_PSA_INIT();
     mbedtls_ssl_session_init(&session);
+    USE_PSA_INIT();
 
     /* Prepare dummy session and get serialized size */
     ((void) endpoint_type);
@@ -2415,8 +2424,8 @@ void ssl_serialize_session_load_buf_size(int ticket_len, char *crt_file,
     /*
      * Test that session_load() fails cleanly on small buffers
      */
-    USE_PSA_INIT();
     mbedtls_ssl_session_init(&session);
+    USE_PSA_INIT();
 
     /* Prepare serialized session data */
     ((void) endpoint_type);
@@ -2476,8 +2485,8 @@ void ssl_session_serialize_version_check(int corrupt_major,
                                       corrupt_config == 1,
                                       corrupt_config == 1 };
 
-    USE_PSA_INIT();
     mbedtls_ssl_session_init(&session);
+    USE_PSA_INIT();
     ((void) endpoint_type);
     ((void) tls_version);
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
@@ -2530,6 +2539,7 @@ void ssl_session_serialize_version_check(int corrupt_major,
             *byte ^= corrupted_bit;
         }
     }
+exit:
     USE_PSA_DONE();
 }
 /* END_CASE */
@@ -2697,6 +2707,8 @@ void handshake_cipher(char *cipher, int pk_alg, int dtls)
 
     /* The goto below is used to avoid an "unused label" warning.*/
     goto exit;
+
+exit:
     MD_OR_USE_PSA_DONE();
 }
 /* END_CASE */
@@ -2906,9 +2918,11 @@ void resize_buffers_serialize_mfl(int mfl)
     USE_PSA_INIT();
     test_resize_buffers(mfl, 0, MBEDTLS_SSL_LEGACY_NO_RENEGOTIATION, 1, 1,
                         (char *) "");
-    USE_PSA_DONE();
     /* The goto below is used to avoid an "unused label" warning.*/
     goto exit;
+
+exit:
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -2918,9 +2932,11 @@ void resize_buffers_renegotiate_mfl(int mfl, int legacy_renegotiation,
 {
     USE_PSA_INIT();
     test_resize_buffers(mfl, 1, legacy_renegotiation, 0, 1, cipher);
-    USE_PSA_DONE();
     /* The goto below is used to avoid an "unused label" warning.*/
     goto exit;
+
+exit:
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -2935,8 +2951,8 @@ void test_multiple_psks()
 
     mbedtls_ssl_config conf;
 
-    MD_OR_USE_PSA_INIT();
     mbedtls_ssl_config_init(&conf);
+    MD_OR_USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_ssl_conf_psk(&conf,
                                      psk0, sizeof(psk0),
@@ -2947,9 +2963,7 @@ void test_multiple_psks()
                 MBEDTLS_ERR_SSL_FEATURE_UNAVAILABLE);
 
 exit:
-
     mbedtls_ssl_config_free(&conf);
-
     MD_OR_USE_PSA_DONE();
 }
 /* END_CASE */
@@ -2979,8 +2993,8 @@ void test_multiple_psks_opaque(int mode)
 
     mbedtls_ssl_config conf;
 
-    MD_OR_USE_PSA_INIT();
     mbedtls_ssl_config_init(&conf);
+    MD_OR_USE_PSA_INIT();
 
     switch (mode) {
         case 0:
@@ -3031,7 +3045,6 @@ void test_multiple_psks_opaque(int mode)
     }
 
 exit:
-
     mbedtls_ssl_config_free(&conf);
     MD_OR_USE_PSA_DONE();
 
@@ -3046,10 +3059,9 @@ void conf_version(int endpoint, int transport,
     mbedtls_ssl_config conf;
     mbedtls_ssl_context ssl;
 
-    MD_OR_USE_PSA_INIT();
-
     mbedtls_ssl_config_init(&conf);
     mbedtls_ssl_init(&ssl);
+    MD_OR_USE_PSA_INIT();
 
     mbedtls_ssl_conf_endpoint(&conf, endpoint);
     mbedtls_ssl_conf_transport(&conf, transport);
@@ -3090,10 +3102,10 @@ void conf_curve()
 #endif
     mbedtls_ssl_conf_curves(&conf, curve_list);
 
-    MD_OR_USE_PSA_INIT();
-
     mbedtls_ssl_context ssl;
     mbedtls_ssl_init(&ssl);
+    MD_OR_USE_PSA_INIT();
+
     TEST_ASSERT(mbedtls_ssl_setup(&ssl, &conf) == 0);
 
     TEST_ASSERT(ssl.handshake != NULL && ssl.handshake->group_list != NULL);
@@ -3106,7 +3118,6 @@ void conf_curve()
     for (size_t i = 0; i < ARRAY_LENGTH(iana_tls_group_list); i++) {
         TEST_EQUAL(iana_tls_group_list[i], ssl.handshake->group_list[i]);
     }
-
 
 exit:
     mbedtls_ssl_free(&ssl);
@@ -3131,10 +3142,10 @@ void conf_group()
 
     mbedtls_ssl_conf_groups(&conf, iana_tls_group_list);
 
-    MD_OR_USE_PSA_INIT();
-
     mbedtls_ssl_context ssl;
     mbedtls_ssl_init(&ssl);
+    MD_OR_USE_PSA_INIT();
+
     TEST_ASSERT(mbedtls_ssl_setup(&ssl, &conf) == 0);
 
     TEST_ASSERT(ssl.conf != NULL && ssl.conf->group_list != NULL);
@@ -3227,9 +3238,10 @@ void cookie_parsing(data_t *cookie, int exp_ret)
     mbedtls_ssl_config conf;
     size_t len;
 
-    USE_PSA_INIT();
     mbedtls_ssl_init(&ssl);
     mbedtls_ssl_config_init(&conf);
+    USE_PSA_INIT();
+
     TEST_EQUAL(mbedtls_ssl_config_defaults(&conf, MBEDTLS_SSL_IS_SERVER,
                                            MBEDTLS_SSL_TRANSPORT_DATAGRAM,
                                            MBEDTLS_SSL_PRESET_DEFAULT),
@@ -3244,6 +3256,7 @@ void cookie_parsing(data_t *cookie, int exp_ret)
                                                     &len),
                exp_ret);
 
+exit:
     mbedtls_ssl_free(&ssl);
     mbedtls_ssl_config_free(&conf);
     USE_PSA_DONE();
@@ -3259,6 +3272,8 @@ void timing_final_delay_accessor()
     mbedtls_timing_set_delay(&delay_context, 50, 100);
 
     TEST_ASSERT(mbedtls_timing_get_final_delay(&delay_context) == 100);
+
+exit:
     USE_PSA_DONE();
 }
 /* END_CASE */
@@ -3276,10 +3291,9 @@ void cid_sanity()
 
     mbedtls_test_rnd_std_rand(NULL, own_cid, sizeof(own_cid));
 
-    MD_OR_USE_PSA_INIT();
-
     mbedtls_ssl_init(&ssl);
     mbedtls_ssl_config_init(&conf);
+    MD_OR_USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_ssl_config_defaults(&conf,
                                             MBEDTLS_SSL_IS_CLIENT,
@@ -3435,11 +3449,12 @@ void tls13_server_certificate_msg_invalid_vector_len()
     /*
      * Test set-up
      */
-    MD_OR_USE_PSA_INIT();
     mbedtls_platform_zeroize(&client_ep, sizeof(client_ep));
     mbedtls_platform_zeroize(&server_ep, sizeof(server_ep));
 
     mbedtls_test_init_handshake_options(&client_options);
+    MD_OR_USE_PSA_INIT();
+
     client_options.pk_alg = MBEDTLS_PK_ECDSA;
     ret = mbedtls_test_ssl_endpoint_init(&client_ep, MBEDTLS_SSL_IS_CLIENT,
                                          &client_options, NULL, NULL, NULL,
@@ -3530,9 +3545,8 @@ void ssl_ecjpake_set_password(int use_opaque_arg)
     size_t pwd_len = 0;
     int ret;
 
-    MD_OR_USE_PSA_INIT();
-
     mbedtls_ssl_init(&ssl);
+    MD_OR_USE_PSA_INIT();
 
     /* test with uninitalized SSL context */
     ECJPAKE_TEST_SET_PASSWORD(MBEDTLS_ERR_SSL_BAD_INPUT_DATA);
@@ -3669,7 +3683,8 @@ void elliptic_curve_get_properties()
 #else
     TEST_UNAVAILABLE_ECC(30, MBEDTLS_ECP_DP_CURVE448, PSA_ECC_FAMILY_MONTGOMERY, 448);
 #endif
-
+    goto exit;
+exit:
     MD_OR_USE_PSA_DONE();
 }
 /* END_CASE */

--- a/tests/suites/test_suite_x509parse.function
+++ b/tests/suites/test_suite_x509parse.function
@@ -428,6 +428,7 @@ void x509_accessor_ext_types(int ext_type, int has_ext_type)
     mbedtls_x509_crt crt;
     int expected_result = ext_type & has_ext_type;
 
+    USE_PSA_INIT();
     mbedtls_x509_crt_init(&crt);
 
     crt.ext_types = ext_type;
@@ -435,6 +436,7 @@ void x509_accessor_ext_types(int ext_type, int has_ext_type)
     TEST_ASSERT(mbedtls_x509_crt_has_ext_type(&crt, has_ext_type) == expected_result);
 
     mbedtls_x509_crt_free(&crt);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -462,6 +464,7 @@ void x509_parse_san(char *crt_file, char *result_str, int parse_result)
     char *p = buf;
     size_t n = sizeof(buf);
 
+    USE_PSA_INIT();
     mbedtls_x509_crt_init(&crt);
     memset(buf, 0, 2000);
 
@@ -492,6 +495,7 @@ void x509_parse_san(char *crt_file, char *result_str, int parse_result)
 exit:
 
     mbedtls_x509_crt_free(&crt);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -502,6 +506,7 @@ void x509_cert_info(char *crt_file, char *result_str)
     char buf[2000];
     int res;
 
+    USE_PSA_INIT();
     mbedtls_x509_crt_init(&crt);
     memset(buf, 0, 2000);
 
@@ -515,6 +520,7 @@ void x509_cert_info(char *crt_file, char *result_str)
 
 exit:
     mbedtls_x509_crt_free(&crt);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -525,6 +531,7 @@ void mbedtls_x509_crl_info(char *crl_file, char *result_str)
     char buf[2000];
     int res;
 
+    USE_PSA_INIT();
     mbedtls_x509_crl_init(&crl);
     memset(buf, 0, 2000);
 
@@ -538,6 +545,7 @@ void mbedtls_x509_crl_info(char *crl_file, char *result_str)
 
 exit:
     mbedtls_x509_crl_free(&crl);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -547,6 +555,7 @@ void mbedtls_x509_crl_parse(char *crl_file, int result)
     mbedtls_x509_crl   crl;
     char buf[2000];
 
+    USE_PSA_INIT();
     mbedtls_x509_crl_init(&crl);
     memset(buf, 0, 2000);
 
@@ -554,6 +563,7 @@ void mbedtls_x509_crl_parse(char *crl_file, int result)
 
 exit:
     mbedtls_x509_crl_free(&crl);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -564,6 +574,7 @@ void mbedtls_x509_csr_info(char *csr_file, char *result_str)
     char buf[2000];
     int res;
 
+    USE_PSA_INIT();
     mbedtls_x509_csr_init(&csr);
     memset(buf, 0, 2000);
 
@@ -577,6 +588,7 @@ void mbedtls_x509_csr_info(char *csr_file, char *result_str)
 
 exit:
     mbedtls_x509_csr_free(&csr);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -586,6 +598,7 @@ void x509_verify_info(int flags, char *prefix, char *result_str)
     char buf[2000];
     int res;
 
+    USE_PSA_INIT();
     memset(buf, 0, sizeof(buf));
 
     res = mbedtls_x509_crt_verify_info(buf, sizeof(buf), prefix, flags);
@@ -593,6 +606,7 @@ void x509_verify_info(int flags, char *prefix, char *result_str)
     TEST_ASSERT(res >= 0);
 
     TEST_ASSERT(strcmp(buf, result_str) == 0);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -616,12 +630,10 @@ void x509_verify_restart(char *crt_file, char *ca_file,
      * - x509_verify() for server5 -> test-ca2:             ~ 18800
      * - x509_verify() for server10 -> int-ca3 -> int-ca2:  ~ 25500
      */
-
+    MD_OR_USE_PSA_INIT();
     mbedtls_x509_crt_restart_init(&rs_ctx);
     mbedtls_x509_crt_init(&crt);
     mbedtls_x509_crt_init(&ca);
-
-    MD_OR_USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_x509_crt_parse_file(&crt, crt_file) == 0);
     TEST_ASSERT(mbedtls_x509_crt_parse_file(&ca, ca_file) == 0);
@@ -670,11 +682,10 @@ void x509_verify(char *crt_file, char *ca_file, char *crl_file,
     char *cn_name = NULL;
     const mbedtls_x509_crt_profile *profile;
 
+    MD_OR_USE_PSA_INIT();
     mbedtls_x509_crt_init(&crt);
     mbedtls_x509_crt_init(&ca);
     mbedtls_x509_crl_init(&crl);
-
-    MD_OR_USE_PSA_INIT();
 
     if (strcmp(cn_name_str, "NULL") != 0) {
         cn_name = cn_name_str;
@@ -756,6 +767,7 @@ void x509_verify_ca_cb_failure(char *crt_file, char *ca_file, char *name,
     mbedtls_x509_crt ca;
     uint32_t flags = 0;
 
+    USE_PSA_INIT();
     mbedtls_x509_crt_init(&crt);
     mbedtls_x509_crt_init(&ca);
 
@@ -775,6 +787,7 @@ void x509_verify_ca_cb_failure(char *crt_file, char *ca_file, char *name,
 exit:
     mbedtls_x509_crt_free(&crt);
     mbedtls_x509_crt_free(&ca);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -788,11 +801,10 @@ void x509_verify_callback(char *crt_file, char *ca_file, char *name,
     uint32_t flags = 0;
     verify_print_context vrfy_ctx;
 
+    MD_OR_USE_PSA_INIT();
     mbedtls_x509_crt_init(&crt);
     mbedtls_x509_crt_init(&ca);
     verify_print_init(&vrfy_ctx);
-
-    MD_OR_USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_x509_crt_parse_file(&crt, crt_file) == 0);
     TEST_ASSERT(mbedtls_x509_crt_parse_file(&ca, ca_file) == 0);
@@ -826,6 +838,7 @@ void mbedtls_x509_dn_gets_subject_replace(char *crt_file,
     char buf[2000];
     int res = 0;
 
+    USE_PSA_INIT();
     mbedtls_x509_crt_init(&crt);
     memset(buf, 0, 2000);
 
@@ -844,6 +857,7 @@ void mbedtls_x509_dn_gets_subject_replace(char *crt_file,
     }
 exit:
     mbedtls_x509_crt_free(&crt);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -854,6 +868,7 @@ void mbedtls_x509_dn_gets(char *crt_file, char *entity, char *result_str)
     char buf[2000];
     int res = 0;
 
+    USE_PSA_INIT();
     mbedtls_x509_crt_init(&crt);
     memset(buf, 0, 2000);
 
@@ -873,6 +888,7 @@ void mbedtls_x509_dn_gets(char *crt_file, char *entity, char *result_str)
 
 exit:
     mbedtls_x509_crt_free(&crt);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -885,6 +901,7 @@ void mbedtls_x509_get_name(char *rdn_sequence, int exp_ret)
     mbedtls_x509_name head;
     int ret;
 
+    USE_PSA_INIT();
     memset(&head, 0, sizeof(head));
 
     name = mbedtls_test_unhexify_alloc(rdn_sequence, &name_len);
@@ -898,6 +915,7 @@ void mbedtls_x509_get_name(char *rdn_sequence, int exp_ret)
     TEST_EQUAL(ret, exp_ret);
 
     mbedtls_free(name);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -916,6 +934,7 @@ void mbedtls_x509_dn_get_next(char *name_str,
     unsigned char buf[80], *out = NULL, *c;
     const char *short_name;
 
+    USE_PSA_INIT();
     memset(&parsed, 0, sizeof(parsed));
     memset(buf, 0, sizeof(buf));
     c = buf + sizeof(buf);
@@ -964,6 +983,7 @@ exit:
     mbedtls_free(out);
     mbedtls_asn1_free_named_data_list(&names);
     mbedtls_asn1_free_named_data_list_shallow(parsed.next);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -972,6 +992,7 @@ void mbedtls_x509_time_is_past(char *crt_file, char *entity, int result)
 {
     mbedtls_x509_crt   crt;
 
+    USE_PSA_INIT();
     mbedtls_x509_crt_init(&crt);
 
     TEST_ASSERT(mbedtls_x509_crt_parse_file(&crt, crt_file) == 0);
@@ -986,6 +1007,7 @@ void mbedtls_x509_time_is_past(char *crt_file, char *entity, int result)
 
 exit:
     mbedtls_x509_crt_free(&crt);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -994,6 +1016,7 @@ void mbedtls_x509_time_is_future(char *crt_file, char *entity, int result)
 {
     mbedtls_x509_crt   crt;
 
+    USE_PSA_INIT();
     mbedtls_x509_crt_init(&crt);
 
     TEST_ASSERT(mbedtls_x509_crt_parse_file(&crt, crt_file) == 0);
@@ -1008,6 +1031,7 @@ void mbedtls_x509_time_is_future(char *crt_file, char *entity, int result)
 
 exit:
     mbedtls_x509_crt_free(&crt);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -1016,12 +1040,14 @@ void x509parse_crt_file(char *crt_file, int result)
 {
     mbedtls_x509_crt crt;
 
+    USE_PSA_INIT();
     mbedtls_x509_crt_init(&crt);
 
     TEST_ASSERT(mbedtls_x509_crt_parse_file(&crt, crt_file) == result);
 
 exit:
     mbedtls_x509_crt_free(&crt);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -1036,6 +1062,7 @@ void x509parse_crt(data_t *buf, char *result_str, int result)
     ((void) result_str);
 #endif
 
+    USE_PSA_INIT();
     mbedtls_x509_crt_init(&crt);
 
     TEST_ASSERT(mbedtls_x509_crt_parse_der(&crt, buf->x, buf->len) == (result));
@@ -1103,6 +1130,7 @@ void x509parse_crt(data_t *buf, char *result_str, int result)
 
 exit:
     mbedtls_x509_crt_free(&crt);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -1119,6 +1147,7 @@ void x509parse_crt_cb(data_t *buf, char *result_str, int result)
     ((void) result_str);
 #endif
 
+    USE_PSA_INIT();
     oid.tag = MBEDTLS_ASN1_OID;
     oid.len = MBEDTLS_OID_SIZE(MBEDTLS_OID_PKIX "\x01\x1F");
     oid.p = (unsigned char *) MBEDTLS_OID_PKIX "\x01\x1F";
@@ -1157,6 +1186,7 @@ void x509parse_crt_cb(data_t *buf, char *result_str, int result)
 
 exit:
     mbedtls_x509_crt_free(&crt);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -1167,6 +1197,7 @@ void x509parse_crl(data_t *buf, char *result_str, int result)
     unsigned char output[2000];
     int res;
 
+    USE_PSA_INIT();
     mbedtls_x509_crl_init(&crl);
     memset(output, 0, 2000);
 
@@ -1183,6 +1214,7 @@ void x509parse_crl(data_t *buf, char *result_str, int result)
 
 exit:
     mbedtls_x509_crl_free(&crl);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -1193,6 +1225,7 @@ void mbedtls_x509_csr_parse(data_t *csr_der, char *ref_out, int ref_ret)
     char my_out[1000];
     int my_ret;
 
+    USE_PSA_INIT();
     mbedtls_x509_csr_init(&csr);
     memset(my_out, 0, sizeof(my_out));
 
@@ -1207,6 +1240,7 @@ void mbedtls_x509_csr_parse(data_t *csr_der, char *ref_out, int ref_ret)
 
 exit:
     mbedtls_x509_csr_free(&csr);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -1217,6 +1251,7 @@ void mbedtls_x509_csr_parse_file(char *csr_file, char *ref_out, int ref_ret)
     char my_out[1000];
     int my_ret;
 
+    USE_PSA_INIT();
     mbedtls_x509_csr_init(&csr);
     memset(my_out, 0, sizeof(my_out));
 
@@ -1231,6 +1266,7 @@ void mbedtls_x509_csr_parse_file(char *csr_file, char *ref_out, int ref_ret)
 
 exit:
     mbedtls_x509_csr_free(&csr);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -1240,6 +1276,7 @@ void mbedtls_x509_crt_parse_path(char *crt_path, int ret, int nb_crt)
     mbedtls_x509_crt chain, *cur;
     int i;
 
+    USE_PSA_INIT();
     mbedtls_x509_crt_init(&chain);
 
     TEST_ASSERT(mbedtls_x509_crt_parse_path(&chain, crt_path) == ret);
@@ -1255,6 +1292,7 @@ void mbedtls_x509_crt_parse_path(char *crt_path, int ret, int nb_crt)
 
 exit:
     mbedtls_x509_crt_free(&chain);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -1271,11 +1309,9 @@ void mbedtls_x509_crt_verify_max(char *ca_file, char *chain_dir, int nb_int,
      * We expect chain_dir to contain certificates 00.crt, 01.crt, etc.
      * with NN.crt signed by NN-1.crt
      */
-
+    MD_OR_USE_PSA_INIT();
     mbedtls_x509_crt_init(&trusted);
     mbedtls_x509_crt_init(&chain);
-
-    MD_OR_USE_PSA_INIT();
 
     /* Load trusted root */
     TEST_ASSERT(mbedtls_x509_crt_parse_file(&trusted, ca_file) == 0);
@@ -1311,10 +1347,9 @@ void mbedtls_x509_crt_verify_chain(char *chain_paths, char *trusted_ca,
     mbedtls_x509_crt trusted, chain;
     const mbedtls_x509_crt_profile *profile = NULL;
 
+    MD_OR_USE_PSA_INIT();
     mbedtls_x509_crt_init(&chain);
     mbedtls_x509_crt_init(&trusted);
-
-    MD_OR_USE_PSA_INIT();
 
     while ((act = mystrsep(&chain_paths, " ")) != NULL) {
         TEST_ASSERT(mbedtls_x509_crt_parse_file(&chain, act) == 0);
@@ -1353,7 +1388,7 @@ void x509_oid_desc(data_t *buf, char *ref_desc)
     const char *desc = NULL;
     int ret;
 
-
+    USE_PSA_INIT();
     oid.tag = MBEDTLS_ASN1_OID;
     oid.p   = buf->x;
     oid.len   = buf->len;
@@ -1368,6 +1403,7 @@ void x509_oid_desc(data_t *buf, char *ref_desc)
         TEST_ASSERT(desc != NULL);
         TEST_ASSERT(strcmp(desc, ref_desc) == 0);
     }
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -1377,6 +1413,7 @@ void x509_oid_numstr(data_t *oid_buf, char *numstr, int blen, int ret)
     mbedtls_x509_buf oid;
     char num_buf[100];
 
+    USE_PSA_INIT();
     memset(num_buf, 0x2a, sizeof(num_buf));
 
     oid.tag = MBEDTLS_ASN1_OID;
@@ -1391,6 +1428,7 @@ void x509_oid_numstr(data_t *oid_buf, char *numstr, int blen, int ret)
         TEST_ASSERT(num_buf[ret] == 0);
         TEST_ASSERT(strcmp(num_buf, numstr) == 0);
     }
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -1399,6 +1437,7 @@ void x509_check_key_usage(char *crt_file, int usage, int ret)
 {
     mbedtls_x509_crt crt;
 
+    USE_PSA_INIT();
     mbedtls_x509_crt_init(&crt);
 
     TEST_ASSERT(mbedtls_x509_crt_parse_file(&crt, crt_file) == 0);
@@ -1407,6 +1446,7 @@ void x509_check_key_usage(char *crt_file, int usage, int ret)
 
 exit:
     mbedtls_x509_crt_free(&crt);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -1416,8 +1456,8 @@ void x509_check_extended_key_usage(char *crt_file, data_t *oid, int ret
 {
     mbedtls_x509_crt crt;
 
+    USE_PSA_INIT();
     mbedtls_x509_crt_init(&crt);
-
 
     TEST_ASSERT(mbedtls_x509_crt_parse_file(&crt, crt_file) == 0);
 
@@ -1426,6 +1466,7 @@ void x509_check_extended_key_usage(char *crt_file, data_t *oid, int ret
 
 exit:
     mbedtls_x509_crt_free(&crt);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -1438,6 +1479,7 @@ void x509_get_time(int tag, char *time_str, int ret, int year, int mon,
     unsigned char *start = buf;
     unsigned char *end = buf;
 
+    USE_PSA_INIT();
     memset(&time, 0x00, sizeof(time));
     *end = (unsigned char) tag; end++;
     *end = strlen(time_str);
@@ -1455,6 +1497,7 @@ void x509_get_time(int tag, char *time_str, int ret, int year, int mon,
         TEST_ASSERT(min  == time.min);
         TEST_ASSERT(sec  == time.sec);
     }
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -1467,6 +1510,8 @@ void x509_parse_rsassa_pss_params(data_t *params, int params_tag,
     mbedtls_x509_buf buf;
     mbedtls_md_type_t my_msg_md, my_mgf_md;
     int my_salt_len;
+
+    USE_PSA_INIT();
 
     buf.p = params->x;
     buf.len = params->len;
@@ -1484,6 +1529,6 @@ void x509_parse_rsassa_pss_params(data_t *params, int params_tag,
     }
 
 exit:
-    ;;
+    USE_PSA_DONE();
 }
 /* END_CASE */

--- a/tests/suites/test_suite_x509parse.function
+++ b/tests/suites/test_suite_x509parse.function
@@ -428,13 +428,14 @@ void x509_accessor_ext_types(int ext_type, int has_ext_type)
     mbedtls_x509_crt crt;
     int expected_result = ext_type & has_ext_type;
 
-    USE_PSA_INIT();
     mbedtls_x509_crt_init(&crt);
+    USE_PSA_INIT();
 
     crt.ext_types = ext_type;
 
     TEST_ASSERT(mbedtls_x509_crt_has_ext_type(&crt, has_ext_type) == expected_result);
 
+exit:
     mbedtls_x509_crt_free(&crt);
     USE_PSA_DONE();
 }
@@ -464,8 +465,8 @@ void x509_parse_san(char *crt_file, char *result_str, int parse_result)
     char *p = buf;
     size_t n = sizeof(buf);
 
-    USE_PSA_INIT();
     mbedtls_x509_crt_init(&crt);
+    USE_PSA_INIT();
     memset(buf, 0, 2000);
 
     TEST_EQUAL(mbedtls_x509_crt_parse_file(&crt, crt_file), parse_result);
@@ -493,7 +494,6 @@ void x509_parse_san(char *crt_file, char *result_str, int parse_result)
     TEST_ASSERT(strcmp(buf, result_str) == 0);
 
 exit:
-
     mbedtls_x509_crt_free(&crt);
     USE_PSA_DONE();
 }
@@ -506,8 +506,8 @@ void x509_cert_info(char *crt_file, char *result_str)
     char buf[2000];
     int res;
 
-    USE_PSA_INIT();
     mbedtls_x509_crt_init(&crt);
+    USE_PSA_INIT();
     memset(buf, 0, 2000);
 
     TEST_ASSERT(mbedtls_x509_crt_parse_file(&crt, crt_file) == 0);
@@ -531,8 +531,8 @@ void mbedtls_x509_crl_info(char *crl_file, char *result_str)
     char buf[2000];
     int res;
 
-    USE_PSA_INIT();
     mbedtls_x509_crl_init(&crl);
+    USE_PSA_INIT();
     memset(buf, 0, 2000);
 
     TEST_ASSERT(mbedtls_x509_crl_parse_file(&crl, crl_file) == 0);
@@ -555,8 +555,8 @@ void mbedtls_x509_crl_parse(char *crl_file, int result)
     mbedtls_x509_crl   crl;
     char buf[2000];
 
-    USE_PSA_INIT();
     mbedtls_x509_crl_init(&crl);
+    USE_PSA_INIT();
     memset(buf, 0, 2000);
 
     TEST_ASSERT(mbedtls_x509_crl_parse_file(&crl, crl_file) == result);
@@ -574,8 +574,8 @@ void mbedtls_x509_csr_info(char *csr_file, char *result_str)
     char buf[2000];
     int res;
 
-    USE_PSA_INIT();
     mbedtls_x509_csr_init(&csr);
+    USE_PSA_INIT();
     memset(buf, 0, 2000);
 
     TEST_ASSERT(mbedtls_x509_csr_parse_file(&csr, csr_file) == 0);
@@ -606,6 +606,8 @@ void x509_verify_info(int flags, char *prefix, char *result_str)
     TEST_ASSERT(res >= 0);
 
     TEST_ASSERT(strcmp(buf, result_str) == 0);
+
+exit:
     USE_PSA_DONE();
 }
 /* END_CASE */
@@ -630,10 +632,10 @@ void x509_verify_restart(char *crt_file, char *ca_file,
      * - x509_verify() for server5 -> test-ca2:             ~ 18800
      * - x509_verify() for server10 -> int-ca3 -> int-ca2:  ~ 25500
      */
-    MD_OR_USE_PSA_INIT();
     mbedtls_x509_crt_restart_init(&rs_ctx);
     mbedtls_x509_crt_init(&crt);
     mbedtls_x509_crt_init(&ca);
+    MD_OR_USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_x509_crt_parse_file(&crt, crt_file) == 0);
     TEST_ASSERT(mbedtls_x509_crt_parse_file(&ca, ca_file) == 0);
@@ -682,10 +684,10 @@ void x509_verify(char *crt_file, char *ca_file, char *crl_file,
     char *cn_name = NULL;
     const mbedtls_x509_crt_profile *profile;
 
-    MD_OR_USE_PSA_INIT();
     mbedtls_x509_crt_init(&crt);
     mbedtls_x509_crt_init(&ca);
     mbedtls_x509_crl_init(&crl);
+    MD_OR_USE_PSA_INIT();
 
     if (strcmp(cn_name_str, "NULL") != 0) {
         cn_name = cn_name_str;
@@ -767,9 +769,9 @@ void x509_verify_ca_cb_failure(char *crt_file, char *ca_file, char *name,
     mbedtls_x509_crt ca;
     uint32_t flags = 0;
 
-    USE_PSA_INIT();
     mbedtls_x509_crt_init(&crt);
     mbedtls_x509_crt_init(&ca);
+    USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_x509_crt_parse_file(&crt, crt_file) == 0);
     TEST_ASSERT(mbedtls_x509_crt_parse_file(&ca, ca_file) == 0);
@@ -801,9 +803,10 @@ void x509_verify_callback(char *crt_file, char *ca_file, char *name,
     uint32_t flags = 0;
     verify_print_context vrfy_ctx;
 
-    MD_OR_USE_PSA_INIT();
     mbedtls_x509_crt_init(&crt);
     mbedtls_x509_crt_init(&ca);
+    MD_OR_USE_PSA_INIT();
+
     verify_print_init(&vrfy_ctx);
 
     TEST_ASSERT(mbedtls_x509_crt_parse_file(&crt, crt_file) == 0);
@@ -838,8 +841,9 @@ void mbedtls_x509_dn_gets_subject_replace(char *crt_file,
     char buf[2000];
     int res = 0;
 
-    USE_PSA_INIT();
     mbedtls_x509_crt_init(&crt);
+    USE_PSA_INIT();
+
     memset(buf, 0, 2000);
 
     TEST_ASSERT(mbedtls_x509_crt_parse_file(&crt, crt_file) == 0);
@@ -868,8 +872,9 @@ void mbedtls_x509_dn_gets(char *crt_file, char *entity, char *result_str)
     char buf[2000];
     int res = 0;
 
-    USE_PSA_INIT();
     mbedtls_x509_crt_init(&crt);
+    USE_PSA_INIT();
+
     memset(buf, 0, 2000);
 
     TEST_ASSERT(mbedtls_x509_crt_parse_file(&crt, crt_file) == 0);
@@ -914,6 +919,7 @@ void mbedtls_x509_get_name(char *rdn_sequence, int exp_ret)
 
     TEST_EQUAL(ret, exp_ret);
 
+exit:
     mbedtls_free(name);
     USE_PSA_DONE();
 }
@@ -992,8 +998,8 @@ void mbedtls_x509_time_is_past(char *crt_file, char *entity, int result)
 {
     mbedtls_x509_crt   crt;
 
-    USE_PSA_INIT();
     mbedtls_x509_crt_init(&crt);
+    USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_x509_crt_parse_file(&crt, crt_file) == 0);
 
@@ -1016,8 +1022,8 @@ void mbedtls_x509_time_is_future(char *crt_file, char *entity, int result)
 {
     mbedtls_x509_crt   crt;
 
-    USE_PSA_INIT();
     mbedtls_x509_crt_init(&crt);
+    USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_x509_crt_parse_file(&crt, crt_file) == 0);
 
@@ -1040,8 +1046,8 @@ void x509parse_crt_file(char *crt_file, int result)
 {
     mbedtls_x509_crt crt;
 
-    USE_PSA_INIT();
     mbedtls_x509_crt_init(&crt);
+    USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_x509_crt_parse_file(&crt, crt_file) == result);
 
@@ -1062,8 +1068,8 @@ void x509parse_crt(data_t *buf, char *result_str, int result)
     ((void) result_str);
 #endif
 
-    USE_PSA_INIT();
     mbedtls_x509_crt_init(&crt);
+    USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_x509_crt_parse_der(&crt, buf->x, buf->len) == (result));
 #if !defined(MBEDTLS_X509_REMOVE_INFO)
@@ -1147,12 +1153,12 @@ void x509parse_crt_cb(data_t *buf, char *result_str, int result)
     ((void) result_str);
 #endif
 
-    USE_PSA_INIT();
     oid.tag = MBEDTLS_ASN1_OID;
     oid.len = MBEDTLS_OID_SIZE(MBEDTLS_OID_PKIX "\x01\x1F");
     oid.p = (unsigned char *) MBEDTLS_OID_PKIX "\x01\x1F";
 
     mbedtls_x509_crt_init(&crt);
+    USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_x509_crt_parse_der_with_ext_cb(&crt, buf->x, buf->len, 0, parse_crt_ext_cb,
                                                        &oid) == (result));
@@ -1197,8 +1203,9 @@ void x509parse_crl(data_t *buf, char *result_str, int result)
     unsigned char output[2000];
     int res;
 
-    USE_PSA_INIT();
     mbedtls_x509_crl_init(&crl);
+    USE_PSA_INIT();
+
     memset(output, 0, 2000);
 
 
@@ -1225,8 +1232,9 @@ void mbedtls_x509_csr_parse(data_t *csr_der, char *ref_out, int ref_ret)
     char my_out[1000];
     int my_ret;
 
-    USE_PSA_INIT();
     mbedtls_x509_csr_init(&csr);
+    USE_PSA_INIT();
+
     memset(my_out, 0, sizeof(my_out));
 
     my_ret = mbedtls_x509_csr_parse_der(&csr, csr_der->x, csr_der->len);
@@ -1251,8 +1259,9 @@ void mbedtls_x509_csr_parse_file(char *csr_file, char *ref_out, int ref_ret)
     char my_out[1000];
     int my_ret;
 
-    USE_PSA_INIT();
     mbedtls_x509_csr_init(&csr);
+    USE_PSA_INIT();
+
     memset(my_out, 0, sizeof(my_out));
 
     my_ret = mbedtls_x509_csr_parse_file(&csr, csr_file);
@@ -1276,8 +1285,8 @@ void mbedtls_x509_crt_parse_path(char *crt_path, int ret, int nb_crt)
     mbedtls_x509_crt chain, *cur;
     int i;
 
-    USE_PSA_INIT();
     mbedtls_x509_crt_init(&chain);
+    USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_x509_crt_parse_path(&chain, crt_path) == ret);
 
@@ -1309,9 +1318,9 @@ void mbedtls_x509_crt_verify_max(char *ca_file, char *chain_dir, int nb_int,
      * We expect chain_dir to contain certificates 00.crt, 01.crt, etc.
      * with NN.crt signed by NN-1.crt
      */
-    MD_OR_USE_PSA_INIT();
     mbedtls_x509_crt_init(&trusted);
     mbedtls_x509_crt_init(&chain);
+    MD_OR_USE_PSA_INIT();
 
     /* Load trusted root */
     TEST_ASSERT(mbedtls_x509_crt_parse_file(&trusted, ca_file) == 0);
@@ -1347,9 +1356,9 @@ void mbedtls_x509_crt_verify_chain(char *chain_paths, char *trusted_ca,
     mbedtls_x509_crt trusted, chain;
     const mbedtls_x509_crt_profile *profile = NULL;
 
-    MD_OR_USE_PSA_INIT();
     mbedtls_x509_crt_init(&chain);
     mbedtls_x509_crt_init(&trusted);
+    MD_OR_USE_PSA_INIT();
 
     while ((act = mystrsep(&chain_paths, " ")) != NULL) {
         TEST_ASSERT(mbedtls_x509_crt_parse_file(&chain, act) == 0);
@@ -1389,6 +1398,7 @@ void x509_oid_desc(data_t *buf, char *ref_desc)
     int ret;
 
     USE_PSA_INIT();
+
     oid.tag = MBEDTLS_ASN1_OID;
     oid.p   = buf->x;
     oid.len   = buf->len;
@@ -1403,6 +1413,8 @@ void x509_oid_desc(data_t *buf, char *ref_desc)
         TEST_ASSERT(desc != NULL);
         TEST_ASSERT(strcmp(desc, ref_desc) == 0);
     }
+
+exit:
     USE_PSA_DONE();
 }
 /* END_CASE */
@@ -1414,6 +1426,7 @@ void x509_oid_numstr(data_t *oid_buf, char *numstr, int blen, int ret)
     char num_buf[100];
 
     USE_PSA_INIT();
+
     memset(num_buf, 0x2a, sizeof(num_buf));
 
     oid.tag = MBEDTLS_ASN1_OID;
@@ -1428,6 +1441,8 @@ void x509_oid_numstr(data_t *oid_buf, char *numstr, int blen, int ret)
         TEST_ASSERT(num_buf[ret] == 0);
         TEST_ASSERT(strcmp(num_buf, numstr) == 0);
     }
+
+exit:
     USE_PSA_DONE();
 }
 /* END_CASE */
@@ -1437,8 +1452,8 @@ void x509_check_key_usage(char *crt_file, int usage, int ret)
 {
     mbedtls_x509_crt crt;
 
-    USE_PSA_INIT();
     mbedtls_x509_crt_init(&crt);
+    USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_x509_crt_parse_file(&crt, crt_file) == 0);
 
@@ -1456,8 +1471,8 @@ void x509_check_extended_key_usage(char *crt_file, data_t *oid, int ret
 {
     mbedtls_x509_crt crt;
 
-    USE_PSA_INIT();
     mbedtls_x509_crt_init(&crt);
+    USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_x509_crt_parse_file(&crt, crt_file) == 0);
 
@@ -1497,6 +1512,7 @@ void x509_get_time(int tag, char *time_str, int ret, int year, int mon,
         TEST_ASSERT(min  == time.min);
         TEST_ASSERT(sec  == time.sec);
     }
+exit:
     USE_PSA_DONE();
 }
 /* END_CASE */

--- a/tests/suites/test_suite_x509parse.function
+++ b/tests/suites/test_suite_x509parse.function
@@ -900,7 +900,7 @@ exit:
 /* BEGIN_CASE depends_on:MBEDTLS_X509_CRT_PARSE_C */
 void mbedtls_x509_get_name(char *rdn_sequence, int exp_ret)
 {
-    unsigned char *name;
+    unsigned char *name = NULL;
     unsigned char *p;
     size_t name_len;
     mbedtls_x509_name head;

--- a/tests/suites/test_suite_x509write.function
+++ b/tests/suites/test_suite_x509write.function
@@ -159,8 +159,6 @@ void x509_csr_check(char *key_file, char *cert_req_check_file, int md_type,
     const char *san_dns_name = "example.com";
     const char *san_uri_name = "http://pki.example.com/";
 
-    MD_OR_USE_PSA_INIT();
-
     san_uri.node.type = MBEDTLS_X509_SAN_UNIFORM_RESOURCE_IDENTIFIER;
     san_uri.node.san.unstructured_name.p = (unsigned char *) san_uri_name;
     san_uri.node.san.unstructured_name.len = strlen(san_uri_name);
@@ -178,8 +176,9 @@ void x509_csr_check(char *key_file, char *cert_req_check_file, int md_type,
     memset(&rnd_info, 0x2a, sizeof(mbedtls_test_rnd_pseudo_info));
 
     mbedtls_x509write_csr_init(&req);
-
     mbedtls_pk_init(&key);
+    MD_OR_USE_PSA_INIT();
+
     TEST_ASSERT(mbedtls_pk_parse_keyfile(&key, key_file, NULL,
                                          mbedtls_test_rnd_std_rand, NULL) == 0);
 
@@ -266,11 +265,10 @@ void x509_csr_check_opaque(char *key_file, int md_type, int key_usage,
     const char *subject_name = "C=NL,O=PolarSSL,CN=PolarSSL Server 1";
     mbedtls_test_rnd_pseudo_info rnd_info;
 
+    mbedtls_x509write_csr_init(&req);
     MD_OR_USE_PSA_INIT();
 
     memset(&rnd_info, 0x2a, sizeof(mbedtls_test_rnd_pseudo_info));
-
-    mbedtls_x509write_csr_init(&req);
 
     md_alg_psa = mbedtls_hash_info_psa_from_md((mbedtls_md_type_t) md_type);
     TEST_ASSERT(md_alg_psa != MBEDTLS_MD_NONE);
@@ -351,8 +349,6 @@ void x509_crt_check(char *subject_key_file, char *subject_pwd,
 #endif
     mbedtls_pk_type_t issuer_key_type;
 
-    MD_OR_USE_PSA_INIT();
-
     memset(&rnd_info, 0x2a, sizeof(mbedtls_test_rnd_pseudo_info));
 #if defined(MBEDTLS_TEST_DEPRECATED) && defined(MBEDTLS_BIGNUM_C)
     mbedtls_mpi_init(&serial_mpi);
@@ -361,8 +357,8 @@ void x509_crt_check(char *subject_key_file, char *subject_pwd,
     mbedtls_pk_init(&subject_key);
     mbedtls_pk_init(&issuer_key);
     mbedtls_pk_init(&issuer_key_alt);
-
     mbedtls_x509write_crt_init(&crt);
+    MD_OR_USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_pk_parse_keyfile(&subject_key, subject_key_file,
                                          subject_pwd, mbedtls_test_rnd_std_rand, NULL) == 0);

--- a/tests/suites/test_suite_x509write.function
+++ b/tests/suites/test_suite_x509write.function
@@ -159,6 +159,8 @@ void x509_csr_check(char *key_file, char *cert_req_check_file, int md_type,
     const char *san_dns_name = "example.com";
     const char *san_uri_name = "http://pki.example.com/";
 
+    MD_OR_USE_PSA_INIT();
+
     san_uri.node.type = MBEDTLS_X509_SAN_UNIFORM_RESOURCE_IDENTIFIER;
     san_uri.node.san.unstructured_name.p = (unsigned char *) san_uri_name;
     san_uri.node.san.unstructured_name.len = strlen(san_uri_name);
@@ -176,8 +178,6 @@ void x509_csr_check(char *key_file, char *cert_req_check_file, int md_type,
     memset(&rnd_info, 0x2a, sizeof(mbedtls_test_rnd_pseudo_info));
 
     mbedtls_x509write_csr_init(&req);
-
-    MD_OR_USE_PSA_INIT();
 
     mbedtls_pk_init(&key);
     TEST_ASSERT(mbedtls_pk_parse_keyfile(&key, key_file, NULL,
@@ -266,11 +266,11 @@ void x509_csr_check_opaque(char *key_file, int md_type, int key_usage,
     const char *subject_name = "C=NL,O=PolarSSL,CN=PolarSSL Server 1";
     mbedtls_test_rnd_pseudo_info rnd_info;
 
+    MD_OR_USE_PSA_INIT();
+
     memset(&rnd_info, 0x2a, sizeof(mbedtls_test_rnd_pseudo_info));
 
     mbedtls_x509write_csr_init(&req);
-
-    MD_OR_USE_PSA_INIT();
 
     md_alg_psa = mbedtls_hash_info_psa_from_md((mbedtls_md_type_t) md_type);
     TEST_ASSERT(md_alg_psa != MBEDTLS_MD_NONE);
@@ -315,7 +315,7 @@ exit:
     mbedtls_x509write_csr_free(&req);
     mbedtls_pk_free(&key);
     psa_destroy_key(key_id);
-    PSA_DONE();
+    MD_OR_USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -351,12 +351,12 @@ void x509_crt_check(char *subject_key_file, char *subject_pwd,
 #endif
     mbedtls_pk_type_t issuer_key_type;
 
+    MD_OR_USE_PSA_INIT();
+
     memset(&rnd_info, 0x2a, sizeof(mbedtls_test_rnd_pseudo_info));
 #if defined(MBEDTLS_TEST_DEPRECATED) && defined(MBEDTLS_BIGNUM_C)
     mbedtls_mpi_init(&serial_mpi);
 #endif
-
-    MD_OR_USE_PSA_INIT();
 
     mbedtls_pk_init(&subject_key);
     mbedtls_pk_init(&issuer_key);
@@ -597,6 +597,7 @@ void x509_set_serial_check()
     mbedtls_x509write_cert ctx;
     uint8_t invalid_serial[MBEDTLS_X509_RFC5280_MAX_SERIAL_LEN + 1];
 
+    USE_PSA_INIT();
     memset(invalid_serial, 0x01, sizeof(invalid_serial));
 
 #if defined(MBEDTLS_TEST_DEPRECATED) && defined(MBEDTLS_BIGNUM_C)
@@ -619,6 +620,7 @@ exit:
 #else
     ;
 #endif
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -631,6 +633,8 @@ void mbedtls_x509_string_to_names(char *name, char *parsed_name, int result
     mbedtls_asn1_named_data *names = NULL;
     mbedtls_x509_name parsed, *parsed_cur, *parsed_prv;
     unsigned char buf[1024], out[1024], *c;
+
+    USE_PSA_INIT();
 
     memset(&parsed, 0, sizeof(parsed));
     memset(out, 0, sizeof(out));
@@ -665,5 +669,6 @@ exit:
         parsed_cur = parsed_cur->next;
         mbedtls_free(parsed_prv);
     }
+    USE_PSA_DONE();
 }
 /* END_CASE */


### PR DESCRIPTION
Resolves #7460 (partially)

## Gatekeeper checklist

- [x] **changelog** not required - tests only
- [x] **backport** #7505 
- [x] **tests** not required