### PR TITLE
Make component_test_psa_crypto_rsa_no_genprime work with PSA_CRYPTO_CONFIG set

### DIFF
--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1366,12 +1366,13 @@ component_build_full_psa_crypto_client_without_crypto_provider () {
     grep mbedtls_pk_copy_from_psa library/libmbedcrypto.a
 }
 
-component_test_psa_crypto_rsa_no_genprime() {
-    msg "build: default config minus MBEDTLS_GENPRIME"
+component_test_no_rsa_key_pair_generation() {
+    msg "build: default config minus PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_GENERATE"
     scripts/config.py unset MBEDTLS_GENPRIME
+    scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_GENERATE
     make
 
-    msg "test: default config minus MBEDTLS_GENPRIME"
+    msg "test: default config minus PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_GENERATE"
     make test
 }
 

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1368,6 +1368,7 @@ component_build_full_psa_crypto_client_without_crypto_provider () {
 
 component_test_no_rsa_key_pair_generation() {
     msg "build: default config minus PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_GENERATE"
+    scripts/config.py set MBEDTLS_PSA_CRYPTO_CONFIG
     scripts/config.py unset MBEDTLS_GENPRIME
     scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_GENERATE
     make


### PR DESCRIPTION
## Description
This is the first PR for #8153 and https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/63. The end goal is to remove the legacy config symbols in `mbedtls_config.h`, and instead use the equivalents in `crypto_config.h` - without losing test coverage for the CI.

This pattern, if approved, will be applied to all relevant CI components.

The effect of this PR is that this component will still work as intended once `PSA_CRYPTO_CONFIG` is enabled by default. Note that: until `MBEDTLS_GENPRIME` is removed from `mbedtls_config.h` we cannot remove the `unset MBEDTLS_GENPRIME` call in this config, as `config_adjust_legacy_from_psa.h` can not undefine symbols defined elsewhere (`MBEDTLS_GENPRIME` is defined in the default `mbedtls_config.h`). We also cannot remove `MBEDTLS_GENPRIME` from `mbedtls_config.h` until `PSA_CRYPTO_CONFIG` is enabled by default, this would result in a loss of test coverage elsewhere.

This also renames the component as suggested in https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/63, so that the name is still accurate once the legacy config options are removed.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog**  not required
- [x] **3.6 backport** not required - This is work for 4.0
- [x] **2.28 backport** not required - This is work for 4.0
- [x] **tests**  not required