### PR TITLE
Arm assembly implementation of constant time primitives

### DIFF
--- a/library/constant_time.c
+++ b/library/constant_time.c
@@ -152,8 +152,13 @@ void mbedtls_ct_memcpy_if(mbedtls_ct_condition_t condition,
                           const unsigned char *src2,
                           size_t len)
 {
+#if defined(MBEDTLS_CT_SIZE_64)
+    const uint64_t mask     = (uint64_t) condition;
+    const uint64_t not_mask = (uint64_t) ~mbedtls_ct_compiler_opaque(condition);
+#else
     const uint32_t mask     = (uint32_t) condition;
     const uint32_t not_mask = (uint32_t) ~mbedtls_ct_compiler_opaque(condition);
+#endif
 
     /* If src2 is NULL, setup src2 so that we read from the destination address.
      *
@@ -167,11 +172,19 @@ void mbedtls_ct_memcpy_if(mbedtls_ct_condition_t condition,
     /* dest[i] = c1 == c2 ? src[i] : dest[i] */
     size_t i = 0;
 #if defined(MBEDTLS_EFFICIENT_UNALIGNED_ACCESS)
+#if defined(MBEDTLS_CT_SIZE_64)
+    for (; (i + 8) <= len; i += 8) {
+        uint64_t a = mbedtls_get_unaligned_uint64(src1 + i) & mask;
+        uint64_t b = mbedtls_get_unaligned_uint64(src2 + i) & not_mask;
+        mbedtls_put_unaligned_uint64(dest + i, a | b);
+    }
+#else
     for (; (i + 4) <= len; i += 4) {
         uint32_t a = mbedtls_get_unaligned_uint32(src1 + i) & mask;
         uint32_t b = mbedtls_get_unaligned_uint32(src2 + i) & not_mask;
         mbedtls_put_unaligned_uint32(dest + i, a | b);
     }
+#endif /* defined(MBEDTLS_CT_SIZE_64) */
 #endif /* MBEDTLS_EFFICIENT_UNALIGNED_ACCESS */
     for (; i < len; i++) {
         dest[i] = (src1[i] & mask) | (src2[i] & not_mask);

--- a/library/constant_time_impl.h
+++ b/library/constant_time_impl.h
@@ -48,8 +48,14 @@
     #pragma GCC diagnostic ignored "-Wredundant-decls"
 #endif
 
-/* Disable asm under Memsan because it confuses Memsan and generates false errors */
-#if defined(MBEDTLS_TEST_CONSTANT_FLOW_MEMSAN)
+/* Disable asm under Memsan because it confuses Memsan and generates false errors.
+ *
+ * We also disable under Valgrind by default, because it's more useful
+ * for Valgrind to test the plain C implementation. MBEDTLS_TEST_CONSTANT_FLOW_ASM //no-check-names
+ * may be set to permit building asm under Valgrind.
+ */
+#if defined(MBEDTLS_TEST_CONSTANT_FLOW_MEMSAN) || \
+    (defined(MBEDTLS_TEST_CONSTANT_FLOW_VALGRIND) && !defined(MBEDTLS_TEST_CONSTANT_FLOW_ASM)) //no-check-names
 #define MBEDTLS_CT_NO_ASM
 #elif defined(__has_feature)
 #if __has_feature(memory_sanitizer)

--- a/library/constant_time_impl.h
+++ b/library/constant_time_impl.h
@@ -243,7 +243,7 @@ static inline mbedtls_ct_condition_t mbedtls_ct_uint_lt(mbedtls_ct_uint_t x, mbe
     uint64_t s1;
     asm volatile ("eor     %x[s1], %x[y], %x[x]          \n\t"
                   "sub     %x[x], %x[x], %x[y]           \n\t"
-                  "bic     %x[x], %x[x], %[s1]           \n\t"
+                  "bic     %x[x], %x[x], %x[s1]          \n\t"
                   "and     %x[s1], %x[s1], %x[y]         \n\t"
                   "orr     %x[s1], %x[x], %x[s1]         \n\t"
                   "asr     %x[x], %x[s1], 63"

--- a/library/constant_time_impl.h
+++ b/library/constant_time_impl.h
@@ -234,14 +234,14 @@ static inline mbedtls_ct_uint_t mbedtls_ct_if(mbedtls_ct_condition_t condition,
 static inline mbedtls_ct_condition_t mbedtls_ct_uint_lt(mbedtls_ct_uint_t x, mbedtls_ct_uint_t y)
 {
 #if defined(MBEDTLS_CT_AARCH64_ASM) && (defined(MBEDTLS_CT_SIZE_32) || defined(MBEDTLS_CT_SIZE_64))
-    uint64_t s1, s2;
+    uint64_t s1;
     asm volatile ("eor     %x[s1], %x[y], %x[x]          \n\t"
-                  "sub     %x[s2], %x[x], %x[y]          \n\t"
-                  "bic     %x[s2], %x[s2], %[s1]         \n\t"
+                  "sub     %x[x], %x[x], %x[y]           \n\t"
+                  "bic     %x[x], %x[x], %[s1]           \n\t"
                   "and     %x[s1], %x[s1], %x[y]         \n\t"
-                  "orr     %x[s1], %x[s2], %x[s1]        \n\t"
+                  "orr     %x[s1], %x[x], %x[s1]         \n\t"
                   "asr     %x[x], %x[s1], 63"
-                  : [s1] "=&r" (s1), [s2] "=&r" (s2), [x] "+r" (x)
+                  : [s1] "=&r" (s1), [x] "+&r" (x)
                   : [y] "r" (y)
                   :
                   );

--- a/library/constant_time_impl.h
+++ b/library/constant_time_impl.h
@@ -183,8 +183,14 @@ static inline mbedtls_ct_condition_t mbedtls_ct_bool(mbedtls_ct_uint_t x)
 #pragma warning( push )
 #pragma warning( disable : 4146 )
 #endif
-    return (mbedtls_ct_condition_t) (((mbedtls_ct_int_t) ((-xo) | -(xo >> 1))) >>
-                                     (MBEDTLS_CT_SIZE - 1));
+    // y is negative (i.e., top bit set) iff x is non-zero
+    mbedtls_ct_int_t y = (-xo) | -(xo >> 1);
+
+    // extract only the sign bit of y so that y == 1 (if x is non-zero) or 0 (if x is zero)
+    y = (((mbedtls_ct_uint_t) y) >> (MBEDTLS_CT_SIZE - 1));
+
+    // -y has all bits set (if x is non-zero), or all bits clear (if x is zero)
+    return (mbedtls_ct_condition_t) (-y);
 #if defined(_MSC_VER)
 #pragma warning( pop )
 #endif

--- a/library/constant_time_internal.h
+++ b/library/constant_time_internal.h
@@ -85,12 +85,14 @@ typedef ptrdiff_t mbedtls_ct_int_t;
 typedef uint64_t  mbedtls_ct_condition_t;
 typedef uint64_t  mbedtls_ct_uint_t;
 typedef int64_t   mbedtls_ct_int_t;
+#define MBEDTLS_CT_SIZE_64
 #define MBEDTLS_CT_TRUE  ((mbedtls_ct_condition_t) mbedtls_ct_compiler_opaque(UINT64_MAX))
 #else
 /* Pointer size <= 32-bit, and no 64-bit MPIs */
 typedef uint32_t  mbedtls_ct_condition_t;
 typedef uint32_t  mbedtls_ct_uint_t;
 typedef int32_t   mbedtls_ct_int_t;
+#define MBEDTLS_CT_SIZE_32
 #define MBEDTLS_CT_TRUE  ((mbedtls_ct_condition_t) mbedtls_ct_compiler_opaque(UINT32_MAX))
 #endif
 #define MBEDTLS_CT_FALSE ((mbedtls_ct_condition_t) mbedtls_ct_compiler_opaque(0))


### PR DESCRIPTION
## Description

Size/performance optimisation for Arm constant-time code. Saves 100b with armclang -Oz under TF-M config (`mtest -S`).

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required - non-functional change
- [x] **backport** not required - too invasive and not a bug-fix
- [x] **tests** already present