### PR TITLE
Modify changelog assembly to work with tf-psa-crypto

### DIFF
--- a/scripts/assemble_changelog.py
+++ b/scripts/assemble_changelog.py
@@ -115,7 +115,7 @@ class ChangelogFormat:
 class TextChangelogFormat(ChangelogFormat):
     """The traditional Mbed TLS changelog format."""
 
-    _unreleased_version_text = '= Mbed TLS x.x.x branch released xxxx-xx-xx'
+    _unreleased_version_text = '= {} x.x.x branch released xxxx-xx-xx'
     @classmethod
     def is_released_version(cls, title):
         # Look for an incomplete release date
@@ -123,6 +123,7 @@ class TextChangelogFormat(ChangelogFormat):
 
     _top_version_re = re.compile(r'(?:\A|\n)(=[^\n]*\n+)(.*?\n)(?:=|$)',
                                  re.DOTALL)
+    _name_re = re.compile(r'=\s(.*)\s[0-9x]+\.', re.DOTALL)
     @classmethod
     def extract_top_version(cls, changelog_file_content):
         """A version section starts with a line starting with '='."""
@@ -132,15 +133,17 @@ class TextChangelogFormat(ChangelogFormat):
             top_version_end = m.end(2)
             top_version_title = m.group(1)
             top_version_body = m.group(2)
+            name = re.match(cls._name_re, top_version_title).group(1)
         # No entries found
         else:
             top_version_start = None
             top_version_end = None
+            name = 'xxx'
             top_version_title = ''
             top_version_body = ''
         if cls.is_released_version(top_version_title):
             top_version_end = top_version_start
-            top_version_title = cls._unreleased_version_text + '\n\n'
+            top_version_title = cls._unreleased_version_text.format(name) + '\n\n'
             top_version_body = ''
         return (changelog_file_content[:top_version_start],
                 top_version_title, top_version_body,

--- a/scripts/assemble_changelog.py
+++ b/scripts/assemble_changelog.py
@@ -128,19 +128,11 @@ class TextChangelogFormat(ChangelogFormat):
     def extract_top_version(cls, changelog_file_content):
         """A version section starts with a line starting with '='."""
         m = re.search(cls._top_version_re, changelog_file_content)
-        if m:
-            top_version_start = m.start(1)
-            top_version_end = m.end(2)
-            top_version_title = m.group(1)
-            top_version_body = m.group(2)
-            name = re.match(cls._name_re, top_version_title).group(1)
-        # No entries found
-        else:
-            top_version_start = None
-            top_version_end = None
-            name = 'xxx'
-            top_version_title = ''
-            top_version_body = ''
+        top_version_start = m.start(1)
+        top_version_end = m.end(2)
+        top_version_title = m.group(1)
+        top_version_body = m.group(2)
+        name = re.match(cls._name_re, top_version_title).group(1)
         if cls.is_released_version(top_version_title):
             top_version_end = top_version_start
             top_version_title = cls._unreleased_version_text.format(name) + '\n\n'
@@ -272,10 +264,8 @@ class ChangeLog:
         """Write the changelog to the specified file.
         """
         with open(filename, 'w', encoding='utf-8') as out:
-            if self.header:
-                out.write(self.header)
-            if self.top_version_title:
-                out.write(self.top_version_title)
+            out.write(self.header)
+            out.write(self.top_version_title)
             for title, body in self.categories.items():
                 if not body:
                     continue

--- a/scripts/assemble_changelog.py
+++ b/scripts/assemble_changelog.py
@@ -246,10 +246,7 @@ class ChangeLog:
         self.categories = OrderedDict()
         for category in STANDARD_CATEGORIES:
             self.categories[category] = ''
-        if self.header:
-            offset = (self.header + self.top_version_title).count('\n') + 1
-        else:
-            offset = 0
+        offset = (self.header + self.top_version_title).count('\n') + 1
 
         self.add_categories_from_text(input_stream.name, offset,
                                       top_version_body, True)


### PR DESCRIPTION
## Description

This PR is part of Mbed-TLS/TF-PSA-Crypto#47.

Add support to specify the name of the project from the previous entries.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required, only internal change
- [x] **backport** not required, new feature
- [x] **tests** not required, already exists
