### PR TITLE
Fix: correct calling to time function in tls13 client&server

### DIFF
--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -1696,7 +1696,7 @@ static int ssl_tls13_parse_server_hello(mbedtls_ssl_context *ssl,
                               cipher_suite, ciphersuite_info->name));
 
 #if defined(MBEDTLS_HAVE_TIME)
-    ssl->session_negotiate->start = time(NULL);
+    ssl->session_negotiate->start = mbedtls_time(NULL);
 #endif /* MBEDTLS_HAVE_TIME */
 
     /* ...

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1846,7 +1846,7 @@ static int ssl_tls13_prepare_server_hello(mbedtls_ssl_context *ssl)
                           MBEDTLS_SERVER_HELLO_RANDOM_LEN);
 
 #if defined(MBEDTLS_HAVE_TIME)
-    ssl->session_negotiate->start = time(NULL);
+    ssl->session_negotiate->start = mbedtls_time(NULL);
 #endif /* MBEDTLS_HAVE_TIME */
 
     return ret;


### PR DESCRIPTION
## Description

In `library/ssl_tls13_client.c` and `library/ssl_tls13_server.c`, calling to `time` function need to be changed to `mbedtls_time` to handle the case when `MBEDTLS_PLATFORM_TIME_MACRO` is defined.

This PR will close #7655

## PR checklist

- [x] **changelog** not required
- [x] **backport** no (no such code in 2.28)
- [x] **tests** not required


## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.
