### PR TITLE
server7 use rsa instead of ecdsa to do encryption

### DIFF
--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -403,7 +403,6 @@ detect_required_features() {
 
     case "$CMD_LINE" in
         *server5*|\
-        *server7*|\
         *dir-maxpath*)
             if [ "$TLS_VERSION" = "TLS13" ]; then
                 # In case of TLS13 the support for ECDSA is enough


### PR DESCRIPTION
## Description

The certificates named *server7* use rsa encryption. we should not check it in ecdsa option.



## PR checklist

- [ ] **changelog** ~~provided, or~~ not required
- [ ] **backport** ~~done, or~~ not required
- [ ] **tests** ~~provided, or~~ not required




