### PR TITLE
Fix #ifdef guard in driver wrapper template

### DIFF
--- a/scripts/data_files/driver_templates/psa_crypto_driver_wrappers_no_static.c.jinja
+++ b/scripts/data_files/driver_templates/psa_crypto_driver_wrappers_no_static.c.jinja
@@ -206,11 +206,11 @@ key_buffer_length
     psa_key_location_t location = PSA_KEY_LIFETIME_GET_LOCATION( psa_get_key_lifetime(attributes) );
     switch( location )
     {
-#if defined(PSA_CRYPTO_DRIVER_TEST)
+#if defined(PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT)
 {% with nest_indent=8 %}
 {% include "OS-template-opaque.jinja" -%}
 {% endwith -%}
-#endif /* PSA_CRYPTO_DRIVER_TEST */
+#endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
         default:
             (void) slot_number;
             (void) key_buffer;


### PR DESCRIPTION
## Description

The jinja template for `psa_crypto_driver_wrappers_no_static.c` has the wrong `#ifdef` guard on the
`psa_driver_wrapper_get_builtin_key` wrapper which prevents having multiple driver entry points pluggable through the
wrapper

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] Changelog, not required
- [x] Tests, not required
- [x] Backport, not required
