### PR TITLE
build_info.h: fix mutual implications with config_psa.h temporarily 

### DIFF
--- a/include/mbedtls/build_info.h
+++ b/include/mbedtls/build_info.h
@@ -87,6 +87,12 @@
 #define MBEDTLS_MD_C
 #endif
 
+/* PSA crypto specific configuration options */
+#if defined(MBEDTLS_PSA_CRYPTO_CONFIG) /* PSA_WANT_xxx influences MBEDTLS_xxx */ || \
+    defined(MBEDTLS_PSA_CRYPTO_C) /* MBEDTLS_xxx influences PSA_WANT_xxx */
+#include "mbedtls/config_psa.h"
+#endif
+
 /* Auto-enable MBEDTLS_MD_LIGHT based on MBEDTLS_MD_C.
  * This allows checking for MD_LIGHT rather than MD_LIGHT || MD_C.
  */
@@ -185,11 +191,6 @@
 
 /* Make sure all configuration symbols are set before including check_config.h,
  * even the ones that are calculated programmatically. */
-#if defined(MBEDTLS_PSA_CRYPTO_CONFIG) /* PSA_WANT_xxx influences MBEDTLS_xxx */ || \
-    defined(MBEDTLS_PSA_CRYPTO_C) /* MBEDTLS_xxx influences PSA_WANT_xxx */
-#include "mbedtls/config_psa.h"
-#endif
-
 #include "mbedtls/check_config.h"
 
 #endif /* MBEDTLS_BUILD_INFO_H */

--- a/include/mbedtls/build_info.h
+++ b/include/mbedtls/build_info.h
@@ -87,7 +87,13 @@
 #define MBEDTLS_MD_C
 #endif
 
-/* PSA crypto specific configuration options */
+/* PSA crypto specific configuration options
+ * - If config_psa.h reads a configuration option in preprocessor directive,
+ *   this symbol should be consulted before its inclusion. (e.g. MBEDTLS_MD_C)
+ * - If config_psa.h writes a configuration option in conditional directive,
+ *   this symbol should be consulted after its inclusion.
+ *   (e.g. MBEDTLS_MD_LIGHT)
+ */
 #if defined(MBEDTLS_PSA_CRYPTO_CONFIG) /* PSA_WANT_xxx influences MBEDTLS_xxx */ || \
     defined(MBEDTLS_PSA_CRYPTO_C) /* MBEDTLS_xxx influences PSA_WANT_xxx */
 #include "mbedtls/config_psa.h"

--- a/include/mbedtls/build_info.h
+++ b/include/mbedtls/build_info.h
@@ -89,7 +89,7 @@
 
 /* PSA crypto specific configuration options
  * - If config_psa.h reads a configuration option in preprocessor directive,
- *   this symbol should be consulted before its inclusion. (e.g. MBEDTLS_MD_C)
+ *   this symbol should be set before its inclusion. (e.g. MBEDTLS_MD_C)
  * - If config_psa.h writes a configuration option in conditional directive,
  *   this symbol should be consulted after its inclusion.
  *   (e.g. MBEDTLS_MD_LIGHT)


### PR DESCRIPTION
## Description

This PR temporarily fix the issues mentioned in #7609. 

By tweaking the location of including `config_psa.h`, config options [after `#include "mbedtls/config_psa.h"`](https://github.com/Mbed-TLS/mbedtls/pull/7611/files#diff-a8f17907111aedcf1c8d23fd7bb54af6f6bc68728f1f33d1b8f21114d68d371fR95) are implied correctly in `build_info.h`. I have checked config options after `#include "mbedtls/config_psa.h"` don't have impact on how config options defined/implied in `config_psa.h`. So this PR could be a quick fix for the mutual implications between `config_psa.h` and `build_info.h`.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required
- [x] **backport** not required
- [x] **tests** not required
