### PR TITLE
pkg-config: add initial pkg-config files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -278,6 +278,8 @@ add_subdirectory(3rdparty)
 
 add_subdirectory(library)
 
+add_subdirectory(pkgconfig)
+
 #
 # The C files in tests/src directory contain test code shared among test suites
 # and programs. This shared test code is compiled and linked to test suites and

--- a/ChangeLog.d/pkg-config-files-addition.txt
+++ b/ChangeLog.d/pkg-config-files-addition.txt
@@ -1,2 +1,4 @@
 Features
-    * Add pc files for pkg-config. eg.) pkg-config --cflags --libs (mbedtls|mbedcrypto|mbedx509)
+   * Add pc files for pkg-config, e.g.:
+     pkg-config --cflags --libs (mbedtls|mbedcrypto|mbedx509)
+

--- a/ChangeLog.d/pkg-config-files-addition.txt
+++ b/ChangeLog.d/pkg-config-files-addition.txt
@@ -1,0 +1,2 @@
+Features
+    * Add pc files for pkg-config. eg.) pkg-config --cflags --libs (mbedtls|mbedcrypto|mbedx509)

--- a/pkgconfig/CMakeLists.txt
+++ b/pkgconfig/CMakeLists.txt
@@ -1,0 +1,25 @@
+if(NOT DISABLE_PACKAGE_CONFIG_AND_INSTALL)
+  include(JoinPaths.cmake)
+  join_paths(PKGCONFIG_INCLUDEDIR "\${prefix}" "${CMAKE_INSTALL_INCLUDEDIR}")
+  join_paths(PKGCONFIG_LIBDIR "\${prefix}" "${CMAKE_INSTALL_LIBDIR}")
+
+  #define these manually since minimum CMAKE version is not 3.9 for DESCRIPTION and 3.12 for HOMEPAGE_URL usage in project() below.
+  # Prefix with something that won't clash with newer versions of CMAKE.
+  set(PKGCONFIG_PROJECT_DESCRIPTION "Mbed TLS is a C library that implements cryptographic primitives, X.509 certificate manipulation and the SSL/TLS and DTLS protocols. Its small code footprint makes it suitable for embedded systems.")
+  set(PKGCONFIG_PROJECT_HOMEPAGE_URL "https://www.trustedfirmware.org/projects/mbed-tls/")
+
+  configure_file(mbedcrypto.pc.in mbedcrypto.pc @ONLY)
+    install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/mbedcrypto.pc
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+
+  configure_file(mbedtls.pc.in mbedtls.pc @ONLY)
+    install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/mbedtls.pc
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+
+  configure_file(mbedx509.pc.in mbedx509.pc @ONLY)
+    install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/mbedx509.pc
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+endif()

--- a/pkgconfig/JoinPaths.cmake
+++ b/pkgconfig/JoinPaths.cmake
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+# This module provides function for joining paths
+# known from most languages
+#
+# Copyright The Mbed TLS Contributors
+#
+# This script originates from:
+#   - https://github.com/jtojnar/cmake-snips
+# Jan has provided re-licensing under Apache 2.0 and GPL 2.0+ and
+# allowed for the change of Copyright.
+#
+# Modelled after Python’s os.path.join
+# https://docs.python.org/3.7/library/os.path.html#os.path.join
+# Windows not supported
+function(join_paths joined_path first_path_segment)
+    set(temp_path "${first_path_segment}")
+    foreach(current_segment IN LISTS ARGN)
+        if(NOT ("${current_segment}" STREQUAL ""))
+            if(IS_ABSOLUTE "${current_segment}")
+                set(temp_path "${current_segment}")
+            else()
+                set(temp_path "${temp_path}/${current_segment}")
+            endif()
+        endif()
+    endforeach()
+    set(${joined_path} "${temp_path}" PARENT_SCOPE)
+endfunction()

--- a/pkgconfig/mbedcrypto.pc.in
+++ b/pkgconfig/mbedcrypto.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+includedir=@PKGCONFIG_INCLUDEDIR@
+libdir=@PKGCONFIG_LIBDIR@
+
+Name: @PROJECT_NAME@
+Description: @PKGCONFIG_PROJECT_DESCRIPTION@
+URL: @PKGCONFIG_PROJECT_HOMEPAGE_URL@
+Version: @PROJECT_VERSION@
+Cflags: -I"${includedir}"
+Libs: -L"${libdir}" -lmbedcrypto

--- a/pkgconfig/mbedtls.pc.in
+++ b/pkgconfig/mbedtls.pc.in
@@ -1,0 +1,11 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+includedir=@PKGCONFIG_INCLUDEDIR@
+libdir=@PKGCONFIG_LIBDIR@
+
+Name: @PROJECT_NAME@
+Description: @PKGCONFIG_PROJECT_DESCRIPTION@
+URL: @PKGCONFIG_PROJECT_HOMEPAGE_URL@
+Version: @PROJECT_VERSION@
+Requires.private: mbedcrypto mbedx509
+Cflags: -I"${includedir}"
+Libs: -L"${libdir}" -lmbedtls

--- a/pkgconfig/mbedx509.pc.in
+++ b/pkgconfig/mbedx509.pc.in
@@ -1,0 +1,11 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+includedir=@PKGCONFIG_INCLUDEDIR@
+libdir=@PKGCONFIG_LIBDIR@
+
+Name: @PROJECT_NAME@
+Description: @PKGCONFIG_PROJECT_DESCRIPTION@
+URL: @PKGCONFIG_PROJECT_HOMEPAGE_URL@
+Version: @PROJECT_VERSION@
+Requires.private: mbedcrypto
+Cflags: -I"${includedir}"
+Libs: -L"${libdir}" -lmbedx509


### PR DESCRIPTION
## Description

Add three package config files for mbedtls, mbedcrypto and mbedx509. Also update various project variables so the generated PC files have the required data needed without hardcoding it everywhere.

This will help distros package the project following existing conventsions between a normal and -devel package that includes the headers and .pc files for pkg-config aware consumers.

Fixes: #228


## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** provided, or not required
- [x] **backport** done, or not required: **Not Required**
- [x] **tests** provided, or not required: **Not Required**