### PR TITLE
make_generated_files.bat: document C compiler requirement

### DIFF
--- a/scripts/make_generated_files.bat
+++ b/scripts/make_generated_files.bat
@@ -3,6 +3,8 @@
 @rem Requirements:
 @rem * Perl must be on the PATH ("perl" command).
 @rem * Python 3.8 or above must be on the PATH ("python" command).
+@rem * Either a C compiler called "cc" must be on the PATH, or
+@rem   the "CC" environment variable must point to a C compiler.
 
 @rem @@@@ library\** @@@@
 @rem psa_crypto_driver_wrappers.h needs to be generated prior to

--- a/scripts/make_generated_files.bat
+++ b/scripts/make_generated_files.bat
@@ -1,6 +1,10 @@
 @rem Generate automatically-generated configuration-independent source files
 @rem and build scripts.
-@rem Perl and Python 3 must be on the PATH.
+@rem Requirements:
+@rem * Perl must be on the PATH ("perl" command).
+@rem * Python 3.8 or above must be on the PATH ("python" command).
+
+@rem @@@@ library\** @@@@
 @rem psa_crypto_driver_wrappers.h needs to be generated prior to
 @rem generate_visualc_files.pl being invoked.
 python scripts\generate_driver_wrappers.py || exit /b 1
@@ -8,8 +12,14 @@ perl scripts\generate_errors.pl || exit /b 1
 perl scripts\generate_query_config.pl || exit /b 1
 perl scripts\generate_features.pl || exit /b 1
 python scripts\generate_ssl_debug_helpers.py || exit /b 1
+
+@rem @@@@ Build @@@@
 perl scripts\generate_visualc_files.pl || exit /b 1
+
+@rem @@@@ programs\** @@@@
 python scripts\generate_psa_constants.py || exit /b 1
+
+@rem @@@@ tests\** @@@@
 python tests\scripts\generate_bignum_tests.py || exit /b 1
 python tests\scripts\generate_ecp_tests.py || exit /b 1
 python tests\scripts\generate_psa_tests.py || exit /b 1


### PR DESCRIPTION
Document that `make_generated_files.bat` needs a C compiler as `%CC%` or `cc` (for `c_build_helper` users: `generate_psa_tests.py`).

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required (documentation improvement)
- [ ] **3.6 backport** TODO
- [x] **2.28 backport** not required (no such file in 2.28)
- [x] **tests** N/A
