### PR TITLE
Remove unnecessary assignments

### DIFF
--- a/library/bignum_core.c
+++ b/library/bignum_core.c
@@ -133,7 +133,7 @@ mbedtls_ct_condition_t mbedtls_mpi_core_lt_ct(const mbedtls_mpi_uint *A,
                                               const mbedtls_mpi_uint *B,
                                               size_t limbs)
 {
-    mbedtls_ct_condition_t ret = MBEDTLS_CT_FALSE, cond = MBEDTLS_CT_FALSE, done = MBEDTLS_CT_FALSE;
+    mbedtls_ct_condition_t ret = MBEDTLS_CT_FALSE, cond, done = MBEDTLS_CT_FALSE;
 
     for (size_t i = limbs; i > 0; i--) {
         /*
@@ -641,7 +641,7 @@ int mbedtls_mpi_core_random(mbedtls_mpi_uint *X,
                             int (*f_rng)(void *, unsigned char *, size_t),
                             void *p_rng)
 {
-    mbedtls_ct_condition_t ge_lower = MBEDTLS_CT_TRUE, lt_upper = MBEDTLS_CT_FALSE;
+    mbedtls_ct_condition_t ge_lower, lt_upper;
     size_t n_bits = mbedtls_mpi_core_bitlen(N, limbs);
     size_t n_bytes = (n_bits + 7) / 8;
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;

--- a/library/entropy.c
+++ b/library/entropy.c
@@ -405,7 +405,7 @@ int mbedtls_entropy_write_seed_file(mbedtls_entropy_context *ctx, const char *pa
     FILE *f = NULL;
     unsigned char buf[MBEDTLS_ENTROPY_BLOCK_SIZE];
 
-    if ((ret = mbedtls_entropy_func(ctx, buf, MBEDTLS_ENTROPY_BLOCK_SIZE)) != 0) {
+    if (mbedtls_entropy_func(ctx, buf, MBEDTLS_ENTROPY_BLOCK_SIZE) != 0) {
         ret = MBEDTLS_ERR_ENTROPY_SOURCE_FAILED;
         goto exit;
     }

--- a/library/hmac_drbg.c
+++ b/library/hmac_drbg.c
@@ -158,8 +158,7 @@ static int hmac_drbg_reseed_core(mbedtls_hmac_drbg_context *ctx,
     memset(seed, 0, MBEDTLS_HMAC_DRBG_MAX_SEED_INPUT);
 
     /* IV. Gather entropy_len bytes of entropy for the seed */
-    if ((ret = ctx->f_entropy(ctx->p_entropy,
-                              seed, ctx->entropy_len)) != 0) {
+    if (ctx->f_entropy(ctx->p_entropy, seed, ctx->entropy_len) != 0) {
         return MBEDTLS_ERR_HMAC_DRBG_ENTROPY_SOURCE_FAILED;
     }
     seedlen += ctx->entropy_len;
@@ -174,9 +173,9 @@ static int hmac_drbg_reseed_core(mbedtls_hmac_drbg_context *ctx,
          *       is larger than the maximum of 32 Bytes that our own
          *       entropy source implementation can emit in a single
          *       call in configurations disabling SHA-512. */
-        if ((ret = ctx->f_entropy(ctx->p_entropy,
-                                  seed + seedlen,
-                                  ctx->entropy_len / 2)) != 0) {
+        if (ctx->f_entropy(ctx->p_entropy,
+                           seed + seedlen,
+                           ctx->entropy_len / 2) != 0) {
             return MBEDTLS_ERR_HMAC_DRBG_ENTROPY_SOURCE_FAILED;
         }
 

--- a/library/pkcs7.c
+++ b/library/pkcs7.c
@@ -204,7 +204,7 @@ static int pkcs7_get_certificates(unsigned char **p, unsigned char *end,
         return MBEDTLS_ERR_PKCS7_FEATURE_UNAVAILABLE;
     }
 
-    if ((ret = mbedtls_x509_crt_parse_der(certs, start, len1)) < 0) {
+    if (mbedtls_x509_crt_parse_der(certs, start, len1) < 0) {
         return MBEDTLS_ERR_PKCS7_INVALID_CERT;
     }
 

--- a/library/pkparse.c
+++ b/library/pkparse.c
@@ -203,7 +203,7 @@ static int pk_group_from_specified(const mbedtls_asn1_buf *params, mbedtls_ecp_g
     p += len;
 
     /* Ignore seed BIT STRING OPTIONAL */
-    if ((ret = mbedtls_asn1_get_tag(&p, end_curve, &len, MBEDTLS_ASN1_BIT_STRING)) == 0) {
+    if (mbedtls_asn1_get_tag(&p, end_curve, &len, MBEDTLS_ASN1_BIT_STRING) == 0) {
         p += len;
     }
 

--- a/library/x509.c
+++ b/library/x509.c
@@ -844,7 +844,7 @@ int mbedtls_x509_dn_gets(char *buf, size_t size, const mbedtls_x509_name *dn)
                           (name->val.tag != MBEDTLS_ASN1_PRINTABLE_STRING) &&
                           (name->val.tag != MBEDTLS_ASN1_IA5_STRING);
 
-        if ((ret = mbedtls_oid_get_attr_short_name(&name->oid, &short_name)) == 0) {
+        if (mbedtls_oid_get_attr_short_name(&name->oid, &short_name) == 0) {
             ret = mbedtls_snprintf(p, n, "%s=", short_name);
         } else {
             if ((ret = mbedtls_oid_get_numeric_string(p, n, &name->oid)) > 0) {

--- a/library/x509_crl.c
+++ b/library/x509_crl.c
@@ -344,8 +344,8 @@ int mbedtls_x509_crl_parse_der(mbedtls_x509_crl *chain,
      *      signatureAlgorithm   AlgorithmIdentifier,
      *      signatureValue       BIT STRING  }
      */
-    if ((ret = mbedtls_asn1_get_tag(&p, end, &len,
-                                    MBEDTLS_ASN1_CONSTRUCTED | MBEDTLS_ASN1_SEQUENCE)) != 0) {
+    if (mbedtls_asn1_get_tag(&p, end, &len,
+                             MBEDTLS_ASN1_CONSTRUCTED | MBEDTLS_ASN1_SEQUENCE) != 0) {
         mbedtls_x509_crl_free(crl);
         return MBEDTLS_ERR_X509_INVALID_FORMAT;
     }
@@ -389,9 +389,9 @@ int mbedtls_x509_crl_parse_der(mbedtls_x509_crl *chain,
 
     crl->version++;
 
-    if ((ret = mbedtls_x509_get_sig_alg(&crl->sig_oid, &sig_params1,
-                                        &crl->sig_md, &crl->sig_pk,
-                                        &crl->sig_opts)) != 0) {
+    if (mbedtls_x509_get_sig_alg(&crl->sig_oid, &sig_params1,
+                                 &crl->sig_md, &crl->sig_pk,
+                                 &crl->sig_opts) != 0) {
         mbedtls_x509_crl_free(crl);
         return MBEDTLS_ERR_X509_UNKNOWN_SIG_ALG;
     }

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -1102,8 +1102,8 @@ static int x509_crt_parse_der_core(mbedtls_x509_crt *crt,
      *      signatureAlgorithm   AlgorithmIdentifier,
      *      signatureValue       BIT STRING  }
      */
-    if ((ret = mbedtls_asn1_get_tag(&p, end, &len,
-                                    MBEDTLS_ASN1_CONSTRUCTED | MBEDTLS_ASN1_SEQUENCE)) != 0) {
+    if (mbedtls_asn1_get_tag(&p, end, &len,
+                             MBEDTLS_ASN1_CONSTRUCTED | MBEDTLS_ASN1_SEQUENCE) != 0) {
         mbedtls_x509_crt_free(crt);
         return MBEDTLS_ERR_X509_INVALID_FORMAT;
     }

--- a/library/x509_csr.c
+++ b/library/x509_csr.c
@@ -305,8 +305,8 @@ static int mbedtls_x509_csr_parse_der_internal(mbedtls_x509_csr *csr,
      *       signature          BIT STRING
      *  }
      */
-    if ((ret = mbedtls_asn1_get_tag(&p, end, &len,
-                                    MBEDTLS_ASN1_CONSTRUCTED | MBEDTLS_ASN1_SEQUENCE)) != 0) {
+    if (mbedtls_asn1_get_tag(&p, end, &len,
+                             MBEDTLS_ASN1_CONSTRUCTED | MBEDTLS_ASN1_SEQUENCE) != 0) {
         mbedtls_x509_csr_free(csr);
         return MBEDTLS_ERR_X509_INVALID_FORMAT;
     }
@@ -407,9 +407,9 @@ static int mbedtls_x509_csr_parse_der_internal(mbedtls_x509_csr *csr,
         return ret;
     }
 
-    if ((ret = mbedtls_x509_get_sig_alg(&csr->sig_oid, &sig_params,
-                                        &csr->sig_md, &csr->sig_pk,
-                                        &csr->sig_opts)) != 0) {
+    if (mbedtls_x509_get_sig_alg(&csr->sig_oid, &sig_params,
+                                 &csr->sig_md, &csr->sig_pk,
+                                 &csr->sig_opts) != 0) {
         mbedtls_x509_csr_free(csr);
         return MBEDTLS_ERR_X509_UNKNOWN_SIG_ALG;
     }


### PR DESCRIPTION
## Description

Imporves readability and calms down `clang-tidy`.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required
- [x] **backport** not required
- [x] **tests** not required