### PR TITLE
Backport 2.28: Support cpuid for win32

### DIFF
--- a/ChangeLog.d/fix-mingw32-build.txt
+++ b/ChangeLog.d/fix-mingw32-build.txt
@@ -1,4 +1,4 @@
 Bugfix
   * Fix an inconsistency between implementations and usages of `__cpuid`,
     which mainly causes failures when building Windows target using
-    mingw or clang. Fix #8334 & #8332.
+    mingw or clang. Fixes #8334 & #8332.

--- a/ChangeLog.d/fix-mingw32-build.txt
+++ b/ChangeLog.d/fix-mingw32-build.txt
@@ -1,0 +1,4 @@
+Bugfix
+  * Fix an inconsistency between implementations and usages of `__cpuid`,
+    which mainly causes failures when building Windows target using
+    mingw or clang. Fix #8334 & #8332.

--- a/library/aesni.c
+++ b/library/aesni.c
@@ -57,7 +57,7 @@ int mbedtls_aesni_has_support(unsigned int what)
 
     if (!done) {
 #if MBEDTLS_AESNI_HAVE_CODE == 2
-        static unsigned info[4] = { 0, 0, 0, 0 };
+        static int info[4] = { 0, 0, 0, 0 };
 #if defined(_WIN32)
         __cpuid(info, 1);
 #else

--- a/library/aesni.c
+++ b/library/aesni.c
@@ -58,7 +58,7 @@ int mbedtls_aesni_has_support(unsigned int what)
     if (!done) {
 #if MBEDTLS_AESNI_HAVE_CODE == 2
         static unsigned info[4] = { 0, 0, 0, 0 };
-#if defined(_MSC_VER)
+#if defined(_WIN32)
         __cpuid(info, 1);
 #else
         __cpuid(1, info[0], info[1], info[2], info[3]);

--- a/library/aesni.c
+++ b/library/aesni.c
@@ -39,10 +39,12 @@
 #if defined(MBEDTLS_AESNI_HAVE_CODE)
 
 #if MBEDTLS_AESNI_HAVE_CODE == 2
-#if !defined(_WIN32)
+#if defined(__GNUC__)
 #include <cpuid.h>
-#else
+#elif defined(_MSC_VER)
 #include <intrin.h>
+#else
+#error "`__cpuid` required by MBEDTLS_AESNI_C is not supported by the compiler"
 #endif
 #include <immintrin.h>
 #endif
@@ -58,7 +60,7 @@ int mbedtls_aesni_has_support(unsigned int what)
     if (!done) {
 #if MBEDTLS_AESNI_HAVE_CODE == 2
         static int info[4] = { 0, 0, 0, 0 };
-#if defined(_WIN32)
+#if defined(_MSC_VER)
         __cpuid(info, 1);
 #else
         __cpuid(1, info[0], info[1], info[2], info[3]);

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -3327,7 +3327,10 @@ component_build_mingw () {
     make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -Wall -Wextra' WINDOWS_BUILD=1 SHARED=1 lib programs
     make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -Wall -Wextra' WINDOWS_BUILD=1 SHARED=1 tests
     make WINDOWS_BUILD=1 clean
-}
+
+    msg "build: Windows cross build - mingw64, make (Library only, AESNI intrinsics)" # ~ 30s
+    make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -Wall -Wextra -maes -msse2 -mpclmul' WINDOWS_BUILD=1 lib
+ }
 support_build_mingw() {
     case $(i686-w64-mingw32-gcc -dumpversion 2>/dev/null) in
         [0-5]*|"") false;;

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -3330,6 +3330,12 @@ component_build_mingw () {
 
     msg "build: Windows cross build - mingw64, make (Library only, AESNI intrinsics)" # ~ 30s
     make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -Wall -Wextra -maes -msse2 -mpclmul' WINDOWS_BUILD=1 lib
+    make WINDOWS_BUILD=1 clean
+
+    msg "build: Windows cross build - mingw64, make (Library only, default config without MBEDTLS_AESNI_C)" # ~ 30s
+    ./scripts/config.py unset MBEDTLS_AESNI_C
+    make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -Wall -Wextra' WINDOWS_BUILD=1 lib
+    make WINDOWS_BUILD=1 clean
  }
 support_build_mingw() {
     case $(i686-w64-mingw32-gcc -dumpversion 2>/dev/null) in


### PR DESCRIPTION
## Description

Backport of #8339 



## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** provided
- [x] **backport** this is a backport
- [x] **tests** not required
