### PR TITLE
Change the comment to match with the script

### DIFF
--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -841,7 +841,7 @@ if [ "$MAX_OUT_LEN" -lt "$MAX_CONTENT_LEN" ]; then
     MAX_CONTENT_LEN="$MAX_OUT_LEN"
 fi
 
-# skip the next test if the SSL output buffer is less than 16KB
+# skip the next test if the SSL output buffer isn't equal to 16KB
 requires_full_size_output_buffer() {
     if [ "$MAX_OUT_LEN" -ne 16384 ]; then
         SKIP_NEXT="YES"


### PR DESCRIPTION
## Description

The description of the output buffer size in ssl-opt.sh doesn't match with the script code, change it.



## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [ ] **changelog** ~~provided, or~~ not required
- [ ] **backport** ~~done, or~~ not required
- [ ] **tests** ~~provided, or~~ not required



