### PR TITLE
Fix C++ build issue when MBEDTLS_ASN1_PARSE_C is not enabled

### DIFF
--- a/ChangeLog.d/fix-cpp-compilation-error.txt
+++ b/ChangeLog.d/fix-cpp-compilation-error.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix compilation error in C++ programs when MBEDTLS_ASN1_PARSE_C is
+     disabled.

--- a/include/mbedtls/asn1.h
+++ b/include/mbedtls/asn1.h
@@ -644,10 +644,10 @@ void mbedtls_asn1_free_named_data_list_shallow(mbedtls_asn1_named_data *name);
 /** \} name Functions to parse ASN.1 data structures */
 /** \} addtogroup asn1_module */
 
+#endif /* MBEDTLS_ASN1_PARSE_C */
+
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* MBEDTLS_ASN1_PARSE_C */
 
 #endif /* asn1.h */


### PR DESCRIPTION
## Description

The closing curly bracket of `extern "C" {` is excluded when `MBEDTLS_ASN1_PARSE_C` is not defined, due to incorrect position of the `#endif /* MBEDTLS_ASN1_PARSE_C */`.

## PR checklist

- [x] **changelog** provided
- [x] **backport** not required because the issue is not present in 2.28
- [x] **tests** not required
