### PR TITLE
Free authority_key_id authorityCertIssuer

### DIFF
--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -3195,6 +3195,8 @@ void mbedtls_x509_crt_free(mbedtls_x509_crt *crt)
         mbedtls_asn1_sequence_free(cert_cur->ext_key_usage.next);
         mbedtls_asn1_sequence_free(cert_cur->subject_alt_names.next);
         mbedtls_asn1_sequence_free(cert_cur->certificate_policies.next);
+        mbedtls_asn1_sequence_free(cert_cur->
+                                   authority_key_id.authorityCertIssuer.next);
 
         if (cert_cur->raw.p != NULL && cert_cur->own_buffer) {
             mbedtls_platform_zeroize(cert_cur->raw.p, cert_cur->raw.len);


### PR DESCRIPTION
Add a line to mbedtls_x509_crt_free to free the sequence allocated as part of the authority_key_id member.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required - fix in unreleased code
- [x] **backport** not required - fix in new features
- [ ] **tests** required
