### PR TITLE
library: psa_crypto: Explicitly initialize shared_secret

### DIFF
--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -7046,7 +7046,7 @@ static psa_status_t psa_key_agreement_internal(psa_key_derivation_operation_t *o
                                                size_t peer_key_length)
 {
     psa_status_t status;
-    uint8_t shared_secret[PSA_RAW_KEY_AGREEMENT_OUTPUT_MAX_SIZE];
+    uint8_t shared_secret[PSA_RAW_KEY_AGREEMENT_OUTPUT_MAX_SIZE] = { 0 };
     size_t shared_secret_length = 0;
     psa_algorithm_t ka_alg = PSA_ALG_KEY_AGREEMENT_GET_BASE(operation->alg);
 


### PR DESCRIPTION
## Description

When building with -Og (specifically Zephyr with
CONFIG_DEBUG_OPTIMIZATIONS=y) one observes the following warning:

'shared_secret' may be used uninitialized [-Werror=maybe-uninitialized]

Fix this by zero initializing 'shared_secret' similar to the issue addressed in commit 2fab5c960 ("Work around for GCC bug").

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required?
- [x] **backport** not critical
- [x] **tests** not required?
