### PR TITLE
Backport 2.28: Fix error handling for secure element keys in `psa_start_key_creation`

### DIFF
--- a/ChangeLog.d/fix-secure-element-key-creation.txt
+++ b/ChangeLog.d/fix-secure-element-key-creation.txt
@@ -1,0 +1,5 @@
+Bugfix
+   * Fix error handling when creating a key in a dynamic secure element
+     (feature enabled by MBEDTLS_PSA_CRYPTO_SE_C). In a low memory condition,
+     the creation could return PSA_SUCCESS but using or destroying the key
+     would not work. Fixes #8537.

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -1711,7 +1711,7 @@ static psa_status_t psa_start_key_creation(
         status = psa_copy_key_material_into_slot(
             slot, (uint8_t *) (&slot_number), sizeof(slot_number));
         if (status != PSA_SUCCESS) {
-                return status;
+            return status;
         }
     }
 

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -1710,6 +1710,9 @@ static psa_status_t psa_start_key_creation(
 
         status = psa_copy_key_material_into_slot(
             slot, (uint8_t *) (&slot_number), sizeof(slot_number));
+        if (status != PSA_SUCCESS) {
+                return status;
+        }
     }
 
     if (*p_drv == NULL && method == PSA_KEY_CREATION_REGISTER) {


### PR DESCRIPTION
## Description

Trivial backport of #8538. Add some error handling for the call to `psa_copy_key_material_into_slot` in `psa_start_key_creation`. Fixes #8537

## PR checklist

- [x] **changelog** provided
- [x] **backport** of #8538 
- [x] **tests** not required, we cannot test out of memory issues
