### PR TITLE
[Bignum] Adjust mbedtls_mpi_core_shift_l to use the core function

### DIFF
--- a/include/mbedtls/bignum.h
+++ b/include/mbedtls/bignum.h
@@ -594,6 +594,8 @@ int mbedtls_mpi_write_binary_le(const mbedtls_mpi *X,
  * \brief          Perform a left-shift on an MPI: X <<= count
  *
  * \param X        The MPI to shift. This must point to an initialized MPI.
+ *                 The MPI pointed by \p X may be resized to fit
+ *                 the resulting number.
  * \param count    The number of bits to shift by.
  *
  * \return         \c 0 if successful.

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -750,12 +750,8 @@ int mbedtls_mpi_write_binary(const mbedtls_mpi *X,
 int mbedtls_mpi_shift_l(mbedtls_mpi *X, size_t count)
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
-    size_t i, v0, t1;
-    mbedtls_mpi_uint r0 = 0, r1;
+    size_t i;
     MPI_VALIDATE_RET(X != NULL);
-
-    v0 = count / (biL);
-    t1 = count & (biL - 1);
 
     i = mbedtls_mpi_bitlen(X) + count;
 
@@ -765,31 +761,7 @@ int mbedtls_mpi_shift_l(mbedtls_mpi *X, size_t count)
 
     ret = 0;
 
-    /*
-     * shift by count / limb_size
-     */
-    if (v0 > 0) {
-        for (i = X->n; i > v0; i--) {
-            X->p[i - 1] = X->p[i - v0 - 1];
-        }
-
-        for (; i > 0; i--) {
-            X->p[i - 1] = 0;
-        }
-    }
-
-    /*
-     * shift by count % limb_size
-     */
-    if (t1 > 0) {
-        for (i = v0; i < X->n; i++) {
-            r1 = X->p[i] >> (biL - t1);
-            X->p[i] <<= t1;
-            X->p[i] |= r0;
-            r0 = r1;
-        }
-    }
-
+    mbedtls_mpi_core_shift_l(X->p, X->n, count);
 cleanup:
 
     return ret;


### PR DESCRIPTION
## Description

Resolves #7246 . This pr updates `mbedtls_mpi_shift_l()` to use the newly introduced `mbedtls_mpi_core_shift_l`

## Gatekeeper checklist

- [x] **changelog** Not required( This is a new interface )
- [x] **backport** Not required( This is a new interface )
- [x] **tests** Not required ( Does not change the functional behaviour of the method, and the new core_method is tested extensively on its own pr)



