### PR TITLE
Extend basic checks and C coding style check to framework files

### DIFF
--- a/tests/scripts/check_files.py
+++ b/tests/scripts/check_files.py
@@ -373,7 +373,7 @@ class LicenseIssueTracker(LineIssueTracker):
         r'3rdparty/(?!(p256-m)/.*)',
         # Documentation explaining the license may have accidental
         # false positives.
-        r'(ChangeLog|LICENSE|[-0-9A-Z_a-z]+\.md)\Z',
+        r'(ChangeLog|LICENSE|framework\/LICENSE|[-0-9A-Z_a-z]+\.md)\Z',
         # Files imported from TF-M, and not used except in test builds,
         # may be under a different license.
         r'configs/ext/crypto_config_profile_medium\.h\Z',
@@ -381,6 +381,7 @@ class LicenseIssueTracker(LineIssueTracker):
         r'configs/ext/README\.md\Z',
         # Third-party file.
         r'dco\.txt\Z',
+        r'framework\/dco\.txt\Z',
     ]
     path_exemptions = re.compile('|'.join(BINARY_FILE_PATH_RE_LIST +
                                           LICENSE_EXEMPTION_RE_LIST))
@@ -486,7 +487,8 @@ class IntegrityChecker:
 
         These are the regular files commited into Git.
         """
-        bytes_output = subprocess.check_output(['git', 'ls-files', '-z'])
+        bytes_output = subprocess.check_output(['git', 'ls-files',
+                                                '--recurse-submodules', '-z'])
         bytes_filepaths = bytes_output.split(b'\0')[:-1]
         ascii_filepaths = map(lambda fp: fp.decode('ascii'), bytes_filepaths)
         # Filter out directories. Normally Git doesn't list directories

--- a/tests/scripts/check_files.py
+++ b/tests/scripts/check_files.py
@@ -487,10 +487,17 @@ class IntegrityChecker:
 
         These are the regular files commited into Git.
         """
-        bytes_output = subprocess.check_output(['git', 'ls-files',
-                                                '--recurse-submodules', '-z'])
-        bytes_filepaths = bytes_output.split(b'\0')[:-1]
+        bytes_output = subprocess.check_output(['git', '-C', 'framework',
+                                                'ls-files', '-z'])
+        bytes_framework_filepaths = bytes_output.split(b'\0')[:-1]
+        bytes_framework_filepaths = ["framework/".encode() + filepath
+                                     for filepath in bytes_framework_filepaths]
+
+        bytes_output = subprocess.check_output(['git', 'ls-files', '-z'])
+        bytes_filepaths = bytes_output.split(b'\0')[:-1] + \
+                          bytes_framework_filepaths
         ascii_filepaths = map(lambda fp: fp.decode('ascii'), bytes_filepaths)
+
         # Filter out directories. Normally Git doesn't list directories
         # (it only knows about the files inside them), but there is
         # at least one case where 'git ls-files' includes a directory:


### PR DESCRIPTION
## Description
Extend basic checks and C coding style checks to framework files
Progresses https://github.com/Mbed-TLS/mbedtls-framework/issues/7

## PR checklist
- [x] **changelog** not required, only check scripts are changed
- [x] **3.6 backport** #9196 
- [x] **2.28 backport** not required, no framework submodule in 2.28
- [x] **tests** not required
