### PR TITLE
Modify lcov.sh to work in tf-psa-crypto as well

### DIFF
--- a/scripts/lcov.sh
+++ b/scripts/lcov.sh
@@ -42,16 +42,21 @@ EOF
 
 set -eu
 
+# Repository detection
+in_mbedtls_repo () {
+     test -d include -a -d library -a -d programs -a -d tests
+ }
+
 # Collect stats and build a HTML report.
 lcov_library_report () {
     rm -rf Coverage
     mkdir Coverage Coverage/tmp
-    lcov --capture --initial --directory library -o Coverage/tmp/files.info
-    lcov --rc lcov_branch_coverage=1 --capture --directory library -o Coverage/tmp/tests.info
+    lcov --capture --initial --directory $library_dir -o Coverage/tmp/files.info
+    lcov --rc lcov_branch_coverage=1 --capture --directory $library_dir -o Coverage/tmp/tests.info
     lcov --rc lcov_branch_coverage=1 --add-tracefile Coverage/tmp/files.info --add-tracefile Coverage/tmp/tests.info -o Coverage/tmp/all.info
     lcov --rc lcov_branch_coverage=1 --remove Coverage/tmp/all.info -o Coverage/tmp/final.info '*.h'
     gendesc tests/Descriptions.txt -o Coverage/tmp/descriptions
-    genhtml --title "Mbed TLS" --description-file Coverage/tmp/descriptions --keep-descriptions --legend --branch-coverage -o Coverage Coverage/tmp/final.info
+    genhtml --title "$title" --description-file Coverage/tmp/descriptions --keep-descriptions --legend --branch-coverage -o Coverage Coverage/tmp/final.info
     rm -f Coverage/tmp/*.info Coverage/tmp/descriptions
     echo "Coverage report in: Coverage/index.html"
 }
@@ -59,14 +64,22 @@ lcov_library_report () {
 # Reset the traces to 0.
 lcov_reset_traces () {
     # Location with plain make
-    rm -f library/*.gcda
+    rm -f $library_dir/*.gcda
     # Location with CMake
-    rm -f library/CMakeFiles/*.dir/*.gcda
+    rm -f $library_dir/CMakeFiles/*.dir/*.gcda
 }
 
 if [ $# -gt 0 ] && [ "$1" = "--help" ]; then
     help
     exit
+fi
+
+if in_mbedtls_repo; then
+    library_dir='library'
+    title='Mbed TLS'
+else
+    library_dir='build/core'
+    title='TF-PSA-Crypto'
 fi
 
 main=lcov_library_report

--- a/scripts/lcov.sh
+++ b/scripts/lcov.sh
@@ -43,8 +43,8 @@ EOF
 set -eu
 
 # Repository detection
-in_mbedtls_repo () {
-     test -d include -a -d library -a -d programs -a -d tests
+in_mbedtls_build_dir () {
+     test -d library
  }
 
 # Collect stats and build a HTML report.
@@ -74,11 +74,11 @@ if [ $# -gt 0 ] && [ "$1" = "--help" ]; then
     exit
 fi
 
-if in_mbedtls_repo; then
+if in_mbedtls_build_dir; then
     library_dir='library'
     title='Mbed TLS'
 else
-    library_dir='build/core'
+    library_dir='core'
     title='TF-PSA-Crypto'
 fi
 


### PR DESCRIPTION
## Description

This PR solves part one of https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/41.

Add repository detection (credit to davidhorstmann-arm for adding this in all.sh previously) and use repository detection to set the library directory and title variables.

I have tested this script locally against both mbedtls and tf-psa-crypto and the results were as expected.

Limitations: The modifications rely on the build directory being named "build" in tf-psa-crypto which may not always be the case. Perhaps this is ok for now, but I will document it. Otherwise perhaps we could supply the build directory name as a command line argument. Open to suggestions.



## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required (non user-visible change)
- [x] **backport** not required, new feature.
- [x] **tests** existing testing is sufficient.



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.
