### PR TITLE
Backport 2.28: Fix a few unchecked return values

### DIFF
--- a/ChangeLog.d/fix-a-few-unchecked-return.txt
+++ b/ChangeLog.d/fix-a-few-unchecked-return.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix some cases where mbedtls_mpi_mod_exp, RSA key construction or ECDSA
+     signature can silently return an incorrect result in low memory conditions.

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -2328,7 +2328,7 @@ int mbedtls_mpi_exp_mod(mbedtls_mpi *X, const mbedtls_mpi *A,
     /*
      * Load the result in the output variable.
      */
-    mbedtls_mpi_copy(X, &W[x_index]);
+    MBEDTLS_MPI_CHK(mbedtls_mpi_copy(X, &W[x_index]));
 
 cleanup:
 

--- a/library/ecdsa.c
+++ b/library/ecdsa.c
@@ -366,7 +366,7 @@ modn:
 
 #if defined(MBEDTLS_ECP_RESTARTABLE)
     if (rs_ctx != NULL && rs_ctx->sig != NULL) {
-        mbedtls_mpi_copy(r, pr);
+        MBEDTLS_MPI_CHK(mbedtls_mpi_copy(r, pr));
     }
 #endif
 
@@ -457,7 +457,7 @@ static int ecdsa_sign_det_restartable(mbedtls_ecp_group *grp,
     MBEDTLS_MPI_CHK(mbedtls_mpi_write_binary(d, data, grp_len));
     MBEDTLS_MPI_CHK(derive_mpi(grp, &h, buf, blen));
     MBEDTLS_MPI_CHK(mbedtls_mpi_write_binary(&h, data + grp_len, grp_len));
-    mbedtls_hmac_drbg_seed_buf(p_rng, md_info, data, 2 * grp_len);
+    MBEDTLS_MPI_CHK(mbedtls_hmac_drbg_seed_buf(p_rng, md_info, data, 2 * grp_len));
 
 #if defined(MBEDTLS_ECP_RESTARTABLE)
     if (rs_ctx != NULL && rs_ctx->det != NULL) {

--- a/library/rsa_internal.c
+++ b/library/rsa_internal.c
@@ -126,7 +126,7 @@ int mbedtls_rsa_deduce_primes(mbedtls_mpi const *N,
     }
 
     for (; attempt < num_primes; ++attempt) {
-        mbedtls_mpi_lset(&K, primes[attempt]);
+        MBEDTLS_MPI_CHK(mbedtls_mpi_lset(&K, primes[attempt]));
 
         /* Check if gcd(K,N) = 1 */
         MBEDTLS_MPI_CHK(mbedtls_mpi_gcd(P, &K, N));


### PR DESCRIPTION
## Description

Patches in this PR are identical with https://github.com/Mbed-TLS/mbedtls/pull/8017.


## PR checklist


- [x] **changelog** provided
- [ ] **backport** this is a backport
- [x] **tests**  not required (we currently don't test low-memory conditions)
