### PR TITLE
Miscellaneous changes to scripts for PSA-Crypto enablement

### DIFF
--- a/scripts/mbedtls_dev/build_tree.py
+++ b/scripts/mbedtls_dev/build_tree.py
@@ -19,11 +19,18 @@
 import os
 import inspect
 
+def looks_like_psa_crypto_root(path: str) -> bool:
+    """Whether the given directory looks like the root of the PSA Crypto source tree."""
+    return all(os.path.isdir(os.path.join(path, subdir))
+               for subdir in ['include', 'core', 'tests'])
 
 def looks_like_mbedtls_root(path: str) -> bool:
     """Whether the given directory looks like the root of the Mbed TLS source tree."""
     return all(os.path.isdir(os.path.join(path, subdir))
                for subdir in ['include', 'library', 'programs', 'tests'])
+
+def looks_like_root(path: str) -> bool:
+    return looks_like_psa_crypto_root(path) or looks_like_mbedtls_root(path)
 
 def check_repo_path():
     """
@@ -42,7 +49,7 @@ def chdir_to_root() -> None:
     for d in [os.path.curdir,
               os.path.pardir,
               os.path.join(os.path.pardir, os.path.pardir)]:
-        if looks_like_mbedtls_root(d):
+        if looks_like_root(d):
             os.chdir(d)
             return
     raise Exception('Mbed TLS source tree not found')
@@ -62,6 +69,6 @@ def guess_mbedtls_root():
             if d in dirs:
                 continue
             dirs.add(d)
-            if looks_like_mbedtls_root(d):
+            if looks_like_root(d):
                 return d
     raise Exception('Mbed TLS source tree not found')

--- a/scripts/mbedtls_dev/build_tree.py
+++ b/scripts/mbedtls_dev/build_tree.py
@@ -22,7 +22,7 @@ import inspect
 def looks_like_psa_crypto_root(path: str) -> bool:
     """Whether the given directory looks like the root of the PSA Crypto source tree."""
     return all(os.path.isdir(os.path.join(path, subdir))
-               for subdir in ['include', 'core', 'tests'])
+               for subdir in ['include', 'core', 'drivers', 'programs', 'tests'])
 
 def looks_like_mbedtls_root(path: str) -> bool:
     """Whether the given directory looks like the root of the Mbed TLS source tree."""

--- a/scripts/mbedtls_dev/psa_storage.py
+++ b/scripts/mbedtls_dev/psa_storage.py
@@ -27,6 +27,7 @@ from typing import Dict, List, Optional, Set, Union
 import unittest
 
 from . import c_build_helper
+from . import build_tree
 
 
 class Expr:
@@ -51,13 +52,16 @@ class Expr:
     def update_cache(self) -> None:
         """Update `value_cache` for expressions registered in `unknown_values`."""
         expressions = sorted(self.unknown_values)
+        includes = ['include']
+        if build_tree.looks_like_psa_crypto_root('.'):
+            includes.append('drivers/builtin/include')
         values = c_build_helper.get_c_expression_values(
             'unsigned long', '%lu',
             expressions,
             header="""
             #include <psa/crypto.h>
             """,
-            include_path=['include']) #type: List[str]
+            include_path=includes) #type: List[str]
         for e, v in zip(expressions, values):
             self.value_cache[e] = int(v, 0)
         self.unknown_values.clear()

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -123,15 +123,23 @@ set -e -o pipefail -u
 # Enable ksh/bash extended file matching patterns
 shopt -s extglob
 
+in_psa_crypto_repo () {
+    test -d core
+}
+
 pre_check_environment () {
-    if [ -d library -a -d include -a -d tests ]; then :; else
-        echo "Must be run from mbed TLS root" >&2
+    if [ \( -d library -o -d core \) -a -d include -a -d tests ]; then :; else
+        echo "Must be run from Mbed TLS root" >&2
         exit 1
     fi
 }
 
 pre_initialize_variables () {
-    CONFIG_H='include/mbedtls/mbedtls_config.h'
+    if in_psa_crypto_repo; then
+        CONFIG_H='drivers/builtin/include/mbedtls/mbedtls_config.h'
+    else
+        CONFIG_H='include/mbedtls/mbedtls_config.h'
+    fi
     CRYPTO_CONFIG_H='include/psa/crypto_config.h'
     CONFIG_TEST_DRIVER_H='tests/include/test/drivers/config_test_driver.h'
 
@@ -141,8 +149,10 @@ pre_initialize_variables () {
     backup_suffix='.all.bak'
     # Files clobbered by config.py
     files_to_back_up="$CONFIG_H $CRYPTO_CONFIG_H $CONFIG_TEST_DRIVER_H"
-    # Files clobbered by in-tree cmake
-    files_to_back_up="$files_to_back_up Makefile library/Makefile programs/Makefile tests/Makefile programs/fuzz/Makefile"
+    if ! in_psa_crypto_repo; then
+        # Files clobbered by in-tree cmake
+        files_to_back_up="$files_to_back_up Makefile library/Makefile programs/Makefile tests/Makefile programs/fuzz/Makefile"
+    fi
 
     append_outcome=0
     MEMORY=0
@@ -299,7 +309,9 @@ EOF
 # Does not remove generated source files.
 cleanup()
 {
-    command make clean
+    if ! in_psa_crypto_repo; then
+        command make clean
+    fi
 
     # Remove CMake artefacts
     find . -name .git -prune -o \
@@ -556,7 +568,7 @@ pre_check_git () {
         fi
 
         if ! git diff --quiet "$CONFIG_H"; then
-            err_msg "Warning - the configuration file 'include/mbedtls/mbedtls_config.h' has been edited. "
+            err_msg "Warning - the configuration file '$CONFIG_H' has been edited. "
             echo "You can either delete or preserve your work, or force the test by rerunning the"
             echo "script as: $0 --force"
             exit 1
@@ -5264,7 +5276,9 @@ pre_prepare_outcome_file
 pre_print_configuration
 pre_check_tools
 cleanup
-pre_generate_files
+if ! in_psa_crypto_repo; then
+    pre_generate_files
+fi
 
 # Run the requested tests.
 for ((error_test_i=1; error_test_i <= error_test; error_test_i++)); do

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -124,7 +124,11 @@ set -e -o pipefail -u
 shopt -s extglob
 
 in_mbedtls_repo () {
-    test ! -d core
+    test -d include -a -d library -a -d programs -a -d tests
+}
+
+in_psa_crypto_repo () {
+    test -d include -a -d core -a -d drivers -a -d programs -a -d tests
 }
 
 pre_check_environment () {

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -123,8 +123,8 @@ set -e -o pipefail -u
 # Enable ksh/bash extended file matching patterns
 shopt -s extglob
 
-in_psa_crypto_repo () {
-    test -d core
+in_mbedtls_repo () {
+    test ! -d core
 }
 
 pre_check_environment () {
@@ -135,10 +135,10 @@ pre_check_environment () {
 }
 
 pre_initialize_variables () {
-    if in_psa_crypto_repo; then
-        CONFIG_H='drivers/builtin/include/mbedtls/mbedtls_config.h'
-    else
+    if in_mbedtls_repo; then
         CONFIG_H='include/mbedtls/mbedtls_config.h'
+    else
+        CONFIG_H='drivers/builtin/include/mbedtls/mbedtls_config.h'
     fi
     CRYPTO_CONFIG_H='include/psa/crypto_config.h'
     CONFIG_TEST_DRIVER_H='tests/include/test/drivers/config_test_driver.h'
@@ -149,7 +149,7 @@ pre_initialize_variables () {
     backup_suffix='.all.bak'
     # Files clobbered by config.py
     files_to_back_up="$CONFIG_H $CRYPTO_CONFIG_H $CONFIG_TEST_DRIVER_H"
-    if ! in_psa_crypto_repo; then
+    if in_mbedtls_repo; then
         # Files clobbered by in-tree cmake
         files_to_back_up="$files_to_back_up Makefile library/Makefile programs/Makefile tests/Makefile programs/fuzz/Makefile"
     fi
@@ -309,7 +309,7 @@ EOF
 # Does not remove generated source files.
 cleanup()
 {
-    if ! in_psa_crypto_repo; then
+    if in_mbedtls_repo; then
         command make clean
     fi
 
@@ -5276,7 +5276,7 @@ pre_prepare_outcome_file
 pre_print_configuration
 pre_check_tools
 cleanup
-if ! in_psa_crypto_repo; then
+if in_mbedtls_repo; then
     pre_generate_files
 fi
 

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -133,7 +133,7 @@ in_psa_crypto_repo () {
 
 pre_check_environment () {
     if in_mbedtls_repo || in_psa_crypto_repo; then :; else
-        echo "Must be run from Mbed TLS root" >&2
+        echo "Must be run from Mbed TLS / psa-crypto root" >&2
         exit 1
     fi
 }

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -132,7 +132,7 @@ in_psa_crypto_repo () {
 }
 
 pre_check_environment () {
-    if [ \( -d library -o -d core \) -a -d include -a -d tests ]; then :; else
+    if in_mbedtls_repo || in_psa_crypto_repo; then :; else
         echo "Must be run from Mbed TLS root" >&2
         exit 1
     fi

--- a/tests/scripts/test_psa_compliance.py
+++ b/tests/scripts/test_psa_compliance.py
@@ -28,6 +28,7 @@ import shutil
 import subprocess
 import sys
 
+#pylint: disable=unused-import
 import scripts_path
 from mbedtls_dev import build_tree
 
@@ -52,11 +53,11 @@ EXPECTED_FAILURES = {
 PSA_ARCH_TESTS_REPO = 'https://github.com/bensze01/psa-arch-tests.git'
 PSA_ARCH_TESTS_REF = 'fix-pr-5736'
 
-#pylint: disable=too-many-branches,too-many-statements
+#pylint: disable=too-many-branches,too-many-statements,too-many-locals
 def main():
     mbedtls_dir = os.getcwd()
 
-    is_psa_crypto = build_tree.looks_like_psa_crypto_root(mbedtls_dir) #type: bool
+    is_psa_crypto = build_tree.looks_like_psa_crypto_root(mbedtls_dir)
 
     if not is_psa_crypto:
         if not os.path.exists('library/libmbedcrypto.a'):

--- a/tests/scripts/test_psa_compliance.py
+++ b/tests/scripts/test_psa_compliance.py
@@ -175,6 +175,7 @@ def main(library_build_dir: str):
 if __name__ == '__main__':
     BUILD_DIR = 'out_of_source_build'
 
+    # pylint: disable=invalid-name
     parser = argparse.ArgumentParser()
     parser.add_argument('--build-dir', nargs=1,
                         help='path to Mbed TLS / PSA Crypto build directory')

--- a/tests/scripts/test_psa_compliance.py
+++ b/tests/scripts/test_psa_compliance.py
@@ -125,8 +125,11 @@ def main(library_build_dir: str):
         )
         test = -1
         unexpected_successes = set(EXPECTED_FAILURES)
-        expected_failures = []
-        unexpected_failures = []
+        expected_failures = [] # type: List[int]
+        unexpected_failures = [] # type: List[int]
+        if proc.stdout is None:
+            return 1
+
         for line in proc.stdout:
             print(line, end='')
             match = test_re.match(line)

--- a/tests/scripts/test_psa_compliance.py
+++ b/tests/scripts/test_psa_compliance.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 """Run the PSA Crypto API compliance test suite.
 Clone the repo and check out the commit specified by PSA_ARCH_TEST_REPO and PSA_ARCH_TEST_REF,
-then compile and run the test suite. The clone is stored at <Mbed TLS root>/psa-arch-tests.
-Known defects in either the test suite or mbedtls - identified by their test number - are ignored,
-while unexpected failures AND successes are reported as errors,
-to help keep the list of known defects as up to date as possible.
+then compile and run the test suite. The clone is stored at <repository root>/psa-arch-tests.
+Known defects in either the test suite or mbedtls / psa-crypto - identified by their test
+number - are ignored, while unexpected failures AND successes are reported as errors, to help
+keep the list of known defects as up to date as possible.
 """
 
 # Copyright The Mbed TLS Contributors
@@ -33,7 +33,8 @@ import sys
 import scripts_path
 from mbedtls_dev import build_tree
 
-# PSA Compliance tests we expect to fail due to known defects in Mbed TLS (or the test suite)
+# PSA Compliance tests we expect to fail due to known defects in Mbed TLS / PSA Crypto
+# (or the test suite).
 # The test numbers correspond to the numbers used by the console output of the test suite.
 # Test number 2xx corresponds to the files in the folder
 # psa-arch-tests/api-tests/dev_apis/crypto/test_c0xx
@@ -162,11 +163,11 @@ def main(library_build_dir: str):
 
 if __name__ == '__main__':
     # Default build directory
-    library_build_dir = 'mbedtls_out_of_source_build'
+    library_build_dir = 'out_of_source_build'
 
     parser = argparse.ArgumentParser()
     parser.add_argument('--build-dir', nargs=1,
-                        help='path to Mbed TLS build directory')
+                        help='path to Mbed TLS / PSA Crypto build directory')
     args = parser.parse_args()
 
     if args.build_dir is not None:

--- a/tests/scripts/test_psa_compliance.py
+++ b/tests/scripts/test_psa_compliance.py
@@ -68,6 +68,7 @@ def main(library_build_dir: str):
         crypto_lib_filename = library_build_dir + '/library/libmbedcrypto.a'
 
     if not os.path.exists(crypto_lib_filename):
+        #pylint: disable=bad-continuation
         subprocess.check_call([
             'cmake', '.',
                      '-GUnix Makefiles',

--- a/tests/scripts/test_psa_compliance.py
+++ b/tests/scripts/test_psa_compliance.py
@@ -87,10 +87,10 @@ def main(library_build_dir: str):
         os.chdir(build_dir)
 
         if is_psa_crypto:
-            psa_crypto_lib_filename = \
+            crypto_lib_filename = \
                 library_build_dir + '/core/libpsacrypto.a'
         else:
-            psa_crypto_lib_filename = library_build_dir + '/library/libmbedcrypto.a'
+            crypto_lib_filename = library_build_dir + '/library/libmbedcrypto.a'
 
         extra_includes = (';{}/drivers/builtin/include'.format(mbedtls_dir)
                           if is_psa_crypto else '')
@@ -103,7 +103,7 @@ def main(library_build_dir: str):
                      '-DTOOLCHAIN=HOST_GCC',
                      '-DSUITE=CRYPTO',
                      '-DPSA_CRYPTO_LIB_FILENAME={}/{}'.format(mbedtls_dir,
-                                                              psa_crypto_lib_filename),
+                                                              crypto_lib_filename),
                      ('-DPSA_INCLUDE_PATHS={}/include' + extra_includes).format(mbedtls_dir)
         ])
         subprocess.check_call(['cmake', '--build', '.'])

--- a/tests/scripts/test_psa_compliance.py
+++ b/tests/scripts/test_psa_compliance.py
@@ -58,7 +58,7 @@ PSA_ARCH_TESTS_REF = 'fix-pr-5736'
 def main(library_build_dir: str):
     mbedtls_dir = os.getcwd()
 
-    is_psa_crypto = build_tree.looks_like_psa_crypto_root(mbedtls_dir)
+    in_psa_crypto_repo = build_tree.looks_like_psa_crypto_root(mbedtls_dir)
 
     if not os.path.exists(library_build_dir + '/library/libmbedcrypto.a'):
         subprocess.check_call([
@@ -86,14 +86,14 @@ def main(library_build_dir: str):
         os.mkdir(build_dir)
         os.chdir(build_dir)
 
-        if is_psa_crypto:
+        if in_psa_crypto_repo:
             crypto_lib_filename = \
                 library_build_dir + '/core/libpsacrypto.a'
         else:
             crypto_lib_filename = library_build_dir + '/library/libmbedcrypto.a'
 
         extra_includes = (';{}/drivers/builtin/include'.format(mbedtls_dir)
-                          if is_psa_crypto else '')
+                          if in_psa_crypto_repo else '')
 
         #pylint: disable=bad-continuation
         subprocess.check_call([

--- a/tests/scripts/test_psa_compliance.py
+++ b/tests/scripts/test_psa_compliance.py
@@ -81,7 +81,7 @@ def main(library_build_dir: str):
                      '-B' + library_build_dir
         ])
         subprocess.check_call(['cmake', '--build', library_build_dir,
-                               '-t', crypto_name])
+                               '--target', crypto_name])
 
     psa_arch_tests_dir = 'psa-arch-tests'
     os.makedirs(psa_arch_tests_dir, exist_ok=True)

--- a/tests/scripts/test_psa_compliance.py
+++ b/tests/scripts/test_psa_compliance.py
@@ -62,10 +62,15 @@ def main(library_build_dir: str):
     in_psa_crypto_repo = build_tree.looks_like_psa_crypto_root(root_dir)
 
     if in_psa_crypto_repo:
-        crypto_lib_filename = \
-            library_build_dir + '/core/libpsacrypto.a'
+        crypto_name = 'psacrypto'
+        library_subdir = 'core'
     else:
-        crypto_lib_filename = library_build_dir + '/library/libmbedcrypto.a'
+        crypto_name = 'mbedcrypto'
+        library_subdir = 'library'
+
+    crypto_lib_filename = (library_build_dir + '/' +
+                           library_subdir + '/' +
+                           'lib' + crypto_name + '.a')
 
     if not os.path.exists(crypto_lib_filename):
         #pylint: disable=bad-continuation
@@ -74,7 +79,8 @@ def main(library_build_dir: str):
                      '-GUnix Makefiles',
                      '-B', library_build_dir
         ])
-        subprocess.check_call(['cmake', '--build', library_build_dir])
+        subprocess.check_call(['cmake', '--build', library_build_dir,
+                               '-t', crypto_name])
 
     psa_arch_tests_dir = 'psa-arch-tests'
     os.makedirs(psa_arch_tests_dir, exist_ok=True)

--- a/tests/scripts/test_psa_compliance.py
+++ b/tests/scripts/test_psa_compliance.py
@@ -56,9 +56,9 @@ PSA_ARCH_TESTS_REF = 'fix-pr-5736'
 
 #pylint: disable=too-many-branches,too-many-statements,too-many-locals
 def main(library_build_dir: str):
-    mbedtls_dir = os.getcwd()
+    root_dir = os.getcwd()
 
-    in_psa_crypto_repo = build_tree.looks_like_psa_crypto_root(mbedtls_dir)
+    in_psa_crypto_repo = build_tree.looks_like_psa_crypto_root(root_dir)
 
     if in_psa_crypto_repo:
         crypto_lib_filename = \
@@ -92,7 +92,7 @@ def main(library_build_dir: str):
         os.mkdir(build_dir)
         os.chdir(build_dir)
 
-        extra_includes = (';{}/drivers/builtin/include'.format(mbedtls_dir)
+        extra_includes = (';{}/drivers/builtin/include'.format(root_dir)
                           if in_psa_crypto_repo else '')
 
         #pylint: disable=bad-continuation
@@ -102,9 +102,9 @@ def main(library_build_dir: str):
                      '-DTARGET=tgt_dev_apis_stdc',
                      '-DTOOLCHAIN=HOST_GCC',
                      '-DSUITE=CRYPTO',
-                     '-DPSA_CRYPTO_LIB_FILENAME={}/{}'.format(mbedtls_dir,
+                     '-DPSA_CRYPTO_LIB_FILENAME={}/{}'.format(root_dir,
                                                               crypto_lib_filename),
-                     ('-DPSA_INCLUDE_PATHS={}/include' + extra_includes).format(mbedtls_dir)
+                     ('-DPSA_INCLUDE_PATHS={}/include' + extra_includes).format(root_dir)
         ])
         subprocess.check_call(['cmake', '--build', '.'])
 
@@ -158,7 +158,7 @@ def main(library_build_dir: str):
             print('SUCCESS')
             return 0
     finally:
-        os.chdir(mbedtls_dir)
+        os.chdir(root_dir)
 
 if __name__ == '__main__':
     # Default build directory

--- a/tests/scripts/test_psa_compliance.py
+++ b/tests/scripts/test_psa_compliance.py
@@ -77,7 +77,7 @@ def main(library_build_dir: str):
         subprocess.check_call([
             'cmake', '.',
                      '-GUnix Makefiles',
-                     '-B', library_build_dir
+                     '-B' + library_build_dir
         ])
         subprocess.check_call(['cmake', '--build', library_build_dir,
                                '-t', crypto_name])

--- a/tests/scripts/test_psa_compliance.py
+++ b/tests/scripts/test_psa_compliance.py
@@ -169,8 +169,7 @@ def main(library_build_dir: str):
         os.chdir(root_dir)
 
 if __name__ == '__main__':
-    # Default build directory
-    library_build_dir = 'out_of_source_build'
+    BUILD_DIR = 'out_of_source_build'
 
     parser = argparse.ArgumentParser()
     parser.add_argument('--build-dir', nargs=1,
@@ -178,6 +177,6 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     if args.build_dir is not None:
-        library_build_dir = args.build_dir[0]
+        BUILD_DIR = args.build_dir[0]
 
-    sys.exit(main(library_build_dir))
+    sys.exit(main(BUILD_DIR))

--- a/tests/scripts/test_psa_compliance.py
+++ b/tests/scripts/test_psa_compliance.py
@@ -60,7 +60,13 @@ def main(library_build_dir: str):
 
     in_psa_crypto_repo = build_tree.looks_like_psa_crypto_root(mbedtls_dir)
 
-    if not os.path.exists(library_build_dir + '/library/libmbedcrypto.a'):
+    if in_psa_crypto_repo:
+        crypto_lib_filename = \
+            library_build_dir + '/core/libpsacrypto.a'
+    else:
+        crypto_lib_filename = library_build_dir + '/library/libmbedcrypto.a'
+
+    if not os.path.exists(crypto_lib_filename):
         subprocess.check_call([
             'cmake', '.',
                      '-GUnix Makefiles',
@@ -85,12 +91,6 @@ def main(library_build_dir: str):
             pass
         os.mkdir(build_dir)
         os.chdir(build_dir)
-
-        if in_psa_crypto_repo:
-            crypto_lib_filename = \
-                library_build_dir + '/core/libpsacrypto.a'
-        else:
-            crypto_lib_filename = library_build_dir + '/library/libmbedcrypto.a'
 
         extra_includes = (';{}/drivers/builtin/include'.format(mbedtls_dir)
                           if in_psa_crypto_repo else '')

--- a/tests/scripts/test_psa_compliance.py
+++ b/tests/scripts/test_psa_compliance.py
@@ -28,6 +28,7 @@ import re
 import shutil
 import subprocess
 import sys
+from typing import List
 
 #pylint: disable=unused-import
 import scripts_path


### PR DESCRIPTION
Enable the scripts to be used either in Mbed TLS or in the PSA Cryptography repository.

Fixes https://github.com/Mbed-TLS/psa-crypto/issues/23

Specifically:
* Change root directory detection logic in several places
* Change filepaths in several places dependent on which repo we are in

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required - internal script changes only
- [x] **backport** not required - The PSA Crypto repo is based on development only
- [x] **tests** not required - changes are only to scripts