### PR TITLE
Fix MBEDTLS_BSWAP32 on armcc 5

### DIFF
--- a/library/alignment.h
+++ b/library/alignment.h
@@ -181,6 +181,9 @@ inline void mbedtls_put_unaligned_uint64(void *p, uint64_t x)
 
 /* Detect armcc built-in byteswap routine */
 #if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 410000) && !defined(MBEDTLS_BSWAP32)
+#if defined(__ARM_ACLE)  /* ARM Compiler 6 - earlier versions don't need a header */
+#include <arm_acle.h>
+#endif
 #define MBEDTLS_BSWAP32 __rev
 #endif
 


### PR DESCRIPTION
## Description

If this particular block of code is ever executed, we define `MBEDTLS_BSWAP32()` to be `__rev()`, but don't include the header that declares the function, and so we get a compilation error - see https://developer.arm.com/documentation/100068/0620/Compiler-Source-Code-Compatibility/Language-extension-compatibility--intrinsics

```
aria.c:350:9: error: call to undeclared function '__rev'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
    t = ARIA_P3(b[j]);                      // big endian
        ^
aria.c:102:20: note: expanded from macro 'ARIA_P3'
#define ARIA_P3(x) MBEDTLS_BSWAP32(x)
                   ^
./alignment.h:185:25: note: expanded from macro 'MBEDTLS_BSWAP32'
#define MBEDTLS_BSWAP32 __rev
                        ^
```

This PR adds the correct header include.

Found when trying to compile #6666 with ArmClang locally with some configuration changes

## Gatekeeper checklist

- [x] **changelog** not required
- [x] **backport** not required - not in 2.28
- [x] **tests** not required
