### PR TITLE
Driver-only: G1: clean up for BLOCK_CIPHER_NO_DECRYPT

### DIFF
--- a/configs/ext/tfm_mbedcrypto_config_profile_medium.h
+++ b/configs/ext/tfm_mbedcrypto_config_profile_medium.h
@@ -326,6 +326,28 @@
 #define MBEDTLS_AES_C
 
 /**
+ * \def MBEDTLS_BLOCK_CIPHER_NO_DECRYPT
+ *
+ * Remove decryption operation for AES, ARIA and Camellia block cipher.
+ *
+ * \note  This feature is incompatible with insecure block cipher,
+ *        MBEDTLS_DES_C, and cipher modes which always require decryption
+ *        operation, MBEDTLS_CIPHER_MODE_CBC, MBEDTLS_CIPHER_MODE_XTS and
+ *        MBEDTLS_NIST_KW_C. When #MBEDTLS_PSA_CRYPTO_CONFIG is enabled,
+ *        this feature is incompatible with following supported PSA equivalence,
+ *        PSA_WANT_ALG_ECB_NO_PADDING, PSA_WANT_ALG_CBC_NO_PADDING,
+ *        PSA_WANT_ALG_CBC_PKCS7 and PSA_WANT_KEY_TYPE_DES.
+ *
+ * Module:  library/aes.c
+ *          library/aesce.c
+ *          library/aesni.c
+ *          library/aria.c
+ *          library/camellia.c
+ *          library/cipher.c
+ */
+#define MBEDTLS_BLOCK_CIPHER_NO_DECRYPT
+
+/**
  * \def MBEDTLS_CIPHER_C
  *
  * Enable the generic cipher layer.

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -2382,7 +2382,10 @@
  * \note  This feature is incompatible with insecure block cipher,
  *        MBEDTLS_DES_C, and cipher modes which always require decryption
  *        operation, MBEDTLS_CIPHER_MODE_CBC, MBEDTLS_CIPHER_MODE_XTS and
- *        MBEDTLS_NIST_KW_C.
+ *        MBEDTLS_NIST_KW_C. When #MBEDTLS_PSA_CRYPTO_CONFIG is enabled,
+ *        this feature is incompatible with following supported PSA equivalence,
+ *        PSA_WANT_ALG_ECB_NO_PADDING, PSA_WANT_ALG_CBC_NO_PADDING,
+ *        PSA_WANT_ALG_CBC_PKCS7 and PSA_WANT_KEY_TYPE_DES.
  *
  * Module:  library/aes.c
  *          library/aesce.c


### PR DESCRIPTION
## Description

Fix #8356


## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required
- [x] **backport** not required (new feature)
- [x] **tests** not required