### PR TITLE
Sync development with accidental merge directly onto master

### DIFF
--- a/ChangeLog.d/fix-win32-llvm-build.txt
+++ b/ChangeLog.d/fix-win32-llvm-build.txt
@@ -1,0 +1,2 @@
+Bugfix
+   * Fix builds on Windows with clang

--- a/library/aesni.c
+++ b/library/aesni.c
@@ -35,6 +35,8 @@
 #if MBEDTLS_AESNI_HAVE_CODE == 2
 #if !defined(_WIN32)
 #include <cpuid.h>
+#else
+#include <intrin.h>
 #endif
 #include <immintrin.h>
 #endif


### PR DESCRIPTION
## Description

Merge master into development, so that development contains the PR that accidentally went into master instead of development.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required
- [x] **backport**  not required
- [x] **tests** not required
