### PR TITLE
mbedtls_ecp_read_key(): don't check priv key when no curves enabled

### DIFF
--- a/library/ecp.c
+++ b/library/ecp.c
@@ -3288,7 +3288,10 @@ int mbedtls_ecp_read_key(mbedtls_ecp_group_id grp_id, mbedtls_ecp_keypair *key,
         MBEDTLS_MPI_CHK(mbedtls_mpi_read_binary(&key->d, buf, buflen));
     }
 #endif
+#if defined(MBEDTLS_ECP_MONTGOMERY_ENABLED) || \
+    defined(MBEDTLS_ECP_SHORT_WEIERSTRASS_ENABLED)
     MBEDTLS_MPI_CHK(mbedtls_ecp_check_privkey(&key->grp, &key->d));
+#endif
 
 cleanup:
 


### PR DESCRIPTION
## Description

When built without `MBEDTLS_ECP_MONTGOMERY_ENABLED` and `MBEDTLS_ECP_SHORT_WEIERSTRASS_ENABLED`, `mbedtls_ecp_read_key()` would previously return `MBEDTLS_ERR_ECP_FEATURE_UNAVAILABLE`, but now it calls `mbedtls_ecp_check_privkey()` on an uninitialised private key.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [ ] **changelog** provided, or not required
- [ ] **backport** done, or not required
- [ ] **tests** provided, or not required
