### PR TITLE
Backport 3.6: Fixed issue of redefinition warning messages for _GNU_SOURCE

### DIFF
--- a/ChangeLog.d/fix-redefination_warning_messages_for_GNU_SOURCE.txt
+++ b/ChangeLog.d/fix-redefination_warning_messages_for_GNU_SOURCE.txt
@@ -1,5 +1,5 @@
 Bugfix
-   * Fix issue of redefinition warning messages for _GNU_SOURCE in 
-     entropy_poll.c and sha_256.c. There was a build warning during 
+   * Fix issue of redefinition warning messages for _GNU_SOURCE in
+     entropy_poll.c and sha_256.c. There was a build warning during
      building for linux platform.
      Resolves #9026

--- a/ChangeLog.d/fix-redefination_warning_messages_for_GNU_SOURCE.txt
+++ b/ChangeLog.d/fix-redefination_warning_messages_for_GNU_SOURCE.txt
@@ -1,0 +1,5 @@
+Bugfix
+   * Fix issue of redefinition warning messages for _GNU_SOURCE in 
+     entropy_poll.c and sha_256.c. There was a build warning during 
+     building for linux platform.
+     Resolves #9026

--- a/library/entropy_poll.c
+++ b/library/entropy_poll.c
@@ -5,9 +5,11 @@
  *  SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
  */
 
-#if defined(__linux__) || defined(__midipix__) && !defined(_GNU_SOURCE)
+#if defined(__linux__) || defined(__midipix__)
 /* Ensure that syscall() is available even when compiling with -std=c99 */
+#if !defined(_GNU_SOURCE)
 #define _GNU_SOURCE
+#endif
 #endif
 
 #include "common.h"

--- a/library/sha256.c
+++ b/library/sha256.c
@@ -44,7 +44,9 @@
 #endif /* defined(__clang__) &&  (__clang_major__ >= 4) */
 
 /* Ensure that SIG_SETMASK is defined when -std=c99 is used. */
+#if !defined(_GNU_SOURCE)
 #define _GNU_SOURCE
+#endif
 
 #include "common.h"
 


### PR DESCRIPTION
## Description

This commit solves the issue of redefinition warning messages for _GNU_SOURCE while building on Linux platform.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** provided
- [x] **2.28 backport** #9086
- [x] **3.6 backport** this is the 3.6 backport of #9026
- [x] **tests** not required

## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
