### PR TITLE
Prototype mbedtls_pk_import_into_psa

### DIFF
--- a/library/pk_internal.h
+++ b/library/pk_internal.h
@@ -17,11 +17,14 @@
 #include "mbedtls/ecp.h"
 #endif
 
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
+#if defined(MBEDTLS_PSA_CRYPTO_CLIENT)
 #include "psa/crypto.h"
 
 #include "psa_util_internal.h"
 #define PSA_PK_TO_MBEDTLS_ERR(status) psa_pk_status_to_mbedtls(status)
+#endif /* MBEDTLS_PSA_CRYPTO_CLIENT */
+
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
 #define PSA_PK_RSA_TO_MBEDTLS_ERR(status) PSA_TO_MBEDTLS_ERR_LIST(status,     \
                                                                   psa_to_pk_rsa_errors,            \
                                                                   psa_pk_status_to_mbedtls)

--- a/tests/suites/test_suite_pkparse.data
+++ b/tests/suites/test_suite_pkparse.data
@@ -906,213 +906,213 @@ pk_parse_public_keyfile_rsa:"data_files/rsa_pkcs1_2048_public.der":0
 
 Parse Public EC Key #1 (RFC 5480, DER)
 depends_on:MBEDTLS_ECP_HAVE_SECP192R1
-pk_parse_public_keyfile_ec:"data_files/ec_pub.der":0
+pk_parse_public_keyfile_ec:"data_files/ec_pub.der":0:PSA_ECC_FAMILY_SECP_R1
 
 Parse Public EC Key #2 (RFC 5480, PEM)
 depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_HAVE_SECP192R1
-pk_parse_public_keyfile_ec:"data_files/ec_pub.pem":0
+pk_parse_public_keyfile_ec:"data_files/ec_pub.pem":0:PSA_ECC_FAMILY_SECP_R1
 
 Parse Public EC Key #2a (RFC 5480, PEM, secp192r1, compressed)
 depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_PK_PARSE_EC_COMPRESSED:MBEDTLS_ECP_DP_SECP192R1_ENABLED
-pk_parse_public_keyfile_ec:"data_files/ec_pub.comp.pem":0
+pk_parse_public_keyfile_ec:"data_files/ec_pub.comp.pem":0:PSA_ECC_FAMILY_SECP_R1
 
 Parse Public EC Key #3 (RFC 5480, secp224r1)
 depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_HAVE_SECP224R1
-pk_parse_public_keyfile_ec:"data_files/ec_224_pub.pem":0
+pk_parse_public_keyfile_ec:"data_files/ec_224_pub.pem":0:PSA_ECC_FAMILY_SECP_R1
 
 # Compressed points parsing does not support MBEDTLS_ECP_DP_SECP224R1 and
 # MBEDTLS_ECP_DP_SECP224K1. Therefore a failure is expected in this case
 Parse Public EC Key #3a (RFC 5480, secp224r1, compressed)
 depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_PK_PARSE_EC_COMPRESSED:MBEDTLS_ECP_DP_SECP224R1_ENABLED
-pk_parse_public_keyfile_ec:"data_files/ec_224_pub.comp.pem":MBEDTLS_ERR_ECP_FEATURE_UNAVAILABLE
+pk_parse_public_keyfile_ec:"data_files/ec_224_pub.comp.pem":MBEDTLS_ERR_ECP_FEATURE_UNAVAILABLE:PSA_ECC_FAMILY_SECP_R1
 
 Parse Public EC Key #4 (RFC 5480, secp256r1)
 depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_HAVE_SECP256R1
-pk_parse_public_keyfile_ec:"data_files/ec_256_pub.pem":0
+pk_parse_public_keyfile_ec:"data_files/ec_256_pub.pem":0:PSA_ECC_FAMILY_SECP_R1
 
 Parse Public EC Key #4a (RFC 5480, secp256r1, compressed)
 depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_PK_PARSE_EC_COMPRESSED:MBEDTLS_ECP_DP_SECP256R1_ENABLED
-pk_parse_public_keyfile_ec:"data_files/ec_256_pub.comp.pem":0
+pk_parse_public_keyfile_ec:"data_files/ec_256_pub.comp.pem":0:PSA_ECC_FAMILY_SECP_R1
 
 Parse Public EC Key #5 (RFC 5480, secp384r1)
 depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_HAVE_SECP384R1
-pk_parse_public_keyfile_ec:"data_files/ec_384_pub.pem":0
+pk_parse_public_keyfile_ec:"data_files/ec_384_pub.pem":0:PSA_ECC_FAMILY_SECP_R1
 
 Parse Public EC Key #5a (RFC 5480, secp384r1, compressed)
 depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_PK_PARSE_EC_COMPRESSED:MBEDTLS_ECP_DP_SECP384R1_ENABLED
-pk_parse_public_keyfile_ec:"data_files/ec_384_pub.comp.pem":0
+pk_parse_public_keyfile_ec:"data_files/ec_384_pub.comp.pem":0:PSA_ECC_FAMILY_SECP_R1
 
 Parse Public EC Key #6 (RFC 5480, secp521r1)
 depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_HAVE_SECP521R1
-pk_parse_public_keyfile_ec:"data_files/ec_521_pub.pem":0
+pk_parse_public_keyfile_ec:"data_files/ec_521_pub.pem":0:PSA_ECC_FAMILY_SECP_R1
 
 Parse Public EC Key #6a (RFC 5480, secp521r1, compressed)
 depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_PK_PARSE_EC_COMPRESSED:MBEDTLS_ECP_DP_SECP521R1_ENABLED
-pk_parse_public_keyfile_ec:"data_files/ec_521_pub.comp.pem":0
+pk_parse_public_keyfile_ec:"data_files/ec_521_pub.comp.pem":0:PSA_ECC_FAMILY_SECP_R1
 
 Parse Public EC Key #7 (RFC 5480, brainpoolP256r1)
 depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_HAVE_BP256R1
-pk_parse_public_keyfile_ec:"data_files/ec_bp256_pub.pem":0
+pk_parse_public_keyfile_ec:"data_files/ec_bp256_pub.pem":0:PSA_ECC_FAMILY_BRAINPOOL_P_R1
 
 Parse Public EC Key #7a (RFC 5480, brainpoolP256r1, compressed)
 depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_PK_PARSE_EC_COMPRESSED:MBEDTLS_ECP_DP_BP256R1_ENABLED
-pk_parse_public_keyfile_ec:"data_files/ec_bp256_pub.comp.pem":0
+pk_parse_public_keyfile_ec:"data_files/ec_bp256_pub.comp.pem":0:PSA_ECC_FAMILY_BRAINPOOL_P_R1
 
 Parse Public EC Key #8 (RFC 5480, brainpoolP384r1)
 depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_HAVE_BP384R1
-pk_parse_public_keyfile_ec:"data_files/ec_bp384_pub.pem":0
+pk_parse_public_keyfile_ec:"data_files/ec_bp384_pub.pem":0:PSA_ECC_FAMILY_BRAINPOOL_P_R1
 
 Parse Public EC Key #8a (RFC 5480, brainpoolP384r1, compressed)
 depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_PK_PARSE_EC_COMPRESSED:MBEDTLS_ECP_DP_BP384R1_ENABLED
-pk_parse_public_keyfile_ec:"data_files/ec_bp384_pub.comp.pem":0
+pk_parse_public_keyfile_ec:"data_files/ec_bp384_pub.comp.pem":0:PSA_ECC_FAMILY_BRAINPOOL_P_R1
 
 Parse Public EC Key #9 (RFC 5480, brainpoolP512r1)
 depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_HAVE_BP512R1
-pk_parse_public_keyfile_ec:"data_files/ec_bp512_pub.pem":0
+pk_parse_public_keyfile_ec:"data_files/ec_bp512_pub.pem":0:PSA_ECC_FAMILY_BRAINPOOL_P_R1
 
 Parse Public EC Key #9a (RFC 5480, brainpoolP512r1, compressed)
 depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_PK_PARSE_EC_COMPRESSED:MBEDTLS_ECP_DP_BP512R1_ENABLED
-pk_parse_public_keyfile_ec:"data_files/ec_bp512_pub.comp.pem":0
+pk_parse_public_keyfile_ec:"data_files/ec_bp512_pub.comp.pem":0:PSA_ECC_FAMILY_BRAINPOOL_P_R1
 
 Parse Public EC Key #10 (RFC 8410, DER, X25519)
 depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_HAVE_CURVE25519
-pk_parse_public_keyfile_ec:"data_files/ec_x25519_pub.der":0
+pk_parse_public_keyfile_ec:"data_files/ec_x25519_pub.der":0:PSA_ECC_FAMILY_MONTGOMERY
 
 Parse Public EC Key #11 (RFC 8410, DER, X448)
 depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_HAVE_CURVE448
-pk_parse_public_keyfile_ec:"data_files/ec_x448_pub.der":0
+pk_parse_public_keyfile_ec:"data_files/ec_x448_pub.der":0:PSA_ECC_FAMILY_MONTGOMERY
 
 Parse Public EC Key #12 (RFC 8410, PEM, X25519)
 depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_HAVE_CURVE25519
-pk_parse_public_keyfile_ec:"data_files/ec_x25519_pub.pem":0
+pk_parse_public_keyfile_ec:"data_files/ec_x25519_pub.pem":0:PSA_ECC_FAMILY_MONTGOMERY
 
 Parse Public EC Key #13 (RFC 8410, PEM, X448)
 depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_HAVE_CURVE448
-pk_parse_public_keyfile_ec:"data_files/ec_x448_pub.pem":0
+pk_parse_public_keyfile_ec:"data_files/ec_x448_pub.pem":0:PSA_ECC_FAMILY_MONTGOMERY
 
 Parse EC Key #1 (SEC1 DER)
 depends_on:MBEDTLS_PK_HAVE_ECC_KEYS:MBEDTLS_ECP_HAVE_SECP192R1
-pk_parse_keyfile_ec:"data_files/ec_prv.sec1.der":"NULL":0
+pk_parse_keyfile_ec:"data_files/ec_prv.sec1.der":"NULL":0:PSA_ECC_FAMILY_SECP_R1
 
 Parse EC Key #2 (SEC1 PEM)
 depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_HAVE_SECP192R1
-pk_parse_keyfile_ec:"data_files/ec_prv.sec1.pem":"NULL":0
+pk_parse_keyfile_ec:"data_files/ec_prv.sec1.pem":"NULL":0:PSA_ECC_FAMILY_SECP_R1
 
 Parse EC Key #2a (SEC1 PEM, secp192r1, compressed)
 depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_PK_PARSE_EC_COMPRESSED:MBEDTLS_ECP_DP_SECP192R1_ENABLED
-pk_parse_keyfile_ec:"data_files/ec_prv.sec1.comp.pem":"NULL":0
+pk_parse_keyfile_ec:"data_files/ec_prv.sec1.comp.pem":"NULL":0:PSA_ECC_FAMILY_SECP_R1
 
 Parse EC Key #3 (SEC1 PEM encrypted)
 depends_on:MBEDTLS_DES_C:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_HAVE_SECP192R1:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_MD_CAN_MD5
-pk_parse_keyfile_ec:"data_files/ec_prv.sec1.pw.pem":"polar":0
+pk_parse_keyfile_ec:"data_files/ec_prv.sec1.pw.pem":"polar":0:PSA_ECC_FAMILY_SECP_R1
 
 Parse EC Key #4 (PKCS8 DER)
 depends_on:MBEDTLS_ECP_HAVE_SECP192R1
-pk_parse_keyfile_ec:"data_files/ec_prv.pk8.der":"NULL":0
+pk_parse_keyfile_ec:"data_files/ec_prv.pk8.der":"NULL":0:PSA_ECC_FAMILY_SECP_R1
 
 Parse EC Key #4a (PKCS8 DER, no public key)
 depends_on:MBEDTLS_ECP_HAVE_SECP256R1
-pk_parse_keyfile_ec:"data_files/ec_prv.pk8nopub.der":"NULL":0
+pk_parse_keyfile_ec:"data_files/ec_prv.pk8nopub.der":"NULL":0:PSA_ECC_FAMILY_SECP_R1
 
 Parse EC Key #4b (PKCS8 DER, no public key, with parameters)
 depends_on:MBEDTLS_ECP_HAVE_SECP256R1
-pk_parse_keyfile_ec:"data_files/ec_prv.pk8nopubparam.der":"NULL":0
+pk_parse_keyfile_ec:"data_files/ec_prv.pk8nopubparam.der":"NULL":0:PSA_ECC_FAMILY_SECP_R1
 
 Parse EC Key #4c (PKCS8 DER, with parameters)
 depends_on:MBEDTLS_ECP_HAVE_SECP256R1
-pk_parse_keyfile_ec:"data_files/ec_prv.pk8param.der":"NULL":0
+pk_parse_keyfile_ec:"data_files/ec_prv.pk8param.der":"NULL":0:PSA_ECC_FAMILY_SECP_R1
 
 Parse EC Key #5 (PKCS8 PEM)
 depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_HAVE_SECP192R1
-pk_parse_keyfile_ec:"data_files/ec_prv.pk8.pem":"NULL":0
+pk_parse_keyfile_ec:"data_files/ec_prv.pk8.pem":"NULL":0:PSA_ECC_FAMILY_SECP_R1
 
 Parse EC Key #5a (PKCS8 PEM, no public key)
 depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_HAVE_SECP256R1
-pk_parse_keyfile_ec:"data_files/ec_prv.pk8nopub.pem":"NULL":0
+pk_parse_keyfile_ec:"data_files/ec_prv.pk8nopub.pem":"NULL":0:PSA_ECC_FAMILY_SECP_R1
 
 Parse EC Key #5b (PKCS8 PEM, no public key, with parameters)
 depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_HAVE_SECP256R1
-pk_parse_keyfile_ec:"data_files/ec_prv.pk8nopubparam.pem":"NULL":0
+pk_parse_keyfile_ec:"data_files/ec_prv.pk8nopubparam.pem":"NULL":0:PSA_ECC_FAMILY_SECP_R1
 
 Parse EC Key #5c (PKCS8 PEM, with parameters)
 depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_HAVE_SECP256R1
-pk_parse_keyfile_ec:"data_files/ec_prv.pk8param.pem":"NULL":0
+pk_parse_keyfile_ec:"data_files/ec_prv.pk8param.pem":"NULL":0:PSA_ECC_FAMILY_SECP_R1
 
 Parse EC Key #8 (SEC1 PEM, secp224r1)
 depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_HAVE_SECP224R1
-pk_parse_keyfile_ec:"data_files/ec_224_prv.pem":"NULL":0
+pk_parse_keyfile_ec:"data_files/ec_224_prv.pem":"NULL":0:PSA_ECC_FAMILY_SECP_R1
 
 Parse EC Key #8a (SEC1 PEM, secp224r1, compressed)
 depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_PK_PARSE_EC_COMPRESSED:MBEDTLS_ECP_DP_SECP224R1_ENABLED
-pk_parse_keyfile_ec:"data_files/ec_224_prv.comp.pem":"NULL":0
+pk_parse_keyfile_ec:"data_files/ec_224_prv.comp.pem":"NULL":0:PSA_ECC_FAMILY_SECP_R1
 
 Parse EC Key #9 (SEC1 PEM, secp256r1)
 depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_HAVE_SECP256R1
-pk_parse_keyfile_ec:"data_files/ec_256_prv.pem":"NULL":0
+pk_parse_keyfile_ec:"data_files/ec_256_prv.pem":"NULL":0:PSA_ECC_FAMILY_SECP_R1
 
 Parse EC Key #9a (SEC1 PEM, secp256r1, compressed)
 depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_PK_PARSE_EC_COMPRESSED:MBEDTLS_ECP_DP_SECP256R1_ENABLED
-pk_parse_keyfile_ec:"data_files/ec_256_prv.comp.pem":"NULL":0
+pk_parse_keyfile_ec:"data_files/ec_256_prv.comp.pem":"NULL":0:PSA_ECC_FAMILY_SECP_R1
 
 Parse EC Key #10 (SEC1 PEM, secp384r1)
 depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_HAVE_SECP384R1
-pk_parse_keyfile_ec:"data_files/ec_384_prv.pem":"NULL":0
+pk_parse_keyfile_ec:"data_files/ec_384_prv.pem":"NULL":0:PSA_ECC_FAMILY_SECP_R1
 
 Parse EC Key #10a (SEC1 PEM, secp384r1, compressed)
 depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_PK_PARSE_EC_COMPRESSED:MBEDTLS_ECP_DP_SECP384R1_ENABLED
-pk_parse_keyfile_ec:"data_files/ec_384_prv.comp.pem":"NULL":0
+pk_parse_keyfile_ec:"data_files/ec_384_prv.comp.pem":"NULL":0:PSA_ECC_FAMILY_SECP_R1
 
 Parse EC Key #11 (SEC1 PEM, secp521r1)
 depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_HAVE_SECP521R1
-pk_parse_keyfile_ec:"data_files/ec_521_prv.pem":"NULL":0
+pk_parse_keyfile_ec:"data_files/ec_521_prv.pem":"NULL":0:PSA_ECC_FAMILY_SECP_R1
 
 Parse EC Key #11a (SEC1 PEM, secp521r1, compressed)
 depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_PK_PARSE_EC_COMPRESSED:MBEDTLS_ECP_DP_SECP521R1_ENABLED
-pk_parse_keyfile_ec:"data_files/ec_521_prv.comp.pem":"NULL":0
+pk_parse_keyfile_ec:"data_files/ec_521_prv.comp.pem":"NULL":0:PSA_ECC_FAMILY_SECP_R1
 
 Parse EC Key #12 (SEC1 PEM, bp256r1)
 depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_HAVE_BP256R1
-pk_parse_keyfile_ec:"data_files/ec_bp256_prv.pem":"NULL":0
+pk_parse_keyfile_ec:"data_files/ec_bp256_prv.pem":"NULL":0:PSA_ECC_FAMILY_BRAINPOOL_P_R1
 
 Parse EC Key #12a (SEC1 PEM, bp256r1, compressed)
 depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_PK_PARSE_EC_COMPRESSED:MBEDTLS_ECP_DP_BP256R1_ENABLED
-pk_parse_keyfile_ec:"data_files/ec_bp256_prv.comp.pem":"NULL":0
+pk_parse_keyfile_ec:"data_files/ec_bp256_prv.comp.pem":"NULL":0:PSA_ECC_FAMILY_BRAINPOOL_P_R1
 
 Parse EC Key #13 (SEC1 PEM, bp384r1)
 depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_HAVE_BP384R1
-pk_parse_keyfile_ec:"data_files/ec_bp384_prv.pem":"NULL":0
+pk_parse_keyfile_ec:"data_files/ec_bp384_prv.pem":"NULL":0:PSA_ECC_FAMILY_BRAINPOOL_P_R1
 
 Parse EC Key #13a (SEC1 PEM, bp384r1, compressed)
 depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_PK_PARSE_EC_COMPRESSED:MBEDTLS_ECP_DP_BP384R1_ENABLED
-pk_parse_keyfile_ec:"data_files/ec_bp384_prv.comp.pem":"NULL":0
+pk_parse_keyfile_ec:"data_files/ec_bp384_prv.comp.pem":"NULL":0:PSA_ECC_FAMILY_BRAINPOOL_P_R1
 
 Parse EC Key #14 (SEC1 PEM, bp512r1)
 depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_HAVE_BP512R1
-pk_parse_keyfile_ec:"data_files/ec_bp512_prv.pem":"NULL":0
+pk_parse_keyfile_ec:"data_files/ec_bp512_prv.pem":"NULL":0:PSA_ECC_FAMILY_BRAINPOOL_P_R1
 
 Parse EC Key #14a (SEC1 PEM, bp512r1, compressed)
 depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_PK_PARSE_EC_COMPRESSED:MBEDTLS_ECP_DP_BP512R1_ENABLED
-pk_parse_keyfile_ec:"data_files/ec_bp512_prv.comp.pem":"NULL":0
+pk_parse_keyfile_ec:"data_files/ec_bp512_prv.comp.pem":"NULL":0:PSA_ECC_FAMILY_BRAINPOOL_P_R1
 
 Parse EC Key #15 (SEC1 DER, secp256k1, SpecifiedECDomain)
 depends_on:MBEDTLS_ECP_DP_SECP256K1_ENABLED:MBEDTLS_PK_PARSE_EC_EXTENDED
-pk_parse_keyfile_ec:"data_files/ec_prv.specdom.der":"NULL":0
+pk_parse_keyfile_ec:"data_files/ec_prv.specdom.der":"NULL":0:PSA_ECC_FAMILY_SECP_K1
 
 Parse EC Key #16 (RFC 8410, DER, X25519)
 depends_on:MBEDTLS_ECP_HAVE_CURVE25519
-pk_parse_keyfile_ec:"data_files/ec_x25519_prv.der":"NULL":0
+pk_parse_keyfile_ec:"data_files/ec_x25519_prv.der":"NULL":0:PSA_ECC_FAMILY_MONTGOMERY
 
 Parse EC Key #17 (RFC 8410, DER, X448)
 depends_on:MBEDTLS_ECP_HAVE_CURVE448
-pk_parse_keyfile_ec:"data_files/ec_x448_prv.der":"NULL":0
+pk_parse_keyfile_ec:"data_files/ec_x448_prv.der":"NULL":0:PSA_ECC_FAMILY_MONTGOMERY
 
 Parse EC Key #18 (RFC 8410, PEM, X25519)
 depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_HAVE_CURVE25519
-pk_parse_keyfile_ec:"data_files/ec_x25519_prv.pem":"NULL":0
+pk_parse_keyfile_ec:"data_files/ec_x25519_prv.pem":"NULL":0:PSA_ECC_FAMILY_MONTGOMERY
 
 Parse EC Key #19 (RFC 8410, PEM, X448)
 depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECP_HAVE_CURVE448
-pk_parse_keyfile_ec:"data_files/ec_x448_prv.pem":"NULL":0
+pk_parse_keyfile_ec:"data_files/ec_x448_prv.pem":"NULL":0:PSA_ECC_FAMILY_MONTGOMERY
 
 Key ASN1 (No data)
 pk_parse_key:"":MBEDTLS_ERR_PK_KEY_INVALID_FORMAT

--- a/tests/suites/test_suite_pkparse.function
+++ b/tests/suites/test_suite_pkparse.function
@@ -6,8 +6,68 @@
 #include "mbedtls/psa_util.h"
 #include "pk_internal.h"
 
+#if defined(MBEDTLS_PSA_CRYPTO_C)
+#include "test/psa_exercise_key.h"
+
+#define MAYBE_PSA_INIT() PSA_INIT()
+#define MAYBE_PSA_DONE() PSA_DONE()
+#else
+#define MAYBE_PSA_INIT() ((void) 0)
+#define MAYBE_PSA_DONE() ((void) 0)
+#endif
+
 #if defined(MBEDTLS_PKCS12_C) || defined(MBEDTLS_PKCS5_C)
 #define HAVE_mbedtls_pk_parse_key_pkcs8_encrypted_der
+#endif
+
+#if defined(MBEDTLS_PSA_CRYPTO_C)
+static void check_psa_import(const mbedtls_pk_context *pk,
+                             psa_key_type_t expected_type)
+{
+    psa_key_attributes_t import_attributes = PSA_KEY_ATTRIBUTES_INIT;
+    psa_key_attributes_t actual_attributes = PSA_KEY_ATTRIBUTES_INIT;
+    mbedtls_svc_key_id_t key_id = MBEDTLS_SVC_KEY_ID_INIT;
+
+    TEST_EQUAL(mbedtls_pk_guess_psa_attributes(pk, &import_attributes), 0);
+    TEST_EQUAL(psa_get_key_type(&import_attributes), expected_type);
+    TEST_EQUAL(mbedtls_pk_import_into_psa(pk, &import_attributes, &key_id), 0);
+    PSA_ASSERT(psa_get_key_attributes(key_id, &actual_attributes));
+    TEST_EQUAL(psa_get_key_type(&actual_attributes), expected_type);
+
+    TEST_ASSERT(mbedtls_test_psa_exercise_key(
+                    key_id,
+                    psa_get_key_usage_flags(&import_attributes),
+                    psa_get_key_algorithm(&import_attributes)));
+    psa_destroy_key(key_id);
+
+    if (PSA_KEY_TYPE_IS_KEY_PAIR(expected_type)) {
+        mbedtls_test_set_step(1);
+        psa_key_type_t public_type =
+            PSA_KEY_TYPE_PUBLIC_KEY_OF_KEY_PAIR(expected_type);
+        psa_key_usage_t public_usage =
+            psa_get_key_usage_flags(&import_attributes);
+        public_usage &= ~PSA_KEY_USAGE_SIGN_HASH;
+        public_usage &= ~PSA_KEY_USAGE_SIGN_MESSAGE;
+        public_usage &= ~PSA_KEY_USAGE_DERIVE;
+        psa_set_key_type(&import_attributes, public_type);
+        psa_set_key_usage_flags(&import_attributes, public_usage);
+        TEST_EQUAL(mbedtls_pk_import_into_psa(pk, &import_attributes, &key_id), 0);
+        PSA_ASSERT(psa_get_key_attributes(key_id, &actual_attributes));
+        TEST_EQUAL(psa_get_key_type(&actual_attributes), public_type);
+        TEST_ASSERT(mbedtls_test_psa_exercise_key(
+                        key_id,
+                        psa_get_key_usage_flags(&import_attributes),
+                        psa_get_key_algorithm(&import_attributes)));
+        psa_destroy_key(key_id);
+    }
+
+exit:
+    psa_reset_key_attributes(&import_attributes);
+    psa_reset_key_attributes(&actual_attributes);
+    psa_destroy_key(key_id);
+}
+#else
+#define check_psa_import(pk, expected_type) ((void) 0)
 #endif
 
 /* END_HEADER */
@@ -25,7 +85,7 @@ void pk_parse_keyfile_rsa(char *key_file, char *password, int result)
     char *pwd = password;
 
     mbedtls_pk_init(&ctx);
-    MD_PSA_INIT();
+    MAYBE_PSA_INIT();
 
     if (strcmp(pwd, "NULL") == 0) {
         pwd = NULL;
@@ -41,11 +101,13 @@ void pk_parse_keyfile_rsa(char *key_file, char *password, int result)
         TEST_ASSERT(mbedtls_pk_can_do(&ctx, MBEDTLS_PK_RSA));
         rsa = mbedtls_pk_rsa(ctx);
         TEST_EQUAL(mbedtls_rsa_check_privkey(rsa), 0);
+
+        check_psa_import(&ctx, PSA_KEY_TYPE_RSA_KEY_PAIR);
     }
 
 exit:
     mbedtls_pk_free(&ctx);
-    MD_PSA_DONE();
+    MAYBE_PSA_DONE();
 }
 
 /* END_CASE */
@@ -57,7 +119,7 @@ void pk_parse_public_keyfile_rsa(char *key_file, int result)
     int res;
 
     mbedtls_pk_init(&ctx);
-    MD_PSA_INIT();
+    MAYBE_PSA_INIT();
 
     res = mbedtls_pk_parse_public_keyfile(&ctx, key_file);
 
@@ -68,22 +130,24 @@ void pk_parse_public_keyfile_rsa(char *key_file, int result)
         TEST_ASSERT(mbedtls_pk_can_do(&ctx, MBEDTLS_PK_RSA));
         rsa = mbedtls_pk_rsa(ctx);
         TEST_EQUAL(mbedtls_rsa_check_pubkey(rsa), 0);
+
+        check_psa_import(&ctx, PSA_KEY_TYPE_RSA_PUBLIC_KEY);
     }
 
 exit:
     mbedtls_pk_free(&ctx);
-    MD_PSA_DONE();
+    MAYBE_PSA_DONE();
 }
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_FS_IO:MBEDTLS_PK_HAVE_ECC_KEYS */
-void pk_parse_public_keyfile_ec(char *key_file, int result)
+void pk_parse_public_keyfile_ec(char *key_file, int result, int expected_family)
 {
     mbedtls_pk_context ctx;
     int res;
 
     mbedtls_pk_init(&ctx);
-    MD_OR_USE_PSA_INIT();
+    MAYBE_PSA_INIT();
 
     res = mbedtls_pk_parse_public_keyfile(&ctx, key_file);
 
@@ -100,22 +164,25 @@ void pk_parse_public_keyfile_ec(char *key_file, int result)
         eckey = mbedtls_pk_ec_ro(ctx);
         TEST_EQUAL(mbedtls_ecp_check_pubkey(&eckey->grp, &eckey->Q), 0);
 #endif
+
+        check_psa_import(&ctx, PSA_KEY_TYPE_ECC_PUBLIC_KEY(expected_family));
     }
 
 exit:
     mbedtls_pk_free(&ctx);
-    MD_OR_USE_PSA_DONE();
+    MAYBE_PSA_DONE();
 }
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_FS_IO:MBEDTLS_PK_HAVE_ECC_KEYS */
-void pk_parse_keyfile_ec(char *key_file, char *password, int result)
+void pk_parse_keyfile_ec(char *key_file, char *password,
+                         int result, int expected_family)
 {
     mbedtls_pk_context ctx;
     int res;
 
     mbedtls_pk_init(&ctx);
-    MD_OR_USE_PSA_INIT();
+    MAYBE_PSA_INIT();
 
     res = mbedtls_pk_parse_keyfile(&ctx, key_file, password,
                                    mbedtls_test_rnd_std_rand, NULL);
@@ -130,11 +197,13 @@ void pk_parse_keyfile_ec(char *key_file, char *password, int result)
 #else
         /* PSA keys are already checked on import so nothing to do here. */
 #endif
+
+        check_psa_import(&ctx, PSA_KEY_TYPE_ECC_KEY_PAIR(expected_family));
     }
 
 exit:
     mbedtls_pk_free(&ctx);
-    MD_OR_USE_PSA_DONE();
+    MAYBE_PSA_DONE();
 }
 /* END_CASE */
 


### PR DESCRIPTION
Prototype `mbedtls_pk_guess_psa_attributes()` and `mbedtls_pk_import_into_psa()`, following the rough design in https://github.com/Mbed-TLS/mbedtls/pull/8657.

Status: for design review only. Probably won't pass the CI in all configurations. Only partially tested.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [ ] **changelog** TODO
- [x] **backport** no
- [ ] **tests** WIP
