### PR TITLE
Add script to add python generated files

### DIFF
--- a/scripts/git_add_generated_files.sh
+++ b/scripts/git_add_generated_files.sh
@@ -1,3 +1,7 @@
+#!/bin/bash
+
+set -eu
+
 cd $(dirname ${BASH_SOURCE[0]})
 cd ..
 git reset .

--- a/scripts/git_add_generated_files.sh
+++ b/scripts/git_add_generated_files.sh
@@ -1,0 +1,7 @@
+cd $(dirname ${BASH_SOURCE[0]})
+cd ..
+git reset .
+git clean -Xfd
+make generated_files
+git ls-files -oi --exclude-standard | git add -f --pathspec-from-file=-
+git ls-files -ci --exclude="*.pyc" | git reset --pathspec-from-file=-


### PR DESCRIPTION
## Description

fix #6134 
For releases we add generated python files so users do not need python to generate the files themselves, but on the development branch these files are untracked and ignored by git. The script generates these files and gets git to track them so then a release commit can be made.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] changelog: not needed because not a feature or bug
- [x] backport: not needed because not a bug
- [x] tests: manually tested

## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.
