### PR TITLE
code_size_compare: disable PSA_CRYPTO_SPM for TF-M code size measurement

### DIFF
--- a/scripts/code_size_compare.py
+++ b/scripts/code_size_compare.py
@@ -164,10 +164,14 @@ CRYPTO_CONFIG_H = 'include/psa/crypto_config.h'
 BACKUP_SUFFIX = '.code_size.bak'
 
 CONFIG_SCRIPT = './scripts/config.py'
-CONFIG_UNSET = 'unset'
-CONFIG_MACROS = [
-    'MBEDTLS_PSA_CRYPTO_SPM',
+TFM_SET_CONFIGS = [] # type: typing.List[str]
+TFM_UNSET_CONFIGS = [
+    'MBEDTLS_PSA_CRYPTO_SPM', # we can't build our TF-M config out of the box if this enabled
 ]
+TFM_CONFIG_CHECKLIST = {
+    "set": TFM_SET_CONFIGS,
+    "unset": TFM_UNSET_CONFIGS,
+}
 
 class CodeSizeBuildInfo: # pylint: disable=too-few-public-methods
     """Gather information used to measure code size.
@@ -236,11 +240,11 @@ class CodeSizeBuildInfo: # pylint: disable=too-few-public-methods
             pre_make_cmd.append('cp {src} {dest}'
                                 .format(src=TFM_MEDIUM_CRYPTO_CONFIG_H,
                                         dest=CRYPTO_CONFIG_H))
-            for macro in CONFIG_MACROS:
-                pre_make_cmd.append('{script} {opt} {macro}'
-                                    .format(script=CONFIG_SCRIPT,
-                                            opt=CONFIG_UNSET,
-                                            macro=macro))
+            for opt, configs in TFM_CONFIG_CHECKLIST.items():
+                for config in configs:
+                    pre_make_cmd.append('{script} {opt} {config}'
+                                        .format(script=CONFIG_SCRIPT,
+                                                opt=opt, config=config))
 
         return pre_make_cmd
 

--- a/scripts/code_size_compare.py
+++ b/scripts/code_size_compare.py
@@ -163,6 +163,12 @@ CONFIG_H = 'include/mbedtls/mbedtls_config.h'
 CRYPTO_CONFIG_H = 'include/psa/crypto_config.h'
 BACKUP_SUFFIX = '.code_size.bak'
 
+CONFIG_SCRIPT = './scripts/config.py'
+CONFIG_UNSET = 'unset'
+CONFIG_MACROS = [
+    'MBEDTLS_PSA_CRYPTO_SPM',
+]
+
 class CodeSizeBuildInfo: # pylint: disable=too-few-public-methods
     """Gather information used to measure code size.
 
@@ -230,6 +236,11 @@ class CodeSizeBuildInfo: # pylint: disable=too-few-public-methods
             pre_make_cmd.append('cp {src} {dest}'
                                 .format(src=TFM_MEDIUM_CRYPTO_CONFIG_H,
                                         dest=CRYPTO_CONFIG_H))
+            for macro in CONFIG_MACROS:
+                pre_make_cmd.append('{script} {opt} {macro}'
+                                    .format(script=CONFIG_SCRIPT,
+                                            opt=CONFIG_UNSET,
+                                            macro=macro))
 
         return pre_make_cmd
 


### PR DESCRIPTION
## Description

We can't measure code size when PSA_CRYPTO_SPM is enabled, so unset this macro for TF-M code size measurement.
See https://github.com/Mbed-TLS/mbedtls/pull/8265#discussion_r1339785785

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required
- [x] **backport** not required
- [x] **tests** not required

