### PR TITLE
Fix gcc warning for { 0 } by using {}

### DIFF
--- a/include/psa/crypto_builtin_composites.h
+++ b/include/psa/crypto_builtin_composites.h
@@ -51,7 +51,7 @@ typedef struct {
     uint8_t MBEDTLS_PRIVATE(opad)[PSA_HMAC_MAX_HASH_BLOCK_SIZE];
 } mbedtls_psa_hmac_operation_t;
 
-#define MBEDTLS_PSA_HMAC_OPERATION_INIT { 0, PSA_HASH_OPERATION_INIT, { 0 } }
+#define MBEDTLS_PSA_HMAC_OPERATION_INIT { 0, PSA_HASH_OPERATION_INIT, {} }
 #endif /* MBEDTLS_PSA_BUILTIN_ALG_HMAC */
 
 typedef struct {
@@ -67,7 +67,7 @@ typedef struct {
     } MBEDTLS_PRIVATE(ctx);
 } mbedtls_psa_mac_operation_t;
 
-#define MBEDTLS_PSA_MAC_OPERATION_INIT { 0, { 0 } }
+#define MBEDTLS_PSA_MAC_OPERATION_INIT { 0, {} }
 
 #if defined(MBEDTLS_PSA_BUILTIN_ALG_GCM) || \
     defined(MBEDTLS_PSA_BUILTIN_ALG_CCM) || \
@@ -100,7 +100,7 @@ typedef struct {
 
 } mbedtls_psa_aead_operation_t;
 
-#define MBEDTLS_PSA_AEAD_OPERATION_INIT { 0, 0, 0, 0, { 0 } }
+#define MBEDTLS_PSA_AEAD_OPERATION_INIT { 0, 0, 0, 0, {} }
 
 #include "mbedtls/ecdsa.h"
 
@@ -132,9 +132,9 @@ typedef struct {
 #if (defined(MBEDTLS_PSA_BUILTIN_ALG_ECDSA) || \
     defined(MBEDTLS_PSA_BUILTIN_ALG_DETERMINISTIC_ECDSA)) && \
     defined(MBEDTLS_ECP_RESTARTABLE)
-#define MBEDTLS_PSA_SIGN_HASH_INTERRUPTIBLE_OPERATION_INIT { { 0 }, { 0 }, 0, 0, 0, 0, 0, 0 }
+#define MBEDTLS_PSA_SIGN_HASH_INTERRUPTIBLE_OPERATION_INIT { {}, {}, 0, 0, 0, 0, 0, 0 }
 #else
-#define MBEDTLS_PSA_SIGN_HASH_INTERRUPTIBLE_OPERATION_INIT { 0 }
+#define MBEDTLS_PSA_SIGN_HASH_INTERRUPTIBLE_OPERATION_INIT {}
 #endif
 
 /* Context structure for the Mbed TLS interruptible verify hash
@@ -168,10 +168,10 @@ typedef struct {
 #if (defined(MBEDTLS_PSA_BUILTIN_ALG_ECDSA) || \
     defined(MBEDTLS_PSA_BUILTIN_ALG_DETERMINISTIC_ECDSA)) && \
     defined(MBEDTLS_ECP_RESTARTABLE)
-#define MBEDTLS_VERIFY_SIGN_HASH_INTERRUPTIBLE_OPERATION_INIT { { 0 }, { 0 }, 0, 0, 0, 0, { 0 }, \
-        { 0 } }
+#define MBEDTLS_VERIFY_SIGN_HASH_INTERRUPTIBLE_OPERATION_INIT { {}, {}, 0, 0, 0, 0, {}, \
+        {} }
 #else
-#define MBEDTLS_VERIFY_SIGN_HASH_INTERRUPTIBLE_OPERATION_INIT { 0 }
+#define MBEDTLS_VERIFY_SIGN_HASH_INTERRUPTIBLE_OPERATION_INIT {}
 #endif
 
 
@@ -209,6 +209,6 @@ typedef struct {
 
 } mbedtls_psa_pake_operation_t;
 
-#define MBEDTLS_PSA_PAKE_OPERATION_INIT { { 0 } }
+#define MBEDTLS_PSA_PAKE_OPERATION_INIT { {} }
 
 #endif /* PSA_CRYPTO_BUILTIN_COMPOSITES_H */

--- a/include/psa/crypto_builtin_primitives.h
+++ b/include/psa/crypto_builtin_primitives.h
@@ -79,7 +79,7 @@ typedef struct {
     } MBEDTLS_PRIVATE(ctx);
 } mbedtls_psa_hash_operation_t;
 
-#define MBEDTLS_PSA_HASH_OPERATION_INIT { 0, { 0 } }
+#define MBEDTLS_PSA_HASH_OPERATION_INIT { 0, {} }
 
 /*
  * Cipher multi-part operation definitions.
@@ -109,6 +109,6 @@ typedef struct {
     } MBEDTLS_PRIVATE(ctx);
 } mbedtls_psa_cipher_operation_t;
 
-#define MBEDTLS_PSA_CIPHER_OPERATION_INIT { 0, 0, 0, { 0 } }
+#define MBEDTLS_PSA_CIPHER_OPERATION_INIT { 0, 0, 0, {} }
 
 #endif /* PSA_CRYPTO_BUILTIN_PRIMITIVES_H */

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -1829,10 +1829,10 @@ psa_status_t psa_pake_abort(psa_pake_operation_t *operation);
  * psa_pake_operation_t.
  */
 #if defined(MBEDTLS_PSA_CRYPTO_CLIENT) && !defined(MBEDTLS_PSA_CRYPTO_C)
-#define PSA_PAKE_OPERATION_INIT { 0 }
+#define PSA_PAKE_OPERATION_INIT {}
 #else
 #define PSA_PAKE_OPERATION_INIT { 0, PSA_ALG_NONE, 0, PSA_PAKE_OPERATION_STAGE_SETUP, \
-                                  { 0 }, { { 0 } } }
+                                  {}, { {} } }
 #endif
 
 struct psa_pake_cipher_suite_s {

--- a/include/psa/crypto_struct.h
+++ b/include/psa/crypto_struct.h
@@ -82,9 +82,9 @@ struct psa_hash_operation_s {
 #endif
 };
 #if defined(MBEDTLS_PSA_CRYPTO_CLIENT) && !defined(MBEDTLS_PSA_CRYPTO_C)
-#define PSA_HASH_OPERATION_INIT { 0 }
+#define PSA_HASH_OPERATION_INIT {}
 #else
-#define PSA_HASH_OPERATION_INIT { 0, { 0 } }
+#define PSA_HASH_OPERATION_INIT { 0, {} }
 #endif
 static inline struct psa_hash_operation_s psa_hash_operation_init(void)
 {
@@ -114,9 +114,9 @@ struct psa_cipher_operation_s {
 };
 
 #if defined(MBEDTLS_PSA_CRYPTO_CLIENT) && !defined(MBEDTLS_PSA_CRYPTO_C)
-#define PSA_CIPHER_OPERATION_INIT { 0 }
+#define PSA_CIPHER_OPERATION_INIT {}
 #else
-#define PSA_CIPHER_OPERATION_INIT { 0, 0, 0, 0, { 0 } }
+#define PSA_CIPHER_OPERATION_INIT { 0, 0, 0, 0, {} }
 #endif
 static inline struct psa_cipher_operation_s psa_cipher_operation_init(void)
 {
@@ -146,9 +146,9 @@ struct psa_mac_operation_s {
 };
 
 #if defined(MBEDTLS_PSA_CRYPTO_CLIENT) && !defined(MBEDTLS_PSA_CRYPTO_C)
-#define PSA_MAC_OPERATION_INIT { 0 }
+#define PSA_MAC_OPERATION_INIT {}
 #else
-#define PSA_MAC_OPERATION_INIT { 0, 0, 0, { 0 } }
+#define PSA_MAC_OPERATION_INIT { 0, 0, 0, {} }
 #endif
 static inline struct psa_mac_operation_s psa_mac_operation_init(void)
 {
@@ -185,9 +185,9 @@ struct psa_aead_operation_s {
 };
 
 #if defined(MBEDTLS_PSA_CRYPTO_CLIENT) && !defined(MBEDTLS_PSA_CRYPTO_C)
-#define PSA_AEAD_OPERATION_INIT { 0 }
+#define PSA_AEAD_OPERATION_INIT {}
 #else
-#define PSA_AEAD_OPERATION_INIT { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, { 0 } }
+#define PSA_AEAD_OPERATION_INIT { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, {} }
 #endif
 static inline struct psa_aead_operation_s psa_aead_operation_init(void)
 {
@@ -211,10 +211,10 @@ struct psa_key_derivation_s {
 };
 
 #if defined(MBEDTLS_PSA_CRYPTO_CLIENT) && !defined(MBEDTLS_PSA_CRYPTO_C)
-#define PSA_KEY_DERIVATION_OPERATION_INIT { 0 }
+#define PSA_KEY_DERIVATION_OPERATION_INIT {}
 #else
 /* This only zeroes out the first byte in the union, the rest is unspecified. */
-#define PSA_KEY_DERIVATION_OPERATION_INIT { 0, 0, 0, { 0 } }
+#define PSA_KEY_DERIVATION_OPERATION_INIT { 0, 0, 0, {} }
 #endif
 static inline struct psa_key_derivation_s psa_key_derivation_operation_init(
     void)
@@ -492,9 +492,9 @@ struct psa_sign_hash_interruptible_operation_s {
 };
 
 #if defined(MBEDTLS_PSA_CRYPTO_CLIENT) && !defined(MBEDTLS_PSA_CRYPTO_C)
-#define PSA_SIGN_HASH_INTERRUPTIBLE_OPERATION_INIT { 0 }
+#define PSA_SIGN_HASH_INTERRUPTIBLE_OPERATION_INIT {}
 #else
-#define PSA_SIGN_HASH_INTERRUPTIBLE_OPERATION_INIT { 0, { 0 }, 0, 0 }
+#define PSA_SIGN_HASH_INTERRUPTIBLE_OPERATION_INIT { 0, {}, 0, 0 }
 #endif
 
 static inline struct psa_sign_hash_interruptible_operation_s
@@ -530,9 +530,9 @@ struct psa_verify_hash_interruptible_operation_s {
 };
 
 #if defined(MBEDTLS_PSA_CRYPTO_CLIENT) && !defined(MBEDTLS_PSA_CRYPTO_C)
-#define PSA_VERIFY_HASH_INTERRUPTIBLE_OPERATION_INIT { 0 }
+#define PSA_VERIFY_HASH_INTERRUPTIBLE_OPERATION_INIT {}
 #else
-#define PSA_VERIFY_HASH_INTERRUPTIBLE_OPERATION_INIT { 0, { 0 }, 0, 0 }
+#define PSA_VERIFY_HASH_INTERRUPTIBLE_OPERATION_INIT { 0, {}, 0, 0 }
 #endif
 
 static inline struct psa_verify_hash_interruptible_operation_s


### PR DESCRIPTION
## Description

mbedtls is triggering the gcc warning "braces around scalar initializer".

This patch fixes the warnings.

mbedtls/include/psa/crypto_struct.h:
In function 'psa_sign_hash_interruptible_operation_init': mbedtls/include/psa/crypto_struct.h:444:9:
warning: braces around scalar initializer
  444 |         PSA_SIGN_HASH_INTERRUPTIBLE_OPERATION_INIT;

Using gcc 12.2.0.

I personally don't agree that gcc should produce a warning for this or that this warning should be enabled by users of mbedtls.

But users are including mbedtls headers and they are enabling this warning.



## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [not required because it's just a warning ] **changelog** provided, or not required
- [not required because it's just a warning ] **backport** done, or not required
- [not required because existing tests should cover changes (no changes expected) ] **tests** provided, or not required



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
