### PR TITLE
cleanup PK parse - part 1

### DIFF
--- a/library/pk_internal.h
+++ b/library/pk_internal.h
@@ -117,14 +117,19 @@ static inline mbedtls_ecp_group_id mbedtls_pk_get_group_id(const mbedtls_pk_cont
 #endif /* MBEDTLS_ECP_HAVE_CURVE25519 || MBEDTLS_ECP_DP_CURVE448 */
 #endif /* MBEDTLS_PK_HAVE_ECC_KEYS */
 
-#if defined(MBEDTLS_TEST_HOOKS)
+/* Helper for (deterministic) ECDSA */
+#if defined(MBEDTLS_ECDSA_DETERMINISTIC)
+#define MBEDTLS_PK_PSA_ALG_ECDSA_MAYBE_DET  PSA_ALG_DETERMINISTIC_ECDSA
+#else
+#define MBEDTLS_PK_PSA_ALG_ECDSA_MAYBE_DET  PSA_ALG_ECDSA
+#endif
 
+#if defined(MBEDTLS_TEST_HOOKS)
 MBEDTLS_STATIC_TESTABLE int mbedtls_pk_parse_key_pkcs8_encrypted_der(
     mbedtls_pk_context *pk,
     unsigned char *key, size_t keylen,
     const unsigned char *pwd, size_t pwdlen,
     int (*f_rng)(void *, unsigned char *, size_t), void *p_rng);
-
 #endif
 
 #endif /* MBEDTLS_PK_INTERNAL_H */

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -1037,13 +1037,8 @@ static int ecdsa_sign_wrap(mbedtls_pk_context *pk, mbedtls_md_type_t md_alg,
     psa_ecc_family_t curve =
         mbedtls_ecc_group_to_psa(ctx->grp.id, &curve_bits);
     size_t key_len = PSA_BITS_TO_BYTES(curve_bits);
-#if defined(MBEDTLS_ECDSA_DETERMINISTIC)
-    psa_algorithm_t psa_sig_md =
-        PSA_ALG_DETERMINISTIC_ECDSA(mbedtls_md_psa_alg_from_type(md_alg));
-#else
-    psa_algorithm_t psa_sig_md =
-        PSA_ALG_ECDSA(mbedtls_md_psa_alg_from_type(md_alg));
-#endif
+    psa_algorithm_t psa_hash = mbedtls_md_psa_alg_from_type(md_alg);
+    psa_algorithm_t psa_sig_md = MBEDTLS_PK_PSA_ALG_ECDSA_MAYBE_DET(psa_hash);
     ((void) f_rng);
     ((void) p_rng);
 

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -976,16 +976,17 @@ static int ecdsa_sign_psa(mbedtls_svc_key_id_t key_id, mbedtls_md_type_t md_alg,
     psa_status_t status;
     psa_algorithm_t psa_sig_md;
     psa_key_attributes_t key_attr = PSA_KEY_ATTRIBUTES_INIT;
-    psa_algorithm_t alg;
+    psa_algorithm_t alg, alg2;
 
     status = psa_get_key_attributes(key_id, &key_attr);
     if (status != PSA_SUCCESS) {
         return PSA_PK_ECDSA_TO_MBEDTLS_ERR(status);
     }
     alg = psa_get_key_algorithm(&key_attr);
+    alg2 = psa_get_key_enrollment_algorithm(&key_attr);
     psa_reset_key_attributes(&key_attr);
 
-    if (PSA_ALG_IS_DETERMINISTIC_ECDSA(alg)) {
+    if (PSA_ALG_IS_DETERMINISTIC_ECDSA(alg) || PSA_ALG_IS_DETERMINISTIC_ECDSA(alg2)) {
         psa_sig_md = PSA_ALG_DETERMINISTIC_ECDSA(mbedtls_md_psa_alg_from_type(md_alg));
     } else {
         psa_sig_md = PSA_ALG_ECDSA(mbedtls_md_psa_alg_from_type(md_alg));

--- a/library/pkparse.c
+++ b/library/pkparse.c
@@ -264,7 +264,7 @@ static int pk_ecc_set_pubkey_psa_ecp_fallback(mbedtls_pk_context *pk,
     mbedtls_ecp_keypair_init(&ecp_key);
     ret = mbedtls_ecp_group_load(&(ecp_key.grp), ecp_group_id);
     if (ret != 0) {
-        return ret;
+        goto exit;
     }
     ret = mbedtls_ecp_point_read_binary(&(ecp_key.grp), &ecp_key.Q,
                                         pub, pub_len);

--- a/library/pkparse.c
+++ b/library/pkparse.c
@@ -238,13 +238,19 @@ static int pk_ecc_set_pubkey_from_prv(mbedtls_pk_context *pk,
  *              out: will have the public key set.
  * [in] pub, pub_len: the public key as an ECPoint,
  *                    in any format supported by ECP.
+ *
+ * Return:
+ * - 0 on success;
+ * - MBEDTLS_ERR_ECP_FEATURE_UNAVAILABLE if the format is potentially valid
+ *   but not supported;
+ * - another error code otherwise.
  */
 static int pk_ecc_set_pubkey_psa_ecp_fallback(mbedtls_pk_context *pk,
                                               const unsigned char *pub,
                                               size_t pub_len)
 {
 #if !defined(MBEDTLS_PK_PARSE_EC_COMPRESSED)
-    return MBEDTLS_ERR_PK_FEATURE_UNAVAILABLE;
+    return MBEDTLS_ERR_ECP_FEATURE_UNAVAILABLE;
 #else /* MBEDTLS_PK_PARSE_EC_COMPRESSED */
     mbedtls_ecp_keypair ecp_key;
     mbedtls_ecp_group_id ecp_group_id;
@@ -280,6 +286,12 @@ exit:
  * [in/out] pk: in: must have its group set, see pk_ecc_set_group().
  *              out: will have the public key set.
  * [in] pub, pub_len: the raw public key (an ECPoint).
+ *
+ * Return:
+ * - 0 on success;
+ * - MBEDTLS_ERR_ECP_FEATURE_UNAVAILABLE if the format is potentially valid
+ *   but not supported;
+ * - another error code otherwise.
  */
 static int pk_ecc_set_pubkey(mbedtls_pk_context *pk,
                              const unsigned char *pub, size_t pub_len)

--- a/library/pkparse.c
+++ b/library/pkparse.c
@@ -504,14 +504,11 @@ static int pk_ecc_set_key(mbedtls_pk_context *pk,
     psa_set_key_type(&attributes, PSA_KEY_TYPE_ECC_KEY_PAIR(pk->ec_family));
     psa_set_key_algorithm(&attributes, PSA_ALG_ECDH);
     psa_key_usage_t flags = PSA_KEY_USAGE_EXPORT | PSA_KEY_USAGE_DERIVE;
+    /* Montgomery allows only ECDH, others ECDSA too */
     if (pk->ec_family != PSA_ECC_FAMILY_MONTGOMERY) {
         flags |= PSA_KEY_USAGE_SIGN_HASH | PSA_KEY_USAGE_SIGN_MESSAGE;
-#if defined(MBEDTLS_ECDSA_DETERMINISTIC)
         psa_set_key_enrollment_algorithm(&attributes,
-                                         PSA_ALG_DETERMINISTIC_ECDSA(PSA_ALG_ANY_HASH));
-#else
-        psa_set_key_enrollment_algorithm(&attributes, PSA_ALG_ECDSA(PSA_ALG_ANY_HASH));
-#endif
+                                         MBEDTLS_PK_PSA_ALG_ECDSA_MAYBE_DET(PSA_ALG_ANY_HASH));
     }
     psa_set_key_usage_flags(&attributes, flags);
 

--- a/library/pkparse.c
+++ b/library/pkparse.c
@@ -26,7 +26,6 @@
 #include "mbedtls/oid.h"
 #include "mbedtls/platform_util.h"
 #include "mbedtls/error.h"
-#include "pk_internal.h"
 
 #include <string.h>
 

--- a/library/pkparse.c
+++ b/library/pkparse.c
@@ -302,8 +302,10 @@ static int pk_ecc_set_pubkey(mbedtls_pk_context *pk,
 #if defined(MBEDTLS_PK_USE_PSA_EC_DATA)
 
     /* Load the key */
-    if (*pub == 0x04) {
-        /* Uncompressed format, directly supported by PSA */
+    if (!PSA_ECC_FAMILY_IS_WEIERSTRASS(pk->ec_family) || *pub == 0x04) {
+        /* Format directly supported by PSA:
+         * - non-Weierstrass curves that only have one format;
+         * - uncompressed format for Weierstrass curves. */
         if (pub_len > sizeof(pk->pub_raw)) {
             return MBEDTLS_ERR_PK_BUFFER_TOO_SMALL;
         }

--- a/library/pkparse.c
+++ b/library/pkparse.c
@@ -29,16 +29,16 @@
 
 #include <string.h>
 
+/* Key types */
 #if defined(MBEDTLS_RSA_C)
 #include "mbedtls/rsa.h"
 #endif
-#include "mbedtls/ecp.h"
 #if defined(MBEDTLS_PK_HAVE_ECC_KEYS)
+#include "mbedtls/ecp.h"
 #include "pk_internal.h"
 #endif
-#if defined(MBEDTLS_ECDSA_C)
-#include "mbedtls/ecdsa.h"
-#endif
+
+/* Extended formats */
 #if defined(MBEDTLS_PEM_PARSE_C)
 #include "mbedtls/pem.h"
 #endif

--- a/library/pkparse.c
+++ b/library/pkparse.c
@@ -156,7 +156,7 @@ static int pk_ecc_set_key(mbedtls_pk_context *pk,
  * Note: the private key information is always available from pk,
  * however for convenience the serialized version is also passed,
  * as it's available at each calling site, and useful in some configs
- * (as otherwise we're have to re-serialize it from the pk context).
+ * (as otherwise we would have to re-serialize it from the pk context).
  *
  * There are three implementations of this function:
  * 1. MBEDTLS_PK_USE_PSA_EC_DATA,

--- a/library/pkparse.c
+++ b/library/pkparse.c
@@ -25,9 +25,15 @@
 #include "mbedtls/asn1.h"
 #include "mbedtls/oid.h"
 #include "mbedtls/platform_util.h"
+#include "mbedtls/platform.h"
 #include "mbedtls/error.h"
 
 #include <string.h>
+
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+#include "mbedtls/psa_util.h"
+#include "psa/crypto.h"
+#endif
 
 /* Key types */
 #if defined(MBEDTLS_RSA_C)
@@ -48,16 +54,6 @@
 #if defined(MBEDTLS_PKCS12_C)
 #include "mbedtls/pkcs12.h"
 #endif
-
-#if defined(MBEDTLS_PSA_CRYPTO_C)
-#include "psa_util_internal.h"
-#endif
-
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
-#include "psa/crypto.h"
-#endif
-
-#include "mbedtls/platform.h"
 
 /* Helper for Montgomery curves */
 #if defined(MBEDTLS_PK_HAVE_ECC_KEYS) && defined(MBEDTLS_PK_HAVE_RFC8410_CURVES)

--- a/library/pkparse.c
+++ b/library/pkparse.c
@@ -55,13 +55,14 @@
 #include "mbedtls/pkcs12.h"
 #endif
 
+#if defined(MBEDTLS_PK_HAVE_ECC_KEYS)
+
 /* Helper for Montgomery curves */
-#if defined(MBEDTLS_PK_HAVE_ECC_KEYS) && defined(MBEDTLS_PK_HAVE_RFC8410_CURVES)
+#if defined(MBEDTLS_PK_HAVE_RFC8410_CURVES)
 #define MBEDTLS_PK_IS_RFC8410_GROUP_ID(id)  \
     ((id == MBEDTLS_ECP_DP_CURVE25519) || (id == MBEDTLS_ECP_DP_CURVE448))
-#endif /* MBEDTLS_PK_HAVE_ECC_KEYS && MBEDTLS_PK_HAVE_RFC8410_CURVES */
+#endif /* MBEDTLS_PK_HAVE_RFC8410_CURVES */
 
-#if defined(MBEDTLS_PK_HAVE_ECC_KEYS)
 /* Minimally parse an ECParameters buffer to and mbedtls_asn1_buf
  *
  * ECParameters ::= CHOICE {

--- a/library/pkparse.c
+++ b/library/pkparse.c
@@ -250,6 +250,9 @@ static int pk_ecc_set_pubkey_psa_ecp_fallback(mbedtls_pk_context *pk,
                                               size_t pub_len)
 {
 #if !defined(MBEDTLS_PK_PARSE_EC_COMPRESSED)
+    (void) pk;
+    (void) pub;
+    (void) pub_len;
     return MBEDTLS_ERR_ECP_FEATURE_UNAVAILABLE;
 #else /* MBEDTLS_PK_PARSE_EC_COMPRESSED */
     mbedtls_ecp_keypair ecp_key;

--- a/library/pkparse.c
+++ b/library/pkparse.c
@@ -351,7 +351,7 @@ static int pk_ecc_set_pubkey(mbedtls_pk_context *pk,
  *      Low-level ECC parsing: optional support for SpecifiedECDomain
  *
  * There are two functions here that are used by the rest of the code:
- * - pk_ecc_tag_may_be_speficied_ec_domain()
+ * - pk_ecc_tag_is_speficied_ec_domain()
  * - pk_ecc_group_id_from_specified()
  *
  * All the other functions are internal to this section.
@@ -365,7 +365,7 @@ static int pk_ecc_set_pubkey(mbedtls_pk_context *pk,
 
 #if !defined(MBEDTLS_PK_PARSE_EC_EXTENDED)
 /* See the "real" version for documentation */
-static int pk_ecc_tag_may_be_specified_ec_domain(int tag)
+static int pk_ecc_tag_is_specified_ec_domain(int tag)
 {
     (void) tag;
     return 0;
@@ -384,7 +384,7 @@ static int pk_ecc_group_id_from_specified(const mbedtls_asn1_buf *params,
  * Tell if the passed tag might be the start of SpecifiedECDomain
  * (that is, a sequence).
  */
-static int pk_ecc_tag_may_be_specified_ec_domain(int tag)
+static int pk_ecc_tag_is_specified_ec_domain(int tag)
 {
     return tag == (MBEDTLS_ASN1_CONSTRUCTED | MBEDTLS_ASN1_SEQUENCE);
 }
@@ -660,7 +660,7 @@ static int pk_get_ecparams(unsigned char **p, const unsigned char *end,
     /* Acceptable tags: OID for namedCurve, or specifiedECDomain */
     params->tag = **p;
     if (params->tag != MBEDTLS_ASN1_OID &&
-        !pk_ecc_tag_may_be_specified_ec_domain(params->tag)) {
+        !pk_ecc_tag_is_specified_ec_domain(params->tag)) {
         return MBEDTLS_ERROR_ADD(MBEDTLS_ERR_PK_KEY_INVALID_FORMAT,
                                  MBEDTLS_ERR_ASN1_UNEXPECTED_TAG);
     }


### PR DESCRIPTION
## Description

This is part 1 of  #7994 - focusing on  `MBEDTLS_PK_USE_PSA_EC_DATA` mostly, plus miscellaneous other things.

I decided to stop after about 20 commits in order to keep it reviewable, I'll continue #7994 in another PR once this one is OK.

Note to reviewers: some commits just move code around and can easily be reviewed with `git show --color-moved <commit_id>`.

## PR checklist

- [x] **changelog** not required - internal refactoring
- [x] **backport** not required - refactoring only applies to 3.x
- [x] **tests** not required - covered by existing tests