### PR TITLE
Wipe the returned slot pointer upon failure in `psa_get_and_lock_key_slot`

### DIFF
--- a/ChangeLog.d/fix-concurrently-loading-non-existent-keys.txt
+++ b/ChangeLog.d/fix-concurrently-loading-non-existent-keys.txt
@@ -1,0 +1,4 @@
+Bugfix
+   * Fix rare concurrent access bug where attempting to operate on a
+     non-existent key while concurrently creating a new key could potentially
+     corrupt the key store.

--- a/library/psa_crypto_slot_management.c
+++ b/library/psa_crypto_slot_management.c
@@ -440,6 +440,9 @@ psa_status_t psa_get_and_lock_key_slot(mbedtls_svc_key_id_t key,
     status = PSA_ERROR_INVALID_HANDLE;
 #endif /* MBEDTLS_PSA_CRYPTO_STORAGE_C || MBEDTLS_PSA_CRYPTO_BUILTIN_KEYS */
 
+    if (status != PSA_SUCCESS) {
+        *p_slot = NULL;
+    }
 #if defined(MBEDTLS_THREADING_C)
     PSA_THREADING_CHK_RET(mbedtls_mutex_unlock(
                               &mbedtls_threading_key_slot_mutex));

--- a/library/psa_crypto_slot_management.c
+++ b/library/psa_crypto_slot_management.c
@@ -424,6 +424,8 @@ psa_status_t psa_get_and_lock_key_slot(mbedtls_svc_key_id_t key,
     if (status != PSA_SUCCESS) {
         psa_wipe_key_slot(*p_slot);
 
+        /* If the key does not exist, we need to return
+         * PSA_ERROR_INVALID_HANDLE. */
         if (status == PSA_ERROR_DOES_NOT_EXIST) {
             status = PSA_ERROR_INVALID_HANDLE;
         }

--- a/library/psa_crypto_slot_management.h
+++ b/library/psa_crypto_slot_management.h
@@ -58,6 +58,9 @@ static inline int psa_key_id_is_volatile(psa_key_id_t key_id)
  * It is the responsibility of the caller to call psa_unregister_read(slot)
  * when they have finished reading the contents of the slot.
  *
+ * On failure, `*p_slot` is set to NULL. This ensures that it is always valid
+ * to call psa_unregister_read on the returned slot.
+ *
  * \param key           Key identifier to query.
  * \param[out] p_slot   On success, `*p_slot` contains a pointer to the
  *                      key slot containing the description of the key


### PR DESCRIPTION
## Description

Throughout the code we assume that it is valid to call `psa_unregister_read(slot)` after calling `psa_get_and_lock_key_slot(key, slot)`, even if the latter call failed. This assumption previously didn't hold, which meant that a set of concurrent key management calls could render the key store in an inconsistent state. This PR makes the assumption official, and upholds it.

Without this change, a bug can occur as follows:
1. Thread A calls some operation on a key `key`.
2. Thread A initializes `slotA` to `NULL`.
3. Thread A calls `psa_get_and_lock_key_slot(key, &slotA)`. When A takes the mutex `key` does not refer to any valid key (it may have existed but been deleted by another thread, or may have never existed).
4. Since the key is not in the key store, the call will reserve some free key slot `n` and set `slotA = n`.
5. The key is not a valid persistent or builtin key, so `PSA_ERROR_INVALID_HANDLE` is returned. `slotA` is still a pointer to `n`, a now `PSA_SLOT_EMPTY` slot.
6. A different thread B loads a key into `n`, this is entirely valid as `n` is in the empty state.
7. Thread A reaches the exit portion of their operation, where `psa_unregister_read_under_mutex(slotA)` is called regardless of return code.
8. Thread A attempts to unregister from a slot which they were not registered to, leading to `PSA_ERROR_CORRUPTION_DETECTED`.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** provided
- [x] **3.6 backport** #9077 
- [x] **2.28 backport** not required
- [x] **tests** provided. This is already tested by the `concurrently_use_and_destroy_same_persistent_key_tests`. The code-path for the bug to occur is not trivial, which could explain how the CI has not yet caught it. This is always a risk with concurrent testing, it is infeasible to test every scenario consistently.
