### PR TITLE
Fix AES dependencies - build TF-M config cleanly - backport 2.28

### DIFF
--- a/ChangeLog.d/fix-tfm-build.txt
+++ b/ChangeLog.d/fix-tfm-build.txt
@@ -1,0 +1,5 @@
+Bugfix
+   * Fix compilation warnings in aes.c, which prevented the
+     example TF-M configuration in configs/ from building cleanly:
+     tfm_mbedcrypto_config_profile_medium.h with 
+     crypto_config_profile_medium.h.

--- a/ChangeLog.d/fix-tfm-build.txt
+++ b/ChangeLog.d/fix-tfm-build.txt
@@ -1,5 +1,3 @@
 Bugfix
-   * Fix compilation warnings in aes.c, which prevented the
-     example TF-M configuration in configs/ from building cleanly:
-     tfm_mbedcrypto_config_profile_medium.h with
-     crypto_config_profile_medium.h.
+   * Fix compilation warnings in aes.c for certain combinations
+     of configuration options.

--- a/ChangeLog.d/fix-tfm-build.txt
+++ b/ChangeLog.d/fix-tfm-build.txt
@@ -1,5 +1,5 @@
 Bugfix
    * Fix compilation warnings in aes.c, which prevented the
      example TF-M configuration in configs/ from building cleanly:
-     tfm_mbedcrypto_config_profile_medium.h with 
+     tfm_mbedcrypto_config_profile_medium.h with
      crypto_config_profile_medium.h.

--- a/library/aes.c
+++ b/library/aes.c
@@ -95,8 +95,8 @@ static const unsigned char FSb[256] =
     0x8C, 0xA1, 0x89, 0x0D, 0xBF, 0xE6, 0x42, 0x68,
     0x41, 0x99, 0x2D, 0x0F, 0xB0, 0x54, 0xBB, 0x16
 };
-#endif \
-    /* !defined(MBEDTLS_AES_ENCRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_ENC_ALT) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT) */
+#endif /* !defined(MBEDTLS_AES_ENCRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_ENC_ALT) || \
+          !defined(MBEDTLS_AES_SETKEY_DEC_ALT) */
 
 /*
  * Forward tables
@@ -350,8 +350,8 @@ static const uint32_t RCON[10] =
 #if !defined(MBEDTLS_AES_ENCRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_ENC_ALT) || \
     !defined(MBEDTLS_AES_SETKEY_DEC_ALT)
 static unsigned char FSb[256];
-#endif \
-    /* !defined(MBEDTLS_AES_ENCRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_ENC_ALT) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT) */
+#endif /* !defined(MBEDTLS_AES_ENCRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_ENC_ALT) || \
+          !defined(MBEDTLS_AES_SETKEY_DEC_ALT) */
 #if !defined(MBEDTLS_AES_ENCRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_ENC_ALT)
 static uint32_t FT0[256];
 #if !defined(MBEDTLS_AES_FEWER_TABLES)
@@ -366,7 +366,7 @@ static uint32_t FT3[256];
  */
 #if !(defined(MBEDTLS_AES_SETKEY_ENC_ALT) && defined(MBEDTLS_AES_DECRYPT_ALT))
 static unsigned char RSb[256];
-#endif
+#endif /* !(defined(MBEDTLS_AES_SETKEY_ENC_ALT) && defined(MBEDTLS_AES_DECRYPT_ALT)) */
 
 #if !defined(MBEDTLS_AES_DECRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT)
 static uint32_t RT0[256];
@@ -591,8 +591,8 @@ static unsigned mbedtls_aes_rk_offset(uint32_t *buf)
 
     return 0;
 }
-#endif \
-    /* defined(MAY_NEED_TO_ALIGN) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT) || !defined(MBEDTLS_AES_SETKEY_ENC_ALT) */
+#endif /* defined(MAY_NEED_TO_ALIGN) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT) || \
+          !defined(MBEDTLS_AES_SETKEY_ENC_ALT) */
 
 /*
  * AES key schedule (encryption)

--- a/library/aes.c
+++ b/library/aes.c
@@ -186,6 +186,7 @@ static const uint32_t FT3[256] = { FT };
 
 #undef FT
 
+#if !(defined(MBEDTLS_AES_SETKEY_ENC_ALT) && defined(MBEDTLS_AES_DECRYPT_ALT))
 /*
  * Reverse S-box
  */
@@ -224,6 +225,7 @@ static const unsigned char RSb[256] =
     0x17, 0x2B, 0x04, 0x7E, 0xBA, 0x77, 0xD6, 0x26,
     0xE1, 0x69, 0x14, 0x63, 0x55, 0x21, 0x0C, 0x7D
 };
+#endif /* !(defined(MBEDTLS_AES_SETKEY_ENC_ALT) && defined(MBEDTLS_AES_DECRYPT_ALT)) */
 
 /*
  * Reverse tables
@@ -343,7 +345,9 @@ static uint32_t FT3[256];
 /*
  * Reverse S-box & tables
  */
+#if !(defined(MBEDTLS_AES_SETKEY_ENC_ALT) && defined(MBEDTLS_AES_DECRYPT_ALT))
 static unsigned char RSb[256];
+#endif
 static uint32_t RT0[256];
 #if !defined(MBEDTLS_AES_FEWER_TABLES)
 static uint32_t RT1[256];

--- a/library/aes.c
+++ b/library/aes.c
@@ -324,9 +324,9 @@ static const uint32_t RT2[256] = { RT };
 static const uint32_t RT3[256] = { RT };
 #undef V
 
-#endif /* !defined(MBEDTLS_AES_DECRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT) */
-
 #endif /* !MBEDTLS_AES_FEWER_TABLES */
+
+#endif /* !defined(MBEDTLS_AES_DECRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT) */
 
 #undef RT
 

--- a/library/aes.c
+++ b/library/aes.c
@@ -322,7 +322,7 @@ static const uint32_t RT2[256] = { RT };
 static const uint32_t RT3[256] = { RT };
 #undef V
 
-#endif /* !defined(MBEDTLS_AES_DECRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_DEC) */
+#endif /* !defined(MBEDTLS_AES_DECRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT) */
 
 #endif /* !MBEDTLS_AES_FEWER_TABLES */
 

--- a/library/aes.c
+++ b/library/aes.c
@@ -319,6 +319,7 @@ static const uint32_t RT3[256] = { RT };
 
 #undef RT
 
+#if !defined(MBEDTLS_AES_SETKEY_ENC_ALT)
 /*
  * Round constants
  */
@@ -328,6 +329,7 @@ static const uint32_t RCON[10] =
     0x00000010, 0x00000020, 0x00000040, 0x00000080,
     0x0000001B, 0x00000036
 };
+#endif /* !defined(MBEDTLS_AES_SETKEY_ENC_ALT) */
 
 #else /* MBEDTLS_AES_ROM_TABLES */
 

--- a/library/aes.c
+++ b/library/aes.c
@@ -187,9 +187,9 @@ static const uint32_t FT2[256] = { FT };
 static const uint32_t FT3[256] = { FT };
 #undef V
 
-#endif /* !defined(MBEDTLS_AES_ENCRYPT_ALT) */
-
 #endif /* !MBEDTLS_AES_FEWER_TABLES */
+
+#endif /* !defined(MBEDTLS_AES_ENCRYPT_ALT) */
 
 #undef FT
 

--- a/library/aes.c
+++ b/library/aes.c
@@ -58,7 +58,8 @@ static int aes_padlock_ace = -1;
 /*
  * Forward S-box
  */
-#if !defined(MBEDTLS_AES_ENCRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_ENC_ALT) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT)
+#if !defined(MBEDTLS_AES_ENCRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_ENC_ALT) || \
+    !defined(MBEDTLS_AES_SETKEY_DEC_ALT)
 static const unsigned char FSb[256] =
 {
     0x63, 0x7C, 0x77, 0x7B, 0xF2, 0x6B, 0x6F, 0xC5,
@@ -94,7 +95,8 @@ static const unsigned char FSb[256] =
     0x8C, 0xA1, 0x89, 0x0D, 0xBF, 0xE6, 0x42, 0x68,
     0x41, 0x99, 0x2D, 0x0F, 0xB0, 0x54, 0xBB, 0x16
 };
-#endif /* !defined(MBEDTLS_AES_ENCRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_ENC_ALT) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT) */
+#endif \
+    /* !defined(MBEDTLS_AES_ENCRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_ENC_ALT) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT) */
 
 /*
  * Forward tables
@@ -345,9 +347,11 @@ static const uint32_t RCON[10] =
 /*
  * Forward S-box & tables
  */
-#if !defined(MBEDTLS_AES_ENCRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_ENC_ALT) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT)
+#if !defined(MBEDTLS_AES_ENCRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_ENC_ALT) || \
+    !defined(MBEDTLS_AES_SETKEY_DEC_ALT)
 static unsigned char FSb[256];
-#endif /* !defined(MBEDTLS_AES_ENCRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_ENC_ALT) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT) */
+#endif \
+    /* !defined(MBEDTLS_AES_ENCRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_ENC_ALT) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT) */
 #if !defined(MBEDTLS_AES_ENCRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_ENC_ALT)
 static uint32_t FT0[256];
 #if !defined(MBEDTLS_AES_FEWER_TABLES)
@@ -549,7 +553,8 @@ void mbedtls_aes_xts_free(mbedtls_aes_xts_context *ctx)
 #define MAY_NEED_TO_ALIGN
 #endif
 
-#if defined(MAY_NEED_TO_ALIGN) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT) || !defined(MBEDTLS_AES_SETKEY_ENC_ALT)
+#if defined(MAY_NEED_TO_ALIGN) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT) || \
+    !defined(MBEDTLS_AES_SETKEY_ENC_ALT)
 static unsigned mbedtls_aes_rk_offset(uint32_t *buf)
 {
 #if defined(MAY_NEED_TO_ALIGN)
@@ -586,7 +591,8 @@ static unsigned mbedtls_aes_rk_offset(uint32_t *buf)
 
     return 0;
 }
-#endif /* defined(MAY_NEED_TO_ALIGN) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT) || !defined(MBEDTLS_AES_SETKEY_ENC_ALT) */
+#endif \
+    /* defined(MAY_NEED_TO_ALIGN) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT) || !defined(MBEDTLS_AES_SETKEY_ENC_ALT) */
 
 /*
  * AES key schedule (encryption)

--- a/library/aes.c
+++ b/library/aes.c
@@ -58,6 +58,7 @@ static int aes_padlock_ace = -1;
 /*
  * Forward S-box
  */
+#if !defined(MBEDTLS_AES_ENCRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_ENC_ALT) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT)
 static const unsigned char FSb[256] =
 {
     0x63, 0x7C, 0x77, 0x7B, 0xF2, 0x6B, 0x6F, 0xC5,
@@ -93,6 +94,7 @@ static const unsigned char FSb[256] =
     0x8C, 0xA1, 0x89, 0x0D, 0xBF, 0xE6, 0x42, 0x68,
     0x41, 0x99, 0x2D, 0x0F, 0xB0, 0x54, 0xBB, 0x16
 };
+#endif /* !defined(MBEDTLS_AES_ENCRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_ENC_ALT) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT) */
 
 /*
  * Forward tables
@@ -164,6 +166,7 @@ static const unsigned char FSb[256] =
     V(C3, 41, 41, 82), V(B0, 99, 99, 29), V(77, 2D, 2D, 5A), V(11, 0F, 0F, 1E), \
     V(CB, B0, B0, 7B), V(FC, 54, 54, A8), V(D6, BB, BB, 6D), V(3A, 16, 16, 2C)
 
+#if !defined(MBEDTLS_AES_ENCRYPT_ALT)
 #define V(a, b, c, d) 0x##a##b##c##d
 static const uint32_t FT0[256] = { FT };
 #undef V
@@ -182,11 +185,13 @@ static const uint32_t FT2[256] = { FT };
 static const uint32_t FT3[256] = { FT };
 #undef V
 
+#endif /* !defined(MBEDTLS_AES_ENCRYPT_ALT) */
+
 #endif /* !MBEDTLS_AES_FEWER_TABLES */
 
 #undef FT
 
-#if !(defined(MBEDTLS_AES_SETKEY_ENC_ALT) && defined(MBEDTLS_AES_DECRYPT_ALT))
+#if !defined(MBEDTLS_AES_DECRYPT_ALT)
 /*
  * Reverse S-box
  */
@@ -297,6 +302,8 @@ static const unsigned char RSb[256] =
     V(71, 01, A8, 39), V(DE, B3, 0C, 08), V(9C, E4, B4, D8), V(90, C1, 56, 64), \
     V(61, 84, CB, 7B), V(70, B6, 32, D5), V(74, 5C, 6C, 48), V(42, 57, B8, D0)
 
+#if !defined(MBEDTLS_AES_DECRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT)
+
 #define V(a, b, c, d) 0x##a##b##c##d
 static const uint32_t RT0[256] = { RT };
 #undef V
@@ -314,6 +321,8 @@ static const uint32_t RT2[256] = { RT };
 #define V(a, b, c, d) 0x##d##a##b##c
 static const uint32_t RT3[256] = { RT };
 #undef V
+
+#endif /* !defined(MBEDTLS_AES_DECRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_DEC) */
 
 #endif /* !MBEDTLS_AES_FEWER_TABLES */
 
@@ -336,13 +345,17 @@ static const uint32_t RCON[10] =
 /*
  * Forward S-box & tables
  */
+#if !defined(MBEDTLS_AES_ENCRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_ENC_ALT) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT)
 static unsigned char FSb[256];
+#endif /* !defined(MBEDTLS_AES_ENCRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_ENC_ALT) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT) */
+#if !defined(MBEDTLS_AES_ENCRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_ENC_ALT)
 static uint32_t FT0[256];
 #if !defined(MBEDTLS_AES_FEWER_TABLES)
 static uint32_t FT1[256];
 static uint32_t FT2[256];
 static uint32_t FT3[256];
 #endif /* !MBEDTLS_AES_FEWER_TABLES */
+#endif /* !defined(MBEDTLS_AES_ENCRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_ENC_ALT) */
 
 /*
  * Reverse S-box & tables
@@ -350,11 +363,14 @@ static uint32_t FT3[256];
 #if !(defined(MBEDTLS_AES_SETKEY_ENC_ALT) && defined(MBEDTLS_AES_DECRYPT_ALT))
 static unsigned char RSb[256];
 #endif
+
+#if !defined(MBEDTLS_AES_DECRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT)
 static uint32_t RT0[256];
 #if !defined(MBEDTLS_AES_FEWER_TABLES)
 static uint32_t RT1[256];
 static uint32_t RT2[256];
 static uint32_t RT3[256];
+#endif /* !defined(MBEDTLS_AES_DECRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT) */
 #endif /* !MBEDTLS_AES_FEWER_TABLES */
 
 #if !defined(MBEDTLS_AES_SETKEY_ENC_ALT)
@@ -435,6 +451,7 @@ static void aes_gen_tables(void)
 
         x = RSb[i];
 
+#if !defined(MBEDTLS_AES_DECRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT)
         RT0[i] = ((uint32_t) MUL(0x0E, x)) ^
                  ((uint32_t) MUL(0x09, x) <<  8) ^
                  ((uint32_t) MUL(0x0D, x) << 16) ^
@@ -445,6 +462,7 @@ static void aes_gen_tables(void)
         RT2[i] = ROTL8(RT1[i]);
         RT3[i] = ROTL8(RT2[i]);
 #endif /* !MBEDTLS_AES_FEWER_TABLES */
+#endif /* !defined(MBEDTLS_AES_DECRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT) */
     }
 }
 

--- a/library/aes.c
+++ b/library/aes.c
@@ -524,6 +524,8 @@ void mbedtls_aes_xts_free(mbedtls_aes_xts_context *ctx)
     (defined(MBEDTLS_AESNI_C) && MBEDTLS_AESNI_HAVE_CODE == 2)
 #define MAY_NEED_TO_ALIGN
 #endif
+
+#if defined(MAY_NEED_TO_ALIGN) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT) || !defined(MBEDTLS_AES_SETKEY_ENC_ALT)
 static unsigned mbedtls_aes_rk_offset(uint32_t *buf)
 {
 #if defined(MAY_NEED_TO_ALIGN)
@@ -560,6 +562,7 @@ static unsigned mbedtls_aes_rk_offset(uint32_t *buf)
 
     return 0;
 }
+#endif /* defined(MAY_NEED_TO_ALIGN) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT) || !defined(MBEDTLS_AES_SETKEY_ENC_ALT) */
 
 /*
  * AES key schedule (encryption)

--- a/library/aes.c
+++ b/library/aes.c
@@ -351,6 +351,7 @@ static uint32_t RT2[256];
 static uint32_t RT3[256];
 #endif /* !MBEDTLS_AES_FEWER_TABLES */
 
+#if !defined(MBEDTLS_AES_SETKEY_ENC_ALT)
 /*
  * Round constants
  */
@@ -440,6 +441,8 @@ static void aes_gen_tables(void)
 #endif /* !MBEDTLS_AES_FEWER_TABLES */
     }
 }
+
+#endif /* !defined(MBEDTLS_AES_SETKEY_ENC_ALT) */
 
 #undef ROTL8
 

--- a/library/aes.c
+++ b/library/aes.c
@@ -232,7 +232,7 @@ static const unsigned char RSb[256] =
     0x17, 0x2B, 0x04, 0x7E, 0xBA, 0x77, 0xD6, 0x26,
     0xE1, 0x69, 0x14, 0x63, 0x55, 0x21, 0x0C, 0x7D
 };
-#endif /* !(defined(MBEDTLS_AES_SETKEY_ENC_ALT) && defined(MBEDTLS_AES_DECRYPT_ALT)) */
+#endif /* defined(MBEDTLS_AES_DECRYPT_ALT)) */
 
 /*
  * Reverse tables
@@ -374,8 +374,8 @@ static uint32_t RT0[256];
 static uint32_t RT1[256];
 static uint32_t RT2[256];
 static uint32_t RT3[256];
-#endif /* !defined(MBEDTLS_AES_DECRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT) */
 #endif /* !MBEDTLS_AES_FEWER_TABLES */
+#endif /* !defined(MBEDTLS_AES_DECRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT) */
 
 #if !defined(MBEDTLS_AES_SETKEY_ENC_ALT)
 /*

--- a/library/ctr_drbg.c
+++ b/library/ctr_drbg.c
@@ -30,6 +30,7 @@
 #include "mbedtls/platform_util.h"
 #include "mbedtls/error.h"
 
+#include <limits.h>
 #include <string.h>
 
 #if defined(MBEDTLS_FS_IO)

--- a/library/entropy.c
+++ b/library/entropy.c
@@ -31,6 +31,8 @@
 #include "mbedtls/entropy_poll.h"
 #include "mbedtls/platform_util.h"
 #include "mbedtls/error.h"
+#include "mbedtls/sha256.h"
+#include "mbedtls/sha512.h"
 
 #include <string.h>
 

--- a/library/pkparse.c
+++ b/library/pkparse.c
@@ -1229,7 +1229,6 @@ int mbedtls_pk_parse_key(mbedtls_pk_context *pk,
                          const unsigned char *pwd, size_t pwdlen)
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
-    const mbedtls_pk_info_t *pk_info;
 #if defined(MBEDTLS_PEM_PARSE_C)
     size_t len;
     mbedtls_pem_context pem;
@@ -1256,6 +1255,7 @@ int mbedtls_pk_parse_key(mbedtls_pk_context *pk,
     }
 
     if (ret == 0) {
+        const mbedtls_pk_info_t *pk_info;
         pk_info = mbedtls_pk_info_from_type(MBEDTLS_PK_RSA);
         if ((ret = mbedtls_pk_setup(pk, pk_info)) != 0 ||
             (ret = pk_parse_key_pkcs1_der(mbedtls_pk_rsa(*pk),

--- a/library/pkparse.c
+++ b/library/pkparse.c
@@ -1229,10 +1229,13 @@ int mbedtls_pk_parse_key(mbedtls_pk_context *pk,
                          const unsigned char *pwd, size_t pwdlen)
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
+    const mbedtls_pk_info_t *pk_info;
 #if defined(MBEDTLS_PEM_PARSE_C)
     size_t len;
     mbedtls_pem_context pem;
 #endif
+
+    (void) pk_info;
 
     PK_VALIDATE_RET(pk != NULL);
     if (keylen == 0) {
@@ -1255,7 +1258,6 @@ int mbedtls_pk_parse_key(mbedtls_pk_context *pk,
     }
 
     if (ret == 0) {
-        const mbedtls_pk_info_t *pk_info;
         pk_info = mbedtls_pk_info_from_type(MBEDTLS_PK_RSA);
         if ((ret = mbedtls_pk_setup(pk, pk_info)) != 0 ||
             (ret = pk_parse_key_pkcs1_der(mbedtls_pk_rsa(*pk),

--- a/library/pkwrite.c
+++ b/library/pkwrite.c
@@ -175,8 +175,11 @@ exit:
 int mbedtls_pk_write_pubkey(unsigned char **p, unsigned char *start,
                             const mbedtls_pk_context *key)
 {
-    int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     size_t len = 0;
+
+    (void) p;
+    (void) start;
+    (void) key;
 
     PK_VALIDATE_RET(p != NULL);
     PK_VALIDATE_RET(*p != NULL);
@@ -312,6 +315,10 @@ int mbedtls_pk_write_key_der(mbedtls_pk_context *key, unsigned char *buf, size_t
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     unsigned char *c;
     size_t len = 0;
+
+    (void) ret;
+    (void) c;
+    (void) key;
 
     PK_VALIDATE_RET(key != NULL);
     if (size == 0) {

--- a/library/pkwrite.c
+++ b/library/pkwrite.c
@@ -175,11 +175,13 @@ exit:
 int mbedtls_pk_write_pubkey(unsigned char **p, unsigned char *start,
                             const mbedtls_pk_context *key)
 {
+    int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     size_t len = 0;
 
     (void) p;
     (void) start;
     (void) key;
+    (void) ret;
 
     PK_VALIDATE_RET(p != NULL);
     PK_VALIDATE_RET(*p != NULL);

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -2496,6 +2496,42 @@ component_test_check_params_silent () {
     make CC=gcc CFLAGS='-Werror -O1' all test
 }
 
+component_build_aes_variations() { # ~45s
+    msg "build: aes.o for all combinations of relevant config options"
+    for a in set unset; do
+    for b in set unset; do
+    for c in set unset; do
+    for d in set unset; do
+    for e in set unset; do
+    for f in set unset; do
+    for g in set unset; do
+    echo ./scripts/config.py $a MBEDTLS_AES_SETKEY_ENC_ALT
+    echo ./scripts/config.py $b MBEDTLS_AES_DECRYPT_ALT
+    echo ./scripts/config.py $c MBEDTLS_AES_ROM_TABLES
+    echo ./scripts/config.py $d MBEDTLS_AES_ENCRYPT_ALT
+    echo ./scripts/config.py $e MBEDTLS_AES_SETKEY_DEC_ALT
+    echo ./scripts/config.py $f MBEDTLS_AES_FEWER_TABLES
+    echo ./scripts/config.py $g MBEDTLS_PADLOCK_C
+
+    ./scripts/config.py $a MBEDTLS_AES_SETKEY_ENC_ALT
+    ./scripts/config.py $b MBEDTLS_AES_DECRYPT_ALT
+    ./scripts/config.py $c MBEDTLS_AES_ROM_TABLES
+    ./scripts/config.py $d MBEDTLS_AES_ENCRYPT_ALT
+    ./scripts/config.py $e MBEDTLS_AES_SETKEY_DEC_ALT
+    ./scripts/config.py $f MBEDTLS_AES_FEWER_TABLES
+    ./scripts/config.py $g MBEDTLS_PADLOCK_C
+
+    rm -f library/aes.o
+    make -C library aes.o CC="clang" CFLAGS="-O0 -std=c99 -Werror -Wall -Wextra -Wwrite-strings -Wpointer-arith -Wimplicit-fallthrough -Wshadow -Wvla -Wformat=2 -Wno-format-nonliteral -Wshadow -Wasm-operand-widths -Wunused"
+    done
+    done
+    done
+    done
+    done
+    done
+    done
+}
+
 component_test_no_platform () {
     # Full configuration build, without platform support, file IO and net sockets.
     # This should catch missing mbedtls_printf definitions, and by disabling file

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -2498,6 +2498,7 @@ component_test_check_params_silent () {
 
 component_build_aes_variations() { # ~45s
     msg "build: aes.o for all combinations of relevant config options"
+
     for a in set unset; do
     for b in set unset; do
     for c in set unset; do
@@ -2505,24 +2506,24 @@ component_build_aes_variations() { # ~45s
     for e in set unset; do
     for f in set unset; do
     for g in set unset; do
-    echo ./scripts/config.py $a MBEDTLS_AES_SETKEY_ENC_ALT
-    echo ./scripts/config.py $b MBEDTLS_AES_DECRYPT_ALT
-    echo ./scripts/config.py $c MBEDTLS_AES_ROM_TABLES
-    echo ./scripts/config.py $d MBEDTLS_AES_ENCRYPT_ALT
-    echo ./scripts/config.py $e MBEDTLS_AES_SETKEY_DEC_ALT
-    echo ./scripts/config.py $f MBEDTLS_AES_FEWER_TABLES
-    echo ./scripts/config.py $g MBEDTLS_PADLOCK_C
+        echo ./scripts/config.py $a MBEDTLS_AES_SETKEY_ENC_ALT
+        echo ./scripts/config.py $b MBEDTLS_AES_DECRYPT_ALT
+        echo ./scripts/config.py $c MBEDTLS_AES_ROM_TABLES
+        echo ./scripts/config.py $d MBEDTLS_AES_ENCRYPT_ALT
+        echo ./scripts/config.py $e MBEDTLS_AES_SETKEY_DEC_ALT
+        echo ./scripts/config.py $f MBEDTLS_AES_FEWER_TABLES
+        echo ./scripts/config.py $g MBEDTLS_PADLOCK_C
 
-    ./scripts/config.py $a MBEDTLS_AES_SETKEY_ENC_ALT
-    ./scripts/config.py $b MBEDTLS_AES_DECRYPT_ALT
-    ./scripts/config.py $c MBEDTLS_AES_ROM_TABLES
-    ./scripts/config.py $d MBEDTLS_AES_ENCRYPT_ALT
-    ./scripts/config.py $e MBEDTLS_AES_SETKEY_DEC_ALT
-    ./scripts/config.py $f MBEDTLS_AES_FEWER_TABLES
-    ./scripts/config.py $g MBEDTLS_PADLOCK_C
+        ./scripts/config.py $a MBEDTLS_AES_SETKEY_ENC_ALT
+        ./scripts/config.py $b MBEDTLS_AES_DECRYPT_ALT
+        ./scripts/config.py $c MBEDTLS_AES_ROM_TABLES
+        ./scripts/config.py $d MBEDTLS_AES_ENCRYPT_ALT
+        ./scripts/config.py $e MBEDTLS_AES_SETKEY_DEC_ALT
+        ./scripts/config.py $f MBEDTLS_AES_FEWER_TABLES
+        ./scripts/config.py $g MBEDTLS_PADLOCK_C
 
-    rm -f library/aes.o
-    make -C library aes.o CC="clang" CFLAGS="-O0 -std=c99 -Werror -Wall -Wextra -Wwrite-strings -Wpointer-arith -Wimplicit-fallthrough -Wshadow -Wvla -Wformat=2 -Wno-format-nonliteral -Wshadow -Wasm-operand-widths -Wunused"
+        rm -f library/aes.o
+        make -C library aes.o CC="clang" CFLAGS="-O0 -std=c99 -Werror -Wall -Wextra -Wwrite-strings -Wpointer-arith -Wimplicit-fallthrough -Wshadow -Wvla -Wformat=2 -Wno-format-nonliteral -Wshadow -Wasm-operand-widths -Wunused"
     done
     done
     done


### PR DESCRIPTION
## Description

Backport of #7851 , plus some extra fixes only needed for 2.28, and excluding the TF-M config build tests (because we don't ship the necessary configs in 2.28). Also includes the build-test for all `aes.c` variations.

It's still necessary to add `MBEDTLS_SHA256_C` to the TF-M config (to allow entropy.c to build) and to disable `MBEDTLS_PSA_CRYPTO_SPM`, but at least all of the warnings about unused variables, etc are addressed.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** provided
- [x] **backport** this is it
- [x] **tests** not required - covered by existing tests

