### PR TITLE
Fix possible NULL dereference issue in X509 cert_req program

### DIFF
--- a/ChangeLog.d/fix-issue-x509-cert_req.txt
+++ b/ChangeLog.d/fix-issue-x509-cert_req.txt
@@ -1,0 +1,2 @@
+Bugfix
+   * Fix possible NULL dereference issue in X509 cert_req program if an entry in the san parameter is not separated by a colon.

--- a/ChangeLog.d/fix-issue-x509-cert_req.txt
+++ b/ChangeLog.d/fix-issue-x509-cert_req.txt
@@ -1,2 +1,3 @@
 Bugfix
-   * Fix possible NULL dereference issue in X509 cert_req program if an entry in the san parameter is not separated by a colon.
+   * Fix possible NULL dereference issue in X509 cert_req program if an entry
+     in the san parameter is not separated by a colon.

--- a/programs/x509/cert_req.c
+++ b/programs/x509/cert_req.c
@@ -261,6 +261,9 @@ usage:
 
                 if ((subtype_value = strchr(q, ':')) != NULL) {
                     *subtype_value++ = '\0';
+                } else {
+                    mbedtls_printf("Invalid argument for option SAN: Entry should be separated by a colon\n");
+                    goto usage;
                 }
                 if (strcmp(q, "RFC822") == 0) {
                     cur->node.type = MBEDTLS_X509_SAN_RFC822_NAME;

--- a/programs/x509/cert_req.c
+++ b/programs/x509/cert_req.c
@@ -262,7 +262,8 @@ usage:
                 if ((subtype_value = strchr(q, ':')) != NULL) {
                     *subtype_value++ = '\0';
                 } else {
-                    mbedtls_printf("Invalid argument for option SAN: Entry should be separated by a colon\n");
+                    mbedtls_printf(
+                        "Invalid argument for option SAN: Entry should be separated by a colon\n");
                     goto usage;
                 }
                 if (strcmp(q, "RFC822") == 0) {

--- a/programs/x509/cert_req.c
+++ b/programs/x509/cert_req.c
@@ -263,7 +263,7 @@ usage:
                     *subtype_value++ = '\0';
                 } else {
                     mbedtls_printf(
-                        "Invalid argument for option SAN: Entry should be separated by a colon\n");
+                        "Invalid argument for option SAN: Entry must be of the form TYPE:value\n");
                     goto usage;
                 }
                 if (strcmp(q, "RFC822") == 0) {


### PR DESCRIPTION
## Description

Fix possible NULL dereference issue in X509 cert_write program if an entry in the san parameter is not separated by a colon.
Issue can happen when running a command like this:
`./cert_req san=IP`



## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [X] **changelog** provided
- [x] **backport** not required - no san option in 2.28
- [X] **tests** provided manually



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.
