### PR TITLE
mbedtls_pk_decrypt/encrypt actually check the padding mode

### DIFF
--- a/ChangeLog.d/8824.txt
+++ b/ChangeLog.d/8824.txt
@@ -1,7 +1,8 @@
 Bugfix
    * Fix mbedtls_pk_sign(), mbedtls_pk_verify(), mbedtls_pk_decrypt() and
      mbedtls_pk_encrypt() on non-opaque RSA keys to honor the padding mode in
-     the RSA context. Before, if MBEDTLS_USE_PSA_CRYPTO was enabled, they always
-     used PKCS#1 v1.5 even when the RSA context was configured for PKCS#1 v2.1
-     (PSS/OAEP). Fixes #8824.
+     the RSA context. Before, if MBEDTLS_USE_PSA_CRYPTO was enabled and the
+     RSA context was configured for PKCS#1 v2.1 (PSS/OAEP), the sign/verify
+     functions performed a PKCS#1 v1.5 signature instead and the
+     encrypt/decrypt functions returned an error. Fixes #8824.
 


### PR DESCRIPTION
I've just realized that I made a mistake in https://github.com/Mbed-TLS/mbedtls/issues/8824. I mostly looked at the sign/verify functions, which happily use the wrong algorithm. The encrypt/decrypt functions actually error out if the padding mode specifies V21.

The [check in `rsa_decrypt_wrap`](https://github.com/Mbed-TLS/mbedtls/blob/mbedtls-3.2.0/library/pk_wrap.c#L382) (and the same in `rsa_encrypt_wrap`) was added in 8e80504b46764c2a590a6290cccc5716ff51ea79 which was part of the [pull request](https://github.com/Mbed-TLS/mbedtls/pull/5519) that added the feature, and it was removed in https://github.com/Mbed-TLS/mbedtls/pull/8826 which fixed the bug. So `development` did not have `mbedtls_pk_encrypt` or `mbedtls_pk_decrypt` performing the wrong algorithm at any point, just failing.

## PR checklist

- [x] **changelog** provided
- [x] **backport** N/A
- [x] **tests** not required
