### PR TITLE
Backport 2.28: Fix bug in ALPN loading from serialised session

### DIFF
--- a/ChangeLog.d/fix-alpn-negotiating-bug.txt
+++ b/ChangeLog.d/fix-alpn-negotiating-bug.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix the restoration of the ALPN when loading serialized connection with
+   * the mbedtls_ssl_context_load() API.

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -6680,7 +6680,7 @@ static int ssl_context_load(mbedtls_ssl_context *ssl,
             /* alpn_chosen should point to an item in the configured list */
             for (cur = ssl->conf->alpn_list; *cur != NULL; cur++) {
                 if (strlen(*cur) == alpn_len &&
-                    memcmp(p, cur, alpn_len) == 0) {
+                    memcmp(p, *cur, alpn_len) == 0) {
                     ssl->alpn_chosen = *cur;
                     break;
                 }


### PR DESCRIPTION
## Description

Trivial backport of #8911 
## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [X] **changelog** provided
- [X] **backport** done
- [X] **tests** not required
