### PR TITLE
Correct styling of Mbed TLS in documentation

### DIFF
--- a/include/mbedtls/config_adjust_legacy_crypto.h
+++ b/include/mbedtls/config_adjust_legacy_crypto.h
@@ -79,7 +79,7 @@
 #define MBEDTLS_ECP_LIGHT
 #endif
 
-/* MBEDTLS_PK_PARSE_EC_COMPRESSED is introduced in MbedTLS version 3.5, while
+/* MBEDTLS_PK_PARSE_EC_COMPRESSED is introduced in Mbed TLS version 3.5, while
  * in previous version compressed points were automatically supported as long
  * as PK_PARSE_C and ECP_C were enabled. As a consequence, for backward
  * compatibility, we auto-enable PK_PARSE_EC_COMPRESSED when these conditions

--- a/library/psa_crypto_pake.c
+++ b/library/psa_crypto_pake.c
@@ -304,10 +304,10 @@ static psa_status_t mbedtls_psa_pake_output_internal(
 
 #if defined(MBEDTLS_PSA_BUILTIN_ALG_JPAKE)
     /*
-     * The PSA CRYPTO PAKE and MbedTLS JPAKE API have a different
+     * The PSA CRYPTO PAKE and Mbed TLS JPAKE API have a different
      * handling of output sequencing.
      *
-     * The MbedTLS JPAKE API outputs the whole X1+X2 and X2S steps data
+     * The Mbed TLS JPAKE API outputs the whole X1+X2 and X2S steps data
      * at once, on the other side the PSA CRYPTO PAKE api requires
      * the KEY_SHARE/ZP_PUBLIC/ZK_PROOF parts of X1, X2 & X2S to be
      * retrieved in sequence.
@@ -423,17 +423,17 @@ static psa_status_t mbedtls_psa_pake_input_internal(
 
 #if defined(MBEDTLS_PSA_BUILTIN_ALG_JPAKE)
     /*
-     * The PSA CRYPTO PAKE and MbedTLS JPAKE API have a different
+     * The PSA CRYPTO PAKE and Mbed TLS JPAKE API have a different
      * handling of input sequencing.
      *
-     * The MbedTLS JPAKE API takes the whole X1+X2 or X4S steps data
+     * The Mbed TLS JPAKE API takes the whole X1+X2 or X4S steps data
      * at once as input, on the other side the PSA CRYPTO PAKE api requires
      * the KEY_SHARE/ZP_PUBLIC/ZK_PROOF parts of X1, X2 & X4S to be
      * given in sequence.
      *
      * In order to achieve API compatibility, each X1+X2 or X4S step data
      * is stored sequentially in an intermediate buffer and given to the
-     * MbedTLS JPAKE API on the last step.
+     * Mbed TLS JPAKE API on the last step.
      *
      * This causes any input error to be only detected on the last step.
      */

--- a/programs/ssl/ssl_context_info.c
+++ b/programs/ssl/ssl_context_info.c
@@ -1,5 +1,5 @@
 /*
- *  MbedTLS SSL context deserializer from base64 code
+ *  Mbed TLS SSL context deserializer from base64 code
  *
  *  Copyright The Mbed TLS Contributors
  *  SPDX-License-Identifier: Apache-2.0

--- a/scripts/code_size_compare.py
+++ b/scripts/code_size_compare.py
@@ -901,7 +901,7 @@ def main():
         '-c', '--config', type=str, default=SupportedConfig.DEFAULT.value,
         choices=list(map(lambda s: s.value, SupportedConfig)),
         help='Specify configuration type for code size comparison. '
-             '(Default is the current MbedTLS configuration.)')
+             '(Default is the current Mbed TLS configuration.)')
     group_optional.add_argument(
         '--markdown', action='store_true', dest='markdown',
         help='Show comparision of code size in a markdown table. '

--- a/tests/scripts/audit-validity-dates.py
+++ b/tests/scripts/audit-validity-dates.py
@@ -276,7 +276,7 @@ class Auditor:
 
     @staticmethod
     def find_test_dir():
-        """Get the relative path for the MbedTLS test directory."""
+        """Get the relative path for the Mbed TLS test directory."""
         return os.path.relpath(build_tree.guess_mbedtls_root() + '/tests')
 
 

--- a/tests/scripts/check_names.py
+++ b/tests/scripts/check_names.py
@@ -941,7 +941,7 @@ def main():
             "This script confirms that the naming of all symbols and identifiers "
             "in Mbed TLS are consistent with the house style and are also "
             "self-consistent.\n\n"
-            "Expected to be run from the MbedTLS root directory.")
+            "Expected to be run from the Mbed TLS root directory.")
     )
     parser.add_argument(
         "-v", "--verbose",

--- a/tests/scripts/test_psa_compliance.py
+++ b/tests/scripts/test_psa_compliance.py
@@ -46,7 +46,7 @@ EXPECTED_FAILURES = {
 }
 
 # We currently use a fork of ARM-software/psa-arch-tests, with a couple of downstream patches
-# that allow it to build with MbedTLS 3, and fixes a couple of issues in the compliance test suite.
+# that allow it to build with Mbed TLS 3, and fixes a couple of issues in the compliance test suite.
 # These fixes allow the tests numbered 216, 248 and 249 to complete successfully.
 #
 # Once all the fixes are upstreamed, this fork should be replaced with an upstream commit/tag.


### PR DESCRIPTION
## Description

Several bits of documentation were incorrectly styling Mbed TLS as MbedTLS.




## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required
- [x] **backport** #8324
- [x] **tests** not required



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.
