### PR TITLE
Add python version check

### DIFF
--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -5700,6 +5700,15 @@ component_check_python_files () {
     tests/scripts/check-python-files.sh
 }
 
+support_check_python_files () {
+    python3 - <<EOF
+import sys
+if sys.version_info.major >= 3 and sys.version_info.minor >= 6:
+    sys.exit(0)
+sys.exit(1)
+EOF
+}
+
 component_check_test_helpers () {
     msg "unit test: generate_test_code.py"
     # unittest writes out mundane stuff like number or tests run on stderr.


### PR DESCRIPTION
## Description

We have requested python 3.6 at https://mbed-tls.readthedocs.io/en/latest/getting_started/building/ . So we must disable CI test for older python


## PR checklist

- [ ] **changelog** ~~provided, or~~ not required( It is internal test script change)
- [ ] **backport** done, or not required
- [ ] **tests** ~~provided, or~~ not required( test scripts)



