### PR TITLE
Rename local variable in aes.c

### DIFF
--- a/library/aes.c
+++ b/library/aes.c
@@ -360,7 +360,7 @@ static const uint32_t RT3[256] = { RT };
 /*
  * Round constants
  */
-static const uint32_t RCON[10] =
+static const uint32_t round_constants[10] =
 {
     0x00000001, 0x00000002, 0x00000004, 0x00000008,
     0x00000010, 0x00000020, 0x00000040, 0x00000080,
@@ -407,7 +407,7 @@ static uint32_t RT3[256];
 /*
  * Round constants
  */
-static uint32_t RCON[10];
+static uint32_t round_constants[10];
 
 /*
  * Tables generation code
@@ -438,7 +438,7 @@ static void aes_gen_tables(void)
      * calculate the round constants
      */
     for (i = 0, x = 1; i < 10; i++) {
-        RCON[i] = x;
+        round_constants[i] = x;
         x = XTIME(x);
     }
 
@@ -666,7 +666,7 @@ int mbedtls_aes_setkey_enc(mbedtls_aes_context *ctx, const unsigned char *key,
         case 10:
 
             for (unsigned int i = 0; i < 10; i++, RK += 4) {
-                RK[4]  = RK[0] ^ RCON[i] ^
+                RK[4]  = RK[0] ^ round_constants[i] ^
                          ((uint32_t) FSb[MBEDTLS_BYTE_1(RK[3])]) ^
                          ((uint32_t) FSb[MBEDTLS_BYTE_2(RK[3])] <<  8) ^
                          ((uint32_t) FSb[MBEDTLS_BYTE_3(RK[3])] << 16) ^
@@ -682,7 +682,7 @@ int mbedtls_aes_setkey_enc(mbedtls_aes_context *ctx, const unsigned char *key,
         case 12:
 
             for (unsigned int i = 0; i < 8; i++, RK += 6) {
-                RK[6]  = RK[0] ^ RCON[i] ^
+                RK[6]  = RK[0] ^ round_constants[i] ^
                          ((uint32_t) FSb[MBEDTLS_BYTE_1(RK[5])]) ^
                          ((uint32_t) FSb[MBEDTLS_BYTE_2(RK[5])] <<  8) ^
                          ((uint32_t) FSb[MBEDTLS_BYTE_3(RK[5])] << 16) ^
@@ -699,7 +699,7 @@ int mbedtls_aes_setkey_enc(mbedtls_aes_context *ctx, const unsigned char *key,
         case 14:
 
             for (unsigned int i = 0; i < 7; i++, RK += 8) {
-                RK[8]  = RK[0] ^ RCON[i] ^
+                RK[8]  = RK[0] ^ round_constants[i] ^
                          ((uint32_t) FSb[MBEDTLS_BYTE_1(RK[7])]) ^
                          ((uint32_t) FSb[MBEDTLS_BYTE_2(RK[7])] <<  8) ^
                          ((uint32_t) FSb[MBEDTLS_BYTE_3(RK[7])] << 16) ^


### PR DESCRIPTION
## Description

This changes local variable name `RCON` to `round_constants`.

RCON being definition in xc32 compiler headers for some PIC32 register. Without this change, mynewt project for PIC32 platform fails to build due to macro redefinition.

This does not changes behavior of library in any way.

Fixes #8338 


## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog**, not required
- [x] **backport** # 8349
- [x] **tests** not required
