### PR TITLE
Remove transparent key check in psa_asymmetric_encrypt/decrypto()

### DIFF
--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -3238,8 +3238,9 @@ psa_status_t psa_asymmetric_encrypt(mbedtls_svc_key_id_t key,
         return PSA_ERROR_INVALID_ARGUMENT;
     }
 
-    status = psa_get_and_lock_transparent_key_slot_with_policy(
-        key, &slot, PSA_KEY_USAGE_ENCRYPT, alg);
+    status = psa_get_and_lock_key_slot_with_policy(key, &slot,
+                                                   PSA_KEY_USAGE_ENCRYPT,
+                                                   alg);
     if (status != PSA_SUCCESS) {
         return status;
     }
@@ -3290,8 +3291,9 @@ psa_status_t psa_asymmetric_decrypt(mbedtls_svc_key_id_t key,
         return PSA_ERROR_INVALID_ARGUMENT;
     }
 
-    status = psa_get_and_lock_transparent_key_slot_with_policy(
-        key, &slot, PSA_KEY_USAGE_DECRYPT, alg);
+    status = psa_get_and_lock_key_slot_with_policy(key, &slot,
+                                                   PSA_KEY_USAGE_DECRYPT,
+                                                   alg);
     if (status != PSA_SUCCESS) {
         return status;
     }


### PR DESCRIPTION
## Description

In `psa_asymmetric_encrypt()` and `psa_asymmetric_decrypt()`, `psa_get_and_lock_transparent_key_slot_with_policy()` is called to check if the key is transparent. The check is incorrect, it always fails in the case of opaque driver.

The PR replaced `psa_get_and_lock_transparent_key_slot_with_policy` with `psa_get_and_lock_key_slot_with_policy`.

Fixes [8461](https://github.com/Mbed-TLS/mbedtls/issues/8461)

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [ ] **changelog** not required
- [ ] **backport** TODO
- [ ] **tests** not required
