### PR TITLE
Fix MBEDTLS_MAYBE_UNUSED for IAR

### DIFF
--- a/library/common.h
+++ b/library/common.h
@@ -344,8 +344,11 @@ static inline void mbedtls_xor_no_simd(unsigned char *r,
 #    define MBEDTLS_MAYBE_UNUSED __attribute__((unused))
 #endif
 #if !defined(MBEDTLS_MAYBE_UNUSED) && defined(__IAR_SYSTEMS_ICC__) && defined(__VER__)
+/* IAR does support __attribute__((unused)), but only if the -e flag (extended language support)
+ * is given; the pragma always works.
+ * Unfortunately the pragma affects the rest of the file where it is used, but this is harmless. */
 #    if (__VER__ >= 8010000) // IAR 8.1 or later
-#        define MBEDTLS_MAYBE_UNUSED __attribute__((unused))
+#        define MBEDTLS_MAYBE_UNUSED _Pragma("diag_suppress=Pe177")
 #    endif
 #endif
 #if !defined(MBEDTLS_MAYBE_UNUSED) && defined(_MSC_VER)

--- a/library/common.h
+++ b/library/common.h
@@ -346,8 +346,11 @@ static inline void mbedtls_xor_no_simd(unsigned char *r,
 #if !defined(MBEDTLS_MAYBE_UNUSED) && defined(__IAR_SYSTEMS_ICC__) && defined(__VER__)
 /* IAR does support __attribute__((unused)), but only if the -e flag (extended language support)
  * is given; the pragma always works.
- * Unfortunately the pragma affects the rest of the file where it is used, but this is harmless. */
-#    if (__VER__ >= 8010000) // IAR 8.1 or later
+ * Unfortunately the pragma affects the rest of the file where it is used, but this is harmless.
+ * Check for version 5.2 or later - this pragma may be supported by earlier versions, but I wasn't
+ * able to find documentation).
+ */
+#    if (__VER__ >= 5020000)
 #        define MBEDTLS_MAYBE_UNUSED _Pragma("diag_suppress=Pe177")
 #    endif
 #endif


### PR DESCRIPTION
## Description

IAR only supports `__attribute__((unused))` if the '-e' flag is passed to the compiler (which we can't detect), so use a more fail-safe implementation of `MBEDTLS_MAYBE_UNUSED`.

Without the -e flag, the current implementation is a compile fail on IAR.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required - old implementation is unreleased.
- [x] **backport** not required - 2.28 unaffected
- [x] **tests**  not required - covered by existing



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.
