### PR TITLE
Fix AES dependencies - build TF-M config cleanly

### DIFF
--- a/ChangeLog.d/fix-tfm-build.txt
+++ b/ChangeLog.d/fix-tfm-build.txt
@@ -1,0 +1,5 @@
+Bugfix
+   * Fix compilation warnings in aes.c, which prevented the
+     example TF-M configuration in configs/ from building cleanly:
+     tfm_mbedcrypto_config_profile_medium.h with 
+     crypto_config_profile_medium.h.

--- a/ChangeLog.d/fix-tfm-build.txt
+++ b/ChangeLog.d/fix-tfm-build.txt
@@ -1,5 +1,5 @@
 Bugfix
    * Fix compilation warnings in aes.c, which prevented the
      example TF-M configuration in configs/ from building cleanly:
-     tfm_mbedcrypto_config_profile_medium.h with 
+     tfm_mbedcrypto_config_profile_medium.h with
      crypto_config_profile_medium.h.

--- a/library/aes.c
+++ b/library/aes.c
@@ -319,7 +319,7 @@ static const uint32_t RT2[256] = { RT };
 static const uint32_t RT3[256] = { RT };
 #undef V
 
-#endif /* !defined(MBEDTLS_AES_DECRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_DEC) */
+#endif /* !defined(MBEDTLS_AES_DECRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT) */
 
 #endif /* !MBEDTLS_AES_FEWER_TABLES */
 

--- a/library/aes.c
+++ b/library/aes.c
@@ -92,8 +92,8 @@ static const unsigned char FSb[256] =
     0x8C, 0xA1, 0x89, 0x0D, 0xBF, 0xE6, 0x42, 0x68,
     0x41, 0x99, 0x2D, 0x0F, 0xB0, 0x54, 0xBB, 0x16
 };
-#endif \
-    /* !defined(MBEDTLS_AES_ENCRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_ENC_ALT) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT) */
+#endif /* !defined(MBEDTLS_AES_ENCRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_ENC_ALT) || \
+          !defined(MBEDTLS_AES_SETKEY_DEC_ALT) */
 
 /*
  * Forward tables
@@ -347,8 +347,8 @@ static const uint32_t RCON[10] =
 #if !defined(MBEDTLS_AES_ENCRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_ENC_ALT) || \
     !defined(MBEDTLS_AES_SETKEY_DEC_ALT)
 static unsigned char FSb[256];
-#endif \
-    /* !defined(MBEDTLS_AES_ENCRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_ENC_ALT) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT) */
+#endif /* !defined(MBEDTLS_AES_ENCRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_ENC_ALT) || \
+          !defined(MBEDTLS_AES_SETKEY_DEC_ALT) */
 #if !defined(MBEDTLS_AES_ENCRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_ENC_ALT)
 static uint32_t FT0[256];
 #if !defined(MBEDTLS_AES_FEWER_TABLES)
@@ -363,7 +363,7 @@ static uint32_t FT3[256];
  */
 #if !(defined(MBEDTLS_AES_SETKEY_ENC_ALT) && defined(MBEDTLS_AES_DECRYPT_ALT))
 static unsigned char RSb[256];
-#endif
+#endif /* !(defined(MBEDTLS_AES_SETKEY_ENC_ALT) && defined(MBEDTLS_AES_DECRYPT_ALT)) */
 
 #if !defined(MBEDTLS_AES_DECRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT)
 static uint32_t RT0[256];
@@ -584,8 +584,8 @@ static unsigned mbedtls_aes_rk_offset(uint32_t *buf)
 
     return 0;
 }
-#endif \
-    /* defined(MAY_NEED_TO_ALIGN) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT) || !defined(MBEDTLS_AES_SETKEY_ENC_ALT) */
+#endif /* defined(MAY_NEED_TO_ALIGN) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT) || \
+          !defined(MBEDTLS_AES_SETKEY_ENC_ALT) */
 
 /*
  * AES key schedule (encryption)

--- a/library/aes.c
+++ b/library/aes.c
@@ -55,7 +55,8 @@ static int aes_padlock_ace = -1;
 /*
  * Forward S-box
  */
-#if !defined(MBEDTLS_AES_ENCRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_ENC_ALT) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT)
+#if !defined(MBEDTLS_AES_ENCRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_ENC_ALT) || \
+    !defined(MBEDTLS_AES_SETKEY_DEC_ALT)
 static const unsigned char FSb[256] =
 {
     0x63, 0x7C, 0x77, 0x7B, 0xF2, 0x6B, 0x6F, 0xC5,
@@ -91,7 +92,8 @@ static const unsigned char FSb[256] =
     0x8C, 0xA1, 0x89, 0x0D, 0xBF, 0xE6, 0x42, 0x68,
     0x41, 0x99, 0x2D, 0x0F, 0xB0, 0x54, 0xBB, 0x16
 };
-#endif /* !defined(MBEDTLS_AES_ENCRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_ENC_ALT) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT) */
+#endif \
+    /* !defined(MBEDTLS_AES_ENCRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_ENC_ALT) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT) */
 
 /*
  * Forward tables
@@ -342,9 +344,11 @@ static const uint32_t RCON[10] =
 /*
  * Forward S-box & tables
  */
-#if !defined(MBEDTLS_AES_ENCRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_ENC_ALT) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT)
+#if !defined(MBEDTLS_AES_ENCRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_ENC_ALT) || \
+    !defined(MBEDTLS_AES_SETKEY_DEC_ALT)
 static unsigned char FSb[256];
-#endif /* !defined(MBEDTLS_AES_ENCRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_ENC_ALT) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT) */
+#endif \
+    /* !defined(MBEDTLS_AES_ENCRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_ENC_ALT) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT) */
 #if !defined(MBEDTLS_AES_ENCRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_ENC_ALT)
 static uint32_t FT0[256];
 #if !defined(MBEDTLS_AES_FEWER_TABLES)
@@ -542,7 +546,8 @@ void mbedtls_aes_xts_free(mbedtls_aes_xts_context *ctx)
 #define MAY_NEED_TO_ALIGN
 #endif
 
-#if defined(MAY_NEED_TO_ALIGN) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT) || !defined(MBEDTLS_AES_SETKEY_ENC_ALT)
+#if defined(MAY_NEED_TO_ALIGN) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT) || \
+    !defined(MBEDTLS_AES_SETKEY_ENC_ALT)
 static unsigned mbedtls_aes_rk_offset(uint32_t *buf)
 {
 #if defined(MAY_NEED_TO_ALIGN)
@@ -579,7 +584,8 @@ static unsigned mbedtls_aes_rk_offset(uint32_t *buf)
 
     return 0;
 }
-#endif /* defined(MAY_NEED_TO_ALIGN) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT) || !defined(MBEDTLS_AES_SETKEY_ENC_ALT) */
+#endif \
+    /* defined(MAY_NEED_TO_ALIGN) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT) || !defined(MBEDTLS_AES_SETKEY_ENC_ALT) */
 
 /*
  * AES key schedule (encryption)

--- a/library/aes.c
+++ b/library/aes.c
@@ -184,9 +184,9 @@ static const uint32_t FT2[256] = { FT };
 static const uint32_t FT3[256] = { FT };
 #undef V
 
-#endif /* !defined(MBEDTLS_AES_ENCRYPT_ALT) */
-
 #endif /* !MBEDTLS_AES_FEWER_TABLES */
+
+#endif /* !defined(MBEDTLS_AES_ENCRYPT_ALT) */
 
 #undef FT
 

--- a/library/aes.c
+++ b/library/aes.c
@@ -229,7 +229,7 @@ static const unsigned char RSb[256] =
     0x17, 0x2B, 0x04, 0x7E, 0xBA, 0x77, 0xD6, 0x26,
     0xE1, 0x69, 0x14, 0x63, 0x55, 0x21, 0x0C, 0x7D
 };
-#endif /* !(defined(MBEDTLS_AES_SETKEY_ENC_ALT) && defined(MBEDTLS_AES_DECRYPT_ALT)) */
+#endif /* defined(MBEDTLS_AES_DECRYPT_ALT)) */
 
 /*
  * Reverse tables
@@ -371,8 +371,8 @@ static uint32_t RT0[256];
 static uint32_t RT1[256];
 static uint32_t RT2[256];
 static uint32_t RT3[256];
-#endif /* !defined(MBEDTLS_AES_DECRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT) */
 #endif /* !MBEDTLS_AES_FEWER_TABLES */
+#endif /* !defined(MBEDTLS_AES_DECRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT) */
 
 #if !defined(MBEDTLS_AES_SETKEY_ENC_ALT)
 /*

--- a/library/aes.c
+++ b/library/aes.c
@@ -316,6 +316,7 @@ static const uint32_t RT3[256] = { RT };
 
 #undef RT
 
+#if !defined(MBEDTLS_AES_SETKEY_ENC_ALT)
 /*
  * Round constants
  */
@@ -325,6 +326,7 @@ static const uint32_t RCON[10] =
     0x00000010, 0x00000020, 0x00000040, 0x00000080,
     0x0000001B, 0x00000036
 };
+#endif /* !defined(MBEDTLS_AES_SETKEY_ENC_ALT) */
 
 #else /* MBEDTLS_AES_ROM_TABLES */
 

--- a/library/aes.c
+++ b/library/aes.c
@@ -55,6 +55,7 @@ static int aes_padlock_ace = -1;
 /*
  * Forward S-box
  */
+#if !defined(MBEDTLS_AES_ENCRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_ENC_ALT) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT)
 static const unsigned char FSb[256] =
 {
     0x63, 0x7C, 0x77, 0x7B, 0xF2, 0x6B, 0x6F, 0xC5,
@@ -90,6 +91,7 @@ static const unsigned char FSb[256] =
     0x8C, 0xA1, 0x89, 0x0D, 0xBF, 0xE6, 0x42, 0x68,
     0x41, 0x99, 0x2D, 0x0F, 0xB0, 0x54, 0xBB, 0x16
 };
+#endif /* !defined(MBEDTLS_AES_ENCRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_ENC_ALT) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT) */
 
 /*
  * Forward tables
@@ -161,6 +163,7 @@ static const unsigned char FSb[256] =
     V(C3, 41, 41, 82), V(B0, 99, 99, 29), V(77, 2D, 2D, 5A), V(11, 0F, 0F, 1E), \
     V(CB, B0, B0, 7B), V(FC, 54, 54, A8), V(D6, BB, BB, 6D), V(3A, 16, 16, 2C)
 
+#if !defined(MBEDTLS_AES_ENCRYPT_ALT)
 #define V(a, b, c, d) 0x##a##b##c##d
 static const uint32_t FT0[256] = { FT };
 #undef V
@@ -179,11 +182,13 @@ static const uint32_t FT2[256] = { FT };
 static const uint32_t FT3[256] = { FT };
 #undef V
 
+#endif /* !defined(MBEDTLS_AES_ENCRYPT_ALT) */
+
 #endif /* !MBEDTLS_AES_FEWER_TABLES */
 
 #undef FT
 
-#if !(defined(MBEDTLS_AES_SETKEY_ENC_ALT) && defined(MBEDTLS_AES_DECRYPT_ALT))
+#if !defined(MBEDTLS_AES_DECRYPT_ALT)
 /*
  * Reverse S-box
  */
@@ -294,6 +299,8 @@ static const unsigned char RSb[256] =
     V(71, 01, A8, 39), V(DE, B3, 0C, 08), V(9C, E4, B4, D8), V(90, C1, 56, 64), \
     V(61, 84, CB, 7B), V(70, B6, 32, D5), V(74, 5C, 6C, 48), V(42, 57, B8, D0)
 
+#if !defined(MBEDTLS_AES_DECRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT)
+
 #define V(a, b, c, d) 0x##a##b##c##d
 static const uint32_t RT0[256] = { RT };
 #undef V
@@ -311,6 +318,8 @@ static const uint32_t RT2[256] = { RT };
 #define V(a, b, c, d) 0x##d##a##b##c
 static const uint32_t RT3[256] = { RT };
 #undef V
+
+#endif /* !defined(MBEDTLS_AES_DECRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_DEC) */
 
 #endif /* !MBEDTLS_AES_FEWER_TABLES */
 
@@ -333,13 +342,17 @@ static const uint32_t RCON[10] =
 /*
  * Forward S-box & tables
  */
+#if !defined(MBEDTLS_AES_ENCRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_ENC_ALT) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT)
 static unsigned char FSb[256];
+#endif /* !defined(MBEDTLS_AES_ENCRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_ENC_ALT) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT) */
+#if !defined(MBEDTLS_AES_ENCRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_ENC_ALT)
 static uint32_t FT0[256];
 #if !defined(MBEDTLS_AES_FEWER_TABLES)
 static uint32_t FT1[256];
 static uint32_t FT2[256];
 static uint32_t FT3[256];
 #endif /* !MBEDTLS_AES_FEWER_TABLES */
+#endif /* !defined(MBEDTLS_AES_ENCRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_ENC_ALT) */
 
 /*
  * Reverse S-box & tables
@@ -347,11 +360,14 @@ static uint32_t FT3[256];
 #if !(defined(MBEDTLS_AES_SETKEY_ENC_ALT) && defined(MBEDTLS_AES_DECRYPT_ALT))
 static unsigned char RSb[256];
 #endif
+
+#if !defined(MBEDTLS_AES_DECRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT)
 static uint32_t RT0[256];
 #if !defined(MBEDTLS_AES_FEWER_TABLES)
 static uint32_t RT1[256];
 static uint32_t RT2[256];
 static uint32_t RT3[256];
+#endif /* !defined(MBEDTLS_AES_DECRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT) */
 #endif /* !MBEDTLS_AES_FEWER_TABLES */
 
 #if !defined(MBEDTLS_AES_SETKEY_ENC_ALT)
@@ -432,6 +448,7 @@ static void aes_gen_tables(void)
 
         x = RSb[i];
 
+#if !defined(MBEDTLS_AES_DECRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT)
         RT0[i] = ((uint32_t) MUL(0x0E, x)) ^
                  ((uint32_t) MUL(0x09, x) <<  8) ^
                  ((uint32_t) MUL(0x0D, x) << 16) ^
@@ -442,6 +459,7 @@ static void aes_gen_tables(void)
         RT2[i] = ROTL8(RT1[i]);
         RT3[i] = ROTL8(RT2[i]);
 #endif /* !MBEDTLS_AES_FEWER_TABLES */
+#endif /* !defined(MBEDTLS_AES_DECRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT) */
     }
 }
 

--- a/library/aes.c
+++ b/library/aes.c
@@ -517,6 +517,8 @@ void mbedtls_aes_xts_free(mbedtls_aes_xts_context *ctx)
     (defined(MBEDTLS_AESNI_C) && MBEDTLS_AESNI_HAVE_CODE == 2)
 #define MAY_NEED_TO_ALIGN
 #endif
+
+#if defined(MAY_NEED_TO_ALIGN) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT) || !defined(MBEDTLS_AES_SETKEY_ENC_ALT)
 static unsigned mbedtls_aes_rk_offset(uint32_t *buf)
 {
 #if defined(MAY_NEED_TO_ALIGN)
@@ -553,6 +555,7 @@ static unsigned mbedtls_aes_rk_offset(uint32_t *buf)
 
     return 0;
 }
+#endif /* defined(MAY_NEED_TO_ALIGN) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT) || !defined(MBEDTLS_AES_SETKEY_ENC_ALT) */
 
 /*
  * AES key schedule (encryption)

--- a/library/aes.c
+++ b/library/aes.c
@@ -183,6 +183,7 @@ static const uint32_t FT3[256] = { FT };
 
 #undef FT
 
+#if !(defined(MBEDTLS_AES_SETKEY_ENC_ALT) && defined(MBEDTLS_AES_DECRYPT_ALT))
 /*
  * Reverse S-box
  */
@@ -221,6 +222,7 @@ static const unsigned char RSb[256] =
     0x17, 0x2B, 0x04, 0x7E, 0xBA, 0x77, 0xD6, 0x26,
     0xE1, 0x69, 0x14, 0x63, 0x55, 0x21, 0x0C, 0x7D
 };
+#endif /* !(defined(MBEDTLS_AES_SETKEY_ENC_ALT) && defined(MBEDTLS_AES_DECRYPT_ALT)) */
 
 /*
  * Reverse tables
@@ -340,7 +342,9 @@ static uint32_t FT3[256];
 /*
  * Reverse S-box & tables
  */
+#if !(defined(MBEDTLS_AES_SETKEY_ENC_ALT) && defined(MBEDTLS_AES_DECRYPT_ALT))
 static unsigned char RSb[256];
+#endif
 static uint32_t RT0[256];
 #if !defined(MBEDTLS_AES_FEWER_TABLES)
 static uint32_t RT1[256];

--- a/library/aes.c
+++ b/library/aes.c
@@ -348,6 +348,7 @@ static uint32_t RT2[256];
 static uint32_t RT3[256];
 #endif /* !MBEDTLS_AES_FEWER_TABLES */
 
+#if !defined(MBEDTLS_AES_SETKEY_ENC_ALT)
 /*
  * Round constants
  */
@@ -437,6 +438,8 @@ static void aes_gen_tables(void)
 #endif /* !MBEDTLS_AES_FEWER_TABLES */
     }
 }
+
+#endif /* !defined(MBEDTLS_AES_SETKEY_ENC_ALT) */
 
 #undef ROTL8
 

--- a/library/x509.c
+++ b/library/x509.c
@@ -134,6 +134,8 @@ int mbedtls_x509_get_alg(unsigned char **p, const unsigned char *end,
 /*
  * Convert md type to string
  */
+#if !defined(MBEDTLS_X509_REMOVE_INFO) && defined(MBEDTLS_X509_RSASSA_PSS_SUPPORT)
+
 static inline const char *md_type_to_string(mbedtls_md_type_t md_alg)
 {
     switch (md_alg) {
@@ -171,6 +173,8 @@ static inline const char *md_type_to_string(mbedtls_md_type_t md_alg)
             return NULL;
     }
 }
+
+#endif
 
 #if defined(MBEDTLS_X509_RSASSA_PSS_SUPPORT)
 /*

--- a/library/x509.c
+++ b/library/x509.c
@@ -174,7 +174,7 @@ static inline const char *md_type_to_string(mbedtls_md_type_t md_alg)
     }
 }
 
-#endif
+#endif /* !defined(MBEDTLS_X509_REMOVE_INFO) && defined(MBEDTLS_X509_RSASSA_PSS_SUPPORT) */
 
 #if defined(MBEDTLS_X509_RSASSA_PSS_SUPPORT)
 /*

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -3338,54 +3338,26 @@ component_build_psa_accel_key_type_rsa_public_key() {
 }
 
 
-support_build_all_configs_armcc () {
+support_build_tfm_armcc () {
     armc6_cc="$ARMC6_BIN_DIR/armclang"
     (check_tools "$armc6_cc" > /dev/null 2>&1)
 }
 
-component_build_all_configs_armcc() { # ~ 45s
-    # Test that all config files in the configs directory will build cleanly
-    # on clang, gcc and armclang with various warnings enabled
+component_build_tfm_armcc() {
+    # test the TF-M configuration can build cleanly with various warning flags enabled
+    cp configs/tfm_mbedcrypto_config_profile_medium.h include/mbedtls/mbedtls_config.h
+    cp configs/crypto_config_profile_medium.h         include/psa/crypto_config.h
 
-    # backup config files
-    cp include/psa/crypto_config.h      include/psa/crypto_config.h.bak
-    cp include/mbedtls/mbedtls_config.h include/mbedtls/mbedtls_config.h.bak
+    msg "build: TF-M config, clang, armv8 thumb2"
+    make lib CC="clang" CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a32 -mthumb -Os -std=c99 -Werror -Wall -Wextra -Wwrite-strings -Wpointer-arith -Wimplicit-fallthrough -Wshadow -Wvla -Wformat=2 -Wno-format-nonliteral -Wshadow -Wasm-operand-widths -Wunused"
 
-    for c in configs/*.h; do
-        if [[ "$c" == "configs/crypto_config_profile_medium.h" ]]; then
-            # skip the crypto_config file
-            continue
-        fi
+    msg "build: TF-M config, gcc native build"
+    make clean
+    make lib CC="gcc" CFLAGS="-Os -std=c99 -Werror -Wall -Wextra -Wwrite-strings -Wpointer-arith -Wimplicit-fallthrough -Wshadow -Wvla -Wformat=2 -Wno-format-nonliteral -Wshadow -Wformat-signedness -Wformat-overflow=2 -Wformat-truncation -Wlogical-op"
 
-        msg "building config: ${c}"
-
-        # copy the configuration file(s) into place
-        cp ${c} include/mbedtls/mbedtls_config.h
-        if [[ "$c" == "configs/configs/tfm_mbedcrypto_config_profile_medium.h" ]]; then
-            # if using the TF-M main config file, also apply the associated crypto_config file
-            cp configs/crypto_config_profile_medium.h include/psa/crypto_config.h
-        fi
-
-        # test the configuration can build cleanly with various warning flags enabled
-        msg "build ${c}, clang, armv8 thumb2"
-        make lib CC="clang" CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a32 -mthumb -O0 -std=c99 -Werror -Wall -Wextra -Wwrite-strings -Wpointer-arith -Wimplicit-fallthrough -Wshadow -Wvla -Wformat=2 -Wno-format-nonliteral -Wshadow -Wasm-operand-widths -Wunused"
-
-        msg "build: ${c}, gcc native build"
-        make clean
-        make lib CC="gcc" CFLAGS="-O0 -std=c99 -Werror -Wall -Wextra -Wwrite-strings -Wpointer-arith -Wimplicit-fallthrough -Wshadow -Wvla -Wformat=2 -Wno-format-nonliteral -Wshadow -Wformat-signedness -Wformat-overflow=2 -Wformat-truncation -Wlogical-op"
-
-        msg "build: ${c}, armclang armv7 thumb2"
-        make clean
-        armc6_build_test "--target=arm-arm-none-eabi -march=armv7-m -mthumb -O0 -std=c99 -Werror -Wall -Wextra -Wwrite-strings -Wpointer-arith -Wimplicit-fallthrough -Wshadow -Wvla -Wformat=2 -Wno-format-nonliteral -Wshadow -Wasm-operand-widths -Wunused"
-
-        # restore config files
-        cp include/psa/crypto_config.h.bak      include/psa/crypto_config.h
-        cp include/mbedtls/mbedtls_config.h.bak include/mbedtls/mbedtls_config.h
-    done
-
-    # remove backup config files
-    rm include/psa/crypto_config.h.bak
-    rm include/mbedtls/mbedtls_config.h.bak
+    msg "build: TF-M config, armclang armv7 thumb2"
+    make clean
+    armc6_build_test "--target=arm-arm-none-eabi -march=armv7-m -mthumb -Os -std=c99 -Werror -Wall -Wextra -Wwrite-strings -Wpointer-arith -Wimplicit-fallthrough -Wshadow -Wvla -Wformat=2 -Wno-format-nonliteral -Wshadow -Wasm-operand-widths -Wunused"
 }
 
 component_test_no_platform () {

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -3363,7 +3363,7 @@ component_build_tfm() {
 
     msg "build: TF-M config, gcc native build"
     make clean
-    make lib CC="gcc" CFLAGS="-Os -std=c99 -Werror -Wall -Wextra -Wwrite-strings -Wpointer-arith -Wimplicit-fallthrough -Wshadow -Wvla -Wformat=2 -Wno-format-nonliteral -Wshadow -Wformat-signedness -Wformat-overflow=2 -Wformat-truncation -Wlogical-op"
+    make lib CC="gcc" CFLAGS="-Os -std=c99 -Werror -Wall -Wextra -Wwrite-strings -Wpointer-arith -Wshadow -Wvla -Wformat=2 -Wno-format-nonliteral -Wshadow -Wformat-signedness -Wlogical-op"
 }
 
 component_build_aes_variations() { # ~45s

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -3372,6 +3372,7 @@ component_build_aes_variations() { # ~45s
     # unused variables/functions, so ensure -Wunused is set.
 
     msg "build: aes.o for all combinations of relevant config options"
+
     for a in set unset; do
     for b in set unset; do
     for c in set unset; do
@@ -3379,24 +3380,24 @@ component_build_aes_variations() { # ~45s
     for e in set unset; do
     for f in set unset; do
     for g in set unset; do
-    echo ./scripts/config.py $a MBEDTLS_AES_SETKEY_ENC_ALT
-    echo ./scripts/config.py $b MBEDTLS_AES_DECRYPT_ALT
-    echo ./scripts/config.py $c MBEDTLS_AES_ROM_TABLES
-    echo ./scripts/config.py $d MBEDTLS_AES_ENCRYPT_ALT
-    echo ./scripts/config.py $e MBEDTLS_AES_SETKEY_DEC_ALT
-    echo ./scripts/config.py $f MBEDTLS_AES_FEWER_TABLES
-    echo ./scripts/config.py $g MBEDTLS_PADLOCK_C
+        echo ./scripts/config.py $a MBEDTLS_AES_SETKEY_ENC_ALT
+        echo ./scripts/config.py $b MBEDTLS_AES_DECRYPT_ALT
+        echo ./scripts/config.py $c MBEDTLS_AES_ROM_TABLES
+        echo ./scripts/config.py $d MBEDTLS_AES_ENCRYPT_ALT
+        echo ./scripts/config.py $e MBEDTLS_AES_SETKEY_DEC_ALT
+        echo ./scripts/config.py $f MBEDTLS_AES_FEWER_TABLES
+        echo ./scripts/config.py $g MBEDTLS_PADLOCK_C
 
-    ./scripts/config.py $a MBEDTLS_AES_SETKEY_ENC_ALT
-    ./scripts/config.py $b MBEDTLS_AES_DECRYPT_ALT
-    ./scripts/config.py $c MBEDTLS_AES_ROM_TABLES
-    ./scripts/config.py $d MBEDTLS_AES_ENCRYPT_ALT
-    ./scripts/config.py $e MBEDTLS_AES_SETKEY_DEC_ALT
-    ./scripts/config.py $f MBEDTLS_AES_FEWER_TABLES
-    ./scripts/config.py $g MBEDTLS_PADLOCK_C
+        ./scripts/config.py $a MBEDTLS_AES_SETKEY_ENC_ALT
+        ./scripts/config.py $b MBEDTLS_AES_DECRYPT_ALT
+        ./scripts/config.py $c MBEDTLS_AES_ROM_TABLES
+        ./scripts/config.py $d MBEDTLS_AES_ENCRYPT_ALT
+        ./scripts/config.py $e MBEDTLS_AES_SETKEY_DEC_ALT
+        ./scripts/config.py $f MBEDTLS_AES_FEWER_TABLES
+        ./scripts/config.py $g MBEDTLS_PADLOCK_C
 
-    rm -f library/aes.o
-    make -C library aes.o CC="clang" CFLAGS="-O0 -std=c99 -Werror -Wall -Wextra -Wwrite-strings -Wpointer-arith -Wimplicit-fallthrough -Wshadow -Wvla -Wformat=2 -Wno-format-nonliteral -Wshadow -Wasm-operand-widths -Wunused"
+        rm -f library/aes.o
+        make -C library aes.o CC="clang" CFLAGS="-O0 -std=c99 -Werror -Wall -Wextra -Wwrite-strings -Wpointer-arith -Wimplicit-fallthrough -Wshadow -Wvla -Wformat=2 -Wno-format-nonliteral -Wshadow -Wasm-operand-widths -Wunused"
     done
     done
     done

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -3338,26 +3338,54 @@ component_build_psa_accel_key_type_rsa_public_key() {
 }
 
 
-support_build_tfm_armcc () {
+support_build_all_configs_armcc () {
     armc6_cc="$ARMC6_BIN_DIR/armclang"
     (check_tools "$armc6_cc" > /dev/null 2>&1)
 }
 
-component_build_tfm_armcc() {
-    # test the TF-M configuration can build cleanly with various warning flags enabled
-    cp configs/tfm_mbedcrypto_config_profile_medium.h include/mbedtls/mbedtls_config.h
-    cp configs/crypto_config_profile_medium.h         include/psa/crypto_config.h
+component_build_all_configs_armcc() { # ~ 45s
+    # Test that all config files in the configs directory will build cleanly
+    # on clang, gcc and armclang with various warnings enabled
 
-    msg "build: TF-M config, clang, armv8 thumb2"
-    make lib CC="clang" CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a32 -mthumb -Os -std=c99 -Werror -Wall -Wextra -Wwrite-strings -Wpointer-arith -Wimplicit-fallthrough -Wshadow -Wvla -Wformat=2 -Wno-format-nonliteral -Wshadow -Wasm-operand-widths -Wunused"
+    # backup config files
+    cp include/psa/crypto_config.h      include/psa/crypto_config.h.bak
+    cp include/mbedtls/mbedtls_config.h include/mbedtls/mbedtls_config.h.bak
 
-    msg "build: TF-M config, gcc native build"
-    make clean
-    make lib CC="gcc" CFLAGS="-Os -std=c99 -Werror -Wall -Wextra -Wwrite-strings -Wpointer-arith -Wimplicit-fallthrough -Wshadow -Wvla -Wformat=2 -Wno-format-nonliteral -Wshadow -Wformat-signedness -Wformat-overflow=2 -Wformat-truncation -Wlogical-op"
+    for c in configs/*.h; do
+        if [[ "$c" == "configs/crypto_config_profile_medium.h" ]]; then
+            # skip the crypto_config file
+            continue
+        fi
 
-    msg "build: TF-M config, armclang armv7 thumb2"
-    make clean
-    armc6_build_test "--target=arm-arm-none-eabi -march=armv7-m -mthumb -Os -std=c99 -Werror -Wall -Wextra -Wwrite-strings -Wpointer-arith -Wimplicit-fallthrough -Wshadow -Wvla -Wformat=2 -Wno-format-nonliteral -Wshadow -Wasm-operand-widths -Wunused"
+        msg "building config: ${c}"
+
+        # copy the configuration file(s) into place
+        cp ${c} include/mbedtls/mbedtls_config.h
+        if [[ "$c" == "configs/configs/tfm_mbedcrypto_config_profile_medium.h" ]]; then
+            # if using the TF-M main config file, also apply the associated crypto_config file
+            cp configs/crypto_config_profile_medium.h include/psa/crypto_config.h
+        fi
+
+        # test the configuration can build cleanly with various warning flags enabled
+        msg "build ${c}, clang, armv8 thumb2"
+        make lib CC="clang" CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a32 -mthumb -O0 -std=c99 -Werror -Wall -Wextra -Wwrite-strings -Wpointer-arith -Wimplicit-fallthrough -Wshadow -Wvla -Wformat=2 -Wno-format-nonliteral -Wshadow -Wasm-operand-widths -Wunused"
+
+        msg "build: ${c}, gcc native build"
+        make clean
+        make lib CC="gcc" CFLAGS="-O0 -std=c99 -Werror -Wall -Wextra -Wwrite-strings -Wpointer-arith -Wimplicit-fallthrough -Wshadow -Wvla -Wformat=2 -Wno-format-nonliteral -Wshadow -Wformat-signedness -Wformat-overflow=2 -Wformat-truncation -Wlogical-op"
+
+        msg "build: ${c}, armclang armv7 thumb2"
+        make clean
+        armc6_build_test "--target=arm-arm-none-eabi -march=armv7-m -mthumb -O0 -std=c99 -Werror -Wall -Wextra -Wwrite-strings -Wpointer-arith -Wimplicit-fallthrough -Wshadow -Wvla -Wformat=2 -Wno-format-nonliteral -Wshadow -Wasm-operand-widths -Wunused"
+
+        # restore config files
+        cp include/psa/crypto_config.h.bak      include/psa/crypto_config.h
+        cp include/mbedtls/mbedtls_config.h.bak include/mbedtls/mbedtls_config.h
+    done
+
+    # remove backup config files
+    rm include/psa/crypto_config.h.bak
+    rm include/mbedtls/mbedtls_config.h.bak
 }
 
 component_test_no_platform () {

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -3348,7 +3348,7 @@ component_build_tfm_armcc() {
     cp configs/tfm_mbedcrypto_config_profile_medium.h include/mbedtls/mbedtls_config.h
     cp configs/crypto_config_profile_medium.h         include/psa/crypto_config.h
 
-    msg "build: TF-M config, armclang armv7 thumb2"
+    msg "build: TF-M config, armclang armv7-m thumb2"
     make clean
     armc6_build_test "--target=arm-arm-none-eabi -march=armv7-m -mthumb -Os -std=c99 -Werror -Wall -Wextra -Wwrite-strings -Wpointer-arith -Wimplicit-fallthrough -Wshadow -Wvla -Wformat=2 -Wno-format-nonliteral -Wshadow -Wasm-operand-widths -Wunused"
 }
@@ -3358,8 +3358,8 @@ component_build_tfm() {
     cp configs/tfm_mbedcrypto_config_profile_medium.h include/mbedtls/mbedtls_config.h
     cp configs/crypto_config_profile_medium.h         include/psa/crypto_config.h
 
-    msg "build: TF-M config, clang, armv8 thumb2"
-    make lib CC="clang" CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a32 -mthumb -Os -std=c99 -Werror -Wall -Wextra -Wwrite-strings -Wpointer-arith -Wimplicit-fallthrough -Wshadow -Wvla -Wformat=2 -Wno-format-nonliteral -Wshadow -Wasm-operand-widths -Wunused"
+    msg "build: TF-M config, clang, armv7-m thumb2"
+    make lib CC="clang" CFLAGS="--target=arm-linux-gnueabihf -march=armv7-m -mthumb -Os -std=c99 -Werror -Wall -Wextra -Wwrite-strings -Wpointer-arith -Wimplicit-fallthrough -Wshadow -Wvla -Wformat=2 -Wno-format-nonliteral -Wshadow -Wasm-operand-widths -Wunused"
 
     msg "build: TF-M config, gcc native build"
     make clean

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -3360,6 +3360,42 @@ component_build_tfm_armcc() {
     armc6_build_test "--target=arm-arm-none-eabi -march=armv7-m -mthumb -Os -std=c99 -Werror -Wall -Wextra -Wwrite-strings -Wpointer-arith -Wimplicit-fallthrough -Wshadow -Wvla -Wformat=2 -Wno-format-nonliteral -Wshadow -Wasm-operand-widths -Wunused"
 }
 
+component_build_aes_variations() { # ~45s
+    msg "build: aes.o for all combinations of relevant config options"
+    for a in set unset; do
+    for b in set unset; do
+    for c in set unset; do
+    for d in set unset; do
+    for e in set unset; do
+    for f in set unset; do
+    for g in set unset; do
+    echo ./scripts/config.py $a MBEDTLS_AES_SETKEY_ENC_ALT
+    echo ./scripts/config.py $b MBEDTLS_AES_DECRYPT_ALT
+    echo ./scripts/config.py $c MBEDTLS_AES_ROM_TABLES
+    echo ./scripts/config.py $d MBEDTLS_AES_ENCRYPT_ALT
+    echo ./scripts/config.py $e MBEDTLS_AES_SETKEY_DEC_ALT
+    echo ./scripts/config.py $f MBEDTLS_AES_FEWER_TABLES
+    echo ./scripts/config.py $g MBEDTLS_PADLOCK_C
+
+    ./scripts/config.py $a MBEDTLS_AES_SETKEY_ENC_ALT
+    ./scripts/config.py $b MBEDTLS_AES_DECRYPT_ALT
+    ./scripts/config.py $c MBEDTLS_AES_ROM_TABLES
+    ./scripts/config.py $d MBEDTLS_AES_ENCRYPT_ALT
+    ./scripts/config.py $e MBEDTLS_AES_SETKEY_DEC_ALT
+    ./scripts/config.py $f MBEDTLS_AES_FEWER_TABLES
+    ./scripts/config.py $g MBEDTLS_PADLOCK_C
+
+    rm -f library/aes.o
+    make -C library aes.o CC="clang" CFLAGS="-O0 -std=c99 -Werror -Wall -Wextra -Wwrite-strings -Wpointer-arith -Wimplicit-fallthrough -Wshadow -Wvla -Wformat=2 -Wno-format-nonliteral -Wshadow -Wasm-operand-widths -Wunused"
+    done
+    done
+    done
+    done
+    done
+    done
+    done
+}
+
 component_test_no_platform () {
     # Full configuration build, without platform support, file IO and net sockets.
     # This should catch missing mbedtls_printf definitions, and by disabling file

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -3337,6 +3337,29 @@ component_build_psa_accel_key_type_rsa_public_key() {
     make CC=gcc CFLAGS="$ASAN_CFLAGS -DPSA_CRYPTO_DRIVER_TEST -DMBEDTLS_PSA_ACCEL_KEY_TYPE_RSA_PUBLIC_KEY -I../tests/include -O2" LDFLAGS="$ASAN_CFLAGS"
 }
 
+
+support_build_tfm_armcc () {
+    armc6_cc="$ARMC6_BIN_DIR/armclang"
+    (check_tools "$armc6_cc" > /dev/null 2>&1)
+}
+
+component_build_tfm_armcc() {
+    # test the TF-M configuration can build cleanly with various warning flags enabled
+    cp configs/tfm_mbedcrypto_config_profile_medium.h include/mbedtls/mbedtls_config.h
+    cp configs/crypto_config_profile_medium.h         include/psa/crypto_config.h
+
+    msg "build: TF-M config, clang, armv8 thumb2"
+    make lib CC="clang" CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a32 -mthumb -Os -std=c99 -Werror -Wall -Wextra -Wwrite-strings -Wpointer-arith -Wimplicit-fallthrough -Wshadow -Wvla -Wformat=2 -Wno-format-nonliteral -Wshadow -Wasm-operand-widths -Wunused"
+
+    msg "build: TF-M config, gcc native build"
+    make clean
+    make lib CC="gcc" CFLAGS="-Os -std=c99 -Werror -Wall -Wextra -Wwrite-strings -Wpointer-arith -Wimplicit-fallthrough -Wshadow -Wvla -Wformat=2 -Wno-format-nonliteral -Wshadow -Wformat-signedness -Wformat-overflow=2 -Wformat-truncation -Wlogical-op"
+
+    msg "build: TF-M config, armclang armv7 thumb2"
+    make clean
+    armc6_build_test "--target=arm-arm-none-eabi -march=armv7-m -mthumb -Os -std=c99 -Werror -Wall -Wextra -Wwrite-strings -Wpointer-arith -Wimplicit-fallthrough -Wshadow -Wvla -Wformat=2 -Wno-format-nonliteral -Wshadow -Wasm-operand-widths -Wunused"
+}
+
 component_test_no_platform () {
     # Full configuration build, without platform support, file IO and net sockets.
     # This should catch missing mbedtls_printf definitions, and by disabling file

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -3361,6 +3361,10 @@ component_build_tfm_armcc() {
 }
 
 component_build_aes_variations() { # ~45s
+    # aes.o has many #if defined(...) guards that intersect in complex ways.
+    # Test that all the combinations build cleanly. The most common issue is
+    # unused variables/functions, so ensure -Wunused is set.
+
     msg "build: aes.o for all combinations of relevant config options"
     for a in set unset; do
     for b in set unset; do

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -3348,16 +3348,22 @@ component_build_tfm_armcc() {
     cp configs/tfm_mbedcrypto_config_profile_medium.h include/mbedtls/mbedtls_config.h
     cp configs/crypto_config_profile_medium.h         include/psa/crypto_config.h
 
+    msg "build: TF-M config, armclang armv7 thumb2"
+    make clean
+    armc6_build_test "--target=arm-arm-none-eabi -march=armv7-m -mthumb -Os -std=c99 -Werror -Wall -Wextra -Wwrite-strings -Wpointer-arith -Wimplicit-fallthrough -Wshadow -Wvla -Wformat=2 -Wno-format-nonliteral -Wshadow -Wasm-operand-widths -Wunused"
+}
+
+component_build_tfm() {
+    # test the TF-M configuration can build cleanly with various warning flags enabled
+    cp configs/tfm_mbedcrypto_config_profile_medium.h include/mbedtls/mbedtls_config.h
+    cp configs/crypto_config_profile_medium.h         include/psa/crypto_config.h
+
     msg "build: TF-M config, clang, armv8 thumb2"
     make lib CC="clang" CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a32 -mthumb -Os -std=c99 -Werror -Wall -Wextra -Wwrite-strings -Wpointer-arith -Wimplicit-fallthrough -Wshadow -Wvla -Wformat=2 -Wno-format-nonliteral -Wshadow -Wasm-operand-widths -Wunused"
 
     msg "build: TF-M config, gcc native build"
     make clean
     make lib CC="gcc" CFLAGS="-Os -std=c99 -Werror -Wall -Wextra -Wwrite-strings -Wpointer-arith -Wimplicit-fallthrough -Wshadow -Wvla -Wformat=2 -Wno-format-nonliteral -Wshadow -Wformat-signedness -Wformat-overflow=2 -Wformat-truncation -Wlogical-op"
-
-    msg "build: TF-M config, armclang armv7 thumb2"
-    make clean
-    armc6_build_test "--target=arm-arm-none-eabi -march=armv7-m -mthumb -Os -std=c99 -Werror -Wall -Wextra -Wwrite-strings -Wpointer-arith -Wimplicit-fallthrough -Wshadow -Wvla -Wformat=2 -Wno-format-nonliteral -Wshadow -Wasm-operand-widths -Wunused"
 }
 
 component_build_aes_variations() { # ~45s


### PR DESCRIPTION
## Description

Fixes the build w.r.t. clang warnings for unused variables for all combinations of:

MBEDTLS_AES_SETKEY_ENC_ALT
MBEDTLS_AES_DECRYPT_ALT
MBEDTLS_AES_ROM_TABLES
MBEDTLS_AES_ENCRYPT_ALT
MBEDTLS_AES_SETKEY_DEC_ALT
MBEDTLS_AES_FEWER_TABLES
MBEDTLS_PADLOCK_C

I've tested every combination of the above - all 128 variations build cleanly.

With this PR, we build cleanly out-of-the-box for the TF-M config that we ship.


## PR checklist

- [x] **changelog** present
- [x] **backport** #7854 
- [x] **tests** provided build test in all.sh

