### PR TITLE
asn1parse: Reject some invalid tags

### DIFF
--- a/library/asn1parse.c
+++ b/library/asn1parse.c
@@ -98,6 +98,11 @@ int mbedtls_asn1_get_len(unsigned char **p,
     return 0;
 }
 
+static int mbedtls_asn1_bad_tag(int tag)
+{
+    return tag < 1 || (tag & ~0xE0) >= 0x1F;
+}
+
 int mbedtls_asn1_get_tag(unsigned char **p,
                          const unsigned char *end,
                          size_t *len, int tag)
@@ -280,6 +285,10 @@ int mbedtls_asn1_traverse_sequence_of(
     while (*p < end) {
         unsigned char const tag = *(*p)++;
 
+        if (mbedtls_asn1_bad_tag(tag)) {
+            return MBEDTLS_ERR_ASN1_UNEXPECTED_TAG;
+        }
+
         if ((tag & tag_must_mask) != tag_must_val) {
             return MBEDTLS_ERR_ASN1_UNEXPECTED_TAG;
         }
@@ -419,6 +428,10 @@ int mbedtls_asn1_get_alg(unsigned char **p,
 
     params->tag = **p;
     (*p)++;
+
+    if (mbedtls_asn1_bad_tag(params->tag)) {
+        return MBEDTLS_ERR_ASN1_UNEXPECTED_TAG;
+    }
 
     if ((ret = mbedtls_asn1_get_len(p, end, &params->len)) != 0) {
         return ret;


### PR DESCRIPTION

## Description

ASN.1 requires tags to be greater than zero, and multi-byte tags are not supported by this library.  Check that tags taken from input data are valid.  Tags provided by the caller are assumed valid.



## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [ ] **changelog** provided, or not required
- [ ] **backport** done, or not required
- [ ] **tests** provided, or not required



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.
