### PR TITLE
PK parse and PK write: add dependency check with OID

### DIFF
--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -444,6 +444,16 @@
 #error "MBEDTLS_PK_WRITE_C defined, but not all prerequisites"
 #endif
 
+#if defined(MBEDTLS_PK_PARSE_C) && defined(MBEDTLS_PK_HAVE_ECC_KEYS) && \
+    !defined(MBEDTLS_OID_C)
+#error "MBEDTLS_PK_PARSE_C and MBEDTLS_PK_HAVE_ECC_KEYS require MBEDTLS_OID_C"
+#endif
+
+#if defined(MBEDTLS_PK_WRITE_C) && defined(MBEDTLS_PK_HAVE_ECC_KEYS) && \
+    !defined(MBEDTLS_OID_C)
+#error "MBEDTLS_PK_WRITE_C and MBEDTLS_PK_HAVE_ECC_KEYS require MBEDTLS_OID_C"
+#endif
+
 #if defined(MBEDTLS_PLATFORM_EXIT_ALT) && !defined(MBEDTLS_PLATFORM_C)
 #error "MBEDTLS_PLATFORM_EXIT_ALT defined, but not all prerequisites"
 #endif

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -207,10 +207,6 @@
 #error "MBEDTLS_ECP_C defined (or a subset enabled), but not all prerequisites"
 #endif
 
-#if defined(MBEDTLS_PK_PARSE_C) && !defined(MBEDTLS_ASN1_PARSE_C)
-#error "MBEDTLS_PK_PARSE_C defined, but not all prerequisites"
-#endif
-
 #if defined(MBEDTLS_ENTROPY_C) && \
     !(defined(MBEDTLS_MD_CAN_SHA512) || defined(MBEDTLS_MD_CAN_SHA256))
 #error "MBEDTLS_ENTROPY_C defined, but not all prerequisites"
@@ -437,7 +433,9 @@
 #endif
 
 #if defined(MBEDTLS_PK_PARSE_C) && \
-    (!defined(MBEDTLS_PK_C) || !defined(MBEDTLS_OID_C))
+    (!defined(MBEDTLS_ASN1_PARSE_C) || \
+     !defined(MBEDTLS_OID_C)        || \
+     !defined(MBEDTLS_PK_C))
 #error "MBEDTLS_PK_PARSE_C defined, but not all prerequisites"
 #endif
 

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -436,22 +436,14 @@
 #error "MBEDTLS_PK_C defined, but not all prerequisites"
 #endif
 
-#if defined(MBEDTLS_PK_PARSE_C) && !defined(MBEDTLS_PK_C)
+#if defined(MBEDTLS_PK_PARSE_C) && \
+    (!defined(MBEDTLS_PK_C) || !defined(MBEDTLS_OID_C))
 #error "MBEDTLS_PK_PARSE_C defined, but not all prerequisites"
 #endif
 
-#if defined(MBEDTLS_PK_WRITE_C) && !defined(MBEDTLS_PK_C)
+#if defined(MBEDTLS_PK_WRITE_C) && \
+    (!defined(MBEDTLS_PK_C) || !defined(MBEDTLS_OID_C))
 #error "MBEDTLS_PK_WRITE_C defined, but not all prerequisites"
-#endif
-
-#if defined(MBEDTLS_PK_PARSE_C) && defined(MBEDTLS_PK_HAVE_ECC_KEYS) && \
-    !defined(MBEDTLS_OID_C)
-#error "MBEDTLS_PK_PARSE_C and MBEDTLS_PK_HAVE_ECC_KEYS require MBEDTLS_OID_C"
-#endif
-
-#if defined(MBEDTLS_PK_WRITE_C) && defined(MBEDTLS_PK_HAVE_ECC_KEYS) && \
-    !defined(MBEDTLS_OID_C)
-#error "MBEDTLS_PK_WRITE_C and MBEDTLS_PK_HAVE_ECC_KEYS require MBEDTLS_OID_C"
 #endif
 
 #if defined(MBEDTLS_PLATFORM_EXIT_ALT) && !defined(MBEDTLS_PLATFORM_C)

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -440,7 +440,9 @@
 #endif
 
 #if defined(MBEDTLS_PK_WRITE_C) && \
-    (!defined(MBEDTLS_PK_C) || !defined(MBEDTLS_OID_C))
+    (!defined(MBEDTLS_ASN1_WRITE_C) || \
+     !defined(MBEDTLS_OID_C)        || \
+     !defined(MBEDTLS_PK_C))
 #error "MBEDTLS_PK_WRITE_C defined, but not all prerequisites"
 #endif
 

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -3059,7 +3059,7 @@
  * Caller:  library/x509_crt.c
  *          library/x509_csr.c
  *
- * Requires: MBEDTLS_PK_C
+ * Requires: MBEDTLS_PK_C, MBEDTLS_OID_C
  *
  * Uncomment to enable generic public key parse functions.
  */
@@ -3073,7 +3073,7 @@
  * Module:  library/pkwrite.c
  * Caller:  library/x509write.c
  *
- * Requires: MBEDTLS_PK_C
+ * Requires: MBEDTLS_PK_C, MBEDTLS_OID_C
  *
  * Uncomment to enable generic public key write functions.
  */

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -3059,7 +3059,7 @@
  * Caller:  library/x509_crt.c
  *          library/x509_csr.c
  *
- * Requires: MBEDTLS_PK_C, MBEDTLS_OID_C
+ * Requires: MBEDTLS_ASN1_PARSE_C, MBEDTLS_OID_C, MBEDTLS_PK_C
  *
  * Uncomment to enable generic public key parse functions.
  */

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -3073,7 +3073,7 @@
  * Module:  library/pkwrite.c
  * Caller:  library/x509write.c
  *
- * Requires: MBEDTLS_PK_C, MBEDTLS_OID_C
+ * Requires: MBEDTLS_ASN1_WRITE_C, MBEDTLS_OID_C, MBEDTLS_PK_C
  *
  * Uncomment to enable generic public key write functions.
  */

--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -181,13 +181,6 @@ typedef struct mbedtls_pk_rsassa_pss_options {
 #define MBEDTLS_PK_USE_PSA_EC_DATA
 #endif
 
-/* Helper symbol to state that the PK module has support for EC keys. This
- * can either be provided through the legacy ECP solution or through the
- * PSA friendly MBEDTLS_PK_USE_PSA_EC_DATA. */
-#if defined(MBEDTLS_PK_USE_PSA_EC_DATA) || defined(MBEDTLS_ECP_C)
-#define MBEDTLS_PK_HAVE_ECC_KEYS
-#endif /* MBEDTLS_PK_USE_PSA_EC_DATA || MBEDTLS_ECP_C */
-
 /**
  * \brief           Types for interfacing with the debug module
  */

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -681,7 +681,7 @@ void valid_parameters()
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_PK_WRITE_C */
+/* BEGIN_CASE depends_on:MBEDTLS_PK_WRITE_C:MBEDTLS_PK_PARSE_C */
 void valid_parameters_pkwrite(data_t *key_data)
 {
     mbedtls_pk_context pk;


### PR DESCRIPTION
## Description

Fix: #8167

**How to reproduce this issue: (based on f5e46fd)**

1. Add following to `configs/config-tfm.h`
```
#define MBEDTLS_PK_PARSE_C
#define MBEDTLS_PK_WRITE_C
#define MBEDTLS_PK_C
#define MBEDTLS_ASN1_PARSE_C
#define MBEDTLS_ASN1_WRITE_C
#undef MBEDTLS_PSA_P256M_DRIVER_ENABLED
```
2. Run `./tests/scripts/test-ref-configs.pl` for `config-tfm.h`, then see error
```
/usr/bin/ld: ../../library/libmbedcrypto.a(pkparse.o): in function `pk_use_ecparams':
pkparse.c:(.text+0x47): undefined reference to `mbedtls_oid_get_ec_grp'
/usr/bin/ld: ../../library/libmbedcrypto.a(pkparse.o): in function `pk_get_pk_alg':
pkparse.c:(.text+0x122): undefined reference to `mbedtls_oid_get_pk_alg'
/usr/bin/ld: pkparse.c:(.text+0x132): undefined reference to `mbedtls_oid_get_ec_grp_algid'
```

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required - just documenting existing dependencies
- [x] **backport** Not needed
- [x] **tests** not required
