### PR TITLE
Mark ssl_tls12_preset_default_sig_algs const

### DIFF
--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -5385,7 +5385,7 @@ static const uint16_t ssl_preset_default_sig_algs[] = {
 
 /* NOTICE: see above */
 #if defined(MBEDTLS_SSL_PROTO_TLS1_2)
-static uint16_t ssl_tls12_preset_default_sig_algs[] = {
+static const uint16_t ssl_tls12_preset_default_sig_algs[] = {
 
 #if defined(PSA_WANT_ALG_SHA_512)
 #if defined(MBEDTLS_KEY_EXCHANGE_ECDSA_CERT_REQ_ALLOWED_ENABLED)

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -5449,7 +5449,7 @@ static const uint16_t ssl_preset_suiteb_sig_algs[] = {
 
 /* NOTICE: see above */
 #if defined(MBEDTLS_SSL_PROTO_TLS1_2)
-static uint16_t ssl_tls12_preset_suiteb_sig_algs[] = {
+static const uint16_t ssl_tls12_preset_suiteb_sig_algs[] = {
 
 #if defined(PSA_WANT_ALG_SHA_256)
 #if defined(MBEDTLS_KEY_EXCHANGE_ECDSA_CERT_REQ_ALLOWED_ENABLED)


### PR DESCRIPTION
To place in flash and save RAM on targets where this applies.

## Description

Save a few bytes of RAM.

## PR checklist

- [x] **changelog** not required because: no user-visible change (except a small memory optimisation)
- [x] **development PR** provided HERE
- [x] **TF-PSA-Crypto PR** not required because: TLS only
- [x] **framework PR** not required
- [x] **3.6 PR** not required because: enhancement, does not need backporting (but can be optionally)
- **tests** not required because: nothing new to cover
