### PR TITLE
ChangeLog: Add missing reference to CVE in security entry

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -144,6 +144,7 @@ Security
    * Fix a stack buffer overread (less than 256 bytes) when parsing a TLS 1.3
      ClientHello in a TLS 1.3 server supporting some PSK key exchange mode. A
      malicious client could cause information disclosure or a denial of service.
+     Fixes CVE-2024-30166.
    * Passing buffers that are stored in untrusted memory as arguments
      to PSA functions is now secure by default.
      The PSA core now protects against modification of inputs or exposure


### PR DESCRIPTION
## Description
Add missing reference to CVE-2024-30166 in security entry

## PR checklist
Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [ ] **changelog** not required, fix of a ChangeLog entry
- [ ] **3.6 backport** required, todo
- [ ] **2.28 backport** not required, the ChangeLog entry that is fixed is not in 2.28
- [ ] **tests** not required

