### PR TITLE
Remove NULLing of ssl context in TLS1.2 transform population 

### DIFF
--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -8159,14 +8159,6 @@ static int ssl_tls12_populate_transform(mbedtls_ssl_transform *transform,
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
 #endif
 
-#if !defined(MBEDTLS_DEBUG_C) && \
-    !defined(MBEDTLS_SSL_DTLS_CONNECTION_ID)
-    if (ssl->f_export_keys == NULL) {
-        ssl = NULL; /* make sure we don't use it except for these cases */
-        (void) ssl;
-    }
-#endif
-
     /*
      * Some data just needs copying into the structure
      */
@@ -8438,7 +8430,7 @@ static int ssl_tls12_populate_transform(mbedtls_ssl_transform *transform,
         goto end;
     }
 
-    if (ssl != NULL && ssl->f_export_keys != NULL) {
+    if (ssl->f_export_keys != NULL) {
         ssl->f_export_keys(ssl->p_export_keys,
                            MBEDTLS_SSL_KEY_EXPORT_TLS12_MASTER_SECRET,
                            master, 48,


### PR DESCRIPTION
## Description

Remove a piece of code that was meant to ensure non-usage of the ssl context (by NULL-ing it) under conditions where it should not be used, as this now makes less sense and also triggers coverity.

Also remove redundant NULL check on the ssl contextt further down the function.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** ~~provided, or~~ not required (minor change to debug code)
- [x] **backport** done ~~, or not required~~ #8386
- [x] **tests** ~~provided, or~~ not required - current tests will cover this.

Have to admit I'm not entirely sure about backporting this one - its not a security fix, just a simplification. I have done the backport, but feel free to express views on this.
