### PR TITLE
Add clangd compilation databases to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ massif-*
 /TAGS
 /cscope*.out
 /tags
+
+# Clangd compilation database
+compile_commands.json


### PR DESCRIPTION
The clangd language server uses a file called `compile_commands.json` to interpret the source tree. This is generated by CMake and must be present in the source tree in order to use clangd properly.

Add this to the gitignore to improve the Mbed TLS developer experience for users of clangd.

- [x] **changelog** not required - Mbed TLS developer facing, not user facing
- [x] **backport** #7707 
- [x] **tests** not required - no code changes