### PR TITLE
Add type casts for integer and enum types

### DIFF
--- a/library/lmots.c
+++ b/library/lmots.c
@@ -438,8 +438,10 @@ int mbedtls_lmots_import_public_key(mbedtls_lmots_public_t *ctx,
     }
 
     ctx->params.type =
-        mbedtls_lms_network_bytes_to_unsigned_int(MBEDTLS_LMOTS_TYPE_LEN,
-                                                  key + MBEDTLS_LMOTS_SIG_TYPE_OFFSET);
+        (mbedtls_lmots_algorithm_type_t) mbedtls_lms_network_bytes_to_unsigned_int(
+            MBEDTLS_LMOTS_TYPE_LEN,
+            key +
+            MBEDTLS_LMOTS_SIG_TYPE_OFFSET);
 
     if (key_len != MBEDTLS_LMOTS_PUBLIC_KEY_LEN(ctx->params.type)) {
         return MBEDTLS_ERR_LMS_BAD_INPUT_DATA;

--- a/library/lms.c
+++ b/library/lms.c
@@ -249,8 +249,10 @@ int mbedtls_lms_import_public_key(mbedtls_lms_public_t *ctx,
     mbedtls_lms_algorithm_type_t type;
     mbedtls_lmots_algorithm_type_t otstype;
 
-    type = mbedtls_lms_network_bytes_to_unsigned_int(MBEDTLS_LMS_TYPE_LEN,
-                                                     key + PUBLIC_KEY_TYPE_OFFSET);
+    type = (mbedtls_lms_algorithm_type_t) mbedtls_lms_network_bytes_to_unsigned_int(
+        MBEDTLS_LMS_TYPE_LEN,
+        key +
+        PUBLIC_KEY_TYPE_OFFSET);
     if (type != MBEDTLS_LMS_SHA256_M32_H10) {
         return MBEDTLS_ERR_LMS_BAD_INPUT_DATA;
     }
@@ -260,8 +262,10 @@ int mbedtls_lms_import_public_key(mbedtls_lms_public_t *ctx,
         return MBEDTLS_ERR_LMS_BAD_INPUT_DATA;
     }
 
-    otstype = mbedtls_lms_network_bytes_to_unsigned_int(MBEDTLS_LMOTS_TYPE_LEN,
-                                                        key + PUBLIC_KEY_OTSTYPE_OFFSET);
+    otstype = (mbedtls_lmots_algorithm_type_t) mbedtls_lms_network_bytes_to_unsigned_int(
+        MBEDTLS_LMOTS_TYPE_LEN,
+        key +
+        PUBLIC_KEY_OTSTYPE_OFFSET);
     if (otstype != MBEDTLS_LMOTS_SHA256_N32_W8) {
         return MBEDTLS_ERR_LMS_BAD_INPUT_DATA;
     }

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -7960,7 +7960,7 @@ static psa_crypto_driver_pake_step_t convert_jpake_computation_stage_to_driver_s
     } else {
         return PSA_JPAKE_STEP_INVALID;
     }
-    return key_share_step + stage->step - PSA_PAKE_STEP_KEY_SHARE;
+    return (psa_crypto_driver_pake_step_t) (key_share_step + stage->step - PSA_PAKE_STEP_KEY_SHARE);
 }
 #endif /* PSA_WANT_ALG_JPAKE */
 

--- a/library/rsa.c
+++ b/library/rsa.c
@@ -1266,13 +1266,13 @@ int mbedtls_rsa_rsaes_oaep_encrypt(mbedtls_rsa_context *ctx,
 
     /* maskedDB: Apply dbMask to DB */
     if ((ret = mgf_mask(output + hlen + 1, olen - hlen - 1, output + 1, hlen,
-                        ctx->hash_id)) != 0) {
+                        (mbedtls_md_type_t) ctx->hash_id)) != 0) {
         return ret;
     }
 
     /* maskedSeed: Apply seedMask to seed */
     if ((ret = mgf_mask(output + 1, hlen, output + hlen + 1, olen - hlen - 1,
-                        ctx->hash_id)) != 0) {
+                        (mbedtls_md_type_t) ctx->hash_id)) != 0) {
         return ret;
     }
 
@@ -1420,10 +1420,10 @@ int mbedtls_rsa_rsaes_oaep_decrypt(mbedtls_rsa_context *ctx,
      */
     /* seed: Apply seedMask to maskedSeed */
     if ((ret = mgf_mask(buf + 1, hlen, buf + hlen + 1, ilen - hlen - 1,
-                        ctx->hash_id)) != 0 ||
+                        (mbedtls_md_type_t) ctx->hash_id)) != 0 ||
         /* DB: Apply dbMask to maskedDB */
         (ret = mgf_mask(buf + hlen + 1, ilen - hlen - 1, buf + 1, hlen,
-                        ctx->hash_id)) != 0) {
+                        (mbedtls_md_type_t) ctx->hash_id)) != 0) {
         goto cleanup;
     }
 
@@ -1649,7 +1649,7 @@ static int rsa_rsassa_pss_sign(mbedtls_rsa_context *ctx,
     p += slen;
 
     /* Generate H = Hash( M' ) */
-    ret = hash_mprime(hash, hashlen, salt, slen, p, ctx->hash_id);
+    ret = hash_mprime(hash, hashlen, salt, slen, p, (mbedtls_md_type_t) ctx->hash_id);
     if (ret != 0) {
         return ret;
     }
@@ -1661,7 +1661,7 @@ static int rsa_rsassa_pss_sign(mbedtls_rsa_context *ctx,
 
     /* maskedDB: Apply dbMask to DB */
     ret = mgf_mask(sig + offset, olen - hlen - 1 - offset, p, hlen,
-                   ctx->hash_id);
+                   (mbedtls_md_type_t) ctx->hash_id);
     if (ret != 0) {
         return ret;
     }

--- a/library/ssl_ciphersuites.c
+++ b/library/ssl_ciphersuites.c
@@ -1931,7 +1931,7 @@ size_t mbedtls_ssl_ciphersuite_get_cipher_key_bitlen(const mbedtls_ssl_ciphersui
     return key_bits;
 #else
     const mbedtls_cipher_info_t * const cipher_info =
-        mbedtls_cipher_info_from_type(info->cipher);
+        mbedtls_cipher_info_from_type((mbedtls_cipher_type_t) info->cipher);
 
     return mbedtls_cipher_info_get_key_bitlen(cipher_info);
 #endif /* MBEDTLS_USE_PSA_CRYPTO */

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -3602,8 +3602,9 @@ static int ssl_parse_record_header(mbedtls_ssl_context const *ssl,
      */
     rec->ver[0] = buf[rec_hdr_version_offset + 0];
     rec->ver[1] = buf[rec_hdr_version_offset + 1];
-    tls_version = mbedtls_ssl_read_version(buf + rec_hdr_version_offset,
-                                           ssl->conf->transport);
+    tls_version = (mbedtls_ssl_protocol_version) mbedtls_ssl_read_version(
+        buf + rec_hdr_version_offset,
+        ssl->conf->transport);
 
     if (tls_version > ssl->conf->max_tls_version) {
         MBEDTLS_SSL_DEBUG_MSG(1, ("TLS version mismatch: got %u, expected max %u",
@@ -5849,15 +5850,19 @@ static void ssl_buffering_free_slot(mbedtls_ssl_context *ssl,
 void mbedtls_ssl_write_version(unsigned char version[2], int transport,
                                mbedtls_ssl_protocol_version tls_version)
 {
+    uint16_t tls_version_formatted;
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
     if (transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM) {
-        tls_version =
+        tls_version_formatted =
             ~(tls_version - (tls_version == 0x0302 ? 0x0202 : 0x0201));
-    }
+    } else
 #else
     ((void) transport);
 #endif
-    MBEDTLS_PUT_UINT16_BE(tls_version, version, 0);
+    {
+        tls_version_formatted = (uint16_t) tls_version;
+    }
+    MBEDTLS_PUT_UINT16_BE(tls_version_formatted, version, 0);
 }
 
 uint16_t mbedtls_ssl_read_version(const unsigned char version[2],

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -2436,7 +2436,7 @@ mbedtls_ssl_mode_t mbedtls_ssl_get_mode_from_ciphersuite(
     }
 #else
     const mbedtls_cipher_info_t *cipher =
-        mbedtls_cipher_info_from_type(suite->cipher);
+        mbedtls_cipher_info_from_type((mbedtls_cipher_type_t) suite->cipher);
     if (cipher != NULL) {
         base_mode =
             mbedtls_ssl_get_base_mode(
@@ -3116,12 +3116,12 @@ void mbedtls_ssl_get_dtls_srtp_negotiation_result(const mbedtls_ssl_context *ssl
 #if !defined(MBEDTLS_DEPRECATED_REMOVED)
 void mbedtls_ssl_conf_max_version(mbedtls_ssl_config *conf, int major, int minor)
 {
-    conf->max_tls_version = (major << 8) | minor;
+    conf->max_tls_version = (mbedtls_ssl_protocol_version) ((major << 8) | minor);
 }
 
 void mbedtls_ssl_conf_min_version(mbedtls_ssl_config *conf, int major, int minor)
 {
-    conf->min_tls_version = (major << 8) | minor;
+    conf->min_tls_version = (mbedtls_ssl_protocol_version) ((major << 8) | minor);
 }
 #endif /* MBEDTLS_DEPRECATED_REMOVED */
 
@@ -3749,7 +3749,7 @@ static int ssl_session_load(mbedtls_ssl_session *session,
     if (1 > (size_t) (end - p)) {
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
-    session->tls_version = 0x0300 | *p++;
+    session->tls_version = (mbedtls_ssl_protocol_version) (0x0300 | *p++);
 
     /* Dispatch according to TLS version. */
     remaining_len = (end - p);
@@ -3852,7 +3852,7 @@ int mbedtls_ssl_handshake_step(mbedtls_ssl_context *ssl)
 #if defined(MBEDTLS_SSL_CLI_C)
     if (ssl->conf->endpoint == MBEDTLS_SSL_IS_CLIENT) {
         MBEDTLS_SSL_DEBUG_MSG(2, ("client state: %s",
-                                  mbedtls_ssl_states_str(ssl->state)));
+                                  mbedtls_ssl_states_str((mbedtls_ssl_states) ssl->state)));
 
         switch (ssl->state) {
             case MBEDTLS_SSL_HELLO_REQUEST:
@@ -6534,7 +6534,7 @@ int mbedtls_ssl_derive_keys(mbedtls_ssl_context *ssl)
 
     /* Set PRF, calc_verify and calc_finished function pointers */
     ret = ssl_set_handshake_prfs(ssl->handshake,
-                                 ciphersuite_info->mac);
+                                 (mbedtls_md_type_t) ciphersuite_info->mac);
     if (ret != 0) {
         MBEDTLS_SSL_DEBUG_RET(1, "ssl_set_handshake_prfs", ret);
         return ret;
@@ -8210,7 +8210,7 @@ static int ssl_tls12_populate_transform(mbedtls_ssl_transform *transform,
         goto end;
     }
 #else
-    cipher_info = mbedtls_cipher_info_from_type(ciphersuite_info->cipher);
+    cipher_info = mbedtls_cipher_info_from_type((mbedtls_cipher_type_t) ciphersuite_info->cipher);
     if (cipher_info == NULL) {
         MBEDTLS_SSL_DEBUG_MSG(1, ("cipher info for %u not found",
                                   ciphersuite_info->cipher));
@@ -8226,7 +8226,7 @@ static int ssl_tls12_populate_transform(mbedtls_ssl_transform *transform,
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 #else
-    md_info = mbedtls_md_info_from_type(ciphersuite_info->mac);
+    md_info = mbedtls_md_info_from_type((mbedtls_md_type_t) ciphersuite_info->mac);
     if (md_info == NULL) {
         MBEDTLS_SSL_DEBUG_MSG(1, ("mbedtls_md info for %u not found",
                                   (unsigned) ciphersuite_info->mac));

--- a/library/ssl_tls12_client.c
+++ b/library/ssl_tls12_client.c
@@ -1271,7 +1271,8 @@ static int ssl_parse_server_hello(mbedtls_ssl_context *ssl)
     buf += mbedtls_ssl_hs_hdr_len(ssl);
 
     MBEDTLS_SSL_DEBUG_BUF(3, "server hello, version", buf, 2);
-    ssl->tls_version = mbedtls_ssl_read_version(buf, ssl->conf->transport);
+    ssl->tls_version = (mbedtls_ssl_protocol_version) mbedtls_ssl_read_version(buf,
+                                                                               ssl->conf->transport);
     ssl->session_negotiate->tls_version = ssl->tls_version;
 
     if (ssl->tls_version < ssl->conf->min_tls_version ||
@@ -3141,7 +3142,8 @@ ecdh_calc_secret:
 
 #if !defined(MBEDTLS_USE_PSA_CRYPTO)
         if ((ret = mbedtls_ssl_psk_derive_premaster(ssl,
-                                                    ciphersuite_info->key_exchange)) != 0) {
+                                                    (mbedtls_key_exchange_type_t) ciphersuite_info->
+                                                    key_exchange)) != 0) {
             MBEDTLS_SSL_DEBUG_RET(1,
                                   "mbedtls_ssl_psk_derive_premaster", ret);
             return ret;

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -1166,7 +1166,8 @@ read_record_header:
      */
     MBEDTLS_SSL_DEBUG_BUF(3, "client hello, version", buf, 2);
 
-    ssl->tls_version = mbedtls_ssl_read_version(buf, ssl->conf->transport);
+    ssl->tls_version = (mbedtls_ssl_protocol_version) mbedtls_ssl_read_version(buf,
+                                                                               ssl->conf->transport);
     ssl->session_negotiate->tls_version = ssl->tls_version;
 
     if (ssl->tls_version != MBEDTLS_SSL_VERSION_TLS1_2) {
@@ -3798,7 +3799,8 @@ static int ssl_parse_client_key_exchange(mbedtls_ssl_context *ssl)
 
 #if !defined(MBEDTLS_USE_PSA_CRYPTO)
         if ((ret = mbedtls_ssl_psk_derive_premaster(ssl,
-                                                    ciphersuite_info->key_exchange)) != 0) {
+                                                    (mbedtls_key_exchange_type_t) ciphersuite_info->
+                                                    key_exchange)) != 0) {
             MBEDTLS_SSL_DEBUG_RET(1, "mbedtls_ssl_psk_derive_premaster", ret);
             return ret;
         }
@@ -3830,7 +3832,8 @@ static int ssl_parse_client_key_exchange(mbedtls_ssl_context *ssl)
 
 #if !defined(MBEDTLS_USE_PSA_CRYPTO)
         if ((ret = mbedtls_ssl_psk_derive_premaster(ssl,
-                                                    ciphersuite_info->key_exchange)) != 0) {
+                                                    (mbedtls_key_exchange_type_t) ciphersuite_info->
+                                                    key_exchange)) != 0) {
             MBEDTLS_SSL_DEBUG_RET(1, "mbedtls_ssl_psk_derive_premaster", ret);
             return ret;
         }
@@ -3871,7 +3874,8 @@ static int ssl_parse_client_key_exchange(mbedtls_ssl_context *ssl)
         MBEDTLS_SSL_DEBUG_MPI(3, "DHM: K ", &ssl->handshake->dhm_ctx.K);
 #else
         if ((ret = mbedtls_ssl_psk_derive_premaster(ssl,
-                                                    ciphersuite_info->key_exchange)) != 0) {
+                                                    (mbedtls_key_exchange_type_t) ciphersuite_info->
+                                                    key_exchange)) != 0) {
             MBEDTLS_SSL_DEBUG_RET(1, "mbedtls_ssl_psk_derive_premaster", ret);
             return ret;
         }
@@ -3971,7 +3975,8 @@ static int ssl_parse_client_key_exchange(mbedtls_ssl_context *ssl)
                                MBEDTLS_DEBUG_ECDH_QP);
 
         if ((ret = mbedtls_ssl_psk_derive_premaster(ssl,
-                                                    ciphersuite_info->key_exchange)) != 0) {
+                                                    (mbedtls_key_exchange_type_t) ciphersuite_info->
+                                                    key_exchange)) != 0) {
             MBEDTLS_SSL_DEBUG_RET(1, "mbedtls_ssl_psk_derive_premaster", ret);
             return ret;
         }

--- a/tests/include/test/macros.h
+++ b/tests/include/test/macros.h
@@ -73,7 +73,7 @@
 #define TEST_EQUAL(expr1, expr2)                                      \
     do {                                                                \
         if (!mbedtls_test_equal( #expr1 " == " #expr2, __LINE__, __FILE__, \
-                                 expr1, expr2))                      \
+                                 (unsigned long long) (expr1), (unsigned long long) (expr2)))                      \
         goto exit;                                                  \
     } while (0)
 

--- a/tests/src/psa_exercise_key.c
+++ b/tests/src/psa_exercise_key.c
@@ -692,7 +692,7 @@ int mbedtls_test_psa_exported_key_sanity_check(
         TEST_EQUAL(mbedtls_asn1_get_tag(&p, end, &len,
                                         MBEDTLS_ASN1_SEQUENCE |
                                         MBEDTLS_ASN1_CONSTRUCTED), 0);
-        TEST_EQUAL(len, end - p);
+        TEST_EQUAL(len, (uintptr_t) end - (uintptr_t) p);
         if (!mbedtls_test_asn1_skip_integer(&p, end, 0, 0, 0)) {
             goto exit;
         }
@@ -722,7 +722,7 @@ int mbedtls_test_psa_exported_key_sanity_check(
         if (!mbedtls_test_asn1_skip_integer(&p, end, 1, bits / 2 + 1, 0)) {
             goto exit;
         }
-        TEST_EQUAL(p - end, 0);
+        TEST_EQUAL((uintptr_t) p - (uintptr_t) end, 0);
 
         TEST_ASSERT(exported_length <= PSA_EXPORT_KEY_PAIR_MAX_SIZE);
     } else
@@ -748,14 +748,14 @@ int mbedtls_test_psa_exported_key_sanity_check(
                                         MBEDTLS_ASN1_SEQUENCE |
                                         MBEDTLS_ASN1_CONSTRUCTED),
                    0);
-        TEST_EQUAL(len, end - p);
+        TEST_EQUAL(len, (uintptr_t) end - (uintptr_t) p);
         if (!mbedtls_test_asn1_skip_integer(&p, end, bits, bits, 1)) {
             goto exit;
         }
         if (!mbedtls_test_asn1_skip_integer(&p, end, 2, bits, 1)) {
             goto exit;
         }
-        TEST_EQUAL(p - end, 0);
+        TEST_EQUAL((uintptr_t) p - (uintptr_t) end, 0);
 
 
         TEST_ASSERT(exported_length <=

--- a/tests/src/psa_exercise_key.c
+++ b/tests/src/psa_exercise_key.c
@@ -692,7 +692,7 @@ int mbedtls_test_psa_exported_key_sanity_check(
         TEST_EQUAL(mbedtls_asn1_get_tag(&p, end, &len,
                                         MBEDTLS_ASN1_SEQUENCE |
                                         MBEDTLS_ASN1_CONSTRUCTED), 0);
-        TEST_EQUAL(len, (uintptr_t) end - (uintptr_t) p);
+        TEST_EQUAL(len, end - p);
         if (!mbedtls_test_asn1_skip_integer(&p, end, 0, 0, 0)) {
             goto exit;
         }
@@ -722,7 +722,7 @@ int mbedtls_test_psa_exported_key_sanity_check(
         if (!mbedtls_test_asn1_skip_integer(&p, end, 1, bits / 2 + 1, 0)) {
             goto exit;
         }
-        TEST_EQUAL((uintptr_t) p - (uintptr_t) end, 0);
+        TEST_EQUAL(p - end, 0);
 
         TEST_ASSERT(exported_length <= PSA_EXPORT_KEY_PAIR_MAX_SIZE);
     } else

--- a/tests/src/psa_exercise_key.c
+++ b/tests/src/psa_exercise_key.c
@@ -748,14 +748,14 @@ int mbedtls_test_psa_exported_key_sanity_check(
                                         MBEDTLS_ASN1_SEQUENCE |
                                         MBEDTLS_ASN1_CONSTRUCTED),
                    0);
-        TEST_EQUAL(len, (uintptr_t) end - (uintptr_t) p);
+        TEST_EQUAL(len, end - p);
         if (!mbedtls_test_asn1_skip_integer(&p, end, bits, bits, 1)) {
             goto exit;
         }
         if (!mbedtls_test_asn1_skip_integer(&p, end, 2, bits, 1)) {
             goto exit;
         }
-        TEST_EQUAL((uintptr_t) p - (uintptr_t) end, 0);
+        TEST_EQUAL(p - end, 0);
 
 
         TEST_ASSERT(exported_length <=

--- a/tests/src/test_helpers/ssl_helpers.c
+++ b/tests/src/test_helpers/ssl_helpers.c
@@ -1020,10 +1020,10 @@ static void set_ciphersuite(mbedtls_ssl_config *conf, const char *cipher,
     TEST_ASSERT(ciphersuite_info->max_tls_version >= conf->min_tls_version);
 
     if (conf->max_tls_version > ciphersuite_info->max_tls_version) {
-        conf->max_tls_version = ciphersuite_info->max_tls_version;
+        conf->max_tls_version = (mbedtls_ssl_protocol_version) ciphersuite_info->max_tls_version;
     }
     if (conf->min_tls_version < ciphersuite_info->min_tls_version) {
-        conf->min_tls_version = ciphersuite_info->min_tls_version;
+        conf->min_tls_version = (mbedtls_ssl_protocol_version) ciphersuite_info->min_tls_version;
     }
 
     mbedtls_ssl_conf_ciphersuites(conf, forced_ciphersuite);
@@ -1140,7 +1140,7 @@ int mbedtls_test_ssl_build_transforms(mbedtls_ssl_transform *t_in,
     maclen = 0;
 
     /* Pick cipher */
-    cipher_info = mbedtls_cipher_info_from_type(cipher_type);
+    cipher_info = mbedtls_cipher_info_from_type((mbedtls_cipher_type_t) cipher_type);
     CHK(cipher_info != NULL);
     CHK(cipher_info->iv_size <= 16);
     CHK(cipher_info->key_bitlen % 8 == 0);
@@ -1198,10 +1198,10 @@ int mbedtls_test_ssl_build_transforms(mbedtls_ssl_transform *t_in,
     if (cipher_info->mode == MBEDTLS_MODE_CBC ||
         cipher_info->mode == MBEDTLS_MODE_STREAM) {
 #if !defined(MBEDTLS_USE_PSA_CRYPTO)
-        mbedtls_md_info_t const *md_info = mbedtls_md_info_from_type(hash_id);
+        mbedtls_md_info_t const *md_info = mbedtls_md_info_from_type((mbedtls_md_type_t) hash_id);
         CHK(md_info != NULL);
 #endif
-        maclen = mbedtls_md_get_size_from_type(hash_id);
+        maclen = mbedtls_md_get_size_from_type((mbedtls_md_type_t) hash_id);
         CHK(maclen != 0);
         /* Pick hash keys */
         CHK((md0 = mbedtls_calloc(1, maclen)) != NULL);


### PR DESCRIPTION
## Description

Part of #7931. Sorts IAR compile warnings about conversion from enum to int and vice versa. This doesn't handle the case in #7917 which requires further discussion.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required not a functionality change
- [x] **backport** not required as above
- [x] **tests** should be covered

