### PR TITLE
Fix IAR trying to use memset_s in platform_util

### DIFF
--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -97,7 +97,8 @@
  * mbedtls_platform_zeroize() to use a suitable implementation for their
  * platform and needs.
  */
-#if !defined(MBEDTLS_PLATFORM_HAS_EXPLICIT_BZERO) && !defined(__STDC_LIB_EXT1__) \
+#if !defined(MBEDTLS_PLATFORM_HAS_EXPLICIT_BZERO) && !(defined(__STDC_LIB_EXT1__) && \
+    !defined(__IAR_SYSTEMS_ICC__)) \
     && !defined(_WIN32)
 static void *(*const volatile memset_func)(void *, int, size_t) = memset;
 #endif
@@ -118,7 +119,7 @@ void mbedtls_platform_zeroize(void *buf, size_t len)
          */
         __msan_unpoison(buf, len);
 #endif
-#elif defined(__STDC_LIB_EXT1__)
+#elif defined(__STDC_LIB_EXT1__) && !defined(__IAR_SYSTEMS_ICC__)
         memset_s(buf, len, 0, len);
 #elif defined(_WIN32)
         SecureZeroMemory(buf, len);


### PR DESCRIPTION
## Description

Originally part of #7939.  In platform_util.c because of IAR predefining `__STDC_LIB_EXT1__` irregardless of whether or not `memset_s` is available we need to add a condition there as well.


## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required as not a feature change
- [x] **backport** not required as problem isn't present in 2.28
- [x] **tests** not required as in changelog

