### PR TITLE
Tidying: Remove unnecessary include from constant_time.c

### DIFF
--- a/library/constant_time.c
+++ b/library/constant_time.c
@@ -30,8 +30,6 @@
 #include "mbedtls/error.h"
 #include "mbedtls/platform_util.h"
 
-#include "../tests/include/test/constant_flow.h"
-
 #include <string.h>
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO) && defined(MBEDTLS_SSL_SOME_SUITES_USE_MAC)


### PR DESCRIPTION
This was added in order to use TEST_CF_XYZ macros which have since been removed.

Fixes #8071.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required - internal change only
- [x] **backport** not required - the unnecessary include does not exist in 2.28
- [x] **tests** not required - no functional change
