### PR TITLE
Small fixes for IAR support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -226,7 +226,9 @@ if(CMAKE_COMPILER_IS_CLANG)
 endif(CMAKE_COMPILER_IS_CLANG)
 
 if(CMAKE_COMPILER_IS_IAR)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --warn_about_c_style_casts -Ohz")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --warn_about_c_style_casts")
+    set(CMAKE_C_FLAGS_RELEASE     "-Ohz")
+    set(CMAKE_C_FLAGS_DEBUG       "--debug -On")
 endif(CMAKE_COMPILER_IS_IAR)
 
 if(CMAKE_COMPILER_IS_MSVC)

--- a/library/aes.c
+++ b/library/aes.c
@@ -1866,7 +1866,7 @@ int mbedtls_aes_self_test(int verbose)
 #elif MBEDTLS_AESNI_HAVE_CODE == 2
         mbedtls_printf("  AES note: AESNI code present (intrinsics implementation).\n");
 #else
-#error Unrecognised value for MBEDTLS_AESNI_HAVE_CODE
+#error "Unrecognised value for MBEDTLS_AESNI_HAVE_CODE"
 #endif
         if (mbedtls_aesni_has_support(MBEDTLS_AESNI_AES)) {
             mbedtls_printf("  AES note: using AESNI.\n");

--- a/library/common.h
+++ b/library/common.h
@@ -288,7 +288,7 @@ static inline void mbedtls_xor_no_simd(unsigned char *r,
 /* Normal case (64-bit pointers): use "r" as the constraint for pointer operands to asm */
 #define MBEDTLS_ASM_AARCH64_PTR_CONSTRAINT "r"
 #else
-#error Unrecognised pointer size for aarch64
+#error "Unrecognised pointer size for aarch64"
 #endif
 #endif
 

--- a/library/constant_time.c
+++ b/library/constant_time.c
@@ -78,7 +78,7 @@ static inline uint32_t mbedtls_get_unaligned_volatile_uint32(volatile const unsi
      */
     uint32_t r;
 #if defined(MBEDTLS_CT_ARM_ASM)
-    __asm volatile ("ldr %0, [%1]" : "=r" (r) : "r" (p) :);
+    asm volatile ("ldr %0, [%1]" : "=r" (r) : "r" (p) :);
 #elif defined(MBEDTLS_CT_AARCH64_ASM)
     asm volatile ("ldr %w0, [%1]" : "=r" (r) : MBEDTLS_ASM_AARCH64_PTR_CONSTRAINT(p) :);
 #else

--- a/library/constant_time.c
+++ b/library/constant_time.c
@@ -78,7 +78,7 @@ static inline uint32_t mbedtls_get_unaligned_volatile_uint32(volatile const unsi
      */
     uint32_t r;
 #if defined(MBEDTLS_CT_ARM_ASM)
-    asm volatile ("ldr %0, [%1]" : "=r" (r) : "r" (p) :);
+    __asm volatile ("ldr %0, [%1]" : "=r" (r) : "r" (p) :);
 #elif defined(MBEDTLS_CT_AARCH64_ASM)
     asm volatile ("ldr %w0, [%1]" : "=r" (r) : MBEDTLS_ASM_AARCH64_PTR_CONSTRAINT(p) :);
 #else

--- a/library/constant_time.c
+++ b/library/constant_time.c
@@ -82,7 +82,7 @@ static inline uint32_t mbedtls_get_unaligned_volatile_uint32(volatile const unsi
 #elif defined(MBEDTLS_CT_AARCH64_ASM)
     asm volatile ("ldr %w0, [%1]" : "=r" (r) : MBEDTLS_ASM_AARCH64_PTR_CONSTRAINT(p) :);
 #else
-#error No assembly defined for mbedtls_get_unaligned_volatile_uint32
+#error "No assembly defined for mbedtls_get_unaligned_volatile_uint32"
 #endif
     return r;
 }

--- a/library/entropy_poll.c
+++ b/library/entropy_poll.c
@@ -75,7 +75,7 @@ int mbedtls_platform_entropy_poll(void *data, unsigned char *output, size_t len,
     return 0;
 }
 #else /* !_WIN32_WINNT_WINXP */
-#error Entropy not available before Windows XP, use MBEDTLS_NO_PLATFORM_ENTROPY
+#error "Entropy not available before Windows XP, use MBEDTLS_NO_PLATFORM_ENTROPY"
 #endif /* !_WIN32_WINNT_WINXP */
 #else /* _WIN32 && !EFIX64 && !EFI32 */
 

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -7049,8 +7049,13 @@ static psa_status_t psa_key_agreement_internal(psa_key_derivation_operation_t *o
                                                size_t peer_key_length)
 {
     psa_status_t status;
+#if PSA_RAW_KEY_AGREEMENT_OUTPUT_MAX_SIZE != 0
     uint8_t shared_secret[PSA_RAW_KEY_AGREEMENT_OUTPUT_MAX_SIZE];
+    size_t shared_secret_length = sizeof(shared_secret);
+#else
+    uint8_t *shared_secret = NULL;
     size_t shared_secret_length = 0;
+#endif
     psa_algorithm_t ka_alg = PSA_ALG_KEY_AGREEMENT_GET_BASE(operation->alg);
 
     /* Step 1: run the secret agreement algorithm to generate the shared
@@ -7059,7 +7064,7 @@ static psa_status_t psa_key_agreement_internal(psa_key_derivation_operation_t *o
                                             private_key,
                                             peer_key, peer_key_length,
                                             shared_secret,
-                                            sizeof(shared_secret),
+                                            shared_secret_length,
                                             &shared_secret_length);
     if (status != PSA_SUCCESS) {
         goto exit;

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -7049,13 +7049,8 @@ static psa_status_t psa_key_agreement_internal(psa_key_derivation_operation_t *o
                                                size_t peer_key_length)
 {
     psa_status_t status;
-#if PSA_RAW_KEY_AGREEMENT_OUTPUT_MAX_SIZE != 0
     uint8_t shared_secret[PSA_RAW_KEY_AGREEMENT_OUTPUT_MAX_SIZE];
-    size_t shared_secret_length = sizeof(shared_secret);
-#else
-    uint8_t *shared_secret = NULL;
     size_t shared_secret_length = 0;
-#endif
     psa_algorithm_t ka_alg = PSA_ALG_KEY_AGREEMENT_GET_BASE(operation->alg);
 
     /* Step 1: run the secret agreement algorithm to generate the shared
@@ -7064,7 +7059,7 @@ static psa_status_t psa_key_agreement_internal(psa_key_derivation_operation_t *o
                                             private_key,
                                             peer_key, peer_key_length,
                                             shared_secret,
-                                            shared_secret_length,
+                                            sizeof(shared_secret),
                                             &shared_secret_length);
     if (status != PSA_SUCCESS) {
         goto exit;

--- a/library/psa_crypto_storage.h
+++ b/library/psa_crypto_storage.h
@@ -39,7 +39,7 @@ extern "C" {
 /* Sanity check: a file size must fit in 32 bits. Allow a generous
  * 64kB of metadata. */
 #if PSA_CRYPTO_MAX_STORAGE_SIZE > 0xffff0000
-#error PSA_CRYPTO_MAX_STORAGE_SIZE > 0xffff0000
+#error "PSA_CRYPTO_MAX_STORAGE_SIZE > 0xffff0000"
 #endif
 
 /** The maximum permitted persistent slot number.

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -1599,7 +1599,7 @@ int mbedtls_x509_crt_parse_path(mbedtls_x509_crt *chain, const char *path)
 cleanup:
     FindClose(hFind);
 #else /* !_WIN32_WINNT_XP */
-#error mbedtls_x509_crt_parse_path not available before Windows XP
+#error "mbedtls_x509_crt_parse_path not available before Windows XP"
 #endif /* !_WIN32_WINNT_XP */
 #else /* _WIN32 */
     int t_ret;


### PR DESCRIPTION
## Description

Applied the same change as in mbed-crypto for using this as a sub project with the IAR toolchain. Use __asm generic ,and avoid empty enum. Avoid declaration of array with null size.

Note: This is a porting of the original patch contributed to trusted-firmware-m at https://git.trustedfirmware.org/TF-M/trusted-firmware-m.git/tree/lib/ext/mbedcrypto/0001-BUILD-Update-For-IAR-support.patch


## PR checklist

- [x] **changelog** not required
- [x] **backport** The backport for 2.28 is available at #8081 .
- [x] **tests**  not required
