### PR TITLE
Guard configuration-specific code in ssl_tls12_server.c

### DIFF
--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -2635,13 +2635,8 @@ static int ssl_get_ecdh_params_from_cert(mbedtls_ssl_context *ssl)
             ssl->handshake->xxdh_psa_type = psa_get_key_type(&key_attributes);
             ssl->handshake->xxdh_psa_bits = psa_get_key_bits(&key_attributes);
 
-            if (pk_type == MBEDTLS_PK_OPAQUE) {
-                /* Opaque key is created by the user (externally from Mbed TLS)
-                 * so we assume it already has the right algorithm and flags
-                 * set. Just copy its ID as reference. */
-                ssl->handshake->xxdh_psa_privkey = pk->priv_id;
-                ssl->handshake->xxdh_psa_privkey_is_external = 1;
-            } else {
+#if defined(MBEDTLS_PK_USE_PSA_EC_DATA)
+            if (pk_type != MBEDTLS_PK_OPAQUE) {
                 /* PK_ECKEY[_DH] and PK_ECDSA instead as parsed from the PK
                  * module and only have ECDSA capabilities. Since we need
                  * them for ECDH later, we export and then re-import them with
@@ -2669,10 +2664,20 @@ static int ssl_get_ecdh_params_from_cert(mbedtls_ssl_context *ssl)
                 /* Set this key as owned by the TLS library: it will be its duty
                  * to clear it exit. */
                 ssl->handshake->xxdh_psa_privkey_is_external = 0;
-            }
 
+                ret = 0;
+                break;
+            }
+#endif /* MBEDTLS_PK_USE_PSA_EC_DATA */
+
+            /* Opaque key is created by the user (externally from Mbed TLS)
+             * so we assume it already has the right algorithm and flags
+             * set. Just copy its ID as reference. */
+            ssl->handshake->xxdh_psa_privkey = pk->priv_id;
+            ssl->handshake->xxdh_psa_privkey_is_external = 1;
             ret = 0;
             break;
+
 #if !defined(MBEDTLS_PK_USE_PSA_EC_DATA)
         case MBEDTLS_PK_ECKEY:
         case MBEDTLS_PK_ECKEY_DH:


### PR DESCRIPTION
A large block of code is only reachable if MBEDTLS_PK_USE_PSA_EC_DATA is enabled, i.e. if MBEDTLS_USE_PSA_CRYPTO is enabled with driver-only ECC. Compilers are likely to figure it out, but still, for clarity and robustness, do guard that block of code with the appropriate conditional compilation guard.

Found by Coverity.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** no (refactoring)
- [x] **3.6 backport** https://github.com/Mbed-TLS/mbedtls/pull/9205
- [x] **2.28 backport** no (new code)
- [x] **tests** existing (refactoring)
