### PR TITLE
Update TF-M config

### DIFF
--- a/configs/tfm_mbedcrypto_config_profile_medium.h
+++ b/configs/tfm_mbedcrypto_config_profile_medium.h
@@ -457,45 +457,6 @@
 #define MBEDTLS_MEMORY_BUFFER_ALLOC_C
 
 /**
- * \def MBEDTLS_PK_C
- *
- * Enable the generic public (asymetric) key layer.
- *
- * Module:  library/pk.c
- *
- * Requires: MBEDTLS_RSA_C or MBEDTLS_ECP_C
- *
- * Uncomment to enable generic public key wrappers.
- */
-#define MBEDTLS_PK_C
-
-/**
- * \def MBEDTLS_PK_PARSE_C
- *
- * Enable the generic public (asymetric) key parser.
- *
- * Module:  library/pkparse.c
- *
- * Requires: MBEDTLS_PK_C
- *
- * Uncomment to enable generic public key parse functions.
- */
-#define MBEDTLS_PK_PARSE_C
-
-/**
- * \def MBEDTLS_PK_WRITE_C
- *
- * Enable the generic public (asymetric) key writer.
- *
- * Module:  library/pkwrite.c
- *
- * Requires: MBEDTLS_PK_C
- *
- * Uncomment to enable generic public key write functions.
- */
-#define MBEDTLS_PK_WRITE_C
-
-/**
  * \def MBEDTLS_PLATFORM_C
  *
  * Enable the platform abstraction layer that allows you to re-assign

--- a/configs/tfm_mbedcrypto_config_profile_medium.h
+++ b/configs/tfm_mbedcrypto_config_profile_medium.h
@@ -408,6 +408,39 @@
 #define MBEDTLS_HKDF_C /* Used for HUK deriviation */
 
 /**
+ * \def MBEDTLS_MD_C
+ *
+ * Enable the generic layer for message digest (hashing) and HMAC.
+ *
+ * Requires: one of: MBEDTLS_MD5_C, MBEDTLS_RIPEMD160_C, MBEDTLS_SHA1_C,
+ *                   MBEDTLS_SHA224_C, MBEDTLS_SHA256_C, MBEDTLS_SHA384_C,
+ *                   MBEDTLS_SHA512_C, or MBEDTLS_PSA_CRYPTO_C with at least
+ *                   one hash.
+ * Module:  library/md.c
+ * Caller:  library/constant_time.c
+ *          library/ecdsa.c
+ *          library/ecjpake.c
+ *          library/hkdf.c
+ *          library/hmac_drbg.c
+ *          library/pk.c
+ *          library/pkcs5.c
+ *          library/pkcs12.c
+ *          library/psa_crypto_ecp.c
+ *          library/psa_crypto_rsa.c
+ *          library/rsa.c
+ *          library/ssl_cookie.c
+ *          library/ssl_msg.c
+ *          library/ssl_tls.c
+ *          library/x509.c
+ *          library/x509_crt.c
+ *          library/x509write_crt.c
+ *          library/x509write_csr.c
+ *
+ * Uncomment to enable generic message digest wrappers.
+ */
+#define MBEDTLS_MD_C
+
+/**
  * \def MBEDTLS_MEMORY_BUFFER_ALLOC_C
  *
  * Enable the buffer allocator implementation that makes use of a (stack)


### PR DESCRIPTION
## Description

This brings our copy of the TF-M config closer to the upstream version by removing PK, as per https://git.trustedfirmware.org/TF-M/trusted-firmware-m.git/tree/lib/ext/mbedcrypto/mbedcrypto_config/tfm_mbedcrypto_config_profile_medium.h?id=8a5469cb2469cbddc2977003aa4b6e480503a374

Also, set `MBEDTLS_MD_C`, because this is required by `MBEDTLS_HKDF_C` (which they do set). (Leaving it unset generally works thanks to `config_adjust_legacy_from_psa.h`, but if `PSA_WANT_ALG_DETERMINISTIC_ECDSA` is unset then it doesn't get set automatically and therefore breaks).

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required
- [x] **backport** not required
- [x] **tests** not required



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.
