### PR TITLE
aesce: do not specify an arch version when enabling crypto instructions

### DIFF
--- a/library/aesce.c
+++ b/library/aesce.c
@@ -72,7 +72,7 @@
 #       define MBEDTLS_POP_TARGET_PRAGMA
 #   elif defined(__GNUC__)
 #       pragma GCC push_options
-#       pragma GCC target ("arch=armv8-a+crypto")
+#       pragma GCC target ("+crypto")
 #       define MBEDTLS_POP_TARGET_PRAGMA
 #   elif defined(_MSC_VER)
 #       error "Required feature(__ARM_FEATURE_AES) is not enabled."


### PR DESCRIPTION
## Description

Building mbedtls with different aarch64 tuning variations revealed that we should use the crypto extensions without forcing a particular architecture version or core, as that can create issues.

This was discovered with yocto, after adding v3.4.0 support to upstream openembedded, where it is built with a lot of tuning variations.


## PR checklist

- [x ] **changelog** not required
- [x ] **backport**  not required
- [x ] **tests** not required (change was tested in yocto with different tuning configurations)

I don't know who should review this, so I am going to cc some folks below:
@gilles-peskine-arm @tom-cosgrove-arm 

Thanks!