### PR TITLE
code_size_compare.py: run make clean before build libraries

### DIFF
--- a/scripts/code_size_compare.py
+++ b/scripts/code_size_compare.py
@@ -273,6 +273,7 @@ class CodeSizeComparison(CodeSizeBase):
         self.old_rev = old_revision
         self.new_rev = new_revision
         self.git_command = "git"
+        self.make_clean = 'make clean'
         self.make_command = code_size_info.make_command
         self.fname_suffix = "-" + code_size_info.arch + "-" +\
                             code_size_info.config
@@ -306,6 +307,10 @@ class CodeSizeComparison(CodeSizeBase):
 
         my_environment = os.environ.copy()
         try:
+            subprocess.check_output(
+                self.make_clean, env=my_environment, shell=True,
+                cwd=git_worktree_path, stderr=subprocess.STDOUT,
+            )
             subprocess.check_output(
                 self.make_command, env=my_environment, shell=True,
                 cwd=git_worktree_path, stderr=subprocess.STDOUT,

--- a/scripts/code_size_compare.py
+++ b/scripts/code_size_compare.py
@@ -91,6 +91,7 @@ class CodeSizeInfo: # pylint: disable=too-few-public-methods
         """
         arch: architecture to measure code size on.
         config: configuration type to measure code size with.
+        sys_arch: host architecture.
         make_command: command to build library (Inferred from arch and config).
         """
         self.arch = arch


### PR DESCRIPTION
## Description

If we don't remove all executable files in current working directory, we might measure code size between different architecture and configuration. This generates a wrong code size comparison report. This PR guarantees it runs `make clean` before build libraries for code size comparison.

This is an enhancement of #7650. 

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** no
- [x] **backport** not required
- [x] **tests** not required