### PR TITLE
[Backport 2.28] Fix potential double-free in calloc selftest

### DIFF
--- a/programs/test/selftest.c
+++ b/programs/test/selftest.c
@@ -83,6 +83,7 @@ static int calloc_self_test(int verbose)
         if (verbose) {
             mbedtls_printf("  CALLOC(0,1): passed (same non-null)\n");
         }
+        empty2 = NULL;
     } else {
         if (verbose) {
             mbedtls_printf("  CALLOC(0,1): passed (distinct non-null)\n");
@@ -107,6 +108,7 @@ static int calloc_self_test(int verbose)
         if (verbose) {
             mbedtls_printf("  CALLOC(1,0): passed (same non-null)\n");
         }
+        empty2 = NULL;
     } else {
         if (verbose) {
             mbedtls_printf("  CALLOC(1,0): passed (distinct non-null)\n");
@@ -123,6 +125,7 @@ static int calloc_self_test(int verbose)
             mbedtls_printf("  CALLOC(1): failed (same buffer twice)\n");
         }
         ++failures;
+        buffer2 = NULL;
     } else {
         if (verbose) {
             mbedtls_printf("  CALLOC(1): passed\n");


### PR DESCRIPTION
Trivial backport of #8619.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required - internal testing change
- [x] **backport** of #8619 
- [x] **tests** not required - minor fix
