### PR TITLE
Put the id field at the end of the psa_key_attributes_s structure

### DIFF
--- a/include/psa/crypto_struct.h
+++ b/include/psa/crypto_struct.h
@@ -239,18 +239,17 @@ typedef struct {
     psa_key_type_t MBEDTLS_PRIVATE(type);
     psa_key_bits_t MBEDTLS_PRIVATE(bits);
     psa_key_lifetime_t MBEDTLS_PRIVATE(lifetime);
-    mbedtls_svc_key_id_t MBEDTLS_PRIVATE(id);
     psa_key_policy_t MBEDTLS_PRIVATE(policy);
     psa_key_attributes_flag_t MBEDTLS_PRIVATE(flags);
+    mbedtls_svc_key_id_t MBEDTLS_PRIVATE(id);
 } psa_core_key_attributes_t;
 
 #define PSA_CORE_KEY_ATTRIBUTES_INIT { PSA_KEY_TYPE_NONE, 0,            \
                                        PSA_KEY_LIFETIME_VOLATILE,       \
-                                       MBEDTLS_SVC_KEY_ID_INIT,         \
-                                       PSA_KEY_POLICY_INIT, 0 }
+                                       PSA_KEY_POLICY_INIT, 0,          \
+                                       MBEDTLS_SVC_KEY_ID_INIT }
 
 struct psa_key_attributes_s {
-    psa_core_key_attributes_t MBEDTLS_PRIVATE(core);
 #if defined(MBEDTLS_PSA_CRYPTO_SE_C)
     psa_key_slot_number_t MBEDTLS_PRIVATE(slot_number);
 #endif /* MBEDTLS_PSA_CRYPTO_SE_C */
@@ -268,12 +267,13 @@ struct psa_key_attributes_s {
      */
     void *MBEDTLS_PRIVATE(domain_parameters);
     size_t MBEDTLS_PRIVATE(domain_parameters_size);
+    psa_core_key_attributes_t MBEDTLS_PRIVATE(core);
 };
 
 #if defined(MBEDTLS_PSA_CRYPTO_SE_C)
-#define PSA_KEY_ATTRIBUTES_INIT { PSA_CORE_KEY_ATTRIBUTES_INIT, 0, NULL, 0 }
+#define PSA_KEY_ATTRIBUTES_INIT { 0, NULL, 0, PSA_CORE_KEY_ATTRIBUTES_INIT }
 #else
-#define PSA_KEY_ATTRIBUTES_INIT { PSA_CORE_KEY_ATTRIBUTES_INIT, NULL, 0 }
+#define PSA_KEY_ATTRIBUTES_INIT { NULL, 0, PSA_CORE_KEY_ATTRIBUTES_INIT }
 #endif
 
 static inline struct psa_key_attributes_s psa_key_attributes_init(void)

--- a/include/psa/crypto_struct.h
+++ b/include/psa/crypto_struct.h
@@ -241,6 +241,17 @@ typedef struct {
     psa_key_lifetime_t MBEDTLS_PRIVATE(lifetime);
     psa_key_policy_t MBEDTLS_PRIVATE(policy);
     psa_key_attributes_flag_t MBEDTLS_PRIVATE(flags);
+    /* This type has a different layout in the client view wrt the
+     * service view of the key id, i.e. in service view usually is
+     * expected to have MBEDTLS_SVC_KEY_ID_ENCODES_OWNER defined
+     * thus adding an owner field to the standard psa_key_id_t. For
+     * implementations with client/service separation, this means the
+     * object will be marshalled through a transport channel and
+     * interpreted differently at each side of the transport. Placing
+     * it at the end of structures allows to interpret the structure
+     * at the client without reorganizing the memory layout of the
+     * struct
+     */
     mbedtls_svc_key_id_t MBEDTLS_PRIVATE(id);
 } psa_core_key_attributes_t;
 
@@ -267,6 +278,12 @@ struct psa_key_attributes_s {
      */
     void *MBEDTLS_PRIVATE(domain_parameters);
     size_t MBEDTLS_PRIVATE(domain_parameters_size);
+    /* With client/service separation, struct psa_key_attributes_s is
+     * marshalled through a transport channel between the client and
+     * service side implementation of the PSA Crypto APIs, thus having
+     * the mbedtls_svc_key_id_t id as the last field of this structure
+     * allows for a more efficient marshalling/unmarshalling of parameters
+     */
     psa_core_key_attributes_t MBEDTLS_PRIVATE(core);
 };
 

--- a/include/psa/crypto_struct.h
+++ b/include/psa/crypto_struct.h
@@ -243,7 +243,7 @@ typedef struct {
     psa_key_attributes_flag_t MBEDTLS_PRIVATE(flags);
     /* This type has a different layout in the client view wrt the
      * service view of the key id, i.e. in service view usually is
-     * expected to have MBEDTLS_SVC_KEY_ID_ENCODES_OWNER defined
+     * expected to have MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER defined
      * thus adding an owner field to the standard psa_key_id_t. For
      * implementations with client/service separation, this means the
      * object will be marshalled through a transport channel and


### PR DESCRIPTION
## Description

Putting the `id` at the of the `psa_key_attributes_s` structure allows for a more efficient marshalling of the parameters around a transport channel which provides separation between a client view and a service view of the key parameters.

## PR checklist

- [x] **changelog** NOT REQUIRED
- [x] **backport** NOT REQUIRED
- [x] **tests** NOT REQUIRED
