### PR TITLE
Convert mpi_one[] array to a const

### DIFF
--- a/library/ecp_curves.c
+++ b/library/ecp_curves.c
@@ -46,7 +46,7 @@
     defined(MBEDTLS_ECP_DP_SECP256K1_ENABLED)
 /* For these curves, we build the group parameters dynamically. */
 #define ECP_LOAD_GROUP
-static mbedtls_mpi_uint mpi_one[] = { 1 };
+static const mbedtls_mpi_uint mpi_one[] = { 1 };
 #endif
 
 /*
@@ -4505,7 +4505,7 @@ static inline void ecp_mpi_set1(mbedtls_mpi *X)
 {
     X->s = 1;
     X->n = 1;
-    X->p = mpi_one;
+    X->p = (mbedtls_mpi_uint *) mpi_one;
 }
 
 /*

--- a/library/ecp_curves_new.c
+++ b/library/ecp_curves_new.c
@@ -51,7 +51,7 @@
     defined(MBEDTLS_ECP_DP_SECP256K1_ENABLED)
 /* For these curves, we build the group parameters dynamically. */
 #define ECP_LOAD_GROUP
-static mbedtls_mpi_uint mpi_one[] = { 1 };
+static const mbedtls_mpi_uint mpi_one[] = { 1 };
 #endif
 
 /*
@@ -4515,7 +4515,7 @@ static inline void ecp_mpi_set1(mbedtls_mpi *X)
 {
     X->s = 1;
     X->n = 1;
-    X->p = mpi_one;
+    X->p = (mbedtls_mpi_uint *) mpi_one;
 }
 
 /*


### PR DESCRIPTION
## Description

`mpi_one[]` is a constant array that is used in elliptic cryptography. It is used for simplifying key copying and generation since some components of the elliptic keys are always "1".
The problem with this array is that, the way it is defined, makes it reside in a .data section in RAM. For applications, which are sensitive to global variables, this is unnecessary hassle.

One example of such sensitive application is a multi-stage code, like bootrom + bootloader + application, where mbedtls resides in the bootrom, and exposes its APIs to further stages - bootloader and the application. As long as mbedtls does not use any global variables, and limits its use to stack, bootloader and the application may call the functions residing in the bootrom code space.

I my application, where RSA and ECDSA are used, mpi_one is the only variable residing in .data. 

The change in this PR does not alter the ECDSA operations. I ran all "basic-build-test.sh" tests.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** no change from caller perspective
- [x] **backport** no change in the flow
- [x] **tests** executed - not provided

Resolves #8792


## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.
