### PR TITLE
Fix failure of ssl-opt "TLS 1.3: no HRR in case of PSK key exchange mode"

### DIFF
--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -13371,7 +13371,7 @@ requires_config_enabled MBEDTLS_SSL_CLI_C
 requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_ENABLED
 requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 run_test    "TLS 1.3: no HRR in case of PSK key exchange mode" \
-            "$P_SRV nbio=2 psk=010203 psk_identity=0a0b0c tls13_kex_modes=psk curves=none" \
+            "$P_SRV nbio=2 psk=010203 psk_identity=0a0b0c tls13_kex_modes=psk groups=none" \
             "$P_CLI nbio=2 debug_level=3 psk=010203 psk_identity=0a0b0c tls13_kex_modes=all" \
             0 \
             -C "received HelloRetryRequest message" \


### PR DESCRIPTION
Reconcile https://github.com/Mbed-TLS/mbedtls/pull/7887 with https://github.com/Mbed-TLS/mbedtls/pull/7858 to fix a [CI failure in `development`](http://ci.trustedfirmware.org/job/mbed-tls-nightly-tests/92/).

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** no (test only)
- [x] **backport** no (only development is affected)
- [x] **tests** N/A (repairing a broken test)
