### PR TITLE
Remove extraneous check in for loop condition

### DIFF
--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1155,8 +1155,7 @@ static int ssl_handshake_init(mbedtls_ssl_context *ssl)
         size_t length;
         const mbedtls_ecp_group_id *curve_list = ssl->conf->curve_list;
 
-        for (length = 0;  (curve_list[length] != MBEDTLS_ECP_DP_NONE) &&
-             (length < MBEDTLS_ECP_DP_MAX); length++) {
+        for (length = 0;  (curve_list[length] != MBEDTLS_ECP_DP_NONE); length++) {
         }
 
         /* Leave room for zero termination */


### PR DESCRIPTION
Fixes #7529.

## Description

Issue 7529 uncovered an unrequired check in a for loop condition in ssl_tls.c. This PR removes said check.

## PR checklist

- [x] **changelog**  - Not provided: not a user visible change.
- [x] **backport** - Not required: doesn't exist in 2.28.
- [x] **tests** - Not required, covered by existing tests.
