### PR TITLE
[BACKPORT 3.6] tests: add a test for pkg-config files

### DIFF
--- a/tests/scripts/components-build-system.sh
+++ b/tests/scripts/components-build-system.sh
@@ -108,10 +108,15 @@ component_test_cmake_as_package () {
     make neat
 
     msg "build: cmake 'as-package' build"
+    root_dir="$(pwd)"
     cd programs/test/cmake_package
+    build_variant_dir="$(pwd)"
     cmake .
     make
     ./cmake_package
+    if [[ "$OSTYPE" == linux* ]]; then
+        PKG_CONFIG_PATH="${build_variant_dir}/mbedtls/pkgconfig" ${root_dir}/tests/scripts/pkgconfig.sh
+    fi
 }
 
 support_test_cmake_as_package () {

--- a/tests/scripts/pkgconfig.sh
+++ b/tests/scripts/pkgconfig.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+#
+# Copyright The Mbed TLS Contributors
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+#
+# Purpose
+#
+# Test pkgconfig files.
+#
+# For each of the build pkg-config files, .pc files, check that
+# they validate and do some basic sanity testing on the output,
+# i.e. that the strings are non-empty.
+#
+# NOTE: This requires the built pc files to be on the pkg-config
+# search path, this can be controlled with env variable
+# PKG_CONFIG_PATH. See man(1) pkg-config for details.
+#
+
+set -e -u
+
+# These are the EXPECTED package names. Renaming these could break
+# consumers of pkg-config, consider carefully.
+all_pcs="mbedtls mbedx509 mbedcrypto"
+
+for pc in $all_pcs; do
+    printf "testing package config file: ${pc} ... "
+    pkg-config --validate "${pc}"
+    version="$(pkg-config --modversion "${pc}")"
+    test -n "$version"
+    cflags="$(pkg-config --cflags "${pc}")"
+    test -n "$cflags"
+    libs="$(pkg-config --libs "${pc}")"
+    test -n "$libs"
+    printf "passed\n"
+done
+
+exit 0


### PR DESCRIPTION
## Description

Trivial Backport of #8988

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** ~~provided, or~~ not required (Tests only, feature was previously added)
- [x] **3.6 backport** ~~done, or~~ not required (This is the backport)
- [x] **tests** provided ~~, or not required~~





