### PR TITLE
[Bignum] Add optimised reduction setup placeholders

### DIFF
--- a/library/bignum_mod.c
+++ b/library/bignum_mod.c
@@ -138,31 +138,15 @@ cleanup:
 
 int mbedtls_mpi_mod_modulus_setup(mbedtls_mpi_mod_modulus *N,
                                   const mbedtls_mpi_uint *p,
-                                  size_t p_limbs,
-                                  mbedtls_mpi_mod_rep_selector int_rep)
+                                  size_t p_limbs)
 {
     int ret = 0;
-
     N->p = p;
     N->limbs = p_limbs;
     N->bits = mbedtls_mpi_core_bitlen(p, p_limbs);
-
-    switch (int_rep) {
-        case MBEDTLS_MPI_MOD_REP_MONTGOMERY:
-            N->int_rep = int_rep;
-            N->rep.mont.mm = mbedtls_mpi_core_montmul_init(N->p);
-            ret = set_mont_const_square(&N->rep.mont.rr, N->p, N->limbs);
-            break;
-        case MBEDTLS_MPI_MOD_REP_OPT_RED:
-            N->int_rep = int_rep;
-            N->rep.ored = NULL;
-            break;
-        default:
-            ret = MBEDTLS_ERR_MPI_BAD_INPUT_DATA;
-            goto exit;
-    }
-
-exit:
+    N->int_rep = MBEDTLS_MPI_MOD_REP_MONTGOMERY;
+    N->rep.mont.mm = mbedtls_mpi_core_montmul_init(N->p);
+    ret = set_mont_const_square(&N->rep.mont.rr, N->p, N->limbs);
 
     if (ret != 0) {
         mbedtls_mpi_mod_modulus_free(N);
@@ -248,8 +232,7 @@ static int mbedtls_mpi_mod_inv_non_mont(mbedtls_mpi_mod_residue *X,
     mbedtls_mpi_mod_modulus Nmont;
     mbedtls_mpi_mod_modulus_init(&Nmont);
 
-    MBEDTLS_MPI_CHK(mbedtls_mpi_mod_modulus_setup(&Nmont, N->p, N->limbs,
-                                                  MBEDTLS_MPI_MOD_REP_MONTGOMERY));
+    MBEDTLS_MPI_CHK(mbedtls_mpi_mod_modulus_setup(&Nmont, N->p, N->limbs));
 
     /* We'll use X->p to hold the Montgomery form of the input A->p */
     mbedtls_mpi_core_to_mont_rep(X->p, A->p, Nmont.p, Nmont.limbs,

--- a/library/bignum_mod.c
+++ b/library/bignum_mod.c
@@ -171,6 +171,19 @@ exit:
     return ret;
 }
 
+int mbedtls_mpi_mod_optred_modulus_setup(mbedtls_mpi_mod_modulus *N,
+                                         const mbedtls_mpi_uint *p,
+                                         size_t p_limbs,
+                                         mbedtls_mpi_opt_red_struct *ored)
+{
+    N->p = p;
+    N->limbs = p_limbs;
+    N->bits = mbedtls_mpi_core_bitlen(p, p_limbs);
+    N->int_rep = MBEDTLS_MPI_MOD_REP_OPT_RED;
+    N->rep.ored =ored ;
+    return 0;
+}
+
 int mbedtls_mpi_mod_mul(mbedtls_mpi_mod_residue *X,
                         const mbedtls_mpi_mod_residue *A,
                         const mbedtls_mpi_mod_residue *B,

--- a/library/bignum_mod.c
+++ b/library/bignum_mod.c
@@ -136,15 +136,23 @@ cleanup:
     return ret;
 }
 
+static inline void standard_modulus_setup(mbedtls_mpi_mod_modulus *N,
+                                         const mbedtls_mpi_uint *p,
+                                         size_t p_limbs,
+                                         mbedtls_mpi_mod_rep_selector int_rep)
+{
+    N->p = p;
+    N->limbs = p_limbs;
+    N->bits = mbedtls_mpi_core_bitlen(p, p_limbs);
+    N->int_rep = int_rep;
+}
+
 int mbedtls_mpi_mod_modulus_setup(mbedtls_mpi_mod_modulus *N,
                                   const mbedtls_mpi_uint *p,
                                   size_t p_limbs)
 {
     int ret = 0;
-    N->p = p;
-    N->limbs = p_limbs;
-    N->bits = mbedtls_mpi_core_bitlen(p, p_limbs);
-    N->int_rep = MBEDTLS_MPI_MOD_REP_MONTGOMERY;
+    standard_modulus_setup(N, p, p_limbs, MBEDTLS_MPI_MOD_REP_MONTGOMERY);
     N->rep.mont.mm = mbedtls_mpi_core_montmul_init(N->p);
     ret = set_mont_const_square(&N->rep.mont.rr, N->p, N->limbs);
 
@@ -160,10 +168,7 @@ int mbedtls_mpi_mod_optred_modulus_setup(mbedtls_mpi_mod_modulus *N,
                                          size_t p_limbs,
                                          mbedtls_mpi_opt_red_struct *ored)
 {
-    N->p = p;
-    N->limbs = p_limbs;
-    N->bits = mbedtls_mpi_core_bitlen(p, p_limbs);
-    N->int_rep = MBEDTLS_MPI_MOD_REP_OPT_RED;
+    standard_modulus_setup(N, p, p_limbs, MBEDTLS_MPI_MOD_REP_OPT_RED);
     N->rep.ored =ored ;
     return 0;
 }

--- a/library/bignum_mod.c
+++ b/library/bignum_mod.c
@@ -137,9 +137,9 @@ cleanup:
 }
 
 static inline void standard_modulus_setup(mbedtls_mpi_mod_modulus *N,
-                                         const mbedtls_mpi_uint *p,
-                                         size_t p_limbs,
-                                         mbedtls_mpi_mod_rep_selector int_rep)
+                                          const mbedtls_mpi_uint *p,
+                                          size_t p_limbs,
+                                          mbedtls_mpi_mod_rep_selector int_rep)
 {
     N->p = p;
     N->limbs = p_limbs;
@@ -169,7 +169,7 @@ int mbedtls_mpi_mod_optred_modulus_setup(mbedtls_mpi_mod_modulus *N,
                                          mbedtls_mpi_opt_red_struct *ored)
 {
     standard_modulus_setup(N, p, p_limbs, MBEDTLS_MPI_MOD_REP_OPT_RED);
-    N->rep.ored =ored ;
+    N->rep.ored = ored;
     return 0;
 }
 

--- a/library/bignum_mod.h
+++ b/library/bignum_mod.h
@@ -208,6 +208,23 @@ int mbedtls_mpi_mod_modulus_setup(mbedtls_mpi_mod_modulus *N,
                                   size_t p_limbs,
                                   mbedtls_mpi_mod_rep_selector int_rep);
 
+/** Setup an optimised-reduction compatible modulus structure.
+ *
+ * \param[out] N    The address of the modulus structure to populate.
+ * \param[in] p     The address of the limb array storing the value of \p N.
+ *                  The memory pointed to by \p p will be used by \p N and must
+ *                  not be modified in any way until after
+ *                  mbedtls_mpi_mod_modulus_free() is called.
+ * \param p_limbs   The number of limbs of \p p.
+ * \param ored      The optimized reduction structure to use. \p p.
+ *
+ * \return      \c 0 if successful.
+ */
+int mbedtls_mpi_mod_optred_modulus_setup(mbedtls_mpi_mod_modulus *N,
+                                         const mbedtls_mpi_uint *p,
+                                         size_t p_limbs,
+                                         mbedtls_mpi_opt_red_struct *ored);
+
 /** Free elements of a modulus structure.
  *
  * This function frees any memory allocated by mbedtls_mpi_mod_modulus_setup().

--- a/library/bignum_mod.h
+++ b/library/bignum_mod.h
@@ -197,16 +197,12 @@ void mbedtls_mpi_mod_modulus_init(mbedtls_mpi_mod_modulus *N);
  *                  not be modified in any way until after
  *                  mbedtls_mpi_mod_modulus_free() is called.
  * \param p_limbs   The number of limbs of \p p.
- * \param int_rep   The internal representation to be used for residues
- *                  associated with \p N (see #mbedtls_mpi_mod_rep_selector).
  *
  * \return      \c 0 if successful.
- * \return      #MBEDTLS_ERR_MPI_BAD_INPUT_DATA if \p int_rep is invalid.
  */
 int mbedtls_mpi_mod_modulus_setup(mbedtls_mpi_mod_modulus *N,
                                   const mbedtls_mpi_uint *p,
-                                  size_t p_limbs,
-                                  mbedtls_mpi_mod_rep_selector int_rep);
+                                  size_t p_limbs);
 
 /** Setup an optimised-reduction compatible modulus structure.
  *

--- a/library/ecp_curves.c
+++ b/library/ecp_curves.c
@@ -5966,8 +5966,7 @@ int mbedtls_ecp_modulus_setup(mbedtls_mpi_mod_modulus *N,
             return MBEDTLS_ERR_ECP_BAD_INPUT_DATA;
     }
 
-    if (mbedtls_mpi_mod_modulus_setup(N, p, p_limbs,
-                                      MBEDTLS_MPI_MOD_REP_MONTGOMERY)) {
+    if (mbedtls_mpi_mod_modulus_setup(N, p, p_limbs)) {
         return MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     }
     return 0;

--- a/tests/src/bignum_helpers.c
+++ b/tests/src/bignum_helpers.c
@@ -99,7 +99,18 @@ int mbedtls_test_read_mpi_modulus(mbedtls_mpi_mod_modulus *N,
     if (ret != 0) {
         return ret;
     }
-    ret = mbedtls_mpi_mod_modulus_setup(N, p, limbs, int_rep);
+
+    switch (int_rep) {
+        case MBEDTLS_MPI_MOD_REP_MONTGOMERY:
+            ret = mbedtls_mpi_mod_modulus_setup(N, p, limbs);
+            break;
+        case MBEDTLS_MPI_MOD_REP_OPT_RED:
+            ret = mbedtls_mpi_mod_optred_modulus_setup(N, p, limbs, NULL);
+            break;
+        default:
+            ret = MBEDTLS_ERR_MPI_BAD_INPUT_DATA;
+            break;
+    }
     if (ret != 0) {
         mbedtls_free(p);
     }

--- a/tests/suites/test_suite_bignum_mod.function
+++ b/tests/suites/test_suite_bignum_mod.function
@@ -110,7 +110,7 @@ void mpi_mod_mul(char *input_A,
     mbedtls_mpi_mod_modulus_init(&m);
 
     TEST_EQUAL(mbedtls_test_read_mpi_modulus(&m, input_N,
-               MBEDTLS_MPI_MOD_REP_MONTGOMERY), 0);
+                                             MBEDTLS_MPI_MOD_REP_MONTGOMERY), 0);
 
     TEST_EQUAL(test_read_residue(&rA, &m, input_A, 0), 0);
     TEST_EQUAL(test_read_residue(&rB, &m, input_B, 0), 0);
@@ -198,7 +198,7 @@ void mpi_mod_mul_neg(char *input_A,
     mbedtls_mpi_mod_modulus_init(&fake_m);
 
     TEST_EQUAL(mbedtls_test_read_mpi_modulus(&m, input_N,
-               MBEDTLS_MPI_MOD_REP_MONTGOMERY), 0);
+                                             MBEDTLS_MPI_MOD_REP_MONTGOMERY), 0);
 
     TEST_EQUAL(test_read_residue(&rA, &m, input_A, 1), 0);
     TEST_EQUAL(test_read_residue(&rB, &m, input_B, 1), 0);
@@ -245,7 +245,7 @@ void mpi_mod_sub(char *input_N,
 
     TEST_EQUAL(0,
                mbedtls_test_read_mpi_modulus(&m, input_N,
-               MBEDTLS_MPI_MOD_REP_MONTGOMERY));
+                                             MBEDTLS_MPI_MOD_REP_MONTGOMERY));
 
     /* test_read_residue() normally checks that inputs have the same number of
      * limbs as the modulus. For negative testing we can ask it to skip this
@@ -347,7 +347,7 @@ void mpi_mod_inv_mont(char *input_N,
 
     TEST_EQUAL(0,
                mbedtls_test_read_mpi_modulus(&N, input_N,
-               MBEDTLS_MPI_MOD_REP_MONTGOMERY));
+                                             MBEDTLS_MPI_MOD_REP_MONTGOMERY));
 
     /* test_read_residue() normally checks that inputs have the same number of
      * limbs as the modulus. For negative testing we can ask it to skip this
@@ -397,7 +397,7 @@ void mpi_mod_inv_non_mont(char *input_N,
 
     TEST_EQUAL(0,
                mbedtls_test_read_mpi_modulus(&N, input_N,
-               MBEDTLS_MPI_MOD_REP_OPT_RED));
+                                             MBEDTLS_MPI_MOD_REP_OPT_RED));
 
     /* test_read_residue() normally checks that inputs have the same number of
      * limbs as the modulus. For negative testing we can ask it to skip this
@@ -448,7 +448,7 @@ void mpi_mod_add(char *input_N,
 
     TEST_EQUAL(0,
                mbedtls_test_read_mpi_modulus(&m, input_N,
-               MBEDTLS_MPI_MOD_REP_MONTGOMERY));
+                                             MBEDTLS_MPI_MOD_REP_MONTGOMERY));
 
     /* test_read_residue() normally checks that inputs have the same number of
      * limbs as the modulus. For negative testing we can ask it to skip this

--- a/tests/suites/test_suite_bignum_mod.function
+++ b/tests/suites/test_suite_bignum_mod.function
@@ -50,7 +50,19 @@ void mpi_mod_setup(int int_rep, int iret)
     memset(mp, 0xFF, sizeof(mp));
 
     mbedtls_mpi_mod_modulus_init(&m);
-    ret = mbedtls_mpi_mod_modulus_setup(&m, mp, MLIMBS, int_rep);
+
+    switch (int_rep) {
+        case MBEDTLS_MPI_MOD_REP_MONTGOMERY:
+            ret = mbedtls_mpi_mod_modulus_setup(&m, mp, MLIMBS);
+            break;
+        case MBEDTLS_MPI_MOD_REP_OPT_RED:
+            ret = mbedtls_mpi_mod_optred_modulus_setup(&m, mp, MLIMBS, NULL);
+            break;
+        default:
+            ret = MBEDTLS_ERR_MPI_BAD_INPUT_DATA;
+            break;
+    }
+
     TEST_EQUAL(ret, iret);
 
     /* Only test if the constants have been set-up  */
@@ -539,8 +551,7 @@ void mpi_residue_setup(char *input_N, char *input_R, int ret)
     TEST_EQUAL(0, mbedtls_test_read_mpi_core(&N, &n_limbs, input_N));
     TEST_EQUAL(0, mbedtls_test_read_mpi_core(&R, &r_limbs, input_R));
 
-    TEST_EQUAL(0, mbedtls_mpi_mod_modulus_setup(&m, N, n_limbs,
-                                                MBEDTLS_MPI_MOD_REP_MONTGOMERY));
+    TEST_EQUAL(0, mbedtls_mpi_mod_modulus_setup(&m, N, n_limbs));
 
     TEST_EQUAL(ret, mbedtls_mpi_mod_residue_setup(&r, &m, R, r_limbs));
 
@@ -581,8 +592,7 @@ void mpi_mod_io_neg(char *input_N, data_t *buf, int ret)
                mbedtls_mpi_mod_write(&r, &m, buf->x, buf->len, endian));
 
     /* Set up modulus and test with residue->p == NULL */
-    TEST_EQUAL(0, mbedtls_mpi_mod_modulus_setup(&m, N, n_limbs,
-                                                MBEDTLS_MPI_MOD_REP_MONTGOMERY));
+    TEST_EQUAL(0, mbedtls_mpi_mod_modulus_setup(&m, N, n_limbs));
 
     TEST_EQUAL(MBEDTLS_ERR_MPI_BAD_INPUT_DATA,
                mbedtls_mpi_mod_read(&r, &m, buf->x, buf->len, endian));
@@ -655,8 +665,7 @@ void mpi_mod_io(char *input_N, data_t *input_A, int endian)
     TEST_LE_U(a_bytes, n_bytes);
 
     /* Init Structures */
-    TEST_EQUAL(0, mbedtls_mpi_mod_modulus_setup(&m, N, n_limbs,
-                                                MBEDTLS_MPI_MOD_REP_MONTGOMERY));
+    TEST_EQUAL(0, mbedtls_mpi_mod_modulus_setup(&m, N, n_limbs));
 
     /* Enforcing p_limbs >= m->limbs */
     TEST_EQUAL(0, mbedtls_mpi_mod_residue_setup(&r, &m, R, n_limbs));

--- a/tests/suites/test_suite_bignum_mod.function
+++ b/tests/suites/test_suite_bignum_mod.function
@@ -10,21 +10,6 @@
     ASSERT_COMPARE((a).p, (a).limbs * sizeof(mbedtls_mpi_uint), \
                    (b).p, (b).limbs * sizeof(mbedtls_mpi_uint))
 
-static int test_read_modulus(mbedtls_mpi_mod_modulus *m,
-                             mbedtls_mpi_mod_rep_selector int_rep,
-                             char *input)
-{
-    mbedtls_mpi_uint *p = NULL;
-    size_t limbs;
-
-    int ret = mbedtls_test_read_mpi_core(&p, &limbs, input);
-    if (ret != 0) {
-        return ret;
-    }
-
-    return mbedtls_mpi_mod_modulus_setup(m, p, limbs, int_rep);
-}
-
 static int test_read_residue(mbedtls_mpi_mod_residue *r,
                              const mbedtls_mpi_mod_modulus *m,
                              char *input,
@@ -112,8 +97,8 @@ void mpi_mod_mul(char *input_A,
     mbedtls_mpi_mod_modulus m;
     mbedtls_mpi_mod_modulus_init(&m);
 
-    TEST_EQUAL(test_read_modulus(&m, MBEDTLS_MPI_MOD_REP_MONTGOMERY, input_N),
-               0);
+    TEST_EQUAL(mbedtls_test_read_mpi_modulus(&m, input_N,
+               MBEDTLS_MPI_MOD_REP_MONTGOMERY), 0);
 
     TEST_EQUAL(test_read_residue(&rA, &m, input_A, 0), 0);
     TEST_EQUAL(test_read_residue(&rB, &m, input_B, 0), 0);
@@ -200,8 +185,8 @@ void mpi_mod_mul_neg(char *input_A,
     mbedtls_mpi_mod_modulus fake_m;
     mbedtls_mpi_mod_modulus_init(&fake_m);
 
-    TEST_EQUAL(test_read_modulus(&m, MBEDTLS_MPI_MOD_REP_MONTGOMERY, input_N),
-               0);
+    TEST_EQUAL(mbedtls_test_read_mpi_modulus(&m, input_N,
+               MBEDTLS_MPI_MOD_REP_MONTGOMERY), 0);
 
     TEST_EQUAL(test_read_residue(&rA, &m, input_A, 1), 0);
     TEST_EQUAL(test_read_residue(&rB, &m, input_B, 1), 0);
@@ -247,7 +232,8 @@ void mpi_mod_sub(char *input_N,
     mbedtls_mpi_mod_modulus_init(&m);
 
     TEST_EQUAL(0,
-               test_read_modulus(&m, MBEDTLS_MPI_MOD_REP_MONTGOMERY, input_N));
+               mbedtls_test_read_mpi_modulus(&m, input_N,
+               MBEDTLS_MPI_MOD_REP_MONTGOMERY));
 
     /* test_read_residue() normally checks that inputs have the same number of
      * limbs as the modulus. For negative testing we can ask it to skip this
@@ -348,7 +334,8 @@ void mpi_mod_inv_mont(char *input_N,
     mbedtls_mpi_mod_modulus_init(&N);
 
     TEST_EQUAL(0,
-               test_read_modulus(&N, MBEDTLS_MPI_MOD_REP_MONTGOMERY, input_N));
+               mbedtls_test_read_mpi_modulus(&N, input_N,
+               MBEDTLS_MPI_MOD_REP_MONTGOMERY));
 
     /* test_read_residue() normally checks that inputs have the same number of
      * limbs as the modulus. For negative testing we can ask it to skip this
@@ -397,7 +384,8 @@ void mpi_mod_inv_non_mont(char *input_N,
     mbedtls_mpi_mod_modulus_init(&N);
 
     TEST_EQUAL(0,
-               test_read_modulus(&N, MBEDTLS_MPI_MOD_REP_OPT_RED, input_N));
+               mbedtls_test_read_mpi_modulus(&N, input_N,
+               MBEDTLS_MPI_MOD_REP_OPT_RED));
 
     /* test_read_residue() normally checks that inputs have the same number of
      * limbs as the modulus. For negative testing we can ask it to skip this
@@ -447,7 +435,8 @@ void mpi_mod_add(char *input_N,
     mbedtls_mpi_mod_modulus_init(&m);
 
     TEST_EQUAL(0,
-               test_read_modulus(&m, MBEDTLS_MPI_MOD_REP_MONTGOMERY, input_N));
+               mbedtls_test_read_mpi_modulus(&m, input_N,
+               MBEDTLS_MPI_MOD_REP_MONTGOMERY));
 
     /* test_read_residue() normally checks that inputs have the same number of
      * limbs as the modulus. For negative testing we can ask it to skip this

--- a/tests/suites/test_suite_bignum_mod_raw.function
+++ b/tests/suites/test_suite_bignum_mod_raw.function
@@ -54,8 +54,7 @@ void mpi_mod_raw_io(data_t *input, int nb_int, int nx_32_int,
 
     mbedtls_mpi_uint init[sizeof(X) / sizeof(X[0])];
     memset(init, 0xFF, sizeof(init));
-    int ret = mbedtls_mpi_mod_modulus_setup(&m, init, nx,
-                                            MBEDTLS_MPI_MOD_REP_MONTGOMERY);
+    int ret = mbedtls_mpi_mod_modulus_setup(&m, init, nx);
     TEST_EQUAL(ret, 0);
 
     if (iendian == MBEDTLS_MPI_MOD_EXT_REP_INVALID && iret != 0) {
@@ -137,8 +136,7 @@ void mpi_mod_raw_cond_assign(char *input_X,
     ASSERT_ALLOC(buff_m, copy_limbs);
     memset(buff_m, 0xFF, copy_limbs);
     TEST_EQUAL(mbedtls_mpi_mod_modulus_setup(
-                   &m, buff_m, copy_limbs,
-                   MBEDTLS_MPI_MOD_REP_MONTGOMERY), 0);
+                   &m, buff_m, copy_limbs), 0);
 
     /* condition is false */
     TEST_CF_SECRET(X, bytes);
@@ -208,8 +206,7 @@ void mpi_mod_raw_cond_swap(char *input_X,
     ASSERT_ALLOC(buff_m, copy_limbs);
     memset(buff_m, 0xFF, copy_limbs);
     TEST_EQUAL(mbedtls_mpi_mod_modulus_setup(
-                   &m, buff_m, copy_limbs,
-                   MBEDTLS_MPI_MOD_REP_MONTGOMERY), 0);
+                   &m, buff_m, copy_limbs), 0);
 
     ASSERT_ALLOC(X, limbs);
     memcpy(X, tmp_X, bytes);
@@ -297,8 +294,7 @@ void mpi_mod_raw_sub(char *input_A,
     ASSERT_ALLOC(X, limbs);
 
     TEST_EQUAL(mbedtls_mpi_mod_modulus_setup(
-                   &m, N, limbs,
-                   MBEDTLS_MPI_MOD_REP_MONTGOMERY), 0);
+                   &m, N, limbs), 0);
 
     mbedtls_mpi_mod_raw_sub(X, A, B, &m);
     ASSERT_COMPARE(X, bytes, res, bytes);
@@ -368,8 +364,7 @@ void mpi_mod_raw_fix_quasi_reduction(char *input_N,
     TEST_ASSERT(c || mbedtls_mpi_core_lt_ct(tmp, N, limbs));
 
     TEST_EQUAL(mbedtls_mpi_mod_modulus_setup(
-                   &m, N, limbs,
-                   MBEDTLS_MPI_MOD_REP_MONTGOMERY), 0);
+                   &m, N, limbs), 0);
 
     mbedtls_mpi_mod_raw_fix_quasi_reduction(X, &m);
     ASSERT_COMPARE(X, bytes, res, bytes);
@@ -419,8 +414,7 @@ void mpi_mod_raw_mul(char *input_A,
     ASSERT_ALLOC(X, limbs);
 
     TEST_EQUAL(mbedtls_mpi_mod_modulus_setup(
-                   &m, N, limbs,
-                   MBEDTLS_MPI_MOD_REP_MONTGOMERY), 0);
+                   &m, N, limbs), 0);
 
     const size_t limbs_T = limbs * 2 + 1;
     ASSERT_ALLOC(T, limbs_T);
@@ -580,9 +574,7 @@ void mpi_mod_raw_add(char *input_N,
     ASSERT_ALLOC(X, limbs);
 
     TEST_EQUAL(mbedtls_mpi_mod_modulus_setup(
-                   &m, N, limbs,
-                   MBEDTLS_MPI_MOD_REP_MONTGOMERY
-                   ), 0);
+                   &m, N, limbs), 0);
 
     /* A + B => Correct result */
     mbedtls_mpi_mod_raw_add(X, A, B, &m);
@@ -720,8 +712,7 @@ void mpi_mod_raw_to_mont_rep(char *input_N, char *input_A, char *input_X)
     size_t limbs = n_limbs;
     size_t bytes = limbs * sizeof(mbedtls_mpi_uint);
 
-    TEST_EQUAL(0, mbedtls_mpi_mod_modulus_setup(&m, N, n_limbs,
-                                                MBEDTLS_MPI_MOD_REP_MONTGOMERY));
+    TEST_EQUAL(0, mbedtls_mpi_mod_modulus_setup(&m, N, n_limbs));
 
     /* 1. Test low-level function first */
 
@@ -785,8 +776,7 @@ void mpi_mod_raw_from_mont_rep(char *input_N, char *input_A, char *input_X)
     size_t limbs = n_limbs;
     size_t bytes = limbs * sizeof(mbedtls_mpi_uint);
 
-    TEST_EQUAL(0, mbedtls_mpi_mod_modulus_setup(&m, N, n_limbs,
-                                                MBEDTLS_MPI_MOD_REP_MONTGOMERY));
+    TEST_EQUAL(0, mbedtls_mpi_mod_modulus_setup(&m, N, n_limbs));
 
     /* 1. Test low-level function first */
 
@@ -847,8 +837,7 @@ void mpi_mod_raw_neg(char *input_N, char *input_A, char *input_X)
     ASSERT_ALLOC(R, n_limbs);
     ASSERT_ALLOC(Z, n_limbs);
 
-    TEST_EQUAL(0, mbedtls_mpi_mod_modulus_setup(&m, N, n_limbs,
-                                                MBEDTLS_MPI_MOD_REP_MONTGOMERY));
+    TEST_EQUAL(0, mbedtls_mpi_mod_modulus_setup(&m, N, n_limbs));
 
     /* Neg( A == 0 ) => Zero result */
     mbedtls_mpi_mod_raw_neg(R, Z, &m);

--- a/tests/suites/test_suite_ecp.function
+++ b/tests/suites/test_suite_ecp.function
@@ -1366,8 +1366,7 @@ void ecp_mod_p_generic_raw(int curve_id,
     TEST_EQUAL(limbs_res, limbs_N);
 
     TEST_EQUAL(mbedtls_mpi_mod_modulus_setup(
-                   &m, N, limbs_N,
-                   MBEDTLS_MPI_MOD_REP_OPT_RED), 0);
+                   &m, N, limbs_N), 0);
 
     TEST_EQUAL((*curve_func)(X, limbs_X), 0);
 


### PR DESCRIPTION
## Description

This PR implements the first step of the design discussed in #7268. It is intended to prepare the code-base for when the dependencies of optimised reduction have been merged.

In short this PR is implementing exactly what is described and agreed in [this design proposal](https://github.com/Mbed-TLS/mbedtls/issues/7268#issuecomment-1541602418) and is a result of the design agreed on #7264 

## PR checklist

- [x] **changelog** Not Required. This is a new Interface and will not be backported
- [x] **backport** Not Required. This is a new Interface and will not be backported
- [x] **tests** Not required. This change does not introduce new functionality that need to be test. Modulus lifecycle is already being tested, and OptRed lifecycle will be tested in the following PR



