### PR TITLE
Disable stdout in require_*_configs_* functions

### DIFF
--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -234,28 +234,28 @@ requires_config_disabled() {
 }
 
 requires_all_configs_enabled() {
-    if ! $P_QUERY -all $*
+    if ! $P_QUERY -all $* 2>&1 > /dev/null
     then
         SKIP_NEXT="YES"
     fi
 }
 
 requires_all_configs_disabled() {
-    if $P_QUERY -any $*
+    if $P_QUERY -any $* 2>&1 > /dev/null
     then
         SKIP_NEXT="YES"
     fi
 }
 
 requires_any_configs_enabled() {
-    if ! $P_QUERY -any $*
+    if ! $P_QUERY -any $* 2>&1 > /dev/null
     then
         SKIP_NEXT="YES"
     fi
 }
 
 requires_any_configs_disabled() {
-    if $P_QUERY -all $*
+    if $P_QUERY -all $* 2>&1 > /dev/null
     then
         SKIP_NEXT="YES"
     fi


### PR DESCRIPTION
## Description

Those commands print information in stdout, that's noise for testing. Just disable them.

This is found in #6280. But it can be separate review.

https://github.com/Mbed-TLS/mbedtls/pull/6280/commits/c2a2a5eda54cb7065f338bc97ee6d46cf18a0c91 is the commit in #6280 

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** ~~provided, or~~ not required. (That's not needed for it just disable unnecessary output message)
- [x] **backport** ~~done, or~~ not required( `requires_{all,any}_configs_{en,dis}abled` does not exist in `mbedtls-2.28`)
- [x] **tests** ~~provided, or~~ not required( build scripts)

