### PR TITLE
Fix resource leak in bignum test failure case

### DIFF
--- a/tests/suites/test_suite_bignum_mod.function
+++ b/tests/suites/test_suite_bignum_mod.function
@@ -737,5 +737,6 @@ exit:
     mbedtls_free(R);
     mbedtls_free(R_COPY);
     mbedtls_free(obuf);
+    mbedtls_free(ref_buf);
 }
 /* END_CASE */


### PR DESCRIPTION
## Description

If any of the tests inside the loop were to fail, execution would jump to exit, and ref_buf would be leaked. Found by Coverity.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** ~~provided, or~~ not required (Tests)
- [x] **backport** ~~done, or~~ not required (test suite does not exist in 2.28)
- [x] **tests** ~~provided, or~~ not required (its a fix to a current test)

