### PR TITLE
TLS1.3: SRV: check `min_tls_version` when parsing ClientHello

### DIFF
--- a/ChangeLog.d/fix-tls13-server-min-version-check.txt
+++ b/ChangeLog.d/fix-tls13-server-min-version-check.txt
@@ -1,4 +1,3 @@
 Bugfix
-   * Add missing check for `min_tls_version` in TLS 1.3 server-side.
-     Without this, TLS 1.3 server may downgrade protocol to a TLS version
-     below its supported minimum TLS version. Fixes #8593.
+   * Fix TLS server accepting TLS 1.2 handshake while TLS 1.2
+     is disabled at runtime. Fixes #8593.

--- a/ChangeLog.d/fix-tls13-server-min-version-check.txt
+++ b/ChangeLog.d/fix-tls13-server-min-version-check.txt
@@ -1,0 +1,4 @@
+Bugfix
+   * Add missing check for `min_tls_version` in TLS 1.3 server-side.
+     Without this, TLS 1.3 server may downgrade protocol to a TLS version
+     below its supported minimum TLS version. Fixes #8593.

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1920,6 +1920,15 @@ static int ssl_tls13_process_client_hello(mbedtls_ssl_context *ssl)
      * will dispatch to the TLS 1.2 state machine.
      */
     if (SSL_CLIENT_HELLO_TLS1_2 == parse_client_hello_ret) {
+        /* Check if server supports TLS 1.2 */
+        if (ssl->conf->min_tls_version > MBEDTLS_SSL_VERSION_TLS1_2) {
+            MBEDTLS_SSL_DEBUG_MSG(
+                1, ("Unsupported version of TLS 1.2 was received"));
+            MBEDTLS_SSL_PEND_FATAL_ALERT(
+                MBEDTLS_SSL_ALERT_MSG_ILLEGAL_PARAMETER,
+                MBEDTLS_ERR_SSL_ILLEGAL_PARAMETER);
+            return MBEDTLS_ERR_SSL_ILLEGAL_PARAMETER;
+        }
         ssl->keep_current_message = 1;
         ssl->tls_version = MBEDTLS_SSL_VERSION_TLS1_2;
         return 0;

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1925,9 +1925,9 @@ static int ssl_tls13_process_client_hello(mbedtls_ssl_context *ssl)
             MBEDTLS_SSL_DEBUG_MSG(
                 1, ("TLS 1.2 not supported."));
             MBEDTLS_SSL_PEND_FATAL_ALERT(
-                MBEDTLS_SSL_ALERT_MSG_ILLEGAL_PARAMETER,
-                MBEDTLS_ERR_SSL_ILLEGAL_PARAMETER);
-            return MBEDTLS_ERR_SSL_ILLEGAL_PARAMETER;
+                MBEDTLS_SSL_ALERT_MSG_PROTOCOL_VERSION,
+                MBEDTLS_ERR_SSL_BAD_PROTOCOL_VERSION);
+            return MBEDTLS_ERR_SSL_BAD_PROTOCOL_VERSION;
         }
         ssl->keep_current_message = 1;
         ssl->tls_version = MBEDTLS_SSL_VERSION_TLS1_2;

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1921,7 +1921,7 @@ static int ssl_tls13_process_client_hello(mbedtls_ssl_context *ssl)
      */
     if (SSL_CLIENT_HELLO_TLS1_2 == parse_client_hello_ret) {
         /* Check if server supports TLS 1.2 */
-        if (ssl->conf->min_tls_version > MBEDTLS_SSL_VERSION_TLS1_2) {
+        if (!mbedtls_ssl_conf_is_tls12_enabled(ssl->conf)) {
             MBEDTLS_SSL_DEBUG_MSG(
                 1, ("Unsupported version of TLS 1.2 was received"));
             MBEDTLS_SSL_PEND_FATAL_ALERT(

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1913,7 +1913,8 @@ static int ssl_tls13_process_client_hello(mbedtls_ssl_context *ssl)
                                    * by MBEDTLS_SSL_PROC_CHK_NEG. */
 
     /*
-     * Version 1.2 of the protocol has been chosen, set the
+     * Version 1.2 of the protocol has to be used for the handshake.
+     * If TLS 1.2 is not supported, abort the handshake. Otherwise, set the
      * ssl->keep_current_message flag for the ClientHello to be kept and parsed
      * as a TLS 1.2 ClientHello. We also change ssl->tls_version to
      * MBEDTLS_SSL_VERSION_TLS1_2 thus from now on mbedtls_ssl_handshake_step()

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1923,7 +1923,7 @@ static int ssl_tls13_process_client_hello(mbedtls_ssl_context *ssl)
         /* Check if server supports TLS 1.2 */
         if (!mbedtls_ssl_conf_is_tls12_enabled(ssl->conf)) {
             MBEDTLS_SSL_DEBUG_MSG(
-                1, ("Unsupported version of TLS 1.2 was received"));
+                1, ("TLS 1.2 not supported."));
             MBEDTLS_SSL_PEND_FATAL_ALERT(
                 MBEDTLS_SSL_ALERT_MSG_ILLEGAL_PARAMETER,
                 MBEDTLS_ERR_SSL_ILLEGAL_PARAMETER);

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -11613,6 +11613,22 @@ run_test    "TLS 1.3: Not supported version check:openssl: srv max TLS 1.2" \
             -S "Version: TLS1.2" \
             -C "Protocol  : TLSv1.2"
 
+requires_config_enabled MBEDTLS_DEBUG_C
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+requires_config_enabled MBEDTLS_SSL_CLI_C
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
+requires_config_enabled MBEDTLS_SSL_SRV_C
+run_test "TLS 1.3 m->m: Not supported version check: cli TLS 1.2 only, srv TLS 1.3 only, fail" \
+         "$P_SRV debug_level=4 max_version=tls13 min_version=tls13" \
+         "$P_CLI debug_level=4 max_version=tls12 min_version=tls12" \
+         1 \
+         -c "The SSL configuration is tls12 only"                   \
+         -c "supported_versions(43) extension does not exist."      \
+         -c "A fatal alert message was received from our peer"      \
+         -s "The SSL configuration is tls13 only"                   \
+         -s "Unsupported version of TLS 1.2 was received"           \
+         -s "! mbedtls_ssl_handshake returned"
+
 requires_openssl_tls1_3_with_compatible_ephemeral
 requires_config_enabled MBEDTLS_DEBUG_C
 requires_config_enabled MBEDTLS_SSL_CLI_C

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -11626,8 +11626,7 @@ run_test "TLS 1.3 m->m: Not supported version check: cli TLS 1.2 only, srv TLS 1
          -c "supported_versions(43) extension does not exist."      \
          -c "A fatal alert message was received from our peer"      \
          -s "The SSL configuration is tls13 only"                   \
-         -s "Unsupported version of TLS 1.2 was received"           \
-         -s "! mbedtls_ssl_handshake returned"
+         -s "TLS 1.2 not supported."
 
 requires_openssl_tls1_3_with_compatible_ephemeral
 requires_config_enabled MBEDTLS_DEBUG_C


### PR DESCRIPTION
## Description

Fix: #8593

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** provided
- [x] **backport** not required (tls1.3 only)
- [x] **tests** provided