### PR TITLE
[Backport 2.28] Coverity fix: Set `type_id` in `x509_get_other_name()`

### DIFF
--- a/ChangeLog.d/initialize-struct-get-other-name.txt
+++ b/ChangeLog.d/initialize-struct-get-other-name.txt
@@ -1,7 +1,7 @@
 Bugfix
    * Fix an issue when parsing an otherName subject alternative name into a
      mbedtls_x509_san_other_name struct. The type-id of the otherName was not
-   	 copied to the struct. This meant that the struct had incomplete
+     copied to the struct. This meant that the struct had incomplete
      information about the otherName SAN and contained uninitialized memory.
    * Fix the detection of HardwareModuleName otherName SANs. These were being
      detected by comparing the wrong field and the check was erroneously

--- a/ChangeLog.d/initialize-struct-get-other-name.txt
+++ b/ChangeLog.d/initialize-struct-get-other-name.txt
@@ -1,0 +1,8 @@
+Bugfix
+   * Fix an issue when parsing an otherName subject alternative name into a
+     mbedtls_x509_san_other_name struct. The type-id of the otherName was not
+   	 copied to the struct. This meant that the struct had incomplete
+     information about the otherName SAN and contained uninitialized memory.
+   * Fix the detection of HardwareModuleName otherName SANs. These were being
+     detected by comparing the wrong field and the check was erroneously
+     inverted.

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -1741,6 +1741,7 @@ static int x509_get_other_name(const mbedtls_x509_buf *subject_alt_name,
     if (MBEDTLS_OID_CMP(MBEDTLS_OID_ON_HW_MODULE_NAME, &cur_oid) != 0) {
         return MBEDTLS_ERR_X509_FEATURE_UNAVAILABLE;
     }
+    other_name->type_id = cur_oid;
 
     p += len;
     if ((ret = mbedtls_asn1_get_tag(&p, end, &len,

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -1830,7 +1830,7 @@ static int x509_info_subject_alt_name(char **buf, size_t *size,
                 MBEDTLS_X509_SAFE_SNPRINTF;
 
                 if (MBEDTLS_OID_CMP(MBEDTLS_OID_ON_HW_MODULE_NAME,
-                                    &other_name->value.hardware_module_name.oid) != 0) {
+                                    &other_name->type_id) == 0) {
                     ret = mbedtls_snprintf(p, n, "\n%s        hardware module name :", prefix);
                     MBEDTLS_X509_SAFE_SNPRINTF;
                     ret =

--- a/tests/suites/test_suite_x509parse.function
+++ b/tests/suites/test_suite_x509parse.function
@@ -240,7 +240,7 @@ int verify_parse_san(mbedtls_x509_subject_alternative_name *san,
             MBEDTLS_X509_SAFE_SNPRINTF;
 
             if (MBEDTLS_OID_CMP(MBEDTLS_OID_ON_HW_MODULE_NAME,
-                                &san->san.other_name.value.hardware_module_name.oid) != 0) {
+                                &san->san.other_name.type_id) == 0) {
                 ret = mbedtls_snprintf(p, n, " hardware module name :");
                 MBEDTLS_X509_SAFE_SNPRINTF;
                 ret = mbedtls_snprintf(p, n, " hardware type : ");


### PR DESCRIPTION
Small but not trivial backport of #8095.

Main difference: Functions that deal with `HardwareModuleName` are in `x509_crt.c` not in `x509.c` as in `development`

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** provided
- [x] **backport** of #8095
- [ ] **tests** provided, or not required