### PR TITLE
gcc 11.3 fails when compiling ecjpake drivers

### DIFF
--- a/tests/src/drivers/test_driver_pake.c
+++ b/tests/src/drivers/test_driver_pake.c
@@ -94,7 +94,8 @@ psa_status_t mbedtls_test_transparent_pake_output(
         defined(LIBTESTDRIVER1_MBEDTLS_PSA_BUILTIN_PAKE)
         mbedtls_test_driver_pake_hooks.driver_status =
             libtestdriver1_mbedtls_psa_pake_output(
-                operation, step, output, output_size, output_length);
+                operation, (libtestdriver1_psa_crypto_driver_pake_step_t) step,
+                output, output_size, output_length);
 #elif defined(MBEDTLS_PSA_BUILTIN_PAKE)
         mbedtls_test_driver_pake_hooks.driver_status =
             mbedtls_psa_pake_output(
@@ -129,7 +130,8 @@ psa_status_t mbedtls_test_transparent_pake_input(
         defined(LIBTESTDRIVER1_MBEDTLS_PSA_BUILTIN_PAKE)
         mbedtls_test_driver_pake_hooks.driver_status =
             libtestdriver1_mbedtls_psa_pake_input(
-                operation, step, input, input_length);
+                operation, (libtestdriver1_psa_crypto_driver_pake_step_t) step,
+                input, input_length);
 #elif defined(MBEDTLS_PSA_BUILTIN_PAKE)
         mbedtls_test_driver_pake_hooks.driver_status =
             mbedtls_psa_pake_input(


### PR DESCRIPTION
Resolves #7341 

## PR checklist

- [ ] **changelog** not required
- [ ] **backport** not required
- [ ] **tests** not required