### PR TITLE
Fix server1.crt.der in tests/data_files/Makefile

### DIFF
--- a/tests/data_files/Makefile
+++ b/tests/data_files/Makefile
@@ -1449,7 +1449,7 @@ server1.der: server1.crt
 	$(OPENSSL) x509 -inform PEM -in $< -outform DER -out $@
 server1.commas.crt: server1.key parse_input/server1.req.commas.sha256 $(test_ca_crt) $(test_ca_key_file_rsa)
 	$(MBEDTLS_CERT_WRITE) request_file=parse_input/server1.req.commas.sha256 issuer_crt=$(test_ca_crt) issuer_key=$(test_ca_key_file_rsa) issuer_pwd=$(test_ca_pwd_rsa) version=1 not_before=20190210144406 not_after=20290210144406 md=SHA1 version=3 output_file=$@
-all_final += server1.crt server1.noauthid.crt server1.crt.der server1.commas.crt
+all_final += server1.crt server1.noauthid.crt parse_input/server1.crt.der server1.commas.crt
 
 parse_input/server1.key_usage.crt: parse_input/server1.req.sha256
 server1.key_usage.crt: server1.req.sha256


### PR DESCRIPTION
## Description

server1.crt.der needed to be changed to parse_input/server1.crt.der to match target earlier in the makefile. Prior the makefile was unable to build.

## PR checklist

- [x] **changelog** not required
- [x] **backport** this particular bug doesn't exist in 2.28
- [x] **tests** not required


