### PR TITLE
test/pkcs7: Fix TOCTOU race condition

### DIFF
--- a/tests/suites/test_suite_pkcs7.function
+++ b/tests/suites/test_suite_pkcs7.function
@@ -121,11 +121,11 @@ void pkcs7_verify(char *pkcs7_file,
         TEST_EQUAL(res, 0);
     }
 
-    res = stat(filetobesigned, &st);
-    TEST_EQUAL(res, 0);
-
     file = fopen(filetobesigned, "rb");
     TEST_ASSERT(file != NULL);
+
+    res = fstat(fileno(file), &st);
+    TEST_EQUAL(res, 0);
 
     datalen = st.st_size;
     /* Special-case for zero-length input so that data will be non-NULL */


### PR DESCRIPTION


## Description

Separately checking the state of a file before operating on it may allow an attacker to modify the file between the two operations. (CWE-367)

Even if this is test code, we may as well follow best practice.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required
- [x] **backport** not required because there is no `tests/suites/test_suite_pkcs7.function` in mbedtls-2.28.
- [x] **tests** not required



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
