### PR TITLE
Make header comments C90 compatible

### DIFF
--- a/include/mbedtls/aes.h
+++ b/include/mbedtls/aes.h
@@ -54,8 +54,7 @@ extern "C" {
 #endif
 
 #if !defined(MBEDTLS_AES_ALT)
-// Regular implementation
-//
+/* Regular implementation */
 
 /**
  * \brief The AES context-type definition.

--- a/include/mbedtls/aria.h
+++ b/include/mbedtls/aria.h
@@ -43,8 +43,7 @@ extern "C" {
 #endif
 
 #if !defined(MBEDTLS_ARIA_ALT)
-// Regular implementation
-//
+/* Regular implementation */
 
 /**
  * \brief The ARIA context-type definition.

--- a/include/mbedtls/camellia.h
+++ b/include/mbedtls/camellia.h
@@ -32,8 +32,7 @@ extern "C" {
 #endif
 
 #if !defined(MBEDTLS_CAMELLIA_ALT)
-// Regular implementation
-//
+/* Regular implementation */
 
 /**
  * \brief          CAMELLIA context structure

--- a/include/mbedtls/ccm.h
+++ b/include/mbedtls/ccm.h
@@ -59,8 +59,7 @@ extern "C" {
 #endif
 
 #if !defined(MBEDTLS_CCM_ALT)
-// Regular implementation
-//
+/* Regular implementation */
 
 /**
  * \brief    The CCM context-type definition. The CCM context is passed

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -227,13 +227,13 @@
 
 #if defined(__has_feature)
 #if __has_feature(memory_sanitizer)
-#define MBEDTLS_HAS_MEMSAN // #undef at the end of this paragraph
+#define MBEDTLS_HAS_MEMSAN /* #undef at the end of this paragraph */
 #endif
 #endif
 #if defined(MBEDTLS_TEST_CONSTANT_FLOW_MEMSAN) &&  !defined(MBEDTLS_HAS_MEMSAN)
 #error "MBEDTLS_TEST_CONSTANT_FLOW_MEMSAN requires building with MemorySanitizer"
 #endif
-#undef MBEDTLS_HAS_MEMSAN // temporary macro defined above
+#undef MBEDTLS_HAS_MEMSAN /* temporary macro defined above */
 
 #if defined(MBEDTLS_CCM_C) && \
     !(defined(MBEDTLS_CCM_GCM_CAN_AES) || defined(MBEDTLS_CCM_GCM_CAN_ARIA) || \
@@ -974,18 +974,18 @@
 #if !defined(MBEDTLS_THREADING_C) || defined(MBEDTLS_THREADING_IMPL)
 #error "MBEDTLS_THREADING_PTHREAD defined, but not all prerequisites"
 #endif
-#define MBEDTLS_THREADING_IMPL // undef at the end of this paragraph
+#define MBEDTLS_THREADING_IMPL /* undef at the end of this paragraph */
 #endif
 #if defined(MBEDTLS_THREADING_ALT)
 #if !defined(MBEDTLS_THREADING_C) || defined(MBEDTLS_THREADING_IMPL)
 #error "MBEDTLS_THREADING_ALT defined, but not all prerequisites"
 #endif
-#define MBEDTLS_THREADING_IMPL // undef at the end of this paragraph
+#define MBEDTLS_THREADING_IMPL /* undef at the end of this paragraph */
 #endif
 #if defined(MBEDTLS_THREADING_C) && !defined(MBEDTLS_THREADING_IMPL)
 #error "MBEDTLS_THREADING_C defined, single threading implementation required"
 #endif
-#undef MBEDTLS_THREADING_IMPL // temporary macro defined above
+#undef MBEDTLS_THREADING_IMPL /* temporary macro defined above */
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO) && !defined(MBEDTLS_PSA_CRYPTO_CLIENT)
 #error "MBEDTLS_USE_PSA_CRYPTO defined, but not all prerequisites"
@@ -1064,47 +1064,47 @@
 /* Reject attempts to enable options that have been removed and that could
  * cause a build to succeed but with features removed. */
 
-#if defined(MBEDTLS_HAVEGE_C) //no-check-names
+#if defined(MBEDTLS_HAVEGE_C) /* //no-check-names */
 #error "MBEDTLS_HAVEGE_C was removed in Mbed TLS 3.0. See https://github.com/Mbed-TLS/mbedtls/issues/2599"
 #endif
 
-#if defined(MBEDTLS_SSL_HW_RECORD_ACCEL) //no-check-names
+#if defined(MBEDTLS_SSL_HW_RECORD_ACCEL) /* //no-check-names */
 #error "MBEDTLS_SSL_HW_RECORD_ACCEL was removed in Mbed TLS 3.0. See https://github.com/Mbed-TLS/mbedtls/issues/4031"
 #endif
 
-#if defined(MBEDTLS_SSL_PROTO_SSL3) //no-check-names
+#if defined(MBEDTLS_SSL_PROTO_SSL3) /* //no-check-names */
 #error "MBEDTLS_SSL_PROTO_SSL3 (SSL v3.0 support) was removed in Mbed TLS 3.0. See https://github.com/Mbed-TLS/mbedtls/issues/4031"
 #endif
 
-#if defined(MBEDTLS_SSL_SRV_SUPPORT_SSLV2_CLIENT_HELLO) //no-check-names
+#if defined(MBEDTLS_SSL_SRV_SUPPORT_SSLV2_CLIENT_HELLO) /* //no-check-names */
 #error "MBEDTLS_SSL_SRV_SUPPORT_SSLV2_CLIENT_HELLO (SSL v2 ClientHello support) was removed in Mbed TLS 3.0. See https://github.com/Mbed-TLS/mbedtls/issues/4031"
 #endif
 
-#if defined(MBEDTLS_SSL_TRUNCATED_HMAC_COMPAT) //no-check-names
+#if defined(MBEDTLS_SSL_TRUNCATED_HMAC_COMPAT) /* //no-check-names */
 #error "MBEDTLS_SSL_TRUNCATED_HMAC_COMPAT (compatibility with the buggy implementation of truncated HMAC in Mbed TLS up to 2.7) was removed in Mbed TLS 3.0. See https://github.com/Mbed-TLS/mbedtls/issues/4031"
 #endif
 
-#if defined(MBEDTLS_TLS_DEFAULT_ALLOW_SHA1_IN_CERTIFICATES) //no-check-names
+#if defined(MBEDTLS_TLS_DEFAULT_ALLOW_SHA1_IN_CERTIFICATES) /* //no-check-names */
 #error "MBEDTLS_TLS_DEFAULT_ALLOW_SHA1_IN_CERTIFICATES was removed in Mbed TLS 3.0. See the ChangeLog entry if you really need SHA-1-signed certificates."
 #endif
 
-#if defined(MBEDTLS_ZLIB_SUPPORT) //no-check-names
+#if defined(MBEDTLS_ZLIB_SUPPORT) /* //no-check-names */
 #error "MBEDTLS_ZLIB_SUPPORT was removed in Mbed TLS 3.0. See https://github.com/Mbed-TLS/mbedtls/issues/4031"
 #endif
 
-#if defined(MBEDTLS_CHECK_PARAMS) //no-check-names
+#if defined(MBEDTLS_CHECK_PARAMS) /* //no-check-names */
 #error "MBEDTLS_CHECK_PARAMS was removed in Mbed TLS 3.0. See https://github.com/Mbed-TLS/mbedtls/issues/4313"
 #endif
 
-#if defined(MBEDTLS_SSL_CID_PADDING_GRANULARITY) //no-check-names
+#if defined(MBEDTLS_SSL_CID_PADDING_GRANULARITY) /* //no-check-names */
 #error "MBEDTLS_SSL_CID_PADDING_GRANULARITY was removed in Mbed TLS 3.0. See https://github.com/Mbed-TLS/mbedtls/issues/4335"
 #endif
 
-#if defined(MBEDTLS_SSL_TLS1_3_PADDING_GRANULARITY) //no-check-names
+#if defined(MBEDTLS_SSL_TLS1_3_PADDING_GRANULARITY) /* //no-check-names */
 #error "MBEDTLS_SSL_TLS1_3_PADDING_GRANULARITY was removed in Mbed TLS 3.0. See https://github.com/Mbed-TLS/mbedtls/issues/4335"
 #endif
 
-#if defined(MBEDTLS_SSL_TRUNCATED_HMAC) //no-check-names
+#if defined(MBEDTLS_SSL_TRUNCATED_HMAC) /* //no-check-names */
 #error "MBEDTLS_SSL_TRUNCATED_HMAC was removed in Mbed TLS 3.0. See https://github.com/Mbed-TLS/mbedtls/issues/4341"
 #endif
 

--- a/include/mbedtls/config_adjust_psa_from_legacy.h
+++ b/include/mbedtls/config_adjust_psa_from_legacy.h
@@ -47,7 +47,7 @@
 #define PSA_WANT_ALG_ECDSA 1
 #define PSA_WANT_ALG_ECDSA_ANY 1
 
-// Only add in DETERMINISTIC support if ECDSA is also enabled
+/* Only add in DETERMINISTIC support if ECDSA is also enabled */
 #if defined(MBEDTLS_ECDSA_DETERMINISTIC)
 #define MBEDTLS_PSA_BUILTIN_ALG_DETERMINISTIC_ECDSA 1
 #define PSA_WANT_ALG_DETERMINISTIC_ECDSA 1

--- a/include/mbedtls/des.h
+++ b/include/mbedtls/des.h
@@ -35,8 +35,7 @@ extern "C" {
 #endif
 
 #if !defined(MBEDTLS_DES_ALT)
-// Regular implementation
-//
+/* Regular implementation */
 
 /**
  * \brief          DES context structure

--- a/include/mbedtls/ecp.h
+++ b/include/mbedtls/ecp.h
@@ -340,7 +340,7 @@ mbedtls_ecp_group;
 #elif defined(MBEDTLS_ECP_DP_CURVE25519_ENABLED)
 #define MBEDTLS_ECP_MAX_BITS 255
 #elif defined(MBEDTLS_ECP_DP_SECP224K1_ENABLED)
-#define MBEDTLS_ECP_MAX_BITS 225 // n is slightly above 2^224
+#define MBEDTLS_ECP_MAX_BITS 225 /* n is slightly above 2^224 */
 #elif defined(MBEDTLS_ECP_DP_SECP224R1_ENABLED)
 #define MBEDTLS_ECP_MAX_BITS 224
 #elif defined(MBEDTLS_ECP_DP_SECP192K1_ENABLED)

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -19,7 +19,7 @@
  * It is equal to the #MBEDTLS_VERSION_NUMBER of the Mbed TLS version that
  * introduced the config format we want to be compatible with.
  */
-//#define MBEDTLS_CONFIG_VERSION 0x03000000
+/* #define MBEDTLS_CONFIG_VERSION 0x03000000 */
 
 /**
  * \name SECTION: System support
@@ -77,7 +77,7 @@
  * example, if double-width division is implemented in software, disabling
  * it can reduce code size in some embedded targets.
  */
-//#define MBEDTLS_NO_UDBL_DIVISION
+/* #define MBEDTLS_NO_UDBL_DIVISION */
 
 /**
  * \def MBEDTLS_NO_64BIT_MULTIPLICATION
@@ -99,7 +99,7 @@
  * Note that depending on the compiler, this may decrease performance compared
  * to using the library function provided by the toolchain.
  */
-//#define MBEDTLS_NO_64BIT_MULTIPLICATION
+/* #define MBEDTLS_NO_64BIT_MULTIPLICATION */
 
 /**
  * \def MBEDTLS_HAVE_SSE2
@@ -108,7 +108,7 @@
  *
  * Uncomment if the CPU supports SSE2 (IA-32 specific).
  */
-//#define MBEDTLS_HAVE_SSE2
+/* #define MBEDTLS_HAVE_SSE2 */
 
 /**
  * \def MBEDTLS_HAVE_TIME
@@ -205,7 +205,7 @@
  *
  * Enable this layer to allow use of alternative memory allocators.
  */
-//#define MBEDTLS_PLATFORM_MEMORY
+/* #define MBEDTLS_PLATFORM_MEMORY */
 
 /**
  * \def MBEDTLS_PLATFORM_NO_STD_FUNCTIONS
@@ -224,7 +224,7 @@
  * Uncomment to prevent default assignment of standard functions in the
  * platform layer.
  */
-//#define MBEDTLS_PLATFORM_NO_STD_FUNCTIONS
+/* #define MBEDTLS_PLATFORM_NO_STD_FUNCTIONS */
 
 /**
  * \def MBEDTLS_PLATFORM_EXIT_ALT
@@ -249,16 +249,16 @@
  * Uncomment a macro to enable alternate implementation of specific base
  * platform function
  */
-//#define MBEDTLS_PLATFORM_SETBUF_ALT
-//#define MBEDTLS_PLATFORM_EXIT_ALT
-//#define MBEDTLS_PLATFORM_TIME_ALT
-//#define MBEDTLS_PLATFORM_FPRINTF_ALT
-//#define MBEDTLS_PLATFORM_PRINTF_ALT
-//#define MBEDTLS_PLATFORM_SNPRINTF_ALT
-//#define MBEDTLS_PLATFORM_VSNPRINTF_ALT
-//#define MBEDTLS_PLATFORM_NV_SEED_ALT
-//#define MBEDTLS_PLATFORM_SETUP_TEARDOWN_ALT
-//#define MBEDTLS_PLATFORM_MS_TIME_ALT
+/* #define MBEDTLS_PLATFORM_SETBUF_ALT */
+/* #define MBEDTLS_PLATFORM_EXIT_ALT */
+/* #define MBEDTLS_PLATFORM_TIME_ALT */
+/* #define MBEDTLS_PLATFORM_FPRINTF_ALT */
+/* #define MBEDTLS_PLATFORM_PRINTF_ALT */
+/* #define MBEDTLS_PLATFORM_SNPRINTF_ALT */
+/* #define MBEDTLS_PLATFORM_VSNPRINTF_ALT */
+/* #define MBEDTLS_PLATFORM_NV_SEED_ALT */
+/* #define MBEDTLS_PLATFORM_SETUP_TEARDOWN_ALT */
+/* #define MBEDTLS_PLATFORM_MS_TIME_ALT */
 
 /**
  * Uncomment the macro to let Mbed TLS use your alternate implementation of
@@ -277,7 +277,7 @@
  * unconditionally use the implementation for mbedtls_platform_gmtime_r()
  * supplied at compile time.
  */
-//#define MBEDTLS_PLATFORM_GMTIME_R_ALT
+/* #define MBEDTLS_PLATFORM_GMTIME_R_ALT */
 
 /**
  * Uncomment the macro to let Mbed TLS use your alternate implementation of
@@ -300,7 +300,7 @@
  * detect its presence, define `MBEDTLS_PLATFORM_ZEROIZE_ALT` to be
  * `explicit_bzero` to use that function as mbedtls_platform_zeroize().
  */
-//#define MBEDTLS_PLATFORM_ZEROIZE_ALT
+/* #define MBEDTLS_PLATFORM_ZEROIZE_ALT */
 
 /**
  * \def MBEDTLS_DEPRECATED_WARNING
@@ -315,7 +315,7 @@
  *
  * Uncomment to get warnings on using deprecated functions and features.
  */
-//#define MBEDTLS_DEPRECATED_WARNING
+/* #define MBEDTLS_DEPRECATED_WARNING */
 
 /**
  * \def MBEDTLS_DEPRECATED_REMOVED
@@ -327,7 +327,7 @@
  *
  * Uncomment to get errors on using deprecated functions and features.
  */
-//#define MBEDTLS_DEPRECATED_REMOVED
+/* #define MBEDTLS_DEPRECATED_REMOVED */
 
 /** \} name SECTION: System support */
 
@@ -350,7 +350,7 @@
  * You will need to provide a header "timing_alt.h" and an implementation at
  * compile time.
  */
-//#define MBEDTLS_TIMING_ALT
+/* #define MBEDTLS_TIMING_ALT */
 
 /**
  * \def MBEDTLS_AES_ALT
@@ -377,25 +377,25 @@
  *            digests and ciphers instead.
  *
  */
-//#define MBEDTLS_AES_ALT
-//#define MBEDTLS_ARIA_ALT
-//#define MBEDTLS_CAMELLIA_ALT
-//#define MBEDTLS_CCM_ALT
-//#define MBEDTLS_CHACHA20_ALT
-//#define MBEDTLS_CHACHAPOLY_ALT
-//#define MBEDTLS_CMAC_ALT
-//#define MBEDTLS_DES_ALT
-//#define MBEDTLS_DHM_ALT
-//#define MBEDTLS_ECJPAKE_ALT
-//#define MBEDTLS_GCM_ALT
-//#define MBEDTLS_NIST_KW_ALT
-//#define MBEDTLS_MD5_ALT
-//#define MBEDTLS_POLY1305_ALT
-//#define MBEDTLS_RIPEMD160_ALT
-//#define MBEDTLS_RSA_ALT
-//#define MBEDTLS_SHA1_ALT
-//#define MBEDTLS_SHA256_ALT
-//#define MBEDTLS_SHA512_ALT
+/* #define MBEDTLS_AES_ALT */
+/* #define MBEDTLS_ARIA_ALT */
+/* #define MBEDTLS_CAMELLIA_ALT */
+/* #define MBEDTLS_CCM_ALT */
+/* #define MBEDTLS_CHACHA20_ALT */
+/* #define MBEDTLS_CHACHAPOLY_ALT */
+/* #define MBEDTLS_CMAC_ALT */
+/* #define MBEDTLS_DES_ALT */
+/* #define MBEDTLS_DHM_ALT */
+/* #define MBEDTLS_ECJPAKE_ALT */
+/* #define MBEDTLS_GCM_ALT */
+/* #define MBEDTLS_NIST_KW_ALT */
+/* #define MBEDTLS_MD5_ALT */
+/* #define MBEDTLS_POLY1305_ALT */
+/* #define MBEDTLS_RIPEMD160_ALT */
+/* #define MBEDTLS_RSA_ALT */
+/* #define MBEDTLS_SHA1_ALT */
+/* #define MBEDTLS_SHA256_ALT */
+/* #define MBEDTLS_SHA512_ALT */
 
 /*
  * When replacing the elliptic curve module, please consider, that it is
@@ -406,7 +406,7 @@
  * macros as described above. The only difference is that you have to make sure
  * that you provide functionality for both .c files.
  */
-//#define MBEDTLS_ECP_ALT
+/* #define MBEDTLS_ECP_ALT */
 
 /**
  * \def MBEDTLS_SHA256_PROCESS_ALT
@@ -445,23 +445,23 @@
  *            implementation should be provided for mbedtls_ecdsa_sign_det_ext().
  *
  */
-//#define MBEDTLS_MD5_PROCESS_ALT
-//#define MBEDTLS_RIPEMD160_PROCESS_ALT
-//#define MBEDTLS_SHA1_PROCESS_ALT
-//#define MBEDTLS_SHA256_PROCESS_ALT
-//#define MBEDTLS_SHA512_PROCESS_ALT
-//#define MBEDTLS_DES_SETKEY_ALT
-//#define MBEDTLS_DES_CRYPT_ECB_ALT
-//#define MBEDTLS_DES3_CRYPT_ECB_ALT
-//#define MBEDTLS_AES_SETKEY_ENC_ALT
-//#define MBEDTLS_AES_SETKEY_DEC_ALT
-//#define MBEDTLS_AES_ENCRYPT_ALT
-//#define MBEDTLS_AES_DECRYPT_ALT
-//#define MBEDTLS_ECDH_GEN_PUBLIC_ALT
-//#define MBEDTLS_ECDH_COMPUTE_SHARED_ALT
-//#define MBEDTLS_ECDSA_VERIFY_ALT
-//#define MBEDTLS_ECDSA_SIGN_ALT
-//#define MBEDTLS_ECDSA_GENKEY_ALT
+/* #define MBEDTLS_MD5_PROCESS_ALT */
+/* #define MBEDTLS_RIPEMD160_PROCESS_ALT */
+/* #define MBEDTLS_SHA1_PROCESS_ALT */
+/* #define MBEDTLS_SHA256_PROCESS_ALT */
+/* #define MBEDTLS_SHA512_PROCESS_ALT */
+/* #define MBEDTLS_DES_SETKEY_ALT */
+/* #define MBEDTLS_DES_CRYPT_ECB_ALT */
+/* #define MBEDTLS_DES3_CRYPT_ECB_ALT */
+/* #define MBEDTLS_AES_SETKEY_ENC_ALT */
+/* #define MBEDTLS_AES_SETKEY_DEC_ALT */
+/* #define MBEDTLS_AES_ENCRYPT_ALT */
+/* #define MBEDTLS_AES_DECRYPT_ALT */
+/* #define MBEDTLS_ECDH_GEN_PUBLIC_ALT */
+/* #define MBEDTLS_ECDH_COMPUTE_SHARED_ALT */
+/* #define MBEDTLS_ECDSA_VERIFY_ALT */
+/* #define MBEDTLS_ECDSA_SIGN_ALT */
+/* #define MBEDTLS_ECDSA_GENKEY_ALT */
 
 /**
  * \def MBEDTLS_ECP_INTERNAL_ALT
@@ -514,19 +514,19 @@
  * function.
  */
 /* Required for all the functions in this section */
-//#define MBEDTLS_ECP_INTERNAL_ALT
+/* #define MBEDTLS_ECP_INTERNAL_ALT */
 /* Turn off software fallback for curves not supported in hardware */
-//#define MBEDTLS_ECP_NO_FALLBACK
+/* #define MBEDTLS_ECP_NO_FALLBACK */
 /* Support for Weierstrass curves with Jacobi representation */
-//#define MBEDTLS_ECP_RANDOMIZE_JAC_ALT
-//#define MBEDTLS_ECP_ADD_MIXED_ALT
-//#define MBEDTLS_ECP_DOUBLE_JAC_ALT
-//#define MBEDTLS_ECP_NORMALIZE_JAC_MANY_ALT
-//#define MBEDTLS_ECP_NORMALIZE_JAC_ALT
+/* #define MBEDTLS_ECP_RANDOMIZE_JAC_ALT */
+/* #define MBEDTLS_ECP_ADD_MIXED_ALT */
+/* #define MBEDTLS_ECP_DOUBLE_JAC_ALT */
+/* #define MBEDTLS_ECP_NORMALIZE_JAC_MANY_ALT */
+/* #define MBEDTLS_ECP_NORMALIZE_JAC_ALT */
 /* Support for curves with Montgomery arithmetic */
-//#define MBEDTLS_ECP_DOUBLE_ADD_MXZ_ALT
-//#define MBEDTLS_ECP_RANDOMIZE_MXZ_ALT
-//#define MBEDTLS_ECP_NORMALIZE_MXZ_ALT
+/* #define MBEDTLS_ECP_DOUBLE_ADD_MXZ_ALT */
+/* #define MBEDTLS_ECP_RANDOMIZE_MXZ_ALT */
+/* #define MBEDTLS_ECP_NORMALIZE_MXZ_ALT */
 
 /**
  * \def MBEDTLS_ENTROPY_HARDWARE_ALT
@@ -540,7 +540,7 @@
  *
  * Uncomment to use your own hardware entropy collector.
  */
-//#define MBEDTLS_ENTROPY_HARDWARE_ALT
+/* #define MBEDTLS_ENTROPY_HARDWARE_ALT */
 
 /**
  * \def MBEDTLS_AES_ROM_TABLES
@@ -559,7 +559,7 @@
  *
  * This option is independent of \c MBEDTLS_AES_FEWER_TABLES.
  */
-//#define MBEDTLS_AES_ROM_TABLES
+/* #define MBEDTLS_AES_ROM_TABLES */
 
 /**
  * \def MBEDTLS_AES_FEWER_TABLES
@@ -580,7 +580,7 @@
  *
  * This option is independent of \c MBEDTLS_AES_ROM_TABLES.
  */
-//#define MBEDTLS_AES_FEWER_TABLES
+/* #define MBEDTLS_AES_FEWER_TABLES */
 
 /**
  * \def MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
@@ -597,7 +597,7 @@
  *
  * Requires: MBEDTLS_AES_C
  */
-//#define MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
+/* #define MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH */
 
 /*
  * Disable plain C implementation for AES.
@@ -611,7 +611,7 @@
  * necessary features. It will not build unless at least one of MBEDTLS_AESCE_C
  * and/or MBEDTLS_AESNI_C is enabled & present in the build.
  */
-//#define MBEDTLS_AES_USE_HARDWARE_ONLY
+/* #define MBEDTLS_AES_USE_HARDWARE_ONLY */
 
 /**
  * \def MBEDTLS_CAMELLIA_SMALL_MEMORY
@@ -620,7 +620,7 @@
  *
  * Uncomment this macro to use less memory for Camellia.
  */
-//#define MBEDTLS_CAMELLIA_SMALL_MEMORY
+/* #define MBEDTLS_CAMELLIA_SMALL_MEMORY */
 
 /**
  * \def MBEDTLS_CHECK_RETURN_WARNING
@@ -643,7 +643,7 @@
  *        macro is not defined. To completely disable return value check
  *        warnings, define #MBEDTLS_CHECK_RETURN with an empty expansion.
  */
-//#define MBEDTLS_CHECK_RETURN_WARNING
+/* #define MBEDTLS_CHECK_RETURN_WARNING */
 
 /**
  * \def MBEDTLS_CIPHER_MODE_CBC
@@ -710,7 +710,7 @@
  *
  * Uncomment this macro to enable the NULL cipher and ciphersuites
  */
-//#define MBEDTLS_CIPHER_NULL_CIPHER
+/* #define MBEDTLS_CIPHER_NULL_CIPHER */
 
 /**
  * \def MBEDTLS_CIPHER_PADDING_PKCS7
@@ -734,7 +734,7 @@
  * Without this, CTR_DRBG uses a 256-bit key
  * unless \c MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH is set.
  */
-//#define MBEDTLS_CTR_DRBG_USE_128_BIT_KEY
+/* #define MBEDTLS_CTR_DRBG_USE_128_BIT_KEY */
 
 /**
  * Enable the verified implementations of ECDH primitives from Project Everest
@@ -746,7 +746,7 @@
  * The Everest code is provided under the Apache 2.0 license only; therefore enabling this
  * option is not compatible with taking the library under the GPL v2.0-or-later license.
  */
-//#define MBEDTLS_ECDH_VARIANT_EVEREST_ENABLED
+/* #define MBEDTLS_ECDH_VARIANT_EVEREST_ENABLED */
 
 /**
  * \def MBEDTLS_ECP_DP_SECP192R1_ENABLED
@@ -836,7 +836,7 @@
  *
  * Uncomment this macro to enable restartable ECC computations.
  */
-//#define MBEDTLS_ECP_RESTARTABLE
+/* #define MBEDTLS_ECP_RESTARTABLE */
 
 /**
  * Uncomment to enable using new bignum code in the ECC modules.
@@ -844,7 +844,7 @@
  * \warning This is currently experimental, incomplete and therefore should not
  * be used in production.
  */
-//#define MBEDTLS_ECP_WITH_MPI_UINT
+/* #define MBEDTLS_ECP_WITH_MPI_UINT */
 
 /**
  * \def MBEDTLS_ECDSA_DETERMINISTIC
@@ -1125,7 +1125,7 @@
  * enabled as well):
  *      MBEDTLS_TLS_ECJPAKE_WITH_AES_128_CCM_8
  */
-//#define MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED
+/* #define MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED */
 
 /**
  * \def MBEDTLS_PK_PARSE_EC_EXTENDED
@@ -1195,7 +1195,7 @@
  *
  * Uncomment this macro to prevent loading of default entropy functions.
  */
-//#define MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES
+/* #define MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES */
 
 /**
  * \def MBEDTLS_NO_PLATFORM_ENTROPY
@@ -1206,7 +1206,7 @@
  *
  * Uncomment this macro to disable the built-in platform entropy functions.
  */
-//#define MBEDTLS_NO_PLATFORM_ENTROPY
+/* #define MBEDTLS_NO_PLATFORM_ENTROPY */
 
 /**
  * \def MBEDTLS_ENTROPY_FORCE_SHA256
@@ -1222,7 +1222,7 @@
  * This option is only useful if both MBEDTLS_SHA256_C and
  * MBEDTLS_SHA512_C are defined. Otherwise the available hash module is used.
  */
-//#define MBEDTLS_ENTROPY_FORCE_SHA256
+/* #define MBEDTLS_ENTROPY_FORCE_SHA256 */
 
 /**
  * \def MBEDTLS_ENTROPY_NV_SEED
@@ -1250,7 +1250,7 @@
  * \note The entropy collector will write to the seed file before entropy is
  *       given to an external source, to update it.
  */
-//#define MBEDTLS_ENTROPY_NV_SEED
+/* #define MBEDTLS_ENTROPY_NV_SEED */
 
 /* MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER
  *
@@ -1262,7 +1262,7 @@
  * Note that this option is meant for internal use only and may be removed
  * without notice.
  */
-//#define MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER
+/* #define MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER */
 
 /**
  * \def MBEDTLS_MEMORY_DEBUG
@@ -1275,7 +1275,7 @@
  *
  * Uncomment this macro to let the buffer allocator print out error messages.
  */
-//#define MBEDTLS_MEMORY_DEBUG
+/* #define MBEDTLS_MEMORY_DEBUG */
 
 /**
  * \def MBEDTLS_MEMORY_BACKTRACE
@@ -1287,7 +1287,7 @@
  *
  * Uncomment this macro to include backtrace information
  */
-//#define MBEDTLS_MEMORY_BACKTRACE
+/* #define MBEDTLS_MEMORY_BACKTRACE */
 
 /**
  * \def MBEDTLS_PK_RSA_ALT_SUPPORT
@@ -1337,7 +1337,7 @@
  * \warning This interface is experimental and may change or be removed
  * without notice.
  */
-//#define MBEDTLS_PSA_CRYPTO_BUILTIN_KEYS
+/* #define MBEDTLS_PSA_CRYPTO_BUILTIN_KEYS */
 
 /** \def MBEDTLS_PSA_CRYPTO_CLIENT
  *
@@ -1353,7 +1353,7 @@
  * \warning This interface is experimental and may change or be removed
  * without notice.
  */
-//#define MBEDTLS_PSA_CRYPTO_CLIENT
+/* #define MBEDTLS_PSA_CRYPTO_CLIENT */
 
 /** \def MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG
  *
@@ -1391,7 +1391,7 @@
  *
  * \note This option is experimental and may be removed without notice.
  */
-//#define MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG
+/* #define MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG */
 
 /**
  * \def MBEDTLS_PSA_CRYPTO_SPM
@@ -1412,7 +1412,7 @@
  * Requires: MBEDTLS_PSA_CRYPTO_C
  *
  */
-//#define MBEDTLS_PSA_CRYPTO_SPM
+/* #define MBEDTLS_PSA_CRYPTO_SPM */
 
 /**
  * Uncomment to enable p256-m. This is an alternative implementation of
@@ -1453,7 +1453,7 @@
  *       #MBEDTLS_PK_PARSE_EC_EXTENDED as those currently require a subset of
  *       the built-in ECC implementation, see docs/driver-only-builds.md.
  */
-//#define MBEDTLS_PSA_P256M_DRIVER_ENABLED
+/* #define MBEDTLS_PSA_P256M_DRIVER_ENABLED */
 
 /**
  * \def MBEDTLS_PSA_INJECT_ENTROPY
@@ -1466,7 +1466,7 @@
  * Requires: MBEDTLS_PSA_CRYPTO_STORAGE_C, MBEDTLS_ENTROPY_NV_SEED
  *
  */
-//#define MBEDTLS_PSA_INJECT_ENTROPY
+/* #define MBEDTLS_PSA_INJECT_ENTROPY */
 
 /**
  * \def MBEDTLS_RSA_NO_CRT
@@ -1477,7 +1477,7 @@
  * Uncomment this macro to disable the use of CRT in RSA.
  *
  */
-//#define MBEDTLS_RSA_NO_CRT
+/* #define MBEDTLS_RSA_NO_CRT */
 
 /**
  * \def MBEDTLS_SELF_TEST
@@ -1500,7 +1500,7 @@
  *
  * Uncomment to enable the smaller implementation of SHA256.
  */
-//#define MBEDTLS_SHA256_SMALLER
+/* #define MBEDTLS_SHA256_SMALLER */
 
 /**
  * \def MBEDTLS_SHA512_SMALLER
@@ -1510,7 +1510,7 @@
  *
  * Uncomment to enable the smaller implementation of SHA512.
  */
-//#define MBEDTLS_SHA512_SMALLER
+/* #define MBEDTLS_SHA512_SMALLER */
 
 /**
  * \def MBEDTLS_SSL_ALL_ALERT_MESSAGES
@@ -1583,7 +1583,7 @@
  *
  * Requires: MBEDTLS_X509_CRT_PARSE_C
  */
-//#define MBEDTLS_SSL_ASYNC_PRIVATE
+/* #define MBEDTLS_SSL_ASYNC_PRIVATE */
 
 /**
  * \def MBEDTLS_SSL_CONTEXT_SERIALIZATION
@@ -1628,7 +1628,7 @@
  * a timing side-channel.
  *
  */
-//#define MBEDTLS_SSL_DEBUG_ALL
+/* #define MBEDTLS_SSL_DEBUG_ALL */
 
 /** \def MBEDTLS_SSL_ENCRYPT_THEN_MAC
  *
@@ -1731,7 +1731,7 @@
  *
  * Uncomment this macro to enable support for the record_size_limit extension
  */
-//#define MBEDTLS_SSL_RECORD_SIZE_LIMIT
+/* #define MBEDTLS_SSL_RECORD_SIZE_LIMIT */
 
 /**
  * \def MBEDTLS_SSL_PROTO_TLS1_2
@@ -1858,7 +1858,7 @@
  *       MBEDTLS_SSL_MAX_EARLY_DATA_SIZE.
  *
  */
-//#define MBEDTLS_SSL_EARLY_DATA
+/* #define MBEDTLS_SSL_EARLY_DATA */
 
 /**
  * \def MBEDTLS_SSL_PROTO_DTLS
@@ -1944,7 +1944,7 @@
  *
  * Uncomment this to enable support for use_srtp extension.
  */
-//#define MBEDTLS_SSL_DTLS_SRTP
+/* #define MBEDTLS_SSL_DTLS_SRTP */
 
 /**
  * \def MBEDTLS_SSL_DTLS_CLIENT_PORT_REUSE
@@ -1995,7 +1995,7 @@
  *
  * Requires: MBEDTLS_SSL_MAX_FRAGMENT_LENGTH
  */
-//#define MBEDTLS_SSL_VARIABLE_BUFFER_LENGTH
+/* #define MBEDTLS_SSL_VARIABLE_BUFFER_LENGTH */
 
 /**
  * \def MBEDTLS_TEST_CONSTANT_FLOW_MEMSAN
@@ -2012,7 +2012,7 @@
  *
  * Uncomment to enable testing of the constant-flow nature of selected code.
  */
-//#define MBEDTLS_TEST_CONSTANT_FLOW_MEMSAN
+/* #define MBEDTLS_TEST_CONSTANT_FLOW_MEMSAN */
 
 /**
  * \def MBEDTLS_TEST_CONSTANT_FLOW_VALGRIND
@@ -2031,7 +2031,7 @@
  *
  * Uncomment to enable testing of the constant-flow nature of selected code.
  */
-//#define MBEDTLS_TEST_CONSTANT_FLOW_VALGRIND
+/* #define MBEDTLS_TEST_CONSTANT_FLOW_VALGRIND */
 
 /**
  * \def MBEDTLS_TEST_HOOKS
@@ -2051,7 +2051,7 @@
  *
  * Uncomment to enable invasive tests.
  */
-//#define MBEDTLS_TEST_HOOKS
+/* #define MBEDTLS_TEST_HOOKS */
 
 /**
  * \def MBEDTLS_THREADING_ALT
@@ -2062,7 +2062,7 @@
  *
  * Uncomment this to allow your own alternate threading implementation.
  */
-//#define MBEDTLS_THREADING_ALT
+/* #define MBEDTLS_THREADING_ALT */
 
 /**
  * \def MBEDTLS_THREADING_PTHREAD
@@ -2073,7 +2073,7 @@
  *
  * Uncomment this to enable pthread mutexes.
  */
-//#define MBEDTLS_THREADING_PTHREAD
+/* #define MBEDTLS_THREADING_PTHREAD */
 
 /**
  * \def MBEDTLS_USE_PSA_CRYPTO
@@ -2103,7 +2103,7 @@
  *
  * Uncomment this to enable internal use of PSA Crypto and new associated APIs.
  */
-//#define MBEDTLS_USE_PSA_CRYPTO
+/* #define MBEDTLS_USE_PSA_CRYPTO */
 
 /**
  * \def MBEDTLS_PSA_CRYPTO_CONFIG
@@ -2135,7 +2135,7 @@
  *          production, as long as you accept that you may need to make
  *          minor changes to psa/crypto_config.h when upgrading Mbed TLS.
  */
-//#define MBEDTLS_PSA_CRYPTO_CONFIG
+/* #define MBEDTLS_PSA_CRYPTO_CONFIG */
 
 /**
  * \def MBEDTLS_VERSION_FEATURES
@@ -2169,7 +2169,7 @@
  *
  * Uncomment to enable trusted certificate callbacks.
  */
-//#define MBEDTLS_X509_TRUSTED_CERTIFICATE_CALLBACK
+/* #define MBEDTLS_X509_TRUSTED_CERTIFICATE_CALLBACK */
 
 /**
  * \def MBEDTLS_X509_REMOVE_INFO
@@ -2180,7 +2180,7 @@
  * and other functions/constants only used by these functions, thus reducing
  * the code footprint by several KB.
  */
-//#define MBEDTLS_X509_REMOVE_INFO
+/* #define MBEDTLS_X509_REMOVE_INFO */
 
 /**
  * \def MBEDTLS_X509_RSASSA_PSS_SUPPORT
@@ -2395,7 +2395,7 @@
  *          library/camellia.c
  *          library/cipher.c
  */
-//#define MBEDTLS_BLOCK_CIPHER_NO_DECRYPT
+/* #define MBEDTLS_BLOCK_CIPHER_NO_DECRYPT */
 
 /**
  * \def MBEDTLS_BIGNUM_C
@@ -2811,7 +2811,7 @@
  *
  * Requires: MBEDTLS_GCM_C
  */
-//#define MBEDTLS_GCM_LARGE_TABLE
+/* #define MBEDTLS_GCM_LARGE_TABLE */
 
 /**
  * \def MBEDTLS_HKDF_C
@@ -2866,7 +2866,7 @@
  *
  * Uncomment to enable the LMS signature algorithm and private key operations.
  */
-//#define MBEDTLS_LMS_PRIVATE
+/* #define MBEDTLS_LMS_PRIVATE */
 
 /**
  * \def MBEDTLS_NIST_KW_C
@@ -2949,7 +2949,7 @@
  *
  * Enable this module to enable the buffer memory allocator.
  */
-//#define MBEDTLS_MEMORY_BUFFER_ALLOC_C
+/* #define MBEDTLS_MEMORY_BUFFER_ALLOC_C */
 
 /**
  * \def MBEDTLS_NET_C
@@ -3206,7 +3206,7 @@
  * Requires: MBEDTLS_PSA_CRYPTO_C, MBEDTLS_PSA_CRYPTO_STORAGE_C
  *
  */
-//#define MBEDTLS_PSA_CRYPTO_SE_C
+/* #define MBEDTLS_PSA_CRYPTO_SE_C */
 
 /**
  * \def MBEDTLS_PSA_CRYPTO_STORAGE_C
@@ -3343,7 +3343,7 @@
  * Uncomment to have the library check for the Armv8-A SHA-256 crypto extensions
  * and use them if available.
  */
-//#define MBEDTLS_SHA256_USE_ARMV8_A_CRYPTO_IF_PRESENT
+/* #define MBEDTLS_SHA256_USE_ARMV8_A_CRYPTO_IF_PRESENT */
 
 /**
  * \def MBEDTLS_SHA256_USE_A64_CRYPTO_IF_PRESENT
@@ -3352,7 +3352,7 @@
  * This name is now deprecated, but may still be used as an alternative form for
  * this option.
  */
-//#define MBEDTLS_SHA256_USE_A64_CRYPTO_IF_PRESENT
+/* #define MBEDTLS_SHA256_USE_A64_CRYPTO_IF_PRESENT */
 
 /**
  * \def MBEDTLS_SHA256_USE_ARMV8_A_CRYPTO_ONLY
@@ -3384,7 +3384,7 @@
  * Uncomment to have the library use the Armv8-A SHA-256 crypto extensions
  * unconditionally.
  */
-//#define MBEDTLS_SHA256_USE_ARMV8_A_CRYPTO_ONLY
+/* #define MBEDTLS_SHA256_USE_ARMV8_A_CRYPTO_ONLY */
 
 /**
  * \def MBEDTLS_SHA256_USE_A64_CRYPTO_ONLY
@@ -3393,7 +3393,7 @@
  * This name is now deprecated, but may still be used as an alternative form for
  * this option.
  */
-//#define MBEDTLS_SHA256_USE_A64_CRYPTO_ONLY
+/* #define MBEDTLS_SHA256_USE_A64_CRYPTO_ONLY */
 
 /**
  * \def MBEDTLS_SHA384_C
@@ -3463,7 +3463,7 @@
  * Uncomment to have the library check for the A64 SHA-512 crypto extensions
  * and use them if available.
  */
-//#define MBEDTLS_SHA512_USE_A64_CRYPTO_IF_PRESENT
+/* #define MBEDTLS_SHA512_USE_A64_CRYPTO_IF_PRESENT */
 
 /**
  * \def MBEDTLS_SHA512_USE_A64_CRYPTO_ONLY
@@ -3491,7 +3491,7 @@
  * Uncomment to have the library use the A64 SHA-512 crypto extensions
  * unconditionally.
  */
-//#define MBEDTLS_SHA512_USE_A64_CRYPTO_ONLY
+/* #define MBEDTLS_SHA512_USE_A64_CRYPTO_ONLY */
 
 /**
  * \def MBEDTLS_SSL_CACHE_C
@@ -3592,7 +3592,7 @@
  *
  * Enable this layer to allow use of mutexes within Mbed TLS
  */
-//#define MBEDTLS_THREADING_C
+/* #define MBEDTLS_THREADING_C */
 
 /**
  * \def MBEDTLS_TIMING_C
@@ -3764,7 +3764,7 @@
  * The value of this symbol is typically a path in double quotes, either
  * absolute or relative to a directory on the include search path.
  */
-//#define MBEDTLS_CONFIG_FILE "mbedtls/mbedtls_config.h"
+/* #define MBEDTLS_CONFIG_FILE "mbedtls/mbedtls_config.h"
 
 /**
  * \def MBEDTLS_USER_CONFIG_FILE
@@ -3781,7 +3781,7 @@
  * The value of this symbol is typically a path in double quotes, either
  * absolute or relative to a directory on the include search path.
  */
-//#define MBEDTLS_USER_CONFIG_FILE "/dev/null"
+/* #define MBEDTLS_USER_CONFIG_FILE "/dev/null"
 
 /**
  * \def MBEDTLS_PSA_CRYPTO_CONFIG_FILE
@@ -3799,7 +3799,7 @@
  * The value of this symbol is typically a path in double quotes, either
  * absolute or relative to a directory on the include search path.
  */
-//#define MBEDTLS_PSA_CRYPTO_CONFIG_FILE "psa/crypto_config.h"
+/* #define MBEDTLS_PSA_CRYPTO_CONFIG_FILE "psa/crypto_config.h"
 
 /**
  * \def MBEDTLS_PSA_CRYPTO_USER_CONFIG_FILE
@@ -3816,7 +3816,7 @@
  * The value of this symbol is typically a path in double quotes, either
  * absolute or relative to a directory on the include search path.
  */
-//#define MBEDTLS_PSA_CRYPTO_USER_CONFIG_FILE "/dev/null"
+/* #define MBEDTLS_PSA_CRYPTO_USER_CONFIG_FILE "/dev/null"
 
 /**
  * \def MBEDTLS_PSA_CRYPTO_PLATFORM_FILE
@@ -3838,7 +3838,7 @@
  * The value of this symbol is typically a path in double quotes, either
  * absolute or relative to a directory on the include search path.
  */
-//#define MBEDTLS_PSA_CRYPTO_PLATFORM_FILE "psa/crypto_platform_alt.h"
+/* #define MBEDTLS_PSA_CRYPTO_PLATFORM_FILE "psa */ /crypto_platform_alt.h"
 
 /**
  * \def MBEDTLS_PSA_CRYPTO_STRUCT_FILE
@@ -3863,7 +3863,7 @@
  * The value of this symbol is typically a path in double quotes, either
  * absolute or relative to a directory on the include search path.
  */
-//#define MBEDTLS_PSA_CRYPTO_STRUCT_FILE "psa/crypto_struct_alt.h"
+/* #define MBEDTLS_PSA_CRYPTO_STRUCT_FILE "psa */ /crypto_struct_alt.h"
 
 /** \} name SECTION: General configuration options */
 
@@ -3887,36 +3887,36 @@
  * comment in the specific module. */
 
 /* MPI / BIGNUM options */
-//#define MBEDTLS_MPI_WINDOW_SIZE            2 /**< Maximum window size used. */
-//#define MBEDTLS_MPI_MAX_SIZE            1024 /**< Maximum number of bytes for usable MPIs. */
+/* #define MBEDTLS_MPI_WINDOW_SIZE            2  */ /**< Maximum window size used. */
+/* #define MBEDTLS_MPI_MAX_SIZE            1024  */ /**< Maximum number of bytes for usable MPIs. */
 
 /* CTR_DRBG options */
-//#define MBEDTLS_CTR_DRBG_ENTROPY_LEN               48 /**< Amount of entropy used per seed by default (48 with SHA-512, 32 with SHA-256) */
-//#define MBEDTLS_CTR_DRBG_RESEED_INTERVAL        10000 /**< Interval before reseed is performed by default */
-//#define MBEDTLS_CTR_DRBG_MAX_INPUT                256 /**< Maximum number of additional input bytes */
-//#define MBEDTLS_CTR_DRBG_MAX_REQUEST             1024 /**< Maximum number of requested bytes per call */
-//#define MBEDTLS_CTR_DRBG_MAX_SEED_INPUT           384 /**< Maximum size of (re)seed buffer */
+/* #define MBEDTLS_CTR_DRBG_ENTROPY_LEN               48  */ /**< Amount of entropy used per seed by default (48 with SHA-512, 32 with SHA-256) */
+/* #define MBEDTLS_CTR_DRBG_RESEED_INTERVAL        10000  */ /**< Interval before reseed is performed by default */
+/* #define MBEDTLS_CTR_DRBG_MAX_INPUT                256  */ /**< Maximum number of additional input bytes */
+/* #define MBEDTLS_CTR_DRBG_MAX_REQUEST             1024  */ /**< Maximum number of requested bytes per call */
+/* #define MBEDTLS_CTR_DRBG_MAX_SEED_INPUT           384  */ /**< Maximum size of (re)seed buffer */
 
 /* HMAC_DRBG options */
-//#define MBEDTLS_HMAC_DRBG_RESEED_INTERVAL   10000 /**< Interval before reseed is performed by default */
-//#define MBEDTLS_HMAC_DRBG_MAX_INPUT           256 /**< Maximum number of additional input bytes */
-//#define MBEDTLS_HMAC_DRBG_MAX_REQUEST        1024 /**< Maximum number of requested bytes per call */
-//#define MBEDTLS_HMAC_DRBG_MAX_SEED_INPUT      384 /**< Maximum size of (re)seed buffer */
+/* #define MBEDTLS_HMAC_DRBG_RESEED_INTERVAL   10000  */ /**< Interval before reseed is performed by default */
+/* #define MBEDTLS_HMAC_DRBG_MAX_INPUT           256  */ /**< Maximum number of additional input bytes */
+/* #define MBEDTLS_HMAC_DRBG_MAX_REQUEST        1024  */ /**< Maximum number of requested bytes per call */
+/* #define MBEDTLS_HMAC_DRBG_MAX_SEED_INPUT      384  */ /**< Maximum size of (re)seed buffer */
 
 /* ECP options */
-//#define MBEDTLS_ECP_WINDOW_SIZE            4 /**< Maximum window size used */
-//#define MBEDTLS_ECP_FIXED_POINT_OPTIM      1 /**< Enable fixed-point speed-up */
+/* #define MBEDTLS_ECP_WINDOW_SIZE            4  */ /**< Maximum window size used */
+/* #define MBEDTLS_ECP_FIXED_POINT_OPTIM      1  */ /**< Enable fixed-point speed-up */
 
 /* Entropy options */
-//#define MBEDTLS_ENTROPY_MAX_SOURCES                20 /**< Maximum number of sources supported */
-//#define MBEDTLS_ENTROPY_MAX_GATHER                128 /**< Maximum amount requested from entropy sources */
-//#define MBEDTLS_ENTROPY_MIN_HARDWARE               32 /**< Default minimum number of bytes required for the hardware entropy source mbedtls_hardware_poll() before entropy is released */
+/* #define MBEDTLS_ENTROPY_MAX_SOURCES                20  */ /**< Maximum number of sources supported */
+/* #define MBEDTLS_ENTROPY_MAX_GATHER                128  */ /**< Maximum amount requested from entropy sources */
+/* #define MBEDTLS_ENTROPY_MIN_HARDWARE               32  */ /**< Default minimum number of bytes required for the hardware entropy source mbedtls_hardware_poll() before entropy is released */
 
 /* Memory buffer allocator options */
-//#define MBEDTLS_MEMORY_ALIGN_MULTIPLE      4 /**< Align on multiples of this value */
+/* #define MBEDTLS_MEMORY_ALIGN_MULTIPLE      4  */ /**< Align on multiples of this value */
 
 /* Platform options */
-//#define MBEDTLS_PLATFORM_STD_MEM_HDR   <stdlib.h> /**< Header to include if MBEDTLS_PLATFORM_NO_STD_FUNCTIONS is defined. Don't define if no header is needed. */
+/* #define MBEDTLS_PLATFORM_STD_MEM_HDR   <stdlib.h>  */ /**< Header to include if MBEDTLS_PLATFORM_NO_STD_FUNCTIONS is defined. Don't define if no header is needed. */
 
 /** \def MBEDTLS_PLATFORM_STD_CALLOC
  *
@@ -3929,7 +3929,7 @@
  * See the description of #MBEDTLS_PLATFORM_MEMORY for more details.
  * The corresponding deallocation function is #MBEDTLS_PLATFORM_STD_FREE.
  */
-//#define MBEDTLS_PLATFORM_STD_CALLOC        calloc
+/* #define MBEDTLS_PLATFORM_STD_CALLOC        calloc */
 
 /** \def MBEDTLS_PLATFORM_STD_FREE
  *
@@ -3939,37 +3939,37 @@
  * An uninitialized #MBEDTLS_PLATFORM_STD_FREE does not do anything.
  * See the description of #MBEDTLS_PLATFORM_MEMORY for more details (same principles as for MBEDTLS_PLATFORM_STD_CALLOC apply).
  */
-//#define MBEDTLS_PLATFORM_STD_FREE            free
-//#define MBEDTLS_PLATFORM_STD_SETBUF      setbuf /**< Default setbuf to use, can be undefined */
-//#define MBEDTLS_PLATFORM_STD_EXIT            exit /**< Default exit to use, can be undefined */
-//#define MBEDTLS_PLATFORM_STD_TIME            time /**< Default time to use, can be undefined. MBEDTLS_HAVE_TIME must be enabled */
-//#define MBEDTLS_PLATFORM_STD_FPRINTF      fprintf /**< Default fprintf to use, can be undefined */
-//#define MBEDTLS_PLATFORM_STD_PRINTF        printf /**< Default printf to use, can be undefined */
+/* #define MBEDTLS_PLATFORM_STD_FREE            free */
+/* #define MBEDTLS_PLATFORM_STD_SETBUF      setbuf  */ /**< Default setbuf to use, can be undefined */
+/* #define MBEDTLS_PLATFORM_STD_EXIT            exit  */ /**< Default exit to use, can be undefined */
+/* #define MBEDTLS_PLATFORM_STD_TIME            time  */ /**< Default time to use, can be undefined. MBEDTLS_HAVE_TIME must be enabled */
+/* #define MBEDTLS_PLATFORM_STD_FPRINTF      fprintf  */ /**< Default fprintf to use, can be undefined */
+/* #define MBEDTLS_PLATFORM_STD_PRINTF        printf  */ /**< Default printf to use, can be undefined */
 /* Note: your snprintf must correctly zero-terminate the buffer! */
-//#define MBEDTLS_PLATFORM_STD_SNPRINTF    snprintf /**< Default snprintf to use, can be undefined */
-//#define MBEDTLS_PLATFORM_STD_EXIT_SUCCESS       0 /**< Default exit value to use, can be undefined */
-//#define MBEDTLS_PLATFORM_STD_EXIT_FAILURE       1 /**< Default exit value to use, can be undefined */
-//#define MBEDTLS_PLATFORM_STD_NV_SEED_READ   mbedtls_platform_std_nv_seed_read /**< Default nv_seed_read function to use, can be undefined */
-//#define MBEDTLS_PLATFORM_STD_NV_SEED_WRITE  mbedtls_platform_std_nv_seed_write /**< Default nv_seed_write function to use, can be undefined */
-//#define MBEDTLS_PLATFORM_STD_NV_SEED_FILE  "seedfile" /**< Seed file to read/write with default implementation */
+/* #define MBEDTLS_PLATFORM_STD_SNPRINTF    snprintf  */ /**< Default snprintf to use, can be undefined */
+/* #define MBEDTLS_PLATFORM_STD_EXIT_SUCCESS       0  */ /**< Default exit value to use, can be undefined */
+/* #define MBEDTLS_PLATFORM_STD_EXIT_FAILURE       1  */ /**< Default exit value to use, can be undefined */
+/* #define MBEDTLS_PLATFORM_STD_NV_SEED_READ   mbedtls_platform_std_nv_seed_read  */ /**< Default nv_seed_read function to use, can be undefined */
+/* #define MBEDTLS_PLATFORM_STD_NV_SEED_WRITE  mbedtls_platform_std_nv_seed_write  */ /**< Default nv_seed_write function to use, can be undefined */
+/* #define MBEDTLS_PLATFORM_STD_NV_SEED_FILE  "seedfile"  */ /**< Seed file to read/write with default implementation */
 
 /* To use the following function macros, MBEDTLS_PLATFORM_C must be enabled. */
 /* MBEDTLS_PLATFORM_XXX_MACRO and MBEDTLS_PLATFORM_XXX_ALT cannot both be defined */
-//#define MBEDTLS_PLATFORM_CALLOC_MACRO        calloc /**< Default allocator macro to use, can be undefined. See MBEDTLS_PLATFORM_STD_CALLOC for requirements. */
-//#define MBEDTLS_PLATFORM_FREE_MACRO            free /**< Default free macro to use, can be undefined. See MBEDTLS_PLATFORM_STD_FREE for requirements. */
-//#define MBEDTLS_PLATFORM_EXIT_MACRO            exit /**< Default exit macro to use, can be undefined */
-//#define MBEDTLS_PLATFORM_SETBUF_MACRO      setbuf /**< Default setbuf macro to use, can be undefined */
-//#define MBEDTLS_PLATFORM_TIME_MACRO            time /**< Default time macro to use, can be undefined. MBEDTLS_HAVE_TIME must be enabled */
-//#define MBEDTLS_PLATFORM_TIME_TYPE_MACRO       time_t /**< Default time macro to use, can be undefined. MBEDTLS_HAVE_TIME must be enabled */
-//#define MBEDTLS_PLATFORM_FPRINTF_MACRO      fprintf /**< Default fprintf macro to use, can be undefined */
-//#define MBEDTLS_PLATFORM_PRINTF_MACRO        printf /**< Default printf macro to use, can be undefined */
+/* #define MBEDTLS_PLATFORM_CALLOC_MACRO        calloc  */ /**< Default allocator macro to use, can be undefined. See MBEDTLS_PLATFORM_STD_CALLOC for requirements. */
+/* #define MBEDTLS_PLATFORM_FREE_MACRO            free  */ /**< Default free macro to use, can be undefined. See MBEDTLS_PLATFORM_STD_FREE for requirements. */
+/* #define MBEDTLS_PLATFORM_EXIT_MACRO            exit  */ /**< Default exit macro to use, can be undefined */
+/* #define MBEDTLS_PLATFORM_SETBUF_MACRO      setbuf  */ /**< Default setbuf macro to use, can be undefined */
+/* #define MBEDTLS_PLATFORM_TIME_MACRO            time  */ /**< Default time macro to use, can be undefined. MBEDTLS_HAVE_TIME must be enabled */
+/* #define MBEDTLS_PLATFORM_TIME_TYPE_MACRO       time_t  */ /**< Default time macro to use, can be undefined. MBEDTLS_HAVE_TIME must be enabled */
+/* #define MBEDTLS_PLATFORM_FPRINTF_MACRO      fprintf  */ /**< Default fprintf macro to use, can be undefined */
+/* #define MBEDTLS_PLATFORM_PRINTF_MACRO        printf  */ /**< Default printf macro to use, can be undefined */
 /* Note: your snprintf must correctly zero-terminate the buffer! */
-//#define MBEDTLS_PLATFORM_SNPRINTF_MACRO    snprintf /**< Default snprintf macro to use, can be undefined */
-//#define MBEDTLS_PLATFORM_VSNPRINTF_MACRO    vsnprintf /**< Default vsnprintf macro to use, can be undefined */
-//#define MBEDTLS_PLATFORM_NV_SEED_READ_MACRO   mbedtls_platform_std_nv_seed_read /**< Default nv_seed_read function to use, can be undefined */
-//#define MBEDTLS_PLATFORM_NV_SEED_WRITE_MACRO  mbedtls_platform_std_nv_seed_write /**< Default nv_seed_write function to use, can be undefined */
-//#define MBEDTLS_PLATFORM_MS_TIME_TYPE_MACRO   int64_t //#define MBEDTLS_PLATFORM_MS_TIME_TYPE_MACRO   int64_t /**< Default milliseconds time macro to use, can be undefined. MBEDTLS_HAVE_TIME must be enabled. It must be signed, and at least 64 bits. If it is changed from the default, MBEDTLS_PRINTF_MS_TIME must be updated to match.*/
-//#define MBEDTLS_PRINTF_MS_TIME    PRId64 /**< Default fmt for printf. That's avoid compiler warning if mbedtls_ms_time_t is redefined */
+/* #define MBEDTLS_PLATFORM_SNPRINTF_MACRO    snprintf  */ /**< Default snprintf macro to use, can be undefined */
+/* #define MBEDTLS_PLATFORM_VSNPRINTF_MACRO    vsnprintf  */ /**< Default vsnprintf macro to use, can be undefined */
+/* #define MBEDTLS_PLATFORM_NV_SEED_READ_MACRO   mbedtls_platform_std_nv_seed_read  */ /**< Default nv_seed_read function to use, can be undefined */
+/* #define MBEDTLS_PLATFORM_NV_SEED_WRITE_MACRO  mbedtls_platform_std_nv_seed_write  */ /**< Default nv_seed_write function to use, can be undefined */
+/* #define MBEDTLS_PLATFORM_MS_TIME_TYPE_MACRO   int64_t  */ /* #define MBEDTLS_PLATFORM_MS_TIME_TYPE_MACRO   int64_t  */ /**< Default milliseconds time macro to use, can be undefined. MBEDTLS_HAVE_TIME must be enabled. It must be signed, and at least 64 bits. If it is changed from the default, MBEDTLS_PRINTF_MS_TIME must be updated to match.*/
+/* #define MBEDTLS_PRINTF_MS_TIME    PRId64  */ /**< Default fmt for printf. That's avoid compiler warning if mbedtls_ms_time_t is redefined */
 
 /** \def MBEDTLS_CHECK_RETURN
  *
@@ -3984,7 +3984,7 @@
  * If the implementation here is empty, this will effectively disable the
  * checking of functions' return values.
  */
-//#define MBEDTLS_CHECK_RETURN __attribute__((__warn_unused_result__))
+/* #define MBEDTLS_CHECK_RETURN __attribute__((__warn_unused_result__)) */
 
 /** \def MBEDTLS_IGNORE_RETURN
  *
@@ -3992,7 +3992,7 @@
  * If that function call would cause a #MBEDTLS_CHECK_RETURN warning, this
  * warning is suppressed.
  */
-//#define MBEDTLS_IGNORE_RETURN( result ) ((void) !(result))
+/* #define MBEDTLS_IGNORE_RETURN( result ) ((void) !(result)) */
 
 /* PSA options */
 /**
@@ -4005,7 +4005,7 @@
  *   #MBEDTLS_MD_SHA512 or #MBEDTLS_MD_SHA256 based on availability and
  *   on unspecified heuristics.
  */
-//#define MBEDTLS_PSA_HMAC_DRBG_MD_TYPE MBEDTLS_MD_SHA256
+/* #define MBEDTLS_PSA_HMAC_DRBG_MD_TYPE MBEDTLS_MD_SHA256 */
 
 /** \def MBEDTLS_PSA_KEY_SLOT_COUNT
  * Restrict the PSA library to supporting a maximum amount of simultaneously
@@ -4016,14 +4016,14 @@
  * If this option is unset, the library will fall back to a default value of
  * 32 keys.
  */
-//#define MBEDTLS_PSA_KEY_SLOT_COUNT 32
+/* #define MBEDTLS_PSA_KEY_SLOT_COUNT 32 */
 
 /* RSA OPTIONS */
-//#define MBEDTLS_RSA_GEN_KEY_MIN_BITS            1024 /**<  Minimum RSA key size that can be generated in bits (Minimum possible value is 128 bits) */
+/* #define MBEDTLS_RSA_GEN_KEY_MIN_BITS            1024  */ /**<  Minimum RSA key size that can be generated in bits (Minimum possible value is 128 bits) */
 
 /* SSL Cache options */
-//#define MBEDTLS_SSL_CACHE_DEFAULT_TIMEOUT       86400 /**< 1 day  */
-//#define MBEDTLS_SSL_CACHE_DEFAULT_MAX_ENTRIES      50 /**< Maximum entries in cache */
+/* #define MBEDTLS_SSL_CACHE_DEFAULT_TIMEOUT       86400  */ /**< 1 day  */
+/* #define MBEDTLS_SSL_CACHE_DEFAULT_MAX_ENTRIES      50  */ /**< Maximum entries in cache */
 
 /* SSL options */
 
@@ -4046,21 +4046,21 @@
  *
  * Uncomment to set the maximum plaintext size of the incoming I/O buffer.
  */
-//#define MBEDTLS_SSL_IN_CONTENT_LEN              16384
+/* #define MBEDTLS_SSL_IN_CONTENT_LEN              16384 */
 
 /** \def MBEDTLS_SSL_CID_IN_LEN_MAX
  *
  * The maximum length of CIDs used for incoming DTLS messages.
  *
  */
-//#define MBEDTLS_SSL_CID_IN_LEN_MAX 32
+/* #define MBEDTLS_SSL_CID_IN_LEN_MAX 32 */
 
 /** \def MBEDTLS_SSL_CID_OUT_LEN_MAX
  *
  * The maximum length of CIDs used for outgoing DTLS messages.
  *
  */
-//#define MBEDTLS_SSL_CID_OUT_LEN_MAX 32
+/* #define MBEDTLS_SSL_CID_OUT_LEN_MAX 32 */
 
 /** \def MBEDTLS_SSL_CID_TLS1_3_PADDING_GRANULARITY
  *
@@ -4076,7 +4076,7 @@
  * Note: On systems lacking division instructions,
  *       a power of two should be preferred.
  */
-//#define MBEDTLS_SSL_CID_TLS1_3_PADDING_GRANULARITY 16
+/* #define MBEDTLS_SSL_CID_TLS1_3_PADDING_GRANULARITY 16 */
 
 /** \def MBEDTLS_SSL_OUT_CONTENT_LEN
  *
@@ -4096,7 +4096,7 @@
  *
  * Uncomment to set the maximum plaintext size of the outgoing I/O buffer.
  */
-//#define MBEDTLS_SSL_OUT_CONTENT_LEN             16384
+/* #define MBEDTLS_SSL_OUT_CONTENT_LEN             16384 */
 
 /** \def MBEDTLS_SSL_DTLS_MAX_BUFFERING
  *
@@ -4113,10 +4113,10 @@
  * while buffering multiple smaller handshake messages.
  *
  */
-//#define MBEDTLS_SSL_DTLS_MAX_BUFFERING             32768
+/* #define MBEDTLS_SSL_DTLS_MAX_BUFFERING             32768 */
 
-//#define MBEDTLS_PSK_MAX_LEN               32 /**< Max size of TLS pre-shared keys, in bytes (default 256 or 384 bits) */
-//#define MBEDTLS_SSL_COOKIE_TIMEOUT        60 /**< Default expiration delay of DTLS cookies, in seconds if HAVE_TIME, or in number of cookies issued */
+/* #define MBEDTLS_PSK_MAX_LEN               32  */ /**< Max size of TLS pre-shared keys, in bytes (default 256 or 384 bits) */
+/* #define MBEDTLS_SSL_COOKIE_TIMEOUT        60  */ /**< Default expiration delay of DTLS cookies, in seconds if HAVE_TIME, or in number of cookies issued */
 
 /**
  * Complete list of ciphersuites to use, in order of preference.
@@ -4130,7 +4130,7 @@
  *
  * The value below is only an example, not the default.
  */
-//#define MBEDTLS_SSL_CIPHERSUITES MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+/* #define MBEDTLS_SSL_CIPHERSUITES MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 */
 
 /**
  * \def MBEDTLS_SSL_MAX_EARLY_DATA_SIZE
@@ -4143,7 +4143,7 @@
  * If MBEDTLS_SSL_EARLY_DATA is not defined, this default value does not
  * have any impact on the build.
  */
-//#define MBEDTLS_SSL_MAX_EARLY_DATA_SIZE        1024
+/* #define MBEDTLS_SSL_MAX_EARLY_DATA_SIZE        1024 */
 
 /**
  * \def MBEDTLS_SSL_TLS1_3_TICKET_AGE_TOLERANCE
@@ -4166,7 +4166,7 @@
  *
  * See section 8.3 of the TLS 1.3 specification(RFC 8446) for more information.
  */
-//#define MBEDTLS_SSL_TLS1_3_TICKET_AGE_TOLERANCE 6000
+/* #define MBEDTLS_SSL_TLS1_3_TICKET_AGE_TOLERANCE 6000 */
 
 /**
  * \def MBEDTLS_SSL_TLS1_3_TICKET_NONCE_LENGTH
@@ -4175,7 +4175,7 @@
  *
  * This must be less than 256.
  */
-//#define MBEDTLS_SSL_TLS1_3_TICKET_NONCE_LENGTH 32
+/* #define MBEDTLS_SSL_TLS1_3_TICKET_NONCE_LENGTH 32 */
 
 /**
  * \def MBEDTLS_SSL_TLS1_3_DEFAULT_NEW_SESSION_TICKETS
@@ -4185,10 +4185,10 @@
  * the MBEDTLS_SSL_SESSION_TICKETS option is enabled.
  *
  */
-//#define MBEDTLS_SSL_TLS1_3_DEFAULT_NEW_SESSION_TICKETS 1
+/* #define MBEDTLS_SSL_TLS1_3_DEFAULT_NEW_SESSION_TICKETS 1 */
 
 /* X509 options */
-//#define MBEDTLS_X509_MAX_INTERMEDIATE_CA   8   /**< Maximum number of intermediate CAs in a verification chain. */
-//#define MBEDTLS_X509_MAX_FILE_PATH_LEN     512 /**< Maximum length of a path/filename string in bytes including the null terminator character ('\0'). */
+/* #define MBEDTLS_X509_MAX_INTERMEDIATE_CA   8    */ /**< Maximum number of intermediate CAs in a verification chain. */
+/* #define MBEDTLS_X509_MAX_FILE_PATH_LEN     512  */ /**< Maximum length of a path/filename string in bytes including the null terminator character ('\0'). */
 
 /** \} name SECTION: Module configuration options */

--- a/include/mbedtls/md5.h
+++ b/include/mbedtls/md5.h
@@ -25,8 +25,7 @@ extern "C" {
 #endif
 
 #if !defined(MBEDTLS_MD5_ALT)
-// Regular implementation
-//
+/* Regular implementation */
 
 /**
  * \brief          MD5 context structure

--- a/include/mbedtls/nist_kw.h
+++ b/include/mbedtls/nist_kw.h
@@ -38,8 +38,7 @@ typedef enum {
 } mbedtls_nist_kw_mode_t;
 
 #if !defined(MBEDTLS_NIST_KW_ALT)
-// Regular implementation
-//
+/* Regular implementation */
 
 /**
  * \brief    The key wrapping context-type definition. The key wrapping context is passed

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -133,7 +133,7 @@ MBEDTLS_DEPRECATED typedef int mbedtls_deprecated_numeric_constant_t;
  * framework, and the framework is going to provide a replacement
  * mbedtls_platform_zeroize() using a preprocessor macro, so the function
  * declaration should be omitted.  */
-#if !defined(MBEDTLS_TEST_DEFINES_ZEROIZE) //no-check-names
+#if !defined(MBEDTLS_TEST_DEFINES_ZEROIZE) /* //no-check-names */
 /**
  * \brief       Securely zeroize a buffer
  *

--- a/include/mbedtls/ripemd160.h
+++ b/include/mbedtls/ripemd160.h
@@ -21,8 +21,7 @@ extern "C" {
 #endif
 
 #if !defined(MBEDTLS_RIPEMD160_ALT)
-// Regular implementation
-//
+/* Regular implementation */
 
 /**
  * \brief          RIPEMD-160 context structure

--- a/include/mbedtls/rsa.h
+++ b/include/mbedtls/rsa.h
@@ -70,8 +70,7 @@ extern "C" {
 #endif
 
 #if !defined(MBEDTLS_RSA_ALT)
-// Regular implementation
-//
+/* Regular implementation */
 
 #if !defined(MBEDTLS_RSA_GEN_KEY_MIN_BITS)
 #define MBEDTLS_RSA_GEN_KEY_MIN_BITS 1024

--- a/include/mbedtls/sha1.h
+++ b/include/mbedtls/sha1.h
@@ -31,8 +31,7 @@ extern "C" {
 #endif
 
 #if !defined(MBEDTLS_SHA1_ALT)
-// Regular implementation
-//
+/* Regular implementation */
 
 /**
  * \brief          The SHA-1 context structure.

--- a/include/mbedtls/sha256.h
+++ b/include/mbedtls/sha256.h
@@ -27,8 +27,7 @@ extern "C" {
 #endif
 
 #if !defined(MBEDTLS_SHA256_ALT)
-// Regular implementation
-//
+/* Regular implementation */
 
 /**
  * \brief          The SHA-256 context structure.

--- a/include/mbedtls/sha512.h
+++ b/include/mbedtls/sha512.h
@@ -26,8 +26,7 @@ extern "C" {
 #endif
 
 #if !defined(MBEDTLS_SHA512_ALT)
-// Regular implementation
-//
+/* Regular implementation */
 
 /**
  * \brief          The SHA-512 context structure.

--- a/include/mbedtls/timing.h
+++ b/include/mbedtls/timing.h
@@ -20,8 +20,7 @@ extern "C" {
 #endif
 
 #if !defined(MBEDTLS_TIMING_ALT)
-// Regular implementation
-//
+/* Regular implementation */
 
 /**
  * \brief          timer structure

--- a/include/mbedtls/x509_crt.h
+++ b/include/mbedtls/x509_crt.h
@@ -968,7 +968,7 @@ void mbedtls_x509write_crt_set_version(mbedtls_x509write_cert *ctx, int version)
  */
 int MBEDTLS_DEPRECATED mbedtls_x509write_crt_set_serial(
     mbedtls_x509write_cert *ctx, const mbedtls_mpi *serial);
-#endif // MBEDTLS_BIGNUM_C && !MBEDTLS_DEPRECATED_REMOVED
+#endif /* MBEDTLS_BIGNUM_C && !MBEDTLS_DEPRECATED_REMOVED */
 
 /**
  * \brief           Set the serial number for a Certificate.

--- a/include/psa/crypto_legacy.h
+++ b/include/psa/crypto_legacy.h
@@ -19,7 +19,7 @@
 #ifndef MBEDTLS_PSA_CRYPTO_LEGACY_H
 #define MBEDTLS_PSA_CRYPTO_LEGACY_H
 
-#if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR) //no-check-names
+#if defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR) /* //no-check-names */
 #if !defined(PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_BASIC)
 #define PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_BASIC      1
 #endif
@@ -37,7 +37,7 @@
 #endif
 #endif
 
-#if defined(PSA_WANT_KEY_TYPE_RSA_KEY_PAIR) //no-check-names
+#if defined(PSA_WANT_KEY_TYPE_RSA_KEY_PAIR) /* //no-check-names */
 #if !defined(PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_BASIC)
 #define PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_BASIC      1
 #endif
@@ -52,7 +52,7 @@
 #endif
 #endif
 
-#if defined(MBEDTLS_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR) //no-check-names
+#if defined(MBEDTLS_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR) /* //no-check-names */
 #if !defined(MBEDTLS_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_BASIC)
 #define MBEDTLS_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR_BASIC
 #endif
@@ -70,7 +70,7 @@
 #endif
 #endif
 
-#if defined(MBEDTLS_PSA_ACCEL_KEY_TYPE_RSA_KEY_PAIR) //no-check-names
+#if defined(MBEDTLS_PSA_ACCEL_KEY_TYPE_RSA_KEY_PAIR) /* //no-check-names */
 #if !defined(MBEDTLS_PSA_ACCEL_KEY_TYPE_RSA_KEY_PAIR_BASIC)
 #define MBEDTLS_PSA_ACCEL_KEY_TYPE_RSA_KEY_PAIR_BASIC
 #endif

--- a/include/psa/crypto_platform.h
+++ b/include/psa/crypto_platform.h
@@ -72,7 +72,7 @@ static inline int mbedtls_key_owner_id_equal(mbedtls_key_owner_id_t id1,
 #if defined(MBEDTLS_PSA_CRYPTO_SPM)
 #define PSA_CRYPTO_SECURE 1
 #include "crypto_spe.h"
-#endif // MBEDTLS_PSA_CRYPTO_SPM
+#endif /* MBEDTLS_PSA_CRYPTO_SPM */
 
 #if defined(MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG)
 /** The type of the context passed to mbedtls_psa_external_get_random().


### PR DESCRIPTION
Replace C99 comments in the headers with C90 compatible comments.

## Description

C99 comments in the headers will cause strictly C90 programs/libraries that use mbedTLS to fail to compile. The simple answer is to replace the `//` comments with `/*` and `*/`.


## PR checklist

- [x] **changelog** not required
- [x] **backport** not required
- [x] **tests** not required