### PR TITLE
aesce: use correct target attribute when building with clang

### DIFF
--- a/library/aesce.c
+++ b/library/aesce.c
@@ -68,7 +68,7 @@
 
 #if !defined(__ARM_FEATURE_AES) || defined(MBEDTLS_ENABLE_ARM_CRYPTO_EXTENSIONS_COMPILER_FLAG)
 #   if defined(__clang__)
-#       pragma clang attribute push (__attribute__((target("crypto"))), apply_to=function)
+#       pragma clang attribute push (__attribute__((target("aes"))), apply_to=function)
 #       define MBEDTLS_POP_TARGET_PRAGMA
 #   elif defined(__GNUC__)
 #       pragma GCC push_options


### PR DESCRIPTION
## Description

Somehow related to https://github.com/Mbed-TLS/mbedtls/pull/7834, it was discovered soon after that one.

Seems clang has its own issues when it comes to crypto extensions, and right now the best way to avoid them is to accurately enable the needed instructions instead of the broad crypto feature.

E.g.: https://github.com/llvm/llvm-project/issues/61645

## PR checklist

- [x] **changelog** not required
- [x] **backport** not required
- [x] **tests** not required (was tested in yocto builds with different aarch64 tunings variations)