### PR TITLE
Document mbedtls_calloc zeroization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,10 @@ jobs:
           packages:
           - clang-10
           - gnutls-bin
+      env:
+        # Platform tests have an allocation that returns null
+        - ASAN_OPTIONS="allocator_may_return_null=1"
+        - MSAN_OPTIONS="allocator_may_return_null=1"
       script:
         # Do a manual build+test sequence rather than using all.sh,
         # because there's no all.sh component that does what we want,
@@ -89,6 +93,10 @@ jobs:
         apt:
           packages:
           - gcc
+      env:
+        # Platform tests have an allocation that returns null
+        - ASAN_OPTIONS="allocator_may_return_null=1"
+        - MSAN_OPTIONS="allocator_may_return_null=1"
       script:
         # Do a manual build+test sequence rather than using all.sh.
         #
@@ -115,6 +123,10 @@ jobs:
           packages:
           - clang
           - gnutls-bin
+      env:
+        # Platform tests have an allocation that returns null
+        - ASAN_OPTIONS="allocator_may_return_null=1"
+        - MSAN_OPTIONS="allocator_may_return_null=1"
       script:
         # Do a manual build+test sequence rather than using all.sh.
         #

--- a/doxygen/mbedtls.doxyfile
+++ b/doxygen/mbedtls.doxyfile
@@ -51,4 +51,5 @@ PREDEFINED             = "MBEDTLS_CHECK_RETURN_CRITICAL="   \
                          "MBEDTLS_CHECK_RETURN_TYPICAL="    \
                          "MBEDTLS_CHECK_RETURN_OPTIONAL="   \
                          "MBEDTLS_PRINTF_ATTRIBUTE(a,b)="   \
+                         "__DOXYGEN__"                      \
 

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -3680,7 +3680,7 @@
 
 /* Platform options */
 //#define MBEDTLS_PLATFORM_STD_MEM_HDR   <stdlib.h> /**< Header to include if MBEDTLS_PLATFORM_NO_STD_FUNCTIONS is defined. Don't define if no header is needed. */
-//#define MBEDTLS_PLATFORM_STD_CALLOC        calloc /**< Default allocator to use, can be undefined */
+//#define MBEDTLS_PLATFORM_STD_CALLOC        calloc /**< Default allocator to use, can be undefined. Please note that it should zeroize the buffer after allocation. */
 //#define MBEDTLS_PLATFORM_STD_FREE            free /**< Default free to use, can be undefined */
 //#define MBEDTLS_PLATFORM_STD_SETBUF      setbuf /**< Default setbuf to use, can be undefined */
 //#define MBEDTLS_PLATFORM_STD_EXIT            exit /**< Default exit to use, can be undefined */

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -3708,7 +3708,8 @@
  *
  * Defining MBEDTLS_PLATFORM_CALLOC_MACRO and MBEDTLS_PLATFORM_STD_CALLOC at the same time is not possible.
  * MBEDTLS_PLATFORM_CALLOC_MACRO and MBEDTLS_PLATFORM_FREE_MACRO must both be defined or undefined at the same time.
- * MBEDTLS_PLATFORM_STD_CALLOC and MBEDTLS_PLATFORM_STD_FREE do not have to be defined at the same time, as, if they are used, dynamic setup of these functions is possible. See the tree above to see how are they handled in all cases.
+ * MBEDTLS_PLATFORM_STD_CALLOC and MBEDTLS_PLATFORM_STD_FREE do not have to be defined at the same time, as, if they are used,
+ * dynamic setup of these functions is possible. See the tree above to see how are they handled in all cases.
  */
 /** \def MBEDTLS_PLATFORM_STD_CALLOC
  *
@@ -3722,7 +3723,7 @@
 //#define MBEDTLS_PLATFORM_STD_CALLOC        calloc
 /** \def MBEDTLS_PLATFORM_STD_FREE
  *
- * Default free to use, can be undefined.
+ * Default free to use, can be undefined. See the description above for more details (same principles as for MBEDTLS_PLATFORM_STD_CALLOC apply).
  * NULL is a valid parameter, and the function must do nothing.
  * A non-null parameter will always be a pointer previously returned by #MBEDTLS_PLATFORM_STD_CALLOC and not yet freed.
  */

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -3711,6 +3711,7 @@
  * MBEDTLS_PLATFORM_STD_CALLOC and MBEDTLS_PLATFORM_STD_FREE do not have to be defined at the same time, as, if they are used,
  * dynamic setup of these functions is possible. See the tree above to see how are they handled in all cases.
  */
+
 /** \def MBEDTLS_PLATFORM_STD_CALLOC
  *
  * Default allocator to use, can be undefined. See the description above for details.
@@ -3721,6 +3722,7 @@
  * The corresponding deallocation function is #MBEDTLS_PLATFORM_STD_FREE.
  */
 //#define MBEDTLS_PLATFORM_STD_CALLOC        calloc
+
 /** \def MBEDTLS_PLATFORM_STD_FREE
  *
  * Default free to use, can be undefined. See the description above for more details (same principles as for MBEDTLS_PLATFORM_STD_CALLOC apply).

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -3683,18 +3683,18 @@
 /** \def MBEDTLS_PLATFORM_STD_CALLOC
  *
  * Default allocator to use, can be undefined.
- * It should initialize the allocated buffer memory to zeroes.
+ * It must initialize the allocated buffer memory to zeroes.
  * The size of the buffer is the product of the two parameters.
- * The behavior is undefined if the product of the two parameters overflows size_t.
+ * The calloc function returns either a null pointer or a pointer to the allocated space.
  * If the product is 0, the function may either return NULL or a valid pointer to an array of size 0 which is a valid input to the deallocation function.
- * The corresponding deallocation function is MBEDTLS_PLATFORM_STD_FREE.
+ * The corresponding deallocation function is #MBEDTLS_PLATFORM_STD_FREE.
  */
 //#define MBEDTLS_PLATFORM_STD_CALLOC        calloc
 /** \def MBEDTLS_PLATFORM_STD_FREE
  *
  * Default free to use, can be undefined.
  * NULL is a valid parameter, and the function must do nothing.
- * A non-null parameter will always be a pointer previously returned by MBEDTLS_PLATFORM_STD_CALLOC and not yet freed.
+ * A non-null parameter will always be a pointer previously returned by #MBEDTLS_PLATFORM_STD_CALLOC and not yet freed.
  */
 //#define MBEDTLS_PLATFORM_STD_FREE            free
 //#define MBEDTLS_PLATFORM_STD_SETBUF      setbuf /**< Default setbuf to use, can be undefined */
@@ -3710,7 +3710,7 @@
 //#define MBEDTLS_PLATFORM_STD_NV_SEED_WRITE  mbedtls_platform_std_nv_seed_write /**< Default nv_seed_write function to use, can be undefined */
 //#define MBEDTLS_PLATFORM_STD_NV_SEED_FILE  "seedfile" /**< Seed file to read/write with default implementation */
 
-/* To Use Function Macros MBEDTLS_PLATFORM_C must be enabled */
+/* To use the following function macros, MBEDTLS_PLATFORM_C must be enabled. */
 /* MBEDTLS_PLATFORM_XXX_MACRO and MBEDTLS_PLATFORM_XXX_ALT cannot both be defined */
 //#define MBEDTLS_PLATFORM_CALLOC_MACRO        calloc /**< Default allocator macro to use, can be undefined. See MBEDTLS_PLATFORM_STD_CALLOC for requirements. */
 //#define MBEDTLS_PLATFORM_FREE_MACRO            free /**< Default free macro to use, can be undefined. See MBEDTLS_PLATFORM_STD_FREE for requirements. */

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -3680,7 +3680,7 @@
 
 /* Platform options */
 //#define MBEDTLS_PLATFORM_STD_MEM_HDR   <stdlib.h> /**< Header to include if MBEDTLS_PLATFORM_NO_STD_FUNCTIONS is defined. Don't define if no header is needed. */
-//#define MBEDTLS_PLATFORM_STD_CALLOC        calloc /**< Default allocator to use, can be undefined. Please note that it should zeroize the buffer after allocation. */
+//#define MBEDTLS_PLATFORM_STD_CALLOC        calloc /**< Default allocator to use, can be undefined. Please note that it should zeroize the allocated buffer. */
 //#define MBEDTLS_PLATFORM_STD_FREE            free /**< Default free to use, can be undefined */
 //#define MBEDTLS_PLATFORM_STD_SETBUF      setbuf /**< Default setbuf to use, can be undefined */
 //#define MBEDTLS_PLATFORM_STD_EXIT            exit /**< Default exit to use, can be undefined */

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -3680,9 +3680,39 @@
 
 /* Platform options */
 //#define MBEDTLS_PLATFORM_STD_MEM_HDR   <stdlib.h> /**< Header to include if MBEDTLS_PLATFORM_NO_STD_FUNCTIONS is defined. Don't define if no header is needed. */
+
+/* An overview of how the value of mbedtls_calloc is determined:
+ *
+ * if !MBEDTLS_PLATFORM_MEMORY
+ *     mbedtls_calloc = calloc
+ * if MBEDTLS_PLATFORM_MEMORY
+ *     if (MBEDTLS_PLATFORM_CALLOC_MACRO && MBEDTLS_PLATFORM_FREE_MACRO):
+ *         mbedtls_calloc = MBEDTLS_PLATFORM_CALLOC_MACRO
+ *     if !(MBEDTLS_PLATFORM_CALLOC_MACRO && MBEDTLS_PLATFORM_FREE_MACRO):
+ *         Dynamic setup via mbedtls_platform_set_calloc_free is now possible with a default value MBEDTLS_PLATFORM_STD_CALLOC.
+ *         How is MBEDTLS_PLATFORM_STD_CALLOC handled?
+ *         if MBEDTLS_PLATFORM_NO_STD_FUNCTIONS:
+ *             MBEDTLS_PLATFORM_STD_CALLOC is not set to anything;
+ *             MBEDTLS_PLATFORM_STD_MEM_HDR can be included if present;
+ *         if !MBEDTLS_PLATFORM_NO_STD_FUNCTIONS:
+ *             if MBEDTLS_PLATFORM_STD_CALLOC is present:
+ *                 User-defined MBEDTLS_PLATFORM_STD_CALLOC is respected;
+ *             if !MBEDTLS_PLATFORM_STD_CALLOC:
+ *                 MBEDTLS_PLATFORM_STD_CALLOC = calloc
+ *
+ *         At this point the presence of MBEDTLS_PLATFORM_STD_CALLOC is checked.
+ *         if !MBEDTLS_PLATFORM_STD_CALLOC
+ *             MBEDTLS_PLATFORM_STD_CALLOC = uninitialized_calloc
+ *
+ *         mbedtls_calloc = MBEDTLS_PLATFORM_STD_CALLOC.
+ *
+ * Defining MBEDTLS_PLATFORM_CALLOC_MACRO and MBEDTLS_PLATFORM_STD_CALLOC at the same time is not possible.
+ * MBEDTLS_PLATFORM_CALLOC_MACRO and MBEDTLS_PLATFORM_FREE_MACRO must both be defined or undefined at the same time.
+ * MBEDTLS_PLATFORM_STD_CALLOC and MBEDTLS_PLATFORM_STD_FREE do not have to be defined at the same time, as, if they are used, dynamic setup of these functions is possible. See the tree above to see how are they handled in all cases.
+ */
 /** \def MBEDTLS_PLATFORM_STD_CALLOC
  *
- * Default allocator to use, can be undefined.
+ * Default allocator to use, can be undefined. See the description above for details.
  * It must initialize the allocated buffer memory to zeroes.
  * The size of the buffer is the product of the two parameters.
  * The calloc function returns either a null pointer or a pointer to the allocated space.

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -3680,8 +3680,23 @@
 
 /* Platform options */
 //#define MBEDTLS_PLATFORM_STD_MEM_HDR   <stdlib.h> /**< Header to include if MBEDTLS_PLATFORM_NO_STD_FUNCTIONS is defined. Don't define if no header is needed. */
-//#define MBEDTLS_PLATFORM_STD_CALLOC        calloc /**< Default allocator to use, can be undefined. Please note that it should zeroize the allocated buffer. */
-//#define MBEDTLS_PLATFORM_STD_FREE            free /**< Default free to use, can be undefined */
+/** \def MBEDTLS_PLATFORM_STD_CALLOC
+ *
+ * Default allocator to use, can be undefined.
+ * It should initialize the allocated buffer memory to zeroes.
+ * The size of the buffer is the product of the two parameters.
+ * The behavior is undefined if the product of the two parameters overflows size_t.
+ * If the product is 0, the function may either return NULL or a valid pointer to an array of size 0 which is a valid input to the deallocation function.
+ * The corresponding deallocation function is MBEDTLS_PLATFORM_STD_FREE.
+ */
+//#define MBEDTLS_PLATFORM_STD_CALLOC        calloc
+/** \def MBEDTLS_PLATFORM_STD_FREE
+ *
+ * Default free to use, can be undefined.
+ * NULL is a valid parameter, and the function must do nothing.
+ * A non-null parameter will always be a pointer previously returned by MBEDTLS_PLATFORM_STD_CALLOC and not yet freed.
+ */
+//#define MBEDTLS_PLATFORM_STD_FREE            free
 //#define MBEDTLS_PLATFORM_STD_SETBUF      setbuf /**< Default setbuf to use, can be undefined */
 //#define MBEDTLS_PLATFORM_STD_EXIT            exit /**< Default exit to use, can be undefined */
 //#define MBEDTLS_PLATFORM_STD_TIME            time /**< Default time to use, can be undefined. MBEDTLS_HAVE_TIME must be enabled */
@@ -3697,8 +3712,8 @@
 
 /* To Use Function Macros MBEDTLS_PLATFORM_C must be enabled */
 /* MBEDTLS_PLATFORM_XXX_MACRO and MBEDTLS_PLATFORM_XXX_ALT cannot both be defined */
-//#define MBEDTLS_PLATFORM_CALLOC_MACRO        calloc /**< Default allocator macro to use, can be undefined */
-//#define MBEDTLS_PLATFORM_FREE_MACRO            free /**< Default free macro to use, can be undefined */
+//#define MBEDTLS_PLATFORM_CALLOC_MACRO        calloc /**< Default allocator macro to use, can be undefined. See MBEDTLS_PLATFORM_STD_CALLOC for requirements. */
+//#define MBEDTLS_PLATFORM_FREE_MACRO            free /**< Default free macro to use, can be undefined. See MBEDTLS_PLATFORM_STD_FREE for requirements. */
 //#define MBEDTLS_PLATFORM_EXIT_MACRO            exit /**< Default exit macro to use, can be undefined */
 //#define MBEDTLS_PLATFORM_SETBUF_MACRO      setbuf /**< Default setbuf macro to use, can be undefined */
 //#define MBEDTLS_PLATFORM_TIME_MACRO            time /**< Default time macro to use, can be undefined. MBEDTLS_HAVE_TIME must be enabled */

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -172,14 +172,46 @@
  * This allows different allocators (self-implemented or provided) to be
  * provided to the platform abstraction layer.
  *
- * Enabling MBEDTLS_PLATFORM_MEMORY without the
+ * Enabling #MBEDTLS_PLATFORM_MEMORY without the
  * MBEDTLS_PLATFORM_{FREE,CALLOC}_MACROs will provide
  * "mbedtls_platform_set_calloc_free()" allowing you to set an alternative calloc() and
  * free() function pointer at runtime.
  *
- * Enabling MBEDTLS_PLATFORM_MEMORY and specifying
+ * Enabling #MBEDTLS_PLATFORM_MEMORY and specifying
  * MBEDTLS_PLATFORM_{CALLOC,FREE}_MACROs will allow you to specify the
  * alternate function at compile time.
+ *
+ * An overview of how the value of mbedtls_calloc is determined:
+ *
+ * - if !MBEDTLS_PLATFORM_MEMORY
+ *     - mbedtls_calloc = calloc
+ * - if MBEDTLS_PLATFORM_MEMORY
+ *     - if (MBEDTLS_PLATFORM_CALLOC_MACRO && MBEDTLS_PLATFORM_FREE_MACRO):
+ *         - mbedtls_calloc = MBEDTLS_PLATFORM_CALLOC_MACRO
+ *     - if !(MBEDTLS_PLATFORM_CALLOC_MACRO && MBEDTLS_PLATFORM_FREE_MACRO):
+ *         - Dynamic setup via mbedtls_platform_set_calloc_free is now possible with a default value MBEDTLS_PLATFORM_STD_CALLOC.
+ *         - How is MBEDTLS_PLATFORM_STD_CALLOC handled?
+ *         - if MBEDTLS_PLATFORM_NO_STD_FUNCTIONS:
+ *             - MBEDTLS_PLATFORM_STD_CALLOC is not set to anything;
+ *             - MBEDTLS_PLATFORM_STD_MEM_HDR can be included if present;
+ *         - if !MBEDTLS_PLATFORM_NO_STD_FUNCTIONS:
+ *             - if MBEDTLS_PLATFORM_STD_CALLOC is present:
+ *                 - User-defined MBEDTLS_PLATFORM_STD_CALLOC is respected;
+ *             - if !MBEDTLS_PLATFORM_STD_CALLOC:
+ *                 - MBEDTLS_PLATFORM_STD_CALLOC = calloc
+ *
+ *         - At this point the presence of MBEDTLS_PLATFORM_STD_CALLOC is checked.
+ *         - if !MBEDTLS_PLATFORM_STD_CALLOC
+ *             - MBEDTLS_PLATFORM_STD_CALLOC = uninitialized_calloc
+ *
+ *         - mbedtls_calloc = MBEDTLS_PLATFORM_STD_CALLOC.
+ *
+ * Defining MBEDTLS_PLATFORM_CALLOC_MACRO and #MBEDTLS_PLATFORM_STD_CALLOC at the same time is not possible.
+ * MBEDTLS_PLATFORM_CALLOC_MACRO and MBEDTLS_PLATFORM_FREE_MACRO must both be defined or undefined at the same time.
+ * #MBEDTLS_PLATFORM_STD_CALLOC and #MBEDTLS_PLATFORM_STD_FREE do not have to be defined at the same time, as, if they are used,
+ * dynamic setup of these functions is possible. See the tree above to see how are they handled in all cases.
+ * An uninitialized #MBEDTLS_PLATFORM_STD_CALLOC always fails, returning a null pointer.
+ * An uninitialized #MBEDTLS_PLATFORM_STD_FREE does not do anything.
  *
  * Requires: MBEDTLS_PLATFORM_C
  *
@@ -3681,53 +3713,26 @@
 /* Platform options */
 //#define MBEDTLS_PLATFORM_STD_MEM_HDR   <stdlib.h> /**< Header to include if MBEDTLS_PLATFORM_NO_STD_FUNCTIONS is defined. Don't define if no header is needed. */
 
-/* An overview of how the value of mbedtls_calloc is determined:
- *
- * if !MBEDTLS_PLATFORM_MEMORY
- *     mbedtls_calloc = calloc
- * if MBEDTLS_PLATFORM_MEMORY
- *     if (MBEDTLS_PLATFORM_CALLOC_MACRO && MBEDTLS_PLATFORM_FREE_MACRO):
- *         mbedtls_calloc = MBEDTLS_PLATFORM_CALLOC_MACRO
- *     if !(MBEDTLS_PLATFORM_CALLOC_MACRO && MBEDTLS_PLATFORM_FREE_MACRO):
- *         Dynamic setup via mbedtls_platform_set_calloc_free is now possible with a default value MBEDTLS_PLATFORM_STD_CALLOC.
- *         How is MBEDTLS_PLATFORM_STD_CALLOC handled?
- *         if MBEDTLS_PLATFORM_NO_STD_FUNCTIONS:
- *             MBEDTLS_PLATFORM_STD_CALLOC is not set to anything;
- *             MBEDTLS_PLATFORM_STD_MEM_HDR can be included if present;
- *         if !MBEDTLS_PLATFORM_NO_STD_FUNCTIONS:
- *             if MBEDTLS_PLATFORM_STD_CALLOC is present:
- *                 User-defined MBEDTLS_PLATFORM_STD_CALLOC is respected;
- *             if !MBEDTLS_PLATFORM_STD_CALLOC:
- *                 MBEDTLS_PLATFORM_STD_CALLOC = calloc
- *
- *         At this point the presence of MBEDTLS_PLATFORM_STD_CALLOC is checked.
- *         if !MBEDTLS_PLATFORM_STD_CALLOC
- *             MBEDTLS_PLATFORM_STD_CALLOC = uninitialized_calloc
- *
- *         mbedtls_calloc = MBEDTLS_PLATFORM_STD_CALLOC.
- *
- * Defining MBEDTLS_PLATFORM_CALLOC_MACRO and MBEDTLS_PLATFORM_STD_CALLOC at the same time is not possible.
- * MBEDTLS_PLATFORM_CALLOC_MACRO and MBEDTLS_PLATFORM_FREE_MACRO must both be defined or undefined at the same time.
- * MBEDTLS_PLATFORM_STD_CALLOC and MBEDTLS_PLATFORM_STD_FREE do not have to be defined at the same time, as, if they are used,
- * dynamic setup of these functions is possible. See the tree above to see how are they handled in all cases.
- */
-
 /** \def MBEDTLS_PLATFORM_STD_CALLOC
  *
- * Default allocator to use, can be undefined. See the description above for details.
+ * Default allocator to use, can be undefined.
  * It must initialize the allocated buffer memory to zeroes.
  * The size of the buffer is the product of the two parameters.
  * The calloc function returns either a null pointer or a pointer to the allocated space.
  * If the product is 0, the function may either return NULL or a valid pointer to an array of size 0 which is a valid input to the deallocation function.
+ * An uninitialized #MBEDTLS_PLATFORM_STD_CALLOC always fails, returning a null pointer.
+ * See the description of #MBEDTLS_PLATFORM_MEMORY for more details.
  * The corresponding deallocation function is #MBEDTLS_PLATFORM_STD_FREE.
  */
 //#define MBEDTLS_PLATFORM_STD_CALLOC        calloc
 
 /** \def MBEDTLS_PLATFORM_STD_FREE
  *
- * Default free to use, can be undefined. See the description above for more details (same principles as for MBEDTLS_PLATFORM_STD_CALLOC apply).
+ * Default free to use, can be undefined.
  * NULL is a valid parameter, and the function must do nothing.
  * A non-null parameter will always be a pointer previously returned by #MBEDTLS_PLATFORM_STD_CALLOC and not yet freed.
+ * An uninitialized #MBEDTLS_PLATFORM_STD_FREE does not do anything.
+ * See the description of #MBEDTLS_PLATFORM_MEMORY for more details (same principles as for MBEDTLS_PLATFORM_STD_CALLOC apply).
  */
 //#define MBEDTLS_PLATFORM_STD_FREE            free
 //#define MBEDTLS_PLATFORM_STD_SETBUF      setbuf /**< Default setbuf to use, can be undefined */

--- a/include/mbedtls/platform.h
+++ b/include/mbedtls/platform.h
@@ -135,7 +135,7 @@ extern "C" {
 
 /*
  * The function pointers for calloc and free.
- * please see MBEDTLS_PLATFORM_STD_CALLOC and MBEDTLS_PLATFORM_STD_FREE
+ * Please see MBEDTLS_PLATFORM_STD_CALLOC and MBEDTLS_PLATFORM_STD_FREE
  * in mbedtls_config.h for more information about behaviour and requirements.
  */
 #if defined(MBEDTLS_PLATFORM_MEMORY)

--- a/include/mbedtls/platform.h
+++ b/include/mbedtls/platform.h
@@ -135,7 +135,8 @@ extern "C" {
 
 /*
  * The function pointers for calloc and free.
- * mbedtls_calloc will allocate and zeroize the buffer.
+ * please see MBEDTLS_PLATFORM_STD_CALLOC and MBEDTLS_PLATFORM_STD_FREE
+ * in mbedtls_config.h for more information about behaviour and requirements.
  */
 #if defined(MBEDTLS_PLATFORM_MEMORY)
 #if defined(MBEDTLS_PLATFORM_FREE_MACRO) && \

--- a/include/mbedtls/platform.h
+++ b/include/mbedtls/platform.h
@@ -130,6 +130,15 @@ extern "C" {
 #endif
 #endif /* MBEDTLS_PLATFORM_NO_STD_FUNCTIONS */
 
+/* Enable certain documented defines only when generating doxygen to avoid
+ * an "unrecognized define" error. */
+#if defined(__DOXYGEN__) && !defined(MBEDTLS_PLATFORM_STD_CALLOC)
+#define MBEDTLS_PLATFORM_STD_CALLOC
+#endif
+
+#if defined(__DOXYGEN__) && !defined(MBEDTLS_PLATFORM_STD_FREE)
+#define MBEDTLS_PLATFORM_STD_FREE
+#endif
 
 /** \} name SECTION: Module settings */
 

--- a/include/mbedtls/platform.h
+++ b/include/mbedtls/platform.h
@@ -135,6 +135,7 @@ extern "C" {
 
 /*
  * The function pointers for calloc and free.
+ * mbedtls_calloc will allocate and zeroize the buffer.
  */
 #if defined(MBEDTLS_PLATFORM_MEMORY)
 #if defined(MBEDTLS_PLATFORM_FREE_MACRO) && \

--- a/programs/test/selftest.c
+++ b/programs/test/selftest.c
@@ -73,8 +73,10 @@ static int calloc_self_test(int verbose)
     void *empty2 = mbedtls_calloc(0, 1);
     void *buffer1 = mbedtls_calloc(1, 1);
     void *buffer2 = mbedtls_calloc(1, 1);
-    unsigned int buf_size = 256;
-    unsigned char *buffer3 = mbedtls_calloc(buf_size, 1);
+    unsigned int buffer_3_size = 256;
+    unsigned int buffer_4_size = 4097; /* Allocate more than the usual page size */
+    unsigned char *buffer3 = mbedtls_calloc(buffer_3_size, 1);
+    unsigned char *buffer4 = mbedtls_calloc(buffer_4_size, 1);
 
     if (empty1 == NULL && empty2 == NULL) {
         if (verbose) {
@@ -148,11 +150,23 @@ static int calloc_self_test(int verbose)
         }
     }
 
-    for (unsigned int i = 0; i < buf_size; i++) {
+    for (unsigned int i = 0; i < buffer_3_size; i++) {
         if (buffer3[i] != 0) {
             ++failures;
             if (verbose) {
-                mbedtls_printf("  CALLOC(%u): failed (memory not initialized to 0)\n", buf_size);
+                mbedtls_printf("  CALLOC(%u): failed (memory not initialized to 0)\n",
+                               buffer_3_size);
+            }
+            break;
+        }
+    }
+
+    for (unsigned int i = 0; i < buffer_4_size; i++) {
+        if (buffer4[i] != 0) {
+            ++failures;
+            if (verbose) {
+                mbedtls_printf("  CALLOC(%u): failed (memory not initialized to 0)\n",
+                               buffer_4_size);
             }
             break;
         }
@@ -166,6 +180,7 @@ static int calloc_self_test(int verbose)
     mbedtls_free(buffer1);
     mbedtls_free(buffer2);
     mbedtls_free(buffer3);
+    mbedtls_free(buffer4);
     return failures;
 }
 #endif /* MBEDTLS_SELF_TEST */

--- a/programs/test/selftest.c
+++ b/programs/test/selftest.c
@@ -77,7 +77,10 @@ static int calloc_self_test(int verbose)
     unsigned int buffer_4_size = 4097; /* Allocate more than the usual page size */
     unsigned char *buffer3 = mbedtls_calloc(buffer_3_size, 1);
     unsigned char *buffer4 = mbedtls_calloc(buffer_4_size, 1);
-
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Walloc-size-larger-than="
+    unsigned char *buffer5 = mbedtls_calloc(SIZE_MAX/2, SIZE_MAX/2);
+#pragma GCC diagnostic pop
     if (empty1 == NULL && empty2 == NULL) {
         if (verbose) {
             mbedtls_printf("  CALLOC(0,1): passed (NULL)\n");
@@ -172,6 +175,13 @@ static int calloc_self_test(int verbose)
         }
     }
 
+    if (buffer5 != NULL) {
+        ++failures;
+        if (verbose) {
+            mbedtls_printf("  CALLOC(SIZE_MAX/2, SIZE_MAX/2): failed (returned a valid pointer)\n");
+        }
+    }
+
     if (verbose) {
         mbedtls_printf("\n");
     }
@@ -181,6 +191,7 @@ static int calloc_self_test(int verbose)
     mbedtls_free(buffer2);
     mbedtls_free(buffer3);
     mbedtls_free(buffer4);
+    mbedtls_free(buffer5);
     return failures;
 }
 #endif /* MBEDTLS_SELF_TEST */

--- a/programs/test/selftest.c
+++ b/programs/test/selftest.c
@@ -74,7 +74,7 @@ static int calloc_self_test(int verbose)
     void *buffer1 = mbedtls_calloc(1, 1);
     void *buffer2 = mbedtls_calloc(1, 1);
     unsigned int buf_size = 256;
-    unsigned char *buffer3 = mbedtls_calloc(buf_size, sizeof(unsigned char));
+    unsigned char *buffer3 = mbedtls_calloc(buf_size, 1);
 
     if (empty1 == NULL && empty2 == NULL) {
         if (verbose) {

--- a/programs/test/selftest.c
+++ b/programs/test/selftest.c
@@ -73,23 +73,49 @@ static int calloc_self_test(int verbose)
     void *empty2 = mbedtls_calloc(0, 1);
     void *buffer1 = mbedtls_calloc(1, 1);
     void *buffer2 = mbedtls_calloc(1, 1);
+    unsigned int buf_size = 256;
+    unsigned char *buffer3 = mbedtls_calloc(buf_size, sizeof(unsigned char));
 
     if (empty1 == NULL && empty2 == NULL) {
         if (verbose) {
-            mbedtls_printf("  CALLOC(0): passed (NULL)\n");
+            mbedtls_printf("  CALLOC(0,1): passed (NULL)\n");
         }
     } else if (empty1 == NULL || empty2 == NULL) {
         if (verbose) {
-            mbedtls_printf("  CALLOC(0): failed (mix of NULL and non-NULL)\n");
+            mbedtls_printf("  CALLOC(0,1): failed (mix of NULL and non-NULL)\n");
         }
         ++failures;
     } else if (empty1 == empty2) {
         if (verbose) {
-            mbedtls_printf("  CALLOC(0): passed (same non-null)\n");
+            mbedtls_printf("  CALLOC(0,1): passed (same non-null)\n");
         }
     } else {
         if (verbose) {
-            mbedtls_printf("  CALLOC(0): passed (distinct non-null)\n");
+            mbedtls_printf("  CALLOC(0,1): passed (distinct non-null)\n");
+        }
+    }
+
+    mbedtls_free(empty1);
+    mbedtls_free(empty2);
+
+    empty1 = mbedtls_calloc(1, 0);
+    empty2 = mbedtls_calloc(1, 0);
+    if (empty1 == NULL && empty2 == NULL) {
+        if (verbose) {
+            mbedtls_printf("  CALLOC(1,0): passed (NULL)\n");
+        }
+    } else if (empty1 == NULL || empty2 == NULL) {
+        if (verbose) {
+            mbedtls_printf("  CALLOC(1,0): failed (mix of NULL and non-NULL)\n");
+        }
+        ++failures;
+    } else if (empty1 == empty2) {
+        if (verbose) {
+            mbedtls_printf("  CALLOC(1,0): passed (same non-null)\n");
+        }
+    } else {
+        if (verbose) {
+            mbedtls_printf("  CALLOC(1,0): passed (distinct non-null)\n");
         }
     }
 
@@ -122,6 +148,16 @@ static int calloc_self_test(int verbose)
         }
     }
 
+    for (unsigned int i = 0; i < buf_size; i++) {
+        if (buffer3[i] != 0) {
+            ++failures;
+            if (verbose) {
+                mbedtls_printf("  CALLOC(%u): failed (memory not initialized to 0)\n", buf_size);
+            }
+            break;
+        }
+    }
+
     if (verbose) {
         mbedtls_printf("\n");
     }
@@ -129,6 +165,7 @@ static int calloc_self_test(int verbose)
     mbedtls_free(empty2);
     mbedtls_free(buffer1);
     mbedtls_free(buffer2);
+    mbedtls_free(buffer3);
     return failures;
 }
 #endif /* MBEDTLS_SELF_TEST */

--- a/programs/test/selftest.c
+++ b/programs/test/selftest.c
@@ -77,10 +77,7 @@ static int calloc_self_test(int verbose)
     unsigned int buffer_4_size = 4097; /* Allocate more than the usual page size */
     unsigned char *buffer3 = mbedtls_calloc(buffer_3_size, 1);
     unsigned char *buffer4 = mbedtls_calloc(buffer_4_size, 1);
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Walloc-size-larger-than="
-    unsigned char *buffer5 = mbedtls_calloc(SIZE_MAX/2, SIZE_MAX/2);
-#pragma GCC diagnostic pop
+
     if (empty1 == NULL && empty2 == NULL) {
         if (verbose) {
             mbedtls_printf("  CALLOC(0,1): passed (NULL)\n");
@@ -175,13 +172,6 @@ static int calloc_self_test(int verbose)
         }
     }
 
-    if (buffer5 != NULL) {
-        ++failures;
-        if (verbose) {
-            mbedtls_printf("  CALLOC(SIZE_MAX/2, SIZE_MAX/2): failed (returned a valid pointer)\n");
-        }
-    }
-
     if (verbose) {
         mbedtls_printf("\n");
     }
@@ -191,7 +181,6 @@ static int calloc_self_test(int verbose)
     mbedtls_free(buffer2);
     mbedtls_free(buffer3);
     mbedtls_free(buffer4);
-    mbedtls_free(buffer5);
     return failures;
 }
 #endif /* MBEDTLS_SELF_TEST */

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -189,6 +189,9 @@ pre_initialize_variables () {
     # default to -O2, use -Ox _after_ this if you want another level
     ASAN_CFLAGS='-O2 -Werror -fsanitize=address,undefined -fno-sanitize-recover=all'
 
+    # Platform tests have an allocation that returns null
+    export ASAN_OPTIONS="allocator_may_return_null=1"
+
     # Gather the list of available components. These are the functions
     # defined in this script whose name starts with "component_".
     # Parse the script with sed. This way we get the functions in the order

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -191,6 +191,7 @@ pre_initialize_variables () {
 
     # Platform tests have an allocation that returns null
     export ASAN_OPTIONS="allocator_may_return_null=1"
+    export MSAN_OPTIONS="allocator_may_return_null=1"
 
     # Gather the list of available components. These are the functions
     # defined in this script whose name starts with "component_".

--- a/tests/suites/test_suite_platform.data
+++ b/tests/suites/test_suite_platform.data
@@ -4,3 +4,6 @@ time_get_milliseconds:
 
 Time: get seconds
 time_get_seconds:
+
+Check mbedtls_calloc overallocation
+check_mbedtls_calloc_overallocation:SIZE_MAX/2:SIZE_MAX/2

--- a/tests/suites/test_suite_platform.data
+++ b/tests/suites/test_suite_platform.data
@@ -4,6 +4,3 @@ time_get_milliseconds:
 
 Time: get seconds
 time_get_seconds:
-
-Check mbedtls_calloc zeroization
-check_mbedtls_calloc_zeroization:

--- a/tests/suites/test_suite_platform.data
+++ b/tests/suites/test_suite_platform.data
@@ -4,3 +4,6 @@ time_get_milliseconds:
 
 Time: get seconds
 time_get_seconds:
+
+Check mbedtls_calloc zeroization
+check_mbedtls_calloc_zeroization:

--- a/tests/suites/test_suite_platform.function
+++ b/tests/suites/test_suite_platform.function
@@ -120,3 +120,17 @@ void time_delay_seconds(int delay_secs)
     goto exit;
 }
 /* END_CASE */
+
+/* BEGIN_CASE */
+void check_mbedtls_calloc_zeroization()
+{
+    unsigned int buf_size = 256;
+    unsigned char *buf;
+    buf = mbedtls_calloc(buf_size, sizeof(unsigned char));
+    for (unsigned int i = 0; i < buf_size; i++) {
+        TEST_EQUAL(buf[i], 0);
+    }
+exit:
+    mbedtls_free(buf);
+}
+/* END_CASE */

--- a/tests/suites/test_suite_platform.function
+++ b/tests/suites/test_suite_platform.function
@@ -126,6 +126,8 @@ void check_mbedtls_calloc_overallocation(intmax_t num, intmax_t size)
 {
     unsigned char *buf;
     buf = mbedtls_calloc((size_t) num, (size_t) size);
+    /* Dummy usage of the pointer to prevent optimizing it */
+    mbedtls_printf("calloc pointer : %p\n", buf);
     TEST_ASSERT(buf == NULL);
 
 exit:

--- a/tests/suites/test_suite_platform.function
+++ b/tests/suites/test_suite_platform.function
@@ -120,17 +120,3 @@ void time_delay_seconds(int delay_secs)
     goto exit;
 }
 /* END_CASE */
-
-/* BEGIN_CASE */
-void check_mbedtls_calloc_zeroization()
-{
-    unsigned int buf_size = 256;
-    unsigned char *buf;
-    buf = mbedtls_calloc(buf_size, sizeof(unsigned char));
-    for (unsigned int i = 0; i < buf_size; i++) {
-        TEST_EQUAL(buf[i], 0);
-    }
-exit:
-    mbedtls_free(buf);
-}
-/* END_CASE */

--- a/tests/suites/test_suite_platform.function
+++ b/tests/suites/test_suite_platform.function
@@ -120,3 +120,15 @@ void time_delay_seconds(int delay_secs)
     goto exit;
 }
 /* END_CASE */
+
+/* BEGIN_CASE */
+void check_mbedtls_calloc_overallocation(intmax_t num, intmax_t size)
+{
+    unsigned char *buf;
+    buf = mbedtls_calloc((size_t) num, (size_t) size);
+    TEST_ASSERT(buf == NULL);
+
+exit:
+    mbedtls_free(buf);
+}
+/* END_CASE */


### PR DESCRIPTION
Update the documentation on the fact that `mbedtls_calloc` also zeroizes the buffer.

## Gatekeeper checklist

- [x] **changelog** not provided - it's a doc update
- [x] **backport** - [here](https://github.com/Mbed-TLS/mbedtls/pull/7487)
- [x] **tests** - test added