### PR TITLE
[3.6 backport] Asn1 missing guard in rsa backport

### DIFF
--- a/ChangeLog.d/asn1-missing-guard-in-rsa.txt
+++ b/ChangeLog.d/asn1-missing-guard-in-rsa.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * MBEDTLS_ASN1_PARSE_C and MBEDTLS_ASN1_WRITE_C is automatically enabled
+     as soon as MBEDTLS_RSA_C is enabled. Fixes #9041.

--- a/ChangeLog.d/asn1-missing-guard-in-rsa.txt
+++ b/ChangeLog.d/asn1-missing-guard-in-rsa.txt
@@ -1,3 +1,3 @@
 Bugfix
-   * MBEDTLS_ASN1_PARSE_C and MBEDTLS_ASN1_WRITE_C is automatically enabled
+   * MBEDTLS_ASN1_PARSE_C and MBEDTLS_ASN1_WRITE_C are now automatically enabled
      as soon as MBEDTLS_RSA_C is enabled. Fixes #9041.

--- a/include/mbedtls/config_adjust_legacy_crypto.h
+++ b/include/mbedtls/config_adjust_legacy_crypto.h
@@ -293,6 +293,14 @@
 #define MBEDTLS_ECP_LIGHT
 #endif
 
+/* Backward compatibility: after #8740 the RSA module offers functions to parse
+ * and write RSA private/public keys without relying on the PK one. Of course
+ * this needs ASN1 support to do so, so we enable it here. */
+#if defined(MBEDTLS_RSA_C)
+#define MBEDTLS_ASN1_PARSE_C
+#define MBEDTLS_ASN1_WRITE_C
+#endif
+
 /* MBEDTLS_PK_PARSE_EC_COMPRESSED is introduced in Mbed TLS version 3.5, while
  * in previous version compressed points were automatically supported as long
  * as PK_PARSE_C and ECP_C were enabled. As a consequence, for backward


### PR DESCRIPTION
## Description

Backport of #9035

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** provided
- [x] **3.6 backport** this is the backport of #9035
- [x] **2.28 backport** not required
- [x] **tests** not required


