### PR TITLE
Using make with paramter GEN_FILES="" still requires Python

### DIFF
--- a/library/Makefile
+++ b/library/Makefile
@@ -357,9 +357,9 @@ version_features.c:
 GENERATED_WRAPPER_FILES = \
                     psa_crypto_driver_wrappers.h \
                     psa_crypto_driver_wrappers_no_static.c
-$(GENERATED_WRAPPER_FILES): ../scripts/generate_driver_wrappers.py
-$(GENERATED_WRAPPER_FILES): ../scripts/data_files/driver_templates/psa_crypto_driver_wrappers.h.jinja
-$(GENERATED_WRAPPER_FILES): ../scripts/data_files/driver_templates/psa_crypto_driver_wrappers_no_static.c.jinja
+$(GENERATED_WRAPPER_FILES): $(gen_file_dep) ../scripts/generate_driver_wrappers.py
+$(GENERATED_WRAPPER_FILES): $(gen_file_dep) ../scripts/data_files/driver_templates/psa_crypto_driver_wrappers.h.jinja
+$(GENERATED_WRAPPER_FILES): $(gen_file_dep) ../scripts/data_files/driver_templates/psa_crypto_driver_wrappers_no_static.c.jinja
 $(GENERATED_WRAPPER_FILES):
 	echo "  Gen   $(GENERATED_WRAPPER_FILES)"
 	$(PYTHON) ../scripts/generate_driver_wrappers.py


### PR DESCRIPTION
## Description

Using make in library with paramter GEN_FILES="" still requires Python installed, since ../scripts/generate_driver_wrappers.py is executed. To get expected behavior $(gen_file_dep) was inserted


## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [ x] **changelog** not required
- [ x] **backport** not required
- [ x] **tests** not required



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.
