### PR TITLE
Generate test data before coverage analysis

### DIFF
--- a/tests/scripts/analyze_outcomes.py
+++ b/tests/scripts/analyze_outcomes.py
@@ -90,10 +90,12 @@ def analyze_coverage(results: Results, outcomes: Outcomes,
     # checkout.
     cp = subprocess.run(['make', 'generated_files'],
                         cwd='tests',
-                        stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+                        stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                        check=False)
     if cp.returncode != 0:
         sys.stderr.write(cp.stdout.decode('utf-8'))
-        results.error("Failed \"make generated_files\" in tests. Coverage analysis may be incorrect.")
+        results.error("Failed \"make generated_files\" in tests. "
+                      "Coverage analysis may be incorrect.")
     available = check_test_cases.collect_available_test_cases()
     for suite_case in available:
         hit = any(suite_case in comp_outcomes.successes or

--- a/tests/scripts/analyze_outcomes.py
+++ b/tests/scripts/analyze_outcomes.py
@@ -85,6 +85,15 @@ def execute_reference_driver_tests(results: Results, ref_component: str, driver_
 def analyze_coverage(results: Results, outcomes: Outcomes,
                      allow_list: typing.List[str], full_coverage: bool) -> None:
     """Check that all available test cases are executed at least once."""
+    # Make sure that the generated data files are present (and up-to-date).
+    # This allows analyze_outcomes.py to run correctly on a fresh Git
+    # checkout.
+    cp = subprocess.run(['make', 'generated_files'],
+                        cwd='tests',
+                        stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    if cp.returncode != 0:
+        sys.stderr.write(cp.stdout.decode('utf-8'))
+        results.error("Failed \"make generated_files\" in tests. Coverage analysis may be incorrect.")
     available = check_test_cases.collect_available_test_cases()
     for suite_case in available:
         hit = any(suite_case in comp_outcomes.successes or


### PR DESCRIPTION
Fixes #8300.

Requires https://github.com/Mbed-TLS/mbedtls-test/pull/166 (before that, we wouldn't have the necessary Python environment to run `make generated_files`).

## PR checklist

- [x] **changelog** no: test only
- [x] **3.6 backport** https://github.com/Mbed-TLS/mbedtls/pull/9166
- [x] **2.28 backport** not required (no generated test cases in 2.28)
- [x] **tests** On the CI, [result analysis](https://mbedtls.trustedfirmware.org/job/mbed-tls-pr-head/job/PR-9159-head/3/execution/node/8531/log/) will now warn about many generated test cases that aren't executed (see https://github.com/Mbed-TLS/mbedtls/pull/9025)
