### PR TITLE
Improve codegen of unaligned access for IAR and gcc

### DIFF
--- a/ChangeLog.d/iar-gcc-perf.txt
+++ b/ChangeLog.d/iar-gcc-perf.txt
@@ -1,0 +1,2 @@
+Features
+   * Improve performance for gcc (versions older than 9.3.0) and IAR.

--- a/include/mbedtls/build_info.h
+++ b/include/mbedtls/build_info.h
@@ -83,6 +83,14 @@
 #endif
 #endif
 
+#if defined(__GNUC__) && !defined(__ARMCC_VERSION) && !defined(__clang__) \
+    && !defined(__llvm__) && !defined(__INTEL_COMPILER)
+/* Defined if the compiler really is gcc and not clang, etc */
+#define MBEDTLS_COMPILER_IS_GCC
+#define MBEDTLS_GCC_VERSION \
+    (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
+#endif
+
 #if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_DEPRECATE)
 #define _CRT_SECURE_NO_DEPRECATE 1
 #endif

--- a/library/alignment.h
+++ b/library/alignment.h
@@ -15,13 +15,7 @@
 #include <string.h>
 #include <stdlib.h>
 
-#if defined(__GNUC__) && !defined(__ARMCC_VERSION) && !defined(__clang__) \
-    && !defined(__llvm__) && !defined(__INTEL_COMPILER)
-/* Defined if the compiler really is gcc and not clang, etc */
-#define MBEDTLS_COMPILER_IS_GCC
-#define MBEDTLS_GCC_VERSION \
-    (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
-#endif
+#include "mbedtls/build_info.h"
 
 /*
  * Define MBEDTLS_EFFICIENT_UNALIGNED_ACCESS for architectures where unaligned memory

--- a/library/alignment.h
+++ b/library/alignment.h
@@ -15,6 +15,14 @@
 #include <string.h>
 #include <stdlib.h>
 
+#if defined(__GNUC__) && !defined(__ARMCC_VERSION) && !defined(__clang__) \
+    && !defined(__llvm__) && !defined(__INTEL_COMPILER)
+/* Defined if the compiler really is gcc and not clang, etc */
+#define MBEDTLS_COMPILER_IS_GCC
+#define MBEDTLS_GCC_VERSION \
+    (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
+#endif
+
 /*
  * Define MBEDTLS_EFFICIENT_UNALIGNED_ACCESS for architectures where unaligned memory
  * accesses are known to be efficient.

--- a/library/alignment.h
+++ b/library/alignment.h
@@ -15,8 +15,6 @@
 #include <string.h>
 #include <stdlib.h>
 
-#include "mbedtls/build_info.h"
-
 /*
  * Define MBEDTLS_EFFICIENT_UNALIGNED_ACCESS for architectures where unaligned memory
  * accesses are known to be efficient.

--- a/library/alignment.h
+++ b/library/alignment.h
@@ -85,6 +85,12 @@ typedef uint32_t __attribute__((__aligned__(1))) mbedtls_uint32_unaligned_t;
 typedef uint64_t __attribute__((__aligned__(1))) mbedtls_uint64_unaligned_t;
  #endif
 
+/*
+ * We try to force mbedtls_(get|put)_unaligned_uintXX to be always inline, because this results
+ * in code that is both smaller and faster. IAR and gcc both benefit from this when optimising
+ * for size.
+ */
+
 /**
  * Read the unsigned 16 bits integer from the given address, which need not
  * be aligned.
@@ -92,7 +98,12 @@ typedef uint64_t __attribute__((__aligned__(1))) mbedtls_uint64_unaligned_t;
  * \param   p pointer to 2 bytes of data
  * \return  Data at the given address
  */
-inline uint16_t mbedtls_get_unaligned_uint16(const void *p)
+#if defined(__IAR_SYSTEMS_ICC__)
+#pragma inline = forced
+#elif defined(__GNUC__)
+__attribute__((always_inline))
+#endif
+static inline uint16_t mbedtls_get_unaligned_uint16(const void *p)
 {
     uint16_t r;
 #if defined(UINT_UNALIGNED)
@@ -111,7 +122,12 @@ inline uint16_t mbedtls_get_unaligned_uint16(const void *p)
  * \param   p pointer to 2 bytes of data
  * \param   x data to write
  */
-inline void mbedtls_put_unaligned_uint16(void *p, uint16_t x)
+#if defined(__IAR_SYSTEMS_ICC__)
+#pragma inline = forced
+#elif defined(__GNUC__)
+__attribute__((always_inline))
+#endif
+static inline void mbedtls_put_unaligned_uint16(void *p, uint16_t x)
 {
 #if defined(UINT_UNALIGNED)
     mbedtls_uint16_unaligned_t *p16 = (mbedtls_uint16_unaligned_t *) p;
@@ -128,7 +144,12 @@ inline void mbedtls_put_unaligned_uint16(void *p, uint16_t x)
  * \param   p pointer to 4 bytes of data
  * \return  Data at the given address
  */
-inline uint32_t mbedtls_get_unaligned_uint32(const void *p)
+#if defined(__IAR_SYSTEMS_ICC__)
+#pragma inline = forced
+#elif defined(__GNUC__)
+__attribute__((always_inline))
+#endif
+static inline uint32_t mbedtls_get_unaligned_uint32(const void *p)
 {
     uint32_t r;
 #if defined(UINT_UNALIGNED)
@@ -147,7 +168,12 @@ inline uint32_t mbedtls_get_unaligned_uint32(const void *p)
  * \param   p pointer to 4 bytes of data
  * \param   x data to write
  */
-inline void mbedtls_put_unaligned_uint32(void *p, uint32_t x)
+#if defined(__IAR_SYSTEMS_ICC__)
+#pragma inline = forced
+#elif defined(__GNUC__)
+__attribute__((always_inline))
+#endif
+static inline void mbedtls_put_unaligned_uint32(void *p, uint32_t x)
 {
 #if defined(UINT_UNALIGNED)
     mbedtls_uint32_unaligned_t *p32 = (mbedtls_uint32_unaligned_t *) p;
@@ -164,7 +190,12 @@ inline void mbedtls_put_unaligned_uint32(void *p, uint32_t x)
  * \param   p pointer to 8 bytes of data
  * \return  Data at the given address
  */
-inline uint64_t mbedtls_get_unaligned_uint64(const void *p)
+#if defined(__IAR_SYSTEMS_ICC__)
+#pragma inline = forced
+#elif defined(__GNUC__)
+__attribute__((always_inline))
+#endif
+static inline uint64_t mbedtls_get_unaligned_uint64(const void *p)
 {
     uint64_t r;
 #if defined(UINT_UNALIGNED)
@@ -183,7 +214,12 @@ inline uint64_t mbedtls_get_unaligned_uint64(const void *p)
  * \param   p pointer to 8 bytes of data
  * \param   x data to write
  */
-inline void mbedtls_put_unaligned_uint64(void *p, uint64_t x)
+#if defined(__IAR_SYSTEMS_ICC__)
+#pragma inline = forced
+#elif defined(__GNUC__)
+__attribute__((always_inline))
+#endif
+static inline void mbedtls_put_unaligned_uint64(void *p, uint64_t x)
 {
 #if defined(UINT_UNALIGNED)
     mbedtls_uint64_unaligned_t *p64 = (mbedtls_uint64_unaligned_t *) p;

--- a/library/common.h
+++ b/library/common.h
@@ -158,6 +158,12 @@ static inline const unsigned char *mbedtls_buffer_offset_const(
     return p == NULL ? NULL : p + n;
 }
 
+/* Always inline mbedtls_xor for similar reasons as mbedtls_xor_no_simd. */
+#if defined(__IAR_SYSTEMS_ICC__)
+#pragma inline = forced
+#elif defined(__GNUC__)
+__attribute__((always_inline))
+#endif
 /**
  * Perform a fast block XOR operation, such that
  * r[i] = a[i] ^ b[i] where 0 <= i < n
@@ -169,7 +175,10 @@ static inline const unsigned char *mbedtls_buffer_offset_const(
  * \param   b Pointer to input (buffer of at least \p n bytes)
  * \param   n Number of bytes to process.
  */
-inline void mbedtls_xor(unsigned char *r, const unsigned char *a, const unsigned char *b, size_t n)
+static inline void mbedtls_xor(unsigned char *r,
+                               const unsigned char *a,
+                               const unsigned char *b,
+                               size_t n)
 {
     size_t i = 0;
 #if defined(MBEDTLS_EFFICIENT_UNALIGNED_ACCESS)
@@ -209,6 +218,13 @@ inline void mbedtls_xor(unsigned char *r, const unsigned char *a, const unsigned
     }
 }
 
+/* Always inline mbedtls_xor_no_simd as we see significant perf regressions when it does not get
+ * inlined (e.g., observed about 3x perf difference in gcm_mult_largetable with gcc 7 - 12) */
+#if defined(__IAR_SYSTEMS_ICC__)
+#pragma inline = forced
+#elif defined(__GNUC__)
+__attribute__((always_inline))
+#endif
 /**
  * Perform a fast block XOR operation, such that
  * r[i] = a[i] ^ b[i] where 0 <= i < n

--- a/library/common.h
+++ b/library/common.h
@@ -158,7 +158,7 @@ static inline const unsigned char *mbedtls_buffer_offset_const(
     return p == NULL ? NULL : p + n;
 }
 
-/* Always inline mbedtls_xor for similar reasons as mbedtls_xor_no_simd. */
+/* Always inline mbedtls_xor() for similar reasons as mbedtls_xor_no_simd(). */
 #if defined(__IAR_SYSTEMS_ICC__)
 #pragma inline = forced
 #elif defined(__GNUC__)
@@ -175,12 +175,12 @@ __attribute__((always_inline))
  * \param   b Pointer to input (buffer of at least \p n bytes)
  * \param   n Number of bytes to process.
  *
- * \note      Depending on the situation, it may be faster to use either mbedtls_xor or
- *            mbedtls_xor_no_simd (these are functionally equivalent).
+ * \note      Depending on the situation, it may be faster to use either mbedtls_xor() or
+ *            mbedtls_xor_no_simd() (these are functionally equivalent).
  *            If the result is used immediately after the xor operation in non-SIMD code (e.g, in
  *            AES-CBC), there may be additional latency to transfer the data from SIMD to scalar
- *            registers, and in this case, mbedtls_xor_no_simd may be faster. In other cases where
- *            the result is not used immediately (e.g., in AES-CTR), mbedtls_xor may be faster.
+ *            registers, and in this case, mbedtls_xor_no_simd() may be faster. In other cases where
+ *            the result is not used immediately (e.g., in AES-CTR), mbedtls_xor() may be faster.
  *            For targets without SIMD support, they will behave the same.
  */
 static inline void mbedtls_xor(unsigned char *r,
@@ -199,10 +199,10 @@ static inline void mbedtls_xor(unsigned char *r,
         uint8x16_t x = veorq_u8(v1, v2);
         vst1q_u8(r + i, x);
     }
-    // This if statement helps some compilers (e.g., IAR) optimise out the byte-by-byte tail case
-    // where n is a constant multiple of 16.
-    // It makes no difference for others (e.g. recent gcc and clang) if n is a compile-time
-    // constant, and very little difference if n is not a compile-time constant.
+    /* This if statement helps some compilers (e.g., IAR) optimise out the byte-by-byte tail case
+     * where n is a constant multiple of 16.
+     * It makes no difference for others (e.g. recent gcc and clang) if n is a compile-time
+     * constant, and very little difference if n is not a compile-time constant. */
     if (n % 16 != 0)
 #elif defined(MBEDTLS_ARCH_IS_X64) || defined(MBEDTLS_ARCH_IS_ARM64)
     /* This codepath probably only makes sense on architectures with 64-bit registers */
@@ -226,7 +226,7 @@ static inline void mbedtls_xor(unsigned char *r,
     }
 }
 
-/* Always inline mbedtls_xor_no_simd as we see significant perf regressions when it does not get
+/* Always inline mbedtls_xor_no_simd() as we see significant perf regressions when it does not get
  * inlined (e.g., observed about 3x perf difference in gcm_mult_largetable with gcc 7 - 12) */
 #if defined(__IAR_SYSTEMS_ICC__)
 #pragma inline = forced
@@ -237,7 +237,7 @@ __attribute__((always_inline))
  * Perform a fast block XOR operation, such that
  * r[i] = a[i] ^ b[i] where 0 <= i < n
  *
- * In some situations, this can perform better than mbedtls_xor (e.g., it's about 5%
+ * In some situations, this can perform better than mbedtls_xor() (e.g., it's about 5%
  * better in AES-CBC).
  *
  * \param   r Pointer to result (buffer of at least \p n bytes). \p r
@@ -247,12 +247,12 @@ __attribute__((always_inline))
  * \param   b Pointer to input (buffer of at least \p n bytes)
  * \param   n Number of bytes to process.
  *
- * \note      Depending on the situation, it may be faster to use either mbedtls_xor or
- *            mbedtls_xor_no_simd (these are functionally equivalent).
+ * \note      Depending on the situation, it may be faster to use either mbedtls_xor() or
+ *            mbedtls_xor_no_simd() (these are functionally equivalent).
  *            If the result is used immediately after the xor operation in non-SIMD code (e.g, in
  *            AES-CBC), there may be additional latency to transfer the data from SIMD to scalar
- *            registers, and in this case, mbedtls_xor_no_simd may be faster. In other cases where
- *            the result is not used immediately (e.g., in AES-CTR), mbedtls_xor may be faster.
+ *            registers, and in this case, mbedtls_xor_no_simd() may be faster. In other cases where
+ *            the result is not used immediately (e.g., in AES-CTR), mbedtls_xor() may be faster.
  *            For targets without SIMD support, they will behave the same.
  */
 static inline void mbedtls_xor_no_simd(unsigned char *r,
@@ -268,10 +268,10 @@ static inline void mbedtls_xor_no_simd(unsigned char *r,
         uint64_t x = mbedtls_get_unaligned_uint64(a + i) ^ mbedtls_get_unaligned_uint64(b + i);
         mbedtls_put_unaligned_uint64(r + i, x);
     }
-    // This if statement helps some compilers (e.g., IAR) optimise out the byte-by-byte tail case
-    // where n is a constant multiple of 8.
-    // It makes no difference for others (e.g. recent gcc and clang) if n is a compile-time
-    // constant, and very little difference if n is not a compile-time constant.
+    /* This if statement helps some compilers (e.g., IAR) optimise out the byte-by-byte tail case
+     * where n is a constant multiple of 16.
+     * It makes no difference for others (e.g. recent gcc and clang) if n is a compile-time
+     * constant, and very little difference if n is not a compile-time constant. */
     if (n % 8 != 0)
 #else
     for (; (i + 4) <= n; i += 4) {

--- a/library/common.h
+++ b/library/common.h
@@ -27,15 +27,6 @@
 #define MBEDTLS_HAVE_NEON_INTRINSICS
 #endif
 
-
-#if defined(__GNUC__) && !defined(__ARMCC_VERSION) && !defined(__clang__) \
-    && !defined(__llvm__) && !defined(__INTEL_COMPILER)
-/* Defined if the compiler really is gcc and not clang, etc */
-#define MBEDTLS_COMPILER_IS_GCC
-#define MBEDTLS_GCC_VERSION \
-    (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
-#endif
-
 /** Helper to define a function as static except when building invasive tests.
  *
  * If a function is only used inside its own source file and should be

--- a/library/common.h
+++ b/library/common.h
@@ -280,7 +280,7 @@ static inline void mbedtls_xor_no_simd(unsigned char *r,
     }
 #if defined(__IAR_SYSTEMS_ICC__)
     /* This if statement helps some compilers (e.g., IAR) optimise out the byte-by-byte tail case
-     * where n is a constant multiple of 16.
+     * where n is a constant multiple of 8.
      * For other compilers (e.g. recent gcc and clang) it makes no difference if n is a compile-time
      * constant, and is a very small perf regression if n is not a compile-time constant. */
     if (n % 8 == 0) {

--- a/library/common.h
+++ b/library/common.h
@@ -199,30 +199,40 @@ static inline void mbedtls_xor(unsigned char *r,
         uint8x16_t x = veorq_u8(v1, v2);
         vst1q_u8(r + i, x);
     }
+#if defined(__IAR_SYSTEMS_ICC__)
     /* This if statement helps some compilers (e.g., IAR) optimise out the byte-by-byte tail case
      * where n is a constant multiple of 16.
-     * It makes no difference for others (e.g. recent gcc and clang) if n is a compile-time
-     * constant, and very little difference if n is not a compile-time constant. */
-    if (n % 16 != 0)
+     * For other compilers (e.g. recent gcc and clang) it makes no difference if n is a compile-time
+     * constant, and is a very small perf regression if n is not a compile-time constant. */
+    if (n % 16 == 0) {
+        return;
+    }
+#endif
 #elif defined(MBEDTLS_ARCH_IS_X64) || defined(MBEDTLS_ARCH_IS_ARM64)
     /* This codepath probably only makes sense on architectures with 64-bit registers */
     for (; (i + 8) <= n; i += 8) {
         uint64_t x = mbedtls_get_unaligned_uint64(a + i) ^ mbedtls_get_unaligned_uint64(b + i);
         mbedtls_put_unaligned_uint64(r + i, x);
     }
-    if (n % 8 != 0)
+#if defined(__IAR_SYSTEMS_ICC__)
+    if (n % 8 == 0) {
+        return;
+    }
+#endif
 #else
     for (; (i + 4) <= n; i += 4) {
         uint32_t x = mbedtls_get_unaligned_uint32(a + i) ^ mbedtls_get_unaligned_uint32(b + i);
         mbedtls_put_unaligned_uint32(r + i, x);
     }
-    if (n % 4 != 0)
+#if defined(__IAR_SYSTEMS_ICC__)
+    if (n % 4 == 0) {
+        return;
+    }
 #endif
 #endif
-    {
-        for (; i < n; i++) {
-            r[i] = a[i] ^ b[i];
-        }
+#endif
+    for (; i < n; i++) {
+        r[i] = a[i] ^ b[i];
     }
 }
 
@@ -268,23 +278,29 @@ static inline void mbedtls_xor_no_simd(unsigned char *r,
         uint64_t x = mbedtls_get_unaligned_uint64(a + i) ^ mbedtls_get_unaligned_uint64(b + i);
         mbedtls_put_unaligned_uint64(r + i, x);
     }
+#if defined(__IAR_SYSTEMS_ICC__)
     /* This if statement helps some compilers (e.g., IAR) optimise out the byte-by-byte tail case
      * where n is a constant multiple of 16.
-     * It makes no difference for others (e.g. recent gcc and clang) if n is a compile-time
-     * constant, and very little difference if n is not a compile-time constant. */
-    if (n % 8 != 0)
+     * For other compilers (e.g. recent gcc and clang) it makes no difference if n is a compile-time
+     * constant, and is a very small perf regression if n is not a compile-time constant. */
+    if (n % 8 == 0) {
+        return;
+    }
+#endif
 #else
     for (; (i + 4) <= n; i += 4) {
         uint32_t x = mbedtls_get_unaligned_uint32(a + i) ^ mbedtls_get_unaligned_uint32(b + i);
         mbedtls_put_unaligned_uint32(r + i, x);
     }
-    if (n % 4 != 0)
+#if defined(__IAR_SYSTEMS_ICC__)
+    if (n % 4 == 0) {
+        return;
+    }
 #endif
 #endif
-    {
-        for (; i < n; i++) {
-            r[i] = a[i] ^ b[i];
-        }
+#endif
+    for (; i < n; i++) {
+        r[i] = a[i] ^ b[i];
     }
 }
 

--- a/library/common.h
+++ b/library/common.h
@@ -174,6 +174,14 @@ __attribute__((always_inline))
  * \param   a Pointer to input (buffer of at least \p n bytes)
  * \param   b Pointer to input (buffer of at least \p n bytes)
  * \param   n Number of bytes to process.
+ *
+ * \note      Depending on the situation, it may be faster to use either mbedtls_xor or
+ *            mbedtls_xor_no_simd (these are functionally equivalent).
+ *            If the result is used immediately after the xor operation in non-SIMD code (e.g, in
+ *            AES-CBC), there may be additional latency to transfer the data from SIMD to scalar
+ *            registers, and in this case, mbedtls_xor_no_simd may be faster. In other cases where
+ *            the result is not used immediately (e.g., in AES-CTR), mbedtls_xor may be faster.
+ *            For targets without SIMD support, they will behave the same.
  */
 static inline void mbedtls_xor(unsigned char *r,
                                const unsigned char *a,
@@ -238,6 +246,14 @@ __attribute__((always_inline))
  * \param   a Pointer to input (buffer of at least \p n bytes)
  * \param   b Pointer to input (buffer of at least \p n bytes)
  * \param   n Number of bytes to process.
+ *
+ * \note      Depending on the situation, it may be faster to use either mbedtls_xor or
+ *            mbedtls_xor_no_simd (these are functionally equivalent).
+ *            If the result is used immediately after the xor operation in non-SIMD code (e.g, in
+ *            AES-CBC), there may be additional latency to transfer the data from SIMD to scalar
+ *            registers, and in this case, mbedtls_xor_no_simd may be faster. In other cases where
+ *            the result is not used immediately (e.g., in AES-CTR), mbedtls_xor may be faster.
+ *            For targets without SIMD support, they will behave the same.
  */
 static inline void mbedtls_xor_no_simd(unsigned char *r,
                                        const unsigned char *a,

--- a/library/common.h
+++ b/library/common.h
@@ -191,21 +191,30 @@ inline void mbedtls_xor(unsigned char *r, const unsigned char *a, const unsigned
         uint8x16_t x = veorq_u8(v1, v2);
         vst1q_u8(r + i, x);
     }
+    // This if statement helps some compilers (e.g., IAR) optimise out the byte-by-byte tail case
+    // where n is a constant multiple of 16.
+    // It makes no difference for others (e.g. recent gcc and clang) if n is a compile-time
+    // constant, and very little difference if n is not a compile-time constant.
+    if (n % 16 != 0)
 #elif defined(MBEDTLS_ARCH_IS_X64) || defined(MBEDTLS_ARCH_IS_ARM64)
     /* This codepath probably only makes sense on architectures with 64-bit registers */
     for (; (i + 8) <= n; i += 8) {
         uint64_t x = mbedtls_get_unaligned_uint64(a + i) ^ mbedtls_get_unaligned_uint64(b + i);
         mbedtls_put_unaligned_uint64(r + i, x);
     }
+    if (n % 8 != 0)
 #else
     for (; (i + 4) <= n; i += 4) {
         uint32_t x = mbedtls_get_unaligned_uint32(a + i) ^ mbedtls_get_unaligned_uint32(b + i);
         mbedtls_put_unaligned_uint32(r + i, x);
     }
+    if (n % 4 != 0)
 #endif
 #endif
-    for (; i < n; i++) {
-        r[i] = a[i] ^ b[i];
+    {
+        for (; i < n; i++) {
+            r[i] = a[i] ^ b[i];
+        }
     }
 }
 
@@ -236,15 +245,23 @@ static inline void mbedtls_xor_no_simd(unsigned char *r,
         uint64_t x = mbedtls_get_unaligned_uint64(a + i) ^ mbedtls_get_unaligned_uint64(b + i);
         mbedtls_put_unaligned_uint64(r + i, x);
     }
+    // This if statement helps some compilers (e.g., IAR) optimise out the byte-by-byte tail case
+    // where n is a constant multiple of 8.
+    // It makes no difference for others (e.g. recent gcc and clang) if n is a compile-time
+    // constant, and very little difference if n is not a compile-time constant.
+    if (n % 8 != 0)
 #else
     for (; (i + 4) <= n; i += 4) {
         uint32_t x = mbedtls_get_unaligned_uint32(a + i) ^ mbedtls_get_unaligned_uint32(b + i);
         mbedtls_put_unaligned_uint32(r + i, x);
     }
+    if (n % 4 != 0)
 #endif
 #endif
-    for (; i < n; i++) {
-        r[i] = a[i] ^ b[i];
+    {
+        for (; i < n; i++) {
+            r[i] = a[i] ^ b[i];
+        }
     }
 }
 

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -217,15 +217,6 @@ struct tm *mbedtls_platform_gmtime_r(const mbedtls_time_t *tt,
 void (*mbedtls_test_hook_test_fail)(const char *, int, const char *);
 #endif /* MBEDTLS_TEST_HOOKS */
 
-/*
- * Provide external definitions of some inline functions so that the compiler
- * has the option to not inline them
- */
-extern inline void mbedtls_xor(unsigned char *r,
-                               const unsigned char *a,
-                               const unsigned char *b,
-                               size_t n);
-
 #if defined(MBEDTLS_HAVE_TIME) && !defined(MBEDTLS_PLATFORM_MS_TIME_ALT)
 
 #include <time.h>

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -226,18 +226,6 @@ extern inline void mbedtls_xor(unsigned char *r,
                                const unsigned char *b,
                                size_t n);
 
-extern inline uint16_t mbedtls_get_unaligned_uint16(const void *p);
-
-extern inline void mbedtls_put_unaligned_uint16(void *p, uint16_t x);
-
-extern inline uint32_t mbedtls_get_unaligned_uint32(const void *p);
-
-extern inline void mbedtls_put_unaligned_uint32(void *p, uint32_t x);
-
-extern inline uint64_t mbedtls_get_unaligned_uint64(const void *p);
-
-extern inline void mbedtls_put_unaligned_uint64(void *p, uint64_t x);
-
 #if defined(MBEDTLS_HAVE_TIME) && !defined(MBEDTLS_PLATFORM_MS_TIME_ALT)
 
 #include <time.h>


### PR DESCRIPTION
## Description

Summary: we saw poor code-gen for IAR, and on further investigation, found similar for some versions of gcc, resulting in decreased perf and increased code-size. This PR:
- ensures efficient unaligned access on IAR and old GCC
- enables better code-size optimisation of mbedtls_xor over constant size input (the common case)
- makes unaligned accessors and mbedtls_xor always inline - this is a win for perf and a mixed outcome for code-size, for the platforms where this wasn't already happening
- overall, our reference config increases by 74 bytes
- I'd expect worst code-size increase for platforms where unaligned access isn't supported, but actually it's not too bad: armv7 thumb2 with -mno-unaligned-access increases by 250 bytes on gcc (TF-M config) and decreases by 156 bytes on clang. This is partly because `mbedtls_xor` turns into 8 instructions without unaligned access, so inlining it isn't very costly.


Iar 9.50, when run with `-Ohz` (optimise for size) and targeting thumb2, generates very suboptimal code for our unaligned memory access wrappers (even though it knows that unaligned accesses are permitted, because it sets `__ARM_FEATURE_UNALIGNED`).

Example:

```
uint32_t test(void *p) {
    return mbedtls_get_unaligned_uint32(p);
}
```

compiles to

```
   0:	6800      	ldr	r0, [r0, #0]
   2:	4770      	bx	lr
```

with clang or gcc, but compiles to

```
  10:	b580      	push	{r7, lr}
  12:	f7ff fffe 	bl	0 <mbedtls_get_unaligned_uint32>
  16:	bd02      	pop	{r1, pc}
```

under IAR with `-Ohz`. If I force it to inline that function with a pragma, we get:

```
   0:	b081      	sub	sp, #4
   2:	6801      	ldr	r1, [r0, #0]
   4:	9100      	str	r1, [sp, #0]
   6:	b001      	add	sp, #4
   8:	4608      	mov	r0, r1
   a:	4770      	bx	lr
```

If we compile with `-Ol` (low optimisation), IAR will generate a branch to `memcpy` for a call like `memcpy(dest, src, 4)` which I would expect for no optimisation (i.e. `-On`), but I found a bit surprising at `-Ol`. But maybe that's typical/intended-behaviour for low optimisation - although gcc and clang at `-O1` both turn this into a single `ldr` instruction?

Adds 72b of code-size (increase is from forcing mbedtls_xor to always be inlined).

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** done
- [x] **backport** no
- [x] **tests** covered by existing