### PR TITLE
Remove always-false null pointer check in sha3.c that Coverity complains about

### DIFF
--- a/library/sha3.c
+++ b/library/sha3.c
@@ -200,7 +200,7 @@ int mbedtls_sha3_starts(mbedtls_sha3_context *ctx, mbedtls_sha3_id id)
         }
     }
 
-    if (p == NULL || p->id == MBEDTLS_SHA3_NONE) {
+    if (p->id == MBEDTLS_SHA3_NONE) {
         return MBEDTLS_ERR_SHA3_BAD_INPUT_DATA;
     }
 


### PR DESCRIPTION
`p` can't be `NULL`

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [ ] **changelog** not required, internal change only
- [ ] **backport** not required, sha3 is `development` only
- [ ] **tests** not required, this test was always-false
