### PR TITLE
TLS13: CLI: EarlyData: Assign ciphersuite after associated verification in EE

### DIFF
--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -2182,14 +2182,15 @@ static int ssl_tls13_process_encrypted_extensions(mbedtls_ssl_context *ssl)
          * - The selected cipher suite
          * - The selected ALPN [RFC7301] protocol, if any
          *
-         * When parsing EncryptedExtensions, the client does not know if
-         * the server will accept early data and select the first proposed
-         * pre-shared key with a cipher suite that is different from the
-         * cipher suite associated to the selected pre-shared key. To address
-         * aforementioned case, when early data is involved, we check:
-         * - the selected pre-shared key is the first proposed one
-         * - the selected cipher suite same as the one associated with the
-         *   pre-shared key.
+         * The server has sent an early data extension in its Encrypted
+         * Extension message thus accepted to receive early data. We
+         * check here that the additional constraints on the handshake
+         * parameters, when early data are exchanged, are met,
+         * namely:
+         * - the selected PSK for the handshake was the first one proposed
+         *   by the client.
+         * - the selected ciphersuite for the handshake is the ciphersuite
+         *   associated with the selected PSK.
          */
         if (handshake->selected_identity != 0 ||
             handshake->ciphersuite_info->id !=

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -2152,9 +2152,7 @@ static int ssl_tls13_process_encrypted_extensions(mbedtls_ssl_context *ssl)
     int ret;
     unsigned char *buf;
     size_t buf_len;
-#if defined(MBEDTLS_SSL_EARLY_DATA)
     mbedtls_ssl_handshake_params *handshake = ssl->handshake;
-#endif
 
     MBEDTLS_SSL_DEBUG_MSG(2, ("=> parse encrypted extensions"));
 

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -2207,8 +2207,7 @@ static int ssl_tls13_process_encrypted_extensions(mbedtls_ssl_context *ssl)
 
     /*
      * Move `session_negotiate->ciphersuite` assignment here which after
-     * early data cipher suite check when receiving "early_data" extension
-     * in EncryptedExtensions.
+     * early data cipher suite check.
      *
      * We compute transform_handshake by the cipher suite chosen from
      * the server in `handshake`. `session_negotiate->ciphersuite` is the

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -2207,13 +2207,14 @@ static int ssl_tls13_process_encrypted_extensions(mbedtls_ssl_context *ssl)
 #endif
 
     /*
-     * Move `session_negotiate->ciphersuite` assignment here which after
-     * early data cipher suite check.
-     *
-     * We compute transform_handshake by the cipher suite chosen from
-     * the server in `handshake`. `session_negotiate->ciphersuite` is the
-     * cipher suite negotiated in previous connection and it is not used for
-     * computing transform_handshake.
+     * In case the client has proposed a PSK associated with a ticket,
+     * `ssl->session_negotiate->ciphersuite` still contains at this point the
+     * identifier of the ciphersuite associated with the ticket. This is that
+     * way because, if an exchange of early data is agreed upon, we need
+     * it to check that the ciphersuite selected for the handshake is the
+     * ticket ciphersuite (see above). This information is not needed
+     * anymore thus we can now set it to the identifier of the ciphersuite
+     * used in this session under negotiation.
      */
     ssl->session_negotiate->ciphersuite = handshake->ciphersuite_info->id;
 

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -2187,12 +2187,14 @@ static int ssl_tls13_process_encrypted_extensions(mbedtls_ssl_context *ssl)
          * check here that the additional constraints on the handshake
          * parameters, when early data are exchanged, are met,
          * namely:
+         * - a PSK has been selected for the handshake
          * - the selected PSK for the handshake was the first one proposed
          *   by the client.
          * - the selected ciphersuite for the handshake is the ciphersuite
          *   associated with the selected PSK.
          */
-        if (handshake->selected_identity != 0 ||
+        if ((!mbedtls_ssl_tls13_key_exchange_mode_with_psk(ssl)) ||
+            handshake->selected_identity != 0 ||
             handshake->ciphersuite_info->id !=
             ssl->session_negotiate->ciphersuite) {
 


### PR DESCRIPTION
## Description

**Context**: `tls13 early_data` in `ssl_tls13_client.c`

In `ssl_tls13_postprocess_server_hello`, we assign `handshake->ciphersuite_info->id` to `ssl->session_negotiate->ciphersuite`, this doesn't matter in `non-early_data` situation.  But if client sends `early_data ext` in `client_hello` and receives `early_data ext` in `encrypted_extensions`, the aforementioned assignment makes the [check](https://github.com/Mbed-TLS/mbedtls/blob/development/library/ssl_tls13_client.c#L2193) non-functional. Thus we have to do the assignment after the check in `encrypted_extensions`. This won't cause problems of generating handshake keys as we use `handshake->ciphersuite_info->id` to compute the keys in `ssl_tls13_postprocess_server_hello`.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required
- [x] **backport** not required (tls13 bugfix)
- [x] **tests** not required