### PR TITLE
2.28 only: Update license of a newly added file

### DIFF
--- a/tests/scripts/generate_server9_bad_saltlen.py
+++ b/tests/scripts/generate_server9_bad_saltlen.py
@@ -5,19 +5,7 @@ Generate a certificate signed with RSA-PSS, with an incorrect salt length.
 """
 
 # Copyright The Mbed TLS Contributors
-# SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may
-# not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 
 import subprocess
 import argparse


### PR DESCRIPTION
Fix `check_files` failing in `mbedtls-2.28` since a few minutes ago.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required
- [x] **backport** only in 2.28
- [x] **tests** CI
