### PR TITLE
Change type of parameter for mbedtls_cipher_info_from_values

### DIFF
--- a/include/mbedtls/cipher.h
+++ b/include/mbedtls/cipher.h
@@ -433,9 +433,9 @@ const mbedtls_cipher_info_t *mbedtls_cipher_info_from_type(const mbedtls_cipher_
  *                      given \p cipher_id.
  * \return              \c NULL if the associated cipher information is not found.
  */
-const mbedtls_cipher_info_t *mbedtls_cipher_info_from_values(const mbedtls_cipher_id_t cipher_id,
-                                                             int key_bitlen,
-                                                             const mbedtls_cipher_mode_t mode);
+const mbedtls_cipher_info_t *mbedtls_cipher_info_from_values(const  mbedtls_cipher_id_t cipher_id,
+                                                             size_t key_bitlen,
+                                                             const  mbedtls_cipher_mode_t mode);
 
 /**
  * \brief               Retrieve the identifier for a cipher info structure.

--- a/library/cipher.c
+++ b/library/cipher.c
@@ -127,14 +127,14 @@ const mbedtls_cipher_info_t *mbedtls_cipher_info_from_string(
 
 const mbedtls_cipher_info_t *mbedtls_cipher_info_from_values(
     const mbedtls_cipher_id_t cipher_id,
-    int key_bitlen,
+    size_t key_bitlen,
     const mbedtls_cipher_mode_t mode)
 {
     const mbedtls_cipher_definition_t *def;
 
     for (def = mbedtls_cipher_definitions; def->info != NULL; def++) {
         if (mbedtls_cipher_get_base(def->info)->cipher == cipher_id &&
-            mbedtls_cipher_info_get_key_bitlen(def->info) == (unsigned) key_bitlen &&
+            mbedtls_cipher_info_get_key_bitlen(def->info) == key_bitlen &&
             def->info->mode == mode) {
             return def->info;
         }

--- a/library/psa_crypto_cipher.c
+++ b/library/psa_crypto_cipher.c
@@ -156,7 +156,7 @@ const mbedtls_cipher_info_t *mbedtls_cipher_info_from_psa(
     }
 
     return mbedtls_cipher_info_from_values(cipher_id_tmp,
-                                           (int) key_bits, mode);
+                                           key_bits, mode);
 }
 
 #if defined(MBEDTLS_PSA_BUILTIN_CIPHER)


### PR DESCRIPTION
## Description

I thought it would be a good idea to change key_bitlen 's type to size_t because it can not take negative values, so no negative value interval is needed. The other thing is that in this way the code is MISRA compliant, which is important because this library is use in many safety critical applications.



## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [ ] **changelog** provided, or not required
- [x] **backport** not required
- [x] **tests** not required
