### PR TITLE
Autodetect whether linking with pthread is needed

### DIFF
--- a/programs/Makefile
+++ b/programs/Makefile
@@ -6,8 +6,10 @@ WARNING_CFLAGS ?= -Wall -Wextra -Wformat=2 -Wno-format-nonliteral
 WARNING_CXXFLAGS ?= -Wall -Wextra -Wformat=2 -Wno-format-nonliteral
 LDFLAGS ?=
 
-MBEDTLS_TEST_PATH:=../tests/src
-MBEDTLS_TEST_OBJS:=$(patsubst %.c,%.o,$(wildcard ${MBEDTLS_TEST_PATH}/*.c ${MBEDTLS_TEST_PATH}/drivers/*.c))
+MBEDTLS_TEST_PATH = ../tests
+# Support code used by test programs and test builds, excluding TLS-specific
+# code which is in the src/test_helpers subdirectory.
+MBEDTLS_TEST_OBJS = $(patsubst %.c,%.o,$(wildcard ${MBEDTLS_TEST_PATH}/src/*.c ${MBEDTLS_TEST_PATH}/src/drivers/*.c))
 
 LOCAL_CFLAGS = $(WARNING_CFLAGS) -I../tests/include -I../include -D_FILE_OFFSET_BITS=64
 LOCAL_CXXFLAGS = $(WARNING_CXXFLAGS) -I../include -I../tests/include -D_FILE_OFFSET_BITS=64

--- a/programs/Makefile
+++ b/programs/Makefile
@@ -1,23 +1,10 @@
-
-# To compile on SunOS: add "-lsocket -lnsl" to LDFLAGS
-
-CFLAGS	?= -O2
-WARNING_CFLAGS ?= -Wall -Wextra -Wformat=2 -Wno-format-nonliteral
-WARNING_CXXFLAGS ?= -Wall -Wextra -Wformat=2 -Wno-format-nonliteral
-LDFLAGS ?=
-
 MBEDTLS_TEST_PATH = ../tests
 # Support code used by test programs and test builds, excluding TLS-specific
 # code which is in the src/test_helpers subdirectory.
 MBEDTLS_TEST_OBJS = $(patsubst %.c,%.o,$(wildcard ${MBEDTLS_TEST_PATH}/src/*.c ${MBEDTLS_TEST_PATH}/src/drivers/*.c))
 
 LOCAL_CFLAGS = $(WARNING_CFLAGS) -I$(MBEDTLS_TEST_PATH)/include -I../include -D_FILE_OFFSET_BITS=64
-LOCAL_CXXFLAGS = $(WARNING_CXXFLAGS) -I../include -I../tests/include -D_FILE_OFFSET_BITS=64
-LOCAL_LDFLAGS = ${MBEDTLS_TEST_OBJS} 		\
-		-L../library 			\
-		-lmbedtls$(SHARED_SUFFIX)	\
-		-lmbedx509$(SHARED_SUFFIX)	\
-		-lmbedcrypto$(SHARED_SUFFIX)
+include ../scripts/common.make
 
 ifeq ($(shell uname -s),Linux)
 DLOPEN_LDFLAGS ?= -ldl

--- a/programs/Makefile
+++ b/programs/Makefile
@@ -11,7 +11,7 @@ MBEDTLS_TEST_PATH = ../tests
 # code which is in the src/test_helpers subdirectory.
 MBEDTLS_TEST_OBJS = $(patsubst %.c,%.o,$(wildcard ${MBEDTLS_TEST_PATH}/src/*.c ${MBEDTLS_TEST_PATH}/src/drivers/*.c))
 
-LOCAL_CFLAGS = $(WARNING_CFLAGS) -I../tests/include -I../include -D_FILE_OFFSET_BITS=64
+LOCAL_CFLAGS = $(WARNING_CFLAGS) -I$(MBEDTLS_TEST_PATH)/include -I../include -D_FILE_OFFSET_BITS=64
 LOCAL_CXXFLAGS = $(WARNING_CXXFLAGS) -I../include -I../tests/include -D_FILE_OFFSET_BITS=64
 LOCAL_LDFLAGS = ${MBEDTLS_TEST_OBJS} 		\
 		-L../library 			\

--- a/programs/Makefile
+++ b/programs/Makefile
@@ -43,16 +43,17 @@ WINDOWS_BUILD=1
 endif
 
 ifdef WINDOWS_BUILD
-DLEXT=dll
-EXEXT=.exe
-LOCAL_LDFLAGS += -lws2_32 -lbcrypt
-ifdef SHARED
-SHARED_SUFFIX=.$(DLEXT)
-endif
-else
-DLEXT ?= so
-EXEXT=
-SHARED_SUFFIX=
+  DLEXT=dll
+  EXEXT=.exe
+  LOCAL_LDFLAGS += -lws2_32 -lbcrypt
+  ifdef SHARED
+    SHARED_SUFFIX=.$(DLEXT)
+  endif
+
+else # Not building for Windows
+  DLEXT ?= so
+  EXEXT=
+  SHARED_SUFFIX=
 endif
 
 ifdef WINDOWS

--- a/programs/Makefile
+++ b/programs/Makefile
@@ -12,44 +12,7 @@ else
 DLOPEN_LDFLAGS ?=
 endif
 
-include ../3rdparty/Makefile.inc
-LOCAL_CFLAGS+=$(THIRDPARTY_INCLUDES)
-
-ifndef SHARED
-MBEDLIBS=../library/libmbedcrypto.a ../library/libmbedx509.a ../library/libmbedtls.a
-else
-MBEDLIBS=../library/libmbedcrypto.$(DLEXT) ../library/libmbedx509.$(DLEXT) ../library/libmbedtls.$(DLEXT)
-endif
 DEP=${MBEDLIBS} ${MBEDTLS_TEST_OBJS}
-
-ifdef DEBUG
-LOCAL_CFLAGS += -g3
-endif
-
-# if we're running on Windows, build for Windows
-ifdef WINDOWS
-WINDOWS_BUILD=1
-endif
-
-ifdef WINDOWS_BUILD
-  DLEXT=dll
-  EXEXT=.exe
-  LOCAL_LDFLAGS += -lws2_32 -lbcrypt
-  ifdef SHARED
-    SHARED_SUFFIX=.$(DLEXT)
-  endif
-
-else # Not building for Windows
-  DLEXT ?= so
-  EXEXT=
-  SHARED_SUFFIX=
-endif
-
-ifdef WINDOWS
-PYTHON ?= python
-else
-PYTHON ?= $(shell if type python3 >/dev/null 2>/dev/null; then echo python3; else echo python; fi)
-endif
 
 # Only build the dlopen test in shared library builds, and not when building
 # for Windows.
@@ -167,14 +130,6 @@ ${MBEDTLS_TEST_OBJS}:
 .PHONY: generated_files
 GENERATED_FILES = psa/psa_constant_names_generated.c test/query_config.c
 generated_files: $(GENERATED_FILES)
-
-# See root Makefile
-GEN_FILES ?= yes
-ifdef GEN_FILES
-gen_file_dep =
-else
-gen_file_dep = |
-endif
 
 psa/psa_constant_names_generated.c: $(gen_file_dep) ../scripts/generate_psa_constants.py
 psa/psa_constant_names_generated.c: $(gen_file_dep) ../include/psa/crypto_values.h

--- a/programs/Makefile
+++ b/programs/Makefile
@@ -121,9 +121,6 @@ endif
 fuzz: ${MBEDTLS_TEST_OBJS}
 	$(MAKE) -C fuzz THIRDPARTY_INCLUDES=$(THIRDPARTY_INCLUDES)
 
-$(MBEDLIBS):
-	$(MAKE) -C ../library
-
 ${MBEDTLS_TEST_OBJS}:
 	$(MAKE) -C ../tests mbedtls_test
 
@@ -431,13 +428,6 @@ else
 	if exist test\cpp_dummy_build.cpp del /Q /F test\cpp_dummy_build.cpp
 endif
 	$(MAKE) -C fuzz clean
-
-neat: clean
-ifndef WINDOWS
-	rm -f $(GENERATED_FILES)
-else
-	for %f in ($(subst /,\,$(GENERATED_FILES))) if exist %f del /Q /F %f
-endif
 
 list:
 	echo $(EXES)

--- a/scripts/common.make
+++ b/scripts/common.make
@@ -62,3 +62,15 @@ gen_file_dep =
 else
 gen_file_dep = |
 endif
+
+default: all
+
+$(MBEDLIBS):
+	$(MAKE) -C ../library
+
+neat: clean
+ifndef WINDOWS
+	rm -f $(GENERATED_FILES)
+else
+	for %f in ($(subst /,\,$(GENERATED_FILES))) if exist %f del /Q /F %f
+endif

--- a/scripts/common.make
+++ b/scripts/common.make
@@ -12,3 +12,53 @@ LOCAL_LDFLAGS = ${MBEDTLS_TEST_OBJS} 		\
 		-lmbedtls$(SHARED_SUFFIX)	\
 		-lmbedx509$(SHARED_SUFFIX)	\
 		-lmbedcrypto$(SHARED_SUFFIX)
+
+include ../3rdparty/Makefile.inc
+LOCAL_CFLAGS+=$(THIRDPARTY_INCLUDES)
+
+ifndef SHARED
+MBEDLIBS=../library/libmbedcrypto.a ../library/libmbedx509.a ../library/libmbedtls.a
+else
+MBEDLIBS=../library/libmbedcrypto.$(DLEXT) ../library/libmbedx509.$(DLEXT) ../library/libmbedtls.$(DLEXT)
+endif
+
+ifdef DEBUG
+LOCAL_CFLAGS += -g3
+endif
+
+# if we're running on Windows, build for Windows
+ifdef WINDOWS
+WINDOWS_BUILD=1
+endif
+
+ifdef WINDOWS_BUILD
+  DLEXT=dll
+  EXEXT=.exe
+  LOCAL_LDFLAGS += -lws2_32 -lbcrypt
+  ifdef SHARED
+    SHARED_SUFFIX=.$(DLEXT)
+  endif
+
+else # Not building for Windows
+  DLEXT ?= so
+  EXEXT=
+  SHARED_SUFFIX=
+
+  ifeq ($(THREADING),pthread)
+    LOCAL_LDFLAGS += -lpthread
+  endif
+endif
+
+ifdef WINDOWS
+PYTHON ?= python
+else
+PYTHON ?= $(shell if type python3 >/dev/null 2>/dev/null; then echo python3; else echo python; fi)
+endif
+
+# See root Makefile
+GEN_FILES ?= yes
+ifdef GEN_FILES
+gen_file_dep =
+else
+gen_file_dep = |
+endif

--- a/scripts/common.make
+++ b/scripts/common.make
@@ -1,0 +1,14 @@
+# To compile on SunOS: add "-lsocket -lnsl" to LDFLAGS
+
+CFLAGS	?= -O2
+WARNING_CFLAGS ?= -Wall -Wextra -Wformat=2 -Wno-format-nonliteral
+WARNING_CXXFLAGS ?= -Wall -Wextra -Wformat=2 -Wno-format-nonliteral
+LDFLAGS ?=
+
+LOCAL_CFLAGS = $(WARNING_CFLAGS) -I../tests/include -I../include -D_FILE_OFFSET_BITS=64
+LOCAL_CXXFLAGS = $(WARNING_CXXFLAGS) -I../include -I../tests/include -D_FILE_OFFSET_BITS=64
+LOCAL_LDFLAGS = ${MBEDTLS_TEST_OBJS} 		\
+		-L../library			\
+		-lmbedtls$(SHARED_SUFFIX)	\
+		-lmbedx509$(SHARED_SUFFIX)	\
+		-lmbedcrypto$(SHARED_SUFFIX)

--- a/scripts/common.make
+++ b/scripts/common.make
@@ -66,6 +66,10 @@ else # Not building for Windows
   SHARED_SUFFIX=
   ifndef THREADING
     # Auto-detect configurations with pthread.
+    # If the call to remove_unset_options returns "control", the symbols
+    # are confirmed set and we link with pthread.
+    # If the auto-detection fails, the result of the call is empty and
+    # we keep THREADING undefined.
     ifeq (control,$(call remove_unset_options,control MBEDTLS_THREADING_C MBEDTLS_THREADING_PTHREAD))
       THREADING := pthread
     endif

--- a/scripts/common.make
+++ b/scripts/common.make
@@ -31,19 +31,19 @@ ifdef WINDOWS
 WINDOWS_BUILD=1
 endif
 
-## Usage: $(call remove_unset_options,PREPROCESSOR_INPUT)
-## Remove the preprocessor symbols that are not set in the current configuration
+## Usage: $(call remove_enabled_options,PREPROCESSOR_INPUT)
+## Remove the preprocessor symbols that are set in the current configuration
 ## from PREPROCESSOR_INPUT. Also normalize whitespace.
 ## Example:
-##   $(call remove_unset_options,MBEDTLS_FOO MBEDTLS_BAR)
+##   $(call remove_set_options,MBEDTLS_FOO MBEDTLS_BAR)
 ## This expands to an empty string "" if MBEDTLS_FOO and MBEDTLS_BAR are both
-## disabled, to "MBEDTLS_FOO" if MBEDTLS_BAR is enabled but MBEDTLS_FOO is
+## enabled, to "MBEDTLS_FOO" if MBEDTLS_BAR is enabled but MBEDTLS_FOO is
 ## disabled, etc.
 ##
 ## This only works with a Unix-like shell environment (Bourne/POSIX-style shell
 ## and standard commands) and a Unix-like compiler (supporting -E). In
 ## other environments, the output is likely to be empty.
-define remove_unset_options
+define remove_enabled_options
 $(strip $(shell
   exec 2>/dev/null;
   { echo '#include <mbedtls/build_info.h>'; echo $(1); } |
@@ -66,11 +66,11 @@ else # Not building for Windows
   SHARED_SUFFIX=
   ifndef THREADING
     # Auto-detect configurations with pthread.
-    # If the call to remove_unset_options returns "control", the symbols
+    # If the call to remove_enabled_options returns "control", the symbols
     # are confirmed set and we link with pthread.
     # If the auto-detection fails, the result of the call is empty and
     # we keep THREADING undefined.
-    ifeq (control,$(call remove_unset_options,control MBEDTLS_THREADING_C MBEDTLS_THREADING_PTHREAD))
+    ifeq (control,$(call remove_enabled_options,control MBEDTLS_THREADING_C MBEDTLS_THREADING_PTHREAD))
       THREADING := pthread
     endif
   endif

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -3,8 +3,6 @@ include ../scripts/common.make
 # Set this to -v to see the details of failing test cases
 TEST_FLAGS ?= $(if $(filter-out 0 OFF Off off NO No no FALSE False false N n,$(CTEST_OUTPUT_ON_FAILURE)),-v,)
 
-default: all
-
 # Also include library headers, for the sake of invasive tests.
 LOCAL_CFLAGS += -I../library
 
@@ -111,9 +109,6 @@ BINARIES := $(addsuffix $(EXEXT),$(APPS))
 
 all: $(BINARIES)
 
-$(MBEDLIBS):
-	$(MAKE) -C ../library
-
 MBEDTLS_TEST_PATH = .
 MBEDTLS_TEST_OBJS = $(patsubst %.c,%.o,$(wildcard ${MBEDTLS_TEST_PATH}/src/*.c ${MBEDTLS_TEST_PATH}/src/drivers/*.c))
 MBEDTLS_TEST_OBJS += $(patsubst %.c,%.o,$(wildcard ${MBEDTLS_TEST_PATH}/src/test_helpers/*.c))
@@ -191,13 +186,6 @@ else
 	if exist src/test_helpers/*.o del /Q /F src/test_helpers/*.o
 	if exist src/libmbed* del /Q /F src/libmed*
 	if exist include/test/instrument_record_status.h del /Q /F include/test/instrument_record_status.h
-endif
-
-neat: clean
-ifndef WINDOWS
-	rm -f $(GENERATED_FILES)
-else
-	for %f in ($(subst /,\,$(GENERATED_FILES))) if exist %f del /Q /F %f
 endif
 
 # Test suites caught by SKIP_TEST_SUITES are built but not executed.

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,23 +1,12 @@
-
-# To compile on SunOS: add "-lsocket -lnsl" to LDFLAGS
-
-CFLAGS	?= -O2
-WARNING_CFLAGS ?= -Wall -Wextra -Wformat=2 -Wno-format-nonliteral
-LDFLAGS ?=
+include ../scripts/common.make
 
 # Set this to -v to see the details of failing test cases
 TEST_FLAGS ?= $(if $(filter-out 0 OFF Off off NO No no FALSE False false N n,$(CTEST_OUTPUT_ON_FAILURE)),-v,)
 
 default: all
 
-LOCAL_CFLAGS = $(WARNING_CFLAGS) -I$(MBEDTLS_TEST_PATH)/include -I../include -D_FILE_OFFSET_BITS=64
 # Also include library headers, for the sake of invasive tests.
 LOCAL_CFLAGS += -I../library
-LOCAL_LDFLAGS = ${MBEDTLS_TEST_OBJS} 		\
-		-L../library 			\
-		-lmbedtls$(SHARED_SUFFIX)	\
-		-lmbedx509$(SHARED_SUFFIX)	\
-		-lmbedcrypto$(SHARED_SUFFIX)
 
 include ../3rdparty/Makefile.inc
 LOCAL_CFLAGS+=$(THIRDPARTY_INCLUDES)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -8,63 +8,13 @@ default: all
 # Also include library headers, for the sake of invasive tests.
 LOCAL_CFLAGS += -I../library
 
-include ../3rdparty/Makefile.inc
-LOCAL_CFLAGS+=$(THIRDPARTY_INCLUDES)
-
 # Enable definition of various functions used throughout the testsuite
 # (gethostname, strdup, fileno...) even when compiling with -std=c99. Harmless
 # on non-POSIX platforms.
 LOCAL_CFLAGS += -D_POSIX_C_SOURCE=200809L
 
-ifndef SHARED
-MBEDLIBS=../library/libmbedcrypto.a ../library/libmbedx509.a ../library/libmbedtls.a
-else
-MBEDLIBS=../library/libmbedcrypto.$(DLEXT) ../library/libmbedx509.$(DLEXT) ../library/libmbedtls.$(DLEXT)
-endif
-
-ifdef DEBUG
-LOCAL_CFLAGS += -g3
-endif
-
 ifdef RECORD_PSA_STATUS_COVERAGE_LOG
 LOCAL_CFLAGS += -Werror -DRECORD_PSA_STATUS_COVERAGE_LOG
-endif
-
-# if we're running on Windows, build for Windows
-ifdef WINDOWS
-WINDOWS_BUILD=1
-endif
-
-ifdef WINDOWS_BUILD
-  DLEXT=dll
-  EXEXT=.exe
-  LOCAL_LDFLAGS += -lws2_32 -lbcrypt
-  ifdef SHARED
-    SHARED_SUFFIX=.$(DLEXT)
-  endif
-
-else # Not building for Windows
-  DLEXT ?= so
-  EXEXT=
-  SHARED_SUFFIX=
-
-  ifeq ($(THREADING),pthread)
-    LOCAL_LDFLAGS += -lpthread
-  endif
-endif
-
-ifdef WINDOWS
-PYTHON ?= python
-else
-PYTHON ?= $(shell if type python3 >/dev/null 2>/dev/null; then echo python3; else echo python; fi)
-endif
-
-# See root Makefile
-GEN_FILES ?= yes
-ifdef GEN_FILES
-gen_file_dep =
-else
-gen_file_dep = |
 endif
 
 .PHONY: generated_files

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -47,20 +47,21 @@ WINDOWS_BUILD=1
 endif
 
 ifdef WINDOWS_BUILD
-DLEXT=dll
-EXEXT=.exe
-LOCAL_LDFLAGS += -lws2_32 -lbcrypt
-ifdef SHARED
-SHARED_SUFFIX=.$(DLEXT)
-endif
-else
-DLEXT ?= so
-EXEXT=
-SHARED_SUFFIX=
+  DLEXT=dll
+  EXEXT=.exe
+  LOCAL_LDFLAGS += -lws2_32 -lbcrypt
+  ifdef SHARED
+    SHARED_SUFFIX=.$(DLEXT)
+  endif
 
-ifeq ($(THREADING),pthread)
-LOCAL_LDFLAGS += -lpthread
-endif
+else # Not building for Windows
+  DLEXT ?= so
+  EXEXT=
+  SHARED_SUFFIX=
+
+  ifeq ($(THREADING),pthread)
+    LOCAL_LDFLAGS += -lpthread
+  endif
 endif
 
 ifdef WINDOWS

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -14,7 +14,8 @@ default: all
 # from ./include, and private header files (used by some invasive tests)
 # from ../library.
 LOCAL_CFLAGS = $(WARNING_CFLAGS) -I./include -I../include -I../library -D_FILE_OFFSET_BITS=64
-LOCAL_LDFLAGS = -L../library			\
+LOCAL_LDFLAGS = ${MBEDTLS_TEST_OBJS} 		\
+		-L../library 			\
 		-lmbedtls$(SHARED_SUFFIX)	\
 		-lmbedx509$(SHARED_SUFFIX)	\
 		-lmbedcrypto$(SHARED_SUFFIX)
@@ -175,7 +176,9 @@ all: $(BINARIES)
 $(MBEDLIBS):
 	$(MAKE) -C ../library
 
-MBEDTLS_TEST_OBJS=$(patsubst %.c,%.o,$(wildcard src/*.c src/drivers/*.c src/test_helpers/*.c))
+MBEDTLS_TEST_PATH = .
+MBEDTLS_TEST_OBJS = $(patsubst %.c,%.o,$(wildcard ${MBEDTLS_TEST_PATH}/src/*.c ${MBEDTLS_TEST_PATH}/src/drivers/*.c))
+MBEDTLS_TEST_OBJS += $(patsubst %.c,%.o,$(wildcard ${MBEDTLS_TEST_PATH}/src/test_helpers/*.c))
 
 mbedtls_test: $(MBEDTLS_TEST_OBJS)
 
@@ -231,7 +234,7 @@ c: $(C_FILES)
 
 $(BINARIES): %$(EXEXT): %.c $(MBEDLIBS) $(TEST_OBJS_DEPS) $(MBEDTLS_TEST_OBJS)
 	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $< $(MBEDTLS_TEST_OBJS) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $< $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 clean:
 ifndef WINDOWS

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -10,10 +10,9 @@ TEST_FLAGS ?= $(if $(filter-out 0 OFF Off off NO No no FALSE False false N n,$(C
 
 default: all
 
-# Include public header files from ../include, test-specific header files
-# from ./include, and private header files (used by some invasive tests)
-# from ../library.
-LOCAL_CFLAGS = $(WARNING_CFLAGS) -I./include -I../include -I../library -D_FILE_OFFSET_BITS=64
+LOCAL_CFLAGS = $(WARNING_CFLAGS) -I$(MBEDTLS_TEST_PATH)/include -I../include -D_FILE_OFFSET_BITS=64
+# Also include library headers, for the sake of invasive tests.
+LOCAL_CFLAGS += -I../library
 LOCAL_LDFLAGS = ${MBEDTLS_TEST_OBJS} 		\
 		-L../library 			\
 		-lmbedtls$(SHARED_SUFFIX)	\

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -216,9 +216,6 @@ pre_initialize_variables () {
         esac
         SUPPORTED_COMPONENTS="$SUPPORTED_COMPONENTS $component"
     done
-
-    # Option to enable linking with pthreads under make
-    MAKE_THREADING_FLAGS="THREADING=pthread"
 }
 
 # Test whether the component $1 is included in the command line patterns.
@@ -933,7 +930,7 @@ helper_get_psa_key_type_list() {
 # Here "things" are PSA_WANT_ symbols but with PSA_WANT_ removed.
 helper_libtestdriver1_make_drivers() {
     loc_accel_flags=$( echo "$1 ${2-}" | sed 's/[^ ]* */-DLIBTESTDRIVER1_MBEDTLS_PSA_ACCEL_&/g' )
-    make CC=$ASAN_CC -C tests libtestdriver1.a CFLAGS=" $ASAN_CFLAGS $loc_accel_flags" LDFLAGS="$ASAN_CFLAGS" $MAKE_THREADING_FLAGS
+    make CC=$ASAN_CC -C tests libtestdriver1.a CFLAGS=" $ASAN_CFLAGS $loc_accel_flags" LDFLAGS="$ASAN_CFLAGS"
 }
 
 # Build the main libraries, programs and tests,
@@ -951,7 +948,7 @@ helper_libtestdriver1_make_main() {
     # we need flags both with and without the LIBTESTDRIVER1_ prefix
     loc_accel_flags=$( echo "$loc_accel_list" | sed 's/[^ ]* */-DLIBTESTDRIVER1_MBEDTLS_PSA_ACCEL_&/g' )
     loc_accel_flags="$loc_accel_flags $( echo "$loc_accel_list" | sed 's/[^ ]* */-DMBEDTLS_PSA_ACCEL_&/g' )"
-    make CC=$ASAN_CC CFLAGS="$ASAN_CFLAGS -I../tests/include -I../tests -I../../tests -DPSA_CRYPTO_DRIVER_TEST -DMBEDTLS_TEST_LIBTESTDRIVER1 $loc_accel_flags" LDFLAGS="-ltestdriver1 $ASAN_CFLAGS" $MAKE_THREADING_FLAGS "$@"
+    make CC=$ASAN_CC CFLAGS="$ASAN_CFLAGS -I../tests/include -I../tests -I../../tests -DPSA_CRYPTO_DRIVER_TEST -DMBEDTLS_TEST_LIBTESTDRIVER1 $loc_accel_flags" LDFLAGS="-ltestdriver1 $ASAN_CFLAGS" "$@"
 }
 
 ################################################################
@@ -1446,7 +1443,7 @@ component_test_psa_external_rng_no_drbg_classic () {
     # When MBEDTLS_USE_PSA_CRYPTO is disabled and there is no DRBG,
     # the SSL test programs don't have an RNG and can't work. Explicitly
     # make them use the PSA RNG with -DMBEDTLS_TEST_USE_PSA_CRYPTO_RNG.
-    make CC=$ASAN_CC CFLAGS="$ASAN_CFLAGS -DMBEDTLS_TEST_USE_PSA_CRYPTO_RNG" LDFLAGS="$ASAN_CFLAGS" $MAKE_THREADING_FLAGS
+    make CC=$ASAN_CC CFLAGS="$ASAN_CFLAGS -DMBEDTLS_TEST_USE_PSA_CRYPTO_RNG" LDFLAGS="$ASAN_CFLAGS"
 
     msg "test: PSA_CRYPTO_EXTERNAL_RNG minus *_DRBG, classic crypto - main suites"
     make test
@@ -1465,7 +1462,7 @@ component_test_psa_external_rng_no_drbg_use_psa () {
     scripts/config.py unset MBEDTLS_CTR_DRBG_C
     scripts/config.py unset MBEDTLS_HMAC_DRBG_C
     scripts/config.py unset MBEDTLS_ECDSA_DETERMINISTIC # requires HMAC_DRBG
-    make CC=$ASAN_CC CFLAGS="$ASAN_CFLAGS" LDFLAGS="$ASAN_CFLAGS" $MAKE_THREADING_FLAGS
+    make CC=$ASAN_CC CFLAGS="$ASAN_CFLAGS" LDFLAGS="$ASAN_CFLAGS"
 
     msg "test: PSA_CRYPTO_EXTERNAL_RNG minus *_DRBG, PSA crypto - main suites"
     make test
@@ -1480,7 +1477,7 @@ component_test_psa_external_rng_use_psa_crypto () {
     scripts/config.py set MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG
     scripts/config.py set MBEDTLS_USE_PSA_CRYPTO
     scripts/config.py unset MBEDTLS_CTR_DRBG_C
-    make CC=$ASAN_CC CFLAGS="$ASAN_CFLAGS" LDFLAGS="$ASAN_CFLAGS" $MAKE_THREADING_FLAGS
+    make CC=$ASAN_CC CFLAGS="$ASAN_CFLAGS" LDFLAGS="$ASAN_CFLAGS"
 
     msg "test: full + PSA_CRYPTO_EXTERNAL_RNG + USE_PSA_CRYPTO minus CTR_DRBG"
     make test
@@ -1498,7 +1495,7 @@ component_test_psa_inject_entropy () {
     scripts/config.py unset MBEDTLS_PLATFORM_NV_SEED_ALT
     scripts/config.py unset MBEDTLS_PLATFORM_STD_NV_SEED_READ
     scripts/config.py unset MBEDTLS_PLATFORM_STD_NV_SEED_WRITE
-    make CC=$ASAN_CC CFLAGS="$ASAN_CFLAGS '-DMBEDTLS_USER_CONFIG_FILE=\"../tests/configs/user-config-for-test.h\"'" LDFLAGS="$ASAN_CFLAGS" $MAKE_THREADING_FLAGS
+    make CC=$ASAN_CC CFLAGS="$ASAN_CFLAGS '-DMBEDTLS_USER_CONFIG_FILE=\"../tests/configs/user-config-for-test.h\"'" LDFLAGS="$ASAN_CFLAGS"
 
     msg "test: full + MBEDTLS_PSA_INJECT_ENTROPY"
     make test
@@ -1532,14 +1529,14 @@ component_test_crypto_full_md_light_only () {
 
     # Note: MD-light is auto-enabled in build_info.h by modules that need it,
     # which we haven't disabled, so no need to explicitly enable it.
-    make CC=$ASAN_CC CFLAGS="$ASAN_CFLAGS" LDFLAGS="$ASAN_CFLAGS" $MAKE_THREADING_FLAGS
+    make CC=$ASAN_CC CFLAGS="$ASAN_CFLAGS" LDFLAGS="$ASAN_CFLAGS"
 
     # Make sure we don't have the HMAC functions, but the hashing functions
     not grep mbedtls_md_hmac library/md.o
     grep mbedtls_md library/md.o
 
     msg "test: crypto_full with only the light subset of MD"
-    make $MAKE_THREADING_FLAGS test
+    make test
 }
 
 component_test_full_no_cipher () {
@@ -1565,7 +1562,7 @@ component_test_full_no_cipher () {
     scripts/config.py unset MBEDTLS_LMS_PRIVATE
 
     msg "test: full no CIPHER no PSA_CRYPTO_C"
-    make $MAKE_THREADING_FLAGS test
+    make test
 }
 
 # This is a common configurator and test function that is used in:
@@ -1614,7 +1611,7 @@ common_test_full_no_cipher_with_psa_crypto () {
     scripts/config.py unset MBEDTLS_PKCS12_C
     scripts/config.py unset MBEDTLS_PKCS5_C
 
-    make $MAKE_THREADING_FLAGS
+    make
 
     # Ensure that CIPHER_C was not re-enabled
     not grep mbedtls_cipher_init library/cipher.o
@@ -1647,7 +1644,7 @@ component_test_full_no_ccm() {
     # PSA_WANT_ALG_CCM to be re-enabled.
     scripts/config.py -f "$CRYPTO_CONFIG_H" unset PSA_WANT_ALG_CCM
 
-    make $MAKE_THREADING_FLAGS
+    make
 
     msg "test: full no PSA_WANT_ALG_CCM"
     make test
@@ -1675,7 +1672,7 @@ component_test_full_no_ccm_star_no_tag() {
     scripts/config.py -f "$CRYPTO_CONFIG_H" unset PSA_WANT_ALG_CBC_NO_PADDING
     scripts/config.py -f "$CRYPTO_CONFIG_H" unset PSA_WANT_ALG_CBC_PKCS7
 
-    make $MAKE_THREADING_FLAGS
+    make
 
     # Ensure MBEDTLS_PSA_BUILTIN_CIPHER was not enabled
     not grep mbedtls_psa_cipher library/psa_crypto_cipher.o
@@ -1732,7 +1729,7 @@ component_test_full_no_bignum () {
     scripts/config.py unset MBEDTLS_SSL_ASYNC_PRIVATE
     scripts/config.py unset MBEDTLS_X509_TRUSTED_CERTIFICATE_CALLBACK
 
-    make $MAKE_THREADING_FLAGS
+    make
 
     msg "test: full minus bignum"
     make test
@@ -2010,7 +2007,7 @@ component_test_small_mbedtls_ssl_dtls_max_buffering () {
 component_test_psa_collect_statuses () {
   msg "build+test: psa_collect_statuses" # ~30s
   scripts/config.py full
-  tests/scripts/psa_collect_statuses.py --make-vars="$MAKE_THREADING_FLAGS"
+  tests/scripts/psa_collect_statuses.py
   # Check that psa_crypto_init() succeeded at least once
   grep -q '^0:psa_crypto_init:' tests/statuses.log
   rm -f tests/statuses.log
@@ -2189,7 +2186,7 @@ component_test_default_no_deprecated () {
 component_test_full_no_deprecated () {
     msg "build: make, full_no_deprecated config" # ~ 30s
     scripts/config.py full_no_deprecated
-    make CC=gcc CFLAGS='-O -Werror -Wall -Wextra' $MAKE_THREADING_FLAGS
+    make CC=gcc CFLAGS='-O -Werror -Wall -Wextra'
 
     msg "test: make, full_no_deprecated config" # ~ 5s
     make test
@@ -2206,7 +2203,7 @@ component_test_full_no_deprecated_deprecated_warning () {
     scripts/config.py full_no_deprecated
     scripts/config.py unset MBEDTLS_DEPRECATED_REMOVED
     scripts/config.py set MBEDTLS_DEPRECATED_WARNING
-    make CC=gcc CFLAGS='-O -Werror -Wall -Wextra' $MAKE_THREADING_FLAGS
+    make CC=gcc CFLAGS='-O -Werror -Wall -Wextra'
 
     msg "test: make, full_no_deprecated config, MBEDTLS_DEPRECATED_WARNING" # ~ 5s
     make test
@@ -2226,7 +2223,7 @@ component_test_full_deprecated_warning () {
     # By default those are disabled when MBEDTLS_DEPRECATED_WARNING is set.
     # Expect warnings from '#warning' directives in check_config.h and
     # from the use of deprecated functions in test suites.
-    make CC=gcc CFLAGS='-O -Werror -Wall -Wextra -Wno-error=deprecated-declarations -Wno-error=cpp -DMBEDTLS_TEST_DEPRECATED' $MAKE_THREADING_FLAGS tests
+    make CC=gcc CFLAGS='-O -Werror -Wall -Wextra -Wno-error=deprecated-declarations -Wno-error=cpp -DMBEDTLS_TEST_DEPRECATED' tests
 
     msg "test: full config + MBEDTLS_TEST_DEPRECATED" # ~ 30s
     make test
@@ -2251,7 +2248,7 @@ component_build_crypto_default () {
 component_build_crypto_full () {
   msg "build: make, crypto only, full config"
   scripts/config.py crypto_full
-  make CFLAGS='-O1 -Werror' $MAKE_THREADING_FLAGS
+  make CFLAGS='-O1 -Werror'
   are_empty_libraries library/libmbedx509.* library/libmbedtls.*
 }
 
@@ -2311,73 +2308,73 @@ support_build_baremetal () {
 # depends.py family of tests
 component_test_depends_py_cipher_id () {
     msg "test/build: depends.py cipher_id (gcc)"
-    tests/scripts/depends.py cipher_id --unset-use-psa --make-vars="$MAKE_THREADING_FLAGS"
+    tests/scripts/depends.py cipher_id --unset-use-psa
 }
 
 component_test_depends_py_cipher_chaining () {
     msg "test/build: depends.py cipher_chaining (gcc)"
-    tests/scripts/depends.py cipher_chaining --unset-use-psa --make-vars="$MAKE_THREADING_FLAGS"
+    tests/scripts/depends.py cipher_chaining --unset-use-psa
 }
 
 component_test_depends_py_cipher_padding () {
     msg "test/build: depends.py cipher_padding (gcc)"
-    tests/scripts/depends.py cipher_padding --unset-use-psa --make-vars="$MAKE_THREADING_FLAGS"
+    tests/scripts/depends.py cipher_padding --unset-use-psa
 }
 
 component_test_depends_py_curves () {
     msg "test/build: depends.py curves (gcc)"
-    tests/scripts/depends.py curves --unset-use-psa --make-vars="$MAKE_THREADING_FLAGS"
+    tests/scripts/depends.py curves --unset-use-psa
 }
 
 component_test_depends_py_hashes () {
     msg "test/build: depends.py hashes (gcc)"
-    tests/scripts/depends.py hashes --unset-use-psa --make-vars="$MAKE_THREADING_FLAGS"
+    tests/scripts/depends.py hashes --unset-use-psa
 }
 
 component_test_depends_py_kex () {
     msg "test/build: depends.py kex (gcc)"
-    tests/scripts/depends.py kex --unset-use-psa --make-vars="$MAKE_THREADING_FLAGS"
+    tests/scripts/depends.py kex --unset-use-psa
 }
 
 component_test_depends_py_pkalgs () {
     msg "test/build: depends.py pkalgs (gcc)"
-    tests/scripts/depends.py pkalgs --unset-use-psa --make-vars="$MAKE_THREADING_FLAGS"
+    tests/scripts/depends.py pkalgs --unset-use-psa
 }
 
 # PSA equivalents of the depends.py tests
 component_test_depends_py_cipher_id_psa () {
     msg "test/build: depends.py cipher_id (gcc) with MBEDTLS_USE_PSA_CRYPTO defined"
-    tests/scripts/depends.py cipher_id --make-vars="$MAKE_THREADING_FLAGS"
+    tests/scripts/depends.py cipher_id
 }
 
 component_test_depends_py_cipher_chaining_psa () {
     msg "test/build: depends.py cipher_chaining (gcc) with MBEDTLS_USE_PSA_CRYPTO defined"
-    tests/scripts/depends.py cipher_chaining --make-vars="$MAKE_THREADING_FLAGS"
+    tests/scripts/depends.py cipher_chaining
 }
 
 component_test_depends_py_cipher_padding_psa () {
     msg "test/build: depends.py cipher_padding (gcc) with MBEDTLS_USE_PSA_CRYPTO defined"
-    tests/scripts/depends.py cipher_padding --make-vars="$MAKE_THREADING_FLAGS"
+    tests/scripts/depends.py cipher_padding
 }
 
 component_test_depends_py_curves_psa () {
     msg "test/build: depends.py curves (gcc) with MBEDTLS_USE_PSA_CRYPTO defined"
-    tests/scripts/depends.py curves --make-vars="$MAKE_THREADING_FLAGS"
+    tests/scripts/depends.py curves
 }
 
 component_test_depends_py_hashes_psa () {
     msg "test/build: depends.py hashes (gcc) with MBEDTLS_USE_PSA_CRYPTO defined"
-    tests/scripts/depends.py hashes --make-vars="$MAKE_THREADING_FLAGS"
+    tests/scripts/depends.py hashes
 }
 
 component_test_depends_py_kex_psa () {
     msg "test/build: depends.py kex (gcc) with MBEDTLS_USE_PSA_CRYPTO defined"
-    tests/scripts/depends.py kex --make-vars="$MAKE_THREADING_FLAGS"
+    tests/scripts/depends.py kex
 }
 
 component_test_depends_py_pkalgs_psa () {
     msg "test/build: depends.py pkalgs (gcc) with MBEDTLS_USE_PSA_CRYPTO defined"
-    tests/scripts/depends.py pkalgs --make-vars="$MAKE_THREADING_FLAGS"
+    tests/scripts/depends.py pkalgs
 }
 
 component_build_no_pk_rsa_alt_support () {
@@ -2389,7 +2386,7 @@ component_build_no_pk_rsa_alt_support () {
     scripts/config.py set MBEDTLS_X509_CRT_WRITE_C
 
     # Only compile - this is primarily to test for compile issues
-    make CC=gcc CFLAGS='-Werror -Wall -Wextra -I../tests/include/alt-dummy' $MAKE_THREADING_FLAGS
+    make CC=gcc CFLAGS='-Werror -Wall -Wextra -I../tests/include/alt-dummy'
 }
 
 component_build_module_alt () {
@@ -2603,7 +2600,7 @@ component_test_psa_crypto_config_reference_ffdh () {
     # Disable things that are not supported
     scripts/config.py unset MBEDTLS_KEY_EXCHANGE_DHE_PSK_ENABLED
     scripts/config.py unset MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED
-    make $MAKE_THREADING_FLAGS
+    make
 
     msg "test suites: full with non-accelerated FFDH alg"
     make test
@@ -2642,7 +2639,7 @@ component_test_psa_crypto_config_accel_pake() {
     # -------------
 
     msg "test: full with accelerated PAKE"
-    make $MAKE_THREADING_FLAGS test
+    make test
 }
 
 component_test_psa_crypto_config_accel_ecc_some_key_types () {
@@ -2702,7 +2699,7 @@ component_test_psa_crypto_config_accel_ecc_some_key_types () {
     # -------------
 
     msg "test suites: full with accelerated EC algs and some key types"
-    make $MAKE_THREADING_FLAGS test
+    make test
 }
 
 # Run tests with only (non-)Weierstrass accelerated
@@ -2901,7 +2898,7 @@ component_test_psa_crypto_config_accel_ecc_ecp_light_only () {
     # -------------
 
     msg "test suites: full with accelerated EC algs"
-    make $MAKE_THREADING_FLAGS test
+    make test
 
     msg "ssl-opt: full with accelerated EC algs"
     tests/ssl-opt.sh
@@ -2913,7 +2910,7 @@ component_test_psa_crypto_config_reference_ecc_ecp_light_only () {
 
     config_psa_crypto_config_ecp_light_only 0
 
-    make $MAKE_THREADING_FLAGS
+    make
 
     msg "test suites: full with non-accelerated EC algs"
     make test
@@ -3006,7 +3003,7 @@ component_test_psa_crypto_config_accel_ecc_no_ecp_at_all () {
     # -------------
 
     msg "test: full + accelerated EC algs - ECP"
-    make $MAKE_THREADING_FLAGS test
+    make test
 
     msg "ssl-opt: full + accelerated EC algs - ECP"
     tests/ssl-opt.sh
@@ -3020,7 +3017,7 @@ component_test_psa_crypto_config_reference_ecc_no_ecp_at_all () {
 
     config_psa_crypto_no_ecp_at_all 0
 
-    make $MAKE_THREADING_FLAGS
+    make
 
     msg "test: full + non accelerated EC algs"
     make test
@@ -3183,7 +3180,7 @@ common_test_psa_crypto_config_accel_ecc_ffdh_no_bignum () {
 
     msg "test suites: full + accelerated $accel_text algs + USE_PSA - $removed_text - DHM - BIGNUM"
 
-    make $MAKE_THREADING_FLAGS test
+    make test
 
     msg "ssl-opt: full + accelerated $accel_text algs + USE_PSA - $removed_text - BIGNUM"
     tests/ssl-opt.sh
@@ -3214,7 +3211,7 @@ common_test_psa_crypto_config_reference_ecc_ffdh_no_bignum () {
 
     config_psa_crypto_config_accel_ecc_ffdh_no_bignum 0 "$test_target"
 
-    make $MAKE_THREADING_FLAGS
+    make
 
     msg "test suites: full + non accelerated EC algs + USE_PSA"
     make test
@@ -3333,7 +3330,7 @@ build_full_minus_something_and_test_tls () {
         scripts/config.py unset $sym
     done
 
-    make $MAKE_THREADING_FLAGS
+    make
 
     msg "test: full minus something, test TLS"
     ( cd tests; ./test_suite_ssl )
@@ -3372,7 +3369,7 @@ build_and_test_psa_want_key_pair_partial() {
     # crypto_config.h so we just disable the one we don't want.
     scripts/config.py -f "$CRYPTO_CONFIG_H" unset "$disabled_psa_want"
 
-    make CC=$ASAN_CC CFLAGS="$ASAN_CFLAGS" LDFLAGS="$ASAN_CFLAGS" $MAKE_THREADING_FLAGS
+    make CC=$ASAN_CC CFLAGS="$ASAN_CFLAGS" LDFLAGS="$ASAN_CFLAGS"
 
     msg "test: full - MBEDTLS_USE_PSA_CRYPTO - ${disabled_psa_want}"
     make test
@@ -3438,7 +3435,7 @@ component_test_psa_crypto_config_accel_rsa_crypto () {
     # -------------
 
     msg "test: crypto_full with accelerated RSA"
-    make $MAKE_THREADING_FLAGS test
+    make test
 }
 
 component_test_psa_crypto_config_reference_rsa_crypto () {
@@ -3450,7 +3447,7 @@ component_test_psa_crypto_config_reference_rsa_crypto () {
 
     # Build
     # -----
-    make $MAKE_THREADING_FLAGS
+    make
 
     # Run the tests
     # -------------
@@ -3652,7 +3649,7 @@ component_test_psa_crypto_config_reference_hash_use_psa() {
 
     config_psa_crypto_hash_use_psa 0
 
-    make $MAKE_THREADING_FLAGS
+    make
 
     msg "test: full without accelerated hashes"
     make test
@@ -3817,7 +3814,7 @@ component_test_psa_crypto_config_accel_cipher_aead () {
     # -------------
 
     msg "test: full config with accelerated cipher and AEAD"
-    make $MAKE_THREADING_FLAGS test
+    make test
 
     msg "ssl-opt: full config with accelerated cipher and AEAD"
     tests/ssl-opt.sh
@@ -3830,7 +3827,7 @@ component_test_psa_crypto_config_reference_cipher_aead () {
     msg "build: full config with non-accelerated cipher and AEAD"
     common_psa_crypto_config_accel_cipher_aead
 
-    make $MAKE_THREADING_FLAGS
+    make
 
     msg "test: full config with non-accelerated cipher and AEAD"
     make test
@@ -3847,7 +3844,7 @@ component_test_aead_chachapoly_disabled() {
     scripts/config.py full
     scripts/config.py unset MBEDTLS_CHACHAPOLY_C
     scripts/config.py -f "$CRYPTO_CONFIG_H" unset PSA_WANT_ALG_CHACHA20_POLY1305
-    make CC=$ASAN_CC CFLAGS="$ASAN_CFLAGS" LDFLAGS="$ASAN_CFLAGS" $MAKE_THREADING_FLAGS
+    make CC=$ASAN_CC CFLAGS="$ASAN_CFLAGS" LDFLAGS="$ASAN_CFLAGS"
 
     msg "test: full minus CHACHAPOLY"
     make test
@@ -3860,7 +3857,7 @@ component_test_aead_only_ccm() {
     scripts/config.py unset MBEDTLS_GCM_C
     scripts/config.py -f "$CRYPTO_CONFIG_H" unset PSA_WANT_ALG_CHACHA20_POLY1305
     scripts/config.py -f "$CRYPTO_CONFIG_H" unset PSA_WANT_ALG_GCM
-    make CC=$ASAN_CC CFLAGS="$ASAN_CFLAGS" LDFLAGS="$ASAN_CFLAGS" $MAKE_THREADING_FLAGS
+    make CC=$ASAN_CC CFLAGS="$ASAN_CFLAGS" LDFLAGS="$ASAN_CFLAGS"
 
     msg "test: full minus CHACHAPOLY and GCM"
     make test
@@ -3891,7 +3888,7 @@ component_build_psa_accel_alg_ecdh() {
     scripts/config.py unset MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED
     scripts/config.py unset MBEDTLS_KEY_EXCHANGE_ECDHE_PSK_ENABLED
     # Need to define the correct symbol and include the test driver header path in order to build with the test driver
-    make CC=$ASAN_CC CFLAGS="$ASAN_CFLAGS -DPSA_CRYPTO_DRIVER_TEST -DMBEDTLS_PSA_ACCEL_ALG_ECDH -I../tests/include" LDFLAGS="$ASAN_CFLAGS" $MAKE_THREADING_FLAGS
+    make CC=$ASAN_CC CFLAGS="$ASAN_CFLAGS -DPSA_CRYPTO_DRIVER_TEST -DMBEDTLS_PSA_ACCEL_ALG_ECDH -I../tests/include" LDFLAGS="$ASAN_CFLAGS"
 }
 
 # This should be renamed to test and updated once the accelerator HMAC code is in place and ready to test.
@@ -3901,7 +3898,7 @@ component_build_psa_accel_alg_hmac() {
     scripts/config.py unset MBEDTLS_USE_PSA_CRYPTO
     scripts/config.py unset MBEDTLS_SSL_PROTO_TLS1_3
     # Need to define the correct symbol and include the test driver header path in order to build with the test driver
-    make CC=$ASAN_CC CFLAGS="$ASAN_CFLAGS -DPSA_CRYPTO_DRIVER_TEST -DMBEDTLS_PSA_ACCEL_ALG_HMAC -I../tests/include" LDFLAGS="$ASAN_CFLAGS" $MAKE_THREADING_FLAGS
+    make CC=$ASAN_CC CFLAGS="$ASAN_CFLAGS -DPSA_CRYPTO_DRIVER_TEST -DMBEDTLS_PSA_ACCEL_ALG_HMAC -I../tests/include" LDFLAGS="$ASAN_CFLAGS"
 }
 
 # This should be renamed to test and updated once the accelerator HKDF code is in place and ready to test.
@@ -3914,7 +3911,7 @@ component_build_psa_accel_alg_hkdf() {
     # Make sure to unset TLS1_3 since it requires HKDF_C and will not build properly without it.
     scripts/config.py unset MBEDTLS_SSL_PROTO_TLS1_3
     # Need to define the correct symbol and include the test driver header path in order to build with the test driver
-    make CC=$ASAN_CC CFLAGS="$ASAN_CFLAGS -DPSA_CRYPTO_DRIVER_TEST -DMBEDTLS_PSA_ACCEL_ALG_HKDF -I../tests/include" LDFLAGS="$ASAN_CFLAGS" $MAKE_THREADING_FLAGS
+    make CC=$ASAN_CC CFLAGS="$ASAN_CFLAGS -DPSA_CRYPTO_DRIVER_TEST -DMBEDTLS_PSA_ACCEL_ALG_HKDF -I../tests/include" LDFLAGS="$ASAN_CFLAGS"
 }
 
 # This should be renamed to test and updated once the accelerator MD5 code is in place and ready to test.
@@ -3933,7 +3930,7 @@ component_build_psa_accel_alg_md5() {
     scripts/config.py unset MBEDTLS_LMS_C
     scripts/config.py unset MBEDTLS_LMS_PRIVATE
     # Need to define the correct symbol and include the test driver header path in order to build with the test driver
-    make CC=$ASAN_CC CFLAGS="$ASAN_CFLAGS -DPSA_CRYPTO_DRIVER_TEST -DMBEDTLS_PSA_ACCEL_ALG_MD5 -I../tests/include" LDFLAGS="$ASAN_CFLAGS" $MAKE_THREADING_FLAGS
+    make CC=$ASAN_CC CFLAGS="$ASAN_CFLAGS -DPSA_CRYPTO_DRIVER_TEST -DMBEDTLS_PSA_ACCEL_ALG_MD5 -I../tests/include" LDFLAGS="$ASAN_CFLAGS"
 }
 
 # This should be renamed to test and updated once the accelerator RIPEMD160 code is in place and ready to test.
@@ -3952,7 +3949,7 @@ component_build_psa_accel_alg_ripemd160() {
     scripts/config.py unset MBEDTLS_LMS_C
     scripts/config.py unset MBEDTLS_LMS_PRIVATE
     # Need to define the correct symbol and include the test driver header path in order to build with the test driver
-    make CC=$ASAN_CC CFLAGS="$ASAN_CFLAGS -DPSA_CRYPTO_DRIVER_TEST -DMBEDTLS_PSA_ACCEL_ALG_RIPEMD160 -I../tests/include" LDFLAGS="$ASAN_CFLAGS" $MAKE_THREADING_FLAGS
+    make CC=$ASAN_CC CFLAGS="$ASAN_CFLAGS -DPSA_CRYPTO_DRIVER_TEST -DMBEDTLS_PSA_ACCEL_ALG_RIPEMD160 -I../tests/include" LDFLAGS="$ASAN_CFLAGS"
 }
 
 # This should be renamed to test and updated once the accelerator SHA1 code is in place and ready to test.
@@ -3971,7 +3968,7 @@ component_build_psa_accel_alg_sha1() {
     scripts/config.py unset MBEDTLS_LMS_C
     scripts/config.py unset MBEDTLS_LMS_PRIVATE
     # Need to define the correct symbol and include the test driver header path in order to build with the test driver
-    make CC=$ASAN_CC CFLAGS="$ASAN_CFLAGS -DPSA_CRYPTO_DRIVER_TEST -DMBEDTLS_PSA_ACCEL_ALG_SHA_1 -I../tests/include" LDFLAGS="$ASAN_CFLAGS" $MAKE_THREADING_FLAGS
+    make CC=$ASAN_CC CFLAGS="$ASAN_CFLAGS -DPSA_CRYPTO_DRIVER_TEST -DMBEDTLS_PSA_ACCEL_ALG_SHA_1 -I../tests/include" LDFLAGS="$ASAN_CFLAGS"
 }
 
 # This should be renamed to test and updated once the accelerator SHA224 code is in place and ready to test.
@@ -3987,7 +3984,7 @@ component_build_psa_accel_alg_sha224() {
     scripts/config.py -f "$CRYPTO_CONFIG_H" unset PSA_WANT_ALG_SHA_512
     scripts/config.py -f "$CRYPTO_CONFIG_H" unset PSA_WANT_ALG_TLS12_ECJPAKE_TO_PMS
     # Need to define the correct symbol and include the test driver header path in order to build with the test driver
-    make CC=$ASAN_CC CFLAGS="$ASAN_CFLAGS -DPSA_CRYPTO_DRIVER_TEST -DMBEDTLS_PSA_ACCEL_ALG_SHA_224 -I../tests/include" LDFLAGS="$ASAN_CFLAGS" $MAKE_THREADING_FLAGS
+    make CC=$ASAN_CC CFLAGS="$ASAN_CFLAGS -DPSA_CRYPTO_DRIVER_TEST -DMBEDTLS_PSA_ACCEL_ALG_SHA_224 -I../tests/include" LDFLAGS="$ASAN_CFLAGS"
 }
 
 # This should be renamed to test and updated once the accelerator SHA256 code is in place and ready to test.
@@ -4003,7 +4000,7 @@ component_build_psa_accel_alg_sha256() {
     scripts/config.py -f "$CRYPTO_CONFIG_H" unset PSA_WANT_ALG_SHA_384
     scripts/config.py -f "$CRYPTO_CONFIG_H" unset PSA_WANT_ALG_SHA_512
     # Need to define the correct symbol and include the test driver header path in order to build with the test driver
-    make CC=$ASAN_CC CFLAGS="$ASAN_CFLAGS -DPSA_CRYPTO_DRIVER_TEST -DMBEDTLS_PSA_ACCEL_ALG_SHA_256 -I../tests/include" LDFLAGS="$ASAN_CFLAGS" $MAKE_THREADING_FLAGS
+    make CC=$ASAN_CC CFLAGS="$ASAN_CFLAGS -DPSA_CRYPTO_DRIVER_TEST -DMBEDTLS_PSA_ACCEL_ALG_SHA_256 -I../tests/include" LDFLAGS="$ASAN_CFLAGS"
 }
 
 # This should be renamed to test and updated once the accelerator SHA384 code is in place and ready to test.
@@ -4021,7 +4018,7 @@ component_build_psa_accel_alg_sha384() {
     scripts/config.py unset MBEDTLS_LMS_C
     scripts/config.py unset MBEDTLS_LMS_PRIVATE
     # Need to define the correct symbol and include the test driver header path in order to build with the test driver
-    make CC=$ASAN_CC CFLAGS="$ASAN_CFLAGS -DPSA_CRYPTO_DRIVER_TEST -DMBEDTLS_PSA_ACCEL_ALG_SHA_384 -I../tests/include" LDFLAGS="$ASAN_CFLAGS" $MAKE_THREADING_FLAGS
+    make CC=$ASAN_CC CFLAGS="$ASAN_CFLAGS -DPSA_CRYPTO_DRIVER_TEST -DMBEDTLS_PSA_ACCEL_ALG_SHA_384 -I../tests/include" LDFLAGS="$ASAN_CFLAGS"
 }
 
 # This should be renamed to test and updated once the accelerator SHA512 code is in place and ready to test.
@@ -4040,7 +4037,7 @@ component_build_psa_accel_alg_sha512() {
     scripts/config.py unset MBEDTLS_LMS_C
     scripts/config.py unset MBEDTLS_LMS_PRIVATE
     # Need to define the correct symbol and include the test driver header path in order to build with the test driver
-    make CC=$ASAN_CC CFLAGS="$ASAN_CFLAGS -DPSA_CRYPTO_DRIVER_TEST -DMBEDTLS_PSA_ACCEL_ALG_SHA_512 -I../tests/include" LDFLAGS="$ASAN_CFLAGS" $MAKE_THREADING_FLAGS
+    make CC=$ASAN_CC CFLAGS="$ASAN_CFLAGS -DPSA_CRYPTO_DRIVER_TEST -DMBEDTLS_PSA_ACCEL_ALG_SHA_512 -I../tests/include" LDFLAGS="$ASAN_CFLAGS"
 }
 
 # This should be renamed to test and updated once the accelerator RSA code is in place and ready to test.
@@ -4054,7 +4051,7 @@ component_build_psa_accel_alg_rsa_pkcs1v15_crypt() {
     scripts/config.py -f "$CRYPTO_CONFIG_H" unset PSA_WANT_ALG_RSA_OAEP
     scripts/config.py -f "$CRYPTO_CONFIG_H" unset PSA_WANT_ALG_RSA_PSS
     # Need to define the correct symbol and include the test driver header path in order to build with the test driver
-    make CC=$ASAN_CC CFLAGS="$ASAN_CFLAGS -DPSA_CRYPTO_DRIVER_TEST -DMBEDTLS_PSA_ACCEL_ALG_RSA_PKCS1V15_CRYPT -I../tests/include" LDFLAGS="$ASAN_CFLAGS" $MAKE_THREADING_FLAGS
+    make CC=$ASAN_CC CFLAGS="$ASAN_CFLAGS -DPSA_CRYPTO_DRIVER_TEST -DMBEDTLS_PSA_ACCEL_ALG_RSA_PKCS1V15_CRYPT -I../tests/include" LDFLAGS="$ASAN_CFLAGS"
 }
 
 # This should be renamed to test and updated once the accelerator RSA code is in place and ready to test.
@@ -4068,7 +4065,7 @@ component_build_psa_accel_alg_rsa_pkcs1v15_sign() {
     scripts/config.py -f "$CRYPTO_CONFIG_H" unset PSA_WANT_ALG_RSA_OAEP
     scripts/config.py -f "$CRYPTO_CONFIG_H" unset PSA_WANT_ALG_RSA_PSS
     # Need to define the correct symbol and include the test driver header path in order to build with the test driver
-    make CC=$ASAN_CC CFLAGS="$ASAN_CFLAGS -DPSA_CRYPTO_DRIVER_TEST -DMBEDTLS_PSA_ACCEL_ALG_RSA_PKCS1V15_SIGN -I../tests/include" LDFLAGS="$ASAN_CFLAGS" $MAKE_THREADING_FLAGS
+    make CC=$ASAN_CC CFLAGS="$ASAN_CFLAGS -DPSA_CRYPTO_DRIVER_TEST -DMBEDTLS_PSA_ACCEL_ALG_RSA_PKCS1V15_SIGN -I../tests/include" LDFLAGS="$ASAN_CFLAGS"
 }
 
 # This should be renamed to test and updated once the accelerator RSA code is in place and ready to test.
@@ -4082,7 +4079,7 @@ component_build_psa_accel_alg_rsa_oaep() {
     scripts/config.py -f "$CRYPTO_CONFIG_H" unset PSA_WANT_ALG_RSA_PKCS1V15_SIGN
     scripts/config.py -f "$CRYPTO_CONFIG_H" unset PSA_WANT_ALG_RSA_PSS
     # Need to define the correct symbol and include the test driver header path in order to build with the test driver
-    make CC=$ASAN_CC CFLAGS="$ASAN_CFLAGS -DPSA_CRYPTO_DRIVER_TEST -DMBEDTLS_PSA_ACCEL_ALG_RSA_OAEP -I../tests/include" LDFLAGS="$ASAN_CFLAGS" $MAKE_THREADING_FLAGS
+    make CC=$ASAN_CC CFLAGS="$ASAN_CFLAGS -DPSA_CRYPTO_DRIVER_TEST -DMBEDTLS_PSA_ACCEL_ALG_RSA_OAEP -I../tests/include" LDFLAGS="$ASAN_CFLAGS"
 }
 
 # This should be renamed to test and updated once the accelerator RSA code is in place and ready to test.
@@ -4096,7 +4093,7 @@ component_build_psa_accel_alg_rsa_pss() {
     scripts/config.py -f "$CRYPTO_CONFIG_H" unset PSA_WANT_ALG_RSA_PKCS1V15_SIGN
     scripts/config.py -f "$CRYPTO_CONFIG_H" unset PSA_WANT_ALG_RSA_OAEP
     # Need to define the correct symbol and include the test driver header path in order to build with the test driver
-    make CC=$ASAN_CC CFLAGS="$ASAN_CFLAGS -DPSA_CRYPTO_DRIVER_TEST -DMBEDTLS_PSA_ACCEL_ALG_RSA_PSS -I../tests/include" LDFLAGS="$ASAN_CFLAGS" $MAKE_THREADING_FLAGS
+    make CC=$ASAN_CC CFLAGS="$ASAN_CFLAGS -DPSA_CRYPTO_DRIVER_TEST -DMBEDTLS_PSA_ACCEL_ALG_RSA_PSS -I../tests/include" LDFLAGS="$ASAN_CFLAGS"
 }
 
 # This should be renamed to test and updated once the accelerator RSA code is in place and ready to test.
@@ -4111,7 +4108,7 @@ component_build_psa_accel_key_type_rsa_key_pair() {
     scripts/config.py -f "$CRYPTO_CONFIG_H" set PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_EXPORT 1
     scripts/config.py -f "$CRYPTO_CONFIG_H" set PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_GENERATE 1
     # Need to define the correct symbol and include the test driver header path in order to build with the test driver
-    make CC=$ASAN_CC CFLAGS="$ASAN_CFLAGS -DPSA_CRYPTO_DRIVER_TEST -DMBEDTLS_PSA_ACCEL_KEY_TYPE_RSA_KEY_PAIR -I../tests/include" LDFLAGS="$ASAN_CFLAGS" $MAKE_THREADING_FLAGS
+    make CC=$ASAN_CC CFLAGS="$ASAN_CFLAGS -DPSA_CRYPTO_DRIVER_TEST -DMBEDTLS_PSA_ACCEL_KEY_TYPE_RSA_KEY_PAIR -I../tests/include" LDFLAGS="$ASAN_CFLAGS"
 }
 
 # This should be renamed to test and updated once the accelerator RSA code is in place and ready to test.
@@ -4123,7 +4120,7 @@ component_build_psa_accel_key_type_rsa_public_key() {
     scripts/config.py -f "$CRYPTO_CONFIG_H" set PSA_WANT_ALG_RSA_PSS 1
     scripts/config.py -f "$CRYPTO_CONFIG_H" set PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY 1
     # Need to define the correct symbol and include the test driver header path in order to build with the test driver
-    make CC=$ASAN_CC CFLAGS="$ASAN_CFLAGS -DPSA_CRYPTO_DRIVER_TEST -DMBEDTLS_PSA_ACCEL_KEY_TYPE_RSA_PUBLIC_KEY -I../tests/include" LDFLAGS="$ASAN_CFLAGS" $MAKE_THREADING_FLAGS
+    make CC=$ASAN_CC CFLAGS="$ASAN_CFLAGS -DPSA_CRYPTO_DRIVER_TEST -DMBEDTLS_PSA_ACCEL_KEY_TYPE_RSA_PUBLIC_KEY -I../tests/include" LDFLAGS="$ASAN_CFLAGS"
 }
 
 
@@ -4292,7 +4289,7 @@ component_test_no_platform () {
     # Note, _DEFAULT_SOURCE needs to be defined for platforms using glibc version >2.19,
     # to re-enable platform integration features otherwise disabled in C99 builds
     make CC=gcc CFLAGS='-Werror -Wall -Wextra -std=c99 -pedantic -Os -D_DEFAULT_SOURCE' lib programs
-    make CC=gcc CFLAGS='-Werror -Wall -Wextra -Os' $MAKE_THREADING_FLAGS test
+    make CC=gcc CFLAGS='-Werror -Wall -Wextra -Os' test
 }
 
 component_build_no_std_function () {
@@ -4310,14 +4307,14 @@ component_build_no_ssl_srv () {
     msg "build: full config except SSL server, make, gcc" # ~ 30s
     scripts/config.py full
     scripts/config.py unset MBEDTLS_SSL_SRV_C
-    make CC=gcc CFLAGS='-Werror -Wall -Wextra -O1' $MAKE_THREADING_FLAGS
+    make CC=gcc CFLAGS='-Werror -Wall -Wextra -O1'
 }
 
 component_build_no_ssl_cli () {
     msg "build: full config except SSL client, make, gcc" # ~ 30s
     scripts/config.py full
     scripts/config.py unset MBEDTLS_SSL_CLI_C
-    make CC=gcc CFLAGS='-Werror -Wall -Wextra -O1' $MAKE_THREADING_FLAGS
+    make CC=gcc CFLAGS='-Werror -Wall -Wextra -O1'
 }
 
 component_build_no_sockets () {
@@ -4492,7 +4489,7 @@ component_test_platform_calloc_macro () {
 component_test_malloc_0_null () {
     msg "build: malloc(0) returns NULL (ASan+UBSan build)"
     scripts/config.py full
-    make CC=$ASAN_CC CFLAGS="'-DMBEDTLS_USER_CONFIG_FILE=\"$PWD/tests/configs/user-config-malloc-0-null.h\"' $ASAN_CFLAGS" LDFLAGS="$ASAN_CFLAGS" $MAKE_THREADING_FLAGS
+    make CC=$ASAN_CC CFLAGS="'-DMBEDTLS_USER_CONFIG_FILE=\"$PWD/tests/configs/user-config-malloc-0-null.h\"' $ASAN_CFLAGS" LDFLAGS="$ASAN_CFLAGS"
 
     msg "test: malloc(0) returns NULL (ASan+UBSan build)"
     make test
@@ -5104,7 +5101,7 @@ component_test_psa_crypto_drivers () {
     loc_cflags="${loc_cflags} '-DMBEDTLS_USER_CONFIG_FILE=\"../tests/configs/user-config-for-test.h\"'"
     loc_cflags="${loc_cflags} -I../tests/include -O2"
 
-    make CC=$ASAN_CC CFLAGS="${loc_cflags}" LDFLAGS="$ASAN_CFLAGS" $MAKE_THREADING_FLAGS
+    make CC=$ASAN_CC CFLAGS="${loc_cflags}" LDFLAGS="$ASAN_CFLAGS"
 
     msg "test: full + test drivers dispatching to builtins"
     make test
@@ -5131,7 +5128,7 @@ test_build_opt () {
     $cc --version
     for opt in "$@"; do
           msg "build/test: $cc $opt, $info" # ~ 30s
-          make CC="$cc" CFLAGS="$opt -std=c99 -pedantic -Wall -Wextra -Werror" $MAKE_THREADING_FLAGS
+          make CC="$cc" CFLAGS="$opt -std=c99 -pedantic -Wall -Wextra -Werror"
           # We're confident enough in compilers to not run _all_ the tests,
           # but at least run the unit tests. In particular, runs with
           # optimizations use inline assembly whereas runs with -O0
@@ -5186,7 +5183,7 @@ component_build_mbedtls_config_file () {
     msg "build: make with MBEDTLS_CONFIG_FILE" # ~40s
     scripts/config.py -w full_config.h full
     echo '#error "MBEDTLS_CONFIG_FILE is not working"' >"$CONFIG_H"
-    make CFLAGS="-I '$PWD' -DMBEDTLS_CONFIG_FILE='\"full_config.h\"'" $MAKE_THREADING_FLAGS
+    make CFLAGS="-I '$PWD' -DMBEDTLS_CONFIG_FILE='\"full_config.h\"'"
     # Make sure this feature is enabled. We'll disable it in the next phase.
     programs/test/query_compile_time_config MBEDTLS_NIST_KW_C
     make clean
@@ -5195,7 +5192,7 @@ component_build_mbedtls_config_file () {
     # In the user config, disable one feature (for simplicity, pick a feature
     # that nothing else depends on).
     echo '#undef MBEDTLS_NIST_KW_C' >user_config.h
-    make CFLAGS="-I '$PWD' -DMBEDTLS_CONFIG_FILE='\"full_config.h\"' -DMBEDTLS_USER_CONFIG_FILE='\"user_config.h\"'" $MAKE_THREADING_FLAGS
+    make CFLAGS="-I '$PWD' -DMBEDTLS_CONFIG_FILE='\"full_config.h\"' -DMBEDTLS_USER_CONFIG_FILE='\"user_config.h\"'"
     not programs/test/query_compile_time_config MBEDTLS_NIST_KW_C
 
     rm -f user_config.h full_config.h
@@ -5254,7 +5251,7 @@ component_test_m32_no_asm () {
     scripts/config.py unset MBEDTLS_HAVE_ASM
     scripts/config.py unset MBEDTLS_PADLOCK_C
     scripts/config.py unset MBEDTLS_AESNI_C # AESNI for 32-bit is tested in test_aesni_m32
-    make CC=gcc CFLAGS="$ASAN_CFLAGS -m32" LDFLAGS="-m32 $ASAN_CFLAGS" $MAKE_THREADING_FLAGS
+    make CC=gcc CFLAGS="$ASAN_CFLAGS -m32" LDFLAGS="-m32 $ASAN_CFLAGS"
 
     msg "test: i386, make, gcc, no asm (ASan build)"
     make test
@@ -5272,7 +5269,7 @@ component_test_m32_o2 () {
     msg "build: i386, make, gcc -O2 (ASan build)" # ~ 30s
     scripts/config.py full
     scripts/config.py unset MBEDTLS_AESNI_C # AESNI for 32-bit is tested in test_aesni_m32
-    make CC=gcc CFLAGS="$ASAN_CFLAGS -m32" LDFLAGS="-m32 $ASAN_CFLAGS" $MAKE_THREADING_FLAGS
+    make CC=gcc CFLAGS="$ASAN_CFLAGS -m32" LDFLAGS="-m32 $ASAN_CFLAGS"
 
     msg "test: i386, make, gcc -O2 (ASan build)"
     make test
@@ -5307,7 +5304,7 @@ support_test_m32_everest () {
 component_test_mx32 () {
     msg "build: 64-bit ILP32, make, gcc" # ~ 30s
     scripts/config.py full
-    make CC=gcc CFLAGS='-Werror -Wall -Wextra -mx32' LDFLAGS='-mx32' $MAKE_THREADING_FLAGS
+    make CC=gcc CFLAGS='-Werror -Wall -Wextra -mx32' LDFLAGS='-mx32'
 
     msg "test: 64-bit ILP32, make, gcc"
     make test
@@ -5371,7 +5368,7 @@ component_test_no_udbl_division () {
     msg "build: MBEDTLS_NO_UDBL_DIVISION native" # ~ 10s
     scripts/config.py full
     scripts/config.py set MBEDTLS_NO_UDBL_DIVISION
-    make CFLAGS='-Werror -O1' $MAKE_THREADING_FLAGS
+    make CFLAGS='-Werror -O1'
 
     msg "test: MBEDTLS_NO_UDBL_DIVISION native" # ~ 10s
     make test
@@ -5381,7 +5378,7 @@ component_test_no_64bit_multiplication () {
     msg "build: MBEDTLS_NO_64BIT_MULTIPLICATION native" # ~ 10s
     scripts/config.py full
     scripts/config.py set MBEDTLS_NO_64BIT_MULTIPLICATION
-    make CFLAGS='-Werror -O1' $MAKE_THREADING_FLAGS
+    make CFLAGS='-Werror -O1'
 
     msg "test: MBEDTLS_NO_64BIT_MULTIPLICATION native" # ~ 10s
     make test
@@ -5395,7 +5392,7 @@ component_test_no_strings () {
     scripts/config.py unset MBEDTLS_ERROR_C
     scripts/config.py set MBEDTLS_ERROR_STRERROR_DUMMY
     scripts/config.py unset MBEDTLS_VERSION_FEATURES
-    make CFLAGS='-Werror -Os' $MAKE_THREADING_FLAGS
+    make CFLAGS='-Werror -Os'
 
     msg "test: no strings" # ~ 10s
     make test
@@ -5406,7 +5403,7 @@ component_test_no_x509_info () {
     scripts/config.pl full
     scripts/config.pl unset MBEDTLS_MEMORY_BACKTRACE # too slow for tests
     scripts/config.pl set MBEDTLS_X509_REMOVE_INFO
-    make CFLAGS='-Werror -O2' $MAKE_THREADING_FLAGS
+    make CFLAGS='-Werror -O2'
 
     msg "test: full + MBEDTLS_X509_REMOVE_INFO" # ~ 10s
     make test
@@ -6009,7 +6006,7 @@ component_build_zeroize_checks () {
     scripts/config.py full
 
     # Only compile - we're looking for sizeof-pointer-memaccess warnings
-    make CC=gcc CFLAGS="'-DMBEDTLS_USER_CONFIG_FILE=\"../tests/configs/user-config-zeroize-memset.h\"' -DMBEDTLS_TEST_DEFINES_ZEROIZE -Werror -Wsizeof-pointer-memaccess" $MAKE_THREADING_FLAGS
+    make CC=gcc CFLAGS="'-DMBEDTLS_USER_CONFIG_FILE=\"../tests/configs/user-config-zeroize-memset.h\"' -DMBEDTLS_TEST_DEFINES_ZEROIZE -Werror -Wsizeof-pointer-memaccess"
 }
 
 

--- a/tests/scripts/check_files.py
+++ b/tests/scripts/check_files.py
@@ -318,6 +318,7 @@ class TabIssueTracker(LineIssueTracker):
 
     heading = "Tabs present:"
     suffix_exemptions = frozenset([
+        ".make",
         ".pem", # some openssl dumps have tabs
         ".sln",
         "/Makefile",

--- a/tests/scripts/depends.py
+++ b/tests/scripts/depends.py
@@ -381,7 +381,7 @@ class DomainData:
 
     def __init__(self, options, conf):
         """Gather data about the library and establish a list of domains to test."""
-        build_command = [options.make_command] + options.make_vars.split(' ') + ['CFLAGS=-Werror']
+        build_command = [options.make_command, 'CFLAGS=-Werror']
         build_and_test = [build_command, [options.make_command, 'test']]
         self.all_config_symbols = set(conf.settings.keys())
         # Find hash modules by name.
@@ -526,9 +526,6 @@ def main():
         parser.add_argument('--make-command', metavar='CMD',
                             help='Command to run instead of make (e.g. gmake)',
                             action='store', default='make')
-        parser.add_argument('--make-vars',
-                            help='optional variable/value pairs to pass to make',
-                            action='store', default='')
         parser.add_argument('--unset-use-psa',
                             help='Unset MBEDTLS_USE_PSA_CRYPTO before any test',
                             action='store_true', dest='unset_use_psa')

--- a/tests/scripts/psa_collect_statuses.py
+++ b/tests/scripts/psa_collect_statuses.py
@@ -82,15 +82,10 @@ def collect_status_logs(options):
                                   cwd='tests',
                                   stdout=sys.stderr)
         with open(os.devnull, 'w') as devnull:
-            build_command = ['make', '-q'] + options.make_vars.split(' ') + \
-                            ['lib', 'tests']
-            make_q_ret = subprocess.call(build_command, stdout=devnull,
-                                         stderr=devnull)
-            print("blagh")
+            make_q_ret = subprocess.call(['make', '-q', 'lib', 'tests'],
+                                         stdout=devnull, stderr=devnull)
         if make_q_ret != 0:
-            build_command = ['make'] + options.make_vars.split(' ') + \
-                            ['RECORD_PSA_STATUS_COVERAGE_LOG=1']
-            subprocess.check_call(build_command,
+            subprocess.check_call(['make', 'RECORD_PSA_STATUS_COVERAGE_LOG=1'],
                                   stdout=sys.stderr)
             rebuilt = True
         subprocess.check_call(['make', 'test'],
@@ -117,9 +112,6 @@ def main():
                         help='Log file location (default: {})'.format(
                             DEFAULT_STATUS_LOG_FILE
                         ))
-    parser.add_argument('--make-vars',
-                        help='optional variable/value pairs to pass to make',
-                        action='store', default='')
     parser.add_argument('--psa-constant-names', metavar='PROGRAM',
                         default=DEFAULT_PSA_CONSTANT_NAMES,
                         help='Path to psa_constant_names (default: {})'.format(


### PR DESCRIPTION
1. Create `scripts/common.make` because I am tired of duplicating code between `programs/Makefile` and `tests/Makefile`. At least for now, `library/Makefile` doesn't include it, though it probably should as a subsequent step.
2. Automatically detect whether linking with `pthread` is needed when building with `make`. This is nice to users, and also means we don't need to pass options through to make. **Fixes the [code coverage build failure](https://mbedtls.trustedfirmware.org/job/mbed-tls-nightly-tests/327/execution/node/899/log/) in the CI.**
3. Clean up the machinery added in #8342 for passing `THREADING=pthread` from `all.sh` down to `make`, since it isn't needed after all.

## PR checklist

- [x] **changelog** no (build scripts only)
- [x] **backport** no (no threading hacks in 2.28, and we probably shouldn't create a new file involved in the build)
- [x] **tests** CI passing + [code coverage](https://mbedtls.trustedfirmware.org/job/mbedtls-release-ci-testing/125/)
