### PR TITLE
Backport 2.28: Support running unit tests from another directory

### DIFF
--- a/tests/suites/host_test.function
+++ b/tests/suites/host_test.function
@@ -442,7 +442,7 @@ static void write_outcome_result(FILE *outcome_file,
  *
  * Failures are silent.
  */
-static void try_chdir(const char *argv0)
+static void try_chdir_if_supported(const char *argv0)
 {
     /* We might want to allow backslash as well, for Windows. But then we also
      * need to consider chdir() vs _chdir(), and different conventions
@@ -466,6 +466,13 @@ static void try_chdir(const char *argv0)
                         __func__, path);
     }
     mbedtls_free(path);
+}
+#else /* MBEDTLS_HAVE_CHDIR */
+/* No chdir() or no support for parsing argv[0] on this platform. */
+static void try_chdir_if_supported(const char *argv0)
+{
+    (void) argv0;
+    return;
 }
 #endif /* MBEDTLS_HAVE_CHDIR */
 

--- a/tests/suites/host_test.function
+++ b/tests/suites/host_test.function
@@ -444,6 +444,11 @@ static void write_outcome_result(FILE *outcome_file,
  */
 static void try_chdir(const char *argv0)
 {
+    /* We might want to allow backslash as well, for Windows. But then we also
+     * need to consider chdir() vs _chdir(), and different conventions
+     * regarding paths in argv[0] (naively enabling this code with
+     * backslash support on Windows leads to chdir into the wrong directory
+     * on the CI). */
     const char *slash = strrchr(argv0, '/');
     if (slash == NULL) {
         return;

--- a/tests/suites/host_test.function
+++ b/tests/suites/host_test.function
@@ -432,6 +432,39 @@ static void write_outcome_result(FILE *outcome_file,
     fflush(outcome_file);
 }
 
+#if defined(__unix__) ||                                \
+    (defined(__APPLE__) && defined(__MACH__)) ||        \
+    defined(_WIN32)
+#define MBEDTLS_HAVE_CHDIR
+#endif
+
+#if defined(MBEDTLS_HAVE_CHDIR)
+/** Try chdir to the directory containing argv0.
+ *
+ * Failures are silent.
+ */
+static void try_chdir(const char *argv0)
+{
+    const char *slash = strrchr(argv0, '/');
+    if (slash == NULL) {
+        return;
+    }
+    size_t path_size = slash - argv0 + 1;
+    char *path = mbedtls_calloc(1, path_size);
+    if (path == NULL) {
+        return;
+    }
+    memcpy(path, argv0, path_size - 1);
+    path[path_size - 1] = 0;
+#if defined(_WIN32)
+    (void) _chdir(path);
+#else
+    (void) chdir(path);
+#endif
+    mbedtls_free(path);
+}
+#endif /* MBEDTLS_HAVE_CHDIR */
+
 /**
  * \brief       Desktop implementation of execute_tests().
  *              Parses command line and executes tests from

--- a/tests/suites/host_test.function
+++ b/tests/suites/host_test.function
@@ -433,8 +433,7 @@ static void write_outcome_result(FILE *outcome_file,
 }
 
 #if defined(__unix__) ||                                \
-    (defined(__APPLE__) && defined(__MACH__)) ||        \
-    defined(_WIN32)
+    (defined(__APPLE__) && defined(__MACH__))
 #define MBEDTLS_HAVE_CHDIR
 #endif
 
@@ -456,11 +455,11 @@ static void try_chdir(const char *argv0)
     }
     memcpy(path, argv0, path_size - 1);
     path[path_size - 1] = 0;
-#if defined(_WIN32)
-    (void) _chdir(path);
-#else
-    (void) chdir(path);
-#endif
+    int ret = chdir(path);
+    if (ret != 0) {
+        mbedtls_fprintf(stderr, "%s: note: chdir(\"%s\") failed.\n",
+                        __func__, path);
+    }
     mbedtls_free(path);
 }
 #endif /* MBEDTLS_HAVE_CHDIR */

--- a/tests/suites/main_test.function
+++ b/tests/suites/main_test.function
@@ -278,7 +278,6 @@ int main(int argc, const char *argv[])
     mbedtls_test_hook_error_add = &mbedtls_test_err_add_check;
 #endif
 
-#ifdef MBEDTLS_HAVE_CHDIR
     /* Try changing to the directory containing the executable, if
      * using the default data file. This allows running the executable
      * from another directory (e.g. the project root) and still access
@@ -290,8 +289,7 @@ int main(int argc, const char *argv[])
      * test-specific files such as the outcome file, which is arguably
      * not desirable and should be fixed later.
      */
-    try_chdir(argv[0]);
-#endif /* MBEDTLS_HAVE_CHDIR */
+    try_chdir_if_supported(argv[0]);
 
     int ret = mbedtls_test_platform_setup();
     if (ret != 0) {

--- a/tests/suites/main_test.function
+++ b/tests/suites/main_test.function
@@ -289,7 +289,9 @@ int main(int argc, const char *argv[])
      * test-specific files such as the outcome file, which is arguably
      * not desirable and should be fixed later.
      */
-    try_chdir_if_supported(argv[0]);
+    if (argc == 1) {
+        try_chdir_if_supported(argv[0]);
+    }
 
     int ret = mbedtls_test_platform_setup();
     if (ret != 0) {

--- a/tests/suites/main_test.function
+++ b/tests/suites/main_test.function
@@ -278,6 +278,21 @@ int main(int argc, const char *argv[])
     mbedtls_test_hook_error_add = &mbedtls_test_err_add_check;
 #endif
 
+#ifdef MBEDTLS_HAVE_CHDIR
+    /* Try changing to the directory containing the executable, if
+     * using the default data file. This allows running the executable
+     * from another directory (e.g. the project root) and still access
+     * the .datax file as well as data files used by test cases
+     * (typically from tests/data_files).
+     *
+     * Note that we do this before the platform setup (which may access
+     * files such as a random seed). We also do this before accessing
+     * test-specific files such as the outcome file, which is arguably
+     * not desirable and should be fixed later.
+     */
+    try_chdir(argv[0]);
+#endif /* MBEDTLS_HAVE_CHDIR */
+
     int ret = mbedtls_test_platform_setup();
     if (ret != 0) {
         mbedtls_fprintf(stderr,


### PR DESCRIPTION
Trivial backport of https://github.com/Mbed-TLS/mbedtls/pull/8294

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** no (test only)
- [x] **backport** of https://github.com/Mbed-TLS/mbedtls/pull/8294
- [x] **tests** no (test only)
