### PR TITLE
Fix unnecessary header prefixes in tests

### DIFF
--- a/tests/suites/test_suite_common.function
+++ b/tests/suites/test_suite_common.function
@@ -1,5 +1,5 @@
 /* BEGIN_HEADER */
-#include "../library/common.h"
+#include "common.h"
 
 void fill_arrays(unsigned char *a, unsigned char *b, unsigned char *r1, unsigned char *r2, size_t n)
 {

--- a/tests/suites/test_suite_psa_its.function
+++ b/tests/suites/test_suite_psa_its.function
@@ -10,7 +10,7 @@
  * before changing how test data is constructed or validated.
  */
 
-#include "../library/psa_crypto_its.h"
+#include "psa_crypto_its.h"
 
 #include "test/psa_helpers.h"
 


### PR DESCRIPTION
Remove unnecessary `../library` prefix from test suite includes. This makes the tests repo-agnostic between the mbedtls and psa-crypto repos.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required - internal change only
- [x] **backport**  #8132 
- [x] **tests** not required - no functional changes
