### PR TITLE
Fix query_config.c generation with CMake build system

### DIFF
--- a/programs/test/CMakeLists.txt
+++ b/programs/test/CMakeLists.txt
@@ -45,11 +45,13 @@ if(GEN_FILES)
             ${PERL}
                 ${CMAKE_CURRENT_SOURCE_DIR}/../../scripts/generate_query_config.pl
                 ${CMAKE_CURRENT_SOURCE_DIR}/../../include/mbedtls/mbedtls_config.h
+                ${CMAKE_CURRENT_SOURCE_DIR}/../../include/psa/crypto_config.h
                 ${CMAKE_CURRENT_SOURCE_DIR}/../../scripts/data_files/query_config.fmt
                 ${CMAKE_CURRENT_BINARY_DIR}/query_config.c
         DEPENDS
             ${CMAKE_CURRENT_SOURCE_DIR}/../../scripts/generate_query_config.pl
             ${CMAKE_CURRENT_SOURCE_DIR}/../../include/mbedtls/mbedtls_config.h
+            ${CMAKE_CURRENT_SOURCE_DIR}/../../include/psa/crypto_config.h
             ${CMAKE_CURRENT_SOURCE_DIR}/../../scripts/data_files/query_config.fmt
     )
     # this file will also be used in another directory, so create a target, see

--- a/scripts/generate_query_config.pl
+++ b/scripts/generate_query_config.pl
@@ -43,7 +43,7 @@ my $default_query_config_format_file = "./scripts/data_files/query_config.fmt";
 my $default_query_config_file = "./programs/test/query_config.c";
 
 if( @ARGV ) {
-    die "Invalid number of arguments - usage: $0 [CONFIG_FILE TEMPLATE_FILE OUTPUT_FILE]" if scalar @ARGV != 4;
+    die "Invalid number of arguments - usage: $0 [MBED_TLS_CONFIG_FILE PSA_CRYPTO_CONFIG_FILE TEMPLATE_FILE OUTPUT_FILE]" if scalar @ARGV != 4;
     ($mbedtls_config_file, $psa_crypto_config_file, $query_config_format_file, $query_config_file) = @ARGV;
 
     -f $mbedtls_config_file or die "No such file: $mbedtls_config_file";

--- a/scripts/generate_query_config.pl
+++ b/scripts/generate_query_config.pl
@@ -7,15 +7,16 @@
 # form (if any). This facilitates querying the compile time configuration of
 # the library, for example, for testing.
 #
-# The query_config.c is generated from the current configuration at
-# include/mbedtls/mbedtls_config.h. The idea is that the mbedtls_config.h contains ALL the
+# The query_config.c is generated from the default configuration files
+# include/mbedtls/mbedtls_config.h and include/psa/crypto_config.h.
+# The idea is that mbedtls_config.h and crypto_config.h contain ALL the
 # compile time configurations available in Mbed TLS (commented or uncommented).
-# This script extracts the configuration macros from the mbedtls_config.h and this
+# This script extracts the configuration macros from the two files and this
 # information is used to automatically generate the body of the query_config()
 # function by using the template in scripts/data_files/query_config.fmt.
 #
 # Usage: scripts/generate_query_config.pl without arguments, or
-# generate_query_config.pl mbedtls_config_file template_file output_file [psa_crypto_config_file]
+# generate_query_config.pl mbedtls_config_file psa_crypto_config_file template_file output_file
 #
 # Copyright The Mbed TLS Contributors
 # SPDX-License-Identifier: Apache-2.0
@@ -34,29 +35,25 @@
 
 use strict;
 
-my ($mbedtls_config_file, $query_config_format_file, $query_config_file, $psa_crypto_config_file);
+my ($mbedtls_config_file, $psa_crypto_config_file, $query_config_format_file, $query_config_file);
 
 my $default_mbedtls_config_file = "./include/mbedtls/mbedtls_config.h";
+my $default_psa_crypto_config_file = "./include/psa/crypto_config.h";
 my $default_query_config_format_file = "./scripts/data_files/query_config.fmt";
 my $default_query_config_file = "./programs/test/query_config.c";
-my $default_psa_crypto_config_file = "./include/psa/crypto_config.h";
 
 if( @ARGV ) {
-    die "Invalid number of arguments - usage: $0 [CONFIG_FILE TEMPLATE_FILE OUTPUT_FILE]" if scalar @ARGV != 3;
-    ($mbedtls_config_file, $query_config_format_file, $query_config_file) = @ARGV;
+    die "Invalid number of arguments - usage: $0 [CONFIG_FILE TEMPLATE_FILE OUTPUT_FILE]" if scalar @ARGV != 4;
+    ($mbedtls_config_file, $psa_crypto_config_file, $query_config_format_file, $query_config_file) = @ARGV;
 
     -f $mbedtls_config_file or die "No such file: $mbedtls_config_file";
+    -f $psa_crypto_config_file or die "No such file: $psa_crypto_config_file";
     -f $query_config_format_file or die "No such file: $query_config_format_file";
-    if (defined($psa_crypto_config_file) && length($psa_crypto_config_file)) {
-        -f $psa_crypto_config_file or die "No such file: $psa_crypto_config_file";
-    } else {
-        $psa_crypto_config_file = (-f $default_psa_crypto_config_file) ? $default_psa_crypto_config_file : undef;
-    }
 } else {
     $mbedtls_config_file = $default_mbedtls_config_file;
+    $psa_crypto_config_file = $default_psa_crypto_config_file;
     $query_config_format_file = $default_query_config_format_file;
     $query_config_file = $default_query_config_file;
-    $psa_crypto_config_file = $default_psa_crypto_config_file;
 
     unless(-f $mbedtls_config_file && -f $query_config_format_file  && -f $psa_crypto_config_file) {
         chdir '..' or die;


### PR DESCRIPTION
## Description
In case of an out-of-tree build with the CMake build system the path to crypto_config.h has to be defined as the path to mbedtls_config.h is. Add this possibility to generate_query_config.pl.

I came across that while investigating on the test framework. 

## PR checklist
- [x] **changelog** no, fixes a test functionality.
- [x] **backport** no, no support for crypto_config.h in generate_query_config.pl in 2.28.
- [x] **tests** no, fixes a test functionality.