### PR TITLE
Fix error handling for secure element keys in `psa_start_key_creation`

### DIFF
--- a/ChangeLog.d/fix-secure-element-key-creation.txt
+++ b/ChangeLog.d/fix-secure-element-key-creation.txt
@@ -1,3 +1,5 @@
 Bugfix
-   * Fix the error handling in psa_start_key_creation so that
-     out of memory issues are properly handled. Fixes #8537.
+   * Fix error handling when creating a key in a dynamic secure element
+     (feature enabled by MBEDTLS_PSA_CRYPTO_SE_C). In a low memory condition,
+     the creation could return PSA_SUCCESS but using or destroying the key
+     would not work. Fixes #8537.

--- a/ChangeLog.d/fix-secure-element-key-creation.txt
+++ b/ChangeLog.d/fix-secure-element-key-creation.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix the error handling in psa_start_key_creation so that
+     out of memory issues are properly handled. Fixes #8537.

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -1841,6 +1841,9 @@ static psa_status_t psa_start_key_creation(
 
         status = psa_copy_key_material_into_slot(
             slot, (uint8_t *) (&slot_number), sizeof(slot_number));
+        if (status != PSA_SUCCESS) {
+            return status;
+        }
     }
 
     if (*p_drv == NULL && method == PSA_KEY_CREATION_REGISTER) {


### PR DESCRIPTION
## Description
Add some error handling for the call to `psa_copy_key_material_into_slot` in `psa_start_key_creation`. Fixes #8537
## PR checklist
- [x] **changelog** provided
- [x] **3.6 backport** #9074
- [x] **backport** #8544
- [x] **tests** not required, we cannot test out of memory issues
