### PR TITLE
Minor cleanups to common.make

### DIFF
--- a/programs/Makefile
+++ b/programs/Makefile
@@ -3,7 +3,6 @@ MBEDTLS_TEST_PATH = ../tests
 # code which is in the src/test_helpers subdirectory.
 MBEDTLS_TEST_OBJS = $(patsubst %.c,%.o,$(wildcard ${MBEDTLS_TEST_PATH}/src/*.c ${MBEDTLS_TEST_PATH}/src/drivers/*.c))
 
-LOCAL_CFLAGS = $(WARNING_CFLAGS) -I$(MBEDTLS_TEST_PATH)/include -I../include -D_FILE_OFFSET_BITS=64
 include ../scripts/common.make
 
 ifeq ($(shell uname -s),Linux)

--- a/programs/Makefile
+++ b/programs/Makefile
@@ -1,8 +1,4 @@
 MBEDTLS_TEST_PATH = ../tests
-# Support code used by test programs and test builds, excluding TLS-specific
-# code which is in the src/test_helpers subdirectory.
-MBEDTLS_TEST_OBJS = $(patsubst %.c,%.o,$(wildcard ${MBEDTLS_TEST_PATH}/src/*.c ${MBEDTLS_TEST_PATH}/src/drivers/*.c))
-
 include ../scripts/common.make
 
 ifeq ($(shell uname -s),Linux)
@@ -10,6 +6,10 @@ DLOPEN_LDFLAGS ?= -ldl
 else
 DLOPEN_LDFLAGS ?=
 endif
+
+# Support code used by test programs and test builds, excluding TLS-specific
+# code which is in the src/test_helpers subdirectory.
+MBEDTLS_TEST_OBJS = $(patsubst %.c,%.o,$(wildcard ${MBEDTLS_TEST_PATH}/src/*.c ${MBEDTLS_TEST_PATH}/src/drivers/*.c))
 
 DEP=${MBEDLIBS} ${MBEDTLS_TEST_OBJS}
 

--- a/programs/Makefile
+++ b/programs/Makefile
@@ -7,10 +7,6 @@ else
 DLOPEN_LDFLAGS ?=
 endif
 
-# Support code used by test programs and test builds, excluding TLS-specific
-# code which is in the src/test_helpers subdirectory.
-MBEDTLS_TEST_OBJS = $(patsubst %.c,%.o,$(wildcard ${MBEDTLS_TEST_PATH}/src/*.c ${MBEDTLS_TEST_PATH}/src/drivers/*.c))
-
 DEP=${MBEDLIBS} ${MBEDTLS_TEST_OBJS}
 
 # Only build the dlopen test in shared library builds, and not when building

--- a/scripts/common.make
+++ b/scripts/common.make
@@ -5,7 +5,7 @@ WARNING_CFLAGS ?= -Wall -Wextra -Wformat=2 -Wno-format-nonliteral
 WARNING_CXXFLAGS ?= -Wall -Wextra -Wformat=2 -Wno-format-nonliteral
 LDFLAGS ?=
 
-LOCAL_CFLAGS = $(WARNING_CFLAGS) -I../tests/include -I../include -D_FILE_OFFSET_BITS=64
+LOCAL_CFLAGS = $(WARNING_CFLAGS) -I$(MBEDTLS_TEST_PATH)/include -I../include -D_FILE_OFFSET_BITS=64
 LOCAL_CXXFLAGS = $(WARNING_CXXFLAGS) -I../include -I../tests/include -D_FILE_OFFSET_BITS=64
 LOCAL_LDFLAGS = ${MBEDTLS_TEST_OBJS} 		\
 		-L../library			\

--- a/scripts/common.make
+++ b/scripts/common.make
@@ -105,3 +105,15 @@ ifndef WINDOWS
 else
 	for %f in ($(subst /,\,$(GENERATED_FILES))) if exist %f del /Q /F %f
 endif
+
+# Auxiliary modules used by tests and some sample programs
+MBEDTLS_CORE_TEST_OBJS = $(patsubst %.c,%.o,$(wildcard \
+    ${MBEDTLS_TEST_PATH}/src/*.c \
+    ${MBEDTLS_TEST_PATH}/src/drivers/*.c \
+  ))
+# Additional auxiliary modules for TLS testing
+MBEDTLS_TLS_TEST_OBJS = $(patsubst %.c,%.o,$(wildcard \
+    ${MBEDTLS_TEST_PATH}/src/test_helpers/*.c \
+  ))
+
+MBEDTLS_TEST_OBJS = $(MBEDTLS_CORE_TEST_OBJS) $(MBEDTLS_TLS_TEST_OBJS)

--- a/scripts/common.make
+++ b/scripts/common.make
@@ -35,7 +35,7 @@ endif
 ## Remove the preprocessor symbols that are set in the current configuration
 ## from PREPROCESSOR_INPUT. Also normalize whitespace.
 ## Example:
-##   $(call remove_set_options,MBEDTLS_FOO MBEDTLS_BAR)
+##   $(call remove_enabled_options,MBEDTLS_FOO MBEDTLS_BAR)
 ## This expands to an empty string "" if MBEDTLS_FOO and MBEDTLS_BAR are both
 ## enabled, to "MBEDTLS_FOO" if MBEDTLS_BAR is enabled but MBEDTLS_FOO is
 ## disabled, etc.

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,3 +1,4 @@
+MBEDTLS_TEST_PATH = .
 include ../scripts/common.make
 
 # Set this to -v to see the details of failing test cases
@@ -109,7 +110,6 @@ BINARIES := $(addsuffix $(EXEXT),$(APPS))
 
 all: $(BINARIES)
 
-MBEDTLS_TEST_PATH = .
 MBEDTLS_TEST_OBJS = $(patsubst %.c,%.o,$(wildcard ${MBEDTLS_TEST_PATH}/src/*.c ${MBEDTLS_TEST_PATH}/src/drivers/*.c))
 MBEDTLS_TEST_OBJS += $(patsubst %.c,%.o,$(wildcard ${MBEDTLS_TEST_PATH}/src/test_helpers/*.c))
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -110,9 +110,6 @@ BINARIES := $(addsuffix $(EXEXT),$(APPS))
 
 all: $(BINARIES)
 
-MBEDTLS_TEST_OBJS = $(patsubst %.c,%.o,$(wildcard ${MBEDTLS_TEST_PATH}/src/*.c ${MBEDTLS_TEST_PATH}/src/drivers/*.c))
-MBEDTLS_TEST_OBJS += $(patsubst %.c,%.o,$(wildcard ${MBEDTLS_TEST_PATH}/src/test_helpers/*.c))
-
 mbedtls_test: $(MBEDTLS_TEST_OBJS)
 
 TEST_OBJS_DEPS = $(wildcard include/test/*.h include/test/*/*.h)


### PR DESCRIPTION
Follow-up to https://github.com/Mbed-TLS/mbedtls/pull/8653, fixing some documentation and robustness issues (mostly raised in review).

Priority: high because this is a follow-up to a merge pull request, which would have been handled by rework before merging in normal circumstances, and was only delayed because the original pull request was very-high-priority.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** no (build scripts only)
- [x] **backport** no (follow-up to 3.x-only stuff)
- [x] **tests** just the CI
