### PR TITLE
MSVC error C4703

### DIFF
--- a/library/pkwrite.c
+++ b/library/pkwrite.c
@@ -379,7 +379,7 @@ int mbedtls_pk_write_pubkey_der(const mbedtls_pk_context *key, unsigned char *bu
 #if defined(MBEDTLS_PK_HAVE_ECC_KEYS)
     mbedtls_ecp_group_id ec_grp_id = MBEDTLS_ECP_DP_NONE;
 #endif
-    const char *oid;
+    const char *oid = NULL;
 
     if (size == 0) {
         return MBEDTLS_ERR_ASN1_BUF_TOO_SMALL;

--- a/library/pkwrite.c
+++ b/library/pkwrite.c
@@ -372,7 +372,7 @@ int mbedtls_pk_write_pubkey(unsigned char **p, unsigned char *start,
 int mbedtls_pk_write_pubkey_der(const mbedtls_pk_context *key, unsigned char *buf, size_t size)
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
-    unsigned char *c;
+    unsigned char *c = NULL;
     int has_par = 1;
     size_t len = 0, par_len = 0, oid_len = 0;
     mbedtls_pk_type_t pk_type;


### PR DESCRIPTION
pkwrite.c(458): error C4703: 使用了可能未初始化的本地指针变量“oid”

Signed-off-by: correy 112426112@qq.com