### PR TITLE
[G2] Tentative definition of Cipher light

### DIFF
--- a/docs/architecture/psa-migration/md-cipher-dispatch.md
+++ b/docs/architecture/psa-migration/md-cipher-dispatch.md
@@ -323,8 +323,6 @@ These problems are easily solvable.
 
 ### MD light
 
-https://github.com/Mbed-TLS/mbedtls/pull/6474 implements part of this specification, but it's based on Mbed TLS 3.2, so it needs to be rewritten for 3.3.
-
 #### Definition of MD light
 
 MD light is a subset of `md.h` that implements the hash calculation interface described in ”[Designing an interface for hashes](#designing-an-interface-for-hashes)”. It is activated by `MBEDTLS_MD_LIGHT` in `mbedtls_config.h`.
@@ -454,31 +452,7 @@ Note that this assumes that an operation that has been started via PSA can be co
 
 #### Error code conversion
 
-After calling a PSA function, call `mbedtls_md_error_from_psa` to convert its status code. This function is currently defined in `hash_info.c`.
-
-### Migration to MD light
-
-#### Migration of modules that used to call MD and now do the legacy-or-PSA dance
-
-Get rid of the case where `MBEDTLS_MD_C` is undefined. Enable `MBEDTLS_MD_LIGHT` in `build_info.h`.
-
-#### Migration of modules that used to call a low-level hash module and now do the legacy-or-PSA dance
-
-Switch to calling MD (light) unconditionally. Enable `MBEDTLS_MD_LIGHT` in `build_info.h`.
-
-#### Migration of modules that call a low-level hash module
-
-Switch to calling MD (light). Enable `MBEDTLS_MD_LIGHT` in `build_info.h`.
-
-#### Migration of use-PSA mixed code
-
-Instead of calling `hash_info.h` functions to obtain metadata, get it from `md.h`.
-
-Optionally, code that currently tests on `MBEDTLS_USE_PSA_CRYPTO` just to determine whether to call MD or PSA to calculate hashes can switch to just having the MD variant.
-
-#### Remove `legacy_or_psa.h`
-
-It's no longer used.
+After calling a PSA function, call `mbedtls_md_error_from_psa` to convert its status code.
 
 ### Support all legacy algorithms in PSA
 
@@ -516,10 +490,6 @@ static inline psa_algorithm_t psa_alg_of_md_info(
 ```
 
 Work in progress on this conversion is at https://github.com/gilles-peskine-arm/mbedtls/tree/hash-unify-ids-wip-1
-
-#### Get rid of the hash_info module
-
-The hash_info module is redundant with MD light. Move `mbedtls_md_error_from_psa` to `md.c`, defined only when `MBEDTLS_MD_SOME_PSA` is defined. The rest is no longer used.
 
 #### Unify HMAC with PSA
 

--- a/docs/architecture/psa-migration/md-cipher-dispatch.md
+++ b/docs/architecture/psa-migration/md-cipher-dispatch.md
@@ -358,7 +358,7 @@ The two AEAD modes, GCM and CCM, have very similar needs and positions in the st
 - CTR-DRBG holds a special position in the stack: most users don't care about it per se, they only care about getting random numbers - in fact PSA users don't even need to know what DRBG is used. In particular, no part of the stack is asking questions like "is CTR-DRBG-AES available?" - an RNG needs to be available and that's it - contrary to similar questions about AES-GCM etc. which are asked for example by TLS.
 
 So, it makes sense to use different designs for CTR-DRBG on one hand, and GCM/CCM on the other hand:
-- CTR-DRBG can just check if `AES_C` is present and "fall back" to PSA is not.
+- CTR-DRBG can just check if `AES_C` is present and "fall back" to PSA if not.
 - GCM and CCM need an common abstraction layer that allows:
   - Using AES, Aria or Camellia in a uniform way.
   - Dispatching to built-in or driver.
@@ -379,7 +379,7 @@ Those costs could be avoided by refactoring (parts of) Cipher, but that would pr
 - significant differences in how the `cipher.h` API is implemented between builds with the full Cipher or only a subset;
 - or more work to apply the simplifications to all of Cipher.
 
-Prototyping both approaches showed better code size savings and cleaner code with a new internal module.
+Prototyping both approaches showed better code size savings and cleaner code with a new internal module (see section "Internal "block cipher" abstraction (Cipher light)" below).
 
 ## Specification
 

--- a/docs/architecture/psa-migration/md-cipher-dispatch.md
+++ b/docs/architecture/psa-migration/md-cipher-dispatch.md
@@ -118,9 +118,11 @@ Hashes and HMAC (after the work on driver-only hashes):
 * ECDSA (HMAC\_DRBG; `md.h` exposed through API)
 * ECJPAKE (hashes via MD-light; `md.h` exposed through API)
 * MD (hashes and HMAC)
+* HKDF (HMAC via `md.h`; `md.h` exposed through API)
 * HMAC\_DRBG (hashes and HMAC via `md.h`; `md.h` exposed through API)
 * PKCS12 (hashes via MD-light)
 * PKCS5 (HMAC via `md.h`; `md.h` exposed through API)
+* PKCS7 (hashes via MD)
 * RSA (hash via MD-light for PSS and OAEP; `md.h` exposed through API)
 * PEM (MD5 hash via MD-light)
 

--- a/docs/architecture/psa-migration/md-cipher-dispatch.md
+++ b/docs/architecture/psa-migration/md-cipher-dispatch.md
@@ -110,23 +110,45 @@ For the purposes of this work, three domains emerge:
 
 #### Non-use-PSA modules
 
-The following modules in Mbed TLS call another module to perform cryptographic operations which, in the long term, will be provided through a PSA interface, but cannot make any PSA-related assumption:
+The following modules in Mbed TLS call another module to perform cryptographic operations which, in the long term, will be provided through a PSA interface, but cannot make any PSA-related assumption.
 
-* CCM (block cipher in ECB mode; interdependent with cipher)
-* cipher (cipher and AEAD algorithms)
-* CMAC (AES-ECB and DES-ECB, but could be extended to the other block ciphers; interdependent with cipher)
-* CTR\_DRBG (AES-ECB, but could be extended to the other block ciphers)
-* entropy (hashes via low-level)
+Hashes and HMAC (after the work on MD-light):
+
+* entropy (hashes via MD-light)
 * ECDSA (HMAC\_DRBG; `md.h` exposed through API)
-* ECJPAKE (hashes via md; `md.h` exposed through API)
-* GCM (block cipher in ECB mode; interdependent with cipher)
-* md (hashes and HMAC)
-* NIST\_KW (AES-ECB; interdependent with cipher)
+* ECJPAKE (hashes via MD-light; `md.h` exposed through API)
+* MD (hashes and HMAC)
 * HMAC\_DRBG (hashes and HMAC via `md.h`; `md.h` exposed through API)
-* PEM (AES and DES in CBC mode without padding; MD5 hash via low-level)
-* PKCS12 (cipher, generically, selected from ASN.1 or function parameters; hashes via md; `cipher.h` exposed through API)
-* PKCS5 (cipher, generically, selected from ASN.1; HMAC via `md.h`; `md.h` exposed through API)
-* RSA (hash via md for PSS and OAEP; `md.h` exposed through API)
+* PKCS12 (hashes via MD-light)
+* PKCS5 (HMAC via `md.h`; `md.h` exposed through API)
+* RSA (hash via MD-light for PSS and OAEP; `md.h` exposed through API)
+* PEM (MD5 hash via MD-light)
+
+Symmetric ciphers and AEADs (before Cipher-light work):
+
+* PEM (AES and DES in CBC mode without padding)
+       AES and DES: setkey_dec + crypt_cbc
+       (look at test data for DES)
+* PKCS12 (cipher, generically, selected from ASN.1 or function parameters; `cipher.h` exposed through API)
+       setup, setkey, set_iv, reset, update, finish (in sequence, once)
+       no documented restriction, block cipher in CBC mode in practice
+       (padding?)
+       (look at test cases)
+* PKCS5 (cipher, generically, selected from ASN.1)
+       only DES-CBC or 3DES-CBC
+       (padding?)
+       setup, setkey, crypt
+* CTR\_DRBG (AES-ECB, but could be extended to the other block ciphers)
+        setkey_enc + crypt_ecb
+* CCM (block cipher in ECB mode; interdependent with cipher)
+        info, setup, setkey, update (several times), (never finish)
+* CMAC (AES-ECB and DES-ECB, but could be extended to the other block ciphers; interdependent with cipher)
+        info, setup, setkey, update (several times), (never finish)
+* GCM (block cipher in ECB mode; interdependent with cipher)
+        info, setup, setkey, update (several times), (never finish)
+* NIST\_KW (AES-ECB; interdependent with cipher)
+        info, setup, setkey, update (several times), (never finish)
+* cipher (cipher and AEAD algorithms)
 
 ### Difficulties
 

--- a/docs/architecture/psa-migration/md-cipher-dispatch.md
+++ b/docs/architecture/psa-migration/md-cipher-dispatch.md
@@ -351,7 +351,7 @@ This excludes things like:
 
 ### Dual-dispatch for block cipher primitives
 
-Considering the priorities stated above, initially we want to support GCM, CCM and CTR-DRBG. All trhee of them use the block cipher primitive only in the encrypt direction. Currently, GCM and CCM use the Cipher layer in order to work with AES, Aria and Camellia (DES is excluded by the standards due to its smaller block size) and CTR-DRBG directly uses the low-level API from `aes.h`. In all cases, access to the "block cipher primitive" is done by using "ECB mode" (which for both Cipher and `aes.h` only allows a single block, contrary to PSA which implements actual ECB mode).
+Considering the priorities stated above, initially we want to support GCM, CCM and CTR-DRBG. All three of them use the block cipher primitive only in the encrypt direction. Currently, GCM and CCM use the Cipher layer in order to work with AES, Aria and Camellia (DES is excluded by the standards due to its smaller block size) and CTR-DRBG directly uses the low-level API from `aes.h`. In all cases, access to the "block cipher primitive" is done by using "ECB mode" (which for both Cipher and `aes.h` only allows a single block, contrary to PSA which implements actual ECB mode).
 
 The two AEAD modes, GCM and CCM, have very similar needs and positions in the stack, strongly suggesting using the same design for both. On the other hand, there are a number of differences between CTR-DRBG and them.
 - CTR-DRBG only uses AES (and there is no plan to extend it to other block ciphers at the moment), while GCM and CCM need to work with 3 block ciphers already.

--- a/docs/architecture/psa-migration/md-cipher-dispatch.md
+++ b/docs/architecture/psa-migration/md-cipher-dispatch.md
@@ -513,9 +513,9 @@ testing, based and what's needed by internal users of Cipher light. The new
 config symbol will not be considered public so its definition may change.
 
 Cipher light will be automatically enabled in `build_info.h` by modules that
-need it, namely: CTR\_DRBG, CCM, GCM. Note: CCM and GCM currently depend on
-the full `CIPHER_C` (enforced by `check_config.h`); this hard dependency would
-be replaced by the above auto-enablement.
+need it, namely: CCM, GCM. Note: CCM and GCM currently depend on the full
+`CIPHER_C` (enforced by `check_config.h`); this hard dependency would be
+replaced by the above auto-enablement.
 
 Cipher light includes:
 - info functions;
@@ -533,26 +533,20 @@ This excludes:
 The following API functions, and supporting types, are candidates for
 inclusion in the Cipher light API, with limited features as above:
 ```
-mbedtls_cipher_info_from_type
+mbedtls_cipher_info_from_values
 mbedtls_cipher_info_get_block_size
 
 mbedtls_cipher_init
 mbedtls_cipher_setup
 mbedtls_cipher_setkey
-mbedtls_cipher_crypt
 mbedtls_cipher_free
 
 mbedtls_cipher_update
-(mbedtls_cipher_finish)
 ```
 
 Note: `mbedtls_cipher_info_get_block_size()` can be hard-coded to return 16,
 as all three supported block ciphers have the same block size (DES was
 excluded).
-
-Note: `mbedtls_cipher_finish()` is not required by any of the modules using
-Cipher light, but it might be convenient to include it anyway as it's used in
-the implementation of `mbedtls_cipher_crypt()`.
 
 #### Cipher light dual dispatch
 

--- a/docs/architecture/psa-migration/md-cipher-dispatch.md
+++ b/docs/architecture/psa-migration/md-cipher-dispatch.md
@@ -499,3 +499,54 @@ The architecture can be extended to support `MBEDTLS_PSA_CRYPTO_CLIENT` with a l
 
 * Compile-time dependencies: instead of checking `defined(MBEDTLS_PSA_CRYPTO_C)`, check `defined(MBEDTLS_PSA_CRYPTO_C) || defined(MBEDTLS_PSA_CRYPTO_CLIENT)`.
 * Implementers of `MBEDTLS_PSA_CRYPTO_CLIENT` will need to provide `psa_can_do_hash()` (or a more general function `psa_can_do`) alongside `psa_crypto_init()`. Note that at this point, it will become a public interface, hence we won't be able to change it at a whim.
+
+### Cipher light
+
+#### Definition
+
+**Note:** this definition is tentative an may be refined when implementing and
+testing, based and what's needed by internal users of Cipher light.
+
+Cipher light will be automatically enabled in `build_info.h` by modules that
+need it. (Tentative list: PEM, PCKS12, PKCS5, CTR\_DRBG, CCM, CMAC, GCM,
+NIS\_KW, PSA Crypto.) Note: some of these modules currently depend on the
+full `CIPHER_C` (enforced by `check_config.h`); this hard dependency would be
+replace by the above auto-enablement.
+
+Cipher light includes:
+- info functions;
+- support for block ciphers in ECB mode (to be confirmed: supporting one block
+  at a time could be enough);
+- support for block ciphers in CBC mode with no padding (to be confirmed: do
+  we need a padding mode?);
+- support for both the "one-shot" and "streaming" APIs for block ciphers.
+
+This excludes:
+- the AEAD/KW API (both one-shot and streaming);
+- support for stream ciphers;
+- support for other modes of block ciphers (CTR, CFB, etc.);
+- support for (other) padding modes of CBC.
+
+The following API functions, and supporting types, are candidates for
+inclusion in the Cipher light API, with limited features as above:
+```
+mbedtls_cipher_info_from_psa
+mbedtls_cipher_info_from_type
+mbedtls_cipher_info_from_values
+
+mbedtls_cipher_info_get_block_size
+mbedtls_cipher_info_get_iv_size
+mbedtls_cipher_info_get_key_bitlen
+
+mbedtls_cipher_init
+mbedtls_cipher_setup
+mbedtls_cipher_setkey
+mbedtls_cipher_set_padding_mode
+mbedtls_cipher_crypt
+mbedtls_cipher_free
+
+mbedtls_cipher_set_iv
+mbedtls_cipher_reset
+mbedtls_cipher_update
+mbedtls_cipher_finish
+```

--- a/docs/architecture/psa-migration/md-cipher-dispatch.md
+++ b/docs/architecture/psa-migration/md-cipher-dispatch.md
@@ -518,13 +518,14 @@ need it, namely: CCM, GCM. Note: CCM and GCM currently depend on the full
 replaced by the above auto-enablement.
 
 Cipher light includes:
-- info functions;
+- some info functions;
 - support for block ciphers in ECB mode, encrypt only (note: in Cipher, "ECB"
   means just one block, contrary to PSA);
-- the one-shot API as well as (part of) the streaming API;
+- part of the streaming API for unauthenticated ciphers;
 - only AES, Aria and Camellia.
 
 This excludes:
+- the one-shot API for unauthenticated ciphers;
 - the AEAD/KW API (both one-shot and streaming);
 - support for stream ciphers;
 - support for other modes of block ciphers (CBC, CTR, CFB, etc.);

--- a/docs/architecture/psa-migration/md-cipher-dispatch.md
+++ b/docs/architecture/psa-migration/md-cipher-dispatch.md
@@ -537,48 +537,51 @@ The architecture can be extended to support `MBEDTLS_PSA_CRYPTO_CLIENT` with a l
 #### Definition
 
 **Note:** this definition is tentative an may be refined when implementing and
-testing, based and what's needed by internal users of Cipher light.
+testing, based and what's needed by internal users of Cipher light. The new
+config symbol will not be considered public so its definition may change.
 
 Cipher light will be automatically enabled in `build_info.h` by modules that
-need it. (Tentative list: PEM, PCKS12, PKCS5, CTR\_DRBG, CCM, CMAC, GCM,
-NIS\_KW, PSA Crypto.) Note: some of these modules currently depend on the
-full `CIPHER_C` (enforced by `check_config.h`); this hard dependency would be
-replace by the above auto-enablement.
+need it, namely: CTR\_DRBG, CCM, GCM. Note: CCM and GCM currently depend on
+the full `CIPHER_C` (enforced by `check_config.h`); this hard dependency would
+be replaced by the above auto-enablement.
 
 Cipher light includes:
 - info functions;
-- support for block ciphers in ECB mode (to be confirmed: supporting one block
-  at a time could be enough);
-- support for block ciphers in CBC mode with no padding (to be confirmed: do
-  we need a padding mode?);
-- support for both the "one-shot" and "streaming" APIs for block ciphers.
+- support for block ciphers in ECB mode, encrypt only (note: in Cipher, "ECB"
+  means just one block, contrary to PSA);
+- the one-shot API as well as (part of) the streaming API;
+- only AES, Aria and Camellia.
 
 This excludes:
 - the AEAD/KW API (both one-shot and streaming);
 - support for stream ciphers;
-- support for other modes of block ciphers (CTR, CFB, etc.);
-- support for (other) padding modes of CBC.
+- support for other modes of block ciphers (CBC, CTR, CFB, etc.);
+- DES and variants (3DES).
 
 The following API functions, and supporting types, are candidates for
 inclusion in the Cipher light API, with limited features as above:
 ```
-mbedtls_cipher_info_from_psa
 mbedtls_cipher_info_from_type
-mbedtls_cipher_info_from_values
-
 mbedtls_cipher_info_get_block_size
-mbedtls_cipher_info_get_iv_size
-mbedtls_cipher_info_get_key_bitlen
 
 mbedtls_cipher_init
 mbedtls_cipher_setup
 mbedtls_cipher_setkey
-mbedtls_cipher_set_padding_mode
 mbedtls_cipher_crypt
 mbedtls_cipher_free
 
-mbedtls_cipher_set_iv
-mbedtls_cipher_reset
 mbedtls_cipher_update
-mbedtls_cipher_finish
+(mbedtls_cipher_finish)
 ```
+
+Note: `mbedtls_cipher_info_get_block_size()` can be hard-coded to return 16,
+as all three supported block ciphers have the same block size (DES was
+excluded).
+
+Note: `mbedtls_cipher_finish()` is not required by any of the modules using
+Cipher light, but it might be convenient to include it anyway as it's used in
+the implementation of `mbedtls_cipher_crypt()`.
+
+#### Cipher light dual dispatch
+
+This is likely to come in the future, but has not been defined yet.


### PR DESCRIPTION
A quick study of what other modules in the library are using, and a tentative definition of Cipher light based on that.

Note: X.509 never uses ciphers/AEADs directly, and when `USE_PSA_CRYPTO` is enabled, TLS doesn't use any function from `cipher.h` (even less low-level ciphers/AEADs APIs).

## PR checklist

- [x] **changelog** not required - documentation only
- [x] **backport** not required - documentation for a new feature
- [x] **tests** not required - documentation only

