### PR TITLE
Fix dependencies of mbedtls_pk_ec_ro and mbedtls_pk_ec_rw

### DIFF
--- a/library/pk_internal.h
+++ b/library/pk_internal.h
@@ -44,7 +44,7 @@
                                                                     psa_pk_status_to_mbedtls)
 #endif
 
-#if defined(MBEDTLS_PK_HAVE_ECC_KEYS)
+#if !defined(MBEDTLS_PK_USE_PSA_EC_DATA)
 /**
  * Public function mbedtls_pk_ec() can be used to get direct access to the
  * wrapped ecp_keypair structure pointed to the pk_ctx. However this is not
@@ -80,7 +80,9 @@ static inline mbedtls_ecp_keypair *mbedtls_pk_ec_rw(const mbedtls_pk_context pk)
             return NULL;
     }
 }
+#endif /* !MBEDTLS_PK_USE_PSA_EC_DATA */
 
+#if defined(MBEDTLS_PK_HAVE_ECC_KEYS)
 static inline mbedtls_ecp_group_id mbedtls_pk_get_group_id(const mbedtls_pk_context *pk)
 {
     mbedtls_ecp_group_id id;

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -2604,9 +2604,9 @@ static int ssl_write_certificate_request(mbedtls_ssl_context *ssl)
 }
 #endif /* MBEDTLS_KEY_EXCHANGE_CERT_REQ_ALLOWED_ENABLED */
 
-#if defined(MBEDTLS_USE_PSA_CRYPTO) &&                      \
-    (defined(MBEDTLS_KEY_EXCHANGE_ECDH_RSA_ENABLED) || \
+#if (defined(MBEDTLS_KEY_EXCHANGE_ECDH_RSA_ENABLED) || \
     defined(MBEDTLS_KEY_EXCHANGE_ECDH_ECDSA_ENABLED))
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
 MBEDTLS_CHECK_RETURN_CRITICAL
 static int ssl_get_ecdh_params_from_cert(mbedtls_ssl_context *ssl)
 {
@@ -2716,8 +2716,7 @@ static int ssl_get_ecdh_params_from_cert(mbedtls_ssl_context *ssl)
 
     return ret;
 }
-#elif defined(MBEDTLS_KEY_EXCHANGE_ECDH_RSA_ENABLED) || \
-    defined(MBEDTLS_KEY_EXCHANGE_ECDH_ECDSA_ENABLED)
+#else /* MBEDTLS_USE_PSA_CRYPTO */
 MBEDTLS_CHECK_RETURN_CRITICAL
 static int ssl_get_ecdh_params_from_cert(mbedtls_ssl_context *ssl)
 {
@@ -2743,6 +2742,7 @@ static int ssl_get_ecdh_params_from_cert(mbedtls_ssl_context *ssl)
 
     return 0;
 }
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 #endif /* MBEDTLS_KEY_EXCHANGE_ECDH_RSA_ENABLED) ||
           MBEDTLS_KEY_EXCHANGE_ECDH_ECDSA_ENABLED */
 

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -676,11 +676,7 @@ static int ssl_check_key_curve(mbedtls_pk_context *pk,
                                uint16_t *curves_tls_id)
 {
     uint16_t *curr_tls_id = curves_tls_id;
-#if defined(MBEDTLS_PK_USE_PSA_EC_DATA)
-    mbedtls_ecp_group_id grp_id = mbedtls_ecc_group_of_psa(pk->ec_family, pk->ec_bits, 0);
-#else
-    mbedtls_ecp_group_id grp_id = mbedtls_pk_ec_ro(*pk)->grp.id;
-#endif
+    mbedtls_ecp_group_id grp_id = mbedtls_pk_get_group_id(pk);
     mbedtls_ecp_group_id curr_grp_id;
 
     while (*curr_tls_id != 0) {

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -676,7 +676,11 @@ static int ssl_check_key_curve(mbedtls_pk_context *pk,
                                uint16_t *curves_tls_id)
 {
     uint16_t *curr_tls_id = curves_tls_id;
+#if defined(MBEDTLS_PK_USE_PSA_EC_DATA)
+    mbedtls_ecp_group_id grp_id = mbedtls_ecc_group_of_psa(pk->ec_family, pk->ec_bits, 0);
+#else
     mbedtls_ecp_group_id grp_id = mbedtls_pk_ec_ro(*pk)->grp.id;
+#endif
     mbedtls_ecp_group_id curr_grp_id;
 
     while (*curr_tls_id != 0) {


### PR DESCRIPTION
## Description

This PR resolves #8263 by using `!MBEDTLS_PK_USE_PSA_EC_DATA` as guard for `mbedtls_pk_ec_[ro/rw]` and fixing related issues.

## PR checklist

- [ ] **changelog** not required as nothing changes for the end user
- [ ] **backport** not required
- [ ] **tests** not required as no new code is introduced and this part is already tested by existing ones