### PR TITLE
[Backport 2.28] Fix unnecessary header prefix in tests

### DIFF
--- a/tests/suites/test_suite_psa_its.function
+++ b/tests/suites/test_suite_psa_its.function
@@ -10,7 +10,7 @@
  * before changing how test data is constructed or validated.
  */
 
-#include "../library/psa_crypto_its.h"
+#include "psa_crypto_its.h"
 
 #include "test/psa_helpers.h"
 


### PR DESCRIPTION
Backport of #8130.



## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required - internal change only
- [x] **backport** of #8130 
- [x] **tests** not required - no functional change
