### PR TITLE
Make mbedtls_aesce_has_support more efficient

### DIFF
--- a/library/aes.c
+++ b/library/aes.c
@@ -653,7 +653,7 @@ int mbedtls_aes_setkey_enc(mbedtls_aes_context *ctx, const unsigned char *key,
 #endif
 
 #if defined(MBEDTLS_AESCE_C) && defined(MBEDTLS_HAVE_ARM64)
-    if (mbedtls_aesce_has_support()) {
+    if (MBEDTLS_AESCE_HAS_SUPPORT()) {
         return mbedtls_aesce_setkey_enc((unsigned char *) RK, key, keybits);
     }
 #endif
@@ -765,7 +765,7 @@ int mbedtls_aes_setkey_dec(mbedtls_aes_context *ctx, const unsigned char *key,
 #endif
 
 #if defined(MBEDTLS_AESCE_C) && defined(MBEDTLS_HAVE_ARM64)
-    if (mbedtls_aesce_has_support()) {
+    if (MBEDTLS_AESCE_HAS_SUPPORT()) {
         mbedtls_aesce_inverse_key(
             (unsigned char *) RK,
             (const unsigned char *) (cty.buf + cty.rk_offset),
@@ -1092,7 +1092,7 @@ int mbedtls_aes_crypt_ecb(mbedtls_aes_context *ctx,
 #endif
 
 #if defined(MBEDTLS_AESCE_C) && defined(MBEDTLS_HAVE_ARM64)
-    if (mbedtls_aesce_has_support()) {
+    if (MBEDTLS_AESCE_HAS_SUPPORT()) {
         return mbedtls_aesce_crypt_ecb(ctx, mode, input, output);
     }
 #endif
@@ -1911,7 +1911,7 @@ int mbedtls_aes_self_test(int verbose)
         } else
 #endif
 #if defined(MBEDTLS_AESCE_C) && defined(MBEDTLS_HAVE_ARM64)
-        if (mbedtls_aesce_has_support()) {
+        if (MBEDTLS_AESCE_HAS_SUPPORT()) {
             mbedtls_printf("  AES note: using AESCE.\n");
         } else
 #endif

--- a/library/aesce.c
+++ b/library/aesce.c
@@ -99,7 +99,7 @@
 #include <asm/hwcap.h>
 #include <sys/auxv.h>
 
-char mbedtls_aesce_has_support_result = 2;
+signed char mbedtls_aesce_has_support_result = -1;
 
 #if !defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
 /*
@@ -113,7 +113,7 @@ int mbedtls_aesce_has_support_impl(void)
      * It is possible that we could end up setting result more than
      * once, but that is harmless.
      */
-    if (mbedtls_aesce_has_support_result == 2) {
+    if (mbedtls_aesce_has_support_result == -1) {
         unsigned long auxval = getauxval(AT_HWCAP);
         if ((auxval & (HWCAP_ASIMD | HWCAP_AES)) ==
             (HWCAP_ASIMD | HWCAP_AES)) {

--- a/library/aesce.c
+++ b/library/aesce.c
@@ -94,27 +94,39 @@
 #endif /* !(__ARM_FEATURE_CRYPTO || __ARM_FEATURE_AES) ||
           MBEDTLS_ENABLE_ARM_CRYPTO_EXTENSIONS_COMPILER_FLAG */
 
-#if defined(__linux__)
+#if defined(__linux__) && !defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
+
 #include <asm/hwcap.h>
 #include <sys/auxv.h>
-#endif
+
+char mbedtls_aesce_has_support_result = 2;
 
 #if !defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
 /*
  * AES instruction support detection routine
  */
-int mbedtls_aesce_has_support(void)
+int mbedtls_aesce_has_support_impl(void)
 {
-#if defined(__linux__)
-    unsigned long auxval = getauxval(AT_HWCAP);
-    return (auxval & (HWCAP_ASIMD | HWCAP_AES)) ==
-           (HWCAP_ASIMD | HWCAP_AES);
-#else
-    /* Assume AES instructions are supported. */
-    return 1;
-#endif
+    /* To avoid many calls to getauxval, cache the result. This is
+     * thread-safe, because we store the result in a char so cannot
+     * be vulnerable to non-atomic updates.
+     * It is possible that we could end up setting result more than
+     * once, but that is harmless.
+     */
+    if (mbedtls_aesce_has_support_result == 2) {
+        unsigned long auxval = getauxval(AT_HWCAP);
+        if ((auxval & (HWCAP_ASIMD | HWCAP_AES)) ==
+            (HWCAP_ASIMD | HWCAP_AES)) {
+            mbedtls_aesce_has_support_result = 1;
+        } else {
+            mbedtls_aesce_has_support_result = 0;
+        }
+    }
+    return mbedtls_aesce_has_support_result;
 }
 #endif
+
+#endif /* defined(__linux__) && !defined(MBEDTLS_AES_USE_HARDWARE_ONLY) */
 
 /* Single round of AESCE encryption */
 #define AESCE_ENCRYPT_ROUND                   \

--- a/library/aesce.h
+++ b/library/aesce.h
@@ -44,7 +44,7 @@ extern "C" {
 
 #if defined(__linux__) && !defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
 
-extern char mbedtls_aesce_has_support_result;
+extern signed char mbedtls_aesce_has_support_result;
 
 /**
  * \brief          Internal function to detect the crypto extension in CPUs.
@@ -53,7 +53,7 @@ extern char mbedtls_aesce_has_support_result;
  */
 int mbedtls_aesce_has_support_impl(void);
 
-#define mbedtls_aesce_has_support() (mbedtls_aesce_has_support_result == 2 ? \
+#define mbedtls_aesce_has_support() (mbedtls_aesce_has_support_result == -1 ? \
                                      mbedtls_aesce_has_support_impl() : \
                                      mbedtls_aesce_has_support_result)
 

--- a/library/aesce.h
+++ b/library/aesce.h
@@ -53,7 +53,7 @@ extern signed char mbedtls_aesce_has_support_result;
  */
 int mbedtls_aesce_has_support_impl(void);
 
-#define mbedtls_aesce_has_support() (mbedtls_aesce_has_support_result == -1 ? \
+#define MBEDTLS_AESCE_HAS_SUPPORT() (mbedtls_aesce_has_support_result == -1 ? \
                                      mbedtls_aesce_has_support_impl() : \
                                      mbedtls_aesce_has_support_result)
 
@@ -62,7 +62,7 @@ int mbedtls_aesce_has_support_impl(void);
 /* If we are not on Linux, we can't detect support so assume that it's supported.
  * Similarly, assume support if MBEDTLS_AES_USE_HARDWARE_ONLY is set.
  */
-#define mbedtls_aesce_has_support() 1
+#define MBEDTLS_AESCE_HAS_SUPPORT() 1
 
 #endif /* defined(__linux__) && !defined(MBEDTLS_AES_USE_HARDWARE_ONLY) */
 

--- a/library/aesce.h
+++ b/library/aesce.h
@@ -42,17 +42,29 @@
 extern "C" {
 #endif
 
+#if defined(__linux__) && !defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
+
+extern char mbedtls_aesce_has_support_result;
+
 /**
  * \brief          Internal function to detect the crypto extension in CPUs.
  *
  * \return         1 if CPU has support for the feature, 0 otherwise
  */
-#if !defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
-int mbedtls_aesce_has_support(void);
-#else
-#define mbedtls_aesce_has_support() 1
-#endif
+int mbedtls_aesce_has_support_impl(void);
 
+#define mbedtls_aesce_has_support() (mbedtls_aesce_has_support_result == 2 ? \
+                                     mbedtls_aesce_has_support_impl() : \
+                                     mbedtls_aesce_has_support_result)
+
+#else /* defined(__linux__) && !defined(MBEDTLS_AES_USE_HARDWARE_ONLY) */
+
+/* If we are not on Linux, we can't detect support so assume that it's supported.
+ * Similarly, assume support if MBEDTLS_AES_USE_HARDWARE_ONLY is set.
+ */
+#define mbedtls_aesce_has_support() 1
+
+#endif /* defined(__linux__) && !defined(MBEDTLS_AES_USE_HARDWARE_ONLY) */
 
 /**
  * \brief          Internal AES-ECB block encryption and decryption

--- a/library/gcm.c
+++ b/library/gcm.c
@@ -98,7 +98,7 @@ static int gcm_gen_table(mbedtls_gcm_context *ctx)
 #endif
 
 #if defined(MBEDTLS_AESCE_C) && defined(MBEDTLS_HAVE_ARM64)
-    if (mbedtls_aesce_has_support()) {
+    if (MBEDTLS_AESCE_HAS_SUPPORT()) {
         return 0;
     }
 #endif
@@ -209,7 +209,7 @@ static void gcm_mult(mbedtls_gcm_context *ctx, const unsigned char x[16],
 #endif /* MBEDTLS_AESNI_HAVE_CODE */
 
 #if defined(MBEDTLS_AESCE_C) && defined(MBEDTLS_HAVE_ARM64)
-    if (mbedtls_aesce_has_support()) {
+    if (MBEDTLS_AESCE_HAS_SUPPORT()) {
         unsigned char h[16];
 
         /* mbedtls_aesce_gcm_mult needs big-endian input */
@@ -886,7 +886,7 @@ int mbedtls_gcm_self_test(int verbose)
 #endif
 
 #if defined(MBEDTLS_AESCE_C) && defined(MBEDTLS_HAVE_ARM64)
-        if (mbedtls_aesce_has_support()) {
+        if (MBEDTLS_AESCE_HAS_SUPPORT()) {
             mbedtls_printf("  GCM note: using AESCE.\n");
         } else
 #endif


### PR DESCRIPTION
## Description

`mbedtls_aesce_has_support()` is called a lot during AES - e.g., `selftest aes` calls it 120,000 times. Avoid calling `getauxval` every time. This improves the overall time to run `selftest aes` by 2.5%. `benchmark aes_ccm` shows an improvement of 4.4%.

**Gatekeeper notice**: Needs https://github.com/Mbed-TLS/mbedtls/pull/7384 to be merged first, [then CI should pass](https://github.com/Mbed-TLS/mbedtls/pull/8035#issuecomment-1665613398).

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required - covered by existing AES perf changelog
- [x] **backport** not required - not in 2.28
- [x] **tests** not required - covered by existing tests



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.
