### PR TITLE
Add support for the `base64url` encoding

### DIFF
--- a/ChangeLog.d/add-base64url-support.txt
+++ b/ChangeLog.d/add-base64url-support.txt
@@ -1,0 +1,3 @@
+Features
+   * Add support for the base64url variant of base64 that replaces
+     '+' and '/' with '-' and '_' respectively.

--- a/include/mbedtls/base64.h
+++ b/include/mbedtls/base64.h
@@ -56,6 +56,29 @@ extern "C" {
  */
 int mbedtls_base64_encode(unsigned char *dst, size_t dlen, size_t *olen,
                           const unsigned char *src, size_t slen);
+/**
+ * \brief          Encode a buffer into base64 format with the base64url
+ *                 encoding. This is identical to regular base64 except that
+ *                 '-' is used instead of '+' and '_' instead of '/'.
+ *
+ * \param dst      destination buffer
+ * \param dlen     size of the destination buffer
+ * \param olen     number of bytes written
+ * \param src      source buffer
+ * \param slen     amount of data to be encoded
+ *
+ * \return         0 if successful, or MBEDTLS_ERR_BASE64_BUFFER_TOO_SMALL.
+ *                 *olen is always updated to reflect the amount
+ *                 of data that has (or would have) been written.
+ *                 If that length cannot be represented, then no data is
+ *                 written to the buffer and *olen is set to the maximum
+ *                 length representable as a size_t.
+ *
+ * \note           Call this function with dlen = 0 to obtain the
+ *                 required buffer size in *olen
+ */
+int mbedtls_base64url_encode(unsigned char *dst, size_t dlen, size_t *olen,
+                             const unsigned char *src, size_t slen);
 
 /**
  * \brief          Decode a base64-formatted buffer
@@ -76,6 +99,28 @@ int mbedtls_base64_encode(unsigned char *dst, size_t dlen, size_t *olen,
  */
 int mbedtls_base64_decode(unsigned char *dst, size_t dlen, size_t *olen,
                           const unsigned char *src, size_t slen);
+
+/**
+ * \brief          Decode a base64-formatted buffer with the base64url
+ *                 encoding. This is identical to regular base64 except that
+ *                 '-' is used instead of '+' and '_' instead of '/'.
+ *
+ * \param dst      destination buffer (can be NULL for checking size)
+ * \param dlen     size of the destination buffer
+ * \param olen     number of bytes written
+ * \param src      source buffer
+ * \param slen     amount of data to be decoded
+ *
+ * \return         0 if successful, MBEDTLS_ERR_BASE64_BUFFER_TOO_SMALL, or
+ *                 MBEDTLS_ERR_BASE64_INVALID_CHARACTER if the input data is
+ *                 not correct. *olen is always updated to reflect the amount
+ *                 of data that has (or would have) been written.
+ *
+ * \note           Call this function with *dst = NULL or dlen = 0 to obtain
+ *                 the required buffer size in *olen
+ */
+int mbedtls_base64url_decode(unsigned char *dst, size_t dlen, size_t *olen,
+                             const unsigned char *src, size_t slen);
 
 #if defined(MBEDTLS_SELF_TEST)
 /**

--- a/library/constant_time.c
+++ b/library/constant_time.c
@@ -346,23 +346,31 @@ void mbedtls_ct_mpi_uint_cond_assign(size_t n,
 
 #if defined(MBEDTLS_BASE64_C)
 
-unsigned char mbedtls_ct_base64_enc_char(unsigned char value)
+unsigned char mbedtls_ct_base64_enc_char(unsigned char value, unsigned char urlsafe)
 {
     unsigned char digit = 0;
+
+    char plus[] = { '+', '-' };
+    char slash[] = { '/', '_' };
+    urlsafe = !!urlsafe;
     /* For each range of values, if value is in that range, mask digit with
      * the corresponding value. Since value can only be in a single range,
      * only at most one masking will change digit. */
     digit |= mbedtls_ct_uchar_mask_of_range(0, 25, value) & ('A' + value);
     digit |= mbedtls_ct_uchar_mask_of_range(26, 51, value) & ('a' + value - 26);
     digit |= mbedtls_ct_uchar_mask_of_range(52, 61, value) & ('0' + value - 52);
-    digit |= mbedtls_ct_uchar_mask_of_range(62, 62, value) & '+';
-    digit |= mbedtls_ct_uchar_mask_of_range(63, 63, value) & '/';
+    digit |= mbedtls_ct_uchar_mask_of_range(62, 62, value) & plus[urlsafe];
+    digit |= mbedtls_ct_uchar_mask_of_range(63, 63, value) & slash[urlsafe];
     return digit;
 }
 
-signed char mbedtls_ct_base64_dec_value(unsigned char c)
+signed char mbedtls_ct_base64_dec_value(unsigned char c, unsigned char urlsafe)
 {
     unsigned char val = 0;
+
+    char plus[] = { '+', '-' };
+    char slash[] = { '/', '_' };
+    urlsafe = !!urlsafe;
     /* For each range of digits, if c is in that range, mask val with
      * the corresponding value. Since c can only be in a single range,
      * only at most one masking will change val. Set val to one plus
@@ -370,8 +378,10 @@ signed char mbedtls_ct_base64_dec_value(unsigned char c)
     val |= mbedtls_ct_uchar_mask_of_range('A', 'Z', c) & (c - 'A' +  0 + 1);
     val |= mbedtls_ct_uchar_mask_of_range('a', 'z', c) & (c - 'a' + 26 + 1);
     val |= mbedtls_ct_uchar_mask_of_range('0', '9', c) & (c - '0' + 52 + 1);
-    val |= mbedtls_ct_uchar_mask_of_range('+', '+', c) & (c - '+' + 62 + 1);
-    val |= mbedtls_ct_uchar_mask_of_range('/', '/', c) & (c - '/' + 63 + 1);
+    val |= mbedtls_ct_uchar_mask_of_range(plus[urlsafe], plus[urlsafe], c)
+           & (c - plus[urlsafe] + 62 + 1);
+    val |= mbedtls_ct_uchar_mask_of_range(slash[urlsafe], slash[urlsafe], c)
+           & (c - slash[urlsafe] + 63 + 1);
     /* At this point, val is 0 if c is an invalid digit and v+1 if c is
      * a digit with the value v. */
     return val - 1;

--- a/library/constant_time_internal.h
+++ b/library/constant_time_internal.h
@@ -194,9 +194,12 @@ void mbedtls_ct_mpi_uint_cond_assign(size_t n,
  *
  * \param value     A value in the range 0..63.
  *
+ * \param urlsafe   Whether to use base64url encoding, where '+' and '/' are
+ *                  substituted for '-' and '_' respectively.
+ *
  * \return          A base64 digit converted from \p value.
  */
-unsigned char mbedtls_ct_base64_enc_char(unsigned char value);
+unsigned char mbedtls_ct_base64_enc_char(unsigned char value, unsigned char urlsafe);
 
 /** Given a Base64 digit, return its value.
  *
@@ -206,11 +209,14 @@ unsigned char mbedtls_ct_base64_enc_char(unsigned char value);
  * The implementation assumes that letters are consecutive (e.g. ASCII
  * but not EBCDIC).
  *
- * \param c     A base64 digit.
+ * \param c         A base64 digit.
  *
- * \return      The value of the base64 digit \p c.
+ * \param urlsafe   Whether to use base64url encoding, where '+' and '/' are
+ *                  substituted for '-' and '_' respectively.
+ *
+ * \return          The value of the base64 digit \p c.
  */
-signed char mbedtls_ct_base64_dec_value(unsigned char c);
+signed char mbedtls_ct_base64_dec_value(unsigned char c, unsigned char urlsafe);
 
 #endif /* MBEDTLS_BASE64_C */
 

--- a/tests/suites/test_suite_base64.data
+++ b/tests/suites/test_suite_base64.data
@@ -23,10 +23,16 @@ mask_of_range 'A'..'Z'
 mask_of_range:65:90
 
 enc_char (all digits)
-enc_chars:
+enc_chars:0
+
+enc_char (all digits, base64url)
+enc_chars:1
 
 dec_value (all characters)
-dec_chars:
+dec_chars:0
+
+dec_value (all characters, base64url)
+dec_chars:1
 
 Test case mbedtls_base64_encode #1 buffer just right
 mbedtls_base64_encode:"":"":0:0

--- a/tests/suites/test_suite_base64.function
+++ b/tests/suites/test_suite_base64.function
@@ -7,6 +7,8 @@
 #if defined(MBEDTLS_TEST_HOOKS)
 static const char base64_digits[] =
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+static const char base64url_digits[] =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
 #endif /* MBEDTLS_TEST_HOOKS */
 
 /* END_HEADER */
@@ -37,36 +39,50 @@ void mask_of_range(int low_arg, int high_arg)
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_TEST_HOOKS */
-void enc_chars()
+void enc_chars(int urlsafe)
 {
     for (unsigned value = 0; value < 64; value++) {
         mbedtls_test_set_step(value);
         TEST_CF_SECRET(&value, sizeof(value));
-        unsigned char digit = mbedtls_ct_base64_enc_char(value);
+        unsigned char digit = mbedtls_ct_base64_enc_char(value, urlsafe);
         TEST_CF_PUBLIC(&value, sizeof(value));
         TEST_CF_PUBLIC(&digit, sizeof(digit));
-        TEST_EQUAL(digit, base64_digits[value]);
+        if (urlsafe) {
+            TEST_EQUAL(digit, base64url_digits[value]);
+        } else {
+            TEST_EQUAL(digit, base64_digits[value]);
+        }
     }
 }
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_TEST_HOOKS */
-void dec_chars()
+void dec_chars(int urlsafe)
 {
     char *p;
     signed char expected;
 
     for (unsigned c = 0; c <= 0xff; c++) {
         mbedtls_test_set_step(c);
+
+        const char *digits;
+        size_t digits_len;
+        if (urlsafe) {
+            digits = base64url_digits;
+            digits_len = sizeof(base64url_digits);
+        } else {
+            digits = base64_digits;
+            digits_len = sizeof(base64_digits);
+        }
         /* base64_digits is 0-terminated. sizeof()-1 excludes the trailing 0. */
-        p = memchr(base64_digits, c, sizeof(base64_digits) - 1);
+        p = memchr(digits, c, digits_len - 1);
         if (p == NULL) {
             expected = -1;
         } else {
-            expected = p - base64_digits;
+            expected = p - digits;
         }
         TEST_CF_SECRET(&c, sizeof(c));
-        signed char actual = mbedtls_ct_base64_dec_value(c);
+        signed char actual = mbedtls_ct_base64_dec_value(c, urlsafe);
         TEST_CF_PUBLIC(&c, sizeof(c));
         TEST_CF_PUBLIC(&actual, sizeof(actual));
         TEST_EQUAL(actual, expected);


### PR DESCRIPTION
Add support for the base64url encoding in base64 code, which replaces `+` and `/` with `-` and `_`, respectively.

Fixes #1285.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** provided
- [x] **backport** not required - new feature
- [x] **tests** provided
