### PR TITLE
[Backport 2.28] Fix wrong dependencies in test cases

### DIFF
--- a/tests/include/test/drivers/key_management.h
+++ b/tests/include/test/drivers/key_management.h
@@ -30,6 +30,10 @@ typedef struct {
     /* Count the amount of times one of the key management driver functions
      * is called. */
     unsigned long hits;
+    /* Subset of hits which only counts public key export operations */
+    unsigned long hits_export_public_key;
+    /* Subset of hits which only counts key generation operations */
+    unsigned long hits_generate_key;
     /* Location of the last key management driver called to import a key. */
     psa_key_location_t location;
 } mbedtls_test_driver_key_management_hooks_t;
@@ -38,7 +42,7 @@ typedef struct {
  * sense that no PSA specification will assign a meaning to this location
  * (stated first in version 1.0.1 of the specification) and that it is not
  * used as a location of an opaque test drivers. */
-#define MBEDTLS_TEST_DRIVER_KEY_MANAGEMENT_INIT { NULL, 0, PSA_SUCCESS, 0, 0x800000 }
+#define MBEDTLS_TEST_DRIVER_KEY_MANAGEMENT_INIT { NULL, 0, PSA_SUCCESS, 0, 0, 0, 0x800000 }
 static inline mbedtls_test_driver_key_management_hooks_t
 mbedtls_test_driver_key_management_hooks_init(void)
 {

--- a/tests/src/drivers/test_driver_key_management.c
+++ b/tests/src/drivers/test_driver_key_management.c
@@ -93,6 +93,7 @@ psa_status_t mbedtls_test_transparent_generate_key(
     uint8_t *key, size_t key_size, size_t *key_length)
 {
     ++mbedtls_test_driver_key_management_hooks.hits;
+    ++mbedtls_test_driver_key_management_hooks.hits_generate_key;
 
     if (mbedtls_test_driver_key_management_hooks.forced_status != PSA_SUCCESS) {
         return mbedtls_test_driver_key_management_hooks.forced_status;

--- a/tests/src/drivers/test_driver_key_management.c
+++ b/tests/src/drivers/test_driver_key_management.c
@@ -292,6 +292,7 @@ psa_status_t mbedtls_test_transparent_export_public_key(
     uint8_t *data, size_t data_size, size_t *data_length)
 {
     ++mbedtls_test_driver_key_management_hooks.hits;
+    ++mbedtls_test_driver_key_management_hooks.hits_export_public_key;
 
     if (mbedtls_test_driver_key_management_hooks.forced_status != PSA_SUCCESS) {
         return mbedtls_test_driver_key_management_hooks.forced_status;

--- a/tests/suites/test_suite_psa_crypto_driver_wrappers.data
+++ b/tests/suites/test_suite_psa_crypto_driver_wrappers.data
@@ -238,6 +238,7 @@ generate_key through transparent driver: fake
 generate_key:PSA_SUCCESS:"ab45435712649cb30bbddac49197eebf2740ffc7f874d9244c3460f54f322d3a":PSA_SUCCESS
 
 generate_key through transparent driver: in-driver
+depends_on:MBEDTLS_PSA_ACCEL_KEY_TYPE_ECC_KEY_PAIR
 generate_key:PSA_SUCCESS:"":PSA_SUCCESS
 
 generate_key through transparent driver: fallback

--- a/tests/suites/test_suite_psa_crypto_driver_wrappers.data
+++ b/tests/suites/test_suite_psa_crypto_driver_wrappers.data
@@ -241,7 +241,7 @@ generate_key through transparent driver: in-driver
 generate_key:PSA_SUCCESS:"":PSA_SUCCESS
 
 generate_key through transparent driver: fallback
-depends_on:MBEDTLS_PSA_BUILTIN_KEY_TYPE_ECC_KEY_PAIR
+depends_on:MBEDTLS_PSA_BUILTIN_KEY_TYPE_ECC_KEY_PAIR:MBEDTLS_PSA_BUILTIN_ECC_SECP_R1_256
 generate_key:PSA_ERROR_NOT_SUPPORTED:"":PSA_SUCCESS
 
 generate_key through transparent driver: fallback not available

--- a/tests/suites/test_suite_psa_crypto_driver_wrappers.function
+++ b/tests/suites/test_suite_psa_crypto_driver_wrappers.function
@@ -426,6 +426,7 @@ void export_key(int force_status_arg,
 
     mbedtls_test_driver_key_management_hooks.hits = 0;
     mbedtls_test_driver_key_management_hooks.forced_status = force_status;
+    mbedtls_test_driver_key_management_hooks.hits_export_public_key = 0;
 
     if (PSA_KEY_TYPE_IS_ECC_PUBLIC_KEY(output_key_type)) {
         actual_status = psa_export_public_key(handle,
@@ -442,7 +443,7 @@ void export_key(int force_status_arg,
 
     if (PSA_KEY_TYPE_IS_ECC_PUBLIC_KEY(output_key_type) &&
         !PSA_KEY_TYPE_IS_ECC_PUBLIC_KEY(input_key_type)) {
-        TEST_EQUAL(mbedtls_test_driver_key_management_hooks.hits, 1);
+        TEST_EQUAL(mbedtls_test_driver_key_management_hooks.hits_export_public_key, 1);
     }
 
     if (actual_status == PSA_SUCCESS) {

--- a/tests/suites/test_suite_psa_crypto_driver_wrappers.function
+++ b/tests/suites/test_suite_psa_crypto_driver_wrappers.function
@@ -300,13 +300,14 @@ void generate_key(int force_status_arg,
                 fake_output->len;
     }
 
-    mbedtls_test_driver_key_management_hooks.hits = 0;
-    mbedtls_test_driver_key_management_hooks.forced_status = force_status;
-
     PSA_ASSERT(psa_crypto_init());
 
+    mbedtls_test_driver_key_management_hooks.hits = 0;
+    mbedtls_test_driver_key_management_hooks.hits_generate_key = 0;
+    mbedtls_test_driver_key_management_hooks.forced_status = force_status;
+
     actual_status = psa_generate_key(&attributes, &key);
-    TEST_EQUAL(mbedtls_test_driver_key_management_hooks.hits, 1);
+    TEST_EQUAL(mbedtls_test_driver_key_management_hooks.hits_generate_key, 1);
     TEST_EQUAL(actual_status, expected_status);
 
     if (actual_status == PSA_SUCCESS) {

--- a/tests/suites/test_suite_psa_crypto_se_driver_hal.function
+++ b/tests/suites/test_suite_psa_crypto_se_driver_hal.function
@@ -669,10 +669,8 @@ static int smoke_test_key(mbedtls_svc_key_id_t key)
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     psa_mac_operation_t mac_operation = PSA_MAC_OPERATION_INIT;
     psa_cipher_operation_t cipher_operation = PSA_CIPHER_OPERATION_INIT;
-#if defined(MBEDTLS_SHA256_C)
     psa_key_derivation_operation_t derivation_operation =
         PSA_KEY_DERIVATION_OPERATION_INIT;
-#endif
     uint8_t buffer[80]; /* large enough for a public key for ECDH */
     size_t length;
     mbedtls_svc_key_id_t key2 = MBEDTLS_SVC_KEY_ID_INIT;

--- a/tests/suites/test_suite_psa_crypto_se_driver_hal.function
+++ b/tests/suites/test_suite_psa_crypto_se_driver_hal.function
@@ -13,6 +13,19 @@
 #include "psa/internal_trusted_storage.h"
 #endif
 
+/* Same in library/psa_crypto.c */
+#if defined(MBEDTLS_PSA_BUILTIN_ALG_HKDF) ||          \
+    defined(MBEDTLS_PSA_BUILTIN_ALG_HKDF_EXTRACT) ||  \
+    defined(MBEDTLS_PSA_BUILTIN_ALG_HKDF_EXPAND)
+#define BUILTIN_ALG_ANY_HKDF 1
+#endif
+#if defined(BUILTIN_ALG_ANY_HKDF) || \
+    defined(MBEDTLS_PSA_BUILTIN_ALG_TLS12_PRF) || \
+    defined(MBEDTLS_PSA_BUILTIN_ALG_TLS12_PSK_TO_MS) || \
+    defined(MBEDTLS_PSA_BUILTIN_ALG_TLS12_ECJPAKE_TO_PMS) || \
+    defined(PSA_HAVE_SOFT_PBKDF2)
+#define AT_LEAST_ONE_BUILTIN_KDF
+#endif
 
 /****************************************************************/
 /* Test driver helpers */
@@ -714,7 +727,7 @@ static int smoke_test_key(mbedtls_svc_key_id_t key)
                                         buffer, sizeof(buffer), NULL, 0,
                                         buffer, sizeof(buffer), &length));
 
-#if defined(MBEDTLS_SHA256_C)
+#if defined(MBEDTLS_SHA256_C) && defined(MBEDTLS_PSA_BUILTIN_ALG_HKDF)
     /* Try the key in a plain key derivation. */
     PSA_ASSERT(psa_key_derivation_setup(&derivation_operation,
                                         PSA_ALG_HKDF(PSA_ALG_SHA_256)));
@@ -747,7 +760,9 @@ static int smoke_test_key(mbedtls_svc_key_id_t key)
                          alg, key, buffer, length,
                          buffer, sizeof(buffer), &length));
     }
-#endif /* MBEDTLS_SHA256_C */
+#else
+    (void) derivation_operation;
+#endif /* MBEDTLS_SHA256_C && MBEDTLS_PSA_BUILTIN_ALG_HKDF */
 
     ok = 1;
 

--- a/tests/suites/test_suite_x509parse.data
+++ b/tests/suites/test_suite_x509parse.data
@@ -327,7 +327,7 @@ depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_SHA512_C:MBEDTLS_RSA_C
 mbedtls_x509_csr_info:"data_files/parse_input/server1.req.sha512":"CSR version   \: 1\nsubject name  \: C=NL, O=PolarSSL, CN=PolarSSL Server 1\nsigned using  \: RSA with SHA-512\nRSA key size  \: 2048 bits\n"
 
 X509 CSR Information RSA with SHA-256, containing commas
-depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_SHA256_C:MBEDTLS_RSA_C:MBEDTS_X509_INFO
+depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_SHA256_C:MBEDTLS_RSA_C
 mbedtls_x509_csr_info:"data_files/parse_input/server1.req.commas.sha256":"CSR version   \: 1\nsubject name  \: C=NL, O=PolarSSL\\, Commas, CN=PolarSSL Server 1\nsigned using  \: RSA with SHA-256\nRSA key size  \: 2048 bits\n"
 
 X509 CSR Information EC with SHA1

--- a/tests/suites/test_suite_x509parse.function
+++ b/tests/suites/test_suite_x509parse.function
@@ -800,7 +800,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_FS_IO:MBEDTLS_X509_CRT_PARSE_C:!MBEDTLS_X509_REMOVE_INFO */
+/* BEGIN_CASE depends_on:MBEDTLS_FS_IO:MBEDTLS_X509_CRT_PARSE_C */
 void mbedtls_x509_dn_gets_subject_replace(char *crt_file,
                                           char *new_subject_ou,
                                           char *result_str,


### PR DESCRIPTION
This is the 2.28 backport of ~#8594~ #8997

Not trivial, as some commits were not applicable, the others had conflicts. Details:

- a2030bfee984 Correct dependancy on `MBEDTLS_X509_INFO` for x509parse
  -> typo present but different resolution
- 77a6940b1530 Fix typo in ssl test suite
  -> typo not present in 2.28, nothing to do
- 07d215646295 Fix wrong dependency in psa_crypto_pake suite
  -> test suite not present in 2.28, nothing to do
- b4ac2ca9ab8c Fix wrong dependency in psa_crypto_driver_wrappers suite
  -> typo not present in 2.28, nothing to do (and no other MBEDTLS_PSA_WANT)
- 6a42399e26f1 Add missing definition of AT_LEAST_ONE_BUILTIN_KDF
  -> applied, contextual differences + fixed the `&` vs `&&` thing at the same time
- aaf66521dfd0 Add missing dependency of fallback test in driver wrappers suite
  -> applied, contextual differences
- f922bc2f6815 Fix failures in psa_cryto_driver_wrappers suite
  -> applied, contextual differences

## PR checklist

- [x] **changelog** not required - test only
- [x] **backport** done: this is the backport
- [x] **tests** not required