### PR TITLE
Don't force _WIN32_WINNT values

### DIFF
--- a/library/entropy_poll.c
+++ b/library/entropy_poll.c
@@ -48,9 +48,6 @@
 
 #if defined(_WIN32) && !defined(EFIX64) && !defined(EFI32)
 
-#if !defined(_WIN32_WINNT)
-#define _WIN32_WINNT 0x0400
-#endif
 #include <windows.h>
 #if _WIN32_WINNT >= 0x0501 /* _WIN32_WINNT_WINXP */
 #include <wincrypt.h>

--- a/library/entropy_poll.c
+++ b/library/entropy_poll.c
@@ -52,6 +52,7 @@
 #define _WIN32_WINNT 0x0400
 #endif
 #include <windows.h>
+#if _WIN32_WINNT >= 0x0501 /* _WIN32_WINNT_WINXP */
 #include <wincrypt.h>
 
 int mbedtls_platform_entropy_poll(void *data, unsigned char *output, size_t len,
@@ -76,6 +77,9 @@ int mbedtls_platform_entropy_poll(void *data, unsigned char *output, size_t len,
 
     return 0;
 }
+#else /* !_WIN32_WINNT_WINXP */
+#error Entropy not available before Windows XP, use MBEDTLS_NO_PLATFORM_ENTROPY
+#endif /* !_WIN32_WINNT_WINXP */
 #else /* _WIN32 && !EFIX64 && !EFI32 */
 
 /*

--- a/library/net_sockets.c
+++ b/library/net_sockets.c
@@ -49,11 +49,6 @@
 
 #define IS_EINTR(ret) ((ret) == WSAEINTR)
 
-#if !defined(_WIN32_WINNT)
-/* Enables getaddrinfo() & Co */
-#define _WIN32_WINNT 0x0501
-#endif
-
 #include <ws2tcpip.h>
 
 #include <winsock2.h>

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -2684,6 +2684,9 @@ find_parent:
 #elif (defined(__MINGW32__) || defined(__MINGW64__)) && _WIN32_WINNT >= 0x0600
 #include <winsock2.h>
 #include <ws2tcpip.h>
+#else
+/* inet_pton() is not supported, fallback to software version */
+#define MBEDTLS_TEST_SW_INET_PTON
 #endif
 #elif defined(__sun)
 /* Solaris requires -lsocket -lnsl for inet_pton() */

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -1540,6 +1540,7 @@ int mbedtls_x509_crt_parse_path(mbedtls_x509_crt *chain, const char *path)
 {
     int ret = 0;
 #if defined(_WIN32) && !defined(EFIX64) && !defined(EFI32)
+#if _WIN32_WINNT >= 0x0501 /* _WIN32_WINNT_XP */
     int w_ret;
     WCHAR szDir[MAX_PATH];
     char filename[MAX_PATH];
@@ -1602,6 +1603,9 @@ int mbedtls_x509_crt_parse_path(mbedtls_x509_crt *chain, const char *path)
 
 cleanup:
     FindClose(hFind);
+#else /* !_WIN32_WINNT_XP */
+#error mbedtls_x509_crt_parse_path not available before Windows XP
+#endif /* !_WIN32_WINNT_XP */
 #else /* _WIN32 */
     int t_ret;
     int snp_ret;

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -61,9 +61,6 @@
 #if defined(MBEDTLS_HAVE_TIME)
 #if defined(_WIN32) && !defined(EFIX64) && !defined(EFI32)
 #define WIN32_LEAN_AND_MEAN
-#ifndef _WIN32_WINNT
-#define _WIN32_WINNT 0x0600
-#endif
 #include <windows.h>
 #else
 #include <time.h>


### PR DESCRIPTION
Forcing `_WIN32_WINNT` when the SDK has a default value is not a good idea. Assuming _WIN32_WINNT can be set to a certain value also has bad consequences and it may force some API's to be called when the (old) system doesn't have that. That should make the mbedtls build unsuable in that case.

Each commit explains why the change is needed. In the end `_WIN32_WINNT` is not used and either fallback calls are used or compilation errors are emited explaining what is wrong.

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required - minor tidy-up to build process
- [x] **backport** not required - not a bugfix
- [x] **tests** not required
