### PR TITLE
Backport 2.28: bugs fixed in "Implement mbedtls_pk_import_into_psa"

### DIFF
--- a/include/psa/crypto_values.h
+++ b/include/psa/crypto_values.h
@@ -400,7 +400,7 @@
     ((type) | PSA_KEY_TYPE_CATEGORY_FLAG_PAIR)
 /** The public key type corresponding to a key pair type.
  *
- * You may also pass a key pair type as \p type, it will be left unchanged.
+ * You may also pass a public key type as \p type, it will be left unchanged.
  *
  * \param type      A public key type or key pair type.
  *

--- a/tests/scripts/depends.py
+++ b/tests/scripts/depends.py
@@ -192,7 +192,10 @@ and subsequent commands are tests that cannot run if the build failed).'''
         success = True
         for command in self.commands:
             log_command(command)
-            ret = subprocess.call(command)
+            env = os.environ.copy()
+            if 'MBEDTLS_TEST_CONFIGURATION' in env:
+                env['MBEDTLS_TEST_CONFIGURATION'] += '-' + self.name
+            ret = subprocess.call(command, env=env)
             if ret != 0:
                 if command[0] not in ['make', options.make_command]:
                     log_line('*** [{}] Error {}'.format(' '.join(command), ret))

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -18,6 +18,13 @@
 #define RSA_KEY_SIZE 512
 #define RSA_KEY_LEN   64
 
+#if defined(MBEDTLS_RSA_C) ||                                           \
+    defined(MBEDTLS_PK_RSA_ALT_SUPPORT) ||                              \
+    defined(MBEDTLS_ECDSA_C) ||                                         \
+    defined(MBEDTLS_USE_PSA_CRYPTO)
+#define PK_CAN_SIGN_SOME
+#endif
+
 /** Generate a key of the desired type.
  *
  * \param pk        The PK object to fill. It must have been initialized
@@ -894,7 +901,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_SHA256_C */
+/* BEGIN_CASE depends_on:MBEDTLS_SHA256_C:PK_CAN_SIGN_SOME */
 void pk_sign_verify(int type, int parameter, int sign_ret, int verify_ret)
 {
     mbedtls_pk_context pk;


### PR DESCRIPTION
Backport of minor bug fixes in tests from https://github.com/Mbed-TLS/mbedtls/pull/8807.

Priority: high even though the bugs are not high-priority, because this is a backport of a high-priority PR.

## PR checklist

- [ ] **changelog** no (test stuff only)
- [ ] **backport** of https://github.com/Mbed-TLS/mbedtls/pull/8807
- [x] **tests** CI
