### PR TITLE
tests: fix `calloc()` argument list (`gcc-14` fix)

### DIFF
--- a/tests/include/test/macros.h
+++ b/tests/include/test/macros.h
@@ -125,8 +125,8 @@
     do {                                                    \
         TEST_ASSERT((pointer) == NULL);                     \
         if ((item_count) != 0) {                            \
-            (pointer) = mbedtls_calloc(sizeof(*(pointer)),  \
-                                       (item_count));       \
+            (pointer) = mbedtls_calloc((item_count),        \
+                                       sizeof(*(pointer))); \
             TEST_ASSERT((pointer) != NULL);                 \
         }                                                   \
     } while (0)
@@ -155,8 +155,8 @@
 #define TEST_CALLOC_NONNULL(pointer, item_count)            \
     do {                                                    \
         TEST_ASSERT((pointer) == NULL);                     \
-        (pointer) = mbedtls_calloc(sizeof(*(pointer)),      \
-                                   (item_count));           \
+        (pointer) = mbedtls_calloc((item_count),            \
+                                   sizeof(*(pointer)));     \
         if (((pointer) == NULL) && ((item_count) == 0)) {   \
             (pointer) = mbedtls_calloc(1, 1);               \
         }                                                   \
@@ -175,8 +175,8 @@
     do {                                                    \
         TEST_ASSERT((pointer) == NULL);                     \
         if ((item_count) != 0) {                            \
-            (pointer) = mbedtls_calloc(sizeof(*(pointer)),  \
-                                       (item_count));       \
+            (pointer) = mbedtls_calloc((item_count),        \
+                                       sizeof(*(pointer))); \
             TEST_ASSUME((pointer) != NULL);                 \
         }                                                   \
     } while (0)


### PR DESCRIPTION
`gcc-14` added a new `-Wcalloc-transposed-args` warning recently. It detected minor infelicity in `calloc()` API usage in `mbedtls`:

    In file included from /build/mbedtls/tests/include/test/ssl_helpers.h:19,
                     from /build/mbedtls/tests/src/test_helpers/ssl_helpers.c:11:
    /build/mbedtls/tests/src/test_helpers/ssl_helpers.c: In function 'mbedtls_test_init_handshake_options':
    /build/mbedtls/tests/include/test/macros.h:128:46:
      error: 'calloc' sizes specified with 'sizeof' in the earlier argument
        and not in the later argument [-Werror=calloc-transposed-args]
      128 |             (pointer) = mbedtls_calloc(sizeof(*(pointer)),  \
          |                                              ^

## Description

Please write a few sentences describing the overall goals of the pull request's commits.



## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** provided, or not required
- [x] **backport** done, or not required
- [x] **tests** provided, or not required



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.
