### PR TITLE
x509_crt: Add LWIP implementation of inet_pton

### DIFF
--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -2704,7 +2704,38 @@ find_parent:
 #if __has_include(<arpa/inet.h>)
 #include <arpa/inet.h>
 #endif
+#if __has_include("lwip/ip_addr.h")
+#define MBEDTLS_LWIP_INET_PTON
 #endif
+#endif
+
+#if defined(MBEDTLS_LWIP_INET_PTON)
+
+#include "lwip/ip_addr.h"
+
+static int x509_inet_pton_ipv6(const char *src, void *dst)
+{
+    int ret = -1;
+#if LWIP_IPV6
+    ip6_addr_t addr;
+    if (ip6addr_aton(src, &addr)) {
+        memcpy(dst, &addr.addr, sizeof(addr.addr));
+        ret = 0;
+    }
+#endif
+    return ret;
+}
+
+static int x509_inet_pton_ipv4(const char *src, void *dst)
+{
+    int ret = -1;
+#if LWIP_IPV4
+    if (ip4addr_aton(src, (ip4_addr_t *) dst)) {
+        ret = 0;
+    }
+#endif
+    return ret;
+}
 
 /* Use whether or not AF_INET6 is defined to indicate whether or not to use
  * the platform inet_pton() or a local implementation (below).  The local
@@ -2718,7 +2749,7 @@ find_parent:
  * provided by headers included (or not) via __has_include() above.
  * MBEDTLS_TEST_SW_INET_PTON is a bypass define to force testing of this code //no-check-names
  * despite having a platform that has inet_pton. */
-#if !defined(AF_INET6) || defined(MBEDTLS_TEST_SW_INET_PTON) //no-check-names
+#elif !defined(AF_INET6) || defined(MBEDTLS_TEST_SW_INET_PTON) //no-check-names
 /* Definition located further below to possibly reduce compiler inlining */
 static int x509_inet_pton_ipv4(const char *src, void *dst);
 


### PR DESCRIPTION
## Description

LWIP is a popular TCP/IP stack implementation used on many platforms.
While BIO implementation is usually provided externally, validating IP SANs does not have an interface.
This seems fairly simple and non-intrusive - is this acceptable in principle?

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [ ] **changelog** provided, or not required -- TODO, assuming agreement in principle
- [ ] **backport** done, or not required -- TODO, assuming agreement in principle
- [ ] **tests** provided, or not required -- TODO, assuming agreement in principle