### PR TITLE
[DO NOT MERGE] Reference commit for package aliasing

### DIFF
--- a/scripts/mbedtls_dev/__init__.py
+++ b/scripts/mbedtls_dev/__init__.py
@@ -1,3 +1,7 @@
 # This file needs to exist to make mbedtls_dev a package.
 # Among other things, this allows modules in this directory to make
 # relative imports.
+
+from pathlib import Path
+
+__all__ = [n.stem for n in Path(__file__).parent.glob('*.py') if not n.stem == "__init__.py"]

--- a/tests/scripts/mbedtls_test_dev/__init__.py
+++ b/tests/scripts/mbedtls_test_dev/__init__.py
@@ -1,0 +1,7 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__),
+                              os.path.pardir,os.path.pardir, os.path.pardir,
+                             'scripts'))
+from mbedtls_dev import *


### PR DESCRIPTION
## Description

Simple showcase of how to create an aliased version of a package in python by overriding the `__all__`  attribute of the module loader. 

Unfortunately we cannot re-use the same name and if we would like to contain python files in multiple locations and expose them as a single pacakge we should consider [namespace packages](https://peps.python.org/pep-0420/#abstract)

I think it is considerably more complicated, then just using the proposed trick with __all__ imports.

In a script in the main codebase you can do 
`from mbedtls_dev import *` while in the test codebase you could do `from mbedtls_test_dev import *` and would still expose the modules directly `bignum_common` so the code won't have to change. 

This PR is not to be merged just for discussion purposes.
