### PR TITLE
Driver-only ECC: TLS: rm uses of mbedtls_debug_print_mpi

### DIFF
--- a/library/debug.c
+++ b/library/debug.c
@@ -324,15 +324,17 @@ static void debug_print_pk(const mbedtls_ssl_context *ssl, int level,
         mbedtls_snprintf(name, sizeof(name), "%s%s", text, items[i].name);
         name[sizeof(name) - 1] = '\0';
 
+#if defined(MBEDTLS_RSA_C)
         if (items[i].type == MBEDTLS_PK_DEBUG_MPI) {
             mbedtls_debug_print_mpi(ssl, level, file, line, name, items[i].value);
         } else
+#endif /* MBEDTLS_RSA_C */
 #if defined(MBEDTLS_ECP_LIGHT)
         if (items[i].type == MBEDTLS_PK_DEBUG_ECP) {
             mbedtls_debug_print_ecp(ssl, level, file, line, name, items[i].value);
         } else
-#endif
-#if defined(MBEDTLS_PK_USE_PSA_EC_DATA)
+#endif /* MBEDTLS_ECP_LIGHT */
+#if defined(MBEDTLS_PK_USE_PSA_EC_DATA) && defined(MBEDTLS_BIGNUM_C)
         if (items[i].type == MBEDTLS_PK_DEBUG_PSA_EC) {
             mbedtls_debug_print_psa_ec(ssl, level, file, line, name, items[i].value);
         } else

--- a/library/debug.c
+++ b/library/debug.c
@@ -144,7 +144,6 @@ void mbedtls_debug_print_buf(const mbedtls_ssl_context *ssl, int level,
 
     debug_send_line(ssl, level, file, line, str);
 
-    idx = 0;
     memset(txt, 0, sizeof(txt));
     for (i = 0; i < len; i++) {
         if (i >= 4096) {
@@ -215,7 +214,6 @@ static void mbedtls_debug_print_ec_coord(const mbedtls_ssl_context *ssl, int lev
 
     debug_send_line(ssl, level, file, line, str);
 
-    idx = 0;
     for (i = 0; i < len; i++) {
         if (i >= 4096) {
             break;

--- a/library/debug.c
+++ b/library/debug.c
@@ -202,17 +202,55 @@ void mbedtls_debug_print_ecp(const mbedtls_ssl_context *ssl, int level,
 }
 #endif /* MBEDTLS_ECP_LIGHT */
 
-#if defined(MBEDTLS_BIGNUM_C)
 #if defined(MBEDTLS_PK_USE_PSA_EC_DATA)
+static void mbedtls_debug_print_ec_coord(const mbedtls_ssl_context *ssl, int level,
+                                         const char *file, int line, const char *text,
+                                         const unsigned char *buf, size_t len)
+{
+    char str[DEBUG_BUF_SIZE];
+    size_t i, idx = 0;
+
+    mbedtls_snprintf(str + idx, sizeof(str) - idx, "value of '%s' (%u bits) is:\n",
+                     text, (unsigned int) len * 8);
+
+    debug_send_line(ssl, level, file, line, str);
+
+    idx = 0;
+    for (i = 0; i < len; i++) {
+        if (i >= 4096) {
+            break;
+        }
+
+        if (i % 16 == 0) {
+            if (i > 0) {
+                mbedtls_snprintf(str + idx, sizeof(str) - idx, "\n");
+                debug_send_line(ssl, level, file, line, str);
+
+                idx = 0;
+            }
+        }
+
+        idx += mbedtls_snprintf(str + idx, sizeof(str) - idx, " %02x",
+                                (unsigned int) buf[i]);
+    }
+
+    if (len > 0) {
+        for (/* i = i */; i % 16 != 0; i++) {
+            idx += mbedtls_snprintf(str + idx, sizeof(str) - idx, "   ");
+        }
+
+        mbedtls_snprintf(str + idx, sizeof(str) - idx, "\n");
+        debug_send_line(ssl, level, file, line, str);
+    }
+}
+
 void mbedtls_debug_print_psa_ec(const mbedtls_ssl_context *ssl, int level,
                                 const char *file, int line,
                                 const char *text, const mbedtls_pk_context *pk)
 {
     char str[DEBUG_BUF_SIZE];
-    mbedtls_mpi mpi;
-    const uint8_t *mpi_start;
-    size_t mpi_len;
-    int ret;
+    const uint8_t *coord_start;
+    size_t coord_len;
 
     if (NULL == ssl              ||
         NULL == ssl->conf        ||
@@ -223,32 +261,21 @@ void mbedtls_debug_print_psa_ec(const mbedtls_ssl_context *ssl, int level,
 
     /* For the description of pk->pk_raw content please refer to the description
      * psa_export_public_key() function. */
-    mpi_len = (pk->pub_raw_len - 1)/2;
+    coord_len = (pk->pub_raw_len - 1)/2;
 
     /* X coordinate */
-    mbedtls_mpi_init(&mpi);
-    mpi_start = pk->pub_raw + 1;
-    ret = mbedtls_mpi_read_binary(&mpi, mpi_start, mpi_len);
-    if (ret != 0) {
-        return;
-    }
+    coord_start = pk->pub_raw + 1;
     mbedtls_snprintf(str, sizeof(str), "%s(X)", text);
-    mbedtls_debug_print_mpi(ssl, level, file, line, str, &mpi);
-    mbedtls_mpi_free(&mpi);
+    mbedtls_debug_print_ec_coord(ssl, level, file, line, str, coord_start, coord_len);
 
     /* Y coordinate */
-    mbedtls_mpi_init(&mpi);
-    mpi_start = mpi_start + mpi_len;
-    ret = mbedtls_mpi_read_binary(&mpi, mpi_start, mpi_len);
-    if (ret != 0) {
-        return;
-    }
+    coord_start = coord_start + coord_len;
     mbedtls_snprintf(str, sizeof(str), "%s(Y)", text);
-    mbedtls_debug_print_mpi(ssl, level, file, line, str, &mpi);
-    mbedtls_mpi_free(&mpi);
+    mbedtls_debug_print_ec_coord(ssl, level, file, line, str, coord_start, coord_len);
 }
 #endif /* MBEDTLS_PK_USE_PSA_EC_DATA */
 
+#if defined(MBEDTLS_BIGNUM_C)
 void mbedtls_debug_print_mpi(const mbedtls_ssl_context *ssl, int level,
                              const char *file, int line,
                              const char *text, const mbedtls_mpi *X)
@@ -334,11 +361,11 @@ static void debug_print_pk(const mbedtls_ssl_context *ssl, int level,
             mbedtls_debug_print_ecp(ssl, level, file, line, name, items[i].value);
         } else
 #endif /* MBEDTLS_ECP_LIGHT */
-#if defined(MBEDTLS_PK_USE_PSA_EC_DATA) && defined(MBEDTLS_BIGNUM_C)
+#if defined(MBEDTLS_PK_USE_PSA_EC_DATA)
         if (items[i].type == MBEDTLS_PK_DEBUG_PSA_EC) {
             mbedtls_debug_print_psa_ec(ssl, level, file, line, name, items[i].value);
         } else
-#endif
+#endif /* MBEDTLS_PK_USE_PSA_EC_DATA */
         { debug_send_line(ssl, level, file, line,
                           "should not happen\n"); }
     }


### PR DESCRIPTION
The purpose of this PR is to be able to use the `debug` module for printing EC points even when BIGNUM_C is not available.

Resolves #7759

## PR checklist

- [x] **changelog** not required for this specific PR as nothing changes from the end user point of view
- [x] **backport** not required since it's an enhancement
- [x] **tests** covered by existing tests, specifically `Debug print certificate #2 (EC)` in `test_suite_debug`. The `MBEDTLS_PK_USE_PSA_EC_DATA` version is selected in the `test_psa_crypto_config_accel_ecc_no_ecp_at_all` component from `all.sh`.