### PR TITLE
Move mbedtls_ecp_modulus_type out of the public headers

### DIFF
--- a/include/mbedtls/ecp.h
+++ b/include/mbedtls/ecp.h
@@ -141,15 +141,6 @@ typedef enum {
     MBEDTLS_ECP_TYPE_MONTGOMERY,           /* y^2 = x^3 + a x^2 + x    */
 } mbedtls_ecp_curve_type;
 
-/*
- * Curve modulus types
- */
-typedef enum {
-    MBEDTLS_ECP_MOD_NONE = 0,
-    MBEDTLS_ECP_MOD_COORDINATE,
-    MBEDTLS_ECP_MOD_SCALAR
-} mbedtls_ecp_modulus_type;
-
 /**
  * Curve information, for use by other modules.
  *

--- a/library/ecp_invasive.h
+++ b/library/ecp_invasive.h
@@ -31,6 +31,15 @@
 #include "bignum_mod.h"
 #include "mbedtls/ecp.h"
 
+/*
+ * Curve modulus types
+ */
+typedef enum {
+    MBEDTLS_ECP_MOD_NONE = 0,
+    MBEDTLS_ECP_MOD_COORDINATE,
+    MBEDTLS_ECP_MOD_SCALAR
+} mbedtls_ecp_modulus_type;
+
 #if defined(MBEDTLS_TEST_HOOKS) && defined(MBEDTLS_ECP_LIGHT)
 
 #if defined(MBEDTLS_ECP_MONTGOMERY_ENABLED)


### PR DESCRIPTION
This is an internal detail of the ECC arithmetic implementation, only exposed for the sake of the unit tests

Mbed TLS 3.4.0 was released with the type mbedtls_ecp_modulus_type defined in a public header, but without Doxygen documentation, and without any public function or data structure using it. So removing it is not an API break.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** no (no user-facing change)
- [x] **backport** no (feature not in LTS)
- [x] **tests** no new test needed
