### PR TITLE
Add a component to all.sh to build and run psasim

### DIFF
--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -6165,6 +6165,16 @@ component_check_test_helpers () {
     python3 -m unittest tests/scripts/translate_ciphers.py 2>&1
 }
 
+component_test_psasim() {
+    msg "build psasim"
+    make -C tests/psa-client-server/psasim
+
+    msg "test psasim"
+    make -C tests/psa-client-server/psasim run
+
+    msg "clean psasim"
+    make -C tests/psa-client-server/psasim clean
+}
 
 ################################################################
 #### Termination


### PR DESCRIPTION
## Description

This PR adds a new `component` in `all.sh` to build and test `psasim`.

Resolves #8962

## PR checklist

- [ ] **changelog** not required: internal testing only
- [ ] **3.6 backport** not required: new feature
- [ ] **2.28 backport** not required: new feature
- [ ] **tests** not required: internal testing only