### PR TITLE
generate_errors.pl: fix handling of long prefixed comments

### DIFF
--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -85,6 +85,7 @@
 /* Error space gap */
 /**
  * Received NewSessionTicket Post Handshake Message.
+ *
  * This error code is experimental and may be changed or removed without notice.
  */
 #define MBEDTLS_ERR_SSL_RECEIVED_NEW_SESSION_TICKET       -0x7B00
@@ -92,6 +93,7 @@
 #define MBEDTLS_ERR_SSL_CANNOT_READ_EARLY_DATA            -0x7B80
 /**
  * Early data has been received as part of an on-going handshake.
+ *
  * This error code can be returned only on server side if and only if early
  * data has been enabled by means of the mbedtls_ssl_conf_early_data() API.
  * This error code can then be returned by mbedtls_ssl_handshake(),

--- a/scripts/generate_errors.pl
+++ b/scripts/generate_errors.pl
@@ -79,9 +79,13 @@ foreach my $file (@files) {
         die "Description both before and after $name in $file\n"
           if defined($before) && defined($after);
         my $description = (defined($before) ? $before : $after);
-        $description =~ s/^\s+//;
+        # For error codes with long descriptions, keep only the first paragraph.
+        $description =~ s/\n[* ]*\n.*//s;
+        # Wrap lines and remove '* ' line prefix.
         $description =~ s/\n( *\*)? */ /g;
-        $description =~ s/\.?\s+$//;
+        # Remove leading and trailing whitespace. Also remove a trailing '.'.
+        $description =~ s/^\s+//;
+        $description =~ s/\.?\s*$//;
         push @matches, [$name, $value, $description];
         ++$found;
     }


### PR DESCRIPTION
Fix #8783

## PR checklist

- [x] **changelog** no (internal script)
- [x] **backport** TODO
- [x] **tests** no (check the generated `errors.c` visually)
