### PR TITLE
Driver-only ECC: auto-enable ECP_LIGHT when needed

### DIFF
--- a/include/mbedtls/build_info.h
+++ b/include/mbedtls/build_info.h
@@ -136,10 +136,14 @@
  * - MBEDTLS_PK_PARSE_EC_EXTENDED and MBEDTLS_PK_PARSE_EC_COMPRESSED because
  *   these features are not supported in PSA so the only way to have them is
  *   to enable the built-in solution.
+ *   Both of them are temporary dependencies:
+ *   - PK_PARSE_EC_EXTENDED will be removed after #7779 and #7789
+ *   - support for compressed points should also be added to PSA, but in this
+ *     case there is no associated issue to track it yet.
  * - PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE because Weierstrass key derivation
- *   still depends on ECP_LIGHT
+ *   still depends on ECP_LIGHT.
  * - PK_C + USE_PSA + PSA_WANT_ALG_ECDSA is a temporary dependency which will
- *   be fixed by #7453
+ *   be fixed by #7453.
  */
 #if defined(MBEDTLS_ECP_C) || \
     defined(MBEDTLS_PK_PARSE_EC_EXTENDED) || \

--- a/include/mbedtls/build_info.h
+++ b/include/mbedtls/build_info.h
@@ -129,11 +129,23 @@
 #define MBEDTLS_MD_LIGHT
 #endif
 
-/* MBEDTLS_ECP_C now consists of MBEDTLS_ECP_LIGHT plus functions for curve
- * arithmetic. As a consequence if MBEDTLS_ECP_C is required for some reason,
- * then MBEDTLS_ECP_LIGHT should be enabled as well. */
-#if defined(MBEDTLS_ECP_C) || defined(MBEDTLS_PK_PARSE_EC_EXTENDED) || \
-    defined(MBEDTLS_PK_PARSE_EC_COMPRESSED)
+/* MBEDTLS_ECP_LIGHT is auto-enabled by the following symbols:
+ * - MBEDTLS_ECP_C because now it consists of MBEDTLS_ECP_LIGHT plus functions
+ *   for curve arithmetic. As a consequence if MBEDTLS_ECP_C is required for
+ *   some reason, then MBEDTLS_ECP_LIGHT should be enabled as well.
+ * - MBEDTLS_PK_PARSE_EC_EXTENDED and MBEDTLS_PK_PARSE_EC_COMPRESSED because
+ *   these features are not supported in PSA so the only way to have them is
+ *   to enable the built-in solution.
+ * - PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE because Weierstrass key derivation
+ *   still depends on ECP_LIGHT
+ * - PK_C + USE_PSA + PSA_WANT_ALG_ECDSA is a temporary dependency which will
+ *   be fixed by #7453
+ */
+#if defined(MBEDTLS_ECP_C) || \
+    defined(MBEDTLS_PK_PARSE_EC_EXTENDED) || \
+    defined(MBEDTLS_PK_PARSE_EC_COMPRESSED) || \
+    defined(MBEDTLS_PSA_BUILTIN_KEY_TYPE_ECC_KEY_PAIR_DERIVE) || \
+    (defined(MBEDTLS_PK_C) && defined(MBEDTLS_USE_PSA_CRYPTO) && defined(PSA_WANT_ALG_ECDSA))
 #define MBEDTLS_ECP_LIGHT
 #endif
 

--- a/include/mbedtls/build_info.h
+++ b/include/mbedtls/build_info.h
@@ -132,7 +132,7 @@
 /* MBEDTLS_ECP_C now consists of MBEDTLS_ECP_LIGHT plus functions for curve
  * arithmetic. As a consequence if MBEDTLS_ECP_C is required for some reason,
  * then MBEDTLS_ECP_LIGHT should be enabled as well. */
-#if defined(MBEDTLS_ECP_C)
+#if defined(MBEDTLS_ECP_C) || defined(MBEDTLS_PK_PARSE_EC_EXTENDED)
 #define MBEDTLS_ECP_LIGHT
 #endif
 

--- a/include/mbedtls/build_info.h
+++ b/include/mbedtls/build_info.h
@@ -149,6 +149,15 @@
 #define MBEDTLS_ECP_LIGHT
 #endif
 
+/* MBEDTLS_PK_PARSE_EC_COMPRESSED is introduced in MbedTLS version 3.5, while
+ * in previous version compressed points were automatically supported as long
+ * as PK_PARSE_C and ECP_C were enabled. As a consequence, for backward
+ * compatibility, we auto-enable PK_PARSE_EC_COMPRESSED when these conditions
+ * are met. */
+#if defined(MBEDTLS_PK_PARSE_C) && defined(MBEDTLS_ECP_C)
+#define MBEDTLS_PK_PARSE_EC_COMPRESSED
+#endif
+
 /* If MBEDTLS_PSA_CRYPTO_C is defined, make sure MBEDTLS_PSA_CRYPTO_CLIENT
  * is defined as well to include all PSA code.
  */

--- a/include/mbedtls/build_info.h
+++ b/include/mbedtls/build_info.h
@@ -132,7 +132,8 @@
 /* MBEDTLS_ECP_C now consists of MBEDTLS_ECP_LIGHT plus functions for curve
  * arithmetic. As a consequence if MBEDTLS_ECP_C is required for some reason,
  * then MBEDTLS_ECP_LIGHT should be enabled as well. */
-#if defined(MBEDTLS_ECP_C) || defined(MBEDTLS_PK_PARSE_EC_EXTENDED)
+#if defined(MBEDTLS_ECP_C) || defined(MBEDTLS_PK_PARSE_EC_EXTENDED) || \
+    defined(MBEDTLS_PK_PARSE_EC_COMPRESSED)
 #define MBEDTLS_ECP_LIGHT
 #endif
 

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -1050,8 +1050,11 @@
  *
  * Enable the support for parsing public keys of type Short Weierstrass
  * (MBEDTLS_ECP_DP_SECP_XXX and MBEDTLS_ECP_DP_BP_XXX) which are using the
- * compressed point format.
- * Please see MBEDTLS_ECP_PF_COMPRESSED in ecp.h for limitations details.
+ * compressed point format. This parsing is done through ECP module's functions.
+ *
+ * \note As explained in the description of MBEDTLS_ECP_PF_COMPRESSED (in ecp.h)
+ *       the only unsupported curves are MBEDTLS_ECP_DP_SECP224R1 and
+ *       MBEDTLS_ECP_DP_SECP224K1.
  */
 #define MBEDTLS_PK_PARSE_EC_COMPRESSED
 

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -1046,6 +1046,16 @@
 #define MBEDTLS_PK_PARSE_EC_EXTENDED
 
 /**
+ * \def MBEDTLS_PK_PARSE_EC_COMPRESSED
+ *
+ * Enable the support for parsing public keys of type Short Weierstrass
+ * (MBEDTLS_ECP_DP_SECP_XXX and MBEDTLS_ECP_DP_BP_XXX) which are using the
+ * compressed point format.
+ * Please see MBEDTLS_ECP_PF_COMPRESSED in ecp.h for limitations details.
+ */
+#define MBEDTLS_PK_PARSE_EC_COMPRESSED
+
+/**
  * \def MBEDTLS_ERROR_STRERROR_DUMMY
  *
  * Enable a dummy error function to make use of mbedtls_strerror() in

--- a/library/pkparse.c
+++ b/library/pkparse.c
@@ -683,7 +683,7 @@ static int pk_parse_key_rfc8410_der(mbedtls_pk_context *pk,
 }
 #endif /* MBEDTLS_PK_HAVE_RFC8410_CURVES */
 
-#if defined(MBEDTLS_PK_USE_PSA_EC_DATA)
+#if defined(MBEDTLS_PK_USE_PSA_EC_DATA) && defined(MBEDTLS_PK_PARSE_EC_COMPRESSED)
 /*
  * Create a temporary ecp_keypair for converting an EC point in compressed
  * format to an uncompressed one
@@ -717,7 +717,7 @@ exit:
     mbedtls_ecp_keypair_free(&ecp_key);
     return ret;
 }
-#endif /* MBEDTLS_PK_USE_PSA_EC_DATA */
+#endif /* MBEDTLS_PK_USE_PSA_EC_DATA && MBEDTLS_PK_PARSE_EC_COMPRESSED */
 
 /*
  * EC public key is an EC point
@@ -744,12 +744,16 @@ static int pk_get_ecpubkey(unsigned char **p, const unsigned char *end,
      * consequence ecp functions are used to "convert" the point to
      * uncompressed format */
     if ((**p == 0x02) || (**p == 0x03)) {
+#if defined(MBEDTLS_PK_PARSE_EC_COMPRESSED)
         ret = pk_convert_compressed_ec(pk, *p, len,
                                        &(pk->pub_raw_len), pk->pub_raw,
                                        PSA_EXPORT_PUBLIC_KEY_MAX_SIZE);
         if (ret != 0) {
             return ret;
         }
+#else /* MBEDTLS_PK_PARSE_EC_COMPRESSED */
+        return MBEDTLS_ERR_PK_FEATURE_UNAVAILABLE;
+#endif /* MBEDTLS_PK_PARSE_EC_COMPRESSED */
     } else {
         /* Uncompressed format */
         if ((end - *p) > MBEDTLS_PK_MAX_EC_PUBKEY_RAW_LEN) {

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -2453,6 +2453,7 @@ config_psa_crypto_no_ecp_at_all () {
     # Disable all the features that auto-enable ECP_LIGHT (see build_info.h)
     scripts/config.py unset MBEDTLS_PK_PARSE_EC_EXTENDED
     scripts/config.py unset MBEDTLS_PK_PARSE_EC_COMPRESSED
+    scripts/config.py -f include/psa/crypto_config.h unset PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE
 
     # Restartable feature is not yet supported by PSA. Once it will in
     # the future, the following line could be removed (see issues

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -2452,6 +2452,7 @@ config_psa_crypto_no_ecp_at_all () {
 
     # Disable all the features that auto-enable ECP_LIGHT (see build_info.h)
     scripts/config.py unset MBEDTLS_PK_PARSE_EC_EXTENDED
+    scripts/config.py unset MBEDTLS_PK_PARSE_EC_COMPRESSED
 
     # Restartable feature is not yet supported by PSA. Once it will in
     # the future, the following line could be removed (see issues

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -2363,10 +2363,6 @@ component_test_psa_crypto_config_accel_ecc_ecp_light_only () {
     # Use the same config as reference, only without built-in EC algs
     config_psa_crypto_config_ecp_ligh_only 1
 
-    # Temporary hack to enable MBEDTLS_ECP_LIGHT
-    # (will soon be auto-enabled in build_info.h)
-    echo '#define MBEDTLS_ECP_LIGHT' >> include/mbedtls/mbedtls_config.h
-
     # Build
     # -----
 

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -2323,10 +2323,10 @@ component_test_psa_crypto_config_accel_pake() {
 #
 # This is used by the two following components to ensure they always use the
 # same config, except for the use of driver or built-in EC algorithms:
-# - component_test_psa_crypto_config_accel_all_ec_algs_use_psa;
-# - component_test_psa_crypto_config_reference_all_ec_algs_use_psa.
+# - component_test_psa_crypto_config_accel_ecc_ecp_light_only;
+# - component_test_psa_crypto_config_reference_ecc_ecp_light_only.
 # This supports comparing their test coverage with analyze_outcomes.py.
-config_psa_crypto_config_all_ec_algs_use_psa () {
+config_psa_crypto_config_ecp_ligh_only () {
     DRIVER_ONLY="$1"
     # start with config full for maximum coverage (also enables USE_PSA)
     helper_libtestdriver1_adjust_config "full"
@@ -2344,8 +2344,8 @@ config_psa_crypto_config_all_ec_algs_use_psa () {
     scripts/config.py unset MBEDTLS_ECP_RESTARTABLE
 }
 
-# Keep in sync with component_test_psa_crypto_config_reference_all_ec_algs_use_psa
-component_test_psa_crypto_config_accel_all_ec_algs_use_psa () {
+# Keep in sync with component_test_psa_crypto_config_reference_ecc_ecp_light_only
+component_test_psa_crypto_config_accel_ecc_ecp_light_only () {
     msg "build: MBEDTLS_PSA_CRYPTO_CONFIG with accelerated EC algs + USE_PSA"
 
     # Algorithms and key types to accelerate
@@ -2358,7 +2358,7 @@ component_test_psa_crypto_config_accel_all_ec_algs_use_psa () {
     # ---------
 
     # Use the same config as reference, only without built-in EC algs
-    config_psa_crypto_config_all_ec_algs_use_psa 1
+    config_psa_crypto_config_ecp_ligh_only 1
 
     # Temporary hack to enable MBEDTLS_ECP_LIGHT
     # (will soon be auto-enabled in build_info.h)
@@ -2389,11 +2389,11 @@ component_test_psa_crypto_config_accel_all_ec_algs_use_psa () {
     tests/ssl-opt.sh
 }
 
-# Keep in sync with component_test_psa_crypto_config_accel_all_ec_algs_use_psa
-component_test_psa_crypto_config_reference_all_ec_algs_use_psa () {
+# Keep in sync with component_test_psa_crypto_config_accel_ecc_ecp_light_only
+component_test_psa_crypto_config_reference_ecc_ecp_light_only () {
     msg "build: MBEDTLS_PSA_CRYPTO_CONFIG with non-accelerated EC algs + USE_PSA"
 
-    config_psa_crypto_config_all_ec_algs_use_psa 0
+    config_psa_crypto_config_ecp_ligh_only 0
 
     make
 
@@ -2405,8 +2405,8 @@ component_test_psa_crypto_config_reference_all_ec_algs_use_psa () {
 }
 
 # This helper function is used by:
-# - component_test_psa_crypto_full_accel_all_ec_algs_no_ecp_use_psa()
-# - component_test_psa_crypto_full_reference_all_ec_algs_no_ecp_use_psa()
+# - component_test_psa_crypto_config_accel_ecc_no_ecp_at_all()
+# - component_test_psa_crypto_config_reference_ecc_no_ecp_at_all()
 # to ensure that both tests use the same underlying configuration when testing
 # driver's coverage with analyze_outcomes.py.
 #
@@ -2417,7 +2417,7 @@ component_test_psa_crypto_config_reference_all_ec_algs_use_psa () {
 #
 # PK_C and RSA_C are always disabled to ensure there is no remaining dependency
 # on the ECP module.
-config_psa_crypto_full_all_ec_algs_no_ecp_use_psa () {
+config_psa_crypto_no_ecp_at_all () {
     DRIVER_ONLY="$1"
     # start with crypto_full config for maximum coverage (also enables USE_PSA),
     # but excluding X509, TLS and key exchanges
@@ -2471,8 +2471,8 @@ config_psa_crypto_full_all_ec_algs_no_ecp_use_psa () {
 # all support and dependencies from ECP and ECP_LIGHT are removed on the library
 # side.
 #
-# Keep in sync with component_test_psa_crypto_full_reference_all_ec_algs_no_ecp_use_psa()
-component_test_psa_crypto_full_accel_all_ec_algs_no_ecp_use_psa () {
+# Keep in sync with component_test_psa_crypto_config_reference_ecc_no_ecp_at_all()
+component_test_psa_crypto_config_accel_ecc_no_ecp_at_all () {
     msg "build: crypto_full + accelerated EC algs + USE_PSA - ECP"
 
     # Algorithms and key types to accelerate
@@ -2485,7 +2485,7 @@ component_test_psa_crypto_full_accel_all_ec_algs_no_ecp_use_psa () {
     # ---------
 
     # Set common configurations between library's and driver's builds
-    config_psa_crypto_full_all_ec_algs_no_ecp_use_psa 1
+    config_psa_crypto_no_ecp_at_all 1
 
     # Build
     # -----
@@ -2514,12 +2514,12 @@ component_test_psa_crypto_full_accel_all_ec_algs_no_ecp_use_psa () {
 }
 
 # Reference function used for driver's coverage analysis in analyze_outcomes.py
-# in conjunction with component_test_psa_crypto_full_accel_all_ec_algs_no_ecp_use_psa().
+# in conjunction with component_test_psa_crypto_config_accel_ecc_no_ecp_at_all().
 # Keep in sync with its accelerated counterpart.
-component_test_psa_crypto_full_reference_all_ec_algs_no_ecp_use_psa () {
+component_test_psa_crypto_config_reference_ecc_no_ecp_at_all () {
     msg "build: crypto_full + non accelerated EC algs + USE_PSA"
 
-    config_psa_crypto_full_all_ec_algs_no_ecp_use_psa 0
+    config_psa_crypto_no_ecp_at_all 0
 
     make
 

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1431,6 +1431,9 @@ component_test_full_no_bignum () {
     scripts/config.py unset MBEDTLS_ECDSA_C
     scripts/config.py unset MBEDTLS_ECJPAKE_C
     scripts/config.py unset MBEDTLS_ECP_RESTARTABLE
+    # Disable what auto-enables ECP_LIGHT
+    scripts/config.py unset MBEDTLS_PK_PARSE_EC_EXTENDED
+    scripts/config.py unset MBEDTLS_PK_PARSE_EC_COMPRESSED
     # Indirect dependencies of ECP
     scripts/config.py unset MBEDTLS_KEY_EXCHANGE_ECDH_ECDSA_ENABLED
     scripts/config.py unset MBEDTLS_KEY_EXCHANGE_ECDH_RSA_ENABLED

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -2432,7 +2432,6 @@ config_psa_crypto_no_ecp_at_all () {
         scripts/config.py unset MBEDTLS_ECJPAKE_C
         # Disable ECP module (entirely)
         scripts/config.py unset MBEDTLS_ECP_C
-        scripts/config.py unset MBEDTLS_ECP_LIGHT
     fi
 
     # Disable PK module since it depends on ECP

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -2450,6 +2450,9 @@ config_psa_crypto_no_ecp_at_all () {
     scripts/config.py unset MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED
     scripts/config.py unset MBEDTLS_KEY_EXCHANGE_ECDH_RSA_ENABLED
 
+    # Disable all the features that auto-enable ECP_LIGHT (see build_info.h)
+    scripts/config.py unset MBEDTLS_PK_PARSE_EC_EXTENDED
+
     # Restartable feature is not yet supported by PSA. Once it will in
     # the future, the following line could be removed (see issues
     # 6061, 6332 and following ones)

--- a/tests/scripts/analyze_outcomes.py
+++ b/tests/scripts/analyze_outcomes.py
@@ -296,7 +296,13 @@ TASKS = {
                     'PSA key derivation: bits=7 invalid for ECC SECT_K1 (ECC enabled)',
                     'PSA key derivation: bits=7 invalid for ECC SECT_R1 (ECC enabled)',
                     'PSA key derivation: bits=7 invalid for ECC SECT_R2 (ECC enabled)',
-                ]
+                ],
+                'test_suite_pkparse': [
+                    # See description provided for the analyze_driver_vs_reference_all_ec_algs
+                    # case above.
+                    ('Key ASN1 (OneAsymmetricKey X25519, doesn\'t match masking '
+                     'requirements, from RFC8410 Appendix A but made into version 0)'),
+                ],
             }
         }
     },

--- a/tests/scripts/analyze_outcomes.py
+++ b/tests/scripts/analyze_outcomes.py
@@ -196,11 +196,11 @@ TASKS = {
             }
         }
     },
-    'analyze_driver_vs_reference_all_ec_algs': {
+    'analyze_driver_vs_reference_ecp_light_only': {
         'test_function': do_analyze_driver_vs_reference,
         'args': {
-            'component_ref': 'test_psa_crypto_config_reference_all_ec_algs_use_psa',
-            'component_driver': 'test_psa_crypto_config_accel_all_ec_algs_use_psa',
+            'component_ref': 'test_psa_crypto_config_reference_ecc_ecp_light_only',
+            'component_driver': 'test_psa_crypto_config_accel_ecc_ecp_light_only',
             'ignored_suites': [
                 'ecdsa',
                 'ecdh',
@@ -265,11 +265,11 @@ TASKS = {
             }
         }
     },
-    'analyze_driver_vs_reference_all_ec_algs_no_ecp': {
+    'analyze_driver_vs_reference_no_ecp_at_all': {
         'test_function': do_analyze_driver_vs_reference,
         'args': {
-            'component_ref': 'test_psa_crypto_full_reference_all_ec_algs_no_ecp_use_psa',
-            'component_driver': 'test_psa_crypto_full_accel_all_ec_algs_no_ecp_use_psa',
+            'component_ref': 'test_psa_crypto_config_reference_ecc_no_ecp_at_all',
+            'component_driver': 'test_psa_crypto_config_accel_ecc_no_ecp_at_all',
             'ignored_suites': [
                 # Ignore test suites for the modules that are disabled in the
                 # accelerated test case.

--- a/tests/scripts/depends.py
+++ b/tests/scripts/depends.py
@@ -237,6 +237,8 @@ REVERSE_DEPENDENCIES = {
                       'MBEDTLS_ECDH_C',
                       'MBEDTLS_ECJPAKE_C',
                       'MBEDTLS_ECP_RESTARTABLE',
+                      'MBEDTLS_PK_PARSE_EC_EXTENDED',
+                      'MBEDTLS_PK_PARSE_EC_COMPRESSED',
                       'MBEDTLS_KEY_EXCHANGE_ECDH_ECDSA_ENABLED',
                       'MBEDTLS_KEY_EXCHANGE_ECDH_RSA_ENABLED',
                       'MBEDTLS_KEY_EXCHANGE_ECDHE_PSK_ENABLED',

--- a/tests/suites/test_suite_pkparse.data
+++ b/tests/suites/test_suite_pkparse.data
@@ -913,7 +913,7 @@ depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_LIGHT:MBEDTLS_ECP_DP_SECP192R1_ENABLE
 pk_parse_public_keyfile_ec:"data_files/ec_pub.pem":0
 
 Parse Public EC Key #2a (RFC 5480, PEM, secp192r1, compressed)
-depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_LIGHT:MBEDTLS_ECP_DP_SECP192R1_ENABLED
+depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_PK_PARSE_EC_COMPRESSED:MBEDTLS_ECP_DP_SECP192R1_ENABLED
 pk_parse_public_keyfile_ec:"data_files/ec_pub.comp.pem":0
 
 Parse Public EC Key #3 (RFC 5480, secp224r1)
@@ -923,7 +923,7 @@ pk_parse_public_keyfile_ec:"data_files/ec_224_pub.pem":0
 # Compressed points parsing does not support MBEDTLS_ECP_DP_SECP224R1 and
 # MBEDTLS_ECP_DP_SECP224K1. Therefore a failure is expected in this case
 Parse Public EC Key #3a (RFC 5480, secp224r1, compressed)
-depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_LIGHT:MBEDTLS_ECP_DP_SECP224R1_ENABLED
+depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_PK_PARSE_EC_COMPRESSED:MBEDTLS_ECP_DP_SECP224R1_ENABLED
 pk_parse_public_keyfile_ec:"data_files/ec_224_pub.comp.pem":MBEDTLS_ERR_ECP_FEATURE_UNAVAILABLE
 
 Parse Public EC Key #4 (RFC 5480, secp256r1)
@@ -931,7 +931,7 @@ depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_LIGHT:MBEDTLS_ECP_DP_SECP256R1_ENABLE
 pk_parse_public_keyfile_ec:"data_files/ec_256_pub.pem":0
 
 Parse Public EC Key #4a (RFC 5480, secp256r1, compressed)
-depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_LIGHT:MBEDTLS_ECP_DP_SECP256R1_ENABLED
+depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_PK_PARSE_EC_COMPRESSED:MBEDTLS_ECP_DP_SECP256R1_ENABLED
 pk_parse_public_keyfile_ec:"data_files/ec_256_pub.comp.pem":0
 
 Parse Public EC Key #5 (RFC 5480, secp384r1)
@@ -939,7 +939,7 @@ depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_LIGHT:MBEDTLS_ECP_DP_SECP384R1_ENABLE
 pk_parse_public_keyfile_ec:"data_files/ec_384_pub.pem":0
 
 Parse Public EC Key #5a (RFC 5480, secp384r1, compressed)
-depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_LIGHT:MBEDTLS_ECP_DP_SECP384R1_ENABLED
+depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_PK_PARSE_EC_COMPRESSED:MBEDTLS_ECP_DP_SECP384R1_ENABLED
 pk_parse_public_keyfile_ec:"data_files/ec_384_pub.comp.pem":0
 
 Parse Public EC Key #6 (RFC 5480, secp521r1)
@@ -947,7 +947,7 @@ depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_LIGHT:MBEDTLS_ECP_DP_SECP521R1_ENABLE
 pk_parse_public_keyfile_ec:"data_files/ec_521_pub.pem":0
 
 Parse Public EC Key #6a (RFC 5480, secp521r1, compressed)
-depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_LIGHT:MBEDTLS_ECP_DP_SECP521R1_ENABLED
+depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_PK_PARSE_EC_COMPRESSED:MBEDTLS_ECP_DP_SECP521R1_ENABLED
 pk_parse_public_keyfile_ec:"data_files/ec_521_pub.comp.pem":0
 
 Parse Public EC Key #7 (RFC 5480, brainpoolP256r1)
@@ -955,7 +955,7 @@ depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_LIGHT:MBEDTLS_ECP_DP_BP256R1_ENABLED
 pk_parse_public_keyfile_ec:"data_files/ec_bp256_pub.pem":0
 
 Parse Public EC Key #7a (RFC 5480, brainpoolP256r1, compressed)
-depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_LIGHT:MBEDTLS_ECP_DP_BP256R1_ENABLED
+depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_PK_PARSE_EC_COMPRESSED:MBEDTLS_ECP_DP_BP256R1_ENABLED
 pk_parse_public_keyfile_ec:"data_files/ec_bp256_pub.comp.pem":0
 
 Parse Public EC Key #8 (RFC 5480, brainpoolP384r1)
@@ -963,7 +963,7 @@ depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_LIGHT:MBEDTLS_ECP_DP_BP384R1_ENABLED
 pk_parse_public_keyfile_ec:"data_files/ec_bp384_pub.pem":0
 
 Parse Public EC Key #8a (RFC 5480, brainpoolP384r1, compressed)
-depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_LIGHT:MBEDTLS_ECP_DP_BP384R1_ENABLED
+depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_PK_PARSE_EC_COMPRESSED:MBEDTLS_ECP_DP_BP384R1_ENABLED
 pk_parse_public_keyfile_ec:"data_files/ec_bp384_pub.comp.pem":0
 
 Parse Public EC Key #9 (RFC 5480, brainpoolP512r1)
@@ -971,7 +971,7 @@ depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_LIGHT:MBEDTLS_ECP_DP_BP512R1_ENABLED
 pk_parse_public_keyfile_ec:"data_files/ec_bp512_pub.pem":0
 
 Parse Public EC Key #9a (RFC 5480, brainpoolP512r1, compressed)
-depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_LIGHT:MBEDTLS_ECP_DP_BP512R1_ENABLED
+depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_PK_PARSE_EC_COMPRESSED:MBEDTLS_ECP_DP_BP512R1_ENABLED
 pk_parse_public_keyfile_ec:"data_files/ec_bp512_pub.comp.pem":0
 
 Parse Public EC Key #10 (RFC 8410, DER, X25519)
@@ -999,7 +999,7 @@ depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_LIGHT:MBEDTLS_ECP_DP_SECP192R1_ENABLE
 pk_parse_keyfile_ec:"data_files/ec_prv.sec1.pem":"NULL":0
 
 Parse EC Key #2a (SEC1 PEM, secp192r1, compressed)
-depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_LIGHT:MBEDTLS_ECP_DP_SECP192R1_ENABLED
+depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_PK_PARSE_EC_COMPRESSED:MBEDTLS_ECP_DP_SECP192R1_ENABLED
 pk_parse_keyfile_ec:"data_files/ec_prv.sec1.comp.pem":"NULL":0
 
 Parse EC Key #3 (SEC1 PEM encrypted)
@@ -1043,7 +1043,7 @@ depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_LIGHT:MBEDTLS_ECP_DP_SECP224R1_ENABLE
 pk_parse_keyfile_ec:"data_files/ec_224_prv.pem":"NULL":0
 
 Parse EC Key #8a (SEC1 PEM, secp224r1, compressed)
-depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_LIGHT:MBEDTLS_ECP_DP_SECP224R1_ENABLED
+depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_PK_PARSE_EC_COMPRESSED:MBEDTLS_ECP_DP_SECP224R1_ENABLED
 pk_parse_keyfile_ec:"data_files/ec_224_prv.comp.pem":"NULL":0
 
 Parse EC Key #9 (SEC1 PEM, secp256r1)
@@ -1051,7 +1051,7 @@ depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_LIGHT:MBEDTLS_ECP_DP_SECP256R1_ENABLE
 pk_parse_keyfile_ec:"data_files/ec_256_prv.pem":"NULL":0
 
 Parse EC Key #9a (SEC1 PEM, secp256r1, compressed)
-depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_LIGHT:MBEDTLS_ECP_DP_SECP256R1_ENABLED
+depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_PK_PARSE_EC_COMPRESSED:MBEDTLS_ECP_DP_SECP256R1_ENABLED
 pk_parse_keyfile_ec:"data_files/ec_256_prv.comp.pem":"NULL":0
 
 Parse EC Key #10 (SEC1 PEM, secp384r1)
@@ -1059,7 +1059,7 @@ depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_LIGHT:MBEDTLS_ECP_DP_SECP384R1_ENABLE
 pk_parse_keyfile_ec:"data_files/ec_384_prv.pem":"NULL":0
 
 Parse EC Key #10a (SEC1 PEM, secp384r1, compressed)
-depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_LIGHT:MBEDTLS_ECP_DP_SECP384R1_ENABLED
+depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_PK_PARSE_EC_COMPRESSED:MBEDTLS_ECP_DP_SECP384R1_ENABLED
 pk_parse_keyfile_ec:"data_files/ec_384_prv.comp.pem":"NULL":0
 
 Parse EC Key #11 (SEC1 PEM, secp521r1)
@@ -1067,7 +1067,7 @@ depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_LIGHT:MBEDTLS_ECP_DP_SECP521R1_ENABLE
 pk_parse_keyfile_ec:"data_files/ec_521_prv.pem":"NULL":0
 
 Parse EC Key #11a (SEC1 PEM, secp521r1, compressed)
-depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_LIGHT:MBEDTLS_ECP_DP_SECP521R1_ENABLED
+depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_PK_PARSE_EC_COMPRESSED:MBEDTLS_ECP_DP_SECP521R1_ENABLED
 pk_parse_keyfile_ec:"data_files/ec_521_prv.comp.pem":"NULL":0
 
 Parse EC Key #12 (SEC1 PEM, bp256r1)
@@ -1075,7 +1075,7 @@ depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_LIGHT:MBEDTLS_ECP_DP_BP256R1_ENABLED
 pk_parse_keyfile_ec:"data_files/ec_bp256_prv.pem":"NULL":0
 
 Parse EC Key #12a (SEC1 PEM, bp256r1, compressed)
-depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_LIGHT:MBEDTLS_ECP_DP_BP256R1_ENABLED
+depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_PK_PARSE_EC_COMPRESSED:MBEDTLS_ECP_DP_BP256R1_ENABLED
 pk_parse_keyfile_ec:"data_files/ec_bp256_prv.comp.pem":"NULL":0
 
 Parse EC Key #13 (SEC1 PEM, bp384r1)
@@ -1083,7 +1083,7 @@ depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_LIGHT:MBEDTLS_ECP_DP_BP384R1_ENABLED
 pk_parse_keyfile_ec:"data_files/ec_bp384_prv.pem":"NULL":0
 
 Parse EC Key #13a (SEC1 PEM, bp384r1, compressed)
-depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_LIGHT:MBEDTLS_ECP_DP_BP384R1_ENABLED
+depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_PK_PARSE_EC_COMPRESSED:MBEDTLS_ECP_DP_BP384R1_ENABLED
 pk_parse_keyfile_ec:"data_files/ec_bp384_prv.comp.pem":"NULL":0
 
 Parse EC Key #14 (SEC1 PEM, bp512r1)
@@ -1091,7 +1091,7 @@ depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_LIGHT:MBEDTLS_ECP_DP_BP512R1_ENABLED
 pk_parse_keyfile_ec:"data_files/ec_bp512_prv.pem":"NULL":0
 
 Parse EC Key #14a (SEC1 PEM, bp512r1, compressed)
-depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_LIGHT:MBEDTLS_ECP_DP_BP512R1_ENABLED
+depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_PK_PARSE_EC_COMPRESSED:MBEDTLS_ECP_DP_BP512R1_ENABLED
 pk_parse_keyfile_ec:"data_files/ec_bp512_prv.comp.pem":"NULL":0
 
 Parse EC Key #15 (SEC1 DER, secp256k1, SpecifiedECDomain)

--- a/tests/suites/test_suite_pkparse.data
+++ b/tests/suites/test_suite_pkparse.data
@@ -1095,7 +1095,7 @@ depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_LIGHT:MBEDTLS_ECP_DP_BP512R1_ENABLED
 pk_parse_keyfile_ec:"data_files/ec_bp512_prv.comp.pem":"NULL":0
 
 Parse EC Key #15 (SEC1 DER, secp256k1, SpecifiedECDomain)
-depends_on:MBEDTLS_ECP_LIGHT:MBEDTLS_ECP_DP_SECP256K1_ENABLED:MBEDTLS_PK_PARSE_EC_EXTENDED
+depends_on:MBEDTLS_ECP_DP_SECP256K1_ENABLED:MBEDTLS_PK_PARSE_EC_EXTENDED
 pk_parse_keyfile_ec:"data_files/ec_prv.specdom.der":"NULL":0
 
 Parse EC Key #16 (RFC 8410, DER, X25519)


### PR DESCRIPTION
This PR resolves #7442 (please refer to the original issue because the goals are described pretty well there).

Depends on ~#7641~ (merged) 
Resolves #7442

## PR checklist

- [x] **changelog** deferred, see #7413
- [x] **backport** not required
- [x] **tests** not required