### PR TITLE
fix build warning with arm64 gcc 5.4

### DIFF
--- a/library/common.h
+++ b/library/common.h
@@ -165,7 +165,10 @@ static inline const unsigned char *mbedtls_buffer_offset_const(
  * \param   b Pointer to input (buffer of at least \p n bytes)
  * \param   n Number of bytes to process.
  */
-inline void mbedtls_xor(unsigned char *r, const unsigned char *a, const unsigned char *b, size_t n)
+static inline void mbedtls_xor(unsigned char *r,
+                               const unsigned char *a,
+                               const unsigned char *b,
+                               size_t n)
 {
     size_t i = 0;
 #if defined(MBEDTLS_EFFICIENT_UNALIGNED_ACCESS)


### PR DESCRIPTION
## Description

GCC 5.4 reports below warning on Arm64
```
warning: 'vst1q_u8' is static but used in inline function 'mbedtls_xor' which is not static
```
This inline function miss `static`, others have the keyword

## PR checklist

- [ ] **changelog** not required( This is a warning fix)
- [ ] **backport** done, or not required
- [ ] **tests** not required( This is a warning fix)


