### PR TITLE
Fix some clang-18 warnings

### DIFF
--- a/library/ssl_client.c
+++ b/library/ssl_client.c
@@ -650,7 +650,8 @@ static int ssl_write_client_hello_body(mbedtls_ssl_context *ssl,
 #if defined(MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED)
     int write_sig_alg_ext = 0;
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
-    write_sig_alg_ext = write_sig_alg_ext || (propose_tls13 && mbedtls_ssl_conf_tls13_ephemeral_enabled(ssl));
+    write_sig_alg_ext = write_sig_alg_ext ||
+                        (propose_tls13 && mbedtls_ssl_conf_tls13_ephemeral_enabled(ssl));
 #endif
 #if defined(MBEDTLS_SSL_PROTO_TLS1_2)
     write_sig_alg_ext = write_sig_alg_ext || propose_tls12;

--- a/library/ssl_client.c
+++ b/library/ssl_client.c
@@ -648,14 +648,15 @@ static int ssl_write_client_hello_body(mbedtls_ssl_context *ssl,
           MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_SOME_EPHEMERAL_ENABLED */
 
 #if defined(MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED)
-    if (
+    int write_sig_alg_ext = 0;
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
-        (propose_tls13 && mbedtls_ssl_conf_tls13_ephemeral_enabled(ssl)) ||
+    write_sig_alg_ext = write_sig_alg_ext || (propose_tls13 && mbedtls_ssl_conf_tls13_ephemeral_enabled(ssl));
 #endif
 #if defined(MBEDTLS_SSL_PROTO_TLS1_2)
-        propose_tls12 ||
+    write_sig_alg_ext = write_sig_alg_ext || propose_tls12;
 #endif
-        0) {
+
+    if (write_sig_alg_ext) {
         ret = mbedtls_ssl_write_sig_alg_ext(ssl, p, end, &output_len);
         if (ret != 0) {
             return ret;

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -4578,13 +4578,14 @@ static int ssl_context_load(mbedtls_ssl_context *ssl,
      * We can't check that the config matches the initial one, but we can at
      * least check it matches the requirements for serializing.
      */
-    if (ssl->conf->transport != MBEDTLS_SSL_TRANSPORT_DATAGRAM ||
-        ssl->conf->max_tls_version < MBEDTLS_SSL_VERSION_TLS1_2 ||
-        ssl->conf->min_tls_version > MBEDTLS_SSL_VERSION_TLS1_2 ||
+    if (
 #if defined(MBEDTLS_SSL_RENEGOTIATION)
         ssl->conf->disable_renegotiation != MBEDTLS_SSL_RENEGOTIATION_DISABLED ||
 #endif
-        0) {
+        ssl->conf->transport != MBEDTLS_SSL_TRANSPORT_DATAGRAM ||
+        ssl->conf->max_tls_version < MBEDTLS_SSL_VERSION_TLS1_2 ||
+        ssl->conf->min_tls_version > MBEDTLS_SSL_VERSION_TLS1_2
+        ) {
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 


### PR DESCRIPTION
## Description

Fix a couple of warnings that emerge when compiling with `clang-18 -std=c23`

- [x] **changelog** not significant enough for a changelog
- [x] **backport** not a bugfix
- [x] **tests** covered by existing
