### PR TITLE
Semi-unroll AES for code-size

### DIFF
--- a/library/aesce.c
+++ b/library/aesce.c
@@ -166,6 +166,7 @@ static uint8x16_t aesce_encrypt_block(uint8x16_t block,
     block = vaesimcq_u8(block);               \
     keys += 16
 
+MBEDTLS_OPTIMIZE_FOR_PERFORMANCE
 static uint8x16_t aesce_decrypt_block(uint8x16_t block,
                                       unsigned char *keys,
                                       int rounds)

--- a/library/common.h
+++ b/library/common.h
@@ -291,8 +291,8 @@ static inline void mbedtls_xor_no_simd(unsigned char *r,
 /* Define compiler branch hints */
 #if defined(__has_builtin)
 #if __has_builtin(__builtin_expect)
-#define MBEDTLS_LIKELY(x)       __builtin_expect((x), 1)
-#define MBEDTLS_UNLIKELY(x)     __builtin_expect((x), 0)
+#define MBEDTLS_LIKELY(x)       __builtin_expect(!!(x), 1)
+#define MBEDTLS_UNLIKELY(x)     __builtin_expect(!!(x), 0)
 #endif
 #endif
 #if !defined(MBEDTLS_LIKELY)

--- a/library/common.h
+++ b/library/common.h
@@ -300,6 +300,22 @@ static inline void mbedtls_xor_no_simd(unsigned char *r,
 #define MBEDTLS_UNLIKELY(x)     x
 #endif
 
+#if defined(__has_builtin)
+#if __has_builtin(__builtin_assume)
+/* MBEDTLS_ASSUME may be used to provide additional information to the compiler
+ * which can result in smaller code-size. For example, see usage in
+ * aesce_encrypt_block().  */
+#define MBEDTLS_ASSUME(x)       __builtin_assume(x)
+// clang provides __builtin_assume
+#elif __has_builtin(__builtin_unreachable)
+#define MBEDTLS_ASSUME(x)       do { if (!(x)) __builtin_unreachable(); } while (0)
+// For gcc, use __builtin_unreachable
+#endif
+#endif
+#if !defined(MBEDTLS_ASSUME)
+#define MBEDTLS_ASSUME(x)
+#endif
+
 #if defined(__GNUC__) && !defined(__ARMCC_VERSION) && !defined(__clang__) \
     && !defined(__llvm__) && !defined(__INTEL_COMPILER)
 /* Defined if the compiler really is gcc and not clang, etc */


### PR DESCRIPTION
## Description

Partially undo the full unrolling of AESCE to improve code size. Introduce `MBEDTLS_ASSUME` which can provide a compiler hint to save a little bit of additional code size.

The trade-off is about 1.5% (GCM) to 5% (XTS) worse performance for 200b less code size (clang). On gcc it saves 130b.
Use of `MBEDTLS_ASSUME` saves 16b of code-size. Note that this affects A-class only so maybe users would care more about perf than size here?

I'm not sure if this is a desirable trade-off or not. On top of previous perf improvements, we are still well ahead of 3.4 on performance with this PR so there is no net regression. I think the `MBEDTLS_ASSUME` is probably useful for size optimisation work regardless of the re-rolling part.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required - not user-visible
- [x] **backport** not required - not a bugfix
- [x] **tests** not required - covered by existing tests
