### PR TITLE
Fix: Allow locally trusted EE certs from a callback

### DIFF
--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -2598,16 +2598,6 @@ static int x509_crt_verify_chain(
             *flags |= MBEDTLS_X509_BADCERT_BAD_PK;
         }
 
-        /* Special case: EE certs that are locally trusted */
-        if (ver_chain->len == 1 &&
-            x509_crt_check_ee_locally_trusted(child, trust_ca) == 0) {
-            return 0;
-        }
-
-#if defined(MBEDTLS_ECDSA_C) && defined(MBEDTLS_ECP_RESTARTABLE)
-find_parent:
-#endif
-
         /* Obtain list of potential trusted signers from CA callback,
          * or use statically provided list. */
 #if defined(MBEDTLS_X509_TRUSTED_CERTIFICATE_CALLBACK)
@@ -2629,6 +2619,16 @@ find_parent:
             ((void) p_ca_cb);
             cur_trust_ca = trust_ca;
         }
+
+        /* Special case: EE certs that are locally trusted */
+        if (ver_chain->len == 1 &&
+            x509_crt_check_ee_locally_trusted(child, cur_trust_ca) == 0) {
+            return 0;
+        }
+
+#if defined(MBEDTLS_ECDSA_C) && defined(MBEDTLS_ECP_RESTARTABLE)
+find_parent:
+#endif
 
         /* Look for a parent in trusted CAs or up the chain */
         ret = x509_crt_find_parent(child, cur_trust_ca, &parent,


### PR DESCRIPTION
When verifying a certificate chain, call the user-provided CA callback before checking whether the current cert is a locally-trusted end-entity cert. This allows the list of locally-trusted EE certs to be supplied dynamically via the callback.

Fixes #8019 

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [ ] **changelog** provided, or not required
- [ ] **backport** done, or not required
- [ ] **tests** provided, or not required
