### PR TITLE
Fix possible old tolerance window fail

### DIFF
--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -1439,7 +1439,7 @@ int dummy_ticket_parse(void *p_ticket, mbedtls_ssl_session *session,
         case 6:
             session->start = mbedtls_time(NULL);
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
-            session->ticket_age_add -= 1000;
+            session->ticket_age_add -= 2000;
 #endif
             break;
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -1439,6 +1439,16 @@ int dummy_ticket_parse(void *p_ticket, mbedtls_ssl_session *session,
         case 6:
             session->start = mbedtls_time(NULL);
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
+            /* To workaround anti-replay failure, 1 second negative tolerance
+             * was added in ticket check, that's due to the unit is second.
+             * This is a negative test. That modifies the age parameter to trigger
+             * fail case. 1 second is not enough for it, when the real age is
+             * large than 1 millisecond, the test will pass which is not
+             * expected.
+             *
+             * And #6788 is fix of anti-replay failure. This test should be
+             * changed when #6788 merged.
+             */
             session->ticket_age_add -= 2000;
 #endif
             break;

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -1445,7 +1445,7 @@ int dummy_ticket_parse(void *p_ticket, mbedtls_ssl_session *session,
              * failure we want.
              * Note: previously tried 1000ms, but that's not enough when real
              * age > 1ms.
-             * TODO: This needs to be changed (XXX to what?) when PR #6788
+             * TODO: This needs to be changed to 1 millsecond when PR #6788
              * (which fixes anti-replay failure) is merged.
              */
             session->ticket_age_add -= 2000;

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -1439,15 +1439,14 @@ int dummy_ticket_parse(void *p_ticket, mbedtls_ssl_session *session,
         case 6:
             session->start = mbedtls_time(NULL);
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
-            /* To workaround anti-replay failure, 1 second negative tolerance
-             * was added in ticket check, that's due to the unit is second.
-             * This is a negative test. That modifies the age parameter to trigger
-             * fail case. 1 second is not enough for it, when the real age is
-             * large than 1 millisecond, the test will pass which is not
-             * expected.
-             *
-             * And #6788 is fix of anti-replay failure. This test should be
-             * changed when #6788 merged.
+            /* For this negative test, we need to workaround anti-replay, which
+             * adds a 1000ms tolerance to the ticket check. So we reduce the
+             * ticket age by 2000ms, which should be enough to trigger the
+             * failure we want.
+             * Note: previously tried 1000ms, but that's not enough when real
+             * age > 1ms.
+             * TODO: This needs to be changed (XXX to what?) when PR #6788
+             * (which fixes anti-replay failure) is merged.
              */
             session->ticket_age_add -= 2000;
 #endif


### PR DESCRIPTION
## Description

Fix #7795.

To [fix GnuTLS anti-replay failure](#6623), we introduce a workaround solution in #6787 . [That add -1 seconds bottom windows](https://github.com/Mbed-TLS/mbedtls/blob/3048c8c90654eb116a6b17c0d2d27c3ccbe6782c/library/ssl_tls13_server.c#L231). In the test we only create [1 second difference](https://github.com/Mbed-TLS/mbedtls/blob/3048c8c90654eb116a6b17c0d2d27c3ccbe6782c/programs/ssl/ssl_server2.c#L1442), that's still in the window. So some time it will fail. 

https://github.com/Mbed-TLS/mbedtls/pull/6788 is fix for #6623, the [preceding-PR](#6891) has been merged now. I think it is ready for review.



## Gatekeeper checklist

- [ ] **changelog** provided, or not required
- [ ] **backport** done, or not required
- [ ] **tests** provided, or not required



