### PR TITLE
TLS 1.3: Add mbedtls_ssl_write_early_data() API

### DIFF
--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -734,6 +734,51 @@ typedef enum {
 }
 mbedtls_ssl_states;
 
+/*
+ * Early data status, client side only.
+ */
+
+#if defined(MBEDTLS_SSL_EARLY_DATA) && defined(MBEDTLS_SSL_CLI_C)
+typedef enum {
+/*
+ * The client has not sent the first ClientHello yet, it is unknown if the
+ * client will send an early data indication extension or not.
+ */
+    MBEDTLS_SSL_EARLY_DATA_STATUS_UNKNOWN,
+
+/*
+ * See documentation of mbedtls_ssl_get_early_data_status().
+ */
+    MBEDTLS_SSL_EARLY_DATA_STATUS_NOT_SENT,
+    MBEDTLS_SSL_EARLY_DATA_STATUS_ACCEPTED,
+    MBEDTLS_SSL_EARLY_DATA_STATUS_REJECTED,
+
+/*
+ * The client has sent an early data indication extension in its first
+ * ClientHello, it has not received the response (ServerHello or
+ * HelloRetryRequest) from the server yet. The transform to protect early data
+ * is not set and early data cannot be sent yet.
+ */
+    MBEDTLS_SSL_EARLY_DATA_STATUS_SENT,
+
+/*
+ * The client has sent an early data indication extension in its first
+ * ClientHello, it has not received the response (ServerHello or
+ * HelloRetryRequest) from the server yet. The transform to protect early data
+ * has been set and early data can be written now.
+ */
+    MBEDTLS_SSL_EARLY_DATA_STATUS_CAN_WRITE,
+
+/*
+ * The client has sent an early data indication extension in its first
+ * ClientHello, the server has accepted them and the client has received the
+ * server Finished message. It cannot send early data to the server anymore.
+ */
+    MBEDTLS_SSL_EARLY_DATA_STATUS_SERVER_FINISHED_RECEIVED,
+} mbedtls_ssl_early_data_status;
+
+#endif /* MBEDTLS_SSL_EARLY_DATA && MBEDTLS_SSL_CLI_C */
+
 /**
  * \brief          Callback type: send data on the network.
  *
@@ -1676,14 +1721,10 @@ struct mbedtls_ssl_context {
 
 #if defined(MBEDTLS_SSL_EARLY_DATA) && defined(MBEDTLS_SSL_CLI_C)
     /**
-     * Status of the negotiation of the use of early data.
-     * See the documentation of mbedtls_ssl_get_early_data_status() for more
-     * information.
-     *
-     * Reset to #MBEDTLS_SSL_EARLY_DATA_STATUS_UNKNOWN when the context is
-     * reset.
+     * Status of the negotiation of the use of early data. Reset to
+     * MBEDTLS_SSL_EARLY_DATA_STATUS_UNKNOWN when the context is reset.
      */
-    int MBEDTLS_PRIVATE(early_data_status);
+    mbedtls_ssl_early_data_status MBEDTLS_PRIVATE(early_data_status);
 #endif
 
     unsigned MBEDTLS_PRIVATE(badmac_seen);       /*!< records with a bad MAC received    */
@@ -5105,10 +5146,6 @@ int mbedtls_ssl_send_alert_message(mbedtls_ssl_context *ssl,
 int mbedtls_ssl_close_notify(mbedtls_ssl_context *ssl);
 
 #if defined(MBEDTLS_SSL_EARLY_DATA)
-
-#define MBEDTLS_SSL_EARLY_DATA_STATUS_NOT_SENT  1
-#define MBEDTLS_SSL_EARLY_DATA_STATUS_ACCEPTED  2
-#define MBEDTLS_SSL_EARLY_DATA_STATUS_REJECTED  3
 
 #if defined(MBEDTLS_SSL_SRV_C)
 /**

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1657,31 +1657,31 @@ struct mbedtls_ssl_context {
 #endif /* MBEDTLS_SSL_RENEGOTIATION */
 
     /**
-     *  Maximum TLS version to be negotiated, then negotiated TLS version.
+     * Maximum TLS version to be negotiated, then negotiated TLS version.
      *
-     *  It is initialized as the configured maximum TLS version to be
-     *  negotiated by mbedtls_ssl_setup().
+     * It is initialized as the configured maximum TLS version to be
+     * negotiated by mbedtls_ssl_setup().
      *
-     *  When renegotiating or resuming a session, it is overwritten in the
-     *  ClientHello writing preparation stage with the previously negotiated
-     *  TLS version.
+     * When renegotiating or resuming a session, it is overwritten in the
+     * ClientHello writing preparation stage with the previously negotiated
+     * TLS version.
      *
-     *  On client side, it is updated to the TLS version selected by the server
-     *  for the handshake when the ServerHello is received.
+     * On client side, it is updated to the TLS version selected by the server
+     * for the handshake when the ServerHello is received.
      *
-     *  On server side, it is updated to the TLS version the server selects for
-     *  the handshake when the ClientHello is received.
+     * On server side, it is updated to the TLS version the server selects for
+     * the handshake when the ClientHello is received.
      */
     mbedtls_ssl_protocol_version MBEDTLS_PRIVATE(tls_version);
 
 #if defined(MBEDTLS_SSL_EARLY_DATA) && defined(MBEDTLS_SSL_CLI_C)
     /**
-     *  Status of the negotiation of the use of early data.
-     *  See the documentation of mbedtls_ssl_get_early_data_status() for more
-     *  information.
+     * Status of the negotiation of the use of early data.
+     * See the documentation of mbedtls_ssl_get_early_data_status() for more
+     * information.
      *
-     *  Reset to #MBEDTLS_SSL_EARLY_DATA_STATUS_NOT_SENT when the context is
-     *  reset.
+     * Reset to #MBEDTLS_SSL_EARLY_DATA_STATUS_UNKNOWN when the context is
+     * reset.
      */
     int MBEDTLS_PRIVATE(early_data_status);
 #endif

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -5256,9 +5256,11 @@ int mbedtls_ssl_read_early_data(mbedtls_ssl_context *ssl,
  *                 already completed.
  *
  *                 It is not possible to write early data for the SSL context
- *                 \p ssl but this does not preclude for using it with
+ *                 \p ssl and any subsequent call to this API will return this
+ *                 error code. But this does not preclude for using it with
  *                 mbedtls_ssl_write(), mbedtls_ssl_read() or
- *                 mbedtls_ssl_handshake().
+ *                 mbedtls_ssl_handshake() and the handshake can be
+ *                 completed by calling one of these APIs.
  *
  * \note           This function may write early data only if the SSL context
  *                 has been configured for the handshake with a PSK for which

--- a/library/ssl_debug_helpers.h
+++ b/library/ssl_debug_helpers.h
@@ -21,6 +21,10 @@
 
 const char *mbedtls_ssl_states_str(mbedtls_ssl_states in);
 
+#if defined(MBEDTLS_SSL_EARLY_DATA) && defined(MBEDTLS_SSL_CLI_C)
+const char *mbedtls_ssl_early_data_status_str(mbedtls_ssl_early_data_status in);
+#endif
+
 const char *mbedtls_ssl_protocol_version_str(mbedtls_ssl_protocol_version in);
 
 const char *mbedtls_tls_prf_types_str(mbedtls_tls_prf_types in);

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -730,16 +730,21 @@ struct mbedtls_ssl_handshake_params {
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
     uint8_t key_exchange_mode; /*!< Selected key exchange mode */
 
-    /** Number of HelloRetryRequest messages received/sent from/to the server. */
-    uint8_t hello_retry_request_count;
+    /**
+     * Flag indicating if, in the course of the current handshake, an
+     * HelloRetryRequest message has been sent by the server or received by
+     * the client (<> 0) or not (0).
+     */
+    uint8_t hello_retry_request_flag;
 
 #if defined(MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE)
     /**
-     *  Number of dummy change_cipher_spec (CCS) record sent. Used to send only
-     *  one CCS per handshake without having to complicate the handshake state
-     *  transitions.
+     * Flag indicating if, in the course of the current handshake, a dummy
+     * change_cipher_spec (CCS) record has already been sent. Used to send only
+     * one CCS per handshake while not complicating the handshake state
+     * transitions for that purpose.
      */
-    uint8_t ccs_count;
+    uint8_t ccs_sent;
 #endif
 
 #if defined(MBEDTLS_SSL_SRV_C)

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -665,21 +665,21 @@ struct mbedtls_ssl_handshake_params {
 #if defined(MBEDTLS_SSL_CLI_C)
     /** Minimum TLS version to be negotiated.
      *
-     *  It is set up in the ClientHello writing preparation stage and used
-     *  throughout the ClientHello writing. Not relevant anymore as soon as
-     *  the protocol version has been negotiated thus as soon as the
-     *  ServerHello is received.
-     *  For a fresh handshake not linked to any previous handshake, it is
-     *  equal to the configured minimum minor version to be negotiated. When
-     *  renegotiating or resuming a session, it is equal to the previously
-     *  negotiated minor version.
+     * It is set up in the ClientHello writing preparation stage and used
+     * throughout the ClientHello writing. Not relevant anymore as soon as
+     * the protocol version has been negotiated thus as soon as the
+     * ServerHello is received.
+     * For a fresh handshake not linked to any previous handshake, it is
+     * equal to the configured minimum minor version to be negotiated. When
+     * renegotiating or resuming a session, it is equal to the previously
+     * negotiated minor version.
      *
-     *  There is no maximum TLS version field in this handshake context.
-     *  From the start of the handshake, we need to define a current protocol
-     *  version for the record layer which we define as the maximum TLS
-     *  version to be negotiated. The `tls_version` field of the SSL context is
-     *  used to store this maximum value until it contains the actual
-     *  negotiated value.
+     * There is no maximum TLS version field in this handshake context.
+     * From the start of the handshake, we need to define a current protocol
+     * version for the record layer which we define as the maximum TLS
+     * version to be negotiated. The `tls_version` field of the SSL context is
+     * used to store this maximum value until it contains the actual
+     * negotiated value.
      */
     mbedtls_ssl_protocol_version min_tls_version;
 #endif

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -2150,38 +2150,6 @@ int mbedtls_ssl_tls13_write_early_data_ext(mbedtls_ssl_context *ssl,
                                            unsigned char *buf,
                                            const unsigned char *end,
                                            size_t *out_len);
-
-#if defined(MBEDTLS_SSL_CLI_C)
-/*
- * The client has not sent the first ClientHello yet, it is unknown if the
- * client will send an early data indication extension or not.
- */
-#define MBEDTLS_SSL_EARLY_DATA_STATUS_UNKNOWN 0
-
-/*
- * The client has sent an early data indication extension in its first
- * ClientHello, it has not received the response (ServerHello or
- * HelloRetryRequest) from the server yet. The transform to protect early data
- * is not set and early data cannot be sent yet.
- */
-#define MBEDTLS_SSL_EARLY_DATA_STATUS_SENT 4
-
-/*
- * The client has sent an early data indication extension in its first
- * ClientHello, it has not received the response (ServerHello or
- * HelloRetryRequest) from the server yet. The transform to protect early data
- * has been set and early data can be written now.
- */
-#define MBEDTLS_SSL_EARLY_DATA_STATUS_CAN_WRITE 5
-
-/*
- * The client has sent an early data indication extension in its first
- * ClientHello, the server has accepted them and the client has received the
- * server Finished message. It cannot send early data to the server anymore.
- */
-#define MBEDTLS_SSL_EARLY_DATA_STATUS_SERVER_FINISHED_RECEIVED 6
-#endif /* MBEDTLS_SSL_CLI_C */
-
 #endif /* MBEDTLS_SSL_EARLY_DATA */
 
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3 */

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -6072,6 +6072,10 @@ int mbedtls_ssl_write_early_data(mbedtls_ssl_context *ssl,
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
+    if (conf->endpoint != MBEDTLS_SSL_IS_CLIENT) {
+        return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
+    }
+
     if ((!mbedtls_ssl_conf_is_tls13_enabled(conf)) ||
         (conf->transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM) ||
         (conf->early_data_enabled != MBEDTLS_SSL_EARLY_DATA_ENABLED)) {

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -1180,6 +1180,14 @@ int mbedtls_ssl_tls13_write_client_hello_exts(mbedtls_ssl_context *ssl,
 #endif
 
 #if defined(MBEDTLS_SSL_EARLY_DATA)
+    /* In the first ClientHello, write the early data indication extension if
+     * necessary and update the early data status.
+     * If an HRR has been received and thus we are currently writing the
+     * second ClientHello, the second ClientHello must not contain an early
+     * data extension and the early data status must stay as it is:
+     * MBEDTLS_SSL_EARLY_DATA_STATUS_NOT_SENT or
+     * MBEDTLS_SSL_EARLY_DATA_STATUS_REJECTED.
+     */
     if (!ssl->handshake->hello_retry_request_flag) {
         if (mbedtls_ssl_conf_tls13_is_some_psk_enabled(ssl) &&
             ssl_tls13_early_data_has_valid_ticket(ssl) &&

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -1180,7 +1180,7 @@ int mbedtls_ssl_tls13_write_client_hello_exts(mbedtls_ssl_context *ssl,
 #endif
 
 #if defined(MBEDTLS_SSL_EARLY_DATA)
-    if (ssl->handshake->hello_retry_request_count == 0) {
+    if (!ssl->handshake->hello_retry_request_flag) {
         if (mbedtls_ssl_conf_tls13_is_some_psk_enabled(ssl) &&
             ssl_tls13_early_data_has_valid_ticket(ssl) &&
             ssl->conf->early_data_enabled == MBEDTLS_SSL_EARLY_DATA_ENABLED) {
@@ -1497,7 +1497,7 @@ static int ssl_tls13_preprocess_server_hello(mbedtls_ssl_context *ssl,
              * to a HelloRetryRequest), it MUST abort the handshake with an
              * "unexpected_message" alert.
              */
-            if (handshake->hello_retry_request_count > 0) {
+            if (handshake->hello_retry_request_flag) {
                 MBEDTLS_SSL_DEBUG_MSG(1, ("Multiple HRRs received"));
                 MBEDTLS_SSL_PEND_FATAL_ALERT(
                     MBEDTLS_SSL_ALERT_MSG_UNEXPECTED_MESSAGE,
@@ -1519,7 +1519,7 @@ static int ssl_tls13_preprocess_server_hello(mbedtls_ssl_context *ssl,
                 return MBEDTLS_ERR_SSL_ILLEGAL_PARAMETER;
             }
 
-            handshake->hello_retry_request_count++;
+            handshake->hello_retry_request_flag = 1;
 
             break;
     }
@@ -1674,7 +1674,7 @@ static int ssl_tls13_parse_server_hello(mbedtls_ssl_context *ssl,
      * proposed in the HRR, we abort the handshake and send an
      * "illegal_parameter" alert.
      */
-    else if ((!is_hrr) && (handshake->hello_retry_request_count > 0) &&
+    else if ((!is_hrr) && handshake->hello_retry_request_flag &&
              (cipher_suite != ssl->session_negotiate->ciphersuite)) {
         fatal_alert = MBEDTLS_SSL_ALERT_MSG_ILLEGAL_PARAMETER;
     }

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -2321,7 +2321,7 @@ cleanup:
 
 int mbedtls_ssl_get_early_data_status(mbedtls_ssl_context *ssl)
 {
-    if ((ssl->conf->endpoint == MBEDTLS_SSL_IS_SERVER) ||
+    if ((ssl->conf->endpoint != MBEDTLS_SSL_IS_CLIENT) ||
         (!mbedtls_ssl_is_handshake_over(ssl))) {
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -2280,6 +2280,7 @@ cleanup:
 
 }
 
+#if defined(MBEDTLS_SSL_EARLY_DATA)
 /*
  * Handler for MBEDTLS_SSL_END_OF_EARLY_DATA
  *
@@ -2317,6 +2318,7 @@ cleanup:
     MBEDTLS_SSL_DEBUG_MSG(2, ("<= write EndOfEarlyData"));
     return ret;
 }
+#endif /* MBEDTLS_SSL_EARLY_DATA */
 
 #if defined(MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED)
 /*
@@ -3040,9 +3042,11 @@ int mbedtls_ssl_tls13_handshake_client_step(mbedtls_ssl_context *ssl)
             ret = ssl_tls13_process_server_finished(ssl);
             break;
 
+#if defined(MBEDTLS_SSL_EARLY_DATA)
         case MBEDTLS_SSL_END_OF_EARLY_DATA:
             ret = ssl_tls13_write_end_of_early_data(ssl);
             break;
+#endif
 
         case MBEDTLS_SSL_CLIENT_CERTIFICATE:
             ret = ssl_tls13_write_client_certificate(ssl);

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -3063,23 +3063,17 @@ int mbedtls_ssl_tls13_handshake_client_step(mbedtls_ssl_context *ssl)
              */
 #if defined(MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE)
         case MBEDTLS_SSL_CLIENT_CCS_BEFORE_2ND_CLIENT_HELLO:
-            ret = 0;
-            if (ssl->handshake->ccs_count == 0) {
-                ret = mbedtls_ssl_tls13_write_change_cipher_spec(ssl);
-                if (ret != 0) {
-                    break;
-                }
+            ret = mbedtls_ssl_tls13_write_change_cipher_spec(ssl);
+            if (ret != 0) {
+                break;
             }
             mbedtls_ssl_handshake_set_state(ssl, MBEDTLS_SSL_CLIENT_HELLO);
             break;
 
         case MBEDTLS_SSL_CLIENT_CCS_AFTER_SERVER_FINISHED:
-            ret = 0;
-            if (ssl->handshake->ccs_count == 0) {
-                ret = mbedtls_ssl_tls13_write_change_cipher_spec(ssl);
-                if (ret != 0) {
-                    break;
-                }
+            ret = mbedtls_ssl_tls13_write_change_cipher_spec(ssl);
+            if (ret != 0) {
+                break;
             }
             mbedtls_ssl_handshake_set_state(ssl, MBEDTLS_SSL_CLIENT_CERTIFICATE);
             break;

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -2318,6 +2318,31 @@ cleanup:
     MBEDTLS_SSL_DEBUG_MSG(2, ("<= write EndOfEarlyData"));
     return ret;
 }
+
+int mbedtls_ssl_get_early_data_status(mbedtls_ssl_context *ssl)
+{
+    if ((ssl->conf->endpoint == MBEDTLS_SSL_IS_SERVER) ||
+        (!mbedtls_ssl_is_handshake_over(ssl))) {
+        return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
+    }
+
+    switch (ssl->early_data_status) {
+        case MBEDTLS_SSL_EARLY_DATA_STATUS_NOT_SENT:
+            return MBEDTLS_SSL_EARLY_DATA_STATUS_NOT_SENT;
+            break;
+
+        case MBEDTLS_SSL_EARLY_DATA_STATUS_REJECTED:
+            return MBEDTLS_SSL_EARLY_DATA_STATUS_REJECTED;
+            break;
+
+        case MBEDTLS_SSL_EARLY_DATA_STATUS_SERVER_FINISHED_RECEIVED:
+            return MBEDTLS_SSL_EARLY_DATA_STATUS_ACCEPTED;
+            break;
+
+        default:
+            return MBEDTLS_ERR_SSL_INTERNAL_ERROR;
+    }
+}
 #endif /* MBEDTLS_SSL_EARLY_DATA */
 
 #if defined(MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED)

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -1380,7 +1380,7 @@ int mbedtls_ssl_tls13_write_change_cipher_spec(mbedtls_ssl_context *ssl)
     MBEDTLS_SSL_DEBUG_MSG(2, ("=> write change cipher spec"));
 
     /* Only one CCS to send. */
-    if (ssl->handshake->ccs_count > 0) {
+    if (ssl->handshake->ccs_sent) {
         ret = 0;
         goto cleanup;
     }
@@ -1396,7 +1396,7 @@ int mbedtls_ssl_tls13_write_change_cipher_spec(mbedtls_ssl_context *ssl)
     /* Dispatch message */
     MBEDTLS_SSL_PROC_CHK(mbedtls_ssl_write_record(ssl, 0));
 
-    ssl->handshake->ccs_count++;
+    ssl->handshake->ccs_sent = 1;
 
 cleanup:
 

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -1379,6 +1379,12 @@ int mbedtls_ssl_tls13_write_change_cipher_spec(mbedtls_ssl_context *ssl)
 
     MBEDTLS_SSL_DEBUG_MSG(2, ("=> write change cipher spec"));
 
+    /* Only one CCS to send. */
+    if (ssl->handshake->ccs_count > 0) {
+        ret = 0;
+        goto cleanup;
+    }
+
     /* Write CCS message */
     MBEDTLS_SSL_PROC_CHK(ssl_tls13_write_change_cipher_spec_body(
                              ssl, ssl->out_msg,

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -3482,12 +3482,9 @@ int mbedtls_ssl_tls13_handshake_server_step(mbedtls_ssl_context *ssl)
             break;
 
         case MBEDTLS_SSL_SERVER_CCS_AFTER_SERVER_HELLO:
-            ret = 0;
-            if (ssl->handshake->ccs_count == 0) {
-                ret = mbedtls_ssl_tls13_write_change_cipher_spec(ssl);
-                if (ret != 0) {
-                    break;
-                }
+            ret = mbedtls_ssl_tls13_write_change_cipher_spec(ssl);
+            if (ret != 0) {
+                break;
             }
             mbedtls_ssl_handshake_set_state(ssl, MBEDTLS_SSL_ENCRYPTED_EXTENSIONS);
             break;

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1535,7 +1535,7 @@ static int ssl_tls13_parse_client_hello(mbedtls_ssl_context *ssl,
         const unsigned char *extension_data_end;
         uint32_t allowed_exts = MBEDTLS_SSL_TLS1_3_ALLOWED_EXTS_OF_CH;
 
-        if (ssl->handshake->hello_retry_request_count > 0) {
+        if (ssl->handshake->hello_retry_request_flag) {
             /* Do not accept early data extension in 2nd ClientHello */
             allowed_exts &= ~MBEDTLS_SSL_EXT_MASK(EARLY_DATA);
         }
@@ -2431,7 +2431,7 @@ MBEDTLS_CHECK_RETURN_CRITICAL
 static int ssl_tls13_prepare_hello_retry_request(mbedtls_ssl_context *ssl)
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
-    if (ssl->handshake->hello_retry_request_count > 0) {
+    if (ssl->handshake->hello_retry_request_flag) {
         MBEDTLS_SSL_DEBUG_MSG(1, ("Too many HRRs"));
         MBEDTLS_SSL_PEND_FATAL_ALERT(MBEDTLS_SSL_ALERT_MSG_HANDSHAKE_FAILURE,
                                      MBEDTLS_ERR_SSL_HANDSHAKE_FAILURE);
@@ -2478,7 +2478,7 @@ static int ssl_tls13_write_hello_retry_request(mbedtls_ssl_context *ssl)
     MBEDTLS_SSL_PROC_CHK(mbedtls_ssl_finish_handshake_msg(ssl, buf_len,
                                                           msg_len));
 
-    ssl->handshake->hello_retry_request_count++;
+    ssl->handshake->hello_retry_request_flag = 1;
 
 #if defined(MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE)
     /* The server sends a dummy change_cipher_spec record immediately

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -3050,7 +3050,7 @@ reconnect:
                 while ((ret = mbedtls_ssl_write_early_data(&ssl, buf + written,
                                                            len - written)) < 0) {
                     if (ret == MBEDTLS_ERR_SSL_CANNOT_WRITE_EARLY_DATA) {
-                        break;
+                        goto end_of_early_data;
                     }
                     if (ret != MBEDTLS_ERR_SSL_WANT_READ &&
                         ret != MBEDTLS_ERR_SSL_WANT_WRITE &&
@@ -3069,14 +3069,13 @@ reconnect:
 #endif
                     }
                 }
-                if (ret == MBEDTLS_ERR_SSL_CANNOT_WRITE_EARLY_DATA) {
-                    break;
-                }
 
                 frags++;
                 written += ret;
             } while (written < len);
         }
+
+end_of_early_data:
 
         buf[written] = '\0';
         mbedtls_printf(

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -52,7 +52,7 @@ int main(void)
 #define DFL_KEY_OPAQUE          0
 #define DFL_KEY_PWD             ""
 #define DFL_PSK                 ""
-#define DFL_EARLY_DATA          MBEDTLS_SSL_EARLY_DATA_DISABLED
+#define DFL_EARLY_DATA          -1
 #define DFL_PSK_OPAQUE          0
 #define DFL_PSK_IDENTITY        "Client_identity"
 #define DFL_ECJPAKE_PW          NULL
@@ -347,7 +347,7 @@ int main(void)
 
 #if defined(MBEDTLS_SSL_EARLY_DATA)
 #define USAGE_EARLY_DATA \
-    "    early_data=%%d      default: 0 (disabled)\n" \
+    "    early_data=%%d      default: library default\n" \
     "                        options: 0 (disabled), 1 (enabled)\n"
 #else
 #define USAGE_EARLY_DATA ""
@@ -2026,7 +2026,9 @@ usage:
     }
 
 #if defined(MBEDTLS_SSL_EARLY_DATA)
-    mbedtls_ssl_conf_early_data(&conf, opt.early_data);
+    if (opt.early_data != DFL_EARLY_DATA) {
+        mbedtls_ssl_conf_early_data(&conf, opt.early_data);
+    }
 #endif /* MBEDTLS_SSL_EARLY_DATA */
 
     if ((ret = mbedtls_ssl_setup(&ssl, &conf)) != 0) {
@@ -3041,7 +3043,7 @@ reconnect:
         }
 
 #if defined(MBEDTLS_SSL_EARLY_DATA)
-        if (opt.early_data == MBEDTLS_SSL_EARLY_DATA_ENABLED) {
+        if (ssl.conf->early_data_enabled == MBEDTLS_SSL_EARLY_DATA_ENABLED) {
             frags = 0;
             written = 0;
             do {

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -733,6 +733,12 @@ static int build_http_request(unsigned char *buf, size_t buf_size, size_t *reque
     tail_len = strlen(GET_REQUEST_END);
     if (opt.request_size != DFL_REQUEST_SIZE) {
         request_size = (size_t) opt.request_size;
+    } else {
+        request_size = len + tail_len;
+    }
+
+    if (request_size > buf_size) {
+        return MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL;
     }
 
     /* Add padding to GET request to reach opt.request_size in length */

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -52,7 +52,7 @@ int main(void)
 #define DFL_KEY_OPAQUE          0
 #define DFL_KEY_PWD             ""
 #define DFL_PSK                 ""
-#define DFL_EARLY_DATA          ""
+#define DFL_EARLY_DATA          MBEDTLS_SSL_EARLY_DATA_DISABLED
 #define DFL_PSK_OPAQUE          0
 #define DFL_PSK_IDENTITY        "Client_identity"
 #define DFL_ECJPAKE_PW          NULL
@@ -347,9 +347,8 @@ int main(void)
 
 #if defined(MBEDTLS_SSL_EARLY_DATA)
 #define USAGE_EARLY_DATA \
-    "    early_data=%%s      The file path to read early data from\n" \
-    "                        default: \"\" (do nothing)\n"            \
-    "                        option: a file path\n"
+    "    early_data=%%d      default: 0 (disabled)\n" \
+    "                        options: 0 (disabled), 1 (enabled)\n"
 #else
 #define USAGE_EARLY_DATA ""
 #endif /* MBEDTLS_SSL_EARLY_DATA && MBEDTLS_SSL_PROTO_TLS1_3 */
@@ -544,7 +543,7 @@ struct options {
     int reproducible;           /* make communication reproducible          */
     int skip_close_notify;      /* skip sending the close_notify alert      */
 #if defined(MBEDTLS_SSL_EARLY_DATA)
-    const char *early_data;     /* the path of the file to read early data from */
+    int early_data;             /* early data enablement flag               */
 #endif
     int query_config_mode;      /* whether to read config                   */
     int use_srtp;               /* Support SRTP                             */
@@ -741,10 +740,6 @@ int main(int argc, char *argv[])
     size_t cid_len = 0;
     size_t cid_renego_len = 0;
 #endif
-
-#if defined(MBEDTLS_SSL_EARLY_DATA)
-    FILE *early_data_fp = NULL;
-#endif /* MBEDTLS_SSL_EARLY_DATA */
 
 #if defined(MBEDTLS_SSL_ALPN)
     const char *alpn_list[ALPN_LIST_SIZE];
@@ -1201,7 +1196,15 @@ usage:
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
 #if defined(MBEDTLS_SSL_EARLY_DATA)
         else if (strcmp(p, "early_data") == 0) {
-            opt.early_data = q;
+            switch (atoi(q)) {
+                case 0:
+                    opt.early_data = MBEDTLS_SSL_EARLY_DATA_DISABLED;
+                    break;
+                case 1:
+                    opt.early_data = MBEDTLS_SSL_EARLY_DATA_ENABLED;
+                    break;
+                default: goto usage;
+            }
         }
 #endif /* MBEDTLS_SSL_EARLY_DATA */
 
@@ -1968,16 +1971,7 @@ usage:
     }
 
 #if defined(MBEDTLS_SSL_EARLY_DATA)
-    int early_data_enabled = MBEDTLS_SSL_EARLY_DATA_DISABLED;
-    if (strlen(opt.early_data) > 0) {
-        if ((early_data_fp = fopen(opt.early_data, "rb")) == NULL) {
-            mbedtls_printf("failed\n  ! Cannot open '%s' for reading.\n",
-                           opt.early_data);
-            goto exit;
-        }
-        early_data_enabled = MBEDTLS_SSL_EARLY_DATA_ENABLED;
-    }
-    mbedtls_ssl_conf_early_data(&conf, early_data_enabled);
+    mbedtls_ssl_conf_early_data(&conf, opt.early_data);
 #endif /* MBEDTLS_SSL_EARLY_DATA */
 
     if ((ret = mbedtls_ssl_setup(&ssl, &conf)) != 0) {
@@ -3034,12 +3028,6 @@ exit:
     mbedtls_ssl_free(&ssl);
     mbedtls_ssl_config_free(&conf);
     mbedtls_ssl_session_free(&saved_session);
-
-#if defined(MBEDTLS_SSL_EARLY_DATA)
-    if (early_data_fp != NULL) {
-        fclose(early_data_fp);
-    }
-#endif
 
     if (session_data != NULL) {
         mbedtls_platform_zeroize(session_data, session_data_len);

--- a/tests/include/test/ssl_helpers.h
+++ b/tests/include/test/ssl_helpers.h
@@ -607,9 +607,7 @@ int mbedtls_test_get_tls13_ticket(
     mbedtls_test_handshake_test_options *client_options,
     mbedtls_test_handshake_test_options *server_options,
     mbedtls_ssl_session *session);
-#endif /* MBEDTLS_SSL_CLI_C && MBEDTLS_SSL_SRV_C &&
-          MBEDTLS_SSL_PROTO_TLS1_3 && MBEDTLS_SSL_SESSION_TICKETS &&
-          MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED */
+#endif
 
 #define ECJPAKE_TEST_PWD        "bla"
 

--- a/tests/opt-testcases/tls13-misc.sh
+++ b/tests/opt-testcases/tls13-misc.sh
@@ -263,7 +263,7 @@ requires_any_configs_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL_
 run_test    "TLS 1.3 m->G: EarlyData: basic check, good" \
             "$G_NEXT_SRV -d 10 --priority=NORMAL:-VERS-ALL:+VERS-TLS1.3:+CIPHER-ALL:+ECDHE-PSK:+PSK \
                          --earlydata --maxearlydata 16384 --disable-client-cert" \
-            "$P_CLI debug_level=4 early_data=$EARLY_DATA_INPUT reco_mode=1 reconnect=1 reco_delay=900" \
+            "$P_CLI debug_level=4 early_data=1 reco_mode=1 reconnect=1 reco_delay=900" \
             0 \
             -c "received max_early_data_size: 16384" \
             -c "Reconnecting with saved session" \
@@ -287,7 +287,7 @@ requires_any_configs_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL_
                              MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_ENABLED
 run_test    "TLS 1.3 m->G: EarlyData: no early_data in NewSessionTicket, good" \
             "$G_NEXT_SRV -d 10 --priority=NORMAL:-VERS-ALL:+VERS-TLS1.3:+CIPHER-ALL:+ECDHE-PSK:+PSK --disable-client-cert" \
-            "$P_CLI debug_level=4 early_data=$EARLY_DATA_INPUT reco_mode=1 reconnect=1" \
+            "$P_CLI debug_level=4 early_data=1 reco_mode=1 reconnect=1" \
             0 \
             -c "Reconnecting with saved session" \
             -C "NewSessionTicket: early_data(42) extension received." \

--- a/tests/opt-testcases/tls13-misc.sh
+++ b/tests/opt-testcases/tls13-misc.sh
@@ -285,6 +285,31 @@ requires_all_configs_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE \
                              MBEDTLS_SSL_EARLY_DATA
 requires_any_configs_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL_ENABLED \
                              MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_ENABLED
+run_test    "TLS 1.3 m->G: EarlyData: write early data, good" \
+            "$G_NEXT_SRV -d 10 --priority=NORMAL:-VERS-ALL:+VERS-TLS1.3:+CIPHER-ALL:+ECDHE-PSK:+PSK --earlydata --disable-client-cert" \
+            "$P_CLI debug_level=4 early_data=1 reco_mode=1 reconnect=1 reco_delay=900" \
+            0 \
+            -c "Reconnecting with saved session" \
+            -c "NewSessionTicket: early_data(42) extension received." \
+            -c "ClientHello: early_data(42) extension exists." \
+            -c "EncryptedExtensions: early_data(42) extension received." \
+            -c "EncryptedExtensions: early_data(42) extension exists." \
+            -c "<= write early_data" \
+            -c "<= write EndOfEarlyData" \
+            -s "Parsing extension 'Early Data/42' (0 bytes)" \
+            -s "Sending extension Early Data/42 (0 bytes)" \
+            -s "END OF EARLY DATA (5) was received." \
+            -s "early data accepted" \
+            -s "decrypted early data with length"
+
+requires_gnutls_tls1_3
+requires_config_enabled MBEDTLS_DEBUG_C
+requires_config_enabled MBEDTLS_SSL_CLI_C
+requires_all_configs_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE \
+                             MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED \
+                             MBEDTLS_SSL_EARLY_DATA
+requires_any_configs_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL_ENABLED \
+                             MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_ENABLED
 run_test    "TLS 1.3 m->G: EarlyData: no early_data in NewSessionTicket, good" \
             "$G_NEXT_SRV -d 10 --priority=NORMAL:-VERS-ALL:+VERS-TLS1.3:+CIPHER-ALL:+ECDHE-PSK:+PSK --disable-client-cert" \
             "$P_CLI debug_level=4 early_data=1 reco_mode=1 reconnect=1" \

--- a/tests/suites/test_suite_ssl.data
+++ b/tests/suites/test_suite_ssl.data
@@ -3274,14 +3274,14 @@ elliptic_curve_get_properties
 TLS 1.3 resume session with ticket
 tls13_resume_session_with_ticket
 
-TLS 1.3 early data, early data accepted
-tls13_early_data:TEST_EARLY_DATA_ACCEPTED
+TLS 1.3 read early data, early data accepted
+tls13_read_early_data:TEST_EARLY_DATA_ACCEPTED
 
-TLS 1.3 early data, server rejects early data
-tls13_early_data:TEST_EARLY_DATA_SERVER_REJECTS
+TLS 1.3 read early data, server rejects early data
+tls13_read_early_data:TEST_EARLY_DATA_SERVER_REJECTS
 
-TLS 1.3 early data, discard after HRR
-tls13_early_data:TEST_EARLY_DATA_HRR
+TLS 1.3 read early data, discard after HRR
+tls13_read_early_data:TEST_EARLY_DATA_HRR
 
 TLS 1.3 cli, early data status, early data accepted
 tls13_cli_early_data_status:TEST_EARLY_DATA_ACCEPTED

--- a/tests/suites/test_suite_ssl.data
+++ b/tests/suites/test_suite_ssl.data
@@ -3277,6 +3277,9 @@ tls13_resume_session_with_ticket
 TLS 1.3 read early data, early data accepted
 tls13_read_early_data:TEST_EARLY_DATA_ACCEPTED
 
+TLS 1.3 read early data, no early data indication
+tls13_read_early_data:TEST_EARLY_DATA_NO_INDICATION_SENT
+
 TLS 1.3 read early data, server rejects early data
 tls13_read_early_data:TEST_EARLY_DATA_SERVER_REJECTS
 

--- a/tests/suites/test_suite_ssl.data
+++ b/tests/suites/test_suite_ssl.data
@@ -3300,3 +3300,6 @@ tls13_write_early_data:TEST_EARLY_DATA_ACCEPTED
 
 TLS 1.3 write early data, no early data indication
 tls13_write_early_data:TEST_EARLY_DATA_NO_INDICATION_SENT
+
+TLS 1.3 write early data, server rejects early data
+tls13_write_early_data:TEST_EARLY_DATA_SERVER_REJECTS

--- a/tests/suites/test_suite_ssl.data
+++ b/tests/suites/test_suite_ssl.data
@@ -3297,3 +3297,6 @@ tls13_cli_early_data_status:TEST_EARLY_DATA_HRR
 
 TLS 1.3 write early data, early data accepted
 tls13_write_early_data:TEST_EARLY_DATA_ACCEPTED
+
+TLS 1.3 write early data, no early data indication
+tls13_write_early_data:TEST_EARLY_DATA_NO_INDICATION_SENT

--- a/tests/suites/test_suite_ssl.data
+++ b/tests/suites/test_suite_ssl.data
@@ -3303,3 +3303,6 @@ tls13_write_early_data:TEST_EARLY_DATA_NO_INDICATION_SENT
 
 TLS 1.3 write early data, server rejects early data
 tls13_write_early_data:TEST_EARLY_DATA_SERVER_REJECTS
+
+TLS 1.3 write early data, hello retry request
+tls13_write_early_data:TEST_EARLY_DATA_HRR

--- a/tests/suites/test_suite_ssl.data
+++ b/tests/suites/test_suite_ssl.data
@@ -3294,3 +3294,6 @@ tls13_cli_early_data_status:TEST_EARLY_DATA_SERVER_REJECTS
 
 TLS 1.3 cli, early data status, hello retry request
 tls13_cli_early_data_status:TEST_EARLY_DATA_HRR
+
+TLS 1.3 write early data, early data accepted
+tls13_write_early_data:TEST_EARLY_DATA_ACCEPTED

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -3903,7 +3903,7 @@ void tls13_cli_early_data_status(int scenario)
                         break;
 
                     case TEST_EARLY_DATA_HRR:
-                        if (client_ep.ssl.handshake->hello_retry_request_count == 0) {
+                        if (!client_ep.ssl.handshake->hello_retry_request_flag) {
                             TEST_EQUAL(client_ep.ssl.early_data_status,
                                        MBEDTLS_SSL_EARLY_DATA_STATUS_UNKNOWN);
                         } else {
@@ -3928,7 +3928,7 @@ void tls13_cli_early_data_status(int scenario)
                         break;
 
                     case TEST_EARLY_DATA_HRR:
-                        if (client_ep.ssl.handshake->hello_retry_request_count == 0) {
+                        if (!client_ep.ssl.handshake->hello_retry_request_flag) {
                             TEST_EQUAL(client_ep.ssl.early_data_status,
                                        MBEDTLS_SSL_EARLY_DATA_STATUS_CAN_WRITE);
                         } else {
@@ -4089,7 +4089,7 @@ void tls13_cli_early_data_status(int scenario)
     } while (client_ep.ssl.state != MBEDTLS_SSL_HANDSHAKE_OVER);
 
 #if defined(MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE)
-    TEST_EQUAL(client_ep.ssl.handshake->ccs_count, 1);
+    TEST_EQUAL(client_ep.ssl.handshake->ccs_sent, 1);
 #endif
 
 exit:
@@ -4248,7 +4248,7 @@ void tls13_write_early_data(int scenario)
                         break;
 
                     case TEST_EARLY_DATA_HRR:
-                        if (client_ep.ssl.handshake->hello_retry_request_count == 0) {
+                        if (!client_ep.ssl.handshake->hello_retry_request_flag) {
                             TEST_EQUAL(write_early_data_ret, early_data_len);
                             TEST_EQUAL(client_ep.ssl.state, MBEDTLS_SSL_SERVER_HELLO);
                         } else {
@@ -4270,7 +4270,7 @@ void tls13_write_early_data(int scenario)
                         break;
 
                     case TEST_EARLY_DATA_HRR:
-                        if (client_ep.ssl.handshake->hello_retry_request_count == 0) {
+                        if (!client_ep.ssl.handshake->hello_retry_request_flag) {
                             TEST_EQUAL(write_early_data_ret, early_data_len);
                             TEST_EQUAL(client_ep.ssl.state, MBEDTLS_SSL_SERVER_HELLO);
                         } else {

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -4143,12 +4143,7 @@ void tls13_write_early_data(int scenario)
         MBEDTLS_SSL_IANA_TLS_GROUP_SECP384R1,
         MBEDTLS_SSL_IANA_TLS_GROUP_NONE
     };
-    int client_state, previous_client_state, beyond_first_hello = 0;
-    const char *early_data_string = "This is early data.";
-    const unsigned char *early_data = (const unsigned char *) early_data_string;
-    size_t early_data_len = strlen(early_data_string);
-    int write_early_data_ret, read_early_data_ret;
-    unsigned char read_buf[64];
+    int beyond_first_hello = 0;
 
     mbedtls_platform_zeroize(&client_ep, sizeof(client_ep));
     mbedtls_platform_zeroize(&server_ep, sizeof(server_ep));
@@ -4225,43 +4220,15 @@ void tls13_write_early_data(int scenario)
      * handshake successfully and then reset the connection to restart the
      * handshake from scratch.
      */
-    previous_client_state = MBEDTLS_SSL_HELLO_REQUEST;
-    client_state = MBEDTLS_SSL_HELLO_REQUEST;
+    do {
+        int client_state = client_ep.ssl.state;
+        int previous_client_state;
+        const char *early_data_string = "This is early data.";
+        const unsigned char *early_data = (const unsigned char *) early_data_string;
+        size_t early_data_len = strlen(early_data_string);
+        int write_early_data_ret, read_early_data_ret;
+        unsigned char read_buf[64];
 
-    while (client_state != MBEDTLS_SSL_HANDSHAKE_OVER) {
-        /* In case of HRR scenario, once we have been through it, move over
-         * the first ClientHello and ServerHello otherwise we just keep playing
-         * this first part of the handshake with HRR.
-         */
-        if ((scenario == TEST_EARLY_DATA_HRR) && (beyond_first_hello)) {
-            TEST_ASSERT(mbedtls_test_move_handshake_to_state(
-                            &(client_ep.ssl), &(server_ep.ssl),
-                            MBEDTLS_SSL_SERVER_HELLO) == 0);
-            TEST_ASSERT(mbedtls_test_move_handshake_to_state(
-                            &(client_ep.ssl), &(server_ep.ssl),
-                            MBEDTLS_SSL_CLIENT_HELLO) == 0);
-        }
-
-        TEST_EQUAL(mbedtls_test_move_handshake_to_state(
-                       &(client_ep.ssl), &(server_ep.ssl),
-                       previous_client_state), 0);
-
-        /* Progress the handshake from at least one state */
-        while (client_ep.ssl.state == previous_client_state) {
-            ret = mbedtls_ssl_handshake_step(&(client_ep.ssl));
-            TEST_ASSERT((ret == 0) ||
-                        (ret == MBEDTLS_ERR_SSL_WANT_READ) ||
-                        (ret == MBEDTLS_ERR_SSL_WANT_WRITE));
-            if (client_ep.ssl.state != previous_client_state) {
-                break;
-            }
-            ret = mbedtls_ssl_handshake_step(&(server_ep.ssl));
-            TEST_ASSERT((ret == 0) ||
-                        (ret == MBEDTLS_ERR_SSL_WANT_READ) ||
-                        (ret == MBEDTLS_ERR_SSL_WANT_WRITE));
-        }
-
-        client_state = client_ep.ssl.state;
         write_early_data_ret = mbedtls_ssl_write_early_data(&(client_ep.ssl),
                                                             early_data,
                                                             early_data_len);
@@ -4273,6 +4240,7 @@ void tls13_write_early_data(int scenario)
         }
 
         switch (client_state) {
+            case MBEDTLS_SSL_HELLO_REQUEST: /* Intentional fallthrough */
             case MBEDTLS_SSL_CLIENT_HELLO:
                 switch (scenario) {
                     case TEST_EARLY_DATA_ACCEPTED: /* Intentional fallthrough */
@@ -4460,7 +4428,42 @@ complete_handshake:
         TEST_EQUAL(ret, 0);
 
         previous_client_state = client_state;
-    }
+        if (previous_client_state == MBEDTLS_SSL_HANDSHAKE_OVER) {
+            break;
+        }
+
+        /* In case of HRR scenario, once we have been through it, move over
+         * the first ClientHello and ServerHello otherwise we just keep playing
+         * this first part of the handshake with HRR.
+         */
+        if ((scenario == TEST_EARLY_DATA_HRR) && (beyond_first_hello)) {
+            TEST_ASSERT(mbedtls_test_move_handshake_to_state(
+                            &(client_ep.ssl), &(server_ep.ssl),
+                            MBEDTLS_SSL_SERVER_HELLO) == 0);
+            TEST_ASSERT(mbedtls_test_move_handshake_to_state(
+                            &(client_ep.ssl), &(server_ep.ssl),
+                            MBEDTLS_SSL_CLIENT_HELLO) == 0);
+        }
+
+        TEST_EQUAL(mbedtls_test_move_handshake_to_state(
+                       &(client_ep.ssl), &(server_ep.ssl),
+                       previous_client_state), 0);
+
+        /* Progress the handshake from at least one state */
+        while (client_ep.ssl.state == previous_client_state) {
+            ret = mbedtls_ssl_handshake_step(&(client_ep.ssl));
+            TEST_ASSERT((ret == 0) ||
+                        (ret == MBEDTLS_ERR_SSL_WANT_READ) ||
+                        (ret == MBEDTLS_ERR_SSL_WANT_WRITE));
+            if (client_ep.ssl.state != previous_client_state) {
+                break;
+            }
+            ret = mbedtls_ssl_handshake_step(&(server_ep.ssl));
+            TEST_ASSERT((ret == 0) ||
+                        (ret == MBEDTLS_ERR_SSL_WANT_READ) ||
+                        (ret == MBEDTLS_ERR_SSL_WANT_WRITE));
+        }
+    } while (1);
 
 exit:
     mbedtls_test_ssl_endpoint_free(&client_ep, NULL);

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -3699,6 +3699,10 @@ void tls13_read_early_data(int scenario)
         case TEST_EARLY_DATA_ACCEPTED:
             break;
 
+        case TEST_EARLY_DATA_NO_INDICATION_SENT:
+            client_options.early_data = MBEDTLS_SSL_EARLY_DATA_DISABLED;
+            break;
+
         case TEST_EARLY_DATA_SERVER_REJECTS:
             mbedtls_debug_set_threshold(3);
             server_pattern.pattern =
@@ -3746,12 +3750,12 @@ void tls13_read_early_data(int scenario)
                    &(client_ep.ssl), &(server_ep.ssl),
                    MBEDTLS_SSL_SERVER_HELLO), 0);
 
-    TEST_ASSERT(client_ep.ssl.early_data_status !=
-                MBEDTLS_SSL_EARLY_DATA_STATUS_NOT_SENT);
-
-    ret = write_early_data(&(client_ep.ssl), (unsigned char *) early_data,
-                           early_data_len);
-    TEST_EQUAL(ret, early_data_len);
+    if (client_ep.ssl.early_data_status !=
+        MBEDTLS_SSL_EARLY_DATA_STATUS_NOT_SENT) {
+        ret = write_early_data(&(client_ep.ssl), (unsigned char *) early_data,
+                               early_data_len);
+        TEST_EQUAL(ret, early_data_len);
+    }
 
     ret = mbedtls_test_move_handshake_to_state(
         &(server_ep.ssl), &(client_ep.ssl),
@@ -3764,6 +3768,11 @@ void tls13_read_early_data(int scenario)
             TEST_EQUAL(mbedtls_ssl_read_early_data(&(server_ep.ssl),
                                                    buf, sizeof(buf)), early_data_len);
             TEST_MEMORY_COMPARE(buf, early_data_len, early_data, early_data_len);
+            break;
+
+        case TEST_EARLY_DATA_NO_INDICATION_SENT:
+            TEST_EQUAL(ret, 0);
+            TEST_EQUAL(server_ep.ssl.handshake->early_data_accepted, 0);
             break;
 
         case TEST_EARLY_DATA_SERVER_REJECTS: /* Intentional fallthrough */

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -3895,6 +3895,11 @@ void tls13_cli_early_data_status(int scenario)
                         (ret == MBEDTLS_ERR_SSL_WANT_WRITE));
         }
 
+        if (client_ep.ssl.state != MBEDTLS_SSL_HANDSHAKE_OVER) {
+            TEST_EQUAL(mbedtls_ssl_get_early_data_status(&(client_ep.ssl)),
+                       MBEDTLS_ERR_SSL_BAD_INPUT_DATA);
+        }
+
         switch (client_ep.ssl.state) {
             case MBEDTLS_SSL_CLIENT_HELLO:
                 switch (scenario) {
@@ -4115,6 +4120,25 @@ void tls13_cli_early_data_status(int scenario)
                 TEST_FAIL("Unexpected state.");
         }
     } while (client_ep.ssl.state != MBEDTLS_SSL_HANDSHAKE_OVER);
+
+    ret = mbedtls_ssl_get_early_data_status(&(client_ep.ssl));
+    switch (scenario) {
+        case TEST_EARLY_DATA_ACCEPTED:
+            TEST_EQUAL(ret, MBEDTLS_SSL_EARLY_DATA_STATUS_ACCEPTED);
+            break;
+
+        case TEST_EARLY_DATA_NO_INDICATION_SENT:
+            TEST_EQUAL(ret, MBEDTLS_SSL_EARLY_DATA_STATUS_NOT_SENT);
+            break;
+
+        case TEST_EARLY_DATA_SERVER_REJECTS: /* Intentional fallthrough */
+        case TEST_EARLY_DATA_HRR:
+            TEST_EQUAL(ret, MBEDTLS_SSL_EARLY_DATA_STATUS_REJECTED);
+            break;
+
+        default:
+            TEST_FAIL("Unknown scenario.");
+    }
 
 #if defined(MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE)
     TEST_EQUAL(client_ep.ssl.handshake->ccs_sent, 1);

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -4110,6 +4110,9 @@ void tls13_cli_early_data_status(int scenario)
             TEST_FAIL("Unknown scenario.");
     }
 
+    ret = mbedtls_ssl_get_early_data_status(&(server_ep.ssl));
+    TEST_EQUAL(ret, MBEDTLS_ERR_SSL_BAD_INPUT_DATA);
+
 #if defined(MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE)
     TEST_EQUAL(client_ep.ssl.handshake->ccs_sent, 1);
 #endif

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -3772,6 +3772,9 @@ void tls13_early_data(int scenario)
             TEST_EQUAL(server_ep.ssl.handshake->early_data_accepted, 0);
             TEST_EQUAL(server_pattern.counter, 1);
             break;
+
+        default:
+            TEST_FAIL("Unknown scenario.");
     }
 
     TEST_EQUAL(mbedtls_test_move_handshake_to_state(
@@ -3911,6 +3914,9 @@ void tls13_cli_early_data_status(int scenario)
                                        MBEDTLS_SSL_EARLY_DATA_STATUS_REJECTED);
                         }
                         break;
+
+                    default:
+                        TEST_FAIL("Unknown scenario.");
                 }
                 break;
 
@@ -3936,6 +3942,9 @@ void tls13_cli_early_data_status(int scenario)
                                        MBEDTLS_SSL_EARLY_DATA_STATUS_REJECTED);
                         }
                         break;
+
+                    default:
+                        TEST_FAIL("Unknown scenario.");
                 }
                 break;
 
@@ -3956,6 +3965,9 @@ void tls13_cli_early_data_status(int scenario)
                         TEST_EQUAL(client_ep.ssl.early_data_status,
                                    MBEDTLS_SSL_EARLY_DATA_STATUS_REJECTED);
                         break;
+
+                    default:
+                        TEST_FAIL("Unknown scenario.");
                 }
                 break;
 
@@ -3976,6 +3988,9 @@ void tls13_cli_early_data_status(int scenario)
                         TEST_EQUAL(client_ep.ssl.early_data_status,
                                    MBEDTLS_SSL_EARLY_DATA_STATUS_REJECTED);
                         break;
+
+                    default:
+                        TEST_FAIL("Unknown scenario.");
                 }
                 break;
 
@@ -4002,6 +4017,9 @@ void tls13_cli_early_data_status(int scenario)
                         TEST_EQUAL(client_ep.ssl.early_data_status,
                                    MBEDTLS_SSL_EARLY_DATA_STATUS_REJECTED);
                         break;
+
+                    default:
+                        TEST_FAIL("Unknown scenario.");
                 }
                 break;
 
@@ -4022,12 +4040,14 @@ void tls13_cli_early_data_status(int scenario)
                         TEST_EQUAL(client_ep.ssl.early_data_status,
                                    MBEDTLS_SSL_EARLY_DATA_STATUS_REJECTED);
                         break;
+
+                    default:
+                        TEST_FAIL("Unknown scenario.");
                 }
                 break;
 
 #if defined(MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE)
             case MBEDTLS_SSL_CLIENT_CCS_AFTER_CLIENT_HELLO:
-                TEST_ASSERT(scenario != TEST_EARLY_DATA_NO_INDICATION_SENT);
                 switch (scenario) {
                     case TEST_EARLY_DATA_ACCEPTED: /* Intentional fallthrough */
                     case TEST_EARLY_DATA_SERVER_REJECTS: /* Intentional fallthrough */
@@ -4035,6 +4055,9 @@ void tls13_cli_early_data_status(int scenario)
                         TEST_EQUAL(client_ep.ssl.early_data_status,
                                    MBEDTLS_SSL_EARLY_DATA_STATUS_SENT);
                         break;
+
+                    default:
+                        TEST_FAIL("Unexpected or unknown scenario.");
                 }
                 break;
 
@@ -4045,7 +4068,6 @@ void tls13_cli_early_data_status(int scenario)
                 break;
 
             case MBEDTLS_SSL_CLIENT_CCS_AFTER_SERVER_FINISHED:
-                TEST_ASSERT(scenario != TEST_EARLY_DATA_ACCEPTED);
                 switch (scenario) {
                     case TEST_EARLY_DATA_NO_INDICATION_SENT:
                         TEST_EQUAL(client_ep.ssl.early_data_status,
@@ -4057,6 +4079,9 @@ void tls13_cli_early_data_status(int scenario)
                         TEST_EQUAL(client_ep.ssl.early_data_status,
                                    MBEDTLS_SSL_EARLY_DATA_STATUS_REJECTED);
                         break;
+
+                    default:
+                        TEST_FAIL("Unexpected or unknown scenario.");
                 }
                 break;
 #endif /* MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE */
@@ -4080,6 +4105,9 @@ void tls13_cli_early_data_status(int scenario)
                         TEST_EQUAL(client_ep.ssl.early_data_status,
                                    MBEDTLS_SSL_EARLY_DATA_STATUS_REJECTED);
                         break;
+
+                    default:
+                        TEST_FAIL("Unknown scenario.");
                 }
                 break;
 
@@ -4236,6 +4264,7 @@ void tls13_write_early_data(int scenario)
         if (scenario == TEST_EARLY_DATA_NO_INDICATION_SENT) {
             TEST_EQUAL(write_early_data_ret, MBEDTLS_ERR_SSL_CANNOT_WRITE_EARLY_DATA);
             TEST_EQUAL(client_ep.ssl.state, client_state);
+            goto reset;
         }
 
         switch (client_state) {
@@ -4258,6 +4287,9 @@ void tls13_write_early_data(int scenario)
                             TEST_EQUAL(client_ep.ssl.state, MBEDTLS_SSL_CLIENT_HELLO);
                         }
                         break;
+
+                    default:
+                        TEST_FAIL("Unknown scenario.");
                 }
                 break;
 
@@ -4279,6 +4311,9 @@ void tls13_write_early_data(int scenario)
                             TEST_EQUAL(client_ep.ssl.state, MBEDTLS_SSL_SERVER_HELLO);
                         }
                         break;
+
+                    default:
+                        TEST_FAIL("Unknown scenario.");
                 }
                 break;
 
@@ -4294,6 +4329,9 @@ void tls13_write_early_data(int scenario)
                         TEST_EQUAL(write_early_data_ret, MBEDTLS_ERR_SSL_CANNOT_WRITE_EARLY_DATA);
                         TEST_EQUAL(client_ep.ssl.state, MBEDTLS_SSL_ENCRYPTED_EXTENSIONS);
                         break;
+
+                    default:
+                        TEST_FAIL("Unknown scenario.");
                 }
                 break;
 
@@ -4313,6 +4351,9 @@ void tls13_write_early_data(int scenario)
                         TEST_EQUAL(write_early_data_ret, MBEDTLS_ERR_SSL_CANNOT_WRITE_EARLY_DATA);
                         TEST_EQUAL(client_ep.ssl.state, MBEDTLS_SSL_SERVER_FINISHED);
                         break;
+
+                    default:
+                        TEST_FAIL("Unknown scenario.");
                 }
                 break;
 
@@ -4331,6 +4372,8 @@ void tls13_write_early_data(int scenario)
                         TEST_EQUAL(write_early_data_ret, early_data_len);
                         TEST_EQUAL(client_ep.ssl.state, MBEDTLS_SSL_SERVER_HELLO);
                         break;
+                    default:
+                        TEST_FAIL("Unknown scenario.");
                 }
                 break;
 
@@ -4341,7 +4384,6 @@ void tls13_write_early_data(int scenario)
                 break;
 
             case MBEDTLS_SSL_CLIENT_CCS_AFTER_SERVER_FINISHED:
-                TEST_ASSERT(scenario != TEST_EARLY_DATA_ACCEPTED);
                 switch (scenario) {
                     case TEST_EARLY_DATA_SERVER_REJECTS: /* Intentional fallthrough */
                     case TEST_EARLY_DATA_HRR:
@@ -4350,6 +4392,8 @@ void tls13_write_early_data(int scenario)
                         TEST_EQUAL(client_ep.ssl.state,
                                    MBEDTLS_SSL_CLIENT_CCS_AFTER_SERVER_FINISHED);
                         break;
+                    default:
+                        TEST_FAIL("Unexpected or unknown scenario.");
                 }
                 break;
 #endif /* MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE */
@@ -4366,6 +4410,8 @@ void tls13_write_early_data(int scenario)
                         TEST_EQUAL(write_early_data_ret, MBEDTLS_ERR_SSL_CANNOT_WRITE_EARLY_DATA);
                         TEST_EQUAL(client_ep.ssl.state, client_state);
                         break;
+                    default:
+                        TEST_FAIL("Unknown scenario.");
                 }
                 break;
 
@@ -4373,6 +4419,7 @@ void tls13_write_early_data(int scenario)
                 TEST_FAIL("Unexpected state.");
         }
 
+reset:
         mbedtls_test_mock_socket_close(&(client_ep.socket));
         mbedtls_test_mock_socket_close(&(server_ep.socket));
 

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -4217,8 +4217,11 @@ void tls13_write_early_data(int scenario)
     TEST_EQUAL(ret, 0);
 
     /*
-     * Run handshakes and test the writing of early data in each possible
-     * state.
+     * Run handshakes going one state further in the handshake sequence at each
+     * loop up to the point where we reach the MBEDTLS_SSL_HANDSHAKE_OVER
+     * state. For each reached handshake state, check the result of the call
+     * to mbedtls_ssl_write_early_data() and then restart the handshake from
+     * scratch (see reset label).
      */
     previous_client_state = MBEDTLS_SSL_HELLO_REQUEST;
     client_state = MBEDTLS_SSL_HELLO_REQUEST;

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -18,49 +18,6 @@
 #define TEST_EARLY_DATA_SERVER_REJECTS 2
 #define TEST_EARLY_DATA_HRR 3
 
-#if (!defined(MBEDTLS_SSL_PROTO_TLS1_2)) && \
-    defined(MBEDTLS_SSL_EARLY_DATA) && defined(MBEDTLS_SSL_CLI_C) && \
-    defined(MBEDTLS_SSL_SRV_C) && defined(MBEDTLS_DEBUG_C) && \
-    defined(MBEDTLS_TEST_AT_LEAST_ONE_TLS1_3_CIPHERSUITE) && \
-    defined(MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED) && \
-    defined(MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL_ENABLED) && \
-    defined(MBEDTLS_MD_CAN_SHA256) && \
-    defined(MBEDTLS_ECP_HAVE_SECP256R1) && defined(MBEDTLS_ECP_HAVE_SECP384R1) && \
-    defined(MBEDTLS_PK_CAN_ECDSA_VERIFY) && defined(MBEDTLS_SSL_SESSION_TICKETS)
-/*
- * The implementation of the function should be based on
- * mbedtls_ssl_write_early_data() eventually. The current version aims at
- * removing the dependency on mbedtls_ssl_write_early_data() for the
- * development and testing of reading early data.
- */
-static int write_early_data(mbedtls_ssl_context *ssl,
-                            unsigned char *buf, size_t len)
-{
-    int ret = mbedtls_ssl_get_max_out_record_payload(ssl);
-
-    TEST_ASSERT(ret > 0);
-    TEST_ASSERT(len <= (size_t) ret);
-
-    ret = mbedtls_ssl_flush_output(ssl);
-    TEST_EQUAL(ret, 0);
-    TEST_EQUAL(ssl->out_left, 0);
-
-    ssl->out_msglen = len;
-    ssl->out_msgtype = MBEDTLS_SSL_MSG_APPLICATION_DATA;
-    if (len > 0) {
-        memcpy(ssl->out_msg, buf, len);
-    }
-
-    ret = mbedtls_ssl_write_record(ssl, 1);
-    TEST_EQUAL(ret, 0);
-
-    ret = len;
-
-exit:
-    return ret;
-}
-#endif
-
 /* END_HEADER */
 
 /* BEGIN_DEPENDENCIES
@@ -3750,11 +3707,15 @@ void tls13_read_early_data(int scenario)
                    &(client_ep.ssl), &(server_ep.ssl),
                    MBEDTLS_SSL_SERVER_HELLO), 0);
 
+    ret = mbedtls_ssl_write_early_data(&(client_ep.ssl),
+                                       (unsigned char *) early_data,
+                                       early_data_len);
+
     if (client_ep.ssl.early_data_status !=
         MBEDTLS_SSL_EARLY_DATA_STATUS_NOT_SENT) {
-        ret = write_early_data(&(client_ep.ssl), (unsigned char *) early_data,
-                               early_data_len);
         TEST_EQUAL(ret, early_data_len);
+    } else {
+        TEST_EQUAL(ret, MBEDTLS_ERR_SSL_CANNOT_WRITE_EARLY_DATA);
     }
 
     ret = mbedtls_test_move_handshake_to_state(

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -4147,7 +4147,8 @@ void tls13_write_early_data(int scenario)
     const char *early_data_string = "This is early data.";
     const unsigned char *early_data = (const unsigned char *) early_data_string;
     size_t early_data_len = strlen(early_data_string);
-    int write_early_data_ret;
+    int write_early_data_ret, read_early_data_ret;
+    unsigned char read_buf[64];
 
     mbedtls_platform_zeroize(&client_ep, sizeof(client_ep));
     mbedtls_platform_zeroize(&server_ep, sizeof(server_ep));
@@ -4220,8 +4221,9 @@ void tls13_write_early_data(int scenario)
      * Run handshakes going one state further in the handshake sequence at each
      * loop up to the point where we reach the MBEDTLS_SSL_HANDSHAKE_OVER
      * state. For each reached handshake state, check the result of the call
-     * to mbedtls_ssl_write_early_data() and then restart the handshake from
-     * scratch (see reset label).
+     * to mbedtls_ssl_write_early_data(), make sure we can complete the
+     * handshake successfully and then reset the connection to restart the
+     * handshake from scratch.
      */
     previous_client_state = MBEDTLS_SSL_HELLO_REQUEST;
     client_state = MBEDTLS_SSL_HELLO_REQUEST;
@@ -4267,7 +4269,7 @@ void tls13_write_early_data(int scenario)
         if (scenario == TEST_EARLY_DATA_NO_INDICATION_SENT) {
             TEST_EQUAL(write_early_data_ret, MBEDTLS_ERR_SSL_CANNOT_WRITE_EARLY_DATA);
             TEST_EQUAL(client_ep.ssl.state, client_state);
-            goto reset;
+            goto complete_handshake;
         }
 
         switch (client_state) {
@@ -4422,7 +4424,25 @@ void tls13_write_early_data(int scenario)
                 TEST_FAIL("Unexpected state.");
         }
 
-reset:
+complete_handshake:
+        do {
+            ret = mbedtls_test_move_handshake_to_state(
+                &(server_ep.ssl), &(client_ep.ssl),
+                MBEDTLS_SSL_HANDSHAKE_OVER);
+
+            if (ret == MBEDTLS_ERR_SSL_RECEIVED_EARLY_DATA) {
+                read_early_data_ret = mbedtls_ssl_read_early_data(
+                    &(server_ep.ssl), read_buf, sizeof(read_buf));
+
+                TEST_EQUAL(read_early_data_ret, early_data_len);
+            }
+        } while (ret == MBEDTLS_ERR_SSL_RECEIVED_EARLY_DATA);
+
+        TEST_EQUAL(ret, 0);
+        TEST_EQUAL(mbedtls_test_move_handshake_to_state(
+                       &(client_ep.ssl), &(server_ep.ssl),
+                       MBEDTLS_SSL_HANDSHAKE_OVER), 0);
+
         mbedtls_test_mock_socket_close(&(client_ep.socket));
         mbedtls_test_mock_socket_close(&(server_ep.socket));
 

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -3647,12 +3647,12 @@ exit:
 /* END_CASE */
 
 /*
- * The !MBEDTLS_SSL_PROTO_TLS1_2 dependency of tls13_early_data() below is
+ * The !MBEDTLS_SSL_PROTO_TLS1_2 dependency of tls13_read_early_data() below is
  * a temporary workaround to not run the test in Windows-2013 where there is
  * an issue with mbedtls_vsnprintf().
  */
 /* BEGIN_CASE depends_on:!MBEDTLS_SSL_PROTO_TLS1_2:MBEDTLS_SSL_EARLY_DATA:MBEDTLS_SSL_CLI_C:MBEDTLS_SSL_SRV_C:MBEDTLS_DEBUG_C:MBEDTLS_TEST_AT_LEAST_ONE_TLS1_3_CIPHERSUITE:MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED:MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL_ENABLED:MBEDTLS_MD_CAN_SHA256:MBEDTLS_ECP_HAVE_SECP256R1:MBEDTLS_ECP_HAVE_SECP384R1:MBEDTLS_PK_CAN_ECDSA_VERIFY:MBEDTLS_SSL_SESSION_TICKETS */
-void tls13_early_data(int scenario)
+void tls13_read_early_data(int scenario)
 {
     int ret = -1;
     unsigned char buf[64];

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -4101,3 +4101,203 @@ exit:
     PSA_DONE();
 }
 /* END_CASE */
+
+/* BEGIN_CASE depends_on:MBEDTLS_SSL_EARLY_DATA:MBEDTLS_SSL_CLI_C:MBEDTLS_SSL_SRV_C:MBEDTLS_TEST_AT_LEAST_ONE_TLS1_3_CIPHERSUITE:MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED:MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL_ENABLED:MBEDTLS_MD_CAN_SHA256:MBEDTLS_ECP_HAVE_SECP256R1:MBEDTLS_ECP_HAVE_SECP384R1:MBEDTLS_PK_CAN_ECDSA_VERIFY:MBEDTLS_SSL_SESSION_TICKETS */
+void tls13_write_early_data(int scenario)
+{
+    int ret = -1;
+    mbedtls_test_ssl_endpoint client_ep, server_ep;
+    mbedtls_test_handshake_test_options client_options;
+    mbedtls_test_handshake_test_options server_options;
+    mbedtls_ssl_session saved_session;
+
+    int client_state, previous_client_state;
+    const char *early_data_string = "This is early data.";
+    const unsigned char *early_data = (const unsigned char *) early_data_string;
+    size_t early_data_len = strlen(early_data_string);
+    int write_early_data_ret;
+
+    mbedtls_platform_zeroize(&client_ep, sizeof(client_ep));
+    mbedtls_platform_zeroize(&server_ep, sizeof(server_ep));
+    mbedtls_test_init_handshake_options(&client_options);
+    mbedtls_test_init_handshake_options(&server_options);
+    mbedtls_ssl_session_init(&saved_session);
+
+    PSA_INIT();
+
+    /*
+     * Run first handshake to get a ticket from the server.
+     */
+    client_options.pk_alg = MBEDTLS_PK_ECDSA;
+    client_options.early_data = MBEDTLS_SSL_EARLY_DATA_ENABLED;
+    server_options.pk_alg = MBEDTLS_PK_ECDSA;
+    server_options.early_data = MBEDTLS_SSL_EARLY_DATA_ENABLED;
+
+    ret = mbedtls_test_get_tls13_ticket(&client_options, &server_options,
+                                        &saved_session);
+    TEST_EQUAL(ret, 0);
+
+
+    /*
+     * Prepare for handshake with the ticket.
+     */
+    switch (scenario) {
+        case TEST_EARLY_DATA_ACCEPTED:
+            break;
+
+        default:
+            TEST_FAIL("Unknown scenario.");
+    }
+
+    ret = mbedtls_test_ssl_endpoint_init(&client_ep, MBEDTLS_SSL_IS_CLIENT,
+                                         &client_options, NULL, NULL, NULL);
+    TEST_EQUAL(ret, 0);
+
+    ret = mbedtls_test_ssl_endpoint_init(&server_ep, MBEDTLS_SSL_IS_SERVER,
+                                         &server_options, NULL, NULL, NULL);
+    TEST_EQUAL(ret, 0);
+
+    mbedtls_ssl_conf_session_tickets_cb(&server_ep.conf,
+                                        mbedtls_test_ticket_write,
+                                        mbedtls_test_ticket_parse,
+                                        NULL);
+
+    ret = mbedtls_test_mock_socket_connect(&(client_ep.socket),
+                                           &(server_ep.socket), 1024);
+    TEST_EQUAL(ret, 0);
+
+    ret = mbedtls_ssl_set_session(&(client_ep.ssl), &saved_session);
+    TEST_EQUAL(ret, 0);
+
+    /*
+     * Run handshakes and test the writing of early data in each possible
+     * state.
+     */
+    previous_client_state = MBEDTLS_SSL_HELLO_REQUEST;
+    client_state = MBEDTLS_SSL_HELLO_REQUEST;
+
+    while (client_state != MBEDTLS_SSL_HANDSHAKE_OVER) {
+        TEST_EQUAL(mbedtls_test_move_handshake_to_state(
+                       &(client_ep.ssl), &(server_ep.ssl),
+                       previous_client_state), 0);
+
+        /* Progress the handshake from at least one state */
+        while (client_ep.ssl.state == previous_client_state) {
+            ret = mbedtls_ssl_handshake_step(&(client_ep.ssl));
+            TEST_ASSERT((ret == 0) ||
+                        (ret == MBEDTLS_ERR_SSL_WANT_READ) ||
+                        (ret == MBEDTLS_ERR_SSL_WANT_WRITE));
+            if (client_ep.ssl.state != previous_client_state) {
+                break;
+            }
+            ret = mbedtls_ssl_handshake_step(&(server_ep.ssl));
+            TEST_ASSERT((ret == 0) ||
+                        (ret == MBEDTLS_ERR_SSL_WANT_READ) ||
+                        (ret == MBEDTLS_ERR_SSL_WANT_WRITE));
+        }
+
+        client_state = client_ep.ssl.state;
+        write_early_data_ret = mbedtls_ssl_write_early_data(&(client_ep.ssl),
+                                                            early_data,
+                                                            early_data_len);
+
+        switch (client_state) {
+            case MBEDTLS_SSL_CLIENT_HELLO:
+                switch (scenario) {
+                    case TEST_EARLY_DATA_ACCEPTED:
+                        TEST_EQUAL(write_early_data_ret, early_data_len);
+                        TEST_EQUAL(client_ep.ssl.state, MBEDTLS_SSL_SERVER_HELLO);
+                        break;
+                }
+                break;
+
+            case MBEDTLS_SSL_SERVER_HELLO:
+                switch (scenario) {
+                    case TEST_EARLY_DATA_ACCEPTED:
+                        TEST_EQUAL(write_early_data_ret, early_data_len);
+                        TEST_EQUAL(client_ep.ssl.state, MBEDTLS_SSL_SERVER_HELLO);
+                        break;
+                }
+                break;
+
+            case MBEDTLS_SSL_ENCRYPTED_EXTENSIONS:
+                switch (scenario) {
+                    case TEST_EARLY_DATA_ACCEPTED:
+                        TEST_EQUAL(write_early_data_ret, early_data_len);
+                        TEST_EQUAL(client_ep.ssl.state, MBEDTLS_SSL_ENCRYPTED_EXTENSIONS);
+                        break;
+                }
+                break;
+
+            case MBEDTLS_SSL_SERVER_FINISHED:
+                switch (scenario) {
+                    case TEST_EARLY_DATA_ACCEPTED:
+                        TEST_EQUAL(write_early_data_ret, early_data_len);
+                        TEST_EQUAL(client_ep.ssl.state, MBEDTLS_SSL_SERVER_FINISHED);
+                        break;
+                }
+                break;
+
+            case MBEDTLS_SSL_END_OF_EARLY_DATA:
+                TEST_EQUAL(scenario, TEST_EARLY_DATA_ACCEPTED);
+                TEST_EQUAL(write_early_data_ret, MBEDTLS_ERR_SSL_CANNOT_WRITE_EARLY_DATA);
+                TEST_EQUAL(client_ep.ssl.state, MBEDTLS_SSL_END_OF_EARLY_DATA);
+                break;
+
+#if defined(MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE)
+            case MBEDTLS_SSL_CLIENT_CCS_AFTER_CLIENT_HELLO:
+                switch (scenario) {
+                    case TEST_EARLY_DATA_ACCEPTED:
+                        TEST_EQUAL(write_early_data_ret, early_data_len);
+                        TEST_EQUAL(client_ep.ssl.state, MBEDTLS_SSL_SERVER_HELLO);
+                        break;
+                }
+                break;
+
+#endif /* MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE */
+
+            case MBEDTLS_SSL_CLIENT_CERTIFICATE: /* Intentional fallthrough */
+            case MBEDTLS_SSL_CLIENT_FINISHED: /* Intentional fallthrough */
+            case MBEDTLS_SSL_FLUSH_BUFFERS: /* Intentional fallthrough */
+            case MBEDTLS_SSL_HANDSHAKE_WRAPUP: /* Intentional fallthrough */
+            case MBEDTLS_SSL_HANDSHAKE_OVER:
+                switch (scenario) {
+                    case TEST_EARLY_DATA_ACCEPTED:
+                        TEST_EQUAL(write_early_data_ret, MBEDTLS_ERR_SSL_CANNOT_WRITE_EARLY_DATA);
+                        TEST_EQUAL(client_ep.ssl.state, client_state);
+                        break;
+                }
+                break;
+
+            default:
+                TEST_FAIL("Unexpected state.");
+        }
+
+        mbedtls_test_mock_socket_close(&(client_ep.socket));
+        mbedtls_test_mock_socket_close(&(server_ep.socket));
+
+        ret = mbedtls_ssl_session_reset(&(client_ep.ssl));
+        TEST_EQUAL(ret, 0);
+
+        ret = mbedtls_ssl_set_session(&(client_ep.ssl), &saved_session);
+        TEST_EQUAL(ret, 0);
+
+        ret = mbedtls_ssl_session_reset(&(server_ep.ssl));
+        TEST_EQUAL(ret, 0);
+
+        ret = mbedtls_test_mock_socket_connect(&(client_ep.socket),
+                                               &(server_ep.socket), 1024);
+        TEST_EQUAL(ret, 0);
+
+        previous_client_state = client_state;
+    }
+
+exit:
+    mbedtls_test_ssl_endpoint_free(&client_ep, NULL);
+    mbedtls_test_ssl_endpoint_free(&server_ep, NULL);
+    mbedtls_test_free_handshake_options(&client_options);
+    mbedtls_test_free_handshake_options(&server_options);
+    mbedtls_ssl_session_free(&saved_session);
+    PSA_DONE();
+}
+/* END_CASE */

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -4145,6 +4145,10 @@ void tls13_write_early_data(int scenario)
         case TEST_EARLY_DATA_ACCEPTED:
             break;
 
+        case TEST_EARLY_DATA_NO_INDICATION_SENT:
+            client_options.early_data = MBEDTLS_SSL_EARLY_DATA_DISABLED;
+            break;
+
         default:
             TEST_FAIL("Unknown scenario.");
     }
@@ -4200,6 +4204,11 @@ void tls13_write_early_data(int scenario)
         write_early_data_ret = mbedtls_ssl_write_early_data(&(client_ep.ssl),
                                                             early_data,
                                                             early_data_len);
+
+        if (scenario == TEST_EARLY_DATA_NO_INDICATION_SENT) {
+            TEST_EQUAL(write_early_data_ret, MBEDTLS_ERR_SSL_CANNOT_WRITE_EARLY_DATA);
+            TEST_EQUAL(client_ep.ssl.state, client_state);
+        }
 
         switch (client_state) {
             case MBEDTLS_SSL_CLIENT_HELLO:

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -4110,7 +4110,12 @@ void tls13_write_early_data(int scenario)
     mbedtls_test_handshake_test_options client_options;
     mbedtls_test_handshake_test_options server_options;
     mbedtls_ssl_session saved_session;
-    int client_state, previous_client_state;
+    uint16_t group_list[3] = {
+        MBEDTLS_SSL_IANA_TLS_GROUP_SECP256R1,
+        MBEDTLS_SSL_IANA_TLS_GROUP_SECP384R1,
+        MBEDTLS_SSL_IANA_TLS_GROUP_NONE
+    };
+    int client_state, previous_client_state, beyond_first_hello = 0;
     const char *early_data_string = "This is early data.";
     const unsigned char *early_data = (const unsigned char *) early_data_string;
     size_t early_data_len = strlen(early_data_string);
@@ -4131,11 +4136,14 @@ void tls13_write_early_data(int scenario)
     client_options.early_data = MBEDTLS_SSL_EARLY_DATA_ENABLED;
     server_options.pk_alg = MBEDTLS_PK_ECDSA;
     server_options.early_data = MBEDTLS_SSL_EARLY_DATA_ENABLED;
+    if (scenario == TEST_EARLY_DATA_HRR) {
+        client_options.group_list = group_list;
+        server_options.group_list = group_list;
+    }
 
     ret = mbedtls_test_get_tls13_ticket(&client_options, &server_options,
                                         &saved_session);
     TEST_EQUAL(ret, 0);
-
 
     /*
      * Prepare for handshake with the ticket.
@@ -4150,6 +4158,10 @@ void tls13_write_early_data(int scenario)
 
         case TEST_EARLY_DATA_SERVER_REJECTS:
             server_options.early_data = MBEDTLS_SSL_EARLY_DATA_DISABLED;
+            break;
+
+        case TEST_EARLY_DATA_HRR:
+            server_options.group_list = group_list + 1;
             break;
 
         default:
@@ -4184,6 +4196,19 @@ void tls13_write_early_data(int scenario)
     client_state = MBEDTLS_SSL_HELLO_REQUEST;
 
     while (client_state != MBEDTLS_SSL_HANDSHAKE_OVER) {
+        /* In case of HRR scenario, once we have been through it, move over
+         * the first ClientHello and ServerHello otherwise we just keep playing
+         * this first part of the handshake with HRR.
+         */
+        if ((scenario == TEST_EARLY_DATA_HRR) && (beyond_first_hello)) {
+            TEST_ASSERT(mbedtls_test_move_handshake_to_state(
+                            &(client_ep.ssl), &(server_ep.ssl),
+                            MBEDTLS_SSL_SERVER_HELLO) == 0);
+            TEST_ASSERT(mbedtls_test_move_handshake_to_state(
+                            &(client_ep.ssl), &(server_ep.ssl),
+                            MBEDTLS_SSL_CLIENT_HELLO) == 0);
+        }
+
         TEST_EQUAL(mbedtls_test_move_handshake_to_state(
                        &(client_ep.ssl), &(server_ep.ssl),
                        previous_client_state), 0);
@@ -4221,6 +4246,18 @@ void tls13_write_early_data(int scenario)
                         TEST_EQUAL(write_early_data_ret, early_data_len);
                         TEST_EQUAL(client_ep.ssl.state, MBEDTLS_SSL_SERVER_HELLO);
                         break;
+
+                    case TEST_EARLY_DATA_HRR:
+                        if (client_ep.ssl.handshake->hello_retry_request_count == 0) {
+                            TEST_EQUAL(write_early_data_ret, early_data_len);
+                            TEST_EQUAL(client_ep.ssl.state, MBEDTLS_SSL_SERVER_HELLO);
+                        } else {
+                            beyond_first_hello = 1;
+                            TEST_EQUAL(write_early_data_ret,
+                                       MBEDTLS_ERR_SSL_CANNOT_WRITE_EARLY_DATA);
+                            TEST_EQUAL(client_ep.ssl.state, MBEDTLS_SSL_CLIENT_HELLO);
+                        }
+                        break;
                 }
                 break;
 
@@ -4231,6 +4268,17 @@ void tls13_write_early_data(int scenario)
                         TEST_EQUAL(write_early_data_ret, early_data_len);
                         TEST_EQUAL(client_ep.ssl.state, MBEDTLS_SSL_SERVER_HELLO);
                         break;
+
+                    case TEST_EARLY_DATA_HRR:
+                        if (client_ep.ssl.handshake->hello_retry_request_count == 0) {
+                            TEST_EQUAL(write_early_data_ret, early_data_len);
+                            TEST_EQUAL(client_ep.ssl.state, MBEDTLS_SSL_SERVER_HELLO);
+                        } else {
+                            TEST_EQUAL(write_early_data_ret,
+                                       MBEDTLS_ERR_SSL_CANNOT_WRITE_EARLY_DATA);
+                            TEST_EQUAL(client_ep.ssl.state, MBEDTLS_SSL_SERVER_HELLO);
+                        }
+                        break;
                 }
                 break;
 
@@ -4239,6 +4287,11 @@ void tls13_write_early_data(int scenario)
                     case TEST_EARLY_DATA_ACCEPTED: /* Intentional fallthrough */
                     case TEST_EARLY_DATA_SERVER_REJECTS:
                         TEST_EQUAL(write_early_data_ret, early_data_len);
+                        TEST_EQUAL(client_ep.ssl.state, MBEDTLS_SSL_ENCRYPTED_EXTENSIONS);
+                        break;
+
+                    case TEST_EARLY_DATA_HRR:
+                        TEST_EQUAL(write_early_data_ret, MBEDTLS_ERR_SSL_CANNOT_WRITE_EARLY_DATA);
                         TEST_EQUAL(client_ep.ssl.state, MBEDTLS_SSL_ENCRYPTED_EXTENSIONS);
                         break;
                 }
@@ -4255,6 +4308,11 @@ void tls13_write_early_data(int scenario)
                         TEST_EQUAL(write_early_data_ret, MBEDTLS_ERR_SSL_CANNOT_WRITE_EARLY_DATA);
                         TEST_EQUAL(client_ep.ssl.state, MBEDTLS_SSL_SERVER_FINISHED);
                         break;
+
+                    case TEST_EARLY_DATA_HRR:
+                        TEST_EQUAL(write_early_data_ret, MBEDTLS_ERR_SSL_CANNOT_WRITE_EARLY_DATA);
+                        TEST_EQUAL(client_ep.ssl.state, MBEDTLS_SSL_SERVER_FINISHED);
+                        break;
                 }
                 break;
 
@@ -4268,19 +4326,29 @@ void tls13_write_early_data(int scenario)
             case MBEDTLS_SSL_CLIENT_CCS_AFTER_CLIENT_HELLO:
                 switch (scenario) {
                     case TEST_EARLY_DATA_ACCEPTED: /* Intentional fallthrough */
-                    case TEST_EARLY_DATA_SERVER_REJECTS:
+                    case TEST_EARLY_DATA_SERVER_REJECTS: /* Intentional fallthrough */
+                    case TEST_EARLY_DATA_HRR:
                         TEST_EQUAL(write_early_data_ret, early_data_len);
                         TEST_EQUAL(client_ep.ssl.state, MBEDTLS_SSL_SERVER_HELLO);
                         break;
                 }
                 break;
 
+            case MBEDTLS_SSL_CLIENT_CCS_BEFORE_2ND_CLIENT_HELLO:
+                TEST_EQUAL(scenario, TEST_EARLY_DATA_HRR);
+                TEST_EQUAL(write_early_data_ret, MBEDTLS_ERR_SSL_CANNOT_WRITE_EARLY_DATA);
+                TEST_EQUAL(client_ep.ssl.state, MBEDTLS_SSL_CLIENT_CCS_BEFORE_2ND_CLIENT_HELLO);
+                break;
+
             case MBEDTLS_SSL_CLIENT_CCS_AFTER_SERVER_FINISHED:
                 TEST_ASSERT(scenario != TEST_EARLY_DATA_ACCEPTED);
                 switch (scenario) {
-                    case TEST_EARLY_DATA_SERVER_REJECTS:
-                        TEST_EQUAL(write_early_data_ret, MBEDTLS_ERR_SSL_CANNOT_WRITE_EARLY_DATA);
-                        TEST_EQUAL(client_ep.ssl.state, MBEDTLS_SSL_CLIENT_CCS_AFTER_SERVER_FINISHED);
+                    case TEST_EARLY_DATA_SERVER_REJECTS: /* Intentional fallthrough */
+                    case TEST_EARLY_DATA_HRR:
+                        TEST_EQUAL(write_early_data_ret,
+                                   MBEDTLS_ERR_SSL_CANNOT_WRITE_EARLY_DATA);
+                        TEST_EQUAL(client_ep.ssl.state,
+                                   MBEDTLS_SSL_CLIENT_CCS_AFTER_SERVER_FINISHED);
                         break;
                 }
                 break;
@@ -4293,7 +4361,8 @@ void tls13_write_early_data(int scenario)
             case MBEDTLS_SSL_HANDSHAKE_OVER:
                 switch (scenario) {
                     case TEST_EARLY_DATA_ACCEPTED: /* Intentional fallthrough */
-                    case TEST_EARLY_DATA_SERVER_REJECTS:
+                    case TEST_EARLY_DATA_SERVER_REJECTS: /* Intentional fallthrough */
+                    case TEST_EARLY_DATA_HRR:
                         TEST_EQUAL(write_early_data_ret, MBEDTLS_ERR_SSL_CANNOT_WRITE_EARLY_DATA);
                         TEST_EQUAL(client_ep.ssl.state, client_state);
                         break;

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -4110,7 +4110,6 @@ void tls13_write_early_data(int scenario)
     mbedtls_test_handshake_test_options client_options;
     mbedtls_test_handshake_test_options server_options;
     mbedtls_ssl_session saved_session;
-
     int client_state, previous_client_state;
     const char *early_data_string = "This is early data.";
     const unsigned char *early_data = (const unsigned char *) early_data_string;
@@ -4147,6 +4146,10 @@ void tls13_write_early_data(int scenario)
 
         case TEST_EARLY_DATA_NO_INDICATION_SENT:
             client_options.early_data = MBEDTLS_SSL_EARLY_DATA_DISABLED;
+            break;
+
+        case TEST_EARLY_DATA_SERVER_REJECTS:
+            server_options.early_data = MBEDTLS_SSL_EARLY_DATA_DISABLED;
             break;
 
         default:
@@ -4213,7 +4216,8 @@ void tls13_write_early_data(int scenario)
         switch (client_state) {
             case MBEDTLS_SSL_CLIENT_HELLO:
                 switch (scenario) {
-                    case TEST_EARLY_DATA_ACCEPTED:
+                    case TEST_EARLY_DATA_ACCEPTED: /* Intentional fallthrough */
+                    case TEST_EARLY_DATA_SERVER_REJECTS:
                         TEST_EQUAL(write_early_data_ret, early_data_len);
                         TEST_EQUAL(client_ep.ssl.state, MBEDTLS_SSL_SERVER_HELLO);
                         break;
@@ -4222,7 +4226,8 @@ void tls13_write_early_data(int scenario)
 
             case MBEDTLS_SSL_SERVER_HELLO:
                 switch (scenario) {
-                    case TEST_EARLY_DATA_ACCEPTED:
+                    case TEST_EARLY_DATA_ACCEPTED: /* Intentional fallthrough */
+                    case TEST_EARLY_DATA_SERVER_REJECTS:
                         TEST_EQUAL(write_early_data_ret, early_data_len);
                         TEST_EQUAL(client_ep.ssl.state, MBEDTLS_SSL_SERVER_HELLO);
                         break;
@@ -4231,7 +4236,8 @@ void tls13_write_early_data(int scenario)
 
             case MBEDTLS_SSL_ENCRYPTED_EXTENSIONS:
                 switch (scenario) {
-                    case TEST_EARLY_DATA_ACCEPTED:
+                    case TEST_EARLY_DATA_ACCEPTED: /* Intentional fallthrough */
+                    case TEST_EARLY_DATA_SERVER_REJECTS:
                         TEST_EQUAL(write_early_data_ret, early_data_len);
                         TEST_EQUAL(client_ep.ssl.state, MBEDTLS_SSL_ENCRYPTED_EXTENSIONS);
                         break;
@@ -4242,6 +4248,11 @@ void tls13_write_early_data(int scenario)
                 switch (scenario) {
                     case TEST_EARLY_DATA_ACCEPTED:
                         TEST_EQUAL(write_early_data_ret, early_data_len);
+                        TEST_EQUAL(client_ep.ssl.state, MBEDTLS_SSL_SERVER_FINISHED);
+                        break;
+
+                    case TEST_EARLY_DATA_SERVER_REJECTS:
+                        TEST_EQUAL(write_early_data_ret, MBEDTLS_ERR_SSL_CANNOT_WRITE_EARLY_DATA);
                         TEST_EQUAL(client_ep.ssl.state, MBEDTLS_SSL_SERVER_FINISHED);
                         break;
                 }
@@ -4256,13 +4267,23 @@ void tls13_write_early_data(int scenario)
 #if defined(MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE)
             case MBEDTLS_SSL_CLIENT_CCS_AFTER_CLIENT_HELLO:
                 switch (scenario) {
-                    case TEST_EARLY_DATA_ACCEPTED:
+                    case TEST_EARLY_DATA_ACCEPTED: /* Intentional fallthrough */
+                    case TEST_EARLY_DATA_SERVER_REJECTS:
                         TEST_EQUAL(write_early_data_ret, early_data_len);
                         TEST_EQUAL(client_ep.ssl.state, MBEDTLS_SSL_SERVER_HELLO);
                         break;
                 }
                 break;
 
+            case MBEDTLS_SSL_CLIENT_CCS_AFTER_SERVER_FINISHED:
+                TEST_ASSERT(scenario != TEST_EARLY_DATA_ACCEPTED);
+                switch (scenario) {
+                    case TEST_EARLY_DATA_SERVER_REJECTS:
+                        TEST_EQUAL(write_early_data_ret, MBEDTLS_ERR_SSL_CANNOT_WRITE_EARLY_DATA);
+                        TEST_EQUAL(client_ep.ssl.state, MBEDTLS_SSL_CLIENT_CCS_AFTER_SERVER_FINISHED);
+                        break;
+                }
+                break;
 #endif /* MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE */
 
             case MBEDTLS_SSL_CLIENT_CERTIFICATE: /* Intentional fallthrough */
@@ -4271,7 +4292,8 @@ void tls13_write_early_data(int scenario)
             case MBEDTLS_SSL_HANDSHAKE_WRAPUP: /* Intentional fallthrough */
             case MBEDTLS_SSL_HANDSHAKE_OVER:
                 switch (scenario) {
-                    case TEST_EARLY_DATA_ACCEPTED:
+                    case TEST_EARLY_DATA_ACCEPTED: /* Intentional fallthrough */
+                    case TEST_EARLY_DATA_SERVER_REJECTS:
                         TEST_EQUAL(write_early_data_ret, MBEDTLS_ERR_SSL_CANNOT_WRITE_EARLY_DATA);
                         TEST_EQUAL(client_ep.ssl.state, client_state);
                         break;


### PR DESCRIPTION
## Description
Second PR of two addressing #6340 .

## PR checklist
- [x] **changelog** not required, will add one for TLS 1.3 early data feature as a whole
- [x] **backport** not required, new feature
- [x] **tests** provided