### PR TITLE
Fix crypt_and_hash decrypt issue when used with stream cipher

### DIFF
--- a/ChangeLog.d/fix-crypt_and_hash-decrypt-issue.txt
+++ b/ChangeLog.d/fix-crypt_and_hash-decrypt-issue.txt
@@ -1,0 +1,4 @@
+Bugfix
+   * Fix crypt_and_hash decryption fail when used with a stream cipher
+     mode of operation due to the input not being multiple of block size.
+     Resolves #7417.

--- a/programs/aes/crypt_and_hash.c
+++ b/programs/aes/crypt_and_hash.c
@@ -406,6 +406,9 @@ int main(int argc, char *argv[])
          * Check the file size.
          */
         if (mbedtls_cipher_info_get_mode(cipher_info) != MBEDTLS_MODE_GCM &&
+            mbedtls_cipher_info_get_mode(cipher_info) != MBEDTLS_MODE_CTR &&
+            mbedtls_cipher_info_get_mode(cipher_info) != MBEDTLS_MODE_CFB &&
+            mbedtls_cipher_info_get_mode(cipher_info) != MBEDTLS_MODE_OFB &&
             ((filesize - mbedtls_md_get_size(md_info)) %
              mbedtls_cipher_get_block_size(&cipher_ctx)) != 0) {
             mbedtls_fprintf(stderr, "File content not a multiple of the block size (%u).\n",

--- a/programs/aes/crypt_and_hash.c
+++ b/programs/aes/crypt_and_hash.c
@@ -88,6 +88,9 @@ int main(int argc, char *argv[])
     const mbedtls_md_info_t *md_info;
     mbedtls_cipher_context_t cipher_ctx;
     mbedtls_md_context_t md_ctx;
+    mbedtls_cipher_mode_t cipher_mode;
+    unsigned int cipher_block_size;
+    unsigned char md_size;
 #if defined(_WIN32_WCE)
     long filesize, offset;
 #elif defined(_WIN32)
@@ -235,6 +238,9 @@ int main(int argc, char *argv[])
         goto exit;
     }
 
+    md_size = mbedtls_md_get_size(md_info);
+    cipher_block_size = mbedtls_cipher_get_block_size(&cipher_ctx);
+
     if (mode == MODE_ENCRYPT) {
         /*
          * Generate the initialization vector as:
@@ -329,9 +335,9 @@ int main(int argc, char *argv[])
         /*
          * Encrypt and write the ciphertext.
          */
-        for (offset = 0; offset < filesize; offset += mbedtls_cipher_get_block_size(&cipher_ctx)) {
-            ilen = ((unsigned int) filesize - offset > mbedtls_cipher_get_block_size(&cipher_ctx)) ?
-                   mbedtls_cipher_get_block_size(&cipher_ctx) : (unsigned int) (filesize - offset);
+        for (offset = 0; offset < filesize; offset += cipher_block_size) {
+            ilen = ((unsigned int) filesize - offset > cipher_block_size) ?
+                   cipher_block_size : (unsigned int) (filesize - offset);
 
             if (fread(buffer, 1, ilen, fin) != ilen) {
                 mbedtls_fprintf(stderr, "fread(%ld bytes) failed\n", (long) ilen);
@@ -376,8 +382,8 @@ int main(int argc, char *argv[])
             goto exit;
         }
 
-        if (fwrite(digest, 1, mbedtls_md_get_size(md_info), fout) != mbedtls_md_get_size(md_info)) {
-            mbedtls_fprintf(stderr, "fwrite(%d bytes) failed\n", mbedtls_md_get_size(md_info));
+        if (fwrite(digest, 1, md_size, fout) != md_size) {
+            mbedtls_fprintf(stderr, "fwrite(%d bytes) failed\n", md_size);
             goto exit;
         }
     }
@@ -392,12 +398,12 @@ int main(int argc, char *argv[])
          *      N*16 .. (N+1)*16 - 1    Encrypted Block #N
          *  (N+1)*16 .. (N+1)*16 + n    Hash(ciphertext)
          */
-        if (filesize < 16 + mbedtls_md_get_size(md_info)) {
+        if (filesize < 16 + md_size) {
             mbedtls_fprintf(stderr, "File too short to be encrypted.\n");
             goto exit;
         }
 
-        if (mbedtls_cipher_get_block_size(&cipher_ctx) == 0) {
+        if (cipher_block_size == 0) {
             mbedtls_fprintf(stderr, "Invalid cipher block size: 0. \n");
             goto exit;
         }
@@ -405,21 +411,21 @@ int main(int argc, char *argv[])
         /*
          * Check the file size.
          */
-        if (mbedtls_cipher_info_get_mode(cipher_info) != MBEDTLS_MODE_GCM &&
-            mbedtls_cipher_info_get_mode(cipher_info) != MBEDTLS_MODE_CTR &&
-            mbedtls_cipher_info_get_mode(cipher_info) != MBEDTLS_MODE_CFB &&
-            mbedtls_cipher_info_get_mode(cipher_info) != MBEDTLS_MODE_OFB &&
-            ((filesize - mbedtls_md_get_size(md_info)) %
-             mbedtls_cipher_get_block_size(&cipher_ctx)) != 0) {
+        cipher_mode = mbedtls_cipher_info_get_mode(cipher_info);
+        if (cipher_mode != MBEDTLS_MODE_GCM &&
+            cipher_mode != MBEDTLS_MODE_CTR &&
+            cipher_mode != MBEDTLS_MODE_CFB &&
+            cipher_mode != MBEDTLS_MODE_OFB &&
+            ((filesize - md_size) % cipher_block_size) != 0) {
             mbedtls_fprintf(stderr, "File content not a multiple of the block size (%u).\n",
-                            mbedtls_cipher_get_block_size(&cipher_ctx));
+                            cipher_block_size);
             goto exit;
         }
 
         /*
          * Subtract the IV + HMAC length.
          */
-        filesize -= (16 + mbedtls_md_get_size(md_info));
+        filesize -= (16 + md_size);
 
         /*
          * Read the IV and original filesize modulo 16.
@@ -483,13 +489,13 @@ int main(int argc, char *argv[])
         /*
          * Decrypt and write the plaintext.
          */
-        for (offset = 0; offset < filesize; offset += mbedtls_cipher_get_block_size(&cipher_ctx)) {
-            ilen = ((unsigned int) filesize - offset > mbedtls_cipher_get_block_size(&cipher_ctx)) ?
-                   mbedtls_cipher_get_block_size(&cipher_ctx) : (unsigned int) (filesize - offset);
+        for (offset = 0; offset < filesize; offset += cipher_block_size) {
+            ilen = ((unsigned int) filesize - offset > cipher_block_size) ?
+                   cipher_block_size : (unsigned int) (filesize - offset);
 
             if (fread(buffer, 1, ilen, fin) != ilen) {
                 mbedtls_fprintf(stderr, "fread(%u bytes) failed\n",
-                                mbedtls_cipher_get_block_size(&cipher_ctx));
+                                cipher_block_size);
                 goto exit;
             }
 
@@ -517,14 +523,14 @@ int main(int argc, char *argv[])
             goto exit;
         }
 
-        if (fread(buffer, 1, mbedtls_md_get_size(md_info), fin) != mbedtls_md_get_size(md_info)) {
-            mbedtls_fprintf(stderr, "fread(%d bytes) failed\n", mbedtls_md_get_size(md_info));
+        if (fread(buffer, 1, md_size, fin) != md_size) {
+            mbedtls_fprintf(stderr, "fread(%d bytes) failed\n", md_size);
             goto exit;
         }
 
         /* Use constant-time buffer comparison */
         diff = 0;
-        for (i = 0; i < mbedtls_md_get_size(md_info); i++) {
+        for (i = 0; i < md_size; i++) {
             diff |= digest[i] ^ buffer[i];
         }
 


### PR DESCRIPTION
crypt_and_hash decryption fails when used with a stream cipher mode of operation due to the input not being multiple of block size, this only applies to block cipher modes and not stream ciphers.This change exempts CTR, CFB & OFB modes from this check.

## Description
fixes #7417
crypt_and_hash decryption fails when used with a stream cipher mode of operation due to the input not being multiple of block size, this only applies to block cipher modes and not stream ciphers.This change exempts CTR, CFB & OFB modes from this check.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** provided
- [x] **backport** done here #7761
- [x] **tests** not required - manually but no automated tests for programs.
