### PR TITLE
types-jsonschema 4.19.0.0 breaks Python 3.5

### DIFF
--- a/scripts/driver.requirements.txt
+++ b/scripts/driver.requirements.txt
@@ -15,5 +15,9 @@ Jinja2 >= 2.10.1; python_version <  '3.10'
 Jinja2 >= 2.10.3; python_version >= '3.10'
 # Jinja2 >=2.10, <3.0 needs a separate package for type annotations
 types-Jinja2
+
 jsonschema >= 3.2.0
-types-jsonschema
+# types-jsonschema 4.19.0.0 doesn't work with Python 3.5 but doesn't declare
+# that dependency.
+types-jsonschema < 4.19; python_version < '3.6'
+types-jsonschema; python_version >= '3.6'


### PR DESCRIPTION
types-jsonschema 4.19.0.0 doesn't work with Python 3.5 but doesn't declare that dependency. Require an older version on older Python.

This should fix the `check_python_files` component on the CI, which broke when types-jsonschema 4.19.0.0 was released.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required
- [x] **backport** not required (no jsonschema in 2.28)
- [x] **tests** CI must pass
