### PR TITLE
Add TEST_FAIL macro for tests

### DIFF
--- a/tests/include/test/macros.h
+++ b/tests/include/test/macros.h
@@ -61,6 +61,16 @@
         }                                                    \
     } while (0)
 
+/** This macro asserts fails the test with given output message.
+ *
+ * \param   MESSAGE The message to be outputed on assertion
+ */
+#define ASSERT_FALSE(MESSAGE)                           \
+    do {                                                  \
+        mbedtls_test_fail(MESSAGE, __LINE__, __FILE__);   \
+        goto exit;                                          \
+    } while (0)                                              \
+
 /** Evaluate two integer expressions and fail the test case if they have
  * different values.
  *

--- a/tests/include/test/macros.h
+++ b/tests/include/test/macros.h
@@ -68,8 +68,8 @@
 #define TEST_FAIL(MESSAGE)                           \
     do {                                                  \
         mbedtls_test_fail(MESSAGE, __LINE__, __FILE__);   \
-        goto exit;                                          \
-    } while (0)                                              \
+        goto exit;                                        \
+    } while (0)
 
 /** Evaluate two integer expressions and fail the test case if they have
  * different values.

--- a/tests/include/test/macros.h
+++ b/tests/include/test/macros.h
@@ -65,7 +65,7 @@
  *
  * \param   MESSAGE The message to be outputed on assertion
  */
-#define ASSERT_FALSE(MESSAGE)                           \
+#define TEST_FAIL(MESSAGE)                           \
     do {                                                  \
         mbedtls_test_fail(MESSAGE, __LINE__, __FILE__);   \
         goto exit;                                          \

--- a/tests/src/psa_exercise_key.c
+++ b/tests/src/psa_exercise_key.c
@@ -309,7 +309,7 @@ static int exercise_signature_key(mbedtls_svc_key_id_t key,
             hash_alg = KNOWN_SUPPORTED_HASH_ALG;
             alg ^= PSA_ALG_ANY_HASH ^ hash_alg;
     #else
-            ASSERT_FALSE("No hash algorithm for hash-and-sign testing");
+            TEST_FAIL("No hash algorithm for hash-and-sign testing");
     #endif
         }
 
@@ -438,7 +438,7 @@ int mbedtls_test_psa_setup_key_derivation_wrap(
                                                   PSA_KEY_DERIVATION_INPUT_LABEL,
                                                   input2, input2_length));
     } else {
-        ASSERT_FALSE("Key derivation algorithm not supported");
+        TEST_FAIL("Key derivation algorithm not supported");
     }
 
     if (capacity != SIZE_MAX) {
@@ -798,7 +798,7 @@ int mbedtls_test_psa_exported_key_sanity_check(
                     PSA_EXPORT_PUBLIC_KEY_MAX_SIZE);
     } else {
         (void) exported;
-        ASSERT_FALSE("Sanity check not implemented for this key type");
+        TEST_FAIL("Sanity check not implemented for this key type");
     }
 
 #if defined(MBEDTLS_DES_C)
@@ -943,7 +943,7 @@ int mbedtls_test_psa_exercise_key(mbedtls_svc_key_id_t key,
     } else if (PSA_ALG_IS_KEY_AGREEMENT(alg)) {
         ok = exercise_key_agreement_key(key, usage, alg);
     } else {
-        ASSERT_FALSE("No code to exercise this category of algorithm");
+        TEST_FAIL("No code to exercise this category of algorithm");
     }
 
     ok = ok && exercise_export_key(key, usage);

--- a/tests/src/psa_exercise_key.c
+++ b/tests/src/psa_exercise_key.c
@@ -309,7 +309,7 @@ static int exercise_signature_key(mbedtls_svc_key_id_t key,
             hash_alg = KNOWN_SUPPORTED_HASH_ALG;
             alg ^= PSA_ALG_ANY_HASH ^ hash_alg;
     #else
-            TEST_ASSERT(!"No hash algorithm for hash-and-sign testing");
+            ASSERT_FALSE("No hash algorithm for hash-and-sign testing");
     #endif
         }
 
@@ -438,7 +438,7 @@ int mbedtls_test_psa_setup_key_derivation_wrap(
                                                   PSA_KEY_DERIVATION_INPUT_LABEL,
                                                   input2, input2_length));
     } else {
-        TEST_ASSERT(!"Key derivation algorithm not supported");
+        ASSERT_FALSE("Key derivation algorithm not supported");
     }
 
     if (capacity != SIZE_MAX) {
@@ -798,7 +798,7 @@ int mbedtls_test_psa_exported_key_sanity_check(
                     PSA_EXPORT_PUBLIC_KEY_MAX_SIZE);
     } else {
         (void) exported;
-        TEST_ASSERT(!"Sanity check not implemented for this key type");
+        ASSERT_FALSE("Sanity check not implemented for this key type");
     }
 
 #if defined(MBEDTLS_DES_C)
@@ -943,7 +943,7 @@ int mbedtls_test_psa_exercise_key(mbedtls_svc_key_id_t key,
     } else if (PSA_ALG_IS_KEY_AGREEMENT(alg)) {
         ok = exercise_key_agreement_key(key, usage, alg);
     } else {
-        TEST_ASSERT(!"No code to exercise this category of algorithm");
+        ASSERT_FALSE("No code to exercise this category of algorithm");
     }
 
     ok = ok && exercise_export_key(key, usage);

--- a/tests/src/test_helpers/ssl_helpers.c
+++ b/tests/src/test_helpers/ssl_helpers.c
@@ -1753,8 +1753,8 @@ static int check_ssl_version(
             break;
 
         default:
-            TEST_ASSERT(
-                !"Version check not implemented for this protocol version");
+            ASSERT_FALSE(
+                "Version check not implemented for this protocol version");
     }
 
     return 1;

--- a/tests/src/test_helpers/ssl_helpers.c
+++ b/tests/src/test_helpers/ssl_helpers.c
@@ -1753,7 +1753,7 @@ static int check_ssl_version(
             break;
 
         default:
-            ASSERT_FALSE(
+            TEST_FAIL(
                 "Version check not implemented for this protocol version");
     }
 

--- a/tests/suites/test_suite_alignment.function
+++ b/tests/suites/test_suite_alignment.function
@@ -121,7 +121,7 @@ void mbedtls_byteswap(char *input_str, int size, char *expected_str)
             r = MBEDTLS_BSWAP64(input);
             break;
         default:
-            TEST_ASSERT(!"size must be 16, 32 or 64");
+            ASSERT_FALSE("size must be 16, 32 or 64");
     }
     TEST_EQUAL(r, expected);
 

--- a/tests/suites/test_suite_alignment.function
+++ b/tests/suites/test_suite_alignment.function
@@ -121,7 +121,7 @@ void mbedtls_byteswap(char *input_str, int size, char *expected_str)
             r = MBEDTLS_BSWAP64(input);
             break;
         default:
-            ASSERT_FALSE("size must be 16, 32 or 64");
+            TEST_FAIL("size must be 16, 32 or 64");
     }
     TEST_EQUAL(r, expected);
 

--- a/tests/suites/test_suite_asn1write.function
+++ b/tests/suites/test_suite_asn1write.function
@@ -316,7 +316,7 @@ void mbedtls_asn1_write_algorithm_identifier(data_t *oid,
                 buf_complete[data_len + 2] = (unsigned char) (expected_params_len >> 8);
                 buf_complete[data_len + 3] = (unsigned char) (expected_params_len);
             } else {
-                ASSERT_FALSE("Bad test data: invalid length of ASN.1 element");
+                TEST_FAIL("Bad test data: invalid length of ASN.1 element");
             }
             unsigned char *p = buf_complete;
             TEST_EQUAL(mbedtls_asn1_get_alg(&p, end_complete,

--- a/tests/suites/test_suite_asn1write.function
+++ b/tests/suites/test_suite_asn1write.function
@@ -316,7 +316,7 @@ void mbedtls_asn1_write_algorithm_identifier(data_t *oid,
                 buf_complete[data_len + 2] = (unsigned char) (expected_params_len >> 8);
                 buf_complete[data_len + 3] = (unsigned char) (expected_params_len);
             } else {
-                TEST_ASSERT(!"Bad test data: invalid length of ASN.1 element");
+                ASSERT_FALSE("Bad test data: invalid length of ASN.1 element");
             }
             unsigned char *p = buf_complete;
             TEST_EQUAL(mbedtls_asn1_get_alg(&p, end_complete,

--- a/tests/suites/test_suite_bignum.function
+++ b/tests/suites/test_suite_bignum.function
@@ -834,7 +834,7 @@ void mpi_mul_int(char *input_X, int input_Y,
     } else if (strcmp(result_comparison, "!=") == 0) {
         TEST_ASSERT(mbedtls_mpi_cmp_mpi(&Z, &A) != 0);
     } else {
-        TEST_ASSERT("unknown operator" == 0);
+        TEST_FAIL("unknown operator");
     }
 
 exit:

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -8780,7 +8780,7 @@ void derive_output(int alg_arg,
                         }
                         break;
                     default:
-                        ASSERT_FALSE("default case not supported");
+                        TEST_FAIL("default case not supported");
                         break;
                 }
                 break;
@@ -8830,7 +8830,7 @@ void derive_output(int alg_arg,
                                        key_agreement_peer_key->len), statuses[i]);
                         break;
                     default:
-                        ASSERT_FALSE("default case not supported");
+                        TEST_FAIL("default case not supported");
                         break;
                 }
 
@@ -9822,7 +9822,7 @@ void persistent_key_load_key_from_storage(data_t *data,
             break;
 
         default:
-            ASSERT_FALSE("generation_method not implemented in test");
+            TEST_FAIL("generation_method not implemented in test");
             break;
     }
     psa_reset_key_attributes(&attributes);

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -8780,7 +8780,7 @@ void derive_output(int alg_arg,
                         }
                         break;
                     default:
-                        TEST_ASSERT(!"default case not supported");
+                        ASSERT_FALSE("default case not supported");
                         break;
                 }
                 break;
@@ -8830,7 +8830,7 @@ void derive_output(int alg_arg,
                                        key_agreement_peer_key->len), statuses[i]);
                         break;
                     default:
-                        TEST_ASSERT(!"default case not supported");
+                        ASSERT_FALSE("default case not supported");
                         break;
                 }
 
@@ -9822,7 +9822,7 @@ void persistent_key_load_key_from_storage(data_t *data,
             break;
 
         default:
-            TEST_ASSERT(!"generation_method not implemented in test");
+            ASSERT_FALSE("generation_method not implemented in test");
             break;
     }
     psa_reset_key_attributes(&attributes);

--- a/tests/suites/test_suite_psa_crypto_driver_wrappers.function
+++ b/tests/suites/test_suite_psa_crypto_driver_wrappers.function
@@ -465,7 +465,7 @@ static int sanity_check_rsa_encryption_result(
         TEST_EQUAL(buf[0], 0x00);
         /* The rest is too hard to check */
     } else {
-        ASSERT_FALSE("Encryption result sanity check not implemented for RSA algorithm");
+        TEST_FAIL("Encryption result sanity check not implemented for RSA algorithm");
     }
 #endif /* MBEDTLS_BIGNUM_C */
 
@@ -2754,7 +2754,7 @@ void asymmetric_encrypt(int alg_arg,
             {
                 (void) modulus;
                 (void) private_exponent;
-                ASSERT_FALSE("Encryption sanity checks not implemented for this key type");
+                TEST_FAIL("Encryption sanity checks not implemented for this key type");
             }
         }
     }

--- a/tests/suites/test_suite_psa_crypto_driver_wrappers.function
+++ b/tests/suites/test_suite_psa_crypto_driver_wrappers.function
@@ -465,7 +465,7 @@ static int sanity_check_rsa_encryption_result(
         TEST_EQUAL(buf[0], 0x00);
         /* The rest is too hard to check */
     } else {
-        TEST_ASSERT(!"Encryption result sanity check not implemented for RSA algorithm");
+        ASSERT_FALSE("Encryption result sanity check not implemented for RSA algorithm");
     }
 #endif /* MBEDTLS_BIGNUM_C */
 
@@ -2754,7 +2754,7 @@ void asymmetric_encrypt(int alg_arg,
             {
                 (void) modulus;
                 (void) private_exponent;
-                TEST_ASSERT(!"Encryption sanity checks not implemented for this key type");
+                ASSERT_FALSE("Encryption sanity checks not implemented for this key type");
             }
         }
     }

--- a/tests/suites/test_suite_psa_crypto_se_driver_hal.function
+++ b/tests/suites/test_suite_psa_crypto_se_driver_hal.function
@@ -1328,7 +1328,7 @@ void sign_verify(int flow,
             key_management.p_export_public = ram_export_public;
             break;
         default:
-            TEST_ASSERT(!"unsupported flow (should be SIGN_IN_xxx)");
+            ASSERT_FALSE("unsupported flow (should be SIGN_IN_xxx)");
             break;
     }
     asymmetric.p_verify = ram_verify;

--- a/tests/suites/test_suite_psa_crypto_se_driver_hal.function
+++ b/tests/suites/test_suite_psa_crypto_se_driver_hal.function
@@ -1328,7 +1328,7 @@ void sign_verify(int flow,
             key_management.p_export_public = ram_export_public;
             break;
         default:
-            ASSERT_FALSE("unsupported flow (should be SIGN_IN_xxx)");
+            TEST_FAIL("unsupported flow (should be SIGN_IN_xxx)");
             break;
     }
     asymmetric.p_verify = ram_verify;

--- a/tests/suites/test_suite_psa_crypto_slot_management.function
+++ b/tests/suites/test_suite_psa_crypto_slot_management.function
@@ -775,7 +775,7 @@ void invalid_handle(int handle_construction,
                 mbedtls_svc_key_id_make(0, PSA_KEY_ID_VENDOR_MAX + 1);
             break;
         default:
-            ASSERT_FALSE("unknown handle construction");
+            TEST_FAIL("unknown handle construction");
     }
 
     /* Attempt to use the invalid handle. */

--- a/tests/suites/test_suite_psa_crypto_slot_management.function
+++ b/tests/suites/test_suite_psa_crypto_slot_management.function
@@ -775,7 +775,7 @@ void invalid_handle(int handle_construction,
                 mbedtls_svc_key_id_make(0, PSA_KEY_ID_VENDOR_MAX + 1);
             break;
         default:
-            TEST_ASSERT(!"unknown handle construction");
+            ASSERT_FALSE("unknown handle construction");
     }
 
     /* Attempt to use the invalid handle. */

--- a/tests/suites/test_suite_shax.function
+++ b/tests/suites/test_suite_shax.function
@@ -275,14 +275,14 @@ void sha3_reuse(data_t *input1, data_t *hash1,
         case 32: type1 = MBEDTLS_SHA3_256; break;
         case 48: type1 = MBEDTLS_SHA3_384; break;
         case 64: type1 = MBEDTLS_SHA3_512; break;
-        default: ASSERT_FALSE("hash1->len validity"); break;
+        default: TEST_FAIL("hash1->len validity"); break;
     }
     switch (hash2->len) {
         case 28: type2 = MBEDTLS_SHA3_224; break;
         case 32: type2 = MBEDTLS_SHA3_256; break;
         case 48: type2 = MBEDTLS_SHA3_384; break;
         case 64: type2 = MBEDTLS_SHA3_512; break;
-        default: ASSERT_FALSE("hash2->len validity"); break;
+        default: TEST_FAIL("hash2->len validity"); break;
     }
 
     /* Round 1 */

--- a/tests/suites/test_suite_shax.function
+++ b/tests/suites/test_suite_shax.function
@@ -275,14 +275,14 @@ void sha3_reuse(data_t *input1, data_t *hash1,
         case 32: type1 = MBEDTLS_SHA3_256; break;
         case 48: type1 = MBEDTLS_SHA3_384; break;
         case 64: type1 = MBEDTLS_SHA3_512; break;
-        default: TEST_ASSERT(!"hash1->len validity"); break;
+        default: ASSERT_FALSE("hash1->len validity"); break;
     }
     switch (hash2->len) {
         case 28: type2 = MBEDTLS_SHA3_224; break;
         case 32: type2 = MBEDTLS_SHA3_256; break;
         case 48: type2 = MBEDTLS_SHA3_384; break;
         case 64: type2 = MBEDTLS_SHA3_512; break;
-        default: TEST_ASSERT(!"hash2->len validity"); break;
+        default: ASSERT_FALSE("hash2->len validity"); break;
     }
 
     /* Round 1 */

--- a/tests/suites/test_suite_x509parse.function
+++ b/tests/suites/test_suite_x509parse.function
@@ -702,7 +702,7 @@ void x509_verify(char *crt_file, char *ca_file, char *crl_file,
     } else if (strcmp(profile_str, "all") == 0) {
         profile = &profile_all;
     } else {
-        TEST_ASSERT("Unknown algorithm profile" == 0);
+        TEST_FAIL("Unknown algorithm profile");
     }
 
     if (strcmp(verify_callback, "NULL") == 0) {
@@ -712,7 +712,7 @@ void x509_verify(char *crt_file, char *ca_file, char *crl_file,
     } else if (strcmp(verify_callback, "verify_all") == 0) {
         f_vrfy = verify_all;
     } else {
-        TEST_ASSERT("No known verify callback selected" == 0);
+        TEST_FAIL("No known verify callback selected");
     }
 
     TEST_EQUAL(mbedtls_x509_crt_parse_file(&crt, crt_file), 0);
@@ -881,7 +881,7 @@ void mbedtls_x509_dn_gets(char *crt_file, char *entity, char *result_str)
     } else if (strcmp(entity, "issuer") == 0) {
         res =  mbedtls_x509_dn_gets(buf, 2000, &crt.issuer);
     } else {
-        TEST_ASSERT("Unknown entity" == 0);
+        TEST_FAIL("Unknown entity");
     }
 
     TEST_ASSERT(res != -1);
@@ -1006,7 +1006,7 @@ void mbedtls_x509_time_is_past(char *crt_file, char *entity, int result)
     } else if (strcmp(entity, "valid_to") == 0) {
         TEST_EQUAL(mbedtls_x509_time_is_past(&crt.valid_to), result);
     } else {
-        TEST_ASSERT("Unknown entity" == 0);
+        TEST_FAIL("Unknown entity");
     }
 
 exit:
@@ -1030,7 +1030,7 @@ void mbedtls_x509_time_is_future(char *crt_file, char *entity, int result)
     } else if (strcmp(entity, "valid_to") == 0) {
         TEST_EQUAL(mbedtls_x509_time_is_future(&crt.valid_to), result);
     } else {
-        TEST_ASSERT("Unknown entity" == 0);
+        TEST_FAIL("Unknown entity");
     }
 
 exit:


### PR DESCRIPTION
## Description

The TEST_ASSERT macro was being used in places where we wanted to just assert false, using the pattern `TEST_ASSERT(!"message")` which expanded to a tautology in the if statement, so the new macro ASSERT_FALSE is being used in these instances.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required as no new functionality
- [x] **backport** #7940 
- [x] **tests** these are changes to the test implementation

