### PR TITLE
Improve support of mbedtls_psa_get_random in client-only builds

### DIFF
--- a/ChangeLog.d/8825.txt
+++ b/ChangeLog.d/8825.txt
@@ -1,6 +1,6 @@
 Features
    * mbedtls_psa_get_random() is always available as soon as
-     MBEDTLS_PSA_CRYPTO_C is enabled at build time and psa_crypto_init() is
+     MBEDTLS_PSA_CRYPTO_CLIENT is enabled at build time and psa_crypto_init() is
      called at runtime. This together with MBEDTLS_PSA_RANDOM_STATE can be
      used as random number generator function(f_rng) and context (p_rng) in
      legacy functions.

--- a/ChangeLog.d/8825.txt
+++ b/ChangeLog.d/8825.txt
@@ -2,5 +2,5 @@ Features
    * mbedtls_psa_get_random() is always available as soon as
      MBEDTLS_PSA_CRYPTO_CLIENT is enabled at build time and psa_crypto_init() is
      called at runtime. This together with MBEDTLS_PSA_RANDOM_STATE can be
-     used as random number generator function(f_rng) and context (p_rng) in
+     used as random number generator function (f_rng) and context (p_rng) in
      legacy functions.

--- a/ChangeLog.d/8825.txt
+++ b/ChangeLog.d/8825.txt
@@ -1,0 +1,6 @@
+Features
+   * mbedtls_psa_get_random() is always available as soon as
+     MBEDTLS_PSA_CRYPTO_C is enabled at build time and psa_crypto_init() is
+     called at runtime. This together with MBEDTLS_PSA_RANDOM_STATE can be
+     used as random number generator function(f_rng) and context (p_rng) in
+     legacy functions.

--- a/include/mbedtls/psa_util.h
+++ b/include/mbedtls/psa_util.h
@@ -23,42 +23,22 @@
 
 #if defined(MBEDTLS_PSA_CRYPTO_C)
 
-/* Expose whatever RNG the PSA subsystem uses to applications using the
- * mbedtls_xxx API. The declarations and definitions here need to be
- * consistent with the implementation in library/psa_crypto_random_impl.h.
- * See that file for implementation documentation. */
-
-
-/* The type of a `f_rng` random generator function that many library functions
- * take.
- *
- * This type name is not part of the Mbed TLS stable API. It may be renamed
- * or moved without warning.
- */
-typedef int mbedtls_f_rng_t(void *p_rng, unsigned char *output, size_t output_size);
-
-#if defined(MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG)
-
 /** The random generator function for the PSA subsystem.
  *
  * This function is suitable as the `f_rng` random generator function
- * parameter of many `mbedtls_xxx` functions. Use #MBEDTLS_PSA_RANDOM_STATE
- * to obtain the \p p_rng parameter.
+ * parameter of many `mbedtls_xxx` functions.
  *
  * The implementation of this function depends on the configuration of the
  * library.
- *
- * \note Depending on the configuration, this may be a function or
- *       a pointer to a function.
  *
  * \note This function may only be used if the PSA crypto subsystem is active.
  *       This means that you must call psa_crypto_init() before any call to
  *       this function, and you must not call this function after calling
  *       mbedtls_psa_crypto_free().
  *
- * \param p_rng         The random generator context. This must be
- *                      #MBEDTLS_PSA_RANDOM_STATE. No other state is
- *                      supported.
+ * \param p_rng         This parameter is only kept for backward compatibility
+ *                      reasons with legacy `f_rng` functions and it's ignored.
+ *                      Set to #MBEDTLS_PSA_RANDOM_STATE or NULL.
  * \param output        The buffer to fill. It must have room for
  *                      \c output_size bytes.
  * \param output_size   The number of bytes to write to \p output.
@@ -80,32 +60,11 @@ int mbedtls_psa_get_random(void *p_rng,
 
 /** The random generator state for the PSA subsystem.
  *
- * This macro expands to an expression which is suitable as the `p_rng`
- * random generator state parameter of many `mbedtls_xxx` functions.
- * It must be used in combination with the random generator function
- * mbedtls_psa_get_random().
- *
- * The implementation of this macro depends on the configuration of the
- * library. Do not make any assumption on its nature.
+ * This macro always expands to NULL because the `p_rng` parameter is unused
+ * in mbedtls_psa_get_random(), but it's kept for interface's backward
+ * compatibility.
  */
-#define MBEDTLS_PSA_RANDOM_STATE NULL
-
-#else /* !defined(MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG) */
-
-#if defined(MBEDTLS_CTR_DRBG_C)
-#include "mbedtls/ctr_drbg.h"
-typedef mbedtls_ctr_drbg_context mbedtls_psa_drbg_context_t;
-static mbedtls_f_rng_t *const mbedtls_psa_get_random = mbedtls_ctr_drbg_random;
-#elif defined(MBEDTLS_HMAC_DRBG_C)
-#include "mbedtls/hmac_drbg.h"
-typedef mbedtls_hmac_drbg_context mbedtls_psa_drbg_context_t;
-static mbedtls_f_rng_t *const mbedtls_psa_get_random = mbedtls_hmac_drbg_random;
-#endif
-extern mbedtls_psa_drbg_context_t *const mbedtls_psa_random_state;
-
-#define MBEDTLS_PSA_RANDOM_STATE mbedtls_psa_random_state
-
-#endif /* !defined(MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG) */
+#define MBEDTLS_PSA_RANDOM_STATE    NULL
 
 /** \defgroup psa_tls_helpers TLS helper functions
  * @{

--- a/include/mbedtls/psa_util.h
+++ b/include/mbedtls/psa_util.h
@@ -21,7 +21,7 @@
  * otherwise error codes would be unknown in test_suite_psa_crypto_util.data.*/
 #include <mbedtls/asn1write.h>
 
-#if defined(MBEDTLS_PSA_CRYPTO_C)
+#if defined(MBEDTLS_PSA_CRYPTO_CLIENT)
 
 /** The random generator function for the PSA subsystem.
  *
@@ -139,7 +139,7 @@ static inline mbedtls_md_type_t mbedtls_md_type_from_psa_alg(psa_algorithm_t psa
 {
     return (mbedtls_md_type_t) (psa_alg & PSA_ALG_HASH_MASK);
 }
-#endif /* MBEDTLS_PSA_CRYPTO_C */
+#endif /* MBEDTLS_PSA_CRYPTO_CLIENT */
 
 #if defined(MBEDTLS_PSA_UTIL_HAVE_ECDSA)
 

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -7373,12 +7373,16 @@ psa_status_t psa_generate_random(uint8_t *output,
 #else /* MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG */
 
     while (output_size > 0) {
+        int ret = MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED;
         size_t request_size =
             (output_size > MBEDTLS_PSA_RANDOM_MAX_REQUEST ?
              MBEDTLS_PSA_RANDOM_MAX_REQUEST :
              output_size);
-        int ret = mbedtls_psa_legacy_get_random(&global_data.rng.drbg,
-                                                output, request_size);
+#if defined(MBEDTLS_CTR_DRBG_C)
+        ret = mbedtls_ctr_drbg_random(&global_data.rng.drbg, output, request_size);
+#elif defined(MBEDTLS_HMAC_DRBG_C)
+        ret = mbedtls_hmac_drbg_random(&global_data.rng.drbg, output, request_size);
+#endif /* !MBEDTLS_CTR_DRBG_C && !MBEDTLS_HMAC_DRBG_C */
         if (ret != 0) {
             return mbedtls_to_psa_error(ret);
         }

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -7394,39 +7394,6 @@ psa_status_t psa_generate_random(uint8_t *output,
 #endif /* MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG */
 }
 
-/* Wrapper function allowing the classic API to use the PSA RNG.
- *
- * `mbedtls_psa_get_random(MBEDTLS_PSA_RANDOM_STATE, ...)` calls
- * `psa_generate_random(...)`. The state parameter is ignored since the
- * PSA API doesn't support passing an explicit state.
- *
- * In the non-external case, psa_generate_random() calls an
- * `mbedtls_xxx_drbg_random` function which has exactly the same signature
- * and semantics as mbedtls_psa_get_random(). As an optimization,
- * instead of doing this back-and-forth between the PSA API and the
- * classic API, psa_crypto_random_impl.h defines `mbedtls_psa_get_random`
- * as a constant function pointer to `mbedtls_xxx_drbg_random`.
- */
-#if defined(MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG)
-int mbedtls_psa_get_random(void *p_rng,
-                           unsigned char *output,
-                           size_t output_size)
-{
-    /* This function takes a pointer to the RNG state because that's what
-     * classic mbedtls functions using an RNG expect. The PSA RNG manages
-     * its own state internally and doesn't let the caller access that state.
-     * So we just ignore the state parameter, and in practice we'll pass
-     * NULL. */
-    (void) p_rng;
-    psa_status_t status = psa_generate_random(output, output_size);
-    if (status == PSA_SUCCESS) {
-        return 0;
-    } else {
-        return MBEDTLS_ERR_ENTROPY_SOURCE_FAILED;
-    }
-}
-#endif /* MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG */
-
 #if defined(MBEDTLS_PSA_INJECT_ENTROPY)
 psa_status_t mbedtls_psa_inject_entropy(const uint8_t *seed,
                                         size_t seed_size)

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -102,7 +102,7 @@ typedef struct {
 static psa_global_data_t global_data;
 
 #if !defined(MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG)
-mbedtls_psa_drbg_context_t *const mbedtls_psa_random_state =
+mbedtls_psa_drbg_context_t *const mbedtls_psa_drbg_ctx =
     &global_data.rng.drbg;
 #endif
 
@@ -7322,7 +7322,7 @@ static void mbedtls_psa_random_init(mbedtls_psa_random_context_t *rng)
                                MBEDTLS_ENTROPY_SOURCE_STRONG);
 #endif
 
-    mbedtls_psa_drbg_init(MBEDTLS_PSA_RANDOM_STATE);
+    mbedtls_psa_drbg_init(MBEDTLS_PSA_DRBG_CTX);
 #endif /* MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG */
 }
 
@@ -7333,7 +7333,7 @@ static void mbedtls_psa_random_free(mbedtls_psa_random_context_t *rng)
 #if defined(MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG)
     memset(rng, 0, sizeof(*rng));
 #else /* MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG */
-    mbedtls_psa_drbg_free(MBEDTLS_PSA_RANDOM_STATE);
+    mbedtls_psa_drbg_free(MBEDTLS_PSA_DRBG_CTX);
     rng->entropy_free(&rng->entropy);
 #endif /* MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG */
 }
@@ -7382,8 +7382,8 @@ psa_status_t psa_generate_random(uint8_t *output,
             (output_size > MBEDTLS_PSA_RANDOM_MAX_REQUEST ?
              MBEDTLS_PSA_RANDOM_MAX_REQUEST :
              output_size);
-        int ret = mbedtls_psa_get_random(MBEDTLS_PSA_RANDOM_STATE,
-                                         output, request_size);
+        int ret = mbedtls_psa_legacy_get_random(MBEDTLS_PSA_DRBG_CTX,
+                                                output, request_size);
         if (ret != 0) {
             return mbedtls_to_psa_error(ret);
         }

--- a/library/psa_crypto_random_impl.h
+++ b/library/psa_crypto_random_impl.h
@@ -118,14 +118,6 @@ typedef struct {
 #define MBEDTLS_PSA_RANDOM_MAX_REQUEST MBEDTLS_HMAC_DRBG_MAX_REQUEST
 #endif
 
-/** A pointer to the PSA DRBG context.
- *
- * This variable is only intended to be used through the macro
- * #MBEDTLS_PSA_DRBG_CTX.
- */
-extern mbedtls_psa_drbg_context_t *const mbedtls_psa_drbg_ctx;
-#define MBEDTLS_PSA_DRBG_CTX    mbedtls_psa_drbg_ctx
-
 /** Seed the PSA DRBG.
  *
  * \param entropy       An entropy context to read the seed from.
@@ -138,18 +130,19 @@ extern mbedtls_psa_drbg_context_t *const mbedtls_psa_drbg_ctx;
  * \return              An Mbed TLS error code (\c MBEDTLS_ERR_xxx) on failure.
  */
 static inline int mbedtls_psa_drbg_seed(
+    mbedtls_psa_drbg_context_t *drbg_ctx,
     mbedtls_entropy_context *entropy,
     const unsigned char *custom, size_t len)
 {
 #if defined(MBEDTLS_CTR_DRBG_C)
-    return mbedtls_ctr_drbg_seed(MBEDTLS_PSA_DRBG_CTX,
+    return mbedtls_ctr_drbg_seed(drbg_ctx,
                                  mbedtls_entropy_func,
                                  entropy,
                                  custom, len);
 #elif defined(MBEDTLS_HMAC_DRBG_C)
     const mbedtls_md_info_t *md_info =
         mbedtls_md_info_from_type(MBEDTLS_PSA_HMAC_DRBG_MD_TYPE);
-    return mbedtls_hmac_drbg_seed(MBEDTLS_PSA_DRBG_CTX,
+    return mbedtls_hmac_drbg_seed(drbg_ctx,
                                   md_info,
                                   mbedtls_entropy_func,
                                   entropy,

--- a/library/psa_util.c
+++ b/library/psa_util.c
@@ -18,7 +18,7 @@
 
 #include "psa_util_internal.h"
 
-#if defined(MBEDTLS_PSA_CRYPTO_C)
+#if defined(MBEDTLS_PSA_CRYPTO_CLIENT)
 
 #include <psa/crypto.h>
 
@@ -363,7 +363,7 @@ int mbedtls_psa_get_random(void *p_rng,
     }
 }
 
-#endif /* MBEDTLS_PSA_CRYPTO_C */
+#endif /* MBEDTLS_PSA_CRYPTO_CLIENT */
 
 #if defined(MBEDTLS_PSA_UTIL_HAVE_ECDSA)
 

--- a/library/psa_util.c
+++ b/library/psa_util.c
@@ -338,6 +338,39 @@ mbedtls_ecp_group_id mbedtls_ecc_group_from_psa(psa_ecc_family_t family,
 }
 #endif /* PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY */
 
+/* Wrapper function allowing the classic API to use the PSA RNG.
+ *
+ * `mbedtls_psa_get_random(MBEDTLS_PSA_RANDOM_STATE, ...)` calls
+ * `psa_generate_random(...)`. The state parameter is ignored since the
+ * PSA API doesn't support passing an explicit state.
+ *
+ * In the non-external case, psa_generate_random() calls an
+ * `mbedtls_xxx_drbg_random` function which has exactly the same signature
+ * and semantics as mbedtls_psa_get_random(). As an optimization,
+ * instead of doing this back-and-forth between the PSA API and the
+ * classic API, psa_crypto_random_impl.h defines `mbedtls_psa_get_random`
+ * as a constant function pointer to `mbedtls_xxx_drbg_random`.
+ */
+#if defined(MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG)
+int mbedtls_psa_get_random(void *p_rng,
+                           unsigned char *output,
+                           size_t output_size)
+{
+    /* This function takes a pointer to the RNG state because that's what
+     * classic mbedtls functions using an RNG expect. The PSA RNG manages
+     * its own state internally and doesn't let the caller access that state.
+     * So we just ignore the state parameter, and in practice we'll pass
+     * NULL. */
+    (void) p_rng;
+    psa_status_t status = psa_generate_random(output, output_size);
+    if (status == PSA_SUCCESS) {
+        return 0;
+    } else {
+        return MBEDTLS_ERR_ENTROPY_SOURCE_FAILED;
+    }
+}
+#endif /* MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG */
+
 #endif /* MBEDTLS_PSA_CRYPTO_C */
 
 #if defined(MBEDTLS_PSA_UTIL_HAVE_ECDSA)

--- a/library/psa_util.c
+++ b/library/psa_util.c
@@ -46,6 +46,7 @@
 #if defined(MBEDTLS_BLOCK_CIPHER_SOME_PSA)
 #include <mbedtls/cipher.h>
 #endif
+#include <mbedtls/entropy.h>
 
 /* PSA_SUCCESS is kept at the top of each error table since
  * it's the most common status when everything functions properly. */
@@ -343,15 +344,7 @@ mbedtls_ecp_group_id mbedtls_ecc_group_from_psa(psa_ecc_family_t family,
  * `mbedtls_psa_get_random(MBEDTLS_PSA_RANDOM_STATE, ...)` calls
  * `psa_generate_random(...)`. The state parameter is ignored since the
  * PSA API doesn't support passing an explicit state.
- *
- * In the non-external case, psa_generate_random() calls an
- * `mbedtls_xxx_drbg_random` function which has exactly the same signature
- * and semantics as mbedtls_psa_get_random(). As an optimization,
- * instead of doing this back-and-forth between the PSA API and the
- * classic API, psa_crypto_random_impl.h defines `mbedtls_psa_get_random`
- * as a constant function pointer to `mbedtls_xxx_drbg_random`.
  */
-#if defined(MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG)
 int mbedtls_psa_get_random(void *p_rng,
                            unsigned char *output,
                            size_t output_size)
@@ -369,7 +362,6 @@ int mbedtls_psa_get_random(void *p_rng,
         return MBEDTLS_ERR_ENTROPY_SOURCE_FAILED;
     }
 }
-#endif /* MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG */
 
 #endif /* MBEDTLS_PSA_CRYPTO_C */
 

--- a/library/psa_util_internal.h
+++ b/library/psa_util_internal.h
@@ -16,7 +16,7 @@
 
 #include "psa/crypto.h"
 
-#if defined(MBEDTLS_PSA_CRYPTO_C)
+#if defined(MBEDTLS_PSA_CRYPTO_CLIENT)
 
 /*************************************************************************
  * FFDH
@@ -96,5 +96,5 @@ int psa_pk_status_to_mbedtls(psa_status_t status);
                           sizeof(error_list)/sizeof(error_list[0]),   \
                           fallback_f)
 
-#endif /* MBEDTLS_PSA_CRYPTO_C */
+#endif /* MBEDTLS_PSA_CRYPTO_CLIENT */
 #endif /* MBEDTLS_PSA_UTIL_INTERNAL_H */

--- a/tests/src/psa_crypto_stubs.c
+++ b/tests/src/psa_crypto_stubs.c
@@ -1,0 +1,25 @@
+/** \file psa_crypto_stubs.c
+ *
+ * \brief Stub functions when MBEDTLS_PSA_CRYPTO_CLIENT is enabled but
+ *        MBEDTLS_PSA_CRYPTO_C is disabled.
+ */
+
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+ */
+
+#include <psa/crypto.h>
+
+#if defined(MBEDTLS_PSA_CRYPTO_CLIENT) && !defined(MBEDTLS_PSA_CRYPTO_C)
+
+psa_status_t psa_generate_random(uint8_t *output,
+                                 size_t output_size)
+{
+    (void) output;
+    (void) output_size;
+
+    return PSA_ERROR_COMMUNICATION_FAILURE;
+}
+
+#endif /* MBEDTLS_PSA_CRYPTO_CLIENT !MBEDTLS_PSA_CRYPTO_C */

--- a/tests/src/psa_crypto_stubs.c
+++ b/tests/src/psa_crypto_stubs.c
@@ -22,4 +22,4 @@ psa_status_t psa_generate_random(uint8_t *output,
     return PSA_ERROR_COMMUNICATION_FAILURE;
 }
 
-#endif /* MBEDTLS_PSA_CRYPTO_CLIENT !MBEDTLS_PSA_CRYPTO_C */
+#endif /* MBEDTLS_PSA_CRYPTO_CLIENT && !MBEDTLS_PSA_CRYPTO_C */


### PR DESCRIPTION
## Description

Resolves #8825.

It does not strictly depends on #8842, but I suspect there might a conflict between the two.

## PR checklist

- [x] **changelog** done
- [x] **backport** not required
- [x] **tests** not required: not adding new code, just changing the way it is enabled