### PR TITLE
Adapt components with MBEDTLS_PSA_CRYPTO_CONFIG enabled

### DIFF
--- a/tests/include/test/psa_test_wrappers.h
+++ b/tests/include/test/psa_test_wrappers.h
@@ -262,12 +262,15 @@ psa_status_t mbedtls_test_wrap_psa_copy_key(
 #define psa_copy_key(arg0_source_key, arg1_attributes, arg2_target_key) \
     mbedtls_test_wrap_psa_copy_key(arg0_source_key, arg1_attributes, arg2_target_key)
 
+#if defined(PSA_WANT_ALG_SOME_PAKE)
 psa_status_t mbedtls_test_wrap_psa_crypto_driver_pake_get_cipher_suite(
     const psa_crypto_driver_pake_inputs_t *arg0_inputs,
     psa_pake_cipher_suite_t *arg1_cipher_suite);
 #define psa_crypto_driver_pake_get_cipher_suite(arg0_inputs, arg1_cipher_suite) \
     mbedtls_test_wrap_psa_crypto_driver_pake_get_cipher_suite(arg0_inputs, arg1_cipher_suite)
+#endif /* defined(PSA_WANT_ALG_SOME_PAKE) */
 
+#if defined(PSA_WANT_ALG_SOME_PAKE)
 psa_status_t mbedtls_test_wrap_psa_crypto_driver_pake_get_password(
     const psa_crypto_driver_pake_inputs_t *arg0_inputs,
     uint8_t *arg1_buffer,
@@ -275,13 +278,17 @@ psa_status_t mbedtls_test_wrap_psa_crypto_driver_pake_get_password(
     size_t *arg3_buffer_length);
 #define psa_crypto_driver_pake_get_password(arg0_inputs, arg1_buffer, arg2_buffer_size, arg3_buffer_length) \
     mbedtls_test_wrap_psa_crypto_driver_pake_get_password(arg0_inputs, arg1_buffer, arg2_buffer_size, arg3_buffer_length)
+#endif /* defined(PSA_WANT_ALG_SOME_PAKE) */
 
+#if defined(PSA_WANT_ALG_SOME_PAKE)
 psa_status_t mbedtls_test_wrap_psa_crypto_driver_pake_get_password_len(
     const psa_crypto_driver_pake_inputs_t *arg0_inputs,
     size_t *arg1_password_len);
 #define psa_crypto_driver_pake_get_password_len(arg0_inputs, arg1_password_len) \
     mbedtls_test_wrap_psa_crypto_driver_pake_get_password_len(arg0_inputs, arg1_password_len)
+#endif /* defined(PSA_WANT_ALG_SOME_PAKE) */
 
+#if defined(PSA_WANT_ALG_SOME_PAKE)
 psa_status_t mbedtls_test_wrap_psa_crypto_driver_pake_get_peer(
     const psa_crypto_driver_pake_inputs_t *arg0_inputs,
     uint8_t *arg1_peer_id,
@@ -289,13 +296,17 @@ psa_status_t mbedtls_test_wrap_psa_crypto_driver_pake_get_peer(
     size_t *arg3_peer_id_length);
 #define psa_crypto_driver_pake_get_peer(arg0_inputs, arg1_peer_id, arg2_peer_id_size, arg3_peer_id_length) \
     mbedtls_test_wrap_psa_crypto_driver_pake_get_peer(arg0_inputs, arg1_peer_id, arg2_peer_id_size, arg3_peer_id_length)
+#endif /* defined(PSA_WANT_ALG_SOME_PAKE) */
 
+#if defined(PSA_WANT_ALG_SOME_PAKE)
 psa_status_t mbedtls_test_wrap_psa_crypto_driver_pake_get_peer_len(
     const psa_crypto_driver_pake_inputs_t *arg0_inputs,
     size_t *arg1_peer_len);
 #define psa_crypto_driver_pake_get_peer_len(arg0_inputs, arg1_peer_len) \
     mbedtls_test_wrap_psa_crypto_driver_pake_get_peer_len(arg0_inputs, arg1_peer_len)
+#endif /* defined(PSA_WANT_ALG_SOME_PAKE) */
 
+#if defined(PSA_WANT_ALG_SOME_PAKE)
 psa_status_t mbedtls_test_wrap_psa_crypto_driver_pake_get_user(
     const psa_crypto_driver_pake_inputs_t *arg0_inputs,
     uint8_t *arg1_user_id,
@@ -303,12 +314,15 @@ psa_status_t mbedtls_test_wrap_psa_crypto_driver_pake_get_user(
     size_t *arg3_user_id_len);
 #define psa_crypto_driver_pake_get_user(arg0_inputs, arg1_user_id, arg2_user_id_size, arg3_user_id_len) \
     mbedtls_test_wrap_psa_crypto_driver_pake_get_user(arg0_inputs, arg1_user_id, arg2_user_id_size, arg3_user_id_len)
+#endif /* defined(PSA_WANT_ALG_SOME_PAKE) */
 
+#if defined(PSA_WANT_ALG_SOME_PAKE)
 psa_status_t mbedtls_test_wrap_psa_crypto_driver_pake_get_user_len(
     const psa_crypto_driver_pake_inputs_t *arg0_inputs,
     size_t *arg1_user_len);
 #define psa_crypto_driver_pake_get_user_len(arg0_inputs, arg1_user_len) \
     mbedtls_test_wrap_psa_crypto_driver_pake_get_user_len(arg0_inputs, arg1_user_len)
+#endif /* defined(PSA_WANT_ALG_SOME_PAKE) */
 
 psa_status_t mbedtls_test_wrap_psa_crypto_init(void);
 #define psa_crypto_init() \
@@ -566,17 +580,22 @@ psa_status_t mbedtls_test_wrap_psa_mac_verify_setup(
 #define psa_mac_verify_setup(arg0_operation, arg1_key, arg2_alg) \
     mbedtls_test_wrap_psa_mac_verify_setup(arg0_operation, arg1_key, arg2_alg)
 
+#if defined(PSA_WANT_ALG_SOME_PAKE)
 psa_status_t mbedtls_test_wrap_psa_pake_abort(
     psa_pake_operation_t *arg0_operation);
 #define psa_pake_abort(arg0_operation) \
     mbedtls_test_wrap_psa_pake_abort(arg0_operation)
+#endif /* defined(PSA_WANT_ALG_SOME_PAKE) */
 
+#if defined(PSA_WANT_ALG_SOME_PAKE)
 psa_status_t mbedtls_test_wrap_psa_pake_get_implicit_key(
     psa_pake_operation_t *arg0_operation,
     psa_key_derivation_operation_t *arg1_output);
 #define psa_pake_get_implicit_key(arg0_operation, arg1_output) \
     mbedtls_test_wrap_psa_pake_get_implicit_key(arg0_operation, arg1_output)
+#endif /* defined(PSA_WANT_ALG_SOME_PAKE) */
 
+#if defined(PSA_WANT_ALG_SOME_PAKE)
 psa_status_t mbedtls_test_wrap_psa_pake_input(
     psa_pake_operation_t *arg0_operation,
     psa_pake_step_t arg1_step,
@@ -584,7 +603,9 @@ psa_status_t mbedtls_test_wrap_psa_pake_input(
     size_t arg3_input_length);
 #define psa_pake_input(arg0_operation, arg1_step, arg2_input, arg3_input_length) \
     mbedtls_test_wrap_psa_pake_input(arg0_operation, arg1_step, arg2_input, arg3_input_length)
+#endif /* defined(PSA_WANT_ALG_SOME_PAKE) */
 
+#if defined(PSA_WANT_ALG_SOME_PAKE)
 psa_status_t mbedtls_test_wrap_psa_pake_output(
     psa_pake_operation_t *arg0_operation,
     psa_pake_step_t arg1_step,
@@ -593,38 +614,49 @@ psa_status_t mbedtls_test_wrap_psa_pake_output(
     size_t *arg4_output_length);
 #define psa_pake_output(arg0_operation, arg1_step, arg2_output, arg3_output_size, arg4_output_length) \
     mbedtls_test_wrap_psa_pake_output(arg0_operation, arg1_step, arg2_output, arg3_output_size, arg4_output_length)
+#endif /* defined(PSA_WANT_ALG_SOME_PAKE) */
 
+#if defined(PSA_WANT_ALG_SOME_PAKE)
 psa_status_t mbedtls_test_wrap_psa_pake_set_password_key(
     psa_pake_operation_t *arg0_operation,
     mbedtls_svc_key_id_t arg1_password);
 #define psa_pake_set_password_key(arg0_operation, arg1_password) \
     mbedtls_test_wrap_psa_pake_set_password_key(arg0_operation, arg1_password)
+#endif /* defined(PSA_WANT_ALG_SOME_PAKE) */
 
+#if defined(PSA_WANT_ALG_SOME_PAKE)
 psa_status_t mbedtls_test_wrap_psa_pake_set_peer(
     psa_pake_operation_t *arg0_operation,
     const uint8_t *arg1_peer_id,
     size_t arg2_peer_id_len);
 #define psa_pake_set_peer(arg0_operation, arg1_peer_id, arg2_peer_id_len) \
     mbedtls_test_wrap_psa_pake_set_peer(arg0_operation, arg1_peer_id, arg2_peer_id_len)
+#endif /* defined(PSA_WANT_ALG_SOME_PAKE) */
 
+#if defined(PSA_WANT_ALG_SOME_PAKE)
 psa_status_t mbedtls_test_wrap_psa_pake_set_role(
     psa_pake_operation_t *arg0_operation,
     psa_pake_role_t arg1_role);
 #define psa_pake_set_role(arg0_operation, arg1_role) \
     mbedtls_test_wrap_psa_pake_set_role(arg0_operation, arg1_role)
+#endif /* defined(PSA_WANT_ALG_SOME_PAKE) */
 
+#if defined(PSA_WANT_ALG_SOME_PAKE)
 psa_status_t mbedtls_test_wrap_psa_pake_set_user(
     psa_pake_operation_t *arg0_operation,
     const uint8_t *arg1_user_id,
     size_t arg2_user_id_len);
 #define psa_pake_set_user(arg0_operation, arg1_user_id, arg2_user_id_len) \
     mbedtls_test_wrap_psa_pake_set_user(arg0_operation, arg1_user_id, arg2_user_id_len)
+#endif /* defined(PSA_WANT_ALG_SOME_PAKE) */
 
+#if defined(PSA_WANT_ALG_SOME_PAKE)
 psa_status_t mbedtls_test_wrap_psa_pake_setup(
     psa_pake_operation_t *arg0_operation,
     const psa_pake_cipher_suite_t *arg1_cipher_suite);
 #define psa_pake_setup(arg0_operation, arg1_cipher_suite) \
     mbedtls_test_wrap_psa_pake_setup(arg0_operation, arg1_cipher_suite)
+#endif /* defined(PSA_WANT_ALG_SOME_PAKE) */
 
 psa_status_t mbedtls_test_wrap_psa_purge_key(
     mbedtls_svc_key_id_t arg0_key);

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1714,69 +1714,28 @@ component_test_crypto_full_md_light_only () {
     make test
 }
 
-component_test_full_no_cipher_no_psa_crypto () {
-    msg "build: full no CIPHER no PSA_CRYPTO_C"
-    scripts/config.py full
-    scripts/config.py unset MBEDTLS_CIPHER_C
-    # Don't pull in cipher via PSA mechanisms
-    # (currently ignored anyway because we completely disable PSA)
-    scripts/config.py unset MBEDTLS_PSA_CRYPTO_CONFIG
-    # Disable features that depend on CIPHER_C
-    scripts/config.py unset MBEDTLS_CMAC_C
-    scripts/config.py unset MBEDTLS_NIST_KW_C
-    scripts/config.py unset MBEDTLS_PSA_CRYPTO_C
-    scripts/config.py unset MBEDTLS_PSA_CRYPTO_CLIENT
-    scripts/config.py unset MBEDTLS_SSL_TLS_C
-    scripts/config.py unset MBEDTLS_SSL_TICKET_C
-    # Disable features that depend on PSA_CRYPTO_C
-    scripts/config.py unset MBEDTLS_PSA_CRYPTO_SE_C
-    scripts/config.py unset MBEDTLS_PSA_CRYPTO_STORAGE_C
-    scripts/config.py unset MBEDTLS_USE_PSA_CRYPTO
-    scripts/config.py unset MBEDTLS_LMS_C
-    scripts/config.py unset MBEDTLS_LMS_PRIVATE
-
-    msg "test: full no CIPHER no PSA_CRYPTO_C"
-    make test
-}
-
-# This is a common configurator and test function that is used in:
-# - component_test_full_no_cipher_with_psa_crypto
-# - component_test_full_no_cipher_with_psa_crypto_config
-# It accepts 2 input parameters:
-# - $1: boolean value which basically reflects status of MBEDTLS_PSA_CRYPTO_CONFIG
-# - $2: a text string which describes the test component
-common_test_full_no_cipher_with_psa_crypto () {
-    USE_CRYPTO_CONFIG="$1"
-    COMPONENT_DESCRIPTION="$2"
-
-    msg "build: $COMPONENT_DESCRIPTION"
+component_test_full_no_cipher () {
+    msg "build: full no CIPHER"
 
     scripts/config.py full
     scripts/config.py unset MBEDTLS_CIPHER_C
 
-    if [ "$USE_CRYPTO_CONFIG" -eq 1 ]; then
-        # The built-in implementation of the following algs/key-types depends
-        # on CIPHER_C so we disable them.
-        # This does not hold for KEY_TYPE_CHACHA20 and ALG_CHACHA20_POLY1305
-        # so we keep them enabled.
-        scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_CCM_STAR_NO_TAG
-        scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_CMAC
-        scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_CBC_NO_PADDING
-        scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_CBC_PKCS7
-        scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_CFB
-        scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_CTR
-        scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_ECB_NO_PADDING
-        scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_OFB
-        scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_PBKDF2_AES_CMAC_PRF_128
-        scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_STREAM_CIPHER
-        scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_KEY_TYPE_DES
-    else
-        # Don't pull in cipher via PSA mechanisms
-        scripts/config.py unset MBEDTLS_PSA_CRYPTO_CONFIG
-        # Disable cipher modes/keys that make PSA depend on CIPHER_C.
-        # Keep CHACHA20 and CHACHAPOLY enabled since they do not depend on CIPHER_C.
-        scripts/config.py unset-all MBEDTLS_CIPHER_MODE
-    fi
+    # The built-in implementation of the following algs/key-types depends
+    # on CIPHER_C so we disable them.
+    # This does not hold for KEY_TYPE_CHACHA20 and ALG_CHACHA20_POLY1305
+    # so we keep them enabled.
+    scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_CCM_STAR_NO_TAG
+    scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_CMAC
+    scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_CBC_NO_PADDING
+    scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_CBC_PKCS7
+    scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_CFB
+    scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_CTR
+    scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_ECB_NO_PADDING
+    scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_OFB
+    scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_PBKDF2_AES_CMAC_PRF_128
+    scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_STREAM_CIPHER
+    scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_KEY_TYPE_DES
+
     # The following modules directly depends on CIPHER_C
     scripts/config.py unset MBEDTLS_CMAC_C
     scripts/config.py unset MBEDTLS_NIST_KW_C
@@ -1786,16 +1745,8 @@ common_test_full_no_cipher_with_psa_crypto () {
     # Ensure that CIPHER_C was not re-enabled
     not grep mbedtls_cipher_init library/cipher.o
 
-    msg "test: $COMPONENT_DESCRIPTION"
+    msg "test: full no CIPHER"
     make test
-}
-
-component_test_full_no_cipher_with_psa_crypto() {
-    common_test_full_no_cipher_with_psa_crypto 0 "full no CIPHER no CRYPTO_CONFIG"
-}
-
-component_test_full_no_cipher_with_psa_crypto_config() {
-    common_test_full_no_cipher_with_psa_crypto 1 "full no CIPHER"
 }
 
 component_test_full_no_ccm() {

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -4377,9 +4377,16 @@ component_test_ssl_alloc_buffer_and_mfl () {
 
 component_test_when_no_ciphersuites_have_mac () {
     msg "build: when no ciphersuites have MAC"
+    scripts/config.py set MBEDTLS_PSA_CRYPTO_CONFIG
+    scripts/config.py -f "$CRYPTO_CONFIG_H" unset PSA_WANT_ALG_CBC_NO_PADDING
+    scripts/config.py -f "$CRYPTO_CONFIG_H" unset PSA_WANT_ALG_CBC_PKCS7
+    scripts/config.py -f "$CRYPTO_CONFIG_H" unset PSA_WANT_ALG_CMAC
+    scripts/config.py -f "$CRYPTO_CONFIG_H" unset PSA_WANT_ALG_PBKDF2_AES_CMAC_PRF_128
+
     scripts/config.py unset MBEDTLS_CIPHER_NULL_CIPHER
     scripts/config.py unset MBEDTLS_CIPHER_MODE_CBC
     scripts/config.py unset MBEDTLS_CMAC_C
+
     make
 
     msg "test: !MBEDTLS_SSL_SOME_SUITES_USE_MAC"

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1689,7 +1689,7 @@ component_full_no_pkparse_pkwrite() {
 component_test_crypto_full_md_light_only () {
     msg "build: crypto_full with only the light subset of MD"
     scripts/config.py crypto_full
-    scripts/config.py unset MBEDTLS_PSA_CRYPTO_CONFIG
+
     # Disable MD
     scripts/config.py unset MBEDTLS_MD_C
     # Disable direct dependencies of MD_C
@@ -1698,6 +1698,7 @@ component_test_crypto_full_md_light_only () {
     scripts/config.py unset MBEDTLS_PKCS7_C
     # Disable indirect dependencies of MD_C
     scripts/config.py unset MBEDTLS_ECDSA_DETERMINISTIC # needs HMAC_DRBG
+    scripts/config.py -f $CRYPTO_CONFIG_H unset PSA_WANT_ALG_DETERMINISTIC_ECDSA
     # Disable things that would auto-enable MD_C
     scripts/config.py unset MBEDTLS_PKCS5_C
 

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1802,60 +1802,6 @@ component_test_full_no_ccm_star_no_tag() {
     make test
 }
 
-component_test_full_no_bignum () {
-    msg "build: full minus bignum"
-    scripts/config.py full
-    scripts/config.py unset MBEDTLS_BIGNUM_C
-    # Direct dependencies of bignum
-    scripts/config.py unset MBEDTLS_ECP_C
-    scripts/config.py unset MBEDTLS_RSA_C
-    scripts/config.py unset MBEDTLS_DHM_C
-    # Direct dependencies of ECP
-    scripts/config.py unset MBEDTLS_ECDH_C
-    scripts/config.py unset MBEDTLS_ECDSA_C
-    scripts/config.py unset MBEDTLS_ECJPAKE_C
-    scripts/config.py unset MBEDTLS_ECP_RESTARTABLE
-    # Disable what auto-enables ECP_LIGHT
-    scripts/config.py unset MBEDTLS_PK_PARSE_EC_EXTENDED
-    scripts/config.py unset MBEDTLS_PK_PARSE_EC_COMPRESSED
-    # Indirect dependencies of ECP
-    scripts/config.py unset MBEDTLS_KEY_EXCHANGE_ECDH_ECDSA_ENABLED
-    scripts/config.py unset MBEDTLS_KEY_EXCHANGE_ECDH_RSA_ENABLED
-    scripts/config.py unset MBEDTLS_KEY_EXCHANGE_ECDHE_PSK_ENABLED
-    scripts/config.py unset MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED
-    scripts/config.py unset MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
-    scripts/config.py unset MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED
-    scripts/config.py unset MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
-    scripts/config.py unset MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL_ENABLED
-    # Direct dependencies of DHM
-    scripts/config.py unset MBEDTLS_KEY_EXCHANGE_DHE_PSK_ENABLED
-    # Direct dependencies of RSA
-    scripts/config.py unset MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED
-    scripts/config.py unset MBEDTLS_KEY_EXCHANGE_RSA_PSK_ENABLED
-    scripts/config.py unset MBEDTLS_KEY_EXCHANGE_RSA_ENABLED
-    scripts/config.py unset MBEDTLS_X509_RSASSA_PSS_SUPPORT
-    # PK and its dependencies
-    scripts/config.py unset MBEDTLS_PK_C
-    scripts/config.py unset MBEDTLS_PK_PARSE_C
-    scripts/config.py unset MBEDTLS_PK_WRITE_C
-    scripts/config.py unset MBEDTLS_X509_USE_C
-    scripts/config.py unset MBEDTLS_X509_CRT_PARSE_C
-    scripts/config.py unset MBEDTLS_X509_CRL_PARSE_C
-    scripts/config.py unset MBEDTLS_X509_CSR_PARSE_C
-    scripts/config.py unset MBEDTLS_X509_CREATE_C
-    scripts/config.py unset MBEDTLS_X509_CRT_WRITE_C
-    scripts/config.py unset MBEDTLS_X509_CSR_WRITE_C
-    scripts/config.py unset MBEDTLS_PKCS7_C
-    scripts/config.py unset MBEDTLS_SSL_SERVER_NAME_INDICATION
-    scripts/config.py unset MBEDTLS_SSL_ASYNC_PRIVATE
-    scripts/config.py unset MBEDTLS_X509_TRUSTED_CERTIFICATE_CALLBACK
-
-    make
-
-    msg "test: full minus bignum"
-    make test
-}
-
 component_test_tls1_2_default_stream_cipher_only () {
     msg "build: default with only stream cipher use psa"
 

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -4382,10 +4382,10 @@ component_test_when_no_ciphersuites_have_mac () {
     scripts/config.py unset MBEDTLS_CMAC_C
     make
 
-    msg "test: !MBEDTLS_SSL_SOME_MODES_USE_MAC"
+    msg "test: !MBEDTLS_SSL_SOME_SUITES_USE_MAC"
     make test
 
-    msg "test ssl-opt.sh: !MBEDTLS_SSL_SOME_MODES_USE_MAC"
+    msg "test ssl-opt.sh: !MBEDTLS_SSL_SOME_SUITES_USE_MAC"
     tests/ssl-opt.sh -f 'Default\|EtM' -e 'without EtM'
 }
 

--- a/tests/src/psa_test_wrappers.c
+++ b/tests/src/psa_test_wrappers.c
@@ -465,6 +465,7 @@ psa_status_t mbedtls_test_wrap_psa_copy_key(
 }
 
 /* Wrapper for psa_crypto_driver_pake_get_cipher_suite */
+#if defined(PSA_WANT_ALG_SOME_PAKE)
 psa_status_t mbedtls_test_wrap_psa_crypto_driver_pake_get_cipher_suite(
     const psa_crypto_driver_pake_inputs_t *arg0_inputs,
     psa_pake_cipher_suite_t *arg1_cipher_suite)
@@ -472,8 +473,10 @@ psa_status_t mbedtls_test_wrap_psa_crypto_driver_pake_get_cipher_suite(
     psa_status_t status = (psa_crypto_driver_pake_get_cipher_suite)(arg0_inputs, arg1_cipher_suite);
     return status;
 }
+#endif /* defined(PSA_WANT_ALG_SOME_PAKE) */
 
 /* Wrapper for psa_crypto_driver_pake_get_password */
+#if defined(PSA_WANT_ALG_SOME_PAKE)
 psa_status_t mbedtls_test_wrap_psa_crypto_driver_pake_get_password(
     const psa_crypto_driver_pake_inputs_t *arg0_inputs,
     uint8_t *arg1_buffer,
@@ -483,8 +486,10 @@ psa_status_t mbedtls_test_wrap_psa_crypto_driver_pake_get_password(
     psa_status_t status = (psa_crypto_driver_pake_get_password)(arg0_inputs, arg1_buffer, arg2_buffer_size, arg3_buffer_length);
     return status;
 }
+#endif /* defined(PSA_WANT_ALG_SOME_PAKE) */
 
 /* Wrapper for psa_crypto_driver_pake_get_password_len */
+#if defined(PSA_WANT_ALG_SOME_PAKE)
 psa_status_t mbedtls_test_wrap_psa_crypto_driver_pake_get_password_len(
     const psa_crypto_driver_pake_inputs_t *arg0_inputs,
     size_t *arg1_password_len)
@@ -492,8 +497,10 @@ psa_status_t mbedtls_test_wrap_psa_crypto_driver_pake_get_password_len(
     psa_status_t status = (psa_crypto_driver_pake_get_password_len)(arg0_inputs, arg1_password_len);
     return status;
 }
+#endif /* defined(PSA_WANT_ALG_SOME_PAKE) */
 
 /* Wrapper for psa_crypto_driver_pake_get_peer */
+#if defined(PSA_WANT_ALG_SOME_PAKE)
 psa_status_t mbedtls_test_wrap_psa_crypto_driver_pake_get_peer(
     const psa_crypto_driver_pake_inputs_t *arg0_inputs,
     uint8_t *arg1_peer_id,
@@ -503,8 +510,10 @@ psa_status_t mbedtls_test_wrap_psa_crypto_driver_pake_get_peer(
     psa_status_t status = (psa_crypto_driver_pake_get_peer)(arg0_inputs, arg1_peer_id, arg2_peer_id_size, arg3_peer_id_length);
     return status;
 }
+#endif /* defined(PSA_WANT_ALG_SOME_PAKE) */
 
 /* Wrapper for psa_crypto_driver_pake_get_peer_len */
+#if defined(PSA_WANT_ALG_SOME_PAKE)
 psa_status_t mbedtls_test_wrap_psa_crypto_driver_pake_get_peer_len(
     const psa_crypto_driver_pake_inputs_t *arg0_inputs,
     size_t *arg1_peer_len)
@@ -512,8 +521,10 @@ psa_status_t mbedtls_test_wrap_psa_crypto_driver_pake_get_peer_len(
     psa_status_t status = (psa_crypto_driver_pake_get_peer_len)(arg0_inputs, arg1_peer_len);
     return status;
 }
+#endif /* defined(PSA_WANT_ALG_SOME_PAKE) */
 
 /* Wrapper for psa_crypto_driver_pake_get_user */
+#if defined(PSA_WANT_ALG_SOME_PAKE)
 psa_status_t mbedtls_test_wrap_psa_crypto_driver_pake_get_user(
     const psa_crypto_driver_pake_inputs_t *arg0_inputs,
     uint8_t *arg1_user_id,
@@ -523,8 +534,10 @@ psa_status_t mbedtls_test_wrap_psa_crypto_driver_pake_get_user(
     psa_status_t status = (psa_crypto_driver_pake_get_user)(arg0_inputs, arg1_user_id, arg2_user_id_size, arg3_user_id_len);
     return status;
 }
+#endif /* defined(PSA_WANT_ALG_SOME_PAKE) */
 
 /* Wrapper for psa_crypto_driver_pake_get_user_len */
+#if defined(PSA_WANT_ALG_SOME_PAKE)
 psa_status_t mbedtls_test_wrap_psa_crypto_driver_pake_get_user_len(
     const psa_crypto_driver_pake_inputs_t *arg0_inputs,
     size_t *arg1_user_len)
@@ -532,6 +545,7 @@ psa_status_t mbedtls_test_wrap_psa_crypto_driver_pake_get_user_len(
     psa_status_t status = (psa_crypto_driver_pake_get_user_len)(arg0_inputs, arg1_user_len);
     return status;
 }
+#endif /* defined(PSA_WANT_ALG_SOME_PAKE) */
 
 /* Wrapper for psa_crypto_init */
 psa_status_t mbedtls_test_wrap_psa_crypto_init(void)
@@ -1008,14 +1022,17 @@ psa_status_t mbedtls_test_wrap_psa_mac_verify_setup(
 }
 
 /* Wrapper for psa_pake_abort */
+#if defined(PSA_WANT_ALG_SOME_PAKE)
 psa_status_t mbedtls_test_wrap_psa_pake_abort(
     psa_pake_operation_t *arg0_operation)
 {
     psa_status_t status = (psa_pake_abort)(arg0_operation);
     return status;
 }
+#endif /* defined(PSA_WANT_ALG_SOME_PAKE) */
 
 /* Wrapper for psa_pake_get_implicit_key */
+#if defined(PSA_WANT_ALG_SOME_PAKE)
 psa_status_t mbedtls_test_wrap_psa_pake_get_implicit_key(
     psa_pake_operation_t *arg0_operation,
     psa_key_derivation_operation_t *arg1_output)
@@ -1023,8 +1040,10 @@ psa_status_t mbedtls_test_wrap_psa_pake_get_implicit_key(
     psa_status_t status = (psa_pake_get_implicit_key)(arg0_operation, arg1_output);
     return status;
 }
+#endif /* defined(PSA_WANT_ALG_SOME_PAKE) */
 
 /* Wrapper for psa_pake_input */
+#if defined(PSA_WANT_ALG_SOME_PAKE)
 psa_status_t mbedtls_test_wrap_psa_pake_input(
     psa_pake_operation_t *arg0_operation,
     psa_pake_step_t arg1_step,
@@ -1040,8 +1059,10 @@ psa_status_t mbedtls_test_wrap_psa_pake_input(
 #endif /* !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS) */
     return status;
 }
+#endif /* defined(PSA_WANT_ALG_SOME_PAKE) */
 
 /* Wrapper for psa_pake_output */
+#if defined(PSA_WANT_ALG_SOME_PAKE)
 psa_status_t mbedtls_test_wrap_psa_pake_output(
     psa_pake_operation_t *arg0_operation,
     psa_pake_step_t arg1_step,
@@ -1058,8 +1079,10 @@ psa_status_t mbedtls_test_wrap_psa_pake_output(
 #endif /* !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS) */
     return status;
 }
+#endif /* defined(PSA_WANT_ALG_SOME_PAKE) */
 
 /* Wrapper for psa_pake_set_password_key */
+#if defined(PSA_WANT_ALG_SOME_PAKE)
 psa_status_t mbedtls_test_wrap_psa_pake_set_password_key(
     psa_pake_operation_t *arg0_operation,
     mbedtls_svc_key_id_t arg1_password)
@@ -1067,8 +1090,10 @@ psa_status_t mbedtls_test_wrap_psa_pake_set_password_key(
     psa_status_t status = (psa_pake_set_password_key)(arg0_operation, arg1_password);
     return status;
 }
+#endif /* defined(PSA_WANT_ALG_SOME_PAKE) */
 
 /* Wrapper for psa_pake_set_peer */
+#if defined(PSA_WANT_ALG_SOME_PAKE)
 psa_status_t mbedtls_test_wrap_psa_pake_set_peer(
     psa_pake_operation_t *arg0_operation,
     const uint8_t *arg1_peer_id,
@@ -1083,8 +1108,10 @@ psa_status_t mbedtls_test_wrap_psa_pake_set_peer(
 #endif /* !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS) */
     return status;
 }
+#endif /* defined(PSA_WANT_ALG_SOME_PAKE) */
 
 /* Wrapper for psa_pake_set_role */
+#if defined(PSA_WANT_ALG_SOME_PAKE)
 psa_status_t mbedtls_test_wrap_psa_pake_set_role(
     psa_pake_operation_t *arg0_operation,
     psa_pake_role_t arg1_role)
@@ -1092,8 +1119,10 @@ psa_status_t mbedtls_test_wrap_psa_pake_set_role(
     psa_status_t status = (psa_pake_set_role)(arg0_operation, arg1_role);
     return status;
 }
+#endif /* defined(PSA_WANT_ALG_SOME_PAKE) */
 
 /* Wrapper for psa_pake_set_user */
+#if defined(PSA_WANT_ALG_SOME_PAKE)
 psa_status_t mbedtls_test_wrap_psa_pake_set_user(
     psa_pake_operation_t *arg0_operation,
     const uint8_t *arg1_user_id,
@@ -1108,8 +1137,10 @@ psa_status_t mbedtls_test_wrap_psa_pake_set_user(
 #endif /* !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS) */
     return status;
 }
+#endif /* defined(PSA_WANT_ALG_SOME_PAKE) */
 
 /* Wrapper for psa_pake_setup */
+#if defined(PSA_WANT_ALG_SOME_PAKE)
 psa_status_t mbedtls_test_wrap_psa_pake_setup(
     psa_pake_operation_t *arg0_operation,
     const psa_pake_cipher_suite_t *arg1_cipher_suite)
@@ -1117,6 +1148,7 @@ psa_status_t mbedtls_test_wrap_psa_pake_setup(
     psa_status_t status = (psa_pake_setup)(arg0_operation, arg1_cipher_suite);
     return status;
 }
+#endif /* defined(PSA_WANT_ALG_SOME_PAKE) */
 
 /* Wrapper for psa_purge_key */
 psa_status_t mbedtls_test_wrap_psa_purge_key(


### PR DESCRIPTION
## Description
Progresses #8153 
Associated mbedtls-framework PR: https://github.com/Mbed-TLS/mbedtls-framework/pull/22

## PR checklist
- [x] **changelog** not required
- [x] **3.6 backport** https://github.com/Mbed-TLS/mbedtls/pull/9289
- [x] **2.28 backport** not required, fixes to be backported to 3.6 not relevant to 2.28
- [x] **tests** not required