### PR TITLE
Backport: Fixing USE_PSA_INIT/DONE in SSL/X509/PK test suites

### DIFF
--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -1112,7 +1112,7 @@ exit:
 void pk_rsa_overflow()
 {
     mbedtls_pk_context pk;
-    size_t hash_len = SIZE_MAX, sig_len = SIZE_MAX;
+    size_t hash_len = UINT_MAX + 1, sig_len = UINT_MAX + 1;
     unsigned char hash[50], sig[100];
 
     if (SIZE_MAX <= UINT_MAX) {

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -133,12 +133,10 @@ void pk_psa_utils()
     size_t len;
     mbedtls_pk_debug_item dbg;
 
-    PSA_ASSERT(psa_crypto_init());
-
     mbedtls_pk_init(&pk);
     mbedtls_pk_init(&pk2);
 
-    TEST_ASSERT(psa_crypto_init() == PSA_SUCCESS);
+    USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_pk_setup_opaque(&pk, MBEDTLS_SVC_KEY_ID_INIT) ==
                 MBEDTLS_ERR_PK_BAD_INPUT_DATA);
@@ -212,6 +210,7 @@ void valid_parameters()
     void *options = NULL;
 
     mbedtls_pk_init(&pk);
+    USE_PSA_INIT();
 
     TEST_VALID_PARAM(mbedtls_pk_free(NULL));
 
@@ -292,6 +291,9 @@ void valid_parameters()
     TEST_ASSERT(mbedtls_pk_parse_public_key(&pk, NULL, 0) ==
                 MBEDTLS_ERR_PK_KEY_INVALID_FORMAT);
 #endif /* MBEDTLS_PK_PARSE_C */
+
+exit:
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -302,6 +304,8 @@ void valid_parameters_pkwrite(data_t *key_data)
 
     /* For the write tests to be effective, we need a valid key pair. */
     mbedtls_pk_init(&pk);
+    USE_PSA_INIT();
+
     TEST_ASSERT(mbedtls_pk_parse_key(&pk,
                                      key_data->x, key_data->len,
                                      NULL, 0) == 0);
@@ -322,6 +326,7 @@ void valid_parameters_pkwrite(data_t *key_data)
 
 exit:
     mbedtls_pk_free(&pk);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -342,6 +347,7 @@ void invalid_parameters()
     (void) str;
 
     mbedtls_pk_init(&pk);
+    USE_PSA_INIT();
 
     TEST_INVALID_PARAM(mbedtls_pk_init(NULL));
 
@@ -591,6 +597,8 @@ void invalid_parameters()
 #endif /* MBEDTLS_PEM_WRITE_C */
 
 #endif /* MBEDTLS_PK_WRITE_C */
+exit:
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -600,6 +608,7 @@ void pk_utils(int type, int parameter, int bitlen, int len, char *name)
     mbedtls_pk_context pk;
 
     mbedtls_pk_init(&pk);
+    USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_pk_setup(&pk, mbedtls_pk_info_from_type(type)) == 0);
     TEST_ASSERT(pk_genkey(&pk, parameter) == 0);
@@ -612,6 +621,7 @@ void pk_utils(int type, int parameter, int bitlen, int len, char *name)
 
 exit:
     mbedtls_pk_free(&pk);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -623,6 +633,7 @@ void mbedtls_pk_check_pair(char *pub_file, char *prv_file, int ret)
     mbedtls_pk_init(&pub);
     mbedtls_pk_init(&prv);
     mbedtls_pk_init(&alt);
+    USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_pk_parse_public_keyfile(&pub, pub_file) == 0);
     TEST_ASSERT(mbedtls_pk_parse_keyfile(&prv, prv_file, NULL) == 0);
@@ -638,9 +649,11 @@ void mbedtls_pk_check_pair(char *pub_file, char *prv_file, int ret)
     }
 #endif
 
+exit:
     mbedtls_pk_free(&pub);
     mbedtls_pk_free(&prv);
     mbedtls_pk_free(&alt);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -663,6 +676,7 @@ void pk_rsa_verify_test_vec(data_t *message_str, int digest, int mod,
 #endif
 
     mbedtls_pk_init(&pk);
+    USE_PSA_INIT();
 
     memset(hash_result, 0x00, MBEDTLS_MD_MAX_SIZE);
 
@@ -691,6 +705,7 @@ exit:
     mbedtls_pk_restart_free(rs_ctx);
 #endif
     mbedtls_pk_free(&pk);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -709,6 +724,7 @@ void pk_rsa_verify_ext_test_vec(data_t *message_str, int digest,
     size_t hash_len;
 
     mbedtls_pk_init(&pk);
+    USE_PSA_INIT();
 
     memset(hash_result, 0x00, sizeof(hash_result));
 
@@ -744,6 +760,7 @@ void pk_rsa_verify_ext_test_vec(data_t *message_str, int digest,
 
 exit:
     mbedtls_pk_free(&pk);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -795,6 +812,7 @@ void pk_sign_verify_restart(int pk_type, int grp_id, char *d_str,
     mbedtls_pk_init(&pub);
     memset(hash, 0, sizeof(hash));
     memset(sig, 0, sizeof(sig));
+    USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_pk_setup(&prv, mbedtls_pk_info_from_type(pk_type)) == 0);
     TEST_ASSERT(mbedtls_ecp_group_load(&mbedtls_pk_ec(prv)->grp, grp_id) == 0);
@@ -872,6 +890,7 @@ exit:
     mbedtls_pk_restart_free(&rs_ctx);
     mbedtls_pk_free(&prv);
     mbedtls_pk_free(&pub);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -980,8 +999,8 @@ void pk_rsa_encrypt_test_vec(data_t *message, int mod,
     memset(&rnd_info,  0, sizeof(mbedtls_test_rnd_pseudo_info));
     memset(output,     0, sizeof(output));
 
-
     mbedtls_pk_init(&pk);
+    USE_PSA_INIT();
     TEST_ASSERT(mbedtls_pk_setup(&pk, mbedtls_pk_info_from_type(MBEDTLS_PK_RSA)) == 0);
     rsa = mbedtls_pk_rsa(pk);
 
@@ -997,6 +1016,7 @@ void pk_rsa_encrypt_test_vec(data_t *message, int mod,
 
 exit:
     mbedtls_pk_free(&pk);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -1016,6 +1036,7 @@ void pk_rsa_decrypt_test_vec(data_t *cipher, int mod,
     mbedtls_pk_init(&pk);
     mbedtls_mpi_init(&N); mbedtls_mpi_init(&P);
     mbedtls_mpi_init(&Q); mbedtls_mpi_init(&E);
+    USE_PSA_INIT();
 
     memset(&rnd_info,  0, sizeof(mbedtls_test_rnd_pseudo_info));
 
@@ -1050,6 +1071,7 @@ exit:
     mbedtls_mpi_free(&N); mbedtls_mpi_free(&P);
     mbedtls_mpi_free(&Q); mbedtls_mpi_free(&E);
     mbedtls_pk_free(&pk);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -1064,6 +1086,7 @@ void pk_ec_nocrypt(int type)
     int ret = MBEDTLS_ERR_PK_TYPE_MISMATCH;
 
     mbedtls_pk_init(&pk);
+    USE_PSA_INIT();
 
     memset(&rnd_info,  0, sizeof(mbedtls_test_rnd_pseudo_info));
     memset(output,     0, sizeof(output));
@@ -1081,6 +1104,7 @@ void pk_ec_nocrypt(int type)
 
 exit:
     mbedtls_pk_free(&pk);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -1099,6 +1123,7 @@ void pk_rsa_overflow()
     memset(sig, 0, sizeof(sig));
 
     mbedtls_pk_init(&pk);
+    USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_pk_setup(&pk,
                                  mbedtls_pk_info_from_type(MBEDTLS_PK_RSA)) == 0);
@@ -1118,6 +1143,7 @@ void pk_rsa_overflow()
 
 exit:
     mbedtls_pk_free(&pk);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -1138,7 +1164,9 @@ void pk_rsa_alt()
     int ret = MBEDTLS_ERR_PK_TYPE_MISMATCH;
 
     mbedtls_rsa_init(&raw, MBEDTLS_RSA_PKCS_V15, MBEDTLS_MD_NONE);
-    mbedtls_pk_init(&rsa); mbedtls_pk_init(&alt);
+    mbedtls_pk_init(&rsa);
+    mbedtls_pk_init(&alt);
+    USE_PSA_INIT();
 
     memset(hash, 0x2a, sizeof(hash));
     memset(sig, 0, sizeof(sig));
@@ -1199,7 +1227,9 @@ void pk_rsa_alt()
 
 exit:
     mbedtls_rsa_free(&raw);
-    mbedtls_pk_free(&rsa); mbedtls_pk_free(&alt);
+    mbedtls_pk_free(&rsa);
+    mbedtls_pk_free(&alt);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -1229,10 +1259,10 @@ void pk_psa_sign(int grpid_arg,
      * - parse it to a PK context and verify the signature this way
      */
 
-    PSA_ASSERT(psa_crypto_init());
-
     /* Create legacy EC public/private key in PK context. */
     mbedtls_pk_init(&pk);
+    USE_PSA_INIT();
+
     TEST_ASSERT(mbedtls_pk_setup(&pk,
                                  mbedtls_pk_info_from_type(MBEDTLS_PK_ECKEY)) == 0);
     TEST_ASSERT(mbedtls_ecp_gen_key(grpid,

--- a/tests/suites/test_suite_pkparse.function
+++ b/tests/suites/test_suite_pkparse.function
@@ -17,6 +17,7 @@ void pk_parse_keyfile_rsa(char *key_file, char *password, int result)
     char *pwd = password;
 
     mbedtls_pk_init(&ctx);
+    USE_PSA_INIT();
 
     if (strcmp(pwd, "NULL") == 0) {
         pwd = NULL;
@@ -35,6 +36,7 @@ void pk_parse_keyfile_rsa(char *key_file, char *password, int result)
 
 exit:
     mbedtls_pk_free(&ctx);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -45,6 +47,7 @@ void pk_parse_public_keyfile_rsa(char *key_file, int result)
     int res;
 
     mbedtls_pk_init(&ctx);
+    USE_PSA_INIT();
 
     res = mbedtls_pk_parse_public_keyfile(&ctx, key_file);
 
@@ -59,6 +62,7 @@ void pk_parse_public_keyfile_rsa(char *key_file, int result)
 
 exit:
     mbedtls_pk_free(&ctx);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -69,6 +73,7 @@ void pk_parse_public_keyfile_ec(char *key_file, int result)
     int res;
 
     mbedtls_pk_init(&ctx);
+    USE_PSA_INIT();
 
     res = mbedtls_pk_parse_public_keyfile(&ctx, key_file);
 
@@ -83,6 +88,7 @@ void pk_parse_public_keyfile_ec(char *key_file, int result)
 
 exit:
     mbedtls_pk_free(&ctx);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -93,6 +99,7 @@ void pk_parse_keyfile_ec(char *key_file, char *password, int result)
     int res;
 
     mbedtls_pk_init(&ctx);
+    USE_PSA_INIT();
 
     res = mbedtls_pk_parse_keyfile(&ctx, key_file, password);
 
@@ -107,6 +114,7 @@ void pk_parse_keyfile_ec(char *key_file, char *password, int result)
 
 exit:
     mbedtls_pk_free(&ctx);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -116,10 +124,12 @@ void pk_parse_key(data_t *buf, int result)
     mbedtls_pk_context pk;
 
     mbedtls_pk_init(&pk);
+    USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_pk_parse_key(&pk, buf->x, buf->len, NULL, 0) == result);
 
 exit:
     mbedtls_pk_free(&pk);
+    USE_PSA_DONE();
 }
 /* END_CASE */

--- a/tests/suites/test_suite_pkwrite.function
+++ b/tests/suites/test_suite_pkwrite.function
@@ -36,6 +36,9 @@ static void pk_write_check_common(char *key_file, int is_public_key, int is_der)
     size_t buf_len, check_buf_len;
     int ret;
 
+    mbedtls_pk_init(&key);
+    USE_PSA_INIT();
+
     /* Note: if mbedtls_pk_load_file() successfully reads the file, then
        it also allocates check_buf, which should be freed on exit */
     TEST_EQUAL(mbedtls_pk_load_file(key_file, &check_buf, &check_buf_len), 0);
@@ -56,7 +59,6 @@ static void pk_write_check_common(char *key_file, int is_public_key, int is_der)
 
     ASSERT_ALLOC(buf, check_buf_len);
 
-    mbedtls_pk_init(&key);
     if (is_public_key) {
         TEST_EQUAL(mbedtls_pk_parse_public_keyfile(&key, key_file), 0);
         if (is_der) {
@@ -97,6 +99,7 @@ exit:
     mbedtls_free(buf);
     mbedtls_free(check_buf);
     mbedtls_pk_free(&key);
+    USE_PSA_DONE();
 }
 /* END_HEADER */
 

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -5,6 +5,8 @@
 
 #include <test/constant_flow.h>
 
+#define SSL_MESSAGE_QUEUE_INIT      { NULL, 0, 0, 0 }
+
 /* END_HEADER */
 
 /* BEGIN_DEPENDENCIES
@@ -451,7 +453,7 @@ exit:
 /* BEGIN_CASE */
 void ssl_message_queue_sanity()
 {
-    mbedtls_test_ssl_message_queue queue = {NULL, 0, 0, 0};
+    mbedtls_test_ssl_message_queue queue = SSL_MESSAGE_QUEUE_INIT;
 
     USE_PSA_INIT();
     /* Trying to push/pull to an empty queue */
@@ -473,7 +475,7 @@ exit:
 /* BEGIN_CASE */
 void ssl_message_queue_basic()
 {
-    mbedtls_test_ssl_message_queue queue = {NULL, 0, 0, 0};
+    mbedtls_test_ssl_message_queue queue = SSL_MESSAGE_QUEUE_INIT;
 
     USE_PSA_INIT();
     TEST_ASSERT(mbedtls_test_ssl_message_queue_setup(&queue, 3) == 0);
@@ -502,7 +504,7 @@ exit:
 /* BEGIN_CASE */
 void ssl_message_queue_overflow_underflow()
 {
-    mbedtls_test_ssl_message_queue queue = {NULL, 0, 0, 0};
+    mbedtls_test_ssl_message_queue queue = SSL_MESSAGE_QUEUE_INIT;
 
     USE_PSA_INIT();
     TEST_ASSERT(mbedtls_test_ssl_message_queue_setup(&queue, 3) == 0);
@@ -530,7 +532,7 @@ exit:
 /* BEGIN_CASE */
 void ssl_message_queue_interleaved()
 {
-    mbedtls_test_ssl_message_queue queue = {NULL, 0, 0, 0};
+    mbedtls_test_ssl_message_queue queue = SSL_MESSAGE_QUEUE_INIT;
 
     USE_PSA_INIT();
     TEST_ASSERT(mbedtls_test_ssl_message_queue_setup(&queue, 3) == 0);
@@ -566,7 +568,7 @@ exit:
 /* BEGIN_CASE */
 void ssl_message_queue_insufficient_buffer()
 {
-    mbedtls_test_ssl_message_queue queue = {NULL, 0, 0, 0};
+    mbedtls_test_ssl_message_queue queue = SSL_MESSAGE_QUEUE_INIT;
     size_t message_len = 10;
     size_t buffer_len = 5;
 

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -108,8 +108,8 @@ void test_callback_buffer(int size, int put1, int put1_ret,
     size_t output_len;
     size_t i, j, written, read;
 
-    USE_PSA_INIT();
     mbedtls_test_ssl_buffer_init(&buf);
+    USE_PSA_INIT();
     TEST_ASSERT(mbedtls_test_ssl_buffer_setup(&buf, size) == 0);
 
     /* Check the sanity of input parameters and initialise local variables. That
@@ -204,8 +204,8 @@ void ssl_mock_sanity()
     unsigned char received[MSGLEN] = { 0 };
     mbedtls_test_mock_socket socket;
 
-    USE_PSA_INIT();
     mbedtls_test_mock_socket_init(&socket);
+    USE_PSA_INIT();
     TEST_ASSERT(mbedtls_test_mock_tcp_send_b(&socket, message, MSGLEN) < 0);
     mbedtls_test_mock_socket_close(&socket);
     mbedtls_test_mock_socket_init(&socket);
@@ -245,7 +245,6 @@ void ssl_mock_tcp(int blocking)
     mbedtls_ssl_recv_t *recv;
     unsigned i;
 
-    USE_PSA_INIT();
     if (blocking == 0) {
         send = mbedtls_test_mock_tcp_send_nb;
         recv = mbedtls_test_mock_tcp_recv_nb;
@@ -256,6 +255,7 @@ void ssl_mock_tcp(int blocking)
 
     mbedtls_test_mock_socket_init(&client);
     mbedtls_test_mock_socket_init(&server);
+    USE_PSA_INIT();
 
     /* Fill up the buffer with structured data so that unwanted changes
      * can be detected */
@@ -343,7 +343,6 @@ void ssl_mock_tcp_interleaving(int blocking)
     mbedtls_ssl_send_t *send;
     mbedtls_ssl_recv_t *recv;
 
-    USE_PSA_INIT();
     if (blocking == 0) {
         send = mbedtls_test_mock_tcp_send_nb;
         recv = mbedtls_test_mock_tcp_recv_nb;
@@ -354,6 +353,7 @@ void ssl_mock_tcp_interleaving(int blocking)
 
     mbedtls_test_mock_socket_init(&client);
     mbedtls_test_mock_socket_init(&server);
+    USE_PSA_INIT();
 
     /* Fill up the buffers with structured data so that unwanted changes
      * can be detected */
@@ -451,7 +451,7 @@ exit:
 /* BEGIN_CASE */
 void ssl_message_queue_sanity()
 {
-    mbedtls_test_ssl_message_queue queue;
+    mbedtls_test_ssl_message_queue queue = {NULL, 0, 0, 0};
 
     USE_PSA_INIT();
     /* Trying to push/pull to an empty queue */
@@ -473,7 +473,7 @@ exit:
 /* BEGIN_CASE */
 void ssl_message_queue_basic()
 {
-    mbedtls_test_ssl_message_queue queue;
+    mbedtls_test_ssl_message_queue queue = {NULL, 0, 0, 0};
 
     USE_PSA_INIT();
     TEST_ASSERT(mbedtls_test_ssl_message_queue_setup(&queue, 3) == 0);
@@ -502,7 +502,7 @@ exit:
 /* BEGIN_CASE */
 void ssl_message_queue_overflow_underflow()
 {
-    mbedtls_test_ssl_message_queue queue;
+    mbedtls_test_ssl_message_queue queue = {NULL, 0, 0, 0};
 
     USE_PSA_INIT();
     TEST_ASSERT(mbedtls_test_ssl_message_queue_setup(&queue, 3) == 0);
@@ -530,7 +530,7 @@ exit:
 /* BEGIN_CASE */
 void ssl_message_queue_interleaved()
 {
-    mbedtls_test_ssl_message_queue queue;
+    mbedtls_test_ssl_message_queue queue = {NULL, 0, 0, 0};
 
     USE_PSA_INIT();
     TEST_ASSERT(mbedtls_test_ssl_message_queue_setup(&queue, 3) == 0);
@@ -566,7 +566,7 @@ exit:
 /* BEGIN_CASE */
 void ssl_message_queue_insufficient_buffer()
 {
-    mbedtls_test_ssl_message_queue queue;
+    mbedtls_test_ssl_message_queue queue = {NULL, 0, 0, 0};
     size_t message_len = 10;
     size_t buffer_len = 5;
 
@@ -648,9 +648,9 @@ void ssl_message_mock_basic()
     mbedtls_test_ssl_message_queue server_queue, client_queue;
     mbedtls_test_message_socket_context server_context, client_context;
 
-    USE_PSA_INIT();
     mbedtls_test_message_socket_init(&server_context);
     mbedtls_test_message_socket_init(&client_context);
+    USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_test_message_socket_setup(&server_queue,
                                                   &client_queue, 1,
@@ -710,9 +710,9 @@ void ssl_message_mock_queue_overflow_underflow()
     mbedtls_test_ssl_message_queue server_queue, client_queue;
     mbedtls_test_message_socket_context server_context, client_context;
 
-    USE_PSA_INIT();
     mbedtls_test_message_socket_init(&server_context);
     mbedtls_test_message_socket_init(&client_context);
+    USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_test_message_socket_setup(&server_queue,
                                                   &client_queue, 2,
@@ -777,9 +777,9 @@ void ssl_message_mock_socket_overflow()
     mbedtls_test_ssl_message_queue server_queue, client_queue;
     mbedtls_test_message_socket_context server_context, client_context;
 
-    USE_PSA_INIT();
     mbedtls_test_message_socket_init(&server_context);
     mbedtls_test_message_socket_init(&client_context);
+    USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_test_message_socket_setup(&server_queue,
                                                   &client_queue, 2,
@@ -832,9 +832,9 @@ void ssl_message_mock_truncated()
     mbedtls_test_ssl_message_queue server_queue, client_queue;
     mbedtls_test_message_socket_context server_context, client_context;
 
-    USE_PSA_INIT();
     mbedtls_test_message_socket_init(&server_context);
     mbedtls_test_message_socket_init(&client_context);
+    USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_test_message_socket_setup(&server_queue,
                                                   &client_queue, 2,
@@ -899,9 +899,9 @@ void ssl_message_mock_socket_read_error()
     mbedtls_test_ssl_message_queue server_queue, client_queue;
     mbedtls_test_message_socket_context server_context, client_context;
 
-    USE_PSA_INIT();
     mbedtls_test_message_socket_init(&server_context);
     mbedtls_test_message_socket_init(&client_context);
+    USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_test_message_socket_setup(&server_queue,
                                                   &client_queue, 1,
@@ -960,9 +960,9 @@ void ssl_message_mock_interleaved_one_way()
     mbedtls_test_ssl_message_queue server_queue, client_queue;
     mbedtls_test_message_socket_context server_context, client_context;
 
-    USE_PSA_INIT();
     mbedtls_test_message_socket_init(&server_context);
     mbedtls_test_message_socket_init(&client_context);
+    USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_test_message_socket_setup(&server_queue,
                                                   &client_queue, 3,
@@ -1023,9 +1023,9 @@ void ssl_message_mock_interleaved_two_ways()
     mbedtls_test_ssl_message_queue server_queue, client_queue;
     mbedtls_test_message_socket_context server_context, client_context;
 
-    USE_PSA_INIT();
     mbedtls_test_message_socket_init(&server_context);
     mbedtls_test_message_socket_init(&client_context);
+    USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_test_message_socket_setup(&server_queue,
                                                   &client_queue, 3,
@@ -1142,8 +1142,8 @@ void ssl_set_hostname_twice(char *hostname0, char *hostname1)
 {
     mbedtls_ssl_context ssl;
 
-    USE_PSA_INIT();
     mbedtls_ssl_init(&ssl);
+    USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_ssl_set_hostname(&ssl, hostname0) == 0);
     TEST_ASSERT(mbedtls_ssl_set_hostname(&ssl, hostname1) == 0);
@@ -1326,9 +1326,9 @@ void ssl_crypt_record_small(int cipher_type, int hash_id,
                        * already seen a successful test. */
 
     mbedtls_ssl_init(&ssl);
-    USE_PSA_INIT();
     mbedtls_ssl_transform_init(&t0);
     mbedtls_ssl_transform_init(&t1);
+    USE_PSA_INIT();
     TEST_ASSERT(mbedtls_test_ssl_build_transforms(&t0, &t1, cipher_type, hash_id,
                                                   etm, tag_mode, ver,
                                                   (size_t) cid0_len,
@@ -1477,9 +1477,9 @@ void ssl_decrypt_non_etm_cbc(int cipher_type, int hash_id, int trunc_hmac,
     const unsigned char pad_max_len = 255; /* Per the standard */
 
     mbedtls_ssl_init(&ssl);
-    USE_PSA_INIT();
     mbedtls_ssl_transform_init(&t0);
     mbedtls_ssl_transform_init(&t1);
+    USE_PSA_INIT();
 
     /* Set up transforms with dummy keys */
     TEST_ASSERT(mbedtls_test_ssl_build_transforms(&t0, &t1, cipher_type, hash_id,
@@ -1838,9 +1838,9 @@ void ssl_serialize_session_save_load(int ticket_len, char *crt_file)
     /*
      * Test that a save-load pair is the identity
      */
-    USE_PSA_INIT();
     mbedtls_ssl_session_init(&original);
     mbedtls_ssl_session_init(&restored);
+    USE_PSA_INIT();
 
     /* Prepare a dummy session to work on */
     TEST_ASSERT(mbedtls_test_ssl_populate_session(
@@ -1939,8 +1939,8 @@ void ssl_serialize_session_load_save(int ticket_len, char *crt_file)
     /*
      * Test that a load-save pair is the identity
      */
-    USE_PSA_INIT();
     mbedtls_ssl_session_init(&session);
+    USE_PSA_INIT();
 
     /* Prepare a dummy session to work on */
     TEST_ASSERT(mbedtls_test_ssl_populate_session(
@@ -1991,8 +1991,8 @@ void ssl_serialize_session_save_buf_size(int ticket_len, char *crt_file)
     /*
      * Test that session_save() fails cleanly on small buffers
      */
-    USE_PSA_INIT();
     mbedtls_ssl_session_init(&session);
+    USE_PSA_INIT();
 
     /* Prepare dummy session and get serialized size */
     TEST_ASSERT(mbedtls_test_ssl_populate_session(
@@ -2028,8 +2028,8 @@ void ssl_serialize_session_load_buf_size(int ticket_len, char *crt_file)
     /*
      * Test that session_load() fails cleanly on small buffers
      */
-    USE_PSA_INIT();
     mbedtls_ssl_session_init(&session);
+    USE_PSA_INIT();
 
     /* Prepare serialized session data */
     TEST_ASSERT(mbedtls_test_ssl_populate_session(
@@ -2077,8 +2077,8 @@ void ssl_session_serialize_version_check(int corrupt_major,
                                       corrupt_config == 1,
                                       corrupt_config == 1 };
 
-    USE_PSA_INIT();
     mbedtls_ssl_session_init(&session);
+    USE_PSA_INIT();
 
     /* Infer length of serialized session. */
     TEST_ASSERT(mbedtls_ssl_session_save(&session,
@@ -2156,7 +2156,6 @@ void move_handshake_to_state(int endpoint_type, int state, int need_pass)
     mbedtls_test_ssl_endpoint base_ep, second_ep;
     int ret = -1;
 
-    USE_PSA_INIT();
     mbedtls_platform_zeroize(&base_ep, sizeof(base_ep));
     mbedtls_platform_zeroize(&second_ep, sizeof(second_ep));
 
@@ -2171,6 +2170,8 @@ void move_handshake_to_state(int endpoint_type, int state, int need_pass)
         MBEDTLS_SSL_IS_CLIENT : MBEDTLS_SSL_IS_SERVER,
         MBEDTLS_PK_RSA, NULL, NULL, NULL, NULL);
     TEST_ASSERT(ret == 0);
+
+    USE_PSA_INIT();
 
     ret = mbedtls_test_mock_socket_connect(&(base_ep.socket),
                                            &(second_ep.socket),
@@ -2388,10 +2389,8 @@ void resize_buffers(int mfl, int renegotiation, int legacy_renegotiation,
 /* BEGIN_CASE depends_on:MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED:MBEDTLS_CERTS_C:!MBEDTLS_USE_PSA_CRYPTO:MBEDTLS_PKCS1_V15:MBEDTLS_SSL_VARIABLE_BUFFER_LENGTH:MBEDTLS_SSL_CONTEXT_SERIALIZATION:MBEDTLS_SSL_PROTO_TLS1_2:MBEDTLS_RSA_C:MBEDTLS_ECP_DP_SECP384R1_ENABLED:MBEDTLS_SSL_PROTO_DTLS:MBEDTLS_ENTROPY_C:MBEDTLS_CTR_DRBG_C:MBEDTLS_SHA256_C:MBEDTLS_CAN_HANDLE_RSA_TEST_KEY */
 void resize_buffers_serialize_mfl(int mfl)
 {
-    USE_PSA_INIT();
     test_resize_buffers(mfl, 0, MBEDTLS_SSL_LEGACY_NO_RENEGOTIATION, 1, 1,
                         (char *) "");
-    USE_PSA_DONE();
     /* The goto below is used to avoid an "unused label" warning.*/
     goto exit;
 }
@@ -2401,9 +2400,7 @@ void resize_buffers_serialize_mfl(int mfl)
 void resize_buffers_renegotiate_mfl(int mfl, int legacy_renegotiation,
                                     char *cipher)
 {
-    USE_PSA_INIT();
     test_resize_buffers(mfl, 1, legacy_renegotiation, 0, 1, cipher);
-    USE_PSA_DONE();
     /* The goto below is used to avoid an "unused label" warning.*/
     goto exit;
 }
@@ -2419,7 +2416,7 @@ void raw_key_agreement_fail(int bad_server_ecdhe_key)
 
     mbedtls_ecp_group_id curve_list[] = { MBEDTLS_ECP_DP_SECP256R1,
                                           MBEDTLS_ECP_DP_NONE };
-    USE_PSA_INIT();
+
     mbedtls_platform_zeroize(&client, sizeof(client));
     mbedtls_platform_zeroize(&server, sizeof(server));
 
@@ -2434,6 +2431,8 @@ void raw_key_agreement_fail(int bad_server_ecdhe_key)
     TEST_EQUAL(mbedtls_test_ssl_endpoint_init(&server, MBEDTLS_SSL_IS_SERVER,
                                               MBEDTLS_PK_ECDSA, NULL, NULL,
                                               NULL, NULL), 0);
+
+    USE_PSA_INIT();
 
     TEST_EQUAL(mbedtls_test_mock_socket_connect(&(client.socket),
                                                 &(server.socket),

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -20,6 +20,7 @@ void test_callback_buffer_sanity()
     unsigned char input[MSGLEN];
     unsigned char output[MSGLEN];
 
+    USE_PSA_INIT();
     memset(input, 0, sizeof(input));
 
     /* Make sure calling put and get on NULL buffer results in error. */
@@ -72,8 +73,8 @@ void test_callback_buffer_sanity()
 
 
 exit:
-
     mbedtls_test_ssl_buffer_free(&buf);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -107,6 +108,7 @@ void test_callback_buffer(int size, int put1, int put1_ret,
     size_t output_len;
     size_t i, j, written, read;
 
+    USE_PSA_INIT();
     mbedtls_test_ssl_buffer_init(&buf);
     TEST_ASSERT(mbedtls_test_ssl_buffer_setup(&buf, size) == 0);
 
@@ -182,10 +184,10 @@ void test_callback_buffer(int size, int put1, int put1_ret,
     }
 
 exit:
-
     mbedtls_free(input);
     mbedtls_free(output);
     mbedtls_test_ssl_buffer_free(&buf);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -202,6 +204,7 @@ void ssl_mock_sanity()
     unsigned char received[MSGLEN] = { 0 };
     mbedtls_test_mock_socket socket;
 
+    USE_PSA_INIT();
     mbedtls_test_mock_socket_init(&socket);
     TEST_ASSERT(mbedtls_test_mock_tcp_send_b(&socket, message, MSGLEN) < 0);
     mbedtls_test_mock_socket_close(&socket);
@@ -217,8 +220,8 @@ void ssl_mock_sanity()
     mbedtls_test_mock_socket_close(&socket);
 
 exit:
-
     mbedtls_test_mock_socket_close(&socket);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -242,6 +245,7 @@ void ssl_mock_tcp(int blocking)
     mbedtls_ssl_recv_t *recv;
     unsigned i;
 
+    USE_PSA_INIT();
     if (blocking == 0) {
         send = mbedtls_test_mock_tcp_send_nb;
         recv = mbedtls_test_mock_tcp_recv_nb;
@@ -309,9 +313,9 @@ void ssl_mock_tcp(int blocking)
     TEST_ASSERT(memcmp(message, received, MSGLEN) == 0);
 
 exit:
-
     mbedtls_test_mock_socket_close(&client);
     mbedtls_test_mock_socket_close(&server);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -339,6 +343,7 @@ void ssl_mock_tcp_interleaving(int blocking)
     mbedtls_ssl_send_t *send;
     mbedtls_ssl_recv_t *recv;
 
+    USE_PSA_INIT();
     if (blocking == 0) {
         send = mbedtls_test_mock_tcp_send_nb;
         recv = mbedtls_test_mock_tcp_recv_nb;
@@ -437,9 +442,9 @@ void ssl_mock_tcp_interleaving(int blocking)
     }
 
 exit:
-
     mbedtls_test_mock_socket_close(&client);
     mbedtls_test_mock_socket_close(&server);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -448,6 +453,7 @@ void ssl_message_queue_sanity()
 {
     mbedtls_test_ssl_message_queue queue;
 
+    USE_PSA_INIT();
     /* Trying to push/pull to an empty queue */
     TEST_ASSERT(mbedtls_test_ssl_message_queue_push_info(NULL, 1)
                 == MBEDTLS_TEST_ERROR_ARG_NULL);
@@ -460,6 +466,7 @@ void ssl_message_queue_sanity()
 
 exit:
     mbedtls_test_ssl_message_queue_free(&queue);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -468,6 +475,7 @@ void ssl_message_queue_basic()
 {
     mbedtls_test_ssl_message_queue queue;
 
+    USE_PSA_INIT();
     TEST_ASSERT(mbedtls_test_ssl_message_queue_setup(&queue, 3) == 0);
 
     /* Sanity test - 3 pushes and 3 pops with sufficient space */
@@ -487,6 +495,7 @@ void ssl_message_queue_basic()
 
 exit:
     mbedtls_test_ssl_message_queue_free(&queue);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -495,6 +504,7 @@ void ssl_message_queue_overflow_underflow()
 {
     mbedtls_test_ssl_message_queue queue;
 
+    USE_PSA_INIT();
     TEST_ASSERT(mbedtls_test_ssl_message_queue_setup(&queue, 3) == 0);
 
     /* 4 pushes (last one with an error), 4 pops (last one with an error) */
@@ -513,6 +523,7 @@ void ssl_message_queue_overflow_underflow()
 
 exit:
     mbedtls_test_ssl_message_queue_free(&queue);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -521,6 +532,7 @@ void ssl_message_queue_interleaved()
 {
     mbedtls_test_ssl_message_queue queue;
 
+    USE_PSA_INIT();
     TEST_ASSERT(mbedtls_test_ssl_message_queue_setup(&queue, 3) == 0);
 
     /* Interleaved test - [2 pushes, 1 pop] twice, and then two pops
@@ -547,6 +559,7 @@ void ssl_message_queue_interleaved()
 
 exit:
     mbedtls_test_ssl_message_queue_free(&queue);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -557,6 +570,7 @@ void ssl_message_queue_insufficient_buffer()
     size_t message_len = 10;
     size_t buffer_len = 5;
 
+    USE_PSA_INIT();
     TEST_ASSERT(mbedtls_test_ssl_message_queue_setup(&queue, 1) == 0);
 
     /* Popping without a sufficient buffer */
@@ -566,6 +580,7 @@ void ssl_message_queue_insufficient_buffer()
                 == (int) buffer_len);
 exit:
     mbedtls_test_ssl_message_queue_free(&queue);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -580,6 +595,7 @@ void ssl_message_mock_uninitialized()
     mbedtls_test_message_socket_init(&server_context);
     mbedtls_test_message_socket_init(&client_context);
 
+    USE_PSA_INIT();
     /* Send with a NULL context */
     TEST_ASSERT(mbedtls_test_mock_tcp_send_msg(NULL, message, MSGLEN)
                 == MBEDTLS_TEST_ERROR_CONTEXT_ERROR);
@@ -618,6 +634,7 @@ void ssl_message_mock_uninitialized()
 exit:
     mbedtls_test_message_socket_close(&server_context);
     mbedtls_test_message_socket_close(&client_context);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -630,6 +647,8 @@ void ssl_message_mock_basic()
     unsigned i;
     mbedtls_test_ssl_message_queue server_queue, client_queue;
     mbedtls_test_message_socket_context server_context, client_context;
+
+    USE_PSA_INIT();
     mbedtls_test_message_socket_init(&server_context);
     mbedtls_test_message_socket_init(&client_context);
 
@@ -677,6 +696,7 @@ void ssl_message_mock_basic()
 exit:
     mbedtls_test_message_socket_close(&server_context);
     mbedtls_test_message_socket_close(&client_context);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -689,6 +709,8 @@ void ssl_message_mock_queue_overflow_underflow()
     unsigned i;
     mbedtls_test_ssl_message_queue server_queue, client_queue;
     mbedtls_test_message_socket_context server_context, client_context;
+
+    USE_PSA_INIT();
     mbedtls_test_message_socket_init(&server_context);
     mbedtls_test_message_socket_init(&client_context);
 
@@ -741,6 +763,7 @@ void ssl_message_mock_queue_overflow_underflow()
 exit:
     mbedtls_test_message_socket_close(&server_context);
     mbedtls_test_message_socket_close(&client_context);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -753,6 +776,8 @@ void ssl_message_mock_socket_overflow()
     unsigned i;
     mbedtls_test_ssl_message_queue server_queue, client_queue;
     mbedtls_test_message_socket_context server_context, client_context;
+
+    USE_PSA_INIT();
     mbedtls_test_message_socket_init(&server_context);
     mbedtls_test_message_socket_init(&client_context);
 
@@ -793,6 +818,7 @@ void ssl_message_mock_socket_overflow()
 exit:
     mbedtls_test_message_socket_close(&server_context);
     mbedtls_test_message_socket_close(&client_context);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -805,6 +831,8 @@ void ssl_message_mock_truncated()
     unsigned i;
     mbedtls_test_ssl_message_queue server_queue, client_queue;
     mbedtls_test_message_socket_context server_context, client_context;
+
+    USE_PSA_INIT();
     mbedtls_test_message_socket_init(&server_context);
     mbedtls_test_message_socket_init(&client_context);
 
@@ -857,6 +885,7 @@ void ssl_message_mock_truncated()
 exit:
     mbedtls_test_message_socket_close(&server_context);
     mbedtls_test_message_socket_close(&client_context);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -869,6 +898,8 @@ void ssl_message_mock_socket_read_error()
     unsigned i;
     mbedtls_test_ssl_message_queue server_queue, client_queue;
     mbedtls_test_message_socket_context server_context, client_context;
+
+    USE_PSA_INIT();
     mbedtls_test_message_socket_init(&server_context);
     mbedtls_test_message_socket_init(&client_context);
 
@@ -915,6 +946,7 @@ void ssl_message_mock_socket_read_error()
 exit:
     mbedtls_test_message_socket_close(&server_context);
     mbedtls_test_message_socket_close(&client_context);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -927,6 +959,8 @@ void ssl_message_mock_interleaved_one_way()
     unsigned i;
     mbedtls_test_ssl_message_queue server_queue, client_queue;
     mbedtls_test_message_socket_context server_context, client_context;
+
+    USE_PSA_INIT();
     mbedtls_test_message_socket_init(&server_context);
     mbedtls_test_message_socket_init(&client_context);
 
@@ -975,6 +1009,7 @@ void ssl_message_mock_interleaved_one_way()
 exit:
     mbedtls_test_message_socket_close(&server_context);
     mbedtls_test_message_socket_close(&client_context);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -987,6 +1022,8 @@ void ssl_message_mock_interleaved_two_ways()
     unsigned i;
     mbedtls_test_ssl_message_queue server_queue, client_queue;
     mbedtls_test_message_socket_context server_context, client_context;
+
+    USE_PSA_INIT();
     mbedtls_test_message_socket_init(&server_context);
     mbedtls_test_message_socket_init(&client_context);
 
@@ -1062,6 +1099,7 @@ void ssl_message_mock_interleaved_two_ways()
 exit:
     mbedtls_test_message_socket_close(&server_context);
     mbedtls_test_message_socket_close(&client_context);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -1074,6 +1112,7 @@ void ssl_dtls_replay(data_t *prevs, data_t *new, int ret)
 
     mbedtls_ssl_init(&ssl);
     mbedtls_ssl_config_init(&conf);
+    USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_ssl_config_defaults(&conf,
                                             MBEDTLS_SSL_IS_CLIENT,
@@ -1091,8 +1130,10 @@ void ssl_dtls_replay(data_t *prevs, data_t *new, int ret)
     memcpy(ssl.in_ctr + 2, new->x, 6);
     TEST_ASSERT(mbedtls_ssl_dtls_replay_check(&ssl) == ret);
 
+exit:
     mbedtls_ssl_free(&ssl);
     mbedtls_ssl_config_free(&conf);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -1100,12 +1141,16 @@ void ssl_dtls_replay(data_t *prevs, data_t *new, int ret)
 void ssl_set_hostname_twice(char *hostname0, char *hostname1)
 {
     mbedtls_ssl_context ssl;
+
+    USE_PSA_INIT();
     mbedtls_ssl_init(&ssl);
 
     TEST_ASSERT(mbedtls_ssl_set_hostname(&ssl, hostname0) == 0);
     TEST_ASSERT(mbedtls_ssl_set_hostname(&ssl, hostname1) == 0);
 
+exit:
     mbedtls_ssl_free(&ssl);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -1130,6 +1175,8 @@ void ssl_crypt_record(int cipher_type, int hash_id,
     mbedtls_record rec, rec_backup;
 
     mbedtls_ssl_init(&ssl);
+    USE_PSA_INIT();
+
     mbedtls_ssl_transform_init(&t0);
     mbedtls_ssl_transform_init(&t1);
     TEST_ASSERT(mbedtls_test_ssl_build_transforms(&t0, &t1, cipher_type, hash_id,
@@ -1230,8 +1277,8 @@ exit:
     mbedtls_ssl_free(&ssl);
     mbedtls_ssl_transform_free(&t0);
     mbedtls_ssl_transform_free(&t1);
-
     mbedtls_free(buf);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -1279,6 +1326,7 @@ void ssl_crypt_record_small(int cipher_type, int hash_id,
                        * already seen a successful test. */
 
     mbedtls_ssl_init(&ssl);
+    USE_PSA_INIT();
     mbedtls_ssl_transform_init(&t0);
     mbedtls_ssl_transform_init(&t1);
     TEST_ASSERT(mbedtls_test_ssl_build_transforms(&t0, &t1, cipher_type, hash_id,
@@ -1390,8 +1438,8 @@ exit:
     mbedtls_ssl_free(&ssl);
     mbedtls_ssl_transform_free(&t0);
     mbedtls_ssl_transform_free(&t1);
-
     mbedtls_free(buf);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -1429,6 +1477,7 @@ void ssl_decrypt_non_etm_cbc(int cipher_type, int hash_id, int trunc_hmac,
     const unsigned char pad_max_len = 255; /* Per the standard */
 
     mbedtls_ssl_init(&ssl);
+    USE_PSA_INIT();
     mbedtls_ssl_transform_init(&t0);
     mbedtls_ssl_transform_init(&t1);
 
@@ -1601,6 +1650,7 @@ exit:
     mbedtls_ssl_transform_free(&t1);
     mbedtls_free(buf);
     mbedtls_free(buf_save);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -1788,7 +1838,7 @@ void ssl_serialize_session_save_load(int ticket_len, char *crt_file)
     /*
      * Test that a save-load pair is the identity
      */
-
+    USE_PSA_INIT();
     mbedtls_ssl_session_init(&original);
     mbedtls_ssl_session_init(&restored);
 
@@ -1875,6 +1925,7 @@ exit:
     mbedtls_ssl_session_free(&original);
     mbedtls_ssl_session_free(&restored);
     mbedtls_free(buf);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -1888,7 +1939,7 @@ void ssl_serialize_session_load_save(int ticket_len, char *crt_file)
     /*
      * Test that a load-save pair is the identity
      */
-
+    USE_PSA_INIT();
     mbedtls_ssl_session_init(&session);
 
     /* Prepare a dummy session to work on */
@@ -1926,6 +1977,7 @@ exit:
     mbedtls_ssl_session_free(&session);
     mbedtls_free(buf1);
     mbedtls_free(buf2);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -1939,7 +1991,7 @@ void ssl_serialize_session_save_buf_size(int ticket_len, char *crt_file)
     /*
      * Test that session_save() fails cleanly on small buffers
      */
-
+    USE_PSA_INIT();
     mbedtls_ssl_session_init(&session);
 
     /* Prepare dummy session and get serialized size */
@@ -1962,6 +2014,7 @@ void ssl_serialize_session_save_buf_size(int ticket_len, char *crt_file)
 exit:
     mbedtls_ssl_session_free(&session);
     mbedtls_free(buf);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -1975,7 +2028,7 @@ void ssl_serialize_session_load_buf_size(int ticket_len, char *crt_file)
     /*
      * Test that session_load() fails cleanly on small buffers
      */
-
+    USE_PSA_INIT();
     mbedtls_ssl_session_init(&session);
 
     /* Prepare serialized session data */
@@ -2004,6 +2057,7 @@ exit:
     mbedtls_ssl_session_free(&session);
     mbedtls_free(good_buf);
     mbedtls_free(bad_buf);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -2023,6 +2077,7 @@ void ssl_session_serialize_version_check(int corrupt_major,
                                       corrupt_config == 1,
                                       corrupt_config == 1 };
 
+    USE_PSA_INIT();
     mbedtls_ssl_session_init(&session);
 
     /* Infer length of serialized session. */
@@ -2065,7 +2120,7 @@ void ssl_session_serialize_version_check(int corrupt_major,
             *byte ^= corrupted_bit;
         }
     }
-
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -2076,6 +2131,7 @@ void mbedtls_endpoint_sanity(int endpoint_type)
     mbedtls_test_ssl_endpoint ep;
     int ret = -1;
 
+    USE_PSA_INIT();
     ret = mbedtls_test_ssl_endpoint_init(NULL, endpoint_type, MBEDTLS_PK_RSA,
                                          NULL, NULL, NULL, NULL);
     TEST_ASSERT(MBEDTLS_ERR_SSL_BAD_INPUT_DATA == ret);
@@ -2089,6 +2145,7 @@ void mbedtls_endpoint_sanity(int endpoint_type)
 
 exit:
     mbedtls_test_ssl_endpoint_free(&ep, NULL);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -2099,6 +2156,7 @@ void move_handshake_to_state(int endpoint_type, int state, int need_pass)
     mbedtls_test_ssl_endpoint base_ep, second_ep;
     int ret = -1;
 
+    USE_PSA_INIT();
     mbedtls_platform_zeroize(&base_ep, sizeof(base_ep));
     mbedtls_platform_zeroize(&second_ep, sizeof(second_ep));
 
@@ -2133,6 +2191,7 @@ void move_handshake_to_state(int endpoint_type, int state, int need_pass)
 exit:
     mbedtls_test_ssl_endpoint_free(&base_ep, NULL);
     mbedtls_test_ssl_endpoint_free(&second_ep, NULL);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -2329,9 +2388,10 @@ void resize_buffers(int mfl, int renegotiation, int legacy_renegotiation,
 /* BEGIN_CASE depends_on:MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED:MBEDTLS_CERTS_C:!MBEDTLS_USE_PSA_CRYPTO:MBEDTLS_PKCS1_V15:MBEDTLS_SSL_VARIABLE_BUFFER_LENGTH:MBEDTLS_SSL_CONTEXT_SERIALIZATION:MBEDTLS_SSL_PROTO_TLS1_2:MBEDTLS_RSA_C:MBEDTLS_ECP_DP_SECP384R1_ENABLED:MBEDTLS_SSL_PROTO_DTLS:MBEDTLS_ENTROPY_C:MBEDTLS_CTR_DRBG_C:MBEDTLS_SHA256_C:MBEDTLS_CAN_HANDLE_RSA_TEST_KEY */
 void resize_buffers_serialize_mfl(int mfl)
 {
+    USE_PSA_INIT();
     test_resize_buffers(mfl, 0, MBEDTLS_SSL_LEGACY_NO_RENEGOTIATION, 1, 1,
                         (char *) "");
-
+    USE_PSA_DONE();
     /* The goto below is used to avoid an "unused label" warning.*/
     goto exit;
 }
@@ -2341,8 +2401,9 @@ void resize_buffers_serialize_mfl(int mfl)
 void resize_buffers_renegotiate_mfl(int mfl, int legacy_renegotiation,
                                     char *cipher)
 {
+    USE_PSA_INIT();
     test_resize_buffers(mfl, 1, legacy_renegotiation, 0, 1, cipher);
-
+    USE_PSA_DONE();
     /* The goto below is used to avoid an "unused label" warning.*/
     goto exit;
 }
@@ -2422,6 +2483,7 @@ void cookie_parsing(data_t *cookie, int exp_ret)
     size_t len;
 
     mbedtls_ssl_init(&ssl);
+    USE_PSA_INIT();
     mbedtls_ssl_config_init(&conf);
     TEST_EQUAL(mbedtls_ssl_config_defaults(&conf, MBEDTLS_SSL_IS_SERVER,
                                            MBEDTLS_SSL_TRANSPORT_DATAGRAM,
@@ -2437,7 +2499,9 @@ void cookie_parsing(data_t *cookie, int exp_ret)
                                                     &len),
                exp_ret);
 
+exit:
     mbedtls_ssl_free(&ssl);
     mbedtls_ssl_config_free(&conf);
+    USE_PSA_DONE();
 }
 /* END_CASE */

--- a/tests/suites/test_suite_x509parse.function
+++ b/tests/suites/test_suite_x509parse.function
@@ -409,6 +409,7 @@ void x509_parse_san(char *crt_file, char *result_str)
 
     mbedtls_x509_crt_init(&crt);
     memset(buf, 0, 2000);
+    USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_x509_crt_parse_file(&crt, crt_file) == 0);
 
@@ -432,6 +433,7 @@ void x509_parse_san(char *crt_file, char *result_str)
 exit:
 
     mbedtls_x509_crt_free(&crt);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -444,6 +446,7 @@ void x509_cert_info(char *crt_file, char *result_str)
 
     mbedtls_x509_crt_init(&crt);
     memset(buf, 0, 2000);
+    USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_x509_crt_parse_file(&crt, crt_file) == 0);
     res = mbedtls_x509_crt_info(buf, 2000, "", &crt);
@@ -455,6 +458,7 @@ void x509_cert_info(char *crt_file, char *result_str)
 
 exit:
     mbedtls_x509_crt_free(&crt);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -467,6 +471,7 @@ void mbedtls_x509_crl_info(char *crl_file, char *result_str)
 
     mbedtls_x509_crl_init(&crl);
     memset(buf, 0, 2000);
+    USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_x509_crl_parse_file(&crl, crl_file) == 0);
     res = mbedtls_x509_crl_info(buf, 2000, "", &crl);
@@ -478,6 +483,7 @@ void mbedtls_x509_crl_info(char *crl_file, char *result_str)
 
 exit:
     mbedtls_x509_crl_free(&crl);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -489,11 +495,13 @@ void mbedtls_x509_crl_parse(char *crl_file, int result)
 
     mbedtls_x509_crl_init(&crl);
     memset(buf, 0, 2000);
+    USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_x509_crl_parse_file(&crl, crl_file) == result);
 
 exit:
     mbedtls_x509_crl_free(&crl);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -506,6 +514,7 @@ void mbedtls_x509_csr_info(char *csr_file, char *result_str)
 
     mbedtls_x509_csr_init(&csr);
     memset(buf, 0, 2000);
+    USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_x509_csr_parse_file(&csr, csr_file) == 0);
     res = mbedtls_x509_csr_info(buf, 2000, "", &csr);
@@ -517,6 +526,7 @@ void mbedtls_x509_csr_info(char *csr_file, char *result_str)
 
 exit:
     mbedtls_x509_csr_free(&csr);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -526,6 +536,7 @@ void x509_verify_info(int flags, char *prefix, char *result_str)
     char buf[2000];
     int res;
 
+    USE_PSA_INIT();
     memset(buf, 0, sizeof(buf));
 
     res = mbedtls_x509_crt_verify_info(buf, sizeof(buf), prefix, flags);
@@ -533,6 +544,9 @@ void x509_verify_info(int flags, char *prefix, char *result_str)
     TEST_ASSERT(res >= 0);
 
     TEST_ASSERT(strcmp(buf, result_str) == 0);
+
+exit:
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -556,10 +570,10 @@ void x509_verify_restart(char *crt_file, char *ca_file,
      * - x509_verify() for server5 -> test-ca2:             ~ 18800
      * - x509_verify() for server10 -> int-ca3 -> int-ca2:  ~ 25500
      */
-
     mbedtls_x509_crt_restart_init(&rs_ctx);
     mbedtls_x509_crt_init(&crt);
     mbedtls_x509_crt_init(&ca);
+    USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_x509_crt_parse_file(&crt, crt_file) == 0);
     TEST_ASSERT(mbedtls_x509_crt_parse_file(&ca, ca_file) == 0);
@@ -589,6 +603,7 @@ exit:
     mbedtls_x509_crt_restart_free(&rs_ctx);
     mbedtls_x509_crt_free(&crt);
     mbedtls_x509_crt_free(&ca);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -695,6 +710,7 @@ void x509_verify_ca_cb_failure(char *crt_file, char *ca_file, char *name,
 
     mbedtls_x509_crt_init(&crt);
     mbedtls_x509_crt_init(&ca);
+    USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_x509_crt_parse_file(&crt, crt_file) == 0);
     TEST_ASSERT(mbedtls_x509_crt_parse_file(&ca, ca_file) == 0);
@@ -712,6 +728,7 @@ void x509_verify_ca_cb_failure(char *crt_file, char *ca_file, char *name,
 exit:
     mbedtls_x509_crt_free(&crt);
     mbedtls_x509_crt_free(&ca);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -762,6 +779,7 @@ void mbedtls_x509_dn_gets(char *crt_file, char *entity, char *result_str)
 
     mbedtls_x509_crt_init(&crt);
     memset(buf, 0, 2000);
+    USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_x509_crt_parse_file(&crt, crt_file) == 0);
     if (strcmp(entity, "subject") == 0) {
@@ -779,6 +797,7 @@ void mbedtls_x509_dn_gets(char *crt_file, char *entity, char *result_str)
 
 exit:
     mbedtls_x509_crt_free(&crt);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -794,6 +813,7 @@ void mbedtls_x509_dn_gets_subject_replace(char *crt_file,
 
     mbedtls_x509_crt_init(&crt);
     memset(buf, 0, 2000);
+    USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_x509_crt_parse_file(&crt, crt_file) == 0);
     crt.subject.next->val.p = (unsigned char *) new_subject_ou;
@@ -810,6 +830,7 @@ void mbedtls_x509_dn_gets_subject_replace(char *crt_file,
     }
 exit:
     mbedtls_x509_crt_free(&crt);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -823,6 +844,7 @@ void mbedtls_x509_get_name(char *rdn_sequence, int exp_ret)
     mbedtls_x509_name *allocated, *prev;
     int ret;
 
+    USE_PSA_INIT();
     memset(&head, 0, sizeof(head));
 
     name = mbedtls_test_unhexify_alloc(rdn_sequence, &name_len);
@@ -843,6 +865,9 @@ void mbedtls_x509_get_name(char *rdn_sequence, int exp_ret)
     TEST_EQUAL(ret, exp_ret);
 
     mbedtls_free(name);
+
+exit:
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -852,6 +877,7 @@ void mbedtls_x509_time_is_past(char *crt_file, char *entity, int result)
     mbedtls_x509_crt   crt;
 
     mbedtls_x509_crt_init(&crt);
+    USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_x509_crt_parse_file(&crt, crt_file) == 0);
 
@@ -865,6 +891,7 @@ void mbedtls_x509_time_is_past(char *crt_file, char *entity, int result)
 
 exit:
     mbedtls_x509_crt_free(&crt);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -874,6 +901,7 @@ void mbedtls_x509_time_is_future(char *crt_file, char *entity, int result)
     mbedtls_x509_crt   crt;
 
     mbedtls_x509_crt_init(&crt);
+    USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_x509_crt_parse_file(&crt, crt_file) == 0);
 
@@ -887,6 +915,7 @@ void mbedtls_x509_time_is_future(char *crt_file, char *entity, int result)
 
 exit:
     mbedtls_x509_crt_free(&crt);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -896,11 +925,13 @@ void x509parse_crt_file(char *crt_file, int result)
     mbedtls_x509_crt crt;
 
     mbedtls_x509_crt_init(&crt);
+    USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_x509_crt_parse_file(&crt, crt_file) == result);
 
 exit:
     mbedtls_x509_crt_free(&crt);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -913,6 +944,7 @@ void x509parse_crt(data_t *buf, char *result_str, int result)
 
     mbedtls_x509_crt_init(&crt);
     memset(output, 0, 2000);
+    USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_x509_crt_parse_der(&crt, buf->x, buf->len) == (result));
     if ((result) == 0) {
@@ -970,6 +1002,7 @@ void x509parse_crt(data_t *buf, char *result_str, int result)
 
 exit:
     mbedtls_x509_crt_free(&crt);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -987,6 +1020,7 @@ void x509parse_crt_cb(data_t *buf, char *result_str, int result)
 
     mbedtls_x509_crt_init(&crt);
     memset(output, 0, 2000);
+    USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_x509_crt_parse_der_with_ext_cb(&crt, buf->x, buf->len, 0, parse_crt_ext_cb,
                                                        &oid) == (result));
@@ -1016,6 +1050,7 @@ void x509parse_crt_cb(data_t *buf, char *result_str, int result)
 
 exit:
     mbedtls_x509_crt_free(&crt);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -1028,7 +1063,7 @@ void x509parse_crl(data_t *buf, char *result_str, int result)
 
     mbedtls_x509_crl_init(&crl);
     memset(output, 0, 2000);
-
+    USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_x509_crl_parse(&crl, buf->x, buf->len) == (result));
     if ((result) == 0) {
@@ -1042,6 +1077,7 @@ void x509parse_crl(data_t *buf, char *result_str, int result)
 
 exit:
     mbedtls_x509_crl_free(&crl);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -1054,6 +1090,7 @@ void mbedtls_x509_csr_parse(data_t *csr_der, char *ref_out, int ref_ret)
 
     mbedtls_x509_csr_init(&csr);
     memset(my_out, 0, sizeof(my_out));
+    USE_PSA_INIT();
 
     my_ret = mbedtls_x509_csr_parse_der(&csr, csr_der->x, csr_der->len);
     TEST_ASSERT(my_ret == ref_ret);
@@ -1066,6 +1103,7 @@ void mbedtls_x509_csr_parse(data_t *csr_der, char *ref_out, int ref_ret)
 
 exit:
     mbedtls_x509_csr_free(&csr);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -1076,6 +1114,7 @@ void mbedtls_x509_crt_parse_path(char *crt_path, int ret, int nb_crt)
     int i;
 
     mbedtls_x509_crt_init(&chain);
+    USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_x509_crt_parse_path(&chain, crt_path) == ret);
 
@@ -1090,6 +1129,7 @@ void mbedtls_x509_crt_parse_path(char *crt_path, int ret, int nb_crt)
 
 exit:
     mbedtls_x509_crt_free(&chain);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -1106,10 +1146,8 @@ void mbedtls_x509_crt_verify_max(char *ca_file, char *chain_dir, int nb_int,
      * We expect chain_dir to contain certificates 00.crt, 01.crt, etc.
      * with NN.crt signed by NN-1.crt
      */
-
     mbedtls_x509_crt_init(&trusted);
     mbedtls_x509_crt_init(&chain);
-
     USE_PSA_INIT();
 
     /* Load trusted root */
@@ -1148,7 +1186,6 @@ void mbedtls_x509_crt_verify_chain(char *chain_paths, char *trusted_ca,
 
     mbedtls_x509_crt_init(&chain);
     mbedtls_x509_crt_init(&trusted);
-
     USE_PSA_INIT();
 
     while ((act = mystrsep(&chain_paths, " ")) != NULL) {
@@ -1188,7 +1225,7 @@ void x509_oid_desc(data_t *buf, char *ref_desc)
     const char *desc = NULL;
     int ret;
 
-
+    USE_PSA_INIT();
     oid.tag = MBEDTLS_ASN1_OID;
     oid.p   = buf->x;
     oid.len   = buf->len;
@@ -1203,6 +1240,9 @@ void x509_oid_desc(data_t *buf, char *ref_desc)
         TEST_ASSERT(desc != NULL);
         TEST_ASSERT(strcmp(desc, ref_desc) == 0);
     }
+
+exit:
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -1212,6 +1252,7 @@ void x509_oid_numstr(data_t *oid_buf, char *numstr, int blen, int ret)
     mbedtls_x509_buf oid;
     char num_buf[100];
 
+    USE_PSA_INIT();
     memset(num_buf, 0x2a, sizeof(num_buf));
 
     oid.tag = MBEDTLS_ASN1_OID;
@@ -1226,6 +1267,9 @@ void x509_oid_numstr(data_t *oid_buf, char *numstr, int blen, int ret)
         TEST_ASSERT(num_buf[ret] == 0);
         TEST_ASSERT(strcmp(num_buf, numstr) == 0);
     }
+
+exit:
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -1235,6 +1279,7 @@ void x509_check_key_usage(char *crt_file, int usage, int ret)
     mbedtls_x509_crt crt;
 
     mbedtls_x509_crt_init(&crt);
+    USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_x509_crt_parse_file(&crt, crt_file) == 0);
 
@@ -1242,6 +1287,7 @@ void x509_check_key_usage(char *crt_file, int usage, int ret)
 
 exit:
     mbedtls_x509_crt_free(&crt);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -1252,7 +1298,7 @@ void x509_check_extended_key_usage(char *crt_file, data_t *oid, int ret
     mbedtls_x509_crt crt;
 
     mbedtls_x509_crt_init(&crt);
-
+    USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_x509_crt_parse_file(&crt, crt_file) == 0);
 
@@ -1261,6 +1307,7 @@ void x509_check_extended_key_usage(char *crt_file, data_t *oid, int ret
 
 exit:
     mbedtls_x509_crt_free(&crt);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -1273,6 +1320,7 @@ void x509_get_time(int tag, char *time_str, int ret, int year, int mon,
     unsigned char *start = buf;
     unsigned char *end = buf;
 
+    USE_PSA_INIT();
     memset(&time, 0x00, sizeof(time));
     *end = (unsigned char) tag; end++;
     *end = strlen(time_str);
@@ -1290,6 +1338,9 @@ void x509_get_time(int tag, char *time_str, int ret, int year, int mon,
         TEST_ASSERT(min  == time.min);
         TEST_ASSERT(sec  == time.sec);
     }
+
+exit:
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -1302,6 +1353,8 @@ void x509_parse_rsassa_pss_params(data_t *params, int params_tag,
     mbedtls_x509_buf buf;
     mbedtls_md_type_t my_msg_md, my_mgf_md;
     int my_salt_len;
+
+    USE_PSA_INIT();
 
     buf.p = params->x;
     buf.len = params->len;
@@ -1319,13 +1372,17 @@ void x509_parse_rsassa_pss_params(data_t *params, int params_tag,
     }
 
 exit:
-    ;;
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_X509_CRT_PARSE_C:MBEDTLS_SELF_TEST */
 void x509_selftest()
 {
+    USE_PSA_INIT();
     TEST_ASSERT(mbedtls_x509_self_test(1) == 0);
+
+exit:
+    USE_PSA_DONE();
 }
 /* END_CASE */

--- a/tests/suites/test_suite_x509parse.function
+++ b/tests/suites/test_suite_x509parse.function
@@ -837,7 +837,7 @@ exit:
 /* BEGIN_CASE depends_on:MBEDTLS_X509_CRT_PARSE_C */
 void mbedtls_x509_get_name(char *rdn_sequence, int exp_ret)
 {
-    unsigned char *name;
+    unsigned char *name = NULL;
     unsigned char *p;
     size_t name_len;
     mbedtls_x509_name head;

--- a/tests/suites/test_suite_x509write.function
+++ b/tests/suites/test_suite_x509write.function
@@ -145,8 +145,9 @@ void x509_csr_check(char *key_file, char *cert_req_check_file, int md_type,
     memset(&rnd_info, 0x2a, sizeof(mbedtls_test_rnd_pseudo_info));
 
     mbedtls_x509write_csr_init(&req);
-
     mbedtls_pk_init(&key);
+    USE_PSA_INIT();
+
     TEST_ASSERT(mbedtls_pk_parse_keyfile(&key, key_file, NULL) == 0);
 
     mbedtls_x509write_csr_set_md_alg(&req, md_type);
@@ -197,6 +198,7 @@ void x509_csr_check(char *key_file, char *cert_req_check_file, int md_type,
 exit:
     mbedtls_x509write_csr_free(&req);
     mbedtls_pk_free(&key);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -246,12 +248,11 @@ void x509_csr_check_opaque(char *key_file, int md_type, int key_usage,
     buf[pem_len] = '\0';
     TEST_ASSERT(x509_crt_verifycsr(buf, pem_len + 1) == 0);
 
-
 exit:
     mbedtls_x509write_csr_free(&req);
     mbedtls_pk_free(&key);
     psa_destroy_key(key_id);
-    PSA_DONE();
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -287,6 +288,7 @@ void x509_crt_check(char *subject_key_file, char *subject_pwd,
     mbedtls_pk_init(&issuer_key_alt);
 
     mbedtls_x509write_crt_init(&crt);
+    USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_pk_parse_keyfile(&subject_key, subject_key_file,
                                          subject_pwd) == 0);
@@ -422,6 +424,7 @@ exit:
     mbedtls_pk_free(&subject_key);
     mbedtls_pk_free(&issuer_key);
     mbedtls_mpi_free(&serial);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -432,6 +435,7 @@ void x509_set_serial_check()
     mbedtls_mpi serial_mpi;
     uint8_t invalid_serial[MBEDTLS_X509_RFC5280_MAX_SERIAL_LEN + 1];
 
+    USE_PSA_INIT();
     memset(invalid_serial, 0x01, sizeof(invalid_serial));
 
     mbedtls_mpi_init(&serial_mpi);
@@ -442,6 +446,7 @@ void x509_set_serial_check()
 
 exit:
     mbedtls_mpi_free(&serial_mpi);
+    USE_PSA_DONE();
 }
 /* END_CASE */
 
@@ -454,6 +459,8 @@ void mbedtls_x509_string_to_names(char *name, char *parsed_name, int result
     mbedtls_asn1_named_data *names = NULL;
     mbedtls_x509_name parsed, *parsed_cur, *parsed_prv;
     unsigned char buf[1024], out[1024], *c;
+
+    USE_PSA_INIT();
 
     memset(&parsed, 0, sizeof(parsed));
     memset(out, 0, sizeof(out));
@@ -488,5 +495,6 @@ exit:
         parsed_cur = parsed_cur->next;
         mbedtls_free(parsed_prv);
     }
+    USE_PSA_DONE();
 }
 /* END_CASE */


### PR DESCRIPTION
This is the backport of PR #7461


## Gatekeeper checklist

- [x] **changelog** not required - tests only
- [x] **backport** not required since this IS the backport
- [x] **tests** not required