### PR TITLE
Add ignoring return value casting and Fix non-uniform cast

### DIFF
--- a/library/aria.c
+++ b/library/aria.c
@@ -875,7 +875,7 @@ int mbedtls_aria_self_test(int verbose)
         if (verbose) {
             mbedtls_printf("  ARIA-ECB-%d (enc): ", 128 + 64 * i);
         }
-        mbedtls_aria_setkey_enc(&ctx, aria_test1_ecb_key, 128 + 64 * i);
+        (void) mbedtls_aria_setkey_enc(&ctx, aria_test1_ecb_key, 128 + 64 * i);
         mbedtls_aria_crypt_ecb(&ctx, aria_test1_ecb_pt, blk);
         ARIA_SELF_TEST_ASSERT(
             memcmp(blk, aria_test1_ecb_ct[i], MBEDTLS_ARIA_BLOCKSIZE)
@@ -885,7 +885,7 @@ int mbedtls_aria_self_test(int verbose)
         if (verbose) {
             mbedtls_printf("  ARIA-ECB-%d (dec): ", 128 + 64 * i);
         }
-        mbedtls_aria_setkey_dec(&ctx, aria_test1_ecb_key, 128 + 64 * i);
+        (void) mbedtls_aria_setkey_dec(&ctx, aria_test1_ecb_key, 128 + 64 * i);
         mbedtls_aria_crypt_ecb(&ctx, aria_test1_ecb_ct[i], blk);
         ARIA_SELF_TEST_ASSERT(
             memcmp(blk, aria_test1_ecb_pt, MBEDTLS_ARIA_BLOCKSIZE)
@@ -904,11 +904,11 @@ int mbedtls_aria_self_test(int verbose)
         if (verbose) {
             mbedtls_printf("  ARIA-CBC-%d (enc): ", 128 + 64 * i);
         }
-        mbedtls_aria_setkey_enc(&ctx, aria_test2_key, 128 + 64 * i);
+        (void) mbedtls_aria_setkey_enc(&ctx, aria_test2_key, 128 + 64 * i);
         memcpy(iv, aria_test2_iv, MBEDTLS_ARIA_BLOCKSIZE);
         memset(buf, 0x55, sizeof(buf));
-        mbedtls_aria_crypt_cbc(&ctx, MBEDTLS_ARIA_ENCRYPT, 48, iv,
-                               aria_test2_pt, buf);
+        (void) mbedtls_aria_crypt_cbc(&ctx, MBEDTLS_ARIA_ENCRYPT, 48, iv,
+                                      aria_test2_pt, buf);
         ARIA_SELF_TEST_ASSERT(memcmp(buf, aria_test2_cbc_ct[i], 48)
                               != 0);
 
@@ -916,11 +916,11 @@ int mbedtls_aria_self_test(int verbose)
         if (verbose) {
             mbedtls_printf("  ARIA-CBC-%d (dec): ", 128 + 64 * i);
         }
-        mbedtls_aria_setkey_dec(&ctx, aria_test2_key, 128 + 64 * i);
+        (void) mbedtls_aria_setkey_dec(&ctx, aria_test2_key, 128 + 64 * i);
         memcpy(iv, aria_test2_iv, MBEDTLS_ARIA_BLOCKSIZE);
         memset(buf, 0xAA, sizeof(buf));
-        mbedtls_aria_crypt_cbc(&ctx, MBEDTLS_ARIA_DECRYPT, 48, iv,
-                               aria_test2_cbc_ct[i], buf);
+        (void) mbedtls_aria_crypt_cbc(&ctx, MBEDTLS_ARIA_DECRYPT, 48, iv,
+                                      aria_test2_cbc_ct[i], buf);
         ARIA_SELF_TEST_ASSERT(memcmp(buf, aria_test2_pt, 48) != 0);
     }
     if (verbose) {
@@ -935,24 +935,24 @@ int mbedtls_aria_self_test(int verbose)
         if (verbose) {
             mbedtls_printf("  ARIA-CFB-%d (enc): ", 128 + 64 * i);
         }
-        mbedtls_aria_setkey_enc(&ctx, aria_test2_key, 128 + 64 * i);
+        (void) mbedtls_aria_setkey_enc(&ctx, aria_test2_key, 128 + 64 * i);
         memcpy(iv, aria_test2_iv, MBEDTLS_ARIA_BLOCKSIZE);
         memset(buf, 0x55, sizeof(buf));
         j = 0;
-        mbedtls_aria_crypt_cfb128(&ctx, MBEDTLS_ARIA_ENCRYPT, 48, &j, iv,
-                                  aria_test2_pt, buf);
+        (void) mbedtls_aria_crypt_cfb128(&ctx, MBEDTLS_ARIA_ENCRYPT, 48, &j,
+                                         iv, aria_test2_pt, buf);
         ARIA_SELF_TEST_ASSERT(memcmp(buf, aria_test2_cfb_ct[i], 48) != 0);
 
         /* Test CFB decryption */
         if (verbose) {
             mbedtls_printf("  ARIA-CFB-%d (dec): ", 128 + 64 * i);
         }
-        mbedtls_aria_setkey_enc(&ctx, aria_test2_key, 128 + 64 * i);
+        (void) mbedtls_aria_setkey_enc(&ctx, aria_test2_key, 128 + 64 * i);
         memcpy(iv, aria_test2_iv, MBEDTLS_ARIA_BLOCKSIZE);
         memset(buf, 0xAA, sizeof(buf));
         j = 0;
-        mbedtls_aria_crypt_cfb128(&ctx, MBEDTLS_ARIA_DECRYPT, 48, &j,
-                                  iv, aria_test2_cfb_ct[i], buf);
+        (void) mbedtls_aria_crypt_cfb128(&ctx, MBEDTLS_ARIA_DECRYPT, 48, &j,
+                                         iv, aria_test2_cfb_ct[i], buf);
         ARIA_SELF_TEST_ASSERT(memcmp(buf, aria_test2_pt, 48) != 0);
     }
     if (verbose) {
@@ -966,24 +966,24 @@ int mbedtls_aria_self_test(int verbose)
         if (verbose) {
             mbedtls_printf("  ARIA-CTR-%d (enc): ", 128 + 64 * i);
         }
-        mbedtls_aria_setkey_enc(&ctx, aria_test2_key, 128 + 64 * i);
+        (void) mbedtls_aria_setkey_enc(&ctx, aria_test2_key, 128 + 64 * i);
         memset(iv, 0, MBEDTLS_ARIA_BLOCKSIZE);                      // IV = 0
         memset(buf, 0x55, sizeof(buf));
         j = 0;
-        mbedtls_aria_crypt_ctr(&ctx, 48, &j, iv, blk,
-                               aria_test2_pt, buf);
+        (void) mbedtls_aria_crypt_ctr(&ctx, 48, &j, iv, blk,
+                                      aria_test2_pt, buf);
         ARIA_SELF_TEST_ASSERT(memcmp(buf, aria_test2_ctr_ct[i], 48) != 0);
 
         /* Test CTR decryption */
         if (verbose) {
             mbedtls_printf("  ARIA-CTR-%d (dec): ", 128 + 64 * i);
         }
-        mbedtls_aria_setkey_enc(&ctx, aria_test2_key, 128 + 64 * i);
+        (void) mbedtls_aria_setkey_enc(&ctx, aria_test2_key, 128 + 64 * i);
         memset(iv, 0, MBEDTLS_ARIA_BLOCKSIZE);                      // IV = 0
         memset(buf, 0xAA, sizeof(buf));
         j = 0;
-        mbedtls_aria_crypt_ctr(&ctx, 48, &j, iv, blk,
-                               aria_test2_ctr_ct[i], buf);
+        (void) mbedtls_aria_crypt_ctr(&ctx, 48, &j, iv, blk,
+                                      aria_test2_ctr_ct[i], buf);
         ARIA_SELF_TEST_ASSERT(memcmp(buf, aria_test2_pt, 48) != 0);
     }
     if (verbose) {

--- a/library/cipher.c
+++ b/library/cipher.c
@@ -135,7 +135,7 @@ const mbedtls_cipher_info_t *mbedtls_cipher_info_from_values(
 
     for (def = mbedtls_cipher_definitions; def->info != NULL; def++) {
         if (mbedtls_cipher_get_base(def->info)->cipher == cipher_id &&
-            mbedtls_cipher_info_get_key_bitlen(def->info) == (unsigned) key_bitlen &&
+            mbedtls_cipher_info_get_key_bitlen(def->info) == (size_t) key_bitlen &&
             def->info->mode == mode) {
             return def->info;
         }


### PR DESCRIPTION
## Description
I have fixed a non-uniform casting file `cipher.c` and missing `void` casting in case of ignoring return type checks of some functions under `aria.c`


## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [ ] **changelog** not required
- [ ] **backport** required
- [ ] **tests** not required



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.
