### PR TITLE
Optimize error translation code size

### DIFF
--- a/library/common.h
+++ b/library/common.h
@@ -65,6 +65,44 @@ extern void (*mbedtls_test_hook_test_fail)(const char *test, int line, const cha
 #define MBEDTLS_TEST_HOOK_TEST_ASSERT(TEST)
 #endif /* defined(MBEDTLS_TEST_HOOKS) */
 
+/** \def ARRAY_LENGTH
+ * Return the number of elements of a static or stack array.
+ *
+ * \param array         A value of array (not pointer) type.
+ *
+ * \return The number of elements of the array.
+ */
+/* A correct implementation of ARRAY_LENGTH, but which silently gives
+ * a nonsensical result if called with a pointer rather than an array. */
+#define ARRAY_LENGTH_UNSAFE(array)            \
+    (sizeof(array) / sizeof(*(array)))
+
+#if defined(__GNUC__)
+/* Test if arg and &(arg)[0] have the same type. This is true if arg is
+ * an array but not if it's a pointer. */
+#define IS_ARRAY_NOT_POINTER(arg)                                     \
+    (!__builtin_types_compatible_p(__typeof__(arg),                \
+                                   __typeof__(&(arg)[0])))
+/* A compile-time constant with the value 0. If `const_expr` is not a
+ * compile-time constant with a nonzero value, cause a compile-time error. */
+#define STATIC_ASSERT_EXPR(const_expr)                                \
+    (0 && sizeof(struct { unsigned int STATIC_ASSERT : 1 - 2 * !(const_expr); }))
+
+/* Return the scalar value `value` (possibly promoted). This is a compile-time
+ * constant if `value` is. `condition` must be a compile-time constant.
+ * If `condition` is false, arrange to cause a compile-time error. */
+#define STATIC_ASSERT_THEN_RETURN(condition, value)   \
+    (STATIC_ASSERT_EXPR(condition) ? 0 : (value))
+
+#define ARRAY_LENGTH(array)                                           \
+    (STATIC_ASSERT_THEN_RETURN(IS_ARRAY_NOT_POINTER(array),         \
+                               ARRAY_LENGTH_UNSAFE(array)))
+
+#else
+/* If we aren't sure the compiler supports our non-standard tricks,
+ * fall back to the unsafe implementation. */
+#define ARRAY_LENGTH(array) ARRAY_LENGTH_UNSAFE(array)
+#endif
 /** Allow library to access its structs' private members.
  *
  * Although structs defined in header files are publicly available,

--- a/library/constant_time.c
+++ b/library/constant_time.c
@@ -54,7 +54,7 @@
 static int local_err_translation(psa_status_t status)
 {
     return psa_status_to_mbedtls(status, psa_to_ssl_errors,
-                                 sizeof(psa_to_ssl_errors),
+                                 ARRAY_LENGTH(psa_to_ssl_errors),
                                  psa_generic_status_to_mbedtls);
 }
 #define PSA_TO_MBEDTLS_ERR(status) local_err_translation(status)

--- a/library/constant_time.c
+++ b/library/constant_time.c
@@ -47,9 +47,15 @@
 
 #include <string.h>
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
-#define PSA_TO_MBEDTLS_ERR(status) PSA_TO_MBEDTLS_ERR_LIST(status,    \
-                                                           psa_to_ssl_errors,              \
-                                                           psa_generic_status_to_mbedtls)
+/* Define a local translating function to save code size by not using too many
+ * arguments in each translating place. */
+static int local_err_translation(psa_status_t status)
+{
+    return psa_status_to_mbedtls(status, psa_to_ssl_errors,
+                                 sizeof(psa_to_ssl_errors),
+                                 psa_generic_status_to_mbedtls);
+}
+#define PSA_TO_MBEDTLS_ERR(status) local_err_translation(status)
 #endif
 
 /*

--- a/library/constant_time.c
+++ b/library/constant_time.c
@@ -46,7 +46,9 @@
 #endif
 
 #include <string.h>
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
+
+#if defined(MBEDTLS_USE_PSA_CRYPTO) && defined(MBEDTLS_SSL_SOME_SUITES_USE_MAC)
+#include "psa/crypto.h"
 /* Define a local translating function to save code size by not using too many
  * arguments in each translating place. */
 static int local_err_translation(psa_status_t status)

--- a/library/lmots.c
+++ b/library/lmots.c
@@ -50,7 +50,7 @@
 static int local_err_translation(psa_status_t status)
 {
     return psa_status_to_mbedtls(status, psa_to_lms_errors,
-                                 sizeof(psa_to_lms_errors),
+                                 ARRAY_LENGTH(psa_to_lms_errors),
                                  psa_generic_status_to_mbedtls);
 }
 #define PSA_TO_MBEDTLS_ERR(status) local_err_translation(status)

--- a/library/lmots.c
+++ b/library/lmots.c
@@ -45,9 +45,15 @@
 
 #include "psa/crypto.h"
 
-#define PSA_TO_MBEDTLS_ERR(status) PSA_TO_MBEDTLS_ERR_LIST(status,   \
-                                                           psa_to_lms_errors,             \
-                                                           psa_generic_status_to_mbedtls)
+/* Define a local translating function to save code size by not using too many
+ * arguments in each translating place. */
+static int local_err_translation(psa_status_t status)
+{
+    return psa_status_to_mbedtls(status, psa_to_lms_errors,
+                                 sizeof(psa_to_lms_errors),
+                                 psa_generic_status_to_mbedtls);
+}
+#define PSA_TO_MBEDTLS_ERR(status) local_err_translation(status)
 
 #define PUBLIC_KEY_TYPE_OFFSET     (0)
 #define PUBLIC_KEY_I_KEY_ID_OFFSET (PUBLIC_KEY_TYPE_OFFSET + \

--- a/library/lms.c
+++ b/library/lms.c
@@ -51,7 +51,7 @@
 static int local_err_translation(psa_status_t status)
 {
     return psa_status_to_mbedtls(status, psa_to_lms_errors,
-                                 sizeof(psa_to_lms_errors),
+                                 ARRAY_LENGTH(psa_to_lms_errors),
                                  psa_generic_status_to_mbedtls);
 }
 #define PSA_TO_MBEDTLS_ERR(status) local_err_translation(status)

--- a/library/lms.c
+++ b/library/lms.c
@@ -46,9 +46,15 @@
 
 #include "mbedtls/platform.h"
 
-#define PSA_TO_MBEDTLS_ERR(status) PSA_TO_MBEDTLS_ERR_LIST(status,   \
-                                                           psa_to_lms_errors,             \
-                                                           psa_generic_status_to_mbedtls)
+/* Define a local translating function to save code size by not using too many
+ * arguments in each translating place. */
+static int local_err_translation(psa_status_t status)
+{
+    return psa_status_to_mbedtls(status, psa_to_lms_errors,
+                                 sizeof(psa_to_lms_errors),
+                                 psa_generic_status_to_mbedtls);
+}
+#define PSA_TO_MBEDTLS_ERR(status) local_err_translation(status)
 
 #define SIG_Q_LEAF_ID_OFFSET     (0)
 #define SIG_OTS_SIG_OFFSET       (SIG_Q_LEAF_ID_OFFSET + \

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -84,8 +84,6 @@
 #include "mbedtls/sha512.h"
 #include "md_psa.h"
 
-#define ARRAY_LENGTH(array) (sizeof(array) / sizeof(*(array)))
-
 #if defined(MBEDTLS_PSA_BUILTIN_ALG_HKDF) ||          \
     defined(MBEDTLS_PSA_BUILTIN_ALG_HKDF_EXTRACT) ||  \
     defined(MBEDTLS_PSA_BUILTIN_ALG_HKDF_EXPAND)

--- a/library/psa_crypto_slot_management.c
+++ b/library/psa_crypto_slot_management.c
@@ -36,8 +36,6 @@
 #include <string.h>
 #include "mbedtls/platform.h"
 
-#define ARRAY_LENGTH(array) (sizeof(array) / sizeof(*(array)))
-
 typedef struct {
     psa_key_slot_t key_slots[MBEDTLS_PSA_KEY_SLOT_COUNT];
     unsigned key_slots_initialized : 1;

--- a/library/sha512.c
+++ b/library/sha512.c
@@ -1001,8 +1001,6 @@ static sha_test_sum_t sha512_test_sum[] =
 };
 #endif /* MBEDTLS_SHA512_C */
 
-#define ARRAY_LENGTH(a)   (sizeof(a) / sizeof((a)[0]))
-
 static int mbedtls_sha512_common_self_test(int verbose, int is384)
 {
     int i, buflen, ret = 0;

--- a/library/ssl_cookie.c
+++ b/library/ssl_cookie.c
@@ -37,9 +37,15 @@
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
 #include "md_psa.h"
-#define PSA_TO_MBEDTLS_ERR(status) PSA_TO_MBEDTLS_ERR_LIST(status,   \
-                                                           psa_to_ssl_errors,             \
-                                                           psa_generic_status_to_mbedtls)
+/* Define a local translating function to save code size by not using too many
+ * arguments in each translating place. */
+static int local_err_translation(psa_status_t status)
+{
+    return psa_status_to_mbedtls(status, psa_to_ssl_errors,
+                                 sizeof(psa_to_ssl_errors),
+                                 psa_generic_status_to_mbedtls);
+}
+#define PSA_TO_MBEDTLS_ERR(status) local_err_translation(status)
 #endif
 
 /*

--- a/library/ssl_cookie.c
+++ b/library/ssl_cookie.c
@@ -42,7 +42,7 @@
 static int local_err_translation(psa_status_t status)
 {
     return psa_status_to_mbedtls(status, psa_to_ssl_errors,
-                                 sizeof(psa_to_ssl_errors),
+                                 ARRAY_LENGTH(psa_to_ssl_errors),
                                  psa_generic_status_to_mbedtls);
 }
 #define PSA_TO_MBEDTLS_ERR(status) local_err_translation(status)

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -54,7 +54,7 @@
 static int local_err_translation(psa_status_t status)
 {
     return psa_status_to_mbedtls(status, psa_to_ssl_errors,
-                                 sizeof(psa_to_ssl_errors),
+                                 ARRAY_LENGTH(psa_to_ssl_errors),
                                  psa_generic_status_to_mbedtls);
 }
 #define PSA_TO_MBEDTLS_ERR(status) local_err_translation(status)

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -49,9 +49,15 @@
 #endif
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
-#define PSA_TO_MBEDTLS_ERR(status) PSA_TO_MBEDTLS_ERR_LIST(status,   \
-                                                           psa_to_ssl_errors,             \
-                                                           psa_generic_status_to_mbedtls)
+/* Define a local translating function to save code size by not using too many
+ * arguments in each translating place. */
+static int local_err_translation(psa_status_t status)
+{
+    return psa_status_to_mbedtls(status, psa_to_ssl_errors,
+                                 sizeof(psa_to_ssl_errors),
+                                 psa_generic_status_to_mbedtls);
+}
+#define PSA_TO_MBEDTLS_ERR(status) local_err_translation(status)
 #endif
 
 static uint32_t ssl_get_hs_total_len(mbedtls_ssl_context const *ssl);

--- a/library/ssl_ticket.c
+++ b/library/ssl_ticket.c
@@ -31,9 +31,15 @@
 #include <string.h>
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
-#define PSA_TO_MBEDTLS_ERR(status) PSA_TO_MBEDTLS_ERR_LIST(status,   \
-                                                           psa_to_ssl_errors,             \
-                                                           psa_generic_status_to_mbedtls)
+/* Define a local translating function to save code size by not using too many
+ * arguments in each translating place. */
+static int local_err_translation(psa_status_t status)
+{
+    return psa_status_to_mbedtls(status, psa_to_ssl_errors,
+                                 sizeof(psa_to_ssl_errors),
+                                 psa_generic_status_to_mbedtls);
+}
+#define PSA_TO_MBEDTLS_ERR(status) local_err_translation(status)
 #endif
 
 /*

--- a/library/ssl_ticket.c
+++ b/library/ssl_ticket.c
@@ -36,7 +36,7 @@
 static int local_err_translation(psa_status_t status)
 {
     return psa_status_to_mbedtls(status, psa_to_ssl_errors,
-                                 sizeof(psa_to_ssl_errors),
+                                 ARRAY_LENGTH(psa_to_ssl_errors),
                                  psa_generic_status_to_mbedtls);
 }
 #define PSA_TO_MBEDTLS_ERR(status) local_err_translation(status)

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -56,7 +56,7 @@
 static int local_err_translation(psa_status_t status)
 {
     return psa_status_to_mbedtls(status, psa_to_ssl_errors,
-                                 sizeof(psa_to_ssl_errors),
+                                 ARRAY_LENGTH(psa_to_ssl_errors),
                                  psa_generic_status_to_mbedtls);
 }
 #define PSA_TO_MBEDTLS_ERR(status) local_err_translation(status)
@@ -64,7 +64,7 @@ static int local_err_translation(psa_status_t status)
 static int local_md_translation(psa_status_t status)
 {
     return psa_status_to_mbedtls(status, psa_to_md_errors,
-                                 sizeof(psa_to_md_errors),
+                                 ARRAY_LENGTH(psa_to_md_errors),
                                  psa_generic_status_to_mbedtls);
 }
 #define PSA_TO_MD_ERR(status) local_md_translation(status)

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -759,8 +759,6 @@ void mbedtls_ssl_print_extensions(const mbedtls_ssl_context *ssl,
 }
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3) && defined(MBEDTLS_SSL_SESSION_TICKETS)
-#define ARRAY_LENGTH(a) (sizeof(a) / sizeof(*(a)))
-
 static const char *ticket_flag_name_table[] =
 {
     [0] = "ALLOW_PSK_RESUMPTION",

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -60,14 +60,6 @@ static int local_err_translation(psa_status_t status)
                                  psa_generic_status_to_mbedtls);
 }
 #define PSA_TO_MBEDTLS_ERR(status) local_err_translation(status)
-
-static int local_md_translation(psa_status_t status)
-{
-    return psa_status_to_mbedtls(status, psa_to_md_errors,
-                                 ARRAY_LENGTH(psa_to_md_errors),
-                                 psa_generic_status_to_mbedtls);
-}
-#define PSA_TO_MD_ERR(status) local_md_translation(status)
 #endif
 
 #if defined(MBEDTLS_TEST_HOOKS)

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -51,12 +51,23 @@
 #endif
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
-#define PSA_TO_MBEDTLS_ERR(status) PSA_TO_MBEDTLS_ERR_LIST(status, \
-                                                           psa_to_ssl_errors, \
-                                                           psa_generic_status_to_mbedtls)
-#define PSA_TO_MD_ERR(status) PSA_TO_MBEDTLS_ERR_LIST(status, \
-                                                      psa_to_md_errors, \
-                                                      psa_generic_status_to_mbedtls)
+/* Define local translating functions to save code size by not using too many
+ * arguments in each translating place. */
+static int local_err_translation(psa_status_t status)
+{
+    return psa_status_to_mbedtls(status, psa_to_ssl_errors,
+                                 sizeof(psa_to_ssl_errors),
+                                 psa_generic_status_to_mbedtls);
+}
+#define PSA_TO_MBEDTLS_ERR(status) local_err_translation(status)
+
+static int local_md_translation(psa_status_t status)
+{
+    return psa_status_to_mbedtls(status, psa_to_md_errors,
+                                 sizeof(psa_to_md_errors),
+                                 psa_generic_status_to_mbedtls);
+}
+#define PSA_TO_MD_ERR(status) local_md_translation(status)
 #endif
 
 #if defined(MBEDTLS_TEST_HOOKS)

--- a/library/ssl_tls12_client.c
+++ b/library/ssl_tls12_client.c
@@ -33,9 +33,15 @@
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
 #include "mbedtls/psa_util.h"
 #include "psa/crypto.h"
-#define PSA_TO_MBEDTLS_ERR(status) PSA_TO_MBEDTLS_ERR_LIST(status,   \
-                                                           psa_to_ssl_errors,             \
-                                                           psa_generic_status_to_mbedtls)
+/* Define a local translating function to save code size by not using too many
+ * arguments in each translating place. */
+static int local_err_translation(psa_status_t status)
+{
+    return psa_status_to_mbedtls(status, psa_to_ssl_errors,
+                                 sizeof(psa_to_ssl_errors),
+                                 psa_generic_status_to_mbedtls);
+}
+#define PSA_TO_MBEDTLS_ERR(status) local_err_translation(status)
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 #include <string.h>

--- a/library/ssl_tls12_client.c
+++ b/library/ssl_tls12_client.c
@@ -39,7 +39,7 @@
 static int local_err_translation(psa_status_t status)
 {
     return psa_status_to_mbedtls(status, psa_to_ssl_errors,
-                                 sizeof(psa_to_ssl_errors),
+                                 ARRAY_LENGTH(psa_to_ssl_errors),
                                  psa_generic_status_to_mbedtls);
 }
 #define PSA_TO_MBEDTLS_ERR(status) local_err_translation(status)

--- a/library/ssl_tls12_client.c
+++ b/library/ssl_tls12_client.c
@@ -33,6 +33,7 @@
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
 #include "mbedtls/psa_util.h"
 #include "psa/crypto.h"
+#if defined(MBEDTLS_KEY_EXCHANGE_ECDHE_PSK_ENABLED)
 /* Define a local translating function to save code size by not using too many
  * arguments in each translating place. */
 static int local_err_translation(psa_status_t status)
@@ -42,6 +43,7 @@ static int local_err_translation(psa_status_t status)
                                  psa_generic_status_to_mbedtls);
 }
 #define PSA_TO_MBEDTLS_ERR(status) local_err_translation(status)
+#endif /* MBEDTLS_KEY_EXCHANGE_ECDHE_PSK_ENABLED */
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 #include <string.h>

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -41,7 +41,7 @@
 static int local_err_translation(psa_status_t status)
 {
     return psa_status_to_mbedtls(status, psa_to_ssl_errors,
-                                 sizeof(psa_to_ssl_errors),
+                                 ARRAY_LENGTH(psa_to_ssl_errors),
                                  psa_generic_status_to_mbedtls);
 }
 #define PSA_TO_MBEDTLS_ERR(status) local_err_translation(status)

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -36,6 +36,8 @@
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
 /* Define a local translating function to save code size by not using too many
  * arguments in each translating place. */
+#if defined(MBEDTLS_KEY_EXCHANGE_SOME_ECDH_ENABLED) || \
+    defined(MBEDTLS_KEY_EXCHANGE_SOME_ECDHE_ENABLED)
 static int local_err_translation(psa_status_t status)
 {
     return psa_status_to_mbedtls(status, psa_to_ssl_errors,
@@ -43,6 +45,7 @@ static int local_err_translation(psa_status_t status)
                                  psa_generic_status_to_mbedtls);
 }
 #define PSA_TO_MBEDTLS_ERR(status) local_err_translation(status)
+#endif
 #endif
 
 #if defined(MBEDTLS_ECP_C)

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -34,9 +34,15 @@
 #include <string.h>
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
-#define PSA_TO_MBEDTLS_ERR(status) PSA_TO_MBEDTLS_ERR_LIST(status,   \
-                                                           psa_to_ssl_errors,             \
-                                                           psa_generic_status_to_mbedtls)
+/* Define a local translating function to save code size by not using too many
+ * arguments in each translating place. */
+static int local_err_translation(psa_status_t status)
+{
+    return psa_status_to_mbedtls(status, psa_to_ssl_errors,
+                                 sizeof(psa_to_ssl_errors),
+                                 psa_generic_status_to_mbedtls);
+}
+#define PSA_TO_MBEDTLS_ERR(status) local_err_translation(status)
 #endif
 
 #if defined(MBEDTLS_ECP_C)

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -40,7 +40,7 @@
 static int local_err_translation(psa_status_t status)
 {
     return psa_status_to_mbedtls(status, psa_to_ssl_errors,
-                                 sizeof(psa_to_ssl_errors),
+                                 ARRAY_LENGTH(psa_to_ssl_errors),
                                  psa_generic_status_to_mbedtls);
 }
 #define PSA_TO_MBEDTLS_ERR(status) local_err_translation(status)

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -35,6 +35,7 @@
 #include "ssl_debug_helpers.h"
 #include "md_psa.h"
 
+#if defined(PSA_WANT_ALG_ECDH)
 /* Define a local translating function to save code size by not using too many
  * arguments in each translating place. */
 static int local_err_translation(psa_status_t status)
@@ -44,6 +45,8 @@ static int local_err_translation(psa_status_t status)
                                  psa_generic_status_to_mbedtls);
 }
 #define PSA_TO_MBEDTLS_ERR(status) local_err_translation(status)
+#endif
+
 /* Write extensions */
 
 /*

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -35,10 +35,15 @@
 #include "ssl_debug_helpers.h"
 #include "md_psa.h"
 
-#define PSA_TO_MBEDTLS_ERR(status) PSA_TO_MBEDTLS_ERR_LIST(status,   \
-                                                           psa_to_ssl_errors,             \
-                                                           psa_generic_status_to_mbedtls)
-
+/* Define a local translating function to save code size by not using too many
+ * arguments in each translating place. */
+static int local_err_translation(psa_status_t status)
+{
+    return psa_status_to_mbedtls(status, psa_to_ssl_errors,
+                                 sizeof(psa_to_ssl_errors),
+                                 psa_generic_status_to_mbedtls);
+}
+#define PSA_TO_MBEDTLS_ERR(status) local_err_translation(status)
 /* Write extensions */
 
 /*

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -39,6 +39,8 @@
 #include "psa/crypto.h"
 #include "mbedtls/psa_util.h"
 
+#if defined(MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED) || \
+    defined(PSA_WANT_ALG_ECDH)
 /* Define a local translating function to save code size by not using too many
  * arguments in each translating place. */
 static int local_err_translation(psa_status_t status)
@@ -48,6 +50,7 @@ static int local_err_translation(psa_status_t status)
                                  psa_generic_status_to_mbedtls);
 }
 #define PSA_TO_MBEDTLS_ERR(status) local_err_translation(status)
+#endif
 
 const uint8_t mbedtls_ssl_tls13_hello_retry_request_magic[
     MBEDTLS_SERVER_HELLO_RANDOM_LEN] =

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -39,9 +39,15 @@
 #include "psa/crypto.h"
 #include "mbedtls/psa_util.h"
 
-#define PSA_TO_MBEDTLS_ERR(status) PSA_TO_MBEDTLS_ERR_LIST(status,   \
-                                                           psa_to_ssl_errors,             \
-                                                           psa_generic_status_to_mbedtls)
+/* Define a local translating function to save code size by not using too many
+ * arguments in each translating place. */
+static int local_err_translation(psa_status_t status)
+{
+    return psa_status_to_mbedtls(status, psa_to_ssl_errors,
+                                 sizeof(psa_to_ssl_errors),
+                                 psa_generic_status_to_mbedtls);
+}
+#define PSA_TO_MBEDTLS_ERR(status) local_err_translation(status)
 
 const uint8_t mbedtls_ssl_tls13_hello_retry_request_magic[
     MBEDTLS_SERVER_HELLO_RANDOM_LEN] =

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -44,7 +44,7 @@
 static int local_err_translation(psa_status_t status)
 {
     return psa_status_to_mbedtls(status, psa_to_ssl_errors,
-                                 sizeof(psa_to_ssl_errors),
+                                 ARRAY_LENGTH(psa_to_ssl_errors),
                                  psa_generic_status_to_mbedtls);
 }
 #define PSA_TO_MBEDTLS_ERR(status) local_err_translation(status)

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -41,7 +41,7 @@
 static int local_err_translation(psa_status_t status)
 {
     return psa_status_to_mbedtls(status, psa_to_ssl_errors,
-                                 sizeof(psa_to_ssl_errors),
+                                 ARRAY_LENGTH(psa_to_ssl_errors),
                                  psa_generic_status_to_mbedtls);
 }
 #define PSA_TO_MBEDTLS_ERR(status) local_err_translation(status)

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -36,9 +36,15 @@
 #include "psa/crypto.h"
 #include "md_psa.h"
 
-#define PSA_TO_MBEDTLS_ERR(status) PSA_TO_MBEDTLS_ERR_LIST(status,   \
-                                                           psa_to_ssl_errors,             \
-                                                           psa_generic_status_to_mbedtls)
+/* Define a local translating function to save code size by not using too many
+ * arguments in each translating place. */
+static int local_err_translation(psa_status_t status)
+{
+    return psa_status_to_mbedtls(status, psa_to_ssl_errors,
+                                 sizeof(psa_to_ssl_errors),
+                                 psa_generic_status_to_mbedtls);
+}
+#define PSA_TO_MBEDTLS_ERR(status) local_err_translation(status)
 
 #define MBEDTLS_SSL_TLS1_3_LABEL(name, string)       \
     .name = string,

--- a/tests/include/test/macros.h
+++ b/tests/include/test/macros.h
@@ -33,6 +33,7 @@
 #if defined(MBEDTLS_MEMORY_BUFFER_ALLOC_C)
 #include "mbedtls/memory_buffer_alloc.h"
 #endif
+#include "common.h"
 
 /**
  * \brief   This macro tests the expression passed to it as a test step or

--- a/tests/include/test/macros.h
+++ b/tests/include/test/macros.h
@@ -196,45 +196,6 @@
         mbedtls_exit(1);                                              \
     }
 
-/** \def ARRAY_LENGTH
- * Return the number of elements of a static or stack array.
- *
- * \param array         A value of array (not pointer) type.
- *
- * \return The number of elements of the array.
- */
-/* A correct implementation of ARRAY_LENGTH, but which silently gives
- * a nonsensical result if called with a pointer rather than an array. */
-#define ARRAY_LENGTH_UNSAFE(array)            \
-    (sizeof(array) / sizeof(*(array)))
-
-#if defined(__GNUC__)
-/* Test if arg and &(arg)[0] have the same type. This is true if arg is
- * an array but not if it's a pointer. */
-#define IS_ARRAY_NOT_POINTER(arg)                                     \
-    (!__builtin_types_compatible_p(__typeof__(arg),                \
-                                   __typeof__(&(arg)[0])))
-/* A compile-time constant with the value 0. If `const_expr` is not a
- * compile-time constant with a nonzero value, cause a compile-time error. */
-#define STATIC_ASSERT_EXPR(const_expr)                                \
-    (0 && sizeof(struct { unsigned int STATIC_ASSERT : 1 - 2 * !(const_expr); }))
-
-/* Return the scalar value `value` (possibly promoted). This is a compile-time
- * constant if `value` is. `condition` must be a compile-time constant.
- * If `condition` is false, arrange to cause a compile-time error. */
-#define STATIC_ASSERT_THEN_RETURN(condition, value)   \
-    (STATIC_ASSERT_EXPR(condition) ? 0 : (value))
-
-#define ARRAY_LENGTH(array)                                           \
-    (STATIC_ASSERT_THEN_RETURN(IS_ARRAY_NOT_POINTER(array),         \
-                               ARRAY_LENGTH_UNSAFE(array)))
-
-#else
-/* If we aren't sure the compiler supports our non-standard tricks,
- * fall back to the unsafe implementation. */
-#define ARRAY_LENGTH(array) ARRAY_LENGTH_UNSAFE(array)
-#endif
-
 /** Return the smaller of two values.
  *
  * \param x         An integer-valued expression without side effects.

--- a/tests/src/psa_crypto_helpers.c
+++ b/tests/src/psa_crypto_helpers.c
@@ -24,7 +24,6 @@
 #include <test/macros.h>
 #include <psa_crypto_slot_management.h>
 #include <test/psa_crypto_helpers.h>
-#include "common.h"
 
 #if defined(MBEDTLS_PSA_CRYPTO_C)
 

--- a/tests/src/psa_crypto_helpers.c
+++ b/tests/src/psa_crypto_helpers.c
@@ -24,6 +24,7 @@
 #include <test/macros.h>
 #include <psa_crypto_slot_management.h>
 #include <test/psa_crypto_helpers.h>
+#include "common.h"
 
 #if defined(MBEDTLS_PSA_CRYPTO_C)
 


### PR DESCRIPTION
Introducing an intermediate function saves code size that's otherwise taken by excessive, repeated arguments in each place that was translating errors. Fixes https://github.com/Mbed-TLS/mbedtls/issues/7402.
Tested using 
```
scripts/config.py baremetal_size
./scripts/footprint.sh
```
Before this PR:
```
default (include/mbedtls/mbedtls_config.h):
   text    data     bss     dec     hex filename
 313232     162    3166  316560   4d490 (TOTALS)
```
After this PR:
```
default (include/mbedtls/mbedtls_config.h):
   text    data     bss     dec     hex filename
 312792     162    3166  316120   4d2d8 (TOTALS)

```
440 bytes saved.

## PR checklist
- [x] **changelog** not required - internal change
- [x] **backport** not required - the original PR that introduced the code, https://github.com/Mbed-TLS/mbedtls/pull/6829, also did not have a backport. 
- [x] **tests** not required - if tests pass and the same errors are used, there's no new tests to add
