### PR TITLE
Fix armclang compile fail

### DIFF
--- a/ChangeLog.d/armclang-compile-fix.txt
+++ b/ChangeLog.d/armclang-compile-fix.txt
@@ -1,4 +1,5 @@
 Bugfix
    * Fix armclang compilation error when targetting certain Arm M-class CPUs
-     (Cortex-M0, Cortex-M0+, Cortex-M1, Cortex-M23, SecurCore SC000).
-     Fixes #1077.
+     (Cortex-M0, Cortex-M0+, Cortex-M1, Cortex-M23, SecurCore SC000). Enable
+     bignum optimisations for most Arm platforms when compiling with -O0,
+     (previously optimisations were not available in this case). Fixes #1077.

--- a/ChangeLog.d/armclang-compile-fix.txt
+++ b/ChangeLog.d/armclang-compile-fix.txt
@@ -1,5 +1,5 @@
 Bugfix
-   * Fix armclang compilation error when targetting certain Arm M-class CPUs
+   * Fix armclang compilation error when targeting certain Arm M-class CPUs
      (Cortex-M0, Cortex-M0+, Cortex-M1, Cortex-M23, SecurCore SC000). Enable
      bignum optimisations for most Arm platforms when compiling with -O0,
      (previously optimisations were not available in this case). Fixes #1077.

--- a/ChangeLog.d/armclang-compile-fix.txt
+++ b/ChangeLog.d/armclang-compile-fix.txt
@@ -1,5 +1,7 @@
 Bugfix
-   * Fix armclang compilation error when targeting certain Arm M-class CPUs
-     (Cortex-M0, Cortex-M0+, Cortex-M1, Cortex-M23, SecurCore SC000). Enable
-     bignum optimisations for most Arm platforms when compiling with -O0,
-     (previously optimisations were not available in this case). Fixes #1077.
+   * Fix clang and armclang compilation error when targeting certain Arm
+     M-class CPUs (Cortex-M0, Cortex-M0+, Cortex-M1, Cortex-M23,
+     SecurCore SC000). Fixes #1077.
+Changes
+   * Enable Arm / Thumb bignum assembly for most Arm platforms when
+     compiling with gcc, clang or armclang and -O0.

--- a/ChangeLog.d/armclang-compile-fix.txt
+++ b/ChangeLog.d/armclang-compile-fix.txt
@@ -1,3 +1,4 @@
 Bugfix
-   * Fix armclang compilation error when targetting certain Arm M-class CPUs (Cortex-M0,
-     Cortex-M0+, Cortex-M1, Cortex-M23, SecurCore SC000). Fixes #1077.
+   * Fix armclang compilation error when targetting certain Arm M-class CPUs
+     (Cortex-M0, Cortex-M0+, Cortex-M1, Cortex-M23, SecurCore SC000).
+     Fixes #1077.

--- a/ChangeLog.d/armclang-compile-fix.txt
+++ b/ChangeLog.d/armclang-compile-fix.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix armclang compilation error when targetting certain Arm M-class CPUs (Cortex-M0,
+     Cortex-M0+, Cortex-M1, Cortex-M23, SecurCore SC000). Fixes #1077.

--- a/library/bn_mul.h
+++ b/library/bn_mul.h
@@ -671,6 +671,8 @@
  * clang and armcc5 under the same conditions).
  */
 
+#if defined(__ARM_ARCH)
+#if __ARM_ARCH >= 6
 
 #if defined(__thumb__) && !defined(__thumb2__) // Thumb1 (not Thumb 2) ISA
 // Only supported by gcc, when optimisation is enabled; only option A works
@@ -696,6 +698,9 @@
 #elif defined(__arm__) // Arm ISA
 // any option builds. A does not seem to work; B is about 2x faster than C (under emulation).
 #define ARM_OPTION_B
+#endif
+
+#endif
 #endif
 
 #if defined(ARM_OPTION_A)

--- a/library/bn_mul.h
+++ b/library/bn_mul.h
@@ -684,15 +684,15 @@
  * instructions to preserve/restore it; otherwise, we can use r7 and avoid
  * the preserve/restore overhead.
  */
-#define MULADDC_SCRATCH         "RS .req r1         \n\t"
-#define MULADDC_PRESERVE_R1     "mov    r10, r1     \n\t"
-#define MULADDC_RESTORE_R1      "mov    r1, r10     \n\t"
-#define MULADDC_SCRATCH_CLOBBER "r10"
+#define MULADDC_SCRATCH              "RS .req r1         \n\t"
+#define MULADDC_PRESERVE_SCRATCH     "mov    r10, r1     \n\t"
+#define MULADDC_RESTORE_SCRATCH      "mov    r1, r10     \n\t"
+#define MULADDC_SCRATCH_CLOBBER      "r10"
 #else /* !defined(__OPTIMIZE__) && defined(__GNUC__) */
-#define MULADDC_SCRATCH         "RS .req r7         \n\t"
-#define MULADDC_PRESERVE_R1     ""
-#define MULADDC_RESTORE_R1      ""
-#define MULADDC_SCRATCH_CLOBBER "r7"
+#define MULADDC_SCRATCH              "RS .req r7         \n\t"
+#define MULADDC_PRESERVE_SCRATCH     ""
+#define MULADDC_RESTORE_SCRATCH      ""
+#define MULADDC_SCRATCH_CLOBBER      "r7"
 #endif /* !defined(__OPTIMIZE__) && defined(__GNUC__) */
 
 #define MULADDC_X1_INIT                                 \
@@ -710,7 +710,7 @@
 
 
 #define MULADDC_X1_CORE                                 \
-            MULADDC_PRESERVE_R1                         \
+            MULADDC_PRESERVE_SCRATCH                         \
             "ldmia  r0!, {r6}                   \n\t"   \
             "lsr    RS, r6, #16                 \n\t"   \
             "lsl    r6, r6, #16                 \n\t"   \
@@ -736,7 +736,7 @@
             "lsl    r3, RS, #16                 \n\t"   \
             "add    r4, r4, r3                  \n\t"   \
             "adc    r5, r2                      \n\t"   \
-            MULADDC_RESTORE_R1                          \
+            MULADDC_RESTORE_SCRATCH                          \
             "ldr    r3, [r1]                    \n\t"   \
             "add    r4, r4, r3                  \n\t"   \
             "adc    r2, r5                      \n\t"   \

--- a/library/bn_mul.h
+++ b/library/bn_mul.h
@@ -673,13 +673,13 @@
 #if defined(__thumb__) && !defined(__thumb2__) // Thumb 1 (not Thumb 2) ISA
 
     // Only supported by gcc, when optimisation is enabled; only Thumb 1 codepath works
-    #if defined(__OPTIMIZE__) && !defined(__ARMCC_VERSION)
+    #if defined(__OPTIMIZE__) && defined(__GNUC__)
     #define ARM_THUMB_1
     #endif
 
 #elif defined(__thumb2__) // Thumb 2 ISA
 
-    #if !defined(__ARMCC_VERSION) && !defined(__OPTIMIZE__)
+    #if defined(__GNUC__) && !defined(__OPTIMIZE__)
         // gcc -O0: only V6+DSP codepath builds
         #if (__ARM_ARCH >= 6) && defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1)
         #define ARM_V6_DSP

--- a/library/bn_mul.h
+++ b/library/bn_mul.h
@@ -710,7 +710,7 @@
 
 
 #define MULADDC_X1_CORE                                 \
-            MULADDC_PRESERVE_SCRATCH                         \
+            MULADDC_PRESERVE_SCRATCH                    \
             "ldmia  r0!, {r6}                   \n\t"   \
             "lsr    RS, r6, #16                 \n\t"   \
             "lsl    r6, r6, #16                 \n\t"   \
@@ -736,7 +736,7 @@
             "lsl    r3, RS, #16                 \n\t"   \
             "add    r4, r4, r3                  \n\t"   \
             "adc    r5, r2                      \n\t"   \
-            MULADDC_RESTORE_SCRATCH                          \
+            MULADDC_RESTORE_SCRATCH                     \
             "ldr    r3, [r1]                    \n\t"   \
             "add    r4, r4, r3                  \n\t"   \
             "adc    r2, r5                      \n\t"   \
@@ -822,8 +822,7 @@
         );                                                   \
     }
 
-#else
-/* Thumb 2 or Arm ISA, without DSP extensions */
+#else /* Thumb 2 or Arm ISA, without DSP extensions */
 
 #define MULADDC_X1_INIT                                 \
     asm(                                                \

--- a/library/bn_mul.h
+++ b/library/bn_mul.h
@@ -670,11 +670,7 @@
  * x !=0, which we can detect using __OPTIMIZE__ (which is also defined by
  * clang and armcc5 under the same conditions).
  */
-
-//#if defined(__ARM_ARCH)
-//#if __ARM_ARCH >= 6
-
-#if defined(__thumb__) && !defined(__thumb2__) // Thumb1 (not Thumb 2) ISA
+#if defined(__thumb__) && !defined(__thumb2__) // Thumb 1 (not Thumb 2) ISA
 
     // Only supported by gcc, when optimisation is enabled; only option A works
     #if defined(__OPTIMIZE__) && !defined(__ARMCC_VERSION)
@@ -685,7 +681,7 @@
 
     #if !defined(__ARMCC_VERSION) && !defined(__OPTIMIZE__)
         // gcc -O0: only option B builds
-        #if defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1)
+        #if (__ARM_ARCH >= 6) && defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1)
         #define ARM_OPTION_B
         #endif
     #else
@@ -698,18 +694,16 @@
     // any option builds. A does not seem to work; B is about 2x faster than C (under emulation).
     #define ARM_OPTION_B_OR_C
 
-#endif
+#endif /* Arm ISA selection */
 
 #if defined(ARM_OPTION_B_OR_C)
+// Prefer B, if we have the right features for it
 #if (__ARM_ARCH >= 6) && defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1)
 #define ARM_OPTION_B
 #else
 #define ARM_OPTION_C
 #endif
-#endif
-
-//#endif
-//#endif
+#endif /* defined(ARM_OPTION_B_OR_C) */
 
 #if defined(ARM_OPTION_A)
 

--- a/library/bn_mul.h
+++ b/library/bn_mul.h
@@ -659,39 +659,46 @@
 #endif /* TriCore */
 
 /*
+ * There is a fairly complex matrix of supported options for Thumb / Thumb2 / Arm
+ * assembly. Choosing the correct code path depends on the target, the compiler,
+ * and the optimisation level.
+ *
  * Note, gcc -O0 by default uses r7 for the frame pointer, so it complains about
  * our use of r7 below, unless -fomit-frame-pointer is passed.
  *
  * On the other hand, -fomit-frame-pointer is implied by any -Ox options with
  * x !=0, which we can detect using __OPTIMIZE__ (which is also defined by
  * clang and armcc5 under the same conditions).
- *
- * So, only use the optimized assembly below for optimized build, which avoids
- * the build error and is pretty reasonable anyway.
  */
-#if defined(__GNUC__) && !defined(__OPTIMIZE__)
-#define MULADDC_CANNOT_USE_R7
+
+
+#if defined(__thumb__) && !defined(__thumb2__) // Thumb1 (not Thumb 2) ISA
+// Only supported by gcc, when optimisation is enabled; only option A works
+#if defined(__OPTIMIZE__) && !defined(__ARMCC_VERSION)
+#define ARM_OPTION_A
 #endif
 
-/*
- * Similarly, we need to disable the assembly below if:
- * - compiler is armclang
- * - optimisation is not -O0
- * - target is Thumb
- * - target cpu is one of cortex-m0, cortex-m0plus, cortex-m1, cortex-m23, sc000
- *
- * Checking for __ARM_ARCH_6M__ or __ARM_ARCH_8M_BASE__ seems to identify exactly these
- * cpus and no others (tested against all values for -mcpu known to armclang 6.20).
- */
-#if defined(__ARMCC_VERSION) && defined(__OPTIMIZE__) && defined(__thumb__)
-#if defined(__ARM_ARCH_8M_BASE__) || defined(__ARM_ARCH_6M__)
-#define MULADDC_CANNOT_USE_R7
-#endif
+#elif defined(__thumb2__) // Thumb 2 ISA
+
+#if !defined(__ARMCC_VERSION) && !defined(__OPTIMIZE__)
+// gcc -O0
+// only option B builds
+#define ARM_OPTION_B
+#elif !defined(__ARMCC_VERSION)
+// gcc with optimisation - any option builds
+#define ARM_OPTION_A
+#else
+// armclang
+// options A or C build
+#define ARM_OPTION_A
 #endif
 
-#if defined(__arm__) && !defined(MULADDC_CANNOT_USE_R7)
+#elif defined(__arm__) // Arm ISA
+// any option builds. A does not seem to work; B is about 2x faster than C (under emulation).
+#define ARM_OPTION_B
+#endif
 
-#if defined(__thumb__) && !defined(__thumb2__)
+#if defined(ARM_OPTION_A)
 
 #define MULADDC_X1_INIT                                 \
     asm(                                                \
@@ -746,8 +753,7 @@
            "r6", "r7", "r8", "r9", "cc"         \
          );
 
-#elif (__ARM_ARCH >= 6) && \
-    defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1)
+#elif defined(ARM_OPTION_B)
 
 #define MULADDC_X1_INIT                            \
     {                                              \
@@ -812,7 +818,7 @@
         );                                                   \
     }
 
-#else
+#elif defined(ARM_OPTION_C)
 
 #define MULADDC_X1_INIT                                 \
     asm(                                                \
@@ -840,9 +846,7 @@
            "r6", "r7", "cc"                     \
          );
 
-#endif /* Thumb */
-
-#endif /* ARMv3 */
+#endif /* Arm */
 
 #if defined(__alpha__)
 

--- a/library/bn_mul.h
+++ b/library/bn_mul.h
@@ -660,7 +660,8 @@
 
 #if defined(__arm__)
 
-#if defined(__thumb__) && !defined(__thumb2__) && !defined(__ARMCC_VERSION)
+#if defined(__thumb__) && !defined(__thumb2__)
+#if !defined(__ARMCC_VERSION)
 /*
  * Thumb 1 ISA. This code path does not work on armclang.
  */
@@ -745,10 +746,13 @@
          : "r0", "r1", "r2", "r3", "r4", "r5",  \
            "r6", MULADDC_SCRATCH_CLOBBER, "r8", "r9", "cc" \
          );
+#endif /* !defined(__ARMCC_VERSION) */
 
 #elif (__ARM_ARCH >= 6) && \
     defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1)
-/* Armv6-M with DSP Instruction Set Extensions */
+/* Armv6-M (or later) with DSP Instruction Set Extensions.
+ * Requires support for either Thumb 2 or Arm ISA.
+ */
 
 #define MULADDC_X1_INIT                            \
     {                                              \
@@ -813,7 +817,7 @@
         );                                                   \
     }
 
-#elif defined(__thumb2__) || !defined(__thumb__)
+#else
 /* Thumb 2 or Arm ISA, without DSP extensions */
 
 #define MULADDC_X1_INIT                                 \

--- a/library/bn_mul.h
+++ b/library/bn_mul.h
@@ -660,7 +660,7 @@
 
 /*
  * There is a fairly complex matrix of supported options for Thumb / Thumb2 / Arm
- * assembly. Choosing the correct code path depends on the target, the compiler,
+ * assembly. Choosing the correct codepath depends on the target, the compiler,
  * and the optimisation level.
  *
  * Note, gcc -O0 by default uses r7 for the frame pointer, so it complains about
@@ -672,7 +672,7 @@
  */
 #if defined(__thumb__) && !defined(__thumb2__) // Thumb 1 (not Thumb 2) ISA
 
-    // Only supported by gcc, when optimisation is enabled; only option A works
+    // Only supported by gcc, when optimisation is enabled; only Thumb 1 codepath works
     #if defined(__OPTIMIZE__) && !defined(__ARMCC_VERSION)
     #define ARM_THUMB_1
     #endif
@@ -680,24 +680,26 @@
 #elif defined(__thumb2__) // Thumb 2 ISA
 
     #if !defined(__ARMCC_VERSION) && !defined(__OPTIMIZE__)
-        // gcc -O0: only option B builds
+        // gcc -O0: only V6+DSP codepath builds
         #if (__ARM_ARCH >= 6) && defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1)
         #define ARM_V6_DSP
         #endif
     #else
-        // gcc with optimisation, or armclang: any option builds
+        // gcc with optimisation, or armclang: any codepath builds
         #define ARM_V6_DSP_OR_THUMB_2
     #endif
 
 #elif defined(__arm__) // Arm ISA
 
-    // any option builds. A does not seem to work; B is about 2x faster than C (under emulation).
+    // any option builds. Thumb 1 codepath does not seem to work.
     #define ARM_V6_DSP_OR_THUMB_2
 
 #endif /* Arm ISA selection */
 
 #if defined(ARM_V6_DSP_OR_THUMB_2)
-// Prefer B, if we have the right features for it
+// Prefer V6+DSP codepath, if we have the right features for it; otherwise
+// fall back to generic Thumb 2 / Arm codepath
+// V6+DSP codepath is about 2x faster than Thumb 2 (under emulation).
 #if (__ARM_ARCH >= 6) && defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1)
 #define ARM_V6_DSP
 #else

--- a/library/bn_mul.h
+++ b/library/bn_mul.h
@@ -671,37 +671,45 @@
  * clang and armcc5 under the same conditions).
  */
 
-#if defined(__ARM_ARCH)
-#if __ARM_ARCH >= 6
+//#if defined(__ARM_ARCH)
+//#if __ARM_ARCH >= 6
 
 #if defined(__thumb__) && !defined(__thumb2__) // Thumb1 (not Thumb 2) ISA
-// Only supported by gcc, when optimisation is enabled; only option A works
-#if defined(__OPTIMIZE__) && !defined(__ARMCC_VERSION)
-#define ARM_OPTION_A
-#endif
+
+    // Only supported by gcc, when optimisation is enabled; only option A works
+    #if defined(__OPTIMIZE__) && !defined(__ARMCC_VERSION)
+    #define ARM_OPTION_A
+    #endif
 
 #elif defined(__thumb2__) // Thumb 2 ISA
 
-#if !defined(__ARMCC_VERSION) && !defined(__OPTIMIZE__)
-// gcc -O0
-// only option B builds
-#define ARM_OPTION_B
-#elif !defined(__ARMCC_VERSION)
-// gcc with optimisation - any option builds
-#define ARM_OPTION_A
-#else
-// armclang
-// options A or C build
-#define ARM_OPTION_A
-#endif
+    #if !defined(__ARMCC_VERSION) && !defined(__OPTIMIZE__)
+        // gcc -O0: only option B builds
+        #if defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1)
+        #define ARM_OPTION_B
+        #endif
+    #else
+        // gcc with optimisation, or armclang: any option builds
+        #define ARM_OPTION_B_OR_C
+    #endif
 
 #elif defined(__arm__) // Arm ISA
-// any option builds. A does not seem to work; B is about 2x faster than C (under emulation).
-#define ARM_OPTION_B
-#endif
+
+    // any option builds. A does not seem to work; B is about 2x faster than C (under emulation).
+    #define ARM_OPTION_B_OR_C
 
 #endif
+
+#if defined(ARM_OPTION_B_OR_C)
+#if (__ARM_ARCH >= 6) && defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1)
+#define ARM_OPTION_B
+#else
+#define ARM_OPTION_C
 #endif
+#endif
+
+//#endif
+//#endif
 
 #if defined(ARM_OPTION_A)
 

--- a/library/bn_mul.h
+++ b/library/bn_mul.h
@@ -661,9 +661,14 @@
 #if defined(__arm__)
 
 #if defined(__thumb__) && !defined(__thumb2__)
-#if !defined(__ARMCC_VERSION) && !defined(__clang__)
+#if !defined(__ARMCC_VERSION) && !defined(__clang__) \
+    && !defined(__llvm__) && !defined(__INTEL_COMPILER)
 /*
- * Thumb 1 ISA. This code path does not build on clang or armclang.
+ * Thumb 1 ISA. This code path has only been tested successfully on gcc;
+ * it does not compile on clang or armclang.
+ *
+ * Other compilers which define __GNUC__ may not work. The above macro
+ * attempts to exclude these untested compilers.
  */
 
 #if !defined(__OPTIMIZE__) && defined(__GNUC__)

--- a/library/bn_mul.h
+++ b/library/bn_mul.h
@@ -674,7 +674,7 @@
 
     // Only supported by gcc, when optimisation is enabled; only option A works
     #if defined(__OPTIMIZE__) && !defined(__ARMCC_VERSION)
-    #define ARM_OPTION_A
+    #define ARM_THUMB_1
     #endif
 
 #elif defined(__thumb2__) // Thumb 2 ISA
@@ -682,30 +682,30 @@
     #if !defined(__ARMCC_VERSION) && !defined(__OPTIMIZE__)
         // gcc -O0: only option B builds
         #if (__ARM_ARCH >= 6) && defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1)
-        #define ARM_OPTION_B
+        #define ARM_V6_DSP
         #endif
     #else
         // gcc with optimisation, or armclang: any option builds
-        #define ARM_OPTION_B_OR_C
+        #define ARM_V6_DSP_OR_THUMB_2
     #endif
 
 #elif defined(__arm__) // Arm ISA
 
     // any option builds. A does not seem to work; B is about 2x faster than C (under emulation).
-    #define ARM_OPTION_B_OR_C
+    #define ARM_V6_DSP_OR_THUMB_2
 
 #endif /* Arm ISA selection */
 
-#if defined(ARM_OPTION_B_OR_C)
+#if defined(ARM_V6_DSP_OR_THUMB_2)
 // Prefer B, if we have the right features for it
 #if (__ARM_ARCH >= 6) && defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1)
-#define ARM_OPTION_B
+#define ARM_V6_DSP
 #else
-#define ARM_OPTION_C
+#define ARM_THUMB_2
 #endif
-#endif /* defined(ARM_OPTION_B_OR_C) */
+#endif /* defined(ARM_V6_DSP_OR_THUMB_2) */
 
-#if defined(ARM_OPTION_A)
+#if defined(ARM_THUMB_1)
 
 #define MULADDC_X1_INIT                                 \
     asm(                                                \
@@ -760,7 +760,7 @@
            "r6", "r7", "r8", "r9", "cc"         \
          );
 
-#elif defined(ARM_OPTION_B)
+#elif defined(ARM_V6_DSP)
 
 #define MULADDC_X1_INIT                            \
     {                                              \
@@ -825,7 +825,7 @@
         );                                                   \
     }
 
-#elif defined(ARM_OPTION_C)
+#elif defined(ARM_THUMB_2)
 
 #define MULADDC_X1_INIT                                 \
     asm(                                                \

--- a/library/bn_mul.h
+++ b/library/bn_mul.h
@@ -661,9 +661,9 @@
 #if defined(__arm__)
 
 #if defined(__thumb__) && !defined(__thumb2__)
-#if !defined(__ARMCC_VERSION)
+#if !defined(__ARMCC_VERSION) && !defined(__clang__)
 /*
- * Thumb 1 ISA. This code path does not work on armclang.
+ * Thumb 1 ISA. This code path does not build on clang or armclang.
  */
 
 #if !defined(__OPTIMIZE__) && defined(__GNUC__)
@@ -746,7 +746,7 @@
          : "r0", "r1", "r2", "r3", "r4", "r5",  \
            "r6", MULADDC_SCRATCH_CLOBBER, "r8", "r9", "cc" \
          );
-#endif /* !defined(__ARMCC_VERSION) */
+#endif /* !defined(__ARMCC_VERSION) && !defined(__clang__) */
 
 #elif (__ARM_ARCH >= 6) && \
     defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1)

--- a/library/bn_mul.h
+++ b/library/bn_mul.h
@@ -679,15 +679,8 @@
 
 #elif defined(__thumb2__) // Thumb 2 ISA
 
-    #if defined(__GNUC__) && !defined(__OPTIMIZE__)
-        // gcc -O0: only V6+DSP codepath builds
-        #if (__ARM_ARCH >= 6) && defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1)
-        #define ARM_V6_DSP
-        #endif
-    #else
-        // gcc with optimisation, or armclang: any codepath builds
-        #define ARM_V6_DSP_OR_THUMB_2
-    #endif
+    // Any codepath builds.
+    #define ARM_V6_DSP_OR_THUMB_2
 
 #elif defined(__arm__) // Arm ISA
 
@@ -841,9 +834,9 @@
             "mov    r5, #0                      \n\t"   \
             "ldr    r6, [r1]                    \n\t"   \
             "umlal  r2, r5, r3, r4              \n\t"   \
-            "adds   r7, r6, r2                  \n\t"   \
+            "adds   r4, r6, r2                  \n\t"   \
             "adc    r2, r5, #0                  \n\t"   \
-            "str    r7, [r1], #4                \n\t"
+            "str    r4, [r1], #4                \n\t"
 
 #define MULADDC_X1_STOP                                 \
             "str    r2, %0                      \n\t"   \
@@ -852,7 +845,7 @@
          : "=m" (c),  "=m" (d), "=m" (s)        \
          : "m" (s), "m" (d), "m" (c), "m" (b)   \
          : "r0", "r1", "r2", "r3", "r4", "r5",  \
-           "r6", "r7", "cc"                     \
+           "r6", "cc"                     \
          );
 
 #endif /* Arm */

--- a/library/bn_mul.h
+++ b/library/bn_mul.h
@@ -673,6 +673,22 @@
 #define MULADDC_CANNOT_USE_R7
 #endif
 
+/*
+ * Similarly, we need to disable the assembly below if:
+ * - compiler is armclang
+ * - optimisation is not -O0
+ * - target is Thumb
+ * - target cpu is one of cortex-m0, cortex-m0plus, cortex-m1, cortex-m23, sc000
+ *
+ * Checking for __ARM_ARCH_6M__ or __ARM_ARCH_8M_BASE__ seems to identify exactly these
+ * cpus and no others (tested against all values for -mcpu known to armclang 6.20).
+ */
+#if defined(__ARMCC_VERSION) && defined(__OPTIMIZE__) && defined(__thumb__)
+#if defined(__ARM_ARCH_8M_BASE__) || defined(__ARM_ARCH_6M__)
+#define MULADDC_CANNOT_USE_R7
+#endif
+#endif
+
 #if defined(__arm__) && !defined(MULADDC_CANNOT_USE_R7)
 
 #if defined(__thumb__) && !defined(__thumb2__)

--- a/library/bn_mul.h
+++ b/library/bn_mul.h
@@ -658,42 +658,14 @@
 
 #endif /* TriCore */
 
+#if defined(__arm__)
+
+#if defined(__thumb__) && !defined(__thumb2__) && !defined(__ARMCC_VERSION)
 /*
- * There is a fairly complex matrix of supported options for Thumb / Thumb2 / Arm
- * assembly. Choosing the correct codepath depends on the target, the compiler,
- * and the optimisation level.
+ * Thumb 1 ISA. This code path does not work on armclang.
  */
-#if defined(__thumb__) && !defined(__thumb2__) // Thumb 1 (not Thumb 2) ISA
 
-    // Only supported by gcc, when optimisation is enabled; only Thumb 1 codepath works
-    #define ARM_THUMB_1
-
-#elif defined(__thumb2__) // Thumb 2 ISA
-
-    // Any codepath builds.
-    #define ARM_V6_DSP_OR_THUMB_2
-
-#elif defined(__arm__) // Arm ISA
-
-    // any option builds. Thumb 1 codepath does not seem to work.
-    #define ARM_V6_DSP_OR_THUMB_2
-
-#endif /* Arm ISA selection */
-
-#if defined(ARM_V6_DSP_OR_THUMB_2)
-// Prefer V6+DSP codepath, if we have the right features for it; otherwise
-// fall back to generic Thumb 2 / Arm codepath
-// V6+DSP codepath is about 2x faster than Thumb 2 (under emulation).
-#if (__ARM_ARCH >= 6) && defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1)
-#define ARM_V6_DSP
-#else
-#define ARM_THUMB_2
-#endif
-#endif /* defined(ARM_V6_DSP_OR_THUMB_2) */
-
-#if defined(ARM_THUMB_1)
-
-#if defined(__OPTIMIZE__) && defined(__GNUC__)
+#if !defined(__OPTIMIZE__) && defined(__GNUC__)
 /*
  * Note, gcc -O0 by default uses r7 for the frame pointer, so it complains about
  * our use of r7 below, unless -fomit-frame-pointer is passed.
@@ -710,12 +682,12 @@
 #define MULADDC_PRESERVE_R1     "mov    r10, r1     \n\t"
 #define MULADDC_RESTORE_R1      "mov    r1, r10     \n\t"
 #define MULADDC_SCRATCH_CLOBBER "r10"
-#else
+#else /* !defined(__OPTIMIZE__) && defined(__GNUC__) */
 #define MULADDC_SCRATCH         "RS .req r7         \n\t"
 #define MULADDC_PRESERVE_R1     ""
 #define MULADDC_RESTORE_R1      ""
 #define MULADDC_SCRATCH_CLOBBER "r7"
-#endif
+#endif /* !defined(__OPTIMIZE__) && defined(__GNUC__) */
 
 #define MULADDC_X1_INIT                                 \
     asm(                                                \
@@ -774,7 +746,9 @@
            "r6", MULADDC_SCRATCH_CLOBBER, "r8", "r9", "cc" \
          );
 
-#elif defined(ARM_V6_DSP)
+#elif (__ARM_ARCH >= 6) && \
+    defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1)
+/* Armv6-M with DSP Instruction Set Extensions */
 
 #define MULADDC_X1_INIT                            \
     {                                              \
@@ -839,7 +813,8 @@
         );                                                   \
     }
 
-#elif defined(ARM_THUMB_2)
+#elif defined(__thumb2__) || !defined(__thumb__)
+/* Thumb 2 or Arm ISA, without DSP extensions */
 
 #define MULADDC_X1_INIT                                 \
     asm(                                                \
@@ -867,7 +842,9 @@
            "r6", "cc"                     \
          );
 
-#endif /* Arm */
+#endif /* ISA codepath selection */
+
+#endif /* defined(__arm__) */
 
 #if defined(__alpha__)
 

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -3894,6 +3894,9 @@ component_build_armcc () {
 
     # ARM Compiler 6 - Target ARMv8.2-A - AArch64
     armc6_build_test "-O1 --target=aarch64-arm-none-eabi -march=armv8.2-a+crypto"
+
+    # ARM Compiler 6 - Target Cortex-M0
+    armc6_build_test "-Os --target=arm-arm-none-eabi -mcpu=cortex-m0"
 }
 support_build_armcc () {
     armc5_cc="$ARMC5_BIN_DIR/armcc"

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -3894,7 +3894,7 @@ component_build_armcc () {
 
     make clean
 
-    # Compile with -O1 since some Arm inline assembly is disabled for -O0.
+    # Compile mostly with -O1 since some Arm inline assembly is disabled for -O0.
 
     # ARM Compiler 6 - Target ARMv7-A
     armc6_build_test "-O1 --target=arm-arm-none-eabi -march=armv7-a"
@@ -3913,6 +3913,9 @@ component_build_armcc () {
 
     # ARM Compiler 6 - Target ARMv8.2-A - AArch64
     armc6_build_test "-O1 --target=aarch64-arm-none-eabi -march=armv8.2-a+crypto"
+
+    # ARM Compiler 6 - Target Cortex-M0 - no optimisation
+    armc6_build_test "-O0 --target=arm-arm-none-eabi -mcpu=cortex-m0"
 
     # ARM Compiler 6 - Target Cortex-M0
     armc6_build_test "-Os --target=arm-arm-none-eabi -mcpu=cortex-m0"

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -3852,6 +3852,25 @@ component_build_arm_none_eabi_gcc_no_64bit_multiplication () {
     not grep __aeabi_lmul library/*.o
 }
 
+component_build_arm_clang_thumb () {
+    # ~ 30s
+
+    scripts/config.py baremetal
+
+    msg "build: clang thumb 2, make"
+    make clean
+    make CC="clang" CFLAGS='-std=c99 -Werror -Os --target=arm-linux-gnueabihf -march=armv7-m -mthumb' lib
+
+    # Some Thumb 1 asm is sensitive to optimisation level, so test both -O0 and -Os
+    msg "build: clang thumb 1 -O0, make"
+    make clean
+    make CC="clang" CFLAGS='-std=c99 -Werror -O0 --target=arm-linux-gnueabihf -mcpu=arm1136j-s -mthumb' lib
+
+    msg "build: clang thumb 1 -Os, make"
+    make clean
+    make CC="clang" CFLAGS='-std=c99 -Werror -Os --target=arm-linux-gnueabihf -mcpu=arm1136j-s -mthumb' lib
+}
+
 component_build_armcc () {
     msg "build: ARM Compiler 5"
     scripts/config.py baremetal


### PR DESCRIPTION
## Description

Fix compile fail on armclang for certain M-class CPUs, when optimisation is enabled. Fixes #1077 

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** provided
- [x] **backport** #7684 
- [x] **tests** build test added to all.sh
