### PR TITLE
Check mbedtls_platform_zeroize() calls

### DIFF
--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -167,28 +167,17 @@ MBEDTLS_DEPRECATED typedef int mbedtls_deprecated_numeric_constant_t;
  * \param len   Length of the buffer in bytes
  *
  */
-#if defined(MBEDTLS_PLATFORM_ZEROIZE_CHECK_UNSAFE)
-#define MBEDTLS_PLATFORM_ZEROIZE_ALT
-#define mbedtls_platform_zeroize(buf, len) memset(buf, 0, len)
-#include <string.h>
-#else
+#if !defined(MBEDTLS_TEST_DEFINES_ZEROIZE)
 void mbedtls_platform_zeroize(void *buf, size_t len);
 #endif
 
-/* MBEDTLS_PLATFORM_ZEROIZE_CHECK_UNSAFE
+/* MBEDTLS_TEST_DEFINES_ZEROIZE
  *
- * Replaces calls to mbedtls_platform_zeroize() with calls to memset(),
- * to allow compiler analysis to check for invalid length arguments (e.g.
- * specifying sizeof(pointer) rather than sizeof(pointee)).
- *
- * Note that this option is meant for internal use only and must not be used
- * in production builds, because that would lead to zeroization calls being
- * optimised out by the compiler.
- *
- * It is only intended to be used in CFLAGS, with -Wsizeof-pointer-memaccess,
- * to check for those incorrect calls to mbedtls_platform_zeroize().
+ * Indicates that the library is being built by the test framework, and the
+ * framework is going to provide a replacement mbedtls_platform_zeroize()
+ * using a pre-processor macro, so the function declaration should be omitted.
  */
-//#define MBEDTLS_PLATFORM_ZEROIZE_CHECK_UNSAFE
+//#define MBEDTLS_TEST_DEFINES_ZEROIZE
 
 #if defined(MBEDTLS_HAVE_TIME_DATE)
 /**

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -145,6 +145,11 @@ MBEDTLS_DEPRECATED typedef int mbedtls_deprecated_numeric_constant_t;
 #define MBEDTLS_IGNORE_RETURN(result) ((void) !(result))
 #endif
 
+/* If the following macro is defined, the library is being built by the test
+ * framework, and the framework is going to provide a replacement
+ * mbedtls_platform_zeroize() using a preprocessor macro, so the function
+ * declaration should be omitted.  */
+#if !defined(MBEDTLS_TEST_DEFINES_ZEROIZE) //no-check-names
 /**
  * \brief       Securely zeroize a buffer
  *
@@ -167,17 +172,8 @@ MBEDTLS_DEPRECATED typedef int mbedtls_deprecated_numeric_constant_t;
  * \param len   Length of the buffer in bytes
  *
  */
-#if !defined(MBEDTLS_TEST_DEFINES_ZEROIZE)
 void mbedtls_platform_zeroize(void *buf, size_t len);
 #endif
-
-/* MBEDTLS_TEST_DEFINES_ZEROIZE
- *
- * Indicates that the library is being built by the test framework, and the
- * framework is going to provide a replacement mbedtls_platform_zeroize()
- * using a pre-processor macro, so the function declaration should be omitted.
- */
-//#define MBEDTLS_TEST_DEFINES_ZEROIZE
 
 #if defined(MBEDTLS_HAVE_TIME_DATE)
 /**

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -167,7 +167,28 @@ MBEDTLS_DEPRECATED typedef int mbedtls_deprecated_numeric_constant_t;
  * \param len   Length of the buffer in bytes
  *
  */
+#if defined(MBEDTLS_PLATFORM_ZEROIZE_CHECK_UNSAFE)
+#define MBEDTLS_PLATFORM_ZEROIZE_ALT
+#define mbedtls_platform_zeroize(buf, len) memset(buf, 0, len)
+#include <string.h>
+#else
 void mbedtls_platform_zeroize(void *buf, size_t len);
+#endif
+
+/* MBEDTLS_PLATFORM_ZEROIZE_CHECK_UNSAFE
+ *
+ * Replaces calls to mbedtls_platform_zeroize() with calls to memset(),
+ * to allow compiler analysis to check for invalid length arguments (e.g.
+ * specifying sizeof(pointer) rather than sizeof(pointee)).
+ *
+ * Note that this option is meant for internal use only and must not be used
+ * in production builds, because that would lead to zeroization calls being
+ * optimised out by the compiler.
+ *
+ * It is only intended to be used in CFLAGS, with -Wsizeof-pointer-memaccess,
+ * to check for those incorrect calls to mbedtls_platform_zeroize().
+ */
+//#define MBEDTLS_PLATFORM_ZEROIZE_CHECK_UNSAFE
 
 #if defined(MBEDTLS_HAVE_TIME_DATE)
 /**

--- a/tests/configs/config-wrapper-zeroize-memset.h
+++ b/tests/configs/config-wrapper-zeroize-memset.h
@@ -1,0 +1,31 @@
+/* mbedtls_config.h wrapper that defines mbedtls_platform_zeroize() to be
+ * memset(), so that the compile can check arguments for us.
+ * Used for testing.
+ */
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include "mbedtls/mbedtls_config.h"
+
+#include <string.h>
+
+/* Define _ALT so we don't get the built-in implementation. The test code will
+ * also need to define MBEDTLS_TEST_DEFINES_ZEROIZE so we don't get the
+ * declaration. */
+#define MBEDTLS_PLATFORM_ZEROIZE_ALT
+
+#define mbedtls_platform_zeroize(buf, len) memset(buf, 0, len)

--- a/tests/configs/user-config-zeroize-memset.h
+++ b/tests/configs/user-config-zeroize-memset.h
@@ -1,4 +1,4 @@
-/* mbedtls_config.h wrapper that defines mbedtls_platform_zeroize() to be
+/* mbedtls_config.h modifier that defines mbedtls_platform_zeroize() to be
  * memset(), so that the compile can check arguments for us.
  * Used for testing.
  */
@@ -18,8 +18,6 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-
-#include "mbedtls/mbedtls_config.h"
 
 #include <string.h>
 

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -5123,7 +5123,7 @@ component_build_zeroize_checks () {
     scripts/config.py full
 
     # Only compile - we're looking for sizeof-pointer-memaccess warnings
-    make CC=gcc CFLAGS="'-DMBEDTLS_USER_CONFIG_FILE=\"../tests/configs/config-wrapper-zeroize-memset.h\"' -DMBEDTLS_TEST_DEFINES_ZEROIZE -Werror -Wsizeof-pointer-memaccess"
+    make CC=gcc CFLAGS="'-DMBEDTLS_USER_CONFIG_FILE=\"../tests/configs/user-config-zeroize-memset.h\"' -DMBEDTLS_TEST_DEFINES_ZEROIZE -Werror -Wsizeof-pointer-memaccess"
 }
 
 

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -5117,6 +5117,16 @@ support_build_cmake_custom_config_file () {
 }
 
 
+component_build_zeroize_checks () {
+    msg "build: check for obviously wrong calls to mbedtls_platform_zeroize()"
+
+    scripts/config.py full
+
+    # Only compile - we're looking for sizeof-pointer-memaccess warnings
+    make CC=gcc CFLAGS='-Werror -DMBEDTLS_PLATFORM_ZEROIZE_CHECK_UNSAFE -Wsizeof-pointer-memaccess'
+}
+
+
 component_test_zeroize () {
     # Test that the function mbedtls_platform_zeroize() is not optimized away by
     # different combinations of compilers and optimization flags by using an

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -5123,7 +5123,7 @@ component_build_zeroize_checks () {
     scripts/config.py full
 
     # Only compile - we're looking for sizeof-pointer-memaccess warnings
-    make CC=gcc CFLAGS='-Werror -DMBEDTLS_PLATFORM_ZEROIZE_CHECK_UNSAFE -Wsizeof-pointer-memaccess'
+    make CC=gcc CFLAGS="'-DMBEDTLS_USER_CONFIG_FILE=\"../tests/configs/config-wrapper-zeroize-memset.h\"' -DMBEDTLS_TEST_DEFINES_ZEROIZE -Werror -Wsizeof-pointer-memaccess"
 }
 
 

--- a/tests/suites/test_suite_pkwrite.function
+++ b/tests/suites/test_suite_pkwrite.function
@@ -194,7 +194,7 @@ void pk_write_public_from_private(char *priv_key_file, char *pub_key_file)
                         pub_key_raw, pub_key_len);
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
-    mbedtls_platform_zeroize(derived_key_raw, sizeof(derived_key_raw));
+    mbedtls_platform_zeroize(derived_key_raw, derived_key_len);
 
     TEST_EQUAL(mbedtls_pk_wrap_as_opaque(&priv_key, &opaque_key_id,
                                          PSA_ALG_NONE, PSA_KEY_USAGE_EXPORT,


### PR DESCRIPTION
## Description

Add the ability to verify mbedtls_platform_zeroize() calls with -Wsizeof-pointer-memaccess, and fix a problem it finds in the tests.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required - this is internal only
- [x] **backport** #8145
- [x] **tests** present - now that #8068 is merged this can be merged too
