### PR TITLE
code size for mbedtls_cipher_validate_values

### DIFF
--- a/library/common.h
+++ b/library/common.h
@@ -330,7 +330,12 @@ static inline void mbedtls_xor_no_simd(unsigned char *r,
 #endif
 #endif
 #if !defined(MBEDTLS_ASSUME)
+#if defined(_MSC_VER)
+/* Supported by MSVC since VS 2005 */
+#define MBEDTLS_ASSUME(x)       __assume(x)
+#else
 #define MBEDTLS_ASSUME(x)       do { } while (0)
+#endif
 #endif
 
 #if defined(__GNUC__) && !defined(__ARMCC_VERSION) && !defined(__clang__) \

--- a/library/common.h
+++ b/library/common.h
@@ -330,7 +330,7 @@ static inline void mbedtls_xor_no_simd(unsigned char *r,
 #endif
 #endif
 #if !defined(MBEDTLS_ASSUME)
-#define MBEDTLS_ASSUME(x)
+#define MBEDTLS_ASSUME(x)       do { } while (0)
 #endif
 
 #if defined(__GNUC__) && !defined(__ARMCC_VERSION) && !defined(__clang__) \

--- a/library/common.h
+++ b/library/common.h
@@ -306,36 +306,34 @@ static inline void mbedtls_xor_no_simd(unsigned char *r,
 #define MBEDTLS_STATIC_ASSERT(expr, msg)
 #endif
 
-/* Define compiler branch hints */
 #if defined(__has_builtin)
-#if __has_builtin(__builtin_expect)
+#define MBEDTLS_HAS_BUILTIN(x) __has_builtin(x)
+#else
+#define MBEDTLS_HAS_BUILTIN(x) 0
+#endif
+
+/* Define compiler branch hints */
+#if MBEDTLS_HAS_BUILTIN(__builtin_expect)
 #define MBEDTLS_LIKELY(x)       __builtin_expect(!!(x), 1)
 #define MBEDTLS_UNLIKELY(x)     __builtin_expect(!!(x), 0)
-#endif
-#endif
-#if !defined(MBEDTLS_LIKELY)
+#else
 #define MBEDTLS_LIKELY(x)       x
 #define MBEDTLS_UNLIKELY(x)     x
 #endif
 
 /* MBEDTLS_ASSUME may be used to provide additional information to the compiler
  * which can result in smaller code-size. */
-#if defined(__has_builtin)
-#if __has_builtin(__builtin_assume)
+#if MBEDTLS_HAS_BUILTIN(__builtin_assume)
 /* clang provides __builtin_assume */
 #define MBEDTLS_ASSUME(x)       __builtin_assume(x)
-#elif __has_builtin(__builtin_unreachable)
+#elif MBEDTLS_HAS_BUILTIN(__builtin_unreachable)
 /* gcc can use __builtin_unreachable */
 #define MBEDTLS_ASSUME(x)       do { if (!(x)) __builtin_unreachable(); } while (0)
-#endif
-#endif
-#if !defined(MBEDTLS_ASSUME)
-#if defined(_MSC_VER)
+#elif defined(_MSC_VER)
 /* Supported by MSVC since VS 2005 */
 #define MBEDTLS_ASSUME(x)       __assume(x)
 #else
 #define MBEDTLS_ASSUME(x)       do { } while (0)
-#endif
 #endif
 
 #if defined(__GNUC__) && !defined(__ARMCC_VERSION) && !defined(__clang__) \

--- a/library/common.h
+++ b/library/common.h
@@ -318,6 +318,21 @@ static inline void mbedtls_xor_no_simd(unsigned char *r,
 #define MBEDTLS_UNLIKELY(x)     x
 #endif
 
+#if defined(__has_builtin)
+#if __has_builtin(__builtin_assume)
+/* MBEDTLS_ASSUME may be used to provide additional information to the compiler
+ * which can result in smaller code-size. */
+#define MBEDTLS_ASSUME(x)       __builtin_assume(x)
+// clang provides __builtin_assume
+#elif __has_builtin(__builtin_unreachable)
+#define MBEDTLS_ASSUME(x)       do { if (!(x)) __builtin_unreachable(); } while (0)
+// For gcc, use __builtin_unreachable
+#endif
+#endif
+#if !defined(MBEDTLS_ASSUME)
+#define MBEDTLS_ASSUME(x)
+#endif
+
 #if defined(__GNUC__) && !defined(__ARMCC_VERSION) && !defined(__clang__) \
     && !defined(__llvm__) && !defined(__INTEL_COMPILER)
 /* Defined if the compiler really is gcc and not clang, etc */

--- a/library/common.h
+++ b/library/common.h
@@ -318,15 +318,15 @@ static inline void mbedtls_xor_no_simd(unsigned char *r,
 #define MBEDTLS_UNLIKELY(x)     x
 #endif
 
-#if defined(__has_builtin)
-#if __has_builtin(__builtin_assume)
 /* MBEDTLS_ASSUME may be used to provide additional information to the compiler
  * which can result in smaller code-size. */
+#if defined(__has_builtin)
+#if __has_builtin(__builtin_assume)
+/* clang provides __builtin_assume */
 #define MBEDTLS_ASSUME(x)       __builtin_assume(x)
-// clang provides __builtin_assume
 #elif __has_builtin(__builtin_unreachable)
+/* gcc can use __builtin_unreachable */
 #define MBEDTLS_ASSUME(x)       do { if (!(x)) __builtin_unreachable(); } while (0)
-// For gcc, use __builtin_unreachable
 #endif
 #endif
 #if !defined(MBEDTLS_ASSUME)

--- a/library/common.h
+++ b/library/common.h
@@ -327,7 +327,7 @@ static inline void mbedtls_xor_no_simd(unsigned char *r,
 /* clang provides __builtin_assume */
 #define MBEDTLS_ASSUME(x)       __builtin_assume(x)
 #elif MBEDTLS_HAS_BUILTIN(__builtin_unreachable)
-/* gcc can use __builtin_unreachable */
+/* gcc and IAR can use __builtin_unreachable */
 #define MBEDTLS_ASSUME(x)       do { if (!(x)) __builtin_unreachable(); } while (0)
 #elif defined(_MSC_VER)
 /* Supported by MSVC since VS 2005 */

--- a/library/psa_crypto_cipher.c
+++ b/library/psa_crypto_cipher.c
@@ -42,6 +42,63 @@ static psa_status_t mbedtls_cipher_validate_values(
     psa_algorithm_t alg,
     psa_key_type_t key_type)
 {
+    /* Reduce code size - hinting to the compiler about what it can assume allows the compiler to
+       eliminate bits of the logic below. */
+#if !defined(PSA_WANT_KEY_TYPE_AES)
+    MBEDTLS_ASSUME(key_type != PSA_KEY_TYPE_AES);
+#endif
+#if !defined(PSA_WANT_KEY_TYPE_ARIA)
+    MBEDTLS_ASSUME(key_type != PSA_KEY_TYPE_ARIA);
+#endif
+#if !defined(PSA_WANT_KEY_TYPE_CAMELLIA)
+    MBEDTLS_ASSUME(key_type != PSA_KEY_TYPE_CAMELLIA);
+#endif
+#if !defined(PSA_WANT_KEY_TYPE_CHACHA20)
+    MBEDTLS_ASSUME(key_type != PSA_KEY_TYPE_CHACHA20);
+#endif
+#if !defined(PSA_WANT_KEY_TYPE_DES)
+    MBEDTLS_ASSUME(key_type != PSA_KEY_TYPE_DES);
+#endif
+#if !defined(PSA_WANT_ALG_CCM)
+    MBEDTLS_ASSUME(alg != PSA_ALG_AEAD_WITH_SHORTENED_TAG(PSA_ALG_CCM, 0));
+#endif
+#if !defined(PSA_WANT_ALG_GCM)
+    MBEDTLS_ASSUME(alg != PSA_ALG_AEAD_WITH_SHORTENED_TAG(PSA_ALG_GCM, 0));
+#endif
+#if !defined(PSA_WANT_ALG_STREAM_CIPHER)
+    MBEDTLS_ASSUME(alg != PSA_ALG_STREAM_CIPHER);
+#endif
+#if !defined(PSA_WANT_ALG_CHACHA20_POLY1305)
+    MBEDTLS_ASSUME(alg != PSA_ALG_AEAD_WITH_SHORTENED_TAG(PSA_ALG_CHACHA20_POLY1305, 0));
+#endif
+#if !defined(PSA_WANT_ALG_CCM_STAR_NO_TAG)
+    MBEDTLS_ASSUME(alg != PSA_ALG_CCM_STAR_NO_TAG);
+#endif
+#if !defined(PSA_WANT_ALG_CTR)
+    MBEDTLS_ASSUME(alg != PSA_ALG_CTR);
+#endif
+#if !defined(PSA_WANT_ALG_CFB)
+    MBEDTLS_ASSUME(alg != PSA_ALG_CFB);
+#endif
+#if !defined(PSA_WANT_ALG_OFB)
+    MBEDTLS_ASSUME(alg != PSA_ALG_OFB);
+#endif
+#if !defined(PSA_WANT_ALG_XTS)
+    MBEDTLS_ASSUME(alg != PSA_ALG_XTS);
+#endif
+#if !defined(PSA_WANT_ALG_ECB_NO_PADDING)
+    MBEDTLS_ASSUME(alg != PSA_ALG_ECB_NO_PADDING);
+#endif
+#if !defined(PSA_WANT_ALG_CBC_NO_PADDING)
+    MBEDTLS_ASSUME(alg != PSA_ALG_CBC_NO_PADDING);
+#endif
+#if !defined(PSA_WANT_ALG_CBC_PKCS7)
+    MBEDTLS_ASSUME(alg != PSA_ALG_CBC_PKCS7);
+#endif
+#if !defined(PSA_WANT_ALG_CMAC)
+    MBEDTLS_ASSUME(alg != PSA_ALG_CMAC);
+#endif
+
     if (alg == PSA_ALG_STREAM_CIPHER ||
         alg == PSA_ALG_AEAD_WITH_SHORTENED_TAG(PSA_ALG_CHACHA20_POLY1305, 0)) {
         if (key_type == PSA_KEY_TYPE_CHACHA20) {

--- a/library/psa_crypto_cipher.c
+++ b/library/psa_crypto_cipher.c
@@ -42,45 +42,40 @@ static psa_status_t mbedtls_cipher_validate_values(
     psa_algorithm_t alg,
     psa_key_type_t key_type)
 {
-    switch (alg) {
-        case PSA_ALG_STREAM_CIPHER:
-        case PSA_ALG_AEAD_WITH_SHORTENED_TAG(PSA_ALG_CHACHA20_POLY1305, 0):
-            if (key_type != PSA_KEY_TYPE_CHACHA20) {
-                return PSA_ERROR_NOT_SUPPORTED;
-            }
-            break;
-
-        case PSA_ALG_AEAD_WITH_SHORTENED_TAG(PSA_ALG_CCM, 0):
-        case PSA_ALG_AEAD_WITH_SHORTENED_TAG(PSA_ALG_GCM, 0):
-        case PSA_ALG_CCM_STAR_NO_TAG:
-            if ((key_type != PSA_KEY_TYPE_AES) &&
-                (key_type != PSA_KEY_TYPE_ARIA) &&
-                (key_type != PSA_KEY_TYPE_CAMELLIA)) {
-                return PSA_ERROR_NOT_SUPPORTED;
-            }
-            break;
-
-        case PSA_ALG_CTR:
-        case PSA_ALG_CFB:
-        case PSA_ALG_OFB:
-        case PSA_ALG_XTS:
-        case PSA_ALG_ECB_NO_PADDING:
-        case PSA_ALG_CBC_NO_PADDING:
-        case PSA_ALG_CBC_PKCS7:
-        case PSA_ALG_CMAC:
-            if ((key_type != PSA_KEY_TYPE_AES) &&
-                (key_type != PSA_KEY_TYPE_ARIA) &&
-                (key_type != PSA_KEY_TYPE_DES) &&
-                (key_type != PSA_KEY_TYPE_CAMELLIA)) {
-                return PSA_ERROR_NOT_SUPPORTED;
-            }
-            break;
-
-        default:
-            return PSA_ERROR_NOT_SUPPORTED;
+    if (alg == PSA_ALG_STREAM_CIPHER ||
+        alg == PSA_ALG_AEAD_WITH_SHORTENED_TAG(PSA_ALG_CHACHA20_POLY1305, 0)) {
+        if (key_type == PSA_KEY_TYPE_CHACHA20) {
+            return PSA_SUCCESS;
+        }
     }
 
-    return PSA_SUCCESS;
+    if (alg == PSA_ALG_AEAD_WITH_SHORTENED_TAG(PSA_ALG_CCM, 0) ||
+        alg == PSA_ALG_AEAD_WITH_SHORTENED_TAG(PSA_ALG_GCM, 0) ||
+        alg == PSA_ALG_CCM_STAR_NO_TAG) {
+        if (key_type == PSA_KEY_TYPE_AES ||
+            key_type == PSA_KEY_TYPE_ARIA ||
+            key_type == PSA_KEY_TYPE_CAMELLIA) {
+            return PSA_SUCCESS;
+        }
+    }
+
+    if (alg == PSA_ALG_CTR ||
+        alg == PSA_ALG_CFB ||
+        alg == PSA_ALG_OFB ||
+        alg == PSA_ALG_XTS ||
+        alg == PSA_ALG_ECB_NO_PADDING ||
+        alg == PSA_ALG_CBC_NO_PADDING ||
+        alg == PSA_ALG_CBC_PKCS7 ||
+        alg == PSA_ALG_CMAC) {
+        if (key_type == PSA_KEY_TYPE_AES ||
+            key_type == PSA_KEY_TYPE_ARIA ||
+            key_type == PSA_KEY_TYPE_DES ||
+            key_type == PSA_KEY_TYPE_CAMELLIA) {
+            return PSA_SUCCESS;
+        }
+    }
+
+    return PSA_ERROR_NOT_SUPPORTED;
 }
 
 psa_status_t mbedtls_cipher_values_from_psa(


### PR DESCRIPTION
## Description

Reduce code size in mbedtls_cipher_validate_values by eliminating code for algorithms that are not built.

#8119 adds 128 bytes - this removes half of that increase for our reference build.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required - not user visible
- [x] **backport**  not in 2.28
- [x] **tests**  not required - covered by existing
