### PR TITLE
Only include psa_pake_setup() and friends if some PAKE algorithms are required

### DIFF
--- a/ChangeLog.d/add-psa_want_alg_some_pake.txt
+++ b/ChangeLog.d/add-psa_want_alg_some_pake.txt
@@ -1,0 +1,3 @@
+Features
+   * Don't include the PSA dispatch functions for PAKEs (psa_pake_setup() etc)
+     if no PAKE algorithms are requested

--- a/include/mbedtls/config_psa.h
+++ b/include/mbedtls/config_psa.h
@@ -908,6 +908,10 @@ extern "C" {
 
 #endif /* MBEDTLS_PSA_CRYPTO_CONFIG */
 
+#if defined(PSA_WANT_ALG_JPAKE)
+#define PSA_WANT_ALG_SOME_PAKE 1
+#endif
+
 /* These features are always enabled. */
 #define PSA_WANT_KEY_TYPE_DERIVE 1
 #define PSA_WANT_KEY_TYPE_PASSWORD 1

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -7384,6 +7384,7 @@ psa_status_t psa_crypto_driver_pake_get_cipher_suite(
     return PSA_SUCCESS;
 }
 
+#if defined(PSA_WANT_ALG_SOME_PAKE)
 psa_status_t psa_pake_setup(
     psa_pake_operation_t *operation,
     const psa_pake_cipher_suite_t *cipher_suite)
@@ -8100,5 +8101,6 @@ psa_status_t psa_pake_abort(
 
     return status;
 }
+#endif /* PSA_WANT_ALG_SOME_PAKE */
 
 #endif /* MBEDTLS_PSA_CRYPTO_C */


### PR DESCRIPTION
This removes several functions if no PAKE algorithms are specified, saving up to ~1.5KB by removing the functions `psa_pake_abort()`, `psa_pake_complete_inputs()`, `psa_pake_get_implicit_key()`, `psa_pake_input()`, `psa_pake_output()`, `psa_pake_set_password_key()`, `psa_pake_set_peer()`, `psa_pake_set_role()`, `psa_pake_set_user()` and `psa_pake_setup()` completely if they are not needed.

Code size improvements for Armv8-M/Thumb2:

| orig:1d046fa0d | orig:6d62faca8 |      Delta | Filename |
|---------------:|-----------:|-----------:|:---------|
|   37556, 4 |   36014, 4 |    -1542+0 | `psa_crypto.o` |

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** provided
- [x] **backport** not required - PAKE is `development`-only
- [x] **tests** not required
