### PR TITLE
Standardise Project Detection in Shell Scripts

### DIFF
--- a/scripts/lcov.sh
+++ b/scripts/lcov.sh
@@ -34,8 +34,12 @@ set -eu
 PROJECT_NAME_FILE='./scripts/project_name.txt'
 
 in_mbedtls_repo () {
+    if [ ! -f $PROJECT_NAME_FILE ]; then
+        echo "$PROJECT_NAME_FILE does not exist... Exiting..."
+        exit 1
+    fi
     grep -Fxq "Mbed TLS" "$PROJECT_NAME_FILE"
- }
+}
 
 # Collect stats and build a HTML report.
 lcov_library_report () {

--- a/scripts/lcov.sh
+++ b/scripts/lcov.sh
@@ -35,7 +35,7 @@ PROJECT_NAME_FILE='./scripts/project_name.txt'
 
 in_mbedtls_repo () {
     if [ ! -f $PROJECT_NAME_FILE ]; then
-        echo "$PROJECT_NAME_FILE does not exist... Exiting..."
+        echo "$PROJECT_NAME_FILE does not exist... Exiting..." >&2
         exit 1
     fi
     grep -Fxq "Mbed TLS" "$PROJECT_NAME_FILE"

--- a/scripts/lcov.sh
+++ b/scripts/lcov.sh
@@ -30,10 +30,12 @@ EOF
 
 set -eu
 
-# Repository detection
-in_mbedtls_build_dir () {
-    test -d library
-}
+# Project detection
+PROJECT_NAME_FILE='./scripts/project_name.txt'
+
+in_mbedtls_repo () {
+    grep -Fxq "Mbed TLS" "$PROJECT_NAME_FILE"
+ }
 
 # Collect stats and build a HTML report.
 lcov_library_report () {
@@ -68,7 +70,7 @@ if [ $# -gt 0 ] && [ "$1" = "--help" ]; then
     exit
 fi
 
-if in_mbedtls_build_dir; then
+if in_mbedtls_repo; then
     library_dir='library'
     title='Mbed TLS'
 else

--- a/scripts/lcov.sh
+++ b/scripts/lcov.sh
@@ -32,13 +32,13 @@ set -eu
 
 # Project detection
 PROJECT_NAME_FILE='./scripts/project_name.txt'
+if read -r PROJECT_NAME < "$PROJECT_NAME_FILE"; then :; else
+    echo "$PROJECT_NAME_FILE does not exist... Exiting..." >&2
+    exit 1
+fi
 
 in_mbedtls_repo () {
-    if [ ! -f $PROJECT_NAME_FILE ]; then
-        echo "$PROJECT_NAME_FILE does not exist... Exiting..." >&2
-        exit 1
-    fi
-    grep -Fxq "Mbed TLS" "$PROJECT_NAME_FILE"
+    test "$PROJECT_NAME" = "Mbed TLS"
 }
 
 # Collect stats and build a HTML report.

--- a/scripts/project_name.txt
+++ b/scripts/project_name.txt
@@ -1,0 +1,1 @@
+Mbed TLS

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -124,7 +124,7 @@ in_mbedtls_repo () {
         exit 1
     fi
     grep -Fxq "Mbed TLS" "$PROJECT_NAME_FILE"
- }
+}
 
 in_tf_psa_crypto_repo () {
     if [ ! -f $PROJECT_NAME_FILE ]; then

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -115,12 +115,15 @@ set -e -o pipefail -u
 # Enable ksh/bash extended file matching patterns
 shopt -s extglob
 
+# For project detection
+PROJECT_NAME_FILE='./scripts/project_name.txt'
+
 in_mbedtls_repo () {
-    test -d include -a -d library -a -d programs -a -d tests
+    grep -Fxq "Mbed TLS" "$PROJECT_NAME_FILE"
 }
 
 in_tf_psa_crypto_repo () {
-    test -d include -a -d core -a -d drivers -a -d programs -a -d tests
+    grep -Fxq "TF-PSA-Crypto" "$PROJECT_NAME_FILE"
 }
 
 pre_check_environment () {

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -119,10 +119,18 @@ shopt -s extglob
 PROJECT_NAME_FILE='./scripts/project_name.txt'
 
 in_mbedtls_repo () {
+    if [ ! -f $PROJECT_NAME_FILE ]; then
+        echo "$PROJECT_NAME_FILE does not exist... Exiting..."
+        exit 1
+    fi
     grep -Fxq "Mbed TLS" "$PROJECT_NAME_FILE"
-}
+ }
 
 in_tf_psa_crypto_repo () {
+    if [ ! -f $PROJECT_NAME_FILE ]; then
+        echo "$PROJECT_NAME_FILE does not exist... Exiting..."
+        exit 1
+    fi
     grep -Fxq "TF-PSA-Crypto" "$PROJECT_NAME_FILE"
 }
 

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -116,12 +116,6 @@ set -e -o pipefail -u
 shopt -s extglob
 
 # For project detection
-PROJECT_NAME_FILE='./scripts/project_name.txt'
-if read -r PROJECT_NAME < "$PROJECT_NAME_FILE"; then :; else
-    echo "$PROJECT_NAME_FILE does not exist... Exiting..." >&2
-    exit 1
-fi
-
 in_mbedtls_repo () {
     test "$PROJECT_NAME" = "Mbed TLS"
 }
@@ -131,6 +125,13 @@ in_tf_psa_crypto_repo () {
 }
 
 pre_check_environment () {
+    # For project detection
+    PROJECT_NAME_FILE='./scripts/project_name.txt'
+    if read -r PROJECT_NAME < "$PROJECT_NAME_FILE"; then :; else
+        echo "$PROJECT_NAME_FILE does not exist... Exiting..." >&2
+        exit 1
+    fi
+
     if in_mbedtls_repo || in_tf_psa_crypto_repo; then :; else
         echo "Must be run from Mbed TLS / TF-PSA-Crypto root" >&2
         exit 1

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -117,21 +117,17 @@ shopt -s extglob
 
 # For project detection
 PROJECT_NAME_FILE='./scripts/project_name.txt'
+if read -r PROJECT_NAME < "$PROJECT_NAME_FILE"; then :; else
+    echo "$PROJECT_NAME_FILE does not exist... Exiting..." >&2
+    exit 1
+fi
 
 in_mbedtls_repo () {
-    if [ ! -f $PROJECT_NAME_FILE ]; then
-        echo "$PROJECT_NAME_FILE does not exist... Exiting..." >&2
-        exit 1
-    fi
-    grep -Fxq "Mbed TLS" "$PROJECT_NAME_FILE"
+    test "$PROJECT_NAME" = "Mbed TLS"
 }
 
 in_tf_psa_crypto_repo () {
-    if [ ! -f $PROJECT_NAME_FILE ]; then
-        echo "$PROJECT_NAME_FILE does not exist... Exiting..." >&2
-        exit 1
-    fi
-    grep -Fxq "TF-PSA-Crypto" "$PROJECT_NAME_FILE"
+    test "$PROJECT_NAME" = "TF-PSA-Crypto"
 }
 
 pre_check_environment () {

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -120,7 +120,7 @@ PROJECT_NAME_FILE='./scripts/project_name.txt'
 
 in_mbedtls_repo () {
     if [ ! -f $PROJECT_NAME_FILE ]; then
-        echo "$PROJECT_NAME_FILE does not exist... Exiting..."
+        echo "$PROJECT_NAME_FILE does not exist... Exiting..." >&2
         exit 1
     fi
     grep -Fxq "Mbed TLS" "$PROJECT_NAME_FILE"
@@ -128,7 +128,7 @@ in_mbedtls_repo () {
 
 in_tf_psa_crypto_repo () {
     if [ ! -f $PROJECT_NAME_FILE ]; then
-        echo "$PROJECT_NAME_FILE does not exist... Exiting..."
+        echo "$PROJECT_NAME_FILE does not exist... Exiting..." >&2
         exit 1
     fi
     grep -Fxq "TF-PSA-Crypto" "$PROJECT_NAME_FILE"


### PR DESCRIPTION
## Description
Fixes #8524 

This PR introduces a more robust way for shell scripts to establish which repository they are being called from, rather than relying on project directory structure as was the case before.

Link to release build CI run for `lcov.sh` testing: https://mbedtls.trustedfirmware.org/job/mbedtls-release-ci-testing/253/
## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required - Not user visible
- [x] **3.6 backport**  #9437
- [x] **2.28 backport** not required - Enhancement
- [x] **tests** not required - Sufficient tests already in place



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.
