### PR TITLE
Fix compile fail for empty enum in cipher_wrap

### DIFF
--- a/ChangeLog.d/fix-empty-enum.txt
+++ b/ChangeLog.d/fix-empty-enum.txt
@@ -1,3 +1,3 @@
 Bugfix
-   * Fix compile failure due to empty enum in cipher_wrap.o, when building
+   * Fix compile failure due to empty enum in cipher_wrap.c, when building
      with a very minimal configuration. Fixes #7625.

--- a/ChangeLog.d/fix-empty-enum.txt
+++ b/ChangeLog.d/fix-empty-enum.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix compile failure due to empty enum in cipher_wrap.o, when building
+     with a very minimal configuration. Fixes #7625.

--- a/library/cipher_wrap.c
+++ b/library/cipher_wrap.c
@@ -120,8 +120,10 @@ enum mbedtls_cipher_base_index {
     MBEDTLS_CIPHER_BASE_INDEX_NULL_BASE,
 #endif
 #if defined(MBEDTLS_CIPHER_MODE_XTS) && defined(MBEDTLS_AES_C)
-    MBEDTLS_CIPHER_BASE_INDEX_XTS_AES
+    MBEDTLS_CIPHER_BASE_INDEX_XTS_AES,
 #endif
+    /* Prevent compile failure due to empty enum */
+    MBEDTLS_PREVENT_EMPTY_ENUM
 };
 
 #if defined(MBEDTLS_GCM_C)

--- a/library/cipher_wrap.c
+++ b/library/cipher_wrap.c
@@ -123,7 +123,7 @@ enum mbedtls_cipher_base_index {
     MBEDTLS_CIPHER_BASE_INDEX_XTS_AES,
 #endif
     /* Prevent compile failure due to empty enum */
-    MBEDTLS_PREVENT_EMPTY_ENUM
+    MBEDTLS_CIPHER_BASE_PREVENT_EMPTY_ENUM
 };
 
 #if defined(MBEDTLS_GCM_C)


### PR DESCRIPTION
## Description

Fix compile fail for minimal configurations. Fixes #7625

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** done
- [x] **backport** 2.28 isn't affected
- [x] **tests** not required - covered by existing
