### PR TITLE
Fixed compilation for Haiku OS

### DIFF
--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -243,10 +243,10 @@ extern inline void mbedtls_put_unaligned_uint64(void *p, uint64_t x);
 #include <time.h>
 #if !defined(_WIN32) && \
     (defined(unix) || defined(__unix) || defined(__unix__) || \
-    (defined(__APPLE__) && defined(__MACH__)))
+    (defined(__APPLE__) && defined(__MACH__)) || defined(__HAIKU__))
 #include <unistd.h>
-#endif /* !_WIN32 && (unix || __unix || __unix__ || (__APPLE__ && __MACH__)) */
-#if (defined(_POSIX_VERSION) && _POSIX_VERSION >= 199309L)
+#endif /* !_WIN32 && (unix || __unix || __unix__ || (__APPLE__ && __MACH__) || defined(__HAIKU__)) */
+#if (defined(_POSIX_VERSION) && _POSIX_VERSION >= 199309L) || defined(__HAIKU__)
 mbedtls_ms_time_t mbedtls_ms_time(void)
 {
     int ret;

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -245,7 +245,7 @@ extern inline void mbedtls_put_unaligned_uint64(void *p, uint64_t x);
     (defined(unix) || defined(__unix) || defined(__unix__) || \
     (defined(__APPLE__) && defined(__MACH__)) || defined(__HAIKU__))
 #include <unistd.h>
-#endif /* !_WIN32 && (unix || __unix || __unix__ || (__APPLE__ && __MACH__) || defined(__HAIKU__)) */
+#endif /* !_WIN32 && (unix || __unix || __unix__ || (__APPLE__ && __MACH__) || __HAIKU__) */
 #if (defined(_POSIX_VERSION) && _POSIX_VERSION >= 199309L) || defined(__HAIKU__)
 mbedtls_ms_time_t mbedtls_ms_time(void)
 {


### PR DESCRIPTION
Related to: https://github.com/Mbed-TLS/mbedtls/issues/8562

## Description

Without this change I was not able to compile for Haiku OS

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required for a compile fix for a niche platform
- [x] **backport** not required
- [x] **tests** not required - we don't have Haiku in the CI
