### PR TITLE
Backport 2.28: Fix crypt_and_hash decrypt issue when used with stream cipher

### DIFF
--- a/ChangeLog.d/fix-crypt_and_hash-decrypt-issue.txt
+++ b/ChangeLog.d/fix-crypt_and_hash-decrypt-issue.txt
@@ -1,0 +1,4 @@
+Bugfix
+   * Fix crypt_and_hash decryption fail when used with a stream cipher
+     mode of operation due to the input not being multiple of block size.
+     Resolves #7417.

--- a/programs/aes/crypt_and_hash.c
+++ b/programs/aes/crypt_and_hash.c
@@ -409,6 +409,9 @@ int main(int argc, char *argv[])
          * Check the file size.
          */
         if (cipher_info->mode != MBEDTLS_MODE_GCM &&
+            cipher_info->mode != MBEDTLS_MODE_CTR &&
+            cipher_info->mode != MBEDTLS_MODE_CFB &&
+            cipher_info->mode != MBEDTLS_MODE_OFB &&
             ((filesize - mbedtls_md_get_size(md_info)) %
              mbedtls_cipher_get_block_size(&cipher_ctx)) != 0) {
             mbedtls_fprintf(stderr, "File content not a multiple of the block size (%u).\n",

--- a/programs/aes/crypt_and_hash.c
+++ b/programs/aes/crypt_and_hash.c
@@ -92,6 +92,7 @@ int main(int argc, char *argv[])
     const mbedtls_md_info_t *md_info;
     mbedtls_cipher_context_t cipher_ctx;
     mbedtls_md_context_t md_ctx;
+    mbedtls_cipher_mode_t cipher_mode;
     unsigned int cipher_block_size;
     unsigned char md_size;
 #if defined(_WIN32_WCE)
@@ -413,10 +414,11 @@ int main(int argc, char *argv[])
         /*
          * Check the file size.
          */
-        if (cipher_info->mode != MBEDTLS_MODE_GCM &&
-            cipher_info->mode != MBEDTLS_MODE_CTR &&
-            cipher_info->mode != MBEDTLS_MODE_CFB &&
-            cipher_info->mode != MBEDTLS_MODE_OFB &&
+        cipher_mode = cipher_info->mode;
+        if (cipher_mode != MBEDTLS_MODE_GCM &&
+            cipher_mode != MBEDTLS_MODE_CTR &&
+            cipher_mode != MBEDTLS_MODE_CFB &&
+            cipher_mode != MBEDTLS_MODE_OFB &&
             ((filesize - md_size) % cipher_block_size) != 0) {
             mbedtls_fprintf(stderr, "File content not a multiple of the block size (%u).\n",
                             cipher_block_size);


### PR DESCRIPTION
## Description

crypt_and_hash decryption fails when used with a stream cipher
mode of operation due to the input not being multiple of block
size, this only applies to block cipher modes and not stream
ciphers.This change exempts CTR, CFB & OFB modes from this check.


## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [X] **changelog** provided
- [X] **backport** done
- [X] **tests** provided - manually done, no automated tests


