### PR TITLE
Deprecate PSA_DH_FAMILY_CUSTOM

### DIFF
--- a/include/psa/crypto_compat.h
+++ b/include/psa/crypto_compat.h
@@ -30,9 +30,35 @@
 #ifndef PSA_CRYPTO_COMPAT_H
 #define PSA_CRYPTO_COMPAT_H
 
+#include "crypto_types.h"
+
+#include <mbedtls/platform_util.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+
+/** \addtogroup attributes
+ * @{
+ */
+
+#if !defined MBEDTLS_DEPRECATED_REMOVED
+/** Custom Diffie-Hellman group.
+ *
+ * For keys of type #PSA_KEY_TYPE_DH_PUBLIC_KEY(#PSA_DH_FAMILY_CUSTOM) or
+ * #PSA_KEY_TYPE_DH_KEY_PAIR(#PSA_DH_FAMILY_CUSTOM), the group data comes
+ * from domain parameters set by psa_set_key_domain_parameters().
+ *
+ * \deprecated This family is not supported in Mbed TLS, and there is
+ *             currently no plan to support it. This constant will be removed
+ *             in a future version of the library.
+ */
+#define PSA_DH_FAMILY_CUSTOM ((psa_dh_family_t) MBEDTLS_DEPRECATED_NUMERIC_CONSTANT(0x7e))
+#endif
+
+/**@}*/
+
 
 /*
  * To support both openless APIs and psa_open_key() temporarily, define

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -419,14 +419,6 @@ psa_status_t mbedtls_psa_inject_entropy(const uint8_t *seed,
  * @{
  */
 
-/** Custom Diffie-Hellman group.
- *
- * For keys of type #PSA_KEY_TYPE_DH_PUBLIC_KEY(#PSA_DH_FAMILY_CUSTOM) or
- * #PSA_KEY_TYPE_DH_KEY_PAIR(#PSA_DH_FAMILY_CUSTOM), the group data comes
- * from domain parameters set by psa_set_key_domain_parameters().
- */
-#define PSA_DH_FAMILY_CUSTOM             ((psa_dh_family_t) 0x7e)
-
 /** PAKE operation stages. */
 #define PSA_PAKE_OPERATION_STAGE_SETUP 0
 #define PSA_PAKE_OPERATION_STAGE_COLLECT_INPUTS 1


### PR DESCRIPTION
It was intended to be used with domain parameters, but we are not going to implement that.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [ ] **changelog** no (should we? We normally announce deprecations, but that constant was not usable for any practical purpose.)
- [ ] **backport** no
- [x] **tests** not required
