### PR TITLE
[Bignum] Split out raw ECP mod p448

### DIFF
--- a/library/ecp_curves.c
+++ b/library/ecp_curves.c
@@ -4613,7 +4613,7 @@ int mbedtls_ecp_mod_p255_raw(mbedtls_mpi_uint *X, size_t X_limbs);
 #if defined(MBEDTLS_ECP_DP_CURVE448_ENABLED)
 static int ecp_mod_p448(mbedtls_mpi *);
 MBEDTLS_STATIC_TESTABLE
-int mbedtls_ecp_mod_p448(mbedtls_mpi_uint *, size_t);
+int mbedtls_ecp_mod_p448_raw(mbedtls_mpi_uint *, size_t);
 #endif
 #if defined(MBEDTLS_ECP_DP_SECP192K1_ENABLED)
 static int ecp_mod_p192k1(mbedtls_mpi *);
@@ -5499,7 +5499,7 @@ static int ecp_mod_p448(mbedtls_mpi *N)
      * will no longer happen. */
     MBEDTLS_MPI_CHK(mbedtls_mpi_grow(N, expected_width));
 
-    ret = mbedtls_ecp_mod_p448(N->p, N->n);
+    ret = mbedtls_ecp_mod_p448_raw(N->p, N->n);
 
 cleanup:
     return ret;
@@ -5517,7 +5517,7 @@ cleanup:
  * since mpi_core_add will then use 64-bit adds.
  */
 MBEDTLS_STATIC_TESTABLE
-int mbedtls_ecp_mod_p448(mbedtls_mpi_uint *X, size_t X_limbs)
+int mbedtls_ecp_mod_p448_raw(mbedtls_mpi_uint *X, size_t X_limbs)
 {
     size_t round;
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;

--- a/library/ecp_invasive.h
+++ b/library/ecp_invasive.h
@@ -284,7 +284,7 @@ int mbedtls_ecp_mod_p255_raw(mbedtls_mpi_uint *X, size_t X_limbs);
  *                  failed.
  */
 MBEDTLS_STATIC_TESTABLE
-int mbedtls_ecp_mod_p448(mbedtls_mpi_uint *X, size_t X_limbs);
+int mbedtls_ecp_mod_p448_raw(mbedtls_mpi_uint *X, size_t X_limbs);
 
 #endif /* MBEDTLS_ECP_DP_CURVE448_ENABLED */
 

--- a/scripts/mbedtls_dev/ecp.py
+++ b/scripts/mbedtls_dev/ecp.py
@@ -784,8 +784,8 @@ class EcpP448Raw(bignum_common.ModOperationCommon,
                  EcpTarget):
     """Test cases for ECP P448 fast reduction."""
     symbol = "-"
-    test_function = "ecp_mod_p448"
-    test_name = "ecp_mod_p448"
+    test_function = "ecp_mod_p_generic_raw"
+    test_name = "ecp_mod_p448_raw"
     input_style = "fixed"
     arity = 1
     dependencies = ["MBEDTLS_ECP_DP_CURVE448_ENABLED"]
@@ -873,3 +873,7 @@ class EcpP448Raw(bignum_common.ModOperationCommon,
     @property
     def is_valid(self) -> bool:
         return True
+
+    def arguments(self):
+        args = super().arguments()
+        return  ["MBEDTLS_ECP_DP_CURVE448"] + args

--- a/tests/suites/test_suite_ecp.function
+++ b/tests/suites/test_suite_ecp.function
@@ -1357,6 +1357,13 @@ void ecp_mod_p_generic_raw(int curve_id,
             curve_func = &mbedtls_ecp_mod_p255_raw;
             break;
 #endif
+#if defined(MBEDTLS_ECP_DP_CURVE448_ENABLED)
+        case MBEDTLS_ECP_DP_CURVE448:
+            limbs = 2 * limbs_N;
+            curve_bits = 448;
+            curve_func = &mbedtls_ecp_mod_p448_raw;
+            break;
+#endif
         default:
             mbedtls_test_fail("Unsupported curve_id", __LINE__, __FILE__);
             goto exit;
@@ -1381,45 +1388,6 @@ exit:
 
     mbedtls_mpi_mod_modulus_free(&m);
     mbedtls_free(N);
-}
-/* END_CASE */
-
-/* BEGIN_CASE depends_on:MBEDTLS_TEST_HOOKS:MBEDTLS_ECP_DP_CURVE448_ENABLED */
-void ecp_mod_p448(char *input_N,
-                  char *input_X,
-                  char *result)
-{
-    mbedtls_mpi X;
-    mbedtls_mpi N;
-    mbedtls_mpi res;
-
-    mbedtls_mpi_init(&X);
-    mbedtls_mpi_init(&N);
-    mbedtls_mpi_init(&res);
-
-    TEST_EQUAL(mbedtls_test_read_mpi(&X,   input_X), 0);
-    TEST_EQUAL(mbedtls_test_read_mpi(&N,   input_N), 0);
-    TEST_EQUAL(mbedtls_test_read_mpi(&res, result),  0);
-
-    TEST_ASSERT(mbedtls_mpi_core_uint_le_mpi(0, X.p, X.n));
-    TEST_ASSERT(mbedtls_mpi_core_uint_le_mpi(0, N.p, N.n));
-    TEST_ASSERT(mbedtls_mpi_core_uint_le_mpi(0, res.p, res.n));
-
-    size_t limbs = N.n;
-    size_t bytes = limbs * sizeof(mbedtls_mpi_uint);
-
-    TEST_LE_U(X.n, 2 * limbs);
-    TEST_EQUAL(res.n, limbs);
-
-    TEST_EQUAL(mbedtls_ecp_mod_p448(X.p, X.n), 0);
-    TEST_EQUAL(mbedtls_mpi_mod_mpi(&X, &X, &N), 0);
-    TEST_LE_U(mbedtls_mpi_core_bitlen(X.p, X.n), 448);
-    ASSERT_COMPARE(X.p, bytes, res.p, bytes);
-
-exit:
-    mbedtls_mpi_free(&X);
-    mbedtls_mpi_free(&N);
-    mbedtls_mpi_free(&res);
 }
 /* END_CASE */
 


### PR DESCRIPTION
## Description

Split out raw functions for ECP mod p448 reduction, and change testing over to using the generic mod P functions.


## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** ~~provided, or~~ not required (part of Bignum work)
- [x] **backport** ~~done, or~~ not required (new feature)
- [x] **tests** provided ~~, or not required~~
