### PR TITLE
AES-NI: use target attributes for x86 32-bit intrinsics

### DIFF
--- a/library/aesni.c
+++ b/library/aesni.c
@@ -43,6 +43,17 @@
 #include <immintrin.h>
 #endif
 
+#if defined(MBEDTLS_ARCH_IS_X86)
+#if defined(MBEDTLS_COMPILER_IS_GCC)
+#pragma GCC push_options
+#pragma GCC target ("pclmul,sse2,aes")
+#define MBEDTLS_POP_TARGET_PRAGMA
+#elif defined(__clang__)
+#pragma clang attribute push (__attribute__((target("pclmul,sse2,aes"))), apply_to=function)
+#define MBEDTLS_POP_TARGET_PRAGMA
+#endif
+#endif
+
 #if !defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
 /*
  * AES-NI support detection routine
@@ -397,6 +408,15 @@ static void aesni_setkey_enc_256(unsigned char *rk_bytes,
     aesni_set_rk_256(rk[12], rk[13], _mm_aeskeygenassist_si128(rk[13], 0x40), &rk[14], &rk[15]);
 }
 #endif /* !MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH */
+
+#if defined(MBEDTLS_POP_TARGET_PRAGMA)
+#if defined(__clang__)
+#pragma clang attribute pop
+#elif defined(__GNUC__)
+#pragma GCC pop_options
+#endif
+#undef MBEDTLS_POP_TARGET_PRAGMA
+#endif
 
 #else /* MBEDTLS_AESNI_HAVE_CODE == 1 */
 

--- a/library/aesni.h
+++ b/library/aesni.h
@@ -50,6 +50,10 @@
 #if (defined(__GNUC__) || defined(__clang__)) && defined(__AES__) && defined(__PCLMUL__)
 #define MBEDTLS_AESNI_HAVE_INTRINSICS
 #endif
+/* For 32-bit, we only support intrinsics */
+#if defined(MBEDTLS_ARCH_IS_X86) && (defined(__GNUC__) || defined(__clang__))
+#define MBEDTLS_AESNI_HAVE_INTRINSICS
+#endif
 
 /* Choose the implementation of AESNI, if one is available.
  *
@@ -60,13 +64,11 @@
 #if defined(MBEDTLS_AESNI_HAVE_INTRINSICS)
 #define MBEDTLS_AESNI_HAVE_CODE 2 // via intrinsics
 #elif defined(MBEDTLS_HAVE_ASM) && \
-    defined(__GNUC__) && defined(MBEDTLS_ARCH_IS_X64)
+    (defined(__GNUC__) || defined(__clang__)) && defined(MBEDTLS_ARCH_IS_X64)
 /* Can we do AESNI with inline assembly?
  * (Only implemented with gas syntax, only for 64-bit.)
  */
 #define MBEDTLS_AESNI_HAVE_CODE 1 // via assembly
-#elif defined(__GNUC__) || defined(__clang__)
-#   error "Must use `-mpclmul -msse2 -maes` for MBEDTLS_AESNI_C"
 #else
 #error "MBEDTLS_AESNI_C defined, but neither intrinsics nor assembly available"
 #endif

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -4400,8 +4400,6 @@ component_test_aesni () { # ~ 60s
     not grep -q "AES note: built-in implementation." ./programs/test/selftest
 }
 
-
-
 support_test_aesni_m32() {
     support_test_m32_o0 && (lscpu | grep -qw aes)
 }
@@ -4417,10 +4415,10 @@ component_test_aesni_m32 () { # ~ 60s
     scripts/config.py unset MBEDTLS_AES_USE_HARDWARE_ONLY
     scripts/config.py set MBEDTLS_HAVE_ASM
 
-    # test the intrinsics implementation
-    msg "AES tests, test intrinsics"
+    # test the intrinsics implementation with gcc
+    msg "AES tests, test intrinsics (gcc)"
     make clean
-    make CC=gcc CFLAGS='-m32 -Werror -Wall -Wextra -mpclmul -msse2 -maes' LDFLAGS='-m32'
+    make CC=gcc CFLAGS='-m32 -Werror -Wall -Wextra' LDFLAGS='-m32'
     # check that we built intrinsics - this should be used by default when supported by the compiler
     ./programs/test/selftest aes | grep "AESNI code" | grep -q "intrinsics"
     grep -q "AES note: using AESNI" ./programs/test/selftest
@@ -4440,6 +4438,36 @@ component_test_aesni_m32 () { # ~ 60s
     not grep -q "AES note: built-in implementation." ./programs/test/selftest
     not grep -q "AES note: using VIA Padlock" ./programs/test/selftest
     not grep -q mbedtls_aesni_has_support ./programs/test/selftest
+}
+
+support_test_aesni_m32_clang() {
+    support_test_aesni_m32 && if command -v clang > /dev/null ; then
+        # clang >= 4 is required to build with target attributes
+        clang_ver="$(clang --version|grep version|sed -E 's#.*version ([0-9]+).*#\1#')"
+        [[ "${clang_ver}" -ge 4 ]]
+    else
+        # clang not available
+        false
+    fi
+}
+
+component_test_aesni_m32_clang() {
+
+    scripts/config.py set MBEDTLS_AESNI_C
+    scripts/config.py set MBEDTLS_PADLOCK_C
+    scripts/config.py unset MBEDTLS_AES_USE_HARDWARE_ONLY
+    scripts/config.py set MBEDTLS_HAVE_ASM
+
+    # test the intrinsics implementation with clang
+    msg "AES tests, test intrinsics (clang)"
+    make clean
+    make CC=clang CFLAGS='-m32 -Werror -Wall -Wextra' LDFLAGS='-m32'
+    # check that we built intrinsics - this should be used by default when supported by the compiler
+    ./programs/test/selftest aes | grep "AESNI code" | grep -q "intrinsics"
+    grep -q "AES note: using AESNI" ./programs/test/selftest
+    grep -q "AES note: built-in implementation." ./programs/test/selftest
+    grep -q "AES note: using VIA Padlock" ./programs/test/selftest
+    grep -q mbedtls_aesni_has_support ./programs/test/selftest
 }
 
 # For timebeing, no aarch64 gcc available in CI and no arm64 CI node.


### PR DESCRIPTION
## Description

Add target attributes for 32-bit builds to compile with intrinsics out of the box.

This fixes 32-bit compilation issues (e.g. https://github.com/Mbed-TLS/mbedtls/issues/8334 and https://github.com/Mbed-TLS/mbedtls/issues/8400).

For 64-bit, assembly will still be used if cpu flags are not passed when building.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required
- [x] **backport** not required, AES-NI is only enabled on 64bit on 2.28
- [x] **tests** provided

Tested that it builds fine on:
Windows 10: MINGW 32-bit/64-bit (13.0.2), Clang 32-bit/64-bit (17.0.1)
Linux Ubuntu 22.04: gcc 32-bit/64-bit (11.4.0), Clang 32-bit/64-bit (14.0.0)

Let me know if there is some better way of doing this.