### PR TITLE
Fix test suite never executed due to an undefined symbol

### DIFF
--- a/tests/suites/test_suite_constant_time_hmac.function
+++ b/tests/suites/test_suite_constant_time_hmac.function
@@ -4,6 +4,7 @@
 #include <mbedtls/md.h>
 #include <constant_time_internal.h>
 #include "md_psa.h"
+#include <ssl_misc.h>
 
 #include <test/constant_flow.h>
 /* END_HEADER */


### PR DESCRIPTION
Some time ago we stopped running `test_suite_constant_time_hmac` on the CI (I guess due to some header file refactoring). ([yesterday's nightly](https://mbedtls.trustedfirmware.org/job/mbed-tls-nightly-tests/213/execution/node/8075/log/)) Fix that.

This would have been detected if https://github.com/Mbed-TLS/mbedtls/issues/2691 had been completed.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required (test only)
- [x] **backport** not required (the test is running in 2.28)
- [x] **tests** provided
