### PR TITLE
Fix skipped tests in configurations without RSA

### DIFF
--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -443,9 +443,9 @@ detect_required_features() {
     esac
 
     case "$CMD_LINE" in
-        *server5*|\
-        *server7*|\
-        *dir-maxpath*)
+        */server5*|\
+        */server7*|\
+        */dir-maxpath*)
             if [ "$TLS_VERSION" = "TLS13" ]; then
                 # In case of TLS13 the support for ECDSA is enough
                 requires_pk_alg "ECDSA"
@@ -477,8 +477,8 @@ detect_required_features() {
     esac
 
     case "$CMD_LINE" in
-        *server2*|\
-        *server7*)
+        */server2*|\
+        */server7*)
             # server2 and server7 certificates use RSA encryption
             requires_config_enabled "MBEDTLS_RSA_C"
     esac


### PR DESCRIPTION
Tighten the matching when detecting which certificates are in use to determine algorithm requirements. This fixes a bug whereby all tests were skipped in configurations without RSA except for an Mbed TLS client against a GnuTLS or OpenSSL server, due to *server2* matching ssl_server2. Fixes #8366.

## PR checklist

- [x] **changelog** no (test only)
- [ ] **3.6 backport** TODO
- [x] **2.28 backport** no (no such dependency autodetection in 2.28)
- [ ] **tests** check that `test-ref-configs` doesn't [skip all `ssl-opt` tests](https://github.com/Mbed-TLS/mbedtls/issues/9063) anymore
