### PR TITLE
Make clienthello comment clear

### DIFF
--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -1128,11 +1128,11 @@ read_record_header:
     msg_len -= mbedtls_ssl_hs_hdr_len(ssl);
 
     /*
-     * ClientHello layer:
+     * ClientHello layout:
      *     0  .   1   protocol version
      *     2  .  33   random bytes (starting with 4 bytes of Unix time)
-     *    34  .  35   session id length (1 byte)
-     *    35  . 34+x  session id
+     *    34  .  34   session id length (1 byte)
+     *    35  . 34+x  session id, where x = session id length from byte 34
      *   35+x . 35+x  DTLS only: cookie length (1 byte)
      *   36+x .  ..   DTLS only: cookie
      *    ..  .  ..   ciphersuite list length (2 bytes)


### PR DESCRIPTION
## Description

The `clienthello` session id comment is wrong, which should be 34 to 34.  And add the meaning of `x`.



## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required:  only change the comment
- [x] **backport** not required
- [x] **tests** not required
