### PR TITLE
[Backport 3.6] ChangeLog: Add missing reference to CVE in security entry

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -144,6 +144,7 @@ Security
    * Fix a stack buffer overread (less than 256 bytes) when parsing a TLS 1.3
      ClientHello in a TLS 1.3 server supporting some PSK key exchange mode. A
      malicious client could cause information disclosure or a denial of service.
+     Fixes CVE-2024-30166.
    * Passing buffers that are stored in untrusted memory as arguments
      to PSA functions is now secure by default.
      The PSA core now protects against modification of inputs or exposure


### PR DESCRIPTION
## Description
Backport to 3.6 of #9087

## PR checklist
- [ ] **changelog** not required, fix of a ChangeLog entry
- [ ] **3.6 backport** n/a, this is a backport
- [ ] **2.28 backport** n/a, this is a backport
- [ ] **tests** not required