### PR TITLE
Fix ChangeLog entry for FFDH in PSA

### DIFF
--- a/ChangeLog.d/driver-ffdh.txt
+++ b/ChangeLog.d/driver-ffdh.txt
@@ -1,3 +1,5 @@
 Features
-   * Add a driver dispatch layer for FFDH keys, enabling alternative
+   * Add support for the FFDH algorithm and DH key types in PSA, with
+     parameters from RFC 7919. This includes a built-in implementation based
+     on MBEDTLS_BIGNUM_C, and a driver dispatch layer enabling alternative
      implementations of FFDH through the driver entry points.


### PR DESCRIPTION
It was jumping directly to "driver support" and omitting the first step of "PSA support".

This provides the missing entry for #6010.

## PR checklist

- [x] **changelog** provided - the whole point of this PR :)
- [x] **backport** not required - new feature, not in 2.28
- [x] **tests** not required - changelog only
