### PR TITLE
ECPf wrap-up

### DIFF
--- a/ChangeLog.d/driver-only-ecc.txt
+++ b/ChangeLog.d/driver-only-ecc.txt
@@ -5,3 +5,6 @@ Features
      MBEDTLS_USE_PSA_CRYPTO. Restartable/interruptible ECDHE operations in
      TLS 1.2 (ECDHE-ECDSA key exchange) are not supported in those builds yet,
      as PSA does not have an API for restartable ECDH yet.
+   * When all of ECDH, ECDSA and EC J-PAKE are either disabled or provided by
+     a driver, it is possible to disable MBEDTLS_ECP_C and still get support
+     for ECC keys and algorithms in PSA. See docs/driver-only-builds.txt.

--- a/ChangeLog.d/extend-pk-opaque-ecc.txt
+++ b/ChangeLog.d/extend-pk-opaque-ecc.txt
@@ -1,0 +1,6 @@
+Features
+   * Support for "opaque" (PSA-held) ECC keys in the PK module has been
+     extended: it is now possible to use mbedtls_pk_write_key_der(),
+     mbedtls_pk_write_key_pem(), mbedtls_pk_check_pair(), and
+     mbedtls_pk_verify() with opaque ECC keys (provided the PSA attributes
+     allow it).

--- a/docs/driver-only-builds.md
+++ b/docs/driver-only-builds.md
@@ -1,0 +1,78 @@
+This document explains how to create builds of Mbed TLS where some
+cryptographic mechanisms are provided only by PSA drivers (that is, no
+built-in implementation of those algorithms), from a user's perspective.
+
+This is useful to save code size for people who are using either a hardware
+accelerator, or an alternative software implementation that's more
+aggressively optimized for code size than the default one in Mbed TLS.
+
+General considerations
+----------------------
+
+This document assumes that you already have a working driver.
+Otherwise, please see the [PSA driver example and
+guide](psa-driver-example-and-guide.md) for information on writing a
+driver.
+
+In order to have some mechanism provided only by a driver, you'll want
+the following compile-time configuration options enabled:
+- `MBEDTLS_PSA_CRYPTO_C` (enabled by default) - this enables PSA Crypto.
+- `MBEDTLS_USE_PSA_CRYPTO` (disabled by default) - this makes PK, X.509 and
+  TLS use PSA Crypto. You need to enable this if you're using PK, X.509 or TLS
+and want them to have access to the algorithms provided by your driver. (See
+[the dedicated document](use-psa-crypto.md) for details.)
+- `MBEDTLS_PSA_CRYPTO_CONFIG` (disabled by default) - this enables
+  configuration of cryptographic algorithms using `PSA_WANT` macros in
+`include/psa/crypto_config.h`. See [Conditional inclusion of cryptographic
+mechanism through the PSA API in Mbed
+TLS](proposed/psa-conditional-inclusion-c.md) for details.
+
+In addition, for each mechanism you want provided only by your driver:
+- Define the corresponding `PSA_WANT` macro in `psa/crypto_config.h` - this
+  means the algorithm will be available in the PSA Crypto API.
+- Define the corresponding `MBEDTLS_PSA_ACCEL` in your build (could be in
+  `psa/crypto_config.h` or your compiler's command line). This informs the PSA
+code that an accelerator is available for this.
+- Undefine / comment out the corresponding `MBEDTLS_xxx_C` macro in
+  `mbedtls/mbedtls_config.h`. This ensures the built-in implementation is not
+included in the build.
+
+For example, if you want SHA-256 to be provided only by a driver, you'll want
+`PSA_WANT_ALG_SHA_256` and `MBEDTLS_PSA_ACCEL_SHA_256` defined, and
+`MBEDTLS_SHA256_C` undefined.
+
+In addition to these compile-time considerations, at runtime you'll need to
+make sure you call `psa_crypto_init()` before any function that uses the
+mechanisms provided only by drivers. Note that this is already a requirement
+for any use of the PSA Crypto API, as well as for use of the PK, X.509 and TLS
+modules when `MBEDTLS_USE_PSA_CRYPTO` is enabled, so in most cases your
+application will already be doing this.
+
+Mechanisms covered
+------------------
+
+For now, only two families are supported:
+- hashes: SHA-3, SHA-2, SHA-1, MD5, etc.
+- elliptic-curve cryptography (ECC): ECDH, ECDSA, EC J-PAKE, ECC key types.
+
+Supported means that when those are provided only by drivers, everything
+(including PK, X.509 and TLS if `MBEDTLS_USE_PSA_CRYPTO` is enabled) should
+work in the same way as if the mechanisms where built-in, except as documented
+in the "Limitations" sub-sections of the sections dedicated to each family
+below.
+
+In the near future (end of 2023), we are planning to also add support for
+ciphers (AES) and AEADs (GCM, CCM, ChachaPoly).
+
+Currently (mid-2023) we don't have plans to extend this to RSA of FFDH. If
+you're interested in driver-only support for those, please let us know.
+
+Hashes
+------
+
+TODO
+
+Elliptic-curve cryptography (ECC)
+---------------------------------
+
+TODO

--- a/docs/driver-only-builds.md
+++ b/docs/driver-only-builds.md
@@ -30,9 +30,9 @@ TLS](proposed/psa-conditional-inclusion-c.md) for details.
 In addition, for each mechanism you want provided only by your driver:
 - Define the corresponding `PSA_WANT` macro in `psa/crypto_config.h` - this
   means the algorithm will be available in the PSA Crypto API.
-- Define the corresponding `MBEDTLS_PSA_ACCEL` in your build (could be in
-  `psa/crypto_config.h` or your compiler's command line). This informs the PSA
-code that an accelerator is available for this.
+- Define the corresponding `MBEDTLS_PSA_ACCEL` in your build. This could be
+  defined in `psa/crypto_config.h` or your compiler's command line. This
+informs the PSA code that an accelerator is available for this mechanism.
 - Undefine / comment out the corresponding `MBEDTLS_xxx_C` macro in
   `mbedtls/mbedtls_config.h`. This ensures the built-in implementation is not
 included in the build.
@@ -43,10 +43,10 @@ For example, if you want SHA-256 to be provided only by a driver, you'll want
 
 In addition to these compile-time considerations, at runtime you'll need to
 make sure you call `psa_crypto_init()` before any function that uses the
-mechanisms provided only by drivers. Note that this is already a requirement
-for any use of the PSA Crypto API, as well as for use of the PK, X.509 and TLS
-modules when `MBEDTLS_USE_PSA_CRYPTO` is enabled, so in most cases your
-application will already be doing this.
+driver-only mechanisms. Note that this is already a requirement for any use of
+the PSA Crypto API, as well as for use of the PK, X.509 and TLS modules when
+`MBEDTLS_USE_PSA_CRYPTO` is enabled, so in most cases your application will
+already be doing this.
 
 Mechanisms covered
 ------------------
@@ -93,7 +93,7 @@ More precisely:
   `MBEDTLS_PSA_ACCEL_ALG_JPAKE` is enabled.
 
 In addition, if none of `MBEDTLS_ECDH_C`, `MBEDTLS_ECDSA_C`,
-`MBEDTLS_ECJPAKE_C` is enabled, you can enable:
+`MBEDTLS_ECJPAKE_C` are enabled, you can enable:
 - `PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY`;
 - `PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_BASIC`;
 - `PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT`;
@@ -125,8 +125,8 @@ result in some code size savings, but not as much as when none of the
 above features are enabled.
 
 We do have plans to support each of these with `ecp.c` fully removed in the
-future, however no established timeline. If you're interested, please let us
-know, so we can take it into consideration in our planning.
+future, however there is no established timeline. If you're interested, please
+let us know, so we can take it into consideration in our planning.
 
 ### Limitations regarding restartable / interruptible ECC operations
 
@@ -139,7 +139,7 @@ are not supported without `ECDH_C`. See also limitations regarding
 restartable operations with `MBEDTLS_USE_PSA_CRYPTO` in [its
 documentation](use-psa-crypto.md).
 
-Again, we have plans to support this in the future but not established
+Again, we have plans to support this in the future but not with an established
 timeline, please let us know if you're interested.
 
 ### Limitations regarding the selection of curves

--- a/docs/driver-only-builds.md
+++ b/docs/driver-only-builds.md
@@ -51,9 +51,10 @@ application will already be doing this.
 Mechanisms covered
 ------------------
 
-For now, only two families are supported:
+For now, only the following (families of) mechanisms are supported:
 - hashes: SHA-3, SHA-2, SHA-1, MD5, etc.
 - elliptic-curve cryptography (ECC): ECDH, ECDSA, EC J-PAKE, ECC key types.
+- finite-field Diffie-Hellman: FFDH algorithm, DH key types.
 
 Supported means that when those are provided only by drivers, everything
 (including PK, X.509 and TLS if `MBEDTLS_USE_PSA_CRYPTO` is enabled) should
@@ -64,8 +65,8 @@ below.
 In the near future (end of 2023), we are planning to also add support for
 ciphers (AES) and AEADs (GCM, CCM, ChachaPoly).
 
-Currently (mid-2023) we don't have plans to extend this to RSA of FFDH. If
-you're interested in driver-only support for those, please let us know.
+Currently (mid-2023) we don't have plans to extend this to RSA. If
+you're interested in driver-only support for RSA, please let us know.
 
 Hashes
 ------
@@ -144,3 +145,8 @@ timeline, please let us know if you're interested.
 
 TODO: apparently we don't really support having some curves built-in and
 others driver-only... investigate and describe the situation. See also #7899.
+
+Finite-field Diffie-Hellman
+---------------------------
+
+TODO

--- a/docs/driver-only-builds.md
+++ b/docs/driver-only-builds.md
@@ -118,10 +118,11 @@ the following is enabled:
 - `PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE` - support for deterministic
   derivation of an ECC keypair with `psa_key_derivation_output_key()`.
 
-Note: when one of the above options is enabled, you can still `MBEDTLS_ECP_C`
-in `mbedtls_config.h`, and it will still result in some code size savings, but
-not as much as when none of these are enabled, as a subset of `ecp.c` will
-still be included in the build in order to support these.
+Note: when any of the above options is enabled, a subset of `ecp.c` will
+automatically be included in the build in order to support it. Therefore
+you can still disable `MBEDTLS_ECP_C` in `mbedtls_config.h` and this will
+result in some code size savings, but not as much as when none of the
+above features are enabled.
 
 We do have plans to support each of these with `ecp.c` fully removed in the
 future, however no established timeline. If you're interested, please let us
@@ -129,7 +130,7 @@ know, so we can take it into consideration in our planning.
 
 ### Limitations regarding restartable / interruptible ECC operations
 
-At the moment, the is not driver support for interruptible operations
+At the moment, there is not driver support for interruptible operations
 (see `psa_sign_hash_start()` + `psa_sign_hash_complete()` etc.) so as a
 consequence these are not supported in builds without `MBEDTLS_ECDSA_C`.
 


### PR DESCRIPTION
## Description

Resolves #7452. The most important part is adding some user-oriented documentation about driver-only builds. So far, only covering generalities as well as ECC - the section on hashes is overdue but will be added in another PR.

## PR checklist

- [x] **changelog** provided
- [x] **backport** not required - documenting 3.x-only features
- [x] **tests** not required - documentation only