### PR TITLE
2.28: Fix AESNI selection

### DIFF
--- a/include/mbedtls/aesni.h
+++ b/include/mbedtls/aesni.h
@@ -36,12 +36,10 @@
 #define MBEDTLS_AESNI_AES      0x02000000u
 #define MBEDTLS_AESNI_CLMUL    0x00000002u
 
-/* Can we do AESNI with inline assembly?
- * (Only implemented with gas syntax, only for 64-bit.)
- */
-#if defined(MBEDTLS_HAVE_ASM) && defined(__GNUC__) && \
-    (defined(__amd64__) || defined(__x86_64__))   &&  \
-    !defined(MBEDTLS_HAVE_X86_64)
+#if !defined(MBEDTLS_HAVE_X86_64) && \
+    (defined(__amd64__) || defined(__x86_64__) || \
+    defined(_M_X64) || defined(_M_AMD64)) && \
+    !defined(_M_ARM64EC)
 #define MBEDTLS_HAVE_X86_64
 #endif
 
@@ -78,7 +76,11 @@
  * favor the assembly-based implementation if it's available. We intend to
  * revise this in a later release of Mbed TLS 3.x. In the long run, we will
  * likely remove the assembly implementation. */
-#if defined(MBEDTLS_HAVE_X86_64)
+#if defined(MBEDTLS_HAVE_ASM) && \
+    defined(__GNUC__) && defined(MBEDTLS_HAVE_X86_64)
+/* Can we do AESNI with inline assembly?
+ * (Only implemented with gas syntax, only for 64-bit.)
+ */
 #define MBEDTLS_AESNI_HAVE_CODE 1 // via assembly
 #elif defined(MBEDTLS_AESNI_HAVE_INTRINSICS)
 #define MBEDTLS_AESNI_HAVE_CODE 2 // via intrinsics

--- a/include/mbedtls/aesni.h
+++ b/include/mbedtls/aesni.h
@@ -176,6 +176,6 @@ int mbedtls_aesni_setkey_enc(unsigned char *rk,
 #endif
 
 #endif /* MBEDTLS_AESNI_HAVE_CODE */
-#endif  /* MBEDTLS_AESNI_C */
+#endif /* MBEDTLS_AESNI_C && (MBEDTLS_HAVE_X86_64 || MBEDTLS_HAVE_X86) */
 
 #endif /* MBEDTLS_AESNI_H */

--- a/include/mbedtls/aesni.h
+++ b/include/mbedtls/aesni.h
@@ -45,6 +45,11 @@
 #define MBEDTLS_HAVE_X86_64
 #endif
 
+#if !defined(MBEDTLS_HAVE_X86) && \
+    (defined(__i386__) || defined(_M_IX86))
+#define MBEDTLS_HAVE_X86
+#endif
+
 #if defined(MBEDTLS_AESNI_C)
 
 /* Can we do AESNI with intrinsics?

--- a/include/mbedtls/aesni.h
+++ b/include/mbedtls/aesni.h
@@ -50,7 +50,8 @@
 #define MBEDTLS_HAVE_X86
 #endif
 
-#if defined(MBEDTLS_AESNI_C)
+#if defined(MBEDTLS_AESNI_C) && \
+    (defined(MBEDTLS_HAVE_X86_64) || defined(MBEDTLS_HAVE_X86))
 
 /* Can we do AESNI with intrinsics?
  * (Only implemented with certain compilers, only for certain targets.)

--- a/include/mbedtls/padlock.h
+++ b/include/mbedtls/padlock.h
@@ -44,8 +44,11 @@
 #endif
 
 /* Some versions of ASan result in errors about not enough registers */
-#if defined(MBEDTLS_HAVE_ASM) && defined(__GNUC__) && defined(__i386__) && \
+#if defined(MBEDTLS_PADLOCK_C) && defined(MBEDTLS_HAVE_ASM) && \
+    defined(__GNUC__) && defined(__i386__) && \
     !defined(MBEDTLS_HAVE_ASAN)
+
+#define MBEDTLS_VIA_PADLOCK_HAVE_CODE
 
 #ifndef MBEDTLS_HAVE_X86
 #define MBEDTLS_HAVE_X86
@@ -120,6 +123,6 @@ int mbedtls_padlock_xcryptcbc(mbedtls_aes_context *ctx,
 }
 #endif
 
-#endif /* HAVE_X86  */
+#endif /* MBEDTLS_VIA_PADLOCK_HAVE_CODE  */
 
 #endif /* padlock.h */

--- a/include/mbedtls/padlock.h
+++ b/include/mbedtls/padlock.h
@@ -123,6 +123,7 @@ int mbedtls_padlock_xcryptcbc(mbedtls_aes_context *ctx,
 }
 #endif
 
-#endif /* MBEDTLS_VIA_PADLOCK_HAVE_CODE */
+#endif /* MBEDTLS_PADLOCK_C && MBEDTLS_HAVE_ASM &&
+          __GNUC__ && __i386__ && !MBEDTLS_HAVE_ASAN */
 
 #endif /* padlock.h */

--- a/include/mbedtls/padlock.h
+++ b/include/mbedtls/padlock.h
@@ -123,6 +123,6 @@ int mbedtls_padlock_xcryptcbc(mbedtls_aes_context *ctx,
 }
 #endif
 
-#endif /* MBEDTLS_VIA_PADLOCK_HAVE_CODE  */
+#endif /* MBEDTLS_VIA_PADLOCK_HAVE_CODE */
 
 #endif /* padlock.h */

--- a/library/aes.c
+++ b/library/aes.c
@@ -50,7 +50,7 @@
 #define AES_VALIDATE(cond)        \
     MBEDTLS_INTERNAL_VALIDATE(cond)
 
-#if defined(MBEDTLS_PADLOCK_C) && defined(MBEDTLS_HAVE_X86)
+#if defined(MBEDTLS_VIA_PADLOCK_HAVE_CODE)
 static int aes_padlock_ace = -1;
 #endif
 
@@ -548,7 +548,7 @@ void mbedtls_aes_xts_free(mbedtls_aes_xts_context *ctx)
  * Note that the offset is in units of elements of buf, i.e. 32-bit words,
  * i.e. an offset of 1 means 4 bytes and so on.
  */
-#if (defined(MBEDTLS_PADLOCK_C) && defined(MBEDTLS_HAVE_X86)) ||        \
+#if defined(MBEDTLS_VIA_PADLOCK_HAVE_CODE) || \
     (defined(MBEDTLS_AESNI_C) && MBEDTLS_AESNI_HAVE_CODE == 2)
 #define MAY_NEED_TO_ALIGN
 #endif
@@ -560,7 +560,7 @@ static unsigned mbedtls_aes_rk_offset(uint32_t *buf)
 #if defined(MAY_NEED_TO_ALIGN)
     int align_16_bytes = 0;
 
-#if defined(MBEDTLS_PADLOCK_C) && defined(MBEDTLS_HAVE_X86)
+#if defined(MBEDTLS_VIA_PADLOCK_HAVE_CODE)
     if (aes_padlock_ace == -1) {
         aes_padlock_ace = mbedtls_padlock_has_support(MBEDTLS_PADLOCK_ACE);
     }
@@ -1076,7 +1076,7 @@ int mbedtls_aes_crypt_ecb(mbedtls_aes_context *ctx,
     }
 #endif
 
-#if defined(MBEDTLS_PADLOCK_C) && defined(MBEDTLS_HAVE_X86)
+#if defined(MBEDTLS_VIA_PADLOCK_HAVE_CODE)
     if (aes_padlock_ace) {
         return mbedtls_padlock_xcryptecb(ctx, mode, input, output);
     }
@@ -1115,7 +1115,7 @@ int mbedtls_aes_crypt_cbc(mbedtls_aes_context *ctx,
         return MBEDTLS_ERR_AES_INVALID_INPUT_LENGTH;
     }
 
-#if defined(MBEDTLS_PADLOCK_C) && defined(MBEDTLS_HAVE_X86)
+#if defined(MBEDTLS_VIA_PADLOCK_HAVE_CODE)
     if (aes_padlock_ace) {
         if (mbedtls_padlock_xcryptcbc(ctx, mode, length, iv, input, output) == 0) {
             return 0;
@@ -1875,7 +1875,7 @@ int mbedtls_aes_self_test(int verbose)
 #if defined(MBEDTLS_AES_ALT)
         mbedtls_printf("  AES note: alternative implementation.\n");
 #else /* MBEDTLS_AES_ALT */
-#if defined(MBEDTLS_PADLOCK_C) && defined(MBEDTLS_HAVE_X86)
+#if defined(MBEDTLS_VIA_PADLOCK_HAVE_CODE)
         if (mbedtls_padlock_has_support(MBEDTLS_PADLOCK_ACE)) {
             mbedtls_printf("  AES note: using VIA Padlock.\n");
         } else

--- a/library/padlock.c
+++ b/library/padlock.c
@@ -37,7 +37,7 @@
 #endif
 /* *INDENT-ON* */
 
-#if defined(MBEDTLS_HAVE_X86)
+#if defined(MBEDTLS_VIA_PADLOCK_HAVE_CODE)
 
 /*
  * PadLock detection routine
@@ -161,6 +161,6 @@ int mbedtls_padlock_xcryptcbc(mbedtls_aes_context *ctx,
     return 0;
 }
 
-#endif /* MBEDTLS_HAVE_X86 */
+#endif /* MBEDTLS_VIA_PADLOCK_HAVE_CODE */
 
 #endif /* MBEDTLS_PADLOCK_C */


### PR DESCRIPTION
## Description

Fix: #8168 

This PR does a clean-up of the arch detection and implementation selection macros in `include/mbedtls/aesni.h`, similar to #7384. This would fix the issue when building with MSVC for ARM/ARM64 target if `MBEDTLS_AESNI_C` is not disabled.


## PR checklist

- [ ] **changelog** provided, or not required
- [x] **backport** not required
- [x] **tests** not required

