### PR TITLE
[Backport 2.28] Set OpenSSL/GnuTLS variables when running release components

### DIFF
--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -711,7 +711,7 @@ pre_check_tools () {
         # Require OpenSSL and GnuTLS if running any tests (as opposed to
         # only doing builds). Not all tests run OpenSSL and GnuTLS, but this
         # is a good enough approximation in practice.
-        *" test_"*)
+        *" test_"* | *" release_test_"*)
             # To avoid setting OpenSSL and GnuTLS for each call to compat.sh
             # and ssl-opt.sh, we just export the variables they require.
             export OPENSSL="$OPENSSL"

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -75,6 +75,7 @@
 #      * component_check_XXX: quick tests that aren't worth parallelizing.
 #      * component_build_XXX: build things but don't run them.
 #      * component_test_XXX: build and test.
+#      * component_release_XXX: tests that the CI should skip during PR testing.
 #  * support_XXX: if support_XXX exists and returns false then
 #    component_XXX is not run by default.
 #  * post_XXX: things to do after running the tests.


### PR DESCRIPTION
## Description

Backport of #8639 

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required: test changes only
- [x] **tests** not required: all.sh changes only