### PR TITLE
driver-only ECC: BN.x509 testing

### DIFF
--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -986,15 +986,15 @@
 #error "MBEDTLS_VERSION_FEATURES defined, but not all prerequisites"
 #endif
 
-#if defined(MBEDTLS_X509_USE_C) && ( !defined(MBEDTLS_BIGNUM_C) ||  \
-    !defined(MBEDTLS_OID_C) || !defined(MBEDTLS_ASN1_PARSE_C) ||    \
+#if defined(MBEDTLS_X509_USE_C) && \
+    (!defined(MBEDTLS_OID_C) || !defined(MBEDTLS_ASN1_PARSE_C) ||   \
     !defined(MBEDTLS_PK_PARSE_C) ||                                 \
     ( !defined(MBEDTLS_MD_C) && !defined(MBEDTLS_USE_PSA_CRYPTO) ) )
 #error "MBEDTLS_X509_USE_C defined, but not all prerequisites"
 #endif
 
-#if defined(MBEDTLS_X509_CREATE_C) && ( !defined(MBEDTLS_BIGNUM_C) ||  \
-    !defined(MBEDTLS_OID_C) || !defined(MBEDTLS_ASN1_WRITE_C) ||       \
+#if defined(MBEDTLS_X509_CREATE_C) && \
+    (!defined(MBEDTLS_OID_C) || !defined(MBEDTLS_ASN1_WRITE_C) ||      \
     !defined(MBEDTLS_PK_PARSE_C) ||                                    \
     ( !defined(MBEDTLS_MD_C) && !defined(MBEDTLS_USE_PSA_CRYPTO) ) )
 #error "MBEDTLS_X509_CREATE_C defined, but not all prerequisites"
@@ -1099,8 +1099,8 @@
 
 #if defined(MBEDTLS_PKCS7_C) && ( ( !defined(MBEDTLS_ASN1_PARSE_C) ) || \
     ( !defined(MBEDTLS_OID_C) ) || ( !defined(MBEDTLS_PK_PARSE_C) ) || \
-    ( !defined(MBEDTLS_X509_CRT_PARSE_C) ) ||\
-    ( !defined(MBEDTLS_X509_CRL_PARSE_C) ) || ( !defined(MBEDTLS_BIGNUM_C) ) || \
+    ( !defined(MBEDTLS_X509_CRT_PARSE_C) ) || \
+    ( !defined(MBEDTLS_X509_CRL_PARSE_C) ) || \
     ( !defined(MBEDTLS_MD_C) ) )
 #error  "MBEDTLS_PKCS7_C is defined, but not all prerequisites"
 #endif

--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -173,7 +173,7 @@ typedef struct mbedtls_pk_rsassa_pss_options {
 
 /* Internal helper to define which fields in the pk_context structure below
  * should be used for EC keys: legacy ecp_keypair or the raw (PSA friendly)
- * format. It should be noticed that this only affect how data is stored, not
+ * format. It should be noticed that this only affects how data is stored, not
  * which functions are used for various operations. The overall picture looks
  * like this:
  * - if USE_PSA is not defined and ECP_C is then use ecp_keypair data structure
@@ -202,7 +202,7 @@ typedef struct mbedtls_pk_rsassa_pss_options {
 
 /* Internal helper to define which fields in the pk_context structure below
  * should be used for EC keys: legacy ecp_keypair or the raw (PSA friendly)
- * format. It should be noticed that this only affect how data is stored, not
+ * format. It should be noted that this only affect how data is stored, not
  * which functions are used for various operations. The overall picture looks
  * like this:
  * - if USE_PSA is not defined and ECP_C is then use ecp_keypair data structure
@@ -213,9 +213,9 @@ typedef struct mbedtls_pk_rsassa_pss_options {
  *     - if !ECP_C then use new raw data and PSA functions directly.
  *
  * The main reason for the "intermediate" (USE_PSA + ECP_C) above is that as long
- * as ECP_C is defined mbedtls_pk_ec() gives the user a read/write access to the
- * ecp_keypair structure inside the pk_context so he/she can modify it using
- * ECP functions which are not under PK module's control.
+ * as ECP_C is defined mbedtls_pk_ec() gives the user read/write access to the
+ * ecp_keypair structure inside the pk_context so they can modify it using
+ * ECP functions which are not under the PK module's control.
  */
 #if defined(MBEDTLS_USE_PSA_CRYPTO) && defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY) && \
     !defined(MBEDTLS_ECP_C)

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -2656,9 +2656,10 @@ component_test_psa_crypto_config_reference_ecc_no_ecp_at_all () {
 # - component_test_psa_crypto_config_reference_ecc_no_bignum
 config_psa_crypto_config_accel_ecc_no_bignum() {
     DRIVER_ONLY="$1"
-    # start with crypto_full config for maximum coverage (also enables USE_PSA),
-    # but excluding X509, TLS and key exchanges
-    helper_libtestdriver1_adjust_config "crypto_full"
+    # start with full config for maximum coverage (also enables USE_PSA),
+    # but keep TLS and key exchanges disabled
+    helper_libtestdriver1_adjust_config "full"
+    scripts/config.py unset MBEDTLS_SSL_TLS_C
 
     if [ "$DRIVER_ONLY" -eq 1 ]; then
         # Disable modules that are accelerated
@@ -2711,7 +2712,7 @@ config_psa_crypto_config_accel_ecc_no_bignum() {
 #
 # Keep in sync with component_test_psa_crypto_config_reference_ecc_no_bignum()
 component_test_psa_crypto_config_accel_ecc_no_bignum () {
-    msg "build: crypto_full + accelerated EC algs + USE_PSA - ECP"
+    msg "build: full + accelerated EC algs + USE_PSA - ECP"
 
     # Algorithms and key types to accelerate
     loc_accel_list="ALG_ECDSA ALG_DETERMINISTIC_ECDSA \
@@ -2753,7 +2754,7 @@ component_test_psa_crypto_config_accel_ecc_no_bignum () {
     # Run the tests
     # -------------
 
-    msg "test suites: crypto_full + accelerated EC algs + USE_PSA - ECP"
+    msg "test suites: full + accelerated EC algs + USE_PSA - ECP"
     make test
 
     # The following will be enabled in #7756
@@ -2765,13 +2766,13 @@ component_test_psa_crypto_config_accel_ecc_no_bignum () {
 # in conjunction with component_test_psa_crypto_config_accel_ecc_no_bignum().
 # Keep in sync with its accelerated counterpart.
 component_test_psa_crypto_config_reference_ecc_no_bignum () {
-    msg "build: crypto_full + non accelerated EC algs + USE_PSA"
+    msg "build: full + non accelerated EC algs + USE_PSA"
 
     config_psa_crypto_config_accel_ecc_no_bignum 0
 
     make
 
-    msg "test suites: crypto_full + non accelerated EC algs + USE_PSA"
+    msg "test suites: full + non accelerated EC algs + USE_PSA"
     make test
 
     # The following will be enabled in #7756

--- a/tests/suites/test_suite_x509parse.function
+++ b/tests/suites/test_suite_x509parse.function
@@ -415,11 +415,6 @@ int parse_crt_ext_cb(void *p_ctx, mbedtls_x509_crt const *crt, mbedtls_x509_buf 
 #endif /* MBEDTLS_X509_CRT_PARSE_C */
 /* END_HEADER */
 
-/* BEGIN_DEPENDENCIES
- * depends_on:MBEDTLS_BIGNUM_C
- * END_DEPENDENCIES
- */
-
 /* BEGIN_CASE depends_on:MBEDTLS_X509_CRT_PARSE_C */
 void x509_accessor_ext_types(int ext_type, int has_ext_type)
 {

--- a/tests/suites/test_suite_x509write.function
+++ b/tests/suites/test_suite_x509write.function
@@ -128,7 +128,7 @@ static int csr_set_extended_key_usage(mbedtls_x509write_csr *ctx,
 /* END_HEADER */
 
 /* BEGIN_DEPENDENCIES
- * depends_on:MBEDTLS_BIGNUM_C:MBEDTLS_FS_IO:MBEDTLS_PK_PARSE_C
+ * depends_on:MBEDTLS_FS_IO:MBEDTLS_PK_PARSE_C
  * END_DEPENDENCIES
  */
 


### PR DESCRIPTION
This PR is the continuation of #7989 and it enables also X509 testing.

Depends on #7989 
Resolves #7755

## PR checklist

- [x] **changelog** will  be provided in #7757
- [x] **backport** not required because it's an enhancement
- [x] **tests** not required because the parity analysis element was already added in #7989