### PR TITLE
x509parse tests: Replace TEST_ASSERT with TEST_EQUAL

### DIFF
--- a/tests/suites/test_suite_x509parse.function
+++ b/tests/suites/test_suite_x509parse.function
@@ -433,7 +433,7 @@ void x509_accessor_ext_types(int ext_type, int has_ext_type)
 
     crt.ext_types = ext_type;
 
-    TEST_ASSERT(mbedtls_x509_crt_has_ext_type(&crt, has_ext_type) == expected_result);
+    TEST_EQUAL(mbedtls_x509_crt_has_ext_type(&crt, has_ext_type), expected_result);
 
 exit:
     mbedtls_x509_crt_free(&crt);
@@ -491,7 +491,7 @@ void x509_parse_san(char *crt_file, char *result_str, int parse_result)
         }
     }
 
-    TEST_ASSERT(strcmp(buf, result_str) == 0);
+    TEST_EQUAL(strcmp(buf, result_str), 0);
 
 exit:
     mbedtls_x509_crt_free(&crt);
@@ -510,13 +510,13 @@ void x509_cert_info(char *crt_file, char *result_str)
     USE_PSA_INIT();
     memset(buf, 0, 2000);
 
-    TEST_ASSERT(mbedtls_x509_crt_parse_file(&crt, crt_file) == 0);
+    TEST_EQUAL(mbedtls_x509_crt_parse_file(&crt, crt_file), 0);
     res = mbedtls_x509_crt_info(buf, 2000, "", &crt);
 
     TEST_ASSERT(res != -1);
     TEST_ASSERT(res != -2);
 
-    TEST_ASSERT(strcmp(buf, result_str) == 0);
+    TEST_EQUAL(strcmp(buf, result_str), 0);
 
 exit:
     mbedtls_x509_crt_free(&crt);
@@ -535,13 +535,13 @@ void mbedtls_x509_crl_info(char *crl_file, char *result_str)
     USE_PSA_INIT();
     memset(buf, 0, 2000);
 
-    TEST_ASSERT(mbedtls_x509_crl_parse_file(&crl, crl_file) == 0);
+    TEST_EQUAL(mbedtls_x509_crl_parse_file(&crl, crl_file), 0);
     res = mbedtls_x509_crl_info(buf, 2000, "", &crl);
 
     TEST_ASSERT(res != -1);
     TEST_ASSERT(res != -2);
 
-    TEST_ASSERT(strcmp(buf, result_str) == 0);
+    TEST_EQUAL(strcmp(buf, result_str), 0);
 
 exit:
     mbedtls_x509_crl_free(&crl);
@@ -559,7 +559,7 @@ void mbedtls_x509_crl_parse(char *crl_file, int result)
     USE_PSA_INIT();
     memset(buf, 0, 2000);
 
-    TEST_ASSERT(mbedtls_x509_crl_parse_file(&crl, crl_file) == result);
+    TEST_EQUAL(mbedtls_x509_crl_parse_file(&crl, crl_file), result);
 
 exit:
     mbedtls_x509_crl_free(&crl);
@@ -578,13 +578,13 @@ void mbedtls_x509_csr_info(char *csr_file, char *result_str)
     USE_PSA_INIT();
     memset(buf, 0, 2000);
 
-    TEST_ASSERT(mbedtls_x509_csr_parse_file(&csr, csr_file) == 0);
+    TEST_EQUAL(mbedtls_x509_csr_parse_file(&csr, csr_file), 0);
     res = mbedtls_x509_csr_info(buf, 2000, "", &csr);
 
     TEST_ASSERT(res != -1);
     TEST_ASSERT(res != -2);
 
-    TEST_ASSERT(strcmp(buf, result_str) == 0);
+    TEST_EQUAL(strcmp(buf, result_str), 0);
 
 exit:
     mbedtls_x509_csr_free(&csr);
@@ -605,7 +605,7 @@ void x509_verify_info(int flags, char *prefix, char *result_str)
 
     TEST_ASSERT(res >= 0);
 
-    TEST_ASSERT(strcmp(buf, result_str) == 0);
+    TEST_EQUAL(strcmp(buf, result_str), 0);
 
 exit:
     USE_PSA_DONE();
@@ -637,8 +637,8 @@ void x509_verify_restart(char *crt_file, char *ca_file,
     mbedtls_x509_crt_init(&ca);
     MD_OR_USE_PSA_INIT();
 
-    TEST_ASSERT(mbedtls_x509_crt_parse_file(&crt, crt_file) == 0);
-    TEST_ASSERT(mbedtls_x509_crt_parse_file(&ca, ca_file) == 0);
+    TEST_EQUAL(mbedtls_x509_crt_parse_file(&crt, crt_file), 0);
+    TEST_EQUAL(mbedtls_x509_crt_parse_file(&ca, ca_file), 0);
 
     mbedtls_ecp_set_max_ops(max_ops);
 
@@ -649,8 +649,8 @@ void x509_verify_restart(char *crt_file, char *ca_file,
                                                   NULL, NULL, &rs_ctx);
     } while (ret == MBEDTLS_ERR_ECP_IN_PROGRESS && ++cnt_restart);
 
-    TEST_ASSERT(ret == result);
-    TEST_ASSERT(flags == (uint32_t) flags_result);
+    TEST_EQUAL(ret, result);
+    TEST_EQUAL(flags, (uint32_t) flags_result);
 
     TEST_ASSERT(cnt_restart >= min_restart);
     TEST_ASSERT(cnt_restart <= max_restart);
@@ -717,9 +717,9 @@ void x509_verify(char *crt_file, char *ca_file, char *crl_file,
         TEST_ASSERT("No known verify callback selected" == 0);
     }
 
-    TEST_ASSERT(mbedtls_x509_crt_parse_file(&crt, crt_file) == 0);
-    TEST_ASSERT(mbedtls_x509_crt_parse_file(&ca, ca_file) == 0);
-    TEST_ASSERT(mbedtls_x509_crl_parse_file(&crl, crl_file) == 0);
+    TEST_EQUAL(mbedtls_x509_crt_parse_file(&crt, crt_file), 0);
+    TEST_EQUAL(mbedtls_x509_crt_parse_file(&ca, ca_file), 0);
+    TEST_EQUAL(mbedtls_x509_crl_parse_file(&crl, crl_file), 0);
 
     res = mbedtls_x509_crt_verify_with_profile(&crt,
                                                &ca,
@@ -748,8 +748,8 @@ void x509_verify(char *crt_file, char *ca_file, char *crl_file,
                                                  f_vrfy,
                                                  NULL);
 
-        TEST_ASSERT(res == (result));
-        TEST_ASSERT(flags == (uint32_t) (flags_result));
+        TEST_EQUAL(res, result);
+        TEST_EQUAL(flags, (uint32_t) (flags_result));
     }
 #endif /* MBEDTLS_X509_TRUSTED_CERTIFICATE_CALLBACK */
 exit:
@@ -773,8 +773,8 @@ void x509_verify_ca_cb_failure(char *crt_file, char *ca_file, char *name,
     mbedtls_x509_crt_init(&ca);
     USE_PSA_INIT();
 
-    TEST_ASSERT(mbedtls_x509_crt_parse_file(&crt, crt_file) == 0);
-    TEST_ASSERT(mbedtls_x509_crt_parse_file(&ca, ca_file) == 0);
+    TEST_EQUAL(mbedtls_x509_crt_parse_file(&crt, crt_file), 0);
+    TEST_EQUAL(mbedtls_x509_crt_parse_file(&ca, ca_file), 0);
 
     if (strcmp(name, "NULL") == 0) {
         name = NULL;
@@ -784,8 +784,8 @@ void x509_verify_ca_cb_failure(char *crt_file, char *ca_file, char *name,
                                              &compat_profile, name, &flags,
                                              NULL, NULL);
 
-    TEST_ASSERT(ret == exp_ret);
-    TEST_ASSERT(flags == (uint32_t) (-1));
+    TEST_EQUAL(ret, exp_ret);
+    TEST_EQUAL(flags, (uint32_t) (-1));
 exit:
     mbedtls_x509_crt_free(&crt);
     mbedtls_x509_crt_free(&ca);
@@ -809,8 +809,8 @@ void x509_verify_callback(char *crt_file, char *ca_file, char *name,
 
     verify_print_init(&vrfy_ctx);
 
-    TEST_ASSERT(mbedtls_x509_crt_parse_file(&crt, crt_file) == 0);
-    TEST_ASSERT(mbedtls_x509_crt_parse_file(&ca, ca_file) == 0);
+    TEST_EQUAL(mbedtls_x509_crt_parse_file(&crt, crt_file), 0);
+    TEST_EQUAL(mbedtls_x509_crt_parse_file(&ca, ca_file), 0);
 
     if (strcmp(name, "NULL") == 0) {
         name = NULL;
@@ -821,8 +821,8 @@ void x509_verify_callback(char *crt_file, char *ca_file, char *name,
                                                name, &flags,
                                                verify_print, &vrfy_ctx);
 
-    TEST_ASSERT(ret == exp_ret);
-    TEST_ASSERT(strcmp(vrfy_ctx.buf, exp_vrfy_out) == 0);
+    TEST_EQUAL(ret, exp_ret);
+    TEST_EQUAL(strcmp(vrfy_ctx.buf, exp_vrfy_out), 0);
 
 exit:
     mbedtls_x509_crt_free(&crt);
@@ -846,18 +846,18 @@ void mbedtls_x509_dn_gets_subject_replace(char *crt_file,
 
     memset(buf, 0, 2000);
 
-    TEST_ASSERT(mbedtls_x509_crt_parse_file(&crt, crt_file) == 0);
+    TEST_EQUAL(mbedtls_x509_crt_parse_file(&crt, crt_file), 0);
     crt.subject.next->val.p = (unsigned char *) new_subject_ou;
     crt.subject.next->val.len = strlen(new_subject_ou);
 
     res =  mbedtls_x509_dn_gets(buf, 2000, &crt.subject);
 
     if (ret != 0) {
-        TEST_ASSERT(res == ret);
+        TEST_EQUAL(res, ret);
     } else {
         TEST_ASSERT(res != -1);
         TEST_ASSERT(res != -2);
-        TEST_ASSERT(strcmp(buf, result_str) == 0);
+        TEST_EQUAL(strcmp(buf, result_str), 0);
     }
 exit:
     mbedtls_x509_crt_free(&crt);
@@ -877,7 +877,7 @@ void mbedtls_x509_dn_gets(char *crt_file, char *entity, char *result_str)
 
     memset(buf, 0, 2000);
 
-    TEST_ASSERT(mbedtls_x509_crt_parse_file(&crt, crt_file) == 0);
+    TEST_EQUAL(mbedtls_x509_crt_parse_file(&crt, crt_file), 0);
     if (strcmp(entity, "subject") == 0) {
         res =  mbedtls_x509_dn_gets(buf, 2000, &crt.subject);
     } else if (strcmp(entity, "issuer") == 0) {
@@ -889,7 +889,7 @@ void mbedtls_x509_dn_gets(char *crt_file, char *entity, char *result_str)
     TEST_ASSERT(res != -1);
     TEST_ASSERT(res != -2);
 
-    TEST_ASSERT(strcmp(buf, result_str) == 0);
+    TEST_EQUAL(strcmp(buf, result_str), 0);
 
 exit:
     mbedtls_x509_crt_free(&crt);
@@ -1001,12 +1001,12 @@ void mbedtls_x509_time_is_past(char *crt_file, char *entity, int result)
     mbedtls_x509_crt_init(&crt);
     USE_PSA_INIT();
 
-    TEST_ASSERT(mbedtls_x509_crt_parse_file(&crt, crt_file) == 0);
+    TEST_EQUAL(mbedtls_x509_crt_parse_file(&crt, crt_file), 0);
 
     if (strcmp(entity, "valid_from") == 0) {
-        TEST_ASSERT(mbedtls_x509_time_is_past(&crt.valid_from) == result);
+        TEST_EQUAL(mbedtls_x509_time_is_past(&crt.valid_from), result);
     } else if (strcmp(entity, "valid_to") == 0) {
-        TEST_ASSERT(mbedtls_x509_time_is_past(&crt.valid_to) == result);
+        TEST_EQUAL(mbedtls_x509_time_is_past(&crt.valid_to), result);
     } else {
         TEST_ASSERT("Unknown entity" == 0);
     }
@@ -1025,12 +1025,12 @@ void mbedtls_x509_time_is_future(char *crt_file, char *entity, int result)
     mbedtls_x509_crt_init(&crt);
     USE_PSA_INIT();
 
-    TEST_ASSERT(mbedtls_x509_crt_parse_file(&crt, crt_file) == 0);
+    TEST_EQUAL(mbedtls_x509_crt_parse_file(&crt, crt_file), 0);
 
     if (strcmp(entity, "valid_from") == 0) {
-        TEST_ASSERT(mbedtls_x509_time_is_future(&crt.valid_from) == result);
+        TEST_EQUAL(mbedtls_x509_time_is_future(&crt.valid_from), result);
     } else if (strcmp(entity, "valid_to") == 0) {
-        TEST_ASSERT(mbedtls_x509_time_is_future(&crt.valid_to) == result);
+        TEST_EQUAL(mbedtls_x509_time_is_future(&crt.valid_to), result);
     } else {
         TEST_ASSERT("Unknown entity" == 0);
     }
@@ -1049,7 +1049,7 @@ void x509parse_crt_file(char *crt_file, int result)
     mbedtls_x509_crt_init(&crt);
     USE_PSA_INIT();
 
-    TEST_ASSERT(mbedtls_x509_crt_parse_file(&crt, crt_file) == result);
+    TEST_EQUAL(mbedtls_x509_crt_parse_file(&crt, crt_file), result);
 
 exit:
     mbedtls_x509_crt_free(&crt);
@@ -1071,14 +1071,14 @@ void x509parse_crt(data_t *buf, char *result_str, int result)
     mbedtls_x509_crt_init(&crt);
     USE_PSA_INIT();
 
-    TEST_ASSERT(mbedtls_x509_crt_parse_der(&crt, buf->x, buf->len) == (result));
+    TEST_EQUAL(mbedtls_x509_crt_parse_der(&crt, buf->x, buf->len), result);
 #if !defined(MBEDTLS_X509_REMOVE_INFO)
     if ((result) == 0) {
         res = mbedtls_x509_crt_info((char *) output, 2000, "", &crt);
         TEST_ASSERT(res != -1);
         TEST_ASSERT(res != -2);
 
-        TEST_ASSERT(strcmp((char *) output, result_str) == 0);
+        TEST_EQUAL(strcmp((char *) output, result_str), 0);
     }
     memset(output, 0, 2000);
 #endif
@@ -1086,7 +1086,7 @@ void x509parse_crt(data_t *buf, char *result_str, int result)
     mbedtls_x509_crt_free(&crt);
     mbedtls_x509_crt_init(&crt);
 
-    TEST_ASSERT(mbedtls_x509_crt_parse_der_nocopy(&crt, buf->x, buf->len) == (result));
+    TEST_EQUAL(mbedtls_x509_crt_parse_der_nocopy(&crt, buf->x, buf->len), result);
 #if !defined(MBEDTLS_X509_REMOVE_INFO)
     if ((result) == 0) {
         memset(output, 0, 2000);
@@ -1096,7 +1096,7 @@ void x509parse_crt(data_t *buf, char *result_str, int result)
         TEST_ASSERT(res != -1);
         TEST_ASSERT(res != -2);
 
-        TEST_ASSERT(strcmp((char *) output, result_str) == 0);
+        TEST_EQUAL(strcmp((char *) output, result_str), 0);
     }
     memset(output, 0, 2000);
 #endif /* !MBEDTLS_X509_REMOVE_INFO */
@@ -1104,8 +1104,8 @@ void x509parse_crt(data_t *buf, char *result_str, int result)
     mbedtls_x509_crt_free(&crt);
     mbedtls_x509_crt_init(&crt);
 
-    TEST_ASSERT(mbedtls_x509_crt_parse_der_with_ext_cb(&crt, buf->x, buf->len, 0, NULL,
-                                                       NULL) == (result));
+    TEST_EQUAL(mbedtls_x509_crt_parse_der_with_ext_cb(&crt, buf->x, buf->len, 0, NULL, NULL),
+               result);
 #if !defined(MBEDTLS_X509_REMOVE_INFO)
     if ((result) == 0) {
         res = mbedtls_x509_crt_info((char *) output, 2000, "", &crt);
@@ -1113,7 +1113,7 @@ void x509parse_crt(data_t *buf, char *result_str, int result)
         TEST_ASSERT(res != -1);
         TEST_ASSERT(res != -2);
 
-        TEST_ASSERT(strcmp((char *) output, result_str) == 0);
+        TEST_EQUAL(strcmp((char *) output, result_str), 0);
     }
     memset(output, 0, 2000);
 #endif /* !MBEDTLS_X509_REMOVE_INFO */
@@ -1121,8 +1121,8 @@ void x509parse_crt(data_t *buf, char *result_str, int result)
     mbedtls_x509_crt_free(&crt);
     mbedtls_x509_crt_init(&crt);
 
-    TEST_ASSERT(mbedtls_x509_crt_parse_der_with_ext_cb(&crt, buf->x, buf->len, 1, NULL,
-                                                       NULL) == (result));
+    TEST_EQUAL(mbedtls_x509_crt_parse_der_with_ext_cb(&crt, buf->x, buf->len, 1, NULL, NULL),
+               result);
 #if !defined(MBEDTLS_X509_REMOVE_INFO)
     if ((result) == 0) {
         res = mbedtls_x509_crt_info((char *) output, 2000, "", &crt);
@@ -1130,7 +1130,7 @@ void x509parse_crt(data_t *buf, char *result_str, int result)
         TEST_ASSERT(res != -1);
         TEST_ASSERT(res != -2);
 
-        TEST_ASSERT(strcmp((char *) output, result_str) == 0);
+        TEST_EQUAL(strcmp((char *) output, result_str), 0);
     }
 #endif /* !MBEDTLS_X509_REMOVE_INFO */
 
@@ -1160,8 +1160,8 @@ void x509parse_crt_cb(data_t *buf, char *result_str, int result)
     mbedtls_x509_crt_init(&crt);
     USE_PSA_INIT();
 
-    TEST_ASSERT(mbedtls_x509_crt_parse_der_with_ext_cb(&crt, buf->x, buf->len, 0, parse_crt_ext_cb,
-                                                       &oid) == (result));
+    TEST_EQUAL(mbedtls_x509_crt_parse_der_with_ext_cb(&crt, buf->x, buf->len, 0, parse_crt_ext_cb,
+                                                      &oid), result);
 #if !defined(MBEDTLS_X509_REMOVE_INFO)
     if ((result) == 0) {
         res = mbedtls_x509_crt_info((char *) output, 2000, "", &crt);
@@ -1169,7 +1169,7 @@ void x509parse_crt_cb(data_t *buf, char *result_str, int result)
         TEST_ASSERT(res != -1);
         TEST_ASSERT(res != -2);
 
-        TEST_ASSERT(strcmp((char *) output, result_str) == 0);
+        TEST_EQUAL(strcmp((char *) output, result_str), 0);
     }
     memset(output, 0, 2000);
 #endif /* !MBEDTLS_X509_REMOVE_INFO */
@@ -1177,8 +1177,8 @@ void x509parse_crt_cb(data_t *buf, char *result_str, int result)
     mbedtls_x509_crt_free(&crt);
     mbedtls_x509_crt_init(&crt);
 
-    TEST_ASSERT(mbedtls_x509_crt_parse_der_with_ext_cb(&crt, buf->x, buf->len, 1, parse_crt_ext_cb,
-                                                       &oid) == (result));
+    TEST_EQUAL(mbedtls_x509_crt_parse_der_with_ext_cb(&crt, buf->x, buf->len, 1, parse_crt_ext_cb,
+                                                      &oid), (result));
 #if !defined(MBEDTLS_X509_REMOVE_INFO)
     if ((result) == 0) {
         res = mbedtls_x509_crt_info((char *) output, 2000, "", &crt);
@@ -1186,7 +1186,7 @@ void x509parse_crt_cb(data_t *buf, char *result_str, int result)
         TEST_ASSERT(res != -1);
         TEST_ASSERT(res != -2);
 
-        TEST_ASSERT(strcmp((char *) output, result_str) == 0);
+        TEST_EQUAL(strcmp((char *) output, result_str), 0);
     }
 #endif /* !MBEDTLS_X509_REMOVE_INFO */
 
@@ -1209,14 +1209,14 @@ void x509parse_crl(data_t *buf, char *result_str, int result)
     memset(output, 0, 2000);
 
 
-    TEST_ASSERT(mbedtls_x509_crl_parse(&crl, buf->x, buf->len) == (result));
+    TEST_EQUAL(mbedtls_x509_crl_parse(&crl, buf->x, buf->len), (result));
     if ((result) == 0) {
         res = mbedtls_x509_crl_info((char *) output, 2000, "", &crl);
 
         TEST_ASSERT(res != -1);
         TEST_ASSERT(res != -2);
 
-        TEST_ASSERT(strcmp((char *) output, result_str) == 0);
+        TEST_EQUAL(strcmp((char *) output, result_str), 0);
     }
 
 exit:
@@ -1238,12 +1238,12 @@ void mbedtls_x509_csr_parse(data_t *csr_der, char *ref_out, int ref_ret)
     memset(my_out, 0, sizeof(my_out));
 
     my_ret = mbedtls_x509_csr_parse_der(&csr, csr_der->x, csr_der->len);
-    TEST_ASSERT(my_ret == ref_ret);
+    TEST_EQUAL(my_ret, ref_ret);
 
     if (ref_ret == 0) {
         size_t my_out_len = mbedtls_x509_csr_info(my_out, sizeof(my_out), "", &csr);
-        TEST_ASSERT(my_out_len == strlen(ref_out));
-        TEST_ASSERT(strcmp(my_out, ref_out) == 0);
+        TEST_EQUAL(my_out_len, strlen(ref_out));
+        TEST_EQUAL(strcmp(my_out, ref_out), 0);
     }
 
 exit:
@@ -1265,12 +1265,12 @@ void mbedtls_x509_csr_parse_file(char *csr_file, char *ref_out, int ref_ret)
     memset(my_out, 0, sizeof(my_out));
 
     my_ret = mbedtls_x509_csr_parse_file(&csr, csr_file);
-    TEST_ASSERT(my_ret == ref_ret);
+    TEST_EQUAL(my_ret, ref_ret);
 
     if (ref_ret == 0) {
         size_t my_out_len = mbedtls_x509_csr_info(my_out, sizeof(my_out), "", &csr);
-        TEST_ASSERT(my_out_len == strlen(ref_out));
-        TEST_ASSERT(strcmp(my_out, ref_out) == 0);
+        TEST_EQUAL(my_out_len, strlen(ref_out));
+        TEST_EQUAL(strcmp(my_out, ref_out), 0);
     }
 
 exit:
@@ -1288,7 +1288,7 @@ void mbedtls_x509_crt_parse_path(char *crt_path, int ret, int nb_crt)
     mbedtls_x509_crt_init(&chain);
     USE_PSA_INIT();
 
-    TEST_ASSERT(mbedtls_x509_crt_parse_path(&chain, crt_path) == ret);
+    TEST_EQUAL(mbedtls_x509_crt_parse_path(&chain, crt_path), ret);
 
     /* Check how many certs we got */
     for (i = 0, cur = &chain; cur != NULL; cur = cur->next) {
@@ -1297,7 +1297,7 @@ void mbedtls_x509_crt_parse_path(char *crt_path, int ret, int nb_crt)
         }
     }
 
-    TEST_ASSERT(i == nb_crt);
+    TEST_EQUAL(i, nb_crt);
 
 exit:
     mbedtls_x509_crt_free(&chain);
@@ -1323,20 +1323,20 @@ void mbedtls_x509_crt_verify_max(char *ca_file, char *chain_dir, int nb_int,
     MD_OR_USE_PSA_INIT();
 
     /* Load trusted root */
-    TEST_ASSERT(mbedtls_x509_crt_parse_file(&trusted, ca_file) == 0);
+    TEST_EQUAL(mbedtls_x509_crt_parse_file(&trusted, ca_file), 0);
 
     /* Load a chain with nb_int intermediates (from 01 to nb_int),
      * plus one "end-entity" cert (nb_int + 1) */
     ret = mbedtls_snprintf(file_buf, sizeof(file_buf), "%s/c%02d.pem", chain_dir,
                            nb_int + 1);
     TEST_ASSERT(ret > 0 && (size_t) ret < sizeof(file_buf));
-    TEST_ASSERT(mbedtls_x509_crt_parse_file(&chain, file_buf) == 0);
+    TEST_EQUAL(mbedtls_x509_crt_parse_file(&chain, file_buf), 0);
 
     /* Try to verify that chain */
     ret = mbedtls_x509_crt_verify(&chain, &trusted, NULL, NULL, &flags,
                                   NULL, NULL);
-    TEST_ASSERT(ret == ret_chk);
-    TEST_ASSERT(flags == (uint32_t) flags_chk);
+    TEST_EQUAL(ret, ret_chk);
+    TEST_EQUAL(flags, (uint32_t) flags_chk);
 
 exit:
     mbedtls_x509_crt_free(&chain);
@@ -1361,9 +1361,9 @@ void mbedtls_x509_crt_verify_chain(char *chain_paths, char *trusted_ca,
     MD_OR_USE_PSA_INIT();
 
     while ((act = mystrsep(&chain_paths, " ")) != NULL) {
-        TEST_ASSERT(mbedtls_x509_crt_parse_file(&chain, act) == 0);
+        TEST_EQUAL(mbedtls_x509_crt_parse_file(&chain, act), 0);
     }
-    TEST_ASSERT(mbedtls_x509_crt_parse_file(&trusted, trusted_ca) == 0);
+    TEST_EQUAL(mbedtls_x509_crt_parse_file(&trusted, trusted_ca), 0);
 
     if (strcmp(profile_name, "") == 0) {
         profile = &mbedtls_x509_crt_profile_default;
@@ -1380,8 +1380,8 @@ void mbedtls_x509_crt_verify_chain(char *chain_paths, char *trusted_ca,
     res = mbedtls_x509_crt_verify_with_profile(&chain, &trusted, NULL, profile,
                                                NULL, &flags, verify_fatal, &vrfy_fatal_lvls);
 
-    TEST_ASSERT(res == (result));
-    TEST_ASSERT(flags == (uint32_t) (flags_result));
+    TEST_EQUAL(res, (result));
+    TEST_EQUAL(flags, (uint32_t) (flags_result));
 
 exit:
     mbedtls_x509_crt_free(&trusted);
@@ -1409,9 +1409,9 @@ void x509_oid_desc(data_t *buf, char *ref_desc)
         TEST_ASSERT(ret != 0);
         TEST_ASSERT(desc == NULL);
     } else {
-        TEST_ASSERT(ret == 0);
+        TEST_EQUAL(ret, 0);
         TEST_ASSERT(desc != NULL);
-        TEST_ASSERT(strcmp(desc, ref_desc) == 0);
+        TEST_EQUAL(strcmp(desc, ref_desc), 0);
     }
 
 exit:
@@ -1435,11 +1435,11 @@ void x509_oid_numstr(data_t *oid_buf, char *numstr, int blen, int ret)
 
     TEST_ASSERT((size_t) blen <= sizeof(num_buf));
 
-    TEST_ASSERT(mbedtls_oid_get_numeric_string(num_buf, blen, &oid) == ret);
+    TEST_EQUAL(mbedtls_oid_get_numeric_string(num_buf, blen, &oid), ret);
 
     if (ret >= 0) {
-        TEST_ASSERT(num_buf[ret] == 0);
-        TEST_ASSERT(strcmp(num_buf, numstr) == 0);
+        TEST_EQUAL(num_buf[ret], 0);
+        TEST_EQUAL(strcmp(num_buf, numstr), 0);
     }
 
 exit:
@@ -1455,9 +1455,9 @@ void x509_check_key_usage(char *crt_file, int usage, int ret)
     mbedtls_x509_crt_init(&crt);
     USE_PSA_INIT();
 
-    TEST_ASSERT(mbedtls_x509_crt_parse_file(&crt, crt_file) == 0);
+    TEST_EQUAL(mbedtls_x509_crt_parse_file(&crt, crt_file), 0);
 
-    TEST_ASSERT(mbedtls_x509_crt_check_key_usage(&crt, usage) == ret);
+    TEST_EQUAL(mbedtls_x509_crt_check_key_usage(&crt, usage), ret);
 
 exit:
     mbedtls_x509_crt_free(&crt);
@@ -1474,10 +1474,10 @@ void x509_check_extended_key_usage(char *crt_file, data_t *oid, int ret
     mbedtls_x509_crt_init(&crt);
     USE_PSA_INIT();
 
-    TEST_ASSERT(mbedtls_x509_crt_parse_file(&crt, crt_file) == 0);
+    TEST_EQUAL(mbedtls_x509_crt_parse_file(&crt, crt_file), 0);
 
-    TEST_ASSERT(mbedtls_x509_crt_check_extended_key_usage(&crt, (const char *) oid->x,
-                                                          oid->len) == ret);
+    TEST_EQUAL(mbedtls_x509_crt_check_extended_key_usage(&crt, (const char *) oid->x, oid->len),
+               ret);
 
 exit:
     mbedtls_x509_crt_free(&crt);
@@ -1503,14 +1503,14 @@ void x509_get_time(int tag, char *time_str, int ret, int year, int mon,
     memcpy(end, time_str, (size_t) *(end - 1));
     end += *(end - 1);
 
-    TEST_ASSERT(mbedtls_x509_get_time(&start, end, &time) == ret);
+    TEST_EQUAL(mbedtls_x509_get_time(&start, end, &time), ret);
     if (ret == 0) {
-        TEST_ASSERT(year == time.year);
-        TEST_ASSERT(mon  == time.mon);
-        TEST_ASSERT(day  == time.day);
-        TEST_ASSERT(hour == time.hour);
-        TEST_ASSERT(min  == time.min);
-        TEST_ASSERT(sec  == time.sec);
+        TEST_EQUAL(year, time.year);
+        TEST_EQUAL(mon, time.mon);
+        TEST_EQUAL(day, time.day);
+        TEST_EQUAL(hour, time.hour);
+        TEST_EQUAL(min, time.min);
+        TEST_EQUAL(sec, time.sec);
     }
 exit:
     USE_PSA_DONE();
@@ -1536,12 +1536,12 @@ void x509_parse_rsassa_pss_params(data_t *params, int params_tag,
     my_ret = mbedtls_x509_get_rsassa_pss_params(&buf, &my_msg_md, &my_mgf_md,
                                                 &my_salt_len);
 
-    TEST_ASSERT(my_ret == ref_ret);
+    TEST_EQUAL(my_ret, ref_ret);
 
     if (ref_ret == 0) {
-        TEST_ASSERT(my_msg_md == (mbedtls_md_type_t) ref_msg_md);
-        TEST_ASSERT(my_mgf_md == (mbedtls_md_type_t) ref_mgf_md);
-        TEST_ASSERT(my_salt_len == ref_salt_len);
+        TEST_EQUAL(my_msg_md, (mbedtls_md_type_t) ref_msg_md);
+        TEST_EQUAL(my_mgf_md, (mbedtls_md_type_t) ref_mgf_md);
+        TEST_EQUAL(my_salt_len, ref_salt_len);
     }
 
 exit:


### PR DESCRIPTION
## Description

The latter gives much more informative errors.



## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required - no functional changes
- [x] **backport** https://github.com/Mbed-TLS/mbedtls/pull/7712
- [x] **tests** not required - no functional changes



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.
