### PR TITLE
Generalize mbedtls_pk_setup_opaque to MBEDTLS_PSA_CRYPTO_CLIENT: SSL testing

### DIFF
--- a/library/ssl_ciphersuites.c
+++ b/library/ssl_ciphersuites.c
@@ -1940,14 +1940,14 @@ mbedtls_pk_type_t mbedtls_ssl_get_ciphersuite_sig_pk_alg(const mbedtls_ssl_ciphe
 
         case MBEDTLS_KEY_EXCHANGE_ECDH_RSA:
         case MBEDTLS_KEY_EXCHANGE_ECDH_ECDSA:
-            return MBEDTLS_PK_ECKEY;
+            return MBEDTLS_PK_ECKEY_DH;
 
         default:
             return MBEDTLS_PK_NONE;
     }
 }
 
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
+#if defined(MBEDTLS_PSA_CRYPTO_CLIENT)
 psa_algorithm_t mbedtls_ssl_get_ciphersuite_sig_pk_psa_alg(const mbedtls_ssl_ciphersuite_t *info)
 {
     switch (info->key_exchange) {
@@ -1990,7 +1990,7 @@ psa_key_usage_t mbedtls_ssl_get_ciphersuite_sig_pk_psa_usage(const mbedtls_ssl_c
             return 0;
     }
 }
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
+#endif /* MBEDTLS_PSA_CRYPTO_CLIENT */
 
 mbedtls_pk_type_t mbedtls_ssl_get_ciphersuite_sig_alg(const mbedtls_ssl_ciphersuite_t *info)
 {

--- a/library/ssl_ciphersuites_internal.h
+++ b/library/ssl_ciphersuites_internal.h
@@ -14,10 +14,10 @@
 
 #if defined(MBEDTLS_PK_C)
 mbedtls_pk_type_t mbedtls_ssl_get_ciphersuite_sig_pk_alg(const mbedtls_ssl_ciphersuite_t *info);
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
+#if defined(MBEDTLS_PSA_CRYPTO_CLIENT)
 psa_algorithm_t mbedtls_ssl_get_ciphersuite_sig_pk_psa_alg(const mbedtls_ssl_ciphersuite_t *info);
 psa_key_usage_t mbedtls_ssl_get_ciphersuite_sig_pk_psa_usage(const mbedtls_ssl_ciphersuite_t *info);
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
+#endif /* MBEDTLS_PSA_CRYPTO_CLIENT */
 mbedtls_pk_type_t mbedtls_ssl_get_ciphersuite_sig_alg(const mbedtls_ssl_ciphersuite_t *info);
 #endif /* MBEDTLS_PK_C */
 

--- a/library/ssl_tls12_client.c
+++ b/library/ssl_tls12_client.c
@@ -1998,8 +1998,9 @@ static int ssl_get_ecdh_params_from_cert(mbedtls_ssl_context *ssl)
     peer_pk = &ssl->session_negotiate->peer_cert->pk;
 #endif /* MBEDTLS_SSL_KEEP_PEER_CERTIFICATE */
 
-    /* This is a public key, so it can't be opaque, so can_do() is a good
-     * enough check to ensure pk_ec() is safe to use below. */
+    /* This is a public key obtained from parsing, so it can't be opaque,
+     * so can_do() is a good enough check to ensure pk_ec_ro() is safe to
+     * use below. */
     if (!mbedtls_pk_can_do(peer_pk, MBEDTLS_PK_ECKEY)) {
         MBEDTLS_SSL_DEBUG_MSG(1, ("server key not ECDH capable"));
         return MBEDTLS_ERR_SSL_PK_TYPE_MISMATCH;

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -2748,8 +2748,12 @@ static int ssl_get_ecdh_params_from_cert(mbedtls_ssl_context *ssl)
         return MBEDTLS_ERR_SSL_PK_TYPE_MISMATCH;
     }
 
-    if ((ret = mbedtls_ecdh_get_params(&ssl->handshake->ecdh_ctx,
-                                       mbedtls_pk_ec_ro(*mbedtls_ssl_own_key(ssl)),
+    const mbedtls_ecp_keypair *ec = mbedtls_pk_ec_ro(*private_key);
+    if (ec == NULL) {
+        MBEDTLS_SSL_DEBUG_MSG(1, ("key for ECDH is ECKEY but not mbedtls_ecp"));
+        return MBEDTLS_ERR_SSL_INTERNAL_ERROR;
+    }
+    if ((ret = mbedtls_ecdh_get_params(&ssl->handshake->ecdh_ctx, ec,
                                        MBEDTLS_ECDH_OURS)) != 0) {
         MBEDTLS_SSL_DEBUG_RET(1, ("mbedtls_ecdh_get_params"), ret);
         return ret;

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -767,8 +767,8 @@ int main(int argc, char *argv[])
     psa_algorithm_t alg = 0;
     psa_key_attributes_t key_attributes;
 #endif
-    psa_status_t status;
-#elif defined(MBEDTLS_SSL_PROTO_TLS1_3)
+#endif
+#if defined(MBEDTLS_PSA_CRYPTO_C)
     psa_status_t status;
 #endif
 
@@ -787,7 +787,7 @@ int main(int argc, char *argv[])
     mbedtls_x509_crt clicert;
     mbedtls_pk_context pkey;
     mbedtls_x509_crt_profile crt_profile_for_test = mbedtls_x509_crt_profile_default;
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
+#if defined(MBEDTLS_PSA_CRYPTO_C)
     mbedtls_svc_key_id_t key_slot = MBEDTLS_SVC_KEY_ID_INIT; /* invalid key slot */
 #endif
 #endif  /* MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED */
@@ -844,15 +844,6 @@ int main(int argc, char *argv[])
     memset((void *) alpn_list, 0, sizeof(alpn_list));
 #endif
 
-#if defined(MBEDTLS_USE_PSA_CRYPTO) || defined(MBEDTLS_SSL_PROTO_TLS1_3)
-    status = psa_crypto_init();
-    if (status != PSA_SUCCESS) {
-        mbedtls_fprintf(stderr, "Failed to initialize PSA Crypto implementation: %d\n",
-                        (int) status);
-        ret = MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
-        goto exit;
-    }
-#endif  /* MBEDTLS_USE_PSA_CRYPTO || MBEDTLS_SSL_PROTO_TLS1_3 */
 #if defined(MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG)
     mbedtls_test_enable_insecure_external_rng();
 #endif  /* MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG */
@@ -1061,7 +1052,7 @@ usage:
         } else if (strcmp(p, "key_pwd") == 0) {
             opt.key_pwd = q;
         }
-#if defined(MBEDTLS_USE_PSA_CRYPTO) && defined(MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED)
+#if defined(MBEDTLS_PSA_CRYPTO_C) && defined(MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED)
         else if (strcmp(p, "key_opaque") == 0) {
             opt.key_opaque = atoi(q);
         }
@@ -1605,6 +1596,25 @@ usage:
     mbedtls_printf("\n  . Seeding the random number generator...");
     fflush(stdout);
 
+#if defined(MBEDTLS_PSA_CRYPTO_C)
+    int need_psa = 0;
+#if defined(MBEDTLS_USE_PSA_CRYPTO) || defined(MBEDTLS_SSL_PROTO_TLS1_3)
+    need_psa = 1;
+#endif
+    if (opt.key_opaque != 0) {
+        need_psa = 1;
+    }
+    if (need_psa) {
+        status = psa_crypto_init();
+        if (status != PSA_SUCCESS) {
+            mbedtls_fprintf(stderr, "Failed to initialize PSA Crypto implementation: %d\n",
+                            (int) status);
+            ret = MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
+            goto exit;
+        }
+    }
+#endif
+
     ret = rng_seed(&rng, opt.reproducible, pers);
     if (ret != 0) {
         goto exit;
@@ -1701,7 +1711,7 @@ usage:
         goto exit;
     }
 
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
+#if defined(MBEDTLS_PSA_CRYPTO_C)
     if (opt.key_opaque != 0) {
         psa_algorithm_t psa_alg, psa_alg2 = PSA_ALG_NONE;
         psa_key_usage_t usage = 0;
@@ -1721,7 +1731,7 @@ usage:
             }
         }
     }
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
+#endif /* MBEDTLS_PSA_CRYPTO_C */
 
     mbedtls_printf(" ok (key type: %s)\n",
                    strlen(opt.key_file) || strlen(opt.key_opaque_alg1) ?
@@ -3056,7 +3066,7 @@ exit:
     mbedtls_x509_crt_free(&clicert);
     mbedtls_x509_crt_free(&cacert);
     mbedtls_pk_free(&pkey);
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
+#if defined(MBEDTLS_PSA_CRYPTO_C)
     psa_destroy_key(key_slot);
 #endif
 #endif /* MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED */
@@ -3116,8 +3126,7 @@ exit:
 
     /* For builds with MBEDTLS_TEST_USE_PSA_CRYPTO_RNG psa crypto
      * resources are freed by rng_free(). */
-#if (defined(MBEDTLS_USE_PSA_CRYPTO) || defined(MBEDTLS_SSL_PROTO_TLS1_3)) && \
-    !defined(MBEDTLS_TEST_USE_PSA_CRYPTO_RNG)
+#if defined(MBEDTLS_PSA_CRYPTO_C) && !defined(MBEDTLS_TEST_USE_PSA_CRYPTO_RNG)
     mbedtls_psa_crypto_free();
 #endif
 

--- a/programs/ssl/ssl_test_lib.c
+++ b/programs/ssl/ssl_test_lib.c
@@ -219,7 +219,7 @@ int key_opaque_alg_parse(const char *arg, const char **alg1, const char **alg2)
     return 0;
 }
 
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
+#if defined(MBEDTLS_PSA_CRYPTO_C)
 int key_opaque_set_alg_usage(const char *alg1, const char *alg2,
                              psa_algorithm_t *psa_alg1,
                              psa_algorithm_t *psa_alg2,
@@ -275,7 +275,7 @@ int key_opaque_set_alg_usage(const char *alg1, const char *alg2,
 
     return 0;
 }
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
+#endif /* MBEDTLS_PSA_CRYPTO_C */
 
 #if defined(MBEDTLS_X509_TRUSTED_CERTIFICATE_CALLBACK)
 int ca_callback(void *data, mbedtls_x509_crt const *child,

--- a/programs/ssl/ssl_test_lib.h
+++ b/programs/ssl/ssl_test_lib.h
@@ -214,7 +214,7 @@ int rng_get(void *p_rng, unsigned char *output, size_t output_len);
  */
 int key_opaque_alg_parse(const char *arg, const char **alg1, const char **alg2);
 
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
+#if defined(MBEDTLS_PSA_CRYPTO_C)
 /** Parse given opaque key algorithms to obtain psa algs and usage
  *  that will be passed to mbedtls_pk_wrap_as_opaque().
  *
@@ -235,7 +235,7 @@ int key_opaque_set_alg_usage(const char *alg1, const char *alg2,
                              psa_algorithm_t *psa_alg2,
                              psa_key_usage_t *usage,
                              mbedtls_pk_type_t key_type);
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
+#endif /* MBEDTLS_PSA_CRYPTO_C */
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO) && defined(MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG)
 /* The test implementation of the PSA external RNG is insecure. When

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -2259,7 +2259,7 @@ run_test    "Opaque key for server authentication: ECDHE-ECDSA" \
             -S "error" \
             -C "error"
 
-requires_config_enabled MBEDTLS_PSA_CRYPTO_C
+requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
 requires_config_enabled MBEDTLS_X509_CRT_PARSE_C
 requires_hash_alg SHA_256
 run_test    "Opaque key for server authentication: ECDH-" \
@@ -2274,6 +2274,23 @@ run_test    "Opaque key for server authentication: ECDH-" \
             -s "Ciphersuite is TLS-ECDH-" \
             -S "error" \
             -C "error"
+
+# Static ECDH is not yet supported with opaque keys when MBEDTLS_USE_PSA_CRYPTO
+# is disabled. Check that we get an internal error and not a crash. When
+# this limitation is lifted, remove this test case and adjust the previous
+# one to depend on MBEDTLS_PSA_CRYPTO_C instead of MBEDTLS_USE_PSA_CRYPTO.
+requires_config_enabled MBEDTLS_PSA_CRYPTO_C
+requires_config_disabled MBEDTLS_USE_PSA_CRYPTO
+requires_config_enabled MBEDTLS_X509_CRT_PARSE_C
+requires_hash_alg SHA_256
+run_test    "Opaque key for server authentication: ECDH- (no USE_PSA_CRYPTO)" \
+            "$P_SRV auth_mode=required key_opaque=1\
+             crt_file=data_files/server5.ku-ka.crt\
+             key_file=data_files/server5.key key_opaque_algs=ecdh,none" \
+            "$P_CLI force_version=tls12" \
+            1 \
+            -s "key types: Opaque, none" \
+            -s "Internal error"
 
 requires_config_enabled MBEDTLS_PSA_CRYPTO_C
 requires_config_enabled MBEDTLS_X509_CRT_PARSE_C
@@ -2372,7 +2389,7 @@ run_test    "Opaque keys for server authentication: EC keys with different algs,
             -S "error" \
             -C "error"
 
-requires_config_enabled MBEDTLS_PSA_CRYPTO_C
+requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
 requires_config_enabled MBEDTLS_X509_CRT_PARSE_C
 requires_hash_alg SHA_384
 requires_config_disabled MBEDTLS_X509_REMOVE_INFO
@@ -2390,6 +2407,25 @@ run_test    "Opaque keys for server authentication: EC keys with different algs,
             -s "Ciphersuite is TLS-ECDH-ECDSA" \
             -S "error" \
             -C "error"
+
+# Static ECDH is not yet supported with opaque keys when MBEDTLS_USE_PSA_CRYPTO
+# is disabled. Check that we get an internal error and not a crash. When
+# this limitation is lifted, remove this test case and adjust the previous
+# one to depend on MBEDTLS_PSA_CRYPTO_C instead of MBEDTLS_USE_PSA_CRYPTO.
+requires_config_enabled MBEDTLS_PSA_CRYPTO_C
+requires_config_disabled MBEDTLS_USE_PSA_CRYPTO
+requires_config_enabled MBEDTLS_X509_CRT_PARSE_C
+requires_hash_alg SHA_384
+requires_config_disabled MBEDTLS_X509_REMOVE_INFO
+run_test    "Opaque keys for server authentication: EC keys with different algs, force ECDH-ECDSA (no USE_PSA_CRYPTO)" \
+            "$P_SRV key_opaque=1 crt_file=data_files/server7.crt \
+             key_file=data_files/server7.key key_opaque_algs=ecdsa-sign,none \
+             crt_file2=data_files/server5.crt key_file2=data_files/server5.key \
+             key_opaque_algs2=ecdh,none debug_level=3" \
+            "$P_CLI force_version=tls12 force_ciphersuite=TLS-ECDH-ECDSA-WITH-CAMELLIA-256-CBC-SHA384" \
+            1 \
+            -s "key types: Opaque, Opaque" \
+            -s "Internal error"
 
 requires_config_enabled MBEDTLS_PSA_CRYPTO_C
 requires_config_enabled MBEDTLS_X509_CRT_PARSE_C

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -2188,7 +2188,7 @@ run_test    "CA callback on server" \
             -C "error"
 
 # Test using an EC opaque private key for client authentication
-requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
+requires_config_enabled MBEDTLS_PSA_CRYPTO_C
 requires_config_enabled MBEDTLS_X509_CRT_PARSE_C
 requires_config_enabled MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
 requires_hash_alg SHA_256
@@ -2206,7 +2206,7 @@ run_test    "Opaque key for client authentication: ECDHE-ECDSA" \
             -C "error"
 
 # Test using a RSA opaque private key for client authentication
-requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
+requires_config_enabled MBEDTLS_PSA_CRYPTO_C
 requires_config_enabled MBEDTLS_X509_CRT_PARSE_C
 requires_config_enabled MBEDTLS_RSA_C
 requires_config_enabled MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED
@@ -2224,7 +2224,7 @@ run_test    "Opaque key for client authentication: ECDHE-RSA" \
             -S "error" \
             -C "error"
 
-requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
+requires_config_enabled MBEDTLS_PSA_CRYPTO_C
 requires_config_enabled MBEDTLS_X509_CRT_PARSE_C
 requires_config_enabled MBEDTLS_RSA_C
 requires_hash_alg SHA_256
@@ -2243,7 +2243,7 @@ run_test    "Opaque key for client authentication: DHE-RSA" \
             -C "error"
 
 # Test using an EC opaque private key for server authentication
-requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
+requires_config_enabled MBEDTLS_PSA_CRYPTO_C
 requires_config_enabled MBEDTLS_X509_CRT_PARSE_C
 requires_config_enabled MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
 requires_hash_alg SHA_256
@@ -2259,7 +2259,7 @@ run_test    "Opaque key for server authentication: ECDHE-ECDSA" \
             -S "error" \
             -C "error"
 
-requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
+requires_config_enabled MBEDTLS_PSA_CRYPTO_C
 requires_config_enabled MBEDTLS_X509_CRT_PARSE_C
 requires_hash_alg SHA_256
 run_test    "Opaque key for server authentication: ECDH-" \
@@ -2275,7 +2275,7 @@ run_test    "Opaque key for server authentication: ECDH-" \
             -S "error" \
             -C "error"
 
-requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
+requires_config_enabled MBEDTLS_PSA_CRYPTO_C
 requires_config_enabled MBEDTLS_X509_CRT_PARSE_C
 requires_config_disabled MBEDTLS_SSL_ASYNC_PRIVATE
 requires_hash_alg SHA_256
@@ -2290,7 +2290,7 @@ run_test    "Opaque key for server authentication: invalid key: decrypt with ECC
             -c "error" \
             -c "Public key type mismatch"
 
-requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
+requires_config_enabled MBEDTLS_PSA_CRYPTO_C
 requires_config_enabled MBEDTLS_X509_CRT_PARSE_C
 requires_config_enabled MBEDTLS_ECDSA_C
 requires_config_enabled MBEDTLS_RSA_C
@@ -2307,7 +2307,7 @@ run_test    "Opaque key for server authentication: invalid key: ecdh with RSA ke
             -c "error" \
             -c "Public key type mismatch"
 
-requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
+requires_config_enabled MBEDTLS_PSA_CRYPTO_C
 requires_config_enabled MBEDTLS_X509_CRT_PARSE_C
 requires_config_enabled MBEDTLS_SSL_ASYNC_PRIVATE
 requires_hash_alg SHA_256
@@ -2322,7 +2322,7 @@ run_test    "Opaque key for server authentication: invalid alg: decrypt with ECC
             -s "error" \
             -c "error"
 
-requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
+requires_config_enabled MBEDTLS_PSA_CRYPTO_C
 requires_config_enabled MBEDTLS_X509_CRT_PARSE_C
 requires_config_enabled MBEDTLS_RSA_C
 requires_config_enabled MBEDTLS_SSL_ASYNC_PRIVATE
@@ -2338,7 +2338,7 @@ run_test    "Opaque key for server authentication: invalid alg: ecdh with RSA ke
             -s "error" \
             -c "error"
 
-requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
+requires_config_enabled MBEDTLS_PSA_CRYPTO_C
 requires_config_enabled MBEDTLS_X509_CRT_PARSE_C
 requires_hash_alg SHA_256
 run_test    "Opaque key for server authentication: invalid alg: ECDHE-ECDSA with ecdh" \
@@ -2352,7 +2352,7 @@ run_test    "Opaque key for server authentication: invalid alg: ECDHE-ECDSA with
             -s "error" \
             -c "error"
 
-requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
+requires_config_enabled MBEDTLS_PSA_CRYPTO_C
 requires_config_enabled MBEDTLS_X509_CRT_PARSE_C
 requires_config_enabled MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
 requires_hash_alg SHA_256
@@ -2372,7 +2372,7 @@ run_test    "Opaque keys for server authentication: EC keys with different algs,
             -S "error" \
             -C "error"
 
-requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
+requires_config_enabled MBEDTLS_PSA_CRYPTO_C
 requires_config_enabled MBEDTLS_X509_CRT_PARSE_C
 requires_hash_alg SHA_384
 requires_config_disabled MBEDTLS_X509_REMOVE_INFO
@@ -2391,7 +2391,7 @@ run_test    "Opaque keys for server authentication: EC keys with different algs,
             -S "error" \
             -C "error"
 
-requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
+requires_config_enabled MBEDTLS_PSA_CRYPTO_C
 requires_config_enabled MBEDTLS_X509_CRT_PARSE_C
 requires_hash_alg SHA_384
 requires_config_disabled MBEDTLS_X509_REMOVE_INFO
@@ -2468,7 +2468,7 @@ run_test    "TLS 1.3 opaque key: 2 keys on server, suitable algorithm found" \
             -S "error" \
 
 # Test using a RSA opaque private key for server authentication
-requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
+requires_config_enabled MBEDTLS_PSA_CRYPTO_C
 requires_config_enabled MBEDTLS_X509_CRT_PARSE_C
 requires_config_enabled MBEDTLS_RSA_C
 requires_config_enabled MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED
@@ -2485,7 +2485,7 @@ run_test    "Opaque key for server authentication: ECDHE-RSA" \
             -S "error" \
             -C "error"
 
-requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
+requires_config_enabled MBEDTLS_PSA_CRYPTO_C
 requires_config_enabled MBEDTLS_X509_CRT_PARSE_C
 requires_config_enabled MBEDTLS_RSA_C
 requires_hash_alg SHA_256
@@ -2501,7 +2501,7 @@ run_test    "Opaque key for server authentication: DHE-RSA" \
             -S "error" \
             -C "error"
 
-requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
+requires_config_enabled MBEDTLS_PSA_CRYPTO_C
 requires_config_enabled MBEDTLS_X509_CRT_PARSE_C
 requires_config_enabled MBEDTLS_RSA_C
 requires_hash_alg SHA_256
@@ -2518,7 +2518,7 @@ run_test    "Opaque key for server authentication: RSA-PSK" \
             -S "error" \
             -C "error"
 
-requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
+requires_config_enabled MBEDTLS_PSA_CRYPTO_C
 requires_config_enabled MBEDTLS_X509_CRT_PARSE_C
 requires_config_enabled MBEDTLS_RSA_C
 requires_hash_alg SHA_256
@@ -2533,7 +2533,7 @@ run_test    "Opaque key for server authentication: RSA-" \
             -S "error" \
             -C "error"
 
-requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
+requires_config_enabled MBEDTLS_PSA_CRYPTO_C
 requires_config_enabled MBEDTLS_X509_CRT_PARSE_C
 requires_config_enabled MBEDTLS_RSA_C
 requires_hash_alg SHA_256
@@ -2548,7 +2548,7 @@ run_test    "Opaque key for server authentication: DHE-RSA, PSS instead of PKCS1
             -s "error" \
             -c "error"
 
-requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
+requires_config_enabled MBEDTLS_PSA_CRYPTO_C
 requires_config_enabled MBEDTLS_X509_CRT_PARSE_C
 requires_config_enabled MBEDTLS_RSA_C
 requires_hash_alg SHA_256
@@ -2569,7 +2569,7 @@ run_test    "Opaque keys for server authentication: RSA keys with different algs
             -S "error" \
             -C "error"
 
-requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
+requires_config_enabled MBEDTLS_PSA_CRYPTO_C
 requires_config_enabled MBEDTLS_X509_CRT_PARSE_C
 requires_config_enabled MBEDTLS_RSA_C
 requires_hash_alg SHA_384
@@ -2590,7 +2590,7 @@ run_test    "Opaque keys for server authentication: EC + RSA, force DHE-RSA" \
             -C "error"
 
 # Test using an EC opaque private key for client/server authentication
-requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
+requires_config_enabled MBEDTLS_PSA_CRYPTO_C
 requires_config_enabled MBEDTLS_X509_CRT_PARSE_C
 requires_config_enabled MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
 requires_hash_alg SHA_256
@@ -2610,7 +2610,7 @@ run_test    "Opaque key for client/server authentication: ECDHE-ECDSA" \
             -C "error"
 
 # Test using a RSA opaque private key for client/server authentication
-requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
+requires_config_enabled MBEDTLS_PSA_CRYPTO_C
 requires_config_enabled MBEDTLS_X509_CRT_PARSE_C
 requires_config_enabled MBEDTLS_RSA_C
 requires_hash_alg SHA_256
@@ -2630,7 +2630,7 @@ run_test    "Opaque key for client/server authentication: ECDHE-RSA" \
             -S "error" \
             -C "error"
 
-requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
+requires_config_enabled MBEDTLS_PSA_CRYPTO_C
 requires_config_enabled MBEDTLS_X509_CRT_PARSE_C
 requires_config_enabled MBEDTLS_RSA_C
 requires_hash_alg SHA_256


### PR DESCRIPTION
## Description

Continuation of https://github.com/Mbed-TLS/mbedtls/pull/8842 for CI and discussion. It will probably need to be cherry-picked into the main PR.

Status: `ssl-opt.sh` has known failures.

* [x] "Opaque key for server authentication: DHE-RSA, PSS instead of PKCS1"
* [x] "Opaque key for server authentication: ECDH-"
* [x] "Opaque key for server authentication: invalid alg: ECDHE-ECDSA with ecdh"
* [x] "Opaque key for server authentication: invalid key: decrypt with ECC key, no async"
* [x] "Opaque key for server authentication: invalid key: ecdh with RSA key, no async"
* [x] "Opaque keys for server authentication: EC keys with different algs, force ECDH-ECDSA"
* [x] "Opaque keys for server authentication: EC keys with different algs, force ECDHE-ECDSA"
* [x] "Opaque keys for server authentication: RSA keys with different algs"

## PR checklist

- [x] **changelog** in main PR
- [x] **backport** N/A
- [x] **tests** yes
