### PR TITLE
Backport 2.28: Typo in build script for IAR toolkit.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,7 +242,7 @@ if(MBEDTLS_FATAL_WARNINGS)
     endif(CMAKE_COMPILER_IS_CLANG OR CMAKE_COMPILER_IS_GNU)
 
     if (CMAKE_COMPILER_IS_IAR)
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --warning_are_errors")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --warnings_are_errors")
     endif(CMAKE_COMPILER_IS_IAR)
 endif(MBEDTLS_FATAL_WARNINGS)
 

--- a/ChangeLog.d/bugfix_iar_typo.txt
+++ b/ChangeLog.d/bugfix_iar_typo.txt
@@ -1,0 +1,2 @@
+Bugfix
+   * Fixed an issue that cause compile error using CMake IAR toolchain.


### PR DESCRIPTION
## Description

Commit 5d8adab9838d8ee6b18edd6a42e75fd8fd191b21 introduced a typo in the flag for the IAR compiler. 
--warnings_are_errors is the correct flag

## PR checklist

- [x] **changelog** provided
- [x] **backport** of #7738 
- [x] **tests** Not required - build option change only