### PR TITLE
Make use of FFDH keys in TLS 1.3 - follow-up

### DIFF
--- a/library/ssl_client.c
+++ b/library/ssl_client.c
@@ -272,7 +272,7 @@ static int ssl_write_supported_groups_ext(mbedtls_ssl_context *ssl,
             }
 #endif
 #if defined(PSA_WANT_ALG_FFDH)
-            if (mbedtls_ssl_tls13_named_group_is_dhe(*group_list)) {
+            if (mbedtls_ssl_tls13_named_group_is_ffdh(*group_list)) {
                 propose_group = 1;
             }
 #endif

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -2125,7 +2125,7 @@ int mbedtls_ssl_reset_transcript_for_hrr(mbedtls_ssl_context *ssl);
 
 #if defined(PSA_WANT_ALG_ECDH) || defined(PSA_WANT_ALG_FFDH)
 MBEDTLS_CHECK_RETURN_CRITICAL
-int mbedtls_ssl_tls13_generate_and_write_dh_key_exchange(
+int mbedtls_ssl_tls13_generate_and_write_xxdh_key_exchange(
     mbedtls_ssl_context *ssl,
     uint16_t named_group,
     unsigned char *buf,

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -757,24 +757,24 @@ struct mbedtls_ssl_handshake_params {
 
 #if defined(PSA_WANT_ALG_ECDH) && defined(PSA_WANT_ALG_FFDH)
 #if (MBEDTLS_PSA_MAX_FFDH_PUBKEY_LENGTH >= MBEDTLS_PSA_MAX_EC_PUBKEY_LENGTH)
-#define DH_PSA_PEERKEY_SIZE MBEDTLS_PSA_MAX_FFDH_PUBKEY_LENGTH
+#define SSL_XXDH_PSA_PEERKEY_SIZE MBEDTLS_PSA_MAX_FFDH_PUBKEY_LENGTH
 #else
-#define DH_PSA_PEERKEY_SIZE MBEDTLS_PSA_MAX_EC_PUBKEY_LENGTH
+#define SSL_XXDH_PSA_PEERKEY_SIZE MBEDTLS_PSA_MAX_EC_PUBKEY_LENGTH
 #endif
 #elif defined(PSA_WANT_ALG_ECDH)
-#define DH_PSA_PEERKEY_SIZE MBEDTLS_PSA_MAX_EC_PUBKEY_LENGTH
+#define SSL_XXDH_PSA_PEERKEY_SIZE MBEDTLS_PSA_MAX_EC_PUBKEY_LENGTH
 #else
-#define DH_PSA_PEERKEY_SIZE MBEDTLS_PSA_MAX_FFDH_PUBKEY_LENGTH
+#define SSL_XXDH_PSA_PEERKEY_SIZE MBEDTLS_PSA_MAX_FFDH_PUBKEY_LENGTH
 #endif
 
 #if (defined(PSA_WANT_ALG_ECDH) || defined(PSA_WANT_ALG_FFDH)) && \
     (defined(MBEDTLS_USE_PSA_CRYPTO) || defined(MBEDTLS_SSL_PROTO_TLS1_3))
-    psa_key_type_t dh_psa_type;
-    size_t dh_bits;
-    mbedtls_svc_key_id_t dh_psa_privkey;
-    uint8_t dh_psa_privkey_is_external;
-    unsigned char dh_psa_peerkey[DH_PSA_PEERKEY_SIZE];
-    size_t dh_psa_peerkey_len;
+    psa_key_type_t xxdh_psa_type;
+    size_t xxdh_bits;
+    mbedtls_svc_key_id_t xxdh_psa_privkey;
+    uint8_t xxdh_psa_privkey_is_external;
+    unsigned char xxdh_psa_peerkey[SSL_XXDH_PSA_PEERKEY_SIZE];
+    size_t xxdh_psa_peerkey_len;
 #endif /* (PSA_WANT_ALG_ECDH || PSA_WANT_ALG_FFDH) &&
           (MBEDTLS_USE_PSA_CRYPTO || MBEDTLS_SSL_PROTO_TLS1_3) */
 
@@ -2660,7 +2660,7 @@ mbedtls_ssl_mode_t mbedtls_ssl_get_mode_from_ciphersuite(
 #if defined(PSA_WANT_ALG_ECDH) || defined(PSA_WANT_ALG_FFDH)
 
 MBEDTLS_CHECK_RETURN_CRITICAL
-int mbedtls_ssl_tls13_read_public_dhe_share(mbedtls_ssl_context *ssl,
+int mbedtls_ssl_tls13_read_public_xxdhe_share(mbedtls_ssl_context *ssl,
                                               const unsigned char *buf,
                                               size_t buf_len);
 

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -2223,7 +2223,7 @@ static inline int mbedtls_ssl_tls13_named_group_is_ecdhe(uint16_t named_group)
            named_group == MBEDTLS_SSL_IANA_TLS_GROUP_X448;
 }
 
-static inline int mbedtls_ssl_tls13_named_group_is_dhe(uint16_t named_group)
+static inline int mbedtls_ssl_tls13_named_group_is_ffdh(uint16_t named_group)
 {
     return named_group >= MBEDTLS_SSL_IANA_TLS_GROUP_FFDHE2048 &&
            named_group <= MBEDTLS_SSL_IANA_TLS_GROUP_FFDHE8192;
@@ -2258,7 +2258,7 @@ static inline int mbedtls_ssl_named_group_is_supported(uint16_t named_group)
     }
 #endif
 #if defined(PSA_WANT_ALG_FFDH)
-    if (mbedtls_ssl_tls13_named_group_is_dhe(named_group)) {
+    if (mbedtls_ssl_tls13_named_group_is_ffdh(named_group)) {
         return 1;
     }
 #endif
@@ -2660,7 +2660,7 @@ mbedtls_ssl_mode_t mbedtls_ssl_get_mode_from_ciphersuite(
 #if defined(PSA_WANT_ALG_ECDH) || defined(PSA_WANT_ALG_FFDH)
 
 MBEDTLS_CHECK_RETURN_CRITICAL
-int mbedtls_ssl_tls13_read_public_ecdhe_share(mbedtls_ssl_context *ssl,
+int mbedtls_ssl_tls13_read_public_dhe_share(mbedtls_ssl_context *ssl,
                                               const unsigned char *buf,
                                               size_t buf_len);
 

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -755,17 +755,25 @@ struct mbedtls_ssl_handshake_params {
     mbedtls_ecdh_context ecdh_ctx;              /*!<  ECDH key exchange       */
 #endif /* MBEDTLS_ECDH_C && !MBEDTLS_USE_PSA_CRYPTO */
 
+#if defined(PSA_WANT_ALG_ECDH) && defined(PSA_WANT_ALG_FFDH)
+#if (MBEDTLS_PSA_MAX_FFDH_PUBKEY_LENGTH >= MBEDTLS_PSA_MAX_EC_PUBKEY_LENGTH)
+#define DH_PSA_PEERKEY_SIZE MBEDTLS_PSA_MAX_FFDH_PUBKEY_LENGTH
+#else
+#define DH_PSA_PEERKEY_SIZE MBEDTLS_PSA_MAX_EC_PUBKEY_LENGTH
+#endif
+#elif defined(PSA_WANT_ALG_ECDH)
+#define DH_PSA_PEERKEY_SIZE MBEDTLS_PSA_MAX_EC_PUBKEY_LENGTH
+#else
+#define DH_PSA_PEERKEY_SIZE MBEDTLS_PSA_MAX_FFDH_PUBKEY_LENGTH
+#endif
+
 #if (defined(PSA_WANT_ALG_ECDH) || defined(PSA_WANT_ALG_FFDH)) && \
     (defined(MBEDTLS_USE_PSA_CRYPTO) || defined(MBEDTLS_SSL_PROTO_TLS1_3))
     psa_key_type_t ecdh_psa_type;
     size_t ecdh_bits;
     mbedtls_svc_key_id_t ecdh_psa_privkey;
     uint8_t ecdh_psa_privkey_is_external;
-#if defined(PSA_WANT_ALG_FFDH)
-    unsigned char ecdh_psa_peerkey[MBEDTLS_PSA_MAX_FFDH_PUBKEY_LENGTH];
-#else
-    unsigned char ecdh_psa_peerkey[MBEDTLS_PSA_MAX_EC_PUBKEY_LENGTH];
-#endif
+    unsigned char ecdh_psa_peerkey[DH_PSA_PEERKEY_SIZE];
     size_t ecdh_psa_peerkey_len;
 #endif /* (PSA_WANT_ALG_ECDH || PSA_WANT_ALG_FFDH) &&
           (MBEDTLS_USE_PSA_CRYPTO || MBEDTLS_SSL_PROTO_TLS1_3) */

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -769,12 +769,12 @@ struct mbedtls_ssl_handshake_params {
 
 #if (defined(PSA_WANT_ALG_ECDH) || defined(PSA_WANT_ALG_FFDH)) && \
     (defined(MBEDTLS_USE_PSA_CRYPTO) || defined(MBEDTLS_SSL_PROTO_TLS1_3))
-    psa_key_type_t ecdh_psa_type;
-    size_t ecdh_bits;
-    mbedtls_svc_key_id_t ecdh_psa_privkey;
-    uint8_t ecdh_psa_privkey_is_external;
-    unsigned char ecdh_psa_peerkey[DH_PSA_PEERKEY_SIZE];
-    size_t ecdh_psa_peerkey_len;
+    psa_key_type_t dh_psa_type;
+    size_t dh_bits;
+    mbedtls_svc_key_id_t dh_psa_privkey;
+    uint8_t dh_psa_privkey_is_external;
+    unsigned char dh_psa_peerkey[DH_PSA_PEERKEY_SIZE];
+    size_t dh_psa_peerkey_len;
 #endif /* (PSA_WANT_ALG_ECDH || PSA_WANT_ALG_FFDH) &&
           (MBEDTLS_USE_PSA_CRYPTO || MBEDTLS_SSL_PROTO_TLS1_3) */
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -4218,8 +4218,8 @@ void mbedtls_ssl_handshake_free(mbedtls_ssl_context *ssl)
 
 #if (defined(PSA_WANT_ALG_ECDH) || defined(PSA_WANT_ALG_FFDH)) && \
     (defined(MBEDTLS_USE_PSA_CRYPTO) || defined(MBEDTLS_SSL_PROTO_TLS1_3))
-    if (handshake->dh_psa_privkey_is_external == 0) {
-        psa_destroy_key(handshake->dh_psa_privkey);
+    if (handshake->xxdh_psa_privkey_is_external == 0) {
+        psa_destroy_key(handshake->xxdh_psa_privkey);
     }
 #endif /* (PSA_WANT_ALG_ECDH || PSA_WANT_ALG_FFDH) &&
           (MBEDTLS_USE_PSA_CRYPTO || MBEDTLS_SSL_PROTO_TLS1_3) */

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -4218,8 +4218,8 @@ void mbedtls_ssl_handshake_free(mbedtls_ssl_context *ssl)
 
 #if (defined(PSA_WANT_ALG_ECDH) || defined(PSA_WANT_ALG_FFDH)) && \
     (defined(MBEDTLS_USE_PSA_CRYPTO) || defined(MBEDTLS_SSL_PROTO_TLS1_3))
-    if (handshake->ecdh_psa_privkey_is_external == 0) {
-        psa_destroy_key(handshake->ecdh_psa_privkey);
+    if (handshake->dh_psa_privkey_is_external == 0) {
+        psa_destroy_key(handshake->dh_psa_privkey);
     }
 #endif /* (PSA_WANT_ALG_ECDH || PSA_WANT_ALG_FFDH) &&
           (MBEDTLS_USE_PSA_CRYPTO || MBEDTLS_SSL_PROTO_TLS1_3) */

--- a/library/ssl_tls12_client.c
+++ b/library/ssl_tls12_client.c
@@ -1779,7 +1779,8 @@ static int ssl_parse_server_ecdh_params(mbedtls_ssl_context *ssl,
         return MBEDTLS_ERR_SSL_HANDSHAKE_FAILURE;
     }
 #else
-    MBEDTLS_STATIC_ASSERT(sizeof(handshake->xxdh_psa_peerkey) >= UINT8_MAX, "peer key buffer too small");
+    MBEDTLS_STATIC_ASSERT(sizeof(handshake->xxdh_psa_peerkey) >= UINT8_MAX,
+                          "peer key buffer too small");
 #endif
 
     memcpy(handshake->xxdh_psa_peerkey, *p, ecpoint_len);

--- a/library/ssl_tls12_client.c
+++ b/library/ssl_tls12_client.c
@@ -1761,8 +1761,8 @@ static int ssl_parse_server_ecdh_params(mbedtls_ssl_context *ssl,
                                                    &ec_bits) == PSA_ERROR_NOT_SUPPORTED) {
         return MBEDTLS_ERR_SSL_HANDSHAKE_FAILURE;
     }
-    handshake->dh_psa_type = key_type;
-    handshake->dh_bits = ec_bits;
+    handshake->xxdh_psa_type = key_type;
+    handshake->xxdh_bits = ec_bits;
 
     /* Keep a copy of the peer's public key */
     ecpoint_len = *(*p)++;
@@ -1771,13 +1771,13 @@ static int ssl_parse_server_ecdh_params(mbedtls_ssl_context *ssl,
     }
 
 #if !defined(PSA_WANT_ALG_FFDH)
-    if (ecpoint_len > sizeof(handshake->dh_psa_peerkey)) {
+    if (ecpoint_len > sizeof(handshake->xxdh_psa_peerkey)) {
         return MBEDTLS_ERR_SSL_HANDSHAKE_FAILURE;
     }
 #endif
 
-    memcpy(handshake->dh_psa_peerkey, *p, ecpoint_len);
-    handshake->dh_psa_peerkey_len = ecpoint_len;
+    memcpy(handshake->xxdh_psa_peerkey, *p, ecpoint_len);
+    handshake->xxdh_psa_peerkey_len = ecpoint_len;
     *p += ecpoint_len;
 
     return 0;
@@ -2038,27 +2038,27 @@ static int ssl_get_ecdh_params_from_cert(mbedtls_ssl_context *ssl)
     /* If the above conversion to TLS ID was fine, then also this one will be,
        so there is no need to check the return value here */
     mbedtls_ssl_get_psa_curve_info_from_tls_id(tls_id, &key_type,
-                                               &ssl->handshake->dh_bits);
+                                               &ssl->handshake->xxdh_bits);
 
-    ssl->handshake->dh_psa_type = key_type;
+    ssl->handshake->xxdh_psa_type = key_type;
 
     /* Store peer's public key in psa format. */
 #if defined(MBEDTLS_PK_USE_PSA_EC_DATA)
-    memcpy(ssl->handshake->dh_psa_peerkey, peer_pk->pub_raw, peer_pk->pub_raw_len);
-    ssl->handshake->dh_psa_peerkey_len = peer_pk->pub_raw_len;
+    memcpy(ssl->handshake->xxdh_psa_peerkey, peer_pk->pub_raw, peer_pk->pub_raw_len);
+    ssl->handshake->xxdh_psa_peerkey_len = peer_pk->pub_raw_len;
     ret = 0;
 #else /* MBEDTLS_PK_USE_PSA_EC_DATA */
     size_t olen = 0;
     ret = mbedtls_ecp_point_write_binary(&peer_key->grp, &peer_key->Q,
                                          MBEDTLS_ECP_PF_UNCOMPRESSED, &olen,
-                                         ssl->handshake->dh_psa_peerkey,
+                                         ssl->handshake->xxdh_psa_peerkey,
                                          MBEDTLS_PSA_MAX_EC_PUBKEY_LENGTH);
 
     if (ret != 0) {
         MBEDTLS_SSL_DEBUG_RET(1, ("mbedtls_ecp_point_write_binary"), ret);
         return ret;
     }
-    ssl->handshake->dh_psa_peerkey_len = olen;
+    ssl->handshake->xxdh_psa_peerkey_len = olen;
 #endif /* MBEDTLS_PK_USE_PSA_EC_DATA */
 #else /* MBEDTLS_USE_PSA_CRYPTO */
     if ((ret = mbedtls_ecdh_get_params(&ssl->handshake->ecdh_ctx, peer_key,
@@ -2788,12 +2788,12 @@ static int ssl_write_client_key_exchange(mbedtls_ssl_context *ssl)
         key_attributes = psa_key_attributes_init();
         psa_set_key_usage_flags(&key_attributes, PSA_KEY_USAGE_DERIVE);
         psa_set_key_algorithm(&key_attributes, PSA_ALG_ECDH);
-        psa_set_key_type(&key_attributes, handshake->dh_psa_type);
-        psa_set_key_bits(&key_attributes, handshake->dh_bits);
+        psa_set_key_type(&key_attributes, handshake->xxdh_psa_type);
+        psa_set_key_bits(&key_attributes, handshake->xxdh_bits);
 
         /* Generate ECDH private key. */
         status = psa_generate_key(&key_attributes,
-                                  &handshake->dh_psa_privkey);
+                                  &handshake->xxdh_psa_privkey);
         if (status != PSA_SUCCESS) {
             return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
         }
@@ -2806,12 +2806,12 @@ static int ssl_write_client_key_exchange(mbedtls_ssl_context *ssl)
         size_t own_pubkey_max_len = (size_t) (end - own_pubkey);
         size_t own_pubkey_len;
 
-        status = psa_export_public_key(handshake->dh_psa_privkey,
+        status = psa_export_public_key(handshake->xxdh_psa_privkey,
                                        own_pubkey, own_pubkey_max_len,
                                        &own_pubkey_len);
         if (status != PSA_SUCCESS) {
-            psa_destroy_key(handshake->dh_psa_privkey);
-            handshake->dh_psa_privkey = MBEDTLS_SVC_KEY_ID_INIT;
+            psa_destroy_key(handshake->xxdh_psa_privkey);
+            handshake->xxdh_psa_privkey = MBEDTLS_SVC_KEY_ID_INIT;
             return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
         }
 
@@ -2822,15 +2822,15 @@ static int ssl_write_client_key_exchange(mbedtls_ssl_context *ssl)
 
         /* Compute ECDH shared secret. */
         status = psa_raw_key_agreement(PSA_ALG_ECDH,
-                                       handshake->dh_psa_privkey,
-                                       handshake->dh_psa_peerkey,
-                                       handshake->dh_psa_peerkey_len,
+                                       handshake->xxdh_psa_privkey,
+                                       handshake->xxdh_psa_peerkey,
+                                       handshake->xxdh_psa_peerkey_len,
                                        ssl->handshake->premaster,
                                        sizeof(ssl->handshake->premaster),
                                        &ssl->handshake->pmslen);
 
-        destruction_status = psa_destroy_key(handshake->dh_psa_privkey);
-        handshake->dh_psa_privkey = MBEDTLS_SVC_KEY_ID_INIT;
+        destruction_status = psa_destroy_key(handshake->xxdh_psa_privkey);
+        handshake->xxdh_psa_privkey = MBEDTLS_SVC_KEY_ID_INIT;
 
         if (status != PSA_SUCCESS || destruction_status != PSA_SUCCESS) {
             return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
@@ -2960,12 +2960,12 @@ ecdh_calc_secret:
         key_attributes = psa_key_attributes_init();
         psa_set_key_usage_flags(&key_attributes, PSA_KEY_USAGE_DERIVE);
         psa_set_key_algorithm(&key_attributes, PSA_ALG_ECDH);
-        psa_set_key_type(&key_attributes, handshake->dh_psa_type);
-        psa_set_key_bits(&key_attributes, handshake->dh_bits);
+        psa_set_key_type(&key_attributes, handshake->xxdh_psa_type);
+        psa_set_key_bits(&key_attributes, handshake->xxdh_bits);
 
         /* Generate ECDH private key. */
         status = psa_generate_key(&key_attributes,
-                                  &handshake->dh_psa_privkey);
+                                  &handshake->xxdh_psa_privkey);
         if (status != PSA_SUCCESS) {
             return PSA_TO_MBEDTLS_ERR(status);
         }
@@ -2978,12 +2978,12 @@ ecdh_calc_secret:
         size_t own_pubkey_max_len = (size_t) (end - own_pubkey);
         size_t own_pubkey_len = 0;
 
-        status = psa_export_public_key(handshake->dh_psa_privkey,
+        status = psa_export_public_key(handshake->xxdh_psa_privkey,
                                        own_pubkey, own_pubkey_max_len,
                                        &own_pubkey_len);
         if (status != PSA_SUCCESS) {
-            psa_destroy_key(handshake->dh_psa_privkey);
-            handshake->dh_psa_privkey = MBEDTLS_SVC_KEY_ID_INIT;
+            psa_destroy_key(handshake->xxdh_psa_privkey);
+            handshake->xxdh_psa_privkey = MBEDTLS_SVC_KEY_ID_INIT;
             return PSA_TO_MBEDTLS_ERR(status);
         }
 
@@ -3005,15 +3005,15 @@ ecdh_calc_secret:
 
         /* Perform ECDH computation after the uint16 reserved for the length */
         status = psa_raw_key_agreement(PSA_ALG_ECDH,
-                                       handshake->dh_psa_privkey,
-                                       handshake->dh_psa_peerkey,
-                                       handshake->dh_psa_peerkey_len,
+                                       handshake->xxdh_psa_privkey,
+                                       handshake->xxdh_psa_peerkey,
+                                       handshake->xxdh_psa_peerkey_len,
                                        pms + zlen_size,
                                        pms_end - (pms + zlen_size),
                                        &zlen);
 
-        destruction_status = psa_destroy_key(handshake->dh_psa_privkey);
-        handshake->dh_psa_privkey = MBEDTLS_SVC_KEY_ID_INIT;
+        destruction_status = psa_destroy_key(handshake->xxdh_psa_privkey);
+        handshake->xxdh_psa_privkey = MBEDTLS_SVC_KEY_ID_INIT;
 
         if (status != PSA_SUCCESS) {
             return PSA_TO_MBEDTLS_ERR(status);

--- a/library/ssl_tls12_client.c
+++ b/library/ssl_tls12_client.c
@@ -1761,8 +1761,8 @@ static int ssl_parse_server_ecdh_params(mbedtls_ssl_context *ssl,
                                                    &ec_bits) == PSA_ERROR_NOT_SUPPORTED) {
         return MBEDTLS_ERR_SSL_HANDSHAKE_FAILURE;
     }
-    handshake->ecdh_psa_type = key_type;
-    handshake->ecdh_bits = ec_bits;
+    handshake->dh_psa_type = key_type;
+    handshake->dh_bits = ec_bits;
 
     /* Keep a copy of the peer's public key */
     ecpoint_len = *(*p)++;
@@ -1771,13 +1771,13 @@ static int ssl_parse_server_ecdh_params(mbedtls_ssl_context *ssl,
     }
 
 #if !defined(PSA_WANT_ALG_FFDH)
-    if (ecpoint_len > sizeof(handshake->ecdh_psa_peerkey)) {
+    if (ecpoint_len > sizeof(handshake->dh_psa_peerkey)) {
         return MBEDTLS_ERR_SSL_HANDSHAKE_FAILURE;
     }
 #endif
 
-    memcpy(handshake->ecdh_psa_peerkey, *p, ecpoint_len);
-    handshake->ecdh_psa_peerkey_len = ecpoint_len;
+    memcpy(handshake->dh_psa_peerkey, *p, ecpoint_len);
+    handshake->dh_psa_peerkey_len = ecpoint_len;
     *p += ecpoint_len;
 
     return 0;
@@ -2038,27 +2038,27 @@ static int ssl_get_ecdh_params_from_cert(mbedtls_ssl_context *ssl)
     /* If the above conversion to TLS ID was fine, then also this one will be,
        so there is no need to check the return value here */
     mbedtls_ssl_get_psa_curve_info_from_tls_id(tls_id, &key_type,
-                                               &ssl->handshake->ecdh_bits);
+                                               &ssl->handshake->dh_bits);
 
-    ssl->handshake->ecdh_psa_type = key_type;
+    ssl->handshake->dh_psa_type = key_type;
 
     /* Store peer's public key in psa format. */
 #if defined(MBEDTLS_PK_USE_PSA_EC_DATA)
-    memcpy(ssl->handshake->ecdh_psa_peerkey, peer_pk->pub_raw, peer_pk->pub_raw_len);
-    ssl->handshake->ecdh_psa_peerkey_len = peer_pk->pub_raw_len;
+    memcpy(ssl->handshake->dh_psa_peerkey, peer_pk->pub_raw, peer_pk->pub_raw_len);
+    ssl->handshake->dh_psa_peerkey_len = peer_pk->pub_raw_len;
     ret = 0;
 #else /* MBEDTLS_PK_USE_PSA_EC_DATA */
     size_t olen = 0;
     ret = mbedtls_ecp_point_write_binary(&peer_key->grp, &peer_key->Q,
                                          MBEDTLS_ECP_PF_UNCOMPRESSED, &olen,
-                                         ssl->handshake->ecdh_psa_peerkey,
+                                         ssl->handshake->dh_psa_peerkey,
                                          MBEDTLS_PSA_MAX_EC_PUBKEY_LENGTH);
 
     if (ret != 0) {
         MBEDTLS_SSL_DEBUG_RET(1, ("mbedtls_ecp_point_write_binary"), ret);
         return ret;
     }
-    ssl->handshake->ecdh_psa_peerkey_len = olen;
+    ssl->handshake->dh_psa_peerkey_len = olen;
 #endif /* MBEDTLS_PK_USE_PSA_EC_DATA */
 #else /* MBEDTLS_USE_PSA_CRYPTO */
     if ((ret = mbedtls_ecdh_get_params(&ssl->handshake->ecdh_ctx, peer_key,
@@ -2788,12 +2788,12 @@ static int ssl_write_client_key_exchange(mbedtls_ssl_context *ssl)
         key_attributes = psa_key_attributes_init();
         psa_set_key_usage_flags(&key_attributes, PSA_KEY_USAGE_DERIVE);
         psa_set_key_algorithm(&key_attributes, PSA_ALG_ECDH);
-        psa_set_key_type(&key_attributes, handshake->ecdh_psa_type);
-        psa_set_key_bits(&key_attributes, handshake->ecdh_bits);
+        psa_set_key_type(&key_attributes, handshake->dh_psa_type);
+        psa_set_key_bits(&key_attributes, handshake->dh_bits);
 
         /* Generate ECDH private key. */
         status = psa_generate_key(&key_attributes,
-                                  &handshake->ecdh_psa_privkey);
+                                  &handshake->dh_psa_privkey);
         if (status != PSA_SUCCESS) {
             return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
         }
@@ -2806,12 +2806,12 @@ static int ssl_write_client_key_exchange(mbedtls_ssl_context *ssl)
         size_t own_pubkey_max_len = (size_t) (end - own_pubkey);
         size_t own_pubkey_len;
 
-        status = psa_export_public_key(handshake->ecdh_psa_privkey,
+        status = psa_export_public_key(handshake->dh_psa_privkey,
                                        own_pubkey, own_pubkey_max_len,
                                        &own_pubkey_len);
         if (status != PSA_SUCCESS) {
-            psa_destroy_key(handshake->ecdh_psa_privkey);
-            handshake->ecdh_psa_privkey = MBEDTLS_SVC_KEY_ID_INIT;
+            psa_destroy_key(handshake->dh_psa_privkey);
+            handshake->dh_psa_privkey = MBEDTLS_SVC_KEY_ID_INIT;
             return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
         }
 
@@ -2822,15 +2822,15 @@ static int ssl_write_client_key_exchange(mbedtls_ssl_context *ssl)
 
         /* Compute ECDH shared secret. */
         status = psa_raw_key_agreement(PSA_ALG_ECDH,
-                                       handshake->ecdh_psa_privkey,
-                                       handshake->ecdh_psa_peerkey,
-                                       handshake->ecdh_psa_peerkey_len,
+                                       handshake->dh_psa_privkey,
+                                       handshake->dh_psa_peerkey,
+                                       handshake->dh_psa_peerkey_len,
                                        ssl->handshake->premaster,
                                        sizeof(ssl->handshake->premaster),
                                        &ssl->handshake->pmslen);
 
-        destruction_status = psa_destroy_key(handshake->ecdh_psa_privkey);
-        handshake->ecdh_psa_privkey = MBEDTLS_SVC_KEY_ID_INIT;
+        destruction_status = psa_destroy_key(handshake->dh_psa_privkey);
+        handshake->dh_psa_privkey = MBEDTLS_SVC_KEY_ID_INIT;
 
         if (status != PSA_SUCCESS || destruction_status != PSA_SUCCESS) {
             return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
@@ -2960,12 +2960,12 @@ ecdh_calc_secret:
         key_attributes = psa_key_attributes_init();
         psa_set_key_usage_flags(&key_attributes, PSA_KEY_USAGE_DERIVE);
         psa_set_key_algorithm(&key_attributes, PSA_ALG_ECDH);
-        psa_set_key_type(&key_attributes, handshake->ecdh_psa_type);
-        psa_set_key_bits(&key_attributes, handshake->ecdh_bits);
+        psa_set_key_type(&key_attributes, handshake->dh_psa_type);
+        psa_set_key_bits(&key_attributes, handshake->dh_bits);
 
         /* Generate ECDH private key. */
         status = psa_generate_key(&key_attributes,
-                                  &handshake->ecdh_psa_privkey);
+                                  &handshake->dh_psa_privkey);
         if (status != PSA_SUCCESS) {
             return PSA_TO_MBEDTLS_ERR(status);
         }
@@ -2978,12 +2978,12 @@ ecdh_calc_secret:
         size_t own_pubkey_max_len = (size_t) (end - own_pubkey);
         size_t own_pubkey_len = 0;
 
-        status = psa_export_public_key(handshake->ecdh_psa_privkey,
+        status = psa_export_public_key(handshake->dh_psa_privkey,
                                        own_pubkey, own_pubkey_max_len,
                                        &own_pubkey_len);
         if (status != PSA_SUCCESS) {
-            psa_destroy_key(handshake->ecdh_psa_privkey);
-            handshake->ecdh_psa_privkey = MBEDTLS_SVC_KEY_ID_INIT;
+            psa_destroy_key(handshake->dh_psa_privkey);
+            handshake->dh_psa_privkey = MBEDTLS_SVC_KEY_ID_INIT;
             return PSA_TO_MBEDTLS_ERR(status);
         }
 
@@ -3005,15 +3005,15 @@ ecdh_calc_secret:
 
         /* Perform ECDH computation after the uint16 reserved for the length */
         status = psa_raw_key_agreement(PSA_ALG_ECDH,
-                                       handshake->ecdh_psa_privkey,
-                                       handshake->ecdh_psa_peerkey,
-                                       handshake->ecdh_psa_peerkey_len,
+                                       handshake->dh_psa_privkey,
+                                       handshake->dh_psa_peerkey,
+                                       handshake->dh_psa_peerkey_len,
                                        pms + zlen_size,
                                        pms_end - (pms + zlen_size),
                                        &zlen);
 
-        destruction_status = psa_destroy_key(handshake->ecdh_psa_privkey);
-        handshake->ecdh_psa_privkey = MBEDTLS_SVC_KEY_ID_INIT;
+        destruction_status = psa_destroy_key(handshake->dh_psa_privkey);
+        handshake->dh_psa_privkey = MBEDTLS_SVC_KEY_ID_INIT;
 
         if (status != PSA_SUCCESS) {
             return PSA_TO_MBEDTLS_ERR(status);

--- a/library/ssl_tls12_client.c
+++ b/library/ssl_tls12_client.c
@@ -1770,10 +1770,16 @@ static int ssl_parse_server_ecdh_params(mbedtls_ssl_context *ssl,
         return MBEDTLS_ERR_SSL_DECODE_ERROR;
     }
 
+    /* When FFDH is enabled, the array handshake->xxdh_psa_peer_key size takes into account
+       the sizes of the FFDH keys which are at least 2048 bits.
+       The size of the array is thus greater than 256 bytes which is greater than any
+       possible value of ecpoint_len (type uint8_t) and the check below can be skipped.*/
 #if !defined(PSA_WANT_ALG_FFDH)
     if (ecpoint_len > sizeof(handshake->xxdh_psa_peerkey)) {
         return MBEDTLS_ERR_SSL_HANDSHAKE_FAILURE;
     }
+#else
+    MBEDTLS_STATIC_ASSERT(sizeof(handshake->xxdh_psa_peerkey) >= UINT8_MAX, "peer key buffer too small");
 #endif
 
     memcpy(handshake->xxdh_psa_peerkey, *p, ecpoint_len);

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -2628,20 +2628,20 @@ static int ssl_get_ecdh_params_from_cert(mbedtls_ssl_context *ssl)
                 return MBEDTLS_ERR_SSL_PK_TYPE_MISMATCH;
             }
 
-            ssl->handshake->dh_psa_privkey = pk->priv_id;
+            ssl->handshake->xxdh_psa_privkey = pk->priv_id;
 
             /* Key should not be destroyed in the TLS library */
-            ssl->handshake->dh_psa_privkey_is_external = 1;
+            ssl->handshake->xxdh_psa_privkey_is_external = 1;
 
-            status = psa_get_key_attributes(ssl->handshake->dh_psa_privkey,
+            status = psa_get_key_attributes(ssl->handshake->xxdh_psa_privkey,
                                             &key_attributes);
             if (status != PSA_SUCCESS) {
-                ssl->handshake->dh_psa_privkey = MBEDTLS_SVC_KEY_ID_INIT;
+                ssl->handshake->xxdh_psa_privkey = MBEDTLS_SVC_KEY_ID_INIT;
                 return PSA_TO_MBEDTLS_ERR(status);
             }
 
-            ssl->handshake->dh_psa_type = psa_get_key_type(&key_attributes);
-            ssl->handshake->dh_bits = psa_get_key_bits(&key_attributes);
+            ssl->handshake->xxdh_psa_type = psa_get_key_type(&key_attributes);
+            ssl->handshake->xxdh_bits = psa_get_key_bits(&key_attributes);
 
             psa_reset_key_attributes(&key_attributes);
 
@@ -2665,16 +2665,16 @@ static int ssl_get_ecdh_params_from_cert(mbedtls_ssl_context *ssl)
             /* If the above conversion to TLS ID was fine, then also this one will
                be, so there is no need to check the return value here */
             mbedtls_ssl_get_psa_curve_info_from_tls_id(tls_id, &key_type,
-                                                       &ssl->handshake->dh_bits);
+                                                       &ssl->handshake->xxdh_bits);
 
-            ssl->handshake->dh_psa_type = key_type;
+            ssl->handshake->xxdh_psa_type = key_type;
 
             key_attributes = psa_key_attributes_init();
             psa_set_key_usage_flags(&key_attributes, PSA_KEY_USAGE_DERIVE);
             psa_set_key_algorithm(&key_attributes, PSA_ALG_ECDH);
             psa_set_key_type(&key_attributes,
-                             PSA_KEY_TYPE_ECC_KEY_PAIR(ssl->handshake->dh_psa_type));
-            psa_set_key_bits(&key_attributes, ssl->handshake->dh_bits);
+                             PSA_KEY_TYPE_ECC_KEY_PAIR(ssl->handshake->xxdh_psa_type));
+            psa_set_key_bits(&key_attributes, ssl->handshake->xxdh_bits);
 
             key_len = PSA_BITS_TO_BYTES(key->grp.pbits);
             ret = mbedtls_ecp_write_key(key, buf, key_len);
@@ -2684,7 +2684,7 @@ static int ssl_get_ecdh_params_from_cert(mbedtls_ssl_context *ssl)
             }
 
             status = psa_import_key(&key_attributes, buf, key_len,
-                                    &ssl->handshake->dh_psa_privkey);
+                                    &ssl->handshake->xxdh_psa_privkey);
             if (status != PSA_SUCCESS) {
                 ret = PSA_TO_MBEDTLS_ERR(status);
                 mbedtls_platform_zeroize(buf, sizeof(buf));
@@ -2981,14 +2981,14 @@ curve_matching_done:
             MBEDTLS_SSL_DEBUG_MSG(1, ("Invalid ecc group parse."));
             return MBEDTLS_ERR_SSL_ILLEGAL_PARAMETER;
         }
-        handshake->dh_psa_type = key_type;
-        handshake->dh_bits = ec_bits;
+        handshake->xxdh_psa_type = key_type;
+        handshake->xxdh_bits = ec_bits;
 
         key_attributes = psa_key_attributes_init();
         psa_set_key_usage_flags(&key_attributes, PSA_KEY_USAGE_DERIVE);
         psa_set_key_algorithm(&key_attributes, PSA_ALG_ECDH);
-        psa_set_key_type(&key_attributes, handshake->dh_psa_type);
-        psa_set_key_bits(&key_attributes, handshake->dh_bits);
+        psa_set_key_type(&key_attributes, handshake->xxdh_psa_type);
+        psa_set_key_bits(&key_attributes, handshake->xxdh_bits);
 
         /*
          * ECParameters curve_params
@@ -3005,7 +3005,7 @@ curve_matching_done:
 
         /* Generate ECDH private key. */
         status = psa_generate_key(&key_attributes,
-                                  &handshake->dh_psa_privkey);
+                                  &handshake->xxdh_psa_privkey);
         if (status != PSA_SUCCESS) {
             ret = PSA_TO_MBEDTLS_ERR(status);
             MBEDTLS_SSL_DEBUG_RET(1, "psa_generate_key", ret);
@@ -3027,14 +3027,14 @@ curve_matching_done:
         size_t own_pubkey_max_len = (size_t) (MBEDTLS_SSL_OUT_CONTENT_LEN
                                               - (own_pubkey - ssl->out_msg));
 
-        status = psa_export_public_key(handshake->dh_psa_privkey,
+        status = psa_export_public_key(handshake->xxdh_psa_privkey,
                                        own_pubkey, own_pubkey_max_len,
                                        &len);
         if (status != PSA_SUCCESS) {
             ret = PSA_TO_MBEDTLS_ERR(status);
             MBEDTLS_SSL_DEBUG_RET(1, "psa_export_public_key", ret);
-            (void) psa_destroy_key(handshake->dh_psa_privkey);
-            handshake->dh_psa_privkey = MBEDTLS_SVC_KEY_ID_INIT;
+            (void) psa_destroy_key(handshake->xxdh_psa_privkey);
+            handshake->xxdh_psa_privkey = MBEDTLS_SVC_KEY_ID_INIT;
             return ret;
         }
 
@@ -3729,27 +3729,27 @@ static int ssl_parse_client_key_exchange(mbedtls_ssl_context *ssl)
         }
 
         /* Store peer's ECDH public key. */
-        memcpy(handshake->dh_psa_peerkey, p, data_len);
-        handshake->dh_psa_peerkey_len = data_len;
+        memcpy(handshake->xxdh_psa_peerkey, p, data_len);
+        handshake->xxdh_psa_peerkey_len = data_len;
 
         /* Compute ECDH shared secret. */
         status = psa_raw_key_agreement(
-            PSA_ALG_ECDH, handshake->dh_psa_privkey,
-            handshake->dh_psa_peerkey, handshake->dh_psa_peerkey_len,
+            PSA_ALG_ECDH, handshake->xxdh_psa_privkey,
+            handshake->xxdh_psa_peerkey, handshake->xxdh_psa_peerkey_len,
             handshake->premaster, sizeof(handshake->premaster),
             &handshake->pmslen);
         if (status != PSA_SUCCESS) {
             ret = PSA_TO_MBEDTLS_ERR(status);
             MBEDTLS_SSL_DEBUG_RET(1, "psa_raw_key_agreement", ret);
-            if (handshake->dh_psa_privkey_is_external == 0) {
-                (void) psa_destroy_key(handshake->dh_psa_privkey);
+            if (handshake->xxdh_psa_privkey_is_external == 0) {
+                (void) psa_destroy_key(handshake->xxdh_psa_privkey);
             }
-            handshake->dh_psa_privkey = MBEDTLS_SVC_KEY_ID_INIT;
+            handshake->xxdh_psa_privkey = MBEDTLS_SVC_KEY_ID_INIT;
             return ret;
         }
 
-        if (handshake->dh_psa_privkey_is_external == 0) {
-            status = psa_destroy_key(handshake->dh_psa_privkey);
+        if (handshake->xxdh_psa_privkey_is_external == 0) {
+            status = psa_destroy_key(handshake->xxdh_psa_privkey);
 
             if (status != PSA_SUCCESS) {
                 ret = PSA_TO_MBEDTLS_ERR(status);
@@ -3757,7 +3757,7 @@ static int ssl_parse_client_key_exchange(mbedtls_ssl_context *ssl)
                 return ret;
             }
         }
-        handshake->dh_psa_privkey = MBEDTLS_SVC_KEY_ID_INIT;
+        handshake->xxdh_psa_privkey = MBEDTLS_SVC_KEY_ID_INIT;
 #else
         if ((ret = mbedtls_ecdh_read_public(&ssl->handshake->ecdh_ctx,
                                             p, end - p)) != 0) {
@@ -3890,35 +3890,35 @@ static int ssl_parse_client_key_exchange(mbedtls_ssl_context *ssl)
 
         if ((ret = ssl_parse_client_psk_identity(ssl, &p, end)) != 0) {
             MBEDTLS_SSL_DEBUG_RET(1, ("ssl_parse_client_psk_identity"), ret);
-            psa_destroy_key(handshake->dh_psa_privkey);
-            handshake->dh_psa_privkey = MBEDTLS_SVC_KEY_ID_INIT;
+            psa_destroy_key(handshake->xxdh_psa_privkey);
+            handshake->xxdh_psa_privkey = MBEDTLS_SVC_KEY_ID_INIT;
             return ret;
         }
 
         /* Keep a copy of the peer's public key */
         if (p >= end) {
-            psa_destroy_key(handshake->dh_psa_privkey);
-            handshake->dh_psa_privkey = MBEDTLS_SVC_KEY_ID_INIT;
+            psa_destroy_key(handshake->xxdh_psa_privkey);
+            handshake->xxdh_psa_privkey = MBEDTLS_SVC_KEY_ID_INIT;
             return MBEDTLS_ERR_SSL_DECODE_ERROR;
         }
 
         ecpoint_len = *(p++);
         if ((size_t) (end - p) < ecpoint_len) {
-            psa_destroy_key(handshake->dh_psa_privkey);
-            handshake->dh_psa_privkey = MBEDTLS_SVC_KEY_ID_INIT;
+            psa_destroy_key(handshake->xxdh_psa_privkey);
+            handshake->xxdh_psa_privkey = MBEDTLS_SVC_KEY_ID_INIT;
             return MBEDTLS_ERR_SSL_DECODE_ERROR;
         }
 
 #if !defined(PSA_WANT_ALG_FFDH)
-        if (ecpoint_len > sizeof(handshake->dh_psa_peerkey)) {
-            psa_destroy_key(handshake->dh_psa_privkey);
-            handshake->dh_psa_privkey = MBEDTLS_SVC_KEY_ID_INIT;
+        if (ecpoint_len > sizeof(handshake->xxdh_psa_peerkey)) {
+            psa_destroy_key(handshake->xxdh_psa_privkey);
+            handshake->xxdh_psa_privkey = MBEDTLS_SVC_KEY_ID_INIT;
             return MBEDTLS_ERR_SSL_HANDSHAKE_FAILURE;
         }
 #endif
 
-        memcpy(handshake->dh_psa_peerkey, p, ecpoint_len);
-        handshake->dh_psa_peerkey_len = ecpoint_len;
+        memcpy(handshake->xxdh_psa_peerkey, p, ecpoint_len);
+        handshake->xxdh_psa_peerkey_len = ecpoint_len;
         p += ecpoint_len;
 
         /* As RFC 5489 section 2, the premaster secret is formed as follows:
@@ -3936,15 +3936,15 @@ static int ssl_parse_client_key_exchange(mbedtls_ssl_context *ssl)
 
         /* Compute ECDH shared secret. */
         status = psa_raw_key_agreement(PSA_ALG_ECDH,
-                                       handshake->dh_psa_privkey,
-                                       handshake->dh_psa_peerkey,
-                                       handshake->dh_psa_peerkey_len,
+                                       handshake->xxdh_psa_privkey,
+                                       handshake->xxdh_psa_peerkey,
+                                       handshake->xxdh_psa_peerkey_len,
                                        psm + zlen_size,
                                        psm_end - (psm + zlen_size),
                                        &zlen);
 
-        destruction_status = psa_destroy_key(handshake->dh_psa_privkey);
-        handshake->dh_psa_privkey = MBEDTLS_SVC_KEY_ID_INIT;
+        destruction_status = psa_destroy_key(handshake->xxdh_psa_privkey);
+        handshake->xxdh_psa_privkey = MBEDTLS_SVC_KEY_ID_INIT;
 
         if (status != PSA_SUCCESS) {
             return PSA_TO_MBEDTLS_ERR(status);

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -3909,10 +3909,10 @@ static int ssl_parse_client_key_exchange(mbedtls_ssl_context *ssl)
             return MBEDTLS_ERR_SSL_DECODE_ERROR;
         }
 
-    /* When FFDH is enabled, the array handshake->xxdh_psa_peer_key size takes into account
-       the sizes of the FFDH keys which are at least 2048 bits.
-       The size of the array is thus greater than 256 bytes which is greater than any
-       possible value of ecpoint_len (type uint8_t) and the check below can be skipped.*/
+        /* When FFDH is enabled, the array handshake->xxdh_psa_peer_key size takes into account
+           the sizes of the FFDH keys which are at least 2048 bits.
+           The size of the array is thus greater than 256 bytes which is greater than any
+           possible value of ecpoint_len (type uint8_t) and the check below can be skipped.*/
 #if !defined(PSA_WANT_ALG_FFDH)
         if (ecpoint_len > sizeof(handshake->xxdh_psa_peerkey)) {
             psa_destroy_key(handshake->xxdh_psa_privkey);
@@ -3920,7 +3920,8 @@ static int ssl_parse_client_key_exchange(mbedtls_ssl_context *ssl)
             return MBEDTLS_ERR_SSL_HANDSHAKE_FAILURE;
         }
 #else
-    MBEDTLS_STATIC_ASSERT(sizeof(handshake->xxdh_psa_peerkey) >= UINT8_MAX, "peer key buffer too small");
+        MBEDTLS_STATIC_ASSERT(sizeof(handshake->xxdh_psa_peerkey) >= UINT8_MAX,
+                              "peer key buffer too small");
 #endif
 
         memcpy(handshake->xxdh_psa_peerkey, p, ecpoint_len);

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -196,7 +196,7 @@ static int ssl_tls13_reset_key_share(mbedtls_ssl_context *ssl)
 
 #if defined(PSA_WANT_ALG_ECDH) || defined(PSA_WANT_ALG_FFDH)
     if (mbedtls_ssl_tls13_named_group_is_ecdhe(group_id) ||
-        mbedtls_ssl_tls13_named_group_is_dhe(group_id)) {
+        mbedtls_ssl_tls13_named_group_is_ffdh(group_id)) {
         int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
         psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
 
@@ -247,7 +247,7 @@ static int ssl_tls13_get_default_group_id(mbedtls_ssl_context *ssl,
         }
 #endif
 #if defined(PSA_WANT_ALG_FFDH)
-        if (mbedtls_ssl_tls13_named_group_is_dhe(*group_list)) {
+        if (mbedtls_ssl_tls13_named_group_is_ffdh(*group_list)) {
             *group_id = *group_list;
             return 0;
         }
@@ -301,7 +301,7 @@ static int ssl_tls13_write_key_share_ext(mbedtls_ssl_context *ssl,
     /* HRR could already have requested something else. */
     group_id = ssl->handshake->offered_group_id;
     if (!mbedtls_ssl_tls13_named_group_is_ecdhe(group_id) &&
-        !mbedtls_ssl_tls13_named_group_is_dhe(group_id)) {
+        !mbedtls_ssl_tls13_named_group_is_ffdh(group_id)) {
         MBEDTLS_SSL_PROC_CHK(ssl_tls13_get_default_group_id(ssl,
                                                             &group_id));
     }
@@ -317,7 +317,7 @@ static int ssl_tls13_write_key_share_ext(mbedtls_ssl_context *ssl,
     client_shares = p;
 #if defined(PSA_WANT_ALG_ECDH) || defined(PSA_WANT_ALG_FFDH)
     if (mbedtls_ssl_tls13_named_group_is_ecdhe(group_id) ||
-        mbedtls_ssl_tls13_named_group_is_dhe(group_id)) {
+        mbedtls_ssl_tls13_named_group_is_ffdh(group_id)) {
         /* Pointer to group */
         unsigned char *group = p;
         /* Length of key_exchange */
@@ -429,7 +429,7 @@ static int ssl_tls13_parse_hrr_key_share_ext(mbedtls_ssl_context *ssl,
         }
 #endif /* PSA_WANT_ALG_ECDH */
 #if defined(PSA_WANT_ALG_FFDH)
-        if (mbedtls_ssl_tls13_named_group_is_dhe(*group_list)) {
+        if (mbedtls_ssl_tls13_named_group_is_ffdh(*group_list)) {
             found = 1;
             break;
         }
@@ -505,10 +505,10 @@ static int ssl_tls13_parse_key_share_ext(mbedtls_ssl_context *ssl,
 
 #if defined(PSA_WANT_ALG_ECDH) || defined(PSA_WANT_ALG_FFDH)
     if (mbedtls_ssl_tls13_named_group_is_ecdhe(group) ||
-        mbedtls_ssl_tls13_named_group_is_dhe(group)) {
+        mbedtls_ssl_tls13_named_group_is_ffdh(group)) {
         MBEDTLS_SSL_DEBUG_MSG(2,
                               ("DHE group name: %s", mbedtls_ssl_named_group_to_str(group)));
-        ret = mbedtls_ssl_tls13_read_public_ecdhe_share(ssl, p, end - p);
+        ret = mbedtls_ssl_tls13_read_public_dhe_share(ssl, p, end - p);
         if (ret != 0) {
             return ret;
         }

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -201,14 +201,14 @@ static int ssl_tls13_reset_key_share(mbedtls_ssl_context *ssl)
         psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
 
         /* Destroy generated private key. */
-        status = psa_destroy_key(ssl->handshake->dh_psa_privkey);
+        status = psa_destroy_key(ssl->handshake->xxdh_psa_privkey);
         if (status != PSA_SUCCESS) {
             ret = PSA_TO_MBEDTLS_ERR(status);
             MBEDTLS_SSL_DEBUG_RET(1, "psa_destroy_key", ret);
             return ret;
         }
 
-        ssl->handshake->dh_psa_privkey = MBEDTLS_SVC_KEY_ID_INIT;
+        ssl->handshake->xxdh_psa_privkey = MBEDTLS_SVC_KEY_ID_INIT;
         return 0;
     } else
 #endif /* PSA_WANT_ALG_ECDH || PSA_WANT_ALG_FFDH */
@@ -508,7 +508,7 @@ static int ssl_tls13_parse_key_share_ext(mbedtls_ssl_context *ssl,
         mbedtls_ssl_tls13_named_group_is_ffdh(group)) {
         MBEDTLS_SSL_DEBUG_MSG(2,
                               ("DHE group name: %s", mbedtls_ssl_named_group_to_str(group)));
-        ret = mbedtls_ssl_tls13_read_public_dhe_share(ssl, p, end - p);
+        ret = mbedtls_ssl_tls13_read_public_xxdhe_share(ssl, p, end - p);
         if (ret != 0) {
             return ret;
         }

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -201,14 +201,14 @@ static int ssl_tls13_reset_key_share(mbedtls_ssl_context *ssl)
         psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
 
         /* Destroy generated private key. */
-        status = psa_destroy_key(ssl->handshake->ecdh_psa_privkey);
+        status = psa_destroy_key(ssl->handshake->dh_psa_privkey);
         if (status != PSA_SUCCESS) {
             ret = PSA_TO_MBEDTLS_ERR(status);
             MBEDTLS_SSL_DEBUG_RET(1, "psa_destroy_key", ret);
             return ret;
         }
 
-        ssl->handshake->ecdh_psa_privkey = MBEDTLS_SVC_KEY_ID_INIT;
+        ssl->handshake->dh_psa_privkey = MBEDTLS_SVC_KEY_ID_INIT;
         return 0;
     } else
 #endif /* PSA_WANT_ALG_ECDH || PSA_WANT_ALG_FFDH */

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -329,7 +329,7 @@ static int ssl_tls13_write_key_share_ext(mbedtls_ssl_context *ssl,
          */
         MBEDTLS_SSL_CHK_BUF_PTR(p, end, 4);
         p += 4;
-        ret = mbedtls_ssl_tls13_generate_and_write_dh_key_exchange(
+        ret = mbedtls_ssl_tls13_generate_and_write_xxdh_key_exchange(
             ssl, group_id, p, end, &key_exchange_len);
         p += key_exchange_len;
         if (ret != 0) {

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -1499,7 +1499,7 @@ int mbedtls_ssl_reset_transcript_for_hrr(mbedtls_ssl_context *ssl)
 
 #if defined(PSA_WANT_ALG_ECDH) || defined(PSA_WANT_ALG_FFDH)
 
-int mbedtls_ssl_tls13_read_public_ecdhe_share(mbedtls_ssl_context *ssl,
+int mbedtls_ssl_tls13_read_public_dhe_share(mbedtls_ssl_context *ssl,
                                               const unsigned char *buf,
                                               size_t buf_len)
 {

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -1499,7 +1499,7 @@ int mbedtls_ssl_reset_transcript_for_hrr(mbedtls_ssl_context *ssl)
 
 #if defined(PSA_WANT_ALG_ECDH) || defined(PSA_WANT_ALG_FFDH)
 
-int mbedtls_ssl_tls13_read_public_dhe_share(mbedtls_ssl_context *ssl,
+int mbedtls_ssl_tls13_read_public_xxdhe_share(mbedtls_ssl_context *ssl,
                                               const unsigned char *buf,
                                               size_t buf_len)
 {
@@ -1516,8 +1516,8 @@ int mbedtls_ssl_tls13_read_public_dhe_share(mbedtls_ssl_context *ssl,
     MBEDTLS_SSL_CHK_BUF_READ_PTR(p, end, peerkey_len);
 
     /* Store peer's ECDH public key. */
-    memcpy(handshake->dh_psa_peerkey, p, peerkey_len);
-    handshake->dh_psa_peerkey_len = peerkey_len;
+    memcpy(handshake->xxdh_psa_peerkey, p, peerkey_len);
+    handshake->xxdh_psa_peerkey_len = peerkey_len;
 
     return 0;
 }
@@ -1592,18 +1592,18 @@ int mbedtls_ssl_tls13_generate_and_write_dh_key_exchange(
         return MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL;
     }
 
-    handshake->dh_psa_type = key_type;
-    ssl->handshake->dh_bits = bits;
+    handshake->xxdh_psa_type = key_type;
+    ssl->handshake->xxdh_bits = bits;
 
     key_attributes = psa_key_attributes_init();
     psa_set_key_usage_flags(&key_attributes, PSA_KEY_USAGE_DERIVE);
     psa_set_key_algorithm(&key_attributes, alg);
-    psa_set_key_type(&key_attributes, handshake->dh_psa_type);
-    psa_set_key_bits(&key_attributes, handshake->dh_bits);
+    psa_set_key_type(&key_attributes, handshake->xxdh_psa_type);
+    psa_set_key_bits(&key_attributes, handshake->xxdh_bits);
 
     /* Generate ECDH/FFDH private key. */
     status = psa_generate_key(&key_attributes,
-                              &handshake->dh_psa_privkey);
+                              &handshake->xxdh_psa_privkey);
     if (status != PSA_SUCCESS) {
         ret = PSA_TO_MBEDTLS_ERR(status);
         MBEDTLS_SSL_DEBUG_RET(1, "psa_generate_key", ret);
@@ -1612,7 +1612,7 @@ int mbedtls_ssl_tls13_generate_and_write_dh_key_exchange(
     }
 
     /* Export the public part of the ECDH/FFDH private key from PSA. */
-    status = psa_export_public_key(handshake->dh_psa_privkey,
+    status = psa_export_public_key(handshake->xxdh_psa_privkey,
                                    buf, buf_size,
                                    &own_pubkey_len);
 

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -1551,7 +1551,7 @@ static psa_status_t  mbedtls_ssl_get_psa_ffdh_info_from_tls_id(
     }
 }
 
-int mbedtls_ssl_tls13_generate_and_write_dh_key_exchange(
+int mbedtls_ssl_tls13_generate_and_write_xxdh_key_exchange(
     mbedtls_ssl_context *ssl,
     uint16_t named_group,
     unsigned char *buf,

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -1516,8 +1516,8 @@ int mbedtls_ssl_tls13_read_public_ecdhe_share(mbedtls_ssl_context *ssl,
     MBEDTLS_SSL_CHK_BUF_READ_PTR(p, end, peerkey_len);
 
     /* Store peer's ECDH public key. */
-    memcpy(handshake->ecdh_psa_peerkey, p, peerkey_len);
-    handshake->ecdh_psa_peerkey_len = peerkey_len;
+    memcpy(handshake->dh_psa_peerkey, p, peerkey_len);
+    handshake->dh_psa_peerkey_len = peerkey_len;
 
     return 0;
 }
@@ -1592,18 +1592,18 @@ int mbedtls_ssl_tls13_generate_and_write_dh_key_exchange(
         return MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL;
     }
 
-    handshake->ecdh_psa_type = key_type;
-    ssl->handshake->ecdh_bits = bits;
+    handshake->dh_psa_type = key_type;
+    ssl->handshake->dh_bits = bits;
 
     key_attributes = psa_key_attributes_init();
     psa_set_key_usage_flags(&key_attributes, PSA_KEY_USAGE_DERIVE);
     psa_set_key_algorithm(&key_attributes, alg);
-    psa_set_key_type(&key_attributes, handshake->ecdh_psa_type);
-    psa_set_key_bits(&key_attributes, handshake->ecdh_bits);
+    psa_set_key_type(&key_attributes, handshake->dh_psa_type);
+    psa_set_key_bits(&key_attributes, handshake->dh_bits);
 
     /* Generate ECDH/FFDH private key. */
     status = psa_generate_key(&key_attributes,
-                              &handshake->ecdh_psa_privkey);
+                              &handshake->dh_psa_privkey);
     if (status != PSA_SUCCESS) {
         ret = PSA_TO_MBEDTLS_ERR(status);
         MBEDTLS_SSL_DEBUG_RET(1, "psa_generate_key", ret);
@@ -1612,7 +1612,7 @@ int mbedtls_ssl_tls13_generate_and_write_dh_key_exchange(
     }
 
     /* Export the public part of the ECDH/FFDH private key from PSA. */
-    status = psa_export_public_key(handshake->ecdh_psa_privkey,
+    status = psa_export_public_key(handshake->dh_psa_privkey,
                                    buf, buf_size,
                                    &own_pubkey_len);
 

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -1502,7 +1502,7 @@ static int ssl_tls13_key_schedule_stage_handshake(mbedtls_ssl_context *ssl)
             psa_status_t status = PSA_ERROR_GENERIC_ERROR;
             psa_key_attributes_t key_attributes = PSA_KEY_ATTRIBUTES_INIT;
 
-            status = psa_get_key_attributes(handshake->dh_psa_privkey,
+            status = psa_get_key_attributes(handshake->xxdh_psa_privkey,
                                             &key_attributes);
             if (status != PSA_SUCCESS) {
                 ret = PSA_TO_MBEDTLS_ERR(status);
@@ -1516,8 +1516,8 @@ static int ssl_tls13_key_schedule_stage_handshake(mbedtls_ssl_context *ssl)
             }
 
             status = psa_raw_key_agreement(
-                alg, handshake->dh_psa_privkey,
-                handshake->dh_psa_peerkey, handshake->dh_psa_peerkey_len,
+                alg, handshake->xxdh_psa_privkey,
+                handshake->xxdh_psa_peerkey, handshake->xxdh_psa_peerkey_len,
                 shared_secret, shared_secret_len, &shared_secret_len);
             if (status != PSA_SUCCESS) {
                 ret = PSA_TO_MBEDTLS_ERR(status);
@@ -1525,14 +1525,14 @@ static int ssl_tls13_key_schedule_stage_handshake(mbedtls_ssl_context *ssl)
                 goto cleanup;
             }
 
-            status = psa_destroy_key(handshake->dh_psa_privkey);
+            status = psa_destroy_key(handshake->xxdh_psa_privkey);
             if (status != PSA_SUCCESS) {
                 ret = PSA_TO_MBEDTLS_ERR(status);
                 MBEDTLS_SSL_DEBUG_RET(1, "psa_destroy_key", ret);
                 goto cleanup;
             }
 
-            handshake->dh_psa_privkey = MBEDTLS_SVC_KEY_ID_INIT;
+            handshake->xxdh_psa_privkey = MBEDTLS_SVC_KEY_ID_INIT;
 #endif /* PSA_WANT_ALG_ECDH || PSA_WANT_ALG_FFDH */
         } else {
             MBEDTLS_SSL_DEBUG_MSG(1, ("Group not supported."));

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -1492,7 +1492,7 @@ static int ssl_tls13_key_schedule_stage_handshake(mbedtls_ssl_context *ssl)
      */
     if (mbedtls_ssl_tls13_key_exchange_mode_with_ephemeral(ssl)) {
         if (mbedtls_ssl_tls13_named_group_is_ecdhe(handshake->offered_group_id) ||
-            mbedtls_ssl_tls13_named_group_is_dhe(handshake->offered_group_id)) {
+            mbedtls_ssl_tls13_named_group_is_ffdh(handshake->offered_group_id)) {
 #if defined(PSA_WANT_ALG_ECDH) || defined(PSA_WANT_ALG_FFDH)
             psa_algorithm_t alg =
                 mbedtls_ssl_tls13_named_group_is_ecdhe(handshake->offered_group_id) ?

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -1502,7 +1502,7 @@ static int ssl_tls13_key_schedule_stage_handshake(mbedtls_ssl_context *ssl)
             psa_status_t status = PSA_ERROR_GENERIC_ERROR;
             psa_key_attributes_t key_attributes = PSA_KEY_ATTRIBUTES_INIT;
 
-            status = psa_get_key_attributes(handshake->ecdh_psa_privkey,
+            status = psa_get_key_attributes(handshake->dh_psa_privkey,
                                             &key_attributes);
             if (status != PSA_SUCCESS) {
                 ret = PSA_TO_MBEDTLS_ERR(status);
@@ -1516,8 +1516,8 @@ static int ssl_tls13_key_schedule_stage_handshake(mbedtls_ssl_context *ssl)
             }
 
             status = psa_raw_key_agreement(
-                alg, handshake->ecdh_psa_privkey,
-                handshake->ecdh_psa_peerkey, handshake->ecdh_psa_peerkey_len,
+                alg, handshake->dh_psa_privkey,
+                handshake->dh_psa_peerkey, handshake->dh_psa_peerkey_len,
                 shared_secret, shared_secret_len, &shared_secret_len);
             if (status != PSA_SUCCESS) {
                 ret = PSA_TO_MBEDTLS_ERR(status);
@@ -1525,14 +1525,14 @@ static int ssl_tls13_key_schedule_stage_handshake(mbedtls_ssl_context *ssl)
                 goto cleanup;
             }
 
-            status = psa_destroy_key(handshake->ecdh_psa_privkey);
+            status = psa_destroy_key(handshake->dh_psa_privkey);
             if (status != PSA_SUCCESS) {
                 ret = PSA_TO_MBEDTLS_ERR(status);
                 MBEDTLS_SSL_DEBUG_RET(1, "psa_destroy_key", ret);
                 goto cleanup;
             }
 
-            handshake->ecdh_psa_privkey = MBEDTLS_SVC_KEY_ID_INIT;
+            handshake->dh_psa_privkey = MBEDTLS_SVC_KEY_ID_INIT;
 #endif /* PSA_WANT_ALG_ECDH || PSA_WANT_ALG_FFDH */
         } else {
             MBEDTLS_SSL_DEBUG_MSG(1, ("Group not supported."));

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -914,11 +914,11 @@ static int ssl_tls13_parse_key_shares_ext(mbedtls_ssl_context *ssl,
          * ECDHE and FFDHE groups are supported
          */
         if (mbedtls_ssl_tls13_named_group_is_ecdhe(group) ||
-            mbedtls_ssl_tls13_named_group_is_dhe(group)) {
+            mbedtls_ssl_tls13_named_group_is_ffdh(group)) {
             MBEDTLS_SSL_DEBUG_MSG(2, ("ECDH/FFDH group: %s (%04x)",
                                       mbedtls_ssl_named_group_to_str(group),
                                       group));
-            ret = mbedtls_ssl_tls13_read_public_ecdhe_share(
+            ret = mbedtls_ssl_tls13_read_public_dhe_share(
                 ssl, key_exchange - 2, key_exchange_len + 2);
             if (ret != 0) {
                 return ret;
@@ -1915,7 +1915,7 @@ static int ssl_tls13_generate_and_write_key_share(mbedtls_ssl_context *ssl,
 
 #if defined(PSA_WANT_ALG_ECDH) || defined(PSA_WANT_ALG_FFDH)
     if (mbedtls_ssl_tls13_named_group_is_ecdhe(named_group) ||
-        mbedtls_ssl_tls13_named_group_is_dhe(named_group)) {
+        mbedtls_ssl_tls13_named_group_is_ffdh(named_group)) {
         ret = mbedtls_ssl_tls13_generate_and_write_dh_key_exchange(
             ssl, named_group, buf, end, out_len);
         if (ret != 0) {

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1916,11 +1916,11 @@ static int ssl_tls13_generate_and_write_key_share(mbedtls_ssl_context *ssl,
 #if defined(PSA_WANT_ALG_ECDH) || defined(PSA_WANT_ALG_FFDH)
     if (mbedtls_ssl_tls13_named_group_is_ecdhe(named_group) ||
         mbedtls_ssl_tls13_named_group_is_ffdh(named_group)) {
-        ret = mbedtls_ssl_tls13_generate_and_write_dh_key_exchange(
+        ret = mbedtls_ssl_tls13_generate_and_write_xxdh_key_exchange(
             ssl, named_group, buf, end, out_len);
         if (ret != 0) {
             MBEDTLS_SSL_DEBUG_RET(
-                1, "mbedtls_ssl_tls13_generate_and_write_dh_key_exchange",
+                1, "mbedtls_ssl_tls13_generate_and_write_xxdh_key_exchange",
                 ret);
             return ret;
         }

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -918,7 +918,7 @@ static int ssl_tls13_parse_key_shares_ext(mbedtls_ssl_context *ssl,
             MBEDTLS_SSL_DEBUG_MSG(2, ("ECDH/FFDH group: %s (%04x)",
                                       mbedtls_ssl_named_group_to_str(group),
                                       group));
-            ret = mbedtls_ssl_tls13_read_public_dhe_share(
+            ret = mbedtls_ssl_tls13_read_public_xxdhe_share(
                 ssl, key_exchange - 2, key_exchange_len + 2);
             if (ret != 0) {
                 return ret;

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -95,7 +95,7 @@ int main(void)
 #define DFL_RECONNECT_HARD      0
 #define DFL_TICKETS             MBEDTLS_SSL_SESSION_TICKETS_ENABLED
 #define DFL_ALPN_STRING         NULL
-#define DFL_CURVES              NULL
+#define DFL_GROUPS              NULL
 #define DFL_SIG_ALGS            NULL
 #define DFL_TRANSPORT           MBEDTLS_SSL_TRANSPORT_STREAM
 #define DFL_HS_TO_MIN           0
@@ -264,14 +264,17 @@ int main(void)
 #if defined(MBEDTLS_ECP_LIGHT) || \
     (defined(MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_SOME_EPHEMERAL_ENABLED) && \
     defined(PSA_WANT_ALG_FFDH))
-#define USAGE_CURVES \
-    "    curves=a,b,c,d      default: \"default\" (library default)\n"  \
-    "                        example: \"secp521r1,brainpoolP512r1\"\n"  \
-    "                        - use \"none\" for empty list\n"           \
-    "                        - see mbedtls_ecp_curve_list()\n"          \
-    "                          for acceptable curve names\n"
+#define USAGE_GROUPS \
+    "    groups=a,b,c,d      default: \"default\" (library default)\n"        \
+    "                        example: \"secp521r1,brainpoolP512r1\"\n"        \
+    "                        - use \"none\" for empty list\n"                 \
+    "                        - see mbedtls_ecp_curve_list()\n"                \
+    "                          for acceptable EC group names\n"               \
+    "                        - the following ffdh groups are supported:\n"    \
+    "                          ffdhe2048, ffdhe3072, ffdhe4096, ffdhe6144,\n" \
+    "                          ffdhe8192\n"
 #else
-#define USAGE_CURVES ""
+#define USAGE_GROUPS ""
 #endif
 
 #if defined(MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED)
@@ -439,7 +442,7 @@ int main(void)
     USAGE_EMS                                               \
     USAGE_ETM                                               \
     USAGE_REPRODUCIBLE                                      \
-    USAGE_CURVES                                            \
+    USAGE_GROUPS                                            \
     USAGE_SIG_ALGS                                          \
     USAGE_EARLY_DATA                                        \
     USAGE_DHMLEN                                            \
@@ -524,7 +527,7 @@ struct options {
     int reco_mode;              /* how to keep the session around           */
     int reconnect_hard;         /* unexpectedly reconnect from the same port */
     int tickets;                /* enable / disable session tickets         */
-    const char *curves;         /* list of supported elliptic curves        */
+    const char *groups;         /* list of supported groups                 */
     const char *sig_algs;       /* supported TLS 1.3 signature algorithms   */
     const char *alpn_string;    /* ALPN supported protocols                 */
     int transport;              /* TLS or DTLS?                             */
@@ -757,7 +760,7 @@ int main(int argc, char *argv[])
 #if defined(MBEDTLS_MEMORY_BUFFER_ALLOC_C)
     unsigned char alloc_buf[MEMORY_HEAP_SIZE];
 #endif
-    uint16_t group_list[CURVE_LIST_SIZE];
+    uint16_t group_list[GROUP_LIST_SIZE];
 #if defined(MBEDTLS_SSL_DTLS_SRTP)
     unsigned char mki[MBEDTLS_TLS_SRTP_MAX_MKI_LENGTH];
     size_t mki_len = 0;
@@ -943,7 +946,7 @@ usage:
     opt.reconnect_hard      = DFL_RECONNECT_HARD;
     opt.tickets             = DFL_TICKETS;
     opt.alpn_string         = DFL_ALPN_STRING;
-    opt.curves              = DFL_CURVES;
+    opt.groups              = DFL_GROUPS;
     opt.sig_algs            = DFL_SIG_ALGS;
 #if defined(MBEDTLS_SSL_EARLY_DATA)
     opt.early_data          = DFL_EARLY_DATA;
@@ -1166,8 +1169,8 @@ usage:
                     break;
                 default: goto usage;
             }
-        } else if (strcmp(p, "curves") == 0) {
-            opt.curves = q;
+        } else if (strcmp(p, "groups") == 0) {
+            opt.groups = q;
         }
 #if defined(MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED)
         else if (strcmp(p, "sig_algs") == 0) {
@@ -1491,8 +1494,8 @@ usage:
     }
 #endif /* MBEDTLS_SSL_DTLS_CONNECTION_ID */
 
-    if (opt.curves != NULL) {
-        if (parse_curves(opt.curves, group_list, CURVE_LIST_SIZE) != 0) {
+    if (opt.groups != NULL) {
+        if (parse_groups(opt.groups, group_list, GROUP_LIST_SIZE) != 0) {
             goto exit;
         }
     }
@@ -1901,8 +1904,8 @@ usage:
 #if defined(MBEDTLS_ECP_LIGHT) || \
     (defined(MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_SOME_EPHEMERAL_ENABLED) && \
     defined(PSA_WANT_ALG_FFDH))
-    if (opt.curves != NULL &&
-        strcmp(opt.curves, "default") != 0) {
+    if (opt.groups != NULL &&
+        strcmp(opt.groups, "default") != 0) {
         mbedtls_ssl_conf_groups(&conf, group_list);
     }
 #endif

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -133,7 +133,7 @@ int main(void)
 #define DFL_CACHE_REMOVE        0
 #define DFL_SNI                 NULL
 #define DFL_ALPN_STRING         NULL
-#define DFL_CURVES              NULL
+#define DFL_GROUPS              NULL
 #define DFL_MAX_EARLY_DATA_SIZE 0
 #define DFL_SIG_ALGS            NULL
 #define DFL_DHM_FILE            NULL
@@ -449,14 +449,17 @@ int main(void)
 #if defined(MBEDTLS_ECP_LIGHT) || \
     (defined(MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_SOME_EPHEMERAL_ENABLED) && \
     defined(PSA_WANT_ALG_FFDH))
-#define USAGE_CURVES \
-    "    curves=a,b,c,d      default: \"default\" (library default)\n"  \
+#define USAGE_GROUPS \
+    "    groups=a,b,c,d      default: \"default\" (library default)\n"  \
     "                        example: \"secp521r1,brainpoolP512r1\"\n"  \
     "                        - use \"none\" for empty list\n"           \
-    "                        - see mbedtls_ecp_curve_list()\n"          \
-    "                          for acceptable curve names\n"
+    "                        - see mbedtls_ecp_curve_list()\n"                \
+    "                          for acceptable EC group names\n"               \
+    "                        - the following ffdh groups are supported:\n"    \
+    "                          ffdhe2048, ffdhe3072, ffdhe4096, ffdhe6144,\n" \
+    "                          ffdhe8192\n"
 #else
-#define USAGE_CURVES ""
+#define USAGE_GROUPS ""
 #endif
 
 #if defined(MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED)
@@ -560,7 +563,7 @@ int main(void)
     USAGE_ALPN                                              \
     USAGE_EMS                                               \
     USAGE_ETM                                               \
-    USAGE_CURVES                                            \
+    USAGE_GROUPS                                            \
     USAGE_SIG_ALGS                                          \
     USAGE_KEY_OPAQUE_ALGS                                   \
     "\n"
@@ -672,7 +675,7 @@ struct options {
 #endif
     int cache_remove;           /* enable / disable cache entry removal     */
     char *sni;                  /* string describing sni information        */
-    const char *curves;         /* list of supported elliptic curves        */
+    const char *groups;         /* list of supported groups                 */
     const char *sig_algs;       /* supported TLS 1.3 signature algorithms   */
     const char *alpn_string;    /* ALPN supported protocols                 */
     const char *dhm_file;       /* the file with the DH parameters          */
@@ -1522,7 +1525,7 @@ int main(int argc, char *argv[])
 #if defined(SNI_OPTION)
     sni_entry *sni_info = NULL;
 #endif
-    uint16_t group_list[CURVE_LIST_SIZE];
+    uint16_t group_list[GROUP_LIST_SIZE];
 #if defined(MBEDTLS_SSL_ALPN)
     const char *alpn_list[ALPN_LIST_SIZE];
 #endif
@@ -1733,7 +1736,7 @@ usage:
     opt.cache_remove        = DFL_CACHE_REMOVE;
     opt.sni                 = DFL_SNI;
     opt.alpn_string         = DFL_ALPN_STRING;
-    opt.curves              = DFL_CURVES;
+    opt.groups              = DFL_GROUPS;
     opt.max_early_data_size = DFL_MAX_EARLY_DATA_SIZE;
     opt.sig_algs            = DFL_SIG_ALGS;
     opt.dhm_file            = DFL_DHM_FILE;
@@ -1913,8 +1916,8 @@ usage:
                 goto usage;
             }
             opt.force_ciphersuite[1] = 0;
-        } else if (strcmp(p, "curves") == 0) {
-            opt.curves = q;
+        } else if (strcmp(p, "groups") == 0) {
+            opt.groups = q;
         }
 #if defined(MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED)
         else if (strcmp(p, "sig_algs") == 0) {
@@ -2386,8 +2389,8 @@ usage:
     }
 #endif /* MBEDTLS_SSL_HANDSHAKE_WITH_PSK_ENABLED */
 
-    if (opt.curves != NULL) {
-        if (parse_curves(opt.curves, group_list, CURVE_LIST_SIZE) != 0) {
+    if (opt.groups != NULL) {
+        if (parse_groups(opt.groups, group_list, GROUP_LIST_SIZE) != 0) {
             goto exit;
         }
     }
@@ -3095,8 +3098,8 @@ usage:
 #if defined(MBEDTLS_ECP_LIGHT) || \
     (defined(MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_SOME_EPHEMERAL_ENABLED) && \
     defined(PSA_WANT_ALG_FFDH))
-    if (opt.curves != NULL &&
-        strcmp(opt.curves, "default") != 0) {
+    if (opt.groups != NULL &&
+        strcmp(opt.groups, "default") != 0) {
         mbedtls_ssl_conf_groups(&conf, group_list);
     }
 #endif

--- a/programs/ssl/ssl_test_lib.c
+++ b/programs/ssl/ssl_test_lib.c
@@ -517,7 +517,7 @@ int parse_groups(const char *groups, uint16_t *group_list, size_t group_list_len
     if (strcmp(p, "none") == 0) {
         group_list[0] = 0;
     } else if (strcmp(p, "default") != 0) {
-        /* Leave room for a final NULL in curve list */
+        /* Leave room for a final NULL in group list */
         while (i < group_list_len - 1 && *p != '\0') {
             q = p;
 #if defined(MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_SOME_EPHEMERAL_ENABLED) && \
@@ -547,9 +547,9 @@ int parse_groups(const char *groups, uint16_t *group_list, size_t group_list_len
             } else
 #endif
             {
-                mbedtls_printf("unknown curve %s\n", q);
+                mbedtls_printf("unknown group %s\n", q);
+                mbedtls_printf("supported groups: ");
 #if defined(MBEDTLS_ECP_LIGHT)
-                mbedtls_printf("supported curves: ");
                 for (curve_cur = mbedtls_ecp_curve_list();
                      curve_cur->grp_id != MBEDTLS_ECP_DP_NONE;
                      curve_cur++) {

--- a/programs/ssl/ssl_test_lib.c
+++ b/programs/ssl/ssl_test_lib.c
@@ -508,9 +508,9 @@ static inline const char *mbedtls_ssl_ffdh_name_from_group(uint16_t group)
 }
 #endif /* MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_SOME_EPHEMERAL_ENABLED && PSA_WANT_ALG_FFDH */
 
-int parse_curves(const char *curves, uint16_t *group_list, size_t group_list_len)
+int parse_groups(const char *groups, uint16_t *group_list, size_t group_list_len)
 {
-    char *p = (char *) curves;
+    char *p = (char *) groups;
     char *q = NULL;
     size_t i = 0;
 
@@ -570,10 +570,10 @@ int parse_curves(const char *curves, uint16_t *group_list, size_t group_list_len
             }
         }
 
-        mbedtls_printf("Number of curves: %u\n", (unsigned int) i);
+        mbedtls_printf("Number of groups: %u\n", (unsigned int) i);
 
         if (i == group_list_len - 1 && *p != '\0') {
-            mbedtls_printf("curves list too long, maximum %u",
+            mbedtls_printf("groups list too long, maximum %u",
                            (unsigned int) (group_list_len - 1));
             return -1;
         }

--- a/programs/ssl/ssl_test_lib.h
+++ b/programs/ssl/ssl_test_lib.h
@@ -312,7 +312,7 @@ void test_hooks_free(void);
 #endif /* !MBEDTLS_TEST_HOOKS */
 
 /* Helper functions for FFDH groups. */
-int parse_groups(const char *curves, uint16_t *group_list, size_t group_list_len);
+int parse_groups(const char *groups, uint16_t *group_list, size_t group_list_len);
 
 #endif /* MBEDTLS_SSL_TEST_IMPOSSIBLE conditions: else */
 #endif /* MBEDTLS_PROGRAMS_SSL_SSL_TEST_LIB_H */

--- a/programs/ssl/ssl_test_lib.h
+++ b/programs/ssl/ssl_test_lib.h
@@ -81,7 +81,7 @@
 #include "../test/query_config.h"
 
 #define ALPN_LIST_SIZE    10
-#define CURVE_LIST_SIZE   25
+#define GROUP_LIST_SIZE   25
 #define SIG_ALG_LIST_SIZE  5
 
 typedef struct eap_tls_keys {
@@ -312,7 +312,7 @@ void test_hooks_free(void);
 #endif /* !MBEDTLS_TEST_HOOKS */
 
 /* Helper functions for FFDH groups. */
-int parse_curves(const char *curves, uint16_t *group_list, size_t group_list_len);
+int parse_groups(const char *curves, uint16_t *group_list, size_t group_list_len);
 
 #endif /* MBEDTLS_SSL_TEST_IMPOSSIBLE conditions: else */
 #endif /* MBEDTLS_PROGRAMS_SSL_SSL_TEST_LIB_H */

--- a/tests/opt-testcases/tls13-compat.sh
+++ b/tests/opt-testcases/tls13-compat.sh
@@ -32,7 +32,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_GCM_SHA256,secp256r1,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_128_GCM_SHA256 -sigalgs ecdsa_secp256r1_sha256 -groups P-256 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -49,7 +49,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_GCM_SHA256,secp256r1,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_128_GCM_SHA256 -sigalgs ecdsa_secp384r1_sha384 -groups P-256 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -66,7 +66,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_GCM_SHA256,secp256r1,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_128_GCM_SHA256 -sigalgs ecdsa_secp521r1_sha512 -groups P-256 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -84,7 +84,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_GCM_SHA256,secp256r1,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca_cat12.crt -ciphersuites TLS_AES_128_GCM_SHA256 -sigalgs rsa_pss_rsae_sha256 -groups P-256 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -101,7 +101,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_GCM_SHA256,secp384r1,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_128_GCM_SHA256 -sigalgs ecdsa_secp256r1_sha256 -groups P-384 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -118,7 +118,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_GCM_SHA256,secp384r1,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_128_GCM_SHA256 -sigalgs ecdsa_secp384r1_sha384 -groups P-384 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -135,7 +135,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_GCM_SHA256,secp384r1,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_128_GCM_SHA256 -sigalgs ecdsa_secp521r1_sha512 -groups P-384 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -153,7 +153,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_GCM_SHA256,secp384r1,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca_cat12.crt -ciphersuites TLS_AES_128_GCM_SHA256 -sigalgs rsa_pss_rsae_sha256 -groups P-384 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -170,7 +170,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_GCM_SHA256,secp521r1,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_128_GCM_SHA256 -sigalgs ecdsa_secp256r1_sha256 -groups P-521 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -187,7 +187,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_GCM_SHA256,secp521r1,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_128_GCM_SHA256 -sigalgs ecdsa_secp384r1_sha384 -groups P-521 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -204,7 +204,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_GCM_SHA256,secp521r1,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_128_GCM_SHA256 -sigalgs ecdsa_secp521r1_sha512 -groups P-521 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -222,7 +222,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_GCM_SHA256,secp521r1,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca_cat12.crt -ciphersuites TLS_AES_128_GCM_SHA256 -sigalgs rsa_pss_rsae_sha256 -groups P-521 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -239,7 +239,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_GCM_SHA256,x25519,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_128_GCM_SHA256 -sigalgs ecdsa_secp256r1_sha256 -groups X25519 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -256,7 +256,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_GCM_SHA256,x25519,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_128_GCM_SHA256 -sigalgs ecdsa_secp384r1_sha384 -groups X25519 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -273,7 +273,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_GCM_SHA256,x25519,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_128_GCM_SHA256 -sigalgs ecdsa_secp521r1_sha512 -groups X25519 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -291,7 +291,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_GCM_SHA256,x25519,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca_cat12.crt -ciphersuites TLS_AES_128_GCM_SHA256 -sigalgs rsa_pss_rsae_sha256 -groups X25519 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -308,7 +308,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_GCM_SHA256,x448,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_128_GCM_SHA256 -sigalgs ecdsa_secp256r1_sha256 -groups X448 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -325,7 +325,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_GCM_SHA256,x448,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_128_GCM_SHA256 -sigalgs ecdsa_secp384r1_sha384 -groups X448 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -342,7 +342,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_GCM_SHA256,x448,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_128_GCM_SHA256 -sigalgs ecdsa_secp521r1_sha512 -groups X448 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -360,7 +360,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_GCM_SHA256,x448,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca_cat12.crt -ciphersuites TLS_AES_128_GCM_SHA256 -sigalgs rsa_pss_rsae_sha256 -groups X448 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -377,7 +377,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 requires_openssl_tls1_3_with_ffdh
 run_test "TLS 1.3 O->m: AES_128_GCM_SHA256,ffdhe2048,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_128_GCM_SHA256 -sigalgs ecdsa_secp256r1_sha256 -groups ffdhe2048 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -394,7 +394,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 requires_openssl_tls1_3_with_ffdh
 run_test "TLS 1.3 O->m: AES_128_GCM_SHA256,ffdhe2048,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_128_GCM_SHA256 -sigalgs ecdsa_secp384r1_sha384 -groups ffdhe2048 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -411,7 +411,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 requires_openssl_tls1_3_with_ffdh
 run_test "TLS 1.3 O->m: AES_128_GCM_SHA256,ffdhe2048,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_128_GCM_SHA256 -sigalgs ecdsa_secp521r1_sha512 -groups ffdhe2048 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -429,7 +429,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_FFDH
 requires_openssl_tls1_3_with_ffdh
 run_test "TLS 1.3 O->m: AES_128_GCM_SHA256,ffdhe2048,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca_cat12.crt -ciphersuites TLS_AES_128_GCM_SHA256 -sigalgs rsa_pss_rsae_sha256 -groups ffdhe2048 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -446,7 +446,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_256_GCM_SHA384,secp256r1,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_256_GCM_SHA384 -sigalgs ecdsa_secp256r1_sha256 -groups P-256 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -463,7 +463,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_256_GCM_SHA384,secp256r1,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_256_GCM_SHA384 -sigalgs ecdsa_secp384r1_sha384 -groups P-256 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -480,7 +480,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_256_GCM_SHA384,secp256r1,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_256_GCM_SHA384 -sigalgs ecdsa_secp521r1_sha512 -groups P-256 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -498,7 +498,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_256_GCM_SHA384,secp256r1,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca_cat12.crt -ciphersuites TLS_AES_256_GCM_SHA384 -sigalgs rsa_pss_rsae_sha256 -groups P-256 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -515,7 +515,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_256_GCM_SHA384,secp384r1,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_256_GCM_SHA384 -sigalgs ecdsa_secp256r1_sha256 -groups P-384 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -532,7 +532,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_256_GCM_SHA384,secp384r1,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_256_GCM_SHA384 -sigalgs ecdsa_secp384r1_sha384 -groups P-384 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -549,7 +549,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_256_GCM_SHA384,secp384r1,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_256_GCM_SHA384 -sigalgs ecdsa_secp521r1_sha512 -groups P-384 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -567,7 +567,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_256_GCM_SHA384,secp384r1,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca_cat12.crt -ciphersuites TLS_AES_256_GCM_SHA384 -sigalgs rsa_pss_rsae_sha256 -groups P-384 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -584,7 +584,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_256_GCM_SHA384,secp521r1,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_256_GCM_SHA384 -sigalgs ecdsa_secp256r1_sha256 -groups P-521 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -601,7 +601,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_256_GCM_SHA384,secp521r1,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_256_GCM_SHA384 -sigalgs ecdsa_secp384r1_sha384 -groups P-521 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -618,7 +618,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_256_GCM_SHA384,secp521r1,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_256_GCM_SHA384 -sigalgs ecdsa_secp521r1_sha512 -groups P-521 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -636,7 +636,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_256_GCM_SHA384,secp521r1,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca_cat12.crt -ciphersuites TLS_AES_256_GCM_SHA384 -sigalgs rsa_pss_rsae_sha256 -groups P-521 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -653,7 +653,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_256_GCM_SHA384,x25519,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_256_GCM_SHA384 -sigalgs ecdsa_secp256r1_sha256 -groups X25519 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -670,7 +670,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_256_GCM_SHA384,x25519,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_256_GCM_SHA384 -sigalgs ecdsa_secp384r1_sha384 -groups X25519 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -687,7 +687,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_256_GCM_SHA384,x25519,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_256_GCM_SHA384 -sigalgs ecdsa_secp521r1_sha512 -groups X25519 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -705,7 +705,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_256_GCM_SHA384,x25519,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca_cat12.crt -ciphersuites TLS_AES_256_GCM_SHA384 -sigalgs rsa_pss_rsae_sha256 -groups X25519 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -722,7 +722,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_256_GCM_SHA384,x448,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_256_GCM_SHA384 -sigalgs ecdsa_secp256r1_sha256 -groups X448 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -739,7 +739,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_256_GCM_SHA384,x448,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_256_GCM_SHA384 -sigalgs ecdsa_secp384r1_sha384 -groups X448 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -756,7 +756,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_256_GCM_SHA384,x448,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_256_GCM_SHA384 -sigalgs ecdsa_secp521r1_sha512 -groups X448 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -774,7 +774,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_256_GCM_SHA384,x448,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca_cat12.crt -ciphersuites TLS_AES_256_GCM_SHA384 -sigalgs rsa_pss_rsae_sha256 -groups X448 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -791,7 +791,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 requires_openssl_tls1_3_with_ffdh
 run_test "TLS 1.3 O->m: AES_256_GCM_SHA384,ffdhe2048,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_256_GCM_SHA384 -sigalgs ecdsa_secp256r1_sha256 -groups ffdhe2048 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -808,7 +808,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 requires_openssl_tls1_3_with_ffdh
 run_test "TLS 1.3 O->m: AES_256_GCM_SHA384,ffdhe2048,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_256_GCM_SHA384 -sigalgs ecdsa_secp384r1_sha384 -groups ffdhe2048 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -825,7 +825,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 requires_openssl_tls1_3_with_ffdh
 run_test "TLS 1.3 O->m: AES_256_GCM_SHA384,ffdhe2048,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_256_GCM_SHA384 -sigalgs ecdsa_secp521r1_sha512 -groups ffdhe2048 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -843,7 +843,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_FFDH
 requires_openssl_tls1_3_with_ffdh
 run_test "TLS 1.3 O->m: AES_256_GCM_SHA384,ffdhe2048,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca_cat12.crt -ciphersuites TLS_AES_256_GCM_SHA384 -sigalgs rsa_pss_rsae_sha256 -groups ffdhe2048 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -860,7 +860,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: CHACHA20_POLY1305_SHA256,secp256r1,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_CHACHA20_POLY1305_SHA256 -sigalgs ecdsa_secp256r1_sha256 -groups P-256 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -877,7 +877,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: CHACHA20_POLY1305_SHA256,secp256r1,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_CHACHA20_POLY1305_SHA256 -sigalgs ecdsa_secp384r1_sha384 -groups P-256 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -894,7 +894,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: CHACHA20_POLY1305_SHA256,secp256r1,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_CHACHA20_POLY1305_SHA256 -sigalgs ecdsa_secp521r1_sha512 -groups P-256 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -912,7 +912,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: CHACHA20_POLY1305_SHA256,secp256r1,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca_cat12.crt -ciphersuites TLS_CHACHA20_POLY1305_SHA256 -sigalgs rsa_pss_rsae_sha256 -groups P-256 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -929,7 +929,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: CHACHA20_POLY1305_SHA256,secp384r1,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_CHACHA20_POLY1305_SHA256 -sigalgs ecdsa_secp256r1_sha256 -groups P-384 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -946,7 +946,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: CHACHA20_POLY1305_SHA256,secp384r1,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_CHACHA20_POLY1305_SHA256 -sigalgs ecdsa_secp384r1_sha384 -groups P-384 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -963,7 +963,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: CHACHA20_POLY1305_SHA256,secp384r1,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_CHACHA20_POLY1305_SHA256 -sigalgs ecdsa_secp521r1_sha512 -groups P-384 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -981,7 +981,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: CHACHA20_POLY1305_SHA256,secp384r1,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca_cat12.crt -ciphersuites TLS_CHACHA20_POLY1305_SHA256 -sigalgs rsa_pss_rsae_sha256 -groups P-384 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -998,7 +998,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: CHACHA20_POLY1305_SHA256,secp521r1,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_CHACHA20_POLY1305_SHA256 -sigalgs ecdsa_secp256r1_sha256 -groups P-521 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1015,7 +1015,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: CHACHA20_POLY1305_SHA256,secp521r1,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_CHACHA20_POLY1305_SHA256 -sigalgs ecdsa_secp384r1_sha384 -groups P-521 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1032,7 +1032,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: CHACHA20_POLY1305_SHA256,secp521r1,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_CHACHA20_POLY1305_SHA256 -sigalgs ecdsa_secp521r1_sha512 -groups P-521 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1050,7 +1050,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: CHACHA20_POLY1305_SHA256,secp521r1,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca_cat12.crt -ciphersuites TLS_CHACHA20_POLY1305_SHA256 -sigalgs rsa_pss_rsae_sha256 -groups P-521 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1067,7 +1067,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: CHACHA20_POLY1305_SHA256,x25519,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_CHACHA20_POLY1305_SHA256 -sigalgs ecdsa_secp256r1_sha256 -groups X25519 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1084,7 +1084,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: CHACHA20_POLY1305_SHA256,x25519,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_CHACHA20_POLY1305_SHA256 -sigalgs ecdsa_secp384r1_sha384 -groups X25519 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1101,7 +1101,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: CHACHA20_POLY1305_SHA256,x25519,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_CHACHA20_POLY1305_SHA256 -sigalgs ecdsa_secp521r1_sha512 -groups X25519 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1119,7 +1119,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: CHACHA20_POLY1305_SHA256,x25519,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca_cat12.crt -ciphersuites TLS_CHACHA20_POLY1305_SHA256 -sigalgs rsa_pss_rsae_sha256 -groups X25519 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1136,7 +1136,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: CHACHA20_POLY1305_SHA256,x448,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_CHACHA20_POLY1305_SHA256 -sigalgs ecdsa_secp256r1_sha256 -groups X448 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1153,7 +1153,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: CHACHA20_POLY1305_SHA256,x448,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_CHACHA20_POLY1305_SHA256 -sigalgs ecdsa_secp384r1_sha384 -groups X448 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1170,7 +1170,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: CHACHA20_POLY1305_SHA256,x448,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_CHACHA20_POLY1305_SHA256 -sigalgs ecdsa_secp521r1_sha512 -groups X448 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1188,7 +1188,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: CHACHA20_POLY1305_SHA256,x448,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca_cat12.crt -ciphersuites TLS_CHACHA20_POLY1305_SHA256 -sigalgs rsa_pss_rsae_sha256 -groups X448 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1205,7 +1205,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 requires_openssl_tls1_3_with_ffdh
 run_test "TLS 1.3 O->m: CHACHA20_POLY1305_SHA256,ffdhe2048,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_CHACHA20_POLY1305_SHA256 -sigalgs ecdsa_secp256r1_sha256 -groups ffdhe2048 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1222,7 +1222,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 requires_openssl_tls1_3_with_ffdh
 run_test "TLS 1.3 O->m: CHACHA20_POLY1305_SHA256,ffdhe2048,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_CHACHA20_POLY1305_SHA256 -sigalgs ecdsa_secp384r1_sha384 -groups ffdhe2048 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1239,7 +1239,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 requires_openssl_tls1_3_with_ffdh
 run_test "TLS 1.3 O->m: CHACHA20_POLY1305_SHA256,ffdhe2048,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_CHACHA20_POLY1305_SHA256 -sigalgs ecdsa_secp521r1_sha512 -groups ffdhe2048 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1257,7 +1257,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_FFDH
 requires_openssl_tls1_3_with_ffdh
 run_test "TLS 1.3 O->m: CHACHA20_POLY1305_SHA256,ffdhe2048,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca_cat12.crt -ciphersuites TLS_CHACHA20_POLY1305_SHA256 -sigalgs rsa_pss_rsae_sha256 -groups ffdhe2048 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1274,7 +1274,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_CCM_SHA256,secp256r1,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_128_CCM_SHA256 -sigalgs ecdsa_secp256r1_sha256 -groups P-256 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1291,7 +1291,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_CCM_SHA256,secp256r1,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_128_CCM_SHA256 -sigalgs ecdsa_secp384r1_sha384 -groups P-256 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1308,7 +1308,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_CCM_SHA256,secp256r1,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_128_CCM_SHA256 -sigalgs ecdsa_secp521r1_sha512 -groups P-256 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1326,7 +1326,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_CCM_SHA256,secp256r1,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca_cat12.crt -ciphersuites TLS_AES_128_CCM_SHA256 -sigalgs rsa_pss_rsae_sha256 -groups P-256 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1343,7 +1343,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_CCM_SHA256,secp384r1,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_128_CCM_SHA256 -sigalgs ecdsa_secp256r1_sha256 -groups P-384 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1360,7 +1360,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_CCM_SHA256,secp384r1,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_128_CCM_SHA256 -sigalgs ecdsa_secp384r1_sha384 -groups P-384 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1377,7 +1377,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_CCM_SHA256,secp384r1,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_128_CCM_SHA256 -sigalgs ecdsa_secp521r1_sha512 -groups P-384 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1395,7 +1395,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_CCM_SHA256,secp384r1,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca_cat12.crt -ciphersuites TLS_AES_128_CCM_SHA256 -sigalgs rsa_pss_rsae_sha256 -groups P-384 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1412,7 +1412,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_CCM_SHA256,secp521r1,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_128_CCM_SHA256 -sigalgs ecdsa_secp256r1_sha256 -groups P-521 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1429,7 +1429,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_CCM_SHA256,secp521r1,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_128_CCM_SHA256 -sigalgs ecdsa_secp384r1_sha384 -groups P-521 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1446,7 +1446,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_CCM_SHA256,secp521r1,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_128_CCM_SHA256 -sigalgs ecdsa_secp521r1_sha512 -groups P-521 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1464,7 +1464,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_CCM_SHA256,secp521r1,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca_cat12.crt -ciphersuites TLS_AES_128_CCM_SHA256 -sigalgs rsa_pss_rsae_sha256 -groups P-521 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1481,7 +1481,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_CCM_SHA256,x25519,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_128_CCM_SHA256 -sigalgs ecdsa_secp256r1_sha256 -groups X25519 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1498,7 +1498,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_CCM_SHA256,x25519,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_128_CCM_SHA256 -sigalgs ecdsa_secp384r1_sha384 -groups X25519 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1515,7 +1515,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_CCM_SHA256,x25519,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_128_CCM_SHA256 -sigalgs ecdsa_secp521r1_sha512 -groups X25519 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1533,7 +1533,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_CCM_SHA256,x25519,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca_cat12.crt -ciphersuites TLS_AES_128_CCM_SHA256 -sigalgs rsa_pss_rsae_sha256 -groups X25519 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1550,7 +1550,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_CCM_SHA256,x448,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_128_CCM_SHA256 -sigalgs ecdsa_secp256r1_sha256 -groups X448 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1567,7 +1567,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_CCM_SHA256,x448,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_128_CCM_SHA256 -sigalgs ecdsa_secp384r1_sha384 -groups X448 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1584,7 +1584,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_CCM_SHA256,x448,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_128_CCM_SHA256 -sigalgs ecdsa_secp521r1_sha512 -groups X448 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1602,7 +1602,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_CCM_SHA256,x448,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca_cat12.crt -ciphersuites TLS_AES_128_CCM_SHA256 -sigalgs rsa_pss_rsae_sha256 -groups X448 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1619,7 +1619,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 requires_openssl_tls1_3_with_ffdh
 run_test "TLS 1.3 O->m: AES_128_CCM_SHA256,ffdhe2048,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_128_CCM_SHA256 -sigalgs ecdsa_secp256r1_sha256 -groups ffdhe2048 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1636,7 +1636,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 requires_openssl_tls1_3_with_ffdh
 run_test "TLS 1.3 O->m: AES_128_CCM_SHA256,ffdhe2048,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_128_CCM_SHA256 -sigalgs ecdsa_secp384r1_sha384 -groups ffdhe2048 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1653,7 +1653,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 requires_openssl_tls1_3_with_ffdh
 run_test "TLS 1.3 O->m: AES_128_CCM_SHA256,ffdhe2048,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_128_CCM_SHA256 -sigalgs ecdsa_secp521r1_sha512 -groups ffdhe2048 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1671,7 +1671,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_FFDH
 requires_openssl_tls1_3_with_ffdh
 run_test "TLS 1.3 O->m: AES_128_CCM_SHA256,ffdhe2048,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca_cat12.crt -ciphersuites TLS_AES_128_CCM_SHA256 -sigalgs rsa_pss_rsae_sha256 -groups ffdhe2048 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1688,7 +1688,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_CCM_8_SHA256,secp256r1,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_128_CCM_8_SHA256 -sigalgs ecdsa_secp256r1_sha256 -groups P-256 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1705,7 +1705,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_CCM_8_SHA256,secp256r1,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_128_CCM_8_SHA256 -sigalgs ecdsa_secp384r1_sha384 -groups P-256 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1722,7 +1722,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_CCM_8_SHA256,secp256r1,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_128_CCM_8_SHA256 -sigalgs ecdsa_secp521r1_sha512 -groups P-256 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1740,7 +1740,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_CCM_8_SHA256,secp256r1,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca_cat12.crt -ciphersuites TLS_AES_128_CCM_8_SHA256 -sigalgs rsa_pss_rsae_sha256 -groups P-256 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1757,7 +1757,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_CCM_8_SHA256,secp384r1,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_128_CCM_8_SHA256 -sigalgs ecdsa_secp256r1_sha256 -groups P-384 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1774,7 +1774,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_CCM_8_SHA256,secp384r1,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_128_CCM_8_SHA256 -sigalgs ecdsa_secp384r1_sha384 -groups P-384 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1791,7 +1791,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_CCM_8_SHA256,secp384r1,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_128_CCM_8_SHA256 -sigalgs ecdsa_secp521r1_sha512 -groups P-384 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1809,7 +1809,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_CCM_8_SHA256,secp384r1,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca_cat12.crt -ciphersuites TLS_AES_128_CCM_8_SHA256 -sigalgs rsa_pss_rsae_sha256 -groups P-384 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1826,7 +1826,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_CCM_8_SHA256,secp521r1,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_128_CCM_8_SHA256 -sigalgs ecdsa_secp256r1_sha256 -groups P-521 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1843,7 +1843,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_CCM_8_SHA256,secp521r1,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_128_CCM_8_SHA256 -sigalgs ecdsa_secp384r1_sha384 -groups P-521 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1860,7 +1860,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_CCM_8_SHA256,secp521r1,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_128_CCM_8_SHA256 -sigalgs ecdsa_secp521r1_sha512 -groups P-521 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1878,7 +1878,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_CCM_8_SHA256,secp521r1,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca_cat12.crt -ciphersuites TLS_AES_128_CCM_8_SHA256 -sigalgs rsa_pss_rsae_sha256 -groups P-521 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1895,7 +1895,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_CCM_8_SHA256,x25519,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_128_CCM_8_SHA256 -sigalgs ecdsa_secp256r1_sha256 -groups X25519 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1912,7 +1912,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_CCM_8_SHA256,x25519,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_128_CCM_8_SHA256 -sigalgs ecdsa_secp384r1_sha384 -groups X25519 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1929,7 +1929,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_CCM_8_SHA256,x25519,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_128_CCM_8_SHA256 -sigalgs ecdsa_secp521r1_sha512 -groups X25519 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1947,7 +1947,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_CCM_8_SHA256,x25519,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca_cat12.crt -ciphersuites TLS_AES_128_CCM_8_SHA256 -sigalgs rsa_pss_rsae_sha256 -groups X25519 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1964,7 +1964,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_CCM_8_SHA256,x448,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_128_CCM_8_SHA256 -sigalgs ecdsa_secp256r1_sha256 -groups X448 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1981,7 +1981,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_CCM_8_SHA256,x448,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_128_CCM_8_SHA256 -sigalgs ecdsa_secp384r1_sha384 -groups X448 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -1998,7 +1998,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_CCM_8_SHA256,x448,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_128_CCM_8_SHA256 -sigalgs ecdsa_secp521r1_sha512 -groups X448 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -2016,7 +2016,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: AES_128_CCM_8_SHA256,x448,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca_cat12.crt -ciphersuites TLS_AES_128_CCM_8_SHA256 -sigalgs rsa_pss_rsae_sha256 -groups X448 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -2033,7 +2033,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 requires_openssl_tls1_3_with_ffdh
 run_test "TLS 1.3 O->m: AES_128_CCM_8_SHA256,ffdhe2048,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_128_CCM_8_SHA256 -sigalgs ecdsa_secp256r1_sha256 -groups ffdhe2048 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -2050,7 +2050,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 requires_openssl_tls1_3_with_ffdh
 run_test "TLS 1.3 O->m: AES_128_CCM_8_SHA256,ffdhe2048,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_128_CCM_8_SHA256 -sigalgs ecdsa_secp384r1_sha384 -groups ffdhe2048 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -2067,7 +2067,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 requires_openssl_tls1_3_with_ffdh
 run_test "TLS 1.3 O->m: AES_128_CCM_8_SHA256,ffdhe2048,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -ciphersuites TLS_AES_128_CCM_8_SHA256 -sigalgs ecdsa_secp521r1_sha512 -groups ffdhe2048 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -2085,7 +2085,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_FFDH
 requires_openssl_tls1_3_with_ffdh
 run_test "TLS 1.3 O->m: AES_128_CCM_8_SHA256,ffdhe2048,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca_cat12.crt -ciphersuites TLS_AES_128_CCM_8_SHA256 -sigalgs rsa_pss_rsae_sha256 -groups ffdhe2048 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -2104,7 +2104,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_GCM_SHA256,secp256r1,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-128-GCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-SECP256R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -2123,7 +2123,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_GCM_SHA256,secp256r1,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-128-GCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-SECP256R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -2142,7 +2142,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_GCM_SHA256,secp256r1,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-128-GCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-SECP256R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -2162,7 +2162,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_GCM_SHA256,secp256r1,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca_cat12.crt --priority=NONE:+AES-128-GCM:+SHA256:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-SECP256R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -2181,7 +2181,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_GCM_SHA256,secp384r1,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-128-GCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-SECP384R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -2200,7 +2200,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_GCM_SHA256,secp384r1,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-128-GCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-SECP384R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -2219,7 +2219,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_GCM_SHA256,secp384r1,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-128-GCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-SECP384R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -2239,7 +2239,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_GCM_SHA256,secp384r1,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca_cat12.crt --priority=NONE:+AES-128-GCM:+SHA256:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-SECP384R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -2258,7 +2258,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_GCM_SHA256,secp521r1,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-128-GCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-SECP521R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -2277,7 +2277,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_GCM_SHA256,secp521r1,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-128-GCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-SECP521R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -2296,7 +2296,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_GCM_SHA256,secp521r1,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-128-GCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-SECP521R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -2316,7 +2316,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_GCM_SHA256,secp521r1,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca_cat12.crt --priority=NONE:+AES-128-GCM:+SHA256:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-SECP521R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -2335,7 +2335,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_GCM_SHA256,x25519,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-128-GCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-X25519:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -2354,7 +2354,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_GCM_SHA256,x25519,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-128-GCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-X25519:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -2373,7 +2373,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_GCM_SHA256,x25519,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-128-GCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-X25519:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -2393,7 +2393,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_GCM_SHA256,x25519,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca_cat12.crt --priority=NONE:+AES-128-GCM:+SHA256:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-X25519:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -2412,7 +2412,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_GCM_SHA256,x448,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-128-GCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-X448:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -2431,7 +2431,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_GCM_SHA256,x448,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-128-GCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-X448:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -2450,7 +2450,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_GCM_SHA256,x448,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-128-GCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-X448:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -2470,7 +2470,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_GCM_SHA256,x448,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca_cat12.crt --priority=NONE:+AES-128-GCM:+SHA256:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-X448:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -2489,7 +2489,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_GCM_SHA256,ffdhe2048,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-128-GCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-FFDHE2048:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -2508,7 +2508,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_GCM_SHA256,ffdhe2048,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-128-GCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-FFDHE2048:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -2527,7 +2527,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_GCM_SHA256,ffdhe2048,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-128-GCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-FFDHE2048:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -2547,7 +2547,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_GCM_SHA256,ffdhe2048,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca_cat12.crt --priority=NONE:+AES-128-GCM:+SHA256:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-FFDHE2048:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -2566,7 +2566,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_256_GCM_SHA384,secp256r1,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-256-GCM:+SHA384:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-SECP256R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -2585,7 +2585,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_256_GCM_SHA384,secp256r1,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-256-GCM:+SHA384:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-SECP256R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -2604,7 +2604,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_256_GCM_SHA384,secp256r1,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-256-GCM:+SHA384:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-SECP256R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -2624,7 +2624,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_256_GCM_SHA384,secp256r1,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca_cat12.crt --priority=NONE:+AES-256-GCM:+SHA384:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-SECP256R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -2643,7 +2643,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_256_GCM_SHA384,secp384r1,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-256-GCM:+SHA384:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-SECP384R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -2662,7 +2662,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_256_GCM_SHA384,secp384r1,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-256-GCM:+SHA384:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-SECP384R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -2681,7 +2681,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_256_GCM_SHA384,secp384r1,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-256-GCM:+SHA384:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-SECP384R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -2701,7 +2701,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_256_GCM_SHA384,secp384r1,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca_cat12.crt --priority=NONE:+AES-256-GCM:+SHA384:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-SECP384R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -2720,7 +2720,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_256_GCM_SHA384,secp521r1,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-256-GCM:+SHA384:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-SECP521R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -2739,7 +2739,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_256_GCM_SHA384,secp521r1,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-256-GCM:+SHA384:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-SECP521R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -2758,7 +2758,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_256_GCM_SHA384,secp521r1,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-256-GCM:+SHA384:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-SECP521R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -2778,7 +2778,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_256_GCM_SHA384,secp521r1,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca_cat12.crt --priority=NONE:+AES-256-GCM:+SHA384:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-SECP521R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -2797,7 +2797,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_256_GCM_SHA384,x25519,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-256-GCM:+SHA384:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-X25519:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -2816,7 +2816,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_256_GCM_SHA384,x25519,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-256-GCM:+SHA384:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-X25519:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -2835,7 +2835,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_256_GCM_SHA384,x25519,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-256-GCM:+SHA384:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-X25519:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -2855,7 +2855,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_256_GCM_SHA384,x25519,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca_cat12.crt --priority=NONE:+AES-256-GCM:+SHA384:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-X25519:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -2874,7 +2874,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_256_GCM_SHA384,x448,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-256-GCM:+SHA384:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-X448:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -2893,7 +2893,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_256_GCM_SHA384,x448,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-256-GCM:+SHA384:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-X448:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -2912,7 +2912,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_256_GCM_SHA384,x448,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-256-GCM:+SHA384:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-X448:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -2932,7 +2932,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_256_GCM_SHA384,x448,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca_cat12.crt --priority=NONE:+AES-256-GCM:+SHA384:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-X448:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -2951,7 +2951,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_256_GCM_SHA384,ffdhe2048,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-256-GCM:+SHA384:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-FFDHE2048:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -2970,7 +2970,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_256_GCM_SHA384,ffdhe2048,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-256-GCM:+SHA384:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-FFDHE2048:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -2989,7 +2989,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_256_GCM_SHA384,ffdhe2048,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-256-GCM:+SHA384:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-FFDHE2048:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -3009,7 +3009,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_256_GCM_SHA384,ffdhe2048,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca_cat12.crt --priority=NONE:+AES-256-GCM:+SHA384:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-FFDHE2048:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -3028,7 +3028,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: CHACHA20_POLY1305_SHA256,secp256r1,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+CHACHA20-POLY1305:+SHA256:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-SECP256R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -3047,7 +3047,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: CHACHA20_POLY1305_SHA256,secp256r1,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+CHACHA20-POLY1305:+SHA256:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-SECP256R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -3066,7 +3066,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: CHACHA20_POLY1305_SHA256,secp256r1,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+CHACHA20-POLY1305:+SHA256:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-SECP256R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -3086,7 +3086,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: CHACHA20_POLY1305_SHA256,secp256r1,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca_cat12.crt --priority=NONE:+CHACHA20-POLY1305:+SHA256:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-SECP256R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -3105,7 +3105,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: CHACHA20_POLY1305_SHA256,secp384r1,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+CHACHA20-POLY1305:+SHA256:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-SECP384R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -3124,7 +3124,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: CHACHA20_POLY1305_SHA256,secp384r1,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+CHACHA20-POLY1305:+SHA256:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-SECP384R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -3143,7 +3143,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: CHACHA20_POLY1305_SHA256,secp384r1,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+CHACHA20-POLY1305:+SHA256:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-SECP384R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -3163,7 +3163,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: CHACHA20_POLY1305_SHA256,secp384r1,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca_cat12.crt --priority=NONE:+CHACHA20-POLY1305:+SHA256:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-SECP384R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -3182,7 +3182,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: CHACHA20_POLY1305_SHA256,secp521r1,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+CHACHA20-POLY1305:+SHA256:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-SECP521R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -3201,7 +3201,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: CHACHA20_POLY1305_SHA256,secp521r1,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+CHACHA20-POLY1305:+SHA256:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-SECP521R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -3220,7 +3220,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: CHACHA20_POLY1305_SHA256,secp521r1,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+CHACHA20-POLY1305:+SHA256:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-SECP521R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -3240,7 +3240,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: CHACHA20_POLY1305_SHA256,secp521r1,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca_cat12.crt --priority=NONE:+CHACHA20-POLY1305:+SHA256:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-SECP521R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -3259,7 +3259,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: CHACHA20_POLY1305_SHA256,x25519,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+CHACHA20-POLY1305:+SHA256:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-X25519:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -3278,7 +3278,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: CHACHA20_POLY1305_SHA256,x25519,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+CHACHA20-POLY1305:+SHA256:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-X25519:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -3297,7 +3297,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: CHACHA20_POLY1305_SHA256,x25519,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+CHACHA20-POLY1305:+SHA256:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-X25519:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -3317,7 +3317,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: CHACHA20_POLY1305_SHA256,x25519,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca_cat12.crt --priority=NONE:+CHACHA20-POLY1305:+SHA256:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-X25519:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -3336,7 +3336,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: CHACHA20_POLY1305_SHA256,x448,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+CHACHA20-POLY1305:+SHA256:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-X448:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -3355,7 +3355,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: CHACHA20_POLY1305_SHA256,x448,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+CHACHA20-POLY1305:+SHA256:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-X448:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -3374,7 +3374,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: CHACHA20_POLY1305_SHA256,x448,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+CHACHA20-POLY1305:+SHA256:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-X448:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -3394,7 +3394,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: CHACHA20_POLY1305_SHA256,x448,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca_cat12.crt --priority=NONE:+CHACHA20-POLY1305:+SHA256:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-X448:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -3413,7 +3413,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: CHACHA20_POLY1305_SHA256,ffdhe2048,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+CHACHA20-POLY1305:+SHA256:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-FFDHE2048:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -3432,7 +3432,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: CHACHA20_POLY1305_SHA256,ffdhe2048,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+CHACHA20-POLY1305:+SHA256:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-FFDHE2048:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -3451,7 +3451,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: CHACHA20_POLY1305_SHA256,ffdhe2048,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+CHACHA20-POLY1305:+SHA256:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-FFDHE2048:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -3471,7 +3471,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: CHACHA20_POLY1305_SHA256,ffdhe2048,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca_cat12.crt --priority=NONE:+CHACHA20-POLY1305:+SHA256:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-FFDHE2048:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -3490,7 +3490,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_CCM_SHA256,secp256r1,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-128-CCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-SECP256R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -3509,7 +3509,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_CCM_SHA256,secp256r1,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-128-CCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-SECP256R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -3528,7 +3528,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_CCM_SHA256,secp256r1,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-128-CCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-SECP256R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -3548,7 +3548,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_CCM_SHA256,secp256r1,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca_cat12.crt --priority=NONE:+AES-128-CCM:+SHA256:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-SECP256R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -3567,7 +3567,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_CCM_SHA256,secp384r1,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-128-CCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-SECP384R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -3586,7 +3586,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_CCM_SHA256,secp384r1,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-128-CCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-SECP384R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -3605,7 +3605,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_CCM_SHA256,secp384r1,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-128-CCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-SECP384R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -3625,7 +3625,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_CCM_SHA256,secp384r1,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca_cat12.crt --priority=NONE:+AES-128-CCM:+SHA256:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-SECP384R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -3644,7 +3644,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_CCM_SHA256,secp521r1,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-128-CCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-SECP521R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -3663,7 +3663,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_CCM_SHA256,secp521r1,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-128-CCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-SECP521R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -3682,7 +3682,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_CCM_SHA256,secp521r1,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-128-CCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-SECP521R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -3702,7 +3702,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_CCM_SHA256,secp521r1,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca_cat12.crt --priority=NONE:+AES-128-CCM:+SHA256:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-SECP521R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -3721,7 +3721,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_CCM_SHA256,x25519,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-128-CCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-X25519:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -3740,7 +3740,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_CCM_SHA256,x25519,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-128-CCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-X25519:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -3759,7 +3759,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_CCM_SHA256,x25519,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-128-CCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-X25519:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -3779,7 +3779,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_CCM_SHA256,x25519,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca_cat12.crt --priority=NONE:+AES-128-CCM:+SHA256:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-X25519:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -3798,7 +3798,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_CCM_SHA256,x448,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-128-CCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-X448:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -3817,7 +3817,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_CCM_SHA256,x448,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-128-CCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-X448:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -3836,7 +3836,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_CCM_SHA256,x448,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-128-CCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-X448:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -3856,7 +3856,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_CCM_SHA256,x448,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca_cat12.crt --priority=NONE:+AES-128-CCM:+SHA256:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-X448:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -3875,7 +3875,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_CCM_SHA256,ffdhe2048,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-128-CCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-FFDHE2048:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -3894,7 +3894,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_CCM_SHA256,ffdhe2048,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-128-CCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-FFDHE2048:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -3913,7 +3913,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_CCM_SHA256,ffdhe2048,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-128-CCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-FFDHE2048:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -3933,7 +3933,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_CCM_SHA256,ffdhe2048,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca_cat12.crt --priority=NONE:+AES-128-CCM:+SHA256:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-FFDHE2048:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -3952,7 +3952,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_CCM_8_SHA256,secp256r1,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-128-CCM-8:+SHA256:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-SECP256R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -3971,7 +3971,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_CCM_8_SHA256,secp256r1,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-128-CCM-8:+SHA256:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-SECP256R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -3990,7 +3990,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_CCM_8_SHA256,secp256r1,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-128-CCM-8:+SHA256:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-SECP256R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -4010,7 +4010,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_CCM_8_SHA256,secp256r1,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca_cat12.crt --priority=NONE:+AES-128-CCM-8:+SHA256:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-SECP256R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -4029,7 +4029,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_CCM_8_SHA256,secp384r1,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-128-CCM-8:+SHA256:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-SECP384R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -4048,7 +4048,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_CCM_8_SHA256,secp384r1,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-128-CCM-8:+SHA256:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-SECP384R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -4067,7 +4067,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_CCM_8_SHA256,secp384r1,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-128-CCM-8:+SHA256:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-SECP384R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -4087,7 +4087,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_CCM_8_SHA256,secp384r1,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca_cat12.crt --priority=NONE:+AES-128-CCM-8:+SHA256:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-SECP384R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -4106,7 +4106,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_CCM_8_SHA256,secp521r1,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-128-CCM-8:+SHA256:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-SECP521R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -4125,7 +4125,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_CCM_8_SHA256,secp521r1,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-128-CCM-8:+SHA256:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-SECP521R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -4144,7 +4144,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_CCM_8_SHA256,secp521r1,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-128-CCM-8:+SHA256:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-SECP521R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -4164,7 +4164,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_CCM_8_SHA256,secp521r1,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca_cat12.crt --priority=NONE:+AES-128-CCM-8:+SHA256:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-SECP521R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -4183,7 +4183,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_CCM_8_SHA256,x25519,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-128-CCM-8:+SHA256:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-X25519:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -4202,7 +4202,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_CCM_8_SHA256,x25519,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-128-CCM-8:+SHA256:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-X25519:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -4221,7 +4221,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_CCM_8_SHA256,x25519,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-128-CCM-8:+SHA256:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-X25519:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -4241,7 +4241,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_CCM_8_SHA256,x25519,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca_cat12.crt --priority=NONE:+AES-128-CCM-8:+SHA256:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-X25519:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -4260,7 +4260,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_CCM_8_SHA256,x448,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-128-CCM-8:+SHA256:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-X448:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -4279,7 +4279,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_CCM_8_SHA256,x448,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-128-CCM-8:+SHA256:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-X448:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -4298,7 +4298,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_CCM_8_SHA256,x448,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-128-CCM-8:+SHA256:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-X448:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -4318,7 +4318,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_CCM_8_SHA256,x448,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca_cat12.crt --priority=NONE:+AES-128-CCM-8:+SHA256:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-X448:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -4337,7 +4337,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_CCM_8_SHA256,ffdhe2048,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-128-CCM-8:+SHA256:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-FFDHE2048:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -4356,7 +4356,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_CCM_8_SHA256,ffdhe2048,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-128-CCM-8:+SHA256:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-FFDHE2048:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -4375,7 +4375,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_CCM_8_SHA256,ffdhe2048,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+AES-128-CCM-8:+SHA256:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-FFDHE2048:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -4395,7 +4395,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_CCM_8_SHA256,ffdhe2048,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca_cat12.crt --priority=NONE:+AES-128-CCM-8:+SHA256:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-FFDHE2048:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -4413,7 +4413,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_GCM_SHA256,secp256r1,ecdsa_secp256r1_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -ciphersuites TLS_AES_128_GCM_SHA256 -sigalgs ecdsa_secp256r1_sha256 -groups P-256 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -4431,7 +4431,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_GCM_SHA256,secp256r1,ecdsa_secp384r1_sha384" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp384r1.crt -key data_files/ecdsa_secp384r1.key -ciphersuites TLS_AES_128_GCM_SHA256 -sigalgs ecdsa_secp384r1_sha384 -groups P-256 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp256r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp256r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -4449,7 +4449,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_GCM_SHA256,secp256r1,ecdsa_secp521r1_sha512" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp521r1.crt -key data_files/ecdsa_secp521r1.key -ciphersuites TLS_AES_128_GCM_SHA256 -sigalgs ecdsa_secp521r1_sha512 -groups P-256 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp256r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp256r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -4468,7 +4468,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_GCM_SHA256,secp256r1,rsa_pss_rsae_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/server2-sha256.crt -key data_files/server2.key -ciphersuites TLS_AES_128_GCM_SHA256 -sigalgs rsa_pss_rsae_sha256 -groups P-256 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp256r1" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp256r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -4486,7 +4486,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_GCM_SHA256,secp384r1,ecdsa_secp256r1_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -ciphersuites TLS_AES_128_GCM_SHA256 -sigalgs ecdsa_secp256r1_sha256 -groups P-384 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -4504,7 +4504,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_GCM_SHA256,secp384r1,ecdsa_secp384r1_sha384" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp384r1.crt -key data_files/ecdsa_secp384r1.key -ciphersuites TLS_AES_128_GCM_SHA256 -sigalgs ecdsa_secp384r1_sha384 -groups P-384 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp384r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp384r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -4522,7 +4522,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_GCM_SHA256,secp384r1,ecdsa_secp521r1_sha512" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp521r1.crt -key data_files/ecdsa_secp521r1.key -ciphersuites TLS_AES_128_GCM_SHA256 -sigalgs ecdsa_secp521r1_sha512 -groups P-384 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp384r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp384r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -4541,7 +4541,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_GCM_SHA256,secp384r1,rsa_pss_rsae_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/server2-sha256.crt -key data_files/server2.key -ciphersuites TLS_AES_128_GCM_SHA256 -sigalgs rsa_pss_rsae_sha256 -groups P-384 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp384r1" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp384r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -4559,7 +4559,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_GCM_SHA256,secp521r1,ecdsa_secp256r1_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -ciphersuites TLS_AES_128_GCM_SHA256 -sigalgs ecdsa_secp256r1_sha256 -groups P-521 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -4577,7 +4577,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_GCM_SHA256,secp521r1,ecdsa_secp384r1_sha384" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp384r1.crt -key data_files/ecdsa_secp384r1.key -ciphersuites TLS_AES_128_GCM_SHA256 -sigalgs ecdsa_secp384r1_sha384 -groups P-521 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp521r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp521r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -4595,7 +4595,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_GCM_SHA256,secp521r1,ecdsa_secp521r1_sha512" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp521r1.crt -key data_files/ecdsa_secp521r1.key -ciphersuites TLS_AES_128_GCM_SHA256 -sigalgs ecdsa_secp521r1_sha512 -groups P-521 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp521r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp521r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -4614,7 +4614,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_GCM_SHA256,secp521r1,rsa_pss_rsae_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/server2-sha256.crt -key data_files/server2.key -ciphersuites TLS_AES_128_GCM_SHA256 -sigalgs rsa_pss_rsae_sha256 -groups P-521 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp521r1" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp521r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -4632,7 +4632,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_GCM_SHA256,x25519,ecdsa_secp256r1_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -ciphersuites TLS_AES_128_GCM_SHA256 -sigalgs ecdsa_secp256r1_sha256 -groups X25519 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=x25519" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=x25519" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -4650,7 +4650,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_GCM_SHA256,x25519,ecdsa_secp384r1_sha384" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp384r1.crt -key data_files/ecdsa_secp384r1.key -ciphersuites TLS_AES_128_GCM_SHA256 -sigalgs ecdsa_secp384r1_sha384 -groups X25519 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=x25519" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=x25519" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -4668,7 +4668,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_GCM_SHA256,x25519,ecdsa_secp521r1_sha512" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp521r1.crt -key data_files/ecdsa_secp521r1.key -ciphersuites TLS_AES_128_GCM_SHA256 -sigalgs ecdsa_secp521r1_sha512 -groups X25519 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=x25519" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=x25519" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -4687,7 +4687,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_GCM_SHA256,x25519,rsa_pss_rsae_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/server2-sha256.crt -key data_files/server2.key -ciphersuites TLS_AES_128_GCM_SHA256 -sigalgs rsa_pss_rsae_sha256 -groups X25519 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=x25519" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=x25519" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -4705,7 +4705,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_GCM_SHA256,x448,ecdsa_secp256r1_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -ciphersuites TLS_AES_128_GCM_SHA256 -sigalgs ecdsa_secp256r1_sha256 -groups X448 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=x448" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=x448" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -4723,7 +4723,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_GCM_SHA256,x448,ecdsa_secp384r1_sha384" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp384r1.crt -key data_files/ecdsa_secp384r1.key -ciphersuites TLS_AES_128_GCM_SHA256 -sigalgs ecdsa_secp384r1_sha384 -groups X448 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=x448" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=x448" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -4741,7 +4741,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_GCM_SHA256,x448,ecdsa_secp521r1_sha512" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp521r1.crt -key data_files/ecdsa_secp521r1.key -ciphersuites TLS_AES_128_GCM_SHA256 -sigalgs ecdsa_secp521r1_sha512 -groups X448 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=x448" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=x448" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -4760,7 +4760,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_GCM_SHA256,x448,rsa_pss_rsae_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/server2-sha256.crt -key data_files/server2.key -ciphersuites TLS_AES_128_GCM_SHA256 -sigalgs rsa_pss_rsae_sha256 -groups X448 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=x448" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=x448" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -4778,7 +4778,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->O: AES_128_GCM_SHA256,ffdhe2048,ecdsa_secp256r1_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -ciphersuites TLS_AES_128_GCM_SHA256 -sigalgs ecdsa_secp256r1_sha256 -groups ffdhe2048 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -4796,7 +4796,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->O: AES_128_GCM_SHA256,ffdhe2048,ecdsa_secp384r1_sha384" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp384r1.crt -key data_files/ecdsa_secp384r1.key -ciphersuites TLS_AES_128_GCM_SHA256 -sigalgs ecdsa_secp384r1_sha384 -groups ffdhe2048 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=ffdhe2048" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=ffdhe2048" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -4814,7 +4814,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->O: AES_128_GCM_SHA256,ffdhe2048,ecdsa_secp521r1_sha512" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp521r1.crt -key data_files/ecdsa_secp521r1.key -ciphersuites TLS_AES_128_GCM_SHA256 -sigalgs ecdsa_secp521r1_sha512 -groups ffdhe2048 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=ffdhe2048" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=ffdhe2048" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -4833,7 +4833,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->O: AES_128_GCM_SHA256,ffdhe2048,rsa_pss_rsae_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/server2-sha256.crt -key data_files/server2.key -ciphersuites TLS_AES_128_GCM_SHA256 -sigalgs rsa_pss_rsae_sha256 -groups ffdhe2048 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=ffdhe2048" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=ffdhe2048" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -4851,7 +4851,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_256_GCM_SHA384,secp256r1,ecdsa_secp256r1_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -ciphersuites TLS_AES_256_GCM_SHA384 -sigalgs ecdsa_secp256r1_sha256 -groups P-256 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -4869,7 +4869,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_256_GCM_SHA384,secp256r1,ecdsa_secp384r1_sha384" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp384r1.crt -key data_files/ecdsa_secp384r1.key -ciphersuites TLS_AES_256_GCM_SHA384 -sigalgs ecdsa_secp384r1_sha384 -groups P-256 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 curves=secp256r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 groups=secp256r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -4887,7 +4887,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_256_GCM_SHA384,secp256r1,ecdsa_secp521r1_sha512" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp521r1.crt -key data_files/ecdsa_secp521r1.key -ciphersuites TLS_AES_256_GCM_SHA384 -sigalgs ecdsa_secp521r1_sha512 -groups P-256 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 curves=secp256r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 groups=secp256r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -4906,7 +4906,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_256_GCM_SHA384,secp256r1,rsa_pss_rsae_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/server2-sha256.crt -key data_files/server2.key -ciphersuites TLS_AES_256_GCM_SHA384 -sigalgs rsa_pss_rsae_sha256 -groups P-256 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 curves=secp256r1" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 groups=secp256r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -4924,7 +4924,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_256_GCM_SHA384,secp384r1,ecdsa_secp256r1_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -ciphersuites TLS_AES_256_GCM_SHA384 -sigalgs ecdsa_secp256r1_sha256 -groups P-384 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -4942,7 +4942,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_256_GCM_SHA384,secp384r1,ecdsa_secp384r1_sha384" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp384r1.crt -key data_files/ecdsa_secp384r1.key -ciphersuites TLS_AES_256_GCM_SHA384 -sigalgs ecdsa_secp384r1_sha384 -groups P-384 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 curves=secp384r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 groups=secp384r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -4960,7 +4960,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_256_GCM_SHA384,secp384r1,ecdsa_secp521r1_sha512" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp521r1.crt -key data_files/ecdsa_secp521r1.key -ciphersuites TLS_AES_256_GCM_SHA384 -sigalgs ecdsa_secp521r1_sha512 -groups P-384 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 curves=secp384r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 groups=secp384r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -4979,7 +4979,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_256_GCM_SHA384,secp384r1,rsa_pss_rsae_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/server2-sha256.crt -key data_files/server2.key -ciphersuites TLS_AES_256_GCM_SHA384 -sigalgs rsa_pss_rsae_sha256 -groups P-384 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 curves=secp384r1" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 groups=secp384r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -4997,7 +4997,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_256_GCM_SHA384,secp521r1,ecdsa_secp256r1_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -ciphersuites TLS_AES_256_GCM_SHA384 -sigalgs ecdsa_secp256r1_sha256 -groups P-521 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -5015,7 +5015,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_256_GCM_SHA384,secp521r1,ecdsa_secp384r1_sha384" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp384r1.crt -key data_files/ecdsa_secp384r1.key -ciphersuites TLS_AES_256_GCM_SHA384 -sigalgs ecdsa_secp384r1_sha384 -groups P-521 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 curves=secp521r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 groups=secp521r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -5033,7 +5033,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_256_GCM_SHA384,secp521r1,ecdsa_secp521r1_sha512" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp521r1.crt -key data_files/ecdsa_secp521r1.key -ciphersuites TLS_AES_256_GCM_SHA384 -sigalgs ecdsa_secp521r1_sha512 -groups P-521 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 curves=secp521r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 groups=secp521r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -5052,7 +5052,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_256_GCM_SHA384,secp521r1,rsa_pss_rsae_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/server2-sha256.crt -key data_files/server2.key -ciphersuites TLS_AES_256_GCM_SHA384 -sigalgs rsa_pss_rsae_sha256 -groups P-521 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 curves=secp521r1" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 groups=secp521r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -5070,7 +5070,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_256_GCM_SHA384,x25519,ecdsa_secp256r1_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -ciphersuites TLS_AES_256_GCM_SHA384 -sigalgs ecdsa_secp256r1_sha256 -groups X25519 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 curves=x25519" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 groups=x25519" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -5088,7 +5088,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_256_GCM_SHA384,x25519,ecdsa_secp384r1_sha384" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp384r1.crt -key data_files/ecdsa_secp384r1.key -ciphersuites TLS_AES_256_GCM_SHA384 -sigalgs ecdsa_secp384r1_sha384 -groups X25519 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 curves=x25519" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 groups=x25519" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -5106,7 +5106,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_256_GCM_SHA384,x25519,ecdsa_secp521r1_sha512" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp521r1.crt -key data_files/ecdsa_secp521r1.key -ciphersuites TLS_AES_256_GCM_SHA384 -sigalgs ecdsa_secp521r1_sha512 -groups X25519 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 curves=x25519" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 groups=x25519" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -5125,7 +5125,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_256_GCM_SHA384,x25519,rsa_pss_rsae_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/server2-sha256.crt -key data_files/server2.key -ciphersuites TLS_AES_256_GCM_SHA384 -sigalgs rsa_pss_rsae_sha256 -groups X25519 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 curves=x25519" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 groups=x25519" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -5143,7 +5143,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_256_GCM_SHA384,x448,ecdsa_secp256r1_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -ciphersuites TLS_AES_256_GCM_SHA384 -sigalgs ecdsa_secp256r1_sha256 -groups X448 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 curves=x448" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 groups=x448" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -5161,7 +5161,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_256_GCM_SHA384,x448,ecdsa_secp384r1_sha384" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp384r1.crt -key data_files/ecdsa_secp384r1.key -ciphersuites TLS_AES_256_GCM_SHA384 -sigalgs ecdsa_secp384r1_sha384 -groups X448 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 curves=x448" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 groups=x448" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -5179,7 +5179,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_256_GCM_SHA384,x448,ecdsa_secp521r1_sha512" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp521r1.crt -key data_files/ecdsa_secp521r1.key -ciphersuites TLS_AES_256_GCM_SHA384 -sigalgs ecdsa_secp521r1_sha512 -groups X448 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 curves=x448" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 groups=x448" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -5198,7 +5198,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_256_GCM_SHA384,x448,rsa_pss_rsae_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/server2-sha256.crt -key data_files/server2.key -ciphersuites TLS_AES_256_GCM_SHA384 -sigalgs rsa_pss_rsae_sha256 -groups X448 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 curves=x448" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 groups=x448" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -5216,7 +5216,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->O: AES_256_GCM_SHA384,ffdhe2048,ecdsa_secp256r1_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -ciphersuites TLS_AES_256_GCM_SHA384 -sigalgs ecdsa_secp256r1_sha256 -groups ffdhe2048 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -5234,7 +5234,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->O: AES_256_GCM_SHA384,ffdhe2048,ecdsa_secp384r1_sha384" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp384r1.crt -key data_files/ecdsa_secp384r1.key -ciphersuites TLS_AES_256_GCM_SHA384 -sigalgs ecdsa_secp384r1_sha384 -groups ffdhe2048 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 curves=ffdhe2048" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 groups=ffdhe2048" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -5252,7 +5252,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->O: AES_256_GCM_SHA384,ffdhe2048,ecdsa_secp521r1_sha512" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp521r1.crt -key data_files/ecdsa_secp521r1.key -ciphersuites TLS_AES_256_GCM_SHA384 -sigalgs ecdsa_secp521r1_sha512 -groups ffdhe2048 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 curves=ffdhe2048" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 groups=ffdhe2048" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -5271,7 +5271,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->O: AES_256_GCM_SHA384,ffdhe2048,rsa_pss_rsae_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/server2-sha256.crt -key data_files/server2.key -ciphersuites TLS_AES_256_GCM_SHA384 -sigalgs rsa_pss_rsae_sha256 -groups ffdhe2048 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 curves=ffdhe2048" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 groups=ffdhe2048" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -5289,7 +5289,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: CHACHA20_POLY1305_SHA256,secp256r1,ecdsa_secp256r1_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -ciphersuites TLS_CHACHA20_POLY1305_SHA256 -sigalgs ecdsa_secp256r1_sha256 -groups P-256 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -5307,7 +5307,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: CHACHA20_POLY1305_SHA256,secp256r1,ecdsa_secp384r1_sha384" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp384r1.crt -key data_files/ecdsa_secp384r1.key -ciphersuites TLS_CHACHA20_POLY1305_SHA256 -sigalgs ecdsa_secp384r1_sha384 -groups P-256 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp256r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp256r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -5325,7 +5325,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: CHACHA20_POLY1305_SHA256,secp256r1,ecdsa_secp521r1_sha512" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp521r1.crt -key data_files/ecdsa_secp521r1.key -ciphersuites TLS_CHACHA20_POLY1305_SHA256 -sigalgs ecdsa_secp521r1_sha512 -groups P-256 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp256r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp256r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -5344,7 +5344,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: CHACHA20_POLY1305_SHA256,secp256r1,rsa_pss_rsae_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/server2-sha256.crt -key data_files/server2.key -ciphersuites TLS_CHACHA20_POLY1305_SHA256 -sigalgs rsa_pss_rsae_sha256 -groups P-256 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp256r1" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp256r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -5362,7 +5362,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: CHACHA20_POLY1305_SHA256,secp384r1,ecdsa_secp256r1_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -ciphersuites TLS_CHACHA20_POLY1305_SHA256 -sigalgs ecdsa_secp256r1_sha256 -groups P-384 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -5380,7 +5380,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: CHACHA20_POLY1305_SHA256,secp384r1,ecdsa_secp384r1_sha384" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp384r1.crt -key data_files/ecdsa_secp384r1.key -ciphersuites TLS_CHACHA20_POLY1305_SHA256 -sigalgs ecdsa_secp384r1_sha384 -groups P-384 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp384r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp384r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -5398,7 +5398,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: CHACHA20_POLY1305_SHA256,secp384r1,ecdsa_secp521r1_sha512" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp521r1.crt -key data_files/ecdsa_secp521r1.key -ciphersuites TLS_CHACHA20_POLY1305_SHA256 -sigalgs ecdsa_secp521r1_sha512 -groups P-384 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp384r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp384r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -5417,7 +5417,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: CHACHA20_POLY1305_SHA256,secp384r1,rsa_pss_rsae_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/server2-sha256.crt -key data_files/server2.key -ciphersuites TLS_CHACHA20_POLY1305_SHA256 -sigalgs rsa_pss_rsae_sha256 -groups P-384 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp384r1" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp384r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -5435,7 +5435,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: CHACHA20_POLY1305_SHA256,secp521r1,ecdsa_secp256r1_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -ciphersuites TLS_CHACHA20_POLY1305_SHA256 -sigalgs ecdsa_secp256r1_sha256 -groups P-521 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -5453,7 +5453,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: CHACHA20_POLY1305_SHA256,secp521r1,ecdsa_secp384r1_sha384" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp384r1.crt -key data_files/ecdsa_secp384r1.key -ciphersuites TLS_CHACHA20_POLY1305_SHA256 -sigalgs ecdsa_secp384r1_sha384 -groups P-521 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp521r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp521r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -5471,7 +5471,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: CHACHA20_POLY1305_SHA256,secp521r1,ecdsa_secp521r1_sha512" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp521r1.crt -key data_files/ecdsa_secp521r1.key -ciphersuites TLS_CHACHA20_POLY1305_SHA256 -sigalgs ecdsa_secp521r1_sha512 -groups P-521 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp521r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp521r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -5490,7 +5490,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: CHACHA20_POLY1305_SHA256,secp521r1,rsa_pss_rsae_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/server2-sha256.crt -key data_files/server2.key -ciphersuites TLS_CHACHA20_POLY1305_SHA256 -sigalgs rsa_pss_rsae_sha256 -groups P-521 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp521r1" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp521r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -5508,7 +5508,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: CHACHA20_POLY1305_SHA256,x25519,ecdsa_secp256r1_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -ciphersuites TLS_CHACHA20_POLY1305_SHA256 -sigalgs ecdsa_secp256r1_sha256 -groups X25519 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=x25519" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=x25519" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -5526,7 +5526,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: CHACHA20_POLY1305_SHA256,x25519,ecdsa_secp384r1_sha384" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp384r1.crt -key data_files/ecdsa_secp384r1.key -ciphersuites TLS_CHACHA20_POLY1305_SHA256 -sigalgs ecdsa_secp384r1_sha384 -groups X25519 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=x25519" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=x25519" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -5544,7 +5544,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: CHACHA20_POLY1305_SHA256,x25519,ecdsa_secp521r1_sha512" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp521r1.crt -key data_files/ecdsa_secp521r1.key -ciphersuites TLS_CHACHA20_POLY1305_SHA256 -sigalgs ecdsa_secp521r1_sha512 -groups X25519 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=x25519" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=x25519" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -5563,7 +5563,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: CHACHA20_POLY1305_SHA256,x25519,rsa_pss_rsae_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/server2-sha256.crt -key data_files/server2.key -ciphersuites TLS_CHACHA20_POLY1305_SHA256 -sigalgs rsa_pss_rsae_sha256 -groups X25519 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=x25519" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=x25519" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -5581,7 +5581,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: CHACHA20_POLY1305_SHA256,x448,ecdsa_secp256r1_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -ciphersuites TLS_CHACHA20_POLY1305_SHA256 -sigalgs ecdsa_secp256r1_sha256 -groups X448 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=x448" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=x448" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -5599,7 +5599,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: CHACHA20_POLY1305_SHA256,x448,ecdsa_secp384r1_sha384" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp384r1.crt -key data_files/ecdsa_secp384r1.key -ciphersuites TLS_CHACHA20_POLY1305_SHA256 -sigalgs ecdsa_secp384r1_sha384 -groups X448 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=x448" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=x448" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -5617,7 +5617,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: CHACHA20_POLY1305_SHA256,x448,ecdsa_secp521r1_sha512" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp521r1.crt -key data_files/ecdsa_secp521r1.key -ciphersuites TLS_CHACHA20_POLY1305_SHA256 -sigalgs ecdsa_secp521r1_sha512 -groups X448 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=x448" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=x448" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -5636,7 +5636,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: CHACHA20_POLY1305_SHA256,x448,rsa_pss_rsae_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/server2-sha256.crt -key data_files/server2.key -ciphersuites TLS_CHACHA20_POLY1305_SHA256 -sigalgs rsa_pss_rsae_sha256 -groups X448 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=x448" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=x448" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -5654,7 +5654,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->O: CHACHA20_POLY1305_SHA256,ffdhe2048,ecdsa_secp256r1_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -ciphersuites TLS_CHACHA20_POLY1305_SHA256 -sigalgs ecdsa_secp256r1_sha256 -groups ffdhe2048 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -5672,7 +5672,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->O: CHACHA20_POLY1305_SHA256,ffdhe2048,ecdsa_secp384r1_sha384" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp384r1.crt -key data_files/ecdsa_secp384r1.key -ciphersuites TLS_CHACHA20_POLY1305_SHA256 -sigalgs ecdsa_secp384r1_sha384 -groups ffdhe2048 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=ffdhe2048" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=ffdhe2048" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -5690,7 +5690,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->O: CHACHA20_POLY1305_SHA256,ffdhe2048,ecdsa_secp521r1_sha512" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp521r1.crt -key data_files/ecdsa_secp521r1.key -ciphersuites TLS_CHACHA20_POLY1305_SHA256 -sigalgs ecdsa_secp521r1_sha512 -groups ffdhe2048 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=ffdhe2048" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=ffdhe2048" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -5709,7 +5709,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->O: CHACHA20_POLY1305_SHA256,ffdhe2048,rsa_pss_rsae_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/server2-sha256.crt -key data_files/server2.key -ciphersuites TLS_CHACHA20_POLY1305_SHA256 -sigalgs rsa_pss_rsae_sha256 -groups ffdhe2048 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=ffdhe2048" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=ffdhe2048" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -5727,7 +5727,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_CCM_SHA256,secp256r1,ecdsa_secp256r1_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -ciphersuites TLS_AES_128_CCM_SHA256 -sigalgs ecdsa_secp256r1_sha256 -groups P-256 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -5745,7 +5745,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_CCM_SHA256,secp256r1,ecdsa_secp384r1_sha384" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp384r1.crt -key data_files/ecdsa_secp384r1.key -ciphersuites TLS_AES_128_CCM_SHA256 -sigalgs ecdsa_secp384r1_sha384 -groups P-256 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp256r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp256r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -5763,7 +5763,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_CCM_SHA256,secp256r1,ecdsa_secp521r1_sha512" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp521r1.crt -key data_files/ecdsa_secp521r1.key -ciphersuites TLS_AES_128_CCM_SHA256 -sigalgs ecdsa_secp521r1_sha512 -groups P-256 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp256r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp256r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -5782,7 +5782,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_CCM_SHA256,secp256r1,rsa_pss_rsae_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/server2-sha256.crt -key data_files/server2.key -ciphersuites TLS_AES_128_CCM_SHA256 -sigalgs rsa_pss_rsae_sha256 -groups P-256 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp256r1" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp256r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -5800,7 +5800,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_CCM_SHA256,secp384r1,ecdsa_secp256r1_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -ciphersuites TLS_AES_128_CCM_SHA256 -sigalgs ecdsa_secp256r1_sha256 -groups P-384 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -5818,7 +5818,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_CCM_SHA256,secp384r1,ecdsa_secp384r1_sha384" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp384r1.crt -key data_files/ecdsa_secp384r1.key -ciphersuites TLS_AES_128_CCM_SHA256 -sigalgs ecdsa_secp384r1_sha384 -groups P-384 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp384r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp384r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -5836,7 +5836,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_CCM_SHA256,secp384r1,ecdsa_secp521r1_sha512" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp521r1.crt -key data_files/ecdsa_secp521r1.key -ciphersuites TLS_AES_128_CCM_SHA256 -sigalgs ecdsa_secp521r1_sha512 -groups P-384 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp384r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp384r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -5855,7 +5855,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_CCM_SHA256,secp384r1,rsa_pss_rsae_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/server2-sha256.crt -key data_files/server2.key -ciphersuites TLS_AES_128_CCM_SHA256 -sigalgs rsa_pss_rsae_sha256 -groups P-384 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp384r1" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp384r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -5873,7 +5873,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_CCM_SHA256,secp521r1,ecdsa_secp256r1_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -ciphersuites TLS_AES_128_CCM_SHA256 -sigalgs ecdsa_secp256r1_sha256 -groups P-521 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -5891,7 +5891,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_CCM_SHA256,secp521r1,ecdsa_secp384r1_sha384" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp384r1.crt -key data_files/ecdsa_secp384r1.key -ciphersuites TLS_AES_128_CCM_SHA256 -sigalgs ecdsa_secp384r1_sha384 -groups P-521 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp521r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp521r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -5909,7 +5909,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_CCM_SHA256,secp521r1,ecdsa_secp521r1_sha512" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp521r1.crt -key data_files/ecdsa_secp521r1.key -ciphersuites TLS_AES_128_CCM_SHA256 -sigalgs ecdsa_secp521r1_sha512 -groups P-521 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp521r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp521r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -5928,7 +5928,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_CCM_SHA256,secp521r1,rsa_pss_rsae_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/server2-sha256.crt -key data_files/server2.key -ciphersuites TLS_AES_128_CCM_SHA256 -sigalgs rsa_pss_rsae_sha256 -groups P-521 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp521r1" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp521r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -5946,7 +5946,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_CCM_SHA256,x25519,ecdsa_secp256r1_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -ciphersuites TLS_AES_128_CCM_SHA256 -sigalgs ecdsa_secp256r1_sha256 -groups X25519 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=x25519" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=x25519" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -5964,7 +5964,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_CCM_SHA256,x25519,ecdsa_secp384r1_sha384" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp384r1.crt -key data_files/ecdsa_secp384r1.key -ciphersuites TLS_AES_128_CCM_SHA256 -sigalgs ecdsa_secp384r1_sha384 -groups X25519 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=x25519" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=x25519" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -5982,7 +5982,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_CCM_SHA256,x25519,ecdsa_secp521r1_sha512" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp521r1.crt -key data_files/ecdsa_secp521r1.key -ciphersuites TLS_AES_128_CCM_SHA256 -sigalgs ecdsa_secp521r1_sha512 -groups X25519 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=x25519" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=x25519" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -6001,7 +6001,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_CCM_SHA256,x25519,rsa_pss_rsae_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/server2-sha256.crt -key data_files/server2.key -ciphersuites TLS_AES_128_CCM_SHA256 -sigalgs rsa_pss_rsae_sha256 -groups X25519 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=x25519" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=x25519" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -6019,7 +6019,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_CCM_SHA256,x448,ecdsa_secp256r1_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -ciphersuites TLS_AES_128_CCM_SHA256 -sigalgs ecdsa_secp256r1_sha256 -groups X448 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=x448" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=x448" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -6037,7 +6037,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_CCM_SHA256,x448,ecdsa_secp384r1_sha384" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp384r1.crt -key data_files/ecdsa_secp384r1.key -ciphersuites TLS_AES_128_CCM_SHA256 -sigalgs ecdsa_secp384r1_sha384 -groups X448 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=x448" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=x448" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -6055,7 +6055,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_CCM_SHA256,x448,ecdsa_secp521r1_sha512" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp521r1.crt -key data_files/ecdsa_secp521r1.key -ciphersuites TLS_AES_128_CCM_SHA256 -sigalgs ecdsa_secp521r1_sha512 -groups X448 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=x448" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=x448" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -6074,7 +6074,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_CCM_SHA256,x448,rsa_pss_rsae_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/server2-sha256.crt -key data_files/server2.key -ciphersuites TLS_AES_128_CCM_SHA256 -sigalgs rsa_pss_rsae_sha256 -groups X448 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=x448" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=x448" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -6092,7 +6092,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->O: AES_128_CCM_SHA256,ffdhe2048,ecdsa_secp256r1_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -ciphersuites TLS_AES_128_CCM_SHA256 -sigalgs ecdsa_secp256r1_sha256 -groups ffdhe2048 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -6110,7 +6110,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->O: AES_128_CCM_SHA256,ffdhe2048,ecdsa_secp384r1_sha384" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp384r1.crt -key data_files/ecdsa_secp384r1.key -ciphersuites TLS_AES_128_CCM_SHA256 -sigalgs ecdsa_secp384r1_sha384 -groups ffdhe2048 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=ffdhe2048" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=ffdhe2048" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -6128,7 +6128,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->O: AES_128_CCM_SHA256,ffdhe2048,ecdsa_secp521r1_sha512" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp521r1.crt -key data_files/ecdsa_secp521r1.key -ciphersuites TLS_AES_128_CCM_SHA256 -sigalgs ecdsa_secp521r1_sha512 -groups ffdhe2048 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=ffdhe2048" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=ffdhe2048" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -6147,7 +6147,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->O: AES_128_CCM_SHA256,ffdhe2048,rsa_pss_rsae_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/server2-sha256.crt -key data_files/server2.key -ciphersuites TLS_AES_128_CCM_SHA256 -sigalgs rsa_pss_rsae_sha256 -groups ffdhe2048 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=ffdhe2048" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=ffdhe2048" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -6165,7 +6165,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_CCM_8_SHA256,secp256r1,ecdsa_secp256r1_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -ciphersuites TLS_AES_128_CCM_8_SHA256 -sigalgs ecdsa_secp256r1_sha256 -groups P-256 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -6183,7 +6183,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_CCM_8_SHA256,secp256r1,ecdsa_secp384r1_sha384" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp384r1.crt -key data_files/ecdsa_secp384r1.key -ciphersuites TLS_AES_128_CCM_8_SHA256 -sigalgs ecdsa_secp384r1_sha384 -groups P-256 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp256r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp256r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -6201,7 +6201,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_CCM_8_SHA256,secp256r1,ecdsa_secp521r1_sha512" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp521r1.crt -key data_files/ecdsa_secp521r1.key -ciphersuites TLS_AES_128_CCM_8_SHA256 -sigalgs ecdsa_secp521r1_sha512 -groups P-256 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp256r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp256r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -6220,7 +6220,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_CCM_8_SHA256,secp256r1,rsa_pss_rsae_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/server2-sha256.crt -key data_files/server2.key -ciphersuites TLS_AES_128_CCM_8_SHA256 -sigalgs rsa_pss_rsae_sha256 -groups P-256 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp256r1" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp256r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -6238,7 +6238,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_CCM_8_SHA256,secp384r1,ecdsa_secp256r1_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -ciphersuites TLS_AES_128_CCM_8_SHA256 -sigalgs ecdsa_secp256r1_sha256 -groups P-384 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -6256,7 +6256,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_CCM_8_SHA256,secp384r1,ecdsa_secp384r1_sha384" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp384r1.crt -key data_files/ecdsa_secp384r1.key -ciphersuites TLS_AES_128_CCM_8_SHA256 -sigalgs ecdsa_secp384r1_sha384 -groups P-384 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp384r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp384r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -6274,7 +6274,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_CCM_8_SHA256,secp384r1,ecdsa_secp521r1_sha512" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp521r1.crt -key data_files/ecdsa_secp521r1.key -ciphersuites TLS_AES_128_CCM_8_SHA256 -sigalgs ecdsa_secp521r1_sha512 -groups P-384 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp384r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp384r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -6293,7 +6293,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_CCM_8_SHA256,secp384r1,rsa_pss_rsae_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/server2-sha256.crt -key data_files/server2.key -ciphersuites TLS_AES_128_CCM_8_SHA256 -sigalgs rsa_pss_rsae_sha256 -groups P-384 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp384r1" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp384r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -6311,7 +6311,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_CCM_8_SHA256,secp521r1,ecdsa_secp256r1_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -ciphersuites TLS_AES_128_CCM_8_SHA256 -sigalgs ecdsa_secp256r1_sha256 -groups P-521 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -6329,7 +6329,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_CCM_8_SHA256,secp521r1,ecdsa_secp384r1_sha384" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp384r1.crt -key data_files/ecdsa_secp384r1.key -ciphersuites TLS_AES_128_CCM_8_SHA256 -sigalgs ecdsa_secp384r1_sha384 -groups P-521 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp521r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp521r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -6347,7 +6347,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_CCM_8_SHA256,secp521r1,ecdsa_secp521r1_sha512" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp521r1.crt -key data_files/ecdsa_secp521r1.key -ciphersuites TLS_AES_128_CCM_8_SHA256 -sigalgs ecdsa_secp521r1_sha512 -groups P-521 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp521r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp521r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -6366,7 +6366,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_CCM_8_SHA256,secp521r1,rsa_pss_rsae_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/server2-sha256.crt -key data_files/server2.key -ciphersuites TLS_AES_128_CCM_8_SHA256 -sigalgs rsa_pss_rsae_sha256 -groups P-521 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp521r1" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp521r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -6384,7 +6384,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_CCM_8_SHA256,x25519,ecdsa_secp256r1_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -ciphersuites TLS_AES_128_CCM_8_SHA256 -sigalgs ecdsa_secp256r1_sha256 -groups X25519 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=x25519" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=x25519" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -6402,7 +6402,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_CCM_8_SHA256,x25519,ecdsa_secp384r1_sha384" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp384r1.crt -key data_files/ecdsa_secp384r1.key -ciphersuites TLS_AES_128_CCM_8_SHA256 -sigalgs ecdsa_secp384r1_sha384 -groups X25519 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=x25519" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=x25519" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -6420,7 +6420,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_CCM_8_SHA256,x25519,ecdsa_secp521r1_sha512" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp521r1.crt -key data_files/ecdsa_secp521r1.key -ciphersuites TLS_AES_128_CCM_8_SHA256 -sigalgs ecdsa_secp521r1_sha512 -groups X25519 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=x25519" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=x25519" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -6439,7 +6439,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_CCM_8_SHA256,x25519,rsa_pss_rsae_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/server2-sha256.crt -key data_files/server2.key -ciphersuites TLS_AES_128_CCM_8_SHA256 -sigalgs rsa_pss_rsae_sha256 -groups X25519 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=x25519" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=x25519" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -6457,7 +6457,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_CCM_8_SHA256,x448,ecdsa_secp256r1_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -ciphersuites TLS_AES_128_CCM_8_SHA256 -sigalgs ecdsa_secp256r1_sha256 -groups X448 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=x448" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=x448" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -6475,7 +6475,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_CCM_8_SHA256,x448,ecdsa_secp384r1_sha384" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp384r1.crt -key data_files/ecdsa_secp384r1.key -ciphersuites TLS_AES_128_CCM_8_SHA256 -sigalgs ecdsa_secp384r1_sha384 -groups X448 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=x448" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=x448" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -6493,7 +6493,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_CCM_8_SHA256,x448,ecdsa_secp521r1_sha512" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp521r1.crt -key data_files/ecdsa_secp521r1.key -ciphersuites TLS_AES_128_CCM_8_SHA256 -sigalgs ecdsa_secp521r1_sha512 -groups X448 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=x448" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=x448" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -6512,7 +6512,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: AES_128_CCM_8_SHA256,x448,rsa_pss_rsae_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/server2-sha256.crt -key data_files/server2.key -ciphersuites TLS_AES_128_CCM_8_SHA256 -sigalgs rsa_pss_rsae_sha256 -groups X448 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=x448" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=x448" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -6530,7 +6530,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->O: AES_128_CCM_8_SHA256,ffdhe2048,ecdsa_secp256r1_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -ciphersuites TLS_AES_128_CCM_8_SHA256 -sigalgs ecdsa_secp256r1_sha256 -groups ffdhe2048 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -6548,7 +6548,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->O: AES_128_CCM_8_SHA256,ffdhe2048,ecdsa_secp384r1_sha384" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp384r1.crt -key data_files/ecdsa_secp384r1.key -ciphersuites TLS_AES_128_CCM_8_SHA256 -sigalgs ecdsa_secp384r1_sha384 -groups ffdhe2048 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=ffdhe2048" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=ffdhe2048" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -6566,7 +6566,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->O: AES_128_CCM_8_SHA256,ffdhe2048,ecdsa_secp521r1_sha512" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp521r1.crt -key data_files/ecdsa_secp521r1.key -ciphersuites TLS_AES_128_CCM_8_SHA256 -sigalgs ecdsa_secp521r1_sha512 -groups ffdhe2048 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=ffdhe2048" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=ffdhe2048" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -6585,7 +6585,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->O: AES_128_CCM_8_SHA256,ffdhe2048,rsa_pss_rsae_sha256" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/server2-sha256.crt -key data_files/server2.key -ciphersuites TLS_AES_128_CCM_8_SHA256 -sigalgs rsa_pss_rsae_sha256 -groups ffdhe2048 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=ffdhe2048" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=ffdhe2048" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -6605,7 +6605,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_GCM_SHA256,secp256r1,ecdsa_secp256r1_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+AES-128-GCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-SECP256R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -6625,7 +6625,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_GCM_SHA256,secp256r1,ecdsa_secp384r1_sha384" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp384r1.crt --x509keyfile data_files/ecdsa_secp384r1.key --priority=NONE:+AES-128-GCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-SECP256R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp256r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp256r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -6645,7 +6645,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_GCM_SHA256,secp256r1,ecdsa_secp521r1_sha512" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp521r1.crt --x509keyfile data_files/ecdsa_secp521r1.key --priority=NONE:+AES-128-GCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-SECP256R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp256r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp256r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -6666,7 +6666,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_GCM_SHA256,secp256r1,rsa_pss_rsae_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/server2-sha256.crt --x509keyfile data_files/server2.key --priority=NONE:+AES-128-GCM:+SHA256:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-SECP256R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp256r1" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp256r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -6686,7 +6686,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_GCM_SHA256,secp384r1,ecdsa_secp256r1_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+AES-128-GCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-SECP384R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -6706,7 +6706,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_GCM_SHA256,secp384r1,ecdsa_secp384r1_sha384" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp384r1.crt --x509keyfile data_files/ecdsa_secp384r1.key --priority=NONE:+AES-128-GCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-SECP384R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp384r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp384r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -6726,7 +6726,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_GCM_SHA256,secp384r1,ecdsa_secp521r1_sha512" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp521r1.crt --x509keyfile data_files/ecdsa_secp521r1.key --priority=NONE:+AES-128-GCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-SECP384R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp384r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp384r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -6747,7 +6747,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_GCM_SHA256,secp384r1,rsa_pss_rsae_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/server2-sha256.crt --x509keyfile data_files/server2.key --priority=NONE:+AES-128-GCM:+SHA256:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-SECP384R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp384r1" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp384r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -6767,7 +6767,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_GCM_SHA256,secp521r1,ecdsa_secp256r1_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+AES-128-GCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-SECP521R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -6787,7 +6787,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_GCM_SHA256,secp521r1,ecdsa_secp384r1_sha384" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp384r1.crt --x509keyfile data_files/ecdsa_secp384r1.key --priority=NONE:+AES-128-GCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-SECP521R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp521r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp521r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -6807,7 +6807,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_GCM_SHA256,secp521r1,ecdsa_secp521r1_sha512" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp521r1.crt --x509keyfile data_files/ecdsa_secp521r1.key --priority=NONE:+AES-128-GCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-SECP521R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp521r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp521r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -6828,7 +6828,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_GCM_SHA256,secp521r1,rsa_pss_rsae_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/server2-sha256.crt --x509keyfile data_files/server2.key --priority=NONE:+AES-128-GCM:+SHA256:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-SECP521R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp521r1" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp521r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -6848,7 +6848,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_GCM_SHA256,x25519,ecdsa_secp256r1_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+AES-128-GCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-X25519:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=x25519" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=x25519" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -6868,7 +6868,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_GCM_SHA256,x25519,ecdsa_secp384r1_sha384" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp384r1.crt --x509keyfile data_files/ecdsa_secp384r1.key --priority=NONE:+AES-128-GCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-X25519:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=x25519" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=x25519" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -6888,7 +6888,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_GCM_SHA256,x25519,ecdsa_secp521r1_sha512" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp521r1.crt --x509keyfile data_files/ecdsa_secp521r1.key --priority=NONE:+AES-128-GCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-X25519:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=x25519" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=x25519" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -6909,7 +6909,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_GCM_SHA256,x25519,rsa_pss_rsae_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/server2-sha256.crt --x509keyfile data_files/server2.key --priority=NONE:+AES-128-GCM:+SHA256:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-X25519:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=x25519" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=x25519" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -6929,7 +6929,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_GCM_SHA256,x448,ecdsa_secp256r1_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+AES-128-GCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-X448:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=x448" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=x448" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -6949,7 +6949,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_GCM_SHA256,x448,ecdsa_secp384r1_sha384" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp384r1.crt --x509keyfile data_files/ecdsa_secp384r1.key --priority=NONE:+AES-128-GCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-X448:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=x448" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=x448" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -6969,7 +6969,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_GCM_SHA256,x448,ecdsa_secp521r1_sha512" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp521r1.crt --x509keyfile data_files/ecdsa_secp521r1.key --priority=NONE:+AES-128-GCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-X448:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=x448" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=x448" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -6990,7 +6990,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_GCM_SHA256,x448,rsa_pss_rsae_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/server2-sha256.crt --x509keyfile data_files/server2.key --priority=NONE:+AES-128-GCM:+SHA256:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-X448:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=x448" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=x448" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -7010,7 +7010,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->G: AES_128_GCM_SHA256,ffdhe2048,ecdsa_secp256r1_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+AES-128-GCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-FFDHE2048:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -7030,7 +7030,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->G: AES_128_GCM_SHA256,ffdhe2048,ecdsa_secp384r1_sha384" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp384r1.crt --x509keyfile data_files/ecdsa_secp384r1.key --priority=NONE:+AES-128-GCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-FFDHE2048:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=ffdhe2048" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=ffdhe2048" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -7050,7 +7050,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->G: AES_128_GCM_SHA256,ffdhe2048,ecdsa_secp521r1_sha512" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp521r1.crt --x509keyfile data_files/ecdsa_secp521r1.key --priority=NONE:+AES-128-GCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-FFDHE2048:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=ffdhe2048" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=ffdhe2048" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -7071,7 +7071,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->G: AES_128_GCM_SHA256,ffdhe2048,rsa_pss_rsae_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/server2-sha256.crt --x509keyfile data_files/server2.key --priority=NONE:+AES-128-GCM:+SHA256:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-FFDHE2048:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=ffdhe2048" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=ffdhe2048" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -7091,7 +7091,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_256_GCM_SHA384,secp256r1,ecdsa_secp256r1_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+AES-256-GCM:+SHA384:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-SECP256R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -7111,7 +7111,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_256_GCM_SHA384,secp256r1,ecdsa_secp384r1_sha384" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp384r1.crt --x509keyfile data_files/ecdsa_secp384r1.key --priority=NONE:+AES-256-GCM:+SHA384:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-SECP256R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 curves=secp256r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 groups=secp256r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -7131,7 +7131,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_256_GCM_SHA384,secp256r1,ecdsa_secp521r1_sha512" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp521r1.crt --x509keyfile data_files/ecdsa_secp521r1.key --priority=NONE:+AES-256-GCM:+SHA384:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-SECP256R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 curves=secp256r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 groups=secp256r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -7152,7 +7152,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_256_GCM_SHA384,secp256r1,rsa_pss_rsae_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/server2-sha256.crt --x509keyfile data_files/server2.key --priority=NONE:+AES-256-GCM:+SHA384:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-SECP256R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 curves=secp256r1" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 groups=secp256r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -7172,7 +7172,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_256_GCM_SHA384,secp384r1,ecdsa_secp256r1_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+AES-256-GCM:+SHA384:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-SECP384R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -7192,7 +7192,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_256_GCM_SHA384,secp384r1,ecdsa_secp384r1_sha384" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp384r1.crt --x509keyfile data_files/ecdsa_secp384r1.key --priority=NONE:+AES-256-GCM:+SHA384:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-SECP384R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 curves=secp384r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 groups=secp384r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -7212,7 +7212,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_256_GCM_SHA384,secp384r1,ecdsa_secp521r1_sha512" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp521r1.crt --x509keyfile data_files/ecdsa_secp521r1.key --priority=NONE:+AES-256-GCM:+SHA384:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-SECP384R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 curves=secp384r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 groups=secp384r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -7233,7 +7233,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_256_GCM_SHA384,secp384r1,rsa_pss_rsae_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/server2-sha256.crt --x509keyfile data_files/server2.key --priority=NONE:+AES-256-GCM:+SHA384:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-SECP384R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 curves=secp384r1" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 groups=secp384r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -7253,7 +7253,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_256_GCM_SHA384,secp521r1,ecdsa_secp256r1_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+AES-256-GCM:+SHA384:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-SECP521R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -7273,7 +7273,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_256_GCM_SHA384,secp521r1,ecdsa_secp384r1_sha384" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp384r1.crt --x509keyfile data_files/ecdsa_secp384r1.key --priority=NONE:+AES-256-GCM:+SHA384:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-SECP521R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 curves=secp521r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 groups=secp521r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -7293,7 +7293,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_256_GCM_SHA384,secp521r1,ecdsa_secp521r1_sha512" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp521r1.crt --x509keyfile data_files/ecdsa_secp521r1.key --priority=NONE:+AES-256-GCM:+SHA384:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-SECP521R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 curves=secp521r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 groups=secp521r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -7314,7 +7314,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_256_GCM_SHA384,secp521r1,rsa_pss_rsae_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/server2-sha256.crt --x509keyfile data_files/server2.key --priority=NONE:+AES-256-GCM:+SHA384:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-SECP521R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 curves=secp521r1" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 groups=secp521r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -7334,7 +7334,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_256_GCM_SHA384,x25519,ecdsa_secp256r1_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+AES-256-GCM:+SHA384:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-X25519:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 curves=x25519" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 groups=x25519" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -7354,7 +7354,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_256_GCM_SHA384,x25519,ecdsa_secp384r1_sha384" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp384r1.crt --x509keyfile data_files/ecdsa_secp384r1.key --priority=NONE:+AES-256-GCM:+SHA384:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-X25519:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 curves=x25519" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 groups=x25519" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -7374,7 +7374,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_256_GCM_SHA384,x25519,ecdsa_secp521r1_sha512" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp521r1.crt --x509keyfile data_files/ecdsa_secp521r1.key --priority=NONE:+AES-256-GCM:+SHA384:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-X25519:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 curves=x25519" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 groups=x25519" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -7395,7 +7395,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_256_GCM_SHA384,x25519,rsa_pss_rsae_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/server2-sha256.crt --x509keyfile data_files/server2.key --priority=NONE:+AES-256-GCM:+SHA384:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-X25519:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 curves=x25519" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 groups=x25519" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -7415,7 +7415,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_256_GCM_SHA384,x448,ecdsa_secp256r1_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+AES-256-GCM:+SHA384:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-X448:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 curves=x448" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 groups=x448" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -7435,7 +7435,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_256_GCM_SHA384,x448,ecdsa_secp384r1_sha384" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp384r1.crt --x509keyfile data_files/ecdsa_secp384r1.key --priority=NONE:+AES-256-GCM:+SHA384:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-X448:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 curves=x448" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 groups=x448" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -7455,7 +7455,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_256_GCM_SHA384,x448,ecdsa_secp521r1_sha512" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp521r1.crt --x509keyfile data_files/ecdsa_secp521r1.key --priority=NONE:+AES-256-GCM:+SHA384:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-X448:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 curves=x448" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 groups=x448" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -7476,7 +7476,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_256_GCM_SHA384,x448,rsa_pss_rsae_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/server2-sha256.crt --x509keyfile data_files/server2.key --priority=NONE:+AES-256-GCM:+SHA384:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-X448:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 curves=x448" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 groups=x448" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -7496,7 +7496,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->G: AES_256_GCM_SHA384,ffdhe2048,ecdsa_secp256r1_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+AES-256-GCM:+SHA384:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-FFDHE2048:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -7516,7 +7516,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->G: AES_256_GCM_SHA384,ffdhe2048,ecdsa_secp384r1_sha384" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp384r1.crt --x509keyfile data_files/ecdsa_secp384r1.key --priority=NONE:+AES-256-GCM:+SHA384:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-FFDHE2048:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 curves=ffdhe2048" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 groups=ffdhe2048" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -7536,7 +7536,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->G: AES_256_GCM_SHA384,ffdhe2048,ecdsa_secp521r1_sha512" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp521r1.crt --x509keyfile data_files/ecdsa_secp521r1.key --priority=NONE:+AES-256-GCM:+SHA384:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-FFDHE2048:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 curves=ffdhe2048" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 groups=ffdhe2048" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -7557,7 +7557,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->G: AES_256_GCM_SHA384,ffdhe2048,rsa_pss_rsae_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/server2-sha256.crt --x509keyfile data_files/server2.key --priority=NONE:+AES-256-GCM:+SHA384:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-FFDHE2048:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 curves=ffdhe2048" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 groups=ffdhe2048" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -7577,7 +7577,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: CHACHA20_POLY1305_SHA256,secp256r1,ecdsa_secp256r1_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+CHACHA20-POLY1305:+SHA256:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-SECP256R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -7597,7 +7597,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: CHACHA20_POLY1305_SHA256,secp256r1,ecdsa_secp384r1_sha384" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp384r1.crt --x509keyfile data_files/ecdsa_secp384r1.key --priority=NONE:+CHACHA20-POLY1305:+SHA256:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-SECP256R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp256r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp256r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -7617,7 +7617,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: CHACHA20_POLY1305_SHA256,secp256r1,ecdsa_secp521r1_sha512" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp521r1.crt --x509keyfile data_files/ecdsa_secp521r1.key --priority=NONE:+CHACHA20-POLY1305:+SHA256:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-SECP256R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp256r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp256r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -7638,7 +7638,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: CHACHA20_POLY1305_SHA256,secp256r1,rsa_pss_rsae_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/server2-sha256.crt --x509keyfile data_files/server2.key --priority=NONE:+CHACHA20-POLY1305:+SHA256:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-SECP256R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp256r1" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp256r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -7658,7 +7658,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: CHACHA20_POLY1305_SHA256,secp384r1,ecdsa_secp256r1_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+CHACHA20-POLY1305:+SHA256:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-SECP384R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -7678,7 +7678,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: CHACHA20_POLY1305_SHA256,secp384r1,ecdsa_secp384r1_sha384" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp384r1.crt --x509keyfile data_files/ecdsa_secp384r1.key --priority=NONE:+CHACHA20-POLY1305:+SHA256:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-SECP384R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp384r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp384r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -7698,7 +7698,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: CHACHA20_POLY1305_SHA256,secp384r1,ecdsa_secp521r1_sha512" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp521r1.crt --x509keyfile data_files/ecdsa_secp521r1.key --priority=NONE:+CHACHA20-POLY1305:+SHA256:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-SECP384R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp384r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp384r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -7719,7 +7719,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: CHACHA20_POLY1305_SHA256,secp384r1,rsa_pss_rsae_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/server2-sha256.crt --x509keyfile data_files/server2.key --priority=NONE:+CHACHA20-POLY1305:+SHA256:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-SECP384R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp384r1" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp384r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -7739,7 +7739,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: CHACHA20_POLY1305_SHA256,secp521r1,ecdsa_secp256r1_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+CHACHA20-POLY1305:+SHA256:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-SECP521R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -7759,7 +7759,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: CHACHA20_POLY1305_SHA256,secp521r1,ecdsa_secp384r1_sha384" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp384r1.crt --x509keyfile data_files/ecdsa_secp384r1.key --priority=NONE:+CHACHA20-POLY1305:+SHA256:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-SECP521R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp521r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp521r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -7779,7 +7779,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: CHACHA20_POLY1305_SHA256,secp521r1,ecdsa_secp521r1_sha512" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp521r1.crt --x509keyfile data_files/ecdsa_secp521r1.key --priority=NONE:+CHACHA20-POLY1305:+SHA256:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-SECP521R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp521r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp521r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -7800,7 +7800,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: CHACHA20_POLY1305_SHA256,secp521r1,rsa_pss_rsae_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/server2-sha256.crt --x509keyfile data_files/server2.key --priority=NONE:+CHACHA20-POLY1305:+SHA256:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-SECP521R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp521r1" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp521r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -7820,7 +7820,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: CHACHA20_POLY1305_SHA256,x25519,ecdsa_secp256r1_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+CHACHA20-POLY1305:+SHA256:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-X25519:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=x25519" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=x25519" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -7840,7 +7840,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: CHACHA20_POLY1305_SHA256,x25519,ecdsa_secp384r1_sha384" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp384r1.crt --x509keyfile data_files/ecdsa_secp384r1.key --priority=NONE:+CHACHA20-POLY1305:+SHA256:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-X25519:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=x25519" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=x25519" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -7860,7 +7860,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: CHACHA20_POLY1305_SHA256,x25519,ecdsa_secp521r1_sha512" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp521r1.crt --x509keyfile data_files/ecdsa_secp521r1.key --priority=NONE:+CHACHA20-POLY1305:+SHA256:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-X25519:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=x25519" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=x25519" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -7881,7 +7881,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: CHACHA20_POLY1305_SHA256,x25519,rsa_pss_rsae_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/server2-sha256.crt --x509keyfile data_files/server2.key --priority=NONE:+CHACHA20-POLY1305:+SHA256:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-X25519:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=x25519" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=x25519" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -7901,7 +7901,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: CHACHA20_POLY1305_SHA256,x448,ecdsa_secp256r1_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+CHACHA20-POLY1305:+SHA256:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-X448:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=x448" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=x448" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -7921,7 +7921,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: CHACHA20_POLY1305_SHA256,x448,ecdsa_secp384r1_sha384" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp384r1.crt --x509keyfile data_files/ecdsa_secp384r1.key --priority=NONE:+CHACHA20-POLY1305:+SHA256:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-X448:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=x448" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=x448" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -7941,7 +7941,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: CHACHA20_POLY1305_SHA256,x448,ecdsa_secp521r1_sha512" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp521r1.crt --x509keyfile data_files/ecdsa_secp521r1.key --priority=NONE:+CHACHA20-POLY1305:+SHA256:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-X448:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=x448" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=x448" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -7962,7 +7962,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: CHACHA20_POLY1305_SHA256,x448,rsa_pss_rsae_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/server2-sha256.crt --x509keyfile data_files/server2.key --priority=NONE:+CHACHA20-POLY1305:+SHA256:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-X448:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=x448" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=x448" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -7982,7 +7982,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->G: CHACHA20_POLY1305_SHA256,ffdhe2048,ecdsa_secp256r1_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+CHACHA20-POLY1305:+SHA256:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-FFDHE2048:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -8002,7 +8002,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->G: CHACHA20_POLY1305_SHA256,ffdhe2048,ecdsa_secp384r1_sha384" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp384r1.crt --x509keyfile data_files/ecdsa_secp384r1.key --priority=NONE:+CHACHA20-POLY1305:+SHA256:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-FFDHE2048:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=ffdhe2048" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=ffdhe2048" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -8022,7 +8022,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->G: CHACHA20_POLY1305_SHA256,ffdhe2048,ecdsa_secp521r1_sha512" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp521r1.crt --x509keyfile data_files/ecdsa_secp521r1.key --priority=NONE:+CHACHA20-POLY1305:+SHA256:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-FFDHE2048:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=ffdhe2048" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=ffdhe2048" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -8043,7 +8043,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->G: CHACHA20_POLY1305_SHA256,ffdhe2048,rsa_pss_rsae_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/server2-sha256.crt --x509keyfile data_files/server2.key --priority=NONE:+CHACHA20-POLY1305:+SHA256:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-FFDHE2048:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=ffdhe2048" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=ffdhe2048" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -8063,7 +8063,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_CCM_SHA256,secp256r1,ecdsa_secp256r1_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+AES-128-CCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-SECP256R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -8083,7 +8083,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_CCM_SHA256,secp256r1,ecdsa_secp384r1_sha384" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp384r1.crt --x509keyfile data_files/ecdsa_secp384r1.key --priority=NONE:+AES-128-CCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-SECP256R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp256r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp256r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -8103,7 +8103,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_CCM_SHA256,secp256r1,ecdsa_secp521r1_sha512" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp521r1.crt --x509keyfile data_files/ecdsa_secp521r1.key --priority=NONE:+AES-128-CCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-SECP256R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp256r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp256r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -8124,7 +8124,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_CCM_SHA256,secp256r1,rsa_pss_rsae_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/server2-sha256.crt --x509keyfile data_files/server2.key --priority=NONE:+AES-128-CCM:+SHA256:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-SECP256R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp256r1" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp256r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -8144,7 +8144,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_CCM_SHA256,secp384r1,ecdsa_secp256r1_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+AES-128-CCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-SECP384R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -8164,7 +8164,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_CCM_SHA256,secp384r1,ecdsa_secp384r1_sha384" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp384r1.crt --x509keyfile data_files/ecdsa_secp384r1.key --priority=NONE:+AES-128-CCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-SECP384R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp384r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp384r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -8184,7 +8184,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_CCM_SHA256,secp384r1,ecdsa_secp521r1_sha512" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp521r1.crt --x509keyfile data_files/ecdsa_secp521r1.key --priority=NONE:+AES-128-CCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-SECP384R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp384r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp384r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -8205,7 +8205,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_CCM_SHA256,secp384r1,rsa_pss_rsae_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/server2-sha256.crt --x509keyfile data_files/server2.key --priority=NONE:+AES-128-CCM:+SHA256:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-SECP384R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp384r1" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp384r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -8225,7 +8225,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_CCM_SHA256,secp521r1,ecdsa_secp256r1_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+AES-128-CCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-SECP521R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -8245,7 +8245,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_CCM_SHA256,secp521r1,ecdsa_secp384r1_sha384" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp384r1.crt --x509keyfile data_files/ecdsa_secp384r1.key --priority=NONE:+AES-128-CCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-SECP521R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp521r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp521r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -8265,7 +8265,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_CCM_SHA256,secp521r1,ecdsa_secp521r1_sha512" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp521r1.crt --x509keyfile data_files/ecdsa_secp521r1.key --priority=NONE:+AES-128-CCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-SECP521R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp521r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp521r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -8286,7 +8286,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_CCM_SHA256,secp521r1,rsa_pss_rsae_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/server2-sha256.crt --x509keyfile data_files/server2.key --priority=NONE:+AES-128-CCM:+SHA256:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-SECP521R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp521r1" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp521r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -8306,7 +8306,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_CCM_SHA256,x25519,ecdsa_secp256r1_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+AES-128-CCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-X25519:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=x25519" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=x25519" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -8326,7 +8326,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_CCM_SHA256,x25519,ecdsa_secp384r1_sha384" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp384r1.crt --x509keyfile data_files/ecdsa_secp384r1.key --priority=NONE:+AES-128-CCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-X25519:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=x25519" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=x25519" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -8346,7 +8346,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_CCM_SHA256,x25519,ecdsa_secp521r1_sha512" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp521r1.crt --x509keyfile data_files/ecdsa_secp521r1.key --priority=NONE:+AES-128-CCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-X25519:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=x25519" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=x25519" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -8367,7 +8367,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_CCM_SHA256,x25519,rsa_pss_rsae_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/server2-sha256.crt --x509keyfile data_files/server2.key --priority=NONE:+AES-128-CCM:+SHA256:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-X25519:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=x25519" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=x25519" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -8387,7 +8387,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_CCM_SHA256,x448,ecdsa_secp256r1_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+AES-128-CCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-X448:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=x448" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=x448" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -8407,7 +8407,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_CCM_SHA256,x448,ecdsa_secp384r1_sha384" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp384r1.crt --x509keyfile data_files/ecdsa_secp384r1.key --priority=NONE:+AES-128-CCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-X448:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=x448" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=x448" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -8427,7 +8427,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_CCM_SHA256,x448,ecdsa_secp521r1_sha512" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp521r1.crt --x509keyfile data_files/ecdsa_secp521r1.key --priority=NONE:+AES-128-CCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-X448:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=x448" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=x448" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -8448,7 +8448,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_CCM_SHA256,x448,rsa_pss_rsae_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/server2-sha256.crt --x509keyfile data_files/server2.key --priority=NONE:+AES-128-CCM:+SHA256:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-X448:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=x448" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=x448" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -8468,7 +8468,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->G: AES_128_CCM_SHA256,ffdhe2048,ecdsa_secp256r1_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+AES-128-CCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-FFDHE2048:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -8488,7 +8488,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->G: AES_128_CCM_SHA256,ffdhe2048,ecdsa_secp384r1_sha384" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp384r1.crt --x509keyfile data_files/ecdsa_secp384r1.key --priority=NONE:+AES-128-CCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-FFDHE2048:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=ffdhe2048" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=ffdhe2048" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -8508,7 +8508,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->G: AES_128_CCM_SHA256,ffdhe2048,ecdsa_secp521r1_sha512" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp521r1.crt --x509keyfile data_files/ecdsa_secp521r1.key --priority=NONE:+AES-128-CCM:+SHA256:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-FFDHE2048:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=ffdhe2048" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=ffdhe2048" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -8529,7 +8529,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->G: AES_128_CCM_SHA256,ffdhe2048,rsa_pss_rsae_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/server2-sha256.crt --x509keyfile data_files/server2.key --priority=NONE:+AES-128-CCM:+SHA256:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-FFDHE2048:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=ffdhe2048" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=ffdhe2048" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -8549,7 +8549,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_CCM_8_SHA256,secp256r1,ecdsa_secp256r1_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+AES-128-CCM-8:+SHA256:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-SECP256R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -8569,7 +8569,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_CCM_8_SHA256,secp256r1,ecdsa_secp384r1_sha384" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp384r1.crt --x509keyfile data_files/ecdsa_secp384r1.key --priority=NONE:+AES-128-CCM-8:+SHA256:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-SECP256R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp256r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp256r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -8589,7 +8589,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_CCM_8_SHA256,secp256r1,ecdsa_secp521r1_sha512" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp521r1.crt --x509keyfile data_files/ecdsa_secp521r1.key --priority=NONE:+AES-128-CCM-8:+SHA256:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-SECP256R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp256r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp256r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -8610,7 +8610,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_CCM_8_SHA256,secp256r1,rsa_pss_rsae_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/server2-sha256.crt --x509keyfile data_files/server2.key --priority=NONE:+AES-128-CCM-8:+SHA256:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-SECP256R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp256r1" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp256r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -8630,7 +8630,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_CCM_8_SHA256,secp384r1,ecdsa_secp256r1_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+AES-128-CCM-8:+SHA256:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-SECP384R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -8650,7 +8650,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_CCM_8_SHA256,secp384r1,ecdsa_secp384r1_sha384" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp384r1.crt --x509keyfile data_files/ecdsa_secp384r1.key --priority=NONE:+AES-128-CCM-8:+SHA256:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-SECP384R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp384r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp384r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -8670,7 +8670,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_CCM_8_SHA256,secp384r1,ecdsa_secp521r1_sha512" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp521r1.crt --x509keyfile data_files/ecdsa_secp521r1.key --priority=NONE:+AES-128-CCM-8:+SHA256:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-SECP384R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp384r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp384r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -8691,7 +8691,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_CCM_8_SHA256,secp384r1,rsa_pss_rsae_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/server2-sha256.crt --x509keyfile data_files/server2.key --priority=NONE:+AES-128-CCM-8:+SHA256:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-SECP384R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp384r1" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp384r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -8711,7 +8711,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_CCM_8_SHA256,secp521r1,ecdsa_secp256r1_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+AES-128-CCM-8:+SHA256:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-SECP521R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -8731,7 +8731,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_CCM_8_SHA256,secp521r1,ecdsa_secp384r1_sha384" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp384r1.crt --x509keyfile data_files/ecdsa_secp384r1.key --priority=NONE:+AES-128-CCM-8:+SHA256:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-SECP521R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp521r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp521r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -8751,7 +8751,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_CCM_8_SHA256,secp521r1,ecdsa_secp521r1_sha512" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp521r1.crt --x509keyfile data_files/ecdsa_secp521r1.key --priority=NONE:+AES-128-CCM-8:+SHA256:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-SECP521R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp521r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp521r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -8772,7 +8772,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_CCM_8_SHA256,secp521r1,rsa_pss_rsae_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/server2-sha256.crt --x509keyfile data_files/server2.key --priority=NONE:+AES-128-CCM-8:+SHA256:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-SECP521R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp521r1" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp521r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -8792,7 +8792,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_CCM_8_SHA256,x25519,ecdsa_secp256r1_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+AES-128-CCM-8:+SHA256:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-X25519:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=x25519" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=x25519" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -8812,7 +8812,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_CCM_8_SHA256,x25519,ecdsa_secp384r1_sha384" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp384r1.crt --x509keyfile data_files/ecdsa_secp384r1.key --priority=NONE:+AES-128-CCM-8:+SHA256:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-X25519:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=x25519" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=x25519" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -8832,7 +8832,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_CCM_8_SHA256,x25519,ecdsa_secp521r1_sha512" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp521r1.crt --x509keyfile data_files/ecdsa_secp521r1.key --priority=NONE:+AES-128-CCM-8:+SHA256:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-X25519:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=x25519" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=x25519" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -8853,7 +8853,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_CCM_8_SHA256,x25519,rsa_pss_rsae_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/server2-sha256.crt --x509keyfile data_files/server2.key --priority=NONE:+AES-128-CCM-8:+SHA256:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-X25519:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=x25519" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=x25519" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -8873,7 +8873,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_CCM_8_SHA256,x448,ecdsa_secp256r1_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+AES-128-CCM-8:+SHA256:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-X448:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=x448" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=x448" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -8893,7 +8893,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_CCM_8_SHA256,x448,ecdsa_secp384r1_sha384" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp384r1.crt --x509keyfile data_files/ecdsa_secp384r1.key --priority=NONE:+AES-128-CCM-8:+SHA256:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-X448:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=x448" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=x448" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -8913,7 +8913,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_CCM_8_SHA256,x448,ecdsa_secp521r1_sha512" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp521r1.crt --x509keyfile data_files/ecdsa_secp521r1.key --priority=NONE:+AES-128-CCM-8:+SHA256:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-X448:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=x448" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=x448" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -8934,7 +8934,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: AES_128_CCM_8_SHA256,x448,rsa_pss_rsae_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/server2-sha256.crt --x509keyfile data_files/server2.key --priority=NONE:+AES-128-CCM-8:+SHA256:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-X448:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=x448" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=x448" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -8954,7 +8954,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->G: AES_128_CCM_8_SHA256,ffdhe2048,ecdsa_secp256r1_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+AES-128-CCM-8:+SHA256:+AEAD:+SIGN-ECDSA-SECP256R1-SHA256:+GROUP-FFDHE2048:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -8974,7 +8974,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->G: AES_128_CCM_8_SHA256,ffdhe2048,ecdsa_secp384r1_sha384" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp384r1.crt --x509keyfile data_files/ecdsa_secp384r1.key --priority=NONE:+AES-128-CCM-8:+SHA256:+AEAD:+SIGN-ECDSA-SECP384R1-SHA384:+GROUP-FFDHE2048:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=ffdhe2048" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=ffdhe2048" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -8994,7 +8994,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->G: AES_128_CCM_8_SHA256,ffdhe2048,ecdsa_secp521r1_sha512" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp521r1.crt --x509keyfile data_files/ecdsa_secp521r1.key --priority=NONE:+AES-128-CCM-8:+SHA256:+AEAD:+SIGN-ECDSA-SECP521R1-SHA512:+GROUP-FFDHE2048:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=ffdhe2048" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=ffdhe2048" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -9015,7 +9015,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->G: AES_128_CCM_8_SHA256,ffdhe2048,rsa_pss_rsae_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/server2-sha256.crt --x509keyfile data_files/server2.key --priority=NONE:+AES-128-CCM-8:+SHA256:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-FFDHE2048:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=ffdhe2048" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=ffdhe2048" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -9036,8 +9036,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_GCM_SHA256,secp256r1,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-GCM-SHA256 ( id=4865 )" \
@@ -9062,8 +9062,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_GCM_SHA256,secp256r1,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp256r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp256r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-GCM-SHA256 ( id=4865 )" \
@@ -9088,8 +9088,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_GCM_SHA256,secp256r1,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp256r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp256r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-GCM-SHA256 ( id=4865 )" \
@@ -9116,8 +9116,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_GCM_SHA256,secp256r1,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp256r1" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp256r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-GCM-SHA256 ( id=4865 )" \
@@ -9142,8 +9142,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_GCM_SHA256,secp384r1,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-GCM-SHA256 ( id=4865 )" \
@@ -9168,8 +9168,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_GCM_SHA256,secp384r1,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp384r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp384r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-GCM-SHA256 ( id=4865 )" \
@@ -9194,8 +9194,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_GCM_SHA256,secp384r1,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp384r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp384r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-GCM-SHA256 ( id=4865 )" \
@@ -9222,8 +9222,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_GCM_SHA256,secp384r1,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp384r1" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp384r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-GCM-SHA256 ( id=4865 )" \
@@ -9248,8 +9248,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_GCM_SHA256,secp521r1,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-GCM-SHA256 ( id=4865 )" \
@@ -9274,8 +9274,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_GCM_SHA256,secp521r1,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp521r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp521r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-GCM-SHA256 ( id=4865 )" \
@@ -9300,8 +9300,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_GCM_SHA256,secp521r1,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp521r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp521r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-GCM-SHA256 ( id=4865 )" \
@@ -9328,8 +9328,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_GCM_SHA256,secp521r1,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp521r1" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp521r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-GCM-SHA256 ( id=4865 )" \
@@ -9354,8 +9354,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_GCM_SHA256,x25519,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=x25519" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=x25519" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-GCM-SHA256 ( id=4865 )" \
@@ -9380,8 +9380,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_GCM_SHA256,x25519,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=x25519" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=x25519" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-GCM-SHA256 ( id=4865 )" \
@@ -9406,8 +9406,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_GCM_SHA256,x25519,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=x25519" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=x25519" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-GCM-SHA256 ( id=4865 )" \
@@ -9434,8 +9434,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_GCM_SHA256,x25519,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=x25519" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=x25519" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-GCM-SHA256 ( id=4865 )" \
@@ -9460,8 +9460,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_GCM_SHA256,x448,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=x448" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=x448" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-GCM-SHA256 ( id=4865 )" \
@@ -9486,8 +9486,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_GCM_SHA256,x448,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=x448" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=x448" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-GCM-SHA256 ( id=4865 )" \
@@ -9512,8 +9512,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_GCM_SHA256,x448,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=x448" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=x448" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-GCM-SHA256 ( id=4865 )" \
@@ -9540,8 +9540,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_GCM_SHA256,x448,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=x448" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=x448" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-GCM-SHA256 ( id=4865 )" \
@@ -9566,8 +9566,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->m: AES_128_GCM_SHA256,ffdhe2048,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-GCM-SHA256 ( id=4865 )" \
@@ -9592,8 +9592,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->m: AES_128_GCM_SHA256,ffdhe2048,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=ffdhe2048" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=ffdhe2048" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-GCM-SHA256 ( id=4865 )" \
@@ -9618,8 +9618,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->m: AES_128_GCM_SHA256,ffdhe2048,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=ffdhe2048" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=ffdhe2048" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-GCM-SHA256 ( id=4865 )" \
@@ -9646,8 +9646,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->m: AES_128_GCM_SHA256,ffdhe2048,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=ffdhe2048" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=ffdhe2048" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-GCM-SHA256 ( id=4865 )" \
@@ -9672,8 +9672,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_256_GCM_SHA384,secp256r1,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-256-GCM-SHA384 ( id=4866 )" \
@@ -9698,8 +9698,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_256_GCM_SHA384,secp256r1,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 curves=secp256r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 groups=secp256r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-256-GCM-SHA384 ( id=4866 )" \
@@ -9724,8 +9724,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_256_GCM_SHA384,secp256r1,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 curves=secp256r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 groups=secp256r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-256-GCM-SHA384 ( id=4866 )" \
@@ -9752,8 +9752,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_256_GCM_SHA384,secp256r1,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 curves=secp256r1" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 groups=secp256r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-256-GCM-SHA384 ( id=4866 )" \
@@ -9778,8 +9778,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_256_GCM_SHA384,secp384r1,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-256-GCM-SHA384 ( id=4866 )" \
@@ -9804,8 +9804,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_256_GCM_SHA384,secp384r1,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 curves=secp384r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 groups=secp384r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-256-GCM-SHA384 ( id=4866 )" \
@@ -9830,8 +9830,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_256_GCM_SHA384,secp384r1,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 curves=secp384r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 groups=secp384r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-256-GCM-SHA384 ( id=4866 )" \
@@ -9858,8 +9858,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_256_GCM_SHA384,secp384r1,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 curves=secp384r1" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 groups=secp384r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-256-GCM-SHA384 ( id=4866 )" \
@@ -9884,8 +9884,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_256_GCM_SHA384,secp521r1,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-256-GCM-SHA384 ( id=4866 )" \
@@ -9910,8 +9910,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_256_GCM_SHA384,secp521r1,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 curves=secp521r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 groups=secp521r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-256-GCM-SHA384 ( id=4866 )" \
@@ -9936,8 +9936,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_256_GCM_SHA384,secp521r1,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 curves=secp521r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 groups=secp521r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-256-GCM-SHA384 ( id=4866 )" \
@@ -9964,8 +9964,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_256_GCM_SHA384,secp521r1,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 curves=secp521r1" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 groups=secp521r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-256-GCM-SHA384 ( id=4866 )" \
@@ -9990,8 +9990,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_256_GCM_SHA384,x25519,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 curves=x25519" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 groups=x25519" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-256-GCM-SHA384 ( id=4866 )" \
@@ -10016,8 +10016,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_256_GCM_SHA384,x25519,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 curves=x25519" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 groups=x25519" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-256-GCM-SHA384 ( id=4866 )" \
@@ -10042,8 +10042,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_256_GCM_SHA384,x25519,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 curves=x25519" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 groups=x25519" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-256-GCM-SHA384 ( id=4866 )" \
@@ -10070,8 +10070,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_256_GCM_SHA384,x25519,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 curves=x25519" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 groups=x25519" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-256-GCM-SHA384 ( id=4866 )" \
@@ -10096,8 +10096,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_256_GCM_SHA384,x448,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 curves=x448" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 groups=x448" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-256-GCM-SHA384 ( id=4866 )" \
@@ -10122,8 +10122,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_256_GCM_SHA384,x448,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 curves=x448" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 groups=x448" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-256-GCM-SHA384 ( id=4866 )" \
@@ -10148,8 +10148,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_256_GCM_SHA384,x448,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 curves=x448" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 groups=x448" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-256-GCM-SHA384 ( id=4866 )" \
@@ -10176,8 +10176,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_256_GCM_SHA384,x448,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 curves=x448" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 groups=x448" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-256-GCM-SHA384 ( id=4866 )" \
@@ -10202,8 +10202,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->m: AES_256_GCM_SHA384,ffdhe2048,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-256-GCM-SHA384 ( id=4866 )" \
@@ -10228,8 +10228,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->m: AES_256_GCM_SHA384,ffdhe2048,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 curves=ffdhe2048" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp384r1_sha384 groups=ffdhe2048" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-256-GCM-SHA384 ( id=4866 )" \
@@ -10254,8 +10254,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->m: AES_256_GCM_SHA384,ffdhe2048,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 curves=ffdhe2048" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=ecdsa_secp521r1_sha512 groups=ffdhe2048" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-256-GCM-SHA384 ( id=4866 )" \
@@ -10282,8 +10282,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->m: AES_256_GCM_SHA384,ffdhe2048,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 curves=ffdhe2048" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 sig_algs=rsa_pss_rsae_sha256 groups=ffdhe2048" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-256-GCM-SHA384 ( id=4866 )" \
@@ -10308,8 +10308,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: CHACHA20_POLY1305_SHA256,secp256r1,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-CHACHA20-POLY1305-SHA256 ( id=4867 )" \
@@ -10334,8 +10334,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: CHACHA20_POLY1305_SHA256,secp256r1,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp256r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp256r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-CHACHA20-POLY1305-SHA256 ( id=4867 )" \
@@ -10360,8 +10360,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: CHACHA20_POLY1305_SHA256,secp256r1,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp256r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp256r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-CHACHA20-POLY1305-SHA256 ( id=4867 )" \
@@ -10388,8 +10388,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: CHACHA20_POLY1305_SHA256,secp256r1,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp256r1" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp256r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-CHACHA20-POLY1305-SHA256 ( id=4867 )" \
@@ -10414,8 +10414,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: CHACHA20_POLY1305_SHA256,secp384r1,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-CHACHA20-POLY1305-SHA256 ( id=4867 )" \
@@ -10440,8 +10440,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: CHACHA20_POLY1305_SHA256,secp384r1,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp384r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp384r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-CHACHA20-POLY1305-SHA256 ( id=4867 )" \
@@ -10466,8 +10466,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: CHACHA20_POLY1305_SHA256,secp384r1,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp384r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp384r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-CHACHA20-POLY1305-SHA256 ( id=4867 )" \
@@ -10494,8 +10494,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: CHACHA20_POLY1305_SHA256,secp384r1,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp384r1" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp384r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-CHACHA20-POLY1305-SHA256 ( id=4867 )" \
@@ -10520,8 +10520,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: CHACHA20_POLY1305_SHA256,secp521r1,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-CHACHA20-POLY1305-SHA256 ( id=4867 )" \
@@ -10546,8 +10546,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: CHACHA20_POLY1305_SHA256,secp521r1,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp521r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp521r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-CHACHA20-POLY1305-SHA256 ( id=4867 )" \
@@ -10572,8 +10572,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: CHACHA20_POLY1305_SHA256,secp521r1,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp521r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp521r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-CHACHA20-POLY1305-SHA256 ( id=4867 )" \
@@ -10600,8 +10600,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: CHACHA20_POLY1305_SHA256,secp521r1,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp521r1" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp521r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-CHACHA20-POLY1305-SHA256 ( id=4867 )" \
@@ -10626,8 +10626,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: CHACHA20_POLY1305_SHA256,x25519,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=x25519" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=x25519" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-CHACHA20-POLY1305-SHA256 ( id=4867 )" \
@@ -10652,8 +10652,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: CHACHA20_POLY1305_SHA256,x25519,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=x25519" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=x25519" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-CHACHA20-POLY1305-SHA256 ( id=4867 )" \
@@ -10678,8 +10678,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: CHACHA20_POLY1305_SHA256,x25519,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=x25519" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=x25519" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-CHACHA20-POLY1305-SHA256 ( id=4867 )" \
@@ -10706,8 +10706,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: CHACHA20_POLY1305_SHA256,x25519,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=x25519" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=x25519" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-CHACHA20-POLY1305-SHA256 ( id=4867 )" \
@@ -10732,8 +10732,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: CHACHA20_POLY1305_SHA256,x448,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=x448" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=x448" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-CHACHA20-POLY1305-SHA256 ( id=4867 )" \
@@ -10758,8 +10758,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: CHACHA20_POLY1305_SHA256,x448,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=x448" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=x448" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-CHACHA20-POLY1305-SHA256 ( id=4867 )" \
@@ -10784,8 +10784,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: CHACHA20_POLY1305_SHA256,x448,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=x448" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=x448" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-CHACHA20-POLY1305-SHA256 ( id=4867 )" \
@@ -10812,8 +10812,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: CHACHA20_POLY1305_SHA256,x448,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=x448" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=x448" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-CHACHA20-POLY1305-SHA256 ( id=4867 )" \
@@ -10838,8 +10838,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->m: CHACHA20_POLY1305_SHA256,ffdhe2048,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-CHACHA20-POLY1305-SHA256 ( id=4867 )" \
@@ -10864,8 +10864,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->m: CHACHA20_POLY1305_SHA256,ffdhe2048,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=ffdhe2048" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=ffdhe2048" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-CHACHA20-POLY1305-SHA256 ( id=4867 )" \
@@ -10890,8 +10890,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->m: CHACHA20_POLY1305_SHA256,ffdhe2048,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=ffdhe2048" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=ffdhe2048" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-CHACHA20-POLY1305-SHA256 ( id=4867 )" \
@@ -10918,8 +10918,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->m: CHACHA20_POLY1305_SHA256,ffdhe2048,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=ffdhe2048" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-CHACHA20-POLY1305-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=ffdhe2048" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-CHACHA20-POLY1305-SHA256 ( id=4867 )" \
@@ -10944,8 +10944,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_CCM_SHA256,secp256r1,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-CCM-SHA256 ( id=4868 )" \
@@ -10970,8 +10970,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_CCM_SHA256,secp256r1,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp256r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp256r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-CCM-SHA256 ( id=4868 )" \
@@ -10996,8 +10996,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_CCM_SHA256,secp256r1,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp256r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp256r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-CCM-SHA256 ( id=4868 )" \
@@ -11024,8 +11024,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_CCM_SHA256,secp256r1,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp256r1" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp256r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-CCM-SHA256 ( id=4868 )" \
@@ -11050,8 +11050,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_CCM_SHA256,secp384r1,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-CCM-SHA256 ( id=4868 )" \
@@ -11076,8 +11076,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_CCM_SHA256,secp384r1,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp384r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp384r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-CCM-SHA256 ( id=4868 )" \
@@ -11102,8 +11102,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_CCM_SHA256,secp384r1,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp384r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp384r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-CCM-SHA256 ( id=4868 )" \
@@ -11130,8 +11130,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_CCM_SHA256,secp384r1,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp384r1" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp384r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-CCM-SHA256 ( id=4868 )" \
@@ -11156,8 +11156,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_CCM_SHA256,secp521r1,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-CCM-SHA256 ( id=4868 )" \
@@ -11182,8 +11182,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_CCM_SHA256,secp521r1,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp521r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp521r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-CCM-SHA256 ( id=4868 )" \
@@ -11208,8 +11208,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_CCM_SHA256,secp521r1,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp521r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp521r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-CCM-SHA256 ( id=4868 )" \
@@ -11236,8 +11236,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_CCM_SHA256,secp521r1,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp521r1" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp521r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-CCM-SHA256 ( id=4868 )" \
@@ -11262,8 +11262,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_CCM_SHA256,x25519,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=x25519" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=x25519" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-CCM-SHA256 ( id=4868 )" \
@@ -11288,8 +11288,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_CCM_SHA256,x25519,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=x25519" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=x25519" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-CCM-SHA256 ( id=4868 )" \
@@ -11314,8 +11314,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_CCM_SHA256,x25519,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=x25519" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=x25519" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-CCM-SHA256 ( id=4868 )" \
@@ -11342,8 +11342,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_CCM_SHA256,x25519,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=x25519" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=x25519" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-CCM-SHA256 ( id=4868 )" \
@@ -11368,8 +11368,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_CCM_SHA256,x448,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=x448" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=x448" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-CCM-SHA256 ( id=4868 )" \
@@ -11394,8 +11394,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_CCM_SHA256,x448,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=x448" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=x448" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-CCM-SHA256 ( id=4868 )" \
@@ -11420,8 +11420,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_CCM_SHA256,x448,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=x448" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=x448" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-CCM-SHA256 ( id=4868 )" \
@@ -11448,8 +11448,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_CCM_SHA256,x448,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=x448" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=x448" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-CCM-SHA256 ( id=4868 )" \
@@ -11474,8 +11474,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->m: AES_128_CCM_SHA256,ffdhe2048,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-CCM-SHA256 ( id=4868 )" \
@@ -11500,8 +11500,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->m: AES_128_CCM_SHA256,ffdhe2048,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=ffdhe2048" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=ffdhe2048" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-CCM-SHA256 ( id=4868 )" \
@@ -11526,8 +11526,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->m: AES_128_CCM_SHA256,ffdhe2048,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=ffdhe2048" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=ffdhe2048" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-CCM-SHA256 ( id=4868 )" \
@@ -11554,8 +11554,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->m: AES_128_CCM_SHA256,ffdhe2048,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=ffdhe2048" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=ffdhe2048" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-CCM-SHA256 ( id=4868 )" \
@@ -11580,8 +11580,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_CCM_8_SHA256,secp256r1,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-CCM-8-SHA256 ( id=4869 )" \
@@ -11606,8 +11606,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_CCM_8_SHA256,secp256r1,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp256r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp256r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-CCM-8-SHA256 ( id=4869 )" \
@@ -11632,8 +11632,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_CCM_8_SHA256,secp256r1,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp256r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp256r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-CCM-8-SHA256 ( id=4869 )" \
@@ -11660,8 +11660,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_CCM_8_SHA256,secp256r1,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp256r1" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp256r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-CCM-8-SHA256 ( id=4869 )" \
@@ -11686,8 +11686,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_CCM_8_SHA256,secp384r1,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-CCM-8-SHA256 ( id=4869 )" \
@@ -11712,8 +11712,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_CCM_8_SHA256,secp384r1,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp384r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp384r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-CCM-8-SHA256 ( id=4869 )" \
@@ -11738,8 +11738,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_CCM_8_SHA256,secp384r1,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp384r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp384r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-CCM-8-SHA256 ( id=4869 )" \
@@ -11766,8 +11766,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_CCM_8_SHA256,secp384r1,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp384r1" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp384r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-CCM-8-SHA256 ( id=4869 )" \
@@ -11792,8 +11792,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_CCM_8_SHA256,secp521r1,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-CCM-8-SHA256 ( id=4869 )" \
@@ -11818,8 +11818,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_CCM_8_SHA256,secp521r1,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=secp521r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=secp521r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-CCM-8-SHA256 ( id=4869 )" \
@@ -11844,8 +11844,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_CCM_8_SHA256,secp521r1,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=secp521r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=secp521r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-CCM-8-SHA256 ( id=4869 )" \
@@ -11872,8 +11872,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_CCM_8_SHA256,secp521r1,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=secp521r1" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=secp521r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-CCM-8-SHA256 ( id=4869 )" \
@@ -11898,8 +11898,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_CCM_8_SHA256,x25519,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=x25519" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=x25519" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-CCM-8-SHA256 ( id=4869 )" \
@@ -11924,8 +11924,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_CCM_8_SHA256,x25519,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=x25519" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=x25519" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-CCM-8-SHA256 ( id=4869 )" \
@@ -11950,8 +11950,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_CCM_8_SHA256,x25519,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=x25519" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=x25519" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-CCM-8-SHA256 ( id=4869 )" \
@@ -11978,8 +11978,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_CCM_8_SHA256,x25519,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=x25519" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=x25519" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-CCM-8-SHA256 ( id=4869 )" \
@@ -12004,8 +12004,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_CCM_8_SHA256,x448,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=x448" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=x448" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-CCM-8-SHA256 ( id=4869 )" \
@@ -12030,8 +12030,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_CCM_8_SHA256,x448,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=x448" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=x448" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-CCM-8-SHA256 ( id=4869 )" \
@@ -12056,8 +12056,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_CCM_8_SHA256,x448,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=x448" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=x448" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-CCM-8-SHA256 ( id=4869 )" \
@@ -12084,8 +12084,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: AES_128_CCM_8_SHA256,x448,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=x448" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=x448" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-CCM-8-SHA256 ( id=4869 )" \
@@ -12110,8 +12110,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->m: AES_128_CCM_8_SHA256,ffdhe2048,ecdsa_secp256r1_sha256" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-CCM-8-SHA256 ( id=4869 )" \
@@ -12136,8 +12136,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->m: AES_128_CCM_8_SHA256,ffdhe2048,ecdsa_secp384r1_sha384" \
-         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 curves=ffdhe2048" \
+         "$P_SRV crt_file=data_files/ecdsa_secp384r1.crt key_file=data_files/ecdsa_secp384r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp384r1_sha384 groups=ffdhe2048" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-CCM-8-SHA256 ( id=4869 )" \
@@ -12162,8 +12162,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->m: AES_128_CCM_8_SHA256,ffdhe2048,ecdsa_secp521r1_sha512" \
-         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 curves=ffdhe2048" \
+         "$P_SRV crt_file=data_files/ecdsa_secp521r1.crt key_file=data_files/ecdsa_secp521r1.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=ecdsa_secp521r1_sha512 groups=ffdhe2048" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-CCM-8-SHA256 ( id=4869 )" \
@@ -12190,8 +12190,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->m: AES_128_CCM_8_SHA256,ffdhe2048,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=ffdhe2048" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=ffdhe2048" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "server hello, chosen ciphersuite: TLS1-3-AES-128-CCM-8-SHA256 ( id=4869 )" \
@@ -12212,7 +12212,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: HRR secp256r1 -> secp384r1" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -groups P-256:P-384 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -12227,7 +12227,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: HRR secp256r1 -> secp521r1" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -groups P-256:P-521 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -12242,7 +12242,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: HRR secp256r1 -> x25519" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -groups P-256:X25519 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -12257,7 +12257,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: HRR secp256r1 -> x448" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -groups P-256:X448 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -12272,7 +12272,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 requires_openssl_tls1_3_with_ffdh
 run_test "TLS 1.3 O->m: HRR secp256r1 -> ffdhe2048" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -groups P-256:ffdhe2048 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -12287,7 +12287,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: HRR secp384r1 -> secp256r1" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -groups P-384:P-256 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -12302,7 +12302,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: HRR secp384r1 -> secp521r1" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -groups P-384:P-521 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -12317,7 +12317,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: HRR secp384r1 -> x25519" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -groups P-384:X25519 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -12332,7 +12332,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: HRR secp384r1 -> x448" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -groups P-384:X448 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -12347,7 +12347,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 requires_openssl_tls1_3_with_ffdh
 run_test "TLS 1.3 O->m: HRR secp384r1 -> ffdhe2048" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -groups P-384:ffdhe2048 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -12362,7 +12362,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: HRR secp521r1 -> secp256r1" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -groups P-521:P-256 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -12377,7 +12377,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: HRR secp521r1 -> secp384r1" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -groups P-521:P-384 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -12392,7 +12392,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: HRR secp521r1 -> x25519" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -groups P-521:X25519 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -12407,7 +12407,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: HRR secp521r1 -> x448" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -groups P-521:X448 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -12422,7 +12422,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 requires_openssl_tls1_3_with_ffdh
 run_test "TLS 1.3 O->m: HRR secp521r1 -> ffdhe2048" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -groups P-521:ffdhe2048 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -12437,7 +12437,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: HRR x25519 -> secp256r1" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -groups X25519:P-256 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -12452,7 +12452,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: HRR x25519 -> secp384r1" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -groups X25519:P-384 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -12467,7 +12467,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: HRR x25519 -> secp521r1" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -groups X25519:P-521 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -12482,7 +12482,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: HRR x25519 -> x448" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -groups X25519:X448 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -12497,7 +12497,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 requires_openssl_tls1_3_with_ffdh
 run_test "TLS 1.3 O->m: HRR x25519 -> ffdhe2048" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -groups X25519:ffdhe2048 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -12512,7 +12512,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: HRR x448 -> secp256r1" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -groups X448:P-256 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -12527,7 +12527,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: HRR x448 -> secp384r1" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -groups X448:P-384 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -12542,7 +12542,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: HRR x448 -> secp521r1" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -groups X448:P-521 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -12557,7 +12557,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3
 run_test "TLS 1.3 O->m: HRR x448 -> x25519" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -groups X448:X25519 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -12572,7 +12572,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_FFDH
 requires_openssl_tls1_3_with_ffdh
 run_test "TLS 1.3 O->m: HRR x448 -> ffdhe2048" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -groups X448:ffdhe2048 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -12587,7 +12587,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3_with_ffdh
 run_test "TLS 1.3 O->m: HRR ffdhe2048 -> secp256r1" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -groups ffdhe2048:P-256 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -12602,7 +12602,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3_with_ffdh
 run_test "TLS 1.3 O->m: HRR ffdhe2048 -> secp384r1" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -groups ffdhe2048:P-384 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -12617,7 +12617,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3_with_ffdh
 run_test "TLS 1.3 O->m: HRR ffdhe2048 -> secp521r1" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -groups ffdhe2048:P-521 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -12632,7 +12632,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3_with_ffdh
 run_test "TLS 1.3 O->m: HRR ffdhe2048 -> x25519" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -groups ffdhe2048:X25519 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -12647,7 +12647,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_openssl_tls1_3_with_ffdh
 run_test "TLS 1.3 O->m: HRR ffdhe2048 -> x448" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$O_NEXT_CLI_NO_CERT -CAfile data_files/test-ca2.crt -groups ffdhe2048:X448 -msg -tls1_3" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -12664,7 +12664,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: HRR secp256r1 -> secp384r1" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-SECP256R1:+GROUP-SECP384R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -12681,7 +12681,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: HRR secp256r1 -> secp521r1" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-SECP256R1:+GROUP-SECP521R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -12698,7 +12698,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: HRR secp256r1 -> x25519" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-SECP256R1:+GROUP-X25519:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -12715,7 +12715,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: HRR secp256r1 -> x448" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-SECP256R1:+GROUP-X448:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -12732,7 +12732,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: HRR secp256r1 -> ffdhe2048" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-SECP256R1:+GROUP-FFDHE2048:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -12749,7 +12749,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: HRR secp384r1 -> secp256r1" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-SECP384R1:+GROUP-SECP256R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -12766,7 +12766,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: HRR secp384r1 -> secp521r1" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-SECP384R1:+GROUP-SECP521R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -12783,7 +12783,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: HRR secp384r1 -> x25519" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-SECP384R1:+GROUP-X25519:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -12800,7 +12800,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: HRR secp384r1 -> x448" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-SECP384R1:+GROUP-X448:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -12817,7 +12817,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: HRR secp384r1 -> ffdhe2048" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-SECP384R1:+GROUP-FFDHE2048:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -12834,7 +12834,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: HRR secp521r1 -> secp256r1" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-SECP521R1:+GROUP-SECP256R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -12851,7 +12851,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: HRR secp521r1 -> secp384r1" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-SECP521R1:+GROUP-SECP384R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -12868,7 +12868,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: HRR secp521r1 -> x25519" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-SECP521R1:+GROUP-X25519:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -12885,7 +12885,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: HRR secp521r1 -> x448" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-SECP521R1:+GROUP-X448:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -12902,7 +12902,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: HRR secp521r1 -> ffdhe2048" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-SECP521R1:+GROUP-FFDHE2048:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -12919,7 +12919,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: HRR x25519 -> secp256r1" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-X25519:+GROUP-SECP256R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -12936,7 +12936,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: HRR x25519 -> secp384r1" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-X25519:+GROUP-SECP384R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -12953,7 +12953,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: HRR x25519 -> secp521r1" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-X25519:+GROUP-SECP521R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -12970,7 +12970,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: HRR x25519 -> x448" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-X25519:+GROUP-X448:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -12987,7 +12987,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: HRR x25519 -> ffdhe2048" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-X25519:+GROUP-FFDHE2048:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -13004,7 +13004,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: HRR x448 -> secp256r1" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-X448:+GROUP-SECP256R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -13021,7 +13021,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: HRR x448 -> secp384r1" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-X448:+GROUP-SECP384R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -13038,7 +13038,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: HRR x448 -> secp521r1" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-X448:+GROUP-SECP521R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -13055,7 +13055,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: HRR x448 -> x25519" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-X448:+GROUP-X25519:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -13072,7 +13072,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: HRR x448 -> ffdhe2048" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-X448:+GROUP-FFDHE2048:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -13089,7 +13089,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: HRR ffdhe2048 -> secp256r1" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-FFDHE2048:+GROUP-SECP256R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -13106,7 +13106,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: HRR ffdhe2048 -> secp384r1" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-FFDHE2048:+GROUP-SECP384R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -13123,7 +13123,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: HRR ffdhe2048 -> secp521r1" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-FFDHE2048:+GROUP-SECP521R1:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -13140,7 +13140,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: HRR ffdhe2048 -> x25519" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-FFDHE2048:+GROUP-X25519:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -13157,7 +13157,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: HRR ffdhe2048 -> x448" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca2.crt --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-FFDHE2048:+GROUP-X448:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -13173,7 +13173,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: HRR secp256r1 -> secp384r1" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -groups P-384 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1,secp384r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1,secp384r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -13191,7 +13191,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: HRR secp256r1 -> secp521r1" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -groups P-521 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1,secp521r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1,secp521r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -13209,7 +13209,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: HRR secp256r1 -> x25519" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -groups X25519 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1,x25519" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1,x25519" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -13227,7 +13227,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: HRR secp256r1 -> x448" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -groups X448 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1,x448" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1,x448" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -13246,7 +13246,7 @@ requires_config_enabled PSA_WANT_ALG_ECDH
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->O: HRR secp256r1 -> ffdhe2048" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -groups ffdhe2048 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1,ffdhe2048" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1,ffdhe2048" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -13264,7 +13264,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: HRR secp384r1 -> secp256r1" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -groups P-256 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1,secp256r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1,secp256r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -13282,7 +13282,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: HRR secp384r1 -> secp521r1" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -groups P-521 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1,secp521r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1,secp521r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -13300,7 +13300,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: HRR secp384r1 -> x25519" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -groups X25519 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1,x25519" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1,x25519" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -13318,7 +13318,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: HRR secp384r1 -> x448" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -groups X448 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1,x448" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1,x448" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -13337,7 +13337,7 @@ requires_config_enabled PSA_WANT_ALG_ECDH
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->O: HRR secp384r1 -> ffdhe2048" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -groups ffdhe2048 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1,ffdhe2048" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1,ffdhe2048" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -13355,7 +13355,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: HRR secp521r1 -> secp256r1" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -groups P-256 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1,secp256r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1,secp256r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -13373,7 +13373,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: HRR secp521r1 -> secp384r1" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -groups P-384 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1,secp384r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1,secp384r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -13391,7 +13391,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: HRR secp521r1 -> x25519" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -groups X25519 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1,x25519" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1,x25519" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -13409,7 +13409,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: HRR secp521r1 -> x448" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -groups X448 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1,x448" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1,x448" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -13428,7 +13428,7 @@ requires_config_enabled PSA_WANT_ALG_ECDH
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->O: HRR secp521r1 -> ffdhe2048" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -groups ffdhe2048 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1,ffdhe2048" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1,ffdhe2048" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -13446,7 +13446,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: HRR x25519 -> secp256r1" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -groups P-256 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x25519,secp256r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x25519,secp256r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -13464,7 +13464,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: HRR x25519 -> secp384r1" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -groups P-384 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x25519,secp384r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x25519,secp384r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -13482,7 +13482,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: HRR x25519 -> secp521r1" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -groups P-521 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x25519,secp521r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x25519,secp521r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -13500,7 +13500,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: HRR x25519 -> x448" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -groups X448 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x25519,x448" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x25519,x448" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -13519,7 +13519,7 @@ requires_config_enabled PSA_WANT_ALG_ECDH
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->O: HRR x25519 -> ffdhe2048" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -groups ffdhe2048 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x25519,ffdhe2048" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x25519,ffdhe2048" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -13537,7 +13537,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: HRR x448 -> secp256r1" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -groups P-256 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x448,secp256r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x448,secp256r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -13555,7 +13555,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: HRR x448 -> secp384r1" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -groups P-384 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x448,secp384r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x448,secp384r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -13573,7 +13573,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: HRR x448 -> secp521r1" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -groups P-521 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x448,secp521r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x448,secp521r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -13591,7 +13591,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->O: HRR x448 -> x25519" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -groups X25519 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x448,x25519" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x448,x25519" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -13610,7 +13610,7 @@ requires_config_enabled PSA_WANT_ALG_ECDH
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->O: HRR x448 -> ffdhe2048" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -groups ffdhe2048 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x448,ffdhe2048" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x448,ffdhe2048" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -13629,7 +13629,7 @@ requires_config_enabled PSA_WANT_ALG_ECDH
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->O: HRR ffdhe2048 -> secp256r1" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -groups P-256 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048,secp256r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048,secp256r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -13648,7 +13648,7 @@ requires_config_enabled PSA_WANT_ALG_ECDH
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->O: HRR ffdhe2048 -> secp384r1" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -groups P-384 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048,secp384r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048,secp384r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -13667,7 +13667,7 @@ requires_config_enabled PSA_WANT_ALG_ECDH
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->O: HRR ffdhe2048 -> secp521r1" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -groups P-521 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048,secp521r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048,secp521r1" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -13686,7 +13686,7 @@ requires_config_enabled PSA_WANT_ALG_ECDH
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->O: HRR ffdhe2048 -> x25519" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -groups X25519 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048,x25519" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048,x25519" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -13705,7 +13705,7 @@ requires_config_enabled PSA_WANT_ALG_ECDH
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->O: HRR ffdhe2048 -> x448" \
          "$O_NEXT_SRV_NO_CERT -cert data_files/ecdsa_secp256r1.crt -key data_files/ecdsa_secp256r1.key -groups X448 -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048,x448" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048,x448" \
          0 \
          -c "HTTP/1.0 200 ok" \
          -c "Protocol is TLSv1.3" \
@@ -13725,7 +13725,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: HRR secp256r1 -> secp384r1" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-SECP384R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1,secp384r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1,secp384r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -13745,7 +13745,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: HRR secp256r1 -> secp521r1" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-SECP521R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1,secp521r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1,secp521r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -13765,7 +13765,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: HRR secp256r1 -> x25519" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-X25519:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1,x25519" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1,x25519" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -13785,7 +13785,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: HRR secp256r1 -> x448" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-X448:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1,x448" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1,x448" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -13806,7 +13806,7 @@ requires_config_enabled PSA_WANT_ALG_ECDH
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->G: HRR secp256r1 -> ffdhe2048" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-FFDHE2048:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1,ffdhe2048" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1,ffdhe2048" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -13826,7 +13826,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: HRR secp384r1 -> secp256r1" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-SECP256R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1,secp256r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1,secp256r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -13846,7 +13846,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: HRR secp384r1 -> secp521r1" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-SECP521R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1,secp521r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1,secp521r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -13866,7 +13866,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: HRR secp384r1 -> x25519" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-X25519:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1,x25519" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1,x25519" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -13886,7 +13886,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: HRR secp384r1 -> x448" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-X448:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1,x448" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1,x448" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -13907,7 +13907,7 @@ requires_config_enabled PSA_WANT_ALG_ECDH
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->G: HRR secp384r1 -> ffdhe2048" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-FFDHE2048:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1,ffdhe2048" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1,ffdhe2048" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -13927,7 +13927,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: HRR secp521r1 -> secp256r1" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-SECP256R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1,secp256r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1,secp256r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -13947,7 +13947,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: HRR secp521r1 -> secp384r1" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-SECP384R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1,secp384r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1,secp384r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -13967,7 +13967,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: HRR secp521r1 -> x25519" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-X25519:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1,x25519" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1,x25519" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -13987,7 +13987,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: HRR secp521r1 -> x448" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-X448:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1,x448" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1,x448" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -14008,7 +14008,7 @@ requires_config_enabled PSA_WANT_ALG_ECDH
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->G: HRR secp521r1 -> ffdhe2048" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-FFDHE2048:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1,ffdhe2048" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1,ffdhe2048" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -14028,7 +14028,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: HRR x25519 -> secp256r1" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-SECP256R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x25519,secp256r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x25519,secp256r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -14048,7 +14048,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: HRR x25519 -> secp384r1" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-SECP384R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x25519,secp384r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x25519,secp384r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -14068,7 +14068,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: HRR x25519 -> secp521r1" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-SECP521R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x25519,secp521r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x25519,secp521r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -14088,7 +14088,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: HRR x25519 -> x448" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-X448:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x25519,x448" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x25519,x448" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -14109,7 +14109,7 @@ requires_config_enabled PSA_WANT_ALG_ECDH
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->G: HRR x25519 -> ffdhe2048" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-FFDHE2048:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x25519,ffdhe2048" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x25519,ffdhe2048" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -14129,7 +14129,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: HRR x448 -> secp256r1" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-SECP256R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x448,secp256r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x448,secp256r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -14149,7 +14149,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: HRR x448 -> secp384r1" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-SECP384R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x448,secp384r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x448,secp384r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -14169,7 +14169,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: HRR x448 -> secp521r1" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-SECP521R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x448,secp521r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x448,secp521r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -14189,7 +14189,7 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->G: HRR x448 -> x25519" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-X25519:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x448,x25519" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x448,x25519" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -14210,7 +14210,7 @@ requires_config_enabled PSA_WANT_ALG_ECDH
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->G: HRR x448 -> ffdhe2048" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-FFDHE2048:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x448,ffdhe2048" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x448,ffdhe2048" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -14231,7 +14231,7 @@ requires_config_enabled PSA_WANT_ALG_ECDH
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->G: HRR ffdhe2048 -> secp256r1" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-SECP256R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048,secp256r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048,secp256r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -14252,7 +14252,7 @@ requires_config_enabled PSA_WANT_ALG_ECDH
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->G: HRR ffdhe2048 -> secp384r1" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-SECP384R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048,secp384r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048,secp384r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -14273,7 +14273,7 @@ requires_config_enabled PSA_WANT_ALG_ECDH
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->G: HRR ffdhe2048 -> secp521r1" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-SECP521R1:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048,secp521r1" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048,secp521r1" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -14294,7 +14294,7 @@ requires_config_enabled PSA_WANT_ALG_ECDH
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->G: HRR ffdhe2048 -> x25519" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-X25519:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048,x25519" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048,x25519" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -14315,7 +14315,7 @@ requires_config_enabled PSA_WANT_ALG_ECDH
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->G: HRR ffdhe2048 -> x448" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/ecdsa_secp256r1.crt --x509keyfile data_files/ecdsa_secp256r1.key --priority=NONE:+CIPHER-ALL:+MAC-ALL:+SIGN-ALL:+GROUP-X448:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048,x448" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048,x448" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -14336,8 +14336,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: HRR secp256r1 -> secp384r1" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1,secp384r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1,secp384r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "got named group: secp384r1(0018)" \
@@ -14361,8 +14361,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: HRR secp256r1 -> secp521r1" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1,secp521r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1,secp521r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "got named group: secp521r1(0019)" \
@@ -14386,8 +14386,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: HRR secp256r1 -> x25519" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1,x25519" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1,x25519" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "got named group: x25519(001d)" \
@@ -14411,8 +14411,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: HRR secp256r1 -> x448" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1,x448" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1,x448" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "got named group: x448(001e)" \
@@ -14437,8 +14437,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->m: HRR secp256r1 -> ffdhe2048" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1,ffdhe2048" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1,ffdhe2048" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "got named group: ffdhe2048(0100)" \
@@ -14462,8 +14462,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: HRR secp384r1 -> secp256r1" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1,secp256r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1,secp256r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "got named group: secp256r1(0017)" \
@@ -14487,8 +14487,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: HRR secp384r1 -> secp521r1" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1,secp521r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1,secp521r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "got named group: secp521r1(0019)" \
@@ -14512,8 +14512,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: HRR secp384r1 -> x25519" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1,x25519" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1,x25519" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "got named group: x25519(001d)" \
@@ -14537,8 +14537,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: HRR secp384r1 -> x448" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1,x448" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1,x448" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "got named group: x448(001e)" \
@@ -14563,8 +14563,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->m: HRR secp384r1 -> ffdhe2048" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1,ffdhe2048" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1,ffdhe2048" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "got named group: ffdhe2048(0100)" \
@@ -14588,8 +14588,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: HRR secp521r1 -> secp256r1" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1,secp256r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1,secp256r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "got named group: secp256r1(0017)" \
@@ -14613,8 +14613,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: HRR secp521r1 -> secp384r1" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1,secp384r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1,secp384r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "got named group: secp384r1(0018)" \
@@ -14638,8 +14638,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: HRR secp521r1 -> x25519" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1,x25519" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1,x25519" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "got named group: x25519(001d)" \
@@ -14663,8 +14663,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: HRR secp521r1 -> x448" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1,x448" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1,x448" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "got named group: x448(001e)" \
@@ -14689,8 +14689,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->m: HRR secp521r1 -> ffdhe2048" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1,ffdhe2048" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1,ffdhe2048" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "got named group: ffdhe2048(0100)" \
@@ -14714,8 +14714,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: HRR x25519 -> secp256r1" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x25519,secp256r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x25519,secp256r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "got named group: secp256r1(0017)" \
@@ -14739,8 +14739,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: HRR x25519 -> secp384r1" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x25519,secp384r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x25519,secp384r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "got named group: secp384r1(0018)" \
@@ -14764,8 +14764,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: HRR x25519 -> secp521r1" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x25519,secp521r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x25519,secp521r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "got named group: secp521r1(0019)" \
@@ -14789,8 +14789,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: HRR x25519 -> x448" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x25519,x448" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x25519,x448" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "got named group: x448(001e)" \
@@ -14815,8 +14815,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->m: HRR x25519 -> ffdhe2048" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x25519,ffdhe2048" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x25519,ffdhe2048" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "got named group: ffdhe2048(0100)" \
@@ -14840,8 +14840,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: HRR x448 -> secp256r1" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x448,secp256r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x448,secp256r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "got named group: secp256r1(0017)" \
@@ -14865,8 +14865,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: HRR x448 -> secp384r1" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x448,secp384r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x448,secp384r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "got named group: secp384r1(0018)" \
@@ -14890,8 +14890,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: HRR x448 -> secp521r1" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x448,secp521r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x448,secp521r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "got named group: secp521r1(0019)" \
@@ -14915,8 +14915,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 m->m: HRR x448 -> x25519" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x448,x25519" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x448,x25519" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "got named group: x25519(001d)" \
@@ -14941,8 +14941,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->m: HRR x448 -> ffdhe2048" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x448,ffdhe2048" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x448,ffdhe2048" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "got named group: ffdhe2048(0100)" \
@@ -14967,8 +14967,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->m: HRR ffdhe2048 -> secp256r1" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048,secp256r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp256r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048,secp256r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "got named group: secp256r1(0017)" \
@@ -14993,8 +14993,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->m: HRR ffdhe2048 -> secp384r1" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048,secp384r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp384r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048,secp384r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "got named group: secp384r1(0018)" \
@@ -15019,8 +15019,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->m: HRR ffdhe2048 -> secp521r1" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048,secp521r1" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=secp521r1 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048,secp521r1" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "got named group: secp521r1(0019)" \
@@ -15045,8 +15045,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->m: HRR ffdhe2048 -> x25519" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048,x25519" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x25519 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048,x25519" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "got named group: x25519(001d)" \
@@ -15071,8 +15071,8 @@ requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
 requires_config_enabled PSA_WANT_ALG_ECDH
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->m: HRR ffdhe2048 -> x448" \
-         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
-         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 curves=ffdhe2048,x448" \
+         "$P_SRV crt_file=data_files/ecdsa_secp256r1.crt key_file=data_files/ecdsa_secp256r1.key debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=x448 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_CLI ca_file=data_files/test-ca2.crt debug_level=4 sig_algs=ecdsa_secp256r1_sha256 groups=ffdhe2048,x448" \
          0 \
          -s "Protocol is TLSv1.3" \
          -s "got named group: x448(001e)" \

--- a/tests/opt-testcases/tls13-kex-modes.sh
+++ b/tests/opt-testcases/tls13-kex-modes.sh
@@ -1537,7 +1537,7 @@ requires_all_configs_enabled MBEDTLS_SSL_PROTO_TLS1_3 MBEDTLS_SSL_TLS1_3_COMPATI
 requires_openssl_tls1_3_with_compatible_ephemeral
 requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL_ENABLED
 run_test "TLS 1.3 O->m: psk_ephemeral group(secp256r1->secp384r1) check, good" \
-         "$P_SRV tls13_kex_modes=psk_ephemeral debug_level=5 psk_list=Client_identity,6162636465666768696a6b6c6d6e6f70,abc,dead,def,beef curves=secp384r1" \
+         "$P_SRV tls13_kex_modes=psk_ephemeral debug_level=5 psk_list=Client_identity,6162636465666768696a6b6c6d6e6f70,abc,dead,def,beef groups=secp384r1" \
          "$O_NEXT_CLI_NO_CERT -tls1_3 -msg -allow_no_dhe_kex -psk_identity Client_identity -psk 6162636465666768696a6b6c6d6e6f70 -groups P-256:P-384" \
          0 \
          -s "write selected_group: secp384r1" \
@@ -1553,7 +1553,7 @@ requires_gnutls_next_disable_tls13_compat
 requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL_ENABLED
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3 G->m: psk_ephemeral group(secp256r1->secp384r1) check, good" \
-         "$P_SRV tls13_kex_modes=psk_ephemeral debug_level=5 psk_list=Client_identity,6162636465666768696a6b6c6d6e6f70,abc,dead,def,beef curves=secp384r1" \
+         "$P_SRV tls13_kex_modes=psk_ephemeral debug_level=5 psk_list=Client_identity,6162636465666768696a6b6c6d6e6f70,abc,dead,def,beef groups=secp384r1" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --priority NORMAL:-VERS-ALL:-KX-ALL:+ECDHE-PSK:+DHE-PSK:+PSK:+VERS-TLS1.3:-GROUP-ALL:+GROUP-SECP256R1:+GROUP-SECP384R1 --pskusername Client_identity --pskkey 6162636465666768696a6b6c6d6e6f70 localhost" \
          0 \
          -s "write selected_group: secp384r1" \

--- a/tests/scripts/generate_tls13_compat_tests.py
+++ b/tests/scripts/generate_tls13_compat_tests.py
@@ -67,9 +67,9 @@ NAMED_GROUP_IANA_VALUE = {
     'secp521r1': 0x19,
     'x25519': 0x1d,
     'x448': 0x1e,
+    # Only one finite field group to keep testing time within reasonable bounds.
     'ffdhe2048': 0x100,
 }
-
 
 class TLSProgram:
     """

--- a/tests/scripts/generate_tls13_compat_tests.py
+++ b/tests/scripts/generate_tls13_compat_tests.py
@@ -362,7 +362,7 @@ class MbedTLSBase(TLSProgram):
 
         if self._named_groups:
             named_groups = ','.join(self._named_groups)
-            ret += ["curves={named_groups}".format(named_groups=named_groups)]
+            ret += ["groups={named_groups}".format(named_groups=named_groups)]
         return ret
 
     def pre_checks(self):

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -1707,8 +1707,8 @@ run_test_psa_force_curve() {
     requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
     set_maybe_calc_verify none
     run_test    "PSA - ECDH with $1" \
-                "$P_SRV debug_level=4 force_version=tls12 curves=$1" \
-                "$P_CLI debug_level=4 force_ciphersuite=TLS-ECDHE-RSA-WITH-AES-128-GCM-SHA256 curves=$1" \
+                "$P_SRV debug_level=4 force_version=tls12 groups=$1" \
+                "$P_CLI debug_level=4 force_ciphersuite=TLS-ECDHE-RSA-WITH-AES-128-GCM-SHA256 groups=$1" \
                 0 \
                 -c "$maybe_calc_verify" \
                 -c "calc PSA finished" \
@@ -5396,7 +5396,7 @@ run_test    "Authentication: server goodcert, client required, no trusted CA" \
 run_test    "Authentication: server ECDH p256v1, client required, p256v1 unsupported" \
             "$P_SRV debug_level=1 key_file=data_files/server5.key \
              crt_file=data_files/server5.ku-ka.crt" \
-            "$P_CLI force_version=tls12 debug_level=3 auth_mode=required curves=secp521r1" \
+            "$P_CLI force_version=tls12 debug_level=3 auth_mode=required groups=secp521r1" \
             1 \
             -c "bad certificate (EC key curve)"\
             -c "! Certificate verification flags"\
@@ -5405,7 +5405,7 @@ run_test    "Authentication: server ECDH p256v1, client required, p256v1 unsuppo
 run_test    "Authentication: server ECDH p256v1, client optional, p256v1 unsupported" \
             "$P_SRV debug_level=1 key_file=data_files/server5.key \
              crt_file=data_files/server5.ku-ka.crt" \
-            "$P_CLI force_version=tls12 debug_level=3 auth_mode=optional curves=secp521r1" \
+            "$P_CLI force_version=tls12 debug_level=3 auth_mode=optional groups=secp521r1" \
             1 \
             -c "bad certificate (EC key curve)"\
             -c "! Certificate verification flags"\
@@ -5783,7 +5783,7 @@ requires_config_enabled MBEDTLS_X509_TRUSTED_CERTIFICATE_CALLBACK
 run_test    "Authentication, CA callback: server ECDH p256v1, client required, p256v1 unsupported" \
             "$P_SRV debug_level=1 key_file=data_files/server5.key \
              crt_file=data_files/server5.ku-ka.crt" \
-            "$P_CLI force_version=tls12 ca_callback=1 debug_level=3 auth_mode=required curves=secp521r1" \
+            "$P_CLI force_version=tls12 ca_callback=1 debug_level=3 auth_mode=required groups=secp521r1" \
             1 \
             -c "use CA callback for X.509 CRT verification" \
             -c "bad certificate (EC key curve)" \
@@ -5794,7 +5794,7 @@ requires_config_enabled MBEDTLS_X509_TRUSTED_CERTIFICATE_CALLBACK
 run_test    "Authentication, CA callback: server ECDH p256v1, client optional, p256v1 unsupported" \
             "$P_SRV debug_level=1 key_file=data_files/server5.key \
              crt_file=data_files/server5.ku-ka.crt" \
-            "$P_CLI force_version=tls12 ca_callback=1 debug_level=3 auth_mode=optional curves=secp521r1" \
+            "$P_CLI force_version=tls12 ca_callback=1 debug_level=3 auth_mode=optional groups=secp521r1" \
             1 \
             -c "use CA callback for X.509 CRT verification" \
             -c "bad certificate (EC key curve)"\
@@ -8430,7 +8430,7 @@ run_test    "Large server packet TLS 1.3 AEAD shorter tag" \
 requires_config_enabled MBEDTLS_ECP_RESTARTABLE
 requires_config_enabled MBEDTLS_ECP_DP_SECP256R1_ENABLED
 run_test    "EC restart: TLS, default" \
-            "$P_SRV curves=secp256r1 auth_mode=required" \
+            "$P_SRV groups=secp256r1 auth_mode=required" \
             "$P_CLI force_ciphersuite=TLS-ECDHE-ECDSA-WITH-AES-128-GCM-SHA256 \
              key_file=data_files/server5.key crt_file=data_files/server5.crt  \
              debug_level=1" \
@@ -8443,7 +8443,7 @@ run_test    "EC restart: TLS, default" \
 requires_config_enabled MBEDTLS_ECP_RESTARTABLE
 requires_config_enabled MBEDTLS_ECP_DP_SECP256R1_ENABLED
 run_test    "EC restart: TLS, max_ops=0" \
-            "$P_SRV curves=secp256r1 auth_mode=required" \
+            "$P_SRV groups=secp256r1 auth_mode=required" \
             "$P_CLI force_ciphersuite=TLS-ECDHE-ECDSA-WITH-AES-128-GCM-SHA256 \
              key_file=data_files/server5.key crt_file=data_files/server5.crt  \
              debug_level=1 ec_max_ops=0" \
@@ -8456,7 +8456,7 @@ run_test    "EC restart: TLS, max_ops=0" \
 requires_config_enabled MBEDTLS_ECP_RESTARTABLE
 requires_config_enabled MBEDTLS_ECP_DP_SECP256R1_ENABLED
 run_test    "EC restart: TLS, max_ops=65535" \
-            "$P_SRV curves=secp256r1 auth_mode=required" \
+            "$P_SRV groups=secp256r1 auth_mode=required" \
             "$P_CLI force_ciphersuite=TLS-ECDHE-ECDSA-WITH-AES-128-GCM-SHA256 \
              key_file=data_files/server5.key crt_file=data_files/server5.crt  \
              debug_level=1 ec_max_ops=65535" \
@@ -8471,7 +8471,7 @@ requires_config_enabled MBEDTLS_ECP_RESTARTABLE
 requires_config_enabled MBEDTLS_ECP_DP_SECP256R1_ENABLED
 requires_config_disabled MBEDTLS_USE_PSA_CRYPTO
 run_test    "EC restart: TLS, max_ops=1000 (no USE_PSA)" \
-            "$P_SRV curves=secp256r1 auth_mode=required" \
+            "$P_SRV groups=secp256r1 auth_mode=required" \
             "$P_CLI force_ciphersuite=TLS-ECDHE-ECDSA-WITH-AES-128-GCM-SHA256 \
              key_file=data_files/server5.key crt_file=data_files/server5.crt  \
              debug_level=1 ec_max_ops=1000" \
@@ -8487,7 +8487,7 @@ requires_config_enabled MBEDTLS_ECP_RESTARTABLE
 requires_config_enabled MBEDTLS_ECP_DP_SECP256R1_ENABLED
 requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
 run_test    "EC restart: TLS, max_ops=1000 (USE_PSA)" \
-            "$P_SRV curves=secp256r1 auth_mode=required" \
+            "$P_SRV groups=secp256r1 auth_mode=required" \
             "$P_CLI force_ciphersuite=TLS-ECDHE-ECDSA-WITH-AES-128-GCM-SHA256 \
              key_file=data_files/server5.key crt_file=data_files/server5.crt  \
              debug_level=1 ec_max_ops=1000" \
@@ -8502,7 +8502,7 @@ run_test    "EC restart: TLS, max_ops=1000 (USE_PSA)" \
 requires_config_enabled MBEDTLS_ECP_RESTARTABLE
 requires_config_enabled MBEDTLS_ECP_DP_SECP256R1_ENABLED
 run_test    "EC restart: TLS, max_ops=1000, badsign" \
-            "$P_SRV curves=secp256r1 auth_mode=required \
+            "$P_SRV groups=secp256r1 auth_mode=required \
              crt_file=data_files/server5-badsign.crt \
              key_file=data_files/server5.key" \
             "$P_CLI force_ciphersuite=TLS-ECDHE-ECDSA-WITH-AES-128-GCM-SHA256 \
@@ -8522,7 +8522,7 @@ requires_config_enabled MBEDTLS_ECP_RESTARTABLE
 requires_config_enabled MBEDTLS_ECP_DP_SECP256R1_ENABLED
 requires_config_disabled MBEDTLS_USE_PSA_CRYPTO
 run_test    "EC restart: TLS, max_ops=1000, auth_mode=optional badsign (no USE_PSA)" \
-            "$P_SRV curves=secp256r1 auth_mode=required \
+            "$P_SRV groups=secp256r1 auth_mode=required \
              crt_file=data_files/server5-badsign.crt \
              key_file=data_files/server5.key" \
             "$P_CLI force_ciphersuite=TLS-ECDHE-ECDSA-WITH-AES-128-GCM-SHA256 \
@@ -8543,7 +8543,7 @@ requires_config_enabled MBEDTLS_ECP_RESTARTABLE
 requires_config_enabled MBEDTLS_ECP_DP_SECP256R1_ENABLED
 requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
 run_test    "EC restart: TLS, max_ops=1000, auth_mode=optional badsign (USE_PSA)" \
-            "$P_SRV curves=secp256r1 auth_mode=required \
+            "$P_SRV groups=secp256r1 auth_mode=required \
              crt_file=data_files/server5-badsign.crt \
              key_file=data_files/server5.key" \
             "$P_CLI force_ciphersuite=TLS-ECDHE-ECDSA-WITH-AES-128-GCM-SHA256 \
@@ -8563,7 +8563,7 @@ requires_config_enabled MBEDTLS_ECP_RESTARTABLE
 requires_config_enabled MBEDTLS_ECP_DP_SECP256R1_ENABLED
 requires_config_disabled MBEDTLS_USE_PSA_CRYPTO
 run_test    "EC restart: TLS, max_ops=1000, auth_mode=none badsign (no USE_PSA)" \
-            "$P_SRV curves=secp256r1 auth_mode=required \
+            "$P_SRV groups=secp256r1 auth_mode=required \
              crt_file=data_files/server5-badsign.crt \
              key_file=data_files/server5.key" \
             "$P_CLI force_ciphersuite=TLS-ECDHE-ECDSA-WITH-AES-128-GCM-SHA256 \
@@ -8584,7 +8584,7 @@ requires_config_enabled MBEDTLS_ECP_RESTARTABLE
 requires_config_enabled MBEDTLS_ECP_DP_SECP256R1_ENABLED
 requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
 run_test    "EC restart: TLS, max_ops=1000, auth_mode=none badsign (USE_PSA)" \
-            "$P_SRV curves=secp256r1 auth_mode=required \
+            "$P_SRV groups=secp256r1 auth_mode=required \
              crt_file=data_files/server5-badsign.crt \
              key_file=data_files/server5.key" \
             "$P_CLI force_ciphersuite=TLS-ECDHE-ECDSA-WITH-AES-128-GCM-SHA256 \
@@ -8604,7 +8604,7 @@ requires_config_enabled MBEDTLS_ECP_RESTARTABLE
 requires_config_enabled MBEDTLS_ECP_DP_SECP256R1_ENABLED
 requires_config_disabled MBEDTLS_USE_PSA_CRYPTO
 run_test    "EC restart: DTLS, max_ops=1000 (no USE_PSA)" \
-            "$P_SRV curves=secp256r1 auth_mode=required dtls=1" \
+            "$P_SRV groups=secp256r1 auth_mode=required dtls=1" \
             "$P_CLI force_ciphersuite=TLS-ECDHE-ECDSA-WITH-AES-128-GCM-SHA256 \
              key_file=data_files/server5.key crt_file=data_files/server5.crt  \
              dtls=1 debug_level=1 ec_max_ops=1000" \
@@ -8620,7 +8620,7 @@ requires_config_enabled MBEDTLS_ECP_RESTARTABLE
 requires_config_enabled MBEDTLS_ECP_DP_SECP256R1_ENABLED
 requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
 run_test    "EC restart: DTLS, max_ops=1000 (USE_PSA)" \
-            "$P_SRV curves=secp256r1 auth_mode=required dtls=1" \
+            "$P_SRV groups=secp256r1 auth_mode=required dtls=1" \
             "$P_CLI force_ciphersuite=TLS-ECDHE-ECDSA-WITH-AES-128-GCM-SHA256 \
              key_file=data_files/server5.key crt_file=data_files/server5.crt  \
              dtls=1 debug_level=1 ec_max_ops=1000" \
@@ -8635,7 +8635,7 @@ requires_config_enabled MBEDTLS_ECP_RESTARTABLE
 requires_config_enabled MBEDTLS_ECP_DP_SECP256R1_ENABLED
 requires_config_disabled MBEDTLS_USE_PSA_CRYPTO
 run_test    "EC restart: TLS, max_ops=1000 no client auth (no USE_PSA)" \
-            "$P_SRV curves=secp256r1" \
+            "$P_SRV groups=secp256r1" \
             "$P_CLI force_ciphersuite=TLS-ECDHE-ECDSA-WITH-AES-128-GCM-SHA256 \
              debug_level=1 ec_max_ops=1000" \
             0 \
@@ -8651,7 +8651,7 @@ requires_config_enabled MBEDTLS_ECP_RESTARTABLE
 requires_config_enabled MBEDTLS_ECP_DP_SECP256R1_ENABLED
 requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
 run_test    "EC restart: TLS, max_ops=1000 no client auth (USE_PSA)" \
-            "$P_SRV curves=secp256r1" \
+            "$P_SRV groups=secp256r1" \
             "$P_CLI force_ciphersuite=TLS-ECDHE-ECDSA-WITH-AES-128-GCM-SHA256 \
              debug_level=1 ec_max_ops=1000" \
             0 \
@@ -8667,7 +8667,7 @@ run_test    "EC restart: TLS, max_ops=1000 no client auth (USE_PSA)" \
 requires_config_enabled MBEDTLS_ECP_RESTARTABLE
 requires_config_enabled MBEDTLS_ECP_DP_SECP256R1_ENABLED
 run_test    "EC restart: TLS, max_ops=1000, ECDHE-RSA" \
-            "$P_SRV curves=secp256r1 auth_mode=required" \
+            "$P_SRV groups=secp256r1 auth_mode=required" \
             "$P_CLI force_ciphersuite=TLS-ECDHE-RSA-WITH-AES-128-GCM-SHA256 \
              key_file=data_files/server5.key crt_file=data_files/server5.crt  \
              debug_level=1 ec_max_ops=1000" \
@@ -12322,8 +12322,8 @@ requires_config_enabled MBEDTLS_SSL_SRV_C
 requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 requires_config_enabled PSA_WANT_ALG_ECDH
 run_test "TLS 1.3: server: HRR check - mbedtls" \
-         "$P_SRV debug_level=4 curves=secp384r1" \
-         "$P_CLI debug_level=4 curves=secp256r1,secp384r1" \
+         "$P_SRV debug_level=4 groups=secp384r1" \
+         "$P_CLI debug_level=4 groups=secp256r1,secp384r1" \
          0 \
         -s "tls13 server state: MBEDTLS_SSL_CLIENT_HELLO" \
         -s "tls13 server state: MBEDTLS_SSL_SERVER_HELLO" \
@@ -12587,8 +12587,8 @@ requires_config_enabled MBEDTLS_SSL_SRV_C
 requires_config_enabled MBEDTLS_SSL_CLI_C
 requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 run_test    "TLS 1.3 m->m HRR both peers do not support middlebox compatibility" \
-            "$P_SRV debug_level=4 curves=secp384r1 tickets=0" \
-            "$P_CLI debug_level=4 curves=secp256r1,secp384r1" \
+            "$P_SRV debug_level=4 groups=secp384r1 tickets=0" \
+            "$P_CLI debug_level=4 groups=secp256r1,secp384r1" \
             0 \
             -s "Protocol is TLSv1.3" \
             -c "Protocol is TLSv1.3" \
@@ -12603,8 +12603,8 @@ requires_config_enabled PSA_WANT_ALG_ECDH
 requires_all_configs_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE \
                              MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 run_test    "TLS 1.3 m->m HRR both with middlebox compat support" \
-            "$P_SRV debug_level=4 curves=secp384r1 tickets=0" \
-            "$P_CLI debug_level=4 curves=secp256r1,secp384r1" \
+            "$P_SRV debug_level=4 groups=secp384r1 tickets=0" \
+            "$P_CLI debug_level=4 groups=secp256r1,secp384r1" \
             0 \
             -s "Protocol is TLSv1.3" \
             -c "Protocol is TLSv1.3" \
@@ -12619,7 +12619,7 @@ requires_config_enabled MBEDTLS_SSL_CLI_C
 requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 run_test    "TLS 1.3 m->O HRR both peers do not support middlebox compatibility" \
             "$O_NEXT_SRV -msg -tls1_3 -groups P-384 -no_middlebox -num_tickets 0 -no_cache" \
-            "$P_CLI debug_level=4 curves=secp256r1,secp384r1" \
+            "$P_CLI debug_level=4 groups=secp256r1,secp384r1" \
             0 \
             -c "Protocol is TLSv1.3" \
             -c "received HelloRetryRequest message" \
@@ -12633,7 +12633,7 @@ requires_config_enabled MBEDTLS_SSL_CLI_C
 requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 run_test    "TLS 1.3 m->O HRR server with middlebox compat support, not client" \
             "$O_NEXT_SRV -msg -tls1_3 -groups P-384 -num_tickets 0 -no_cache" \
-            "$P_CLI debug_level=4 curves=secp256r1,secp384r1" \
+            "$P_CLI debug_level=4 groups=secp256r1,secp384r1" \
             1 \
             -c "received HelloRetryRequest message" \
             -c "ChangeCipherSpec invalid in TLS 1.3 without compatibility mode"
@@ -12645,7 +12645,7 @@ requires_all_configs_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE \
                              MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 run_test    "TLS 1.3 m->O HRR both with middlebox compat support" \
             "$O_NEXT_SRV -msg -tls1_3 -groups P-384 -num_tickets 0 -no_resume_ephemeral -no_cache" \
-            "$P_CLI debug_level=4 curves=secp256r1,secp384r1" \
+            "$P_CLI debug_level=4 groups=secp256r1,secp384r1" \
             0 \
             -c "Protocol is TLSv1.3" \
             -c "Ignore ChangeCipherSpec in TLS 1.3 compatibility mode"
@@ -12659,7 +12659,7 @@ requires_config_enabled MBEDTLS_SSL_CLI_C
 requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 run_test    "TLS 1.3 m->G HRR both peers do not support middlebox compatibility" \
             "$G_NEXT_SRV --priority=NORMAL:-GROUP-ALL:+GROUP-SECP384R1:-VERS-ALL:+VERS-TLS1.3:%NO_TICKETS:%DISABLE_TLS13_COMPAT_MODE --disable-client-cert" \
-            "$P_CLI debug_level=4 curves=secp256r1,secp384r1" \
+            "$P_CLI debug_level=4 groups=secp256r1,secp384r1" \
             0 \
             -c "Protocol is TLSv1.3" \
             -c "received HelloRetryRequest message" \
@@ -12674,7 +12674,7 @@ requires_config_enabled MBEDTLS_SSL_CLI_C
 requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 run_test    "TLS 1.3 m->G HRR server with middlebox compat support, not client" \
             "$G_NEXT_SRV --priority=NORMAL:-GROUP-ALL:+GROUP-SECP384R1:-VERS-ALL:+VERS-TLS1.3:%NO_TICKETS --disable-client-cert" \
-            "$P_CLI debug_level=4 curves=secp256r1,secp384r1" \
+            "$P_CLI debug_level=4 groups=secp256r1,secp384r1" \
             1 \
             -c "received HelloRetryRequest message" \
             -c "ChangeCipherSpec invalid in TLS 1.3 without compatibility mode"
@@ -12688,7 +12688,7 @@ requires_all_configs_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE \
                              MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 run_test    "TLS 1.3 m->G HRR both with middlebox compat support" \
             "$G_NEXT_SRV --priority=NORMAL:-GROUP-ALL:+GROUP-SECP384R1:-VERS-ALL:+VERS-TLS1.3:+CIPHER-ALL:%NO_TICKETS --disable-client-cert" \
-            "$P_CLI debug_level=4 curves=secp256r1,secp384r1" \
+            "$P_CLI debug_level=4 groups=secp256r1,secp384r1" \
             0 \
             -c "Protocol is TLSv1.3" \
             -c "Ignore ChangeCipherSpec in TLS 1.3 compatibility mode"
@@ -12699,7 +12699,7 @@ requires_config_enabled MBEDTLS_DEBUG_C
 requires_config_enabled MBEDTLS_SSL_SRV_C
 requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 run_test    "TLS 1.3 O->m HRR both peers do not support middlebox compatibility" \
-            "$P_SRV debug_level=4 crt_file=data_files/server5.crt key_file=data_files/server5.key curves=secp384r1 tickets=0" \
+            "$P_SRV debug_level=4 crt_file=data_files/server5.crt key_file=data_files/server5.key groups=secp384r1 tickets=0" \
             "$O_NEXT_CLI -msg -debug -groups P-256:P-384 -no_middlebox" \
             0 \
             -s "Protocol is TLSv1.3" \
@@ -12712,7 +12712,7 @@ requires_config_enabled MBEDTLS_SSL_SRV_C
 requires_all_configs_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE \
                              MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 run_test    "TLS 1.3 O->m HRR server with middlebox compat support, not client" \
-            "$P_SRV debug_level=4 crt_file=data_files/server5.crt key_file=data_files/server5.key curves=secp384r1 tickets=0" \
+            "$P_SRV debug_level=4 crt_file=data_files/server5.crt key_file=data_files/server5.key groups=secp384r1 tickets=0" \
             "$O_NEXT_CLI -msg -debug -groups P-256:P-384 -no_middlebox" \
             0 \
             -s "Protocol is TLSv1.3" \
@@ -12724,7 +12724,7 @@ requires_config_enabled MBEDTLS_SSL_SRV_C
 requires_all_configs_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE \
                              MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 run_test    "TLS 1.3 O->m HRR both with middlebox compat support" \
-            "$P_SRV debug_level=4 crt_file=data_files/server5.crt key_file=data_files/server5.key curves=secp384r1 tickets=0" \
+            "$P_SRV debug_level=4 crt_file=data_files/server5.crt key_file=data_files/server5.key groups=secp384r1 tickets=0" \
             "$O_NEXT_CLI -msg -debug -groups P-256:P-384" \
             0 \
             -s "Protocol is TLSv1.3" \
@@ -12739,7 +12739,7 @@ requires_config_enabled MBEDTLS_DEBUG_C
 requires_config_enabled MBEDTLS_SSL_SRV_C
 requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 run_test    "TLS 1.3 G->m HRR both peers do not support middlebox compatibility" \
-            "$P_SRV debug_level=4 crt_file=data_files/server5.crt key_file=data_files/server5.key curves=secp384r1 tickets=0" \
+            "$P_SRV debug_level=4 crt_file=data_files/server5.crt key_file=data_files/server5.key groups=secp384r1 tickets=0" \
             "$G_NEXT_CLI localhost --priority=NORMAL:-GROUP-ALL:+GROUP-SECP256R1:+GROUP-SECP384R1:%NO_TICKETS:%DISABLE_TLS13_COMPAT_MODE -V" \
             0 \
             -s "Protocol is TLSv1.3" \
@@ -12755,7 +12755,7 @@ requires_config_enabled PSA_WANT_ALG_ECDH
 requires_all_configs_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE \
                              MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 run_test    "TLS 1.3 G->m HRR server with middlebox compat support, not client" \
-            "$P_SRV debug_level=4 crt_file=data_files/server5.crt key_file=data_files/server5.key curves=secp384r1 tickets=0" \
+            "$P_SRV debug_level=4 crt_file=data_files/server5.crt key_file=data_files/server5.key groups=secp384r1 tickets=0" \
             "$G_NEXT_CLI localhost --debug=10 --priority=NORMAL:-GROUP-ALL:+GROUP-SECP256R1:+GROUP-SECP384R1:%NO_TICKETS:%DISABLE_TLS13_COMPAT_MODE -V" \
             0 \
             -s "Protocol is TLSv1.3" \
@@ -12772,7 +12772,7 @@ requires_config_enabled PSA_WANT_ALG_ECDH
 requires_all_configs_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE \
                              MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 run_test    "TLS 1.3 G->m HRR both with middlebox compat support" \
-            "$P_SRV debug_level=4 crt_file=data_files/server5.crt key_file=data_files/server5.key curves=secp384r1 tickets=0" \
+            "$P_SRV debug_level=4 crt_file=data_files/server5.crt key_file=data_files/server5.key groups=secp384r1 tickets=0" \
             "$G_NEXT_CLI localhost --debug=10 --priority=NORMAL:-GROUP-ALL:+GROUP-SECP256R1:+GROUP-SECP384R1:%NO_TICKETS:%DISABLE_TLS13_COMPAT_MODE -V" \
             0 \
             -s "Protocol is TLSv1.3" \
@@ -13204,7 +13204,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_GCM_SHA256,ffdhe3072,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=ffdhe3072 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=ffdhe3072 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca_cat12.crt --priority=NONE:+AES-128-GCM:+SHA256:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-FFDHE3072:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -13226,7 +13226,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->G: AES_128_GCM_SHA256,ffdhe3072,rsa_pss_rsae_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/server2-sha256.crt --x509keyfile data_files/server2.key --priority=NONE:+AES-128-GCM:+SHA256:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-FFDHE3072:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=ffdhe3072" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=ffdhe3072" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -13246,7 +13246,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_GCM_SHA256,ffdhe4096,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=ffdhe4096 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=ffdhe4096 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca_cat12.crt --priority=NONE:+AES-128-GCM:+SHA256:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-FFDHE4096:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -13268,7 +13268,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->G: AES_128_GCM_SHA256,ffdhe4096,rsa_pss_rsae_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/server2-sha256.crt --x509keyfile data_files/server2.key --priority=NONE:+AES-128-GCM:+SHA256:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-FFDHE4096:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=ffdhe4096" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=ffdhe4096" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -13288,7 +13288,7 @@ requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 run_test "TLS 1.3 G->m: AES_128_GCM_SHA256,ffdhe6144,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=ffdhe6144 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=ffdhe6144 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca_cat12.crt --priority=NONE:+AES-128-GCM:+SHA256:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-FFDHE6144:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -13309,7 +13309,7 @@ requires_config_enabled MBEDTLS_X509_RSASSA_PSS_SUPPORT
 requires_config_enabled PSA_WANT_ALG_FFDH
 run_test "TLS 1.3 m->G: AES_128_GCM_SHA256,ffdhe6144,rsa_pss_rsae_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/server2-sha256.crt --x509keyfile data_files/server2.key --priority=NONE:+AES-128-GCM:+SHA256:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-FFDHE6144:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=ffdhe6144" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=ffdhe6144" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \
@@ -13330,7 +13330,7 @@ requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat
 client_needs_more_time 4
 run_test "TLS 1.3 G->m: AES_128_GCM_SHA256,ffdhe8192,rsa_pss_rsae_sha256" \
-         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=ffdhe8192 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
+         "$P_SRV crt_file=data_files/server2-sha256.crt key_file=data_files/server2.key debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=ffdhe8192 tls13_kex_modes=ephemeral cookies=0 tickets=0" \
          "$G_NEXT_CLI_NO_CERT --debug=4 --single-key-share --x509cafile data_files/test-ca_cat12.crt --priority=NONE:+AES-128-GCM:+SHA256:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-FFDHE8192:+VERS-TLS1.3:%NO_TICKETS" \
          0 \
          -s "Protocol is TLSv1.3" \
@@ -13352,7 +13352,7 @@ requires_config_enabled PSA_WANT_ALG_FFDH
 client_needs_more_time 4
 run_test "TLS 1.3 m->G: AES_128_GCM_SHA256,ffdhe8192,rsa_pss_rsae_sha256" \
          "$G_NEXT_SRV_NO_CERT --http --disable-client-cert --debug=4 --x509certfile data_files/server2-sha256.crt --x509keyfile data_files/server2.key --priority=NONE:+AES-128-GCM:+SHA256:+AEAD:+SIGN-RSA-PSS-RSAE-SHA256:+GROUP-FFDHE8192:+VERS-TLS1.3:%NO_TICKETS" \
-         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 curves=ffdhe8192" \
+         "$P_CLI ca_file=data_files/test-ca_cat12.crt debug_level=4 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 sig_algs=rsa_pss_rsae_sha256 groups=ffdhe8192" \
          0 \
          -c "HTTP/1.0 200 OK" \
          -c "Protocol is TLSv1.3" \

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -3386,7 +3386,7 @@ void raw_key_agreement_fail(int bad_server_ecdhe_key)
     if (bad_server_ecdhe_key) {
         /* Force a simulated bitflip in the server key. to make the
          * raw key agreement in ssl_write_client_key_exchange fail. */
-        (client.ssl).handshake->ecdh_psa_peerkey[0] ^= 0x02;
+        (client.ssl).handshake->dh_psa_peerkey[0] ^= 0x02;
     }
 
     TEST_EQUAL(mbedtls_test_move_handshake_to_state(

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -3386,7 +3386,7 @@ void raw_key_agreement_fail(int bad_server_ecdhe_key)
     if (bad_server_ecdhe_key) {
         /* Force a simulated bitflip in the server key. to make the
          * raw key agreement in ssl_write_client_key_exchange fail. */
-        (client.ssl).handshake->dh_psa_peerkey[0] ^= 0x02;
+        (client.ssl).handshake->xxdh_psa_peerkey[0] ^= 0x02;
     }
 
     TEST_EQUAL(mbedtls_test_move_handshake_to_state(


### PR DESCRIPTION
## Description

Follow-up PR for PR https://github.com/Mbed-TLS/mbedtls/pull/7627. Resolves https://github.com/Mbed-TLS/mbedtls/issues/7667
Built on top of PR https://github.com/Mbed-TLS/mbedtls/pull/7627.

Clean up the code by adapting names (function, fields, macros, parameters, etc.) for FFDH.

## PR checklist

- [X] **changelog** Not needed (code clean-up)
- [X] **backport** not needed (code clean-up)
- [X] **tests** not needed (code clean-up)

