### PR TITLE
Update README.txt

### DIFF
--- a/configs/README.txt
+++ b/configs/README.txt
@@ -1,24 +1,20 @@
 This directory contains example configuration files.
 
-The examples are generally focused on a particular usage case (eg, support for
-a restricted number of ciphersuites) and aim at minimizing resource usage for
-this target. They can be used as a basis for custom configurations.
+The examples are generally focused on a particular use case (e.g., support for a restricted number of cipher suites) and aim to minimize resource usage for this target. They can be used as a basis for custom configurations.
 
-These files are complete replacements for the default mbedtls_config.h. To use one of
-them, you can pick one of the following methods:
+These files are complete replacements for the default mbedtls_config.h. To use one of them, you can choose one of the following methods:
 
-1. Replace the default file include/mbedtls/mbedtls_config.h with the chosen one.
+Replace the default file include/mbedtls/mbedtls_config.h with the chosen one.
 
-2. Define MBEDTLS_CONFIG_FILE and adjust the include path accordingly.
-   For example, using make:
+Define MBEDTLS_CONFIG_FILE and adjust the include path accordingly.
+For example, using make:
 
     CFLAGS="-I$PWD/configs -DMBEDTLS_CONFIG_FILE='<foo.h>'" make
 
-   Or, using cmake:
+Or, using cmake:
 
-    find . -iname '*cmake*' -not -name CMakeLists.txt -exec rm -rf {} +
-    CFLAGS="-I$PWD/configs -DMBEDTLS_CONFIG_FILE='<foo.h>'" cmake .
-    make
+find . -iname '*cmake*' -not -name CMakeLists.txt -exec rm -rf {} +
+CFLAGS="-I$PWD/configs -DMBEDTLS_CONFIG_FILE='<foo.h>'" cmake .
+make
 
-Note that the second method also works if you want to keep your custom
-configuration file outside the Mbed TLS tree.
+Note that the second method also works if you want to keep your custom configuration file outside the Mbed TLS tree.

--- a/configs/README.txt
+++ b/configs/README.txt
@@ -1,20 +1,24 @@
 This directory contains example configuration files.
 
-The examples are generally focused on a particular use case (e.g., support for a restricted number of cipher suites) and aim to minimize resource usage for this target. They can be used as a basis for custom configurations.
+The examples are generally focused on a particular usage case (e.g., support for
+a restricted number of ciphersuites) and aim to minimizing resource usage for
+this target. They can be used as a basis for custom configurations.
 
-These files are complete replacements for the default mbedtls_config.h. To use one of them, you can choose one of the following methods:
+These files are complete replacements for the default mbedtls_config.h. To use one of
+them, you can pick one of the following methods:
 
-Replace the default file include/mbedtls/mbedtls_config.h with the chosen one.
+1. Replace the default file include/mbedtls/mbedtls_config.h with the chosen one.
 
-Define MBEDTLS_CONFIG_FILE and adjust the include path accordingly.
-For example, using make:
+2. Define MBEDTLS_CONFIG_FILE and adjust the include path accordingly.
+   For example, using make:
 
     CFLAGS="-I$PWD/configs -DMBEDTLS_CONFIG_FILE='<foo.h>'" make
 
-Or, using cmake:
+   Or, using cmake:
 
-find . -iname '*cmake*' -not -name CMakeLists.txt -exec rm -rf {} +
-CFLAGS="-I$PWD/configs -DMBEDTLS_CONFIG_FILE='<foo.h>'" cmake .
-make
+    find . -iname '*cmake*' -not -name CMakeLists.txt -exec rm -rf {} +
+    CFLAGS="-I$PWD/configs -DMBEDTLS_CONFIG_FILE='<foo.h>'" cmake .
+    make
 
-Note that the second method also works if you want to keep your custom configuration file outside the Mbed TLS tree.
+Note that the second method also works if you want to keep your custom
+configuration file outside the Mbed TLS tree.


### PR DESCRIPTION
- Replaced "eg" with "e.g." for proper abbreviation.
- Changed "aim at" to "aim to" for smoother flow.
- Added "to" after "basis" for better clarity.
- Made some minor rephrasing for improved readability and consistency.

