### PR TITLE
[Backport 2.28] Fix possible free of uninitialized MPI

### DIFF
--- a/tests/suites/test_suite_x509write.function
+++ b/tests/suites/test_suite_x509write.function
@@ -435,10 +435,11 @@ void x509_set_serial_check()
     mbedtls_mpi serial_mpi;
     uint8_t invalid_serial[MBEDTLS_X509_RFC5280_MAX_SERIAL_LEN + 1];
 
+    mbedtls_mpi_init(&serial_mpi);
+
     USE_PSA_INIT();
     memset(invalid_serial, 0x01, sizeof(invalid_serial));
 
-    mbedtls_mpi_init(&serial_mpi);
     TEST_EQUAL(mbedtls_mpi_read_binary(&serial_mpi, invalid_serial,
                                        sizeof(invalid_serial)), 0);
     TEST_EQUAL(mbedtls_x509write_crt_set_serial(&ctx, &serial_mpi),


### PR DESCRIPTION
Simple if not trivial backport of #8626.

This prevents a call to `mbedtls_mpi_free()` on uninitialized data when `USE_PSA_INIT()` fails.

Issue reported by Coverity.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required - minor non-user-facing fix
- [x] **backport** of #8626 
- [x] **tests** not required - fixes a test
