### PR TITLE
Backport 2.28: Show unmet dependencies by name in test_suite_xxx -v

### DIFF
--- a/tests/scripts/generate_test_code.py
+++ b/tests/scripts/generate_test_code.py
@@ -805,7 +805,7 @@ def gen_dependencies_element(dep):
     :param dep: Dependency macro
     :return: Dependency array element initializer
     """
-    _not, core_dep = ('!', dep[1:]) if dep[0] == '!' else ('', dep)
+    not_, core_dep = ('!', dep[1:]) if dep[0] == '!' else ('', dep)
     if not core_dep:
         raise GeneratorInputError("Dependency should not be an empty string.")
 
@@ -813,13 +813,13 @@ def gen_dependencies_element(dep):
     if not dependency:
         raise GeneratorInputError('Invalid dependency %s' % dep)
 
-    _defined = '' if dependency.group(2) else 'defined'
-    _cond = dependency.group(2) if dependency.group(2) else ''
-    _value = dependency.group(3) if dependency.group(3) else ''
+    defined = '' if dependency.group(2) else 'defined'
+    cond = dependency.group(2) if dependency.group(2) else ''
+    value = dependency.group(3) if dependency.group(3) else ''
 
-    pp_expr = '{_not}{_defined}({macro}{_cond}{_value})'.format(
-        _not=_not, _defined=_defined, macro=dependency.group(1),
-        _cond=_cond, _value=_value)
+    pp_expr = '{not_}{defined}({macro}{cond}{value})'.format(
+        not_=not_, defined=defined, macro=dependency.group(1),
+        cond=cond, value=value)
     dep_check = '''\
 #if {pp_expr}
         NULL,

--- a/tests/scripts/generate_test_code.py
+++ b/tests/scripts/generate_test_code.py
@@ -827,7 +827,7 @@ def gen_dep_check(dep_id, dep):
 #if {_not}{_defined}({macro}{_cond}{_value})
                 ret = DEPENDENCY_SUPPORTED;
 #else
-                ret = DEPENDENCY_NOT_SUPPORTED;
+                ret = UNSUPPORTED_TEST_CASE_DEPENDENCY;
 #endif
             }}
             break;'''.format(_not=_not, _defined=_defined,

--- a/tests/scripts/generate_test_code.py
+++ b/tests/scripts/generate_test_code.py
@@ -947,7 +947,7 @@ def get_function_info(func_info, function_name, line_no):
     return func_info[test_function_name]
 
 
-def gen_from_test_data(data_f, out_data_f, func_info, suite_dependencies):
+def gen_from_test_data(data_f, out_data_f, func_info):
     """
     This function reads test case name, dependencies and test vectors
     from the .data file. This information is correlated with the test
@@ -1091,7 +1091,7 @@ def parse_function_file(funcs_file, snippets):
 
 
 def generate_intermediate_data_file(data_file, out_data_file,
-                                    suite_dependencies, func_info, snippets):
+                                    func_info, snippets):
     """
     Generates intermediate data file from input data file and
     information read from functions file.
@@ -1107,7 +1107,7 @@ def generate_intermediate_data_file(data_file, out_data_file,
     with FileWrapper(data_file) as data_f, \
             open(out_data_file, 'w') as out_data_f:
         dependencies_code, expression_code = gen_from_test_data(
-            data_f, out_data_f, func_info, suite_dependencies)
+            data_f, out_data_f, func_info)
         snippets['dependencies_code'] = dependencies_code
         snippets['expression_code'] = expression_code
 
@@ -1152,7 +1152,7 @@ def generate_code(**input_info):
                    c_file, snippets)
     suite_dependencies, func_info = parse_function_file(funcs_file, snippets)
     generate_intermediate_data_file(data_file, out_data_file,
-                                    suite_dependencies, func_info, snippets)
+                                    func_info, snippets)
     write_test_source_file(template_file, c_file, snippets)
 
 

--- a/tests/scripts/generate_test_code.py
+++ b/tests/scripts/generate_test_code.py
@@ -817,11 +817,11 @@ def gen_dependencies_element(dep):
     _cond = dependency.group(2) if dependency.group(2) else ''
     _value = dependency.group(3) if dependency.group(3) else ''
 
-    pp_expr = '{_not}{_defined}({macro}{_cond}{_value}'.format(
+    pp_expr = '{_not}{_defined}({macro}{_cond}{_value})'.format(
         _not=_not, _defined=_defined, macro=dependency.group(1),
         _cond=_cond, _value=_value)
     dep_check = '''\
-#if {pp_expr})
+#if {pp_expr}
         NULL,
 #else
         "{dep}",

--- a/tests/scripts/generate_test_code.py
+++ b/tests/scripts/generate_test_code.py
@@ -607,7 +607,7 @@ def parse_function_code(funcs_f, dependencies):
     function and dispatch code.
 
     :param funcs_f: file object of the functions file.
-    :param suite_dependencies: List of test suite dependencies
+    :param dependencies: List of dependencies of the function.
     :return: Function name, arguments, function code and dispatch code.
     """
     line_directive = '#line %d "%s"\n' % (funcs_f.line_no + 1, funcs_f.name)

--- a/tests/scripts/generate_test_code.py
+++ b/tests/scripts/generate_test_code.py
@@ -135,12 +135,10 @@ __MBEDTLS_TEST_TEMPLATE__EXPRESSION_CODE
 __MBEDTLS_TEST_TEMPLATE__SUITE_DEPENDENCIES
             A preprocessor expression for the build dependencies
             that apply to the whole test suite.
-__MBEDTLS_TEST_TEMPLATE__DEP_CHECK_CODE
-            This script enumerates all
-            build dependencies and generate
-            code to handle enumerated build
-            dependency Id and return status: if
-            the dependency is defined or not.
+__MBEDTLS_TEST_TEMPLATE__DEPENDENCIES_CODE
+            Initializer for an array where each element is
+            a string literal explaining why a dependency is unmet,
+            or NULL if the dependency is met.
 __MBEDTLS_TEST_TEMPLATE__DISPATCH_CODE
             This script enumerates the functions
             specified in the input test data file
@@ -800,23 +798,18 @@ def parse_test_data(data_f):
                                   "%s" % (data_f.name, data_f.line_no, name))
 
 
-def gen_dep_check(dep_id, dep):
+def gen_dependencies_element(dep):
     """
-    Generate code for checking dependency with the associated
-    identifier.
+    Generate an entry in the dependency array.
 
-    :param dep_id: Dependency identifier
     :param dep: Dependency macro
-    :return: Dependency check code
+    :return: Dependency array element initializer
     """
-    if dep_id < 0:
-        raise GeneratorInputError("Dependency Id should be a positive "
-                                  "integer.")
-    _not, dep = ('!', dep[1:]) if dep[0] == '!' else ('', dep)
-    if not dep:
+    _not, core_dep = ('!', dep[1:]) if dep[0] == '!' else ('', dep)
+    if not core_dep:
         raise GeneratorInputError("Dependency should not be an empty string.")
 
-    dependency = re.match(CONDITION_REGEX, dep, re.I)
+    dependency = re.match(CONDITION_REGEX, core_dep, re.I)
     if not dependency:
         raise GeneratorInputError('Invalid dependency %s' % dep)
 
@@ -824,20 +817,26 @@ def gen_dep_check(dep_id, dep):
     _cond = dependency.group(2) if dependency.group(2) else ''
     _value = dependency.group(3) if dependency.group(3) else ''
 
-    dep_check = '''
-        case {id}:
-            {{
-#if {_not}{_defined}({macro}{_cond}{_value})
-                ret = DEPENDENCY_SUPPORTED;
+    pp_expr = '{_not}{_defined}({macro}{_cond}{_value}'.format(
+        _not=_not, _defined=_defined, macro=dependency.group(1),
+        _cond=_cond, _value=_value)
+    dep_check = '''\
+#if {pp_expr})
+        NULL,
 #else
-                ret = UNSUPPORTED_TEST_CASE_DEPENDENCY;
+        "{dep}",
 #endif
-            }}
-            break;'''.format(_not=_not, _defined=_defined,
-                             macro=dependency.group(1), id=dep_id,
-                             _cond=_cond, _value=_value)
+'''.format(pp_expr=pp_expr, dep=dep)
     return dep_check
 
+def gen_dependencies_array(dependencies):
+    """
+    Generate the dependency array.
+
+    :param dep: Dependency macros
+    :return: Dependency array initializer (without surrounding braces)
+    """
+    return ''.join(gen_dependencies_element(dep) for dep in dependencies)
 
 def gen_expression_check(exp_id, exp):
     """
@@ -872,21 +871,17 @@ def write_dependencies(out_data_f, test_dependencies, unique_dependencies):
     :param test_dependencies: Dependencies
     :param unique_dependencies: Mutable list to track unique dependencies
            that are global to this re-entrant function.
-    :return: returns dependency check code.
     """
-    dep_check_code = ''
     if test_dependencies:
         out_data_f.write('depends_on')
         for dep in test_dependencies:
             if dep not in unique_dependencies:
                 unique_dependencies.append(dep)
                 dep_id = unique_dependencies.index(dep)
-                dep_check_code += gen_dep_check(dep_id, dep)
             else:
                 dep_id = unique_dependencies.index(dep)
             out_data_f.write(':' + str(dep_id))
         out_data_f.write('\n')
-    return dep_check_code
 
 
 INT_VAL_REGEX = re.compile(r'-?(\d+|0x[0-9a-f]+)$', re.I)
@@ -934,32 +929,6 @@ def write_parameters(out_data_f, test_args, func_args, unique_expressions):
     return expression_code
 
 
-def gen_suite_dep_checks(suite_dependencies, dep_check_code, expression_code):
-    """
-    Generates preprocessor checks for test suite dependencies.
-
-    :param suite_dependencies: Test suite dependencies read from the
-            .function file.
-    :param dep_check_code: Dependency check code
-    :param expression_code: Expression check code
-    :return: Dependency and expression code guarded by test suite
-             dependencies.
-    """
-    if suite_dependencies:
-        preprocessor_check = gen_dependencies_expression(suite_dependencies)
-        dep_check_code = '''
-#if {preprocessor_check}
-{code}
-#endif
-'''.format(preprocessor_check=preprocessor_check, code=dep_check_code)
-        expression_code = '''
-#if {preprocessor_check}
-{code}
-#endif
-'''.format(preprocessor_check=preprocessor_check, code=expression_code)
-    return dep_check_code, expression_code
-
-
 def get_function_info(func_info, function_name, line_no):
     """Look up information about a test function by name.
 
@@ -998,15 +967,13 @@ def gen_from_test_data(data_f, out_data_f, func_info, suite_dependencies):
     """
     unique_dependencies = []
     unique_expressions = []
-    dep_check_code = ''
     expression_code = ''
     for line_no, test_name, function_name, test_dependencies, test_args in \
             parse_test_data(data_f):
         out_data_f.write(test_name + '\n')
 
         # Write dependencies
-        dep_check_code += write_dependencies(out_data_f, test_dependencies,
-                                             unique_dependencies)
+        write_dependencies(out_data_f, test_dependencies, unique_dependencies)
 
         # Write test function name
         func_id, func_args = \
@@ -1024,9 +991,9 @@ def gen_from_test_data(data_f, out_data_f, func_info, suite_dependencies):
         # Write a newline as test case separator
         out_data_f.write('\n')
 
-    dep_check_code, expression_code = gen_suite_dep_checks(
-        suite_dependencies, dep_check_code, expression_code)
-    return dep_check_code, expression_code
+    dependencies_code = gen_dependencies_array(unique_dependencies)
+
+    return dependencies_code, expression_code
 
 
 def add_input_info(funcs_file, data_file, template_file,
@@ -1139,9 +1106,9 @@ def generate_intermediate_data_file(data_file, out_data_file,
     """
     with FileWrapper(data_file) as data_f, \
             open(out_data_file, 'w') as out_data_f:
-        dep_check_code, expression_code = gen_from_test_data(
+        dependencies_code, expression_code = gen_from_test_data(
             data_f, out_data_f, func_info, suite_dependencies)
-        snippets['dep_check_code'] = dep_check_code
+        snippets['dependencies_code'] = dependencies_code
         snippets['expression_code'] = expression_code
 
 

--- a/tests/scripts/test_generate_test_code.py
+++ b/tests/scripts/test_generate_test_code.py
@@ -1705,11 +1705,10 @@ func1:0
         data_f = StringIOWrapper('test_suite_ut.data', data)
         out_data_f = StringIOWrapper('test_suite_ut.datax', '')
         func_info = {'test_func1': (1, ('int',))}
-        suite_dependencies = []
         write_parameters_mock.side_effect = write_parameters
         write_dependencies_mock.side_effect = write_dependencies
         gen_dependencies_array_mock.side_effect = gen_dependencies_array
-        gen_from_test_data(data_f, out_data_f, func_info, suite_dependencies)
+        gen_from_test_data(data_f, out_data_f, func_info)
         write_dependencies_mock.assert_called_with(out_data_f,
                                                    ['DEP1'], ['DEP1'])
         write_parameters_mock.assert_called_with(out_data_f, ['0'],
@@ -1729,9 +1728,8 @@ func1:0
         data_f = StringIOWrapper('test_suite_ut.data', data)
         out_data_f = StringIOWrapper('test_suite_ut.datax', '')
         func_info = {'test_func2': (1, ('int',))}
-        suite_dependencies = []
         self.assertRaises(GeneratorInputError, gen_from_test_data,
-                          data_f, out_data_f, func_info, suite_dependencies)
+                          data_f, out_data_f, func_info)
 
     def test_different_func_args(self):
         """
@@ -1747,9 +1745,8 @@ func1:0
         data_f = StringIOWrapper('test_suite_ut.data', data)
         out_data_f = StringIOWrapper('test_suite_ut.datax', '')
         func_info = {'test_func2': (1, ('int', 'hex'))}
-        suite_dependencies = []
         self.assertRaises(GeneratorInputError, gen_from_test_data, data_f,
-                          out_data_f, func_info, suite_dependencies)
+                          out_data_f, func_info)
 
     def test_output(self):
         """
@@ -1769,10 +1766,8 @@ func2:"yahoo":88:MACRO1
         out_data_f = StringIOWrapper('test_suite_ut.datax', '')
         func_info = {'test_func1': (0, ('int', 'int', 'int', 'int')),
                      'test_func2': (1, ('char*', 'int', 'int'))}
-        suite_dependencies = []
         dep_check_code, expression_code = \
-            gen_from_test_data(data_f, out_data_f, func_info,
-                               suite_dependencies)
+            gen_from_test_data(data_f, out_data_f, func_info)
         expected_dependencies_code = '''\
 #if defined(DEP1)
         NULL,

--- a/tests/scripts/test_generate_test_code.py
+++ b/tests/scripts/test_generate_test_code.py
@@ -27,9 +27,9 @@ from generate_test_code import write_parameters
 from generate_test_code import gen_from_test_data
 
 
-class GenDep(TestCase):
+class GenDependencies(TestCase):
     """
-    Test suite for function gen_dep()
+    Test suite for function gen_dependencies()
     """
 
     def test_dependencies_list(self):
@@ -117,7 +117,7 @@ class GenDep(TestCase):
                          'Preprocessor generated incorrectly')
 
 
-class GenDepOneLine(TestCase):
+class GenDependenciesExpression(TestCase):
     """
     Test Suite for testing gen_dependencies_expression()
     """
@@ -459,7 +459,7 @@ class ParseFuncDependencies(TestCase):
         self.assertEqual(dependencies, ['MBEDTLS_FS_IO', 'A', '!B', 'C', 'F'])
 
 
-class ParseFuncSignature(TestCase):
+class ParseFunctionArguments(TestCase):
     """
     Test Suite for parse_function_arguments().
     """
@@ -938,7 +938,7 @@ exit:
         self.assertEqual(code, expected)
 
 
-class ParseFunction(TestCase):
+class ParseFunctions(TestCase):
     """
     Test Suite for testing parse_functions()
     """
@@ -1261,7 +1261,7 @@ class EscapedSplit(TestCase):
 
 class ParseTestData(TestCase):
     """
-    Test suite for parse test data.
+    Test suite for parse_test_data.
     """
 
     def test_parser(self):
@@ -1387,7 +1387,7 @@ depends_on:YAHOO
             self.assertEqual(type(err), GeneratorInputError)
 
 
-class GenDepCheck(TestCase):
+class GenDependenciesElement(TestCase):
     """
     Test suite for gen_dependencies_element(). It is assumed this function is
     called with valid inputs.
@@ -1431,7 +1431,7 @@ class GenDepCheck(TestCase):
         self.assertRaises(GeneratorInputError, gen_dependencies_element, '!')
 
 
-class GenExpCheck(TestCase):
+class GenExpressionCheck(TestCase):
     """
     Test suite for gen_expression_check(). It is assumed this function
     is called with valid inputs.
@@ -1550,7 +1550,7 @@ class WriteDependencies(TestCase):
                          'depends_on:0:1\ndepends_on:1:2\ndepends_on:2:0\n')
 
 
-class WriteParams(TestCase):
+class WriteParameters(TestCase):
     """
     Test Suite for testing write_parameters().
     """

--- a/tests/scripts/test_generate_test_code.py
+++ b/tests/scripts/test_generate_test_code.py
@@ -1404,7 +1404,7 @@ class GenDepCheck(TestCase):
 #if defined(YAHOO)
                 ret = DEPENDENCY_SUPPORTED;
 #else
-                ret = DEPENDENCY_NOT_SUPPORTED;
+                ret = UNSUPPORTED_TEST_CASE_DEPENDENCY;
 #endif
             }
             break;"""
@@ -1422,7 +1422,7 @@ class GenDepCheck(TestCase):
 #if !defined(YAHOO)
                 ret = DEPENDENCY_SUPPORTED;
 #else
-                ret = DEPENDENCY_NOT_SUPPORTED;
+                ret = UNSUPPORTED_TEST_CASE_DEPENDENCY;
 #endif
             }
             break;"""
@@ -1512,7 +1512,7 @@ class WriteDependencies(TestCase):
 #if defined(DEP3)
                 ret = DEPENDENCY_SUPPORTED;
 #else
-                ret = DEPENDENCY_NOT_SUPPORTED;
+                ret = UNSUPPORTED_TEST_CASE_DEPENDENCY;
 #endif
             }
             break;
@@ -1521,7 +1521,7 @@ class WriteDependencies(TestCase):
 #if defined(DEP2)
                 ret = DEPENDENCY_SUPPORTED;
 #else
-                ret = DEPENDENCY_NOT_SUPPORTED;
+                ret = UNSUPPORTED_TEST_CASE_DEPENDENCY;
 #endif
             }
             break;
@@ -1530,7 +1530,7 @@ class WriteDependencies(TestCase):
 #if defined(DEP1)
                 ret = DEPENDENCY_SUPPORTED;
 #else
-                ret = DEPENDENCY_NOT_SUPPORTED;
+                ret = UNSUPPORTED_TEST_CASE_DEPENDENCY;
 #endif
             }
             break;'''
@@ -1558,7 +1558,7 @@ class WriteDependencies(TestCase):
 #if defined(DEP3)
                 ret = DEPENDENCY_SUPPORTED;
 #else
-                ret = DEPENDENCY_NOT_SUPPORTED;
+                ret = UNSUPPORTED_TEST_CASE_DEPENDENCY;
 #endif
             }
             break;
@@ -1567,7 +1567,7 @@ class WriteDependencies(TestCase):
 #if defined(DEP2)
                 ret = DEPENDENCY_SUPPORTED;
 #else
-                ret = DEPENDENCY_NOT_SUPPORTED;
+                ret = UNSUPPORTED_TEST_CASE_DEPENDENCY;
 #endif
             }
             break;
@@ -1576,7 +1576,7 @@ class WriteDependencies(TestCase):
 #if defined(DEP1)
                 ret = DEPENDENCY_SUPPORTED;
 #else
-                ret = DEPENDENCY_NOT_SUPPORTED;
+                ret = UNSUPPORTED_TEST_CASE_DEPENDENCY;
 #endif
             }
             break;'''
@@ -1803,7 +1803,7 @@ func1:0
 #if defined(DEP1)
                 ret = DEPENDENCY_SUPPORTED;
 #else
-                ret = DEPENDENCY_NOT_SUPPORTED;
+                ret = UNSUPPORTED_TEST_CASE_DEPENDENCY;
 #endif
             }
             break;'''
@@ -1873,7 +1873,7 @@ func2:"yahoo":88:MACRO1
 #if defined(DEP1)
                 ret = DEPENDENCY_SUPPORTED;
 #else
-                ret = DEPENDENCY_NOT_SUPPORTED;
+                ret = UNSUPPORTED_TEST_CASE_DEPENDENCY;
 #endif
             }
             break;
@@ -1882,7 +1882,7 @@ func2:"yahoo":88:MACRO1
 #if defined(DEP2)
                 ret = DEPENDENCY_SUPPORTED;
 #else
-                ret = DEPENDENCY_NOT_SUPPORTED;
+                ret = UNSUPPORTED_TEST_CASE_DEPENDENCY;
 #endif
             }
             break;'''

--- a/tests/suites/helpers.function
+++ b/tests/suites/helpers.function
@@ -38,13 +38,15 @@
 
 #define KEY_VALUE_MAPPING_NOT_FOUND       -1  /* Integer expression not found */
 #define UNSUPPORTED_TEST_CASE_DEPENDENCY  -2  /* Dependency not supported */
-#define DISPATCH_TEST_FN_NOT_FOUND        -3  /* Test function not found */
-#define DISPATCH_INVALID_TEST_DATA        -4  /* Invalid test parameter type.
+#define UNSUPPORTED_TEST_FUNCTION_DEPENDENCY -3  /* Test function not supported
+                                                    by the build */
+#define UNSUPPORTED_TEST_SUITE_DEPENDENCY -4  /* Test suite not supported by the
+                                                 build */
+#define DISPATCH_TEST_FN_NOT_FOUND        -5  /* Test function not found */
+#define DISPATCH_INVALID_TEST_DATA        -6  /* Invalid test parameter type.
                                                  Only int, string, binary data
                                                  and integer expressions are
                                                  allowed */
-#define UNSUPPORTED_TEST_SUITE_DEPENDENCY -5  /* Test suite not supported by the
-                                                 build */
 
 /*----------------------------------------------------------------------------*/
 /* Global variables */

--- a/tests/suites/helpers.function
+++ b/tests/suites/helpers.function
@@ -36,15 +36,15 @@
 #define KEY_VALUE_MAPPING_FOUND         0   /* Integer expression found */
 #define DISPATCH_TEST_SUCCESS           0   /* Test dispatch successful */
 
-#define KEY_VALUE_MAPPING_NOT_FOUND     -1  /* Integer expression not found */
-#define DEPENDENCY_NOT_SUPPORTED        -2  /* Dependency not supported */
-#define DISPATCH_TEST_FN_NOT_FOUND      -3  /* Test function not found */
-#define DISPATCH_INVALID_TEST_DATA      -4  /* Invalid test parameter type.
-                                               Only int, string, binary data
-                                               and integer expressions are
-                                               allowed */
-#define DISPATCH_UNSUPPORTED_SUITE      -5  /* Test suite not supported by the
-                                               build */
+#define KEY_VALUE_MAPPING_NOT_FOUND       -1  /* Integer expression not found */
+#define UNSUPPORTED_TEST_CASE_DEPENDENCY  -2  /* Dependency not supported */
+#define DISPATCH_TEST_FN_NOT_FOUND        -3  /* Test function not found */
+#define DISPATCH_INVALID_TEST_DATA        -4  /* Invalid test parameter type.
+                                                 Only int, string, binary data
+                                                 and integer expressions are
+                                                 allowed */
+#define UNSUPPORTED_TEST_SUITE_DEPENDENCY -5  /* Test suite not supported by the
+                                                 build */
 
 /*----------------------------------------------------------------------------*/
 /* Global variables */

--- a/tests/suites/host_test.function
+++ b/tests/suites/host_test.function
@@ -421,7 +421,7 @@ static void write_outcome_result(FILE *outcome_file,
         case DISPATCH_INVALID_TEST_DATA:
             mbedtls_fprintf(outcome_file, "FAIL;Invalid test data");
             break;
-        case DISPATCH_UNSUPPORTED_SUITE:
+        case UNSUPPORTED_TEST_SUITE_DEPENDENCY:
             mbedtls_fprintf(outcome_file, "SKIP;Unsupported suite");
             break;
         default:
@@ -691,11 +691,11 @@ int execute_tests(int argc, const char **argv)
                                  unmet_dep_count, unmet_dependencies,
                                  missing_unmet_dependencies,
                                  ret, &mbedtls_test_info);
-            if (unmet_dep_count > 0 || ret == DISPATCH_UNSUPPORTED_SUITE) {
+            if (unmet_dep_count > 0 || ret == UNSUPPORTED_TEST_SUITE_DEPENDENCY) {
                 total_skipped++;
                 mbedtls_fprintf(stdout, "----");
 
-                if (1 == option_verbose && ret == DISPATCH_UNSUPPORTED_SUITE) {
+                if (1 == option_verbose && ret == UNSUPPORTED_TEST_SUITE_DEPENDENCY) {
                     mbedtls_fprintf(stdout, "\n   Test Suite not enabled");
                 }
 

--- a/tests/suites/host_test.function
+++ b/tests/suites/host_test.function
@@ -375,7 +375,7 @@ static void write_outcome_entry(FILE *outcome_file,
  */
 static void write_outcome_result(FILE *outcome_file,
                                  size_t unmet_dep_count,
-                                 int unmet_dependencies[],
+                                 const unsigned unmet_dependencies[],
                                  int missing_unmet_dependencies,
                                  int ret,
                                  const mbedtls_test_info_t *info)
@@ -392,7 +392,7 @@ static void write_outcome_result(FILE *outcome_file,
                 size_t i;
                 mbedtls_fprintf(outcome_file, "SKIP");
                 for (i = 0; i < unmet_dep_count; i++) {
-                    mbedtls_fprintf(outcome_file, "%c%d",
+                    mbedtls_fprintf(outcome_file, "%c%u",
                                     i == 0 ? ';' : ':',
                                     unmet_dependencies[i]);
                 }
@@ -589,7 +589,7 @@ int execute_tests(int argc, const char **argv)
          testfile_index < testfile_count;
          testfile_index++) {
         size_t unmet_dep_count = 0;
-        int unmet_dependencies[20];
+        unsigned unmet_dependencies[20];
         int missing_unmet_dependencies = 0;
 
         test_filename = test_files[testfile_index];
@@ -637,7 +637,7 @@ int execute_tests(int argc, const char **argv)
 
             if (strcmp(params[0], "depends_on") == 0) {
                 for (i = 1; i < cnt; i++) {
-                    int dep_id = strtol(params[i], NULL, 10);
+                    unsigned dep_id = strtoul(params[i], NULL, 10);
                     if (dep_check(dep_id) != DEPENDENCY_SUPPORTED) {
                         if (unmet_dep_count <
                             ARRAY_LENGTH(unmet_dependencies)) {
@@ -688,6 +688,8 @@ int execute_tests(int argc, const char **argv)
                 }
 #endif /* __unix__ || __APPLE__ __MACH__ */
 
+            } else {
+                ret = UNSUPPORTED_TEST_CASE_DEPENDENCY;
             }
 
             write_outcome_result(outcome_file,
@@ -708,11 +710,19 @@ int execute_tests(int argc, const char **argv)
                     }
                 }
 
-                if (1 == option_verbose && unmet_dep_count > 0) {
+                if (1 == option_verbose && ret == UNSUPPORTED_TEST_CASE_DEPENDENCY) {
                     mbedtls_fprintf(stdout, "\n   Unmet dependencies: ");
                     for (i = 0; i < unmet_dep_count; i++) {
-                        mbedtls_fprintf(stdout, "%d ",
-                                        unmet_dependencies[i]);
+                        unsigned dep_id = unmet_dependencies[i];
+                        const char *name = NULL;
+                        if (dep_id < ARRAY_LENGTH(unsupported_dependencies)) {
+                            name = unsupported_dependencies[dep_id];
+                        }
+                        if (name == NULL) {
+                            mbedtls_fprintf(stdout, "%u ", dep_id);
+                        } else {
+                            mbedtls_fprintf(stdout, "%s ", name);
+                        }
                     }
                     if (missing_unmet_dependencies) {
                         mbedtls_fprintf(stdout, "...");

--- a/tests/suites/host_test.function
+++ b/tests/suites/host_test.function
@@ -415,14 +415,17 @@ static void write_outcome_result(FILE *outcome_file,
                     break;
             }
             break;
+        case UNSUPPORTED_TEST_FUNCTION_DEPENDENCY:
+            mbedtls_fprintf(outcome_file, "SKIP;Unsupported function");
+            break;
+        case UNSUPPORTED_TEST_SUITE_DEPENDENCY:
+            mbedtls_fprintf(outcome_file, "SKIP;Unsupported suite");
+            break;
         case DISPATCH_TEST_FN_NOT_FOUND:
             mbedtls_fprintf(outcome_file, "FAIL;Test function not found");
             break;
         case DISPATCH_INVALID_TEST_DATA:
             mbedtls_fprintf(outcome_file, "FAIL;Invalid test data");
-            break;
-        case UNSUPPORTED_TEST_SUITE_DEPENDENCY:
-            mbedtls_fprintf(outcome_file, "SKIP;Unsupported suite");
             break;
         default:
             mbedtls_fprintf(outcome_file, "FAIL;Unknown cause");
@@ -691,12 +694,18 @@ int execute_tests(int argc, const char **argv)
                                  unmet_dep_count, unmet_dependencies,
                                  missing_unmet_dependencies,
                                  ret, &mbedtls_test_info);
-            if (unmet_dep_count > 0 || ret == UNSUPPORTED_TEST_SUITE_DEPENDENCY) {
+            if (unmet_dep_count > 0 ||
+                ret == UNSUPPORTED_TEST_FUNCTION_DEPENDENCY ||
+                ret == UNSUPPORTED_TEST_SUITE_DEPENDENCY) {
                 total_skipped++;
                 mbedtls_fprintf(stdout, "----");
 
-                if (1 == option_verbose && ret == UNSUPPORTED_TEST_SUITE_DEPENDENCY) {
-                    mbedtls_fprintf(stdout, "\n   Test Suite not enabled");
+                if (1 == option_verbose) {
+                    if (ret == UNSUPPORTED_TEST_SUITE_DEPENDENCY) {
+                        mbedtls_fprintf(stdout, "\n   Test suite not enabled");
+                    } else if (ret == UNSUPPORTED_TEST_FUNCTION_DEPENDENCY) {
+                        mbedtls_fprintf(stdout, "\n   Test function not enabled");
+                    }
                 }
 
                 if (1 == option_verbose && unmet_dep_count > 0) {

--- a/tests/suites/main_test.function
+++ b/tests/suites/main_test.function
@@ -143,7 +143,7 @@ int dep_check(int dep_id)
  */
 typedef void (*TestWrapper_t)(void **param_array);
 
-
+#if __MBEDTLS_TEST_TEMPLATE__SUITE_DEPENDENCIES
 /**
  * \brief       Table of test function wrappers. Used by dispatch_test().
  *              This table is populated by script:
@@ -155,6 +155,7 @@ TestWrapper_t test_funcs[] =
     __MBEDTLS_TEST_TEMPLATE__DISPATCH_CODE
 #line __MBEDTLS_TEST_TEMPLATE__LINE_NO "suites/main_test.function"
 };
+#endif /* __MBEDTLS_TEST_TEMPLATE__SUITE_DEPENDENCIES */
 
 /**
  * \brief        Execute the test function.
@@ -206,10 +207,14 @@ void execute_function_ptr(TestWrapper_t fp, void **params)
  *
  * \return       DISPATCH_TEST_SUCCESS if found
  *               DISPATCH_TEST_FN_NOT_FOUND if not found
- *               UNSUPPORTED_TEST_SUITE_DEPENDENCY if not compile time enabled.
+ *               UNSUPPORTED_TEST_FUNCTION_DEPENDENCY if the function
+ *               is not enabled at compile time.
+ *               UNSUPPORTED_TEST_SUITE_DEPENDENCY if the test suite
+ *               is not enabled at compile time.
  */
 int dispatch_test(size_t func_idx, void **params)
 {
+#if __MBEDTLS_TEST_TEMPLATE__SUITE_DEPENDENCIES
     int ret = DISPATCH_TEST_SUCCESS;
     TestWrapper_t fp = NULL;
 
@@ -218,13 +223,19 @@ int dispatch_test(size_t func_idx, void **params)
         if (fp) {
             execute_function_ptr(fp, params);
         } else {
-            ret = UNSUPPORTED_TEST_SUITE_DEPENDENCY;
+            ret = UNSUPPORTED_TEST_FUNCTION_DEPENDENCY;
         }
     } else {
         ret = DISPATCH_TEST_FN_NOT_FOUND;
     }
 
     return ret;
+
+#else /* __MBEDTLS_TEST_TEMPLATE__SUITE_DEPENDENCIES */
+    (void) func_idx;
+    (void) params;
+    return UNSUPPORTED_TEST_SUITE_DEPENDENCY;
+#endif /* __MBEDTLS_TEST_TEMPLATE__SUITE_DEPENDENCIES */
 }
 
 
@@ -236,23 +247,32 @@ int dispatch_test(size_t func_idx, void **params)
  *
  * \return       DISPATCH_TEST_SUCCESS if found
  *               DISPATCH_TEST_FN_NOT_FOUND if not found
- *               UNSUPPORTED_TEST_SUITE_DEPENDENCY if not compile time enabled.
+ *               UNSUPPORTED_TEST_FUNCTION_DEPENDENCY if the function
+ *               is not enabled at compile time.
+ *               UNSUPPORTED_TEST_SUITE_DEPENDENCY if the test suite
+ *               is not enabled at compile time.
  */
 int check_test(size_t func_idx)
 {
+#if __MBEDTLS_TEST_TEMPLATE__SUITE_DEPENDENCIES
     int ret = DISPATCH_TEST_SUCCESS;
     TestWrapper_t fp = NULL;
 
     if (func_idx < (int) (sizeof(test_funcs)/sizeof(TestWrapper_t))) {
         fp = test_funcs[func_idx];
         if (fp == NULL) {
-            ret = UNSUPPORTED_TEST_SUITE_DEPENDENCY;
+            ret = UNSUPPORTED_TEST_FUNCTION_DEPENDENCY;
         }
     } else {
         ret = DISPATCH_TEST_FN_NOT_FOUND;
     }
 
     return ret;
+
+#else /* __MBEDTLS_TEST_TEMPLATE__SUITE_DEPENDENCIES */
+    (void) func_idx;
+    return UNSUPPORTED_TEST_SUITE_DEPENDENCY;
+#endif /* __MBEDTLS_TEST_TEMPLATE__SUITE_DEPENDENCIES */
 }
 
 

--- a/tests/suites/main_test.function
+++ b/tests/suites/main_test.function
@@ -89,8 +89,10 @@ int get_expression(int32_t exp_id, intmax_t *out_value)
     (void) out_value;
 
     switch (exp_id) {
+#if __MBEDTLS_TEST_TEMPLATE__SUITE_DEPENDENCIES
     __MBEDTLS_TEST_TEMPLATE__EXPRESSION_CODE
 #line __MBEDTLS_TEST_TEMPLATE__LINE_NO "suites/main_test.function"
+#endif /* __MBEDTLS_TEST_TEMPLATE__SUITE_DEPENDENCIES */
         default:
         {
             ret = KEY_VALUE_MAPPING_NOT_FOUND;
@@ -100,6 +102,14 @@ int get_expression(int32_t exp_id, intmax_t *out_value)
     return ret;
 }
 
+
+static const char *unsupported_dependencies[] = {
+#if __MBEDTLS_TEST_TEMPLATE__SUITE_DEPENDENCIES
+    __MBEDTLS_TEST_TEMPLATE__DEPENDENCIES_CODE
+#endif /* __MBEDTLS_TEST_TEMPLATE__SUITE_DEPENDENCIES */
+    NULL                        /* Make sure the array is never empty */
+};
+#line __MBEDTLS_TEST_TEMPLATE__LINE_NO "suites/main_test.function"
 
 /**
  * \brief       Checks if the dependency i.e. the compile flag is set.
@@ -112,19 +122,16 @@ int get_expression(int32_t exp_id, intmax_t *out_value)
  *
  * \return       DEPENDENCY_SUPPORTED if set else UNSUPPORTED_TEST_CASE_DEPENDENCY
  */
-int dep_check(int dep_id)
+int dep_check(unsigned dep_id)
 {
-    int ret = UNSUPPORTED_TEST_CASE_DEPENDENCY;
-
-    (void) dep_id;
-
-    switch (dep_id) {
-    __MBEDTLS_TEST_TEMPLATE__DEP_CHECK_CODE
-#line __MBEDTLS_TEST_TEMPLATE__LINE_NO "suites/main_test.function"
-        default:
-            break;
+    if (dep_id >= ARRAY_LENGTH(unsupported_dependencies)) {
+        return DISPATCH_INVALID_TEST_DATA;
     }
-    return ret;
+    if (unsupported_dependencies[dep_id] == NULL) {
+        return DEPENDENCY_SUPPORTED;
+    } else {
+        return UNSUPPORTED_TEST_CASE_DEPENDENCY;
+    }
 }
 
 

--- a/tests/suites/main_test.function
+++ b/tests/suites/main_test.function
@@ -110,11 +110,11 @@ int get_expression(int32_t exp_id, intmax_t *out_value)
  *
  * \param dep_id    Dependency identifier.
  *
- * \return       DEPENDENCY_SUPPORTED if set else DEPENDENCY_NOT_SUPPORTED
+ * \return       DEPENDENCY_SUPPORTED if set else UNSUPPORTED_TEST_CASE_DEPENDENCY
  */
 int dep_check(int dep_id)
 {
-    int ret = DEPENDENCY_NOT_SUPPORTED;
+    int ret = UNSUPPORTED_TEST_CASE_DEPENDENCY;
 
     (void) dep_id;
 
@@ -206,7 +206,7 @@ void execute_function_ptr(TestWrapper_t fp, void **params)
  *
  * \return       DISPATCH_TEST_SUCCESS if found
  *               DISPATCH_TEST_FN_NOT_FOUND if not found
- *               DISPATCH_UNSUPPORTED_SUITE if not compile time enabled.
+ *               UNSUPPORTED_TEST_SUITE_DEPENDENCY if not compile time enabled.
  */
 int dispatch_test(size_t func_idx, void **params)
 {
@@ -218,7 +218,7 @@ int dispatch_test(size_t func_idx, void **params)
         if (fp) {
             execute_function_ptr(fp, params);
         } else {
-            ret = DISPATCH_UNSUPPORTED_SUITE;
+            ret = UNSUPPORTED_TEST_SUITE_DEPENDENCY;
         }
     } else {
         ret = DISPATCH_TEST_FN_NOT_FOUND;
@@ -236,7 +236,7 @@ int dispatch_test(size_t func_idx, void **params)
  *
  * \return       DISPATCH_TEST_SUCCESS if found
  *               DISPATCH_TEST_FN_NOT_FOUND if not found
- *               DISPATCH_UNSUPPORTED_SUITE if not compile time enabled.
+ *               UNSUPPORTED_TEST_SUITE_DEPENDENCY if not compile time enabled.
  */
 int check_test(size_t func_idx)
 {
@@ -246,7 +246,7 @@ int check_test(size_t func_idx)
     if (func_idx < (int) (sizeof(test_funcs)/sizeof(TestWrapper_t))) {
         fp = test_funcs[func_idx];
         if (fp == NULL) {
-            ret = DISPATCH_UNSUPPORTED_SUITE;
+            ret = UNSUPPORTED_TEST_SUITE_DEPENDENCY;
         }
     } else {
         ret = DISPATCH_TEST_FN_NOT_FOUND;


### PR DESCRIPTION
When running a test suite verbosely, if a test case is skipped due to a compile-time dependency on the test case, show e.g. `Unmet dependencies: PSA_WANT_ALG_XTS PSA_WANT_ECC_FAMILY_TWISTED_EDWARDS` rather than `Unmet dependencies: 42 19`.

Ideally we'd also do that for function and suite dependencies. But that's less useful and would take additional work, so I don't intend to do it today.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** no (test stuff only)
- [ ] **backport** of TODO
- [x] **tests** yes
