### PR TITLE
Implement mbedtls_net_connect_timeout

### DIFF
--- a/ChangeLog.d/mbedtls_net_connect_timeout.txt
+++ b/ChangeLog.d/mbedtls_net_connect_timeout.txt
@@ -1,0 +1,3 @@
+Features
+    * Add mbedtls_net_connect_timeout() function which behaves the same as
+      mbedtls_net_connect() but allows specifying a connect timeout.

--- a/include/mbedtls/net_sockets.h
+++ b/include/mbedtls/net_sockets.h
@@ -129,6 +129,28 @@ void mbedtls_net_init(mbedtls_net_context *ctx);
 int mbedtls_net_connect(mbedtls_net_context *ctx, const char *host, const char *port, int proto);
 
 /**
+ * \brief          Initiate a connection with host:port in the given protocol with a timeout
+ *
+ * \param ctx      Socket to use
+ * \param host     Host to connect to
+ * \param port     Port to connect to
+ * \param proto    Protocol: MBEDTLS_NET_PROTO_TCP or MBEDTLS_NET_PROTO_UDP
+ * \param timeout  The timeout in milliseconds
+ *
+ * \return         0 if successful, or one of:
+ *                      MBEDTLS_ERR_NET_SOCKET_FAILED,
+ *                      MBEDTLS_ERR_NET_UNKNOWN_HOST,
+ *                      MBEDTLS_ERR_NET_CONNECT_FAILED
+ *
+ * \note           Sets the socket in connected mode even with UDP.
+ */
+int mbedtls_net_connect_timeout(mbedtls_net_context *ctx,
+                                const char *host,
+                                const char *port,
+                                int proto,
+                                int timeout);
+
+/**
  * \brief          Create a receiving socket on bind_ip:port in the chosen
  *                 protocol. If bind_ip == NULL, all interfaces are bound.
  *

--- a/include/mbedtls/net_sockets.h
+++ b/include/mbedtls/net_sockets.h
@@ -135,7 +135,8 @@ int mbedtls_net_connect(mbedtls_net_context *ctx, const char *host, const char *
  * \param host     Host to connect to
  * \param port     Port to connect to
  * \param proto    Protocol: MBEDTLS_NET_PROTO_TCP or MBEDTLS_NET_PROTO_UDP
- * \param timeout  The timeout in milliseconds
+ * \param timeout  Maximum number of milliseconds to wait for a connection
+ *                 0 means no timeout (wait forever)
  *
  * \return         0 if successful, or one of:
  *                      MBEDTLS_ERR_NET_SOCKET_FAILED,
@@ -148,7 +149,7 @@ int mbedtls_net_connect_timeout(mbedtls_net_context *ctx,
                                 const char *host,
                                 const char *port,
                                 int proto,
-                                int timeout);
+                                uint32_t timeout);
 
 /**
  * \brief          Create a receiving socket on bind_ip:port in the chosen

--- a/library/net_sockets.c
+++ b/library/net_sockets.c
@@ -174,52 +174,14 @@ void mbedtls_net_init(mbedtls_net_context *ctx)
 int mbedtls_net_connect(mbedtls_net_context *ctx, const char *host,
                         const char *port, int proto)
 {
-    int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
-    struct addrinfo hints, *addr_list, *cur;
-
-    if ((ret = net_prepare()) != 0) {
-        return ret;
-    }
-
-    /* Do name resolution with both IPv6 and IPv4 */
-    memset(&hints, 0, sizeof(hints));
-    hints.ai_family = AF_UNSPEC;
-    hints.ai_socktype = proto == MBEDTLS_NET_PROTO_UDP ? SOCK_DGRAM : SOCK_STREAM;
-    hints.ai_protocol = proto == MBEDTLS_NET_PROTO_UDP ? IPPROTO_UDP : IPPROTO_TCP;
-
-    if (getaddrinfo(host, port, &hints, &addr_list) != 0) {
-        return MBEDTLS_ERR_NET_UNKNOWN_HOST;
-    }
-
-    /* Try the sockaddrs until a connection succeeds */
-    ret = MBEDTLS_ERR_NET_UNKNOWN_HOST;
-    for (cur = addr_list; cur != NULL; cur = cur->ai_next) {
-        ctx->fd = (int) socket(cur->ai_family, cur->ai_socktype,
-                               cur->ai_protocol);
-        if (ctx->fd < 0) {
-            ret = MBEDTLS_ERR_NET_SOCKET_FAILED;
-            continue;
-        }
-
-        if (connect(ctx->fd, cur->ai_addr, MSVC_INT_CAST cur->ai_addrlen) == 0) {
-            ret = 0;
-            break;
-        }
-
-        close(ctx->fd);
-        ret = MBEDTLS_ERR_NET_CONNECT_FAILED;
-    }
-
-    freeaddrinfo(addr_list);
-
-    return ret;
+    return mbedtls_net_connect_timeout(ctx, host, port, proto, 0);
 }
 
 /*
- * Initiate a TCP connection with host:port and the given protocol with a timeout (ms)
+ * Initiate a TCP connection with host:port and the given protocol blocking for at most 'timeout' ms
  */
 int mbedtls_net_connect_timeout(mbedtls_net_context *ctx, const char *host,
-                                const char *port, int proto, int timeout)
+                                const char *port, int proto, uint32_t timeout)
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     struct addrinfo hints, *addr_list, *cur;


### PR DESCRIPTION
Implement a new function `mbedtls_net_connect_timeout()` which takes a timeout
argument. Reimplement the original `mbedtls_net_connect()` in terms of this new function.



## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** provided
- [ ] **backport** done, or not required
- [ ] **tests** provided, or not required
