### PR TITLE
Update CMake minimum version(s) to match main CMakeLists.txt

### DIFF
--- a/programs/test/cmake_package/CMakeLists.txt
+++ b/programs/test/cmake_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5.1)
 
 #
 # Simulate configuring and building Mbed TLS as the user might do it. We'll

--- a/programs/test/cmake_package_install/CMakeLists.txt
+++ b/programs/test/cmake_package_install/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5.1)
 
 #
 # Simulate configuring and building Mbed TLS as the user might do it. We'll

--- a/programs/test/cmake_subproject/CMakeLists.txt
+++ b/programs/test/cmake_subproject/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Test the target renaming support by adding a prefix to the targets built
 set(MBEDTLS_TARGET_PREFIX subproject_test_)


### PR DESCRIPTION
## Description

Update the minimum version in the CMake tests CMakeLists.txt to match the main CMakeLists.txt.

As of cmake 3.27.4 (and possibly prior) CMake is now emitting warnings that support for CMake versions less than 3.5 will be dropped in a future version. Our main CMakelists.txt is fine, as the minimum version is 3.5.1, however some of the other CMakeLists.txt used for the CMake tests had not been updated.

I cannot see any features used within these that require the older version, this is just the minimum version as used to be, so I think these need updating, and especially before any new LTS is made.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** ~~provided, or~~ not required (there is no actual change, CMake 3.5.1 was already required to build the project)
- [x] **backport** ~~done, or~~ not required (Minimum versions in LTS are different, for obvious reasons)
- [x] **tests** ~~provided, or~~ not required (build system change)
