### PR TITLE
2.28 only: Fix the build without check_config.h (inclusion of limits.h)

### DIFF
--- a/ChangeLog.d/build_without_check_config.txt
+++ b/ChangeLog.d/build_without_check_config.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix the build in some configurations when check_config.h is not included.
+     Fix #9152.

--- a/library/oid.c
+++ b/library/oid.c
@@ -15,6 +15,7 @@
 #include "mbedtls/rsa.h"
 #include "mbedtls/error.h"
 
+#include <limits.h>
 #include <stdio.h>
 #include <string.h>
 

--- a/library/psa_crypto_rsa.c
+++ b/library/psa_crypto_rsa.c
@@ -16,6 +16,7 @@
 #include "psa_crypto_rsa.h"
 #include "psa_crypto_hash.h"
 
+#include <limits.h>
 #include <stdlib.h>
 #include <string.h>
 #include "mbedtls/platform.h"

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -29,6 +29,7 @@
 #include "constant_time_internal.h"
 #include "mbedtls/constant_time.h"
 
+#include <limits.h>
 #include <string.h>
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -26,6 +26,7 @@
 #include "mbedtls/oid.h"
 #include "mbedtls/platform_util.h"
 
+#include <limits.h>
 #include <string.h>
 
 #if defined(MBEDTLS_PEM_PARSE_C)

--- a/programs/test/udp_proxy.c
+++ b/programs/test/udp_proxy.c
@@ -35,6 +35,8 @@
 #define MBEDTLS_EXIT_FAILURE    EXIT_FAILURE
 #endif /* MBEDTLS_PLATFORM_C */
 
+#include <limits.h>
+
 #if !defined(MBEDTLS_NET_C)
 int main(void)
 {

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -886,6 +886,13 @@ component_test_default_out_of_box () {
     tests/scripts/run_demos.py
 }
 
+component_build_without_check_config () {
+    msg "build: full without check_config.h"
+    scripts/config.py full
+    sed -i '/#include.*check_config\.h/ s!^!//!' "$CONFIG_H"
+    make
+}
+
 component_test_default_cmake_gcc_asan () {
     msg "build: cmake, gcc, ASan" # ~ 1 min 50s
     CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .

--- a/tests/src/test_helpers/ssl_helpers.c
+++ b/tests/src/test_helpers/ssl_helpers.c
@@ -10,6 +10,8 @@
 
 #include <test/ssl_helpers.h>
 
+#include <limits.h>
+
 #if defined(MBEDTLS_SSL_TLS_C)
 
 void mbedtls_test_ssl_log_analyzer(void *ctx, int level,


### PR DESCRIPTION
Including `mbedtls/check_config.h` from `mbedtls/config.h` is optional. If done, `limits.h` gets included. If not done, we were missing the inclusion of `limits.h` in several source files. Fix this and add a test build that doesn't include `mbedtls/check_config.h`. Fixes #9152.

Not applicable to ≥3.0 because there `check_config.h` has no side effects (they're in `build_info.h`).

## PR checklist

- [x] **changelog** provided
- [x] **development** N/A
- [x] **3.6 backport** N/A
- [x] **tests** provided
