### PR TITLE
FFDH 4: driver-only parity testing - with TLS 1.3

### DIFF
--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -2254,9 +2254,6 @@ component_test_psa_crypto_config_accel_ecdh () {
 component_test_psa_crypto_config_accel_ffdh () {
     msg "build: MBEDTLS_PSA_CRYPTO_CONFIG with accelerated FFDH"
 
-    # Start with full
-    scripts/config.py full
-
     # Algorithms and key types to accelerate
     loc_accel_list="ALG_FFDH KEY_TYPE_DH_KEY_PAIR KEY_TYPE_DH_PUBLIC_KEY"
 
@@ -2264,7 +2261,7 @@ component_test_psa_crypto_config_accel_ffdh () {
     # ---------
 
     # Start from default config (no TLS 1.3, no USE_PSA)
-    helper_libtestdriver1_adjust_config "default"
+    helper_libtestdriver1_adjust_config "full"
 
     # Disable the module that's accelerated
     scripts/config.py unset MBEDTLS_DHM_C
@@ -2288,6 +2285,9 @@ component_test_psa_crypto_config_accel_ffdh () {
 
     msg "test: MBEDTLS_PSA_CRYPTO_CONFIG with accelerated FFDH"
     make test
+
+    msg "ssl-opt: MBEDTLS_PSA_CRYPTO_CONFIG with accelerated FFDH alg"
+    tests/ssl-opt.sh -f "ffdh"
 }
 
 component_test_psa_crypto_config_reference_ffdh () {
@@ -2307,7 +2307,7 @@ component_test_psa_crypto_config_reference_ffdh () {
     # Disable things that are not supported
     scripts/config.py unset MBEDTLS_KEY_EXCHANGE_DHE_PSK_ENABLED
     scripts/config.py unset MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED
-    scripts/config.py unset MBEDTLS_DHM_C
+    scripts/config.py unset MBEDTLS_PSA_CRYPTO_SE_C
 
     make
 
@@ -2315,7 +2315,7 @@ component_test_psa_crypto_config_reference_ffdh () {
     make test
 
     msg "ssl-opt: MBEDTLS_PSA_CRYPTO_CONFIG with non-accelerated FFDH alg + USE_PSA"
-    tests/ssl-opt.sh -f "FFDH"
+    tests/ssl-opt.sh -f "ffdh"
 }
 
 component_test_psa_crypto_config_accel_pake() {

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -2260,7 +2260,7 @@ component_test_psa_crypto_config_accel_ffdh () {
     # Configure
     # ---------
 
-    # Start from default config (no TLS 1.3, no USE_PSA)
+    # start with full (USE_PSA and TLS 1.3)
     helper_libtestdriver1_adjust_config "full"
 
     # Disable the module that's accelerated
@@ -2294,21 +2294,11 @@ component_test_psa_crypto_config_reference_ffdh () {
     msg "build: MBEDTLS_PSA_CRYPTO_CONFIG with accelerated FFDH"
 
     # Start with full (USE_PSA and TLS 1.3)
-    scripts/config.py full
-
-    # Disable ALG_STREAM_CIPHER and ALG_ECB_NO_PADDING to avoid having
-    # partial support for cipher operations in the driver test library.
-    scripts/config.py -f include/psa/crypto_config.h unset PSA_WANT_ALG_STREAM_CIPHER
-    scripts/config.py -f include/psa/crypto_config.h unset PSA_WANT_ALG_ECB_NO_PADDING
-
-    # enable support for drivers and configuring PSA-only algorithms
-    scripts/config.py set MBEDTLS_PSA_CRYPTO_CONFIG
+    helper_libtestdriver1_adjust_config "full"
 
     # Disable things that are not supported
     scripts/config.py unset MBEDTLS_KEY_EXCHANGE_DHE_PSK_ENABLED
     scripts/config.py unset MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED
-    scripts/config.py unset MBEDTLS_PSA_CRYPTO_SE_C
-
     make
 
     msg "test suites: MBEDTLS_PSA_CRYPTO_CONFIG with non-accelerated FFDH alg + USE_PSA"

--- a/tests/scripts/analyze_outcomes.py
+++ b/tests/scripts/analyze_outcomes.py
@@ -333,10 +333,8 @@ TASKS = {
         'args': {
             'component_ref': 'test_psa_crypto_config_reference_ffdh',
             'component_driver': 'test_psa_crypto_config_accel_ffdh',
-            'ignored_suites': [
-            ],
-            'ignored_tests': {
-            }
+            'ignored_suites': ['dhm'],
+            'ignored_tests': {'test_suite_pkparse': ['DH group family: RFC 7919']}
         }
     },
 }

--- a/tests/scripts/analyze_outcomes.py
+++ b/tests/scripts/analyze_outcomes.py
@@ -262,7 +262,7 @@ TASKS = {
                     ('Key ASN1 (OneAsymmetricKey X25519, doesn\'t match masking '
                      'requirements, from RFC8410 Appendix A but made into version 0)'),
                 ],
-            }
+            },
         }
     },
     'analyze_driver_vs_reference_no_ecp_at_all': {
@@ -325,6 +325,17 @@ TASKS = {
                     'Parse Public EC Key #8a (RFC 5480, brainpoolP384r1, compressed)',
                     'Parse Public EC Key #9a (RFC 5480, brainpoolP512r1, compressed)',
                 ],
+            }
+        }
+    },
+    'analyze_driver_vs_reference_ffdh_alg': {
+        'test_function': do_analyze_driver_vs_reference,
+        'args': {
+            'component_ref': 'test_psa_crypto_config_reference_ffdh',
+            'component_driver': 'test_psa_crypto_config_accel_ffdh',
+            'ignored_suites': [
+            ],
+            'ignored_tests': {
             }
         }
     },

--- a/tests/scripts/analyze_outcomes.py
+++ b/tests/scripts/analyze_outcomes.py
@@ -334,7 +334,7 @@ TASKS = {
             'component_ref': 'test_psa_crypto_config_reference_ffdh',
             'component_driver': 'test_psa_crypto_config_accel_ffdh',
             'ignored_suites': ['dhm'],
-            'ignored_tests': {'test_suite_pkparse': ['DH group family: RFC 7919']}
+            'ignored_tests': {}
         }
     },
 }

--- a/tests/suites/test_suite_psa_crypto_metadata.function
+++ b/tests/suites/test_suite_psa_crypto_metadata.function
@@ -699,7 +699,7 @@ void ecc_key_family(int curve_arg)
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_DHM_C */
+/* BEGIN_CASE depends_on:PSA_KEY_TYPE_DH_PUBLIC_KEY:PSA_KEY_TYPE_DH_KEY_PAIR */
 void dh_key_family(int group_arg)
 {
     psa_dh_family_t group = group_arg;


### PR DESCRIPTION
## Description

Resolves: https://github.com/Mbed-TLS/mbedtls/issues/7569

Needs: https://github.com/Mbed-TLS/mbedtls/pull/7577 https://github.com/Mbed-TLS/mbedtls/pull/7627

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [X] **changelog** not required (just test component)
- [X] **backport** not required
- [X] **tests** provided
