### PR TITLE
Prevent potential use of uninitialised data in pkcs7 tests

### DIFF
--- a/tests/suites/test_suite_pkcs7.function
+++ b/tests/suites/test_suite_pkcs7.function
@@ -78,6 +78,8 @@ void pkcs7_verify(char *pkcs7_file,
 
     MD_OR_USE_PSA_INIT();
 
+    mbedtls_pkcs7_init(&pkcs7);
+
     /* crt_files are space seprated list */
     for (i = 0; i < strlen(crt_files); i++) {
         if (crt_files[i] == ' ') {
@@ -100,7 +102,6 @@ void pkcs7_verify(char *pkcs7_file,
         i = k;
     }
 
-    mbedtls_pkcs7_init(&pkcs7);
     for (i = 0; i < n_crts; i++) {
         TEST_CALLOC(crts[i], 1);
         mbedtls_x509_crt_init(crts[i]);


### PR DESCRIPTION
## Description

Move the initialisation of the pkcs7 object to before the first possible test failure, otherwise failure in those tests could result in an uninitialised pointer being free'd. Found by coverity.

## PR checklist

- [ ] **changelog** ~~provided, or~~ not required (tests only)
- [ ] **backport** ~~done, or~~ not required (pkcs7 not in LTS)
- [ ] **tests** ~~provided, or~~ not required (fix is in test code)
