### PR TITLE
Disable p256-m asm on aarch64

### DIFF
--- a/3rdparty/p256-m/p256-m/p256-m.c
+++ b/3rdparty/p256-m/p256-m/p256-m.c
@@ -199,10 +199,12 @@ static uint64_t u32_muladd64(uint32_t x, uint32_t y, uint32_t z, uint32_t t);
  * Currently assembly optimisations are only supported with GCC/Clang for
  * Arm's Cortex-A and Cortex-M lines of CPUs, which start with the v6-M and
  * v7-M architectures. __ARM_ARCH_PROFILE is not defined for v6 and earlier.
+ * Thumb and 32-bit assembly is supported; aarch64 is not supported.
  */
 #if defined(__GNUC__) &&\
     defined(__ARM_ARCH) && __ARM_ARCH >= 6 && defined(__ARM_ARCH_PROFILE) && \
-    ( __ARM_ARCH_PROFILE == 77 || __ARM_ARCH_PROFILE == 65 ) /* 'M' or 'A' */
+    ( __ARM_ARCH_PROFILE == 77 || __ARM_ARCH_PROFILE == 65 ) /* 'M' or 'A' */ && \
+    !defined(__aarch64__)
 
 /*
  * This set of CPUs is conveniently partitioned as follows:


### PR DESCRIPTION
## Description

The optimised assembly in p256-m does not support aarch64. With this PR, it compiles cleanly for Thumb 1, Thumb 2, arm and aarch64 (tested with `mtest MBEDTLS_P256M_EXAMPLE_DRIVER_ENABLED thumb1 thumb2 arm aarch64 clang gcc`).

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not previously released
- [x] **backport** not in 2.28
- [x] **tests** out of scope for this PR - we should add build tests as part of p256-m productisation
