### PR TITLE
Add partial support for URI SubjectAltNames verification

### DIFF
--- a/ChangeLog.d/basic-uri-verification.txt
+++ b/ChangeLog.d/basic-uri-verification.txt
@@ -1,0 +1,4 @@
+Features
+   * X.509 hostname verification now partially supports URI Subject Alternate
+     Names. Only exact matching, without any normalization procedures
+     described in 7.4 of RFC5280, will result in a positive URI verification.

--- a/include/mbedtls/x509_crt.h
+++ b/include/mbedtls/x509_crt.h
@@ -641,8 +641,12 @@ int mbedtls_x509_crt_verify_info(char *buf, size_t size, const char *prefix,
  * \param cn       The expected Common Name. This will be checked to be
  *                 present in the certificate's subjectAltNames extension or,
  *                 if this extension is absent, as a CN component in its
- *                 Subject name. DNS names and IP addresses are supported. This
- *                 may be \c NULL if the CN need not be verified.
+ *                 Subject name. DNS names and IP addresses are fully
+ *                 supported, while the URI subtype is partially supported:
+ *                 only exact matching, without any normalization procedures
+ *                 described in 7.4 of RFC5280, will result in a positive
+ *                 URI verification.
+ *                 This may be \c NULL if the CN need not be verified.
  * \param flags    The address at which to store the result of the verification.
  *                 If the verification couldn't be completed, the flag value is
  *                 set to (uint32_t) -1.

--- a/tests/suites/test_suite_x509parse.data
+++ b/tests/suites/test_suite_x509parse.data
@@ -1043,6 +1043,22 @@ X509 CRT verification: mismatching IPv6 in SubjectAltName
 depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_PK_CAN_ECDSA_SOME:MBEDTLS_MD_CAN_SHA256:MBEDTLS_ECP_DP_SECP256R1_ENABLED:MBEDTLS_RSA_C
 x509_verify:"data_files/server5-tricky-ip-san.crt":"data_files/server5-tricky-ip-san.crt":"data_files/crl_sha256.pem":"6162\:6364\:\:6F6D":MBEDTLS_ERR_X509_CERT_VERIFY_FAILED:MBEDTLS_X509_BADCERT_CN_MISMATCH:"":"NULL"
 
+X509 CRT verification: matching URI in SubjectAltName
+depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_PK_CAN_ECDSA_SOME:MBEDTLS_MD_CAN_SHA256:MBEDTLS_ECP_DP_SECP256R1_ENABLED:MBEDTLS_RSA_C
+x509_verify:"data_files/rsa_single_san_uri.crt.der":"data_files/rsa_single_san_uri.crt.der":"data_files/crl_sha256.pem":"urn\:example.com\:5ff40f78-9210-494f-8206-c2c082f0609c":0:0:"":"NULL"
+
+X509 CRT verification: URI with trailing data in SubjectAltName
+depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_PK_CAN_ECDSA_SOME:MBEDTLS_MD_CAN_SHA256:MBEDTLS_ECP_DP_SECP256R1_ENABLED:MBEDTLS_RSA_C
+x509_verify:"data_files/rsa_single_san_uri.crt.der":"data_files/rsa_single_san_uri.crt.der":"data_files/crl_sha256.pem":"urn\:example.com\:5ff40f78-9210-494f-8206-c2c082f0609cz":MBEDTLS_ERR_X509_CERT_VERIFY_FAILED:MBEDTLS_X509_BADCERT_CN_MISMATCH:"":"NULL"
+
+X509 CRT verification: URI with preceding data in SubjectAltName
+depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_PK_CAN_ECDSA_SOME:MBEDTLS_MD_CAN_SHA256:MBEDTLS_ECP_DP_SECP256R1_ENABLED:MBEDTLS_RSA_C
+x509_verify:"data_files/rsa_single_san_uri.crt.der":"data_files/rsa_single_san_uri.crt.der":"data_files/crl_sha256.pem":"zurn\:example.com\:5ff40f78-9210-494f-8206-c2c082f0609c":MBEDTLS_ERR_X509_CERT_VERIFY_FAILED:MBEDTLS_X509_BADCERT_CN_MISMATCH:"":"NULL"
+
+X509 CRT verification: URI with bad data in SubjectAltName
+depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_PK_CAN_ECDSA_SOME:MBEDTLS_MD_CAN_SHA256:MBEDTLS_ECP_DP_SECP256R1_ENABLED:MBEDTLS_RSA_C
+x509_verify:"data_files/rsa_single_san_uri.crt.der":"data_files/rsa_single_san_uri.crt.der":"data_files/crl_sha256.pem":"bad\:example.com\:5ff40f78-9210-494f-8206-c2c082f0609c":MBEDTLS_ERR_X509_CERT_VERIFY_FAILED:MBEDTLS_X509_BADCERT_CN_MISMATCH:"":"NULL"
+
 X509 CRT parse CN: IPv4 valid address
 x509_crt_parse_cn_inet_pton:"10.10.10.10":"0A0A0A0A":4
 


### PR DESCRIPTION
Only exact matching without normalization is supported.
Fixes https://github.com/Mbed-TLS/mbedtls/issues/7563.
See https://github.com/Mbed-TLS/mbedtls/pull/7436 and https://github.com/Mbed-TLS/mbedtls/pull/7025 for comparison.

## PR checklist
- [x] **changelog** provided
- [x] **backport** not required - new feature
- [x] **tests** provided