### PR TITLE
[Backport 2.28] Re-add python install of requirements to Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,18 @@
-distro: xenial
+# Declare python as our language. This way we get our chosen Python version,
+# and pip is available. Gcc and clang are available anyway.
+dist: jammy
 os: linux
-language: c
-compiler: gcc
+language: python
+python: 3.10
 
 cache: ccache
 
 branches:
   only:
     coverity_scan
+
+install:
+  - $PYTHON scripts/min_requirements.py
 
 env:
   global:


### PR DESCRIPTION
## Description

Re-add the python dependancies installation to Travis CI, also correct 'distro to 'dist' and update ubuntu to focal in line with previous Travis settings. Too much got removed when disabling travis and the Coverity scan build was failing on 'make generated-files', due to lack of installed python dependencies.

Trivial backport of #8253 

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [ ] **changelog** ~~provided, or~~ not required (no user facing change)
- [ ] **backport** ~~done, or not required (This is the backport)
- [ ] **tests** ~~provided, or~~ not required
