### PR TITLE
[Bugfix] Fix null dereference in `mbedtls_pk_verify_ext()`

### DIFF
--- a/ChangeLog.d/fix-null-dereference-verify-ext.txt
+++ b/ChangeLog.d/fix-null-dereference-verify-ext.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix NULL pointer dereference in mbedtls_pk_verify_ext() when called using
+     an opaque RSA context and specifying MBEDTLS_PK_RSASSA_PSS as key type.

--- a/library/pk.c
+++ b/library/pk.c
@@ -1126,6 +1126,12 @@ int mbedtls_pk_verify_ext(mbedtls_pk_type_t type, const void *options,
         return mbedtls_pk_verify(ctx, md_alg, hash, hash_len, sig, sig_len);
     }
 
+    /* Ensure the PK context is of the right type otherwise mbedtls_pk_rsa()
+     * below would return a NULL pointer. */
+    if (mbedtls_pk_get_type(ctx) != MBEDTLS_PK_RSA) {
+        return MBEDTLS_ERR_PK_FEATURE_UNAVAILABLE;
+    }
+
 #if defined(MBEDTLS_RSA_C) && defined(MBEDTLS_PKCS1_V21)
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     const mbedtls_pk_rsassa_pss_options *pss_opts;

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -2060,6 +2060,18 @@ void pk_psa_wrap_sign_ext(int pk_type, int key_bits, int key_pk_type, int md_alg
                                    sig, sizeof(sig), &sig_len,
                                    mbedtls_test_rnd_std_rand, NULL), 0);
 
+    /* Trying to perform a verify_ext() using the opaque context is not supported
+     * so here we verify that this does not crash. */
+    if (key_pk_type == MBEDTLS_PK_RSASSA_PSS) {
+        mbedtls_pk_rsassa_pss_options pss_opts = {
+            .mgf1_hash_id = md_alg,
+            .expected_salt_len = MBEDTLS_RSA_SALT_LEN_ANY,
+        };
+        TEST_EQUAL(mbedtls_pk_verify_ext(key_pk_type, &pss_opts, &pk, md_alg,
+                                         hash, hash_len, sig, sig_len),
+                   MBEDTLS_ERR_PK_FEATURE_UNAVAILABLE);
+    }
+
     mbedtls_pk_free(&pk);
     TEST_EQUAL(PSA_SUCCESS, psa_destroy_key(key_id));
 

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -2060,8 +2060,7 @@ void pk_psa_wrap_sign_ext(int pk_type, int key_bits, int key_pk_type, int md_alg
                                    sig, sizeof(sig), &sig_len,
                                    mbedtls_test_rnd_std_rand, NULL), 0);
 
-    /* Trying to perform a verify_ext() using the opaque context is not supported
-     * so here we verify that this does not crash. */
+    /* verify_ext() is not supported when using an opaque context. */
     if (key_pk_type == MBEDTLS_PK_RSASSA_PSS) {
         mbedtls_pk_rsassa_pss_options pss_opts = {
             .mgf1_hash_id = md_alg,
@@ -2070,6 +2069,10 @@ void pk_psa_wrap_sign_ext(int pk_type, int key_bits, int key_pk_type, int md_alg
         TEST_EQUAL(mbedtls_pk_verify_ext(key_pk_type, &pss_opts, &pk, md_alg,
                                          hash, hash_len, sig, sig_len),
                    MBEDTLS_ERR_PK_FEATURE_UNAVAILABLE);
+    } else {
+        TEST_EQUAL(mbedtls_pk_verify_ext(key_pk_type, NULL, &pk, md_alg,
+                                         hash, hash_len, sig, sig_len),
+                   MBEDTLS_ERR_PK_TYPE_MISMATCH);
     }
 
     mbedtls_pk_free(&pk);


### PR DESCRIPTION
## Description

This fixes a NULL dereference crash in `mbedtls_pk_verify_ext()` that was possible when this function was called with an opaque RSA key. The issue was found while working at #8937.

## PR checklist

- [x] **changelog** provided
- [x] **backport** not required - no opaque RSA keys in 2.28
- [x] **tests** provided