### PR TITLE
Remove all travis builds except for coverity_scan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,185 +1,21 @@
 # Declare python as our language. This way we get our chosen Python version,
 # and pip is available. Gcc and clang are available anyway.
+distro: xenial
+os: linux
 language: python
 python: 3.5
-sudo: false
+
 cache: ccache
 
-jobs:
-  include:
-    - name: basic checks and reference configurations
-      addons:
-        apt:
-          packages:
-          - gnutls-bin
-          - doxygen
-          - graphviz
-          - gcc-arm-none-eabi
-          - libnewlib-arm-none-eabi
-          - gcc-arm-linux-gnueabi
-          - libc6-dev-armel-cross
-      script:
-        - tests/scripts/all.sh -k 'check_*'
-        - tests/scripts/all.sh -k test_default_out_of_box
-        - tests/scripts/all.sh -k test_ref_configs
-        - tests/scripts/all.sh -k build_arm_linux_gnueabi_gcc_arm5vte build_arm_none_eabi_gcc_m0plus
-
-    - name: full configuration
-      os: linux
-      dist: focal
-      addons:
-        apt:
-          packages:
-          - clang-10
-          - gnutls-bin
-      env:
-        # Platform tests have an allocation that returns null
-        - ASAN_OPTIONS="allocator_may_return_null=1"
-        - MSAN_OPTIONS="allocator_may_return_null=1"
-      script:
-        # Do a manual build+test sequence rather than using all.sh,
-        # because there's no all.sh component that does what we want,
-        # which is a build with Clang >= 10 and ASan, running all the SSL
-        # testing.
-        #   - The clang executable in the default PATH is Clang 7 on
-        #     Travis's focal instances, but we want Clang >= 10.
-        #   - Running all the SSL testing requires a specific set of
-        #     OpenSSL and GnuTLS versions and we don't want to bother
-        #     with those on Travis.
-        # So we explicitly select clang-10 as the compiler, and we
-        # have ad hoc restrictions on SSL testing based on what is
-        # passing at the time of writing. We will remove these limitations
-        # gradually.
-        - make generated_files
-        - make CC=clang-10 CFLAGS='-Werror -Wall -Wextra -fsanitize=address,undefined -fno-sanitize-recover=all -O2' LDFLAGS='-Werror -Wall -Wextra -fsanitize=address,undefined -fno-sanitize-recover=all'
-        - make test
-        - programs/test/selftest
-        - tests/scripts/test_psa_constant_names.py
-        - tests/ssl-opt.sh
-        # Modern OpenSSL does not support null ciphers.
-        - tests/compat.sh -p OpenSSL -e 'NULL'
-        - tests/scripts/travis-log-failure.sh
-        # GnuTLS supports CAMELLIA but compat.sh doesn't properly enable it.
-        - tests/compat.sh -p GnuTLS -e 'CAMELLIA'
-        - tests/scripts/travis-log-failure.sh
-        - tests/context-info.sh
-
-    - name: Windows
-      os: windows
-      # The language 'python' is currently unsupported on the
-      # Windows Build Environment. And 'generic' causes the job to get stuck
-      # on "Booting virtual machine".
-      language: c
-      before_install:
-        - choco install python --version=3.5.4
-      env:
-        # Add the directory where the Choco packages go
-        - PATH=/c/Python35:/c/Python35/Scripts:$PATH
-        - PYTHON=python.exe
-      script:
-        - type perl; perl --version
-        - type python; python --version
-        - scripts/make_generated_files.bat
-        # Logs appear out of sequence on Windows. Give time to catch up.
-        - sleep 5
-        - scripts/windows_msbuild.bat v141 # Visual Studio 2017
-        - visualc/VS2013/x64/Release/selftest.exe
-
-    - name: full configuration on arm64
-      os: linux
-      dist: focal
-      arch: arm64
-      addons:
-        apt:
-          packages:
-          - gcc
-      env:
-        # Platform tests have an allocation that returns null
-        - ASAN_OPTIONS="allocator_may_return_null=1"
-        - MSAN_OPTIONS="allocator_may_return_null=1"
-      script:
-        # Do a manual build+test sequence rather than using all.sh.
-        #
-        # On Arm64 host of Travis CI, the time of `test_full_cmake_*` exceeds
-        # limitation of Travis CI. Base on `test_full_cmake_*`, we removed
-        # `ssl-opt.sh` and GnuTLS compat.sh here to meet the time limitation.
-        - scripts/config.py full
-        - make generated_files
-        - make CFLAGS='-O3 -Werror -fsanitize=address,undefined -fno-sanitize-recover=all' LDFLAGS='-Werror -fsanitize=address,undefined -fno-sanitize-recover=all'
-        - make test
-        - programs/test/selftest
-        - tests/scripts/test_psa_constant_names.py
-        # Modern OpenSSL does not support fixed ECDH or null ciphers.
-        - tests/compat.sh -p OpenSSL -e 'NULL\|ECDH_'
-        - tests/scripts/travis-log-failure.sh
-        - tests/context-info.sh
-
-    - name: full configuration(GnuTLS compat tests) on arm64
-      os: linux
-      dist: focal
-      arch: arm64
-      addons:
-        apt:
-          packages:
-          - clang
-          - gnutls-bin
-      env:
-        # Platform tests have an allocation that returns null
-        - ASAN_OPTIONS="allocator_may_return_null=1"
-        - MSAN_OPTIONS="allocator_may_return_null=1"
-      script:
-        # Do a manual build+test sequence rather than using all.sh.
-        #
-        # On Arm64 host of Travis CI, the time of `test_full_cmake_*` exceeds
-        # limitation of Travis CI. Base on `test_full_cmake_*`, we removed
-        # `ssl-opt.sh` and OpenSSl compat.sh here to meet the time limitation.
-        - scripts/config.py full
-        - make generated_files
-        - make CC=clang CFLAGS='-O3 -Werror -fsanitize=address,undefined -fno-sanitize-recover=all' LDFLAGS='-Werror -fsanitize=address,undefined -fno-sanitize-recover=all'
-        # GnuTLS supports CAMELLIA but compat.sh doesn't properly enable it.
-        - tests/compat.sh -p GnuTLS -e 'CAMELLIA'
-        - tests/scripts/travis-log-failure.sh
-        - tests/context-info.sh
-
-    - name: Arm64 accelerators tests on arm64 host
-      os: linux
-      dist: focal
-      arch: arm64
-      addons:
-        apt:
-          packages:
-          - gcc
-      script:
-        # Do a manual build+test sequence rather than using all.sh.
-        #
-        # This is arm64 host only test for no runtime detection case. Internal
-        # and Open CI do not include Arm64 host, and they check if components
-        # are be tested. As result, it will always fail on `pre-test-check` in
-        # them.
-        - scripts/config.py unset MBEDTLS_AESNI_C
-        - scripts/config.py unset MBEDTLS_PADLOCK_C
-        - scripts/config.py set MBEDTLS_AESCE_C
-        - scripts/config.py set MBEDTLS_AES_USE_HARDWARE_ONLY
-        - make generated_files
-        - make
-        - programs/test/selftest aes | grep "using AESCE"
-        - tests/context-info.sh
-
-after_failure:
-- tests/scripts/travis-log-failure.sh
+branches:
+  only:
+    coverity_scan
 
 env:
   global:
     - SEED=1
     - secure: "GF/Fde5fkm15T/RNykrjrPV5Uh1KJ70cP308igL6Xkk3eJmqkkmWCe9JqRH12J3TeWw2fu9PYPHt6iFSg6jasgqysfUyg+W03knRT5QNn3h5eHgt36cQJiJr6t3whPrRaiM6U9omE0evm+c0cAwlkA3GGSMw8Z+na4EnKI6OFCo="
-
-install:
-  - $PYTHON scripts/min_requirements.py
-
 addons:
-  apt:
-    packages:
-    - gnutls-bin
   coverity_scan:
     project:
       name: "ARMmbed/mbedtls"


### PR DESCRIPTION
## Description

Remove all travis builds, except for the coverity_scan push. This has to be done in time for our paid plan to run out at the end of the month. Travis has already been set as not required for green CI, so this should not affect anyone.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [ ] **changelog** ~~provided, or~~ not required (not a code change)
- [ ] **backport** done ~~, or not required~~ #8245 
- [ ] **tests** ~~provided, or~~ not required (build system only)
