### PR TITLE
Fix fake cases listed of compat.sh

### DIFF
--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -131,22 +131,34 @@ print_test_case() {
 
 # list_test_cases lists all potential test cases in compat.sh without execution
 list_test_cases() {
-    reset_ciphersuites
     for TYPE in $TYPES; do
+        reset_ciphersuites
         add_common_ciphersuites
         add_openssl_ciphersuites
         add_gnutls_ciphersuites
         add_mbedtls_ciphersuites
-    done
 
-    for VERIFY in $VERIFIES; do
-        VERIF=$(echo $VERIFY | tr '[:upper:]' '[:lower:]')
-        for MODE in $MODES; do
-            print_test_case m O "$O_CIPHERS"
-            print_test_case O m "$O_CIPHERS"
-            print_test_case m G "$G_CIPHERS"
-            print_test_case G m "$G_CIPHERS"
-            print_test_case m m "$M_CIPHERS"
+        # PSK cipher suites do not allow client certificate verification.
+        SUB_VERIFIES=$VERIFIES
+        if [ "$TYPE" = "PSK" ]; then
+            SUB_VERIFIES="NO"
+        fi
+
+        for VERIFY in $SUB_VERIFIES; do
+            VERIF=$(echo $VERIFY | tr '[:upper:]' '[:lower:]')
+            for MODE in $MODES; do
+                # For GnuTLS client -> Mbed TLS server,
+                # we need to force IPv4 by connecting to 127.0.0.1 but then auth fails
+                SUB_G_CIPHERS=$G_CIPHERS
+                if is_dtls "$MODE" && [ "X$VERIFY" = "XYES" ]; then
+                    SUB_G_CIPHERS=""
+                fi
+                print_test_case m O "$O_CIPHERS"
+                print_test_case O m "$O_CIPHERS"
+                print_test_case m G "$G_CIPHERS"
+                print_test_case G m "$SUB_G_CIPHERS"
+                print_test_case m m "$M_CIPHERS"
+            done
         done
     done
 }

--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -147,16 +147,10 @@ list_test_cases() {
         for VERIFY in $SUB_VERIFIES; do
             VERIF=$(echo $VERIFY | tr '[:upper:]' '[:lower:]')
             for MODE in $MODES; do
-                # For GnuTLS client -> Mbed TLS server,
-                # we need to force IPv4 by connecting to 127.0.0.1 but then auth fails
-                SUB_G_CIPHERS=$G_CIPHERS
-                if is_dtls "$MODE" && [ "X$VERIFY" = "XYES" ]; then
-                    SUB_G_CIPHERS=""
-                fi
                 print_test_case m O "$O_CIPHERS"
                 print_test_case O m "$O_CIPHERS"
                 print_test_case m G "$G_CIPHERS"
-                print_test_case G m "$SUB_G_CIPHERS"
+                print_test_case G m "$G_CIPHERS"
                 print_test_case m m "$M_CIPHERS"
             done
         done
@@ -275,12 +269,6 @@ filter_ciphersuites()
 
         # Ciphersuite for GnuTLS
         G_CIPHERS=$( filter "$G_CIPHERS" )
-    fi
-
-    # For GnuTLS client -> Mbed TLS server,
-    # we need to force IPv4 by connecting to 127.0.0.1 but then auth fails
-    if is_dtls "$MODE" && [ "X$VERIFY" = "XYES" ]; then
-        G_CIPHERS=""
     fi
 }
 
@@ -951,13 +939,7 @@ run_client() {
             ;;
 
         [Gg]nu*)
-            # need to force IPv4 with UDP, but keep localhost for auth
-            if is_dtls "$MODE"; then
-                G_HOST="127.0.0.1"
-            else
-                G_HOST="localhost"
-            fi
-            CLIENT_CMD="$GNUTLS_CLI $G_CLIENT_ARGS --priority $G_PRIO_MODE:$3 $G_HOST"
+            CLIENT_CMD="$GNUTLS_CLI $G_CLIENT_ARGS --priority $G_PRIO_MODE:$3 localhost"
             log "$CLIENT_CMD"
             echo "$CLIENT_CMD" > $CLI_OUT
             printf 'GET HTTP/1.0\r\n\r\n' | $CLIENT_CMD >> $CLI_OUT 2>&1 &


### PR DESCRIPTION
## Description

Same topic: #8575, #8594

`compat.sh` does not correctly list test cases it runs. E.g:

We got on CI:
```
[2023-11-30T13:36:16.703Z] Warning: Test case not executed: compat;G->m dtls12,yes TLS_DHE_PSK_WITH_AES_128_CBC_SHA
...
[2023-11-30T13:36:16.703Z] Warning: Test case not executed: compat;G->m dtls12,yes TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
```
But actually we don't run these kinds of tests:

- PSK cipher suites do not allow client certificate verification. No PSK cipher suites tests with `VERIFY=YES`
- We workarround all `G->m dtls12,yes ,<cipher_suite>` tests for some reason.



## PR checklist

- [x] **changelog** not required, test script change.
- [x] **backport** https://github.com/Mbed-TLS/mbedtls/pull/8956
- [x] **tests** not required

