### PR TITLE
Add pragma for bcrypt.lib - Fix win build with cmake

### DIFF
--- a/library/entropy_poll.c
+++ b/library/entropy_poll.c
@@ -40,6 +40,10 @@
 #include <bcrypt.h>
 #include <intsafe.h>
 
+#if defined(_MSC_VER)
+#pragma comment( lib, "bcrypt.lib" )
+#endif /* _MSC_VER */
+
 int mbedtls_platform_entropy_poll(void *data, unsigned char *output, size_t len,
                                   size_t *olen)
 {


### PR DESCRIPTION
## Description

If we build with cmake on windows, it's missing the link to bcrypt.lib. 
Add the pragma in the code, like for the winsock ws2.lib.



## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [ ] **changelog**  not required
- [ ] **3.6 backport**  not required
- [ ] **2.28 backport** not required
- [ ] **tests**  not required



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
