### PR TITLE
Update gitignore for `test_keys.h`, `test_certs.h` and `.vscode`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ massif-*
 compile_commands.json
 # clangd index files
 /.cache/clangd/index/
+
+# VScode folder to store local debug files and configurations
+.vscode

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -21,4 +21,6 @@ libtestdriver1/*
 /suites/*.generated.data
 /suites/test_suite_psa_crypto_storage_format.v[0-9]*.data
 /suites/test_suite_psa_crypto_storage_format.current.data
+/src/test_keys.h
+/src/test_certs.h
 ###END_GENERATED_FILES###


### PR DESCRIPTION
## Description

This quick PR fixes a missing update to `.gitignore` in #9017: since `test_certs.h` and `test_keys.h` are automatically generated at build time, they should not be tracked.

While at this, this PR also adds `.vscode` to the `.gitignore` file at the MbedTLS root in order to ignore that local configuration folder automatically created by VScode.

## PR checklist

- [x] **changelog** not required
- [x] **3.6 backport** #9130
- [x] **2.28 backport** not required - generated files are committed in that branch
- [x] **tests** not required
