### PR TITLE
Work around a bug in ancient lcov

### DIFF
--- a/scripts/lcov.sh
+++ b/scripts/lcov.sh
@@ -39,13 +39,19 @@ in_mbedtls_build_dir () {
 lcov_library_report () {
     rm -rf Coverage
     mkdir Coverage Coverage/tmp
-    lcov --capture --initial --directory $library_dir -o Coverage/tmp/files.info
-    lcov --rc lcov_branch_coverage=1 --capture --directory $library_dir -o Coverage/tmp/tests.info
-    lcov --rc lcov_branch_coverage=1 --add-tracefile Coverage/tmp/files.info --add-tracefile Coverage/tmp/tests.info -o Coverage/tmp/all.info
-    lcov --rc lcov_branch_coverage=1 --remove Coverage/tmp/all.info -o Coverage/tmp/final.info '*.h'
-    gendesc tests/Descriptions.txt -o Coverage/tmp/descriptions
-    genhtml --title "$title" --description-file Coverage/tmp/descriptions --keep-descriptions --legend --branch-coverage -o Coverage Coverage/tmp/final.info
-    rm -f Coverage/tmp/*.info Coverage/tmp/descriptions
+    # Pass absolute paths as lcov output files. This works around a bug
+    # whereby lcov tries to create the output file in the root directory
+    # if it has emitted a warning. A fix was released in lcov 1.13 in 2016.
+    # Ubuntu 16.04 is affected, 18.04 and above are not.
+    # https://github.com/linux-test-project/lcov/commit/632c25a0d1f5e4d2f4fd5b28ce7c8b86d388c91f
+    COVTMP=$PWD/Coverage/tmp
+    lcov --capture --initial --directory $library_dir -o "$COVTMP/files.info"
+    lcov --rc lcov_branch_coverage=1 --capture --directory $library_dir -o "$COVTMP/tests.info"
+    lcov --rc lcov_branch_coverage=1 --add-tracefile "$COVTMP/files.info" --add-tracefile "$COVTMP/tests.info" -o "$COVTMP/all.info"
+    lcov --rc lcov_branch_coverage=1 --remove "$COVTMP/all.info" -o "$COVTMP/final.info" '*.h'
+    gendesc tests/Descriptions.txt -o "$COVTMP/descriptions"
+    genhtml --title "$title" --description-file "$COVTMP/descriptions" --keep-descriptions --legend --branch-coverage -o Coverage "$COVTMP/final.info"
+    rm -f "$COVTMP/"*.info "$COVTMP/descriptions"
     echo "Coverage report in: Coverage/index.html"
 }
 


### PR DESCRIPTION
1. We added multithreaded tests. They cause
    ```
    lcov: WARNING: negative counts found in tracefile Coverage/tmp/tests.info
    ```
   This is [known to be caused by a bug in gcov](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=67937), possibly due to a race condition. We may be getting slightly bad data about a few test cases, but we can live with that.
2. Lcov had a [bug](https://github.com/linux-test-project/lcov/commit/632c25a0d1f5e4d2f4fd5b28ce7c8b86d388c91f) in a warning handler that caused it to change to the root directory before writing the output file.
    ```
    lcov: ERROR: cannot write to Coverage/tmp/all.info!
    ```
    So when the warning triggers, we don't get output at all. We can't live with that.

As we are nearing a release, I am proposing a minimalistic workaround that just prevents the warning from triggering the error. The proper fix is to [move away from ancient tooling](https://github.com/Mbed-TLS/mbedtls-test/issues/59) but I do not propose to do that the week before a release.

## PR checklist

- [x] **changelog** no
- [x] **backport** not needed (no multithreaded tests causing the lcov warning in 2.28)
- [x] **tests** Run the code-coverage job until there's a WARNING but no ERROR (the failure is non-deterministic so this may require a few tries). The normal pull request testing does not run the code-coverage job. https://mbedtls.trustedfirmware.org/job/mbedtls-release-ci-testing/152
