### PR TITLE
IAR compiler considerations

### DIFF
--- a/library/common.h
+++ b/library/common.h
@@ -242,7 +242,11 @@ static inline void mbedtls_xor_no_simd(unsigned char *r,
 /* Define `asm` for compilers which don't define it. */
 /* *INDENT-OFF* */
 #ifndef asm
+#if defined(__IAR_SYSTEMS_ICC__)
+#define asm __asm
+#else
 #define asm __asm__
+#endif
 #endif
 /* *INDENT-ON* */
 

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -97,7 +97,8 @@
  * mbedtls_platform_zeroize() to use a suitable implementation for their
  * platform and needs.
  */
-#if !defined(MBEDTLS_PLATFORM_HAS_EXPLICIT_BZERO) && !defined(__STDC_LIB_EXT1__) \
+#if !defined(MBEDTLS_PLATFORM_HAS_EXPLICIT_BZERO) && !(defined(__STDC_LIB_EXT1__) && \
+    !defined(__IAR_SYSTEMS_ICC__)) \
     && !defined(_WIN32)
 static void *(*const volatile memset_func)(void *, int, size_t) = memset;
 #endif
@@ -118,7 +119,7 @@ void mbedtls_platform_zeroize(void *buf, size_t len)
          */
         __msan_unpoison(buf, len);
 #endif
-#elif defined(__STDC_LIB_EXT1__)
+#elif defined(__STDC_LIB_EXT1__) && !defined(__IAR_SYSTEMS_ICC__)
         memset_s(buf, len, 0, len);
 #elif defined(_WIN32)
         SecureZeroMemory(buf, len);


### PR DESCRIPTION
## Description

IAR doesn't recognise the `__asm__` keyword so in common.h we add a preprocessor condition. In platform_util.c because of IAR predefining `__STDC_LIB_EXT1__` irregardless of whether or not memset_s is available we need to add a condition there as well.

## PR checklist

- [x] **changelog* not required as not a feature change
- [ ] **backport** 
- [x] **tests** included in current changes


