### PR TITLE
[Backport] Update gitignore for `test_keys.h`, `test_certs.h` and `.vscode`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ massif-*
 compile_commands.json
 # clangd index files
 /.cache/clangd/index/
+
+# VScode folder to store local debug files and configurations
+.vscode

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -21,4 +21,6 @@ libtestdriver1/*
 /suites/*.generated.data
 /suites/test_suite_psa_crypto_storage_format.v[0-9]*.data
 /suites/test_suite_psa_crypto_storage_format.current.data
+/src/test_keys.h
+/src/test_certs.h
 ###END_GENERATED_FILES###


### PR DESCRIPTION
## Description

This is the backport of #9129.
It simply cherry-picks commits from the #9129 to `mbedtls-3.6` branch.

## PR checklist

- [x] **changelog** not required
- [x] **3.6 backport** this is it
- [x] **2.28 backport** not required
- [x] **tests**  not required