### PR TITLE
Add more protection to mbedtls_platform_zeroize

### DIFF
--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -137,7 +137,7 @@ void mbedtls_platform_zeroize(void *buf, size_t len)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wvla"
 #endif
-        asm volatile ("" : : "m" (*(char (*)[len]) buf) : );
+        asm volatile ("" : : "m" (*(char (*)[len]) buf) :);
 #if defined(__clang__)
 #pragma clang diagnostic pop
 #elif defined(MBEDTLS_COMPILER_IS_GCC)

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -126,6 +126,15 @@ void mbedtls_platform_zeroize(void *buf, size_t len)
 #else
         memset_func(buf, 0, len);
 #endif
+
+#if defined(__GNUC__)
+        /* For clang and gcc, pretend that we have some assembly that reads the
+         * zero'd memory as an additional protection against being optimised away. */
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
+        asm volatile ("" : : "m" (*(char (*)[len]) buf) : );
+#pragma clang diagnostic pop
+#endif
     }
 }
 #endif /* MBEDTLS_PLATFORM_ZEROIZE_ALT */

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -130,10 +130,19 @@ void mbedtls_platform_zeroize(void *buf, size_t len)
 #if defined(__GNUC__)
         /* For clang and gcc, pretend that we have some assembly that reads the
          * zero'd memory as an additional protection against being optimised away. */
+#if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvla"
+#elif defined(MBEDTLS_COMPILER_IS_GCC)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wvla"
+#endif
         asm volatile ("" : : "m" (*(char (*)[len]) buf) : );
+#if defined(__clang__)
 #pragma clang diagnostic pop
+#elif defined(MBEDTLS_COMPILER_IS_GCC)
+#pragma GCC diagnostic pop
+#endif
 #endif
     }
 }

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -128,8 +128,9 @@ void mbedtls_platform_zeroize(void *buf, size_t len)
 #endif
 
 #if defined(__GNUC__)
-        /* For clang and gcc, pretend that we have some assembly that reads the
+        /* For clang and recent gcc, pretend that we have some assembly that reads the
          * zero'd memory as an additional protection against being optimised away. */
+#if defined(__clang__) || (__GNUC__ >= 10)
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvla"
@@ -142,6 +143,7 @@ void mbedtls_platform_zeroize(void *buf, size_t len)
 #pragma clang diagnostic pop
 #elif defined(MBEDTLS_COMPILER_IS_GCC)
 #pragma GCC diagnostic pop
+#endif
 #endif
 #endif
     }


### PR DESCRIPTION
## Description

Strengthen `mbedtls_platform_zeroize` to further protect against being optimised away.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required - not user-visible
- [x] **backport** not required - not a bugfix
- [x] **tests** not required - covered by existing