### PR TITLE
[G2] Make CCM and GCM work with the new block_cipher module

### DIFF
--- a/ChangeLog.d/8060.txt
+++ b/ChangeLog.d/8060.txt
@@ -1,0 +1,4 @@
+Features
+    * The CCM and GCM modules no longer depend on MBEDTLS_CIPHER_C. People who
+      use CCM and GCM but don't need the Cipher API can now disable
+      MBEDTLS_CIPHER_C in order to save code size.

--- a/include/mbedtls/ccm.h
+++ b/include/mbedtls/ccm.h
@@ -40,6 +40,10 @@
 
 #include "mbedtls/cipher.h"
 
+#if !defined(MBEDTLS_CIPHER_C)
+#include "mbedtls/block_cipher.h"
+#endif
+
 #define MBEDTLS_CCM_DECRYPT       0
 #define MBEDTLS_CCM_ENCRYPT       1
 #define MBEDTLS_CCM_STAR_DECRYPT  2
@@ -80,7 +84,11 @@ typedef struct mbedtls_ccm_context {
                                               #MBEDTLS_CCM_DECRYPT or
                                               #MBEDTLS_CCM_STAR_ENCRYPT or
                                               #MBEDTLS_CCM_STAR_DECRYPT. */
+#if defined(MBEDTLS_CIPHER_C)
     mbedtls_cipher_context_t MBEDTLS_PRIVATE(cipher_ctx);    /*!< The cipher context used. */
+#else
+    mbedtls_block_cipher_context_t MBEDTLS_PRIVATE(block_cipher_ctx);    /*!< The cipher context used. */
+#endif
     int MBEDTLS_PRIVATE(state);              /*!< Working value holding context's
                                                   state. Used for chunked data input */
 }

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -306,16 +306,8 @@
 #error "MBEDTLS_CCM_C defined, but not all prerequisites"
 #endif
 
-#if defined(MBEDTLS_CCM_C) && !defined(MBEDTLS_CIPHER_C)
-#error "MBEDTLS_CCM_C defined, but not all prerequisites"
-#endif
-
 #if defined(MBEDTLS_GCM_C) && (                                        \
     !defined(MBEDTLS_AES_C) && !defined(MBEDTLS_CAMELLIA_C) && !defined(MBEDTLS_ARIA_C) )
-#error "MBEDTLS_GCM_C defined, but not all prerequisites"
-#endif
-
-#if defined(MBEDTLS_GCM_C) && !defined(MBEDTLS_CIPHER_C)
 #error "MBEDTLS_GCM_C defined, but not all prerequisites"
 #endif
 

--- a/include/mbedtls/config_adjust_legacy_crypto.h
+++ b/include/mbedtls/config_adjust_legacy_crypto.h
@@ -22,8 +22,8 @@
 #ifndef MBEDTLS_CONFIG_ADJUST_LEGACY_CRYPTO_H
 #define MBEDTLS_CONFIG_ADJUST_LEGACY_CRYPTO_H
 
-/* Temporary hack to pacify check_names.py.
- * (GCM and CCM still hard-depend on CIPHER_C for now.) */
+/* GCM_C and CCM_C can either depend on (in order of preference) CIPHER_C or
+ * BLOCK_CIPHER_C. If the former is not defined, auto-enable the latter. */
 #if (defined(MBEDTLS_GCM_C) || defined(MBEDTLS_CCM_C)) && \
     !defined(MBEDTLS_CIPHER_C)
 #define MBEDTLS_BLOCK_CIPHER_C

--- a/include/mbedtls/gcm.h
+++ b/include/mbedtls/gcm.h
@@ -24,6 +24,10 @@
 
 #include "mbedtls/cipher.h"
 
+#if !defined(MBEDTLS_CIPHER_C)
+#include "mbedtls/block_cipher.h"
+#endif
+
 #include <stdint.h>
 
 #define MBEDTLS_GCM_ENCRYPT     1
@@ -46,7 +50,11 @@ extern "C" {
  * \brief          The GCM context structure.
  */
 typedef struct mbedtls_gcm_context {
+#if defined(MBEDTLS_CIPHER_C)
     mbedtls_cipher_context_t MBEDTLS_PRIVATE(cipher_ctx);  /*!< The cipher context used. */
+#else
+    mbedtls_block_cipher_context_t MBEDTLS_PRIVATE(block_cipher_ctx);  /*!< The cipher context used. */
+#endif
     uint64_t MBEDTLS_PRIVATE(HL)[16];                      /*!< Precalculated HTable low. */
     uint64_t MBEDTLS_PRIVATE(HH)[16];                      /*!< Precalculated HTable high. */
     uint64_t MBEDTLS_PRIVATE(len);                         /*!< The total length of the encrypted data. */

--- a/library/ccm.c
+++ b/library/ccm.c
@@ -130,20 +130,15 @@ static int mbedtls_ccm_crypt(mbedtls_ccm_context *ctx,
 
 #if defined(MBEDTLS_CIPHER_C)
     size_t olen = 0;
-
-    if ((ret = mbedtls_cipher_update(&ctx->cipher_ctx, ctx->ctr, 16, tmp_buf,
-                                     &olen)) != 0) {
-        ctx->state |= CCM_STATE__ERROR;
-        mbedtls_platform_zeroize(tmp_buf, sizeof(tmp_buf));
-        return ret;
-    }
+    ret = mbedtls_cipher_update(&ctx->cipher_ctx, ctx->ctr, 16, tmp_buf, &olen);
 #else
-    if ((ret = mbedtls_block_cipher_encrypt(&ctx->block_cipher_ctx, ctx->ctr, tmp_buf)) != 0) {
+    ret = mbedtls_block_cipher_encrypt(&ctx->block_cipher_ctx, ctx->ctr, tmp_buf);
+#endif
+    if (ret != 0) {
         ctx->state |= CCM_STATE__ERROR;
         mbedtls_platform_zeroize(tmp_buf, sizeof(tmp_buf));
         return ret;
     }
-#endif
 
     mbedtls_xor(output, input, tmp_buf + offset, use_len);
 
@@ -212,16 +207,14 @@ static int ccm_calculate_first_block_if_ready(mbedtls_ccm_context *ctx)
 
     /* Start CBC-MAC with first block*/
 #if defined(MBEDTLS_CIPHER_C)
-    if ((ret = mbedtls_cipher_update(&ctx->cipher_ctx, ctx->y, 16, ctx->y, &olen)) != 0) {
-        ctx->state |= CCM_STATE__ERROR;
-        return ret;
-    }
+    ret = mbedtls_cipher_update(&ctx->cipher_ctx, ctx->y, 16, ctx->y, &olen);
 #else
-    if ((ret = mbedtls_block_cipher_encrypt(&ctx->block_cipher_ctx, ctx->y, ctx->y)) != 0) {
+    ret = mbedtls_block_cipher_encrypt(&ctx->block_cipher_ctx, ctx->y, ctx->y);
+#endif
+    if (ret != 0) {
         ctx->state |= CCM_STATE__ERROR;
         return ret;
     }
-#endif
 
     return 0;
 }

--- a/library/ccm.c
+++ b/library/ccm.c
@@ -23,6 +23,10 @@
 #include "mbedtls/error.h"
 #include "mbedtls/constant_time.h"
 
+#if !defined(MBEDTLS_CIPHER_C)
+#include "block_cipher_internal.h"
+#endif
+
 #include <string.h>
 
 #if defined(MBEDTLS_PLATFORM_C)
@@ -51,6 +55,8 @@ int mbedtls_ccm_setkey(mbedtls_ccm_context *ctx,
                        unsigned int keybits)
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
+
+#if defined(MBEDTLS_CIPHER_C)
     const mbedtls_cipher_info_t *cipher_info;
 
     cipher_info = mbedtls_cipher_info_from_values(cipher, keybits,
@@ -73,6 +79,17 @@ int mbedtls_ccm_setkey(mbedtls_ccm_context *ctx,
                                      MBEDTLS_ENCRYPT)) != 0) {
         return ret;
     }
+#else
+    mbedtls_block_cipher_free(&ctx->block_cipher_ctx);
+
+    if ((ret = mbedtls_block_cipher_setup(&ctx->block_cipher_ctx, cipher)) != 0) {
+        return MBEDTLS_ERR_CCM_BAD_INPUT;
+    }
+
+    if ((ret = mbedtls_block_cipher_setkey(&ctx->block_cipher_ctx, key, keybits)) != 0) {
+        return MBEDTLS_ERR_CCM_BAD_INPUT;
+    }
+#endif
 
     return 0;
 }
@@ -85,7 +102,11 @@ void mbedtls_ccm_free(mbedtls_ccm_context *ctx)
     if (ctx == NULL) {
         return;
     }
+#if defined(MBEDTLS_CIPHER_C)
     mbedtls_cipher_free(&ctx->cipher_ctx);
+#else
+    mbedtls_block_cipher_free(&ctx->block_cipher_ctx);
+#endif
     mbedtls_platform_zeroize(ctx, sizeof(mbedtls_ccm_context));
 }
 
@@ -104,9 +125,11 @@ static int mbedtls_ccm_crypt(mbedtls_ccm_context *ctx,
                              const unsigned char *input,
                              unsigned char *output)
 {
-    size_t olen = 0;
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     unsigned char tmp_buf[16] = { 0 };
+
+#if defined(MBEDTLS_CIPHER_C)
+    size_t olen = 0;
 
     if ((ret = mbedtls_cipher_update(&ctx->cipher_ctx, ctx->ctr, 16, tmp_buf,
                                      &olen)) != 0) {
@@ -114,6 +137,13 @@ static int mbedtls_ccm_crypt(mbedtls_ccm_context *ctx,
         mbedtls_platform_zeroize(tmp_buf, sizeof(tmp_buf));
         return ret;
     }
+#else
+    if ((ret = mbedtls_block_cipher_encrypt(&ctx->block_cipher_ctx, ctx->ctr, tmp_buf)) != 0) {
+        ctx->state |= CCM_STATE__ERROR;
+        mbedtls_platform_zeroize(tmp_buf, sizeof(tmp_buf));
+        return ret;
+    }
+#endif
 
     mbedtls_xor(output, input, tmp_buf + offset, use_len);
 
@@ -132,7 +162,10 @@ static int ccm_calculate_first_block_if_ready(mbedtls_ccm_context *ctx)
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     unsigned char i;
-    size_t len_left, olen;
+    size_t len_left;
+#if defined(MBEDTLS_CIPHER_C)
+    size_t olen;
+#endif
 
     /* length calculation can be done only after both
      * mbedtls_ccm_starts() and mbedtls_ccm_set_lengths() have been executed
@@ -178,10 +211,17 @@ static int ccm_calculate_first_block_if_ready(mbedtls_ccm_context *ctx)
     }
 
     /* Start CBC-MAC with first block*/
+#if defined(MBEDTLS_CIPHER_C)
     if ((ret = mbedtls_cipher_update(&ctx->cipher_ctx, ctx->y, 16, ctx->y, &olen)) != 0) {
         ctx->state |= CCM_STATE__ERROR;
         return ret;
     }
+#else
+    if ((ret = mbedtls_block_cipher_encrypt(&ctx->block_cipher_ctx, ctx->y, ctx->y)) != 0) {
+        ctx->state |= CCM_STATE__ERROR;
+        return ret;
+    }
+#endif
 
     return 0;
 }
@@ -258,7 +298,10 @@ int mbedtls_ccm_update_ad(mbedtls_ccm_context *ctx,
                           size_t add_len)
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
-    size_t olen, use_len, offset;
+    size_t use_len, offset;
+#if defined(MBEDTLS_CIPHER_C)
+    size_t olen;
+#endif
 
     if (ctx->state & CCM_STATE__ERROR) {
         return MBEDTLS_ERR_CCM_BAD_INPUT;
@@ -298,8 +341,12 @@ int mbedtls_ccm_update_ad(mbedtls_ccm_context *ctx,
             add += use_len;
 
             if (use_len + offset == 16 || ctx->processed == ctx->add_len) {
-                if ((ret =
-                         mbedtls_cipher_update(&ctx->cipher_ctx, ctx->y, 16, ctx->y, &olen)) != 0) {
+#if defined(MBEDTLS_CIPHER_C)
+                ret = mbedtls_cipher_update(&ctx->cipher_ctx, ctx->y, 16, ctx->y, &olen);
+#else
+                ret = mbedtls_block_cipher_encrypt(&ctx->block_cipher_ctx, ctx->y, ctx->y);
+#endif
+                if (ret != 0) {
                     ctx->state |= CCM_STATE__ERROR;
                     return ret;
                 }
@@ -322,7 +369,10 @@ int mbedtls_ccm_update(mbedtls_ccm_context *ctx,
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     unsigned char i;
-    size_t use_len, offset, olen;
+    size_t use_len, offset;
+#if defined(MBEDTLS_CIPHER_C)
+    size_t olen;
+#endif
 
     unsigned char local_output[16];
 
@@ -360,8 +410,12 @@ int mbedtls_ccm_update(mbedtls_ccm_context *ctx,
             mbedtls_xor(ctx->y + offset, ctx->y + offset, input, use_len);
 
             if (use_len + offset == 16 || ctx->processed == ctx->plaintext_len) {
-                if ((ret =
-                         mbedtls_cipher_update(&ctx->cipher_ctx, ctx->y, 16, ctx->y, &olen)) != 0) {
+#if defined(MBEDTLS_CIPHER_C)
+                ret = mbedtls_cipher_update(&ctx->cipher_ctx, ctx->y, 16, ctx->y, &olen);
+#else
+                ret = mbedtls_block_cipher_encrypt(&ctx->block_cipher_ctx, ctx->y, ctx->y);
+#endif
+                if (ret != 0) {
                     ctx->state |= CCM_STATE__ERROR;
                     goto exit;
                 }
@@ -391,8 +445,12 @@ int mbedtls_ccm_update(mbedtls_ccm_context *ctx,
             memcpy(output, local_output, use_len);
 
             if (use_len + offset == 16 || ctx->processed == ctx->plaintext_len) {
-                if ((ret =
-                         mbedtls_cipher_update(&ctx->cipher_ctx, ctx->y, 16, ctx->y, &olen)) != 0) {
+#if defined(MBEDTLS_CIPHER_C)
+                ret = mbedtls_cipher_update(&ctx->cipher_ctx, ctx->y, 16, ctx->y, &olen);
+#else
+                ret = mbedtls_block_cipher_encrypt(&ctx->block_cipher_ctx, ctx->y, ctx->y);
+#endif
+                if (ret != 0) {
                     ctx->state |= CCM_STATE__ERROR;
                     goto exit;
                 }

--- a/library/gcm.c
+++ b/library/gcm.c
@@ -68,15 +68,13 @@ static int gcm_gen_table(mbedtls_gcm_context *ctx)
 
 #if defined(MBEDTLS_CIPHER_C)
     size_t olen = 0;
-
-    if ((ret = mbedtls_cipher_update(&ctx->cipher_ctx, h, 16, h, &olen)) != 0) {
-        return ret;
-    }
+    ret = mbedtls_cipher_update(&ctx->cipher_ctx, h, 16, h, &olen);
 #else
-    if ((ret = mbedtls_block_cipher_encrypt(&ctx->block_cipher_ctx, h, h)) != 0) {
+    ret = mbedtls_block_cipher_encrypt(&ctx->block_cipher_ctx, h, h);
+#endif
+    if (ret != 0) {
         return ret;
     }
-#endif
 
     /* pack h as two 64-bits ints, big-endian */
     hi = MBEDTLS_GET_UINT32_BE(h,  0);
@@ -323,16 +321,13 @@ int mbedtls_gcm_starts(mbedtls_gcm_context *ctx,
 
 
 #if defined(MBEDTLS_CIPHER_C)
-    if ((ret = mbedtls_cipher_update(&ctx->cipher_ctx, ctx->y, 16,
-                                     ctx->base_ectr, &olen)) != 0) {
-        return ret;
-    }
+    ret = mbedtls_cipher_update(&ctx->cipher_ctx, ctx->y, 16, ctx->base_ectr, &olen);
 #else
-    if ((ret = mbedtls_block_cipher_encrypt(&ctx->block_cipher_ctx, ctx->y,
-                                            ctx->base_ectr)) != 0) {
+    ret = mbedtls_block_cipher_encrypt(&ctx->block_cipher_ctx, ctx->y, ctx->base_ectr);
+#endif
+    if (ret != 0) {
         return ret;
     }
-#endif
 
     return 0;
 }
@@ -423,22 +418,17 @@ static int gcm_mask(mbedtls_gcm_context *ctx,
                     unsigned char *output)
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
+
 #if defined(MBEDTLS_CIPHER_C)
     size_t olen = 0;
-
-    if ((ret = mbedtls_cipher_update(&ctx->cipher_ctx, ctx->y, 16, ectr,
-                                     &olen)) != 0) {
-        mbedtls_platform_zeroize(ectr, 16);
-        return ret;
-    }
-
+    ret = mbedtls_cipher_update(&ctx->cipher_ctx, ctx->y, 16, ectr, &olen);
 #else
-
-    if ((ret = mbedtls_block_cipher_encrypt(&ctx->block_cipher_ctx, ctx->y, ectr)) != 0) {
+    ret = mbedtls_block_cipher_encrypt(&ctx->block_cipher_ctx, ctx->y, ectr);
+#endif
+    if (ret != 0) {
         mbedtls_platform_zeroize(ectr, 16);
         return ret;
     }
-#endif
 
     if (ctx->mode == MBEDTLS_GCM_DECRYPT) {
         mbedtls_xor(ctx->buf + offset, ctx->buf + offset, input, use_len);

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1538,9 +1538,7 @@ component_test_full_no_cipher () {
     # (currently ignored anyway because we completely disable PSA)
     scripts/config.py unset MBEDTLS_PSA_CRYPTO_CONFIG
     # Disable features that depend on CIPHER_C
-    scripts/config.py unset MBEDTLS_CCM_C
     scripts/config.py unset MBEDTLS_CMAC_C
-    scripts/config.py unset MBEDTLS_GCM_C
     scripts/config.py unset MBEDTLS_NIST_KW_C
     scripts/config.py unset MBEDTLS_PKCS12_C
     scripts/config.py unset MBEDTLS_PKCS5_C
@@ -1553,7 +1551,6 @@ component_test_full_no_cipher () {
     scripts/config.py unset MBEDTLS_USE_PSA_CRYPTO
     scripts/config.py unset MBEDTLS_LMS_C
     scripts/config.py unset MBEDTLS_LMS_PRIVATE
-    make CFLAGS='-DMBEDTLS_BLOCK_CIPHER_C'
 
     msg "test: full no CIPHER no PSA_CRYPTO_C"
     make test


### PR DESCRIPTION
## Description

Resolves #8060

## PR checklist

- [x] **changelog** provided
- [x] **backport** not required because it's an enhancement
- [x] **tests** provided: GCM/CCM modules are already tested with proper test suites and a build where they use the new module was added to `all.sh`.