### PR TITLE
Use the correct variable when tracking padding length

### DIFF
--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -1973,7 +1973,7 @@ hmac_failed_etm_enabled:
             increment = mbedtls_ct_size_if_else_0(b, increment);
             pad_count += increment;
         }
-        correct = mbedtls_ct_size_if_else_0(mbedtls_ct_uint_eq(pad_count, padlen), padlen);
+        correct = mbedtls_ct_size_if_else_0(mbedtls_ct_uint_eq(pad_count, padlen), correct);
 
 #if defined(MBEDTLS_SSL_DEBUG_ALL)
         if (padlen > 0 && correct == 0) {


### PR DESCRIPTION
## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required - this is not user-facing, and this defect has not been released yet
- [x] **backport** not required - only in development
- [x] **tests** not present - would have expected some failure from existing TLS tests, so any test is going to take a lot of investigation to create
