### PR TITLE
Backport 2.28: pkwrite: use heap to save stack usage for writing keys in PEM string

### DIFF
--- a/ChangeLog.d/pkwrite-pem-use-heap.txt
+++ b/ChangeLog.d/pkwrite-pem-use-heap.txt
@@ -1,4 +1,4 @@
 Changes
-   * Use heap memory to allocate DER encoded RSA public/private key.
+   * Use heap memory to allocate DER encoded public/private key.
      This reduces stack usage significantly for writing a public/private
      key to a PEM string.

--- a/ChangeLog.d/pkwrite-pem-use-heap.txt
+++ b/ChangeLog.d/pkwrite-pem-use-heap.txt
@@ -1,0 +1,4 @@
+Changes
+   * Use heap memory to allocate DER encoded RSA public/private key.
+     This reduces stack usage significantly for writing a public/private
+     key to a PEM string.

--- a/library/pkwrite.c
+++ b/library/pkwrite.c
@@ -583,19 +583,19 @@ int mbedtls_pk_write_pubkey_pem(mbedtls_pk_context *key, unsigned char *buf, siz
 
     if ((ret = mbedtls_pk_write_pubkey_der(key, output_buf,
                                            PUB_DER_MAX_BYTES)) < 0) {
-        free(output_buf);
-        return ret;
+        goto cleanup;
     }
 
     if ((ret = mbedtls_pem_write_buffer(PEM_BEGIN_PUBLIC_KEY, PEM_END_PUBLIC_KEY,
                                         output_buf + PUB_DER_MAX_BYTES - ret,
                                         ret, buf, size, &olen)) != 0) {
-        free(output_buf);
-        return ret;
+        goto cleanup;
     }
 
+    ret = 0;
+cleanup:
     free(output_buf);
-    return 0;
+    return ret;
 }
 
 int mbedtls_pk_write_key_pem(mbedtls_pk_context *key, unsigned char *buf, size_t size)
@@ -613,8 +613,7 @@ int mbedtls_pk_write_key_pem(mbedtls_pk_context *key, unsigned char *buf, size_t
     PK_VALIDATE_RET(buf != NULL || size == 0);
 
     if ((ret = mbedtls_pk_write_key_der(key, output_buf, PRV_DER_MAX_BYTES)) < 0) {
-        free(output_buf);
-        return ret;
+        goto cleanup;
     }
 
 #if defined(MBEDTLS_RSA_C)
@@ -630,19 +629,20 @@ int mbedtls_pk_write_key_pem(mbedtls_pk_context *key, unsigned char *buf, size_t
     } else
 #endif
     {
-        free(output_buf);
-        return MBEDTLS_ERR_PK_FEATURE_UNAVAILABLE;
+        ret = MBEDTLS_ERR_PK_FEATURE_UNAVAILABLE;
+        goto cleanup;
     }
 
     if ((ret = mbedtls_pem_write_buffer(begin, end,
                                         output_buf + PRV_DER_MAX_BYTES - ret,
                                         ret, buf, size, &olen)) != 0) {
-        free(output_buf);
-        return ret;
+        goto cleanup;
     }
 
+    ret = 0;
+cleanup:
     free(output_buf);
-    return 0;
+    return ret;
 }
 #endif /* MBEDTLS_PEM_WRITE_C */
 

--- a/library/pkwrite.c
+++ b/library/pkwrite.c
@@ -571,23 +571,30 @@ end_of_export:
 int mbedtls_pk_write_pubkey_pem(mbedtls_pk_context *key, unsigned char *buf, size_t size)
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
-    unsigned char output_buf[PUB_DER_MAX_BYTES];
+    unsigned char *output_buf = NULL;
+    output_buf = calloc(1, PUB_DER_MAX_BYTES);
+    if (output_buf == NULL) {
+        return MBEDTLS_ERR_PK_ALLOC_FAILED;
+    }
     size_t olen = 0;
 
     PK_VALIDATE_RET(key != NULL);
     PK_VALIDATE_RET(buf != NULL || size == 0);
 
     if ((ret = mbedtls_pk_write_pubkey_der(key, output_buf,
-                                           sizeof(output_buf))) < 0) {
+                                           PUB_DER_MAX_BYTES)) < 0) {
+        free(output_buf);
         return ret;
     }
 
     if ((ret = mbedtls_pem_write_buffer(PEM_BEGIN_PUBLIC_KEY, PEM_END_PUBLIC_KEY,
-                                        output_buf + sizeof(output_buf) - ret,
+                                        output_buf + PUB_DER_MAX_BYTES - ret,
                                         ret, buf, size, &olen)) != 0) {
+        free(output_buf);
         return ret;
     }
 
+    free(output_buf);
     return 0;
 }
 

--- a/library/pkwrite.c
+++ b/library/pkwrite.c
@@ -572,7 +572,7 @@ int mbedtls_pk_write_pubkey_pem(mbedtls_pk_context *key, unsigned char *buf, siz
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     unsigned char *output_buf = NULL;
-    output_buf = calloc(1, PUB_DER_MAX_BYTES);
+    output_buf = mbedtls_calloc(1, PUB_DER_MAX_BYTES);
     if (output_buf == NULL) {
         return MBEDTLS_ERR_PK_ALLOC_FAILED;
     }
@@ -594,7 +594,7 @@ int mbedtls_pk_write_pubkey_pem(mbedtls_pk_context *key, unsigned char *buf, siz
 
     ret = 0;
 cleanup:
-    free(output_buf);
+    mbedtls_free(output_buf);
     return ret;
 }
 
@@ -602,7 +602,7 @@ int mbedtls_pk_write_key_pem(mbedtls_pk_context *key, unsigned char *buf, size_t
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     unsigned char *output_buf = NULL;
-    output_buf = calloc(1, PRV_DER_MAX_BYTES);
+    output_buf = mbedtls_calloc(1, PRV_DER_MAX_BYTES);
     if (output_buf == NULL) {
         return MBEDTLS_ERR_PK_ALLOC_FAILED;
     }
@@ -641,7 +641,7 @@ int mbedtls_pk_write_key_pem(mbedtls_pk_context *key, unsigned char *buf, size_t
 
     ret = 0;
 cleanup:
-    free(output_buf);
+    mbedtls_free(output_buf);
     return ret;
 }
 #endif /* MBEDTLS_PEM_WRITE_C */

--- a/library/pkwrite.c
+++ b/library/pkwrite.c
@@ -601,14 +601,19 @@ int mbedtls_pk_write_pubkey_pem(mbedtls_pk_context *key, unsigned char *buf, siz
 int mbedtls_pk_write_key_pem(mbedtls_pk_context *key, unsigned char *buf, size_t size)
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
-    unsigned char output_buf[PRV_DER_MAX_BYTES];
+    unsigned char *output_buf = NULL;
+    output_buf = calloc(1, PRV_DER_MAX_BYTES);
+    if (output_buf == NULL) {
+        return MBEDTLS_ERR_PK_ALLOC_FAILED;
+    }
     const char *begin, *end;
     size_t olen = 0;
 
     PK_VALIDATE_RET(key != NULL);
     PK_VALIDATE_RET(buf != NULL || size == 0);
 
-    if ((ret = mbedtls_pk_write_key_der(key, output_buf, sizeof(output_buf))) < 0) {
+    if ((ret = mbedtls_pk_write_key_der(key, output_buf, PRV_DER_MAX_BYTES)) < 0) {
+        free(output_buf);
         return ret;
     }
 
@@ -624,14 +629,19 @@ int mbedtls_pk_write_key_pem(mbedtls_pk_context *key, unsigned char *buf, size_t
         end = PEM_END_PRIVATE_KEY_EC;
     } else
 #endif
-    return MBEDTLS_ERR_PK_FEATURE_UNAVAILABLE;
+    {
+        free(output_buf);
+        return MBEDTLS_ERR_PK_FEATURE_UNAVAILABLE;
+    }
 
     if ((ret = mbedtls_pem_write_buffer(begin, end,
-                                        output_buf + sizeof(output_buf) - ret,
+                                        output_buf + PRV_DER_MAX_BYTES - ret,
                                         ret, buf, size, &olen)) != 0) {
+        free(output_buf);
         return ret;
     }
 
+    free(output_buf);
     return 0;
 }
 #endif /* MBEDTLS_PEM_WRITE_C */

--- a/library/pkwrite.c
+++ b/library/pkwrite.c
@@ -641,6 +641,7 @@ int mbedtls_pk_write_key_pem(mbedtls_pk_context *key, unsigned char *buf, size_t
 
     ret = 0;
 cleanup:
+    mbedtls_platform_zeroize(output_buf, PRV_DER_MAX_BYTES);
     mbedtls_free(output_buf);
     return ret;
 }


### PR DESCRIPTION
## Description

backport of #8062 

Similar to #7991 , in `mbedtls_pk_write_pubkey_pem` and `mbedtls_pk_write_key_pem`, we would allocate `2086` and `5679` respectively for a RSA public/private key. We can use heap to save stack usage a lot.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** provided
- [x] **backport** of https://github.com/Mbed-TLS/mbedtls/pull/8062
- [x] **tests** not required