### PR TITLE
Fix check_config for ECP_LIGHT

### DIFF
--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -231,7 +231,7 @@
 #error "MBEDTLS_ECDSA_DETERMINISTIC defined, but not all prerequisites"
 #endif
 
-#if defined(MBEDTLS_ECP_C) && ( !defined(MBEDTLS_BIGNUM_C) || (    \
+#if defined(MBEDTLS_ECP_LIGHT) && ( !defined(MBEDTLS_BIGNUM_C) || (    \
     !defined(MBEDTLS_ECP_DP_SECP192R1_ENABLED) &&                  \
     !defined(MBEDTLS_ECP_DP_SECP224R1_ENABLED) &&                  \
     !defined(MBEDTLS_ECP_DP_SECP256R1_ENABLED) &&                  \
@@ -245,7 +245,7 @@
     !defined(MBEDTLS_ECP_DP_SECP256K1_ENABLED) &&                  \
     !defined(MBEDTLS_ECP_DP_CURVE25519_ENABLED) &&                 \
     !defined(MBEDTLS_ECP_DP_CURVE448_ENABLED) ) )
-#error "MBEDTLS_ECP_C defined, but not all prerequisites"
+#error "MBEDTLS_ECP_C defined (or a subset enabled), but not all prerequisites"
 #endif
 
 #if defined(MBEDTLS_PK_PARSE_C) && !defined(MBEDTLS_ASN1_PARSE_C)

--- a/library/ecp.c
+++ b/library/ecp.c
@@ -3288,7 +3288,10 @@ int mbedtls_ecp_read_key(mbedtls_ecp_group_id grp_id, mbedtls_ecp_keypair *key,
         MBEDTLS_MPI_CHK(mbedtls_mpi_read_binary(&key->d, buf, buflen));
     }
 #endif
-    MBEDTLS_MPI_CHK(mbedtls_ecp_check_privkey(&key->grp, &key->d));
+
+    if (ret == 0) {
+        MBEDTLS_MPI_CHK(mbedtls_ecp_check_privkey(&key->grp, &key->d));
+    }
 
 cleanup:
 


### PR DESCRIPTION
## Description

This is IMO an oversight from when we introduced `ECP_LIGHT`. While at it, also fix a concern from https://github.com/Mbed-TLS/mbedtls/pull/8362 which is what initially made me notice.

## PR checklist

- [x] **changelog** not required - no user-visible change except you now get a compile-time error for something that would have never worked at runtime.
- [ ] **backport** ???
- [x] **tests** not required