### PR TITLE
[Backport 2.28] Fix demo scripts for out-of-tree builds

### DIFF
--- a/programs/psa/key_ladder_demo.sh
+++ b/programs/psa/key_ladder_demo.sh
@@ -17,8 +17,26 @@
 
 set -e -u
 
-program="${0%/*}"/key_ladder_demo
+program_name="key_ladder_demo"
+program="${0%/*}/$program_name"
 files_to_clean=
+
+if [ ! -e "$program" ]; then
+    # Look for programs in the current directory and the directories above it
+    for dir in "." ".." "../.."; do
+        program="$dir/programs/psa/$program_name"
+        if [ -e "$program" ]; then
+            break
+        fi
+    done
+    if [ ! -e "$program" ]; then
+        echo "Could not find $program_name executable"
+
+        echo "If building out-of-tree, this script must be run" \
+             "from the project build directory."
+        exit 1
+    fi
+fi
 
 run () {
     echo

--- a/programs/test/dlopen_demo.sh
+++ b/programs/test/dlopen_demo.sh
@@ -20,8 +20,29 @@
 
 set -e -u
 
+program_name="dlopen"
 program_dir="${0%/*}"
-program="$program_dir/dlopen"
+program="$program_dir/$program_name"
+
+if [ ! -e "$program" ]; then
+    # Look for programs in the current directory and the directories above it
+    for dir in "." ".." "../.."; do
+        program_dir="$dir/programs/test"
+        program="$program_dir/$program_name"
+        if [ -e "$program" ]; then
+            break
+        fi
+    done
+    if [ ! -e "$program" ]; then
+        echo "Could not find $program_name program"
+
+        echo "Make sure that Mbed TLS is built as a shared library." \
+             "If building out-of-tree, this script must be run" \
+             "from the project build directory."
+        exit 1
+    fi
+fi
+
 top_dir="$program_dir/../.."
 library_dir="$top_dir/library"
 


### PR DESCRIPTION
Trivial backport of #5237.


## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required - minor change to scripts
- [x] **backport** #5237
- [x] **tests** not required - minor script change
