### PR TITLE
[Backport 2.28] Remove NULLing of ssl context in TLS1.2 transform population

### DIFF
--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1004,8 +1004,7 @@ static int ssl_populate_transform(mbedtls_ssl_transform *transform,
     !defined(MBEDTLS_SSL_EXPORT_KEYS) && \
     !defined(MBEDTLS_SSL_DTLS_CONNECTION_ID) && \
     !defined(MBEDTLS_DEBUG_C)
-    ssl = NULL; /* make sure we don't use it except for those cases */
-    (void) ssl;
+    (void) ssl; /* ssl is unused except for those cases */
 #endif
 
     /*


### PR DESCRIPTION
## Description

Remove a piece of code that was meant to ensure non-usage of the ssl context (by NULL-ing it) under conditions where it should not be used, as this now makes less sense. Backport of #8384

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [ ] **changelog** ~~provided, or~~ not required (minor change)
- [ ] **backport** ~~done, or~~ not required (This is the backport)
- [ ] **tests** ~~provided, or~~ not required (current tests will cover)



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.
