### PR TITLE
Fix missing pre shared key ext sent mask

### DIFF
--- a/library/ssl_client.c
+++ b/library/ssl_client.c
@@ -705,11 +705,6 @@ static int ssl_write_client_hello_body(mbedtls_ssl_context *ssl,
                               p_extensions_len, extensions_len);
     }
 
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3)
-    MBEDTLS_SSL_PRINT_EXTS(
-        3, MBEDTLS_SSL_HS_CLIENT_HELLO, handshake->sent_extensions);
-#endif
-
     *out_len = p - buf;
     return 0;
 }
@@ -1020,6 +1015,11 @@ int mbedtls_ssl_write_client_hello(mbedtls_ssl_context *ssl)
         }
 #endif
     }
+
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3)
+    MBEDTLS_SSL_PRINT_EXTS(
+        3, MBEDTLS_SSL_HS_CLIENT_HELLO, ssl->handshake->sent_extensions);
+#endif
 
 cleanup:
 

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -1022,6 +1022,8 @@ int mbedtls_ssl_tls13_write_identities_of_pre_shared_key_ext(
 
     MBEDTLS_SSL_DEBUG_BUF(3, "pre_shared_key identities", buf, p - buf);
 
+    mbedtls_ssl_tls13_set_hs_sent_ext_mask(ssl, MBEDTLS_TLS_EXT_PRE_SHARED_KEY);
+
     return 0;
 }
 

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -1022,8 +1022,6 @@ int mbedtls_ssl_tls13_write_identities_of_pre_shared_key_ext(
 
     MBEDTLS_SSL_DEBUG_BUF(3, "pre_shared_key identities", buf, p - buf);
 
-    mbedtls_ssl_tls13_set_hs_sent_ext_mask(ssl, MBEDTLS_TLS_EXT_PRE_SHARED_KEY);
-
     return 0;
 }
 


### PR DESCRIPTION
## Description

When send `pre_shared_key` extension, then sent_extension should be correctly set for future using. It is missed.

This issue is found in #6280. And this commit is also included in #6280. But I think it can be separate review.



## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** ~~provided, or~~ not required( That is debug message bug fix)
- [x] **backport** ~~done, or~~ not required( That is based on new debug feature of `development`)
- [x] **tests** ~~provided, or~~ not required(The test scripts is in #6280)


