### PR TITLE
Fix typo in CMakeList.txt in IAR compiler flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,7 +245,7 @@ if(MBEDTLS_FATAL_WARNINGS)
     endif(CMAKE_COMPILER_IS_CLANG OR CMAKE_COMPILER_IS_GNU)
 
     if (CMAKE_COMPILER_IS_IAR)
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --warning_are_errors")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --warnings_are_errors")
     endif(CMAKE_COMPILER_IS_IAR)
 endif(MBEDTLS_FATAL_WARNINGS)
 

--- a/ChangeLog.d/bugfix_iar_typo.txt
+++ b/ChangeLog.d/bugfix_iar_typo.txt
@@ -1,2 +1,3 @@
 Bugfix
-   * Fixed an issue that cause compile error using CMake IAR toolchain.
+   * Fixed an issue that caused compile errors when using CMake and the IAR
+     toolchain.

--- a/ChangeLog.d/bugfix_iar_typo.txt
+++ b/ChangeLog.d/bugfix_iar_typo.txt
@@ -1,0 +1,2 @@
+Bugfix
+   * Fixed an issue that cause compile error using CMake IAR toolchain.


### PR DESCRIPTION
Continuation of #7657.

## Description

Commit 5d8adab9838d8ee6b18edd6a42e75fd8fd191b21 introduced a typo in the flag for the IAR compiler. 
--warnings_are_errors is the correct flag


## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** provided
- [x] **backport** #7739
- [x] **tests** Not required - build option change only
