### PR TITLE
tests/test_suite_pem: Augment DES test cases with AES: PEM

### DIFF
--- a/tests/suites/test_suite_pem.data
+++ b/tests/suites/test_suite_pem.data
@@ -30,6 +30,10 @@ PEM read (DES-CBC + invalid iv)
 depends_on:MBEDTLS_MD_CAN_MD5:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_DES_C
 mbedtls_pem_read_buffer:"^":"$":"^\nProc-Type\: 4,ENCRYPTED\nDEK-Info\: DES-CBC,00$":"pwd":MBEDTLS_ERR_PEM_INVALID_ENC_IV:""
 
+PEM read (AES-128-CBC + invalid iv)
+depends_on:MBEDTLS_MD_CAN_MD5:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_AES_C
+mbedtls_pem_read_buffer:"^":"$":"^\nProc-Type\: 4,ENCRYPTED\nDEK-Info\: AES-128-CBC,00$":"pwd":MBEDTLS_ERR_PEM_INVALID_ENC_IV:""
+
 PEM read (unknown encryption algorithm)
 depends_on:MBEDTLS_MD_CAN_MD5:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_AES_C
 mbedtls_pem_read_buffer:"^":"$":"^\nProc-Type\: 4,ENCRYPTED\nDEK-Info\: AES-,00$":"pwd":MBEDTLS_ERR_PEM_UNKNOWN_ENC_ALG:""


### PR DESCRIPTION
## Description

A few negative test cases in test_suite_pem.data rely on DES (“invalid iv”, “malformed”). DES is deprecated.
Construct similar test cases using AES and use them to remove the DES ones.

This is in response to issue #7037 

## PR checklist

- [x] **changelog**: Not needed because this is a change in the test data.
- [x] **backport** : https://github.com/Mbed-TLS/mbedtls/pull/7901
- [x] **tests**: Provided


## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.
