### PR TITLE
Fix compiling AESNI in Mbed-TLS with clang on Windows

### DIFF
--- a/ChangeLog.d/8372.txt
+++ b/ChangeLog.d/8372.txt
@@ -1,0 +1,3 @@
+Features
+   *  AES-NI is now supported in Windows builds with clang and clang-cl.
+      Resolves #8372.

--- a/library/aesni.c
+++ b/library/aesni.c
@@ -52,7 +52,7 @@ int mbedtls_aesni_has_support(unsigned int what)
 
     if (!done) {
 #if MBEDTLS_AESNI_HAVE_CODE == 2
-        static unsigned info[4] = { 0, 0, 0, 0 };
+        static int info[4] = { 0, 0, 0, 0 };
 #if defined(_MSC_VER)
         __cpuid(info, 1);
 #else
@@ -187,7 +187,7 @@ void mbedtls_aesni_gcm_mult(unsigned char c[16],
                             const unsigned char a[16],
                             const unsigned char b[16])
 {
-    __m128i aa, bb, cc, dd;
+    __m128i aa = { 0 }, bb = { 0 }, cc, dd;
 
     /* The inputs are in big-endian order, so byte-reverse them */
     for (size_t i = 0; i < 16; i++) {

--- a/library/aesni.h
+++ b/library/aesni.h
@@ -39,7 +39,7 @@
  * (Only implemented with certain compilers, only for certain targets.)
  */
 #undef MBEDTLS_AESNI_HAVE_INTRINSICS
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && !defined(__clang__)
 /* Visual Studio supports AESNI intrinsics since VS 2008 SP1. We only support
  * VS 2013 and up for other reasons anyway, so no need to check the version. */
 #define MBEDTLS_AESNI_HAVE_INTRINSICS
@@ -47,7 +47,7 @@
 /* GCC-like compilers: currently, we only support intrinsics if the requisite
  * target flag is enabled when building the library (e.g. `gcc -mpclmul -msse2`
  * or `clang -maes -mpclmul`). */
-#if defined(__GNUC__) && defined(__AES__) && defined(__PCLMUL__)
+#if (defined(__GNUC__) || defined(__clang__)) && defined(__AES__) && defined(__PCLMUL__)
 #define MBEDTLS_AESNI_HAVE_INTRINSICS
 #endif
 
@@ -65,7 +65,7 @@
  * (Only implemented with gas syntax, only for 64-bit.)
  */
 #define MBEDTLS_AESNI_HAVE_CODE 1 // via assembly
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
 #   error "Must use `-mpclmul -msse2 -maes` for MBEDTLS_AESNI_C"
 #else
 #error "MBEDTLS_AESNI_C defined, but neither intrinsics nor assembly available"


### PR DESCRIPTION
## Description

Fixes #8372. Does not conflict with #8339.

It can successfully compile w/ the clang options `-maes -mpclmul`.

The macro `__GNUC__` is not defined by Clang on Windows, thus use the macro `__clang__` for `-maes -mpclmul`.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** done
- [x] **backport** done https://github.com/Mbed-TLS/mbedtls/pull/8373
- [x] **tests** not required
