### PR TITLE
Implement the key slot mutex

### DIFF
--- a/include/mbedtls/threading.h
+++ b/include/mbedtls/threading.h
@@ -100,6 +100,20 @@ extern mbedtls_threading_mutex_t mbedtls_threading_readdir_mutex;
 extern mbedtls_threading_mutex_t mbedtls_threading_gmtime_mutex;
 #endif /* MBEDTLS_HAVE_TIME_DATE && !MBEDTLS_PLATFORM_GMTIME_R_ALT */
 
+#if defined(MBEDTLS_PSA_CRYPTO_C)
+/*
+ * A mutex used to make the PSA subsystem thread safe.
+ *
+ * key_slot_mutex protects the registered_readers and
+ * state variable for all key slots in &global_data.key_slots.
+ *
+ * This mutex must be held when any read from or write to a state or
+ * registered_readers field is performed, i.e. when calling functions:
+ * psa_key_slot_state_transition(), psa_register_read(), psa_unregister_read(),
+ * psa_key_slot_has_readers() and psa_wipe_key_slot(). */
+extern mbedtls_threading_mutex_t mbedtls_threading_key_slot_mutex;
+#endif
+
 #endif /* MBEDTLS_THREADING_C */
 
 #ifdef __cplusplus

--- a/include/psa/crypto_values.h
+++ b/include/psa/crypto_values.h
@@ -279,6 +279,11 @@
  * to read from a resource. */
 #define PSA_ERROR_INSUFFICIENT_DATA     ((psa_status_t)-143)
 
+/** This can be returned if a function can no longer operate correctly.
+ * For example, if an essential initialization operation failed or
+ * a mutex operation failed. */
+#define PSA_ERROR_SERVICE_FAILURE       ((psa_status_t)-144)
+
 /** The key identifier is not valid. See also :ref:\`key-handles\`.
  */
 #define PSA_ERROR_INVALID_HANDLE        ((psa_status_t)-136)

--- a/library/psa_crypto_core.h
+++ b/library/psa_crypto_core.h
@@ -117,6 +117,8 @@ typedef struct {
         0)
 
 /** Test whether a key slot has any registered readers.
+ * If multi-threading is enabled, the caller must hold the
+ * global key slot mutex.
  *
  * \param[in] slot      The key slot to test.
  *
@@ -195,6 +197,8 @@ static inline psa_key_slot_number_t psa_key_slot_get_slot_number(
  *
  * Persistent storage is not affected.
  * Sets the slot's state to PSA_SLOT_EMPTY.
+ * If multi-threading is enabled, the caller must hold the
+ * global key slot mutex.
  *
  * \param[in,out] slot  The key slot to wipe.
  *

--- a/library/psa_crypto_slot_management.c
+++ b/library/psa_crypto_slot_management.c
@@ -23,10 +23,27 @@
 #include <stdlib.h>
 #include <string.h>
 #include "mbedtls/platform.h"
+#if defined(MBEDTLS_THREADING_C)
+#include "mbedtls/threading.h"
+#endif
 
 typedef struct {
     psa_key_slot_t key_slots[MBEDTLS_PSA_KEY_SLOT_COUNT];
     uint8_t key_slots_initialized;
+
+#if defined(MBEDTLS_THREADING_C)
+    /*
+     * A mutex used to make the PSA subsystem thread safe.
+     *
+     * key_slot_mutex protects key_slots[i].registered_readers and
+     * key_slots[i].state for all valid i.
+     *
+     * This mutex must be held when any read from or write to a state or
+     * registered_readers field is performed, i.e. when calling functions:
+     * psa_key_slot_state_transition, psa_register_read, psa_unregister_read,
+     * psa_key_slot_has_readers and psa_wipe_key_slot. */
+    mbedtls_threading_mutex_t MBEDTLS_PRIVATE(key_slot_mutex);
+#endif
 } psa_global_data_t;
 
 static psa_global_data_t global_data;

--- a/library/psa_crypto_slot_management.h
+++ b/library/psa_crypto_slot_management.h
@@ -85,10 +85,6 @@ psa_status_t psa_get_and_lock_key_slot(mbedtls_svc_key_id_t key,
                                        psa_key_slot_t **p_slot);
 
 /** Initialize the key slot structures.
- * If multi-threading is enabled then initialize the key slot mutex.
- * This function is not thread-safe,
- * if called by competing threads the key slot mutex may be initialized
- * more than once.
  *
  * \retval #PSA_SUCCESS
  *         Currently this function always succeeds.
@@ -96,10 +92,6 @@ psa_status_t psa_get_and_lock_key_slot(mbedtls_svc_key_id_t key,
 psa_status_t psa_initialize_key_slots(void);
 
 /** Delete all data from key slots in memory.
- * If multi-threading is enabled then free the key slot mutex.
- * This function is not thread-safe,
- * if called by competing threads the key slot mutex may be freed
- * more than once.
  *
  * This does not affect persistent storage. */
 void psa_wipe_all_key_slots(void);
@@ -186,7 +178,7 @@ static inline psa_status_t psa_register_read(psa_key_slot_t *slot)
  * This function decrements the key slot registered reader counter by one.
  * If the state of the slot is PSA_SLOT_PENDING_DELETION,
  * and there is only one registered reader (the caller),
- * this function will call psa_wipe_slot().
+ * this function will call psa_wipe_key_slot().
  * If multi-threading is enabled, the caller must hold the
  * global key slot mutex.
  *

--- a/library/psa_crypto_slot_management.h
+++ b/library/psa_crypto_slot_management.h
@@ -134,6 +134,9 @@ psa_status_t psa_reserve_free_key_slot(psa_key_id_t *volatile_key_id,
  * new state. If the state of the slot was not expected_state, the state is
  * unchanged.
  *
+ * If multi-threading is enabled, the caller must hold the
+ * global key slot mutex.
+ *
  * \param[in] slot            The key slot.
  * \param[in] expected_state  The current state of the slot.
  * \param[in] new_state       The new state of the slot.
@@ -157,7 +160,8 @@ static inline psa_status_t psa_key_slot_state_transition(
 /** Register as a reader of a key slot.
  *
  * This function increments the key slot registered reader counter by one.
- *
+ * If multi-threading is enabled, the caller must hold the
+ * global key slot mutex.
  * \param[in] slot  The key slot.
  *
  * \retval #PSA_SUCCESS
@@ -182,7 +186,9 @@ static inline psa_status_t psa_register_read(psa_key_slot_t *slot)
  * This function decrements the key slot registered reader counter by one.
  * If the state of the slot is PSA_SLOT_PENDING_DELETION,
  * and there is only one registered reader (the caller),
- * this function will call psa_wipe_key_slot().
+ * this function will call psa_wipe_slot().
+ * If multi-threading is enabled, the caller must hold the
+ * global key slot mutex.
  *
  * \note To ease the handling of errors in retrieving a key slot
  *       a NULL input pointer is valid, and the function returns

--- a/library/psa_crypto_slot_management.h
+++ b/library/psa_crypto_slot_management.h
@@ -85,6 +85,10 @@ psa_status_t psa_get_and_lock_key_slot(mbedtls_svc_key_id_t key,
                                        psa_key_slot_t **p_slot);
 
 /** Initialize the key slot structures.
+ * If multi-threading is enabled then initialize the key slot mutex.
+ * This function is not thread-safe,
+ * if called by competing threads the key slot mutex may be initialized
+ * more than once.
  *
  * \retval #PSA_SUCCESS
  *         Currently this function always succeeds.
@@ -92,6 +96,10 @@ psa_status_t psa_get_and_lock_key_slot(mbedtls_svc_key_id_t key,
 psa_status_t psa_initialize_key_slots(void);
 
 /** Delete all data from key slots in memory.
+ * If multi-threading is enabled then free the key slot mutex.
+ * This function is not thread-safe,
+ * if called by competing threads the key slot mutex may be freed
+ * more than once.
  *
  * This does not affect persistent storage. */
 void psa_wipe_all_key_slots(void);

--- a/library/psa_crypto_slot_management.h
+++ b/library/psa_crypto_slot_management.h
@@ -154,6 +154,7 @@ static inline psa_status_t psa_key_slot_state_transition(
  * This function increments the key slot registered reader counter by one.
  * If multi-threading is enabled, the caller must hold the
  * global key slot mutex.
+ *
  * \param[in] slot  The key slot.
  *
  * \retval #PSA_SUCCESS

--- a/library/threading.c
+++ b/library/threading.c
@@ -149,7 +149,7 @@ void mbedtls_threading_set_alt(void (*mutex_init)(mbedtls_threading_mutex_t *),
     mbedtls_mutex_init(&mbedtls_threading_gmtime_mutex);
 #endif
 #if defined(MBEDTLS_PSA_CRYPTO_C)
-    mbedtls_mutext_init(&mbedtls_threading_key_slot_mutex);
+    mbedtls_mutex_init(&mbedtls_threading_key_slot_mutex);
 #endif
 }
 

--- a/library/threading.c
+++ b/library/threading.c
@@ -148,6 +148,9 @@ void mbedtls_threading_set_alt(void (*mutex_init)(mbedtls_threading_mutex_t *),
 #if defined(THREADING_USE_GMTIME)
     mbedtls_mutex_init(&mbedtls_threading_gmtime_mutex);
 #endif
+#if defined(MBEDTLS_PSA_CRYPTO_C)
+    mbedtls_mutext_init(&mbedtls_threading_key_slot_mutex);
+#endif
 }
 
 /*
@@ -160,6 +163,9 @@ void mbedtls_threading_free_alt(void)
 #endif
 #if defined(THREADING_USE_GMTIME)
     mbedtls_mutex_free(&mbedtls_threading_gmtime_mutex);
+#endif
+#if defined(MBEDTLS_PSA_CRYPTO_C)
+    mbedtls_mutex_free(&mbedtls_threading_key_slot_mutex);
 #endif
 }
 #endif /* MBEDTLS_THREADING_ALT */
@@ -175,6 +181,9 @@ mbedtls_threading_mutex_t mbedtls_threading_readdir_mutex MUTEX_INIT;
 #endif
 #if defined(THREADING_USE_GMTIME)
 mbedtls_threading_mutex_t mbedtls_threading_gmtime_mutex MUTEX_INIT;
+#endif
+#if defined(MBEDTLS_PSA_CRYPTO_C)
+mbedtls_threading_mutex_t mbedtls_threading_key_slot_mutex MUTEX_INIT;
 #endif
 
 #endif /* MBEDTLS_THREADING_C */


### PR DESCRIPTION
## Description
Add the global key slot mutex, make it initialize and free when we have an Alt implementation, and document that it needs to be held for the key slot primitive functions. Follows on from the work in #8672. Resolves #8674.

## PR checklist
- [x] **changelog** not required for individual tasks on this epic
- [x] **backport**  not required
- [x] **tests** not required for individual tasks on this epic
