### PR TITLE
Backport 2.28: check_test_cases.py: support to collect test cases for compat.sh

### DIFF
--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -40,7 +40,6 @@ TESTS=0
 FAILED=0
 SKIPPED=0
 SRVMEM=0
-LIST_TEST_CASE=0
 
 # default commands, can be overridden by the environment
 : ${M_SRV:=../programs/ssl/ssl_server2}
@@ -134,6 +133,14 @@ print_usage() {
     printf "                   \t(default: \$MBEDTLS_TEST_OUTCOME_FILE, none if empty)\n"
 }
 
+# print_test_case <CLIENT> <SERVER> <STANDARD_CIPHER_SUITE>
+print_test_case() {
+    for i in $3; do
+        uniform_title $1 $2 $i
+        echo $TITLE
+    done
+}
+
 list_test_case() {
     reset_ciphersuites
     for TYPE in $TYPES; do
@@ -146,11 +153,11 @@ list_test_case() {
     for VERIFY in $VERIFIES; do
         VERIF=$(echo $VERIFY | tr '[:upper:]' '[:lower:]')
         for MODE in $MODES; do
-            print_test_title m O "$O_CIPHERS"
-            print_test_title O m "$O_CIPHERS"
-            print_test_title m G "$G_CIPHERS"
-            print_test_title G m "$G_CIPHERS"
-            print_test_title m m "$M_CIPHERS"
+            print_test_case m O "$O_CIPHERS"
+            print_test_case O m "$O_CIPHERS"
+            print_test_case m G "$G_CIPHERS"
+            print_test_case G m "$G_CIPHERS"
+            print_test_case m m "$M_CIPHERS"
         done
     done
 }
@@ -183,7 +190,6 @@ get_options() {
                 MEMCHECK=1
                 ;;
             --list-test-case)
-                LIST_TEST_CASE=1
                 list_test_case
                 exit 0
                 ;;
@@ -1227,21 +1233,21 @@ report_fail() {
     fi
 }
 
-# print_test_title <CLIENT> <SERVER> <STANDARD_CIPHER_SUITE>
-print_test_title() {
-    for i in $3; do
-        TITLE="$1->$2 $MODE,$VERIF $i"
-        DOTS72="........................................................................"
-        printf "%s %.*s " "$TITLE" "$((71 - ${#TITLE}))" "$DOTS72"
-        [ $LIST_TEST_CASE -eq 1 ] && printf "\n"
-    done
+# uniform_title <CLIENT> <SERVER> <STANDARD_CIPHER_SUITE>
+# $TITLE is considered as test case description for both --list-test-case and
+# MBEDTLS_TEST_OUTCOME_FILE. This function aims to control the format of
+# each test case description.
+uniform_title() {
+    TITLE="$1->$2 $MODE,$VERIF $3"
 }
 
 # run_client <name> <cipher>
 run_client() {
     # announce what we're going to do
     TESTS=$(( $TESTS + 1 ))
-    print_test_title ${1%"${1#?}"} ${SERVER_NAME%"${SERVER_NAME#?}"} $2
+    uniform_title "${1%"${1#?}"}" "${SERVER_NAME%"${SERVER_NAME#?}"}" $2
+    DOTS72="........................................................................"
+    printf "%s %.*s " "$TITLE" "$((71 - ${#TITLE}))" "$DOTS72"
 
     # should we skip?
     if [ "X$SKIP_NEXT" = "XYES" ]; then

--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -128,8 +128,38 @@ print_usage() {
     printf "            \tAlso available: GnuTLS (needs v3.2.15 or higher)\n"
     printf "  -M|--memcheck\tCheck memory leaks and errors.\n"
     printf "  -v|--verbose\tSet verbose output.\n"
+    printf "     --list-test-case\tList all potential test cases (No Execution)\n"
     printf "     --outcome-file\tFile where test outcomes are written\n"
     printf "                   \t(default: \$MBEDTLS_TEST_OUTCOME_FILE, none if empty)\n"
+}
+
+# print_test_title <CLIENT> <SERVER> <STANDARD_CIPHER_SUITE>
+print_test_title() {
+    for i in $3; do
+        TITLE="$1->$2 $MODE,$VERIF $i"
+        echo "$TITLE"
+    done
+}
+
+list_test_case() {
+    reset_ciphersuites
+    for TYPE in $TYPES; do
+        add_common_ciphersuites
+        add_openssl_ciphersuites
+        add_gnutls_ciphersuites
+        add_mbedtls_ciphersuites
+    done
+
+    for VERIFY in $VERIFIES; do
+        VERIF=$(echo $VERIFY | tr '[:upper:]' '[:lower:]')
+        for MODE in $MODES; do
+            print_test_title m o "$O_CIPHERS"
+            print_test_title o m "$O_CIPHERS"
+            print_test_title m g "$G_CIPHERS"
+            print_test_title g m "$G_CIPHERS"
+            print_test_title m m "$M_CIPHERS"
+        done
+    done
 }
 
 get_options() {
@@ -158,6 +188,10 @@ get_options() {
                 ;;
             -M|--memcheck)
                 MEMCHECK=1
+                ;;
+            --list-test-case)
+                list_test_case
+                exit 0
                 ;;
             --outcome-file)
                 shift; MBEDTLS_TEST_OUTCOME_FILE=$1

--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -194,7 +194,7 @@ get_options() {
             # if you have to modify option, --list-test-case
             --list-test-case)
                 list_test_case
-                exit 0
+                exit $?
                 ;;
             --outcome-file)
                 shift; MBEDTLS_TEST_OUTCOME_FILE=$1

--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -146,10 +146,10 @@ list_test_case() {
     for VERIFY in $VERIFIES; do
         VERIF=$(echo $VERIFY | tr '[:upper:]' '[:lower:]')
         for MODE in $MODES; do
-            print_test_title m o "$O_CIPHERS"
-            print_test_title o m "$O_CIPHERS"
-            print_test_title m g "$G_CIPHERS"
-            print_test_title g m "$G_CIPHERS"
+            print_test_title m O "$O_CIPHERS"
+            print_test_title O m "$O_CIPHERS"
+            print_test_title m G "$G_CIPHERS"
+            print_test_title G m "$G_CIPHERS"
             print_test_title m m "$M_CIPHERS"
         done
     done

--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -143,22 +143,21 @@ print_test_case() {
 
 # list_test_case lists all potential test cases in compat.sh without execution
 list_test_case() {
-    reset_ciphersuites
-    for TYPE in $TYPES; do
-        add_common_ciphersuites
-        add_openssl_ciphersuites
-        add_gnutls_ciphersuites
-        add_mbedtls_ciphersuites
-    done
-
-    for VERIFY in $VERIFIES; do
-        VERIF=$(echo $VERIFY | tr '[:upper:]' '[:lower:]')
-        for MODE in $MODES; do
-            print_test_case m O "$O_CIPHERS"
-            print_test_case O m "$O_CIPHERS"
-            print_test_case m G "$G_CIPHERS"
-            print_test_case G m "$G_CIPHERS"
-            print_test_case m m "$M_CIPHERS"
+    for MODE in $MODES; do
+        for TYPE in $TYPES; do
+            for VERIFY in $VERIFIES; do
+                VERIF=$(echo $VERIFY | tr '[:upper:]' '[:lower:]')
+                reset_ciphersuites
+                add_common_ciphersuites
+                add_openssl_ciphersuites
+                add_gnutls_ciphersuites
+                add_mbedtls_ciphersuites
+                print_test_case m O "$O_CIPHERS"
+                print_test_case O m "$O_CIPHERS"
+                print_test_case m G "$G_CIPHERS"
+                print_test_case G m "$G_CIPHERS"
+                print_test_case m m "$M_CIPHERS"
+            done
         done
     done
 }

--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -40,6 +40,7 @@ TESTS=0
 FAILED=0
 SKIPPED=0
 SRVMEM=0
+LIST_TEST_CASE=0
 
 # default commands, can be overridden by the environment
 : ${M_SRV:=../programs/ssl/ssl_server2}
@@ -133,14 +134,6 @@ print_usage() {
     printf "                   \t(default: \$MBEDTLS_TEST_OUTCOME_FILE, none if empty)\n"
 }
 
-# print_test_title <CLIENT> <SERVER> <STANDARD_CIPHER_SUITE>
-print_test_title() {
-    for i in $3; do
-        TITLE="$1->$2 $MODE,$VERIF $i"
-        echo "$TITLE"
-    done
-}
-
 list_test_case() {
     reset_ciphersuites
     for TYPE in $TYPES; do
@@ -190,6 +183,7 @@ get_options() {
                 MEMCHECK=1
                 ;;
             --list-test-case)
+                LIST_TEST_CASE=1
                 list_test_case
                 exit 0
                 ;;
@@ -1233,15 +1227,21 @@ report_fail() {
     fi
 }
 
+# print_test_title <CLIENT> <SERVER> <STANDARD_CIPHER_SUITE>
+print_test_title() {
+    for i in $3; do
+        TITLE="$1->$2 $MODE,$VERIF $i"
+        DOTS72="........................................................................"
+        printf "%s %.*s " "$TITLE" "$((71 - ${#TITLE}))" "$DOTS72"
+        [ $LIST_TEST_CASE -eq 1 ] && printf "\n"
+    done
+}
+
 # run_client <name> <cipher>
 run_client() {
     # announce what we're going to do
     TESTS=$(( $TESTS + 1 ))
-    TITLE="`echo $1 | head -c1`->`echo $SERVER_NAME | head -c1`"
-    TITLE="$TITLE $MODE,$VERIF $2"
-    printf "%s " "$TITLE"
-    LEN=$(( 72 - `echo "$TITLE" | wc -c` ))
-    for i in `seq 1 $LEN`; do printf '.'; done; printf ' '
+    print_test_title ${1%"${1#?}"} ${SERVER_NAME%"${SERVER_NAME#?}"} $2
 
     # should we skip?
     if [ "X$SKIP_NEXT" = "XYES" ]; then

--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -141,6 +141,7 @@ print_test_case() {
     done
 }
 
+# list_test_case lists all potential test cases in compat.sh without execution
 list_test_case() {
     reset_ciphersuites
     for TYPE in $TYPES; do
@@ -189,6 +190,8 @@ get_options() {
             -M|--memcheck)
                 MEMCHECK=1
                 ;;
+            # Please check scripts/check_test_cases.py correspondingly
+            # if you have to modify option, --list-test-case
             --list-test-case)
                 list_test_case
                 exit 0

--- a/tests/scripts/check_test_cases.py
+++ b/tests/scripts/check_test_cases.py
@@ -123,8 +123,8 @@ state may override this method.
             print(*compat_cmd, 'returned', str(result.returncode))
             return
         else:
-            # Pattern: g->m dtls12,no TLS_DHE_PSK_WITH_AES_128_CBC_SHA\n
-            m = re.findall(br'[^ogm]*((?:[ogm]->[ogm]\s*\w*.\w*\s\w*)*)\n',
+            # Pattern: g->m dtls12,no TLS_DHE_PSK_WITH_AES_128_CBC_SHA .......... \n
+            m = re.findall(br'[^ogm]*((?:[ogm]->[ogm]\s*\w*.\w*\s\w*)*)\s*\.*\s*\n',
                            result.stdout)
             if m:
                 for i in m:

--- a/tests/scripts/check_test_cases.py
+++ b/tests/scripts/check_test_cases.py
@@ -116,8 +116,7 @@ state may override this method.
         """Iterate over the test cases compat.sh with a similar format."""
         descriptions = self.new_per_file_state() # pylint: disable=assignment-from-none
         compat_cmd = ['sh', file_name, '--list-test-case']
-        compat_output = subprocess.check_output(compat_cmd,
-                                                stderr=subprocess.STDOUT)
+        compat_output = subprocess.check_output(compat_cmd)
         # Assume compat.sh is responsible for printing identical format of
         # test case description between --list-test-case and its OUTCOME.CSV
         description = compat_output.strip().split(b'\n')

--- a/tests/scripts/check_test_cases.py
+++ b/tests/scripts/check_test_cases.py
@@ -116,18 +116,13 @@ state may override this method.
         """Iterate over the test cases compat.sh with a similar format."""
         descriptions = self.new_per_file_state() # pylint: disable=assignment-from-none
         compat_cmd = ['sh', file_name, '--list-test-case']
-        result = subprocess.run(compat_cmd,
-                                stdout=subprocess.PIPE,
-                                check=False)
-        if result.returncode != 0:
-            print(*compat_cmd, 'returned', str(result.returncode))
-            return
-        else:
-            # Assume compat.sh is responsible for printing identical format of
-            # test case description between --list-test-case and its OUTCOME.CSV
-            description = result.stdout.strip().split(b'\n')
-            for idx, descrip in enumerate(description):
-                self.process_test_case(descriptions, file_name, idx, descrip)
+        compat_output = subprocess.check_output(compat_cmd,
+                                                stderr=subprocess.STDOUT)
+        # Assume compat.sh is responsible for printing identical format of
+        # test case description between --list-test-case and its OUTCOME.CSV
+        description = compat_output.strip().split(b'\n')
+        for idx, descrip in enumerate(description):
+            self.process_test_case(descriptions, file_name, idx, descrip)
 
     @staticmethod
     def collect_test_directories():

--- a/tests/scripts/check_test_cases.py
+++ b/tests/scripts/check_test_cases.py
@@ -123,12 +123,11 @@ state may override this method.
             print(*compat_cmd, 'returned', str(result.returncode))
             return
         else:
-            # Pattern: g->m dtls12,no TLS_DHE_PSK_WITH_AES_128_CBC_SHA .......... \n
-            m = re.findall(br'[^ogm]*((?:[ogm]->[ogm]\s*\w*.\w*\s\w*)*)\s*\.*\s*\n',
-                           result.stdout)
-            if m:
-                for i in m:
-                    self.process_test_case(descriptions, file_name, 1, i)
+            # Assume compat.sh is responsible for printing identical format of
+            # test case description between --list-test-case and its OUTCOME.CSV
+            description = result.stdout.strip().split(b'\n')
+            for idx, descrip in enumerate(description):
+                self.process_test_case(descriptions, file_name, idx, descrip)
 
     @staticmethod
     def collect_test_directories():

--- a/tests/scripts/check_test_cases.py
+++ b/tests/scripts/check_test_cases.py
@@ -25,6 +25,7 @@ import argparse
 import glob
 import os
 import re
+import subprocess
 import sys
 
 class Results:
@@ -111,6 +112,24 @@ state may override this method.
                 self.process_test_case(descriptions,
                                        file_name, line_number, description)
 
+    def walk_compat_sh(self, file_name):
+        """Iterate over the test cases compat.sh with a similar format."""
+        descriptions = self.new_per_file_state() # pylint: disable=assignment-from-none
+        compat_cmd = ['sh', file_name, '--list-test-case']
+        result = subprocess.run(compat_cmd,
+                                stdout=subprocess.PIPE,
+                                check=False)
+        if result.returncode != 0:
+            print(*compat_cmd, 'returned', str(result.returncode))
+            return
+        else:
+            # Pattern: g->m dtls12,no TLS_DHE_PSK_WITH_AES_128_CBC_SHA\n
+            m = re.findall(br'[^ogm]*((?:[ogm]->[ogm]\s*\w*.\w*\s\w*)*)\n',
+                           result.stdout)
+            if m:
+                for i in m:
+                    self.process_test_case(descriptions, file_name, 1, i)
+
     @staticmethod
     def collect_test_directories():
         """Get the relative path for the TLS and Crypto test directories."""
@@ -133,6 +152,9 @@ state may override this method.
             ssl_opt_sh = os.path.join(directory, 'ssl-opt.sh')
             if os.path.exists(ssl_opt_sh):
                 self.walk_ssl_opt_sh(ssl_opt_sh)
+            compat_sh = os.path.join(directory, 'compat.sh')
+            if os.path.exists(compat_sh):
+                self.walk_compat_sh(compat_sh)
 
 class TestDescriptions(TestDescriptionExplorer):
     """Collect the available test cases."""

--- a/tests/scripts/check_test_cases.py
+++ b/tests/scripts/check_test_cases.py
@@ -120,6 +120,8 @@ state may override this method.
         # Assume compat.sh is responsible for printing identical format of
         # test case description between --list-test-case and its OUTCOME.CSV
         description = compat_output.strip().split(b'\n')
+        # idx indicates the number of test case since there is no line number
+        # in `compat.sh` for each test case.
         for idx, descrip in enumerate(description):
             self.process_test_case(descriptions, file_name, idx, descrip)
 


### PR DESCRIPTION
## Description

Backport of #7165 

## Comments

This PR adds support to list all potential test cases in `compat.sh` by `./tests/compat.sh --list-test-case`. Therefore, `check_test_cases.py` is able to collect those test case description in order to report duplicated test cases.

To analyze outcome by `analyze_outcomes.py`, the test case description should be identical with `OUTCOME.CSV` in #7136 . Please consider those two PRs together. 

## Gatekeeper checklist

- [x] **changelog** not required
- [x] **backport** of https://github.com/Mbed-TLS/mbedtls/pull/7165
- [x] **tests** not required

