### PR TITLE
Reduce variations tested in constant_time_hmac

### DIFF
--- a/tests/suites/test_suite_constant_time_hmac.function
+++ b/tests/suites/test_suite_constant_time_hmac.function
@@ -78,11 +78,20 @@ void ssl_cf_hmac(int hash)
 #endif
 
     /*
-     * Test all possible lengths up to a point. The difference between
+     * Test various possible lengths up to a point. The difference between
      * max_in_len and min_in_len is at most 255, and make sure they both vary
      * by at least one block size.
+     *
+     * It is quite expensive to test all possible lengths, so we test values
+     * which are within 1 of a multiple of 64, plus loop end values.
      */
     for (max_in_len = 0; max_in_len <= 255 + block_size; max_in_len++) {
+        int no_skip = (((max_in_len + 65) % 64) < 3) ||
+                      (max_in_len >= ((255 + block_size) - 1));
+        if (!no_skip) {
+            continue;
+        }
+
         mbedtls_test_set_step(max_in_len * 10000);
 
         /* Use allocated in buffer to catch overreads */


### PR DESCRIPTION
## Description

Reduce time to run constant_time_hmac (from around 15m to ~50s under Valgrind).


## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** provided, or not required
- [ ] **backport** not yet
- [x] **tests** provided, or not required
