### PR TITLE
Fix compilation when -Werror=maybe-uninitialized is enabled

### DIFF
--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -2523,7 +2523,7 @@ static int x509_crt_verify_chain(
     int signature_is_good;
     unsigned self_cnt;
     mbedtls_x509_crt *cur_trust_ca = NULL;
-    mbedtls_x509_time now;
+    mbedtls_x509_time now = {0};
 
 #if defined(MBEDTLS_HAVE_TIME_DATE)
     if (mbedtls_x509_time_gmtime(mbedtls_time(NULL), &now) != 0) {


### PR DESCRIPTION
## Description

The `now` struct is not initialized and the compiler complains about it when `-Werror=maybe-uninitialized` is enabled. This PR solves this by initializing the struct to zero before it is being used.



## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required
- [x] **backport** not required
- [x] **tests** not required



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
