### PR TITLE
CMake: fix build with 3rdparty module enabled through a custom config

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -1,10 +1,2 @@
-execute_process(COMMAND ${MBEDTLS_PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/../scripts/config.py -f ${CMAKE_CURRENT_SOURCE_DIR}/../include/mbedtls/mbedtls_config.h get MBEDTLS_ECDH_VARIANT_EVEREST_ENABLED RESULT_VARIABLE everest_result)
-execute_process(COMMAND ${MBEDTLS_PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/../scripts/config.py -f ${CMAKE_CURRENT_SOURCE_DIR}/../include/mbedtls/mbedtls_config.h get MBEDTLS_PSA_P256M_DRIVER_ENABLED RESULT_VARIABLE p256m_result)
-
-if(${everest_result} EQUAL 0)
-    add_subdirectory(everest)
-endif()
-
-if(${p256m_result} EQUAL 0)
-    add_subdirectory(p256-m)
-endif()
+add_subdirectory(everest)
+add_subdirectory(p256-m)

--- a/3rdparty/everest/CMakeLists.txt
+++ b/3rdparty/everest/CMakeLists.txt
@@ -11,6 +11,19 @@ target_include_directories(everest
           include/everest/kremlib
           ${MBEDTLS_DIR}/library/)
 
+# Pass-through MBEDTLS_CONFIG_FILE and MBEDTLS_USER_CONFIG_FILE
+# This must be duplicated from library/CMakeLists.txt because
+# everest is not directly linked against any mbedtls targets
+# so does not inherit the compile definitions.
+if(MBEDTLS_CONFIG_FILE)
+    target_compile_definitions(everest
+        PUBLIC MBEDTLS_CONFIG_FILE="${MBEDTLS_CONFIG_FILE}")
+endif()
+if(MBEDTLS_USER_CONFIG_FILE)
+    target_compile_definitions(everest
+        PUBLIC MBEDTLS_USER_CONFIG_FILE="${MBEDTLS_USER_CONFIG_FILE}")
+endif()
+
 if(INSTALL_MBEDTLS_HEADERS)
 
   install(DIRECTORY include/everest

--- a/3rdparty/p256-m/CMakeLists.txt
+++ b/3rdparty/p256-m/CMakeLists.txt
@@ -9,6 +9,19 @@ target_include_directories(p256m
          $<INSTALL_INTERFACE:include>
   PRIVATE ${MBEDTLS_DIR}/library/)
 
+# Pass-through MBEDTLS_CONFIG_FILE and MBEDTLS_USER_CONFIG_FILE
+# This must be duplicated from library/CMakeLists.txt because
+# p256m is not directly linked against any mbedtls targets
+# so does not inherit the compile definitions.
+if(MBEDTLS_CONFIG_FILE)
+    target_compile_definitions(p256m
+        PUBLIC MBEDTLS_CONFIG_FILE="${MBEDTLS_CONFIG_FILE}")
+endif()
+if(MBEDTLS_USER_CONFIG_FILE)
+    target_compile_definitions(p256m
+        PUBLIC MBEDTLS_USER_CONFIG_FILE="${MBEDTLS_USER_CONFIG_FILE}")
+endif()
+
 if(INSTALL_MBEDTLS_HEADERS)
 
   install(DIRECTORY :${CMAKE_CURRENT_SOURCE_DIR}

--- a/ChangeLog.d/fix-cmake-3rdparty-custom-config.txt
+++ b/ChangeLog.d/fix-cmake-3rdparty-custom-config.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix the build with CMake when Everest or P256-m is enabled through
+     a user configuration file or the compiler command line. Fixes #8165.


### PR DESCRIPTION
Fixes #8165

@adeaarm confirms that this fixes the problem for TF-M

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** provided
- [x] **backport** #8302 
- [x] **tests** CI
