### PR TITLE
Reword the description of `mbedtls_net_free()`

### DIFF
--- a/include/mbedtls/net_sockets.h
+++ b/include/mbedtls/net_sockets.h
@@ -283,16 +283,16 @@ int mbedtls_net_recv_timeout(void *ctx, unsigned char *buf, size_t len,
                              uint32_t timeout);
 
 /**
- * \brief          Closes down the connection and free associated data
+ * \brief          Close down the connection and clear the context
  *
  * \param ctx      The context to close
  */
 void mbedtls_net_close(mbedtls_net_context *ctx);
 
 /**
- * \brief          Gracefully shutdown the connection and free associated data
+ * \brief          Gracefully shutdown the connection and clear the context
  *
- * \param ctx      The context to free
+ * \param ctx      The context to gracefully shutdown
  */
 void mbedtls_net_free(mbedtls_net_context *ctx);
 

--- a/include/mbedtls/net_sockets.h
+++ b/include/mbedtls/net_sockets.h
@@ -283,16 +283,24 @@ int mbedtls_net_recv_timeout(void *ctx, unsigned char *buf, size_t len,
                              uint32_t timeout);
 
 /**
- * \brief          Close down the connection and clear the context
+ * \brief          Closes down the connection and free associated data
  *
  * \param ctx      The context to close
+ *
+ * \note           This function frees and clears data associated with the
+ *                 context but does not free the memory pointed to by \p ctx.
+ *                 This memory is the responsibility of the caller.
  */
 void mbedtls_net_close(mbedtls_net_context *ctx);
 
 /**
- * \brief          Gracefully shutdown the connection and clear the context
+ * \brief          Gracefully shutdown the connection and free associated data
  *
- * \param ctx      The context to gracefully shutdown
+ * \param ctx      The context to free
+ *
+ * \note           This function frees and clears data associated with the
+ *                 context but does not free the memory pointed to by \p ctx.
+ *                 This memory is the responsibility of the caller.
  */
 void mbedtls_net_free(mbedtls_net_context *ctx);
 


### PR DESCRIPTION
This makes it clearer that the context itself is not being freed.

Fixes #2544.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required - minor description change
- [x] **backport** #7828 
- [x] **tests** not required - comment/docs only