### PR TITLE
[2.28] Fix compat.sh tests (reported as) not executed

### DIFF
--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -655,14 +655,18 @@ add_gnutls_ciphersuites()
             ;;
 
         "RSA")
-            # Not actually supported with all GnuTLS versions. See
-            # GNUTLS_HAS_TLS1_RSA_NULL_SHA256= below.
-            M_CIPHERS="$M_CIPHERS                               \
-                    TLS-RSA-WITH-NULL-SHA256                    \
-                    "
-            G_CIPHERS="$G_CIPHERS                               \
-                    +RSA:+NULL:+SHA256                          \
-                    "
+            if [ `minor_ver "$MODE"` -ge 1 ]
+            then
+                # Not actually supported with all GnuTLS versions. See
+                # GNUTLS_HAS_TLS1_RSA_NULL_SHA256= below.
+                M_CIPHERS="$M_CIPHERS                               \
+                        TLS-RSA-WITH-NULL-SHA256                    \
+                        "
+                G_CIPHERS="$G_CIPHERS                               \
+                        +RSA:+NULL:+SHA256                          \
+                        "
+            fi
+
             if [ `minor_ver "$MODE"` -ge 3 ]
             then
                 M_CIPHERS="$M_CIPHERS                           \

--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -133,6 +133,11 @@ print_test_case() {
 
 # list_test_case lists all potential test cases in compat.sh without execution
 list_test_cases() {
+    # We want to call filter_ciphersuites to apply standard-defined exclusions
+    # (like "no RC4 with DTLS") but without user-defined exludes/filters.
+    EXCLUDE='^$'
+    FILTER=""
+
     for MODE in $MODES; do
         for TYPE in $TYPES; do
             # PSK cipher suites do not allow client certificate verification.
@@ -147,6 +152,7 @@ list_test_cases() {
                 add_openssl_ciphersuites
                 add_gnutls_ciphersuites
                 add_mbedtls_ciphersuites
+                filter_ciphersuites
                 print_test_case m O "$O_CIPHERS"
                 print_test_case O m "$O_CIPHERS"
                 print_test_case m G "$G_CIPHERS"

--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -955,8 +955,6 @@ o_check_ciphersuite()
             *ECDH-*) SKIP_NEXT="YES"
         esac
     fi
-
-    printf "\no_check: $MODE $1 ($O_SUPPORT_DTLS12) -> $SKIP_NEXT\n"
 }
 
 # g_check_ciphersuite CIPHER_SUITE_NAME

--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -272,17 +272,9 @@ filter()
 
 filter_ciphersuites()
 {
-    if [ "X" != "X$FILTER" -o "X" != "X$EXCLUDE" ];
-    then
-        # Ciphersuite for Mbed TLS
-        M_CIPHERS=$( filter "$M_CIPHERS" )
-
-        # Ciphersuite for OpenSSL
-        O_CIPHERS=$( filter "$O_CIPHERS" )
-
-        # Ciphersuite for GnuTLS
-        G_CIPHERS=$( filter "$G_CIPHERS" )
-    fi
+    M_CIPHERS=$( filter "$M_CIPHERS" )
+    O_CIPHERS=$( filter "$O_CIPHERS" )
+    G_CIPHERS=$( filter "$G_CIPHERS" )
 }
 
 reset_ciphersuites()

--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -138,6 +138,9 @@ list_test_cases() {
     EXCLUDE='^$'
     FILTER=""
 
+    # ssl3 is excluded by default, but it's still available
+    MODES="ssl3 $MODES"
+
     for MODE in $MODES; do
         for TYPE in $TYPES; do
             # PSK cipher suites do not allow client certificate verification.

--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -147,17 +147,31 @@ list_test_cases() {
             fi
             for VERIFY in $SUB_VERIFIES; do
                 VERIF=$(echo $VERIFY | tr '[:upper:]' '[:lower:]')
-                reset_ciphersuites
-                add_common_ciphersuites
-                add_openssl_ciphersuites
-                add_gnutls_ciphersuites
-                add_mbedtls_ciphersuites
-                filter_ciphersuites
-                print_test_case m O "$O_CIPHERS"
-                print_test_case O m "$O_CIPHERS"
-                print_test_case m G "$G_CIPHERS"
-                print_test_case G m "$G_CIPHERS"
-                print_test_case m m "$M_CIPHERS"
+                for PEER in $PEERS; do
+                    reset_ciphersuites
+                    add_common_ciphersuites
+                    case "$PEER" in
+                        [Oo]pen*)
+                            add_openssl_ciphersuites
+                            filter_ciphersuites
+                            print_test_case m O "$M_CIPHERS"
+                            print_test_case O m "$O_CIPHERS"
+                            ;;
+                        [Gg]nu*)
+                            add_gnutls_ciphersuites
+                            filter_ciphersuites
+                            print_test_case m G "$M_CIPHERS"
+                            print_test_case G m "$G_CIPHERS"
+                            ;;
+                        mbed*)
+                            add_openssl_ciphersuites
+                            add_gnutls_ciphersuites
+                            add_mbedtls_ciphersuites
+                            filter_ciphersuites
+                            print_test_case m m "$M_CIPHERS"
+                            ;;
+                    esac
+                done
             done
         done
     done

--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -936,13 +936,17 @@ o_check_ciphersuite()
         SKIP_NEXT_="YES"
     fi
 
-    # OpenSSL <1.0.2 doesn't support DTLS 1.2. Check if OpenSSL
-    # supports $O_MODE from the s_server help. (The s_client
-    # help isn't accurate as of 1.0.2g: it supports DTLS 1.2
-    # but doesn't list it. But the s_server help seems to be
-    # accurate.)
-    if ! $OPENSSL s_server -help 2>&1 | grep -q "^ *-$O_MODE "; then
-        SKIP_NEXT_="YES"
+    # skip DTLS 1.2 is support was not detected
+    if [ "$O_SUPPORT_DTLS12" = "NO" -a "$MODE" = "dtls12" ]; then
+        SKIP_NEXT="YES"
+    fi
+
+    # skip single-DES ciphersuite if no longer supported
+    if [ "$O_SUPPORT_SINGLE_DES" = "NO" ]; then
+        case "$1" in
+            # note: 3DES is DES-CBC3 for OpenSSL, 3DES for Mbed TLS
+            *-DES-CBC-*|DES-CBC-*) SKIP_NEXT="YES"
+        esac
     fi
 
     # skip static ECDH when OpenSSL doesn't support it
@@ -951,6 +955,8 @@ o_check_ciphersuite()
             *ECDH-*) SKIP_NEXT="YES"
         esac
     fi
+
+    printf "\no_check: $MODE $1 ($O_SUPPORT_DTLS12) -> $SKIP_NEXT\n"
 }
 
 # g_check_ciphersuite CIPHER_SUITE_NAME
@@ -1058,6 +1064,21 @@ setup_arguments()
         *ECDH-ECDSA*|*ECDH-RSA*) O_SUPPORT_STATIC_ECDH="YES";;
         *) O_SUPPORT_STATIC_ECDH="NO";;
     esac
+
+    case $($OPENSSL ciphers ALL) in
+        *DES-CBC-*) O_SUPPORT_SINGLE_DES="YES";;
+        *) O_SUPPORT_SINGLE_DES="NO";;
+    esac
+
+    # OpenSSL <1.0.2 doesn't support DTLS 1.2. Check if OpenSSL
+    # supports -dtls1_2 from the s_server help. (The s_client
+    # help isn't accurate as of 1.0.2g: it supports DTLS 1.2
+    # but doesn't list it. But the s_server help seems to be
+    # accurate.)
+    O_SUPPORT_DTLS12="NO"
+    if $OPENSSL s_server -help 2>&1 | grep -q "^ *-dtls1_2 "; then
+        O_SUPPORT_DTLS12="YES"
+    fi
 
     if [ "X$VERIFY" = "XYES" ];
     then

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -928,8 +928,18 @@ component_test_full_cmake_gcc_asan () {
     msg "test: ssl-opt.sh (full config, ASan build)"
     tests/ssl-opt.sh
 
-    msg "test: compat.sh (full config, ASan build)"
-    tests/compat.sh
+    msg "test: compat.sh all except legacy/next (full config, ASan build)"
+    tests/compat.sh -e '^DES-CBC-\|-DES-CBC-\|ARIA\|CHACHA' \
+        -m 'ssl3 tls1 tls1_1 tls12 dtls1 dtls12'
+
+    msg "test: compat.sh single-DES (full config, ASan build)"
+    env OPENSSL="$OPENSSL_LEGACY" tests/compat.sh -e '^$' -f '^DES-CBC\|-DES-CBC-' \
+        -m 'ssl3 tls1 tls1_1 tls12 dtls1 dtls12'
+
+    # ARIA and ChachaPoly are both (D)TLS 1.2 only
+    msg "test: compat.sh ARIA + ChachaPoly (full config, ASan build)"
+    env OPENSSL="$OPENSSL_NEXT" tests/compat.sh -e '^$' -f 'ARIA\|CHACHA' \
+        -m 'dtls12 dtls12'
 
     msg "test: context-info.sh (full config, ASan build)" # ~ 15 sec
     tests/context-info.sh
@@ -1628,19 +1638,6 @@ component_test_full_cmake_clang () {
 
     msg "test: ssl-opt.sh default, ECJPAKE, SSL async (full config)" # ~ 1s
     tests/ssl-opt.sh -f 'Default\|ECJPAKE\|SSL async private'
-
-    msg "test: compat.sh all except legacy/next (full config)"
-    tests/compat.sh -e '^DES-CBC-\|-DES-CBC-\|ARIA\|CHACHA' \
-        -m 'ssl3 tls1 tls1_1 tls12 dtls1 dtls12'
-
-    msg "test: compat.sh single-DES (full config)"
-    env OPENSSL="$OPENSSL_LEGACY" tests/compat.sh -e '^$' -f '^DES-CBC\|-DES-CBC-' \
-        -m 'ssl3 tls1 tls1_1 tls12 dtls1 dtls12'
-
-    # ARIA and ChachaPoly are both (D)TLS 1.2 only
-    msg "test: compat.sh ARIA + ChachaPoly (full config)"
-    env OPENSSL="$OPENSSL_NEXT" tests/compat.sh -e '^$' -f 'ARIA\|CHACHA' \
-        -m 'dtls12 dtls12'
 }
 
 skip_suites_without_constant_flow () {

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1629,11 +1629,16 @@ component_test_full_cmake_clang () {
     msg "test: ssl-opt.sh default, ECJPAKE, SSL async (full config)" # ~ 1s
     tests/ssl-opt.sh -f 'Default\|ECJPAKE\|SSL async private'
 
+    msg "test: compat.sh default ciphers"
+    tests/compat.sh -m 'ssl3 tls1 tls1_1 tls12 dtls1 dtls12'
+
     msg "test: compat.sh RC4, 3DES & NULL (full config)" # ~ 2min
-    tests/compat.sh -e '^$' -f 'NULL\|3DES\|DES-CBC3\|RC4\|ARCFOUR'
+    tests/compat.sh -e '^$' -f 'NULL\|3DES\|DES-CBC3\|RC4\|ARCFOUR' \
+        -m 'ssl3 tls1 tls1_1 tls12 dtls1 dtls12'
 
     msg "test: compat.sh single-DES (full config)" # ~ 30s
-    env OPENSSL="$OPENSSL_LEGACY" tests/compat.sh -e '3DES\|DES-CBC3' -f 'DES'
+    env OPENSSL="$OPENSSL_LEGACY" tests/compat.sh -e '3DES\|DES-CBC3' -f 'DES' \
+        -m 'ssl3 tls1 tls1_1 tls12 dtls1 dtls12'
 
     msg "test: compat.sh ARIA + ChachaPoly"
     env OPENSSL="$OPENSSL_NEXT" tests/compat.sh -e '^$' -f 'ARIA\|CHACHA'
@@ -1926,13 +1931,15 @@ component_test_no_use_psa_crypto_full_cmake_asan() {
     tests/ssl-opt.sh
 
     msg "test: compat.sh default (full minus MBEDTLS_USE_PSA_CRYPTO)"
-    tests/compat.sh
+    tests/compat.sh -m 'ssl3 tls1 tls1_1 tls12 dtls1 dtls12'
 
     msg "test: compat.sh RC4, 3DES & NULL (full minus MBEDTLS_USE_PSA_CRYPTO)"
-    tests/compat.sh -e '^$' -f 'NULL\|3DES\|DES-CBC3\|RC4\|ARCFOUR'
+    tests/compat.sh -e '^$' -f 'NULL\|3DES\|DES-CBC3\|RC4\|ARCFOUR' \
+        -m 'ssl3 tls1 tls1_1 tls12 dtls1 dtls12'
 
     msg "test: compat.sh single-DES (full minus MBEDTLS_USE_PSA_CRYPTO)"
-    env OPENSSL="$OPENSSL_LEGACY" tests/compat.sh -e '3DES\|DES-CBC3' -f 'DES'
+    env OPENSSL="$OPENSSL_LEGACY" tests/compat.sh -e '3DES\|DES-CBC3' -f 'DES' \
+        -m 'ssl3 tls1 tls1_1 tls12 dtls1 dtls12'
 
     msg "test: compat.sh ARIA + ChachaPoly (full minus MBEDTLS_USE_PSA_CRYPTO)"
     env OPENSSL="$OPENSSL_NEXT" tests/compat.sh -e '^$' -f 'ARIA\|CHACHA'

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -939,7 +939,7 @@ component_test_full_cmake_gcc_asan () {
     # ARIA and ChachaPoly are both (D)TLS 1.2 only
     msg "test: compat.sh ARIA + ChachaPoly (full config, ASan build)"
     env OPENSSL="$OPENSSL_NEXT" tests/compat.sh -e '^$' -f 'ARIA\|CHACHA' \
-        -m 'dtls12 dtls12'
+        -m 'tls12 dtls12'
 
     msg "test: context-info.sh (full config, ASan build)" # ~ 15 sec
     tests/context-info.sh
@@ -1937,7 +1937,7 @@ component_test_no_use_psa_crypto_full_cmake_asan() {
     # ARIA and ChachaPoly are both (D)TLS 1.2 only
     msg "test: compat.sh ARIA + ChachaPoly (full minus MBEDTLS_USE_PSA_CRYPTO)"
     env OPENSSL="$OPENSSL_NEXT" tests/compat.sh -e '^$' -f 'ARIA\|CHACHA' \
-        -m 'dtls12 dtls12'
+        -m 'tls12 dtls12'
 }
 
 component_test_psa_crypto_config_accel_ecdsa () {

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1629,19 +1629,18 @@ component_test_full_cmake_clang () {
     msg "test: ssl-opt.sh default, ECJPAKE, SSL async (full config)" # ~ 1s
     tests/ssl-opt.sh -f 'Default\|ECJPAKE\|SSL async private'
 
-    msg "test: compat.sh default ciphers"
-    tests/compat.sh -m 'ssl3 tls1 tls1_1 tls12 dtls1 dtls12'
-
-    msg "test: compat.sh RC4, 3DES & NULL (full config)" # ~ 2min
-    tests/compat.sh -e '^$' -f 'NULL\|3DES\|DES-CBC3\|RC4\|ARCFOUR' \
+    msg "test: compat.sh all except legacy/next (full config)"
+    tests/compat.sh -e '^DES-CBC-\|-DES-CBC-\|ARIA\|CHACHA' \
         -m 'ssl3 tls1 tls1_1 tls12 dtls1 dtls12'
 
-    msg "test: compat.sh single-DES (full config)" # ~ 30s
-    env OPENSSL="$OPENSSL_LEGACY" tests/compat.sh -e '3DES\|DES-CBC3' -f 'DES' \
+    msg "test: compat.sh single-DES (full config)"
+    env OPENSSL="$OPENSSL_LEGACY" tests/compat.sh -e '^$' -f '^DES-CBC\|-DES-CBC-' \
         -m 'ssl3 tls1 tls1_1 tls12 dtls1 dtls12'
 
-    msg "test: compat.sh ARIA + ChachaPoly"
-    env OPENSSL="$OPENSSL_NEXT" tests/compat.sh -e '^$' -f 'ARIA\|CHACHA'
+    # ARIA and ChachaPoly are both (D)TLS 1.2 only
+    msg "test: compat.sh ARIA + ChachaPoly (full config)"
+    env OPENSSL="$OPENSSL_NEXT" tests/compat.sh -e '^$' -f 'ARIA\|CHACHA' \
+        -m 'dtls12 dtls12'
 }
 
 skip_suites_without_constant_flow () {
@@ -1930,19 +1929,18 @@ component_test_no_use_psa_crypto_full_cmake_asan() {
     msg "test: ssl-opt.sh (full minus MBEDTLS_USE_PSA_CRYPTO)"
     tests/ssl-opt.sh
 
-    msg "test: compat.sh default (full minus MBEDTLS_USE_PSA_CRYPTO)"
-    tests/compat.sh -m 'ssl3 tls1 tls1_1 tls12 dtls1 dtls12'
-
-    msg "test: compat.sh RC4, 3DES & NULL (full minus MBEDTLS_USE_PSA_CRYPTO)"
-    tests/compat.sh -e '^$' -f 'NULL\|3DES\|DES-CBC3\|RC4\|ARCFOUR' \
+    msg "test: compat.sh all except legacy/next (full minus MBEDTLS_USE_PSA_CRYPTO)"
+    tests/compat.sh -e '^DES-CBC-\|-DES-CBC-\|ARIA\|CHACHA' \
         -m 'ssl3 tls1 tls1_1 tls12 dtls1 dtls12'
 
     msg "test: compat.sh single-DES (full minus MBEDTLS_USE_PSA_CRYPTO)"
-    env OPENSSL="$OPENSSL_LEGACY" tests/compat.sh -e '3DES\|DES-CBC3' -f 'DES' \
+    env OPENSSL="$OPENSSL_LEGACY" tests/compat.sh -e '^$' -f '^DES-CBC\|-DES-CBC-' \
         -m 'ssl3 tls1 tls1_1 tls12 dtls1 dtls12'
 
+    # ARIA and ChachaPoly are both (D)TLS 1.2 only
     msg "test: compat.sh ARIA + ChachaPoly (full minus MBEDTLS_USE_PSA_CRYPTO)"
-    env OPENSSL="$OPENSSL_NEXT" tests/compat.sh -e '^$' -f 'ARIA\|CHACHA'
+    env OPENSSL="$OPENSSL_NEXT" tests/compat.sh -e '^$' -f 'ARIA\|CHACHA' \
+        -m 'dtls12 dtls12'
 }
 
 component_test_psa_crypto_config_accel_ecdsa () {

--- a/tests/scripts/analyze_outcomes.py
+++ b/tests/scripts/analyze_outcomes.py
@@ -113,6 +113,18 @@ TASKS = {
                 'test_suite_psa_crypto_metadata;Asymmetric signature: pure EdDSA',
                 # Algorithm not supported yet
                 'test_suite_psa_crypto_metadata;Cipher: XTS',
+                # compat.sh tests with OpenSSL, DTLS 1.2 and singled-DES:
+                # we have no version of OpenSSL on the CI that supports both
+                # DTLS 1.2 and single-DES (1.0.2g is too recent for single-DES
+                # and 1.0.1j is too old for DTLS 1.2).
+                'compat;O->m dtls12,no DES-CBC-SHA',
+                'compat;O->m dtls12,no EDH-RSA-DES-CBC-SHA',
+                'compat;O->m dtls12,yes DES-CBC-SHA',
+                'compat;O->m dtls12,yes EDH-RSA-DES-CBC-SHA',
+                'compat;m->O dtls12,no TLS-DHE-RSA-WITH-DES-CBC-SHA',
+                'compat;m->O dtls12,no TLS-RSA-WITH-DES-CBC-SHA',
+                'compat;m->O dtls12,yes TLS-DHE-RSA-WITH-DES-CBC-SHA',
+                'compat;m->O dtls12,yes TLS-RSA-WITH-DES-CBC-SHA',
             ],
             'full_coverage': False,
         }

--- a/tests/scripts/basic-build-test.sh
+++ b/tests/scripts/basic-build-test.sh
@@ -110,7 +110,8 @@ echo '################ compat.sh ################'
 
     echo '#### compat.sh: legacy (null, DES, RC4)'
     OPENSSL="$OPENSSL_LEGACY" \
-    sh compat.sh -e '^$' -f 'NULL\|DES\|RC4\|ARCFOUR'
+    sh compat.sh -e '^$' -f 'NULL\|DES\|RC4\|ARCFOUR' \
+        -m 'ssl3 tls1 tls1_1 tls12 dtls1 dtls12'
     echo
 
     echo '#### compat.sh: next (ARIA, ChaCha)'

--- a/tests/scripts/basic-build-test.sh
+++ b/tests/scripts/basic-build-test.sh
@@ -104,18 +104,20 @@ echo
 # Step 2c - Compatibility tests (keep going even if some tests fail)
 echo '################ compat.sh ################'
 {
-    echo '#### compat.sh: Default ciphers'
-    sh compat.sh -m 'ssl3 tls1 tls1_1 tls12 dtls1 dtls12'
-    echo
-
-    echo '#### compat.sh: legacy (null, DES, RC4)'
-    OPENSSL="$OPENSSL_LEGACY" \
-    sh compat.sh -e '^$' -f 'NULL\|DES\|RC4\|ARCFOUR' \
+    echo '#### compat.sh: all except legacy/next'
+    sh compat.sh -e '^DES-CBC-\|-DES-CBC-\|ARIA\|CHACHA' \
         -m 'ssl3 tls1 tls1_1 tls12 dtls1 dtls12'
     echo
 
+    echo '#### compat.sh: legacy (single-DES)'
+    OPENSSL="$OPENSSL_LEGACY" sh compat.sh -e '^$' -f '^DES-CBC\|-DES-CBC-' \
+        -m 'ssl3 tls1 tls1_1 tls12 dtls1 dtls12'
+    echo
+
+    # ARIA and ChachaPoly are both (D)TLS 1.2 only
     echo '#### compat.sh: next (ARIA, ChaCha)'
-    OPENSSL="$OPENSSL_NEXT" sh compat.sh -e '^$' -f 'ARIA\|CHACHA'
+    OPENSSL="$OPENSSL_NEXT" sh compat.sh -e '^$' -f 'ARIA\|CHACHA' \
+        -m 'dtls12 dtls12'
     echo
 } | tee compat-test-$TEST_OUTPUT
 echo '^^^^^^^^^^^^^^^^ compat.sh ^^^^^^^^^^^^^^^^'

--- a/tests/scripts/basic-build-test.sh
+++ b/tests/scripts/basic-build-test.sh
@@ -117,7 +117,7 @@ echo '################ compat.sh ################'
     # ARIA and ChachaPoly are both (D)TLS 1.2 only
     echo '#### compat.sh: next (ARIA, ChaCha)'
     OPENSSL="$OPENSSL_NEXT" sh compat.sh -e '^$' -f 'ARIA\|CHACHA' \
-        -m 'dtls12 dtls12'
+        -m 'tls12 dtls12'
     echo
 } | tee compat-test-$TEST_OUTPUT
 echo '^^^^^^^^^^^^^^^^ compat.sh ^^^^^^^^^^^^^^^^'


### PR DESCRIPTION
## Description

In 2.28 (but not in 3.6 or development), `analyze_outcomes.py` lists 1000+ `compat.sh` test cases as not executed on the CI. While investigating that, I noticed that there are also tests passing in `outcomes.csv` that are not listed by `--list-test-cases`. This PR makes things consistent.

The biggest inconsistency was the different naming schemes were used in `--list-test-cases` and in writing to the outcomes file. (In 3.x we fixed this by using the standard name everywhere, but in 2.28 we still report what we have to pass to the client as the name.)

Then there was a number of special cases, all of them related to things that have been removed in 3.0: SSLv3 / TLS < 1.2, RC4, single-DES suites...

However a few of the changes (reporting all skipped tests instead of silently ignoring some of them) are relevant to development/3.6, so I'll forward-port them.

## PR checklist

- [x] **changelog** not required
- [x] **3.6 backport** done #9021
- [x] **2.28 backport** of #9022
- [x] **tests** not required - semi-manual testing for now (see [script below](https://github.com/Mbed-TLS/mbedtls/pull/9019#issuecomment-2049125225)), may extend `analyze_outcomes.py` with [further consistency checks](https://github.com/Mbed-TLS/mbedtls/issues/8300#issuecomment-2044346474) later.
- [x] double-check that I didn't break `basic-build-test.sh`: [release job](https://mbedtls.trustedfirmware.org/blue/organizations/jenkins/mbedtls-release-ci-testing/detail/mbedtls-release-ci-testing/159/pipeline) OK
