### PR TITLE
Make key destruction thread safe

### DIFF
--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -198,6 +198,8 @@ psa_status_t mbedtls_psa_register_se_key(
  *
  * This function clears all data associated with the PSA layer,
  * including the whole key store.
+ * This function is not thread safe, it wipes every key slot regardless of
+ * state and reader count. It should only be called when no slot is in use.
  *
  * This is an Mbed TLS extension.
  */

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -1072,6 +1072,10 @@ psa_status_t psa_destroy_key(mbedtls_svc_key_id_t key)
     }
 
 #if defined(MBEDTLS_THREADING_C)
+    /* We cannot unlock between setting the state to PENDING_DELETION
+     * and destroying the key in storage, as otherwise another thread
+     * could load the key into a new slot and the key will not be
+     * fully destroyed. */
     PSA_THREADING_CHK_GOTO_EXIT(mbedtls_mutex_lock(
                                     &mbedtls_threading_key_slot_mutex));
 #endif

--- a/library/psa_crypto_slot_management.c
+++ b/library/psa_crypto_slot_management.c
@@ -529,6 +529,9 @@ psa_status_t psa_close_key(psa_key_handle_t handle)
     }
 
 #if defined(MBEDTLS_THREADING_C)
+    /* We need to set status as success, otherwise CORRUPTION_DETECTED
+     * would be returned if the lock fails. */
+    status = PSA_SUCCESS;
     PSA_THREADING_CHK_RET(mbedtls_mutex_lock(
                               &mbedtls_threading_key_slot_mutex));
 #endif
@@ -563,6 +566,9 @@ psa_status_t psa_purge_key(mbedtls_svc_key_id_t key)
     psa_key_slot_t *slot;
 
 #if defined(MBEDTLS_THREADING_C)
+    /* We need to set status as success, otherwise CORRUPTION_DETECTED
+     * would be returned if the lock fails. */
+    status = PSA_SUCCESS;
     PSA_THREADING_CHK_RET(mbedtls_mutex_lock(
                               &mbedtls_threading_key_slot_mutex));
 #endif

--- a/library/psa_crypto_slot_management.c
+++ b/library/psa_crypto_slot_management.c
@@ -536,11 +536,22 @@ psa_status_t psa_close_key(psa_key_handle_t handle)
 
         return status;
     }
+
+#if defined(MBEDTLS_THREADING_C)
+    PSA_THREADING_CHK_RET(mbedtls_mutex_lock(
+                              &mbedtls_threading_key_slot_mutex));
+#endif
     if (slot->registered_readers == 1) {
-        return psa_wipe_key_slot(slot);
+        status = psa_wipe_key_slot(slot);
     } else {
-        return psa_unregister_read(slot);
+        status = psa_unregister_read(slot);
     }
+#if defined(MBEDTLS_THREADING_C)
+    PSA_THREADING_CHK_RET(mbedtls_mutex_unlock(
+                              &mbedtls_threading_key_slot_mutex));
+#endif
+
+    return status;
 }
 
 psa_status_t psa_purge_key(mbedtls_svc_key_id_t key)

--- a/library/psa_crypto_slot_management.c
+++ b/library/psa_crypto_slot_management.c
@@ -144,6 +144,9 @@ void psa_wipe_all_key_slots(void)
 {
     size_t slot_idx;
 
+#if defined(MBEDTLS_THREADING_C)
+    mbedtls_mutex_lock(&mbedtls_threading_key_slot_mutex);
+#endif
     for (slot_idx = 0; slot_idx < MBEDTLS_PSA_KEY_SLOT_COUNT; slot_idx++) {
         psa_key_slot_t *slot = &global_data.key_slots[slot_idx];
         slot->registered_readers = 1;
@@ -151,6 +154,9 @@ void psa_wipe_all_key_slots(void)
         (void) psa_wipe_key_slot(slot);
     }
     global_data.key_slots_initialized = 0;
+#if defined(MBEDTLS_THREADING_C)
+    mbedtls_mutex_unlock(&mbedtls_threading_key_slot_mutex);
+#endif
 }
 
 psa_status_t psa_reserve_free_key_slot(psa_key_id_t *volatile_key_id,

--- a/library/psa_crypto_slot_management.c
+++ b/library/psa_crypto_slot_management.c
@@ -144,9 +144,6 @@ void psa_wipe_all_key_slots(void)
 {
     size_t slot_idx;
 
-#if defined(MBEDTLS_THREADING_C)
-    mbedtls_mutex_lock(&mbedtls_threading_key_slot_mutex);
-#endif
     for (slot_idx = 0; slot_idx < MBEDTLS_PSA_KEY_SLOT_COUNT; slot_idx++) {
         psa_key_slot_t *slot = &global_data.key_slots[slot_idx];
         slot->registered_readers = 1;
@@ -154,9 +151,6 @@ void psa_wipe_all_key_slots(void)
         (void) psa_wipe_key_slot(slot);
     }
     global_data.key_slots_initialized = 0;
-#if defined(MBEDTLS_THREADING_C)
-    mbedtls_mutex_unlock(&mbedtls_threading_key_slot_mutex);
-#endif
 }
 
 psa_status_t psa_reserve_free_key_slot(psa_key_id_t *volatile_key_id,

--- a/library/psa_crypto_slot_management.h
+++ b/library/psa_crypto_slot_management.h
@@ -92,6 +92,8 @@ psa_status_t psa_get_and_lock_key_slot(mbedtls_svc_key_id_t key,
 psa_status_t psa_initialize_key_slots(void);
 
 /** Delete all data from key slots in memory.
+ * This function is not thread safe, it wipes every key slot regardless of
+ * state and reader count. It should only be called when no slot is in use.
  *
  * This does not affect persistent storage. */
 void psa_wipe_all_key_slots(void);


### PR DESCRIPTION
## Description
Make functions which transition the state of key slots from PSA_SLOT_FULL to PSA_SLOT_EMPTY thread safe. Make our implementation of the [PSA key destruction API](https://arm-software.github.io/psa-api/crypto/1.1/api/keys/management.html#key-destruction) thread safe. Resolves #8677.

The work of this PR and the issues #8675, #8676 and #8412 is to ensure that API calls are linearizable and correct. To do this we rely on some properties, these properties need to be enforced. The relevant properties are:

- All calls to `psa_register_read`, `psa_unregister_read`, `psa_key_slot_state_transition`, `psa_wipe_key_slot` and `psa_key_slot_has_readers` are performed under the global mutex.
- Every API call has at most one point in time where effects are made visible to other threads. By effects here we mean something like a key being created and now existing in the eyes of other threads, or a key being destroyed. We do not need to consider resource constraints here.
- Any function which iterates through key slots or finds a key slot containing X ignores all slots in the FILLING or PENDING_DELETION state. Whoever sets a slot to FILLING directly or via `psa_reserve_free_key_slot` has exclusive access to the slot. A slot in PENDING_DELETION can only be read by the registered readers, and must be wiped upon the final reader unregistering.
- If a slot in the FULL state has more than 1 registered reader then it cannot be wiped (with the exception of a call to `mbedtls_psa_cypto_free`, a non-threadsafe function).
- No key can be in multiple FULL slots at the same time, each FULL slot must hold a unique key ID.
- Other threads running other API calls mustn't interfere in a destructive way.

(See the [thread safety document](https://github.com/Mbed-TLS/mbedtls/blob/development/docs/architecture/psa-thread-safety/psa-thread-safety.md) for more details.) This PR must make the key destruction functions enforce these properties. It also documents the non-thread safety of `mbedtls_psa_crypto_free` and `psa_wipe_all_key_slots`.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required for individual tasks on this epic
- [x] **backport** not required
- [x] **tests** To be added in #8420

