### PR TITLE
fix ciphersuite list fail

### DIFF
--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -358,7 +358,7 @@ requires_protocol_version() {
 
 # Space-separated list of ciphersuites supported by this build of
 # Mbed TLS.
-P_CIPHERSUITES=" $($P_CLI --help 2>/dev/null |
+P_CIPHERSUITES=" $($P_CLI help_ciphersuites 2>/dev/null |
                    grep 'TLS-\|TLS1-3' |
                    tr -s ' \n' ' ')"
 requires_ciphersuite_enabled() {


### PR DESCRIPTION
## Description

Ciphersuite list has been changed from $PROG --help to $PROG help_ciphersuites . With old parameter, the script can not receive any ciphersuite.


## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required (This is test script bug fix)
- [x] **backport** done(#8570)
- [x] **tests** provided (This is test script bug fix)

