### PR TITLE
Implement locking primitives for PSA subsystem thread safety

### DIFF
--- a/include/psa/crypto_values.h
+++ b/include/psa/crypto_values.h
@@ -279,6 +279,11 @@
  * to read from a resource. */
 #define PSA_ERROR_INSUFFICIENT_DATA     ((psa_status_t)-143)
 
+/** This can be returned if a function can no longer operate correctly.
+ * For example, if an essential initialization operation failed or
+ * a mutex operation failed. */
+#define PSA_ERROR_SERVICE_FAILURE       ((psa_status_t)-144)
+
 /** The key identifier is not valid. See also :ref:\`key-handles\`.
  */
 #define PSA_ERROR_INVALID_HANDLE        ((psa_status_t)-136)

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -1101,7 +1101,7 @@ static psa_status_t psa_get_and_lock_key_slot_with_policy(
 
 error:
     *p_slot = NULL;
-    psa_unlock_key_slot(slot);
+    psa_release_key_slot_read_lock(slot);
 
     return status;
 }
@@ -1132,7 +1132,7 @@ static psa_status_t psa_get_and_lock_transparent_key_slot_with_policy(
     }
 
     if (psa_key_lifetime_is_external((*p_slot)->attr.lifetime)) {
-        psa_unlock_key_slot(*p_slot);
+        psa_release_key_slot_read_lock(*p_slot);
         *p_slot = NULL;
         return PSA_ERROR_NOT_SUPPORTED;
     }
@@ -1216,7 +1216,7 @@ psa_status_t psa_destroy_key(mbedtls_svc_key_id_t key)
      * stopped.
      */
     if (slot->lock_count > 1) {
-        psa_unlock_key_slot(slot);
+        psa_release_key_slot_read_lock(slot);
         return PSA_ERROR_GENERIC_ERROR;
     }
 
@@ -1412,7 +1412,7 @@ psa_status_t psa_get_key_attributes(mbedtls_svc_key_id_t key,
         psa_reset_key_attributes(attributes);
     }
 
-    unlock_status = psa_unlock_key_slot(slot);
+    unlock_status = psa_release_key_slot_read_lock(slot);
 
     return (status == PSA_SUCCESS) ? unlock_status : status;
 }
@@ -1508,7 +1508,7 @@ psa_status_t psa_export_key(mbedtls_svc_key_id_t key,
                                            slot->key.data, slot->key.bytes,
                                            data, data_size, data_length);
 
-    unlock_status = psa_unlock_key_slot(slot);
+    unlock_status = psa_release_key_slot_read_lock(slot);
 
     return (status == PSA_SUCCESS) ? unlock_status : status;
 }
@@ -1622,7 +1622,7 @@ psa_status_t psa_export_public_key(mbedtls_svc_key_id_t key,
         data, data_size, data_length);
 
 exit:
-    unlock_status = psa_unlock_key_slot(slot);
+    unlock_status = psa_release_key_slot_read_lock(slot);
 
     return (status == PSA_SUCCESS) ? unlock_status : status;
 }
@@ -1940,7 +1940,7 @@ static psa_status_t psa_finish_key_creation(
 
     if (status == PSA_SUCCESS) {
         *key = slot->attr.id;
-        status = psa_unlock_key_slot(slot);
+        status = psa_release_key_slot_read_lock(slot);
         if (status != PSA_SUCCESS) {
             *key = MBEDTLS_SVC_KEY_ID_INIT;
         }
@@ -2294,7 +2294,7 @@ exit:
         psa_fail_key_creation(target_slot, driver);
     }
 
-    unlock_status = psa_unlock_key_slot(source_slot);
+    unlock_status = psa_release_key_slot_read_lock(source_slot);
 
     return (status == PSA_SUCCESS) ? unlock_status : status;
 }
@@ -2615,7 +2615,7 @@ exit:
         psa_mac_abort(operation);
     }
 
-    unlock_status = psa_unlock_key_slot(slot);
+    unlock_status = psa_release_key_slot_read_lock(slot);
 
     return (status == PSA_SUCCESS) ? unlock_status : status;
 }
@@ -2801,7 +2801,7 @@ exit:
 
     psa_wipe_tag_output_buffer(mac, status, mac_size, *mac_length);
 
-    unlock_status = psa_unlock_key_slot(slot);
+    unlock_status = psa_release_key_slot_read_lock(slot);
 
     return (status == PSA_SUCCESS) ? unlock_status : status;
 }
@@ -2945,7 +2945,7 @@ exit:
     psa_wipe_tag_output_buffer(signature, status, signature_size,
                                *signature_length);
 
-    unlock_status = psa_unlock_key_slot(slot);
+    unlock_status = psa_release_key_slot_read_lock(slot);
 
     return (status == PSA_SUCCESS) ? unlock_status : status;
 }
@@ -2993,7 +2993,7 @@ static psa_status_t psa_verify_internal(mbedtls_svc_key_id_t key,
             signature, signature_length);
     }
 
-    unlock_status = psa_unlock_key_slot(slot);
+    unlock_status = psa_release_key_slot_read_lock(slot);
 
     return (status == PSA_SUCCESS) ? unlock_status : status;
 
@@ -3260,7 +3260,7 @@ psa_status_t psa_asymmetric_encrypt(mbedtls_svc_key_id_t key,
         alg, input, input_length, salt, salt_length,
         output, output_size, output_length);
 exit:
-    unlock_status = psa_unlock_key_slot(slot);
+    unlock_status = psa_release_key_slot_read_lock(slot);
 
     return (status == PSA_SUCCESS) ? unlock_status : status;
 }
@@ -3312,7 +3312,7 @@ psa_status_t psa_asymmetric_decrypt(mbedtls_svc_key_id_t key,
         output, output_size, output_length);
 
 exit:
-    unlock_status = psa_unlock_key_slot(slot);
+    unlock_status = psa_release_key_slot_read_lock(slot);
 
     return (status == PSA_SUCCESS) ? unlock_status : status;
 }
@@ -3421,7 +3421,7 @@ exit:
         psa_sign_hash_abort_internal(operation);
     }
 
-    unlock_status = psa_unlock_key_slot(slot);
+    unlock_status = psa_release_key_slot_read_lock(slot);
 
     if (unlock_status != PSA_SUCCESS) {
         operation->error_occurred = 1;
@@ -3566,7 +3566,7 @@ psa_status_t psa_verify_hash_start(
         psa_verify_hash_abort_internal(operation);
     }
 
-    unlock_status = psa_unlock_key_slot(slot);
+    unlock_status = psa_release_key_slot_read_lock(slot);
 
     if (unlock_status != PSA_SUCCESS) {
         operation->error_occurred = 1;
@@ -4138,7 +4138,7 @@ exit:
         psa_cipher_abort(operation);
     }
 
-    unlock_status = psa_unlock_key_slot(slot);
+    unlock_status = psa_release_key_slot_read_lock(slot);
 
     return (status == PSA_SUCCESS) ? unlock_status : status;
 }
@@ -4383,7 +4383,7 @@ psa_status_t psa_cipher_encrypt(mbedtls_svc_key_id_t key,
         output_size - default_iv_length, output_length);
 
 exit:
-    unlock_status = psa_unlock_key_slot(slot);
+    unlock_status = psa_release_key_slot_read_lock(slot);
     if (status == PSA_SUCCESS) {
         status = unlock_status;
     }
@@ -4444,7 +4444,7 @@ psa_status_t psa_cipher_decrypt(mbedtls_svc_key_id_t key,
         output, output_size, output_length);
 
 exit:
-    unlock_status = psa_unlock_key_slot(slot);
+    unlock_status = psa_release_key_slot_read_lock(slot);
     if (status == PSA_SUCCESS) {
         status = unlock_status;
     }
@@ -4570,7 +4570,7 @@ psa_status_t psa_aead_encrypt(mbedtls_svc_key_id_t key,
     }
 
 exit:
-    psa_unlock_key_slot(slot);
+    psa_release_key_slot_read_lock(slot);
 
     return status;
 }
@@ -4625,7 +4625,7 @@ psa_status_t psa_aead_decrypt(mbedtls_svc_key_id_t key,
     }
 
 exit:
-    psa_unlock_key_slot(slot);
+    psa_release_key_slot_read_lock(slot);
 
     return status;
 }
@@ -4737,7 +4737,7 @@ static psa_status_t psa_aead_setup(psa_aead_operation_t *operation,
     operation->key_type = psa_get_key_type(&attributes);
 
 exit:
-    unlock_status = psa_unlock_key_slot(slot);
+    unlock_status = psa_release_key_slot_read_lock(slot);
 
     if (status == PSA_SUCCESS) {
         status = unlock_status;
@@ -7060,7 +7060,7 @@ psa_status_t psa_key_derivation_input_key(
                                                slot->key.data,
                                                slot->key.bytes);
 
-    unlock_status = psa_unlock_key_slot(slot);
+    unlock_status = psa_release_key_slot_read_lock(slot);
 
     return (status == PSA_SUCCESS) ? unlock_status : status;
 }
@@ -7217,7 +7217,7 @@ psa_status_t psa_key_derivation_key_agreement(psa_key_derivation_operation_t *op
         }
     }
 
-    unlock_status = psa_unlock_key_slot(slot);
+    unlock_status = psa_release_key_slot_read_lock(slot);
 
     return (status == PSA_SUCCESS) ? unlock_status : status;
 }
@@ -7278,7 +7278,7 @@ exit:
         *output_length = output_size;
     }
 
-    unlock_status = psa_unlock_key_slot(slot);
+    unlock_status = psa_release_key_slot_read_lock(slot);
 
     return (status == PSA_SUCCESS) ? unlock_status : status;
 }
@@ -7952,7 +7952,7 @@ exit:
     if (status != PSA_SUCCESS) {
         psa_pake_abort(operation);
     }
-    unlock_status = psa_unlock_key_slot(slot);
+    unlock_status = psa_release_key_slot_read_lock(slot);
     return (status == PSA_SUCCESS) ? unlock_status : status;
 }
 

--- a/library/psa_crypto_core.h
+++ b/library/psa_crypto_core.h
@@ -50,25 +50,25 @@ typedef struct {
      * Number of locks on the key slot held by the library.
      *
      * This counter is incremented by one each time a library function
-     * calls the psa_lock_key_slot() API, library functions must do this
+     * calls the psa_acquire_key_slot_read_lock() API, library functions must do this
      * before they read the current content of the slot for an operation.
      *
      * This counter is set to SIZE_MAX by a call to
-     * psa_lock_key_slot_for_writing(), library functions must do this
+     * psa_acquire_key_slot_write_lock(), library functions must do this
      * before they write to any field in the slot other than lock_count.
      *
      * This counter is decremented by one each time a library function stops
      * reading the key slot and states it by calling the
-     * psa_unlock_key_slot() API.
+     * psa_release_key_slot_read_lock() API.
      *
      * This counter is set to 0 when a library function stops
      * writing to the key slot and states it by calling
-     * psa_unlock_key_slot_for_writing().
+     * psa_release_key_slot_write_lock().
      *
      * If this counter is equal to 0, the slot is UNUSED.
      * If the counter is equal to SIZE_MAX, the slot is in a WRITING state.
-     * In this state, calls to psa_lock_key_slot() or psa_unlock_key_slot()
-     * will fail.
+     * In this state, calls to psa_acquire_key_slot_read_lock()
+     * or psa_release_key_slot_read_lock() will fail.
      * Else the counter is equal to some n, and there are n operations with
      * a reading lock on the slot.
      *

--- a/library/psa_crypto_core.h
+++ b/library/psa_crypto_core.h
@@ -49,28 +49,17 @@ typedef struct {
     /*
      * Number of locks on the key slot held by the library.
      *
-     * This counter is incremented by one each time a library function
-     * calls the psa_acquire_key_slot_read_lock() API, library functions must do this
-     * before they read the current content of the slot for an operation.
+     * Library functions must not write directly to lock_count.
      *
-     * This counter is set to SIZE_MAX by a call to
-     * psa_acquire_key_slot_write_lock(), library functions must do this
-     * before they write to any field in the slot other than lock_count.
+     * A function must call psa_acquire_key_slot_read_lock()
+     * before reading the current contents of the slot for an operation.
+     * They then must call psa_release_key_slot_read_lock()
+     * once they have finished reading the current contents of the slot.
      *
-     * This counter is decremented by one each time a library function stops
-     * reading the key slot and states it by calling the
-     * psa_release_key_slot_read_lock() API.
-     *
-     * This counter is set to 0 when a library function stops
-     * writing to the key slot and states it by calling
-     * psa_release_key_slot_write_lock().
-     *
-     * If this counter is equal to 0, the slot is UNUSED.
-     * If the counter is equal to SIZE_MAX, the slot is in a WRITING state.
-     * In this state, calls to psa_acquire_key_slot_read_lock()
-     * or psa_release_key_slot_read_lock() will fail.
-     * Else the counter is equal to some n, and there are n operations with
-     * a reading lock on the slot.
+     * A function must call psa_acquire_key_slot_write_lock()
+     * before writing to the contents of the slot.
+     * They then must call psa_release_key_slot_write_lock()
+     * once they have finished writing to the contents of the slot.
      *
      * This counter is used to prevent resetting the key slot while the library
      * may access it. For example, such control is needed in the following

--- a/library/psa_crypto_slot_management.c
+++ b/library/psa_crypto_slot_management.c
@@ -146,7 +146,7 @@ psa_status_t psa_initialize_key_slots(void)
      * If multi-threading is enabled, then initialize the
      * global key slot mutex. */
 #if defined(MBEDTLS_THREADING_C)
-    if(!global_data.key_slots_initialized) {
+    if (!global_data.key_slots_initialized) {
         mbedtls_mutex_init(&global_data.key_slot_mutex);
     }
 #endif
@@ -166,7 +166,7 @@ void psa_wipe_all_key_slots(void)
     }
 
 #if defined(MBEDTLS_THREADING_C)
-    if(global_data.key_slots_initialized) {
+    if (global_data.key_slots_initialized) {
         mbedtls_mutex_free(&global_data.key_slot_mutex);
     }
 #endif

--- a/library/psa_crypto_slot_management.c
+++ b/library/psa_crypto_slot_management.c
@@ -129,7 +129,7 @@ static psa_status_t psa_get_and_lock_key_slot_in_memory(
     }
 
     if (status == PSA_SUCCESS) {
-        status = psa_lock_key_slot(slot);
+        status = psa_acquire_key_slot_read_lock(slot);
         if (status == PSA_SUCCESS) {
             *p_slot = slot;
         }
@@ -216,7 +216,7 @@ psa_status_t psa_get_empty_key_slot(psa_key_id_t *volatile_key_id,
     }
 
     if (selected_slot != NULL) {
-        status = psa_lock_key_slot(selected_slot);
+        status = psa_acquire_key_slot_read_lock(selected_slot);
         if (status != PSA_SUCCESS) {
             goto error;
         }
@@ -421,7 +421,7 @@ psa_status_t psa_get_and_lock_key_slot(mbedtls_svc_key_id_t key,
 #endif /* MBEDTLS_PSA_CRYPTO_STORAGE_C || MBEDTLS_PSA_CRYPTO_BUILTIN_KEYS */
 }
 
-psa_status_t psa_unlock_key_slot(psa_key_slot_t *slot)
+psa_status_t psa_release_key_slot_read_lock(psa_key_slot_t *slot)
 {
     if (slot == NULL) {
         return PSA_SUCCESS;
@@ -507,7 +507,7 @@ psa_status_t psa_open_key(mbedtls_svc_key_id_t key, psa_key_handle_t *handle)
 
     *handle = key;
 
-    return psa_unlock_key_slot(slot);
+    return psa_release_key_slot_read_lock(slot);
 
 #else /* MBEDTLS_PSA_CRYPTO_STORAGE_C || MBEDTLS_PSA_CRYPTO_BUILTIN_KEYS */
     (void) key;
@@ -536,7 +536,7 @@ psa_status_t psa_close_key(psa_key_handle_t handle)
     if (slot->lock_count <= 1) {
         return psa_wipe_key_slot(slot);
     } else {
-        return psa_unlock_key_slot(slot);
+        return psa_release_key_slot_read_lock(slot);
     }
 }
 
@@ -554,7 +554,7 @@ psa_status_t psa_purge_key(mbedtls_svc_key_id_t key)
         (slot->lock_count <= 1)) {
         return psa_wipe_key_slot(slot);
     } else {
-        return psa_unlock_key_slot(slot);
+        return psa_release_key_slot_read_lock(slot);
     }
 }
 

--- a/library/psa_crypto_slot_management.c
+++ b/library/psa_crypto_slot_management.c
@@ -145,10 +145,13 @@ psa_status_t psa_initialize_key_slots(void)
      * means that all the key slots are in a valid, empty state.
      * If multi-threading is enabled, then initialize the
      * global key slot mutex. */
-    global_data.key_slots_initialized = 1;
 #if defined(MBEDTLS_THREADING_C)
-    mbedtls_mutex_init(&global_data.key_slot_mutex);
+    if(!global_data.key_slots_initialized) {
+        mbedtls_mutex_init(&global_data.key_slot_mutex);
+    }
 #endif
+
+    global_data.key_slots_initialized = 1;
     return PSA_SUCCESS;
 }
 
@@ -161,10 +164,14 @@ void psa_wipe_all_key_slots(void)
         slot->lock_count = 1;
         (void) psa_wipe_key_slot(slot);
     }
-    global_data.key_slots_initialized = 0;
+
 #if defined(MBEDTLS_THREADING_C)
-    mbedtls_mutex_free(&global_data.key_slot_mutex);
+    if(global_data.key_slots_initialized) {
+        mbedtls_mutex_free(&global_data.key_slot_mutex);
+    }
 #endif
+
+    global_data.key_slots_initialized = 0;
 }
 
 psa_status_t psa_get_empty_key_slot(psa_key_id_t *volatile_key_id,

--- a/library/psa_crypto_slot_management.c
+++ b/library/psa_crypto_slot_management.c
@@ -420,7 +420,7 @@ psa_status_t psa_unlock_key_slot(psa_key_slot_t *slot)
         return PSA_SUCCESS;
     }
 
-    if (slot->lock_count > 0) {
+    if (slot->lock_count > 0 && slot->lock_count != SIZE_MAX) {
         slot->lock_count--;
         return PSA_SUCCESS;
     }
@@ -433,7 +433,7 @@ psa_status_t psa_unlock_key_slot(psa_key_slot_t *slot)
      * the function is called as part of the execution of a test suite, the
      * execution of the test suite is stopped in error if the assertion fails.
      */
-    MBEDTLS_TEST_HOOK_TEST_ASSERT(slot->lock_count > 0);
+    MBEDTLS_TEST_HOOK_TEST_ASSERT(slot->lock_count > 0 && slot->lock_count != SIZE_MAX);
     return PSA_ERROR_CORRUPTION_DETECTED;
 }
 

--- a/library/psa_crypto_slot_management.h
+++ b/library/psa_crypto_slot_management.h
@@ -83,14 +83,16 @@ static inline int psa_key_id_is_volatile(psa_key_id_t key_id)
 psa_status_t psa_get_and_lock_key_slot(mbedtls_svc_key_id_t key,
                                        psa_key_slot_t **p_slot);
 
-/** Initialize the key slot structures.
+/** Initialize the key slot structures,
+ * if multi-threading is enabled then initialize the key slot mutex.
  *
  * \retval #PSA_SUCCESS
  *         Currently this function always succeeds.
  */
 psa_status_t psa_initialize_key_slots(void);
 
-/** Delete all data from key slots in memory.
+/** Delete all data from key slots in memory,
+ * if multi-threading is enabled then free the key slot mutex.
  *
  * This does not affect persistent storage. */
 void psa_wipe_all_key_slots(void);

--- a/library/psa_crypto_slot_management.h
+++ b/library/psa_crypto_slot_management.h
@@ -85,6 +85,9 @@ psa_status_t psa_get_and_lock_key_slot(mbedtls_svc_key_id_t key,
 
 /** Initialize the key slot structures,
  * if multi-threading is enabled then initialize the key slot mutex.
+ * This function is not thread-safe,
+ * if called by competing threads the key slot mutex may be initialized
+ * more than once.
  *
  * \retval #PSA_SUCCESS
  *         Currently this function always succeeds.
@@ -93,6 +96,9 @@ psa_status_t psa_initialize_key_slots(void);
 
 /** Delete all data from key slots in memory,
  * if multi-threading is enabled then free the key slot mutex.
+ * This function is not thread-safe,
+ * if called by competing threads the key slot mutex may be freed
+ * more than once.
  *
  * This does not affect persistent storage. */
 void psa_wipe_all_key_slots(void);

--- a/library/psa_crypto_slot_management.h
+++ b/library/psa_crypto_slot_management.h
@@ -129,7 +129,7 @@ psa_status_t psa_get_empty_key_slot(psa_key_id_t *volatile_key_id,
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
  *             The slot was in a writing state.
  */
-static inline psa_status_t psa_lock_key_slot(psa_key_slot_t *slot)
+static inline psa_status_t psa_acquire_key_slot_read_lock(psa_key_slot_t *slot)
 {
     if (slot->lock_count == SIZE_MAX) {
         return PSA_ERROR_CORRUPTION_DETECTED;
@@ -153,7 +153,7 @@ static inline psa_status_t psa_lock_key_slot(psa_key_slot_t *slot)
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
  *             The lock counter was already in a writing state.
  */
-static inline psa_status_t psa_lock_key_slot_for_writing(psa_key_slot_t *slot)
+static inline psa_status_t psa_acquire_key_slot_write_lock(psa_key_slot_t *slot)
 {
     if (slot->lock_count == SIZE_MAX) {
         return PSA_ERROR_CORRUPTION_DETECTED;
@@ -183,7 +183,7 @@ static inline psa_status_t psa_lock_key_slot_for_writing(psa_key_slot_t *slot)
  *             writing state.
  *
  */
-psa_status_t psa_unlock_key_slot(psa_key_slot_t *slot);
+psa_status_t psa_release_key_slot_read_lock(psa_key_slot_t *slot);
 
 /** Test whether a lifetime designates a key in an external cryptoprocessor.
  *
@@ -212,7 +212,7 @@ psa_status_t psa_unlock_key_slot(psa_key_slot_t *slot);
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
  *             The lock counter was not in a WRITING state.
  */
-static inline psa_status_t psa_unlock_key_slot_for_writing(psa_key_slot_t *slot)
+static inline psa_status_t psa_release_key_slot_write_lock(psa_key_slot_t *slot)
 {
     if (slot->lock_count != SIZE_MAX) {
         return PSA_ERROR_CORRUPTION_DETECTED;

--- a/library/psa_crypto_slot_management.h
+++ b/library/psa_crypto_slot_management.h
@@ -142,7 +142,8 @@ static inline psa_status_t psa_acquire_key_slot_read_lock(psa_key_slot_t *slot)
 
 /** Lock a key slot for writing.
  *
- * This function sets the slot's lock_count to SIZE_MAX.
+ * This function sets the slot's lock_count to SIZE_MAX,
+ * indicating that the slot is now in a WRITING state.
  * If multi-threading is enabled, the caller must hold the
  * global key slot mutex.
  *
@@ -151,7 +152,7 @@ static inline psa_status_t psa_acquire_key_slot_read_lock(psa_key_slot_t *slot)
  * \retval #PSA_SUCCESS
                The key slot lock counter was set to SIZE_MAX.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
- *             The lock counter was already in a writing state.
+ *             The lock counter was already in a WRITING state.
  */
 static inline psa_status_t psa_acquire_key_slot_write_lock(psa_key_slot_t *slot)
 {
@@ -163,7 +164,7 @@ static inline psa_status_t psa_acquire_key_slot_write_lock(psa_key_slot_t *slot)
     return PSA_SUCCESS;
 }
 
-/** Unlock a key slot.
+/** Unlock a key slot from a reading state.
  *
  * This function decrements the key slot lock counter by one.
  * If slot is in a WRITING state, this will fail.
@@ -180,25 +181,12 @@ static inline psa_status_t psa_acquire_key_slot_write_lock(psa_key_slot_t *slot)
  *             decremented successfully.
  * \retval #PSA_ERROR_CORRUPTION_DETECTED
  *             The lock counter was equal to 0, or the slot was in a
- *             writing state.
+ *             WRITING state.
  *
  */
 psa_status_t psa_release_key_slot_read_lock(psa_key_slot_t *slot);
 
-/** Test whether a lifetime designates a key in an external cryptoprocessor.
- *
- * \param lifetime      The lifetime to test.
- *
- * \retval 1
- *         The lifetime designates an external key. There should be a
- *         registered driver for this lifetime, otherwise the key cannot
- *         be created or manipulated.
- * \retval 0
- *         The lifetime designates a key that is volatile or in internal
- *         storage.
- */
-
-/** Lock a key slot for writing.
+/** Unlock a key slot from a writing state.
  *
  * This function sets the slot's lock_count to 0.
  * If slot is not in a WRITING state, this will fail.
@@ -221,6 +209,19 @@ static inline psa_status_t psa_release_key_slot_write_lock(psa_key_slot_t *slot)
 
     return PSA_SUCCESS;
 }
+
+/** Test whether a lifetime designates a key in an external cryptoprocessor.
+ *
+ * \param lifetime      The lifetime to test.
+ *
+ * \retval 1
+ *         The lifetime designates an external key. There should be a
+ *         registered driver for this lifetime, otherwise the key cannot
+ *         be created or manipulated.
+ * \retval 0
+ *         The lifetime designates a key that is volatile or in internal
+ *         storage.
+ */
 
 static inline int psa_key_lifetime_is_external(psa_key_lifetime_t lifetime)
 {


### PR DESCRIPTION
## Description
Implement a global mutex to protect the `lock_count` fields of all key slots. Update the documentation for `lock_count` and the getting and setting functions for the `lock_count` field. Add the extra primitive functions needed to implement the UNUSED/READING/WRITING key slot states as described in docs/architecture/psa-thread-safety.md. Add support for [PSA_ERROR_SERVICE_FAILURE](https://arm-software.github.io/psa-api/status-code/1.0/api/status-codes.html#c.PSA_ERROR_SERVICE_FAILURE) (the error code for mutex locking/unlocking failures).

This is the first part of #8410, future work will use this mutex and these primitives to make the PSA subsystem thread-safe. The new documentation states assumptions that will be made true by this future work. 

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required for individual tasks on this epic.
- [x] **backport** not required (new feature)
- [x] **tests** not required