### PR TITLE
mbedtls_net_send API description typo fix

### DIFF
--- a/include/mbedtls/net_sockets.h
+++ b/include/mbedtls/net_sockets.h
@@ -229,7 +229,7 @@ int mbedtls_net_recv(void *ctx, unsigned char *buf, size_t len);
 
 /**
  * \brief          Write at most 'len' characters. If no error occurs,
- *                 the actual amount read is returned.
+ *                 the actual amount written is returned.
  *
  * \param ctx      Socket
  * \param buf      The buffer to read from


### PR DESCRIPTION
## Description

Minor correction to API documentation for `mbedtls_net_send()`.

## PR checklist

- [x] **changelog** not required
- [x] **crypto** not required: TLS only
- [x] **development** here
- [x] **3.6 backport** https://github.com/Mbed-TLS/mbedtls/pull/10058
- [x] **2.28 backport** https://github.com/Mbed-TLS/mbedtls/pull/10059
- [x] **tests** not required