### PR TITLE
Updating check-generated-files

### DIFF
--- a/tests/scripts/check-generated-files.sh
+++ b/tests/scripts/check-generated-files.sh
@@ -128,7 +128,7 @@ check()
 
 check scripts/generate_errors.pl library/error.c
 check scripts/generate_query_config.pl programs/test/query_config.c
-check scripts/generate_driver_wrappers.py library/psa_crypto_driver_wrappers.h
+check scripts/generate_driver_wrappers.py library/psa_crypto_driver_wrappers.h library/psa_crypto_driver_wrappers_no_static.c
 check scripts/generate_features.pl library/version_features.c
 check scripts/generate_ssl_debug_helpers.py library/ssl_debug_helpers_generated.c
 # generate_visualc_files enumerates source files (library/*.c). It doesn't


### PR DESCRIPTION
## Description

This PR updates check-generated-files.sh to check/include the newly added `psa_crypto_driver_wrappers_no_static.c` file

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** Not required, this is a helper script change for code quality.
- [x] **backport** Not required, this is a helper script not presentin LTS.
- [x] **tests** Not required



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.
