### PR TITLE
Fix "unterminated '#pragma clang attribute push'" in sha256/sha512.c

### DIFF
--- a/ChangeLog.d/fix-unterminated-pragma-clang-attribute-push.txt
+++ b/ChangeLog.d/fix-unterminated-pragma-clang-attribute-push.txt
@@ -1,0 +1,4 @@
+Bugfix
+   * Fix "unterminated '#pragma clang attribute push'" in sha256/sha512.c when
+     built with MBEDTLS_SHAxxx_USE_A64_CRYPTO_IF_PRESENT but don't have a
+     way to detect the crypto extensions required. A warning is still issued.

--- a/library/sha256.c
+++ b/library/sha256.c
@@ -399,6 +399,8 @@ int mbedtls_internal_sha256_process_a64_crypto(mbedtls_sha256_context *ctx,
             SHA256_BLOCK_SIZE) ? 0 : -1;
 }
 
+#endif /* MBEDTLS_SHA256_USE_A64_CRYPTO_IF_PRESENT || MBEDTLS_SHA256_USE_A64_CRYPTO_ONLY */
+
 #if defined(MBEDTLS_POP_TARGET_PRAGMA)
 #if defined(__clang__)
 #pragma clang attribute pop
@@ -407,8 +409,6 @@ int mbedtls_internal_sha256_process_a64_crypto(mbedtls_sha256_context *ctx,
 #endif
 #undef MBEDTLS_POP_TARGET_PRAGMA
 #endif
-
-#endif /* MBEDTLS_SHA256_USE_A64_CRYPTO_IF_PRESENT || MBEDTLS_SHA256_USE_A64_CRYPTO_ONLY */
 
 #if !defined(MBEDTLS_SHA256_USE_A64_CRYPTO_IF_PRESENT)
 #define mbedtls_internal_sha256_process_many_c mbedtls_internal_sha256_process_many

--- a/library/sha512.c
+++ b/library/sha512.c
@@ -569,6 +569,8 @@ int mbedtls_internal_sha512_process_a64_crypto(mbedtls_sha512_context *ctx,
             SHA512_BLOCK_SIZE) ? 0 : -1;
 }
 
+#endif /* MBEDTLS_SHA512_USE_A64_CRYPTO_IF_PRESENT || MBEDTLS_SHA512_USE_A64_CRYPTO_ONLY */
+
 #if defined(MBEDTLS_POP_TARGET_PRAGMA)
 #if defined(__clang__)
 #pragma clang attribute pop
@@ -577,8 +579,6 @@ int mbedtls_internal_sha512_process_a64_crypto(mbedtls_sha512_context *ctx,
 #endif
 #undef MBEDTLS_POP_TARGET_PRAGMA
 #endif
-
-#endif /* MBEDTLS_SHA512_USE_A64_CRYPTO_IF_PRESENT || MBEDTLS_SHA512_USE_A64_CRYPTO_ONLY */
 
 
 #if !defined(MBEDTLS_SHA512_USE_A64_CRYPTO_IF_PRESENT)

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -3954,16 +3954,14 @@ component_build_armcc () {
     # ARM Compiler 6 - Target ARMv8-M
     armc6_build_test "-O1 --target=arm-arm-none-eabi -march=armv8-m.main"
 
-    # ARM Compiler 6 - Target ARMv8.2-A - AArch64
-    armc6_build_test "-O1 --target=aarch64-arm-none-eabi -march=armv8.2-a+crypto"
-
     # ARM Compiler 6 - Target Cortex-M0 - no optimisation
     armc6_build_test "-O0 --target=arm-arm-none-eabi -mcpu=cortex-m0"
 
     # ARM Compiler 6 - Target Cortex-M0
     armc6_build_test "-Os --target=arm-arm-none-eabi -mcpu=cortex-m0"
 
-    # Check that we handle "No mechanism to detect A64_CRYPTO found" properly
+    # ARM Compiler 6 - Target ARMv8.2-A - AArch64, and
+    # check that we handle "No mechanism to detect A64_CRYPTO found" properly
     scripts/config.py set MBEDTLS_SHA256_USE_A64_CRYPTO_IF_PRESENT
     scripts/config.py set MBEDTLS_SHA512_USE_A64_CRYPTO_IF_PRESENT
     armc6_build_test "-Wno-#warnings -O1 --target=aarch64-arm-none-eabi -march=armv8.2-a+crypto"

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -3966,18 +3966,16 @@ component_build_armcc () {
     # ARM Compiler 6 - Target ARMv8-M
     armc6_build_test "-O1 --target=arm-arm-none-eabi -march=armv8-m.main"
 
+    # ARM Compiler 6 - Target ARMv8.2-A - AArch64
+    armc6_build_test "-O1 --target=aarch64-arm-none-eabi -march=armv8.2-a+crypto"
+
     # ARM Compiler 6 - Target Cortex-M0 - no optimisation
     armc6_build_test "-O0 --target=arm-arm-none-eabi -mcpu=cortex-m0"
 
     # ARM Compiler 6 - Target Cortex-M0
     armc6_build_test "-Os --target=arm-arm-none-eabi -mcpu=cortex-m0"
-
-    # ARM Compiler 6 - Target ARMv8.2-A - AArch64, and
-    # check that we handle "No mechanism to detect A64_CRYPTO found" properly
-    scripts/config.py set MBEDTLS_SHA256_USE_A64_CRYPTO_IF_PRESENT
-    scripts/config.py set MBEDTLS_SHA512_USE_A64_CRYPTO_IF_PRESENT
-    armc6_build_test "-Wno-#warnings -O1 --target=aarch64-arm-none-eabi -march=armv8.2-a+crypto"
 }
+
 support_build_armcc () {
     armc5_cc="$ARMC5_BIN_DIR/armcc"
     armc6_cc="$ARMC6_BIN_DIR/armclang"

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -3962,6 +3962,11 @@ component_build_armcc () {
 
     # ARM Compiler 6 - Target Cortex-M0
     armc6_build_test "-Os --target=arm-arm-none-eabi -mcpu=cortex-m0"
+
+    # Check that we handle "No mechanism to detect A64_CRYPTO found" properly
+    scripts/config.py set MBEDTLS_SHA256_USE_A64_CRYPTO_IF_PRESENT
+    scripts/config.py set MBEDTLS_SHA512_USE_A64_CRYPTO_IF_PRESENT
+    armc6_build_test "-Wno-#warnings -O1 --target=aarch64-arm-none-eabi -march=armv8.2-a+crypto"
 }
 support_build_armcc () {
     armc5_cc="$ARMC5_BIN_DIR/armcc"

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -411,6 +411,18 @@ check_tools()
     done
 }
 
+pre_parse_command_line_for_dirs () {
+    # Make an early pass through the options given, so we can set directories
+    # for Arm compilers, before SUPPORTED_COMPONENTS is determined.
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --armc5-bin-dir) shift; ARMC5_BIN_DIR="$1";;
+            --armc6-bin-dir) shift; ARMC6_BIN_DIR="$1";;
+        esac
+        shift
+    done
+}
+
 pre_parse_command_line () {
     COMMAND_LINE_COMPONENTS=
     all_except=0
@@ -427,8 +439,8 @@ pre_parse_command_line () {
             --arm-none-eabi-gcc-prefix) shift; ARM_NONE_EABI_GCC_PREFIX="$1";;
             --arm-linux-gnueabi-gcc-prefix) shift; ARM_LINUX_GNUEABI_GCC_PREFIX="$1";;
             --armcc) no_armcc=;;
-            --armc5-bin-dir) shift; ARMC5_BIN_DIR="$1";;
-            --armc6-bin-dir) shift; ARMC6_BIN_DIR="$1";;
+            --armc5-bin-dir) shift; ;; # assignment to ARMC5_BIN_DIR done in pre_parse_command_line_for_dirs
+            --armc6-bin-dir) shift; ;; # assignment to ARMC6_BIN_DIR done in pre_parse_command_line_for_dirs
             --error-test) error_test=$((error_test + 1));;
             --except) all_except=1;;
             --force|-f) FORCE=1;;
@@ -4447,6 +4459,7 @@ run_component () {
 
 # Preliminary setup
 pre_check_environment
+pre_parse_command_line_for_dirs "$@"
 pre_initialize_variables
 pre_parse_command_line "$@"
 


### PR DESCRIPTION
If we're built with `MBEDTLS_SHAxxx_USE_A64_CRYPTO_IF_PRESENT` but don't have a way to detect the crypto extensions required, the code turns off `xxx_IF_PRESENT` and falls back to C only (with a warning). This was done after the attributes are pushed, and the pop is done only `#if defined(xxx_IF_PRESENT)`, so this commit fixes that.

Also fix an issue with `all.sh` that cropped up while testing (`--armc5-bin-dir` and `--armc6-bin-dir` don't work)

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** provided
- [x] **backport** not required - this feature is on `development` only
- [x] **tests** provided



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.
