### PR TITLE
Add early exit if zero length AEAD additional data passed in.

### DIFF
--- a/ChangeLog.d/fix_ubsan_mp_aead_gcm.txt
+++ b/ChangeLog.d/fix_ubsan_mp_aead_gcm.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix undefined behaviour (incrementing a NULL pointer by zero length) when
+     passing in zero length additional data to multipart AEAD.

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -5194,6 +5194,12 @@ psa_status_t psa_aead_update_ad(psa_aead_operation_t *operation,
         goto exit;
     }
 
+    /* No input to add (zero length), nothing to do. */
+    if (input_length == 0) {
+        status = PSA_SUCCESS;
+        goto exit;
+    }
+
     if (operation->lengths_set) {
         if (operation->ad_remaining < input_length) {
             status = PSA_ERROR_INVALID_ARGUMENT;


### PR DESCRIPTION
## Description

With multipart AEAD, if we attempt to add zero length additional data, then with the buffer sharing fixes this can now lead to undefined behaviour when using gcm because where we had a valid pointer but zero length before buffer sharing, we now have a NULL pointer and zero length.

Fix this by returning early, as there is nothing to do if the input length is zero. Fixes #9064

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [ ] **changelog** provided, ~~or not required~~
- [ ] **3.6 backport** done ~~, or not required~~ ( #9066 )
- [ ] **2.28 backport** ~~done, or~~ not required (Issue does not exist in 2.28)
- [ ] **tests** ~~provided, or~~ not required (Existing tests cover this, and detect it with clang 16.06)
