### PR TITLE
Feature/disable src generation release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,11 +56,6 @@ option(ENABLE_PROGRAMS "Build mbed TLS programs." ON)
 
 option(UNSAFE_BUILD "Allow unsafe builds. These builds ARE NOT SECURE." OFF)
 option(MBEDTLS_FATAL_WARNINGS "Compiler warnings treated as errors" ON)
-if(CMAKE_HOST_WIN32)
-    option(GEN_FILES "Generate the auto-generated files as needed" OFF)
-else()
-    option(GEN_FILES "Generate the auto-generated files as needed" ON)
-endif()
 
 option(DISABLE_PACKAGE_CONFIG_AND_INSTALL "Disable package configuration, target export and installation" ${MBEDTLS_AS_SUBPROJECT})
 
@@ -68,6 +63,21 @@ string(REGEX MATCH "Clang" CMAKE_COMPILER_IS_CLANG "${CMAKE_C_COMPILER_ID}")
 string(REGEX MATCH "GNU" CMAKE_COMPILER_IS_GNU "${CMAKE_C_COMPILER_ID}")
 string(REGEX MATCH "IAR" CMAKE_COMPILER_IS_IAR "${CMAKE_C_COMPILER_ID}")
 string(REGEX MATCH "MSVC" CMAKE_COMPILER_IS_MSVC "${CMAKE_C_COMPILER_ID}")
+
+# Only attempt to auto-detect if the user has not explicitly
+# overriden the -D GEN_FILES.
+if(NOT DEFINED GEN_FILES)
+    option(GEN_FILES "Generate the auto-generated files as needed" ON)
+    execute_process(COMMAND git describe --exact-match HEAD
+                        OUTPUT_QUIET ERROR_QUIET RESULT_VARIABLE result)
+    if(${result} EQUAL 0)
+        message(INFO "Configuring on release tag, disabling file auto-generation.")
+        set(GEN_FILES OFF)
+    elseif(CMAKE_HOST_WIN32)
+        message(INFO "Configuring on Windows Host, disabling file auto-generation.")
+        set(GEN_FILES OFF)
+    endif()
+endif()
 
 # the test suites currently have compile errors with MSVC
 if(CMAKE_COMPILER_IS_MSVC)

--- a/ChangeLog.d/platform-update-autogenerated-behaviour.txt
+++ b/ChangeLog.d/platform-update-autogenerated-behaviour.txt
@@ -1,0 +1,2 @@
+Default behavior changes
+   * Automatic file generation is disabled by default on release build tags.

--- a/Makefile
+++ b/Makefile
@@ -31,10 +31,12 @@ tests/%:
 	$(MAKE) -C tests $*
 
 .PHONY: generated_files
+ifneq ($(GEN_FILES), 0)
 generated_files: library/generated_files
 generated_files: programs/generated_files
 generated_files: tests/generated_files
 generated_files: visualc_files
+endif
 
 .PHONY: visualc_files
 VISUALC_FILES = visualc/VS2013/mbedTLS.sln visualc/VS2013/mbedTLS.vcxproj

--- a/Makefile
+++ b/Makefile
@@ -31,12 +31,10 @@ tests/%:
 	$(MAKE) -C tests $*
 
 .PHONY: generated_files
-ifneq ($(GEN_FILES), 0)
 generated_files: library/generated_files
 generated_files: programs/generated_files
 generated_files: tests/generated_files
 generated_files: visualc_files
-endif
 
 .PHONY: visualc_files
 VISUALC_FILES = visualc/VS2013/mbedTLS.sln visualc/VS2013/mbedTLS.vcxproj

--- a/library/Makefile
+++ b/library/Makefile
@@ -309,6 +309,7 @@ libmbedcrypto.dll: $(OBJS_CRYPTO)
 	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) -o $@ -c $<
 
 .PHONY: generated_files
+ifneq ($(GEN_FILES), 0)
 GENERATED_FILES = \
 	error.c version_features.c \
 	ssl_debug_helpers_generated.c \
@@ -345,6 +346,7 @@ psa_crypto_driver_wrappers.c: ../scripts/data_files/driver_templates/psa_crypto_
 psa_crypto_driver_wrappers.c:
 	echo "  Gen   $@"
 	$(PYTHON) ../scripts/generate_driver_wrappers.py
+endif
 
 clean:
 ifndef WINDOWS

--- a/library/Makefile
+++ b/library/Makefile
@@ -309,6 +309,13 @@ libmbedcrypto.dll: $(OBJS_CRYPTO)
 	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) -o $@ -c $<
 
 .PHONY: generated_files
+ifndef WINDOWS
+    GIT_DESCR := $(shell git describe --exact-match HEAD  >> /dev/null 2>&1; echo $$?)
+    ifeq ($(GIT_DESCR), 0)
+        GEN_FILES = 0
+    endif
+endif
+
 ifneq ($(GEN_FILES), 0)
 GENERATED_FILES = \
 	error.c version_features.c \

--- a/programs/Makefile
+++ b/programs/Makefile
@@ -173,6 +173,7 @@ ${MBEDTLS_TEST_OBJS}:
 	$(MAKE) -C ../tests mbedtls_test
 
 .PHONY: generated_files
+ifneq ($(GEN_FILES), 0)
 GENERATED_FILES = psa/psa_constant_names_generated.c test/query_config.c
 generated_files: $(GENERATED_FILES)
 
@@ -195,6 +196,7 @@ test/query_config.c: ../scripts/data_files/query_config.fmt
 test/query_config.c:
 	echo "  Gen   $@"
 	$(PERL) ../scripts/generate_query_config.pl
+endif
 
 aes/crypt_and_hash$(EXEXT): aes/crypt_and_hash.c $(DEP)
 	echo "  CC    aes/crypt_and_hash.c"

--- a/programs/Makefile
+++ b/programs/Makefile
@@ -173,6 +173,13 @@ ${MBEDTLS_TEST_OBJS}:
 	$(MAKE) -C ../tests mbedtls_test
 
 .PHONY: generated_files
+ifndef WINDOWS
+    GIT_DESCR := $(shell git describe --exact-match HEAD  >> /dev/null 2>&1; echo $$?)
+    ifeq ($(GIT_DESCR), 0)
+        GEN_FILES = 0
+    endif
+endif
+
 ifneq ($(GEN_FILES), 0)
 GENERATED_FILES = psa/psa_constant_names_generated.c test/query_config.c
 generated_files: $(GENERATED_FILES)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -66,6 +66,13 @@ PYTHON ?= $(shell if type python3 >/dev/null 2>/dev/null; then echo python3; els
 endif
 
 .PHONY: generated_files
+ifndef WINDOWS
+    GIT_DESCR := $(shell git describe --exact-match HEAD  >> /dev/null 2>&1; echo $$?)
+    ifeq ($(GIT_DESCR), 0)
+        GEN_FILES = 0
+    endif
+endif
+
 ifneq ($(GEN_FILES), 0)
 GENERATED_BIGNUM_DATA_FILES := $(patsubst tests/%,%,$(shell \
 	$(PYTHON) scripts/generate_bignum_tests.py --list || \

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -66,6 +66,7 @@ PYTHON ?= $(shell if type python3 >/dev/null 2>/dev/null; then echo python3; els
 endif
 
 .PHONY: generated_files
+ifneq ($(GEN_FILES), 0)
 GENERATED_BIGNUM_DATA_FILES := $(patsubst tests/%,%,$(shell \
 	$(PYTHON) scripts/generate_bignum_tests.py --list || \
 	echo FAILED \
@@ -140,6 +141,7 @@ generated_psa_test_data: suites/test_suite_psa_crypto_metadata.data
 generated_psa_test_data:
 	echo "  Gen   $(GENERATED_PSA_DATA_FILES) ..."
 	$(PYTHON) scripts/generate_psa_tests.py
+endif
 
 # A test application is built for each suites/test_suite_*.data file.
 # Application name is same as .data file's base name and can be


### PR DESCRIPTION
## Description

Resolves #5432 . The changes introduced will de-assert the `GEN_FILES` flag when building a release using cmake `CMAKE_BUILD_TYPE:String=Release`.

It also modifies the make system in a way that the use can explicitely disable automatic file generation through the enviroment.
`make GEN_FILES=0`

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** provided
- [x] **backport**Not required. Thisi s a not a feature that needs to be backported.
- [x] **tests** Not required. Tests exist, just updated according to the changes brought forward.


