### PR TITLE
Make multi-part operations thread-safe

### DIFF
--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -3371,7 +3371,7 @@ exit:
         psa_sign_hash_abort_internal(operation);
     }
 
-    unlock_status = psa_unregister_read(slot);
+    unlock_status = psa_unregister_read_under_mutex(slot);
 
     if (unlock_status != PSA_SUCCESS) {
         operation->error_occurred = 1;

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -2565,7 +2565,7 @@ exit:
         psa_mac_abort(operation);
     }
 
-    unlock_status = psa_unregister_read(slot);
+    unlock_status = psa_unregister_read_under_mutex(slot);
 
     return (status == PSA_SUCCESS) ? unlock_status : status;
 }

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -3516,7 +3516,7 @@ psa_status_t psa_verify_hash_start(
         psa_verify_hash_abort_internal(operation);
     }
 
-    unlock_status = psa_unregister_read(slot);
+    unlock_status = psa_unregister_read_under_mutex(slot);
 
     if (unlock_status != PSA_SUCCESS) {
         operation->error_occurred = 1;

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -7953,7 +7953,7 @@ exit:
     if (status != PSA_SUCCESS) {
         psa_pake_abort(operation);
     }
-    unlock_status = psa_unregister_read(slot);
+    unlock_status = psa_unregister_read_under_mutex(slot);
     return (status == PSA_SUCCESS) ? unlock_status : status;
 }
 

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -4088,7 +4088,7 @@ exit:
         psa_cipher_abort(operation);
     }
 
-    unlock_status = psa_unregister_read(slot);
+    unlock_status = psa_unregister_read_under_mutex(slot);
 
     return (status == PSA_SUCCESS) ? unlock_status : status;
 }

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -7061,7 +7061,7 @@ psa_status_t psa_key_derivation_input_key(
                                                slot->key.data,
                                                slot->key.bytes);
 
-    unlock_status = psa_unregister_read(slot);
+    unlock_status = psa_unregister_read_under_mutex(slot);
 
     return (status == PSA_SUCCESS) ? unlock_status : status;
 }
@@ -7218,7 +7218,7 @@ psa_status_t psa_key_derivation_key_agreement(psa_key_derivation_operation_t *op
         }
     }
 
-    unlock_status = psa_unregister_read(slot);
+    unlock_status = psa_unregister_read_under_mutex(slot);
 
     return (status == PSA_SUCCESS) ? unlock_status : status;
 }

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -4687,7 +4687,7 @@ static psa_status_t psa_aead_setup(psa_aead_operation_t *operation,
     operation->key_type = psa_get_key_type(&attributes);
 
 exit:
-    unlock_status = psa_unregister_read(slot);
+    unlock_status = psa_unregister_read_under_mutex(slot);
 
     if (status == PSA_SUCCESS) {
         status = unlock_status;


### PR DESCRIPTION
## Description
Makes all multi-part and restartable operations thread-safe. Resolves #8412.

The work of this PR and the issues #8675, #8676 and #8677 is to ensure that API calls are linearizable and correct. To do this we rely on some properties, these properties need to be enforced once these PRs are merged. The relevant properties are:
- All calls to `psa_register_read`, `psa_unregister_read`, `psa_key_slot_state_transition`, `psa_wipe_key_slot` and `psa_key_slot_has_readers` are performed under the global mutex.
- Every API call has at most one point in time where effects are made visible to other threads. By effects here we mean something like a key being created and now existing in the eyes of other threads, or a key being destroyed. We do not need to consider resource constraints here.
- Any function which iterates through key slots or finds a key slot containing X ignores all slots in the FILLING or PENDING_DELETION state. Whoever sets a slot to FILLING directly or via `psa_reserve_free_key_slot` has exclusive access to the slot. A slot in PENDING_DELETION can only be read by the registered readers, and must be wiped upon the final reader unregistering.
- If a slot in the FULL state has more than 1 registered reader then it cannot be wiped (with the exception of a call to `mbedtls_psa_cypto_free`, a non-threadsafe function).
- No key can be in multiple FULL slots at the same time, each FULL slot must hold a unique key ID.
- Other threads running other API calls mustn't interfere in a destructive way.

(See the [thread safety document](https://github.com/Mbed-TLS/mbedtls/blob/development/docs/architecture/psa-thread-safety/psa-thread-safety.md) for more details.) This PR must make multi-part operations abide by these properties.

### Note for reviewers
Ensure that multi-part operations cannot write to any slot (except for key derivation and writing in the locking/unregistering call), or read from any slot at any time where they are not a registered reader of the slot, or write unsafely to any shared memory. Note that we do not require thread safety in the case where an `operation` object is used simultaneously by different threads.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required for individual tasks on this epic
- [x] **backport** not required
- [x] **tests** To be added in #8420

