### PR TITLE
misc improvements

### DIFF
--- a/library/aesni.h
+++ b/library/aesni.h
@@ -165,6 +165,6 @@ int mbedtls_aesni_setkey_enc(unsigned char *rk,
 #endif
 
 #endif /* MBEDTLS_AESNI_HAVE_CODE */
-#endif  /* MBEDTLS_AESNI_C */
+#endif  /* MBEDTLS_AESNI_C && (MBEDTLS_ARCH_IS_X64 || MBEDTLS_ARCH_IS_X86) */
 
 #endif /* MBEDTLS_AESNI_H */

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -1146,21 +1146,21 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED */
-void ssl_set_hostname_twice(char *hostname0, char *hostname1)
+void ssl_set_hostname_twice(char *input_hostname0, char *input_hostname1)
 {
-    const char *hostname;
+    const char *output_hostname;
     mbedtls_ssl_context ssl;
 
     mbedtls_ssl_init(&ssl);
     USE_PSA_INIT();
 
-    TEST_ASSERT(mbedtls_ssl_set_hostname(&ssl, hostname0) == 0);
-    hostname = mbedtls_ssl_get_hostname(&ssl);
-    TEST_ASSERT(strcmp(hostname0, hostname) == 0);
+    TEST_ASSERT(mbedtls_ssl_set_hostname(&ssl, input_hostname0) == 0);
+    output_hostname = mbedtls_ssl_get_hostname(&ssl);
+    TEST_ASSERT(strcmp(input_hostname0, output_hostname) == 0);
 
-    TEST_ASSERT(mbedtls_ssl_set_hostname(&ssl, hostname1) == 0);
-    hostname = mbedtls_ssl_get_hostname(&ssl);
-    TEST_ASSERT(strcmp(hostname1, hostname) == 0);
+    TEST_ASSERT(mbedtls_ssl_set_hostname(&ssl, input_hostname1) == 0);
+    output_hostname = mbedtls_ssl_get_hostname(&ssl);
+    TEST_ASSERT(strcmp(input_hostname1, output_hostname) == 0);
 
 exit:
     mbedtls_ssl_free(&ssl);


### PR DESCRIPTION
## Description

This PR is aimed to collect some improvements or comments of merged PR that were not worth iterating the original ones. Until it contains sufficient contents, this PR is not worth to be reviewed.

## Content list

- 9d87a38976cb0b9f8df8228c47acb0ebefe0c00f: improve variable naming in ssl_set_hostname_twice. Resolve https://github.com/Mbed-TLS/mbedtls/pull/7216#discussion_r1258372308
- 6f0259e6da4d7677b48701a68adb529ea02b4473: Resolve https://github.com/Mbed-TLS/mbedtls/pull/8209#discussion_r1326834863



## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not needed
- [x] **backport** aesni.h has a backport; the test change does not - not worth backporting
- [x] **tests** not needed
