### PR TITLE
[Backport 2.28] Fix typo in CMakeList.txt in IAR compiler flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,7 +242,7 @@ if(MBEDTLS_FATAL_WARNINGS)
     endif(CMAKE_COMPILER_IS_CLANG OR CMAKE_COMPILER_IS_GNU)
 
     if (CMAKE_COMPILER_IS_IAR)
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --warning_are_errors")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --warnings_are_errors")
     endif(CMAKE_COMPILER_IS_IAR)
 endif(MBEDTLS_FATAL_WARNINGS)
 

--- a/ChangeLog.d/bugfix_iar_typo.txt
+++ b/ChangeLog.d/bugfix_iar_typo.txt
@@ -1,2 +1,3 @@
 Bugfix
-   * Fixed an issue that cause compile error using CMake IAR toolchain.
+   * Fixed an issue that caused compile errors when using CMake and the IAR
+     toolchain.

--- a/ChangeLog.d/bugfix_iar_typo.txt
+++ b/ChangeLog.d/bugfix_iar_typo.txt
@@ -1,0 +1,2 @@
+Bugfix
+   * Fixed an issue that cause compile error using CMake IAR toolchain.


### PR DESCRIPTION
Trivial backport of #7738.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** provided
- [x] **backport** of #7738 
- [x] **tests** not required - build option fix



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.
