### PR TITLE
Make TLS 1.2 components work with PSA_CRYPTO_CONFIG set

### DIFF
--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1875,6 +1875,7 @@ component_test_tls1_2_default_stream_cipher_only () {
     scripts/config.py set MBEDTLS_PSA_CRYPTO_CONFIG
     # Disable AEAD (controlled by the presence of one of GCM_C, CCM_C, CHACHAPOLY_C)
     scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_CCM
+    scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_CCM_STAR_NO_TAG
     scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_GCM
     scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_CHACHA20_POLY1305
     # Note: The three unsets below are to be removed for Mbed TLS 4.0
@@ -1912,6 +1913,7 @@ component_test_tls1_2_default_cbc_legacy_cipher_only () {
     scripts/config.py set MBEDTLS_PSA_CRYPTO_CONFIG
     # Disable AEAD (controlled by the presence of one of GCM_C, CCM_C, CHACHAPOLY_C)
     scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_CCM
+    scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_CCM_STAR_NO_TAG
     scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_GCM
     scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_CHACHA20_POLY1305
     # Note: The three unsets below are to be removed for Mbed TLS 4.0
@@ -1946,6 +1948,7 @@ component_test_tls1_2_default_cbc_legacy_cbc_etm_cipher_only () {
     scripts/config.py set MBEDTLS_PSA_CRYPTO_CONFIG
     # Disable AEAD (controlled by the presence of one of GCM_C, CCM_C, CHACHAPOLY_C)
     scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_CCM
+    scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_CCM_STAR_NO_TAG
     scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_GCM
     scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_CHACHA20_POLY1305
     # Note: The three unsets below are to be removed for Mbed TLS 4.0

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1868,7 +1868,7 @@ component_test_full_no_bignum () {
     make test
 }
 
-component_test_tls1_2_default_stream_cipher_only_use_psa () {
+component_test_tls1_2_default_stream_cipher_only () {
     msg "build: default with only stream cipher use psa"
 
     scripts/config.py set MBEDTLS_USE_PSA_CRYPTO
@@ -1905,7 +1905,7 @@ component_test_tls1_2_default_stream_cipher_only_use_psa () {
     # Not running ssl-opt.sh because most tests require a non-NULL ciphersuite.
 }
 
-component_test_tls1_2_deafult_cbc_legacy_cipher_only_use_psa () {
+component_test_tls1_2_deafult_cbc_legacy_cipher_only () {
     msg "build: default with only CBC-legacy cipher use psa"
 
     scripts/config.py set MBEDTLS_USE_PSA_CRYPTO
@@ -1943,7 +1943,7 @@ component_test_tls1_2_deafult_cbc_legacy_cipher_only_use_psa () {
     tests/ssl-opt.sh -f "TLS 1.2"
 }
 
-component_test_tls1_2_default_cbc_legacy_cbc_etm_cipher_only_use_psa () {
+component_test_tls1_2_default_cbc_legacy_cbc_etm_cipher_only () {
     msg "build: default with only CBC-legacy and CBC-EtM ciphers use psa"
 
     scripts/config.py set MBEDTLS_USE_PSA_CRYPTO

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1905,7 +1905,7 @@ component_test_tls1_2_default_stream_cipher_only () {
     # Not running ssl-opt.sh because most tests require a non-NULL ciphersuite.
 }
 
-component_test_tls1_2_deafult_cbc_legacy_cipher_only () {
+component_test_tls1_2_default_cbc_legacy_cipher_only () {
     msg "build: default with only CBC-legacy cipher use psa"
 
     scripts/config.py set MBEDTLS_USE_PSA_CRYPTO

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1904,6 +1904,10 @@ component_test_tls1_2_default_stream_cipher_only_use_psa () {
     scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_CCM
     scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_GCM
     scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_CHACHA20_POLY1305
+    # Note: The three unsets below are to be removed for Mbed TLS 4.0
+    scripts/config.py unset MBEDTLS_GCM_C
+    scripts/config.py unset MBEDTLS_CCM_C
+    scripts/config.py unset MBEDTLS_CHACHAPOLY_C
     #Disable TLS 1.3 (as no AEAD)
     scripts/config.py unset MBEDTLS_SSL_PROTO_TLS1_3
     # Disable CBC. Note: When implemented, PSA_WANT_ALG_CBC_MAC will also need to be unset here to fully disable CBC
@@ -1962,6 +1966,10 @@ component_test_tls1_2_deafult_cbc_legacy_cipher_only_use_psa () {
     scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_CCM
     scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_GCM
     scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_CHACHA20_POLY1305
+    # Note: The three unsets below are to be removed for Mbed TLS 4.0
+    scripts/config.py unset MBEDTLS_GCM_C
+    scripts/config.py unset MBEDTLS_CCM_C
+    scripts/config.py unset MBEDTLS_CHACHAPOLY_C
     #Disable TLS 1.3 (as no AEAD)
     scripts/config.py unset MBEDTLS_SSL_PROTO_TLS1_3
     # Enable CBC-legacy (controlled by MBEDTLS_CIPHER_MODE_CBC plus at least one block cipher (AES, ARIA, Camellia, DES))
@@ -2022,6 +2030,10 @@ component_test_tls1_2_default_cbc_legacy_cbc_etm_cipher_only_use_psa () {
     scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_CCM
     scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_GCM
     scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_CHACHA20_POLY1305
+    # Note: The three unsets below are to be removed for Mbed TLS 4.0
+    scripts/config.py unset MBEDTLS_GCM_C
+    scripts/config.py unset MBEDTLS_CCM_C
+    scripts/config.py unset MBEDTLS_CHACHAPOLY_C
     #Disable TLS 1.3 (as no AEAD)
     scripts/config.py unset MBEDTLS_SSL_PROTO_TLS1_3
     # Enable CBC-legacy (controlled by MBEDTLS_CIPHER_MODE_CBC plus at least one block cipher (AES, ARIA, Camellia, DES))

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1913,6 +1913,9 @@ component_test_tls1_2_default_stream_cipher_only_use_psa () {
     # Disable CBC. Note: When implemented, PSA_WANT_ALG_CBC_MAC will also need to be unset here to fully disable CBC
     scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_CBC_NO_PADDING
     scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_CBC_PKCS7
+    # Disable CBC-legacy (controlled by MBEDTLS_CIPHER_MODE_CBC plus at least one block cipher (AES, ARIA, Camellia, DES))
+    # Note: The unset below is to be removed for 4.0
+    scripts/config.py unset MBEDTLS_CIPHER_MODE_CBC
     # Disable CBC-EtM (controlled by the same as CBC-legacy plus MBEDTLS_SSL_ENCRYPT_THEN_MAC)
     scripts/config.py unset MBEDTLS_SSL_ENCRYPT_THEN_MAC
     # Enable stream (currently that's just the NULL pseudo-cipher (controlled by MBEDTLS_CIPHER_NULL_CIPHER))
@@ -1973,6 +1976,8 @@ component_test_tls1_2_deafult_cbc_legacy_cipher_only_use_psa () {
     #Disable TLS 1.3 (as no AEAD)
     scripts/config.py unset MBEDTLS_SSL_PROTO_TLS1_3
     # Enable CBC-legacy (controlled by MBEDTLS_CIPHER_MODE_CBC plus at least one block cipher (AES, ARIA, Camellia, DES))
+    # Note: The set below is to be removed for 4.0
+    scripts/config.py set MBEDTLS_CIPHER_MODE_CBC
     # Note: When implemented, PSA_WANT_ALG_CBC_MAC will also need to be set here to fully enable CBC
     scripts/config.py -f $CRYPTO_CONFIG_H set PSA_WANT_ALG_CBC_NO_PADDING
     scripts/config.py -f $CRYPTO_CONFIG_H set PSA_WANT_ALG_CBC_PKCS7
@@ -2037,6 +2042,8 @@ component_test_tls1_2_default_cbc_legacy_cbc_etm_cipher_only_use_psa () {
     #Disable TLS 1.3 (as no AEAD)
     scripts/config.py unset MBEDTLS_SSL_PROTO_TLS1_3
     # Enable CBC-legacy (controlled by MBEDTLS_CIPHER_MODE_CBC plus at least one block cipher (AES, ARIA, Camellia, DES))
+    # Note: The set below is to be removed for 4.0
+    scripts/config.py set MBEDTLS_CIPHER_MODE_CBC
     # Note: When implemented, PSA_WANT_ALG_CBC_MAC will also need to be set here to fully enable CBC
     scripts/config.py -f $CRYPTO_CONFIG_H set PSA_WANT_ALG_CBC_NO_PADDING
     scripts/config.py -f $CRYPTO_CONFIG_H set PSA_WANT_ALG_CBC_PKCS7

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -2017,14 +2017,17 @@ component_test_tls1_2_default_cbc_legacy_cbc_etm_cipher_only_use_psa () {
     msg "build: default with only CBC-legacy and CBC-EtM ciphers use psa"
 
     scripts/config.py set MBEDTLS_USE_PSA_CRYPTO
+    scripts/config.py set MBEDTLS_PSA_CRYPTO_CONFIG
     # Disable AEAD (controlled by the presence of one of GCM_C, CCM_C, CHACHAPOLY_C)
-    scripts/config.py unset MBEDTLS_GCM_C
-    scripts/config.py unset MBEDTLS_CCM_C
-    scripts/config.py unset MBEDTLS_CHACHAPOLY_C
+    scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_CCM
+    scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_GCM
+    scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_CHACHA20_POLY1305
     #Disable TLS 1.3 (as no AEAD)
     scripts/config.py unset MBEDTLS_SSL_PROTO_TLS1_3
     # Enable CBC-legacy (controlled by MBEDTLS_CIPHER_MODE_CBC plus at least one block cipher (AES, ARIA, Camellia, DES))
-    scripts/config.py set MBEDTLS_CIPHER_MODE_CBC
+    # Note: When implemented, PSA_WANT_ALG_CBC_MAC will also need to be set here to fully enable CBC
+    scripts/config.py -f $CRYPTO_CONFIG_H set PSA_WANT_ALG_CBC_NO_PADDING
+    scripts/config.py -f $CRYPTO_CONFIG_H set PSA_WANT_ALG_CBC_PKCS7
     # Enable CBC-EtM (controlled by the same as CBC-legacy plus MBEDTLS_SSL_ENCRYPT_THEN_MAC)
     scripts/config.py set MBEDTLS_SSL_ENCRYPT_THEN_MAC
     # Disable stream (currently that's just the NULL pseudo-cipher (controlled by MBEDTLS_CIPHER_NULL_CIPHER))

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1899,14 +1899,16 @@ component_test_tls1_2_default_stream_cipher_only_use_psa () {
     msg "build: default with only stream cipher use psa"
 
     scripts/config.py set MBEDTLS_USE_PSA_CRYPTO
+    scripts/config.py set MBEDTLS_PSA_CRYPTO_CONFIG
     # Disable AEAD (controlled by the presence of one of GCM_C, CCM_C, CHACHAPOLY_C)
-    scripts/config.py unset MBEDTLS_GCM_C
-    scripts/config.py unset MBEDTLS_CCM_C
-    scripts/config.py unset MBEDTLS_CHACHAPOLY_C
+    scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_CCM
+    scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_GCM
+    scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_CHACHA20_POLY1305
     #Disable TLS 1.3 (as no AEAD)
     scripts/config.py unset MBEDTLS_SSL_PROTO_TLS1_3
-    # Disable CBC-legacy (controlled by MBEDTLS_CIPHER_MODE_CBC plus at least one block cipher (AES, ARIA, Camellia, DES))
-    scripts/config.py unset MBEDTLS_CIPHER_MODE_CBC
+    # Disable CBC. Note: When implemented, PSA_WANT_ALG_CBC_MAC will also need to be unset here to fully disable CBC
+    scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_CBC_NO_PADDING
+    scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_CBC_PKCS7
     # Disable CBC-EtM (controlled by the same as CBC-legacy plus MBEDTLS_SSL_ENCRYPT_THEN_MAC)
     scripts/config.py unset MBEDTLS_SSL_ENCRYPT_THEN_MAC
     # Enable stream (currently that's just the NULL pseudo-cipher (controlled by MBEDTLS_CIPHER_NULL_CIPHER))

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1957,14 +1957,17 @@ component_test_tls1_2_deafult_cbc_legacy_cipher_only_use_psa () {
     msg "build: default with only CBC-legacy cipher use psa"
 
     scripts/config.py set MBEDTLS_USE_PSA_CRYPTO
+    scripts/config.py set MBEDTLS_PSA_CRYPTO_CONFIG
     # Disable AEAD (controlled by the presence of one of GCM_C, CCM_C, CHACHAPOLY_C)
-    scripts/config.py unset MBEDTLS_GCM_C
-    scripts/config.py unset MBEDTLS_CCM_C
-    scripts/config.py unset MBEDTLS_CHACHAPOLY_C
+    scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_CCM
+    scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_GCM
+    scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_CHACHA20_POLY1305
     #Disable TLS 1.3 (as no AEAD)
     scripts/config.py unset MBEDTLS_SSL_PROTO_TLS1_3
     # Enable CBC-legacy (controlled by MBEDTLS_CIPHER_MODE_CBC plus at least one block cipher (AES, ARIA, Camellia, DES))
-    scripts/config.py set MBEDTLS_CIPHER_MODE_CBC
+    # Note: When implemented, PSA_WANT_ALG_CBC_MAC will also need to be set here to fully enable CBC
+    scripts/config.py -f $CRYPTO_CONFIG_H set PSA_WANT_ALG_CBC_NO_PADDING
+    scripts/config.py -f $CRYPTO_CONFIG_H set PSA_WANT_ALG_CBC_PKCS7
     # Disable CBC-EtM (controlled by the same as CBC-legacy plus MBEDTLS_SSL_ENCRYPT_THEN_MAC)
     scripts/config.py unset MBEDTLS_SSL_ENCRYPT_THEN_MAC
     # Disable stream (currently that's just the NULL pseudo-cipher (controlled by MBEDTLS_CIPHER_NULL_CIPHER))

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1868,33 +1868,6 @@ component_test_full_no_bignum () {
     make test
 }
 
-component_test_tls1_2_default_stream_cipher_only () {
-    msg "build: default with only stream cipher"
-
-    # Disable AEAD (controlled by the presence of one of GCM_C, CCM_C, CHACHAPOLY_C
-    scripts/config.py unset MBEDTLS_GCM_C
-    scripts/config.py unset MBEDTLS_CCM_C
-    scripts/config.py unset MBEDTLS_CHACHAPOLY_C
-    #Disable TLS 1.3 (as no AEAD)
-    scripts/config.py unset MBEDTLS_SSL_PROTO_TLS1_3
-    # Disable CBC-legacy (controlled by MBEDTLS_CIPHER_MODE_CBC plus at least one block cipher (AES, ARIA, Camellia, DES))
-    scripts/config.py unset MBEDTLS_CIPHER_MODE_CBC
-    # Disable CBC-EtM (controlled by the same as CBC-legacy plus MBEDTLS_SSL_ENCRYPT_THEN_MAC)
-    scripts/config.py unset MBEDTLS_SSL_ENCRYPT_THEN_MAC
-    # Enable stream (currently that's just the NULL pseudo-cipher (controlled by MBEDTLS_CIPHER_NULL_CIPHER))
-    scripts/config.py set MBEDTLS_CIPHER_NULL_CIPHER
-    # Modules that depend on AEAD
-    scripts/config.py unset MBEDTLS_SSL_CONTEXT_SERIALIZATION
-    scripts/config.py unset MBEDTLS_SSL_TICKET_C
-
-    make
-
-    msg "test: default with only stream cipher"
-    make test
-
-    # Not running ssl-opt.sh because most tests require a non-NULL ciphersuite.
-}
-
 component_test_tls1_2_default_stream_cipher_only_use_psa () {
     msg "build: default with only stream cipher use psa"
 
@@ -1932,34 +1905,6 @@ component_test_tls1_2_default_stream_cipher_only_use_psa () {
     # Not running ssl-opt.sh because most tests require a non-NULL ciphersuite.
 }
 
-component_test_tls1_2_default_cbc_legacy_cipher_only () {
-    msg "build: default with only CBC-legacy cipher"
-
-    # Disable AEAD (controlled by the presence of one of GCM_C, CCM_C, CHACHAPOLY_C)
-    scripts/config.py unset MBEDTLS_GCM_C
-    scripts/config.py unset MBEDTLS_CCM_C
-    scripts/config.py unset MBEDTLS_CHACHAPOLY_C
-    #Disable TLS 1.3 (as no AEAD)
-    scripts/config.py unset MBEDTLS_SSL_PROTO_TLS1_3
-    # Enable CBC-legacy (controlled by MBEDTLS_CIPHER_MODE_CBC plus at least one block cipher (AES, ARIA, Camellia, DES))
-    scripts/config.py set MBEDTLS_CIPHER_MODE_CBC
-    # Disable CBC-EtM (controlled by the same as CBC-legacy plus MBEDTLS_SSL_ENCRYPT_THEN_MAC)
-    scripts/config.py unset MBEDTLS_SSL_ENCRYPT_THEN_MAC
-    # Disable stream (currently that's just the NULL pseudo-cipher (controlled by MBEDTLS_CIPHER_NULL_CIPHER))
-    scripts/config.py unset MBEDTLS_CIPHER_NULL_CIPHER
-    # Modules that depend on AEAD
-    scripts/config.py unset MBEDTLS_SSL_CONTEXT_SERIALIZATION
-    scripts/config.py unset MBEDTLS_SSL_TICKET_C
-
-    make
-
-    msg "test: default with only CBC-legacy cipher"
-    make test
-
-    msg "test: default with only CBC-legacy cipher - ssl-opt.sh (subset)"
-    tests/ssl-opt.sh -f "TLS 1.2"
-}
-
 component_test_tls1_2_deafult_cbc_legacy_cipher_only_use_psa () {
     msg "build: default with only CBC-legacy cipher use psa"
 
@@ -1995,34 +1940,6 @@ component_test_tls1_2_deafult_cbc_legacy_cipher_only_use_psa () {
     make test
 
     msg "test: default with only CBC-legacy cipher use psa - ssl-opt.sh (subset)"
-    tests/ssl-opt.sh -f "TLS 1.2"
-}
-
-component_test_tls1_2_default_cbc_legacy_cbc_etm_cipher_only () {
-    msg "build: default with only CBC-legacy and CBC-EtM ciphers"
-
-    # Disable AEAD (controlled by the presence of one of GCM_C, CCM_C, CHACHAPOLY_C)
-    scripts/config.py unset MBEDTLS_GCM_C
-    scripts/config.py unset MBEDTLS_CCM_C
-    scripts/config.py unset MBEDTLS_CHACHAPOLY_C
-    #Disable TLS 1.3 (as no AEAD)
-    scripts/config.py unset MBEDTLS_SSL_PROTO_TLS1_3
-    # Enable CBC-legacy (controlled by MBEDTLS_CIPHER_MODE_CBC plus at least one block cipher (AES, ARIA, Camellia, DES))
-    scripts/config.py set MBEDTLS_CIPHER_MODE_CBC
-    # Enable CBC-EtM (controlled by the same as CBC-legacy plus MBEDTLS_SSL_ENCRYPT_THEN_MAC)
-    scripts/config.py set MBEDTLS_SSL_ENCRYPT_THEN_MAC
-    # Disable stream (currently that's just the NULL pseudo-cipher (controlled by MBEDTLS_CIPHER_NULL_CIPHER))
-    scripts/config.py unset MBEDTLS_CIPHER_NULL_CIPHER
-    # Modules that depend on AEAD
-    scripts/config.py unset MBEDTLS_SSL_CONTEXT_SERIALIZATION
-    scripts/config.py unset MBEDTLS_SSL_TICKET_C
-
-    make
-
-    msg "test: default with only CBC-legacy and CBC-EtM ciphers"
-    make test
-
-    msg "test: default with only CBC-legacy and CBC-EtM ciphers - ssl-opt.sh (subset)"
     tests/ssl-opt.sh -f "TLS 1.2"
 }
 

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1921,11 +1921,7 @@ component_test_tls1_2_default_cbc_legacy_cipher_only () {
     #Disable TLS 1.3 (as no AEAD)
     scripts/config.py unset MBEDTLS_SSL_PROTO_TLS1_3
     # Enable CBC-legacy (controlled by MBEDTLS_CIPHER_MODE_CBC plus at least one block cipher (AES, ARIA, Camellia, DES))
-    # Note: The set below is to be removed for 4.0
-    scripts/config.py set MBEDTLS_CIPHER_MODE_CBC
-    # Note: When implemented, PSA_WANT_ALG_CBC_MAC will also need to be set here to fully enable CBC
     scripts/config.py -f $CRYPTO_CONFIG_H set PSA_WANT_ALG_CBC_NO_PADDING
-    scripts/config.py -f $CRYPTO_CONFIG_H set PSA_WANT_ALG_CBC_PKCS7
     # Disable CBC-EtM (controlled by the same as CBC-legacy plus MBEDTLS_SSL_ENCRYPT_THEN_MAC)
     scripts/config.py unset MBEDTLS_SSL_ENCRYPT_THEN_MAC
     # Disable stream (currently that's just the NULL pseudo-cipher (controlled by MBEDTLS_CIPHER_NULL_CIPHER))
@@ -1959,11 +1955,7 @@ component_test_tls1_2_default_cbc_legacy_cbc_etm_cipher_only () {
     #Disable TLS 1.3 (as no AEAD)
     scripts/config.py unset MBEDTLS_SSL_PROTO_TLS1_3
     # Enable CBC-legacy (controlled by MBEDTLS_CIPHER_MODE_CBC plus at least one block cipher (AES, ARIA, Camellia, DES))
-    # Note: The set below is to be removed for 4.0
-    scripts/config.py set MBEDTLS_CIPHER_MODE_CBC
-    # Note: When implemented, PSA_WANT_ALG_CBC_MAC will also need to be set here to fully enable CBC
     scripts/config.py -f $CRYPTO_CONFIG_H set PSA_WANT_ALG_CBC_NO_PADDING
-    scripts/config.py -f $CRYPTO_CONFIG_H set PSA_WANT_ALG_CBC_PKCS7
     # Enable CBC-EtM (controlled by the same as CBC-legacy plus MBEDTLS_SSL_ENCRYPT_THEN_MAC)
     scripts/config.py set MBEDTLS_SSL_ENCRYPT_THEN_MAC
     # Disable stream (currently that's just the NULL pseudo-cipher (controlled by MBEDTLS_CIPHER_NULL_CIPHER))


### PR DESCRIPTION
## Description
Progresses #8153.

Replace Mbed TLS API config options with their PSA API equivalents in three TLS 1.2 components in `all.sh`.

This PR modifies the following three components:
- test_tls1_2_default_stream_cipher_only_use_psa
- test_tls1_2_deafult_cbc_legacy_cipher_only_use_psa
- test_tls1_2_default_cbc_legacy_cbc_etm_cipher_only_use_psa

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required
- [x] **3.6 backport** 4.0 only
- [x] **2.28 backport** 4.0 only
- [x] **tests** existing tests suffice



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
