### PR TITLE
Announce that #7420 is fixed

### DIFF
--- a/ChangeLog.d/config_psa-include-order.txt
+++ b/ChangeLog.d/config_psa-include-order.txt
@@ -1,0 +1,4 @@
+Bugfix
+   * Fix a build error in some configurations with MBEDTLS_PSA_CRYPTO_CONFIG
+     enabled, where some low-level modules required by requested PSA crypto
+     features were not getting automatically enabled. Fixes #7420.


### PR DESCRIPTION
This is just a changelog entry for an issue #7420 that we're resolving in pieces. The next release will have fixed the user-visible part, so we should announce it in the changelog.

This is part of a bigger issue https://github.com/Mbed-TLS/mbedtls/issues/7609 which is still pending since there are still configurations that are not handled correctly. However we have essentially resolved #7420:

* https://github.com/Mbed-TLS/mbedtls/pull/7611 moved the inclusion of `config_psa.h` in `build_info.h` as requested.
* https://github.com/Mbed-TLS/mbedtls/pull/7650 constitutes a non-regression test via the TF-M reference configuration.
* #7420 also requests a comment in `build_info.h` to explain the inclusion order. This is important: after https://github.com/Mbed-TLS/mbedtls/pull/7611, the requested order was broken by some new additions. However, the requested order in #7420 is [only a simplification of what should be the correct order](https://github.com/Mbed-TLS/mbedtls/pull/8094#discussion_r1303240209), and the correct order is a much bigger task https://github.com/Mbed-TLS/mbedtls/issues/7609. So adding this comment can either be done via https://github.com/Mbed-TLS/mbedtls/pull/8094 or be deferred to #7609.
