### PR TITLE
Backport 2.28: Benchmark: add AES_CFB128 and AES_CFB8 

### DIFF
--- a/programs/test/benchmark.c
+++ b/programs/test/benchmark.c
@@ -436,6 +436,7 @@ int main(int argc, char *argv[])
 #if defined(MBEDTLS_ARC4_C)
     if (todo.arc4) {
         mbedtls_arc4_context arc4;
+
         mbedtls_arc4_init(&arc4);
         mbedtls_arc4_setup(&arc4, tmp, 32);
         TIME_AND_TSC("ARC4", mbedtls_arc4_crypt(&arc4, BUFSIZE, buf, buf));
@@ -447,6 +448,7 @@ int main(int argc, char *argv[])
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
     if (todo.des3) {
         mbedtls_des3_context des3;
+
         mbedtls_des3_init(&des3);
         if (mbedtls_des3_set3key_enc(&des3, tmp) != 0) {
             mbedtls_exit(1);
@@ -458,6 +460,7 @@ int main(int argc, char *argv[])
 
     if (todo.des) {
         mbedtls_des_context des;
+
         mbedtls_des_init(&des);
         if (mbedtls_des_setkey_enc(&des, tmp) != 0) {
             mbedtls_exit(1);
@@ -490,6 +493,7 @@ int main(int argc, char *argv[])
     if (todo.aes_cbc) {
         int keysize;
         mbedtls_aes_context aes;
+
         mbedtls_aes_init(&aes);
         for (keysize = 128; keysize <= 256; keysize += 64) {
             mbedtls_snprintf(title, sizeof(title), "AES-CBC-%d", keysize);
@@ -509,6 +513,7 @@ int main(int argc, char *argv[])
         int keysize;
         size_t iv_off = 0;
         mbedtls_aes_context aes;
+
         mbedtls_aes_init(&aes);
         for (keysize = 128; keysize <= 256; keysize += 64) {
             mbedtls_snprintf(title, sizeof(title), "AES-CFB128-%d", keysize);
@@ -526,6 +531,7 @@ int main(int argc, char *argv[])
     if (todo.aes_cfb8) {
         int keysize;
         mbedtls_aes_context aes;
+
         mbedtls_aes_init(&aes);
         for (keysize = 128; keysize <= 256; keysize += 64) {
             mbedtls_snprintf(title, sizeof(title), "AES-CFB8-%d", keysize);
@@ -657,6 +663,7 @@ int main(int argc, char *argv[])
     if (todo.aria) {
         int keysize;
         mbedtls_aria_context aria;
+
         mbedtls_aria_init(&aria);
         for (keysize = 128; keysize <= 256; keysize += 64) {
             mbedtls_snprintf(title, sizeof(title), "ARIA-CBC-%d", keysize);
@@ -677,6 +684,7 @@ int main(int argc, char *argv[])
     if (todo.camellia) {
         int keysize;
         mbedtls_camellia_context camellia;
+
         mbedtls_camellia_init(&camellia);
         for (keysize = 128; keysize <= 256; keysize += 64) {
             mbedtls_snprintf(title, sizeof(title), "CAMELLIA-CBC-%d", keysize);
@@ -709,6 +717,7 @@ int main(int argc, char *argv[])
     if (todo.blowfish) {
         int keysize;
         mbedtls_blowfish_context blowfish;
+
         mbedtls_blowfish_init(&blowfish);
 
         for (keysize = 128; keysize <= 256; keysize += 64) {
@@ -730,6 +739,7 @@ int main(int argc, char *argv[])
 #if defined(MBEDTLS_HAVEGE_C)
     if (todo.havege) {
         mbedtls_havege_state hs;
+
         mbedtls_havege_init(&hs);
         TIME_AND_TSC("HAVEGE", mbedtls_havege_random(&hs, buf, BUFSIZE));
         mbedtls_havege_free(&hs);
@@ -814,6 +824,7 @@ int main(int argc, char *argv[])
     if (todo.rsa) {
         int keysize;
         mbedtls_rsa_context rsa;
+
         for (keysize = 2048; keysize <= 4096; keysize *= 2) {
             mbedtls_snprintf(title, sizeof(title), "RSA-%d", keysize);
 
@@ -855,6 +866,7 @@ int main(int argc, char *argv[])
 
         mbedtls_dhm_context dhm;
         size_t olen;
+
         for (i = 0; (size_t) i < sizeof(dhm_sizes) / sizeof(dhm_sizes[0]); i++) {
             mbedtls_dhm_init(&dhm);
 
@@ -968,6 +980,7 @@ int main(int argc, char *argv[])
 
         if (curve_list == (const mbedtls_ecp_curve_info *) &single_curve) {
             mbedtls_ecp_group grp;
+
             mbedtls_ecp_group_init(&grp);
             if (mbedtls_ecp_group_load(&grp, curve_list->grp_id) != 0) {
                 mbedtls_exit(1);

--- a/programs/test/benchmark.c
+++ b/programs/test/benchmark.c
@@ -89,12 +89,12 @@ int main(void)
 #define HEADER_FORMAT   "  %-24s :  "
 #define TITLE_LEN       25
 
-#define OPTIONS                                                         \
-    "md4, md5, ripemd160, sha1, sha256, sha512,\n"                      \
-    "arc4, des3, des, camellia, blowfish, chacha20,\n"                  \
-    "aes_cbc, aes_cfb128, aes_gcm, aes_ccm, aes_xts, chachapoly,\n"     \
-    "aes_cmac, des3_cmac, poly1305\n"                                   \
-    "havege, ctr_drbg, hmac_drbg\n"                                     \
+#define OPTIONS                                                               \
+    "md4, md5, ripemd160, sha1, sha256, sha512,\n"                            \
+    "arc4, des3, des, camellia, blowfish, chacha20,\n"                        \
+    "aes_cbc, aes_cfb128, aes_cfb8, aes_gcm, aes_ccm, aes_xts, chachapoly,\n" \
+    "aes_cmac, des3_cmac, poly1305\n"                                         \
+    "havege, ctr_drbg, hmac_drbg\n"                                           \
     "rsa, dhm, ecdsa, ecdh.\n"
 
 #if defined(MBEDTLS_ERROR_C)
@@ -280,7 +280,7 @@ unsigned char buf[BUFSIZE];
 typedef struct {
     char md4, md5, ripemd160, sha1, sha256, sha512,
          arc4, des3, des,
-         aes_cbc, aes_cfb128, aes_gcm, aes_ccm, aes_xts, chachapoly,
+         aes_cbc, aes_cfb128, aes_cfb8, aes_gcm, aes_ccm, aes_xts, chachapoly,
          aes_cmac, des3_cmac,
          aria, camellia, blowfish, chacha20,
          poly1305,
@@ -338,6 +338,8 @@ int main(int argc, char *argv[])
                 todo.aes_cbc = 1;
             } else if (strcmp(argv[i], "aes_cfb128") == 0) {
                 todo.aes_cfb128 = 1;
+            } else if (strcmp(argv[i], "aes_cfb8") == 0) {
+                todo.aes_cfb8 = 1;
             } else if (strcmp(argv[i], "aes_xts") == 0) {
                 todo.aes_xts = 1;
             } else if (strcmp(argv[i], "aes_gcm") == 0) {
@@ -518,6 +520,22 @@ int main(int argc, char *argv[])
             TIME_AND_TSC(title,
                          mbedtls_aes_crypt_cfb128(&aes, MBEDTLS_AES_ENCRYPT, BUFSIZE,
                                                   &iv_off, tmp, buf, buf));
+        }
+        mbedtls_aes_free(&aes);
+    }
+    if (todo.aes_cfb8) {
+        int keysize;
+        mbedtls_aes_context aes;
+        mbedtls_aes_init(&aes);
+        for (keysize = 128; keysize <= 256; keysize += 64) {
+            mbedtls_snprintf(title, sizeof(title), "AES-CFB8-%d", keysize);
+
+            memset(buf, 0, sizeof(buf));
+            memset(tmp, 0, sizeof(tmp));
+            CHECK_AND_CONTINUE(mbedtls_aes_setkey_enc(&aes, tmp, keysize));
+
+            TIME_AND_TSC(title,
+                         mbedtls_aes_crypt_cfb8(&aes, MBEDTLS_AES_ENCRYPT, BUFSIZE, tmp, buf, buf));
         }
         mbedtls_aes_free(&aes);
     }


### PR DESCRIPTION
## Description

Backport of #8185 

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required
- [x] **backport** of https://github.com/Mbed-TLS/mbedtls/pull/8185
- [x] **tests** not required
