### PR TITLE
Make empty key slots explicit

### DIFF
--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -1786,7 +1786,6 @@ static psa_status_t psa_start_key_creation(
      * definition. */
 
     slot->attr = attributes->core;
-    slot->status = PSA_SLOT_OCCUPIED;
     if (PSA_KEY_LIFETIME_IS_VOLATILE(slot->attr.lifetime)) {
 #if !defined(MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER)
         slot->attr.id = volatile_key_id;
@@ -1849,6 +1848,8 @@ static psa_status_t psa_start_key_creation(
         return PSA_ERROR_INVALID_ARGUMENT;
     }
 #endif /* MBEDTLS_PSA_CRYPTO_SE_C */
+
+    slot->status = PSA_SLOT_OCCUPIED;
 
     return PSA_SUCCESS;
 }

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -1786,6 +1786,7 @@ static psa_status_t psa_start_key_creation(
      * definition. */
 
     slot->attr = attributes->core;
+    slot->status = PSA_SLOT_OCCUPIED;
     if (PSA_KEY_LIFETIME_IS_VOLATILE(slot->attr.lifetime)) {
 #if !defined(MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER)
         slot->attr.id = volatile_key_id;

--- a/library/psa_crypto_core.h
+++ b/library/psa_crypto_core.h
@@ -33,16 +33,18 @@
  */
 int psa_can_do_hash(psa_algorithm_t hash_alg);
 
+typedef enum {
+    PSA_SLOT_EMPTY = 0,
+    PSA_SLOT_OCCUPIED,
+} psa_key_slot_status_t;
+
 /** The data structure representing a key slot, containing key material
  * and metadata for one key.
  */
 typedef struct {
     psa_core_key_attributes_t attr;
 
-    enum {
-        PSA_SLOT_EMPTY = 0,
-        PSA_SLOT_OCCUPIED,
-    } status;
+    psa_key_slot_status_t status;
 
     /*
      * Number of locks on the key slot held by the library.

--- a/library/psa_crypto_core.h
+++ b/library/psa_crypto_core.h
@@ -39,6 +39,11 @@ int psa_can_do_hash(psa_algorithm_t hash_alg);
 typedef struct {
     psa_core_key_attributes_t attr;
 
+    enum {
+        PSA_SLOT_EMPTY = 0,
+        PSA_SLOT_OCCUPIED,
+    } status;
+
     /*
      * Number of locks on the key slot held by the library.
      *
@@ -88,7 +93,7 @@ typedef struct {
  */
 static inline int psa_is_key_slot_occupied(const psa_key_slot_t *slot)
 {
-    return slot->attr.type != 0;
+    return slot->status == PSA_SLOT_OCCUPIED;
 }
 
 /** Test whether a key slot is locked.

--- a/library/psa_crypto_slot_management.c
+++ b/library/psa_crypto_slot_management.c
@@ -237,12 +237,16 @@ static psa_status_t psa_load_persistent_key_into_slot(psa_key_slot_t *slot)
         data = (psa_se_key_data_storage_t *) key_data;
         status = psa_copy_key_material_into_slot(
             slot, data->slot_number, sizeof(data->slot_number));
+
+        if (status == PSA_SUCCESS) {
+            slot->status = PSA_SLOT_OCCUPIED;
+        }
         goto exit;
     }
 #endif /* MBEDTLS_PSA_CRYPTO_SE_C */
 
     status = psa_copy_key_material_into_slot(slot, key_data, key_data_length);
-    if (status != PSA_SUCCESS){
+    if (status != PSA_SUCCESS) {
         goto exit;
     }
 

--- a/library/psa_crypto_slot_management.c
+++ b/library/psa_crypto_slot_management.c
@@ -234,10 +234,14 @@ static psa_status_t psa_load_persistent_key_into_slot(psa_key_slot_t *slot)
             status = PSA_ERROR_DATA_INVALID;
             goto exit;
         }
-
         data = (psa_se_key_data_storage_t *) key_data;
-        key_data = data->slot_number;
-        key_data_length = sizeof(key_data);
+        status = psa_copy_key_material_into_slot(
+            slot, data->slot_number, sizeof(data->slot_number));
+
+        if (status == PSA_SUCCESS) {
+            slot->status = PSA_SLOT_OCCUPIED;
+        }
+        goto exit;
     }
 #endif /* MBEDTLS_PSA_CRYPTO_SE_C */
 

--- a/library/psa_crypto_slot_management.c
+++ b/library/psa_crypto_slot_management.c
@@ -221,7 +221,6 @@ static psa_status_t psa_load_persistent_key_into_slot(psa_key_slot_t *slot)
     if (status != PSA_SUCCESS) {
         goto exit;
     }
-    slot->status = PSA_SLOT_OCCUPIED;
 
 #if defined(MBEDTLS_PSA_CRYPTO_SE_C)
     /* Special handling is required for loading keys associated with a
@@ -243,6 +242,11 @@ static psa_status_t psa_load_persistent_key_into_slot(psa_key_slot_t *slot)
 #endif /* MBEDTLS_PSA_CRYPTO_SE_C */
 
     status = psa_copy_key_material_into_slot(slot, key_data, key_data_length);
+    if (status != PSA_SUCCESS){
+        goto exit;
+    }
+
+    slot->status = PSA_SLOT_OCCUPIED;
 
 exit:
     psa_free_persistent_key_data(key_data, key_data_length);

--- a/library/psa_crypto_slot_management.c
+++ b/library/psa_crypto_slot_management.c
@@ -234,14 +234,10 @@ static psa_status_t psa_load_persistent_key_into_slot(psa_key_slot_t *slot)
             status = PSA_ERROR_DATA_INVALID;
             goto exit;
         }
-        data = (psa_se_key_data_storage_t *) key_data;
-        status = psa_copy_key_material_into_slot(
-            slot, data->slot_number, sizeof(data->slot_number));
 
-        if (status == PSA_SUCCESS) {
-            slot->status = PSA_SLOT_OCCUPIED;
-        }
-        goto exit;
+        data = (psa_se_key_data_storage_t *) key_data;
+        key_data = data->slot_number;
+        key_data_length = sizeof(key_data);
     }
 #endif /* MBEDTLS_PSA_CRYPTO_SE_C */
 

--- a/library/psa_crypto_slot_management.c
+++ b/library/psa_crypto_slot_management.c
@@ -221,6 +221,7 @@ static psa_status_t psa_load_persistent_key_into_slot(psa_key_slot_t *slot)
     if (status != PSA_SUCCESS) {
         goto exit;
     }
+    slot->status = PSA_SLOT_OCCUPIED;
 
 #if defined(MBEDTLS_PSA_CRYPTO_SE_C)
     /* Special handling is required for loading keys associated with a
@@ -315,6 +316,7 @@ static psa_status_t psa_load_builtin_key_into_slot(psa_key_slot_t *slot)
     /* Copy actual key length and core attributes into the slot on success */
     slot->key.bytes = key_buffer_length;
     slot->attr = attributes.core;
+    slot->status = PSA_SLOT_OCCUPIED;
 
 exit:
     if (status != PSA_SUCCESS) {


### PR DESCRIPTION
## Description

Add new status field to key slots, use it in `psa_is_key_slot_occupied()`, and make any function setting `slot->attr.type` use the field. Closes https://github.com/Mbed-TLS/mbedtls/issues/8409

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required for individual tasks on this epic
- [x] **backport** not required (new feature)
- [x] **tests** not required