### PR TITLE
Create a metatest program

### DIFF
--- a/programs/.gitignore
+++ b/programs/.gitignore
@@ -38,6 +38,7 @@ psa/crypto_examples
 psa/hmac_demo
 psa/key_ladder_demo
 psa/psa_constant_names
+psa/psa_hash
 random/gen_entropy
 random/gen_random_ctr_drbg
 ssl/dtls_client

--- a/programs/.gitignore
+++ b/programs/.gitignore
@@ -56,6 +56,7 @@ test/cpp_dummy_build
 test/cpp_dummy_build.cpp
 test/dlopen
 test/ecp-bench
+test/metatest
 test/query_compile_time_config
 test/query_included_headers
 test/selftest

--- a/programs/Makefile
+++ b/programs/Makefile
@@ -123,6 +123,7 @@ APPS = \
 	ssl/ssl_server \
 	ssl/ssl_server2 \
 	test/benchmark \
+	test/metatest \
 	test/query_compile_time_config \
 	test/query_included_headers \
 	test/selftest \
@@ -412,6 +413,10 @@ test/dlopen$(EXEXT): test/dlopen.c $(DEP)
 # purpose of testing dynamic loading).
 	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) test/dlopen.c $(LDFLAGS) $(DLOPEN_LDFLAGS) -o $@
 endif
+
+test/metatest$(EXEXT): test/metatest.c $(DEP)
+	echo "  CC    test/metatest.c"
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) test/metatest.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test/query_config.o: test/query_config.c test/query_config.h $(DEP)
 	echo "  CC    test/query_config.c"

--- a/programs/Makefile
+++ b/programs/Makefile
@@ -416,7 +416,7 @@ endif
 
 test/metatest$(EXEXT): test/metatest.c $(DEP)
 	echo "  CC    test/metatest.c"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) test/metatest.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) -I ../library test/metatest.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test/query_config.o: test/query_config.c test/query_config.h $(DEP)
 	echo "  CC    test/query_config.c"

--- a/programs/test/CMakeLists.txt
+++ b/programs/test/CMakeLists.txt
@@ -73,6 +73,7 @@ foreach(exe IN LISTS executables_libs executables_mbedcrypto)
     add_executable(${exe} ${exe}.c $<TARGET_OBJECTS:mbedtls_test>
         ${extra_sources})
     target_include_directories(${exe} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../tests/include)
+    target_include_directories(${exe} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../library)
     if(exe STREQUAL "query_compile_time_config")
         target_include_directories(${exe} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
     endif()

--- a/programs/test/CMakeLists.txt
+++ b/programs/test/CMakeLists.txt
@@ -3,6 +3,7 @@ set(libs
 )
 
 set(executables_libs
+    metatest
     query_included_headers
     selftest
     udp_proxy

--- a/programs/test/metatest.c
+++ b/programs/test/metatest.c
@@ -18,6 +18,17 @@
 
 
 /****************************************************************/
+/* Test framework features */
+/****************************************************************/
+
+void meta_test_fail(const char *name)
+{
+    (void) name;
+    mbedtls_test_fail("Forced test failure", __LINE__, __FILE__);
+}
+
+
+/****************************************************************/
 /* Command line entry point */
 /****************************************************************/
 
@@ -28,6 +39,7 @@ typedef struct {
 } metatest_t;
 
 metatest_t metatests[] = {
+    { "test_fail", "any", meta_test_fail },
     { NULL, NULL, NULL }
 };
 

--- a/programs/test/metatest.c
+++ b/programs/test/metatest.c
@@ -54,7 +54,10 @@ void null_pointer_call(const char *name)
     (void) name;
     unsigned (*p)(void);
     mbedtls_platform_zeroize(&p, sizeof(p));
-    mbedtls_printf("%llx() -> %u\n", (unsigned long long) (uintptr_t) p, p());
+    /* The pointer representation may be truncated, but we don't care:
+     * the only point of printing it is to have some use of the pointer
+     * to dissuade the compiler from optimizing it away. */
+    mbedtls_printf("%lx() -> %u\n", (unsigned long) (uintptr_t) p, p());
 }
 
 

--- a/programs/test/metatest.c
+++ b/programs/test/metatest.c
@@ -29,6 +29,29 @@ void meta_test_fail(const char *name)
 
 
 /****************************************************************/
+/* Platform features */
+/****************************************************************/
+
+void null_pointer_dereference(const char *name)
+{
+    (void) name;
+    char *p;
+    memset(&p, 0, sizeof(p));
+    volatile char c;
+    c = *p;
+    (void) c;
+}
+
+void null_pointer_call(const char *name)
+{
+    (void) name;
+    void (*p)(void);
+    memset(&p, 0, sizeof(p));
+    p();
+}
+
+
+/****************************************************************/
 /* Command line entry point */
 /****************************************************************/
 
@@ -40,6 +63,8 @@ typedef struct {
 
 metatest_t metatests[] = {
     { "test_fail", "any", meta_test_fail },
+    { "null_dereference", "any", null_pointer_dereference },
+    { "null_call", "any", null_pointer_call },
     { NULL, NULL, NULL }
 };
 

--- a/programs/test/metatest.c
+++ b/programs/test/metatest.c
@@ -54,7 +54,7 @@ void null_pointer_call(const char *name)
     (void) name;
     unsigned (*p)(void);
     mbedtls_platform_zeroize(&p, sizeof(p));
-    mbedtls_printf("%p() -> %u\n", (void *) p, p());
+    mbedtls_printf("%llx() -> %u\n", (unsigned long long) p, p());
 }
 
 

--- a/programs/test/metatest.c
+++ b/programs/test/metatest.c
@@ -30,9 +30,9 @@ volatile int false_but_the_compiler_does_not_know = 0;
 
 /* Set n bytes at the address p to all-bits-zero, in such a way that
  * the compiler should not know that p is all-bits-zero. */
-static void set_to_zero_but_the_compiler_does_not_know(void *p, size_t n)
+static void set_to_zero_but_the_compiler_does_not_know(volatile void *p, size_t n)
 {
-    memset(p, false_but_the_compiler_does_not_know, n);
+    memset((void *) p, false_but_the_compiler_does_not_know, n);
 }
 
 
@@ -54,7 +54,7 @@ void meta_test_fail(const char *name)
 void null_pointer_dereference(const char *name)
 {
     (void) name;
-    volatile char *p;
+    volatile char *volatile p;
     set_to_zero_but_the_compiler_does_not_know(&p, sizeof(p));
     mbedtls_printf("%p -> %u\n", p, (unsigned) *p);
 }
@@ -62,7 +62,7 @@ void null_pointer_dereference(const char *name)
 void null_pointer_call(const char *name)
 {
     (void) name;
-    unsigned (*p)(void);
+    unsigned(*volatile p)(void);
     set_to_zero_but_the_compiler_does_not_know(&p, sizeof(p));
     /* The pointer representation may be truncated, but we don't care:
      * the only point of printing it is to have some use of the pointer

--- a/programs/test/metatest.c
+++ b/programs/test/metatest.c
@@ -96,12 +96,13 @@ void double_free(const char *name)
 void read_uninitialized_stack(const char *name)
 {
     (void) name;
-    volatile char buf[1];
+    char buf[1];
     if (false_but_the_compiler_does_not_know) {
         buf[0] = '!';
     }
-    if (*buf != 0) {
-        mbedtls_printf("%u\n", (unsigned) *buf);
+    char *volatile p = buf;
+    if (*p != 0) {
+        mbedtls_printf("%u\n", (unsigned) *p);
     }
 }
 

--- a/programs/test/metatest.c
+++ b/programs/test/metatest.c
@@ -45,7 +45,7 @@ void null_pointer_dereference(const char *name)
 {
     (void) name;
     volatile char *p;
-    mbedtls_platform_zeroize(&p, sizeof(p));
+    mbedtls_platform_zeroize((void *) &p, sizeof(p));
     mbedtls_printf("%p -> %u\n", p, (unsigned) *p);
 }
 
@@ -54,7 +54,7 @@ void null_pointer_call(const char *name)
     (void) name;
     unsigned (*p)(void);
     mbedtls_platform_zeroize(&p, sizeof(p));
-    mbedtls_printf("%p() -> %u\n", p, p());
+    mbedtls_printf("%p() -> %u\n", (void *) p, p());
 }
 
 

--- a/programs/test/metatest.c
+++ b/programs/test/metatest.c
@@ -141,7 +141,7 @@ void mutex_lock_not_initialized(const char *name)
     (void) name;
     /* Mutex usage verification is only done with pthread, not with other
      * threading implementations. See tests/src/threading_helpers.c. */
-#if defined(MBEDTLS_THREADING_PTHREAD)
+#if defined(MBEDTLS_THREADING_C)
     mbedtls_threading_mutex_t mutex;
     memset(&mutex, 0, sizeof(mutex));
     TEST_ASSERT(mbedtls_mutex_lock(&mutex) == 0);
@@ -203,7 +203,7 @@ void mutex_leak(const char *name)
     (void) name;
     /* Mutex usage verification is only done with pthread, not with other
      * threading implementations. See tests/src/threading_helpers.c. */
-#if defined(MBEDTLS_THREADING_PTHREAD)
+#if defined(MBEDTLS_THREADING_C)
     mbedtls_threading_mutex_t mutex;
     mbedtls_mutex_init(&mutex);
 #endif

--- a/programs/test/metatest.c
+++ b/programs/test/metatest.c
@@ -54,7 +54,7 @@ void null_pointer_call(const char *name)
     (void) name;
     unsigned (*p)(void);
     mbedtls_platform_zeroize(&p, sizeof(p));
-    mbedtls_printf("%llx() -> %u\n", (unsigned long long) p, p());
+    mbedtls_printf("%llx() -> %u\n", (unsigned long long) (uintptr_t) p, p());
 }
 
 

--- a/programs/test/metatest.c
+++ b/programs/test/metatest.c
@@ -1,0 +1,81 @@
+/** \file metatest.c
+ *
+ *  \brief Test features of the test framework.
+ */
+
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+ */
+
+#define MBEDTLS_ALLOW_PRIVATE_ACCESS
+
+#include <mbedtls/platform.h>
+#include "test/helpers.h"
+
+#include <stdio.h>
+#include <string.h>
+
+
+/****************************************************************/
+/* Command line entry point */
+/****************************************************************/
+
+typedef struct {
+    const char *name;
+    const char *platform;
+    void (*entry_point)(const char *name);
+} metatest_t;
+
+metatest_t metatests[] = {
+    { NULL, NULL, NULL }
+};
+
+static void help(FILE *out, const char *argv0)
+{
+    mbedtls_fprintf(out, "Usage: %s list|TEST\n", argv0);
+    mbedtls_fprintf(out, "Run a meta-test that should cause a test failure.\n");
+    mbedtls_fprintf(out, "With 'list', list the available tests and their platform requirement.\n");
+}
+
+int main(int argc, char *argv[])
+{
+    const char *argv0 = argc > 0 ? argv[0] : "metatest";
+    if (argc != 2) {
+        help(stderr, argv0);
+        mbedtls_exit(MBEDTLS_EXIT_FAILURE);
+    }
+
+    /* Support "-help", "--help", "--list", etc. */
+    const char *command = argv[1];
+    while (*command == '-') {
+        ++command;
+    }
+
+    if (strcmp(argv[1], "help") == 0) {
+        help(stdout, argv0);
+        mbedtls_exit(MBEDTLS_EXIT_SUCCESS);
+    }
+    if (strcmp(argv[1], "list") == 0) {
+        for (const metatest_t *p = metatests; p->name != NULL; p++) {
+            mbedtls_printf("%s %s\n", p->name, p->platform);
+        }
+        mbedtls_exit(MBEDTLS_EXIT_SUCCESS);
+    }
+
+    for (const metatest_t *p = metatests; p->name != NULL; p++) {
+        if (strcmp(argv[1], p->name) == 0) {
+            mbedtls_printf("Running metatest %s...\n", argv[1]);
+            p->entry_point(argv[1]);
+            mbedtls_printf("Running metatest %s... done, result=%d\n",
+                           argv[1], (int) mbedtls_test_info.result);
+            mbedtls_exit(mbedtls_test_info.result == MBEDTLS_TEST_RESULT_SUCCESS ?
+                         MBEDTLS_EXIT_SUCCESS :
+                         MBEDTLS_EXIT_FAILURE);
+        }
+    }
+
+    mbedtls_fprintf(stderr, "%s: FATAL: No such metatest: %s\n",
+                    argv0, command);
+    mbedtls_exit(MBEDTLS_EXIT_FAILURE);
+}

--- a/scripts/generate_visualc_files.pl
+++ b/scripts/generate_visualc_files.pl
@@ -144,6 +144,7 @@ sub gen_app {
     my $guid = gen_app_guid( $path );
     $path =~ s!/!\\!g;
     (my $appname = $path) =~ s/.*\\//;
+    my $is_test_app = ($path =~ m/^test\\/);
 
     my $srcs = "<ClCompile Include=\"..\\..\\programs\\$path.c\" \/>";
     if( $appname eq "ssl_client2" or $appname eq "ssl_server2" or
@@ -158,7 +159,9 @@ sub gen_app {
     $content =~ s/<SOURCES>/$srcs/g;
     $content =~ s/<APPNAME>/$appname/g;
     $content =~ s/<GUID>/$guid/g;
-    $content =~ s/INCLUDE_DIRECTORIES\n/$include_directories/g;
+    $content =~ s/INCLUDE_DIRECTORIES\n/($is_test_app ?
+                                         $library_include_directories :
+                                         $include_directories)/ge;
 
     content_to_file( $content, "$dir/$appname.$ext" );
 }

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1065,6 +1065,9 @@ component_test_default_cmake_gcc_asan () {
     msg "test: selftest (ASan build)" # ~ 10s
     programs/test/selftest
 
+    msg "test: metatests (GCC, ASan build)"
+    tests/scripts/run-metatests.sh any asan
+
     msg "test: ssl-opt.sh (ASan build)" # ~ 1 min
     tests/ssl-opt.sh
 
@@ -1830,6 +1833,9 @@ component_test_everest () {
     msg "test: Everest ECDH context - main suites (inc. selftests) (ASan build)" # ~ 50s
     make test
 
+    msg "test: metatests (clang, ASan)"
+    tests/scripts/run-metatests.sh any asan
+
     msg "test: Everest ECDH context - ECDH-related part of ssl-opt.sh (ASan build)" # ~ 5s
     tests/ssl-opt.sh -f ECDH
 
@@ -1917,6 +1923,9 @@ component_test_full_cmake_clang () {
 
     msg "test: cpp_dummy_build (full config, clang)" # ~ 1s
     programs/test/cpp_dummy_build
+
+    msg "test: metatests (clang)"
+    tests/scripts/run-metatests.sh any
 
     msg "program demos (full config, clang)" # ~10s
     tests/scripts/run_demos.py
@@ -5402,6 +5411,9 @@ component_test_memsan () {
 
     msg "test: main suites (MSan)" # ~ 10s
     make test
+
+    msg "test: metatests (MSan)"
+    tests/scripts/run-metatests.sh any msan
 
     msg "program demos (MSan)" # ~20s
     tests/scripts/run_demos.py

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1925,7 +1925,7 @@ component_test_full_cmake_clang () {
     programs/test/cpp_dummy_build
 
     msg "test: metatests (clang)"
-    tests/scripts/run-metatests.sh any
+    tests/scripts/run-metatests.sh any pthread
 
     msg "program demos (full config, clang)" # ~10s
     tests/scripts/run_demos.py

--- a/tests/scripts/run-metatests.sh
+++ b/tests/scripts/run-metatests.sh
@@ -6,6 +6,14 @@ Usage: $0 [OPTION] [PLATFORM]...
 Run all the metatests whose platform matches any of the given PLATFORM.
 A PLATFORM can contain shell wildcards.
 
+Expected output: a lot of scary-looking error messages, since each
+metatest is expected to report a failure. The final line should be
+"Ran N metatests, all good."
+
+If something goes wrong: the final line should be
+"Ran N metatests, X unexpected successes". Look for "Unexpected success"
+in the logs above.
+
   -l  List the available metatests, don't run them.
 EOF
 }

--- a/tests/scripts/run-metatests.sh
+++ b/tests/scripts/run-metatests.sh
@@ -1,0 +1,81 @@
+#!/bin/sh
+
+help () {
+    cat <<EOF
+Usage: $0 [OPTION] [PLATFORM]...
+Run all the metatests whose platform matches any of the given PLATFORM.
+A PLATFORM can contain shell wildcards.
+
+  -l  List the available metatests, don't run them.
+EOF
+}
+
+# Copyright The Mbed TLS Contributors
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+
+set -e -u
+
+if [ -d programs ]; then
+    METATEST_PROGRAM=programs/test/metatest
+elif [ -d ../programs ]; then
+    METATEST_PROGRAM=../programs/test/metatest
+elif [ -d ../../programs ]; then
+    METATEST_PROGRAM=../../programs/test/metatest
+else
+    echo >&2 "$0: FATAL: programs/test/metatest not found"
+    exit 120
+fi
+
+LIST_ONLY=
+while getopts hl OPTLET; do
+    case $OPTLET in
+        h) help; exit;;
+        l) LIST_ONLY=1;;
+        \?) help >&2; exit 120;;
+    esac
+done
+shift $((OPTIND - 1))
+
+list_matches () {
+    while read name platform junk; do
+        for pattern; do
+            case $platform in
+                $pattern) echo "$name"; break;;
+            esac
+        done
+    done
+}
+
+count=0
+errors=0
+run_metatest () {
+    ret=0
+    "$METATEST_PROGRAM" "$1" || ret=$?
+    if [ $ret -eq 0 ]; then
+        echo >&2 "$0: Unexpected success: $1"
+        errors=$((errors + 1))
+    fi
+    count=$((count + 1))
+}
+
+# Don't pipe the output of metatest so that if it fails, this script exits
+# immediately with a failure status.
+full_list=$("$METATEST_PROGRAM" list)
+matching_list=$(printf '%s\n' "$full_list" | list_matches "$@")
+
+if [ -n "$LIST_ONLY" ]; then
+    printf '%s\n' $matching_list
+    exit
+fi
+
+for name in $matching_list; do
+    run_metatest "$name"
+done
+
+if [ $errors -eq 0 ]; then
+    echo "Ran $count metatests, all good."
+    exit 0
+else
+    echo "Ran $count metatests, $errors unexpected successes."
+    exit 1
+fi

--- a/tests/scripts/run-metatests.sh
+++ b/tests/scripts/run-metatests.sh
@@ -46,7 +46,7 @@ shift $((OPTIND - 1))
 
 list_matches () {
     while read name platform junk; do
-        for pattern; do
+        for pattern in "$@"; do
             case $platform in
                 $pattern) echo "$name"; break;;
             esac


### PR DESCRIPTION
Add a small framework to validate that we to catch some expected errors in our test configurations. For example, check that `test_fail` causes a test failure, and that Asan detects a memory leak.

The scope of this pull request is limited to some basics. We can add more metatests and more sophistication in follow-ups.

Status: ready.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** no (test only)
- [x] **backport** https://github.com/Mbed-TLS/mbedtls/pull/8543
- [x] **tests** provided
