### PR TITLE
Support hw-accelerated AES on Thumb and Arm

### DIFF
--- a/ChangeLog.d/armv8-aesce.txt
+++ b/ChangeLog.d/armv8-aesce.txt
@@ -1,0 +1,3 @@
+Features
+   * Support use of Arm Crypto Extensions for hardware acclerated AES on
+     Thumb and Arm targets.

--- a/ChangeLog.d/armv8-aesce.txt
+++ b/ChangeLog.d/armv8-aesce.txt
@@ -1,3 +1,3 @@
 Features
-   * Support use of Arm Crypto Extensions for hardware acclerated AES on
+   * Support use of Armv8-A Crypto Extensions for hardware acclerated AES on
      Thumb and Arm targets.

--- a/ChangeLog.d/armv8-aesce.txt
+++ b/ChangeLog.d/armv8-aesce.txt
@@ -1,3 +1,3 @@
 Features
-   * Support use of Armv8-A Crypto Extensions for hardware acclerated AES on
-     Thumb and Arm targets.
+   * Support use of Armv8-A Cryptographic Extensions for hardware acclerated
+     AES when compiling for Thumb (T32) or 32-bit Arm (A32).

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -2258,13 +2258,14 @@
  *          system, Armv8-A Cryptographic Extensions must be supported by
  *          the CPU when this option is enabled.
  *
- * \note    Minimum compiler versions for this feature are Clang 4.0,
- *          armclang 6.6, GCC 6.0 or MSVC 2019 version 16.11.2.
+ * \note    Minimum compiler versions for this feature are Clang 4.0;
+ *          armclang 6.6 when targeting aarch64, or 6.20 when targeting
+ *          Thumb or 32-bit Arm; GCC 6.0; or MSVC 2019 version 16.11.2.
  *
  * \note \c CFLAGS must be set to a minimum of \c -march=armv8-a+crypto for
  * armclang <= 6.9
  *
- * This module adds support for the AES Armv8-A Cryptographic Extensions on Aarch64 systems.
+ * This module adds support for the AES Armv8-A Cryptographic Extensions on Armv8 systems.
  */
 #define MBEDTLS_AESCE_C
 

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -2247,7 +2247,7 @@
 /**
  * \def MBEDTLS_AESCE_C
  *
- * Enable AES cryptographic extension support on 64-bit Arm.
+ * Enable AES cryptographic extension support on Armv8.
  *
  * Module:  library/aesce.c
  * Caller:  library/aes.c

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -2258,9 +2258,10 @@
  *          system, Armv8-A Cryptographic Extensions must be supported by
  *          the CPU when this option is enabled.
  *
- * \note    Minimum compiler versions for this feature are Clang 4.0;
- *          armclang 6.6 when targeting aarch64, or 6.20 when targeting
- *          Thumb or 32-bit Arm; GCC 6.0; or MSVC 2019 version 16.11.2.
+ * \note    Minimum compiler versions for this feature when targeting aarch64
+ *          are Clang 4.0; armclang 6.6; GCC 6.0; or MSVC 2019 version 16.11.2.
+ *          Minimum compiler versions for this feature when targeting 32-bit
+ *          Arm or Thumb are Clang 11.0; armclang 6.20; or GCC 6.0.
  *
  * \note \c CFLAGS must be set to a minimum of \c -march=armv8-a+crypto for
  * armclang <= 6.9

--- a/library/aes.c
+++ b/library/aes.c
@@ -35,9 +35,9 @@
 #include "mbedtls/error.h"
 
 #if defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
-#if !((defined(MBEDTLS_ARCH_IS_ARM64) && defined(MBEDTLS_AESCE_C)) || \
-    (defined(MBEDTLS_ARCH_IS_X64)   && defined(MBEDTLS_AESNI_C)) || \
-    (defined(MBEDTLS_ARCH_IS_X86)   && defined(MBEDTLS_AESNI_C)))
+#if !((defined(MBEDTLS_ARCH_IS_ARMV8) && defined(MBEDTLS_AESCE_C)) || \
+    (defined(MBEDTLS_ARCH_IS_X64)     && defined(MBEDTLS_AESNI_C)) || \
+    (defined(MBEDTLS_ARCH_IS_X86)     && defined(MBEDTLS_AESNI_C)))
 #error "MBEDTLS_AES_USE_HARDWARE_ONLY defined, but not all prerequisites"
 #endif
 #endif

--- a/library/aes.c
+++ b/library/aes.c
@@ -35,9 +35,9 @@
 #include "mbedtls/error.h"
 
 #if defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
-#if !((defined(MBEDTLS_ARCH_IS_ARMV8) && defined(MBEDTLS_AESCE_C)) || \
-    (defined(MBEDTLS_ARCH_IS_X64)     && defined(MBEDTLS_AESNI_C)) || \
-    (defined(MBEDTLS_ARCH_IS_X86)     && defined(MBEDTLS_AESNI_C)))
+#if !((defined(MBEDTLS_ARCH_IS_ARMV8_A) && defined(MBEDTLS_AESCE_C)) || \
+    (defined(MBEDTLS_ARCH_IS_X64)       && defined(MBEDTLS_AESNI_C)) || \
+    (defined(MBEDTLS_ARCH_IS_X86)       && defined(MBEDTLS_AESNI_C)))
 #error "MBEDTLS_AES_USE_HARDWARE_ONLY defined, but not all prerequisites"
 #endif
 #endif

--- a/library/aesce.c
+++ b/library/aesce.c
@@ -108,7 +108,7 @@ typedef uint8x16_t poly128_t;
 static inline poly128_t vmull_p64(poly64_t a, poly64_t b)
 {
     poly128_t r;
-    asm ("vmull.p64	%[r], %[a], %[b]": [r] "=w" (r) : [a] "w" (a), [b] "w" (b) :);
+    asm ("vmull.p64 %[r], %[a], %[b]": [r] "=w" (r) : [a] "w" (a), [b] "w" (b) :);
     return r;
 }
 

--- a/library/aesce.c
+++ b/library/aesce.c
@@ -57,7 +57,7 @@
 
 #include "aesce.h"
 
-#if defined(MBEDTLS_ARCH_IS_ARMV8)
+#if defined(MBEDTLS_ARCH_IS_ARMV8) && defined(__ARM_NEON)
 
 /* Compiler version checks. */
 #if defined(__clang__)

--- a/library/aesce.c
+++ b/library/aesce.c
@@ -190,6 +190,16 @@ int mbedtls_aesce_has_support_impl(void)
      * once, but that is harmless.
      */
     if (mbedtls_aesce_has_support_result == -1) {
+#if defined(MBEDTLS_ARCH_IS_ARM32)
+        unsigned long auxval  = getauxval(AT_HWCAP);
+        unsigned long auxval2 = getauxval(AT_HWCAP2);
+        if (((auxval  & HWCAP_NEON) == HWCAP_NEON) &&
+            ((auxval2 & HWCAP2_AES) == HWCAP2_AES)) {
+            mbedtls_aesce_has_support_result = 1;
+        } else {
+            mbedtls_aesce_has_support_result = 0;
+        }
+#else
         unsigned long auxval = getauxval(AT_HWCAP);
         if ((auxval & (HWCAP_ASIMD | HWCAP_AES)) ==
             (HWCAP_ASIMD | HWCAP_AES)) {
@@ -197,6 +207,7 @@ int mbedtls_aesce_has_support_impl(void)
         } else {
             mbedtls_aesce_has_support_result = 0;
         }
+#endif
     }
     return mbedtls_aesce_has_support_result;
 }

--- a/library/aesce.c
+++ b/library/aesce.c
@@ -75,6 +75,15 @@
 #   if _MSC_VER < 1929
 #       error "Minimum version of MSVC for MBEDTLS_AESCE_C is 2019 version 16.11.2."
 #   endif
+#elif defined(__ARMCC_VERSION)
+#    if defined(MBEDTLS_ARCH_IS_ARM32) && (__ARMCC_VERSION < 6200002)
+/* TODO: We haven't verified armclang for 32-bit Arm/Thumb prior to 6.20.
+ * If someone verified that, please update this and document of
+ * `MBEDTLS_AESCE_C` in `mbedtls_config.h`. */
+#         error "Minimum version of armclang for MBEDTLS_AESCE_C on 32-bit Arm is 6.20."
+#    elif defined(MBEDTLS_ARCH_IS_ARM64) && (__ARMCC_VERSION < 6060000)
+#         error "Minimum version of armclang for MBEDTLS_AESCE_C on aarch64 is 6.6."
+#    endif
 #endif
 
 #ifdef __ARM_NEON

--- a/library/aesce.c
+++ b/library/aesce.c
@@ -93,7 +93,7 @@
 
 #if defined(MBEDTLS_ARCH_IS_ARM32)
 #if defined(__clang__)
-/* On clang for A32/T32, work around some missing intrinsics and types */
+/* On clang for A32/T32, work around some missing intrinsics and types which are listed in [ACLE](https://arm-software.github.io/acle/neon_intrinsics/advsimd.html#polynomial-1) */
 
 #ifndef vreinterpretq_p64_u8
 #define vreinterpretq_p64_u8 (poly64x2_t)

--- a/library/aesce.c
+++ b/library/aesce.c
@@ -118,8 +118,19 @@
 
 #if defined(__linux__) && !defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
 
-#include <asm/hwcap.h>
 #include <sys/auxv.h>
+#if !defined(HWCAP_NEON)
+#define HWCAP_NEON  (1 << 12)
+#endif
+#if !defined(HWCAP2_AES)
+#define HWCAP2_AES  (1 << 0)
+#endif
+#if !defined(HWCAP_AES)
+#define HWCAP_AES   (1 << 3)
+#endif
+#if !defined(HWCAP_ASIMD)
+#define HWCAP_ASIMD (1 << 1)
+#endif
 
 signed char mbedtls_aesce_has_support_result = -1;
 

--- a/library/aesce.c
+++ b/library/aesce.c
@@ -19,15 +19,15 @@
 
 #if defined(__clang__) &&  (__clang_major__ >= 4)
 
-/* Ideally, we would simply use MBEDTLS_ARCH_IS_ARMV8 in the following #if,
+/* Ideally, we would simply use MBEDTLS_ARCH_IS_ARMV8_A in the following #if,
  * but that is defined by build_info.h, and we need this block to happen first. */
 #if defined(__ARM_ARCH)
 #if __ARM_ARCH >= 8
-#define MBEDTLS_AESCE_ARCH_IS_ARMV8
+#define MBEDTLS_AESCE_ARCH_IS_ARMV8_A
 #endif
 #endif
 
-#if defined(MBEDTLS_AESCE_ARCH_IS_ARMV8) && !defined(__ARM_FEATURE_CRYPTO)
+#if defined(MBEDTLS_AESCE_ARCH_IS_ARMV8_A) && !defined(__ARM_FEATURE_CRYPTO)
 /* TODO: Re-consider above after https://reviews.llvm.org/D131064 merged.
  *
  * The intrinsic declaration are guarded by predefined ACLE macros in clang:
@@ -57,7 +57,7 @@
 
 #include "aesce.h"
 
-#if defined(MBEDTLS_ARCH_IS_ARMV8) && defined(__ARM_NEON)
+#if defined(MBEDTLS_ARCH_IS_ARMV8_A) && defined(__ARM_NEON)
 
 /* Compiler version checks. */
 #if defined(__clang__)
@@ -611,6 +611,6 @@ void mbedtls_aesce_gcm_mult(unsigned char c[16],
 #undef MBEDTLS_POP_TARGET_PRAGMA
 #endif
 
-#endif /* MBEDTLS_ARCH_IS_ARMV8 */
+#endif /* MBEDTLS_ARCH_IS_ARMV8_A */
 
 #endif /* MBEDTLS_AESCE_C */

--- a/library/aesce.c
+++ b/library/aesce.c
@@ -95,15 +95,9 @@
 #if defined(__clang__)
 /* On clang for A32/T32, work around some missing intrinsics and types which are listed in [ACLE](https://arm-software.github.io/acle/neon_intrinsics/advsimd.html#polynomial-1) */
 
-#ifndef vreinterpretq_p64_u8
 #define vreinterpretq_p64_u8 (poly64x2_t)
-#endif
-#ifndef vreinterpretq_u8_p128
 #define vreinterpretq_u8_p128 (uint8x16_t)
-#endif
-#ifndef vreinterpretq_u64_p64
 #define vreinterpretq_u64_p64 (uint64x2_t)
-#endif
 
 typedef uint8x16_t poly128_t;
 

--- a/library/aesce.c
+++ b/library/aesce.c
@@ -62,7 +62,7 @@
 /* Compiler version checks. */
 #if defined(__clang__)
 #   if defined(MBEDTLS_ARCH_IS_ARM32) && (__clang_major__ < 11)
-#       error "Minimum version of Clang for MBEDTLS_AESCE_C on 32-bit Arm or Thumb is 111.0."
+#       error "Minimum version of Clang for MBEDTLS_AESCE_C on 32-bit Arm or Thumb is 11.0."
 #   elif defined(MBEDTLS_ARCH_IS_ARM64) && (__clang_major__ < 4)
 #       error "Minimum version of Clang for MBEDTLS_AESCE_C on aarch64 is 4.0."
 #   endif

--- a/library/aesce.c
+++ b/library/aesce.c
@@ -61,8 +61,10 @@
 
 /* Compiler version checks. */
 #if defined(__clang__)
-#   if __clang_major__ < 4
-#       error "Minimum version of Clang for MBEDTLS_AESCE_C is 4.0."
+#   if defined(MBEDTLS_ARCH_IS_ARM32) && (__clang_major__ < 11)
+#       error "Minimum version of Clang for MBEDTLS_AESCE_C on 32-bit Arm or Thumb is 111.0."
+#   elif defined(MBEDTLS_ARCH_IS_ARM64) && (__clang_major__ < 4)
+#       error "Minimum version of Clang for MBEDTLS_AESCE_C on aarch64 is 4.0."
 #   endif
 #elif defined(__GNUC__)
 #   if __GNUC__ < 6

--- a/library/aesce.c
+++ b/library/aesce.c
@@ -568,7 +568,7 @@ static inline uint8x16_t poly_mult_reduce(uint8x16x3_t input)
     /* use 'asm' as an optimisation barrier to prevent loading MODULO from
      * memory. It is for GNUC compatible compilers.
      */
-    asm ("" : "+w" (r));
+    asm volatile ("" : "+w" (r));
 #endif
     uint8x16_t const MODULO = vreinterpretq_u8_u64(vshrq_n_u64(r, 64 - 8));
     uint8x16_t h, m, l; /* input high/middle/low 128b */

--- a/library/aesce.c
+++ b/library/aesce.c
@@ -104,7 +104,7 @@ typedef uint8x16_t poly128_t;
 static inline poly128_t vmull_p64(poly64_t a, poly64_t b)
 {
     poly128_t r;
-    asm ("vmull.p64 %[r], %[a], %[b]": [r] "=w" (r) : [a] "w" (a), [b] "w" (b) :);
+    asm ("vmull.p64 %[r], %[a], %[b]" : [r] "=w" (r) : [a] "w" (a), [b] "w" (b) :);
     return r;
 }
 

--- a/library/aesce.h
+++ b/library/aesce.h
@@ -2,7 +2,7 @@
  * \file aesce.h
  *
  * \brief Support hardware AES acceleration on Armv8-A processors with
- *        the Armv8-A Cryptographic Extension in AArch64 execution state.
+ *        the Armv8-A Cryptographic Extension.
  *
  * \warning These functions are only for internal use by other library
  *          functions; you must not call them directly.
@@ -31,7 +31,7 @@
 #include "mbedtls/aes.h"
 
 
-#if defined(MBEDTLS_AESCE_C) && defined(MBEDTLS_ARCH_IS_ARMV8)
+#if defined(MBEDTLS_AESCE_C) && defined(MBEDTLS_ARCH_IS_ARMV8) && defined(__ARM_NEON)
 
 #define MBEDTLS_AESCE_HAVE_CODE
 
@@ -128,6 +128,12 @@ int mbedtls_aesce_setkey_enc(unsigned char *rk,
 }
 #endif
 
-#endif /* MBEDTLS_AESCE_C && MBEDTLS_ARCH_IS_ARM64 */
+#else
+
+#if defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
+#error "AES hardware acceleration not supported on this platform"
+#endif
+
+#endif /* MBEDTLS_AESCE_C && MBEDTLS_ARCH_IS_ARMV8 && __ARM_NEON */
 
 #endif /* MBEDTLS_AESCE_H */

--- a/library/aesce.h
+++ b/library/aesce.h
@@ -31,7 +31,7 @@
 #include "mbedtls/aes.h"
 
 
-#if defined(MBEDTLS_AESCE_C) && defined(MBEDTLS_ARCH_IS_ARM64)
+#if defined(MBEDTLS_AESCE_C) && defined(MBEDTLS_ARCH_IS_ARMV8)
 
 #define MBEDTLS_AESCE_HAVE_CODE
 

--- a/library/aesce.h
+++ b/library/aesce.h
@@ -130,7 +130,7 @@ int mbedtls_aesce_setkey_enc(unsigned char *rk,
 
 #else
 
-#if defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
+#if defined(MBEDTLS_AES_USE_HARDWARE_ONLY) && defined(MBEDTLS_ARCH_IS_ARMV8)
 #error "AES hardware acceleration not supported on this platform"
 #endif
 

--- a/library/aesce.h
+++ b/library/aesce.h
@@ -31,7 +31,7 @@
 #include "mbedtls/aes.h"
 
 
-#if defined(MBEDTLS_AESCE_C) && defined(MBEDTLS_ARCH_IS_ARMV8) && defined(__ARM_NEON)
+#if defined(MBEDTLS_AESCE_C) && defined(MBEDTLS_ARCH_IS_ARMV8_A) && defined(__ARM_NEON)
 
 #define MBEDTLS_AESCE_HAVE_CODE
 
@@ -130,10 +130,10 @@ int mbedtls_aesce_setkey_enc(unsigned char *rk,
 
 #else
 
-#if defined(MBEDTLS_AES_USE_HARDWARE_ONLY) && defined(MBEDTLS_ARCH_IS_ARMV8)
+#if defined(MBEDTLS_AES_USE_HARDWARE_ONLY) && defined(MBEDTLS_ARCH_IS_ARMV8_A)
 #error "AES hardware acceleration not supported on this platform"
 #endif
 
-#endif /* MBEDTLS_AESCE_C && MBEDTLS_ARCH_IS_ARMV8 && __ARM_NEON */
+#endif /* MBEDTLS_AESCE_C && MBEDTLS_ARCH_IS_ARMV8_A && __ARM_NEON */
 
 #endif /* MBEDTLS_AESCE_H */

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -4411,21 +4411,16 @@ component_build_aes_armce () {
     msg "MBEDTLS_AES_USE_HARDWARE_ONLY, clang, thumb"
     make -B library/aesce.o CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a32+crypto -mthumb"
 
-    # we need asm/hwcap.h available for runtime detection
-    if (echo '#include <asm/hwcap.h>' | clang -E - >/dev/null 2>&1); then
-        scripts/config.py unset MBEDTLS_AES_USE_HARDWARE_ONLY
+    scripts/config.py unset MBEDTLS_AES_USE_HARDWARE_ONLY
 
-        msg "no MBEDTLS_AES_USE_HARDWARE_ONLY, clang, aarch64"
-        make -B library/aesce.o CC=clang CFLAGS="--target=aarch64-linux-gnu -march=armv8-a+crypto"
+    msg "no MBEDTLS_AES_USE_HARDWARE_ONLY, clang, aarch64"
+    make -B library/aesce.o CC=clang CFLAGS="--target=aarch64-linux-gnu -march=armv8-a+crypto"
 
-        msg "no MBEDTLS_AES_USE_HARDWARE_ONLY, clang, arm"
-        make -B library/aesce.o CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a72+crypto -marm"
+    msg "no MBEDTLS_AES_USE_HARDWARE_ONLY, clang, arm"
+    make -B library/aesce.o CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a72+crypto -marm"
 
-        msg "no MBEDTLS_AES_USE_HARDWARE_ONLY, clang, thumb"
-        make -B library/aesce.o CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a32+crypto -mthumb"
-    else
-        msg "can't include <asm/hwcap.h> - skipping runtime detection tests"
-    fi
+    msg "no MBEDTLS_AES_USE_HARDWARE_ONLY, clang, thumb"
+    make -B library/aesce.o CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a32+crypto -mthumb"
 
     # test for presence of AES instructions
     scripts/config.py set MBEDTLS_AES_USE_HARDWARE_ONLY

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -4403,7 +4403,7 @@ component_build_aes_armce () {
     scripts/config.py set MBEDTLS_AES_USE_HARDWARE_ONLY
 
     msg "MBEDTLS_AES_USE_HARDWARE_ONLY, clang, aarch64"
-    make -B library/aesce.o CC=clang CFLAGS="--target=aarch64-linux-gnu -march=armv8-a"
+    make -B library/aesce.o CC=clang CFLAGS="--target=aarch64-linux-gnu -march=armv8-a+crypto"
 
     msg "MBEDTLS_AES_USE_HARDWARE_ONLY, clang, arm"
     make -B library/aesce.o CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a72+crypto -marm"
@@ -4414,7 +4414,7 @@ component_build_aes_armce () {
     scripts/config.py unset MBEDTLS_AES_USE_HARDWARE_ONLY
 
     msg "no MBEDTLS_AES_USE_HARDWARE_ONLY, clang, aarch64"
-    make -B library/aesce.o CC=clang CFLAGS="--target=aarch64-linux-gnu -march=armv8-a"
+    make -B library/aesce.o CC=clang CFLAGS="--target=aarch64-linux-gnu -march=armv8-a+crypto"
 
     msg "no MBEDTLS_AES_USE_HARDWARE_ONLY, clang, arm"
     make -B library/aesce.o CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a72+crypto -marm"

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -4411,16 +4411,21 @@ component_build_aes_armce () {
     msg "MBEDTLS_AES_USE_HARDWARE_ONLY, clang, thumb"
     make -B library/aesce.o CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a32+crypto -mthumb"
 
-    scripts/config.py unset MBEDTLS_AES_USE_HARDWARE_ONLY
+    # we need asm/hwcap.h available for runtime detection
+    if (echo '#include <asm/hwcap.h>' | clang -E - >/dev/null 2>&1); then
+        scripts/config.py unset MBEDTLS_AES_USE_HARDWARE_ONLY
 
-    msg "no MBEDTLS_AES_USE_HARDWARE_ONLY, clang, aarch64"
-    make -B library/aesce.o CC=clang CFLAGS="--target=aarch64-linux-gnu -march=armv8-a+crypto"
+        msg "no MBEDTLS_AES_USE_HARDWARE_ONLY, clang, aarch64"
+        make -B library/aesce.o CC=clang CFLAGS="--target=aarch64-linux-gnu -march=armv8-a+crypto"
 
-    msg "no MBEDTLS_AES_USE_HARDWARE_ONLY, clang, arm"
-    make -B library/aesce.o CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a72+crypto -marm"
+        msg "no MBEDTLS_AES_USE_HARDWARE_ONLY, clang, arm"
+        make -B library/aesce.o CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a72+crypto -marm"
 
-    msg "no MBEDTLS_AES_USE_HARDWARE_ONLY, clang, thumb"
-    make -B library/aesce.o CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a32+crypto -mthumb"
+        msg "no MBEDTLS_AES_USE_HARDWARE_ONLY, clang, thumb"
+        make -B library/aesce.o CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a32+crypto -mthumb"
+    else
+        msg "can't include <asm/hwcap.h> - skipping runtime detection tests"
+    fi
 }
 
 support_build_sha_armce() {

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -4391,6 +4391,38 @@ component_build_aes_aesce_armcc () {
     armc6_build_test "-O1 --target=aarch64-arm-none-eabi -march=armv8-a+crypto"
 }
 
+support_build_aes_armce() {
+    # clang >= 4 is required to build with AES extensions
+    ver="$(clang --version|grep version|sed -E 's#.*version ([0-9]+).*#\1#')"
+    [ "${ver}" -ge 4 ]
+}
+
+component_build_aes_armce () {
+    # Test variations of AES with Armv8 crypto extensions
+    scripts/config.py set MBEDTLS_AESCE_C
+    scripts/config.py set MBEDTLS_AES_USE_HARDWARE_ONLY
+
+    msg "MBEDTLS_AES_USE_HARDWARE_ONLY, clang, aarch64"
+    make -B library/aesce.o CC=clang CFLAGS="--target=aarch64-linux-gnu -march=armv8-a"
+
+    msg "MBEDTLS_AES_USE_HARDWARE_ONLY, clang, arm"
+    make -B library/aesce.o CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a72+crypto -marm"
+
+    msg "MBEDTLS_AES_USE_HARDWARE_ONLY, clang, thumb"
+    make -B library/aesce.o CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a32+crypto -mthumb"
+
+    scripts/config.py unset MBEDTLS_AES_USE_HARDWARE_ONLY
+
+    msg "no MBEDTLS_AES_USE_HARDWARE_ONLY, clang, aarch64"
+    make -B library/aesce.o CC=clang CFLAGS="--target=aarch64-linux-gnu -march=armv8-a"
+
+    msg "no MBEDTLS_AES_USE_HARDWARE_ONLY, clang, arm"
+    make -B library/aesce.o CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a72+crypto -marm"
+
+    msg "no MBEDTLS_AES_USE_HARDWARE_ONLY, clang, thumb"
+    make -B library/aesce.o CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a32+crypto -mthumb"
+}
+
 support_build_sha_armce() {
     if command -v clang > /dev/null ; then
         # clang >= 4 is required to build with SHA extensions

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -5044,6 +5044,9 @@ component_build_armcc () {
     # armc[56] don't support SHA-512 intrinsics
     scripts/config.py unset MBEDTLS_SHA512_USE_A64_CRYPTO_IF_PRESENT
 
+    # older versions of armcc/armclang don't support AESCE_C on 32-bit Arm
+    scripts/config.py unset MBEDTLS_AESCE_C
+
     # Stop armclang warning about feature detection for A64_CRYPTO.
     # With this enabled, the library does build correctly under armclang,
     # but in baremetal builds (as tested here), feature detection is
@@ -5078,14 +5081,18 @@ component_build_armcc () {
     # ARM Compiler 6 - Target ARMv8-M
     armc6_build_test "-O1 --target=arm-arm-none-eabi -march=armv8-m.main"
 
-    # ARM Compiler 6 - Target ARMv8.2-A - AArch64
-    armc6_build_test "-O1 --target=aarch64-arm-none-eabi -march=armv8.2-a+crypto"
-
     # ARM Compiler 6 - Target Cortex-M0 - no optimisation
     armc6_build_test "-O0 --target=arm-arm-none-eabi -mcpu=cortex-m0"
 
     # ARM Compiler 6 - Target Cortex-M0
     armc6_build_test "-Os --target=arm-arm-none-eabi -mcpu=cortex-m0"
+
+    # ARM Compiler 6 - Target ARMv8.2-A - AArch64
+    #
+    # Re-enable MBEDTLS_AESCE_C as this should be supported by the version of armclang
+    # that we have in our CI
+    scripts/config.py set MBEDTLS_AESCE_C
+    armc6_build_test "-O1 --target=aarch64-arm-none-eabi -march=armv8.2-a+crypto"
 }
 
 support_build_armcc () {

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -4394,7 +4394,7 @@ component_build_aes_aesce_armcc () {
 support_build_aes_armce() {
     # clang >= 4 is required to build with AES extensions
     ver="$(clang --version|grep version|sed -E 's#.*version ([0-9]+).*#\1#')"
-    [ "${ver}" -ge 4 ]
+    [ "${ver}" -ge 11 ]
 }
 
 component_build_aes_armce () {

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -4426,6 +4426,31 @@ component_build_aes_armce () {
     else
         msg "can't include <asm/hwcap.h> - skipping runtime detection tests"
     fi
+
+    # test for presence of AES instructions
+    scripts/config.py set MBEDTLS_AES_USE_HARDWARE_ONLY
+    msg "clang, test A32 crypto instructions built"
+    make -B library/aesce.o CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a72+crypto -marm -S"
+    grep -E 'aes[0-9a-z]+.[0-9]\s*[qv]' library/aesce.o
+    msg "clang, test T32 crypto instructions built"
+    make -B library/aesce.o CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a32+crypto -mthumb -S"
+    grep -E 'aes[0-9a-z]+.[0-9]\s*[qv]' library/aesce.o
+    msg "clang, test aarch64 crypto instructions built"
+    make -B library/aesce.o CC=clang CFLAGS="--target=aarch64-linux-gnu -march=armv8-a -S"
+    grep -E 'aes[a-z]+\s*[qv]' library/aesce.o
+
+    # test for absence of AES instructions
+    scripts/config.py unset MBEDTLS_AES_USE_HARDWARE_ONLY
+    scripts/config.py unset MBEDTLS_AESCE_C
+    msg "clang, test A32 crypto instructions not built"
+    make -B library/aesce.o CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a72+crypto -marm -S"
+    not grep -E 'aes[0-9a-z]+.[0-9]\s*[qv]' library/aesce.o
+    msg "clang, test T32 crypto instructions not built"
+    make -B library/aesce.o CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a32+crypto -mthumb -S"
+    not grep -E 'aes[0-9a-z]+.[0-9]\s*[qv]' library/aesce.o
+    msg "clang, test aarch64 crypto instructions not built"
+    make -B library/aesce.o CC=clang CFLAGS="--target=aarch64-linux-gnu -march=armv8-a -S"
+    not grep -E 'aes[a-z]+\s*[qv]' library/aesce.o
 }
 
 support_build_sha_armce() {


### PR DESCRIPTION
## Description

Extend support for AESCE to 32-bit builds.

Saves around 450b for Thumb 2 -Oz (but not for TF-M, because our reference target doesn't have Neon).

Manually tested via qemu, for arm, thumb and aarch64 with gcc and clang.

Do we want to put this in the Changelog as Security, because it enables const-time AES for these targets?

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** provided
- [x] **backport** no - not a bugfix
- [x] **tests** provided - build test only. Manually tested with qemu
