### PR TITLE
Fix very high stack usage in SSL debug code

### DIFF
--- a/ChangeLog.d/ssl_debug_helpers-stack_usage.txt
+++ b/ChangeLog.d/ssl_debug_helpers-stack_usage.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix very high stack usage in SSL debug code. Reported by Maximilian
+     Gerhardt in #7804.

--- a/scripts/generate_ssl_debug_helpers.py
+++ b/scripts/generate_ssl_debug_helpers.py
@@ -209,24 +209,18 @@ class EnumDefinition:
                     continue
                 member = field.strip().split()[0]
                 translation_table.append(
-                    '{space}[{member}] = "{member}",'.format(member=member,
-                                                             space=' '*8)
+                    '{space}case {member}:\n{space}    return "{member};";'
+                    .format(member=member, space=' '*8)
                 )
 
         body = textwrap.dedent('''\
             const char *{name}_str( {prototype} in )
             {{
-                const char * in_to_str[]=
-                {{
+                switch (in) {{
             {translation_table}
-                }};
-
-                if( in > ( sizeof( in_to_str )/sizeof( in_to_str[0]) - 1 ) ||
-                    in_to_str[ in ] == NULL )
-                {{
-                    return "UNKNOWN_VALUE";
+                    default:
+                        return "UNKNOWN_VALUE";
                 }}
-                return in_to_str[ in ];
             }}
                     ''')
         body = body.format(translation_table='\n'.join(translation_table),

--- a/scripts/generate_ssl_debug_helpers.py
+++ b/scripts/generate_ssl_debug_helpers.py
@@ -209,7 +209,7 @@ class EnumDefinition:
                     continue
                 member = field.strip().split()[0]
                 translation_table.append(
-                    '{space}case {member}:\n{space}    return "{member};";'
+                    '{space}case {member}:\n{space}    return "{member}";'
                     .format(member=member, space=' '*8)
                 )
 


### PR DESCRIPTION
Use a switch instead of an array. The array was very hollow for some enum types such as mbedtls_ssl_protocol_version (which formerly used small values, but switched to using the protocol encoding as enum values in Mbed TLS 3.2.0). Optimizing compilers know how to compile a switch into a lookup table when the range warrants it. Fixes #7804.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** provided
- [x] **backport** not required (not in 2.28)
- [x] **tests** no new tests (internal change only)
