### PR TITLE
Backport 2.28: Don't use Lucky Thirteen countermeasure with stream ciphers

### DIFF
--- a/ChangeLog.d/ssl-stream-cipher-hmac.txt
+++ b/ChangeLog.d/ssl-stream-cipher-hmac.txt
@@ -1,0 +1,6 @@
+Bugfix
+   * Fix a performance regression in (D)TLS with RC4 or a null cipher when
+     receiving messages. The code was unnecessarily slow in this case since
+     Mbed TLS 2.24 due to a security countermeasure which is only necessary
+     for CBC-based cipher suites. Stop using the countermeasure for RC4 and
+     null-cipher cipher suites. Fixes #7588.

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -1622,7 +1622,28 @@ hmac_failed_etm_enabled:
              * length, as we previously did in_msglen -= maclen too.
              */
             const size_t max_len = rec->data_len + padlen;
-            const size_t min_len = (max_len > 256) ? max_len - 256 : 0;
+            size_t min_len;
+            switch (mode) {
+#if defined(MBEDTLS_SSL_SOME_SUITES_USE_CBC)
+                case MBEDTLS_MODE_CBC:
+                    /* CBC in TLS can have up to 256 bytes of padding. */
+                    min_len = (max_len > 256) ? max_len - 256 : 0;
+                    break;
+#endif /* MBEDTLS_SSL_SOME_SUITES_USE_CBC */
+#if defined(MBEDTLS_ARC4_C) || defined(MBEDTLS_CIPHER_NULL_CIPHER)
+                case MBEDTLS_MODE_STREAM:
+                    /* With a stream cipher + HMAC, there is no padding.
+                     * We reuse the mbedtls_ct_hmac() code path here to avoid
+                     * making this  function even more complex. In terms of
+                     * performance, with min_len==max_len, the overhead is
+                     * negligible over mbedtls_md_hmac(). */
+                    min_len = max_len;
+                    break;
+#endif /* defined(MBEDTLS_ARC4_C) || defined(MBEDTLS_CIPHER_NULL_CIPHER) */
+                default:
+                    MBEDTLS_SSL_DEBUG_MSG(1, ("should never happen"));
+                    return MBEDTLS_ERR_SSL_INTERNAL_ERROR;
+            }
 
             ret = mbedtls_ct_hmac(&transform->md_ctx_dec,
                                   add_data, add_data_len,

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -1174,6 +1174,7 @@ void ssl_crypt_record(int cipher_type, int hash_id,
 
     mbedtls_ssl_transform t0, t1;
     unsigned char *buf = NULL;
+    unsigned char *buf_backup = NULL;
     size_t const buflen = 512;
     mbedtls_record rec, rec_backup;
 
@@ -1187,7 +1188,8 @@ void ssl_crypt_record(int cipher_type, int hash_id,
                                                   (size_t) cid0_len,
                                                   (size_t) cid1_len) == 0);
 
-    TEST_ASSERT((buf = mbedtls_calloc(1, buflen)) != NULL);
+    ASSERT_ALLOC(buf, buflen);
+    ASSERT_ALLOC(buf_backup, buflen);
 
     while (num_records-- > 0) {
         /* Use the variable as the test step number. Note that this
@@ -1238,6 +1240,8 @@ void ssl_crypt_record(int cipher_type, int hash_id,
 
         /* Make a copy for later comparison */
         rec_backup = rec;
+        rec_backup.buf = buf_backup;
+        memcpy(buf_backup, buf, rec.data_offset + rec.data_len);
 
         /* Encrypt record */
         ret = mbedtls_ssl_encrypt_buf(&ssl, t_enc, &rec,
@@ -1283,11 +1287,11 @@ void ssl_crypt_record(int cipher_type, int hash_id,
             TEST_ASSERT(memcmp(rec.ctr, rec_backup.ctr, 8) == 0);
             TEST_ASSERT(rec.ver[0] == rec_backup.ver[0]);
             TEST_ASSERT(rec.ver[1] == rec_backup.ver[1]);
-            TEST_ASSERT(rec.data_len == rec_backup.data_len);
             TEST_ASSERT(rec.data_offset == rec_backup.data_offset);
-            TEST_ASSERT(memcmp(rec.buf + rec.data_offset,
-                               rec_backup.buf + rec_backup.data_offset,
-                               rec.data_len) == 0);
+            ASSERT_COMPARE(rec.buf + rec.data_offset,
+                           rec.data_len,
+                           rec_backup.buf + rec_backup.data_offset,
+                           rec_backup.data_len);
         }
     }
 
@@ -1298,6 +1302,7 @@ exit:
     mbedtls_ssl_transform_free(&t0);
     mbedtls_ssl_transform_free(&t1);
     mbedtls_free(buf);
+    mbedtls_free(buf_backup);
     USE_PSA_DONE();
 }
 /* END_CASE */

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -1168,7 +1168,8 @@ void ssl_crypt_record(int cipher_type, int hash_id,
      */
 
     int ret;
-    int num_records = 16;
+    int num_good_records = 16;
+    int num_records = 2 * num_good_records;
     mbedtls_ssl_context ssl; /* ONLY for debugging */
 
     mbedtls_ssl_transform t0, t1;
@@ -1189,6 +1190,10 @@ void ssl_crypt_record(int cipher_type, int hash_id,
     TEST_ASSERT((buf = mbedtls_calloc(1, buflen)) != NULL);
 
     while (num_records-- > 0) {
+        /* Use the variable as the test step number. Note that this
+         * means step numbers go backwards. */
+        mbedtls_test_set_step(num_records);
+
         mbedtls_ssl_transform *t_dec, *t_enc;
         /* Take turns in who's sending and who's receiving. */
         if (num_records % 3 == 0) {
@@ -1198,6 +1203,9 @@ void ssl_crypt_record(int cipher_type, int hash_id,
             t_dec = &t1;
             t_enc = &t0;
         }
+
+        /* Good case for the first half, bad case for the second half */
+        int corrupt_ciphertext = (num_records < num_good_records);
 
         /*
          * The record header affects the transformation in two ways:
@@ -1257,20 +1265,30 @@ void ssl_crypt_record(int cipher_type, int hash_id,
         }
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
+        /* Maybe corrupt the encrypted record */
+        if (corrupt_ciphertext) {
+            /* Flip a bit in the first byte */
+            rec.buf[rec.data_offset] ^= 1;
+        }
+
         /* Decrypt record with t_dec */
         ret = mbedtls_ssl_decrypt_buf(&ssl, t_dec, &rec);
-        TEST_ASSERT(ret == 0);
 
-        /* Compare results */
-        TEST_ASSERT(rec.type == rec_backup.type);
-        TEST_ASSERT(memcmp(rec.ctr, rec_backup.ctr, 8) == 0);
-        TEST_ASSERT(rec.ver[0] == rec_backup.ver[0]);
-        TEST_ASSERT(rec.ver[1] == rec_backup.ver[1]);
-        TEST_ASSERT(rec.data_len == rec_backup.data_len);
-        TEST_ASSERT(rec.data_offset == rec_backup.data_offset);
-        TEST_ASSERT(memcmp(rec.buf + rec.data_offset,
-                           rec_backup.buf + rec_backup.data_offset,
-                           rec.data_len) == 0);
+        if (corrupt_ciphertext) {
+            TEST_EQUAL(ret, MBEDTLS_ERR_SSL_INVALID_MAC);
+        } else {
+            TEST_ASSERT(ret == 0);
+            /* Compare results */
+            TEST_ASSERT(rec.type == rec_backup.type);
+            TEST_ASSERT(memcmp(rec.ctr, rec_backup.ctr, 8) == 0);
+            TEST_ASSERT(rec.ver[0] == rec_backup.ver[0]);
+            TEST_ASSERT(rec.ver[1] == rec_backup.ver[1]);
+            TEST_ASSERT(rec.data_len == rec_backup.data_len);
+            TEST_ASSERT(rec.data_offset == rec_backup.data_offset);
+            TEST_ASSERT(memcmp(rec.buf + rec.data_offset,
+                               rec_backup.buf + rec_backup.data_offset,
+                               rec.data_len) == 0);
+        }
     }
 
 exit:


### PR DESCRIPTION
Since Mbed TLS 2.24, in TLS, we do a fully constant-trace authentication when decrypting messages in a CBC ciphersuite with encrypt-then-MAC. This is necessary to avoid a padding oracle attack (timing-based Lucky Thirteen variants), but it's slow. We use unnecessarily slow code even in stream-based cipher suite (RC4 or null cipher). Fix this. Fixes https://github.com/Mbed-TLS/mbedtls/issues/7588.

This is a simple patch, basically fixing code that was technically incorrect (allowing a MAC at an invalid position in the wrapper function, though `mbedtls_ct_hmac` itself would correctly reject it so the functionality was correct). The code still uses `mbedtls_ct_hmac` for simplicity, but arranges to only check the MAC at a single position. This means that performance is almost on par with a naive HMAC. This patch does not change the code size (or only very marginally) — this misses a potential small code size improvement in builds with RC4/NULL but not CBC, but saves code size in builds with both.

Note: in `development` the relevant part of the code is both simpler due to having removed SSL 3.0 and more complex due to PSA support. We may want a fix with a different structure; in particular it would make sense to call the PSA HMAC rather than `mbedtls_ct_hmac` when using a null cipher with `MBEDTLS_USE_PSA_CRYPTO` enabled.

Status: up for team discussion. Is this patch low-risk enough for an LTS branch? What testing to we want to do beyond what's already in the CI?

## PR checklist

- [x] **changelog** provided
- [ ] **backport** of TODO
- [x] **tests** added
