### PR TITLE
Update capitalization of "Mbed" and fix bump_version.sh

### DIFF
--- a/3rdparty/everest/include/everest/vs2013/inttypes.h
+++ b/3rdparty/everest/include/everest/vs2013/inttypes.h
@@ -17,7 +17,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  *
- *  This file is part of mbed TLS (https://tls.mbed.org)
+ *  This file is part of Mbed TLS (https://tls.mbed.org)
  */
 
 #ifndef _INTTYPES_H_VS2010

--- a/3rdparty/everest/include/everest/vs2013/stdbool.h
+++ b/3rdparty/everest/include/everest/vs2013/stdbool.h
@@ -17,7 +17,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  *
- *  This file is part of mbed TLS (https://tls.mbed.org)
+ *  This file is part of Mbed TLS (https://tls.mbed.org)
  */
 
 #ifndef _STDBOOL_H_VS2010

--- a/3rdparty/everest/include/everest/x25519.h
+++ b/3rdparty/everest/include/everest/x25519.h
@@ -16,7 +16,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  *
- *  This file is part of mbed TLS (https://tls.mbed.org)
+ *  This file is part of Mbed TLS (https://tls.mbed.org)
  */
 
 #ifndef MBEDTLS_X25519_H

--- a/3rdparty/everest/library/Hacl_Curve25519_joined.c
+++ b/3rdparty/everest/library/Hacl_Curve25519_joined.c
@@ -16,7 +16,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  *
- *  This file is part of mbed TLS (https://tls.mbed.org)
+ *  This file is part of Mbed TLS (https://tls.mbed.org)
  */
 #ifndef _BSD_SOURCE
 /* Required to get htole64() from gcc/glibc's endian.h (older systems)

--- a/3rdparty/everest/library/x25519.c
+++ b/3rdparty/everest/library/x25519.c
@@ -16,7 +16,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  *
- *  This file is part of mbed TLS (https://tls.mbed.org)
+ *  This file is part of Mbed TLS (https://tls.mbed.org)
  */
 
 #include "common.h"

--- a/3rdparty/p256-m/p256-m_driver_entrypoints.h
+++ b/3rdparty/p256-m/p256-m_driver_entrypoints.h
@@ -31,7 +31,7 @@
 
 /** Generate SECP256R1 ECC Key Pair.
  *  Interface function which calls the p256-m key generation function and
- *  places it in the key buffer provided by the caller (mbed TLS) in the
+ *  places it in the key buffer provided by the caller (Mbed TLS) in the
  *  correct format. For a SECP256R1 curve this is the 32 bit private key.
  *
  * \param[in]  attributes           The attributes of the key to use for the

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,14 +34,14 @@ cmake_policy(SET CMP0011 NEW)
 cmake_policy(SET CMP0012 NEW)
 
 if(TEST_CPP)
-    project("mbed TLS" LANGUAGES C CXX)
+    project("Mbed TLS" LANGUAGES C CXX)
 else()
-    project("mbed TLS" LANGUAGES C)
+    project("Mbed TLS" LANGUAGES C)
 endif()
 
 include(GNUInstallDirs)
 
-# Determine if mbed TLS is being built as a subproject using add_subdirectory()
+# Determine if Mbed TLS is being built as a subproject using add_subdirectory()
 if(NOT DEFINED MBEDTLS_AS_SUBPROJECT)
   set(MBEDTLS_AS_SUBPROJECT ON)
   if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
@@ -52,7 +52,7 @@ endif()
 # Set the project root directory.
 set(MBEDTLS_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
-option(ENABLE_PROGRAMS "Build mbed TLS programs." ON)
+option(ENABLE_PROGRAMS "Build Mbed TLS programs." ON)
 
 option(UNSAFE_BUILD "Allow unsafe builds. These builds ARE NOT SECURE." OFF)
 option(MBEDTLS_FATAL_WARNINGS "Compiler warnings treated as errors" ON)
@@ -71,9 +71,9 @@ string(REGEX MATCH "MSVC" CMAKE_COMPILER_IS_MSVC "${CMAKE_C_COMPILER_ID}")
 
 # the test suites currently have compile errors with MSVC
 if(CMAKE_COMPILER_IS_MSVC)
-    option(ENABLE_TESTING "Build mbed TLS tests." OFF)
+    option(ENABLE_TESTING "Build Mbed TLS tests." OFF)
 else()
-    option(ENABLE_TESTING "Build mbed TLS tests." ON)
+    option(ENABLE_TESTING "Build Mbed TLS tests." ON)
 endif()
 
 # Warning string - created as a list for compatibility with CMake 2.8

--- a/DartConfiguration.tcl
+++ b/DartConfiguration.tcl
@@ -1,4 +1,4 @@
 Site: localhost
-BuildName: mbed TLS-test
+BuildName: Mbed TLS-test
 CoverageCommand: /usr/bin/gcov
 MemoryCheckCommand: /usr/bin/valgrind

--- a/configs/README.txt
+++ b/configs/README.txt
@@ -21,4 +21,4 @@ them, you can pick one of the following methods:
     make
 
 Note that the second method also works if you want to keep your custom
-configuration file outside the mbed TLS tree.
+configuration file outside the Mbed TLS tree.

--- a/configs/config-no-entropy.h
+++ b/configs/config-no-entropy.h
@@ -33,7 +33,7 @@
 #define MBEDTLS_HAVE_ASM
 #define MBEDTLS_HAVE_TIME
 
-/* mbed TLS feature support */
+/* Mbed TLS feature support */
 #define MBEDTLS_CIPHER_MODE_CBC
 #define MBEDTLS_CIPHER_PADDING_PKCS7
 #define MBEDTLS_ECP_DP_SECP256R1_ENABLED
@@ -47,7 +47,7 @@
 #define MBEDTLS_SELF_TEST
 #define MBEDTLS_VERSION_FEATURES
 
-/* mbed TLS modules */
+/* Mbed TLS modules */
 #define MBEDTLS_AES_C
 #define MBEDTLS_ASN1_PARSE_C
 #define MBEDTLS_ASN1_WRITE_C

--- a/configs/config-suite-b.h
+++ b/configs/config-suite-b.h
@@ -37,13 +37,13 @@
 #define MBEDTLS_HAVE_ASM
 #define MBEDTLS_HAVE_TIME
 
-/* mbed TLS feature support */
+/* Mbed TLS feature support */
 #define MBEDTLS_ECP_DP_SECP256R1_ENABLED
 #define MBEDTLS_ECP_DP_SECP384R1_ENABLED
 #define MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
 #define MBEDTLS_SSL_PROTO_TLS1_2
 
-/* mbed TLS modules */
+/* Mbed TLS modules */
 #define MBEDTLS_AES_C
 #define MBEDTLS_ASN1_PARSE_C
 #define MBEDTLS_ASN1_WRITE_C

--- a/configs/config-thread.h
+++ b/configs/config-thread.h
@@ -35,7 +35,7 @@
 /* System support */
 #define MBEDTLS_HAVE_ASM
 
-/* mbed TLS feature support */
+/* Mbed TLS feature support */
 #define MBEDTLS_AES_ROM_TABLES
 #define MBEDTLS_ECP_DP_SECP256R1_ENABLED
 #define MBEDTLS_ECP_NIST_OPTIM
@@ -46,7 +46,7 @@
 #define MBEDTLS_SSL_DTLS_ANTI_REPLAY
 #define MBEDTLS_SSL_DTLS_HELLO_VERIFY
 
-/* mbed TLS modules */
+/* Mbed TLS modules */
 #define MBEDTLS_AES_C
 #define MBEDTLS_ASN1_PARSE_C
 #define MBEDTLS_ASN1_WRITE_C

--- a/doxygen/mbedtls.doxyfile
+++ b/doxygen/mbedtls.doxyfile
@@ -1,4 +1,4 @@
-PROJECT_NAME           = "mbed TLS v3.4.1"
+PROJECT_NAME           = "Mbed TLS v3.4.1"
 OUTPUT_DIRECTORY       = ../apidoc/
 FULL_PATH_NAMES        = NO
 OPTIMIZE_OUTPUT_FOR_C  = YES

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,4 +1,4 @@
-option(INSTALL_MBEDTLS_HEADERS "Install mbed TLS headers." ON)
+option(INSTALL_MBEDTLS_HEADERS "Install Mbed TLS headers." ON)
 
 if(INSTALL_MBEDTLS_HEADERS)
 

--- a/include/mbedtls/build_info.h
+++ b/include/mbedtls/build_info.h
@@ -47,7 +47,7 @@
  */
 #define MBEDTLS_VERSION_NUMBER         0x03040100
 #define MBEDTLS_VERSION_STRING         "3.4.1"
-#define MBEDTLS_VERSION_STRING_FULL    "mbed TLS 3.4.1"
+#define MBEDTLS_VERSION_STRING_FULL    "Mbed TLS 3.4.1"
 
 #if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_DEPRECATE)
 #define _CRT_SECURE_NO_DEPRECATE 1

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -30,7 +30,7 @@
  */
 #include <limits.h>
 #if CHAR_BIT != 8
-#error "mbed TLS requires a platform with 8-bit chars"
+#error "Mbed TLS requires a platform with 8-bit chars"
 #endif
 
 #include <stdint.h>

--- a/include/mbedtls/ecp.h
+++ b/include/mbedtls/ecp.h
@@ -175,7 +175,7 @@ mbedtls_ecp_point;
 
 #if !defined(MBEDTLS_ECP_ALT)
 /*
- * default mbed TLS elliptic curve arithmetic implementation
+ * default Mbed TLS elliptic curve arithmetic implementation
  *
  * (in case MBEDTLS_ECP_ALT is defined then the developer has to provide an
  * alternative implementation for the whole module and it will replace this

--- a/include/mbedtls/error.h
+++ b/include/mbedtls/error.h
@@ -166,7 +166,7 @@ static inline int mbedtls_error_add(int high, int low,
 }
 
 /**
- * \brief Translate a mbed TLS error code into a string representation,
+ * \brief Translate a Mbed TLS error code into a string representation,
  *        Result is truncated if necessary and always includes a terminating
  *        null byte.
  *

--- a/include/mbedtls/error.h
+++ b/include/mbedtls/error.h
@@ -166,9 +166,9 @@ static inline int mbedtls_error_add(int high, int low,
 }
 
 /**
- * \brief Translate a Mbed TLS error code into a string representation,
- *        Result is truncated if necessary and always includes a terminating
- *        null byte.
+ * \brief Translate an Mbed TLS error code into a string representation.
+ *        The result is truncated if necessary and always includes a
+ *        terminating null byte.
  *
  * \param errnum    error code
  * \param buffer    buffer to place representation in

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -168,7 +168,7 @@
  *
  * Enable the memory allocation layer.
  *
- * By default mbed TLS uses the system-provided calloc() and free().
+ * By default Mbed TLS uses the system-provided calloc() and free().
  * This allows different allocators (self-implemented or provided) to be
  * provided to the platform abstraction layer.
  *
@@ -241,10 +241,10 @@
 /**
  * \def MBEDTLS_PLATFORM_EXIT_ALT
  *
- * MBEDTLS_PLATFORM_XXX_ALT: Uncomment a macro to let mbed TLS support the
+ * MBEDTLS_PLATFORM_XXX_ALT: Uncomment a macro to let Mbed TLS support the
  * function in the platform abstraction layer.
  *
- * Example: In case you uncomment MBEDTLS_PLATFORM_PRINTF_ALT, mbed TLS will
+ * Example: In case you uncomment MBEDTLS_PLATFORM_PRINTF_ALT, Mbed TLS will
  * provide a function "mbedtls_platform_set_printf()" that allows you to set an
  * alternative printf function pointer.
  *
@@ -344,7 +344,7 @@
 /** \} name SECTION: System support */
 
 /**
- * \name SECTION: mbed TLS feature support
+ * \name SECTION: Mbed TLS feature support
  *
  * This section sets support for features that are or are not needed
  * within the modules that are enabled.
@@ -367,7 +367,7 @@
 /**
  * \def MBEDTLS_AES_ALT
  *
- * MBEDTLS__MODULE_NAME__ALT: Uncomment a macro to let mbed TLS use your
+ * MBEDTLS__MODULE_NAME__ALT: Uncomment a macro to let Mbed TLS use your
  * alternate core implementation of a symmetric crypto, an arithmetic or hash
  * module (e.g. platform specific assembly optimized implementations). Keep
  * in mind that the function prototypes should remain the same.
@@ -375,7 +375,7 @@
  * This replaces the whole module. If you only want to replace one of the
  * functions, use one of the MBEDTLS__FUNCTION_NAME__ALT flags.
  *
- * Example: In case you uncomment MBEDTLS_AES_ALT, mbed TLS will no longer
+ * Example: In case you uncomment MBEDTLS_AES_ALT, Mbed TLS will no longer
  * provide the "struct mbedtls_aes_context" definition and omit the base
  * function declarations and implementations. "aes_alt.h" will be included from
  * "aes.h" to include the new function definitions.
@@ -423,14 +423,14 @@
 /**
  * \def MBEDTLS_SHA256_PROCESS_ALT
  *
- * MBEDTLS__FUNCTION_NAME__ALT: Uncomment a macro to let mbed TLS use you
+ * MBEDTLS__FUNCTION_NAME__ALT: Uncomment a macro to let Mbed TLS use you
  * alternate core implementation of symmetric crypto or hash function. Keep in
  * mind that function prototypes should remain the same.
  *
- * This replaces only one function. The header file from mbed TLS is still
+ * This replaces only one function. The header file from Mbed TLS is still
  * used, in contrast to the MBEDTLS__MODULE_NAME__ALT flags.
  *
- * Example: In case you uncomment MBEDTLS_SHA256_PROCESS_ALT, mbed TLS will
+ * Example: In case you uncomment MBEDTLS_SHA256_PROCESS_ALT, Mbed TLS will
  * no longer provide the mbedtls_sha1_process() function, but it will still provide
  * the other function (using your mbedtls_sha1_process() function) and the definition
  * of mbedtls_sha1_context, so your implementation of mbedtls_sha1_process must be compatible
@@ -480,11 +480,11 @@
  *
  * Expose a part of the internal interface of the Elliptic Curve Point module.
  *
- * MBEDTLS_ECP__FUNCTION_NAME__ALT: Uncomment a macro to let mbed TLS use your
+ * MBEDTLS_ECP__FUNCTION_NAME__ALT: Uncomment a macro to let Mbed TLS use your
  * alternative core implementation of elliptic curve arithmetic. Keep in mind
  * that function prototypes should remain the same.
  *
- * This partially replaces one function. The header file from mbed TLS is still
+ * This partially replaces one function. The header file from Mbed TLS is still
  * used, in contrast to the MBEDTLS_ECP_ALT flag. The original implementation
  * is still present and it is used for group structures not supported by the
  * alternative.
@@ -508,11 +508,11 @@
  * implement optimized set up and tear down instructions.
  *
  * Example: In case you set MBEDTLS_ECP_INTERNAL_ALT and
- * MBEDTLS_ECP_DOUBLE_JAC_ALT, mbed TLS will still provide the ecp_double_jac()
+ * MBEDTLS_ECP_DOUBLE_JAC_ALT, Mbed TLS will still provide the ecp_double_jac()
  * function, but will use your mbedtls_internal_ecp_double_jac() if the group
  * for the operation is supported by your implementation (i.e. your
  * mbedtls_internal_ecp_grp_capable() function returns 1 for this group). If the
- * group is not supported by your implementation, then the original mbed TLS
+ * group is not supported by your implementation, then the original Mbed TLS
  * implementation of ecp_double_jac() is used instead, unless this fallback
  * behaviour is disabled by setting MBEDTLS_ECP_NO_FALLBACK (in which case
  * ecp_double_jac() will return MBEDTLS_ERR_ECP_FEATURE_UNAVAILABLE).
@@ -543,7 +543,7 @@
 /**
  * \def MBEDTLS_ENTROPY_HARDWARE_ALT
  *
- * Uncomment this macro to let mbed TLS use your own implementation of a
+ * Uncomment this macro to let Mbed TLS use your own implementation of a
  * hardware entropy collector.
  *
  * Your function must be called \c mbedtls_hardware_poll(), have the same
@@ -1491,7 +1491,7 @@
  * \def MBEDTLS_SSL_ALL_ALERT_MESSAGES
  *
  * Enable sending of alert messages in case of encountered errors as per RFC.
- * If you choose not to send the alert messages, mbed TLS can still communicate
+ * If you choose not to send the alert messages, Mbed TLS can still communicate
  * with other servers, only debugging of failures is harder.
  *
  * The advantage of not sending alert messages, is that no information is given
@@ -2181,12 +2181,12 @@
  * Comment this macro to disallow using RSASSA-PSS in certificates.
  */
 #define MBEDTLS_X509_RSASSA_PSS_SUPPORT
-/** \} name SECTION: mbed TLS feature support */
+/** \} name SECTION: Mbed TLS feature support */
 
 /**
- * \name SECTION: mbed TLS modules
+ * \name SECTION: Mbed TLS modules
  *
- * This section enables or disables entire modules in mbed TLS
+ * This section enables or disables entire modules in Mbed TLS
  * \{
  */
 
@@ -2882,7 +2882,7 @@
  * Module:  library/memory_buffer_alloc.c
  *
  * Requires: MBEDTLS_PLATFORM_C
- *           MBEDTLS_PLATFORM_MEMORY (to use it within mbed TLS)
+ *           MBEDTLS_PLATFORM_MEMORY (to use it within Mbed TLS)
  *
  * Enable this module to enable the buffer memory allocator.
  */
@@ -3484,7 +3484,7 @@
  * \def MBEDTLS_THREADING_C
  *
  * Enable the threading abstraction layer.
- * By default mbed TLS assumes it is used in a non-threaded environment or that
+ * By default Mbed TLS assumes it is used in a non-threaded environment or that
  * contexts are not shared between threads. If you do intend to use contexts
  * between threads, you will need to enable this layer to prevent race
  * conditions. See also our Knowledge Base article about threading:
@@ -3498,7 +3498,7 @@
  * You will have to enable either MBEDTLS_THREADING_ALT or
  * MBEDTLS_THREADING_PTHREAD.
  *
- * Enable this layer to allow use of mutexes within mbed TLS
+ * Enable this layer to allow use of mutexes within Mbed TLS
  */
 //#define MBEDTLS_THREADING_C
 
@@ -3644,7 +3644,7 @@
  */
 #define MBEDTLS_X509_CSR_WRITE_C
 
-/** \} name SECTION: mbed TLS modules */
+/** \} name SECTION: Mbed TLS modules */
 
 /**
  * \name SECTION: General configuration options

--- a/include/mbedtls/platform_time.h
+++ b/include/mbedtls/platform_time.h
@@ -1,7 +1,7 @@
 /**
  * \file platform_time.h
  *
- * \brief mbed TLS Platform time abstraction
+ * \brief Mbed TLS Platform time abstraction
  */
 /*
  *  Copyright The Mbed TLS Contributors

--- a/include/mbedtls/ssl_ciphersuites.h
+++ b/include/mbedtls/ssl_ciphersuites.h
@@ -1,7 +1,7 @@
 /**
  * \file ssl_ciphersuites.h
  *
- * \brief SSL Ciphersuites for mbed TLS
+ * \brief SSL Ciphersuites for Mbed TLS
  */
 /*
  *  Copyright The Mbed TLS Contributors

--- a/include/mbedtls/threading.h
+++ b/include/mbedtls/threading.h
@@ -55,9 +55,9 @@ typedef struct mbedtls_threading_mutex_t {
  * \brief           Set your alternate threading implementation function
  *                  pointers and initialize global mutexes. If used, this
  *                  function must be called once in the main thread before any
- *                  other mbed TLS function is called, and
+ *                  other Mbed TLS function is called, and
  *                  mbedtls_threading_free_alt() must be called once in the main
- *                  thread after all other mbed TLS functions.
+ *                  thread after all other Mbed TLS functions.
  *
  * \note            mutex_init() and mutex_free() don't return a status code.
  *                  If mutex_init() fails, it should leave its argument (the

--- a/include/mbedtls/version.h
+++ b/include/mbedtls/version.h
@@ -52,9 +52,9 @@ unsigned int mbedtls_version_get_number(void);
 void mbedtls_version_get_string(char *string);
 
 /**
- * Get the full version string ("mbed TLS x.y.z").
+ * Get the full version string ("Mbed TLS x.y.z").
  *
- * \param string    The string that will receive the value. The mbed TLS version
+ * \param string    The string that will receive the value. The Mbed TLS version
  *                  string will use 18 bytes AT MOST including a terminating
  *                  null byte.
  *                  (So the buffer should be at least 18 bytes to receive this
@@ -64,12 +64,12 @@ void mbedtls_version_get_string_full(char *string);
 
 /**
  * \brief           Check if support for a feature was compiled into this
- *                  mbed TLS binary. This allows you to see at runtime if the
+ *                  Mbed TLS binary. This allows you to see at runtime if the
  *                  library was for instance compiled with or without
  *                  Multi-threading support.
  *
  * \note            only checks against defines in the sections "System
- *                  support", "mbed TLS modules" and "mbed TLS feature
+ *                  support", "Mbed TLS modules" and "Mbed TLS feature
  *                  support" in mbedtls_config.h
  *
  * \param feature   The string for the define to check (e.g. "MBEDTLS_AES_C")

--- a/include/mbedtls/x509_crt.h
+++ b/include/mbedtls/x509_crt.h
@@ -1007,7 +1007,7 @@ int mbedtls_x509write_crt_set_validity(mbedtls_x509write_cert *ctx, const char *
  * \brief           Set the issuer name for a Certificate
  *                  Issuer names should contain a comma-separated list
  *                  of OID types and values:
- *                  e.g. "C=UK,O=ARM,CN=mbed TLS CA"
+ *                  e.g. "C=UK,O=ARM,CN=Mbed TLS CA"
  *
  * \param ctx           CRT context to use
  * \param issuer_name   issuer name to set
@@ -1022,7 +1022,7 @@ int mbedtls_x509write_crt_set_issuer_name(mbedtls_x509write_cert *ctx,
  * \brief           Set the subject name for a Certificate
  *                  Subject names should contain a comma-separated list
  *                  of OID types and values:
- *                  e.g. "C=UK,O=ARM,CN=mbed TLS Server 1"
+ *                  e.g. "C=UK,O=ARM,CN=Mbed TLS Server 1"
  *
  * \param ctx           CRT context to use
  * \param subject_name  subject name to set

--- a/include/mbedtls/x509_csr.h
+++ b/include/mbedtls/x509_csr.h
@@ -180,7 +180,7 @@ void mbedtls_x509write_csr_init(mbedtls_x509write_csr *ctx);
  * \brief           Set the subject name for a CSR
  *                  Subject names should contain a comma-separated list
  *                  of OID types and values:
- *                  e.g. "C=UK,O=ARM,CN=mbed TLS Server 1"
+ *                  e.g. "C=UK,O=ARM,CN=Mbed TLS Server 1"
  *
  * \param ctx           CSR context to use
  * \param subject_name  subject name to set

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -1,7 +1,7 @@
-option(USE_STATIC_MBEDTLS_LIBRARY "Build mbed TLS static library." ON)
-option(USE_SHARED_MBEDTLS_LIBRARY "Build mbed TLS shared library." OFF)
-option(LINK_WITH_PTHREAD "Explicitly link mbed TLS library to pthread." OFF)
-option(LINK_WITH_TRUSTED_STORAGE "Explicitly link mbed TLS library to trusted_storage." OFF)
+option(USE_STATIC_MBEDTLS_LIBRARY "Build Mbed TLS static library." ON)
+option(USE_SHARED_MBEDTLS_LIBRARY "Build Mbed TLS shared library." OFF)
+option(LINK_WITH_PTHREAD "Explicitly link Mbed TLS library to pthread." OFF)
+option(LINK_WITH_TRUSTED_STORAGE "Explicitly link Mbed TLS library to trusted_storage." OFF)
 
 # Set the project root directory if it's not already defined, as may happen if
 # the library folder is included directly by a parent project, without

--- a/library/cipher.c
+++ b/library/cipher.c
@@ -1,7 +1,7 @@
 /**
  * \file cipher.c
  *
- * \brief Generic cipher wrapper for mbed TLS
+ * \brief Generic cipher wrapper for Mbed TLS
  *
  * \author Adriaan de Jong <dejong@fox-it.com>
  *

--- a/library/cipher_wrap.c
+++ b/library/cipher_wrap.c
@@ -1,7 +1,7 @@
 /**
  * \file cipher_wrap.c
  *
- * \brief Generic cipher wrapper for mbed TLS
+ * \brief Generic cipher wrapper for Mbed TLS
  *
  * \author Adriaan de Jong <dejong@fox-it.com>
  *

--- a/library/ecjpake.c
+++ b/library/ecjpake.c
@@ -1131,7 +1131,7 @@ int mbedtls_ecjpake_self_test(int verbose)
 #if !defined(MBEDTLS_ECJPAKE_ALT)
     /* 'reference handshake' tests can only be run against implementations
      * for which we have 100% control over how the random ephemeral keys
-     * are generated. This is only the case for the internal mbed TLS
+     * are generated. This is only the case for the internal Mbed TLS
      * implementation, so these tests are skipped in case the internal
      * implementation is swapped out for an alternative one. */
     if (verbose != 0) {

--- a/library/entropy_poll.h
+++ b/library/entropy_poll.h
@@ -50,7 +50,7 @@ int mbedtls_platform_entropy_poll(void *data,
 /**
  * \brief           Entropy poll callback for a hardware source
  *
- * \warning         This is not provided by mbed TLS!
+ * \warning         This is not provided by Mbed TLS!
  *                  See \c MBEDTLS_ENTROPY_HARDWARE_ALT in mbedtls_config.h.
  *
  * \note            This must accept NULL as its first argument.

--- a/library/md.c
+++ b/library/md.c
@@ -1,7 +1,7 @@
 /**
  * \file md.c
  *
- * \brief Generic message digest wrapper for mbed TLS
+ * \brief Generic message digest wrapper for Mbed TLS
  *
  * \author Adriaan de Jong <dejong@fox-it.com>
  *

--- a/library/mps_common.h
+++ b/library/mps_common.h
@@ -14,7 +14,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  *
- *  This file is part of mbed TLS (https://tls.mbed.org)
+ *  This file is part of Mbed TLS (https://tls.mbed.org)
  */
 
 /**

--- a/library/mps_error.h
+++ b/library/mps_error.h
@@ -14,7 +14,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  *
- *  This file is part of mbed TLS (https://tls.mbed.org)
+ *  This file is part of Mbed TLS (https://tls.mbed.org)
  */
 
 /**

--- a/library/mps_reader.h
+++ b/library/mps_reader.h
@@ -14,7 +14,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  *
- *  This file is part of mbed TLS (https://tls.mbed.org)
+ *  This file is part of Mbed TLS (https://tls.mbed.org)
  */
 
 /**

--- a/library/mps_trace.h
+++ b/library/mps_trace.h
@@ -14,7 +14,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  *
- *  This file is part of mbed TLS (https://tls.mbed.org)
+ *  This file is part of Mbed TLS (https://tls.mbed.org)
  */
 
 /**

--- a/library/psa_crypto_core.h
+++ b/library/psa_crypto_core.h
@@ -225,12 +225,12 @@ psa_status_t psa_copy_key_material_into_slot(psa_key_slot_t *slot,
                                              const uint8_t *data,
                                              size_t data_length);
 
-/** Convert an mbed TLS error code to a PSA error code
+/** Convert an Mbed TLS error code to a PSA error code
  *
  * \note This function is provided solely for the convenience of
  *       Mbed TLS and may be removed at any time without notice.
  *
- * \param ret           An mbed TLS-thrown error code
+ * \param ret           An Mbed TLS-thrown error code
  *
  * \return              The corresponding PSA error code
  */

--- a/library/ssl_ciphersuites.c
+++ b/library/ssl_ciphersuites.c
@@ -1,7 +1,7 @@
 /**
  * \file ssl_ciphersuites.c
  *
- * \brief SSL ciphersuites for mbed TLS
+ * \brief SSL ciphersuites for Mbed TLS
  *
  *  Copyright The Mbed TLS Contributors
  *  SPDX-License-Identifier: Apache-2.0

--- a/library/ssl_client.c
+++ b/library/ssl_client.c
@@ -16,7 +16,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  *
- *  This file is part of mbed TLS ( https://tls.mbed.org )
+ *  This file is part of Mbed TLS ( https://tls.mbed.org )
  */
 
 #include "common.h"

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -16,7 +16,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  *
- *  This file is part of mbed TLS ( https://tls.mbed.org )
+ *  This file is part of Mbed TLS ( https://tls.mbed.org )
  */
 
 #include "common.h"

--- a/programs/ssl/ssl_fork_server.c
+++ b/programs/ssl/ssl_fork_server.c
@@ -65,7 +65,7 @@ int main(void)
 
 #define HTTP_RESPONSE \
     "HTTP/1.0 200 OK\r\nContent-Type: text/html\r\n\r\n" \
-    "<h2>mbed TLS Test Server</h2>\r\n" \
+    "<h2>Mbed TLS Test Server</h2>\r\n" \
     "<p>Successful connection using: %s</p>\r\n"
 
 #define DEBUG_LEVEL 0

--- a/programs/ssl/ssl_mail_client.c
+++ b/programs/ssl/ssl_mail_client.c
@@ -775,9 +775,9 @@ usage:
     mbedtls_printf("  > Write content to server:");
     fflush(stdout);
 
-    len = sprintf((char *) buf, "From: %s\r\nSubject: mbed TLS Test mail\r\n\r\n"
+    len = sprintf((char *) buf, "From: %s\r\nSubject: Mbed TLS Test mail\r\n\r\n"
                                 "This is a simple test mail from the "
-                                "mbed TLS mail client example.\r\n"
+                                "Mbed TLS mail client example.\r\n"
                                 "\r\n"
                                 "Enjoy!", opt.mail_from);
     ret = write_ssl_data(&ssl, buf, len);

--- a/programs/ssl/ssl_pthread_server.c
+++ b/programs/ssl/ssl_pthread_server.c
@@ -66,7 +66,7 @@ int main(void)
 
 #define HTTP_RESPONSE \
     "HTTP/1.0 200 OK\r\nContent-Type: text/html\r\n\r\n" \
-    "<h2>mbed TLS Test Server</h2>\r\n" \
+    "<h2>Mbed TLS Test Server</h2>\r\n" \
     "<p>Successful connection using: %s</p>\r\n"
 
 #define DEBUG_LEVEL 0

--- a/programs/ssl/ssl_server.c
+++ b/programs/ssl/ssl_server.c
@@ -59,7 +59,7 @@ int main(void)
 
 #define HTTP_RESPONSE \
     "HTTP/1.0 200 OK\r\nContent-Type: text/html\r\n\r\n" \
-    "<h2>mbed TLS Test Server</h2>\r\n" \
+    "<h2>Mbed TLS Test Server</h2>\r\n" \
     "<p>Successful connection using: %s</p>\r\n"
 
 #define DEBUG_LEVEL 0

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -173,7 +173,7 @@ int main(void)
  * packets (for fragmentation purposes) */
 #define HTTP_RESPONSE \
     "HTTP/1.0 200 OK\r\nContent-Type: text/html\r\n\r\n" \
-    "<h2>mbed TLS Test Server</h2>\r\n" \
+    "<h2>Mbed TLS Test Server</h2>\r\n" \
     "<p>Successful connection using: %s</p>\r\n" // LONG_RESPONSE
 
 /*

--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -142,7 +142,7 @@ mv tmp tests/suites/test_suite_version.data
 [ $VERBOSE ] && echo "Bumping PROJECT_NAME in doxygen/mbedtls.doxyfile and doxygen/input/doc_mainpage.h"
 for i in doxygen/mbedtls.doxyfile doxygen/input/doc_mainpage.h;
 do
-  sed -e "s/mbed TLS v[0-9\.]\{1,\}/mbed TLS v$VERSION/g" < $i > tmp
+  sed -e "s/\\([Mm]bed TLS v\\)[0-9][0-9.]*/\\1$VERSION/g" < $i > tmp
   mv tmp $i
 done
 

--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -131,7 +131,7 @@ cat include/mbedtls/build_info.h |                                    \
     sed -e "s/\(# *define  *[A-Z]*_VERSION\)_PATCH .\{1,\}/\1_PATCH  $PATCH/" |    \
     sed -e "s/\(# *define  *[A-Z]*_VERSION\)_NUMBER .\{1,\}/\1_NUMBER         $VERSION_NR/" |    \
     sed -e "s/\(# *define  *[A-Z]*_VERSION\)_STRING .\{1,\}/\1_STRING         \"$VERSION\"/" |    \
-    sed -e "s/\(# *define  *[A-Z]*_VERSION\)_STRING_FULL .\{1,\}/\1_STRING_FULL    \"mbed TLS $VERSION\"/" \
+    sed -e "s/\(# *define  *[A-Z]*_VERSION\)_STRING_FULL .\{1,\}/\1_STRING_FULL    \"Mbed TLS $VERSION\"/" \
     > tmp
 mv tmp include/mbedtls/build_info.h
 

--- a/scripts/footprint.sh
+++ b/scripts/footprint.sh
@@ -17,7 +17,7 @@
 #
 # Purpose
 #
-# This script determines ROM size (or code size) for the standard mbed TLS
+# This script determines ROM size (or code size) for the standard Mbed TLS
 # configurations, when built for a Cortex M3/M4 target.
 #
 # Configurations included:
@@ -108,7 +108,7 @@ else
 fi
 
 log ""
-log "mbed TLS $MBEDTLS_VERSION$GIT_VERSION"
+log "Mbed TLS $MBEDTLS_VERSION$GIT_VERSION"
 log "$( arm-none-eabi-gcc --version | head -n1 )"
 log "CFLAGS=$ARMGCC_FLAGS"
 

--- a/scripts/generate_features.pl
+++ b/scripts/generate_features.pl
@@ -39,8 +39,8 @@ if( @ARGV ) {
 
 my $feature_format_file = $data_dir.'/version_features.fmt';
 
-my @sections = ( "System support", "mbed TLS modules",
-                 "mbed TLS feature support" );
+my @sections = ( "System support", "Mbed TLS modules",
+                 "Mbed TLS feature support" );
 
 my $line_separator = $/;
 undef $/;

--- a/scripts/lcov.sh
+++ b/scripts/lcov.sh
@@ -51,7 +51,7 @@ lcov_library_report () {
     lcov --rc lcov_branch_coverage=1 --add-tracefile Coverage/tmp/files.info --add-tracefile Coverage/tmp/tests.info -o Coverage/tmp/all.info
     lcov --rc lcov_branch_coverage=1 --remove Coverage/tmp/all.info -o Coverage/tmp/final.info '*.h'
     gendesc tests/Descriptions.txt -o Coverage/tmp/descriptions
-    genhtml --title "mbed TLS" --description-file Coverage/tmp/descriptions --keep-descriptions --legend --branch-coverage -o Coverage Coverage/tmp/final.info
+    genhtml --title "Mbed TLS" --description-file Coverage/tmp/descriptions --keep-descriptions --legend --branch-coverage -o Coverage Coverage/tmp/final.info
     rm -f Coverage/tmp/*.info Coverage/tmp/descriptions
     echo "Coverage report in: Coverage/index.html"
 }

--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -262,7 +262,7 @@ filter_ciphersuites()
 {
     if [ "X" != "X$FILTER" -o "X" != "X$EXCLUDE" ];
     then
-        # Ciphersuite for mbed TLS
+        # Ciphersuite for Mbed TLS
         M_CIPHERS=$( filter "$M_CIPHERS" )
 
         # Ciphersuite for OpenSSL
@@ -272,7 +272,7 @@ filter_ciphersuites()
         G_CIPHERS=$( filter "$G_CIPHERS" )
     fi
 
-    # For GnuTLS client -> mbed TLS server,
+    # For GnuTLS client -> Mbed TLS server,
     # we need to force IPv4 by connecting to 127.0.0.1 but then auth fails
     if is_dtls "$MODE" && [ "X$VERIFY" = "XYES" ]; then
         G_CIPHERS=""

--- a/tests/data_files/Makefile
+++ b/tests/data_files/Makefile
@@ -1,7 +1,7 @@
 ## This file contains a record of how some of the test data was
 ## generated. The final build products are committed to the repository
 ## as well to make sure that the test data is identical. You do not
-## need to use this makefile unless you're extending mbed TLS's tests.
+## need to use this makefile unless you're extending Mbed TLS's tests.
 
 ## Many data files were generated prior to the existence of this
 ## makefile, so the method of their generation was not recorded.

--- a/tests/scripts/basic-build-test.sh
+++ b/tests/scripts/basic-build-test.sh
@@ -43,7 +43,7 @@
 set -eu
 
 if [ -d library -a -d include -a -d tests ]; then :; else
-    echo "Must be run from mbed TLS root" >&2
+    echo "Must be run from Mbed TLS root" >&2
     exit 1
 fi
 

--- a/tests/scripts/check-doxy-blocks.pl
+++ b/tests/scripts/check-doxy-blocks.pl
@@ -68,7 +68,7 @@ sub check_dir {
 # Check that the script is being run from the project's root directory.
 for my $dir (@directories) {
     if (! -d $dir) {
-        die "This script must be run from the mbed TLS root directory";
+        die "This script must be run from the Mbed TLS root directory";
     } else {
         check_dir($dir)
     }

--- a/tests/scripts/check-generated-files.sh
+++ b/tests/scripts/check-generated-files.sh
@@ -35,7 +35,7 @@ EOF
 fi
 
 if [ -d library -a -d include -a -d tests ]; then :; else
-    echo "Must be run from mbed TLS root" >&2
+    echo "Must be run from Mbed TLS root" >&2
     exit 1
 fi
 

--- a/tests/scripts/doxygen.sh
+++ b/tests/scripts/doxygen.sh
@@ -21,7 +21,7 @@
 set -eu
 
 if [ -d library -a -d include -a -d tests ]; then :; else
-    echo "Must be run from mbed TLS root" >&2
+    echo "Must be run from Mbed TLS root" >&2
     exit 1
 fi
 

--- a/tests/scripts/generate-afl-tests.sh
+++ b/tests/scripts/generate-afl-tests.sh
@@ -41,7 +41,7 @@ THIS_DIR=$(basename $PWD)
 if [ -d ../library -a -d ../include -a -d ../tests -a $THIS_DIR == "tests" ];
 then :;
 else
-    echo " [!] Must be run from mbed TLS tests directory" >&2
+    echo " [!] Must be run from Mbed TLS tests directory" >&2
     exit 1
 fi
 

--- a/tests/suites/test_suite_ecp.function
+++ b/tests/suites/test_suite_ecp.function
@@ -166,7 +166,7 @@ void ecp_test_vect_restart(int id,
      * MBEDTLS_ECP_WINDOW_SIZE, as well as implementation details that may
      * change in the future. A factor 2 is a minimum safety margin.
      *
-     * For reference, with mbed TLS 2.4 and default settings, for P-256:
+     * For reference, with Mbed TLS 2.4 and default settings, for P-256:
      * - Random point mult:     ~3250M
      * - Cold base point mult:  ~3300M
      * - Hot base point mult:   ~1100M

--- a/tests/suites/test_suite_version.function
+++ b/tests/suites/test_suite_version.function
@@ -20,7 +20,7 @@ void check_compiletime_version(char *version_str)
     mbedtls_snprintf(build_str, 100, "%d.%d.%d", MBEDTLS_VERSION_MAJOR,
                      MBEDTLS_VERSION_MINOR, MBEDTLS_VERSION_PATCH);
 
-    mbedtls_snprintf(build_str_full, 100, "mbed TLS %d.%d.%d", MBEDTLS_VERSION_MAJOR,
+    mbedtls_snprintf(build_str_full, 100, "Mbed TLS %d.%d.%d", MBEDTLS_VERSION_MAJOR,
                      MBEDTLS_VERSION_MINOR, MBEDTLS_VERSION_PATCH);
 
     build_int = MBEDTLS_VERSION_MAJOR << 24 |
@@ -56,7 +56,7 @@ void check_runtime_version(char *version_str)
                      (get_int >> 24) & 0xFF,
                      (get_int >> 16) & 0xFF,
                      (get_int >> 8) & 0xFF);
-    mbedtls_snprintf(build_str_full, 100, "mbed TLS %s", version_str);
+    mbedtls_snprintf(build_str_full, 100, "Mbed TLS %s", version_str);
 
     TEST_ASSERT(strcmp(build_str, version_str) == 0);
     TEST_ASSERT(strcmp(build_str_full, get_str_full) == 0);

--- a/tests/suites/test_suite_x509parse.function
+++ b/tests/suites/test_suite_x509parse.function
@@ -619,7 +619,7 @@ void x509_verify_restart(char *crt_file, char *ca_file,
     /*
      * See comments on ecp_test_vect_restart() for op count precision.
      *
-     * For reference, with mbed TLS 2.6 and default settings:
+     * For reference, with Mbed TLS 2.6 and default settings:
      * - ecdsa_verify() for P-256:  ~  6700
      * - ecdsa_verify() for P-384:  ~ 18800
      * - x509_verify() for server5 -> test-ca2:             ~ 18800


### PR DESCRIPTION
* Update the spelling of "Mbed TLS". The official spelling used to be "mbed TLS" but changed a few years ago and we haven't caught up. Keep the old spelling in places where it can change things: where it gets embedded in test certificates, and in an imported file.
* Fix a bug in `bump_version.sh` (already noticed in the 3.4.0 release) that caused it to miss a file due to the spelling change.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required
- [x] **backport** https://github.com/Mbed-TLS/mbedtls/pull/8194
- [x] **tests** not required
