### PR TITLE
Deprecate psa_aead_set_lengths() before setting the nonce

### DIFF
--- a/ChangeLog.d/psa_aead_set_lengths-deprecate_order.txt
+++ b/ChangeLog.d/psa_aead_set_lengths-deprecate_order.txt
@@ -1,0 +1,4 @@
+New deprecations
+   * Calling psa_aead_set_lengths() after setting the nonce is deprecated.
+     This possibility existed in an early draft of the PSA Crypto API
+     specification, but was removed before the first official release.

--- a/include/psa/crypto.h
+++ b/include/psa/crypto.h
@@ -2415,7 +2415,9 @@ psa_status_t psa_aead_generate_nonce(psa_aead_operation_t *operation,
  * encryption or decryption operation.
  *
  * The application must call psa_aead_encrypt_setup() or
- * psa_aead_decrypt_setup() before calling this function.
+ * psa_aead_decrypt_setup(),
+ * as well as psa_aead_set_lengths() if desired,
+ * before calling this function.
  *
  * If this function returns an error status, the operation enters an error
  * state and must be aborted by calling psa_aead_abort().
@@ -2451,13 +2453,10 @@ psa_status_t psa_aead_set_nonce(psa_aead_operation_t *operation,
 /** Declare the lengths of the message and additional data for AEAD.
  *
  * The application must call this function before calling
- * psa_aead_update_ad() or psa_aead_update() if the algorithm for
+ * psa_aead_set_nonce() or psa_aead_generate_nonce() if the algorithm for
  * the operation requires it. If the algorithm does not require it,
  * calling this function is optional, but if this function is called
  * then the implementation must enforce the lengths.
- *
- * You may call this function before or after setting the nonce with
- * psa_aead_set_nonce() or psa_aead_generate_nonce().
  *
  * - For #PSA_ALG_CCM, calling this function is required.
  * - For the other AEAD algorithms defined in this specification, calling
@@ -2466,6 +2465,12 @@ psa_status_t psa_aead_set_nonce(psa_aead_operation_t *operation,
  *
  * If this function returns an error status, the operation enters an error
  * state and must be aborted by calling psa_aead_abort().
+ *
+ * \deprecated
+ * You may call this function after calling psa_aead_set_nonce() or
+ * psa_aead_generate_nonce() (but before calling any update or finish function).
+ * This possibility is deprecated and will be removed in a future version of
+ * the library.
  *
  * \param[in,out] operation     Active AEAD operation.
  * \param ad_length             Size of the non-encrypted additional

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -4717,6 +4717,9 @@ psa_status_t psa_aead_set_lengths(psa_aead_operation_t *operation,
         goto exit;
     }
 
+    /* Don't check operation->nonce_set here because Mbed TLS supports
+     * psa_aead_set_lengths() after setting the nonce for backward
+     * compatibility. */
     if (operation->lengths_set || operation->ad_started ||
         operation->body_started) {
         status = PSA_ERROR_BAD_STATE;

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -310,6 +310,9 @@ typedef enum {
 typedef enum {
     DO_NOT_SET_LENGTHS = 0,
     SET_LENGTHS_BEFORE_NONCE = 1,
+    /* psa_aead_set_lengths() after psa_aead_set_nonce() or
+     * psa_aead_generate_nonce() is not allowed by the PSA specification,
+     * but Mbed TLS supports it for backward compatibility. */
     SET_LENGTHS_AFTER_NONCE = 2
 } set_lengths_method_t;
 


### PR DESCRIPTION
This possibility existed in an early draft of the PSA Crypto API specification, but was removed before the first official release. It's still present in Mbed TLS because we missed this change when implementing multipart AEAD, so we now have to support it throughout the lifetime of Mbed TLS 3.x for backward compatibility. But we intend to remove it when we can, so announce that it's deprecated.

Addresses https://github.com/Mbed-TLS/mbedtls/issues/7454. Does not address [the problem with drivers](https://github.com/Mbed-TLS/mbedtls/issues/7473).

## Gatekeeper checklist

- [x] **changelog** provided
- [x] **backport** no (things don't get deprecated in an LTS)
- [x] **tests** N/A
