### PR TITLE
Backport 2.28: Fix bug in mbedtls_x509_set_extension

### DIFF
--- a/library/x509_create.c
+++ b/library/x509_create.c
@@ -195,6 +195,10 @@ int mbedtls_x509_set_extension(mbedtls_asn1_named_data **head, const char *oid, 
 {
     mbedtls_asn1_named_data *cur;
 
+    if (val_len > (SIZE_MAX  - 1)) {
+        return MBEDTLS_ERR_X509_BAD_INPUT_DATA;
+    }
+
     if ((cur = mbedtls_asn1_store_named_data(head, oid, oid_len,
                                              NULL, val_len + 1)) == NULL) {
         return MBEDTLS_ERR_X509_ALLOC_FAILED;

--- a/tests/suites/test_suite_x509write.data
+++ b/tests/suites/test_suite_x509write.data
@@ -138,3 +138,6 @@ mbedtls_x509_string_to_names:"ABC123":"":MBEDTLS_ERR_X509_INVALID_NAME
 
 Check max serial length
 x509_set_serial_check:
+
+Check max extension length
+x509_set_extension_length_check:

--- a/tests/suites/test_suite_x509write.function
+++ b/tests/suites/test_suite_x509write.function
@@ -499,3 +499,24 @@ exit:
     USE_PSA_DONE();
 }
 /* END_CASE */
+
+/* BEGIN_CASE depends_on:MBEDTLS_X509_CSR_WRITE_C */
+void x509_set_extension_length_check()
+{
+    int ret = 0;
+
+    mbedtls_x509write_csr ctx;
+    mbedtls_x509write_csr_init(&ctx);
+
+    unsigned char buf[EXT_KEY_USAGE_TMP_BUF_MAX_LENGTH] = { 0 };
+    unsigned char *p = buf + sizeof(buf);
+
+    ret = mbedtls_x509_set_extension(&(ctx.extensions),
+                                     MBEDTLS_OID_EXTENDED_KEY_USAGE,
+                                     MBEDTLS_OID_SIZE(MBEDTLS_OID_EXTENDED_KEY_USAGE),
+                                     0,
+                                     p,
+                                     SIZE_MAX);
+    TEST_ASSERT(MBEDTLS_ERR_X509_BAD_INPUT_DATA == ret);
+}
+/* END_CASE */


### PR DESCRIPTION
## Description

Adds tests and a fix for Issue [#8687](https://github.com/Mbed-TLS/mbedtls/issues/8687).
Backport of [#8688](https://github.com/Mbed-TLS/mbedtls/pull/8688).


## PR checklist

- [x] **changelog**: not required
- [x] **backport**: This is the backport of [#8688](https://github.com/Mbed-TLS/mbedtls/pull/8688)
- [x] **tests**: provided