### PR TITLE
Backport 2.28: officially require Python 3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ You need the following tools to build the library with the provided makefiles:
 
 * GNU Make or a build tool that CMake supports.
 * A C99 toolchain (compiler, linker, archiver). We actively test with GCC 5.4, Clang 3.8, IAR8 and Visual Studio 2013. More recent versions should work. Slightly older versions may work.
-* Python 3 to generate the test code.
+* Python 3.6 or later to generate the test code.
 * Perl to run the tests.
 
 ### Make


### PR DESCRIPTION
Mbed TLS 2.28.0 was released on 2021-12-15. At the time, the oldest officially supported Python version was 3.6 (which reached its end of life on 2021-12-23). So promise backward compatibility with 3.6, but no earlier.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** no (this is a clarification, not a change)
- [x] **backport** of https://github.com/Mbed-TLS/mbedtls/pull/7867 (sort of)
- [x] **tests** N/A



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.
