### PR TITLE
Fix for arm64_32 (aka ILP32) on Clang

### DIFF
--- a/library/constant_time.c
+++ b/library/constant_time.c
@@ -78,8 +78,10 @@ static inline uint32_t mbedtls_get_unaligned_volatile_uint32(volatile const unsi
     uint32_t r;
 #if defined(__arm__) || defined(__thumb__) || defined(__thumb2__)
     asm volatile ("ldr %0, [%1]" : "=r" (r) : "r" (p) :);
-#elif defined(__aarch64__)
+#elif defined(__aarch64__) && (SIZE_MAX == 0xffffffffffffffff)
     asm volatile ("ldr %w0, [%1]" : "=r" (r) : "r" (p) :);
+#elif defined(__aarch64__) && (SIZE_MAX == 0xffffffff)
+    asm volatile ("ldr %w0, [%w1]" : "=r" (r) : "r" (p) :);
 #endif
     return r;
 }


### PR DESCRIPTION
## Description

Possible fix for ILP32 compile issue described in #7787 

Untested because I haven't been able to figure out how to get clang or armclang to build for ILP32.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [ ] **changelog** TODO
- [ ] **backport** TODO
- [ ] **tests** TODO
