### PR TITLE
Simplify directory name comparison in AuthorityKeyIdentifier tests

### DIFF
--- a/tests/suites/test_suite_x509parse.data
+++ b/tests/suites/test_suite_x509parse.data
@@ -3323,11 +3323,11 @@ x509_crt_parse_subjectkeyid:"data_files/authorityKeyId_subjectKeyId_tag_len_malf
 
 X509 CRT parse Authority Key Id - Correct Authority Key ID
 depends_on:MBEDTLS_MD_CAN_SHA256:MBEDTLS_RSA_C
-x509_crt_parse_authoritykeyid:"data_files/authorityKeyId_subjectKeyId.crt.der":"A505E864B8DCDF600F50124D60A864AF4D8B4393":"NL/PolarSSL/PolarSSL Test CA/":"680430CD074DE63FCDC051260FD042C2B512B6BA":0
+x509_crt_parse_authoritykeyid:"data_files/authorityKeyId_subjectKeyId.crt.der":"A505E864B8DCDF600F50124D60A864AF4D8B4393":"C=NL, OU=PolarSSL, CN=PolarSSL Test CA":"680430CD074DE63FCDC051260FD042C2B512B6BA":0
 
 X509 CRT parse Authority Key Id - Correct Authority Key ID (no keyid)
 depends_on:MBEDTLS_MD_CAN_SHA256:MBEDTLS_RSA_C
-x509_crt_parse_authoritykeyid:"data_files/authorityKeyId_no_keyid.crt.der":"":"NL/PolarSSL/PolarSSL Test CA/":"680430CD074DE63FCDC051260FD042C2B512B6BA":0
+x509_crt_parse_authoritykeyid:"data_files/authorityKeyId_no_keyid.crt.der":"":"C=NL, OU=PolarSSL, CN=PolarSSL Test CA":"680430CD074DE63FCDC051260FD042C2B512B6BA":0
 
 X509 CRT parse Authority Key Id - Correct Authority Key ID (no issuer)
 depends_on:MBEDTLS_MD_CAN_SHA256:MBEDTLS_RSA_C

--- a/tests/suites/test_suite_x509parse.function
+++ b/tests/suites/test_suite_x509parse.function
@@ -1578,11 +1578,8 @@ void x509_crt_parse_authoritykeyid(char *file,
                                    int ref_ret)
 {
     mbedtls_x509_crt crt;
-    int bufferCounter = 0;
-    size_t issuerCounter = 0;
-    unsigned int result = 0;
     mbedtls_x509_subject_alternative_name san;
-    mbedtls_x509_name *pname = NULL;
+    char name_buf[128];
 
     mbedtls_x509_crt_init(&crt);
 
@@ -1606,18 +1603,12 @@ void x509_crt_parse_authoritykeyid(char *file,
 
             TEST_EQUAL(mbedtls_x509_parse_subject_alt_name(&issuerPtr->buf, &san), 0);
 
-            pname = &san.san.directory_name;
+            TEST_ASSERT(mbedtls_x509_dn_gets(name_buf, sizeof(name_buf),
+                                             &san.san.directory_name)
+                        > 0);
+            TEST_EQUAL(strcmp(name_buf, authorityKeyId_issuer), 0);
 
-            while (pname != NULL) {
-                for (issuerCounter = 0; issuerCounter < pname->val.len; issuerCounter++) {
-                    result |=
-                        (authorityKeyId_issuer[bufferCounter++] != pname->val.p[issuerCounter]);
-                }
-                bufferCounter++; /* Skipping the slash */
-                pname = pname->next;
-            }
             mbedtls_x509_free_subject_alt_name(&san);
-            TEST_EQUAL(result, 0);
         }
 
         /* Serial test */


### PR DESCRIPTION
Remove custom parsing code in AuthorityKeyIdentifier tests and use `mbedtls_x509_dn_gets()` and `strcmp()` instead.

Followup for a [comment](https://github.com/Mbed-TLS/mbedtls/pull/7411/files#r1228451285) on #7411.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required - internal change only
- [x] **backport** not required - change to 3.x-only code
- [x] **tests** not required - change to tests themselves