### PR TITLE
Officially require Python 3.8

### DIFF
--- a/ChangeLog.d/python3.8.txt
+++ b/ChangeLog.d/python3.8.txt
@@ -1,0 +1,2 @@
+Requirement changes
+   * Officially require Python 3.8 now that earlier versions are out of support.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ You need the following tools to build the library with the provided makefiles:
 
 * GNU Make 3.82 or a build tool that CMake supports.
 * A C99 toolchain (compiler, linker, archiver). We actively test with GCC 5.4, Clang 3.8, IAR 8 and Visual Studio 2013. More recent versions should work. Slightly older versions may work.
-* Python 3.6 to generate the test code, and to generate sample programs in the development branch.
+* Python 3.6 to generate the test code. Python is also needed to integrate PSA drivers and to build the development branch (see next section).
 * Perl to run the tests, and to generate some source files in the development branch.
 * CMake 3.10.2 or later (if using CMake).
 * Microsoft Visual Studio 2013 or later (if using Visual Studio).

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ You need the following tools to build the library with the provided makefiles:
 
 * GNU Make 3.82 or a build tool that CMake supports.
 * A C99 toolchain (compiler, linker, archiver). We actively test with GCC 5.4, Clang 3.8, IAR 8 and Visual Studio 2013. More recent versions should work. Slightly older versions may work.
-* Python 3.6 to generate the test code. Python is also needed to integrate PSA drivers and to build the development branch (see next section).
+* Python 3.8 to generate the test code. Python is also needed to integrate PSA drivers and to build the development branch (see next section).
 * Perl to run the tests, and to generate some source files in the development branch.
 * CMake 3.10.2 or later (if using CMake).
 * Microsoft Visual Studio 2013 or later (if using Visual Studio).
@@ -61,7 +61,7 @@ The source code of Mbed TLS includes some files that are automatically generated
 The following tools are required:
 
 * Perl, for some library source files and for Visual Studio build files.
-* Python 3 and some Python packages, for some library source files, sample programs and test data. To install the necessary packages, run:
+* Python 3.8 and some Python packages, for some library source files, sample programs and test data. To install the necessary packages, run:
     ```
     python3 -m pip install --user -r scripts/basic.requirements.txt
     ```


### PR DESCRIPTION
Python 3.7 [has just reached its end of life](https://devguide.python.org/versions/). Officially require Python 3.8.

Currently all of our scripts work with Python 3.5, but we do not promise that this will remain true in the next release.

Targetting the next release, because by that time we might not be testing everything on older Python versions anymore.

Note: 2.28.0 was released a few days before EOL of Python 3.6. Its documentation states a requirement for “Python 3”.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** provided
- [x] **backport** #7868  (just clarifying, not changing, the Python version requirement)
- [x] **tests** N/A
