### PR TITLE
check_config.h not complete about builds without CIPHER_C

### DIFF
--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -203,6 +203,19 @@
 #endif
 #endif
 
+#if defined(MBEDTLS_PSA_CRYPTO_C) && \
+    (defined(MBEDTLS_PSA_BUILTIN_ALG_STREAM_CIPHER) || \
+    defined(MBEDTLS_PSA_BUILTIN_ALG_CTR) || \
+    defined(MBEDTLS_PSA_BUILTIN_ALG_CFB) || \
+    defined(MBEDTLS_PSA_BUILTIN_ALG_OFB) || \
+    defined(MBEDTLS_PSA_BUILTIN_ALG_ECB_NO_PADDING) || \
+    defined(MBEDTLS_PSA_BUILTIN_ALG_CBC_NO_PADDING) || \
+    defined(MBEDTLS_PSA_BUILTIN_ALG_CBC_PKCS7) || \
+    defined(MBEDTLS_PSA_BUILTIN_ALG_CCM_STAR_NO_TAG)) && \
+    !defined(MBEDTLS_CIPHER_C)
+#error "Built-in unauthenticated ciphers are enabled in PSA, but not all prerequisites"
+#endif
+
 #if defined(MBEDTLS_ECDH_C) && !defined(MBEDTLS_ECP_C)
 #error "MBEDTLS_ECDH_C defined, but not all prerequisites"
 #endif

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -203,19 +203,6 @@
 #endif
 #endif
 
-#if defined(MBEDTLS_PSA_CRYPTO_C) && \
-    (defined(MBEDTLS_PSA_BUILTIN_ALG_STREAM_CIPHER) || \
-    defined(MBEDTLS_PSA_BUILTIN_ALG_CTR) || \
-    defined(MBEDTLS_PSA_BUILTIN_ALG_CFB) || \
-    defined(MBEDTLS_PSA_BUILTIN_ALG_OFB) || \
-    defined(MBEDTLS_PSA_BUILTIN_ALG_ECB_NO_PADDING) || \
-    defined(MBEDTLS_PSA_BUILTIN_ALG_CBC_NO_PADDING) || \
-    defined(MBEDTLS_PSA_BUILTIN_ALG_CBC_PKCS7) || \
-    defined(MBEDTLS_PSA_BUILTIN_ALG_CCM_STAR_NO_TAG)) && \
-    !defined(MBEDTLS_CIPHER_C)
-#error "Built-in unauthenticated ciphers are enabled in PSA, but not all prerequisites"
-#endif
-
 #if defined(MBEDTLS_ECDH_C) && !defined(MBEDTLS_ECP_C)
 #error "MBEDTLS_ECDH_C defined, but not all prerequisites"
 #endif

--- a/include/mbedtls/config_adjust_legacy_crypto.h
+++ b/include/mbedtls/config_adjust_legacy_crypto.h
@@ -22,6 +22,20 @@
 #ifndef MBEDTLS_CONFIG_ADJUST_LEGACY_CRYPTO_H
 #define MBEDTLS_CONFIG_ADJUST_LEGACY_CRYPTO_H
 
+/* Auto-enable CIPHER_C when any of the unauthenticated ciphers is builtin
+ * in PSA. */
+#if defined(MBEDTLS_PSA_CRYPTO_C) && \
+    (defined(MBEDTLS_PSA_BUILTIN_ALG_STREAM_CIPHER) || \
+    defined(MBEDTLS_PSA_BUILTIN_ALG_CTR) || \
+    defined(MBEDTLS_PSA_BUILTIN_ALG_CFB) || \
+    defined(MBEDTLS_PSA_BUILTIN_ALG_OFB) || \
+    defined(MBEDTLS_PSA_BUILTIN_ALG_ECB_NO_PADDING) || \
+    defined(MBEDTLS_PSA_BUILTIN_ALG_CBC_NO_PADDING) || \
+    defined(MBEDTLS_PSA_BUILTIN_ALG_CBC_PKCS7) || \
+    defined(MBEDTLS_PSA_BUILTIN_ALG_CCM_STAR_NO_TAG))
+#define MBEDTLS_CIPHER_C
+#endif
+
 /* Auto-enable MBEDTLS_MD_LIGHT based on MBEDTLS_MD_C.
  * This allows checking for MD_LIGHT rather than MD_LIGHT || MD_C.
  */

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -2579,6 +2579,8 @@
  *          library/ssl_ciphersuites.c
  *          library/ssl_msg.c
  *          library/ssl_ticket.c (unless MBEDTLS_USE_PSA_CRYPTO is enabled)
+ * Auto-enabled by: MBEDTLS_PSA_CRYPTO_C depending on which ciphers are enabled
+ *                  (see the documentation of that option for details).
  *
  * Uncomment to enable generic cipher wrappers.
  */
@@ -3167,9 +3169,10 @@
  *
  * Requires: either MBEDTLS_CTR_DRBG_C and MBEDTLS_ENTROPY_C,
  *           or MBEDTLS_HMAC_DRBG_C and MBEDTLS_ENTROPY_C,
- *           or MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG;
- *           MBEDTLS_CIPHER_C if any unauthenticated cipher is builtin in PSA.
- *
+ *           or MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG.
+ * Auto-enables: MBEDTLS_CIPHER_C if any unauthenticated (ie, non-AEAD) cipher
+ *               is enabled in PSA (unless it's fully accelerated, see
+ *               docs/driver-only-builds.md about that).
  */
 #define MBEDTLS_PSA_CRYPTO_C
 

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -3167,7 +3167,8 @@
  *
  * Requires: either MBEDTLS_CTR_DRBG_C and MBEDTLS_ENTROPY_C,
  *           or MBEDTLS_HMAC_DRBG_C and MBEDTLS_ENTROPY_C,
- *           or MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG.
+ *           or MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG;
+ *           MBEDTLS_CIPHER_C if any unauthenticated cipher is builtin in PSA.
  *
  */
 #define MBEDTLS_PSA_CRYPTO_C


### PR DESCRIPTION
Check if `CIPHER_C` is enabled when PSA builtin unauthenticated ciphers are enabled.
Resolves #8646

## PR checklist

- [x] **changelog** not required
- [x] **backport** not required
- [x] **tests** not required
