### PR TITLE
Add invalid `padding_len` check in `get_pkcs_padding`

### DIFF
--- a/library/cipher.c
+++ b/library/cipher.c
@@ -849,6 +849,9 @@ static int get_pkcs_padding(unsigned char *input, size_t input_len,
     }
 
     padding_len = input[input_len - 1];
+    if (padding_len == 0 || padding_len > (int)input_len) {
+        return MBEDTLS_ERR_CIPHER_INVALID_PADDING;
+    }
     *data_len = input_len - padding_len;
 
     mbedtls_ct_condition_t bad = mbedtls_ct_uint_gt(padding_len, input_len);

--- a/library/cipher.c
+++ b/library/cipher.c
@@ -849,7 +849,7 @@ static int get_pkcs_padding(unsigned char *input, size_t input_len,
     }
 
     padding_len = input[input_len - 1];
-    if (padding_len == 0 || padding_len > (int)input_len) {
+    if (padding_len == 0 || padding_len > input_len) {
         return MBEDTLS_ERR_CIPHER_INVALID_PADDING;
     }
     *data_len = input_len - padding_len;

--- a/tests/suites/test_suite_cipher.function
+++ b/tests/suites/test_suite_cipher.function
@@ -549,6 +549,10 @@ void enc_fail(int cipher_id, int pad_mode, int key_len, int length_val,
     /* encode length number of bytes from inbuf */
     TEST_ASSERT(0 == mbedtls_cipher_update(&ctx, inbuf, length, encbuf, &outlen));
     TEST_ASSERT(ret == mbedtls_cipher_finish(&ctx, encbuf + outlen, &outlen));
+    if (0 != ret) {
+        /* Check output parameter is set to the least-harmful value on error */
+        TEST_ASSERT(0 == outlen);
+    }
 
     /* done */
 exit:
@@ -826,6 +830,10 @@ void decrypt_test_vec(int cipher_id, int pad_mode, data_t *key,
     total_len += outlen;
     TEST_ASSERT(finish_result == mbedtls_cipher_finish(&ctx, output + outlen,
                                                        &outlen));
+    if (0 != finish_result) {
+        /* Check output parameter is set to the least-harmful value on error */
+        TEST_ASSERT(0 == outlen);
+    }
     total_len += outlen;
 #if defined(MBEDTLS_GCM_C) || defined(MBEDTLS_CHACHAPOLY_C)
     int tag_expected = (ctx.cipher_info->mode == MBEDTLS_MODE_GCM ||


### PR DESCRIPTION
When trying to decrypt data with an invalid key, we found that `mbedtls` returned `0x6200` (`-25088`), which means "_CIPHER - Input data contains invalid padding and is rejected_" from `mbedtls_cipher_finish`, but it also set the output len as `18446744073709551516`.

In case we detect an error with padding, we leave the output len zero'ed and return `MBEDTLS_ERR_CIPHER_INVALID_PADDING`. I believe that the current test cases are sufficient, as they fail if I return the alternative code `MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA`, so they do already expect a padding failure, but now we don't change the output len in the error case.

Here's a reference for the way `openssl` checks the padding length:
  - https://github.com/openssl/openssl/blob/1848c561ec39a9ea91ff1bf740a554be274f98b0/crypto/evp/evp_enc.c#L1023
  - https://github.com/openssl/openssl/commit/b554eef43b9ac5b92f590da6a120dbfd9ca0582e

## Description

Adds a missing check when doing the padding check in the case of `MBEDTLS_CIPHER_AES_128_CBC` decryption with padding. Even thought `mbedtls` was returning an error, the output parameter was being set instead of leaving it with zero. This check exists in `openssl`, so this makes the behavior closer between both libraries.

Closes #9083.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** no (robustness improvement)
- [x] **3.6 backport** https://github.com/Mbed-TLS/mbedtls/pull/9132
- [x] **2.28 backport** not required
- [x] **tests** yes

