### PR TITLE
Revert "Fix a few IAR warnings" which breaks the CI

### DIFF
--- a/library/pkcs12.c
+++ b/library/pkcs12.c
@@ -172,7 +172,6 @@ int mbedtls_pkcs12_pbe_ext(mbedtls_asn1_buf *pbe_params, int mode,
     size_t iv_len = 0;
     size_t finish_olen = 0;
     unsigned int padlen = 0;
-    mbedtls_cipher_padding_t padding;
 
     if (pwd == NULL && pwdlen != 0) {
         return MBEDTLS_ERR_PKCS12_BAD_INPUT_DATA;
@@ -219,7 +218,7 @@ int mbedtls_pkcs12_pbe_ext(mbedtls_asn1_buf *pbe_params, int mode,
 #if defined(MBEDTLS_CIPHER_MODE_WITH_PADDING)
     /* PKCS12 uses CBC with PKCS7 padding */
 
-    padding = MBEDTLS_PADDING_PKCS7;
+    mbedtls_cipher_padding_t padding = MBEDTLS_PADDING_PKCS7;
 #if !defined(MBEDTLS_CIPHER_PADDING_PKCS7)
     /* For historical reasons, when decrypting, this function works when
      * decrypting even when support for PKCS7 padding is disabled. In this

--- a/library/pkcs5.c
+++ b/library/pkcs5.c
@@ -152,7 +152,6 @@ int mbedtls_pkcs5_pbes2_ext(const mbedtls_asn1_buf *pbe_params, int mode,
     mbedtls_cipher_type_t cipher_alg;
     mbedtls_cipher_context_t cipher_ctx;
     unsigned int padlen = 0;
-    mbedtls_cipher_padding_t padding;
 
     p = pbe_params->p;
     end = p + pbe_params->len;
@@ -247,7 +246,7 @@ int mbedtls_pkcs5_pbes2_ext(const mbedtls_asn1_buf *pbe_params, int mode,
      * "PKCS5 padding" except that it's typically only called PKCS5
      * with 64-bit-block ciphers).
      */
-    padding = MBEDTLS_PADDING_PKCS7;
+    mbedtls_cipher_padding_t padding = MBEDTLS_PADDING_PKCS7;
 #if !defined(MBEDTLS_CIPHER_PADDING_PKCS7)
     /* For historical reasons, when decrypting, this function works when
      * decrypting even when support for PKCS7 padding is disabled. In this

--- a/library/x509_create.c
+++ b/library/x509_create.c
@@ -254,33 +254,31 @@ static int parse_attribute_value_hex_der_encoded(const char *s,
     /* Step 3: decode the DER. */
     /* We've checked that der_length >= 1 above. */
     *tag = der[0];
-    {
-        unsigned char *p = der + 1;
-        if (mbedtls_asn1_get_len(&p, der + der_length, data_len) != 0) {
-            goto error;
-        }
-        /* Now p points to the first byte of the payload inside der,
-        * and *data_len is the length of the payload. */
+    unsigned char *p = der + 1;
+    if (mbedtls_asn1_get_len(&p, der + der_length, data_len) != 0) {
+        goto error;
+    }
+    /* Now p points to the first byte of the payload inside der,
+     * and *data_len is the length of the payload. */
 
-        /* Step 4: payload validation */
-        if (*data_len > MBEDTLS_X509_MAX_DN_NAME_SIZE) {
-            goto error;
-        }
-        /* Strings must not contain null bytes. */
-        if (MBEDTLS_ASN1_IS_STRING_TAG(*tag)) {
-            for (size_t i = 0; i < *data_len; i++) {
-                if (p[i] == 0) {
-                    goto error;
-                }
+    /* Step 4: payload validation */
+    if (*data_len > MBEDTLS_X509_MAX_DN_NAME_SIZE) {
+        goto error;
+    }
+    /* Strings must not contain null bytes. */
+    if (MBEDTLS_ASN1_IS_STRING_TAG(*tag)) {
+        for (size_t i = 0; i < *data_len; i++) {
+            if (p[i] == 0) {
+                goto error;
             }
         }
-
-        /* Step 5: output the payload. */
-        if (*data_len > data_size) {
-            goto error;
-        }
-        memcpy(data, p, *data_len);
     }
+
+    /* Step 5: output the payload. */
+    if (*data_len > data_size) {
+        goto error;
+    }
+    memcpy(data, p, *data_len);
     mbedtls_free(der);
 
     return 0;


### PR DESCRIPTION
Reverts Mbed-TLS/mbedtls#8352 because it's making the CI fail.

We do want Mbed-TLS/mbedtls#8352, but only once it's fixed.