### PR TITLE
[Backport 2.28] Fix fake cases listed of compat.sh

### DIFF
--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -147,16 +147,10 @@ list_test_cases() {
                 add_openssl_ciphersuites
                 add_gnutls_ciphersuites
                 add_mbedtls_ciphersuites
-                # For GnuTLS client -> Mbed TLS server,
-                # we need to force IPv4 by connecting to 127.0.0.1 but then auth fails
-                SUB_G_CIPHERS=$G_CIPHERS
-                if is_dtls "$MODE" && [ "X$VERIFY" = "XYES" ]; then
-                    SUB_G_CIPHERS=""
-                fi
                 print_test_case m O "$O_CIPHERS"
                 print_test_case O m "$O_CIPHERS"
                 print_test_case m G "$G_CIPHERS"
-                print_test_case G m "$SUB_G_CIPHERS"
+                print_test_case G m "$G_CIPHERS"
                 print_test_case m m "$M_CIPHERS"
             done
         done
@@ -288,12 +282,6 @@ filter_ciphersuites()
 
         # Ciphersuite for GnuTLS
         G_CIPHERS=$( filter "$G_CIPHERS" )
-    fi
-
-    # For GnuTLS client -> Mbed TLS server,
-    # we need to force IPv4 by connecting to 127.0.0.1 but then auth fails
-    if is_dtls "$MODE" && [ "X$VERIFY" = "XYES" ]; then
-        G_CIPHERS=""
     fi
 }
 
@@ -1298,13 +1286,7 @@ run_client() {
             ;;
 
         [Gg]nu*)
-            # need to force IPv4 with UDP, but keep localhost for auth
-            if is_dtls "$MODE"; then
-                G_HOST="127.0.0.1"
-            else
-                G_HOST="localhost"
-            fi
-            CLIENT_CMD="$GNUTLS_CLI $G_CLIENT_ARGS --priority $G_PRIO_MODE:$2 $G_HOST"
+            CLIENT_CMD="$GNUTLS_CLI $G_CLIENT_ARGS --priority $G_PRIO_MODE:$2 localhost"
             log "$CLIENT_CMD"
             echo "$CLIENT_CMD" > $CLI_OUT
             printf 'GET HTTP/1.0\r\n\r\n' | $CLIENT_CMD >> $CLI_OUT 2>&1 &

--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -922,7 +922,6 @@ o_check_ciphersuite()
 # g_check_ciphersuite CIPHER_SUITE_NAME
 g_check_ciphersuite()
 {
-    set -x
     if [ -z "$GNUTLS_HAS_TLS1_RSA_NULL_SHA256" ]; then
         case "$MODE" in
             tls1|tls1_1|dtls1)
@@ -932,7 +931,6 @@ g_check_ciphersuite()
                 esac;;
         esac
     fi
-    set +x
 }
 
 


### PR DESCRIPTION
## Description

This is the 2.28 backport of #8586.

The backport of the 1st commit is not trivial as the loops are nested differently in 2.28 (the various `add_xxx_ciphersuites` function access the `MODE` variable).

The backport of the 2nd commit is trivial.

## PR checklist

- [x] **changelog** not required, testing only
- [x] **backport** this is the backport
- [x] **tests** not required - manually checked the output of running the script without options, and with `--list-test-cases` before and after, and checking that all differences are the ones we expect.
