### PR TITLE
Disallow leading zeroes when parsing IPv4 addresses

### DIFF
--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -2684,7 +2684,7 @@ static int x509_inet_pton_ipv4(const char *src, void *dst)
             /* Don't allow leading zeroes. These might mean octal format,
              * which this implementation does not support. */
             if (octet == 0 && num_digits > 0) {
-                break;
+                return -1;
             }
 
             octet = octet * 10 + digit;
@@ -2693,7 +2693,7 @@ static int x509_inet_pton_ipv4(const char *src, void *dst)
         } while (num_digits < 3);
 
         if (octet >= 256 || num_digits > 3 || num_digits == 0) {
-            break;
+            return -1;
         }
         *res++ = (uint8_t) octet;
         num_octets++;

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -2667,7 +2667,6 @@ static int x509_inet_pton_ipv6(const char *src, void *dst)
 
 static int x509_inet_pton_ipv4(const char *src, void *dst)
 {
-    /* note: allows leading 0's, e.g. 000.000.000.000 */
     const unsigned char *p = (const unsigned char *) src;
     uint8_t *res = (uint8_t *) dst;
     uint8_t digit, num_digits = 0;
@@ -2681,6 +2680,13 @@ static int x509_inet_pton_ipv4(const char *src, void *dst)
             if (digit > 9) {
                 break;
             }
+
+            /* Don't allow leading zeroes. These might mean octal format,
+             * which this implementation does not support. */
+            if (octet == 0 && num_digits > 0) {
+                break;
+            }
+
             octet = octet * 10 + digit;
             num_digits++;
             p++;

--- a/tests/suites/test_suite_x509parse.data
+++ b/tests/suites/test_suite_x509parse.data
@@ -1046,6 +1046,12 @@ x509_verify:"data_files/server5-tricky-ip-san.crt":"data_files/server5-tricky-ip
 X509 CRT parse CN: IPv4 valid address
 x509_crt_parse_cn_inet_pton:"10.10.10.10":"0A0A0A0A":4
 
+X509 CRT parse CN: IPv4 leading zeroes #1
+x509_crt_parse_cn_inet_pton:"010.10.10.10":"":0
+
+X509 CRT parse CN: IPv4 leading zeroes #2
+x509_crt_parse_cn_inet_pton:"10.10.10.001":"":0
+
 X509 CRT parse CN: IPv4 excess 0s
 x509_crt_parse_cn_inet_pton:"10.0000.10.10":"":0
 


### PR DESCRIPTION
Leading zeroes in IPv4 addresses might mean that we're dealing with the octal format, and we do not support that.
Current behaviour might lead to an ambiguity and a flaw where we accept 0.010.0.0 (as octal, decimal equivalent 0.8.0.0) as 0.10.0.0. 
Following the discussion [here](https://github.com/Mbed-TLS/mbedtls/issues/7477), this PR removes the support for leading zeroes.
Resolves https://github.com/Mbed-TLS/mbedtls/issues/7477.

## Gatekeeper checklist

- [x] **changelog** not required - feature not yet released, and we didn't promise support for leading zeroes
- [x] **backport** not required - new feature
- [x] **tests** provided
