### PR TITLE
Silence gcc 12.2.0 warning

### DIFF
--- a/library/psa_crypto_cipher.c
+++ b/library/psa_crypto_cipher.c
@@ -263,7 +263,7 @@ const mbedtls_cipher_info_t *mbedtls_cipher_info_from_psa(
 {
     mbedtls_cipher_mode_t mode;
     psa_status_t status;
-    mbedtls_cipher_id_t cipher_id_tmp;
+    mbedtls_cipher_id_t cipher_id_tmp = MBEDTLS_CIPHER_ID_NONE;
 
     status = mbedtls_cipher_values_from_psa(alg, key_type, &key_bits, &mode, &cipher_id_tmp);
     if (status != PSA_SUCCESS) {


### PR DESCRIPTION
Unfortunately this compiler complains about a variable potentially being used un-initialized.  Silence the warning by initializing it to a sane default.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required
- [x] **3.6 backport** #9272 
- [x] **2.28 backport**  #9270 
- [x] **tests** no