### PR TITLE
Uncrustify warnings

### DIFF
--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -5689,7 +5689,7 @@ component_check_code_style () {
 }
 
 support_check_code_style() {
-    case $(uncrustify --version) in
+    case $(uncrustify --version 2>/dev/null) in
         *0.75.1*) true;;
         *) false;;
     esac


### PR DESCRIPTION
Make `scripts/code_style.py` easier to use by occasional contributors. In particular, insist on the version we require. Currently we have a warning [but people ignore warnings](https://github.com/Mbed-TLS/mbedtls/pull/8510#issuecomment-1807662284).

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required
- [ ] **backport** TODO
- [x] **tests** manually only (maintenance script)
