### PR TITLE
Fix "inconsistent annotation" warnings #7531

### DIFF
--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -514,7 +514,7 @@ void mbedtls_ssl_set_chk_buf_ptr_fail_args(
     const uint8_t *cur, const uint8_t *end, size_t need);
 void mbedtls_ssl_reset_chk_buf_ptr_fail_args(void);
 
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_cmp_chk_buf_ptr_fail_args(mbedtls_ssl_chk_buf_ptr_args *args);
 
 static inline int mbedtls_ssl_chk_buf_ptr(const uint8_t *cur,
@@ -710,11 +710,11 @@ struct mbedtls_ssl_handshake_params {
 
     mbedtls_ssl_ciphersuite_t const *ciphersuite_info;
 
-    MBEDTLS_CHECK_RETURN_CRITICAL
+    
     int (*update_checksum)(mbedtls_ssl_context *, const unsigned char *, size_t);
-    MBEDTLS_CHECK_RETURN_CRITICAL
+    
     int (*calc_verify)(const mbedtls_ssl_context *, unsigned char *, size_t *);
-    MBEDTLS_CHECK_RETURN_CRITICAL
+    
     int (*calc_finished)(mbedtls_ssl_context *, unsigned char *, int);
     mbedtls_ssl_tls_prf_cb *tls_prf;
 
@@ -1255,7 +1255,7 @@ struct mbedtls_ssl_flight_item {
  *                      (<> 0) or not ( 0 ).
  * \param[out]  out_len Length of the data written into the buffer \p buf
  */
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_tls12_write_client_hello_exts(mbedtls_ssl_context *ssl,
                                               unsigned char *buf,
                                               const unsigned char *end,
@@ -1307,9 +1307,9 @@ void mbedtls_ssl_set_inbound_transform(mbedtls_ssl_context *ssl,
 void mbedtls_ssl_set_outbound_transform(mbedtls_ssl_context *ssl,
                                         mbedtls_ssl_transform *transform);
 
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_handshake_client_step(mbedtls_ssl_context *ssl);
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_handshake_server_step(mbedtls_ssl_context *ssl);
 void mbedtls_ssl_handshake_wrapup(mbedtls_ssl_context *ssl);
 static inline void mbedtls_ssl_handshake_set_state(mbedtls_ssl_context *ssl,
@@ -1318,22 +1318,22 @@ static inline void mbedtls_ssl_handshake_set_state(mbedtls_ssl_context *ssl,
     ssl->state = (int) state;
 }
 
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_send_fatal_handshake_failure(mbedtls_ssl_context *ssl);
 
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_reset_checksum(mbedtls_ssl_context *ssl);
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_2)
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_derive_keys(mbedtls_ssl_context *ssl);
 #endif /* MBEDTLS_SSL_PROTO_TLS1_2  */
 
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_handle_message_type(mbedtls_ssl_context *ssl);
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_prepare_handshake_record(mbedtls_ssl_context *ssl);
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_update_handshake_status(mbedtls_ssl_context *ssl);
 
 /**
@@ -1412,20 +1412,20 @@ int mbedtls_ssl_update_handshake_status(mbedtls_ssl_context *ssl);
  *              following the above definition.
  *
  */
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_read_record(mbedtls_ssl_context *ssl,
                             unsigned update_hs_digest);
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_fetch_input(mbedtls_ssl_context *ssl, size_t nb_want);
 
 /*
  * Write handshake message header
  */
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_start_handshake_msg(mbedtls_ssl_context *ssl, unsigned hs_type,
                                     unsigned char **buf, size_t *buf_len);
 
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_write_handshake_msg_ext(mbedtls_ssl_context *ssl,
                                         int update_checksum,
                                         int force_flush);
@@ -1437,28 +1437,28 @@ static inline int mbedtls_ssl_write_handshake_msg(mbedtls_ssl_context *ssl)
 /*
  * Write handshake message tail
  */
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_finish_handshake_msg(mbedtls_ssl_context *ssl,
                                      size_t buf_len, size_t msg_len);
 
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_write_record(mbedtls_ssl_context *ssl, int force_flush);
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_flush_output(mbedtls_ssl_context *ssl);
 
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_parse_certificate(mbedtls_ssl_context *ssl);
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_write_certificate(mbedtls_ssl_context *ssl);
 
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_parse_change_cipher_spec(mbedtls_ssl_context *ssl);
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_write_change_cipher_spec(mbedtls_ssl_context *ssl);
 
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_parse_finished(mbedtls_ssl_context *ssl);
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_write_finished(mbedtls_ssl_context *ssl);
 
 void mbedtls_ssl_optimize_checksum(mbedtls_ssl_context *ssl,
@@ -1467,20 +1467,20 @@ void mbedtls_ssl_optimize_checksum(mbedtls_ssl_context *ssl,
 /*
  * Update checksum of handshake messages.
  */
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_add_hs_msg_to_checksum(mbedtls_ssl_context *ssl,
                                        unsigned hs_type,
                                        unsigned char const *msg,
                                        size_t msg_len);
 
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_add_hs_hdr_to_checksum(mbedtls_ssl_context *ssl,
                                        unsigned hs_type,
                                        size_t total_hs_len);
 
 #if defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED)
 #if !defined(MBEDTLS_USE_PSA_CRYPTO)
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_psk_derive_premaster(mbedtls_ssl_context *ssl,
                                      mbedtls_key_exchange_type_t key_ex);
 #endif /* !MBEDTLS_USE_PSA_CRYPTO */
@@ -1488,7 +1488,7 @@ int mbedtls_ssl_psk_derive_premaster(mbedtls_ssl_context *ssl,
 
 #if defined(MBEDTLS_SSL_HANDSHAKE_WITH_PSK_ENABLED)
 #if defined(MBEDTLS_SSL_CLI_C)
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_conf_has_static_psk(mbedtls_ssl_config const *conf);
 #endif
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
@@ -1550,14 +1550,14 @@ mbedtls_md_type_t mbedtls_ssl_md_alg_from_hash(unsigned char hash);
 unsigned char mbedtls_ssl_hash_from_md_alg(int md);
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_2)
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_set_calc_verify_md(mbedtls_ssl_context *ssl, int md);
 #endif
 
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_check_curve_tls_id(const mbedtls_ssl_context *ssl, uint16_t tls_id);
 #if defined(MBEDTLS_PK_HAVE_ECC_KEYS)
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_check_curve(const mbedtls_ssl_context *ssl, mbedtls_ecp_group_id grp_id);
 #endif /* MBEDTLS_PK_HAVE_ECC_KEYS */
 
@@ -1662,7 +1662,7 @@ static inline mbedtls_x509_crt *mbedtls_ssl_own_cert(mbedtls_ssl_context *ssl)
  *
  * Return 0 if everything is OK, -1 if not.
  */
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_check_cert_usage(const mbedtls_x509_crt *cert,
                                  const mbedtls_ssl_ciphersuite_t *ciphersuite,
                                  int cert_endpoint,
@@ -1710,26 +1710,26 @@ static inline size_t mbedtls_ssl_hs_hdr_len(const mbedtls_ssl_context *ssl)
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
 void mbedtls_ssl_send_flight_completed(mbedtls_ssl_context *ssl);
 void mbedtls_ssl_recv_flight_completed(mbedtls_ssl_context *ssl);
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_resend(mbedtls_ssl_context *ssl);
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_flight_transmit(mbedtls_ssl_context *ssl);
 #endif
 
 /* Visible for testing purposes only */
 #if defined(MBEDTLS_SSL_DTLS_ANTI_REPLAY)
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_dtls_replay_check(mbedtls_ssl_context const *ssl);
 void mbedtls_ssl_dtls_replay_update(mbedtls_ssl_context *ssl);
 #endif
 
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_session_copy(mbedtls_ssl_session *dst,
                              const mbedtls_ssl_session *src);
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_2)
 /* The hash buffer must have at least MBEDTLS_MD_MAX_SIZE bytes of length. */
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_get_key_exchange_md_tls1_2(mbedtls_ssl_context *ssl,
                                            unsigned char *hash, size_t *hashlen,
                                            unsigned char *data, size_t data_len,
@@ -1741,13 +1741,13 @@ int mbedtls_ssl_get_key_exchange_md_tls1_2(mbedtls_ssl_context *ssl,
 #endif
 
 void mbedtls_ssl_transform_init(mbedtls_ssl_transform *transform);
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_encrypt_buf(mbedtls_ssl_context *ssl,
                             mbedtls_ssl_transform *transform,
                             mbedtls_record *rec,
                             int (*f_rng)(void *, unsigned char *, size_t),
                             void *p_rng);
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_decrypt_buf(mbedtls_ssl_context const *ssl,
                             mbedtls_ssl_transform *transform,
                             mbedtls_record *rec);
@@ -1766,12 +1766,12 @@ static inline size_t mbedtls_ssl_ep_len(const mbedtls_ssl_context *ssl)
 }
 
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_resend_hello_request(mbedtls_ssl_context *ssl);
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
 
 void mbedtls_ssl_set_timer(mbedtls_ssl_context *ssl, uint32_t millisecs);
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_check_timer(mbedtls_ssl_context *ssl);
 
 void mbedtls_ssl_reset_in_out_pointers(mbedtls_ssl_context *ssl);
@@ -1779,7 +1779,7 @@ void mbedtls_ssl_update_out_pointers(mbedtls_ssl_context *ssl,
                                      mbedtls_ssl_transform *transform);
 void mbedtls_ssl_update_in_pointers(mbedtls_ssl_context *ssl);
 
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_session_reset_int(mbedtls_ssl_context *ssl, int partial);
 void mbedtls_ssl_session_reset_msg_layer(mbedtls_ssl_context *ssl,
                                          int partial);
@@ -1787,7 +1787,7 @@ void mbedtls_ssl_session_reset_msg_layer(mbedtls_ssl_context *ssl,
 /*
  * Send pending alert
  */
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_handle_pending_alert(mbedtls_ssl_context *ssl);
 
 /*
@@ -1808,7 +1808,7 @@ void mbedtls_ssl_dtls_replay_reset(mbedtls_ssl_context *ssl);
 void mbedtls_ssl_handshake_wrapup_free_hs_transform(mbedtls_ssl_context *ssl);
 
 #if defined(MBEDTLS_SSL_RENEGOTIATION)
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_start_renegotiation(mbedtls_ssl_context *ssl);
 #endif /* MBEDTLS_SSL_RENEGOTIATION */
 
@@ -1873,9 +1873,9 @@ static inline int mbedtls_ssl_conf_is_hybrid_tls12_tls13(const mbedtls_ssl_confi
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
 extern const uint8_t mbedtls_ssl_tls13_hello_retry_request_magic[
     MBEDTLS_SERVER_HELLO_RANDOM_LEN];
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_tls13_process_finished_message(mbedtls_ssl_context *ssl);
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_tls13_write_finished_message(mbedtls_ssl_context *ssl);
 void mbedtls_ssl_tls13_handshake_wrapup(mbedtls_ssl_context *ssl);
 
@@ -1888,7 +1888,7 @@ void mbedtls_ssl_tls13_handshake_wrapup(mbedtls_ssl_context *ssl);
  * \param[in]   end     End address of the buffer where to write the extensions
  * \param[out]  out_len Length of the data written into the buffer \p buf
  */
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_tls13_write_client_hello_exts(mbedtls_ssl_context *ssl,
                                               unsigned char *buf,
                                               unsigned char *end,
@@ -1899,7 +1899,7 @@ int mbedtls_ssl_tls13_write_client_hello_exts(mbedtls_ssl_context *ssl,
  *
  * \param ssl       SSL context
  */
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_tls13_handshake_client_step(mbedtls_ssl_context *ssl);
 
 /**
@@ -1907,7 +1907,7 @@ int mbedtls_ssl_tls13_handshake_client_step(mbedtls_ssl_context *ssl);
  *
  * \param ssl       SSL context
  */
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_tls13_handshake_server_step(mbedtls_ssl_context *ssl);
 
 
@@ -2005,7 +2005,7 @@ static inline int mbedtls_ssl_tls13_some_psk_enabled(mbedtls_ssl_context *ssl)
  * Helper functions for extensions checking.
  */
 
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_tls13_check_received_extension(
     mbedtls_ssl_context *ssl,
     int hs_msg_type,
@@ -2045,7 +2045,7 @@ static inline int mbedtls_ssl_tls13_key_exchange_mode_with_ephemeral(
 /*
  * Fetch TLS 1.3 handshake message header
  */
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_tls13_fetch_handshake_msg(mbedtls_ssl_context *ssl,
                                           unsigned hs_type,
                                           unsigned char **buf,
@@ -2071,7 +2071,7 @@ int mbedtls_ssl_tls13_fetch_handshake_msg(mbedtls_ssl_context *ssl,
  * \return    A negative value if an error occurred while parsing the
  *            extensions.
  */
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_tls13_is_supported_versions_ext_present_in_exts(
     mbedtls_ssl_context *ssl,
     const unsigned char *buf, const unsigned char *end,
@@ -2081,20 +2081,20 @@ int mbedtls_ssl_tls13_is_supported_versions_ext_present_in_exts(
 /*
  * Handler of TLS 1.3 server certificate message
  */
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_tls13_process_certificate(mbedtls_ssl_context *ssl);
 
 #if defined(MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED)
 /*
  * Handler of TLS 1.3 write Certificate message
  */
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_tls13_write_certificate(mbedtls_ssl_context *ssl);
 
 /*
  * Handler of TLS 1.3 write Certificate Verify message
  */
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_tls13_write_certificate_verify(mbedtls_ssl_context *ssl);
 
 #endif /* MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED */
@@ -2102,20 +2102,20 @@ int mbedtls_ssl_tls13_write_certificate_verify(mbedtls_ssl_context *ssl);
 /*
  * Generic handler of Certificate Verify
  */
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_tls13_process_certificate_verify(mbedtls_ssl_context *ssl);
 
 /*
  * Write of dummy-CCS's for middlebox compatibility
  */
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_tls13_write_change_cipher_spec(mbedtls_ssl_context *ssl);
 
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_reset_transcript_for_hrr(mbedtls_ssl_context *ssl);
 
 #if defined(PSA_WANT_ALG_ECDH) || defined(PSA_WANT_ALG_FFDH)
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_tls13_generate_and_write_xxdh_key_exchange(
     mbedtls_ssl_context *ssl,
     uint16_t named_group,
@@ -2137,20 +2137,20 @@ int mbedtls_ssl_tls13_write_early_data_ext(mbedtls_ssl_context *ssl,
 /*
  * Write Signature Algorithm extension
  */
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_write_sig_alg_ext(mbedtls_ssl_context *ssl, unsigned char *buf,
                                   const unsigned char *end, size_t *out_len);
 /*
  * Parse TLS Signature Algorithm extension
  */
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_parse_sig_alg_ext(mbedtls_ssl_context *ssl,
                                   const unsigned char *buf,
                                   const unsigned char *end);
 #endif /* MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED */
 
 /* Get handshake transcript */
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_get_handshake_transcript(mbedtls_ssl_context *ssl,
                                          const mbedtls_md_type_t md,
                                          unsigned char *dst,
@@ -2374,7 +2374,7 @@ static inline int mbedtls_ssl_tls13_sig_alg_is_supported(
     return 1;
 }
 
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_tls13_check_sig_alg_cert_key_match(uint16_t sig_alg,
                                                    mbedtls_pk_context *key);
 #endif /* MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED */
@@ -2650,7 +2650,7 @@ mbedtls_ssl_mode_t mbedtls_ssl_get_mode_from_ciphersuite(
 
 #if defined(PSA_WANT_ALG_ECDH) || defined(PSA_WANT_ALG_FFDH)
 
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_tls13_read_public_xxdhe_share(mbedtls_ssl_context *ssl,
                                               const unsigned char *buf,
                                               size_t buf_len);
@@ -2681,7 +2681,7 @@ static inline int mbedtls_ssl_tls13_cipher_suite_is_offered(
  *
  * \return 0 if valid, negative value otherwise.
  */
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_validate_ciphersuite(
     const mbedtls_ssl_context *ssl,
     const mbedtls_ssl_ciphersuite_t *suite_info,
@@ -2689,7 +2689,7 @@ int mbedtls_ssl_validate_ciphersuite(
     mbedtls_ssl_protocol_version max_tls_version);
 
 #if defined(MBEDTLS_SSL_SERVER_NAME_INDICATION)
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_parse_server_name_ext(mbedtls_ssl_context *ssl,
                                       const unsigned char *buf,
                                       const unsigned char *end);
@@ -2699,20 +2699,20 @@ int mbedtls_ssl_parse_server_name_ext(mbedtls_ssl_context *ssl,
 #define MBEDTLS_SSL_RECORD_SIZE_LIMIT_EXTENSION_DATA_LENGTH (2)
 #define MBEDTLS_SSL_RECORD_SIZE_LIMIT_MIN (64)
 
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_tls13_parse_record_size_limit_ext(mbedtls_ssl_context *ssl,
                                                   const unsigned char *buf,
                                                   const unsigned char *end);
 #endif /* MBEDTLS_SSL_RECORD_SIZE_LIMIT */
 
 #if defined(MBEDTLS_SSL_ALPN)
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_parse_alpn_ext(mbedtls_ssl_context *ssl,
                                const unsigned char *buf,
                                const unsigned char *end);
 
 
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_write_alpn_ext(mbedtls_ssl_context *ssl,
                                unsigned char *buf,
                                unsigned char *end,
@@ -2741,7 +2741,7 @@ int mbedtls_ssl_check_dtls_clihlo_cookie(
  * \param[out]  binders_len Length of the binders to be written at the end of
  *                          the extension.
  */
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_tls13_write_identities_of_pre_shared_key_ext(
     mbedtls_ssl_context *ssl,
     unsigned char *buf, unsigned char *end,
@@ -2756,7 +2756,7 @@ int mbedtls_ssl_tls13_write_identities_of_pre_shared_key_ext(
  * \param[in]   buf     Base address of the buffer where to write the binders
  * \param[in]   end     End address of the buffer where to write the binders
  */
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_tls13_write_binders_of_pre_shared_key_ext(
     mbedtls_ssl_context *ssl,
     unsigned char *buf, unsigned char *end);
@@ -2766,7 +2766,7 @@ int mbedtls_ssl_tls13_write_binders_of_pre_shared_key_ext(
     defined(MBEDTLS_SSL_SESSION_TICKETS) && \
     defined(MBEDTLS_SSL_SERVER_NAME_INDICATION) && \
     defined(MBEDTLS_SSL_CLI_C)
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_session_set_hostname(mbedtls_ssl_session *session,
                                      const char *hostname);
 #endif

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -313,7 +313,7 @@ int mbedtls_ssl_session_copy(mbedtls_ssl_session *dst,
 }
 
 #if defined(MBEDTLS_SSL_VARIABLE_BUFFER_LENGTH)
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 static int resize_buffer(unsigned char **buffer, size_t len_new, size_t *len_old)
 {
     unsigned char *resized_buffer = mbedtls_calloc(1, len_new);
@@ -408,7 +408,7 @@ typedef int ssl_tls_prf_t(const unsigned char *, size_t, const char *,
                           const unsigned char *, size_t,
                           unsigned char *, size_t);
 
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 static int ssl_tls12_populate_transform(mbedtls_ssl_transform *transform,
                                         int ciphersuite,
                                         const unsigned char master[48],
@@ -422,7 +422,7 @@ static int ssl_tls12_populate_transform(mbedtls_ssl_transform *transform,
                                         const mbedtls_ssl_context *ssl);
 
 #if defined(MBEDTLS_MD_CAN_SHA256)
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 static int tls_prf_sha256(const unsigned char *secret, size_t slen,
                           const char *label,
                           const unsigned char *random, size_t rlen,
@@ -433,7 +433,7 @@ static int ssl_calc_finished_tls_sha256(mbedtls_ssl_context *, unsigned char *, 
 #endif /* MBEDTLS_MD_CAN_SHA256*/
 
 #if defined(MBEDTLS_MD_CAN_SHA384)
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 static int tls_prf_sha384(const unsigned char *secret, size_t slen,
                           const char *label,
                           const unsigned char *random, size_t rlen,
@@ -447,7 +447,7 @@ static size_t ssl_tls12_session_save(const mbedtls_ssl_session *session,
                                      unsigned char *buf,
                                      size_t buf_len);
 
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 static int ssl_tls12_session_load(mbedtls_ssl_session *session,
                                   const unsigned char *buf,
                                   size_t len);
@@ -1045,7 +1045,7 @@ void mbedtls_ssl_session_init(mbedtls_ssl_session *session)
     memset(session, 0, sizeof(mbedtls_ssl_session));
 }
 
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 static int ssl_handshake_init(mbedtls_ssl_context *ssl)
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
@@ -1258,7 +1258,7 @@ static int ssl_handshake_init(mbedtls_ssl_context *ssl)
 
 #if defined(MBEDTLS_SSL_DTLS_HELLO_VERIFY) && defined(MBEDTLS_SSL_SRV_C)
 /* Dummy cookie callbacks for defaults */
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 static int ssl_cookie_write_dummy(void *ctx,
                                   unsigned char **p, unsigned char *end,
                                   const unsigned char *cli_id, size_t cli_id_len)
@@ -1272,7 +1272,7 @@ static int ssl_cookie_write_dummy(void *ctx,
     return MBEDTLS_ERR_SSL_FEATURE_UNAVAILABLE;
 }
 
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 static int ssl_cookie_check_dummy(void *ctx,
                                   const unsigned char *cookie, size_t cookie_len,
                                   const unsigned char *cli_id, size_t cli_id_len)
@@ -1295,7 +1295,7 @@ void mbedtls_ssl_init(mbedtls_ssl_context *ssl)
     memset(ssl, 0, sizeof(mbedtls_ssl_context));
 }
 
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 static int ssl_conf_version_check(const mbedtls_ssl_context *ssl)
 {
     const mbedtls_ssl_config *conf = ssl->conf;
@@ -1335,7 +1335,7 @@ static int ssl_conf_version_check(const mbedtls_ssl_context *ssl)
     return MBEDTLS_ERR_SSL_BAD_CONFIG;
 }
 
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 static int ssl_conf_check(const mbedtls_ssl_context *ssl)
 {
     int ret;
@@ -1818,7 +1818,7 @@ static void ssl_key_cert_free(mbedtls_ssl_key_cert *key_cert)
 }
 
 /* Append a new keycert entry to a (possibly empty) list */
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 static int ssl_append_key_cert(mbedtls_ssl_key_cert **head,
                                mbedtls_x509_crt *cert,
                                mbedtls_pk_context *key)
@@ -2140,7 +2140,7 @@ static void ssl_conf_remove_psk(mbedtls_ssl_config *conf)
  * It checks that the provided identity is well-formed and attempts
  * to make a copy of it in the SSL config.
  * On failure, the PSK identity in the config remains unset. */
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 static int ssl_conf_set_psk_identity(mbedtls_ssl_config *conf,
                                      unsigned char const *psk_identity,
                                      size_t psk_identity_len)
@@ -2473,7 +2473,7 @@ mbedtls_ssl_mode_t mbedtls_ssl_get_mode_from_ciphersuite(
  *
  */
 #if defined(MBEDTLS_SSL_SESSION_TICKETS)
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 static int ssl_tls13_session_save(const mbedtls_ssl_session *session,
                                   unsigned char *buf,
                                   size_t buf_len,
@@ -2574,7 +2574,7 @@ static int ssl_tls13_session_save(const mbedtls_ssl_session *session,
     return 0;
 }
 
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 static int ssl_tls13_session_load(mbedtls_ssl_session *session,
                                   const unsigned char *buf,
                                   size_t len)
@@ -2677,7 +2677,7 @@ static int ssl_tls13_session_load(mbedtls_ssl_session *session,
 
 }
 #else /* MBEDTLS_SSL_SESSION_TICKETS */
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 static int ssl_tls13_session_save(const mbedtls_ssl_session *session,
                                   unsigned char *buf,
                                   size_t buf_len,
@@ -3621,7 +3621,7 @@ static unsigned char ssl_serialized_session_header[] = {
  *
  */
 
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 static int ssl_session_save(const mbedtls_ssl_session *session,
                             unsigned char omit_header,
                             unsigned char *buf,
@@ -3708,7 +3708,7 @@ int mbedtls_ssl_session_save(const mbedtls_ssl_session *session,
  * This internal version is wrapped by a public function that cleans up in
  * case of error, and has an extra option omit_header.
  */
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 static int ssl_session_load(mbedtls_ssl_session *session,
                             unsigned char omit_header,
                             const unsigned char *buf,
@@ -3784,7 +3784,7 @@ int mbedtls_ssl_session_load(mbedtls_ssl_session *session,
 /*
  * Perform a single step of the SSL handshake
  */
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 static int ssl_prepare_handshake_step(mbedtls_ssl_context *ssl)
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
@@ -3949,7 +3949,7 @@ int mbedtls_ssl_handshake(mbedtls_ssl_context *ssl)
 /*
  * Write HelloRequest to request renegotiation on server
  */
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 static int ssl_write_hello_request(mbedtls_ssl_context *ssl)
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
@@ -4550,7 +4550,7 @@ int mbedtls_ssl_context_save(mbedtls_ssl_context *ssl,
  * This internal version is wrapped by a public function that cleans up in
  * case of error.
  */
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 static int ssl_context_load(mbedtls_ssl_context *ssl,
                             const unsigned char *buf,
                             size_t len)
@@ -5131,7 +5131,7 @@ static uint16_t ssl_preset_suiteb_groups[] = {
 #if defined(MBEDTLS_DEBUG_C) && defined(MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED)
 /* Function for checking `ssl_preset_*_sig_algs` and `ssl_tls12_preset_*_sig_algs`
  * to make sure there are no duplicated signature algorithm entries. */
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 static int ssl_check_no_sig_alg_duplication(uint16_t *sig_algs)
 {
     size_t i, j;
@@ -5790,7 +5790,7 @@ exit:
 #else /* MBEDTLS_USE_PSA_CRYPTO */
 
 #if defined(MBEDTLS_MD_CAN_SHA384)
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 static int ssl_get_handshake_transcript_sha384(mbedtls_ssl_context *ssl,
                                                unsigned char *dst,
                                                size_t dst_len,
@@ -5828,7 +5828,7 @@ exit:
 #endif /* MBEDTLS_MD_CAN_SHA384 */
 
 #if defined(MBEDTLS_MD_CAN_SHA256)
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 static int ssl_get_handshake_transcript_sha256(mbedtls_ssl_context *ssl,
                                                unsigned char *dst,
                                                size_t dst_len,
@@ -6073,7 +6073,7 @@ static psa_status_t setup_psa_key_derivation(psa_key_derivation_operation_t *der
 
 #if defined(PSA_WANT_ALG_SHA_384) || \
     defined(PSA_WANT_ALG_SHA_256)
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 static int tls_prf_generic(mbedtls_md_type_t md_type,
                            const unsigned char *secret, size_t slen,
                            const char *label,
@@ -6153,7 +6153,7 @@ static int tls_prf_generic(mbedtls_md_type_t md_type,
 #if defined(MBEDTLS_MD_C) &&       \
     (defined(MBEDTLS_MD_CAN_SHA256) || \
     defined(MBEDTLS_MD_CAN_SHA384))
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 static int tls_prf_generic(mbedtls_md_type_t md_type,
                            const unsigned char *secret, size_t slen,
                            const char *label,
@@ -6260,7 +6260,7 @@ exit:
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 #if defined(MBEDTLS_MD_CAN_SHA256)
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 static int tls_prf_sha256(const unsigned char *secret, size_t slen,
                           const char *label,
                           const unsigned char *random, size_t rlen,
@@ -6272,7 +6272,7 @@ static int tls_prf_sha256(const unsigned char *secret, size_t slen,
 #endif /* MBEDTLS_MD_CAN_SHA256*/
 
 #if defined(MBEDTLS_MD_CAN_SHA384)
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 static int tls_prf_sha384(const unsigned char *secret, size_t slen,
                           const char *label,
                           const unsigned char *random, size_t rlen,
@@ -6292,7 +6292,7 @@ static int tls_prf_sha384(const unsigned char *secret, size_t slen,
  * Outputs:
  * - the tls_prf, calc_verify and calc_finished members of handshake structure
  */
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 static int ssl_set_handshake_prfs(mbedtls_ssl_handshake_params *handshake,
                                   mbedtls_md_type_t hash)
 {
@@ -6335,7 +6335,7 @@ static int ssl_set_handshake_prfs(mbedtls_ssl_handshake_params *handshake,
  *      EMS: passed to calc_verify (debug + session_negotiate)
  *      PSA-PSA: conf
  */
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 static int ssl_compute_master(mbedtls_ssl_handshake_params *handshake,
                               unsigned char *master,
                               const mbedtls_ssl_context *ssl)
@@ -6842,7 +6842,7 @@ int mbedtls_ssl_psk_derive_premaster(mbedtls_ssl_context *ssl, mbedtls_key_excha
 #endif /* !MBEDTLS_USE_PSA_CRYPTO && MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED */
 
 #if defined(MBEDTLS_SSL_SRV_C) && defined(MBEDTLS_SSL_RENEGOTIATION)
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 static int ssl_write_hello_request(mbedtls_ssl_context *ssl);
 
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
@@ -7001,7 +7001,7 @@ int mbedtls_ssl_write_certificate(mbedtls_ssl_context *ssl)
 #if defined(MBEDTLS_SSL_RENEGOTIATION) && defined(MBEDTLS_SSL_CLI_C)
 
 #if defined(MBEDTLS_SSL_KEEP_PEER_CERTIFICATE)
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 static int ssl_check_peer_crt_unchanged(mbedtls_ssl_context *ssl,
                                         unsigned char *crt_buf,
                                         size_t crt_buf_len)
@@ -7019,7 +7019,7 @@ static int ssl_check_peer_crt_unchanged(mbedtls_ssl_context *ssl,
     return memcmp(peer_crt->raw.p, crt_buf, peer_crt->raw.len);
 }
 #else /* MBEDTLS_SSL_KEEP_PEER_CERTIFICATE */
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 static int ssl_check_peer_crt_unchanged(mbedtls_ssl_context *ssl,
                                         unsigned char *crt_buf,
                                         size_t crt_buf_len)
@@ -7057,7 +7057,7 @@ static int ssl_check_peer_crt_unchanged(mbedtls_ssl_context *ssl,
  * Once the certificate message is read, parse it into a cert chain and
  * perform basic checks, but leave actual verification to the caller
  */
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 static int ssl_parse_certificate_chain(mbedtls_ssl_context *ssl,
                                        mbedtls_x509_crt *chain)
 {
@@ -7203,7 +7203,7 @@ crt_parse_der_failed:
 }
 
 #if defined(MBEDTLS_SSL_SRV_C)
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 static int ssl_srv_check_client_no_crt_notification(mbedtls_ssl_context *ssl)
 {
     if (ssl->conf->endpoint == MBEDTLS_SSL_IS_CLIENT) {
@@ -7229,7 +7229,7 @@ static int ssl_srv_check_client_no_crt_notification(mbedtls_ssl_context *ssl)
  */
 #define SSL_CERTIFICATE_EXPECTED 0
 #define SSL_CERTIFICATE_SKIP     1
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 static int ssl_parse_certificate_coordinate(mbedtls_ssl_context *ssl,
                                             int authmode)
 {
@@ -7259,7 +7259,7 @@ static int ssl_parse_certificate_coordinate(mbedtls_ssl_context *ssl,
     return SSL_CERTIFICATE_EXPECTED;
 }
 
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 static int ssl_parse_certificate_verify(mbedtls_ssl_context *ssl,
                                         int authmode,
                                         mbedtls_x509_crt *chain,
@@ -7450,7 +7450,7 @@ static int ssl_parse_certificate_verify(mbedtls_ssl_context *ssl,
 }
 
 #if !defined(MBEDTLS_SSL_KEEP_PEER_CERTIFICATE)
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 static int ssl_remember_peer_crt_digest(mbedtls_ssl_context *ssl,
                                         unsigned char *start, size_t len)
 {
@@ -7481,7 +7481,7 @@ static int ssl_remember_peer_crt_digest(mbedtls_ssl_context *ssl,
     return ret;
 }
 
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 static int ssl_remember_peer_pubkey(mbedtls_ssl_context *ssl,
                                     unsigned char *start, size_t len)
 {
@@ -8116,7 +8116,7 @@ static mbedtls_tls_prf_types tls_prf_get_type(mbedtls_ssl_tls_prf_cb *tls_prf)
  *      [in] optionally used for:
  *        - MBEDTLS_DEBUG_C: ssl->conf->{f,p}_dbg
  */
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 static int ssl_tls12_populate_transform(mbedtls_ssl_transform *transform,
                                         int ciphersuite,
                                         const unsigned char master[48],
@@ -8992,7 +8992,7 @@ static size_t ssl_tls12_session_save(const mbedtls_ssl_session *session,
     return used;
 }
 
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 static int ssl_tls12_session_load(mbedtls_ssl_session *session,
                                   const unsigned char *buf,
                                   size_t len)
@@ -9361,7 +9361,7 @@ int mbedtls_ssl_write_sig_alg_ext(mbedtls_ssl_context *ssl, unsigned char *buf,
  *          ServerName server_name_list<1..2^16-1>
  *     } ServerNameList;
  */
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_parse_server_name_ext(mbedtls_ssl_context *ssl,
                                       const unsigned char *buf,
                                       const unsigned char *end)
@@ -9415,7 +9415,7 @@ int mbedtls_ssl_parse_server_name_ext(mbedtls_ssl_context *ssl,
 #endif /* MBEDTLS_SSL_SERVER_NAME_INDICATION */
 
 #if defined(MBEDTLS_SSL_ALPN)
-MBEDTLS_CHECK_RETURN_CRITICAL
+
 int mbedtls_ssl_parse_alpn_ext(mbedtls_ssl_context *ssl,
                                const unsigned char *buf,
                                const unsigned char *end)


### PR DESCRIPTION
## Description

I have removed some of `MBEDTLS_CHECK_RETURN_CRITICAL` which described on #7531 Issue.


## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required
- [x] **backport** not required
- [x] **tests** not required


## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.
