### PR TITLE
Fix gcc -O3 warnings

### DIFF
--- a/library/cmac.c
+++ b/library/cmac.c
@@ -224,6 +224,10 @@ int mbedtls_cipher_cmac_update(mbedtls_cipher_context_t *ctx,
     block_size = mbedtls_cipher_info_get_block_size(ctx->cipher_info);
     state = ctx->cmac_ctx->state;
 
+    /* Without the MBEDTLS_ASSUME below, gcc -O3 will generate a warning of the form
+     * error: writing 16 bytes into a region of size 0 [-Werror=stringop-overflow=] */
+    MBEDTLS_ASSUME(block_size <= MBEDTLS_CMAC_MAX_BLOCK_SIZE);
+
     /* Is there data still to process from the last call, that's greater in
      * size than a block? */
     if (cmac_ctx->unprocessed_len > 0 &&
@@ -291,6 +295,7 @@ int mbedtls_cipher_cmac_finish(mbedtls_cipher_context_t *ctx,
 
     cmac_ctx = ctx->cmac_ctx;
     block_size = mbedtls_cipher_info_get_block_size(ctx->cipher_info);
+    MBEDTLS_ASSUME(block_size <= MBEDTLS_CMAC_MAX_BLOCK_SIZE); // silence GCC warning
     state = cmac_ctx->state;
 
     mbedtls_platform_zeroize(K1, sizeof(K1));

--- a/library/gcm.c
+++ b/library/gcm.c
@@ -412,7 +412,16 @@ int mbedtls_gcm_starts(mbedtls_gcm_context *ctx,
         while (iv_len > 0) {
             use_len = (iv_len < 16) ? iv_len : 16;
 
+#if defined(MBEDTLS_COMPILER_IS_GCC)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wstringop-overflow=0"
+#endif
+
             mbedtls_xor(ctx->y, ctx->y, p, use_len);
+
+#if defined(MBEDTLS_COMPILER_IS_GCC)
+#pragma GCC diagnostic pop
+#endif
 
             gcm_mult(ctx, ctx->y, ctx->y);
 

--- a/library/gcm.c
+++ b/library/gcm.c
@@ -412,14 +412,14 @@ int mbedtls_gcm_starts(mbedtls_gcm_context *ctx,
         while (iv_len > 0) {
             use_len = (iv_len < 16) ? iv_len : 16;
 
-#if defined(MBEDTLS_COMPILER_IS_GCC)
+#if defined(MBEDTLS_COMPILER_IS_GCC) && (MBEDTLS_GCC_VERSION >= 70110)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic warning "-Wstringop-overflow=0"
 #endif
 
             mbedtls_xor(ctx->y, ctx->y, p, use_len);
 
-#if defined(MBEDTLS_COMPILER_IS_GCC)
+#if defined(MBEDTLS_COMPILER_IS_GCC) && (MBEDTLS_GCC_VERSION >= 70110)
 #pragma GCC diagnostic pop
 #endif
 


### PR DESCRIPTION
## Description

Surprisingly, `gcc -O3` generates a few (spurious) warnings that other optimisation levels do not (the warnings are also platform dependent).

These were observed on x86 (gcm) and aarch64, thumb2 and x86 (cmac).

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required
- [x] **backport** not required
- [x] **tests** not required
