### PR TITLE
[cipher.h]  Arithmetic overflow in binary left shift operation

### DIFF
--- a/include/mbedtls/cipher.h
+++ b/include/mbedtls/cipher.h
@@ -480,7 +480,7 @@ static inline size_t mbedtls_cipher_info_get_key_bitlen(
     if (info == NULL) {
         return 0;
     } else {
-        return info->MBEDTLS_PRIVATE(key_bitlen) << MBEDTLS_KEY_BITLEN_SHIFT;
+        return ((size_t) info->MBEDTLS_PRIVATE(key_bitlen)) << MBEDTLS_KEY_BITLEN_SHIFT;
     }
 }
 


### PR DESCRIPTION
Fixing arithmetic overflow warning (C6297), if compiled in Visual Studio


## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required
- [x] **backport** not in 2.28
- [x] **tests** not required - no functional change