### PR TITLE
AES perf improvements

### DIFF
--- a/ChangeLog.d/aes-perf.txt
+++ b/ChangeLog.d/aes-perf.txt
@@ -1,4 +1,4 @@
 Features
    * AES performance improvements on 64-bit architectures. Uplift
-     varies by platform, toolchain and mode, in the 0 - 54% range.
-     Aarch64, gcc -Os and GCM/XTS benefit the most.
+     varies by platform, toolchain, optimisation flags and mode,
+     in the 0 - 84% range. Aarch64, gcc and GCM/XTS benefit the most.

--- a/ChangeLog.d/aes-perf.txt
+++ b/ChangeLog.d/aes-perf.txt
@@ -1,3 +1,4 @@
 Features
-   * AES performance improvements (XTS, GCM, CCM and CMAC) on 64-bit
-     architectures, of around 5-10%.
+   * AES performance improvements on 64-bit architectures. Uplift
+     varies by platform, toolchain and mode, in the 0 - 54% range.
+     Aarch64, gcc -Os and GCM/XTS benefit the most.

--- a/ChangeLog.d/aes-perf.txt
+++ b/ChangeLog.d/aes-perf.txt
@@ -1,0 +1,3 @@
+Features
+   * AES performance improvements (XTS, GCM, CCM and CMAC) on 64-bit
+     architectures, of around 5-10%.

--- a/library/aes.c
+++ b/library/aes.c
@@ -1068,6 +1068,8 @@ int mbedtls_aes_crypt_cbc(mbedtls_aes_context *ctx,
     }
 #endif
 
+    const unsigned char *ivp = iv;
+
     if (mode == MBEDTLS_AES_DECRYPT) {
         while (length > 0) {
             memcpy(temp, input, 16);
@@ -1086,18 +1088,19 @@ int mbedtls_aes_crypt_cbc(mbedtls_aes_context *ctx,
         }
     } else {
         while (length > 0) {
-            mbedtls_xor(temp, input, iv, 16);
+            mbedtls_xor(output, input, ivp, 16);
 
-            ret = mbedtls_aes_crypt_ecb(ctx, mode, temp, iv);
-            memcpy(output, iv, 16);
+            ret = mbedtls_aes_crypt_ecb(ctx, mode, output, output);
             if (ret != 0) {
                 goto exit;
             }
+            ivp = output;
 
             input  += 16;
             output += 16;
             length -= 16;
         }
+        memcpy(iv, ivp, 16);
     }
     ret = 0;
 

--- a/library/aes.c
+++ b/library/aes.c
@@ -1069,15 +1069,14 @@ int mbedtls_aes_crypt_cbc(mbedtls_aes_context *ctx,
 #endif
 
     if (mode == MBEDTLS_AES_DECRYPT) {
-        unsigned char temp2[16];
         while (length > 0) {
             memcpy(temp, input, 16);
-            ret = mbedtls_aes_crypt_ecb(ctx, mode, input, temp2);
+            ret = mbedtls_aes_crypt_ecb(ctx, mode, input, output);
             if (ret != 0) {
                 goto exit;
             }
 
-            mbedtls_xor(output, temp2, iv, 16);
+            mbedtls_xor(output, output, iv, 16);
 
             memcpy(iv, temp, 16);
 

--- a/library/aes.c
+++ b/library/aes.c
@@ -1071,26 +1071,21 @@ int mbedtls_aes_crypt_cbc(mbedtls_aes_context *ctx,
     const unsigned char *ivp = iv;
 
     if (mode == MBEDTLS_AES_DECRYPT) {
-        if (length >= 16) {
-            unsigned char temp2[16];
-            memcpy(temp, input + length - 16, 16);
-
-            while (length > 0) {
-                ret = mbedtls_aes_crypt_ecb(ctx, mode, input, temp2);
-                if (ret != 0) {
-                    goto exit;
-                }
-
-                mbedtls_xor(output, temp2, ivp, 16);
-
-                ivp = input;
-
-                input  += 16;
-                output += 16;
-                length -= 16;
+        unsigned char temp2[16];
+        while (length > 0) {
+            memcpy(temp, input, 16);
+            ret = mbedtls_aes_crypt_ecb(ctx, mode, input, temp2);
+            if (ret != 0) {
+                goto exit;
             }
 
+            mbedtls_xor(output, temp2, iv, 16);
+
             memcpy(iv, temp, 16);
+
+            input  += 16;
+            output += 16;
+            length -= 16;
         }
     } else {
         while (length > 0) {

--- a/library/aes.c
+++ b/library/aes.c
@@ -1068,36 +1068,45 @@ int mbedtls_aes_crypt_cbc(mbedtls_aes_context *ctx,
     }
 #endif
 
+    const unsigned char *ivp = iv;
+
     if (mode == MBEDTLS_AES_DECRYPT) {
-        while (length > 0) {
-            memcpy(temp, input, 16);
-            ret = mbedtls_aes_crypt_ecb(ctx, mode, input, output);
-            if (ret != 0) {
-                goto exit;
+        if (length >= 16) {
+            unsigned char temp2[16];
+            memcpy(temp, input + length - 16, 16);
+
+            while (length > 0) {
+                ret = mbedtls_aes_crypt_ecb(ctx, mode, input, temp2);
+                if (ret != 0) {
+                    goto exit;
+                }
+
+                mbedtls_xor(output, temp2, ivp, 16);
+
+                ivp = input;
+
+                input  += 16;
+                output += 16;
+                length -= 16;
             }
 
-            mbedtls_xor(output, output, iv, 16);
-
             memcpy(iv, temp, 16);
-
-            input  += 16;
-            output += 16;
-            length -= 16;
         }
     } else {
         while (length > 0) {
-            mbedtls_xor(output, input, iv, 16);
+            mbedtls_xor(output, input, ivp, 16);
 
             ret = mbedtls_aes_crypt_ecb(ctx, mode, output, output);
             if (ret != 0) {
                 goto exit;
             }
-            memcpy(iv, output, 16);
+            ivp = output;
 
             input  += 16;
             output += 16;
             length -= 16;
         }
+        memcpy(iv, ivp, 16);
     }
     ret = 0;
 

--- a/library/aes.c
+++ b/library/aes.c
@@ -1068,8 +1068,6 @@ int mbedtls_aes_crypt_cbc(mbedtls_aes_context *ctx,
     }
 #endif
 
-    const unsigned char *ivp = iv;
-
     if (mode == MBEDTLS_AES_DECRYPT) {
         unsigned char temp2[16];
         while (length > 0) {
@@ -1089,19 +1087,18 @@ int mbedtls_aes_crypt_cbc(mbedtls_aes_context *ctx,
         }
     } else {
         while (length > 0) {
-            mbedtls_xor(output, input, ivp, 16);
+            mbedtls_xor(temp, input, iv, 16);
 
-            ret = mbedtls_aes_crypt_ecb(ctx, mode, output, output);
+            ret = mbedtls_aes_crypt_ecb(ctx, mode, temp, iv);
+            memcpy(output, iv, 16);
             if (ret != 0) {
                 goto exit;
             }
-            ivp = output;
 
             input  += 16;
             output += 16;
             length -= 16;
         }
-        memcpy(iv, ivp, 16);
     }
     ret = 0;
 

--- a/library/aes.c
+++ b/library/aes.c
@@ -1037,17 +1037,17 @@ int mbedtls_aes_crypt_ecb(mbedtls_aes_context *ctx,
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
 
 #if defined(__ARM_NEON) && defined(__aarch64__)
-            /* Avoid using the NEON implementation of mbedtls_xor. Because of the dependency on
-             * the result for the next block in CBC, and the cost of transferring that data from
-             * NEON registers, it is faster to use the following on aarch64.
-             * For 32-bit arm, NEON should be faster. */
+/* Avoid using the NEON implementation of mbedtls_xor. Because of the dependency on
+ * the result for the next block in CBC, and the cost of transferring that data from
+ * NEON registers, it is faster to use the following on aarch64.
+ * For 32-bit arm, NEON should be faster. */
 #define CBC_XOR_16(r, a, b) do {                                           \
-            mbedtls_put_unaligned_uint64(r,                                    \
-                                         mbedtls_get_unaligned_uint64(a) ^     \
-                                         mbedtls_get_unaligned_uint64(b));     \
-            mbedtls_put_unaligned_uint64(r + 8,                                \
-                                         mbedtls_get_unaligned_uint64(a + 8) ^ \
-                                         mbedtls_get_unaligned_uint64(b + 8)); \
+        mbedtls_put_unaligned_uint64(r,                                    \
+                                     mbedtls_get_unaligned_uint64(a) ^     \
+                                     mbedtls_get_unaligned_uint64(b));     \
+        mbedtls_put_unaligned_uint64(r + 8,                                \
+                                     mbedtls_get_unaligned_uint64(a + 8) ^ \
+                                     mbedtls_get_unaligned_uint64(b + 8)); \
 } while (0)
 #else
 #define CBC_XOR_16(r, a, b) mbedtls_xor(r, a, b, 16)

--- a/library/aes.c
+++ b/library/aes.c
@@ -1172,7 +1172,7 @@ int mbedtls_aes_crypt_xts(mbedtls_aes_xts_context *ctx,
     }
 
     while (blocks--) {
-        if (leftover && (mode == MBEDTLS_AES_DECRYPT) && blocks == 0) {
+        if (MBEDTLS_UNLIKELY(leftover && (mode == MBEDTLS_AES_DECRYPT) && blocks == 0)) {
             /* We are on the last block in a decrypt operation that has
              * leftover bytes, so we need to use the next tweak for this block,
              * and this tweak for the leftover bytes. Save the current tweak for

--- a/library/common.h
+++ b/library/common.h
@@ -185,8 +185,8 @@ inline void mbedtls_xor(unsigned char *r, const unsigned char *a, const unsigned
 /* Define compiler branch hints */
 #if defined(__has_builtin)
 #if __has_builtin(__builtin_expect)
-#define MBEDTLS_LIKELY(x)       __builtin_expect((x),1)
-#define MBEDTLS_UNLIKELY(x)     __builtin_expect((x),0)
+#define MBEDTLS_LIKELY(x)       __builtin_expect((x), 1)
+#define MBEDTLS_UNLIKELY(x)     __builtin_expect((x), 0)
 #endif
 #endif
 #if !defined(MBEDTLS_LIKELY)

--- a/library/common.h
+++ b/library/common.h
@@ -142,11 +142,12 @@ inline void mbedtls_xor(unsigned char *r, const unsigned char *a, const unsigned
         uint64_t x = mbedtls_get_unaligned_uint64(a + i) ^ mbedtls_get_unaligned_uint64(b + i);
         mbedtls_put_unaligned_uint64(r + i, x);
     }
-#endif
+#else
     for (; (i + 4) <= n; i += 4) {
         uint32_t x = mbedtls_get_unaligned_uint32(a + i) ^ mbedtls_get_unaligned_uint32(b + i);
         mbedtls_put_unaligned_uint32(r + i, x);
     }
+#endif
 #endif
     for (; i < n; i++) {
         r[i] = a[i] ^ b[i];

--- a/library/common.h
+++ b/library/common.h
@@ -182,4 +182,16 @@ inline void mbedtls_xor(unsigned char *r, const unsigned char *a, const unsigned
 #define MBEDTLS_STATIC_ASSERT(expr, msg)
 #endif
 
+/* Define compiler branch hints */
+#if defined(__has_builtin)
+#if __has_builtin(__builtin_expect)
+#define MBEDTLS_LIKELY(x)       __builtin_expect((x),1)
+#define MBEDTLS_UNLIKELY(x)     __builtin_expect((x),0)
+#endif
+#endif
+#if !defined(MBEDTLS_LIKELY)
+#define MBEDTLS_LIKELY(x)       x
+#define MBEDTLS_UNLIKELY(x)     x
+#endif
+
 #endif /* MBEDTLS_LIBRARY_COMMON_H */

--- a/library/common.h
+++ b/library/common.h
@@ -31,7 +31,7 @@
 #include <stdint.h>
 #include <stddef.h>
 
-#ifdef __ARM_NEON
+#if defined(__ARM_NEON)
 #include <arm_neon.h>
 #endif /* __ARM_NEON */
 
@@ -129,7 +129,7 @@ inline void mbedtls_xor(unsigned char *r, const unsigned char *a, const unsigned
 {
     size_t i = 0;
 #if defined(MBEDTLS_EFFICIENT_UNALIGNED_ACCESS)
-#if defined(__aarch64__) && defined(__ARM_NEON)
+#if defined(__ARM_NEON)
     for (; (i + 16) <= n; i += 16) {
         uint64x2_t v1 = vld1q_u64((uint64_t *) (a + i));
         uint64x2_t v2 = vld1q_u64((uint64_t *) (b + i));

--- a/library/common.h
+++ b/library/common.h
@@ -125,6 +125,13 @@ inline void mbedtls_xor(unsigned char *r, const unsigned char *a, const unsigned
 {
     size_t i = 0;
 #if defined(MBEDTLS_EFFICIENT_UNALIGNED_ACCESS)
+#if defined(__amd64__) || defined(__x86_64__) || defined(__aarch64__)
+    /* This codepath probably only makes sense on architectures with 64-bit registers */
+    for (; (i + 8) <= n; i += 8) {
+        uint64_t x = mbedtls_get_unaligned_uint64(a + i) ^ mbedtls_get_unaligned_uint64(b + i);
+        mbedtls_put_unaligned_uint64(r + i, x);
+    }
+#endif
     for (; (i + 4) <= n; i += 4) {
         uint32_t x = mbedtls_get_unaligned_uint32(a + i) ^ mbedtls_get_unaligned_uint32(b + i);
         mbedtls_put_unaligned_uint32(r + i, x);

--- a/library/common.h
+++ b/library/common.h
@@ -131,10 +131,10 @@ inline void mbedtls_xor(unsigned char *r, const unsigned char *a, const unsigned
 #if defined(MBEDTLS_EFFICIENT_UNALIGNED_ACCESS)
 #if defined(__ARM_NEON)
     for (; (i + 16) <= n; i += 16) {
-        uint64x2_t v1 = vld1q_u64((uint64_t *) (a + i));
-        uint64x2_t v2 = vld1q_u64((uint64_t *) (b + i));
-        uint64x2_t x = veorq_u64(v1, v2);
-        vst1q_u64((uint64_t *) (r + i), x);
+        uint8x16_t v1 = vld1q_u8((uint64_t *) (a + i));
+        uint8x16_t v2 = vld1q_u8((uint64_t *) (b + i));
+        uint8x16_t x = veorq_u8(v1, v2);
+        vst1q_u8((uint64_t *) (r + i), x);
     }
 #elif defined(__amd64__) || defined(__x86_64__) || defined(__aarch64__)
     /* This codepath probably only makes sense on architectures with 64-bit registers */

--- a/library/common.h
+++ b/library/common.h
@@ -131,10 +131,10 @@ inline void mbedtls_xor(unsigned char *r, const unsigned char *a, const unsigned
 #if defined(MBEDTLS_EFFICIENT_UNALIGNED_ACCESS)
 #if defined(__aarch64__) && defined(__ARM_NEON)
     for (; (i + 16) <= n; i += 16) {
-        uint64x2_t v1 = vld1q_u64((uint64_t *) a);
-        uint64x2_t v2 = vld1q_u64((uint64_t *) b);
+        uint64x2_t v1 = vld1q_u64((uint64_t *) (a + i));
+        uint64x2_t v2 = vld1q_u64((uint64_t *) (b + i));
         uint64x2_t x = veorq_u64(v1, v2);
-        vst1q_u64((uint64_t *) r, x);
+        vst1q_u64((uint64_t *) (r + i), x);
     }
 #elif defined(__amd64__) || defined(__x86_64__) || defined(__aarch64__)
     /* This codepath probably only makes sense on architectures with 64-bit registers */

--- a/library/common.h
+++ b/library/common.h
@@ -131,10 +131,10 @@ inline void mbedtls_xor(unsigned char *r, const unsigned char *a, const unsigned
 #if defined(MBEDTLS_EFFICIENT_UNALIGNED_ACCESS)
 #if defined(__ARM_NEON)
     for (; (i + 16) <= n; i += 16) {
-        uint8x16_t v1 = vld1q_u8((uint64_t *) (a + i));
-        uint8x16_t v2 = vld1q_u8((uint64_t *) (b + i));
+        uint8x16_t v1 = vld1q_u8(a + i);
+        uint8x16_t v2 = vld1q_u8(b + i);
         uint8x16_t x = veorq_u8(v1, v2);
-        vst1q_u8((uint64_t *) (r + i), x);
+        vst1q_u8(r + i, x);
     }
 #elif defined(__amd64__) || defined(__x86_64__) || defined(__aarch64__)
     /* This codepath probably only makes sense on architectures with 64-bit registers */

--- a/tests/suites/test_suite_common.data
+++ b/tests/suites/test_suite_common.data
@@ -18,3 +18,45 @@ mbedtls_xor:8
 
 Block xor, length 16
 mbedtls_xor:16
+
+Block xor, length 64
+mbedtls_xor:64
+
+Block xor, length 256
+mbedtls_xor:256
+
+Block xor, length 257
+mbedtls_xor:257
+
+Block xor, length 16+8
+mbedtls_xor:24
+
+Block xor, length 16+8+4
+mbedtls_xor:28
+
+Block xor, length 16+8+4+1
+mbedtls_xor:29
+
+Block xor, length 16+8+1
+mbedtls_xor:25
+
+Block xor, length 16+4
+mbedtls_xor:20
+
+Block xor, length 16+4+1
+mbedtls_xor:21
+
+Block xor, length 16+1
+mbedtls_xor:17
+
+Block xor, length 8+4
+mbedtls_xor:12
+
+Block xor, length 8+4+1
+mbedtls_xor:13
+
+Block xor, length 8+1
+mbedtls_xor:9
+
+Block xor, length 4+1
+mbedtls_xor:5


### PR DESCRIPTION
## Description

This improves block-XOR performance on architectures with 64-bit registers, which benefits mostly AES (presumably because use of AESCE / AESNI is fast so the XOR part is more significant than other ciphers).

I've modified the AES-CBC implementation to make better use of this and also eliminated some unnecessary memcpy's, which has improved AES-CBC performance everywhere (around 7%-11%).

Performance uplift is quite varied depending on compiler (clang vs gcc), optimisation level (O2 vs Os) and mode (all measurements on M1 Pro). Everything is same-or-faster (only clang -Os XTS is the same; everything else sees some uplift). gcc gets most benefit (around 30% average over the different modes and optimisation levels). clang averages around 8% uplift overall. Biggest win is AES-XTS (61-85% on gcc -O2); GCM gets 11-58% uplift (gcc -Os is 44-58%; everything else is 11-17%).

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** provided
- [x] **backport** not required - not a bugfix
- [x] **tests** covered by existing tests
