### PR TITLE
Clarify changelog not needed for compiler warnings

### DIFF
--- a/ChangeLog.d/00README.md
+++ b/ChangeLog.d/00README.md
@@ -21,6 +21,9 @@ We generally don't include changelog entries for:
 * Performance improvements, unless they are particularly significant.
 * Changes to parts of the code base that users don't interact with directly,
   such as test code and test data.
+* Fixes for compiler warnings. Releases typically contain a number of fixes
+  of this kind, so we will only mention them in the Changelog if they are
+  particularly significant.
 
 Until Mbed TLS 2.24.0, we required changelog entries in more cases.
 Looking at older changelog entries is good practice for how to write a


### PR DESCRIPTION
## Description

Clarify the guidance on requiring a Changelog update for compiler warning fixes.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required
- [x] **backport** #8024 
- [x] **tests** not required

