### PR TITLE
Psa native its build 3.4

### DIFF
--- a/library/psa_crypto_its.h
+++ b/library/psa_crypto_its.h
@@ -21,10 +21,19 @@
 #ifndef PSA_CRYPTO_ITS_H
 #define PSA_CRYPTO_ITS_H
 
+/* Include the configuration directly, without going through common.h,
+ * to make this header file somewhat independent from the rest of the
+ * library. We do of course still need the library configuration . */
+#include "mbedtls/build_info.h"
+
+#if defined(MBEDTLS_PSA_ITS_FILE_C)
+
 #include <stddef.h>
 #include <stdint.h>
 
+/* For psa_status_t. */
 #include <psa/crypto_types.h>
+/* For PSA_ERROR_xxx constants used by the ITS implementation. */
 #include <psa/crypto_values.h>
 
 #ifdef __cplusplus
@@ -139,5 +148,14 @@ psa_status_t psa_its_remove(psa_storage_uid_t uid);
 #ifdef __cplusplus
 }
 #endif
+
+#else /* Native ITS implementation */
+
+/* Include the native PSA ITS headers, in case it tweaks the API in a way
+ * that makes it different from our copy (e.g. it may implement a different
+ * PSA_ITS_API_VERSION_MINOR). */
+#include "psa/internal_trusted_storage.h"
+
+#endif /* MBEDTLS_PSA_ITS_FILE_C */
 
 #endif /* PSA_CRYPTO_ITS_H */

--- a/library/psa_crypto_se.c
+++ b/library/psa_crypto_se.c
@@ -29,12 +29,7 @@
 
 #include "psa_crypto_se.h"
 
-#if defined(MBEDTLS_PSA_ITS_FILE_C)
 #include "psa_crypto_its.h"
-#else /* Native ITS implementation */
-#include "psa/error.h"
-#include "psa/internal_trusted_storage.h"
-#endif
 
 #include "mbedtls/platform.h"
 

--- a/library/psa_crypto_storage.c
+++ b/library/psa_crypto_storage.c
@@ -29,12 +29,7 @@
 #include "psa_crypto_storage.h"
 #include "mbedtls/platform_util.h"
 
-#if defined(MBEDTLS_PSA_ITS_FILE_C)
 #include "psa_crypto_its.h"
-#else /* Native ITS implementation */
-#include "psa/error.h"
-#include "psa/internal_trusted_storage.h"
-#endif
 
 #include "mbedtls/platform.h"
 

--- a/tests/include/psa-its-fake/psa/internal_trusted_storage.h
+++ b/tests/include/psa-its-fake/psa/internal_trusted_storage.h
@@ -1,0 +1,77 @@
+/* Dummy implementation of PSA Internal Trusted Storage */
+
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef PSA_ITS_FAKE_INTERNAL_TRUSTED_STORAGE_H
+#define PSA_ITS_FAKE_INTERNAL_TRUSTED_STORAGE_H
+
+#include <stdint.h>
+
+/* A compatible definition per the PSA specification.
+ * It's ok to have this here whether the macro is also defined in another
+ * header or not. */
+#define PSA_ERROR_NOT_SUPPORTED         ((psa_status_t)-134)
+
+typedef uint32_t psa_storage_create_flags_t;
+typedef uint64_t psa_storage_uid_t;
+struct psa_storage_info_t {
+    uint32_t size;
+    psa_storage_create_flags_t flags;
+};
+
+static inline psa_status_t psa_its_set(psa_storage_uid_t uid,
+                                       uint32_t data_length,
+                                       const void *p_data,
+                                       psa_storage_create_flags_t create_flags)
+{
+    (void) uid;
+    (void) data_length;
+    (void) p_data;
+    (void) create_flags;
+    return PSA_ERROR_NOT_SUPPORTED;
+}
+
+static inline psa_status_t psa_its_get(psa_storage_uid_t uid,
+                                       uint32_t data_offset,
+                                       uint32_t data_length,
+                                       void *p_data,
+                                       size_t *p_data_length)
+{
+    (void) uid;
+    (void) data_offset;
+    (void) data_length;
+    (void) p_data;
+    (void) p_data_length;
+    return PSA_ERROR_NOT_SUPPORTED;
+}
+
+static inline psa_status_t psa_its_get_info(psa_storage_uid_t uid,
+                                            struct psa_storage_info_t *p_info)
+{
+    (void) uid;
+    (void) p_info;
+    return PSA_ERROR_NOT_SUPPORTED;
+}
+
+static inline psa_status_t psa_its_remove(psa_storage_uid_t uid)
+{
+    (void) uid;
+    return PSA_ERROR_NOT_SUPPORTED;
+}
+
+#endif /* PSA_ITS_FAKE_INTERNAL_TRUSTED_STORAGE_H */

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1004,6 +1004,16 @@ component_test_psa_crypto_client () {
     make test
 }
 
+component_build_psa_native_its () {
+    msg "build: full config - MBEDTLS_PSA_ITS_FILE_C, make"
+    scripts/config.py full
+    scripts/config.py unset MBEDTLS_PSA_ITS_FILE_C
+    make CFLAGS="-I '$PWD/tests/include/psa-its-fake' -O"
+
+    # We don't run the tests because the fake ITS implementation we're linking
+    # with doesn't actually work: it's only enough for compiling and linking.
+}
+
 component_test_psa_crypto_rsa_no_genprime() {
     msg "build: default config minus MBEDTLS_GENPRIME"
     scripts/config.py unset MBEDTLS_GENPRIME

--- a/tests/suites/test_suite_psa_crypto_se_driver_hal.function
+++ b/tests/suites/test_suite_psa_crypto_se_driver_hal.function
@@ -6,12 +6,7 @@
 #include "psa_crypto_storage.h"
 
 /* Invasive peeking: check the persistent data */
-#if defined(MBEDTLS_PSA_ITS_FILE_C)
 #include "psa_crypto_its.h"
-#else /* Native ITS implementation */
-#include "psa/error.h"
-#include "psa/internal_trusted_storage.h"
-#endif
 
 
 /****************************************************************/

--- a/tests/suites/test_suite_psa_crypto_storage_format.function
+++ b/tests/suites/test_suite_psa_crypto_storage_format.function
@@ -34,6 +34,10 @@ static int test_written_key(const psa_key_attributes_t *attributes,
                                          created_key_id));
 
     /* Check that the key is represented as expected. */
+    /* Initialize the size field, in case the compiler sees that
+     * psa_its_get_info does not initialize it systematically but does
+     * not see that it is always initialized on success. */
+    storage_info.size = 0;
     PSA_ASSERT(psa_its_get_info(uid, &storage_info));
     TEST_EQUAL(storage_info.size, expected_representation->len);
     ASSERT_ALLOC(actual_representation, storage_info.size);


### PR DESCRIPTION
Test building against a native implementation of PSA ITS instead of our implementation over stdio. Currently we have no build with `MBEDTLS_PSA_CRYPTO_STORAGE_C` enabled and `MBEDTLS_PSA_ITS_FILE_C` disabled.

I am not aware of any bug, but it's good to have a test. At first I thought that was the root cause for https://github.com/Mbed-TLS/mbedtls/issues/7562, but upon closer inspection the root cause turns out to be how TF-M modifies `include/psa/crypto*.h` and disabling `MBEDTLS_PSA_ITS_FILE_C` is just a trigger for this problem with the TF-M integration, not a trigger for a problem in Mbed TLS. Having this test would have helped orient the analysis away from a wrong path.

## PR checklist

- [x] **changelog** no (test only)
- [ ] **backport** TODO
- [x] **tests** yes
