### PR TITLE
python [requirements]: Added maximum version for jsonschema

### DIFF
--- a/scripts/driver.requirements.txt
+++ b/scripts/driver.requirements.txt
@@ -15,5 +15,5 @@ Jinja2 >= 2.10.1; python_version <  '3.10'
 Jinja2 >= 2.10.3; python_version >= '3.10'
 # Jinja2 >=2.10, <3.0 needs a separate package for type annotations
 types-Jinja2 >= 2.11.9
-jsonschema >= 3.2.0
-types-jsonschema >= 3.2.0
+jsonschema >= 3.2.0, < 4.18.*
+types-jsonschema >= 3.2.0, < 4.18.*


### PR DESCRIPTION
## Description

This PR is using [PEP0440](https://peps.python.org/pep-0440/#compatible-release)/ [PYPA spec](https://packaging.python.org/en/latest/specifications/) to lock the jsonschema version to versions between `3.2.0` and  `4.17.X`.

The problem is caused by version [4.18](https://github.com/python-jsonschema/jsonschema/releases/tag/v4.18.0) of jsonschema which added an indirect extra dependency `rpds_py` without listing it in the changelog. 

[prds_py ](https://pypi.org/project/rpds-py/) brings in a lot of rust dependencies since it is compiled from source, and pip install will fai in a system that does not have properly configured `rustc` and `cargo`.

The issue has been documented in multiple other projects:
https://github.com/python-poetry/poetry/issues/8160
https://github.com/pydantic/pydantic/issues/4790
https://github.com/canonical/prometheus-k8s-operator/issues/493

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** Not required, does not modify the library, just build enviroment. 
- [x] **backport** Not required, the driver auto-generation does not exist in 2.28X
- [x] **tests** Not required, only changes build enviroment.


