### PR TITLE
project: set version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,9 +34,15 @@ cmake_policy(SET CMP0011 NEW)
 cmake_policy(SET CMP0012 NEW)
 
 if(TEST_CPP)
-    project("Mbed TLS" LANGUAGES C CXX)
+    project("Mbed TLS"
+        LANGUAGES C CXX
+        VERSION 3.5.2
+    )
 else()
-    project("Mbed TLS" LANGUAGES C)
+    project("Mbed TLS"
+        LANGUAGES C
+        VERSION 3.5.2
+    )
 endif()
 
 include(GNUInstallDirs)


### PR DESCRIPTION
Set the version of the project within the project() declaration so other cmake scripts can use PROJECT_VERSION.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required - non user-facing change
- [x] **backport** backport of this fix is with backport of feature at #8851
- [x] **tests** not required - build system changes only
