### PR TITLE
Ensure all md_<hash>_finish functions perform zeroization

### DIFF
--- a/library/md5.c
+++ b/library/md5.c
@@ -286,7 +286,7 @@ int mbedtls_md5_finish(mbedtls_md5_context *ctx,
         memset(ctx->buffer + used, 0, 64 - used);
 
         if ((ret = mbedtls_internal_md5_process(ctx, ctx->buffer)) != 0) {
-            return ret;
+            goto exit;
         }
 
         memset(ctx->buffer, 0, 56);
@@ -303,7 +303,7 @@ int mbedtls_md5_finish(mbedtls_md5_context *ctx,
     MBEDTLS_PUT_UINT32_LE(high, ctx->buffer, 60);
 
     if ((ret = mbedtls_internal_md5_process(ctx, ctx->buffer)) != 0) {
-        return ret;
+        goto exit;
     }
 
     /*
@@ -314,7 +314,11 @@ int mbedtls_md5_finish(mbedtls_md5_context *ctx,
     MBEDTLS_PUT_UINT32_LE(ctx->state[2], output,  8);
     MBEDTLS_PUT_UINT32_LE(ctx->state[3], output, 12);
 
-    return 0;
+    ret = 0;
+
+exit:
+    mbedtls_md5_free(ctx);
+    return ret;
 }
 
 #endif /* !MBEDTLS_MD5_ALT */

--- a/library/ripemd160.c
+++ b/library/ripemd160.c
@@ -356,12 +356,12 @@ int mbedtls_ripemd160_finish(mbedtls_ripemd160_context *ctx,
 
     ret = mbedtls_ripemd160_update(ctx, ripemd160_padding, padn);
     if (ret != 0) {
-        return ret;
+        goto exit;
     }
 
     ret = mbedtls_ripemd160_update(ctx, msglen, 8);
     if (ret != 0) {
-        return ret;
+        goto exit;
     }
 
     MBEDTLS_PUT_UINT32_LE(ctx->state[0], output,  0);
@@ -370,7 +370,11 @@ int mbedtls_ripemd160_finish(mbedtls_ripemd160_context *ctx,
     MBEDTLS_PUT_UINT32_LE(ctx->state[3], output, 12);
     MBEDTLS_PUT_UINT32_LE(ctx->state[4], output, 16);
 
-    return 0;
+    ret = 0;
+
+exit:
+    mbedtls_ripemd160_free(ctx);
+    return ret;
 }
 
 #endif /* ! MBEDTLS_RIPEMD160_ALT */

--- a/library/sha1.c
+++ b/library/sha1.c
@@ -322,7 +322,7 @@ int mbedtls_sha1_finish(mbedtls_sha1_context *ctx,
         memset(ctx->buffer + used, 0, 64 - used);
 
         if ((ret = mbedtls_internal_sha1_process(ctx, ctx->buffer)) != 0) {
-            return ret;
+            goto exit;
         }
 
         memset(ctx->buffer, 0, 56);
@@ -339,7 +339,7 @@ int mbedtls_sha1_finish(mbedtls_sha1_context *ctx,
     MBEDTLS_PUT_UINT32_BE(low,  ctx->buffer, 60);
 
     if ((ret = mbedtls_internal_sha1_process(ctx, ctx->buffer)) != 0) {
-        return ret;
+        goto exit;
     }
 
     /*
@@ -351,7 +351,11 @@ int mbedtls_sha1_finish(mbedtls_sha1_context *ctx,
     MBEDTLS_PUT_UINT32_BE(ctx->state[3], output, 12);
     MBEDTLS_PUT_UINT32_BE(ctx->state[4], output, 16);
 
-    return 0;
+    ret = 0;
+
+exit:
+    mbedtls_sha1_free(ctx);
+    return ret;
 }
 
 #endif /* !MBEDTLS_SHA1_ALT */
@@ -382,7 +386,6 @@ int mbedtls_sha1(const unsigned char *input,
 
 exit:
     mbedtls_sha1_free(&ctx);
-
     return ret;
 }
 

--- a/library/sha256.c
+++ b/library/sha256.c
@@ -697,7 +697,7 @@ int mbedtls_sha256_finish(mbedtls_sha256_context *ctx,
         memset(ctx->buffer + used, 0, SHA256_BLOCK_SIZE - used);
 
         if ((ret = mbedtls_internal_sha256_process(ctx, ctx->buffer)) != 0) {
-            return ret;
+            goto exit;
         }
 
         memset(ctx->buffer, 0, 56);
@@ -714,7 +714,7 @@ int mbedtls_sha256_finish(mbedtls_sha256_context *ctx,
     MBEDTLS_PUT_UINT32_BE(low,  ctx->buffer, 60);
 
     if ((ret = mbedtls_internal_sha256_process(ctx, ctx->buffer)) != 0) {
-        return ret;
+        goto exit;
     }
 
     /*
@@ -736,7 +736,11 @@ int mbedtls_sha256_finish(mbedtls_sha256_context *ctx,
         MBEDTLS_PUT_UINT32_BE(ctx->state[7], output, 28);
     }
 
-    return 0;
+    ret = 0;
+
+exit:
+    mbedtls_sha256_free(ctx);
+    return ret;
 }
 
 #endif /* !MBEDTLS_SHA256_ALT */

--- a/library/sha512.c
+++ b/library/sha512.c
@@ -844,7 +844,7 @@ int mbedtls_sha512_finish(mbedtls_sha512_context *ctx,
         memset(ctx->buffer + used, 0, SHA512_BLOCK_SIZE - used);
 
         if ((ret = mbedtls_internal_sha512_process(ctx, ctx->buffer)) != 0) {
-            return ret;
+            goto exit;
         }
 
         memset(ctx->buffer, 0, 112);
@@ -861,7 +861,7 @@ int mbedtls_sha512_finish(mbedtls_sha512_context *ctx,
     sha512_put_uint64_be(low,  ctx->buffer, 120);
 
     if ((ret = mbedtls_internal_sha512_process(ctx, ctx->buffer)) != 0) {
-        return ret;
+        goto exit;
     }
 
     /*
@@ -883,7 +883,11 @@ int mbedtls_sha512_finish(mbedtls_sha512_context *ctx,
         sha512_put_uint64_be(ctx->state[7], output, 56);
     }
 
-    return 0;
+    ret = 0;
+
+exit:
+    mbedtls_sha512_free(ctx);
+    return ret;
 }
 
 #endif /* !MBEDTLS_SHA512_ALT */


### PR DESCRIPTION
## Description

Ensure that all hash functions perform zeroization when finish is called.

- [x] **changelog** not required - not user visible
- [x] **backport** maybe todo?
- [x] **tests** covered by existing
