### PR TITLE
Fix builds in conda-forge, which doesn't have CLOCK_BOOTTIME

### DIFF
--- a/ChangeLog.d/fix-linux-builds-in-conda-forge.txt
+++ b/ChangeLog.d/fix-linux-builds-in-conda-forge.txt
@@ -1,0 +1,2 @@
+Bugfix
+   * Fix build failure in conda-forge.  Fixes #8422.

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -265,7 +265,7 @@ mbedtls_ms_time_t mbedtls_ms_time(void)
     struct timespec tv;
     mbedtls_ms_time_t current_ms;
 
-#if defined(__linux__)
+#if defined(__linux__) && defined(CLOCK_BOOTTIME)
     ret = clock_gettime(CLOCK_BOOTTIME, &tv);
 #else
     ret = clock_gettime(CLOCK_MONOTONIC, &tv);


### PR DESCRIPTION
Conda-forge seems to be using a very old set of system headers (I had to go back to CentOS 6 to reproduce the problem)

Fixes #8422

- [ ] **changelog** provided
- [ ] **backport** not required (LTS doesn't have `mbedtls_ms_time()`)
- [ ] **tests** not required
