### PR TITLE
Support compilation using CLang on Windows

### DIFF
--- a/ChangeLog.d/fix-win32-llvm-build.txt
+++ b/ChangeLog.d/fix-win32-llvm-build.txt
@@ -1,0 +1,2 @@
+Bugfix
+   * Fix builds on Windows with clang

--- a/library/aesni.c
+++ b/library/aesni.c
@@ -35,6 +35,8 @@
 #if MBEDTLS_AESNI_HAVE_CODE == 2
 #if !defined(_WIN32)
 #include <cpuid.h>
+#else
+#include <intrin.h>
 #endif
 #include <immintrin.h>
 #endif


### PR DESCRIPTION
## Description

The Microsoft-only equivalent to GCC's `cpuid.h` is `intrin.h`. CLang contains both, but neither is directly included in Win32 builds, causing `__cpuid` to not be defined. This change explicitly includes `intrin.h` when `cpuid.h` is not used.



## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [X] **changelog** not required - In built versions, nothing has changed. This only influences build on environments that previously suffered a compile-time error.
- [x] **backport** - #7823
- [X] **tests** not required - Only affects build. If build fails, all tests fail.



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.
