### PR TITLE
Set LANGUAGES explicitly in CMakeLists.txt project()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,9 +34,9 @@ cmake_policy(SET CMP0011 NEW)
 cmake_policy(SET CMP0012 NEW)
 
 if(TEST_CPP)
-    project("mbed TLS" C CXX)
+    project("mbed TLS" LANGUAGES C CXX)
 else()
-    project("mbed TLS" C)
+    project("mbed TLS" LANGUAGES C)
 endif()
 
 include(GNUInstallDirs)


### PR DESCRIPTION
## Description

When Mbed TLS is built as a TF-M subproject with a recent enough version of cmake (i.e. 3.22.1), GNUInstallDirs complains about LANGUAGES not being set in project when the short signature is used. So make sure to use the normal signature, i.e. set the LANGUAGES option explicitly


## PR checklist

- [x] **changelog** not required
- [x] **backport** not required
- [x] **tests** not required
