### PR TITLE
PKCS12: use one-shot API

### DIFF
--- a/tests/suites/test_suite_pkcs12.data
+++ b/tests/suites/test_suite_pkcs12.data
@@ -1,4 +1,4 @@
-PKCS#12 derive key : MD5: Zero length password and hash
+PKCS#12 derive key: MD5: Zero length password and hash
 depends_on:MBEDTLS_MD_CAN_MD5
 pkcs12_derive_key:MBEDTLS_MD_MD5:48:"":USE_GIVEN_INPUT:"":USE_GIVEN_INPUT:3:"6afdcbd5ebf943272134f1c3de2dc11b6afdcbd5ebf943272134f1c3de2dc11b6afdcbd5ebf943272134f1c3de2dc11b":0
 


### PR DESCRIPTION
## Description

This PR resolves #8052 by replacing all the ciphers steps used in `pkcs12` module with a single call to `mbedtls_cipher_crypt()`.

## PR checklist

- [x] **changelog** not required as nothing changes from end user point of view
- [x] **backport** not required
- [x] **tests** not required as the already existing tests already evaluate this part of the code