### PR TITLE
[MBEDTLS_PRIVATE] Add accessor for session and ciphersuite_id

### DIFF
--- a/ChangeLog.d/add_ssl_session_accessors.txt
+++ b/ChangeLog.d/add_ssl_session_accessors.txt
@@ -1,0 +1,6 @@
+Features
+   * Add new accessors to expose the private session-id,
+     session-id length, and ciphersuite-id members of
+     `mbedtls_ssl_session` structure.
+     Add new accessor to expose the ciphersuite-id of
+     `mbedtls_ssl_ciphersuite_t` structure.Design ref: #8529

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -2718,6 +2718,30 @@ static inline int mbedtls_ssl_session_get_ticket_creation_time(
 #endif /* MBEDTLS_SSL_SESSION_TICKETS && MBEDTLS_SSL_SRV_C */
 
 /**
+ * \brief          Get the session-id buffer.
+ *
+ * \param session  SSL session.
+ *
+ * \return         The address of the session-id buffer.
+ */
+static inline const unsigned char[32]* mbedtls_ssl_session_get_id(const mbedtls_ssl_session *session)
+{
+    return &session->MBEDTLS_PRIVATE(id);
+}
+
+/**
+ * \brief          Get the size of the session-id.
+ *
+ * \param session  SSL session.
+ *
+ * \return         size_t size of session-id buffer.
+ */
+static inline const size_t mbedtls_ssl_session_get_id_len(const mbedtls_ssl_session *session)
+{
+    return session->MBEDTLS_PRIVATE(id_len);
+}
+
+/**
  * \brief   Configure a key export callback.
  *          (Default: none.)
  *

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -2743,6 +2743,18 @@ static inline size_t mbedtls_ssl_session_get_id_len(const mbedtls_ssl_session *s
 }
 
 /**
+ * \brief          Get the ciphersuite-id.
+ *
+ * \param session  SSL session.
+ *
+ * \return         int represetation for ciphersuite.
+ */
+static inline int mbedtls_ssl_session_get_ciphersuite_id(const mbedtls_ssl_session *session)
+{
+    return session->MBEDTLS_PRIVATE(ciphersuite);
+}
+
+/**
  * \brief   Configure a key export callback.
  *          (Default: none.)
  *

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -2724,7 +2724,8 @@ static inline int mbedtls_ssl_session_get_ticket_creation_time(
  *
  * \return         The address of the session-id buffer.
  */
-static inline const unsigned char[32]* mbedtls_ssl_session_get_id(const mbedtls_ssl_session *session)
+static inline unsigned const char (*mbedtls_ssl_session_get_id(const mbedtls_ssl_session *
+                                                               session))[32]
 {
     return &session->MBEDTLS_PRIVATE(id);
 }
@@ -2736,7 +2737,7 @@ static inline const unsigned char[32]* mbedtls_ssl_session_get_id(const mbedtls_
  *
  * \return         size_t size of session-id buffer.
  */
-static inline const size_t mbedtls_ssl_session_get_id_len(const mbedtls_ssl_session *session)
+static inline size_t mbedtls_ssl_session_get_id_len(const mbedtls_ssl_session *session)
 {
     return session->MBEDTLS_PRIVATE(id_len);
 }

--- a/include/mbedtls/ssl_ciphersuites.h
+++ b/include/mbedtls/ssl_ciphersuites.h
@@ -468,6 +468,11 @@ static inline const char *mbedtls_ssl_ciphersuite_get_name(const mbedtls_ssl_cip
     return info->MBEDTLS_PRIVATE(name);
 }
 
+static inline const int mbedtls_ssl_ciphersuite_get_id(const mbedtls_ssl_ciphersuite_t *info)
+{
+    return info->MBEDTLS_PRIVATE(id);
+}
+
 size_t mbedtls_ssl_ciphersuite_get_cipher_key_bitlen(const mbedtls_ssl_ciphersuite_t *info);
 
 #ifdef __cplusplus

--- a/include/mbedtls/ssl_ciphersuites.h
+++ b/include/mbedtls/ssl_ciphersuites.h
@@ -468,7 +468,7 @@ static inline const char *mbedtls_ssl_ciphersuite_get_name(const mbedtls_ssl_cip
     return info->MBEDTLS_PRIVATE(name);
 }
 
-static inline const int mbedtls_ssl_ciphersuite_get_id(const mbedtls_ssl_ciphersuite_t *info)
+static inline int mbedtls_ssl_ciphersuite_get_id(const mbedtls_ssl_ciphersuite_t *info)
 {
     return info->MBEDTLS_PRIVATE(id);
 }

--- a/tests/suites/test_suite_ssl.data
+++ b/tests/suites/test_suite_ssl.data
@@ -961,6 +961,14 @@ TLS 1.3: SRV: session serialization: Wrong config
 depends_on:MBEDTLS_SSL_PROTO_TLS1_3:MBEDTLS_SSL_SRV_C
 ssl_session_serialize_version_check:0:0:0:1:MBEDTLS_SSL_IS_SERVER:MBEDTLS_SSL_VERSION_TLS1_3
 
+Test Session id & Ciphersuite accesors TLS 1.2
+depends_on:MBEDTLS_SSL_PROTO_TLS1_2
+ssl_session_id_accessors_check:MBEDTLS_SSL_VERSION_TLS1_2
+
+Test Session id & Ciphersuite accesors TLS 1.3
+depends_on:MBEDTLS_SSL_PROTO_TLS1_3
+ssl_session_id_accessors_check:MBEDTLS_SSL_VERSION_TLS1_3
+
 Record crypt, AES-128-CBC, 1.2, SHA-384
 depends_on:MBEDTLS_SSL_HAVE_AES:MBEDTLS_SSL_HAVE_CBC:MBEDTLS_SSL_PROTO_TLS1_2:MBEDTLS_MD_CAN_SHA384
 ssl_crypt_record:MBEDTLS_CIPHER_AES_128_CBC:MBEDTLS_MD_SHA384:0:0:MBEDTLS_SSL_VERSION_TLS1_2:0:0

--- a/tests/suites/test_suite_ssl.data
+++ b/tests/suites/test_suite_ssl.data
@@ -961,11 +961,11 @@ TLS 1.3: SRV: session serialization: Wrong config
 depends_on:MBEDTLS_SSL_PROTO_TLS1_3:MBEDTLS_SSL_SRV_C
 ssl_session_serialize_version_check:0:0:0:1:MBEDTLS_SSL_IS_SERVER:MBEDTLS_SSL_VERSION_TLS1_3
 
-Test Session id & Ciphersuite accesors TLS 1.2
+Test Session id & Ciphersuite accessors TLS 1.2
 depends_on:MBEDTLS_SSL_PROTO_TLS1_2
 ssl_session_id_accessors_check:MBEDTLS_SSL_VERSION_TLS1_2
 
-Test Session id & Ciphersuite accesors TLS 1.3
+Test Session id & Ciphersuite accessors TLS 1.3
 depends_on:MBEDTLS_SSL_PROTO_TLS1_3
 ssl_session_id_accessors_check:MBEDTLS_SSL_VERSION_TLS1_3
 

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -2379,6 +2379,54 @@ exit:
 }
 /* END_CASE */
 
+/* BEGIN_CASE */
+void ssl_session_id_accessors_check(int tls_version)
+{
+    mbedtls_ssl_session session;
+    int ciphersuite_id;
+    const mbedtls_ssl_ciphersuite_t *ciphersuite_info;
+
+    mbedtls_ssl_session_init(&session);
+    USE_PSA_INIT();
+
+    switch (tls_version) {
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3)
+        case MBEDTLS_SSL_VERSION_TLS1_3:
+            ciphersuite_id = MBEDTLS_TLS1_3_AES_128_GCM_SHA256;
+            TEST_ASSERT(mbedtls_test_ssl_tls13_populate_session(
+                            &session, 0, MBEDTLS_SSL_IS_SERVER) == 0);
+            break;
+#endif
+#if defined(MBEDTLS_SSL_PROTO_TLS1_2)
+        case MBEDTLS_SSL_VERSION_TLS1_2:
+            ciphersuite_id = MBEDTLS_TLS_PSK_WITH_AES_128_GCM_SHA256;
+            TEST_ASSERT(mbedtls_test_ssl_tls12_populate_session(
+                            &session, 0, MBEDTLS_SSL_IS_SERVER, NULL) == 0);
+
+            break;
+#endif
+        default:
+            /* should never happen */
+            TEST_ASSERT(0);
+            break;
+    }
+    TEST_ASSERT(*mbedtls_ssl_session_get_id(&session) == session.id);
+    TEST_ASSERT(mbedtls_ssl_session_get_id_len(&session) == session.id_len);
+    /* mbedtls_test_ssl_tls1x_populate_session sets a mock suite-id of 0xabcd */
+    TEST_ASSERT(mbedtls_ssl_session_get_ciphersuite_id(&session) == 0xabcd);
+
+    /* Test setting a reference id for tls1.3 and tls1.2 */
+    ciphersuite_info = mbedtls_ssl_ciphersuite_from_id(ciphersuite_id);
+    if (ciphersuite_info != NULL) {
+        TEST_ASSERT(mbedtls_ssl_ciphersuite_get_id(ciphersuite_info) == ciphersuite_id);
+    }
+
+exit:
+    mbedtls_ssl_session_free(&session);
+    USE_PSA_DONE();
+}
+/* END_CASE */
+
 /* BEGIN_CASE depends_on:MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED:MBEDTLS_RSA_C:MBEDTLS_ECP_HAVE_SECP384R1:!MBEDTLS_SSL_PROTO_TLS1_3:MBEDTLS_PKCS1_V15:MBEDTLS_MD_CAN_SHA256 */
 void mbedtls_endpoint_sanity(int endpoint_type)
 {


### PR DESCRIPTION
## Description

The ps is adding accessors for the following members of the `mbedtls_ssl_session`
- `int MBEDTLS_PRIVATE(ciphersuite)` -> `mbedtls_ssl_session_get_ciphersuite_id()`
- `size_t MBEDTLS_PRIVATE(id_len)` -> `mbedtls_ssl_session_get_id_len()`
-`unsigned char MBEDTLS_PRIVATE(id)[32` -> `mbedtls_ssl_session_get_id()`

As well as one accessor for the `mbedtls_ssl_ciphersuite_t` struct
- `uint8_t MBEDTLS_PRIVATE(cipher)` -> `mbedtls_ssl_ciphersuite_get_id()`

Resolves #8529

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** Included
- [x] **backport** Not required new API calls.
- [x] **tests** provided

