### PR TITLE
Fix empty union when TLS is disabled

### DIFF
--- a/ChangeLog.d/ssl_premaster_secret-empty.txt
+++ b/ChangeLog.d/ssl_premaster_secret-empty.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix a compilation error on some platforms when including mbedtls/ssl.h
+     with all TLS support disabled. Fixes #6628.

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -620,6 +620,7 @@
 
 /* Dummy type used only for its size */
 union mbedtls_ssl_premaster_secret {
+    unsigned char dummy; /* Make the union non-empty even with SSL disabled */
 #if defined(MBEDTLS_KEY_EXCHANGE_RSA_ENABLED)
     unsigned char _pms_rsa[48];                         /* RFC 5246 8.1.1 */
 #endif


### PR DESCRIPTION
When all TLS 1.2 support is disabled, `union mbedtls_ssl_premaster_secret` was empty, which is not valid C even if the union is never used. Fixes #6628.

As this is a bit of an edge case and has a simple workaround (don't include `mbedtls/ssl.h` if you aren't going to use it), I haven't gone through the effort of adding a test. If we think this really needs a test, I think we should use the following strategy: have a test program that includes all headers, which is built by a plain `make` — this way we would test that all headers work correctly in all the configurations we test (including ones with no TLS, and ones with picky compilers). We already have such a test program, but it's a C++ program, which we don't build in most configurations. So the implementation of this test would be to change `programs/test/generate_cpp_dummy_build.sh` to generate a header that includes all the library headers, and separate out the trivial C++ wrapping and make a similar C wrapping that is always built. Then make sure we pass `-pedantic` in `CFLAGS` in `all.sh` (otherwise gcc doesn't mind).

Manual testing:
```
scripts/config.py crypto
make lib CFLAGS='-Werror -pedantic'
```
Before: “error: union has no members”; after: passes.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** provided
- [ ] **backport** https://github.com/Mbed-TLS/mbedtls/pull/7987
- [x] **tests** manual: I don't think it's worth the effort to automate




## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.
