### PR TITLE
Ensure mbedtls_sha3_finish zeroizes the context

### DIFF
--- a/library/sha3.c
+++ b/library/sha3.c
@@ -286,7 +286,7 @@ int mbedtls_sha3_finish(mbedtls_sha3_context *ctx,
     ret = 0;
 
 exit:
-    mbedtls_platform_zeroize(ctx, sizeof(mbedtls_sha3_context));
+    mbedtls_sha3_free(ctx);
     return ret;
 }
 

--- a/library/sha3.c
+++ b/library/sha3.c
@@ -259,10 +259,13 @@ int mbedtls_sha3_update(mbedtls_sha3_context *ctx,
 int mbedtls_sha3_finish(mbedtls_sha3_context *ctx,
                         uint8_t *output, size_t olen)
 {
+    int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
+
     /* Catch SHA-3 families, with fixed output length */
     if (ctx->olen > 0) {
         if (ctx->olen > olen) {
-            return MBEDTLS_ERR_SHA3_BAD_INPUT_DATA;
+            ret = MBEDTLS_ERR_SHA3_BAD_INPUT_DATA;
+            goto exit;
         }
         olen = ctx->olen;
     }
@@ -280,7 +283,11 @@ int mbedtls_sha3_finish(mbedtls_sha3_context *ctx,
         }
     }
 
-    return 0;
+    ret = 0;
+
+exit:
+    mbedtls_platform_zeroize(ctx, sizeof(mbedtls_sha3_context));
+    return ret;
 }
 
 /*

--- a/tests/suites/test_suite_shax.function
+++ b/tests/suites/test_suite_shax.function
@@ -176,9 +176,12 @@ void sha3_invalid_param()
     TEST_EQUAL(mbedtls_sha3_starts(&ctx, MBEDTLS_SHA3_NONE), MBEDTLS_ERR_SHA3_BAD_INPUT_DATA);
 
     TEST_EQUAL(mbedtls_sha3_starts(&ctx, MBEDTLS_SHA3_256), 0);
-
     TEST_EQUAL(mbedtls_sha3_finish(&ctx, output, 0), MBEDTLS_ERR_SHA3_BAD_INPUT_DATA);
+
+    TEST_EQUAL(mbedtls_sha3_starts(&ctx, MBEDTLS_SHA3_256), 0);
     TEST_EQUAL(mbedtls_sha3_finish(&ctx, output, 31), MBEDTLS_ERR_SHA3_BAD_INPUT_DATA);
+
+    TEST_EQUAL(mbedtls_sha3_starts(&ctx, MBEDTLS_SHA3_256), 0);
     TEST_EQUAL(mbedtls_sha3_finish(&ctx, output, 32), 0);
 
 exit:


### PR DESCRIPTION
## Description

Improve zeroization in SHA-3.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required - not previously released
- [x] **backport** not in 2.28
- [x] **tests** covered by existing
