### PR TITLE
Add in-tree configuration file for Readthedocs redirects

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,8 +15,10 @@ build:
     - make apidoc
     - breathe-apidoc -o docs/api apidoc/xml
     post_build:
-    - '[ "$READTHEDOCS_VERSION" != "development" ] || "$READTHEDOCS_VIRTUALENV_PATH/bin/rtd" projects "Mbed TLS API" redirects sync --wet-run -f docs/redirects.yaml'
-
+    - |
+      if [ "$READTHEDOCS_VERSION" = "development" ]; then
+        "$READTHEDOCS_VIRTUALENV_PATH/bin/rtd" projects "Mbed TLS API" redirects sync --wet-run -f docs/redirects.yaml
+      fi
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,6 +16,7 @@ build:
     - breathe-apidoc -o docs/api apidoc/xml
     post_build:
     - |
+      # Work around Readthedocs bug: Command parsing fails if the 'if' statement is on the first line
       if [ "$READTHEDOCS_VERSION" = "development" ]; then
         "$READTHEDOCS_VIRTUALENV_PATH/bin/rtd" projects "Mbed TLS API" redirects sync --wet-run -f docs/redirects.yaml
       fi

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,8 +12,11 @@ build:
     python: "3.9"
   jobs:
     pre_build:
-      - make apidoc
-      - breathe-apidoc -o docs/api apidoc/xml
+    - make apidoc
+    - breathe-apidoc -o docs/api apidoc/xml
+    post_build:
+    - '[ "$READTHEDOCS_VERSION" != "development" ] || "$READTHEDOCS_VIRTUALENV_PATH/bin/rtd" projects "Mbed TLS API" redirects sync --wet-run -f docs/redirects.yaml'
+
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/docs/redirects.yaml
+++ b/docs/redirects.yaml
@@ -1,9 +1,10 @@
 # Readthedocs redirects
 # See https://docs.readthedocs.io/en/stable/user-defined-redirects.html
 #
-# In order to prevent exposing the API token, PR jobs do not update the
-# redirects - changes to this file are only applied when they are merged
-# into the main branch.
+# Changes to this file do not take effect until they are merged into the
+# 'development' branch. This is because the API token (RTD_TOKEN) is not
+# made available in PR jobs - preventing bad actors from crafting PRs to
+# expose it.
 
 - type: exact
   from_url: /projects/api/en/latest/$rest

--- a/docs/redirects.yaml
+++ b/docs/redirects.yaml
@@ -1,0 +1,10 @@
+# Readthedocs redirects
+# See https://docs.readthedocs.io/en/stable/user-defined-redirects.html
+#
+# In order to prevent exposing the API token, PR jobs do not update the
+# redirects - changes to this file are only applied when they are merged
+# into the main branch.
+
+- type: exact
+  from_url: /projects/api/en/latest/$rest
+  to_url: /projects/api/en/development/

--- a/docs/requirements.in
+++ b/docs/requirements.in
@@ -1,2 +1,3 @@
-sphinx-rtd-theme
 breathe
+readthedocs-cli
+sphinx-rtd-theme

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -14,6 +14,8 @@ certifi==2022.12.7
     # via requests
 charset-normalizer==3.1.0
     # via requests
+click==8.1.3
+    # via readthedocs-cli
 docutils==0.17.1
     # via
     #   breathe
@@ -27,14 +29,28 @@ importlib-metadata==6.0.0
     # via sphinx
 jinja2==3.1.2
     # via sphinx
+markdown-it-py==2.2.0
+    # via rich
 markupsafe==2.1.2
     # via jinja2
+mdurl==0.1.2
+    # via markdown-it-py
 packaging==23.0
     # via sphinx
 pygments==2.14.0
-    # via sphinx
+    # via
+    #   rich
+    #   sphinx
+pyyaml==6.0
+    # via readthedocs-cli
+readthedocs-cli==4
+    # via -r requirements.in
 requests==2.28.2
-    # via sphinx
+    # via
+    #   readthedocs-cli
+    #   sphinx
+rich==13.3.5
+    # via readthedocs-cli
 snowballstemmer==2.2.0
     # via sphinx
 sphinx==4.5.0


### PR DESCRIPTION
## Description

This PR is a port of Mbed-TLS/mbedtls-docs#91 for the versioned documentation.
It allows us to maintain our page redirects in-tree.
The update step only runs when the `development` version is built ie. after a PR is merged.

Test runs on a separate [test branch](https://github.com/Mbed-TLS/mbedtls/tree/dev/bensze01/in-tree-redirects-test), and with the branch filter modified (needed because the API token is not exported in PR jobs for safety reasons.):
- 7ce8fba - https://readthedocs.org/projects/mbedtls-versioned/builds/20362324/
- 71f41de - https://readthedocs.org/projects/mbedtls-versioned/builds/20596236/


## Gatekeeper checklist

- [x] **changelog** not required - no user-facing changes
- [x] **backport** not required - this post-build step should only run when merged into the development branch.
- [x] **tests** not required - the changes are tested by the existing readthedocs build process.