### PR TITLE
Remove unused/non-compiling code

### DIFF
--- a/library/constant_time.c
+++ b/library/constant_time.c
@@ -21,19 +21,6 @@
 
 #include <string.h>
 
-#if defined(MBEDTLS_USE_PSA_CRYPTO) && defined(MBEDTLS_SSL_SOME_SUITES_USE_MAC)
-#include "psa/crypto.h"
-/* Define a local translating function to save code size by not using too many
- * arguments in each translating place. */
-static int local_err_translation(psa_status_t status)
-{
-    return psa_status_to_mbedtls(status, psa_to_ssl_errors,
-                                 ARRAY_LENGTH(psa_to_ssl_errors),
-                                 psa_generic_status_to_mbedtls);
-}
-#define PSA_TO_MBEDTLS_ERR(status) local_err_translation(status)
-#endif
-
 #if !defined(MBEDTLS_CT_ASM)
 /*
  * Define an object with the value zero, such that the compiler cannot prove that it


### PR DESCRIPTION
## Description

Remove unused (and non-compiling) code in `constant_time.c` that prevents some configurations from building.

This can be reproduced with: `mtest MBEDTLS_USE_PSA_CRYPTO MBEDTLS_SSL_SOME_SUITES_USE_MAC`

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required for trivial build fix
- [x] **backport** not required - 2.28 not affected
- [x] **tests** not required for trivial build fix
