### PR TITLE
Shorten encoding of version features

### DIFF
--- a/scripts/data_files/version_features.fmt
+++ b/scripts/data_files/version_features.fmt
@@ -44,6 +44,12 @@ int mbedtls_version_check_feature(const char *feature)
         return -1;
     }
 
+    if (strncmp(feature, "MBEDTLS_", 8)) {
+        return -1;
+    }
+
+    feature += 8;
+
     while (*idx != NULL) {
         if (!strcmp(*idx, feature)) {
             return 0;

--- a/scripts/generate_features.pl
+++ b/scripts/generate_features.pl
@@ -72,7 +72,7 @@ while (my $line = <CONFIG_H>)
             die "Feature does not start with 'MBEDTLS_': $line\n";
         }
         $feature_defines .= "#if defined(MBEDTLS_${define})\n";
-        $feature_defines .= "    \"${define}\",\n";
+        $feature_defines .= "    \"${define}\", //no-check-names\n";
         $feature_defines .= "#endif /* MBEDTLS_${define} */\n";
     }
 

--- a/scripts/generate_features.pl
+++ b/scripts/generate_features.pl
@@ -66,11 +66,14 @@ while (my $line = <CONFIG_H>)
             $in_section = 0;
             next;
         }
-
-        my ($define) = $line =~ /#define (\w+)/;
-        $feature_defines .= "#if defined(${define})\n";
+        # Strip leading MBEDTLS_ to save binary size
+        my ($mbedtls_prefix, $define) = $line =~ /#define (MBEDTLS_)?(\w+)/;
+        if (!$mbedtls_prefix) {
+            die "Feature does not start with 'MBEDTLS_': $line\n";
+        }
+        $feature_defines .= "#if defined(MBEDTLS_${define})\n";
         $feature_defines .= "    \"${define}\",\n";
-        $feature_defines .= "#endif /* ${define} */\n";
+        $feature_defines .= "#endif /* MBEDTLS_${define} */\n";
     }
 
     if (!$in_section) {


### PR DESCRIPTION
## Description

Save code-size by not storing the "MBEDTLS_" prefix that is present for every feature macro.

Saves a bit over 1 kB for clang -Os with default configuration.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required - not user-visible
- [x] **backport** not required
- [x] **tests** covered by existing tests
