### PR TITLE
PK: move the opaque context to a new member of the mbedtls_pk_context structure

### DIFF
--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -236,7 +236,7 @@ typedef struct mbedtls_pk_info_t mbedtls_pk_info_t;
  * \brief           Public key container
  *
  * \note            The priv_id is guarded by MBEDTLS_PSA_CRYPTO_C and not
- *                  only by MBEDTLS_USE_PSA_CRYPTO because it can be used also
+ *                  by MBEDTLS_USE_PSA_CRYPTO because it can be used also
  *                  in mbedtls_pk_sign_ext for RSA keys.
  */
 typedef struct mbedtls_pk_context {

--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -235,7 +235,7 @@ typedef struct mbedtls_pk_info_t mbedtls_pk_info_t;
 /**
  * \brief           Public key container
  *
- * \note            The opaque_id is guarded by MBEDTLS_PSA_CRYPTO_C and not
+ * \note            The priv_id is guarded by MBEDTLS_PSA_CRYPTO_C and not
  *                  only by MBEDTLS_USE_PSA_CRYPTO because it can be used also
  *                  in mbedtls_pk_sign_ext for RSA keys.
  */
@@ -243,7 +243,7 @@ typedef struct mbedtls_pk_context {
     const mbedtls_pk_info_t *MBEDTLS_PRIVATE(pk_info);    /**< Public key information         */
     void *MBEDTLS_PRIVATE(pk_ctx);                        /**< Underlying public key context  */
 #if defined(MBEDTLS_PSA_CRYPTO_C)
-    mbedtls_svc_key_id_t MBEDTLS_PRIVATE(opaque_id);      /**< Key ID for opaque keys */
+    mbedtls_svc_key_id_t MBEDTLS_PRIVATE(priv_id);      /**< Key ID for opaque keys */
 #endif /* MBEDTLS_PSA_CRYPTO_C */
 } mbedtls_pk_context;
 

--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -40,7 +40,7 @@
 #include "mbedtls/ecdsa.h"
 #endif
 
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
+#if defined(MBEDTLS_USE_PSA_CRYPTO) || defined(MBEDTLS_PSA_CRYPTO_C)
 #include "psa/crypto.h"
 #endif
 
@@ -234,10 +234,17 @@ typedef struct mbedtls_pk_info_t mbedtls_pk_info_t;
 
 /**
  * \brief           Public key container
+ *
+ * \note            The opaque_id is guarded by MBEDTLS_PSA_CRYPTO_C and not
+ *                  only by MBEDTLS_USE_PSA_CRYPTO because it can be used also
+ *                  in mbedtls_pk_sign_ext for RSA keys.
  */
 typedef struct mbedtls_pk_context {
     const mbedtls_pk_info_t *MBEDTLS_PRIVATE(pk_info);    /**< Public key information         */
     void *MBEDTLS_PRIVATE(pk_ctx);                        /**< Underlying public key context  */
+#if defined(MBEDTLS_PSA_CRYPTO_C)
+    mbedtls_svc_key_id_t MBEDTLS_PRIVATE(opaque_id);      /**< Key ID for opaque keys */
+#endif /* MBEDTLS_PSA_CRYPTO_C */
 } mbedtls_pk_context;
 
 #if defined(MBEDTLS_ECDSA_C) && defined(MBEDTLS_ECP_RESTARTABLE)

--- a/library/pk.c
+++ b/library/pk.c
@@ -61,7 +61,7 @@ void mbedtls_pk_init(mbedtls_pk_context *ctx)
     ctx->pk_info = NULL;
     ctx->pk_ctx = NULL;
 #if defined(MBEDTLS_PSA_CRYPTO_C)
-    ctx->opaque_id = MBEDTLS_SVC_KEY_ID_INIT;
+    ctx->priv_id = MBEDTLS_SVC_KEY_ID_INIT;
 #endif /* MBEDTLS_PSA_CRYPTO_C */
 }
 
@@ -183,7 +183,7 @@ int mbedtls_pk_setup_opaque(mbedtls_pk_context *ctx,
     }
 
     ctx->pk_info = info;
-    ctx->opaque_id = key;
+    ctx->priv_id = key;
 
     return 0;
 }
@@ -316,7 +316,7 @@ int mbedtls_pk_can_do_ext(const mbedtls_pk_context *ctx, psa_algorithm_t alg,
     psa_algorithm_t key_alg, key_alg2;
     psa_status_t status;
 
-    status = psa_get_key_attributes(ctx->opaque_id, &attributes);
+    status = psa_get_key_attributes(ctx->priv_id, &attributes);
     if (status != PSA_SUCCESS) {
         return 0;
     }
@@ -699,7 +699,7 @@ int mbedtls_pk_sign_ext(mbedtls_pk_type_t pk_type,
     if (mbedtls_pk_get_type(ctx) == MBEDTLS_PK_OPAQUE) {
         psa_status_t status;
 
-        status = psa_sign_hash(ctx->opaque_id, PSA_ALG_RSA_PSS(psa_md_alg),
+        status = psa_sign_hash(ctx->priv_id, PSA_ALG_RSA_PSS(psa_md_alg),
                                hash, hash_len,
                                sig, sig_size, sig_len);
         return PSA_PK_RSA_TO_MBEDTLS_ERR(status);

--- a/library/pk.c
+++ b/library/pk.c
@@ -312,12 +312,11 @@ int mbedtls_pk_can_do_ext(const mbedtls_pk_context *ctx, psa_algorithm_t alg,
         return (key_usage & usage) == usage;
     }
 
-    const mbedtls_svc_key_id_t *key = (const mbedtls_svc_key_id_t *) ctx->pk_ctx;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     psa_algorithm_t key_alg, key_alg2;
     psa_status_t status;
 
-    status = psa_get_key_attributes(*key, &attributes);
+    status = psa_get_key_attributes(ctx->opaque_id, &attributes);
     if (status != PSA_SUCCESS) {
         return 0;
     }
@@ -698,10 +697,9 @@ int mbedtls_pk_sign_ext(mbedtls_pk_type_t pk_type,
     }
 
     if (mbedtls_pk_get_type(ctx) == MBEDTLS_PK_OPAQUE) {
-        const mbedtls_svc_key_id_t *key = (const mbedtls_svc_key_id_t *) ctx->pk_ctx;
         psa_status_t status;
 
-        status = psa_sign_hash(*key, PSA_ALG_RSA_PSS(psa_md_alg),
+        status = psa_sign_hash(ctx->opaque_id, PSA_ALG_RSA_PSS(psa_md_alg),
                                hash, hash_len,
                                sig, sig_size, sig_len);
         return PSA_PK_RSA_TO_MBEDTLS_ERR(status);

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -1503,22 +1503,6 @@ const mbedtls_pk_info_t mbedtls_rsa_alt_info = {
 #endif /* MBEDTLS_PK_RSA_ALT_SUPPORT */
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
-
-static void *pk_opaque_alloc_wrap(void)
-{
-    void *ctx = mbedtls_calloc(1, sizeof(mbedtls_svc_key_id_t));
-
-    /* no _init() function to call, as calloc() already zeroized */
-
-    return ctx;
-}
-
-static void pk_opaque_free_wrap(void *ctx)
-{
-    mbedtls_platform_zeroize(ctx, sizeof(mbedtls_svc_key_id_t));
-    mbedtls_free(ctx);
-}
-
 static size_t pk_opaque_get_bitlen(mbedtls_pk_context *pk)
 {
     const mbedtls_svc_key_id_t *key = pk->pk_ctx;
@@ -1635,8 +1619,8 @@ const mbedtls_pk_info_t mbedtls_pk_ecdsa_opaque_info = {
     NULL, /* decrypt - not relevant */
     NULL, /* encrypt - not relevant */
     NULL, /* check_pair - could be done later or left NULL */
-    pk_opaque_alloc_wrap,
-    pk_opaque_free_wrap,
+    NULL, /* alloc - no need to allocate new data dynamically */
+    NULL, /* free - as for the alloc, there is no data to free */
 #if defined(MBEDTLS_ECDSA_C) && defined(MBEDTLS_ECP_RESTARTABLE)
     NULL, /* restart alloc - not relevant */
     NULL, /* restart free - not relevant */
@@ -1687,8 +1671,8 @@ const mbedtls_pk_info_t mbedtls_pk_rsa_opaque_info = {
 #endif /* PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY */
     NULL, /* encrypt - will be done later */
     NULL, /* check_pair - could be done later or left NULL */
-    pk_opaque_alloc_wrap,
-    pk_opaque_free_wrap,
+    NULL, /* alloc - no need to allocate new data dynamically */
+    NULL, /* free - as for the alloc, there is no data to free */
 #if defined(MBEDTLS_ECDSA_C) && defined(MBEDTLS_ECP_RESTARTABLE)
     NULL, /* restart alloc - not relevant */
     NULL, /* restart free - not relevant */

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -1505,11 +1505,10 @@ const mbedtls_pk_info_t mbedtls_rsa_alt_info = {
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
 static size_t pk_opaque_get_bitlen(mbedtls_pk_context *pk)
 {
-    const mbedtls_svc_key_id_t *key = pk->pk_ctx;
     size_t bits;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
 
-    if (PSA_SUCCESS != psa_get_key_attributes(*key, &attributes)) {
+    if (PSA_SUCCESS != psa_get_key_attributes(pk->opaque_id, &attributes)) {
         return 0;
     }
 
@@ -1547,7 +1546,6 @@ static int pk_opaque_sign_wrap(mbedtls_pk_context *pk, mbedtls_md_type_t md_alg,
     ((void) p_rng);
     return MBEDTLS_ERR_PK_FEATURE_UNAVAILABLE;
 #else /* !MBEDTLS_PK_CAN_ECDSA_SIGN && !MBEDTLS_RSA_C */
-    const mbedtls_svc_key_id_t *key = pk->pk_ctx;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     psa_algorithm_t alg;
     psa_key_type_t type;
@@ -1557,7 +1555,7 @@ static int pk_opaque_sign_wrap(mbedtls_pk_context *pk, mbedtls_md_type_t md_alg,
     (void) f_rng;
     (void) p_rng;
 
-    status = psa_get_key_attributes(*key, &attributes);
+    status = psa_get_key_attributes(pk->opaque_id, &attributes);
     if (status != PSA_SUCCESS) {
         return PSA_PK_TO_MBEDTLS_ERR(status);
     }
@@ -1578,7 +1576,7 @@ static int pk_opaque_sign_wrap(mbedtls_pk_context *pk, mbedtls_md_type_t md_alg,
     return MBEDTLS_ERR_PK_FEATURE_UNAVAILABLE;
 
     /* make the signature */
-    status = psa_sign_hash(*key, alg, hash, hash_len,
+    status = psa_sign_hash(pk->opaque_id, alg, hash, hash_len,
                            sig, sig_size, sig_len);
     if (status != PSA_SUCCESS) {
 #if defined(MBEDTLS_PK_CAN_ECDSA_SIGN)
@@ -1634,14 +1632,13 @@ static int pk_opaque_rsa_decrypt(mbedtls_pk_context *pk,
                                  unsigned char *output, size_t *olen, size_t osize,
                                  int (*f_rng)(void *, unsigned char *, size_t), void *p_rng)
 {
-    const mbedtls_svc_key_id_t *key = pk->pk_ctx;
     psa_status_t status;
 
     /* PSA has its own RNG */
     (void) f_rng;
     (void) p_rng;
 
-    status = psa_asymmetric_decrypt(*key, PSA_ALG_RSA_PKCS1V15_CRYPT,
+    status = psa_asymmetric_decrypt(pk->opaque_id, PSA_ALG_RSA_PKCS1V15_CRYPT,
                                     input, ilen,
                                     NULL, 0,
                                     output, osize, olen);

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -1508,7 +1508,7 @@ static size_t pk_opaque_get_bitlen(mbedtls_pk_context *pk)
     size_t bits;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
 
-    if (PSA_SUCCESS != psa_get_key_attributes(pk->opaque_id, &attributes)) {
+    if (PSA_SUCCESS != psa_get_key_attributes(pk->priv_id, &attributes)) {
         return 0;
     }
 
@@ -1555,7 +1555,7 @@ static int pk_opaque_sign_wrap(mbedtls_pk_context *pk, mbedtls_md_type_t md_alg,
     (void) f_rng;
     (void) p_rng;
 
-    status = psa_get_key_attributes(pk->opaque_id, &attributes);
+    status = psa_get_key_attributes(pk->priv_id, &attributes);
     if (status != PSA_SUCCESS) {
         return PSA_PK_TO_MBEDTLS_ERR(status);
     }
@@ -1576,7 +1576,7 @@ static int pk_opaque_sign_wrap(mbedtls_pk_context *pk, mbedtls_md_type_t md_alg,
     return MBEDTLS_ERR_PK_FEATURE_UNAVAILABLE;
 
     /* make the signature */
-    status = psa_sign_hash(pk->opaque_id, alg, hash, hash_len,
+    status = psa_sign_hash(pk->priv_id, alg, hash, hash_len,
                            sig, sig_size, sig_len);
     if (status != PSA_SUCCESS) {
 #if defined(MBEDTLS_PK_CAN_ECDSA_SIGN)
@@ -1638,7 +1638,7 @@ static int pk_opaque_rsa_decrypt(mbedtls_pk_context *pk,
     (void) f_rng;
     (void) p_rng;
 
-    status = psa_asymmetric_decrypt(pk->opaque_id, PSA_ALG_RSA_PKCS1V15_CRYPT,
+    status = psa_asymmetric_decrypt(pk->priv_id, PSA_ALG_RSA_PKCS1V15_CRYPT,
                                     input, ilen,
                                     NULL, 0,
                                     output, osize, olen);

--- a/library/pkwrite.c
+++ b/library/pkwrite.c
@@ -188,14 +188,13 @@ int mbedtls_pk_write_pubkey(unsigned char **p, unsigned char *start,
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     if (mbedtls_pk_get_type(key) == MBEDTLS_PK_OPAQUE) {
         size_t buffer_size;
-        mbedtls_svc_key_id_t *key_id = (mbedtls_svc_key_id_t *) key->pk_ctx;
 
         if (*p < start) {
             return MBEDTLS_ERR_PK_BAD_INPUT_DATA;
         }
 
         buffer_size = (size_t) (*p - start);
-        if (psa_export_public_key(*key_id, start, buffer_size, &len)
+        if (psa_export_public_key(key->opaque_id, start, buffer_size, &len)
             != PSA_SUCCESS) {
             return MBEDTLS_ERR_PK_BAD_INPUT_DATA;
         } else {
@@ -254,9 +253,11 @@ int mbedtls_pk_write_pubkey_der(const mbedtls_pk_context *key, unsigned char *bu
     if (pk_type == MBEDTLS_PK_OPAQUE) {
         psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
         psa_key_type_t key_type;
-        mbedtls_svc_key_id_t key_id;
-        key_id = *((mbedtls_svc_key_id_t *) key->pk_ctx);
-        if (PSA_SUCCESS != psa_get_key_attributes(key_id, &attributes)) {
+        psa_ecc_family_t curve;
+        size_t bits;
+
+        if (PSA_SUCCESS != psa_get_key_attributes(key->opaque_id,
+                                                  &attributes)) {
             return MBEDTLS_ERR_PLATFORM_HW_ACCEL_FAILED;
         }
         key_type = psa_get_key_type(&attributes);

--- a/library/pkwrite.c
+++ b/library/pkwrite.c
@@ -194,7 +194,7 @@ int mbedtls_pk_write_pubkey(unsigned char **p, unsigned char *start,
         }
 
         buffer_size = (size_t) (*p - start);
-        if (psa_export_public_key(key->opaque_id, start, buffer_size, &len)
+        if (psa_export_public_key(key->priv_id, start, buffer_size, &len)
             != PSA_SUCCESS) {
             return MBEDTLS_ERR_PK_BAD_INPUT_DATA;
         } else {
@@ -256,7 +256,7 @@ int mbedtls_pk_write_pubkey_der(const mbedtls_pk_context *key, unsigned char *bu
         psa_ecc_family_t curve;
         size_t bits;
 
-        if (PSA_SUCCESS != psa_get_key_attributes(key->opaque_id,
+        if (PSA_SUCCESS != psa_get_key_attributes(key->priv_id,
                                                   &attributes)) {
             return MBEDTLS_ERR_PLATFORM_HW_ACCEL_FAILED;
         }

--- a/library/pkwrite.c
+++ b/library/pkwrite.c
@@ -253,8 +253,6 @@ int mbedtls_pk_write_pubkey_der(const mbedtls_pk_context *key, unsigned char *bu
     if (pk_type == MBEDTLS_PK_OPAQUE) {
         psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
         psa_key_type_t key_type;
-        psa_ecc_family_t curve;
-        size_t bits;
 
         if (PSA_SUCCESS != psa_get_key_attributes(key->priv_id,
                                                   &attributes)) {

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -2614,7 +2614,7 @@ static int ssl_get_ecdh_params_from_cert(mbedtls_ssl_context *ssl)
                 return MBEDTLS_ERR_SSL_PK_TYPE_MISMATCH;
             }
 
-            ssl->handshake->ecdh_psa_privkey = pk->opaque_id;
+            ssl->handshake->ecdh_psa_privkey = pk->priv_id;
 
             /* Key should not be destroyed in the TLS library */
             ssl->handshake->ecdh_psa_privkey_is_external = 1;

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -2614,8 +2614,7 @@ static int ssl_get_ecdh_params_from_cert(mbedtls_ssl_context *ssl)
                 return MBEDTLS_ERR_SSL_PK_TYPE_MISMATCH;
             }
 
-            ssl->handshake->ecdh_psa_privkey =
-                *((mbedtls_svc_key_id_t *) pk->pk_ctx);
+            ssl->handshake->ecdh_psa_privkey = pk->opaque_id;
 
             /* Key should not be destroyed in the TLS library */
             ssl->handshake->ecdh_psa_privkey_is_external = 1;

--- a/tests/src/test_helpers/ssl_helpers.c
+++ b/tests/src/test_helpers/ssl_helpers.c
@@ -595,7 +595,7 @@ static void test_ssl_endpoint_certificate_free(mbedtls_test_ssl_endpoint *ep)
         if (cert->pkey != NULL) {
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
             if (mbedtls_pk_get_type(cert->pkey) == MBEDTLS_PK_OPAQUE) {
-                psa_destroy_key(cert->pkey->opaque_id);
+                psa_destroy_key(cert->pkey->priv_id);
             }
 #endif
             mbedtls_pk_free(cert->pkey);

--- a/tests/src/test_helpers/ssl_helpers.c
+++ b/tests/src/test_helpers/ssl_helpers.c
@@ -595,8 +595,7 @@ static void test_ssl_endpoint_certificate_free(mbedtls_test_ssl_endpoint *ep)
         if (cert->pkey != NULL) {
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
             if (mbedtls_pk_get_type(cert->pkey) == MBEDTLS_PK_OPAQUE) {
-                mbedtls_svc_key_id_t *key_slot = cert->pkey->pk_ctx;
-                psa_destroy_key(*key_slot);
+                psa_destroy_key(cert->pkey->opaque_id);
             }
 #endif
             mbedtls_pk_free(cert->pkey);


### PR DESCRIPTION
Store the opaque key ID directly into the `mbedtls_pk_context` instead of the previous `pk_ctx` member of that structure.

Resolves #7513


## Gatekeeper checklist

- [x] **changelog** not provided - internal refactoring
- [x] **backport**not required - internal refactoring to support upcoming new features
- [x] **tests** not required - covered by existing tests
