### PR TITLE
Backport 2.28: Rename test macros ASSERT_COMPARE(), ASSERT_ALLOC() and ASSERT_ALLOC_WEAK()

### DIFF
--- a/tests/include/test/macros.h
+++ b/tests/include/test/macros.h
@@ -143,22 +143,22 @@
  *                  This expression may be evaluated multiple times.
  *
  */
-#define ASSERT_ALLOC(pointer, length)                           \
-    do                                                            \
-    {                                                             \
-        TEST_ASSERT((pointer) == NULL);                       \
-        if ((length) != 0)                                     \
-        {                                                         \
-            (pointer) = mbedtls_calloc(sizeof(*(pointer)), \
+#define TEST_CALLOC_OR_FAIL(pointer, length)                \
+    do {                                                    \
+        TEST_ASSERT((pointer) == NULL);                     \
+        if ((length) != 0) {                                \
+            (pointer) = mbedtls_calloc(sizeof(*(pointer)),  \
                                        (length));           \
-            TEST_ASSERT((pointer) != NULL);                   \
-        }                                                         \
-    }                                                             \
-    while (0)
+            TEST_ASSERT((pointer) != NULL);                 \
+        }                                                   \
+    } while (0)
+
+/* For backwards compatibility */
+#define ASSERT_ALLOC(pointer, length) TEST_CALLOC_OR_FAIL(pointer, length)
 
 /** Allocate memory dynamically. If the allocation fails, skip the test case.
  *
- * This macro behaves like #ASSERT_ALLOC, except that if the allocation
+ * This macro behaves like #TEST_CALLOC_OR_FAIL, except that if the allocation
  * fails, it marks the test as skipped rather than failed.
  */
 #define ASSERT_ALLOC_WEAK(pointer, length)                      \

--- a/tests/include/test/macros.h
+++ b/tests/include/test/macros.h
@@ -186,7 +186,7 @@
  * \param size2     Size of the second buffer in bytes.
  *                  This expression may be evaluated multiple times.
  */
-#define TEST_BUFFERS_EQUAL(p1, size1, p2, size2)               \
+#define TEST_MEMORY_COMPARE(p1, size1, p2, size2)              \
     do {                                                       \
         TEST_EQUAL((size1), (size2));                          \
         if ((size1) != 0) {                                    \
@@ -195,7 +195,7 @@
     } while (0)
 
 /* For backwards compatibility */
-#define ASSERT_COMPARE(p1, size1, p2, size2) TEST_BUFFERS_EQUAL(p1, size1, p2, size2)
+#define ASSERT_COMPARE(p1, size1, p2, size2) TEST_MEMORY_COMPARE(p1, size1, p2, size2)
 
 /**
  * \brief   This macro tests the expression passed to it and skips the

--- a/tests/include/test/macros.h
+++ b/tests/include/test/macros.h
@@ -186,14 +186,16 @@
  * \param size2     Size of the second buffer in bytes.
  *                  This expression may be evaluated multiple times.
  */
-#define ASSERT_COMPARE(p1, size1, p2, size2)                          \
-    do                                                                  \
-    {                                                                   \
+#define TEST_BUFFERS_EQUAL(p1, size1, p2, size2)               \
+    do {                                                       \
         TEST_EQUAL((size1), (size2));                          \
-        if ((size1) != 0)                                            \
-        TEST_ASSERT(memcmp((p1), (p2), (size1)) == 0);    \
-    }                                                                   \
-    while (0)
+        if ((size1) != 0) {                                    \
+            TEST_ASSERT(memcmp((p1), (p2), (size1)) == 0);     \
+        }                                                      \
+    } while (0)
+
+/* For backwards compatibility */
+#define ASSERT_COMPARE(p1, size1, p2, size2) TEST_BUFFERS_EQUAL(p1, size1, p2, size2)
 
 /**
  * \brief   This macro tests the expression passed to it and skips the

--- a/tests/include/test/macros.h
+++ b/tests/include/test/macros.h
@@ -161,18 +161,18 @@
  * This macro behaves like #TEST_CALLOC_OR_FAIL, except that if the allocation
  * fails, it marks the test as skipped rather than failed.
  */
-#define ASSERT_ALLOC_WEAK(pointer, length)                      \
-    do                                                            \
-    {                                                             \
-        TEST_ASSERT((pointer) == NULL);                       \
-        if ((length) != 0)                                     \
-        {                                                         \
-            (pointer) = mbedtls_calloc(sizeof(*(pointer)), \
+#define TEST_CALLOC_OR_SKIP(pointer, length)                \
+    do {                                                    \
+        TEST_ASSERT((pointer) == NULL);                     \
+        if ((length) != 0) {                                \
+            (pointer) = mbedtls_calloc(sizeof(*(pointer)),  \
                                        (length));           \
-            TEST_ASSUME((pointer) != NULL);                   \
-        }                                                         \
-    }                                                             \
-    while (0)
+            TEST_ASSUME((pointer) != NULL);                 \
+        }                                                   \
+    } while (0)
+
+/* For backwards compatibility */
+#define ASSERT_ALLOC_WEAK(pointer, length) TEST_CALLOC_OR_SKIP(pointer, length)
 
 /** Compare two buffers and fail the test case if they differ.
  *

--- a/tests/include/test/macros.h
+++ b/tests/include/test/macros.h
@@ -143,7 +143,7 @@
  *                  This expression may be evaluated multiple times.
  *
  */
-#define TEST_CALLOC_OR_FAIL(pointer, length)                \
+#define TEST_CALLOC(pointer, length)                        \
     do {                                                    \
         TEST_ASSERT((pointer) == NULL);                     \
         if ((length) != 0) {                                \
@@ -154,11 +154,11 @@
     } while (0)
 
 /* For backwards compatibility */
-#define ASSERT_ALLOC(pointer, length) TEST_CALLOC_OR_FAIL(pointer, length)
+#define ASSERT_ALLOC(pointer, length) TEST_CALLOC(pointer, length)
 
 /** Allocate memory dynamically. If the allocation fails, skip the test case.
  *
- * This macro behaves like #TEST_CALLOC_OR_FAIL, except that if the allocation
+ * This macro behaves like #TEST_CALLOC, except that if the allocation
  * fails, it marks the test as skipped rather than failed.
  */
 #define TEST_CALLOC_OR_SKIP(pointer, length)                \

--- a/tests/include/test/macros.h
+++ b/tests/include/test/macros.h
@@ -127,52 +127,52 @@
  * The allocated memory will be filled with zeros.
  *
  * You must set \p pointer to \c NULL before calling this macro and
- * put `mbedtls_free( pointer )` in the test's cleanup code.
+ * put `mbedtls_free(pointer)` in the test's cleanup code.
  *
- * If \p length is zero, the resulting \p pointer will be \c NULL.
+ * If \p item_count is zero, the resulting \p pointer will be \c NULL.
  * This is usually what we want in tests since API functions are
  * supposed to accept null pointers when a buffer size is zero.
  *
  * This macro expands to an instruction, not an expression.
  * It may jump to the \c exit label.
  *
- * \param pointer   An lvalue where the address of the allocated buffer
- *                  will be stored.
- *                  This expression may be evaluated multiple times.
- * \param length    Number of elements to allocate.
- *                  This expression may be evaluated multiple times.
+ * \param pointer    An lvalue where the address of the allocated buffer
+ *                   will be stored.
+ *                   This expression may be evaluated multiple times.
+ * \param item_count Number of elements to allocate.
+ *                   This expression may be evaluated multiple times.
  *
  */
-#define TEST_CALLOC(pointer, length)                        \
+#define TEST_CALLOC(pointer, item_count)                    \
     do {                                                    \
         TEST_ASSERT((pointer) == NULL);                     \
-        if ((length) != 0) {                                \
+        if ((item_count) != 0) {                            \
             (pointer) = mbedtls_calloc(sizeof(*(pointer)),  \
-                                       (length));           \
+                                       (item_count));       \
             TEST_ASSERT((pointer) != NULL);                 \
         }                                                   \
     } while (0)
 
 /* For backwards compatibility */
-#define ASSERT_ALLOC(pointer, length) TEST_CALLOC(pointer, length)
+#define ASSERT_ALLOC(pointer, item_count) TEST_CALLOC(pointer, item_count)
 
 /** Allocate memory dynamically. If the allocation fails, skip the test case.
  *
  * This macro behaves like #TEST_CALLOC, except that if the allocation
  * fails, it marks the test as skipped rather than failed.
  */
-#define TEST_CALLOC_OR_SKIP(pointer, length)                \
+#define TEST_CALLOC_OR_SKIP(pointer, item_count)            \
     do {                                                    \
         TEST_ASSERT((pointer) == NULL);                     \
-        if ((length) != 0) {                                \
+        if ((item_count) != 0) {                            \
             (pointer) = mbedtls_calloc(sizeof(*(pointer)),  \
-                                       (length));           \
+                                       (item_count));       \
             TEST_ASSUME((pointer) != NULL);                 \
         }                                                   \
     } while (0)
 
 /* For backwards compatibility */
-#define ASSERT_ALLOC_WEAK(pointer, length) TEST_CALLOC_OR_SKIP(pointer, length)
+#define ASSERT_ALLOC_WEAK(pointer, item_count) TEST_CALLOC_OR_SKIP(pointer, item_count)
 
 /** Compare two buffers and fail the test case if they differ.
  *

--- a/tests/src/psa_exercise_key.c
+++ b/tests/src/psa_exercise_key.c
@@ -505,7 +505,7 @@ psa_status_t mbedtls_test_psa_key_agreement_with_self(
     key_bits = psa_get_key_bits(&attributes);
     public_key_type = PSA_KEY_TYPE_PUBLIC_KEY_OF_KEY_PAIR(private_key_type);
     public_key_length = PSA_EXPORT_PUBLIC_KEY_OUTPUT_SIZE(public_key_type, key_bits);
-    TEST_CALLOC_OR_FAIL(public_key, public_key_length);
+    TEST_CALLOC(public_key, public_key_length);
     PSA_ASSERT(psa_export_public_key(key, public_key, public_key_length,
                                      &public_key_length));
 
@@ -547,7 +547,7 @@ psa_status_t mbedtls_test_psa_raw_key_agreement_with_self(
     key_bits = psa_get_key_bits(&attributes);
     public_key_type = PSA_KEY_TYPE_PUBLIC_KEY_OF_KEY_PAIR(private_key_type);
     public_key_length = PSA_EXPORT_PUBLIC_KEY_OUTPUT_SIZE(public_key_type, key_bits);
-    TEST_CALLOC_OR_FAIL(public_key, public_key_length);
+    TEST_CALLOC(public_key, public_key_length);
     PSA_ASSERT(psa_export_public_key(key,
                                      public_key, public_key_length,
                                      &public_key_length));
@@ -807,7 +807,7 @@ static int exercise_export_key(mbedtls_svc_key_id_t key,
     exported_size = PSA_EXPORT_KEY_OUTPUT_SIZE(
         psa_get_key_type(&attributes),
         psa_get_key_bits(&attributes));
-    TEST_CALLOC_OR_FAIL(exported, exported_size);
+    TEST_CALLOC(exported, exported_size);
 
     if ((usage & PSA_KEY_USAGE_EXPORT) == 0 &&
         !PSA_KEY_TYPE_IS_PUBLIC_KEY(psa_get_key_type(&attributes))) {
@@ -850,7 +850,7 @@ static int exercise_export_public_key(mbedtls_svc_key_id_t key)
         exported_size = PSA_EXPORT_KEY_OUTPUT_SIZE(
             psa_get_key_type(&attributes),
             psa_get_key_bits(&attributes));
-        TEST_CALLOC_OR_FAIL(exported, exported_size);
+        TEST_CALLOC(exported, exported_size);
 
         TEST_EQUAL(psa_export_public_key(key, exported,
                                          exported_size, &exported_length),
@@ -863,7 +863,7 @@ static int exercise_export_public_key(mbedtls_svc_key_id_t key)
         psa_get_key_type(&attributes));
     exported_size = PSA_EXPORT_PUBLIC_KEY_OUTPUT_SIZE(public_type,
                                                       psa_get_key_bits(&attributes));
-    TEST_CALLOC_OR_FAIL(exported, exported_size);
+    TEST_CALLOC(exported, exported_size);
 
     PSA_ASSERT(psa_export_public_key(key,
                                      exported, exported_size,

--- a/tests/src/psa_exercise_key.c
+++ b/tests/src/psa_exercise_key.c
@@ -505,7 +505,7 @@ psa_status_t mbedtls_test_psa_key_agreement_with_self(
     key_bits = psa_get_key_bits(&attributes);
     public_key_type = PSA_KEY_TYPE_PUBLIC_KEY_OF_KEY_PAIR(private_key_type);
     public_key_length = PSA_EXPORT_PUBLIC_KEY_OUTPUT_SIZE(public_key_type, key_bits);
-    ASSERT_ALLOC(public_key, public_key_length);
+    TEST_CALLOC_OR_FAIL(public_key, public_key_length);
     PSA_ASSERT(psa_export_public_key(key, public_key, public_key_length,
                                      &public_key_length));
 
@@ -547,7 +547,7 @@ psa_status_t mbedtls_test_psa_raw_key_agreement_with_self(
     key_bits = psa_get_key_bits(&attributes);
     public_key_type = PSA_KEY_TYPE_PUBLIC_KEY_OF_KEY_PAIR(private_key_type);
     public_key_length = PSA_EXPORT_PUBLIC_KEY_OUTPUT_SIZE(public_key_type, key_bits);
-    ASSERT_ALLOC(public_key, public_key_length);
+    TEST_CALLOC_OR_FAIL(public_key, public_key_length);
     PSA_ASSERT(psa_export_public_key(key,
                                      public_key, public_key_length,
                                      &public_key_length));
@@ -807,7 +807,7 @@ static int exercise_export_key(mbedtls_svc_key_id_t key,
     exported_size = PSA_EXPORT_KEY_OUTPUT_SIZE(
         psa_get_key_type(&attributes),
         psa_get_key_bits(&attributes));
-    ASSERT_ALLOC(exported, exported_size);
+    TEST_CALLOC_OR_FAIL(exported, exported_size);
 
     if ((usage & PSA_KEY_USAGE_EXPORT) == 0 &&
         !PSA_KEY_TYPE_IS_PUBLIC_KEY(psa_get_key_type(&attributes))) {
@@ -850,7 +850,7 @@ static int exercise_export_public_key(mbedtls_svc_key_id_t key)
         exported_size = PSA_EXPORT_KEY_OUTPUT_SIZE(
             psa_get_key_type(&attributes),
             psa_get_key_bits(&attributes));
-        ASSERT_ALLOC(exported, exported_size);
+        TEST_CALLOC_OR_FAIL(exported, exported_size);
 
         TEST_EQUAL(psa_export_public_key(key, exported,
                                          exported_size, &exported_length),
@@ -863,7 +863,7 @@ static int exercise_export_public_key(mbedtls_svc_key_id_t key)
         psa_get_key_type(&attributes));
     exported_size = PSA_EXPORT_PUBLIC_KEY_OUTPUT_SIZE(public_type,
                                                       psa_get_key_bits(&attributes));
-    ASSERT_ALLOC(exported, exported_size);
+    TEST_CALLOC_OR_FAIL(exported, exported_size);
 
     PSA_ASSERT(psa_export_public_key(key,
                                      exported, exported_size,

--- a/tests/src/test_helpers/ssl_helpers.c
+++ b/tests/src/test_helpers/ssl_helpers.c
@@ -566,9 +566,9 @@ int mbedtls_test_ssl_endpoint_certificate_init(mbedtls_test_ssl_endpoint *ep,
     }
 
     cert = &(ep->cert);
-    TEST_CALLOC_OR_FAIL(cert->ca_cert, 1);
-    TEST_CALLOC_OR_FAIL(cert->cert, 1);
-    TEST_CALLOC_OR_FAIL(cert->pkey, 1);
+    TEST_CALLOC(cert->ca_cert, 1);
+    TEST_CALLOC(cert->cert, 1);
+    TEST_CALLOC(cert->pkey, 1);
 
     mbedtls_x509_crt_init(cert->ca_cert);
     mbedtls_x509_crt_init(cert->cert);

--- a/tests/src/test_helpers/ssl_helpers.c
+++ b/tests/src/test_helpers/ssl_helpers.c
@@ -566,9 +566,9 @@ int mbedtls_test_ssl_endpoint_certificate_init(mbedtls_test_ssl_endpoint *ep,
     }
 
     cert = &(ep->cert);
-    ASSERT_ALLOC(cert->ca_cert, 1);
-    ASSERT_ALLOC(cert->cert, 1);
-    ASSERT_ALLOC(cert->pkey, 1);
+    TEST_CALLOC_OR_FAIL(cert->ca_cert, 1);
+    TEST_CALLOC_OR_FAIL(cert->cert, 1);
+    TEST_CALLOC_OR_FAIL(cert->pkey, 1);
 
     mbedtls_x509_crt_init(cert->ca_cert);
     mbedtls_x509_crt_init(cert->cert);

--- a/tests/suites/test_suite_aes.function
+++ b/tests/suites/test_suite_aes.function
@@ -34,7 +34,7 @@ static int test_ctx_alignment(const data_t *key,
     // Decrypt
     TEST_ASSERT(mbedtls_aes_crypt_ecb(dec, MBEDTLS_AES_DECRYPT,
                                       ciphertext, output) == 0);
-    TEST_BUFFERS_EQUAL(plaintext, 16, output, 16);
+    TEST_MEMORY_COMPARE(plaintext, 16, output, 16);
 
     mbedtls_aes_free(dec);
 

--- a/tests/suites/test_suite_aes.function
+++ b/tests/suites/test_suite_aes.function
@@ -688,8 +688,8 @@ void aes_ecb_context_alignment(data_t *key)
     struct align1 *dec1 = NULL;
 
     /* All peak alignment */
-    ASSERT_ALLOC(enc0, 1);
-    ASSERT_ALLOC(dec0, 1);
+    TEST_CALLOC_OR_FAIL(enc0, 1);
+    TEST_CALLOC_OR_FAIL(dec0, 1);
     if (!test_ctx_alignment(key, &enc0->ctx, &dec0->ctx)) {
         goto exit;
     }
@@ -699,8 +699,8 @@ void aes_ecb_context_alignment(data_t *key)
     dec0 = NULL;
 
     /* Enc aligned, dec not */
-    ASSERT_ALLOC(enc0, 1);
-    ASSERT_ALLOC(dec1, 1);
+    TEST_CALLOC_OR_FAIL(enc0, 1);
+    TEST_CALLOC_OR_FAIL(dec1, 1);
     if (!test_ctx_alignment(key, &enc0->ctx, &dec1->ctx)) {
         goto exit;
     }
@@ -710,8 +710,8 @@ void aes_ecb_context_alignment(data_t *key)
     dec1 = NULL;
 
     /* Dec aligned, enc not */
-    ASSERT_ALLOC(enc1, 1);
-    ASSERT_ALLOC(dec0, 1);
+    TEST_CALLOC_OR_FAIL(enc1, 1);
+    TEST_CALLOC_OR_FAIL(dec0, 1);
     if (!test_ctx_alignment(key, &enc1->ctx, &dec0->ctx)) {
         goto exit;
     }
@@ -721,8 +721,8 @@ void aes_ecb_context_alignment(data_t *key)
     dec0 = NULL;
 
     /* Both shifted */
-    ASSERT_ALLOC(enc1, 1);
-    ASSERT_ALLOC(dec1, 1);
+    TEST_CALLOC_OR_FAIL(enc1, 1);
+    TEST_CALLOC_OR_FAIL(dec1, 1);
     if (!test_ctx_alignment(key, &enc1->ctx, &dec1->ctx)) {
         goto exit;
     }

--- a/tests/suites/test_suite_aes.function
+++ b/tests/suites/test_suite_aes.function
@@ -688,8 +688,8 @@ void aes_ecb_context_alignment(data_t *key)
     struct align1 *dec1 = NULL;
 
     /* All peak alignment */
-    TEST_CALLOC_OR_FAIL(enc0, 1);
-    TEST_CALLOC_OR_FAIL(dec0, 1);
+    TEST_CALLOC(enc0, 1);
+    TEST_CALLOC(dec0, 1);
     if (!test_ctx_alignment(key, &enc0->ctx, &dec0->ctx)) {
         goto exit;
     }
@@ -699,8 +699,8 @@ void aes_ecb_context_alignment(data_t *key)
     dec0 = NULL;
 
     /* Enc aligned, dec not */
-    TEST_CALLOC_OR_FAIL(enc0, 1);
-    TEST_CALLOC_OR_FAIL(dec1, 1);
+    TEST_CALLOC(enc0, 1);
+    TEST_CALLOC(dec1, 1);
     if (!test_ctx_alignment(key, &enc0->ctx, &dec1->ctx)) {
         goto exit;
     }
@@ -710,8 +710,8 @@ void aes_ecb_context_alignment(data_t *key)
     dec1 = NULL;
 
     /* Dec aligned, enc not */
-    TEST_CALLOC_OR_FAIL(enc1, 1);
-    TEST_CALLOC_OR_FAIL(dec0, 1);
+    TEST_CALLOC(enc1, 1);
+    TEST_CALLOC(dec0, 1);
     if (!test_ctx_alignment(key, &enc1->ctx, &dec0->ctx)) {
         goto exit;
     }
@@ -721,8 +721,8 @@ void aes_ecb_context_alignment(data_t *key)
     dec0 = NULL;
 
     /* Both shifted */
-    TEST_CALLOC_OR_FAIL(enc1, 1);
-    TEST_CALLOC_OR_FAIL(dec1, 1);
+    TEST_CALLOC(enc1, 1);
+    TEST_CALLOC(dec1, 1);
     if (!test_ctx_alignment(key, &enc1->ctx, &dec1->ctx)) {
         goto exit;
     }

--- a/tests/suites/test_suite_aes.function
+++ b/tests/suites/test_suite_aes.function
@@ -34,7 +34,7 @@ static int test_ctx_alignment(const data_t *key,
     // Decrypt
     TEST_ASSERT(mbedtls_aes_crypt_ecb(dec, MBEDTLS_AES_DECRYPT,
                                       ciphertext, output) == 0);
-    ASSERT_COMPARE(plaintext, 16, output, 16);
+    TEST_BUFFERS_EQUAL(plaintext, 16, output, 16);
 
     mbedtls_aes_free(dec);
 

--- a/tests/suites/test_suite_aria.function
+++ b/tests/suites/test_suite_aria.function
@@ -224,7 +224,7 @@ void aria_encrypt_ecb(data_t *key_str, data_t *src_str,
                                                output + i) == 0);
         }
 
-        ASSERT_COMPARE(output, expected_output->len,
+        TEST_BUFFERS_EQUAL(output, expected_output->len,
                        expected_output->x, expected_output->len);
     }
 
@@ -252,7 +252,7 @@ void aria_decrypt_ecb(data_t *key_str, data_t *src_str,
                                                output + i) == 0);
         }
 
-        ASSERT_COMPARE(output, expected_output->len,
+        TEST_BUFFERS_EQUAL(output, expected_output->len,
                        expected_output->x, expected_output->len);
     }
 
@@ -277,7 +277,7 @@ void aria_encrypt_cbc(data_t *key_str, data_t *iv_str,
                                        src_str->len, iv_str->x, src_str->x,
                                        output) == cbc_result);
     if (cbc_result == 0) {
-        ASSERT_COMPARE(output, expected_output->len,
+        TEST_BUFFERS_EQUAL(output, expected_output->len,
                        expected_output->x, expected_output->len);
     }
 
@@ -302,7 +302,7 @@ void aria_decrypt_cbc(data_t *key_str, data_t *iv_str,
                                        src_str->len, iv_str->x, src_str->x,
                                        output) == cbc_result);
     if (cbc_result == 0) {
-        ASSERT_COMPARE(output, expected_output->len,
+        TEST_BUFFERS_EQUAL(output, expected_output->len,
                        expected_output->x, expected_output->len);
     }
 
@@ -329,7 +329,7 @@ void aria_encrypt_cfb128(data_t *key_str, data_t *iv_str,
                                           iv_str->x, src_str->x, output)
                 == result);
 
-    ASSERT_COMPARE(output, expected_output->len,
+    TEST_BUFFERS_EQUAL(output, expected_output->len,
                    expected_output->x, expected_output->len);
 
 exit:
@@ -355,7 +355,7 @@ void aria_decrypt_cfb128(data_t *key_str, data_t *iv_str,
                                           iv_str->x, src_str->x, output)
                 == result);
 
-    ASSERT_COMPARE(output, expected_output->len,
+    TEST_BUFFERS_EQUAL(output, expected_output->len,
                    expected_output->x, expected_output->len);
 
 exit:
@@ -381,7 +381,7 @@ void aria_encrypt_ctr(data_t *key_str, data_t *iv_str,
                                        iv_str->x, blk, src_str->x, output)
                 == result);
 
-    ASSERT_COMPARE(output, expected_output->len,
+    TEST_BUFFERS_EQUAL(output, expected_output->len,
                    expected_output->x, expected_output->len);
 
 exit:
@@ -407,7 +407,7 @@ void aria_decrypt_ctr(data_t *key_str, data_t *iv_str,
                                        iv_str->x, blk, src_str->x, output)
                 == result);
 
-    ASSERT_COMPARE(output, expected_output->len,
+    TEST_BUFFERS_EQUAL(output, expected_output->len,
                    expected_output->x, expected_output->len);
 
 exit:

--- a/tests/suites/test_suite_aria.function
+++ b/tests/suites/test_suite_aria.function
@@ -224,7 +224,7 @@ void aria_encrypt_ecb(data_t *key_str, data_t *src_str,
                                                output + i) == 0);
         }
 
-        TEST_BUFFERS_EQUAL(output, expected_output->len,
+        TEST_MEMORY_COMPARE(output, expected_output->len,
                        expected_output->x, expected_output->len);
     }
 
@@ -252,7 +252,7 @@ void aria_decrypt_ecb(data_t *key_str, data_t *src_str,
                                                output + i) == 0);
         }
 
-        TEST_BUFFERS_EQUAL(output, expected_output->len,
+        TEST_MEMORY_COMPARE(output, expected_output->len,
                        expected_output->x, expected_output->len);
     }
 
@@ -277,7 +277,7 @@ void aria_encrypt_cbc(data_t *key_str, data_t *iv_str,
                                        src_str->len, iv_str->x, src_str->x,
                                        output) == cbc_result);
     if (cbc_result == 0) {
-        TEST_BUFFERS_EQUAL(output, expected_output->len,
+        TEST_MEMORY_COMPARE(output, expected_output->len,
                        expected_output->x, expected_output->len);
     }
 
@@ -302,7 +302,7 @@ void aria_decrypt_cbc(data_t *key_str, data_t *iv_str,
                                        src_str->len, iv_str->x, src_str->x,
                                        output) == cbc_result);
     if (cbc_result == 0) {
-        TEST_BUFFERS_EQUAL(output, expected_output->len,
+        TEST_MEMORY_COMPARE(output, expected_output->len,
                        expected_output->x, expected_output->len);
     }
 
@@ -329,7 +329,7 @@ void aria_encrypt_cfb128(data_t *key_str, data_t *iv_str,
                                           iv_str->x, src_str->x, output)
                 == result);
 
-    TEST_BUFFERS_EQUAL(output, expected_output->len,
+    TEST_MEMORY_COMPARE(output, expected_output->len,
                    expected_output->x, expected_output->len);
 
 exit:
@@ -355,7 +355,7 @@ void aria_decrypt_cfb128(data_t *key_str, data_t *iv_str,
                                           iv_str->x, src_str->x, output)
                 == result);
 
-    TEST_BUFFERS_EQUAL(output, expected_output->len,
+    TEST_MEMORY_COMPARE(output, expected_output->len,
                    expected_output->x, expected_output->len);
 
 exit:
@@ -381,7 +381,7 @@ void aria_encrypt_ctr(data_t *key_str, data_t *iv_str,
                                        iv_str->x, blk, src_str->x, output)
                 == result);
 
-    TEST_BUFFERS_EQUAL(output, expected_output->len,
+    TEST_MEMORY_COMPARE(output, expected_output->len,
                    expected_output->x, expected_output->len);
 
 exit:
@@ -407,7 +407,7 @@ void aria_decrypt_ctr(data_t *key_str, data_t *iv_str,
                                        iv_str->x, blk, src_str->x, output)
                 == result);
 
-    TEST_BUFFERS_EQUAL(output, expected_output->len,
+    TEST_MEMORY_COMPARE(output, expected_output->len,
                    expected_output->x, expected_output->len);
 
 exit:

--- a/tests/suites/test_suite_aria.function
+++ b/tests/suites/test_suite_aria.function
@@ -225,7 +225,7 @@ void aria_encrypt_ecb(data_t *key_str, data_t *src_str,
         }
 
         TEST_MEMORY_COMPARE(output, expected_output->len,
-                       expected_output->x, expected_output->len);
+                            expected_output->x, expected_output->len);
     }
 
 exit:
@@ -253,7 +253,7 @@ void aria_decrypt_ecb(data_t *key_str, data_t *src_str,
         }
 
         TEST_MEMORY_COMPARE(output, expected_output->len,
-                       expected_output->x, expected_output->len);
+                            expected_output->x, expected_output->len);
     }
 
 exit:
@@ -278,7 +278,7 @@ void aria_encrypt_cbc(data_t *key_str, data_t *iv_str,
                                        output) == cbc_result);
     if (cbc_result == 0) {
         TEST_MEMORY_COMPARE(output, expected_output->len,
-                       expected_output->x, expected_output->len);
+                            expected_output->x, expected_output->len);
     }
 
 exit:
@@ -303,7 +303,7 @@ void aria_decrypt_cbc(data_t *key_str, data_t *iv_str,
                                        output) == cbc_result);
     if (cbc_result == 0) {
         TEST_MEMORY_COMPARE(output, expected_output->len,
-                       expected_output->x, expected_output->len);
+                            expected_output->x, expected_output->len);
     }
 
 exit:
@@ -330,7 +330,7 @@ void aria_encrypt_cfb128(data_t *key_str, data_t *iv_str,
                 == result);
 
     TEST_MEMORY_COMPARE(output, expected_output->len,
-                   expected_output->x, expected_output->len);
+                        expected_output->x, expected_output->len);
 
 exit:
     mbedtls_aria_free(&ctx);
@@ -356,7 +356,7 @@ void aria_decrypt_cfb128(data_t *key_str, data_t *iv_str,
                 == result);
 
     TEST_MEMORY_COMPARE(output, expected_output->len,
-                   expected_output->x, expected_output->len);
+                        expected_output->x, expected_output->len);
 
 exit:
     mbedtls_aria_free(&ctx);
@@ -382,7 +382,7 @@ void aria_encrypt_ctr(data_t *key_str, data_t *iv_str,
                 == result);
 
     TEST_MEMORY_COMPARE(output, expected_output->len,
-                   expected_output->x, expected_output->len);
+                        expected_output->x, expected_output->len);
 
 exit:
     mbedtls_aria_free(&ctx);
@@ -408,7 +408,7 @@ void aria_decrypt_ctr(data_t *key_str, data_t *iv_str,
                 == result);
 
     TEST_MEMORY_COMPARE(output, expected_output->len,
-                   expected_output->x, expected_output->len);
+                        expected_output->x, expected_output->len);
 
 exit:
     mbedtls_aria_free(&ctx);

--- a/tests/suites/test_suite_asn1parse.function
+++ b/tests/suites/test_suite_asn1parse.function
@@ -139,7 +139,7 @@ int get_len_step(const data_t *input, size_t buffer_size,
         end = buf + 1;
         p = end;
     } else {
-        ASSERT_ALLOC_WEAK(buf, buffer_size);
+        TEST_CALLOC_OR_SKIP(buf, buffer_size);
         if (buffer_size > input->len) {
             memcpy(buf, input->x, input->len);
             memset(buf + input->len, 'A', buffer_size - input->len);

--- a/tests/suites/test_suite_asn1parse.function
+++ b/tests/suites/test_suite_asn1parse.function
@@ -135,7 +135,7 @@ int get_len_step(const data_t *input, size_t buffer_size,
     /* Allocate a new buffer of exactly the length to parse each time.
      * This gives memory sanitizers a chance to catch buffer overreads. */
     if (buffer_size == 0) {
-        TEST_CALLOC_OR_FAIL(buf, 1);
+        TEST_CALLOC(buf, 1);
         end = buf + 1;
         p = end;
     } else {
@@ -247,7 +247,7 @@ void parse_prefixes(const data_t *input,
         mbedtls_test_set_step(buffer_size);
         /* Allocate a new buffer of exactly the length to parse each time.
          * This gives memory sanitizers a chance to catch buffer overreads. */
-        TEST_CALLOC_OR_FAIL(buf, buffer_size);
+        TEST_CALLOC(buf, buffer_size);
         memcpy(buf, input->x, buffer_size);
         p = buf;
         ret = nested_parse(&p, buf + buffer_size);
@@ -506,7 +506,7 @@ void get_mpi_too_large()
 
     mbedtls_mpi_init(&actual_mpi);
 
-    TEST_CALLOC_OR_FAIL(buf, size);
+    TEST_CALLOC(buf, size);
     buf[0] = 0x02; /* tag: INTEGER */
     buf[1] = 0x84; /* 4-octet length */
     buf[2] = (too_many_octets >> 24) & 0xff;
@@ -729,10 +729,10 @@ void free_named_data(int with_oid, int with_val, int with_next)
     { { 0x06, 0, NULL }, { 0, 0, NULL }, NULL, 0 };
 
     if (with_oid) {
-        TEST_CALLOC_OR_FAIL(head.oid.p, 1);
+        TEST_CALLOC(head.oid.p, 1);
     }
     if (with_val) {
-        TEST_CALLOC_OR_FAIL(head.val.p, 1);
+        TEST_CALLOC(head.val.p, 1);
     }
     if (with_next) {
         head.next = &next;
@@ -758,7 +758,7 @@ void free_named_data_list(int length)
 
     for (i = 0; i < length; i++) {
         mbedtls_asn1_named_data *new = NULL;
-        TEST_CALLOC_OR_FAIL(new, 1);
+        TEST_CALLOC(new, 1);
         new->next = head;
         head = new;
     }

--- a/tests/suites/test_suite_asn1parse.function
+++ b/tests/suites/test_suite_asn1parse.function
@@ -135,7 +135,7 @@ int get_len_step(const data_t *input, size_t buffer_size,
     /* Allocate a new buffer of exactly the length to parse each time.
      * This gives memory sanitizers a chance to catch buffer overreads. */
     if (buffer_size == 0) {
-        ASSERT_ALLOC(buf, 1);
+        TEST_CALLOC_OR_FAIL(buf, 1);
         end = buf + 1;
         p = end;
     } else {
@@ -247,7 +247,7 @@ void parse_prefixes(const data_t *input,
         mbedtls_test_set_step(buffer_size);
         /* Allocate a new buffer of exactly the length to parse each time.
          * This gives memory sanitizers a chance to catch buffer overreads. */
-        ASSERT_ALLOC(buf, buffer_size);
+        TEST_CALLOC_OR_FAIL(buf, buffer_size);
         memcpy(buf, input->x, buffer_size);
         p = buf;
         ret = nested_parse(&p, buf + buffer_size);
@@ -506,7 +506,7 @@ void get_mpi_too_large()
 
     mbedtls_mpi_init(&actual_mpi);
 
-    ASSERT_ALLOC(buf, size);
+    TEST_CALLOC_OR_FAIL(buf, size);
     buf[0] = 0x02; /* tag: INTEGER */
     buf[1] = 0x84; /* 4-octet length */
     buf[2] = (too_many_octets >> 24) & 0xff;
@@ -729,10 +729,10 @@ void free_named_data(int with_oid, int with_val, int with_next)
     { { 0x06, 0, NULL }, { 0, 0, NULL }, NULL, 0 };
 
     if (with_oid) {
-        ASSERT_ALLOC(head.oid.p, 1);
+        TEST_CALLOC_OR_FAIL(head.oid.p, 1);
     }
     if (with_val) {
-        ASSERT_ALLOC(head.val.p, 1);
+        TEST_CALLOC_OR_FAIL(head.val.p, 1);
     }
     if (with_next) {
         head.next = &next;
@@ -758,7 +758,7 @@ void free_named_data_list(int length)
 
     for (i = 0; i < length; i++) {
         mbedtls_asn1_named_data *new = NULL;
-        ASSERT_ALLOC(new, 1);
+        TEST_CALLOC_OR_FAIL(new, 1);
         new->next = head;
         head = new;
     }

--- a/tests/suites/test_suite_asn1write.function
+++ b/tests/suites/test_suite_asn1write.function
@@ -37,7 +37,7 @@ int generic_write_finish_step(generic_write_data_t *data,
         TEST_EQUAL(ret, data->end - data->p);
         TEST_ASSERT(data->p >= data->start);
         TEST_ASSERT(data->p <= data->end);
-        TEST_BUFFERS_EQUAL(data->p, (size_t) (data->end - data->p),
+        TEST_MEMORY_COMPARE(data->p, (size_t) (data->end - data->p),
                        expected->x, expected->len);
     }
     ok = 1;
@@ -322,7 +322,7 @@ void mbedtls_asn1_write_algorithm_identifier(data_t *oid,
             TEST_EQUAL(mbedtls_asn1_get_alg(&p, end_complete,
                                             &alg, &params), 0);
             TEST_EQUAL(alg.tag, MBEDTLS_ASN1_OID);
-            TEST_BUFFERS_EQUAL(alg.p, alg.len, oid->x, oid->len);
+            TEST_MEMORY_COMPARE(alg.p, alg.len, oid->x, oid->len);
             TEST_EQUAL(params.tag, expected_params_tag);
             TEST_EQUAL(params.len, expected_params_len);
             mbedtls_free(buf_complete);
@@ -440,7 +440,7 @@ void test_asn1_write_bitstrings(data_t *bitstring, int bits,
             mbedtls_asn1_bitstring read = { 0, 0, NULL };
             TEST_EQUAL(mbedtls_asn1_get_bitstring(&data.p, data.end,
                                                   &read), 0);
-            TEST_BUFFERS_EQUAL(read.p, read.len,
+            TEST_MEMORY_COMPARE(read.p, read.len,
                            masked_bitstring, byte_length);
             TEST_EQUAL(read.unused_bits, 8 * byte_length - value_bits);
         }
@@ -545,7 +545,7 @@ void store_named_data_val_found(int old_len, int new_len)
     TEST_ASSERT(found == head);
 
     if (new_val != NULL) {
-        TEST_BUFFERS_EQUAL(found->val.p, found->val.len,
+        TEST_MEMORY_COMPARE(found->val.p, found->val.len,
                        new_val, (size_t) new_len);
     }
     if (new_len == 0) {
@@ -580,14 +580,14 @@ void store_named_data_val_new(int new_len, int set_new_val)
     TEST_ASSERT(found != NULL);
     TEST_ASSERT(found == head);
     TEST_ASSERT(found->oid.p != oid);
-    TEST_BUFFERS_EQUAL(found->oid.p, found->oid.len, oid, oid_len);
+    TEST_MEMORY_COMPARE(found->oid.p, found->oid.len, oid, oid_len);
     if (new_len == 0) {
         TEST_ASSERT(found->val.p == NULL);
     } else if (new_val == NULL) {
         TEST_ASSERT(found->val.p != NULL);
     } else {
         TEST_ASSERT(found->val.p != new_val);
-        TEST_BUFFERS_EQUAL(found->val.p, found->val.len,
+        TEST_MEMORY_COMPARE(found->val.p, found->val.len,
                        new_val, (size_t) new_len);
     }
 

--- a/tests/suites/test_suite_asn1write.function
+++ b/tests/suites/test_suite_asn1write.function
@@ -37,7 +37,7 @@ int generic_write_finish_step(generic_write_data_t *data,
         TEST_EQUAL(ret, data->end - data->p);
         TEST_ASSERT(data->p >= data->start);
         TEST_ASSERT(data->p <= data->end);
-        ASSERT_COMPARE(data->p, (size_t) (data->end - data->p),
+        TEST_BUFFERS_EQUAL(data->p, (size_t) (data->end - data->p),
                        expected->x, expected->len);
     }
     ok = 1;
@@ -322,7 +322,7 @@ void mbedtls_asn1_write_algorithm_identifier(data_t *oid,
             TEST_EQUAL(mbedtls_asn1_get_alg(&p, end_complete,
                                             &alg, &params), 0);
             TEST_EQUAL(alg.tag, MBEDTLS_ASN1_OID);
-            ASSERT_COMPARE(alg.p, alg.len, oid->x, oid->len);
+            TEST_BUFFERS_EQUAL(alg.p, alg.len, oid->x, oid->len);
             TEST_EQUAL(params.tag, expected_params_tag);
             TEST_EQUAL(params.len, expected_params_len);
             mbedtls_free(buf_complete);
@@ -440,7 +440,7 @@ void test_asn1_write_bitstrings(data_t *bitstring, int bits,
             mbedtls_asn1_bitstring read = { 0, 0, NULL };
             TEST_EQUAL(mbedtls_asn1_get_bitstring(&data.p, data.end,
                                                   &read), 0);
-            ASSERT_COMPARE(read.p, read.len,
+            TEST_BUFFERS_EQUAL(read.p, read.len,
                            masked_bitstring, byte_length);
             TEST_EQUAL(read.unused_bits, 8 * byte_length - value_bits);
         }
@@ -545,7 +545,7 @@ void store_named_data_val_found(int old_len, int new_len)
     TEST_ASSERT(found == head);
 
     if (new_val != NULL) {
-        ASSERT_COMPARE(found->val.p, found->val.len,
+        TEST_BUFFERS_EQUAL(found->val.p, found->val.len,
                        new_val, (size_t) new_len);
     }
     if (new_len == 0) {
@@ -580,14 +580,14 @@ void store_named_data_val_new(int new_len, int set_new_val)
     TEST_ASSERT(found != NULL);
     TEST_ASSERT(found == head);
     TEST_ASSERT(found->oid.p != oid);
-    ASSERT_COMPARE(found->oid.p, found->oid.len, oid, oid_len);
+    TEST_BUFFERS_EQUAL(found->oid.p, found->oid.len, oid, oid_len);
     if (new_len == 0) {
         TEST_ASSERT(found->val.p == NULL);
     } else if (new_val == NULL) {
         TEST_ASSERT(found->val.p != NULL);
     } else {
         TEST_ASSERT(found->val.p != new_val);
-        ASSERT_COMPARE(found->val.p, found->val.len,
+        TEST_BUFFERS_EQUAL(found->val.p, found->val.len,
                        new_val, (size_t) new_len);
     }
 

--- a/tests/suites/test_suite_asn1write.function
+++ b/tests/suites/test_suite_asn1write.function
@@ -17,7 +17,7 @@ int generic_write_start_step(generic_write_data_t *data)
     mbedtls_test_set_step(data->size);
     mbedtls_free(data->output);
     data->output = NULL;
-    ASSERT_ALLOC(data->output, data->size == 0 ? 1 : data->size);
+    TEST_CALLOC_OR_FAIL(data->output, data->size == 0 ? 1 : data->size);
     data->end = data->output + data->size;
     data->p = data->end;
     data->start = data->end - data->size;
@@ -296,7 +296,7 @@ void mbedtls_asn1_write_algorithm_identifier(data_t *oid,
             size_t len_complete = data_len + par_len;
             unsigned char expected_params_tag;
             size_t expected_params_len;
-            ASSERT_ALLOC(buf_complete, len_complete);
+            TEST_CALLOC_OR_FAIL(buf_complete, len_complete);
             unsigned char *end_complete = buf_complete + len_complete;
             memcpy(buf_complete, data.p, data_len);
             if (par_len == 0) {
@@ -404,7 +404,7 @@ void test_asn1_write_bitstrings(data_t *bitstring, int bits,
     TEST_ASSERT(bitstring->len >= byte_length);
 
 #if defined(MBEDTLS_ASN1_PARSE_C)
-    ASSERT_ALLOC(masked_bitstring, byte_length);
+    TEST_CALLOC_OR_FAIL(masked_bitstring, byte_length);
     if (byte_length != 0) {
         memcpy(masked_bitstring, bitstring->x, byte_length);
         if (bits % 8 != 0) {
@@ -477,7 +477,7 @@ void store_named_data_find(data_t *oid0, data_t *oid1,
     }
     pointers[ARRAY_LENGTH(nd)] = NULL;
     for (i = 0; i < ARRAY_LENGTH(nd); i++) {
-        ASSERT_ALLOC(nd[i].oid.p, oid[i]->len);
+        TEST_CALLOC_OR_FAIL(nd[i].oid.p, oid[i]->len);
         memcpy(nd[i].oid.p, oid[i]->x, oid[i]->len);
         nd[i].oid.len = oid[i]->len;
         nd[i].next = pointers[i+1];
@@ -529,7 +529,7 @@ void store_named_data_val_found(int old_len, int new_len)
     unsigned char *new_val = (unsigned char *) "new value";
 
     if (old_len != 0) {
-        ASSERT_ALLOC(nd.val.p, (size_t) old_len);
+        TEST_CALLOC_OR_FAIL(nd.val.p, (size_t) old_len);
         old_val = nd.val.p;
         nd.val.len = old_len;
         memset(old_val, 'x', old_len);

--- a/tests/suites/test_suite_asn1write.function
+++ b/tests/suites/test_suite_asn1write.function
@@ -38,7 +38,7 @@ int generic_write_finish_step(generic_write_data_t *data,
         TEST_ASSERT(data->p >= data->start);
         TEST_ASSERT(data->p <= data->end);
         TEST_MEMORY_COMPARE(data->p, (size_t) (data->end - data->p),
-                       expected->x, expected->len);
+                            expected->x, expected->len);
     }
     ok = 1;
 
@@ -441,7 +441,7 @@ void test_asn1_write_bitstrings(data_t *bitstring, int bits,
             TEST_EQUAL(mbedtls_asn1_get_bitstring(&data.p, data.end,
                                                   &read), 0);
             TEST_MEMORY_COMPARE(read.p, read.len,
-                           masked_bitstring, byte_length);
+                                masked_bitstring, byte_length);
             TEST_EQUAL(read.unused_bits, 8 * byte_length - value_bits);
         }
 #endif /* MBEDTLS_ASN1_PARSE_C */
@@ -546,7 +546,7 @@ void store_named_data_val_found(int old_len, int new_len)
 
     if (new_val != NULL) {
         TEST_MEMORY_COMPARE(found->val.p, found->val.len,
-                       new_val, (size_t) new_len);
+                            new_val, (size_t) new_len);
     }
     if (new_len == 0) {
         TEST_ASSERT(found->val.p == NULL);
@@ -588,7 +588,7 @@ void store_named_data_val_new(int new_len, int set_new_val)
     } else {
         TEST_ASSERT(found->val.p != new_val);
         TEST_MEMORY_COMPARE(found->val.p, found->val.len,
-                       new_val, (size_t) new_len);
+                            new_val, (size_t) new_len);
     }
 
 exit:

--- a/tests/suites/test_suite_asn1write.function
+++ b/tests/suites/test_suite_asn1write.function
@@ -17,7 +17,7 @@ int generic_write_start_step(generic_write_data_t *data)
     mbedtls_test_set_step(data->size);
     mbedtls_free(data->output);
     data->output = NULL;
-    TEST_CALLOC_OR_FAIL(data->output, data->size == 0 ? 1 : data->size);
+    TEST_CALLOC(data->output, data->size == 0 ? 1 : data->size);
     data->end = data->output + data->size;
     data->p = data->end;
     data->start = data->end - data->size;
@@ -296,7 +296,7 @@ void mbedtls_asn1_write_algorithm_identifier(data_t *oid,
             size_t len_complete = data_len + par_len;
             unsigned char expected_params_tag;
             size_t expected_params_len;
-            TEST_CALLOC_OR_FAIL(buf_complete, len_complete);
+            TEST_CALLOC(buf_complete, len_complete);
             unsigned char *end_complete = buf_complete + len_complete;
             memcpy(buf_complete, data.p, data_len);
             if (par_len == 0) {
@@ -404,7 +404,7 @@ void test_asn1_write_bitstrings(data_t *bitstring, int bits,
     TEST_ASSERT(bitstring->len >= byte_length);
 
 #if defined(MBEDTLS_ASN1_PARSE_C)
-    TEST_CALLOC_OR_FAIL(masked_bitstring, byte_length);
+    TEST_CALLOC(masked_bitstring, byte_length);
     if (byte_length != 0) {
         memcpy(masked_bitstring, bitstring->x, byte_length);
         if (bits % 8 != 0) {
@@ -477,7 +477,7 @@ void store_named_data_find(data_t *oid0, data_t *oid1,
     }
     pointers[ARRAY_LENGTH(nd)] = NULL;
     for (i = 0; i < ARRAY_LENGTH(nd); i++) {
-        TEST_CALLOC_OR_FAIL(nd[i].oid.p, oid[i]->len);
+        TEST_CALLOC(nd[i].oid.p, oid[i]->len);
         memcpy(nd[i].oid.p, oid[i]->x, oid[i]->len);
         nd[i].oid.len = oid[i]->len;
         nd[i].next = pointers[i+1];
@@ -529,7 +529,7 @@ void store_named_data_val_found(int old_len, int new_len)
     unsigned char *new_val = (unsigned char *) "new value";
 
     if (old_len != 0) {
-        TEST_CALLOC_OR_FAIL(nd.val.p, (size_t) old_len);
+        TEST_CALLOC(nd.val.p, (size_t) old_len);
         old_val = nd.val.p;
         nd.val.len = old_len;
         memset(old_val, 'x', old_len);

--- a/tests/suites/test_suite_bignum.function
+++ b/tests/suites/test_suite_bignum.function
@@ -1507,7 +1507,7 @@ void mpi_random_many(int min, data_t *bound_bytes, int iterations)
         full_stats = 0;
         stats_len = n_bits;
     }
-    ASSERT_ALLOC(stats, stats_len);
+    TEST_CALLOC_OR_FAIL(stats, stats_len);
 
     for (i = 0; i < (size_t) iterations; i++) {
         mbedtls_test_set_step(i);

--- a/tests/suites/test_suite_bignum.function
+++ b/tests/suites/test_suite_bignum.function
@@ -1507,7 +1507,7 @@ void mpi_random_many(int min, data_t *bound_bytes, int iterations)
         full_stats = 0;
         stats_len = n_bits;
     }
-    TEST_CALLOC_OR_FAIL(stats, stats_len);
+    TEST_CALLOC(stats, stats_len);
 
     for (i = 0; i < (size_t) iterations; i++) {
         mbedtls_test_set_step(i);

--- a/tests/suites/test_suite_ccm.function
+++ b/tests/suites/test_suite_ccm.function
@@ -48,7 +48,7 @@ void ccm_lengths(int msg_len, int iv_len, int add_len, int tag_len, int res)
 
     mbedtls_ccm_init(&ctx);
 
-    ASSERT_ALLOC_WEAK(add, add_len);
+    TEST_CALLOC_OR_SKIP(add, add_len);
     memset(key, 0, sizeof(key));
     memset(msg, 0, sizeof(msg));
     memset(iv, 0, sizeof(iv));

--- a/tests/suites/test_suite_chacha20.function
+++ b/tests/suites/test_suite_chacha20.function
@@ -29,7 +29,7 @@ void chacha20_crypt(data_t *key_str,
     TEST_ASSERT(mbedtls_chacha20_crypt(key_str->x, nonce_str->x, counter, src_str->len, src_str->x,
                                        output) == 0);
 
-    ASSERT_COMPARE(output, expected_output_str->len,
+    TEST_BUFFERS_EQUAL(output, expected_output_str->len,
                    expected_output_str->x, expected_output_str->len);
 
     /*
@@ -44,7 +44,7 @@ void chacha20_crypt(data_t *key_str,
     memset(output, 0x00, sizeof(output));
     TEST_ASSERT(mbedtls_chacha20_update(&ctx, src_str->len, src_str->x, output) == 0);
 
-    ASSERT_COMPARE(output, expected_output_str->len,
+    TEST_BUFFERS_EQUAL(output, expected_output_str->len,
                    expected_output_str->x, expected_output_str->len);
 
     /*
@@ -60,7 +60,7 @@ void chacha20_crypt(data_t *key_str,
     TEST_ASSERT(mbedtls_chacha20_update(&ctx, src_str->len - 1,
                                         src_str->x + 1, output + 1) == 0);
 
-    ASSERT_COMPARE(output, expected_output_str->len,
+    TEST_BUFFERS_EQUAL(output, expected_output_str->len,
                    expected_output_str->x, expected_output_str->len);
 
     mbedtls_chacha20_free(&ctx);

--- a/tests/suites/test_suite_chacha20.function
+++ b/tests/suites/test_suite_chacha20.function
@@ -29,7 +29,7 @@ void chacha20_crypt(data_t *key_str,
     TEST_ASSERT(mbedtls_chacha20_crypt(key_str->x, nonce_str->x, counter, src_str->len, src_str->x,
                                        output) == 0);
 
-    TEST_BUFFERS_EQUAL(output, expected_output_str->len,
+    TEST_MEMORY_COMPARE(output, expected_output_str->len,
                    expected_output_str->x, expected_output_str->len);
 
     /*
@@ -44,7 +44,7 @@ void chacha20_crypt(data_t *key_str,
     memset(output, 0x00, sizeof(output));
     TEST_ASSERT(mbedtls_chacha20_update(&ctx, src_str->len, src_str->x, output) == 0);
 
-    TEST_BUFFERS_EQUAL(output, expected_output_str->len,
+    TEST_MEMORY_COMPARE(output, expected_output_str->len,
                    expected_output_str->x, expected_output_str->len);
 
     /*
@@ -60,7 +60,7 @@ void chacha20_crypt(data_t *key_str,
     TEST_ASSERT(mbedtls_chacha20_update(&ctx, src_str->len - 1,
                                         src_str->x + 1, output + 1) == 0);
 
-    TEST_BUFFERS_EQUAL(output, expected_output_str->len,
+    TEST_MEMORY_COMPARE(output, expected_output_str->len,
                    expected_output_str->x, expected_output_str->len);
 
     mbedtls_chacha20_free(&ctx);

--- a/tests/suites/test_suite_chacha20.function
+++ b/tests/suites/test_suite_chacha20.function
@@ -30,7 +30,7 @@ void chacha20_crypt(data_t *key_str,
                                        output) == 0);
 
     TEST_MEMORY_COMPARE(output, expected_output_str->len,
-                   expected_output_str->x, expected_output_str->len);
+                        expected_output_str->x, expected_output_str->len);
 
     /*
      * Test the streaming API
@@ -45,7 +45,7 @@ void chacha20_crypt(data_t *key_str,
     TEST_ASSERT(mbedtls_chacha20_update(&ctx, src_str->len, src_str->x, output) == 0);
 
     TEST_MEMORY_COMPARE(output, expected_output_str->len,
-                   expected_output_str->x, expected_output_str->len);
+                        expected_output_str->x, expected_output_str->len);
 
     /*
      * Test the streaming API again, piecewise
@@ -61,7 +61,7 @@ void chacha20_crypt(data_t *key_str,
                                         src_str->x + 1, output + 1) == 0);
 
     TEST_MEMORY_COMPARE(output, expected_output_str->len,
-                   expected_output_str->x, expected_output_str->len);
+                        expected_output_str->x, expected_output_str->len);
 
     mbedtls_chacha20_free(&ctx);
 }

--- a/tests/suites/test_suite_cipher.function
+++ b/tests/suites/test_suite_cipher.function
@@ -1229,7 +1229,7 @@ void auth_crypt_tv(int cipher_id, data_t *key, data_t *iv,
      * (we need the tag appended to the ciphertext)
      */
     cipher_plus_tag_len = cipher->len + tag->len;
-    TEST_CALLOC_OR_FAIL(cipher_plus_tag, cipher_plus_tag_len);
+    TEST_CALLOC(cipher_plus_tag, cipher_plus_tag_len);
     memcpy(cipher_plus_tag, cipher->x, cipher->len);
     memcpy(cipher_plus_tag + cipher->len, tag->x, tag->len);
 
@@ -1247,7 +1247,7 @@ void auth_crypt_tv(int cipher_id, data_t *key, data_t *iv,
      * Try decrypting to a buffer that's 1B too small
      */
     if (decrypt_buf_len != 0) {
-        TEST_CALLOC_OR_FAIL(decrypt_buf, decrypt_buf_len - 1);
+        TEST_CALLOC(decrypt_buf, decrypt_buf_len - 1);
 
         outlen = 0;
         ret = mbedtls_cipher_auth_decrypt_ext(&ctx, iv->x, iv->len,
@@ -1262,7 +1262,7 @@ void auth_crypt_tv(int cipher_id, data_t *key, data_t *iv,
     /*
      * Authenticate and decrypt, and check result
      */
-    TEST_CALLOC_OR_FAIL(decrypt_buf, decrypt_buf_len);
+    TEST_CALLOC(decrypt_buf, decrypt_buf_len);
 
     outlen = 0;
     ret = mbedtls_cipher_auth_decrypt_ext(&ctx, iv->x, iv->len,
@@ -1306,7 +1306,7 @@ void auth_crypt_tv(int cipher_id, data_t *key, data_t *iv,
         /*
          * Try encrypting with an output buffer that's 1B too small
          */
-        TEST_CALLOC_OR_FAIL(encrypt_buf, encrypt_buf_len - 1);
+        TEST_CALLOC(encrypt_buf, encrypt_buf_len - 1);
 
         outlen = 0;
         ret = mbedtls_cipher_auth_encrypt_ext(&ctx, iv->x, iv->len,
@@ -1320,7 +1320,7 @@ void auth_crypt_tv(int cipher_id, data_t *key, data_t *iv,
         /*
          * Encrypt and check the result
          */
-        TEST_CALLOC_OR_FAIL(encrypt_buf, encrypt_buf_len);
+        TEST_CALLOC(encrypt_buf, encrypt_buf_len);
 
         outlen = 0;
         ret = mbedtls_cipher_auth_encrypt_ext(&ctx, iv->x, iv->len,
@@ -1374,7 +1374,7 @@ void auth_crypt_tv(int cipher_id, data_t *key, data_t *iv,
      * Authenticate and decrypt, and check result
      */
 
-    TEST_CALLOC_OR_FAIL(decrypt_buf, cipher->len);
+    TEST_CALLOC(decrypt_buf, cipher->len);
     outlen = 0;
     ret = mbedtls_cipher_auth_decrypt(&ctx, iv->x, iv->len, ad->x, ad->len,
                                       tmp_cipher, cipher->len, decrypt_buf, &outlen,
@@ -1411,14 +1411,14 @@ void auth_crypt_tv(int cipher_id, data_t *key, data_t *iv,
         /* prepare buffers for encryption */
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
         if (use_psa) {
-            TEST_CALLOC_OR_FAIL(cipher_plus_tag, cipher->len + tag->len);
+            TEST_CALLOC(cipher_plus_tag, cipher->len + tag->len);
             tmp_cipher = cipher_plus_tag;
             tmp_tag = cipher_plus_tag + cipher->len;
         } else
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
         {
-            TEST_CALLOC_OR_FAIL(encrypt_buf, cipher->len);
-            TEST_CALLOC_OR_FAIL(tag_buf, tag->len);
+            TEST_CALLOC(encrypt_buf, cipher->len);
+            TEST_CALLOC(tag_buf, tag->len);
             tmp_cipher = encrypt_buf;
             tmp_tag = tag_buf;
         }

--- a/tests/suites/test_suite_cipher.function
+++ b/tests/suites/test_suite_cipher.function
@@ -1274,7 +1274,7 @@ void auth_crypt_tv(int cipher_id, data_t *key, data_t *iv,
         TEST_ASSERT(buffer_is_all_zero(decrypt_buf, decrypt_buf_len));
     } else {
         TEST_ASSERT(ret == 0);
-        ASSERT_COMPARE(decrypt_buf, outlen, clear->x, clear->len);
+        TEST_BUFFERS_EQUAL(decrypt_buf, outlen, clear->x, clear->len);
     }
 
     /* Free this, but keep cipher_plus_tag for deprecated function with PSA */
@@ -1390,7 +1390,7 @@ void auth_crypt_tv(int cipher_id, data_t *key, data_t *iv,
     } else {
         /* authentic message: is the plaintext correct? */
         TEST_ASSERT(ret == 0);
-        ASSERT_COMPARE(decrypt_buf, outlen, clear->x, clear->len);
+        TEST_BUFFERS_EQUAL(decrypt_buf, outlen, clear->x, clear->len);
     }
 
     mbedtls_free(decrypt_buf);

--- a/tests/suites/test_suite_cipher.function
+++ b/tests/suites/test_suite_cipher.function
@@ -1274,7 +1274,7 @@ void auth_crypt_tv(int cipher_id, data_t *key, data_t *iv,
         TEST_ASSERT(buffer_is_all_zero(decrypt_buf, decrypt_buf_len));
     } else {
         TEST_ASSERT(ret == 0);
-        TEST_BUFFERS_EQUAL(decrypt_buf, outlen, clear->x, clear->len);
+        TEST_MEMORY_COMPARE(decrypt_buf, outlen, clear->x, clear->len);
     }
 
     /* Free this, but keep cipher_plus_tag for deprecated function with PSA */
@@ -1390,7 +1390,7 @@ void auth_crypt_tv(int cipher_id, data_t *key, data_t *iv,
     } else {
         /* authentic message: is the plaintext correct? */
         TEST_ASSERT(ret == 0);
-        TEST_BUFFERS_EQUAL(decrypt_buf, outlen, clear->x, clear->len);
+        TEST_MEMORY_COMPARE(decrypt_buf, outlen, clear->x, clear->len);
     }
 
     mbedtls_free(decrypt_buf);

--- a/tests/suites/test_suite_cipher.function
+++ b/tests/suites/test_suite_cipher.function
@@ -1229,7 +1229,7 @@ void auth_crypt_tv(int cipher_id, data_t *key, data_t *iv,
      * (we need the tag appended to the ciphertext)
      */
     cipher_plus_tag_len = cipher->len + tag->len;
-    ASSERT_ALLOC(cipher_plus_tag, cipher_plus_tag_len);
+    TEST_CALLOC_OR_FAIL(cipher_plus_tag, cipher_plus_tag_len);
     memcpy(cipher_plus_tag, cipher->x, cipher->len);
     memcpy(cipher_plus_tag + cipher->len, tag->x, tag->len);
 
@@ -1247,7 +1247,7 @@ void auth_crypt_tv(int cipher_id, data_t *key, data_t *iv,
      * Try decrypting to a buffer that's 1B too small
      */
     if (decrypt_buf_len != 0) {
-        ASSERT_ALLOC(decrypt_buf, decrypt_buf_len - 1);
+        TEST_CALLOC_OR_FAIL(decrypt_buf, decrypt_buf_len - 1);
 
         outlen = 0;
         ret = mbedtls_cipher_auth_decrypt_ext(&ctx, iv->x, iv->len,
@@ -1262,7 +1262,7 @@ void auth_crypt_tv(int cipher_id, data_t *key, data_t *iv,
     /*
      * Authenticate and decrypt, and check result
      */
-    ASSERT_ALLOC(decrypt_buf, decrypt_buf_len);
+    TEST_CALLOC_OR_FAIL(decrypt_buf, decrypt_buf_len);
 
     outlen = 0;
     ret = mbedtls_cipher_auth_decrypt_ext(&ctx, iv->x, iv->len,
@@ -1306,7 +1306,7 @@ void auth_crypt_tv(int cipher_id, data_t *key, data_t *iv,
         /*
          * Try encrypting with an output buffer that's 1B too small
          */
-        ASSERT_ALLOC(encrypt_buf, encrypt_buf_len - 1);
+        TEST_CALLOC_OR_FAIL(encrypt_buf, encrypt_buf_len - 1);
 
         outlen = 0;
         ret = mbedtls_cipher_auth_encrypt_ext(&ctx, iv->x, iv->len,
@@ -1320,7 +1320,7 @@ void auth_crypt_tv(int cipher_id, data_t *key, data_t *iv,
         /*
          * Encrypt and check the result
          */
-        ASSERT_ALLOC(encrypt_buf, encrypt_buf_len);
+        TEST_CALLOC_OR_FAIL(encrypt_buf, encrypt_buf_len);
 
         outlen = 0;
         ret = mbedtls_cipher_auth_encrypt_ext(&ctx, iv->x, iv->len,
@@ -1374,7 +1374,7 @@ void auth_crypt_tv(int cipher_id, data_t *key, data_t *iv,
      * Authenticate and decrypt, and check result
      */
 
-    ASSERT_ALLOC(decrypt_buf, cipher->len);
+    TEST_CALLOC_OR_FAIL(decrypt_buf, cipher->len);
     outlen = 0;
     ret = mbedtls_cipher_auth_decrypt(&ctx, iv->x, iv->len, ad->x, ad->len,
                                       tmp_cipher, cipher->len, decrypt_buf, &outlen,
@@ -1411,14 +1411,14 @@ void auth_crypt_tv(int cipher_id, data_t *key, data_t *iv,
         /* prepare buffers for encryption */
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
         if (use_psa) {
-            ASSERT_ALLOC(cipher_plus_tag, cipher->len + tag->len);
+            TEST_CALLOC_OR_FAIL(cipher_plus_tag, cipher->len + tag->len);
             tmp_cipher = cipher_plus_tag;
             tmp_tag = cipher_plus_tag + cipher->len;
         } else
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
         {
-            ASSERT_ALLOC(encrypt_buf, cipher->len);
-            ASSERT_ALLOC(tag_buf, tag->len);
+            TEST_CALLOC_OR_FAIL(encrypt_buf, cipher->len);
+            TEST_CALLOC_OR_FAIL(tag_buf, tag->len);
             tmp_cipher = encrypt_buf;
             tmp_tag = tag_buf;
         }

--- a/tests/suites/test_suite_constant_time.function
+++ b/tests/suites/test_suite_constant_time.function
@@ -38,7 +38,7 @@ void ssl_cf_memcpy_offset(int offset_min, int offset_max, int len)
         TEST_CF_PUBLIC(&secret, sizeof(secret));
         TEST_CF_PUBLIC(dst, len);
 
-        TEST_BUFFERS_EQUAL(dst, len, src + secret, len);
+        TEST_MEMORY_COMPARE(dst, len, src + secret, len);
     }
 
 exit:

--- a/tests/suites/test_suite_constant_time.function
+++ b/tests/suites/test_suite_constant_time.function
@@ -38,7 +38,7 @@ void ssl_cf_memcpy_offset(int offset_min, int offset_max, int len)
         TEST_CF_PUBLIC(&secret, sizeof(secret));
         TEST_CF_PUBLIC(dst, len);
 
-        ASSERT_COMPARE(dst, len, src + secret, len);
+        TEST_BUFFERS_EQUAL(dst, len, src + secret, len);
     }
 
 exit:

--- a/tests/suites/test_suite_constant_time.function
+++ b/tests/suites/test_suite_constant_time.function
@@ -23,8 +23,8 @@ void ssl_cf_memcpy_offset(int offset_min, int offset_max, int len)
     size_t src_len = offset_max + len;
     size_t secret;
 
-    TEST_CALLOC_OR_FAIL(dst, len);
-    TEST_CALLOC_OR_FAIL(src, src_len);
+    TEST_CALLOC(dst, len);
+    TEST_CALLOC(src, src_len);
 
     /* Fill src in a way that we can detect if we copied the right bytes */
     mbedtls_test_rnd_std_rand(NULL, src, src_len);

--- a/tests/suites/test_suite_constant_time.function
+++ b/tests/suites/test_suite_constant_time.function
@@ -23,8 +23,8 @@ void ssl_cf_memcpy_offset(int offset_min, int offset_max, int len)
     size_t src_len = offset_max + len;
     size_t secret;
 
-    ASSERT_ALLOC(dst, len);
-    ASSERT_ALLOC(src, src_len);
+    TEST_CALLOC_OR_FAIL(dst, len);
+    TEST_CALLOC_OR_FAIL(src, src_len);
 
     /* Fill src in a way that we can detect if we copied the right bytes */
     mbedtls_test_rnd_std_rand(NULL, src, src_len);

--- a/tests/suites/test_suite_constant_time_hmac.function
+++ b/tests/suites/test_suite_constant_time_hmac.function
@@ -84,7 +84,7 @@ void ssl_cf_hmac(int hash)
             TEST_EQUAL(0, mbedtls_md_hmac_reset(&ref_ctx));
 
             /* Compare */
-            TEST_BUFFERS_EQUAL(out, out_len, ref_out, out_len);
+            TEST_MEMORY_COMPARE(out, out_len, ref_out, out_len);
         }
 
         mbedtls_free(data);

--- a/tests/suites/test_suite_constant_time_hmac.function
+++ b/tests/suites/test_suite_constant_time_hmac.function
@@ -84,7 +84,7 @@ void ssl_cf_hmac(int hash)
             TEST_EQUAL(0, mbedtls_md_hmac_reset(&ref_ctx));
 
             /* Compare */
-            ASSERT_COMPARE(out, out_len, ref_out, out_len);
+            TEST_BUFFERS_EQUAL(out, out_len, ref_out, out_len);
         }
 
         mbedtls_free(data);

--- a/tests/suites/test_suite_constant_time_hmac.function
+++ b/tests/suites/test_suite_constant_time_hmac.function
@@ -35,7 +35,7 @@ void ssl_cf_hmac(int hash)
     block_size = hash == MBEDTLS_MD_SHA384 ? 128 : 64;
 
     /* Use allocated out buffer to catch overwrites */
-    TEST_CALLOC_OR_FAIL(out, out_len);
+    TEST_CALLOC(out, out_len);
 
     /* Set up contexts with the given hash and a dummy key */
     TEST_EQUAL(0, mbedtls_md_setup(&ctx, md_info, 1));
@@ -54,7 +54,7 @@ void ssl_cf_hmac(int hash)
         mbedtls_test_set_step(max_in_len * 10000);
 
         /* Use allocated in buffer to catch overreads */
-        TEST_CALLOC_OR_FAIL(data, max_in_len);
+        TEST_CALLOC(data, max_in_len);
 
         min_in_len = max_in_len > 255 ? max_in_len - 255 : 0;
         for (in_len = min_in_len; in_len <= max_in_len; in_len++) {

--- a/tests/suites/test_suite_constant_time_hmac.function
+++ b/tests/suites/test_suite_constant_time_hmac.function
@@ -35,7 +35,7 @@ void ssl_cf_hmac(int hash)
     block_size = hash == MBEDTLS_MD_SHA384 ? 128 : 64;
 
     /* Use allocated out buffer to catch overwrites */
-    ASSERT_ALLOC(out, out_len);
+    TEST_CALLOC_OR_FAIL(out, out_len);
 
     /* Set up contexts with the given hash and a dummy key */
     TEST_EQUAL(0, mbedtls_md_setup(&ctx, md_info, 1));
@@ -54,7 +54,7 @@ void ssl_cf_hmac(int hash)
         mbedtls_test_set_step(max_in_len * 10000);
 
         /* Use allocated in buffer to catch overreads */
-        ASSERT_ALLOC(data, max_in_len);
+        TEST_CALLOC_OR_FAIL(data, max_in_len);
 
         min_in_len = max_in_len > 255 ? max_in_len - 255 : 0;
         for (in_len = min_in_len; in_len <= max_in_len; in_len++) {

--- a/tests/suites/test_suite_ecp.function
+++ b/tests/suites/test_suite_ecp.function
@@ -852,7 +852,7 @@ void ecp_muladd(int id,
                    &len, actual_result, sizeof(actual_result)));
     TEST_ASSERT(len <= MBEDTLS_ECP_MAX_PT_LEN);
 
-    ASSERT_COMPARE(expected_result->x, expected_result->len,
+    TEST_BUFFERS_EQUAL(expected_result->x, expected_result->len,
                    actual_result, len);
 
 exit:
@@ -1356,7 +1356,7 @@ void mbedtls_ecp_read_key(int grp_id, data_t *in_key, int expected, int canonica
             ret = mbedtls_ecp_write_key(&key, buf, in_key->len);
             TEST_ASSERT(ret == 0);
 
-            ASSERT_COMPARE(in_key->x, in_key->len,
+            TEST_BUFFERS_EQUAL(in_key->x, in_key->len,
                            buf, in_key->len);
         } else {
             unsigned char export1[MBEDTLS_ECP_MAX_BYTES];
@@ -1371,7 +1371,7 @@ void mbedtls_ecp_read_key(int grp_id, data_t *in_key, int expected, int canonica
             ret = mbedtls_ecp_write_key(&key2, export2, in_key->len);
             TEST_ASSERT(ret == 0);
 
-            ASSERT_COMPARE(export1, in_key->len,
+            TEST_BUFFERS_EQUAL(export1, in_key->len,
                            export2, in_key->len);
         }
     }
@@ -1448,7 +1448,7 @@ void genkey_mx_known_answer(int bits, data_t *seed, data_t *expected)
          *   (can be enforced by checking these bits).
          * - Other bits must be random (by testing with different RNG outputs,
          *   we validate that those bits are indeed influenced by the RNG). */
-        ASSERT_COMPARE(expected->x, expected->len,
+        TEST_BUFFERS_EQUAL(expected->x, expected->len,
                        actual, expected->len);
     }
 

--- a/tests/suites/test_suite_ecp.function
+++ b/tests/suites/test_suite_ecp.function
@@ -853,7 +853,7 @@ void ecp_muladd(int id,
     TEST_ASSERT(len <= MBEDTLS_ECP_MAX_PT_LEN);
 
     TEST_MEMORY_COMPARE(expected_result->x, expected_result->len,
-                   actual_result, len);
+                        actual_result, len);
 
 exit:
     mbedtls_ecp_group_free(&grp);
@@ -1357,7 +1357,7 @@ void mbedtls_ecp_read_key(int grp_id, data_t *in_key, int expected, int canonica
             TEST_ASSERT(ret == 0);
 
             TEST_MEMORY_COMPARE(in_key->x, in_key->len,
-                           buf, in_key->len);
+                                buf, in_key->len);
         } else {
             unsigned char export1[MBEDTLS_ECP_MAX_BYTES];
             unsigned char export2[MBEDTLS_ECP_MAX_BYTES];
@@ -1372,7 +1372,7 @@ void mbedtls_ecp_read_key(int grp_id, data_t *in_key, int expected, int canonica
             TEST_ASSERT(ret == 0);
 
             TEST_MEMORY_COMPARE(export1, in_key->len,
-                           export2, in_key->len);
+                                export2, in_key->len);
         }
     }
 
@@ -1449,7 +1449,7 @@ void genkey_mx_known_answer(int bits, data_t *seed, data_t *expected)
          * - Other bits must be random (by testing with different RNG outputs,
          *   we validate that those bits are indeed influenced by the RNG). */
         TEST_MEMORY_COMPARE(expected->x, expected->len,
-                       actual, expected->len);
+                            actual, expected->len);
     }
 
 exit:

--- a/tests/suites/test_suite_ecp.function
+++ b/tests/suites/test_suite_ecp.function
@@ -1426,7 +1426,7 @@ void genkey_mx_known_answer(int bits, data_t *seed, data_t *expected)
     rnd_info.fallback_f_rng = NULL;
     rnd_info.fallback_p_rng = NULL;
 
-    TEST_CALLOC_OR_FAIL(actual, expected->len);
+    TEST_CALLOC(actual, expected->len);
 
     ret = mbedtls_ecp_gen_privkey_mx(bits, &d,
                                      mbedtls_test_rnd_buffer_rand, &rnd_info);

--- a/tests/suites/test_suite_ecp.function
+++ b/tests/suites/test_suite_ecp.function
@@ -852,7 +852,7 @@ void ecp_muladd(int id,
                    &len, actual_result, sizeof(actual_result)));
     TEST_ASSERT(len <= MBEDTLS_ECP_MAX_PT_LEN);
 
-    TEST_BUFFERS_EQUAL(expected_result->x, expected_result->len,
+    TEST_MEMORY_COMPARE(expected_result->x, expected_result->len,
                    actual_result, len);
 
 exit:
@@ -1356,7 +1356,7 @@ void mbedtls_ecp_read_key(int grp_id, data_t *in_key, int expected, int canonica
             ret = mbedtls_ecp_write_key(&key, buf, in_key->len);
             TEST_ASSERT(ret == 0);
 
-            TEST_BUFFERS_EQUAL(in_key->x, in_key->len,
+            TEST_MEMORY_COMPARE(in_key->x, in_key->len,
                            buf, in_key->len);
         } else {
             unsigned char export1[MBEDTLS_ECP_MAX_BYTES];
@@ -1371,7 +1371,7 @@ void mbedtls_ecp_read_key(int grp_id, data_t *in_key, int expected, int canonica
             ret = mbedtls_ecp_write_key(&key2, export2, in_key->len);
             TEST_ASSERT(ret == 0);
 
-            TEST_BUFFERS_EQUAL(export1, in_key->len,
+            TEST_MEMORY_COMPARE(export1, in_key->len,
                            export2, in_key->len);
         }
     }
@@ -1448,7 +1448,7 @@ void genkey_mx_known_answer(int bits, data_t *seed, data_t *expected)
          *   (can be enforced by checking these bits).
          * - Other bits must be random (by testing with different RNG outputs,
          *   we validate that those bits are indeed influenced by the RNG). */
-        TEST_BUFFERS_EQUAL(expected->x, expected->len,
+        TEST_MEMORY_COMPARE(expected->x, expected->len,
                        actual, expected->len);
     }
 

--- a/tests/suites/test_suite_ecp.function
+++ b/tests/suites/test_suite_ecp.function
@@ -1426,7 +1426,7 @@ void genkey_mx_known_answer(int bits, data_t *seed, data_t *expected)
     rnd_info.fallback_f_rng = NULL;
     rnd_info.fallback_p_rng = NULL;
 
-    ASSERT_ALLOC(actual, expected->len);
+    TEST_CALLOC_OR_FAIL(actual, expected->len);
 
     ret = mbedtls_ecp_gen_privkey_mx(bits, &d,
                                      mbedtls_test_rnd_buffer_rand, &rnd_info);

--- a/tests/suites/test_suite_hkdf.function
+++ b/tests/suites/test_suite_hkdf.function
@@ -24,7 +24,7 @@ void test_hkdf(int md_alg, data_t *ikm, data_t *salt, data_t *info,
                        info->x, info->len, okm, expected_okm->len);
     TEST_ASSERT(ret == 0);
 
-    TEST_BUFFERS_EQUAL(okm, expected_okm->len,
+    TEST_MEMORY_COMPARE(okm, expected_okm->len,
                    expected_okm->x, expected_okm->len);
 }
 /* END_CASE */
@@ -53,7 +53,7 @@ void test_hkdf_extract(int md_alg, char *hex_ikm_string,
     ret = mbedtls_hkdf_extract(md, salt, salt_len, ikm, ikm_len, output_prk);
     TEST_ASSERT(ret == 0);
 
-    TEST_BUFFERS_EQUAL(output_prk, output_prk_len, prk, prk_len);
+    TEST_MEMORY_COMPARE(output_prk, output_prk_len, prk, prk_len);
 
 exit:
     mbedtls_free(ikm);
@@ -89,7 +89,7 @@ void test_hkdf_expand(int md_alg, char *hex_info_string,
     ret = mbedtls_hkdf_expand(md, prk, prk_len, info, info_len,
                               output_okm, OKM_LEN);
     TEST_ASSERT(ret == 0);
-    TEST_BUFFERS_EQUAL(output_okm, okm_len, okm, okm_len);
+    TEST_MEMORY_COMPARE(output_okm, okm_len, okm, okm_len);
 
 exit:
     mbedtls_free(info);

--- a/tests/suites/test_suite_hkdf.function
+++ b/tests/suites/test_suite_hkdf.function
@@ -25,7 +25,7 @@ void test_hkdf(int md_alg, data_t *ikm, data_t *salt, data_t *info,
     TEST_ASSERT(ret == 0);
 
     TEST_MEMORY_COMPARE(okm, expected_okm->len,
-                   expected_okm->x, expected_okm->len);
+                        expected_okm->x, expected_okm->len);
 }
 /* END_CASE */
 

--- a/tests/suites/test_suite_hkdf.function
+++ b/tests/suites/test_suite_hkdf.function
@@ -24,7 +24,7 @@ void test_hkdf(int md_alg, data_t *ikm, data_t *salt, data_t *info,
                        info->x, info->len, okm, expected_okm->len);
     TEST_ASSERT(ret == 0);
 
-    ASSERT_COMPARE(okm, expected_okm->len,
+    TEST_BUFFERS_EQUAL(okm, expected_okm->len,
                    expected_okm->x, expected_okm->len);
 }
 /* END_CASE */
@@ -53,7 +53,7 @@ void test_hkdf_extract(int md_alg, char *hex_ikm_string,
     ret = mbedtls_hkdf_extract(md, salt, salt_len, ikm, ikm_len, output_prk);
     TEST_ASSERT(ret == 0);
 
-    ASSERT_COMPARE(output_prk, output_prk_len, prk, prk_len);
+    TEST_BUFFERS_EQUAL(output_prk, output_prk_len, prk, prk_len);
 
 exit:
     mbedtls_free(ikm);
@@ -89,7 +89,7 @@ void test_hkdf_expand(int md_alg, char *hex_info_string,
     ret = mbedtls_hkdf_expand(md, prk, prk_len, info, info_len,
                               output_okm, OKM_LEN);
     TEST_ASSERT(ret == 0);
-    ASSERT_COMPARE(output_okm, okm_len, okm, okm_len);
+    TEST_BUFFERS_EQUAL(output_okm, okm_len, okm, okm_len);
 
 exit:
     mbedtls_free(info);

--- a/tests/suites/test_suite_md.function
+++ b/tests/suites/test_suite_md.function
@@ -139,7 +139,7 @@ void md_text(int md_type, char *text_src_string, data_t *hash)
 
     TEST_EQUAL(0, mbedtls_md(md_info, src, src_len, output));
 
-    ASSERT_COMPARE(output, mbedtls_md_get_size(md_info), hash->x, hash->len);
+    TEST_BUFFERS_EQUAL(output, mbedtls_md_get_size(md_info), hash->x, hash->len);
 }
 /* END_CASE */
 
@@ -155,7 +155,7 @@ void md_hex(int md_type, data_t *src_str, data_t *hash)
     TEST_EQUAL(0, mbedtls_md(md_info, src_str->x, src_str->len, output));
 
 
-    ASSERT_COMPARE(output, mbedtls_md_get_size(md_info), hash->x, hash->len);
+    TEST_BUFFERS_EQUAL(output, mbedtls_md_get_size(md_info), hash->x, hash->len);
 }
 /* END_CASE */
 
@@ -188,14 +188,14 @@ void md_text_multi(int md_type, char *text_src_string,
 
     TEST_EQUAL(0, mbedtls_md_update(&ctx, src + halfway, src_len - halfway));
     TEST_EQUAL(0, mbedtls_md_finish(&ctx, output));
-    ASSERT_COMPARE(output, mbedtls_md_get_size(md_info), hash->x, hash->len);
+    TEST_BUFFERS_EQUAL(output, mbedtls_md_get_size(md_info), hash->x, hash->len);
 
     /* Test clone */
     memset(output, 0x00, sizeof(output));
 
     TEST_EQUAL(0, mbedtls_md_update(&ctx_copy, src + halfway, src_len - halfway));
     TEST_EQUAL(0, mbedtls_md_finish(&ctx_copy, output));
-    ASSERT_COMPARE(output, mbedtls_md_get_size(md_info), hash->x, hash->len);
+    TEST_BUFFERS_EQUAL(output, mbedtls_md_get_size(md_info), hash->x, hash->len);
 
 exit:
     mbedtls_md_free(&ctx);
@@ -228,14 +228,14 @@ void md_hex_multi(int md_type, data_t *src_str, data_t *hash)
 
     TEST_EQUAL(0, mbedtls_md_update(&ctx, src_str->x + halfway, src_str->len - halfway));
     TEST_EQUAL(0, mbedtls_md_finish(&ctx, output));
-    ASSERT_COMPARE(output, mbedtls_md_get_size(md_info), hash->x, hash->len);
+    TEST_BUFFERS_EQUAL(output, mbedtls_md_get_size(md_info), hash->x, hash->len);
 
     /* Test clone */
     memset(output, 0x00, sizeof(output));
 
     TEST_EQUAL(0, mbedtls_md_update(&ctx_copy, src_str->x + halfway, src_str->len - halfway));
     TEST_EQUAL(0, mbedtls_md_finish(&ctx_copy, output));
-    ASSERT_COMPARE(output, mbedtls_md_get_size(md_info), hash->x, hash->len);
+    TEST_BUFFERS_EQUAL(output, mbedtls_md_get_size(md_info), hash->x, hash->len);
 
 exit:
     mbedtls_md_free(&ctx);
@@ -258,7 +258,7 @@ void mbedtls_md_hmac(int md_type, int trunc_size,
     TEST_EQUAL(0, mbedtls_md_hmac(md_info, key_str->x, key_str->len,
                                   src_str->x, src_str->len, output));
 
-    ASSERT_COMPARE(output, trunc_size, hash->x, hash->len);
+    TEST_BUFFERS_EQUAL(output, trunc_size, hash->x, hash->len);
 }
 /* END_CASE */
 
@@ -285,7 +285,7 @@ void md_hmac_multi(int md_type, int trunc_size, data_t *key_str,
     TEST_EQUAL(0, mbedtls_md_hmac_update(&ctx, src_str->x + halfway, src_str->len - halfway));
     TEST_EQUAL(0, mbedtls_md_hmac_finish(&ctx, output));
 
-    ASSERT_COMPARE(output, trunc_size, hash->x, hash->len);
+    TEST_BUFFERS_EQUAL(output, trunc_size, hash->x, hash->len);
 
     /* Test again, for reset() */
     memset(output, 0x00, sizeof(output));
@@ -295,7 +295,7 @@ void md_hmac_multi(int md_type, int trunc_size, data_t *key_str,
     TEST_EQUAL(0, mbedtls_md_hmac_update(&ctx, src_str->x + halfway, src_str->len - halfway));
     TEST_EQUAL(0, mbedtls_md_hmac_finish(&ctx, output));
 
-    ASSERT_COMPARE(output, trunc_size, hash->x, hash->len);
+    TEST_BUFFERS_EQUAL(output, trunc_size, hash->x, hash->len);
 
 exit:
     mbedtls_md_free(&ctx);
@@ -314,6 +314,6 @@ void mbedtls_md_file(int md_type, char *filename,
 
     TEST_EQUAL(0, mbedtls_md_file(md_info, filename, output));
 
-    ASSERT_COMPARE(output, mbedtls_md_get_size(md_info), hash->x, hash->len);
+    TEST_BUFFERS_EQUAL(output, mbedtls_md_get_size(md_info), hash->x, hash->len);
 }
 /* END_CASE */

--- a/tests/suites/test_suite_md.function
+++ b/tests/suites/test_suite_md.function
@@ -139,7 +139,7 @@ void md_text(int md_type, char *text_src_string, data_t *hash)
 
     TEST_EQUAL(0, mbedtls_md(md_info, src, src_len, output));
 
-    TEST_BUFFERS_EQUAL(output, mbedtls_md_get_size(md_info), hash->x, hash->len);
+    TEST_MEMORY_COMPARE(output, mbedtls_md_get_size(md_info), hash->x, hash->len);
 }
 /* END_CASE */
 
@@ -155,7 +155,7 @@ void md_hex(int md_type, data_t *src_str, data_t *hash)
     TEST_EQUAL(0, mbedtls_md(md_info, src_str->x, src_str->len, output));
 
 
-    TEST_BUFFERS_EQUAL(output, mbedtls_md_get_size(md_info), hash->x, hash->len);
+    TEST_MEMORY_COMPARE(output, mbedtls_md_get_size(md_info), hash->x, hash->len);
 }
 /* END_CASE */
 
@@ -188,14 +188,14 @@ void md_text_multi(int md_type, char *text_src_string,
 
     TEST_EQUAL(0, mbedtls_md_update(&ctx, src + halfway, src_len - halfway));
     TEST_EQUAL(0, mbedtls_md_finish(&ctx, output));
-    TEST_BUFFERS_EQUAL(output, mbedtls_md_get_size(md_info), hash->x, hash->len);
+    TEST_MEMORY_COMPARE(output, mbedtls_md_get_size(md_info), hash->x, hash->len);
 
     /* Test clone */
     memset(output, 0x00, sizeof(output));
 
     TEST_EQUAL(0, mbedtls_md_update(&ctx_copy, src + halfway, src_len - halfway));
     TEST_EQUAL(0, mbedtls_md_finish(&ctx_copy, output));
-    TEST_BUFFERS_EQUAL(output, mbedtls_md_get_size(md_info), hash->x, hash->len);
+    TEST_MEMORY_COMPARE(output, mbedtls_md_get_size(md_info), hash->x, hash->len);
 
 exit:
     mbedtls_md_free(&ctx);
@@ -228,14 +228,14 @@ void md_hex_multi(int md_type, data_t *src_str, data_t *hash)
 
     TEST_EQUAL(0, mbedtls_md_update(&ctx, src_str->x + halfway, src_str->len - halfway));
     TEST_EQUAL(0, mbedtls_md_finish(&ctx, output));
-    TEST_BUFFERS_EQUAL(output, mbedtls_md_get_size(md_info), hash->x, hash->len);
+    TEST_MEMORY_COMPARE(output, mbedtls_md_get_size(md_info), hash->x, hash->len);
 
     /* Test clone */
     memset(output, 0x00, sizeof(output));
 
     TEST_EQUAL(0, mbedtls_md_update(&ctx_copy, src_str->x + halfway, src_str->len - halfway));
     TEST_EQUAL(0, mbedtls_md_finish(&ctx_copy, output));
-    TEST_BUFFERS_EQUAL(output, mbedtls_md_get_size(md_info), hash->x, hash->len);
+    TEST_MEMORY_COMPARE(output, mbedtls_md_get_size(md_info), hash->x, hash->len);
 
 exit:
     mbedtls_md_free(&ctx);
@@ -258,7 +258,7 @@ void mbedtls_md_hmac(int md_type, int trunc_size,
     TEST_EQUAL(0, mbedtls_md_hmac(md_info, key_str->x, key_str->len,
                                   src_str->x, src_str->len, output));
 
-    TEST_BUFFERS_EQUAL(output, trunc_size, hash->x, hash->len);
+    TEST_MEMORY_COMPARE(output, trunc_size, hash->x, hash->len);
 }
 /* END_CASE */
 
@@ -285,7 +285,7 @@ void md_hmac_multi(int md_type, int trunc_size, data_t *key_str,
     TEST_EQUAL(0, mbedtls_md_hmac_update(&ctx, src_str->x + halfway, src_str->len - halfway));
     TEST_EQUAL(0, mbedtls_md_hmac_finish(&ctx, output));
 
-    TEST_BUFFERS_EQUAL(output, trunc_size, hash->x, hash->len);
+    TEST_MEMORY_COMPARE(output, trunc_size, hash->x, hash->len);
 
     /* Test again, for reset() */
     memset(output, 0x00, sizeof(output));
@@ -295,7 +295,7 @@ void md_hmac_multi(int md_type, int trunc_size, data_t *key_str,
     TEST_EQUAL(0, mbedtls_md_hmac_update(&ctx, src_str->x + halfway, src_str->len - halfway));
     TEST_EQUAL(0, mbedtls_md_hmac_finish(&ctx, output));
 
-    TEST_BUFFERS_EQUAL(output, trunc_size, hash->x, hash->len);
+    TEST_MEMORY_COMPARE(output, trunc_size, hash->x, hash->len);
 
 exit:
     mbedtls_md_free(&ctx);
@@ -314,6 +314,6 @@ void mbedtls_md_file(int md_type, char *filename,
 
     TEST_EQUAL(0, mbedtls_md_file(md_info, filename, output));
 
-    TEST_BUFFERS_EQUAL(output, mbedtls_md_get_size(md_info), hash->x, hash->len);
+    TEST_MEMORY_COMPARE(output, mbedtls_md_get_size(md_info), hash->x, hash->len);
 }
 /* END_CASE */

--- a/tests/suites/test_suite_mps.function
+++ b/tests/suites/test_suite_mps.function
@@ -60,7 +60,7 @@ void mbedtls_mps_reader_no_pausing_single_step_single_round(int with_acc)
     /* Consumption (upper layer) */
     /* Consume exactly what's available */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 100, &tmp, NULL) == 0);
-    TEST_BUFFERS_EQUAL(tmp, 100, bufA, 100);
+    TEST_MEMORY_COMPARE(tmp, 100, bufA, 100);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
     /* Wrapup (lower layer) */
     TEST_ASSERT(mbedtls_mps_reader_reclaim(&rd, &paused) == 0);
@@ -108,14 +108,14 @@ void mbedtls_mps_reader_no_pausing_single_step_multiple_rounds(int with_acc)
     /* Consumption (upper layer) */
     /* Consume exactly what's available */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 100, &tmp, NULL) == 0);
-    TEST_BUFFERS_EQUAL(tmp, 100, bufA, 100);
+    TEST_MEMORY_COMPARE(tmp, 100, bufA, 100);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
     /* Preparation */
     TEST_ASSERT(mbedtls_mps_reader_reclaim(&rd, NULL) == 0);
     TEST_ASSERT(mbedtls_mps_reader_feed(&rd, bufB, sizeof(bufB)) == 0);
     /* Consumption */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 100, &tmp, NULL) == 0);
-    TEST_BUFFERS_EQUAL(tmp, 100, bufB, 100);
+    TEST_MEMORY_COMPARE(tmp, 100, bufB, 100);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
     /* Wrapup (lower layer) */
     TEST_ASSERT(mbedtls_mps_reader_reclaim(&rd, NULL) == 0);
@@ -162,11 +162,11 @@ void mbedtls_mps_reader_no_pausing_multiple_steps_single_round(int with_acc)
     TEST_ASSERT(mbedtls_mps_reader_feed(&rd, buf, sizeof(buf)) == 0);
     /* Consumption (upper layer) */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 10, &tmp, NULL) == 0);
-    TEST_BUFFERS_EQUAL(tmp, 10, buf, 10);
+    TEST_MEMORY_COMPARE(tmp, 10, buf, 10);
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 70, &tmp, NULL) == 0);
-    TEST_BUFFERS_EQUAL(tmp, 70, buf + 10, 70);
+    TEST_MEMORY_COMPARE(tmp, 70, buf + 10, 70);
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 30, &tmp, &tmp_len) == 0);
-    TEST_BUFFERS_EQUAL(tmp, tmp_len, buf + 80, 20);
+    TEST_MEMORY_COMPARE(tmp, tmp_len, buf + 80, 20);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
     /* Wrapup (lower layer) */
     TEST_ASSERT(mbedtls_mps_reader_reclaim(&rd, NULL) == 0);
@@ -202,18 +202,18 @@ void mbedtls_mps_reader_no_pausing_multiple_steps_multiple_rounds(int with_acc)
     TEST_ASSERT(mbedtls_mps_reader_feed(&rd, bufA, sizeof(bufA)) == 0);
     /* Consumption (upper layer) */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 10, &tmp, NULL) == 0);
-    TEST_BUFFERS_EQUAL(tmp, 10, bufA, 10);
+    TEST_MEMORY_COMPARE(tmp, 10, bufA, 10);
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 70, &tmp, NULL) == 0);
-    TEST_BUFFERS_EQUAL(tmp, 70, bufA + 10, 70);
+    TEST_MEMORY_COMPARE(tmp, 70, bufA + 10, 70);
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 30, &tmp, &tmp_len) == 0);
-    TEST_BUFFERS_EQUAL(tmp, tmp_len, bufA + 80, 20);
+    TEST_MEMORY_COMPARE(tmp, tmp_len, bufA + 80, 20);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
     /* Preparation */
     TEST_ASSERT(mbedtls_mps_reader_reclaim(&rd, NULL) == 0);
     TEST_ASSERT(mbedtls_mps_reader_feed(&rd, bufB, sizeof(bufB)) == 0);
     /* Consumption */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 100, &tmp, NULL) == 0);
-    TEST_BUFFERS_EQUAL(tmp, 100, bufB, 100);
+    TEST_MEMORY_COMPARE(tmp, 100, bufB, 100);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
     /* Wrapup */
     TEST_ASSERT(mbedtls_mps_reader_reclaim(&rd, NULL) == 0);
@@ -243,7 +243,7 @@ void mbedtls_mps_reader_pausing_needed_disabled()
     TEST_ASSERT(mbedtls_mps_reader_feed(&rd, buf, sizeof(buf)) == 0);
     /* Consumption (upper layer) */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 50, &tmp, NULL) == 0);
-    TEST_BUFFERS_EQUAL(tmp, 50, buf, 50);
+    TEST_MEMORY_COMPARE(tmp, 50, buf, 50);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 100, &tmp, NULL) ==
                 MBEDTLS_ERR_MPS_READER_OUT_OF_DATA);
@@ -284,10 +284,10 @@ void mbedtls_mps_reader_pausing_needed_buffer_too_small()
     TEST_ASSERT(mbedtls_mps_reader_feed(&rd, buf, sizeof(buf)) == 0);
     /* Consumption (upper layer) */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 50, &tmp, NULL) == 0);
-    TEST_BUFFERS_EQUAL(tmp, 50, buf, 50);
+    TEST_MEMORY_COMPARE(tmp, 50, buf, 50);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 10, &tmp, NULL) == 0);
-    TEST_BUFFERS_EQUAL(tmp, 10, buf + 50, 10);
+    TEST_MEMORY_COMPARE(tmp, 10, buf + 50, 10);
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 100, &tmp, NULL) ==
                 MBEDTLS_ERR_MPS_READER_OUT_OF_DATA);
     /* Wrapup (lower layer) */
@@ -295,7 +295,7 @@ void mbedtls_mps_reader_pausing_needed_buffer_too_small()
                 MBEDTLS_ERR_MPS_READER_ACCUMULATOR_TOO_SMALL);
 
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 50, &tmp, &tmp_len) == 0);
-    TEST_BUFFERS_EQUAL(tmp, tmp_len, buf + 50, 50);
+    TEST_MEMORY_COMPARE(tmp, tmp_len, buf + 50, 50);
 
     mbedtls_mps_reader_free(&rd);
 }
@@ -325,7 +325,7 @@ void mbedtls_mps_reader_reclaim_overflow()
     TEST_ASSERT(mbedtls_mps_reader_feed(&rd, buf, sizeof(buf)) == 0);
     /* Consumption (upper layer) */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 50, &tmp, NULL) == 0);
-    TEST_BUFFERS_EQUAL(tmp, 50, buf, 50);
+    TEST_MEMORY_COMPARE(tmp, 50, buf, 50);
     /* Excess request */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, (mbedtls_mps_size_t) -1, &tmp, NULL) ==
                 MBEDTLS_ERR_MPS_READER_OUT_OF_DATA);
@@ -376,10 +376,10 @@ void mbedtls_mps_reader_pausing(int option)
     /* Consumption (upper layer) */
     /* Ask for more than what's available. */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 80, &tmp, NULL) == 0);
-    TEST_BUFFERS_EQUAL(tmp, 80, bufA, 80);
+    TEST_MEMORY_COMPARE(tmp, 80, bufA, 80);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 10, &tmp, NULL) == 0);
-    TEST_BUFFERS_EQUAL(tmp, 10, bufA + 80, 10);
+    TEST_MEMORY_COMPARE(tmp, 10, bufA + 80, 10);
     switch (option) {
         case 0:  /* Single uncommitted fetch at pausing */
         case 1:
@@ -400,50 +400,50 @@ void mbedtls_mps_reader_pausing(int option)
     switch (option) {
         case 0: /* Single fetch at pausing, re-fetch with commit. */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 20, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 90, 10);
-            TEST_BUFFERS_EQUAL(tmp + 10, 10, bufB, 10);
+            TEST_MEMORY_COMPARE(tmp, 10, bufA + 90, 10);
+            TEST_MEMORY_COMPARE(tmp + 10, 10, bufB, 10);
             TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
             break;
 
         case 1: /* Single fetch at pausing, re-fetch without commit. */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 20, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 90, 10);
-            TEST_BUFFERS_EQUAL(tmp + 10, 10, bufB, 10);
+            TEST_MEMORY_COMPARE(tmp, 10, bufA + 90, 10);
+            TEST_MEMORY_COMPARE(tmp + 10, 10, bufB, 10);
             break;
 
         case 2: /* Multiple fetches at pausing, repeat without commit. */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 10, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 80, 10);
+            TEST_MEMORY_COMPARE(tmp, 10, bufA + 80, 10);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 20, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 90, 10);
-            TEST_BUFFERS_EQUAL(tmp + 10, 10, bufB, 10);
+            TEST_MEMORY_COMPARE(tmp, 10, bufA + 90, 10);
+            TEST_MEMORY_COMPARE(tmp + 10, 10, bufB, 10);
             break;
 
         case 3: /* Multiple fetches at pausing, repeat with commit 1. */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 10, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 80, 10);
+            TEST_MEMORY_COMPARE(tmp, 10, bufA + 80, 10);
             TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 20, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 90, 10);
-            TEST_BUFFERS_EQUAL(tmp + 10, 10, bufB, 10);
+            TEST_MEMORY_COMPARE(tmp, 10, bufA + 90, 10);
+            TEST_MEMORY_COMPARE(tmp + 10, 10, bufB, 10);
             break;
 
         case 4: /* Multiple fetches at pausing, repeat with commit 2. */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 10, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 80, 10);
+            TEST_MEMORY_COMPARE(tmp, 10, bufA + 80, 10);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 20, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 90, 10);
-            TEST_BUFFERS_EQUAL(tmp + 10, 10, bufB, 10);
+            TEST_MEMORY_COMPARE(tmp, 10, bufA + 90, 10);
+            TEST_MEMORY_COMPARE(tmp + 10, 10, bufB, 10);
             TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
             break;
 
         case 5: /* Multiple fetches at pausing, repeat with commit 3. */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 10, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 80, 10);
+            TEST_MEMORY_COMPARE(tmp, 10, bufA + 80, 10);
             TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 20, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 90, 10);
-            TEST_BUFFERS_EQUAL(tmp + 10, 10, bufB, 10);
+            TEST_MEMORY_COMPARE(tmp, 10, bufA + 90, 10);
+            TEST_MEMORY_COMPARE(tmp + 10, 10, bufB, 10);
             TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
             break;
 
@@ -453,7 +453,7 @@ void mbedtls_mps_reader_pausing(int option)
 
     /* In all cases, fetch the rest of the second buffer. */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 90, &tmp, NULL) == 0);
-    TEST_BUFFERS_EQUAL(tmp, 90, bufB + 10, 90);
+    TEST_MEMORY_COMPARE(tmp, 90, bufB + 10, 90);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
 
     /* Wrapup */
@@ -498,7 +498,7 @@ void mbedtls_mps_reader_pausing_multiple_feeds(int option)
     /* Consumption (upper layer) */
     /* Ask for more than what's available. */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 80, &tmp, NULL) == 0);
-    TEST_BUFFERS_EQUAL(tmp, 80, bufA, 80);
+    TEST_MEMORY_COMPARE(tmp, 80, bufA, 80);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
     /* 20 left, ask for 70 -> 50 overhead */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 70, &tmp, NULL) ==
@@ -538,8 +538,8 @@ void mbedtls_mps_reader_pausing_multiple_feeds(int option)
 
     /* Consumption */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 70, &tmp, NULL) == 0);
-    TEST_BUFFERS_EQUAL(tmp, 20, bufA + 80, 20);
-    TEST_BUFFERS_EQUAL(tmp + 20, 50, bufB, 50);
+    TEST_MEMORY_COMPARE(tmp, 20, bufA + 80, 20);
+    TEST_MEMORY_COMPARE(tmp + 20, 50, bufB, 50);
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 1000, &tmp, &fetch_len) == 0);
     switch (option) {
         case 0:
@@ -591,14 +591,14 @@ void mbedtls_mps_reader_reclaim_data_left(int option)
             /* Fetch (but not commit) the entire buffer. */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, sizeof(buf), &tmp, NULL)
                         == 0);
-            TEST_BUFFERS_EQUAL(tmp, 100, buf, 100);
+            TEST_MEMORY_COMPARE(tmp, 100, buf, 100);
             break;
 
         case 1:
             /* Fetch (but not commit) parts of the buffer. */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, sizeof(buf) / 2,
                                                &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, sizeof(buf) / 2, buf, sizeof(buf) / 2);
+            TEST_MEMORY_COMPARE(tmp, sizeof(buf) / 2, buf, sizeof(buf) / 2);
             break;
 
         case 2:
@@ -606,11 +606,11 @@ void mbedtls_mps_reader_reclaim_data_left(int option)
              * fetch but not commit the rest of the buffer. */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, sizeof(buf) / 2,
                                                &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, sizeof(buf) / 2, buf, sizeof(buf) / 2);
+            TEST_MEMORY_COMPARE(tmp, sizeof(buf) / 2, buf, sizeof(buf) / 2);
             TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, sizeof(buf) / 2,
                                                &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, sizeof(buf) / 2,
+            TEST_MEMORY_COMPARE(tmp, sizeof(buf) / 2,
                            buf + sizeof(buf) / 2,
                            sizeof(buf) / 2);
             break;
@@ -646,16 +646,16 @@ void mbedtls_mps_reader_reclaim_data_left_retry()
     TEST_ASSERT(mbedtls_mps_reader_feed(&rd, buf, sizeof(buf)) == 0);
     /* Consumption (upper layer) */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 50, &tmp, NULL) == 0);
-    TEST_BUFFERS_EQUAL(tmp, 50, buf, 50);
+    TEST_MEMORY_COMPARE(tmp, 50, buf, 50);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 50, &tmp, NULL) == 0);
-    TEST_BUFFERS_EQUAL(tmp, 50, buf + 50, 50);
+    TEST_MEMORY_COMPARE(tmp, 50, buf + 50, 50);
     /* Preparation */
     TEST_ASSERT(mbedtls_mps_reader_reclaim(&rd, NULL) ==
                 MBEDTLS_ERR_MPS_READER_DATA_LEFT);
     /* Consumption */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 50, &tmp, NULL) == 0);
-    TEST_BUFFERS_EQUAL(tmp, 50, buf + 50, 50);
+    TEST_MEMORY_COMPARE(tmp, 50, buf + 50, 50);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
     /* Wrapup */
     TEST_ASSERT(mbedtls_mps_reader_reclaim(&rd, NULL) == 0);
@@ -699,10 +699,10 @@ void mbedtls_mps_reader_multiple_pausing(int option)
     /* Consumption (upper layer) */
     /* Ask for more than what's available. */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 80, &tmp, NULL) == 0);
-    TEST_BUFFERS_EQUAL(tmp, 80, bufA, 80);
+    TEST_MEMORY_COMPARE(tmp, 80, bufA, 80);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 10, &tmp, NULL) == 0);
-    TEST_BUFFERS_EQUAL(tmp, 10, bufA + 80, 10);
+    TEST_MEMORY_COMPARE(tmp, 10, bufA + 80, 10);
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 20, &tmp, NULL) ==
                 MBEDTLS_ERR_MPS_READER_OUT_OF_DATA);
 
@@ -717,10 +717,10 @@ void mbedtls_mps_reader_multiple_pausing(int option)
 
             /* Consume */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 10, &tmp, &tmp_len) == 0);
-            TEST_BUFFERS_EQUAL(tmp, tmp_len, bufA + 80, 10);
+            TEST_MEMORY_COMPARE(tmp, tmp_len, bufA + 80, 10);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 20, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 90, 10);
-            TEST_BUFFERS_EQUAL(tmp + 10, 10, bufB, 10);
+            TEST_MEMORY_COMPARE(tmp, 10, bufA + 90, 10);
+            TEST_MEMORY_COMPARE(tmp + 10, 10, bufB, 10);
             TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 20, &tmp, NULL) ==
                         MBEDTLS_ERR_MPS_READER_OUT_OF_DATA);
@@ -731,18 +731,18 @@ void mbedtls_mps_reader_multiple_pausing(int option)
 
             /* Consume */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 20, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 10, bufB + 10, 10);
-            TEST_BUFFERS_EQUAL(tmp + 10, 10, bufC, 10);
+            TEST_MEMORY_COMPARE(tmp, 10, bufB + 10, 10);
+            TEST_MEMORY_COMPARE(tmp + 10, 10, bufC, 10);
             break;
 
         case 1: /* Fetch same chunks, commit afterwards, and
                  * then exceed bounds of new buffer; accumulator
                  * not large enough. */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 10, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 80, 10);
+            TEST_MEMORY_COMPARE(tmp, 10, bufA + 80, 10);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 20, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 90, 10);
-            TEST_BUFFERS_EQUAL(tmp + 10, 10, bufB, 10);
+            TEST_MEMORY_COMPARE(tmp, 10, bufA + 90, 10);
+            TEST_MEMORY_COMPARE(tmp + 10, 10, bufB, 10);
             TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 51, &tmp, NULL) ==
                         MBEDTLS_ERR_MPS_READER_OUT_OF_DATA);
@@ -756,10 +756,10 @@ void mbedtls_mps_reader_multiple_pausing(int option)
                  * then exceed bounds of new buffer; accumulator
                  * large enough. */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 10, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 80, 10);
+            TEST_MEMORY_COMPARE(tmp, 10, bufA + 80, 10);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 20, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 90, 10);
-            TEST_BUFFERS_EQUAL(tmp + 10, 10, bufB, 10);
+            TEST_MEMORY_COMPARE(tmp, 10, bufA + 90, 10);
+            TEST_MEMORY_COMPARE(tmp + 10, 10, bufB, 10);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 20, &tmp, NULL) ==
                         MBEDTLS_ERR_MPS_READER_OUT_OF_DATA);
 
@@ -769,19 +769,19 @@ void mbedtls_mps_reader_multiple_pausing(int option)
 
             /* Consume */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 50, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 20, bufA + 80, 20);
-            TEST_BUFFERS_EQUAL(tmp + 20, 20, bufB, 20);
-            TEST_BUFFERS_EQUAL(tmp + 40, 10, bufC, 10);
+            TEST_MEMORY_COMPARE(tmp, 20, bufA + 80, 20);
+            TEST_MEMORY_COMPARE(tmp + 20, 20, bufB, 20);
+            TEST_MEMORY_COMPARE(tmp + 40, 10, bufC, 10);
             break;
 
         case 3: /* Fetch same chunks, don't commit afterwards, and
                  * then exceed bounds of new buffer; accumulator
                  * not large enough. */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 10, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 80, 10);
+            TEST_MEMORY_COMPARE(tmp, 10, bufA + 80, 10);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 20, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 90, 10);
-            TEST_BUFFERS_EQUAL(tmp + 10, 10, bufB, 10);
+            TEST_MEMORY_COMPARE(tmp, 10, bufA + 90, 10);
+            TEST_MEMORY_COMPARE(tmp + 10, 10, bufB, 10);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 21, &tmp, NULL) ==
                         MBEDTLS_ERR_MPS_READER_OUT_OF_DATA);
 
@@ -1005,16 +1005,16 @@ void mbedtls_reader_inconsistent_usage(int option)
         case 0:
             /* Ask for buffered data in a single chunk, no commit */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 30, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 20, bufA + 80, 20);
-            TEST_BUFFERS_EQUAL(tmp + 20, 10, bufB, 10);
+            TEST_MEMORY_COMPARE(tmp, 20, bufA + 80, 20);
+            TEST_MEMORY_COMPARE(tmp + 20, 10, bufB, 10);
             success = 1;
             break;
 
         case 1:
             /* Ask for buffered data in a single chunk, with commit */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 30, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 20, bufA + 80, 20);
-            TEST_BUFFERS_EQUAL(tmp + 20, 10, bufB, 10);
+            TEST_MEMORY_COMPARE(tmp, 20, bufA + 80, 20);
+            TEST_MEMORY_COMPARE(tmp + 20, 10, bufB, 10);
             TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
             success = 1;
             break;
@@ -1035,7 +1035,7 @@ void mbedtls_reader_inconsistent_usage(int option)
             /* Asking for buffered data in different
              * chunks than before CAN fail. */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 15, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 15, bufA + 80, 15);
+            TEST_MEMORY_COMPARE(tmp, 15, bufA + 80, 15);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 10, &tmp, NULL) ==
                         MBEDTLS_ERR_MPS_READER_INCONSISTENT_REQUESTS);
             break;
@@ -1044,10 +1044,10 @@ void mbedtls_reader_inconsistent_usage(int option)
             /* Asking for buffered data different chunks
              * than before NEED NOT fail - no commits */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 15, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 15, bufA + 80, 15);
+            TEST_MEMORY_COMPARE(tmp, 15, bufA + 80, 15);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 15, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 5, bufA + 95, 5);
-            TEST_BUFFERS_EQUAL(tmp + 5, 10, bufB, 10);
+            TEST_MEMORY_COMPARE(tmp, 5, bufA + 95, 5);
+            TEST_MEMORY_COMPARE(tmp + 5, 10, bufB, 10);
             success = 1;
             break;
 
@@ -1055,11 +1055,11 @@ void mbedtls_reader_inconsistent_usage(int option)
             /* Asking for buffered data different chunks
              * than before NEED NOT fail - intermediate commit */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 15, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 15, bufA + 80, 15);
+            TEST_MEMORY_COMPARE(tmp, 15, bufA + 80, 15);
             TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 15, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 5, bufA + 95, 5);
-            TEST_BUFFERS_EQUAL(tmp + 5, 10, bufB, 10);
+            TEST_MEMORY_COMPARE(tmp, 5, bufA + 95, 5);
+            TEST_MEMORY_COMPARE(tmp + 5, 10, bufB, 10);
             success = 1;
             break;
 
@@ -1067,10 +1067,10 @@ void mbedtls_reader_inconsistent_usage(int option)
             /* Asking for buffered data different chunks
              * than before NEED NOT fail - end commit */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 15, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 15, bufA + 80, 15);
+            TEST_MEMORY_COMPARE(tmp, 15, bufA + 80, 15);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 15, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 5, bufA + 95, 5);
-            TEST_BUFFERS_EQUAL(tmp + 5, 10, bufB, 10);
+            TEST_MEMORY_COMPARE(tmp, 5, bufA + 95, 5);
+            TEST_MEMORY_COMPARE(tmp + 5, 10, bufB, 10);
             TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
             success = 1;
             break;
@@ -1079,11 +1079,11 @@ void mbedtls_reader_inconsistent_usage(int option)
             /* Asking for buffered data different chunks
              * than before NEED NOT fail - intermediate & end commit */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 15, &tmp, NULL) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 15, bufA + 80, 15);
+            TEST_MEMORY_COMPARE(tmp, 15, bufA + 80, 15);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 15, &tmp, NULL) == 0);
             TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
-            TEST_BUFFERS_EQUAL(tmp, 5, bufA + 95, 5);
-            TEST_BUFFERS_EQUAL(tmp + 5, 10, bufB, 10);
+            TEST_MEMORY_COMPARE(tmp, 5, bufA + 95, 5);
+            TEST_MEMORY_COMPARE(tmp + 5, 10, bufB, 10);
             TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
             success = 1;
             break;
@@ -1096,7 +1096,7 @@ void mbedtls_reader_inconsistent_usage(int option)
     if (success == 1) {
         /* In all succeeding cases, fetch the rest of the second buffer. */
         TEST_ASSERT(mbedtls_mps_reader_get(&rd, 90, &tmp, NULL) == 0);
-        TEST_BUFFERS_EQUAL(tmp, 90, bufB + 10, 90);
+        TEST_MEMORY_COMPARE(tmp, 90, bufB + 10, 90);
         TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
 
         /* Wrapup */
@@ -1131,7 +1131,7 @@ void mbedtls_mps_reader_feed_empty()
 
     /* Consumption (upper layer) */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 100, &tmp, NULL) == 0);
-    TEST_BUFFERS_EQUAL(tmp, 100, buf, 100);
+    TEST_MEMORY_COMPARE(tmp, 100, buf, 100);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
 
     /* Wrapup */

--- a/tests/suites/test_suite_mps.function
+++ b/tests/suites/test_suite_mps.function
@@ -844,15 +844,15 @@ void mbedtls_mps_reader_random_usage(int num_out_chunks,
     mbedtls_mps_reader rd;
 
     if (acc_size > 0) {
-        TEST_CALLOC_OR_FAIL(acc, acc_size);
+        TEST_CALLOC(acc, acc_size);
     }
 
     /* This probably needs to be changed because we want
      * our tests to be deterministic. */
     //    srand( time( NULL ) );
 
-    TEST_CALLOC_OR_FAIL(outgoing, num_out_chunks * max_chunk_size);
-    TEST_CALLOC_OR_FAIL(incoming, num_out_chunks * max_chunk_size);
+    TEST_CALLOC(outgoing, num_out_chunks * max_chunk_size);
+    TEST_CALLOC(incoming, num_out_chunks * max_chunk_size);
 
     mbedtls_mps_reader_init(&rd, acc, acc_size);
 
@@ -884,7 +884,7 @@ void mbedtls_mps_reader_random_usage(int num_out_chunks,
                 }
 
                 tmp_size = (rand() % max_chunk_size) + 1;
-                TEST_CALLOC_OR_FAIL(tmp, tmp_size);
+                TEST_CALLOC(tmp, tmp_size);
 
                 TEST_ASSERT(mbedtls_test_rnd_std_rand(NULL, tmp, tmp_size) == 0);
                 ret = mbedtls_mps_reader_feed(&rd, tmp, tmp_size);

--- a/tests/suites/test_suite_mps.function
+++ b/tests/suites/test_suite_mps.function
@@ -611,8 +611,8 @@ void mbedtls_mps_reader_reclaim_data_left(int option)
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, sizeof(buf) / 2,
                                                &tmp, NULL) == 0);
             TEST_MEMORY_COMPARE(tmp, sizeof(buf) / 2,
-                           buf + sizeof(buf) / 2,
-                           sizeof(buf) / 2);
+                                buf + sizeof(buf) / 2,
+                                sizeof(buf) / 2);
             break;
 
         default:

--- a/tests/suites/test_suite_mps.function
+++ b/tests/suites/test_suite_mps.function
@@ -60,7 +60,7 @@ void mbedtls_mps_reader_no_pausing_single_step_single_round(int with_acc)
     /* Consumption (upper layer) */
     /* Consume exactly what's available */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 100, &tmp, NULL) == 0);
-    ASSERT_COMPARE(tmp, 100, bufA, 100);
+    TEST_BUFFERS_EQUAL(tmp, 100, bufA, 100);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
     /* Wrapup (lower layer) */
     TEST_ASSERT(mbedtls_mps_reader_reclaim(&rd, &paused) == 0);
@@ -108,14 +108,14 @@ void mbedtls_mps_reader_no_pausing_single_step_multiple_rounds(int with_acc)
     /* Consumption (upper layer) */
     /* Consume exactly what's available */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 100, &tmp, NULL) == 0);
-    ASSERT_COMPARE(tmp, 100, bufA, 100);
+    TEST_BUFFERS_EQUAL(tmp, 100, bufA, 100);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
     /* Preparation */
     TEST_ASSERT(mbedtls_mps_reader_reclaim(&rd, NULL) == 0);
     TEST_ASSERT(mbedtls_mps_reader_feed(&rd, bufB, sizeof(bufB)) == 0);
     /* Consumption */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 100, &tmp, NULL) == 0);
-    ASSERT_COMPARE(tmp, 100, bufB, 100);
+    TEST_BUFFERS_EQUAL(tmp, 100, bufB, 100);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
     /* Wrapup (lower layer) */
     TEST_ASSERT(mbedtls_mps_reader_reclaim(&rd, NULL) == 0);
@@ -162,11 +162,11 @@ void mbedtls_mps_reader_no_pausing_multiple_steps_single_round(int with_acc)
     TEST_ASSERT(mbedtls_mps_reader_feed(&rd, buf, sizeof(buf)) == 0);
     /* Consumption (upper layer) */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 10, &tmp, NULL) == 0);
-    ASSERT_COMPARE(tmp, 10, buf, 10);
+    TEST_BUFFERS_EQUAL(tmp, 10, buf, 10);
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 70, &tmp, NULL) == 0);
-    ASSERT_COMPARE(tmp, 70, buf + 10, 70);
+    TEST_BUFFERS_EQUAL(tmp, 70, buf + 10, 70);
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 30, &tmp, &tmp_len) == 0);
-    ASSERT_COMPARE(tmp, tmp_len, buf + 80, 20);
+    TEST_BUFFERS_EQUAL(tmp, tmp_len, buf + 80, 20);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
     /* Wrapup (lower layer) */
     TEST_ASSERT(mbedtls_mps_reader_reclaim(&rd, NULL) == 0);
@@ -202,18 +202,18 @@ void mbedtls_mps_reader_no_pausing_multiple_steps_multiple_rounds(int with_acc)
     TEST_ASSERT(mbedtls_mps_reader_feed(&rd, bufA, sizeof(bufA)) == 0);
     /* Consumption (upper layer) */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 10, &tmp, NULL) == 0);
-    ASSERT_COMPARE(tmp, 10, bufA, 10);
+    TEST_BUFFERS_EQUAL(tmp, 10, bufA, 10);
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 70, &tmp, NULL) == 0);
-    ASSERT_COMPARE(tmp, 70, bufA + 10, 70);
+    TEST_BUFFERS_EQUAL(tmp, 70, bufA + 10, 70);
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 30, &tmp, &tmp_len) == 0);
-    ASSERT_COMPARE(tmp, tmp_len, bufA + 80, 20);
+    TEST_BUFFERS_EQUAL(tmp, tmp_len, bufA + 80, 20);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
     /* Preparation */
     TEST_ASSERT(mbedtls_mps_reader_reclaim(&rd, NULL) == 0);
     TEST_ASSERT(mbedtls_mps_reader_feed(&rd, bufB, sizeof(bufB)) == 0);
     /* Consumption */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 100, &tmp, NULL) == 0);
-    ASSERT_COMPARE(tmp, 100, bufB, 100);
+    TEST_BUFFERS_EQUAL(tmp, 100, bufB, 100);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
     /* Wrapup */
     TEST_ASSERT(mbedtls_mps_reader_reclaim(&rd, NULL) == 0);
@@ -243,7 +243,7 @@ void mbedtls_mps_reader_pausing_needed_disabled()
     TEST_ASSERT(mbedtls_mps_reader_feed(&rd, buf, sizeof(buf)) == 0);
     /* Consumption (upper layer) */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 50, &tmp, NULL) == 0);
-    ASSERT_COMPARE(tmp, 50, buf, 50);
+    TEST_BUFFERS_EQUAL(tmp, 50, buf, 50);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 100, &tmp, NULL) ==
                 MBEDTLS_ERR_MPS_READER_OUT_OF_DATA);
@@ -284,10 +284,10 @@ void mbedtls_mps_reader_pausing_needed_buffer_too_small()
     TEST_ASSERT(mbedtls_mps_reader_feed(&rd, buf, sizeof(buf)) == 0);
     /* Consumption (upper layer) */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 50, &tmp, NULL) == 0);
-    ASSERT_COMPARE(tmp, 50, buf, 50);
+    TEST_BUFFERS_EQUAL(tmp, 50, buf, 50);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 10, &tmp, NULL) == 0);
-    ASSERT_COMPARE(tmp, 10, buf + 50, 10);
+    TEST_BUFFERS_EQUAL(tmp, 10, buf + 50, 10);
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 100, &tmp, NULL) ==
                 MBEDTLS_ERR_MPS_READER_OUT_OF_DATA);
     /* Wrapup (lower layer) */
@@ -295,7 +295,7 @@ void mbedtls_mps_reader_pausing_needed_buffer_too_small()
                 MBEDTLS_ERR_MPS_READER_ACCUMULATOR_TOO_SMALL);
 
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 50, &tmp, &tmp_len) == 0);
-    ASSERT_COMPARE(tmp, tmp_len, buf + 50, 50);
+    TEST_BUFFERS_EQUAL(tmp, tmp_len, buf + 50, 50);
 
     mbedtls_mps_reader_free(&rd);
 }
@@ -325,7 +325,7 @@ void mbedtls_mps_reader_reclaim_overflow()
     TEST_ASSERT(mbedtls_mps_reader_feed(&rd, buf, sizeof(buf)) == 0);
     /* Consumption (upper layer) */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 50, &tmp, NULL) == 0);
-    ASSERT_COMPARE(tmp, 50, buf, 50);
+    TEST_BUFFERS_EQUAL(tmp, 50, buf, 50);
     /* Excess request */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, (mbedtls_mps_size_t) -1, &tmp, NULL) ==
                 MBEDTLS_ERR_MPS_READER_OUT_OF_DATA);
@@ -376,10 +376,10 @@ void mbedtls_mps_reader_pausing(int option)
     /* Consumption (upper layer) */
     /* Ask for more than what's available. */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 80, &tmp, NULL) == 0);
-    ASSERT_COMPARE(tmp, 80, bufA, 80);
+    TEST_BUFFERS_EQUAL(tmp, 80, bufA, 80);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 10, &tmp, NULL) == 0);
-    ASSERT_COMPARE(tmp, 10, bufA + 80, 10);
+    TEST_BUFFERS_EQUAL(tmp, 10, bufA + 80, 10);
     switch (option) {
         case 0:  /* Single uncommitted fetch at pausing */
         case 1:
@@ -400,50 +400,50 @@ void mbedtls_mps_reader_pausing(int option)
     switch (option) {
         case 0: /* Single fetch at pausing, re-fetch with commit. */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 20, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 10, bufA + 90, 10);
-            ASSERT_COMPARE(tmp + 10, 10, bufB, 10);
+            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 90, 10);
+            TEST_BUFFERS_EQUAL(tmp + 10, 10, bufB, 10);
             TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
             break;
 
         case 1: /* Single fetch at pausing, re-fetch without commit. */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 20, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 10, bufA + 90, 10);
-            ASSERT_COMPARE(tmp + 10, 10, bufB, 10);
+            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 90, 10);
+            TEST_BUFFERS_EQUAL(tmp + 10, 10, bufB, 10);
             break;
 
         case 2: /* Multiple fetches at pausing, repeat without commit. */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 10, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 10, bufA + 80, 10);
+            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 80, 10);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 20, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 10, bufA + 90, 10);
-            ASSERT_COMPARE(tmp + 10, 10, bufB, 10);
+            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 90, 10);
+            TEST_BUFFERS_EQUAL(tmp + 10, 10, bufB, 10);
             break;
 
         case 3: /* Multiple fetches at pausing, repeat with commit 1. */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 10, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 10, bufA + 80, 10);
+            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 80, 10);
             TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 20, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 10, bufA + 90, 10);
-            ASSERT_COMPARE(tmp + 10, 10, bufB, 10);
+            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 90, 10);
+            TEST_BUFFERS_EQUAL(tmp + 10, 10, bufB, 10);
             break;
 
         case 4: /* Multiple fetches at pausing, repeat with commit 2. */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 10, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 10, bufA + 80, 10);
+            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 80, 10);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 20, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 10, bufA + 90, 10);
-            ASSERT_COMPARE(tmp + 10, 10, bufB, 10);
+            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 90, 10);
+            TEST_BUFFERS_EQUAL(tmp + 10, 10, bufB, 10);
             TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
             break;
 
         case 5: /* Multiple fetches at pausing, repeat with commit 3. */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 10, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 10, bufA + 80, 10);
+            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 80, 10);
             TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 20, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 10, bufA + 90, 10);
-            ASSERT_COMPARE(tmp + 10, 10, bufB, 10);
+            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 90, 10);
+            TEST_BUFFERS_EQUAL(tmp + 10, 10, bufB, 10);
             TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
             break;
 
@@ -453,7 +453,7 @@ void mbedtls_mps_reader_pausing(int option)
 
     /* In all cases, fetch the rest of the second buffer. */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 90, &tmp, NULL) == 0);
-    ASSERT_COMPARE(tmp, 90, bufB + 10, 90);
+    TEST_BUFFERS_EQUAL(tmp, 90, bufB + 10, 90);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
 
     /* Wrapup */
@@ -498,7 +498,7 @@ void mbedtls_mps_reader_pausing_multiple_feeds(int option)
     /* Consumption (upper layer) */
     /* Ask for more than what's available. */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 80, &tmp, NULL) == 0);
-    ASSERT_COMPARE(tmp, 80, bufA, 80);
+    TEST_BUFFERS_EQUAL(tmp, 80, bufA, 80);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
     /* 20 left, ask for 70 -> 50 overhead */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 70, &tmp, NULL) ==
@@ -538,8 +538,8 @@ void mbedtls_mps_reader_pausing_multiple_feeds(int option)
 
     /* Consumption */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 70, &tmp, NULL) == 0);
-    ASSERT_COMPARE(tmp, 20, bufA + 80, 20);
-    ASSERT_COMPARE(tmp + 20, 50, bufB, 50);
+    TEST_BUFFERS_EQUAL(tmp, 20, bufA + 80, 20);
+    TEST_BUFFERS_EQUAL(tmp + 20, 50, bufB, 50);
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 1000, &tmp, &fetch_len) == 0);
     switch (option) {
         case 0:
@@ -591,14 +591,14 @@ void mbedtls_mps_reader_reclaim_data_left(int option)
             /* Fetch (but not commit) the entire buffer. */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, sizeof(buf), &tmp, NULL)
                         == 0);
-            ASSERT_COMPARE(tmp, 100, buf, 100);
+            TEST_BUFFERS_EQUAL(tmp, 100, buf, 100);
             break;
 
         case 1:
             /* Fetch (but not commit) parts of the buffer. */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, sizeof(buf) / 2,
                                                &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, sizeof(buf) / 2, buf, sizeof(buf) / 2);
+            TEST_BUFFERS_EQUAL(tmp, sizeof(buf) / 2, buf, sizeof(buf) / 2);
             break;
 
         case 2:
@@ -606,11 +606,11 @@ void mbedtls_mps_reader_reclaim_data_left(int option)
              * fetch but not commit the rest of the buffer. */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, sizeof(buf) / 2,
                                                &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, sizeof(buf) / 2, buf, sizeof(buf) / 2);
+            TEST_BUFFERS_EQUAL(tmp, sizeof(buf) / 2, buf, sizeof(buf) / 2);
             TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, sizeof(buf) / 2,
                                                &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, sizeof(buf) / 2,
+            TEST_BUFFERS_EQUAL(tmp, sizeof(buf) / 2,
                            buf + sizeof(buf) / 2,
                            sizeof(buf) / 2);
             break;
@@ -646,16 +646,16 @@ void mbedtls_mps_reader_reclaim_data_left_retry()
     TEST_ASSERT(mbedtls_mps_reader_feed(&rd, buf, sizeof(buf)) == 0);
     /* Consumption (upper layer) */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 50, &tmp, NULL) == 0);
-    ASSERT_COMPARE(tmp, 50, buf, 50);
+    TEST_BUFFERS_EQUAL(tmp, 50, buf, 50);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 50, &tmp, NULL) == 0);
-    ASSERT_COMPARE(tmp, 50, buf + 50, 50);
+    TEST_BUFFERS_EQUAL(tmp, 50, buf + 50, 50);
     /* Preparation */
     TEST_ASSERT(mbedtls_mps_reader_reclaim(&rd, NULL) ==
                 MBEDTLS_ERR_MPS_READER_DATA_LEFT);
     /* Consumption */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 50, &tmp, NULL) == 0);
-    ASSERT_COMPARE(tmp, 50, buf + 50, 50);
+    TEST_BUFFERS_EQUAL(tmp, 50, buf + 50, 50);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
     /* Wrapup */
     TEST_ASSERT(mbedtls_mps_reader_reclaim(&rd, NULL) == 0);
@@ -699,10 +699,10 @@ void mbedtls_mps_reader_multiple_pausing(int option)
     /* Consumption (upper layer) */
     /* Ask for more than what's available. */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 80, &tmp, NULL) == 0);
-    ASSERT_COMPARE(tmp, 80, bufA, 80);
+    TEST_BUFFERS_EQUAL(tmp, 80, bufA, 80);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 10, &tmp, NULL) == 0);
-    ASSERT_COMPARE(tmp, 10, bufA + 80, 10);
+    TEST_BUFFERS_EQUAL(tmp, 10, bufA + 80, 10);
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 20, &tmp, NULL) ==
                 MBEDTLS_ERR_MPS_READER_OUT_OF_DATA);
 
@@ -717,10 +717,10 @@ void mbedtls_mps_reader_multiple_pausing(int option)
 
             /* Consume */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 10, &tmp, &tmp_len) == 0);
-            ASSERT_COMPARE(tmp, tmp_len, bufA + 80, 10);
+            TEST_BUFFERS_EQUAL(tmp, tmp_len, bufA + 80, 10);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 20, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 10, bufA + 90, 10);
-            ASSERT_COMPARE(tmp + 10, 10, bufB, 10);
+            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 90, 10);
+            TEST_BUFFERS_EQUAL(tmp + 10, 10, bufB, 10);
             TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 20, &tmp, NULL) ==
                         MBEDTLS_ERR_MPS_READER_OUT_OF_DATA);
@@ -731,18 +731,18 @@ void mbedtls_mps_reader_multiple_pausing(int option)
 
             /* Consume */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 20, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 10, bufB + 10, 10);
-            ASSERT_COMPARE(tmp + 10, 10, bufC, 10);
+            TEST_BUFFERS_EQUAL(tmp, 10, bufB + 10, 10);
+            TEST_BUFFERS_EQUAL(tmp + 10, 10, bufC, 10);
             break;
 
         case 1: /* Fetch same chunks, commit afterwards, and
                  * then exceed bounds of new buffer; accumulator
                  * not large enough. */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 10, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 10, bufA + 80, 10);
+            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 80, 10);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 20, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 10, bufA + 90, 10);
-            ASSERT_COMPARE(tmp + 10, 10, bufB, 10);
+            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 90, 10);
+            TEST_BUFFERS_EQUAL(tmp + 10, 10, bufB, 10);
             TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 51, &tmp, NULL) ==
                         MBEDTLS_ERR_MPS_READER_OUT_OF_DATA);
@@ -756,10 +756,10 @@ void mbedtls_mps_reader_multiple_pausing(int option)
                  * then exceed bounds of new buffer; accumulator
                  * large enough. */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 10, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 10, bufA + 80, 10);
+            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 80, 10);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 20, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 10, bufA + 90, 10);
-            ASSERT_COMPARE(tmp + 10, 10, bufB, 10);
+            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 90, 10);
+            TEST_BUFFERS_EQUAL(tmp + 10, 10, bufB, 10);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 20, &tmp, NULL) ==
                         MBEDTLS_ERR_MPS_READER_OUT_OF_DATA);
 
@@ -769,19 +769,19 @@ void mbedtls_mps_reader_multiple_pausing(int option)
 
             /* Consume */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 50, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 20, bufA + 80, 20);
-            ASSERT_COMPARE(tmp + 20, 20, bufB, 20);
-            ASSERT_COMPARE(tmp + 40, 10, bufC, 10);
+            TEST_BUFFERS_EQUAL(tmp, 20, bufA + 80, 20);
+            TEST_BUFFERS_EQUAL(tmp + 20, 20, bufB, 20);
+            TEST_BUFFERS_EQUAL(tmp + 40, 10, bufC, 10);
             break;
 
         case 3: /* Fetch same chunks, don't commit afterwards, and
                  * then exceed bounds of new buffer; accumulator
                  * not large enough. */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 10, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 10, bufA + 80, 10);
+            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 80, 10);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 20, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 10, bufA + 90, 10);
-            ASSERT_COMPARE(tmp + 10, 10, bufB, 10);
+            TEST_BUFFERS_EQUAL(tmp, 10, bufA + 90, 10);
+            TEST_BUFFERS_EQUAL(tmp + 10, 10, bufB, 10);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 21, &tmp, NULL) ==
                         MBEDTLS_ERR_MPS_READER_OUT_OF_DATA);
 
@@ -1005,16 +1005,16 @@ void mbedtls_reader_inconsistent_usage(int option)
         case 0:
             /* Ask for buffered data in a single chunk, no commit */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 30, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 20, bufA + 80, 20);
-            ASSERT_COMPARE(tmp + 20, 10, bufB, 10);
+            TEST_BUFFERS_EQUAL(tmp, 20, bufA + 80, 20);
+            TEST_BUFFERS_EQUAL(tmp + 20, 10, bufB, 10);
             success = 1;
             break;
 
         case 1:
             /* Ask for buffered data in a single chunk, with commit */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 30, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 20, bufA + 80, 20);
-            ASSERT_COMPARE(tmp + 20, 10, bufB, 10);
+            TEST_BUFFERS_EQUAL(tmp, 20, bufA + 80, 20);
+            TEST_BUFFERS_EQUAL(tmp + 20, 10, bufB, 10);
             TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
             success = 1;
             break;
@@ -1035,7 +1035,7 @@ void mbedtls_reader_inconsistent_usage(int option)
             /* Asking for buffered data in different
              * chunks than before CAN fail. */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 15, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 15, bufA + 80, 15);
+            TEST_BUFFERS_EQUAL(tmp, 15, bufA + 80, 15);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 10, &tmp, NULL) ==
                         MBEDTLS_ERR_MPS_READER_INCONSISTENT_REQUESTS);
             break;
@@ -1044,10 +1044,10 @@ void mbedtls_reader_inconsistent_usage(int option)
             /* Asking for buffered data different chunks
              * than before NEED NOT fail - no commits */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 15, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 15, bufA + 80, 15);
+            TEST_BUFFERS_EQUAL(tmp, 15, bufA + 80, 15);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 15, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 5, bufA + 95, 5);
-            ASSERT_COMPARE(tmp + 5, 10, bufB, 10);
+            TEST_BUFFERS_EQUAL(tmp, 5, bufA + 95, 5);
+            TEST_BUFFERS_EQUAL(tmp + 5, 10, bufB, 10);
             success = 1;
             break;
 
@@ -1055,11 +1055,11 @@ void mbedtls_reader_inconsistent_usage(int option)
             /* Asking for buffered data different chunks
              * than before NEED NOT fail - intermediate commit */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 15, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 15, bufA + 80, 15);
+            TEST_BUFFERS_EQUAL(tmp, 15, bufA + 80, 15);
             TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 15, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 5, bufA + 95, 5);
-            ASSERT_COMPARE(tmp + 5, 10, bufB, 10);
+            TEST_BUFFERS_EQUAL(tmp, 5, bufA + 95, 5);
+            TEST_BUFFERS_EQUAL(tmp + 5, 10, bufB, 10);
             success = 1;
             break;
 
@@ -1067,10 +1067,10 @@ void mbedtls_reader_inconsistent_usage(int option)
             /* Asking for buffered data different chunks
              * than before NEED NOT fail - end commit */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 15, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 15, bufA + 80, 15);
+            TEST_BUFFERS_EQUAL(tmp, 15, bufA + 80, 15);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 15, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 5, bufA + 95, 5);
-            ASSERT_COMPARE(tmp + 5, 10, bufB, 10);
+            TEST_BUFFERS_EQUAL(tmp, 5, bufA + 95, 5);
+            TEST_BUFFERS_EQUAL(tmp + 5, 10, bufB, 10);
             TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
             success = 1;
             break;
@@ -1079,11 +1079,11 @@ void mbedtls_reader_inconsistent_usage(int option)
             /* Asking for buffered data different chunks
              * than before NEED NOT fail - intermediate & end commit */
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 15, &tmp, NULL) == 0);
-            ASSERT_COMPARE(tmp, 15, bufA + 80, 15);
+            TEST_BUFFERS_EQUAL(tmp, 15, bufA + 80, 15);
             TEST_ASSERT(mbedtls_mps_reader_get(&rd, 15, &tmp, NULL) == 0);
             TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
-            ASSERT_COMPARE(tmp, 5, bufA + 95, 5);
-            ASSERT_COMPARE(tmp + 5, 10, bufB, 10);
+            TEST_BUFFERS_EQUAL(tmp, 5, bufA + 95, 5);
+            TEST_BUFFERS_EQUAL(tmp + 5, 10, bufB, 10);
             TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
             success = 1;
             break;
@@ -1096,7 +1096,7 @@ void mbedtls_reader_inconsistent_usage(int option)
     if (success == 1) {
         /* In all succeeding cases, fetch the rest of the second buffer. */
         TEST_ASSERT(mbedtls_mps_reader_get(&rd, 90, &tmp, NULL) == 0);
-        ASSERT_COMPARE(tmp, 90, bufB + 10, 90);
+        TEST_BUFFERS_EQUAL(tmp, 90, bufB + 10, 90);
         TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
 
         /* Wrapup */
@@ -1131,7 +1131,7 @@ void mbedtls_mps_reader_feed_empty()
 
     /* Consumption (upper layer) */
     TEST_ASSERT(mbedtls_mps_reader_get(&rd, 100, &tmp, NULL) == 0);
-    ASSERT_COMPARE(tmp, 100, buf, 100);
+    TEST_BUFFERS_EQUAL(tmp, 100, buf, 100);
     TEST_ASSERT(mbedtls_mps_reader_commit(&rd) == 0);
 
     /* Wrapup */

--- a/tests/suites/test_suite_mps.function
+++ b/tests/suites/test_suite_mps.function
@@ -844,15 +844,15 @@ void mbedtls_mps_reader_random_usage(int num_out_chunks,
     mbedtls_mps_reader rd;
 
     if (acc_size > 0) {
-        ASSERT_ALLOC(acc, acc_size);
+        TEST_CALLOC_OR_FAIL(acc, acc_size);
     }
 
     /* This probably needs to be changed because we want
      * our tests to be deterministic. */
     //    srand( time( NULL ) );
 
-    ASSERT_ALLOC(outgoing, num_out_chunks * max_chunk_size);
-    ASSERT_ALLOC(incoming, num_out_chunks * max_chunk_size);
+    TEST_CALLOC_OR_FAIL(outgoing, num_out_chunks * max_chunk_size);
+    TEST_CALLOC_OR_FAIL(incoming, num_out_chunks * max_chunk_size);
 
     mbedtls_mps_reader_init(&rd, acc, acc_size);
 
@@ -884,7 +884,7 @@ void mbedtls_mps_reader_random_usage(int num_out_chunks,
                 }
 
                 tmp_size = (rand() % max_chunk_size) + 1;
-                ASSERT_ALLOC(tmp, tmp_size);
+                TEST_CALLOC_OR_FAIL(tmp, tmp_size);
 
                 TEST_ASSERT(mbedtls_test_rnd_std_rand(NULL, tmp, tmp_size) == 0);
                 ret = mbedtls_mps_reader_feed(&rd, tmp, tmp_size);

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -915,7 +915,7 @@ void pk_sign_verify(int type, int parameter, int sign_ret, int verify_ret)
 #endif
 
     hash_len = mbedtls_md_get_size(mbedtls_md_info_from_type(md));
-    ASSERT_ALLOC(hash, hash_len);
+    TEST_CALLOC_OR_FAIL(hash, hash_len);
 
     mbedtls_pk_init(&pk);
     USE_PSA_INIT();

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -915,7 +915,7 @@ void pk_sign_verify(int type, int parameter, int sign_ret, int verify_ret)
 #endif
 
     hash_len = mbedtls_md_get_size(mbedtls_md_info_from_type(md));
-    TEST_CALLOC_OR_FAIL(hash, hash_len);
+    TEST_CALLOC(hash, hash_len);
 
     mbedtls_pk_init(&pk);
     USE_PSA_INIT();

--- a/tests/suites/test_suite_pkcs12.function
+++ b/tests/suites/test_suite_pkcs12.function
@@ -58,7 +58,7 @@ void pkcs12_derive_key(int md_type, int key_size_arg,
 
     if (expected_status == 0) {
         TEST_MEMORY_COMPARE(expected_output->x, expected_output->len,
-                       output_data, key_size);
+                            output_data, key_size);
     }
 
 exit:

--- a/tests/suites/test_suite_pkcs12.function
+++ b/tests/suites/test_suite_pkcs12.function
@@ -57,7 +57,7 @@ void pkcs12_derive_key(int md_type, int key_size_arg,
     TEST_EQUAL(ret, expected_status);
 
     if (expected_status == 0) {
-        TEST_BUFFERS_EQUAL(expected_output->x, expected_output->len,
+        TEST_MEMORY_COMPARE(expected_output->x, expected_output->len,
                        output_data, key_size);
     }
 

--- a/tests/suites/test_suite_pkcs12.function
+++ b/tests/suites/test_suite_pkcs12.function
@@ -42,7 +42,7 @@ void pkcs12_derive_key(int md_type, int key_size_arg,
 
     salt_len = salt_arg->len;
 
-    TEST_CALLOC_OR_FAIL(output_data, key_size);
+    TEST_CALLOC(output_data, key_size);
 
     int ret = mbedtls_pkcs12_derivation(output_data,
                                         key_size,

--- a/tests/suites/test_suite_pkcs12.function
+++ b/tests/suites/test_suite_pkcs12.function
@@ -57,7 +57,7 @@ void pkcs12_derive_key(int md_type, int key_size_arg,
     TEST_EQUAL(ret, expected_status);
 
     if (expected_status == 0) {
-        ASSERT_COMPARE(expected_output->x, expected_output->len,
+        TEST_BUFFERS_EQUAL(expected_output->x, expected_output->len,
                        output_data, key_size);
     }
 

--- a/tests/suites/test_suite_pkcs12.function
+++ b/tests/suites/test_suite_pkcs12.function
@@ -42,7 +42,7 @@ void pkcs12_derive_key(int md_type, int key_size_arg,
 
     salt_len = salt_arg->len;
 
-    ASSERT_ALLOC(output_data, key_size);
+    TEST_CALLOC_OR_FAIL(output_data, key_size);
 
     int ret = mbedtls_pkcs12_derivation(output_data,
                                         key_size,

--- a/tests/suites/test_suite_pkcs1_v21.function
+++ b/tests/suites/test_suite_pkcs1_v21.function
@@ -42,7 +42,7 @@ void pkcs1_rsaes_oaep_encrypt(int mod, data_t *input_N, data_t *input_E,
                                           message_str->len, message_str->x,
                                           output) == result);
     if (result == 0) {
-        TEST_BUFFERS_EQUAL(output, ctx.len, result_str->x, result_str->len);
+        TEST_MEMORY_COMPARE(output, ctx.len, result_str->x, result_str->len);
     }
 
 exit:
@@ -98,7 +98,7 @@ void pkcs1_rsaes_oaep_decrypt(int mod, data_t *input_P, data_t *input_Q,
                                               output,
                                               sizeof(output)) == result);
         if (result == 0) {
-            TEST_BUFFERS_EQUAL(output, output_len, result_str->x, result_str->len);
+            TEST_MEMORY_COMPARE(output, output_len, result_str->x, result_str->len);
         }
     }
 
@@ -154,7 +154,7 @@ void pkcs1_rsassa_pss_sign(int mod, data_t *input_P, data_t *input_Q,
                                            &info, MBEDTLS_RSA_PRIVATE, digest, 0,
                                            hash_result, output) == result);
         if (result == 0) {
-            TEST_BUFFERS_EQUAL(output, ctx.len, result_str->x, result_str->len);
+            TEST_MEMORY_COMPARE(output, ctx.len, result_str->x, result_str->len);
         }
 
         info.buf = rnd_buf->x;
@@ -165,7 +165,7 @@ void pkcs1_rsassa_pss_sign(int mod, data_t *input_P, data_t *input_Q,
                                                 &info, digest, 0, hash_result,
                                                 fixed_salt_length, output) == result);
     if (result == 0) {
-        TEST_BUFFERS_EQUAL(output, ctx.len, result_str->x, result_str->len);
+        TEST_MEMORY_COMPARE(output, ctx.len, result_str->x, result_str->len);
     }
 
 exit:

--- a/tests/suites/test_suite_pkcs1_v21.function
+++ b/tests/suites/test_suite_pkcs1_v21.function
@@ -42,7 +42,7 @@ void pkcs1_rsaes_oaep_encrypt(int mod, data_t *input_N, data_t *input_E,
                                           message_str->len, message_str->x,
                                           output) == result);
     if (result == 0) {
-        ASSERT_COMPARE(output, ctx.len, result_str->x, result_str->len);
+        TEST_BUFFERS_EQUAL(output, ctx.len, result_str->x, result_str->len);
     }
 
 exit:
@@ -98,7 +98,7 @@ void pkcs1_rsaes_oaep_decrypt(int mod, data_t *input_P, data_t *input_Q,
                                               output,
                                               sizeof(output)) == result);
         if (result == 0) {
-            ASSERT_COMPARE(output, output_len, result_str->x, result_str->len);
+            TEST_BUFFERS_EQUAL(output, output_len, result_str->x, result_str->len);
         }
     }
 
@@ -154,7 +154,7 @@ void pkcs1_rsassa_pss_sign(int mod, data_t *input_P, data_t *input_Q,
                                            &info, MBEDTLS_RSA_PRIVATE, digest, 0,
                                            hash_result, output) == result);
         if (result == 0) {
-            ASSERT_COMPARE(output, ctx.len, result_str->x, result_str->len);
+            TEST_BUFFERS_EQUAL(output, ctx.len, result_str->x, result_str->len);
         }
 
         info.buf = rnd_buf->x;
@@ -165,7 +165,7 @@ void pkcs1_rsassa_pss_sign(int mod, data_t *input_P, data_t *input_Q,
                                                 &info, digest, 0, hash_result,
                                                 fixed_salt_length, output) == result);
     if (result == 0) {
-        ASSERT_COMPARE(output, ctx.len, result_str->x, result_str->len);
+        TEST_BUFFERS_EQUAL(output, ctx.len, result_str->x, result_str->len);
     }
 
 exit:

--- a/tests/suites/test_suite_pkwrite.function
+++ b/tests/suites/test_suite_pkwrite.function
@@ -58,7 +58,7 @@ static void pk_write_check_common(char *key_file, int is_public_key, int is_der)
     }
     TEST_ASSERT(check_buf_len > 0);
 
-    TEST_CALLOC_OR_FAIL(buf, check_buf_len);
+    TEST_CALLOC(buf, check_buf_len);
 
     if (is_public_key) {
         TEST_EQUAL(mbedtls_pk_parse_public_keyfile(&key, key_file), 0);
@@ -145,7 +145,7 @@ void pk_write_public_from_private(char *priv_key_file, char *pub_key_file)
                                     &pub_key_len), 0);
 
     derived_key_len = pub_key_len;
-    TEST_CALLOC_OR_FAIL(derived_key_raw, derived_key_len);
+    TEST_CALLOC(derived_key_raw, derived_key_len);
 
     TEST_EQUAL(mbedtls_pk_write_pubkey_der(&priv_key, derived_key_raw,
                                            derived_key_len), pub_key_len);

--- a/tests/suites/test_suite_pkwrite.function
+++ b/tests/suites/test_suite_pkwrite.function
@@ -94,7 +94,7 @@ static void pk_write_check_common(char *key_file, int is_public_key, int is_der)
         start_buf = buf;
     }
 
-    TEST_BUFFERS_EQUAL(start_buf, buf_len, check_buf, check_buf_len);
+    TEST_MEMORY_COMPARE(start_buf, buf_len, check_buf, check_buf_len);
 
 exit:
     mbedtls_free(buf);
@@ -150,7 +150,7 @@ void pk_write_public_from_private(char *priv_key_file, char *pub_key_file)
     TEST_EQUAL(mbedtls_pk_write_pubkey_der(&priv_key, derived_key_raw,
                                            derived_key_len), pub_key_len);
 
-    TEST_BUFFERS_EQUAL(derived_key_raw, derived_key_len,
+    TEST_MEMORY_COMPARE(derived_key_raw, derived_key_len,
                    pub_key_raw, pub_key_len);
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
@@ -162,7 +162,7 @@ void pk_write_public_from_private(char *priv_key_file, char *pub_key_file)
     TEST_EQUAL(mbedtls_pk_write_pubkey_der(&priv_key, derived_key_raw,
                                            derived_key_len), pub_key_len);
 
-    TEST_BUFFERS_EQUAL(derived_key_raw, derived_key_len,
+    TEST_MEMORY_COMPARE(derived_key_raw, derived_key_len,
                    pub_key_raw, pub_key_len);
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 

--- a/tests/suites/test_suite_pkwrite.function
+++ b/tests/suites/test_suite_pkwrite.function
@@ -58,7 +58,7 @@ static void pk_write_check_common(char *key_file, int is_public_key, int is_der)
     }
     TEST_ASSERT(check_buf_len > 0);
 
-    ASSERT_ALLOC(buf, check_buf_len);
+    TEST_CALLOC_OR_FAIL(buf, check_buf_len);
 
     if (is_public_key) {
         TEST_EQUAL(mbedtls_pk_parse_public_keyfile(&key, key_file), 0);
@@ -145,7 +145,7 @@ void pk_write_public_from_private(char *priv_key_file, char *pub_key_file)
                                     &pub_key_len), 0);
 
     derived_key_len = pub_key_len;
-    ASSERT_ALLOC(derived_key_raw, derived_key_len);
+    TEST_CALLOC_OR_FAIL(derived_key_raw, derived_key_len);
 
     TEST_EQUAL(mbedtls_pk_write_pubkey_der(&priv_key, derived_key_raw,
                                            derived_key_len), pub_key_len);

--- a/tests/suites/test_suite_pkwrite.function
+++ b/tests/suites/test_suite_pkwrite.function
@@ -151,7 +151,7 @@ void pk_write_public_from_private(char *priv_key_file, char *pub_key_file)
                                            derived_key_len), pub_key_len);
 
     TEST_MEMORY_COMPARE(derived_key_raw, derived_key_len,
-                   pub_key_raw, pub_key_len);
+                        pub_key_raw, pub_key_len);
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     mbedtls_platform_zeroize(derived_key_raw, derived_key_len);
@@ -163,7 +163,7 @@ void pk_write_public_from_private(char *priv_key_file, char *pub_key_file)
                                            derived_key_len), pub_key_len);
 
     TEST_MEMORY_COMPARE(derived_key_raw, derived_key_len,
-                   pub_key_raw, pub_key_len);
+                        pub_key_raw, pub_key_len);
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 exit:

--- a/tests/suites/test_suite_pkwrite.function
+++ b/tests/suites/test_suite_pkwrite.function
@@ -94,7 +94,7 @@ static void pk_write_check_common(char *key_file, int is_public_key, int is_der)
         start_buf = buf;
     }
 
-    ASSERT_COMPARE(start_buf, buf_len, check_buf, check_buf_len);
+    TEST_BUFFERS_EQUAL(start_buf, buf_len, check_buf, check_buf_len);
 
 exit:
     mbedtls_free(buf);
@@ -150,7 +150,7 @@ void pk_write_public_from_private(char *priv_key_file, char *pub_key_file)
     TEST_EQUAL(mbedtls_pk_write_pubkey_der(&priv_key, derived_key_raw,
                                            derived_key_len), pub_key_len);
 
-    ASSERT_COMPARE(derived_key_raw, derived_key_len,
+    TEST_BUFFERS_EQUAL(derived_key_raw, derived_key_len,
                    pub_key_raw, pub_key_len);
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
@@ -162,7 +162,7 @@ void pk_write_public_from_private(char *priv_key_file, char *pub_key_file)
     TEST_EQUAL(mbedtls_pk_write_pubkey_der(&priv_key, derived_key_raw,
                                            derived_key_len), pub_key_len);
 
-    ASSERT_COMPARE(derived_key_raw, derived_key_len,
+    TEST_BUFFERS_EQUAL(derived_key_raw, derived_key_len,
                    pub_key_raw, pub_key_len);
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 

--- a/tests/suites/test_suite_platform_printf.function
+++ b/tests/suites/test_suite_platform_printf.function
@@ -34,7 +34,7 @@ void printf_int(char *format, /* any format expecting one int argument, e.g. "%d
     /* Nominal case: buffer just large enough */
     ASSERT_ALLOC(output, n + 1);
     TEST_EQUAL(n, mbedtls_snprintf(output, n + 1, format, x));
-    ASSERT_COMPARE(result, n + 1, output, n + 1);
+    TEST_BUFFERS_EQUAL(result, n + 1, output, n + 1);
     mbedtls_free(output);
     output = NULL;
 
@@ -59,7 +59,7 @@ void printf_long_max(const char *format, /* "%lx" or longer type */
 
     ASSERT_ALLOC(output, n + 1);
     TEST_EQUAL(n, mbedtls_snprintf(output, n + 1, format, value));
-    ASSERT_COMPARE(expected, n + 1, output, n + 1);
+    TEST_BUFFERS_EQUAL(expected, n + 1, output, n + 1);
     mbedtls_free(output);
     output = NULL;
 
@@ -79,7 +79,7 @@ void printf_char2(char *format, /* "%c%c" */
     /* Nominal case: buffer just large enough */
     ASSERT_ALLOC(output, n + 1);
     TEST_EQUAL(n, mbedtls_snprintf(output, n + 1, format, arg1, arg2));
-    ASSERT_COMPARE(result, n + 1, output, n + 1);
+    TEST_BUFFERS_EQUAL(result, n + 1, output, n + 1);
     mbedtls_free(output);
     output = NULL;
 

--- a/tests/suites/test_suite_platform_printf.function
+++ b/tests/suites/test_suite_platform_printf.function
@@ -32,7 +32,7 @@ void printf_int(char *format, /* any format expecting one int argument, e.g. "%d
     const size_t n = strlen(result);
 
     /* Nominal case: buffer just large enough */
-    TEST_CALLOC_OR_FAIL(output, n + 1);
+    TEST_CALLOC(output, n + 1);
     TEST_EQUAL(n, mbedtls_snprintf(output, n + 1, format, x));
     TEST_BUFFERS_EQUAL(result, n + 1, output, n + 1);
     mbedtls_free(output);
@@ -53,11 +53,11 @@ void printf_long_max(const char *format, /* "%lx" or longer type */
     const size_t n = sizeof(value) * 2;
 
     /* We assume that long has no padding bits! */
-    TEST_CALLOC_OR_FAIL(expected, n + 1);
+    TEST_CALLOC(expected, n + 1);
     expected[0] = '7';
     memset(expected + 1, 'f', sizeof(value) * 2 - 1);
 
-    TEST_CALLOC_OR_FAIL(output, n + 1);
+    TEST_CALLOC(output, n + 1);
     TEST_EQUAL(n, mbedtls_snprintf(output, n + 1, format, value));
     TEST_BUFFERS_EQUAL(expected, n + 1, output, n + 1);
     mbedtls_free(output);
@@ -77,7 +77,7 @@ void printf_char2(char *format, /* "%c%c" */
     const size_t n = strlen(result);
 
     /* Nominal case: buffer just large enough */
-    TEST_CALLOC_OR_FAIL(output, n + 1);
+    TEST_CALLOC(output, n + 1);
     TEST_EQUAL(n, mbedtls_snprintf(output, n + 1, format, arg1, arg2));
     TEST_BUFFERS_EQUAL(result, n + 1, output, n + 1);
     mbedtls_free(output);

--- a/tests/suites/test_suite_platform_printf.function
+++ b/tests/suites/test_suite_platform_printf.function
@@ -32,7 +32,7 @@ void printf_int(char *format, /* any format expecting one int argument, e.g. "%d
     const size_t n = strlen(result);
 
     /* Nominal case: buffer just large enough */
-    ASSERT_ALLOC(output, n + 1);
+    TEST_CALLOC_OR_FAIL(output, n + 1);
     TEST_EQUAL(n, mbedtls_snprintf(output, n + 1, format, x));
     TEST_BUFFERS_EQUAL(result, n + 1, output, n + 1);
     mbedtls_free(output);
@@ -53,11 +53,11 @@ void printf_long_max(const char *format, /* "%lx" or longer type */
     const size_t n = sizeof(value) * 2;
 
     /* We assume that long has no padding bits! */
-    ASSERT_ALLOC(expected, n + 1);
+    TEST_CALLOC_OR_FAIL(expected, n + 1);
     expected[0] = '7';
     memset(expected + 1, 'f', sizeof(value) * 2 - 1);
 
-    ASSERT_ALLOC(output, n + 1);
+    TEST_CALLOC_OR_FAIL(output, n + 1);
     TEST_EQUAL(n, mbedtls_snprintf(output, n + 1, format, value));
     TEST_BUFFERS_EQUAL(expected, n + 1, output, n + 1);
     mbedtls_free(output);
@@ -77,7 +77,7 @@ void printf_char2(char *format, /* "%c%c" */
     const size_t n = strlen(result);
 
     /* Nominal case: buffer just large enough */
-    ASSERT_ALLOC(output, n + 1);
+    TEST_CALLOC_OR_FAIL(output, n + 1);
     TEST_EQUAL(n, mbedtls_snprintf(output, n + 1, format, arg1, arg2));
     TEST_BUFFERS_EQUAL(result, n + 1, output, n + 1);
     mbedtls_free(output);

--- a/tests/suites/test_suite_platform_printf.function
+++ b/tests/suites/test_suite_platform_printf.function
@@ -34,7 +34,7 @@ void printf_int(char *format, /* any format expecting one int argument, e.g. "%d
     /* Nominal case: buffer just large enough */
     TEST_CALLOC(output, n + 1);
     TEST_EQUAL(n, mbedtls_snprintf(output, n + 1, format, x));
-    TEST_BUFFERS_EQUAL(result, n + 1, output, n + 1);
+    TEST_MEMORY_COMPARE(result, n + 1, output, n + 1);
     mbedtls_free(output);
     output = NULL;
 
@@ -59,7 +59,7 @@ void printf_long_max(const char *format, /* "%lx" or longer type */
 
     TEST_CALLOC(output, n + 1);
     TEST_EQUAL(n, mbedtls_snprintf(output, n + 1, format, value));
-    TEST_BUFFERS_EQUAL(expected, n + 1, output, n + 1);
+    TEST_MEMORY_COMPARE(expected, n + 1, output, n + 1);
     mbedtls_free(output);
     output = NULL;
 
@@ -79,7 +79,7 @@ void printf_char2(char *format, /* "%c%c" */
     /* Nominal case: buffer just large enough */
     TEST_CALLOC(output, n + 1);
     TEST_EQUAL(n, mbedtls_snprintf(output, n + 1, format, arg1, arg2));
-    TEST_BUFFERS_EQUAL(result, n + 1, output, n + 1);
+    TEST_MEMORY_COMPARE(result, n + 1, output, n + 1);
     mbedtls_free(output);
     output = NULL;
 

--- a/tests/suites/test_suite_poly1305.function
+++ b/tests/suites/test_suite_poly1305.function
@@ -22,7 +22,7 @@ void mbedtls_poly1305(data_t *key, data_t *expected_mac, data_t *src_str)
     TEST_ASSERT(mbedtls_poly1305_mac(key->x, src_str->x,
                                      src_str->len, mac) == 0);
 
-    TEST_BUFFERS_EQUAL(mac, expected_mac->len,
+    TEST_MEMORY_COMPARE(mac, expected_mac->len,
                    expected_mac->x, expected_mac->len);
 
     /*
@@ -36,7 +36,7 @@ void mbedtls_poly1305(data_t *key, data_t *expected_mac, data_t *src_str)
 
     TEST_ASSERT(mbedtls_poly1305_finish(&ctx, mac) == 0);
 
-    TEST_BUFFERS_EQUAL(mac, expected_mac->len,
+    TEST_MEMORY_COMPARE(mac, expected_mac->len,
                    expected_mac->x, expected_mac->len);
 
     /*
@@ -53,7 +53,7 @@ void mbedtls_poly1305(data_t *key, data_t *expected_mac, data_t *src_str)
 
         TEST_ASSERT(mbedtls_poly1305_finish(&ctx, mac) == 0);
 
-        TEST_BUFFERS_EQUAL(mac, expected_mac->len,
+        TEST_MEMORY_COMPARE(mac, expected_mac->len,
                        expected_mac->x, expected_mac->len);
     }
 
@@ -69,7 +69,7 @@ void mbedtls_poly1305(data_t *key, data_t *expected_mac, data_t *src_str)
 
         TEST_ASSERT(mbedtls_poly1305_finish(&ctx, mac) == 0);
 
-        TEST_BUFFERS_EQUAL(mac, expected_mac->len,
+        TEST_MEMORY_COMPARE(mac, expected_mac->len,
                        expected_mac->x, expected_mac->len);
     }
 

--- a/tests/suites/test_suite_poly1305.function
+++ b/tests/suites/test_suite_poly1305.function
@@ -22,7 +22,7 @@ void mbedtls_poly1305(data_t *key, data_t *expected_mac, data_t *src_str)
     TEST_ASSERT(mbedtls_poly1305_mac(key->x, src_str->x,
                                      src_str->len, mac) == 0);
 
-    ASSERT_COMPARE(mac, expected_mac->len,
+    TEST_BUFFERS_EQUAL(mac, expected_mac->len,
                    expected_mac->x, expected_mac->len);
 
     /*
@@ -36,7 +36,7 @@ void mbedtls_poly1305(data_t *key, data_t *expected_mac, data_t *src_str)
 
     TEST_ASSERT(mbedtls_poly1305_finish(&ctx, mac) == 0);
 
-    ASSERT_COMPARE(mac, expected_mac->len,
+    TEST_BUFFERS_EQUAL(mac, expected_mac->len,
                    expected_mac->x, expected_mac->len);
 
     /*
@@ -53,7 +53,7 @@ void mbedtls_poly1305(data_t *key, data_t *expected_mac, data_t *src_str)
 
         TEST_ASSERT(mbedtls_poly1305_finish(&ctx, mac) == 0);
 
-        ASSERT_COMPARE(mac, expected_mac->len,
+        TEST_BUFFERS_EQUAL(mac, expected_mac->len,
                        expected_mac->x, expected_mac->len);
     }
 
@@ -69,7 +69,7 @@ void mbedtls_poly1305(data_t *key, data_t *expected_mac, data_t *src_str)
 
         TEST_ASSERT(mbedtls_poly1305_finish(&ctx, mac) == 0);
 
-        ASSERT_COMPARE(mac, expected_mac->len,
+        TEST_BUFFERS_EQUAL(mac, expected_mac->len,
                        expected_mac->x, expected_mac->len);
     }
 

--- a/tests/suites/test_suite_poly1305.function
+++ b/tests/suites/test_suite_poly1305.function
@@ -23,7 +23,7 @@ void mbedtls_poly1305(data_t *key, data_t *expected_mac, data_t *src_str)
                                      src_str->len, mac) == 0);
 
     TEST_MEMORY_COMPARE(mac, expected_mac->len,
-                   expected_mac->x, expected_mac->len);
+                        expected_mac->x, expected_mac->len);
 
     /*
      * Test the streaming API
@@ -37,7 +37,7 @@ void mbedtls_poly1305(data_t *key, data_t *expected_mac, data_t *src_str)
     TEST_ASSERT(mbedtls_poly1305_finish(&ctx, mac) == 0);
 
     TEST_MEMORY_COMPARE(mac, expected_mac->len,
-                   expected_mac->x, expected_mac->len);
+                        expected_mac->x, expected_mac->len);
 
     /*
      * Test the streaming API again, piecewise
@@ -54,7 +54,7 @@ void mbedtls_poly1305(data_t *key, data_t *expected_mac, data_t *src_str)
         TEST_ASSERT(mbedtls_poly1305_finish(&ctx, mac) == 0);
 
         TEST_MEMORY_COMPARE(mac, expected_mac->len,
-                       expected_mac->x, expected_mac->len);
+                            expected_mac->x, expected_mac->len);
     }
 
     /*
@@ -70,7 +70,7 @@ void mbedtls_poly1305(data_t *key, data_t *expected_mac, data_t *src_str)
         TEST_ASSERT(mbedtls_poly1305_finish(&ctx, mac) == 0);
 
         TEST_MEMORY_COMPARE(mac, expected_mac->len,
-                       expected_mac->x, expected_mac->len);
+                            expected_mac->x, expected_mac->len);
     }
 
     mbedtls_poly1305_free(&ctx);

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -533,7 +533,7 @@ void import_rsa_made_up(int bits_arg, int keypair, int expected_status_arg)
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
 
     PSA_ASSERT(psa_crypto_init());
-    TEST_CALLOC_OR_FAIL(buffer, buffer_size);
+    TEST_CALLOC(buffer, buffer_size);
 
     TEST_ASSERT((ret = construct_fake_rsa_key(buffer, buffer_size, &p,
                                               bits, keypair)) >= 0);
@@ -578,9 +578,9 @@ void import_export(data_t *data,
     psa_key_attributes_t got_attributes = PSA_KEY_ATTRIBUTES_INIT;
 
     export_size = (ptrdiff_t) data->len + export_size_delta;
-    TEST_CALLOC_OR_FAIL(exported, export_size);
+    TEST_CALLOC(exported, export_size);
     if (!canonical_input) {
-        TEST_CALLOC_OR_FAIL(reexported, export_size);
+        TEST_CALLOC(reexported, export_size);
     }
     PSA_ASSERT(psa_crypto_init());
 
@@ -687,7 +687,7 @@ void import_export_public_key(data_t *data,
     PSA_ASSERT(psa_import_key(&attributes, data->x, data->len, &key));
 
     /* Export the public key */
-    TEST_CALLOC_OR_FAIL(exported, export_size);
+    TEST_CALLOC(exported, export_size);
     status = psa_export_public_key(key,
                                    exported, export_size,
                                    &exported_length);
@@ -1081,7 +1081,7 @@ void asymmetric_encryption_key_policy(int policy_usage_arg,
     key_bits = psa_get_key_bits(&attributes);
     buffer_length = PSA_ASYMMETRIC_ENCRYPT_OUTPUT_SIZE(key_type, key_bits,
                                                        exercise_alg);
-    TEST_CALLOC_OR_FAIL(buffer, buffer_length);
+    TEST_CALLOC(buffer, buffer_length);
 
     status = psa_asymmetric_encrypt(key, exercise_alg,
                                     NULL, 0,
@@ -1446,7 +1446,7 @@ void copy_success(int source_usage_arg,
                psa_get_key_enrollment_algorithm(&target_attributes));
     if (expected_usage & PSA_KEY_USAGE_EXPORT) {
         size_t length;
-        TEST_CALLOC_OR_FAIL(export_buffer, material->len);
+        TEST_CALLOC(export_buffer, material->len);
         PSA_ASSERT(psa_export_key(target_key, export_buffer,
                                   material->len, &length));
         TEST_BUFFERS_EQUAL(material->x, material->len,
@@ -1599,7 +1599,7 @@ void hash_compute_fail(int alg_arg, data_t *input,
     psa_status_t expected_status = expected_status_arg;
     psa_status_t status;
 
-    TEST_CALLOC_OR_FAIL(output, output_size);
+    TEST_CALLOC(output, output_size);
 
     PSA_ASSERT(psa_crypto_init());
 
@@ -2187,7 +2187,7 @@ void mac_sign(int key_type_arg,
              PSA_ERROR_BUFFER_TOO_SMALL);
 
         mbedtls_test_set_step(output_size);
-        TEST_CALLOC_OR_FAIL(actual_mac, output_size);
+        TEST_CALLOC(actual_mac, output_size);
 
         /* Calculate the MAC, one-shot case. */
         TEST_EQUAL(psa_mac_compute(key, alg,
@@ -2283,7 +2283,7 @@ void mac_verify(int key_type_arg,
                PSA_ERROR_INVALID_SIGNATURE);
 
     /* Test a MAC that's too long, one-shot case. */
-    TEST_CALLOC_OR_FAIL(perturbed_mac, expected_mac->len + 1);
+    TEST_CALLOC(perturbed_mac, expected_mac->len + 1);
     memcpy(perturbed_mac, expected_mac->x, expected_mac->len);
     TEST_EQUAL(psa_mac_verify(key, alg,
                               input->x, input->len,
@@ -2608,7 +2608,7 @@ void cipher_encrypt_fail(int alg_arg,
 
         output_buffer_size = PSA_CIPHER_ENCRYPT_OUTPUT_SIZE(key_type, alg,
                                                             input->len);
-        TEST_CALLOC_OR_FAIL(output, output_buffer_size);
+        TEST_CALLOC(output, output_buffer_size);
 
         PSA_ASSERT(psa_import_key(&attributes, key_data->x, key_data->len,
                                   &key));
@@ -2662,7 +2662,7 @@ void cipher_alg_without_iv(int alg_arg, int key_type_arg, data_t *key_data,
                               &key));
     output_buffer_size = PSA_CIPHER_ENCRYPT_OUTPUT_SIZE(key_type, alg,
                                                         plaintext->len);
-    TEST_CALLOC_OR_FAIL(output, output_buffer_size);
+    TEST_CALLOC(output, output_buffer_size);
 
     /* set_iv() is not allowed */
     PSA_ASSERT(psa_cipher_encrypt_setup(&operation, key, alg));
@@ -2811,8 +2811,8 @@ void cipher_encrypt_validation(int alg_arg,
     output1_buffer_size = PSA_CIPHER_ENCRYPT_OUTPUT_SIZE(key_type, alg, input->len);
     output2_buffer_size = PSA_CIPHER_UPDATE_OUTPUT_SIZE(key_type, alg, input->len) +
                           PSA_CIPHER_FINISH_OUTPUT_SIZE(key_type, alg);
-    TEST_CALLOC_OR_FAIL(output1, output1_buffer_size);
-    TEST_CALLOC_OR_FAIL(output2, output2_buffer_size);
+    TEST_CALLOC(output1, output1_buffer_size);
+    TEST_CALLOC(output2, output2_buffer_size);
 
     PSA_ASSERT(psa_import_key(&attributes, key_data->x, key_data->len,
                               &key));
@@ -2903,7 +2903,7 @@ void cipher_encrypt_multipart(int alg_arg, int key_type_arg,
 
     output_buffer_size = PSA_CIPHER_UPDATE_OUTPUT_SIZE(key_type, alg, input->len) +
                          PSA_CIPHER_FINISH_OUTPUT_SIZE(key_type, alg);
-    TEST_CALLOC_OR_FAIL(output, output_buffer_size);
+    TEST_CALLOC(output, output_buffer_size);
 
     TEST_LE_U(first_part_size, input->len);
     PSA_ASSERT(psa_cipher_update(&operation, input->x, first_part_size,
@@ -3002,7 +3002,7 @@ void cipher_decrypt_multipart(int alg_arg, int key_type_arg,
 
     output_buffer_size = PSA_CIPHER_UPDATE_OUTPUT_SIZE(key_type, alg, input->len) +
                          PSA_CIPHER_FINISH_OUTPUT_SIZE(key_type, alg);
-    TEST_CALLOC_OR_FAIL(output, output_buffer_size);
+    TEST_CALLOC(output, output_buffer_size);
 
     TEST_LE_U(first_part_size, input->len);
     PSA_ASSERT(psa_cipher_update(&operation,
@@ -3095,13 +3095,13 @@ void cipher_decrypt_fail(int alg_arg,
     /* Allocate input buffer and copy the iv and the plaintext */
     input_buffer_size = ((size_t) input_arg->len + (size_t) iv->len);
     if (input_buffer_size > 0) {
-        TEST_CALLOC_OR_FAIL(input, input_buffer_size);
+        TEST_CALLOC(input, input_buffer_size);
         memcpy(input, iv->x, iv->len);
         memcpy(input + iv->len, input_arg->x, input_arg->len);
     }
 
     output_buffer_size = PSA_CIPHER_DECRYPT_OUTPUT_SIZE(key_type, alg, input_buffer_size);
-    TEST_CALLOC_OR_FAIL(output, output_buffer_size);
+    TEST_CALLOC(output, output_buffer_size);
 
     status = psa_cipher_decrypt(key, alg, input, input_buffer_size, output,
                                 output_buffer_size, &output_length);
@@ -3142,13 +3142,13 @@ void cipher_decrypt(int alg_arg,
     /* Allocate input buffer and copy the iv and the plaintext */
     input_buffer_size = ((size_t) input_arg->len + (size_t) iv->len);
     if (input_buffer_size > 0) {
-        TEST_CALLOC_OR_FAIL(input, input_buffer_size);
+        TEST_CALLOC(input, input_buffer_size);
         memcpy(input, iv->x, iv->len);
         memcpy(input + iv->len, input_arg->x, input_arg->len);
     }
 
     output_buffer_size = PSA_CIPHER_DECRYPT_OUTPUT_SIZE(key_type, alg, input_buffer_size);
-    TEST_CALLOC_OR_FAIL(output, output_buffer_size);
+    TEST_CALLOC(output, output_buffer_size);
 
     PSA_ASSERT(psa_import_key(&attributes, key_data->x, key_data->len,
                               &key));
@@ -3196,7 +3196,7 @@ void cipher_verify_output(int alg_arg,
     PSA_ASSERT(psa_import_key(&attributes, key_data->x, key_data->len,
                               &key));
     output1_size = PSA_CIPHER_ENCRYPT_OUTPUT_SIZE(key_type, alg, input->len);
-    TEST_CALLOC_OR_FAIL(output1, output1_size);
+    TEST_CALLOC(output1, output1_size);
 
     PSA_ASSERT(psa_cipher_encrypt(key, alg, input->x, input->len,
                                   output1, output1_size,
@@ -3207,7 +3207,7 @@ void cipher_verify_output(int alg_arg,
               PSA_CIPHER_ENCRYPT_OUTPUT_MAX_SIZE(input->len));
 
     output2_size = output1_length;
-    TEST_CALLOC_OR_FAIL(output2, output2_size);
+    TEST_CALLOC(output2, output2_size);
 
     PSA_ASSERT(psa_cipher_decrypt(key, alg, output1, output1_length,
                                   output2, output2_size,
@@ -3273,7 +3273,7 @@ void cipher_verify_output_multipart(int alg_arg,
     output1_buffer_size = PSA_CIPHER_ENCRYPT_OUTPUT_SIZE(key_type, alg, input->len);
     TEST_LE_U(output1_buffer_size,
               PSA_CIPHER_ENCRYPT_OUTPUT_MAX_SIZE(input->len));
-    TEST_CALLOC_OR_FAIL(output1, output1_buffer_size);
+    TEST_CALLOC(output1, output1_buffer_size);
 
     TEST_LE_U(first_part_size, input->len);
 
@@ -3316,7 +3316,7 @@ void cipher_verify_output_multipart(int alg_arg,
               PSA_CIPHER_DECRYPT_OUTPUT_SIZE(key_type, alg, output1_length));
     TEST_LE_U(output2_buffer_size,
               PSA_CIPHER_DECRYPT_OUTPUT_MAX_SIZE(output1_length));
-    TEST_CALLOC_OR_FAIL(output2, output2_buffer_size);
+    TEST_CALLOC(output2, output2_buffer_size);
 
     if (iv_length > 0) {
         PSA_ASSERT(psa_cipher_set_iv(&operation2,
@@ -3412,7 +3412,7 @@ void aead_encrypt_decrypt(int key_type_arg, data_t *key_data,
         TEST_ASSERT(output_size <=
                     PSA_AEAD_ENCRYPT_OUTPUT_MAX_SIZE(input_data->len));
     }
-    TEST_CALLOC_OR_FAIL(output_data, output_size);
+    TEST_CALLOC(output_data, output_size);
 
     status = psa_aead_encrypt(key, alg,
                               nonce->x, nonce->len,
@@ -3433,7 +3433,7 @@ void aead_encrypt_decrypt(int key_type_arg, data_t *key_data,
     TEST_EQUAL(status, expected_result);
 
     if (PSA_SUCCESS == expected_result) {
-        TEST_CALLOC_OR_FAIL(output_data2, output_length);
+        TEST_CALLOC(output_data2, output_length);
 
         /* For all currently defined algorithms, PSA_AEAD_DECRYPT_OUTPUT_SIZE
          * should be exact. */
@@ -3501,7 +3501,7 @@ void aead_encrypt(int key_type_arg, data_t *key_data,
                PSA_AEAD_ENCRYPT_OUTPUT_SIZE(key_type, alg, input_data->len));
     TEST_ASSERT(output_size <=
                 PSA_AEAD_ENCRYPT_OUTPUT_MAX_SIZE(input_data->len));
-    TEST_CALLOC_OR_FAIL(output_data, output_size);
+    TEST_CALLOC(output_data, output_size);
 
     status = psa_aead_encrypt(key, alg,
                               nonce->x, nonce->len,
@@ -3571,7 +3571,7 @@ void aead_decrypt(int key_type_arg, data_t *key_data,
         TEST_ASSERT(output_size <=
                     PSA_AEAD_DECRYPT_OUTPUT_MAX_SIZE(input_data->len));
     }
-    TEST_CALLOC_OR_FAIL(output_data, output_size);
+    TEST_CALLOC(output_data, output_size);
 
     status = psa_aead_decrypt(key, alg,
                               nonce->x, nonce->len,
@@ -3655,7 +3655,7 @@ void sign_hash_deterministic(int key_type_arg, data_t *key_data,
                                           key_bits, alg);
     TEST_ASSERT(signature_size != 0);
     TEST_LE_U(signature_size, PSA_SIGNATURE_MAX_SIZE);
-    TEST_CALLOC_OR_FAIL(signature, signature_size);
+    TEST_CALLOC(signature, signature_size);
 
     /* Perform the signature. */
     PSA_ASSERT(psa_sign_hash(key, alg,
@@ -3705,7 +3705,7 @@ void sign_hash_fail(int key_type_arg, data_t *key_data,
     size_t signature_length = 0xdeadbeef;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
 
-    TEST_CALLOC_OR_FAIL(signature, signature_size);
+    TEST_CALLOC(signature, signature_size);
 
     PSA_ASSERT(psa_crypto_init());
 
@@ -3775,7 +3775,7 @@ void sign_verify_hash(int key_type_arg, data_t *key_data,
                                           key_bits, alg);
     TEST_ASSERT(signature_size != 0);
     TEST_LE_U(signature_size, PSA_SIGNATURE_MAX_SIZE);
-    TEST_CALLOC_OR_FAIL(signature, signature_size);
+    TEST_CALLOC(signature, signature_size);
 
     /* Perform the signature. */
     PSA_ASSERT(psa_sign_hash(key, alg,
@@ -3926,7 +3926,7 @@ void sign_message_deterministic(int key_type_arg,
     signature_size = PSA_SIGN_OUTPUT_SIZE(key_type, key_bits, alg);
     TEST_ASSERT(signature_size != 0);
     TEST_LE_U(signature_size, PSA_SIGNATURE_MAX_SIZE);
-    TEST_CALLOC_OR_FAIL(signature, signature_size);
+    TEST_CALLOC(signature, signature_size);
 
     PSA_ASSERT(psa_sign_message(key, alg,
                                 input_data->x, input_data->len,
@@ -3964,7 +3964,7 @@ void sign_message_fail(int key_type_arg,
     size_t signature_length = 0xdeadbeef;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
 
-    TEST_CALLOC_OR_FAIL(signature, signature_size);
+    TEST_CALLOC(signature, signature_size);
 
     PSA_ASSERT(psa_crypto_init());
 
@@ -4024,7 +4024,7 @@ void sign_verify_message(int key_type_arg,
     signature_size = PSA_SIGN_OUTPUT_SIZE(key_type, key_bits, alg);
     TEST_ASSERT(signature_size != 0);
     TEST_LE_U(signature_size, PSA_SIGNATURE_MAX_SIZE);
-    TEST_CALLOC_OR_FAIL(signature, signature_size);
+    TEST_CALLOC(signature, signature_size);
 
     PSA_ASSERT(psa_sign_message(key, alg,
                                 input_data->x, input_data->len,
@@ -4164,7 +4164,7 @@ void asymmetric_encrypt(int key_type_arg,
 
     output_size = PSA_ASYMMETRIC_ENCRYPT_OUTPUT_SIZE(key_type, key_bits, alg);
     TEST_LE_U(output_size, PSA_ASYMMETRIC_ENCRYPT_OUTPUT_MAX_SIZE);
-    TEST_CALLOC_OR_FAIL(output, output_size);
+    TEST_CALLOC(output, output_size);
 
     /* Encrypt the input */
     actual_status = psa_asymmetric_encrypt(key, alg,
@@ -4246,13 +4246,13 @@ void asymmetric_encrypt_decrypt(int key_type_arg,
 
     output_size = PSA_ASYMMETRIC_ENCRYPT_OUTPUT_SIZE(key_type, key_bits, alg);
     TEST_LE_U(output_size, PSA_ASYMMETRIC_ENCRYPT_OUTPUT_MAX_SIZE);
-    TEST_CALLOC_OR_FAIL(output, output_size);
+    TEST_CALLOC(output, output_size);
 
     output2_size = input_data->len;
     TEST_LE_U(output2_size,
               PSA_ASYMMETRIC_DECRYPT_OUTPUT_SIZE(key_type, key_bits, alg));
     TEST_LE_U(output2_size, PSA_ASYMMETRIC_DECRYPT_OUTPUT_MAX_SIZE);
-    TEST_CALLOC_OR_FAIL(output2, output2_size);
+    TEST_CALLOC(output2, output2_size);
 
     /* We test encryption by checking that encrypt-then-decrypt gives back
      * the original plaintext because of the non-optional random
@@ -4320,7 +4320,7 @@ void asymmetric_decrypt(int key_type_arg,
     /* Determine the maximum ciphertext length */
     output_size = PSA_ASYMMETRIC_DECRYPT_OUTPUT_SIZE(key_type, key_bits, alg);
     TEST_LE_U(output_size, PSA_ASYMMETRIC_DECRYPT_OUTPUT_MAX_SIZE);
-    TEST_CALLOC_OR_FAIL(output, output_size);
+    TEST_CALLOC(output, output_size);
 
     PSA_ASSERT(psa_asymmetric_decrypt(key, alg,
                                       input_data->x, input_data->len,
@@ -4375,7 +4375,7 @@ void asymmetric_decrypt_fail(int key_type_arg,
     psa_status_t expected_status = expected_status_arg;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
 
-    TEST_CALLOC_OR_FAIL(output, output_size);
+    TEST_CALLOC(output, output_size);
 
     PSA_ASSERT(psa_crypto_init());
 
@@ -4694,7 +4694,7 @@ void derive_output(int alg_arg,
             expected_outputs[i] = NULL;
         }
     }
-    TEST_CALLOC_OR_FAIL(output_buffer, output_buffer_size);
+    TEST_CALLOC(output_buffer, output_buffer_size);
     PSA_ASSERT(psa_crypto_init());
 
     psa_set_key_usage_flags(&attributes, PSA_KEY_USAGE_DERIVE);
@@ -4931,8 +4931,8 @@ void derive_key_export(int alg_arg,
     psa_key_attributes_t derived_attributes = PSA_KEY_ATTRIBUTES_INIT;
     size_t length;
 
-    TEST_CALLOC_OR_FAIL(output_buffer, capacity);
-    TEST_CALLOC_OR_FAIL(export_buffer, capacity);
+    TEST_CALLOC(output_buffer, capacity);
+    TEST_CALLOC(export_buffer, capacity);
     PSA_ASSERT(psa_crypto_init());
 
     psa_set_key_usage_flags(&base_attributes, PSA_KEY_USAGE_DERIVE);
@@ -5128,7 +5128,7 @@ void raw_key_agreement(int alg_arg,
               PSA_RAW_KEY_AGREEMENT_OUTPUT_MAX_SIZE);
 
     /* Good case with exact output size */
-    TEST_CALLOC_OR_FAIL(output, expected_output->len);
+    TEST_CALLOC(output, expected_output->len);
     PSA_ASSERT(psa_raw_key_agreement(alg, our_key,
                                      peer_key_data->x, peer_key_data->len,
                                      output, expected_output->len,
@@ -5140,7 +5140,7 @@ void raw_key_agreement(int alg_arg,
     output_length = ~0;
 
     /* Larger buffer */
-    TEST_CALLOC_OR_FAIL(output, expected_output->len + 1);
+    TEST_CALLOC(output, expected_output->len + 1);
     PSA_ASSERT(psa_raw_key_agreement(alg, our_key,
                                      peer_key_data->x, peer_key_data->len,
                                      output, expected_output->len + 1,
@@ -5152,7 +5152,7 @@ void raw_key_agreement(int alg_arg,
     output_length = ~0;
 
     /* Buffer too small */
-    TEST_CALLOC_OR_FAIL(output, expected_output->len - 1);
+    TEST_CALLOC(output, expected_output->len - 1);
     TEST_EQUAL(psa_raw_key_agreement(alg, our_key,
                                      peer_key_data->x, peer_key_data->len,
                                      output, expected_output->len - 1,
@@ -5241,7 +5241,7 @@ void key_agreement_output(int alg_arg,
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     uint8_t *actual_output = NULL;
 
-    TEST_CALLOC_OR_FAIL(actual_output, MAX(expected_output1->len,
+    TEST_CALLOC(actual_output, MAX(expected_output1->len,
                                     expected_output2->len));
 
     PSA_ASSERT(psa_crypto_init());
@@ -5297,8 +5297,8 @@ void generate_random(int bytes_arg)
 
     TEST_ASSERT(bytes_arg >= 0);
 
-    TEST_CALLOC_OR_FAIL(output, bytes);
-    TEST_CALLOC_OR_FAIL(changed, bytes);
+    TEST_CALLOC(output, bytes);
+    TEST_CALLOC(changed, bytes);
 
     PSA_ASSERT(psa_crypto_init());
 
@@ -5416,8 +5416,8 @@ void generate_key_rsa(int bits_arg,
         is_default_public_exponent = 1;
         e_read_size = 0;
     }
-    TEST_CALLOC_OR_FAIL(e_read_buffer, e_read_size);
-    TEST_CALLOC_OR_FAIL(exported, exported_size);
+    TEST_CALLOC(e_read_buffer, e_read_size);
+    TEST_CALLOC(exported, exported_size);
 
     PSA_ASSERT(psa_crypto_init());
 
@@ -5519,8 +5519,8 @@ void persistent_key_load_key_from_storage(data_t *data,
     size_t second_exported_length;
 
     if (usage_flags & PSA_KEY_USAGE_EXPORT) {
-        TEST_CALLOC_OR_FAIL(first_export, export_size);
-        TEST_CALLOC_OR_FAIL(second_export, export_size);
+        TEST_CALLOC(first_export, export_size);
+        TEST_CALLOC(second_export, export_size);
     }
 
     PSA_ASSERT(psa_crypto_init());

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -623,7 +623,7 @@ void import_export(data_t *data,
     }
 
     if (canonical_input) {
-        ASSERT_COMPARE(data->x, data->len, exported, exported_length);
+        TEST_BUFFERS_EQUAL(data->x, data->len, exported, exported_length);
     } else {
         mbedtls_svc_key_id_t key2 = MBEDTLS_SVC_KEY_ID_INIT;
         PSA_ASSERT(psa_import_key(&attributes, exported, exported_length,
@@ -632,7 +632,7 @@ void import_export(data_t *data,
                                   reexported,
                                   export_size,
                                   &reexported_length));
-        ASSERT_COMPARE(exported, exported_length,
+        TEST_BUFFERS_EQUAL(exported, exported_length,
                        reexported, reexported_length);
         PSA_ASSERT(psa_destroy_key(key2));
     }
@@ -703,7 +703,7 @@ void import_export_public_key(data_t *data,
                   PSA_EXPORT_PUBLIC_KEY_OUTPUT_SIZE(public_type, bits));
         TEST_LE_U(expected_public_key->len,
                   PSA_EXPORT_PUBLIC_KEY_MAX_SIZE);
-        ASSERT_COMPARE(expected_public_key->x, expected_public_key->len,
+        TEST_BUFFERS_EQUAL(expected_public_key->x, expected_public_key->len,
                        exported, exported_length);
     }
 
@@ -1449,7 +1449,7 @@ void copy_success(int source_usage_arg,
         ASSERT_ALLOC(export_buffer, material->len);
         PSA_ASSERT(psa_export_key(target_key, export_buffer,
                                   material->len, &length));
-        ASSERT_COMPARE(material->x, material->len,
+        TEST_BUFFERS_EQUAL(material->x, material->len,
                        export_buffer, length);
     }
 
@@ -1650,7 +1650,7 @@ void hash_compute_compare(int alg_arg, data_t *input,
                                 output, PSA_HASH_LENGTH(alg),
                                 &output_length));
     TEST_EQUAL(output_length, PSA_HASH_LENGTH(alg));
-    ASSERT_COMPARE(output, output_length,
+    TEST_BUFFERS_EQUAL(output, output_length,
                    expected_output->x, expected_output->len);
 
     /* Compute with larger buffer */
@@ -1658,7 +1658,7 @@ void hash_compute_compare(int alg_arg, data_t *input,
                                 output, sizeof(output),
                                 &output_length));
     TEST_EQUAL(output_length, PSA_HASH_LENGTH(alg));
-    ASSERT_COMPARE(output, output_length,
+    TEST_BUFFERS_EQUAL(output, output_length,
                    expected_output->x, expected_output->len);
 
     /* Compare with correct hash */
@@ -2195,7 +2195,7 @@ void mac_sign(int key_type_arg,
                                    actual_mac, output_size, &mac_length),
                    expected_status);
         if (expected_status == PSA_SUCCESS) {
-            ASSERT_COMPARE(expected_mac->x, expected_mac->len,
+            TEST_BUFFERS_EQUAL(expected_mac->x, expected_mac->len,
                            actual_mac, mac_length);
         }
 
@@ -2214,7 +2214,7 @@ void mac_sign(int key_type_arg,
         PSA_ASSERT(psa_mac_abort(&operation));
 
         if (expected_status == PSA_SUCCESS) {
-            ASSERT_COMPARE(expected_mac->x, expected_mac->len,
+            TEST_BUFFERS_EQUAL(expected_mac->x, expected_mac->len,
                            actual_mac, mac_length);
         }
         mbedtls_free(actual_mac);
@@ -2697,7 +2697,7 @@ void cipher_alg_without_iv(int alg_arg, int key_type_arg, data_t *key_data,
                                  output_buffer_size - output_length,
                                  &length));
     output_length += length;
-    ASSERT_COMPARE(ciphertext->x, ciphertext->len,
+    TEST_BUFFERS_EQUAL(ciphertext->x, ciphertext->len,
                    output, output_length);
 
     /* Multipart encryption */
@@ -2715,7 +2715,7 @@ void cipher_alg_without_iv(int alg_arg, int key_type_arg, data_t *key_data,
                                  output_buffer_size - output_length,
                                  &length));
     output_length += length;
-    ASSERT_COMPARE(plaintext->x, plaintext->len,
+    TEST_BUFFERS_EQUAL(plaintext->x, plaintext->len,
                    output, output_length);
 
     /* One-shot encryption */
@@ -2723,7 +2723,7 @@ void cipher_alg_without_iv(int alg_arg, int key_type_arg, data_t *key_data,
     PSA_ASSERT(psa_cipher_encrypt(key, alg, plaintext->x, plaintext->len,
                                   output, output_buffer_size,
                                   &output_length));
-    ASSERT_COMPARE(ciphertext->x, ciphertext->len,
+    TEST_BUFFERS_EQUAL(ciphertext->x, ciphertext->len,
                    output, output_length);
 
     /* One-shot decryption */
@@ -2731,7 +2731,7 @@ void cipher_alg_without_iv(int alg_arg, int key_type_arg, data_t *key_data,
     PSA_ASSERT(psa_cipher_decrypt(key, alg, ciphertext->x, ciphertext->len,
                                   output, output_buffer_size,
                                   &output_length));
-    ASSERT_COMPARE(plaintext->x, plaintext->len,
+    TEST_BUFFERS_EQUAL(plaintext->x, plaintext->len,
                    output, output_length);
 
 exit:
@@ -2850,7 +2850,7 @@ void cipher_encrypt_validation(int alg_arg,
     output2_length += function_output_length;
 
     PSA_ASSERT(psa_cipher_abort(&operation));
-    ASSERT_COMPARE(output1 + iv_size, output1_length - iv_size,
+    TEST_BUFFERS_EQUAL(output1 + iv_size, output1_length - iv_size,
                    output2, output2_length);
 
 exit:
@@ -2949,7 +2949,7 @@ void cipher_encrypt_multipart(int alg_arg, int key_type_arg,
     if (expected_status == PSA_SUCCESS) {
         PSA_ASSERT(psa_cipher_abort(&operation));
 
-        ASSERT_COMPARE(expected_output->x, expected_output->len,
+        TEST_BUFFERS_EQUAL(expected_output->x, expected_output->len,
                        output, total_output_length);
     }
 
@@ -3049,7 +3049,7 @@ void cipher_decrypt_multipart(int alg_arg, int key_type_arg,
     if (expected_status == PSA_SUCCESS) {
         PSA_ASSERT(psa_cipher_abort(&operation));
 
-        ASSERT_COMPARE(expected_output->x, expected_output->len,
+        TEST_BUFFERS_EQUAL(expected_output->x, expected_output->len,
                        output, total_output_length);
     }
 
@@ -3160,7 +3160,7 @@ void cipher_decrypt(int alg_arg,
     TEST_LE_U(output_length,
               PSA_CIPHER_DECRYPT_OUTPUT_MAX_SIZE(input_buffer_size));
 
-    ASSERT_COMPARE(expected_output->x, expected_output->len,
+    TEST_BUFFERS_EQUAL(expected_output->x, expected_output->len,
                    output, output_length);
 exit:
     mbedtls_free(input);
@@ -3217,7 +3217,7 @@ void cipher_verify_output(int alg_arg,
     TEST_LE_U(output2_length,
               PSA_CIPHER_DECRYPT_OUTPUT_MAX_SIZE(output1_length));
 
-    ASSERT_COMPARE(input->x, input->len, output2, output2_length);
+    TEST_BUFFERS_EQUAL(input->x, input->len, output2, output2_length);
 
 exit:
     mbedtls_free(output1);
@@ -3357,7 +3357,7 @@ void cipher_verify_output_multipart(int alg_arg,
 
     PSA_ASSERT(psa_cipher_abort(&operation2));
 
-    ASSERT_COMPARE(input->x, input->len, output2, output2_length);
+    TEST_BUFFERS_EQUAL(input->x, input->len, output2, output2_length);
 
 exit:
     psa_cipher_abort(&operation1);
@@ -3452,7 +3452,7 @@ void aead_encrypt_decrypt(int key_type_arg, data_t *key_data,
                                     &output_length2),
                    expected_result);
 
-        ASSERT_COMPARE(input_data->x, input_data->len,
+        TEST_BUFFERS_EQUAL(input_data->x, input_data->len,
                        output_data2, output_length2);
     }
 
@@ -3519,7 +3519,7 @@ void aead_encrypt(int key_type_arg, data_t *key_data,
     }
 
     PSA_ASSERT(status);
-    ASSERT_COMPARE(expected_result->x, expected_result->len,
+    TEST_BUFFERS_EQUAL(expected_result->x, expected_result->len,
                    output_data, output_length);
 
 exit:
@@ -3592,7 +3592,7 @@ void aead_decrypt(int key_type_arg, data_t *key_data,
     TEST_EQUAL(status, expected_result);
 
     if (expected_result == PSA_SUCCESS) {
-        ASSERT_COMPARE(expected_data->x, expected_data->len,
+        TEST_BUFFERS_EQUAL(expected_data->x, expected_data->len,
                        output_data, output_length);
     }
 
@@ -3663,7 +3663,7 @@ void sign_hash_deterministic(int key_type_arg, data_t *key_data,
                              signature, signature_size,
                              &signature_length));
     /* Verify that the signature is what is expected. */
-    ASSERT_COMPARE(output_data->x, output_data->len,
+    TEST_BUFFERS_EQUAL(output_data->x, output_data->len,
                    signature, signature_length);
 
 #if defined(MBEDTLS_TEST_DEPRECATED)
@@ -3673,7 +3673,7 @@ void sign_hash_deterministic(int key_type_arg, data_t *key_data,
                                    input_data->x, input_data->len,
                                    signature, signature_size,
                                    &signature_length));
-    ASSERT_COMPARE(output_data->x, output_data->len,
+    TEST_BUFFERS_EQUAL(output_data->x, output_data->len,
                    signature, signature_length);
 #endif /* MBEDTLS_TEST_DEPRECATED */
 
@@ -3933,7 +3933,7 @@ void sign_message_deterministic(int key_type_arg,
                                 signature, signature_size,
                                 &signature_length));
 
-    ASSERT_COMPARE(output_data->x, output_data->len,
+    TEST_BUFFERS_EQUAL(output_data->x, output_data->len,
                    signature, signature_length);
 
 exit:
@@ -4271,7 +4271,7 @@ void asymmetric_encrypt_decrypt(int key_type_arg,
                                       label->x, label->len,
                                       output2, output2_size,
                                       &output2_length));
-    ASSERT_COMPARE(input_data->x, input_data->len,
+    TEST_BUFFERS_EQUAL(input_data->x, input_data->len,
                    output2, output2_length);
 
 exit:
@@ -4328,7 +4328,7 @@ void asymmetric_decrypt(int key_type_arg,
                                       output,
                                       output_size,
                                       &output_length));
-    ASSERT_COMPARE(expected_data->x, expected_data->len,
+    TEST_BUFFERS_EQUAL(expected_data->x, expected_data->len,
                    output, output_length);
 
     /* If the label is empty, the test framework puts a non-null pointer
@@ -4344,7 +4344,7 @@ void asymmetric_decrypt(int key_type_arg,
                                           output,
                                           output_size,
                                           &output_length));
-        ASSERT_COMPARE(expected_data->x, expected_data->len,
+        TEST_BUFFERS_EQUAL(expected_data->x, expected_data->len,
                        output, output_length);
     }
 
@@ -4756,7 +4756,7 @@ void derive_output(int alg_arg,
         /* Success. Check the read data. */
         PSA_ASSERT(status);
         if (output_sizes[i] != 0) {
-            ASSERT_COMPARE(output_buffer, output_sizes[i],
+            TEST_BUFFERS_EQUAL(output_buffer, output_sizes[i],
                            expected_outputs[i], output_sizes[i]);
         }
         /* Check the operation status. */
@@ -4982,7 +4982,7 @@ void derive_key_export(int alg_arg,
     TEST_EQUAL(length, bytes2);
 
     /* Compare the outputs from the two runs. */
-    ASSERT_COMPARE(output_buffer, bytes1 + bytes2,
+    TEST_BUFFERS_EQUAL(output_buffer, bytes1 + bytes2,
                    export_buffer, capacity);
 
 exit:
@@ -5133,7 +5133,7 @@ void raw_key_agreement(int alg_arg,
                                      peer_key_data->x, peer_key_data->len,
                                      output, expected_output->len,
                                      &output_length));
-    ASSERT_COMPARE(output, output_length,
+    TEST_BUFFERS_EQUAL(output, output_length,
                    expected_output->x, expected_output->len);
     mbedtls_free(output);
     output = NULL;
@@ -5145,7 +5145,7 @@ void raw_key_agreement(int alg_arg,
                                      peer_key_data->x, peer_key_data->len,
                                      output, expected_output->len + 1,
                                      &output_length));
-    ASSERT_COMPARE(output, output_length,
+    TEST_BUFFERS_EQUAL(output, output_length,
                    expected_output->x, expected_output->len);
     mbedtls_free(output);
     output = NULL;
@@ -5268,13 +5268,13 @@ void key_agreement_output(int alg_arg,
     PSA_ASSERT(psa_key_derivation_output_bytes(&operation,
                                                actual_output,
                                                expected_output1->len));
-    ASSERT_COMPARE(actual_output, expected_output1->len,
+    TEST_BUFFERS_EQUAL(actual_output, expected_output1->len,
                    expected_output1->x, expected_output1->len);
     if (expected_output2->len != 0) {
         PSA_ASSERT(psa_key_derivation_output_bytes(&operation,
                                                    actual_output,
                                                    expected_output2->len));
-        ASSERT_COMPARE(actual_output, expected_output2->len,
+        TEST_BUFFERS_EQUAL(actual_output, expected_output2->len,
                        expected_output2->x, expected_output2->len);
     }
 
@@ -5443,7 +5443,7 @@ void generate_key_rsa(int bits_arg,
     if (is_default_public_exponent) {
         TEST_EQUAL(e_read_length, 0);
     } else {
-        ASSERT_COMPARE(e_read_buffer, e_read_length, e_arg->x, e_arg->len);
+        TEST_BUFFERS_EQUAL(e_read_buffer, e_read_length, e_arg->x, e_arg->len);
     }
 
     /* Do something with the key according to its type and permitted usage. */
@@ -5479,7 +5479,7 @@ void generate_key_rsa(int bits_arg,
             TEST_EQUAL(p[1], 0);
             TEST_EQUAL(p[2], 1);
         } else {
-            ASSERT_COMPARE(p, len, e_arg->x, e_arg->len);
+            TEST_BUFFERS_EQUAL(p, len, e_arg->x, e_arg->len);
         }
     }
 
@@ -5588,7 +5588,7 @@ void persistent_key_load_key_from_storage(data_t *data,
                                   first_export, export_size,
                                   &first_exported_length));
         if (generation_method == IMPORT_KEY) {
-            ASSERT_COMPARE(data->x, data->len,
+            TEST_BUFFERS_EQUAL(data->x, data->len,
                            first_export, first_exported_length);
         }
     }
@@ -5615,7 +5615,7 @@ void persistent_key_load_key_from_storage(data_t *data,
         PSA_ASSERT(psa_export_key(key,
                                   second_export, export_size,
                                   &second_exported_length));
-        ASSERT_COMPARE(first_export, first_exported_length,
+        TEST_BUFFERS_EQUAL(first_export, first_exported_length,
                        second_export, second_exported_length);
     }
 

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -471,7 +471,7 @@ void import_large_key(int type_arg, int byte_size_arg,
 
     /* Skip the test case if the target running the test cannot
      * accommodate large keys due to heap size constraints */
-    ASSERT_ALLOC_WEAK(buffer, buffer_size);
+    TEST_CALLOC_OR_SKIP(buffer, buffer_size);
     memset(buffer, 'K', byte_size);
 
     PSA_ASSERT(psa_crypto_init());

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -623,7 +623,7 @@ void import_export(data_t *data,
     }
 
     if (canonical_input) {
-        TEST_BUFFERS_EQUAL(data->x, data->len, exported, exported_length);
+        TEST_MEMORY_COMPARE(data->x, data->len, exported, exported_length);
     } else {
         mbedtls_svc_key_id_t key2 = MBEDTLS_SVC_KEY_ID_INIT;
         PSA_ASSERT(psa_import_key(&attributes, exported, exported_length,
@@ -632,7 +632,7 @@ void import_export(data_t *data,
                                   reexported,
                                   export_size,
                                   &reexported_length));
-        TEST_BUFFERS_EQUAL(exported, exported_length,
+        TEST_MEMORY_COMPARE(exported, exported_length,
                        reexported, reexported_length);
         PSA_ASSERT(psa_destroy_key(key2));
     }
@@ -703,7 +703,7 @@ void import_export_public_key(data_t *data,
                   PSA_EXPORT_PUBLIC_KEY_OUTPUT_SIZE(public_type, bits));
         TEST_LE_U(expected_public_key->len,
                   PSA_EXPORT_PUBLIC_KEY_MAX_SIZE);
-        TEST_BUFFERS_EQUAL(expected_public_key->x, expected_public_key->len,
+        TEST_MEMORY_COMPARE(expected_public_key->x, expected_public_key->len,
                        exported, exported_length);
     }
 
@@ -1449,7 +1449,7 @@ void copy_success(int source_usage_arg,
         TEST_CALLOC(export_buffer, material->len);
         PSA_ASSERT(psa_export_key(target_key, export_buffer,
                                   material->len, &length));
-        TEST_BUFFERS_EQUAL(material->x, material->len,
+        TEST_MEMORY_COMPARE(material->x, material->len,
                        export_buffer, length);
     }
 
@@ -1650,7 +1650,7 @@ void hash_compute_compare(int alg_arg, data_t *input,
                                 output, PSA_HASH_LENGTH(alg),
                                 &output_length));
     TEST_EQUAL(output_length, PSA_HASH_LENGTH(alg));
-    TEST_BUFFERS_EQUAL(output, output_length,
+    TEST_MEMORY_COMPARE(output, output_length,
                    expected_output->x, expected_output->len);
 
     /* Compute with larger buffer */
@@ -1658,7 +1658,7 @@ void hash_compute_compare(int alg_arg, data_t *input,
                                 output, sizeof(output),
                                 &output_length));
     TEST_EQUAL(output_length, PSA_HASH_LENGTH(alg));
-    TEST_BUFFERS_EQUAL(output, output_length,
+    TEST_MEMORY_COMPARE(output, output_length,
                    expected_output->x, expected_output->len);
 
     /* Compare with correct hash */
@@ -2195,7 +2195,7 @@ void mac_sign(int key_type_arg,
                                    actual_mac, output_size, &mac_length),
                    expected_status);
         if (expected_status == PSA_SUCCESS) {
-            TEST_BUFFERS_EQUAL(expected_mac->x, expected_mac->len,
+            TEST_MEMORY_COMPARE(expected_mac->x, expected_mac->len,
                            actual_mac, mac_length);
         }
 
@@ -2214,7 +2214,7 @@ void mac_sign(int key_type_arg,
         PSA_ASSERT(psa_mac_abort(&operation));
 
         if (expected_status == PSA_SUCCESS) {
-            TEST_BUFFERS_EQUAL(expected_mac->x, expected_mac->len,
+            TEST_MEMORY_COMPARE(expected_mac->x, expected_mac->len,
                            actual_mac, mac_length);
         }
         mbedtls_free(actual_mac);
@@ -2697,7 +2697,7 @@ void cipher_alg_without_iv(int alg_arg, int key_type_arg, data_t *key_data,
                                  output_buffer_size - output_length,
                                  &length));
     output_length += length;
-    TEST_BUFFERS_EQUAL(ciphertext->x, ciphertext->len,
+    TEST_MEMORY_COMPARE(ciphertext->x, ciphertext->len,
                    output, output_length);
 
     /* Multipart encryption */
@@ -2715,7 +2715,7 @@ void cipher_alg_without_iv(int alg_arg, int key_type_arg, data_t *key_data,
                                  output_buffer_size - output_length,
                                  &length));
     output_length += length;
-    TEST_BUFFERS_EQUAL(plaintext->x, plaintext->len,
+    TEST_MEMORY_COMPARE(plaintext->x, plaintext->len,
                    output, output_length);
 
     /* One-shot encryption */
@@ -2723,7 +2723,7 @@ void cipher_alg_without_iv(int alg_arg, int key_type_arg, data_t *key_data,
     PSA_ASSERT(psa_cipher_encrypt(key, alg, plaintext->x, plaintext->len,
                                   output, output_buffer_size,
                                   &output_length));
-    TEST_BUFFERS_EQUAL(ciphertext->x, ciphertext->len,
+    TEST_MEMORY_COMPARE(ciphertext->x, ciphertext->len,
                    output, output_length);
 
     /* One-shot decryption */
@@ -2731,7 +2731,7 @@ void cipher_alg_without_iv(int alg_arg, int key_type_arg, data_t *key_data,
     PSA_ASSERT(psa_cipher_decrypt(key, alg, ciphertext->x, ciphertext->len,
                                   output, output_buffer_size,
                                   &output_length));
-    TEST_BUFFERS_EQUAL(plaintext->x, plaintext->len,
+    TEST_MEMORY_COMPARE(plaintext->x, plaintext->len,
                    output, output_length);
 
 exit:
@@ -2850,7 +2850,7 @@ void cipher_encrypt_validation(int alg_arg,
     output2_length += function_output_length;
 
     PSA_ASSERT(psa_cipher_abort(&operation));
-    TEST_BUFFERS_EQUAL(output1 + iv_size, output1_length - iv_size,
+    TEST_MEMORY_COMPARE(output1 + iv_size, output1_length - iv_size,
                    output2, output2_length);
 
 exit:
@@ -2949,7 +2949,7 @@ void cipher_encrypt_multipart(int alg_arg, int key_type_arg,
     if (expected_status == PSA_SUCCESS) {
         PSA_ASSERT(psa_cipher_abort(&operation));
 
-        TEST_BUFFERS_EQUAL(expected_output->x, expected_output->len,
+        TEST_MEMORY_COMPARE(expected_output->x, expected_output->len,
                        output, total_output_length);
     }
 
@@ -3049,7 +3049,7 @@ void cipher_decrypt_multipart(int alg_arg, int key_type_arg,
     if (expected_status == PSA_SUCCESS) {
         PSA_ASSERT(psa_cipher_abort(&operation));
 
-        TEST_BUFFERS_EQUAL(expected_output->x, expected_output->len,
+        TEST_MEMORY_COMPARE(expected_output->x, expected_output->len,
                        output, total_output_length);
     }
 
@@ -3160,7 +3160,7 @@ void cipher_decrypt(int alg_arg,
     TEST_LE_U(output_length,
               PSA_CIPHER_DECRYPT_OUTPUT_MAX_SIZE(input_buffer_size));
 
-    TEST_BUFFERS_EQUAL(expected_output->x, expected_output->len,
+    TEST_MEMORY_COMPARE(expected_output->x, expected_output->len,
                    output, output_length);
 exit:
     mbedtls_free(input);
@@ -3217,7 +3217,7 @@ void cipher_verify_output(int alg_arg,
     TEST_LE_U(output2_length,
               PSA_CIPHER_DECRYPT_OUTPUT_MAX_SIZE(output1_length));
 
-    TEST_BUFFERS_EQUAL(input->x, input->len, output2, output2_length);
+    TEST_MEMORY_COMPARE(input->x, input->len, output2, output2_length);
 
 exit:
     mbedtls_free(output1);
@@ -3357,7 +3357,7 @@ void cipher_verify_output_multipart(int alg_arg,
 
     PSA_ASSERT(psa_cipher_abort(&operation2));
 
-    TEST_BUFFERS_EQUAL(input->x, input->len, output2, output2_length);
+    TEST_MEMORY_COMPARE(input->x, input->len, output2, output2_length);
 
 exit:
     psa_cipher_abort(&operation1);
@@ -3452,7 +3452,7 @@ void aead_encrypt_decrypt(int key_type_arg, data_t *key_data,
                                     &output_length2),
                    expected_result);
 
-        TEST_BUFFERS_EQUAL(input_data->x, input_data->len,
+        TEST_MEMORY_COMPARE(input_data->x, input_data->len,
                        output_data2, output_length2);
     }
 
@@ -3519,7 +3519,7 @@ void aead_encrypt(int key_type_arg, data_t *key_data,
     }
 
     PSA_ASSERT(status);
-    TEST_BUFFERS_EQUAL(expected_result->x, expected_result->len,
+    TEST_MEMORY_COMPARE(expected_result->x, expected_result->len,
                    output_data, output_length);
 
 exit:
@@ -3592,7 +3592,7 @@ void aead_decrypt(int key_type_arg, data_t *key_data,
     TEST_EQUAL(status, expected_result);
 
     if (expected_result == PSA_SUCCESS) {
-        TEST_BUFFERS_EQUAL(expected_data->x, expected_data->len,
+        TEST_MEMORY_COMPARE(expected_data->x, expected_data->len,
                        output_data, output_length);
     }
 
@@ -3663,7 +3663,7 @@ void sign_hash_deterministic(int key_type_arg, data_t *key_data,
                              signature, signature_size,
                              &signature_length));
     /* Verify that the signature is what is expected. */
-    TEST_BUFFERS_EQUAL(output_data->x, output_data->len,
+    TEST_MEMORY_COMPARE(output_data->x, output_data->len,
                    signature, signature_length);
 
 #if defined(MBEDTLS_TEST_DEPRECATED)
@@ -3673,7 +3673,7 @@ void sign_hash_deterministic(int key_type_arg, data_t *key_data,
                                    input_data->x, input_data->len,
                                    signature, signature_size,
                                    &signature_length));
-    TEST_BUFFERS_EQUAL(output_data->x, output_data->len,
+    TEST_MEMORY_COMPARE(output_data->x, output_data->len,
                    signature, signature_length);
 #endif /* MBEDTLS_TEST_DEPRECATED */
 
@@ -3933,7 +3933,7 @@ void sign_message_deterministic(int key_type_arg,
                                 signature, signature_size,
                                 &signature_length));
 
-    TEST_BUFFERS_EQUAL(output_data->x, output_data->len,
+    TEST_MEMORY_COMPARE(output_data->x, output_data->len,
                    signature, signature_length);
 
 exit:
@@ -4271,7 +4271,7 @@ void asymmetric_encrypt_decrypt(int key_type_arg,
                                       label->x, label->len,
                                       output2, output2_size,
                                       &output2_length));
-    TEST_BUFFERS_EQUAL(input_data->x, input_data->len,
+    TEST_MEMORY_COMPARE(input_data->x, input_data->len,
                    output2, output2_length);
 
 exit:
@@ -4328,7 +4328,7 @@ void asymmetric_decrypt(int key_type_arg,
                                       output,
                                       output_size,
                                       &output_length));
-    TEST_BUFFERS_EQUAL(expected_data->x, expected_data->len,
+    TEST_MEMORY_COMPARE(expected_data->x, expected_data->len,
                    output, output_length);
 
     /* If the label is empty, the test framework puts a non-null pointer
@@ -4344,7 +4344,7 @@ void asymmetric_decrypt(int key_type_arg,
                                           output,
                                           output_size,
                                           &output_length));
-        TEST_BUFFERS_EQUAL(expected_data->x, expected_data->len,
+        TEST_MEMORY_COMPARE(expected_data->x, expected_data->len,
                        output, output_length);
     }
 
@@ -4756,7 +4756,7 @@ void derive_output(int alg_arg,
         /* Success. Check the read data. */
         PSA_ASSERT(status);
         if (output_sizes[i] != 0) {
-            TEST_BUFFERS_EQUAL(output_buffer, output_sizes[i],
+            TEST_MEMORY_COMPARE(output_buffer, output_sizes[i],
                            expected_outputs[i], output_sizes[i]);
         }
         /* Check the operation status. */
@@ -4982,7 +4982,7 @@ void derive_key_export(int alg_arg,
     TEST_EQUAL(length, bytes2);
 
     /* Compare the outputs from the two runs. */
-    TEST_BUFFERS_EQUAL(output_buffer, bytes1 + bytes2,
+    TEST_MEMORY_COMPARE(output_buffer, bytes1 + bytes2,
                    export_buffer, capacity);
 
 exit:
@@ -5133,7 +5133,7 @@ void raw_key_agreement(int alg_arg,
                                      peer_key_data->x, peer_key_data->len,
                                      output, expected_output->len,
                                      &output_length));
-    TEST_BUFFERS_EQUAL(output, output_length,
+    TEST_MEMORY_COMPARE(output, output_length,
                    expected_output->x, expected_output->len);
     mbedtls_free(output);
     output = NULL;
@@ -5145,7 +5145,7 @@ void raw_key_agreement(int alg_arg,
                                      peer_key_data->x, peer_key_data->len,
                                      output, expected_output->len + 1,
                                      &output_length));
-    TEST_BUFFERS_EQUAL(output, output_length,
+    TEST_MEMORY_COMPARE(output, output_length,
                    expected_output->x, expected_output->len);
     mbedtls_free(output);
     output = NULL;
@@ -5268,13 +5268,13 @@ void key_agreement_output(int alg_arg,
     PSA_ASSERT(psa_key_derivation_output_bytes(&operation,
                                                actual_output,
                                                expected_output1->len));
-    TEST_BUFFERS_EQUAL(actual_output, expected_output1->len,
+    TEST_MEMORY_COMPARE(actual_output, expected_output1->len,
                    expected_output1->x, expected_output1->len);
     if (expected_output2->len != 0) {
         PSA_ASSERT(psa_key_derivation_output_bytes(&operation,
                                                    actual_output,
                                                    expected_output2->len));
-        TEST_BUFFERS_EQUAL(actual_output, expected_output2->len,
+        TEST_MEMORY_COMPARE(actual_output, expected_output2->len,
                        expected_output2->x, expected_output2->len);
     }
 
@@ -5443,7 +5443,7 @@ void generate_key_rsa(int bits_arg,
     if (is_default_public_exponent) {
         TEST_EQUAL(e_read_length, 0);
     } else {
-        TEST_BUFFERS_EQUAL(e_read_buffer, e_read_length, e_arg->x, e_arg->len);
+        TEST_MEMORY_COMPARE(e_read_buffer, e_read_length, e_arg->x, e_arg->len);
     }
 
     /* Do something with the key according to its type and permitted usage. */
@@ -5479,7 +5479,7 @@ void generate_key_rsa(int bits_arg,
             TEST_EQUAL(p[1], 0);
             TEST_EQUAL(p[2], 1);
         } else {
-            TEST_BUFFERS_EQUAL(p, len, e_arg->x, e_arg->len);
+            TEST_MEMORY_COMPARE(p, len, e_arg->x, e_arg->len);
         }
     }
 
@@ -5588,7 +5588,7 @@ void persistent_key_load_key_from_storage(data_t *data,
                                   first_export, export_size,
                                   &first_exported_length));
         if (generation_method == IMPORT_KEY) {
-            TEST_BUFFERS_EQUAL(data->x, data->len,
+            TEST_MEMORY_COMPARE(data->x, data->len,
                            first_export, first_exported_length);
         }
     }
@@ -5615,7 +5615,7 @@ void persistent_key_load_key_from_storage(data_t *data,
         PSA_ASSERT(psa_export_key(key,
                                   second_export, export_size,
                                   &second_exported_length));
-        TEST_BUFFERS_EQUAL(first_export, first_exported_length,
+        TEST_MEMORY_COMPARE(first_export, first_exported_length,
                        second_export, second_exported_length);
     }
 

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -533,7 +533,7 @@ void import_rsa_made_up(int bits_arg, int keypair, int expected_status_arg)
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
 
     PSA_ASSERT(psa_crypto_init());
-    ASSERT_ALLOC(buffer, buffer_size);
+    TEST_CALLOC_OR_FAIL(buffer, buffer_size);
 
     TEST_ASSERT((ret = construct_fake_rsa_key(buffer, buffer_size, &p,
                                               bits, keypair)) >= 0);
@@ -578,9 +578,9 @@ void import_export(data_t *data,
     psa_key_attributes_t got_attributes = PSA_KEY_ATTRIBUTES_INIT;
 
     export_size = (ptrdiff_t) data->len + export_size_delta;
-    ASSERT_ALLOC(exported, export_size);
+    TEST_CALLOC_OR_FAIL(exported, export_size);
     if (!canonical_input) {
-        ASSERT_ALLOC(reexported, export_size);
+        TEST_CALLOC_OR_FAIL(reexported, export_size);
     }
     PSA_ASSERT(psa_crypto_init());
 
@@ -687,7 +687,7 @@ void import_export_public_key(data_t *data,
     PSA_ASSERT(psa_import_key(&attributes, data->x, data->len, &key));
 
     /* Export the public key */
-    ASSERT_ALLOC(exported, export_size);
+    TEST_CALLOC_OR_FAIL(exported, export_size);
     status = psa_export_public_key(key,
                                    exported, export_size,
                                    &exported_length);
@@ -1081,7 +1081,7 @@ void asymmetric_encryption_key_policy(int policy_usage_arg,
     key_bits = psa_get_key_bits(&attributes);
     buffer_length = PSA_ASYMMETRIC_ENCRYPT_OUTPUT_SIZE(key_type, key_bits,
                                                        exercise_alg);
-    ASSERT_ALLOC(buffer, buffer_length);
+    TEST_CALLOC_OR_FAIL(buffer, buffer_length);
 
     status = psa_asymmetric_encrypt(key, exercise_alg,
                                     NULL, 0,
@@ -1446,7 +1446,7 @@ void copy_success(int source_usage_arg,
                psa_get_key_enrollment_algorithm(&target_attributes));
     if (expected_usage & PSA_KEY_USAGE_EXPORT) {
         size_t length;
-        ASSERT_ALLOC(export_buffer, material->len);
+        TEST_CALLOC_OR_FAIL(export_buffer, material->len);
         PSA_ASSERT(psa_export_key(target_key, export_buffer,
                                   material->len, &length));
         TEST_BUFFERS_EQUAL(material->x, material->len,
@@ -1599,7 +1599,7 @@ void hash_compute_fail(int alg_arg, data_t *input,
     psa_status_t expected_status = expected_status_arg;
     psa_status_t status;
 
-    ASSERT_ALLOC(output, output_size);
+    TEST_CALLOC_OR_FAIL(output, output_size);
 
     PSA_ASSERT(psa_crypto_init());
 
@@ -2187,7 +2187,7 @@ void mac_sign(int key_type_arg,
              PSA_ERROR_BUFFER_TOO_SMALL);
 
         mbedtls_test_set_step(output_size);
-        ASSERT_ALLOC(actual_mac, output_size);
+        TEST_CALLOC_OR_FAIL(actual_mac, output_size);
 
         /* Calculate the MAC, one-shot case. */
         TEST_EQUAL(psa_mac_compute(key, alg,
@@ -2283,7 +2283,7 @@ void mac_verify(int key_type_arg,
                PSA_ERROR_INVALID_SIGNATURE);
 
     /* Test a MAC that's too long, one-shot case. */
-    ASSERT_ALLOC(perturbed_mac, expected_mac->len + 1);
+    TEST_CALLOC_OR_FAIL(perturbed_mac, expected_mac->len + 1);
     memcpy(perturbed_mac, expected_mac->x, expected_mac->len);
     TEST_EQUAL(psa_mac_verify(key, alg,
                               input->x, input->len,
@@ -2608,7 +2608,7 @@ void cipher_encrypt_fail(int alg_arg,
 
         output_buffer_size = PSA_CIPHER_ENCRYPT_OUTPUT_SIZE(key_type, alg,
                                                             input->len);
-        ASSERT_ALLOC(output, output_buffer_size);
+        TEST_CALLOC_OR_FAIL(output, output_buffer_size);
 
         PSA_ASSERT(psa_import_key(&attributes, key_data->x, key_data->len,
                                   &key));
@@ -2662,7 +2662,7 @@ void cipher_alg_without_iv(int alg_arg, int key_type_arg, data_t *key_data,
                               &key));
     output_buffer_size = PSA_CIPHER_ENCRYPT_OUTPUT_SIZE(key_type, alg,
                                                         plaintext->len);
-    ASSERT_ALLOC(output, output_buffer_size);
+    TEST_CALLOC_OR_FAIL(output, output_buffer_size);
 
     /* set_iv() is not allowed */
     PSA_ASSERT(psa_cipher_encrypt_setup(&operation, key, alg));
@@ -2811,8 +2811,8 @@ void cipher_encrypt_validation(int alg_arg,
     output1_buffer_size = PSA_CIPHER_ENCRYPT_OUTPUT_SIZE(key_type, alg, input->len);
     output2_buffer_size = PSA_CIPHER_UPDATE_OUTPUT_SIZE(key_type, alg, input->len) +
                           PSA_CIPHER_FINISH_OUTPUT_SIZE(key_type, alg);
-    ASSERT_ALLOC(output1, output1_buffer_size);
-    ASSERT_ALLOC(output2, output2_buffer_size);
+    TEST_CALLOC_OR_FAIL(output1, output1_buffer_size);
+    TEST_CALLOC_OR_FAIL(output2, output2_buffer_size);
 
     PSA_ASSERT(psa_import_key(&attributes, key_data->x, key_data->len,
                               &key));
@@ -2903,7 +2903,7 @@ void cipher_encrypt_multipart(int alg_arg, int key_type_arg,
 
     output_buffer_size = PSA_CIPHER_UPDATE_OUTPUT_SIZE(key_type, alg, input->len) +
                          PSA_CIPHER_FINISH_OUTPUT_SIZE(key_type, alg);
-    ASSERT_ALLOC(output, output_buffer_size);
+    TEST_CALLOC_OR_FAIL(output, output_buffer_size);
 
     TEST_LE_U(first_part_size, input->len);
     PSA_ASSERT(psa_cipher_update(&operation, input->x, first_part_size,
@@ -3002,7 +3002,7 @@ void cipher_decrypt_multipart(int alg_arg, int key_type_arg,
 
     output_buffer_size = PSA_CIPHER_UPDATE_OUTPUT_SIZE(key_type, alg, input->len) +
                          PSA_CIPHER_FINISH_OUTPUT_SIZE(key_type, alg);
-    ASSERT_ALLOC(output, output_buffer_size);
+    TEST_CALLOC_OR_FAIL(output, output_buffer_size);
 
     TEST_LE_U(first_part_size, input->len);
     PSA_ASSERT(psa_cipher_update(&operation,
@@ -3095,13 +3095,13 @@ void cipher_decrypt_fail(int alg_arg,
     /* Allocate input buffer and copy the iv and the plaintext */
     input_buffer_size = ((size_t) input_arg->len + (size_t) iv->len);
     if (input_buffer_size > 0) {
-        ASSERT_ALLOC(input, input_buffer_size);
+        TEST_CALLOC_OR_FAIL(input, input_buffer_size);
         memcpy(input, iv->x, iv->len);
         memcpy(input + iv->len, input_arg->x, input_arg->len);
     }
 
     output_buffer_size = PSA_CIPHER_DECRYPT_OUTPUT_SIZE(key_type, alg, input_buffer_size);
-    ASSERT_ALLOC(output, output_buffer_size);
+    TEST_CALLOC_OR_FAIL(output, output_buffer_size);
 
     status = psa_cipher_decrypt(key, alg, input, input_buffer_size, output,
                                 output_buffer_size, &output_length);
@@ -3142,13 +3142,13 @@ void cipher_decrypt(int alg_arg,
     /* Allocate input buffer and copy the iv and the plaintext */
     input_buffer_size = ((size_t) input_arg->len + (size_t) iv->len);
     if (input_buffer_size > 0) {
-        ASSERT_ALLOC(input, input_buffer_size);
+        TEST_CALLOC_OR_FAIL(input, input_buffer_size);
         memcpy(input, iv->x, iv->len);
         memcpy(input + iv->len, input_arg->x, input_arg->len);
     }
 
     output_buffer_size = PSA_CIPHER_DECRYPT_OUTPUT_SIZE(key_type, alg, input_buffer_size);
-    ASSERT_ALLOC(output, output_buffer_size);
+    TEST_CALLOC_OR_FAIL(output, output_buffer_size);
 
     PSA_ASSERT(psa_import_key(&attributes, key_data->x, key_data->len,
                               &key));
@@ -3196,7 +3196,7 @@ void cipher_verify_output(int alg_arg,
     PSA_ASSERT(psa_import_key(&attributes, key_data->x, key_data->len,
                               &key));
     output1_size = PSA_CIPHER_ENCRYPT_OUTPUT_SIZE(key_type, alg, input->len);
-    ASSERT_ALLOC(output1, output1_size);
+    TEST_CALLOC_OR_FAIL(output1, output1_size);
 
     PSA_ASSERT(psa_cipher_encrypt(key, alg, input->x, input->len,
                                   output1, output1_size,
@@ -3207,7 +3207,7 @@ void cipher_verify_output(int alg_arg,
               PSA_CIPHER_ENCRYPT_OUTPUT_MAX_SIZE(input->len));
 
     output2_size = output1_length;
-    ASSERT_ALLOC(output2, output2_size);
+    TEST_CALLOC_OR_FAIL(output2, output2_size);
 
     PSA_ASSERT(psa_cipher_decrypt(key, alg, output1, output1_length,
                                   output2, output2_size,
@@ -3273,7 +3273,7 @@ void cipher_verify_output_multipart(int alg_arg,
     output1_buffer_size = PSA_CIPHER_ENCRYPT_OUTPUT_SIZE(key_type, alg, input->len);
     TEST_LE_U(output1_buffer_size,
               PSA_CIPHER_ENCRYPT_OUTPUT_MAX_SIZE(input->len));
-    ASSERT_ALLOC(output1, output1_buffer_size);
+    TEST_CALLOC_OR_FAIL(output1, output1_buffer_size);
 
     TEST_LE_U(first_part_size, input->len);
 
@@ -3316,7 +3316,7 @@ void cipher_verify_output_multipart(int alg_arg,
               PSA_CIPHER_DECRYPT_OUTPUT_SIZE(key_type, alg, output1_length));
     TEST_LE_U(output2_buffer_size,
               PSA_CIPHER_DECRYPT_OUTPUT_MAX_SIZE(output1_length));
-    ASSERT_ALLOC(output2, output2_buffer_size);
+    TEST_CALLOC_OR_FAIL(output2, output2_buffer_size);
 
     if (iv_length > 0) {
         PSA_ASSERT(psa_cipher_set_iv(&operation2,
@@ -3412,7 +3412,7 @@ void aead_encrypt_decrypt(int key_type_arg, data_t *key_data,
         TEST_ASSERT(output_size <=
                     PSA_AEAD_ENCRYPT_OUTPUT_MAX_SIZE(input_data->len));
     }
-    ASSERT_ALLOC(output_data, output_size);
+    TEST_CALLOC_OR_FAIL(output_data, output_size);
 
     status = psa_aead_encrypt(key, alg,
                               nonce->x, nonce->len,
@@ -3433,7 +3433,7 @@ void aead_encrypt_decrypt(int key_type_arg, data_t *key_data,
     TEST_EQUAL(status, expected_result);
 
     if (PSA_SUCCESS == expected_result) {
-        ASSERT_ALLOC(output_data2, output_length);
+        TEST_CALLOC_OR_FAIL(output_data2, output_length);
 
         /* For all currently defined algorithms, PSA_AEAD_DECRYPT_OUTPUT_SIZE
          * should be exact. */
@@ -3501,7 +3501,7 @@ void aead_encrypt(int key_type_arg, data_t *key_data,
                PSA_AEAD_ENCRYPT_OUTPUT_SIZE(key_type, alg, input_data->len));
     TEST_ASSERT(output_size <=
                 PSA_AEAD_ENCRYPT_OUTPUT_MAX_SIZE(input_data->len));
-    ASSERT_ALLOC(output_data, output_size);
+    TEST_CALLOC_OR_FAIL(output_data, output_size);
 
     status = psa_aead_encrypt(key, alg,
                               nonce->x, nonce->len,
@@ -3571,7 +3571,7 @@ void aead_decrypt(int key_type_arg, data_t *key_data,
         TEST_ASSERT(output_size <=
                     PSA_AEAD_DECRYPT_OUTPUT_MAX_SIZE(input_data->len));
     }
-    ASSERT_ALLOC(output_data, output_size);
+    TEST_CALLOC_OR_FAIL(output_data, output_size);
 
     status = psa_aead_decrypt(key, alg,
                               nonce->x, nonce->len,
@@ -3655,7 +3655,7 @@ void sign_hash_deterministic(int key_type_arg, data_t *key_data,
                                           key_bits, alg);
     TEST_ASSERT(signature_size != 0);
     TEST_LE_U(signature_size, PSA_SIGNATURE_MAX_SIZE);
-    ASSERT_ALLOC(signature, signature_size);
+    TEST_CALLOC_OR_FAIL(signature, signature_size);
 
     /* Perform the signature. */
     PSA_ASSERT(psa_sign_hash(key, alg,
@@ -3705,7 +3705,7 @@ void sign_hash_fail(int key_type_arg, data_t *key_data,
     size_t signature_length = 0xdeadbeef;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
 
-    ASSERT_ALLOC(signature, signature_size);
+    TEST_CALLOC_OR_FAIL(signature, signature_size);
 
     PSA_ASSERT(psa_crypto_init());
 
@@ -3775,7 +3775,7 @@ void sign_verify_hash(int key_type_arg, data_t *key_data,
                                           key_bits, alg);
     TEST_ASSERT(signature_size != 0);
     TEST_LE_U(signature_size, PSA_SIGNATURE_MAX_SIZE);
-    ASSERT_ALLOC(signature, signature_size);
+    TEST_CALLOC_OR_FAIL(signature, signature_size);
 
     /* Perform the signature. */
     PSA_ASSERT(psa_sign_hash(key, alg,
@@ -3926,7 +3926,7 @@ void sign_message_deterministic(int key_type_arg,
     signature_size = PSA_SIGN_OUTPUT_SIZE(key_type, key_bits, alg);
     TEST_ASSERT(signature_size != 0);
     TEST_LE_U(signature_size, PSA_SIGNATURE_MAX_SIZE);
-    ASSERT_ALLOC(signature, signature_size);
+    TEST_CALLOC_OR_FAIL(signature, signature_size);
 
     PSA_ASSERT(psa_sign_message(key, alg,
                                 input_data->x, input_data->len,
@@ -3964,7 +3964,7 @@ void sign_message_fail(int key_type_arg,
     size_t signature_length = 0xdeadbeef;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
 
-    ASSERT_ALLOC(signature, signature_size);
+    TEST_CALLOC_OR_FAIL(signature, signature_size);
 
     PSA_ASSERT(psa_crypto_init());
 
@@ -4024,7 +4024,7 @@ void sign_verify_message(int key_type_arg,
     signature_size = PSA_SIGN_OUTPUT_SIZE(key_type, key_bits, alg);
     TEST_ASSERT(signature_size != 0);
     TEST_LE_U(signature_size, PSA_SIGNATURE_MAX_SIZE);
-    ASSERT_ALLOC(signature, signature_size);
+    TEST_CALLOC_OR_FAIL(signature, signature_size);
 
     PSA_ASSERT(psa_sign_message(key, alg,
                                 input_data->x, input_data->len,
@@ -4164,7 +4164,7 @@ void asymmetric_encrypt(int key_type_arg,
 
     output_size = PSA_ASYMMETRIC_ENCRYPT_OUTPUT_SIZE(key_type, key_bits, alg);
     TEST_LE_U(output_size, PSA_ASYMMETRIC_ENCRYPT_OUTPUT_MAX_SIZE);
-    ASSERT_ALLOC(output, output_size);
+    TEST_CALLOC_OR_FAIL(output, output_size);
 
     /* Encrypt the input */
     actual_status = psa_asymmetric_encrypt(key, alg,
@@ -4246,13 +4246,13 @@ void asymmetric_encrypt_decrypt(int key_type_arg,
 
     output_size = PSA_ASYMMETRIC_ENCRYPT_OUTPUT_SIZE(key_type, key_bits, alg);
     TEST_LE_U(output_size, PSA_ASYMMETRIC_ENCRYPT_OUTPUT_MAX_SIZE);
-    ASSERT_ALLOC(output, output_size);
+    TEST_CALLOC_OR_FAIL(output, output_size);
 
     output2_size = input_data->len;
     TEST_LE_U(output2_size,
               PSA_ASYMMETRIC_DECRYPT_OUTPUT_SIZE(key_type, key_bits, alg));
     TEST_LE_U(output2_size, PSA_ASYMMETRIC_DECRYPT_OUTPUT_MAX_SIZE);
-    ASSERT_ALLOC(output2, output2_size);
+    TEST_CALLOC_OR_FAIL(output2, output2_size);
 
     /* We test encryption by checking that encrypt-then-decrypt gives back
      * the original plaintext because of the non-optional random
@@ -4320,7 +4320,7 @@ void asymmetric_decrypt(int key_type_arg,
     /* Determine the maximum ciphertext length */
     output_size = PSA_ASYMMETRIC_DECRYPT_OUTPUT_SIZE(key_type, key_bits, alg);
     TEST_LE_U(output_size, PSA_ASYMMETRIC_DECRYPT_OUTPUT_MAX_SIZE);
-    ASSERT_ALLOC(output, output_size);
+    TEST_CALLOC_OR_FAIL(output, output_size);
 
     PSA_ASSERT(psa_asymmetric_decrypt(key, alg,
                                       input_data->x, input_data->len,
@@ -4375,7 +4375,7 @@ void asymmetric_decrypt_fail(int key_type_arg,
     psa_status_t expected_status = expected_status_arg;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
 
-    ASSERT_ALLOC(output, output_size);
+    TEST_CALLOC_OR_FAIL(output, output_size);
 
     PSA_ASSERT(psa_crypto_init());
 
@@ -4694,7 +4694,7 @@ void derive_output(int alg_arg,
             expected_outputs[i] = NULL;
         }
     }
-    ASSERT_ALLOC(output_buffer, output_buffer_size);
+    TEST_CALLOC_OR_FAIL(output_buffer, output_buffer_size);
     PSA_ASSERT(psa_crypto_init());
 
     psa_set_key_usage_flags(&attributes, PSA_KEY_USAGE_DERIVE);
@@ -4931,8 +4931,8 @@ void derive_key_export(int alg_arg,
     psa_key_attributes_t derived_attributes = PSA_KEY_ATTRIBUTES_INIT;
     size_t length;
 
-    ASSERT_ALLOC(output_buffer, capacity);
-    ASSERT_ALLOC(export_buffer, capacity);
+    TEST_CALLOC_OR_FAIL(output_buffer, capacity);
+    TEST_CALLOC_OR_FAIL(export_buffer, capacity);
     PSA_ASSERT(psa_crypto_init());
 
     psa_set_key_usage_flags(&base_attributes, PSA_KEY_USAGE_DERIVE);
@@ -5128,7 +5128,7 @@ void raw_key_agreement(int alg_arg,
               PSA_RAW_KEY_AGREEMENT_OUTPUT_MAX_SIZE);
 
     /* Good case with exact output size */
-    ASSERT_ALLOC(output, expected_output->len);
+    TEST_CALLOC_OR_FAIL(output, expected_output->len);
     PSA_ASSERT(psa_raw_key_agreement(alg, our_key,
                                      peer_key_data->x, peer_key_data->len,
                                      output, expected_output->len,
@@ -5140,7 +5140,7 @@ void raw_key_agreement(int alg_arg,
     output_length = ~0;
 
     /* Larger buffer */
-    ASSERT_ALLOC(output, expected_output->len + 1);
+    TEST_CALLOC_OR_FAIL(output, expected_output->len + 1);
     PSA_ASSERT(psa_raw_key_agreement(alg, our_key,
                                      peer_key_data->x, peer_key_data->len,
                                      output, expected_output->len + 1,
@@ -5152,7 +5152,7 @@ void raw_key_agreement(int alg_arg,
     output_length = ~0;
 
     /* Buffer too small */
-    ASSERT_ALLOC(output, expected_output->len - 1);
+    TEST_CALLOC_OR_FAIL(output, expected_output->len - 1);
     TEST_EQUAL(psa_raw_key_agreement(alg, our_key,
                                      peer_key_data->x, peer_key_data->len,
                                      output, expected_output->len - 1,
@@ -5241,7 +5241,7 @@ void key_agreement_output(int alg_arg,
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     uint8_t *actual_output = NULL;
 
-    ASSERT_ALLOC(actual_output, MAX(expected_output1->len,
+    TEST_CALLOC_OR_FAIL(actual_output, MAX(expected_output1->len,
                                     expected_output2->len));
 
     PSA_ASSERT(psa_crypto_init());
@@ -5297,8 +5297,8 @@ void generate_random(int bytes_arg)
 
     TEST_ASSERT(bytes_arg >= 0);
 
-    ASSERT_ALLOC(output, bytes);
-    ASSERT_ALLOC(changed, bytes);
+    TEST_CALLOC_OR_FAIL(output, bytes);
+    TEST_CALLOC_OR_FAIL(changed, bytes);
 
     PSA_ASSERT(psa_crypto_init());
 
@@ -5416,8 +5416,8 @@ void generate_key_rsa(int bits_arg,
         is_default_public_exponent = 1;
         e_read_size = 0;
     }
-    ASSERT_ALLOC(e_read_buffer, e_read_size);
-    ASSERT_ALLOC(exported, exported_size);
+    TEST_CALLOC_OR_FAIL(e_read_buffer, e_read_size);
+    TEST_CALLOC_OR_FAIL(exported, exported_size);
 
     PSA_ASSERT(psa_crypto_init());
 
@@ -5519,8 +5519,8 @@ void persistent_key_load_key_from_storage(data_t *data,
     size_t second_exported_length;
 
     if (usage_flags & PSA_KEY_USAGE_EXPORT) {
-        ASSERT_ALLOC(first_export, export_size);
-        ASSERT_ALLOC(second_export, export_size);
+        TEST_CALLOC_OR_FAIL(first_export, export_size);
+        TEST_CALLOC_OR_FAIL(second_export, export_size);
     }
 
     PSA_ASSERT(psa_crypto_init());

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -633,7 +633,7 @@ void import_export(data_t *data,
                                   export_size,
                                   &reexported_length));
         TEST_MEMORY_COMPARE(exported, exported_length,
-                       reexported, reexported_length);
+                            reexported, reexported_length);
         PSA_ASSERT(psa_destroy_key(key2));
     }
     TEST_ASSERT(exported_length <=
@@ -704,7 +704,7 @@ void import_export_public_key(data_t *data,
         TEST_LE_U(expected_public_key->len,
                   PSA_EXPORT_PUBLIC_KEY_MAX_SIZE);
         TEST_MEMORY_COMPARE(expected_public_key->x, expected_public_key->len,
-                       exported, exported_length);
+                            exported, exported_length);
     }
 
 exit:
@@ -1450,7 +1450,7 @@ void copy_success(int source_usage_arg,
         PSA_ASSERT(psa_export_key(target_key, export_buffer,
                                   material->len, &length));
         TEST_MEMORY_COMPARE(material->x, material->len,
-                       export_buffer, length);
+                            export_buffer, length);
     }
 
     if (!mbedtls_test_psa_exercise_key(target_key, expected_usage, expected_alg)) {
@@ -1651,7 +1651,7 @@ void hash_compute_compare(int alg_arg, data_t *input,
                                 &output_length));
     TEST_EQUAL(output_length, PSA_HASH_LENGTH(alg));
     TEST_MEMORY_COMPARE(output, output_length,
-                   expected_output->x, expected_output->len);
+                        expected_output->x, expected_output->len);
 
     /* Compute with larger buffer */
     PSA_ASSERT(psa_hash_compute(alg, input->x, input->len,
@@ -1659,7 +1659,7 @@ void hash_compute_compare(int alg_arg, data_t *input,
                                 &output_length));
     TEST_EQUAL(output_length, PSA_HASH_LENGTH(alg));
     TEST_MEMORY_COMPARE(output, output_length,
-                   expected_output->x, expected_output->len);
+                        expected_output->x, expected_output->len);
 
     /* Compare with correct hash */
     PSA_ASSERT(psa_hash_compare(alg, input->x, input->len,
@@ -2196,7 +2196,7 @@ void mac_sign(int key_type_arg,
                    expected_status);
         if (expected_status == PSA_SUCCESS) {
             TEST_MEMORY_COMPARE(expected_mac->x, expected_mac->len,
-                           actual_mac, mac_length);
+                                actual_mac, mac_length);
         }
 
         if (output_size > 0) {
@@ -2215,7 +2215,7 @@ void mac_sign(int key_type_arg,
 
         if (expected_status == PSA_SUCCESS) {
             TEST_MEMORY_COMPARE(expected_mac->x, expected_mac->len,
-                           actual_mac, mac_length);
+                                actual_mac, mac_length);
         }
         mbedtls_free(actual_mac);
         actual_mac = NULL;
@@ -2698,7 +2698,7 @@ void cipher_alg_without_iv(int alg_arg, int key_type_arg, data_t *key_data,
                                  &length));
     output_length += length;
     TEST_MEMORY_COMPARE(ciphertext->x, ciphertext->len,
-                   output, output_length);
+                        output, output_length);
 
     /* Multipart encryption */
     PSA_ASSERT(psa_cipher_decrypt_setup(&operation, key, alg));
@@ -2716,7 +2716,7 @@ void cipher_alg_without_iv(int alg_arg, int key_type_arg, data_t *key_data,
                                  &length));
     output_length += length;
     TEST_MEMORY_COMPARE(plaintext->x, plaintext->len,
-                   output, output_length);
+                        output, output_length);
 
     /* One-shot encryption */
     output_length = ~0;
@@ -2724,7 +2724,7 @@ void cipher_alg_without_iv(int alg_arg, int key_type_arg, data_t *key_data,
                                   output, output_buffer_size,
                                   &output_length));
     TEST_MEMORY_COMPARE(ciphertext->x, ciphertext->len,
-                   output, output_length);
+                        output, output_length);
 
     /* One-shot decryption */
     output_length = ~0;
@@ -2732,7 +2732,7 @@ void cipher_alg_without_iv(int alg_arg, int key_type_arg, data_t *key_data,
                                   output, output_buffer_size,
                                   &output_length));
     TEST_MEMORY_COMPARE(plaintext->x, plaintext->len,
-                   output, output_length);
+                        output, output_length);
 
 exit:
     mbedtls_free(output);
@@ -2851,7 +2851,7 @@ void cipher_encrypt_validation(int alg_arg,
 
     PSA_ASSERT(psa_cipher_abort(&operation));
     TEST_MEMORY_COMPARE(output1 + iv_size, output1_length - iv_size,
-                   output2, output2_length);
+                        output2, output2_length);
 
 exit:
     psa_cipher_abort(&operation);
@@ -2950,7 +2950,7 @@ void cipher_encrypt_multipart(int alg_arg, int key_type_arg,
         PSA_ASSERT(psa_cipher_abort(&operation));
 
         TEST_MEMORY_COMPARE(expected_output->x, expected_output->len,
-                       output, total_output_length);
+                            output, total_output_length);
     }
 
 exit:
@@ -3050,7 +3050,7 @@ void cipher_decrypt_multipart(int alg_arg, int key_type_arg,
         PSA_ASSERT(psa_cipher_abort(&operation));
 
         TEST_MEMORY_COMPARE(expected_output->x, expected_output->len,
-                       output, total_output_length);
+                            output, total_output_length);
     }
 
 exit:
@@ -3161,7 +3161,7 @@ void cipher_decrypt(int alg_arg,
               PSA_CIPHER_DECRYPT_OUTPUT_MAX_SIZE(input_buffer_size));
 
     TEST_MEMORY_COMPARE(expected_output->x, expected_output->len,
-                   output, output_length);
+                        output, output_length);
 exit:
     mbedtls_free(input);
     mbedtls_free(output);
@@ -3453,7 +3453,7 @@ void aead_encrypt_decrypt(int key_type_arg, data_t *key_data,
                    expected_result);
 
         TEST_MEMORY_COMPARE(input_data->x, input_data->len,
-                       output_data2, output_length2);
+                            output_data2, output_length2);
     }
 
 exit:
@@ -3520,7 +3520,7 @@ void aead_encrypt(int key_type_arg, data_t *key_data,
 
     PSA_ASSERT(status);
     TEST_MEMORY_COMPARE(expected_result->x, expected_result->len,
-                   output_data, output_length);
+                        output_data, output_length);
 
 exit:
     psa_destroy_key(key);
@@ -3593,7 +3593,7 @@ void aead_decrypt(int key_type_arg, data_t *key_data,
 
     if (expected_result == PSA_SUCCESS) {
         TEST_MEMORY_COMPARE(expected_data->x, expected_data->len,
-                       output_data, output_length);
+                            output_data, output_length);
     }
 
 exit:
@@ -3664,7 +3664,7 @@ void sign_hash_deterministic(int key_type_arg, data_t *key_data,
                              &signature_length));
     /* Verify that the signature is what is expected. */
     TEST_MEMORY_COMPARE(output_data->x, output_data->len,
-                   signature, signature_length);
+                        signature, signature_length);
 
 #if defined(MBEDTLS_TEST_DEPRECATED)
     memset(signature, 0, signature_size);
@@ -3674,7 +3674,7 @@ void sign_hash_deterministic(int key_type_arg, data_t *key_data,
                                    signature, signature_size,
                                    &signature_length));
     TEST_MEMORY_COMPARE(output_data->x, output_data->len,
-                   signature, signature_length);
+                        signature, signature_length);
 #endif /* MBEDTLS_TEST_DEPRECATED */
 
 exit:
@@ -3934,7 +3934,7 @@ void sign_message_deterministic(int key_type_arg,
                                 &signature_length));
 
     TEST_MEMORY_COMPARE(output_data->x, output_data->len,
-                   signature, signature_length);
+                        signature, signature_length);
 
 exit:
     psa_reset_key_attributes(&attributes);
@@ -4272,7 +4272,7 @@ void asymmetric_encrypt_decrypt(int key_type_arg,
                                       output2, output2_size,
                                       &output2_length));
     TEST_MEMORY_COMPARE(input_data->x, input_data->len,
-                   output2, output2_length);
+                        output2, output2_length);
 
 exit:
     /*
@@ -4329,7 +4329,7 @@ void asymmetric_decrypt(int key_type_arg,
                                       output_size,
                                       &output_length));
     TEST_MEMORY_COMPARE(expected_data->x, expected_data->len,
-                   output, output_length);
+                        output, output_length);
 
     /* If the label is empty, the test framework puts a non-null pointer
      * in label->x. Test that a null pointer works as well. */
@@ -4345,7 +4345,7 @@ void asymmetric_decrypt(int key_type_arg,
                                           output_size,
                                           &output_length));
         TEST_MEMORY_COMPARE(expected_data->x, expected_data->len,
-                       output, output_length);
+                            output, output_length);
     }
 
 exit:
@@ -4757,7 +4757,7 @@ void derive_output(int alg_arg,
         PSA_ASSERT(status);
         if (output_sizes[i] != 0) {
             TEST_MEMORY_COMPARE(output_buffer, output_sizes[i],
-                           expected_outputs[i], output_sizes[i]);
+                                expected_outputs[i], output_sizes[i]);
         }
         /* Check the operation status. */
         expected_capacity -= output_sizes[i];
@@ -4983,7 +4983,7 @@ void derive_key_export(int alg_arg,
 
     /* Compare the outputs from the two runs. */
     TEST_MEMORY_COMPARE(output_buffer, bytes1 + bytes2,
-                   export_buffer, capacity);
+                        export_buffer, capacity);
 
 exit:
     mbedtls_free(output_buffer);
@@ -5134,7 +5134,7 @@ void raw_key_agreement(int alg_arg,
                                      output, expected_output->len,
                                      &output_length));
     TEST_MEMORY_COMPARE(output, output_length,
-                   expected_output->x, expected_output->len);
+                        expected_output->x, expected_output->len);
     mbedtls_free(output);
     output = NULL;
     output_length = ~0;
@@ -5146,7 +5146,7 @@ void raw_key_agreement(int alg_arg,
                                      output, expected_output->len + 1,
                                      &output_length));
     TEST_MEMORY_COMPARE(output, output_length,
-                   expected_output->x, expected_output->len);
+                        expected_output->x, expected_output->len);
     mbedtls_free(output);
     output = NULL;
     output_length = ~0;
@@ -5242,7 +5242,7 @@ void key_agreement_output(int alg_arg,
     uint8_t *actual_output = NULL;
 
     TEST_CALLOC(actual_output, MAX(expected_output1->len,
-                                    expected_output2->len));
+                                   expected_output2->len));
 
     PSA_ASSERT(psa_crypto_init());
 
@@ -5269,13 +5269,13 @@ void key_agreement_output(int alg_arg,
                                                actual_output,
                                                expected_output1->len));
     TEST_MEMORY_COMPARE(actual_output, expected_output1->len,
-                   expected_output1->x, expected_output1->len);
+                        expected_output1->x, expected_output1->len);
     if (expected_output2->len != 0) {
         PSA_ASSERT(psa_key_derivation_output_bytes(&operation,
                                                    actual_output,
                                                    expected_output2->len));
         TEST_MEMORY_COMPARE(actual_output, expected_output2->len,
-                       expected_output2->x, expected_output2->len);
+                            expected_output2->x, expected_output2->len);
     }
 
 exit:
@@ -5589,7 +5589,7 @@ void persistent_key_load_key_from_storage(data_t *data,
                                   &first_exported_length));
         if (generation_method == IMPORT_KEY) {
             TEST_MEMORY_COMPARE(data->x, data->len,
-                           first_export, first_exported_length);
+                                first_export, first_exported_length);
         }
     }
 
@@ -5616,7 +5616,7 @@ void persistent_key_load_key_from_storage(data_t *data,
                                   second_export, export_size,
                                   &second_exported_length));
         TEST_MEMORY_COMPARE(first_export, first_exported_length,
-                       second_export, second_exported_length);
+                            second_export, second_exported_length);
     }
 
     /* Do something with the key according to its type and permitted usage. */

--- a/tests/suites/test_suite_psa_crypto_driver_wrappers.function
+++ b/tests/suites/test_suite_psa_crypto_driver_wrappers.function
@@ -64,7 +64,7 @@ void sign_hash(int key_type_arg,
                                   &signature_length);
     TEST_EQUAL(actual_status, expected_status);
     if (expected_status == PSA_SUCCESS) {
-        TEST_BUFFERS_EQUAL(signature, signature_length,
+        TEST_MEMORY_COMPARE(signature, signature_length,
                        expected_output->x, expected_output->len);
     }
     TEST_EQUAL(mbedtls_test_driver_signature_sign_hooks.hits, 1);
@@ -191,7 +191,7 @@ void sign_message(int key_type_arg,
                                      &signature_length);
     TEST_EQUAL(actual_status, expected_status);
     if (expected_status == PSA_SUCCESS) {
-        TEST_BUFFERS_EQUAL(signature, signature_length,
+        TEST_MEMORY_COMPARE(signature, signature_length,
                        expected_output->x, expected_output->len);
     }
     /* In the builtin algorithm the driver is called twice. */
@@ -313,7 +313,7 @@ void generate_key(int force_status_arg,
         psa_export_key(key, actual_output, sizeof(actual_output), &actual_output_length);
 
         if (fake_output->len > 0) {
-            TEST_BUFFERS_EQUAL(actual_output, actual_output_length,
+            TEST_MEMORY_COMPARE(actual_output, actual_output_length,
                            expected_output, expected_output_length);
         } else {
             size_t zeroes = 0;
@@ -445,7 +445,7 @@ void export_key(int force_status_arg,
     }
 
     if (actual_status == PSA_SUCCESS) {
-        TEST_BUFFERS_EQUAL(actual_output, actual_output_length,
+        TEST_MEMORY_COMPARE(actual_output, actual_output_length,
                        expected_output_ptr, expected_output_length);
     }
 exit:
@@ -527,7 +527,7 @@ void cipher_encrypt_validation(int alg_arg,
     PSA_ASSERT(psa_cipher_abort(&operation));
     // driver function should've been called as part of the finish() core routine
     TEST_EQUAL(mbedtls_test_driver_cipher_hooks.hits, 0);
-    TEST_BUFFERS_EQUAL(output1 + iv_size, output1_length - iv_size,
+    TEST_MEMORY_COMPARE(output1 + iv_size, output1_length - iv_size,
                    output2, output2_length);
 
 exit:
@@ -655,7 +655,7 @@ void cipher_encrypt_multipart(int alg_arg,
         PSA_ASSERT(psa_cipher_abort(&operation));
         TEST_EQUAL(mbedtls_test_driver_cipher_hooks.hits, 0);
 
-        TEST_BUFFERS_EQUAL(expected_output->x, expected_output->len,
+        TEST_MEMORY_COMPARE(expected_output->x, expected_output->len,
                        output, total_output_length);
     }
 
@@ -784,7 +784,7 @@ void cipher_decrypt_multipart(int alg_arg,
         PSA_ASSERT(psa_cipher_abort(&operation));
         TEST_EQUAL(mbedtls_test_driver_cipher_hooks.hits, 0);
 
-        TEST_BUFFERS_EQUAL(expected_output->x, expected_output->len,
+        TEST_MEMORY_COMPARE(expected_output->x, expected_output->len,
                        output, total_output_length);
     }
 
@@ -856,7 +856,7 @@ void cipher_decrypt(int alg_arg,
     TEST_EQUAL(status, expected_status);
 
     if (expected_status == PSA_SUCCESS) {
-        TEST_BUFFERS_EQUAL(expected_output->x, expected_output->len,
+        TEST_MEMORY_COMPARE(expected_output->x, expected_output->len,
                        output, output_length);
     }
 
@@ -1141,7 +1141,7 @@ void aead_encrypt(int key_type_arg, data_t *key_data,
                PSA_SUCCESS : forced_status);
 
     if (status == PSA_SUCCESS) {
-        TEST_BUFFERS_EQUAL(expected_result->x, expected_result->len,
+        TEST_MEMORY_COMPARE(expected_result->x, expected_result->len,
                        output_data, output_length);
     }
 
@@ -1204,7 +1204,7 @@ void aead_decrypt(int key_type_arg, data_t *key_data,
                PSA_SUCCESS : forced_status);
 
     if (status == PSA_SUCCESS) {
-        TEST_BUFFERS_EQUAL(expected_data->x, expected_data->len,
+        TEST_MEMORY_COMPARE(expected_data->x, expected_data->len,
                        output_data, output_length);
     }
 
@@ -1326,7 +1326,7 @@ void mac_sign(int key_type_arg,
     }
 
     if (forced_status == PSA_SUCCESS) {
-        TEST_BUFFERS_EQUAL(expected_mac->x, expected_mac->len,
+        TEST_MEMORY_COMPARE(expected_mac->x, expected_mac->len,
                        actual_mac, mac_length);
     }
 
@@ -1477,7 +1477,7 @@ void builtin_key_export(int builtin_key_id_arg,
     if (expected_status == PSA_SUCCESS) {
         PSA_ASSERT(actual_status);
         TEST_EQUAL(output_size, expected_output->len);
-        TEST_BUFFERS_EQUAL(output_buffer, output_size,
+        TEST_MEMORY_COMPARE(output_buffer, output_size,
                        expected_output->x, expected_output->len);
 
         PSA_ASSERT(psa_get_key_attributes(key, &attributes));
@@ -1528,7 +1528,7 @@ void builtin_pubkey_export(int builtin_key_id_arg,
     if (expected_status == PSA_SUCCESS) {
         PSA_ASSERT(actual_status);
         TEST_EQUAL(output_size, expected_output->len);
-        TEST_BUFFERS_EQUAL(output_buffer, output_size,
+        TEST_MEMORY_COMPARE(output_buffer, output_size,
                        expected_output->x, expected_output->len);
 
         PSA_ASSERT(psa_get_key_attributes(key, &attributes));
@@ -1573,7 +1573,7 @@ void hash_compute(int alg_arg,
     TEST_EQUAL(mbedtls_test_driver_hash_hooks.driver_status, forced_status);
 
     if (expected_status == PSA_SUCCESS) {
-        TEST_BUFFERS_EQUAL(output, output_length, hash->x, hash->len);
+        TEST_MEMORY_COMPARE(output, output_length, hash->x, hash->len);
     }
 
 exit:
@@ -1619,7 +1619,7 @@ void hash_multipart_setup(int alg_arg,
                    forced_status == PSA_ERROR_NOT_SUPPORTED ? 1 : 4);
         TEST_EQUAL(mbedtls_test_driver_hash_hooks.driver_status, forced_status);
 
-        TEST_BUFFERS_EQUAL(output, output_length, hash->x, hash->len);
+        TEST_MEMORY_COMPARE(output, output_length, hash->x, hash->len);
     }
 
 exit:
@@ -1674,7 +1674,7 @@ void hash_multipart_update(int alg_arg,
         TEST_EQUAL(mbedtls_test_driver_hash_hooks.hits, 2);
         TEST_EQUAL(mbedtls_test_driver_hash_hooks.driver_status, PSA_SUCCESS);
 
-        TEST_BUFFERS_EQUAL(output, output_length, hash->x, hash->len);
+        TEST_MEMORY_COMPARE(output, output_length, hash->x, hash->len);
     }
 
 exit:
@@ -1727,7 +1727,7 @@ void hash_multipart_finish(int alg_arg,
     TEST_EQUAL(mbedtls_test_driver_hash_hooks.driver_status, forced_status);
 
     if (forced_status == PSA_SUCCESS) {
-        TEST_BUFFERS_EQUAL(output, output_length, hash->x, hash->len);
+        TEST_MEMORY_COMPARE(output, output_length, hash->x, hash->len);
     }
 
 exit:
@@ -1786,7 +1786,7 @@ void hash_clone(int alg_arg,
         TEST_EQUAL(mbedtls_test_driver_hash_hooks.hits, 3);
         TEST_EQUAL(mbedtls_test_driver_hash_hooks.driver_status, PSA_SUCCESS);
 
-        TEST_BUFFERS_EQUAL(output, output_length, hash->x, hash->len);
+        TEST_MEMORY_COMPARE(output, output_length, hash->x, hash->len);
     }
 
 exit:

--- a/tests/suites/test_suite_psa_crypto_driver_wrappers.function
+++ b/tests/suites/test_suite_psa_crypto_driver_wrappers.function
@@ -64,7 +64,7 @@ void sign_hash(int key_type_arg,
                                   &signature_length);
     TEST_EQUAL(actual_status, expected_status);
     if (expected_status == PSA_SUCCESS) {
-        ASSERT_COMPARE(signature, signature_length,
+        TEST_BUFFERS_EQUAL(signature, signature_length,
                        expected_output->x, expected_output->len);
     }
     TEST_EQUAL(mbedtls_test_driver_signature_sign_hooks.hits, 1);
@@ -191,7 +191,7 @@ void sign_message(int key_type_arg,
                                      &signature_length);
     TEST_EQUAL(actual_status, expected_status);
     if (expected_status == PSA_SUCCESS) {
-        ASSERT_COMPARE(signature, signature_length,
+        TEST_BUFFERS_EQUAL(signature, signature_length,
                        expected_output->x, expected_output->len);
     }
     /* In the builtin algorithm the driver is called twice. */
@@ -313,7 +313,7 @@ void generate_key(int force_status_arg,
         psa_export_key(key, actual_output, sizeof(actual_output), &actual_output_length);
 
         if (fake_output->len > 0) {
-            ASSERT_COMPARE(actual_output, actual_output_length,
+            TEST_BUFFERS_EQUAL(actual_output, actual_output_length,
                            expected_output, expected_output_length);
         } else {
             size_t zeroes = 0;
@@ -445,7 +445,7 @@ void export_key(int force_status_arg,
     }
 
     if (actual_status == PSA_SUCCESS) {
-        ASSERT_COMPARE(actual_output, actual_output_length,
+        TEST_BUFFERS_EQUAL(actual_output, actual_output_length,
                        expected_output_ptr, expected_output_length);
     }
 exit:
@@ -527,7 +527,7 @@ void cipher_encrypt_validation(int alg_arg,
     PSA_ASSERT(psa_cipher_abort(&operation));
     // driver function should've been called as part of the finish() core routine
     TEST_EQUAL(mbedtls_test_driver_cipher_hooks.hits, 0);
-    ASSERT_COMPARE(output1 + iv_size, output1_length - iv_size,
+    TEST_BUFFERS_EQUAL(output1 + iv_size, output1_length - iv_size,
                    output2, output2_length);
 
 exit:
@@ -655,7 +655,7 @@ void cipher_encrypt_multipart(int alg_arg,
         PSA_ASSERT(psa_cipher_abort(&operation));
         TEST_EQUAL(mbedtls_test_driver_cipher_hooks.hits, 0);
 
-        ASSERT_COMPARE(expected_output->x, expected_output->len,
+        TEST_BUFFERS_EQUAL(expected_output->x, expected_output->len,
                        output, total_output_length);
     }
 
@@ -784,7 +784,7 @@ void cipher_decrypt_multipart(int alg_arg,
         PSA_ASSERT(psa_cipher_abort(&operation));
         TEST_EQUAL(mbedtls_test_driver_cipher_hooks.hits, 0);
 
-        ASSERT_COMPARE(expected_output->x, expected_output->len,
+        TEST_BUFFERS_EQUAL(expected_output->x, expected_output->len,
                        output, total_output_length);
     }
 
@@ -856,7 +856,7 @@ void cipher_decrypt(int alg_arg,
     TEST_EQUAL(status, expected_status);
 
     if (expected_status == PSA_SUCCESS) {
-        ASSERT_COMPARE(expected_output->x, expected_output->len,
+        TEST_BUFFERS_EQUAL(expected_output->x, expected_output->len,
                        output, output_length);
     }
 
@@ -1141,7 +1141,7 @@ void aead_encrypt(int key_type_arg, data_t *key_data,
                PSA_SUCCESS : forced_status);
 
     if (status == PSA_SUCCESS) {
-        ASSERT_COMPARE(expected_result->x, expected_result->len,
+        TEST_BUFFERS_EQUAL(expected_result->x, expected_result->len,
                        output_data, output_length);
     }
 
@@ -1204,7 +1204,7 @@ void aead_decrypt(int key_type_arg, data_t *key_data,
                PSA_SUCCESS : forced_status);
 
     if (status == PSA_SUCCESS) {
-        ASSERT_COMPARE(expected_data->x, expected_data->len,
+        TEST_BUFFERS_EQUAL(expected_data->x, expected_data->len,
                        output_data, output_length);
     }
 
@@ -1326,7 +1326,7 @@ void mac_sign(int key_type_arg,
     }
 
     if (forced_status == PSA_SUCCESS) {
-        ASSERT_COMPARE(expected_mac->x, expected_mac->len,
+        TEST_BUFFERS_EQUAL(expected_mac->x, expected_mac->len,
                        actual_mac, mac_length);
     }
 
@@ -1477,7 +1477,7 @@ void builtin_key_export(int builtin_key_id_arg,
     if (expected_status == PSA_SUCCESS) {
         PSA_ASSERT(actual_status);
         TEST_EQUAL(output_size, expected_output->len);
-        ASSERT_COMPARE(output_buffer, output_size,
+        TEST_BUFFERS_EQUAL(output_buffer, output_size,
                        expected_output->x, expected_output->len);
 
         PSA_ASSERT(psa_get_key_attributes(key, &attributes));
@@ -1528,7 +1528,7 @@ void builtin_pubkey_export(int builtin_key_id_arg,
     if (expected_status == PSA_SUCCESS) {
         PSA_ASSERT(actual_status);
         TEST_EQUAL(output_size, expected_output->len);
-        ASSERT_COMPARE(output_buffer, output_size,
+        TEST_BUFFERS_EQUAL(output_buffer, output_size,
                        expected_output->x, expected_output->len);
 
         PSA_ASSERT(psa_get_key_attributes(key, &attributes));
@@ -1573,7 +1573,7 @@ void hash_compute(int alg_arg,
     TEST_EQUAL(mbedtls_test_driver_hash_hooks.driver_status, forced_status);
 
     if (expected_status == PSA_SUCCESS) {
-        ASSERT_COMPARE(output, output_length, hash->x, hash->len);
+        TEST_BUFFERS_EQUAL(output, output_length, hash->x, hash->len);
     }
 
 exit:
@@ -1619,7 +1619,7 @@ void hash_multipart_setup(int alg_arg,
                    forced_status == PSA_ERROR_NOT_SUPPORTED ? 1 : 4);
         TEST_EQUAL(mbedtls_test_driver_hash_hooks.driver_status, forced_status);
 
-        ASSERT_COMPARE(output, output_length, hash->x, hash->len);
+        TEST_BUFFERS_EQUAL(output, output_length, hash->x, hash->len);
     }
 
 exit:
@@ -1674,7 +1674,7 @@ void hash_multipart_update(int alg_arg,
         TEST_EQUAL(mbedtls_test_driver_hash_hooks.hits, 2);
         TEST_EQUAL(mbedtls_test_driver_hash_hooks.driver_status, PSA_SUCCESS);
 
-        ASSERT_COMPARE(output, output_length, hash->x, hash->len);
+        TEST_BUFFERS_EQUAL(output, output_length, hash->x, hash->len);
     }
 
 exit:
@@ -1727,7 +1727,7 @@ void hash_multipart_finish(int alg_arg,
     TEST_EQUAL(mbedtls_test_driver_hash_hooks.driver_status, forced_status);
 
     if (forced_status == PSA_SUCCESS) {
-        ASSERT_COMPARE(output, output_length, hash->x, hash->len);
+        TEST_BUFFERS_EQUAL(output, output_length, hash->x, hash->len);
     }
 
 exit:
@@ -1786,7 +1786,7 @@ void hash_clone(int alg_arg,
         TEST_EQUAL(mbedtls_test_driver_hash_hooks.hits, 3);
         TEST_EQUAL(mbedtls_test_driver_hash_hooks.driver_status, PSA_SUCCESS);
 
-        ASSERT_COMPARE(output, output_length, hash->x, hash->len);
+        TEST_BUFFERS_EQUAL(output, output_length, hash->x, hash->len);
     }
 
 exit:

--- a/tests/suites/test_suite_psa_crypto_driver_wrappers.function
+++ b/tests/suites/test_suite_psa_crypto_driver_wrappers.function
@@ -65,7 +65,7 @@ void sign_hash(int key_type_arg,
     TEST_EQUAL(actual_status, expected_status);
     if (expected_status == PSA_SUCCESS) {
         TEST_MEMORY_COMPARE(signature, signature_length,
-                       expected_output->x, expected_output->len);
+                            expected_output->x, expected_output->len);
     }
     TEST_EQUAL(mbedtls_test_driver_signature_sign_hooks.hits, 1);
 
@@ -192,7 +192,7 @@ void sign_message(int key_type_arg,
     TEST_EQUAL(actual_status, expected_status);
     if (expected_status == PSA_SUCCESS) {
         TEST_MEMORY_COMPARE(signature, signature_length,
-                       expected_output->x, expected_output->len);
+                            expected_output->x, expected_output->len);
     }
     /* In the builtin algorithm the driver is called twice. */
     TEST_EQUAL(mbedtls_test_driver_signature_sign_hooks.hits,
@@ -314,7 +314,7 @@ void generate_key(int force_status_arg,
 
         if (fake_output->len > 0) {
             TEST_MEMORY_COMPARE(actual_output, actual_output_length,
-                           expected_output, expected_output_length);
+                                expected_output, expected_output_length);
         } else {
             size_t zeroes = 0;
             for (size_t i = 0; i < sizeof(actual_output); i++) {
@@ -446,7 +446,7 @@ void export_key(int force_status_arg,
 
     if (actual_status == PSA_SUCCESS) {
         TEST_MEMORY_COMPARE(actual_output, actual_output_length,
-                       expected_output_ptr, expected_output_length);
+                            expected_output_ptr, expected_output_length);
     }
 exit:
     psa_reset_key_attributes(&attributes);
@@ -528,7 +528,7 @@ void cipher_encrypt_validation(int alg_arg,
     // driver function should've been called as part of the finish() core routine
     TEST_EQUAL(mbedtls_test_driver_cipher_hooks.hits, 0);
     TEST_MEMORY_COMPARE(output1 + iv_size, output1_length - iv_size,
-                   output2, output2_length);
+                        output2, output2_length);
 
 exit:
     psa_cipher_abort(&operation);
@@ -656,7 +656,7 @@ void cipher_encrypt_multipart(int alg_arg,
         TEST_EQUAL(mbedtls_test_driver_cipher_hooks.hits, 0);
 
         TEST_MEMORY_COMPARE(expected_output->x, expected_output->len,
-                       output, total_output_length);
+                            output, total_output_length);
     }
 
 exit:
@@ -785,7 +785,7 @@ void cipher_decrypt_multipart(int alg_arg,
         TEST_EQUAL(mbedtls_test_driver_cipher_hooks.hits, 0);
 
         TEST_MEMORY_COMPARE(expected_output->x, expected_output->len,
-                       output, total_output_length);
+                            output, total_output_length);
     }
 
 exit:
@@ -857,7 +857,7 @@ void cipher_decrypt(int alg_arg,
 
     if (expected_status == PSA_SUCCESS) {
         TEST_MEMORY_COMPARE(expected_output->x, expected_output->len,
-                       output, output_length);
+                            output, output_length);
     }
 
 exit:
@@ -1142,7 +1142,7 @@ void aead_encrypt(int key_type_arg, data_t *key_data,
 
     if (status == PSA_SUCCESS) {
         TEST_MEMORY_COMPARE(expected_result->x, expected_result->len,
-                       output_data, output_length);
+                            output_data, output_length);
     }
 
 exit:
@@ -1205,7 +1205,7 @@ void aead_decrypt(int key_type_arg, data_t *key_data,
 
     if (status == PSA_SUCCESS) {
         TEST_MEMORY_COMPARE(expected_data->x, expected_data->len,
-                       output_data, output_length);
+                            output_data, output_length);
     }
 
 exit:
@@ -1327,7 +1327,7 @@ void mac_sign(int key_type_arg,
 
     if (forced_status == PSA_SUCCESS) {
         TEST_MEMORY_COMPARE(expected_mac->x, expected_mac->len,
-                       actual_mac, mac_length);
+                            actual_mac, mac_length);
     }
 
     mbedtls_free(actual_mac);
@@ -1478,7 +1478,7 @@ void builtin_key_export(int builtin_key_id_arg,
         PSA_ASSERT(actual_status);
         TEST_EQUAL(output_size, expected_output->len);
         TEST_MEMORY_COMPARE(output_buffer, output_size,
-                       expected_output->x, expected_output->len);
+                            expected_output->x, expected_output->len);
 
         PSA_ASSERT(psa_get_key_attributes(key, &attributes));
         TEST_EQUAL(psa_get_key_bits(&attributes), builtin_key_bits);
@@ -1529,7 +1529,7 @@ void builtin_pubkey_export(int builtin_key_id_arg,
         PSA_ASSERT(actual_status);
         TEST_EQUAL(output_size, expected_output->len);
         TEST_MEMORY_COMPARE(output_buffer, output_size,
-                       expected_output->x, expected_output->len);
+                            expected_output->x, expected_output->len);
 
         PSA_ASSERT(psa_get_key_attributes(key, &attributes));
         TEST_EQUAL(psa_get_key_bits(&attributes), builtin_key_bits);

--- a/tests/suites/test_suite_psa_crypto_driver_wrappers.function
+++ b/tests/suites/test_suite_psa_crypto_driver_wrappers.function
@@ -56,7 +56,7 @@ void sign_hash(int key_type_arg,
 
     TEST_ASSERT(signature_size != 0);
     TEST_ASSERT(signature_size <= PSA_SIGNATURE_MAX_SIZE);
-    ASSERT_ALLOC(signature, signature_size);
+    TEST_CALLOC_OR_FAIL(signature, signature_size);
 
     actual_status = psa_sign_hash(key, alg,
                                   data_input->x, data_input->len,
@@ -183,7 +183,7 @@ void sign_message(int key_type_arg,
 
     TEST_ASSERT(signature_size != 0);
     TEST_ASSERT(signature_size <= PSA_SIGNATURE_MAX_SIZE);
-    ASSERT_ALLOC(signature, signature_size);
+    TEST_CALLOC_OR_FAIL(signature, signature_size);
 
     actual_status = psa_sign_message(key, alg,
                                      data_input->x, data_input->len,
@@ -487,8 +487,8 @@ void cipher_encrypt_validation(int alg_arg,
     output1_buffer_size = PSA_CIPHER_ENCRYPT_OUTPUT_SIZE(key_type, alg, input->len);
     output2_buffer_size = PSA_CIPHER_UPDATE_OUTPUT_SIZE(key_type, alg, input->len) +
                           PSA_CIPHER_FINISH_OUTPUT_SIZE(key_type, alg);
-    ASSERT_ALLOC(output1, output1_buffer_size);
-    ASSERT_ALLOC(output2, output2_buffer_size);
+    TEST_CALLOC_OR_FAIL(output1, output1_buffer_size);
+    TEST_CALLOC_OR_FAIL(output2, output2_buffer_size);
 
     PSA_ASSERT(psa_import_key(&attributes, key_data->x, key_data->len,
                               &key));
@@ -605,7 +605,7 @@ void cipher_encrypt_multipart(int alg_arg,
 
     output_buffer_size = ((size_t) input->len +
                           PSA_BLOCK_CIPHER_BLOCK_LENGTH(key_type));
-    ASSERT_ALLOC(output, output_buffer_size);
+    TEST_CALLOC_OR_FAIL(output, output_buffer_size);
 
     if (mock_output_arg) {
         mbedtls_test_driver_cipher_hooks.forced_output = expected_output->x;
@@ -733,7 +733,7 @@ void cipher_decrypt_multipart(int alg_arg,
 
     output_buffer_size = ((size_t) input->len +
                           PSA_BLOCK_CIPHER_BLOCK_LENGTH(key_type));
-    ASSERT_ALLOC(output, output_buffer_size);
+    TEST_CALLOC_OR_FAIL(output, output_buffer_size);
 
     if (mock_output_arg) {
         mbedtls_test_driver_cipher_hooks.forced_output = expected_output->x;
@@ -832,13 +832,13 @@ void cipher_decrypt(int alg_arg,
     /* Allocate input buffer and copy the iv and the plaintext */
     input_buffer_size = ((size_t) input_arg->len + (size_t) iv->len);
     if (input_buffer_size > 0) {
-        ASSERT_ALLOC(input, input_buffer_size);
+        TEST_CALLOC_OR_FAIL(input, input_buffer_size);
         memcpy(input, iv->x, iv->len);
         memcpy(input + iv->len, input_arg->x, input_arg->len);
     }
 
     output_buffer_size = PSA_CIPHER_DECRYPT_OUTPUT_SIZE(key_type, alg, input_buffer_size);
-    ASSERT_ALLOC(output, output_buffer_size);
+    TEST_CALLOC_OR_FAIL(output, output_buffer_size);
 
     PSA_ASSERT(psa_import_key(&attributes, key_data->x, key_data->len,
                               &key));
@@ -885,7 +885,7 @@ void cipher_entry_points(int alg_arg, int key_type_arg,
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     mbedtls_test_driver_cipher_hooks = mbedtls_test_driver_cipher_hooks_init();
 
-    ASSERT_ALLOC(output, input->len + 16);
+    TEST_CALLOC_OR_FAIL(output, input->len + 16);
     output_buffer_size = input->len + 16;
 
     PSA_ASSERT(psa_crypto_init());
@@ -1125,7 +1125,7 @@ void aead_encrypt(int key_type_arg, data_t *key_data,
                PSA_AEAD_ENCRYPT_OUTPUT_SIZE(key_type, alg, input_data->len));
     TEST_ASSERT(output_size <=
                 PSA_AEAD_ENCRYPT_OUTPUT_MAX_SIZE(input_data->len));
-    ASSERT_ALLOC(output_data, output_size);
+    TEST_CALLOC_OR_FAIL(output_data, output_size);
 
     mbedtls_test_driver_aead_hooks.forced_status = forced_status;
     status = psa_aead_encrypt(key, alg,
@@ -1187,7 +1187,7 @@ void aead_decrypt(int key_type_arg, data_t *key_data,
 
     output_size = input_data->len - PSA_AEAD_TAG_LENGTH(key_type, key_bits,
                                                         alg);
-    ASSERT_ALLOC(output_data, output_size);
+    TEST_CALLOC_OR_FAIL(output_data, output_size);
 
     mbedtls_test_driver_aead_hooks.forced_status = forced_status;
     status = psa_aead_decrypt(key, alg,
@@ -1250,7 +1250,7 @@ void mac_sign(int key_type_arg,
     PSA_ASSERT(psa_import_key(&attributes, key_data->x, key_data->len,
                               &key));
 
-    ASSERT_ALLOC(actual_mac, mac_buffer_size);
+    TEST_CALLOC_OR_FAIL(actual_mac, mac_buffer_size);
     mbedtls_test_driver_mac_hooks.forced_status = forced_status;
 
     /*
@@ -1470,7 +1470,7 @@ void builtin_key_export(int builtin_key_id_arg,
     psa_status_t actual_status;
 
     PSA_ASSERT(psa_crypto_init());
-    ASSERT_ALLOC(output_buffer, expected_output->len);
+    TEST_CALLOC_OR_FAIL(output_buffer, expected_output->len);
 
     actual_status = psa_export_key(key, output_buffer, expected_output->len, &output_size);
 
@@ -1521,7 +1521,7 @@ void builtin_pubkey_export(int builtin_key_id_arg,
     psa_status_t actual_status;
 
     PSA_ASSERT(psa_crypto_init());
-    ASSERT_ALLOC(output_buffer, expected_output->len);
+    TEST_CALLOC_OR_FAIL(output_buffer, expected_output->len);
 
     actual_status = psa_export_public_key(key, output_buffer, expected_output->len, &output_size);
 
@@ -1564,7 +1564,7 @@ void hash_compute(int alg_arg,
     mbedtls_test_driver_hash_hooks.forced_status = forced_status;
 
     PSA_ASSERT(psa_crypto_init());
-    ASSERT_ALLOC(output, PSA_HASH_LENGTH(alg));
+    TEST_CALLOC_OR_FAIL(output, PSA_HASH_LENGTH(alg));
 
     TEST_EQUAL(psa_hash_compute(alg, input->x, input->len,
                                 output, PSA_HASH_LENGTH(alg),
@@ -1597,7 +1597,7 @@ void hash_multipart_setup(int alg_arg,
     size_t output_length;
 
     mbedtls_test_driver_hash_hooks = mbedtls_test_driver_hash_hooks_init();
-    ASSERT_ALLOC(output, PSA_HASH_LENGTH(alg));
+    TEST_CALLOC_OR_FAIL(output, PSA_HASH_LENGTH(alg));
 
     PSA_ASSERT(psa_crypto_init());
 
@@ -1642,7 +1642,7 @@ void hash_multipart_update(int alg_arg,
     size_t output_length;
 
     mbedtls_test_driver_hash_hooks = mbedtls_test_driver_hash_hooks_init();
-    ASSERT_ALLOC(output, PSA_HASH_LENGTH(alg));
+    TEST_CALLOC_OR_FAIL(output, PSA_HASH_LENGTH(alg));
 
     PSA_ASSERT(psa_crypto_init());
 
@@ -1697,7 +1697,7 @@ void hash_multipart_finish(int alg_arg,
     size_t output_length;
 
     mbedtls_test_driver_hash_hooks = mbedtls_test_driver_hash_hooks_init();
-    ASSERT_ALLOC(output, PSA_HASH_LENGTH(alg));
+    TEST_CALLOC_OR_FAIL(output, PSA_HASH_LENGTH(alg));
 
     PSA_ASSERT(psa_crypto_init());
 
@@ -1751,7 +1751,7 @@ void hash_clone(int alg_arg,
     size_t output_length;
 
     mbedtls_test_driver_hash_hooks = mbedtls_test_driver_hash_hooks_init();
-    ASSERT_ALLOC(output, PSA_HASH_LENGTH(alg));
+    TEST_CALLOC_OR_FAIL(output, PSA_HASH_LENGTH(alg));
 
     PSA_ASSERT(psa_crypto_init());
 

--- a/tests/suites/test_suite_psa_crypto_driver_wrappers.function
+++ b/tests/suites/test_suite_psa_crypto_driver_wrappers.function
@@ -56,7 +56,7 @@ void sign_hash(int key_type_arg,
 
     TEST_ASSERT(signature_size != 0);
     TEST_ASSERT(signature_size <= PSA_SIGNATURE_MAX_SIZE);
-    TEST_CALLOC_OR_FAIL(signature, signature_size);
+    TEST_CALLOC(signature, signature_size);
 
     actual_status = psa_sign_hash(key, alg,
                                   data_input->x, data_input->len,
@@ -183,7 +183,7 @@ void sign_message(int key_type_arg,
 
     TEST_ASSERT(signature_size != 0);
     TEST_ASSERT(signature_size <= PSA_SIGNATURE_MAX_SIZE);
-    TEST_CALLOC_OR_FAIL(signature, signature_size);
+    TEST_CALLOC(signature, signature_size);
 
     actual_status = psa_sign_message(key, alg,
                                      data_input->x, data_input->len,
@@ -487,8 +487,8 @@ void cipher_encrypt_validation(int alg_arg,
     output1_buffer_size = PSA_CIPHER_ENCRYPT_OUTPUT_SIZE(key_type, alg, input->len);
     output2_buffer_size = PSA_CIPHER_UPDATE_OUTPUT_SIZE(key_type, alg, input->len) +
                           PSA_CIPHER_FINISH_OUTPUT_SIZE(key_type, alg);
-    TEST_CALLOC_OR_FAIL(output1, output1_buffer_size);
-    TEST_CALLOC_OR_FAIL(output2, output2_buffer_size);
+    TEST_CALLOC(output1, output1_buffer_size);
+    TEST_CALLOC(output2, output2_buffer_size);
 
     PSA_ASSERT(psa_import_key(&attributes, key_data->x, key_data->len,
                               &key));
@@ -605,7 +605,7 @@ void cipher_encrypt_multipart(int alg_arg,
 
     output_buffer_size = ((size_t) input->len +
                           PSA_BLOCK_CIPHER_BLOCK_LENGTH(key_type));
-    TEST_CALLOC_OR_FAIL(output, output_buffer_size);
+    TEST_CALLOC(output, output_buffer_size);
 
     if (mock_output_arg) {
         mbedtls_test_driver_cipher_hooks.forced_output = expected_output->x;
@@ -733,7 +733,7 @@ void cipher_decrypt_multipart(int alg_arg,
 
     output_buffer_size = ((size_t) input->len +
                           PSA_BLOCK_CIPHER_BLOCK_LENGTH(key_type));
-    TEST_CALLOC_OR_FAIL(output, output_buffer_size);
+    TEST_CALLOC(output, output_buffer_size);
 
     if (mock_output_arg) {
         mbedtls_test_driver_cipher_hooks.forced_output = expected_output->x;
@@ -832,13 +832,13 @@ void cipher_decrypt(int alg_arg,
     /* Allocate input buffer and copy the iv and the plaintext */
     input_buffer_size = ((size_t) input_arg->len + (size_t) iv->len);
     if (input_buffer_size > 0) {
-        TEST_CALLOC_OR_FAIL(input, input_buffer_size);
+        TEST_CALLOC(input, input_buffer_size);
         memcpy(input, iv->x, iv->len);
         memcpy(input + iv->len, input_arg->x, input_arg->len);
     }
 
     output_buffer_size = PSA_CIPHER_DECRYPT_OUTPUT_SIZE(key_type, alg, input_buffer_size);
-    TEST_CALLOC_OR_FAIL(output, output_buffer_size);
+    TEST_CALLOC(output, output_buffer_size);
 
     PSA_ASSERT(psa_import_key(&attributes, key_data->x, key_data->len,
                               &key));
@@ -885,7 +885,7 @@ void cipher_entry_points(int alg_arg, int key_type_arg,
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     mbedtls_test_driver_cipher_hooks = mbedtls_test_driver_cipher_hooks_init();
 
-    TEST_CALLOC_OR_FAIL(output, input->len + 16);
+    TEST_CALLOC(output, input->len + 16);
     output_buffer_size = input->len + 16;
 
     PSA_ASSERT(psa_crypto_init());
@@ -1125,7 +1125,7 @@ void aead_encrypt(int key_type_arg, data_t *key_data,
                PSA_AEAD_ENCRYPT_OUTPUT_SIZE(key_type, alg, input_data->len));
     TEST_ASSERT(output_size <=
                 PSA_AEAD_ENCRYPT_OUTPUT_MAX_SIZE(input_data->len));
-    TEST_CALLOC_OR_FAIL(output_data, output_size);
+    TEST_CALLOC(output_data, output_size);
 
     mbedtls_test_driver_aead_hooks.forced_status = forced_status;
     status = psa_aead_encrypt(key, alg,
@@ -1187,7 +1187,7 @@ void aead_decrypt(int key_type_arg, data_t *key_data,
 
     output_size = input_data->len - PSA_AEAD_TAG_LENGTH(key_type, key_bits,
                                                         alg);
-    TEST_CALLOC_OR_FAIL(output_data, output_size);
+    TEST_CALLOC(output_data, output_size);
 
     mbedtls_test_driver_aead_hooks.forced_status = forced_status;
     status = psa_aead_decrypt(key, alg,
@@ -1250,7 +1250,7 @@ void mac_sign(int key_type_arg,
     PSA_ASSERT(psa_import_key(&attributes, key_data->x, key_data->len,
                               &key));
 
-    TEST_CALLOC_OR_FAIL(actual_mac, mac_buffer_size);
+    TEST_CALLOC(actual_mac, mac_buffer_size);
     mbedtls_test_driver_mac_hooks.forced_status = forced_status;
 
     /*
@@ -1470,7 +1470,7 @@ void builtin_key_export(int builtin_key_id_arg,
     psa_status_t actual_status;
 
     PSA_ASSERT(psa_crypto_init());
-    TEST_CALLOC_OR_FAIL(output_buffer, expected_output->len);
+    TEST_CALLOC(output_buffer, expected_output->len);
 
     actual_status = psa_export_key(key, output_buffer, expected_output->len, &output_size);
 
@@ -1521,7 +1521,7 @@ void builtin_pubkey_export(int builtin_key_id_arg,
     psa_status_t actual_status;
 
     PSA_ASSERT(psa_crypto_init());
-    TEST_CALLOC_OR_FAIL(output_buffer, expected_output->len);
+    TEST_CALLOC(output_buffer, expected_output->len);
 
     actual_status = psa_export_public_key(key, output_buffer, expected_output->len, &output_size);
 
@@ -1564,7 +1564,7 @@ void hash_compute(int alg_arg,
     mbedtls_test_driver_hash_hooks.forced_status = forced_status;
 
     PSA_ASSERT(psa_crypto_init());
-    TEST_CALLOC_OR_FAIL(output, PSA_HASH_LENGTH(alg));
+    TEST_CALLOC(output, PSA_HASH_LENGTH(alg));
 
     TEST_EQUAL(psa_hash_compute(alg, input->x, input->len,
                                 output, PSA_HASH_LENGTH(alg),
@@ -1597,7 +1597,7 @@ void hash_multipart_setup(int alg_arg,
     size_t output_length;
 
     mbedtls_test_driver_hash_hooks = mbedtls_test_driver_hash_hooks_init();
-    TEST_CALLOC_OR_FAIL(output, PSA_HASH_LENGTH(alg));
+    TEST_CALLOC(output, PSA_HASH_LENGTH(alg));
 
     PSA_ASSERT(psa_crypto_init());
 
@@ -1642,7 +1642,7 @@ void hash_multipart_update(int alg_arg,
     size_t output_length;
 
     mbedtls_test_driver_hash_hooks = mbedtls_test_driver_hash_hooks_init();
-    TEST_CALLOC_OR_FAIL(output, PSA_HASH_LENGTH(alg));
+    TEST_CALLOC(output, PSA_HASH_LENGTH(alg));
 
     PSA_ASSERT(psa_crypto_init());
 
@@ -1697,7 +1697,7 @@ void hash_multipart_finish(int alg_arg,
     size_t output_length;
 
     mbedtls_test_driver_hash_hooks = mbedtls_test_driver_hash_hooks_init();
-    TEST_CALLOC_OR_FAIL(output, PSA_HASH_LENGTH(alg));
+    TEST_CALLOC(output, PSA_HASH_LENGTH(alg));
 
     PSA_ASSERT(psa_crypto_init());
 
@@ -1751,7 +1751,7 @@ void hash_clone(int alg_arg,
     size_t output_length;
 
     mbedtls_test_driver_hash_hooks = mbedtls_test_driver_hash_hooks_init();
-    TEST_CALLOC_OR_FAIL(output, PSA_HASH_LENGTH(alg));
+    TEST_CALLOC(output, PSA_HASH_LENGTH(alg));
 
     PSA_ASSERT(psa_crypto_init());
 

--- a/tests/suites/test_suite_psa_crypto_entropy.function
+++ b/tests/suites/test_suite_psa_crypto_entropy.function
@@ -114,8 +114,8 @@ void external_rng_failure_sign(int key_type, data_t *key_data, int alg,
     size_t signature_size = PSA_SIGNATURE_MAX_SIZE;
     size_t signature_length;
 
-    TEST_CALLOC_OR_FAIL(input, input_size);
-    TEST_CALLOC_OR_FAIL(signature, signature_size);
+    TEST_CALLOC(input, input_size);
+    TEST_CALLOC(signature, signature_size);
 
     PSA_ASSERT(psa_crypto_init());
     PSA_ASSERT(psa_import_key(&attributes, key_data->x, key_data->len,
@@ -163,7 +163,7 @@ void validate_entropy_seed_injection(int seed_length_a,
     } else {
         seed_size = seed_length_b;
     }
-    TEST_CALLOC_OR_FAIL(seed, seed_size);
+    TEST_CALLOC(seed, seed_size);
     /* fill seed with some data */
     for (i = 0; i < seed_size; ++i) {
         seed[i] = i;

--- a/tests/suites/test_suite_psa_crypto_entropy.function
+++ b/tests/suites/test_suite_psa_crypto_entropy.function
@@ -114,8 +114,8 @@ void external_rng_failure_sign(int key_type, data_t *key_data, int alg,
     size_t signature_size = PSA_SIGNATURE_MAX_SIZE;
     size_t signature_length;
 
-    ASSERT_ALLOC(input, input_size);
-    ASSERT_ALLOC(signature, signature_size);
+    TEST_CALLOC_OR_FAIL(input, input_size);
+    TEST_CALLOC_OR_FAIL(signature, signature_size);
 
     PSA_ASSERT(psa_crypto_init());
     PSA_ASSERT(psa_import_key(&attributes, key_data->x, key_data->len,
@@ -163,7 +163,7 @@ void validate_entropy_seed_injection(int seed_length_a,
     } else {
         seed_size = seed_length_b;
     }
-    ASSERT_ALLOC(seed, seed_size);
+    TEST_CALLOC_OR_FAIL(seed, seed_size);
     /* fill seed with some data */
     for (i = 0; i < seed_size; ++i) {
         seed[i] = i;

--- a/tests/suites/test_suite_psa_crypto_hash.function
+++ b/tests/suites/test_suite_psa_crypto_hash.function
@@ -25,7 +25,7 @@ void hash_finish(int alg_arg, data_t *input, data_t *expected_hash)
     PSA_ASSERT(psa_hash_finish(&operation,
                                actual_hash, sizeof(actual_hash),
                                &actual_hash_length));
-    TEST_BUFFERS_EQUAL(expected_hash->x, expected_hash->len,
+    TEST_MEMORY_COMPARE(expected_hash->x, expected_hash->len,
                    actual_hash, actual_hash_length);
 
 exit:
@@ -83,13 +83,13 @@ void hash_multi_part(int alg_arg, data_t *input, data_t *expected_hash)
         PSA_ASSERT(psa_hash_finish(&operation,
                                    actual_hash, sizeof(actual_hash),
                                    &actual_hash_length));
-        TEST_BUFFERS_EQUAL(expected_hash->x, expected_hash->len,
+        TEST_MEMORY_COMPARE(expected_hash->x, expected_hash->len,
                        actual_hash, actual_hash_length);
 
         PSA_ASSERT(psa_hash_finish(&operation2,
                                    actual_hash, sizeof(actual_hash),
                                    &actual_hash_length));
-        TEST_BUFFERS_EQUAL(expected_hash->x, expected_hash->len,
+        TEST_MEMORY_COMPARE(expected_hash->x, expected_hash->len,
                        actual_hash, actual_hash_length);
     } while (len++ != input->len);
 

--- a/tests/suites/test_suite_psa_crypto_hash.function
+++ b/tests/suites/test_suite_psa_crypto_hash.function
@@ -26,7 +26,7 @@ void hash_finish(int alg_arg, data_t *input, data_t *expected_hash)
                                actual_hash, sizeof(actual_hash),
                                &actual_hash_length));
     TEST_MEMORY_COMPARE(expected_hash->x, expected_hash->len,
-                   actual_hash, actual_hash_length);
+                        actual_hash, actual_hash_length);
 
 exit:
     psa_hash_abort(&operation);
@@ -84,13 +84,13 @@ void hash_multi_part(int alg_arg, data_t *input, data_t *expected_hash)
                                    actual_hash, sizeof(actual_hash),
                                    &actual_hash_length));
         TEST_MEMORY_COMPARE(expected_hash->x, expected_hash->len,
-                       actual_hash, actual_hash_length);
+                            actual_hash, actual_hash_length);
 
         PSA_ASSERT(psa_hash_finish(&operation2,
                                    actual_hash, sizeof(actual_hash),
                                    &actual_hash_length));
         TEST_MEMORY_COMPARE(expected_hash->x, expected_hash->len,
-                       actual_hash, actual_hash_length);
+                            actual_hash, actual_hash_length);
     } while (len++ != input->len);
 
 exit:

--- a/tests/suites/test_suite_psa_crypto_hash.function
+++ b/tests/suites/test_suite_psa_crypto_hash.function
@@ -25,7 +25,7 @@ void hash_finish(int alg_arg, data_t *input, data_t *expected_hash)
     PSA_ASSERT(psa_hash_finish(&operation,
                                actual_hash, sizeof(actual_hash),
                                &actual_hash_length));
-    ASSERT_COMPARE(expected_hash->x, expected_hash->len,
+    TEST_BUFFERS_EQUAL(expected_hash->x, expected_hash->len,
                    actual_hash, actual_hash_length);
 
 exit:
@@ -83,13 +83,13 @@ void hash_multi_part(int alg_arg, data_t *input, data_t *expected_hash)
         PSA_ASSERT(psa_hash_finish(&operation,
                                    actual_hash, sizeof(actual_hash),
                                    &actual_hash_length));
-        ASSERT_COMPARE(expected_hash->x, expected_hash->len,
+        TEST_BUFFERS_EQUAL(expected_hash->x, expected_hash->len,
                        actual_hash, actual_hash_length);
 
         PSA_ASSERT(psa_hash_finish(&operation2,
                                    actual_hash, sizeof(actual_hash),
                                    &actual_hash_length));
-        ASSERT_COMPARE(expected_hash->x, expected_hash->len,
+        TEST_BUFFERS_EQUAL(expected_hash->x, expected_hash->len,
                        actual_hash, actual_hash_length);
     } while (len++ != input->len);
 

--- a/tests/suites/test_suite_psa_crypto_init.function
+++ b/tests/suites/test_suite_psa_crypto_init.function
@@ -289,7 +289,7 @@ void entropy_from_nv_seed(int seed_size_arg,
     uint8_t *seed = NULL;
     size_t seed_size = seed_size_arg;
 
-    ASSERT_ALLOC(seed, seed_size);
+    TEST_CALLOC_OR_FAIL(seed, seed_size);
     TEST_ASSERT(mbedtls_nv_seed_write(seed, seed_size) >= 0);
 
     custom_entropy_sources_mask = ENTROPY_SOURCE_NV_SEED;

--- a/tests/suites/test_suite_psa_crypto_init.function
+++ b/tests/suites/test_suite_psa_crypto_init.function
@@ -289,7 +289,7 @@ void entropy_from_nv_seed(int seed_size_arg,
     uint8_t *seed = NULL;
     size_t seed_size = seed_size_arg;
 
-    TEST_CALLOC_OR_FAIL(seed, seed_size);
+    TEST_CALLOC(seed, seed_size);
     TEST_ASSERT(mbedtls_nv_seed_write(seed, seed_size) >= 0);
 
     custom_entropy_sources_mask = ENTROPY_SOURCE_NV_SEED;

--- a/tests/suites/test_suite_psa_crypto_persistent_key.function
+++ b/tests/suites/test_suite_psa_crypto_persistent_key.function
@@ -61,7 +61,7 @@ void format_storage_data_check(data_t *key_data,
     psa_set_key_algorithm(&attributes, key_alg);
     psa_set_key_enrollment_algorithm(&attributes, key_alg2);
 
-    ASSERT_ALLOC(file_data, file_data_length);
+    TEST_CALLOC_OR_FAIL(file_data, file_data_length);
     psa_format_key_data_for_storage(key_data->x, key_data->len,
                                     &attributes.core,
                                     file_data);
@@ -127,7 +127,7 @@ void save_large_persistent_key(int data_length_arg, int expected_status)
     size_t data_length = data_length_arg;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
 
-    ASSERT_ALLOC(data, data_length);
+    TEST_CALLOC_OR_FAIL(data, data_length);
 
     PSA_ASSERT(psa_crypto_init());
 
@@ -267,7 +267,7 @@ void import_export_persistent_key(data_t *data, int type_arg,
     size_t exported_length;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
 
-    ASSERT_ALLOC(exported, export_size);
+    TEST_CALLOC_OR_FAIL(exported, export_size);
 
     PSA_ASSERT(psa_crypto_init());
 

--- a/tests/suites/test_suite_psa_crypto_persistent_key.function
+++ b/tests/suites/test_suite_psa_crypto_persistent_key.function
@@ -67,7 +67,7 @@ void format_storage_data_check(data_t *key_data,
                                     file_data);
 
     TEST_MEMORY_COMPARE(expected_file_data->x, expected_file_data->len,
-                   file_data, file_data_length);
+                        file_data, file_data_length);
 
 exit:
     mbedtls_free(file_data);
@@ -112,7 +112,7 @@ void parse_storage_data_check(data_t *file_data,
     TEST_EQUAL(psa_get_key_enrollment_algorithm(&attributes),
                (uint32_t) expected_key_alg2);
     TEST_MEMORY_COMPARE(expected_key_data->x, expected_key_data->len,
-                   key_data, key_data_length);
+                        key_data, key_data_length);
 
 exit:
     mbedtls_free(key_data);

--- a/tests/suites/test_suite_psa_crypto_persistent_key.function
+++ b/tests/suites/test_suite_psa_crypto_persistent_key.function
@@ -66,7 +66,7 @@ void format_storage_data_check(data_t *key_data,
                                     &attributes.core,
                                     file_data);
 
-    ASSERT_COMPARE(expected_file_data->x, expected_file_data->len,
+    TEST_BUFFERS_EQUAL(expected_file_data->x, expected_file_data->len,
                    file_data, file_data_length);
 
 exit:
@@ -111,7 +111,7 @@ void parse_storage_data_check(data_t *file_data,
                (uint32_t) expected_key_alg);
     TEST_EQUAL(psa_get_key_enrollment_algorithm(&attributes),
                (uint32_t) expected_key_alg2);
-    ASSERT_COMPARE(expected_key_data->x, expected_key_data->len,
+    TEST_BUFFERS_EQUAL(expected_key_data->x, expected_key_data->len,
                    key_data, key_data_length);
 
 exit:
@@ -307,7 +307,7 @@ void import_export_persistent_key(data_t *data, int type_arg,
     PSA_ASSERT(psa_export_key(key_id, exported, export_size,
                               &exported_length));
 
-    ASSERT_COMPARE(data->x, data->len, exported, exported_length);
+    TEST_BUFFERS_EQUAL(data->x, data->len, exported, exported_length);
 
     /* Destroy the key */
     PSA_ASSERT(psa_destroy_key(key_id));

--- a/tests/suites/test_suite_psa_crypto_persistent_key.function
+++ b/tests/suites/test_suite_psa_crypto_persistent_key.function
@@ -66,7 +66,7 @@ void format_storage_data_check(data_t *key_data,
                                     &attributes.core,
                                     file_data);
 
-    TEST_BUFFERS_EQUAL(expected_file_data->x, expected_file_data->len,
+    TEST_MEMORY_COMPARE(expected_file_data->x, expected_file_data->len,
                    file_data, file_data_length);
 
 exit:
@@ -111,7 +111,7 @@ void parse_storage_data_check(data_t *file_data,
                (uint32_t) expected_key_alg);
     TEST_EQUAL(psa_get_key_enrollment_algorithm(&attributes),
                (uint32_t) expected_key_alg2);
-    TEST_BUFFERS_EQUAL(expected_key_data->x, expected_key_data->len,
+    TEST_MEMORY_COMPARE(expected_key_data->x, expected_key_data->len,
                    key_data, key_data_length);
 
 exit:
@@ -307,7 +307,7 @@ void import_export_persistent_key(data_t *data, int type_arg,
     PSA_ASSERT(psa_export_key(key_id, exported, export_size,
                               &exported_length));
 
-    TEST_BUFFERS_EQUAL(data->x, data->len, exported, exported_length);
+    TEST_MEMORY_COMPARE(data->x, data->len, exported, exported_length);
 
     /* Destroy the key */
     PSA_ASSERT(psa_destroy_key(key_id));

--- a/tests/suites/test_suite_psa_crypto_persistent_key.function
+++ b/tests/suites/test_suite_psa_crypto_persistent_key.function
@@ -61,7 +61,7 @@ void format_storage_data_check(data_t *key_data,
     psa_set_key_algorithm(&attributes, key_alg);
     psa_set_key_enrollment_algorithm(&attributes, key_alg2);
 
-    TEST_CALLOC_OR_FAIL(file_data, file_data_length);
+    TEST_CALLOC(file_data, file_data_length);
     psa_format_key_data_for_storage(key_data->x, key_data->len,
                                     &attributes.core,
                                     file_data);
@@ -127,7 +127,7 @@ void save_large_persistent_key(int data_length_arg, int expected_status)
     size_t data_length = data_length_arg;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
 
-    TEST_CALLOC_OR_FAIL(data, data_length);
+    TEST_CALLOC(data, data_length);
 
     PSA_ASSERT(psa_crypto_init());
 
@@ -267,7 +267,7 @@ void import_export_persistent_key(data_t *data, int type_arg,
     size_t exported_length;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
 
-    TEST_CALLOC_OR_FAIL(exported, export_size);
+    TEST_CALLOC(exported, export_size);
 
     PSA_ASSERT(psa_crypto_init());
 

--- a/tests/suites/test_suite_psa_crypto_se_driver_hal.function
+++ b/tests/suites/test_suite_psa_crypto_se_driver_hal.function
@@ -601,7 +601,7 @@ static int check_persistent_data(psa_key_location_t location,
     int ok = 0;
 
     PSA_ASSERT(psa_its_get_info(uid, &info));
-    ASSERT_ALLOC(loaded, info.size);
+    TEST_CALLOC_OR_FAIL(loaded, info.size);
     PSA_ASSERT(psa_its_get(uid, 0, info.size, loaded, NULL));
     TEST_BUFFERS_EQUAL(expected_data, size, loaded, info.size);
     ok = 1;

--- a/tests/suites/test_suite_psa_crypto_se_driver_hal.function
+++ b/tests/suites/test_suite_psa_crypto_se_driver_hal.function
@@ -601,7 +601,7 @@ static int check_persistent_data(psa_key_location_t location,
     int ok = 0;
 
     PSA_ASSERT(psa_its_get_info(uid, &info));
-    TEST_CALLOC_OR_FAIL(loaded, info.size);
+    TEST_CALLOC(loaded, info.size);
     PSA_ASSERT(psa_its_get(uid, 0, info.size, loaded, NULL));
     TEST_BUFFERS_EQUAL(expected_data, size, loaded, info.size);
     ok = 1;

--- a/tests/suites/test_suite_psa_crypto_se_driver_hal.function
+++ b/tests/suites/test_suite_psa_crypto_se_driver_hal.function
@@ -603,7 +603,7 @@ static int check_persistent_data(psa_key_location_t location,
     PSA_ASSERT(psa_its_get_info(uid, &info));
     ASSERT_ALLOC(loaded, info.size);
     PSA_ASSERT(psa_its_get(uid, 0, info.size, loaded, NULL));
-    ASSERT_COMPARE(expected_data, size, loaded, info.size);
+    TEST_BUFFERS_EQUAL(expected_data, size, loaded, info.size);
     ok = 1;
 
 exit:
@@ -958,7 +958,7 @@ void key_creation_import_export(int lifetime_arg, int min_slot, int restart)
     PSA_ASSERT(psa_export_key(returned_id,
                               exported, sizeof(exported),
                               &exported_length));
-    ASSERT_COMPARE(key_material, sizeof(key_material),
+    TEST_BUFFERS_EQUAL(key_material, sizeof(key_material),
                    exported, exported_length);
 
     PSA_ASSERT(psa_destroy_key(returned_id));

--- a/tests/suites/test_suite_psa_crypto_se_driver_hal.function
+++ b/tests/suites/test_suite_psa_crypto_se_driver_hal.function
@@ -603,7 +603,7 @@ static int check_persistent_data(psa_key_location_t location,
     PSA_ASSERT(psa_its_get_info(uid, &info));
     TEST_CALLOC(loaded, info.size);
     PSA_ASSERT(psa_its_get(uid, 0, info.size, loaded, NULL));
-    TEST_BUFFERS_EQUAL(expected_data, size, loaded, info.size);
+    TEST_MEMORY_COMPARE(expected_data, size, loaded, info.size);
     ok = 1;
 
 exit:
@@ -958,7 +958,7 @@ void key_creation_import_export(int lifetime_arg, int min_slot, int restart)
     PSA_ASSERT(psa_export_key(returned_id,
                               exported, sizeof(exported),
                               &exported_length));
-    TEST_BUFFERS_EQUAL(key_material, sizeof(key_material),
+    TEST_MEMORY_COMPARE(key_material, sizeof(key_material),
                    exported, exported_length);
 
     PSA_ASSERT(psa_destroy_key(returned_id));

--- a/tests/suites/test_suite_psa_crypto_se_driver_hal.function
+++ b/tests/suites/test_suite_psa_crypto_se_driver_hal.function
@@ -959,7 +959,7 @@ void key_creation_import_export(int lifetime_arg, int min_slot, int restart)
                               exported, sizeof(exported),
                               &exported_length));
     TEST_MEMORY_COMPARE(key_material, sizeof(key_material),
-                   exported, exported_length);
+                        exported, exported_length);
 
     PSA_ASSERT(psa_destroy_key(returned_id));
     if (!check_persistent_data(location,

--- a/tests/suites/test_suite_psa_crypto_slot_management.function
+++ b/tests/suites/test_suite_psa_crypto_slot_management.function
@@ -303,7 +303,7 @@ void persistent_slot_lifecycle(int lifetime_arg, int owner_id_arg, int id_arg,
                        psa_get_key_type(&read_attributes));
             TEST_EQUAL(psa_get_key_bits(&attributes),
                        psa_get_key_bits(&read_attributes));
-            ASSERT_ALLOC(reexported, key_data->len);
+            TEST_CALLOC_OR_FAIL(reexported, key_data->len);
             if (usage_flags & PSA_KEY_USAGE_EXPORT) {
                 PSA_ASSERT(psa_export_key(id, reexported, key_data->len,
                                           &reexported_length));
@@ -575,7 +575,7 @@ void copy_across_lifetimes(int source_lifetime_arg, int source_owner_id_arg,
                psa_get_key_enrollment_algorithm(&target_attributes));
     if (expected_usage & PSA_KEY_USAGE_EXPORT) {
         size_t length;
-        ASSERT_ALLOC(export_buffer, material->len);
+        TEST_CALLOC_OR_FAIL(export_buffer, material->len);
         PSA_ASSERT(psa_export_key(returned_target_id, export_buffer,
                                   material->len, &length));
         TEST_BUFFERS_EQUAL(material->x, material->len,
@@ -689,7 +689,7 @@ void copy_to_occupied(int source_lifetime_arg, int source_id_arg,
                psa_get_key_algorithm(&attributes2));
     if (target_usage & PSA_KEY_USAGE_EXPORT) {
         size_t length;
-        ASSERT_ALLOC(export_buffer, target_material->len);
+        TEST_CALLOC_OR_FAIL(export_buffer, target_material->len);
         PSA_ASSERT(psa_export_key(returned_target_id, export_buffer,
                                   target_material->len, &length));
         TEST_BUFFERS_EQUAL(target_material->x, target_material->len,
@@ -813,7 +813,7 @@ void many_transient_keys(int max_keys_arg)
     uint8_t exported[sizeof(size_t)];
     size_t exported_length;
 
-    ASSERT_ALLOC(keys, max_keys);
+    TEST_CALLOC_OR_FAIL(keys, max_keys);
     PSA_ASSERT(psa_crypto_init());
 
     psa_set_key_usage_flags(&attributes, PSA_KEY_USAGE_EXPORT);
@@ -942,7 +942,7 @@ void non_reusable_key_slots_integrity_in_case_of_key_slot_starvation()
 
     TEST_ASSERT(MBEDTLS_PSA_KEY_SLOT_COUNT >= 1);
 
-    ASSERT_ALLOC(keys, MBEDTLS_PSA_KEY_SLOT_COUNT);
+    TEST_CALLOC_OR_FAIL(keys, MBEDTLS_PSA_KEY_SLOT_COUNT);
     PSA_ASSERT(psa_crypto_init());
 
     psa_set_key_usage_flags(&attributes,

--- a/tests/suites/test_suite_psa_crypto_slot_management.function
+++ b/tests/suites/test_suite_psa_crypto_slot_management.function
@@ -303,7 +303,7 @@ void persistent_slot_lifecycle(int lifetime_arg, int owner_id_arg, int id_arg,
                        psa_get_key_type(&read_attributes));
             TEST_EQUAL(psa_get_key_bits(&attributes),
                        psa_get_key_bits(&read_attributes));
-            TEST_CALLOC_OR_FAIL(reexported, key_data->len);
+            TEST_CALLOC(reexported, key_data->len);
             if (usage_flags & PSA_KEY_USAGE_EXPORT) {
                 PSA_ASSERT(psa_export_key(id, reexported, key_data->len,
                                           &reexported_length));
@@ -575,7 +575,7 @@ void copy_across_lifetimes(int source_lifetime_arg, int source_owner_id_arg,
                psa_get_key_enrollment_algorithm(&target_attributes));
     if (expected_usage & PSA_KEY_USAGE_EXPORT) {
         size_t length;
-        TEST_CALLOC_OR_FAIL(export_buffer, material->len);
+        TEST_CALLOC(export_buffer, material->len);
         PSA_ASSERT(psa_export_key(returned_target_id, export_buffer,
                                   material->len, &length));
         TEST_BUFFERS_EQUAL(material->x, material->len,
@@ -689,7 +689,7 @@ void copy_to_occupied(int source_lifetime_arg, int source_id_arg,
                psa_get_key_algorithm(&attributes2));
     if (target_usage & PSA_KEY_USAGE_EXPORT) {
         size_t length;
-        TEST_CALLOC_OR_FAIL(export_buffer, target_material->len);
+        TEST_CALLOC(export_buffer, target_material->len);
         PSA_ASSERT(psa_export_key(returned_target_id, export_buffer,
                                   target_material->len, &length));
         TEST_BUFFERS_EQUAL(target_material->x, target_material->len,
@@ -813,7 +813,7 @@ void many_transient_keys(int max_keys_arg)
     uint8_t exported[sizeof(size_t)];
     size_t exported_length;
 
-    TEST_CALLOC_OR_FAIL(keys, max_keys);
+    TEST_CALLOC(keys, max_keys);
     PSA_ASSERT(psa_crypto_init());
 
     psa_set_key_usage_flags(&attributes, PSA_KEY_USAGE_EXPORT);
@@ -942,7 +942,7 @@ void non_reusable_key_slots_integrity_in_case_of_key_slot_starvation()
 
     TEST_ASSERT(MBEDTLS_PSA_KEY_SLOT_COUNT >= 1);
 
-    TEST_CALLOC_OR_FAIL(keys, MBEDTLS_PSA_KEY_SLOT_COUNT);
+    TEST_CALLOC(keys, MBEDTLS_PSA_KEY_SLOT_COUNT);
     PSA_ASSERT(psa_crypto_init());
 
     psa_set_key_usage_flags(&attributes,

--- a/tests/suites/test_suite_psa_crypto_slot_management.function
+++ b/tests/suites/test_suite_psa_crypto_slot_management.function
@@ -308,7 +308,7 @@ void persistent_slot_lifecycle(int lifetime_arg, int owner_id_arg, int id_arg,
                 PSA_ASSERT(psa_export_key(id, reexported, key_data->len,
                                           &reexported_length));
                 TEST_MEMORY_COMPARE(key_data->x, key_data->len,
-                               reexported, reexported_length);
+                                    reexported, reexported_length);
             } else {
                 TEST_EQUAL(psa_export_key(id, reexported,
                                           key_data->len, &reexported_length),
@@ -403,7 +403,7 @@ void create_existent(int lifetime_arg, int owner_id_arg, int id_arg,
                               reexported, sizeof(reexported),
                               &reexported_length));
     TEST_MEMORY_COMPARE(material1, sizeof(material1),
-                   reexported, reexported_length);
+                        reexported, reexported_length);
 
     PSA_ASSERT(psa_close_key(id));
 
@@ -579,7 +579,7 @@ void copy_across_lifetimes(int source_lifetime_arg, int source_owner_id_arg,
         PSA_ASSERT(psa_export_key(returned_target_id, export_buffer,
                                   material->len, &length));
         TEST_MEMORY_COMPARE(material->x, material->len,
-                       export_buffer, length);
+                            export_buffer, length);
     } else {
         size_t length;
         /* Check that the key is actually non-exportable. */
@@ -693,7 +693,7 @@ void copy_to_occupied(int source_lifetime_arg, int source_id_arg,
         PSA_ASSERT(psa_export_key(returned_target_id, export_buffer,
                                   target_material->len, &length));
         TEST_MEMORY_COMPARE(target_material->x, target_material->len,
-                       export_buffer, length);
+                            export_buffer, length);
     }
 
     PSA_ASSERT(psa_destroy_key(returned_source_id));
@@ -841,7 +841,7 @@ void many_transient_keys(int max_keys_arg)
                                   exported, sizeof(exported),
                                   &exported_length));
         TEST_MEMORY_COMPARE(exported, exported_length,
-                       (uint8_t *) &i, sizeof(i));
+                            (uint8_t *) &i, sizeof(i));
     }
     PSA_ASSERT(psa_close_key(keys[i - 1]));
 
@@ -918,7 +918,7 @@ void key_slot_eviction_to_import_new_key(int lifetime_arg)
                                   exported, sizeof(exported),
                                   &exported_length));
         TEST_MEMORY_COMPARE(exported, exported_length,
-                       (uint8_t *) &i, sizeof(i));
+                            (uint8_t *) &i, sizeof(i));
         PSA_ASSERT(psa_destroy_key(key));
     }
 
@@ -1017,7 +1017,7 @@ void non_reusable_key_slots_integrity_in_case_of_key_slot_starvation()
                                   exported, sizeof(exported),
                                   &exported_length));
         TEST_MEMORY_COMPARE(exported, exported_length,
-                       (uint8_t *) &i, sizeof(i));
+                            (uint8_t *) &i, sizeof(i));
         PSA_ASSERT(psa_destroy_key(keys[i]));
     }
 
@@ -1029,7 +1029,7 @@ void non_reusable_key_slots_integrity_in_case_of_key_slot_starvation()
     PSA_ASSERT(psa_export_key(persistent_key, exported, sizeof(exported),
                               &exported_length));
     TEST_MEMORY_COMPARE(exported, exported_length,
-                   (uint8_t *) &persistent_key, sizeof(persistent_key));
+                        (uint8_t *) &persistent_key, sizeof(persistent_key));
 exit:
     /*
      * Key attributes may have been returned by psa_get_key_attributes()

--- a/tests/suites/test_suite_psa_crypto_slot_management.function
+++ b/tests/suites/test_suite_psa_crypto_slot_management.function
@@ -307,7 +307,7 @@ void persistent_slot_lifecycle(int lifetime_arg, int owner_id_arg, int id_arg,
             if (usage_flags & PSA_KEY_USAGE_EXPORT) {
                 PSA_ASSERT(psa_export_key(id, reexported, key_data->len,
                                           &reexported_length));
-                ASSERT_COMPARE(key_data->x, key_data->len,
+                TEST_BUFFERS_EQUAL(key_data->x, key_data->len,
                                reexported, reexported_length);
             } else {
                 TEST_EQUAL(psa_export_key(id, reexported,
@@ -402,7 +402,7 @@ void create_existent(int lifetime_arg, int owner_id_arg, int id_arg,
     PSA_ASSERT(psa_export_key(id,
                               reexported, sizeof(reexported),
                               &reexported_length));
-    ASSERT_COMPARE(material1, sizeof(material1),
+    TEST_BUFFERS_EQUAL(material1, sizeof(material1),
                    reexported, reexported_length);
 
     PSA_ASSERT(psa_close_key(id));
@@ -578,7 +578,7 @@ void copy_across_lifetimes(int source_lifetime_arg, int source_owner_id_arg,
         ASSERT_ALLOC(export_buffer, material->len);
         PSA_ASSERT(psa_export_key(returned_target_id, export_buffer,
                                   material->len, &length));
-        ASSERT_COMPARE(material->x, material->len,
+        TEST_BUFFERS_EQUAL(material->x, material->len,
                        export_buffer, length);
     } else {
         size_t length;
@@ -692,7 +692,7 @@ void copy_to_occupied(int source_lifetime_arg, int source_id_arg,
         ASSERT_ALLOC(export_buffer, target_material->len);
         PSA_ASSERT(psa_export_key(returned_target_id, export_buffer,
                                   target_material->len, &length));
-        ASSERT_COMPARE(target_material->x, target_material->len,
+        TEST_BUFFERS_EQUAL(target_material->x, target_material->len,
                        export_buffer, length);
     }
 
@@ -840,7 +840,7 @@ void many_transient_keys(int max_keys_arg)
         PSA_ASSERT(psa_export_key(keys[i],
                                   exported, sizeof(exported),
                                   &exported_length));
-        ASSERT_COMPARE(exported, exported_length,
+        TEST_BUFFERS_EQUAL(exported, exported_length,
                        (uint8_t *) &i, sizeof(i));
     }
     PSA_ASSERT(psa_close_key(keys[i - 1]));
@@ -917,7 +917,7 @@ void key_slot_eviction_to_import_new_key(int lifetime_arg)
         PSA_ASSERT(psa_export_key(key,
                                   exported, sizeof(exported),
                                   &exported_length));
-        ASSERT_COMPARE(exported, exported_length,
+        TEST_BUFFERS_EQUAL(exported, exported_length,
                        (uint8_t *) &i, sizeof(i));
         PSA_ASSERT(psa_destroy_key(key));
     }
@@ -988,7 +988,7 @@ void non_reusable_key_slots_integrity_in_case_of_key_slot_starvation()
                               exported, sizeof(exported),
                               &exported_length));
     i = MBEDTLS_PSA_KEY_SLOT_COUNT - 1;
-    ASSERT_COMPARE(exported, exported_length, (uint8_t *) &i, sizeof(i));
+    TEST_BUFFERS_EQUAL(exported, exported_length, (uint8_t *) &i, sizeof(i));
     PSA_ASSERT(psa_destroy_key(keys[MBEDTLS_PSA_KEY_SLOT_COUNT - 1]));
 
     /*
@@ -1016,7 +1016,7 @@ void non_reusable_key_slots_integrity_in_case_of_key_slot_starvation()
         PSA_ASSERT(psa_export_key(keys[i],
                                   exported, sizeof(exported),
                                   &exported_length));
-        ASSERT_COMPARE(exported, exported_length,
+        TEST_BUFFERS_EQUAL(exported, exported_length,
                        (uint8_t *) &i, sizeof(i));
         PSA_ASSERT(psa_destroy_key(keys[i]));
     }
@@ -1028,7 +1028,7 @@ void non_reusable_key_slots_integrity_in_case_of_key_slot_starvation()
 
     PSA_ASSERT(psa_export_key(persistent_key, exported, sizeof(exported),
                               &exported_length));
-    ASSERT_COMPARE(exported, exported_length,
+    TEST_BUFFERS_EQUAL(exported, exported_length,
                    (uint8_t *) &persistent_key, sizeof(persistent_key));
 exit:
     /*

--- a/tests/suites/test_suite_psa_crypto_slot_management.function
+++ b/tests/suites/test_suite_psa_crypto_slot_management.function
@@ -307,7 +307,7 @@ void persistent_slot_lifecycle(int lifetime_arg, int owner_id_arg, int id_arg,
             if (usage_flags & PSA_KEY_USAGE_EXPORT) {
                 PSA_ASSERT(psa_export_key(id, reexported, key_data->len,
                                           &reexported_length));
-                TEST_BUFFERS_EQUAL(key_data->x, key_data->len,
+                TEST_MEMORY_COMPARE(key_data->x, key_data->len,
                                reexported, reexported_length);
             } else {
                 TEST_EQUAL(psa_export_key(id, reexported,
@@ -402,7 +402,7 @@ void create_existent(int lifetime_arg, int owner_id_arg, int id_arg,
     PSA_ASSERT(psa_export_key(id,
                               reexported, sizeof(reexported),
                               &reexported_length));
-    TEST_BUFFERS_EQUAL(material1, sizeof(material1),
+    TEST_MEMORY_COMPARE(material1, sizeof(material1),
                    reexported, reexported_length);
 
     PSA_ASSERT(psa_close_key(id));
@@ -578,7 +578,7 @@ void copy_across_lifetimes(int source_lifetime_arg, int source_owner_id_arg,
         TEST_CALLOC(export_buffer, material->len);
         PSA_ASSERT(psa_export_key(returned_target_id, export_buffer,
                                   material->len, &length));
-        TEST_BUFFERS_EQUAL(material->x, material->len,
+        TEST_MEMORY_COMPARE(material->x, material->len,
                        export_buffer, length);
     } else {
         size_t length;
@@ -692,7 +692,7 @@ void copy_to_occupied(int source_lifetime_arg, int source_id_arg,
         TEST_CALLOC(export_buffer, target_material->len);
         PSA_ASSERT(psa_export_key(returned_target_id, export_buffer,
                                   target_material->len, &length));
-        TEST_BUFFERS_EQUAL(target_material->x, target_material->len,
+        TEST_MEMORY_COMPARE(target_material->x, target_material->len,
                        export_buffer, length);
     }
 
@@ -840,7 +840,7 @@ void many_transient_keys(int max_keys_arg)
         PSA_ASSERT(psa_export_key(keys[i],
                                   exported, sizeof(exported),
                                   &exported_length));
-        TEST_BUFFERS_EQUAL(exported, exported_length,
+        TEST_MEMORY_COMPARE(exported, exported_length,
                        (uint8_t *) &i, sizeof(i));
     }
     PSA_ASSERT(psa_close_key(keys[i - 1]));
@@ -917,7 +917,7 @@ void key_slot_eviction_to_import_new_key(int lifetime_arg)
         PSA_ASSERT(psa_export_key(key,
                                   exported, sizeof(exported),
                                   &exported_length));
-        TEST_BUFFERS_EQUAL(exported, exported_length,
+        TEST_MEMORY_COMPARE(exported, exported_length,
                        (uint8_t *) &i, sizeof(i));
         PSA_ASSERT(psa_destroy_key(key));
     }
@@ -988,7 +988,7 @@ void non_reusable_key_slots_integrity_in_case_of_key_slot_starvation()
                               exported, sizeof(exported),
                               &exported_length));
     i = MBEDTLS_PSA_KEY_SLOT_COUNT - 1;
-    TEST_BUFFERS_EQUAL(exported, exported_length, (uint8_t *) &i, sizeof(i));
+    TEST_MEMORY_COMPARE(exported, exported_length, (uint8_t *) &i, sizeof(i));
     PSA_ASSERT(psa_destroy_key(keys[MBEDTLS_PSA_KEY_SLOT_COUNT - 1]));
 
     /*
@@ -1016,7 +1016,7 @@ void non_reusable_key_slots_integrity_in_case_of_key_slot_starvation()
         PSA_ASSERT(psa_export_key(keys[i],
                                   exported, sizeof(exported),
                                   &exported_length));
-        TEST_BUFFERS_EQUAL(exported, exported_length,
+        TEST_MEMORY_COMPARE(exported, exported_length,
                        (uint8_t *) &i, sizeof(i));
         PSA_ASSERT(psa_destroy_key(keys[i]));
     }
@@ -1028,7 +1028,7 @@ void non_reusable_key_slots_integrity_in_case_of_key_slot_starvation()
 
     PSA_ASSERT(psa_export_key(persistent_key, exported, sizeof(exported),
                               &exported_length));
-    TEST_BUFFERS_EQUAL(exported, exported_length,
+    TEST_MEMORY_COMPARE(exported, exported_length,
                    (uint8_t *) &persistent_key, sizeof(persistent_key));
 exit:
     /*

--- a/tests/suites/test_suite_psa_crypto_storage_format.function
+++ b/tests/suites/test_suite_psa_crypto_storage_format.function
@@ -39,7 +39,7 @@ static int test_written_key(const psa_key_attributes_t *attributes,
     TEST_CALLOC(actual_representation, storage_info.size);
     PSA_ASSERT(psa_its_get(uid, 0, storage_info.size,
                            actual_representation, &length));
-    TEST_BUFFERS_EQUAL(expected_representation->x, expected_representation->len,
+    TEST_MEMORY_COMPARE(expected_representation->x, expected_representation->len,
                    actual_representation, length);
 
     ok = 1;
@@ -272,7 +272,7 @@ static int test_read_key(const psa_key_attributes_t *expected_attributes,
         PSA_ASSERT(psa_export_key(key_id,
                                   exported_material, expected_material->len,
                                   &length));
-        TEST_BUFFERS_EQUAL(expected_material->x, expected_material->len,
+        TEST_MEMORY_COMPARE(expected_material->x, expected_material->len,
                        exported_material, length);
     }
 

--- a/tests/suites/test_suite_psa_crypto_storage_format.function
+++ b/tests/suites/test_suite_psa_crypto_storage_format.function
@@ -36,7 +36,7 @@ static int test_written_key(const psa_key_attributes_t *attributes,
     /* Check that the key is represented as expected. */
     PSA_ASSERT(psa_its_get_info(uid, &storage_info));
     TEST_EQUAL(storage_info.size, expected_representation->len);
-    TEST_CALLOC_OR_FAIL(actual_representation, storage_info.size);
+    TEST_CALLOC(actual_representation, storage_info.size);
     PSA_ASSERT(psa_its_get(uid, 0, storage_info.size,
                            actual_representation, &length));
     TEST_BUFFERS_EQUAL(expected_representation->x, expected_representation->len,
@@ -268,7 +268,7 @@ static int test_read_key(const psa_key_attributes_t *expected_attributes,
     TEST_EQUAL(psa_get_key_enrollment_algorithm(expected_attributes),
                psa_get_key_enrollment_algorithm(&actual_attributes));
     if (can_export(expected_attributes)) {
-        TEST_CALLOC_OR_FAIL(exported_material, expected_material->len);
+        TEST_CALLOC(exported_material, expected_material->len);
         PSA_ASSERT(psa_export_key(key_id,
                                   exported_material, expected_material->len,
                                   &length));

--- a/tests/suites/test_suite_psa_crypto_storage_format.function
+++ b/tests/suites/test_suite_psa_crypto_storage_format.function
@@ -39,7 +39,7 @@ static int test_written_key(const psa_key_attributes_t *attributes,
     ASSERT_ALLOC(actual_representation, storage_info.size);
     PSA_ASSERT(psa_its_get(uid, 0, storage_info.size,
                            actual_representation, &length));
-    ASSERT_COMPARE(expected_representation->x, expected_representation->len,
+    TEST_BUFFERS_EQUAL(expected_representation->x, expected_representation->len,
                    actual_representation, length);
 
     ok = 1;
@@ -272,7 +272,7 @@ static int test_read_key(const psa_key_attributes_t *expected_attributes,
         PSA_ASSERT(psa_export_key(key_id,
                                   exported_material, expected_material->len,
                                   &length));
-        ASSERT_COMPARE(expected_material->x, expected_material->len,
+        TEST_BUFFERS_EQUAL(expected_material->x, expected_material->len,
                        exported_material, length);
     }
 

--- a/tests/suites/test_suite_psa_crypto_storage_format.function
+++ b/tests/suites/test_suite_psa_crypto_storage_format.function
@@ -40,7 +40,7 @@ static int test_written_key(const psa_key_attributes_t *attributes,
     PSA_ASSERT(psa_its_get(uid, 0, storage_info.size,
                            actual_representation, &length));
     TEST_MEMORY_COMPARE(expected_representation->x, expected_representation->len,
-                   actual_representation, length);
+                        actual_representation, length);
 
     ok = 1;
 
@@ -273,7 +273,7 @@ static int test_read_key(const psa_key_attributes_t *expected_attributes,
                                   exported_material, expected_material->len,
                                   &length));
         TEST_MEMORY_COMPARE(expected_material->x, expected_material->len,
-                       exported_material, length);
+                            exported_material, length);
     }
 
     if ((flags & TEST_FLAG_EXERCISE) && can_exercise(&actual_attributes)) {

--- a/tests/suites/test_suite_psa_crypto_storage_format.function
+++ b/tests/suites/test_suite_psa_crypto_storage_format.function
@@ -36,7 +36,7 @@ static int test_written_key(const psa_key_attributes_t *attributes,
     /* Check that the key is represented as expected. */
     PSA_ASSERT(psa_its_get_info(uid, &storage_info));
     TEST_EQUAL(storage_info.size, expected_representation->len);
-    ASSERT_ALLOC(actual_representation, storage_info.size);
+    TEST_CALLOC_OR_FAIL(actual_representation, storage_info.size);
     PSA_ASSERT(psa_its_get(uid, 0, storage_info.size,
                            actual_representation, &length));
     TEST_BUFFERS_EQUAL(expected_representation->x, expected_representation->len,
@@ -268,7 +268,7 @@ static int test_read_key(const psa_key_attributes_t *expected_attributes,
     TEST_EQUAL(psa_get_key_enrollment_algorithm(expected_attributes),
                psa_get_key_enrollment_algorithm(&actual_attributes));
     if (can_export(expected_attributes)) {
-        ASSERT_ALLOC(exported_material, expected_material->len);
+        TEST_CALLOC_OR_FAIL(exported_material, expected_material->len);
         PSA_ASSERT(psa_export_key(key_id,
                                   exported_material, expected_material->len,
                                   &length));

--- a/tests/suites/test_suite_psa_its.function
+++ b/tests/suites/test_suite_psa_its.function
@@ -100,7 +100,7 @@ void set_get_remove(int uid_arg, int flags_arg, data_t *data)
     TEST_ASSERT(info.size == data->len);
     TEST_ASSERT(info.flags == flags);
     PSA_ASSERT(psa_its_get(uid, 0, data->len, buffer, &ret_len));
-    TEST_BUFFERS_EQUAL(data->x, data->len, buffer, ret_len);
+    TEST_MEMORY_COMPARE(data->x, data->len, buffer, ret_len);
 
     PSA_ASSERT(psa_its_remove(uid));
 
@@ -129,7 +129,7 @@ void set_overwrite(int uid_arg,
     TEST_ASSERT(info.size == data1->len);
     TEST_ASSERT(info.flags == flags1);
     PSA_ASSERT(psa_its_get(uid, 0, data1->len, buffer, &ret_len));
-    TEST_BUFFERS_EQUAL(data1->x, data1->len, buffer, ret_len);
+    TEST_MEMORY_COMPARE(data1->x, data1->len, buffer, ret_len);
 
     PSA_ASSERT(psa_its_set_wrap(uid, data2->len, data2->x, flags2));
     PSA_ASSERT(psa_its_get_info(uid, &info));
@@ -137,7 +137,7 @@ void set_overwrite(int uid_arg,
     TEST_ASSERT(info.flags == flags2);
     ret_len = 0;
     PSA_ASSERT(psa_its_get(uid, 0, data2->len, buffer, &ret_len));
-    TEST_BUFFERS_EQUAL(data2->x, data2->len, buffer, ret_len);
+    TEST_MEMORY_COMPARE(data2->x, data2->len, buffer, ret_len);
 
     PSA_ASSERT(psa_its_remove(uid));
 
@@ -167,7 +167,7 @@ void set_multiple(int first_id, int count)
         mbedtls_snprintf(stored, sizeof(stored),
                          "Content of file 0x%08lx", (unsigned long) uid);
         PSA_ASSERT(psa_its_get(uid, 0, sizeof(stored), retrieved, &ret_len));
-        TEST_BUFFERS_EQUAL(retrieved, ret_len,
+        TEST_MEMORY_COMPARE(retrieved, ret_len,
                        stored, sizeof(stored));
         PSA_ASSERT(psa_its_remove(uid));
         TEST_ASSERT(psa_its_get(uid, 0, 0, NULL, NULL) ==
@@ -223,7 +223,7 @@ void get_at(int uid_arg, data_t *data,
     status = psa_its_get(uid, offset, length_arg, buffer, &ret_len);
     TEST_ASSERT(status == (psa_status_t) expected_status);
     if (status == PSA_SUCCESS) {
-        TEST_BUFFERS_EQUAL(data->x + offset, (size_t) length_arg,
+        TEST_MEMORY_COMPARE(data->x + offset, (size_t) length_arg,
                        buffer, ret_len);
     }
     for (i = 0; i < 16; i++) {

--- a/tests/suites/test_suite_psa_its.function
+++ b/tests/suites/test_suite_psa_its.function
@@ -168,7 +168,7 @@ void set_multiple(int first_id, int count)
                          "Content of file 0x%08lx", (unsigned long) uid);
         PSA_ASSERT(psa_its_get(uid, 0, sizeof(stored), retrieved, &ret_len));
         TEST_MEMORY_COMPARE(retrieved, ret_len,
-                       stored, sizeof(stored));
+                            stored, sizeof(stored));
         PSA_ASSERT(psa_its_remove(uid));
         TEST_ASSERT(psa_its_get(uid, 0, 0, NULL, NULL) ==
                     PSA_ERROR_DOES_NOT_EXIST);
@@ -224,7 +224,7 @@ void get_at(int uid_arg, data_t *data,
     TEST_ASSERT(status == (psa_status_t) expected_status);
     if (status == PSA_SUCCESS) {
         TEST_MEMORY_COMPARE(data->x + offset, (size_t) length_arg,
-                       buffer, ret_len);
+                            buffer, ret_len);
     }
     for (i = 0; i < 16; i++) {
         TEST_ASSERT(trailer[i] == '-');

--- a/tests/suites/test_suite_psa_its.function
+++ b/tests/suites/test_suite_psa_its.function
@@ -92,7 +92,7 @@ void set_get_remove(int uid_arg, int flags_arg, data_t *data)
     unsigned char *buffer = NULL;
     size_t ret_len = 0;
 
-    ASSERT_ALLOC(buffer, data->len);
+    TEST_CALLOC_OR_FAIL(buffer, data->len);
 
     PSA_ASSERT(psa_its_set_wrap(uid, data->len, data->x, flags));
 
@@ -122,7 +122,7 @@ void set_overwrite(int uid_arg,
     unsigned char *buffer = NULL;
     size_t ret_len = 0;
 
-    ASSERT_ALLOC(buffer, MAX(data1->len, data2->len));
+    TEST_CALLOC_OR_FAIL(buffer, MAX(data1->len, data2->len));
 
     PSA_ASSERT(psa_its_set_wrap(uid, data1->len, data1->x, flags1));
     PSA_ASSERT(psa_its_get_info(uid, &info));
@@ -214,7 +214,7 @@ void get_at(int uid_arg, data_t *data,
     size_t i;
     size_t ret_len = 0;
 
-    ASSERT_ALLOC(buffer, length + 16);
+    TEST_CALLOC_OR_FAIL(buffer, length + 16);
     trailer = buffer + length;
     memset(trailer, '-', 16);
 

--- a/tests/suites/test_suite_psa_its.function
+++ b/tests/suites/test_suite_psa_its.function
@@ -100,7 +100,7 @@ void set_get_remove(int uid_arg, int flags_arg, data_t *data)
     TEST_ASSERT(info.size == data->len);
     TEST_ASSERT(info.flags == flags);
     PSA_ASSERT(psa_its_get(uid, 0, data->len, buffer, &ret_len));
-    ASSERT_COMPARE(data->x, data->len, buffer, ret_len);
+    TEST_BUFFERS_EQUAL(data->x, data->len, buffer, ret_len);
 
     PSA_ASSERT(psa_its_remove(uid));
 
@@ -129,7 +129,7 @@ void set_overwrite(int uid_arg,
     TEST_ASSERT(info.size == data1->len);
     TEST_ASSERT(info.flags == flags1);
     PSA_ASSERT(psa_its_get(uid, 0, data1->len, buffer, &ret_len));
-    ASSERT_COMPARE(data1->x, data1->len, buffer, ret_len);
+    TEST_BUFFERS_EQUAL(data1->x, data1->len, buffer, ret_len);
 
     PSA_ASSERT(psa_its_set_wrap(uid, data2->len, data2->x, flags2));
     PSA_ASSERT(psa_its_get_info(uid, &info));
@@ -137,7 +137,7 @@ void set_overwrite(int uid_arg,
     TEST_ASSERT(info.flags == flags2);
     ret_len = 0;
     PSA_ASSERT(psa_its_get(uid, 0, data2->len, buffer, &ret_len));
-    ASSERT_COMPARE(data2->x, data2->len, buffer, ret_len);
+    TEST_BUFFERS_EQUAL(data2->x, data2->len, buffer, ret_len);
 
     PSA_ASSERT(psa_its_remove(uid));
 
@@ -167,7 +167,7 @@ void set_multiple(int first_id, int count)
         mbedtls_snprintf(stored, sizeof(stored),
                          "Content of file 0x%08lx", (unsigned long) uid);
         PSA_ASSERT(psa_its_get(uid, 0, sizeof(stored), retrieved, &ret_len));
-        ASSERT_COMPARE(retrieved, ret_len,
+        TEST_BUFFERS_EQUAL(retrieved, ret_len,
                        stored, sizeof(stored));
         PSA_ASSERT(psa_its_remove(uid));
         TEST_ASSERT(psa_its_get(uid, 0, 0, NULL, NULL) ==
@@ -223,7 +223,7 @@ void get_at(int uid_arg, data_t *data,
     status = psa_its_get(uid, offset, length_arg, buffer, &ret_len);
     TEST_ASSERT(status == (psa_status_t) expected_status);
     if (status == PSA_SUCCESS) {
-        ASSERT_COMPARE(data->x + offset, (size_t) length_arg,
+        TEST_BUFFERS_EQUAL(data->x + offset, (size_t) length_arg,
                        buffer, ret_len);
     }
     for (i = 0; i < 16; i++) {

--- a/tests/suites/test_suite_psa_its.function
+++ b/tests/suites/test_suite_psa_its.function
@@ -92,7 +92,7 @@ void set_get_remove(int uid_arg, int flags_arg, data_t *data)
     unsigned char *buffer = NULL;
     size_t ret_len = 0;
 
-    TEST_CALLOC_OR_FAIL(buffer, data->len);
+    TEST_CALLOC(buffer, data->len);
 
     PSA_ASSERT(psa_its_set_wrap(uid, data->len, data->x, flags));
 
@@ -122,7 +122,7 @@ void set_overwrite(int uid_arg,
     unsigned char *buffer = NULL;
     size_t ret_len = 0;
 
-    TEST_CALLOC_OR_FAIL(buffer, MAX(data1->len, data2->len));
+    TEST_CALLOC(buffer, MAX(data1->len, data2->len));
 
     PSA_ASSERT(psa_its_set_wrap(uid, data1->len, data1->x, flags1));
     PSA_ASSERT(psa_its_get_info(uid, &info));
@@ -214,7 +214,7 @@ void get_at(int uid_arg, data_t *data,
     size_t i;
     size_t ret_len = 0;
 
-    TEST_CALLOC_OR_FAIL(buffer, length + 16);
+    TEST_CALLOC(buffer, length + 16);
     trailer = buffer + length;
     memset(trailer, '-', 16);
 

--- a/tests/suites/test_suite_random.function
+++ b/tests/suites/test_suite_random.function
@@ -163,7 +163,7 @@ void mbedtls_psa_get_random_length(int n)
     unsigned char *output = NULL;
 
     PSA_ASSERT(psa_crypto_init());
-    TEST_CALLOC_OR_FAIL(output, n);
+    TEST_CALLOC(output, n);
 
     TEST_EQUAL(0, mbedtls_psa_get_random(MBEDTLS_PSA_RANDOM_STATE,
                                          output, n));

--- a/tests/suites/test_suite_random.function
+++ b/tests/suites/test_suite_random.function
@@ -163,7 +163,7 @@ void mbedtls_psa_get_random_length(int n)
     unsigned char *output = NULL;
 
     PSA_ASSERT(psa_crypto_init());
-    ASSERT_ALLOC(output, n);
+    TEST_CALLOC_OR_FAIL(output, n);
 
     TEST_EQUAL(0, mbedtls_psa_get_random(MBEDTLS_PSA_RANDOM_STATE,
                                          output, n));

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -1689,7 +1689,7 @@ void ssl_tls1_3_hkdf_expand_label(int hash_alg,
                     ctx->x, ctx->len,
                     dst, desired_length) == 0);
 
-    ASSERT_COMPARE(dst, (size_t) desired_length,
+    TEST_BUFFERS_EQUAL(dst, (size_t) desired_length,
                    expected->x, (size_t) expected->len);
 }
 /* END_CASE */
@@ -1724,19 +1724,19 @@ void ssl_tls1_3_traffic_key_generation(int hash_alg,
                     desired_key_len, desired_iv_len,
                     &keys) == 0);
 
-    ASSERT_COMPARE(keys.client_write_key,
+    TEST_BUFFERS_EQUAL(keys.client_write_key,
                    keys.key_len,
                    expected_client_write_key->x,
                    (size_t) desired_key_len);
-    ASSERT_COMPARE(keys.server_write_key,
+    TEST_BUFFERS_EQUAL(keys.server_write_key,
                    keys.key_len,
                    expected_server_write_key->x,
                    (size_t) desired_key_len);
-    ASSERT_COMPARE(keys.client_write_iv,
+    TEST_BUFFERS_EQUAL(keys.client_write_iv,
                    keys.iv_len,
                    expected_client_write_iv->x,
                    (size_t) desired_iv_len);
-    ASSERT_COMPARE(keys.server_write_iv,
+    TEST_BUFFERS_EQUAL(keys.server_write_iv,
                    keys.iv_len,
                    expected_server_write_iv->x,
                    (size_t) desired_iv_len);
@@ -1778,7 +1778,7 @@ void ssl_tls1_3_derive_secret(int hash_alg,
                     already_hashed,
                     dst, desired_length) == 0);
 
-    ASSERT_COMPARE(dst, desired_length,
+    TEST_BUFFERS_EQUAL(dst, desired_length,
                    expected->x, desired_length);
 }
 /* END_CASE */
@@ -1797,7 +1797,7 @@ void ssl_tls1_3_key_evolution(int hash_alg,
                     input->len ? input->x : NULL, input->len,
                     secret_new) == 0);
 
-    ASSERT_COMPARE(secret_new, (size_t) expected->len,
+    TEST_BUFFERS_EQUAL(secret_new, (size_t) expected->len,
                    expected->x, (size_t) expected->len);
 }
 /* END_CASE */

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -1689,7 +1689,7 @@ void ssl_tls1_3_hkdf_expand_label(int hash_alg,
                     ctx->x, ctx->len,
                     dst, desired_length) == 0);
 
-    TEST_BUFFERS_EQUAL(dst, (size_t) desired_length,
+    TEST_MEMORY_COMPARE(dst, (size_t) desired_length,
                    expected->x, (size_t) expected->len);
 }
 /* END_CASE */
@@ -1724,19 +1724,19 @@ void ssl_tls1_3_traffic_key_generation(int hash_alg,
                     desired_key_len, desired_iv_len,
                     &keys) == 0);
 
-    TEST_BUFFERS_EQUAL(keys.client_write_key,
+    TEST_MEMORY_COMPARE(keys.client_write_key,
                    keys.key_len,
                    expected_client_write_key->x,
                    (size_t) desired_key_len);
-    TEST_BUFFERS_EQUAL(keys.server_write_key,
+    TEST_MEMORY_COMPARE(keys.server_write_key,
                    keys.key_len,
                    expected_server_write_key->x,
                    (size_t) desired_key_len);
-    TEST_BUFFERS_EQUAL(keys.client_write_iv,
+    TEST_MEMORY_COMPARE(keys.client_write_iv,
                    keys.iv_len,
                    expected_client_write_iv->x,
                    (size_t) desired_iv_len);
-    TEST_BUFFERS_EQUAL(keys.server_write_iv,
+    TEST_MEMORY_COMPARE(keys.server_write_iv,
                    keys.iv_len,
                    expected_server_write_iv->x,
                    (size_t) desired_iv_len);
@@ -1778,7 +1778,7 @@ void ssl_tls1_3_derive_secret(int hash_alg,
                     already_hashed,
                     dst, desired_length) == 0);
 
-    TEST_BUFFERS_EQUAL(dst, desired_length,
+    TEST_MEMORY_COMPARE(dst, desired_length,
                    expected->x, desired_length);
 }
 /* END_CASE */
@@ -1797,7 +1797,7 @@ void ssl_tls1_3_key_evolution(int hash_alg,
                     input->len ? input->x : NULL, input->len,
                     secret_new) == 0);
 
-    TEST_BUFFERS_EQUAL(secret_new, (size_t) expected->len,
+    TEST_MEMORY_COMPARE(secret_new, (size_t) expected->len,
                    expected->x, (size_t) expected->len);
 }
 /* END_CASE */

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -1690,7 +1690,7 @@ void ssl_tls1_3_hkdf_expand_label(int hash_alg,
                     dst, desired_length) == 0);
 
     TEST_MEMORY_COMPARE(dst, (size_t) desired_length,
-                   expected->x, (size_t) expected->len);
+                        expected->x, (size_t) expected->len);
 }
 /* END_CASE */
 
@@ -1725,21 +1725,21 @@ void ssl_tls1_3_traffic_key_generation(int hash_alg,
                     &keys) == 0);
 
     TEST_MEMORY_COMPARE(keys.client_write_key,
-                   keys.key_len,
-                   expected_client_write_key->x,
-                   (size_t) desired_key_len);
+                        keys.key_len,
+                        expected_client_write_key->x,
+                        (size_t) desired_key_len);
     TEST_MEMORY_COMPARE(keys.server_write_key,
-                   keys.key_len,
-                   expected_server_write_key->x,
-                   (size_t) desired_key_len);
+                        keys.key_len,
+                        expected_server_write_key->x,
+                        (size_t) desired_key_len);
     TEST_MEMORY_COMPARE(keys.client_write_iv,
-                   keys.iv_len,
-                   expected_client_write_iv->x,
-                   (size_t) desired_iv_len);
+                        keys.iv_len,
+                        expected_client_write_iv->x,
+                        (size_t) desired_iv_len);
     TEST_MEMORY_COMPARE(keys.server_write_iv,
-                   keys.iv_len,
-                   expected_server_write_iv->x,
-                   (size_t) desired_iv_len);
+                        keys.iv_len,
+                        expected_server_write_iv->x,
+                        (size_t) desired_iv_len);
 }
 /* END_CASE */
 
@@ -1779,7 +1779,7 @@ void ssl_tls1_3_derive_secret(int hash_alg,
                     dst, desired_length) == 0);
 
     TEST_MEMORY_COMPARE(dst, desired_length,
-                   expected->x, desired_length);
+                        expected->x, desired_length);
 }
 /* END_CASE */
 
@@ -1798,7 +1798,7 @@ void ssl_tls1_3_key_evolution(int hash_alg,
                     secret_new) == 0);
 
     TEST_MEMORY_COMPARE(secret_new, (size_t) expected->len,
-                   expected->x, (size_t) expected->len);
+                        expected->x, (size_t) expected->len);
 }
 /* END_CASE */
 

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -147,7 +147,7 @@ void test_callback_buffer(int size, int put1, int put1_ret,
     if (input_len == 0) {
         input_len = 1;
     }
-    TEST_CALLOC_OR_FAIL(input, input_len);
+    TEST_CALLOC(input, input_len);
 
     output_len = 0;
     for (j = 0; j < ROUNDS; j++) {
@@ -161,7 +161,7 @@ void test_callback_buffer(int size, int put1, int put1_ret,
     if (output_len == 0) {
         output_len = 1;
     }
-    TEST_CALLOC_OR_FAIL(output, output_len);
+    TEST_CALLOC(output, output_len);
 
     /* Fill up the buffer with structured data so that unwanted changes
      * can be detected */
@@ -1516,8 +1516,8 @@ void ssl_decrypt_non_etm_cbc(int cipher_type, int hash_id, int trunc_hmac,
              + plaintext_len
              + t0.maclen
              + padlen + 1;
-    TEST_CALLOC_OR_FAIL(buf, buflen);
-    TEST_CALLOC_OR_FAIL(buf_save, buflen);
+    TEST_CALLOC(buf, buflen);
+    TEST_CALLOC(buf_save, buflen);
 
     /* Prepare a dummy record header */
     memset(rec.ctr, 0, sizeof(rec.ctr));

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -147,7 +147,7 @@ void test_callback_buffer(int size, int put1, int put1_ret,
     if (input_len == 0) {
         input_len = 1;
     }
-    ASSERT_ALLOC(input, input_len);
+    TEST_CALLOC_OR_FAIL(input, input_len);
 
     output_len = 0;
     for (j = 0; j < ROUNDS; j++) {
@@ -161,7 +161,7 @@ void test_callback_buffer(int size, int put1, int put1_ret,
     if (output_len == 0) {
         output_len = 1;
     }
-    ASSERT_ALLOC(output, output_len);
+    TEST_CALLOC_OR_FAIL(output, output_len);
 
     /* Fill up the buffer with structured data so that unwanted changes
      * can be detected */
@@ -1516,8 +1516,8 @@ void ssl_decrypt_non_etm_cbc(int cipher_type, int hash_id, int trunc_hmac,
              + plaintext_len
              + t0.maclen
              + padlen + 1;
-    ASSERT_ALLOC(buf, buflen);
-    ASSERT_ALLOC(buf_save, buflen);
+    TEST_CALLOC_OR_FAIL(buf, buflen);
+    TEST_CALLOC_OR_FAIL(buf_save, buflen);
 
     /* Prepare a dummy record header */
     memset(rec.ctr, 0, sizeof(rec.ctr));


### PR DESCRIPTION
## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required as internal to tests
- [x] **backport** this is the backport of #6253
- [x] **tests** these are changes to the test framework
