### PR TITLE
Add 3.6 backport checkbox to the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,8 @@ Please write a few sentences describing the overall goals of the pull request's 
 Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")
 
 - [ ] **changelog** provided, or not required
-- [ ] **backport** done, or not required
+- [ ] **3.6 backport** done, or not required
+- [ ] **2.28 backport** done, or not required
 - [ ] **tests** provided, or not required
 
 


### PR DESCRIPTION
## Description

We now have two LTS branches to backport to.

## PR checklist

- [x] **changelog** not required - doc only
- [x] **backport** not required - PR template is taken from the default branch
- [x] **tests** not required - doc only
