### PR TITLE
Backport 2.28: Remove unneeded setting of ret from ssl programs

### DIFF
--- a/programs/ssl/dtls_client.c
+++ b/programs/ssl/dtls_client.c
@@ -294,7 +294,6 @@ send_request:
 
             case MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY:
                 mbedtls_printf(" connection was closed gracefully\n");
-                ret = 0;
                 goto close_notify;
 
             default:

--- a/programs/ssl/dtls_server.c
+++ b/programs/ssl/dtls_server.c
@@ -331,7 +331,6 @@ reset:
 
             case MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY:
                 printf(" connection was closed gracefully\n");
-                ret = 0;
                 goto close_notify;
 
             default:

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -3437,7 +3437,6 @@ data_exchange:
             switch (ret) {
                 case MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY:
                     mbedtls_printf(" connection was closed gracefully\n");
-                    ret = 0;
                     goto close_notify;
 
                 default:


### PR DESCRIPTION
## Description

Remove coverity warnings on unused values. Trivial backport of #8217 

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [ ] **changelog** ~~provided, or~~ not required (minor change in example programs)
- [ ] **backport** ~~done, or~~ not required~~ (This is the backport)
- [ ] **tests** ~~provided, or~~ not required (minor change in programs)