### PR TITLE
code_size_compare.py: preparation work to show code size changes in PR comment

### DIFF
--- a/scripts/code_size_compare.py
+++ b/scripts/code_size_compare.py
@@ -31,6 +31,7 @@ import sys
 import typing
 from enum import Enum
 
+from types import SimpleNamespace
 from mbedtls_dev import typing_util
 from mbedtls_dev import build_tree
 
@@ -72,7 +73,7 @@ def detect_arch() -> str:
         print("Unknown host architecture, cannot auto-detect arch.")
         sys.exit(1)
 
-class CodeSizeInfo: # pylint: disable=too-few-public-methods
+class CodeSizeBuildInfo: # pylint: disable=too-few-public-methods
     """Gather information used to measure code size.
 
     It collects information about architecture, configuration in order to
@@ -87,25 +88,23 @@ class CodeSizeInfo: # pylint: disable=too-few-public-methods
         "-a " + SupportedArch.ARMV8_M.value + " -c " + SupportedConfig.TFM_MEDIUM.value,
     ]
 
-    def __init__(self, arch: str, config: str, sys_arch: str) -> None:
+    def __init__(self, size_version: SimpleNamespace) -> None:
         """
-        arch: architecture to measure code size on.
-        config: configuration type to measure code size with.
-        sys_arch: host architecture.
+        size_version: SimpleNamespace containing info for code size measurement.
+        size_version.arch: architecture to measure code size on.
+        size_version.config: configuration type to measure code size with.
+        size_version.host_arch: host architecture.
         """
-        self.arch = arch
-        self.config = config
-        self.sys_arch = sys_arch
-        self.make_cmd = self.set_make_command()
+        self.size_version = size_version
 
-    def set_make_command(self) -> str:
+    def infer_make_command(self) -> str:
         """Infer build command based on architecture and configuration."""
 
-        if self.config == SupportedConfig.DEFAULT.value and \
-            self.arch == self.sys_arch:
+        if self.size_version.config == SupportedConfig.DEFAULT.value and \
+            self.size_version.arch == self.size_version.host_arch:
             return 'make -j lib CFLAGS=\'-Os \' '
-        elif self.arch == SupportedArch.ARMV8_M.value and \
-             self.config == SupportedConfig.TFM_MEDIUM.value:
+        elif self.size_version.arch == SupportedArch.ARMV8_M.value and \
+             self.size_version.config == SupportedConfig.TFM_MEDIUM.value:
             return \
                  'make -j lib CC=armclang \
                   CFLAGS=\'--target=arm-arm-none-eabi -mcpu=cortex-m33 -Os \
@@ -113,13 +112,13 @@ class CodeSizeInfo: # pylint: disable=too-few-public-methods
                  -DMBEDTLS_PSA_CRYPTO_CONFIG_FILE=\\\"' + CONFIG_TFM_MEDIUM_PSA_CRYPTO_H + '\\\" \''
         else:
             print("Unsupported combination of architecture: {} and configuration: {}"
-                  .format(self.arch, self.config))
+                  .format(self.size_version.arch, self.size_version.config))
             print("\nPlease use supported combination of architecture and configuration:")
-            for comb in CodeSizeInfo.SupportedArchConfig:
+            for comb in CodeSizeBuildInfo.SupportedArchConfig:
                 print(comb)
             print("\nFor your system, please use:")
-            for comb in CodeSizeInfo.SupportedArchConfig:
-                if "default" in comb and self.sys_arch not in comb:
+            for comb in CodeSizeBuildInfo.SupportedArchConfig:
+                if "default" in comb and self.size_version.host_arch not in comb:
                     continue
                 print(comb)
             sys.exit(1)
@@ -433,16 +432,14 @@ class CodeSizeComparison:
 
     def __init__(
             self,
-            old_revision: str,
-            new_revision: str,
+            old_size_version: SimpleNamespace,
+            new_size_version: SimpleNamespace,
             result_dir: str,
-            code_size_info: CodeSizeInfo
     ) -> None:
         """
         old_revision: revision to compare against.
         new_revision:
         result_dir: directory for comparison result.
-        code_size_info: an object containing information to build library.
         """
         self.repo_path = "."
         self.result_dir = os.path.abspath(result_dir)
@@ -451,56 +448,72 @@ class CodeSizeComparison:
         self.csv_dir = os.path.abspath("code_size_records/")
         os.makedirs(self.csv_dir, exist_ok=True)
 
-        self.old_rev = old_revision
-        self.new_rev = new_revision
+        self.old_size_version = old_size_version
+        self.new_size_version = new_size_version
+        self.old_size_version.make_cmd = \
+                CodeSizeBuildInfo(self.old_size_version).infer_make_command()
+        self.new_size_version.make_cmd = \
+                CodeSizeBuildInfo(self.new_size_version).infer_make_command()
         self.git_command = "git"
         self.make_clean = 'make clean'
-        self.make_cmd = code_size_info.make_cmd
-        self.fname_suffix = "-" + code_size_info.arch + "-" +\
-                            code_size_info.config
         self.code_size_generator = CodeSizeGeneratorWithSize()
 
-    def cal_code_size(self, revision: str):
+    @staticmethod
+    def cal_code_size(size_version: SimpleNamespace):
         """Calculate code size of library objects in a UTF-8 encoding"""
 
-        return CodeSizeCalculator(revision, self.make_cmd).\
+        return CodeSizeCalculator(size_version.revision, size_version.make_cmd).\
                 cal_libraries_code_size()
 
-    def gen_code_size_report(self, revision):
+    @staticmethod
+    def gen_file_name(old_size_version, new_size_version=None):
+        if new_size_version:
+            return '{}-{}-{}-{}-{}-{}.csv'\
+                    .format(old_size_version.revision[:7],
+                            old_size_version.arch, old_size_version.config,
+                            new_size_version.revision[:7],
+                            new_size_version.arch, new_size_version.config)
+        else:
+            return '{}-{}-{}.csv'\
+                    .format(old_size_version.revision[:7],
+                            old_size_version.arch, old_size_version.config)
+
+    def gen_code_size_report(self, size_version: SimpleNamespace):
         """Generate code size record and write it into a file."""
 
-        output_file = os.path.join(self.csv_dir,\
-                revision + self.fname_suffix +  ".csv")
+        output_file = os.path.join(self.csv_dir, self.gen_file_name(size_version))
         # Check if the corresponding record exists
-        if (revision != "current") and os.path.exists(output_file):
-            print("Code size csv file for", revision, "already exists.")
-            self.code_size_generator.read_size_record(revision, output_file)
+        if (size_version.revision != "current") and os.path.exists(output_file):
+            print("Code size csv file for", size_version.revision, "already exists.")
+            self.code_size_generator.read_size_record(size_version.revision, output_file)
         else:
-            self.code_size_generator.size_generator_write_record(revision,\
-                self.cal_code_size(revision), output_file)
+            self.code_size_generator.size_generator_write_record(\
+                    size_version.revision, self.cal_code_size(size_version),
+                    output_file)
 
     def gen_code_size_comparison(self) -> int:
         """Generate results of code size changes between two revisions,
         old and new. Measured code size results of these two revisions
         must be available."""
 
-        output_file = os.path.join(self.result_dir, "compare-" +
-                                   self.old_rev + "-" + self.new_rev +
-                                   self.fname_suffix + ".csv")
+        output_file = os.path.join(self.result_dir,\
+                self.gen_file_name(self.old_size_version, self.new_size_version))
 
         print("\nGenerating comparison results between",\
-                self.old_rev, "and", self.new_rev)
+                self.old_size_version.revision, "and", self.new_size_version.revision)
         self.code_size_generator.size_generator_write_comparison(\
-                self.old_rev, self.new_rev, output_file)
+                self.old_size_version.revision, self.new_size_version.revision,\
+                output_file)
         return 0
 
     def get_comparision_results(self) -> int:
         """Compare size of library/*.o between self.old_rev and self.new_rev,
         and generate the result file."""
         build_tree.check_repo_path()
-        self.gen_code_size_report(self.old_rev)
-        self.gen_code_size_report(self.new_rev)
+        self.gen_code_size_report(self.old_size_version)
+        self.gen_code_size_report(self.new_size_version)
         return self.gen_code_size_comparison()
+
 
 def main():
     parser = argparse.ArgumentParser(description=(__doc__))
@@ -547,13 +560,25 @@ def main():
     else:
         new_revision = "current"
 
-    code_size_info = CodeSizeInfo(comp_args.arch, comp_args.config,
-                                  detect_arch())
-    print("Measure code size for architecture: {}, configuration: {}\n"
-          .format(code_size_info.arch, code_size_info.config))
-    result_dir = comp_args.result_dir
-    size_compare = CodeSizeComparison(old_revision, new_revision, result_dir,
-                                      code_size_info)
+    old_size_version = SimpleNamespace(
+        version="old",
+        revision=old_revision,
+        config=comp_args.config,
+        arch=comp_args.arch,
+        host_arch=detect_arch(),
+        make_cmd='',
+    )
+    new_size_version = SimpleNamespace(
+        version="new",
+        revision=new_revision,
+        config=comp_args.config,
+        arch=comp_args.arch,
+        host_arch=detect_arch(),
+        make_cmd='',
+    )
+
+    size_compare = CodeSizeComparison(old_size_version, new_size_version,\
+            comp_args.result_dir)
     return_code = size_compare.get_comparision_results()
     sys.exit(return_code)
 

--- a/scripts/code_size_compare.py
+++ b/scripts/code_size_compare.py
@@ -856,7 +856,10 @@ def main():
 
     logger = logging.getLogger()
     logging_util.configure_logger(logger)
-    logger.setLevel(logging.DEBUG if comp_args.verbose else logging.INFO)
+    if comp_args.stdout and not comp_args.verbose:
+        logger.setLevel(logging.ERROR)
+    else:
+        logger.setLevel(logging.DEBUG if comp_args.verbose else logging.INFO)
 
     if os.path.isfile(comp_args.comp_dir):
         logger.error("{} is not a directory".format(comp_args.comp_dir))

--- a/scripts/code_size_compare.py
+++ b/scripts/code_size_compare.py
@@ -644,13 +644,15 @@ class CodeSizeGeneratorWithSize(CodeSizeGenerator):
                 delta = new_attr - old_attr
                 change_attr = '{0:{1}}'.format(delta, '+' if delta else '')
             elif old_size:
-                new_attr = - old_size.__dict__[sect]
+                new_attr = 'Removed'
                 old_attr = old_size.__dict__[sect]
-                change_attr = 'Removed'
+                delta = - old_attr
+                change_attr = '{0:{1}}'.format(delta, '+' if delta else '')
             elif new_size:
                 new_attr = new_size.__dict__[sect]
                 old_attr = 'NotCreated'
-                change_attr = 'None'
+                delta = new_attr
+                change_attr = '{0:{1}}'.format(delta, '+' if delta else '')
             else:
                 # Should never happen
                 new_attr = 'Error'

--- a/scripts/code_size_compare.py
+++ b/scripts/code_size_compare.py
@@ -594,7 +594,7 @@ class CodeSizeGeneratorWithSize(CodeSizeGenerator):
         """Write comparison result into a file.
 
         Writing Format: file_name current(text,data) old(text,data)\
-                change(text,data) change_pct%(text,data)
+                change(text,data)
         """
 
         def cal_size_section_variation(mod, fname, size_entry, attr):
@@ -603,26 +603,22 @@ class CodeSizeGeneratorWithSize(CodeSizeGenerator):
             if fname in self.code_size[old_rev][mod]:
                 old_size = int(self.code_size[old_rev][mod][fname].__dict__[attr])
                 change = new_size - old_size
-                if old_size != 0:
-                    change_pct = change / old_size
-                else:
-                    change_pct = 0
-                return [new_size, old_size, change, change_pct]
+                return [new_size, old_size, change]
             else:
                 return [new_size]
 
         if with_markdown:
-            format_string = "| {:<30} | {:<18} | {:<14} | {:<17} | {:<18} |\n"
+            format_string = "| {:<30} | {:<18} | {:<14} | {:<17} |\n"
         else:
-            format_string = "{:<30} {:<18} {:<14} {:<17} {:<18}\n"
+            format_string = "{:<30} {:<18} {:<14} {:<17}\n"
 
         output.write(format_string
                      .format("filename",
                              "current(text,data)", "old(text,data)",
-                             "change(text,data)", "change%(text,data)"))
+                             "change(text,data)"))
         if with_markdown:
             output.write(format_string
-                         .format(":----", "----:", "----:", "----:", "----:"))
+                         .format(":----", "----:", "----:", "----:"))
 
         for mod, fname, size_entry in \
                 self._size_reader_helper(new_rev, output, with_markdown):
@@ -644,17 +640,14 @@ class CodeSizeGeneratorWithSize(CodeSizeGenerator):
                             # old(text,data)
                             str(text_vari[1]) + "," + str(data_vari[1]),
                             # change(text,data)
-                            str(text_vari[2]) + "," + str(data_vari[2]),
-                            # change%(text,data)
-                            "{:.0%}".format(text_vari[3]) + ","
-                            + "{:.0%}".format(data_vari[3])))
+                            str(text_vari[2]) + "," + str(data_vari[2])))
             else:
                 output.write(
                     format_string
                     .format(fname,
                             # current(text,data)
                             str(text_vari[0]) + "," + str(data_vari[0]),
-                            'None', 'None', 'None'))
+                            'None', 'None'))
 
 
 class CodeSizeComparison:

--- a/scripts/code_size_compare.py
+++ b/scripts/code_size_compare.py
@@ -647,9 +647,11 @@ class CodeSizeGeneratorWithSize(CodeSizeGenerator):
                             "{:.2%}".format(text_vari[3]) + ","
                             + "{:.2%}".format(data_vari[3])))
             else:
-                output.write("{:<30} {:<18}\n"
-                             .format(fname,
-                                     str(text_vari[0]) + "," + str(data_vari[0])))
+                output.write(
+                    format_string
+                    .format(fname,
+                            str(text_vari[0]) + "," + str(data_vari[0]),
+                            'None', 'None', 'None'))
 
 
 class CodeSizeComparison:

--- a/scripts/code_size_compare.py
+++ b/scripts/code_size_compare.py
@@ -604,10 +604,10 @@ class CodeSizeGeneratorWithSize(CodeSizeGenerator):
 
         if with_markdown:
             dash_line = [":----", "----:", "----:", "----:", "----:"]
-            line_format = "| {0:<30} | {1:<10} | {3:<10} | {2:<12} | {4:<12} |\n"
+            line_format = "| {0:<30} | {1:>10} | {3:>10} | {2:>12} | {4:>12} |\n"
             bold_text = lambda x: '**' + str(x) + '**'
         else:
-            line_format = "{0:<30} {1:<10} {3:<10} {2:<12} {4:<12}\n"
+            line_format = "{0:<30} {1:>10} {3:>10} {2:>12} {4:>12}\n"
 
         def cal_sect_change(
                 old_size: typing.Optional[CodeSizeGeneratorWithSize.SizeEntry],

--- a/scripts/code_size_compare.py
+++ b/scripts/code_size_compare.py
@@ -906,11 +906,8 @@ def main():
     comp_args = parser.parse_args()
 
     logger = logging.getLogger()
-    logging_util.configure_logger(logger)
-    if comp_args.stdout and not comp_args.verbose:
-        logger.setLevel(logging.ERROR)
-    else:
-        logger.setLevel(logging.DEBUG if comp_args.verbose else logging.INFO)
+    logging_util.configure_logger(logger, split_level=logging.NOTSET)
+    logger.setLevel(logging.DEBUG if comp_args.verbose else logging.INFO)
 
     if os.path.isfile(comp_args.record_dir):
         logger.error("record directory: {} is not a directory"

--- a/scripts/code_size_compare.py
+++ b/scripts/code_size_compare.py
@@ -776,10 +776,6 @@ class CodeSizeComparison:
                                  self.new_size_dist_info.git_rev))
         if self.result_options.stdout:
             output = sys.stdout
-            print("Measure code size between `{}` and `{}` by `{}`."
-                  .format(self.old_size_dist_info.get_info_indication(),
-                          self.new_size_dist_info.get_info_indication(),
-                          self.size_common_info.get_info_indication()))
         else:
             output_file = os.path.join(
                 self.comp_dir,
@@ -792,6 +788,12 @@ class CodeSizeComparison:
         self.logger.debug("Generating comparison results between {} and {}."
                           .format(self.old_size_dist_info.git_rev,
                                   self.new_size_dist_info.git_rev))
+        if self.result_options.with_markdown or self.result_options.stdout:
+            print("Measure code size between {} and {} by `{}`."
+                  .format(self.old_size_dist_info.get_info_indication(),
+                          self.new_size_dist_info.get_info_indication(),
+                          self.size_common_info.get_info_indication()),
+                  file=output)
         self.code_size_generator.write_comparison(
             self.old_size_dist_info.git_rev,
             self.new_size_dist_info.git_rev,

--- a/scripts/code_size_compare.py
+++ b/scripts/code_size_compare.py
@@ -815,11 +815,11 @@ def main():
         'optional arguments',
         'optional arguments to parse for running ' + os.path.basename(__file__))
     group_optional.add_argument(
-        '--record_dir', type=str, default='code_size_records',
+        '--record-dir', type=str, default='code_size_records',
         help='directory where code size record is stored. '
              '(Default: code_size_records)')
     group_optional.add_argument(
-        '-r', '--comp-dir', type=str, default='comparison',
+        '--comp-dir', type=str, default='comparison',
         help='directory where comparison result is stored. '
              '(Default: comparison)')
     group_optional.add_argument(
@@ -858,9 +858,14 @@ def main():
     else:
         logger.setLevel(logging.DEBUG if comp_args.verbose else logging.INFO)
 
+    if os.path.isfile(comp_args.record_dir):
+        logger.error("record directory: {} is not a directory"
+                     .format(comp_args.record_dir))
+        sys.exit(1)
     if os.path.isfile(comp_args.comp_dir):
-        logger.error("{} is not a directory".format(comp_args.comp_dir))
-        parser.exit()
+        logger.error("comparison directory: {} is not a directory"
+                     .format(comp_args.comp_dir))
+        sys.exit(1)
 
     comp_args.old_rev = CodeSizeCalculator.validate_git_revision(
         comp_args.old_rev)

--- a/scripts/code_size_compare.py
+++ b/scripts/code_size_compare.py
@@ -92,9 +92,7 @@ class CodeSizeDistinctInfo: # pylint: disable=too-few-public-methods
 
     def get_info_indication(self):
         """Return a unique string to indicate Code Size Distinct Information."""
-        return '{rev}-{arch}-{config}-{cc}'\
-               .format(rev=self.git_rev, arch=self.arch, config=self.config,
-                       cc=self.compiler)
+        return '{git_rev}-{arch}-{config}-{compiler}'.format(**self.__dict__)
 
 
 class CodeSizeCommonInfo: # pylint: disable=too-few-public-methods
@@ -518,10 +516,7 @@ class CodeSizeGeneratorWithSize(CodeSizeGenerator):
             # file_name: SizeEntry(text, data, bss, dec)
             size_record[data[5]] = CodeSizeGeneratorWithSize.SizeEntry(
                 data[0], data[1], data[2], data[3])
-        if git_rev in self.code_size:
-            self.code_size[git_rev].update({mod: size_record})
-        else:
-            self.code_size[git_rev] = {mod: size_record}
+        self.code_size.setdefault(git_rev, {}).update({mod: size_record})
 
     def read_size_record(self, git_rev: str, fname: str) -> None:
         """Read size information from csv file and write it into code_size.

--- a/scripts/code_size_compare.py
+++ b/scripts/code_size_compare.py
@@ -222,9 +222,9 @@ class CodeSizeBuildInfo: # pylint: disable=too-few-public-methods
         """Infer command to set up proper configuration before running make."""
         pre_make_cmd = [] #type: typing.List[str]
         if self.config == SupportedConfig.TFM_MEDIUM.value:
-            pre_make_cmd.append('cp -r {src} {dest}'
+            pre_make_cmd.append('cp {src} {dest}'
                                 .format(src=TFM_MEDIUM_CONFIG_H, dest=CONFIG_H))
-            pre_make_cmd.append('cp -r {src} {dest}'
+            pre_make_cmd.append('cp {src} {dest}'
                                 .format(src=TFM_MEDIUM_CRYPTO_CONFIG_H,
                                         dest=CRYPTO_CONFIG_H))
 

--- a/scripts/code_size_compare.py
+++ b/scripts/code_size_compare.py
@@ -92,8 +92,9 @@ class CodeSizeDistinctInfo: # pylint: disable=too-few-public-methods
 
     def get_info_indication(self):
         """Return a unique string to indicate Code Size Distinct Information."""
-        return '{}-{}-{}-{}'\
-               .format(self.git_rev, self.arch, self.config, self.compiler)
+        return '{rev}-{arch}-{config}-{cc}'\
+               .format(rev=self.git_rev, arch=self.arch, config=self.config,
+                       cc=self.compiler)
 
 
 class CodeSizeCommonInfo: # pylint: disable=too-few-public-methods
@@ -112,8 +113,8 @@ class CodeSizeCommonInfo: # pylint: disable=too-few-public-methods
 
     def get_info_indication(self):
         """Return a unique string to indicate Code Size Common Information."""
-        return '{}'\
-               .format(self.measure_cmd.strip().split(' ')[0])
+        return '{measure_tool}'\
+               .format(measure_tool=self.measure_cmd.strip().split(' ')[0])
 
 class CodeSizeResultInfo: # pylint: disable=too-few-public-methods
     """Data structure to store result options for code size comparison."""
@@ -223,11 +224,11 @@ class CodeSizeBuildInfo: # pylint: disable=too-few-public-methods
         """Infer command to set up proper configuration before running make."""
         pre_make_cmd = [] #type: typing.List[str]
         if self.config == SupportedConfig.TFM_MEDIUM.value:
-            pre_make_cmd.append('cp -r {} {}'
-                                .format(TFM_MEDIUM_CONFIG_H, CONFIG_H))
-            pre_make_cmd.append('cp -r {} {}'
-                                .format(TFM_MEDIUM_CRYPTO_CONFIG_H,
-                                        CRYPTO_CONFIG_H))
+            pre_make_cmd.append('cp -r {src} {dest}'
+                                .format(src=TFM_MEDIUM_CONFIG_H, dest=CONFIG_H))
+            pre_make_cmd.append('cp -r {src} {dest}'
+                                .format(src=TFM_MEDIUM_CRYPTO_CONFIG_H,
+                                        dest=CRYPTO_CONFIG_H))
 
         return pre_make_cmd
 
@@ -641,15 +642,20 @@ class CodeSizeGeneratorWithSize(CodeSizeGenerator):
                 output.write(
                     format_string
                     .format(fname,
+                            # current(text,data)
                             str(text_vari[0]) + "," + str(data_vari[0]),
+                            # old(text,data)
                             str(text_vari[1]) + "," + str(data_vari[1]),
+                            # change(text,data)
                             str(text_vari[2]) + "," + str(data_vari[2]),
+                            # change%(text,data)
                             "{:.0%}".format(text_vari[3]) + ","
                             + "{:.0%}".format(data_vari[3])))
             else:
                 output.write(
                     format_string
                     .format(fname,
+                            # current(text,data)
                             str(text_vari[0]) + "," + str(data_vari[0]),
                             'None', 'None', 'None'))
 

--- a/scripts/code_size_compare.py
+++ b/scripts/code_size_compare.py
@@ -147,7 +147,7 @@ def detect_arch() -> str:
         return SupportedArch.AARCH32.value
     if '__x86_64__' in cc_output:
         return SupportedArch.X86_64.value
-    if '__x86__' in cc_output:
+    if '__i386__' in cc_output:
         return SupportedArch.X86.value
     else:
         print("Unknown host architecture, cannot auto-detect arch.")

--- a/scripts/code_size_compare.py
+++ b/scripts/code_size_compare.py
@@ -423,9 +423,11 @@ class CodeSizeCalculator:
         """
 
         git_worktree_path = self._create_git_worktree()
-        self._build_libraries(git_worktree_path)
-        res = self._gen_raw_code_size(git_worktree_path)
-        self._remove_worktree(git_worktree_path)
+        try:
+            self._build_libraries(git_worktree_path)
+            res = self._gen_raw_code_size(git_worktree_path)
+        finally:
+            self._remove_worktree(git_worktree_path)
 
         return res
 

--- a/scripts/code_size_compare.py
+++ b/scripts/code_size_compare.py
@@ -625,7 +625,7 @@ class CodeSizeGeneratorWithSize(CodeSizeGenerator):
                              "change(text,data)", "change%(text,data)"))
         if with_markdown:
             output.write(format_string
-                         .format("----:", "----:", "----:", "----:", "----:"))
+                         .format(":----", "----:", "----:", "----:", "----:"))
 
         for mod, fname, size_entry in \
                 self._size_reader_helper(new_rev, output, with_markdown):

--- a/scripts/code_size_compare.py
+++ b/scripts/code_size_compare.py
@@ -815,10 +815,11 @@ class CodeSizeComparison:
         else:
             output_file = os.path.join(
                 self.comp_dir,
-                '{}-{}-{}.csv'
+                '{}-{}-{}.{}'
                 .format(self.old_size_dist_info.get_info_indication(),
                         self.new_size_dist_info.get_info_indication(),
-                        self.size_common_info.get_info_indication()))
+                        self.size_common_info.get_info_indication(),
+                        'md' if self.result_options.with_markdown else 'csv'))
             output = open(output_file, "w")
 
         self.logger.debug("Generating comparison results between {} and {}."

--- a/scripts/code_size_compare.py
+++ b/scripts/code_size_compare.py
@@ -633,7 +633,8 @@ class CodeSizeGeneratorWithSize(CodeSizeGenerator):
             """
             if old_size and new_size:
                 new_attr = new_size.__dict__[sect]
-                change_attr = new_size.__dict__[sect] - old_size.__dict__[sect]
+                delta = new_size.__dict__[sect] - old_size.__dict__[sect]
+                change_attr = '{0:{1}}'.format(delta, '+' if delta else '')
             elif old_size:
                 new_attr = - old_size.__dict__[sect]
                 change_attr = 'Removed'
@@ -665,7 +666,7 @@ class CodeSizeGeneratorWithSize(CodeSizeGenerator):
                 text_sect = cal_sect_change(old_size, new_size, 'text')
                 data_sect = cal_sect_change(old_size, new_size, 'data')
                 # skip the files that haven't changed in code size
-                if not show_all and text_sect[1] == 0 and data_sect[1] == 0:
+                if not show_all and text_sect[1] == '0' and data_sect[1] == '0':
                     continue
 
                 res.append([fname, *text_sect, *data_sect])

--- a/scripts/code_size_compare.py
+++ b/scripts/code_size_compare.py
@@ -262,16 +262,16 @@ class CodeSizeBuildInfo: # pylint: disable=too-few-public-methods
                               "and configuration: {}.\n"
                               .format(self.arch,
                                       self.config))
-            self.logger.info("Please use supported combination of " \
+            self.logger.error("Please use supported combination of " \
                              "architecture and configuration:")
             for comb in CodeSizeBuildInfo.SupportedArchConfig:
-                self.logger.info(comb)
-            self.logger.info("")
-            self.logger.info("For your system, please use:")
+                self.logger.error(comb)
+            self.logger.error("")
+            self.logger.error("For your system, please use:")
             for comb in CodeSizeBuildInfo.SupportedArchConfig:
                 if "default" in comb and self.host_arch not in comb:
                     continue
-                self.logger.info(comb)
+                self.logger.error(comb)
             sys.exit(1)
 
 

--- a/scripts/code_size_compare.py
+++ b/scripts/code_size_compare.py
@@ -828,7 +828,7 @@ def main():
         help='directory where comparison result is stored. '
              '(Default: comparison)')
     group_optional.add_argument(
-        '-n', '--new-rev', type=str, default=None,
+        '-n', '--new-rev', type=str, default='current',
         help='new Git revision as comparison base. '
              '(Default is the current work directory, including uncommitted '
              'changes.)')
@@ -867,18 +867,17 @@ def main():
         logger.error("{} is not a directory".format(comp_args.comp_dir))
         parser.exit()
 
-    old_revision = CodeSizeCalculator.validate_git_revision(comp_args.old_rev)
-    if comp_args.new_rev is not None:
-        new_revision = CodeSizeCalculator.validate_git_revision(
+    comp_args.old_rev = CodeSizeCalculator.validate_git_revision(
+        comp_args.old_rev)
+    if comp_args.new_rev != 'current':
+        comp_args.new_rev = CodeSizeCalculator.validate_git_revision(
             comp_args.new_rev)
-    else:
-        new_revision = 'current'
 
     # version, git_rev, arch, config, compiler, opt_level
     old_size_dist_info = CodeSizeDistinctInfo(
-        'old', old_revision, comp_args.arch, comp_args.config, 'cc', '-Os')
+        'old', comp_args.old_rev, comp_args.arch, comp_args.config, 'cc', '-Os')
     new_size_dist_info = CodeSizeDistinctInfo(
-        'new', new_revision, comp_args.arch, comp_args.config, 'cc', '-Os')
+        'new', comp_args.new_rev, comp_args.arch, comp_args.config, 'cc', '-Os')
     # host_arch, measure_cmd
     size_common_info = CodeSizeCommonInfo(
         detect_arch(), 'size -t')

--- a/scripts/code_size_compare.py
+++ b/scripts/code_size_compare.py
@@ -644,8 +644,8 @@ class CodeSizeGeneratorWithSize(CodeSizeGenerator):
                             str(text_vari[0]) + "," + str(data_vari[0]),
                             str(text_vari[1]) + "," + str(data_vari[1]),
                             str(text_vari[2]) + "," + str(data_vari[2]),
-                            "{:.2%}".format(text_vari[3]) + ","
-                            + "{:.2%}".format(data_vari[3])))
+                            "{:.0%}".format(text_vari[3]) + ","
+                            + "{:.0%}".format(data_vari[3])))
             else:
                 output.write(
                     format_string

--- a/scripts/code_size_compare.py
+++ b/scripts/code_size_compare.py
@@ -768,6 +768,10 @@ class CodeSizeComparison:
                                  self.new_size_dist_info.git_rev))
         if self.result_options.stdout:
             output = sys.stdout
+            print("Measure code size between `{}` and `{}` by `{}`."
+                  .format(self.old_size_dist_info.get_info_indication(),
+                          self.new_size_dist_info.get_info_indication(),
+                          self.size_common_info.get_info_indication()))
         else:
             output_file = os.path.join(
                 self.comp_dir,

--- a/scripts/code_size_compare.py
+++ b/scripts/code_size_compare.py
@@ -593,7 +593,7 @@ class CodeSizeGeneratorWithSize(CodeSizeGenerator):
     ) -> None:
         """Write comparison result into a file.
 
-        Writing Format: file_name current(text,data) old(text,data)\
+        Writing Format: file_name new(text,data) old(text,data)\
                 change(text,data)
         """
 
@@ -608,17 +608,17 @@ class CodeSizeGeneratorWithSize(CodeSizeGenerator):
                 return [new_size]
 
         if with_markdown:
-            format_string = "| {:<30} | {:<18} | {:<14} | {:<17} |\n"
+            format_string = "| {:<30} | {:<9} | {:<9} | {:<12} | {:<12} |\n"
         else:
-            format_string = "{:<30} {:<18} {:<14} {:<17}\n"
+            format_string = "{:<30} {:<9} {:<9} {:<12} {:<12}\n"
 
         output.write(format_string
                      .format("filename",
-                             "current(text,data)", "old(text,data)",
-                             "change(text,data)"))
+                             "new(text)", "new(data)", "change(text)",
+                             "change(data)"))
         if with_markdown:
             output.write(format_string
-                         .format(":----", "----:", "----:", "----:"))
+                         .format(":----", "----:", "----:", "----:", "----:"))
 
         for mod, fname, size_entry in \
                 self._size_reader_helper(new_rev, output, with_markdown):
@@ -635,18 +635,17 @@ class CodeSizeGeneratorWithSize(CodeSizeGenerator):
                 output.write(
                     format_string
                     .format(fname,
-                            # current(text,data)
-                            str(text_vari[0]) + "," + str(data_vari[0]),
-                            # old(text,data)
-                            str(text_vari[1]) + "," + str(data_vari[1]),
-                            # change(text,data)
-                            str(text_vari[2]) + "," + str(data_vari[2])))
+                            # new(text), new(data)
+                            str(text_vari[0]), str(data_vari[0]),
+                            # change(text), change(data)
+                            str(text_vari[2]), str(data_vari[2])))
             else:
                 output.write(
                     format_string
                     .format(fname,
-                            # current(text,data)
-                            str(text_vari[0]) + "," + str(data_vari[0]),
+                            # new(text), new(data)
+                            str(text_vari[0]), str(data_vari[0]),
+                            # change(text), change(data)
                             'None', 'None'))
 
 

--- a/scripts/mbedtls_dev/logging_util.py
+++ b/scripts/mbedtls_dev/logging_util.py
@@ -21,14 +21,16 @@ import sys
 
 def configure_logger(
         logger: logging.Logger,
-        log_format="[%(levelname)s]: %(message)s"
+        log_format="[%(levelname)s]: %(message)s",
+        split_level=logging.WARNING
     ) -> None:
     """
     Configure the logging.Logger instance so that:
         - Format is set to any log_format.
             Default: "[%(levelname)s]: %(message)s"
-        - loglevel >= WARNING are printed to stderr.
-        - loglevel <  WARNING are printed to stdout.
+        - loglevel >= split_level are printed to stderr.
+        - loglevel <  split_level are printed to stdout.
+            Default: logging.WARNING
     """
     class MaxLevelFilter(logging.Filter):
         # pylint: disable=too-few-public-methods
@@ -41,14 +43,14 @@ def configure_logger(
 
     log_formatter = logging.Formatter(log_format)
 
-    # set loglevel >= WARNING to be printed to stderr
+    # set loglevel >= split_level to be printed to stderr
     stderr_hdlr = logging.StreamHandler(sys.stderr)
-    stderr_hdlr.setLevel(logging.WARNING)
+    stderr_hdlr.setLevel(split_level)
     stderr_hdlr.setFormatter(log_formatter)
 
-    # set loglevel <= INFO to be printed to stdout
+    # set loglevel < split_level to be printed to stdout
     stdout_hdlr = logging.StreamHandler(sys.stdout)
-    stdout_hdlr.addFilter(MaxLevelFilter(logging.INFO))
+    stdout_hdlr.addFilter(MaxLevelFilter(split_level - 1))
     stdout_hdlr.setFormatter(log_formatter)
 
     logger.addHandler(stderr_hdlr)

--- a/scripts/mbedtls_dev/logging_util.py
+++ b/scripts/mbedtls_dev/logging_util.py
@@ -1,0 +1,55 @@
+"""Auxiliary functions used for logging module.
+"""
+
+# Copyright The Mbed TLS Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import sys
+
+def configure_logger(
+        logger: logging.Logger,
+        logger_format="[%(levelname)s]: %(message)s"
+    ) -> None:
+    """
+    Configure the logging.Logger instance so that:
+        - Format is set to any logger_format.
+            Default: "[%(levelname)s]: %(message)s"
+        - loglevel >= WARNING are printed to stderr.
+        - loglevel <  WARNING are printed to stdout.
+    """
+    class MaxLevelFilter(logging.Filter):
+        # pylint: disable=too-few-public-methods
+        def __init__(self, max_level, name=''):
+            super().__init__(name)
+            self.max_level = max_level
+
+        def filter(self, record: logging.LogRecord) -> bool:
+            return record.levelno <= self.max_level
+
+    log_formatter = logging.Formatter(logger_format)
+
+    # set loglevel >= WARNING to be printed to stderr
+    stderr_hdlr = logging.StreamHandler(sys.stderr)
+    stderr_hdlr.setLevel(logging.WARNING)
+    stderr_hdlr.setFormatter(log_formatter)
+
+    # set loglevel <= INFO to be printed to stdout
+    stdout_hdlr = logging.StreamHandler(sys.stdout)
+    stdout_hdlr.addFilter(MaxLevelFilter(logging.INFO))
+    stdout_hdlr.setFormatter(log_formatter)
+
+    logger.addHandler(stderr_hdlr)
+    logger.addHandler(stdout_hdlr)

--- a/scripts/mbedtls_dev/logging_util.py
+++ b/scripts/mbedtls_dev/logging_util.py
@@ -21,11 +21,11 @@ import sys
 
 def configure_logger(
         logger: logging.Logger,
-        logger_format="[%(levelname)s]: %(message)s"
+        log_format="[%(levelname)s]: %(message)s"
     ) -> None:
     """
     Configure the logging.Logger instance so that:
-        - Format is set to any logger_format.
+        - Format is set to any log_format.
             Default: "[%(levelname)s]: %(message)s"
         - loglevel >= WARNING are printed to stderr.
         - loglevel <  WARNING are printed to stdout.
@@ -39,7 +39,7 @@ def configure_logger(
         def filter(self, record: logging.LogRecord) -> bool:
             return record.levelno <= self.max_level
 
-    log_formatter = logging.Formatter(logger_format)
+    log_formatter = logging.Formatter(log_format)
 
     # set loglevel >= WARNING to be printed to stderr
     stderr_hdlr = logging.StreamHandler(sys.stderr)

--- a/tests/scripts/audit-validity-dates.py
+++ b/tests/scripts/audit-validity-dates.py
@@ -24,7 +24,6 @@ from tests/data_files/ and tests/suites/*.data files by default.
 """
 
 import os
-import sys
 import re
 import typing
 import argparse
@@ -43,6 +42,7 @@ from generate_test_code import FileWrapper
 
 import scripts_path # pylint: disable=unused-import
 from mbedtls_dev import build_tree
+from mbedtls_dev import logging_util
 
 def check_cryptography_version():
     match = re.match(r'^[0-9]+', cryptography.__version__)
@@ -393,38 +393,6 @@ def list_all(audit_data: AuditData):
             loc))
 
 
-def configure_logger(logger: logging.Logger) -> None:
-    """
-    Configure the logging.Logger instance so that:
-        - Format is set to "[%(levelname)s]: %(message)s".
-        - loglevel >= WARNING are printed to stderr.
-        - loglevel <  WARNING are printed to stdout.
-    """
-    class MaxLevelFilter(logging.Filter):
-        # pylint: disable=too-few-public-methods
-        def __init__(self, max_level, name=''):
-            super().__init__(name)
-            self.max_level = max_level
-
-        def filter(self, record: logging.LogRecord) -> bool:
-            return record.levelno <= self.max_level
-
-    log_formatter = logging.Formatter("[%(levelname)s]: %(message)s")
-
-    # set loglevel >= WARNING to be printed to stderr
-    stderr_hdlr = logging.StreamHandler(sys.stderr)
-    stderr_hdlr.setLevel(logging.WARNING)
-    stderr_hdlr.setFormatter(log_formatter)
-
-    # set loglevel <= INFO to be printed to stdout
-    stdout_hdlr = logging.StreamHandler(sys.stdout)
-    stdout_hdlr.addFilter(MaxLevelFilter(logging.INFO))
-    stdout_hdlr.setFormatter(log_formatter)
-
-    logger.addHandler(stderr_hdlr)
-    logger.addHandler(stdout_hdlr)
-
-
 def main():
     """
     Perform argument parsing.
@@ -457,7 +425,7 @@ def main():
     # start main routine
     # setup logger
     logger = logging.getLogger()
-    configure_logger(logger)
+    logging_util.configure_logger(logger)
     logger.setLevel(logging.DEBUG if args.verbose else logging.ERROR)
 
     td_auditor = TestDataAuditor(logger)


### PR DESCRIPTION
## Description

In order to show code size changes between `development` and `latest commit` in a PR, this PR adds support to show results in a marddown format. We wont' show `total` as code size anymore, it's been splitted as `text,data` as this is what we care about in code-size-optimization.

Furthermore, the code is re-constructed as 
- `CodeSizeBuildInfo` to only infer build commands based on input arguments, like architecture, config.
- `CodeSizeCalculator` to calculate code size for a specified commit.
- `CodeSizeGenerator` to generate code size record and comparison result as a parser for a measurement tool.
- `CodeSizeComparison` to control the whole process of workflow.

**Example of usage:**

E.g. `./scripts/code_size_compare.py -o bc775c4~100  -n bc775c4 -a armv8-m -c tfm-medium --markdown --stdout`

The output is as following: (copy & paste directly)

Measure code size between 3f2448b-armv8-m-tfm-medium-cc and bc775c4-armv8-m-tfm-medium-cc by `size`.
| filename                       | new(text) | new(data) | change(text) | change(data) |
| :----                          |     ----: |     ----: |        ----: |        ----: |
| bignum.o                       |      7393 |         0 |          +60 |            0 |
| ccm.o                          |      2010 |         0 |           +4 |            0 |
| cipher.o                       |      1362 |         0 |         +146 |            0 |
| cipher_wrap.o                  |       504 |         8 |         -216 |           +8 |
| constant_time.o                |       666 |         0 |           -6 |            0 |
| ecp.o                          |      7066 |         0 |           -8 |            0 |
| ecp_curves.o                   |      1064 |         4 |           -4 |            0 |
| md.o                           |      1520 |         0 |          -44 |            0 |
| pkparse.o                      |      1234 |         0 |           -2 |            0 |
| psa_crypto.o                   |     18234 |         4 |         -216 |            0 |
| psa_crypto_cipher.o            |      1110 |         0 |         +996 |            0 |
| psa_crypto_driver_wrappers.o   |      2416 |         0 |         +210 |            0 |
| psa_crypto_ecp.o               |      1686 |         0 |          -16 |            0 |
| **CRYPTO-TOTALS**              | **76990** |    **24** |     **+904** |       **+8** |

E.g. `./scripts/code_size_compare.py -o bc775c4~150  -n bc775c4  --markdown --stdout`

The output is as following: (copy & paste directly)

Measure code size between 84b547b-x86_64-default-cc and bc775c4-x86_64-default-cc by `size`.
| filename                       | new(text) | new(data) | change(text) | change(data) |
| :----                          |     ----: |     ----: |        ----: |        ----: |
| aes.o                          |     12338 |         0 |         +374 |            0 |
| asn1write.o                    |      2772 |         0 |           +1 |            0 |
| bignum.o                       |     18037 |         0 |         -630 |            0 |
| bignum_core.o                  |      4449 |         0 |           +5 |            0 |
| bignum_mod.o                   |      2213 |         0 |          +40 |            0 |
| bignum_mod_raw.o               |      1661 |         0 |         +165 |            0 |
| ccm.o                          |      4528 |         0 |           +4 |            0 |
| cipher.o                       |      5562 |         0 |         +408 |            0 |
| cipher_wrap.o                  |      4153 |      4416 |            0 |        -3712 |
| cmac.o                         |      5176 |         0 |          +20 |            0 |
| constant_time.o                |      3081 |         0 |          +23 |            0 |
| dhm.o                          |      4287 |         0 |          -26 |            0 |
| ecdsa.o                        |      3947 |         0 |          -30 |            0 |
| ecjpake.o                      |      9380 |        24 |           -5 |            0 |
| ecp.o                          |     17593 |       372 |          -46 |          -32 |
| ecp_curves.o                   |     36275 |     11552 |         -871 |        -5760 |
| ecp_new.o                      |        32 |         0 |          +32 |            0 |
| error.o                        |     15660 |         0 |          +50 |            0 |
| gcm.o                          |      8317 |         0 |         -923 |            0 |
| hash_info.o                    |   Removed |   Removed |         -453 |            0 |
| md.o                           |      4535 |       176 |         +936 |          +64 |
| nist_kw.o                      |      4407 |         0 |           +4 |            0 |
| oid.o                          |      6506 |      3720 |         +833 |            0 |
| pk.o                           |      2607 |         0 |           +2 |            0 |
| pk_wrap.o                      |      3790 |       480 |           -3 |            0 |
| pkcs12.o                       |      2034 |         0 |          +18 |            0 |
| pkcs5.o                        |      3197 |         0 |          +13 |            0 |
| pkparse.o                      |      9139 |         0 |         -168 |            0 |
| pkwrite.o                      |      4334 |         0 |           -3 |            0 |
| psa_crypto.o                   |     36016 |        12 |          +77 |            0 |
| psa_crypto_cipher.o            |      2773 |         0 |          +12 |            0 |
| psa_crypto_ecp.o               |      3401 |         0 |         -215 |            0 |
| psa_crypto_ffdh.o              |      4819 |         0 |           -2 |            0 |
| psa_crypto_rsa.o               |      3840 |         0 |          +27 |            0 |
| psa_util.o                     |       472 |         0 |          +20 |            0 |
| rsa.o                          |     14345 |         0 |          -41 |            0 |
| rsa_alt_helpers.o              |      3007 |         0 |           -8 |            0 |
| sha3.o                         |      4572 |        40 |        +4572 |          +40 |
| version_features.o             |      2351 |      1104 |        -1009 |          +16 |
| **CRYPTO-TOTALS**              | **384380** | **21896** |    **+3203** |    **-9384** |
| x509.o                         |     10572 |         0 |         +487 |            0 |
| x509_create.o                  |      2254 |       928 |          +24 |            0 |
| x509_crt.o                     |     13213 |       336 |         +251 |            0 |
| **X509-TOTALS**                | **44930** |  **1264** |     **+762** |        **0** |
| debug.o                        |      3587 |         0 |           -1 |            0 |
| ssl_ciphersuites.o             |      7524 |      3984 |           +7 |            0 |
| ssl_client.o                   |      3964 |         0 |          -29 |            0 |
| ssl_debug_helpers_generated.o  |      3134 |         0 |         +152 |         -296 |
| ssl_msg.o                      |     35145 |         0 |           +8 |            0 |
| ssl_ticket.o                   |      2006 |         0 |          +15 |            0 |
| ssl_tls.o                      |     36919 |       613 |         -346 |         -120 |
| ssl_tls12_client.o             |     17606 |         0 |           +5 |            0 |
| ssl_tls12_server.o             |     22894 |         0 |           -3 |            0 |
| **TLS-TOTALS**                 | **138498** |  **4597** |     **-192** |     **-416** |

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required
- [x] **backport** not required (Only avaliable in `development`)
- [x] **tests** not required
