### PR TITLE
Changelog entry for 7298

### DIFF
--- a/ChangeLog.d/MBEDTLS_ERR_SSL_CACHE_ENTRY_NOT_FOUND.txt
+++ b/ChangeLog.d/MBEDTLS_ERR_SSL_CACHE_ENTRY_NOT_FOUND.txt
@@ -1,0 +1,4 @@
+Bugfix
+   * Functions in the ssl_cache module now return a negative MBEDTLS_ERR_xxx
+     error code on failure. Before, they returned 1 to indicate failure in
+     some cases involving a missing entry or a full cache.


### PR DESCRIPTION
https://github.com/Mbed-TLS/mbedtls/pull/7298 wasn't just cleanup, it fixed a bug, so it needs a changelog entry.

And maybe a backport?

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** provided now
- [x] **backport** the bug isn't fixed in 2.28
- [x] **tests** N/A
