### PR TITLE
Fix test_suite_platform failure with Asan on modern Clang

### DIFF
--- a/tests/include/test/helpers.h
+++ b/tests/include/test/helpers.h
@@ -20,6 +20,21 @@
 
 #include "mbedtls/build_info.h"
 
+#if defined(__SANITIZE_ADDRESS__) /* gcc -fsanitize=address */
+#  define MBEDTLS_TEST_HAVE_ASAN
+#endif
+#if defined(__has_feature)
+#  if __has_feature(address_sanitizer) /* clang -fsanitize=address */
+#    define MBEDTLS_TEST_HAVE_ASAN
+#  endif
+#  if __has_feature(memory_sanitizer) /* clang -fsanitize=memory */
+#    define MBEDTLS_TEST_HAVE_MSAN
+#  endif
+#  if __has_feature(thread_sanitizer) /* clang -fsanitize=thread */
+#    define MBEDTLS_TEST_HAVE_TSAN
+#  endif
+#endif
+
 #if defined(MBEDTLS_THREADING_C) && defined(MBEDTLS_THREADING_PTHREAD) && \
     defined(MBEDTLS_TEST_HOOKS)
 #define MBEDTLS_TEST_MUTEX_USAGE

--- a/tests/scripts/analyze_outcomes.py
+++ b/tests/scripts/analyze_outcomes.py
@@ -232,6 +232,12 @@ KNOWN_TASKS = {
                 'psa_crypto_low_hash.generated', # testing the builtins
             ],
             'ignored_tests': {
+                'test_suite_platform': [
+                    # Incompatible with sanitizers (e.g. ASan). If the driver
+                    # component uses a sanitizer but the reference component
+                    # doesn't, we have a PASS vs SKIP mismatch.
+                    'Check mbedtls_calloc overallocation',
+                ],
             }
         }
     },
@@ -254,6 +260,12 @@ KNOWN_TASKS = {
                 # The rest of PEM (write, unencrypted read) works though.
                 'test_suite_pem': [
                     re.compile(r'PEM read .*(AES|DES|\bencrypt).*'),
+                ],
+                'test_suite_platform': [
+                    # Incompatible with sanitizers (e.g. ASan). If the driver
+                    # component uses a sanitizer but the reference component
+                    # doesn't, we have a PASS vs SKIP mismatch.
+                    'Check mbedtls_calloc overallocation',
                 ],
                 # Following tests depend on AES_C/DES_C but are not about
                 # them really, just need to know some error code is there.
@@ -297,6 +309,12 @@ KNOWN_TASKS = {
                 'ecdsa', 'ecdh', 'ecjpake',
             ],
             'ignored_tests': {
+                'test_suite_platform': [
+                    # Incompatible with sanitizers (e.g. ASan). If the driver
+                    # component uses a sanitizer but the reference component
+                    # doesn't, we have a PASS vs SKIP mismatch.
+                    'Check mbedtls_calloc overallocation',
+                ],
                 # This test wants a legacy function that takes f_rng, p_rng
                 # arguments, and uses legacy ECDSA for that. The test is
                 # really about the wrapper around the PSA RNG, not ECDSA.
@@ -330,6 +348,12 @@ KNOWN_TASKS = {
                 'ecp', 'ecdsa', 'ecdh', 'ecjpake',
             ],
             'ignored_tests': {
+                'test_suite_platform': [
+                    # Incompatible with sanitizers (e.g. ASan). If the driver
+                    # component uses a sanitizer but the reference component
+                    # doesn't, we have a PASS vs SKIP mismatch.
+                    'Check mbedtls_calloc overallocation',
+                ],
                 # See ecp_light_only
                 'test_suite_random': [
                     'PSA classic wrapper: ECDSA signature (SECP256R1)',
@@ -363,6 +387,12 @@ KNOWN_TASKS = {
                 'bignum.generated', 'bignum.misc',
             ],
             'ignored_tests': {
+                'test_suite_platform': [
+                    # Incompatible with sanitizers (e.g. ASan). If the driver
+                    # component uses a sanitizer but the reference component
+                    # doesn't, we have a PASS vs SKIP mismatch.
+                    'Check mbedtls_calloc overallocation',
+                ],
                 # See ecp_light_only
                 'test_suite_random': [
                     'PSA classic wrapper: ECDSA signature (SECP256R1)',
@@ -400,6 +430,12 @@ KNOWN_TASKS = {
                 'bignum.generated', 'bignum.misc',
             ],
             'ignored_tests': {
+                'test_suite_platform': [
+                    # Incompatible with sanitizers (e.g. ASan). If the driver
+                    # component uses a sanitizer but the reference component
+                    # doesn't, we have a PASS vs SKIP mismatch.
+                    'Check mbedtls_calloc overallocation',
+                ],
                 # See ecp_light_only
                 'test_suite_random': [
                     'PSA classic wrapper: ECDSA signature (SECP256R1)',
@@ -431,7 +467,14 @@ KNOWN_TASKS = {
             'component_ref': 'test_psa_crypto_config_reference_ffdh',
             'component_driver': 'test_psa_crypto_config_accel_ffdh',
             'ignored_suites': ['dhm'],
-            'ignored_tests': {}
+            'ignored_tests': {
+                'test_suite_platform': [
+                    # Incompatible with sanitizers (e.g. ASan). If the driver
+                    # component uses a sanitizer but the reference component
+                    # doesn't, we have a PASS vs SKIP mismatch.
+                    'Check mbedtls_calloc overallocation',
+                ],
+            }
         }
     },
     'analyze_driver_vs_reference_tfm_config': {
@@ -447,6 +490,12 @@ KNOWN_TASKS = {
                 'bignum.generated', 'bignum.misc',
             ],
             'ignored_tests': {
+                'test_suite_platform': [
+                    # Incompatible with sanitizers (e.g. ASan). If the driver
+                    # component uses a sanitizer but the reference component
+                    # doesn't, we have a PASS vs SKIP mismatch.
+                    'Check mbedtls_calloc overallocation',
+                ],
                 # See ecp_light_only
                 'test_suite_random': [
                     'PSA classic wrapper: ECDSA signature (SECP256R1)',

--- a/tests/suites/test_suite_platform.data
+++ b/tests/suites/test_suite_platform.data
@@ -7,9 +7,9 @@ time_get_seconds:
 
 Check mbedtls_calloc overallocation
 # This test case exercises an integer overflow in calloc. Under Asan, with
-# a modern Clang, this triggers an Asan complaint. The complaint can be
-# avoided with ASAN_OPTIONS=allocator_may_return_null=1, but this has to
-# be set in the environment before the program starts, and could hide
-# other errors.
-depends_on:!MBEDTLS_TEST_HAVE_ASAN
+# a modern Clang, this triggers an ASan/MSan/TSan complaint. The complaint
+# can be avoided with e.g. ASAN_OPTIONS=allocator_may_return_null=1,
+# but this has to be set in the environment before the program starts,
+# and could hide other errors.
+depends_on:!MBEDTLS_TEST_HAVE_ASAN:!MBEDTLS_TEST_HAVE_MSAN:!MBEDTLS_TEST_HAVE_TSAN
 check_mbedtls_calloc_overallocation:SIZE_MAX/2:SIZE_MAX/2

--- a/tests/suites/test_suite_platform.data
+++ b/tests/suites/test_suite_platform.data
@@ -6,4 +6,10 @@ Time: get seconds
 time_get_seconds:
 
 Check mbedtls_calloc overallocation
+# This test case exercises an integer overflow in calloc. Under Asan, with
+# a modern Clang, this triggers an Asan complaint. The complaint can be
+# avoided with ASAN_OPTIONS=allocator_may_return_null=1, but this has to
+# be set in the environment before the program starts, and could hide
+# other errors.
+depends_on:!MBEDTLS_TEST_HAVE_ASAN
 check_mbedtls_calloc_overallocation:SIZE_MAX/2:SIZE_MAX/2


### PR DESCRIPTION
Fix https://github.com/Mbed-TLS/mbedtls/issues/8285

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** no (test only)
- [x] **backport** The problematic test case doesn't exist in 2.28. But do backport the new macros. https://github.com/Mbed-TLS/mbedtls/pull/8558
- [x] **tests** provided
