### PR TITLE
Make code_style.py --since more precise

### DIFF
--- a/scripts/code_style.py
+++ b/scripts/code_style.py
@@ -82,14 +82,14 @@ def get_src_files(since: Optional[str]) -> List[str]:
     src_files = output.split()
     if since:
         # get all files changed in commits since the starting point
-        cmd = ["git", "log", since + "..HEAD", "--name-only", "--pretty=", "--" ] + src_files
+        cmd = ["git", "log", since + "..HEAD", "--name-only", "--pretty=", "--"] + src_files
         output = subprocess.check_output(cmd, universal_newlines=True)
         committed_changed_files = output.split()
         # and also get all files with uncommitted changes
         cmd = ["git", "diff", "--name-only", "--" ] + src_files
         output = subprocess.check_output(cmd, universal_newlines=True)
         uncommitted_changed_files = output.split()
-        src_files = set(committed_changed_files + uncommitted_changed_files)
+        src_files = list(set(committed_changed_files + uncommitted_changed_files))
 
     generated_files = list_generated_files()
     # Don't correct style for third-party files (and, for simplicity,

--- a/scripts/code_style.py
+++ b/scripts/code_style.py
@@ -81,11 +81,15 @@ def get_src_files(since: Optional[str]) -> List[str]:
                                      universal_newlines=True)
     src_files = output.split()
     if since:
-        output = subprocess.check_output(["git", "diff", "--name-only",
-                                          since, "--"] +
-                                         src_files,
-                                         universal_newlines=True)
-        src_files = output.split()
+        # get all files changed in commits since the starting point
+        cmd = ["git", "log", since + "..HEAD", "--name-only", "--pretty=", "--" ] + src_files
+        output = subprocess.check_output(cmd, universal_newlines=True)
+        committed_changed_files = output.split()
+        # and also get all files with uncommitted changes
+        cmd = ["git", "diff", "--name-only", "--" ] + src_files
+        output = subprocess.check_output(cmd, universal_newlines=True)
+        uncommitted_changed_files = output.split()
+        src_files = set(committed_changed_files + uncommitted_changed_files)
 
     generated_files = list_generated_files()
     # Don't correct style for third-party files (and, for simplicity,

--- a/scripts/code_style.py
+++ b/scripts/code_style.py
@@ -86,7 +86,7 @@ def get_src_files(since: Optional[str]) -> List[str]:
         output = subprocess.check_output(cmd, universal_newlines=True)
         committed_changed_files = output.split()
         # and also get all files with uncommitted changes
-        cmd = ["git", "diff", "--name-only", "--" ] + src_files
+        cmd = ["git", "diff", "--name-only", "--"] + src_files
         output = subprocess.check_output(cmd, universal_newlines=True)
         uncommitted_changed_files = output.split()
         src_files = list(set(committed_changed_files + uncommitted_changed_files))

--- a/scripts/code_style.py
+++ b/scripts/code_style.py
@@ -193,9 +193,10 @@ def main() -> int:
     parser.add_argument('-f', '--fix', action='store_true',
                         help=('modify source files to fix the code style '
                               '(default: print diff, do not modify files)'))
-    parser.add_argument('-s', '--since', metavar='COMMIT',
+    parser.add_argument('-s', '--since', metavar='COMMIT', const='development', nargs='?',
                         help=('only check files modified since the specified commit'
-                              ' (e.g. --since=HEAD~3 or --since=development)'))
+                              ' (e.g. --since=HEAD~3 or --since=development). If no'
+                              ' commit is specified, default to development.'))
     # --subset is almost useless: it only matters if there are no files
     # ('code_style.py' without arguments checks all files known to Git,
     # 'code_style.py --subset' does nothing). In particular,


### PR DESCRIPTION
## Description

Ensure that code_style.py doesn't pick up more files than needed (if development has moved on a lot, `code_style.py -s development` can end up including files changed in development, which are not changed in the range `development..HEAD`.

Also make `-s` default to `-s development`, which is normally what is wanted.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required
- [x] **backport** #8004 
- [x] **tests** not required
