### PR TITLE
Fix potential double-free in calloc selftest

### DIFF
--- a/programs/test/selftest.c
+++ b/programs/test/selftest.c
@@ -79,6 +79,7 @@ static int calloc_self_test(int verbose)
         if (verbose) {
             mbedtls_printf("  CALLOC(0,1): passed (same non-null)\n");
         }
+        empty2 = NULL;
     } else {
         if (verbose) {
             mbedtls_printf("  CALLOC(0,1): passed (distinct non-null)\n");
@@ -103,6 +104,7 @@ static int calloc_self_test(int verbose)
         if (verbose) {
             mbedtls_printf("  CALLOC(1,0): passed (same non-null)\n");
         }
+        empty2 = NULL;
     } else {
         if (verbose) {
             mbedtls_printf("  CALLOC(1,0): passed (distinct non-null)\n");
@@ -119,6 +121,7 @@ static int calloc_self_test(int verbose)
             mbedtls_printf("  CALLOC(1): failed (same buffer twice)\n");
         }
         ++failures;
+        buffer2 = NULL;
     } else {
         if (verbose) {
             mbedtls_printf("  CALLOC(1): passed\n");


### PR DESCRIPTION
Where `calloc()` returns two references to the same buffer, avoid calling `free()` on both references by setting one to NULL.

Reported by Coverity.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required - testing fixes, internal only
- [x] **backport** done
- [x] **tests** not required - minor fix