### PR TITLE
AES: fix mismatch comment in #endif

### DIFF
--- a/library/aes.c
+++ b/library/aes.c
@@ -321,9 +321,9 @@ static const uint32_t RT2[256] = { RT };
 static const uint32_t RT3[256] = { RT };
 #undef V
 
-#endif /* !defined(MBEDTLS_AES_DECRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT) */
-
 #endif /* !MBEDTLS_AES_FEWER_TABLES */
+
+#endif /* !defined(MBEDTLS_AES_DECRYPT_ALT) || !defined(MBEDTLS_AES_SETKEY_DEC_ALT) */
 
 #undef RT
 


### PR DESCRIPTION
## Description

A tiny and quick fix to match comment in `#endif` for aes.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required
- [x] **backport** no, there is no issue in 2.28, so backport is not needed.
- [x] **tests** not required

