### PR TITLE
Add CMake include path for generated header

### DIFF
--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -323,7 +323,9 @@ foreach(target IN LISTS target_libraries)
     target_include_directories(${target}
         PUBLIC $<BUILD_INTERFACE:${MBEDTLS_DIR}/include/>
                $<INSTALL_INTERFACE:include/>
-        PRIVATE ${MBEDTLS_DIR}/library/)
+        PRIVATE ${MBEDTLS_DIR}/library/
+                # Needed to include psa_crypto_driver_wrappers.h
+                ${CMAKE_CURRENT_BINARY_DIR})
     # Pass-through MBEDTLS_CONFIG_FILE and MBEDTLS_USER_CONFIG_FILE
     if(MBEDTLS_CONFIG_FILE)
         target_compile_definitions(${target}

--- a/programs/test/cmake_package/CMakeLists.txt
+++ b/programs/test/cmake_package/CMakeLists.txt
@@ -13,7 +13,9 @@ execute_process(
         "-H${MbedTLS_SOURCE_DIR}"
         "-B${MbedTLS_BINARY_DIR}"
         "-DENABLE_PROGRAMS=NO"
-        "-DENABLE_TESTING=NO")
+        "-DENABLE_TESTING=NO"
+        # Turn on generated files explicitly in case this is a release
+        "-DGEN_FILES=ON")
 
 execute_process(
     COMMAND "${CMAKE_COMMAND}"

--- a/programs/test/cmake_package_install/CMakeLists.txt
+++ b/programs/test/cmake_package_install/CMakeLists.txt
@@ -15,6 +15,8 @@ execute_process(
         "-B${MbedTLS_BINARY_DIR}"
         "-DENABLE_PROGRAMS=NO"
         "-DENABLE_TESTING=NO"
+        # Turn on generated files explicitly in case this is a release
+        "-DGEN_FILES=ON"
         "-DCMAKE_INSTALL_PREFIX=${MbedTLS_INSTALL_DIR}")
 
 execute_process(

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -5176,7 +5176,7 @@ support_test_cmake_out_of_source () {
 }
 
 component_test_cmake_out_of_source () {
-    # remove existing generated files so that we use the ones cmake
+    # Remove existing generated files so that we use the ones cmake
     # generates
     make neat
 

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -5222,8 +5222,13 @@ support_test_cmake_as_subdirectory () {
 }
 
 component_test_cmake_as_package () {
+    # Remove existing generated files so that we use the ones CMake
+    # generates
+    make neat
+
     msg "build: cmake 'as-package' build"
     cd programs/test/cmake_package
+    # Note: Explicitly generate files as these are turned off in releases
     cmake .
     make
     ./cmake_package
@@ -5233,8 +5238,13 @@ support_test_cmake_as_package () {
 }
 
 component_test_cmake_as_package_install () {
+    # Remove existing generated files so that we use the ones CMake
+    # generates
+    make neat
+
     msg "build: cmake 'as-installed-package' build"
     cd programs/test/cmake_package_install
+    # Note: Explicitly generate files as these are turned off in releases
     cmake .
     make
     ./cmake_package_install

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -5228,7 +5228,6 @@ component_test_cmake_as_package () {
 
     msg "build: cmake 'as-package' build"
     cd programs/test/cmake_package
-    # Note: Explicitly generate files as these are turned off in releases
     cmake .
     make
     ./cmake_package
@@ -5244,7 +5243,6 @@ component_test_cmake_as_package_install () {
 
     msg "build: cmake 'as-installed-package' build"
     cd programs/test/cmake_package_install
-    # Note: Explicitly generate files as these are turned off in releases
     cmake .
     make
     ./cmake_package_install

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -5176,11 +5176,16 @@ support_test_cmake_out_of_source () {
 }
 
 component_test_cmake_out_of_source () {
+    # remove existing generated files so that we use the ones cmake
+    # generates
+    make neat
+
     msg "build: cmake 'out-of-source' build"
     MBEDTLS_ROOT_DIR="$PWD"
     mkdir "$OUT_OF_SOURCE_DIR"
     cd "$OUT_OF_SOURCE_DIR"
-    cmake -D CMAKE_BUILD_TYPE:String=Check "$MBEDTLS_ROOT_DIR"
+    # Note: Explicitly generate files as these are turned off in releases
+    cmake -D CMAKE_BUILD_TYPE:String=Check -D GEN_FILES=ON "$MBEDTLS_ROOT_DIR"
     make
 
     msg "test: cmake 'out-of-source' build"
@@ -5201,9 +5206,14 @@ component_test_cmake_out_of_source () {
 }
 
 component_test_cmake_as_subdirectory () {
+    # Remove existing generated files so that we use the ones CMake
+    # generates
+    make neat
+
     msg "build: cmake 'as-subdirectory' build"
     cd programs/test/cmake_subproject
-    cmake .
+    # Note: Explicitly generate files as these are turned off in releases
+    cmake -D GEN_FILES=ON .
     make
     ./cmake_subproject
 }


### PR DESCRIPTION
Fix a build error from #7980 when building out-of-source with CMake and generating files

Now that we are generating `psa_crypto_driver_wrappers.h`, we need to pass `build/library` as an include directory.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required - build problem never released
- [x] **backport** not required - error was introduced in `development` only
- [x] **tests** provided - modified `all.sh` components to catch this
