### PR TITLE
Create Cipher light

### DIFF
--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -174,13 +174,53 @@
 #endif
 
 #if defined(MBEDTLS_CMAC_C) && \
-    ( !defined(MBEDTLS_CIPHER_C ) || ( !defined(MBEDTLS_AES_C) && !defined(MBEDTLS_DES_C) ) )
+    ( !defined(MBEDTLS_CIPHER_LIGHT) || ( !defined(MBEDTLS_AES_C) && !defined(MBEDTLS_DES_C) ) )
 #error "MBEDTLS_CMAC_C defined, but not all prerequisites"
 #endif
 
 #if defined(MBEDTLS_NIST_KW_C) && \
     ( !defined(MBEDTLS_AES_C) || !defined(MBEDTLS_CIPHER_C) )
 #error "MBEDTLS_NIST_KW_C defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_CHACHA20_C) && !defined(MBEDTLS_CIPHER_C)
+#error "MBEDTLS_CHACHA20_C defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_CIPHER_NULL_CIPHER) && !defined(MBEDTLS_CIPHER_C)
+#error "MBEDTLS_CIPHER_NULL_CIPHER defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_CIPHER_MODE_CFB) && !defined(MBEDTLS_CIPHER_C)
+#error "MBEDTLS_CIPHER_MODE_CFB defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_CIPHER_MODE_CTR) && !defined(MBEDTLS_CIPHER_C)
+#error "MBEDTLS_CIPHER_MODE_CTR defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_CIPHER_MODE_OFB) && !defined(MBEDTLS_CIPHER_C)
+#error "MBEDTLS_CIPHER_MODE_OFB defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_CIPHER_MODE_XTS) && !defined(MBEDTLS_CIPHER_C)
+#error "MBEDTLS_CIPHER_MODE_XTS defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_CIPHER_PADDING_PKCS7) && !defined(MBEDTLS_CIPHER_C)
+#error "MBEDTLS_CIPHER_PADDING_PKCS7 defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_CIPHER_PADDING_ONE_AND_ZEROS) && !defined(MBEDTLS_CIPHER_C)
+#error "MBEDTLS_CIPHER_PADDING_ONE_AND_ZEROS defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_CIPHER_PADDING_ZEROS_AND_LEN) && !defined(MBEDTLS_CIPHER_C)
+#error "MBEDTLS_CIPHER_PADDING_ZEROS_AND_LEN defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_CIPHER_PADDING_ZEROS) && !defined(MBEDTLS_CIPHER_C)
+#error "MBEDTLS_CIPHER_PADDING_ZEROS defined, but not all prerequisites"
 #endif
 
 #if defined(MBEDTLS_ECDH_C) && !defined(MBEDTLS_ECP_C)
@@ -252,12 +292,11 @@
 #error "MBEDTLS_PK_PARSE_C defined, but not all prerequisites"
 #endif
 
-#if defined(MBEDTLS_PKCS12_C) && !defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_PKCS12_C) && !defined(MBEDTLS_CIPHER_LIGHT)
 #error "MBEDTLS_PKCS12_C defined, but not all prerequisites"
 #endif
 
-#if defined(MBEDTLS_PKCS5_C) && \
-    !defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_PKCS5_C) && !defined(MBEDTLS_CIPHER_LIGHT)
 #error "MBEDTLS_PKCS5_C defined, but not all prerequisites"
 #endif
 
@@ -309,7 +348,7 @@
 #error "MBEDTLS_CCM_C defined, but not all prerequisites"
 #endif
 
-#if defined(MBEDTLS_CCM_C) && !defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CCM_C) && !defined(MBEDTLS_CIPHER_LIGHT)
 #error "MBEDTLS_CCM_C defined, but not all prerequisites"
 #endif
 
@@ -318,7 +357,7 @@
 #error "MBEDTLS_GCM_C defined, but not all prerequisites"
 #endif
 
-#if defined(MBEDTLS_GCM_C) && !defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_GCM_C) && !defined(MBEDTLS_CIPHER_LIGHT)
 #error "MBEDTLS_GCM_C defined, but not all prerequisites"
 #endif
 
@@ -766,7 +805,7 @@
 #error "MBEDTLS_PSA_CRYPTO_C defined, but not all prerequisites (missing RNG)"
 #endif
 
-#if defined(MBEDTLS_PSA_CRYPTO_C) && !defined(MBEDTLS_CIPHER_C )
+#if defined(MBEDTLS_PSA_CRYPTO_C) && !defined(MBEDTLS_CIPHER_LIGHT)
 #error "MBEDTLS_PSA_CRYPTO_C defined, but not all prerequisites"
 #endif
 

--- a/include/mbedtls/config_adjust_legacy_crypto.h
+++ b/include/mbedtls/config_adjust_legacy_crypto.h
@@ -56,6 +56,23 @@
 #define MBEDTLS_MD_LIGHT
 #endif
 
+/* For backward compatibility, we need to enable CIPHER_LIGHT when the following
+ * modules are enabled. */
+#if defined(MBEDTLS_PKCS12_C) || defined(MBEDTLS_PKCS5_C) || \
+    defined(MBEDTLS_CCM_C) || defined(MBEDTLS_CMAC_C) || \
+    defined(MBEDTLS_GCM_C) || defined(MBEDTLS_PSA_CRYPTO_C)
+#define MBEDTLS_CIPHER_LIGHT
+#endif
+
+/* CIPHER_C is an enhancement of CIPHER_LIGHT which adds support for:
+ * - CFB, OFB, CTR, XTS and stream modes
+ * - padding mode for CBC
+ * - AEAD and NIST_KW
+ * Of course it requires CIPHER_LIGHT as its base. */
+#if defined(MBEDTLS_CIPHER_C)
+#define MBEDTLS_CIPHER_LIGHT
+#endif /* MBEDTLS_CIPHER_C */
+
 /* MBEDTLS_ECP_LIGHT is auto-enabled by the following symbols:
  * - MBEDTLS_ECP_C because now it consists of MBEDTLS_ECP_LIGHT plus functions
  *   for curve arithmetic. As a consequence if MBEDTLS_ECP_C is required for

--- a/include/mbedtls/oid.h
+++ b/include/mbedtls/oid.h
@@ -30,7 +30,7 @@
 
 #include <stddef.h>
 
-#if defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_LIGHT)
 #include "mbedtls/cipher.h"
 #endif
 
@@ -700,7 +700,7 @@ int mbedtls_oid_get_certificate_policies(const mbedtls_asn1_buf *oid, const char
  */
 int mbedtls_oid_get_oid_by_md(mbedtls_md_type_t md_alg, const char **oid, size_t *olen);
 
-#if defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_LIGHT)
 /**
  * \brief          Translate encryption algorithm OID into cipher_type
  *
@@ -710,7 +710,7 @@ int mbedtls_oid_get_oid_by_md(mbedtls_md_type_t md_alg, const char **oid, size_t
  * \return         0 if successful, or MBEDTLS_ERR_OID_NOT_FOUND
  */
 int mbedtls_oid_get_cipher_alg(const mbedtls_asn1_buf *oid, mbedtls_cipher_type_t *cipher_alg);
-#endif /* MBEDTLS_CIPHER_C */
+#endif /* MBEDTLS_CIPHER_LIGHT */
 
 #if defined(MBEDTLS_PKCS12_C)
 /**

--- a/library/cipher.c
+++ b/library/cipher.c
@@ -23,7 +23,7 @@
 
 #include "common.h"
 
-#if defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_LIGHT)
 
 #include "mbedtls/cipher.h"
 #include "cipher_wrap.h"
@@ -739,7 +739,7 @@ int mbedtls_cipher_update(mbedtls_cipher_context_t *ctx, const unsigned char *in
     }
 #endif /* MBEDTLS_CIPHER_MODE_CBC */
 
-#if defined(MBEDTLS_CIPHER_MODE_CFB)
+#if defined(MBEDTLS_CIPHER_MODE_CFB) && defined(MBEDTLS_CIPHER_C)
     if (((mbedtls_cipher_mode_t) ctx->cipher_info->mode) == MBEDTLS_MODE_CFB) {
         if (0 != (ret = mbedtls_cipher_get_base(ctx->cipher_info)->cfb_func(ctx->cipher_ctx,
                                                                             ctx->operation, ilen,
@@ -755,7 +755,7 @@ int mbedtls_cipher_update(mbedtls_cipher_context_t *ctx, const unsigned char *in
     }
 #endif /* MBEDTLS_CIPHER_MODE_CFB */
 
-#if defined(MBEDTLS_CIPHER_MODE_OFB)
+#if defined(MBEDTLS_CIPHER_MODE_OFB) && defined(MBEDTLS_CIPHER_C)
     if (((mbedtls_cipher_mode_t) ctx->cipher_info->mode) == MBEDTLS_MODE_OFB) {
         if (0 != (ret = mbedtls_cipher_get_base(ctx->cipher_info)->ofb_func(ctx->cipher_ctx,
                                                                             ilen,
@@ -771,7 +771,7 @@ int mbedtls_cipher_update(mbedtls_cipher_context_t *ctx, const unsigned char *in
     }
 #endif /* MBEDTLS_CIPHER_MODE_OFB */
 
-#if defined(MBEDTLS_CIPHER_MODE_CTR)
+#if defined(MBEDTLS_CIPHER_MODE_CTR) && defined(MBEDTLS_CIPHER_C)
     if (((mbedtls_cipher_mode_t) ctx->cipher_info->mode) == MBEDTLS_MODE_CTR) {
         if (0 != (ret = mbedtls_cipher_get_base(ctx->cipher_info)->ctr_func(ctx->cipher_ctx,
                                                                             ilen,
@@ -788,7 +788,7 @@ int mbedtls_cipher_update(mbedtls_cipher_context_t *ctx, const unsigned char *in
     }
 #endif /* MBEDTLS_CIPHER_MODE_CTR */
 
-#if defined(MBEDTLS_CIPHER_MODE_XTS)
+#if defined(MBEDTLS_CIPHER_MODE_XTS) && defined(MBEDTLS_CIPHER_C)
     if (((mbedtls_cipher_mode_t) ctx->cipher_info->mode) == MBEDTLS_MODE_XTS) {
         if (ctx->unprocessed_len > 0) {
             /* We can only process an entire data unit at a time. */
@@ -811,7 +811,7 @@ int mbedtls_cipher_update(mbedtls_cipher_context_t *ctx, const unsigned char *in
     }
 #endif /* MBEDTLS_CIPHER_MODE_XTS */
 
-#if defined(MBEDTLS_CIPHER_MODE_STREAM)
+#if defined(MBEDTLS_CIPHER_MODE_STREAM) && defined(MBEDTLS_CIPHER_C)
     if (((mbedtls_cipher_mode_t) ctx->cipher_info->mode) == MBEDTLS_MODE_STREAM) {
         if (0 != (ret = mbedtls_cipher_get_base(ctx->cipher_info)->stream_func(ctx->cipher_ctx,
                                                                                ilen, input,
@@ -829,7 +829,7 @@ int mbedtls_cipher_update(mbedtls_cipher_context_t *ctx, const unsigned char *in
 }
 
 #if defined(MBEDTLS_CIPHER_MODE_WITH_PADDING)
-#if defined(MBEDTLS_CIPHER_PADDING_PKCS7)
+#if defined(MBEDTLS_CIPHER_PADDING_PKCS7) && defined(MBEDTLS_CIPHER_C)
 /*
  * PKCS7 (and PKCS5) padding: fill with ll bytes, with ll = padding_len
  */
@@ -870,9 +870,9 @@ static int get_pkcs_padding(unsigned char *input, size_t input_len,
 
     return MBEDTLS_ERR_CIPHER_INVALID_PADDING * (bad != 0);
 }
-#endif /* MBEDTLS_CIPHER_PADDING_PKCS7 */
+#endif /* MBEDTLS_CIPHER_PADDING_PKCS7 && MBEDTLS_CIPHER_C */
 
-#if defined(MBEDTLS_CIPHER_PADDING_ONE_AND_ZEROS)
+#if defined(MBEDTLS_CIPHER_PADDING_ONE_AND_ZEROS) && defined(MBEDTLS_CIPHER_C)
 /*
  * One and zeros padding: fill with 80 00 ... 00
  */
@@ -910,9 +910,9 @@ static int get_one_and_zeros_padding(unsigned char *input, size_t input_len,
     return MBEDTLS_ERR_CIPHER_INVALID_PADDING * (bad != 0);
 
 }
-#endif /* MBEDTLS_CIPHER_PADDING_ONE_AND_ZEROS */
+#endif /* MBEDTLS_CIPHER_PADDING_ONE_AND_ZEROS && MBEDTLS_CIPHER_C */
 
-#if defined(MBEDTLS_CIPHER_PADDING_ZEROS_AND_LEN)
+#if defined(MBEDTLS_CIPHER_PADDING_ZEROS_AND_LEN) && defined(MBEDTLS_CIPHER_C)
 /*
  * Zeros and len padding: fill with 00 ... 00 ll, where ll is padding length
  */
@@ -953,9 +953,9 @@ static int get_zeros_and_len_padding(unsigned char *input, size_t input_len,
 
     return MBEDTLS_ERR_CIPHER_INVALID_PADDING * (bad != 0);
 }
-#endif /* MBEDTLS_CIPHER_PADDING_ZEROS_AND_LEN */
+#endif /* MBEDTLS_CIPHER_PADDING_ZEROS_AND_LEN && MBEDTLS_CIPHER_C */
 
-#if defined(MBEDTLS_CIPHER_PADDING_ZEROS)
+#if defined(MBEDTLS_CIPHER_PADDING_ZEROS) && defined(MBEDTLS_CIPHER_C)
 /*
  * Zero padding: fill with 00 ... 00
  */
@@ -988,7 +988,7 @@ static int get_zeros_padding(unsigned char *input, size_t input_len,
 
     return 0;
 }
-#endif /* MBEDTLS_CIPHER_PADDING_ZEROS */
+#endif /* MBEDTLS_CIPHER_PADDING_ZEROS && MBEDTLS_CIPHER_C */
 
 /*
  * No padding: don't pad :)
@@ -1129,25 +1129,25 @@ int mbedtls_cipher_set_padding_mode(mbedtls_cipher_context_t *ctx,
 #endif /* MBEDTLS_USE_PSA_CRYPTO && !MBEDTLS_DEPRECATED_REMOVED */
 
     switch (mode) {
-#if defined(MBEDTLS_CIPHER_PADDING_PKCS7)
+#if defined(MBEDTLS_CIPHER_PADDING_PKCS7) && defined(MBEDTLS_CIPHER_C)
         case MBEDTLS_PADDING_PKCS7:
             ctx->add_padding = add_pkcs_padding;
             ctx->get_padding = get_pkcs_padding;
             break;
 #endif
-#if defined(MBEDTLS_CIPHER_PADDING_ONE_AND_ZEROS)
+#if defined(MBEDTLS_CIPHER_PADDING_ONE_AND_ZEROS) && defined(MBEDTLS_CIPHER_C)
         case MBEDTLS_PADDING_ONE_AND_ZEROS:
             ctx->add_padding = add_one_and_zeros_padding;
             ctx->get_padding = get_one_and_zeros_padding;
             break;
 #endif
-#if defined(MBEDTLS_CIPHER_PADDING_ZEROS_AND_LEN)
+#if defined(MBEDTLS_CIPHER_PADDING_ZEROS_AND_LEN) && defined(MBEDTLS_CIPHER_C)
         case MBEDTLS_PADDING_ZEROS_AND_LEN:
             ctx->add_padding = add_zeros_and_len_padding;
             ctx->get_padding = get_zeros_and_len_padding;
             break;
 #endif
-#if defined(MBEDTLS_CIPHER_PADDING_ZEROS)
+#if defined(MBEDTLS_CIPHER_PADDING_ZEROS) && defined(MBEDTLS_CIPHER_C)
         case MBEDTLS_PADDING_ZEROS:
             ctx->add_padding = add_zeros_padding;
             ctx->get_padding = get_zeros_padding;
@@ -1385,7 +1385,7 @@ int mbedtls_cipher_crypt(mbedtls_cipher_context_t *ctx,
     return 0;
 }
 
-#if defined(MBEDTLS_CIPHER_MODE_AEAD)
+#if defined(MBEDTLS_CIPHER_MODE_AEAD) && defined(MBEDTLS_CIPHER_C)
 /*
  * Packet-oriented encryption for AEAD modes: internal function used by
  * mbedtls_cipher_auth_encrypt_ext().
@@ -1564,9 +1564,10 @@ static int mbedtls_cipher_aead_decrypt(mbedtls_cipher_context_t *ctx,
 
     return MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE;
 }
-#endif /* MBEDTLS_CIPHER_MODE_AEAD */
+#endif /* MBEDTLS_CIPHER_MODE_AEAD && MBEDTLS_CIPHER_C*/
 
-#if defined(MBEDTLS_CIPHER_MODE_AEAD) || defined(MBEDTLS_NIST_KW_C)
+#if (defined(MBEDTLS_CIPHER_MODE_AEAD) || defined(MBEDTLS_NIST_KW_C)) && \
+    defined(MBEDTLS_CIPHER_C)
 /*
  * Packet-oriented encryption for AEAD/NIST_KW: public function.
  */
@@ -1666,6 +1667,6 @@ int mbedtls_cipher_auth_decrypt_ext(mbedtls_cipher_context_t *ctx,
     return MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE;
 #endif /* MBEDTLS_CIPHER_MODE_AEAD */
 }
-#endif /* MBEDTLS_CIPHER_MODE_AEAD || MBEDTLS_NIST_KW_C */
+#endif /* (MBEDTLS_CIPHER_MODE_AEAD || MBEDTLS_NIST_KW_C) && MBEDTLS_CIPHER_C */
 
-#endif /* MBEDTLS_CIPHER_C */
+#endif /* MBEDTLS_CIPHER_LIGHT */

--- a/library/cipher.c
+++ b/library/cipher.c
@@ -739,7 +739,7 @@ int mbedtls_cipher_update(mbedtls_cipher_context_t *ctx, const unsigned char *in
     }
 #endif /* MBEDTLS_CIPHER_MODE_CBC */
 
-#if defined(MBEDTLS_CIPHER_MODE_CFB) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
     if (((mbedtls_cipher_mode_t) ctx->cipher_info->mode) == MBEDTLS_MODE_CFB) {
         if (0 != (ret = mbedtls_cipher_get_base(ctx->cipher_info)->cfb_func(ctx->cipher_ctx,
                                                                             ctx->operation, ilen,
@@ -755,7 +755,7 @@ int mbedtls_cipher_update(mbedtls_cipher_context_t *ctx, const unsigned char *in
     }
 #endif /* MBEDTLS_CIPHER_MODE_CFB */
 
-#if defined(MBEDTLS_CIPHER_MODE_OFB) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_OFB)
     if (((mbedtls_cipher_mode_t) ctx->cipher_info->mode) == MBEDTLS_MODE_OFB) {
         if (0 != (ret = mbedtls_cipher_get_base(ctx->cipher_info)->ofb_func(ctx->cipher_ctx,
                                                                             ilen,
@@ -771,7 +771,7 @@ int mbedtls_cipher_update(mbedtls_cipher_context_t *ctx, const unsigned char *in
     }
 #endif /* MBEDTLS_CIPHER_MODE_OFB */
 
-#if defined(MBEDTLS_CIPHER_MODE_CTR) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
     if (((mbedtls_cipher_mode_t) ctx->cipher_info->mode) == MBEDTLS_MODE_CTR) {
         if (0 != (ret = mbedtls_cipher_get_base(ctx->cipher_info)->ctr_func(ctx->cipher_ctx,
                                                                             ilen,
@@ -788,7 +788,7 @@ int mbedtls_cipher_update(mbedtls_cipher_context_t *ctx, const unsigned char *in
     }
 #endif /* MBEDTLS_CIPHER_MODE_CTR */
 
-#if defined(MBEDTLS_CIPHER_MODE_XTS) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_XTS)
     if (((mbedtls_cipher_mode_t) ctx->cipher_info->mode) == MBEDTLS_MODE_XTS) {
         if (ctx->unprocessed_len > 0) {
             /* We can only process an entire data unit at a time. */
@@ -811,7 +811,7 @@ int mbedtls_cipher_update(mbedtls_cipher_context_t *ctx, const unsigned char *in
     }
 #endif /* MBEDTLS_CIPHER_MODE_XTS */
 
-#if defined(MBEDTLS_CIPHER_MODE_STREAM) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_STREAM)
     if (((mbedtls_cipher_mode_t) ctx->cipher_info->mode) == MBEDTLS_MODE_STREAM) {
         if (0 != (ret = mbedtls_cipher_get_base(ctx->cipher_info)->stream_func(ctx->cipher_ctx,
                                                                                ilen, input,
@@ -829,7 +829,7 @@ int mbedtls_cipher_update(mbedtls_cipher_context_t *ctx, const unsigned char *in
 }
 
 #if defined(MBEDTLS_CIPHER_MODE_WITH_PADDING)
-#if defined(MBEDTLS_CIPHER_PADDING_PKCS7) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_PADDING_PKCS7)
 /*
  * PKCS7 (and PKCS5) padding: fill with ll bytes, with ll = padding_len
  */
@@ -870,9 +870,9 @@ static int get_pkcs_padding(unsigned char *input, size_t input_len,
 
     return MBEDTLS_ERR_CIPHER_INVALID_PADDING * (bad != 0);
 }
-#endif /* MBEDTLS_CIPHER_PADDING_PKCS7 && MBEDTLS_CIPHER_C */
+#endif /* MBEDTLS_CIPHER_PADDING_PKCS7 */
 
-#if defined(MBEDTLS_CIPHER_PADDING_ONE_AND_ZEROS) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_PADDING_ONE_AND_ZEROS)
 /*
  * One and zeros padding: fill with 80 00 ... 00
  */
@@ -910,9 +910,9 @@ static int get_one_and_zeros_padding(unsigned char *input, size_t input_len,
     return MBEDTLS_ERR_CIPHER_INVALID_PADDING * (bad != 0);
 
 }
-#endif /* MBEDTLS_CIPHER_PADDING_ONE_AND_ZEROS && MBEDTLS_CIPHER_C */
+#endif /* MBEDTLS_CIPHER_PADDING_ONE_AND_ZEROS */
 
-#if defined(MBEDTLS_CIPHER_PADDING_ZEROS_AND_LEN) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_PADDING_ZEROS_AND_LEN)
 /*
  * Zeros and len padding: fill with 00 ... 00 ll, where ll is padding length
  */
@@ -953,9 +953,9 @@ static int get_zeros_and_len_padding(unsigned char *input, size_t input_len,
 
     return MBEDTLS_ERR_CIPHER_INVALID_PADDING * (bad != 0);
 }
-#endif /* MBEDTLS_CIPHER_PADDING_ZEROS_AND_LEN && MBEDTLS_CIPHER_C */
+#endif /* MBEDTLS_CIPHER_PADDING_ZEROS_AND_LEN */
 
-#if defined(MBEDTLS_CIPHER_PADDING_ZEROS) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_PADDING_ZEROS)
 /*
  * Zero padding: fill with 00 ... 00
  */
@@ -988,7 +988,7 @@ static int get_zeros_padding(unsigned char *input, size_t input_len,
 
     return 0;
 }
-#endif /* MBEDTLS_CIPHER_PADDING_ZEROS && MBEDTLS_CIPHER_C */
+#endif /* MBEDTLS_CIPHER_PADDING_ZEROS */
 
 /*
  * No padding: don't pad :)
@@ -1129,25 +1129,25 @@ int mbedtls_cipher_set_padding_mode(mbedtls_cipher_context_t *ctx,
 #endif /* MBEDTLS_USE_PSA_CRYPTO && !MBEDTLS_DEPRECATED_REMOVED */
 
     switch (mode) {
-#if defined(MBEDTLS_CIPHER_PADDING_PKCS7) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_PADDING_PKCS7)
         case MBEDTLS_PADDING_PKCS7:
             ctx->add_padding = add_pkcs_padding;
             ctx->get_padding = get_pkcs_padding;
             break;
 #endif
-#if defined(MBEDTLS_CIPHER_PADDING_ONE_AND_ZEROS) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_PADDING_ONE_AND_ZEROS)
         case MBEDTLS_PADDING_ONE_AND_ZEROS:
             ctx->add_padding = add_one_and_zeros_padding;
             ctx->get_padding = get_one_and_zeros_padding;
             break;
 #endif
-#if defined(MBEDTLS_CIPHER_PADDING_ZEROS_AND_LEN) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_PADDING_ZEROS_AND_LEN)
         case MBEDTLS_PADDING_ZEROS_AND_LEN:
             ctx->add_padding = add_zeros_and_len_padding;
             ctx->get_padding = get_zeros_and_len_padding;
             break;
 #endif
-#if defined(MBEDTLS_CIPHER_PADDING_ZEROS) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_PADDING_ZEROS)
         case MBEDTLS_PADDING_ZEROS:
             ctx->add_padding = add_zeros_padding;
             ctx->get_padding = get_zeros_padding;

--- a/library/cipher_wrap.c
+++ b/library/cipher_wrap.c
@@ -23,7 +23,7 @@
 
 #include "common.h"
 
-#if defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_LIGHT)
 
 #include "cipher_wrap.h"
 #include "mbedtls/error.h"
@@ -113,13 +113,13 @@ enum mbedtls_cipher_base_index {
 #if defined(MBEDTLS_GCM_C) && defined(MBEDTLS_CAMELLIA_C)
     MBEDTLS_CIPHER_BASE_INDEX_GCM_CAMELLIA,
 #endif
-#if defined(MBEDTLS_NIST_KW_C)
+#if defined(MBEDTLS_NIST_KW_C) && defined(MBEDTLS_CIPHER_C)
     MBEDTLS_CIPHER_BASE_INDEX_KW_AES,
 #endif
 #if defined(MBEDTLS_CIPHER_NULL_CIPHER)
     MBEDTLS_CIPHER_BASE_INDEX_NULL_BASE,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_XTS) && defined(MBEDTLS_AES_C)
+#if defined(MBEDTLS_CIPHER_MODE_XTS) && defined(MBEDTLS_AES_C) && defined(MBEDTLS_CIPHER_C)
     MBEDTLS_CIPHER_BASE_INDEX_XTS_AES,
 #endif
     /* Prevent compile failure due to empty enum */
@@ -183,7 +183,7 @@ static int aes_crypt_cbc_wrap(void *ctx, mbedtls_operation_t operation, size_t l
 }
 #endif /* MBEDTLS_CIPHER_MODE_CBC */
 
-#if defined(MBEDTLS_CIPHER_MODE_CFB)
+#if defined(MBEDTLS_CIPHER_MODE_CFB) && defined(MBEDTLS_CIPHER_C)
 static int aes_crypt_cfb128_wrap(void *ctx, mbedtls_operation_t operation,
                                  size_t length, size_t *iv_off, unsigned char *iv,
                                  const unsigned char *input, unsigned char *output)
@@ -191,18 +191,18 @@ static int aes_crypt_cfb128_wrap(void *ctx, mbedtls_operation_t operation,
     return mbedtls_aes_crypt_cfb128((mbedtls_aes_context *) ctx, operation, length, iv_off, iv,
                                     input, output);
 }
-#endif /* MBEDTLS_CIPHER_MODE_CFB */
+#endif /* MBEDTLS_CIPHER_MODE_CFB && MBEDTLS_CIPHER_C */
 
-#if defined(MBEDTLS_CIPHER_MODE_OFB)
+#if defined(MBEDTLS_CIPHER_MODE_OFB) && defined(MBEDTLS_CIPHER_C)
 static int aes_crypt_ofb_wrap(void *ctx, size_t length, size_t *iv_off,
                               unsigned char *iv, const unsigned char *input, unsigned char *output)
 {
     return mbedtls_aes_crypt_ofb((mbedtls_aes_context *) ctx, length, iv_off,
                                  iv, input, output);
 }
-#endif /* MBEDTLS_CIPHER_MODE_OFB */
+#endif /* MBEDTLS_CIPHER_MODE_OFB && MBEDTLS_CIPHER_C */
 
-#if defined(MBEDTLS_CIPHER_MODE_CTR)
+#if defined(MBEDTLS_CIPHER_MODE_CTR) && defined(MBEDTLS_CIPHER_C)
 static int aes_crypt_ctr_wrap(void *ctx, size_t length, size_t *nc_off,
                               unsigned char *nonce_counter, unsigned char *stream_block,
                               const unsigned char *input, unsigned char *output)
@@ -210,9 +210,9 @@ static int aes_crypt_ctr_wrap(void *ctx, size_t length, size_t *nc_off,
     return mbedtls_aes_crypt_ctr((mbedtls_aes_context *) ctx, length, nc_off, nonce_counter,
                                  stream_block, input, output);
 }
-#endif /* MBEDTLS_CIPHER_MODE_CTR */
+#endif /* MBEDTLS_CIPHER_MODE_CTR && MBEDTLS_CIPHER_C */
 
-#if defined(MBEDTLS_CIPHER_MODE_XTS)
+#if defined(MBEDTLS_CIPHER_MODE_XTS) && defined(MBEDTLS_CIPHER_C)
 static int aes_crypt_xts_wrap(void *ctx, mbedtls_operation_t operation,
                               size_t length,
                               const unsigned char data_unit[16],
@@ -236,7 +236,7 @@ static int aes_crypt_xts_wrap(void *ctx, mbedtls_operation_t operation,
     return mbedtls_aes_crypt_xts(xts_ctx, mode, length,
                                  data_unit, input, output);
 }
-#endif /* MBEDTLS_CIPHER_MODE_XTS */
+#endif /* MBEDTLS_CIPHER_MODE_XTS && MBEDTLS_CIPHER_C */
 
 static int aes_setkey_dec_wrap(void *ctx, const unsigned char *key,
                                unsigned int key_bitlen)
@@ -275,19 +275,19 @@ static const mbedtls_cipher_base_t aes_info = {
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
     aes_crypt_cbc_wrap,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CFB)
+#if defined(MBEDTLS_CIPHER_MODE_CFB) && defined(MBEDTLS_CIPHER_C)
     aes_crypt_cfb128_wrap,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_OFB)
+#if defined(MBEDTLS_CIPHER_MODE_OFB) && defined(MBEDTLS_CIPHER_C)
     aes_crypt_ofb_wrap,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CTR)
+#if defined(MBEDTLS_CIPHER_MODE_CTR) && defined(MBEDTLS_CIPHER_C)
     aes_crypt_ctr_wrap,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_XTS)
+#if defined(MBEDTLS_CIPHER_MODE_XTS) && defined(MBEDTLS_CIPHER_C)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_STREAM)
+#if defined(MBEDTLS_CIPHER_MODE_STREAM) && defined(MBEDTLS_CIPHER_C)
     NULL,
 #endif
     aes_setkey_enc_wrap,
@@ -368,7 +368,7 @@ static const mbedtls_cipher_info_t aes_256_cbc_info = {
 #endif
 #endif /* MBEDTLS_CIPHER_MODE_CBC */
 
-#if defined(MBEDTLS_CIPHER_MODE_CFB)
+#if defined(MBEDTLS_CIPHER_MODE_CFB) && defined(MBEDTLS_CIPHER_C)
 static const mbedtls_cipher_info_t aes_128_cfb128_info = {
     "AES-128-CFB128",
     16,
@@ -403,9 +403,9 @@ static const mbedtls_cipher_info_t aes_256_cfb128_info = {
     MBEDTLS_CIPHER_BASE_INDEX_AES
 };
 #endif
-#endif /* MBEDTLS_CIPHER_MODE_CFB */
+#endif /* MBEDTLS_CIPHER_MODE_CFB && MBEDTLS_CIPHER_C */
 
-#if defined(MBEDTLS_CIPHER_MODE_OFB)
+#if defined(MBEDTLS_CIPHER_MODE_OFB) && defined(MBEDTLS_CIPHER_C)
 static const mbedtls_cipher_info_t aes_128_ofb_info = {
     "AES-128-OFB",
     16,
@@ -440,9 +440,9 @@ static const mbedtls_cipher_info_t aes_256_ofb_info = {
     MBEDTLS_CIPHER_BASE_INDEX_AES
 };
 #endif
-#endif /* MBEDTLS_CIPHER_MODE_OFB */
+#endif /* MBEDTLS_CIPHER_MODE_OFB && MBEDTLS_CIPHER_C */
 
-#if defined(MBEDTLS_CIPHER_MODE_CTR)
+#if defined(MBEDTLS_CIPHER_MODE_CTR) && defined(MBEDTLS_CIPHER_C)
 static const mbedtls_cipher_info_t aes_128_ctr_info = {
     "AES-128-CTR",
     16,
@@ -477,9 +477,9 @@ static const mbedtls_cipher_info_t aes_256_ctr_info = {
     MBEDTLS_CIPHER_BASE_INDEX_AES
 };
 #endif
-#endif /* MBEDTLS_CIPHER_MODE_CTR */
+#endif /* MBEDTLS_CIPHER_MODE_CTR && MBEDTLS_CIPHER_C */
 
-#if defined(MBEDTLS_CIPHER_MODE_XTS)
+#if defined(MBEDTLS_CIPHER_MODE_XTS) && defined(MBEDTLS_CIPHER_C)
 static int xts_aes_setkey_enc_wrap(void *ctx, const unsigned char *key,
                                    unsigned int key_bitlen)
 {
@@ -567,7 +567,7 @@ static const mbedtls_cipher_info_t aes_256_xts_info = {
     MBEDTLS_CIPHER_BASE_INDEX_XTS_AES
 };
 #endif
-#endif /* MBEDTLS_CIPHER_MODE_XTS */
+#endif /* MBEDTLS_CIPHER_MODE_XTS && MBEDTLS_CIPHER_C */
 
 #if defined(MBEDTLS_GCM_C)
 static int gcm_aes_setkey_wrap(void *ctx, const unsigned char *key,
@@ -583,19 +583,19 @@ static const mbedtls_cipher_base_t gcm_aes_info = {
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CFB)
+#if defined(MBEDTLS_CIPHER_MODE_CFB) && defined(MBEDTLS_CIPHER_C)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_OFB)
+#if defined(MBEDTLS_CIPHER_MODE_OFB) && defined(MBEDTLS_CIPHER_C)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CTR)
+#if defined(MBEDTLS_CIPHER_MODE_CTR) && defined(MBEDTLS_CIPHER_C)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_XTS)
+#if defined(MBEDTLS_CIPHER_MODE_XTS) && defined(MBEDTLS_CIPHER_C)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_STREAM)
+#if defined(MBEDTLS_CIPHER_MODE_STREAM) && defined(MBEDTLS_CIPHER_C)
     NULL,
 #endif
     gcm_aes_setkey_wrap,
@@ -654,19 +654,19 @@ static const mbedtls_cipher_base_t ccm_aes_info = {
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CFB)
+#if defined(MBEDTLS_CIPHER_MODE_CFB) && defined(MBEDTLS_CIPHER_C)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_OFB)
+#if defined(MBEDTLS_CIPHER_MODE_OFB) && defined(MBEDTLS_CIPHER_C)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CTR)
+#if defined(MBEDTLS_CIPHER_MODE_CTR) && defined(MBEDTLS_CIPHER_C)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_XTS)
+#if defined(MBEDTLS_CIPHER_MODE_XTS) && defined(MBEDTLS_CIPHER_C)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_STREAM)
+#if defined(MBEDTLS_CIPHER_MODE_STREAM) && defined(MBEDTLS_CIPHER_C)
     NULL,
 #endif
     ccm_aes_setkey_wrap,
@@ -767,7 +767,7 @@ static int camellia_crypt_cbc_wrap(void *ctx, mbedtls_operation_t operation,
 }
 #endif /* MBEDTLS_CIPHER_MODE_CBC */
 
-#if defined(MBEDTLS_CIPHER_MODE_CFB)
+#if defined(MBEDTLS_CIPHER_MODE_CFB) && defined(MBEDTLS_CIPHER_C)
 static int camellia_crypt_cfb128_wrap(void *ctx, mbedtls_operation_t operation,
                                       size_t length, size_t *iv_off, unsigned char *iv,
                                       const unsigned char *input, unsigned char *output)
@@ -775,9 +775,9 @@ static int camellia_crypt_cfb128_wrap(void *ctx, mbedtls_operation_t operation,
     return mbedtls_camellia_crypt_cfb128((mbedtls_camellia_context *) ctx, operation, length,
                                          iv_off, iv, input, output);
 }
-#endif /* MBEDTLS_CIPHER_MODE_CFB */
+#endif /* MBEDTLS_CIPHER_MODE_CFB && MBEDTLS_CIPHER_C */
 
-#if defined(MBEDTLS_CIPHER_MODE_CTR)
+#if defined(MBEDTLS_CIPHER_MODE_CTR) && defined(MBEDTLS_CIPHER_C)
 static int camellia_crypt_ctr_wrap(void *ctx, size_t length, size_t *nc_off,
                                    unsigned char *nonce_counter, unsigned char *stream_block,
                                    const unsigned char *input, unsigned char *output)
@@ -785,7 +785,7 @@ static int camellia_crypt_ctr_wrap(void *ctx, size_t length, size_t *nc_off,
     return mbedtls_camellia_crypt_ctr((mbedtls_camellia_context *) ctx, length, nc_off,
                                       nonce_counter, stream_block, input, output);
 }
-#endif /* MBEDTLS_CIPHER_MODE_CTR */
+#endif /* MBEDTLS_CIPHER_MODE_CTR && MBEDTLS_CIPHER_C */
 
 static int camellia_setkey_dec_wrap(void *ctx, const unsigned char *key,
                                     unsigned int key_bitlen)
@@ -825,19 +825,19 @@ static const mbedtls_cipher_base_t camellia_info = {
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
     camellia_crypt_cbc_wrap,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CFB)
+#if defined(MBEDTLS_CIPHER_MODE_CFB) && defined(MBEDTLS_CIPHER_C)
     camellia_crypt_cfb128_wrap,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_OFB)
+#if defined(MBEDTLS_CIPHER_MODE_OFB) && defined(MBEDTLS_CIPHER_C)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CTR)
+#if defined(MBEDTLS_CIPHER_MODE_CTR) && defined(MBEDTLS_CIPHER_C)
     camellia_crypt_ctr_wrap,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_XTS)
+#if defined(MBEDTLS_CIPHER_MODE_XTS) && defined(MBEDTLS_CIPHER_C)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_STREAM)
+#if defined(MBEDTLS_CIPHER_MODE_STREAM) && defined(MBEDTLS_CIPHER_C)
     NULL,
 #endif
     camellia_setkey_enc_wrap,
@@ -914,7 +914,7 @@ static const mbedtls_cipher_info_t camellia_256_cbc_info = {
 };
 #endif /* MBEDTLS_CIPHER_MODE_CBC */
 
-#if defined(MBEDTLS_CIPHER_MODE_CFB)
+#if defined(MBEDTLS_CIPHER_MODE_CFB) && defined(MBEDTLS_CIPHER_C)
 static const mbedtls_cipher_info_t camellia_128_cfb128_info = {
     "CAMELLIA-128-CFB128",
     16,
@@ -947,9 +947,9 @@ static const mbedtls_cipher_info_t camellia_256_cfb128_info = {
     0,
     MBEDTLS_CIPHER_BASE_INDEX_CAMELLIA
 };
-#endif /* MBEDTLS_CIPHER_MODE_CFB */
+#endif /* MBEDTLS_CIPHER_MODE_CFB && MBEDTLS_CIPHER_C */
 
-#if defined(MBEDTLS_CIPHER_MODE_CTR)
+#if defined(MBEDTLS_CIPHER_MODE_CTR) && defined(MBEDTLS_CIPHER_C)
 static const mbedtls_cipher_info_t camellia_128_ctr_info = {
     "CAMELLIA-128-CTR",
     16,
@@ -982,7 +982,7 @@ static const mbedtls_cipher_info_t camellia_256_ctr_info = {
     0,
     MBEDTLS_CIPHER_BASE_INDEX_CAMELLIA
 };
-#endif /* MBEDTLS_CIPHER_MODE_CTR */
+#endif /* MBEDTLS_CIPHER_MODE_CTR && MBEDTLS_CIPHER_C */
 
 #if defined(MBEDTLS_GCM_C)
 static int gcm_camellia_setkey_wrap(void *ctx, const unsigned char *key,
@@ -998,19 +998,19 @@ static const mbedtls_cipher_base_t gcm_camellia_info = {
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CFB)
+#if defined(MBEDTLS_CIPHER_MODE_CFB) && defined(MBEDTLS_CIPHER_C)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_OFB)
+#if defined(MBEDTLS_CIPHER_MODE_OFB) && defined(MBEDTLS_CIPHER_C)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CTR)
+#if defined(MBEDTLS_CIPHER_MODE_CTR) && defined(MBEDTLS_CIPHER_C)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_XTS)
+#if defined(MBEDTLS_CIPHER_MODE_XTS) && defined(MBEDTLS_CIPHER_C)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_STREAM)
+#if defined(MBEDTLS_CIPHER_MODE_STREAM) && defined(MBEDTLS_CIPHER_C)
     NULL,
 #endif
     gcm_camellia_setkey_wrap,
@@ -1067,19 +1067,19 @@ static const mbedtls_cipher_base_t ccm_camellia_info = {
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CFB)
+#if defined(MBEDTLS_CIPHER_MODE_CFB) && defined(MBEDTLS_CIPHER_C)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_OFB)
+#if defined(MBEDTLS_CIPHER_MODE_OFB) && defined(MBEDTLS_CIPHER_C)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CTR)
+#if defined(MBEDTLS_CIPHER_MODE_CTR) && defined(MBEDTLS_CIPHER_C)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_XTS)
+#if defined(MBEDTLS_CIPHER_MODE_XTS) && defined(MBEDTLS_CIPHER_C)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_STREAM)
+#if defined(MBEDTLS_CIPHER_MODE_STREAM) && defined(MBEDTLS_CIPHER_C)
     NULL,
 #endif
     ccm_camellia_setkey_wrap,
@@ -1177,7 +1177,7 @@ static int aria_crypt_cbc_wrap(void *ctx, mbedtls_operation_t operation,
 }
 #endif /* MBEDTLS_CIPHER_MODE_CBC */
 
-#if defined(MBEDTLS_CIPHER_MODE_CFB)
+#if defined(MBEDTLS_CIPHER_MODE_CFB) && defined(MBEDTLS_CIPHER_C)
 static int aria_crypt_cfb128_wrap(void *ctx, mbedtls_operation_t operation,
                                   size_t length, size_t *iv_off, unsigned char *iv,
                                   const unsigned char *input, unsigned char *output)
@@ -1185,9 +1185,9 @@ static int aria_crypt_cfb128_wrap(void *ctx, mbedtls_operation_t operation,
     return mbedtls_aria_crypt_cfb128((mbedtls_aria_context *) ctx, operation, length,
                                      iv_off, iv, input, output);
 }
-#endif /* MBEDTLS_CIPHER_MODE_CFB */
+#endif /* MBEDTLS_CIPHER_MODE_CFB && MBEDTLS_CIPHER_C */
 
-#if defined(MBEDTLS_CIPHER_MODE_CTR)
+#if defined(MBEDTLS_CIPHER_MODE_CTR) && defined(MBEDTLS_CIPHER_C)
 static int aria_crypt_ctr_wrap(void *ctx, size_t length, size_t *nc_off,
                                unsigned char *nonce_counter, unsigned char *stream_block,
                                const unsigned char *input, unsigned char *output)
@@ -1195,7 +1195,7 @@ static int aria_crypt_ctr_wrap(void *ctx, size_t length, size_t *nc_off,
     return mbedtls_aria_crypt_ctr((mbedtls_aria_context *) ctx, length, nc_off,
                                   nonce_counter, stream_block, input, output);
 }
-#endif /* MBEDTLS_CIPHER_MODE_CTR */
+#endif /* MBEDTLS_CIPHER_MODE_CTR && MBEDTLS_CIPHER_C */
 
 static int aria_setkey_dec_wrap(void *ctx, const unsigned char *key,
                                 unsigned int key_bitlen)
@@ -1235,19 +1235,19 @@ static const mbedtls_cipher_base_t aria_info = {
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
     aria_crypt_cbc_wrap,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CFB)
+#if defined(MBEDTLS_CIPHER_MODE_CFB) && defined(MBEDTLS_CIPHER_C)
     aria_crypt_cfb128_wrap,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_OFB)
+#if defined(MBEDTLS_CIPHER_MODE_OFB) && defined(MBEDTLS_CIPHER_C)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CTR)
+#if defined(MBEDTLS_CIPHER_MODE_CTR) && defined(MBEDTLS_CIPHER_C)
     aria_crypt_ctr_wrap,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_XTS)
+#if defined(MBEDTLS_CIPHER_MODE_XTS) && defined(MBEDTLS_CIPHER_C)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_STREAM)
+#if defined(MBEDTLS_CIPHER_MODE_STREAM) && defined(MBEDTLS_CIPHER_C)
     NULL,
 #endif
     aria_setkey_enc_wrap,
@@ -1324,7 +1324,7 @@ static const mbedtls_cipher_info_t aria_256_cbc_info = {
 };
 #endif /* MBEDTLS_CIPHER_MODE_CBC */
 
-#if defined(MBEDTLS_CIPHER_MODE_CFB)
+#if defined(MBEDTLS_CIPHER_MODE_CFB) && defined(MBEDTLS_CIPHER_C)
 static const mbedtls_cipher_info_t aria_128_cfb128_info = {
     "ARIA-128-CFB128",
     16,
@@ -1357,9 +1357,9 @@ static const mbedtls_cipher_info_t aria_256_cfb128_info = {
     0,
     MBEDTLS_CIPHER_BASE_INDEX_ARIA
 };
-#endif /* MBEDTLS_CIPHER_MODE_CFB */
+#endif /* MBEDTLS_CIPHER_MODE_CFB && MBEDTLS_CIPHER_C */
 
-#if defined(MBEDTLS_CIPHER_MODE_CTR)
+#if defined(MBEDTLS_CIPHER_MODE_CTR) && defined(MBEDTLS_CIPHER_C)
 static const mbedtls_cipher_info_t aria_128_ctr_info = {
     "ARIA-128-CTR",
     16,
@@ -1392,7 +1392,7 @@ static const mbedtls_cipher_info_t aria_256_ctr_info = {
     0,
     MBEDTLS_CIPHER_BASE_INDEX_ARIA
 };
-#endif /* MBEDTLS_CIPHER_MODE_CTR */
+#endif /* MBEDTLS_CIPHER_MODE_CTR && MBEDTLS_CIPHER_C */
 
 #if defined(MBEDTLS_GCM_C)
 static int gcm_aria_setkey_wrap(void *ctx, const unsigned char *key,
@@ -1408,19 +1408,19 @@ static const mbedtls_cipher_base_t gcm_aria_info = {
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CFB)
+#if defined(MBEDTLS_CIPHER_MODE_CFB) && defined(MBEDTLS_CIPHER_C)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_OFB)
+#if defined(MBEDTLS_CIPHER_MODE_OFB) && defined(MBEDTLS_CIPHER_C)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CTR)
+#if defined(MBEDTLS_CIPHER_MODE_CTR) && defined(MBEDTLS_CIPHER_C)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_XTS)
+#if defined(MBEDTLS_CIPHER_MODE_XTS) && defined(MBEDTLS_CIPHER_C)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_STREAM)
+#if defined(MBEDTLS_CIPHER_MODE_STREAM) && defined(MBEDTLS_CIPHER_C)
     NULL,
 #endif
     gcm_aria_setkey_wrap,
@@ -1477,19 +1477,19 @@ static const mbedtls_cipher_base_t ccm_aria_info = {
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CFB)
+#if defined(MBEDTLS_CIPHER_MODE_CFB) && defined(MBEDTLS_CIPHER_C)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_OFB)
+#if defined(MBEDTLS_CIPHER_MODE_OFB) && defined(MBEDTLS_CIPHER_C)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CTR)
+#if defined(MBEDTLS_CIPHER_MODE_CTR) && defined(MBEDTLS_CIPHER_C)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_XTS)
+#if defined(MBEDTLS_CIPHER_MODE_XTS) && defined(MBEDTLS_CIPHER_C)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_STREAM)
+#if defined(MBEDTLS_CIPHER_MODE_STREAM) && defined(MBEDTLS_CIPHER_C)
     NULL,
 #endif
     ccm_aria_setkey_wrap,
@@ -1694,19 +1694,19 @@ static const mbedtls_cipher_base_t des_info = {
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
     des_crypt_cbc_wrap,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CFB)
+#if defined(MBEDTLS_CIPHER_MODE_CFB) && defined(MBEDTLS_CIPHER_C)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_OFB)
+#if defined(MBEDTLS_CIPHER_MODE_OFB) && defined(MBEDTLS_CIPHER_C)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CTR)
+#if defined(MBEDTLS_CIPHER_MODE_CTR) && defined(MBEDTLS_CIPHER_C)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_XTS)
+#if defined(MBEDTLS_CIPHER_MODE_XTS) && defined(MBEDTLS_CIPHER_C)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_STREAM)
+#if defined(MBEDTLS_CIPHER_MODE_STREAM) && defined(MBEDTLS_CIPHER_C)
     NULL,
 #endif
     des_setkey_enc_wrap,
@@ -1745,19 +1745,19 @@ static const mbedtls_cipher_base_t des_ede_info = {
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
     des3_crypt_cbc_wrap,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CFB)
+#if defined(MBEDTLS_CIPHER_MODE_CFB) && defined(MBEDTLS_CIPHER_C)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_OFB)
+#if defined(MBEDTLS_CIPHER_MODE_OFB) && defined(MBEDTLS_CIPHER_C)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CTR)
+#if defined(MBEDTLS_CIPHER_MODE_CTR) && defined(MBEDTLS_CIPHER_C)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_XTS)
+#if defined(MBEDTLS_CIPHER_MODE_XTS) && defined(MBEDTLS_CIPHER_C)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_STREAM)
+#if defined(MBEDTLS_CIPHER_MODE_STREAM) && defined(MBEDTLS_CIPHER_C)
     NULL,
 #endif
     des3_set2key_enc_wrap,
@@ -1796,19 +1796,19 @@ static const mbedtls_cipher_base_t des_ede3_info = {
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
     des3_crypt_cbc_wrap,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CFB)
+#if defined(MBEDTLS_CIPHER_MODE_CFB) && defined(MBEDTLS_CIPHER_C)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_OFB)
+#if defined(MBEDTLS_CIPHER_MODE_OFB) && defined(MBEDTLS_CIPHER_C)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CTR)
+#if defined(MBEDTLS_CIPHER_MODE_CTR) && defined(MBEDTLS_CIPHER_C)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_XTS)
+#if defined(MBEDTLS_CIPHER_MODE_XTS) && defined(MBEDTLS_CIPHER_C)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_STREAM)
+#if defined(MBEDTLS_CIPHER_MODE_STREAM) && defined(MBEDTLS_CIPHER_C)
     NULL,
 #endif
     des3_set3key_enc_wrap,
@@ -1841,7 +1841,7 @@ static const mbedtls_cipher_info_t des_ede3_cbc_info = {
 #endif /* MBEDTLS_CIPHER_MODE_CBC */
 #endif /* MBEDTLS_DES_C */
 
-#if defined(MBEDTLS_CHACHA20_C)
+#if defined(MBEDTLS_CHACHA20_C) && defined(MBEDTLS_CIPHER_C)
 
 static int chacha20_setkey_wrap(void *ctx, const unsigned char *key,
                                 unsigned int key_bitlen)
@@ -1927,9 +1927,9 @@ static const mbedtls_cipher_info_t chacha20_info = {
     0,
     MBEDTLS_CIPHER_BASE_INDEX_CHACHA20_BASE
 };
-#endif /* MBEDTLS_CHACHA20_C */
+#endif /* MBEDTLS_CHACHA20_C && MBEDTLS_CIPHER_C */
 
-#if defined(MBEDTLS_CHACHAPOLY_C)
+#if defined(MBEDTLS_CHACHAPOLY_C) && defined(MBEDTLS_CIPHER_C)
 
 static int chachapoly_setkey_wrap(void *ctx,
                                   const unsigned char *key,
@@ -2002,9 +2002,9 @@ static const mbedtls_cipher_info_t chachapoly_info = {
     0,
     MBEDTLS_CIPHER_BASE_INDEX_CHACHAPOLY_BASE
 };
-#endif /* MBEDTLS_CHACHAPOLY_C */
+#endif /* MBEDTLS_CHACHAPOLY_C && MBEDTLS_CIPHER_C */
 
-#if defined(MBEDTLS_CIPHER_NULL_CIPHER)
+#if defined(MBEDTLS_CIPHER_NULL_CIPHER) && defined(MBEDTLS_CIPHER_C)
 static int null_crypt_stream(void *ctx, size_t length,
                              const unsigned char *input,
                              unsigned char *output)
@@ -2073,7 +2073,7 @@ static const mbedtls_cipher_info_t null_cipher_info = {
 };
 #endif /* defined(MBEDTLS_CIPHER_NULL_CIPHER) */
 
-#if defined(MBEDTLS_NIST_KW_C)
+#if defined(MBEDTLS_NIST_KW_C) && defined(MBEDTLS_CIPHER_C)
 static void *kw_ctx_alloc(void)
 {
     void *ctx = mbedtls_calloc(1, sizeof(mbedtls_nist_kw_context));
@@ -2201,7 +2201,7 @@ static const mbedtls_cipher_info_t aes_256_nist_kwp_info = {
     MBEDTLS_CIPHER_BASE_INDEX_KW_AES
 };
 #endif
-#endif /* MBEDTLS_NIST_KW_C */
+#endif /* MBEDTLS_NIST_KW_C && MBEDTLS_CIPHER_C */
 
 const mbedtls_cipher_definition_t mbedtls_cipher_definitions[] =
 {
@@ -2218,28 +2218,28 @@ const mbedtls_cipher_definition_t mbedtls_cipher_definitions[] =
     { MBEDTLS_CIPHER_AES_256_CBC,          &aes_256_cbc_info },
 #endif
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CFB)
+#if defined(MBEDTLS_CIPHER_MODE_CFB) && defined(MBEDTLS_CIPHER_C)
     { MBEDTLS_CIPHER_AES_128_CFB128,       &aes_128_cfb128_info },
 #if !defined(MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH)
     { MBEDTLS_CIPHER_AES_192_CFB128,       &aes_192_cfb128_info },
     { MBEDTLS_CIPHER_AES_256_CFB128,       &aes_256_cfb128_info },
 #endif
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_OFB)
+#if defined(MBEDTLS_CIPHER_MODE_OFB) && defined(MBEDTLS_CIPHER_C)
     { MBEDTLS_CIPHER_AES_128_OFB,          &aes_128_ofb_info },
 #if !defined(MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH)
     { MBEDTLS_CIPHER_AES_192_OFB,          &aes_192_ofb_info },
     { MBEDTLS_CIPHER_AES_256_OFB,          &aes_256_ofb_info },
 #endif
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CTR)
+#if defined(MBEDTLS_CIPHER_MODE_CTR) && defined(MBEDTLS_CIPHER_C)
     { MBEDTLS_CIPHER_AES_128_CTR,          &aes_128_ctr_info },
 #if !defined(MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH)
     { MBEDTLS_CIPHER_AES_192_CTR,          &aes_192_ctr_info },
     { MBEDTLS_CIPHER_AES_256_CTR,          &aes_256_ctr_info },
 #endif
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_XTS)
+#if defined(MBEDTLS_CIPHER_MODE_XTS) && defined(MBEDTLS_CIPHER_C)
     { MBEDTLS_CIPHER_AES_128_XTS,          &aes_128_xts_info },
 #if !defined(MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH)
     { MBEDTLS_CIPHER_AES_256_XTS,          &aes_256_xts_info },
@@ -2275,12 +2275,12 @@ const mbedtls_cipher_definition_t mbedtls_cipher_definitions[] =
     { MBEDTLS_CIPHER_CAMELLIA_192_CBC,     &camellia_192_cbc_info },
     { MBEDTLS_CIPHER_CAMELLIA_256_CBC,     &camellia_256_cbc_info },
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CFB)
+#if defined(MBEDTLS_CIPHER_MODE_CFB) && defined(MBEDTLS_CIPHER_C)
     { MBEDTLS_CIPHER_CAMELLIA_128_CFB128,  &camellia_128_cfb128_info },
     { MBEDTLS_CIPHER_CAMELLIA_192_CFB128,  &camellia_192_cfb128_info },
     { MBEDTLS_CIPHER_CAMELLIA_256_CFB128,  &camellia_256_cfb128_info },
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CTR)
+#if defined(MBEDTLS_CIPHER_MODE_CTR) && defined(MBEDTLS_CIPHER_C)
     { MBEDTLS_CIPHER_CAMELLIA_128_CTR,     &camellia_128_ctr_info },
     { MBEDTLS_CIPHER_CAMELLIA_192_CTR,     &camellia_192_ctr_info },
     { MBEDTLS_CIPHER_CAMELLIA_256_CTR,     &camellia_256_ctr_info },
@@ -2309,12 +2309,12 @@ const mbedtls_cipher_definition_t mbedtls_cipher_definitions[] =
     { MBEDTLS_CIPHER_ARIA_192_CBC,     &aria_192_cbc_info },
     { MBEDTLS_CIPHER_ARIA_256_CBC,     &aria_256_cbc_info },
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CFB)
+#if defined(MBEDTLS_CIPHER_MODE_CFB) && defined(MBEDTLS_CIPHER_C)
     { MBEDTLS_CIPHER_ARIA_128_CFB128,  &aria_128_cfb128_info },
     { MBEDTLS_CIPHER_ARIA_192_CFB128,  &aria_192_cfb128_info },
     { MBEDTLS_CIPHER_ARIA_256_CFB128,  &aria_256_cfb128_info },
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CTR)
+#if defined(MBEDTLS_CIPHER_MODE_CTR) && defined(MBEDTLS_CIPHER_C)
     { MBEDTLS_CIPHER_ARIA_128_CTR,     &aria_128_ctr_info },
     { MBEDTLS_CIPHER_ARIA_192_CTR,     &aria_192_ctr_info },
     { MBEDTLS_CIPHER_ARIA_256_CTR,     &aria_256_ctr_info },
@@ -2345,15 +2345,15 @@ const mbedtls_cipher_definition_t mbedtls_cipher_definitions[] =
 #endif
 #endif /* MBEDTLS_DES_C */
 
-#if defined(MBEDTLS_CHACHA20_C)
+#if defined(MBEDTLS_CHACHA20_C) && defined(MBEDTLS_CIPHER_C)
     { MBEDTLS_CIPHER_CHACHA20,             &chacha20_info },
 #endif
 
-#if defined(MBEDTLS_CHACHAPOLY_C)
+#if defined(MBEDTLS_CHACHAPOLY_C) && defined(MBEDTLS_CIPHER_C)
     { MBEDTLS_CIPHER_CHACHA20_POLY1305,    &chachapoly_info },
 #endif
 
-#if defined(MBEDTLS_NIST_KW_C)
+#if defined(MBEDTLS_NIST_KW_C) && defined(MBEDTLS_CIPHER_C)
     { MBEDTLS_CIPHER_AES_128_KW,          &aes_128_nist_kw_info },
 #if !defined(MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH)
     { MBEDTLS_CIPHER_AES_192_KW,          &aes_192_nist_kw_info },
@@ -2366,9 +2366,9 @@ const mbedtls_cipher_definition_t mbedtls_cipher_definitions[] =
 #endif
 #endif
 
-#if defined(MBEDTLS_CIPHER_NULL_CIPHER)
+#if defined(MBEDTLS_CIPHER_NULL_CIPHER) && defined(MBEDTLS_CIPHER_C)
     { MBEDTLS_CIPHER_NULL,                 &null_cipher_info },
-#endif /* MBEDTLS_CIPHER_NULL_CIPHER */
+#endif /* MBEDTLS_CIPHER_NULL_CIPHER && MBEDTLS_CIPHER_C */
 
     { MBEDTLS_CIPHER_NONE, NULL }
 };
@@ -2396,10 +2396,10 @@ const mbedtls_cipher_base_t *mbedtls_cipher_base_lookup_table[] = {
 #if defined(MBEDTLS_CCM_C) && defined(MBEDTLS_CAMELLIA_C)
     [MBEDTLS_CIPHER_BASE_INDEX_CCM_CAMELLIA] = &ccm_camellia_info,
 #endif
-#if defined(MBEDTLS_CHACHA20_C)
+#if defined(MBEDTLS_CHACHA20_C) && defined(MBEDTLS_CIPHER_C)
     [MBEDTLS_CIPHER_BASE_INDEX_CHACHA20_BASE] = &chacha20_base_info,
 #endif
-#if defined(MBEDTLS_CHACHAPOLY_C)
+#if defined(MBEDTLS_CHACHAPOLY_C) && defined(MBEDTLS_CIPHER_C)
     [MBEDTLS_CIPHER_BASE_INDEX_CHACHAPOLY_BASE] = &chachapoly_base_info,
 #endif
 #if defined(MBEDTLS_DES_C)
@@ -2420,15 +2420,15 @@ const mbedtls_cipher_base_t *mbedtls_cipher_base_lookup_table[] = {
 #if defined(MBEDTLS_GCM_C) && defined(MBEDTLS_CAMELLIA_C)
     [MBEDTLS_CIPHER_BASE_INDEX_GCM_CAMELLIA] = &gcm_camellia_info,
 #endif
-#if defined(MBEDTLS_NIST_KW_C)
+#if defined(MBEDTLS_NIST_KW_C) && defined(MBEDTLS_CIPHER_C)
     [MBEDTLS_CIPHER_BASE_INDEX_KW_AES] = &kw_aes_info,
 #endif
-#if defined(MBEDTLS_CIPHER_NULL_CIPHER)
+#if defined(MBEDTLS_CIPHER_NULL_CIPHER) && defined(MBEDTLS_CIPHER_C)
     [MBEDTLS_CIPHER_BASE_INDEX_NULL_BASE] = &null_base_info,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_XTS) && defined(MBEDTLS_AES_C)
+#if defined(MBEDTLS_CIPHER_MODE_XTS) && defined(MBEDTLS_AES_C) && defined(MBEDTLS_CIPHER_C)
     [MBEDTLS_CIPHER_BASE_INDEX_XTS_AES] = &xts_aes_info
 #endif
 };
 
-#endif /* MBEDTLS_CIPHER_C */
+#endif /* MBEDTLS_CIPHER_LIGHT */

--- a/library/cipher_wrap.c
+++ b/library/cipher_wrap.c
@@ -113,13 +113,13 @@ enum mbedtls_cipher_base_index {
 #if defined(MBEDTLS_GCM_C) && defined(MBEDTLS_CAMELLIA_C)
     MBEDTLS_CIPHER_BASE_INDEX_GCM_CAMELLIA,
 #endif
-#if defined(MBEDTLS_NIST_KW_C) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_NIST_KW_C)
     MBEDTLS_CIPHER_BASE_INDEX_KW_AES,
 #endif
 #if defined(MBEDTLS_CIPHER_NULL_CIPHER)
     MBEDTLS_CIPHER_BASE_INDEX_NULL_BASE,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_XTS) && defined(MBEDTLS_AES_C) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_XTS) && defined(MBEDTLS_AES_C)
     MBEDTLS_CIPHER_BASE_INDEX_XTS_AES,
 #endif
     /* Prevent compile failure due to empty enum */
@@ -183,7 +183,7 @@ static int aes_crypt_cbc_wrap(void *ctx, mbedtls_operation_t operation, size_t l
 }
 #endif /* MBEDTLS_CIPHER_MODE_CBC */
 
-#if defined(MBEDTLS_CIPHER_MODE_CFB) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
 static int aes_crypt_cfb128_wrap(void *ctx, mbedtls_operation_t operation,
                                  size_t length, size_t *iv_off, unsigned char *iv,
                                  const unsigned char *input, unsigned char *output)
@@ -191,18 +191,18 @@ static int aes_crypt_cfb128_wrap(void *ctx, mbedtls_operation_t operation,
     return mbedtls_aes_crypt_cfb128((mbedtls_aes_context *) ctx, operation, length, iv_off, iv,
                                     input, output);
 }
-#endif /* MBEDTLS_CIPHER_MODE_CFB && MBEDTLS_CIPHER_C */
+#endif /* MBEDTLS_CIPHER_MODE_CFB */
 
-#if defined(MBEDTLS_CIPHER_MODE_OFB) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_OFB)
 static int aes_crypt_ofb_wrap(void *ctx, size_t length, size_t *iv_off,
                               unsigned char *iv, const unsigned char *input, unsigned char *output)
 {
     return mbedtls_aes_crypt_ofb((mbedtls_aes_context *) ctx, length, iv_off,
                                  iv, input, output);
 }
-#endif /* MBEDTLS_CIPHER_MODE_OFB && MBEDTLS_CIPHER_C */
+#endif /* MBEDTLS_CIPHER_MODE_OFB */
 
-#if defined(MBEDTLS_CIPHER_MODE_CTR) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
 static int aes_crypt_ctr_wrap(void *ctx, size_t length, size_t *nc_off,
                               unsigned char *nonce_counter, unsigned char *stream_block,
                               const unsigned char *input, unsigned char *output)
@@ -210,9 +210,9 @@ static int aes_crypt_ctr_wrap(void *ctx, size_t length, size_t *nc_off,
     return mbedtls_aes_crypt_ctr((mbedtls_aes_context *) ctx, length, nc_off, nonce_counter,
                                  stream_block, input, output);
 }
-#endif /* MBEDTLS_CIPHER_MODE_CTR && MBEDTLS_CIPHER_C */
+#endif /* MBEDTLS_CIPHER_MODE_CTR */
 
-#if defined(MBEDTLS_CIPHER_MODE_XTS) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_XTS)
 static int aes_crypt_xts_wrap(void *ctx, mbedtls_operation_t operation,
                               size_t length,
                               const unsigned char data_unit[16],
@@ -236,7 +236,7 @@ static int aes_crypt_xts_wrap(void *ctx, mbedtls_operation_t operation,
     return mbedtls_aes_crypt_xts(xts_ctx, mode, length,
                                  data_unit, input, output);
 }
-#endif /* MBEDTLS_CIPHER_MODE_XTS && MBEDTLS_CIPHER_C */
+#endif /* MBEDTLS_CIPHER_MODE_XTS */
 
 static int aes_setkey_dec_wrap(void *ctx, const unsigned char *key,
                                unsigned int key_bitlen)
@@ -275,19 +275,19 @@ static const mbedtls_cipher_base_t aes_info = {
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
     aes_crypt_cbc_wrap,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CFB) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
     aes_crypt_cfb128_wrap,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_OFB) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_OFB)
     aes_crypt_ofb_wrap,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CTR) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
     aes_crypt_ctr_wrap,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_XTS) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_XTS)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_STREAM) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_STREAM)
     NULL,
 #endif
     aes_setkey_enc_wrap,
@@ -368,7 +368,7 @@ static const mbedtls_cipher_info_t aes_256_cbc_info = {
 #endif
 #endif /* MBEDTLS_CIPHER_MODE_CBC */
 
-#if defined(MBEDTLS_CIPHER_MODE_CFB) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
 static const mbedtls_cipher_info_t aes_128_cfb128_info = {
     "AES-128-CFB128",
     16,
@@ -403,9 +403,9 @@ static const mbedtls_cipher_info_t aes_256_cfb128_info = {
     MBEDTLS_CIPHER_BASE_INDEX_AES
 };
 #endif
-#endif /* MBEDTLS_CIPHER_MODE_CFB && MBEDTLS_CIPHER_C */
+#endif /* MBEDTLS_CIPHER_MODE_CFB */
 
-#if defined(MBEDTLS_CIPHER_MODE_OFB) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_OFB)
 static const mbedtls_cipher_info_t aes_128_ofb_info = {
     "AES-128-OFB",
     16,
@@ -440,9 +440,9 @@ static const mbedtls_cipher_info_t aes_256_ofb_info = {
     MBEDTLS_CIPHER_BASE_INDEX_AES
 };
 #endif
-#endif /* MBEDTLS_CIPHER_MODE_OFB && MBEDTLS_CIPHER_C */
+#endif /* MBEDTLS_CIPHER_MODE_OFB */
 
-#if defined(MBEDTLS_CIPHER_MODE_CTR) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
 static const mbedtls_cipher_info_t aes_128_ctr_info = {
     "AES-128-CTR",
     16,
@@ -477,9 +477,9 @@ static const mbedtls_cipher_info_t aes_256_ctr_info = {
     MBEDTLS_CIPHER_BASE_INDEX_AES
 };
 #endif
-#endif /* MBEDTLS_CIPHER_MODE_CTR && MBEDTLS_CIPHER_C */
+#endif /* MBEDTLS_CIPHER_MODE_CTR */
 
-#if defined(MBEDTLS_CIPHER_MODE_XTS) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_XTS)
 static int xts_aes_setkey_enc_wrap(void *ctx, const unsigned char *key,
                                    unsigned int key_bitlen)
 {
@@ -567,7 +567,7 @@ static const mbedtls_cipher_info_t aes_256_xts_info = {
     MBEDTLS_CIPHER_BASE_INDEX_XTS_AES
 };
 #endif
-#endif /* MBEDTLS_CIPHER_MODE_XTS && MBEDTLS_CIPHER_C */
+#endif /* MBEDTLS_CIPHER_MODE_XTS */
 
 #if defined(MBEDTLS_GCM_C)
 static int gcm_aes_setkey_wrap(void *ctx, const unsigned char *key,
@@ -583,19 +583,19 @@ static const mbedtls_cipher_base_t gcm_aes_info = {
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CFB) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_OFB) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_OFB)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CTR) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_XTS) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_XTS)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_STREAM) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_STREAM)
     NULL,
 #endif
     gcm_aes_setkey_wrap,
@@ -654,19 +654,19 @@ static const mbedtls_cipher_base_t ccm_aes_info = {
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CFB) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_OFB) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_OFB)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CTR) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_XTS) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_XTS)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_STREAM) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_STREAM)
     NULL,
 #endif
     ccm_aes_setkey_wrap,
@@ -767,7 +767,7 @@ static int camellia_crypt_cbc_wrap(void *ctx, mbedtls_operation_t operation,
 }
 #endif /* MBEDTLS_CIPHER_MODE_CBC */
 
-#if defined(MBEDTLS_CIPHER_MODE_CFB) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
 static int camellia_crypt_cfb128_wrap(void *ctx, mbedtls_operation_t operation,
                                       size_t length, size_t *iv_off, unsigned char *iv,
                                       const unsigned char *input, unsigned char *output)
@@ -775,9 +775,9 @@ static int camellia_crypt_cfb128_wrap(void *ctx, mbedtls_operation_t operation,
     return mbedtls_camellia_crypt_cfb128((mbedtls_camellia_context *) ctx, operation, length,
                                          iv_off, iv, input, output);
 }
-#endif /* MBEDTLS_CIPHER_MODE_CFB && MBEDTLS_CIPHER_C */
+#endif /* MBEDTLS_CIPHER_MODE_CFB */
 
-#if defined(MBEDTLS_CIPHER_MODE_CTR) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
 static int camellia_crypt_ctr_wrap(void *ctx, size_t length, size_t *nc_off,
                                    unsigned char *nonce_counter, unsigned char *stream_block,
                                    const unsigned char *input, unsigned char *output)
@@ -785,7 +785,7 @@ static int camellia_crypt_ctr_wrap(void *ctx, size_t length, size_t *nc_off,
     return mbedtls_camellia_crypt_ctr((mbedtls_camellia_context *) ctx, length, nc_off,
                                       nonce_counter, stream_block, input, output);
 }
-#endif /* MBEDTLS_CIPHER_MODE_CTR && MBEDTLS_CIPHER_C */
+#endif /* MBEDTLS_CIPHER_MODE_CTR */
 
 static int camellia_setkey_dec_wrap(void *ctx, const unsigned char *key,
                                     unsigned int key_bitlen)
@@ -825,19 +825,19 @@ static const mbedtls_cipher_base_t camellia_info = {
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
     camellia_crypt_cbc_wrap,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CFB) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
     camellia_crypt_cfb128_wrap,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_OFB) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_OFB)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CTR) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
     camellia_crypt_ctr_wrap,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_XTS) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_XTS)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_STREAM) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_STREAM)
     NULL,
 #endif
     camellia_setkey_enc_wrap,
@@ -914,7 +914,7 @@ static const mbedtls_cipher_info_t camellia_256_cbc_info = {
 };
 #endif /* MBEDTLS_CIPHER_MODE_CBC */
 
-#if defined(MBEDTLS_CIPHER_MODE_CFB) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
 static const mbedtls_cipher_info_t camellia_128_cfb128_info = {
     "CAMELLIA-128-CFB128",
     16,
@@ -947,9 +947,9 @@ static const mbedtls_cipher_info_t camellia_256_cfb128_info = {
     0,
     MBEDTLS_CIPHER_BASE_INDEX_CAMELLIA
 };
-#endif /* MBEDTLS_CIPHER_MODE_CFB && MBEDTLS_CIPHER_C */
+#endif /* MBEDTLS_CIPHER_MODE_CFB */
 
-#if defined(MBEDTLS_CIPHER_MODE_CTR) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
 static const mbedtls_cipher_info_t camellia_128_ctr_info = {
     "CAMELLIA-128-CTR",
     16,
@@ -982,7 +982,7 @@ static const mbedtls_cipher_info_t camellia_256_ctr_info = {
     0,
     MBEDTLS_CIPHER_BASE_INDEX_CAMELLIA
 };
-#endif /* MBEDTLS_CIPHER_MODE_CTR && MBEDTLS_CIPHER_C */
+#endif /* MBEDTLS_CIPHER_MODE_CTR */
 
 #if defined(MBEDTLS_GCM_C)
 static int gcm_camellia_setkey_wrap(void *ctx, const unsigned char *key,
@@ -998,19 +998,19 @@ static const mbedtls_cipher_base_t gcm_camellia_info = {
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CFB) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_OFB) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_OFB)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CTR) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_XTS) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_XTS)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_STREAM) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_STREAM)
     NULL,
 #endif
     gcm_camellia_setkey_wrap,
@@ -1067,19 +1067,19 @@ static const mbedtls_cipher_base_t ccm_camellia_info = {
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CFB) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_OFB) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_OFB)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CTR) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_XTS) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_XTS)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_STREAM) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_STREAM)
     NULL,
 #endif
     ccm_camellia_setkey_wrap,
@@ -1177,7 +1177,7 @@ static int aria_crypt_cbc_wrap(void *ctx, mbedtls_operation_t operation,
 }
 #endif /* MBEDTLS_CIPHER_MODE_CBC */
 
-#if defined(MBEDTLS_CIPHER_MODE_CFB) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
 static int aria_crypt_cfb128_wrap(void *ctx, mbedtls_operation_t operation,
                                   size_t length, size_t *iv_off, unsigned char *iv,
                                   const unsigned char *input, unsigned char *output)
@@ -1185,9 +1185,9 @@ static int aria_crypt_cfb128_wrap(void *ctx, mbedtls_operation_t operation,
     return mbedtls_aria_crypt_cfb128((mbedtls_aria_context *) ctx, operation, length,
                                      iv_off, iv, input, output);
 }
-#endif /* MBEDTLS_CIPHER_MODE_CFB && MBEDTLS_CIPHER_C */
+#endif /* MBEDTLS_CIPHER_MODE_CFB */
 
-#if defined(MBEDTLS_CIPHER_MODE_CTR) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
 static int aria_crypt_ctr_wrap(void *ctx, size_t length, size_t *nc_off,
                                unsigned char *nonce_counter, unsigned char *stream_block,
                                const unsigned char *input, unsigned char *output)
@@ -1195,7 +1195,7 @@ static int aria_crypt_ctr_wrap(void *ctx, size_t length, size_t *nc_off,
     return mbedtls_aria_crypt_ctr((mbedtls_aria_context *) ctx, length, nc_off,
                                   nonce_counter, stream_block, input, output);
 }
-#endif /* MBEDTLS_CIPHER_MODE_CTR && MBEDTLS_CIPHER_C */
+#endif /* MBEDTLS_CIPHER_MODE_CTR */
 
 static int aria_setkey_dec_wrap(void *ctx, const unsigned char *key,
                                 unsigned int key_bitlen)
@@ -1235,19 +1235,19 @@ static const mbedtls_cipher_base_t aria_info = {
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
     aria_crypt_cbc_wrap,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CFB) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
     aria_crypt_cfb128_wrap,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_OFB) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_OFB)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CTR) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
     aria_crypt_ctr_wrap,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_XTS) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_XTS)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_STREAM) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_STREAM)
     NULL,
 #endif
     aria_setkey_enc_wrap,
@@ -1324,7 +1324,7 @@ static const mbedtls_cipher_info_t aria_256_cbc_info = {
 };
 #endif /* MBEDTLS_CIPHER_MODE_CBC */
 
-#if defined(MBEDTLS_CIPHER_MODE_CFB) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
 static const mbedtls_cipher_info_t aria_128_cfb128_info = {
     "ARIA-128-CFB128",
     16,
@@ -1357,9 +1357,9 @@ static const mbedtls_cipher_info_t aria_256_cfb128_info = {
     0,
     MBEDTLS_CIPHER_BASE_INDEX_ARIA
 };
-#endif /* MBEDTLS_CIPHER_MODE_CFB && MBEDTLS_CIPHER_C */
+#endif /* MBEDTLS_CIPHER_MODE_CFB */
 
-#if defined(MBEDTLS_CIPHER_MODE_CTR) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
 static const mbedtls_cipher_info_t aria_128_ctr_info = {
     "ARIA-128-CTR",
     16,
@@ -1392,7 +1392,7 @@ static const mbedtls_cipher_info_t aria_256_ctr_info = {
     0,
     MBEDTLS_CIPHER_BASE_INDEX_ARIA
 };
-#endif /* MBEDTLS_CIPHER_MODE_CTR && MBEDTLS_CIPHER_C */
+#endif /* MBEDTLS_CIPHER_MODE_CTR */
 
 #if defined(MBEDTLS_GCM_C)
 static int gcm_aria_setkey_wrap(void *ctx, const unsigned char *key,
@@ -1408,19 +1408,19 @@ static const mbedtls_cipher_base_t gcm_aria_info = {
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CFB) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_OFB) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_OFB)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CTR) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_XTS) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_XTS)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_STREAM) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_STREAM)
     NULL,
 #endif
     gcm_aria_setkey_wrap,
@@ -1477,19 +1477,19 @@ static const mbedtls_cipher_base_t ccm_aria_info = {
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CFB) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_OFB) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_OFB)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CTR) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_XTS) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_XTS)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_STREAM) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_STREAM)
     NULL,
 #endif
     ccm_aria_setkey_wrap,
@@ -1694,19 +1694,19 @@ static const mbedtls_cipher_base_t des_info = {
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
     des_crypt_cbc_wrap,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CFB) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_OFB) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_OFB)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CTR) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_XTS) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_XTS)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_STREAM) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_STREAM)
     NULL,
 #endif
     des_setkey_enc_wrap,
@@ -1745,19 +1745,19 @@ static const mbedtls_cipher_base_t des_ede_info = {
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
     des3_crypt_cbc_wrap,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CFB) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_OFB) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_OFB)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CTR) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_XTS) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_XTS)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_STREAM) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_STREAM)
     NULL,
 #endif
     des3_set2key_enc_wrap,
@@ -1796,19 +1796,19 @@ static const mbedtls_cipher_base_t des_ede3_info = {
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
     des3_crypt_cbc_wrap,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CFB) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_OFB) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_OFB)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CTR) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_XTS) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_XTS)
     NULL,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_STREAM) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_STREAM)
     NULL,
 #endif
     des3_set3key_enc_wrap,
@@ -1841,7 +1841,7 @@ static const mbedtls_cipher_info_t des_ede3_cbc_info = {
 #endif /* MBEDTLS_CIPHER_MODE_CBC */
 #endif /* MBEDTLS_DES_C */
 
-#if defined(MBEDTLS_CHACHA20_C) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CHACHA20_C)
 
 static int chacha20_setkey_wrap(void *ctx, const unsigned char *key,
                                 unsigned int key_bitlen)
@@ -1927,9 +1927,9 @@ static const mbedtls_cipher_info_t chacha20_info = {
     0,
     MBEDTLS_CIPHER_BASE_INDEX_CHACHA20_BASE
 };
-#endif /* MBEDTLS_CHACHA20_C && MBEDTLS_CIPHER_C */
+#endif /* MBEDTLS_CHACHA20_C */
 
-#if defined(MBEDTLS_CHACHAPOLY_C) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CHACHAPOLY_C)
 
 static int chachapoly_setkey_wrap(void *ctx,
                                   const unsigned char *key,
@@ -2002,9 +2002,9 @@ static const mbedtls_cipher_info_t chachapoly_info = {
     0,
     MBEDTLS_CIPHER_BASE_INDEX_CHACHAPOLY_BASE
 };
-#endif /* MBEDTLS_CHACHAPOLY_C && MBEDTLS_CIPHER_C */
+#endif /* MBEDTLS_CHACHAPOLY_C */
 
-#if defined(MBEDTLS_CIPHER_NULL_CIPHER) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_NULL_CIPHER)
 static int null_crypt_stream(void *ctx, size_t length,
                              const unsigned char *input,
                              unsigned char *output)
@@ -2073,7 +2073,7 @@ static const mbedtls_cipher_info_t null_cipher_info = {
 };
 #endif /* defined(MBEDTLS_CIPHER_NULL_CIPHER) */
 
-#if defined(MBEDTLS_NIST_KW_C) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_NIST_KW_C)
 static void *kw_ctx_alloc(void)
 {
     void *ctx = mbedtls_calloc(1, sizeof(mbedtls_nist_kw_context));
@@ -2201,7 +2201,7 @@ static const mbedtls_cipher_info_t aes_256_nist_kwp_info = {
     MBEDTLS_CIPHER_BASE_INDEX_KW_AES
 };
 #endif
-#endif /* MBEDTLS_NIST_KW_C && MBEDTLS_CIPHER_C */
+#endif /* MBEDTLS_NIST_KW_C */
 
 const mbedtls_cipher_definition_t mbedtls_cipher_definitions[] =
 {
@@ -2218,28 +2218,28 @@ const mbedtls_cipher_definition_t mbedtls_cipher_definitions[] =
     { MBEDTLS_CIPHER_AES_256_CBC,          &aes_256_cbc_info },
 #endif
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CFB) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
     { MBEDTLS_CIPHER_AES_128_CFB128,       &aes_128_cfb128_info },
 #if !defined(MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH)
     { MBEDTLS_CIPHER_AES_192_CFB128,       &aes_192_cfb128_info },
     { MBEDTLS_CIPHER_AES_256_CFB128,       &aes_256_cfb128_info },
 #endif
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_OFB) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_OFB)
     { MBEDTLS_CIPHER_AES_128_OFB,          &aes_128_ofb_info },
 #if !defined(MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH)
     { MBEDTLS_CIPHER_AES_192_OFB,          &aes_192_ofb_info },
     { MBEDTLS_CIPHER_AES_256_OFB,          &aes_256_ofb_info },
 #endif
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CTR) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
     { MBEDTLS_CIPHER_AES_128_CTR,          &aes_128_ctr_info },
 #if !defined(MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH)
     { MBEDTLS_CIPHER_AES_192_CTR,          &aes_192_ctr_info },
     { MBEDTLS_CIPHER_AES_256_CTR,          &aes_256_ctr_info },
 #endif
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_XTS) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_XTS)
     { MBEDTLS_CIPHER_AES_128_XTS,          &aes_128_xts_info },
 #if !defined(MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH)
     { MBEDTLS_CIPHER_AES_256_XTS,          &aes_256_xts_info },
@@ -2275,12 +2275,12 @@ const mbedtls_cipher_definition_t mbedtls_cipher_definitions[] =
     { MBEDTLS_CIPHER_CAMELLIA_192_CBC,     &camellia_192_cbc_info },
     { MBEDTLS_CIPHER_CAMELLIA_256_CBC,     &camellia_256_cbc_info },
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CFB) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
     { MBEDTLS_CIPHER_CAMELLIA_128_CFB128,  &camellia_128_cfb128_info },
     { MBEDTLS_CIPHER_CAMELLIA_192_CFB128,  &camellia_192_cfb128_info },
     { MBEDTLS_CIPHER_CAMELLIA_256_CFB128,  &camellia_256_cfb128_info },
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CTR) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
     { MBEDTLS_CIPHER_CAMELLIA_128_CTR,     &camellia_128_ctr_info },
     { MBEDTLS_CIPHER_CAMELLIA_192_CTR,     &camellia_192_ctr_info },
     { MBEDTLS_CIPHER_CAMELLIA_256_CTR,     &camellia_256_ctr_info },
@@ -2309,12 +2309,12 @@ const mbedtls_cipher_definition_t mbedtls_cipher_definitions[] =
     { MBEDTLS_CIPHER_ARIA_192_CBC,     &aria_192_cbc_info },
     { MBEDTLS_CIPHER_ARIA_256_CBC,     &aria_256_cbc_info },
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CFB) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
     { MBEDTLS_CIPHER_ARIA_128_CFB128,  &aria_128_cfb128_info },
     { MBEDTLS_CIPHER_ARIA_192_CFB128,  &aria_192_cfb128_info },
     { MBEDTLS_CIPHER_ARIA_256_CFB128,  &aria_256_cfb128_info },
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CTR) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
     { MBEDTLS_CIPHER_ARIA_128_CTR,     &aria_128_ctr_info },
     { MBEDTLS_CIPHER_ARIA_192_CTR,     &aria_192_ctr_info },
     { MBEDTLS_CIPHER_ARIA_256_CTR,     &aria_256_ctr_info },
@@ -2345,15 +2345,15 @@ const mbedtls_cipher_definition_t mbedtls_cipher_definitions[] =
 #endif
 #endif /* MBEDTLS_DES_C */
 
-#if defined(MBEDTLS_CHACHA20_C) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CHACHA20_C)
     { MBEDTLS_CIPHER_CHACHA20,             &chacha20_info },
 #endif
 
-#if defined(MBEDTLS_CHACHAPOLY_C) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CHACHAPOLY_C)
     { MBEDTLS_CIPHER_CHACHA20_POLY1305,    &chachapoly_info },
 #endif
 
-#if defined(MBEDTLS_NIST_KW_C) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_NIST_KW_C)
     { MBEDTLS_CIPHER_AES_128_KW,          &aes_128_nist_kw_info },
 #if !defined(MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH)
     { MBEDTLS_CIPHER_AES_192_KW,          &aes_192_nist_kw_info },
@@ -2366,9 +2366,9 @@ const mbedtls_cipher_definition_t mbedtls_cipher_definitions[] =
 #endif
 #endif
 
-#if defined(MBEDTLS_CIPHER_NULL_CIPHER) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_NULL_CIPHER)
     { MBEDTLS_CIPHER_NULL,                 &null_cipher_info },
-#endif /* MBEDTLS_CIPHER_NULL_CIPHER && MBEDTLS_CIPHER_C */
+#endif /* MBEDTLS_CIPHER_NULL_CIPHER */
 
     { MBEDTLS_CIPHER_NONE, NULL }
 };
@@ -2396,10 +2396,10 @@ const mbedtls_cipher_base_t *mbedtls_cipher_base_lookup_table[] = {
 #if defined(MBEDTLS_CCM_C) && defined(MBEDTLS_CAMELLIA_C)
     [MBEDTLS_CIPHER_BASE_INDEX_CCM_CAMELLIA] = &ccm_camellia_info,
 #endif
-#if defined(MBEDTLS_CHACHA20_C) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CHACHA20_C)
     [MBEDTLS_CIPHER_BASE_INDEX_CHACHA20_BASE] = &chacha20_base_info,
 #endif
-#if defined(MBEDTLS_CHACHAPOLY_C) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CHACHAPOLY_C)
     [MBEDTLS_CIPHER_BASE_INDEX_CHACHAPOLY_BASE] = &chachapoly_base_info,
 #endif
 #if defined(MBEDTLS_DES_C)
@@ -2420,13 +2420,13 @@ const mbedtls_cipher_base_t *mbedtls_cipher_base_lookup_table[] = {
 #if defined(MBEDTLS_GCM_C) && defined(MBEDTLS_CAMELLIA_C)
     [MBEDTLS_CIPHER_BASE_INDEX_GCM_CAMELLIA] = &gcm_camellia_info,
 #endif
-#if defined(MBEDTLS_NIST_KW_C) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_NIST_KW_C)
     [MBEDTLS_CIPHER_BASE_INDEX_KW_AES] = &kw_aes_info,
 #endif
-#if defined(MBEDTLS_CIPHER_NULL_CIPHER) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_NULL_CIPHER)
     [MBEDTLS_CIPHER_BASE_INDEX_NULL_BASE] = &null_base_info,
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_XTS) && defined(MBEDTLS_AES_C) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_XTS) && defined(MBEDTLS_AES_C)
     [MBEDTLS_CIPHER_BASE_INDEX_XTS_AES] = &xts_aes_info
 #endif
 };

--- a/library/cipher_wrap.h
+++ b/library/cipher_wrap.h
@@ -54,14 +54,14 @@ struct mbedtls_cipher_base_t {
                     unsigned char *output);
 #endif
 
-#if defined(MBEDTLS_CIPHER_MODE_CFB)
+#if defined(MBEDTLS_CIPHER_MODE_CFB) && defined(MBEDTLS_CIPHER_C)
     /** Encrypt using CFB (Full length) */
     int (*cfb_func)(void *ctx, mbedtls_operation_t mode, size_t length, size_t *iv_off,
                     unsigned char *iv, const unsigned char *input,
                     unsigned char *output);
 #endif
 
-#if defined(MBEDTLS_CIPHER_MODE_OFB)
+#if defined(MBEDTLS_CIPHER_MODE_OFB) && defined(MBEDTLS_CIPHER_C)
     /** Encrypt using OFB (Full length) */
     int (*ofb_func)(void *ctx, size_t length, size_t *iv_off,
                     unsigned char *iv,
@@ -69,21 +69,21 @@ struct mbedtls_cipher_base_t {
                     unsigned char *output);
 #endif
 
-#if defined(MBEDTLS_CIPHER_MODE_CTR)
+#if defined(MBEDTLS_CIPHER_MODE_CTR) && defined(MBEDTLS_CIPHER_C)
     /** Encrypt using CTR */
     int (*ctr_func)(void *ctx, size_t length, size_t *nc_off,
                     unsigned char *nonce_counter, unsigned char *stream_block,
                     const unsigned char *input, unsigned char *output);
 #endif
 
-#if defined(MBEDTLS_CIPHER_MODE_XTS)
+#if defined(MBEDTLS_CIPHER_MODE_XTS) && defined(MBEDTLS_CIPHER_C)
     /** Encrypt or decrypt using XTS. */
     int (*xts_func)(void *ctx, mbedtls_operation_t mode, size_t length,
                     const unsigned char data_unit[16],
                     const unsigned char *input, unsigned char *output);
 #endif
 
-#if defined(MBEDTLS_CIPHER_MODE_STREAM)
+#if defined(MBEDTLS_CIPHER_MODE_STREAM) && defined(MBEDTLS_CIPHER_C)
     /** Encrypt using STREAM */
     int (*stream_func)(void *ctx, size_t length,
                        const unsigned char *input, unsigned char *output);

--- a/library/cipher_wrap.h
+++ b/library/cipher_wrap.h
@@ -54,14 +54,14 @@ struct mbedtls_cipher_base_t {
                     unsigned char *output);
 #endif
 
-#if defined(MBEDTLS_CIPHER_MODE_CFB) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
     /** Encrypt using CFB (Full length) */
     int (*cfb_func)(void *ctx, mbedtls_operation_t mode, size_t length, size_t *iv_off,
                     unsigned char *iv, const unsigned char *input,
                     unsigned char *output);
 #endif
 
-#if defined(MBEDTLS_CIPHER_MODE_OFB) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_OFB)
     /** Encrypt using OFB (Full length) */
     int (*ofb_func)(void *ctx, size_t length, size_t *iv_off,
                     unsigned char *iv,
@@ -69,21 +69,21 @@ struct mbedtls_cipher_base_t {
                     unsigned char *output);
 #endif
 
-#if defined(MBEDTLS_CIPHER_MODE_CTR) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
     /** Encrypt using CTR */
     int (*ctr_func)(void *ctx, size_t length, size_t *nc_off,
                     unsigned char *nonce_counter, unsigned char *stream_block,
                     const unsigned char *input, unsigned char *output);
 #endif
 
-#if defined(MBEDTLS_CIPHER_MODE_XTS) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_XTS)
     /** Encrypt or decrypt using XTS. */
     int (*xts_func)(void *ctx, mbedtls_operation_t mode, size_t length,
                     const unsigned char data_unit[16],
                     const unsigned char *input, unsigned char *output);
 #endif
 
-#if defined(MBEDTLS_CIPHER_MODE_STREAM) && defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_MODE_STREAM)
     /** Encrypt using STREAM */
     int (*stream_func)(void *ctx, size_t length,
                        const unsigned char *input, unsigned char *output);

--- a/library/oid.c
+++ b/library/oid.c
@@ -676,7 +676,7 @@ FN_OID_GET_OID_BY_ATTR1(mbedtls_oid_get_oid_by_ec_grp_algid,
                         grp_id)
 #endif /* MBEDTLS_PK_HAVE_ECC_KEYS */
 
-#if defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_LIGHT)
 /*
  * For PKCS#5 PBES2 encryption algorithm
  */
@@ -707,7 +707,7 @@ FN_OID_GET_ATTR1(mbedtls_oid_get_cipher_alg,
                  cipher_alg,
                  mbedtls_cipher_type_t,
                  cipher_alg)
-#endif /* MBEDTLS_CIPHER_C */
+#endif /* MBEDTLS_CIPHER_LIGHT */
 
 /*
  * For digestAlgorithm

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1511,7 +1511,7 @@ component_test_crypto_full_md_light_only () {
     make test
 }
 
-component_test_full_no_cipher () {
+component_test_full_no_cipher_at_all () {
     msg "build: full minus CIPHER"
     scripts/config.py full
     scripts/config.py unset MBEDTLS_CIPHER_C
@@ -1541,6 +1541,8 @@ component_test_full_no_cipher () {
     scripts/config.py unset MBEDTLS_LMS_C
     scripts/config.py unset MBEDTLS_LMS_PRIVATE
     make
+
+    not grep mbedtls_cipher library/cipher.o
 
     msg "test: full minus CIPHER"
     make test

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1518,13 +1518,26 @@ component_test_full_no_cipher_at_all () {
     # Don't pull in cipher via PSA mechanisms
     # (currently ignored anyway because we completely disable PSA)
     scripts/config.py unset MBEDTLS_PSA_CRYPTO_CONFIG
-    # Direct dependencies
+    # Direct dependencies for CIPHER_LIGHT
     scripts/config.py unset MBEDTLS_CCM_C
     scripts/config.py unset MBEDTLS_CMAC_C
     scripts/config.py unset MBEDTLS_GCM_C
     scripts/config.py unset MBEDTLS_NIST_KW_C
     scripts/config.py unset MBEDTLS_PKCS12_C
     scripts/config.py unset MBEDTLS_PKCS5_C
+    # Direct dependencies for CIPHER_C
+    scripts/config.py unset MBEDTLS_NIST_KW_C
+    scripts/config.py unset MBEDTLS_CIPHER_MODE_CFB
+    scripts/config.py unset MBEDTLS_CIPHER_MODE_CTR
+    scripts/config.py unset MBEDTLS_CIPHER_MODE_OFB
+    scripts/config.py unset MBEDTLS_CIPHER_MODE_XTS
+    scripts/config.py unset MBEDTLS_CHACHA20_C
+    scripts/config.py unset MBEDTLS_CHACHAPOLY_C
+    scripts/config.py unset MBEDTLS_CIPHER_NULL_CIPHER
+    scripts/config.py unset MBEDTLS_CIPHER_PADDING_PKCS7
+    scripts/config.py unset MBEDTLS_CIPHER_PADDING_ONE_AND_ZEROS
+    scripts/config.py unset MBEDTLS_CIPHER_PADDING_ZEROS_AND_LEN
+    scripts/config.py unset MBEDTLS_CIPHER_PADDING_ZEROS
     scripts/config.py unset MBEDTLS_PSA_CRYPTO_C
     scripts/config.py unset MBEDTLS_SSL_TLS_C
     scripts/config.py unset MBEDTLS_SSL_TICKET_C
@@ -1537,10 +1550,11 @@ component_test_full_no_cipher_at_all () {
     scripts/config.py unset MBEDTLS_SSL_DTLS_CONNECTION_ID_COMPAT
     scripts/config.py unset MBEDTLS_SSL_PROTO_TLS1_3
     scripts/config.py unset MBEDTLS_SSL_SRV_C
+    scripts/config.py unset MBEDTLS_SSL_CONTEXT_SERIALIZATION
     scripts/config.py unset MBEDTLS_USE_PSA_CRYPTO
     scripts/config.py unset MBEDTLS_LMS_C
     scripts/config.py unset MBEDTLS_LMS_PRIVATE
-    make
+    make CFLAGS="-O0 -g"
 
     not grep mbedtls_cipher library/cipher.o
 
@@ -1552,13 +1566,24 @@ component_test_full_cipher_light_only () {
     msg "build: full minus CIPHER"
     scripts/config.py full
     scripts/config.py unset MBEDTLS_CIPHER_C
-    # Direct dependencies
-    scripts/config.py unset MBEDTLS_CCM_C
-    scripts/config.py unset MBEDTLS_CMAC_C
-    scripts/config.py unset MBEDTLS_GCM_C
+    # Direct dependencies for CIPHER_C
     scripts/config.py unset MBEDTLS_NIST_KW_C
-    scripts/config.py unset MBEDTLS_PKCS12_C
-    scripts/config.py unset MBEDTLS_PKCS5_C
+    scripts/config.py unset MBEDTLS_CIPHER_MODE_CFB
+    scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_CFB
+    scripts/config.py unset MBEDTLS_CIPHER_MODE_CTR
+    scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_CTR
+    scripts/config.py unset MBEDTLS_CIPHER_MODE_OFB
+    scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_OFB
+    scripts/config.py unset MBEDTLS_CIPHER_MODE_XTS
+    scripts/config.py unset MBEDTLS_CHACHA20_C
+    scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_KEY_TYPE_CHACHA20
+    scripts/config.py unset MBEDTLS_CHACHAPOLY_C
+    scripts/config.py unset MBEDTLS_CIPHER_NULL_CIPHER
+    scripts/config.py unset MBEDTLS_CIPHER_PADDING_PKCS7
+    scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_CBC_PKCS7
+    scripts/config.py unset MBEDTLS_CIPHER_PADDING_ONE_AND_ZEROS
+    scripts/config.py unset MBEDTLS_CIPHER_PADDING_ZEROS_AND_LEN
+    scripts/config.py unset MBEDTLS_CIPHER_PADDING_ZEROS
     scripts/config.py unset MBEDTLS_PSA_CRYPTO_C
     scripts/config.py unset MBEDTLS_SSL_TLS_C
     scripts/config.py unset MBEDTLS_SSL_TICKET_C
@@ -1574,8 +1599,8 @@ component_test_full_cipher_light_only () {
     scripts/config.py unset MBEDTLS_USE_PSA_CRYPTO
     scripts/config.py unset MBEDTLS_LMS_C
     scripts/config.py unset MBEDTLS_LMS_PRIVATE
-    # Build with CIPHER_LIGHT enabled
-    make CFLAGS="-DMBEDTLS_CIPHER_LIGHT"
+
+    make
 
     not grep mbedtls_cipher_auth library/cipher.o
 

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1548,6 +1548,41 @@ component_test_full_no_cipher_at_all () {
     make test
 }
 
+component_test_full_cipher_light_only () {
+    msg "build: full minus CIPHER"
+    scripts/config.py full
+    scripts/config.py unset MBEDTLS_CIPHER_C
+    # Direct dependencies
+    scripts/config.py unset MBEDTLS_CCM_C
+    scripts/config.py unset MBEDTLS_CMAC_C
+    scripts/config.py unset MBEDTLS_GCM_C
+    scripts/config.py unset MBEDTLS_NIST_KW_C
+    scripts/config.py unset MBEDTLS_PKCS12_C
+    scripts/config.py unset MBEDTLS_PKCS5_C
+    scripts/config.py unset MBEDTLS_PSA_CRYPTO_C
+    scripts/config.py unset MBEDTLS_SSL_TLS_C
+    scripts/config.py unset MBEDTLS_SSL_TICKET_C
+    # Indirect dependencies
+    scripts/config.py unset MBEDTLS_SSL_CLI_C
+    scripts/config.py unset MBEDTLS_PSA_CRYPTO_SE_C
+    scripts/config.py unset MBEDTLS_PSA_CRYPTO_STORAGE_C
+    scripts/config.py unset MBEDTLS_SSL_DTLS_ANTI_REPLAY
+    scripts/config.py unset MBEDTLS_SSL_DTLS_CONNECTION_ID
+    scripts/config.py unset MBEDTLS_SSL_DTLS_CONNECTION_ID_COMPAT
+    scripts/config.py unset MBEDTLS_SSL_PROTO_TLS1_3
+    scripts/config.py unset MBEDTLS_SSL_SRV_C
+    scripts/config.py unset MBEDTLS_USE_PSA_CRYPTO
+    scripts/config.py unset MBEDTLS_LMS_C
+    scripts/config.py unset MBEDTLS_LMS_PRIVATE
+    # Build with CIPHER_LIGHT enabled
+    make CFLAGS="-DMBEDTLS_CIPHER_LIGHT"
+
+    not grep mbedtls_cipher_auth library/cipher.o
+
+    msg "test: full minus CIPHER"
+    make test
+}
+
 component_test_full_no_bignum () {
     msg "build: full minus bignum"
     scripts/config.py full

--- a/tests/suites/test_suite_cipher.function
+++ b/tests/suites/test_suite_cipher.function
@@ -82,7 +82,7 @@ exit:
     return 0;
 }
 
-#if defined(MBEDTLS_CIPHER_AUTH_CRYPT)
+#if defined(MBEDTLS_CIPHER_AUTH_CRYPT) && defined(MBEDTLS_CIPHER_C)
 /* Helper for resetting key/direction
  *
  * The documentation doesn't explicitly say whether calling
@@ -140,7 +140,7 @@ int buffer_is_all_zero(const uint8_t *buf, size_t size)
 /* END_HEADER */
 
 /* BEGIN_DEPENDENCIES
- * depends_on:MBEDTLS_CIPHER_C
+ * depends_on:MBEDTLS_CIPHER_LIGHT
  * END_DEPENDENCIES
  */
 
@@ -832,7 +832,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_CIPHER_AUTH_CRYPT */
+/* BEGIN_CASE depends_on:MBEDTLS_CIPHER_AUTH_CRYPT:MBEDTLS_CIPHER_C */
 void auth_crypt_tv(int cipher_id, data_t *key, data_t *iv,
                    data_t *ad, data_t *cipher, data_t *tag,
                    char *result, data_t *clear, int use_psa)


### PR DESCRIPTION
This PR tries to introduce `CIPHER_LIGHT`, a "reduced" version of `CIPHER_C`, following the requirements of #8058 (i.e. the associated task) and #8057.

Resolves #8058

**Depends on:**
- #8057
- #8119 

## PR checklist

- [ ] **changelog** since we add the possibility for the end user to have a reduced version of `CIPHER_C` I think this is required, right?
- [ ] **backport** not required because it's an enhancement
- [ ] **tests** provided: a new test component was added