### PR TITLE
Fix compiler error on gcc 4.5.2.

### DIFF
--- a/library/constant_time_impl.h
+++ b/library/constant_time_impl.h
@@ -546,7 +546,7 @@ static inline mbedtls_ct_condition_t mbedtls_ct_bool_not(mbedtls_ct_condition_t 
     return (mbedtls_ct_condition_t) (~x);
 }
 
-#ifdef __GNUC__
+#if __GNUC__ > 4
 /* Restore warnings for -Wredundant-decls on gcc */
     #pragma GCC diagnostic pop
 #endif

--- a/library/constant_time_impl.h
+++ b/library/constant_time_impl.h
@@ -31,7 +31,7 @@
  * Disable -Wredundant-decls so that gcc does not warn about this. This is re-enabled
  * at the bottom of this file.
  */
-#ifdef __GNUC__
+#ifdef __GNUC__ > 4
     #pragma GCC diagnostic push
     #pragma GCC diagnostic ignored "-Wredundant-decls"
 #endif

--- a/library/constant_time_impl.h
+++ b/library/constant_time_impl.h
@@ -546,7 +546,7 @@ static inline mbedtls_ct_condition_t mbedtls_ct_bool_not(mbedtls_ct_condition_t 
     return (mbedtls_ct_condition_t) (~x);
 }
 
-#if __GNUC__ > 4
+#if defined(MBEDTLS_COMPILER_IS_GCC) && (__GNUC__ > 4)
 /* Restore warnings for -Wredundant-decls on gcc */
     #pragma GCC diagnostic pop
 #endif

--- a/library/constant_time_impl.h
+++ b/library/constant_time_impl.h
@@ -31,7 +31,7 @@
  * Disable -Wredundant-decls so that gcc does not warn about this. This is re-enabled
  * at the bottom of this file.
  */
-#ifdef __GNUC__ > 4
+#if __GNUC__ > 4
     #pragma GCC diagnostic push
     #pragma GCC diagnostic ignored "-Wredundant-decls"
 #endif

--- a/library/constant_time_impl.h
+++ b/library/constant_time_impl.h
@@ -31,7 +31,7 @@
  * Disable -Wredundant-decls so that gcc does not warn about this. This is re-enabled
  * at the bottom of this file.
  */
-#if __GNUC__ > 4
+#if defined(MBEDTLS_COMPILER_IS_GCC) && (__GNUC__ > 4)
     #pragma GCC diagnostic push
     #pragma GCC diagnostic ignored "-Wredundant-decls"
 #endif


### PR DESCRIPTION
## Description

When compiling with:
```
arm-none-eabi-gcc.exe (Sourcery G++ Lite 2011.03-42) 4.5.2
```
We get the following error:
```
constant_time_impl.h:47:13: error: expected [error|warning|ignored] after '#pragma GCC diagnostic'
```

using this commit, we activat the pragma only for GCC 5+



## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [X] **changelog** not required
- [X] **backport** not required
- [X] **tests** not required

