### PR TITLE
Check remaning dependencies on ECP in PK module

### DIFF
--- a/docs/architecture/psa-migration/syms.sh
+++ b/docs/architecture/psa-migration/syms.sh
@@ -17,13 +17,20 @@
 #
 # Purpose
 #
-# Show symbols in the X.509 and TLS libraries that are defined in another
-# libmbedtlsXXX.a library. This is usually done to list Crypto dependencies.
+# Show external links in built libraries (X509 or TLS) or modules. This is
+# usually done to list Crypto dependencies or to check modules'
+# interdependencies.
 #
 # Usage:
 # - build the library with debug symbols and the config you're interested in
 #   (default, full minus MBEDTLS_USE_PSA_CRYPTO, full, etc.)
-# - run this script with the name of your config as the only argument
+# - launch this script with 1 or more arguments depending on the analysis' goal:
+#     - if only 1 argument is used (which is the name of the used config,
+#       ex: full), then the analysis is done on libmbedx509 and libmbedtls
+#       libraries by default
+#     - if multiple arguments are provided, then modules' names (ex: pk,
+#       pkparse, pkwrite, etc) are expected after the 1st one and the analysis
+#       will be done on those modules instead of the libraries.
 
 set -eu
 
@@ -35,10 +42,21 @@ syms() {
     nm "$FILE" | sed -n "s/[0-9a-f ]*${TYPE} \(mbedtls_.*\)/\1/p" | sort -u
 }
 
+# Check if the provided name refers to a module or library and return the
+# same path with proper extension
+get_file_with_extension() {
+    BASE=$1
+    if [ -f $BASE.o ]; then
+        echo $BASE.o
+    elif [ -f $BASE.a ]; then
+        echo $BASE.a
+    fi
+}
+
 # create listings for the given library
 list() {
     NAME="$1"
-    FILE="library/libmbed${NAME}.a"
+    FILE=$(get_file_with_extension "library/${NAME}")
     PREF="${CONFIG}-$NAME"
 
     syms '[TRrD]' $FILE > ${PREF}-defined
@@ -54,5 +72,14 @@ list() {
 
 CONFIG="${1:-unknown}"
 
-list x509
-list tls
+# List of modules to check is provided as parameters
+if [ $# -gt 1 ]; then
+    shift 1
+    ITEMS_TO_CHECK="$@"
+else
+    ITEMS_TO_CHECK="libmbedx509 libmbedtls"
+fi
+
+for ITEM in $ITEMS_TO_CHECK; do
+    list $ITEM
+done

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -946,13 +946,13 @@ component_test_full_cmake_gcc_asan () {
 
     # TODO: replace "mbedtls_ecp_curve" with "mbedtls_ecp" also for
     # "full-tls-external" once Issue6839 is completed
-    not grep mbedtls_ecp_curve full-tls-external
-    not grep mbedtls_ecp full-x509-external
+    not grep mbedtls_ecp_curve full-libmbedtls-external
+    not grep mbedtls_ecp full-libmbedx509-external
 
-    rm  full-tls-external \
-        full-tls-modules \
-        full-x509-external \
-        full-x509-modules
+    rm  full-libmbedtls-external \
+        full-libmbedtls-modules \
+        full-libmbedx509-external \
+        full-libmbedx509-modules
 }
 
 component_test_psa_crypto_key_id_encodes_owner () {


### PR DESCRIPTION
This is the 3rd step of #7460
Resolves #7460 (partially)
~Requires #7463~

## Gatekeeper checklist

- [x] **changelog** not required - internal script
- [x] **backport** not required - internal script
- [x] **tests** not required - internal script