### PR TITLE
clz size/perf optimisation

### DIFF
--- a/library/bignum_core.c
+++ b/library/bignum_core.c
@@ -35,6 +35,36 @@
 
 size_t mbedtls_mpi_core_clz(mbedtls_mpi_uint a)
 {
+#if defined(__has_builtin)
+#if __has_builtin(__builtin_clz)
+    if (sizeof(mbedtls_mpi_uint) == sizeof(unsigned int)) {
+        // __builtin_clz is undefined if a == 0
+        if (a == 0) {
+            return sizeof(mbedtls_mpi_uint) * 8;
+        } else {
+            return (size_t) __builtin_clz(a);
+        }
+    }
+#endif
+#if __has_builtin(__builtin_clzl)
+    if (sizeof(mbedtls_mpi_uint) == sizeof(unsigned long)) {
+        if (a == 0) {
+            return sizeof(mbedtls_mpi_uint) * 8;
+        } else {
+            return (size_t) __builtin_clzl(a);
+        }
+    }
+#endif
+#if __has_builtin(__builtin_clzll)
+    if (sizeof(mbedtls_mpi_uint) == sizeof(unsigned long long)) {
+        if (a == 0) {
+            return sizeof(mbedtls_mpi_uint) * 8;
+        } else {
+            return (size_t) __builtin_clzll(a);
+        }
+    }
+#endif
+#endif
     size_t j;
     mbedtls_mpi_uint mask = (mbedtls_mpi_uint) 1 << (biL - 1);
 

--- a/library/bignum_core.c
+++ b/library/bignum_core.c
@@ -71,12 +71,10 @@ size_t mbedtls_mpi_core_bitlen(const mbedtls_mpi_uint *A, size_t A_limbs)
     int i;
     size_t j;
 
-    if (A_limbs != 0) {
-        for (i = (int) A_limbs - 1; i >= 0; i--) {
-            if (A[i] != 0) {
-                j = biL - mbedtls_mpi_core_clz(A[i]);
-                return (i * biL) + j;
-            }
+    for (i = ((int) A_limbs) - 1; i >= 0; i--) {
+        if (A[i] != 0) {
+            j = biL - mbedtls_mpi_core_clz(A[i]);
+            return (i * biL) + j;
         }
     }
 

--- a/library/bignum_core.c
+++ b/library/bignum_core.c
@@ -33,16 +33,6 @@
 #include "bn_mul.h"
 #include "constant_time_internal.h"
 
-/**
- * \brief          Count leading zeros
- *
- * \warning        The result is undefined if \p a == 0
- *
- * \param a        The value to operate on
- *
- * \return         The number of leading zeros, if \p a != 0. If \p a == 0, the result
- *                 is undefined.
- */
 inline size_t mbedtls_mpi_core_clz(mbedtls_mpi_uint a)
 {
 #if defined(__has_builtin)

--- a/library/bignum_core.c
+++ b/library/bignum_core.c
@@ -33,11 +33,18 @@
 #include "bn_mul.h"
 #include "constant_time_internal.h"
 
+/**
+ * \brief          Count leading zeros
+ *
+ * \warning        The result is undefined if \p a == 0
+ *
+ * \param a        The value to operate on
+ *
+ * \return         The number of leading zeros, if \p a != 0. If \p a == 0, the result
+ *                 is undefined.
+ */
 inline size_t mbedtls_mpi_core_clz(mbedtls_mpi_uint a)
 {
-    /* Note: the result is undefined for a == 0
-     * (because this is the behaviour of __builtin_clz).
-     */
 #if defined(__has_builtin)
 #if __has_builtin(__builtin_clz)
     if (sizeof(mbedtls_mpi_uint) == sizeof(unsigned int)) {

--- a/library/bignum_core.h
+++ b/library/bignum_core.h
@@ -102,9 +102,12 @@
 
 /** Count leading zero bits in a given integer.
  *
+ * \warning     The result is undefined if \p a == 0
+ *
  * \param a     Integer to count leading zero bits.
  *
- * \return      The number of leading zero bits in \p a.
+ * \return      The number of leading zero bits in \p a, if \p a != 0.
+ *              If \p a == 0, the result is undefined.
  */
 size_t mbedtls_mpi_core_clz(mbedtls_mpi_uint a);
 

--- a/tests/suites/test_suite_bignum_core.function
+++ b/tests/suites/test_suite_bignum_core.function
@@ -311,25 +311,28 @@ exit:
 
 
 /* BEGIN_CASE */
-void mpi_core_clz(int lz, int tz)
+void mpi_core_clz(int leading_zeros, int trailing_zeros)
 {
-    if ((size_t) (lz + tz) >= (sizeof(mbedtls_mpi_uint) * 8)) {
+    if ((size_t) (leading_zeros + trailing_zeros) >= (sizeof(mbedtls_mpi_uint) * 8)) {
         // can't fit required number of leading and trailing zeros - skip test
         goto exit;
     }
 
+    // Construct a test input value where the count of leading zeros and
+    // trailing zeros is given in the test case, and we add ones to fill
+    // the gap.
     mbedtls_mpi_uint x;
-    if ((lz + tz) > 0) {
+    if ((leading_zeros + trailing_zeros) > 0) {
         // some zero bits
-        uint32_t s = (sizeof(mbedtls_mpi_uint) * 8 - lz - tz);
-        x = ((((mbedtls_mpi_uint) 1) << s) - 1) << tz;
+        uint32_t s = (sizeof(mbedtls_mpi_uint) * 8 - leading_zeros - trailing_zeros);
+        x = ((((mbedtls_mpi_uint) 1) << s) - 1) << trailing_zeros;
     } else {
         // all bits set
         x = ~((mbedtls_mpi_uint) 0);
     }
 
     size_t n = mbedtls_mpi_core_clz(x);
-    TEST_EQUAL(n, lz);
+    TEST_EQUAL(n, leading_zeros);
 exit:
     ;
 }

--- a/tests/suites/test_suite_bignum_core.function
+++ b/tests/suites/test_suite_bignum_core.function
@@ -309,6 +309,43 @@ exit:
 }
 /* END_CASE */
 
+
+/* BEGIN_CASE */
+void mpi_core_clz(int lz, int tz)
+{
+    if ((size_t) (lz + tz) >= (sizeof(mbedtls_mpi_uint) * 8)) {
+        // can't fit required number of leading and trailing zeros - skip test
+        goto exit;
+    }
+
+    mbedtls_mpi_uint x;
+    size_t expected;
+
+    // generate x with lz leading zeros and tz trailing zeros, all other bits set.
+    if (lz == -1) {
+        // special case: all zero
+        x = 0;
+        expected = sizeof(mbedtls_mpi_uint) * 8;
+    } else {
+        expected = lz;
+        if ((lz + tz) > 0) {
+            // some zero bits
+            uint32_t s = (sizeof(mbedtls_mpi_uint) * 8 - lz - tz);
+            x = ((1ULL << s) - 1) << tz;
+        } else {
+            // all bits set
+            x = ~0ULL;
+        }
+    }
+
+    size_t n = mbedtls_mpi_core_clz(x);
+    TEST_EQUAL(n, expected);
+exit:
+    ;
+}
+/* END_CASE */
+
+
 /* BEGIN_CASE */
 void mpi_core_lt_ct(char *input_X, char *input_Y, int exp_ret)
 {

--- a/tests/suites/test_suite_bignum_core.function
+++ b/tests/suites/test_suite_bignum_core.function
@@ -301,11 +301,7 @@ void mpi_core_bitlen(char *input_X, int nr_bits)
     mbedtls_mpi_uint *X = NULL;
     size_t limbs;
 
-    if (strlen(input_X) == 0) {
-        limbs = 0;
-    } else {
-        TEST_EQUAL(mbedtls_test_read_mpi_core(&X, &limbs, input_X), 0);
-    }
+    TEST_EQUAL(mbedtls_test_read_mpi_core(&X, &limbs, input_X), 0);
     TEST_EQUAL(mbedtls_mpi_core_bitlen(X, limbs), nr_bits);
 
 exit:

--- a/tests/suites/test_suite_bignum_core.function
+++ b/tests/suites/test_suite_bignum_core.function
@@ -331,10 +331,10 @@ void mpi_core_clz(int lz, int tz)
         if ((lz + tz) > 0) {
             // some zero bits
             uint32_t s = (sizeof(mbedtls_mpi_uint) * 8 - lz - tz);
-            x = ((1ULL << s) - 1) << tz;
+            x = ((((mbedtls_mpi_uint) 1) << s) - 1) << tz;
         } else {
             // all bits set
-            x = ~0ULL;
+            x = ~((mbedtls_mpi_uint) 0);
         }
     }
 

--- a/tests/suites/test_suite_bignum_core.function
+++ b/tests/suites/test_suite_bignum_core.function
@@ -301,7 +301,11 @@ void mpi_core_bitlen(char *input_X, int nr_bits)
     mbedtls_mpi_uint *X = NULL;
     size_t limbs;
 
-    TEST_EQUAL(mbedtls_test_read_mpi_core(&X, &limbs, input_X), 0);
+    if (strlen(input_X) == 0) {
+        limbs = 0;
+    } else {
+        TEST_EQUAL(mbedtls_test_read_mpi_core(&X, &limbs, input_X), 0);
+    }
     TEST_EQUAL(mbedtls_mpi_core_bitlen(X, limbs), nr_bits);
 
 exit:

--- a/tests/suites/test_suite_bignum_core.function
+++ b/tests/suites/test_suite_bignum_core.function
@@ -319,27 +319,17 @@ void mpi_core_clz(int lz, int tz)
     }
 
     mbedtls_mpi_uint x;
-    size_t expected;
-
-    // generate x with lz leading zeros and tz trailing zeros, all other bits set.
-    if (lz == -1) {
-        // special case: all zero
-        x = 0;
-        expected = sizeof(mbedtls_mpi_uint) * 8;
+    if ((lz + tz) > 0) {
+        // some zero bits
+        uint32_t s = (sizeof(mbedtls_mpi_uint) * 8 - lz - tz);
+        x = ((((mbedtls_mpi_uint) 1) << s) - 1) << tz;
     } else {
-        expected = lz;
-        if ((lz + tz) > 0) {
-            // some zero bits
-            uint32_t s = (sizeof(mbedtls_mpi_uint) * 8 - lz - tz);
-            x = ((((mbedtls_mpi_uint) 1) << s) - 1) << tz;
-        } else {
-            // all bits set
-            x = ~((mbedtls_mpi_uint) 0);
-        }
+        // all bits set
+        x = ~((mbedtls_mpi_uint) 0);
     }
 
     size_t n = mbedtls_mpi_core_clz(x);
-    TEST_EQUAL(n, expected);
+    TEST_EQUAL(n, lz);
 exit:
     ;
 }

--- a/tests/suites/test_suite_bignum_core.misc.data
+++ b/tests/suites/test_suite_bignum_core.misc.data
@@ -494,9 +494,6 @@ mpi_core_fill_random:42:0:-5:0:MBEDTLS_ERR_MPI_BAD_INPUT_DATA
 CLZ: 0 0: all ones
 mpi_core_clz:0:0
 
-CLZ: -1 -1: all zeros
-mpi_core_clz:-1:-1
-
 CLZ: 1 0
 mpi_core_clz:1:0
 

--- a/tests/suites/test_suite_bignum_core.misc.data
+++ b/tests/suites/test_suite_bignum_core.misc.data
@@ -155,6 +155,9 @@ mpi_core_bitlen:"10":5
 Test mbedtls_mpi_core_bitlen 0x0a
 mpi_core_bitlen:"a":4
 
+Test mbedtls_mpi_core_bitlen: 0 limbs
+mpi_core_bitlen:"":0
+
 Test mbedtls_mpi_core_bitlen: 0 (1 limb)
 mpi_core_bitlen:"0":0
 

--- a/tests/suites/test_suite_bignum_core.misc.data
+++ b/tests/suites/test_suite_bignum_core.misc.data
@@ -491,3 +491,38 @@ mpi_core_fill_random:42:0:-1:0:MBEDTLS_ERR_MPI_BAD_INPUT_DATA
 Fill random core: 42 bytes, 5 missing limbs
 mpi_core_fill_random:42:0:-5:0:MBEDTLS_ERR_MPI_BAD_INPUT_DATA
 
+CLZ: 0 0: all ones
+mpi_core_clz:0:0
+
+CLZ: -1 -1: all zeros
+mpi_core_clz:-1:-1
+
+CLZ: 1 0
+mpi_core_clz:1:0
+
+CLZ: 1 1
+mpi_core_clz:1:1
+
+CLZ: 4 5
+mpi_core_clz:4:5
+
+CLZ: 8 16
+mpi_core_clz:8:16
+
+CLZ: 31 0
+mpi_core_clz:31:0
+
+CLZ: 32 0
+mpi_core_clz:32:0
+
+CLZ: 33 0
+mpi_core_clz:33:0
+
+CLZ: 63 0
+mpi_core_clz:63:0
+
+CLZ: 64 0
+mpi_core_clz:64:0
+
+CLZ: 100000 0: skip overly long input
+mpi_core_clz:100000:0

--- a/tests/suites/test_suite_bignum_core.misc.data
+++ b/tests/suites/test_suite_bignum_core.misc.data
@@ -155,9 +155,6 @@ mpi_core_bitlen:"10":5
 Test mbedtls_mpi_core_bitlen 0x0a
 mpi_core_bitlen:"a":4
 
-Test mbedtls_mpi_core_bitlen: 0 limbs
-mpi_core_bitlen:"":0
-
 Test mbedtls_mpi_core_bitlen: 0 (1 limb)
 mpi_core_bitlen:"0":0
 


### PR DESCRIPTION
## Description

For clang and gcc, this saves a few instructions (with gcc -Os on aarch64, the size of libmbedcrypto is reduced by 88b). It also covers a test gap (this function was not directly tested before). Performance is not very different according to programs/test/benchmark.

## Gatekeeper checklist

- [x] **changelog** not required - non functional change
- [x] **backport** not required - not a bugfix
- [x] **tests** provided
