### PR TITLE
Add architecture detection macros

### DIFF
--- a/include/mbedtls/build_info.h
+++ b/include/mbedtls/build_info.h
@@ -49,6 +49,55 @@
 #define MBEDTLS_VERSION_STRING         "3.4.1"
 #define MBEDTLS_VERSION_STRING_FULL    "mbed TLS 3.4.1"
 
+/* Macros for build-time platform detection */
+
+#if !defined(MBEDTLS_ARCH_IS_ARM64) && \
+    (defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC))
+#define MBEDTLS_ARCH_IS_ARM64
+#endif
+
+#if !defined(MBEDTLS_ARCH_IS_ARM32) && \
+    (defined(__arm__) || defined(_M_ARM) || \
+    defined(_M_ARMT) || defined(__thumb__) || defined(__thumb2__))
+#define MBEDTLS_ARCH_IS_ARM32
+#endif
+
+#if !defined(MBEDTLS_ARCH_IS_X64) && \
+    (defined(__amd64__) || defined(__x86_64__) || \
+    ((defined(_M_X64) || defined(_M_AMD64)) && !defined(_M_ARM64EC)))
+#define MBEDTLS_ARCH_IS_X64
+#endif
+
+#if !defined(MBEDTLS_ARCH_IS_X86) && \
+    (defined(__i386__) || defined(_X86_) || \
+    (defined(_M_IX86) && !defined(_M_I86)))
+#define MBEDTLS_ARCH_IS_X86
+#endif
+/* Macros for build-time platform detection */
+
+#if !defined(MBEDTLS_ARCH_IS_ARM64) && \
+    (defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC))
+#define MBEDTLS_ARCH_IS_ARM64
+#endif
+
+#if !defined(MBEDTLS_ARCH_IS_ARM32) && \
+    (defined(__arm__) || defined(_M_ARM) || \
+    defined(_M_ARMT) || defined(__thumb__) || defined(__thumb2__))
+#define MBEDTLS_ARCH_IS_ARM32
+#endif
+
+#if !defined(MBEDTLS_ARCH_IS_X64) && \
+    (defined(__amd64__) || defined(__x86_64__) || \
+    ((defined(_M_X64) || defined(_M_AMD64)) && !defined(_M_ARM64EC)))
+#define MBEDTLS_ARCH_IS_X64
+#endif
+
+#if !defined(MBEDTLS_ARCH_IS_X86) && \
+    (defined(__i386__) || defined(_X86_) || \
+    (defined(_M_IX86) && !defined(_M_I86)))
+#define MBEDTLS_ARCH_IS_X86
+#endif
+
 #if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_DEPRECATE)
 #define _CRT_SECURE_NO_DEPRECATE 1
 #endif

--- a/include/mbedtls/build_info.h
+++ b/include/mbedtls/build_info.h
@@ -73,30 +73,6 @@
     (defined(_M_IX86) && !defined(_M_I86)))
 #define MBEDTLS_ARCH_IS_X86
 #endif
-/* Macros for build-time platform detection */
-
-#if !defined(MBEDTLS_ARCH_IS_ARM64) && \
-    (defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC))
-#define MBEDTLS_ARCH_IS_ARM64
-#endif
-
-#if !defined(MBEDTLS_ARCH_IS_ARM32) && \
-    (defined(__arm__) || defined(_M_ARM) || \
-    defined(_M_ARMT) || defined(__thumb__) || defined(__thumb2__))
-#define MBEDTLS_ARCH_IS_ARM32
-#endif
-
-#if !defined(MBEDTLS_ARCH_IS_X64) && \
-    (defined(__amd64__) || defined(__x86_64__) || \
-    ((defined(_M_X64) || defined(_M_AMD64)) && !defined(_M_ARM64EC)))
-#define MBEDTLS_ARCH_IS_X64
-#endif
-
-#if !defined(MBEDTLS_ARCH_IS_X86) && \
-    (defined(__i386__) || defined(_X86_) || \
-    (defined(_M_IX86) && !defined(_M_I86)))
-#define MBEDTLS_ARCH_IS_X86
-#endif
 
 #if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_DEPRECATE)
 #define _CRT_SECURE_NO_DEPRECATE 1

--- a/library/aes.c
+++ b/library/aes.c
@@ -34,7 +34,7 @@
 #include "mbedtls/platform_util.h"
 #include "mbedtls/error.h"
 
-#if defined(__aarch64__)
+#if defined(MBEDTLS_ARCH_IS_ARM64)
 #if !defined(MBEDTLS_AESCE_C) && defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
 #error "MBEDTLS_AES_USE_HARDWARE_ONLY defined, but not all prerequisites"
 #endif
@@ -652,7 +652,7 @@ int mbedtls_aes_setkey_enc(mbedtls_aes_context *ctx, const unsigned char *key,
     }
 #endif
 
-#if defined(MBEDTLS_AESCE_C) && defined(MBEDTLS_HAVE_ARM64)
+#if defined(MBEDTLS_AESCE_HAVE_CODE)
     if (MBEDTLS_AESCE_HAS_SUPPORT()) {
         return mbedtls_aesce_setkey_enc((unsigned char *) RK, key, keybits);
     }
@@ -764,7 +764,7 @@ int mbedtls_aes_setkey_dec(mbedtls_aes_context *ctx, const unsigned char *key,
     }
 #endif
 
-#if defined(MBEDTLS_AESCE_C) && defined(MBEDTLS_HAVE_ARM64)
+#if defined(MBEDTLS_AESCE_HAVE_CODE)
     if (MBEDTLS_AESCE_HAS_SUPPORT()) {
         mbedtls_aesce_inverse_key(
             (unsigned char *) RK,
@@ -1091,7 +1091,7 @@ int mbedtls_aes_crypt_ecb(mbedtls_aes_context *ctx,
     }
 #endif
 
-#if defined(MBEDTLS_AESCE_C) && defined(MBEDTLS_HAVE_ARM64)
+#if defined(MBEDTLS_AESCE_HAVE_CODE)
     if (MBEDTLS_AESCE_HAS_SUPPORT()) {
         return mbedtls_aesce_crypt_ecb(ctx, mode, input, output);
     }
@@ -1910,7 +1910,7 @@ int mbedtls_aes_self_test(int verbose)
             mbedtls_printf("  AES note: using VIA Padlock.\n");
         } else
 #endif
-#if defined(MBEDTLS_AESCE_C) && defined(MBEDTLS_HAVE_ARM64)
+#if defined(MBEDTLS_AESCE_HAVE_CODE)
         if (MBEDTLS_AESCE_HAS_SUPPORT()) {
             mbedtls_printf("  AES note: using AESCE.\n");
         } else

--- a/library/aes.c
+++ b/library/aes.c
@@ -40,14 +40,13 @@
 #endif
 #endif
 
-#if defined(__amd64__) || defined(__x86_64__) || \
-    ((defined(_M_X64) || defined(_M_AMD64)) && !defined(_M_ARM64EC))
+#if defined(MBEDTLS_ARCH_IS_X64)
 #if !defined(MBEDTLS_AESNI_C) && defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
 #error "MBEDTLS_AES_USE_HARDWARE_ONLY defined, but not all prerequisites"
 #endif
 #endif
 
-#if defined(__i386__) || defined(_M_IX86)
+#if defined(MBEDTLS_ARCH_IS_X86)
 #if defined(MBEDTLS_AES_USE_HARDWARE_ONLY) && !defined(MBEDTLS_AESNI_C)
 #error "MBEDTLS_AES_USE_HARDWARE_ONLY defined, but not all prerequisites"
 #endif

--- a/library/aesce.c
+++ b/library/aesce.c
@@ -46,7 +46,7 @@
 
 #include "aesce.h"
 
-#if defined(MBEDTLS_HAVE_ARM64)
+#if defined(MBEDTLS_ARCH_IS_ARM64)
 
 /* Compiler version checks. */
 #if defined(__clang__)
@@ -510,6 +510,6 @@ void mbedtls_aesce_gcm_mult(unsigned char c[16],
 #undef MBEDTLS_POP_TARGET_PRAGMA
 #endif
 
-#endif /* MBEDTLS_HAVE_ARM64 */
+#endif /* MBEDTLS_ARCH_IS_ARM64 */
 
 #endif /* MBEDTLS_AESCE_C */

--- a/library/aesce.h
+++ b/library/aesce.h
@@ -30,7 +30,6 @@
 
 #include "mbedtls/aes.h"
 
-#include "common.h"
 
 #if defined(MBEDTLS_AESCE_C) && defined(MBEDTLS_ARCH_IS_ARM64)
 

--- a/library/aesce.h
+++ b/library/aesce.h
@@ -30,13 +30,11 @@
 
 #include "mbedtls/aes.h"
 
-#if !defined(MBEDTLS_HAVE_ARM64)
-#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
-#define MBEDTLS_HAVE_ARM64
-#endif
-#endif
+#include "common.h"
 
-#if defined(MBEDTLS_HAVE_ARM64)
+#if defined(MBEDTLS_AESCE_C) && defined(MBEDTLS_ARCH_IS_ARM64)
+
+#define MBEDTLS_AESCE_HAVE_CODE
 
 #ifdef __cplusplus
 extern "C" {
@@ -131,6 +129,6 @@ int mbedtls_aesce_setkey_enc(unsigned char *rk,
 }
 #endif
 
-#endif /* MBEDTLS_HAVE_ARM64 */
+#endif /* MBEDTLS_AESCE_C && MBEDTLS_ARCH_IS_ARM64 */
 
 #endif /* MBEDTLS_AESCE_H */

--- a/library/aesni.h
+++ b/library/aesni.h
@@ -35,20 +35,9 @@
 /* Can we do AESNI with inline assembly?
  * (Only implemented with gas syntax, only for 64-bit.)
  */
-#if !defined(MBEDTLS_HAVE_X86_64) && \
-    (defined(__amd64__) || defined(__x86_64__) || \
-    defined(_M_X64) || defined(_M_AMD64)) && \
-    !defined(_M_ARM64EC)
-#define MBEDTLS_HAVE_X86_64
-#endif
-
-#if !defined(MBEDTLS_HAVE_X86) && \
-    (defined(__i386__) || defined(_M_IX86))
-#define MBEDTLS_HAVE_X86
-#endif
 
 #if defined(MBEDTLS_AESNI_C) && \
-    (defined(MBEDTLS_HAVE_X86_64) || defined(MBEDTLS_HAVE_X86))
+    (defined(MBEDTLS_ARCH_IS_X64) || defined(MBEDTLS_ARCH_IS_X86))
 
 /* Can we do AESNI with intrinsics?
  * (Only implemented with certain compilers, only for certain targets.)
@@ -75,7 +64,7 @@
 #if defined(MBEDTLS_AESNI_HAVE_INTRINSICS)
 #define MBEDTLS_AESNI_HAVE_CODE 2 // via intrinsics
 #elif defined(MBEDTLS_HAVE_ASM) && \
-    defined(__GNUC__) && defined(MBEDTLS_HAVE_X86_64)
+    defined(__GNUC__) && defined(MBEDTLS_ARCH_IS_X64)
 #define MBEDTLS_AESNI_HAVE_CODE 1 // via assembly
 #elif defined(__GNUC__)
 #   error "Must use `-mpclmul -msse2 -maes` for MBEDTLS_AESNI_C"

--- a/library/aesni.h
+++ b/library/aesni.h
@@ -32,10 +32,6 @@
 #define MBEDTLS_AESNI_AES      0x02000000u
 #define MBEDTLS_AESNI_CLMUL    0x00000002u
 
-/* Can we do AESNI with inline assembly?
- * (Only implemented with gas syntax, only for 64-bit.)
- */
-
 #if defined(MBEDTLS_AESNI_C) && \
     (defined(MBEDTLS_ARCH_IS_X64) || defined(MBEDTLS_ARCH_IS_X86))
 
@@ -65,6 +61,9 @@
 #define MBEDTLS_AESNI_HAVE_CODE 2 // via intrinsics
 #elif defined(MBEDTLS_HAVE_ASM) && \
     defined(__GNUC__) && defined(MBEDTLS_ARCH_IS_X64)
+/* Can we do AESNI with inline assembly?
+ * (Only implemented with gas syntax, only for 64-bit.)
+ */
 #define MBEDTLS_AESNI_HAVE_CODE 1 // via assembly
 #elif defined(__GNUC__)
 #   error "Must use `-mpclmul -msse2 -maes` for MBEDTLS_AESNI_C"

--- a/library/gcm.c
+++ b/library/gcm.c
@@ -97,7 +97,7 @@ static int gcm_gen_table(mbedtls_gcm_context *ctx)
     }
 #endif
 
-#if defined(MBEDTLS_AESCE_C) && defined(MBEDTLS_HAVE_ARM64)
+#if defined(MBEDTLS_AESCE_HAVE_CODE)
     if (MBEDTLS_AESCE_HAS_SUPPORT()) {
         return 0;
     }
@@ -208,7 +208,7 @@ static void gcm_mult(mbedtls_gcm_context *ctx, const unsigned char x[16],
     }
 #endif /* MBEDTLS_AESNI_HAVE_CODE */
 
-#if defined(MBEDTLS_AESCE_C) && defined(MBEDTLS_HAVE_ARM64)
+#if defined(MBEDTLS_AESCE_HAVE_CODE)
     if (MBEDTLS_AESCE_HAS_SUPPORT()) {
         unsigned char h[16];
 
@@ -885,7 +885,7 @@ int mbedtls_gcm_self_test(int verbose)
         } else
 #endif
 
-#if defined(MBEDTLS_AESCE_C) && defined(MBEDTLS_HAVE_ARM64)
+#if defined(MBEDTLS_AESCE_HAVE_CODE)
         if (MBEDTLS_AESCE_HAS_SUPPORT()) {
             mbedtls_printf("  GCM note: using AESCE.\n");
         } else

--- a/library/padlock.c
+++ b/library/padlock.c
@@ -31,7 +31,7 @@
 
 #include <string.h>
 
-#if defined(MBEDTLS_HAVE_X86)
+#if defined(MBEDTLS_VIA_PADLOCK_HAVE_CODE)
 
 /*
  * PadLock detection routine
@@ -162,6 +162,6 @@ int mbedtls_padlock_xcryptcbc(mbedtls_aes_context *ctx,
     return 0;
 }
 
-#endif /* MBEDTLS_HAVE_X86 */
+#endif /* MBEDTLS_VIA_PADLOCK_HAVE_CODE */
 
 #endif /* MBEDTLS_PADLOCK_C */

--- a/library/padlock.h
+++ b/library/padlock.h
@@ -39,14 +39,10 @@
 #endif
 
 /* Some versions of ASan result in errors about not enough registers */
-#if defined(MBEDTLS_HAVE_ASM) && defined(__GNUC__) && defined(__i386__) && \
-    !defined(MBEDTLS_HAVE_ASAN)
+#if defined(__GNUC__) && defined(MBEDTLS_ARCH_IS_X86) && \
+    defined(MBEDTLS_HAVE_ASM) && !defined(MBEDTLS_HAVE_ASAN)
 
 #define MBEDTLS_VIA_PADLOCK_HAVE_CODE
-
-#ifndef MBEDTLS_HAVE_X86
-#define MBEDTLS_HAVE_X86
-#endif
 
 #include <stdint.h>
 

--- a/library/padlock.h
+++ b/library/padlock.h
@@ -38,9 +38,14 @@
 #endif
 #endif
 
-/* Some versions of ASan result in errors about not enough registers */
-#if defined(__GNUC__) && defined(MBEDTLS_ARCH_IS_X86) && \
-    defined(MBEDTLS_HAVE_ASM) && !defined(MBEDTLS_HAVE_ASAN)
+/*
+ * - `padlock` is implements with GNUC assembly for x86 target.
+ * - Some versions of ASan result in errors about not enough registers.
+ */
+#if defined(MBEDTLS_PADLOCK_C) && \
+    defined(__GNUC__) && defined(MBEDTLS_ARCH_IS_X86) && \
+    defined(MBEDTLS_HAVE_ASM) && \
+    !defined(MBEDTLS_HAVE_ASAN)
 
 #define MBEDTLS_VIA_PADLOCK_HAVE_CODE
 


### PR DESCRIPTION
## Description

There are many place to detect target architecture, this PR add utility macros for this purpose.

relative to: #7078 .
see also :https://github.com/Mbed-TLS/mbedtls/pull/7384#discussion_r1296594488
preceding-PR: #7384 


## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [X] **changelog** provided, or not required
- [ ] **backport** done, or not required
- [X] **tests** provided, or not required


