### PR TITLE
Ensure drivers have threading enabled if required

### DIFF
--- a/tests/include/test/drivers/config_test_driver.h
+++ b/tests/include/test/drivers/config_test_driver.h
@@ -40,5 +40,7 @@
 //#define MBEDTLS_MD_C
 //#define MBEDTLS_PEM_PARSE_C
 //#define MBEDTLS_BASE64_C
+//#define MBEDTLS_THREADING_C
+//#define MBEDTLS_THREADING_PTHREAD
 
 #endif /* MBEDTLS_CONFIG_H */

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -889,6 +889,16 @@ helper_libtestdriver1_adjust_config() {
     # Dynamic secure element support is a deprecated feature and needs to be disabled here.
     # This is done to have the same form of psa_key_attributes_s for libdriver and library.
     scripts/config.py unset MBEDTLS_PSA_CRYPTO_SE_C
+
+    # If threading is enabled on the normal build, then we need to enable it in the drivers as well,
+    # otherwise we will end up running multithreaded tests without mutexes to protect them.
+    if scripts/config.py get MBEDTLS_THREADING_C; then
+        scripts/config.py -f "$CONFIG_TEST_DRIVER_H" set MBEDTLS_THREADING_C
+    fi
+
+    if scripts/config.py get MBEDTLS_THREADING_PTHREAD; then
+        scripts/config.py -f "$CONFIG_TEST_DRIVER_H" set MBEDTLS_THREADING_PTHREAD
+    fi
 }
 
 # When called with no parameter this function disables all builtin curves.


### PR DESCRIPTION
## Description

As a precursor to adding threading tests, it had been noticed that when running the driver tests, `MBEDTLS_THREADING_C` and `MBEDTLS_THREADING_PTHREAD` were defined (as part of a full config), however within libtestdriver1, `LIBTESTDRIVER1_MBEDTLS_THREADING_C` and `LIBTESTDRIVER1_MBEDTLS_THREADING_PTHREAD` were **not** defined.

This lead to a situation whereby when running the driver tests the requirements for the multithreaded tests were met (predicated on `MBEDTLS_*` defines), so they were running, however safety mutexes were removed due to the lack of the `LIBTESTDRIVER1_*` defines. This obviously causes some fairly serious test failures.

Attempt to fix this for all driver tests, by basically setting the requisite defines for the driver build config if they are set in the normal config. 

We do need to have multithreading enabled in driver tests, as we are adding thread safety around keys, and this would definitely leave a test gap if we disabled threading in driver tests.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [ ] **changelog** ~~provided, or~~ not required (part of multthreading EPIC)
- [ ] **backport** ~~done, or~~ not required (new work not present in LTS)
- [ ] **tests** ~~provided, or~~ not required (part of testing framework)
