### PR TITLE
Fix uninitialized variable warnings in ssl_msg.c

### DIFF
--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -3632,7 +3632,7 @@ MBEDTLS_CHECK_RETURN_CRITICAL
 static int ssl_handle_possible_reconnect(mbedtls_ssl_context *ssl)
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
-    size_t len;
+    size_t len = 0;
 
     if (ssl->conf->f_cookie_write == NULL ||
         ssl->conf->f_cookie_check == NULL) {


### PR DESCRIPTION
## Description

We are requested to compile our code with warnings for potentially uninitialized variables enabled and all warnings considered as errors.

When building ssl_msg.c, the following error pops up:
```
library\ssl_msg.c: In function 'mbedtls_ssl_read_record':
library\ssl_msg.c:3653:12: error: 'len' may be used uninitialized in this function
```

In this PR, we fix the problem by initializing the `len` variable to 0.

Uncrustified ssl_msg.c in second commit.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [X] **changelog** not required
- [X] **backport** not required
- [X] **tests** not required
