### PR TITLE
Optimize strings in MD

### DIFF
--- a/include/mbedtls/md.h
+++ b/include/mbedtls/md.h
@@ -464,8 +464,8 @@ const int *mbedtls_md_list(void);
 const mbedtls_md_info_t *mbedtls_md_info_from_string(const char *md_name);
 
 /**
- * \brief           This function extracts the message-digest name from the
- *                  message-digest information structure.
+ * \brief           This function returns the name of the message digest for
+ *                  the message-digest information structure given.
  *
  * \param md_info   The information structure of the message-digest algorithm
  *                  to use.

--- a/library/md.c
+++ b/library/md.c
@@ -76,91 +76,75 @@
 #error "Internal error: MBEDTLS_MD_MAX_SIZE < PSA_HASH_MAX_SIZE"
 #endif
 
+#if defined(MBEDTLS_MD_C)
+#define MD_INFO(type, out_size, block_size) type, out_size, block_size,
+#else
+#define MD_INFO(type, out_size, block_size) type, out_size,
+#endif
+
 #if defined(MBEDTLS_MD_CAN_MD5)
 static const mbedtls_md_info_t mbedtls_md5_info = {
-    MBEDTLS_MD_MD5,
-    16,
-    64,
+    MD_INFO(MBEDTLS_MD_MD5, 16, 64)
 };
 #endif
 
 #if defined(MBEDTLS_MD_CAN_RIPEMD160)
 static const mbedtls_md_info_t mbedtls_ripemd160_info = {
-    MBEDTLS_MD_RIPEMD160,
-    20,
-    64,
+    MD_INFO(MBEDTLS_MD_RIPEMD160, 20, 64)
 };
 #endif
 
 #if defined(MBEDTLS_MD_CAN_SHA1)
 static const mbedtls_md_info_t mbedtls_sha1_info = {
-    MBEDTLS_MD_SHA1,
-    20,
-    64,
+    MD_INFO(MBEDTLS_MD_SHA1, 20, 64)
 };
 #endif
 
 #if defined(MBEDTLS_MD_CAN_SHA224)
 static const mbedtls_md_info_t mbedtls_sha224_info = {
-    MBEDTLS_MD_SHA224,
-    28,
-    64,
+    MD_INFO(MBEDTLS_MD_SHA224, 28, 64)
 };
 #endif
 
 #if defined(MBEDTLS_MD_CAN_SHA256)
 static const mbedtls_md_info_t mbedtls_sha256_info = {
-    MBEDTLS_MD_SHA256,
-    32,
-    64,
+    MD_INFO(MBEDTLS_MD_SHA256, 32, 64)
 };
 #endif
 
 #if defined(MBEDTLS_MD_CAN_SHA384)
 static const mbedtls_md_info_t mbedtls_sha384_info = {
-    MBEDTLS_MD_SHA384,
-    48,
-    128,
+    MD_INFO(MBEDTLS_MD_SHA384, 48, 128)
 };
 #endif
 
 #if defined(MBEDTLS_MD_CAN_SHA512)
 static const mbedtls_md_info_t mbedtls_sha512_info = {
-    MBEDTLS_MD_SHA512,
-    64,
-    128,
+    MD_INFO(MBEDTLS_MD_SHA512, 64, 128)
 };
 #endif
 
 #if defined(MBEDTLS_MD_CAN_SHA3_224)
 static const mbedtls_md_info_t mbedtls_sha3_224_info = {
-    MBEDTLS_MD_SHA3_224,
-    28,
-    144,
+    MD_INFO(MBEDTLS_MD_SHA3_224, 28, 144)
 };
 #endif
 
 #if defined(MBEDTLS_MD_CAN_SHA3_256)
 static const mbedtls_md_info_t mbedtls_sha3_256_info = {
-    MBEDTLS_MD_SHA3_256,
-    32,
-    136,
+    MD_INFO(MBEDTLS_MD_SHA3_256, 32, 136)
 };
 #endif
 
 #if defined(MBEDTLS_MD_CAN_SHA3_384)
 static const mbedtls_md_info_t mbedtls_sha3_384_info = {
-    MBEDTLS_MD_SHA3_384,
-    48,
-    104,
+    MD_INFO(MBEDTLS_MD_SHA3_384, 48, 104)
 };
 #endif
 
 #if defined(MBEDTLS_MD_CAN_SHA3_512)
 static const mbedtls_md_info_t mbedtls_sha3_512_info = {
-    MBEDTLS_MD_SHA3_512,
-    64,
-    72,
+    MD_INFO(MBEDTLS_MD_SHA3_512, 64, 72)
 };
 #endif
 

--- a/library/md.c
+++ b/library/md.c
@@ -77,7 +77,7 @@
 #endif
 
 #if defined(MBEDTLS_MD_CAN_MD5)
-const mbedtls_md_info_t mbedtls_md5_info = {
+static const mbedtls_md_info_t mbedtls_md5_info = {
     MBEDTLS_MD_MD5,
     16,
     64,
@@ -85,7 +85,7 @@ const mbedtls_md_info_t mbedtls_md5_info = {
 #endif
 
 #if defined(MBEDTLS_MD_CAN_RIPEMD160)
-const mbedtls_md_info_t mbedtls_ripemd160_info = {
+static const mbedtls_md_info_t mbedtls_ripemd160_info = {
     MBEDTLS_MD_RIPEMD160,
     20,
     64,
@@ -93,7 +93,7 @@ const mbedtls_md_info_t mbedtls_ripemd160_info = {
 #endif
 
 #if defined(MBEDTLS_MD_CAN_SHA1)
-const mbedtls_md_info_t mbedtls_sha1_info = {
+static const mbedtls_md_info_t mbedtls_sha1_info = {
     MBEDTLS_MD_SHA1,
     20,
     64,
@@ -101,7 +101,7 @@ const mbedtls_md_info_t mbedtls_sha1_info = {
 #endif
 
 #if defined(MBEDTLS_MD_CAN_SHA224)
-const mbedtls_md_info_t mbedtls_sha224_info = {
+static const mbedtls_md_info_t mbedtls_sha224_info = {
     MBEDTLS_MD_SHA224,
     28,
     64,
@@ -109,7 +109,7 @@ const mbedtls_md_info_t mbedtls_sha224_info = {
 #endif
 
 #if defined(MBEDTLS_MD_CAN_SHA256)
-const mbedtls_md_info_t mbedtls_sha256_info = {
+static const mbedtls_md_info_t mbedtls_sha256_info = {
     MBEDTLS_MD_SHA256,
     32,
     64,
@@ -117,7 +117,7 @@ const mbedtls_md_info_t mbedtls_sha256_info = {
 #endif
 
 #if defined(MBEDTLS_MD_CAN_SHA384)
-const mbedtls_md_info_t mbedtls_sha384_info = {
+static const mbedtls_md_info_t mbedtls_sha384_info = {
     MBEDTLS_MD_SHA384,
     48,
     128,
@@ -125,7 +125,7 @@ const mbedtls_md_info_t mbedtls_sha384_info = {
 #endif
 
 #if defined(MBEDTLS_MD_CAN_SHA512)
-const mbedtls_md_info_t mbedtls_sha512_info = {
+static const mbedtls_md_info_t mbedtls_sha512_info = {
     MBEDTLS_MD_SHA512,
     64,
     128,
@@ -133,7 +133,7 @@ const mbedtls_md_info_t mbedtls_sha512_info = {
 #endif
 
 #if defined(MBEDTLS_MD_CAN_SHA3_224)
-const mbedtls_md_info_t mbedtls_sha3_224_info = {
+static const mbedtls_md_info_t mbedtls_sha3_224_info = {
     MBEDTLS_MD_SHA3_224,
     28,
     144,
@@ -141,7 +141,7 @@ const mbedtls_md_info_t mbedtls_sha3_224_info = {
 #endif
 
 #if defined(MBEDTLS_MD_CAN_SHA3_256)
-const mbedtls_md_info_t mbedtls_sha3_256_info = {
+static const mbedtls_md_info_t mbedtls_sha3_256_info = {
     MBEDTLS_MD_SHA3_256,
     32,
     136,
@@ -149,7 +149,7 @@ const mbedtls_md_info_t mbedtls_sha3_256_info = {
 #endif
 
 #if defined(MBEDTLS_MD_CAN_SHA3_384)
-const mbedtls_md_info_t mbedtls_sha3_384_info = {
+static const mbedtls_md_info_t mbedtls_sha3_384_info = {
     MBEDTLS_MD_SHA3_384,
     48,
     104,
@@ -157,7 +157,7 @@ const mbedtls_md_info_t mbedtls_sha3_384_info = {
 #endif
 
 #if defined(MBEDTLS_MD_CAN_SHA3_512)
-const mbedtls_md_info_t mbedtls_sha3_512_info = {
+static const mbedtls_md_info_t mbedtls_sha3_512_info = {
     MBEDTLS_MD_SHA3_512,
     64,
     72,

--- a/library/md.c
+++ b/library/md.c
@@ -78,7 +78,6 @@
 
 #if defined(MBEDTLS_MD_CAN_MD5)
 const mbedtls_md_info_t mbedtls_md5_info = {
-    "MD5",
     MBEDTLS_MD_MD5,
     16,
     64,
@@ -87,7 +86,6 @@ const mbedtls_md_info_t mbedtls_md5_info = {
 
 #if defined(MBEDTLS_MD_CAN_RIPEMD160)
 const mbedtls_md_info_t mbedtls_ripemd160_info = {
-    "RIPEMD160",
     MBEDTLS_MD_RIPEMD160,
     20,
     64,
@@ -96,7 +94,6 @@ const mbedtls_md_info_t mbedtls_ripemd160_info = {
 
 #if defined(MBEDTLS_MD_CAN_SHA1)
 const mbedtls_md_info_t mbedtls_sha1_info = {
-    "SHA1",
     MBEDTLS_MD_SHA1,
     20,
     64,
@@ -105,7 +102,6 @@ const mbedtls_md_info_t mbedtls_sha1_info = {
 
 #if defined(MBEDTLS_MD_CAN_SHA224)
 const mbedtls_md_info_t mbedtls_sha224_info = {
-    "SHA224",
     MBEDTLS_MD_SHA224,
     28,
     64,
@@ -114,7 +110,6 @@ const mbedtls_md_info_t mbedtls_sha224_info = {
 
 #if defined(MBEDTLS_MD_CAN_SHA256)
 const mbedtls_md_info_t mbedtls_sha256_info = {
-    "SHA256",
     MBEDTLS_MD_SHA256,
     32,
     64,
@@ -123,7 +118,6 @@ const mbedtls_md_info_t mbedtls_sha256_info = {
 
 #if defined(MBEDTLS_MD_CAN_SHA384)
 const mbedtls_md_info_t mbedtls_sha384_info = {
-    "SHA384",
     MBEDTLS_MD_SHA384,
     48,
     128,
@@ -132,7 +126,6 @@ const mbedtls_md_info_t mbedtls_sha384_info = {
 
 #if defined(MBEDTLS_MD_CAN_SHA512)
 const mbedtls_md_info_t mbedtls_sha512_info = {
-    "SHA512",
     MBEDTLS_MD_SHA512,
     64,
     128,
@@ -141,7 +134,6 @@ const mbedtls_md_info_t mbedtls_sha512_info = {
 
 #if defined(MBEDTLS_MD_CAN_SHA3_224)
 const mbedtls_md_info_t mbedtls_sha3_224_info = {
-    "SHA3-224",
     MBEDTLS_MD_SHA3_224,
     28,
     144,
@@ -150,7 +142,6 @@ const mbedtls_md_info_t mbedtls_sha3_224_info = {
 
 #if defined(MBEDTLS_MD_CAN_SHA3_256)
 const mbedtls_md_info_t mbedtls_sha3_256_info = {
-    "SHA3-256",
     MBEDTLS_MD_SHA3_256,
     32,
     136,
@@ -159,7 +150,6 @@ const mbedtls_md_info_t mbedtls_sha3_256_info = {
 
 #if defined(MBEDTLS_MD_CAN_SHA3_384)
 const mbedtls_md_info_t mbedtls_sha3_384_info = {
-    "SHA3-384",
     MBEDTLS_MD_SHA3_384,
     48,
     104,
@@ -168,7 +158,6 @@ const mbedtls_md_info_t mbedtls_sha3_384_info = {
 
 #if defined(MBEDTLS_MD_CAN_SHA3_512)
 const mbedtls_md_info_t mbedtls_sha3_512_info = {
-    "SHA3-512",
     MBEDTLS_MD_SHA3_512,
     64,
     72,
@@ -928,69 +917,77 @@ const int *mbedtls_md_list(void)
     return supported_digests;
 }
 
+typedef struct {
+    const char *md_name;
+    mbedtls_md_type_t md_type;
+} md_name_entry;
+
+static const md_name_entry md_names[] = {
+#if defined(MBEDTLS_MD_CAN_MD5)
+    { "MD5", MBEDTLS_MD_MD5 },
+#endif
+#if defined(MBEDTLS_MD_CAN_RIPEMD160)
+    { "RIPEMD160", MBEDTLS_MD_RIPEMD160 },
+#endif
+#if defined(MBEDTLS_MD_CAN_SHA1)
+    { "SHA1", MBEDTLS_MD_SHA1 },
+    { "SHA", MBEDTLS_MD_SHA1 }, // compatibility fallback
+#endif
+#if defined(MBEDTLS_MD_CAN_SHA224)
+    { "SHA224", MBEDTLS_MD_SHA224 },
+#endif
+#if defined(MBEDTLS_MD_CAN_SHA256)
+    { "SHA256", MBEDTLS_MD_SHA256 },
+#endif
+#if defined(MBEDTLS_MD_CAN_SHA384)
+    { "SHA384", MBEDTLS_MD_SHA384 },
+#endif
+#if defined(MBEDTLS_MD_CAN_SHA512)
+    { "SHA512", MBEDTLS_MD_SHA512 },
+#endif
+#if defined(MBEDTLS_MD_CAN_SHA3_224)
+    { "SHA3-224", MBEDTLS_MD_SHA3_224 },
+#endif
+#if defined(MBEDTLS_MD_CAN_SHA3_256)
+    { "SHA3-256", MBEDTLS_MD_SHA3_256 },
+#endif
+#if defined(MBEDTLS_MD_CAN_SHA3_384)
+    { "SHA3-384", MBEDTLS_MD_SHA3_384 },
+#endif
+#if defined(MBEDTLS_MD_CAN_SHA3_512)
+    { "SHA3-512", MBEDTLS_MD_SHA3_512 },
+#endif
+    { NULL, MBEDTLS_MD_NONE },
+};
+
 const mbedtls_md_info_t *mbedtls_md_info_from_string(const char *md_name)
 {
     if (NULL == md_name) {
         return NULL;
     }
 
-    /* Get the appropriate digest information */
-#if defined(MBEDTLS_MD_CAN_MD5)
-    if (!strcmp("MD5", md_name)) {
-        return mbedtls_md_info_from_type(MBEDTLS_MD_MD5);
+    const md_name_entry *entry = md_names;
+    while (entry->md_name != NULL &&
+           strcmp(entry->md_name, md_name) != 0) {
+        ++entry;
     }
-#endif
-#if defined(MBEDTLS_MD_CAN_RIPEMD160)
-    if (!strcmp("RIPEMD160", md_name)) {
-        return mbedtls_md_info_from_type(MBEDTLS_MD_RIPEMD160);
+
+    return mbedtls_md_info_from_type(entry->md_type);
+}
+
+const char *mbedtls_md_get_name(const mbedtls_md_info_t *md_info)
+{
+    if (md_info == NULL) {
+        return NULL;
     }
-#endif
-#if defined(MBEDTLS_MD_CAN_SHA1)
-    if (!strcmp("SHA1", md_name) || !strcmp("SHA", md_name)) {
-        return mbedtls_md_info_from_type(MBEDTLS_MD_SHA1);
+
+    const md_name_entry *entry = md_names;
+    while (entry->md_type != MBEDTLS_MD_NONE &&
+           entry->md_type != md_info->type) {
+        ++entry;
     }
-#endif
-#if defined(MBEDTLS_MD_CAN_SHA224)
-    if (!strcmp("SHA224", md_name)) {
-        return mbedtls_md_info_from_type(MBEDTLS_MD_SHA224);
-    }
-#endif
-#if defined(MBEDTLS_MD_CAN_SHA256)
-    if (!strcmp("SHA256", md_name)) {
-        return mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
-    }
-#endif
-#if defined(MBEDTLS_MD_CAN_SHA384)
-    if (!strcmp("SHA384", md_name)) {
-        return mbedtls_md_info_from_type(MBEDTLS_MD_SHA384);
-    }
-#endif
-#if defined(MBEDTLS_MD_CAN_SHA512)
-    if (!strcmp("SHA512", md_name)) {
-        return mbedtls_md_info_from_type(MBEDTLS_MD_SHA512);
-    }
-#endif
-#if defined(MBEDTLS_MD_CAN_SHA3_224)
-    if (!strcmp("SHA3-224", md_name)) {
-        return mbedtls_md_info_from_type(MBEDTLS_MD_SHA3_224);
-    }
-#endif
-#if defined(MBEDTLS_MD_CAN_SHA3_256)
-    if (!strcmp("SHA3-256", md_name)) {
-        return mbedtls_md_info_from_type(MBEDTLS_MD_SHA3_256);
-    }
-#endif
-#if defined(MBEDTLS_MD_CAN_SHA3_384)
-    if (!strcmp("SHA3-384", md_name)) {
-        return mbedtls_md_info_from_type(MBEDTLS_MD_SHA3_384);
-    }
-#endif
-#if defined(MBEDTLS_MD_CAN_SHA3_512)
-    if (!strcmp("SHA3-512", md_name)) {
-        return mbedtls_md_info_from_type(MBEDTLS_MD_SHA3_512);
-    }
-#endif
-    return NULL;
+
+    return entry->md_name;
 }
 
 const mbedtls_md_info_t *mbedtls_md_info_from_ctx(
@@ -1189,15 +1186,6 @@ cleanup:
     mbedtls_md_free(&ctx);
 
     return ret;
-}
-
-const char *mbedtls_md_get_name(const mbedtls_md_info_t *md_info)
-{
-    if (md_info == NULL) {
-        return NULL;
-    }
-
-    return md_info->name;
 }
 
 #endif /* MBEDTLS_MD_C */

--- a/library/md_wrap.h
+++ b/library/md_wrap.h
@@ -39,9 +39,6 @@ extern "C" {
  * Allows message digest functions to be called in a generic way.
  */
 struct mbedtls_md_info_t {
-    /** Name of the message digest */
-    const char *name;
-
     /** Digest identifier */
     mbedtls_md_type_t type;
 

--- a/library/md_wrap.h
+++ b/library/md_wrap.h
@@ -45,8 +45,10 @@ struct mbedtls_md_info_t {
     /** Output length of the digest function in bytes */
     unsigned char size;
 
+#if defined(MBEDTLS_MD_C)
     /** Block length of the digest function in bytes */
     unsigned char block_size;
+#endif
 };
 
 #ifdef __cplusplus

--- a/library/md_wrap.h
+++ b/library/md_wrap.h
@@ -49,34 +49,6 @@ struct mbedtls_md_info_t {
     unsigned char block_size;
 };
 
-#if defined(MBEDTLS_MD5_C)
-extern const mbedtls_md_info_t mbedtls_md5_info;
-#endif
-#if defined(MBEDTLS_RIPEMD160_C)
-extern const mbedtls_md_info_t mbedtls_ripemd160_info;
-#endif
-#if defined(MBEDTLS_SHA1_C)
-extern const mbedtls_md_info_t mbedtls_sha1_info;
-#endif
-#if defined(MBEDTLS_SHA224_C)
-extern const mbedtls_md_info_t mbedtls_sha224_info;
-#endif
-#if defined(MBEDTLS_SHA256_C)
-extern const mbedtls_md_info_t mbedtls_sha256_info;
-#endif
-#if defined(MBEDTLS_SHA384_C)
-extern const mbedtls_md_info_t mbedtls_sha384_info;
-#endif
-#if defined(MBEDTLS_SHA512_C)
-extern const mbedtls_md_info_t mbedtls_sha512_info;
-#endif
-#if defined(MBEDTLS_SHA3_C)
-extern const mbedtls_md_info_t mbedtls_sha3_224_info;
-extern const mbedtls_md_info_t mbedtls_sha3_256_info;
-extern const mbedtls_md_info_t mbedtls_sha3_384_info;
-extern const mbedtls_md_info_t mbedtls_sha3_512_info;
-#endif
-
 #ifdef __cplusplus
 }
 #endif

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -72,7 +72,6 @@
 #include "mbedtls/gcm.h"
 #include "mbedtls/md5.h"
 #include "mbedtls/md.h"
-#include "md_wrap.h"
 #include "mbedtls/pk.h"
 #include "pk_wrap.h"
 #include "mbedtls/platform_util.h"

--- a/library/psa_crypto_hash.h
+++ b/library/psa_crypto_hash.h
@@ -23,8 +23,6 @@
 
 #include <psa/crypto.h>
 
-#include "md_wrap.h"
-
 /** Calculate the hash (digest) of a message using Mbed TLS routines.
  *
  * \note The signature of this function is that of a PSA driver hash_compute


### PR DESCRIPTION
## Description

Resolves #6996.

Note: did not do the part about `get_size`, as I believe it wouldn't actually save code size in configs with only a few hashes enabled, considering the PSA macros is not optimized in this case but the current code is.

Code size savings (default config, [see below](https://github.com/Mbed-TLS/mbedtls/pull/7811#issuecomment-1600400301)):
- 151 bytes with `MD_C`;
- 152 bytes with only `MD_LIGHT`.

Note: this is in a config with all hashes enabled; we'd expect smaller savings in configs with fewer hashes enabled.

## PR checklist


- [x] **changelog** not required - internal change
- [x] **backport** not required - optimization
- [x] **tests** not required - covered by existing tests
