### PR TITLE
code_style.py --since

### DIFF
--- a/scripts/code_style.py
+++ b/scripts/code_style.py
@@ -74,21 +74,18 @@ def get_src_files(since: Optional[str]) -> List[str]:
     Only C files are included, and certain files (generated, or 3rdparty)
     are excluded.
     """
-    if since is None:
-        git_ls_files_cmd = ["git", "ls-files",
-                            "*.[hc]",
-                            "tests/suites/*.function",
-                            "scripts/data_files/*.fmt"]
-        output = subprocess.check_output(git_ls_files_cmd,
-                                         universal_newlines=True)
-    else:
-        git_ls_files_cmd = ["git", "diff", "--name-only", since, "--",
-                            "*.[hc]",
-                            "tests/suites/*.function",
-                            "scripts/data_files/*.fmt"]
-        output = subprocess.check_output(git_ls_files_cmd,
-                                         universal_newlines=True)
+    file_patterns = ["*.[hc]",
+                     "tests/suites/*.function",
+                     "scripts/data_files/*.fmt"]
+    output = subprocess.check_output(["git", "ls-files"] + file_patterns,
+                                     universal_newlines=True)
     src_files = output.split()
+    if since:
+        output = subprocess.check_output(["git", "diff", "--name-only",
+                                          since, "--"] +
+                                         src_files,
+                                         universal_newlines=True)
+        src_files = output.split()
 
     generated_files = list_generated_files()
     # Don't correct style for third-party files (and, for simplicity,

--- a/scripts/code_style.py
+++ b/scripts/code_style.py
@@ -65,29 +65,27 @@ def list_generated_files() -> FrozenSet[str]:
 
 def get_src_files() -> List[str]:
     """
-    Use git ls-files to get a list of the source files
+    Use git to get a list of the source files.
+
+    Only C files are included, and certain files (generated, or 3rdparty)
+    are excluded.
     """
     git_ls_files_cmd = ["git", "ls-files",
                         "*.[hc]",
                         "tests/suites/*.function",
                         "scripts/data_files/*.fmt"]
+    output = subprocess.check_output(git_ls_files_cmd,
+                                     universal_newlines=True)
+    src_files = output.split()
 
-    result = subprocess.run(git_ls_files_cmd, stdout=subprocess.PIPE,
-                            check=False)
-
-    if result.returncode != 0:
-        print_err("git ls-files returned: " + str(result.returncode))
-        return []
-    else:
-        generated_files = list_generated_files()
-        src_files = str(result.stdout, "utf-8").split()
-        # Don't correct style for third-party files (and, for simplicity,
-        # companion files in the same subtree), or for automatically
-        # generated files (we're correcting the templates instead).
-        src_files = [filename for filename in src_files
-                     if not (filename.startswith("3rdparty/") or
-                             filename in generated_files)]
-        return src_files
+    generated_files = list_generated_files()
+    # Don't correct style for third-party files (and, for simplicity,
+    # companion files in the same subtree), or for automatically
+    # generated files (we're correcting the templates instead).
+    src_files = [filename for filename in src_files
+                 if not (filename.startswith("3rdparty/") or
+                         filename in generated_files)]
+    return src_files
 
 def get_uncrustify_version() -> str:
     """


### PR DESCRIPTION
Add an option to speed up the code style check by only considering files modified since a given commit:
```
scripts/code_style.py -s HEAD # only check files that aren't committed yet
scripts/code_style.py -s HEAD~3 # only check files modified in the last 3 commits
scripts/code_style.py -s upstream/development # only check files modified in my branch
```

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** N/A (support script only)
- [ ] **backport** TODO
- [x] **tests** N/A (support script that doesn't have tests)



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.
