### PR TITLE
Migrate to new RTD redirect format

### DIFF
--- a/docs/redirects.yaml
+++ b/docs/redirects.yaml
@@ -7,5 +7,5 @@
 # expose it.
 
 - type: exact
-  from_url: /projects/api/en/latest/$rest
-  to_url: /projects/api/en/development/
+  from_url: /projects/api/en/latest/*
+  to_url: /projects/api/en/development/:splat


### PR DESCRIPTION
## Description

Migrate to the new redirect format introduced by ReadTheDocs in readthedocs/readthedocs.org#10881

The redirect format is described in full [here](https://docs.readthedocs.io/en/stable/user-defined-redirects.html)

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** Not required - no user facing changes
- [x] **backport** Not required - redirections are only updated in the `development` branch
- [x] **tests** not required - no library changes