### PR TITLE
Auto-enable ASN1 when RSA is enabled

### DIFF
--- a/ChangeLog.d/asn1-missing-guard-in-rsa.txt
+++ b/ChangeLog.d/asn1-missing-guard-in-rsa.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * MBEDTLS_ASN1_PARSE_C and MBEDTLS_ASN1_WRITE_C is automatically enabled
+     as soon as MBEDTLS_RSA_C is enabled. Fixes #9041.

--- a/ChangeLog.d/asn1-missing-guard-in-rsa.txt
+++ b/ChangeLog.d/asn1-missing-guard-in-rsa.txt
@@ -1,3 +1,3 @@
 Bugfix
-   * MBEDTLS_ASN1_PARSE_C and MBEDTLS_ASN1_WRITE_C is automatically enabled
+   * MBEDTLS_ASN1_PARSE_C and MBEDTLS_ASN1_WRITE_C are now automatically enabled
      as soon as MBEDTLS_RSA_C is enabled. Fixes #9041.

--- a/include/mbedtls/config_adjust_legacy_crypto.h
+++ b/include/mbedtls/config_adjust_legacy_crypto.h
@@ -293,6 +293,14 @@
 #define MBEDTLS_ECP_LIGHT
 #endif
 
+/* Backward compatibility: after #8740 the RSA module offers functions to parse
+ * and write RSA private/public keys without relying on the PK one. Of course
+ * this needs ASN1 support to do so, so we enable it here. */
+#if defined(MBEDTLS_RSA_C)
+#define MBEDTLS_ASN1_PARSE_C
+#define MBEDTLS_ASN1_WRITE_C
+#endif
+
 /* MBEDTLS_PK_PARSE_EC_COMPRESSED is introduced in Mbed TLS version 3.5, while
  * in previous version compressed points were automatically supported as long
  * as PK_PARSE_C and ECP_C were enabled. As a consequence, for backward


### PR DESCRIPTION
## Description

RSA needs ASN1 functions to parse/write private and public keys, but there is no guards in the code for that. So we need to enable ASN1 support whenever RSA is enabled.

Resolves #9041.

## PR checklist

- [x] **changelog** added
- [x] **3.6 backport** https://github.com/Mbed-TLS/mbedtls/pull/9042
- [x] **2.28 backport**  not required because in that version RSA didn't have the functions to parse and write private/public keys
- [x] **tests** not required