### PR TITLE
Fixes log level for got supported group message

### DIFF
--- a/ChangeLog.d/fix-log-level-msg.txt
+++ b/ChangeLog.d/fix-log-level-msg.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix an incorrect log level that was causing excessive messages during
+     DTLS handshakes. Fixes #6765.

--- a/include/mbedtls/version.h
+++ b/include/mbedtls/version.h
@@ -46,21 +46,21 @@ unsigned int mbedtls_version_get_number(void);
 /**
  * Get the version string ("x.y.z").
  *
- * \param string    The string that will receive the value.
+ * \return          The string that will return the value.
  *                  (Should be at least 9 bytes in size)
  */
-void mbedtls_version_get_string(char *string);
+const char *mbedtls_version_get_string(void);
 
 /**
  * Get the full version string ("Mbed TLS x.y.z").
  *
- * \param string    The string that will receive the value. The Mbed TLS version
+ * \return          The string that will return the value. The Mbed TLS version
  *                  string will use 18 bytes AT MOST including a terminating
  *                  null byte.
  *                  (So the buffer should be at least 18 bytes to receive this
  *                  version string).
  */
-void mbedtls_version_get_string_full(char *string);
+const char *mbedtls_version_get_string(void);
 
 /**
  * \brief           Check if support for a feature was compiled into this

--- a/library/ssl_client.c
+++ b/library/ssl_client.c
@@ -260,7 +260,7 @@ static int ssl_write_supported_groups_ext(mbedtls_ssl_context *ssl,
     for (; *group_list != 0; group_list++) {
         int propose_group = 0;
 
-        MBEDTLS_SSL_DEBUG_MSG(1, ("got supported group(%04x)", *group_list));
+        MBEDTLS_SSL_DEBUG_MSG(3, ("got supported group(%04x)", *group_list));
 
 #if defined(MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_SOME_EPHEMERAL_ENABLED)
         if (flags & SSL_WRITE_SUPPORTED_GROUPS_EXT_TLS1_3_FLAG) {

--- a/library/version.c
+++ b/library/version.c
@@ -29,16 +29,14 @@ unsigned int mbedtls_version_get_number(void)
     return MBEDTLS_VERSION_NUMBER;
 }
 
-void mbedtls_version_get_string(char *string)
+const char *mbedtls_version_get_string(void)
 {
-    memcpy(string, MBEDTLS_VERSION_STRING,
-           sizeof(MBEDTLS_VERSION_STRING));
+    return MBEDTLS_VERSION_STRING;
 }
 
 void mbedtls_version_get_string_full(char *string)
 {
-    memcpy(string, MBEDTLS_VERSION_STRING_FULL,
-           sizeof(MBEDTLS_VERSION_STRING_FULL));
+   return MBEDTLS_VERSION_STRING_FULL;
 }
 
 #endif /* MBEDTLS_VERSION_C */

--- a/programs/test/cmake_package/cmake_package.c
+++ b/programs/test/cmake_package/cmake_package.c
@@ -31,7 +31,7 @@ int main()
     /* This version string is 18 bytes long, as advised by version.h. */
     char version[18];
 
-    mbedtls_version_get_string_full(version);
+    memcpy(version, mbedtls_version_get_string(), sizeof(version));
 
     mbedtls_printf("Built against %s\n", version);
 

--- a/programs/test/cmake_package_install/cmake_package_install.c
+++ b/programs/test/cmake_package_install/cmake_package_install.c
@@ -32,7 +32,7 @@ int main()
     /* This version string is 18 bytes long, as advised by version.h. */
     char version[18];
 
-    mbedtls_version_get_string_full(version);
+    memcpy(version, mbedtls_version_get_string_full(), sizeof(version));
 
     mbedtls_printf("Built against %s\n", version);
 

--- a/tests/suites/test_suite_version.function
+++ b/tests/suites/test_suite_version.function
@@ -49,8 +49,8 @@ void check_runtime_version(char *version_str)
     memset(get_str_full, 0, 100);
 
     get_int = mbedtls_version_get_number();
-    mbedtls_version_get_string(get_str);
-    mbedtls_version_get_string_full(get_str_full);
+    memcpy(get_str, mbedtls_version_get_string(), 100);
+    memcpy(mbedtls_version_get_string_full(get_str_full);
 
     mbedtls_snprintf(build_str, 100, "%u.%u.%u",
                      (get_int >> 24) & 0xFF,


### PR DESCRIPTION
## Description

This is the copy PR of the previous https://github.com/Mbed-TLS/mbedtls/pull/7314
somehow I cannot re-open that.

This PR resolve https://github.com/Mbed-TLS/mbedtls/issues/6765 issue. During one successful DTLS handshake, user seeing many message caused by wrong log level.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [ ] **changelog** todo
- [x] **backport** not needed (code not present in 2.28)
- [x] **tests** not required



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.
