### PR TITLE
Undefined reference to mbedtls_md_error_from_psa() function

### DIFF
--- a/library/md.c
+++ b/library/md.c
@@ -41,7 +41,7 @@
 #include "mbedtls/sha512.h"
 #include "mbedtls/sha3.h"
 
-#if defined(MBEDTLS_PSA_CRYPTO_C)
+#if defined(MBEDTLS_PSA_CRYPTO_CLIENT)
 #include <psa/crypto.h>
 #include "md_psa.h"
 #include "psa_util_internal.h"
@@ -761,13 +761,13 @@ mbedtls_md_type_t mbedtls_md_get_type(const mbedtls_md_info_t *md_info)
     return md_info->type;
 }
 
-#if defined(MBEDTLS_PSA_CRYPTO_C)
+#if defined(MBEDTLS_PSA_CRYPTO_CLIENT)
 int mbedtls_md_error_from_psa(psa_status_t status)
 {
     return PSA_TO_MBEDTLS_ERR_LIST(status, psa_to_md_errors,
                                    psa_generic_status_to_mbedtls);
 }
-#endif /* MBEDTLS_PSA_CRYPTO_C */
+#endif /* MBEDTLS_PSA_CRYPTO_CLIENT */
 
 
 /************************************************************************


### PR DESCRIPTION
This PR fixes guards for `mbedtls_md_error_from_psa()`.

Resolves #9068.

## PR checklist

- [x] **changelog** not required - support for `CRYPTO_CLIENT && !CRYPTO_C` is still unofficial
- [x] **3.6 backport** https://github.com/Mbed-TLS/mbedtls/pull/9090
- [x] **2.28 backport** not required - this is not in 2.28
- [x] **tests** not required