### PR TITLE
Test with TF-M config and p256-m driver (part 1)

### DIFF
--- a/3rdparty/p256-m/p256-m_driver_entrypoints.c
+++ b/3rdparty/p256-m/p256-m_driver_entrypoints.c
@@ -114,7 +114,7 @@ psa_status_t p256_transparent_key_agreement(
     /*
      *  Check that private key = 32 bytes, peer public key = 65 bytes,
      *  and that the shared secret buffer is big enough. */
-    psa_status_t status = PSA_ERROR_NOT_SUPPORTED;
+    psa_status_t status = PSA_ERROR_INVALID_ARGUMENT;
     if (key_buffer_size != 32 || shared_secret_size < 32 ||
         peer_key_length != 65) {
         return status;
@@ -150,7 +150,7 @@ psa_status_t p256_transparent_sign_hash(
     (void) alg;
 
     psa_status_t status = PSA_ERROR_NOT_SUPPORTED;
-    if (key_buffer_size != 32 || signature_size != 64) {
+    if (key_buffer_size != 32 || signature_size < 64) {
         return status;
     }
 

--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -222,6 +222,28 @@ typedef struct mbedtls_pk_rsassa_pss_options {
 #define MBEDTLS_PK_USE_PSA_EC_DATA
 #endif /* MBEDTLS_USE_PSA_CRYPTO && !MBEDTLS_ECP_C */
 
+/* Internal helper to define which fields in the pk_context structure below
+ * should be used for EC keys: legacy ecp_keypair or the raw (PSA friendly)
+ * format. It should be noticed that this only affect how data is stored, not
+ * which functions are used for various operations. The overall picture looks
+ * like this:
+ * - if USE_PSA is not defined and ECP_C is then use ecp_keypair data structure
+ *   and legacy functions
+ * - if USE_PSA is defined and
+ *     - if ECP_C then use ecp_keypair structure, convert data to a PSA friendly
+ *       format and use PSA functions
+ *     - if !ECP_C then use new raw data and PSA functions directly.
+ *
+ * The main reason for the "intermediate" (USE_PSA + ECP_C) above is that as long
+ * as ECP_C is defined mbedtls_pk_ec() gives the user a read/write access to the
+ * ecp_keypair structure inside the pk_context so he/she can modify it using
+ * ECP functions which are not under PK module's control.
+ */
+#if defined(MBEDTLS_USE_PSA_CRYPTO) && defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY) && \
+    !defined(MBEDTLS_ECP_C)
+#define MBEDTLS_PK_USE_PSA_EC_DATA
+#endif /* MBEDTLS_USE_PSA_CRYPTO && !MBEDTLS_ECP_C */
+
 /**
  * \brief           Types for interfacing with the debug module
  */

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -2780,6 +2780,9 @@ component_test_psa_crypto_config_reference_ecc_no_bignum () {
     #tests/ssl-opt.sh
 }
 
+# Helper for setting common configurations between:
+# - component_test_tfm_config_p256m_driver_accel_ec()
+# - component_test_tfm_config()
 common_tfm_config () {
     # Enable TF-M config
     cp configs/tfm_mbedcrypto_config_profile_medium.h "$CONFIG_H"
@@ -2809,6 +2812,8 @@ common_tfm_config () {
     echo "#define MBEDTLS_FS_IO" >> "$CONFIG_H"
 }
 
+# Keep this in sync with component_test_tfm_config() as they are both meant
+# to be used in analyze_outcomes.py for driver's coverage analysis.
 component_test_tfm_config_p256m_driver_accel_ec () {
     msg "build: TF-M config + p256m driver + accel ECDH(E)/ECDSA"
 
@@ -2858,6 +2863,9 @@ component_test_tfm_config_p256m_driver_accel_ec () {
     make test
 }
 
+# Keep this in sync with component_test_tfm_config_p256m_driver_accel_ec() as
+# they are both meant to be used in analyze_outcomes.py for driver's coverage
+# analysis.
 component_test_tfm_config() {
     common_tfm_config
 

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -2780,31 +2780,55 @@ component_test_psa_crypto_config_reference_ecc_no_bignum () {
     #tests/ssl-opt.sh
 }
 
-component_test_tfm_config_p256m_driver_accel_ec () {
-    msg "build: TFM config + p256m driver + accel ECDH(E)/ECDSA"
-
-    # Replace "mbedtls_config.h" and "cypto_config.h" with TFM ones
+common_tfm_config () {
+    # Enable TF-M config
     cp configs/tfm_mbedcrypto_config_profile_medium.h "$CONFIG_H"
     cp configs/crypto_config_profile_medium.h "$CRYPTO_CONFIG_H"
 
-    # Create a fake "mbedtls_entropy_nv_seed_config.h" which is required by
-    # the TFM configuration. It will be deleted on exit.
-    touch "include/mbedtls/mbedtls_entropy_nv_seed_config.h"
+    # Adjust for the fact that we're building outside the TF-M environment.
+    #
+    # TF-M has separation, our build doesn't
+    scripts/config.py unset MBEDTLS_PSA_CRYPTO_SPM
+    scripts/config.py unset MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER
+    # TF-M provdes its own (dummy) implemenation, from their tree
+    scripts/config.py unset MBEDTLS_AES_DECRYPT_ALT
+    scripts/config.py unset MBEDTLS_AES_SETKEY_DEC_ALT
+    # We have an OS that provides entropy, use it
+    scripts/config.py unset MBEDTLS_NO_PLATFORM_ENTROPY
+
+    # Other config adjustments to make the tests pass.
+    # Those are a surprise and should be investigated and fixed.
+    #
+    # pkparse.c and pkwrite.c fail to link without this
+    echo "#define MBEDTLS_OID_C" >> "$CONFIG_H"
+
+    # Config adjustements for better test coverage in our environment.
+    # These are not needed just to build and pass tests.
+    #
+    # Enable filesystem I/O for the benefit of PK parse/write tests.
+    echo "#define MBEDTLS_FS_IO" >> "$CONFIG_H"
+}
+
+component_test_tfm_config_p256m_driver_accel_ec () {
+    msg "build: TF-M config + p256m driver + accel ECDH(E)/ECDSA"
+
+    common_tfm_config
 
     # Disable all the features that auto-enable ECP_LIGHT (see build_info.h)
     scripts/config.py -f "$CRYPTO_CONFIG_H" unset PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE
 
-    # Unset PSA_CRYPTO_SPM because test and sample programs aren't equipped
-    # for the modified names used when MBEDTLS_PSA_CRYPTO_SPM is active.
-    scripts/config.py unset MBEDTLS_PSA_CRYPTO_SPM
-    # Use our implementation of AES
-    scripts/config.py unset MBEDTLS_AES_DECRYPT_ALT
-    scripts/config.py unset MBEDTLS_AES_SETKEY_DEC_ALT
-    # Configure entropy support
-    scripts/config.py unset MBEDTLS_NO_PLATFORM_ENTROPY
-    scripts/config.py set MBEDTLS_ENTROPY_NV_SEED
-    # Enable crypto storage
-    scripts/config.py set MBEDTLS_PSA_CRYPTO_STORAGE_C
+    # Add missing symbols from "tfm_mbedcrypto_config_profile_medium.h"
+    #
+    # - USE_PSA_CRYPTO for PK_HAVE_ECC_KEYS
+    echo "#define MBEDTLS_USE_PSA_CRYPTO" >> "$CONFIG_H"
+    # - ECP_C and BIGNUM because P256M does not have support for import and export
+    #       of keys so we need the builtin support for that
+    echo "#define MBEDTLS_ECP_C" >> "$CONFIG_H"
+    echo "#define MBEDTLS_BIGNUM_C" >> "$CONFIG_H"
+    # - ASN1_[PARSE/WRITE]_C and OID_C found by check_config.h
+    echo "#define MBEDTLS_ASN1_PARSE_C" >> "$CONFIG_H"
+    echo "#define MBEDTLS_ASN1_WRITE_C" >> "$CONFIG_H"
+    echo "#define MBEDTLS_OID_C" >> "$CONFIG_H"
 
     # Set the list of accelerated components in order to remove them from
     # builtin support. We don't set IMPORT and EXPORT because P256M does not
@@ -2815,23 +2839,9 @@ component_test_tfm_config_p256m_driver_accel_ec () {
                     KEY_TYPE_ECC_KEY_PAIR_GENERATE \
                     KEY_TYPE_ECC_PUBLIC_KEY"
     loc_accel_flags="$( echo "$loc_accel_list" | sed 's/[^ ]* */-DMBEDTLS_PSA_ACCEL_&/g' )"
-    # Add missing symbols from "tfm_mbedcrypto_config_profile_medium.h". All of
-    # them fix missing items:
-    # - USE_PSA_CRYPTO for PK_HAVE_ECC_KEYS
-    # - FS_IO for the plaform + entropy modules
-    # - ECP_C and BIGNUM because P256M does not have support for import and export
-    #       of keys so we need the builtin support for that
-    # - ASN1_[PARSE/WRITE]_C and OID_C found by check_config.h
-    cflags="-DMBEDTLS_USE_PSA_CRYPTO \
-            -DMBEDTLS_ASN1_PARSE_C \
-            -DMBEDTLS_ASN1_WRITE_C \
-            -DMBEDTLS_OID_C \
-            -DMBEDTLS_FS_IO \
-            -DMBEDTLS_ECP_C \
-            -DMBEDTLS_BIGNUM_C \
-            -DMBEDTLS_PSA_ITS_FILE_C"
+
     # Build crypto library specifying we want to use P256M code for EC operations
-    make CFLAGS="$cflags $loc_accel_flags -DMBEDTLS_P256M_EXAMPLE_DRIVER_ENABLED -O0 -g"
+    make CFLAGS="$loc_accel_flags -DMBEDTLS_P256M_EXAMPLE_DRIVER_ENABLED"
 
     # Make sure any built-in EC alg was not re-enabled by accident (additive config)
     #not grep mbedtls_ecdsa_ library/ecdsa.o # this is needed for deterministic ECDSA
@@ -2844,11 +2854,18 @@ component_test_tfm_config_p256m_driver_accel_ec () {
     #not grep mbedtls_mpi_ library/bignum.o # this is needed from ECP module
 
     # Run the tests
-    msg "test: TFM config + p256m driver + accel ECDH(E)/ECDSA"
+    msg "test: TF-M config + p256m driver + accel ECDH(E)/ECDSA"
     make test
+}
 
-    # Remove unnecessary files generated for the test
-    rm "include/mbedtls/mbedtls_entropy_nv_seed_config.h"
+component_test_tfm_config() {
+    common_tfm_config
+
+    msg "build: TF-M config"
+    make tests
+
+    msg "test: TF-M config"
+    make test
 }
 
 # Helper function used in:

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -2798,6 +2798,8 @@ common_tfm_config () {
     scripts/config.py unset MBEDTLS_AES_SETKEY_DEC_ALT
     # We have an OS that provides entropy, use it
     scripts/config.py unset MBEDTLS_NO_PLATFORM_ENTROPY
+    # Disable buffer allocator and use dynamic memory for calloc/free
+    scripts/config.py unset MBEDTLS_MEMORY_BUFFER_ALLOC_C
 
     # Other config adjustments to make the tests pass.
     # Those are a surprise and should be investigated and fixed.
@@ -2846,7 +2848,7 @@ component_test_tfm_config_p256m_driver_accel_ec () {
     loc_accel_flags="$( echo "$loc_accel_list" | sed 's/[^ ]* */-DMBEDTLS_PSA_ACCEL_&/g' )"
 
     # Build crypto library specifying we want to use P256M code for EC operations
-    make CFLAGS="$loc_accel_flags -DMBEDTLS_P256M_EXAMPLE_DRIVER_ENABLED"
+    make CFLAGS="$ASAN_CFLAGS $loc_accel_flags -DMBEDTLS_P256M_EXAMPLE_DRIVER_ENABLED" LDFLAGS="$ASAN_CFLAGS"
 
     # Make sure any built-in EC alg was not re-enabled by accident (additive config)
     #not grep mbedtls_ecdsa_ library/ecdsa.o # this is needed for deterministic ECDSA

--- a/tests/scripts/analyze_outcomes.py
+++ b/tests/scripts/analyze_outcomes.py
@@ -402,6 +402,66 @@ TASKS = {
             'ignored_tests': {}
         }
     },
+    'analyze_driver_vs_reference_tfm_config': {
+        'test_function':  do_analyze_driver_vs_reference,
+        'args': {
+            'component_ref': 'test_tfm_config',
+            'component_driver': 'test_tfm_config_p256m_driver_accel_ec',
+            # Ignore test suites for the modules that are disabled in the
+            # accelerated test case.
+            'ignored_suites': ['ecdh', 'ecdsa'],
+            'ignored_tests': {
+                # Ignore all tests that require DERIVE support which is disabled
+                # in the driver version
+                'test_suite_psa_crypto': [
+                    'PSA key agreement setup: ECDH + HKDF-SHA-256: good',
+                    ('PSA key agreement setup: ECDH + HKDF-SHA-256: good, key algorithm broader '
+                     'than required'),
+                    'PSA key agreement setup: ECDH + HKDF-SHA-256: public key not on curve',
+                    'PSA key agreement setup: KDF instead of a key agreement algorithm',
+                    'PSA key agreement setup: bad key agreement algorithm',
+                    'PSA key agreement: ECDH SECP256R1 (RFC 5903) + HKDF-SHA-256: capacity=8160',
+                    'PSA key agreement: ECDH SECP256R1 (RFC 5903) + HKDF-SHA-256: read 0+32',
+                    'PSA key agreement: ECDH SECP256R1 (RFC 5903) + HKDF-SHA-256: read 1+31',
+                    'PSA key agreement: ECDH SECP256R1 (RFC 5903) + HKDF-SHA-256: read 31+1',
+                    'PSA key agreement: ECDH SECP256R1 (RFC 5903) + HKDF-SHA-256: read 32+0',
+                    'PSA key agreement: ECDH SECP256R1 (RFC 5903) + HKDF-SHA-256: read 32+32',
+                    'PSA key agreement: ECDH SECP256R1 (RFC 5903) + HKDF-SHA-256: read 64+0',
+                    'PSA key derivation: ECDH on P256 with HKDF-SHA256, info first',
+                    'PSA key derivation: ECDH on P256 with HKDF-SHA256, key output',
+                    'PSA key derivation: ECDH on P256 with HKDF-SHA256, missing info',
+                    'PSA key derivation: ECDH on P256 with HKDF-SHA256, omitted salt',
+                    'PSA key derivation: ECDH on P256 with HKDF-SHA256, raw output',
+                    'PSA key derivation: ECDH on P256 with HKDF-SHA256, salt after secret',
+                    'PSA key derivation: ECDH with TLS 1.2 PRF SHA-256, good case',
+                    'PSA key derivation: ECDH with TLS 1.2 PRF SHA-256, missing label',
+                    'PSA key derivation: ECDH with TLS 1.2 PRF SHA-256, missing label and secret',
+                    'PSA key derivation: ECDH with TLS 1.2 PRF SHA-256, no inputs',
+                    'PSA key derivation: HKDF-SHA-256 -> ECC secp256r1',
+                    'PSA key derivation: HKDF-SHA-256 -> ECC secp256r1 (1 redraw)',
+                    'PSA key derivation: HKDF-SHA-256 -> ECC secp256r1, exercise ECDSA',
+                    'PSA key derivation: TLS 1.2 Mix-PSK-to-MS, SHA-256, 0+48, ka',
+                    'PSA key derivation: TLS 1.2 Mix-PSK-to-MS, SHA-256, 24+24, ka',
+                    'PSA key derivation: TLS 1.2 Mix-PSK-to-MS, SHA-256, 48+0, ka',
+                    'PSA key derivation: TLS 1.2 Mix-PSK-to-MS, bad state #1, ka',
+                    'PSA key derivation: TLS 1.2 Mix-PSK-to-MS, bad state #3, ka',
+                    'PSA key derivation: TLS 1.2 Mix-PSK-to-MS, bad state #4, ka',
+                    'PSA key derivation: bits=7 invalid for ECC BRAINPOOL_P_R1 (ECC enabled)',
+                    'PSA key derivation: bits=7 invalid for ECC MONTGOMERY (ECC enabled)',
+                    'PSA key derivation: bits=7 invalid for ECC SECP_K1 (ECC enabled)',
+                    'PSA key derivation: bits=7 invalid for ECC SECP_R1 (ECC enabled)',
+                    'PSA key derivation: bits=7 invalid for ECC SECP_R2 (ECC enabled)',
+                    'PSA key derivation: bits=7 invalid for ECC SECT_K1 (ECC enabled)',
+                    'PSA key derivation: bits=7 invalid for ECC SECT_R1 (ECC enabled)',
+                    'PSA key derivation: bits=7 invalid for ECC SECT_R2 (ECC enabled)',
+                    'PSA raw key agreement: ECDH SECP256R1 (RFC 5903)',
+                ],
+                'test_suite_psa_crypto_pake': [
+                    'PSA PAKE: ecjpake size macros',
+                ]
+            }
+        }
+    }
 }
 
 def main():


### PR DESCRIPTION
Opening this PR as draft for multiple reasons:

- P256M does not support import/export of keys, so I had to enable the builtin support for those operations
    - builtin support means enabling `ECP_C` and `BIGNUM_C` which is not the purpose of #8006
- P256M also does not support deterministic ECDSA so also this part is builtin
- there are some symbols missing from the default TFM configuration file, which were added in the `cflag` variable in the test. Is this expected?

BTW the component builds and all the test suites pass.

~Depends on #7992~
Depends on https://github.com/Mbed-TLS/mbedtls/pull/8164
First step towards #8006 - will be complete by #8041

## PR checklist

- [x] **changelog** not required - test only
- [x] **backport** not required - test for a new feature
- [x] **tests** provided