### PR TITLE
Backport 2.28: Correct styling of Mbed TLS in documentation

### DIFF
--- a/programs/ssl/ssl_context_info.c
+++ b/programs/ssl/ssl_context_info.c
@@ -1,5 +1,5 @@
 /*
- *  MbedTLS SSL context deserializer from base64 code
+ *  Mbed TLS SSL context deserializer from base64 code
  *
  *  Copyright The Mbed TLS Contributors
  *  SPDX-License-Identifier: Apache-2.0

--- a/tests/scripts/check_names.py
+++ b/tests/scripts/check_names.py
@@ -930,7 +930,7 @@ def main():
             "This script confirms that the naming of all symbols and identifiers "
             "in Mbed TLS are consistent with the house style and are also "
             "self-consistent.\n\n"
-            "Expected to be run from the MbedTLS root directory.")
+            "Expected to be run from the Mbed TLS root directory.")
     )
     parser.add_argument(
         "-v", "--verbose",

--- a/tests/src/external_timing/timing_alt.h
+++ b/tests/src/external_timing/timing_alt.h
@@ -1,5 +1,5 @@
 /*
- * Copy of the internal MbedTLS timing implementation, to be used in tests.
+ * Copy of the internal Mbed TLS timing implementation, to be used in tests.
  */
 /*
  *  Copyright The Mbed TLS Contributors


### PR DESCRIPTION
## Description

Several bits of documentation were incorrectly styling Mbed TLS as MbedTLS.



## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required
- [x] **backport** done
- [x] **tests** not required



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.
