### PR TITLE
driver-only ECC: BN.TLS testing

### DIFF
--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -1521,6 +1521,7 @@ int mbedtls_ssl_tls13_read_public_xxdhe_share(mbedtls_ssl_context *ssl,
     return 0;
 }
 
+#if defined(PSA_WANT_ALG_FFDH)
 static psa_status_t  mbedtls_ssl_get_psa_ffdh_info_from_tls_id(
     uint16_t tls_id, size_t *bits, psa_key_type_t *key_type)
 {
@@ -1549,6 +1550,7 @@ static psa_status_t  mbedtls_ssl_get_psa_ffdh_info_from_tls_id(
             return PSA_ERROR_NOT_SUPPORTED;
     }
 }
+#endif /* PSA_WANT_ALG_FFDH */
 
 int mbedtls_ssl_tls13_generate_and_write_xxdh_key_exchange(
     mbedtls_ssl_context *ssl,

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -2656,10 +2656,8 @@ component_test_psa_crypto_config_reference_ecc_no_ecp_at_all () {
 # - component_test_psa_crypto_config_reference_ecc_no_bignum
 config_psa_crypto_config_accel_ecc_no_bignum() {
     DRIVER_ONLY="$1"
-    # start with full config for maximum coverage (also enables USE_PSA),
-    # but keep TLS and key exchanges disabled
+    # start with full config for maximum coverage (also enables USE_PSA)
     helper_libtestdriver1_adjust_config "full"
-    scripts/config.py unset MBEDTLS_SSL_TLS_C
 
     if [ "$DRIVER_ONLY" -eq 1 ]; then
         # Disable modules that are accelerated
@@ -2712,7 +2710,7 @@ config_psa_crypto_config_accel_ecc_no_bignum() {
 #
 # Keep in sync with component_test_psa_crypto_config_reference_ecc_no_bignum()
 component_test_psa_crypto_config_accel_ecc_no_bignum () {
-    msg "build: full + accelerated EC algs + USE_PSA - ECP"
+    msg "build: full + accelerated EC algs + USE_PSA - ECP - BIGNUM"
 
     # Algorithms and key types to accelerate
     loc_accel_list="ALG_ECDSA ALG_DETERMINISTIC_ECDSA \
@@ -2754,12 +2752,12 @@ component_test_psa_crypto_config_accel_ecc_no_bignum () {
     # Run the tests
     # -------------
 
-    msg "test suites: full + accelerated EC algs + USE_PSA - ECP"
+    msg "test suites: full + accelerated EC algs + USE_PSA - ECP - BIGNUM"
     make test
 
     # The following will be enabled in #7756
-    #msg "ssl-opt: full + accelerated EC algs + USE_PSA - ECP"
-    #tests/ssl-opt.sh
+    msg "ssl-opt: full + accelerated EC algs + USE_PSA - ECP - BIGNUM"
+    tests/ssl-opt.sh
 }
 
 # Reference function used for driver's coverage analysis in analyze_outcomes.py
@@ -2776,8 +2774,8 @@ component_test_psa_crypto_config_reference_ecc_no_bignum () {
     make test
 
     # The following will be enabled in #7756
-    #msg "ssl-opt: full + non accelerated EC algs + USE_PSA"
-    #tests/ssl-opt.sh
+    msg "ssl-opt: full + non accelerated EC algs + USE_PSA"
+    tests/ssl-opt.sh
 }
 
 # Helper function used in:

--- a/tests/scripts/analyze_outcomes.py
+++ b/tests/scripts/analyze_outcomes.py
@@ -390,6 +390,16 @@ TASKS = {
                     'ASN.1 Write mpi, 255*8-1 bits',
                     'ASN.1 Write mpi, 256*8-1 bits',
                 ],
+                'test_suite_debug': [
+                    # Following tests depends on BIGNUM_C
+                    'Debug print mbedtls_mpi #2: 3 bits',
+                    'Debug print mbedtls_mpi: 0 (empty representation)',
+                    'Debug print mbedtls_mpi: 0 (non-empty representation)',
+                    'Debug print mbedtls_mpi: 49 bits',
+                    'Debug print mbedtls_mpi: 759 bits',
+                    'Debug print mbedtls_mpi: 764 bits #1',
+                    'Debug print mbedtls_mpi: 764 bits #2',
+                ],
             }
         }
     },

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -2282,7 +2282,6 @@ run_test    "Opaque key for server authentication: invalid alg: ECDHE-ECDSA with
 
 requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
 requires_config_enabled MBEDTLS_X509_CRT_PARSE_C
-requires_config_enabled MBEDTLS_RSA_C
 requires_config_enabled MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
 requires_hash_alg SHA_256
 requires_config_disabled MBEDTLS_X509_REMOVE_INFO
@@ -2303,7 +2302,6 @@ run_test    "Opaque keys for server authentication: EC keys with different algs,
 
 requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
 requires_config_enabled MBEDTLS_X509_CRT_PARSE_C
-requires_config_enabled MBEDTLS_RSA_C
 requires_hash_alg SHA_384
 requires_config_disabled MBEDTLS_X509_REMOVE_INFO
 run_test    "Opaque keys for server authentication: EC keys with different algs, force ECDH-ECDSA" \
@@ -2323,7 +2321,6 @@ run_test    "Opaque keys for server authentication: EC keys with different algs,
 
 requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
 requires_config_enabled MBEDTLS_X509_CRT_PARSE_C
-requires_config_enabled MBEDTLS_RSA_C
 requires_hash_alg SHA_384
 requires_config_enabled MBEDTLS_CCM_C
 requires_config_disabled MBEDTLS_X509_REMOVE_INFO

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -435,6 +435,13 @@ detect_required_features() {
             ;;
     esac
 
+    case "$CMD_LINE" in
+        *server2*|\
+        *server7*)
+            # server2 and server7 certificates use RSA encryption
+            requires_config_enabled "MBEDTLS_RSA_C"
+    esac
+
     unset tmp
 }
 
@@ -2275,6 +2282,7 @@ run_test    "Opaque key for server authentication: invalid alg: ECDHE-ECDSA with
 
 requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
 requires_config_enabled MBEDTLS_X509_CRT_PARSE_C
+requires_config_enabled MBEDTLS_RSA_C
 requires_config_enabled MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
 requires_hash_alg SHA_256
 requires_config_disabled MBEDTLS_X509_REMOVE_INFO
@@ -2295,6 +2303,7 @@ run_test    "Opaque keys for server authentication: EC keys with different algs,
 
 requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
 requires_config_enabled MBEDTLS_X509_CRT_PARSE_C
+requires_config_enabled MBEDTLS_RSA_C
 requires_hash_alg SHA_384
 requires_config_disabled MBEDTLS_X509_REMOVE_INFO
 run_test    "Opaque keys for server authentication: EC keys with different algs, force ECDH-ECDSA" \
@@ -2314,6 +2323,7 @@ run_test    "Opaque keys for server authentication: EC keys with different algs,
 
 requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
 requires_config_enabled MBEDTLS_X509_CRT_PARSE_C
+requires_config_enabled MBEDTLS_RSA_C
 requires_hash_alg SHA_384
 requires_config_enabled MBEDTLS_CCM_C
 requires_config_disabled MBEDTLS_X509_REMOVE_INFO


### PR DESCRIPTION
This PR is the continuation of #7992 and it enables also TLS and key exchanges as well as `ssl-opt` testing. 

Depends on #7992 and #7999
Resolves #7756

## PR checklist

- [x] **changelog** will be provided in #7757
- [x] **backport** not required since it's an enhancement
- [x] **tests** provided as `ecc_no_bignum()` components (driver and reference) are both updated in this PR