### PR TITLE
Backport 2.28: Bug Fix: mbedtls_ecdsa_verify_restartable fails with ECDSA_SIGN_ALT

### DIFF
--- a/ChangeLog.d/mbedtls_ecdsa_can_do-unconditional-define.txt
+++ b/ChangeLog.d/mbedtls_ecdsa_can_do-unconditional-define.txt
@@ -1,0 +1,4 @@
+Bugfix
+   * Removes !ECDSA_SIGN_ALT condition around mbedtls_ecdsa_can_do 
+     definition, so that mbedtls_ecdsa_verify_restartable will not 
+     automatically fail.

--- a/ChangeLog.d/mbedtls_ecdsa_can_do-unconditional-define.txt
+++ b/ChangeLog.d/mbedtls_ecdsa_can_do-unconditional-define.txt
@@ -1,4 +1,3 @@
 Bugfix
-   * Removes !ECDSA_SIGN_ALT condition around mbedtls_ecdsa_can_do 
-     definition, so that mbedtls_ecdsa_verify_restartable will not 
-     automatically fail.
+   * Fix an error when MBEDTLS_ECDSA_SIGN_ALT is defined but not
+     MBEDTLS_ECDSA_VERIFY_ALT, causing ecdsa verify to fail. Fixes #7498.

--- a/library/ecdsa.c
+++ b/library/ecdsa.c
@@ -240,9 +240,6 @@ cleanup:
 }
 #endif /* ECDSA_DETERMINISTIC || !ECDSA_SIGN_ALT || !ECDSA_VERIFY_ALT */
 
-#if !defined(MBEDTLS_ECDSA_SIGN_ALT)     || \
-    !defined(MBEDTLS_ECDSA_VERIFY_ALT)
-
 int mbedtls_ecdsa_can_do(mbedtls_ecp_group_id gid)
 {
     switch (gid) {
@@ -255,8 +252,6 @@ int mbedtls_ecdsa_can_do(mbedtls_ecp_group_id gid)
         default: return 1;
     }
 }
-
-#endif /* !ECDSA_SIGN_ALT || !ECDSA_VERIFY_ALT */
 
 #if !defined(MBEDTLS_ECDSA_SIGN_ALT)
 /*

--- a/library/ecdsa.c
+++ b/library/ecdsa.c
@@ -240,6 +240,24 @@ cleanup:
 }
 #endif /* ECDSA_DETERMINISTIC || !ECDSA_SIGN_ALT || !ECDSA_VERIFY_ALT */
 
+#if !defined(MBEDTLS_ECDSA_SIGN_ALT)     || \
+    !defined(MBEDTLS_ECDSA_VERIFY_ALT)
+
+int mbedtls_ecdsa_can_do(mbedtls_ecp_group_id gid)
+{
+    switch (gid) {
+#ifdef MBEDTLS_ECP_DP_CURVE25519_ENABLED
+        case MBEDTLS_ECP_DP_CURVE25519: return 0;
+#endif
+#ifdef MBEDTLS_ECP_DP_CURVE448_ENABLED
+        case MBEDTLS_ECP_DP_CURVE448: return 0;
+#endif
+        default: return 1;
+    }
+}
+
+#endif /* !ECDSA_SIGN_ALT || !ECDSA_VERIFY_ALT */
+
 #if !defined(MBEDTLS_ECDSA_SIGN_ALT)
 /*
  * Compute ECDSA signature of a hashed message (SEC1 4.1.3)
@@ -377,19 +395,6 @@ cleanup:
     ECDSA_RS_LEAVE(sig);
 
     return ret;
-}
-
-int mbedtls_ecdsa_can_do(mbedtls_ecp_group_id gid)
-{
-    switch (gid) {
-#ifdef MBEDTLS_ECP_DP_CURVE25519_ENABLED
-        case MBEDTLS_ECP_DP_CURVE25519: return 0;
-#endif
-#ifdef MBEDTLS_ECP_DP_CURVE448_ENABLED
-        case MBEDTLS_ECP_DP_CURVE448: return 0;
-#endif
-        default: return 1;
-    }
 }
 
 /*


### PR DESCRIPTION
Straightforward backport of https://github.com/Mbed-TLS/mbedtls/pull/7499

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** provided
- [x] **backport** of https://github.com/Mbed-TLS/mbedtls/pull/7499
- [x] **tests** manually

Testing manually:

```
./config.py set MBEDTLS_ECDSA_SIGN_ALT
make -C programs pkey/ecdsa
```
Expected: a link error about missing `mbedtls_ecdsa_sign` (when you enable `MBEDTLS_ECDSA_SIGN_ALT`, you have to provide that function).
Actual before this fix: also missing `mbedtls_ecdsa_can_do`
