### PR TITLE
Harmonise the names and return values of check functions in TLS code

### DIFF
--- a/library/ssl_client.c
+++ b/library/ssl_client.c
@@ -609,7 +609,7 @@ static int ssl_write_client_hello_body(mbedtls_ssl_context *ssl,
         int ssl_write_supported_groups_ext_flags = 0;
 
 #if defined(MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_SOME_EPHEMERAL_ENABLED)
-        if (propose_tls13 && mbedtls_ssl_conf_tls13_some_ephemeral_enabled(ssl)) {
+        if (propose_tls13 && mbedtls_ssl_conf_tls13_is_some_ephemeral_enabled(ssl)) {
             ssl_write_supported_groups_ext_flags |=
                 SSL_WRITE_SUPPORTED_GROUPS_EXT_TLS1_3_FLAG;
         }
@@ -637,7 +637,7 @@ static int ssl_write_client_hello_body(mbedtls_ssl_context *ssl,
     int write_sig_alg_ext = 0;
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
     write_sig_alg_ext = write_sig_alg_ext ||
-                        (propose_tls13 && mbedtls_ssl_conf_tls13_ephemeral_enabled(ssl));
+                        (propose_tls13 && mbedtls_ssl_conf_tls13_is_ephemeral_enabled(ssl));
 #endif
 #if defined(MBEDTLS_SSL_PROTO_TLS1_2)
     write_sig_alg_ext = write_sig_alg_ext || propose_tls12;
@@ -668,7 +668,7 @@ static int ssl_write_client_hello_body(mbedtls_ssl_context *ssl,
     /* The "pre_shared_key" extension (RFC 8446 Section 4.2.11)
      * MUST be the last extension in the ClientHello.
      */
-    if (propose_tls13 && mbedtls_ssl_conf_tls13_some_psk_enabled(ssl)) {
+    if (propose_tls13 && mbedtls_ssl_conf_tls13_is_some_psk_enabled(ssl)) {
         ret = mbedtls_ssl_tls13_write_identities_of_pre_shared_key_ext(
             ssl, p, end, &output_len, binders_len);
         if (ret != 0) {

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -1907,31 +1907,31 @@ static inline int mbedtls_ssl_conf_tls13_is_kex_mode_enabled(mbedtls_ssl_context
     return (ssl->conf->tls13_kex_modes & kex_mode_mask) != 0;
 }
 
-static inline int mbedtls_ssl_conf_tls13_psk_enabled(mbedtls_ssl_context *ssl)
+static inline int mbedtls_ssl_conf_tls13_is_psk_enabled(mbedtls_ssl_context *ssl)
 {
     return mbedtls_ssl_conf_tls13_is_kex_mode_enabled(ssl,
                                                       MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK);
 }
 
-static inline int mbedtls_ssl_conf_tls13_psk_ephemeral_enabled(mbedtls_ssl_context *ssl)
+static inline int mbedtls_ssl_conf_tls13_is_psk_ephemeral_enabled(mbedtls_ssl_context *ssl)
 {
     return mbedtls_ssl_conf_tls13_is_kex_mode_enabled(ssl,
                                                       MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL);
 }
 
-static inline int mbedtls_ssl_conf_tls13_ephemeral_enabled(mbedtls_ssl_context *ssl)
+static inline int mbedtls_ssl_conf_tls13_is_ephemeral_enabled(mbedtls_ssl_context *ssl)
 {
     return mbedtls_ssl_conf_tls13_is_kex_mode_enabled(ssl,
                                                       MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL);
 }
 
-static inline int mbedtls_ssl_conf_tls13_some_ephemeral_enabled(mbedtls_ssl_context *ssl)
+static inline int mbedtls_ssl_conf_tls13_is_some_ephemeral_enabled(mbedtls_ssl_context *ssl)
 {
     return mbedtls_ssl_conf_tls13_is_kex_mode_enabled(ssl,
                                                       MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ALL);
 }
 
-static inline int mbedtls_ssl_conf_tls13_some_psk_enabled(mbedtls_ssl_context *ssl)
+static inline int mbedtls_ssl_conf_tls13_is_some_psk_enabled(mbedtls_ssl_context *ssl)
 {
     return mbedtls_ssl_conf_tls13_is_kex_mode_enabled(ssl,
                                                       MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_ALL);

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -1904,37 +1904,37 @@ int mbedtls_ssl_tls13_handshake_server_step(mbedtls_ssl_context *ssl);
 static inline unsigned mbedtls_ssl_conf_tls13_check_kex_modes(mbedtls_ssl_context *ssl,
                                                               int kex_mode_mask)
 {
-    return (ssl->conf->tls13_kex_modes & kex_mode_mask) != 0;
+    return (ssl->conf->tls13_kex_modes & kex_mode_mask) == 0;
 }
 
 static inline int mbedtls_ssl_conf_tls13_psk_enabled(mbedtls_ssl_context *ssl)
 {
-    return mbedtls_ssl_conf_tls13_check_kex_modes(ssl,
-                                                  MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK);
+    return !mbedtls_ssl_conf_tls13_check_kex_modes(ssl,
+                                                   MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK);
 }
 
 static inline int mbedtls_ssl_conf_tls13_psk_ephemeral_enabled(mbedtls_ssl_context *ssl)
 {
-    return mbedtls_ssl_conf_tls13_check_kex_modes(ssl,
-                                                  MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL);
+    return !mbedtls_ssl_conf_tls13_check_kex_modes(ssl,
+                                                   MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL);
 }
 
 static inline int mbedtls_ssl_conf_tls13_ephemeral_enabled(mbedtls_ssl_context *ssl)
 {
-    return mbedtls_ssl_conf_tls13_check_kex_modes(ssl,
-                                                  MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL);
+    return !mbedtls_ssl_conf_tls13_check_kex_modes(ssl,
+                                                   MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL);
 }
 
 static inline int mbedtls_ssl_conf_tls13_some_ephemeral_enabled(mbedtls_ssl_context *ssl)
 {
-    return mbedtls_ssl_conf_tls13_check_kex_modes(ssl,
-                                                  MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ALL);
+    return !mbedtls_ssl_conf_tls13_check_kex_modes(ssl,
+                                                   MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ALL);
 }
 
 static inline int mbedtls_ssl_conf_tls13_some_psk_enabled(mbedtls_ssl_context *ssl)
 {
-    return mbedtls_ssl_conf_tls13_check_kex_modes(ssl,
-                                                  MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_ALL);
+    return !mbedtls_ssl_conf_tls13_check_kex_modes(ssl,
+                                                   MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_ALL);
 }
 
 #if defined(MBEDTLS_SSL_SRV_C) && \

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -1901,40 +1901,40 @@ int mbedtls_ssl_tls13_handshake_server_step(mbedtls_ssl_context *ssl);
 /*
  * Helper functions around key exchange modes.
  */
-static inline unsigned mbedtls_ssl_conf_tls13_check_kex_modes(mbedtls_ssl_context *ssl,
-                                                              int kex_mode_mask)
+static inline int mbedtls_ssl_conf_tls13_is_kex_mode_enabled(mbedtls_ssl_context *ssl,
+                                                             int kex_mode_mask)
 {
-    return (ssl->conf->tls13_kex_modes & kex_mode_mask) == 0;
+    return (ssl->conf->tls13_kex_modes & kex_mode_mask) != 0;
 }
 
 static inline int mbedtls_ssl_conf_tls13_psk_enabled(mbedtls_ssl_context *ssl)
 {
-    return !mbedtls_ssl_conf_tls13_check_kex_modes(ssl,
-                                                   MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK);
+    return mbedtls_ssl_conf_tls13_is_kex_mode_enabled(ssl,
+                                                      MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK);
 }
 
 static inline int mbedtls_ssl_conf_tls13_psk_ephemeral_enabled(mbedtls_ssl_context *ssl)
 {
-    return !mbedtls_ssl_conf_tls13_check_kex_modes(ssl,
-                                                   MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL);
+    return mbedtls_ssl_conf_tls13_is_kex_mode_enabled(ssl,
+                                                      MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL);
 }
 
 static inline int mbedtls_ssl_conf_tls13_ephemeral_enabled(mbedtls_ssl_context *ssl)
 {
-    return !mbedtls_ssl_conf_tls13_check_kex_modes(ssl,
-                                                   MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL);
+    return mbedtls_ssl_conf_tls13_is_kex_mode_enabled(ssl,
+                                                      MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL);
 }
 
 static inline int mbedtls_ssl_conf_tls13_some_ephemeral_enabled(mbedtls_ssl_context *ssl)
 {
-    return !mbedtls_ssl_conf_tls13_check_kex_modes(ssl,
-                                                   MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ALL);
+    return mbedtls_ssl_conf_tls13_is_kex_mode_enabled(ssl,
+                                                      MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ALL);
 }
 
 static inline int mbedtls_ssl_conf_tls13_some_psk_enabled(mbedtls_ssl_context *ssl)
 {
-    return !mbedtls_ssl_conf_tls13_check_kex_modes(ssl,
-                                                   MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_ALL);
+    return mbedtls_ssl_conf_tls13_is_kex_mode_enabled(ssl,
+                                                      MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_ALL);
 }
 
 #if defined(MBEDTLS_SSL_SRV_C) && \

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -2776,24 +2776,30 @@ static inline unsigned int mbedtls_ssl_session_get_ticket_flags(
            (flags & MBEDTLS_SSL_TLS1_3_TICKET_FLAGS_MASK);
 }
 
-static inline unsigned int mbedtls_ssl_session_check_ticket_flags(
+/**
+ * Check if at least one of the given flags is set in
+ * the session ticket. See the definition of
+ * `MBEDTLS_SSL_TLS1_3_TICKET_FLAGS_MASK` to get all
+ * permitted flags.
+ */
+static inline int mbedtls_ssl_session_ticket_has_flags(
     mbedtls_ssl_session *session, unsigned int flags)
 {
-    return mbedtls_ssl_session_get_ticket_flags(session, flags) == 0;
+    return mbedtls_ssl_session_get_ticket_flags(session, flags) != 0;
 }
 
-static inline unsigned int mbedtls_ssl_session_ticket_allow_psk(
+static inline int mbedtls_ssl_session_ticket_allow_psk(
     mbedtls_ssl_session *session)
 {
-    return !mbedtls_ssl_session_check_ticket_flags(session,
-                                                   MBEDTLS_SSL_TLS1_3_TICKET_ALLOW_PSK_RESUMPTION);
+    return mbedtls_ssl_session_ticket_has_flags(session,
+                                                MBEDTLS_SSL_TLS1_3_TICKET_ALLOW_PSK_RESUMPTION);
 }
 
-static inline unsigned int mbedtls_ssl_session_ticket_allow_psk_ephemeral(
+static inline int mbedtls_ssl_session_ticket_allow_psk_ephemeral(
     mbedtls_ssl_session *session)
 {
-    return !mbedtls_ssl_session_check_ticket_flags(session,
-                                                   MBEDTLS_SSL_TLS1_3_TICKET_ALLOW_PSK_EPHEMERAL_RESUMPTION);
+    return mbedtls_ssl_session_ticket_has_flags(session,
+                                                MBEDTLS_SSL_TLS1_3_TICKET_ALLOW_PSK_EPHEMERAL_RESUMPTION);
 }
 
 static inline unsigned int mbedtls_ssl_session_ticket_allow_early_data(

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -1955,32 +1955,32 @@ static inline int mbedtls_ssl_tls13_is_kex_mode_supported(mbedtls_ssl_context *s
     return (ssl->handshake->tls13_kex_modes & kex_modes_mask) != 0;
 }
 
-static inline int mbedtls_ssl_tls13_psk_enabled(mbedtls_ssl_context *ssl)
+static inline int mbedtls_ssl_tls13_is_psk_supported(mbedtls_ssl_context *ssl)
 {
     return mbedtls_ssl_tls13_is_kex_mode_supported(ssl,
                                                    MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK);
 }
 
-static inline int mbedtls_ssl_tls13_psk_ephemeral_enabled(
+static inline int mbedtls_ssl_tls13_is_psk_ephemeral_supported(
     mbedtls_ssl_context *ssl)
 {
     return mbedtls_ssl_tls13_is_kex_mode_supported(ssl,
                                                    MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL);
 }
 
-static inline int mbedtls_ssl_tls13_ephemeral_enabled(mbedtls_ssl_context *ssl)
+static inline int mbedtls_ssl_tls13_is_ephemeral_supported(mbedtls_ssl_context *ssl)
 {
     return mbedtls_ssl_tls13_is_kex_mode_supported(ssl,
                                                    MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL);
 }
 
-static inline int mbedtls_ssl_tls13_some_ephemeral_enabled(mbedtls_ssl_context *ssl)
+static inline int mbedtls_ssl_tls13_is_some_ephemeral_supported(mbedtls_ssl_context *ssl)
 {
     return mbedtls_ssl_tls13_is_kex_mode_supported(ssl,
                                                    MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ALL);
 }
 
-static inline int mbedtls_ssl_tls13_some_psk_enabled(mbedtls_ssl_context *ssl)
+static inline int mbedtls_ssl_tls13_is_some_psk_supported(mbedtls_ssl_context *ssl)
 {
     return mbedtls_ssl_tls13_is_kex_mode_supported(ssl,
                                                    MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_ALL);

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -1946,8 +1946,8 @@ static inline int mbedtls_ssl_conf_tls13_is_some_psk_enabled(mbedtls_ssl_context
  * \param[in] ssl  SSL context
  * \param kex_modes_mask  Mask of the key exchange modes to check
  *
- * \return Non-zero, if at least one of the key exchange modes is supported by
- *         the peer, otherwise \0.
+ * \return Non-zero if at least one of the key exchange modes is supported by
+ *         the peer, otherwise \c 0.
  */
 static inline int mbedtls_ssl_tls13_is_kex_mode_supported(mbedtls_ssl_context *ssl,
                                                           int kex_modes_mask)

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -2769,7 +2769,7 @@ int mbedtls_ssl_session_set_hostname(mbedtls_ssl_session *session,
 
 #define MBEDTLS_SSL_TLS1_3_MAX_ALLOWED_TICKET_LIFETIME (604800)
 
-static inline unsigned int mbedtls_ssl_session_get_ticket_flags(
+static inline unsigned int mbedtls_ssl_tls13_session_get_ticket_flags(
     mbedtls_ssl_session *session, unsigned int flags)
 {
     return session->ticket_flags &
@@ -2782,40 +2782,40 @@ static inline unsigned int mbedtls_ssl_session_get_ticket_flags(
  * `MBEDTLS_SSL_TLS1_3_TICKET_FLAGS_MASK` to get all
  * permitted flags.
  */
-static inline int mbedtls_ssl_session_ticket_has_flags(
+static inline int mbedtls_ssl_tls13_session_ticket_has_flags(
     mbedtls_ssl_session *session, unsigned int flags)
 {
-    return mbedtls_ssl_session_get_ticket_flags(session, flags) != 0;
+    return mbedtls_ssl_tls13_session_get_ticket_flags(session, flags) != 0;
 }
 
-static inline int mbedtls_ssl_session_ticket_allow_psk(
+static inline int mbedtls_ssl_tls13_session_ticket_allow_psk(
     mbedtls_ssl_session *session)
 {
-    return mbedtls_ssl_session_ticket_has_flags(session,
-                                                MBEDTLS_SSL_TLS1_3_TICKET_ALLOW_PSK_RESUMPTION);
+    return mbedtls_ssl_tls13_session_ticket_has_flags(
+        session, MBEDTLS_SSL_TLS1_3_TICKET_ALLOW_PSK_RESUMPTION);
 }
 
-static inline int mbedtls_ssl_session_ticket_allow_psk_ephemeral(
+static inline int mbedtls_ssl_tls13_session_ticket_allow_psk_ephemeral(
     mbedtls_ssl_session *session)
 {
-    return mbedtls_ssl_session_ticket_has_flags(session,
-                                                MBEDTLS_SSL_TLS1_3_TICKET_ALLOW_PSK_EPHEMERAL_RESUMPTION);
+    return mbedtls_ssl_tls13_session_ticket_has_flags(
+        session, MBEDTLS_SSL_TLS1_3_TICKET_ALLOW_PSK_EPHEMERAL_RESUMPTION);
 }
 
-static inline unsigned int mbedtls_ssl_session_ticket_allow_early_data(
+static inline unsigned int mbedtls_ssl_tls13_session_ticket_allow_early_data(
     mbedtls_ssl_session *session)
 {
-    return !mbedtls_ssl_session_check_ticket_flags(session,
-                                                   MBEDTLS_SSL_TLS1_3_TICKET_ALLOW_EARLY_DATA);
+    return mbedtls_ssl_tls13_session_ticket_has_flags(
+        session, MBEDTLS_SSL_TLS1_3_TICKET_ALLOW_EARLY_DATA);
 }
 
-static inline void mbedtls_ssl_session_set_ticket_flags(
+static inline void mbedtls_ssl_tls13_session_set_ticket_flags(
     mbedtls_ssl_session *session, unsigned int flags)
 {
     session->ticket_flags |= (flags & MBEDTLS_SSL_TLS1_3_TICKET_FLAGS_MASK);
 }
 
-static inline void mbedtls_ssl_session_clear_ticket_flags(
+static inline void mbedtls_ssl_tls13_session_clear_ticket_flags(
     mbedtls_ssl_session *session, unsigned int flags)
 {
     session->ticket_flags &= ~(flags & MBEDTLS_SSL_TLS1_3_TICKET_FLAGS_MASK);

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -1941,49 +1941,49 @@ static inline int mbedtls_ssl_conf_tls13_is_some_psk_enabled(mbedtls_ssl_context
     defined(MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_SOME_PSK_ENABLED)
 /**
  * Given a list of key exchange modes, check if at least one of them is
- * supported.
+ * supported by peer.
  *
  * \param[in] ssl  SSL context
  * \param kex_modes_mask  Mask of the key exchange modes to check
  *
- * \return 0 if at least one of the key exchange modes is supported,
- *         !=0 otherwise.
+ * \return True, if at least one of the key exchange modes is supported,
+ *         False, otherwise.
  */
-static inline unsigned mbedtls_ssl_tls13_check_kex_modes(mbedtls_ssl_context *ssl,
-                                                         int kex_modes_mask)
+static inline int mbedtls_ssl_tls13_is_kex_mode_supported(mbedtls_ssl_context *ssl,
+                                                          int kex_modes_mask)
 {
-    return (ssl->handshake->tls13_kex_modes & kex_modes_mask) == 0;
+    return (ssl->handshake->tls13_kex_modes & kex_modes_mask) != 0;
 }
 
 static inline int mbedtls_ssl_tls13_psk_enabled(mbedtls_ssl_context *ssl)
 {
-    return !mbedtls_ssl_tls13_check_kex_modes(ssl,
-                                              MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK);
+    return mbedtls_ssl_tls13_is_kex_mode_supported(ssl,
+                                                   MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK);
 }
 
 static inline int mbedtls_ssl_tls13_psk_ephemeral_enabled(
     mbedtls_ssl_context *ssl)
 {
-    return !mbedtls_ssl_tls13_check_kex_modes(ssl,
-                                              MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL);
+    return mbedtls_ssl_tls13_is_kex_mode_supported(ssl,
+                                                   MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL);
 }
 
 static inline int mbedtls_ssl_tls13_ephemeral_enabled(mbedtls_ssl_context *ssl)
 {
-    return !mbedtls_ssl_tls13_check_kex_modes(ssl,
-                                              MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL);
+    return mbedtls_ssl_tls13_is_kex_mode_supported(ssl,
+                                                   MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL);
 }
 
 static inline int mbedtls_ssl_tls13_some_ephemeral_enabled(mbedtls_ssl_context *ssl)
 {
-    return !mbedtls_ssl_tls13_check_kex_modes(ssl,
-                                              MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ALL);
+    return mbedtls_ssl_tls13_is_kex_mode_supported(ssl,
+                                                   MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ALL);
 }
 
 static inline int mbedtls_ssl_tls13_some_psk_enabled(mbedtls_ssl_context *ssl)
 {
-    return !mbedtls_ssl_tls13_check_kex_modes(ssl,
-                                              MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_ALL);
+    return mbedtls_ssl_tls13_is_kex_mode_supported(ssl,
+                                                   MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_ALL);
 }
 #endif /* MBEDTLS_SSL_SRV_C &&
           MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_SOME_PSK_ENABLED */

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -1946,8 +1946,8 @@ static inline int mbedtls_ssl_conf_tls13_is_some_psk_enabled(mbedtls_ssl_context
  * \param[in] ssl  SSL context
  * \param kex_modes_mask  Mask of the key exchange modes to check
  *
- * \return True, if at least one of the key exchange modes is supported,
- *         False, otherwise.
+ * \return Non-zero, if at least one of the key exchange modes is supported by
+ *         the peer, otherwise \0.
  */
 static inline int mbedtls_ssl_tls13_is_kex_mode_supported(mbedtls_ssl_context *ssl,
                                                           int kex_modes_mask)

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1342,7 +1342,7 @@ static int ssl_conf_check(const mbedtls_ssl_context *ssl)
      * bad config.
      *
      */
-    if (mbedtls_ssl_conf_tls13_ephemeral_enabled(
+    if (mbedtls_ssl_conf_tls13_is_ephemeral_enabled(
             (mbedtls_ssl_context *) ssl)                            &&
         ssl->conf->endpoint == MBEDTLS_SSL_IS_CLIENT                &&
         ssl->conf->max_tls_version == MBEDTLS_SSL_VERSION_TLS1_3    &&

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -621,7 +621,7 @@ static int ssl_tls13_write_psk_key_exchange_modes_ext(mbedtls_ssl_context *ssl,
     /* Skip writing extension if no PSK key exchange mode
      * is enabled in the config.
      */
-    if (!mbedtls_ssl_conf_tls13_some_psk_enabled(ssl)) {
+    if (!mbedtls_ssl_conf_tls13_is_some_psk_enabled(ssl)) {
         MBEDTLS_SSL_DEBUG_MSG(3, ("skip psk_key_exchange_modes extension"));
         return 0;
     }
@@ -640,14 +640,14 @@ static int ssl_tls13_write_psk_key_exchange_modes_ext(mbedtls_ssl_context *ssl,
      */
     p += 5;
 
-    if (mbedtls_ssl_conf_tls13_psk_ephemeral_enabled(ssl)) {
+    if (mbedtls_ssl_conf_tls13_is_psk_ephemeral_enabled(ssl)) {
         *p++ = MBEDTLS_SSL_TLS1_3_PSK_MODE_ECDHE;
         ke_modes_len++;
 
         MBEDTLS_SSL_DEBUG_MSG(4, ("Adding PSK-ECDHE key exchange mode"));
     }
 
-    if (mbedtls_ssl_conf_tls13_psk_enabled(ssl)) {
+    if (mbedtls_ssl_conf_tls13_is_psk_enabled(ssl)) {
         *p++ = MBEDTLS_SSL_TLS1_3_PSK_MODE_PURE;
         ke_modes_len++;
 
@@ -1161,7 +1161,7 @@ int mbedtls_ssl_tls13_write_client_hello_exts(mbedtls_ssl_context *ssl,
     p += ext_len;
 
 #if defined(MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_SOME_EPHEMERAL_ENABLED)
-    if (mbedtls_ssl_conf_tls13_some_ephemeral_enabled(ssl)) {
+    if (mbedtls_ssl_conf_tls13_is_some_ephemeral_enabled(ssl)) {
         ret = ssl_tls13_write_key_share_ext(ssl, p, end, &ext_len);
         if (ret != 0) {
             return ret;
@@ -1171,7 +1171,7 @@ int mbedtls_ssl_tls13_write_client_hello_exts(mbedtls_ssl_context *ssl,
 #endif
 
 #if defined(MBEDTLS_SSL_EARLY_DATA)
-    if (mbedtls_ssl_conf_tls13_some_psk_enabled(ssl) &&
+    if (mbedtls_ssl_conf_tls13_is_some_psk_enabled(ssl) &&
         ssl_tls13_early_data_has_valid_ticket(ssl) &&
         ssl->conf->early_data_enabled == MBEDTLS_SSL_EARLY_DATA_ENABLED) {
 
@@ -1457,7 +1457,7 @@ static int ssl_tls13_preprocess_server_hello(mbedtls_ssl_context *ssl,
                                  ssl, MBEDTLS_SSL_HS_SERVER_HELLO,
                                  buf, (size_t) (end - buf)));
 
-        if (mbedtls_ssl_conf_tls13_some_ephemeral_enabled(ssl)) {
+        if (mbedtls_ssl_conf_tls13_is_some_ephemeral_enabled(ssl)) {
             ret = ssl_tls13_reset_key_share(ssl);
             if (ret != 0) {
                 return ret;
@@ -1499,7 +1499,7 @@ static int ssl_tls13_preprocess_server_hello(mbedtls_ssl_context *ssl,
              * in the ClientHello.
              * In a PSK only key exchange that what we expect.
              */
-            if (!mbedtls_ssl_conf_tls13_some_ephemeral_enabled(ssl)) {
+            if (!mbedtls_ssl_conf_tls13_is_some_ephemeral_enabled(ssl)) {
                 MBEDTLS_SSL_DEBUG_MSG(1,
                                       ("Unexpected HRR in pure PSK key exchange."));
                 MBEDTLS_SSL_PEND_FATAL_ALERT(
@@ -1776,7 +1776,7 @@ static int ssl_tls13_parse_server_hello(mbedtls_ssl_context *ssl,
 
             case MBEDTLS_TLS_EXT_KEY_SHARE:
                 MBEDTLS_SSL_DEBUG_MSG(3, ("found key_shares extension"));
-                if (!mbedtls_ssl_conf_tls13_some_ephemeral_enabled(ssl)) {
+                if (!mbedtls_ssl_conf_tls13_is_some_ephemeral_enabled(ssl)) {
                     fatal_alert = MBEDTLS_SSL_ALERT_MSG_UNSUPPORTED_EXT;
                     goto cleanup;
                 }

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -684,7 +684,7 @@ static int ssl_tls13_has_configured_ticket(mbedtls_ssl_context *ssl)
     mbedtls_ssl_session *session = ssl->session_negotiate;
     return ssl->handshake->resume &&
            session != NULL && session->ticket != NULL &&
-           !mbedtls_ssl_conf_tls13_check_kex_modes(
+           mbedtls_ssl_conf_tls13_is_kex_mode_enabled(
         ssl, mbedtls_ssl_session_get_ticket_flags(
             session, MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_ALL));
 }
@@ -1879,7 +1879,7 @@ static int ssl_tls13_postprocess_server_hello(mbedtls_ssl_context *ssl)
             goto cleanup;
     }
 
-    if (mbedtls_ssl_conf_tls13_check_kex_modes(
+    if (!mbedtls_ssl_conf_tls13_is_kex_mode_enabled(
             ssl, handshake->key_exchange_mode)) {
         ret = MBEDTLS_ERR_SSL_HANDSHAKE_FAILURE;
         MBEDTLS_SSL_DEBUG_MSG(

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -684,7 +684,7 @@ static int ssl_tls13_has_configured_ticket(mbedtls_ssl_context *ssl)
     mbedtls_ssl_session *session = ssl->session_negotiate;
     return ssl->handshake->resume &&
            session != NULL && session->ticket != NULL &&
-           mbedtls_ssl_conf_tls13_check_kex_modes(
+           !mbedtls_ssl_conf_tls13_check_kex_modes(
         ssl, mbedtls_ssl_session_get_ticket_flags(
             session, MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_ALL));
 }
@@ -1879,7 +1879,7 @@ static int ssl_tls13_postprocess_server_hello(mbedtls_ssl_context *ssl)
             goto cleanup;
     }
 
-    if (!mbedtls_ssl_conf_tls13_check_kex_modes(
+    if (mbedtls_ssl_conf_tls13_check_kex_modes(
             ssl, handshake->key_exchange_mode)) {
         ret = MBEDTLS_ERR_SSL_HANDSHAKE_FAILURE;
         MBEDTLS_SSL_DEBUG_MSG(

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -685,7 +685,7 @@ static int ssl_tls13_has_configured_ticket(mbedtls_ssl_context *ssl)
     return ssl->handshake->resume &&
            session != NULL && session->ticket != NULL &&
            mbedtls_ssl_conf_tls13_is_kex_mode_enabled(
-        ssl, mbedtls_ssl_session_get_ticket_flags(
+        ssl, mbedtls_ssl_tls13_session_get_ticket_flags(
             session, MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_ALL));
 }
 
@@ -695,7 +695,7 @@ static int ssl_tls13_early_data_has_valid_ticket(mbedtls_ssl_context *ssl)
     mbedtls_ssl_session *session = ssl->session_negotiate;
     return ssl->handshake->resume &&
            session->tls_version == MBEDTLS_SSL_VERSION_TLS1_3 &&
-           mbedtls_ssl_session_ticket_allow_early_data(session) &&
+           mbedtls_ssl_tls13_session_ticket_allow_early_data(session) &&
            mbedtls_ssl_tls13_cipher_suite_is_offered(ssl, session->ciphersuite);
 }
 #endif
@@ -2685,7 +2685,7 @@ static int ssl_tls13_parse_new_session_ticket_early_data_ext(
     MBEDTLS_SSL_CHK_BUF_READ_PTR(buf, end, 4);
 
     session->max_early_data_size = MBEDTLS_GET_UINT32_BE(buf, 0);
-    mbedtls_ssl_session_set_ticket_flags(
+    mbedtls_ssl_tls13_session_set_ticket_flags(
         session, MBEDTLS_SSL_TLS1_3_TICKET_ALLOW_EARLY_DATA);
     MBEDTLS_SSL_DEBUG_MSG(
         3, ("received max_early_data_size: %u",
@@ -2836,7 +2836,7 @@ static int ssl_tls13_parse_new_session_ticket(mbedtls_ssl_context *ssl,
     session->ticket_len = ticket_len;
 
     /* Clear all flags in ticket_flags */
-    mbedtls_ssl_session_clear_ticket_flags(
+    mbedtls_ssl_tls13_session_clear_ticket_flags(
         session, MBEDTLS_SSL_TLS1_3_TICKET_FLAGS_MASK);
 
     MBEDTLS_SSL_CHK_BUF_READ_PTR(p, end, 2);
@@ -2923,7 +2923,7 @@ static int ssl_tls13_postprocess_new_session_ticket(mbedtls_ssl_context *ssl,
                           session->resumption_key_len);
 
     /* Set ticket_flags depends on the selected key exchange modes */
-    mbedtls_ssl_session_set_ticket_flags(
+    mbedtls_ssl_tls13_session_set_ticket_flags(
         session, ssl->conf->tls13_kex_modes);
     MBEDTLS_SSL_PRINT_TICKET_FLAGS(4, session->ticket_flags);
 

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1003,8 +1003,8 @@ static int ssl_tls13_client_hello_has_exts_for_psk_ephemeral_key_exchange(
 
 #if defined(MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_SOME_PSK_ENABLED)
 MBEDTLS_CHECK_RETURN_CRITICAL
-static int ssl_tls13_ticket_permission_check(mbedtls_ssl_context *ssl,
-                                             unsigned int kex_mode)
+static int ssl_tls13_ticket_is_kex_mode_permitted(mbedtls_ssl_context *ssl,
+                                                  unsigned int kex_mode)
 {
 #if defined(MBEDTLS_SSL_SESSION_TICKETS)
     if (ssl->handshake->resume) {
@@ -1037,7 +1037,7 @@ MBEDTLS_CHECK_RETURN_CRITICAL
 static int ssl_tls13_key_exchange_psk_available(mbedtls_ssl_context *ssl)
 {
 #if defined(MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_ENABLED)
-    return ssl_tls13_ticket_permission_check(
+    return ssl_tls13_ticket_is_kex_mode_permitted(
         ssl, MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK) &&
            mbedtls_ssl_conf_tls13_psk_enabled(ssl) &&
            mbedtls_ssl_tls13_psk_enabled(ssl) &&
@@ -1052,7 +1052,7 @@ MBEDTLS_CHECK_RETURN_CRITICAL
 static int ssl_tls13_key_exchange_psk_ephemeral_available(mbedtls_ssl_context *ssl)
 {
 #if defined(MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL_ENABLED)
-    return ssl_tls13_ticket_permission_check(
+    return ssl_tls13_ticket_is_kex_mode_permitted(
         ssl, MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL) &&
            mbedtls_ssl_conf_tls13_psk_ephemeral_enabled(ssl) &&
            mbedtls_ssl_tls13_psk_ephemeral_enabled(ssl) &&

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -95,9 +95,9 @@ static int ssl_tls13_parse_key_exchange_modes_ext(mbedtls_ssl_context *ssl,
 
 #if defined(MBEDTLS_SSL_SESSION_TICKETS)
 MBEDTLS_CHECK_RETURN_CRITICAL
-static int ssl_tls13_key_exchange_psk_available(mbedtls_ssl_context *ssl);
+static int ssl_tls13_key_exchange_is_psk_available(mbedtls_ssl_context *ssl);
 MBEDTLS_CHECK_RETURN_CRITICAL
-static int ssl_tls13_key_exchange_psk_ephemeral_available(mbedtls_ssl_context *ssl);
+static int ssl_tls13_key_exchange_is_psk_ephemeral_available(mbedtls_ssl_context *ssl);
 
 MBEDTLS_CHECK_RETURN_CRITICAL
 static int ssl_tls13_offered_psks_check_identity_match_ticket(
@@ -176,11 +176,11 @@ static int ssl_tls13_offered_psks_check_identity_match_ticket(
 
     key_exchanges = 0;
     if (mbedtls_ssl_session_ticket_allow_psk_ephemeral(session) &&
-        ssl_tls13_key_exchange_psk_ephemeral_available(ssl)) {
+        ssl_tls13_key_exchange_is_psk_ephemeral_available(ssl)) {
         key_exchanges |= MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL;
     }
     if (mbedtls_ssl_session_ticket_allow_psk(session) &&
-        ssl_tls13_key_exchange_psk_available(ssl)) {
+        ssl_tls13_key_exchange_is_psk_available(ssl)) {
         key_exchanges |= MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK;
     }
 
@@ -1022,7 +1022,7 @@ static int ssl_tls13_ticket_is_kex_mode_permitted(mbedtls_ssl_context *ssl,
 #endif /* MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_SOME_PSK_ENABLED */
 
 MBEDTLS_CHECK_RETURN_CRITICAL
-static int ssl_tls13_key_exchange_ephemeral_available(mbedtls_ssl_context *ssl)
+static int ssl_tls13_key_exchange_is_ephemeral_available(mbedtls_ssl_context *ssl)
 {
 #if defined(MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED)
     return mbedtls_ssl_conf_tls13_is_ephemeral_enabled(ssl) &&
@@ -1034,7 +1034,7 @@ static int ssl_tls13_key_exchange_ephemeral_available(mbedtls_ssl_context *ssl)
 }
 
 MBEDTLS_CHECK_RETURN_CRITICAL
-static int ssl_tls13_key_exchange_psk_available(mbedtls_ssl_context *ssl)
+static int ssl_tls13_key_exchange_is_psk_available(mbedtls_ssl_context *ssl)
 {
 #if defined(MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_ENABLED)
     return ssl_tls13_ticket_is_kex_mode_permitted(
@@ -1049,7 +1049,7 @@ static int ssl_tls13_key_exchange_psk_available(mbedtls_ssl_context *ssl)
 }
 
 MBEDTLS_CHECK_RETURN_CRITICAL
-static int ssl_tls13_key_exchange_psk_ephemeral_available(mbedtls_ssl_context *ssl)
+static int ssl_tls13_key_exchange_is_psk_ephemeral_available(mbedtls_ssl_context *ssl)
 {
 #if defined(MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL_ENABLED)
     return ssl_tls13_ticket_is_kex_mode_permitted(
@@ -1083,17 +1083,17 @@ static int ssl_tls13_determine_key_exchange_mode(mbedtls_ssl_context *ssl)
     ssl->handshake->key_exchange_mode =
         MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_NONE;
 
-    if (ssl_tls13_key_exchange_psk_ephemeral_available(ssl)) {
+    if (ssl_tls13_key_exchange_is_psk_ephemeral_available(ssl)) {
         ssl->handshake->key_exchange_mode =
             MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL;
         MBEDTLS_SSL_DEBUG_MSG(2, ("key exchange mode: psk_ephemeral"));
     } else
-    if (ssl_tls13_key_exchange_ephemeral_available(ssl)) {
+    if (ssl_tls13_key_exchange_is_ephemeral_available(ssl)) {
         ssl->handshake->key_exchange_mode =
             MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL;
         MBEDTLS_SSL_DEBUG_MSG(2, ("key exchange mode: ephemeral"));
     } else
-    if (ssl_tls13_key_exchange_psk_available(ssl)) {
+    if (ssl_tls13_key_exchange_is_psk_available(ssl)) {
         ssl->handshake->key_exchange_mode =
             MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK;
         MBEDTLS_SSL_DEBUG_MSG(2, ("key exchange mode: psk"));
@@ -1737,8 +1737,8 @@ static int ssl_tls13_parse_client_hello(mbedtls_ssl_context *ssl,
      * - The content up to but excluding the PSK extension, if present.
      */
     /* If we've settled on a PSK-based exchange, parse PSK identity ext */
-    if (ssl_tls13_key_exchange_psk_available(ssl) ||
-        ssl_tls13_key_exchange_psk_ephemeral_available(ssl)) {
+    if (ssl_tls13_key_exchange_is_psk_available(ssl) ||
+        ssl_tls13_key_exchange_is_psk_ephemeral_available(ssl)) {
         ret = handshake->update_checksum(ssl, buf,
                                          pre_shared_key_ext - buf);
         if (0 != ret) {

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1008,7 +1008,7 @@ static int ssl_tls13_ticket_is_kex_mode_permitted(mbedtls_ssl_context *ssl,
 {
 #if defined(MBEDTLS_SSL_SESSION_TICKETS)
     if (ssl->handshake->resume) {
-        if (mbedtls_ssl_session_check_ticket_flags(
+        if (!mbedtls_ssl_session_ticket_has_flags(
                 ssl->session_negotiate, kex_mode)) {
             return 0;
         }

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1025,7 +1025,7 @@ MBEDTLS_CHECK_RETURN_CRITICAL
 static int ssl_tls13_key_exchange_ephemeral_available(mbedtls_ssl_context *ssl)
 {
 #if defined(MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED)
-    return mbedtls_ssl_conf_tls13_ephemeral_enabled(ssl) &&
+    return mbedtls_ssl_conf_tls13_is_ephemeral_enabled(ssl) &&
            ssl_tls13_client_hello_has_exts_for_ephemeral_key_exchange(ssl);
 #else
     ((void) ssl);
@@ -1039,7 +1039,7 @@ static int ssl_tls13_key_exchange_psk_available(mbedtls_ssl_context *ssl)
 #if defined(MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_ENABLED)
     return ssl_tls13_ticket_is_kex_mode_permitted(
         ssl, MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK) &&
-           mbedtls_ssl_conf_tls13_psk_enabled(ssl) &&
+           mbedtls_ssl_conf_tls13_is_psk_enabled(ssl) &&
            mbedtls_ssl_tls13_psk_enabled(ssl) &&
            ssl_tls13_client_hello_has_exts_for_psk_key_exchange(ssl);
 #else
@@ -1054,7 +1054,7 @@ static int ssl_tls13_key_exchange_psk_ephemeral_available(mbedtls_ssl_context *s
 #if defined(MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL_ENABLED)
     return ssl_tls13_ticket_is_kex_mode_permitted(
         ssl, MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL) &&
-           mbedtls_ssl_conf_tls13_psk_ephemeral_enabled(ssl) &&
+           mbedtls_ssl_conf_tls13_is_psk_ephemeral_enabled(ssl) &&
            mbedtls_ssl_tls13_psk_ephemeral_enabled(ssl) &&
            ssl_tls13_client_hello_has_exts_for_psk_ephemeral_key_exchange(ssl);
 #else

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1040,7 +1040,7 @@ static int ssl_tls13_key_exchange_psk_available(mbedtls_ssl_context *ssl)
     return ssl_tls13_ticket_is_kex_mode_permitted(
         ssl, MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK) &&
            mbedtls_ssl_conf_tls13_is_psk_enabled(ssl) &&
-           mbedtls_ssl_tls13_psk_enabled(ssl) &&
+           mbedtls_ssl_tls13_is_psk_supported(ssl) &&
            ssl_tls13_client_hello_has_exts_for_psk_key_exchange(ssl);
 #else
     ((void) ssl);
@@ -1055,7 +1055,7 @@ static int ssl_tls13_key_exchange_psk_ephemeral_available(mbedtls_ssl_context *s
     return ssl_tls13_ticket_is_kex_mode_permitted(
         ssl, MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL) &&
            mbedtls_ssl_conf_tls13_is_psk_ephemeral_enabled(ssl) &&
-           mbedtls_ssl_tls13_psk_ephemeral_enabled(ssl) &&
+           mbedtls_ssl_tls13_is_psk_ephemeral_supported(ssl) &&
            ssl_tls13_client_hello_has_exts_for_psk_ephemeral_key_exchange(ssl);
 #else
     ((void) ssl);
@@ -3072,7 +3072,7 @@ static int ssl_tls13_handshake_wrapup(mbedtls_ssl_context *ssl)
  *       expected to be resolved with issue#6395.
  */
     /* Sent NewSessionTicket message only when client supports PSK */
-    if (mbedtls_ssl_tls13_some_psk_enabled(ssl)) {
+    if (mbedtls_ssl_tls13_is_some_psk_supported(ssl)) {
         mbedtls_ssl_handshake_set_state(
             ssl, MBEDTLS_SSL_TLS1_3_NEW_SESSION_TICKET);
     } else

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -175,11 +175,11 @@ static int ssl_tls13_offered_psks_check_identity_match_ticket(
     MBEDTLS_SSL_PRINT_TICKET_FLAGS(4, session->ticket_flags);
 
     key_exchanges = 0;
-    if (mbedtls_ssl_session_ticket_allow_psk_ephemeral(session) &&
+    if (mbedtls_ssl_tls13_session_ticket_allow_psk_ephemeral(session) &&
         ssl_tls13_key_exchange_is_psk_ephemeral_available(ssl)) {
         key_exchanges |= MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL;
     }
-    if (mbedtls_ssl_session_ticket_allow_psk(session) &&
+    if (mbedtls_ssl_tls13_session_ticket_allow_psk(session) &&
         ssl_tls13_key_exchange_is_psk_available(ssl)) {
         key_exchanges |= MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK;
     }
@@ -1008,7 +1008,7 @@ static int ssl_tls13_ticket_is_kex_mode_permitted(mbedtls_ssl_context *ssl,
 {
 #if defined(MBEDTLS_SSL_SESSION_TICKETS)
     if (ssl->handshake->resume) {
-        if (!mbedtls_ssl_session_ticket_has_flags(
+        if (!mbedtls_ssl_tls13_session_ticket_has_flags(
                 ssl->session_negotiate, kex_mode)) {
             return 0;
         }
@@ -1845,7 +1845,7 @@ static void ssl_tls13_update_early_data_status(mbedtls_ssl_context *ssl)
 
     }
 
-    if (!mbedtls_ssl_session_ticket_allow_early_data(ssl->session_negotiate)) {
+    if (!mbedtls_ssl_tls13_session_ticket_allow_early_data(ssl->session_negotiate)) {
         MBEDTLS_SSL_DEBUG_MSG(
             1,
             ("EarlyData: rejected, early_data not allowed in ticket "
@@ -3131,17 +3131,17 @@ static int ssl_tls13_prepare_new_session_ticket(mbedtls_ssl_context *ssl,
 #endif
 
     /* Set ticket_flags depends on the advertised psk key exchange mode */
-    mbedtls_ssl_session_clear_ticket_flags(
+    mbedtls_ssl_tls13_session_clear_ticket_flags(
         session, MBEDTLS_SSL_TLS1_3_TICKET_FLAGS_MASK);
 #if defined(MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_SOME_PSK_ENABLED)
-    mbedtls_ssl_session_set_ticket_flags(
+    mbedtls_ssl_tls13_session_set_ticket_flags(
         session, ssl->handshake->tls13_kex_modes);
 #endif
 
 #if defined(MBEDTLS_SSL_EARLY_DATA)
     if (ssl->conf->early_data_enabled == MBEDTLS_SSL_EARLY_DATA_ENABLED &&
         ssl->conf->max_early_data_size > 0) {
-        mbedtls_ssl_session_set_ticket_flags(
+        mbedtls_ssl_tls13_session_set_ticket_flags(
             session, MBEDTLS_SSL_TLS1_3_TICKET_ALLOW_EARLY_DATA);
     }
 #endif /* MBEDTLS_SSL_EARLY_DATA */
@@ -3321,7 +3321,7 @@ static int ssl_tls13_write_new_session_ticket_body(mbedtls_ssl_context *ssl,
     p += 2;
 
 #if defined(MBEDTLS_SSL_EARLY_DATA)
-    if (mbedtls_ssl_session_ticket_allow_early_data(session)) {
+    if (mbedtls_ssl_tls13_session_ticket_allow_early_data(session)) {
         size_t output_len;
 
         if ((ret = mbedtls_ssl_tls13_write_early_data_ext(


### PR DESCRIPTION
## Description

Fix [comment](https://github.com/Mbed-TLS/mbedtls/pull/6945/files#r1363489728)

Fixes #6935

>Note: convention in TLS code, "check" functions return 0 if the check is successful, something different from zero otherwise. By the way, we should rename or change the value returned by ssl_tls13_check_*_key_exchange() functions.



## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required, internall change
- [x] **backport** not required, no TLS13 code in `2.28`
- [x] **tests** not required
