### PR TITLE
pkwrite: use heap to save stack usage for writing keys in PEM string

### DIFF
--- a/ChangeLog.d/pkwrite-pem-use-heap.txt
+++ b/ChangeLog.d/pkwrite-pem-use-heap.txt
@@ -1,4 +1,4 @@
 Changes
-   * Use heap memory to allocate DER encoded RSA public/private key.
+   * Use heap memory to allocate DER encoded public/private key.
      This reduces stack usage significantly for writing a public/private
      key to a PEM string.

--- a/ChangeLog.d/pkwrite-pem-use-heap.txt
+++ b/ChangeLog.d/pkwrite-pem-use-heap.txt
@@ -1,0 +1,4 @@
+Changes
+   * Use heap memory to allocate DER encoded RSA public/private key.
+     This reduces stack usage significantly for writing a public/private
+     key to a PEM string.

--- a/library/pkwrite.c
+++ b/library/pkwrite.c
@@ -860,7 +860,7 @@ int mbedtls_pk_write_key_pem(const mbedtls_pk_context *key, unsigned char *buf, 
 
     ret = 0;
 cleanup:
-    mbedtls_free(output_buf);
+    mbedtls_zeroize_and_free(output_buf, PRV_DER_MAX_BYTES);
     return ret;
 }
 #endif /* MBEDTLS_PEM_WRITE_C */

--- a/library/pkwrite.c
+++ b/library/pkwrite.c
@@ -786,7 +786,11 @@ int mbedtls_pk_write_pubkey_pem(const mbedtls_pk_context *key, unsigned char *bu
 int mbedtls_pk_write_key_pem(const mbedtls_pk_context *key, unsigned char *buf, size_t size)
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
-    unsigned char output_buf[PRV_DER_MAX_BYTES];
+    unsigned char *output_buf = NULL;
+    output_buf = calloc(1, PRV_DER_MAX_BYTES);
+    if (output_buf == NULL) {
+        return MBEDTLS_ERR_PK_ALLOC_FAILED;
+    }
     const char *begin, *end;
     size_t olen = 0;
 #if defined(MBEDTLS_PK_HAVE_ECC_KEYS)
@@ -799,7 +803,8 @@ int mbedtls_pk_write_key_pem(const mbedtls_pk_context *key, unsigned char *buf, 
     int is_rsa_opaque = 0;
 #endif
 
-    if ((ret = mbedtls_pk_write_key_der(key, output_buf, sizeof(output_buf))) < 0) {
+    if ((ret = mbedtls_pk_write_key_der(key, output_buf, PRV_DER_MAX_BYTES)) < 0) {
+        free(output_buf);
         return ret;
     }
 
@@ -843,14 +848,19 @@ int mbedtls_pk_write_key_pem(const mbedtls_pk_context *key, unsigned char *buf, 
         }
     } else
 #endif /* MBEDTLS_PK_HAVE_ECC_KEYS */
-    return MBEDTLS_ERR_PK_FEATURE_UNAVAILABLE;
+    {
+        free(output_buf);
+        return MBEDTLS_ERR_PK_FEATURE_UNAVAILABLE;
+    }
 
     if ((ret = mbedtls_pem_write_buffer(begin, end,
-                                        output_buf + sizeof(output_buf) - ret,
+                                        output_buf + PRV_DER_MAX_BYTES - ret,
                                         ret, buf, size, &olen)) != 0) {
+        free(output_buf);
         return ret;
     }
 
+    free(output_buf);
     return 0;
 }
 #endif /* MBEDTLS_PEM_WRITE_C */

--- a/library/pkwrite.c
+++ b/library/pkwrite.c
@@ -768,19 +768,19 @@ int mbedtls_pk_write_pubkey_pem(const mbedtls_pk_context *key, unsigned char *bu
 
     if ((ret = mbedtls_pk_write_pubkey_der(key, output_buf,
                                            PUB_DER_MAX_BYTES)) < 0) {
-        free(output_buf);
-        return ret;
+        goto cleanup;
     }
 
     if ((ret = mbedtls_pem_write_buffer(PEM_BEGIN_PUBLIC_KEY, PEM_END_PUBLIC_KEY,
                                         output_buf + PUB_DER_MAX_BYTES - ret,
                                         ret, buf, size, &olen)) != 0) {
-        free(output_buf);
-        return ret;
+        goto cleanup;
     }
 
+    ret = 0;
+cleanup:
     free(output_buf);
-    return 0;
+    return ret;
 }
 
 int mbedtls_pk_write_key_pem(const mbedtls_pk_context *key, unsigned char *buf, size_t size)
@@ -804,8 +804,7 @@ int mbedtls_pk_write_key_pem(const mbedtls_pk_context *key, unsigned char *buf, 
 #endif
 
     if ((ret = mbedtls_pk_write_key_der(key, output_buf, PRV_DER_MAX_BYTES)) < 0) {
-        free(output_buf);
-        return ret;
+        goto cleanup;
     }
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
@@ -849,19 +848,20 @@ int mbedtls_pk_write_key_pem(const mbedtls_pk_context *key, unsigned char *buf, 
     } else
 #endif /* MBEDTLS_PK_HAVE_ECC_KEYS */
     {
-        free(output_buf);
-        return MBEDTLS_ERR_PK_FEATURE_UNAVAILABLE;
+        ret = MBEDTLS_ERR_PK_FEATURE_UNAVAILABLE;
+        goto cleanup;
     }
 
     if ((ret = mbedtls_pem_write_buffer(begin, end,
                                         output_buf + PRV_DER_MAX_BYTES - ret,
                                         ret, buf, size, &olen)) != 0) {
-        free(output_buf);
-        return ret;
+        goto cleanup;
     }
 
+    ret = 0;
+cleanup:
     free(output_buf);
-    return 0;
+    return ret;
 }
 #endif /* MBEDTLS_PEM_WRITE_C */
 

--- a/library/pkwrite.c
+++ b/library/pkwrite.c
@@ -760,7 +760,7 @@ int mbedtls_pk_write_pubkey_pem(const mbedtls_pk_context *key, unsigned char *bu
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     unsigned char *output_buf = NULL;
-    output_buf = calloc(1, PUB_DER_MAX_BYTES);
+    output_buf = mbedtls_calloc(1, PUB_DER_MAX_BYTES);
     if (output_buf == NULL) {
         return MBEDTLS_ERR_PK_ALLOC_FAILED;
     }
@@ -779,7 +779,7 @@ int mbedtls_pk_write_pubkey_pem(const mbedtls_pk_context *key, unsigned char *bu
 
     ret = 0;
 cleanup:
-    free(output_buf);
+    mbedtls_free(output_buf);
     return ret;
 }
 
@@ -787,7 +787,7 @@ int mbedtls_pk_write_key_pem(const mbedtls_pk_context *key, unsigned char *buf, 
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     unsigned char *output_buf = NULL;
-    output_buf = calloc(1, PRV_DER_MAX_BYTES);
+    output_buf = mbedtls_calloc(1, PRV_DER_MAX_BYTES);
     if (output_buf == NULL) {
         return MBEDTLS_ERR_PK_ALLOC_FAILED;
     }
@@ -860,7 +860,7 @@ int mbedtls_pk_write_key_pem(const mbedtls_pk_context *key, unsigned char *buf, 
 
     ret = 0;
 cleanup:
-    free(output_buf);
+    mbedtls_free(output_buf);
     return ret;
 }
 #endif /* MBEDTLS_PEM_WRITE_C */

--- a/library/pkwrite.c
+++ b/library/pkwrite.c
@@ -759,20 +759,27 @@ int mbedtls_pk_write_key_der(const mbedtls_pk_context *key, unsigned char *buf, 
 int mbedtls_pk_write_pubkey_pem(const mbedtls_pk_context *key, unsigned char *buf, size_t size)
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
-    unsigned char output_buf[PUB_DER_MAX_BYTES];
+    unsigned char *output_buf = NULL;
+    output_buf = calloc(1, PUB_DER_MAX_BYTES);
+    if (output_buf == NULL) {
+        return MBEDTLS_ERR_PK_ALLOC_FAILED;
+    }
     size_t olen = 0;
 
     if ((ret = mbedtls_pk_write_pubkey_der(key, output_buf,
-                                           sizeof(output_buf))) < 0) {
+                                           PUB_DER_MAX_BYTES)) < 0) {
+        free(output_buf);
         return ret;
     }
 
     if ((ret = mbedtls_pem_write_buffer(PEM_BEGIN_PUBLIC_KEY, PEM_END_PUBLIC_KEY,
-                                        output_buf + sizeof(output_buf) - ret,
+                                        output_buf + PUB_DER_MAX_BYTES - ret,
                                         ret, buf, size, &olen)) != 0) {
+        free(output_buf);
         return ret;
     }
 
+    free(output_buf);
     return 0;
 }
 


### PR DESCRIPTION
## Description

Similar to #7991 , in `mbedtls_pk_write_pubkey_pem` and `mbedtls_pk_write_key_pem`, we would allocate `2086` and `5679` respectively for a RSA public/private key. We can use heap to save stack usage a lot.

Saves of stack usage (measured by 0882828 with `default config` on `x86_64`):
| Function | Old Size | New Size | Change (Bytes) |
| :--- | ---: |  ---: |  ---: |
| mbedtls_pk_write_pubkey_pem | 2176 | 96 | -2080 |
| mbedtls_pk_write_key_pem | 5808 | 128 | -5680 |

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** provided
- [x] **backport** https://github.com/Mbed-TLS/mbedtls/pull/8162
- [x] **tests** not required