### PR TITLE
Exclude Driver Wrapper Function Prototype

### DIFF
--- a/library/psa_crypto_driver_wrappers.h
+++ b/library/psa_crypto_driver_wrappers.h
@@ -37,6 +37,11 @@ void psa_driver_wrapper_free(void);
 /*
  * Signature functions
  */
+#if !defined(PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT) && !defined(PSA_CRYPTO_DRIVER_TEST)
+#define psa_driver_wrapper_sign_message psa_sign_message_builtin
+#endif
+
+#if defined(PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT) || defined(PSA_CRYPTO_DRIVER_TEST)
 psa_status_t psa_driver_wrapper_sign_message(
     const psa_key_attributes_t *attributes,
     const uint8_t *key_buffer,
@@ -47,6 +52,7 @@ psa_status_t psa_driver_wrapper_sign_message(
     uint8_t *signature,
     size_t signature_size,
     size_t *signature_length);
+#endif
 
 psa_status_t psa_driver_wrapper_verify_message(
     const psa_key_attributes_t *attributes,
@@ -154,6 +160,22 @@ psa_status_t psa_driver_wrapper_copy_key(
 /*
  * Cipher functions
  */
+#if !defined(PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT) && !defined(PSA_CRYPTO_DRIVER_TEST)
+#if defined(MBEDTLS_PSA_BUILTIN_CIPHER)
+#define psa_driver_wrapper_cipher_encrypt mbedtls_psa_cipher_encrypt
+#else
+#define psa_driver_wrapper_cipher_encrypt(attributes, key_buffer, \
+                                          key_buffer_size, alg, iv, iv_length, \
+                                          input, input_length, output, \
+                                          output_size, output_length) \
+    ((void) attributes, (void) key_buffer, (void) key_buffer_size, \
+     (void) alg, (void) iv, (void) iv_length, (void) input, (void) input_length, \
+     (void) output, (void) output_length, \
+     PSA_ERROR_NOT_SUPPORTED)
+#endif
+#endif
+
+#if defined(PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT) || defined(PSA_CRYPTO_DRIVER_TEST)
 psa_status_t psa_driver_wrapper_cipher_encrypt(
     const psa_key_attributes_t *attributes,
     const uint8_t *key_buffer,
@@ -166,7 +188,24 @@ psa_status_t psa_driver_wrapper_cipher_encrypt(
     uint8_t *output,
     size_t output_size,
     size_t *output_length);
+#endif
 
+#if !defined(PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT) && !defined(PSA_CRYPTO_DRIVER_TEST)
+#if defined(MBEDTLS_PSA_BUILTIN_CIPHER)
+#define psa_driver_wrapper_cipher_decrypt mbedtls_psa_cipher_decrypt
+#else
+#define psa_driver_wrapper_cipher_decrypt(attributes, key_buffer, \
+                                          key_buffer_size, alg, input, \
+                                          input_length, output, output_size, \
+                                          output_length) \
+    ((void) attributes, (void) key_buffer, (void) key_buffer_size, \
+     (void) alg, (void) input, (void) input_length, (void) output, \
+     (void) output_size, (void) output_length, \
+     PSA_ERROR_NOT_SUPPORTED)
+#endif
+#endif
+
+#if defined(PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT) || defined(PSA_CRYPTO_DRIVER_TEST)
 psa_status_t psa_driver_wrapper_cipher_decrypt(
     const psa_key_attributes_t *attributes,
     const uint8_t *key_buffer,
@@ -177,6 +216,7 @@ psa_status_t psa_driver_wrapper_cipher_decrypt(
     uint8_t *output,
     size_t output_size,
     size_t *output_length);
+#endif
 
 psa_status_t psa_driver_wrapper_cipher_encrypt_setup(
     psa_cipher_operation_t *operation,

--- a/scripts/data_files/driver_templates/psa_crypto_driver_wrappers.c.jinja
+++ b/scripts/data_files/driver_templates/psa_crypto_driver_wrappers.c.jinja
@@ -120,6 +120,7 @@ void psa_driver_wrapper_free( void )
 }
 
 /* Start delegation functions */
+#if defined(PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT) || defined(PSA_CRYPTO_DRIVER_TEST)
 psa_status_t psa_driver_wrapper_sign_message(
     const psa_key_attributes_t *attributes,
     const uint8_t *key_buffer,
@@ -194,6 +195,7 @@ psa_status_t psa_driver_wrapper_sign_message(
                                       signature_size,
                                       signature_length ) );
 }
+#endif /* PSA_CRYPTO_DRIVER_TEST || PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
 
 psa_status_t psa_driver_wrapper_verify_message(
     const psa_key_attributes_t *attributes,
@@ -1190,6 +1192,7 @@ target_key_buffer_length
 /*
  * Cipher functions
  */
+#if defined(PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT) || defined(PSA_CRYPTO_DRIVER_TEST)
 psa_status_t psa_driver_wrapper_cipher_encrypt(
     const psa_key_attributes_t *attributes,
     const uint8_t *key_buffer,
@@ -1281,7 +1284,9 @@ psa_status_t psa_driver_wrapper_cipher_encrypt(
             return( PSA_ERROR_INVALID_ARGUMENT );
     }
 }
+#endif /* PSA_CRYPTO_DRIVER_TEST || PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
 
+#if defined(PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT) || defined(PSA_CRYPTO_DRIVER_TEST)
 psa_status_t psa_driver_wrapper_cipher_decrypt(
     const psa_key_attributes_t *attributes,
     const uint8_t *key_buffer,
@@ -1363,6 +1368,7 @@ psa_status_t psa_driver_wrapper_cipher_decrypt(
             return( PSA_ERROR_INVALID_ARGUMENT );
     }
 }
+#endif /* PSA_CRYPTO_DRIVER_TEST || PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
 
 psa_status_t psa_driver_wrapper_cipher_encrypt_setup(
     psa_cipher_operation_t *operation,


### PR DESCRIPTION
## Description
Fixes #7395 

The goal of this PR is to introduce a prototype mechanism for excluding the driver wrapper code when there is no hardware acceleration available and the built-in implementation will be used.


## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- **changelog**: not required - not a user visible change.
- **backport** not required - this is an enhancement.
- **tests** not required - covered by existing tests.



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.
