### PR TITLE
Add ECP key pair import function

### DIFF
--- a/include/mbedtls/ecp.h
+++ b/include/mbedtls/ecp.h
@@ -1324,6 +1324,26 @@ int mbedtls_ecp_check_pub_priv(
     int (*f_rng)(void *, unsigned char *, size_t), void *p_rng);
 
 /**
+ * \brief           This function imports generic key-pair parameters.
+ *
+ * \param key       The key pair to import to.
+ * \param grp       Slot for exported ECP group.
+ *                  It must point to an initialized ECP group.
+ * \param d         Slot for the exported secret value.
+ *                  It must point to an initialized mpi.
+ * \param Q         Slot for the exported public value.
+ *                  It must point to an initialized ECP point.
+ *
+ * \return          \c 0 on success,
+ * \return          #MBEDTLS_ERR_MPI_ALLOC_FAILED on memory-allocation failure.
+ * \return          #MBEDTLS_ERR_ECP_FEATURE_UNAVAILABLE if key id doesn't
+ *                  correspond to a known group.
+ * \return          Another negative error code on other kinds of failure.
+ */
+int mbedtls_ecp_import(mbedtls_ecp_keypair *key, const mbedtls_ecp_group *grp,
+                       const mbedtls_mpi *d, const mbedtls_ecp_point *Q);
+
+/**
  * \brief           This function exports generic key-pair parameters.
  *
  * \param key       The key pair to export from.

--- a/library/ecp.c
+++ b/library/ecp.c
@@ -3365,6 +3365,29 @@ cleanup:
 #endif /* MBEDTLS_ECP_C */
 
 /*
+ * Import generic key-pair parameters.
+ */
+int mbedtls_ecp_import(mbedtls_ecp_keypair *key, const mbedtls_ecp_group *grp,
+                       const mbedtls_mpi *d, const mbedtls_ecp_point *Q)
+{
+    int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
+
+    if ((ret = mbedtls_ecp_group_copy(&key->grp, grp)) != 0) {
+        return ret;
+    }
+
+    if ((ret = mbedtls_mpi_copy(&key->d, d)) != 0) {
+        return ret;
+    }
+
+    if ((ret = mbedtls_ecp_copy(&key->Q, Q)) != 0) {
+        return ret;
+    }
+
+    return 0;
+}
+
+/*
  * Export generic key-pair parameters.
  */
 int mbedtls_ecp_export(const mbedtls_ecp_keypair *key, mbedtls_ecp_group *grp,


### PR DESCRIPTION
## Description

Add an ECP key pair import function (mbedtls_ecp_import) similar to the export function (mbedtls_ecp_export) that was added in https://github.com/Mbed-TLS/mbedtls/pull/5642. This fixes issue https://github.com/Mbed-TLS/mbedtls/issues/8652, where no suitable public API can be used to import grp, d, and Q into a mbedtls_ecp_keypair since the struct members have been made private. Combined with mbedtls_ecdsa_from_keypair, it now also becomes possible to initialize mbedtls_ecdsa_context from generic, imported parameters, which was the original problem I encountered while migrating to mbedtls 3.x.

## PR checklist

- [ ] **changelog**: not provided, I'm not familiar with the procedure.
- [ ] **backport**: not needed, I'm fine without a backport for my needs
- [ ] **tests**: not provided, I don't really know how to add them.

