### PR TITLE
Test usage of MBEDTLS_PRINTF_SIZET in mbedtls_debug_print_msg

### DIFF
--- a/tests/suites/test_suite_debug.data
+++ b/tests/suites/test_suite_debug.data
@@ -8,10 +8,10 @@ printf "%" MBEDTLS_PRINTF_MS_TIME, 0
 printf_int_expr:PRINTF_MS_TIME:sizeof(mbedtls_ms_time_t):0:"0"
 
 Debug print msg (threshold 1, level 0)
-debug_print_msg_threshold:1:0:"MyFile":999:"MyFile(0999)\: Text message, 2 == 2\n"
+debug_print_msg_threshold:1:0:"MyFile":999:"MyFile(0999)\: Text message, 2 == 2, len=10\n"
 
 Debug print msg (threshold 1, level 1)
-debug_print_msg_threshold:1:1:"MyFile":999:"MyFile(0999)\: Text message, 2 == 2\n"
+debug_print_msg_threshold:1:1:"MyFile":999:"MyFile(0999)\: Text message, 2 == 2, len=10\n"
 
 Debug print msg (threshold 1, level 2)
 debug_print_msg_threshold:1:2:"MyFile":999:""

--- a/tests/suites/test_suite_debug.function
+++ b/tests/suites/test_suite_debug.function
@@ -144,6 +144,7 @@ void debug_print_msg_threshold(int threshold, int level, char *file,
     mbedtls_ssl_context ssl;
     mbedtls_ssl_config conf;
     struct buffer_data buffer;
+    size_t len = 10;
 
     mbedtls_ssl_init(&ssl);
     mbedtls_ssl_config_init(&conf);
@@ -163,7 +164,8 @@ void debug_print_msg_threshold(int threshold, int level, char *file,
     mbedtls_debug_set_threshold(threshold);
 
     mbedtls_debug_print_msg(&ssl, level, file, line,
-                            "Text message, 2 == %d", 2);
+                            "Text message, 2 == %d, len=%" MBEDTLS_PRINTF_SIZET,
+                            2, len);
 
     TEST_ASSERT(strcmp(buffer.buf, result_str) == 0);
 


### PR DESCRIPTION
## Description
Test usage of MBEDTLS_PRINTF_SIZET in mbedtls_debug_print_msg

## PR checklist
- [x] **changelog** not required, just changing an unit test
- [x] **backport** not required, just changing an unit test
- [x] **tests** not required, just changing an unit test