### PR TITLE
Fix invalid commands for ec_x{25519,448}_{prv,pub}.{der,pem}

### DIFF
--- a/tests/data_files/Makefile
+++ b/tests/data_files/Makefile
@@ -1019,8 +1019,8 @@ ec_x25519_prv.pem: ec_x25519_prv.der
 	$(OPENSSL) pkey -in $< -inform DER -out $@
 all_final += ec_x25519_prv.pem
 
-ec_x25519_pub.pem: ec_x25519_pub.der
-	$(OPENSSL) pkey -in $< -inform DER -out $@ -pubin
+ec_x25519_pub.pem: ec_x25519_prv.der
+	$(OPENSSL) pkey -in $< -inform DER -out $@ -pubout
 all_final += ec_x25519_pub.pem
 
 ec_x448_prv.der:
@@ -1035,8 +1035,8 @@ ec_x448_prv.pem: ec_x448_prv.der
 	$(OPENSSL) pkey -in $< -inform DER -out $@
 all_final += ec_x448_prv.pem
 
-ec_x448_pub.pem: ec_x448_pub.der
-	$(OPENSSL) pkey -in $< -inform DER -out $@ -pubin
+ec_x448_pub.pem: ec_x448_prv.der
+	$(OPENSSL) pkey -in $< -inform DER -out $@ -pubout
 all_final += ec_x448_pub.pem
 
 ################################################################

--- a/tests/data_files/Makefile
+++ b/tests/data_files/Makefile
@@ -1011,32 +1011,32 @@ ec_x25519_prv.der:
 	$(OPENSSL) genpkey -algorithm X25519 -out $@ -outform DER
 all_final += ec_x25519_prv.der
 
-ec_x25519_pub.der: ec_x25519_pub.der
-	$(OPENSSL) pkey -in $< -inform DER -out $@ -outform DER
+ec_x25519_pub.der: ec_x25519_prv.der
+	$(OPENSSL) pkey -in $< -inform DER -out $@ -outform DER -pubout
 all_final += ec_x25519_pub.der
 
-ec_x25519_prv.pem: ec_x25519_prv.pem
+ec_x25519_prv.pem: ec_x25519_prv.der
 	$(OPENSSL) pkey -in $< -inform DER -out $@
 all_final += ec_x25519_prv.pem
 
-ec_x25519_pub.pem: ec_x25519_pub.pem
-	$(OPENSSL) pkey -in $< -inform DER -out $@
+ec_x25519_pub.pem: ec_x25519_pub.der
+	$(OPENSSL) pkey -in $< -inform DER -out $@ -pubin
 all_final += ec_x25519_pub.pem
 
 ec_x448_prv.der:
 	$(OPENSSL) genpkey -algorithm X448 -out $@ -outform DER
 all_final += ec_x448_prv.der
 
-ec_x448_pub.der: ec_x448_pub.der
-	$(OPENSSL) pkey -in $< -inform DER -out $@ -outform DER
+ec_x448_pub.der: ec_x448_prv.der
+	$(OPENSSL) pkey -in $< -inform DER -out $@ -outform DER -pubout
 all_final += ec_x448_pub.der
 
-ec_x448_prv.pem: ec_x448_prv.pem
+ec_x448_prv.pem: ec_x448_prv.der
 	$(OPENSSL) pkey -in $< -inform DER -out $@
 all_final += ec_x448_prv.pem
 
-ec_x448_pub.pem: ec_x448_pub.pem
-	$(OPENSSL) pkey -in $< -inform DER -out $@
+ec_x448_pub.pem: ec_x448_pub.der
+	$(OPENSSL) pkey -in $< -inform DER -out $@ -pubin
 all_final += ec_x448_pub.pem
 
 ################################################################


### PR DESCRIPTION
## Description

The commands in `tests/data_files/Makefile` to generate ec key files is invalid, which is introduced in #6838 



## PR checklist

- [x] **changelog** not required, internal use.
- [x] **backport** not required, new feature bug fix.
- [x] **tests** not required
