### PR TITLE
Backport 2.28: ssl_cache: misc improvements

### DIFF
--- a/ChangeLog.d/MBEDTLS_ERR_SSL_CACHE_ENTRY_NOT_FOUND.txt
+++ b/ChangeLog.d/MBEDTLS_ERR_SSL_CACHE_ENTRY_NOT_FOUND.txt
@@ -1,0 +1,4 @@
+Bugfix
+   * Functions in the ssl_cache module now return a negative MBEDTLS_ERR_xxx
+     error code on failure. Before, they returned 1 to indicate failure in
+     some cases involving a missing entry or a full cache.

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -193,6 +193,8 @@
 #define MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS                -0x7000
 /** Invalid value in SSL config */
 #define MBEDTLS_ERR_SSL_BAD_CONFIG                        -0x5E80
+/** Cache entry not found */
+#define MBEDTLS_ERR_SSL_CACHE_ENTRY_NOT_FOUND             -0x5E00
 
 /*
  * Various constants

--- a/include/mbedtls/ssl_cache.h
+++ b/include/mbedtls/ssl_cache.h
@@ -99,6 +99,11 @@ void mbedtls_ssl_cache_init(mbedtls_ssl_cache_context *cache);
  *
  * \param data     SSL cache context
  * \param session  session to retrieve entry for
+ *
+ * \return                \c 0 on success.
+ * \return                #MBEDTLS_ERR_SSL_CACHE_ENTRY_NOT_FOUND if there is
+ *                        no cache entry with specified session ID found, or
+ *                        any other negative error code for other failures.
  */
 int mbedtls_ssl_cache_get(void *data, mbedtls_ssl_session *session);
 
@@ -108,6 +113,9 @@ int mbedtls_ssl_cache_get(void *data, mbedtls_ssl_session *session);
  *
  * \param data     SSL cache context
  * \param session  session to store entry for
+ *
+ * \return                \c 0 on success.
+ * \return                A negative error code on failure.
  */
 int mbedtls_ssl_cache_set(void *data, const mbedtls_ssl_session *session);
 

--- a/library/error.c
+++ b/library/error.c
@@ -518,6 +518,8 @@ const char *mbedtls_high_level_strerr(int error_code)
             return( "SSL - A cryptographic operation is in progress. Try again later" );
         case -(MBEDTLS_ERR_SSL_BAD_CONFIG):
             return( "SSL - Invalid value in SSL config" );
+        case -(MBEDTLS_ERR_SSL_CACHE_ENTRY_NOT_FOUND):
+            return( "SSL - Cache entry not found" );
 #endif /* MBEDTLS_SSL_TLS_C */
 
 #if defined(MBEDTLS_X509_USE_C) || defined(MBEDTLS_X509_CREATE_C)


### PR DESCRIPTION
This is a backport of the bug fix in https://github.com/Mbed-TLS/mbedtls/pull/7298: functions in the `ssl_cache` module were returning 1 on many error conditions, unlike the rest of the library where errors are conveyed by an error code that's always negative.

There was significant refactoring in the `ssl_cache` module in 3.x, so cherry-picking the commits led to significant conflicts, and instead I mostly re-did the same changes:

* Create a new error code — it had to have a different number in 2.28 because the one from 3.5 is taken in 2.28. Also, in 2.28, `error.c` needs to be updated.
* Change functions to return a negative error code — I searched for `return 1` or `ret = 1` and changed to what seemed like sensible values.
* Documentation update — I copied the text we used in 3.5.
* In 2.28, only `mbedtls_ssl_cache_get` and `mbedtls_ssl_cache_set` are concerned, there's no `mbedtls_ssl_cache_remove`.
* I included the changelog entry which was in a separate PR https://github.com/Mbed-TLS/mbedtls/pull/8278.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** provided
- [x] **backport** of https://github.com/Mbed-TLS/mbedtls/pull/7298 + https://github.com/Mbed-TLS/mbedtls/pull/8278
- [ ] **tests** no, the `ssl_cache` module is not tested (it's used in SSL tests, but they don't really test error conditions) **← RISK!**
