### PR TITLE
Backport 3.6: Update README about PSA

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 README for Mbed TLS
 ===================
 
-Mbed TLS is a C library that implements cryptographic primitives, X.509 certificate manipulation and the SSL/TLS and DTLS protocols. Its small code footprint makes it suitable for embedded systems.
-
-Mbed TLS includes a reference implementation of the [PSA Cryptography API](#psa-cryptography-api). This is currently a preview for evaluation purposes only.
+Mbed TLS is a C library that implements cryptographic primitives (including the [PSA Cryptography API](#psa-cryptography-api)), X.509 certificate manipulation and the SSL/TLS and DTLS protocols. Its small code footprint makes it suitable for embedded systems.
 
 Configuration
 -------------
@@ -298,8 +296,7 @@ Arm welcomes feedback on the design of the API. If you think something could be 
 
 ### PSA implementation in Mbed TLS
 
-Mbed TLS includes a reference implementation of the PSA Cryptography API.
-However, it does not aim to implement the whole specification; in particular it does not implement all the algorithms.
+Mbed TLS includes an implementation of the PSA Cryptography API. It covers most, but not all algorithms.
 
 The X.509 and TLS code can use PSA cryptography for most operations. To enable this support, activate the compilation option `MBEDTLS_USE_PSA_CRYPTO` in `mbedtls_config.h`. Note that TLS 1.3 uses PSA cryptography for most operations regardless of this option. See `docs/use-psa-crypto.md` for details.
 

--- a/docs/architecture/psa-crypto-implementation-structure.md
+++ b/docs/architecture/psa-crypto-implementation-structure.md
@@ -3,7 +3,7 @@ PSA Cryptography API implementation and PSA driver interface
 
 ## Introduction
 
-The [PSA Cryptography API specification](https://armmbed.github.io/mbed-crypto/psa/#application-programming-interface) defines an interface to cryptographic operations for which the Mbed TLS library provides a reference implementation. The PSA Cryptography API specification is complemented by the PSA driver interface specification which defines an interface for cryptoprocessor drivers.
+The [PSA Cryptography API specification](https://armmbed.github.io/mbed-crypto/psa/#application-programming-interface) defines an interface to cryptographic operations for which the Mbed TLS library provides a reference implementation (in the sense that it implements most features, and it is where new features are usually tried out). The PSA Cryptography API specification is complemented by the PSA driver interface specification which defines an interface for cryptoprocessor drivers.
 
 This document describes the high level organization of the Mbed TLS PSA Cryptography API implementation which is tightly related to the PSA driver interface.
 

--- a/docs/proposed/psa-driver-interface.md
+++ b/docs/proposed/psa-driver-interface.md
@@ -3,7 +3,7 @@ PSA Cryptoprocessor Driver Interface
 
 This document describes an interface for cryptoprocessor drivers in the PSA cryptography API. This interface complements the [PSA Cryptography API specification](https://armmbed.github.io/mbed-crypto/psa/#application-programming-interface), which describes the interface between a PSA Cryptography implementation and an application.
 
-This specification is work in progress and should be considered to be in a beta stage. There is ongoing work to implement this interface in Mbed TLS, which is the reference implementation of the PSA Cryptography API. At this stage, Arm does not expect major changes, but minor changes are expected based on experience from the first implementation and on external feedback.
+This specification is work in progress and should be considered to be in a beta stage. There is ongoing work to implement this interface in Mbed TLS, which is the reference implementation of the PSA Cryptography API (although it omits a few functions and mechanisms). At this stage, Arm does not expect major changes, but minor changes are expected based on experience from the first implementation and on external feedback.
 
 For a practical guide, with a description of the current state of drivers Mbed TLS, see our [PSA Cryptoprocessor driver development examples](../psa-driver-example-and-guide.html).
 

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -1494,8 +1494,8 @@ psa_status_t psa_export_key_internal(
             key_buffer, key_buffer_size,
             data, data_size, data_length);
     } else {
-        /* This shouldn't happen in the reference implementation, but
-           it is valid for a special-purpose implementation to omit
+        /* This shouldn't happen in the built-in implementation, but
+           it is valid for a special-purpose drivers to omit
            support for exporting certain key types. */
         return PSA_ERROR_NOT_SUPPORTED;
     }


### PR DESCRIPTION
The PSA implementation has not been experimental for a long while (before 2.28), but we forgot to update the readme.

Don't prominently label it a "reference" implementation. That implies that it's a complete implementation, but it isn't: we do not intend to implement every mechanism that the PSA specification has an encoding for. That also tends to imply that it's for demonstration purposes and not ready for production, but Mbed TLS is intended to be used in production.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required because: doc only
- [x] **3.6 PR** here
- [x] **crypto PR** not required: none of the problematic wording is present in the [crypto README](https://github.com/Mbed-TLS/TF-PSA-Crypto/blob/development/README.md)
- [x] **development PR** not required because: crypto only (`README.md` has obsolete stuff, but everything about crypto should go away when we adapt the file for the product split anyway, covered by https://github.com/Mbed-TLS/mbedtls/issues/10252)
- [x] **tests** not required because: doc only
