### PR TITLE
Use TF-M config verbatim

### DIFF
--- a/configs/config-tfm.h
+++ b/configs/config-tfm.h
@@ -21,9 +21,6 @@
 /* MBEDTLS_PSA_CRYPTO_SPM needs third-party files, so disable it. */
 #undef MBEDTLS_PSA_CRYPTO_SPM
 
-/* Use built-in platform entropy functions (TF-M provides its own). */
-#undef MBEDTLS_NO_PLATFORM_ENTROPY
-
 /* Disable buffer-based memory allocator. This isn't strictly required,
  * but using the native allocator is faster and works better with
  * memory management analysis frameworks such as ASan. */
@@ -53,10 +50,14 @@
 /*
  * In order to get an example config that works cleanly out-of-the-box
  * for both baremetal and non-baremetal builds, we detect baremetal builds
- * and set this variable automatically.
+ * (either IAR, Arm compiler or __ARM_EABI__ defined), and adjust some
+ * variables accordingly.
  */
-#if defined(__IAR_SYSTEMS_ICC__) || defined(__ARM_EABI__)
+#if defined(__IAR_SYSTEMS_ICC__) || defined(__ARMCC_VERSION) || defined(__ARM_EABI__)
 #define MBEDTLS_NO_PLATFORM_ENTROPY
+#else
+/* Use built-in platform entropy functions (TF-M provides its own). */
+#undef MBEDTLS_NO_PLATFORM_ENTROPY
 #endif
 
 /***********************************************************************

--- a/configs/config-tfm.h
+++ b/configs/config-tfm.h
@@ -42,11 +42,6 @@
 #undef MBEDTLS_PLATFORM_STD_EXIT_SUCCESS
 #undef MBEDTLS_PLATFORM_STD_EXIT_FAILURE
 
-/* CCM is the only cipher/AEAD enabled in TF-M configuration files, but it
- * does not need CIPHER_C to be enabled, so we can disable it in order
- * to reduce code size further. */
-#undef MBEDTLS_CIPHER_C
-
 /*
  * In order to get an example config that works cleanly out-of-the-box
  * for both baremetal and non-baremetal builds, we detect baremetal builds
@@ -66,3 +61,8 @@
 
 // We expect TF-M to pick this up soon
 #define MBEDTLS_BLOCK_CIPHER_NO_DECRYPT
+
+/* CCM is the only cipher/AEAD enabled in TF-M configuration files, but it
+ * does not need CIPHER_C to be enabled, so we can disable it in order
+ * to reduce code size further. */
+#undef MBEDTLS_CIPHER_C

--- a/configs/ext/README.md
+++ b/configs/ext/README.md
@@ -2,7 +2,7 @@ Summary
 -------
 
 All files in this directory are distributed under the normal Mbed TLS dual Apache 2.0 or GPLv2-or-later
-license.
+license, and are copyright The Mbed TLS Contributors.
 
 Background
 -----------
@@ -14,7 +14,7 @@ https://git.trustedfirmware.org/TF-M/trusted-firmware-m.git/tree/lib/ext/mbedcry
 
 In TF-M, they are distributed under a 3-Clause BSD license, as noted at the top of the files.
 
-In Mbed TLS, with permission from the TF-M project, they are distributed under a dual [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) OR [GPL-2.0-or-later](https://spdx.org/licenses/GPL-2.0-or-later.html) license.
+In Mbed TLS, with permission from the TF-M project, they are distributed under a dual [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) OR [GPL-2.0-or-later](https://spdx.org/licenses/GPL-2.0-or-later.html) license, with copyright assigned to The Mbed TLS Contributors.
 
 We only retain the note at the top of the files because we are taking the files un-modified, for ease of
 maintenance.

--- a/configs/ext/README.md
+++ b/configs/ext/README.md
@@ -1,11 +1,16 @@
 Summary
 -------
 
-All files in this directory are distributed under the normal Mbed TLS dual Apache 2.0 or GPLv2-or-later
-license, and are copyright The Mbed TLS Contributors.
+The two files:
+
+* crypto_config_profile_medium.h
+* tfm_mbedcrypto_config_profile_medium.h
+
+are copyright The Mbed TLS Contributors, and are distributed under the license normally
+used by Mbed TLS: a dual Apache 2.0 or GPLv2-or-later license.
 
 Background
------------
+----------
 
 The two files crypto_config_profile_medium.h and tfm_mbedcrypto_config_profile_medium.h
 are taken verbatim from the TF-M source code here:
@@ -16,5 +21,5 @@ In TF-M, they are distributed under a 3-Clause BSD license, as noted at the top 
 
 In Mbed TLS, with permission from the TF-M project, they are distributed under a dual [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) OR [GPL-2.0-or-later](https://spdx.org/licenses/GPL-2.0-or-later.html) license, with copyright assigned to The Mbed TLS Contributors.
 
-We only retain the note at the top of the files because we are taking the files un-modified, for ease of
+We only retain the note at the top of the files because we are taking the files verbatim, for ease of
 maintenance.

--- a/configs/ext/README.md
+++ b/configs/ext/README.md
@@ -1,0 +1,20 @@
+Summary
+-------
+
+All files in this directory are distributed under the normal Mbed TLS dual Apache 2.0 or GPLv2-or-later
+license.
+
+Background
+-----------
+
+The two files crypto_config_profile_medium.h and tfm_mbedcrypto_config_profile_medium.h
+are taken verbatim from the TF-M source code here:
+
+https://git.trustedfirmware.org/TF-M/trusted-firmware-m.git/tree/lib/ext/mbedcrypto/mbedcrypto_config
+
+In TF-M, they are distributed under a 3-Clause BSD license, as noted at the top of the files.
+
+In Mbed TLS, with permission from the TF-M project, they are distributed under a dual [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) OR [GPL-2.0-or-later](https://spdx.org/licenses/GPL-2.0-or-later.html) license.
+
+We only retain the note at the top of the files because we are taking the files un-modified, for ease of
+maintenance.

--- a/configs/ext/config_tfm.h
+++ b/configs/ext/config_tfm.h
@@ -1,0 +1,13 @@
+/*
+ *  Empty placeholder
+ *
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+ */
+
+/*
+ * This file is intentionally empty.
+ *
+ * Having an empty file here allows us to build the TF-M config, which references this file,
+ * without making any changes to the TF-M config.
+ */

--- a/configs/ext/crypto_config_profile_medium.h
+++ b/configs/ext/crypto_config_profile_medium.h
@@ -1,13 +1,14 @@
+/*
+ * Copyright (c) 2018-2023, Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
 /**
  * \file psa/crypto_config.h
  * \brief PSA crypto configuration options (set of defines)
  *
  */
-/*
- * Copyright The Mbed TLS Contributors
- * SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
- */
-
 #if defined(MBEDTLS_PSA_CRYPTO_CONFIG)
 /**
  * When #MBEDTLS_PSA_CRYPTO_CONFIG is enabled in mbedtls_config.h,

--- a/configs/ext/mbedtls_entropy_nv_seed_config.h
+++ b/configs/ext/mbedtls_entropy_nv_seed_config.h
@@ -1,0 +1,13 @@
+/*
+ *  Empty placeholder
+ *
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+ */
+
+/*
+ * This file is intentionally empty.
+ *
+ * Having an empty file here allows us to build the TF-M config, which references this file,
+ * without making any changes to the TF-M config.
+ */

--- a/configs/ext/tfm_mbedcrypto_config_profile_medium.h
+++ b/configs/ext/tfm_mbedcrypto_config_profile_medium.h
@@ -8,14 +8,28 @@
  *  memory footprint.
  */
 /*
- *  Copyright The Mbed TLS Contributors
- *  SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+ *  Copyright (C) 2006-2023, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
  */
 
 #ifndef PROFILE_M_MBEDTLS_CONFIG_H
 #define PROFILE_M_MBEDTLS_CONFIG_H
 
-//#include "config_tfm.h"
+#include "config_tfm.h"
 
 #if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_DEPRECATE)
 #define _CRT_SECURE_NO_DEPRECATE 1
@@ -549,7 +563,7 @@
 #endif /* CRYPTO_NV_SEED */
 
 #if !defined(CRYPTO_HW_ACCELERATOR) && defined(MBEDTLS_ENTROPY_NV_SEED)
-//#include "mbedtls_entropy_nv_seed_config.h"
+#include "mbedtls_entropy_nv_seed_config.h"
 #endif
 
 #ifdef CRYPTO_HW_ACCELERATOR

--- a/tests/scripts/check_files.py
+++ b/tests/scripts/check_files.py
@@ -373,8 +373,9 @@ class LicenseIssueTracker(LineIssueTracker):
         r'(ChangeLog|LICENSE|[-0-9A-Z_a-z]+\.md)\Z',
         # Files imported from TF-M, and not used except in test builds,
         # may be under a different license.
-        r'configs/crypto_config_profile_medium\.h\Z',
-        r'configs/tfm_mbedcrypto_config_profile_medium\.h\Z',
+        r'configs/ext/crypto_config_profile_medium\.h\Z',
+        r'configs/ext/tfm_mbedcrypto_config_profile_medium\.h\Z',
+        r'configs/ext/README\.md\Z',
         # Third-party file.
         r'dco\.txt\Z',
     ]


### PR DESCRIPTION
## Description

To simplify maintenance, take the TF-M config verbatim.

Update: also moves a recent change introduced in #8599 into the correct section, and fixes building with armclang for aarch64 (this was not being detected as baremetal because `__ARM_EABI__` isn't set).

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required
- [x] **backport** not required
- [x] **tests** not required
