### PR TITLE
Use correct asm keyword for IAR compilers

### DIFF
--- a/library/common.h
+++ b/library/common.h
@@ -242,7 +242,11 @@ static inline void mbedtls_xor_no_simd(unsigned char *r,
 /* Define `asm` for compilers which don't define it. */
 /* *INDENT-OFF* */
 #ifndef asm
+#if defined(__IAR_SYSTEMS_ICC__)
+#define asm __asm
+#else
 #define asm __asm__
+#endif
 #endif
 /* *INDENT-ON* */
 


### PR DESCRIPTION
## Description

Originally part of #7939. IAR doesn't recognise the __asm__ keyword so in common.h we add a preprocessor condition.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required as not a feature change
- [x] **backport** not required as problem isn't present in 2.28
- [x] **tests** not required as in changelog

