### PR TITLE
Adapt to new PSA Crypto repo name

### DIFF
--- a/include/psa/crypto_platform.h
+++ b/include/psa/crypto_platform.h
@@ -35,7 +35,7 @@
 #include "mbedtls/private_access.h"
 
 /*
- * Include the build-time configuration information file. Here, we do not
+ * Include the build-time configuration information header. Here, we do not
  * include `"mbedtls/build_info.h"` directly but `"psa/build_info.h"`, which
  * is basically just an alias to it. This is to ease the maintenance of the
  * TF-PSA-Crypto repository which has a different build system and

--- a/include/psa/crypto_platform.h
+++ b/include/psa/crypto_platform.h
@@ -38,7 +38,7 @@
  * Include the build-time configuration information file. Here, we do not
  * include `"mbedtls/build_info.h"` directly but `"psa/build_info.h"`, which
  * is basically just an alias to it. This is to ease the maintenance of the
- * PSA cryptography repository which has a different build system and
+ * TF-PSA-Crypto repository which has a different build system and
  * configuration.
  */
 #include "psa/build_info.h"

--- a/include/psa/crypto_sizes.h
+++ b/include/psa/crypto_sizes.h
@@ -44,7 +44,7 @@
  * Include the build-time configuration information file. Here, we do not
  * include `"mbedtls/build_info.h"` directly but `"psa/build_info.h"`, which
  * is basically just an alias to it. This is to ease the maintenance of the
- * PSA cryptography repository which has a different build system and
+ * TF-PSA-Crypto repository which has a different build system and
  * configuration.
  */
 #include "psa/build_info.h"

--- a/include/psa/crypto_sizes.h
+++ b/include/psa/crypto_sizes.h
@@ -41,7 +41,7 @@
 #define PSA_CRYPTO_SIZES_H
 
 /*
- * Include the build-time configuration information file. Here, we do not
+ * Include the build-time configuration information header. Here, we do not
  * include `"mbedtls/build_info.h"` directly but `"psa/build_info.h"`, which
  * is basically just an alias to it. This is to ease the maintenance of the
  * TF-PSA-Crypto repository which has a different build system and

--- a/include/psa/crypto_struct.h
+++ b/include/psa/crypto_struct.h
@@ -66,9 +66,14 @@
 extern "C" {
 #endif
 
-/* Include the Mbed TLS configuration file, the way Mbed TLS does it
- * in each of its header files. */
-#include "mbedtls/build_info.h"
+/*
+ * Include the build-time configuration information header. Here, we do not
+ * include `"mbedtls/build_info.h"` directly but `"psa/build_info.h"`, which
+ * is basically just an alias to it. This is to ease the maintenance of the
+ * TF-PSA-Crypto repository which has a different build system and
+ * configuration.
+ */
+#include "psa/build_info.h"
 
 /* Include the context definition for the compiled-in drivers for the primitive
  * algorithms. */

--- a/include/psa/crypto_types.h
+++ b/include/psa/crypto_types.h
@@ -33,8 +33,15 @@
 #ifndef PSA_CRYPTO_TYPES_H
 #define PSA_CRYPTO_TYPES_H
 
-/* Make sure the Mbed TLS configuration is visible. */
-#include "mbedtls/build_info.h"
+/*
+ * Include the build-time configuration information header. Here, we do not
+ * include `"mbedtls/build_info.h"` directly but `"psa/build_info.h"`, which
+ * is basically just an alias to it. This is to ease the maintenance of the
+ * TF-PSA-Crypto repository which has a different build system and
+ * configuration.
+ */
+#include "psa/build_info.h"
+
 /* Define the MBEDTLS_PRIVATE macro. */
 #include "mbedtls/private_access.h"
 

--- a/library/psa_crypto_core.h
+++ b/library/psa_crypto_core.h
@@ -21,7 +21,14 @@
 #ifndef PSA_CRYPTO_CORE_H
 #define PSA_CRYPTO_CORE_H
 
-#include "mbedtls/build_info.h"
+/*
+ * Include the build-time configuration information header. Here, we do not
+ * include `"mbedtls/build_info.h"` directly but `"psa/build_info.h"`, which
+ * is basically just an alias to it. This is to ease the maintenance of the
+ * TF-PSA-Crypto repository which has a different build system and
+ * configuration.
+ */
+#include "psa/build_info.h"
 
 #include "psa/crypto.h"
 #include "psa/crypto_se_driver.h"

--- a/library/psa_crypto_invasive.h
+++ b/library/psa_crypto_invasive.h
@@ -28,7 +28,14 @@
 #ifndef PSA_CRYPTO_INVASIVE_H
 #define PSA_CRYPTO_INVASIVE_H
 
-#include "mbedtls/build_info.h"
+/*
+ * Include the build-time configuration information header. Here, we do not
+ * include `"mbedtls/build_info.h"` directly but `"psa/build_info.h"`, which
+ * is basically just an alias to it. This is to ease the maintenance of the
+ * TF-PSA-Crypto repository which has a different build system and
+ * configuration.
+ */
+#include "psa/build_info.h"
 
 #include "psa/crypto.h"
 #include "common.h"

--- a/library/psa_crypto_se.h
+++ b/library/psa_crypto_se.h
@@ -21,7 +21,14 @@
 #ifndef PSA_CRYPTO_SE_H
 #define PSA_CRYPTO_SE_H
 
-#include "mbedtls/build_info.h"
+/*
+ * Include the build-time configuration information header. Here, we do not
+ * include `"mbedtls/build_info.h"` directly but `"psa/build_info.h"`, which
+ * is basically just an alias to it. This is to ease the maintenance of the
+ * TF-PSA-Crypto repository which has a different build system and
+ * configuration.
+ */
+#include "psa/build_info.h"
 
 #include "psa/crypto.h"
 #include "psa/crypto_se_driver.h"

--- a/scripts/mbedtls_dev/build_tree.py
+++ b/scripts/mbedtls_dev/build_tree.py
@@ -19,7 +19,7 @@
 import os
 import inspect
 
-def looks_like_psa_crypto_root(path: str) -> bool:
+def looks_like_tf_psa_crypto_root(path: str) -> bool:
     """Whether the given directory looks like the root of the PSA Crypto source tree."""
     return all(os.path.isdir(os.path.join(path, subdir))
                for subdir in ['include', 'core', 'drivers', 'programs', 'tests'])
@@ -30,7 +30,7 @@ def looks_like_mbedtls_root(path: str) -> bool:
                for subdir in ['include', 'library', 'programs', 'tests'])
 
 def looks_like_root(path: str) -> bool:
-    return looks_like_psa_crypto_root(path) or looks_like_mbedtls_root(path)
+    return looks_like_tf_psa_crypto_root(path) or looks_like_mbedtls_root(path)
 
 def check_repo_path():
     """

--- a/scripts/mbedtls_dev/psa_storage.py
+++ b/scripts/mbedtls_dev/psa_storage.py
@@ -53,7 +53,7 @@ class Expr:
         """Update `value_cache` for expressions registered in `unknown_values`."""
         expressions = sorted(self.unknown_values)
         includes = ['include']
-        if build_tree.looks_like_psa_crypto_root('.'):
+        if build_tree.looks_like_tf_psa_crypto_root('.'):
             includes.append('drivers/builtin/include')
         values = c_build_helper.get_c_expression_values(
             'unsigned long', '%lu',

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -127,13 +127,13 @@ in_mbedtls_repo () {
     test -d include -a -d library -a -d programs -a -d tests
 }
 
-in_psa_crypto_repo () {
+in_tf_psa_crypto_repo () {
     test -d include -a -d core -a -d drivers -a -d programs -a -d tests
 }
 
 pre_check_environment () {
-    if in_mbedtls_repo || in_psa_crypto_repo; then :; else
-        echo "Must be run from Mbed TLS / psa-crypto root" >&2
+    if in_mbedtls_repo || in_tf_psa_crypto_repo; then :; else
+        echo "Must be run from Mbed TLS / TF-PSA-Crypto root" >&2
         exit 1
     fi
 }

--- a/tests/scripts/test_psa_compliance.py
+++ b/tests/scripts/test_psa_compliance.py
@@ -2,7 +2,7 @@
 """Run the PSA Crypto API compliance test suite.
 Clone the repo and check out the commit specified by PSA_ARCH_TEST_REPO and PSA_ARCH_TEST_REF,
 then compile and run the test suite. The clone is stored at <repository root>/psa-arch-tests.
-Known defects in either the test suite or mbedtls / psa-crypto - identified by their test
+Known defects in either the test suite or mbedtls / TF-PSA-Crypto - identified by their test
 number - are ignored, while unexpected failures AND successes are reported as errors, to help
 keep the list of known defects as up to date as possible.
 """
@@ -34,8 +34,8 @@ from typing import List
 import scripts_path
 from mbedtls_dev import build_tree
 
-# PSA Compliance tests we expect to fail due to known defects in Mbed TLS / PSA Crypto
-# (or the test suite).
+# PSA Compliance tests we expect to fail due to known defects in Mbed TLS /
+# TF-PSA-Crypto (or the test suite).
 # The test numbers correspond to the numbers used by the console output of the test suite.
 # Test number 2xx corresponds to the files in the folder
 # psa-arch-tests/api-tests/dev_apis/crypto/test_c0xx
@@ -60,10 +60,10 @@ PSA_ARCH_TESTS_REF = 'fix-pr-5736'
 def main(library_build_dir: str):
     root_dir = os.getcwd()
 
-    in_psa_crypto_repo = build_tree.looks_like_psa_crypto_root(root_dir)
+    in_tf_psa_crypto_repo = build_tree.looks_like_tf_psa_crypto_root(root_dir)
 
-    if in_psa_crypto_repo:
-        crypto_name = 'psacrypto'
+    if in_tf_psa_crypto_repo:
+        crypto_name = 'tfpsacrypto'
         library_subdir = 'core'
     else:
         crypto_name = 'mbedcrypto'
@@ -102,7 +102,7 @@ def main(library_build_dir: str):
         os.chdir(build_dir)
 
         extra_includes = (';{}/drivers/builtin/include'.format(root_dir)
-                          if in_psa_crypto_repo else '')
+                          if in_tf_psa_crypto_repo else '')
 
         #pylint: disable=bad-continuation
         subprocess.check_call([
@@ -178,7 +178,7 @@ if __name__ == '__main__':
     # pylint: disable=invalid-name
     parser = argparse.ArgumentParser()
     parser.add_argument('--build-dir', nargs=1,
-                        help='path to Mbed TLS / PSA Crypto build directory')
+                        help='path to Mbed TLS / TF-PSA-Crypto build directory')
     args = parser.parse_args()
 
     if args.build_dir is not None:


### PR DESCRIPTION
## Description

Patterns I looked for:
grep -i "psa-crypto"
grep -i "psa.*crypto.*repo"
grep -i "psa.*crypto.*root"

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required, no change for users
- [x] **backport** not required, 3.x only code
- [x] **tests** not required, just some renaming