### PR TITLE
[Backport 2.28] Fix false success return code in `mbedtls_x509_string_to_names()`

### DIFF
--- a/ChangeLog.d/fix-string-to-names-retcode.txt
+++ b/ChangeLog.d/fix-string-to-names-retcode.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix a bug in which mbedtls_x509_string_to_names() would return success
+     when given a invalid name string if it did not contain '=' or ','.

--- a/library/x509_create.c
+++ b/library/x509_create.c
@@ -125,7 +125,7 @@ static const x509_attr_descriptor_t *x509_attr_descr_from_name(const char *name,
 
 int mbedtls_x509_string_to_names(mbedtls_asn1_named_data **head, const char *name)
 {
-    int ret = 0;
+    int ret = MBEDTLS_ERR_X509_INVALID_NAME;
     const char *s = name, *c = s;
     const char *end = s + strlen(s);
     const char *oid = NULL;
@@ -177,6 +177,9 @@ int mbedtls_x509_string_to_names(mbedtls_asn1_named_data **head, const char *nam
 
             s = c + 1;
             in_tag = 1;
+
+            /* Successfully parsed one name, update ret to success */
+            ret = 0;
         }
 
         if (!in_tag && s != c + 1) {

--- a/tests/suites/test_suite_x509write.data
+++ b/tests/suites/test_suite_x509write.data
@@ -133,5 +133,8 @@ mbedtls_x509_string_to_names:"C=NL, O=Offspark\\a Inc., OU=PolarSSL":"":MBEDTLS_
 X509 String to Names #6 (Escape at end)
 mbedtls_x509_string_to_names:"C=NL, O=Offspark\\":"":MBEDTLS_ERR_X509_INVALID_NAME
 
+X509 String to Names #6 (Invalid, no '=' or ',')
+mbedtls_x509_string_to_names:"ABC123":"":MBEDTLS_ERR_X509_INVALID_NAME
+
 Check max serial length
 x509_set_serial_check:


### PR DESCRIPTION
Trivial backport of #7849.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** provided
- [x] **backport** of #7849
- [x] **tests** provided