### PR TITLE
Use earliest latest compilers

### DIFF
--- a/library/ecp.c
+++ b/library/ecp.c
@@ -3639,7 +3639,7 @@ cleanup:
 #if defined(MBEDTLS_TEST_HOOKS)
 
 MBEDTLS_STATIC_TESTABLE
-mbedtls_ecp_variant mbedtls_ecp_get_variant()
+mbedtls_ecp_variant mbedtls_ecp_get_variant(void)
 {
     return MBEDTLS_ECP_VARIANT_WITH_MPI_STRUCT;
 }

--- a/programs/fuzz/common.c
+++ b/programs/fuzz/common.c
@@ -13,7 +13,7 @@ mbedtls_time_t dummy_constant_time(mbedtls_time_t *time)
 }
 #endif
 
-void dummy_init()
+void dummy_init(void)
 {
 #if defined(MBEDTLS_PLATFORM_TIME_ALT)
     mbedtls_platform_set_time(dummy_constant_time);

--- a/programs/fuzz/common.h
+++ b/programs/fuzz/common.h
@@ -15,7 +15,7 @@ typedef struct fuzzBufferOffset {
 #if defined(MBEDTLS_HAVE_TIME)
 mbedtls_time_t dummy_constant_time(mbedtls_time_t *time);
 #endif
-void dummy_init();
+void dummy_init(void);
 
 int dummy_send(void *ctx, const unsigned char *buf, size_t len);
 int fuzz_recv(void *ctx, unsigned char *buf, size_t len);

--- a/programs/ssl/ssl_context_info.c
+++ b/programs/ssl/ssl_context_info.c
@@ -125,12 +125,12 @@ const char buf_ln_err[] = "Buffer does not have enough data to complete the pars
 /*
  * Basic printing functions
  */
-void print_version()
+void print_version(void)
 {
     printf("%s v%d.%d\n", PROG_NAME, VER_MAJOR, VER_MINOR);
 }
 
-void print_usage()
+void print_usage(void)
 {
     print_version();
     printf("\nThis program is used to deserialize an Mbed TLS SSL session from the base64 code provided\n"
@@ -179,7 +179,7 @@ void printf_err(const char *str, ...)
 /*
  * Exit from the program in case of error
  */
-void error_exit()
+void error_exit(void)
 {
     if (NULL != b64_file) {
         fclose(b64_file);

--- a/programs/test/udp_proxy.c
+++ b/programs/test/udp_proxy.c
@@ -644,7 +644,7 @@ void delay_packet(packet *delay)
     memcpy(&prev[prev_len++], delay, sizeof(packet));
 }
 
-int send_delayed()
+int send_delayed(void)
 {
     uint8_t offset;
     int ret;

--- a/scripts/output_env.sh
+++ b/scripts/output_env.sh
@@ -105,19 +105,35 @@ echo
 print_version "gcc" "--version" "" "head -n 1"
 echo
 
-print_version "gcc-earliest" "--version" "" "head -n 1"
+if [ -n "${GCC_EARLIEST+set}" ]; then
+    print_version "${GCC_EARLIEST}" "--version" "" "head -n 1"
+else
+    echo " GCC_EARLIEST : Not configured."
+fi
 echo
 
-print_version "gcc-latest" "--version" "" "head -n 1"
+if [ -n "${GCC_LATEST+set}" ]; then
+    print_version "${GCC_LATEST}" "--version" "" "head -n 1"
+else
+    echo " GCC_LATEST : Not configured."
+fi
 echo
 
 print_version "clang" "--version" "" "head -n 2"
 echo
 
-print_version "clang-earliest" "--version" "" "head -n 2"
+if [ -n "${CLANG_EARLIEST+set}" ]; then
+    print_version "${CLANG_EARLIEST}" "--version" "" "head -n 2"
+else
+    echo " CLANG_EARLIEST : Not configured."
+fi
 echo
 
-print_version "clang-latest" "--version" "" "head -n 2"
+if [ -n "${CLANG_LATEST+set}" ]; then
+    print_version "${CLANG_LATEST}" "--version" "" "head -n 2"
+else
+    echo " CLANG_LATEST : Not configured."
+fi
 echo
 
 print_version "ldd" "--version" "" "head -n 1"

--- a/scripts/output_env.sh
+++ b/scripts/output_env.sh
@@ -105,7 +105,19 @@ echo
 print_version "gcc" "--version" "" "head -n 1"
 echo
 
+print_version "gcc-earliest" "--version" "" "head -n 1"
+echo
+
+print_version "gcc-latest" "--version" "" "head -n 1"
+echo
+
 print_version "clang" "--version" "" "head -n 2"
+echo
+
+print_version "clang-earliest" "--version" "" "head -n 2"
+echo
+
+print_version "clang-latest" "--version" "" "head -n 2"
 echo
 
 print_version "ldd" "--version" "" "head -n 1"

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -176,10 +176,10 @@ pre_initialize_variables () {
     : ${ARMC6_BIN_DIR:=/usr/bin}
     : ${ARM_NONE_EABI_GCC_PREFIX:=arm-none-eabi-}
     : ${ARM_LINUX_GNUEABI_GCC_PREFIX:=arm-linux-gnueabi-}
-    : ${CLANG_LATEST:="clang-16"}
-    : ${CLANG_EARLIEST:="clang-3.5"}
-    : ${GCC_LATEST:="gcc-12"}
-    : ${GCC_EARLIEST:="gcc-4.7"}
+    : ${CLANG_LATEST:="clang-latest"}
+    : ${CLANG_EARLIEST:="clang-earliest"}
+    : ${GCC_LATEST:="gcc-latest"}
+    : ${GCC_EARLIEST:="gcc-earliest"}
     # if MAKEFLAGS is not set add the -j option to speed up invocations of make
     if [ -z "${MAKEFLAGS+set}" ]; then
         export MAKEFLAGS="-j$(all_sh_nproc)"

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -195,13 +195,6 @@ pre_initialize_variables () {
     # they are defined.
     ALL_COMPONENTS=$(sed -n 's/^ *component_\([0-9A-Z_a-z]*\) *().*/\1/p' <"$0")
 
-    # For Linux platforms we run latest/earliest versions of clang and the
-    # test_clang_opt function is only for FreeBSD. This condition removes
-    # test_clang_opt element from the ALL_COMPONENTS array for Linux.
-    if [[ $(uname) == "Linux" ]]; then
-        ALL_COMPONENTS=( "${ALL_COMPONENTS[@]/test_clang_opt}" )
-    fi
-
     # Exclude components that are not supported on this platform.
     SUPPORTED_COMPONENTS=
     for component in $ALL_COMPONENTS; do

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -191,9 +191,7 @@ pre_initialize_variables () {
 
     # Gather the list of available components. These are the functions
     # defined in this script whose name starts with "component_".
-    # Parse the script with sed. This way we get the functions in the order
-    # they are defined.
-    ALL_COMPONENTS=$(sed -n 's/^ *component_\([0-9A-Z_a-z]*\) *().*/\1/p' <"$0")
+    ALL_COMPONENTS=$(compgen -A function component_ | sed 's/component_//')
 
     # Exclude components that are not supported on this platform.
     SUPPORTED_COMPONENTS=

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -176,7 +176,10 @@ pre_initialize_variables () {
     : ${ARMC6_BIN_DIR:=/usr/bin}
     : ${ARM_NONE_EABI_GCC_PREFIX:=arm-none-eabi-}
     : ${ARM_LINUX_GNUEABI_GCC_PREFIX:=arm-linux-gnueabi-}
-
+    : ${CLANG_LATEST:="clang-16"}
+    : ${CLANG_EARLIEST:="clang-3.5"}
+    : ${GCC_LATEST:="gcc-12"}
+    : ${GCC_EARLIEST:="gcc-4.7"}
     # if MAKEFLAGS is not set add the -j option to speed up invocations of make
     if [ -z "${MAKEFLAGS+set}" ]; then
         export MAKEFLAGS="-j$(all_sh_nproc)"
@@ -273,6 +276,10 @@ General options:
 Tool path options:
      --armc5-bin-dir=<ARMC5_bin_dir_path>       ARM Compiler 5 bin directory.
      --armc6-bin-dir=<ARMC6_bin_dir_path>       ARM Compiler 6 bin directory.
+     --clang-earliest=<Clang_earliest_path>     Earliest version of clang available
+     --clang-latest=<Clang_latest_path>         Latest version of clang available
+     --gcc-earliest=<GCC_earliest_path>         Earliest version of GCC available
+     --gcc-latest=<GCC_latest_path>             Latest version of GCC available
      --gnutls-cli=<GnuTLS_cli_path>             GnuTLS client executable to use for most tests.
      --gnutls-serv=<GnuTLS_serv_path>           GnuTLS server executable to use for most tests.
      --gnutls-legacy-cli=<GnuTLS_cli_path>      GnuTLS client executable to use for legacy tests.
@@ -439,9 +446,13 @@ pre_parse_command_line () {
             --armcc) no_armcc=;;
             --armc5-bin-dir) shift; ;; # assignment to ARMC5_BIN_DIR done in pre_parse_command_line_for_dirs
             --armc6-bin-dir) shift; ;; # assignment to ARMC6_BIN_DIR done in pre_parse_command_line_for_dirs
+            --clang-earliest) shift; CLANG_EARLIEST="$1";;
+            --clang-latest) shift; CLANG_LATEST="$1";;
             --error-test) error_test=$((error_test + 1));;
             --except) all_except=1;;
             --force|-f) FORCE=1;;
+            --gcc-earliest) shift; GCC_EARLIEST="$1";;
+            --gcc-latest) shift; GCC_LATEST="$1";;
             --gnutls-cli) shift; GNUTLS_CLI="$1";;
             --gnutls-legacy-cli) shift; GNUTLS_LEGACY_CLI="$1";;
             --gnutls-legacy-serv) shift; GNUTLS_LEGACY_SERV="$1";;
@@ -4015,34 +4026,34 @@ fi
 
 component_test_clang_latest_opt () {
     scripts/config.py full
-    test_build_opt 'full config' clang-latest -O0 -Os -O2
+    test_build_opt 'full config' "$CLANG_LATEST" -O0 -Os -O2
 }
 support_test_clang_latest_opt () {
-    type clang-latest >/dev/null 2>/dev/null
+    type "$CLANG_LATEST" >/dev/null 2>/dev/null
 }
 
 component_test_clang_earliest_opt () {
     scripts/config.py full
-    test_build_opt 'full config' clang-earliest -O0
+    test_build_opt 'full config' "$CLANG_EARLIEST" -O0
 }
 support_test_clang_earliest_opt () {
-    type clang-earliest >/dev/null 2>/dev/null
+    type "$CLANG_EARLIEST" >/dev/null 2>/dev/null
 }
 
 component_test_gcc_latest_opt () {
     scripts/config.py full
-    test_build_opt 'full config' gcc-latest -O0 -Os -O2
+    test_build_opt 'full config' "$GCC_LATEST" -O0 -Os -O2
 }
 support_test_gcc_latest_opt () {
-    type gcc-latest >/dev/null 2>/dev/null
+    type "$GCC_LATEST" >/dev/null 2>/dev/null
 }
 
 component_test_gcc_earliest_opt () {
     scripts/config.py full
-    test_build_opt 'full config' gcc-earliest -O0
+    test_build_opt 'full config' "$GCC_EARLIEST" -O0
 }
 support_test_gcc_earliest_opt () {
-    type gcc-earliest >/dev/null 2>/dev/null
+    type "$GCC_EARLIEST" >/dev/null 2>/dev/null
 }
 
 component_build_mbedtls_config_file () {

--- a/tests/scripts/generate_test_code.py
+++ b/tests/scripts/generate_test_code.py
@@ -667,6 +667,11 @@ def parse_function_code(funcs_f, dependencies, suite_dependencies):
     code = code.replace(name, 'test_' + name, 1)
     name = 'test_' + name
 
+    # If a test function has no arguments then add 'void' argument to
+    # avoid "-Wstrict-prototypes" warnings from clang-16
+    if len(args) == 0:
+        code = code.replace('()', '(void)', 1)
+
     for line in funcs_f:
         if re.search(END_CASE_REGEX, line):
             break

--- a/tests/scripts/generate_test_code.py
+++ b/tests/scripts/generate_test_code.py
@@ -668,7 +668,7 @@ def parse_function_code(funcs_f, dependencies, suite_dependencies):
     name = 'test_' + name
 
     # If a test function has no arguments then add 'void' argument to
-    # avoid "-Wstrict-prototypes" warnings from clang-16
+    # avoid "-Wstrict-prototypes" warnings from clang
     if len(args) == 0:
         code = code.replace('()', '(void)', 1)
 

--- a/tests/scripts/test_generate_test_code.py
+++ b/tests/scripts/test_generate_test_code.py
@@ -647,7 +647,7 @@ void func()
         self.assertEqual(arg, [])
         expected = '''#line 1 "test_suite_ut.function"
 
-void test_func()
+void test_func(void)
 {
     ba ba black sheep
     have you any wool
@@ -690,7 +690,7 @@ exit:
 
         expected = '''#line 1 "test_suite_ut.function"
 
-void test_func()
+void test_func(void)
 {
     ba ba black sheep
     have you any wool
@@ -750,7 +750,7 @@ exit:
 void
 
 
-test_func()
+test_func(void)
 {
     ba ba black sheep
     have you any wool
@@ -803,7 +803,7 @@ exit:
 
 
 
-void test_func()
+void test_func(void)
 {
     ba ba black sheep
     have you any wool
@@ -1139,7 +1139,7 @@ void func2()
 #if defined(MBEDTLS_ENTROPY_NV_SEED)
 #if defined(MBEDTLS_FS_IO)
 #line 13 "test_suite_ut.function"
-void test_func1()
+void test_func1(void)
 {
 exit:
     ;
@@ -1156,7 +1156,7 @@ void test_func1_wrapper( void ** params )
 #if defined(MBEDTLS_ENTROPY_NV_SEED)
 #if defined(MBEDTLS_FS_IO)
 #line 19 "test_suite_ut.function"
-void test_func2()
+void test_func2(void)
 {
 exit:
     ;


### PR DESCRIPTION
Closes #7891

Needs https://github.com/Mbed-TLS/mbedtls-test/pull/118 to be merged, otherwise the CI won't pass.

This PR has adds following changes: 

- The Ubuntu 16.04 and 22.04 docker images in mbedtls-test have been updated with earliest and latest versions of gcc and clang respectively. This PR adds the components and support functions required for the CI to run these compilers. For FreeBSD, we invoke the function by name so a condition is added to disable the existing test_clang_opt function for Linux. 

- Running clang-16 on mbedtls reports warnings of type "-Wstrict-prototypes". This patch fixes these warnings by adding void to functions with no arguments.



## PR checklist

- [x] **changelog**  not required
- [x] **backport** #7969
- [x] **tests** not required


