### PR TITLE
Backport 3.6: Add invalid `padding_len` check in `get_pkcs_padding`

### DIFF
--- a/library/cipher.c
+++ b/library/cipher.c
@@ -849,6 +849,9 @@ static int get_pkcs_padding(unsigned char *input, size_t input_len,
     }
 
     padding_len = input[input_len - 1];
+    if (padding_len == 0 || padding_len > input_len) {
+        return MBEDTLS_ERR_CIPHER_INVALID_PADDING;
+    }
     *data_len = input_len - padding_len;
 
     mbedtls_ct_condition_t bad = mbedtls_ct_uint_gt(padding_len, input_len);

--- a/tests/suites/test_suite_cipher.function
+++ b/tests/suites/test_suite_cipher.function
@@ -549,6 +549,10 @@ void enc_fail(int cipher_id, int pad_mode, int key_len, int length_val,
     /* encode length number of bytes from inbuf */
     TEST_ASSERT(0 == mbedtls_cipher_update(&ctx, inbuf, length, encbuf, &outlen));
     TEST_ASSERT(ret == mbedtls_cipher_finish(&ctx, encbuf + outlen, &outlen));
+    if (0 != ret) {
+        /* Check output parameter is set to the least-harmful value on error */
+        TEST_ASSERT(0 == outlen);
+    }
 
     /* done */
 exit:
@@ -826,6 +830,10 @@ void decrypt_test_vec(int cipher_id, int pad_mode, data_t *key,
     total_len += outlen;
     TEST_ASSERT(finish_result == mbedtls_cipher_finish(&ctx, output + outlen,
                                                        &outlen));
+    if (0 != finish_result) {
+        /* Check output parameter is set to the least-harmful value on error */
+        TEST_ASSERT(0 == outlen);
+    }
     total_len += outlen;
 #if defined(MBEDTLS_GCM_C) || defined(MBEDTLS_CHACHAPOLY_C)
     int tag_expected = (ctx.cipher_info->mode == MBEDTLS_MODE_GCM ||


### PR DESCRIPTION
Trivial backport of https://github.com/Mbed-TLS/mbedtls/pull/9082

## PR checklist

- [x] **changelog** provided
- [x] **3.6 backport** done here
- [x] **2.28 backport** not required
- [x] **tests** provided

## Notes for the submitter