### PR TITLE
Fix IAR warning

### DIFF
--- a/library/bignum.c
+++ b/library/bignum.c
@@ -1692,10 +1692,12 @@ int mbedtls_mpi_exp_mod(mbedtls_mpi *X, const mbedtls_mpi *A,
     /*
      * Convert to and from Montgomery around mbedtls_mpi_core_exp_mod().
      */
-    mbedtls_mpi_uint mm = mbedtls_mpi_core_montmul_init(N->p);
-    mbedtls_mpi_core_to_mont_rep(X->p, X->p, N->p, N->n, mm, RR.p, T);
-    mbedtls_mpi_core_exp_mod(X->p, X->p, N->p, N->n, E->p, E->n, RR.p, T);
-    mbedtls_mpi_core_from_mont_rep(X->p, X->p, N->p, N->n, mm, T);
+    {
+        mbedtls_mpi_uint mm = mbedtls_mpi_core_montmul_init(N->p);
+        mbedtls_mpi_core_to_mont_rep(X->p, X->p, N->p, N->n, mm, RR.p, T);
+        mbedtls_mpi_core_exp_mod(X->p, X->p, N->p, N->n, E->p, E->n, RR.p, T);
+        mbedtls_mpi_core_from_mont_rep(X->p, X->p, N->p, N->n, mm, T);
+    }
 
     /*
      * Correct for negative A.


### PR DESCRIPTION
## Description

Follow-up to #8831 which unfortunately triggers an IAR warning (for something that is a non-issue):

```
                MBEDTLS_MPI_CHK(mbedtls_mpi_core_get_mont_r2_unsafe(&RR, N));
                  ^
        "/home/davrod01/code/mbedtls/library/bignum.c",1656  Error[Pe546]: transfer of
                  control bypasses initialization of:
                    variable "mm" (declared at line 1695)
```

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required
- [x] **backport** not required
- [x] **tests** not required
