### PR TITLE
add support for MBEDTLS_SSL_VERIFY_EXTERNAL authmode

### DIFF
--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -290,6 +290,7 @@
 #define MBEDTLS_SSL_VERIFY_OPTIONAL             1
 #define MBEDTLS_SSL_VERIFY_REQUIRED             2
 #define MBEDTLS_SSL_VERIFY_UNSET                3 /* Used only for sni_authmode */
+#define MBEDTLS_SSL_VERIFY_EXTERNAL             4
 
 #define MBEDTLS_SSL_LEGACY_RENEGOTIATION        0
 #define MBEDTLS_SSL_SECURE_RENEGOTIATION        1
@@ -1971,6 +1972,10 @@ void mbedtls_ssl_conf_transport(mbedtls_ssl_config *conf, int transport);
  *  MBEDTLS_SSL_VERIFY_REQUIRED:  peer *must* present a valid certificate,
  *                        handshake is aborted if verification failed.
  *                        (default on client)
+ * 
+ *  MBEDTLS_SSL_VERIFY_EXTERNAL:  external certificate validation mode,
+ *                        a verification callback *must* be registered using
+ *                        mbedtls_ssl_conf_verify() or mbedtls_ssl_set_verify().
  *
  * \note On client, MBEDTLS_SSL_VERIFY_REQUIRED is the recommended mode.
  * With MBEDTLS_SSL_VERIFY_OPTIONAL, the user needs to call mbedtls_ssl_get_verify_result() at

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -7279,6 +7279,19 @@ static int ssl_parse_certificate_verify(mbedtls_ssl_context *ssl,
         p_vrfy = ssl->conf->p_vrfy;
     }
 
+    if (authmode == MBEDTLS_SSL_VERIFY_EXTERNAL) {
+        if (f_vrfy == NULL) {
+            MBEDTLS_SSL_DEBUG_MSG(1, ("No callback registered for external verification mode"));
+            return MBEDTLS_ERR_SSL_INTERNAL_ERROR;
+        }
+        MBEDTLS_SSL_DEBUG_MSG(3, ("Use callback for external verification"));
+        ret = f_vrfy(p_vrfy, ssl->session_negotiate->peer_cert, -1, &ssl->session_negotiate->verify_result);
+        if (ret != 0) {
+            MBEDTLS_SSL_DEBUG_RET(1, "x509_verify_cert", ret);
+        }
+        return ret;
+    }
+
     /*
      * Main check: verify certificate
      */


### PR DESCRIPTION
## Description

Add MBEDTLS_SSL_VERIFY_EXTERNAL authmode for external certificate verification by registered callback, making it easy for an application to take full control and customize the verification process. This is a refreshed pull request for the old one that was [already discussed and reviewed years ago, but ended up going stale and unmerged](https://github.com/Mbed-TLS/mbedtls/pull/2091). I'm currently migrating to mbedtls 3.x so I've been spending a bit of time cleaning up our patches, and hopefully, this time is the good one for this minor but so useful improvement to make its way upstream.

## PR checklist

- [ ] **changelog** TODO
- [x] **backport** not required - new feature
- [ ] **tests** TODO