### PR TITLE
TLS 1.3: SRV: Improve key exchange mode selection

### DIFF
--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -608,18 +608,16 @@ static int ssl_tls13_parse_pre_shared_key_ext(
                     ssl, ciphersuites, ciphersuites_end,
                     &cipher_suite, &ciphersuite_info);
                 break;
-            case MBEDTLS_SSL_TLS1_3_PSK_RESUMPTION:
 #if defined(MBEDTLS_SSL_SESSION_TICKETS)
+            case MBEDTLS_SSL_TLS1_3_PSK_RESUMPTION:
                 ret = ssl_tls13_select_ciphersuite_for_resumption(
                     ssl, ciphersuites, ciphersuites_end, &session,
                     &cipher_suite, &ciphersuite_info);
                 if (ret != 0) {
                     mbedtls_ssl_session_free(&session);
                 }
-#else
-                ret = MBEDTLS_ERR_SSL_FEATURE_UNAVAILABLE;
-#endif
                 break;
+#endif
             default:
                 return MBEDTLS_ERR_SSL_INTERNAL_ERROR;
         }

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -995,30 +995,10 @@ static int ssl_tls13_client_hello_has_exts_for_psk_ephemeral_key_exchange(
 
 #if defined(MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_SOME_PSK_ENABLED)
 MBEDTLS_CHECK_RETURN_CRITICAL
-static int ssl_tls13_ticket_is_kex_mode_permitted(mbedtls_ssl_context *ssl,
-                                                  unsigned int kex_mode)
-{
-#if defined(MBEDTLS_SSL_SESSION_TICKETS)
-    if (ssl->handshake->resume) {
-        if (!mbedtls_ssl_tls13_session_ticket_has_flags(
-                ssl->session_negotiate, kex_mode)) {
-            return 0;
-        }
-    }
-#else
-    ((void) ssl);
-    ((void) kex_mode);
-#endif
-    return 1;
-}
-
-MBEDTLS_CHECK_RETURN_CRITICAL
 static int ssl_tls13_key_exchange_is_psk_available(mbedtls_ssl_context *ssl)
 {
 #if defined(MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_ENABLED)
-    return ssl_tls13_ticket_is_kex_mode_permitted(
-        ssl, MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK) &&
-           mbedtls_ssl_conf_tls13_is_psk_enabled(ssl) &&
+    return mbedtls_ssl_conf_tls13_is_psk_enabled(ssl) &&
            mbedtls_ssl_tls13_is_psk_supported(ssl) &&
            ssl_tls13_client_hello_has_exts_for_psk_key_exchange(ssl);
 #else
@@ -1031,9 +1011,7 @@ MBEDTLS_CHECK_RETURN_CRITICAL
 static int ssl_tls13_key_exchange_is_psk_ephemeral_available(mbedtls_ssl_context *ssl)
 {
 #if defined(MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL_ENABLED)
-    return ssl_tls13_ticket_is_kex_mode_permitted(
-        ssl, MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL) &&
-           mbedtls_ssl_conf_tls13_is_psk_ephemeral_enabled(ssl) &&
+    return mbedtls_ssl_conf_tls13_is_psk_ephemeral_enabled(ssl) &&
            mbedtls_ssl_tls13_is_psk_ephemeral_supported(ssl) &&
            ssl_tls13_client_hello_has_exts_for_psk_ephemeral_key_exchange(ssl);
 #else

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -324,6 +324,8 @@ static int ssl_tls13_offered_psks_check_identity_match(
     return SSL_TLS1_3_OFFERED_PSK_NOT_MATCH;
 }
 
+#define SSL_TLS1_3_BINDER_DOES_NOT_MATCH 1
+#define SSL_TLS1_3_BINDER_MATCH 0
 MBEDTLS_CHECK_RETURN_CRITICAL
 static int ssl_tls13_offered_psks_check_binder_match(
     mbedtls_ssl_context *ssl,
@@ -368,12 +370,12 @@ static int ssl_tls13_offered_psks_check_binder_match(
     MBEDTLS_SSL_DEBUG_BUF(3, "psk binder ( received ): ", binder, binder_len);
 
     if (mbedtls_ct_memcmp(server_computed_binder, binder, binder_len) == 0) {
-        return SSL_TLS1_3_OFFERED_PSK_MATCH;
+        return SSL_TLS1_3_BINDER_MATCH;
     }
 
     mbedtls_platform_zeroize(server_computed_binder,
                              sizeof(server_computed_binder));
-    return SSL_TLS1_3_OFFERED_PSK_NOT_MATCH;
+    return SSL_TLS1_3_BINDER_DOES_NOT_MATCH;
 }
 
 MBEDTLS_CHECK_RETURN_CRITICAL
@@ -626,7 +628,7 @@ static int ssl_tls13_parse_pre_shared_key_ext(
         ret = ssl_tls13_offered_psks_check_binder_match(
             ssl, binder, binder_len, psk_type,
             mbedtls_md_psa_alg_from_type((mbedtls_md_type_t) ciphersuite_info->mac));
-        if (ret != SSL_TLS1_3_OFFERED_PSK_MATCH) {
+        if (ret != SSL_TLS1_3_BINDER_MATCH) {
             /* For security reasons, the handshake should be aborted when we
              * fail to validate a binder value. See RFC 8446 section 4.2.11.2
              * and appendix E.6. */

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1074,6 +1074,7 @@ static int ssl_tls13_determine_key_exchange_mode(mbedtls_ssl_context *ssl)
         MBEDTLS_SSL_DEBUG_MSG(2, ("key exchange mode: psk_ephemeral"));
     } else
     if (ssl_tls13_key_exchange_is_ephemeral_available(ssl)) {
+        ssl->handshake->resume = 0;
         ssl->handshake->key_exchange_mode =
             MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL;
         MBEDTLS_SSL_DEBUG_MSG(2, ("key exchange mode: ephemeral"));

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -92,7 +92,8 @@ static void ssl_tls13_select_ciphersuite(
         return;
     }
 
-    MBEDTLS_SSL_DEBUG_MSG(2, ("No matched ciphersuite"));
+    MBEDTLS_SSL_DEBUG_MSG(2, ("No matched ciphersuite, psk_ciphersuite_id=%x, psk_hash_alg=%x",
+                              (unsigned) psk_ciphersuite_id, psk_hash_alg));
 }
 
 #if defined(MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_SOME_PSK_ENABLED)
@@ -210,7 +211,6 @@ static int ssl_tls13_offered_psks_check_identity_match_ticket(
      */
     ticket_buffer = mbedtls_calloc(1, identity_len);
     if (ticket_buffer == NULL) {
-        MBEDTLS_SSL_DEBUG_MSG(1, ("buffer too small"));
         return MBEDTLS_ERR_SSL_ALLOC_FAILED;
     }
     memcpy(ticket_buffer, identity, identity_len);

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -282,9 +282,9 @@ static int ssl_tls13_offered_psks_check_identity_match(
     ssl->handshake->resume = 0;
 
 #if defined(MBEDTLS_SSL_SESSION_TICKETS)
-    if (ssl_tls13_offered_psks_check_identity_match_ticket(
-            ssl, identity, identity_len, obfuscated_ticket_age,
-            session) == SSL_TLS1_3_PSK_IDENTITY_MATCH) {
+    ret = ssl_tls13_offered_psks_check_identity_match_ticket(
+        ssl, identity, identity_len, obfuscated_ticket_age, session);
+    if (ret == SSL_TLS1_3_PSK_IDENTITY_MATCH) {
         ssl->handshake->resume = 1;
         *psk_type = MBEDTLS_SSL_TLS1_3_PSK_RESUMPTION;
         ret = mbedtls_ssl_set_hs_psk(ssl,
@@ -301,6 +301,8 @@ static int ssl_tls13_offered_psks_check_identity_match(
         MBEDTLS_SSL_DEBUG_MSG(4, ("ticket: obfuscated_ticket_age: %u",
                                   (unsigned) obfuscated_ticket_age));
         return SSL_TLS1_3_PSK_IDENTITY_MATCH;
+    } else if (ret == SSL_TLS1_3_PSK_IDENTITY_MATCH_BUT_PSK_NOT_USABLE) {
+        return SSL_TLS1_3_PSK_IDENTITY_MATCH_BUT_PSK_NOT_USABLE;
     }
 #endif /* MBEDTLS_SSL_SESSION_TICKETS */
 

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1744,10 +1744,11 @@ static int ssl_tls13_parse_client_hello(mbedtls_ssl_context *ssl,
     /* Update checksum with either
      * - The entire content of the CH message, if no PSK extension is present
      * - The content up to but excluding the PSK extension, if present.
+     * Always parse the pre-shared key extension when present in the
+     * ClientHello even if some pre-requisites for PSK key exchange modes are
+     * not met. That way we always validate the syntax of the extension.
      */
-    /* If we've settled on a PSK-based exchange, parse PSK identity ext */
-    if (ssl_tls13_key_exchange_is_psk_available(ssl) ||
-        ssl_tls13_key_exchange_is_psk_ephemeral_available(ssl)) {
+    if (handshake->received_extensions & MBEDTLS_SSL_EXT_MASK(PRE_SHARED_KEY)) {
         ret = handshake->update_checksum(ssl, buf,
                                          pre_shared_key_ext - buf);
         if (0 != ret) {

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -74,8 +74,8 @@ static void ssl_tls13_select_ciphersuite(
         }
 
         /*
-         * If a valid PSK ciphersuite identifier has been passed in, we seek
-         * for an exact match.
+         * If a valid PSK ciphersuite identifier has been passed in, we want
+         * an exact match.
          */
         if (psk_ciphersuite_id != 0) {
             if (id != psk_ciphersuite_id) {
@@ -155,7 +155,7 @@ static int ssl_tls13_parse_key_exchange_modes_ext(mbedtls_ssl_context *ssl,
  * up by the callers of this function as a generic success condition.
  *
  * The return value SSL_TLS1_3_PSK_IDENTITY_MATCH_BUT_PSK_NOT_USABLE means
- * that the pre-shared-key identity matches that of a ticket or an external
+ * that the pre-shared-key identity matches that of a ticket or an externally-
  * provisioned pre-shared-key. We have thus been able to retrieve the
  * attributes of the pre-shared-key but at least one of them does not meet
  * some criteria and the pre-shared-key cannot be used. For example, a ticket
@@ -1673,7 +1673,7 @@ static int ssl_tls13_parse_client_hello(mbedtls_ssl_context *ssl,
     /* Update checksum with either
      * - The entire content of the CH message, if no PSK extension is present
      * - The content up to but excluding the PSK extension, if present.
-     * Always parse the pre-shared key extension when present in the
+     * Always parse the pre-shared-key extension when present in the
      * ClientHello even if some pre-requisites for PSK key exchange modes are
      * not met. That way we always validate the syntax of the extension.
      */

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -123,7 +123,7 @@ static int ssl_tls13_offered_psks_check_identity_match_ticket(
 
     /* Ticket parser is not configured, Skip */
     if (ssl->conf->f_ticket_parse == NULL || identity_len == 0) {
-        return 0;
+        return SSL_TLS1_3_OFFERED_PSK_NOT_MATCH;
     }
 
     /* We create a copy of the encrypted ticket since the ticket parsing
@@ -171,7 +171,6 @@ static int ssl_tls13_offered_psks_check_identity_match_ticket(
      *
      * We regard the ticket with incompatible key exchange modes as not match.
      */
-    ret = MBEDTLS_ERR_ERROR_GENERIC_ERROR;
     MBEDTLS_SSL_PRINT_TICKET_FLAGS(4, session->ticket_flags);
 
     key_exchanges = 0;
@@ -186,11 +185,12 @@ static int ssl_tls13_offered_psks_check_identity_match_ticket(
 
     if (key_exchanges == 0) {
         MBEDTLS_SSL_DEBUG_MSG(3, ("No suitable key exchange mode"));
+        ret = MBEDTLS_ERR_ERROR_GENERIC_ERROR;
         goto exit;
     }
 
-    ret = MBEDTLS_ERR_SSL_SESSION_TICKET_EXPIRED;
 #if defined(MBEDTLS_HAVE_TIME)
+    ret = MBEDTLS_ERR_SSL_SESSION_TICKET_EXPIRED;
     now = mbedtls_ms_time();
 
     if (now < session->ticket_creation_time) {
@@ -244,7 +244,6 @@ static int ssl_tls13_offered_psks_check_identity_match_ticket(
     }
 
     ret = 0;
-
 #endif /* MBEDTLS_HAVE_TIME */
 
 exit:

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -478,7 +478,7 @@ struct psk_attributes {
     int key_exchange_mode;
     const mbedtls_ssl_ciphersuite_t *ciphersuite_info;
 };
-#define PSK_ATTRIBUTES_INIT { 0, 0, 0 }
+#define PSK_ATTRIBUTES_INIT { 0, 0, NULL }
 
 /* Parser for pre_shared_key extension in client hello
  *    struct {

--- a/tests/opt-testcases/tls13-kex-modes.sh
+++ b/tests/opt-testcases/tls13-kex-modes.sh
@@ -23,7 +23,7 @@ run_test    "TLS 1.3: G->m: all/psk, good" \
             -s "Found PSK_EPHEMERAL KEX MODE" \
             -s "Found PSK KEX MODE" \
             -s "Pre shared key found" \
-            -S "No matched PSK or ticket" \
+            -S "No usable PSK or ticket" \
             -s "key exchange mode: psk$"  \
             -S "key exchange mode: psk_ephemeral"  \
             -S "key exchange mode: ephemeral"
@@ -41,7 +41,7 @@ run_test    "TLS 1.3: G->m: all/psk, fail, key id mismatch" \
             -s "found pre_shared_key extension" \
             -s "Found PSK_EPHEMERAL KEX MODE" \
             -s "Found PSK KEX MODE" \
-            -s "No matched PSK or ticket" \
+            -s "No usable PSK or ticket" \
             -S "key exchange mode: psk$"  \
             -S "key exchange mode: psk_ephemeral"  \
             -S "key exchange mode: ephemeral"
@@ -78,7 +78,7 @@ run_test    "TLS 1.3: G->m: psk_or_ephemeral/psk, good" \
             -S "Found PSK_EPHEMERAL KEX MODE" \
             -s "Found PSK KEX MODE" \
             -s "Pre shared key found" \
-            -S "No matched PSK or ticket" \
+            -S "No usable PSK or ticket" \
             -s "key exchange mode: psk$"  \
             -S "key exchange mode: psk_ephemeral"  \
             -S "key exchange mode: ephemeral"
@@ -96,7 +96,7 @@ run_test    "TLS 1.3: G->m: psk_or_ephemeral/psk, fail, key id mismatch" \
             -s "found pre_shared_key extension" \
             -S "Found PSK_EPHEMERAL KEX MODE" \
             -s "Found PSK KEX MODE" \
-            -s "No matched PSK or ticket" \
+            -s "No usable PSK or ticket" \
             -S "key exchange mode: psk$"  \
             -S "key exchange mode: psk_ephemeral"  \
             -S "key exchange mode: ephemeral"
@@ -133,7 +133,7 @@ run_test    "TLS 1.3: G->m: ephemeral_all/psk_ephemeral, good" \
             -s "Found PSK_EPHEMERAL KEX MODE" \
             -S "Found PSK KEX MODE" \
             -s "Pre shared key found" \
-            -S "No matched PSK or ticket" \
+            -S "No usable PSK or ticket" \
             -S "key exchange mode: psk$"  \
             -s "key exchange mode: psk_ephemeral"  \
             -S "key exchange mode: ephemeral"
@@ -151,7 +151,7 @@ run_test    "TLS 1.3: G->m: ephemeral_all/psk_ephemeral, fail, key id mismatch" 
             -s "found pre_shared_key extension" \
             -s "Found PSK_EPHEMERAL KEX MODE" \
             -S "Found PSK KEX MODE" \
-            -s "No matched PSK or ticket" \
+            -s "No usable PSK or ticket" \
             -S "key exchange mode: psk$"  \
             -S "key exchange mode: psk_ephemeral"  \
             -S "key exchange mode: ephemeral"
@@ -188,7 +188,7 @@ run_test    "TLS 1.3: G->m: all/psk_ephemeral, good" \
             -s "Found PSK_EPHEMERAL KEX MODE" \
             -s "Found PSK KEX MODE" \
             -s "Pre shared key found" \
-            -S "No matched PSK or ticket" \
+            -S "No usable PSK or ticket" \
             -S "key exchange mode: psk$"  \
             -s "key exchange mode: psk_ephemeral"  \
             -S "key exchange mode: ephemeral"
@@ -206,7 +206,7 @@ run_test    "TLS 1.3: G->m: all/psk_ephemeral, fail, key id mismatch" \
             -s "found pre_shared_key extension" \
             -s "Found PSK_EPHEMERAL KEX MODE" \
             -s "Found PSK KEX MODE" \
-            -s "No matched PSK or ticket" \
+            -s "No usable PSK or ticket" \
             -S "key exchange mode: psk$"  \
             -S "key exchange mode: psk_ephemeral"  \
             -S "key exchange mode: ephemeral"
@@ -261,7 +261,7 @@ run_test    "TLS 1.3: G->m: ephemeral_all/psk_all, good" \
             -s "Found PSK_EPHEMERAL KEX MODE" \
             -S "Found PSK KEX MODE" \
             -s "Pre shared key found" \
-            -S "No matched PSK or ticket" \
+            -S "No usable PSK or ticket" \
             -S "key exchange mode: psk$"  \
             -s "key exchange mode: psk_ephemeral"  \
             -S "key exchange mode: ephemeral"
@@ -280,7 +280,7 @@ run_test    "TLS 1.3: G->m: ephemeral_all/psk_all, fail, key id mismatch" \
             -s "found pre_shared_key extension" \
             -s "Found PSK_EPHEMERAL KEX MODE" \
             -S "Found PSK KEX MODE" \
-            -s "No matched PSK or ticket" \
+            -s "No usable PSK or ticket" \
             -S "key exchange mode: psk$"  \
             -S "key exchange mode: psk_ephemeral"  \
             -S "key exchange mode: ephemeral"
@@ -319,7 +319,7 @@ run_test    "TLS 1.3: G->m: all/psk_all, good" \
             -s "Found PSK_EPHEMERAL KEX MODE" \
             -s "Found PSK KEX MODE" \
             -s "Pre shared key found" \
-            -S "No matched PSK or ticket" \
+            -S "No usable PSK or ticket" \
             -S "key exchange mode: psk$"  \
             -s "key exchange mode: psk_ephemeral"  \
             -S "key exchange mode: ephemeral"
@@ -338,7 +338,7 @@ run_test    "TLS 1.3: G->m: all/psk_all, fail, key id mismatch" \
             -s "found pre_shared_key extension" \
             -s "Found PSK_EPHEMERAL KEX MODE" \
             -s "Found PSK KEX MODE" \
-            -s "No matched PSK or ticket" \
+            -s "No usable PSK or ticket" \
             -S "key exchange mode: psk$"  \
             -S "key exchange mode: psk_ephemeral"  \
             -S "key exchange mode: ephemeral"
@@ -377,7 +377,7 @@ run_test    "TLS 1.3: G->m: psk_or_ephemeral/psk_all, good" \
             -S "Found PSK_EPHEMERAL KEX MODE" \
             -s "Found PSK KEX MODE" \
             -s "Pre shared key found" \
-            -S "No matched PSK or ticket" \
+            -S "No usable PSK or ticket" \
             -s "key exchange mode: psk$"  \
             -S "key exchange mode: psk_ephemeral"  \
             -S "key exchange mode: ephemeral"
@@ -396,7 +396,7 @@ run_test    "TLS 1.3: G->m: psk_or_ephemeral/psk_all, fail, key id mismatch" \
             -s "found pre_shared_key extension" \
             -S "Found PSK_EPHEMERAL KEX MODE" \
             -s "Found PSK KEX MODE" \
-            -s "No matched PSK or ticket" \
+            -s "No usable PSK or ticket" \
             -S "key exchange mode: psk$"  \
             -S "key exchange mode: psk_ephemeral"  \
             -S "key exchange mode: ephemeral"
@@ -435,7 +435,7 @@ run_test    "TLS 1.3: G->m: ephemeral_all/ephemeral_all, good" \
             -s "Found PSK_EPHEMERAL KEX MODE" \
             -S "Found PSK KEX MODE" \
             -s "Pre shared key found" \
-            -S "No matched PSK or ticket" \
+            -S "No usable PSK or ticket" \
             -S "key exchange mode: psk$"  \
             -s "key exchange mode: psk_ephemeral"  \
             -S "key exchange mode: ephemeral"
@@ -454,7 +454,7 @@ run_test    "TLS 1.3: G->m: ephemeral_all/ephemeral_all, good, key id mismatch, 
             -s "found pre_shared_key extension" \
             -s "Found PSK_EPHEMERAL KEX MODE" \
             -S "Found PSK KEX MODE" \
-            -s "No matched PSK or ticket" \
+            -s "No usable PSK or ticket" \
             -S "key exchange mode: psk$"  \
             -S "key exchange mode: psk_ephemeral"  \
             -s "key exchange mode: ephemeral"
@@ -493,7 +493,7 @@ run_test    "TLS 1.3: G->m: all/ephemeral_all, good" \
             -s "Found PSK_EPHEMERAL KEX MODE" \
             -s "Found PSK KEX MODE" \
             -s "Pre shared key found" \
-            -S "No matched PSK or ticket" \
+            -S "No usable PSK or ticket" \
             -S "key exchange mode: psk$"  \
             -s "key exchange mode: psk_ephemeral"  \
             -S "key exchange mode: ephemeral"
@@ -512,7 +512,7 @@ run_test    "TLS 1.3: G->m: all/ephemeral_all, good, key id mismatch, dhe." \
             -s "found pre_shared_key extension" \
             -s "Found PSK_EPHEMERAL KEX MODE" \
             -s "Found PSK KEX MODE" \
-            -s "No matched PSK or ticket" \
+            -s "No usable PSK or ticket" \
             -S "key exchange mode: psk$"  \
             -S "key exchange mode: psk_ephemeral"  \
             -s "key exchange mode: ephemeral"
@@ -550,8 +550,9 @@ run_test    "TLS 1.3: G->m: psk_or_ephemeral/ephemeral_all, good" \
             -s "found pre_shared_key extension" \
             -S "Found PSK_EPHEMERAL KEX MODE" \
             -s "Found PSK KEX MODE" \
-            -s "Pre shared key found" \
-            -S "No matched PSK or ticket" \
+            -s "No suitable PSK key exchange mode" \
+            -S "Pre shared key found" \
+            -s "No usable PSK or ticket" \
             -S "key exchange mode: psk$"  \
             -S "key exchange mode: psk_ephemeral"  \
             -s "key exchange mode: ephemeral"
@@ -572,7 +573,7 @@ run_test    "TLS 1.3: G->m: ephemeral_all/all, good" \
             -s "Found PSK_EPHEMERAL KEX MODE" \
             -S "Found PSK KEX MODE" \
             -s "Pre shared key found" \
-            -S "No matched PSK or ticket" \
+            -S "No usable PSK or ticket" \
             -S "key exchange mode: psk$"  \
             -s "key exchange mode: psk_ephemeral"  \
             -S "key exchange mode: ephemeral"
@@ -592,7 +593,7 @@ run_test    "TLS 1.3: G->m: ephemeral_all/all, good, key id mismatch, dhe." \
             -s "found pre_shared_key extension" \
             -s "Found PSK_EPHEMERAL KEX MODE" \
             -S "Found PSK KEX MODE" \
-            -s "No matched PSK or ticket" \
+            -s "No usable PSK or ticket" \
             -S "key exchange mode: psk$"  \
             -S "key exchange mode: psk_ephemeral"  \
             -s "key exchange mode: ephemeral"
@@ -633,7 +634,7 @@ run_test    "TLS 1.3: G->m: all/all, good" \
             -s "Found PSK_EPHEMERAL KEX MODE" \
             -s "Found PSK KEX MODE" \
             -s "Pre shared key found" \
-            -S "No matched PSK or ticket" \
+            -S "No usable PSK or ticket" \
             -S "key exchange mode: psk$"  \
             -s "key exchange mode: psk_ephemeral"  \
             -S "key exchange mode: ephemeral"
@@ -653,7 +654,7 @@ run_test    "TLS 1.3: G->m: all/all, good, key id mismatch, dhe." \
             -s "found pre_shared_key extension" \
             -s "Found PSK_EPHEMERAL KEX MODE" \
             -s "Found PSK KEX MODE" \
-            -s "No matched PSK or ticket" \
+            -s "No usable PSK or ticket" \
             -S "key exchange mode: psk$"  \
             -S "key exchange mode: psk_ephemeral"  \
             -s "key exchange mode: ephemeral"
@@ -694,7 +695,7 @@ run_test    "TLS 1.3: G->m: psk_or_ephemeral/all, good" \
             -S "Found PSK_EPHEMERAL KEX MODE" \
             -s "Found PSK KEX MODE" \
             -s "Pre shared key found" \
-            -S "No matched PSK or ticket" \
+            -S "No usable PSK or ticket" \
             -S "key exchange mode: psk$"  \
             -S "key exchange mode: psk_ephemeral"  \
             -s "key exchange mode: ephemeral"
@@ -733,8 +734,9 @@ run_test    "TLS 1.3: G->m: ephemeral_all/psk_or_ephemeral, good" \
             -s "found pre_shared_key extension" \
             -s "Found PSK_EPHEMERAL KEX MODE" \
             -S "Found PSK KEX MODE" \
-            -s "Pre shared key found" \
-            -S "No matched PSK or ticket" \
+            -s "No suitable PSK key exchange mode" \
+            -S "Pre shared key found" \
+            -s "No usable PSK or ticket" \
             -S "key exchange mode: psk$"  \
             -S "key exchange mode: psk_ephemeral"  \
             -s "key exchange mode: ephemeral"
@@ -754,7 +756,7 @@ run_test    "TLS 1.3: G->m: all/psk_or_ephemeral, good" \
             -s "Found PSK_EPHEMERAL KEX MODE" \
             -s "Found PSK KEX MODE" \
             -s "Pre shared key found" \
-            -S "No matched PSK or ticket" \
+            -S "No usable PSK or ticket" \
             -S "key exchange mode: psk$"  \
             -S "key exchange mode: psk_ephemeral"  \
             -s "key exchange mode: ephemeral"
@@ -793,7 +795,7 @@ run_test    "TLS 1.3: G->m: psk_or_ephemeral/psk_or_ephemeral, good" \
             -S "Found PSK_EPHEMERAL KEX MODE" \
             -s "Found PSK KEX MODE" \
             -s "Pre shared key found" \
-            -S "No matched PSK or ticket" \
+            -S "No usable PSK or ticket" \
             -S "key exchange mode: psk$"  \
             -S "key exchange mode: psk_ephemeral"  \
             -s "key exchange mode: ephemeral"
@@ -921,7 +923,7 @@ run_test    "TLS 1.3: O->m: all/psk, good" \
             -s "Found PSK_EPHEMERAL KEX MODE" \
             -s "Found PSK KEX MODE" \
             -s "Pre shared key found" \
-            -S "No matched PSK or ticket" \
+            -S "No usable PSK or ticket" \
             -s "key exchange mode: psk$"  \
             -S "key exchange mode: psk_ephemeral"  \
             -S "key exchange mode: ephemeral"
@@ -938,7 +940,7 @@ run_test    "TLS 1.3: O->m: all/psk, fail, key id mismatch" \
             -s "found pre_shared_key extension" \
             -s "Found PSK_EPHEMERAL KEX MODE" \
             -s "Found PSK KEX MODE" \
-            -s "No matched PSK or ticket" \
+            -s "No usable PSK or ticket" \
             -S "key exchange mode: psk$"  \
             -S "key exchange mode: psk_ephemeral"  \
             -S "key exchange mode: ephemeral"
@@ -973,7 +975,7 @@ run_test    "TLS 1.3: O->m: ephemeral_all/psk_ephemeral, good" \
             -s "Found PSK_EPHEMERAL KEX MODE" \
             -S "Found PSK KEX MODE" \
             -s "Pre shared key found" \
-            -S "No matched PSK or ticket" \
+            -S "No usable PSK or ticket" \
             -S "key exchange mode: psk$"  \
             -s "key exchange mode: psk_ephemeral"  \
             -S "key exchange mode: ephemeral"
@@ -990,7 +992,7 @@ run_test    "TLS 1.3: O->m: ephemeral_all/psk_ephemeral, fail, key id mismatch" 
             -s "found pre_shared_key extension" \
             -s "Found PSK_EPHEMERAL KEX MODE" \
             -S "Found PSK KEX MODE" \
-            -s "No matched PSK or ticket" \
+            -s "No usable PSK or ticket" \
             -S "key exchange mode: psk$"  \
             -S "key exchange mode: psk_ephemeral"  \
             -S "key exchange mode: ephemeral"
@@ -1025,7 +1027,7 @@ run_test    "TLS 1.3: O->m: all/psk_ephemeral, good" \
             -s "Found PSK_EPHEMERAL KEX MODE" \
             -s "Found PSK KEX MODE" \
             -s "Pre shared key found" \
-            -S "No matched PSK or ticket" \
+            -S "No usable PSK or ticket" \
             -S "key exchange mode: psk$"  \
             -s "key exchange mode: psk_ephemeral"  \
             -S "key exchange mode: ephemeral"
@@ -1042,7 +1044,7 @@ run_test    "TLS 1.3: O->m: all/psk_ephemeral, fail, key id mismatch" \
             -s "found pre_shared_key extension" \
             -s "Found PSK_EPHEMERAL KEX MODE" \
             -s "Found PSK KEX MODE" \
-            -s "No matched PSK or ticket" \
+            -s "No usable PSK or ticket" \
             -S "key exchange mode: psk$"  \
             -S "key exchange mode: psk_ephemeral"  \
             -S "key exchange mode: ephemeral"
@@ -1078,7 +1080,7 @@ run_test    "TLS 1.3: O->m: ephemeral_all/psk_all, good" \
             -s "Found PSK_EPHEMERAL KEX MODE" \
             -S "Found PSK KEX MODE" \
             -s "Pre shared key found" \
-            -S "No matched PSK or ticket" \
+            -S "No usable PSK or ticket" \
             -S "key exchange mode: psk$"  \
             -s "key exchange mode: psk_ephemeral"  \
             -S "key exchange mode: ephemeral"
@@ -1096,7 +1098,7 @@ run_test    "TLS 1.3: O->m: ephemeral_all/psk_all, fail, key id mismatch" \
             -s "found pre_shared_key extension" \
             -s "Found PSK_EPHEMERAL KEX MODE" \
             -S "Found PSK KEX MODE" \
-            -s "No matched PSK or ticket" \
+            -s "No usable PSK or ticket" \
             -S "key exchange mode: psk$"  \
             -S "key exchange mode: psk_ephemeral"  \
             -S "key exchange mode: ephemeral"
@@ -1133,7 +1135,7 @@ run_test    "TLS 1.3: O->m: all/psk_all, good" \
             -s "Found PSK_EPHEMERAL KEX MODE" \
             -s "Found PSK KEX MODE" \
             -s "Pre shared key found" \
-            -S "No matched PSK or ticket" \
+            -S "No usable PSK or ticket" \
             -S "key exchange mode: psk$"  \
             -s "key exchange mode: psk_ephemeral"  \
             -S "key exchange mode: ephemeral"
@@ -1151,7 +1153,7 @@ run_test    "TLS 1.3: O->m: all/psk_all, fail, key id mismatch" \
             -s "found pre_shared_key extension" \
             -s "Found PSK_EPHEMERAL KEX MODE" \
             -s "Found PSK KEX MODE" \
-            -s "No matched PSK or ticket" \
+            -s "No usable PSK or ticket" \
             -S "key exchange mode: psk$"  \
             -S "key exchange mode: psk_ephemeral"  \
             -S "key exchange mode: ephemeral"
@@ -1188,7 +1190,7 @@ run_test    "TLS 1.3: O->m: ephemeral_all/ephemeral_all, good" \
             -s "Found PSK_EPHEMERAL KEX MODE" \
             -S "Found PSK KEX MODE" \
             -s "Pre shared key found" \
-            -S "No matched PSK or ticket" \
+            -S "No usable PSK or ticket" \
             -S "key exchange mode: psk$"  \
             -s "key exchange mode: psk_ephemeral"  \
             -S "key exchange mode: ephemeral"
@@ -1206,7 +1208,7 @@ run_test    "TLS 1.3: O->m: ephemeral_all/ephemeral_all, good, key id mismatch, 
             -s "found pre_shared_key extension" \
             -s "Found PSK_EPHEMERAL KEX MODE" \
             -S "Found PSK KEX MODE" \
-            -s "No matched PSK or ticket" \
+            -s "No usable PSK or ticket" \
             -S "key exchange mode: psk$"  \
             -S "key exchange mode: psk_ephemeral"  \
             -s "key exchange mode: ephemeral"
@@ -1243,7 +1245,7 @@ run_test    "TLS 1.3: O->m: all/ephemeral_all, good" \
             -s "Found PSK_EPHEMERAL KEX MODE" \
             -s "Found PSK KEX MODE" \
             -s "Pre shared key found" \
-            -S "No matched PSK or ticket" \
+            -S "No usable PSK or ticket" \
             -S "key exchange mode: psk$"  \
             -s "key exchange mode: psk_ephemeral"  \
             -S "key exchange mode: ephemeral"
@@ -1261,7 +1263,7 @@ run_test    "TLS 1.3: O->m: all/ephemeral_all, good, key id mismatch, dhe." \
             -s "found pre_shared_key extension" \
             -s "Found PSK_EPHEMERAL KEX MODE" \
             -s "Found PSK KEX MODE" \
-            -s "No matched PSK or ticket" \
+            -s "No usable PSK or ticket" \
             -S "key exchange mode: psk$"  \
             -S "key exchange mode: psk_ephemeral"  \
             -s "key exchange mode: ephemeral"
@@ -1299,7 +1301,7 @@ run_test    "TLS 1.3: O->m: ephemeral_all/all, good" \
             -s "Found PSK_EPHEMERAL KEX MODE" \
             -S "Found PSK KEX MODE" \
             -s "Pre shared key found" \
-            -S "No matched PSK or ticket" \
+            -S "No usable PSK or ticket" \
             -S "key exchange mode: psk$"  \
             -s "key exchange mode: psk_ephemeral"  \
             -S "key exchange mode: ephemeral"
@@ -1318,7 +1320,7 @@ run_test    "TLS 1.3: O->m: ephemeral_all/all, good, key id mismatch, dhe." \
             -s "found pre_shared_key extension" \
             -s "Found PSK_EPHEMERAL KEX MODE" \
             -S "Found PSK KEX MODE" \
-            -s "No matched PSK or ticket" \
+            -s "No usable PSK or ticket" \
             -S "key exchange mode: psk$"  \
             -S "key exchange mode: psk_ephemeral"  \
             -s "key exchange mode: ephemeral"
@@ -1357,7 +1359,7 @@ run_test    "TLS 1.3: O->m: all/all, good" \
             -s "Found PSK_EPHEMERAL KEX MODE" \
             -s "Found PSK KEX MODE" \
             -s "Pre shared key found" \
-            -S "No matched PSK or ticket" \
+            -S "No usable PSK or ticket" \
             -S "key exchange mode: psk$"  \
             -s "key exchange mode: psk_ephemeral"  \
             -S "key exchange mode: ephemeral"
@@ -1376,7 +1378,7 @@ run_test    "TLS 1.3: O->m: all/all, good, key id mismatch, dhe." \
             -s "found pre_shared_key extension" \
             -s "Found PSK_EPHEMERAL KEX MODE" \
             -s "Found PSK KEX MODE" \
-            -s "No matched PSK or ticket" \
+            -s "No usable PSK or ticket" \
             -S "key exchange mode: psk$"  \
             -S "key exchange mode: psk_ephemeral"  \
             -s "key exchange mode: ephemeral"
@@ -1413,8 +1415,9 @@ run_test    "TLS 1.3: O->m: ephemeral_all/psk_or_ephemeral, good" \
             -s "found pre_shared_key extension" \
             -s "Found PSK_EPHEMERAL KEX MODE" \
             -S "Found PSK KEX MODE" \
-            -s "Pre shared key found" \
-            -S "No matched PSK or ticket" \
+            -s "No suitable PSK key exchange mode" \
+            -S "Pre shared key found" \
+            -s "No usable PSK or ticket" \
             -S "key exchange mode: psk$"  \
             -S "key exchange mode: psk_ephemeral"  \
             -s "key exchange mode: ephemeral"
@@ -1433,7 +1436,7 @@ run_test    "TLS 1.3: O->m: all/psk_or_ephemeral, good" \
             -s "Found PSK_EPHEMERAL KEX MODE" \
             -s "Found PSK KEX MODE" \
             -s "Pre shared key found" \
-            -S "No matched PSK or ticket" \
+            -S "No usable PSK or ticket" \
             -S "key exchange mode: psk$"  \
             -S "key exchange mode: psk_ephemeral"  \
             -s "key exchange mode: ephemeral"
@@ -1580,7 +1583,7 @@ run_test    "TLS 1.3: m->m: psk/psk, fail, key id mismatch" \
             -c "client hello, adding pre_shared_key extension, omitting PSK binder list" \
             -c "client hello, adding psk_key_exchange_modes extension" \
             -c "client hello, adding PSK binder list" \
-            -s "No matched PSK or ticket"
+            -s "No usable PSK or ticket"
 
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_config_enabled MBEDTLS_SSL_SRV_C
@@ -1665,7 +1668,7 @@ run_test    "TLS 1.3: m->m: psk/psk_all, fail, key id mismatch" \
             -c "client hello, adding pre_shared_key extension, omitting PSK binder list" \
             -c "client hello, adding psk_key_exchange_modes extension" \
             -c "client hello, adding PSK binder list" \
-            -s "No matched PSK or ticket" \
+            -s "No usable PSK or ticket" \
             -s "ClientHello message misses mandatory extensions."
 
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -1711,7 +1714,7 @@ run_test    "TLS 1.3: m->m: psk/all, fail, key id mismatch" \
             -c "client hello, adding pre_shared_key extension, omitting PSK binder list" \
             -c "client hello, adding psk_key_exchange_modes extension" \
             -c "client hello, adding PSK binder list" \
-            -s "No matched PSK or ticket" \
+            -s "No usable PSK or ticket" \
             -s "ClientHello message misses mandatory extensions."
 
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -1769,7 +1772,7 @@ run_test    "TLS 1.3: m->m: psk_ephemeral/psk_ephemeral, fail, key id mismatch" 
             -c "client hello, adding pre_shared_key extension, omitting PSK binder list" \
             -c "client hello, adding psk_key_exchange_modes extension" \
             -c "client hello, adding PSK binder list" \
-            -s "No matched PSK or ticket" \
+            -s "No usable PSK or ticket" \
             -s "ClientHello message misses mandatory extensions."
 
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -1827,7 +1830,7 @@ run_test    "TLS 1.3: m->m: psk_ephemeral/ephemeral_all, fail, key id mismatch" 
             -c "client hello, adding pre_shared_key extension, omitting PSK binder list" \
             -c "client hello, adding psk_key_exchange_modes extension" \
             -c "client hello, adding PSK binder list" \
-            -s "No matched PSK or ticket"
+            -s "No usable PSK or ticket"
 
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_config_enabled MBEDTLS_SSL_SRV_C
@@ -1870,7 +1873,7 @@ run_test    "TLS 1.3: m->m: psk_ephemeral/psk_all, fail, key id mismatch" \
             -c "client hello, adding pre_shared_key extension, omitting PSK binder list" \
             -c "client hello, adding psk_key_exchange_modes extension" \
             -c "client hello, adding PSK binder list" \
-            -s "No matched PSK or ticket" \
+            -s "No usable PSK or ticket" \
             -s "ClientHello message misses mandatory extensions."
 
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -1916,7 +1919,7 @@ run_test    "TLS 1.3: m->m: psk_ephemeral/all, fail, key id mismatch" \
             -c "client hello, adding pre_shared_key extension, omitting PSK binder list" \
             -c "client hello, adding psk_key_exchange_modes extension" \
             -c "client hello, adding PSK binder list" \
-            -s "No matched PSK or ticket" \
+            -s "No usable PSK or ticket" \
 
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_config_enabled MBEDTLS_SSL_SRV_C
@@ -2047,7 +2050,7 @@ run_test    "TLS 1.3: m->m: ephemeral_all/psk_ephemeral, fail, key id mismatch" 
             -c "client hello, adding pre_shared_key extension, omitting PSK binder list" \
             -c "client hello, adding psk_key_exchange_modes extension" \
             -c "client hello, adding PSK binder list" \
-            -s "No matched PSK or ticket"
+            -s "No usable PSK or ticket"
 
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_config_enabled MBEDTLS_SSL_SRV_C
@@ -2106,7 +2109,7 @@ run_test    "TLS 1.3: m->m: ephemeral_all/ephemeral_all,good,key id mismatch,fal
             -c "client hello, adding pre_shared_key extension, omitting PSK binder list" \
             -c "client hello, adding psk_key_exchange_modes extension" \
             -c "client hello, adding PSK binder list" \
-            -s "No matched PSK or ticket" \
+            -s "No usable PSK or ticket" \
             -s "key exchange mode: ephemeral"
 
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -2152,7 +2155,7 @@ run_test    "TLS 1.3: m->m: ephemeral_all/psk_all, fail, key id mismatch" \
             -c "client hello, adding pre_shared_key extension, omitting PSK binder list" \
             -c "client hello, adding psk_key_exchange_modes extension" \
             -c "client hello, adding PSK binder list" \
-            -s "No matched PSK or ticket" \
+            -s "No usable PSK or ticket" \
             -s "ClientHello message misses mandatory extensions."
 
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -2199,7 +2202,7 @@ run_test    "TLS 1.3: m->m: ephemeral_all/all, good, key id mismatch, fallback" 
             -c "client hello, adding pre_shared_key extension, omitting PSK binder list" \
             -c "client hello, adding psk_key_exchange_modes extension" \
             -c "client hello, adding PSK binder list" \
-            -s "No matched PSK or ticket" \
+            -s "No usable PSK or ticket" \
             -s "key exchange mode: ephemeral"
 
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -2288,7 +2291,7 @@ run_test    "TLS 1.3: m->m: psk_all/psk_ephemeral, fail, key id mismatch" \
             -c "client hello, adding pre_shared_key extension, omitting PSK binder list" \
             -c "client hello, adding psk_key_exchange_modes extension" \
             -c "client hello, adding PSK binder list" \
-            -s "No matched PSK or ticket" \
+            -s "No usable PSK or ticket" \
             -s "ClientHello message misses mandatory extensions."
 
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -2348,7 +2351,7 @@ run_test    "TLS 1.3: m->m: psk_all/ephemeral_all, fail, key id mismatch" \
             -c "client hello, adding pre_shared_key extension, omitting PSK binder list" \
             -c "client hello, adding psk_key_exchange_modes extension" \
             -c "client hello, adding PSK binder list" \
-            -s "No matched PSK or ticket"
+            -s "No usable PSK or ticket"
 
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_config_enabled MBEDTLS_SSL_SRV_C
@@ -2392,7 +2395,7 @@ run_test    "TLS 1.3: m->m: psk_all/psk_all, fail, key id mismatch" \
             -c "client hello, adding pre_shared_key extension, omitting PSK binder list" \
             -c "client hello, adding psk_key_exchange_modes extension" \
             -c "client hello, adding PSK binder list" \
-            -s "No matched PSK or ticket" \
+            -s "No usable PSK or ticket" \
             -s "ClientHello message misses mandatory extensions."
 
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -2438,7 +2441,7 @@ run_test    "TLS 1.3: m->m: psk_all/all, fail, key id mismatch" \
             -c "client hello, adding pre_shared_key extension, omitting PSK binder list" \
             -c "client hello, adding psk_key_exchange_modes extension" \
             -c "client hello, adding PSK binder list" \
-            -s "No matched PSK or ticket"
+            -s "No usable PSK or ticket"
 
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_config_enabled MBEDTLS_SSL_SRV_C
@@ -2485,7 +2488,7 @@ run_test    "TLS 1.3: m->m: all/psk, fail, key id mismatch" \
             -c "client hello, adding pre_shared_key extension, omitting PSK binder list" \
             -c "client hello, adding psk_key_exchange_modes extension" \
             -c "client hello, adding PSK binder list" \
-            -s "No matched PSK or ticket" \
+            -s "No usable PSK or ticket" \
             -s "ClientHello message misses mandatory extensions."
 
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -2532,7 +2535,7 @@ run_test    "TLS 1.3: m->m: all/psk_ephemeral, fail, key id mismatch" \
             -c "client hello, adding pre_shared_key extension, omitting PSK binder list" \
             -c "client hello, adding psk_key_exchange_modes extension" \
             -c "client hello, adding PSK binder list" \
-            -s "No matched PSK or ticket" \
+            -s "No usable PSK or ticket" \
             -s "ClientHello message misses mandatory extensions."
 
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -2595,7 +2598,7 @@ run_test    "TLS 1.3: m->m: all/ephemeral_all, good, key id mismatch, fallback" 
             -c "client hello, adding pre_shared_key extension, omitting PSK binder list" \
             -c "client hello, adding psk_key_exchange_modes extension" \
             -c "client hello, adding PSK binder list" \
-            -s "No matched PSK or ticket" \
+            -s "No usable PSK or ticket" \
             -c "Selected key exchange mode: ephemeral" \
             -c "HTTP/1.0 200 OK"
 
@@ -2643,7 +2646,7 @@ run_test    "TLS 1.3: m->m: all/psk_all, fail, key id mismatch" \
             -c "client hello, adding pre_shared_key extension, omitting PSK binder list" \
             -c "client hello, adding psk_key_exchange_modes extension" \
             -c "client hello, adding PSK binder list" \
-            -s "No matched PSK or ticket" \
+            -s "No usable PSK or ticket" \
             -s "ClientHello message misses mandatory extensions."
 
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -2690,7 +2693,7 @@ run_test    "TLS 1.3: m->m: all/all, good, key id mismatch, fallback" \
             -c "client hello, adding pre_shared_key extension, omitting PSK binder list" \
             -c "client hello, adding psk_key_exchange_modes extension" \
             -c "client hello, adding PSK binder list" \
-            -s "No matched PSK or ticket" \
+            -s "No usable PSK or ticket" \
             -s "key exchange mode: ephemeral"
 
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3

--- a/tests/opt-testcases/tls13-kex-modes.sh
+++ b/tests/opt-testcases/tls13-kex-modes.sh
@@ -550,7 +550,7 @@ run_test    "TLS 1.3: G->m: psk_or_ephemeral/ephemeral_all, good" \
             -s "found pre_shared_key extension" \
             -S "Found PSK_EPHEMERAL KEX MODE" \
             -s "Found PSK KEX MODE" \
-            -S "Pre shared key found" \
+            -s "Pre shared key found" \
             -S "No matched PSK or ticket" \
             -S "key exchange mode: psk$"  \
             -S "key exchange mode: psk_ephemeral"  \
@@ -733,7 +733,7 @@ run_test    "TLS 1.3: G->m: ephemeral_all/psk_or_ephemeral, good" \
             -s "found pre_shared_key extension" \
             -s "Found PSK_EPHEMERAL KEX MODE" \
             -S "Found PSK KEX MODE" \
-            -S "Pre shared key found" \
+            -s "Pre shared key found" \
             -S "No matched PSK or ticket" \
             -S "key exchange mode: psk$"  \
             -S "key exchange mode: psk_ephemeral"  \
@@ -1413,7 +1413,7 @@ run_test    "TLS 1.3: O->m: ephemeral_all/psk_or_ephemeral, good" \
             -s "found pre_shared_key extension" \
             -s "Found PSK_EPHEMERAL KEX MODE" \
             -S "Found PSK KEX MODE" \
-            -S "Pre shared key found" \
+            -s "Pre shared key found" \
             -S "No matched PSK or ticket" \
             -S "key exchange mode: psk$"  \
             -S "key exchange mode: psk_ephemeral"  \

--- a/tests/opt-testcases/tls13-misc.sh
+++ b/tests/opt-testcases/tls13-misc.sh
@@ -543,7 +543,7 @@ requires_all_configs_enabled MBEDTLS_SSL_EARLY_DATA MBEDTLS_SSL_SESSION_TICKETS 
                              MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 run_test "TLS 1.3 m->m: Ephemeral over PSK kex with early data enabled" \
          "$P_SRV force_version=tls13 debug_level=4 max_early_data_size=1024" \
-         "$P_CLI debug_level=4 early_data=$EARLY_DATA_INPUT tls13_kex_modes=psk_or_ephemeral reco_mode=1 reconnect=1" \
+         "$P_CLI debug_level=4 early_data=1 tls13_kex_modes=psk_or_ephemeral reco_mode=1 reconnect=1" \
          0 \
          -s "key exchange mode: ephemeral" \
          -S "key exchange mode: psk" \

--- a/tests/opt-testcases/tls13-misc.sh
+++ b/tests/opt-testcases/tls13-misc.sh
@@ -535,3 +535,18 @@ run_test "TLS 1.3 G->m: EarlyData: feature is enabled, good." \
          -s "$( tail -1 $EARLY_DATA_INPUT )"                                \
          -s "200 early data bytes read"                                     \
          -s "106 early data bytes read"
+
+requires_all_configs_enabled MBEDTLS_SSL_EARLY_DATA MBEDTLS_SSL_SESSION_TICKETS \
+                             MBEDTLS_SSL_CLI_C MBEDTLS_SSL_SRV_C \
+                             MBEDTLS_DEBUG_C MBEDTLS_HAVE_TIME \
+                             MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_ENABLED \
+                             MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
+run_test "TLS 1.3 m->m: Ephemeral over PSK kex with early data enabled" \
+         "$P_SRV force_version=tls13 debug_level=4 max_early_data_size=1024" \
+         "$P_CLI debug_level=4 early_data=$EARLY_DATA_INPUT tls13_kex_modes=psk_or_ephemeral reco_mode=1 reconnect=1" \
+         0 \
+         -s "key exchange mode: ephemeral" \
+         -S "key exchange mode: psk" \
+         -s "found matched identity" \
+         -s "EarlyData: rejected, not a session resumption" \
+         -C "EncryptedExtensions: early_data(42) extension exists."

--- a/tests/opt-testcases/tls13-misc.sh
+++ b/tests/opt-testcases/tls13-misc.sh
@@ -353,8 +353,8 @@ run_test "TLS 1.3 m->m: Resumption with ticket flags, psk/none." \
          -s "key exchange mode: ephemeral" \
          -S "key exchange mode: psk_ephemeral" \
          -S "key exchange mode: psk$" \
-         -s "No suitable key exchange mode" \
-         -s "No matched PSK or ticket"
+         -s "No suitable PSK key exchange mode" \
+         -s "No usable PSK or ticket"
 
 requires_all_configs_enabled MBEDTLS_SSL_SESSION_TICKETS \
                              MBEDTLS_SSL_SRV_C MBEDTLS_SSL_CLI_C MBEDTLS_DEBUG_C \
@@ -365,7 +365,7 @@ run_test "TLS 1.3 m->m: Resumption with ticket flags, psk/psk." \
          "$P_CLI debug_level=4 tls13_kex_modes=psk_or_ephemeral reconnect=1" \
          0 \
          -c "Pre-configured PSK number = 1" \
-         -S "No suitable key exchange mode" \
+         -S "No suitable PSK key exchange mode" \
          -s "found matched identity"
 
 requires_all_configs_enabled MBEDTLS_SSL_SESSION_TICKETS \
@@ -381,8 +381,8 @@ run_test "TLS 1.3 m->m: Resumption with ticket flags, psk/psk_ephemeral." \
          -s "key exchange mode: ephemeral" \
          -S "key exchange mode: psk_ephemeral" \
          -S "key exchange mode: psk$" \
-         -s "No suitable key exchange mode" \
-         -s "No matched PSK or ticket"
+         -s "No suitable PSK key exchange mode" \
+         -s "No usable PSK or ticket"
 
 requires_all_configs_enabled MBEDTLS_SSL_SESSION_TICKETS \
                              MBEDTLS_SSL_SRV_C MBEDTLS_SSL_CLI_C MBEDTLS_DEBUG_C \
@@ -393,7 +393,7 @@ run_test "TLS 1.3 m->m: Resumption with ticket flags, psk/psk_all." \
          "$P_CLI debug_level=4 tls13_kex_modes=psk_or_ephemeral reconnect=1" \
          0 \
          -c "Pre-configured PSK number = 1" \
-         -S "No suitable key exchange mode" \
+         -S "No suitable PSK key exchange mode" \
          -s "found matched identity"
 
 requires_all_configs_enabled MBEDTLS_SSL_SESSION_TICKETS \
@@ -409,8 +409,8 @@ run_test "TLS 1.3 m->m: Resumption with ticket flags, psk_ephemeral/none." \
          -s "key exchange mode: ephemeral" \
          -S "key exchange mode: psk_ephemeral" \
          -S "key exchange mode: psk$" \
-         -s "No suitable key exchange mode" \
-         -s "No matched PSK or ticket"
+         -s "No suitable PSK key exchange mode" \
+         -s "No usable PSK or ticket"
 
 requires_all_configs_enabled MBEDTLS_SSL_SESSION_TICKETS \
                              MBEDTLS_SSL_SRV_C MBEDTLS_SSL_CLI_C MBEDTLS_DEBUG_C \
@@ -425,8 +425,8 @@ run_test "TLS 1.3 m->m: Resumption with ticket flags, psk_ephemeral/psk." \
          -s "key exchange mode: ephemeral" \
          -S "key exchange mode: psk_ephemeral" \
          -S "key exchange mode: psk$" \
-         -s "No suitable key exchange mode" \
-         -s "No matched PSK or ticket"
+         -s "No suitable PSK key exchange mode" \
+         -s "No usable PSK or ticket"
 
 requires_all_configs_enabled MBEDTLS_SSL_SESSION_TICKETS \
                              MBEDTLS_SSL_SRV_C MBEDTLS_SSL_CLI_C MBEDTLS_DEBUG_C \
@@ -437,7 +437,7 @@ run_test "TLS 1.3 m->m: Resumption with ticket flags, psk_ephemeral/psk_ephemera
          "$P_CLI debug_level=4 tls13_kex_modes=ephemeral_all reconnect=1" \
          0 \
          -c "Pre-configured PSK number = 1" \
-         -S "No suitable key exchange mode" \
+         -S "No suitable PSK key exchange mode" \
          -s "found matched identity" \
          -s "key exchange mode: psk_ephemeral"
 
@@ -450,7 +450,7 @@ run_test "TLS 1.3 m->m: Resumption with ticket flags, psk_ephemeral/psk_all." \
          "$P_CLI debug_level=4 tls13_kex_modes=ephemeral_all reconnect=1" \
          0 \
          -c "Pre-configured PSK number = 1" \
-         -S "No suitable key exchange mode" \
+         -S "No suitable PSK key exchange mode" \
          -s "found matched identity" \
          -s "key exchange mode: psk_ephemeral"
 
@@ -468,8 +468,8 @@ run_test "TLS 1.3 m->m: Resumption with ticket flags, psk_all/none." \
          -s "key exchange mode: ephemeral" \
          -S "key exchange mode: psk_ephemeral" \
          -S "key exchange mode: psk$" \
-         -s "No suitable key exchange mode" \
-         -s "No matched PSK or ticket"
+         -s "No suitable PSK key exchange mode" \
+         -s "No usable PSK or ticket"
 
 requires_all_configs_enabled MBEDTLS_SSL_SESSION_TICKETS \
                              MBEDTLS_SSL_SRV_C MBEDTLS_SSL_CLI_C MBEDTLS_DEBUG_C \
@@ -481,7 +481,7 @@ run_test "TLS 1.3 m->m: Resumption with ticket flags, psk_all/psk." \
          "$P_CLI debug_level=4 tls13_kex_modes=all reconnect=1" \
          0 \
          -c "Pre-configured PSK number = 1" \
-         -S "No suitable key exchange mode" \
+         -S "No suitable PSK key exchange mode" \
          -s "found matched identity"
 
 requires_all_configs_enabled MBEDTLS_SSL_SESSION_TICKETS \
@@ -494,7 +494,7 @@ run_test "TLS 1.3 m->m: Resumption with ticket flags, psk_all/psk_ephemeral." \
          "$P_CLI debug_level=4 tls13_kex_modes=all reconnect=1" \
          0 \
          -c "Pre-configured PSK number = 1" \
-         -S "No suitable key exchange mode" \
+         -S "No suitable PSK key exchange mode" \
          -s "found matched identity" \
          -s "key exchange mode: psk_ephemeral"
 
@@ -508,7 +508,7 @@ run_test "TLS 1.3 m->m: Resumption with ticket flags, psk_all/psk_all." \
          "$P_CLI debug_level=4 tls13_kex_modes=all reconnect=1" \
          0 \
          -c "Pre-configured PSK number = 1" \
-         -S "No suitable key exchange mode" \
+         -S "No suitable PSK key exchange mode" \
          -s "found matched identity" \
          -s "key exchange mode: psk_ephemeral"
 


### PR DESCRIPTION
## Description
Fix #8448  

## PR checklist
- [x] **changelog** not required, implementation rework
- [x] **backport** not required, no TLS 1.3 support in 2.28
- [x] **tests** one additional ssl-opt.sh test