### PR TITLE
Fix wrong suite name in check_test_cases.py

### DIFF
--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -125,7 +125,7 @@ print_usage() {
 print_test_case() {
     for i in $3; do
         uniform_title $1 $2 $i
-        echo $TITLE
+        echo "compat;$TITLE"
     done
 }
 

--- a/tests/scripts/analyze_outcomes.py
+++ b/tests/scripts/analyze_outcomes.py
@@ -85,7 +85,12 @@ def execute_reference_driver_tests(results: Results, ref_component: str, driver_
 def analyze_coverage(results: Results, outcomes: Outcomes,
                      allow_list: typing.List[str], full_coverage: bool) -> None:
     """Check that all available test cases are executed at least once."""
-    available = check_test_cases.collect_available_test_cases()
+    try:
+        available = check_test_cases.collect_available_test_cases()
+    except check_test_cases.ScriptOutputError:
+        results.error("fail to collect available test cases")
+        return
+
     for suite_case in available:
         hit = any(suite_case in comp_outcomes.successes or
                   suite_case in comp_outcomes.failures

--- a/tests/scripts/analyze_outcomes.py
+++ b/tests/scripts/analyze_outcomes.py
@@ -85,12 +85,7 @@ def execute_reference_driver_tests(results: Results, ref_component: str, driver_
 def analyze_coverage(results: Results, outcomes: Outcomes,
                      allow_list: typing.List[str], full_coverage: bool) -> None:
     """Check that all available test cases are executed at least once."""
-    try:
-        available = check_test_cases.collect_available_test_cases()
-    except check_test_cases.ScriptOutputError:
-        results.error("fail to collect available test cases")
-        return
-
+    available = check_test_cases.collect_available_test_cases()
     for suite_case in available:
         hit = any(suite_case in comp_outcomes.successes or
                   suite_case in comp_outcomes.failures

--- a/tests/scripts/check_test_cases.py
+++ b/tests/scripts/check_test_cases.py
@@ -172,6 +172,15 @@ class DescriptionChecker(TestDescriptionExplorer):
         """Check test case descriptions for errors."""
         results = self.results
         seen = per_file_state
+        if not file_name.endswith('.data'):
+            script_output = description.split(b';', 1)
+            if len(script_output) == 2:
+                description = script_output[1]
+            else:
+                results.error(file_name, line_number,
+                              '"{}" should be listed in '
+                              '"<suite>;<description>" format',
+                              description.decode('ascii'))
         if description in seen:
             results.error(file_name, line_number,
                           'Duplicate description (also line {})',

--- a/tests/scripts/check_test_cases.py
+++ b/tests/scripts/check_test_cases.py
@@ -137,8 +137,14 @@ class TestDescriptions(TestDescriptionExplorer):
     def process_test_case(self, _per_file_state,
                           file_name, _line_number, description):
         """Record an available test case."""
-        base_name = re.sub(r'\.[^.]*$', '', re.sub(r'.*/', '', file_name))
-        key = ';'.join([base_name, description.decode('utf-8')])
+        if file_name.endswith('.data'):
+            base_name = re.sub(r'\.[^.]*$', '', re.sub(r'.*/', '', file_name))
+            key = ';'.join([base_name, description.decode('utf-8')])
+        else:
+            # For test cases defined in scripts (i.e. ssl-op.sh and compat.sh),
+            # we need the script to list the suite name, and use the outputs
+            # as keys directly.
+            key = description.decode('utf-8')
         self.descriptions.add(key)
 
 def collect_available_test_cases():

--- a/tests/scripts/check_test_cases.py
+++ b/tests/scripts/check_test_cases.py
@@ -149,8 +149,7 @@ option"""
 
             for sh_file in ['ssl-opt.sh', 'compat.sh']:
                 sh_file = os.path.join(directory, sh_file)
-                if os.path.exists(sh_file):
-                    self.collect_from_script(sh_file)
+                self.collect_from_script(sh_file)
 
 class TestDescriptions(TestDescriptionExplorer):
     """Collect the available test cases."""

--- a/tests/scripts/check_test_cases.py
+++ b/tests/scripts/check_test_cases.py
@@ -16,6 +16,23 @@ import re
 import subprocess
 import sys
 
+class ScriptOutputError(ValueError):
+    """A kind of ValueError that indicates we found
+    the script doesn't list test cases in an expected
+    pattern.
+    """
+
+    @property
+    def script_name(self):
+        return super().args[0]
+
+    @property
+    def idx(self):
+        return super().args[1]
+
+    @property
+    def line(self):
+        return super().args[2]
 
 class Results:
     """Store file and line information about errors or warnings in test suites."""
@@ -86,19 +103,27 @@ state may override this method.
                                            data_file_name, line_number, line)
                 in_paragraph = True
 
-    def collect_from_script(self, file_name):
+    def collect_from_script(self, script_name):
         """Collect the test cases in a script by calling its listing test cases
 option"""
         descriptions = self.new_per_file_state() # pylint: disable=assignment-from-none
-        listed = subprocess.check_output(['sh', file_name, '--list-test-cases'])
+        listed = subprocess.check_output(['sh', script_name, '--list-test-cases'])
         # Assume test file is responsible for printing identical format of
         # test case description between --list-test-cases and its OUTCOME.CSV
         #
         # idx indicates the number of test case since there is no line number
         # in the script for each test case.
-        for idx, description in enumerate(listed.splitlines()):
+        for idx, line in enumerate(listed.splitlines()):
+            # We are expecting the script to list the test cases in
+            # `<suite_name>;<description>` pattern.
+            script_outputs = line.split(b';', 1)
+            if len(script_outputs) == 2:
+                suite_name, description = script_outputs
+            else:
+                raise ScriptOutputError(script_name, idx, line.decode("utf-8"))
+
             self.process_test_case(descriptions,
-                                   file_name,
+                                   suite_name.decode('utf-8'),
                                    idx,
                                    description.rstrip())
 
@@ -137,14 +162,8 @@ class TestDescriptions(TestDescriptionExplorer):
     def process_test_case(self, _per_file_state,
                           file_name, _line_number, description):
         """Record an available test case."""
-        if file_name.endswith('.data'):
-            base_name = re.sub(r'\.[^.]*$', '', re.sub(r'.*/', '', file_name))
-            key = ';'.join([base_name, description.decode('utf-8')])
-        else:
-            # For test cases defined in scripts (i.e. ssl-op.sh and compat.sh),
-            # we need the script to list the suite name, and use the outputs
-            # as keys directly.
-            key = description.decode('utf-8')
+        base_name = re.sub(r'\.[^.]*$', '', re.sub(r'.*/', '', file_name))
+        key = ';'.join([base_name, description.decode('utf-8')])
         self.descriptions.add(key)
 
 def collect_available_test_cases():
@@ -172,15 +191,6 @@ class DescriptionChecker(TestDescriptionExplorer):
         """Check test case descriptions for errors."""
         results = self.results
         seen = per_file_state
-        if not file_name.endswith('.data'):
-            script_output = description.split(b';', 1)
-            if len(script_output) == 2:
-                description = script_output[1]
-            else:
-                results.error(file_name, line_number,
-                              '"{}" should be listed in '
-                              '"<suite>;<description>" format',
-                              description.decode('ascii'))
         if description in seen:
             results.error(file_name, line_number,
                           'Duplicate description (also line {})',
@@ -217,7 +227,12 @@ def main():
         return
     results = Results(options)
     checker = DescriptionChecker(results)
-    checker.walk_all()
+    try:
+        checker.walk_all()
+    except ScriptOutputError as e:
+        results.error(e.script_name, e.idx,
+                      '"{}" should be listed as "<suite_name>;<description>"',
+                      e.line)
     if (results.warnings or results.errors) and not options.quiet:
         sys.stderr.write('{}: {} errors, {} warnings\n'
                          .format(sys.argv[0], results.errors, results.warnings))

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -1620,7 +1620,7 @@ run_test() {
     fi
 
     if [ "$LIST_TESTS" -gt 0 ]; then
-        printf "%s\n" "$NAME"
+        printf "%s\n" "${TEST_SUITE_NAME:-ssl-opt};$NAME"
         return
     fi
 


### PR DESCRIPTION
## Description

~Depends on: #8561~
Same topic: #8586, #8594
Fix: https://github.com/Mbed-TLS/mbedtls/pull/8561#issuecomment-1831125509

In `analyze_outcomes.py`, we use "\<suite\>;\<case\>" generated by `check_test_cases.py` as keys and check if they are excuted at lease once. So, it is critical to make the generated keys consistent with that in the outcomes files.



## PR checklist
- [x] **changelog** not required, test script change.
- [x] **backport** [No](https://github.com/Mbed-TLS/mbedtls/pull/8575#issuecomment-1850850149) (`ssl-opt.sh` is not split in 2.28)
- [x] **tests** not required.

