### PR TITLE
Fix: no newline when debug msg over DEBUG_BUF_SIZE - backport 2.28

### DIFF
--- a/library/debug.c
+++ b/library/debug.c
@@ -68,7 +68,11 @@ void mbedtls_debug_print_msg(const mbedtls_ssl_context *ssl, int level,
     va_list argp;
     char str[DEBUG_BUF_SIZE];
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
-    int newline = -1;
+    int eol = -1;
+
+#if defined(static_assert)
+    static_assert(DEBUG_BUF_SIZE >= 2)
+#endif
 
     if (NULL == ssl              ||
         NULL == ssl->conf        ||
@@ -81,23 +85,21 @@ void mbedtls_debug_print_msg(const mbedtls_ssl_context *ssl, int level,
     ret = mbedtls_vsnprintf(str, DEBUG_BUF_SIZE, format, argp);
     va_end(argp);
 
-    if (DEBUG_BUF_SIZE >= 2) {
-        if (ret < 0) {
-            newline = 0;
-        } else {
-            newline = ret;
-            if (ret >= DEBUG_BUF_SIZE - 1) {
-                newline = DEBUG_BUF_SIZE - 2;
-            }
+    if (ret < 0) {
+        eol= 0;
+    } else {
+        eol= ret;
+        if (ret >= DEBUG_BUF_SIZE - 1) {
+            eol = DEBUG_BUF_SIZE - 2;
         }
     }
 
     /*
      * Send if str contains '\n'.
      */
-    if (newline >= 0) {
-        str[newline]     = '\n';
-        str[newline + 1] = '\0';
+    if (eol >= 0) {
+        str[eol]     = '\n';
+        str[eol + 1] = '\0';
 
         debug_send_line(ssl, level, file, line, str);
     }

--- a/library/debug.c
+++ b/library/debug.c
@@ -84,6 +84,10 @@ void mbedtls_debug_print_msg(const mbedtls_ssl_context *ssl, int level,
         str[ret]     = '\n';
         str[ret + 1] = '\0';
     }
+    else 
+    {
+        str[DEBUG_BUF_SIZE - 2] = '\n';
+    }
 
     debug_send_line(ssl, level, file, line, str);
 }

--- a/library/debug.c
+++ b/library/debug.c
@@ -86,9 +86,9 @@ void mbedtls_debug_print_msg(const mbedtls_ssl_context *ssl, int level,
     va_end(argp);
 
     if (ret < 0) {
-        eol= 0;
+        eol = 0;
     } else {
-        eol= ret;
+        eol = ret;
         if (ret >= DEBUG_BUF_SIZE - 1) {
             eol = DEBUG_BUF_SIZE - 2;
         }

--- a/library/debug.c
+++ b/library/debug.c
@@ -68,7 +68,6 @@ void mbedtls_debug_print_msg(const mbedtls_ssl_context *ssl, int level,
     va_list argp;
     char str[DEBUG_BUF_SIZE];
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
-    int eol = -1;
 
 #if defined(static_assert)
     static_assert(DEBUG_BUF_SIZE >= 2)
@@ -86,23 +85,16 @@ void mbedtls_debug_print_msg(const mbedtls_ssl_context *ssl, int level,
     va_end(argp);
 
     if (ret < 0) {
-        eol = 0;
+        ret = 0;
     } else {
-        eol = ret;
         if (ret >= DEBUG_BUF_SIZE - 1) {
-            eol = DEBUG_BUF_SIZE - 2;
+            ret = DEBUG_BUF_SIZE - 2;
         }
     }
+    str[ret]     = '\n';
+    str[ret + 1] = '\0';
 
-    /*
-     * Send if str contains '\n'.
-     */
-    if (eol >= 0) {
-        str[eol]     = '\n';
-        str[eol + 1] = '\0';
-
-        debug_send_line(ssl, level, file, line, str);
-    }
+    debug_send_line(ssl, level, file, line, str);
 }
 
 void mbedtls_debug_print_ret(const mbedtls_ssl_context *ssl, int level,

--- a/library/debug.c
+++ b/library/debug.c
@@ -30,6 +30,7 @@
 #include <stdio.h>
 #include <string.h>
 
+/* DEBUG_BUF_SIZE must be at least 2 */
 #define DEBUG_BUF_SIZE      512
 
 static int debug_threshold = 0;

--- a/library/debug.c
+++ b/library/debug.c
@@ -84,7 +84,7 @@ void mbedtls_debug_print_msg(const mbedtls_ssl_context *ssl, int level,
         str[ret]     = '\n';
         str[ret + 1] = '\0';
     }
-    else 
+    else
     {
         str[DEBUG_BUF_SIZE - 2] = '\n';
     }

--- a/library/debug.c
+++ b/library/debug.c
@@ -70,9 +70,7 @@ void mbedtls_debug_print_msg(const mbedtls_ssl_context *ssl, int level,
     char str[DEBUG_BUF_SIZE];
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
 
-#if defined(static_assert)
-    static_assert(DEBUG_BUF_SIZE >= 2)
-#endif
+    MBEDTLS_STATIC_ASSERT(DEBUG_BUF_SIZE >= 2, "DEBUG_BUF_SIZE too small");
 
     if (NULL == ssl              ||
         NULL == ssl->conf        ||


### PR DESCRIPTION
## Description

Trivial backport of #7607 

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required
- [x] **backport** of #7607
- [x] **tests** not required
