### PR TITLE
Make psa_open_key threadsafe

### DIFF
--- a/library/psa_crypto_slot_management.c
+++ b/library/psa_crypto_slot_management.c
@@ -542,7 +542,7 @@ psa_status_t psa_open_key(mbedtls_svc_key_id_t key, psa_key_handle_t *handle)
 
     *handle = key;
 
-    return psa_unregister_read(slot);
+    return psa_unregister_read_under_mutex(slot);
 
 #else /* MBEDTLS_PSA_CRYPTO_STORAGE_C || MBEDTLS_PSA_CRYPTO_BUILTIN_KEYS */
     (void) key;


### PR DESCRIPTION
## Description
This is a very simple case of the usual get_and_lock -> unregister_under_mutex approach.
This is the only unaccounted for `unregister_read` (the rest remaining in development are covered by #8833). The function is deprecated, but we need to keep it thread safe.
## PR checklist
- [x] **changelog** not required for individual tasks on this epic
- [x] **backport** not required
- [x] **tests** To be added in #8420
