### PR TITLE
Fix clang warnings about unreachable code

### DIFF
--- a/include/mbedtls/bignum.h
+++ b/include/mbedtls/bignum.h
@@ -186,6 +186,15 @@ typedef uint64_t mbedtls_t_udbl;
     #endif /* !MBEDTLS_NO_UDBL_DIVISION */
 #endif /* !MBEDTLS_HAVE_INT64 */
 
+/*
+ * Sanity check that exactly one of MBEDTLS_HAVE_INT32 or MBEDTLS_HAVE_INT64 is defined,
+ * so that code elsewhere doesn't have to check.
+ */
+#if (!(defined(MBEDTLS_HAVE_INT32) || defined(MBEDTLS_HAVE_INT64))) || \
+    (defined(MBEDTLS_HAVE_INT32) && defined(MBEDTLS_HAVE_INT64))
+#error "Only 32-bit or 64-bit limbs are supported in bignum"
+#endif
+
 /** \typedef mbedtls_mpi_uint
  * \brief The type of machine digits in a bignum, called _limbs_.
  *

--- a/library/bignum_core.c
+++ b/library/bignum_core.c
@@ -77,40 +77,19 @@ size_t mbedtls_mpi_core_bitlen(const mbedtls_mpi_uint *A, size_t A_limbs)
     return 0;
 }
 
-/* Convert a big-endian byte array aligned to the size of mbedtls_mpi_uint
- * into the storage form used by mbedtls_mpi. */
-static mbedtls_mpi_uint mpi_bigendian_to_host_c(mbedtls_mpi_uint a)
-{
-    uint8_t i;
-    unsigned char *a_ptr;
-    mbedtls_mpi_uint tmp = 0;
-
-    for (i = 0, a_ptr = (unsigned char *) &a; i < ciL; i++, a_ptr++) {
-        tmp <<= CHAR_BIT;
-        tmp |= (mbedtls_mpi_uint) *a_ptr;
-    }
-
-    return tmp;
-}
-
 static mbedtls_mpi_uint mpi_bigendian_to_host(mbedtls_mpi_uint a)
 {
     if (MBEDTLS_IS_BIG_ENDIAN) {
         /* Nothing to do on bigendian systems. */
         return a;
     } else {
-MBEDTLS_IGNORE_UNREACHABLE_BEGIN
-        switch (sizeof(mbedtls_mpi_uint)) {
-            case 4:
-                return (mbedtls_mpi_uint) MBEDTLS_BSWAP32((uint32_t) a);
-            case 8:
-                return (mbedtls_mpi_uint) MBEDTLS_BSWAP64((uint64_t) a);
-        }
-
-        /* Fall back to C-based reordering if we don't know the byte order
-         * or we couldn't use a compiler-specific builtin. */
-        return mpi_bigendian_to_host_c(a);
-MBEDTLS_IGNORE_UNREACHABLE_END
+#if defined(MBEDTLS_HAVE_INT32)
+        return (mbedtls_mpi_uint) MBEDTLS_BSWAP32((uint32_t) a);
+#elif defined(MBEDTLS_HAVE_INT64)
+        return (mbedtls_mpi_uint) MBEDTLS_BSWAP64((uint64_t) a);
+#else
+#error "This is one of several places that need to be adapted to support a new limb size"
+#endif
     }
 }
 

--- a/library/bignum_core.c
+++ b/library/bignum_core.c
@@ -87,8 +87,6 @@ static mbedtls_mpi_uint mpi_bigendian_to_host(mbedtls_mpi_uint a)
         return (mbedtls_mpi_uint) MBEDTLS_BSWAP32(a);
 #elif defined(MBEDTLS_HAVE_INT64)
         return (mbedtls_mpi_uint) MBEDTLS_BSWAP64(a);
-#else
-#error "This is one of several places that need to be adapted to support a new limb size"
 #endif
     }
 }

--- a/library/bignum_core.c
+++ b/library/bignum_core.c
@@ -84,9 +84,9 @@ static mbedtls_mpi_uint mpi_bigendian_to_host(mbedtls_mpi_uint a)
         return a;
     } else {
 #if defined(MBEDTLS_HAVE_INT32)
-        return (mbedtls_mpi_uint) MBEDTLS_BSWAP32((uint32_t) a);
+        return (mbedtls_mpi_uint) MBEDTLS_BSWAP32(a);
 #elif defined(MBEDTLS_HAVE_INT64)
-        return (mbedtls_mpi_uint) MBEDTLS_BSWAP64((uint64_t) a);
+        return (mbedtls_mpi_uint) MBEDTLS_BSWAP64(a);
 #else
 #error "This is one of several places that need to be adapted to support a new limb size"
 #endif

--- a/library/bignum_core.c
+++ b/library/bignum_core.c
@@ -99,6 +99,7 @@ static mbedtls_mpi_uint mpi_bigendian_to_host(mbedtls_mpi_uint a)
         /* Nothing to do on bigendian systems. */
         return a;
     } else {
+MBEDTLS_IGNORE_UNREACHABLE_BEGIN
         switch (sizeof(mbedtls_mpi_uint)) {
             case 4:
                 return (mbedtls_mpi_uint) MBEDTLS_BSWAP32((uint32_t) a);
@@ -109,6 +110,7 @@ static mbedtls_mpi_uint mpi_bigendian_to_host(mbedtls_mpi_uint a)
         /* Fall back to C-based reordering if we don't know the byte order
          * or we couldn't use a compiler-specific builtin. */
         return mpi_bigendian_to_host_c(a);
+MBEDTLS_IGNORE_UNREACHABLE_END
     }
 }
 

--- a/library/common.h
+++ b/library/common.h
@@ -334,23 +334,4 @@ static inline void mbedtls_xor_no_simd(unsigned char *r,
 #define MBEDTLS_OPTIMIZE_FOR_PERFORMANCE
 #endif
 
-/* Define macros that can be used to disable warnings about unreachable code. */
-#if defined(__clang__)
-
-#define MBEDTLS_PRAGMA(x) _Pragma(#x)
-
-#define MBEDTLS_IGNORE_UNREACHABLE_BEGIN \
-    MBEDTLS_PRAGMA(clang diagnostic push) \
-    MBEDTLS_PRAGMA(clang diagnostic ignored "-Wunreachable-code")
-
-#define MBEDTLS_IGNORE_UNREACHABLE_END \
-    MBEDTLS_PRAGMA(clang diagnostic pop)
-
-#else
-
-#define MBEDTLS_IGNORE_UNREACHABLE_BEGIN
-#define MBEDTLS_IGNORE_UNREACHABLE_END
-
-#endif
-
 #endif /* MBEDTLS_LIBRARY_COMMON_H */

--- a/library/common.h
+++ b/library/common.h
@@ -334,4 +334,23 @@ static inline void mbedtls_xor_no_simd(unsigned char *r,
 #define MBEDTLS_OPTIMIZE_FOR_PERFORMANCE
 #endif
 
+/* Define macros that can be used to disable warnings about unreachable code. */
+#if defined(__clang__)
+
+#define MBEDTLS_PRAGMA(x) _Pragma(#x)
+
+#define MBEDTLS_IGNORE_UNREACHABLE_BEGIN \
+    MBEDTLS_PRAGMA(clang diagnostic push) \
+    MBEDTLS_PRAGMA(clang diagnostic ignored "-Wunreachable-code")
+
+#define MBEDTLS_IGNORE_UNREACHABLE_END \
+    MBEDTLS_PRAGMA(clang diagnostic pop)
+
+#else
+
+#define MBEDTLS_IGNORE_UNREACHABLE_BEGIN
+#define MBEDTLS_IGNORE_UNREACHABLE_END
+
+#endif
+
 #endif /* MBEDTLS_LIBRARY_COMMON_H */

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -2754,8 +2754,8 @@ static int x509_inet_pton_ipv6(const char *src, void *dst)
             p++;
         }
         if (num_digits != 0) {
-            addr[nonzero_groups++] = MBEDTLS_IS_BIG_ENDIAN ? group :
-                                     (group << 8) | (group >> 8);
+            MBEDTLS_PUT_UINT16_BE(group, addr, nonzero_groups);
+            nonzero_groups++;
             if (*p == '\0') {
                 break;
             } else if (*p == '.') {


### PR DESCRIPTION
## Description

Ensure we compile cleanly under clang with `-Wunreachable-code`. Under gcc, this warning has no effect (see https://gcc.gnu.org/legacy-ml/gcc-help/2011-05/msg00360.html ).

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required - minor code hygiene improvement
- [x] **backport** not required - as above
- [x] **tests** not required - as above
