### PR TITLE
Set mbedtls_pk_ec() as internal function when ECP_C is not defined

### DIFF
--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -778,7 +778,7 @@ static inline mbedtls_rsa_context *mbedtls_pk_rsa(const mbedtls_pk_context pk)
 }
 #endif /* MBEDTLS_RSA_C */
 
-#if defined(MBEDTLS_ECP_LIGHT)
+#if defined(MBEDTLS_ECP_C)
 /**
  * Quick access to an EC context inside a PK context.
  *
@@ -801,7 +801,7 @@ static inline mbedtls_ecp_keypair *mbedtls_pk_ec(const mbedtls_pk_context pk)
             return NULL;
     }
 }
-#endif /* MBEDTLS_ECP_LIGHT */
+#endif /* MBEDTLS_ECP_C */
 
 #if defined(MBEDTLS_PK_PARSE_C)
 /** \ingroup pk_module */

--- a/include/mbedtls/x509.h
+++ b/include/mbedtls/x509.h
@@ -27,7 +27,6 @@
 
 #include "mbedtls/asn1.h"
 #include "mbedtls/pk.h"
-#include "pk_internal.h"
 
 #if defined(MBEDTLS_RSA_C)
 #include "mbedtls/rsa.h"

--- a/include/mbedtls/x509.h
+++ b/include/mbedtls/x509.h
@@ -27,6 +27,7 @@
 
 #include "mbedtls/asn1.h"
 #include "mbedtls/pk.h"
+#include "pk_internal.h"
 
 #if defined(MBEDTLS_RSA_C)
 #include "mbedtls/rsa.h"

--- a/library/pk.c
+++ b/library/pk.c
@@ -23,6 +23,7 @@
 #include "mbedtls/pk.h"
 #include "pk_wrap.h"
 #include "pkwrite.h"
+#include "pk_internal.h"
 
 #include "hash_info.h"
 

--- a/library/pk.c
+++ b/library/pk.c
@@ -879,7 +879,7 @@ int mbedtls_pk_wrap_as_opaque(mbedtls_pk_context *pk,
         psa_status_t status;
 
         /* export the private key material in the format PSA wants */
-        ec = mbedtls_pk_ec(*pk);
+        ec = mbedtls_pk_ec_rw(*pk);
         d_len = PSA_BITS_TO_BYTES(ec->grp.nbits);
         if ((ret = mbedtls_ecp_write_key(ec, d, d_len)) != 0) {
             return ret;

--- a/library/pk_internal.h
+++ b/library/pk_internal.h
@@ -1,0 +1,68 @@
+/**
+ * \file pk_internal.h
+ *
+ * \brief Public Key abstraction layer: internal (i.e. library only) functions
+ *        and definitions.
+ */
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+#ifndef MBEDTLS_PK_INTERNAL_H
+#define MBEDTLS_PK_INTERNAL_H
+
+#if defined(MBEDTLS_ECP_LIGHT)
+#include "mbedtls/ecp.h"
+#endif
+
+#if defined(MBEDTLS_ECP_LIGHT)
+/**
+ * Public function mbedtls_pk_ec() can be used to get direct access to the
+ * wrapped ecp_keypair strucure pointed to the pk_ctx. However this is not
+ * ideal because it bypasses the PK module on the control of its internal's
+ * structure (pk_context) fields.
+ * For backward compatibility we keep mbedtls_pk_ec() when ECP_C is defined, but
+ * we provide 2 very similar function when only ECP_LIGHT is enabled and not
+ * ECP_C.
+ * These variants embed the "ro" or "rw" keywords in their name to make the
+ * usage of the returned pointer explicit. Of course the returned value is
+ * const or non-const accordingly.
+ */
+static inline const mbedtls_ecp_keypair *mbedtls_pk_ec_ro(const mbedtls_pk_context pk)
+{
+    switch (mbedtls_pk_get_type(&pk)) {
+        case MBEDTLS_PK_ECKEY:
+        case MBEDTLS_PK_ECKEY_DH:
+        case MBEDTLS_PK_ECDSA:
+            return (mbedtls_ecp_keypair *) (pk).MBEDTLS_PRIVATE(pk_ctx);
+        default:
+            return NULL;
+    }
+}
+
+static inline mbedtls_ecp_keypair *mbedtls_pk_ec_rw(const mbedtls_pk_context pk)
+{
+    switch (mbedtls_pk_get_type(&pk)) {
+        case MBEDTLS_PK_ECKEY:
+        case MBEDTLS_PK_ECKEY_DH:
+        case MBEDTLS_PK_ECDSA:
+            return (mbedtls_ecp_keypair *) (pk).MBEDTLS_PRIVATE(pk_ctx);
+        default:
+            return NULL;
+    }
+}
+#endif /* MBEDTLS_ECP_LIGHT */
+
+#endif /* MBEDTLS_PK_INTERNAL_H */

--- a/library/pk_internal.h
+++ b/library/pk_internal.h
@@ -46,7 +46,7 @@ static inline const mbedtls_ecp_keypair *mbedtls_pk_ec_ro(const mbedtls_pk_conte
         case MBEDTLS_PK_ECKEY:
         case MBEDTLS_PK_ECKEY_DH:
         case MBEDTLS_PK_ECDSA:
-            return (mbedtls_ecp_keypair *) (pk).MBEDTLS_PRIVATE(pk_ctx);
+            return (const mbedtls_ecp_keypair *) (pk).MBEDTLS_PRIVATE(pk_ctx);
         default:
             return NULL;
     }

--- a/library/pkwrite.c
+++ b/library/pkwrite.c
@@ -26,6 +26,7 @@
 #include "mbedtls/oid.h"
 #include "mbedtls/platform_util.h"
 #include "mbedtls/error.h"
+#include "pk_internal.h"
 
 #include <string.h>
 
@@ -182,7 +183,7 @@ int mbedtls_pk_write_pubkey(unsigned char **p, unsigned char *start,
 #endif
 #if defined(MBEDTLS_ECP_LIGHT)
     if (mbedtls_pk_get_type(key) == MBEDTLS_PK_ECKEY) {
-        MBEDTLS_ASN1_CHK_ADD(len, pk_write_ec_pubkey(p, start, mbedtls_pk_ec(*key)));
+        MBEDTLS_ASN1_CHK_ADD(len, pk_write_ec_pubkey(p, start, mbedtls_pk_ec_rw(*key)));
     } else
 #endif
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
@@ -246,7 +247,7 @@ int mbedtls_pk_write_pubkey_der(const mbedtls_pk_context *key, unsigned char *bu
     pk_type = mbedtls_pk_get_type(key);
 #if defined(MBEDTLS_ECP_LIGHT)
     if (pk_type == MBEDTLS_PK_ECKEY) {
-        ec_grp_id = mbedtls_pk_ec(*key)->grp.id;
+        ec_grp_id = mbedtls_pk_ec_ro(*key)->grp.id;
     }
 #endif /* MBEDTLS_ECP_LIGHT */
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
@@ -469,7 +470,7 @@ end_of_export:
 #endif /* MBEDTLS_RSA_C */
 #if defined(MBEDTLS_ECP_LIGHT)
     if (mbedtls_pk_get_type(key) == MBEDTLS_PK_ECKEY) {
-        mbedtls_ecp_keypair *ec = mbedtls_pk_ec(*key);
+        mbedtls_ecp_keypair *ec = mbedtls_pk_ec_rw(*key);
         size_t pub_len = 0, par_len = 0;
 
 #if defined(MBEDTLS_PK_HAVE_RFC8410_CURVES)
@@ -591,7 +592,7 @@ int mbedtls_pk_write_key_pem(const mbedtls_pk_context *key, unsigned char *buf, 
 #if defined(MBEDTLS_ECP_LIGHT)
     if (mbedtls_pk_get_type(key) == MBEDTLS_PK_ECKEY) {
 #if defined(MBEDTLS_PK_HAVE_RFC8410_CURVES)
-        if (mbedtls_pk_is_rfc8410_curve(mbedtls_pk_ec(*key)->grp.id)) {
+        if (mbedtls_pk_is_rfc8410_curve(mbedtls_pk_ec_ro(*key)->grp.id)) {
             begin = PEM_BEGIN_PRIVATE_KEY_PKCS8;
             end = PEM_END_PRIVATE_KEY_PKCS8;
         } else

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -55,6 +55,7 @@
 #endif
 
 #include "mbedtls/pk.h"
+#include "pk_internal.h"
 #include "common.h"
 
 /* Shorthand for restartable ECC */

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -7388,9 +7388,9 @@ static int ssl_parse_certificate_verify(mbedtls_ssl_context *ssl,
             /* and in the unlikely case the above assumption no longer holds
              * we are making sure that pk_ec() here does not return a NULL
              */
-            const mbedtls_ecp_keypair *ec = mbedtls_pk_ec(*pk);
+            const mbedtls_ecp_keypair *ec = mbedtls_pk_ec_ro(*pk);
             if (ec == NULL) {
-                MBEDTLS_SSL_DEBUG_MSG(1, ("mbedtls_pk_ec() returned NULL"));
+                MBEDTLS_SSL_DEBUG_MSG(1, ("mbedtls_pk_ec_ro() returned NULL"));
                 return MBEDTLS_ERR_SSL_INTERNAL_ERROR;
             }
 

--- a/library/ssl_tls12_client.c
+++ b/library/ssl_tls12_client.c
@@ -2007,7 +2007,7 @@ static int ssl_get_ecdh_params_from_cert(mbedtls_ssl_context *ssl)
         return MBEDTLS_ERR_SSL_PK_TYPE_MISMATCH;
     }
 
-    peer_key = mbedtls_pk_ec(*peer_pk);
+    peer_key = mbedtls_pk_ec_ro(*peer_pk);
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     size_t olen = 0;

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -2636,7 +2636,7 @@ static int ssl_get_ecdh_params_from_cert(mbedtls_ssl_context *ssl)
         case MBEDTLS_PK_ECKEY:
         case MBEDTLS_PK_ECKEY_DH:
         case MBEDTLS_PK_ECDSA:
-            key = mbedtls_pk_ec_ro(*pk);
+            key = mbedtls_pk_ec_rw(*pk);
             if (key == NULL) {
                 return MBEDTLS_ERR_ECP_BAD_INPUT_DATA;
             }

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -666,7 +666,7 @@ static int ssl_check_key_curve(mbedtls_pk_context *pk,
                                uint16_t *curves_tls_id)
 {
     uint16_t *curr_tls_id = curves_tls_id;
-    mbedtls_ecp_group_id grp_id = mbedtls_pk_ec(*pk)->grp.id;
+    mbedtls_ecp_group_id grp_id = mbedtls_pk_ec_ro(*pk)->grp.id;
     mbedtls_ecp_group_id curr_grp_id;
 
     while (*curr_tls_id != 0) {
@@ -2636,7 +2636,7 @@ static int ssl_get_ecdh_params_from_cert(mbedtls_ssl_context *ssl)
         case MBEDTLS_PK_ECKEY:
         case MBEDTLS_PK_ECKEY_DH:
         case MBEDTLS_PK_ECDSA:
-            key = mbedtls_pk_ec(*pk);
+            key = mbedtls_pk_ec_ro(*pk);
             if (key == NULL) {
                 return MBEDTLS_ERR_ECP_BAD_INPUT_DATA;
             }
@@ -2704,7 +2704,7 @@ static int ssl_get_ecdh_params_from_cert(mbedtls_ssl_context *ssl)
     }
 
     if ((ret = mbedtls_ecdh_get_params(&ssl->handshake->ecdh_ctx,
-                                       mbedtls_pk_ec(*mbedtls_ssl_own_key(ssl)),
+                                       mbedtls_pk_ec_ro(*mbedtls_ssl_own_key(ssl)),
                                        MBEDTLS_ECDH_OURS)) != 0) {
         MBEDTLS_SSL_DEBUG_RET(1, ("mbedtls_ecdh_get_params"), ret);
         return ret;

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -237,7 +237,7 @@ static int x509_profile_check_key(const mbedtls_x509_crt_profile *profile,
     if (pk_alg == MBEDTLS_PK_ECDSA ||
         pk_alg == MBEDTLS_PK_ECKEY ||
         pk_alg == MBEDTLS_PK_ECKEY_DH) {
-        const mbedtls_ecp_group_id gid = mbedtls_pk_ec(*pk)->grp.id;
+        const mbedtls_ecp_group_id gid = mbedtls_pk_ec_ro(*pk)->grp.id;
 
         if (gid == MBEDTLS_ECP_DP_NONE) {
             return -1;

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -50,6 +50,7 @@
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 #include "hash_info.h"
 #include "x509_invasive.h"
+#include "pk_internal.h"
 
 #include "mbedtls/platform.h"
 

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -6,6 +6,7 @@
 #include "mbedtls/base64.h"
 #include "mbedtls/ecp.h"
 #include "mbedtls/rsa.h"
+#include "pk_internal.h"
 
 #include "hash_info.h"
 
@@ -101,20 +102,20 @@ static int pk_genkey(mbedtls_pk_context *pk, int parameter)
         mbedtls_pk_get_type(pk) == MBEDTLS_PK_ECKEY_DH ||
         mbedtls_pk_get_type(pk) == MBEDTLS_PK_ECDSA) {
         int ret;
-        if ((ret = mbedtls_ecp_group_load(&mbedtls_pk_ec(*pk)->grp,
+        if ((ret = mbedtls_ecp_group_load(&mbedtls_pk_ec_rw(*pk)->grp,
                                           parameter)) != 0) {
             return ret;
         }
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
-        return pk_genkey_ec(&mbedtls_pk_ec(*pk)->grp,
-                            &mbedtls_pk_ec(*pk)->d,
-                            &mbedtls_pk_ec(*pk)->Q);
+        return pk_genkey_ec(&mbedtls_pk_ec_rw(*pk)->grp,
+                            &mbedtls_pk_ec_rw(*pk)->d,
+                            &mbedtls_pk_ec_rw(*pk)->Q);
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 #if defined(MBEDTLS_ECP_C)
-        return mbedtls_ecp_gen_keypair(&mbedtls_pk_ec(*pk)->grp,
-                                       &mbedtls_pk_ec(*pk)->d,
-                                       &mbedtls_pk_ec(*pk)->Q,
+        return mbedtls_ecp_gen_keypair(&mbedtls_pk_ec_rw(*pk)->grp,
+                                       &mbedtls_pk_ec_rw(*pk)->d,
+                                       &mbedtls_pk_ec_rw(*pk)->Q,
                                        mbedtls_test_rnd_std_rand, NULL);
 #endif /* MBEDTLS_ECP_C */
     }
@@ -709,7 +710,7 @@ void pk_ec_test_vec(int type, int id, data_t *key, data_t *hash,
     TEST_ASSERT(mbedtls_pk_setup(&pk, mbedtls_pk_info_from_type(type)) == 0);
 
     TEST_ASSERT(mbedtls_pk_can_do(&pk, MBEDTLS_PK_ECDSA));
-    eckey = mbedtls_pk_ec(pk);
+    eckey = mbedtls_pk_ec_rw(pk);
 
     TEST_ASSERT(mbedtls_ecp_group_load(&eckey->grp, id) == 0);
     TEST_ASSERT(mbedtls_ecp_point_read_binary(&eckey->grp, &eckey->Q,
@@ -745,12 +746,12 @@ void pk_sign_verify_restart(int pk_type, int grp_id, char *d_str,
     memset(sig, 0, sizeof(sig));
 
     TEST_ASSERT(mbedtls_pk_setup(&prv, mbedtls_pk_info_from_type(pk_type)) == 0);
-    TEST_ASSERT(mbedtls_ecp_group_load(&mbedtls_pk_ec(prv)->grp, grp_id) == 0);
-    TEST_ASSERT(mbedtls_test_read_mpi(&mbedtls_pk_ec(prv)->d, d_str) == 0);
+    TEST_ASSERT(mbedtls_ecp_group_load(&mbedtls_pk_ec_rw(prv)->grp, grp_id) == 0);
+    TEST_ASSERT(mbedtls_test_read_mpi(&mbedtls_pk_ec_rw(prv)->d, d_str) == 0);
 
     TEST_ASSERT(mbedtls_pk_setup(&pub, mbedtls_pk_info_from_type(pk_type)) == 0);
-    TEST_ASSERT(mbedtls_ecp_group_load(&mbedtls_pk_ec(pub)->grp, grp_id) == 0);
-    TEST_ASSERT(mbedtls_ecp_point_read_string(&mbedtls_pk_ec(pub)->Q, 16, QX_str, QY_str) == 0);
+    TEST_ASSERT(mbedtls_ecp_group_load(&mbedtls_pk_ec_rw(pub)->grp, grp_id) == 0);
+    TEST_ASSERT(mbedtls_ecp_point_read_string(&mbedtls_pk_ec_rw(pub)->Q, 16, QX_str, QY_str) == 0);
 
     mbedtls_ecp_set_max_ops(max_ops);
 
@@ -1316,8 +1317,8 @@ void pk_psa_sign(int parameter_arg,
     /* mbedtls_pk_write_pubkey_der() writes backwards in the data buffer. */
     pkey_legacy_start = pkey_legacy + sizeof(pkey_legacy) - klen_legacy;
 #else
-    ret = mbedtls_ecp_point_write_binary(&(mbedtls_pk_ec(pk)->grp),
-                                         &(mbedtls_pk_ec(pk)->Q),
+    ret = mbedtls_ecp_point_write_binary(&(mbedtls_pk_ec_ro(pk)->grp),
+                                         &(mbedtls_pk_ec_ro(pk)->Q),
                                          MBEDTLS_ECP_PF_UNCOMPRESSED,
                                          &klen_legacy, pkey_legacy,
                                          sizeof(pkey_legacy));
@@ -1379,10 +1380,10 @@ void pk_psa_sign(int parameter_arg,
     TEST_EQUAL(mbedtls_pk_setup(&pk,
                                 mbedtls_pk_info_from_type(MBEDTLS_PK_ECKEY)), 0);
     TEST_EQUAL(mbedtls_ecp_group_load(
-                   &(mbedtls_pk_ec(pk)->grp),
+                   &(mbedtls_pk_ec_rw(pk)->grp),
                    (mbedtls_ecp_group_id) parameter_arg), 0);
-    TEST_EQUAL(mbedtls_ecp_point_read_binary(&(mbedtls_pk_ec(pk)->grp),
-                                             &(mbedtls_pk_ec(pk)->Q),
+    TEST_EQUAL(mbedtls_ecp_point_read_binary(&(mbedtls_pk_ec_ro(pk)->grp),
+                                             &(mbedtls_pk_ec_rw(pk)->Q),
                                              pkey_legacy_start, klen_legacy), 0);
 #endif
     TEST_ASSERT(mbedtls_pk_verify(&pk, MBEDTLS_MD_SHA256,

--- a/tests/suites/test_suite_pkparse.function
+++ b/tests/suites/test_suite_pkparse.function
@@ -3,6 +3,7 @@
 #include "mbedtls/pem.h"
 #include "mbedtls/oid.h"
 #include "mbedtls/ecp.h"
+#include "pk_internal.h"
 /* END_HEADER */
 
 /* BEGIN_DEPENDENCIES
@@ -83,9 +84,9 @@ void pk_parse_public_keyfile_ec(char *key_file, int result)
     TEST_ASSERT(res == result);
 
     if (res == 0) {
-        mbedtls_ecp_keypair *eckey;
+        const mbedtls_ecp_keypair *eckey;
         TEST_ASSERT(mbedtls_pk_can_do(&ctx, MBEDTLS_PK_ECKEY));
-        eckey = mbedtls_pk_ec(ctx);
+        eckey = mbedtls_pk_ec_ro(ctx);
         TEST_ASSERT(mbedtls_ecp_check_pubkey(&eckey->grp, &eckey->Q) == 0);
     }
 
@@ -110,9 +111,9 @@ void pk_parse_keyfile_ec(char *key_file, char *password, int result)
     TEST_ASSERT(res == result);
 
     if (res == 0) {
-        mbedtls_ecp_keypair *eckey;
+        const mbedtls_ecp_keypair *eckey;
         TEST_ASSERT(mbedtls_pk_can_do(&ctx, MBEDTLS_PK_ECKEY));
-        eckey = mbedtls_pk_ec(ctx);
+        eckey = mbedtls_pk_ec_ro(ctx);
         TEST_ASSERT(mbedtls_ecp_check_privkey(&eckey->grp, &eckey->d) == 0);
     }
 


### PR DESCRIPTION
The `mbedtls_pk_ec()` is not ideal as:

- provides direct access to the `ecp_keypair` structure embedded by the `pk_context` and
- it bypasses the control of the PK module

However it cannot be deprecated since it is a public function (i.e. it might be used by some user) and at the same time it is not easy to find the right replacement.

As a consequence, as intermediate solution, this PR does the following:

- when ECP_C is defined, then the legacy `mbedtls_pk_ec` is available
- when ECP_C is not defined, but `ECP_LIGHT` is, then 2 new functions are present: `mbedtls_pk_ec_[ro/rw]`
    - they still return a pointer, but it will be `const` or non-`const` accordingly
    - their name explicitly state the usage purpose of the returned pointer

## PR checklist

- [x] **changelog** not required - the only non-internal change reverts to how things were in 3.4.0, the rest is internal
- [x] **backport** not required - supporting development of new features
- [x] **tests** not required - covered by existing tests