### PR TITLE
Update BRANCHES for 3.6

### DIFF
--- a/BRANCHES.md
+++ b/BRANCHES.md
@@ -6,12 +6,13 @@ At any point in time, we have a number of maintained branches, currently consist
   this always contains the latest release, including all publicly available
   security fixes.
 - The [`development`](https://github.com/Mbed-TLS/mbedtls/tree/development) branch:
-  this is where the current major version of Mbed TLS (version 3.x) is being
-  prepared. It has API changes that make it incompatible with Mbed TLS 2.x,
+  this is where the next major version of Mbed TLS (version 4.0) is being
+  prepared. It has API changes that make it incompatible with Mbed TLS 3.x,
   as well as all the new features and bug fixes and security fixes.
 - One or more long-time support (LTS) branches: these only get bug fixes and
-  security fixes. Currently, the only supported LTS branch is:
-  [`mbedtls-2.28`](https://github.com/Mbed-TLS/mbedtls/tree/mbedtls-2.28).
+  security fixes. Currently, the supported LTS branches are:
+- [`mbedtls-2.28`](https://github.com/Mbed-TLS/mbedtls/tree/mbedtls-2.28).
+- [`mbedtls-3.6`](https://github.com/Mbed-TLS/mbedtls/tree/mbedtls-3.6).
 
 We retain a number of historical branches, whose names are prefixed by `archive/`,
 such as [`archive/mbedtls-2.7`](https://github.com/Mbed-TLS/mbedtls/tree/archive/mbedtls-2.7).
@@ -23,10 +24,10 @@ the API of 3.(x+1) is backward compatible with 3.x). We only break API
 compatibility on major version changes (e.g. from 3.x to 4.0). We also maintain
 ABI compatibility within LTS branches; see the next section for details.
 
-Every major version will become an LTS branch when the next major version is
-released. We may occasionally create LTS branches from other releases at our
-discretion.
-When a new LTS branch is created, it usually remains supported for three years.
+We will make regular LTS releases on an 18-month cycle, each of which will have
+a 3 year support lifetime. On this basis, 3.6 LTS (released March 2024) will be
+supported until March 2027. The next LTS release will be a 4.x release, which is
+planned for September 2025.
 
 ## Backwards Compatibility for application code
 
@@ -104,8 +105,11 @@ The following branches are currently maintained:
 
 - [master](https://github.com/Mbed-TLS/mbedtls/tree/master)
 - [`development`](https://github.com/Mbed-TLS/mbedtls/)
+- [`mbedtls-3.6`](https://github.com/Mbed-TLS/mbedtls/tree/mbedtls-3.6)
+ maintained until March 2027, see
+  <https://github.com/Mbed-TLS/mbedtls/releases/tag/v3.6.0>.
 - [`mbedtls-2.28`](https://github.com/Mbed-TLS/mbedtls/tree/mbedtls-2.28)
- maintained until at least the end of 2024, see
-  <https://github.com/Mbed-TLS/mbedtls/releases/tag/v2.28.7>.
+ maintained until the end of 2024, see
+  <https://github.com/Mbed-TLS/mbedtls/releases/tag/v2.28.8>.
 
 Users are urged to always use the latest version of a maintained branch.

--- a/BRANCHES.md
+++ b/BRANCHES.md
@@ -2,7 +2,7 @@
 
 At any point in time, we have a number of maintained branches, currently consisting of:
 
-- The [`master`](https://github.com/Mbed-TLS/mbedtls/tree/master) branch:
+- The [`main`](https://github.com/Mbed-TLS/mbedtls/tree/main) branch:
   this always contains the latest release, including all publicly available
   security fixes.
 - The [`development`](https://github.com/Mbed-TLS/mbedtls/tree/development) branch:
@@ -19,7 +19,7 @@ such as [`archive/mbedtls-2.7`](https://github.com/Mbed-TLS/mbedtls/tree/archive
 These branches will not receive any changes or updates.
 
 We use [Semantic Versioning](https://semver.org/). In particular, we maintain
-API compatibility in the `master` branch across minor version changes (e.g.
+API compatibility in the `main` branch across minor version changes (e.g.
 the API of 3.(x+1) is backward compatible with 3.x). We only break API
 compatibility on major version changes (e.g. from 3.x to 4.0). We also maintain
 ABI compatibility within LTS branches; see the next section for details.
@@ -103,7 +103,7 @@ CONTRIBUTING](CONTRIBUTING.md#backwards-compatibility).
 
 The following branches are currently maintained:
 
-- [master](https://github.com/Mbed-TLS/mbedtls/tree/master)
+- [main](https://github.com/Mbed-TLS/mbedtls/tree/main)
 - [`development`](https://github.com/Mbed-TLS/mbedtls/)
 - [`mbedtls-3.6`](https://github.com/Mbed-TLS/mbedtls/tree/mbedtls-3.6)
  maintained until March 2027, see

--- a/BUGS.md
+++ b/BUGS.md
@@ -7,7 +7,7 @@ Known issues in Mbed TLS are [tracked on GitHub](https://github.com/Mbed-TLS/mbe
 If you think you've found a bug in Mbed TLS, please follow these steps:
 
 1. Make sure you're using the latest version of a
-   [maintained branch](BRANCHES.md): `master`, `development`,
+   [maintained branch](BRANCHES.md): `main`, `development`,
    or a long-time support branch.
 2. Check [GitHub](https://github.com/Mbed-TLS/mbedtls/issues) to see if
    your issue has already been reported. If not, …

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ For machines with a Unix shell and OpenSSL (and optionally GnuTLS) installed, ad
 -   `tests/scripts/depends.py` test builds in configurations with a single curve, key exchange, hash, cipher, or pkalg on.
 -   `tests/scripts/all.sh` runs a combination of the above tests, plus some more, with various build options (such as ASan, full `mbedtls_config.h`, etc).
 
-Instead of manually installing the required versions of all tools required for testing, it is possible to use the Docker images from our CI systems, as explained in [our testing infrastructure repository](https://github.com/Mbed-TLS/mbedtls-test/blob/master/README.md#quick-start).
+Instead of manually installing the required versions of all tools required for testing, it is possible to use the Docker images from our CI systems, as explained in [our testing infrastructure repository](https://github.com/Mbed-TLS/mbedtls-test/blob/main/README.md#quick-start).
 
 Porting Mbed TLS
 ----------------


### PR DESCRIPTION
## Description

Update BRANCHES.md, and replace references to `master` with `main` - I propose that from 3.6.0, we maintain both `master` and `main`, but only document `main`. At some point in the future (4.0?) we could drop `master`.

I propose to change `master` to be a tag which points at `main`, to ensure consistency. `main` IMO should also be a tag, which in turn points at the latest release (currently it's a branch).

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required
- [x] **backport** #8959 
- [x] **tests**  not required
