### PR TITLE
Prepare to split config_psa.h

### DIFF
--- a/ChangeLog.d/psa_crypto_user_config_file.txt
+++ b/ChangeLog.d/psa_crypto_user_config_file.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Don't try to include MBEDTLS_PSA_CRYPTO_USER_CONFIG_FILE when
+     MBEDTLS_PSA_CRYPTO_CONFIG is disabled.

--- a/include/mbedtls/build_info.h
+++ b/include/mbedtls/build_info.h
@@ -88,11 +88,10 @@
 #else
 #include "psa/crypto_config.h"
 #endif
-#endif /* defined(MBEDTLS_PSA_CRYPTO_CONFIG) */
-
 #if defined(MBEDTLS_PSA_CRYPTO_USER_CONFIG_FILE)
 #include MBEDTLS_PSA_CRYPTO_USER_CONFIG_FILE
 #endif
+#endif /* defined(MBEDTLS_PSA_CRYPTO_CONFIG) */
 
 /* Auto-enable MBEDTLS_CTR_DRBG_USE_128_BIT_KEY if
  * MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH and MBEDTLS_CTR_DRBG_C defined

--- a/include/mbedtls/build_info.h
+++ b/include/mbedtls/build_info.h
@@ -59,6 +59,7 @@
 #define inline __inline
 #endif
 
+/* X.509, TLS and non-PSA crypto configuration */
 #if !defined(MBEDTLS_CONFIG_FILE)
 #include "mbedtls/mbedtls_config.h"
 #else
@@ -78,6 +79,19 @@
  */
 #if defined(MBEDTLS_USER_CONFIG_FILE)
 #include MBEDTLS_USER_CONFIG_FILE
+#endif
+
+/* PSA crypto configuration */
+#if defined(MBEDTLS_PSA_CRYPTO_CONFIG)
+#if defined(MBEDTLS_PSA_CRYPTO_CONFIG_FILE)
+#include MBEDTLS_PSA_CRYPTO_CONFIG_FILE
+#else
+#include "psa/crypto_config.h"
+#endif
+#endif /* defined(MBEDTLS_PSA_CRYPTO_CONFIG) */
+
+#if defined(MBEDTLS_PSA_CRYPTO_USER_CONFIG_FILE)
+#include MBEDTLS_PSA_CRYPTO_USER_CONFIG_FILE
 #endif
 
 /* Auto-enable MBEDTLS_CTR_DRBG_USE_128_BIT_KEY if

--- a/include/mbedtls/config_psa.h
+++ b/include/mbedtls/config_psa.h
@@ -44,10 +44,6 @@
 
 #include "psa/crypto_legacy.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 
 
 /****************************************************************/
@@ -1073,9 +1069,5 @@ extern "C" {
 #define PSA_WANT_KEY_TYPE_PASSWORD 1
 #define PSA_WANT_KEY_TYPE_PASSWORD_HASH 1
 #define PSA_WANT_KEY_TYPE_RAW_DATA 1
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* MBEDTLS_CONFIG_PSA_H */

--- a/include/mbedtls/config_psa.h
+++ b/include/mbedtls/config_psa.h
@@ -30,18 +30,6 @@
 #ifndef MBEDTLS_CONFIG_PSA_H
 #define MBEDTLS_CONFIG_PSA_H
 
-#if defined(MBEDTLS_PSA_CRYPTO_CONFIG)
-#if defined(MBEDTLS_PSA_CRYPTO_CONFIG_FILE)
-#include MBEDTLS_PSA_CRYPTO_CONFIG_FILE
-#else
-#include "psa/crypto_config.h"
-#endif
-#endif /* defined(MBEDTLS_PSA_CRYPTO_CONFIG) */
-
-#if defined(MBEDTLS_PSA_CRYPTO_USER_CONFIG_FILE)
-#include MBEDTLS_PSA_CRYPTO_USER_CONFIG_FILE
-#endif
-
 #include "psa/crypto_legacy.h"
 
 

--- a/include/psa/crypto_config.h
+++ b/include/psa/crypto_config.h
@@ -92,7 +92,8 @@
 #define PSA_WANT_ALG_TLS12_PSK_TO_MS            1
 #define PSA_WANT_ALG_TLS12_ECJPAKE_TO_PMS       1
 
-/* Note: when adding support, also adjust include/mbedtls/config_psa.h */
+/* XTS is not yet supported via the PSA API in Mbed TLS.
+ * Note: when adding support, also adjust include/mbedtls/config_psa.h */
 //#define PSA_WANT_ALG_XTS                        1
 
 #define PSA_WANT_ECC_BRAINPOOL_P_R1_256         1

--- a/programs/test/generate_cpp_dummy_build.sh
+++ b/programs/test/generate_cpp_dummy_build.sh
@@ -63,6 +63,7 @@ EOF
     for header in include/mbedtls/*.h include/psa/*.h; do
         case ${header#include/} in
             mbedtls/mbedtls_config.h) :;; # not meant for direct inclusion
+            mbedtls/config_*.h) :;; # not meant for direct inclusion
             psa/crypto_config.h) :;; # not meant for direct inclusion
             # Some of the psa/crypto_*.h headers are not meant to be included
             # directly. They do have include guards that make them no-ops if

--- a/tests/include/test/drivers/config_test_driver.h
+++ b/tests/include/test/drivers/config_test_driver.h
@@ -53,7 +53,4 @@
 //#define MBEDTLS_PEM_PARSE_C
 //#define MBEDTLS_BASE64_C
 
-#include "mbedtls/config_psa.h"
-#include "mbedtls/check_config.h"
-
 #endif /* MBEDTLS_CONFIG_H */


### PR DESCRIPTION
These are minor things from https://github.com/Mbed-TLS/mbedtls/pull/7615 which don't have much impact, but will make the actual split easier. No semantic change except that "Fix condition to include MBEDTLS_PSA_CRYPTO_USER_CONFIG_FILE" fixes how a marginal configuration is handled.

This is step 1 of 3+. [Next steps](https://github.com/Mbed-TLS/mbedtls/pull/7615#issuecomment-1686447123): actually split `config_psa.h`, then fix some of the problems with the ordering.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required
- [x] **backport** no
- [x] **tests** not required
