### PR TITLE
Fix NULL argument handling in mbedtls_xxx_free() functions

### DIFF
--- a/library/block_cipher.c
+++ b/library/block_cipher.c
@@ -51,6 +51,10 @@ static int mbedtls_cipher_error_from_psa(psa_status_t status)
 
 void mbedtls_block_cipher_free(mbedtls_block_cipher_context_t *ctx)
 {
+    if (ctx == NULL) {
+        return;
+    }
+
 #if defined(MBEDTLS_BLOCK_CIPHER_SOME_PSA)
     if (ctx->engine == MBEDTLS_BLOCK_CIPHER_ENGINE_PSA) {
         psa_destroy_key(ctx->psa_key_id);

--- a/library/entropy.c
+++ b/library/entropy.c
@@ -61,6 +61,10 @@ void mbedtls_entropy_init(mbedtls_entropy_context *ctx)
 
 void mbedtls_entropy_free(mbedtls_entropy_context *ctx)
 {
+    if (ctx == NULL) {
+        return;
+    }
+
     /* If the context was already free, don't call free() again.
      * This is important for mutexes which don't allow double-free. */
     if (ctx->accumulator_started == -1) {

--- a/library/lmots.c
+++ b/library/lmots.c
@@ -387,6 +387,10 @@ void mbedtls_lmots_public_init(mbedtls_lmots_public_t *ctx)
 
 void mbedtls_lmots_public_free(mbedtls_lmots_public_t *ctx)
 {
+    if (ctx == NULL) {
+        return;
+    }
+
     mbedtls_platform_zeroize(ctx, sizeof(*ctx));
 }
 
@@ -556,6 +560,10 @@ void mbedtls_lmots_private_init(mbedtls_lmots_private_t *ctx)
 
 void mbedtls_lmots_private_free(mbedtls_lmots_private_t *ctx)
 {
+    if (ctx == NULL) {
+        return;
+    }
+
     mbedtls_platform_zeroize(ctx,
                              sizeof(*ctx));
 }

--- a/library/lms.c
+++ b/library/lms.c
@@ -229,6 +229,10 @@ void mbedtls_lms_public_init(mbedtls_lms_public_t *ctx)
 
 void mbedtls_lms_public_free(mbedtls_lms_public_t *ctx)
 {
+    if (ctx == NULL) {
+        return;
+    }
+
     mbedtls_platform_zeroize(ctx, sizeof(*ctx));
 }
 
@@ -528,6 +532,10 @@ void mbedtls_lms_private_init(mbedtls_lms_private_t *ctx)
 
 void mbedtls_lms_private_free(mbedtls_lms_private_t *ctx)
 {
+    if (ctx == NULL) {
+        return;
+    }
+
     unsigned int idx;
 
     if (ctx->have_private_key) {

--- a/library/net_sockets.c
+++ b/library/net_sockets.c
@@ -683,7 +683,7 @@ void mbedtls_net_close(mbedtls_net_context *ctx)
  */
 void mbedtls_net_free(mbedtls_net_context *ctx)
 {
-    if (ctx->fd == -1) {
+    if (ctx == NULL || ctx->fd == -1) {
         return;
     }
 

--- a/library/nist_kw.c
+++ b/library/nist_kw.c
@@ -102,6 +102,10 @@ int mbedtls_nist_kw_setkey(mbedtls_nist_kw_context *ctx,
  */
 void mbedtls_nist_kw_free(mbedtls_nist_kw_context *ctx)
 {
+    if (ctx == NULL) {
+        return;
+    }
+
     mbedtls_cipher_free(&ctx->cipher_ctx);
     mbedtls_platform_zeroize(ctx, sizeof(mbedtls_nist_kw_context));
 }

--- a/library/pem.c
+++ b/library/pem.c
@@ -481,6 +481,10 @@ int mbedtls_pem_read_buffer(mbedtls_pem_context *ctx, const char *header, const 
 
 void mbedtls_pem_free(mbedtls_pem_context *ctx)
 {
+    if (ctx == NULL) {
+        return;
+    }
+
     if (ctx->buf != NULL) {
         mbedtls_zeroize_and_free(ctx->buf, ctx->buflen);
     }

--- a/library/ssl_cookie.c
+++ b/library/ssl_cookie.c
@@ -84,6 +84,10 @@ void mbedtls_ssl_cookie_set_timeout(mbedtls_ssl_cookie_ctx *ctx, unsigned long d
 
 void mbedtls_ssl_cookie_free(mbedtls_ssl_cookie_ctx *ctx)
 {
+    if (ctx == NULL) {
+        return;
+    }
+
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     psa_destroy_key(ctx->psa_hmac_key);
 #else

--- a/library/ssl_ticket.c
+++ b/library/ssl_ticket.c
@@ -534,6 +534,10 @@ cleanup:
  */
 void mbedtls_ssl_ticket_free(mbedtls_ssl_ticket_context *ctx)
 {
+    if (ctx == NULL) {
+        return;
+    }
+
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     psa_destroy_key(ctx->keys[0].key);
     psa_destroy_key(ctx->keys[1].key);

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -6029,6 +6029,10 @@ int mbedtls_ssl_config_defaults(mbedtls_ssl_config *conf,
  */
 void mbedtls_ssl_config_free(mbedtls_ssl_config *conf)
 {
+    if (conf == NULL) {
+        return;
+    }
+
 #if defined(MBEDTLS_DHM_C)
     mbedtls_mpi_free(&conf->dhm_P);
     mbedtls_mpi_free(&conf->dhm_G);

--- a/library/x509write_crt.c
+++ b/library/x509write_crt.c
@@ -46,6 +46,10 @@ void mbedtls_x509write_crt_init(mbedtls_x509write_cert *ctx)
 
 void mbedtls_x509write_crt_free(mbedtls_x509write_cert *ctx)
 {
+    if (ctx == NULL) {
+        return;
+    }
+
     mbedtls_asn1_free_named_data_list(&ctx->subject);
     mbedtls_asn1_free_named_data_list(&ctx->issuer);
     mbedtls_asn1_free_named_data_list(&ctx->extensions);

--- a/library/x509write_csr.c
+++ b/library/x509write_csr.c
@@ -43,6 +43,10 @@ void mbedtls_x509write_csr_init(mbedtls_x509write_csr *ctx)
 
 void mbedtls_x509write_csr_free(mbedtls_x509write_csr *ctx)
 {
+    if (ctx == NULL) {
+        return;
+    }
+
     mbedtls_asn1_free_named_data_list(&ctx->subject);
     mbedtls_asn1_free_named_data_list(&ctx->extensions);
 


### PR DESCRIPTION
## Description

Added conditional statements to mbedtls_xxx_free() functions to handle NULL arguments.
Resolves #8915
Replaces PR #8955


## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required
- [x] **3.6 backport** https://github.com/Mbed-TLS/mbedtls/pull/9045
- [x] **2.28 backport** not required
- [x] **tests** not required
