### PR TITLE
[G4] Make CTR-DRBG fall back on PSA when AES not built in

### DIFF
--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -153,7 +153,9 @@
 #endif /* not all curves accelerated */
 #endif /* some curve accelerated */
 
-#if defined(MBEDTLS_CTR_DRBG_C) && !defined(MBEDTLS_AES_C)
+#if defined(MBEDTLS_CTR_DRBG_C) && !(defined(MBEDTLS_AES_C) || \
+    (defined(MBEDTLS_PSA_CRYPTO_C) && defined(PSA_WANT_KEY_TYPE_AES) && \
+    defined(PSA_WANT_ALG_ECB_NO_PADDING)))
 #error "MBEDTLS_CTR_DRBG_C defined, but not all prerequisites"
 #endif
 

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -2607,6 +2607,13 @@
  * The CTR_DRBG generator uses AES-256 by default.
  * To use AES-128 instead, enable \c MBEDTLS_CTR_DRBG_USE_128_BIT_KEY above.
  *
+ * AES support can either be achived through builtin (MBEDTLS_AES_C) or PSA.
+ * Builtin is the default option when MBEDTLS_AES_C is defined otherwise PSA
+ * is used.
+ *
+ * \warning When using PSA, the user should call `psa_crypto_init()` before
+ *          using any CTR_DRBG operation (except `mbedtls_ctr_drbg_init()`).
+ *
  * \note AES-128 will be used if \c MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH is set.
  *
  * \note To achieve a 256-bit security strength with CTR_DRBG,
@@ -2616,7 +2623,9 @@
  * Module:  library/ctr_drbg.c
  * Caller:
  *
- * Requires: MBEDTLS_AES_C
+ * Requires: MBEDTLS_AES_C or
+ *           (PSA_WANT_KEY_TYPE_AES and PSA_WANT_ALG_ECB_NO_PADDING and
+ *            MBEDTLS_PSA_CRYPTO_C)
  *
  * This module provides the CTR_DRBG AES random number generator.
  */
@@ -3155,8 +3164,7 @@
  *
  * Module:  library/psa_crypto.c
  *
- * Requires: MBEDTLS_CIPHER_C,
- *           either MBEDTLS_CTR_DRBG_C and MBEDTLS_ENTROPY_C,
+ * Requires: either MBEDTLS_CTR_DRBG_C and MBEDTLS_ENTROPY_C,
  *           or MBEDTLS_HMAC_DRBG_C and MBEDTLS_ENTROPY_C,
  *           or MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG.
  *

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -194,15 +194,6 @@ psa_status_t mbedtls_psa_register_se_key(
 /**@}*/
 
 /**
- * \brief PSA random deinitialization.
- *
- * This function frees the RNG implementation used by PSA.
- *
- * This is an Mbed TLS extension.
- */
-void mbedtls_psa_random_free(void);
-
-/**
  * \brief Library deinitialization.
  *
  * This function clears all data associated with the PSA layer,

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -194,6 +194,15 @@ psa_status_t mbedtls_psa_register_se_key(
 /**@}*/
 
 /**
+ * \brief PSA random deinitialization.
+ *
+ * This function frees the RNG implementation used by PSA.
+ *
+ * This is an Mbed TLS extension.
+ */
+void mbedtls_psa_random_free(void);
+
+/**
  * \brief Library deinitialization.
  *
  * This function clears all data associated with the PSA layer,

--- a/tests/include/test/drivers/cipher.h
+++ b/tests/include/test/drivers/cipher.h
@@ -26,7 +26,7 @@ typedef struct {
     /* Count the amount of times one of the cipher driver functions is called. */
     unsigned long hits;
     unsigned long cipher_encrypt_hits;
-    unsigned long cipher_update_hits;
+    unsigned long cipher_update_forced_status_hits;
 } mbedtls_test_driver_cipher_hooks_t;
 
 #define MBEDTLS_TEST_DRIVER_CIPHER_INIT { NULL, 0, PSA_SUCCESS, 0, 0, 0 }

--- a/tests/include/test/drivers/cipher.h
+++ b/tests/include/test/drivers/cipher.h
@@ -25,9 +25,10 @@ typedef struct {
     psa_status_t forced_status;
     /* Count the amount of times one of the cipher driver functions is called. */
     unsigned long hits;
+    unsigned long cipher_encrypt_hits;
 } mbedtls_test_driver_cipher_hooks_t;
 
-#define MBEDTLS_TEST_DRIVER_CIPHER_INIT { NULL, 0, PSA_SUCCESS, 0 }
+#define MBEDTLS_TEST_DRIVER_CIPHER_INIT { NULL, 0, PSA_SUCCESS, 0, 0 }
 static inline mbedtls_test_driver_cipher_hooks_t
 mbedtls_test_driver_cipher_hooks_init(void)
 {

--- a/tests/include/test/drivers/cipher.h
+++ b/tests/include/test/drivers/cipher.h
@@ -23,13 +23,17 @@ typedef struct {
     /* If not PSA_SUCCESS, return this error code instead of processing the
      * function call. */
     psa_status_t forced_status;
+    psa_status_t forced_status_encrypt;
+    psa_status_t forced_status_set_iv;
     /* Count the amount of times one of the cipher driver functions is called. */
     unsigned long hits;
-    unsigned long cipher_encrypt_hits;
-    unsigned long cipher_update_forced_status_hits;
+    unsigned long hits_encrypt;
+    unsigned long hits_set_iv;
 } mbedtls_test_driver_cipher_hooks_t;
 
-#define MBEDTLS_TEST_DRIVER_CIPHER_INIT { NULL, 0, PSA_SUCCESS, 0, 0, 0 }
+#define MBEDTLS_TEST_DRIVER_CIPHER_INIT { NULL, 0, \
+                                          PSA_SUCCESS, PSA_SUCCESS, PSA_SUCCESS, \
+                                          0, 0, 0 }
 static inline mbedtls_test_driver_cipher_hooks_t
 mbedtls_test_driver_cipher_hooks_init(void)
 {

--- a/tests/include/test/drivers/cipher.h
+++ b/tests/include/test/drivers/cipher.h
@@ -26,9 +26,10 @@ typedef struct {
     /* Count the amount of times one of the cipher driver functions is called. */
     unsigned long hits;
     unsigned long cipher_encrypt_hits;
+    unsigned long cipher_update_hits;
 } mbedtls_test_driver_cipher_hooks_t;
 
-#define MBEDTLS_TEST_DRIVER_CIPHER_INIT { NULL, 0, PSA_SUCCESS, 0, 0 }
+#define MBEDTLS_TEST_DRIVER_CIPHER_INIT { NULL, 0, PSA_SUCCESS, 0, 0, 0 }
 static inline mbedtls_test_driver_cipher_hooks_t
 mbedtls_test_driver_cipher_hooks_init(void)
 {

--- a/tests/include/test/drivers/key_management.h
+++ b/tests/include/test/drivers/key_management.h
@@ -27,7 +27,7 @@ typedef struct {
      * is called. */
     unsigned long hits;
     /* Subset of hits which only counts key operations with EC key */
-    unsigned long export_public_key_hits;
+    unsigned long hits_export_public_key;
     /* Location of the last key management driver called to import a key. */
     psa_key_location_t location;
 } mbedtls_test_driver_key_management_hooks_t;

--- a/tests/include/test/drivers/key_management.h
+++ b/tests/include/test/drivers/key_management.h
@@ -26,6 +26,8 @@ typedef struct {
     /* Count the amount of times one of the key management driver functions
      * is called. */
     unsigned long hits;
+    /* Subset of hits which only counts key operations with EC key */
+    unsigned long export_public_key_hits;
     /* Location of the last key management driver called to import a key. */
     psa_key_location_t location;
 } mbedtls_test_driver_key_management_hooks_t;
@@ -34,7 +36,7 @@ typedef struct {
  * sense that no PSA specification will assign a meaning to this location
  * (stated first in version 1.0.1 of the specification) and that it is not
  * used as a location of an opaque test drivers. */
-#define MBEDTLS_TEST_DRIVER_KEY_MANAGEMENT_INIT { NULL, 0, PSA_SUCCESS, 0, 0x800000 }
+#define MBEDTLS_TEST_DRIVER_KEY_MANAGEMENT_INIT { NULL, 0, PSA_SUCCESS, 0, 0, 0x800000 }
 static inline mbedtls_test_driver_key_management_hooks_t
 mbedtls_test_driver_key_management_hooks_init(void)
 {

--- a/tests/include/test/psa_crypto_helpers.h
+++ b/tests/include/test/psa_crypto_helpers.h
@@ -397,4 +397,27 @@ uint64_t mbedtls_test_parse_binary_string(data_t *bin_string);
 #define MD_OR_USE_PSA_DONE() ((void) 0)
 #endif
 
+/** \def AES_PSA_INIT
+ *
+ * Call this macro to initialize the PSA subsystem if AES_C is not defined,
+ * so that CTR_DRBG uses PSA implementation to get AES-ECB.
+ *
+ * If the initialization fails, mark the test case as failed and jump to the
+ * \p exit label.
+ */
+/** \def AES_PSA_DONE
+ *
+ * Call this macro at the end of a test case if you called #AES_PSA_INIT.
+ *
+ * This is like #PSA_DONE except it does nothing under the same conditions as
+ * #AES_PSA_INIT.
+ */
+#if defined(MBEDTLS_AES_C)
+#define AES_PSA_INIT() ((void) 0)
+#define AES_PSA_DONE() ((void) 0)
+#else /* MBEDTLS_AES_C */
+#define AES_PSA_INIT()   PSA_INIT()
+#define AES_PSA_DONE()   PSA_DONE()
+#endif /* MBEDTLS_AES_C */
+
 #endif /* PSA_CRYPTO_HELPERS_H */

--- a/tests/include/test/psa_crypto_helpers.h
+++ b/tests/include/test/psa_crypto_helpers.h
@@ -34,7 +34,6 @@
 #define PSA_DONE()                                                      \
     do                                                                  \
     {                                                                   \
-        mbedtls_psa_random_free();                                      \
         mbedtls_test_fail_if_psa_leaking(__LINE__, __FILE__);           \
         mbedtls_test_psa_purge_key_storage();                           \
         mbedtls_psa_crypto_free();                                      \
@@ -126,21 +125,17 @@ const char *mbedtls_test_helper_is_psa_leaking(void);
 
 /** Shut down the PSA Crypto subsystem, allowing persistent keys to survive.
  * Expect a clean shutdown, with no slots in use.
- * mbedtls_psa_random_free() is called before any check for remaining open
- * keys because when AES_C is not defined, CTR_DRBG relies on PSA to perform
- * AES-ECB so it holds an open AES key for that since psa_crypto_init().
  *
  * If some key slots are still in use, record the test case as failed and
  * jump to the `exit` label.
  */
 #define PSA_SESSION_DONE()                                             \
-    do                                                                 \
-    {                                                                  \
-        mbedtls_psa_random_free();                                     \
+    do                                                                  \
+    {                                                                   \
         mbedtls_test_psa_purge_key_cache();                            \
         ASSERT_PSA_PRISTINE();                                         \
         mbedtls_psa_crypto_free();                                     \
-    }                                                                  \
+    }                                                                   \
     while (0)
 
 

--- a/tests/include/test/psa_crypto_helpers.h
+++ b/tests/include/test/psa_crypto_helpers.h
@@ -34,6 +34,7 @@
 #define PSA_DONE()                                                      \
     do                                                                  \
     {                                                                   \
+        mbedtls_psa_random_free();                                      \
         mbedtls_test_fail_if_psa_leaking(__LINE__, __FILE__);           \
         mbedtls_test_psa_purge_key_storage();                           \
         mbedtls_psa_crypto_free();                                      \
@@ -125,17 +126,21 @@ const char *mbedtls_test_helper_is_psa_leaking(void);
 
 /** Shut down the PSA Crypto subsystem, allowing persistent keys to survive.
  * Expect a clean shutdown, with no slots in use.
+ * mbedtls_psa_random_free() is called before any check for remaining open
+ * keys because when AES_C is not defined, CTR_DRBG relies on PSA to perform
+ * AES-ECB so it holds an open AES key for that since psa_crypto_init().
  *
  * If some key slots are still in use, record the test case as failed and
  * jump to the `exit` label.
  */
 #define PSA_SESSION_DONE()                                             \
-    do                                                                  \
-    {                                                                   \
+    do                                                                 \
+    {                                                                  \
+        mbedtls_psa_random_free();                                     \
         mbedtls_test_psa_purge_key_cache();                            \
         ASSERT_PSA_PRISTINE();                                         \
         mbedtls_psa_crypto_free();                                     \
-    }                                                                   \
+    }                                                                  \
     while (0)
 
 

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -3729,7 +3729,6 @@ common_psa_crypto_config_accel_cipher_aead() {
     scripts/config.py unset MBEDTLS_PKCS5_C
     scripts/config.py unset MBEDTLS_PKCS12_C
 
-    scripts/config.py unset MBEDTLS_CTR_DRBG_C
     scripts/config.py unset MBEDTLS_NIST_KW_C
 }
 

--- a/tests/src/drivers/test_driver_cipher.c
+++ b/tests/src/drivers/test_driver_cipher.c
@@ -41,6 +41,7 @@ psa_status_t mbedtls_test_transparent_cipher_encrypt(
     size_t *output_length)
 {
     mbedtls_test_driver_cipher_hooks.hits++;
+    mbedtls_test_driver_cipher_hooks.cipher_encrypt_hits++;
 
     if (mbedtls_test_driver_cipher_hooks.forced_output != NULL) {
         if (output_size < mbedtls_test_driver_cipher_hooks.forced_output_length) {

--- a/tests/src/drivers/test_driver_cipher.c
+++ b/tests/src/drivers/test_driver_cipher.c
@@ -41,7 +41,7 @@ psa_status_t mbedtls_test_transparent_cipher_encrypt(
     size_t *output_length)
 {
     mbedtls_test_driver_cipher_hooks.hits++;
-    mbedtls_test_driver_cipher_hooks.cipher_encrypt_hits++;
+    mbedtls_test_driver_cipher_hooks.hits_encrypt++;
 
     if (mbedtls_test_driver_cipher_hooks.forced_output != NULL) {
         if (output_size < mbedtls_test_driver_cipher_hooks.forced_output_length) {
@@ -58,6 +58,9 @@ psa_status_t mbedtls_test_transparent_cipher_encrypt(
 
     if (mbedtls_test_driver_cipher_hooks.forced_status != PSA_SUCCESS) {
         return mbedtls_test_driver_cipher_hooks.forced_status;
+    }
+    if (mbedtls_test_driver_cipher_hooks.forced_status_encrypt != PSA_SUCCESS) {
+        return mbedtls_test_driver_cipher_hooks.forced_status_encrypt;
     }
 
 #if defined(MBEDTLS_TEST_LIBTESTDRIVER1) && \
@@ -209,9 +212,13 @@ psa_status_t mbedtls_test_transparent_cipher_set_iv(
     size_t iv_length)
 {
     mbedtls_test_driver_cipher_hooks.hits++;
+    mbedtls_test_driver_cipher_hooks.hits_set_iv++;
 
     if (mbedtls_test_driver_cipher_hooks.forced_status != PSA_SUCCESS) {
         return mbedtls_test_driver_cipher_hooks.forced_status;
+    }
+    if (mbedtls_test_driver_cipher_hooks.forced_status_set_iv != PSA_SUCCESS) {
+        return mbedtls_test_driver_cipher_hooks.forced_status_set_iv;
     }
 
 #if defined(MBEDTLS_TEST_LIBTESTDRIVER1) && \
@@ -249,7 +256,6 @@ psa_status_t mbedtls_test_transparent_cipher_update(
     }
 
     if (mbedtls_test_driver_cipher_hooks.forced_status != PSA_SUCCESS) {
-        ++mbedtls_test_driver_cipher_hooks.cipher_update_forced_status_hits;
         return mbedtls_test_driver_cipher_hooks.forced_status;
     }
 

--- a/tests/src/drivers/test_driver_cipher.c
+++ b/tests/src/drivers/test_driver_cipher.c
@@ -234,7 +234,6 @@ psa_status_t mbedtls_test_transparent_cipher_update(
     size_t *output_length)
 {
     mbedtls_test_driver_cipher_hooks.hits++;
-    mbedtls_test_driver_cipher_hooks.cipher_update_hits++;
 
     if (mbedtls_test_driver_cipher_hooks.forced_output != NULL) {
         if (output_size < mbedtls_test_driver_cipher_hooks.forced_output_length) {
@@ -250,6 +249,7 @@ psa_status_t mbedtls_test_transparent_cipher_update(
     }
 
     if (mbedtls_test_driver_cipher_hooks.forced_status != PSA_SUCCESS) {
+        ++mbedtls_test_driver_cipher_hooks.cipher_update_forced_status_hits;
         return mbedtls_test_driver_cipher_hooks.forced_status;
     }
 

--- a/tests/src/drivers/test_driver_cipher.c
+++ b/tests/src/drivers/test_driver_cipher.c
@@ -234,6 +234,7 @@ psa_status_t mbedtls_test_transparent_cipher_update(
     size_t *output_length)
 {
     mbedtls_test_driver_cipher_hooks.hits++;
+    mbedtls_test_driver_cipher_hooks.cipher_update_hits++;
 
     if (mbedtls_test_driver_cipher_hooks.forced_output != NULL) {
         if (output_size < mbedtls_test_driver_cipher_hooks.forced_output_length) {

--- a/tests/src/drivers/test_driver_key_management.c
+++ b/tests/src/drivers/test_driver_key_management.c
@@ -529,6 +529,7 @@ psa_status_t mbedtls_test_transparent_export_public_key(
     uint8_t *data, size_t data_size, size_t *data_length)
 {
     ++mbedtls_test_driver_key_management_hooks.hits;
+    ++mbedtls_test_driver_key_management_hooks.export_public_key_hits;
 
     if (mbedtls_test_driver_key_management_hooks.forced_status != PSA_SUCCESS) {
         return mbedtls_test_driver_key_management_hooks.forced_status;

--- a/tests/src/drivers/test_driver_key_management.c
+++ b/tests/src/drivers/test_driver_key_management.c
@@ -529,7 +529,7 @@ psa_status_t mbedtls_test_transparent_export_public_key(
     uint8_t *data, size_t data_size, size_t *data_length)
 {
     ++mbedtls_test_driver_key_management_hooks.hits;
-    ++mbedtls_test_driver_key_management_hooks.export_public_key_hits;
+    ++mbedtls_test_driver_key_management_hooks.hits_export_public_key;
 
     if (mbedtls_test_driver_key_management_hooks.forced_status != PSA_SUCCESS) {
         return mbedtls_test_driver_key_management_hooks.forced_status;

--- a/tests/suites/test_suite_ctr_drbg.function
+++ b/tests/suites/test_suite_ctr_drbg.function
@@ -137,10 +137,12 @@ void ctr_drbg_validate_no_reseed(data_t *add_init, data_t *entropy,
                                  data_t *result_string)
 {
     data_t empty = { 0, 0 };
+    AES_PSA_INIT();
     ctr_drbg_validate_internal(RESEED_NEVER, add_init,
                                entropy->len, entropy,
                                &empty, add1, add2,
                                result_string);
+    AES_PSA_DONE();
     goto exit; // goto is needed to avoid warning ( no test assertions in func)
 }
 /* END_CASE */
@@ -151,10 +153,12 @@ void ctr_drbg_validate_pr(data_t *add_init, data_t *entropy,
                           data_t *result_string)
 {
     data_t empty = { 0, 0 };
+    AES_PSA_INIT();
     ctr_drbg_validate_internal(RESEED_ALWAYS, add_init,
                                entropy->len / 3, entropy,
                                &empty, add1, add2,
                                result_string);
+    AES_PSA_DONE();
     goto exit; // goto is needed to avoid warning ( no test assertions in func)
 }
 /* END_CASE */
@@ -164,10 +168,12 @@ void ctr_drbg_validate_reseed_between(data_t *add_init, data_t *entropy,
                                       data_t *add1, data_t *add_reseed,
                                       data_t *add2, data_t *result_string)
 {
+    AES_PSA_INIT();
     ctr_drbg_validate_internal(RESEED_SECOND, add_init,
                                entropy->len / 2, entropy,
                                add_reseed, add1, add2,
                                result_string);
+    AES_PSA_DONE();
     goto exit; // goto is needed to avoid warning ( no test assertions in func)
 }
 /* END_CASE */
@@ -177,10 +183,12 @@ void ctr_drbg_validate_reseed_first(data_t *add_init, data_t *entropy,
                                     data_t *add1, data_t *add_reseed,
                                     data_t *add2, data_t *result_string)
 {
+    AES_PSA_INIT();
     ctr_drbg_validate_internal(RESEED_FIRST, add_init,
                                entropy->len / 2, entropy,
                                add_reseed, add1, add2,
                                result_string);
+    AES_PSA_DONE();
     goto exit; // goto is needed to avoid warning ( no test assertions in func)
 }
 /* END_CASE */
@@ -196,6 +204,8 @@ void ctr_drbg_entropy_strength(int expected_bit_strength)
     size_t byte_strength = expected_bit_strength / 8;
 
     mbedtls_ctr_drbg_init(&ctx);
+
+    AES_PSA_INIT();
     test_offset_idx = 0;
     test_max_idx = sizeof(entropy);
     memset(entropy, 0, sizeof(entropy));
@@ -214,6 +224,7 @@ void ctr_drbg_entropy_strength(int expected_bit_strength)
 
 exit:
     mbedtls_ctr_drbg_free(&ctx);
+    AES_PSA_DONE();
 }
 /* END_CASE */
 
@@ -228,6 +239,9 @@ void ctr_drbg_entropy_usage(int entropy_nonce_len)
     size_t expected_idx = 0;
 
     mbedtls_ctr_drbg_init(&ctx);
+
+    AES_PSA_INIT();
+
     test_offset_idx = 0;
     test_max_idx = sizeof(entropy);
     memset(entropy, 0, sizeof(entropy));
@@ -307,6 +321,7 @@ void ctr_drbg_entropy_usage(int entropy_nonce_len)
 
 exit:
     mbedtls_ctr_drbg_free(&ctx);
+    AES_PSA_DONE();
 }
 /* END_CASE */
 
@@ -317,6 +332,8 @@ void ctr_drbg_seed_file(char *path, int ret)
 
     mbedtls_ctr_drbg_init(&ctx);
 
+    AES_PSA_INIT();
+
     TEST_ASSERT(mbedtls_ctr_drbg_seed(&ctx, mbedtls_test_rnd_std_rand,
                                       NULL, NULL, 0) == 0);
     TEST_ASSERT(mbedtls_ctr_drbg_write_seed_file(&ctx, path) == ret);
@@ -324,12 +341,15 @@ void ctr_drbg_seed_file(char *path, int ret)
 
 exit:
     mbedtls_ctr_drbg_free(&ctx);
+    AES_PSA_DONE();
 }
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_SELF_TEST */
 void ctr_drbg_selftest()
 {
+    AES_PSA_INIT();
     TEST_ASSERT(mbedtls_ctr_drbg_self_test(1) == 0);
+    AES_PSA_DONE();
 }
 /* END_CASE */

--- a/tests/suites/test_suite_psa_crypto_driver_wrappers.function
+++ b/tests/suites/test_suite_psa_crypto_driver_wrappers.function
@@ -1489,7 +1489,7 @@ void cipher_entry_points(int alg_arg, int key_type_arg,
         output[i] = 0xa5;
     }
 
-    mbedtls_test_driver_cipher_hooks.cipher_update_hits = 0;
+    mbedtls_test_driver_cipher_hooks.cipher_update_forced_status_hits = 0;
     mbedtls_test_driver_cipher_hooks.cipher_encrypt_hits = 0;
     status = psa_cipher_encrypt(
         key, alg, input->x, input->len,
@@ -1501,7 +1501,7 @@ void cipher_entry_points(int alg_arg, int key_type_arg,
      * 1st access to the driver since "forced_status" is set. However this
      * initial access happens in psa_cipher_update() (random number generation
      * for IV) so psa_cipher_encrypt() never gets called. */
-    TEST_EQUAL(mbedtls_test_driver_cipher_hooks.cipher_update_hits, 1);
+    TEST_EQUAL(mbedtls_test_driver_cipher_hooks.cipher_update_forced_status_hits, 1);
 #endif
     TEST_EQUAL(status, PSA_ERROR_GENERIC_ERROR);
     /*

--- a/tests/suites/test_suite_psa_crypto_driver_wrappers.function
+++ b/tests/suites/test_suite_psa_crypto_driver_wrappers.function
@@ -1061,10 +1061,10 @@ void cipher_encrypt_validation(int alg_arg,
                               &key));
 
     mbedtls_test_driver_cipher_hooks.hits = 0;
-    mbedtls_test_driver_cipher_hooks.cipher_encrypt_hits = 0;
+    mbedtls_test_driver_cipher_hooks.hits_encrypt = 0;
     PSA_ASSERT(psa_cipher_encrypt(key, alg, input->x, input->len, output1,
                                   output1_buffer_size, &output1_length));
-    TEST_EQUAL(mbedtls_test_driver_cipher_hooks.cipher_encrypt_hits, 1);
+    TEST_EQUAL(mbedtls_test_driver_cipher_hooks.hits_encrypt, 1);
     mbedtls_test_driver_cipher_hooks.hits = 0;
 
     PSA_ASSERT(psa_cipher_encrypt_setup(&operation, key, alg));
@@ -1475,34 +1475,25 @@ void cipher_entry_points(int alg_arg, int key_type_arg,
      * successful, then force driver error.
      */
     mbedtls_test_driver_cipher_hooks.hits = 0;
-    mbedtls_test_driver_cipher_hooks.cipher_encrypt_hits = 0;
+    mbedtls_test_driver_cipher_hooks.hits_encrypt = 0;
     status = psa_cipher_encrypt(
         key, alg, input->x, input->len,
         output, output_buffer_size, &function_output_length);
-    TEST_EQUAL(mbedtls_test_driver_cipher_hooks.cipher_encrypt_hits, 1);
+    TEST_EQUAL(mbedtls_test_driver_cipher_hooks.hits_encrypt, 1);
     TEST_EQUAL(status, PSA_SUCCESS);
     mbedtls_test_driver_cipher_hooks.hits = 0;
 
-    mbedtls_test_driver_cipher_hooks.forced_status = PSA_ERROR_GENERIC_ERROR;
+    mbedtls_test_driver_cipher_hooks.forced_status_encrypt = PSA_ERROR_GENERIC_ERROR;
     /* Set the output buffer in a given state. */
     for (size_t i = 0; i < output_buffer_size; i++) {
         output[i] = 0xa5;
     }
 
-    mbedtls_test_driver_cipher_hooks.cipher_update_forced_status_hits = 0;
-    mbedtls_test_driver_cipher_hooks.cipher_encrypt_hits = 0;
+    mbedtls_test_driver_cipher_hooks.hits_encrypt = 0;
     status = psa_cipher_encrypt(
         key, alg, input->x, input->len,
         output, output_buffer_size, &function_output_length);
-#if defined(MBEDTLS_AES_C)
-    TEST_EQUAL(mbedtls_test_driver_cipher_hooks.cipher_encrypt_hits, 1);
-#else
-    /* The call to psa_cipher_encrypt() is intentionally supposed to fail on the
-     * 1st access to the driver since "forced_status" is set. However this
-     * initial access happens in psa_cipher_update() (random number generation
-     * for IV) so psa_cipher_encrypt() never gets called. */
-    TEST_EQUAL(mbedtls_test_driver_cipher_hooks.cipher_update_forced_status_hits, 1);
-#endif
+    TEST_EQUAL(mbedtls_test_driver_cipher_hooks.hits_encrypt, 1);
     TEST_EQUAL(status, PSA_ERROR_GENERIC_ERROR);
     /*
      * Check that the output buffer is still in the same state.
@@ -1563,25 +1554,18 @@ void cipher_entry_points(int alg_arg, int key_type_arg,
     TEST_EQUAL(mbedtls_test_driver_cipher_hooks.hits, 1);
     TEST_EQUAL(status, mbedtls_test_driver_cipher_hooks.forced_status);
     mbedtls_test_driver_cipher_hooks.hits = 0;
+    mbedtls_test_driver_cipher_hooks.hits_set_iv = 0;
 
-    mbedtls_test_driver_cipher_hooks.forced_status = PSA_ERROR_GENERIC_ERROR;
+    mbedtls_test_driver_cipher_hooks.forced_status_set_iv = PSA_ERROR_GENERIC_ERROR;
     /* Set the output buffer in a given state. */
     for (size_t i = 0; i < 16; i++) {
         output[i] = 0xa5;
     }
 
     status = psa_cipher_generate_iv(&operation, output, 16, &function_output_length);
-    /* When generating the IV fails, it should call abort too */
-#if defined(MBEDTLS_AES_C)
-    TEST_EQUAL(mbedtls_test_driver_cipher_hooks.hits, 2);
-#else
-    /* Previously failed call to psa_cipher_encrypt() above caused PSA to abort
-     * the cipher operation related to RNG. Therefore this call to
-     * psa_cipher_generate_iv() will failed due to unitialized RNG. Only the
-     * last driver call to psa_cipher_abort() remains. */
-    TEST_EQUAL(mbedtls_test_driver_cipher_hooks.hits, 1);
-#endif
-    TEST_EQUAL(status, mbedtls_test_driver_cipher_hooks.forced_status);
+    TEST_EQUAL(mbedtls_test_driver_cipher_hooks.hits_set_iv, 1);
+    TEST_EQUAL(status, mbedtls_test_driver_cipher_hooks.forced_status_set_iv);
+    mbedtls_test_driver_cipher_hooks.forced_status_set_iv = PSA_SUCCESS;
     /*
      * Check that the output buffer is still in the same state.
      * This will fail if the output buffer is used by the core to pass the IV

--- a/tests/suites/test_suite_psa_crypto_driver_wrappers.function
+++ b/tests/suites/test_suite_psa_crypto_driver_wrappers.function
@@ -906,7 +906,7 @@ void export_key(int force_status_arg,
     }
 
     mbedtls_test_driver_key_management_hooks.hits = 0;
-    mbedtls_test_driver_key_management_hooks.export_public_key_hits = 0;
+    mbedtls_test_driver_key_management_hooks.hits_export_public_key = 0;
     mbedtls_test_driver_key_management_hooks.forced_status = force_status;
 
     if (PSA_KEY_TYPE_IS_ECC_PUBLIC_KEY(output_key_type)) {
@@ -924,7 +924,7 @@ void export_key(int force_status_arg,
 
     if (PSA_KEY_TYPE_IS_ECC_PUBLIC_KEY(output_key_type) &&
         !PSA_KEY_TYPE_IS_ECC_PUBLIC_KEY(input_key_type)) {
-        TEST_EQUAL(mbedtls_test_driver_key_management_hooks.export_public_key_hits, 1);
+        TEST_EQUAL(mbedtls_test_driver_key_management_hooks.hits_export_public_key, 1);
     }
 
     if (actual_status == PSA_SUCCESS) {

--- a/tests/suites/test_suite_psa_crypto_driver_wrappers.function
+++ b/tests/suites/test_suite_psa_crypto_driver_wrappers.function
@@ -1489,7 +1489,7 @@ void cipher_entry_points(int alg_arg, int key_type_arg,
         output[i] = 0xa5;
     }
 
-    mbedtls_test_driver_cipher_hooks.cipher_encrypt_hits = 0;
+    mbedtls_test_driver_cipher_hooks.cipher_update_hits = 0;
     status = psa_cipher_encrypt(
         key, alg, input->x, input->len,
         output, output_buffer_size, &function_output_length);
@@ -1500,7 +1500,7 @@ void cipher_entry_points(int alg_arg, int key_type_arg,
      * 1st access to the driver since "forced_status" is set. However this
      * initial access happens in psa_cipher_update() (random number generation
      * for IV) so psa_cipher_encrypt() never gets called. */
-    TEST_EQUAL(mbedtls_test_driver_cipher_hooks.cipher_encrypt_hits, 0);
+    TEST_EQUAL(mbedtls_test_driver_cipher_hooks.cipher_update_hits, 1);
 #endif
     TEST_EQUAL(status, PSA_ERROR_GENERIC_ERROR);
     /*

--- a/tests/suites/test_suite_psa_crypto_driver_wrappers.function
+++ b/tests/suites/test_suite_psa_crypto_driver_wrappers.function
@@ -1490,6 +1490,7 @@ void cipher_entry_points(int alg_arg, int key_type_arg,
     }
 
     mbedtls_test_driver_cipher_hooks.cipher_update_hits = 0;
+    mbedtls_test_driver_cipher_hooks.cipher_encrypt_hits = 0;
     status = psa_cipher_encrypt(
         key, alg, input->x, input->len,
         output, output_buffer_size, &function_output_length);

--- a/tests/suites/test_suite_psa_crypto_driver_wrappers.function
+++ b/tests/suites/test_suite_psa_crypto_driver_wrappers.function
@@ -845,10 +845,10 @@ void validate_key(int force_status_arg,
     psa_set_key_bits(&attributes, 0);
     psa_set_key_usage_flags(&attributes, PSA_KEY_USAGE_EXPORT);
 
-    mbedtls_test_driver_key_management_hooks.forced_status = force_status;
-
     PSA_ASSERT(psa_crypto_init());
 
+    mbedtls_test_driver_key_management_hooks.hits = 0;
+    mbedtls_test_driver_key_management_hooks.forced_status = force_status;
     actual_status = psa_import_key(&attributes, key_input->x, key_input->len, &key);
     TEST_EQUAL(mbedtls_test_driver_key_management_hooks.hits, 1);
     TEST_EQUAL(actual_status, expected_status);
@@ -906,6 +906,7 @@ void export_key(int force_status_arg,
     }
 
     mbedtls_test_driver_key_management_hooks.hits = 0;
+    mbedtls_test_driver_key_management_hooks.export_public_key_hits = 0;
     mbedtls_test_driver_key_management_hooks.forced_status = force_status;
 
     if (PSA_KEY_TYPE_IS_ECC_PUBLIC_KEY(output_key_type)) {
@@ -923,7 +924,7 @@ void export_key(int force_status_arg,
 
     if (PSA_KEY_TYPE_IS_ECC_PUBLIC_KEY(output_key_type) &&
         !PSA_KEY_TYPE_IS_ECC_PUBLIC_KEY(input_key_type)) {
-        TEST_EQUAL(mbedtls_test_driver_key_management_hooks.hits, 1);
+        TEST_EQUAL(mbedtls_test_driver_key_management_hooks.export_public_key_hits, 1);
     }
 
     if (actual_status == PSA_SUCCESS) {
@@ -1059,9 +1060,11 @@ void cipher_encrypt_validation(int alg_arg,
     PSA_ASSERT(psa_import_key(&attributes, key_data->x, key_data->len,
                               &key));
 
+    mbedtls_test_driver_cipher_hooks.hits = 0;
+    mbedtls_test_driver_cipher_hooks.cipher_encrypt_hits = 0;
     PSA_ASSERT(psa_cipher_encrypt(key, alg, input->x, input->len, output1,
                                   output1_buffer_size, &output1_length));
-    TEST_EQUAL(mbedtls_test_driver_cipher_hooks.hits, 1);
+    TEST_EQUAL(mbedtls_test_driver_cipher_hooks.cipher_encrypt_hits, 1);
     mbedtls_test_driver_cipher_hooks.hits = 0;
 
     PSA_ASSERT(psa_cipher_encrypt_setup(&operation, key, alg));
@@ -1161,6 +1164,7 @@ void cipher_encrypt_multipart(int alg_arg,
     PSA_ASSERT(psa_import_key(&attributes, key_data->x, key_data->len,
                               &key));
 
+    mbedtls_test_driver_cipher_hooks.hits = 0;
     PSA_ASSERT(psa_cipher_encrypt_setup(&operation, key, alg));
     TEST_EQUAL(mbedtls_test_driver_cipher_hooks.hits, 1);
     mbedtls_test_driver_cipher_hooks.hits = 0;
@@ -1289,6 +1293,7 @@ void cipher_decrypt_multipart(int alg_arg,
     PSA_ASSERT(psa_import_key(&attributes, key_data->x, key_data->len,
                               &key));
 
+    mbedtls_test_driver_cipher_hooks.hits = 0;
     PSA_ASSERT(psa_cipher_decrypt_setup(&operation, key, alg));
     TEST_EQUAL(mbedtls_test_driver_cipher_hooks.hits, 1);
     mbedtls_test_driver_cipher_hooks.hits = 0;
@@ -1414,6 +1419,7 @@ void cipher_decrypt(int alg_arg,
         mbedtls_test_driver_cipher_hooks.forced_output_length = expected_output->len;
     }
 
+    mbedtls_test_driver_cipher_hooks.hits = 0;
     status = psa_cipher_decrypt(key, alg, input, input_buffer_size, output,
                                 output_buffer_size, &output_length);
     TEST_EQUAL(mbedtls_test_driver_cipher_hooks.hits, 1);
@@ -1468,10 +1474,12 @@ void cipher_entry_points(int alg_arg, int key_type_arg,
      * First test that if we don't force a driver error, encryption is
      * successful, then force driver error.
      */
+    mbedtls_test_driver_cipher_hooks.hits = 0;
+    mbedtls_test_driver_cipher_hooks.cipher_encrypt_hits = 0;
     status = psa_cipher_encrypt(
         key, alg, input->x, input->len,
         output, output_buffer_size, &function_output_length);
-    TEST_EQUAL(mbedtls_test_driver_cipher_hooks.hits, 1);
+    TEST_EQUAL(mbedtls_test_driver_cipher_hooks.cipher_encrypt_hits, 1);
     TEST_EQUAL(status, PSA_SUCCESS);
     mbedtls_test_driver_cipher_hooks.hits = 0;
 
@@ -1481,10 +1489,19 @@ void cipher_entry_points(int alg_arg, int key_type_arg,
         output[i] = 0xa5;
     }
 
+    mbedtls_test_driver_cipher_hooks.cipher_encrypt_hits = 0;
     status = psa_cipher_encrypt(
         key, alg, input->x, input->len,
         output, output_buffer_size, &function_output_length);
-    TEST_EQUAL(mbedtls_test_driver_cipher_hooks.hits, 1);
+#if defined(MBEDTLS_AES_C)
+    TEST_EQUAL(mbedtls_test_driver_cipher_hooks.cipher_encrypt_hits, 1);
+#else
+    /* The call to psa_cipher_encrypt() is intentionally supposed to fail on the
+     * 1st access to the driver since "forced_status" is set. However this
+     * initial access happens in psa_cipher_update() (random number generation
+     * for IV) so psa_cipher_encrypt() never gets called. */
+    TEST_EQUAL(mbedtls_test_driver_cipher_hooks.cipher_encrypt_hits, 0);
+#endif
     TEST_EQUAL(status, PSA_ERROR_GENERIC_ERROR);
     /*
      * Check that the output buffer is still in the same state.
@@ -1554,7 +1571,15 @@ void cipher_entry_points(int alg_arg, int key_type_arg,
 
     status = psa_cipher_generate_iv(&operation, output, 16, &function_output_length);
     /* When generating the IV fails, it should call abort too */
+#if defined(MBEDTLS_AES_C)
     TEST_EQUAL(mbedtls_test_driver_cipher_hooks.hits, 2);
+#else
+    /* Previously failed call to psa_cipher_encrypt() above caused PSA to abort
+     * the cipher operation related to RNG. Therefore this call to
+     * psa_cipher_generate_iv() will failed due to unitialized RNG. Only the
+     * last driver call to psa_cipher_abort() remains. */
+    TEST_EQUAL(mbedtls_test_driver_cipher_hooks.hits, 1);
+#endif
     TEST_EQUAL(status, mbedtls_test_driver_cipher_hooks.forced_status);
     /*
      * Check that the output buffer is still in the same state.

--- a/tests/suites/test_suite_psa_crypto_slot_management.function
+++ b/tests/suites/test_suite_psa_crypto_slot_management.function
@@ -90,10 +90,10 @@ static int invalidate_psa(invalidate_method_t invalidate_method)
             break;
     }
 
-    /* When AES_C is not defined CTR_DRBG relies on PSA to get AES-ECB so it
-     * holds an open key once psa_crypto_init() is called. */
-    ASSERT_PSA_PRISTINE();
     PSA_ASSERT(psa_crypto_init());
+
+    ASSERT_PSA_PRISTINE();
+
     return 1;
 
 exit:

--- a/tests/suites/test_suite_psa_crypto_slot_management.function
+++ b/tests/suites/test_suite_psa_crypto_slot_management.function
@@ -91,9 +91,7 @@ static int invalidate_psa(invalidate_method_t invalidate_method)
     }
 
     PSA_ASSERT(psa_crypto_init());
-
     ASSERT_PSA_PRISTINE();
-
     return 1;
 
 exit:

--- a/tests/suites/test_suite_psa_crypto_slot_management.function
+++ b/tests/suites/test_suite_psa_crypto_slot_management.function
@@ -90,8 +90,10 @@ static int invalidate_psa(invalidate_method_t invalidate_method)
             break;
     }
 
-    PSA_ASSERT(psa_crypto_init());
+    /* When AES_C is not defined CTR_DRBG relies on PSA to get AES-ECB so it
+     * holds an open key once psa_crypto_init() is called. */
     ASSERT_PSA_PRISTINE();
+    PSA_ASSERT(psa_crypto_init());
     return 1;
 
 exit:
@@ -746,19 +748,12 @@ void invalid_handle(int handle_construction,
              * MBEDTLS_SVC_KEY_ID_GET_KEY_ID( valid_handle ) is a volatile
              * key identifier as the imported key is a volatile key. Volatile
              * key identifiers are in the range from PSA_KEY_ID_VOLATILE_MIN
-             * to PSA_KEY_ID_VOLATILE_MAX included. Thus pick a key identifier
-             * in the range from PSA_KEY_ID_VOLATILE_MIN to
-             * PSA_KEY_ID_VOLATILE_MAX different from
-             * MBEDTLS_SVC_KEY_ID_GET_KEY_ID( valid_handle ) to build an
-             * unopened and thus invalid identifier.
+             * to PSA_KEY_ID_VOLATILE_MAX included. It is very unlikely that
+             * all IDs are used up to the last one, so pick
+             * PSA_KEY_ID_VOLATILE_MAX to build an unopened and thus invalid
+             * identifier.
              */
-
-            if (MBEDTLS_SVC_KEY_ID_GET_KEY_ID(valid_handle) ==
-                PSA_KEY_ID_VOLATILE_MIN) {
-                key_id = PSA_KEY_ID_VOLATILE_MIN + 1;
-            } else {
-                key_id = MBEDTLS_SVC_KEY_ID_GET_KEY_ID(valid_handle) - 1;
-            }
+            key_id = PSA_KEY_ID_VOLATILE_MAX;
 
             invalid_handle =
                 mbedtls_svc_key_id_make(0, key_id);
@@ -938,11 +933,16 @@ void non_reusable_key_slots_integrity_in_case_of_key_slot_starvation()
     mbedtls_svc_key_id_t persistent_key2 = MBEDTLS_SVC_KEY_ID_INIT;
     mbedtls_svc_key_id_t returned_key_id = MBEDTLS_SVC_KEY_ID_INIT;
     mbedtls_svc_key_id_t *keys = NULL;
+    mbedtls_psa_stats_t psa_key_slots_stats;
+    size_t available_key_slots = 0;
 
     TEST_ASSERT(MBEDTLS_PSA_KEY_SLOT_COUNT >= 1);
 
-    TEST_CALLOC(keys, MBEDTLS_PSA_KEY_SLOT_COUNT);
     PSA_ASSERT(psa_crypto_init());
+    mbedtls_psa_get_stats(&psa_key_slots_stats);
+    available_key_slots = psa_key_slots_stats.empty_slots;
+
+    TEST_CALLOC(keys, available_key_slots);
 
     psa_set_key_usage_flags(&attributes,
                             PSA_KEY_USAGE_EXPORT | PSA_KEY_USAGE_COPY);
@@ -961,10 +961,10 @@ void non_reusable_key_slots_integrity_in_case_of_key_slot_starvation()
     TEST_ASSERT(mbedtls_svc_key_id_equal(returned_key_id, persistent_key));
 
     /*
-     * Create MBEDTLS_PSA_KEY_SLOT_COUNT volatile keys
+     * Create the maximum available number of volatile keys
      */
     psa_set_key_lifetime(&attributes, PSA_KEY_LIFETIME_VOLATILE);
-    for (i = 0; i < MBEDTLS_PSA_KEY_SLOT_COUNT; i++) {
+    for (i = 0; i < available_key_slots; i++) {
         PSA_ASSERT(psa_import_key(&attributes,
                                   (uint8_t *) &i, sizeof(i),
                                   &keys[i]));
@@ -983,12 +983,12 @@ void non_reusable_key_slots_integrity_in_case_of_key_slot_starvation()
      * Check we can export the volatile key created last and that it has the
      * expected value. Then, destroy it.
      */
-    PSA_ASSERT(psa_export_key(keys[MBEDTLS_PSA_KEY_SLOT_COUNT - 1],
+    PSA_ASSERT(psa_export_key(keys[available_key_slots - 1],
                               exported, sizeof(exported),
                               &exported_length));
-    i = MBEDTLS_PSA_KEY_SLOT_COUNT - 1;
+    i = available_key_slots - 1;
     TEST_MEMORY_COMPARE(exported, exported_length, (uint8_t *) &i, sizeof(i));
-    PSA_ASSERT(psa_destroy_key(keys[MBEDTLS_PSA_KEY_SLOT_COUNT - 1]));
+    PSA_ASSERT(psa_destroy_key(keys[available_key_slots - 1]));
 
     /*
      * Check that we can now access the persistent key again.
@@ -1011,7 +1011,7 @@ void non_reusable_key_slots_integrity_in_case_of_key_slot_starvation()
      * Check we can export the remaining volatile keys and that they have the
      * expected values.
      */
-    for (i = 0; i < (MBEDTLS_PSA_KEY_SLOT_COUNT - 1); i++) {
+    for (i = 0; i < (available_key_slots - 1); i++) {
         PSA_ASSERT(psa_export_key(keys[i],
                                   exported, sizeof(exported),
                                   &exported_length));

--- a/tests/suites/test_suite_random.function
+++ b/tests/suites/test_suite_random.function
@@ -26,7 +26,12 @@ void random_twice_with_ctr_drbg()
     unsigned char output1[OUTPUT_SIZE];
     unsigned char output2[OUTPUT_SIZE];
 
+#if defined(MBEDTLS_AES_C)
     MD_PSA_INIT();
+#else
+    USE_PSA_INIT();
+#endif
+
 
     /* First round */
     mbedtls_entropy_init(&entropy);
@@ -56,7 +61,11 @@ void random_twice_with_ctr_drbg()
 exit:
     mbedtls_ctr_drbg_free(&drbg);
     mbedtls_entropy_free(&entropy);
+#if defined(MBEDTLS_AES_C)
     MD_PSA_DONE();
+#else
+    USE_PSA_DONE();
+#endif
 }
 /* END_CASE */
 


### PR DESCRIPTION
## Description

Resolves #8441.

Opening this PR as draft because it includes several fixes to test I'm not really sure about. In particular `test_suite_psa_crypto_driver_wrappers` is expected to fail in `component_test_psa_crypto_config_accel_cipher_aead`. This is where I'm looking for suggestions (as also reported on the last commit).

## PR checklist

- [ ] **changelog** TODO
- [ ] **backport** not required as this is an enhancement
- [ ] **tests** provided: `component_test_psa_crypto_config_accel_cipher_aead` is testing the new solution