### PR TITLE
Improve test info data accessors

### DIFF
--- a/tests/src/helpers.c
+++ b/tests/src/helpers.c
@@ -50,7 +50,7 @@ mbedtls_test_result_t mbedtls_test_get_result(void)
     return result;
 }
 
-void mbedtls_test_set_result(mbedtls_test_result_t result, const char *test,
+static void mbedtls_test_set_result(mbedtls_test_result_t result, const char *test,
                              int line_no, const char *filename)
 {
     /* Internal function only - mbedtls_test_info_mutex should be held prior
@@ -144,7 +144,7 @@ unsigned long mbedtls_test_get_step(void)
     return step;
 }
 
-void mbedtls_test_reset_step(void)
+static void mbedtls_test_reset_step(void)
 {
     /* Internal function only - mbedtls_test_info_mutex should be held prior
      * to calling this function. */
@@ -178,7 +178,7 @@ void mbedtls_test_get_line1(char *line)
 #endif /* MBEDTLS_THREADING_C */
 }
 
-void mbedtls_test_set_line1(const char *line)
+static void mbedtls_test_set_line1(const char *line)
 {
     /* Internal function only - mbedtls_test_info_mutex should be held prior
      * to calling this function. */
@@ -203,7 +203,7 @@ void mbedtls_test_get_line2(char *line)
 #endif /* MBEDTLS_THREADING_C */
 }
 
-void mbedtls_test_set_line2(const char *line)
+static void mbedtls_test_set_line2(const char *line)
 {
     /* Internal function only - mbedtls_test_info_mutex should be held prior
      * to calling this function. */
@@ -255,7 +255,7 @@ unsigned mbedtls_test_get_case_uses_negative_0(void)
     return test_case_uses_negative_0;
 }
 
-void mbedtls_test_set_case_uses_negative_0(unsigned uses)
+static void mbedtls_test_set_case_uses_negative_0(unsigned uses)
 {
     /* Internal function only - mbedtls_test_info_mutex should be held prior
      * to calling this function. */

--- a/tests/src/helpers.c
+++ b/tests/src/helpers.c
@@ -229,7 +229,19 @@ static void mbedtls_test_set_line2_internal(const char *line)
 #if defined(MBEDTLS_TEST_MUTEX_USAGE)
 const char *mbedtls_test_get_mutex_usage_error(void)
 {
-    return mbedtls_test_info.mutex_usage_error;
+    const char *usage_error;
+
+#ifdef MBEDTLS_THREADING_C
+    mbedtls_mutex_lock(&mbedtls_test_info_mutex);
+#endif /* MBEDTLS_THREADING_C */
+
+    usage_error = mbedtls_test_info.mutex_usage_error;
+
+#ifdef MBEDTLS_THREADING_C
+    mbedtls_mutex_unlock(&mbedtls_test_info_mutex);
+#endif /* MBEDTLS_THREADING_C */
+
+    return usage_error;
 }
 
 void mbedtls_test_set_mutex_usage_error(const char *msg)

--- a/tests/src/helpers.c
+++ b/tests/src/helpers.c
@@ -33,15 +33,14 @@ mbedtls_threading_mutex_t mbedtls_test_info_mutex;
 /*----------------------------------------------------------------------------*/
 /* Mbedtls Test Info accessors
  *
- * NOTE - there are two types of accessors here; the _internal functions, which
- * are expected to be used from this module *only*. These do not attempt to lock
- * the mbedtls_test_info_mutex, as they are designed to be called from within
- * public functions which do lock the mutex first (if mutexes are enabled).
- * The main reason for this is the need to set some sets of test data
- * atomically, without releasing the mutex inbetween to prevent race conditions
- * resulting in mixed test info. The other public accessors have prototypes in
- * the header and have to lock the mutex for safety as we obviously cannot
- * control where they are called from. */
+ * NOTE - there are two types of accessors here: public accessors and internal
+ * accessors. The public accessors have prototypes in helpers.h and lock
+ * mbedtls_test_info_mutex (if mutexes are enabled). The _internal accessors,
+ * which are expected to be used from this module *only*, do not lock the mutex.
+ * These are designed to be called from within public functions which already
+ * hold the mutex. The main reason for this difference is the need to set
+ * multiple test data values atomically (without releasing the mutex) to prevent
+ * race conditions. */
 
 mbedtls_test_result_t mbedtls_test_get_result(void)
 {

--- a/tests/src/threading_helpers.c
+++ b/tests/src/threading_helpers.c
@@ -321,8 +321,8 @@ void mbedtls_test_mutex_usage_check(void)
         if (live_mutexes != 0) {
             /* A positive number (more init than free) means that a mutex resource
              * is leaking (on platforms where a mutex consumes more than the
-             * mbedtls_threading_mutex_t object itself). The rare case of a
-             * negative number means a missing init somewhere. */
+             * mbedtls_threading_mutex_t object itself). The (hopefully) rare
+             * case of a negative number means a missing init somewhere. */
             mbedtls_fprintf(stdout, "[mutex: %d leaked] ", live_mutexes);
             live_mutexes = 0;
             mbedtls_test_set_mutex_usage_error("missing free");


### PR DESCRIPTION
## Description

After comments on the recent deadlock fix, attempt to improve the test info data acessors:

1. Mark all internal only functions as static, and rename them as `*_internal` in order to make them more obvious (in line with the aforementioned fix). Also add a comment block to further explain the mutex policies.
2. Whilst checking all the internal functions I spotted two cases which should have had mutex locks but did not (likely due to crossover between two PRs) and have fixed these.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [ ] **changelog** ~~provided, or~~ not required (Part of multithreading work)
- [ ] **backport** ~~done, or~~ not required (code does not exist in LTS)
- [ ] **tests** ~~provided, or~~ not required (Part of test code)
