### PR TITLE
Backport 2.28: Init PSA in ssl and x509 programs

### DIFF
--- a/ChangeLog.d/programs_psa_fix.txt
+++ b/ChangeLog.d/programs_psa_fix.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix missing PSA initialization in sample programs when
+     MBEDTLS_USE_PSA_CRYPTO is enabled.

--- a/programs/fuzz/fuzz_client.c
+++ b/programs/fuzz/fuzz_client.c
@@ -191,7 +191,9 @@ exit:
     mbedtls_ctr_drbg_free(&ctr_drbg);
     mbedtls_ssl_config_free(&conf);
     mbedtls_ssl_free(&ssl);
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     mbedtls_psa_crypto_free();
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 #else
     (void) Data;

--- a/programs/fuzz/fuzz_client.c
+++ b/programs/fuzz/fuzz_client.c
@@ -77,6 +77,13 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
     mbedtls_ctr_drbg_init(&ctr_drbg);
     mbedtls_entropy_init(&entropy);
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_status_t status = psa_crypto_init();
+    if (status != PSA_SUCCESS) {
+        goto exit;
+    }
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
+
     if (mbedtls_ctr_drbg_seed(&ctr_drbg, dummy_entropy, &entropy,
                               (const unsigned char *) pers, strlen(pers)) != 0) {
         goto exit;
@@ -184,6 +191,7 @@ exit:
     mbedtls_ctr_drbg_free(&ctr_drbg);
     mbedtls_ssl_config_free(&conf);
     mbedtls_ssl_free(&ssl);
+    mbedtls_psa_crypto_free();
 
 #else
     (void) Data;

--- a/programs/fuzz/fuzz_dtlsclient.c
+++ b/programs/fuzz/fuzz_dtlsclient.c
@@ -61,6 +61,13 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
     mbedtls_ctr_drbg_init(&ctr_drbg);
     mbedtls_entropy_init(&entropy);
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_status_t status = psa_crypto_init();
+    if (status != PSA_SUCCESS) {
+        goto exit;
+    }
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
+
     srand(1);
     if (mbedtls_ctr_drbg_seed(&ctr_drbg, dummy_entropy, &entropy,
                               (const unsigned char *) pers, strlen(pers)) != 0) {
@@ -119,6 +126,7 @@ exit:
     mbedtls_ctr_drbg_free(&ctr_drbg);
     mbedtls_ssl_config_free(&conf);
     mbedtls_ssl_free(&ssl);
+    mbedtls_psa_crypto_free();
 
 #else
     (void) Data;

--- a/programs/fuzz/fuzz_dtlsclient.c
+++ b/programs/fuzz/fuzz_dtlsclient.c
@@ -126,7 +126,9 @@ exit:
     mbedtls_ctr_drbg_free(&ctr_drbg);
     mbedtls_ssl_config_free(&conf);
     mbedtls_ssl_free(&ssl);
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     mbedtls_psa_crypto_free();
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 #else
     (void) Data;

--- a/programs/fuzz/fuzz_dtlsserver.c
+++ b/programs/fuzz/fuzz_dtlsserver.c
@@ -166,7 +166,9 @@ exit:
     mbedtls_ctr_drbg_free(&ctr_drbg);
     mbedtls_ssl_config_free(&conf);
     mbedtls_ssl_free(&ssl);
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     mbedtls_psa_crypto_free();
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 #else
     (void) Data;

--- a/programs/fuzz/fuzz_dtlsserver.c
+++ b/programs/fuzz/fuzz_dtlsserver.c
@@ -74,6 +74,13 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
     mbedtls_entropy_init(&entropy);
     mbedtls_ssl_cookie_init(&cookie_ctx);
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_status_t status = psa_crypto_init();
+    if (status != PSA_SUCCESS) {
+        goto exit;
+    }
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
+
     if (mbedtls_ctr_drbg_seed(&ctr_drbg, dummy_entropy, &entropy,
                               (const unsigned char *) pers, strlen(pers)) != 0) {
         goto exit;
@@ -152,9 +159,14 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 exit:
     mbedtls_ssl_cookie_free(&cookie_ctx);
     mbedtls_entropy_free(&entropy);
+#if defined(MBEDTLS_X509_CRT_PARSE_C) && defined(MBEDTLS_PEM_PARSE_C)
+    mbedtls_pk_free(&pkey);
+    mbedtls_x509_crt_free(&srvcert);
+#endif
     mbedtls_ctr_drbg_free(&ctr_drbg);
     mbedtls_ssl_config_free(&conf);
     mbedtls_ssl_free(&ssl);
+    mbedtls_psa_crypto_free();
 
 #else
     (void) Data;

--- a/programs/fuzz/fuzz_privkey.c
+++ b/programs/fuzz/fuzz_privkey.c
@@ -71,9 +71,11 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
             abort();
         }
     }
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
 exit:
-    mbedtls_pk_free(&pk);
     mbedtls_psa_crypto_free();
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
+    mbedtls_pk_free(&pk);
 #else
     (void) Data;
     (void) Size;

--- a/programs/fuzz/fuzz_privkey.c
+++ b/programs/fuzz/fuzz_privkey.c
@@ -18,6 +18,14 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
     }
 
     mbedtls_pk_init(&pk);
+
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_status_t status = psa_crypto_init();
+    if (status != PSA_SUCCESS) {
+        goto exit;
+    }
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
+
     ret = mbedtls_pk_parse_key(&pk, Data, Size, NULL, 0);
     if (ret == 0) {
 #if defined(MBEDTLS_RSA_C)
@@ -63,7 +71,9 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
             abort();
         }
     }
+exit:
     mbedtls_pk_free(&pk);
+    mbedtls_psa_crypto_free();
 #else
     (void) Data;
     (void) Size;

--- a/programs/fuzz/fuzz_pubkey.c
+++ b/programs/fuzz/fuzz_pubkey.c
@@ -74,7 +74,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 exit:
     mbedtls_psa_crypto_free();
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
-mbedtls_pk_free(&pk);
+    mbedtls_pk_free(&pk);
 #else
     (void) Data;
     (void) Size;

--- a/programs/fuzz/fuzz_pubkey.c
+++ b/programs/fuzz/fuzz_pubkey.c
@@ -70,9 +70,11 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
             abort();
         }
     }
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
 exit:
-    mbedtls_pk_free(&pk);
     mbedtls_psa_crypto_free();
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
+mbedtls_pk_free(&pk);
 #else
     (void) Data;
     (void) Size;

--- a/programs/fuzz/fuzz_pubkey.c
+++ b/programs/fuzz/fuzz_pubkey.c
@@ -9,6 +9,12 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
     mbedtls_pk_context pk;
 
     mbedtls_pk_init(&pk);
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_status_t status = psa_crypto_init();
+    if (status != PSA_SUCCESS) {
+        goto exit;
+    }
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
     ret = mbedtls_pk_parse_public_key(&pk, Data, Size);
     if (ret == 0) {
 #if defined(MBEDTLS_RSA_C)
@@ -64,7 +70,9 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
             abort();
         }
     }
+exit:
     mbedtls_pk_free(&pk);
+    mbedtls_psa_crypto_free();
 #else
     (void) Data;
     (void) Size;

--- a/programs/fuzz/fuzz_server.c
+++ b/programs/fuzz/fuzz_server.c
@@ -89,6 +89,13 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
     mbedtls_ssl_ticket_init(&ticket_ctx);
 #endif
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_status_t status = psa_crypto_init();
+    if (status != PSA_SUCCESS) {
+        goto exit;
+    }
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
+
     if (mbedtls_ctr_drbg_seed(&ctr_drbg, dummy_entropy, &entropy,
                               (const unsigned char *) pers, strlen(pers)) != 0) {
         goto exit;
@@ -195,8 +202,14 @@ exit:
     mbedtls_entropy_free(&entropy);
     mbedtls_ctr_drbg_free(&ctr_drbg);
     mbedtls_ssl_config_free(&conf);
+#if defined(MBEDTLS_X509_CRT_PARSE_C) && defined(MBEDTLS_PEM_PARSE_C)
+    mbedtls_x509_crt_free(&srvcert);
+    mbedtls_pk_free(&pkey);
+#endif
     mbedtls_ssl_free(&ssl);
-
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    mbedtls_psa_crypto_free();
+#endif
 #else
     (void) Data;
     (void) Size;

--- a/programs/fuzz/fuzz_x509crl.c
+++ b/programs/fuzz/fuzz_x509crl.c
@@ -19,9 +19,11 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
     if (ret == 0) {
         ret = mbedtls_x509_crl_info((char *) buf, sizeof(buf) - 1, " ", &crl);
     }
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
 exit:
-    mbedtls_x509_crl_free(&crl);
     mbedtls_psa_crypto_free();
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
+    mbedtls_x509_crl_free(&crl);
 #else
     (void) Data;
     (void) Size;

--- a/programs/fuzz/fuzz_x509crl.c
+++ b/programs/fuzz/fuzz_x509crl.c
@@ -9,11 +9,19 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
     unsigned char buf[4096];
 
     mbedtls_x509_crl_init(&crl);
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_status_t status = psa_crypto_init();
+    if (status != PSA_SUCCESS) {
+        goto exit;
+    }
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
     ret = mbedtls_x509_crl_parse(&crl, Data, Size);
     if (ret == 0) {
         ret = mbedtls_x509_crl_info((char *) buf, sizeof(buf) - 1, " ", &crl);
     }
+exit:
     mbedtls_x509_crl_free(&crl);
+    mbedtls_psa_crypto_free();
 #else
     (void) Data;
     (void) Size;

--- a/programs/fuzz/fuzz_x509crt.c
+++ b/programs/fuzz/fuzz_x509crt.c
@@ -19,9 +19,11 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
     if (ret == 0) {
         ret = mbedtls_x509_crt_info((char *) buf, sizeof(buf) - 1, " ", &crt);
     }
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
 exit:
-    mbedtls_x509_crt_free(&crt);
     mbedtls_psa_crypto_free();
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
+    mbedtls_x509_crt_free(&crt);
 #else
     (void) Data;
     (void) Size;

--- a/programs/fuzz/fuzz_x509crt.c
+++ b/programs/fuzz/fuzz_x509crt.c
@@ -9,11 +9,19 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
     unsigned char buf[4096];
 
     mbedtls_x509_crt_init(&crt);
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_status_t status = psa_crypto_init();
+    if (status != PSA_SUCCESS) {
+        goto exit;
+    }
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
     ret = mbedtls_x509_crt_parse(&crt, Data, Size);
     if (ret == 0) {
         ret = mbedtls_x509_crt_info((char *) buf, sizeof(buf) - 1, " ", &crt);
     }
+exit:
     mbedtls_x509_crt_free(&crt);
+    mbedtls_psa_crypto_free();
 #else
     (void) Data;
     (void) Size;

--- a/programs/fuzz/fuzz_x509csr.c
+++ b/programs/fuzz/fuzz_x509csr.c
@@ -19,9 +19,11 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
     if (ret == 0) {
         ret = mbedtls_x509_csr_info((char *) buf, sizeof(buf) - 1, " ", &csr);
     }
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
 exit:
-    mbedtls_x509_csr_free(&csr);
     mbedtls_psa_crypto_free();
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
+mbedtls_x509_csr_free(&csr);
 #else
     (void) Data;
     (void) Size;

--- a/programs/fuzz/fuzz_x509csr.c
+++ b/programs/fuzz/fuzz_x509csr.c
@@ -23,7 +23,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 exit:
     mbedtls_psa_crypto_free();
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
-mbedtls_x509_csr_free(&csr);
+    mbedtls_x509_csr_free(&csr);
 #else
     (void) Data;
     (void) Size;

--- a/programs/fuzz/fuzz_x509csr.c
+++ b/programs/fuzz/fuzz_x509csr.c
@@ -9,11 +9,19 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
     unsigned char buf[4096];
 
     mbedtls_x509_csr_init(&csr);
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_status_t status = psa_crypto_init();
+    if (status != PSA_SUCCESS) {
+        goto exit;
+    }
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
     ret = mbedtls_x509_csr_parse(&csr, Data, Size);
     if (ret == 0) {
         ret = mbedtls_x509_csr_info((char *) buf, sizeof(buf) - 1, " ", &csr);
     }
+exit:
     mbedtls_x509_csr_free(&csr);
+    mbedtls_psa_crypto_free();
 #else
     (void) Data;
     (void) Size;

--- a/programs/pkey/gen_key.c
+++ b/programs/pkey/gen_key.c
@@ -420,7 +420,9 @@ exit:
     mbedtls_pk_free(&key);
     mbedtls_ctr_drbg_free(&ctr_drbg);
     mbedtls_entropy_free(&entropy);
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     mbedtls_psa_crypto_free();
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 #if defined(_WIN32)
     mbedtls_printf("  + Press Enter to exit this program.\n");

--- a/programs/pkey/gen_key.c
+++ b/programs/pkey/gen_key.c
@@ -204,6 +204,15 @@ int main(int argc, char *argv[])
     mbedtls_ctr_drbg_init(&ctr_drbg);
     memset(buf, 0, sizeof(buf));
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_status_t status = psa_crypto_init();
+    if (status != PSA_SUCCESS) {
+        mbedtls_fprintf(stderr, "Failed to initialize PSA Crypto implementation: %d\n",
+                        (int) status);
+        goto exit;
+    }
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
+
     if (argc < 2) {
 usage:
         mbedtls_printf(USAGE);
@@ -411,6 +420,7 @@ exit:
     mbedtls_pk_free(&key);
     mbedtls_ctr_drbg_free(&ctr_drbg);
     mbedtls_entropy_free(&entropy);
+    mbedtls_psa_crypto_free();
 
 #if defined(_WIN32)
     mbedtls_printf("  + Press Enter to exit this program.\n");

--- a/programs/pkey/key_app.c
+++ b/programs/pkey/key_app.c
@@ -284,7 +284,9 @@ cleanup:
 #endif
 
     mbedtls_pk_free(&pk);
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     mbedtls_psa_crypto_free();
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
     mbedtls_mpi_free(&N); mbedtls_mpi_free(&P); mbedtls_mpi_free(&Q);
     mbedtls_mpi_free(&D); mbedtls_mpi_free(&E); mbedtls_mpi_free(&DP);
     mbedtls_mpi_free(&DQ); mbedtls_mpi_free(&QP);

--- a/programs/pkey/key_app.c
+++ b/programs/pkey/key_app.c
@@ -91,6 +91,15 @@ int main(int argc, char *argv[])
     mbedtls_pk_init(&pk);
     memset(buf, 0, sizeof(buf));
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_status_t status = psa_crypto_init();
+    if (status != PSA_SUCCESS) {
+        mbedtls_fprintf(stderr, "Failed to initialize PSA Crypto implementation: %d\n",
+                        (int) status);
+        goto cleanup;
+    }
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
+
     mbedtls_mpi_init(&N); mbedtls_mpi_init(&P); mbedtls_mpi_init(&Q);
     mbedtls_mpi_init(&D); mbedtls_mpi_init(&E); mbedtls_mpi_init(&DP);
     mbedtls_mpi_init(&DQ); mbedtls_mpi_init(&QP);
@@ -275,6 +284,7 @@ cleanup:
 #endif
 
     mbedtls_pk_free(&pk);
+    mbedtls_psa_crypto_free();
     mbedtls_mpi_free(&N); mbedtls_mpi_free(&P); mbedtls_mpi_free(&Q);
     mbedtls_mpi_free(&D); mbedtls_mpi_free(&E); mbedtls_mpi_free(&DP);
     mbedtls_mpi_free(&DQ); mbedtls_mpi_free(&QP);

--- a/programs/pkey/key_app_writer.c
+++ b/programs/pkey/key_app_writer.c
@@ -409,7 +409,9 @@ exit:
     mbedtls_mpi_free(&DQ); mbedtls_mpi_free(&QP);
 
     mbedtls_pk_free(&key);
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     mbedtls_psa_crypto_free();
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 #if defined(_WIN32)
     mbedtls_printf("  + Press Enter to exit this program.\n");

--- a/programs/pkey/key_app_writer.c
+++ b/programs/pkey/key_app_writer.c
@@ -205,6 +205,15 @@ int main(int argc, char *argv[])
     memset(buf, 0, sizeof(buf));
 #endif
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_status_t status = psa_crypto_init();
+    if (status != PSA_SUCCESS) {
+        mbedtls_fprintf(stderr, "Failed to initialize PSA Crypto implementation: %d\n",
+                        (int) status);
+        goto exit;
+    }
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
+
     mbedtls_mpi_init(&N); mbedtls_mpi_init(&P); mbedtls_mpi_init(&Q);
     mbedtls_mpi_init(&D); mbedtls_mpi_init(&E); mbedtls_mpi_init(&DP);
     mbedtls_mpi_init(&DQ); mbedtls_mpi_init(&QP);
@@ -400,6 +409,7 @@ exit:
     mbedtls_mpi_free(&DQ); mbedtls_mpi_free(&QP);
 
     mbedtls_pk_free(&key);
+    mbedtls_psa_crypto_free();
 
 #if defined(_WIN32)
     mbedtls_printf("  + Press Enter to exit this program.\n");

--- a/programs/pkey/pk_decrypt.c
+++ b/programs/pkey/pk_decrypt.c
@@ -71,6 +71,15 @@ int main(int argc, char *argv[])
 
     memset(result, 0, sizeof(result));
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_status_t status = psa_crypto_init();
+    if (status != PSA_SUCCESS) {
+        mbedtls_fprintf(stderr, "Failed to initialize PSA Crypto implementation: %d\n",
+                        (int) status);
+        goto exit;
+    }
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
+
     if (argc != 2) {
         mbedtls_printf("usage: mbedtls_pk_decrypt <key_file>\n");
 
@@ -142,6 +151,7 @@ exit:
     mbedtls_pk_free(&pk);
     mbedtls_entropy_free(&entropy);
     mbedtls_ctr_drbg_free(&ctr_drbg);
+    mbedtls_psa_crypto_free();
 
 #if defined(MBEDTLS_ERROR_C)
     if (exit_code != MBEDTLS_EXIT_SUCCESS) {

--- a/programs/pkey/pk_decrypt.c
+++ b/programs/pkey/pk_decrypt.c
@@ -151,7 +151,9 @@ exit:
     mbedtls_pk_free(&pk);
     mbedtls_entropy_free(&entropy);
     mbedtls_ctr_drbg_free(&ctr_drbg);
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     mbedtls_psa_crypto_free();
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 #if defined(MBEDTLS_ERROR_C)
     if (exit_code != MBEDTLS_EXIT_SUCCESS) {

--- a/programs/pkey/pk_encrypt.c
+++ b/programs/pkey/pk_encrypt.c
@@ -67,6 +67,15 @@ int main(int argc, char *argv[])
     mbedtls_entropy_init(&entropy);
     mbedtls_pk_init(&pk);
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_status_t status = psa_crypto_init();
+    if (status != PSA_SUCCESS) {
+        mbedtls_fprintf(stderr, "Failed to initialize PSA Crypto implementation: %d\n",
+                        (int) status);
+        goto exit;
+    }
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
+
     if (argc != 3) {
         mbedtls_printf("usage: mbedtls_pk_encrypt <key_file> <string of max 100 characters>\n");
 
@@ -144,6 +153,7 @@ exit:
     mbedtls_pk_free(&pk);
     mbedtls_entropy_free(&entropy);
     mbedtls_ctr_drbg_free(&ctr_drbg);
+    mbedtls_psa_crypto_free();
 
 #if defined(MBEDTLS_ERROR_C)
     if (exit_code != MBEDTLS_EXIT_SUCCESS) {

--- a/programs/pkey/pk_encrypt.c
+++ b/programs/pkey/pk_encrypt.c
@@ -153,7 +153,9 @@ exit:
     mbedtls_pk_free(&pk);
     mbedtls_entropy_free(&entropy);
     mbedtls_ctr_drbg_free(&ctr_drbg);
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     mbedtls_psa_crypto_free();
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 #if defined(MBEDTLS_ERROR_C)
     if (exit_code != MBEDTLS_EXIT_SUCCESS) {

--- a/programs/pkey/pk_sign.c
+++ b/programs/pkey/pk_sign.c
@@ -66,6 +66,15 @@ int main(int argc, char *argv[])
     mbedtls_ctr_drbg_init(&ctr_drbg);
     mbedtls_pk_init(&pk);
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_status_t status = psa_crypto_init();
+    if (status != PSA_SUCCESS) {
+        mbedtls_fprintf(stderr, "Failed to initialize PSA Crypto implementation: %d\n",
+                        (int) status);
+        goto exit;
+    }
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
+
     if (argc != 3) {
         mbedtls_printf("usage: mbedtls_pk_sign <key_file> <filename>\n");
 
@@ -141,6 +150,7 @@ exit:
     mbedtls_pk_free(&pk);
     mbedtls_ctr_drbg_free(&ctr_drbg);
     mbedtls_entropy_free(&entropy);
+    mbedtls_psa_crypto_free();
 
 #if defined(MBEDTLS_ERROR_C)
     if (exit_code != MBEDTLS_EXIT_SUCCESS) {

--- a/programs/pkey/pk_sign.c
+++ b/programs/pkey/pk_sign.c
@@ -150,7 +150,9 @@ exit:
     mbedtls_pk_free(&pk);
     mbedtls_ctr_drbg_free(&ctr_drbg);
     mbedtls_entropy_free(&entropy);
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     mbedtls_psa_crypto_free();
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 #if defined(MBEDTLS_ERROR_C)
     if (exit_code != MBEDTLS_EXIT_SUCCESS) {

--- a/programs/pkey/pk_verify.c
+++ b/programs/pkey/pk_verify.c
@@ -126,7 +126,9 @@ int main(int argc, char *argv[])
 
 exit:
     mbedtls_pk_free(&pk);
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     mbedtls_psa_crypto_free();
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 #if defined(MBEDTLS_ERROR_C)
     if (exit_code != MBEDTLS_EXIT_SUCCESS) {

--- a/programs/pkey/pk_verify.c
+++ b/programs/pkey/pk_verify.c
@@ -58,6 +58,15 @@ int main(int argc, char *argv[])
 
     mbedtls_pk_init(&pk);
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_status_t status = psa_crypto_init();
+    if (status != PSA_SUCCESS) {
+        mbedtls_fprintf(stderr, "Failed to initialize PSA Crypto implementation: %d\n",
+                        (int) status);
+        goto exit;
+    }
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
+
     if (argc != 3) {
         mbedtls_printf("usage: mbedtls_pk_verify <key_file> <filename>\n");
 
@@ -117,6 +126,7 @@ int main(int argc, char *argv[])
 
 exit:
     mbedtls_pk_free(&pk);
+    mbedtls_psa_crypto_free();
 
 #if defined(MBEDTLS_ERROR_C)
     if (exit_code != MBEDTLS_EXIT_SUCCESS) {

--- a/programs/pkey/rsa_sign_pss.c
+++ b/programs/pkey/rsa_sign_pss.c
@@ -67,6 +67,15 @@ int main(int argc, char *argv[])
     mbedtls_pk_init(&pk);
     mbedtls_ctr_drbg_init(&ctr_drbg);
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_status_t status = psa_crypto_init();
+    if (status != PSA_SUCCESS) {
+        mbedtls_fprintf(stderr, "Failed to initialize PSA Crypto implementation: %d\n",
+                        (int) status);
+        goto exit;
+    }
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
+
     if (argc != 3) {
         mbedtls_printf("usage: rsa_sign_pss <key_file> <filename>\n");
 
@@ -149,6 +158,7 @@ exit:
     mbedtls_pk_free(&pk);
     mbedtls_ctr_drbg_free(&ctr_drbg);
     mbedtls_entropy_free(&entropy);
+    mbedtls_psa_crypto_free();
 
 #if defined(_WIN32)
     mbedtls_printf("  + Press Enter to exit this program.\n");

--- a/programs/pkey/rsa_sign_pss.c
+++ b/programs/pkey/rsa_sign_pss.c
@@ -158,7 +158,9 @@ exit:
     mbedtls_pk_free(&pk);
     mbedtls_ctr_drbg_free(&ctr_drbg);
     mbedtls_entropy_free(&entropy);
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     mbedtls_psa_crypto_free();
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 #if defined(_WIN32)
     mbedtls_printf("  + Press Enter to exit this program.\n");

--- a/programs/pkey/rsa_verify_pss.c
+++ b/programs/pkey/rsa_verify_pss.c
@@ -61,6 +61,15 @@ int main(int argc, char *argv[])
 
     mbedtls_pk_init(&pk);
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_status_t status = psa_crypto_init();
+    if (status != PSA_SUCCESS) {
+        mbedtls_fprintf(stderr, "Failed to initialize PSA Crypto implementation: %d\n",
+                        (int) status);
+        goto exit;
+    }
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
+
     if (argc != 3) {
         mbedtls_printf("usage: rsa_verify_pss <key_file> <filename>\n");
 
@@ -127,6 +136,7 @@ int main(int argc, char *argv[])
 
 exit:
     mbedtls_pk_free(&pk);
+    mbedtls_psa_crypto_free();
 
 #if defined(_WIN32)
     mbedtls_printf("  + Press Enter to exit this program.\n");

--- a/programs/pkey/rsa_verify_pss.c
+++ b/programs/pkey/rsa_verify_pss.c
@@ -136,7 +136,9 @@ int main(int argc, char *argv[])
 
 exit:
     mbedtls_pk_free(&pk);
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     mbedtls_psa_crypto_free();
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 #if defined(_WIN32)
     mbedtls_printf("  + Press Enter to exit this program.\n");

--- a/programs/ssl/dtls_client.c
+++ b/programs/ssl/dtls_client.c
@@ -334,12 +334,12 @@ exit:
 #endif
 
     mbedtls_net_free(&server_fd);
-
     mbedtls_x509_crt_free(&cacert);
     mbedtls_ssl_free(&ssl);
     mbedtls_ssl_config_free(&conf);
     mbedtls_ctr_drbg_free(&ctr_drbg);
     mbedtls_entropy_free(&entropy);
+    mbedtls_psa_crypto_free();
 
 #if defined(_WIN32)
     mbedtls_printf("  + Press Enter to exit this program.\n");

--- a/programs/ssl/dtls_client.c
+++ b/programs/ssl/dtls_client.c
@@ -101,16 +101,6 @@ int main(int argc, char *argv[])
     ((void) argc);
     ((void) argv);
 
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
-    psa_status_t status = psa_crypto_init();
-    if (status != PSA_SUCCESS) {
-        mbedtls_fprintf(stderr, "Failed to initialize PSA Crypto implementation: %d\n",
-                        (int) status);
-        ret = MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
-        goto exit;
-    }
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
-
 #if defined(MBEDTLS_DEBUG_C)
     mbedtls_debug_set_threshold(DEBUG_LEVEL);
 #endif
@@ -123,11 +113,21 @@ int main(int argc, char *argv[])
     mbedtls_ssl_config_init(&conf);
     mbedtls_x509_crt_init(&cacert);
     mbedtls_ctr_drbg_init(&ctr_drbg);
+    mbedtls_entropy_init(&entropy);
+
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_status_t status = psa_crypto_init();
+    if (status != PSA_SUCCESS) {
+        mbedtls_fprintf(stderr, "Failed to initialize PSA Crypto implementation: %d\n",
+                        (int) status);
+        ret = MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
+        goto exit;
+    }
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     mbedtls_printf("\n  . Seeding the random number generator...");
     fflush(stdout);
 
-    mbedtls_entropy_init(&entropy);
     if ((ret = mbedtls_ctr_drbg_seed(&ctr_drbg, mbedtls_entropy_func, &entropy,
                                      (const unsigned char *) pers,
                                      strlen(pers))) != 0) {

--- a/programs/ssl/dtls_client.c
+++ b/programs/ssl/dtls_client.c
@@ -339,7 +339,9 @@ exit:
     mbedtls_ssl_config_free(&conf);
     mbedtls_ctr_drbg_free(&ctr_drbg);
     mbedtls_entropy_free(&entropy);
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     mbedtls_psa_crypto_free();
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 #if defined(_WIN32)
     mbedtls_printf("  + Press Enter to exit this program.\n");

--- a/programs/ssl/dtls_client.c
+++ b/programs/ssl/dtls_client.c
@@ -101,6 +101,16 @@ int main(int argc, char *argv[])
     ((void) argc);
     ((void) argv);
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_status_t status = psa_crypto_init();
+    if (status != PSA_SUCCESS) {
+        mbedtls_fprintf(stderr, "Failed to initialize PSA Crypto implementation: %d\n",
+                        (int) status);
+        ret = MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
+        goto exit;
+    }
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
+
 #if defined(MBEDTLS_DEBUG_C)
     mbedtls_debug_set_threshold(DEBUG_LEVEL);
 #endif

--- a/programs/ssl/dtls_server.c
+++ b/programs/ssl/dtls_server.c
@@ -111,16 +111,6 @@ int main(void)
     mbedtls_ssl_cache_context cache;
 #endif
 
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
-    psa_status_t status = psa_crypto_init();
-    if (status != PSA_SUCCESS) {
-        mbedtls_fprintf(stderr, "Failed to initialize PSA Crypto implementation: %d\n",
-                        (int) status);
-        ret = MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
-        goto exit;
-    }
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
-
     mbedtls_net_init(&listen_fd);
     mbedtls_net_init(&client_fd);
     mbedtls_ssl_init(&ssl);
@@ -133,6 +123,16 @@ int main(void)
     mbedtls_pk_init(&pkey);
     mbedtls_entropy_init(&entropy);
     mbedtls_ctr_drbg_init(&ctr_drbg);
+
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_status_t status = psa_crypto_init();
+    if (status != PSA_SUCCESS) {
+        mbedtls_fprintf(stderr, "Failed to initialize PSA Crypto implementation: %d\n",
+                        (int) status);
+        ret = MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
+        goto exit;
+    }
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 #if defined(MBEDTLS_DEBUG_C)
     mbedtls_debug_set_threshold(DEBUG_LEVEL);

--- a/programs/ssl/dtls_server.c
+++ b/programs/ssl/dtls_server.c
@@ -404,6 +404,7 @@ exit:
 #endif
     mbedtls_ctr_drbg_free(&ctr_drbg);
     mbedtls_entropy_free(&entropy);
+    mbedtls_psa_crypto_free();
 
 #if defined(_WIN32)
     printf("  Press Enter to exit this program.\n");

--- a/programs/ssl/dtls_server.c
+++ b/programs/ssl/dtls_server.c
@@ -111,6 +111,16 @@ int main(void)
     mbedtls_ssl_cache_context cache;
 #endif
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_status_t status = psa_crypto_init();
+    if (status != PSA_SUCCESS) {
+        mbedtls_fprintf(stderr, "Failed to initialize PSA Crypto implementation: %d\n",
+                        (int) status);
+        ret = MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
+        goto exit;
+    }
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
+
     mbedtls_net_init(&listen_fd);
     mbedtls_net_init(&client_fd);
     mbedtls_ssl_init(&ssl);

--- a/programs/ssl/dtls_server.c
+++ b/programs/ssl/dtls_server.c
@@ -404,7 +404,9 @@ exit:
 #endif
     mbedtls_ctr_drbg_free(&ctr_drbg);
     mbedtls_entropy_free(&entropy);
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     mbedtls_psa_crypto_free();
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 #if defined(_WIN32)
     printf("  Press Enter to exit this program.\n");

--- a/programs/ssl/mini_client.c
+++ b/programs/ssl/mini_client.c
@@ -184,8 +184,6 @@ int main(void)
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     psa_status_t status = psa_crypto_init();
     if (status != PSA_SUCCESS) {
-        mbedtls_fprintf(stderr, "Failed to initialize PSA Crypto implementation: %d\n",
-                        (int) status);
         ret = MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
         goto exit;
     }

--- a/programs/ssl/mini_client.c
+++ b/programs/ssl/mini_client.c
@@ -170,6 +170,17 @@ int main(void)
     mbedtls_ssl_config conf;
     mbedtls_ctr_drbg_init(&ctr_drbg);
 
+    /*
+     * 0. Initialize and setup stuff
+     */
+    mbedtls_net_init(&server_fd);
+    mbedtls_ssl_init(&ssl);
+    mbedtls_ssl_config_init(&conf);
+#if defined(MBEDTLS_X509_CRT_PARSE_C)
+    mbedtls_x509_crt_init(&ca);
+#endif
+    mbedtls_entropy_init(&entropy);
+
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     psa_status_t status = psa_crypto_init();
     if (status != PSA_SUCCESS) {
@@ -180,17 +191,6 @@ int main(void)
     }
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
-    /*
-     * 0. Initialize and setup stuff
-     */
-    mbedtls_net_init(&server_fd);
-    mbedtls_ssl_init(&ssl);
-    mbedtls_ssl_config_init(&conf);
-#if defined(MBEDTLS_X509_CRT_PARSE_C)
-    mbedtls_x509_crt_init(&ca);
-#endif
-
-    mbedtls_entropy_init(&entropy);
     if (mbedtls_ctr_drbg_seed(&ctr_drbg, mbedtls_entropy_func, &entropy,
                               (const unsigned char *) pers, strlen(pers)) != 0) {
         ret = ctr_drbg_seed_failed;

--- a/programs/ssl/mini_client.c
+++ b/programs/ssl/mini_client.c
@@ -170,6 +170,16 @@ int main(void)
     mbedtls_ssl_config conf;
     mbedtls_ctr_drbg_init(&ctr_drbg);
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_status_t status = psa_crypto_init();
+    if (status != PSA_SUCCESS) {
+        mbedtls_fprintf(stderr, "Failed to initialize PSA Crypto implementation: %d\n",
+                        (int) status);
+        ret = MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
+        goto exit;
+    }
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
+
     /*
      * 0. Initialize and setup stuff
      */

--- a/programs/ssl/mini_client.c
+++ b/programs/ssl/mini_client.c
@@ -281,7 +281,9 @@ exit:
 #if defined(MBEDTLS_X509_CRT_PARSE_C)
     mbedtls_x509_crt_free(&ca);
 #endif
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     mbedtls_psa_crypto_free();
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     mbedtls_exit(ret);
 }

--- a/programs/ssl/mini_client.c
+++ b/programs/ssl/mini_client.c
@@ -274,7 +274,6 @@ int main(void)
 
 exit:
     mbedtls_net_free(&server_fd);
-
     mbedtls_ssl_free(&ssl);
     mbedtls_ssl_config_free(&conf);
     mbedtls_ctr_drbg_free(&ctr_drbg);
@@ -282,6 +281,7 @@ exit:
 #if defined(MBEDTLS_X509_CRT_PARSE_C)
     mbedtls_x509_crt_free(&ca);
 #endif
+    mbedtls_psa_crypto_free();
 
     mbedtls_exit(ret);
 }

--- a/programs/ssl/ssl_client1.c
+++ b/programs/ssl/ssl_client1.c
@@ -87,6 +87,15 @@ int main(void)
     mbedtls_debug_set_threshold(DEBUG_LEVEL);
 #endif
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_status_t status = psa_crypto_init();
+    if (status != PSA_SUCCESS) {
+        mbedtls_fprintf(stderr, "Failed to initialize PSA Crypto implementation: %d\n",
+                        (int) status);
+        goto exit;
+    }
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
+
     /*
      * 0. Initialize the RNG and the session data
      */

--- a/programs/ssl/ssl_client1.c
+++ b/programs/ssl/ssl_client1.c
@@ -87,6 +87,16 @@ int main(void)
     mbedtls_debug_set_threshold(DEBUG_LEVEL);
 #endif
 
+    /*
+     * 0. Initialize the RNG and the session data
+     */
+    mbedtls_net_init(&server_fd);
+    mbedtls_ssl_init(&ssl);
+    mbedtls_ssl_config_init(&conf);
+    mbedtls_x509_crt_init(&cacert);
+    mbedtls_ctr_drbg_init(&ctr_drbg);
+    mbedtls_entropy_init(&entropy);
+
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     psa_status_t status = psa_crypto_init();
     if (status != PSA_SUCCESS) {
@@ -96,19 +106,10 @@ int main(void)
     }
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
-    /*
-     * 0. Initialize the RNG and the session data
-     */
-    mbedtls_net_init(&server_fd);
-    mbedtls_ssl_init(&ssl);
-    mbedtls_ssl_config_init(&conf);
-    mbedtls_x509_crt_init(&cacert);
-    mbedtls_ctr_drbg_init(&ctr_drbg);
-
     mbedtls_printf("\n  . Seeding the random number generator...");
     fflush(stdout);
 
-    mbedtls_entropy_init(&entropy);
+
     if ((ret = mbedtls_ctr_drbg_seed(&ctr_drbg, mbedtls_entropy_func, &entropy,
                                      (const unsigned char *) pers,
                                      strlen(pers))) != 0) {

--- a/programs/ssl/ssl_client1.c
+++ b/programs/ssl/ssl_client1.c
@@ -289,7 +289,9 @@ exit:
     mbedtls_ssl_config_free(&conf);
     mbedtls_ctr_drbg_free(&ctr_drbg);
     mbedtls_entropy_free(&entropy);
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     mbedtls_psa_crypto_free();
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 #if defined(_WIN32)
     mbedtls_printf("  + Press Enter to exit this program.\n");

--- a/programs/ssl/ssl_client1.c
+++ b/programs/ssl/ssl_client1.c
@@ -284,12 +284,12 @@ exit:
 #endif
 
     mbedtls_net_free(&server_fd);
-
     mbedtls_x509_crt_free(&cacert);
     mbedtls_ssl_free(&ssl);
     mbedtls_ssl_config_free(&conf);
     mbedtls_ctr_drbg_free(&ctr_drbg);
     mbedtls_entropy_free(&entropy);
+    mbedtls_psa_crypto_free();
 
 #if defined(_WIN32)
     mbedtls_printf("  + Press Enter to exit this program.\n");

--- a/programs/ssl/ssl_context_info.c
+++ b/programs/ssl/ssl_context_info.c
@@ -23,6 +23,7 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 #include "mbedtls/debug.h"
+#include "mbedtls/platform.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -938,6 +939,15 @@ int main(int argc, char *argv[])
     size_t b64_max_len = SSL_INIT_LEN;
     size_t ssl_max_len = SSL_INIT_LEN;
     size_t ssl_len = 0;
+
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_status_t status = psa_crypto_init();
+    if (status != PSA_SUCCESS) {
+        mbedtls_fprintf(stderr, "Failed to initialize PSA Crypto implementation: %d\n",
+                        (int) status);
+        return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
+    }
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     /* The 'b64_file' is opened when parsing arguments to check that the
      * file name is correct */

--- a/programs/ssl/ssl_context_info.c
+++ b/programs/ssl/ssl_context_info.c
@@ -1017,7 +1017,9 @@ int main(int argc, char *argv[])
         printf("Finished. No valid base64 code found\n");
     }
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     mbedtls_psa_crypto_free();
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     return 0;
 }

--- a/programs/ssl/ssl_context_info.c
+++ b/programs/ssl/ssl_context_info.c
@@ -1017,6 +1017,8 @@ int main(int argc, char *argv[])
         printf("Finished. No valid base64 code found\n");
     }
 
+    mbedtls_psa_crypto_free();
+
     return 0;
 }
 

--- a/programs/ssl/ssl_fork_server.c
+++ b/programs/ssl/ssl_fork_server.c
@@ -100,15 +100,6 @@ int main(void)
     mbedtls_x509_crt srvcert;
     mbedtls_pk_context pkey;
 
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
-    psa_status_t status = psa_crypto_init();
-    if (status != PSA_SUCCESS) {
-        mbedtls_fprintf(stderr, "Failed to initialize PSA Crypto implementation: %d\n",
-                        (int) status);
-        goto exit;
-    }
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
-
     mbedtls_net_init(&listen_fd);
     mbedtls_net_init(&client_fd);
     mbedtls_ssl_init(&ssl);
@@ -117,6 +108,15 @@ int main(void)
     mbedtls_pk_init(&pkey);
     mbedtls_x509_crt_init(&srvcert);
     mbedtls_ctr_drbg_init(&ctr_drbg);
+
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_status_t status = psa_crypto_init();
+    if (status != PSA_SUCCESS) {
+        mbedtls_fprintf(stderr, "Failed to initialize PSA Crypto implementation: %d\n",
+                        (int) status);
+        goto exit;
+    }
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     signal(SIGCHLD, SIG_IGN);
 

--- a/programs/ssl/ssl_fork_server.c
+++ b/programs/ssl/ssl_fork_server.c
@@ -100,6 +100,15 @@ int main(void)
     mbedtls_x509_crt srvcert;
     mbedtls_pk_context pkey;
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_status_t status = psa_crypto_init();
+    if (status != PSA_SUCCESS) {
+        mbedtls_fprintf(stderr, "Failed to initialize PSA Crypto implementation: %d\n",
+                        (int) status);
+        goto exit;
+    }
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
+
     mbedtls_net_init(&listen_fd);
     mbedtls_net_init(&client_fd);
     mbedtls_ssl_init(&ssl);

--- a/programs/ssl/ssl_fork_server.c
+++ b/programs/ssl/ssl_fork_server.c
@@ -384,7 +384,9 @@ exit:
     mbedtls_ssl_config_free(&conf);
     mbedtls_ctr_drbg_free(&ctr_drbg);
     mbedtls_entropy_free(&entropy);
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     mbedtls_psa_crypto_free();
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 #if defined(_WIN32)
     mbedtls_printf("  Press Enter to exit this program.\n");

--- a/programs/ssl/ssl_fork_server.c
+++ b/programs/ssl/ssl_fork_server.c
@@ -378,13 +378,13 @@ int main(void)
 exit:
     mbedtls_net_free(&client_fd);
     mbedtls_net_free(&listen_fd);
-
     mbedtls_x509_crt_free(&srvcert);
     mbedtls_pk_free(&pkey);
     mbedtls_ssl_free(&ssl);
     mbedtls_ssl_config_free(&conf);
     mbedtls_ctr_drbg_free(&ctr_drbg);
     mbedtls_entropy_free(&entropy);
+    mbedtls_psa_crypto_free();
 
 #if defined(_WIN32)
     mbedtls_printf("  Press Enter to exit this program.\n");

--- a/programs/ssl/ssl_mail_client.c
+++ b/programs/ssl/ssl_mail_client.c
@@ -355,6 +355,15 @@ int main(int argc, char *argv[])
     char *p, *q;
     const int *list;
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_status_t status = psa_crypto_init();
+    if (status != PSA_SUCCESS) {
+        mbedtls_fprintf(stderr, "Failed to initialize PSA Crypto implementation: %d\n",
+                        (int) status);
+        goto exit;
+    }
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
+
     /*
      * Make sure memory references are valid in case we exit early.
      */

--- a/programs/ssl/ssl_mail_client.c
+++ b/programs/ssl/ssl_mail_client.c
@@ -355,15 +355,6 @@ int main(int argc, char *argv[])
     char *p, *q;
     const int *list;
 
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
-    psa_status_t status = psa_crypto_init();
-    if (status != PSA_SUCCESS) {
-        mbedtls_fprintf(stderr, "Failed to initialize PSA Crypto implementation: %d\n",
-                        (int) status);
-        goto exit;
-    }
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
-
     /*
      * Make sure memory references are valid in case we exit early.
      */
@@ -375,6 +366,16 @@ int main(int argc, char *argv[])
     mbedtls_x509_crt_init(&clicert);
     mbedtls_pk_init(&pkey);
     mbedtls_ctr_drbg_init(&ctr_drbg);
+    mbedtls_entropy_init(&entropy);
+
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_status_t status = psa_crypto_init();
+    if (status != PSA_SUCCESS) {
+        mbedtls_fprintf(stderr, "Failed to initialize PSA Crypto implementation: %d\n",
+                        (int) status);
+        goto exit;
+    }
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     if (argc < 2) {
 usage:
@@ -464,7 +465,6 @@ usage:
     mbedtls_printf("\n  . Seeding the random number generator...");
     fflush(stdout);
 
-    mbedtls_entropy_init(&entropy);
     if ((ret = mbedtls_ctr_drbg_seed(&ctr_drbg, mbedtls_entropy_func, &entropy,
                                      (const unsigned char *) pers,
                                      strlen(pers))) != 0) {

--- a/programs/ssl/ssl_mail_client.c
+++ b/programs/ssl/ssl_mail_client.c
@@ -801,6 +801,7 @@ exit:
     mbedtls_ssl_config_free(&conf);
     mbedtls_ctr_drbg_free(&ctr_drbg);
     mbedtls_entropy_free(&entropy);
+    mbedtls_psa_crypto_free();
 
 #if defined(_WIN32)
     mbedtls_printf("  + Press Enter to exit this program.\n");

--- a/programs/ssl/ssl_mail_client.c
+++ b/programs/ssl/ssl_mail_client.c
@@ -801,7 +801,9 @@ exit:
     mbedtls_ssl_config_free(&conf);
     mbedtls_ctr_drbg_free(&ctr_drbg);
     mbedtls_entropy_free(&entropy);
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     mbedtls_psa_crypto_free();
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 #if defined(_WIN32)
     mbedtls_printf("  + Press Enter to exit this program.\n");

--- a/programs/ssl/ssl_pthread_server.c
+++ b/programs/ssl/ssl_pthread_server.c
@@ -492,7 +492,9 @@ exit:
 #if defined(MBEDTLS_MEMORY_BUFFER_ALLOC_C)
     mbedtls_memory_buffer_alloc_free();
 #endif
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     mbedtls_psa_crypto_free();
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 #if defined(_WIN32)
     mbedtls_printf("  Press Enter to exit this program.\n");

--- a/programs/ssl/ssl_pthread_server.c
+++ b/programs/ssl/ssl_pthread_server.c
@@ -311,16 +311,6 @@ int main(void)
     mbedtls_ssl_cache_context cache;
 #endif
 
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
-    psa_status_t status = psa_crypto_init();
-    if (status != PSA_SUCCESS) {
-        mbedtls_fprintf(stderr, "Failed to initialize PSA Crypto implementation: %d\n",
-                        (int) status);
-        ret = MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
-        goto exit;
-    }
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
-
 #if defined(MBEDTLS_MEMORY_BUFFER_ALLOC_C)
     mbedtls_memory_buffer_alloc_init(alloc_buf, sizeof(alloc_buf));
 #endif
@@ -346,6 +336,16 @@ int main(void)
      * We use only a single entropy source that is used in all the threads.
      */
     mbedtls_entropy_init(&entropy);
+
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_status_t status = psa_crypto_init();
+    if (status != PSA_SUCCESS) {
+        mbedtls_fprintf(stderr, "Failed to initialize PSA Crypto implementation: %d\n",
+                        (int) status);
+        ret = MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
+        goto exit;
+    }
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     /*
      * 1. Load the certificates and private RSA key

--- a/programs/ssl/ssl_pthread_server.c
+++ b/programs/ssl/ssl_pthread_server.c
@@ -311,6 +311,16 @@ int main(void)
     mbedtls_ssl_cache_context cache;
 #endif
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_status_t status = psa_crypto_init();
+    if (status != PSA_SUCCESS) {
+        mbedtls_fprintf(stderr, "Failed to initialize PSA Crypto implementation: %d\n",
+                        (int) status);
+        ret = MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
+        goto exit;
+    }
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
+
 #if defined(MBEDTLS_MEMORY_BUFFER_ALLOC_C)
     mbedtls_memory_buffer_alloc_init(alloc_buf, sizeof(alloc_buf));
 #endif

--- a/programs/ssl/ssl_pthread_server.c
+++ b/programs/ssl/ssl_pthread_server.c
@@ -487,14 +487,12 @@ exit:
     mbedtls_ctr_drbg_free(&ctr_drbg);
     mbedtls_entropy_free(&entropy);
     mbedtls_ssl_config_free(&conf);
-
     mbedtls_net_free(&listen_fd);
-
     mbedtls_mutex_free(&debug_mutex);
-
 #if defined(MBEDTLS_MEMORY_BUFFER_ALLOC_C)
     mbedtls_memory_buffer_alloc_free();
 #endif
+    mbedtls_psa_crypto_free();
 
 #if defined(_WIN32)
     mbedtls_printf("  Press Enter to exit this program.\n");

--- a/programs/ssl/ssl_server.c
+++ b/programs/ssl/ssl_server.c
@@ -357,7 +357,6 @@ exit:
 
     mbedtls_net_free(&client_fd);
     mbedtls_net_free(&listen_fd);
-
     mbedtls_x509_crt_free(&srvcert);
     mbedtls_pk_free(&pkey);
     mbedtls_ssl_free(&ssl);
@@ -367,6 +366,7 @@ exit:
 #endif
     mbedtls_ctr_drbg_free(&ctr_drbg);
     mbedtls_entropy_free(&entropy);
+    mbedtls_psa_crypto_free();
 
 #if defined(_WIN32)
     mbedtls_printf("  Press Enter to exit this program.\n");

--- a/programs/ssl/ssl_server.c
+++ b/programs/ssl/ssl_server.c
@@ -366,7 +366,9 @@ exit:
 #endif
     mbedtls_ctr_drbg_free(&ctr_drbg);
     mbedtls_entropy_free(&entropy);
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     mbedtls_psa_crypto_free();
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 #if defined(_WIN32)
     mbedtls_printf("  Press Enter to exit this program.\n");

--- a/programs/ssl/ssl_server.c
+++ b/programs/ssl/ssl_server.c
@@ -97,6 +97,16 @@ int main(void)
     mbedtls_ssl_cache_context cache;
 #endif
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_status_t status = psa_crypto_init();
+    if (status != PSA_SUCCESS) {
+        mbedtls_fprintf(stderr, "Failed to initialize PSA Crypto implementation: %d\n",
+                        (int) status);
+        ret = MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
+        goto exit;
+    }
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
+
     mbedtls_net_init(&listen_fd);
     mbedtls_net_init(&client_fd);
     mbedtls_ssl_init(&ssl);

--- a/programs/ssl/ssl_server.c
+++ b/programs/ssl/ssl_server.c
@@ -97,16 +97,6 @@ int main(void)
     mbedtls_ssl_cache_context cache;
 #endif
 
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
-    psa_status_t status = psa_crypto_init();
-    if (status != PSA_SUCCESS) {
-        mbedtls_fprintf(stderr, "Failed to initialize PSA Crypto implementation: %d\n",
-                        (int) status);
-        ret = MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
-        goto exit;
-    }
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
-
     mbedtls_net_init(&listen_fd);
     mbedtls_net_init(&client_fd);
     mbedtls_ssl_init(&ssl);
@@ -118,6 +108,16 @@ int main(void)
     mbedtls_pk_init(&pkey);
     mbedtls_entropy_init(&entropy);
     mbedtls_ctr_drbg_init(&ctr_drbg);
+
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_status_t status = psa_crypto_init();
+    if (status != PSA_SUCCESS) {
+        mbedtls_fprintf(stderr, "Failed to initialize PSA Crypto implementation: %d\n",
+                        (int) status);
+        ret = MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
+        goto exit;
+    }
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 #if defined(MBEDTLS_DEBUG_C)
     mbedtls_debug_set_threshold(DEBUG_LEVEL);

--- a/programs/x509/cert_app.c
+++ b/programs/x509/cert_app.c
@@ -149,15 +149,6 @@ int main(int argc, char *argv[])
     char *p, *q;
     const char *pers = "cert_app";
 
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
-    psa_status_t status = psa_crypto_init();
-    if (status != PSA_SUCCESS) {
-        mbedtls_fprintf(stderr, "Failed to initialize PSA Crypto implementation: %d\n",
-                        (int) status);
-        goto exit;
-    }
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
-
     /*
      * Set to sane values
      */
@@ -174,6 +165,15 @@ int main(int argc, char *argv[])
        it to the verify function */
     memset(&cacrl, 0, sizeof(mbedtls_x509_crl));
 #endif
+
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_status_t status = psa_crypto_init();
+    if (status != PSA_SUCCESS) {
+        mbedtls_fprintf(stderr, "Failed to initialize PSA Crypto implementation: %d\n",
+                        (int) status);
+        goto exit;
+    }
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     if (argc < 2) {
 usage:

--- a/programs/x509/cert_app.c
+++ b/programs/x509/cert_app.c
@@ -166,6 +166,7 @@ int main(int argc, char *argv[])
     mbedtls_ssl_init(&ssl);
     mbedtls_ssl_config_init(&conf);
     mbedtls_x509_crt_init(&cacert);
+    mbedtls_entropy_init(&entropy);
 #if defined(MBEDTLS_X509_CRL_PARSE_C)
     mbedtls_x509_crl_init(&cacrl);
 #else
@@ -351,7 +352,6 @@ usage:
         mbedtls_printf("\n  . Seeding the random number generator...");
         fflush(stdout);
 
-        mbedtls_entropy_init(&entropy);
         if ((ret = mbedtls_ctr_drbg_seed(&ctr_drbg, mbedtls_entropy_func, &entropy,
                                          (const unsigned char *) pers,
                                          strlen(pers))) != 0) {

--- a/programs/x509/cert_app.c
+++ b/programs/x509/cert_app.c
@@ -461,6 +461,7 @@ exit:
 #endif
     mbedtls_ctr_drbg_free(&ctr_drbg);
     mbedtls_entropy_free(&entropy);
+    mbedtls_psa_crypto_free();
 
 #if defined(_WIN32)
     mbedtls_printf("  + Press Enter to exit this program.\n");

--- a/programs/x509/cert_app.c
+++ b/programs/x509/cert_app.c
@@ -461,7 +461,9 @@ exit:
 #endif
     mbedtls_ctr_drbg_free(&ctr_drbg);
     mbedtls_entropy_free(&entropy);
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     mbedtls_psa_crypto_free();
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 #if defined(_WIN32)
     mbedtls_printf("  + Press Enter to exit this program.\n");

--- a/programs/x509/cert_app.c
+++ b/programs/x509/cert_app.c
@@ -149,6 +149,15 @@ int main(int argc, char *argv[])
     char *p, *q;
     const char *pers = "cert_app";
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_status_t status = psa_crypto_init();
+    if (status != PSA_SUCCESS) {
+        mbedtls_fprintf(stderr, "Failed to initialize PSA Crypto implementation: %d\n",
+                        (int) status);
+        goto exit;
+    }
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
+
     /*
      * Set to sane values
      */

--- a/programs/x509/cert_req.c
+++ b/programs/x509/cert_req.c
@@ -155,6 +155,15 @@ int main(int argc, char *argv[])
     mbedtls_ctr_drbg_context ctr_drbg;
     const char *pers = "csr example app";
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_status_t status = psa_crypto_init();
+    if (status != PSA_SUCCESS) {
+        mbedtls_fprintf(stderr, "Failed to initialize PSA Crypto implementation: %d\n",
+                        (int) status);
+        goto exit;
+    }
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
+
     /*
      * Set to sane values
      */

--- a/programs/x509/cert_req.c
+++ b/programs/x509/cert_req.c
@@ -155,6 +155,15 @@ int main(int argc, char *argv[])
     mbedtls_ctr_drbg_context ctr_drbg;
     const char *pers = "csr example app";
 
+    /*
+     * Set to sane values
+     */
+    mbedtls_x509write_csr_init(&req);
+    mbedtls_pk_init(&key);
+    mbedtls_ctr_drbg_init(&ctr_drbg);
+    memset(buf, 0, sizeof(buf));
+    mbedtls_entropy_init(&entropy);
+
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     psa_status_t status = psa_crypto_init();
     if (status != PSA_SUCCESS) {
@@ -163,14 +172,6 @@ int main(int argc, char *argv[])
         goto exit;
     }
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
-
-    /*
-     * Set to sane values
-     */
-    mbedtls_x509write_csr_init(&req);
-    mbedtls_pk_init(&key);
-    mbedtls_ctr_drbg_init(&ctr_drbg);
-    memset(buf, 0, sizeof(buf));
 
     if (argc < 2) {
 usage:
@@ -303,7 +304,6 @@ usage:
     mbedtls_printf("  . Seeding the random number generator...");
     fflush(stdout);
 
-    mbedtls_entropy_init(&entropy);
     if ((ret = mbedtls_ctr_drbg_seed(&ctr_drbg, mbedtls_entropy_func, &entropy,
                                      (const unsigned char *) pers,
                                      strlen(pers))) != 0) {

--- a/programs/x509/cert_req.c
+++ b/programs/x509/cert_req.c
@@ -374,7 +374,9 @@ exit:
     mbedtls_pk_free(&key);
     mbedtls_ctr_drbg_free(&ctr_drbg);
     mbedtls_entropy_free(&entropy);
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     mbedtls_psa_crypto_free();
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 #if defined(_WIN32)
     mbedtls_printf("  + Press Enter to exit this program.\n");

--- a/programs/x509/cert_req.c
+++ b/programs/x509/cert_req.c
@@ -374,6 +374,7 @@ exit:
     mbedtls_pk_free(&key);
     mbedtls_ctr_drbg_free(&ctr_drbg);
     mbedtls_entropy_free(&entropy);
+    mbedtls_psa_crypto_free();
 
 #if defined(_WIN32)
     mbedtls_printf("  + Press Enter to exit this program.\n");

--- a/programs/x509/cert_write.c
+++ b/programs/x509/cert_write.c
@@ -226,6 +226,15 @@ int main(int argc, char *argv[])
     mbedtls_ctr_drbg_context ctr_drbg;
     const char *pers = "crt example app";
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_status_t status = psa_crypto_init();
+    if (status != PSA_SUCCESS) {
+        mbedtls_fprintf(stderr, "Failed to initialize PSA Crypto implementation: %d\n",
+                        (int) status);
+        goto exit;
+    }
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
+
     /*
      * Set to sane values
      */

--- a/programs/x509/cert_write.c
+++ b/programs/x509/cert_write.c
@@ -726,6 +726,7 @@ exit:
     mbedtls_mpi_free(&serial);
     mbedtls_ctr_drbg_free(&ctr_drbg);
     mbedtls_entropy_free(&entropy);
+    mbedtls_psa_crypto_free();
 
 #if defined(_WIN32)
     mbedtls_printf("  + Press Enter to exit this program.\n");

--- a/programs/x509/cert_write.c
+++ b/programs/x509/cert_write.c
@@ -726,7 +726,9 @@ exit:
     mbedtls_mpi_free(&serial);
     mbedtls_ctr_drbg_free(&ctr_drbg);
     mbedtls_entropy_free(&entropy);
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     mbedtls_psa_crypto_free();
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 #if defined(_WIN32)
     mbedtls_printf("  + Press Enter to exit this program.\n");

--- a/programs/x509/cert_write.c
+++ b/programs/x509/cert_write.c
@@ -226,15 +226,6 @@ int main(int argc, char *argv[])
     mbedtls_ctr_drbg_context ctr_drbg;
     const char *pers = "crt example app";
 
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
-    psa_status_t status = psa_crypto_init();
-    if (status != PSA_SUCCESS) {
-        mbedtls_fprintf(stderr, "Failed to initialize PSA Crypto implementation: %d\n",
-                        (int) status);
-        goto exit;
-    }
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
-
     /*
      * Set to sane values
      */
@@ -249,6 +240,15 @@ int main(int argc, char *argv[])
 #endif
     mbedtls_x509_crt_init(&issuer_crt);
     memset(buf, 0, 1024);
+
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_status_t status = psa_crypto_init();
+    if (status != PSA_SUCCESS) {
+        mbedtls_fprintf(stderr, "Failed to initialize PSA Crypto implementation: %d\n",
+                        (int) status);
+        goto exit;
+    }
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     if (argc < 2) {
 usage:

--- a/programs/x509/crl_app.c
+++ b/programs/x509/crl_app.c
@@ -136,6 +136,7 @@ usage:
 
 exit:
     mbedtls_x509_crl_free(&crl);
+    mbedtls_psa_crypto_free();
 
 #if defined(_WIN32)
     mbedtls_printf("  + Press Enter to exit this program.\n");

--- a/programs/x509/crl_app.c
+++ b/programs/x509/crl_app.c
@@ -67,6 +67,11 @@ int main(int argc, char *argv[])
     int i;
     char *p, *q;
 
+    /*
+     * Set to sane values
+     */
+    mbedtls_x509_crl_init(&crl);
+
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     psa_status_t status = psa_crypto_init();
     if (status != PSA_SUCCESS) {
@@ -75,11 +80,6 @@ int main(int argc, char *argv[])
         goto exit;
     }
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
-
-    /*
-     * Set to sane values
-     */
-    mbedtls_x509_crl_init(&crl);
 
     if (argc < 2) {
 usage:

--- a/programs/x509/crl_app.c
+++ b/programs/x509/crl_app.c
@@ -67,6 +67,15 @@ int main(int argc, char *argv[])
     int i;
     char *p, *q;
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_status_t status = psa_crypto_init();
+    if (status != PSA_SUCCESS) {
+        mbedtls_fprintf(stderr, "Failed to initialize PSA Crypto implementation: %d\n",
+                        (int) status);
+        goto exit;
+    }
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
+
     /*
      * Set to sane values
      */

--- a/programs/x509/crl_app.c
+++ b/programs/x509/crl_app.c
@@ -136,7 +136,9 @@ usage:
 
 exit:
     mbedtls_x509_crl_free(&crl);
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     mbedtls_psa_crypto_free();
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 #if defined(_WIN32)
     mbedtls_printf("  + Press Enter to exit this program.\n");

--- a/programs/x509/load_roots.c
+++ b/programs/x509/load_roots.c
@@ -127,11 +127,6 @@ int main(int argc, char *argv[])
     struct mbedtls_timing_hr_time timer;
     unsigned long ms;
 
-    if (argc <= 1) {
-        mbedtls_printf(USAGE);
-        goto exit;
-    }
-
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     psa_status_t status = psa_crypto_init();
     if (status != PSA_SUCCESS) {
@@ -140,6 +135,11 @@ int main(int argc, char *argv[])
         goto exit;
     }
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
+
+    if (argc <= 1) {
+        mbedtls_printf(USAGE);
+        goto exit;
+    }
 
     opt.filenames = NULL;
     opt.iterations = DFL_ITERATIONS;
@@ -200,6 +200,7 @@ int main(int argc, char *argv[])
     exit_code = MBEDTLS_EXIT_SUCCESS;
 
 exit:
+    mbedtls_psa_crypto_free();
     mbedtls_exit(exit_code);
 }
 #endif /* necessary configuration */

--- a/programs/x509/load_roots.c
+++ b/programs/x509/load_roots.c
@@ -200,7 +200,9 @@ int main(int argc, char *argv[])
     exit_code = MBEDTLS_EXIT_SUCCESS;
 
 exit:
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     mbedtls_psa_crypto_free();
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
     mbedtls_exit(exit_code);
 }
 #endif /* necessary configuration */

--- a/programs/x509/load_roots.c
+++ b/programs/x509/load_roots.c
@@ -132,6 +132,15 @@ int main(int argc, char *argv[])
         goto exit;
     }
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_status_t status = psa_crypto_init();
+    if (status != PSA_SUCCESS) {
+        mbedtls_fprintf(stderr, "Failed to initialize PSA Crypto implementation: %d\n",
+                        (int) status);
+        goto exit;
+    }
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
+
     opt.filenames = NULL;
     opt.iterations = DFL_ITERATIONS;
     opt.prime_cache = DFL_PRIME_CACHE;

--- a/programs/x509/req_app.c
+++ b/programs/x509/req_app.c
@@ -136,7 +136,9 @@ usage:
 
 exit:
     mbedtls_x509_csr_free(&csr);
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     mbedtls_psa_crypto_free();
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 #if defined(_WIN32)
     mbedtls_printf("  + Press Enter to exit this program.\n");

--- a/programs/x509/req_app.c
+++ b/programs/x509/req_app.c
@@ -67,6 +67,11 @@ int main(int argc, char *argv[])
     int i;
     char *p, *q;
 
+    /*
+     * Set to sane values
+     */
+    mbedtls_x509_csr_init(&csr);
+
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     psa_status_t status = psa_crypto_init();
     if (status != PSA_SUCCESS) {
@@ -75,11 +80,6 @@ int main(int argc, char *argv[])
         goto exit;
     }
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
-
-    /*
-     * Set to sane values
-     */
-    mbedtls_x509_csr_init(&csr);
 
     if (argc < 2) {
 usage:

--- a/programs/x509/req_app.c
+++ b/programs/x509/req_app.c
@@ -67,6 +67,15 @@ int main(int argc, char *argv[])
     int i;
     char *p, *q;
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_status_t status = psa_crypto_init();
+    if (status != PSA_SUCCESS) {
+        mbedtls_fprintf(stderr, "Failed to initialize PSA Crypto implementation: %d\n",
+                        (int) status);
+        goto exit;
+    }
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
+
     /*
      * Set to sane values
      */

--- a/programs/x509/req_app.c
+++ b/programs/x509/req_app.c
@@ -136,6 +136,7 @@ usage:
 
 exit:
     mbedtls_x509_csr_free(&csr);
+    mbedtls_psa_crypto_free();
 
 #if defined(_WIN32)
     mbedtls_printf("  + Press Enter to exit this program.\n");


### PR DESCRIPTION
## Description

Initialize PSA in ssl, x509, fuzz and cert programs.

## Gatekeeper checklist

- [X] **changelog** provided
- [X] **backport** of https://github.com/Mbed-TLS/mbedtls/pull/7443
- [X] **tests** not required



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

