### PR TITLE
Replace CLOCK_MONOTONIC with CLOCK_BOOTTIME for `mbedtls_ms_time` on linux

### DIFF
--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -235,7 +235,11 @@ mbedtls_ms_time_t mbedtls_ms_time(void)
     struct timespec tv;
     mbedtls_ms_time_t current_ms;
 
+#if defined(__linux__)
+    ret = clock_gettime(CLOCK_BOOTTIME, &tv);
+#else
     ret = clock_gettime(CLOCK_MONOTONIC, &tv);
+#endif
     if (ret) {
         return time(NULL) * 1000;
     }


### PR DESCRIPTION

## Description

CLOCK_MONOTONIC does not account for time when suspend. And CLOCK_BOOTTIME does it.

It is also reported at https://github.com/golang/go/issues/24595, https://github.com/eclipse/paho.mqtt.c/issues/1095

## Gatekeeper checklist

- [ ] **changelog** TODO
- [ ] **backport** not required
- [x] **tests** provided, or not required




