### PR TITLE
CMAC size and perf

### DIFF
--- a/library/cmac.c
+++ b/library/cmac.c
@@ -56,16 +56,20 @@ static int cmac_multiply_by_u(unsigned char *output,
                               size_t blocksize)
 {
     const unsigned char R_128 = 0x87;
-    const unsigned char R_64 = 0x1B;
     unsigned char R_n, mask;
     uint32_t overflow = 0x00;
     int i;
 
     if (blocksize == MBEDTLS_AES_BLOCK_SIZE) {
         R_n = R_128;
-    } else if (blocksize == MBEDTLS_DES3_BLOCK_SIZE) {
+    }
+#if defined(MBEDTLS_DES_C)
+    else if (blocksize == MBEDTLS_DES3_BLOCK_SIZE) {
+        const unsigned char R_64 = 0x1B;
         R_n = R_64;
-    } else {
+    }
+#endif
+    else {
         return MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA;
     }
 

--- a/library/cmac.c
+++ b/library/cmac.c
@@ -58,7 +58,7 @@ static int cmac_multiply_by_u(unsigned char *output,
     const unsigned char R_128 = 0x87;
     const unsigned char R_64 = 0x1B;
     unsigned char R_n, mask;
-    unsigned char overflow = 0x00;
+    uint32_t overflow = 0x00;
     int i;
 
     if (blocksize == MBEDTLS_AES_BLOCK_SIZE) {
@@ -69,9 +69,12 @@ static int cmac_multiply_by_u(unsigned char *output,
         return MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA;
     }
 
-    for (i = (int) blocksize - 1; i >= 0; i--) {
-        output[i] = input[i] << 1 | overflow;
-        overflow = input[i] >> 7;
+    for (i = (int) blocksize - 4; i >= 0; i -= 4) {
+        uint32_t i32 = MBEDTLS_GET_UINT32_BE(&input[i], 0);
+        uint32_t new_overflow = i32 >> 31;
+        i32 = (i32 << 1) | overflow;
+        MBEDTLS_PUT_UINT32_BE(i32, &output[i], 0);
+        overflow = new_overflow;
     }
 
     /* mask = ( input[0] >> 7 ) ? 0xff : 0x00


### PR DESCRIPTION
## Description

Very small change to get some perf improvement in CMAC. This benefits PBKDF2 with CMAC significantly - the CMAC parts of the PBKDF2 tests are about 16% faster with this change (`test_suite_psa_crypto.pbkdf2` is ~5% faster overall with this change, which is worth having). Also saves 8 bytes.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required
- [x] **backport** not required
- [x] **tests** not required
