### PR TITLE
Reduce size of static data in gcm

### DIFF
--- a/library/gcm.c
+++ b/library/gcm.c
@@ -174,7 +174,7 @@ int mbedtls_gcm_setkey(mbedtls_gcm_context *ctx,
  *      last4[x] = x times P^128
  * where x and last4[x] are seen as elements of GF(2^128) as in [MGV]
  */
-static const uint64_t last4[16] =
+static const uint16_t last4[16] =
 {
     0x0000, 0x1c20, 0x3840, 0x2460,
     0x7080, 0x6ca0, 0x48c0, 0x54e0,


### PR DESCRIPTION
## Description

Reduce size of static data in gcm. Saves 104 bytes.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required - not user visible
- [x] **backport** not required - not a bugfix
- [x] **tests** not required
