### PR TITLE
Halve size of mbedtls_error_pair_t

### DIFF
--- a/include/mbedtls/psa_util.h
+++ b/include/mbedtls/psa_util.h
@@ -345,7 +345,11 @@ extern mbedtls_psa_drbg_context_t *const mbedtls_psa_random_state;
 #endif /* !defined(MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG) */
 
 typedef struct {
-    psa_status_t psa_status;
+    /* Error codes used by PSA crypto are in -255..-128, fitting in 16 bits. */
+    int16_t psa_status;
+    /* Error codes used by Mbed TLS are in one of the ranges
+     * -127..-1 (low-level) or (-128) * (128..511) (high-level),
+     * fitting in 16 bits. */
     int16_t mbedtls_error;
 } mbedtls_error_pair_t;
 


### PR DESCRIPTION
Reduce the size of the PSA-to-legacy error conversion tables from 8 to 4 bytes. This saves up to 116 bytes of code size (29 entries in a full build).

In principle, since PSA error codes fit in 7 bits, and each table either contain 7-bit legacy low-level error codes or 9-bit legacy high-level error codes but not both, it would be possible to shrink the table entries to 2 bytes. But there are diminishing returns, further reduced by needing to change the code that traverses up these tables, so it might be even worse in builds with reduced algorithms. And both the tables and the code would have to be modified.

## Gatekeeper checklist

- [x] **changelog** no (no behavior change)
- [x] **backport** no (not applicable to 2.28)
- [x] **tests** no (no behavior change)
