### PR TITLE
Test PSA compliance in nightlies only

### DIFF
--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -6371,7 +6371,7 @@ component_test_zeroize () {
     done
 }
 
-component_test_psa_compliance () {
+component_release_test_psa_compliance () {
     # The arch tests build with gcc, so require use of gcc here to link properly
     msg "build: make, default config (out-of-box), libmbedcrypto.a only"
     CC=gcc make -C library libmbedcrypto.a
@@ -6380,7 +6380,7 @@ component_test_psa_compliance () {
     CC=gcc ./tests/scripts/test_psa_compliance.py
 }
 
-support_test_psa_compliance () {
+support_release_test_psa_compliance () {
     # psa-compliance-tests only supports CMake >= 3.10.0
     ver="$(cmake --version)"
     ver="${ver#cmake version }"


### PR DESCRIPTION
Once we're compliant with a given version of the PSA compliance tests, we tend to stay compliant: otherwise plenty of unit tests would fail. So we don't need to test it on every pull request job.

This doesn't save a lot of CI resources, but of all the jobs in `all.sh`, it's probably the one that has the lowest risk of being the single failure.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** no (test only)
- [ ] **3.6 backport** TODO
- [ ] **2.28 backport** TODO
- [x] **tests** N/A
