### PR TITLE
Remove type qualifier in assignment casts

### DIFF
--- a/ChangeLog.d/fix-iar-compiler-warnings.txt
+++ b/ChangeLog.d/fix-iar-compiler-warnings.txt
@@ -1,2 +1,2 @@
 Bugfix
-   * Improve general IAR support
+   * Fix IAR compiler warnings. Fixes #7873, #4300.

--- a/ChangeLog.d/fix-iar-compiler-warnings.txt
+++ b/ChangeLog.d/fix-iar-compiler-warnings.txt
@@ -1,2 +1,3 @@
 Bugfix
    * Improve general IAR support
+   

--- a/ChangeLog.d/fix-iar-compiler-warnings.txt
+++ b/ChangeLog.d/fix-iar-compiler-warnings.txt
@@ -1,2 +1,2 @@
 Bugfix
-   * Fix IAR compiler warnings. Fixes #7873, #4300.
+   * Fix IAR compiler warnings.

--- a/ChangeLog.d/fix-iar-compiler-warnings.txt
+++ b/ChangeLog.d/fix-iar-compiler-warnings.txt
@@ -1,3 +1,2 @@
 Bugfix
    * Improve general IAR support
-   

--- a/ChangeLog.d/fix-iar-compiler-warnings.txt
+++ b/ChangeLog.d/fix-iar-compiler-warnings.txt
@@ -1,0 +1,2 @@
+Bugfix
+   * Improve general IAR support

--- a/library/constant_time_impl.h
+++ b/library/constant_time_impl.h
@@ -189,8 +189,8 @@ static inline unsigned char mbedtls_ct_uchar_in_range_if(unsigned char low,
                                                          unsigned char c,
                                                          unsigned char t)
 {
-    const unsigned char co = (const unsigned char) mbedtls_ct_compiler_opaque(c);
-    const unsigned char to = (const unsigned char) mbedtls_ct_compiler_opaque(t);
+    const unsigned char co= (unsigned char) mbedtls_ct_compiler_opaque(c);
+    const unsigned char to= (unsigned char) mbedtls_ct_compiler_opaque(t);
 
     /* low_mask is: 0 if low <= c, 0x...ff if low > c */
     unsigned low_mask = ((unsigned) co - low) >> 8;

--- a/library/constant_time_impl.h
+++ b/library/constant_time_impl.h
@@ -189,8 +189,8 @@ static inline unsigned char mbedtls_ct_uchar_in_range_if(unsigned char low,
                                                          unsigned char c,
                                                          unsigned char t)
 {
-    const unsigned char co= (unsigned char) mbedtls_ct_compiler_opaque(c);
-    const unsigned char to= (unsigned char) mbedtls_ct_compiler_opaque(t);
+    const unsigned char co = (unsigned char) mbedtls_ct_compiler_opaque(c);
+    const unsigned char to = (unsigned char) mbedtls_ct_compiler_opaque(t);
 
     /* low_mask is: 0 if low <= c, 0x...ff if low > c */
     unsigned low_mask = ((unsigned) co - low) >> 8;


### PR DESCRIPTION
## Description

IAR warned on unneeded "const" keywords, so removed. Changelog added for all previous changes for IAR support.

## PR checklist

- [x] **changelog** provided
- [x] **backport** - code modifications not required in LTS, but ChangeLog is in #8102
- [x] **tests** not required

