### PR TITLE
[Backport 2.28] Build the docs in realfull config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,8 +12,8 @@ build:
     python: "3.9"
   jobs:
     pre_build:
-      - ./scripts/apidoc_full.sh
-      - breathe-apidoc -o docs/api apidoc/xml
+    - ./scripts/apidoc_full.sh
+    - breathe-apidoc -o docs/api apidoc/xml
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,7 +12,7 @@ build:
     python: "3.9"
   jobs:
     pre_build:
-      - make apidoc
+      - ./scripts/apidoc_full.sh
       - breathe-apidoc -o docs/api apidoc/xml
 
 # Build documentation in the docs/ directory with Sphinx


### PR DESCRIPTION
Tiny but not trivial backport of #7750.

Ensure that all possible config options are documented by building the docs in the realfull config on Read The Docs.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required - internal non-API change
- [x] **backport** of #7750 
- [x] **tests** not required - docs change only