### PR TITLE
Fix possible NULL dereference issue in X509 cert_write program

### DIFF
--- a/ChangeLog.d/fix-issue-x509-cert_write.txt
+++ b/ChangeLog.d/fix-issue-x509-cert_write.txt
@@ -1,2 +1,3 @@
 Bugfix
-   * Fix possible NULL dereference issue in X509 cert_write program if an entry in the san parameter is not separated by a colon.
+   * Fix possible NULL dereference issue in X509 cert_write program if an entry
+     in the san parameter is not separated by a colon.

--- a/ChangeLog.d/fix-issue-x509-cert_write.txt
+++ b/ChangeLog.d/fix-issue-x509-cert_write.txt
@@ -1,0 +1,2 @@
+Bugfix
+   * Fix possible NULL dereference issue in X509 cert_write program if an entry in the san parameter is not separated by a colon.

--- a/programs/x509/cert_write.c
+++ b/programs/x509/cert_write.c
@@ -585,7 +585,7 @@ usage:
                     *subtype_value++ = '\0';
                 } else {
                     mbedtls_printf(
-                        "Invalid argument for option SAN: Entry should be separated by a colon\n");
+                        "Invalid argument for option SAN: Entry must be of the form TYPE:value\n");
                     goto usage;
                 }
                 if (strcmp(q, "RFC822") == 0) {

--- a/programs/x509/cert_write.c
+++ b/programs/x509/cert_write.c
@@ -583,6 +583,9 @@ usage:
 
                 if ((subtype_value = strchr(q, ':')) != NULL) {
                     *subtype_value++ = '\0';
+                } else {
+                    mbedtls_printf("Invalid argument for option SAN: Entry should be seperated by a colon\n");
+                    goto usage;
                 }
                 if (strcmp(q, "RFC822") == 0) {
                     cur->node.type = MBEDTLS_X509_SAN_RFC822_NAME;

--- a/programs/x509/cert_write.c
+++ b/programs/x509/cert_write.c
@@ -584,7 +584,7 @@ usage:
                 if ((subtype_value = strchr(q, ':')) != NULL) {
                     *subtype_value++ = '\0';
                 } else {
-                    mbedtls_printf("Invalid argument for option SAN: Entry should be seperated by a colon\n");
+                    mbedtls_printf("Invalid argument for option SAN: Entry should be separated by a colon\n");
                     goto usage;
                 }
                 if (strcmp(q, "RFC822") == 0) {

--- a/programs/x509/cert_write.c
+++ b/programs/x509/cert_write.c
@@ -584,7 +584,8 @@ usage:
                 if ((subtype_value = strchr(q, ':')) != NULL) {
                     *subtype_value++ = '\0';
                 } else {
-                    mbedtls_printf("Invalid argument for option SAN: Entry should be separated by a colon\n");
+                    mbedtls_printf(
+                        "Invalid argument for option SAN: Entry should be separated by a colon\n");
                     goto usage;
                 }
                 if (strcmp(q, "RFC822") == 0) {


### PR DESCRIPTION
## Description

Fix possible NULL dereference issue in X509 cert_write program if an entry in the san parameter is not separated by a colon.
Issue can happen when running a command like this:
`./cert_write is_ca=1 serial=3 request_file=test-ca.req.sha256 selfsign=1 issuer_name="C=NL,O=PolarSSL,CN=PolarSSL Test CA" issuer_key=/Users/walelm01/MbedTLS-fork/mbedtls/tests/data_files/test-ca.key issuer_pwd="PolarSSLTest" not_before=20190210144400 not_after=20290210144400 md=SHA1 version=3  output_file=/Users/walelm01/cert san="DN:C=UK,O=\"Mbed TLS\",CN=\"SubjectAltName test\";URI:http://pki.example.com/;IP:127.1.1.0;DNS"`


## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** provided
- [x] **backport** not required - no san option in 2.28
- [X] **tests** provided manually


## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.
