### PR TITLE
Backport 2.28: x509parse tests: Replace TEST_ASSERT with TEST_EQUAL

### DIFF
--- a/tests/suites/test_suite_x509parse.function
+++ b/tests/suites/test_suite_x509parse.function
@@ -411,7 +411,7 @@ void x509_parse_san(char *crt_file, char *result_str)
     memset(buf, 0, 2000);
     USE_PSA_INIT();
 
-    TEST_ASSERT(mbedtls_x509_crt_parse_file(&crt, crt_file) == 0);
+    TEST_EQUAL(mbedtls_x509_crt_parse_file(&crt, crt_file), 0);
 
     if (crt.ext_types & MBEDTLS_X509_EXT_SUBJECT_ALT_NAME) {
         cur = &crt.subject_alt_names;
@@ -422,13 +422,13 @@ void x509_parse_san(char *crt_file, char *result_str)
              * If san type not supported, ignore.
              */
             if (ret == 0) {
-                TEST_ASSERT(verify_parse_san(&san, &p, &n) == 0);
+                TEST_EQUAL(verify_parse_san(&san, &p, &n), 0);
             }
             cur = cur->next;
         }
     }
 
-    TEST_ASSERT(strcmp(buf, result_str) == 0);
+    TEST_EQUAL(strcmp(buf, result_str), 0);
 
 exit:
 
@@ -448,13 +448,13 @@ void x509_cert_info(char *crt_file, char *result_str)
     memset(buf, 0, 2000);
     USE_PSA_INIT();
 
-    TEST_ASSERT(mbedtls_x509_crt_parse_file(&crt, crt_file) == 0);
+    TEST_EQUAL(mbedtls_x509_crt_parse_file(&crt, crt_file), 0);
     res = mbedtls_x509_crt_info(buf, 2000, "", &crt);
 
     TEST_ASSERT(res != -1);
     TEST_ASSERT(res != -2);
 
-    TEST_ASSERT(strcmp(buf, result_str) == 0);
+    TEST_EQUAL(strcmp(buf, result_str), 0);
 
 exit:
     mbedtls_x509_crt_free(&crt);
@@ -473,13 +473,13 @@ void mbedtls_x509_crl_info(char *crl_file, char *result_str)
     memset(buf, 0, 2000);
     USE_PSA_INIT();
 
-    TEST_ASSERT(mbedtls_x509_crl_parse_file(&crl, crl_file) == 0);
+    TEST_EQUAL(mbedtls_x509_crl_parse_file(&crl, crl_file), 0);
     res = mbedtls_x509_crl_info(buf, 2000, "", &crl);
 
     TEST_ASSERT(res != -1);
     TEST_ASSERT(res != -2);
 
-    TEST_ASSERT(strcmp(buf, result_str) == 0);
+    TEST_EQUAL(strcmp(buf, result_str), 0);
 
 exit:
     mbedtls_x509_crl_free(&crl);
@@ -497,7 +497,7 @@ void mbedtls_x509_crl_parse(char *crl_file, int result)
     memset(buf, 0, 2000);
     USE_PSA_INIT();
 
-    TEST_ASSERT(mbedtls_x509_crl_parse_file(&crl, crl_file) == result);
+    TEST_EQUAL(mbedtls_x509_crl_parse_file(&crl, crl_file), result);
 
 exit:
     mbedtls_x509_crl_free(&crl);
@@ -516,13 +516,13 @@ void mbedtls_x509_csr_info(char *csr_file, char *result_str)
     memset(buf, 0, 2000);
     USE_PSA_INIT();
 
-    TEST_ASSERT(mbedtls_x509_csr_parse_file(&csr, csr_file) == 0);
+    TEST_EQUAL(mbedtls_x509_csr_parse_file(&csr, csr_file), 0);
     res = mbedtls_x509_csr_info(buf, 2000, "", &csr);
 
     TEST_ASSERT(res != -1);
     TEST_ASSERT(res != -2);
 
-    TEST_ASSERT(strcmp(buf, result_str) == 0);
+    TEST_EQUAL(strcmp(buf, result_str), 0);
 
 exit:
     mbedtls_x509_csr_free(&csr);
@@ -543,7 +543,7 @@ void x509_verify_info(int flags, char *prefix, char *result_str)
 
     TEST_ASSERT(res >= 0);
 
-    TEST_ASSERT(strcmp(buf, result_str) == 0);
+    TEST_EQUAL(strcmp(buf, result_str), 0);
 
 exit:
     USE_PSA_DONE();
@@ -575,8 +575,8 @@ void x509_verify_restart(char *crt_file, char *ca_file,
     mbedtls_x509_crt_init(&ca);
     USE_PSA_INIT();
 
-    TEST_ASSERT(mbedtls_x509_crt_parse_file(&crt, crt_file) == 0);
-    TEST_ASSERT(mbedtls_x509_crt_parse_file(&ca, ca_file) == 0);
+    TEST_EQUAL(mbedtls_x509_crt_parse_file(&crt, crt_file), 0);
+    TEST_EQUAL(mbedtls_x509_crt_parse_file(&ca, ca_file), 0);
 
     mbedtls_ecp_set_max_ops(max_ops);
 
@@ -587,8 +587,8 @@ void x509_verify_restart(char *crt_file, char *ca_file,
                                                   NULL, NULL, &rs_ctx);
     } while (ret == MBEDTLS_ERR_ECP_IN_PROGRESS && ++cnt_restart);
 
-    TEST_ASSERT(ret == result);
-    TEST_ASSERT(flags == (uint32_t) flags_result);
+    TEST_EQUAL(ret, result);
+    TEST_EQUAL(flags, (uint32_t) flags_result);
 
     TEST_ASSERT(cnt_restart >= min_restart);
     TEST_ASSERT(cnt_restart <= max_restart);
@@ -656,9 +656,9 @@ void x509_verify(char *crt_file, char *ca_file, char *crl_file,
         TEST_ASSERT("No known verify callback selected" == 0);
     }
 
-    TEST_ASSERT(mbedtls_x509_crt_parse_file(&crt, crt_file) == 0);
-    TEST_ASSERT(mbedtls_x509_crt_parse_file(&ca, ca_file) == 0);
-    TEST_ASSERT(mbedtls_x509_crl_parse_file(&crl, crl_file) == 0);
+    TEST_EQUAL(mbedtls_x509_crt_parse_file(&crt, crt_file), 0);
+    TEST_EQUAL(mbedtls_x509_crt_parse_file(&ca, ca_file), 0);
+    TEST_EQUAL(mbedtls_x509_crl_parse_file(&crl, crl_file), 0);
 
     res = mbedtls_x509_crt_verify_with_profile(&crt,
                                                &ca,
@@ -669,8 +669,8 @@ void x509_verify(char *crt_file, char *ca_file, char *crl_file,
                                                f_vrfy,
                                                NULL);
 
-    TEST_ASSERT(res == (result));
-    TEST_ASSERT(flags == (uint32_t) (flags_result));
+    TEST_EQUAL(res, (result));
+    TEST_EQUAL(flags, (uint32_t) (flags_result));
 
 #if defined(MBEDTLS_X509_TRUSTED_CERTIFICATE_CALLBACK)
     /* CRLs aren't supported with CA callbacks, so skip the CA callback
@@ -687,8 +687,8 @@ void x509_verify(char *crt_file, char *ca_file, char *crl_file,
                                                  f_vrfy,
                                                  NULL);
 
-        TEST_ASSERT(res == (result));
-        TEST_ASSERT(flags == (uint32_t) (flags_result));
+        TEST_EQUAL(res, result);
+        TEST_EQUAL(flags, (uint32_t) (flags_result));
     }
 #endif /* MBEDTLS_X509_TRUSTED_CERTIFICATE_CALLBACK */
 exit:
@@ -712,8 +712,8 @@ void x509_verify_ca_cb_failure(char *crt_file, char *ca_file, char *name,
     mbedtls_x509_crt_init(&ca);
     USE_PSA_INIT();
 
-    TEST_ASSERT(mbedtls_x509_crt_parse_file(&crt, crt_file) == 0);
-    TEST_ASSERT(mbedtls_x509_crt_parse_file(&ca, ca_file) == 0);
+    TEST_EQUAL(mbedtls_x509_crt_parse_file(&crt, crt_file), 0);
+    TEST_EQUAL(mbedtls_x509_crt_parse_file(&ca, ca_file), 0);
 
     if (strcmp(name, "NULL") == 0) {
         name = NULL;
@@ -723,8 +723,8 @@ void x509_verify_ca_cb_failure(char *crt_file, char *ca_file, char *name,
                                              &compat_profile, name, &flags,
                                              NULL, NULL);
 
-    TEST_ASSERT(ret == exp_ret);
-    TEST_ASSERT(flags == (uint32_t) (-1));
+    TEST_EQUAL(ret, exp_ret);
+    TEST_EQUAL(flags, (uint32_t) (-1));
 exit:
     mbedtls_x509_crt_free(&crt);
     mbedtls_x509_crt_free(&ca);
@@ -748,8 +748,8 @@ void x509_verify_callback(char *crt_file, char *ca_file, char *name,
 
     USE_PSA_INIT();
 
-    TEST_ASSERT(mbedtls_x509_crt_parse_file(&crt, crt_file) == 0);
-    TEST_ASSERT(mbedtls_x509_crt_parse_file(&ca, ca_file) == 0);
+    TEST_EQUAL(mbedtls_x509_crt_parse_file(&crt, crt_file), 0);
+    TEST_EQUAL(mbedtls_x509_crt_parse_file(&ca, ca_file), 0);
 
     if (strcmp(name, "NULL") == 0) {
         name = NULL;
@@ -760,8 +760,8 @@ void x509_verify_callback(char *crt_file, char *ca_file, char *name,
                                                name, &flags,
                                                verify_print, &vrfy_ctx);
 
-    TEST_ASSERT(ret == exp_ret);
-    TEST_ASSERT(strcmp(vrfy_ctx.buf, exp_vrfy_out) == 0);
+    TEST_EQUAL(ret, exp_ret);
+    TEST_EQUAL(strcmp(vrfy_ctx.buf, exp_vrfy_out), 0);
 
 exit:
     mbedtls_x509_crt_free(&crt);
@@ -781,7 +781,7 @@ void mbedtls_x509_dn_gets(char *crt_file, char *entity, char *result_str)
     memset(buf, 0, 2000);
     USE_PSA_INIT();
 
-    TEST_ASSERT(mbedtls_x509_crt_parse_file(&crt, crt_file) == 0);
+    TEST_EQUAL(mbedtls_x509_crt_parse_file(&crt, crt_file), 0);
     if (strcmp(entity, "subject") == 0) {
         res =  mbedtls_x509_dn_gets(buf, 2000, &crt.subject);
     } else if (strcmp(entity, "issuer") == 0) {
@@ -793,7 +793,7 @@ void mbedtls_x509_dn_gets(char *crt_file, char *entity, char *result_str)
     TEST_ASSERT(res != -1);
     TEST_ASSERT(res != -2);
 
-    TEST_ASSERT(strcmp(buf, result_str) == 0);
+    TEST_EQUAL(strcmp(buf, result_str), 0);
 
 exit:
     mbedtls_x509_crt_free(&crt);
@@ -815,18 +815,18 @@ void mbedtls_x509_dn_gets_subject_replace(char *crt_file,
     memset(buf, 0, 2000);
     USE_PSA_INIT();
 
-    TEST_ASSERT(mbedtls_x509_crt_parse_file(&crt, crt_file) == 0);
+    TEST_EQUAL(mbedtls_x509_crt_parse_file(&crt, crt_file), 0);
     crt.subject.next->val.p = (unsigned char *) new_subject_ou;
     crt.subject.next->val.len = strlen(new_subject_ou);
 
     res =  mbedtls_x509_dn_gets(buf, 2000, &crt.subject);
 
     if (ret != 0) {
-        TEST_ASSERT(res == ret);
+        TEST_EQUAL(res, ret);
     } else {
         TEST_ASSERT(res != -1);
         TEST_ASSERT(res != -2);
-        TEST_ASSERT(strcmp(buf, result_str) == 0);
+        TEST_EQUAL(strcmp(buf, result_str), 0);
     }
 exit:
     mbedtls_x509_crt_free(&crt);
@@ -879,12 +879,12 @@ void mbedtls_x509_time_is_past(char *crt_file, char *entity, int result)
     mbedtls_x509_crt_init(&crt);
     USE_PSA_INIT();
 
-    TEST_ASSERT(mbedtls_x509_crt_parse_file(&crt, crt_file) == 0);
+    TEST_EQUAL(mbedtls_x509_crt_parse_file(&crt, crt_file), 0);
 
     if (strcmp(entity, "valid_from") == 0) {
-        TEST_ASSERT(mbedtls_x509_time_is_past(&crt.valid_from) == result);
+        TEST_EQUAL(mbedtls_x509_time_is_past(&crt.valid_from), result);
     } else if (strcmp(entity, "valid_to") == 0) {
-        TEST_ASSERT(mbedtls_x509_time_is_past(&crt.valid_to) == result);
+        TEST_EQUAL(mbedtls_x509_time_is_past(&crt.valid_to), result);
     } else {
         TEST_ASSERT("Unknown entity" == 0);
     }
@@ -903,12 +903,12 @@ void mbedtls_x509_time_is_future(char *crt_file, char *entity, int result)
     mbedtls_x509_crt_init(&crt);
     USE_PSA_INIT();
 
-    TEST_ASSERT(mbedtls_x509_crt_parse_file(&crt, crt_file) == 0);
+    TEST_EQUAL(mbedtls_x509_crt_parse_file(&crt, crt_file), 0);
 
     if (strcmp(entity, "valid_from") == 0) {
-        TEST_ASSERT(mbedtls_x509_time_is_future(&crt.valid_from) == result);
+        TEST_EQUAL(mbedtls_x509_time_is_future(&crt.valid_from), result);
     } else if (strcmp(entity, "valid_to") == 0) {
-        TEST_ASSERT(mbedtls_x509_time_is_future(&crt.valid_to) == result);
+        TEST_EQUAL(mbedtls_x509_time_is_future(&crt.valid_to), result);
     } else {
         TEST_ASSERT("Unknown entity" == 0);
     }
@@ -927,7 +927,7 @@ void x509parse_crt_file(char *crt_file, int result)
     mbedtls_x509_crt_init(&crt);
     USE_PSA_INIT();
 
-    TEST_ASSERT(mbedtls_x509_crt_parse_file(&crt, crt_file) == result);
+    TEST_EQUAL(mbedtls_x509_crt_parse_file(&crt, crt_file), result);
 
 exit:
     mbedtls_x509_crt_free(&crt);
@@ -946,58 +946,58 @@ void x509parse_crt(data_t *buf, char *result_str, int result)
     memset(output, 0, 2000);
     USE_PSA_INIT();
 
-    TEST_ASSERT(mbedtls_x509_crt_parse_der(&crt, buf->x, buf->len) == (result));
+    TEST_EQUAL(mbedtls_x509_crt_parse_der(&crt, buf->x, buf->len), result);
     if ((result) == 0) {
         res = mbedtls_x509_crt_info((char *) output, 2000, "", &crt);
 
         TEST_ASSERT(res != -1);
         TEST_ASSERT(res != -2);
 
-        TEST_ASSERT(strcmp((char *) output, result_str) == 0);
+        TEST_EQUAL(strcmp((char *) output, result_str), 0);
     }
 
     mbedtls_x509_crt_free(&crt);
     mbedtls_x509_crt_init(&crt);
     memset(output, 0, 2000);
 
-    TEST_ASSERT(mbedtls_x509_crt_parse_der_nocopy(&crt, buf->x, buf->len) == (result));
+    TEST_EQUAL(mbedtls_x509_crt_parse_der_nocopy(&crt, buf->x, buf->len), result);
     if ((result) == 0) {
         res = mbedtls_x509_crt_info((char *) output, 2000, "", &crt);
 
         TEST_ASSERT(res != -1);
         TEST_ASSERT(res != -2);
 
-        TEST_ASSERT(strcmp((char *) output, result_str) == 0);
+        TEST_EQUAL(strcmp((char *) output, result_str), 0);
     }
 
     mbedtls_x509_crt_free(&crt);
     mbedtls_x509_crt_init(&crt);
     memset(output, 0, 2000);
 
-    TEST_ASSERT(mbedtls_x509_crt_parse_der_with_ext_cb(&crt, buf->x, buf->len, 0, NULL,
-                                                       NULL) == (result));
+    TEST_EQUAL(mbedtls_x509_crt_parse_der_with_ext_cb(&crt, buf->x, buf->len, 0, NULL, NULL),
+               result);
     if ((result) == 0) {
         res = mbedtls_x509_crt_info((char *) output, 2000, "", &crt);
 
         TEST_ASSERT(res != -1);
         TEST_ASSERT(res != -2);
 
-        TEST_ASSERT(strcmp((char *) output, result_str) == 0);
+        TEST_EQUAL(strcmp((char *) output, result_str), 0);
     }
 
     mbedtls_x509_crt_free(&crt);
     mbedtls_x509_crt_init(&crt);
     memset(output, 0, 2000);
 
-    TEST_ASSERT(mbedtls_x509_crt_parse_der_with_ext_cb(&crt, buf->x, buf->len, 1, NULL,
-                                                       NULL) == (result));
+    TEST_EQUAL(mbedtls_x509_crt_parse_der_with_ext_cb(&crt, buf->x, buf->len, 1, NULL, NULL),
+               result);
     if ((result) == 0) {
         res = mbedtls_x509_crt_info((char *) output, 2000, "", &crt);
 
         TEST_ASSERT(res != -1);
         TEST_ASSERT(res != -2);
 
-        TEST_ASSERT(strcmp((char *) output, result_str) == 0);
+        TEST_EQUAL(strcmp((char *) output, result_str), 0);
     }
 
 exit:
@@ -1022,30 +1022,30 @@ void x509parse_crt_cb(data_t *buf, char *result_str, int result)
     memset(output, 0, 2000);
     USE_PSA_INIT();
 
-    TEST_ASSERT(mbedtls_x509_crt_parse_der_with_ext_cb(&crt, buf->x, buf->len, 0, parse_crt_ext_cb,
-                                                       &oid) == (result));
+    TEST_EQUAL(mbedtls_x509_crt_parse_der_with_ext_cb(&crt, buf->x, buf->len, 0, parse_crt_ext_cb,
+                                                      &oid), result);
     if ((result) == 0) {
         res = mbedtls_x509_crt_info((char *) output, 2000, "", &crt);
 
         TEST_ASSERT(res != -1);
         TEST_ASSERT(res != -2);
 
-        TEST_ASSERT(strcmp((char *) output, result_str) == 0);
+        TEST_EQUAL(strcmp((char *) output, result_str), 0);
     }
 
     mbedtls_x509_crt_free(&crt);
     mbedtls_x509_crt_init(&crt);
     memset(output, 0, 2000);
 
-    TEST_ASSERT(mbedtls_x509_crt_parse_der_with_ext_cb(&crt, buf->x, buf->len, 1, parse_crt_ext_cb,
-                                                       &oid) == (result));
+    TEST_EQUAL(mbedtls_x509_crt_parse_der_with_ext_cb(&crt, buf->x, buf->len, 1, parse_crt_ext_cb,
+                                                      &oid), (result));
     if ((result) == 0) {
         res = mbedtls_x509_crt_info((char *) output, 2000, "", &crt);
 
         TEST_ASSERT(res != -1);
         TEST_ASSERT(res != -2);
 
-        TEST_ASSERT(strcmp((char *) output, result_str) == 0);
+        TEST_EQUAL(strcmp((char *) output, result_str), 0);
     }
 
 exit:
@@ -1065,14 +1065,14 @@ void x509parse_crl(data_t *buf, char *result_str, int result)
     memset(output, 0, 2000);
     USE_PSA_INIT();
 
-    TEST_ASSERT(mbedtls_x509_crl_parse(&crl, buf->x, buf->len) == (result));
+    TEST_EQUAL(mbedtls_x509_crl_parse(&crl, buf->x, buf->len), (result));
     if ((result) == 0) {
         res = mbedtls_x509_crl_info((char *) output, 2000, "", &crl);
 
         TEST_ASSERT(res != -1);
         TEST_ASSERT(res != -2);
 
-        TEST_ASSERT(strcmp((char *) output, result_str) == 0);
+        TEST_EQUAL(strcmp((char *) output, result_str), 0);
     }
 
 exit:
@@ -1093,12 +1093,12 @@ void mbedtls_x509_csr_parse(data_t *csr_der, char *ref_out, int ref_ret)
     USE_PSA_INIT();
 
     my_ret = mbedtls_x509_csr_parse_der(&csr, csr_der->x, csr_der->len);
-    TEST_ASSERT(my_ret == ref_ret);
+    TEST_EQUAL(my_ret, ref_ret);
 
     if (ref_ret == 0) {
         size_t my_out_len = mbedtls_x509_csr_info(my_out, sizeof(my_out), "", &csr);
-        TEST_ASSERT(my_out_len == strlen(ref_out));
-        TEST_ASSERT(strcmp(my_out, ref_out) == 0);
+        TEST_EQUAL(my_out_len, strlen(ref_out));
+        TEST_EQUAL(strcmp(my_out, ref_out), 0);
     }
 
 exit:
@@ -1116,7 +1116,7 @@ void mbedtls_x509_crt_parse_path(char *crt_path, int ret, int nb_crt)
     mbedtls_x509_crt_init(&chain);
     USE_PSA_INIT();
 
-    TEST_ASSERT(mbedtls_x509_crt_parse_path(&chain, crt_path) == ret);
+    TEST_EQUAL(mbedtls_x509_crt_parse_path(&chain, crt_path), ret);
 
     /* Check how many certs we got */
     for (i = 0, cur = &chain; cur != NULL; cur = cur->next) {
@@ -1125,7 +1125,7 @@ void mbedtls_x509_crt_parse_path(char *crt_path, int ret, int nb_crt)
         }
     }
 
-    TEST_ASSERT(i == nb_crt);
+    TEST_EQUAL(i, nb_crt);
 
 exit:
     mbedtls_x509_crt_free(&chain);
@@ -1151,20 +1151,20 @@ void mbedtls_x509_crt_verify_max(char *ca_file, char *chain_dir, int nb_int,
     USE_PSA_INIT();
 
     /* Load trusted root */
-    TEST_ASSERT(mbedtls_x509_crt_parse_file(&trusted, ca_file) == 0);
+    TEST_EQUAL(mbedtls_x509_crt_parse_file(&trusted, ca_file), 0);
 
     /* Load a chain with nb_int intermediates (from 01 to nb_int),
      * plus one "end-entity" cert (nb_int + 1) */
     ret = mbedtls_snprintf(file_buf, sizeof(file_buf), "%s/c%02d.pem", chain_dir,
                            nb_int + 1);
     TEST_ASSERT(ret > 0 && (size_t) ret < sizeof(file_buf));
-    TEST_ASSERT(mbedtls_x509_crt_parse_file(&chain, file_buf) == 0);
+    TEST_EQUAL(mbedtls_x509_crt_parse_file(&chain, file_buf), 0);
 
     /* Try to verify that chain */
     ret = mbedtls_x509_crt_verify(&chain, &trusted, NULL, NULL, &flags,
                                   NULL, NULL);
-    TEST_ASSERT(ret == ret_chk);
-    TEST_ASSERT(flags == (uint32_t) flags_chk);
+    TEST_EQUAL(ret, ret_chk);
+    TEST_EQUAL(flags, (uint32_t) flags_chk);
 
 exit:
     mbedtls_x509_crt_free(&chain);
@@ -1189,9 +1189,9 @@ void mbedtls_x509_crt_verify_chain(char *chain_paths, char *trusted_ca,
     USE_PSA_INIT();
 
     while ((act = mystrsep(&chain_paths, " ")) != NULL) {
-        TEST_ASSERT(mbedtls_x509_crt_parse_file(&chain, act) == 0);
+        TEST_EQUAL(mbedtls_x509_crt_parse_file(&chain, act), 0);
     }
-    TEST_ASSERT(mbedtls_x509_crt_parse_file(&trusted, trusted_ca) == 0);
+    TEST_EQUAL(mbedtls_x509_crt_parse_file(&trusted, trusted_ca), 0);
 
     if (strcmp(profile_name, "") == 0) {
         profile = &mbedtls_x509_crt_profile_default;
@@ -1208,8 +1208,8 @@ void mbedtls_x509_crt_verify_chain(char *chain_paths, char *trusted_ca,
     res = mbedtls_x509_crt_verify_with_profile(&chain, &trusted, NULL, profile,
                                                NULL, &flags, verify_fatal, &vrfy_fatal_lvls);
 
-    TEST_ASSERT(res == (result));
-    TEST_ASSERT(flags == (uint32_t) (flags_result));
+    TEST_EQUAL(res, (result));
+    TEST_EQUAL(flags, (uint32_t) (flags_result));
 
 exit:
     mbedtls_x509_crt_free(&trusted);
@@ -1236,9 +1236,9 @@ void x509_oid_desc(data_t *buf, char *ref_desc)
         TEST_ASSERT(ret != 0);
         TEST_ASSERT(desc == NULL);
     } else {
-        TEST_ASSERT(ret == 0);
+        TEST_EQUAL(ret, 0);
         TEST_ASSERT(desc != NULL);
-        TEST_ASSERT(strcmp(desc, ref_desc) == 0);
+        TEST_EQUAL(strcmp(desc, ref_desc), 0);
     }
 
 exit:
@@ -1261,11 +1261,11 @@ void x509_oid_numstr(data_t *oid_buf, char *numstr, int blen, int ret)
 
     TEST_ASSERT((size_t) blen <= sizeof(num_buf));
 
-    TEST_ASSERT(mbedtls_oid_get_numeric_string(num_buf, blen, &oid) == ret);
+    TEST_EQUAL(mbedtls_oid_get_numeric_string(num_buf, blen, &oid), ret);
 
     if (ret >= 0) {
-        TEST_ASSERT(num_buf[ret] == 0);
-        TEST_ASSERT(strcmp(num_buf, numstr) == 0);
+        TEST_EQUAL(num_buf[ret], 0);
+        TEST_EQUAL(strcmp(num_buf, numstr), 0);
     }
 
 exit:
@@ -1281,9 +1281,9 @@ void x509_check_key_usage(char *crt_file, int usage, int ret)
     mbedtls_x509_crt_init(&crt);
     USE_PSA_INIT();
 
-    TEST_ASSERT(mbedtls_x509_crt_parse_file(&crt, crt_file) == 0);
+    TEST_EQUAL(mbedtls_x509_crt_parse_file(&crt, crt_file), 0);
 
-    TEST_ASSERT(mbedtls_x509_crt_check_key_usage(&crt, usage) == ret);
+    TEST_EQUAL(mbedtls_x509_crt_check_key_usage(&crt, usage), ret);
 
 exit:
     mbedtls_x509_crt_free(&crt);
@@ -1300,10 +1300,10 @@ void x509_check_extended_key_usage(char *crt_file, data_t *oid, int ret
     mbedtls_x509_crt_init(&crt);
     USE_PSA_INIT();
 
-    TEST_ASSERT(mbedtls_x509_crt_parse_file(&crt, crt_file) == 0);
+    TEST_EQUAL(mbedtls_x509_crt_parse_file(&crt, crt_file), 0);
 
-    TEST_ASSERT(mbedtls_x509_crt_check_extended_key_usage(&crt, (const char *) oid->x,
-                                                          oid->len) == ret);
+    TEST_EQUAL(mbedtls_x509_crt_check_extended_key_usage(&crt, (const char *) oid->x, oid->len),
+               ret);
 
 exit:
     mbedtls_x509_crt_free(&crt);
@@ -1329,14 +1329,14 @@ void x509_get_time(int tag, char *time_str, int ret, int year, int mon,
     memcpy(end, time_str, (size_t) *(end - 1));
     end += *(end - 1);
 
-    TEST_ASSERT(mbedtls_x509_get_time(&start, end, &time) == ret);
+    TEST_EQUAL(mbedtls_x509_get_time(&start, end, &time), ret);
     if (ret == 0) {
-        TEST_ASSERT(year == time.year);
-        TEST_ASSERT(mon  == time.mon);
-        TEST_ASSERT(day  == time.day);
-        TEST_ASSERT(hour == time.hour);
-        TEST_ASSERT(min  == time.min);
-        TEST_ASSERT(sec  == time.sec);
+        TEST_EQUAL(year, time.year);
+        TEST_EQUAL(mon, time.mon);
+        TEST_EQUAL(day, time.day);
+        TEST_EQUAL(hour, time.hour);
+        TEST_EQUAL(min, time.min);
+        TEST_EQUAL(sec, time.sec);
     }
 
 exit:
@@ -1363,12 +1363,12 @@ void x509_parse_rsassa_pss_params(data_t *params, int params_tag,
     my_ret = mbedtls_x509_get_rsassa_pss_params(&buf, &my_msg_md, &my_mgf_md,
                                                 &my_salt_len);
 
-    TEST_ASSERT(my_ret == ref_ret);
+    TEST_EQUAL(my_ret, ref_ret);
 
     if (ref_ret == 0) {
-        TEST_ASSERT(my_msg_md == (mbedtls_md_type_t) ref_msg_md);
-        TEST_ASSERT(my_mgf_md == (mbedtls_md_type_t) ref_mgf_md);
-        TEST_ASSERT(my_salt_len == ref_salt_len);
+        TEST_EQUAL(my_msg_md, (mbedtls_md_type_t) ref_msg_md);
+        TEST_EQUAL(my_mgf_md, (mbedtls_md_type_t) ref_mgf_md);
+        TEST_EQUAL(my_salt_len, ref_salt_len);
     }
 
 exit:
@@ -1380,7 +1380,7 @@ exit:
 void x509_selftest()
 {
     USE_PSA_INIT();
-    TEST_ASSERT(mbedtls_x509_self_test(1) == 0);
+    TEST_EQUAL(mbedtls_x509_self_test(1), 0);
 
 exit:
     USE_PSA_DONE();


### PR DESCRIPTION
Backport of https://github.com/Mbed-TLS/mbedtls/pull/7691

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required (no semantic change)
- [x] **backport** of https://github.com/Mbed-TLS/mbedtls/pull/7691
- [x] **tests** no semantic change
