### PR TITLE
[Backport 2.28] Add TEST_FAIL macro for tests

### DIFF
--- a/tests/include/test/macros.h
+++ b/tests/include/test/macros.h
@@ -78,8 +78,8 @@
 #define TEST_FAIL(MESSAGE)                           \
     do {                                                  \
         mbedtls_test_fail(MESSAGE, __LINE__, __FILE__);   \
-        goto exit;                                          \
-    } while (0)                                              \
+        goto exit;                                        \
+    } while (0)
 
 /** Evaluate two integer expressions and fail the test case if they have
  * different values.

--- a/tests/include/test/macros.h
+++ b/tests/include/test/macros.h
@@ -71,6 +71,16 @@
         }                                                    \
     } while (0)
 
+/** This macro asserts fails the test with given output message.
+ *
+ * \param   MESSAGE The message to be outputed on assertion
+ */
+#define TEST_FAIL(MESSAGE)                           \
+    do {                                                  \
+        mbedtls_test_fail(MESSAGE, __LINE__, __FILE__);   \
+        goto exit;                                          \
+    } while (0)                                              \
+
 /** Evaluate two integer expressions and fail the test case if they have
  * different values.
  *

--- a/tests/src/psa_exercise_key.c
+++ b/tests/src/psa_exercise_key.c
@@ -308,7 +308,7 @@ static int exercise_signature_key(mbedtls_svc_key_id_t key,
             hash_alg = KNOWN_MBEDTLS_SUPPORTED_HASH_ALG;
             alg ^= PSA_ALG_ANY_HASH ^ hash_alg;
     #else
-            TEST_ASSERT(!"No hash algorithm for hash-and-sign testing");
+            TEST_FAIL("No hash algorithm for hash-and-sign testing");
     #endif
         }
 
@@ -437,7 +437,7 @@ int mbedtls_test_psa_setup_key_derivation_wrap(
                                                   PSA_KEY_DERIVATION_INPUT_LABEL,
                                                   input2, input2_length));
     } else {
-        TEST_ASSERT(!"Key derivation algorithm not supported");
+        TEST_FAIL("Key derivation algorithm not supported");
     }
 
     if (capacity != SIZE_MAX) {
@@ -767,7 +767,7 @@ int mbedtls_test_psa_exported_key_sanity_check(
 
     {
         (void) exported;
-        TEST_ASSERT(!"Sanity check not implemented for this key type");
+        TEST_FAIL("Sanity check not implemented for this key type");
     }
 
 #if defined(MBEDTLS_DES_C)
@@ -912,7 +912,7 @@ int mbedtls_test_psa_exercise_key(mbedtls_svc_key_id_t key,
     } else if (PSA_ALG_IS_KEY_AGREEMENT(alg)) {
         ok = exercise_key_agreement_key(key, usage, alg);
     } else {
-        TEST_ASSERT(!"No code to exercise this category of algorithm");
+        TEST_FAIL("No code to exercise this category of algorithm");
     }
 
     ok = ok && exercise_export_key(key, usage);

--- a/tests/suites/test_suite_asn1write.function
+++ b/tests/suites/test_suite_asn1write.function
@@ -316,7 +316,7 @@ void mbedtls_asn1_write_algorithm_identifier(data_t *oid,
                 buf_complete[data_len + 2] = (unsigned char) (expected_params_len >> 8);
                 buf_complete[data_len + 3] = (unsigned char) (expected_params_len);
             } else {
-                TEST_ASSERT(!"Bad test data: invalid length of ASN.1 element");
+                TEST_FAIL("Bad test data: invalid length of ASN.1 element");
             }
             unsigned char *p = buf_complete;
             TEST_EQUAL(mbedtls_asn1_get_alg(&p, end_complete,

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -5577,7 +5577,7 @@ void persistent_key_load_key_from_storage(data_t *data,
             break;
 
         default:
-            TEST_ASSERT(!"generation_method not implemented in test");
+            TEST_FAIL("generation_method not implemented in test");
             break;
     }
     psa_reset_key_attributes(&attributes);

--- a/tests/suites/test_suite_psa_crypto_se_driver_hal.function
+++ b/tests/suites/test_suite_psa_crypto_se_driver_hal.function
@@ -1321,7 +1321,7 @@ void sign_verify(int flow,
             key_management.p_export_public = ram_export_public;
             break;
         default:
-            TEST_ASSERT(!"unsupported flow (should be SIGN_IN_xxx)");
+            TEST_FAIL("unsupported flow (should be SIGN_IN_xxx)");
             break;
     }
     asymmetric.p_verify = ram_verify;

--- a/tests/suites/test_suite_psa_crypto_slot_management.function
+++ b/tests/suites/test_suite_psa_crypto_slot_management.function
@@ -775,7 +775,7 @@ void invalid_handle(int handle_construction,
                 mbedtls_svc_key_id_make(0, PSA_KEY_ID_VENDOR_MAX + 1);
             break;
         default:
-            TEST_ASSERT(!"unknown handle construction");
+            TEST_FAIL("unknown handle construction");
     }
 
     /* Attempt to use the invalid handle. */


### PR DESCRIPTION
## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog**  not required
- [x] **backport** backport of #7936 
- [x] **tests** not required


