### PR TITLE
[Backport 2.28] Remove all travis builds except for coverity_scan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,93 +1,19 @@
+distro: xenial
+os: linux
 language: c
 compiler: gcc
-sudo: false
+
 cache: ccache
 
-jobs:
-  include:
-    - name: basic checks and reference configurations
-      addons:
-        apt:
-          packages:
-          - gnutls-bin
-          - doxygen
-          - graphviz
-          - gcc-arm-none-eabi
-          - libnewlib-arm-none-eabi
-          - gcc-arm-linux-gnueabi
-          - libc6-dev-armel-cross
-      language: python # Needed to get pip for Python 3
-      python: 3.5 # version from Ubuntu 16.04
-      install:
-        - scripts/min_requirements.py
-      script:
-        - tests/scripts/all.sh -k 'check_*'
-        - tests/scripts/all.sh -k test_default_out_of_box
-        - tests/scripts/all.sh -k test_ref_configs
-        - tests/scripts/all.sh -k build_arm_linux_gnueabi_gcc_arm5vte build_arm_none_eabi_gcc_m0plus
-
-    - name: full configuration
-      os: linux
-      dist: focal
-      addons:
-        apt:
-          packages:
-          - clang-10
-          - gnutls-bin
-      env:
-        # Platform tests have an allocation that returns null
-        - ASAN_OPTIONS="allocator_may_return_null=1"
-        - MSAN_OPTIONS="allocator_may_return_null=1"
-      script:
-        # Do a manual build+test sequence rather than using all.sh,
-        # because there's no all.sh component that does what we want,
-        # which is a build with Clang >= 10 and ASan, running all the SSL
-        # testing.
-        #   - The clang executable in the default PATH is Clang 7 on
-        #     Travis's focal instances, but we want Clang >= 10.
-        #   - Running all the SSL testing requires a specific set of
-        #     OpenSSL and GnuTLS versions and we don't want to bother
-        #     with those on Travis.
-        # So we explicitly select clang-10 as the compiler, and we
-        # have ad hoc restrictions on SSL testing based on what is
-        # passing at the time of writing. We will remove these limitations
-        # gradually.
-        - make CC=clang-10 CFLAGS='-Werror -Wall -Wextra -fsanitize=address,undefined -fno-sanitize-recover=all -O2' LDFLAGS='-Werror -Wall -Wextra -fsanitize=address,undefined -fno-sanitize-recover=all'
-        - make test
-        - programs/test/selftest
-        - tests/scripts/test_psa_constant_names.py
-        # Exclude a few test cases that are failing mysteriously.
-        # https://github.com/Mbed-TLS/mbedtls/issues/6660
-        - tests/ssl-opt.sh -e 'Fallback SCSV:\ .*list'
-        # Modern OpenSSL does not support null or ancient ciphers.
-        - tests/compat.sh -p OpenSSL -e 'NULL\|DES\|RC4'
-        - tests/scripts/travis-log-failure.sh
-        # GnuTLS supports CAMELLIA but compat.sh doesn't properly enable it.
-        # Modern GnuTLS does not support DES.
-        # One NULL cipher suite is strangely missing in pre-1.2 protocol
-        # versions (it works with (D)TLS1.2, but don't bother).
-        - tests/compat.sh -p GnuTLS -e 'CAMELLIA\|DES\|TLS-RSA-WITH-NULL-SHA256'
-        - tests/scripts/travis-log-failure.sh
-        - tests/context-info.sh
-
-    - name: Windows
-      os: windows
-      script:
-        - scripts/windows_msbuild.bat v141 # Visual Studio 2017
-        - visualc/VS2010/x64/Release/selftest.exe --ci
-
-after_failure:
-- tests/scripts/travis-log-failure.sh
+branches:
+  only:
+    coverity_scan
 
 env:
   global:
     - SEED=1
-    - secure: "JECCru6HASpKZ0OLfHh8f/KXhKkdrCwjquZghd/qbA4ksxsWImjR7KEPERcaPndXEilzhDbKwuFvJiQX2duVgTGoq745YGhLZIjzo1i8tySkceCVd48P8WceYGz+F/bmY7r+m6fFNuxDSoGGSVeA4Lnjvmm8PFUP45YodDV9no4="
-
+    - secure: "GF/Fde5fkm15T/RNykrjrPV5Uh1KJ70cP308igL6Xkk3eJmqkkmWCe9JqRH12J3TeWw2fu9PYPHt6iFSg6jasgqysfUyg+W03knRT5QNn3h5eHgt36cQJiJr6t3whPrRaiM6U9omE0evm+c0cAwlkA3GGSMw8Z+na4EnKI6OFCo="
 addons:
-  apt:
-    packages:
-    - gnutls-bin
   coverity_scan:
     project:
       name: "ARMmbed/mbedtls"


### PR DESCRIPTION
## Description

Remove all travis builds except for the coverity_scan push. This needs to be done prior to our paid plan expiring at the end of the month.

Backport of #8244 

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [ ] **changelog** ~~provided, or~~ not required (not a code change)
- [ ] **backport** ~~done, or~~ not required (this is the backport)
- [ ] **tests** ~~provided, or~~ not required (not a code change)

