### PR TITLE
Declare p256-m as ready for production

### DIFF
--- a/ChangeLog.d/p256-m.txt
+++ b/ChangeLog.d/p256-m.txt
@@ -1,0 +1,5 @@
+Features
+   * Applications using ECC over secp256r1 through the PSA API can use a
+     new implementation with a much smaller footprint, but some minor
+     usage restrictions. See the documentation of the new configuration
+     option MBEDTLS_P256M_EXAMPLE_DRIVER_ENABLED for details.

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -856,16 +856,32 @@
 //#define MBEDTLS_ECP_WITH_MPI_UINT
 
 /**
- * Uncomment to enable p256-m, which implements ECC key generation, ECDH,
- * and ECDSA for SECP256R1 curves. This driver is used as an example to
- * document how a third-party driver or software accelerator can be integrated
- * to work alongside Mbed TLS.
+ * Uncomment to enable p256-m. This is an alternative implementation of
+ * key generation, ECDH and (randomized) ECDSA on the curve SECP256R1.
+ * Compared to the default implementation:
  *
- * \warning p256-m has only been included to serve as a sample implementation
- * of how a driver/accelerator can be integrated alongside Mbed TLS. It is not
- * intended for use in production. p256-m files in Mbed TLS are not updated
- * regularly, so they may not contain upstream fixes/improvements.
- * DO NOT ENABLE/USE THIS MACRO IN PRODUCTION BUILDS!
+ * - p256-m has a much smaller code size and RAM footprint.
+ * - p256-m is only available via the PSA API. This includes the pk module
+ *   when #MBEDTLS_USE_PSA_CRYPTO is enabled.
+ * - p256-m does not support deterministic ECDSA, EC-JPAKE, custom protocols
+ *   over the core arithmetic, or deterministic derivation of keys.
+ *
+ * We recommend enabling this option if your application uses the PSA API
+ * and the only elliptic curve support it needs is ECDH and ECDSA over
+ * SECP256R1.
+ *
+ * If you enable this option, you do not need to enable any ECC-related
+ * MBEDTLS_xxx option. You do need to separately request support for the
+ * cryptographic mechanisms through the PSA API:
+ * - #MBEDTLS_PSA_CRYPTO_C and #MBEDTLS_PSA_CRYPTO_CONFIG for PSA-based
+ *   configuration;
+ * - #MBEDTLS_USE_PSA_CRYPTO if you want to use p256-m from PK, X.509 or TLS;
+ * - #PSA_WANT_ECC_SECP_R1_256;
+ * - #PSA_WANT_ALG_ECDH and/or #PSA_WANT_ALG_ECDSA as needed;
+ * - #PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY, #PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_BASIC,
+ *   #PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT,
+ *   #PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT and/or
+ *   #PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE as needed.
  */
 //#define MBEDTLS_P256M_EXAMPLE_DRIVER_ENABLED
 


### PR DESCRIPTION
I have reviewed the p256-m implementation and integration. The conclusion of my review is:

* The upstream code is very well-written and approved with flying colors. (There was only one upstream bug, in the selection of assembly, listed below.)
* There were a few things missing in the integration (listed below), once those are fixed the integration is fine.
* The [readme needs some work](https://github.com/Mbed-TLS/mbedtls/issues/7882). Not a blocker for release.
* [zeroize was not integrated](https://github.com/Mbed-TLS/mbedtls/issues/7883). Resolved by https://github.com/Mbed-TLS/mbedtls/pull/8166.
* Needs to be tested on the CI. Will be resolved by https://github.com/Mbed-TLS/mbedtls/pull/8041.
* I have not fully reviewed whether the guards around the assembly implementations are correct, but I consider the matter resolved by https://github.com/Mbed-TLS/mbedtls/pull/8126.
* `MBEDTLS_P256M_EXAMPLE_DRIVER_ENABLED` is not a good name for a production feature. Filed as https://github.com/Mbed-TLS/mbedtls/issues/8202.
* https://github.com/Mbed-TLS/mbedtls/issues/8165, a preexisting issue (for Everest) which is not a release blocker.
* Other minor things (minor readability improvements, a couple of possible missed optimizations) which I've recorded in https://github.com/gilles-peskine-arm/mbedtls/tree/p256-m-review-comments. All of these are just nice-to-have.

## PR checklist

- [x] **changelog** provided
- [x] **backport** not required
- [x] **tests** addressed separately in https://github.com/Mbed-TLS/mbedtls/pull/8041

**Note:** Will need rebasing if #8041 gets merged first, see https://github.com/Mbed-TLS/mbedtls/pull/8203#discussion_r1325546135
