### PR TITLE
sha256_context: guard is224 by MBEDTLS_SHA224_C

### DIFF
--- a/include/mbedtls/sha256.h
+++ b/include/mbedtls/sha256.h
@@ -53,8 +53,10 @@ typedef struct mbedtls_sha256_context {
     unsigned char MBEDTLS_PRIVATE(buffer)[64];   /*!< The data block being processed. */
     uint32_t MBEDTLS_PRIVATE(total)[2];          /*!< The number of Bytes processed.  */
     uint32_t MBEDTLS_PRIVATE(state)[8];          /*!< The intermediate digest state.  */
+#if defined(MBEDTLS_SHA224_C)
     int MBEDTLS_PRIVATE(is224);                  /*!< Determines which function to use:
                                                     0: Use SHA-256, or 1: Use SHA-224. */
+#endif
 }
 mbedtls_sha256_context;
 


### PR DESCRIPTION
## Description

`is224` should be guarded by `MBEDTLS_SHA224_C`, same as `is384` in `sha512.h`.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required
- [x] **backport** There is no separation between `SHA-224` and `SHA-256` in `mbedtls-2.28`. So backport is not required.
- [x] **tests** not required
