### PR TITLE
Disable hw AES on Arm for IAR

### DIFF
--- a/library/aesce.c
+++ b/library/aesce.c
@@ -45,7 +45,7 @@
 
 #include "aesce.h"
 
-#if defined(MBEDTLS_ARCH_IS_ARMV8_A) && defined(__ARM_NEON)
+#if defined(MBEDTLS_AESCE_HAVE_CODE)
 
 /* Compiler version checks. */
 #if defined(__clang__)

--- a/library/aesce.h
+++ b/library/aesce.h
@@ -15,12 +15,17 @@
 #define MBEDTLS_AESCE_H
 
 #include "mbedtls/build_info.h"
+#include "common.h"
 
 #include "mbedtls/aes.h"
 
 
-#if defined(MBEDTLS_AESCE_C) && defined(MBEDTLS_ARCH_IS_ARMV8_A) && defined(__ARM_NEON)
+#if defined(MBEDTLS_AESCE_C) && defined(MBEDTLS_ARCH_IS_ARMV8_A) && defined(__ARM_NEON) \
+    && (defined(MBEDTLS_COMPILER_IS_GCC) || defined(__clang__) || defined(MSC_VER))
 
+/* MBEDTLS_AESCE_HAVE_CODE is defined if we have a suitable target platform, and a
+ * potentially suitable compiler (compiler version & flags are not checked when defining
+ * this). */
 #define MBEDTLS_AESCE_HAVE_CODE
 
 #ifdef __cplusplus
@@ -121,9 +126,10 @@ int mbedtls_aesce_setkey_enc(unsigned char *rk,
 #else
 
 #if defined(MBEDTLS_AES_USE_HARDWARE_ONLY) && defined(MBEDTLS_ARCH_IS_ARMV8_A)
-#error "AES hardware acceleration not supported on this platform"
+#error "AES hardware acceleration not supported on this platform / compiler"
 #endif
 
-#endif /* MBEDTLS_AESCE_C && MBEDTLS_ARCH_IS_ARMV8_A && __ARM_NEON */
+#endif /* MBEDTLS_AESCE_C && MBEDTLS_ARCH_IS_ARMV8_A && __ARM_NEON &&
+          (MBEDTLS_COMPILER_IS_GCC || __clang__ || MSC_VER) */
 
 #endif /* MBEDTLS_AESCE_H */


### PR DESCRIPTION
## Description

Ensures clean out-of-box build under IAR. Currently we see a lot of errors from IAR trying to compile AESCE code (regression due to #8326).

Ensure that IAR either produces a clear error message, if `MBEDTLS_AES_USE_HARDWARE_ONLY` is set, or quietly disables AESCE (as clang and gcc do, if on a non-supported platform), if `MBEDTLS_AESCE_C` is set and `MBEDTLS_AES_USE_HARDWARE_ONLY` is unset.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required
- [x] **backport** not required
- [x] **tests** covered by existing
