### PR TITLE
Fix uninitialised variable in mbedtls_pk_context

### DIFF
--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -220,6 +220,7 @@ static int rsa_verify_wrap(mbedtls_pk_context *pk, mbedtls_md_type_t md_alg,
 
     /* mbedtls_pk_write_pubkey_der() expects a full PK context;
      * re-construct one to make it happy */
+    mbedtls_pk_init(&key);
     key.pk_info = &mbedtls_rsa_info;
     key.pk_ctx = rsa;
     key_len = mbedtls_pk_write_pubkey_der(&key, buf, sizeof(buf));
@@ -321,6 +322,7 @@ int  mbedtls_pk_psa_rsa_sign_ext(psa_algorithm_t alg,
 
     /* mbedtls_pk_write_key_der() expects a full PK context;
      * re-construct one to make it happy */
+    mbedtls_pk_init(&key);
     key.pk_info = &pk_info;
     key.pk_ctx = rsa_ctx;
     key_len = mbedtls_pk_write_key_der(&key, buf, MBEDTLS_PK_RSA_PRV_DER_MAX_BYTES);
@@ -433,6 +435,7 @@ static int rsa_decrypt_wrap(mbedtls_pk_context *pk,
 
     /* mbedtls_pk_write_key_der() expects a full PK context;
      * re-construct one to make it happy */
+    mbedtls_pk_init(&key);
     key.pk_info = &mbedtls_rsa_info;
     key.pk_ctx = rsa;
     key_len = mbedtls_pk_write_key_der(&key, buf, sizeof(buf));
@@ -519,6 +522,7 @@ static int rsa_encrypt_wrap(mbedtls_pk_context *pk,
 
     /* mbedtls_pk_write_pubkey_der() expects a full PK context;
      * re-construct one to make it happy */
+    mbedtls_pk_init(&key);
     key.pk_info = &mbedtls_rsa_info;
     key.pk_ctx = rsa;
     key_len = mbedtls_pk_write_pubkey_der(&key, buf, sizeof(buf));


### PR DESCRIPTION
## Description

Found by coverity.

Since the pk_wrap code was written, new elements have been added to the mbedtls_pk_context, which were left uninitialised in this case as the wrappers presumed only certain elements needed to be initialised. 

Although this is in these cases correct (its RSA only, which does not appear to access any of the new members, which are ECC focussed), seeing that several members of the mbedtls_pk_context were uninitialised did not entirely feel right, so I added an mbedtls_pk_init() call prior to the context building to hopefully future proof this against any future 
(potentially breaking) changes.

I appreciate this might also need a changelog entry, but I'm a bit unsure what that woulld look like to be honest, given this is just safety code.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [ ] **changelog** provided, or not required - Unsure on this one.
- [ ] **backport** ~~done, or~~ not required (new variables not in 2.28)
- [ ] **tests** ~~provided, or~~ not required
