### PR TITLE
Disable MBEDTLS_PSA_CRYPTO_SPM in our TF-M config

### DIFF
--- a/configs/tfm_mbedcrypto_config_profile_medium.h
+++ b/configs/tfm_mbedcrypto_config_profile_medium.h
@@ -270,7 +270,7 @@
  * Requires: MBEDTLS_PSA_CRYPTO_C
  *
  */
-#define MBEDTLS_PSA_CRYPTO_SPM
+//#define MBEDTLS_PSA_CRYPTO_SPM
 
 /**
  * \def MBEDTLS_SHA256_SMALLER


### PR DESCRIPTION
## Description

Follow-up to #8260 - that change means that we can't build our TF-M config out of the box (which breaks our size measurement tools).

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required - minor change to example config
- [x] **backport** not required - not in 2.28
- [x] **tests** not required



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.
