### PR TITLE
SHA-256 and 512 support for old libc

### DIFF
--- a/ChangeLog.d/linux-aarch64-hwcap.txt
+++ b/ChangeLog.d/linux-aarch64-hwcap.txt
@@ -1,0 +1,4 @@
+Bugfix
+   * On Linux on ARMv8, fix a build error with SHA-256 and SHA-512
+     acceleration detection when the libc headers do not define the
+     corresponding constant. Reported by valord577.

--- a/library/sha512.c
+++ b/library/sha512.c
@@ -102,6 +102,14 @@
 #      if defined(__linux__)
 /* Our preferred method of detection is getauxval() */
 #        include <sys/auxv.h>
+#        if !defined(HWCAP_SHA512)
+/* The same header that declares getauxval() should provide the HWCAP_xxx
+ * constants to analyze its return value. However, the libc may be too
+ * old to have the constant that we need. So if it's missing, assume that
+ * the value is the same one used by the Linux kernel ABI.
+ */
+#          define HWCAP_SHA512 (1 << 21)
+#        endif
 #      endif
 /* Use SIGILL on Unix, and fall back to it on Linux */
 #      include <signal.h>


### PR DESCRIPTION
## Description

Pick up the changelog from #7121 .

7121 was closed because the SHA-256 changes were already done, but in preparing this I noticed that we didn't have a fix for SHA-512, so I've added that here (following the existing pattern in `sha256.c`, rather than in 7121).

Tested locally: builds correctly and enables hw acceleration where appropriate for all combinations of `MBEDTLS_SHA512_USE_A64_CRYPTO_ONLY` and `MBEDTLS_SHA512_USE_A64_CRYPTO_IF_PRESENT`, for aarch64. Also tested on x86_64 and armv8 Thumb 2 and behaves as expected there (not enabled).

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** provided
- [x] **backport** not required - hw acceleration for SHA-256 and SHA-512 not in 2.28
- [x] **tests** not required - covered by existing