### PR TITLE
Avoid warning with -Wsign-conversion

### DIFF
--- a/include/mbedtls/cipher.h
+++ b/include/mbedtls/cipher.h
@@ -480,7 +480,7 @@ static inline size_t mbedtls_cipher_info_get_key_bitlen(
     if (info == NULL) {
         return 0;
     } else {
-        return ((size_t) info->MBEDTLS_PRIVATE(key_bitlen)) << MBEDTLS_KEY_BITLEN_SHIFT;
+        return (size_t) info->MBEDTLS_PRIVATE(key_bitlen) << MBEDTLS_KEY_BITLEN_SHIFT;
     }
 }
 


### PR DESCRIPTION
## Description

https://github.com/Mbed-TLS/mbedtls/pull/7825#discussion_r1381670098
Implicit sign conversion breaks compilation in other projects that enforce warnings; e.g.: this happens when building Mongoose in MacOS:
```
/usr/local/Cellar/mbedtls/3.5.0/include/mbedtls/cipher.h:495:50: error: implicit conversion changes signedness: 'int' to 'size_t' (aka 'unsigned long') [-Werror,-Wsign-conversion]
            return info->MBEDTLS_PRIVATE(key_bitlen) << MBEDTLS_KEY_BITLEN_SHIFT;
            ~~~~~~ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
```
