### PR TITLE
ssl_client2: Add Host to HTTP GET request

### DIFF
--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -108,7 +108,7 @@ int main(void)
 #define DFL_SRTP_MKI            ""
 #define DFL_KEY_OPAQUE_ALG      "none"
 
-#define GET_REQUEST "GET %s HTTP/1.0\r\nExtra-header: "
+#define GET_REQUEST "GET %s HTTP/1.0\r\nHost: %s\r\nExtra-header: "
 #define GET_REQUEST_END "\r\n\r\n"
 
 #if defined(MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED)
@@ -724,7 +724,7 @@ static int build_http_request(unsigned char *buf, size_t buf_size, size_t *reque
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     size_t len, tail_len, request_size;
 
-    ret = mbedtls_snprintf((char *) buf, buf_size, GET_REQUEST, opt.request_page);
+    ret = mbedtls_snprintf((char *) buf, buf_size, GET_REQUEST, opt.request_page, opt.server_name);
     if (ret < 0) {
         return ret;
     }


### PR DESCRIPTION
## Description

If an IP address shares multiple domain names with different SSL certificates and makes a GET request without the remote server name (host), it will fail with a 421 Misdirect Request.

Please read https://github.com/Mbed-TLS/mbedtls/issues/9093 for more details on how to reproduce the problem that this PR is addressing and further details. 

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [ ] ~~**changelog** provided~~. _Not required_. Please let me know if it's required to update the changelog.
- [X] **3.6 backport**. 
- [ ] ~~**2.28 backport**~~. N/A
- [ ] **tests** provided. _Waiting on CI results_

## Notes for the submitter

- [X] Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the checklist for PR contributors.

Help make review efficient:
- [X] Multiple simple commits
  - [X] please structure your PR into a series of small commits, each of which does one thing
- [X] Avoid force-push
  - [X] please do not force-push to update your PR - just add new commit(s)
- [X] See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
