### PR TITLE
Revert "Install cryptography only on linux platform"

### DIFF
--- a/scripts/ci.requirements.txt
+++ b/scripts/ci.requirements.txt
@@ -14,5 +14,4 @@ mypy >= 0.780
 # Install cryptography to avoid import-error reported by pylint.
 # What we really need is cryptography >= 35.0.0, which is only
 # available for Python >= 3.6.
-cryptography >= 35.0.0; sys_platform == 'linux' and python_version >= '3.6'
-cryptography;           sys_platform == 'linux' and python_version <  '3.6'
+cryptography # >= 35.0.0


### PR DESCRIPTION
We temporarily turned off the requirement on the Python `cryptography` package on Windows due to a CI instance that had an old, incompatible verison of pip (see https://github.com/Mbed-TLS/mbedtls/pull/7399#discussion_r1176473358). That CI instance has been upgraded ([internal link](https://jira.arm.com/browse/OSSDEVOPS-6170)) so we no longer need the workaround.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** no (not user-visible)
- [x] **backport** no (not present in 2.28)
- [x] **tests** we just want the CI to pass



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.
