### PR TITLE
[Bignum] Fix 32 bit unreachable code build failure

### DIFF
--- a/library/ecp_curves.c
+++ b/library/ecp_curves.c
@@ -5577,9 +5577,9 @@ int mbedtls_ecp_mod_p448_raw(mbedtls_mpi_uint *X, size_t X_limbs)
     (void) mbedtls_mpi_core_add(X, X, Q, Q_limbs);
 
     /* M = B0 */
-    if (ciL > 4) {
-        M[P224_WIDTH_MIN] &= ((mbedtls_mpi_uint)-1) >> (P224_UNUSED_BITS);
-    }
+#ifdef MBEDTLS_HAVE_INT64
+    M[P224_WIDTH_MIN] &= ((mbedtls_mpi_uint)-1) >> (P224_UNUSED_BITS);
+ #endif
     memset(M + P224_WIDTH_MAX, 0, ((M_limbs - P224_WIDTH_MAX) * ciL));
 
     /* M = M + Q = B0 + B1 */


### PR DESCRIPTION
## Description

Given the size of ciL is set dependant on MBEDTLS_HAVE_INT32, clang rightfully reports this as unreachable code. Fix this by using #define guards instead.

Addresses #7787

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [ ] **changelog** ~~provided, or~~ not required
- [ ] **backport** ~~done, or~~ not required
- [ ] **tests** ~~provided, or~~ not required
