### PR TITLE
Adjust to match current TF-M config

### DIFF
--- a/configs/config-tfm.h
+++ b/configs/config-tfm.h
@@ -21,16 +21,6 @@
 /* MBEDTLS_PSA_CRYPTO_SPM needs third-party files, so disable it. */
 #undef MBEDTLS_PSA_CRYPTO_SPM
 
-/* TF-M provides its own dummy implementations to save code size.
- * We don't have any way to disable the tests that need these feature,
- * so we just keep AES decryption enabled. We will resolve this through
- * an official way to disable AES decryption, then this deviation
- * will no longer be needed:
- * https://github.com/Mbed-TLS/mbedtls/issues/7368
- */
-#undef MBEDTLS_AES_SETKEY_DEC_ALT
-#undef MBEDTLS_AES_DECRYPT_ALT
-
 /* Use built-in platform entropy functions (TF-M provides its own). */
 #undef MBEDTLS_NO_PLATFORM_ENTROPY
 

--- a/configs/config-tfm.h
+++ b/configs/config-tfm.h
@@ -45,6 +45,15 @@
 #undef MBEDTLS_PLATFORM_STD_EXIT_SUCCESS
 #undef MBEDTLS_PLATFORM_STD_EXIT_FAILURE
 
+/*
+ * In order to get an example config that works cleanly out-of-the-box
+ * for both baremetal and non-baremetal builds, we detect baremetal builds
+ * and set this variable automatically.
+ */
+#if defined(__IAR_SYSTEMS_ICC__) || defined(__ARM_EABI__)
+#define MBEDTLS_NO_PLATFORM_ENTROPY
+#endif
+
 /***********************************************************************
  * Local changes to crypto config below this delimiter
  **********************************************************************/

--- a/configs/config-tfm.h
+++ b/configs/config-tfm.h
@@ -51,18 +51,3 @@
 /***********************************************************************
  * Local changes to crypto config below this delimiter
  **********************************************************************/
-
-/* Between Mbed TLS 3.4 and 3.5, the PSA_WANT_KEY_TYPE_RSA_KEY_PAIR macro
- * (commented-out above) has been replaced with the following new macros: */
-//#define PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_BASIC      1
-//#define PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_IMPORT     1
-//#define PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_EXPORT     1
-//#define PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_GENERATE   1
-//#define PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_DERIVE     1 /* Not supported */
-
-/* Between Mbed TLS 3.4 and 3.5, the following macros have been added: */
-//#define PSA_WANT_KEY_TYPE_DH_KEY_PAIR_BASIC       1
-//#define PSA_WANT_KEY_TYPE_DH_KEY_PAIR_IMPORT    1
-//#define PSA_WANT_KEY_TYPE_DH_KEY_PAIR_EXPORT    1
-//#define PSA_WANT_KEY_TYPE_DH_KEY_PAIR_GENERATE  1
-//#define PSA_WANT_KEY_TYPE_DH_KEY_PAIR_DERIVE    1 // Not supported

--- a/configs/config-tfm.h
+++ b/configs/config-tfm.h
@@ -45,9 +45,9 @@
 #undef MBEDTLS_PLATFORM_STD_EXIT_SUCCESS
 #undef MBEDTLS_PLATFORM_STD_EXIT_FAILURE
 
-// We expect TF-M to pick this up soon
-#define MBEDTLS_BLOCK_CIPHER_NO_DECRYPT
-
 /***********************************************************************
  * Local changes to crypto config below this delimiter
  **********************************************************************/
+
+// We expect TF-M to pick this up soon
+#define MBEDTLS_BLOCK_CIPHER_NO_DECRYPT

--- a/configs/config-tfm.h
+++ b/configs/config-tfm.h
@@ -28,3 +28,41 @@
  * but using the native allocator is faster and works better with
  * memory management analysis frameworks such as ASan. */
 #undef MBEDTLS_MEMORY_BUFFER_ALLOC_C
+
+// This macro is enabled in TFM Medium but is disabled here because it is
+// incompatible with baremetal builds in Mbed TLS.
+#undef MBEDTLS_PSA_CRYPTO_STORAGE_C
+
+// This macro is enabled in TFM Medium but is disabled here because it is
+// incompatible with baremetal builds in Mbed TLS.
+#undef MBEDTLS_ENTROPY_NV_SEED
+
+// These platform-related TF-M settings are not useful here.
+#undef MBEDTLS_PLATFORM_NO_STD_FUNCTIONS
+#undef MBEDTLS_PLATFORM_STD_MEM_HDR
+#undef MBEDTLS_PLATFORM_SNPRINTF_MACRO
+#undef MBEDTLS_PLATFORM_PRINTF_ALT
+#undef MBEDTLS_PLATFORM_STD_EXIT_SUCCESS
+#undef MBEDTLS_PLATFORM_STD_EXIT_FAILURE
+
+// We expect TF-M to pick this up soon
+#define MBEDTLS_BLOCK_CIPHER_NO_DECRYPT
+
+/***********************************************************************
+ * Local changes to crypto config below this delimiter
+ **********************************************************************/
+
+/* Between Mbed TLS 3.4 and 3.5, the PSA_WANT_KEY_TYPE_RSA_KEY_PAIR macro
+ * (commented-out above) has been replaced with the following new macros: */
+//#define PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_BASIC      1
+//#define PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_IMPORT     1
+//#define PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_EXPORT     1
+//#define PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_GENERATE   1
+//#define PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_DERIVE     1 /* Not supported */
+
+/* Between Mbed TLS 3.4 and 3.5, the following macros have been added: */
+//#define PSA_WANT_KEY_TYPE_DH_KEY_PAIR_BASIC       1
+//#define PSA_WANT_KEY_TYPE_DH_KEY_PAIR_IMPORT    1
+//#define PSA_WANT_KEY_TYPE_DH_KEY_PAIR_EXPORT    1
+//#define PSA_WANT_KEY_TYPE_DH_KEY_PAIR_GENERATE  1
+//#define PSA_WANT_KEY_TYPE_DH_KEY_PAIR_DERIVE    1 // Not supported

--- a/configs/ext/crypto_config_profile_medium.h
+++ b/configs/ext/crypto_config_profile_medium.h
@@ -50,7 +50,7 @@
 //#define PSA_WANT_ALG_CFB                        1
 //#define PSA_WANT_ALG_CHACHA20_POLY1305          1
 //#define PSA_WANT_ALG_CTR                        1
-#define PSA_WANT_ALG_DETERMINISTIC_ECDSA        1
+//#define PSA_WANT_ALG_DETERMINISTIC_ECDSA        1
 //#define PSA_WANT_ALG_ECB_NO_PADDING             1
 #define PSA_WANT_ALG_ECDH                       1
 #define PSA_WANT_ALG_ECDSA                      1
@@ -105,33 +105,27 @@
 //#define PSA_WANT_KEY_TYPE_CAMELLIA              1
 //#define PSA_WANT_KEY_TYPE_CHACHA20              1
 //#define PSA_WANT_KEY_TYPE_DES                   1
-#define PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_BASIC    1
+//#define PSA_WANT_KEY_TYPE_ECC_KEY_PAIR          1 /* Deprecated */
+#define PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY        1
+#define PSA_WANT_KEY_TYPE_RAW_DATA              1
+//#define PSA_WANT_KEY_TYPE_RSA_KEY_PAIR          1 /* Deprecated */
+//#define PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY        1
+
+/*
+ * The following symbols extend and deprecate the legacy
+ * PSA_WANT_KEY_TYPE_xxx_KEY_PAIR ones. They include the usage of that key in
+ * the name's suffix. "_USE" is the most generic and it can be used to describe
+ * a generic suport, whereas other ones add more features on top of that and
+ * they are more specific.
+ */
+#define PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_BASIC      1
 #define PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT   1
 #define PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT   1
 #define PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE 1
-#define PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE   1
-#define PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY        1
-#define PSA_WANT_KEY_TYPE_RAW_DATA              1
-//#define PSA_WANT_KEY_TYPE_RSA_KEY_PAIR          1
-//#define PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY        1
+//#define PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE   1
 
-/***********************************************************************
- * Local edits below this delimiter
- **********************************************************************/
-
-/* Between Mbed TLS 3.4 and 3.5, the PSA_WANT_KEY_TYPE_RSA_KEY_PAIR macro
- * (commented-out above) has been replaced with the following new macros: */
-//#define PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_BASIC      1
-//#define PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_IMPORT     1
-//#define PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_EXPORT     1
-//#define PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_GENERATE   1
-//#define PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_DERIVE     1 /* Not supported */
-
-/* Between Mbed TLS 3.4 and 3.5, the following macros have been added: */
-//#define PSA_WANT_KEY_TYPE_DH_KEY_PAIR_BASIC       1
-//#define PSA_WANT_KEY_TYPE_DH_KEY_PAIR_IMPORT    1
-//#define PSA_WANT_KEY_TYPE_DH_KEY_PAIR_EXPORT    1
-//#define PSA_WANT_KEY_TYPE_DH_KEY_PAIR_GENERATE  1
-//#define PSA_WANT_KEY_TYPE_DH_KEY_PAIR_DERIVE    1 // Not supported
+#ifdef CRYPTO_HW_ACCELERATOR
+#include "crypto_accelerator_config.h"
+#endif
 
 #endif /* PROFILE_M_PSA_CRYPTO_CONFIG_H */

--- a/configs/ext/tfm_mbedcrypto_config_profile_medium.h
+++ b/configs/ext/tfm_mbedcrypto_config_profile_medium.h
@@ -8,22 +8,8 @@
  *  memory footprint.
  */
 /*
- *  Copyright (C) 2006-2023, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
- *
- *  Licensed under the Apache License, Version 2.0 (the "License"); you may
- *  not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
- *  This file is part of mbed TLS (https://tls.mbed.org)
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
  */
 
 #ifndef PROFILE_M_MBEDTLS_CONFIG_H

--- a/configs/ext/tfm_mbedcrypto_config_profile_medium.h
+++ b/configs/ext/tfm_mbedcrypto_config_profile_medium.h
@@ -8,12 +8,28 @@
  *  memory footprint.
  */
 /*
- *  Copyright The Mbed TLS Contributors
- *  SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+ *  Copyright (C) 2006-2023, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
  */
 
 #ifndef PROFILE_M_MBEDTLS_CONFIG_H
 #define PROFILE_M_MBEDTLS_CONFIG_H
+
+//#include "config_tfm.h"
 
 #if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_DEPRECATE)
 #define _CRT_SECURE_NO_DEPRECATE 1
@@ -81,44 +97,6 @@
  */
 
 /**
- * \def MBEDTLS_MD2_PROCESS_ALT
- *
- * MBEDTLS__FUNCTION_NAME__ALT: Uncomment a macro to let mbed TLS use you
- * alternate core implementation of symmetric crypto or hash function. Keep in
- * mind that function prototypes should remain the same.
- *
- * This replaces only one function. The header file from mbed TLS is still
- * used, in contrast to the MBEDTLS__MODULE_NAME__ALT flags.
- *
- * Example: In case you uncomment MBEDTLS_SHA256_PROCESS_ALT, mbed TLS will
- * no longer provide the mbedtls_sha1_process() function, but it will still provide
- * the other function (using your mbedtls_sha1_process() function) and the definition
- * of mbedtls_sha1_context, so your implementation of mbedtls_sha1_process must be compatible
- * with this definition.
- *
- * \note Because of a signature change, the core AES encryption and decryption routines are
- *       currently named mbedtls_aes_internal_encrypt and mbedtls_aes_internal_decrypt,
- *       respectively. When setting up alternative implementations, these functions should
- *       be overridden, but the wrapper functions mbedtls_aes_decrypt and mbedtls_aes_encrypt
- *       must stay untouched.
- *
- * \note If you use the AES_xxx_ALT macros, then is is recommended to also set
- *       MBEDTLS_AES_ROM_TABLES in order to help the linker garbage-collect the AES
- *       tables.
- *
- * Uncomment a macro to enable alternate implementation of the corresponding
- * function.
- *
- * \warning   MD2, MD4, MD5, DES and SHA-1 are considered weak and their use
- *            constitutes a security risk. If possible, we recommend avoiding
- *            dependencies on them, and considering stronger message digests
- *            and ciphers instead.
- *
- */
-#define MBEDTLS_AES_SETKEY_DEC_ALT
-#define MBEDTLS_AES_DECRYPT_ALT
-
-/**
  * \def MBEDTLS_AES_ROM_TABLES
  *
  * Use precomputed AES tables stored in ROM.
@@ -172,21 +150,6 @@
 #define MBEDTLS_ECP_NIST_OPTIM
 
 /**
- * \def MBEDTLS_ERROR_STRERROR_DUMMY
- *
- * Enable a dummy error function to make use of mbedtls_strerror() in
- * third party libraries easier when MBEDTLS_ERROR_C is disabled
- * (no effect when MBEDTLS_ERROR_C is enabled).
- *
- * You can safely disable this if MBEDTLS_ERROR_C is enabled, or if you're
- * not using mbedtls_strerror() or error_strerror() in your application.
- *
- * Disable if you run into name conflicts and want to really remove the
- * mbedtls_strerror()
- */
-#define MBEDTLS_ERROR_STRERROR_DUMMY
-
-/**
  * \def MBEDTLS_NO_PLATFORM_ENTROPY
  *
  * Do not use built-in platform entropy functions.
@@ -223,26 +186,7 @@
  * \note The entropy collector will write to the seed file before entropy is
  *       given to an external source, to update it.
  */
-// This macro is enabled in TFM Medium but is disabled here because it is
-// incompatible with baremetal builds in Mbed TLS.
-//#define MBEDTLS_ENTROPY_NV_SEED
-
-/* MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER
- *
- * Enable key identifiers that encode a key owner identifier.
- *
- * This is only meaningful when building the library as part of a
- * multi-client service. When you activate this option, you must provide an
- * implementation of the type mbedtls_key_owner_id_t and a translation from
- * mbedtls_svc_key_id_t to file name in all the storage backends that you
- * you wish to support.
- *
- * Note that while this define has been removed from TF-M's copy of this config
- * file, TF-M still passes this option to Mbed TLS during the build via CMake.
- * Therefore we keep it in our copy. See discussion on PR #7426 for more info.
- *
- */
-#define MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER
+#define MBEDTLS_ENTROPY_NV_SEED
 
 /**
  * \def MBEDTLS_PSA_CRYPTO_SPM
@@ -326,26 +270,21 @@
 #define MBEDTLS_AES_C
 
 /**
- * \def MBEDTLS_BLOCK_CIPHER_NO_DECRYPT
+ * \def MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
  *
- * Remove decryption operation for AES, ARIA and Camellia block cipher.
+ * Use only 128-bit keys in AES operations to save ROM.
  *
- * \note  This feature is incompatible with insecure block cipher,
- *        MBEDTLS_DES_C, and cipher modes which always require decryption
- *        operation, MBEDTLS_CIPHER_MODE_CBC, MBEDTLS_CIPHER_MODE_XTS and
- *        MBEDTLS_NIST_KW_C. When #MBEDTLS_PSA_CRYPTO_CONFIG is enabled,
- *        this feature is incompatible with following supported PSA equivalence,
- *        PSA_WANT_ALG_ECB_NO_PADDING, PSA_WANT_ALG_CBC_NO_PADDING,
- *        PSA_WANT_ALG_CBC_PKCS7 and PSA_WANT_KEY_TYPE_DES.
+ * Uncomment this macro to remove support for AES operations that use 192-
+ * or 256-bit keys.
+ *
+ * Uncommenting this macro reduces the size of AES code by ~300 bytes
+ * on v8-M/Thumb2.
  *
  * Module:  library/aes.c
- *          library/aesce.c
- *          library/aesni.c
- *          library/aria.c
- *          library/camellia.c
- *          library/cipher.c
+ *
+ * Requires: MBEDTLS_AES_C
  */
-#define MBEDTLS_BLOCK_CIPHER_NO_DECRYPT
+#define MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 
 /**
  * \def MBEDTLS_CIPHER_C
@@ -389,18 +328,6 @@
 #define MBEDTLS_ENTROPY_C
 
 /**
- * \def MBEDTLS_ERROR_C
- *
- * Enable error code to error string conversion.
- *
- * Module:  library/error.c
- * Caller:
- *
- * This module enables mbedtls_strerror().
- */
-#define MBEDTLS_ERROR_C
-
-/**
  * \def MBEDTLS_HKDF_C
  *
  * Enable the HKDF algorithm (RFC 5869).
@@ -413,40 +340,7 @@
  * This module adds support for the Hashed Message Authentication Code
  * (HMAC)-based key derivation function (HKDF).
  */
-#define MBEDTLS_HKDF_C /* Used for HUK deriviation */
-
-/**
- * \def MBEDTLS_MD_C
- *
- * Enable the generic layer for message digest (hashing) and HMAC.
- *
- * Requires: one of: MBEDTLS_MD5_C, MBEDTLS_RIPEMD160_C, MBEDTLS_SHA1_C,
- *                   MBEDTLS_SHA224_C, MBEDTLS_SHA256_C, MBEDTLS_SHA384_C,
- *                   MBEDTLS_SHA512_C, or MBEDTLS_PSA_CRYPTO_C with at least
- *                   one hash.
- * Module:  library/md.c
- * Caller:  library/constant_time.c
- *          library/ecdsa.c
- *          library/ecjpake.c
- *          library/hkdf.c
- *          library/hmac_drbg.c
- *          library/pk.c
- *          library/pkcs5.c
- *          library/pkcs12.c
- *          library/psa_crypto_ecp.c
- *          library/psa_crypto_rsa.c
- *          library/rsa.c
- *          library/ssl_cookie.c
- *          library/ssl_msg.c
- *          library/ssl_tls.c
- *          library/x509.c
- *          library/x509_crt.c
- *          library/x509write_crt.c
- *          library/x509write_csr.c
- *
- * Uncomment to enable generic message digest wrappers.
- */
-#define MBEDTLS_MD_C
+//#define MBEDTLS_HKDF_C /* Used for HUK deriviation */
 
 /**
  * \def MBEDTLS_MEMORY_BUFFER_ALLOC_C
@@ -484,6 +378,15 @@
  */
 #define MBEDTLS_PLATFORM_C
 
+#define MBEDTLS_PLATFORM_NO_STD_FUNCTIONS
+#define MBEDTLS_PLATFORM_STD_MEM_HDR   <stdlib.h>
+
+#include <stdio.h>
+
+#define MBEDTLS_PLATFORM_SNPRINTF_MACRO      snprintf
+#define MBEDTLS_PLATFORM_PRINTF_ALT
+#define MBEDTLS_PLATFORM_STD_EXIT_SUCCESS  EXIT_SUCCESS
+#define MBEDTLS_PLATFORM_STD_EXIT_FAILURE  EXIT_FAILURE
 
 /**
  * \def MBEDTLS_PSA_CRYPTO_C
@@ -508,9 +411,7 @@
  *           either MBEDTLS_PSA_ITS_FILE_C or a native implementation of
  *           the PSA ITS interface
  */
-// This macro is enabled in TFM Medium but is disabled here because it is
-// incompatible with baremetal builds in Mbed TLS.
-//#define MBEDTLS_PSA_CRYPTO_STORAGE_C
+#define MBEDTLS_PSA_CRYPTO_STORAGE_C
 
 /* \} name SECTION: mbed TLS modules */
 
@@ -614,6 +515,47 @@
 /* ECP options */
 #define MBEDTLS_ECP_FIXED_POINT_OPTIM        0 /**< Disable fixed-point speed-up */
 
+/**
+ * Uncomment to enable p256-m. This is an alternative implementation of
+ * key generation, ECDH and (randomized) ECDSA on the curve SECP256R1.
+ * Compared to the default implementation:
+ *
+ * - p256-m has a much smaller code size and RAM footprint.
+ * - p256-m is only available via the PSA API. This includes the pk module
+ *   when #MBEDTLS_USE_PSA_CRYPTO is enabled.
+ * - p256-m does not support deterministic ECDSA, EC-JPAKE, custom protocols
+ *   over the core arithmetic, or deterministic derivation of keys.
+ *
+ * We recommend enabling this option if your application uses the PSA API
+ * and the only elliptic curve support it needs is ECDH and ECDSA over
+ * SECP256R1.
+ *
+ * If you enable this option, you do not need to enable any ECC-related
+ * MBEDTLS_xxx option. You do need to separately request support for the
+ * cryptographic mechanisms through the PSA API:
+ * - #MBEDTLS_PSA_CRYPTO_C and #MBEDTLS_PSA_CRYPTO_CONFIG for PSA-based
+ *   configuration;
+ * - #MBEDTLS_USE_PSA_CRYPTO if you want to use p256-m from PK, X.509 or TLS;
+ * - #PSA_WANT_ECC_SECP_R1_256;
+ * - #PSA_WANT_ALG_ECDH and/or #PSA_WANT_ALG_ECDSA as needed;
+ * - #PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY, #PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_BASIC,
+ *   #PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT,
+ *   #PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT and/or
+ *   #PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE as needed.
+ *
+ * \note To benefit from the smaller code size of p256-m, make sure that you
+ *       do not enable any ECC-related option not supported by p256-m: this
+ *       would cause the built-in ECC implementation to be built as well, in
+ *       order to provide the required option.
+ *       Make sure #PSA_WANT_ALG_DETERMINISTIC_ECDSA, #PSA_WANT_ALG_JPAKE and
+ *       #PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE, and curves other than
+ *       SECP256R1 are disabled as they are not supported by this driver.
+ *       Also, avoid defining #MBEDTLS_PK_PARSE_EC_COMPRESSED or
+ *       #MBEDTLS_PK_PARSE_EC_EXTENDED as those currently require a subset of
+ *       the built-in ECC implementation, see docs/driver-only-builds.md.
+ */
+#define MBEDTLS_PSA_P256M_DRIVER_ENABLED
+
 /* \} name SECTION: Customisation configuration options */
 
 #if CRYPTO_NV_SEED
@@ -621,7 +563,7 @@
 #endif /* CRYPTO_NV_SEED */
 
 #if !defined(CRYPTO_HW_ACCELERATOR) && defined(MBEDTLS_ENTROPY_NV_SEED)
-#include "mbedtls_entropy_nv_seed_config.h"
+//#include "mbedtls_entropy_nv_seed_config.h"
 #endif
 
 #ifdef CRYPTO_HW_ACCELERATOR

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -3276,7 +3276,7 @@ component_test_tfm_config_p256m_driver_accel_ec () {
     not grep mbedtls_dhm_ library/dhm.o
     not grep mbedtls_mpi_ library/bignum.o
     # Check that p256m was built
-    grep -q p256_ecdsa_verify library/libmbedcrypto.a
+    grep -q p256_ecdsa_ library/libmbedcrypto.a
 
     # Run the tests
     msg "test: TF-M config + p256m driver + accel ECDH(E)/ECDSA"
@@ -3297,7 +3297,7 @@ component_test_tfm_config() {
     make CFLAGS='-Werror -Wall -Wextra -I../tests/include/spe' tests
 
     # Check that p256m was not built
-    not grep p256_ecdsa_verify library/libmbedcrypto.a
+    not grep p256_ecdsa_ library/libmbedcrypto.a
 
     msg "test: TF-M config"
     make test

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -4123,8 +4123,10 @@ support_build_tfm_armcc () {
 
 component_build_tfm_armcc() {
     # test the TF-M configuration can build cleanly with various warning flags enabled
-    cp configs/ext/tfm_mbedcrypto_config_profile_medium.h "$CONFIG_H"
-    cp configs/ext/crypto_config_profile_medium.h "$CRYPTO_CONFIG_H"
+    cp configs/config-tfm.h "$CONFIG_H"
+
+    # MBEDTLS_NO_PLATFORM_ENTROPY is needed as we are building for baremetal
+    ./scripts/config.py --force set MBEDTLS_NO_PLATFORM_ENTROPY
 
     msg "build: TF-M config, armclang armv7-m thumb2"
     armc6_build_test "--target=arm-arm-none-eabi -march=armv7-m -mthumb -Os -std=c99 -Werror -Wall -Wextra -Wwrite-strings -Wpointer-arith -Wimplicit-fallthrough -Wshadow -Wvla -Wformat=2 -Wno-format-nonliteral -Wshadow -Wasm-operand-widths -Wunused -I../tests/include/spe"
@@ -4136,8 +4138,7 @@ component_build_tfm() {
     # TF-M configuration needs a TF-M platform. A tweaked version of
     # the configuration that works on mainstream platforms is in
     # configs/config-tfm.h, tested via test-ref-configs.pl.
-    cp configs/ext/tfm_mbedcrypto_config_profile_medium.h "$CONFIG_H"
-    cp configs/ext/crypto_config_profile_medium.h "$CRYPTO_CONFIG_H"
+    cp configs/config-tfm.h "$CONFIG_H"
 
     msg "build: TF-M config, clang, armv7-m thumb2"
     make lib CC="clang" CFLAGS="--target=arm-linux-gnueabihf -march=armv7-m -mthumb -Os -std=c99 -Werror -Wall -Wextra -Wwrite-strings -Wpointer-arith -Wimplicit-fallthrough -Wshadow -Wvla -Wformat=2 -Wno-format-nonliteral -Wshadow -Wasm-operand-widths -Wunused -I../tests/include/spe"

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -4125,9 +4125,6 @@ component_build_tfm_armcc() {
     # test the TF-M configuration can build cleanly with various warning flags enabled
     cp configs/config-tfm.h "$CONFIG_H"
 
-    # MBEDTLS_NO_PLATFORM_ENTROPY is needed as we are building for baremetal
-    ./scripts/config.py --force set MBEDTLS_NO_PLATFORM_ENTROPY
-
     msg "build: TF-M config, armclang armv7-m thumb2"
     armc6_build_test "--target=arm-arm-none-eabi -march=armv7-m -mthumb -Os -std=c99 -Werror -Wall -Wextra -Wwrite-strings -Wpointer-arith -Wimplicit-fallthrough -Wshadow -Wvla -Wformat=2 -Wno-format-nonliteral -Wshadow -Wasm-operand-widths -Wunused -I../tests/include/spe"
 }


### PR DESCRIPTION
## Description

Bring Mbed TLS in line with recent changes to TF-M config

https://git.trustedfirmware.org/TF-M/trusted-firmware-m.git/log/lib/ext/mbedcrypto/mbedcrypto_config

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required
- [x] **backport** not in 2.28
- [x] **tests** not required
