### PR TITLE
[Backport 2.28] CMake: fix build with 3rdparty module enabled through a custom config

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -4,11 +4,7 @@ list (APPEND thirdparty_inc_public)
 list (APPEND thirdparty_inc)
 list (APPEND thirdparty_def)
 
-execute_process(COMMAND ${MBEDTLS_PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/../scripts/config.py -f ${CMAKE_CURRENT_SOURCE_DIR}/../include/mbedtls/config.h get MBEDTLS_ECDH_VARIANT_EVEREST_ENABLED RESULT_VARIABLE result)
-
-if(${result} EQUAL 0)
-    add_subdirectory(everest)
-endif()
+add_subdirectory(everest)
 
 set(thirdparty_src ${thirdparty_src} PARENT_SCOPE)
 set(thirdparty_lib ${thirdparty_lib} PARENT_SCOPE)

--- a/ChangeLog.d/fix-cmake-3rdparty-custom-config.txt
+++ b/ChangeLog.d/fix-cmake-3rdparty-custom-config.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix the build with CMake when Everest is enabled through
+     a user configuration file or the compiler command line. Fixes #8165.


### PR DESCRIPTION
Backport of #8284.

Main difference: The custom config propagation is not needed due to a difference in the way `3rdparty` works in 2.28.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** provided
- [x] **backport** not required (This is the backport)
- [x] **tests** not required - build system
