### PR TITLE
Add test for driver-only HMAC

### DIFF
--- a/docs/driver-only-builds.md
+++ b/docs/driver-only-builds.md
@@ -105,7 +105,26 @@ provided by a driver or built-in, you should use the following macros:
 - for code that uses only the PSA Crypto API: `PSA_WANT_ALG_xxx` from
   `psa/crypto.h`;
 - for code that uses non-PSA crypto APIs: `MBEDTLS_MD_CAN_xxx` from
-  `mbedtls/md.h`.
+  `mbedtls/config_adjust_legacy_crypto.h`.
+
+### HMAC
+
+In addition to accelerated hash operations, it is also possible to accelerate
+HMAC by enabling and accelerating:
+- HMAC algorithm and key type, i.e. `[PSA_WANT|MBEDTLS_PSA_ACCEL]_ALG_HMAC` and
+  `[PSA_WANT|MBEDTLS_PSA_ACCEL]KEY_TYPE_HMAC`.
+- Required hash algorithm(s) as explained in [Hashes](#hashes) section.
+
+In such a build it is possible to disable legacy HMAC support by disabling
+`MBEDTLS_MD_C` and still getting crypto operations, X.509 and TLS to work as
+usual. Exceptions are:
+- [Hashes](#hashes) are obviously valid here for the accelerated algorithms.
+- Legacy HMAC support (`mbedtls_md_hmac_xxx()`) won't be possible.
+- `MBEDTLS_PKCS[5|7]_C`, `MBEDTLS_HMAC_DRBG_C` and `MBEDTLS_HKDF_C` since they
+  depend on the legacy implementation of HMAC.
+  - disabling HMAC_DRBG_C cause deterministic ECDSA (i.e.
+  `MBEDTLS_DETERMINISTIC_ECDSA` on the legacy side and 
+  `PSA_WANT_ALG_DETERMINISTIC_ECDSA` on the PSA one) to be not available.
 
 Elliptic-curve cryptography (ECC)
 ---------------------------------

--- a/docs/driver-only-builds.md
+++ b/docs/driver-only-builds.md
@@ -118,7 +118,9 @@ HMAC by enabling and accelerating:
 In such a build it is possible to disable legacy HMAC support by disabling
 `MBEDTLS_MD_C` and still getting crypto operations, X.509 and TLS to work as
 usual. Exceptions are:
-- [Hashes](#hashes) are obviously valid here for the accelerated algorithms.
+- As mentioned in [Hashes](#hashes) direct calls to legacy lo-level hash APIs
+  (`mbedtls_sha256()` etc.) will not be possible for the legacy modules that
+  are disabled.
 - Legacy HMAC support (`mbedtls_md_hmac_xxx()`) won't be possible.
 - `MBEDTLS_PKCS[5|7]_C`, `MBEDTLS_HMAC_DRBG_C` and `MBEDTLS_HKDF_C` since they
   depend on the legacy implementation of HMAC.

--- a/programs/x509/cert_req.c
+++ b/programs/x509/cert_req.c
@@ -14,7 +14,8 @@
 #if !defined(MBEDTLS_X509_CSR_WRITE_C) || !defined(MBEDTLS_X509_CRT_PARSE_C) || \
     !defined(MBEDTLS_PK_PARSE_C) || !defined(MBEDTLS_MD_CAN_SHA256) || \
     !defined(MBEDTLS_ENTROPY_C) || !defined(MBEDTLS_CTR_DRBG_C) || \
-    !defined(MBEDTLS_PEM_WRITE_C) || !defined(MBEDTLS_FS_IO)
+    !defined(MBEDTLS_PEM_WRITE_C) || !defined(MBEDTLS_FS_IO) || \
+    !defined(MBEDTLS_MD_C)
 int main(void)
 {
     mbedtls_printf("MBEDTLS_X509_CSR_WRITE_C and/or MBEDTLS_FS_IO and/or "

--- a/programs/x509/cert_write.c
+++ b/programs/x509/cert_write.c
@@ -15,7 +15,7 @@
     !defined(MBEDTLS_X509_CRT_PARSE_C) || !defined(MBEDTLS_FS_IO) || \
     !defined(MBEDTLS_ENTROPY_C) || !defined(MBEDTLS_CTR_DRBG_C) || \
     !defined(MBEDTLS_ERROR_C) || !defined(MBEDTLS_MD_CAN_SHA256) || \
-    !defined(MBEDTLS_PEM_WRITE_C)
+    !defined(MBEDTLS_PEM_WRITE_C) || !defined(MBEDTLS_MD_C)
 int main(void)
 {
     mbedtls_printf("MBEDTLS_X509_CRT_WRITE_C and/or MBEDTLS_X509_CRT_PARSE_C and/or "

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -3655,6 +3655,68 @@ component_test_psa_crypto_config_reference_hash_use_psa() {
     tests/ssl-opt.sh
 }
 
+# Auxiliary function to build config for hashes with and without drivers
+config_psa_crypto_hmac_use_psa () {
+    driver_only="$1"
+    # start with config full for maximum coverage (also enables USE_PSA)
+    helper_libtestdriver1_adjust_config "full"
+
+    # Direct dependencies of MD_C. We disable them also in the reference
+    # component to work with the same set of features.
+    scripts/config.py unset MBEDTLS_PKCS7_C
+    scripts/config.py unset MBEDTLS_PKCS5_C
+    scripts/config.py unset MBEDTLS_HMAC_DRBG_C
+    scripts/config.py unset MBEDTLS_HKDF_C
+    # Dependencies of HMAC_DRBG
+    scripts/config.py unset MBEDTLS_ECDSA_DETERMINISTIC
+    scripts/config.py -f "$CRYPTO_CONFIG_H" unset PSA_WANT_ALG_DETERMINISTIC_ECDSA
+}
+
+component_test_psa_crypto_config_accel_hmac() {
+    msg "test: full with accelerated hmac"
+
+    loc_accel_list="ALG_HMAC KEY_TYPE_HMAC \
+                    ALG_MD5 ALG_RIPEMD160 ALG_SHA_1 \
+                    ALG_SHA_224 ALG_SHA_256 ALG_SHA_384 ALG_SHA_512 \
+                    ALG_SHA3_224 ALG_SHA3_256 ALG_SHA3_384 ALG_SHA3_512"
+
+    # Configure
+    # ---------
+
+    config_psa_crypto_hmac_use_psa 1
+
+    # Disable MD_C in order to disable the builtin support for HMAC. MD_LIGHT
+    # is still enabled though.
+    scripts/config.py unset MBEDTLS_MD_C
+
+    # Build
+    # -----
+
+    helper_libtestdriver1_make_drivers "$loc_accel_list"
+
+    helper_libtestdriver1_make_main "$loc_accel_list"
+
+    # Ensure that built-in support for HMAC is disabled.
+    not grep mbedtls_md_hmac library/md.o
+
+    # Run the tests
+    # -------------
+
+    msg "test: full with accelerated hmac"
+    make test
+}
+
+component_test_psa_crypto_config_reference_hmac() {
+    msg "test: full without accelerated hmac"
+
+    config_psa_crypto_hmac_use_psa 0
+
+    make
+
+    msg "test: full without accelerated hmac"
+    make test
+}
+
 component_test_psa_crypto_config_accel_des () {
     msg "test: MBEDTLS_PSA_CRYPTO_CONFIG with accelerated DES"
 

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -3661,6 +3661,17 @@ config_psa_crypto_hmac_use_psa () {
     # start with config full for maximum coverage (also enables USE_PSA)
     helper_libtestdriver1_adjust_config "full"
 
+    if [ "$driver_only" -eq 1 ]; then
+        # Disable MD_C in order to disable the builtin support for HMAC. MD_LIGHT
+        # is still enabled though (for ENTROPY_C among others).
+        scripts/config.py unset MBEDTLS_MD_C
+        # Disable also the builtin hashes since they are supported by the driver
+        # and MD module is able to perform PSA dispathing.
+        scripts/config.py unset-all MBEDTLS_SHA
+        scripts/config.py unset MBEDTLS_MD5_C
+        scripts/config.py unset MBEDTLS_RIPEMD160_C
+    fi
+
     # Direct dependencies of MD_C. We disable them also in the reference
     # component to work with the same set of features.
     scripts/config.py unset MBEDTLS_PKCS7_C
@@ -3684,10 +3695,6 @@ component_test_psa_crypto_config_accel_hmac() {
     # ---------
 
     config_psa_crypto_hmac_use_psa 1
-
-    # Disable MD_C in order to disable the builtin support for HMAC. MD_LIGHT
-    # is still enabled though.
-    scripts/config.py unset MBEDTLS_MD_C
 
     # Build
     # -----

--- a/tests/scripts/analyze_outcomes.py
+++ b/tests/scripts/analyze_outcomes.py
@@ -246,6 +246,9 @@ KNOWN_TASKS = {
             'component_ref': 'test_psa_crypto_config_reference_hmac',
             'component_driver': 'test_psa_crypto_config_accel_hmac',
             'ignored_suites': [
+                # These suites require legacy hash support, which is disabled
+                # in the accelerate component.
+                'shax', 'mdx',
                 # This suite tests builtins directly, but these are missing
                 # in the accelerated case.
                 'psa_crypto_low_hash.generated',

--- a/tests/scripts/analyze_outcomes.py
+++ b/tests/scripts/analyze_outcomes.py
@@ -247,7 +247,7 @@ KNOWN_TASKS = {
             'component_driver': 'test_psa_crypto_config_accel_hmac',
             'ignored_suites': [
                 # These suites require legacy hash support, which is disabled
-                # in the accelerate component.
+                # in the accelerated component.
                 'shax', 'mdx',
                 # This suite tests builtins directly, but these are missing
                 # in the accelerated case.

--- a/tests/scripts/analyze_outcomes.py
+++ b/tests/scripts/analyze_outcomes.py
@@ -240,6 +240,41 @@ KNOWN_TASKS = {
             }
         }
     },
+    'analyze_driver_vs_reference_hmac': {
+        'test_function': do_analyze_driver_vs_reference,
+        'args': {
+            'component_ref': 'test_psa_crypto_config_reference_hmac',
+            'component_driver': 'test_psa_crypto_config_accel_hmac',
+            'ignored_suites': [
+                # This suite tests builtins directly, but these are missing
+                # in the accelerated case.
+                'psa_crypto_low_hash.generated',
+            ],
+            'ignored_tests': {
+                'test_suite_md': [
+                    # Builtin HMAC is not supported in the accelerate component.
+                    re.compile('.*HMAC.*'),
+                    # Following tests make use of functions which are not available
+                    # when MD_C is disabled, as it happens in the accelerated
+                    # test component.
+                    re.compile('generic .* Hash file .*'),
+                    'MD list',
+                ],
+                'test_suite_md.psa': [
+                    # "legacy only" tests require hash algorithms to be NOT
+                    # accelerated, but this of course false for the accelerated
+                    # test component.
+                    re.compile('PSA dispatch .* legacy only'),
+                ],
+                'test_suite_platform': [
+                    # Incompatible with sanitizers (e.g. ASan). If the driver
+                    # component uses a sanitizer but the reference component
+                    # doesn't, we have a PASS vs SKIP mismatch.
+                    'Check mbedtls_calloc overallocation',
+                ],
+            }
+        }
+    },
     'analyze_driver_vs_reference_cipher_aead_cmac': {
         'test_function': do_analyze_driver_vs_reference,
         'args': {

--- a/tests/suites/test_suite_entropy.function
+++ b/tests/suites/test_suite_entropy.function
@@ -447,7 +447,7 @@ void entropy_nv_seed_std_io()
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_MD_C:MBEDTLS_ENTROPY_NV_SEED:MBEDTLS_PLATFORM_NV_SEED_ALT */
+/* BEGIN_CASE depends_on:MBEDTLS_MD_LIGHT:MBEDTLS_ENTROPY_NV_SEED:MBEDTLS_PLATFORM_NV_SEED_ALT */
 void entropy_nv_seed(data_t *read_seed)
 {
 #if defined(MBEDTLS_ENTROPY_SHA512_ACCUMULATOR)


### PR DESCRIPTION
## Description

This PR add a couple of test components to `all.sh`:
- `component_test_psa_crypto_config_accel_hmac` which accelerates HMAC and all hash alorithms
- `component_test_psa_crypto_config_reference_hmac` which is used as reference component

Test coverage parity is ensured by adding the proper task to `analyze_outcomes.py`.

Resolves #8564 

## PR checklist

- [x] **changelog** not required
- [x] **backport** not required
- [x] **tests** provided