### PR TITLE
Remove unused variable and unreachable return from mbedtls_pk_write_key_der()

### DIFF
--- a/library/pkwrite.c
+++ b/library/pkwrite.c
@@ -688,7 +688,6 @@ end_of_export:
 int mbedtls_pk_write_key_der(const mbedtls_pk_context *key, unsigned char *buf, size_t size)
 {
     unsigned char *c;
-    size_t len = 0;
 #if defined(MBEDTLS_RSA_C)
     int is_rsa_opaque = 0;
 #endif /* MBEDTLS_RSA_C */
@@ -733,8 +732,6 @@ int mbedtls_pk_write_key_der(const mbedtls_pk_context *key, unsigned char *buf, 
     } else
 #endif /* MBEDTLS_PK_HAVE_ECC_KEYS */
     return MBEDTLS_ERR_PK_FEATURE_UNAVAILABLE;
-
-    return (int) len;
 }
 
 #if defined(MBEDTLS_PEM_WRITE_C)


### PR DESCRIPTION
## Description

I'm sure some compiler/static analysis tool will complain about these at some point.

Oh, wait:

```
Microsoft (R) C/C++ Optimizing Compiler Version 19.29.30140 for x64
Copyright (C) Microsoft Corporation.  All rights reserved.

pkwrite.c
D:\home\tom\projects\mbedtls\master\library\pkwrite.c(737) : error C4702: unreachable code
```

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [ ] **changelog** don't think it's required - internal change
- [ ] **backport** this is more complicated, as this function has been much simplified in`development` - will look at it if this change is accepted
- [ ] **tests** not required
