### PR TITLE
cert_audit: Improvements of audit script

### DIFF
--- a/tests/scripts/audit-validity-dates.py
+++ b/tests/scripts/audit-validity-dates.py
@@ -45,7 +45,7 @@ from mbedtls_dev import build_tree
 
 def check_cryptography_version():
     match = re.match(r'^[0-9]+', cryptography.__version__)
-    if match is None or int(match[0]) < 35:
+    if match is None or int(match.group(0)) < 35:
         raise Exception("audit-validity-dates requires cryptography >= 35.0.0"
                         + "({} is too old)".format(cryptography.__version__))
 

--- a/tests/scripts/audit-validity-dates.py
+++ b/tests/scripts/audit-validity-dates.py
@@ -383,13 +383,13 @@ def merge_auditdata(original: typing.List[AuditData]) \
 
 
 def list_all(audit_data: AuditData):
-    print("{:20}\t{:20}\t{:3}\t{}".format(
-        audit_data.not_valid_before.isoformat(timespec='seconds'),
-        audit_data.not_valid_after.isoformat(timespec='seconds'),
-        audit_data.data_type.name,
-        audit_data.locations[0]))
-    for loc in audit_data.locations[1:]:
-        print("{:20}\t{:20}\t{:3}\t{}".format('', '', '', loc))
+    for loc in audit_data.locations:
+        print("{}\t{:20}\t{:20}\t{:3}\t{}".format(
+            audit_data.identifier,
+            audit_data.not_valid_before.isoformat(timespec='seconds'),
+            audit_data.not_valid_after.isoformat(timespec='seconds'),
+            audit_data.data_type.name,
+            loc))
 
 
 def configure_logger(logger: logging.Logger) -> None:

--- a/tests/scripts/audit-validity-dates.py
+++ b/tests/scripts/audit-validity-dates.py
@@ -73,9 +73,6 @@ class AuditData:
         encoding = cryptography.hazmat.primitives.serialization.Encoding.DER
         self._identifier = hashlib.sha1(self._obj.public_bytes(encoding)).hexdigest()
 
-    def __eq__(self, __value) -> bool:
-        return self._obj == __value._obj
-
     @property
     def identifier(self):
         """
@@ -263,7 +260,7 @@ class Auditor:
         Iterate over all the files in the list and get audit data. The
         results will be written to `results` passed to this function.
 
-        :param results: The dictionary used to store the parsed 
+        :param results: The dictionary used to store the parsed
                         AuditData. The keys of this dictionary should
                         be the identifier of the AuditData.
         """
@@ -374,22 +371,6 @@ class SuiteDataAuditor(Auditor):
                 audit_data_list.append(audit_data)
 
         return audit_data_list
-
-
-def merge_auditdata(original: typing.List[AuditData]) \
-    -> typing.List[AuditData]:
-    """
-    Multiple AuditData might be extracted from different locations for
-    an identical X.509 object. Merge them into one entry in the list.
-    """
-    results = []
-    for x in original:
-        if x not in results:
-            results.append(x)
-        else:
-            idx = results.index(x)
-            results[idx].locations.extend(x.locations)
-    return results
 
 
 def list_all(audit_data: AuditData):

--- a/tests/scripts/audit-validity-dates.py
+++ b/tests/scripts/audit-validity-dates.py
@@ -302,10 +302,20 @@ class TestDataAuditor(Auditor):
             data = f.read()
 
         results = []
+        # Try to parse all PEM blocks.
+        is_pem = False
         for idx, m in enumerate(re.finditer(X509Parser.PEM_REGEX, data, flags=re.S), 1):
+            is_pem = True
             result = self.parse_bytes(data[m.start():m.end()])
             if result is not None:
                 result.locations.append("{}#{}".format(filename, idx))
+                results.append(result)
+
+        # Might be DER format.
+        if not is_pem:
+            result = self.parse_bytes(data)
+            if result is not None:
+                result.locations.append("{}".format(filename))
                 results.append(result)
 
         return results

--- a/tests/scripts/audit-validity-dates.py
+++ b/tests/scripts/audit-validity-dates.py
@@ -487,11 +487,13 @@ def main():
     filter_func = lambda d: (start_date < d.not_valid_before) or \
                             (d.not_valid_after < end_date)
 
+    sortby_end = lambda d: d.not_valid_after
+
     if args.all:
         filter_func = None
 
     # filter and output the results
-    for d in filter(filter_func, audit_results):
+    for d in sorted(filter(filter_func, audit_results), key=sortby_end):
         list_all(d)
 
     logger.debug("Done!")

--- a/tests/scripts/audit-validity-dates.py
+++ b/tests/scripts/audit-validity-dates.py
@@ -31,6 +31,7 @@ import argparse
 import datetime
 import glob
 import logging
+import hashlib
 from enum import Enum
 
 # The script requires cryptography >= 35.0.0 which is only available
@@ -69,9 +70,19 @@ class AuditData:
         self.locations = [] # type: typing.List[str]
         self.fill_validity_duration(x509_obj)
         self._obj = x509_obj
+        encoding = cryptography.hazmat.primitives.serialization.Encoding.DER
+        self._identifier = hashlib.sha1(self._obj.public_bytes(encoding)).hexdigest()
 
     def __eq__(self, __value) -> bool:
         return self._obj == __value._obj
+
+    @property
+    def identifier(self):
+        """
+        Identifier of the underlying X.509 object, which is consistent across
+        different runs.
+        """
+        return self._identifier
 
     def fill_validity_duration(self, x509_obj):
         """Read validity period from an X.509 object."""


### PR DESCRIPTION
## Description

Preceding PR: https://github.com/Mbed-TLS/mbedtls/pull/7399 — ~~the first new commit is the one after "[cert_audit: Reword the options and their descriptions](https://github.com/Mbed-TLS/mbedtls/pull/7399/commits/1d4cc917cea1abc710e96465e4e6aa7f6296c738)"~~

This PR contains several improvements of the certificate audit scripts.

- Support parsing multiple PEM objects in a single file.
- Merge the AuditData for identical X.509 objects in different locations.
- Sorted outputs

## Gatekeeper checklist

- [x] **changelog** no (maintenance script only)
- [x] **backport** No, [same as the preceding PR](https://github.com/Mbed-TLS/mbedtls/pull/7399#issuecomment-1523731788)
- [x] **tests** no (maintenance script only)
