### PR TITLE
TLS 1.3 SRV EarlyData: Ignore application message when rejected

### DIFF
--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -122,7 +122,7 @@ int main(void)
 #define DFL_SNI                 NULL
 #define DFL_ALPN_STRING         NULL
 #define DFL_GROUPS              NULL
-#define DFL_MAX_EARLY_DATA_SIZE 0
+#define DFL_MAX_EARLY_DATA_SIZE MBEDTLS_SSL_MAX_EARLY_DATA_SIZE
 #define DFL_SIG_ALGS            NULL
 #define DFL_DHM_FILE            NULL
 #define DFL_TRANSPORT           MBEDTLS_SSL_TRANSPORT_STREAM
@@ -429,9 +429,8 @@ int main(void)
 
 #if defined(MBEDTLS_SSL_EARLY_DATA)
 #define USAGE_EARLY_DATA \
-    "    max_early_data_size=%%d default: -1 (disabled)\n"             \
-    "                            options: -1 (disabled), "           \
-    "                                     >= 0 (enabled, max amount of early data )\n"
+    "    max_early_data_size=%%d The max amount 0-RTT data. up to UINT64_MAX.\n"    \
+    "                            default: MBEDTLS_SSL_MAX_EARLY_DATA_SIZE\n"
 #else
 #define USAGE_EARLY_DATA ""
 #endif /* MBEDTLS_SSL_EARLY_DATA */
@@ -694,7 +693,9 @@ struct options {
     const char *cid_val_renego; /* the CID to use for incoming messages
                                  * after renegotiation                      */
     int reproducible;           /* make communication reproducible          */
-    uint32_t max_early_data_size; /* max amount of early data               */
+#if defined(MBEDTLS_SSL_EARLY_DATA)
+    size_t max_early_data_size; /* max amount of early data                 */
+#endif
     int query_config_mode;      /* whether to read config                   */
     int use_srtp;               /* Support SRTP                             */
     int force_srtp_profile;     /* SRTP protection profile to use or all    */
@@ -1609,9 +1610,6 @@ int main(int argc, char *argv[])
     };
 #endif /* MBEDTLS_SSL_DTLS_SRTP */
 
-#if defined(MBEDTLS_SSL_EARLY_DATA)
-    int tls13_early_data_enabled = MBEDTLS_SSL_EARLY_DATA_DISABLED;
-#endif
 #if defined(MBEDTLS_MEMORY_BUFFER_ALLOC_C)
     mbedtls_memory_buffer_alloc_init(alloc_buf, sizeof(alloc_buf));
 #if defined(MBEDTLS_MEMORY_DEBUG)
@@ -1746,7 +1744,9 @@ int main(int argc, char *argv[])
     opt.sni                 = DFL_SNI;
     opt.alpn_string         = DFL_ALPN_STRING;
     opt.groups              = DFL_GROUPS;
+#if defined(MBEDTLS_SSL_EARLY_DATA)
     opt.max_early_data_size = DFL_MAX_EARLY_DATA_SIZE;
+#endif
     opt.sig_algs            = DFL_SIG_ALGS;
     opt.dhm_file            = DFL_DHM_FILE;
     opt.transport           = DFL_TRANSPORT;
@@ -1980,13 +1980,7 @@ usage:
 #endif
 #if defined(MBEDTLS_SSL_EARLY_DATA)
         else if (strcmp(p, "max_early_data_size") == 0) {
-            long long value = atoll(q);
-            tls13_early_data_enabled =
-                value >= 0 ? MBEDTLS_SSL_EARLY_DATA_ENABLED :
-                MBEDTLS_SSL_EARLY_DATA_DISABLED;
-            if (tls13_early_data_enabled) {
-                opt.max_early_data_size = atoi(q);
-            }
+            opt.max_early_data_size = (size_t) strtoull(q, NULL, 0);
         }
 #endif /* MBEDTLS_SSL_EARLY_DATA */
         else if (strcmp(p, "renegotiation") == 0) {
@@ -2808,11 +2802,7 @@ usage:
     }
 
 #if defined(MBEDTLS_SSL_EARLY_DATA)
-    mbedtls_ssl_conf_early_data(&conf, tls13_early_data_enabled);
-    if (tls13_early_data_enabled == MBEDTLS_SSL_EARLY_DATA_ENABLED) {
-        mbedtls_ssl_conf_max_early_data_size(
-            &conf, opt.max_early_data_size);
-    }
+    mbedtls_ssl_conf_max_early_data_size(&conf, opt.max_early_data_size);
 #endif /* MBEDTLS_SSL_EARLY_DATA */
 
 #if defined(MBEDTLS_KEY_EXCHANGE_CERT_REQ_ALLOWED_ENABLED)

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -124,6 +124,7 @@ int main(void)
 #define DFL_GROUPS              NULL
 #define DFL_MAX_EARLY_DATA_SIZE MBEDTLS_SSL_MAX_EARLY_DATA_SIZE
 #define DFL_EARLY_DATA          0
+#define DFL_RECO_EARLY_DATA     NULL
 #define DFL_SIG_ALGS            NULL
 #define DFL_DHM_FILE            NULL
 #define DFL_TRANSPORT           MBEDTLS_SSL_TRANSPORT_STREAM
@@ -433,7 +434,9 @@ int main(void)
     "    max_early_data_size=%%d The max amount 0-RTT data. up to UINT64_MAX.\n"    \
     "                            default: MBEDTLS_SSL_MAX_EARLY_DATA_SIZE\n"        \
     "    early_data=%%s         default: disable, enable/disable early_data feature.\n"  \
-    "                           available values: disable, enable\n"
+    "                           available values: disable, enable\n"                \
+    "    reco_early_data=%%s    default: early_data in 1st connection.\n"           \
+    "                           enable/disable early data when re-connection.\n"
 #else
 #define USAGE_EARLY_DATA ""
 #endif /* MBEDTLS_SSL_EARLY_DATA */
@@ -699,6 +702,7 @@ struct options {
 #if defined(MBEDTLS_SSL_EARLY_DATA)
     size_t max_early_data_size; /* max amount of early data                 */
     int    early_data;          /* enable/disable early data feature        */
+    const char *reco_early_data;/* {en,dis}able early data in 2nd flight    */
 #endif
     int query_config_mode;      /* whether to read config                   */
     int use_srtp;               /* Support SRTP                             */
@@ -1765,6 +1769,7 @@ int main(int argc, char *argv[])
 #if defined(MBEDTLS_SSL_EARLY_DATA)
     opt.max_early_data_size = DFL_MAX_EARLY_DATA_SIZE;
     opt.early_data          = DFL_EARLY_DATA;
+    opt.reco_early_data     = DFL_RECO_EARLY_DATA;
 #endif
     opt.sig_algs            = DFL_SIG_ALGS;
     opt.dhm_file            = DFL_DHM_FILE;
@@ -2005,6 +2010,11 @@ usage:
             if (opt.early_data < 0) {
                 goto usage;
             }
+        } else if (strcmp(p, "reco_early_data") == 0) {
+            if (parse_early_data(q) < 0) {
+                goto usage;
+            }
+            opt.reco_early_data = q;
         }
 #endif /* MBEDTLS_SSL_EARLY_DATA */
         else if (strcmp(p, "renegotiation") == 0) {
@@ -3356,6 +3366,11 @@ reset:
     mbedtls_net_free(&client_fd);
 
     if (connection_counter++) {
+#if defined(MBEDTLS_SSL_EARLY_DATA)
+        if (opt.reco_early_data) {
+            mbedtls_ssl_conf_early_data(&conf, parse_early_data(opt.reco_early_data));
+        }
+#endif
     }
 
     mbedtls_ssl_session_reset(&ssl);

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -1627,6 +1627,7 @@ int main(int argc, char *argv[])
     };
 #endif /* MBEDTLS_SSL_DTLS_SRTP */
 
+    int connection_counter = 0;
 #if defined(MBEDTLS_MEMORY_BUFFER_ALLOC_C)
     mbedtls_memory_buffer_alloc_init(alloc_buf, sizeof(alloc_buf));
 #if defined(MBEDTLS_MEMORY_DEBUG)
@@ -3353,6 +3354,9 @@ reset:
 #endif
 
     mbedtls_net_free(&client_fd);
+
+    if (connection_counter++) {
+    }
 
     mbedtls_ssl_session_reset(&ssl);
 

--- a/tests/opt-testcases/tls13-misc.sh
+++ b/tests/opt-testcases/tls13-misc.sh
@@ -498,7 +498,7 @@ requires_all_configs_enabled MBEDTLS_SSL_EARLY_DATA MBEDTLS_SSL_SESSION_TICKETS 
 requires_any_configs_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_ENABLED \
                              MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL_ENABLED
 run_test "TLS 1.3 G->m: EarlyData: feature is enabled, good." \
-         "$P_SRV force_version=tls13 debug_level=4 max_early_data_size=$EARLY_DATA_INPUT_LEN" \
+         "$P_SRV force_version=tls13 debug_level=4 max_early_data_size=$EARLY_DATA_INPUT_LEN early_data=enable" \
          "$G_NEXT_CLI localhost --priority=NORMAL:-VERS-ALL:+VERS-TLS1.3:+GROUP-ALL:+KX-ALL \
                       -d 10 -r --earlydata $EARLY_DATA_INPUT " \
          0 \

--- a/tests/opt-testcases/tls13-misc.sh
+++ b/tests/opt-testcases/tls13-misc.sh
@@ -502,8 +502,8 @@ run_test "TLS 1.3 G->m: EarlyData: feature is enabled, good." \
          "$G_NEXT_CLI localhost --priority=NORMAL:-VERS-ALL:+VERS-TLS1.3:+GROUP-ALL:+KX-ALL \
                       -d 10 -r --earlydata $EARLY_DATA_INPUT " \
          0 \
-         -s "NewSessionTicket: early_data(42) extension exists."            \
          -s "Sent max_early_data_size=$EARLY_DATA_INPUT_LEN"                \
+         -s "NewSessionTicket: early_data(42) extension exists."            \
          -s "ClientHello: early_data(42) extension exists."                 \
          -s "EncryptedExtensions: early_data(42) extension exists."         \
          -s "$( tail -1 $EARLY_DATA_INPUT )"


### PR DESCRIPTION
## Description

fix #6360.


- Ignore the extension and return a regular 1-RTT response. The server then skips past early data by attempting to deprotect received records using the handshake traffic key, discarding records which fail deprotection (up to the configured max_early_data_size). Once a record is deprotected successfully, it is treated as the start of the client’s second flight and the server proceeds as with an ordinary 1-RTT handshake.

## PR checklist


- [x] **changelog** not required
- [x] **backport**  not required
- [x] **tests** provided


