### PR TITLE
Add benchmark for RSA 3072

### DIFF
--- a/programs/test/benchmark.c
+++ b/programs/test/benchmark.c
@@ -1011,7 +1011,7 @@ int main(int argc, char *argv[])
         int keysize;
         mbedtls_rsa_context rsa;
 
-        for (keysize = 2048; keysize <= 4096; keysize *= 2) {
+        for (keysize = 2048; keysize <= 4096; keysize += 1024) {
             mbedtls_snprintf(title, sizeof(title), "RSA-%d", keysize);
 
             mbedtls_rsa_init(&rsa);


### PR DESCRIPTION
## Description

With a security strength of 128, RSA 3072 is a good compromize between security and processing time. So far, the benchmark considered only RSA 2048 and 4096, however, the latter does not even reach the next level of security strength, namely 192. Hence, when designing products with a particular security security strength in mind, it is good to have some benchmarks available.

I uncrustified the sourcecode using scripts/code_style.py first, before committing my new code in the second commit.



## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [X] **changelog** not required
- [X] **backport** not required
- [X] **tests** not required
