### PR TITLE
Remove redundant test component component_test_crypto_full_no_cipher

### DIFF
--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1507,30 +1507,6 @@ component_test_full_no_cipher () {
     make test
 }
 
-component_test_crypto_full_no_cipher () {
-    msg "build: crypto_full minus CIPHER"
-    scripts/config.py crypto_full
-    scripts/config.py unset MBEDTLS_CIPHER_C
-    # Direct dependencies
-    scripts/config.py unset MBEDTLS_CCM_C
-    scripts/config.py unset MBEDTLS_CMAC_C
-    scripts/config.py unset MBEDTLS_GCM_C
-    scripts/config.py unset MBEDTLS_NIST_KW_C
-    scripts/config.py unset MBEDTLS_PKCS12_C
-    scripts/config.py unset MBEDTLS_PKCS5_C
-    scripts/config.py unset MBEDTLS_PSA_CRYPTO_C
-    # Indirect dependencies
-    scripts/config.py unset MBEDTLS_PSA_CRYPTO_SE_C
-    scripts/config.py unset MBEDTLS_PSA_CRYPTO_STORAGE_C
-    scripts/config.py unset MBEDTLS_USE_PSA_CRYPTO
-    scripts/config.py unset MBEDTLS_LMS_C
-    scripts/config.py unset MBEDTLS_LMS_PRIVATE
-    make
-
-    msg "test: crypto_full minus CIPHER"
-    make test
-}
-
 component_test_full_no_bignum () {
     msg "build: full minus bignum"
     scripts/config.py full


### PR DESCRIPTION
[component_test_crypto_full_no_cipher doesn't bring any extra value given the existence of component_test_full_no_cipher](https://github.com/Mbed-TLS/mbedtls/pull/5794#discussion_r1289868953).

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required
- [x] **backport** N/A
- [x] **tests** N/A
