### PR TITLE
Fix IAR warning about unnecessary type quantifier

### DIFF
--- a/library/ecp.c
+++ b/library/ecp.c
@@ -166,7 +166,7 @@ static int ecp_drbg_seed(ecp_drbg_context *ctx,
     unsigned char secret_bytes[MBEDTLS_ECP_MAX_BYTES];
     /* The list starts with strong hashes */
     const mbedtls_md_type_t md_type =
-        (const mbedtls_md_type_t) (mbedtls_md_list()[0]);
+        (mbedtls_md_type_t) (mbedtls_md_list()[0]);
     const mbedtls_md_info_t *md_info = mbedtls_md_info_from_type(md_type);
 
     if (secret_len > MBEDTLS_ECP_MAX_BYTES) {


### PR DESCRIPTION
## Description

This fixes the first of the compiler errors in #7873.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required (IAR improvements will be added to the changelog eventually)
- [x] **backport** not required
- [x] **tests** not required
