### PR TITLE
Robustness fix to MBEDTLS_LIKELY

### DIFF
--- a/library/common.h
+++ b/library/common.h
@@ -291,8 +291,8 @@ static inline void mbedtls_xor_no_simd(unsigned char *r,
 /* Define compiler branch hints */
 #if defined(__has_builtin)
 #if __has_builtin(__builtin_expect)
-#define MBEDTLS_LIKELY(x)       __builtin_expect((x), 1)
-#define MBEDTLS_UNLIKELY(x)     __builtin_expect((x), 0)
+#define MBEDTLS_LIKELY(x)       __builtin_expect(!!(x), 1)
+#define MBEDTLS_UNLIKELY(x)     __builtin_expect(!!(x), 0)
 #endif
 #endif
 #if !defined(MBEDTLS_LIKELY)


### PR DESCRIPTION
## Description

Ensure proper behaviour when the argument does not evaluate to either 0 or 1.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not user-visible
- [x] **backport** not in 2.28
- [x] **tests** not required
