### PR TITLE
TLS 1.3: Rename early_data and max_early_data_size configuration function

### DIFF
--- a/ChangeLog.d/rename-conf-early-data-API.txt
+++ b/ChangeLog.d/rename-conf-early-data-API.txt
@@ -1,5 +1,4 @@
 API changes
-   * In TLS 1.3 early data, rename mbedtls_ssl_tls13_conf_early_data() and
-     mbedtls_ssl_tls13_conf_max_early_data_size() to
-     mbedtls_ssl_conf_early_data() and mbedtls_ssl_conf_max_early_data_size()
-     respectively.
+   * Remove `tls13_` prefix in the name of mbedtls_ssl_tls13_conf_early_data()
+     and mbedtls_ssl_tls13_conf_max_early_data_size(). Early data feature may
+     not be TLS 1.3 specific in the furture, as requested in #6909.

--- a/ChangeLog.d/rename-conf-early-data-API.txt
+++ b/ChangeLog.d/rename-conf-early-data-API.txt
@@ -1,0 +1,5 @@
+API changes
+   * In TLS 1.3 early data, rename mbedtls_ssl_tls13_conf_early_data() and
+     mbedtls_ssl_tls13_conf_max_early_data_size() to
+     mbedtls_ssl_conf_early_data() and mbedtls_ssl_conf_max_early_data_size()
+     respectively.

--- a/ChangeLog.d/rename-conf-early-data-API.txt
+++ b/ChangeLog.d/rename-conf-early-data-API.txt
@@ -1,4 +1,4 @@
 API changes
-   * Remove `tls13_` prefix in the name of mbedtls_ssl_tls13_conf_early_data()
-     and mbedtls_ssl_tls13_conf_max_early_data_size(). Early data feature may
-     not be TLS 1.3 specific in the furture, as requested in #6909.
+   * Remove `tls13_` in mbedtls_ssl_tls13_conf_early_data() and
+     mbedtls_ssl_tls13_conf_max_early_data_size() API names. Early data
+     feature may not be TLS 1.3 specific in the future. Fixes #6909.

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -4080,7 +4080,7 @@
  * \def MBEDTLS_SSL_MAX_EARLY_DATA_SIZE
  *
  * The default maximum amount of 0-RTT data. See the documentation of
- * \c mbedtls_ssl_tls13_conf_max_early_data_size() for more information.
+ * \c mbedtls_ssl_conf_max_early_data_size() for more information.
  *
  * It must be positive and smaller than UINT32_MAX.
  *

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -2000,8 +2000,8 @@ void mbedtls_ssl_conf_authmode(mbedtls_ssl_config *conf, int authmode);
  * \warning This interface is experimental and may change without notice.
  *
  */
-void mbedtls_ssl_tls13_conf_early_data(mbedtls_ssl_config *conf,
-                                       int early_data_enabled);
+void mbedtls_ssl_conf_early_data(mbedtls_ssl_config *conf,
+                                 int early_data_enabled);
 
 #if defined(MBEDTLS_SSL_SRV_C)
 /**

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -2027,7 +2027,7 @@ void mbedtls_ssl_conf_early_data(mbedtls_ssl_config *conf,
  * \warning This interface is experimental and may change without notice.
  *
  */
-void mbedtls_ssl_tls13_conf_max_early_data_size(
+void mbedtls_ssl_conf_max_early_data_size(
     mbedtls_ssl_config *conf, uint32_t max_early_data_size);
 #endif /* MBEDTLS_SSL_SRV_C */
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1777,7 +1777,7 @@ void mbedtls_ssl_conf_early_data(mbedtls_ssl_config *conf,
 }
 
 #if defined(MBEDTLS_SSL_SRV_C)
-void mbedtls_ssl_tls13_conf_max_early_data_size(
+void mbedtls_ssl_conf_max_early_data_size(
     mbedtls_ssl_config *conf, uint32_t max_early_data_size)
 {
     conf->max_early_data_size = max_early_data_size;
@@ -5249,8 +5249,7 @@ int mbedtls_ssl_config_defaults(mbedtls_ssl_config *conf,
 #if defined(MBEDTLS_SSL_EARLY_DATA)
     mbedtls_ssl_conf_early_data(conf, MBEDTLS_SSL_EARLY_DATA_DISABLED);
 #if defined(MBEDTLS_SSL_SRV_C)
-    mbedtls_ssl_tls13_conf_max_early_data_size(
-        conf, MBEDTLS_SSL_MAX_EARLY_DATA_SIZE);
+    mbedtls_ssl_conf_max_early_data_size(conf, MBEDTLS_SSL_MAX_EARLY_DATA_SIZE);
 #endif
 #endif /* MBEDTLS_SSL_EARLY_DATA */
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1770,8 +1770,8 @@ void mbedtls_ssl_conf_tls13_key_exchange_modes(mbedtls_ssl_config *conf,
 }
 
 #if defined(MBEDTLS_SSL_EARLY_DATA)
-void mbedtls_ssl_tls13_conf_early_data(mbedtls_ssl_config *conf,
-                                       int early_data_enabled)
+void mbedtls_ssl_conf_early_data(mbedtls_ssl_config *conf,
+                                 int early_data_enabled)
 {
     conf->early_data_enabled = early_data_enabled;
 }
@@ -5247,7 +5247,7 @@ int mbedtls_ssl_config_defaults(mbedtls_ssl_config *conf,
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
 
 #if defined(MBEDTLS_SSL_EARLY_DATA)
-    mbedtls_ssl_tls13_conf_early_data(conf, MBEDTLS_SSL_EARLY_DATA_DISABLED);
+    mbedtls_ssl_conf_early_data(conf, MBEDTLS_SSL_EARLY_DATA_DISABLED);
 #if defined(MBEDTLS_SSL_SRV_C)
     mbedtls_ssl_tls13_conf_max_early_data_size(
         conf, MBEDTLS_SSL_MAX_EARLY_DATA_SIZE);

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -1971,7 +1971,7 @@ usage:
     }
 
 #if defined(MBEDTLS_SSL_EARLY_DATA)
-    mbedtls_ssl_tls13_conf_early_data(&conf, opt.early_data);
+    mbedtls_ssl_conf_early_data(&conf, opt.early_data);
 #endif /* MBEDTLS_SSL_EARLY_DATA */
 
     if ((ret = mbedtls_ssl_setup(&ssl, &conf)) != 0) {

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -2778,7 +2778,7 @@ usage:
 #if defined(MBEDTLS_SSL_EARLY_DATA)
     mbedtls_ssl_conf_early_data(&conf, tls13_early_data_enabled);
     if (tls13_early_data_enabled == MBEDTLS_SSL_EARLY_DATA_ENABLED) {
-        mbedtls_ssl_tls13_conf_max_early_data_size(
+        mbedtls_ssl_conf_max_early_data_size(
             &conf, opt.max_early_data_size);
     }
 #endif /* MBEDTLS_SSL_EARLY_DATA */

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -2776,7 +2776,7 @@ usage:
     }
 
 #if defined(MBEDTLS_SSL_EARLY_DATA)
-    mbedtls_ssl_tls13_conf_early_data(&conf, tls13_early_data_enabled);
+    mbedtls_ssl_conf_early_data(&conf, tls13_early_data_enabled);
     if (tls13_early_data_enabled == MBEDTLS_SSL_EARLY_DATA_ENABLED) {
         mbedtls_ssl_tls13_conf_max_early_data_size(
             &conf, opt.max_early_data_size);

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -1513,7 +1513,7 @@ do_run_test_once() {
 # $1 and $2 contain the server and client command lines, respectively.
 #
 # Note: this function only provides some guess about TLS version by simply
-#       looking at the server/client command lines. Even thought this works
+#       looking at the server/client command lines. Even though this works
 #       for the sake of tests' filtering (especially in conjunction with the
 #       detect_required_features() function), it does NOT guarantee that the
 #       result is accurate. It does not check other conditions, such as:
@@ -1626,7 +1626,7 @@ run_test() {
         requires_config_enabled MBEDTLS_SSL_PROTO_DTLS
     fi
 
-    # Check if we are trying to use an external tool wich does not support ECDH
+    # Check if we are trying to use an external tool which does not support ECDH
     EXT_WO_ECDH=$(use_ext_tool_without_ecdh_support "$SRV_CMD" "$CLI_CMD")
 
     # Guess the TLS version which is going to be used


### PR DESCRIPTION
## Description

`mbedtls_ssl_tls13_conf_early_data` -> `mbedtls_ssl_conf_early_data`,
`mbedtls_ssl_tls13_conf_max_early_data_size` -> `mbedtls_ssl_conf_max_early_data_size`,
since in the future this may not be specific to TLS 1.3, we shouldn't need `tls13` prefix.

Fix #6909 

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** provided
- [x] **backport** not required (tls1.3 only)
- [x] **tests** not required
