### PR TITLE
Fix error handling in psa_driver_wrapper_xxx_hash_get_num_ops

### DIFF
--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -3470,7 +3470,9 @@ psa_status_t psa_sign_hash_complete(
                                                    signature_length);
 
     /* Update ops count with work done. */
-    operation->num_ops = psa_driver_wrapper_sign_hash_get_num_ops(operation);
+    if (status == PSA_SUCCESS) {
+        status = psa_driver_wrapper_sign_hash_get_num_ops(operation, &operation->num_ops);
+    }
 
 exit:
 
@@ -3601,8 +3603,9 @@ psa_status_t psa_verify_hash_complete(
     status = psa_driver_wrapper_verify_hash_complete(operation);
 
     /* Update ops count with work done. */
-    operation->num_ops = psa_driver_wrapper_verify_hash_get_num_ops(
-        operation);
+    if (status == PSA_SUCCESS) {
+        status = psa_driver_wrapper_verify_hash_get_num_ops(operation, &operation->num_ops);
+    }
 
 exit:
 

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -3448,6 +3448,7 @@ psa_status_t psa_sign_hash_complete(
     size_t *signature_length)
 {
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
+    psa_status_t numops_status = PSA_ERROR_CORRUPTION_DETECTED;
 
     *signature_length = 0;
 
@@ -3470,8 +3471,9 @@ psa_status_t psa_sign_hash_complete(
                                                    signature_length);
 
     /* Update ops count with work done. */
+    numops_status = psa_driver_wrapper_sign_hash_get_num_ops(operation, &operation->num_ops);
     if (status == PSA_SUCCESS) {
-        status = psa_driver_wrapper_sign_hash_get_num_ops(operation, &operation->num_ops);
+        status = numops_status;
     }
 
 exit:
@@ -3592,6 +3594,7 @@ psa_status_t psa_verify_hash_complete(
     psa_verify_hash_interruptible_operation_t *operation)
 {
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
+    psa_status_t numops_status = PSA_ERROR_CORRUPTION_DETECTED;
 
     /* Check that start has been called first, and that operation has not
      * previously errored. */
@@ -3603,8 +3606,9 @@ psa_status_t psa_verify_hash_complete(
     status = psa_driver_wrapper_verify_hash_complete(operation);
 
     /* Update ops count with work done. */
+    numops_status = psa_driver_wrapper_verify_hash_get_num_ops(operation, &operation->num_ops);
     if (status == PSA_SUCCESS) {
-        status = psa_driver_wrapper_verify_hash_get_num_ops(operation, &operation->num_ops);
+        status = numops_status;
     }
 
 exit:

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -3448,7 +3448,6 @@ psa_status_t psa_sign_hash_complete(
     size_t *signature_length)
 {
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
-    psa_status_t numops_status = PSA_ERROR_CORRUPTION_DETECTED;
 
     *signature_length = 0;
 
@@ -3471,10 +3470,7 @@ psa_status_t psa_sign_hash_complete(
                                                    signature_length);
 
     /* Update ops count with work done. */
-    numops_status = psa_driver_wrapper_sign_hash_get_num_ops(operation, &operation->num_ops);
-    if (status == PSA_SUCCESS) {
-        status = numops_status;
-    }
+    operation->num_ops = psa_driver_wrapper_sign_hash_get_num_ops(operation);
 
 exit:
 
@@ -3594,7 +3590,6 @@ psa_status_t psa_verify_hash_complete(
     psa_verify_hash_interruptible_operation_t *operation)
 {
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
-    psa_status_t numops_status = PSA_ERROR_CORRUPTION_DETECTED;
 
     /* Check that start has been called first, and that operation has not
      * previously errored. */
@@ -3606,10 +3601,8 @@ psa_status_t psa_verify_hash_complete(
     status = psa_driver_wrapper_verify_hash_complete(operation);
 
     /* Update ops count with work done. */
-    numops_status = psa_driver_wrapper_verify_hash_get_num_ops(operation, &operation->num_ops);
-    if (status == PSA_SUCCESS) {
-        status = numops_status;
-    }
+    operation->num_ops = psa_driver_wrapper_verify_hash_get_num_ops(
+        operation);
 
 exit:
 

--- a/scripts/data_files/driver_templates/psa_crypto_driver_wrappers.h.jinja
+++ b/scripts/data_files/driver_templates/psa_crypto_driver_wrappers.h.jinja
@@ -472,17 +472,19 @@ static inline psa_status_t psa_driver_wrapper_verify_hash(
     }
 }
 
-static inline uint32_t psa_driver_wrapper_sign_hash_get_num_ops(
-    psa_sign_hash_interruptible_operation_t *operation )
+static inline int psa_driver_wrapper_sign_hash_get_num_ops(
+    psa_sign_hash_interruptible_operation_t *operation, uint32_t *num_ops )
 {
     switch( operation->id )
     {
         /* If uninitialised, return 0, as no work can have been done. */
         case 0:
-            return 0;
+            *num_ops = 0;
+            return PSA_SUCCESS;
 
         case PSA_CRYPTO_MBED_TLS_DRIVER_ID:
-            return(mbedtls_psa_sign_hash_get_num_ops(&operation->ctx.mbedtls_ctx));
+            *num_ops = mbedtls_psa_sign_hash_get_num_ops(&operation->ctx.mbedtls_ctx);
+            return PSA_SUCCESS;
 
 #if defined(PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT)
 #if defined(PSA_CRYPTO_DRIVER_TEST)
@@ -495,17 +497,19 @@ static inline uint32_t psa_driver_wrapper_sign_hash_get_num_ops(
     return( PSA_ERROR_INVALID_ARGUMENT );
 }
 
-static inline uint32_t psa_driver_wrapper_verify_hash_get_num_ops(
-    psa_verify_hash_interruptible_operation_t *operation )
+static inline int psa_driver_wrapper_verify_hash_get_num_ops(
+    psa_verify_hash_interruptible_operation_t *operation, uint32_t *num_ops )
 {
     switch( operation->id )
     {
         /* If uninitialised, return 0, as no work can have been done. */
         case 0:
-            return 0;
+            *num_ops = 0;
+            return PSA_SUCCESS;
 
         case PSA_CRYPTO_MBED_TLS_DRIVER_ID:
-            return (mbedtls_psa_verify_hash_get_num_ops(&operation->ctx.mbedtls_ctx));
+            *num_ops = mbedtls_psa_verify_hash_get_num_ops(&operation->ctx.mbedtls_ctx);
+            return PSA_SUCCESS;
 
 #if defined(PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT)
 #if defined(PSA_CRYPTO_DRIVER_TEST)
@@ -516,7 +520,7 @@ static inline uint32_t psa_driver_wrapper_verify_hash_get_num_ops(
 
     }
 
-    return( PSA_ERROR_INVALID_ARGUMENT );
+    return ( PSA_ERROR_INVALID_ARGUMENT );
 }
 
 static inline psa_status_t psa_driver_wrapper_sign_hash_start(

--- a/scripts/data_files/driver_templates/psa_crypto_driver_wrappers.h.jinja
+++ b/scripts/data_files/driver_templates/psa_crypto_driver_wrappers.h.jinja
@@ -472,7 +472,7 @@ static inline psa_status_t psa_driver_wrapper_verify_hash(
     }
 }
 
-static inline int psa_driver_wrapper_sign_hash_get_num_ops(
+static inline psa_status_t psa_driver_wrapper_sign_hash_get_num_ops(
     psa_sign_hash_interruptible_operation_t *operation, uint32_t *num_ops )
 {
     switch( operation->id )
@@ -497,7 +497,7 @@ static inline int psa_driver_wrapper_sign_hash_get_num_ops(
     return( PSA_ERROR_INVALID_ARGUMENT );
 }
 
-static inline int psa_driver_wrapper_verify_hash_get_num_ops(
+static inline psa_status_t psa_driver_wrapper_verify_hash_get_num_ops(
     psa_verify_hash_interruptible_operation_t *operation, uint32_t *num_ops )
 {
     switch( operation->id )

--- a/scripts/data_files/driver_templates/psa_crypto_driver_wrappers.h.jinja
+++ b/scripts/data_files/driver_templates/psa_crypto_driver_wrappers.h.jinja
@@ -472,19 +472,17 @@ static inline psa_status_t psa_driver_wrapper_verify_hash(
     }
 }
 
-static inline psa_status_t psa_driver_wrapper_sign_hash_get_num_ops(
-    psa_sign_hash_interruptible_operation_t *operation, uint32_t *num_ops )
+static inline uint32_t psa_driver_wrapper_sign_hash_get_num_ops(
+    psa_sign_hash_interruptible_operation_t *operation )
 {
     switch( operation->id )
     {
         /* If uninitialised, return 0, as no work can have been done. */
         case 0:
-            *num_ops = 0;
-            return PSA_SUCCESS;
+            return 0;
 
         case PSA_CRYPTO_MBED_TLS_DRIVER_ID:
-            *num_ops = mbedtls_psa_sign_hash_get_num_ops(&operation->ctx.mbedtls_ctx);
-            return PSA_SUCCESS;
+            return(mbedtls_psa_sign_hash_get_num_ops(&operation->ctx.mbedtls_ctx));
 
 #if defined(PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT)
 #if defined(PSA_CRYPTO_DRIVER_TEST)
@@ -494,22 +492,21 @@ static inline psa_status_t psa_driver_wrapper_sign_hash_get_num_ops(
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
     }
 
-    return( PSA_ERROR_INVALID_ARGUMENT );
+    /* Can't happen (see discussion in #8271) */
+    return 0;
 }
 
-static inline psa_status_t psa_driver_wrapper_verify_hash_get_num_ops(
-    psa_verify_hash_interruptible_operation_t *operation, uint32_t *num_ops )
+static inline uint32_t psa_driver_wrapper_verify_hash_get_num_ops(
+    psa_verify_hash_interruptible_operation_t *operation )
 {
     switch( operation->id )
     {
         /* If uninitialised, return 0, as no work can have been done. */
         case 0:
-            *num_ops = 0;
-            return PSA_SUCCESS;
+            return 0;
 
         case PSA_CRYPTO_MBED_TLS_DRIVER_ID:
-            *num_ops = mbedtls_psa_verify_hash_get_num_ops(&operation->ctx.mbedtls_ctx);
-            return PSA_SUCCESS;
+            return (mbedtls_psa_verify_hash_get_num_ops(&operation->ctx.mbedtls_ctx));
 
 #if defined(PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT)
 #if defined(PSA_CRYPTO_DRIVER_TEST)
@@ -520,7 +517,8 @@ static inline psa_status_t psa_driver_wrapper_verify_hash_get_num_ops(
 
     }
 
-    return ( PSA_ERROR_INVALID_ARGUMENT );
+    /* Can't happen (see discussion in #8271) */
+    return 0;
 }
 
 static inline psa_status_t psa_driver_wrapper_sign_hash_start(


### PR DESCRIPTION
## Description

Fix broken error handling in psa_driver_wrapper_xxx_hash_get_num_ops

Does this count as an API break?

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required
- [x] **backport** not in 2.28
- [x] **tests** covered by existing
