### PR TITLE
Update entropy_poll.c to allow build in z/OS

### DIFF
--- a/ChangeLog.d/8726.txt
+++ b/ChangeLog.d/8726.txt
@@ -1,0 +1,3 @@
+Features
+   * Add platform support for z/OS.
+   

--- a/ChangeLog.d/8726.txt
+++ b/ChangeLog.d/8726.txt
@@ -1,3 +1,2 @@
 Features
-   * Add platform support for z/OS.
-   
+   * Add partial platform support for z/OS.

--- a/library/entropy_poll.c
+++ b/library/entropy_poll.c
@@ -29,7 +29,7 @@
 
 #if !defined(unix) && !defined(__unix__) && !defined(__unix) && \
     !defined(__APPLE__) && !defined(_WIN32) && !defined(__QNXNTO__) && \
-    !defined(__HAIKU__) && !defined(__midipix__)
+    !defined(__HAIKU__) && !defined(__midipix__) && !defined(__MVS__)
 #error \
     "Platform entropy sources only work on Unix and Windows, see MBEDTLS_NO_PLATFORM_ENTROPY in mbedtls_config.h"
 #endif


### PR DESCRIPTION
## Description

Adding the necessary flag to allow this to build in z/OS (an IBM mainframe operating system).


## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** entry created
- [x] **backport** not required
- [x] **tests** done downstream as a part of [building DuckDB for z/OS](https://github.com/ZOSOpenTools/duckdbport/pull/7)



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.
