### PR TITLE
Fix logical dead code found by Coverity

### DIFF
--- a/library/psa_crypto_pake.c
+++ b/library/psa_crypto_pake.c
@@ -178,12 +178,12 @@ psa_status_t mbedtls_psa_pake_setup(mbedtls_psa_pake_operation_t *operation,
         return status;
     }
 
-    psa_crypto_driver_pake_get_user_len(inputs, &user_len);
+    status = psa_crypto_driver_pake_get_user_len(inputs, &user_len);
     if (status != PSA_SUCCESS) {
         return status;
     }
 
-    psa_crypto_driver_pake_get_peer_len(inputs, &peer_len);
+    status = psa_crypto_driver_pake_get_peer_len(inputs, &peer_len);
     if (status != PSA_SUCCESS) {
         return status;
     }


### PR DESCRIPTION
## Description

I'm not entirely sure what happened here, and the last person to touch this code is not around to ask anymore, so I am opening this to attract opinion as much as anything.

I'm also not entirely happy with this - whilst I fixed the dead code issue, I am presuming here that these errors do not require the calling of `mbedtls_psa_pake_abort()`, which I have to say I am unsure about.

Given we are clearly not testing these paths, should we be?

I'm going to be away, but wanted to get this out here - feel free to take over this PR, if you wish, otherwise I will continue with it on return.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** ~~provided, or~~ not required (Minor change, I think)
- [x] **backport** ~~done, or~~ not required (code does not exist in 2.28)
- [ ] **tests** provided, or not required (?)
