### PR TITLE
Backport 2.28: Fix empty union when TLS is disabled

### DIFF
--- a/ChangeLog.d/ssl_premaster_secret-empty.txt
+++ b/ChangeLog.d/ssl_premaster_secret-empty.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix a compilation error on some platforms when including mbedtls/ssl.h
+     with all TLS support disabled. Fixes #6628.

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -494,6 +494,7 @@
 
 /* Dummy type used only for its size */
 union mbedtls_ssl_premaster_secret {
+    unsigned char dummy; /* Make the union non-empty even with SSL disabled */
 #if defined(MBEDTLS_KEY_EXCHANGE_RSA_ENABLED)
     unsigned char _pms_rsa[48];                         /* RFC 5246 8.1.1 */
 #endif


### PR DESCRIPTION
Trivial backport of https://github.com/Mbed-TLS/mbedtls/pull/7835

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** provided
- [x] **backport** of https://github.com/Mbed-TLS/mbedtls/pull/7835
- [x] **tests** no (see original PR)



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.
