### PR TITLE
Fix a comment in ecp

### DIFF
--- a/library/ecp.c
+++ b/library/ecp.c
@@ -2614,8 +2614,8 @@ static int ecp_mul_mxz(mbedtls_ecp_group *grp, mbedtls_ecp_point *R,
     /* RP.X might be slightly larger than P, so reduce it */
     MOD_ADD(RP.X);
 
+    /* Randomize coordinates of the starting point */
 #if defined(MBEDTLS_ECP_NO_INTERNAL_RNG)
-    /* Derandomize coordinates of the starting point */
     if (f_rng == NULL) {
         have_rng = 0;
     }


### PR DESCRIPTION
## Description
The modified comment is indeed for the bigger scope(ended by the call to ecp_randomize_mxz()).
Fixes 5521b4ce37b2b7768a66c3a2b5a2fcff200ca11a.

## PR checklist


- [x] **changelog** not required
- [x] **backport** not needed. This is only for LTS branch.
- [x] **tests** not required
