### PR TITLE
Fix compilation when memcpy() is a function-like macro

### DIFF
--- a/ChangeLog.d/fix-compilation-when-memcpy-is-function-like-macro.txt
+++ b/ChangeLog.d/fix-compilation-when-memcpy-is-function-like-macro.txt
@@ -1,0 +1,2 @@
+Bugfix
+   * Fix compilation error when memcpy() is a function-like macros. Fixes #8994.

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -193,10 +193,12 @@ static void ssl_tls13_create_verify_structure(const unsigned char *transcript_ha
     idx = 64;
 
     if (from == MBEDTLS_SSL_IS_CLIENT) {
-        memcpy(verify_buffer + idx, MBEDTLS_SSL_TLS1_3_LBL_WITH_LEN(client_cv));
+        memcpy(verify_buffer + idx, mbedtls_ssl_tls13_labels.client_cv,
+               MBEDTLS_SSL_TLS1_3_LBL_LEN(client_cv));
         idx += MBEDTLS_SSL_TLS1_3_LBL_LEN(client_cv);
     } else { /* from == MBEDTLS_SSL_IS_SERVER */
-        memcpy(verify_buffer + idx, MBEDTLS_SSL_TLS1_3_LBL_WITH_LEN(server_cv));
+        memcpy(verify_buffer + idx, mbedtls_ssl_tls13_labels.server_cv,
+               MBEDTLS_SSL_TLS1_3_LBL_LEN(server_cv));
         idx += MBEDTLS_SSL_TLS1_3_LBL_LEN(server_cv);
     }
 


### PR DESCRIPTION
Fixes #8994

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** provided
- [x] **backport 2.28** not required - this code is in TLS 1.3, which is not present in 2.28
- [x] **backport 3.6** done - #9000
- [x] **tests** ~provided, or~ not required
