### PR TITLE
[2.28 backport] Fix bad keyfile prereqs

### DIFF
--- a/tests/data_files/Makefile
+++ b/tests/data_files/Makefile
@@ -41,8 +41,8 @@ test_ca_key_file_rsa = test-ca.key
 test_ca_pwd_rsa = PolarSSLTest
 test_ca_config_file = test-ca.opensslconf
 
-$(test_ca_key_file_rsa):$(test_ca_pwd_rsa)
-    $(OPENSSL) genrsa -aes-128-cbc -passout pass:$< -out $@ 2048
+$(test_ca_key_file_rsa):
+	$(OPENSSL) genrsa -aes-128-cbc -passout pass:$(test_ca_pwd_rsa) -out $@ 2048
 all_final += $(test_ca_key_file_rsa)
 
 test-ca.req.sha256: $(test_ca_key_file_rsa)


### PR DESCRIPTION
## Description

Backport of https://github.com/Mbed-TLS/mbedtls/pull/7634.
https://github.com/Mbed-TLS/mbedtls/commit/b17f6a211daa6df3d7783f9a1373ba21fe8ca117 from https://github.com/Mbed-TLS/mbedtls/pull/7416 introduced a Makefile target that has two issues: missing tab and a prerequisite that's not a file. This PR fixes that.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required - it's a test data change
- [x] **backport** - this is a backport
- [x] **tests** manual tests done
