### PR TITLE
PSA: add guards for PAKE getter functions

### DIFF
--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -7629,6 +7629,7 @@ exit:
     return status;
 }
 
+#if defined(PSA_WANT_ALG_SOME_PAKE)
 psa_status_t psa_crypto_driver_pake_get_password_len(
     const psa_crypto_driver_pake_inputs_t *inputs,
     size_t *password_len)
@@ -7735,7 +7736,6 @@ psa_status_t psa_crypto_driver_pake_get_cipher_suite(
     return PSA_SUCCESS;
 }
 
-#if defined(PSA_WANT_ALG_SOME_PAKE)
 psa_status_t psa_pake_setup(
     psa_pake_operation_t *operation,
     const psa_pake_cipher_suite_t *cipher_suite)


### PR DESCRIPTION
## Description

PAKE getter functions should be removed if no PAKE algorithms are specified. This adds guard for `psa_crypto_driver_pake_get_password_len`,  `psa_crypto_driver_pake_get_password`, `psa_crypto_driver_pake_get_user_len`, `psa_crypto_driver_pake_get_user`, `psa_crypto_driver_pake_get_peer_len`, `psa_crypto_driver_pake_get_peer` and `psa_crypto_driver_pake_get_cipher_suite`.

**Size measured:**

command: `./scripts/code_size_compare.py -o 6aca2c9 -n e6d0038 -a armv8-m -c tfm-medium`

| armclang(6.19) | File Name | Old Size | New Size | Change (Bytes) | Change (%) |
| ---: | ---: | ---: |  ---: |  ---: | ---: |
|  | psa_crypto.o | 19206 | 18936 | -270 | -1.41% |
|  | libmbedcrypto.a | 78278 | 78008 | -270 | -0.34% |

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** should not be required, as we only add proper guard for some PAKE getter functions.
- [x] **backport** not required
- [x] **tests** not required

