### PR TITLE
TLS 1.3: CLI: Split early data user status and internal state

### DIFF
--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -750,10 +750,10 @@ typedef enum {
 
 typedef enum {
 /*
- * The client has not sent the first ClientHello yet, it is unknown if the
- * client will send an early data indication extension or not.
+ * The client has not sent the first ClientHello yet, the negotiation of early
+ * data has not started yet.
  */
-    MBEDTLS_SSL_EARLY_DATA_STATE_UNKNOWN,
+    MBEDTLS_SSL_EARLY_DATA_STATE_IDLE,
 
 /*
  * The client has not indicated the use of early data to the server.
@@ -1756,7 +1756,7 @@ struct mbedtls_ssl_context {
 #if defined(MBEDTLS_SSL_EARLY_DATA) && defined(MBEDTLS_SSL_CLI_C)
     /**
      * State of the negotiation and transfer of early data. Reset to
-     * MBEDTLS_SSL_EARLY_DATA_STATE_UNKNOWN when the context is reset.
+     * MBEDTLS_SSL_EARLY_DATA_STATE_IDLE when the context is reset.
      */
     mbedtls_ssl_early_data_state MBEDTLS_PRIVATE(early_data_state);
 #endif

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -762,18 +762,6 @@ typedef enum {
     MBEDTLS_SSL_EARLY_DATA_STATE_NO_IND_SENT,
 
 /*
- * The client has indicated the use of early data and the server has accepted
- * it.
- */
-    MBEDTLS_SSL_EARLY_DATA_STATE_ACCEPTED,
-
-/*
- * The client has indicated the use of early data but the server has rejected
- * it.
- */
-    MBEDTLS_SSL_EARLY_DATA_STATE_REJECTED,
-
-/*
  * The client has sent an early data indication extension in its first
  * ClientHello, it has not received the response (ServerHello or
  * HelloRetryRequest) from the server yet. The transform to protect early data
@@ -791,11 +779,24 @@ typedef enum {
     MBEDTLS_SSL_EARLY_DATA_STATE_CAN_WRITE,
 
 /*
+ * The client has indicated the use of early data and the server has accepted
+ * it.
+ */
+    MBEDTLS_SSL_EARLY_DATA_STATE_ACCEPTED,
+
+/*
+ * The client has indicated the use of early data but the server has rejected
+ * it.
+ */
+    MBEDTLS_SSL_EARLY_DATA_STATE_REJECTED,
+
+/*
  * The client has sent an early data indication extension in its first
  * ClientHello, the server has accepted them and the client has received the
  * server Finished message. It cannot send early data to the server anymore.
  */
     MBEDTLS_SSL_EARLY_DATA_STATE_SERVER_FINISHED_RECEIVED,
+
 } mbedtls_ssl_early_data_state;
 #endif /* MBEDTLS_SSL_EARLY_DATA && MBEDTLS_SSL_CLI_C */
 

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -756,9 +756,10 @@ typedef enum {
     MBEDTLS_SSL_EARLY_DATA_STATE_IDLE,
 
 /*
- * The client has not indicated the use of early data to the server.
+ * In its ClientHello, the client has not included an early data indication
+ * extension.
  */
-    MBEDTLS_SSL_EARLY_DATA_STATE_NOT_SENT,
+    MBEDTLS_SSL_EARLY_DATA_STATE_NO_IND_SENT,
 
 /*
  * The client has indicated the use of early data and the server has accepted

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -743,7 +743,7 @@ typedef enum {
 /*
  * See documentation of mbedtls_ssl_get_early_data_status().
  */
-    MBEDTLS_SSL_EARLY_DATA_STATUS_NOT_SENT,
+    MBEDTLS_SSL_EARLY_DATA_STATUS_NO_IND_SENT,
     MBEDTLS_SSL_EARLY_DATA_STATUS_ACCEPTED,
     MBEDTLS_SSL_EARLY_DATA_STATUS_REJECTED,
 } mbedtls_ssl_early_data_status;
@@ -5358,7 +5358,7 @@ int mbedtls_ssl_write_early_data(mbedtls_ssl_context *ssl,
  * \return         #MBEDTLS_ERR_SSL_BAD_INPUT_DATA if this function is called
  *                 prior to completion of the handshake.
  *
- * \return         #MBEDTLS_SSL_EARLY_DATA_STATUS_NOT_SENT if the client has
+ * \return         #MBEDTLS_SSL_EARLY_DATA_STATUS_NO_IND_SENT if the client has
  *                 not indicated the use of early data to the server.
  *
  * \return         #MBEDTLS_SSL_EARLY_DATA_STATUS_ACCEPTED if the client has

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -777,9 +777,10 @@ typedef enum {
  * The client has sent an early data indication extension in its first
  * ClientHello, it has not received the response (ServerHello or
  * HelloRetryRequest) from the server yet. The transform to protect early data
- * is not set and early data cannot be sent yet.
+ * is not set either as for middlebox compatibility a dummy CCs may have to be
+ * sent in clear. Early data cannot be sent to the server yet.
  */
-    MBEDTLS_SSL_EARLY_DATA_STATE_SENT,
+    MBEDTLS_SSL_EARLY_DATA_STATE_IND_SENT,
 
 /*
  * The client has sent an early data indication extension in its first

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -741,17 +741,36 @@ mbedtls_ssl_states;
 #if defined(MBEDTLS_SSL_EARLY_DATA) && defined(MBEDTLS_SSL_CLI_C)
 typedef enum {
 /*
- * The client has not sent the first ClientHello yet, it is unknown if the
- * client will send an early data indication extension or not.
- */
-    MBEDTLS_SSL_EARLY_DATA_STATUS_UNKNOWN,
-
-/*
  * See documentation of mbedtls_ssl_get_early_data_status().
  */
     MBEDTLS_SSL_EARLY_DATA_STATUS_NOT_SENT,
     MBEDTLS_SSL_EARLY_DATA_STATUS_ACCEPTED,
     MBEDTLS_SSL_EARLY_DATA_STATUS_REJECTED,
+} mbedtls_ssl_early_data_status;
+
+typedef enum {
+/*
+ * The client has not sent the first ClientHello yet, it is unknown if the
+ * client will send an early data indication extension or not.
+ */
+    MBEDTLS_SSL_EARLY_DATA_STATE_UNKNOWN,
+
+/*
+ * The client has not indicated the use of early data to the server.
+ */
+    MBEDTLS_SSL_EARLY_DATA_STATE_NOT_SENT,
+
+/*
+ * The client has indicated the use of early data and the server has accepted
+ * it.
+ */
+    MBEDTLS_SSL_EARLY_DATA_STATE_ACCEPTED,
+
+/*
+ * The client has indicated the use of early data but the server has rejected
+ * it.
+ */
+    MBEDTLS_SSL_EARLY_DATA_STATE_REJECTED,
 
 /*
  * The client has sent an early data indication extension in its first
@@ -759,7 +778,7 @@ typedef enum {
  * HelloRetryRequest) from the server yet. The transform to protect early data
  * is not set and early data cannot be sent yet.
  */
-    MBEDTLS_SSL_EARLY_DATA_STATUS_SENT,
+    MBEDTLS_SSL_EARLY_DATA_STATE_SENT,
 
 /*
  * The client has sent an early data indication extension in its first
@@ -767,16 +786,15 @@ typedef enum {
  * HelloRetryRequest) from the server yet. The transform to protect early data
  * has been set and early data can be written now.
  */
-    MBEDTLS_SSL_EARLY_DATA_STATUS_CAN_WRITE,
+    MBEDTLS_SSL_EARLY_DATA_STATE_CAN_WRITE,
 
 /*
  * The client has sent an early data indication extension in its first
  * ClientHello, the server has accepted them and the client has received the
  * server Finished message. It cannot send early data to the server anymore.
  */
-    MBEDTLS_SSL_EARLY_DATA_STATUS_SERVER_FINISHED_RECEIVED,
-} mbedtls_ssl_early_data_status;
-
+    MBEDTLS_SSL_EARLY_DATA_STATE_SERVER_FINISHED_RECEIVED,
+} mbedtls_ssl_early_data_state;
 #endif /* MBEDTLS_SSL_EARLY_DATA && MBEDTLS_SSL_CLI_C */
 
 /**
@@ -1737,10 +1755,10 @@ struct mbedtls_ssl_context {
 
 #if defined(MBEDTLS_SSL_EARLY_DATA) && defined(MBEDTLS_SSL_CLI_C)
     /**
-     * Status of the negotiation of the use of early data. Reset to
-     * MBEDTLS_SSL_EARLY_DATA_STATUS_UNKNOWN when the context is reset.
+     * State of the negotiation and transfer of early data. Reset to
+     * MBEDTLS_SSL_EARLY_DATA_STATE_UNKNOWN when the context is reset.
      */
-    mbedtls_ssl_early_data_status MBEDTLS_PRIVATE(early_data_status);
+    mbedtls_ssl_early_data_state MBEDTLS_PRIVATE(early_data_state);
 #endif
 
     unsigned MBEDTLS_PRIVATE(badmac_seen);       /*!< records with a bad MAC received    */

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -747,57 +747,6 @@ typedef enum {
     MBEDTLS_SSL_EARLY_DATA_STATUS_ACCEPTED,
     MBEDTLS_SSL_EARLY_DATA_STATUS_REJECTED,
 } mbedtls_ssl_early_data_status;
-
-typedef enum {
-/*
- * The client has not sent the first ClientHello yet, the negotiation of early
- * data has not started yet.
- */
-    MBEDTLS_SSL_EARLY_DATA_STATE_IDLE,
-
-/*
- * In its ClientHello, the client has not included an early data indication
- * extension.
- */
-    MBEDTLS_SSL_EARLY_DATA_STATE_NO_IND_SENT,
-
-/*
- * The client has sent an early data indication extension in its first
- * ClientHello, it has not received the response (ServerHello or
- * HelloRetryRequest) from the server yet. The transform to protect early data
- * is not set either as for middlebox compatibility a dummy CCs may have to be
- * sent in clear. Early data cannot be sent to the server yet.
- */
-    MBEDTLS_SSL_EARLY_DATA_STATE_IND_SENT,
-
-/*
- * The client has sent an early data indication extension in its first
- * ClientHello, it has not received the response (ServerHello or
- * HelloRetryRequest) from the server yet. The transform to protect early data
- * has been set and early data can be written now.
- */
-    MBEDTLS_SSL_EARLY_DATA_STATE_CAN_WRITE,
-
-/*
- * The client has indicated the use of early data and the server has accepted
- * it.
- */
-    MBEDTLS_SSL_EARLY_DATA_STATE_ACCEPTED,
-
-/*
- * The client has indicated the use of early data but the server has rejected
- * it.
- */
-    MBEDTLS_SSL_EARLY_DATA_STATE_REJECTED,
-
-/*
- * The client has sent an early data indication extension in its first
- * ClientHello, the server has accepted them and the client has received the
- * server Finished message. It cannot send early data to the server anymore.
- */
-    MBEDTLS_SSL_EARLY_DATA_STATE_SERVER_FINISHED_RECEIVED,
-
-} mbedtls_ssl_early_data_state;
 #endif /* MBEDTLS_SSL_EARLY_DATA && MBEDTLS_SSL_CLI_C */
 
 /**
@@ -1761,7 +1710,7 @@ struct mbedtls_ssl_context {
      * State of the negotiation and transfer of early data. Reset to
      * MBEDTLS_SSL_EARLY_DATA_STATE_IDLE when the context is reset.
      */
-    mbedtls_ssl_early_data_state MBEDTLS_PRIVATE(early_data_state);
+    int MBEDTLS_PRIVATE(early_data_state);
 #endif
 
     unsigned MBEDTLS_PRIVATE(badmac_seen);       /*!< records with a bad MAC received    */

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -743,7 +743,7 @@ typedef enum {
 /*
  * See documentation of mbedtls_ssl_get_early_data_status().
  */
-    MBEDTLS_SSL_EARLY_DATA_STATUS_NO_IND_SENT,
+    MBEDTLS_SSL_EARLY_DATA_STATUS_NOT_INDICATED,
     MBEDTLS_SSL_EARLY_DATA_STATUS_ACCEPTED,
     MBEDTLS_SSL_EARLY_DATA_STATUS_REJECTED,
 } mbedtls_ssl_early_data_status;
@@ -5310,8 +5310,8 @@ int mbedtls_ssl_write_early_data(mbedtls_ssl_context *ssl,
  * \return         #MBEDTLS_ERR_SSL_BAD_INPUT_DATA if this function is called
  *                 prior to completion of the handshake.
  *
- * \return         #MBEDTLS_SSL_EARLY_DATA_STATUS_NO_IND_SENT if the client has
- *                 not indicated the use of early data to the server.
+ * \return         #MBEDTLS_SSL_EARLY_DATA_STATUS_NOT_INDICATED if the client
+ *                 has not indicated the use of early data to the server.
  *
  * \return         #MBEDTLS_SSL_EARLY_DATA_STATUS_ACCEPTED if the client has
  *                 indicated the use of early data and the server has accepted

--- a/library/ssl_debug_helpers.h
+++ b/library/ssl_debug_helpers.h
@@ -23,6 +23,7 @@ const char *mbedtls_ssl_states_str(mbedtls_ssl_states in);
 
 #if defined(MBEDTLS_SSL_EARLY_DATA) && defined(MBEDTLS_SSL_CLI_C)
 const char *mbedtls_ssl_early_data_status_str(mbedtls_ssl_early_data_status in);
+const char *mbedtls_ssl_early_data_state_str(mbedtls_ssl_early_data_state in);
 #endif
 
 const char *mbedtls_ssl_protocol_version_str(mbedtls_ssl_protocol_version in);

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -2153,6 +2153,57 @@ int mbedtls_ssl_tls13_write_early_data_ext(mbedtls_ssl_context *ssl,
 
 int mbedtls_ssl_tls13_check_early_data_len(mbedtls_ssl_context *ssl,
                                            size_t early_data_len);
+
+typedef enum {
+/*
+ * The client has not sent the first ClientHello yet, the negotiation of early
+ * data has not started yet.
+ */
+    MBEDTLS_SSL_EARLY_DATA_STATE_IDLE,
+
+/*
+ * In its ClientHello, the client has not included an early data indication
+ * extension.
+ */
+    MBEDTLS_SSL_EARLY_DATA_STATE_NO_IND_SENT,
+
+/*
+ * The client has sent an early data indication extension in its first
+ * ClientHello, it has not received the response (ServerHello or
+ * HelloRetryRequest) from the server yet. The transform to protect early data
+ * is not set either as for middlebox compatibility a dummy CCs may have to be
+ * sent in clear. Early data cannot be sent to the server yet.
+ */
+    MBEDTLS_SSL_EARLY_DATA_STATE_IND_SENT,
+
+/*
+ * The client has sent an early data indication extension in its first
+ * ClientHello, it has not received the response (ServerHello or
+ * HelloRetryRequest) from the server yet. The transform to protect early data
+ * has been set and early data can be written now.
+ */
+    MBEDTLS_SSL_EARLY_DATA_STATE_CAN_WRITE,
+
+/*
+ * The client has indicated the use of early data and the server has accepted
+ * it.
+ */
+    MBEDTLS_SSL_EARLY_DATA_STATE_ACCEPTED,
+
+/*
+ * The client has indicated the use of early data but the server has rejected
+ * it.
+ */
+    MBEDTLS_SSL_EARLY_DATA_STATE_REJECTED,
+
+/*
+ * The client has sent an early data indication extension in its first
+ * ClientHello, the server has accepted them and the client has received the
+ * server Finished message. It cannot send early data to the server anymore.
+ */
+    MBEDTLS_SSL_EARLY_DATA_STATE_SERVER_FINISHED_RECEIVED,
+
+} mbedtls_ssl_early_data_state;
 #endif /* MBEDTLS_SSL_EARLY_DATA */
 
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3 */

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -2171,7 +2171,7 @@ typedef enum {
  * The client has sent an early data indication extension in its first
  * ClientHello, it has not received the response (ServerHello or
  * HelloRetryRequest) from the server yet. The transform to protect early data
- * is not set either as for middlebox compatibility a dummy CCs may have to be
+ * is not set either as for middlebox compatibility a dummy CCS may have to be
  * sent in clear. Early data cannot be sent to the server yet.
  */
     MBEDTLS_SSL_EARLY_DATA_STATE_IND_SENT,

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -6098,7 +6098,7 @@ int mbedtls_ssl_write_early_data(mbedtls_ssl_context *ssl,
 
     /*
      * If we are at the beginning of the handshake, the early data state being
-     * equal to MBEDTLS_SSL_EARLY_DATA_STATE_UNKNOWN or
+     * equal to MBEDTLS_SSL_EARLY_DATA_STATE_IDLE or
      * MBEDTLS_SSL_EARLY_DATA_STATE_SENT advance the handshake just
      * enough to be able to send early data if possible. That way, we can
      * guarantee that when starting the handshake with this function we will
@@ -6108,9 +6108,9 @@ int mbedtls_ssl_write_early_data(mbedtls_ssl_context *ssl,
      * as the early data outbound transform has not been set as we may have to
      * first send a dummy CCS in clear.
      */
-    if ((ssl->early_data_state == MBEDTLS_SSL_EARLY_DATA_STATE_UNKNOWN) ||
+    if ((ssl->early_data_state == MBEDTLS_SSL_EARLY_DATA_STATE_IDLE) ||
         (ssl->early_data_state == MBEDTLS_SSL_EARLY_DATA_STATE_SENT)) {
-        while ((ssl->early_data_state == MBEDTLS_SSL_EARLY_DATA_STATE_UNKNOWN) ||
+        while ((ssl->early_data_state == MBEDTLS_SSL_EARLY_DATA_STATE_IDLE) ||
                (ssl->early_data_state == MBEDTLS_SSL_EARLY_DATA_STATE_SENT)) {
             ret = mbedtls_ssl_handshake_step(ssl);
             if (ret != 0) {

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -6099,19 +6099,19 @@ int mbedtls_ssl_write_early_data(mbedtls_ssl_context *ssl,
     /*
      * If we are at the beginning of the handshake, the early data state being
      * equal to MBEDTLS_SSL_EARLY_DATA_STATE_IDLE or
-     * MBEDTLS_SSL_EARLY_DATA_STATE_SENT advance the handshake just
+     * MBEDTLS_SSL_EARLY_DATA_STATE_IND_SENT advance the handshake just
      * enough to be able to send early data if possible. That way, we can
      * guarantee that when starting the handshake with this function we will
      * send at least one record of early data. Note that when the state is
-     * MBEDTLS_SSL_EARLY_DATA_STATE_SENT and not yet
-     * MBEDTLS_SSL_EARLY_DATA_STATE_CAN_WRITE, we cannot send early data yet
+     * MBEDTLS_SSL_EARLY_DATA_STATE_IND_SENT and not yet
+     * MBEDTLS_SSL_EARLY_DATA_STATE_CAN_WRITE, we cannot send early data
      * as the early data outbound transform has not been set as we may have to
      * first send a dummy CCS in clear.
      */
     if ((ssl->early_data_state == MBEDTLS_SSL_EARLY_DATA_STATE_IDLE) ||
-        (ssl->early_data_state == MBEDTLS_SSL_EARLY_DATA_STATE_SENT)) {
+        (ssl->early_data_state == MBEDTLS_SSL_EARLY_DATA_STATE_IND_SENT)) {
         while ((ssl->early_data_state == MBEDTLS_SSL_EARLY_DATA_STATE_IDLE) ||
-               (ssl->early_data_state == MBEDTLS_SSL_EARLY_DATA_STATE_SENT)) {
+               (ssl->early_data_state == MBEDTLS_SSL_EARLY_DATA_STATE_IND_SENT)) {
             ret = mbedtls_ssl_handshake_step(ssl);
             if (ret != 0) {
                 MBEDTLS_SSL_DEBUG_RET(1, "mbedtls_ssl_handshake_step", ret);

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -6097,21 +6097,21 @@ int mbedtls_ssl_write_early_data(mbedtls_ssl_context *ssl,
     }
 
     /*
-     * If we are at the beginning of the handshake, the early data status being
-     * equal to MBEDTLS_SSL_EARLY_DATA_STATUS_UNKNOWN or
-     * MBEDTLS_SSL_EARLY_DATA_STATUS_SENT advance the handshake just
+     * If we are at the beginning of the handshake, the early data state being
+     * equal to MBEDTLS_SSL_EARLY_DATA_STATE_UNKNOWN or
+     * MBEDTLS_SSL_EARLY_DATA_STATE_SENT advance the handshake just
      * enough to be able to send early data if possible. That way, we can
      * guarantee that when starting the handshake with this function we will
-     * send at least one record of early data. Note that when the status is
-     * MBEDTLS_SSL_EARLY_DATA_STATUS_SENT and not yet
-     * MBEDTLS_SSL_EARLY_DATA_STATUS_CAN_WRITE, we cannot send early data yet
+     * send at least one record of early data. Note that when the state is
+     * MBEDTLS_SSL_EARLY_DATA_STATE_SENT and not yet
+     * MBEDTLS_SSL_EARLY_DATA_STATE_CAN_WRITE, we cannot send early data yet
      * as the early data outbound transform has not been set as we may have to
      * first send a dummy CCS in clear.
      */
-    if ((ssl->early_data_status == MBEDTLS_SSL_EARLY_DATA_STATUS_UNKNOWN) ||
-        (ssl->early_data_status == MBEDTLS_SSL_EARLY_DATA_STATUS_SENT)) {
-        while ((ssl->early_data_status == MBEDTLS_SSL_EARLY_DATA_STATUS_UNKNOWN) ||
-               (ssl->early_data_status == MBEDTLS_SSL_EARLY_DATA_STATUS_SENT)) {
+    if ((ssl->early_data_state == MBEDTLS_SSL_EARLY_DATA_STATE_UNKNOWN) ||
+        (ssl->early_data_state == MBEDTLS_SSL_EARLY_DATA_STATE_SENT)) {
+        while ((ssl->early_data_state == MBEDTLS_SSL_EARLY_DATA_STATE_UNKNOWN) ||
+               (ssl->early_data_state == MBEDTLS_SSL_EARLY_DATA_STATE_SENT)) {
             ret = mbedtls_ssl_handshake_step(ssl);
             if (ret != 0) {
                 MBEDTLS_SSL_DEBUG_RET(1, "mbedtls_ssl_handshake_step", ret);
@@ -6133,8 +6133,8 @@ int mbedtls_ssl_write_early_data(mbedtls_ssl_context *ssl,
          * it too much. If we reach a point where we can still send early data,
          * then we will send some.
          */
-        if ((ssl->early_data_status != MBEDTLS_SSL_EARLY_DATA_STATUS_CAN_WRITE) &&
-            (ssl->early_data_status != MBEDTLS_SSL_EARLY_DATA_STATUS_ACCEPTED)) {
+        if ((ssl->early_data_state != MBEDTLS_SSL_EARLY_DATA_STATE_CAN_WRITE) &&
+            (ssl->early_data_state != MBEDTLS_SSL_EARLY_DATA_STATE_ACCEPTED)) {
             return MBEDTLS_ERR_SSL_CANNOT_WRITE_EARLY_DATA;
         }
 
@@ -6152,8 +6152,8 @@ int mbedtls_ssl_write_early_data(mbedtls_ssl_context *ssl,
         }
     }
 
-    if (((ssl->early_data_status != MBEDTLS_SSL_EARLY_DATA_STATUS_CAN_WRITE) &&
-         (ssl->early_data_status != MBEDTLS_SSL_EARLY_DATA_STATUS_ACCEPTED))
+    if (((ssl->early_data_state != MBEDTLS_SSL_EARLY_DATA_STATE_CAN_WRITE) &&
+         (ssl->early_data_state != MBEDTLS_SSL_EARLY_DATA_STATE_ACCEPTED))
         || (remaining == 0)) {
         return MBEDTLS_ERR_SSL_CANNOT_WRITE_EARLY_DATA;
     }

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1096,7 +1096,7 @@ static int ssl_handshake_init(mbedtls_ssl_context *ssl)
 
 #if defined(MBEDTLS_SSL_EARLY_DATA)
 #if defined(MBEDTLS_SSL_CLI_C)
-    ssl->early_data_state = MBEDTLS_SSL_EARLY_DATA_STATE_UNKNOWN;
+    ssl->early_data_state = MBEDTLS_SSL_EARLY_DATA_STATE_IDLE;
 #endif
 #if defined(MBEDTLS_SSL_SRV_C)
     ssl->discard_early_data_record = MBEDTLS_SSL_EARLY_DATA_NO_DISCARD;

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1096,7 +1096,7 @@ static int ssl_handshake_init(mbedtls_ssl_context *ssl)
 
 #if defined(MBEDTLS_SSL_EARLY_DATA)
 #if defined(MBEDTLS_SSL_CLI_C)
-    ssl->early_data_status = MBEDTLS_SSL_EARLY_DATA_STATUS_UNKNOWN;
+    ssl->early_data_state = MBEDTLS_SSL_EARLY_DATA_STATE_UNKNOWN;
 #endif
 #if defined(MBEDTLS_SSL_SRV_C)
     ssl->discard_early_data_record = MBEDTLS_SSL_EARLY_DATA_NO_DISCARD;

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -1185,7 +1185,7 @@ int mbedtls_ssl_tls13_write_client_hello_exts(mbedtls_ssl_context *ssl,
      * If an HRR has been received and thus we are currently writing the
      * second ClientHello, the second ClientHello must not contain an early
      * data extension and the early data state must stay as it is:
-     * MBEDTLS_SSL_EARLY_DATA_STATE_NOT_SENT or
+     * MBEDTLS_SSL_EARLY_DATA_STATE_NO_IND_SENT or
      * MBEDTLS_SSL_EARLY_DATA_STATE_REJECTED.
      */
     if (!ssl->handshake->hello_retry_request_flag) {
@@ -1201,7 +1201,7 @@ int mbedtls_ssl_tls13_write_client_hello_exts(mbedtls_ssl_context *ssl,
 
             ssl->early_data_state = MBEDTLS_SSL_EARLY_DATA_STATE_SENT;
         } else {
-            ssl->early_data_state = MBEDTLS_SSL_EARLY_DATA_STATE_NOT_SENT;
+            ssl->early_data_state = MBEDTLS_SSL_EARLY_DATA_STATE_NO_IND_SENT;
         }
     }
 #endif /* MBEDTLS_SSL_EARLY_DATA */
@@ -1919,7 +1919,7 @@ static int ssl_tls13_postprocess_server_hello(mbedtls_ssl_context *ssl)
      * cases we compute it here.
      */
 #if defined(MBEDTLS_SSL_EARLY_DATA)
-    if (ssl->early_data_state == MBEDTLS_SSL_EARLY_DATA_STATE_NOT_SENT ||
+    if (ssl->early_data_state == MBEDTLS_SSL_EARLY_DATA_STATE_NO_IND_SENT ||
         handshake->key_exchange_mode ==
         MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL)
 #endif
@@ -1975,7 +1975,7 @@ static int ssl_tls13_postprocess_hrr(mbedtls_ssl_context *ssl)
     ssl->session_negotiate->ciphersuite = ssl->handshake->ciphersuite_info->id;
 
 #if defined(MBEDTLS_SSL_EARLY_DATA)
-    if (ssl->early_data_state != MBEDTLS_SSL_EARLY_DATA_STATE_NOT_SENT) {
+    if (ssl->early_data_state != MBEDTLS_SSL_EARLY_DATA_STATE_NO_IND_SENT) {
         ssl->early_data_state = MBEDTLS_SSL_EARLY_DATA_STATE_REJECTED;
     }
 #endif
@@ -2239,7 +2239,8 @@ static int ssl_tls13_process_encrypted_extensions(mbedtls_ssl_context *ssl)
         }
 
         ssl->early_data_state = MBEDTLS_SSL_EARLY_DATA_STATE_ACCEPTED;
-    } else if (ssl->early_data_state != MBEDTLS_SSL_EARLY_DATA_STATE_NOT_SENT) {
+    } else if (ssl->early_data_state !=
+               MBEDTLS_SSL_EARLY_DATA_STATE_NO_IND_SENT) {
         ssl->early_data_state = MBEDTLS_SSL_EARLY_DATA_STATE_REJECTED;
     }
 #endif
@@ -2325,7 +2326,7 @@ int mbedtls_ssl_get_early_data_status(mbedtls_ssl_context *ssl)
     }
 
     switch (ssl->early_data_state) {
-        case MBEDTLS_SSL_EARLY_DATA_STATE_NOT_SENT:
+        case MBEDTLS_SSL_EARLY_DATA_STATE_NO_IND_SENT:
             return MBEDTLS_SSL_EARLY_DATA_STATUS_NO_IND_SENT;
             break;
 

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -2326,7 +2326,7 @@ int mbedtls_ssl_get_early_data_status(mbedtls_ssl_context *ssl)
 
     switch (ssl->early_data_state) {
         case MBEDTLS_SSL_EARLY_DATA_STATE_NOT_SENT:
-            return MBEDTLS_SSL_EARLY_DATA_STATUS_NOT_SENT;
+            return MBEDTLS_SSL_EARLY_DATA_STATUS_NO_IND_SENT;
             break;
 
         case MBEDTLS_SSL_EARLY_DATA_STATE_REJECTED:

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -2327,7 +2327,7 @@ int mbedtls_ssl_get_early_data_status(mbedtls_ssl_context *ssl)
 
     switch (ssl->early_data_state) {
         case MBEDTLS_SSL_EARLY_DATA_STATE_NO_IND_SENT:
-            return MBEDTLS_SSL_EARLY_DATA_STATUS_NO_IND_SENT;
+            return MBEDTLS_SSL_EARLY_DATA_STATUS_NOT_INDICATED;
             break;
 
         case MBEDTLS_SSL_EARLY_DATA_STATE_REJECTED:

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -1199,7 +1199,7 @@ int mbedtls_ssl_tls13_write_client_hello_exts(mbedtls_ssl_context *ssl,
             }
             p += ext_len;
 
-            ssl->early_data_state = MBEDTLS_SSL_EARLY_DATA_STATE_SENT;
+            ssl->early_data_state = MBEDTLS_SSL_EARLY_DATA_STATE_IND_SENT;
         } else {
             ssl->early_data_state = MBEDTLS_SSL_EARLY_DATA_STATE_NO_IND_SENT;
         }
@@ -1239,7 +1239,7 @@ int mbedtls_ssl_tls13_finalize_client_hello(mbedtls_ssl_context *ssl)
     size_t psk_len;
     const mbedtls_ssl_ciphersuite_t *ciphersuite_info;
 
-    if (ssl->early_data_state == MBEDTLS_SSL_EARLY_DATA_STATE_SENT) {
+    if (ssl->early_data_state == MBEDTLS_SSL_EARLY_DATA_STATE_IND_SENT) {
         MBEDTLS_SSL_DEBUG_MSG(
             1, ("Set hs psk for early data when writing the first psk"));
 

--- a/tests/suites/test_suite_ssl.data
+++ b/tests/suites/test_suite_ssl.data
@@ -3286,17 +3286,17 @@ tls13_read_early_data:TEST_EARLY_DATA_SERVER_REJECTS
 TLS 1.3 read early data, discard after HRR
 tls13_read_early_data:TEST_EARLY_DATA_HRR
 
-TLS 1.3 cli, early data status, early data accepted
-tls13_cli_early_data_status:TEST_EARLY_DATA_ACCEPTED
+TLS 1.3 cli, early data state, early data accepted
+tls13_cli_early_data_state:TEST_EARLY_DATA_ACCEPTED
 
-TLS 1.3 cli, early data status, no early data indication
-tls13_cli_early_data_status:TEST_EARLY_DATA_NO_INDICATION_SENT
+TLS 1.3 cli, early data state, no early data indication
+tls13_cli_early_data_state:TEST_EARLY_DATA_NO_INDICATION_SENT
 
-TLS 1.3 cli, early data status, server rejects early data
-tls13_cli_early_data_status:TEST_EARLY_DATA_SERVER_REJECTS
+TLS 1.3 cli, early data state, server rejects early data
+tls13_cli_early_data_state:TEST_EARLY_DATA_SERVER_REJECTS
 
-TLS 1.3 cli, early data status, hello retry request
-tls13_cli_early_data_status:TEST_EARLY_DATA_HRR
+TLS 1.3 cli, early data state, hello retry request
+tls13_cli_early_data_state:TEST_EARLY_DATA_HRR
 
 TLS 1.3 write early data, early data accepted
 tls13_write_early_data:TEST_EARLY_DATA_ACCEPTED

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -4125,7 +4125,7 @@ void tls13_cli_early_data_state(int scenario)
             break;
 
         case TEST_EARLY_DATA_NO_INDICATION_SENT:
-            TEST_EQUAL(ret, MBEDTLS_SSL_EARLY_DATA_STATUS_NO_IND_SENT);
+            TEST_EQUAL(ret, MBEDTLS_SSL_EARLY_DATA_STATUS_NOT_INDICATED);
             break;
 
         case TEST_EARLY_DATA_SERVER_REJECTS: /* Intentional fallthrough */

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -4125,7 +4125,7 @@ void tls13_cli_early_data_state(int scenario)
             break;
 
         case TEST_EARLY_DATA_NO_INDICATION_SENT:
-            TEST_EQUAL(ret, MBEDTLS_SSL_EARLY_DATA_STATUS_NOT_SENT);
+            TEST_EQUAL(ret, MBEDTLS_SSL_EARLY_DATA_STATUS_NO_IND_SENT);
             break;
 
         case TEST_EARLY_DATA_SERVER_REJECTS: /* Intentional fallthrough */

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -3738,8 +3738,8 @@ void tls13_read_early_data(int scenario)
                                        (unsigned char *) early_data,
                                        early_data_len);
 
-    if (client_ep.ssl.early_data_status !=
-        MBEDTLS_SSL_EARLY_DATA_STATUS_NOT_SENT) {
+    if (client_ep.ssl.early_data_state !=
+        MBEDTLS_SSL_EARLY_DATA_STATE_NOT_SENT) {
         TEST_EQUAL(ret, early_data_len);
     } else {
         TEST_EQUAL(ret, MBEDTLS_ERR_SSL_CANNOT_WRITE_EARLY_DATA);
@@ -3790,7 +3790,7 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_SSL_EARLY_DATA:MBEDTLS_SSL_CLI_C:MBEDTLS_SSL_SRV_C:MBEDTLS_TEST_AT_LEAST_ONE_TLS1_3_CIPHERSUITE:MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED:MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL_ENABLED:MBEDTLS_MD_CAN_SHA256:MBEDTLS_ECP_HAVE_SECP256R1:MBEDTLS_ECP_HAVE_SECP384R1:MBEDTLS_PK_CAN_ECDSA_VERIFY:MBEDTLS_SSL_SESSION_TICKETS */
-void tls13_cli_early_data_status(int scenario)
+void tls13_cli_early_data_state(int scenario)
 {
     int ret = -1;
     mbedtls_test_ssl_endpoint client_ep, server_ep;
@@ -3903,17 +3903,17 @@ void tls13_cli_early_data_status(int scenario)
                     case TEST_EARLY_DATA_ACCEPTED: /* Intentional fallthrough */
                     case TEST_EARLY_DATA_NO_INDICATION_SENT: /* Intentional fallthrough */
                     case TEST_EARLY_DATA_SERVER_REJECTS:
-                        TEST_EQUAL(client_ep.ssl.early_data_status,
-                                   MBEDTLS_SSL_EARLY_DATA_STATUS_UNKNOWN);
+                        TEST_EQUAL(client_ep.ssl.early_data_state,
+                                   MBEDTLS_SSL_EARLY_DATA_STATE_UNKNOWN);
                         break;
 
                     case TEST_EARLY_DATA_HRR:
                         if (!client_ep.ssl.handshake->hello_retry_request_flag) {
-                            TEST_EQUAL(client_ep.ssl.early_data_status,
-                                       MBEDTLS_SSL_EARLY_DATA_STATUS_UNKNOWN);
+                            TEST_EQUAL(client_ep.ssl.early_data_state,
+                                       MBEDTLS_SSL_EARLY_DATA_STATE_UNKNOWN);
                         } else {
-                            TEST_EQUAL(client_ep.ssl.early_data_status,
-                                       MBEDTLS_SSL_EARLY_DATA_STATUS_REJECTED);
+                            TEST_EQUAL(client_ep.ssl.early_data_state,
+                                       MBEDTLS_SSL_EARLY_DATA_STATE_REJECTED);
                         }
                         break;
 
@@ -3926,22 +3926,22 @@ void tls13_cli_early_data_status(int scenario)
                 switch (scenario) {
                     case TEST_EARLY_DATA_ACCEPTED: /* Intentional fallthrough */
                     case TEST_EARLY_DATA_SERVER_REJECTS:
-                        TEST_EQUAL(client_ep.ssl.early_data_status,
-                                   MBEDTLS_SSL_EARLY_DATA_STATUS_CAN_WRITE);
+                        TEST_EQUAL(client_ep.ssl.early_data_state,
+                                   MBEDTLS_SSL_EARLY_DATA_STATE_CAN_WRITE);
                         break;
 
                     case TEST_EARLY_DATA_NO_INDICATION_SENT:
-                        TEST_EQUAL(client_ep.ssl.early_data_status,
-                                   MBEDTLS_SSL_EARLY_DATA_STATUS_NOT_SENT);
+                        TEST_EQUAL(client_ep.ssl.early_data_state,
+                                   MBEDTLS_SSL_EARLY_DATA_STATE_NOT_SENT);
                         break;
 
                     case TEST_EARLY_DATA_HRR:
                         if (!client_ep.ssl.handshake->hello_retry_request_flag) {
-                            TEST_EQUAL(client_ep.ssl.early_data_status,
-                                       MBEDTLS_SSL_EARLY_DATA_STATUS_CAN_WRITE);
+                            TEST_EQUAL(client_ep.ssl.early_data_state,
+                                       MBEDTLS_SSL_EARLY_DATA_STATE_CAN_WRITE);
                         } else {
-                            TEST_EQUAL(client_ep.ssl.early_data_status,
-                                       MBEDTLS_SSL_EARLY_DATA_STATUS_REJECTED);
+                            TEST_EQUAL(client_ep.ssl.early_data_state,
+                                       MBEDTLS_SSL_EARLY_DATA_STATE_REJECTED);
                         }
                         break;
 
@@ -3954,18 +3954,18 @@ void tls13_cli_early_data_status(int scenario)
                 switch (scenario) {
                     case TEST_EARLY_DATA_ACCEPTED: /* Intentional fallthrough */
                     case TEST_EARLY_DATA_SERVER_REJECTS:
-                        TEST_EQUAL(client_ep.ssl.early_data_status,
-                                   MBEDTLS_SSL_EARLY_DATA_STATUS_CAN_WRITE);
+                        TEST_EQUAL(client_ep.ssl.early_data_state,
+                                   MBEDTLS_SSL_EARLY_DATA_STATE_CAN_WRITE);
                         break;
 
                     case TEST_EARLY_DATA_NO_INDICATION_SENT:
-                        TEST_EQUAL(client_ep.ssl.early_data_status,
-                                   MBEDTLS_SSL_EARLY_DATA_STATUS_NOT_SENT);
+                        TEST_EQUAL(client_ep.ssl.early_data_state,
+                                   MBEDTLS_SSL_EARLY_DATA_STATE_NOT_SENT);
                         break;
 
                     case TEST_EARLY_DATA_HRR:
-                        TEST_EQUAL(client_ep.ssl.early_data_status,
-                                   MBEDTLS_SSL_EARLY_DATA_STATUS_REJECTED);
+                        TEST_EQUAL(client_ep.ssl.early_data_state,
+                                   MBEDTLS_SSL_EARLY_DATA_STATE_REJECTED);
                         break;
 
                     default:
@@ -3976,19 +3976,19 @@ void tls13_cli_early_data_status(int scenario)
             case MBEDTLS_SSL_SERVER_FINISHED:
                 switch (scenario) {
                     case TEST_EARLY_DATA_ACCEPTED:
-                        TEST_EQUAL(client_ep.ssl.early_data_status,
-                                   MBEDTLS_SSL_EARLY_DATA_STATUS_ACCEPTED);
+                        TEST_EQUAL(client_ep.ssl.early_data_state,
+                                   MBEDTLS_SSL_EARLY_DATA_STATE_ACCEPTED);
                         break;
 
                     case TEST_EARLY_DATA_NO_INDICATION_SENT:
-                        TEST_EQUAL(client_ep.ssl.early_data_status,
-                                   MBEDTLS_SSL_EARLY_DATA_STATUS_NOT_SENT);
+                        TEST_EQUAL(client_ep.ssl.early_data_state,
+                                   MBEDTLS_SSL_EARLY_DATA_STATE_NOT_SENT);
                         break;
 
                     case TEST_EARLY_DATA_SERVER_REJECTS: /* Intentional fallthrough */
                     case TEST_EARLY_DATA_HRR:
-                        TEST_EQUAL(client_ep.ssl.early_data_status,
-                                   MBEDTLS_SSL_EARLY_DATA_STATUS_REJECTED);
+                        TEST_EQUAL(client_ep.ssl.early_data_state,
+                                   MBEDTLS_SSL_EARLY_DATA_STATE_REJECTED);
                         break;
 
                     default:
@@ -3998,26 +3998,26 @@ void tls13_cli_early_data_status(int scenario)
 
             case MBEDTLS_SSL_END_OF_EARLY_DATA:
                 TEST_EQUAL(scenario, TEST_EARLY_DATA_ACCEPTED);
-                TEST_EQUAL(client_ep.ssl.early_data_status,
-                           MBEDTLS_SSL_EARLY_DATA_STATUS_SERVER_FINISHED_RECEIVED);
+                TEST_EQUAL(client_ep.ssl.early_data_state,
+                           MBEDTLS_SSL_EARLY_DATA_STATE_SERVER_FINISHED_RECEIVED);
                 break;
 
             case MBEDTLS_SSL_CLIENT_CERTIFICATE:
                 switch (scenario) {
                     case TEST_EARLY_DATA_ACCEPTED:
-                        TEST_EQUAL(client_ep.ssl.early_data_status,
-                                   MBEDTLS_SSL_EARLY_DATA_STATUS_SERVER_FINISHED_RECEIVED);
+                        TEST_EQUAL(client_ep.ssl.early_data_state,
+                                   MBEDTLS_SSL_EARLY_DATA_STATE_SERVER_FINISHED_RECEIVED);
                         break;
 
                     case TEST_EARLY_DATA_NO_INDICATION_SENT:
-                        TEST_EQUAL(client_ep.ssl.early_data_status,
-                                   MBEDTLS_SSL_EARLY_DATA_STATUS_NOT_SENT);
+                        TEST_EQUAL(client_ep.ssl.early_data_state,
+                                   MBEDTLS_SSL_EARLY_DATA_STATE_NOT_SENT);
                         break;
 
                     case TEST_EARLY_DATA_SERVER_REJECTS: /* Intentional fallthrough */
                     case TEST_EARLY_DATA_HRR:
-                        TEST_EQUAL(client_ep.ssl.early_data_status,
-                                   MBEDTLS_SSL_EARLY_DATA_STATUS_REJECTED);
+                        TEST_EQUAL(client_ep.ssl.early_data_state,
+                                   MBEDTLS_SSL_EARLY_DATA_STATE_REJECTED);
                         break;
 
                     default:
@@ -4028,19 +4028,19 @@ void tls13_cli_early_data_status(int scenario)
             case MBEDTLS_SSL_CLIENT_FINISHED:
                 switch (scenario) {
                     case TEST_EARLY_DATA_ACCEPTED:
-                        TEST_EQUAL(client_ep.ssl.early_data_status,
-                                   MBEDTLS_SSL_EARLY_DATA_STATUS_SERVER_FINISHED_RECEIVED);
+                        TEST_EQUAL(client_ep.ssl.early_data_state,
+                                   MBEDTLS_SSL_EARLY_DATA_STATE_SERVER_FINISHED_RECEIVED);
                         break;
 
                     case TEST_EARLY_DATA_NO_INDICATION_SENT:
-                        TEST_EQUAL(client_ep.ssl.early_data_status,
-                                   MBEDTLS_SSL_EARLY_DATA_STATUS_NOT_SENT);
+                        TEST_EQUAL(client_ep.ssl.early_data_state,
+                                   MBEDTLS_SSL_EARLY_DATA_STATE_NOT_SENT);
                         break;
 
                     case TEST_EARLY_DATA_SERVER_REJECTS: /* Intentional fallthrough */
                     case TEST_EARLY_DATA_HRR:
-                        TEST_EQUAL(client_ep.ssl.early_data_status,
-                                   MBEDTLS_SSL_EARLY_DATA_STATUS_REJECTED);
+                        TEST_EQUAL(client_ep.ssl.early_data_state,
+                                   MBEDTLS_SSL_EARLY_DATA_STATE_REJECTED);
                         break;
 
                     default:
@@ -4054,8 +4054,8 @@ void tls13_cli_early_data_status(int scenario)
                     case TEST_EARLY_DATA_ACCEPTED: /* Intentional fallthrough */
                     case TEST_EARLY_DATA_SERVER_REJECTS: /* Intentional fallthrough */
                     case TEST_EARLY_DATA_HRR:
-                        TEST_EQUAL(client_ep.ssl.early_data_status,
-                                   MBEDTLS_SSL_EARLY_DATA_STATUS_SENT);
+                        TEST_EQUAL(client_ep.ssl.early_data_state,
+                                   MBEDTLS_SSL_EARLY_DATA_STATE_SENT);
                         break;
 
                     default:
@@ -4065,21 +4065,21 @@ void tls13_cli_early_data_status(int scenario)
 
             case MBEDTLS_SSL_CLIENT_CCS_BEFORE_2ND_CLIENT_HELLO:
                 TEST_ASSERT(scenario == TEST_EARLY_DATA_HRR);
-                TEST_EQUAL(client_ep.ssl.early_data_status,
-                           MBEDTLS_SSL_EARLY_DATA_STATUS_REJECTED);
+                TEST_EQUAL(client_ep.ssl.early_data_state,
+                           MBEDTLS_SSL_EARLY_DATA_STATE_REJECTED);
                 break;
 
             case MBEDTLS_SSL_CLIENT_CCS_AFTER_SERVER_FINISHED:
                 switch (scenario) {
                     case TEST_EARLY_DATA_NO_INDICATION_SENT:
-                        TEST_EQUAL(client_ep.ssl.early_data_status,
-                                   MBEDTLS_SSL_EARLY_DATA_STATUS_NOT_SENT);
+                        TEST_EQUAL(client_ep.ssl.early_data_state,
+                                   MBEDTLS_SSL_EARLY_DATA_STATE_NOT_SENT);
                         break;
 
                     case TEST_EARLY_DATA_SERVER_REJECTS: /* Intentional fallthrough */
                     case TEST_EARLY_DATA_HRR:
-                        TEST_EQUAL(client_ep.ssl.early_data_status,
-                                   MBEDTLS_SSL_EARLY_DATA_STATUS_REJECTED);
+                        TEST_EQUAL(client_ep.ssl.early_data_state,
+                                   MBEDTLS_SSL_EARLY_DATA_STATE_REJECTED);
                         break;
 
                     default:
@@ -4093,19 +4093,19 @@ void tls13_cli_early_data_status(int scenario)
             case MBEDTLS_SSL_HANDSHAKE_OVER:
                 switch (scenario) {
                     case TEST_EARLY_DATA_ACCEPTED:
-                        TEST_EQUAL(client_ep.ssl.early_data_status,
-                                   MBEDTLS_SSL_EARLY_DATA_STATUS_SERVER_FINISHED_RECEIVED);
+                        TEST_EQUAL(client_ep.ssl.early_data_state,
+                                   MBEDTLS_SSL_EARLY_DATA_STATE_SERVER_FINISHED_RECEIVED);
                         break;
 
                     case TEST_EARLY_DATA_NO_INDICATION_SENT:
-                        TEST_EQUAL(client_ep.ssl.early_data_status,
-                                   MBEDTLS_SSL_EARLY_DATA_STATUS_NOT_SENT);
+                        TEST_EQUAL(client_ep.ssl.early_data_state,
+                                   MBEDTLS_SSL_EARLY_DATA_STATE_NOT_SENT);
                         break;
 
                     case TEST_EARLY_DATA_SERVER_REJECTS: /* Intentional fallthrough */
                     case TEST_EARLY_DATA_HRR:
-                        TEST_EQUAL(client_ep.ssl.early_data_status,
-                                   MBEDTLS_SSL_EARLY_DATA_STATUS_REJECTED);
+                        TEST_EQUAL(client_ep.ssl.early_data_state,
+                                   MBEDTLS_SSL_EARLY_DATA_STATE_REJECTED);
                         break;
 
                     default:
@@ -4606,8 +4606,8 @@ void tls13_cli_max_early_data_size(int max_early_data_size_arg)
     ret = mbedtls_ssl_write_early_data(&(client_ep.ssl), buf, 1);
     TEST_EQUAL(ret, MBEDTLS_ERR_SSL_CANNOT_WRITE_EARLY_DATA);
     TEST_EQUAL(client_ep.ssl.total_early_data_size, max_early_data_size);
-    TEST_EQUAL(client_ep.ssl.early_data_status,
-               MBEDTLS_SSL_EARLY_DATA_STATUS_CAN_WRITE);
+    TEST_EQUAL(client_ep.ssl.early_data_state,
+               MBEDTLS_SSL_EARLY_DATA_STATE_CAN_WRITE);
 
     /*
      * Now, check data on server side. It is not done in the previous loop as
@@ -4780,8 +4780,8 @@ void tls13_srv_max_early_data_size(int scenario, int max_early_data_size_arg, in
                    &(client_ep.ssl), &(server_ep.ssl),
                    MBEDTLS_SSL_SERVER_HELLO), 0);
 
-    TEST_ASSERT(client_ep.ssl.early_data_status !=
-                MBEDTLS_SSL_EARLY_DATA_STATUS_NOT_SENT);
+    TEST_ASSERT(client_ep.ssl.early_data_state !=
+                MBEDTLS_SSL_EARLY_DATA_STATE_NOT_SENT);
 
     ret = mbedtls_ssl_handshake(&(server_ep.ssl));
     TEST_EQUAL(ret, MBEDTLS_ERR_SSL_WANT_READ);

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -4055,7 +4055,7 @@ void tls13_cli_early_data_state(int scenario)
                     case TEST_EARLY_DATA_SERVER_REJECTS: /* Intentional fallthrough */
                     case TEST_EARLY_DATA_HRR:
                         TEST_EQUAL(client_ep.ssl.early_data_state,
-                                   MBEDTLS_SSL_EARLY_DATA_STATE_SENT);
+                                   MBEDTLS_SSL_EARLY_DATA_STATE_IND_SENT);
                         break;
 
                     default:

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -3739,7 +3739,7 @@ void tls13_read_early_data(int scenario)
                                        early_data_len);
 
     if (client_ep.ssl.early_data_state !=
-        MBEDTLS_SSL_EARLY_DATA_STATE_NOT_SENT) {
+        MBEDTLS_SSL_EARLY_DATA_STATE_NO_IND_SENT) {
         TEST_EQUAL(ret, early_data_len);
     } else {
         TEST_EQUAL(ret, MBEDTLS_ERR_SSL_CANNOT_WRITE_EARLY_DATA);
@@ -3932,7 +3932,7 @@ void tls13_cli_early_data_state(int scenario)
 
                     case TEST_EARLY_DATA_NO_INDICATION_SENT:
                         TEST_EQUAL(client_ep.ssl.early_data_state,
-                                   MBEDTLS_SSL_EARLY_DATA_STATE_NOT_SENT);
+                                   MBEDTLS_SSL_EARLY_DATA_STATE_NO_IND_SENT);
                         break;
 
                     case TEST_EARLY_DATA_HRR:
@@ -3960,7 +3960,7 @@ void tls13_cli_early_data_state(int scenario)
 
                     case TEST_EARLY_DATA_NO_INDICATION_SENT:
                         TEST_EQUAL(client_ep.ssl.early_data_state,
-                                   MBEDTLS_SSL_EARLY_DATA_STATE_NOT_SENT);
+                                   MBEDTLS_SSL_EARLY_DATA_STATE_NO_IND_SENT);
                         break;
 
                     case TEST_EARLY_DATA_HRR:
@@ -3982,7 +3982,7 @@ void tls13_cli_early_data_state(int scenario)
 
                     case TEST_EARLY_DATA_NO_INDICATION_SENT:
                         TEST_EQUAL(client_ep.ssl.early_data_state,
-                                   MBEDTLS_SSL_EARLY_DATA_STATE_NOT_SENT);
+                                   MBEDTLS_SSL_EARLY_DATA_STATE_NO_IND_SENT);
                         break;
 
                     case TEST_EARLY_DATA_SERVER_REJECTS: /* Intentional fallthrough */
@@ -4011,7 +4011,7 @@ void tls13_cli_early_data_state(int scenario)
 
                     case TEST_EARLY_DATA_NO_INDICATION_SENT:
                         TEST_EQUAL(client_ep.ssl.early_data_state,
-                                   MBEDTLS_SSL_EARLY_DATA_STATE_NOT_SENT);
+                                   MBEDTLS_SSL_EARLY_DATA_STATE_NO_IND_SENT);
                         break;
 
                     case TEST_EARLY_DATA_SERVER_REJECTS: /* Intentional fallthrough */
@@ -4034,7 +4034,7 @@ void tls13_cli_early_data_state(int scenario)
 
                     case TEST_EARLY_DATA_NO_INDICATION_SENT:
                         TEST_EQUAL(client_ep.ssl.early_data_state,
-                                   MBEDTLS_SSL_EARLY_DATA_STATE_NOT_SENT);
+                                   MBEDTLS_SSL_EARLY_DATA_STATE_NO_IND_SENT);
                         break;
 
                     case TEST_EARLY_DATA_SERVER_REJECTS: /* Intentional fallthrough */
@@ -4073,7 +4073,7 @@ void tls13_cli_early_data_state(int scenario)
                 switch (scenario) {
                     case TEST_EARLY_DATA_NO_INDICATION_SENT:
                         TEST_EQUAL(client_ep.ssl.early_data_state,
-                                   MBEDTLS_SSL_EARLY_DATA_STATE_NOT_SENT);
+                                   MBEDTLS_SSL_EARLY_DATA_STATE_NO_IND_SENT);
                         break;
 
                     case TEST_EARLY_DATA_SERVER_REJECTS: /* Intentional fallthrough */
@@ -4099,7 +4099,7 @@ void tls13_cli_early_data_state(int scenario)
 
                     case TEST_EARLY_DATA_NO_INDICATION_SENT:
                         TEST_EQUAL(client_ep.ssl.early_data_state,
-                                   MBEDTLS_SSL_EARLY_DATA_STATE_NOT_SENT);
+                                   MBEDTLS_SSL_EARLY_DATA_STATE_NO_IND_SENT);
                         break;
 
                     case TEST_EARLY_DATA_SERVER_REJECTS: /* Intentional fallthrough */
@@ -4781,7 +4781,7 @@ void tls13_srv_max_early_data_size(int scenario, int max_early_data_size_arg, in
                    MBEDTLS_SSL_SERVER_HELLO), 0);
 
     TEST_ASSERT(client_ep.ssl.early_data_state !=
-                MBEDTLS_SSL_EARLY_DATA_STATE_NOT_SENT);
+                MBEDTLS_SSL_EARLY_DATA_STATE_NO_IND_SENT);
 
     ret = mbedtls_ssl_handshake(&(server_ep.ssl));
     TEST_EQUAL(ret, MBEDTLS_ERR_SSL_WANT_READ);

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -3904,13 +3904,13 @@ void tls13_cli_early_data_state(int scenario)
                     case TEST_EARLY_DATA_NO_INDICATION_SENT: /* Intentional fallthrough */
                     case TEST_EARLY_DATA_SERVER_REJECTS:
                         TEST_EQUAL(client_ep.ssl.early_data_state,
-                                   MBEDTLS_SSL_EARLY_DATA_STATE_UNKNOWN);
+                                   MBEDTLS_SSL_EARLY_DATA_STATE_IDLE);
                         break;
 
                     case TEST_EARLY_DATA_HRR:
                         if (!client_ep.ssl.handshake->hello_retry_request_flag) {
                             TEST_EQUAL(client_ep.ssl.early_data_state,
-                                       MBEDTLS_SSL_EARLY_DATA_STATE_UNKNOWN);
+                                       MBEDTLS_SSL_EARLY_DATA_STATE_IDLE);
                         } else {
                             TEST_EQUAL(client_ep.ssl.early_data_state,
                                        MBEDTLS_SSL_EARLY_DATA_STATE_REJECTED);


### PR DESCRIPTION
## Description
Follow-up of #8760, addressing comments https://github.com/Mbed-TLS/mbedtls/pull/8760#discussion_r1505805139, https://github.com/Mbed-TLS/mbedtls/pull/8760#discussion_r1505807730 and https://github.com/Mbed-TLS/mbedtls/pull/8760#discussion_r1505817245.

## PR checklist
- [x] **changelog** not required, will add one for TLS 1.3 early data feature as a whole
- [x] **backport** not required, new feature
- [x] **tests** not required, code improvement