### PR TITLE
Improve `outcome-analysis.sh` script

### DIFF
--- a/docs/architecture/psa-migration/outcome-analysis.sh
+++ b/docs/architecture/psa-migration/outcome-analysis.sh
@@ -44,14 +44,10 @@ record() {
 }
 
 # save current HEAD.
-# Note: unfortunately "git branch --show-current" was added only in GIT
-# version 2.22.
-GIT_VERSION="$(git --version | sed 's/git version //')"
-if dpkg --compare-versions "$GIT_VERSION" "gt" "2.22.0"; then
-    HEAD=$(git branch --show-current)
-else
-    HEAD=$(git rev-parse --abbrev-ref HEAD)
-fi
+# Note: this can optionally be updated to
+#   HEAD=$(git branch --show-current)
+# when using a Git version above 2.22
+HEAD=$(git rev-parse --abbrev-ref HEAD)
 
 # get the numbers before this PR for default and full
 cleanup

--- a/docs/architecture/psa-migration/outcome-analysis.sh
+++ b/docs/architecture/psa-migration/outcome-analysis.sh
@@ -43,8 +43,15 @@ record() {
     fi
 }
 
-# save current HEAD
-HEAD=$(git branch --show-current)
+# save current HEAD.
+# Note: unfortunately "git branch --show-current" was added only in GIT
+# version 2.22.
+GIT_VERSION="$(git --version | sed 's/git version //')"
+if dpkg --compare-versions "$GIT_VERSION" "gt" "2.22.0"; then
+    HEAD=$(git branch --show-current)
+else
+    HEAD=$(git rev-parse --abbrev-ref HEAD)
+fi
 
 # get the numbers before this PR for default and full
 cleanup


### PR DESCRIPTION
`outcome-analysis.sh` scripts should be run on the same Docker instance that is used by the CI in order to have also tests included by `ssl-opt` script to be executed with the proper OpenSSL/GnuTLS versions.
Unfortunately that Docker instance have an old version of Git (2.7.4) which does not support a command used in this script:
```
git branch --show-current
```
This was added only in Git version 2.22.

As a consequence this PR:

- proposes a "fall back" solution when an old Git version is used
- speeds up the build time by parallelizing the work (not related to the issue above, but beneficial for testing purposes)


## PR checklist

- [ ] **changelog** not required as nothing changes from end user point of view
- [ ] **backport** not required since this is a test enhancement
- [ ] **tests** not required the PR itself modifies a test