### PR TITLE
Backport 2.28: Ignore *.o everywhere

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ massif-*
 .project
 /.settings
 
+# Unix-like build artifacts:
+*.o
+
 # MSVC build artifacts:
 *.exe
 *.pdb

--- a/3rdparty/everest/.gitignore
+++ b/3rdparty/everest/.gitignore
@@ -1,2 +1,1 @@
-*.o
 Makefile

--- a/library/.gitignore
+++ b/library/.gitignore
@@ -1,4 +1,3 @@
-*.o
 libmbed*
 *.sln
 *.vcxproj

--- a/programs/.gitignore
+++ b/programs/.gitignore
@@ -5,9 +5,6 @@
 *.sln
 *.vcxproj
 
-*.o
-*.exe
-
 aes/crypt_and_hash
 hash/generic_sum
 hash/hello

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -10,9 +10,6 @@ data_files/entropy_seed
 
 include/test/instrument_record_status.h
 
-src/*.o
-src/test_helpers/*.o
-src/drivers/*.o
 src/libmbed*
 
 libtestdriver1/*


### PR DESCRIPTION
Backport of https://github.com/Mbed-TLS/mbedtls/pull/7586, just to keep the branches aligned to facilitate future backports (especially in the tests).

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** no (git stuff only)
- [x] **backport** of https://github.com/Mbed-TLS/mbedtls/pull/7586
- [x] **tests** N/A



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.
