### PR TITLE
Test with ECC and FFDH accelerated and no bignum

### DIFF
--- a/docs/driver-only-builds.md
+++ b/docs/driver-only-builds.md
@@ -105,7 +105,7 @@ size saving.
 
 [Coming soon] As noted in the "Limitations regarding the selection of curves"
 section below, there is an upcoming requirement for all the required curves to
-be also accelerated in the PSA driver in order to exclude the builtin algs
+also be accelerated in the PSA driver in order to exclude the builtin algs
 support.
 
 ### Limitations regarding fully removing `ecp.c`
@@ -146,8 +146,8 @@ timeline, please let us know if you're interested.
 ### Limitations regarding the selection of curves
 
 There is an ongoing work which tries to establish a link/constrain between
-the list of supported curves and supported algorithms both in builtin and PSA
-sides. In particular:
+the list of supported curves and supported algorithms both in the builtin and
+PSA sides. In particular:
 
 - #8014 ensures that the curves supported on the PSA side (`PSA_WANT_ECC_xxx`)
   are always a superset of the builtin ones (`MBEDTLS_ECP_DP_xxx`)
@@ -170,7 +170,7 @@ Key management and usage can be enabled by means of the usual `PSA_WANT` +
 - `[PSA_WANT|MBEDTLS_PSA_ACCEL]_KEY_TYPE_DH_KEY_PAIR_GENERATE`;
 
 The same holds for the associated algorithm:
-`[PSA_WANT|MBEDTLS_PSA_ACCEL]_ALG_FFDH` allow to build accelerating FFDH and
+`[PSA_WANT|MBEDTLS_PSA_ACCEL]_ALG_FFDH` allow builds accelerating FFDH and
 removing builtin support (i.e. `MBEDTLS_DHM_C`).
 
 ### Limitations

--- a/docs/driver-only-builds.md
+++ b/docs/driver-only-builds.md
@@ -76,10 +76,6 @@ TODO
 Elliptic-curve cryptography (ECC)
 ---------------------------------
 
-Note: things are still evolving. This section describes the situation right
-after #7452 has been merged. It will be updated again in #7757 when bignum is
-done.
-
 It is possible to have most ECC operations provided only by a driver:
 - the ECDH, ECDSA and EC J-PAKE algorithms;
 - key import, export, and random generation.
@@ -106,6 +102,11 @@ without `MBEDTLS_ECP_C` provided the corresponding
 "Limitations regarding fully removing `ecp.c`" below), and you're not using
 RSA or FFDH, then you can also disable `MBEDTLS_BIGNUM_C` for further code
 size saving.
+
+[Coming soon] As noted in the "Limitations regarding the selection of curves"
+section below, there is an upcoming requirement for all the required curves to
+be also accelerated in the PSA driver in order to exclude the builtin algs
+support.
 
 ### Limitations regarding fully removing `ecp.c`
 
@@ -144,10 +145,34 @@ timeline, please let us know if you're interested.
 
 ### Limitations regarding the selection of curves
 
-TODO: apparently we don't really support having some curves built-in and
-others driver-only... investigate and describe the situation. See also #7899.
+There is an ongoing work which tries to establish a link/constrain between
+the list of supported curves and supported algorithms both in builtin and PSA
+sides. In particular:
+
+- #8014 ensures that the curves supported on the PSA side (`PSA_WANT_ECC_xxx`)
+  are always a superset of the builtin ones (`MBEDTLS_ECP_DP_xxx`)
+- #8016 forces builtin alg support as soon as there is at least one builtin
+  curve. In other words, in order to exclue all builtin algs, all the required
+  curves should be supported and accelerated by the PSA driver.
 
 Finite-field Diffie-Hellman
 ---------------------------
 
-TODO
+Support is pretty similar to the "Elliptic-curve cryptography (ECC)" section
+above.
+Key management and usage can be enabled by means of the usual `PSA_WANT` +
+`MBEDTLS_PSA_ACCEL` pairs:
+
+- `[PSA_WANT|MBEDTLS_PSA_ACCEL]_KEY_TYPE_DH_PUBLIC_KEY`;
+- `[PSA_WANT|MBEDTLS_PSA_ACCEL]_KEY_TYPE_DH_KEY_PAIR_BASIC`;
+- `[PSA_WANT|MBEDTLS_PSA_ACCEL]_KEY_TYPE_DH_KEY_PAIR_IMPORT`;
+- `[PSA_WANT|MBEDTLS_PSA_ACCEL]_KEY_TYPE_DH_KEY_PAIR_EXPORT`;
+- `[PSA_WANT|MBEDTLS_PSA_ACCEL]_KEY_TYPE_DH_KEY_PAIR_GENERATE`;
+
+The same holds for the associated algorithm:
+`[PSA_WANT|MBEDTLS_PSA_ACCEL]_ALG_FFDH` allow to build accelerating FFDH and
+removing builtin support (i.e. `MBEDTLS_DHM_C`).
+
+### Limitations
+Support for deterministic derivation of a DH keypair
+(i.e. `PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_DERIVE`) is not supported.

--- a/docs/driver-only-builds.md
+++ b/docs/driver-only-builds.md
@@ -145,9 +145,9 @@ timeline, please let us know if you're interested.
 
 ### Limitations regarding the selection of curves
 
-There is an ongoing work which tries to establish a link/constrain between
-the list of supported curves and supported algorithms both in the builtin and
-PSA sides. In particular:
+There is ongoing work which is trying to establish the links and constraints
+between the list of supported curves and supported algorithms both in the
+builtin and PSA sides. In particular:
 
 - #8014 ensures that the curves supported on the PSA side (`PSA_WANT_ECC_xxx`)
   are always a superset of the builtin ones (`MBEDTLS_ECP_DP_xxx`)

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -2622,16 +2622,29 @@ component_test_psa_crypto_config_reference_ecc_no_ecp_at_all () {
     tests/ssl-opt.sh
 }
 
-# This function is really similar to config_psa_crypto_no_ecp_at_all() above so
-# its description is basically the same. The main difference in this case is
-# that when the EC built-in implementation is disabled, then also Bignum module
-# and its dependencies are disabled as well.
-#
-# This is the common helper between:
+# This is a common configuration helper used directly from:
+# - common_test_psa_crypto_config_accel_ecc_ffdh_no_bignum
+# - common_test_psa_crypto_config_reference_ecc_ffdh_no_bignum
+# and indirectly from:
 # - component_test_psa_crypto_config_accel_ecc_no_bignum
+#       - accelerate all EC algs, disable RSA and FFDH
 # - component_test_psa_crypto_config_reference_ecc_no_bignum
-config_psa_crypto_config_accel_ecc_no_bignum() {
+#       - this is the reference component of the above
+#       - it still disables RSA and FFDH, but it uses builtin EC algs
+# - component_test_psa_crypto_config_accel_ecc_ffdh_no_bignum
+#       - accelerate all EC and FFDH algs, disable only RSA
+# - component_test_psa_crypto_config_reference_ecc_ffdh_no_bignum
+#       - this is the reference component of the above
+#       - it still disables RSA, but it uses builtin EC and FFDH algs
+#
+# This function accepts 2 parameters:
+# $1: it is a boolean values which states if we are testing an accelerated
+#     scenario or not.
+# $2: it is a string value which states which are the tested components. Allowed
+#     values are "ECC" or "ECC_DH".
+config_psa_crypto_config_accel_ecc_ffdh_no_bignum() {
     DRIVER_ONLY="$1"
+    TEST_TARGET="$2"
     # start with full config for maximum coverage (also enables USE_PSA)
     helper_libtestdriver1_adjust_config "full"
 
@@ -2666,13 +2679,23 @@ config_psa_crypto_config_accel_ecc_no_bignum() {
     scripts/config.py unset MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED
     scripts/config.py unset MBEDTLS_KEY_EXCHANGE_ECDH_RSA_ENABLED
 
-    # Disable FFDH because it also depends on BIGNUM.
-    scripts/config.py -f include/psa/crypto_config.h unset PSA_WANT_ALG_FFDH
-    scripts/config.py -f "$CRYPTO_CONFIG_H" unset-all "PSA_WANT_KEY_TYPE_DH_[0-9A-Z_a-z]*"
-    scripts/config.py unset MBEDTLS_DHM_C
-    # Also disable key exchanges that depend on FFDH
-    scripts/config.py unset MBEDTLS_KEY_EXCHANGE_DHE_PSK_ENABLED
-    scripts/config.py unset MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED
+    if [ "$TEST_TARGET" = "ECC" ]; then
+        # When testing ECC only, we disable FFDH support, both from builtin and
+        # PSA sides, and also disable the key exchanges that depend on DHM.
+        scripts/config.py -f include/psa/crypto_config.h unset PSA_WANT_ALG_FFDH
+        scripts/config.py -f "$CRYPTO_CONFIG_H" unset-all "PSA_WANT_KEY_TYPE_DH_[0-9A-Z_a-z]*"
+        scripts/config.py unset MBEDTLS_DHM_C
+        scripts/config.py unset MBEDTLS_KEY_EXCHANGE_DHE_PSK_ENABLED
+        scripts/config.py unset MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED
+    else
+        # When testing ECC and DH instead, we disable DHM and depending key
+        # exchanges only in the accelerated build
+        if [ "$DRIVER_ONLY" -eq 1 ]; then
+            scripts/config.py unset MBEDTLS_DHM_C
+            scripts/config.py unset MBEDTLS_KEY_EXCHANGE_DHE_PSK_ENABLED
+            scripts/config.py unset MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED
+        fi
+    fi
 
     # Restartable feature is not yet supported by PSA. Once it will in
     # the future, the following line could be removed (see issues
@@ -2680,15 +2703,32 @@ config_psa_crypto_config_accel_ecc_no_bignum() {
     scripts/config.py unset MBEDTLS_ECP_RESTARTABLE
 }
 
-# Build and test a configuration where driver accelerates all EC algs while
-# all support and dependencies from ECP and ECP_LIGHT are removed on the library
-# side.
+# Common helper used by:
+# - component_test_psa_crypto_config_accel_ecc_no_bignum
+# - component_test_psa_crypto_config_accel_ecc_ffdh_no_bignum
 #
-# Keep in sync with component_test_psa_crypto_config_reference_ecc_no_bignum()
-component_test_psa_crypto_config_accel_ecc_no_bignum () {
-    msg "build: full + accelerated EC algs + USE_PSA - ECP - BIGNUM"
+# The goal is to build and test accelerating either:
+# - ECC only or
+# - both ECC and FFDH
+#
+# It is meant to be used in conjunction with
+# common_test_psa_crypto_config_reference_ecc_ffdh_no_bignum() for drivers'
+# coverage analysis in "analyze_outcomes.py" script.
+common_test_psa_crypto_config_accel_ecc_ffdh_no_bignum () {
+    TEST_TARGET="$1"
 
-    # Algorithms and key types to accelerate
+    # This is an internal helper to simplify text messages' handling
+    if [ "$TEST_TARGET" = "ECC_DH" ]; then
+        ACCEL_TEXT="ECC/FFDH"
+        REMOVED_TEXT="ECP - DH"
+    else
+        ACCEL_TEXT="ECC"
+        REMOVED_TEXT="ECP"
+    fi
+
+    msg "build: full + accelerated $ACCEL_TEXT algs + USE_PSA - $REMOVED_TEXT - BIGNUM"
+
+    # By default we accelerate all EC keys/algs
     loc_accel_list="ALG_ECDSA ALG_DETERMINISTIC_ECDSA \
                     ALG_ECDH \
                     ALG_JPAKE \
@@ -2697,12 +2737,22 @@ component_test_psa_crypto_config_accel_ecc_no_bignum () {
                     KEY_TYPE_ECC_KEY_PAIR_EXPORT \
                     KEY_TYPE_ECC_KEY_PAIR_GENERATE \
                     KEY_TYPE_ECC_PUBLIC_KEY"
+    # Optionally we can also add DH to the list of accelerated items
+    if [ "$TEST_TARGET" = "ECC_DH" ]; then
+        loc_accel_list="$loc_accel_list \
+                        ALG_FFDH \
+                        KEY_TYPE_DH_KEY_PAIR_BASIC \
+                        KEY_TYPE_DH_KEY_PAIR_IMPORT \
+                        KEY_TYPE_DH_KEY_PAIR_EXPORT \
+                        KEY_TYPE_DH_KEY_PAIR_GENERATE \
+                        KEY_TYPE_DH_PUBLIC_KEY"
+    fi
 
     # Configure
     # ---------
 
     # Set common configurations between library's and driver's builds
-    config_psa_crypto_config_accel_ecc_no_bignum 1
+    config_psa_crypto_config_accel_ecc_ffdh_no_bignum 1 "$TEST_TARGET"
 
     # Build
     # -----
@@ -2719,39 +2769,71 @@ component_test_psa_crypto_config_accel_ecc_no_bignum () {
     not grep mbedtls_ecdsa_ library/ecdsa.o
     not grep mbedtls_ecdh_ library/ecdh.o
     not grep mbedtls_ecjpake_ library/ecjpake.o
-    # Also ensure that ECP, RSA, DHM or BIGNUM modules were not re-enabled
+    # Also ensure that ECP, RSA, [DHM] or BIGNUM modules were not re-enabled
     not grep mbedtls_ecp_ library/ecp.o
     not grep mbedtls_rsa_ library/rsa.o
-    not grep mbedtls_dhm_ library/dhm.o
     not grep mbedtls_mpi_ library/bignum.o
+    not grep mbedtls_dhm_ library/dhm.o
 
     # Run the tests
     # -------------
 
-    msg "test suites: full + accelerated EC algs + USE_PSA - ECP - BIGNUM"
+    msg "test suites: full + accelerated $ACCEL_TEXT algs + USE_PSA - $REMOVED_TEXT - DHM - BIGNUM"
+
     make test
 
-    # The following will be enabled in #7756
-    msg "ssl-opt: full + accelerated EC algs + USE_PSA - ECP - BIGNUM"
+    msg "ssl-opt: full + accelerated $ACCEL_TEXT algs + USE_PSA - $REMOVED_TEXT - BIGNUM"
     tests/ssl-opt.sh
 }
 
-# Reference function used for driver's coverage analysis in analyze_outcomes.py
-# in conjunction with component_test_psa_crypto_config_accel_ecc_no_bignum().
-# Keep in sync with its accelerated counterpart.
-component_test_psa_crypto_config_reference_ecc_no_bignum () {
-    msg "build: full + non accelerated EC algs + USE_PSA"
+# Common helper used by:
+# - component_test_psa_crypto_config_reference_ecc_no_bignum
+# - component_test_psa_crypto_config_reference_ecc_ffdh_no_bignum
+#
+# The goal is to build and test a reference scenario (i.e. with builtin
+# components) compared to the ones used in
+# common_test_psa_crypto_config_accel_ecc_ffdh_no_bignum() above.
+#
+# It is meant to be used in conjunction with
+# common_test_psa_crypto_config_accel_ecc_ffdh_no_bignum() for drivers'
+# coverage analysis in "analyze_outcomes.py" script.
+common_test_psa_crypto_config_reference_ecc_ffdh_no_bignum () {
+    TEST_TARGET="$1"
 
-    config_psa_crypto_config_accel_ecc_no_bignum 0
+    # This is an internal helper to simplify text messages' handling
+    if [ "$TEST_TARGET" = "ECC_DH" ]; then
+        ACCEL_TEXT="ECC/FFDH"
+    else
+        ACCEL_TEXT="ECC"
+    fi
+
+    msg "build: full + non accelerated $ACCEL_TEXT algs + USE_PSA"
+
+    config_psa_crypto_config_accel_ecc_ffdh_no_bignum 0 "$TEST_TARGET"
 
     make
 
     msg "test suites: full + non accelerated EC algs + USE_PSA"
     make test
 
-    # The following will be enabled in #7756
-    msg "ssl-opt: full + non accelerated EC algs + USE_PSA"
+    msg "ssl-opt: full + non accelerated $ACCEL_TEXT algs + USE_PSA"
     tests/ssl-opt.sh
+}
+
+component_test_psa_crypto_config_accel_ecc_no_bignum () {
+    common_test_psa_crypto_config_accel_ecc_ffdh_no_bignum "ECC"
+}
+
+component_test_psa_crypto_config_reference_ecc_no_bignum () {
+    common_test_psa_crypto_config_reference_ecc_ffdh_no_bignum "ECC"
+}
+
+component_test_psa_crypto_config_accel_ecc_ffdh_no_bignum () {
+    common_test_psa_crypto_config_accel_ecc_ffdh_no_bignum "ECC_DH"
+}
+
+component_test_psa_crypto_config_reference_ecc_ffdh_no_bignum () {
+    common_test_psa_crypto_config_reference_ecc_ffdh_no_bignum "ECC_DH"
 }
 
 # Helper function used in:

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -2638,10 +2638,10 @@ component_test_psa_crypto_config_reference_ecc_no_ecp_at_all () {
 #       - it still disables RSA, but it uses builtin EC and FFDH algs
 #
 # This function accepts 2 parameters:
-# $1: it is a boolean values which states if we are testing an accelerated
-#     scenario or not.
-# $2: it is a string value which states which are the tested components. Allowed
-#     values are "ECC" or "ECC_DH".
+# $1: a boolean value which states if we are testing an accelerated scenario
+#     or not.
+# $2: a string value which states which components are tested. Allowed values
+#     are "ECC" or "ECC_DH".
 config_psa_crypto_config_accel_ecc_ffdh_no_bignum() {
     DRIVER_ONLY="$1"
     TEST_TARGET="$2"
@@ -2712,12 +2712,12 @@ config_psa_crypto_config_accel_ecc_ffdh_no_bignum() {
 # - both ECC and FFDH
 #
 # It is meant to be used in conjunction with
-# common_test_psa_crypto_config_reference_ecc_ffdh_no_bignum() for drivers'
-# coverage analysis in "analyze_outcomes.py" script.
+# common_test_psa_crypto_config_reference_ecc_ffdh_no_bignum() for drivers
+# coverage analysis in the "analyze_outcomes.py" script.
 common_test_psa_crypto_config_accel_ecc_ffdh_no_bignum () {
     TEST_TARGET="$1"
 
-    # This is an internal helper to simplify text messages' handling
+    # This is an internal helper to simplify text message handling
     if [ "$TEST_TARGET" = "ECC_DH" ]; then
         ACCEL_TEXT="ECC/FFDH"
         REMOVED_TEXT="ECP - DH"
@@ -2800,7 +2800,7 @@ common_test_psa_crypto_config_accel_ecc_ffdh_no_bignum () {
 common_test_psa_crypto_config_reference_ecc_ffdh_no_bignum () {
     TEST_TARGET="$1"
 
-    # This is an internal helper to simplify text messages' handling
+    # This is an internal helper to simplify text message handling
     if [ "$TEST_TARGET" = "ECC_DH" ]; then
         ACCEL_TEXT="ECC/FFDH"
     else

--- a/tests/scripts/analyze_outcomes.py
+++ b/tests/scripts/analyze_outcomes.py
@@ -310,7 +310,7 @@ TASKS = {
             }
         }
     },
-    'analyze_driver_vs_reference_no_bignum': {
+    'analyze_driver_vs_reference_ecc_no_bignum': {
         'test_function': do_analyze_driver_vs_reference,
         'args': {
             'component_ref': 'test_psa_crypto_config_reference_ecc_no_bignum',
@@ -328,6 +328,100 @@ TASKS = {
                 'bignum_mod_raw',
                 'bignum.generated',
                 'bignum.misc',
+            ],
+            'ignored_tests': {
+                'test_suite_random': [
+                    'PSA classic wrapper: ECDSA signature (SECP256R1)',
+                ],
+                'test_suite_psa_crypto': [
+                    'PSA key derivation: HKDF-SHA-256 -> ECC secp256r1',
+                    'PSA key derivation: HKDF-SHA-256 -> ECC secp256r1 (1 redraw)',
+                    'PSA key derivation: HKDF-SHA-256 -> ECC secp256r1, exercise ECDSA',
+                    'PSA key derivation: HKDF-SHA-256 -> ECC secp384r1',
+                    'PSA key derivation: HKDF-SHA-256 -> ECC secp521r1 #0',
+                    'PSA key derivation: HKDF-SHA-256 -> ECC secp521r1 #1',
+                    'PSA key derivation: bits=7 invalid for ECC BRAINPOOL_P_R1 (ECC enabled)',
+                    'PSA key derivation: bits=7 invalid for ECC SECP_K1 (ECC enabled)',
+                    'PSA key derivation: bits=7 invalid for ECC SECP_R1 (ECC enabled)',
+                    'PSA key derivation: bits=7 invalid for ECC SECP_R2 (ECC enabled)',
+                    'PSA key derivation: bits=7 invalid for ECC SECT_K1 (ECC enabled)',
+                    'PSA key derivation: bits=7 invalid for ECC SECT_R1 (ECC enabled)',
+                    'PSA key derivation: bits=7 invalid for ECC SECT_R2 (ECC enabled)',
+                ],
+                'test_suite_pkparse': [
+                    # See the description provided above in the
+                    # analyze_driver_vs_reference_no_ecp_at_all component.
+                    'Parse EC Key #10a (SEC1 PEM, secp384r1, compressed)',
+                    'Parse EC Key #11a (SEC1 PEM, secp521r1, compressed)',
+                    'Parse EC Key #12a (SEC1 PEM, bp256r1, compressed)',
+                    'Parse EC Key #13a (SEC1 PEM, bp384r1, compressed)',
+                    'Parse EC Key #14a (SEC1 PEM, bp512r1, compressed)',
+                    'Parse EC Key #2a (SEC1 PEM, secp192r1, compressed)',
+                    'Parse EC Key #8a (SEC1 PEM, secp224r1, compressed)',
+                    'Parse EC Key #9a (SEC1 PEM, secp256r1, compressed)',
+                    'Parse Public EC Key #2a (RFC 5480, PEM, secp192r1, compressed)',
+                    'Parse Public EC Key #3a (RFC 5480, secp224r1, compressed)',
+                    'Parse Public EC Key #4a (RFC 5480, secp256r1, compressed)',
+                    'Parse Public EC Key #5a (RFC 5480, secp384r1, compressed)',
+                    'Parse Public EC Key #6a (RFC 5480, secp521r1, compressed)',
+                    'Parse Public EC Key #7a (RFC 5480, brainpoolP256r1, compressed)',
+                    'Parse Public EC Key #8a (RFC 5480, brainpoolP384r1, compressed)',
+                    'Parse Public EC Key #9a (RFC 5480, brainpoolP512r1, compressed)',
+                ],
+                'test_suite_asn1parse': [
+                    # This test depends on BIGNUM_C
+                    'INTEGER too large for mpi',
+                ],
+                'test_suite_asn1write': [
+                    # Following tests depends on BIGNUM_C
+                    'ASN.1 Write mpi 0 (1 limb)',
+                    'ASN.1 Write mpi 0 (null)',
+                    'ASN.1 Write mpi 0x100',
+                    'ASN.1 Write mpi 0x7f',
+                    'ASN.1 Write mpi 0x7f with leading 0 limb',
+                    'ASN.1 Write mpi 0x80',
+                    'ASN.1 Write mpi 0x80 with leading 0 limb',
+                    'ASN.1 Write mpi 0xff',
+                    'ASN.1 Write mpi 1',
+                    'ASN.1 Write mpi, 127*8 bits',
+                    'ASN.1 Write mpi, 127*8+1 bits',
+                    'ASN.1 Write mpi, 127*8-1 bits',
+                    'ASN.1 Write mpi, 255*8 bits',
+                    'ASN.1 Write mpi, 255*8-1 bits',
+                    'ASN.1 Write mpi, 256*8-1 bits',
+                ],
+                'test_suite_debug': [
+                    # Following tests depends on BIGNUM_C
+                    'Debug print mbedtls_mpi #2: 3 bits',
+                    'Debug print mbedtls_mpi: 0 (empty representation)',
+                    'Debug print mbedtls_mpi: 0 (non-empty representation)',
+                    'Debug print mbedtls_mpi: 49 bits',
+                    'Debug print mbedtls_mpi: 759 bits',
+                    'Debug print mbedtls_mpi: 764 bits #1',
+                    'Debug print mbedtls_mpi: 764 bits #2',
+                ],
+            }
+        }
+    },
+    'analyze_driver_vs_reference_ecc_ffdh_no_bignum': {
+        'test_function': do_analyze_driver_vs_reference,
+        'args': {
+            'component_ref': 'test_psa_crypto_config_reference_ecc_ffdh_no_bignum',
+            'component_driver': 'test_psa_crypto_config_accel_ecc_ffdh_no_bignum',
+            'ignored_suites': [
+                # Ignore test suites for the modules that are disabled in the
+                # accelerated test case.
+                'ecp',
+                'ecdsa',
+                'ecdh',
+                'ecjpake',
+                'bignum_core',
+                'bignum_random',
+                'bignum_mod',
+                'bignum_mod_raw',
+                'bignum.generated',
+                'bignum.misc',
+                'dhm',
             ],
             'ignored_tests': {
                 'test_suite_random': [


### PR DESCRIPTION
This PR:
- extends test scenario introduced by the #7754 + #7755 + #7756 series by accelerating also FFDH together with ECC.
- improves the `driver-only-builds.md` documentation as requested by the issue

Resolves #8005

## PR checklist

- [x] **changelog** deferred to #7757
- [x] **backport** not required, since it's only related to test
- [x] **tests** included - that's what the PR is about!