### PR TITLE
Improve AES hardware-only check

### DIFF
--- a/library/aes.c
+++ b/library/aes.c
@@ -34,21 +34,12 @@
 #include "mbedtls/platform_util.h"
 #include "mbedtls/error.h"
 
-#if defined(MBEDTLS_ARCH_IS_ARM64)
-#if !defined(MBEDTLS_AESCE_C) && defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
+#if defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
+#if !((defined(MBEDTLS_ARCH_IS_ARM64) && defined(MBEDTLS_AESCE_C)) || \
+      (defined(MBEDTLS_ARCH_IS_X64)   && defined(MBEDTLS_AESNI_C)) || \
+      (defined(MBEDTLS_ARCH_IS_X86)   && defined(MBEDTLS_AESNI_C)))
 #error "MBEDTLS_AES_USE_HARDWARE_ONLY defined, but not all prerequisites"
 #endif
-#endif
-
-#if defined(MBEDTLS_ARCH_IS_X64)
-#if !defined(MBEDTLS_AESNI_C) && defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
-#error "MBEDTLS_AES_USE_HARDWARE_ONLY defined, but not all prerequisites"
-#endif
-#endif
-
-#if defined(MBEDTLS_ARCH_IS_X86)
-#if defined(MBEDTLS_AES_USE_HARDWARE_ONLY) && !defined(MBEDTLS_AESNI_C)
-#error "MBEDTLS_AES_USE_HARDWARE_ONLY defined, but not all prerequisites"
 #endif
 
 #if defined(MBEDTLS_PADLOCK_C)

--- a/library/aes.c
+++ b/library/aes.c
@@ -42,6 +42,7 @@
 #endif
 #endif
 
+#if defined(MBEDTLS_ARCH_IS_X86)
 #if defined(MBEDTLS_PADLOCK_C)
 #if !defined(MBEDTLS_HAVE_ASM)
 #error "MBEDTLS_PADLOCK_C defined, but not all prerequisites"

--- a/library/aes.c
+++ b/library/aes.c
@@ -36,8 +36,8 @@
 
 #if defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
 #if !((defined(MBEDTLS_ARCH_IS_ARM64) && defined(MBEDTLS_AESCE_C)) || \
-      (defined(MBEDTLS_ARCH_IS_X64)   && defined(MBEDTLS_AESNI_C)) || \
-      (defined(MBEDTLS_ARCH_IS_X86)   && defined(MBEDTLS_AESNI_C)))
+    (defined(MBEDTLS_ARCH_IS_X64)   && defined(MBEDTLS_AESNI_C)) || \
+    (defined(MBEDTLS_ARCH_IS_X86)   && defined(MBEDTLS_AESNI_C)))
 #error "MBEDTLS_AES_USE_HARDWARE_ONLY defined, but not all prerequisites"
 #endif
 #endif


### PR DESCRIPTION
## Description

Looking at #7384 (adds MBEDTLS_AES_USE_HARDWARE_ONLY), we complain with a #error message if this is set on x86 / x86_64 and MBEDTLS_AESNI_C is not set, and similar for Arm.

But if we set AES_USE_HARDWARE_ONLY on some other platform, there's no clean error about "not all prerequisites set", only an unexplained compile fail. This PR fixes that gap.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required - minor enhancement, no change to functionality
- [x] **backport**  not required - not in 2.28
- [x] **tests** not required - covered by existing
