### PR TITLE
Update links to Rijndael paper and NIST SP 800-90 DRBGs

### DIFF
--- a/library/aes.c
+++ b/library/aes.c
@@ -19,7 +19,7 @@
 /*
  *  The AES block cipher was designed by Vincent Rijmen and Joan Daemen.
  *
- *  http://csrc.nist.gov/encryption/aes/rijndael/Rijndael.pdf
+ *  https://csrc.nist.gov/csrc/media/projects/cryptographic-standards-and-guidelines/documents/aes-development/rijndael-ammended.pdf
  *  http://csrc.nist.gov/publications/fips/fips197/fips-197.pdf
  */
 

--- a/library/ctr_drbg.c
+++ b/library/ctr_drbg.c
@@ -19,7 +19,7 @@
 /*
  *  The NIST SP 800-90 DRBGs are described in the following publication.
  *
- *  http://csrc.nist.gov/publications/nistpubs/800-90/SP800-90revised_March2007.pdf
+ *  https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-90r.pdf
  */
 
 #include "common.h"


### PR DESCRIPTION
The link to the DRBG paper points to the March 2007 version, the same as the original link (rather than the latest version).

The amended Rijndael paper has a two-page "Note on naming" prefix.

Fixes #7193

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required - this is internal documentation
- [x] **backport** done in #8037
- [x] **tests** not required - this is internal documentation
