### PR TITLE
Stop platform test failures with GCC and TSAN

### DIFF
--- a/tests/include/test/helpers.h
+++ b/tests/include/test/helpers.h
@@ -23,6 +23,10 @@
 #if defined(__SANITIZE_ADDRESS__) /* gcc -fsanitize=address */
 #  define MBEDTLS_TEST_HAVE_ASAN
 #endif
+#if defined(__SANITIZE_THREAD__) /* gcc -fsanitize-thread */
+#  define MBEDTLS_TEST_HAVE_TSAN
+#endif
+
 #if defined(__has_feature)
 #  if __has_feature(address_sanitizer) /* clang -fsanitize=address */
 #    define MBEDTLS_TEST_HAVE_ASAN


### PR DESCRIPTION
## Description

Prior to this, we were only detecting TSAN run under clang, and thus not running the platform test that will break under any kind of sanitiser. GCC also supports TSAN, so fix the detection code.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [ ] **changelog** ~~provided, or~~ not required (minor change)
- [ ] **backport** ~~done, or~~ not required (New feature, only in development)
- [ ] **tests** ~~provided, or~~ not required (Platform tests should now run clean under GCC and TSAN)
