### PR TITLE
Libtestdriver1 helpers

### DIFF
--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -2388,8 +2388,7 @@ component_test_psa_crypto_config_reference_all_ec_algs_use_psa () {
     msg "build: MBEDTLS_PSA_CRYPTO_CONFIG with non-accelerated EC algs + USE_PSA"
 
     # To be aligned with component_test_psa_crypto_config_accel_all_ec_algs_use_psa()
-    scripts/config.py -f include/psa/crypto_config.h unset PSA_WANT_ALG_STREAM_CIPHER
-    scripts/config.py -f include/psa/crypto_config.h unset PSA_WANT_ALG_ECB_NO_PADDING
+    helper_libtestdriver1_adjust_config
 
     config_psa_crypto_config_all_ec_algs_use_psa 0
 
@@ -2456,10 +2455,8 @@ config_psa_crypto_full_all_ec_algs_no_ecp_use_psa () {
     # This is done to have the same form of psa_key_attributes_s for libdriver and library.
     scripts/config.py unset MBEDTLS_PSA_CRYPTO_SE_C
 
-    # Disable ALG_STREAM_CIPHER and ALG_ECB_NO_PADDING to avoid having
-    # partial support for cipher operations in the driver test library.
-    scripts/config.py -f include/psa/crypto_config.h unset PSA_WANT_ALG_STREAM_CIPHER
-    scripts/config.py -f include/psa/crypto_config.h unset PSA_WANT_ALG_ECB_NO_PADDING
+    # Adjustments for the test driver library
+    helper_libtestdriver1_adjust_config
 
     # Disable PSA_WANT symbols that would re-enable PK
     scripts/config.py -f include/psa/crypto_config.h unset PSA_WANT_KEY_TYPE_RSA_KEY_PAIR
@@ -2875,8 +2872,8 @@ component_test_psa_crypto_config_accel_hash_use_psa () {
 component_test_psa_crypto_config_reference_hash_use_psa() {
     msg "test: MBEDTLS_PSA_CRYPTO_CONFIG without accelerated hash and USE_PSA"
 
-    scripts/config.py -f include/psa/crypto_config.h unset PSA_WANT_ALG_STREAM_CIPHER
-    scripts/config.py -f include/psa/crypto_config.h unset PSA_WANT_ALG_ECB_NO_PADDING
+    # To be aligned with the accelerated component
+    helper_libtestdriver1_adjust_config
 
     config_psa_crypto_hash_use_psa 0
 
@@ -2899,13 +2896,12 @@ component_test_psa_crypto_config_accel_cipher () {
 
     helper_libtestdriver1_adjust_config
 
-    # There is no intended accelerator support for ALG STREAM_CIPHER and
-    # ALG_ECB_NO_PADDING. Therefore, asking for them in the build implies the
-    # inclusion of the Mbed TLS cipher operations. As we want to test here with
-    # cipher operations solely supported by accelerators, disabled those
-    # PSA configuration options.
-    scripts/config.py -f include/psa/crypto_config.h unset PSA_WANT_ALG_STREAM_CIPHER
-    scripts/config.py -f include/psa/crypto_config.h unset PSA_WANT_ALG_ECB_NO_PADDING
+    # There is no intended accelerator support for ALG CMAC. Therefore, asking
+    # for it in the build implies the inclusion of the Mbed TLS cipher
+    # operations. As we want to test here with cipher operations solely
+    # supported by accelerators, disabled this PSA configuration option.
+    # (Note: the same applies to STREAM_CIPHER and ECB_NO_PADDING, which are
+    # already disabled by helper_libtestdriver1_adjust_config above.)
     scripts/config.py -f include/psa/crypto_config.h unset PSA_WANT_ALG_CMAC
 
     # Configure and build the test driver library

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -799,6 +799,40 @@ pre_generate_files() {
 #### Helpers for components using libtestdriver1
 ################################################################
 
+# How to use libtestdriver1
+# -------------------------
+#
+# 1. Define the list algorithms and key types to accelerate,
+#    designated the same way as PSA_WANT_ macros but without PSA_WANT_.
+#    Examples:
+#      - loc_accel_list="ALG_JPAKE"
+#      - loc_accel_list="ALG_FFDH KEY_TYPE_DH_KEY_PAIR KEY_TYPE_DH_PUBLIC_KEY"
+# 2. Make configurations changes that are common to driver and main libraries.
+#    WARNING: both libraries MUST have the same set of PSA_WANT_ALG symbols,
+#    as they determine the ABI between them, so all changes to these symbols
+#    go here.
+#    2a. Call helper_libtestdriver1_adjust_config.
+#    2b. Any other change you need to make.
+# 3. Build the driver library: libtestdriver1.a.
+#    Just call helper_libtestdriver1_make_drivers, passing "$loc_accel_list".
+#    You may need to enable more algorithms here, typically hash algorithms
+#    when accelerating some signature algoritms (ECDSA, RSAv2). This is done
+#    by passing a 2nd argument listing the extra algorithms.
+#    Example:
+#      loc_extra_list="ALG_SHA_224 ALG_SHA_256 ALG_SHA_384 ALG_SHA_512"
+#      helper_libtestdriver1_make_drivers "$loc_accel_list" "$loc_extra_list"
+# 4. Configure and build the main libraries using drivers.
+#    4a. (optional) Call scripts/config.py full if you want.
+#    4b. Call scripts/config.py set MBEDTLS_PSA_CRYPTO_CONFIG
+#    4c. Make any other config adjustments you want. Typically you want to
+#        disable the modules that are being accelerated. You may need to also
+#        disable modules that depend on them or options that are not supported
+#        with drivers.
+#        WARNING: do NOT change any PSA_WANT symbol at that point, that should
+#        only be done in step 2 above.
+#    4d. Call helper_libtestdriver1_make_main "$loc_accel_list".
+# 5. Run the tests you want.
+
 # Adjust the configuration - for both libtestdriver1 and main library,
 # as they should have the same PSA_WANT macros.
 helper_libtestdriver1_adjust_config() {

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -2639,6 +2639,17 @@ component_test_psa_crypto_config_accel_rsa_signature () {
     scripts/config.py -f include/psa/crypto_config.h unset PSA_WANT_ALG_RSA_OAEP
     scripts/config.py -f include/psa/crypto_config.h unset PSA_WANT_ALG_RSA_PKCS1V15_CRYPT
 
+    # Remove RSA support and its dependencies
+    scripts/config.py unset MBEDTLS_RSA_C
+    scripts/config.py unset MBEDTLS_PKCS1_V15
+    scripts/config.py unset MBEDTLS_PKCS1_V21
+    scripts/config.py unset MBEDTLS_X509_RSASSA_PSS_SUPPORT
+    scripts/config.py unset MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED
+    scripts/config.py unset MBEDTLS_KEY_EXCHANGE_ECDH_RSA_ENABLED
+    scripts/config.py unset MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED
+    scripts/config.py unset MBEDTLS_KEY_EXCHANGE_RSA_PSK_ENABLED
+    scripts/config.py unset MBEDTLS_KEY_EXCHANGE_RSA_ENABLED
+
     # Make sure both the library and the test library support the SHA hash
     # algorithms and only those ones (SHA256 is included by default). That way:
     # - the test library can compute the RSA signatures even in the case of a
@@ -2651,26 +2662,11 @@ component_test_psa_crypto_config_accel_rsa_signature () {
     #   PSA_ALG_ANY_HASH as algorithm to test with the key, the chosen hash
     #   algorithm based on the hashes supported by the library is also
     #   supported by the test library.
-    # Disabled unwanted hashes here, we'll enable hashes we want in loc_accel_flags.
+    # Disable unwanted hashes here, we'll enable hashes we want in loc_extra_list.
     scripts/config.py -f include/psa/crypto_config.h unset PSA_WANT_ALG_MD5
     scripts/config.py -f include/psa/crypto_config.h unset PSA_WANT_ALG_RIPEMD160_C
-
-    # Remove RSA support and its dependencies
-    scripts/config.py unset MBEDTLS_PKCS1_V15
-    scripts/config.py unset MBEDTLS_PKCS1_V21
-    scripts/config.py unset MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED
-    scripts/config.py unset MBEDTLS_KEY_EXCHANGE_ECDH_RSA_ENABLED
-    scripts/config.py unset MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED
-    scripts/config.py unset MBEDTLS_KEY_EXCHANGE_RSA_PSK_ENABLED
-    scripts/config.py unset MBEDTLS_KEY_EXCHANGE_RSA_ENABLED
-    scripts/config.py unset MBEDTLS_RSA_C
-    scripts/config.py unset MBEDTLS_X509_RSASSA_PSS_SUPPORT
-
     scripts/config.py unset MBEDTLS_MD5_C
     scripts/config.py unset MBEDTLS_RIPEMD160_C
-    scripts/config.py unset MBEDTLS_SSL_PROTO_TLS1
-    scripts/config.py unset MBEDTLS_SSL_PROTO_TLS1_1
-    scripts/config.py unset MBEDTLS_SSL_CBC_RECORD_SPLITTING
 
     # We need PEM parsing in the test library as well to support the import
     # of PEM encoded RSA keys.

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -2571,9 +2571,13 @@ psa_crypto_config_accel_all_curves_except_one () {
     # build with ECP_C.
     scripts/config.py set $BUILTIN_CURVE
     # Accelerate all curves listed in "crypto_config.h" (skipping the ones that
-    # are commented out)
+    # are commented out).
+    # Note: Those are handled in a special way by the libtestdriver machinery,
+    # so we only want to include them in the accel list when building the main
+    # libraries, hence the use of a separate variable.
+    loc_curve_list=""
     for CURVE in $(sed -n 's/^#define PSA_WANT_\(ECC_[0-9A-Z_a-z]*\).*/\1/p' <"$CRYPTO_CONFIG_H"); do
-        loc_accel_list="$loc_accel_list $CURVE"
+        loc_curve_list="$loc_curve_list $CURVE"
     done
 
     # Build
@@ -2583,8 +2587,8 @@ psa_crypto_config_accel_all_curves_except_one () {
     loc_extra_list="ALG_SHA_224 ALG_SHA_256 ALG_SHA_384 ALG_SHA_512"
     helper_libtestdriver1_make_drivers "$loc_accel_list" "$loc_extra_list"
 
-    # build and link with test drivers
-    helper_libtestdriver1_make_main "$loc_accel_list"
+    # (See above regarding loc_curve_list.)
+    helper_libtestdriver1_make_main "$loc_accel_list $loc_curve_list"
 
     # make sure excluded modules were not auto-re-enabled by accident
     not grep mbedtls_ecdh_ library/ecdh.o

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -2228,16 +2228,12 @@ component_test_psa_crypto_config_accel_ffdh () {
     # Algorithms and key types to accelerate
     loc_accel_list="ALG_FFDH KEY_TYPE_DH_KEY_PAIR KEY_TYPE_DH_PUBLIC_KEY"
 
+    helper_libtestdriver1_adjust_config
+
     # Configure and build the test driver library
     # -------------------------------------------
 
-    # Disable ALG_STREAM_CIPHER and ALG_ECB_NO_PADDING to avoid having
-    # partial support for cipher operations in the driver test library.
-    scripts/config.py -f include/psa/crypto_config.h unset PSA_WANT_ALG_STREAM_CIPHER
-    scripts/config.py -f include/psa/crypto_config.h unset PSA_WANT_ALG_ECB_NO_PADDING
-
-    loc_accel_flags=$( echo "$loc_accel_list" | sed 's/[^ ]* */-DLIBTESTDRIVER1_MBEDTLS_PSA_ACCEL_&/g' )
-    make -C tests libtestdriver1.a CFLAGS=" $ASAN_CFLAGS $loc_accel_flags" LDFLAGS="$ASAN_CFLAGS"
+    helper_libtestdriver1_make_drivers "$loc_extra_list"
 
     # Configure and build the main libraries
     # --------------------------------------
@@ -2253,8 +2249,7 @@ component_test_psa_crypto_config_accel_ffdh () {
     scripts/config.py unset MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED
 
     # Build the main library
-    loc_accel_flags="$loc_accel_flags $( echo "$loc_accel_list" | sed 's/[^ ]* */-DMBEDTLS_PSA_ACCEL_&/g' )"
-    make CFLAGS="$ASAN_CFLAGS -O -Werror -I../tests/include -I../tests -I../../tests -DPSA_CRYPTO_DRIVER_TEST -DMBEDTLS_TEST_LIBTESTDRIVER1 $loc_accel_flags" LDFLAGS="-ltestdriver1 $ASAN_CFLAGS"
+    helper_libtestdriver1_make_main "$loc_extra_list"
 
     # Make sure this was not re-enabled by accident (additive config)
     not grep mbedtls_dhm_ library/dhm.o

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -807,7 +807,7 @@ pre_generate_files() {
 #    Examples:
 #      - loc_accel_list="ALG_JPAKE"
 #      - loc_accel_list="ALG_FFDH KEY_TYPE_DH_KEY_PAIR KEY_TYPE_DH_PUBLIC_KEY"
-# 2. Make configurations changes that are common to driver and main libraries.
+# 2. Make configuration changes that are common to driver and main libraries.
 #    WARNING: both libraries MUST have the same set of PSA_WANT_ALG symbols,
 #    as they determine the ABI between them, so all changes to these symbols
 #    go here.
@@ -816,7 +816,7 @@ pre_generate_files() {
 # 3. Build the driver library: libtestdriver1.a.
 #    Just call helper_libtestdriver1_make_drivers, passing "$loc_accel_list".
 #    You may need to enable more algorithms here, typically hash algorithms
-#    when accelerating some signature algoritms (ECDSA, RSAv2). This is done
+#    when accelerating some signature algorithms (ECDSA, RSAv2). This is done
 #    by passing a 2nd argument listing the extra algorithms.
 #    Example:
 #      loc_extra_list="ALG_SHA_224 ALG_SHA_256 ALG_SHA_384 ALG_SHA_512"
@@ -2233,7 +2233,7 @@ component_test_psa_crypto_config_accel_ffdh () {
     # Configure and build the test driver library
     # -------------------------------------------
 
-    helper_libtestdriver1_make_drivers "$loc_extra_list"
+    helper_libtestdriver1_make_drivers "$loc_accel_list"
 
     # Configure and build the main libraries
     # --------------------------------------
@@ -2249,7 +2249,7 @@ component_test_psa_crypto_config_accel_ffdh () {
     scripts/config.py unset MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED
 
     # Build the main library
-    helper_libtestdriver1_make_main "$loc_extra_list"
+    helper_libtestdriver1_make_main "$loc_accel_list"
 
     # Make sure this was not re-enabled by accident (additive config)
     not grep mbedtls_dhm_ library/dhm.o

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -2166,8 +2166,9 @@ component_test_psa_crypto_config_accel_ecdsa () {
     # Configure
     # ---------
 
-    # Start from default config (no TLS 1.3, no USE_PSA)
+    # Start from default config (no USE_PSA) + TLS 1.3
     helper_libtestdriver1_adjust_config "default"
+    scripts/config.py set MBEDTLS_SSL_PROTO_TLS1_3
 
     # Disable the module that's accelerated
     scripts/config.py unset MBEDTLS_ECDSA_C

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -795,7 +795,18 @@ pre_generate_files() {
     fi
 }
 
+################################################################
+#### Helpers for components using libtestdriver1
+################################################################
 
+# Adjust the configuration - for both libtestdriver1 and main library,
+# as they should have the same PSA_WANT macros.
+helper_libtestdriver1_adjust_config() {
+    # Disable ALG_STREAM_CIPHER and ALG_ECB_NO_PADDING to avoid having
+    # partial support for cipher operations in the driver test library.
+    scripts/config.py -f include/psa/crypto_config.h unset PSA_WANT_ALG_STREAM_CIPHER
+    scripts/config.py -f include/psa/crypto_config.h unset PSA_WANT_ALG_ECB_NO_PADDING
+}
 
 ################################################################
 #### Basic checks
@@ -2072,10 +2083,7 @@ component_test_psa_crypto_config_accel_ecdsa () {
     # Configure and build the test driver library
     # -------------------------------------------
 
-    # Disable ALG_STREAM_CIPHER and ALG_ECB_NO_PADDING to avoid having
-    # partial support for cipher operations in the driver test library.
-    scripts/config.py -f include/psa/crypto_config.h unset PSA_WANT_ALG_STREAM_CIPHER
-    scripts/config.py -f include/psa/crypto_config.h unset PSA_WANT_ALG_ECB_NO_PADDING
+    helper_libtestdriver1_adjust_config
 
     loc_accel_flags=$( echo "$loc_accel_list" | sed 's/[^ ]* */-DLIBTESTDRIVER1_MBEDTLS_PSA_ACCEL_&/g' )
     # These hashes are needed for some ECDSA signature tests.
@@ -2122,10 +2130,7 @@ component_test_psa_crypto_config_accel_ecdh () {
     # Configure and build the test driver library
     # -------------------------------------------
 
-    # Disable ALG_STREAM_CIPHER and ALG_ECB_NO_PADDING to avoid having
-    # partial support for cipher operations in the driver test library.
-    scripts/config.py -f include/psa/crypto_config.h unset PSA_WANT_ALG_STREAM_CIPHER
-    scripts/config.py -f include/psa/crypto_config.h unset PSA_WANT_ALG_ECB_NO_PADDING
+    helper_libtestdriver1_adjust_config
 
     loc_accel_flags=$( echo "$loc_accel_list" | sed 's/[^ ]* */-DLIBTESTDRIVER1_MBEDTLS_PSA_ACCEL_&/g' )
     make -C tests libtestdriver1.a CFLAGS=" $ASAN_CFLAGS $loc_accel_flags" LDFLAGS="$ASAN_CFLAGS"
@@ -2210,10 +2215,7 @@ component_test_psa_crypto_config_accel_pake() {
     # Start with full
     scripts/config.py full
 
-    # Disable ALG_STREAM_CIPHER and ALG_ECB_NO_PADDING to avoid having
-    # partial support for cipher operations in the driver test library.
-    scripts/config.py -f include/psa/crypto_config.h unset PSA_WANT_ALG_STREAM_CIPHER
-    scripts/config.py -f include/psa/crypto_config.h unset PSA_WANT_ALG_ECB_NO_PADDING
+    helper_libtestdriver1_adjust_config
 
     loc_accel_list="ALG_JPAKE"
     loc_accel_flags=$( echo "$loc_accel_list" | sed 's/[^ ]* */-DLIBTESTDRIVER1_MBEDTLS_PSA_ACCEL_&/g' )
@@ -2285,10 +2287,7 @@ component_test_psa_crypto_config_accel_all_ec_algs_use_psa () {
     # Configure and build the test driver library
     # -------------------------------------------
 
-    # Disable ALG_STREAM_CIPHER and ALG_ECB_NO_PADDING to avoid having
-    # partial support for cipher operations in the driver test library.
-    scripts/config.py -f include/psa/crypto_config.h unset PSA_WANT_ALG_STREAM_CIPHER
-    scripts/config.py -f include/psa/crypto_config.h unset PSA_WANT_ALG_ECB_NO_PADDING
+    helper_libtestdriver1_adjust_config
 
     # Things we wanted supported in libtestdriver1, but not accelerated in the main library:
     # SHA-1 and all SHA-2 variants, as they are used by ECDSA deterministic.
@@ -2431,6 +2430,8 @@ component_test_psa_crypto_full_accel_all_ec_algs_no_ecp_use_psa () {
     # Configure and build the test driver library
     # -------------------------------------------
 
+    helper_libtestdriver1_adjust_config
+
     # Things we wanted supported in libtestdriver1, but not accelerated in the main library:
     # SHA-1 and all SHA-2 variants, as they are used by ECDSA deterministic.
     loc_extra_list="ALG_SHA_1 ALG_SHA_224 ALG_SHA_256 ALG_SHA_384 ALG_SHA_512"
@@ -2498,10 +2499,7 @@ psa_crypto_config_accel_all_curves_except_one () {
     # Configure and build the test driver library
     # --------------------------------------------
 
-    # Disable ALG_STREAM_CIPHER and ALG_ECB_NO_PADDING to avoid having
-    # partial support for cipher operations in the driver test library.
-    scripts/config.py -f include/psa/crypto_config.h unset PSA_WANT_ALG_STREAM_CIPHER
-    scripts/config.py -f include/psa/crypto_config.h unset PSA_WANT_ALG_ECB_NO_PADDING
+    helper_libtestdriver1_adjust_config
 
     # RSA support is intentionally disabled on this test (see below for
     # explanation) so lets disable it also on the driver side
@@ -2604,10 +2602,7 @@ component_test_psa_crypto_config_accel_all_curves_except_x25519 () {
 component_test_psa_crypto_config_accel_rsa_signature () {
     msg "test: MBEDTLS_PSA_CRYPTO_CONFIG with accelerated RSA signature"
 
-    # Disable ALG_STREAM_CIPHER and ALG_ECB_NO_PADDING to avoid having
-    # partial support for cipher operations in the driver test library.
-    scripts/config.py -f include/psa/crypto_config.h unset PSA_WANT_ALG_STREAM_CIPHER
-    scripts/config.py -f include/psa/crypto_config.h unset PSA_WANT_ALG_ECB_NO_PADDING
+    helper_libtestdriver1_adjust_config
 
     # It seems it is not possible to remove only the support for RSA signature
     # in the library. Thus we have to remove all RSA support (signature and
@@ -2681,10 +2676,7 @@ component_test_psa_crypto_config_accel_rsa_signature () {
 component_test_psa_crypto_config_accel_hash () {
     msg "test: MBEDTLS_PSA_CRYPTO_CONFIG with accelerated hash"
 
-    # Disable ALG_STREAM_CIPHER and ALG_ECB_NO_PADDING to avoid having
-    # partial support for cipher operations in the driver test library.
-    scripts/config.py -f include/psa/crypto_config.h unset PSA_WANT_ALG_STREAM_CIPHER
-    scripts/config.py -f include/psa/crypto_config.h unset PSA_WANT_ALG_ECB_NO_PADDING
+    helper_libtestdriver1_adjust_config
 
     loc_accel_list="ALG_MD5 ALG_RIPEMD160 ALG_SHA_1 ALG_SHA_224 ALG_SHA_256 ALG_SHA_384 ALG_SHA_512"
     loc_accel_flags=$( echo "$loc_accel_list" | sed 's/[^ ]* */-DLIBTESTDRIVER1_MBEDTLS_PSA_ACCEL_&/g' )
@@ -2718,10 +2710,7 @@ component_test_psa_crypto_config_accel_hash_keep_builtins () {
     # This component ensures that all the test cases for
     # md_psa_dynamic_dispatch with legacy+driver in test_suite_md are run.
 
-    # Disable ALG_STREAM_CIPHER and ALG_ECB_NO_PADDING to avoid having
-    # partial support for cipher operations in the driver test library.
-    scripts/config.py -f include/psa/crypto_config.h unset PSA_WANT_ALG_STREAM_CIPHER
-    scripts/config.py -f include/psa/crypto_config.h unset PSA_WANT_ALG_ECB_NO_PADDING
+    helper_libtestdriver1_adjust_config
 
     loc_accel_list="ALG_MD5 ALG_RIPEMD160 ALG_SHA_1 ALG_SHA_224 ALG_SHA_256 ALG_SHA_384 ALG_SHA_512"
     loc_accel_flags=$( echo "$loc_accel_list" | sed 's/[^ ]* */-DLIBTESTDRIVER1_MBEDTLS_PSA_ACCEL_&/g' )
@@ -2766,10 +2755,7 @@ config_psa_crypto_hash_use_psa () {
 component_test_psa_crypto_config_accel_hash_use_psa () {
     msg "test: MBEDTLS_PSA_CRYPTO_CONFIG with accelerated hash and USE_PSA"
 
-    # Disable ALG_STREAM_CIPHER and ALG_ECB_NO_PADDING to avoid having
-    # partial support for cipher operations in the driver test library.
-    scripts/config.py -f include/psa/crypto_config.h unset PSA_WANT_ALG_STREAM_CIPHER
-    scripts/config.py -f include/psa/crypto_config.h unset PSA_WANT_ALG_ECB_NO_PADDING
+    helper_libtestdriver1_adjust_config
 
     loc_accel_list="ALG_MD5 ALG_RIPEMD160 ALG_SHA_1 ALG_SHA_224 ALG_SHA_256 ALG_SHA_384 ALG_SHA_512"
     loc_accel_flags=$( echo "$loc_accel_list" | sed 's/[^ ]* */-DLIBTESTDRIVER1_MBEDTLS_PSA_ACCEL_&/g' )
@@ -2827,6 +2813,8 @@ component_test_psa_crypto_config_reference_hash_use_psa() {
 component_test_psa_crypto_config_accel_cipher () {
     msg "test: MBEDTLS_PSA_CRYPTO_CONFIG with accelerated cipher"
 
+    helper_libtestdriver1_adjust_config
+
     loc_accel_list="ALG_CBC_NO_PADDING ALG_CBC_PKCS7 ALG_CTR ALG_CFB ALG_OFB ALG_XTS KEY_TYPE_DES"
     loc_accel_flags=$( echo "$loc_accel_list" | sed 's/[^ ]* */-DLIBTESTDRIVER1_MBEDTLS_PSA_ACCEL_&/g' )
     make -C tests libtestdriver1.a CFLAGS="$ASAN_CFLAGS $loc_accel_flags" LDFLAGS="$ASAN_CFLAGS"
@@ -2862,10 +2850,7 @@ component_test_psa_crypto_config_accel_cipher () {
 component_test_psa_crypto_config_accel_aead () {
     msg "test: MBEDTLS_PSA_CRYPTO_CONFIG with accelerated AEAD"
 
-    # Disable ALG_STREAM_CIPHER and ALG_ECB_NO_PADDING to avoid having
-    # partial support for cipher operations in the driver test library.
-    scripts/config.py -f include/psa/crypto_config.h unset PSA_WANT_ALG_STREAM_CIPHER
-    scripts/config.py -f include/psa/crypto_config.h unset PSA_WANT_ALG_ECB_NO_PADDING
+    helper_libtestdriver1_adjust_config
 
     loc_accel_list="ALG_GCM ALG_CCM ALG_CHACHA20_POLY1305 KEY_TYPE_AES KEY_TYPE_CHACHA20 KEY_TYPE_ARIA KEY_TYPE_CAMELLIA"
     loc_accel_flags=$( echo "$loc_accel_list" | sed 's/[^ ]* */-DLIBTESTDRIVER1_MBEDTLS_PSA_ACCEL_&/g' )
@@ -2899,10 +2884,7 @@ component_test_psa_crypto_config_accel_pake() {
     # Start with full
     scripts/config.py full
 
-    # Disable ALG_STREAM_CIPHER and ALG_ECB_NO_PADDING to avoid having
-    # partial support for cipher operations in the driver test library.
-    scripts/config.py -f include/psa/crypto_config.h unset PSA_WANT_ALG_STREAM_CIPHER
-    scripts/config.py -f include/psa/crypto_config.h unset PSA_WANT_ALG_ECB_NO_PADDING
+    helper_libtestdriver1_adjust_config
 
     loc_accel_list="ALG_JPAKE"
     loc_accel_flags=$( echo "$loc_accel_list" | sed 's/[^ ]* */-DLIBTESTDRIVER1_MBEDTLS_PSA_ACCEL_&/g' )

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -811,7 +811,7 @@ pre_generate_files() {
 #    2a. Call helper_libtestdriver1_adjust_config <base>, where the argument
 #        can be either "default" to start with the default config, or a name
 #        supported by scripts/config.py (for example, "full"). This selects
-#        the base to use, and make common adjustments.
+#        the base to use, and makes common adjustments.
 #    2b. If desired, adjust the PSA_WANT symbols in psa/crypto_config.h.
 #        These changes affect both the driver and the main libraries.
 #        (Note: they need to have the same set of PSA_WANT symbols, as that
@@ -856,6 +856,10 @@ helper_libtestdriver1_adjust_config() {
     # partial support for cipher operations in the driver test library.
     scripts/config.py -f include/psa/crypto_config.h unset PSA_WANT_ALG_STREAM_CIPHER
     scripts/config.py -f include/psa/crypto_config.h unset PSA_WANT_ALG_ECB_NO_PADDING
+
+    # Dynamic secure element support is a deprecated feature and needs to be disabled here.
+    # This is done to have the same form of psa_key_attributes_s for libdriver and library.
+    scripts/config.py unset MBEDTLS_PSA_CRYPTO_SE_C
 }
 
 # Build the drivers library libtestdriver1.a (with ASan).
@@ -2281,10 +2285,6 @@ component_test_psa_crypto_config_accel_pake() {
     scripts/config.py unset MBEDTLS_ECJPAKE_C
     scripts/config.py unset MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED
 
-    # Dynamic secure element support is a deprecated feature and needs to be disabled here.
-    # This is done to have the same form of psa_key_attributes_s for libdriver and library.
-    scripts/config.py unset MBEDTLS_PSA_CRYPTO_SE_C
-
     # Build
     # -----
 
@@ -2329,9 +2329,6 @@ config_psa_crypto_config_all_ec_algs_use_psa () {
     # the future, the following line could be removed (see issues
     # 6061, 6332 and following ones)
     scripts/config.py unset MBEDTLS_ECP_RESTARTABLE
-    # Dynamic secure element support is a deprecated feature and needs to be disabled here.
-    # This is done to have the same form of psa_key_attributes_s for libdriver and library.
-    scripts/config.py unset MBEDTLS_PSA_CRYPTO_SE_C
 }
 
 # Keep in sync with component_test_psa_crypto_config_reference_all_ec_algs_use_psa
@@ -2445,9 +2442,6 @@ config_psa_crypto_full_all_ec_algs_no_ecp_use_psa () {
     # the future, the following line could be removed (see issues
     # 6061, 6332 and following ones)
     scripts/config.py unset MBEDTLS_ECP_RESTARTABLE
-    # Dynamic secure element support is a deprecated feature and needs to be disabled here.
-    # This is done to have the same form of psa_key_attributes_s for libdriver and library.
-    scripts/config.py unset MBEDTLS_PSA_CRYPTO_SE_C
 
     # Disable PSA_WANT symbols that would re-enable PK
     scripts/config.py -f include/psa/crypto_config.h unset PSA_WANT_KEY_TYPE_RSA_KEY_PAIR
@@ -2541,10 +2535,6 @@ psa_crypto_config_accel_all_curves_except_one () {
     # ---------
 
     helper_libtestdriver1_adjust_config "full"
-
-    # Dynamic secure element support is a deprecated feature and needs to be disabled here.
-    # This is done to have the same form of psa_key_attributes_s for libdriver and library.
-    scripts/config.py unset MBEDTLS_PSA_CRYPTO_SE_C
 
     # restartable is not yet supported in PSA
     scripts/config.py unset MBEDTLS_ECP_RESTARTABLE
@@ -2784,10 +2774,6 @@ config_psa_crypto_hash_use_psa () {
         scripts/config.py unset MBEDTLS_SHA512_C
         scripts/config.py unset MBEDTLS_SHA512_USE_A64_CRYPTO_IF_PRESENT
     fi
-
-    # Dynamic secure element support is a deprecated feature and needs to be disabled here.
-    # This is done to have the same form of psa_key_attributes_s for libdriver and library.
-    scripts/config.py unset MBEDTLS_PSA_CRYPTO_SE_C
 }
 
 # Note that component_test_psa_crypto_config_reference_hash_use_psa
@@ -2950,10 +2936,6 @@ component_test_psa_crypto_config_accel_pake() {
     # Make build-in fallback not available
     scripts/config.py unset MBEDTLS_ECJPAKE_C
     scripts/config.py unset MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED
-
-    # Dynamic secure element support is a deprecated feature and needs to be disabled here.
-    # This is done to have the same form of psa_key_attributes_s for libdriver and library.
-    scripts/config.py unset MBEDTLS_PSA_CRYPTO_SE_C
 
     # Build
     # -----


### PR DESCRIPTION
## Description

The various all.sh components that use libtestdriver1 have a lot of code in common. Factor the common bits into helper functions: this reduces duplication and makes each component less cluttered hence more readable. Also add a bit of documentation.

The purpose of this PR is to change as little as possible while making things more readable and uniform.

Questions such as "is the current content of `helper_libtestdriver1_adjust_config` really needed?" or "should it not include CMAC as well?" or "should we take an entirely different approach to things that don't have their own ACCEL macros?" are explicitly out of scope for this PR.

## PR checklist

- [x] **changelog** not required - internal to tests
- [x] **backport** not required. The reason we usually backport test improvements is to make backports of future bug fixes (with new tests) easier, but I'm not convinced we'll find ourselves backporting changes to all.sh components involving libtestdriver1. 
- [x] **tests** not required - refactoring test scripts
