### PR TITLE
Fix potential corruption of IV for AES CBC with zero length

### DIFF
--- a/ChangeLog.d/fix-aes-cbc-iv-corruption
+++ b/ChangeLog.d/fix-aes-cbc-iv-corruption
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix a potential corruption of the passed-in IV when mbedtls_aes_crypt_cbc()
+     is called with zero length and padlock is not enabled.

--- a/library/aes.c
+++ b/library/aes.c
@@ -1094,6 +1094,11 @@ int mbedtls_aes_crypt_cbc(mbedtls_aes_context *ctx,
         return MBEDTLS_ERR_AES_BAD_INPUT_DATA;
     }
 
+    /* Nothing to do if length is zero. */
+    if (length == 0) {
+        return 0;
+    }
+
     if (length % 16) {
         return MBEDTLS_ERR_AES_INVALID_INPUT_LENGTH;
     }


### PR DESCRIPTION
## Description

If passed a zero length, AES CBC could potentially corrupt the passed in IV by memcpying it over itself. Although this might be ok with some more recent compilers, its not for every compiler we support. Found by coverity.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** provided ~~, or not required~~
- [x] **backport** ~~done, or~~ not required (Bug does not exist in 2.28)
- [x] **tests** ~~provided, or~~ not required
