### PR TITLE
Fixes redundant declarations for psa_set_key_domain_parameters

### DIFF
--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -486,10 +486,13 @@ psa_status_t mbedtls_psa_inject_entropy(const uint8_t *seed,
  * \retval #PSA_ERROR_NOT_SUPPORTED \emptydescription
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY \emptydescription
  */
+#if !defined(PSA_SET_KEY_DOMAIN_PARAMETERS)
+#define PSA_SET_KEY_DOMAIN_PARAMETERS
 psa_status_t psa_set_key_domain_parameters(psa_key_attributes_t *attributes,
                                            psa_key_type_t type,
                                            const uint8_t *data,
                                            size_t data_length);
+#endif /* PSA_SET_KEY_DOMAIN_PARAMETERS */
 
 /**
  * \brief Get domain parameters for a key.

--- a/include/psa/crypto_struct.h
+++ b/include/psa/crypto_struct.h
@@ -356,10 +356,13 @@ static inline psa_algorithm_t psa_get_key_algorithm(
 
 /* This function is declared in crypto_extra.h, which comes after this
  * header file, but we need the function here, so repeat the declaration. */
+#if !defined(PSA_SET_KEY_DOMAIN_PARAMETERS)
+#define PSA_SET_KEY_DOMAIN_PARAMETERS
 psa_status_t psa_set_key_domain_parameters(psa_key_attributes_t *attributes,
                                            psa_key_type_t type,
                                            const uint8_t *data,
                                            size_t data_length);
+#endif /* PSA_SET_KEY_DOMAIN_PARAMETERS */
 
 static inline void psa_set_key_type(psa_key_attributes_t *attributes,
                                     psa_key_type_t type)


### PR DESCRIPTION
## Description

Fixes https://github.com/Mbed-TLS/mbedtls/issues/6910



## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [X] **changelog** not required
- [X] **backport** not required
- [X] **tests** not required

