### PR TITLE
Fix TLS pad buffer zeroization

### DIFF
--- a/ChangeLog.d/fix-tls-padbuf-zeroization
+++ b/ChangeLog.d/fix-tls-padbuf-zeroization
@@ -1,0 +1,4 @@
+Security
+   * Fix a case where potentially sensitive information held in memory would not
+     be completely zeroized during TLS 1.2 handshake, in both server and client
+     configurations.

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -7722,7 +7722,7 @@ static int ssl_calc_finished_tls_generic(mbedtls_ssl_context *ssl, void *ctx,
 
     MBEDTLS_SSL_DEBUG_BUF(3, "calc finished result", buf, len);
 
-    mbedtls_platform_zeroize(padbuf, sizeof(padbuf));
+    mbedtls_platform_zeroize(padbuf, hlen);
 
     MBEDTLS_SSL_DEBUG_MSG(2, ("<= calc finished"));
 


### PR DESCRIPTION
## Description

Fix an issue whereby the pad buffer was not completely zeroized in some cases during TLS handshake.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** provided ~~, or not required~~
- [x] **backport** ~~done, or~~ not required - code does not exist in 2.28
- [ ] **tests** ~~provided, or~~ not required - not something that is easily testable, XXX err, actually see #8143
