### PR TITLE
PK: add support for check_pair() with "opaque" EC keys

### DIFF
--- a/library/pk.c
+++ b/library/pk.c
@@ -825,7 +825,8 @@ int mbedtls_pk_check_pair(const mbedtls_pk_context *pub,
             return MBEDTLS_ERR_PK_TYPE_MISMATCH;
         }
     } else {
-        if (pub->pk_info != prv->pk_info) {
+        if ((prv->pk_info->type != MBEDTLS_PK_OPAQUE) &&
+            (pub->pk_info != prv->pk_info)) {
             return MBEDTLS_ERR_PK_TYPE_MISMATCH;
         }
     }

--- a/library/pk_internal.h
+++ b/library/pk_internal.h
@@ -86,11 +86,11 @@ static inline mbedtls_ecp_group_id mbedtls_pk_get_group_id(const mbedtls_pk_cont
     mbedtls_ecp_group_id id;
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
-    psa_key_attributes_t opaque_attrs = PSA_KEY_ATTRIBUTES_INIT;
-    psa_key_type_t opaque_key_type;
-    psa_ecc_family_t curve;
-
     if (mbedtls_pk_get_type(pk) == MBEDTLS_PK_OPAQUE) {
+        psa_key_attributes_t opaque_attrs = PSA_KEY_ATTRIBUTES_INIT;
+        psa_key_type_t opaque_key_type;
+        psa_ecc_family_t curve;
+
         if (psa_get_key_attributes(pk->priv_id, &opaque_attrs) != PSA_SUCCESS) {
             return MBEDTLS_ECP_DP_NONE;
         }

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -562,6 +562,9 @@ exit:
 void mbedtls_pk_check_pair(char *pub_file, char *prv_file, int ret)
 {
     mbedtls_pk_context pub, prv, alt;
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    mbedtls_svc_key_id_t opaque_key_id = MBEDTLS_SVC_KEY_ID_INIT;
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     mbedtls_pk_init(&pub);
     mbedtls_pk_init(&prv);
@@ -575,7 +578,7 @@ void mbedtls_pk_check_pair(char *pub_file, char *prv_file, int ret)
     if (ret == MBEDTLS_ERR_ECP_BAD_INPUT_DATA) {
         ret = MBEDTLS_ERR_PK_BAD_INPUT_DATA;
     }
-#endif
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     TEST_ASSERT(mbedtls_pk_parse_public_keyfile(&pub, pub_file) == 0);
     TEST_ASSERT(mbedtls_pk_parse_keyfile(&prv, prv_file, NULL,
@@ -596,7 +599,20 @@ void mbedtls_pk_check_pair(char *pub_file, char *prv_file, int ret)
                     == ret);
     }
 #endif
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    if (mbedtls_pk_get_type(&prv) == MBEDTLS_PK_ECKEY) {
+        TEST_EQUAL(mbedtls_pk_wrap_as_opaque(&prv, &opaque_key_id,
+                                             PSA_ALG_ANY_HASH,
+                                             PSA_KEY_USAGE_EXPORT, 0), 0);
+        TEST_EQUAL(mbedtls_pk_check_pair(&pub, &prv, mbedtls_test_rnd_std_rand,
+                                         NULL), ret);
+    }
+#endif
 
+exit:
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_destroy_key(opaque_key_id);
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
     mbedtls_pk_free(&pub);
     mbedtls_pk_free(&prv);
     mbedtls_pk_free(&alt);


### PR DESCRIPTION
Add support for key pair check for opaque EC keys.

Depends on #7533 
Resolves #7485

## PR checklist

- [x] **changelog** will be done in #7452
- [x] **backport** not required as it's an enhancement
- [x] **tests** provided