### PR TITLE
[Backport 3.6] Clarify the documentation of mbedtls_pk_setup_opaque

### DIFF
--- a/docs/use-psa-crypto.md
+++ b/docs/use-psa-crypto.md
@@ -75,13 +75,8 @@ operations and its public part can be exported.
 
 **Benefits:** isolation of long-term secrets, use of PSA Crypto drivers.
 
-**Limitations:** can only wrap a key pair, can only use it for private key
-operations. (That is, signature generation, and for RSA decryption too.)
-Note: for ECDSA, currently this uses randomized ECDSA while Mbed TLS uses
-deterministic ECDSA by default. The following operations are not supported
-with a context set this way, while they would be available with a normal
-context: `mbedtls_pk_check_pair()`, `mbedtls_pk_debug()`, all public key
-operations.
+**Limitations:** please refer to the documentation of `mbedtls_pk_setup_opaque()`
+for a full list of supported operations and limitations.
 
 **Use in X.509 and TLS:** opt-in. The application needs to construct the PK context
 using the new API in order to get the benefits; it can then pass the

--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -374,10 +374,19 @@ int mbedtls_pk_setup(mbedtls_pk_context *ctx, const mbedtls_pk_info_t *info);
  *                  operations and, based on the key type, used algorithms will be:
  *                  * EC:
  *                      * verify: #PSA_ALG_ECDSA_ANY;
- *                      * sign: try both deterministic and non-deterministic ECDSA.
+ *                      * sign: try #PSA_ALG_DETERMINISTIC_ECDSA() first and, in
+ *                        case it fails, try with #PSA_ALG_ECDSA().
  *                  * RSA:
  *                      * sign: #PSA_ALG_RSA_PKCS1V15_SIGN();
- *                      * decrypt: #PSA_ALG_RSA_PKCS1V15_CRYPT.
+ *                      * sign_ext: use the algorithm associated with the wrapped
+ *                        PSA key;
+ *                      * verify: not supported;
+ *                      * verify_ext: not supported;
+ *                      * decrypt: #PSA_ALG_RSA_PKCS1V15_CRYPT;
+ *                      * encrypt: not supported.
+ *                  In order to have above mentioned operations to succeed it is
+ *                  mandatory that the wrapped PSA key allows the specified
+ *                  algorithm in its policy.
  *
  * \param ctx       The context to initialize. It must be empty (type NONE).
  * \param key       The PSA key to wrap, which must hold an ECC or RSA key

--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -361,10 +361,10 @@ int mbedtls_pk_setup(mbedtls_pk_context *ctx, const mbedtls_pk_info_t *info);
 /**
  * \brief Initialize a PK context to wrap a PSA key.
  *
- * This function helps creating a PK context which wraps a PSA key. The PSA wrapped
- * key must be an EC or RSA key pair (DH is not suported in PK module).
+ * This function creates a PK context which wraps a PSA key. The PSA wrapped
+ * key must be an EC or RSA key pair (DH is not suported in the PK module).
  *
- * Under the hood PSA functions are used to perform the required
+ * Under the hood PSA functions will be used to perform the required
  * operations and, based on the key type, used algorithms will be:
  * * EC:
  *     * verify, verify_ext, sign, sign_ext: ECDSA.

--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -361,23 +361,27 @@ int mbedtls_pk_setup(mbedtls_pk_context *ctx, const mbedtls_pk_info_t *info);
 /**
  * \brief           Initialize a PK context to wrap a PSA key.
  *
- * \note            This function replaces mbedtls_pk_setup() for contexts
- *                  that wrap a (possibly opaque) PSA key instead of
- *                  storing and manipulating the key material directly.
+ *                  This function helps creating a PK context which wraps a
+ *                  PSA key. The PSA wrapped key must:
+ *                  * remain valid as long as the wrapping PK context is in use,
+ *                    that is at least between the point this function is
+ *                    called and the point mbedtls_pk_free() is called on this
+ *                    context;
+ *                  * be a key pair;
+ *                  * be an EC or RSA type (DH is not suported in PK module).
+ *
+ *                  Under the hood PSA functions are used to perform the required
+ *                  operations and, based on the key type, used algorithms will be:
+ *                  * EC:
+ *                      * verify: #PSA_ALG_ECDSA_ANY;
+ *                      * sign: try both deterministic and non-deterministic ECDSA.
+ *                  * RSA:
+ *                      * sign: #PSA_ALG_RSA_PKCS1V15_SIGN();
+ *                      * decrypt: #PSA_ALG_RSA_PKCS1V15_CRYPT.
  *
  * \param ctx       The context to initialize. It must be empty (type NONE).
  * \param key       The PSA key to wrap, which must hold an ECC or RSA key
  *                  pair (see notes below).
- *
- * \note            The wrapped key must remain valid as long as the
- *                  wrapping PK context is in use, that is at least between
- *                  the point this function is called and the point
- *                  mbedtls_pk_free() is called on this context. The wrapped
- *                  key might then be independently used or destroyed.
- *
- * \note            This function is currently only available for ECC or RSA
- *                  key pairs (that is, keys containing private key material).
- *                  Support for other key types may be added later.
  *
  * \return          \c 0 on success.
  * \return          #MBEDTLS_ERR_PK_BAD_INPUT_DATA on invalid input

--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -390,7 +390,8 @@ int mbedtls_pk_setup(mbedtls_pk_context *ctx, const mbedtls_pk_info_t *info);
  * \return    \c 0 on success.
  * \return    #MBEDTLS_ERR_PK_BAD_INPUT_DATA on invalid input (context already
  *            used, invalid key identifier).
- * \return    #MBEDTLS_ERR_PK_FEATURE_UNAVAILABLE if the key is not an ECC key pair.
+ * \return    #MBEDTLS_ERR_PK_FEATURE_UNAVAILABLE if the key is not an ECC or
+ *            RSA key pair.
  * \return    #MBEDTLS_ERR_PK_ALLOC_FAILED on allocation failure.
  */
 int mbedtls_pk_setup_opaque(mbedtls_pk_context *ctx,

--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -359,38 +359,34 @@ int mbedtls_pk_setup(mbedtls_pk_context *ctx, const mbedtls_pk_info_t *info);
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
 /**
- * \brief           Initialize a PK context to wrap a PSA key.
+ * \brief Initialize a PK context to wrap a PSA key.
  *
- *                  This function helps creating a PK context which wraps a
- *                  PSA key. The PSA wrapped key must be an EC or RSA key pair
- *                  (DH is not suported in PK module).
+ * This function helps creating a PK context which wraps a PSA key. The PSA wrapped
+ * key must be an EC or RSA key pair (DH is not suported in PK module).
  *
- *                  Under the hood PSA functions are used to perform the required
- *                  operations and, based on the key type, used algorithms will be:
- *                  * EC:
- *                      * verify, verify_ext, sign, sign_ext: ECDSA.
- *                  * RSA:
- *                      * sign, sign_ext, decrypt: use the primary algorithm in
- *                        the wrapped PSA key;
- *                      * verify, verify_ext, encrypt: not supported.
+ * Under the hood PSA functions are used to perform the required
+ * operations and, based on the key type, used algorithms will be:
+ * * EC:
+ *     * verify, verify_ext, sign, sign_ext: ECDSA.
+ * * RSA:
+ *     * sign, sign_ext, decrypt: use the primary algorithm in the wrapped PSA key;
+ *     * verify, verify_ext, encrypt: not supported.
  *
- *                  In order for the above operations to succeed, the policy of
- *                  the wrapped PSA key must allow the specified algorithm.
+ * In order for the above operations to succeed, the policy of the wrapped PSA
+ * key must allow the specified algorithm.
  *
- * \warning         The PSA wrapped key must remain valid as long as the wrapping
- *                  PK context is in use, that is at least between the point this
- *                  function is called and the point mbedtls_pk_free() is called
- *                  on this context.
+ * \warning The PSA wrapped key must remain valid as long as the wrapping PK
+ *          context is in use, that is at least between the point this function
+ *          is called and the point mbedtls_pk_free() is called on this context.
  *
- * \param ctx       The context to initialize. It must be empty (type NONE).
- * \param key       The PSA key to wrap, which must hold an ECC or RSA key pair.
+ * \param ctx The context to initialize. It must be empty (type NONE).
+ * \param key The PSA key to wrap, which must hold an ECC or RSA key pair.
  *
- * \return          \c 0 on success.
- * \return          #MBEDTLS_ERR_PK_BAD_INPUT_DATA on invalid input
- *                  (context already used, invalid key identifier).
- * \return          #MBEDTLS_ERR_PK_FEATURE_UNAVAILABLE if the key is not an
- *                  ECC key pair.
- * \return          #MBEDTLS_ERR_PK_ALLOC_FAILED on allocation failure.
+ * \return    \c 0 on success.
+ * \return    #MBEDTLS_ERR_PK_BAD_INPUT_DATA on invalid input (context already
+ *            used, invalid key identifier).
+ * \return    #MBEDTLS_ERR_PK_FEATURE_UNAVAILABLE if the key is not an ECC key pair.
+ * \return    #MBEDTLS_ERR_PK_ALLOC_FAILED on allocation failure.
  */
 int mbedtls_pk_setup_opaque(mbedtls_pk_context *ctx,
                             const mbedtls_svc_key_id_t key);

--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -362,33 +362,28 @@ int mbedtls_pk_setup(mbedtls_pk_context *ctx, const mbedtls_pk_info_t *info);
  * \brief           Initialize a PK context to wrap a PSA key.
  *
  *                  This function helps creating a PK context which wraps a
- *                  PSA key. The PSA wrapped key must:
- *                  * remain valid as long as the wrapping PK context is in use,
- *                    that is at least between the point this function is
- *                    called and the point mbedtls_pk_free() is called on this
- *                    context;
- *                  * be a key pair;
- *                  * be an EC or RSA type (DH is not suported in PK module).
+ *                  PSA key. The PSA wrapped key must be an EC or RSA key pair
+ *                  (DH is not suported in PK module).
  *
  *                  Under the hood PSA functions are used to perform the required
  *                  operations and, based on the key type, used algorithms will be:
  *                  * EC:
- *                      * verify, verify_ext: #PSA_ALG_ECDSA_ANY;
- *                      * sign, sign_ext: try #PSA_ALG_DETERMINISTIC_ECDSA()
- *                        first and, in case it fails, try with #PSA_ALG_ECDSA().
+ *                      * verify, verify_ext, sign, sign_ext: ECDSA.
  *                  * RSA:
- *                      * sign, sign_ext: use the algorithm associated with the
- *                        wrapped PSA key;
- *                      * verify: not supported;
- *                      * verify_ext: not supported;
- *                      * decrypt: #PSA_ALG_RSA_PKCS1V15_CRYPT;
- *                      * encrypt: not supported.
+ *                      * sign, sign_ext, decrypt: use the primary algorithm in
+ *                        the wrapped PSA key;
+ *                      * verify, verify_ext, encrypt: not supported.
+ *
  *                  In order for the above operations to succeed, the policy of
  *                  the wrapped PSA key must allow the specified algorithm.
  *
+ * \warning         The PSA wrapped key must remain valid as long as the wrapping
+ *                  PK context is in use, that is at least between the point this
+ *                  function is called and the point mbedtls_pk_free() is called
+ *                  on this context.
+ *
  * \param ctx       The context to initialize. It must be empty (type NONE).
- * \param key       The PSA key to wrap, which must hold an ECC or RSA key
- *                  pair (see notes below).
+ * \param key       The PSA key to wrap, which must hold an ECC or RSA key pair.
  *
  * \return          \c 0 on success.
  * \return          #MBEDTLS_ERR_PK_BAD_INPUT_DATA on invalid input

--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -377,6 +377,9 @@ int mbedtls_pk_setup(mbedtls_pk_context *ctx, const mbedtls_pk_info_t *info);
  * In order for the above operations to succeed, the policy of the wrapped PSA
  * key must allow the specified algorithm.
  *
+ * Opaque PK contexts wrapping an EC keys also support \c mbedtls_pk_check_pair(),
+ * whereas RSA ones do not.
+ *
  * \warning The PSA wrapped key must remain valid as long as the wrapping PK
  *          context is in use, that is at least between the point this function
  *          is called and the point mbedtls_pk_free() is called on this context.

--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -377,9 +377,8 @@ int mbedtls_pk_setup(mbedtls_pk_context *ctx, const mbedtls_pk_info_t *info);
  *                      * sign, sign_ext: try #PSA_ALG_DETERMINISTIC_ECDSA()
  *                        first and, in case it fails, try with #PSA_ALG_ECDSA().
  *                  * RSA:
- *                      * sign: #PSA_ALG_RSA_PKCS1V15_SIGN();
- *                      * sign_ext: use the algorithm associated with the wrapped
- *                        PSA key;
+ *                      * sign, sign_ext: use the algorithm associated with the
+ *                        wrapped PSA key;
  *                      * verify: not supported;
  *                      * verify_ext: not supported;
  *                      * decrypt: #PSA_ALG_RSA_PKCS1V15_CRYPT;

--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -373,9 +373,9 @@ int mbedtls_pk_setup(mbedtls_pk_context *ctx, const mbedtls_pk_info_t *info);
  *                  Under the hood PSA functions are used to perform the required
  *                  operations and, based on the key type, used algorithms will be:
  *                  * EC:
- *                      * verify: #PSA_ALG_ECDSA_ANY;
- *                      * sign: try #PSA_ALG_DETERMINISTIC_ECDSA() first and, in
- *                        case it fails, try with #PSA_ALG_ECDSA().
+ *                      * verify, verify_ext: #PSA_ALG_ECDSA_ANY;
+ *                      * sign, sign_ext: try #PSA_ALG_DETERMINISTIC_ECDSA()
+ *                        first and, in case it fails, try with #PSA_ALG_ECDSA().
  *                  * RSA:
  *                      * sign: #PSA_ALG_RSA_PKCS1V15_SIGN();
  *                      * sign_ext: use the algorithm associated with the wrapped
@@ -384,9 +384,8 @@ int mbedtls_pk_setup(mbedtls_pk_context *ctx, const mbedtls_pk_info_t *info);
  *                      * verify_ext: not supported;
  *                      * decrypt: #PSA_ALG_RSA_PKCS1V15_CRYPT;
  *                      * encrypt: not supported.
- *                  In order to have above mentioned operations to succeed it is
- *                  mandatory that the wrapped PSA key allows the specified
- *                  algorithm in its policy.
+ *                  In order for the above operations to succeed, the policy of
+ *                  the wrapped PSA key must allow the specified algorithm.
  *
  * \param ctx       The context to initialize. It must be empty (type NONE).
  * \param key       The PSA key to wrap, which must hold an ECC or RSA key

--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -369,7 +369,9 @@ int mbedtls_pk_setup(mbedtls_pk_context *ctx, const mbedtls_pk_info_t *info);
  * * EC:
  *     * verify, verify_ext, sign, sign_ext: ECDSA.
  * * RSA:
- *     * sign, sign_ext, decrypt: use the primary algorithm in the wrapped PSA key;
+ *     * sign, decrypt: use the primary algorithm in the wrapped PSA key;
+ *     * sign_ext: RSA PSS if the pk_type is #MBEDTLS_PK_RSASSA_PSS, otherwise
+ *       it falls back to the sign() case;
  *     * verify, verify_ext, encrypt: not supported.
  *
  * In order for the above operations to succeed, the policy of the wrapped PSA

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -2082,6 +2082,19 @@ void pk_psa_wrap_sign_ext(int pk_type, int key_bits, int key_pk_type, int md_alg
     memset(hash, 0x2a, sizeof(hash));
     memset(sig, 0, sizeof(sig));
 
+#if defined(MBEDTLS_PKCS1_V21)
+    /* Check that trying to use the wrong pk_type in sign_ext() results in a failure.
+     * The PSA key was setup to use PKCS1 v1.5 signature algorithm, but here we try
+     * to use it for PSS (PKCS1 v2.1) and it should fail. */
+    if (key_pk_type == MBEDTLS_PK_RSA) {
+        TEST_EQUAL(mbedtls_pk_sign_ext(MBEDTLS_PK_RSASSA_PSS, &pk, md_alg, hash, hash_len,
+                                       sig, sizeof(sig), &sig_len,
+                                       mbedtls_test_rnd_std_rand, NULL),
+                   MBEDTLS_ERR_RSA_BAD_INPUT_DATA);
+    }
+#endif /* MBEDTLS_PKCS1_V21 */
+
+    /* Perform sign_ext() with the correct pk_type. */
     TEST_EQUAL(mbedtls_pk_sign_ext(key_pk_type, &pk, md_alg, hash, hash_len,
                                    sig, sizeof(sig), &sig_len,
                                    mbedtls_test_rnd_std_rand, NULL), 0);


### PR DESCRIPTION
This is the 3.6 backport of #8937 (all commits just cherry-picked from there). 

## PR checklist

- [x] **changelog** not required, as in the original PR
- [x] **backport** not required since this is a backport
- [x] **tests** provided as in the original PR
