### PR TITLE
Remove redundant test component

### DIFF
--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1164,21 +1164,6 @@ component_test_full_cmake_gcc_asan_new_bignum () {
     tests/context-info.sh
 }
 
-component_test_full_cmake_gcc_asan_new_bignum_test_hooks () {
-    msg "build: full config, cmake, gcc, ASan"
-    scripts/config.py full
-    scripts/config.py set MBEDTLS_TEST_HOOKS
-    scripts/config.py set MBEDTLS_ECP_WITH_MPI_UINT
-    CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
-    make
-
-    msg "test: main suites (inc. selftests) (full config, ASan build)"
-    make test
-
-    msg "test: selftest (ASan build)" # ~ 10s
-    programs/test/selftest
-}
-
 component_test_psa_crypto_key_id_encodes_owner () {
     msg "build: full config + PSA_CRYPTO_KEY_ID_ENCODES_OWNER, cmake, gcc, ASan"
     scripts/config.py full


### PR DESCRIPTION
## Description
In the full configuration MBEDTLS_TEST_HOOKS is enabled thus the configurations in test_full_cmake_gcc_asan_new_bignum and
test_full_cmake_gcc_asan_new_bignum_test_hooks are the same. Keep the component that runs more tests.

## PR checklist
Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** no, just removing an al.sh test component
- [x] **backport** no, only in development
- [x] **tests** no, just removing redundant testing
