### PR TITLE
[3.6] Small fixes to compat.sh (partial forward-port)

### DIFF
--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -588,7 +588,22 @@ add_mbedtls_ciphersuites()
 # o_check_ciphersuite STANDARD_CIPHER_SUITE
 o_check_ciphersuite()
 {
-    if [ "${O_SUPPORT_ECDH}" = "NO" ]; then
+    # skip DTLS when lack of support was declared
+    if test "$OSSL_NO_DTLS" -gt 0 && is_dtls "$MODE"; then
+        SKIP_NEXT_="YES"
+    fi
+
+    # OpenSSL <1.0.2 doesn't support DTLS 1.2. Check if OpenSSL
+    # supports $O_MODE from the s_server help. (The s_client
+    # help isn't accurate as of 1.0.2g: it supports DTLS 1.2
+    # but doesn't list it. But the s_server help seems to be
+    # accurate.)
+    if ! $OPENSSL s_server -help 2>&1 | grep -q "^ *-$O_MODE "; then
+        SKIP_NEXT_="YES"
+    fi
+
+    # skip static ECDH when OpenSSL doesn't support it
+    if [ "${O_SUPPORT_STATIC_ECDH}" = "NO" ]; then
         case "$1" in
             *ECDH_*) SKIP_NEXT="YES"
         esac
@@ -665,8 +680,8 @@ setup_arguments()
     esac
 
     case $($OPENSSL ciphers ALL) in
-        *ECDH-ECDSA*|*ECDH-RSA*) O_SUPPORT_ECDH="YES";;
-        *) O_SUPPORT_ECDH="NO";;
+        *ECDH-ECDSA*|*ECDH-RSA*) O_SUPPORT_STATIC_ECDH="YES";;
+        *) O_SUPPORT_STATIC_ECDH="NO";;
     esac
 
     if [ "X$VERIFY" = "XYES" ];
@@ -1108,19 +1123,6 @@ for MODE in $MODES; do
             case "$PEER" in
 
                 [Oo]pen*)
-
-                    if test "$OSSL_NO_DTLS" -gt 0 && is_dtls "$MODE"; then
-                        continue;
-                    fi
-
-                    # OpenSSL <1.0.2 doesn't support DTLS 1.2. Check if OpenSSL
-                    # supports $O_MODE from the s_server help. (The s_client
-                    # help isn't accurate as of 1.0.2g: it supports DTLS 1.2
-                    # but doesn't list it. But the s_server help seems to be
-                    # accurate.)
-                    if ! $OPENSSL s_server -help 2>&1 | grep -q "^ *-$O_MODE "; then
-                        continue;
-                    fi
 
                     reset_ciphersuites
                     add_common_ciphersuites

--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -593,13 +593,9 @@ o_check_ciphersuite()
         SKIP_NEXT_="YES"
     fi
 
-    # OpenSSL <1.0.2 doesn't support DTLS 1.2. Check if OpenSSL
-    # supports $O_MODE from the s_server help. (The s_client
-    # help isn't accurate as of 1.0.2g: it supports DTLS 1.2
-    # but doesn't list it. But the s_server help seems to be
-    # accurate.)
-    if ! $OPENSSL s_server -help 2>&1 | grep -q "^ *-$O_MODE "; then
-        SKIP_NEXT_="YES"
+    # skip DTLS 1.2 is support was not detected
+    if [ "$O_SUPPORT_DTLS12" = "NO" -a "$MODE" = "dtls12" ]; then
+        SKIP_NEXT="YES"
     fi
 
     # skip static ECDH when OpenSSL doesn't support it
@@ -683,6 +679,21 @@ setup_arguments()
         *ECDH-ECDSA*|*ECDH-RSA*) O_SUPPORT_STATIC_ECDH="YES";;
         *) O_SUPPORT_STATIC_ECDH="NO";;
     esac
+
+    case $($OPENSSL ciphers ALL) in
+        *DES-CBC-*) O_SUPPORT_SINGLE_DES="YES";;
+        *) O_SUPPORT_SINGLE_DES="NO";;
+    esac
+
+    # OpenSSL <1.0.2 doesn't support DTLS 1.2. Check if OpenSSL
+    # supports -dtls1_2 from the s_server help. (The s_client
+    # help isn't accurate as of 1.0.2g: it supports DTLS 1.2
+    # but doesn't list it. But the s_server help seems to be
+    # accurate.)
+    O_SUPPORT_DTLS12="NO"
+    if $OPENSSL s_server -help 2>&1 | grep -q "^ *-dtls1_2 "; then
+        O_SUPPORT_DTLS12="YES"
+    fi
 
     if [ "X$VERIFY" = "XYES" ];
     then

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1218,8 +1218,11 @@ component_test_full_cmake_gcc_asan () {
     msg "test: ssl-opt.sh (full config, ASan build)"
     tests/ssl-opt.sh
 
-    msg "test: compat.sh (full config, ASan build)"
-    tests/compat.sh
+    msg "test: compat.sh: NULL (full config, ASan build)"
+    tests/compat.sh -f 'NULL'
+
+    msg "test: compat.sh next: all except NULL (full config, ASan build)"
+    env OPENSSL="$OPENSSL_NEXT" tests/compat.sh -e 'NULL'
 
     msg "test: context-info.sh (full config, ASan build)" # ~ 15 sec
     tests/context-info.sh
@@ -1242,8 +1245,11 @@ component_test_full_cmake_gcc_asan_new_bignum () {
     msg "test: ssl-opt.sh (full config, ASan build)"
     tests/ssl-opt.sh
 
-    msg "test: compat.sh (full config, ASan build)"
-    tests/compat.sh
+    msg "test: compat.sh: NULL (full config, ASan build)"
+    tests/compat.sh -f 'NULL'
+
+    msg "test: compat.sh next: all except NULL (full config, ASan build)"
+    env OPENSSL="$OPENSSL_NEXT" tests/compat.sh -e 'NULL'
 
     msg "test: context-info.sh (full config, ASan build)" # ~ 15 sec
     tests/context-info.sh
@@ -2161,12 +2167,6 @@ component_test_full_cmake_clang () {
 
     msg "test: ssl-opt.sh default, ECJPAKE, SSL async (full config)" # ~ 1s
     tests/ssl-opt.sh -f 'Default\|ECJPAKE\|SSL async private'
-
-    msg "test: compat.sh NULL (full config)" # ~ 2 min
-    tests/compat.sh -e '^$' -f 'NULL'
-
-    msg "test: compat.sh ARIA + ChachaPoly"
-    env OPENSSL="$OPENSSL_NEXT" tests/compat.sh -e '^$' -f 'ARIA\|CHACHA'
 }
 
 skip_suites_without_constant_flow () {
@@ -2610,14 +2610,11 @@ component_test_no_psa_crypto_full_cmake_asan() {
     msg "test: ssl-opt.sh (full minus PSA crypto)"
     tests/ssl-opt.sh
 
-    msg "test: compat.sh default (full minus PSA crypto)"
-    tests/compat.sh
-
-    msg "test: compat.sh NULL (full minus PSA crypto)"
+    msg "test: compat.sh: NULL (full minus PSA crypto)"
     tests/compat.sh -f 'NULL'
 
-    msg "test: compat.sh ARIA + ChachaPoly (full minus PSA crypto)"
-    env OPENSSL="$OPENSSL_NEXT" tests/compat.sh -e '^$' -f 'ARIA\|CHACHA'
+    msg "test: compat.sh next: all except NULL (full minus PSA crypto)"
+    env OPENSSL="$OPENSSL_NEXT" tests/compat.sh -e 'NULL'
 }
 
 component_test_psa_crypto_config_accel_ecdsa () {

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1212,17 +1212,19 @@ component_test_full_cmake_gcc_asan () {
     msg "test: main suites (inc. selftests) (full config, ASan build)"
     make test
 
-    msg "test: selftest (ASan build)" # ~ 10s
+    msg "test: selftest (full config, ASan build)" # ~ 10s
     programs/test/selftest
 
     msg "test: ssl-opt.sh (full config, ASan build)"
     tests/ssl-opt.sh
 
-    msg "test: compat.sh: NULL (full config, ASan build)"
-    tests/compat.sh -f 'NULL'
+    # Note: the next two invocations cover all compat.sh test cases.
+    # We should use the same here and in basic-build-test.sh.
+    msg "test: compat.sh: default version (full config, ASan build)"
+    tests/compat.sh -e 'ARIA\|CHACHA'
 
-    msg "test: compat.sh next: all except NULL (full config, ASan build)"
-    env OPENSSL="$OPENSSL_NEXT" tests/compat.sh -e 'NULL'
+    msg "test: compat.sh: next: ARIA, Chacha (full config, ASan build)"
+    env OPENSSL="$OPENSSL_NEXT" tests/compat.sh -e '^$' -f 'ARIA\|CHACHA'
 
     msg "test: context-info.sh (full config, ASan build)" # ~ 15 sec
     tests/context-info.sh
@@ -1236,22 +1238,24 @@ component_test_full_cmake_gcc_asan_new_bignum () {
     CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
     make
 
-    msg "test: main suites (inc. selftests) (full config, ASan build)"
+    msg "test: main suites (inc. selftests) (full config, new bignum, ASan)"
     make test
 
-    msg "test: selftest (ASan build)" # ~ 10s
+    msg "test: selftest (full config, new bignum, ASan)" # ~ 10s
     programs/test/selftest
 
-    msg "test: ssl-opt.sh (full config, ASan build)"
+    msg "test: ssl-opt.sh (full config, new bignum, ASan)"
     tests/ssl-opt.sh
 
-    msg "test: compat.sh: NULL (full config, ASan build)"
-    tests/compat.sh -f 'NULL'
+    # Note: the next two invocations cover all compat.sh test cases.
+    # We should use the same here and in basic-build-test.sh.
+    msg "test: compat.sh: default version (full config, new bignum, ASan)"
+    tests/compat.sh -e 'ARIA\|CHACHA'
 
-    msg "test: compat.sh next: all except NULL (full config, ASan build)"
-    env OPENSSL="$OPENSSL_NEXT" tests/compat.sh -e 'NULL'
+    msg "test: compat.sh: next: ARIA, Chacha (full config, new bignum, ASan)"
+    env OPENSSL="$OPENSSL_NEXT" tests/compat.sh -e '^$' -f 'ARIA\|CHACHA'
 
-    msg "test: context-info.sh (full config, ASan build)" # ~ 15 sec
+    msg "test: context-info.sh (full config, new bignum, ASan)" # ~ 15 sec
     tests/context-info.sh
 }
 
@@ -2610,11 +2614,13 @@ component_test_no_psa_crypto_full_cmake_asan() {
     msg "test: ssl-opt.sh (full minus PSA crypto)"
     tests/ssl-opt.sh
 
-    msg "test: compat.sh: NULL (full minus PSA crypto)"
-    tests/compat.sh -f 'NULL'
+    # Note: the next two invocations cover all compat.sh test cases.
+    # We should use the same here and in basic-build-test.sh.
+    msg "test: compat.sh: default version (full minus PSA crypto)"
+    tests/compat.sh -e 'ARIA\|CHACHA'
 
-    msg "test: compat.sh next: all except NULL (full minus PSA crypto)"
-    env OPENSSL="$OPENSSL_NEXT" tests/compat.sh -e 'NULL'
+    msg "test: compat.sh: next: ARIA, Chacha (full minus PSA crypto)"
+    env OPENSSL="$OPENSSL_NEXT" tests/compat.sh -e '^$' -f 'ARIA\|CHACHA'
 }
 
 component_test_psa_crypto_config_accel_ecdsa () {

--- a/tests/scripts/basic-build-test.sh
+++ b/tests/scripts/basic-build-test.sh
@@ -102,12 +102,12 @@ echo
 # Step 2c - Compatibility tests (keep going even if some tests fail)
 echo '################ compat.sh ################'
 {
-    echo '#### compat.sh: NULL ciphersuites'
-    sh compat.sh -e '^$' -f 'NULL'
+    echo '#### compat.sh: Default versions'
+    sh compat.sh -e 'ARIA\|CHACHA'
     echo
 
-    echo '#### compat.sh: next (all except NULL)'
-    OPENSSL="$OPENSSL_NEXT" sh compat.sh -e 'NULL'
+    echo '#### compat.sh: next (ARIA, ChaCha)'
+    OPENSSL="$OPENSSL_NEXT" sh compat.sh -e '^$' -f 'ARIA\|CHACHA'
     echo
 } | tee compat-test-$TEST_OUTPUT
 echo '^^^^^^^^^^^^^^^^ compat.sh ^^^^^^^^^^^^^^^^'

--- a/tests/scripts/basic-build-test.sh
+++ b/tests/scripts/basic-build-test.sh
@@ -102,16 +102,12 @@ echo
 # Step 2c - Compatibility tests (keep going even if some tests fail)
 echo '################ compat.sh ################'
 {
-    echo '#### compat.sh: Default versions'
-    sh compat.sh
-    echo
-
-    echo '#### compat.sh: null cipher'
+    echo '#### compat.sh: NULL ciphersuites'
     sh compat.sh -e '^$' -f 'NULL'
     echo
 
-    echo '#### compat.sh: next (ARIA, ChaCha)'
-    OPENSSL="$OPENSSL_NEXT" sh compat.sh -e '^$' -f 'ARIA\|CHACHA'
+    echo '#### compat.sh: next (all except NULL)'
+    OPENSSL="$OPENSSL_NEXT" sh compat.sh -e 'NULL'
     echo
 } | tee compat-test-$TEST_OUTPUT
 echo '^^^^^^^^^^^^^^^^ compat.sh ^^^^^^^^^^^^^^^^'


### PR DESCRIPTION
## Description

This is the forward-port to 3.6 of the relevant bits of #9019 / backport to 3.6 of #9022

## PR checklist

- [x] **changelog** not required - test only
- [x] **3.6 backport** done - this is it
- [x] **2.28 backport** done #9019
- [x] **tests** not required