### PR TITLE
Fix MSVC error C4703 about possibly uninitialized variable in pkwrite.c

### DIFF
--- a/library/pkwrite.c
+++ b/library/pkwrite.c
@@ -379,7 +379,7 @@ int mbedtls_pk_write_pubkey_der(const mbedtls_pk_context *key, unsigned char *bu
 #if defined(MBEDTLS_PK_HAVE_ECC_KEYS)
     mbedtls_ecp_group_id ec_grp_id = MBEDTLS_ECP_DP_NONE;
 #endif
-    const char *oid;
+    const char *oid = NULL;
 
     if (size == 0) {
         return MBEDTLS_ERR_ASN1_BUF_TOO_SMALL;


### PR DESCRIPTION
(Note: previous contents of this comment were the contents of the `library/pkwrite.c` file itself; they have been deleted)

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [ ] **changelog**  is it required?
- [ ] **backport** not required - not an issue in LTS
- [ ] **tests** not required