### PR TITLE
Add `MBEDTLS_TARGET_PREFIX` to 3rdparty CMake

### DIFF
--- a/3rdparty/everest/CMakeLists.txt
+++ b/3rdparty/everest/CMakeLists.txt
@@ -1,9 +1,11 @@
-add_library(everest
+set(everest_target "${MBEDTLS_TARGET_PREFIX}everest")
+
+add_library(${everest_target}
   library/everest.c
   library/x25519.c
   library/Hacl_Curve25519_joined.c)
 
-target_include_directories(everest
+target_include_directories(${everest_target}
   PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
          $<BUILD_INTERFACE:${MBEDTLS_DIR}/include>
          $<INSTALL_INTERFACE:include>
@@ -16,11 +18,11 @@ target_include_directories(everest
 # everest is not directly linked against any mbedtls targets
 # so does not inherit the compile definitions.
 if(MBEDTLS_CONFIG_FILE)
-    target_compile_definitions(everest
+    target_compile_definitions(${everest_target}
         PUBLIC MBEDTLS_CONFIG_FILE="${MBEDTLS_CONFIG_FILE}")
 endif()
 if(MBEDTLS_USER_CONFIG_FILE)
-    target_compile_definitions(everest
+    target_compile_definitions(${everest_target}
         PUBLIC MBEDTLS_USER_CONFIG_FILE="${MBEDTLS_USER_CONFIG_FILE}")
 endif()
 
@@ -34,7 +36,7 @@ if(INSTALL_MBEDTLS_HEADERS)
 
 endif(INSTALL_MBEDTLS_HEADERS)
 
-install(TARGETS everest
+install(TARGETS ${everest_target}
   EXPORT MbedTLSTargets
   DESTINATION ${CMAKE_INSTALL_LIBDIR}
   PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)

--- a/3rdparty/p256-m/CMakeLists.txt
+++ b/3rdparty/p256-m/CMakeLists.txt
@@ -1,8 +1,10 @@
-add_library(p256m
+set(p256m_target ${MBEDTLS_TARGET_PREFIX}p256m)
+
+add_library(${p256m_target}
     p256-m_driver_entrypoints.c
     p256-m/p256-m.c)
 
-target_include_directories(p256m
+target_include_directories(${p256m_target}
   PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
          $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/p256-m>
          $<BUILD_INTERFACE:${MBEDTLS_DIR}/include>
@@ -14,11 +16,11 @@ target_include_directories(p256m
 # p256m is not directly linked against any mbedtls targets
 # so does not inherit the compile definitions.
 if(MBEDTLS_CONFIG_FILE)
-    target_compile_definitions(p256m
+    target_compile_definitions(${p256m_target}
         PUBLIC MBEDTLS_CONFIG_FILE="${MBEDTLS_CONFIG_FILE}")
 endif()
 if(MBEDTLS_USER_CONFIG_FILE)
-    target_compile_definitions(p256m
+    target_compile_definitions(${p256m_target}
         PUBLIC MBEDTLS_USER_CONFIG_FILE="${MBEDTLS_USER_CONFIG_FILE}")
 endif()
 
@@ -32,7 +34,7 @@ if(INSTALL_MBEDTLS_HEADERS)
 
 endif(INSTALL_MBEDTLS_HEADERS)
 
-install(TARGETS p256m
+install(TARGETS ${p256m_target}
 EXPORT MbedTLSTargets
 DESTINATION ${CMAKE_INSTALL_LIBDIR}
 PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)

--- a/ChangeLog.d/fix-cmake-target-prefix-3rdparty
+++ b/ChangeLog.d/fix-cmake-target-prefix-3rdparty
@@ -1,0 +1,4 @@
+Bugfix
+   * Respect the MBEDTLS_TARGET_PREFIX CMake variable with 3rdparty targets.
+	 Previously this was ignored for 3rdparty targets, preventing projects from
+	 including mbedtls multiple times when using 3rdparty targets.

--- a/ChangeLog.d/fix-cmake-target-prefix-3rdparty
+++ b/ChangeLog.d/fix-cmake-target-prefix-3rdparty
@@ -1,4 +1,4 @@
 Bugfix
    * Respect the MBEDTLS_TARGET_PREFIX CMake variable with 3rdparty targets.
-	 Previously this was ignored for 3rdparty targets, preventing projects from
-	 including mbedtls multiple times when using 3rdparty targets.
+     Previously this was ignored for 3rdparty targets, preventing projects from
+     including mbedtls multiple times when using 3rdparty targets.

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -268,17 +268,20 @@ if(USE_STATIC_MBEDTLS_LIBRARY AND USE_SHARED_MBEDTLS_LIBRARY)
         ${mbedtls_static_target})
 endif()
 
+set(p256m_target "${MBEDTLS_TARGET_PREFIX}p256m")
+set(everest_target "${MBEDTLS_TARGET_PREFIX}everest")
+
 if(USE_STATIC_MBEDTLS_LIBRARY)
     add_library(${mbedcrypto_static_target} STATIC ${src_crypto})
     set_target_properties(${mbedcrypto_static_target} PROPERTIES OUTPUT_NAME mbedcrypto)
     target_link_libraries(${mbedcrypto_static_target} PUBLIC ${libs})
 
-    if(TARGET everest)
-        target_link_libraries(${mbedcrypto_static_target} PUBLIC everest)
+    if(TARGET ${everest_target})
+        target_link_libraries(${mbedcrypto_static_target} PUBLIC ${everest_target})
     endif()
 
-    if(TARGET p256m)
-        target_link_libraries(${mbedcrypto_static_target} PUBLIC p256m)
+    if(TARGET ${p256m_target})
+        target_link_libraries(${mbedcrypto_static_target} PUBLIC ${p256m_target})
     endif()
 
     add_library(${mbedx509_static_target} STATIC ${src_x509})
@@ -296,12 +299,12 @@ if(USE_SHARED_MBEDTLS_LIBRARY)
     set_target_properties(${mbedcrypto_target} PROPERTIES VERSION 3.4.1 SOVERSION 14)
     target_link_libraries(${mbedcrypto_target} PUBLIC ${libs})
 
-    if(TARGET everest)
-        target_link_libraries(${mbedcrypto_target} PUBLIC everest)
+    if(TARGET ${everest_target})
+        target_link_libraries(${mbedcrypto_target} PUBLIC ${everest_target})
     endif()
 
-    if(TARGET p256m)
-        target_link_libraries(${mbedcrypto_target} PUBLIC p256m)
+    if(TARGET ${p256m_target})
+        target_link_libraries(${mbedcrypto_target} PUBLIC ${p256m_target})
     endif()
 
     add_library(${mbedx509_target} SHARED ${src_x509})


### PR DESCRIPTION
Fix #8269.

`MBEDTLS_TARGET_PREFIX` is prepended to the CMake targets for Mbed TLS except for targets in the `3rdparty` directory. Change this so that 3rdparty targets use the prefix as well.

This allows multiple copies of Mbed TLS to be used in the same CMake tree when using code in the `3rdparty` directory.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** provided ~~, or not required~~
- [x] **backport** ~~done, or~~ not required - The `3rdparty` directory does not declare any new CMake targets in 2.28
- [x] **tests** ~~provided, or~~ not required (existing tests cover)