### PR TITLE
AES: use uint8_t for array of pow and log to save RAM usage

### DIFF
--- a/library/aes.c
+++ b/library/aes.c
@@ -365,15 +365,15 @@ static int aes_init_done = 0;
 static void aes_gen_tables(void)
 {
     int i, x, y, z;
-    int pow[256];
-    int log[256];
+    uint8_t pow[256];
+    uint8_t log[256];
 
     /*
      * compute pow and log tables over GF(2^8)
      */
     for (i = 0, x = 1; i < 256; i++) {
-        pow[i] = x;
-        log[x] = i;
+        pow[i] = (uint8_t) x;
+        log[x] = (uint8_t) i;
         x = MBEDTLS_BYTE_0(x ^ XTIME(x));
     }
 

--- a/library/aes.c
+++ b/library/aes.c
@@ -364,7 +364,8 @@ static int aes_init_done = 0;
 
 static void aes_gen_tables(void)
 {
-    int i, x, y, z;
+    int i;
+    uint8_t x, y, z;
     uint8_t pow[256];
     uint8_t log[256];
 
@@ -372,17 +373,17 @@ static void aes_gen_tables(void)
      * compute pow and log tables over GF(2^8)
      */
     for (i = 0, x = 1; i < 256; i++) {
-        pow[i] = (uint8_t) x;
+        pow[i] = x;
         log[x] = (uint8_t) i;
-        x = MBEDTLS_BYTE_0(x ^ XTIME(x));
+        x ^= XTIME(x);
     }
 
     /*
      * calculate the round constants
      */
     for (i = 0, x = 1; i < 10; i++) {
-        RCON[i] = (uint32_t) x;
-        x = MBEDTLS_BYTE_0(XTIME(x));
+        RCON[i] = x;
+        x = XTIME(x);
     }
 
     /*
@@ -394,13 +395,13 @@ static void aes_gen_tables(void)
     for (i = 1; i < 256; i++) {
         x = pow[255 - log[i]];
 
-        y  = x; y = MBEDTLS_BYTE_0((y << 1) | (y >> 7));
-        x ^= y; y = MBEDTLS_BYTE_0((y << 1) | (y >> 7));
-        x ^= y; y = MBEDTLS_BYTE_0((y << 1) | (y >> 7));
-        x ^= y; y = MBEDTLS_BYTE_0((y << 1) | (y >> 7));
+        y  = x; y = (y << 1) | (y >> 7);
+        x ^= y; y = (y << 1) | (y >> 7);
+        x ^= y; y = (y << 1) | (y >> 7);
+        x ^= y; y = (y << 1) | (y >> 7);
         x ^= y ^ 0x63;
 
-        FSb[i] = (unsigned char) x;
+        FSb[i] = x;
         RSb[x] = (unsigned char) i;
     }
 
@@ -409,8 +410,8 @@ static void aes_gen_tables(void)
      */
     for (i = 0; i < 256; i++) {
         x = FSb[i];
-        y = MBEDTLS_BYTE_0(XTIME(x));
-        z = MBEDTLS_BYTE_0(y ^ x);
+        y = XTIME(x);
+        z = y ^ x;
 
         FT0[i] = ((uint32_t) y) ^
                  ((uint32_t) x <<  8) ^


### PR DESCRIPTION
## Description

Fix: #7381, #744

This PR changes `pow` and `log` table in `aes_gen_tables` from `int` to `uint8_t` in order to save RAM usage. Additionally, local variable `x`, `y`, `z` only handles values of `8 bit`. We can also use `uint8_t` for those three values to save RAM usage further.

**RAM Usage**: (at 961f5dc)
`command: make CC=gcc CFLAGS="-fstack-usage" -j` 

| Function | Old Size | New Size | Change (Bytes) |
| ---: | ---: |  ---: |  ---: |
| aes_gen_tables | 2096 | 560 | -1536 |

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required as it's a refactor
- [x] **backport** no - not a bugfix
- [x] **tests** not required
