### PR TITLE
Bug:fix `test_tls13_only_ephemeral_ffdh` fail

### DIFF
--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -35,7 +35,7 @@
 #include "ssl_debug_helpers.h"
 #include "md_psa.h"
 
-#if defined(PSA_WANT_ALG_ECDH)
+#if defined(PSA_WANT_ALG_ECDH) || defined(PSA_WANT_ALG_FFDH)
 /* Define a local translating function to save code size by not using too many
  * arguments in each translating place. */
 static int local_err_translation(psa_status_t status)


### PR DESCRIPTION
## Description

#7665  and #7627 are conflict on the guards.  When `PSA_WANT_ALG_ECDH` is disabled, it reports build break


https://github.com/Mbed-TLS/mbedtls/blob/9cf17dad9d32dc4cedbac0d25ea57d2006a3a34b/library/ssl_tls13_client.c#L38 is conflict with  https://github.com/Mbed-TLS/mbedtls/blob/9cf17dad9d32dc4cedbac0d25ea57d2006a3a34b/library/ssl_tls13_client.c#L197

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [ ] **changelog** provided, or not required
- [ ] **backport** done, or not required
- [ ] **tests** provided, or not required


