### PR TITLE
Do not perform adjustments on legacy crypto from PSA, when MBEDTLS_PSA_CRYPTO_CLIENT && !MBEDTLS_PSA_CRYPTO_C

### DIFF
--- a/ChangeLog.d/9126.txt
+++ b/ChangeLog.d/9126.txt
@@ -1,0 +1,5 @@
+Default behavior changes
+   * In a PSA-client-only build (i.e. MBEDTLS_PSA_CRYPTO_CLIENT &&
+     !MBEDTLS_PSA_CRYPTO_C), do not automatically enable local crypto when the
+     corresponding PSA mechanism is enabled, since the server provides the
+     crypto. Fixes #9126.

--- a/include/mbedtls/config_psa.h
+++ b/include/mbedtls/config_psa.h
@@ -32,7 +32,11 @@
  * before we deduce what built-ins are required. */
 #include "psa/crypto_adjust_config_key_pair_types.h"
 
+#if defined(MBEDTLS_PSA_CRYPTO_C)
+/* If we are implementing PSA crypto ourselves, then we want to enable the
+ * required built-ins. Otherwise, PSA features will be provided by the server. */
 #include "mbedtls/config_adjust_legacy_from_psa.h"
+#endif
 
 #else /* MBEDTLS_PSA_CRYPTO_CONFIG */
 


### PR DESCRIPTION
## Description

Resolves #9126.

## PR checklist

- [x] **changelog** done
- [x] **3.6 backport** https://github.com/Mbed-TLS/mbedtls/pull/9305
- [x] **2.28 backport** not required
- [x] **tests** not required