### PR TITLE
Add changelog entry for 2.28 IAR warning fixes

### DIFF
--- a/ChangeLog.d/fix-iar-compiler-warnings.txt
+++ b/ChangeLog.d/fix-iar-compiler-warnings.txt
@@ -1,0 +1,2 @@
+Bugfix
+   * Fix IAR compiler warnings. Fixes #7873, #4300.


### PR DESCRIPTION
## Description

Changelog entry for recent IAR compiler warning fixes.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** provided
- [ ] **backport** this is the backport of #8084 (ChangeLog entry only)
- [ ] **tests** not required

