### PR TITLE
Fixes invalid default choice of thumb assembler syntax.

### DIFF
--- a/library/constant_time_impl.h
+++ b/library/constant_time_impl.h
@@ -123,7 +123,7 @@ static inline mbedtls_ct_uint_t mbedtls_ct_compiler_opaque(mbedtls_ct_uint_t x)
  * For gcc, restore divided syntax afterwards - otherwise old versions of gcc
  * seem to apply unified syntax globally, which breaks other asm code.
  */
-#if !defined(__clang__)
+#if !defined(__clang__) && !(__GNUC__ == 4 && __GNUC_MINOR__ == 9)
 #define RESTORE_ASM_SYNTAX  ".syntax divided                      \n\t"
 #else
 #define RESTORE_ASM_SYNTAX


### PR DESCRIPTION
## Description

In the implementation, it is assumed that the default thumb assembler syntax is always `divided` with non-clang compilers. So when the syntax is to be restored in https://github.com/Mbed-TLS/mbedtls/blob/development/library/constant_time_impl.h#L127, it will be restored to `divided`.

However, there are some compilers that by default use the `unified` syntax which leads to problems when "restoring" the `divided` syntax.
```
arm-none-eabi-gcc.exe (GNU Tools for ARM Embedded Processors) 4.9.3 20150529 (release) [ARM/embedded-4_9-branch revision 227977]
```

Errors:
```
C:\Users\mschulz\AppData\Local\Temp\ccYw2Mch.s: Assembler messages:
C:\Users\mschulz\AppData\Local\Temp\ccYw2Mch.s:72: Error: Thumb does not support conditional execution
C:\Users\mschulz\AppData\Local\Temp\ccYw2Mch.s:74: Error: instruction not allowed in IT block -- `str r3,[r0]'
C:\Users\mschulz\AppData\Local\Temp\ccYw2Mch.s:80: Error: Thumb does not support conditional execution
C:\Users\mschulz\AppData\Local\Temp\ccYw2Mch.s:81: Error: Thumb does not support conditional execution
C:\Users\mschulz\AppData\Local\Temp\ccYw2Mch.s:83: Error: instruction not allowed in IT block -- `sub r3,r2,#97'
C:\Users\mschulz\AppData\Local\Temp\ccYw2Mch.s:84: Error: instruction not allowed in IT block -- `cmp r3,#5'
C:\Users\mschulz\AppData\Local\Temp\ccYw2Mch.s:87: Error: Thumb does not support conditional execution
C:\Users\mschulz\AppData\Local\Temp\ccYw2Mch.s:89: Error: Thumb does not support conditional execution
C:\Users\mschulz\AppData\Local\Temp\ccYw2Mch.s:91: Error: instruction not allowed in IT block -- `ldr r3,[r0]'
C:\Users\mschulz\AppData\Local\Temp\ccYw2Mch.s:92: Error: instruction not allowed in IT block -- `cmp r3,r1'
C:\Users\mschulz\AppData\Local\Temp\ccYw2Mch.s:95: Error: Thumb does not support conditional execution
C:\Users\mschulz\AppData\Local\Temp\ccYw2Mch.s:97: Error: Thumb does not support conditional execution
...
```

In this PR, we add a check for that particular compiler version, however, we cannot guarantee that the same issue occurs in every variant of GCC 4.9.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [X] **changelog** not required
- [X] **backport** not required
- [X] **tests** not required



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.
