### PR TITLE
Move initialisation in test to before first test

### DIFF
--- a/tests/suites/test_suite_cipher.function
+++ b/tests/suites/test_suite_cipher.function
@@ -1218,6 +1218,8 @@ void check_set_padding(int cipher_id)
     const mbedtls_cipher_info_t *cipher_info;
     size_t keylen = 0;
 
+    mbedtls_cipher_init(&ctx);
+
     cipher_info = mbedtls_cipher_info_from_type(cipher_id);
 
     if (cipher_info->mode != MBEDTLS_MODE_CBC) {
@@ -1227,8 +1229,6 @@ void check_set_padding(int cipher_id)
     keylen = mbedtls_cipher_info_get_key_bitlen(cipher_info);
     TEST_CALLOC(key, keylen/8);
     memset(key, 0, keylen/8);
-
-    mbedtls_cipher_init(&ctx);
 
     TEST_EQUAL(0, mbedtls_cipher_setup(&ctx, cipher_info));
 


### PR DESCRIPTION
## Description

Found by coverity:

Calling mbedtls_cipher_free() on a context that was not initialised is dangerous, and this could happen if the first test in check_set_padding() failed.

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [ ] **changelog** ~~provided, or~~ not required (minor fix to test)
- [ ] **backport** ~~done, or~~ not required (issue does not exist in 2.28)
- [ ] **tests** ~~provided, or~~ not required (fix is in tests)



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.
