### PR TITLE
Change early data flag to input file

### DIFF
--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -348,8 +348,8 @@ int main(void)
 #if defined(MBEDTLS_SSL_EARLY_DATA)
 #define USAGE_EARLY_DATA \
     "    early_data=%%s      The file path to read early data from\n" \
-    "                         default: \"\" (do nothing)\n"                    \
-    "                         option: a file path\n"
+    "                        default: \"\" (do nothing)\n"            \
+    "                        option: a file path\n"
 #else
 #define USAGE_EARLY_DATA ""
 #endif /* MBEDTLS_SSL_EARLY_DATA && MBEDTLS_SSL_PROTO_TLS1_3 */
@@ -544,7 +544,8 @@ struct options {
     int reproducible;           /* make communication reproducible          */
     int skip_close_notify;      /* skip sending the close_notify alert      */
 #if defined(MBEDTLS_SSL_EARLY_DATA)
-    const char *early_data_file; /* the file path of early data             */
+    const char *early_data_file; /* the path of the file containing the
+                                  * early data to send                      */
 #endif
     int query_config_mode;      /* whether to read config                   */
     int use_srtp;               /* Support SRTP                             */

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -742,6 +742,10 @@ int main(int argc, char *argv[])
     size_t cid_renego_len = 0;
 #endif
 
+#if defined(MBEDTLS_SSL_EARLY_DATA)
+    FILE *early_data_fp = NULL;
+#endif /* MBEDTLS_SSL_EARLY_DATA */
+
 #if defined(MBEDTLS_SSL_ALPN)
     const char *alpn_list[ALPN_LIST_SIZE];
 #endif
@@ -1965,7 +1969,6 @@ usage:
 
 #if defined(MBEDTLS_SSL_EARLY_DATA)
     int early_data_enabled = MBEDTLS_SSL_EARLY_DATA_DISABLED;
-    FILE *early_data_fp = NULL;
     if (strlen(opt.early_data) > 0) {
         if ((early_data_fp = fopen(opt.early_data, "rb")) == NULL) {
             mbedtls_printf("failed\n  ! Cannot open '%s' for reading.\n",

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -2010,14 +2010,12 @@ usage:
     }
 
 #if defined(MBEDTLS_SSL_EARLY_DATA)
-    int early_data_enabled = 0;
+    int early_data_enabled = MBEDTLS_SSL_EARLY_DATA_DISABLED;
     size_t early_data_len;
     if (strlen(opt.early_data_file) > 0 &&
-        ssl_early_data_read_file(opt.early_data_file,
-                                 &early_data, &early_data_len) == 0) {
+        ssl_read_file_text(opt.early_data_file,
+                           &early_data, &early_data_len) == 0) {
         early_data_enabled = MBEDTLS_SSL_EARLY_DATA_ENABLED;
-    } else {
-        early_data_enabled = MBEDTLS_SSL_EARLY_DATA_DISABLED;
     }
     mbedtls_ssl_conf_early_data(&conf, early_data_enabled);
 #endif /* MBEDTLS_SSL_EARLY_DATA */

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -1217,6 +1217,12 @@ usage:
             }
         } else if (strcmp(p, "early_data_file") == 0) {
             opt.early_data_file = q;
+            if ((early_data_fp = fopen(opt.early_data_file, "rb")) == NULL) {
+                mbedtls_printf("failed\n  ! Cannot open '%s' for reading.\n",
+                               opt.early_data_file);
+                ret = MBEDTLS_ERR_SSL_INTERNAL_ERROR;
+                goto exit;
+            }
         }
 #endif /* MBEDTLS_SSL_EARLY_DATA */
 
@@ -3007,25 +3013,6 @@ reconnect:
                            (unsigned int) -ret);
             goto exit;
         }
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3) && defined(MBEDTLS_SSL_EARLY_DATA)
-        if (opt.early_data == MBEDTLS_SSL_EARLY_DATA_ENABLED
-            && strlen(opt.early_data_file) > 0) {
-            if ((early_data_fp = fopen(opt.early_data_file, "rb")) == NULL) {
-                mbedtls_printf("failed\n  ! Cannot open '%s' for reading.\n",
-                               opt.early_data_file);
-                ret = MBEDTLS_ERR_SSL_INTERNAL_ERROR;
-                goto exit;
-            }
-
-            mbedtls_printf("Read early data successfully...");
-
-            /* TODO: read the early data from early_data_fp in chunks, and call
-             * mbedtls_ssl_write_early_data() to initial the handshake and send
-             * out the early data. Then finish the handshake.
-             */
-
-        } else
-#endif
 
         while ((ret = mbedtls_ssl_handshake(&ssl)) != 0) {
             if (ret != MBEDTLS_ERR_SSL_WANT_READ &&

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -544,8 +544,8 @@ struct options {
     int reproducible;           /* make communication reproducible          */
     int skip_close_notify;      /* skip sending the close_notify alert      */
 #if defined(MBEDTLS_SSL_EARLY_DATA)
-    const char *early_data_file; /* the path of the file containing the
-                                  * early data to send                      */
+    const char *early_data;     /* the path of the file containing the
+                                 * early data to send                       */
 #endif
     int query_config_mode;      /* whether to read config                   */
     int use_srtp;               /* Support SRTP                             */
@@ -914,7 +914,7 @@ int main(int argc, char *argv[])
     opt.groups              = DFL_GROUPS;
     opt.sig_algs            = DFL_SIG_ALGS;
 #if defined(MBEDTLS_SSL_EARLY_DATA)
-    opt.early_data_file     = DFL_EARLY_DATA_FILE;
+    opt.early_data          = DFL_EARLY_DATA_FILE;
 #endif
     opt.transport           = DFL_TRANSPORT;
     opt.hs_to_min           = DFL_HS_TO_MIN;
@@ -1198,7 +1198,7 @@ usage:
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
 #if defined(MBEDTLS_SSL_EARLY_DATA)
         else if (strcmp(p, "early_data") == 0) {
-            opt.early_data_file = q;
+            opt.early_data = q;
         }
 #endif /* MBEDTLS_SSL_EARLY_DATA */
 
@@ -1968,10 +1968,10 @@ usage:
     int early_data_enabled = MBEDTLS_SSL_EARLY_DATA_DISABLED;
     FILE *early_data_fp = NULL;
     size_t early_data_len = 0;
-    if (strlen(opt.early_data_file) > 0) {
-        if ((early_data_fp = fopen(opt.early_data_file, "rb")) == NULL) {
+    if (strlen(opt.early_data) > 0) {
+        if ((early_data_fp = fopen(opt.early_data, "rb")) == NULL) {
             mbedtls_printf("failed\n  ! Cannot open '%s' for reading.\n",
-                           opt.early_data_file);
+                           opt.early_data);
             goto exit;
         }
         early_data_len = fread(buf, 1, sizeof(buf), early_data_fp);

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -1967,17 +1967,13 @@ usage:
 #if defined(MBEDTLS_SSL_EARLY_DATA)
     int early_data_enabled = MBEDTLS_SSL_EARLY_DATA_DISABLED;
     FILE *early_data_fp = NULL;
-    size_t early_data_len = 0;
     if (strlen(opt.early_data) > 0) {
         if ((early_data_fp = fopen(opt.early_data, "rb")) == NULL) {
             mbedtls_printf("failed\n  ! Cannot open '%s' for reading.\n",
                            opt.early_data);
             goto exit;
         }
-        early_data_len = fread(buf, 1, sizeof(buf), early_data_fp);
-        if (early_data_len > 0) {
-            early_data_enabled = MBEDTLS_SSL_EARLY_DATA_ENABLED;
-        }
+        early_data_enabled = MBEDTLS_SSL_EARLY_DATA_ENABLED;
     }
     mbedtls_ssl_conf_early_data(&conf, early_data_enabled);
 #endif /* MBEDTLS_SSL_EARLY_DATA */

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -720,21 +720,22 @@ exit:
 
 #if defined(MBEDTLS_SSL_EARLY_DATA)
 
-#define MBEDTLS_ERR_EARLY_FILE_IO_ERROR -2
+#define MBEDTLS_ERR_FILE_IO_ERROR -2
 
-int ssl_early_data_read_file(const char *path, unsigned char **buffer, size_t *length)
+static int ssl_read_file_text(const char *path,
+                              unsigned char **buffer, size_t *length)
 {
     FILE *f;
     long size;
 
     if ((f = fopen(path, "rb")) == NULL) {
-        return MBEDTLS_ERR_EARLY_FILE_IO_ERROR;
+        return MBEDTLS_ERR_FILE_IO_ERROR;
     }
 
     fseek(f, 0, SEEK_END);
     if ((size = ftell(f)) == -1) {
         fclose(f);
-        return MBEDTLS_ERR_EARLY_FILE_IO_ERROR;
+        return MBEDTLS_ERR_FILE_IO_ERROR;
     }
     fseek(f, 0, SEEK_SET);
 
@@ -747,7 +748,7 @@ int ssl_early_data_read_file(const char *path, unsigned char **buffer, size_t *l
 
     if (fread(*buffer, 1, *length, f) != *length) {
         fclose(f);
-        return MBEDTLS_ERR_EARLY_FILE_IO_ERROR;
+        return MBEDTLS_ERR_FILE_IO_ERROR;
     }
 
     fclose(f);

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -3007,6 +3007,22 @@ reconnect:
                            (unsigned int) -ret);
             goto exit;
         }
+#if defined(MBEDTLS_SSL_EARLY_DATA)
+        if (opt.early_data == MBEDTLS_SSL_EARLY_DATA_ENABLED
+            && strlen(opt.early_data) > 0) {
+            if ((early_data_fp = fopen(opt.early_data_file, "rb")) == NULL) {
+                mbedtls_printf("failed\n  ! Cannot open '%s' for reading.\n",
+                               opt.early_data);
+                goto exit;
+            }
+
+            /* TODO: read the early data from early_data_fp in chunks, and call
+             * mbedtls_ssl_write_early_data() to initial the handshake and send
+             * out the early data. Then finish the handshake.
+             */
+
+        }
+#endif
 
         while ((ret = mbedtls_ssl_handshake(&ssl)) != 0) {
             if (ret != MBEDTLS_ERR_SSL_WANT_READ &&

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -3007,21 +3007,24 @@ reconnect:
                            (unsigned int) -ret);
             goto exit;
         }
-#if defined(MBEDTLS_SSL_EARLY_DATA)
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3) && defined(MBEDTLS_SSL_EARLY_DATA)
         if (opt.early_data == MBEDTLS_SSL_EARLY_DATA_ENABLED
-            && strlen(opt.early_data) > 0) {
+            && strlen(opt.early_data_file) > 0) {
             if ((early_data_fp = fopen(opt.early_data_file, "rb")) == NULL) {
                 mbedtls_printf("failed\n  ! Cannot open '%s' for reading.\n",
-                               opt.early_data);
+                               opt.early_data_file);
+                ret = MBEDTLS_ERR_SSL_INTERNAL_ERROR;
                 goto exit;
             }
+
+            mbedtls_printf("Read early data successfully...");
 
             /* TODO: read the early data from early_data_fp in chunks, and call
              * mbedtls_ssl_write_early_data() to initial the handshake and send
              * out the early data. Then finish the handshake.
              */
 
-        }
+        } else
 #endif
 
         while ((ret = mbedtls_ssl_handshake(&ssl)) != 0) {

--- a/tests/opt-testcases/tls13-misc.sh
+++ b/tests/opt-testcases/tls13-misc.sh
@@ -263,7 +263,7 @@ requires_any_configs_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL_
 run_test    "TLS 1.3 m->G: EarlyData: basic check, good" \
             "$G_NEXT_SRV -d 10 --priority=NORMAL:-VERS-ALL:+VERS-TLS1.3:+CIPHER-ALL:+ECDHE-PSK:+PSK \
                          --earlydata --maxearlydata 16384 --disable-client-cert" \
-            "$P_CLI debug_level=4 early_data=1 reco_mode=1 reconnect=1 reco_delay=900" \
+            "$P_CLI debug_level=4 early_data=1 early_data_file=$EARLY_DATA_INPUT reco_mode=1 reconnect=1 reco_delay=900" \
             0 \
             -c "received max_early_data_size: 16384" \
             -c "Reconnecting with saved session" \
@@ -294,32 +294,6 @@ run_test    "TLS 1.3 m->G: EarlyData: no early_data in NewSessionTicket, good" \
             -c "ClientHello: early_data(42) extension does not exist." \
             -C "EncryptedExtensions: early_data(42) extension received." \
             -C "EncryptedExtensions: early_data(42) extension exists."
-
-requires_gnutls_tls1_3
-requires_config_enabled MBEDTLS_DEBUG_C
-requires_config_enabled MBEDTLS_SSL_CLI_C
-requires_all_configs_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE \
-                             MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED \
-                             MBEDTLS_SSL_EARLY_DATA
-requires_any_configs_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL_ENABLED \
-                             MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_ENABLED
-run_test    "TLS 1.3 m->G: EarlyData: write early data, fallback, good" \
-            "$G_NEXT_SRV -d 10 --priority=NORMAL:-VERS-ALL:+VERS-TLS1.3:+CIPHER-ALL:+ECDHE-PSK:+PSK \
-                         --earlydata --maxearlydata 16384 --disable-client-cert" \
-            "$P_CLI debug_level=4 early_data=1 early_data_file=$EARLY_DATA_INPUT reco_mode=1 reconnect=1 reco_delay=900" \
-            0 \
-            -c "received max_early_data_size: 16384" \
-            -c "Reconnecting with saved session" \
-            -c "Read early data successfully..." \
-            -c "NewSessionTicket: early_data(42) extension received." \
-            -c "ClientHello: early_data(42) extension exists." \
-            -c "EncryptedExtensions: early_data(42) extension received." \
-            -c "EncryptedExtensions: early_data(42) extension exists." \
-            -c "<= write EndOfEarlyData" \
-            -s "Parsing extension 'Early Data/42' (0 bytes)" \
-            -s "Sending extension Early Data/42 (0 bytes)" \
-            -s "END OF EARLY DATA (5) was received." \
-            -s "early data accepted"
 
 #TODO: OpenSSL tests don't work now. It might be openssl options issue, cause GnuTLS has worked.
 skip_next_test

--- a/tests/opt-testcases/tls13-misc.sh
+++ b/tests/opt-testcases/tls13-misc.sh
@@ -295,6 +295,32 @@ run_test    "TLS 1.3 m->G: EarlyData: no early_data in NewSessionTicket, good" \
             -C "EncryptedExtensions: early_data(42) extension received." \
             -C "EncryptedExtensions: early_data(42) extension exists."
 
+requires_gnutls_tls1_3
+requires_config_enabled MBEDTLS_DEBUG_C
+requires_config_enabled MBEDTLS_SSL_CLI_C
+requires_all_configs_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE \
+                             MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED \
+                             MBEDTLS_SSL_EARLY_DATA
+requires_any_configs_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL_ENABLED \
+                             MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_ENABLED
+run_test    "TLS 1.3 m->G: EarlyData: write early data, fallback, good" \
+            "$G_NEXT_SRV -d 10 --priority=NORMAL:-VERS-ALL:+VERS-TLS1.3:+CIPHER-ALL:+ECDHE-PSK:+PSK \
+                         --earlydata --maxearlydata 16384 --disable-client-cert" \
+            "$P_CLI debug_level=4 early_data=1 early_data_file=$EARLY_DATA_INPUT reco_mode=1 reconnect=1 reco_delay=900" \
+            0 \
+            -c "received max_early_data_size: 16384" \
+            -c "Reconnecting with saved session" \
+            -c "Read early data successfully..." \
+            -c "NewSessionTicket: early_data(42) extension received." \
+            -c "ClientHello: early_data(42) extension exists." \
+            -c "EncryptedExtensions: early_data(42) extension received." \
+            -c "EncryptedExtensions: early_data(42) extension exists." \
+            -c "<= write EndOfEarlyData" \
+            -s "Parsing extension 'Early Data/42' (0 bytes)" \
+            -s "Sending extension Early Data/42 (0 bytes)" \
+            -s "END OF EARLY DATA (5) was received." \
+            -s "early data accepted"
+
 #TODO: OpenSSL tests don't work now. It might be openssl options issue, cause GnuTLS has worked.
 skip_next_test
 requires_openssl_tls1_3

--- a/tests/opt-testcases/tls13-misc.sh
+++ b/tests/opt-testcases/tls13-misc.sh
@@ -263,7 +263,7 @@ requires_any_configs_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL_
 run_test    "TLS 1.3 m->G: EarlyData: basic check, good" \
             "$G_NEXT_SRV -d 10 --priority=NORMAL:-VERS-ALL:+VERS-TLS1.3:+CIPHER-ALL:+ECDHE-PSK:+PSK \
                          --earlydata --maxearlydata 16384 --disable-client-cert" \
-            "$P_CLI debug_level=4 early_data=1 reco_mode=1 reconnect=1 reco_delay=900" \
+            "$P_CLI debug_level=4 early_data=$EARLY_DATA_INPUT reco_mode=1 reconnect=1 reco_delay=900" \
             0 \
             -c "received max_early_data_size: 16384" \
             -c "Reconnecting with saved session" \
@@ -287,7 +287,7 @@ requires_any_configs_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL_
                              MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_ENABLED
 run_test    "TLS 1.3 m->G: EarlyData: no early_data in NewSessionTicket, good" \
             "$G_NEXT_SRV -d 10 --priority=NORMAL:-VERS-ALL:+VERS-TLS1.3:+CIPHER-ALL:+ECDHE-PSK:+PSK --disable-client-cert" \
-            "$P_CLI debug_level=4 early_data=1 reco_mode=1 reconnect=1" \
+            "$P_CLI debug_level=4 early_data=$EARLY_DATA_INPUT reco_mode=1 reconnect=1" \
             0 \
             -c "Reconnecting with saved session" \
             -C "NewSessionTicket: early_data(42) extension received." \

--- a/tests/opt-testcases/tls13-misc.sh
+++ b/tests/opt-testcases/tls13-misc.sh
@@ -263,7 +263,7 @@ requires_any_configs_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL_
 run_test    "TLS 1.3 m->G: EarlyData: basic check, good" \
             "$G_NEXT_SRV -d 10 --priority=NORMAL:-VERS-ALL:+VERS-TLS1.3:+CIPHER-ALL:+ECDHE-PSK:+PSK \
                          --earlydata --maxearlydata 16384 --disable-client-cert" \
-            "$P_CLI debug_level=4 early_data=$EARLY_DATA_INPUT reco_mode=1 reconnect=1 reco_delay=900" \
+            "$P_CLI debug_level=4 early_data=1 reco_mode=1 reconnect=1 reco_delay=900" \
             0 \
             -c "received max_early_data_size: 16384" \
             -c "Reconnecting with saved session" \
@@ -287,7 +287,7 @@ requires_any_configs_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL_
                              MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_ENABLED
 run_test    "TLS 1.3 m->G: EarlyData: no early_data in NewSessionTicket, good" \
             "$G_NEXT_SRV -d 10 --priority=NORMAL:-VERS-ALL:+VERS-TLS1.3:+CIPHER-ALL:+ECDHE-PSK:+PSK --disable-client-cert" \
-            "$P_CLI debug_level=4 early_data=$EARLY_DATA_INPUT reco_mode=1 reconnect=1" \
+            "$P_CLI debug_level=4 early_data=1 reco_mode=1 reconnect=1" \
             0 \
             -c "Reconnecting with saved session" \
             -C "NewSessionTicket: early_data(42) extension received." \

--- a/tests/opt-testcases/tls13-misc.sh
+++ b/tests/opt-testcases/tls13-misc.sh
@@ -263,7 +263,7 @@ requires_any_configs_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL_
 run_test    "TLS 1.3 m->G: EarlyData: basic check, good" \
             "$G_NEXT_SRV -d 10 --priority=NORMAL:-VERS-ALL:+VERS-TLS1.3:+CIPHER-ALL:+ECDHE-PSK:+PSK \
                          --earlydata --maxearlydata 16384 --disable-client-cert" \
-            "$P_CLI debug_level=4 early_data=1 early_data_file=$EARLY_DATA_INPUT reco_mode=1 reconnect=1 reco_delay=900" \
+            "$P_CLI debug_level=4 early_data=$EARLY_DATA_INPUT reco_mode=1 reconnect=1 reco_delay=900" \
             0 \
             -c "received max_early_data_size: 16384" \
             -c "Reconnecting with saved session" \
@@ -287,7 +287,7 @@ requires_any_configs_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL_
                              MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_ENABLED
 run_test    "TLS 1.3 m->G: EarlyData: no early_data in NewSessionTicket, good" \
             "$G_NEXT_SRV -d 10 --priority=NORMAL:-VERS-ALL:+VERS-TLS1.3:+CIPHER-ALL:+ECDHE-PSK:+PSK --disable-client-cert" \
-            "$P_CLI debug_level=4 early_data=1 reco_mode=1 reconnect=1" \
+            "$P_CLI debug_level=4 early_data=$EARLY_DATA_INPUT reco_mode=1 reconnect=1" \
             0 \
             -c "Reconnecting with saved session" \
             -C "NewSessionTicket: early_data(42) extension received." \


### PR DESCRIPTION
## Description

Originally we have one input option to control whether enable early data or not. Currently we need one extra parameter to input various length of  early data. This pr will integrate them together.

This is part of #6542 



## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [ ] **changelog** ~~provided, or~~ not required
- [ ] **backport** ~~done, or~~ not required
- [x] **tests** provided ~~, or not required~~




