### PR TITLE
Backport 2.28: Fix test_suite_platform failure with Asan on modern Clang

### DIFF
--- a/tests/include/test/helpers.h
+++ b/tests/include/test/helpers.h
@@ -19,6 +19,21 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#if defined(__SANITIZE_ADDRESS__) /* gcc -fsanitize=address */
+#  define MBEDTLS_TEST_HAVE_ASAN
+#endif
+#if defined(__has_feature)
+#  if __has_feature(address_sanitizer) /* clang -fsanitize=address */
+#    define MBEDTLS_TEST_HAVE_ASAN
+#  endif
+#  if __has_feature(memory_sanitizer) /* clang -fsanitize=memory */
+#    define MBEDTLS_TEST_HAVE_MSAN
+#  endif
+#  if __has_feature(thread_sanitizer) /* clang -fsanitize=thread */
+#    define MBEDTLS_TEST_HAVE_TSAN
+#  endif
+#endif
+
 #if defined(MBEDTLS_THREADING_C) && defined(MBEDTLS_THREADING_PTHREAD) && \
     defined(MBEDTLS_TEST_HOOKS)
 #define MBEDTLS_TEST_MUTEX_USAGE


### PR DESCRIPTION
Backport of https://github.com/Mbed-TLS/mbedtls/pull/8286. The problematic test case doesn't exist in 2.28, but backport the new helper macros.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** no (test only)
- [x] **backport** of https://github.com/Mbed-TLS/mbedtls/pull/8286
- [x] **tests** N/A
