### PR TITLE
Fix typo in psa_key_production_parameters_t doc: 65535 should be 65537

### DIFF
--- a/include/psa/crypto_types.h
+++ b/include/psa/crypto_types.h
@@ -469,7 +469,7 @@ typedef uint16_t psa_key_derivation_step_t;
  *     - \c flags: must be 0.
  *     - \c data: the public exponent, in little-endian order.
  *       This must be an odd integer and must not be 1.
- *       Implementations must support 65535, should support 3 and may
+ *       Implementations must support 65537, should support 3 and may
  *       support other values.
  *       When not using a driver, Mbed TLS supports values up to \c INT_MAX.
  *       If this is empty or if the custom production parameters are omitted


### PR DESCRIPTION
## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [ ] **changelog** ~provided, or~ not required
- [ ] **backport** ~done, or~ not required - `psa_generate_key_ext()` was added to `development` only
- [ ] **tests** ~provided, or~ not required
