### PR TITLE
PK-PSA bridge design: symmetric

### DIFF
--- a/docs/architecture/psa-migration/psa-legacy-bridges.md
+++ b/docs/architecture/psa-migration/psa-legacy-bridges.md
@@ -113,7 +113,23 @@ The legacy API does not have a unified interface for key derivation. It has an H
 
 ### Random generation gap analysis
 
-[TODO]
+#### Random generation interfaces
+
+Most applications using the legacy crypto API instantiate an entropy context and a DRBG context (either CTR\_DRBG or HMAC\_DRBG) to obtain random byte strings and to pass a random generator (`f_rng, p_rng`) to functions that require one.
+
+PSA has its own random generation internally. By default, it is based on the same configuration of entropy sources as the legacy API. As a consequence, typical applications to not need to take any explicit steps to transition to PSA.
+
+Applications that transition to PSA may wish to take advantage of its random generator even if they call functions that expect a random generator with the legacy `f_rng, p_rng` interface. This is already implemented through `mbedtls_psa_get_random()`.
+
+The legacy API allows applications to provide their own implementation of the RNG interface. Such a feature was deliberately not included in the PSA API due to the low use in our target space and high cost in implementation complexity and risk of misconfiguration.
+
+#### Entropy sources
+
+As of Mbed TLS 3.6, the PSA subsystem uses the same entropy sources as the legacy module (unless explicitly configured otherwise). As a consequence, there is no transition to help with regarding entropy sources.
+
+#### Deterministic random generation
+
+The legacy API includes interfaces for two deterministic random generator families: CTR\_DRBG and HMAC\_DRBG. There is no corresponding PSA interface. (One is under discussion as of early 2024, but it will not be finalized until well after Mbed TLS 3.6 is released.) As a consequence, there is no transition to help with regarding DRBG interfaces.
 
 ### Asymmetric cryptography gap analysis
 
@@ -234,7 +250,7 @@ Based on the [gap analysis](#key-derivation-gap-analysis): nothing to do.
 
 ### Random generation APIs
 
-[TODO]
+Based on the [gap analysis](#random-generation-gap-analysis): nothing to do.
 
 ### Asymmetric cryptography APIs
 

--- a/docs/architecture/psa-migration/psa-legacy-bridges.md
+++ b/docs/architecture/psa-migration/psa-legacy-bridges.md
@@ -109,7 +109,7 @@ MAC do not have any nontrivial format for keys or outputs, so there is no need f
 
 ### Key derivation gap analysis
 
-[TODO]
+The legacy API does not have a unified interface for key derivation. It has an HKDF interface, an interface for PBKDF2 (`mbedtls_pkcs5_pbkdf2_hmac`), and an interface for the long-deprecated PKCS#12 password-based key derivation (`mbedtls_pkcs12_derivation`). Thus there is no interface gap to fill, apart from hash mechanism identification which is covered under [hash analysis](#hash-gap-analysis).
 
 ### Random generation gap analysis
 
@@ -230,7 +230,7 @@ Based on the [gap analysis](#mac-gap-analysis): nothing to do.
 
 ### Key derivation APIs
 
-[TODO]
+Based on the [gap analysis](#key-derivation-gap-analysis): nothing to do.
 
 ### Random generation APIs
 

--- a/docs/architecture/psa-migration/psa-legacy-bridges.md
+++ b/docs/architecture/psa-migration/psa-legacy-bridges.md
@@ -97,7 +97,11 @@ Gap: functions to convert between `psa_algorithm_t` hash algorithms and `mbedtls
 
 ### MAC gap analysis
 
-[TODO]
+The legacy API does not have a unified interface for MAC, only separate interfaces for HMAC and CMAC. As a consequence, applications need ad hoc code to support both HMAC and CMAC anyway. With respect to MAC mechanism identification, there is no gap to fill.
+
+Within the scope of HMAC, applications need to convert between hash mechanism identifications; this is part of the more general [hash analysis](#hash-gap-analysis). Within the scope of CMAC, applications need to convert between block cipher identifications; this is part of the more general [cipher and AEAD analysis](#cipher-and-aead-gap-analysis).
+
+MAC do not have any nontrivial format for keys or outputs, so there is no need for any conversion functions.
 
 ### Cipher and AEAD gap analysis
 
@@ -218,7 +222,7 @@ Based on the [gap analysis](#hash-gap-analysis):
 
 ### MAC APIs
 
-[TODO]
+Based on the [gap analysis](#mac-gap-analysis): nothing to do.
 
 ### Cipher and AEAD APIs
 


### PR DESCRIPTION
Document requirements for bridging legacy APIs and PSA APIs. The scope of this pull request is symmetric crytography (cipher/AEAD, MAC, key derivation, random generation). Together with https://github.com/Mbed-TLS/mbedtls/pull/8657, it represents all the classes of cryptographic mechanisms that exist in some form in both APIs.

Follow-up to https://github.com/Mbed-TLS/mbedtls/pull/8657, to be rebased once that is merged.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** no
- [x] **backport** no
- [x] **tests** no
