### PR TITLE
Use compile-time determination of which __builtin_clz() to use, with new MBEDTLS_MPI_UINT_SIZE macro

### DIFF
--- a/include/mbedtls/bignum.h
+++ b/include/mbedtls/bignum.h
@@ -129,7 +129,7 @@
         #endif /* !MBEDTLS_HAVE_INT64 */
 typedef  int64_t mbedtls_mpi_sint;
 typedef uint64_t mbedtls_mpi_uint;
-#define MBEDTLS_MPI_UINT_MAX                18446744073709551615UL
+#define MBEDTLS_MPI_UINT_MAX                18446744073709551615U
     #elif defined(__GNUC__) && (                         \
     defined(__amd64__) || defined(__x86_64__)     || \
     defined(__ppc64__) || defined(__powerpc64__)  || \

--- a/include/mbedtls/bignum.h
+++ b/include/mbedtls/bignum.h
@@ -129,6 +129,7 @@
         #endif /* !MBEDTLS_HAVE_INT64 */
 typedef  int64_t mbedtls_mpi_sint;
 typedef uint64_t mbedtls_mpi_uint;
+#define MBEDTLS_MPI_UINT_MAX                18446744073709551615UL
     #elif defined(__GNUC__) && (                         \
     defined(__amd64__) || defined(__x86_64__)     || \
     defined(__ppc64__) || defined(__powerpc64__)  || \
@@ -141,6 +142,7 @@ typedef uint64_t mbedtls_mpi_uint;
         #endif /* MBEDTLS_HAVE_INT64 */
 typedef  int64_t mbedtls_mpi_sint;
 typedef uint64_t mbedtls_mpi_uint;
+#define MBEDTLS_MPI_UINT_MAX                18446744073709551615UL
         #if !defined(MBEDTLS_NO_UDBL_DIVISION)
 /* mbedtls_t_udbl defined as 128-bit unsigned int */
 typedef unsigned int mbedtls_t_udbl __attribute__((mode(TI)));
@@ -156,6 +158,7 @@ typedef unsigned int mbedtls_t_udbl __attribute__((mode(TI)));
         #endif /* !MBEDTLS_HAVE_INT64 */
 typedef  int64_t mbedtls_mpi_sint;
 typedef uint64_t mbedtls_mpi_uint;
+#define MBEDTLS_MPI_UINT_MAX                18446744073709551615UL
         #if !defined(MBEDTLS_NO_UDBL_DIVISION)
 /* mbedtls_t_udbl defined as 128-bit unsigned int */
 typedef __uint128_t mbedtls_t_udbl;
@@ -165,6 +168,7 @@ typedef __uint128_t mbedtls_t_udbl;
 /* Force 64-bit integers with unknown compiler */
 typedef  int64_t mbedtls_mpi_sint;
 typedef uint64_t mbedtls_mpi_uint;
+#define MBEDTLS_MPI_UINT_MAX                18446744073709551615UL
     #endif
 #endif /* !MBEDTLS_HAVE_INT32 */
 
@@ -175,6 +179,7 @@ typedef uint64_t mbedtls_mpi_uint;
     #endif /* !MBEDTLS_HAVE_INT32 */
 typedef  int32_t mbedtls_mpi_sint;
 typedef uint32_t mbedtls_mpi_uint;
+#define MBEDTLS_MPI_UINT_MAX                4294967295UL
     #if !defined(MBEDTLS_NO_UDBL_DIVISION)
 typedef uint64_t mbedtls_t_udbl;
         #define MBEDTLS_HAVE_UDBL

--- a/include/mbedtls/bignum.h
+++ b/include/mbedtls/bignum.h
@@ -129,7 +129,7 @@
         #endif /* !MBEDTLS_HAVE_INT64 */
 typedef  int64_t mbedtls_mpi_sint;
 typedef uint64_t mbedtls_mpi_uint;
-#define MBEDTLS_MPI_UINT_MAX                18446744073709551615U
+#define MBEDTLS_MPI_UINT_MAX                UINT64_MAX
     #elif defined(__GNUC__) && (                         \
     defined(__amd64__) || defined(__x86_64__)     || \
     defined(__ppc64__) || defined(__powerpc64__)  || \
@@ -142,7 +142,7 @@ typedef uint64_t mbedtls_mpi_uint;
         #endif /* MBEDTLS_HAVE_INT64 */
 typedef  int64_t mbedtls_mpi_sint;
 typedef uint64_t mbedtls_mpi_uint;
-#define MBEDTLS_MPI_UINT_MAX                18446744073709551615U
+#define MBEDTLS_MPI_UINT_MAX                UINT64_MAX
         #if !defined(MBEDTLS_NO_UDBL_DIVISION)
 /* mbedtls_t_udbl defined as 128-bit unsigned int */
 typedef unsigned int mbedtls_t_udbl __attribute__((mode(TI)));
@@ -158,7 +158,7 @@ typedef unsigned int mbedtls_t_udbl __attribute__((mode(TI)));
         #endif /* !MBEDTLS_HAVE_INT64 */
 typedef  int64_t mbedtls_mpi_sint;
 typedef uint64_t mbedtls_mpi_uint;
-#define MBEDTLS_MPI_UINT_MAX                18446744073709551615U
+#define MBEDTLS_MPI_UINT_MAX                UINT64_MAX
         #if !defined(MBEDTLS_NO_UDBL_DIVISION)
 /* mbedtls_t_udbl defined as 128-bit unsigned int */
 typedef __uint128_t mbedtls_t_udbl;
@@ -168,7 +168,7 @@ typedef __uint128_t mbedtls_t_udbl;
 /* Force 64-bit integers with unknown compiler */
 typedef  int64_t mbedtls_mpi_sint;
 typedef uint64_t mbedtls_mpi_uint;
-#define MBEDTLS_MPI_UINT_MAX                18446744073709551615U
+#define MBEDTLS_MPI_UINT_MAX                UINT64_MAX
     #endif
 #endif /* !MBEDTLS_HAVE_INT32 */
 
@@ -179,7 +179,7 @@ typedef uint64_t mbedtls_mpi_uint;
     #endif /* !MBEDTLS_HAVE_INT32 */
 typedef  int32_t mbedtls_mpi_sint;
 typedef uint32_t mbedtls_mpi_uint;
-#define MBEDTLS_MPI_UINT_MAX                4294967295U
+#define MBEDTLS_MPI_UINT_MAX                UINT32_MAX
     #if !defined(MBEDTLS_NO_UDBL_DIVISION)
 typedef uint64_t mbedtls_t_udbl;
         #define MBEDTLS_HAVE_UDBL

--- a/include/mbedtls/bignum.h
+++ b/include/mbedtls/bignum.h
@@ -142,7 +142,7 @@ typedef uint64_t mbedtls_mpi_uint;
         #endif /* MBEDTLS_HAVE_INT64 */
 typedef  int64_t mbedtls_mpi_sint;
 typedef uint64_t mbedtls_mpi_uint;
-#define MBEDTLS_MPI_UINT_MAX                18446744073709551615UL
+#define MBEDTLS_MPI_UINT_MAX                18446744073709551615U
         #if !defined(MBEDTLS_NO_UDBL_DIVISION)
 /* mbedtls_t_udbl defined as 128-bit unsigned int */
 typedef unsigned int mbedtls_t_udbl __attribute__((mode(TI)));
@@ -158,7 +158,7 @@ typedef unsigned int mbedtls_t_udbl __attribute__((mode(TI)));
         #endif /* !MBEDTLS_HAVE_INT64 */
 typedef  int64_t mbedtls_mpi_sint;
 typedef uint64_t mbedtls_mpi_uint;
-#define MBEDTLS_MPI_UINT_MAX                18446744073709551615UL
+#define MBEDTLS_MPI_UINT_MAX                18446744073709551615U
         #if !defined(MBEDTLS_NO_UDBL_DIVISION)
 /* mbedtls_t_udbl defined as 128-bit unsigned int */
 typedef __uint128_t mbedtls_t_udbl;
@@ -168,7 +168,7 @@ typedef __uint128_t mbedtls_t_udbl;
 /* Force 64-bit integers with unknown compiler */
 typedef  int64_t mbedtls_mpi_sint;
 typedef uint64_t mbedtls_mpi_uint;
-#define MBEDTLS_MPI_UINT_MAX                18446744073709551615UL
+#define MBEDTLS_MPI_UINT_MAX                18446744073709551615U
     #endif
 #endif /* !MBEDTLS_HAVE_INT32 */
 
@@ -179,7 +179,7 @@ typedef uint64_t mbedtls_mpi_uint;
     #endif /* !MBEDTLS_HAVE_INT32 */
 typedef  int32_t mbedtls_mpi_sint;
 typedef uint32_t mbedtls_mpi_uint;
-#define MBEDTLS_MPI_UINT_MAX                4294967295UL
+#define MBEDTLS_MPI_UINT_MAX                4294967295U
     #if !defined(MBEDTLS_NO_UDBL_DIVISION)
 typedef uint64_t mbedtls_t_udbl;
         #define MBEDTLS_HAVE_UDBL

--- a/library/bignum_core.c
+++ b/library/bignum_core.c
@@ -35,21 +35,18 @@
 
 size_t mbedtls_mpi_core_clz(mbedtls_mpi_uint a)
 {
-
+    
 #if defined(__has_builtin)
-#if (MBEDTLS_MPI_UINT_MAX == UINT_MAX)
-#if __has_builtin(__builtin_clz)
-    return (size_t) __builtin_clz(a);
-#endif
-#elif (MBEDTLS_MPI_UINT_MAX == ULONG_MAX)
-#if __has_builtin(__builtin_clzl)
-    return (size_t) __builtin_clzl(a);
-#endif
-#elif (MBEDTLS_MPI_UINT_MAX == ULLONG_MAX)
-#if __has_builtin(__builtin_clzll)
-    return (size_t) __builtin_clzll(a);
+#if (MBEDTLS_MPI_UINT_MAX == UINT_MAX) && __has_builtin(__builtin_clz)
+    #define core_clz __builtin_clz
+#elif (MBEDTLS_MPI_UINT_MAX == ULONG_MAX) && __has_builtin(__builtin_clzl)
+    #define core_clz __builtin_clzl
+#elif (MBEDTLS_MPI_UINT_MAX == ULLONG_MAX) && __has_builtin(__builtin_clzll)
+    #define core_clz __builtin_clzll
 #endif
 #endif
+#if defined(core_clz)
+    return (size_t) core_clz(a);
 #else
     size_t j;
     mbedtls_mpi_uint mask = (mbedtls_mpi_uint) 1 << (biL - 1);

--- a/library/bignum_core.c
+++ b/library/bignum_core.c
@@ -35,23 +35,22 @@
 
 size_t mbedtls_mpi_core_clz(mbedtls_mpi_uint a)
 {
+
 #if defined(__has_builtin)
+#if (MBEDTLS_MPI_UINT_MAX == UINT_MAX)
 #if __has_builtin(__builtin_clz)
-    if (sizeof(mbedtls_mpi_uint) == sizeof(unsigned int)) {
-        return (size_t) __builtin_clz(a);
-    }
+    return (size_t) __builtin_clz(a);
 #endif
+#elif (MBEDTLS_MPI_UINT_MAX == ULONG_MAX)
 #if __has_builtin(__builtin_clzl)
-    if (sizeof(mbedtls_mpi_uint) == sizeof(unsigned long)) {
-        return (size_t) __builtin_clzl(a);
-    }
+    return (size_t) __builtin_clzl(a);
 #endif
+#elif (MBEDTLS_MPI_UINT_MAX == ULLONG_MAX)
 #if __has_builtin(__builtin_clzll)
-    if (sizeof(mbedtls_mpi_uint) == sizeof(unsigned long long)) {
-        return (size_t) __builtin_clzll(a);
-    }
+    return (size_t) __builtin_clzll(a);
 #endif
 #endif
+#else
     size_t j;
     mbedtls_mpi_uint mask = (mbedtls_mpi_uint) 1 << (biL - 1);
 
@@ -64,6 +63,7 @@ size_t mbedtls_mpi_core_clz(mbedtls_mpi_uint a)
     }
 
     return j;
+#endif
 }
 
 size_t mbedtls_mpi_core_bitlen(const mbedtls_mpi_uint *A, size_t A_limbs)

--- a/library/bignum_core.c
+++ b/library/bignum_core.c
@@ -35,7 +35,6 @@
 
 size_t mbedtls_mpi_core_clz(mbedtls_mpi_uint a)
 {
-    
 #if defined(__has_builtin)
 #if (MBEDTLS_MPI_UINT_MAX == UINT_MAX) && __has_builtin(__builtin_clz)
     #define core_clz __builtin_clz


### PR DESCRIPTION
## Description

Since the max size of `mbedtls_mpi_uint` is platform dependent, some checks in mbedtls_mpi_core can be redundant, so a macro was added to check this. This is a part of #7931 .

Fixes:

```
      if (sizeof(mbedtls_mpi_uint) == sizeof(unsigned long)) {
      ^
"/home/agabra02/Documents/mbedtls/library/bignum_core.c",45  Warning[Pe111]: 
          statement is unreachable

      if (sizeof(mbedtls_mpi_uint) == sizeof(unsigned long long)) {
      ^
"/home/agabra02/Documents/mbedtls/library/bignum_core.c",50  Warning[Pe111]: 
          statement is unreachable
```

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required as no change in functionality
- [x] **backport** not required for similar reasons
- [x] **tests** not needed

