### PR TITLE
Bug Fix: mbedtls_ecdsa_verify_restartable fails with ECDSA_SIGN_ALT

### DIFF
--- a/ChangeLog.d/mbedtls_ecdsa_can_do-unconditional-define.txt
+++ b/ChangeLog.d/mbedtls_ecdsa_can_do-unconditional-define.txt
@@ -1,0 +1,4 @@
+Bugfix
+   * Removes !ECDSA_SIGN_ALT condition around mbedtls_ecdsa_can_do 
+     definition, so that mbedtls_ecdsa_verify_restartable will not 
+     automatically fail.

--- a/ChangeLog.d/mbedtls_ecdsa_can_do-unconditional-define.txt
+++ b/ChangeLog.d/mbedtls_ecdsa_can_do-unconditional-define.txt
@@ -1,4 +1,3 @@
 Bugfix
-   * Removes !ECDSA_SIGN_ALT condition around mbedtls_ecdsa_can_do 
-     definition, so that mbedtls_ecdsa_verify_restartable will not 
-     automatically fail.
+   * Fix an error when MBEDTLS_ECDSA_SIGN_ALT is defined but not
+     MBEDTLS_ECDSA_VERIFY_ALT, causing ecdsa verify to fail. Fixes #7498.

--- a/library/ecdsa.c
+++ b/library/ecdsa.c
@@ -234,9 +234,6 @@ cleanup:
 }
 #endif /* ECDSA_DETERMINISTIC || !ECDSA_SIGN_ALT || !ECDSA_VERIFY_ALT */
 
-#if !defined(MBEDTLS_ECDSA_SIGN_ALT)     || \
-    !defined(MBEDTLS_ECDSA_VERIFY_ALT)
-
 int mbedtls_ecdsa_can_do(mbedtls_ecp_group_id gid)
 {
     switch (gid) {
@@ -249,8 +246,6 @@ int mbedtls_ecdsa_can_do(mbedtls_ecp_group_id gid)
         default: return 1;
     }
 }
-
-#endif /* !ECDSA_SIGN_ALT || !ECDSA_VERIFY_ALT */
 
 #if !defined(MBEDTLS_ECDSA_SIGN_ALT)
 /*

--- a/library/ecdsa.c
+++ b/library/ecdsa.c
@@ -234,6 +234,24 @@ cleanup:
 }
 #endif /* ECDSA_DETERMINISTIC || !ECDSA_SIGN_ALT || !ECDSA_VERIFY_ALT */
 
+#if !defined(MBEDTLS_ECDSA_SIGN_ALT)     || \
+    !defined(MBEDTLS_ECDSA_VERIFY_ALT)
+
+int mbedtls_ecdsa_can_do(mbedtls_ecp_group_id gid)
+{
+    switch (gid) {
+#ifdef MBEDTLS_ECP_DP_CURVE25519_ENABLED
+        case MBEDTLS_ECP_DP_CURVE25519: return 0;
+#endif
+#ifdef MBEDTLS_ECP_DP_CURVE448_ENABLED
+        case MBEDTLS_ECP_DP_CURVE448: return 0;
+#endif
+        default: return 1;
+    }
+}
+
+#endif /* !ECDSA_SIGN_ALT || !ECDSA_VERIFY_ALT */
+
 #if !defined(MBEDTLS_ECDSA_SIGN_ALT)
 /*
  * Compute ECDSA signature of a hashed message (SEC1 4.1.3)
@@ -371,19 +389,6 @@ cleanup:
     ECDSA_RS_LEAVE(sig);
 
     return ret;
-}
-
-int mbedtls_ecdsa_can_do(mbedtls_ecp_group_id gid)
-{
-    switch (gid) {
-#ifdef MBEDTLS_ECP_DP_CURVE25519_ENABLED
-        case MBEDTLS_ECP_DP_CURVE25519: return 0;
-#endif
-#ifdef MBEDTLS_ECP_DP_CURVE448_ENABLED
-        case MBEDTLS_ECP_DP_CURVE448: return 0;
-#endif
-        default: return 1;
-    }
 }
 
 /*


### PR DESCRIPTION
When ECDSA_SIGN_ALT but not ECDSA_VERIFY_ALT, mbedtls_ecdsa_can_do was not being defined causing mbedtls_ecdsa_verify_restartable to always fail

closes #7498

## Description

This will support ATECC608 integration for signing but not verification.

## Gatekeeper checklist

- [x] **changelog** provided, or not required
- [ ] **backport** done, or not required
- [ ] **tests** provided, or not required



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

