### PR TITLE
[Bignum] Split out _raw Koblitz reduction functions

### DIFF
--- a/library/ecp_curves.c
+++ b/library/ecp_curves.c
@@ -4613,7 +4613,7 @@ int mbedtls_ecp_mod_p448(mbedtls_mpi *);
 #if defined(MBEDTLS_ECP_DP_SECP192K1_ENABLED)
 static int ecp_mod_p192k1(mbedtls_mpi *);
 MBEDTLS_STATIC_TESTABLE
-int mbedtls_ecp_mod_p192k1(mbedtls_mpi *);
+int mbedtls_ecp_mod_p192k1_raw(mbedtls_mpi_uint *X, size_t X_limbs);
 #endif
 #if defined(MBEDTLS_ECP_DP_SECP224K1_ENABLED)
 static int ecp_mod_p224k1(mbedtls_mpi *);
@@ -5629,21 +5629,21 @@ static int ecp_mod_p192k1(mbedtls_mpi *N)
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     size_t expected_width = 2 * ((192 + biL - 1) / biL);
     MBEDTLS_MPI_CHK(mbedtls_mpi_grow(N, expected_width));
-    ret = mbedtls_ecp_mod_p192k1(N);
+    ret = mbedtls_ecp_mod_p192k1_raw(N->p, expected_width);
 
 cleanup:
     return ret;
 }
 
 MBEDTLS_STATIC_TESTABLE
-int mbedtls_ecp_mod_p192k1(mbedtls_mpi *N)
+int mbedtls_ecp_mod_p192k1_raw(mbedtls_mpi_uint *X, size_t X_limbs)
 {
     static mbedtls_mpi_uint Rp[] = {
-        MBEDTLS_BYTES_TO_T_UINT_8(0xC9, 0x11, 0x00, 0x00, 0x01, 0x00, 0x00,
-                                  0x00)
+        MBEDTLS_BYTES_TO_T_UINT_8(0xC9, 0x11, 0x00, 0x00,
+                                  0x01, 0x00, 0x00, 0x00)
     };
 
-    return ecp_mod_koblitz(N->p, N->n, Rp, 192);
+    return ecp_mod_koblitz(X, X_limbs, Rp, 192);
 }
 
 #endif /* MBEDTLS_ECP_DP_SECP192K1_ENABLED */

--- a/library/ecp_curves.c
+++ b/library/ecp_curves.c
@@ -5643,6 +5643,10 @@ int mbedtls_ecp_mod_p192k1_raw(mbedtls_mpi_uint *X, size_t X_limbs)
                                   0x01, 0x00, 0x00, 0x00)
     };
 
+    if (X_limbs != 2 * ((192 + biL - 1) / biL)) {
+        return MBEDTLS_ERR_ECP_BAD_INPUT_DATA;
+    }
+
     return ecp_mod_koblitz(X, X_limbs, Rp, 192);
 }
 
@@ -5673,6 +5677,10 @@ int mbedtls_ecp_mod_p224k1_raw(mbedtls_mpi_uint *X, size_t X_limbs)
                                   0x01, 0x00, 0x00, 0x00)
     };
 
+    if (X_limbs != 2 * 224 / biL) {
+        return MBEDTLS_ERR_ECP_BAD_INPUT_DATA;
+    }
+
     return ecp_mod_koblitz(X, X_limbs, Rp, 224);
 }
 
@@ -5702,6 +5710,11 @@ int mbedtls_ecp_mod_p256k1_raw(mbedtls_mpi_uint *X, size_t X_limbs)
         MBEDTLS_BYTES_TO_T_UINT_8(0xD1, 0x03, 0x00, 0x00,
                                   0x01, 0x00, 0x00, 0x00)
     };
+
+    if (X_limbs != 2 * ((256 + biL - 1) / biL)) {
+        return MBEDTLS_ERR_ECP_BAD_INPUT_DATA;
+    }
+
     return ecp_mod_koblitz(X, X_limbs, Rp, 256);
 }
 

--- a/library/ecp_curves.c
+++ b/library/ecp_curves.c
@@ -5532,7 +5532,7 @@ cleanup:
  * Fast quasi-reduction modulo P = 2^s - R,
  * with R about 33 bits, used by the Koblitz curves.
  *
- * Write N as A0 + 2^224 A1, return A0 + R * A1.
+ * Write X as A0 + 2^224 A1, return A0 + R * A1.
  */
 #define P_KOBLITZ_R     (8 / sizeof(mbedtls_mpi_uint))            // Limbs in R
 

--- a/library/ecp_curves.c
+++ b/library/ecp_curves.c
@@ -4618,7 +4618,7 @@ int mbedtls_ecp_mod_p192k1_raw(mbedtls_mpi_uint *X, size_t X_limbs);
 #if defined(MBEDTLS_ECP_DP_SECP224K1_ENABLED)
 static int ecp_mod_p224k1(mbedtls_mpi *);
 MBEDTLS_STATIC_TESTABLE
-int mbedtls_ecp_mod_p224k1(mbedtls_mpi *);
+int mbedtls_ecp_mod_p224k1_raw(mbedtls_mpi_uint *X, size_t X_limbs);
 #endif
 #if defined(MBEDTLS_ECP_DP_SECP256K1_ENABLED)
 static int ecp_mod_p256k1(mbedtls_mpi *);
@@ -5650,30 +5650,30 @@ int mbedtls_ecp_mod_p192k1_raw(mbedtls_mpi_uint *X, size_t X_limbs)
 
 #if defined(MBEDTLS_ECP_DP_SECP224K1_ENABLED)
 
+/*
+ * Fast quasi-reduction modulo p224k1 = 2^224 - R,
+ * with R = 2^32 + 2^12 + 2^11 + 2^9 + 2^7 + 2^4 + 2 + 1 = 0x0100001A93
+ */
 static int ecp_mod_p224k1(mbedtls_mpi *N)
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     size_t expected_width =  2 * 224 / biL;
     MBEDTLS_MPI_CHK(mbedtls_mpi_grow(N, expected_width));
-    ret = mbedtls_ecp_mod_p224k1(N);
+    ret = mbedtls_ecp_mod_p224k1_raw(N->p, expected_width);
 
 cleanup:
     return ret;
 }
 
-/*
- * Fast quasi-reduction modulo p224k1 = 2^224 - R,
- * with R = 2^32 + 2^12 + 2^11 + 2^9 + 2^7 + 2^4 + 2 + 1 = 0x0100001A93
- */
 MBEDTLS_STATIC_TESTABLE
-int mbedtls_ecp_mod_p224k1(mbedtls_mpi *N)
+int mbedtls_ecp_mod_p224k1_raw(mbedtls_mpi_uint *X, size_t X_limbs)
 {
     static mbedtls_mpi_uint Rp[] = {
-        MBEDTLS_BYTES_TO_T_UINT_8(0x93, 0x1A, 0x00, 0x00, 0x01, 0x00, 0x00,
-                                  0x00)
+        MBEDTLS_BYTES_TO_T_UINT_8(0x93, 0x1A, 0x00, 0x00,
+                                  0x01, 0x00, 0x00, 0x00)
     };
 
-    return ecp_mod_koblitz(N->p, N->n, Rp, 224);
+    return ecp_mod_koblitz(X, X_limbs, Rp, 224);
 }
 
 #endif /* MBEDTLS_ECP_DP_SECP224K1_ENABLED */

--- a/library/ecp_curves.c
+++ b/library/ecp_curves.c
@@ -4623,7 +4623,7 @@ int mbedtls_ecp_mod_p224k1_raw(mbedtls_mpi_uint *X, size_t X_limbs);
 #if defined(MBEDTLS_ECP_DP_SECP256K1_ENABLED)
 static int ecp_mod_p256k1(mbedtls_mpi *);
 MBEDTLS_STATIC_TESTABLE
-int mbedtls_ecp_mod_p256k1(mbedtls_mpi *);
+int mbedtls_ecp_mod_p256k1_raw(mbedtls_mpi_uint *X, size_t X_limbs);
 #endif
 
 #if defined(ECP_LOAD_GROUP)
@@ -5680,30 +5680,31 @@ int mbedtls_ecp_mod_p224k1_raw(mbedtls_mpi_uint *X, size_t X_limbs)
 
 #if defined(MBEDTLS_ECP_DP_SECP256K1_ENABLED)
 
+/*
+ * Fast quasi-reduction modulo p256k1 = 2^256 - R,
+ * with R = 2^32 + 2^9 + 2^8 + 2^7 + 2^6 + 2^4 + 1 = 0x01000003D1
+ */
 static int ecp_mod_p256k1(mbedtls_mpi *N)
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     size_t expected_width = 2 * ((256 + biL - 1) / biL);
     MBEDTLS_MPI_CHK(mbedtls_mpi_grow(N, expected_width));
-    ret = mbedtls_ecp_mod_p256k1(N);
+    ret = mbedtls_ecp_mod_p256k1_raw(N->p, expected_width);
 
 cleanup:
     return ret;
 }
 
-/*
- * Fast quasi-reduction modulo p256k1 = 2^256 - R,
- * with R = 2^32 + 2^9 + 2^8 + 2^7 + 2^6 + 2^4 + 1 = 0x01000003D1
- */
 MBEDTLS_STATIC_TESTABLE
-int mbedtls_ecp_mod_p256k1(mbedtls_mpi *N)
+int mbedtls_ecp_mod_p256k1_raw(mbedtls_mpi_uint *X, size_t X_limbs)
 {
     static mbedtls_mpi_uint Rp[] = {
-        MBEDTLS_BYTES_TO_T_UINT_8(0xD1, 0x03, 0x00, 0x00, 0x01, 0x00, 0x00,
-                                  0x00)
+        MBEDTLS_BYTES_TO_T_UINT_8(0xD1, 0x03, 0x00, 0x00,
+                                  0x01, 0x00, 0x00, 0x00)
     };
-    return ecp_mod_koblitz(N->p, N->n, Rp, 256);
+    return ecp_mod_koblitz(X, X_limbs, Rp, 256);
 }
+
 #endif /* MBEDTLS_ECP_DP_SECP256K1_ENABLED */
 
 #if defined(MBEDTLS_TEST_HOOKS)

--- a/library/ecp_invasive.h
+++ b/library/ecp_invasive.h
@@ -190,7 +190,7 @@ int mbedtls_ecp_mod_p224k1_raw(mbedtls_mpi_uint *X, size_t X_limbs);
 #if defined(MBEDTLS_ECP_DP_SECP256K1_ENABLED)
 
 MBEDTLS_STATIC_TESTABLE
-int mbedtls_ecp_mod_p256k1(mbedtls_mpi *N);
+int mbedtls_ecp_mod_p256k1_raw(mbedtls_mpi_uint *X, size_t X_limbs);
 
 #endif /* MBEDTLS_ECP_DP_SECP256K1_ENABLED */
 

--- a/library/ecp_invasive.h
+++ b/library/ecp_invasive.h
@@ -179,10 +179,11 @@ MBEDTLS_STATIC_TESTABLE
 int mbedtls_ecp_mod_p192k1_raw(mbedtls_mpi_uint *X, size_t X_limbs);
 
 #endif /* MBEDTLS_ECP_DP_SECP192K1_ENABLED */
+
 #if defined(MBEDTLS_ECP_DP_SECP224K1_ENABLED)
 
 MBEDTLS_STATIC_TESTABLE
-int mbedtls_ecp_mod_p224k1(mbedtls_mpi *N);
+int mbedtls_ecp_mod_p224k1_raw(mbedtls_mpi_uint *X, size_t X_limbs);
 
 #endif /* MBEDTLS_ECP_DP_SECP224K1_ENABLED */
 

--- a/library/ecp_invasive.h
+++ b/library/ecp_invasive.h
@@ -176,7 +176,7 @@ int  mbedtls_ecp_mod_p384_raw(mbedtls_mpi_uint *X, size_t X_limbs);
  * with R = 2^32 + 2^12 + 2^8 + 2^7 + 2^6 + 2^3 + 1 = 0x0100001119
  */
 MBEDTLS_STATIC_TESTABLE
-int mbedtls_ecp_mod_p192k1(mbedtls_mpi *N);
+int mbedtls_ecp_mod_p192k1_raw(mbedtls_mpi_uint *X, size_t X_limbs);
 
 #endif /* MBEDTLS_ECP_DP_SECP192K1_ENABLED */
 #if defined(MBEDTLS_ECP_DP_SECP224K1_ENABLED)

--- a/library/ecp_invasive.h
+++ b/library/ecp_invasive.h
@@ -184,6 +184,8 @@ int  mbedtls_ecp_mod_p384_raw(mbedtls_mpi_uint *X, size_t X_limbs);
  * \param[in]       X_limbs The length of \p X in limbs.
  *
  * \return          \c 0 on success.
+ * \return          #MBEDTLS_ERR_ECP_BAD_INPUT_DATA if \p X does not have
+ *                  twice as many limbs as the modulus.
  * \return          #MBEDTLS_ERR_ECP_ALLOC_FAILED if memory allocation failed.
  */
 MBEDTLS_STATIC_TESTABLE
@@ -206,6 +208,8 @@ int mbedtls_ecp_mod_p192k1_raw(mbedtls_mpi_uint *X, size_t X_limbs);
  * \param[in]       X_limbs The length of \p X in limbs.
  *
  * \return          \c 0 on success.
+ * \return          #MBEDTLS_ERR_ECP_BAD_INPUT_DATA if \p X does not have
+ *                  twice as many limbs as the modulus.
  * \return          #MBEDTLS_ERR_ECP_ALLOC_FAILED if memory allocation failed.
  */
 MBEDTLS_STATIC_TESTABLE
@@ -228,6 +232,8 @@ int mbedtls_ecp_mod_p224k1_raw(mbedtls_mpi_uint *X, size_t X_limbs);
  * \param[in]       X_limbs The length of \p X in limbs.
  *
  * \return          \c 0 on success.
+ * \return          #MBEDTLS_ERR_ECP_BAD_INPUT_DATA if \p X does not have
+ *                  twice as many limbs as the modulus.
  * \return          #MBEDTLS_ERR_ECP_ALLOC_FAILED if memory allocation failed.
  */
 MBEDTLS_STATIC_TESTABLE

--- a/library/ecp_invasive.h
+++ b/library/ecp_invasive.h
@@ -171,9 +171,20 @@ int  mbedtls_ecp_mod_p384_raw(mbedtls_mpi_uint *X, size_t X_limbs);
 
 #if defined(MBEDTLS_ECP_DP_SECP192K1_ENABLED)
 
-/*
- * Fast quasi-reduction modulo p192k1 = 2^192 - R,
- * with R = 2^32 + 2^12 + 2^8 + 2^7 + 2^6 + 2^3 + 1 = 0x0100001119
+/** Fast quasi-reduction modulo p192k1 = 2^192 - R,
+ * with R = 2^32 + 2^12 + 2^8 + 2^7 + 2^6 + 2^3 + 1 = 0x01000011C9
+ *
+ * \param[in,out]   X       The address of the MPI to be converted.
+ *                          Must have exact limb size that stores a 384-bit MPI
+ *                          (double the bitlength of the modulus).
+ *                          Upon return holds the reduced value which is
+ *                          in range `0 <= X < 2 * N` (where N is the modulus).
+ *                          The bitlength of the reduced value is the same as
+ *                          that of the modulus (192 bits).
+ * \param[in]       X_limbs The length of \p X in limbs.
+ *
+ * \return          \c 0 on success.
+ * \return          #MBEDTLS_ERR_ECP_ALLOC_FAILED if memory allocation failed.
  */
 MBEDTLS_STATIC_TESTABLE
 int mbedtls_ecp_mod_p192k1_raw(mbedtls_mpi_uint *X, size_t X_limbs);
@@ -182,6 +193,21 @@ int mbedtls_ecp_mod_p192k1_raw(mbedtls_mpi_uint *X, size_t X_limbs);
 
 #if defined(MBEDTLS_ECP_DP_SECP224K1_ENABLED)
 
+/** Fast quasi-reduction modulo p224k1 = 2^224 - R,
+ * with R = 2^32 + 2^12 + 2^11 + 2^9 + 2^7 + 2^4 + 2 + 1 = 0x0100001A93
+ *
+ * \param[in,out]   X       The address of the MPI to be converted.
+ *                          Must have exact limb size that stores a 448-bit MPI
+ *                          (double the bitlength of the modulus).
+ *                          Upon return holds the reduced value which is
+ *                          in range `0 <= X < 2 * N` (where N is the modulus).
+ *                          The bitlength of the reduced value is the same as
+ *                          that of the modulus (224 bits).
+ * \param[in]       X_limbs The length of \p X in limbs.
+ *
+ * \return          \c 0 on success.
+ * \return          #MBEDTLS_ERR_ECP_ALLOC_FAILED if memory allocation failed.
+ */
 MBEDTLS_STATIC_TESTABLE
 int mbedtls_ecp_mod_p224k1_raw(mbedtls_mpi_uint *X, size_t X_limbs);
 
@@ -189,6 +215,21 @@ int mbedtls_ecp_mod_p224k1_raw(mbedtls_mpi_uint *X, size_t X_limbs);
 
 #if defined(MBEDTLS_ECP_DP_SECP256K1_ENABLED)
 
+/** Fast quasi-reduction modulo p256k1 = 2^256 - R,
+ * with R = 2^32 + 2^9 + 2^8 + 2^7 + 2^6 + 2^4 + 1 = 0x01000003D1
+ *
+ * \param[in,out]   X       The address of the MPI to be converted.
+ *                          Must have exact limb size that stores a 512-bit MPI
+ *                          (double the bitlength of the modulus).
+ *                          Upon return holds the reduced value which is
+ *                          in range `0 <= X < 2 * N` (where N is the modulus).
+ *                          The bitlength of the reduced value is the same as
+ *                          that of the modulus (256 bits).
+ * \param[in]       X_limbs The length of \p X in limbs.
+ *
+ * \return          \c 0 on success.
+ * \return          #MBEDTLS_ERR_ECP_ALLOC_FAILED if memory allocation failed.
+ */
 MBEDTLS_STATIC_TESTABLE
 int mbedtls_ecp_mod_p256k1_raw(mbedtls_mpi_uint *X, size_t X_limbs);
 

--- a/scripts/mbedtls_dev/ecp.py
+++ b/scripts/mbedtls_dev/ecp.py
@@ -566,8 +566,8 @@ class EcpP224K1Raw(bignum_common.ModOperationCommon,
                    EcpTarget):
     """Test cases for ECP P224 fast reduction."""
     symbol = "-"
-    test_function = "ecp_mod_p224k1"
-    test_name = "ecp_mod_p224k1"
+    test_function = "ecp_mod_p_generic_raw"
+    test_name = "ecp_mod_p224k1_raw"
     input_style = "fixed"
     arity = 1
     dependencies = ["MBEDTLS_ECP_DP_SECP224K1_ENABLED"]
@@ -586,7 +586,7 @@ class EcpP224K1Raw(bignum_common.ModOperationCommon,
         # 2^224 - 1
         "ffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
 
-        # Maximum canonical P224 multiplication result
+        # Maximum canonical P224K1 multiplication result
         ("fffffffffffffffffffffffffffffffffffffffffffffffdffffcad8"
          "00000000000000000000000000000000000000010000352802c26590"),
 
@@ -629,6 +629,10 @@ class EcpP224K1Raw(bignum_common.ModOperationCommon,
     @property
     def is_valid(self) -> bool:
         return True
+
+    def arguments(self):
+        args = super().arguments()
+        return  ["MBEDTLS_ECP_DP_SECP224K1"] + args
 
 
 class EcpP256K1Raw(bignum_common.ModOperationCommon,

--- a/scripts/mbedtls_dev/ecp.py
+++ b/scripts/mbedtls_dev/ecp.py
@@ -494,8 +494,8 @@ class EcpP192K1Raw(bignum_common.ModOperationCommon,
                    EcpTarget):
     """Test cases for ECP P192K1 fast reduction."""
     symbol = "-"
-    test_function = "ecp_mod_p192k1"
-    test_name = "ecp_mod_p192k1"
+    test_function = "ecp_mod_p_generic_raw"
+    test_name = "ecp_mod_p192k1_raw"
     input_style = "fixed"
     arity = 1
     dependencies = ["MBEDTLS_ECP_DP_SECP192K1_ENABLED"]
@@ -556,6 +556,10 @@ class EcpP192K1Raw(bignum_common.ModOperationCommon,
     @property
     def is_valid(self) -> bool:
         return True
+
+    def arguments(self):
+        args = super().arguments()
+        return  ["MBEDTLS_ECP_DP_SECP192K1"] + args
 
 
 class EcpP224K1Raw(bignum_common.ModOperationCommon,

--- a/scripts/mbedtls_dev/ecp.py
+++ b/scripts/mbedtls_dev/ecp.py
@@ -639,8 +639,8 @@ class EcpP256K1Raw(bignum_common.ModOperationCommon,
                    EcpTarget):
     """Test cases for ECP P256 fast reduction."""
     symbol = "-"
-    test_function = "ecp_mod_p256k1"
-    test_name = "ecp_mod_p256k1"
+    test_function = "ecp_mod_p_generic_raw"
+    test_name = "ecp_mod_p256k1_raw"
     input_style = "fixed"
     arity = 1
     dependencies = ["MBEDTLS_ECP_DP_SECP256K1_ENABLED"]
@@ -659,9 +659,13 @@ class EcpP256K1Raw(bignum_common.ModOperationCommon,
         # 2^256 - 1
         "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
 
-        # Maximum canonical P256 multiplication result
-        ("fffffffffffffffffffffffffffffffffffffffffffffffffffffffdfffff85c0"
-         "00000000000000000000000000000000000000000000001000007a4000e9844"),
+        # Maximum canonical P256K1 multiplication result
+        ("fffffffffffffffffffffffffffffffffffffffffffffffffffffffdfffff85c"
+         "000000000000000000000000000000000000000000000001000007a4000e9844"),
+
+        # Test case for overflow during addition
+        ("0000fffffc2f000e90a0c86a0a63234e5ba641f43a7e4aecc4040e67ec850562"
+         "00000000000000000000000000000000000000000000000000000000585674fd"),
 
         # Test case for overflow during addition
         ("0000fffffc2f000e90a0c86a0a63234e5ba641f43a7e4aecc4040e67ec850562"
@@ -701,6 +705,10 @@ class EcpP256K1Raw(bignum_common.ModOperationCommon,
     @property
     def is_valid(self) -> bool:
         return True
+
+    def arguments(self):
+        args = super().arguments()
+        return  ["MBEDTLS_ECP_DP_SECP256K1"] + args
 
 
 class EcpP448Raw(bignum_common.ModOperationCommon,

--- a/tests/suites/test_suite_ecp.function
+++ b/tests/suites/test_suite_ecp.function
@@ -1328,6 +1328,13 @@ void ecp_mod_p_generic_raw(int curve_id,
             curve_func = &mbedtls_ecp_mod_p521_raw;
             break;
 #endif
+#if defined(MBEDTLS_ECP_DP_SECP192K1_ENABLED)
+        case MBEDTLS_ECP_DP_SECP192K1:
+            limbs = 2 * limbs_N;
+            curve_bits = 192;
+            curve_func = &mbedtls_ecp_mod_p192k1_raw;
+            break;
+#endif
         default:
             mbedtls_test_fail("Unsupported curve_id", __LINE__, __FILE__);
             goto exit;
@@ -1352,45 +1359,6 @@ exit:
 
     mbedtls_mpi_mod_modulus_free(&m);
     mbedtls_free(N);
-}
-/* END_CASE */
-
-/* BEGIN_CASE depends_on:MBEDTLS_TEST_HOOKS:MBEDTLS_ECP_DP_SECP192K1_ENABLED */
-void ecp_mod_p192k1(char *input_N,
-                    char *input_X,
-                    char *result)
-{
-    mbedtls_mpi X;
-    mbedtls_mpi N;
-    mbedtls_mpi res;
-
-    mbedtls_mpi_init(&X);
-    mbedtls_mpi_init(&N);
-    mbedtls_mpi_init(&res);
-
-    TEST_EQUAL(mbedtls_test_read_mpi(&X,   input_X), 0);
-    TEST_EQUAL(mbedtls_test_read_mpi(&N,   input_N), 0);
-    TEST_EQUAL(mbedtls_test_read_mpi(&res, result),  0);
-
-    TEST_ASSERT(mbedtls_mpi_core_uint_le_mpi(0, X.p, X.n));
-    TEST_ASSERT(mbedtls_mpi_core_uint_le_mpi(0, N.p, N.n));
-    TEST_ASSERT(mbedtls_mpi_core_uint_le_mpi(0, res.p, res.n));
-
-    size_t limbs = N.n;
-    size_t bytes = limbs * sizeof(mbedtls_mpi_uint);
-
-    TEST_EQUAL(X.n, 2 * limbs);
-    TEST_EQUAL(res.n, limbs);
-
-    TEST_EQUAL(mbedtls_ecp_mod_p192k1(&X), 0);
-    TEST_EQUAL(mbedtls_mpi_mod_mpi(&X, &X, &N), 0);
-    TEST_LE_U(mbedtls_mpi_core_bitlen(X.p, X.n), 192);
-    ASSERT_COMPARE(X.p, bytes, res.p, bytes);
-
-exit:
-    mbedtls_mpi_free(&X);
-    mbedtls_mpi_free(&N);
-    mbedtls_mpi_free(&res);
 }
 /* END_CASE */
 

--- a/tests/suites/test_suite_ecp.function
+++ b/tests/suites/test_suite_ecp.function
@@ -1335,6 +1335,13 @@ void ecp_mod_p_generic_raw(int curve_id,
             curve_func = &mbedtls_ecp_mod_p192k1_raw;
             break;
 #endif
+#if defined(MBEDTLS_ECP_DP_SECP224K1_ENABLED)
+        case MBEDTLS_ECP_DP_SECP224K1:
+            limbs = 448 / biL;
+            curve_bits = 224;
+            curve_func = &mbedtls_ecp_mod_p224k1_raw;
+            break;
+#endif
         default:
             mbedtls_test_fail("Unsupported curve_id", __LINE__, __FILE__);
             goto exit;
@@ -1362,44 +1369,6 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_TEST_HOOKS:MBEDTLS_ECP_DP_SECP224K1_ENABLED */
-void ecp_mod_p224k1(char *input_N,
-                    char *input_X,
-                    char *result)
-{
-    mbedtls_mpi X;
-    mbedtls_mpi N;
-    mbedtls_mpi res;
-
-    mbedtls_mpi_init(&X);
-    mbedtls_mpi_init(&N);
-    mbedtls_mpi_init(&res);
-
-    TEST_EQUAL(mbedtls_test_read_mpi(&X,   input_X), 0);
-    TEST_EQUAL(mbedtls_test_read_mpi(&N,   input_N), 0);
-    TEST_EQUAL(mbedtls_test_read_mpi(&res, result),  0);
-
-    TEST_ASSERT(mbedtls_mpi_core_uint_le_mpi(0, X.p, X.n));
-    TEST_ASSERT(mbedtls_mpi_core_uint_le_mpi(0, N.p, N.n));
-    TEST_ASSERT(mbedtls_mpi_core_uint_le_mpi(0, res.p, res.n));
-
-    size_t limbs = N.n;
-    size_t bytes = limbs * sizeof(mbedtls_mpi_uint);
-
-    TEST_LE_U(X.n, 448 / biL);
-    TEST_EQUAL(res.n, limbs);
-
-    TEST_EQUAL(mbedtls_ecp_mod_p224k1(&X), 0);
-    TEST_EQUAL(mbedtls_mpi_mod_mpi(&X, &X, &N), 0);
-    TEST_LE_U(mbedtls_mpi_core_bitlen(X.p, X.n), 224);
-    ASSERT_COMPARE(X.p, bytes, res.p, bytes);
-
-exit:
-    mbedtls_mpi_free(&X);
-    mbedtls_mpi_free(&N);
-    mbedtls_mpi_free(&res);
-}
-/* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_TEST_HOOKS:MBEDTLS_ECP_DP_SECP256K1_ENABLED */
 void ecp_mod_p256k1(char *input_N,

--- a/tests/suites/test_suite_ecp.function
+++ b/tests/suites/test_suite_ecp.function
@@ -1342,6 +1342,13 @@ void ecp_mod_p_generic_raw(int curve_id,
             curve_func = &mbedtls_ecp_mod_p224k1_raw;
             break;
 #endif
+#if defined(MBEDTLS_ECP_DP_SECP256K1_ENABLED)
+        case MBEDTLS_ECP_DP_SECP256K1:
+            limbs = 2 * limbs_N;
+            curve_bits = 256;
+            curve_func = &mbedtls_ecp_mod_p256k1_raw;
+            break;
+#endif
         default:
             mbedtls_test_fail("Unsupported curve_id", __LINE__, __FILE__);
             goto exit;
@@ -1366,46 +1373,6 @@ exit:
 
     mbedtls_mpi_mod_modulus_free(&m);
     mbedtls_free(N);
-}
-/* END_CASE */
-
-
-/* BEGIN_CASE depends_on:MBEDTLS_TEST_HOOKS:MBEDTLS_ECP_DP_SECP256K1_ENABLED */
-void ecp_mod_p256k1(char *input_N,
-                    char *input_X,
-                    char *result)
-{
-    mbedtls_mpi X;
-    mbedtls_mpi N;
-    mbedtls_mpi res;
-
-    mbedtls_mpi_init(&X);
-    mbedtls_mpi_init(&N);
-    mbedtls_mpi_init(&res);
-
-    TEST_EQUAL(mbedtls_test_read_mpi(&X,   input_X), 0);
-    TEST_EQUAL(mbedtls_test_read_mpi(&N,   input_N), 0);
-    TEST_EQUAL(mbedtls_test_read_mpi(&res, result),  0);
-
-    TEST_ASSERT(mbedtls_mpi_core_uint_le_mpi(0, X.p, X.n));
-    TEST_ASSERT(mbedtls_mpi_core_uint_le_mpi(0, N.p, N.n));
-    TEST_ASSERT(mbedtls_mpi_core_uint_le_mpi(0, res.p, res.n));
-
-    size_t limbs = N.n;
-    size_t bytes = limbs * sizeof(mbedtls_mpi_uint);
-
-    TEST_LE_U(X.n, 2 * limbs);
-    TEST_EQUAL(res.n, limbs);
-
-    TEST_EQUAL(mbedtls_ecp_mod_p256k1(&X), 0);
-    TEST_EQUAL(mbedtls_mpi_mod_mpi(&X, &X, &N), 0);
-    TEST_LE_U(mbedtls_mpi_core_bitlen(X.p, X.n), 256);
-    ASSERT_COMPARE(X.p, bytes, res.p, bytes);
-
-exit:
-    mbedtls_mpi_free(&X);
-    mbedtls_mpi_free(&N);
-    mbedtls_mpi_free(&res);
 }
 /* END_CASE */
 


### PR DESCRIPTION
## Description

Create ecp_mod_p192k1_raw(), ecp_mod_p224k1_raw() and ecp_mod_256k1_raw() which are called by their non-raw counterparts.

Resolves #7263 

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required
- [x] **backport** not required
- [x] **tests** provided
