### PR TITLE
Officially document non thread-safety of MBEDTLS_PSA_CRYPTO_SE_C

### DIFF
--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -3201,6 +3201,9 @@
  * \deprecated This feature is deprecated. Please switch to the PSA driver
  *             interface.
  *
+ * \warning    This feature is not thread-safe, and should not be used in a
+ *             multi-threaded environment.
+ *
  * Module:  library/psa_crypto_se.c
  *
  * Requires: MBEDTLS_PSA_CRYPTO_C, MBEDTLS_PSA_CRYPTO_STORAGE_C

--- a/library/psa_crypto_storage.h
+++ b/library/psa_crypto_storage.h
@@ -231,8 +231,9 @@ typedef uint16_t psa_crypto_transaction_type_t;
  * This type is designed to be serialized by writing the memory representation
  * and reading it back on the same device.
  *
- * \note The transaction mechanism is designed for a single active transaction
- *       at a time. The transaction object is #psa_crypto_transaction.
+ * \note The transaction mechanism is not thread-safe. There can only be one
+ *       single active transaction at a time.
+ *       The transaction object is #psa_crypto_transaction.
  *
  * \note If an API call starts a transaction, it must complete this transaction
  *       before returning to the application.

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -2178,6 +2178,9 @@ component_test_tsan () {
     scripts/config.py set MBEDTLS_THREADING_C
     scripts/config.py set MBEDTLS_THREADING_PTHREAD
 
+    # The deprecated MBEDTLS_PSA_CRYPTO_SE_C interface is not thread safe.
+    scripts/config.py unset MBEDTLS_PSA_CRYPTO_SE_C
+
     CC=clang cmake -D CMAKE_BUILD_TYPE:String=TSan .
     make
 


### PR DESCRIPTION
## Description
This has been replaced by a new driver interface which does support thread-safety.
Explicitly remove the deprecated flag from the TSan config. Closes #8849.
## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required for individual tasks on this epic
- [x] **backport** not required.
- [x] **tests** not required.
