### PR TITLE
Fix new bignum tests

### DIFF
--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -3997,4 +3997,13 @@
  */
 //#define MBEDTLS_P256M_EXAMPLE_DRIVER_ENABLED
 
+
+/**
+ * Uncomment to enable using new bignum code in the ECC modules.
+ *
+ * \warning ECC implementation using new bignum code is a work in progress,
+ * this option serves only development and testing purposes.
+ */
+//#define MBEDTLS_ECP_WITH_MPI_UINT
+
 /** \} name SECTION: Module configuration options */

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -4001,8 +4001,8 @@
 /**
  * Uncomment to enable using new bignum code in the ECC modules.
  *
- * \warning ECC implementation using new bignum code is a work in progress,
- * this option serves only development and testing purposes.
+ * \warning This is currently experimental, incomplete and therefore should not
+ * be used in production.
  */
 //#define MBEDTLS_ECP_WITH_MPI_UINT
 

--- a/library/ecp_invasive.h
+++ b/library/ecp_invasive.h
@@ -32,6 +32,14 @@
 #include "mbedtls/ecp.h"
 
 /*
+ * Turning this option on enables using the new bignum code in the ECC modules.
+ *
+ * WARNING: ECC implementation using the new bignum code is a work in progress,
+ * this option serves only development and testing purposes.
+ */
+//#define MBEDTLS_ECP_WITH_MPI_UINT
+
+/*
  * Curve modulus types
  */
 typedef enum {
@@ -39,11 +47,6 @@ typedef enum {
     MBEDTLS_ECP_MOD_COORDINATE,
     MBEDTLS_ECP_MOD_SCALAR
 } mbedtls_ecp_modulus_type;
-
-/* Provide a commented-out definition so that `check_names.py` knows that
- * it's not a typo.
- */
-//#define MBEDTLS_ECP_WITH_MPI_UINT
 
 typedef enum {
     MBEDTLS_ECP_VARIANT_NONE = 0,

--- a/library/ecp_invasive.h
+++ b/library/ecp_invasive.h
@@ -32,14 +32,6 @@
 #include "mbedtls/ecp.h"
 
 /*
- * Turning this option on enables using the new bignum code in the ECC modules.
- *
- * WARNING: ECC implementation using the new bignum code is a work in progress,
- * this option serves only development and testing purposes.
- */
-//#define MBEDTLS_ECP_WITH_MPI_UINT
-
-/*
  * Curve modulus types
  */
 typedef enum {

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -195,6 +195,7 @@ EXCLUDE_FROM_FULL = frozenset([
     'MBEDTLS_DEPRECATED_WARNING', # conflicts with deprecated options
     'MBEDTLS_ECDH_VARIANT_EVEREST_ENABLED', # influences the use of ECDH in TLS
     'MBEDTLS_ECP_NO_FALLBACK', # removes internal ECP implementation
+    'MBEDTLS_ECP_WITH_MPI_UINT', # disables the default ECP and is experimental
     'MBEDTLS_ENTROPY_FORCE_SHA256', # interacts with CTR_DRBG_128_BIT_KEY
     'MBEDTLS_HAVE_SSE2', # hardware dependency
     'MBEDTLS_MEMORY_BACKTRACE', # depends on MEMORY_BUFFER_ALLOC_C
@@ -204,6 +205,7 @@ EXCLUDE_FROM_FULL = frozenset([
     'MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES', # removes a feature
     'MBEDTLS_NO_PLATFORM_ENTROPY', # removes a feature
     'MBEDTLS_NO_UDBL_DIVISION', # influences anything that uses bignum
+    'MBEDTLS_P256M_EXAMPLE_DRIVER_ENABLED', # influences SECP256R1 KeyGen/ECDH/ECDSA
     'MBEDTLS_PLATFORM_NO_STD_FUNCTIONS', # removes a feature
     'MBEDTLS_PSA_CRYPTO_CONFIG', # toggles old/new style PSA config
     'MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG', # behavior change + build dependency
@@ -213,12 +215,10 @@ EXCLUDE_FROM_FULL = frozenset([
     'MBEDTLS_RSA_NO_CRT', # influences the use of RSA in X.509 and TLS
     'MBEDTLS_SHA256_USE_A64_CRYPTO_ONLY', # interacts with *_USE_A64_CRYPTO_IF_PRESENT
     'MBEDTLS_SHA512_USE_A64_CRYPTO_ONLY', # interacts with *_USE_A64_CRYPTO_IF_PRESENT
+    'MBEDTLS_SSL_RECORD_SIZE_LIMIT', # in development, currently breaks other tests
     'MBEDTLS_TEST_CONSTANT_FLOW_MEMSAN', # build dependency (clang+memsan)
     'MBEDTLS_TEST_CONSTANT_FLOW_VALGRIND', # build dependency (valgrind headers)
     'MBEDTLS_X509_REMOVE_INFO', # removes a feature
-    'MBEDTLS_SSL_RECORD_SIZE_LIMIT', # in development, currently breaks other tests
-    'MBEDTLS_P256M_EXAMPLE_DRIVER_ENABLED', # influences SECP256R1 KeyGen/ECDH/ECDSA
-    'MBEDTLS_ECP_WITH_MPI_UINT' # disables the default ECP and is experimental
 ])
 
 def is_seamless_alt(name):

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -217,7 +217,8 @@ EXCLUDE_FROM_FULL = frozenset([
     'MBEDTLS_TEST_CONSTANT_FLOW_VALGRIND', # build dependency (valgrind headers)
     'MBEDTLS_X509_REMOVE_INFO', # removes a feature
     'MBEDTLS_SSL_RECORD_SIZE_LIMIT', # in development, currently breaks other tests
-    'MBEDTLS_P256M_EXAMPLE_DRIVER_ENABLED' # influences SECP256R1 KeyGen/ECDH/ECDSA
+    'MBEDTLS_P256M_EXAMPLE_DRIVER_ENABLED', # influences SECP256R1 KeyGen/ECDH/ECDSA
+    'MBEDTLS_ECP_WITH_MPI_UINT' # disables the default ECP and is experimental
 ])
 
 def is_seamless_alt(name):

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -134,13 +134,14 @@ pre_initialize_variables () {
     CONFIG_H='include/mbedtls/mbedtls_config.h'
     CRYPTO_CONFIG_H='include/psa/crypto_config.h'
     CONFIG_TEST_DRIVER_H='tests/include/test/drivers/config_test_driver.h'
+    CONFIG_NEW_BIGNUM_H='library/ecp_invasive.h'
 
     # Files that are clobbered by some jobs will be backed up. Use a different
     # suffix from auxiliary scripts so that all.sh and auxiliary scripts can
     # independently decide when to remove the backup file.
     backup_suffix='.all.bak'
     # Files clobbered by config.py
-    files_to_back_up="$CONFIG_H $CRYPTO_CONFIG_H $CONFIG_TEST_DRIVER_H"
+    files_to_back_up="$CONFIG_H $CRYPTO_CONFIG_H $CONFIG_TEST_DRIVER_H $CONFIG_NEW_BIGNUM_H"
     # Files clobbered by in-tree cmake
     files_to_back_up="$files_to_back_up Makefile library/Makefile programs/Makefile tests/Makefile programs/fuzz/Makefile"
 
@@ -1028,8 +1029,9 @@ component_test_default_cmake_gcc_asan () {
 
 component_test_default_cmake_gcc_asan_new_bignum () {
     msg "build: cmake, gcc, ASan" # ~ 1 min 50s
+    scripts/config.py -f "$CONFIG_NEW_BIGNUM_H" set MBEDTLS_ECP_WITH_MPI_UINT
     CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
-    make CFLAGS="-D MBEDTLS_ECP_WITH_MPI_UINT"
+    make
 
     msg "test: main suites (inc. selftests) (ASan build)" # ~ 50s
     make test
@@ -1086,8 +1088,9 @@ component_test_full_cmake_gcc_asan () {
 component_test_full_cmake_gcc_asan_new_bignum () {
     msg "build: full config, cmake, gcc, ASan"
     scripts/config.py full
+    scripts/config.py -f "$CONFIG_NEW_BIGNUM_H" set MBEDTLS_ECP_WITH_MPI_UINT
     CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
-    make CFLAGS="-D MBEDTLS_ECP_WITH_MPI_UINT"
+    make
 
     msg "test: main suites (inc. selftests) (full config, ASan build)"
     make test
@@ -1122,8 +1125,9 @@ component_test_full_cmake_gcc_asan_new_bignum_test_hooks () {
     msg "build: full config, cmake, gcc, ASan"
     scripts/config.py full
     scripts/config.py set MBEDTLS_TEST_HOOKS
+    scripts/config.py -f "$CONFIG_NEW_BIGNUM_H" set MBEDTLS_ECP_WITH_MPI_UINT
     CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
-    make CFLAGS="-DMBEDTLS_ECP_WITH_MPI_UINT"
+    make
 
     msg "test: main suites (inc. selftests) (full config, ASan build)"
     make test

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -4216,7 +4216,8 @@ component_test_have_int32_cmake_new_bignum () {
     scripts/config.py unset MBEDTLS_PADLOCK_C
     scripts/config.py unset MBEDTLS_AESCE_C
     scripts/config.py set MBEDTLS_TEST_HOOKS
-    make CC=gcc CFLAGS="$ASAN_CFLAGS -Werror -Wall -Wextra -DMBEDTLS_HAVE_INT32 -DMBEDTLS_ECP_WITH_MPI_UINT" LDFLAGS="$ASAN_CFLAGS"
+    scripts/config.py -f "$CONFIG_NEW_BIGNUM_H" set MBEDTLS_ECP_WITH_MPI_UINT
+    make CC=gcc CFLAGS="$ASAN_CFLAGS -Werror -Wall -Wextra -DMBEDTLS_HAVE_INT32" LDFLAGS="$ASAN_CFLAGS"
 
     msg "test: gcc, force 32-bit bignum limbs, new bignum interface, test hooks (ASan build)"
     make test

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -134,14 +134,13 @@ pre_initialize_variables () {
     CONFIG_H='include/mbedtls/mbedtls_config.h'
     CRYPTO_CONFIG_H='include/psa/crypto_config.h'
     CONFIG_TEST_DRIVER_H='tests/include/test/drivers/config_test_driver.h'
-    CONFIG_NEW_BIGNUM_H='library/ecp_invasive.h'
 
     # Files that are clobbered by some jobs will be backed up. Use a different
     # suffix from auxiliary scripts so that all.sh and auxiliary scripts can
     # independently decide when to remove the backup file.
     backup_suffix='.all.bak'
     # Files clobbered by config.py
-    files_to_back_up="$CONFIG_H $CRYPTO_CONFIG_H $CONFIG_TEST_DRIVER_H $CONFIG_NEW_BIGNUM_H"
+    files_to_back_up="$CONFIG_H $CRYPTO_CONFIG_H $CONFIG_TEST_DRIVER_H"
     # Files clobbered by in-tree cmake
     files_to_back_up="$files_to_back_up Makefile library/Makefile programs/Makefile tests/Makefile programs/fuzz/Makefile"
 
@@ -1029,7 +1028,7 @@ component_test_default_cmake_gcc_asan () {
 
 component_test_default_cmake_gcc_asan_new_bignum () {
     msg "build: cmake, gcc, ASan" # ~ 1 min 50s
-    scripts/config.py -f "$CONFIG_NEW_BIGNUM_H" set MBEDTLS_ECP_WITH_MPI_UINT
+    scripts/config.py set MBEDTLS_ECP_WITH_MPI_UINT
     CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
     make
 
@@ -1088,7 +1087,7 @@ component_test_full_cmake_gcc_asan () {
 component_test_full_cmake_gcc_asan_new_bignum () {
     msg "build: full config, cmake, gcc, ASan"
     scripts/config.py full
-    scripts/config.py -f "$CONFIG_NEW_BIGNUM_H" set MBEDTLS_ECP_WITH_MPI_UINT
+    scripts/config.py set MBEDTLS_ECP_WITH_MPI_UINT
     CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
     make
 
@@ -1125,7 +1124,7 @@ component_test_full_cmake_gcc_asan_new_bignum_test_hooks () {
     msg "build: full config, cmake, gcc, ASan"
     scripts/config.py full
     scripts/config.py set MBEDTLS_TEST_HOOKS
-    scripts/config.py -f "$CONFIG_NEW_BIGNUM_H" set MBEDTLS_ECP_WITH_MPI_UINT
+    scripts/config.py set MBEDTLS_ECP_WITH_MPI_UINT
     CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
     make
 
@@ -4216,7 +4215,7 @@ component_test_have_int32_cmake_new_bignum () {
     scripts/config.py unset MBEDTLS_PADLOCK_C
     scripts/config.py unset MBEDTLS_AESCE_C
     scripts/config.py set MBEDTLS_TEST_HOOKS
-    scripts/config.py -f "$CONFIG_NEW_BIGNUM_H" set MBEDTLS_ECP_WITH_MPI_UINT
+    scripts/config.py set MBEDTLS_ECP_WITH_MPI_UINT
     make CC=gcc CFLAGS="$ASAN_CFLAGS -Werror -Wall -Wextra -DMBEDTLS_HAVE_INT32" LDFLAGS="$ASAN_CFLAGS"
 
     msg "test: gcc, force 32-bit bignum limbs, new bignum interface, test hooks (ASan build)"


### PR DESCRIPTION
These new bignum weren't working, because they use CMake and can't pass options with CFLAGS directly.

This PR fixes them by using config.py as it is less invasive and more standard than using a CMake option.

~The test being added in https://github.com/Mbed-TLS/mbedtls/pull/7988 is correct, as it is using make. I will rebase after https://github.com/Mbed-TLS/mbedtls/pull/7988 is in and make all new bignum tests use config.py~

~Preceding PR: https://github.com/Mbed-TLS/mbedtls/pull/7988~