### PR TITLE
ssl_mail_client: Fix unbounded write of sprintf()

### DIFF
--- a/programs/ssl/ssl_mail_client.c
+++ b/programs/ssl/ssl_mail_client.c
@@ -728,7 +728,7 @@ usage:
     fflush(stdout);
 
     len = mbedtls_snprintf((char *) buf, sizeof(buf), "MAIL FROM:<%s>\r\n", opt.mail_from);
-    if (len < 0 || (size_t)len >= sizeof(buf)) {
+    if (len < 0 || (size_t) len >= sizeof(buf)) {
         mbedtls_printf(" failed\n  ! mbedtls_snprintf encountered error or truncated output\n\n");
         goto exit;
     }
@@ -744,7 +744,7 @@ usage:
     fflush(stdout);
 
     len = mbedtls_snprintf((char *) buf, sizeof(buf), "RCPT TO:<%s>\r\n", opt.mail_to);
-    if (len < 0 || (size_t)len >= sizeof(buf)) {
+    if (len < 0 || (size_t) len >= sizeof(buf)) {
         mbedtls_printf(" failed\n  ! mbedtls_snprintf encountered error or truncated output\n\n");
         goto exit;
     }
@@ -772,12 +772,12 @@ usage:
     fflush(stdout);
 
     len = mbedtls_snprintf((char *) buf, sizeof(buf),
-                   "From: %s\r\nSubject: Mbed TLS Test mail\r\n\r\n"
-                   "This is a simple test mail from the "
-                   "Mbed TLS mail client example.\r\n"
-                   "\r\n"
-                   "Enjoy!", opt.mail_from);
-    if (len < 0 || (size_t)len >= sizeof(buf)) {
+                           "From: %s\r\nSubject: Mbed TLS Test mail\r\n\r\n"
+                           "This is a simple test mail from the "
+                           "Mbed TLS mail client example.\r\n"
+                           "\r\n"
+                           "Enjoy!", opt.mail_from);
+    if (len < 0 || (size_t) len >= sizeof(buf)) {
         mbedtls_printf(" failed\n  ! mbedtls_snprintf encountered error or truncated output\n\n");
         goto exit;
     }

--- a/programs/ssl/ssl_mail_client.c
+++ b/programs/ssl/ssl_mail_client.c
@@ -727,7 +727,7 @@ usage:
     mbedtls_printf("  > Write MAIL FROM to server:");
     fflush(stdout);
 
-    len = snprintf((char *) buf, sizeof(buf), "MAIL FROM:<%s>\r\n", opt.mail_from);
+    len = mbedtls_snprintf((char *) buf, sizeof(buf), "MAIL FROM:<%s>\r\n", opt.mail_from);
     ret = write_ssl_and_get_response(&ssl, buf, len);
     if (ret < 200 || ret > 299) {
         mbedtls_printf(" failed\n  ! server responded with %d\n\n", ret);
@@ -739,7 +739,7 @@ usage:
     mbedtls_printf("  > Write RCPT TO to server:");
     fflush(stdout);
 
-    len = snprintf((char *) buf, sizeof(buf), "RCPT TO:<%s>\r\n", opt.mail_to);
+    len = mbedtls_snprintf((char *) buf, sizeof(buf), "RCPT TO:<%s>\r\n", opt.mail_to);
     ret = write_ssl_and_get_response(&ssl, buf, len);
     if (ret < 200 || ret > 299) {
         mbedtls_printf(" failed\n  ! server responded with %d\n\n", ret);
@@ -763,7 +763,7 @@ usage:
     mbedtls_printf("  > Write content to server:");
     fflush(stdout);
 
-    len = snprintf((char *) buf, sizeof(buf),
+    len = mbedtls_snprintf((char *) buf, sizeof(buf),
                    "From: %s\r\nSubject: Mbed TLS Test mail\r\n\r\n"
                    "This is a simple test mail from the "
                    "Mbed TLS mail client example.\r\n"

--- a/programs/ssl/ssl_mail_client.c
+++ b/programs/ssl/ssl_mail_client.c
@@ -727,7 +727,7 @@ usage:
     mbedtls_printf("  > Write MAIL FROM to server:");
     fflush(stdout);
 
-    len = sprintf((char *) buf, "MAIL FROM:<%s>\r\n", opt.mail_from);
+    len = snprintf((char *) buf, sizeof(buf), "MAIL FROM:<%s>\r\n", opt.mail_from);
     ret = write_ssl_and_get_response(&ssl, buf, len);
     if (ret < 200 || ret > 299) {
         mbedtls_printf(" failed\n  ! server responded with %d\n\n", ret);
@@ -739,7 +739,7 @@ usage:
     mbedtls_printf("  > Write RCPT TO to server:");
     fflush(stdout);
 
-    len = sprintf((char *) buf, "RCPT TO:<%s>\r\n", opt.mail_to);
+    len = snprintf((char *) buf, sizeof(buf), "RCPT TO:<%s>\r\n", opt.mail_to);
     ret = write_ssl_and_get_response(&ssl, buf, len);
     if (ret < 200 || ret > 299) {
         mbedtls_printf(" failed\n  ! server responded with %d\n\n", ret);
@@ -763,11 +763,12 @@ usage:
     mbedtls_printf("  > Write content to server:");
     fflush(stdout);
 
-    len = sprintf((char *) buf, "From: %s\r\nSubject: Mbed TLS Test mail\r\n\r\n"
-                                "This is a simple test mail from the "
-                                "Mbed TLS mail client example.\r\n"
-                                "\r\n"
-                                "Enjoy!", opt.mail_from);
+    len = snprintf((char *) buf, sizeof(buf),
+                   "From: %s\r\nSubject: Mbed TLS Test mail\r\n\r\n"
+                   "This is a simple test mail from the "
+                   "Mbed TLS mail client example.\r\n"
+                   "\r\n"
+                   "Enjoy!", opt.mail_from);
     ret = write_ssl_data(&ssl, buf, len);
 
     len = sprintf((char *) buf, "\r\n.\r\n");

--- a/programs/ssl/ssl_mail_client.c
+++ b/programs/ssl/ssl_mail_client.c
@@ -728,6 +728,10 @@ usage:
     fflush(stdout);
 
     len = mbedtls_snprintf((char *) buf, sizeof(buf), "MAIL FROM:<%s>\r\n", opt.mail_from);
+    if (len < 0 || (size_t)len >= sizeof(buf)) {
+        mbedtls_printf(" failed\n  ! mbedtls_snprintf encountered error or truncated output\n\n");
+        goto exit;
+    }
     ret = write_ssl_and_get_response(&ssl, buf, len);
     if (ret < 200 || ret > 299) {
         mbedtls_printf(" failed\n  ! server responded with %d\n\n", ret);
@@ -740,6 +744,10 @@ usage:
     fflush(stdout);
 
     len = mbedtls_snprintf((char *) buf, sizeof(buf), "RCPT TO:<%s>\r\n", opt.mail_to);
+    if (len < 0 || (size_t)len >= sizeof(buf)) {
+        mbedtls_printf(" failed\n  ! mbedtls_snprintf encountered error or truncated output\n\n");
+        goto exit;
+    }
     ret = write_ssl_and_get_response(&ssl, buf, len);
     if (ret < 200 || ret > 299) {
         mbedtls_printf(" failed\n  ! server responded with %d\n\n", ret);
@@ -769,6 +777,10 @@ usage:
                    "Mbed TLS mail client example.\r\n"
                    "\r\n"
                    "Enjoy!", opt.mail_from);
+    if (len < 0 || (size_t)len >= sizeof(buf)) {
+        mbedtls_printf(" failed\n  ! mbedtls_snprintf encountered error or truncated output\n\n");
+        goto exit;
+    }
     ret = write_ssl_data(&ssl, buf, len);
 
     len = sprintf((char *) buf, "\r\n.\r\n");


### PR DESCRIPTION
## Description

These calls to sprintf may overflow buf because opt.mail_from and opt.mail_to are controlled by users. Fix by replacing sprintf with snprintf.



## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required
- [x] 3.6 backport #9076
- [x] **2.28 backport** #8907
- [x] **tests** not required



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
