### PR TITLE
Fix build of v3.6 (issues #9186 and #9188)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,7 +204,7 @@ if(CMAKE_COMPILER_IS_GNU)
     # note: starting with CMake 2.8 we could use CMAKE_C_COMPILER_VERSION
     execute_process(COMMAND ${CMAKE_C_COMPILER} -dumpversion
                     OUTPUT_VARIABLE GCC_VERSION)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wwrite-strings")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wwrite-strings -Wmissing-prototypes")
     if (GCC_VERSION VERSION_GREATER 3.0 OR GCC_VERSION VERSION_EQUAL 3.0)
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wformat=2 -Wno-format-nonliteral")
     endif()
@@ -238,7 +238,7 @@ if(CMAKE_COMPILER_IS_GNU)
 endif(CMAKE_COMPILER_IS_GNU)
 
 if(CMAKE_COMPILER_IS_CLANG)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wwrite-strings -Wpointer-arith -Wimplicit-fallthrough -Wshadow -Wvla -Wformat=2 -Wno-format-nonliteral")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wwrite-strings -Wmissing-prototypes -Wpointer-arith -Wimplicit-fallthrough -Wshadow -Wvla -Wformat=2 -Wno-format-nonliteral")
     set(CMAKE_C_FLAGS_RELEASE     "-O2")
     set(CMAKE_C_FLAGS_DEBUG       "-O0 -g3")
     set(CMAKE_C_FLAGS_COVERAGE    "-O0 -g3 --coverage")

--- a/ChangeLog.d/fix-clang-psa-build-without-dhm.txt
+++ b/ChangeLog.d/fix-clang-psa-build-without-dhm.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix Clang compilation error when MBEDTLS_USE_PSA_CRYPTO is enabled
+     but MBEDTLS_DHM_C is disabled. Reported by Michael Schuster in #9188.

--- a/ChangeLog.d/fix-server-mode-only-build.txt
+++ b/ChangeLog.d/fix-server-mode-only-build.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix server mode only build when MBEDTLS_SSL_SRV_C is enabled but
+     MBEDTLS_SSL_CLI_C is disabled. Reported by M-Bab on GitHub in #9186.

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -201,11 +201,11 @@ else()
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCC)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wmissing-declarations -Wmissing-prototypes")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wmissing-declarations")
 endif(CMAKE_COMPILER_IS_GNUCC)
 
 if(CMAKE_COMPILER_IS_CLANG)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wmissing-declarations -Wmissing-prototypes -Wdocumentation -Wno-documentation-deprecated-sync -Wunreachable-code")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wmissing-declarations -Wdocumentation -Wno-documentation-deprecated-sync -Wunreachable-code")
 endif(CMAKE_COMPILER_IS_CLANG)
 
 if(CMAKE_COMPILER_IS_MSVC)

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -1507,7 +1507,7 @@ int mbedtls_ssl_psk_derive_premaster(mbedtls_ssl_context *ssl,
 #endif /* MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED */
 
 #if defined(MBEDTLS_SSL_HANDSHAKE_WITH_PSK_ENABLED)
-#if defined(MBEDTLS_SSL_CLI_C)
+#if defined(MBEDTLS_SSL_CLI_C) || defined(MBEDTLS_SSL_SRV_C)
 MBEDTLS_CHECK_RETURN_CRITICAL
 int mbedtls_ssl_conf_has_static_psk(mbedtls_ssl_config const *conf);
 #endif

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -3921,7 +3921,7 @@ static int ssl_parse_client_key_exchange(mbedtls_ssl_context *ssl)
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
         psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
         psa_status_t destruction_status = PSA_ERROR_CORRUPTION_DETECTED;
-        uint8_t ecpoint_len;
+        size_t ecpoint_len;
 
         mbedtls_ssl_handshake_params *handshake = ssl->handshake;
 

--- a/programs/cipher/cipher_aead_demo.c
+++ b/programs/cipher/cipher_aead_demo.c
@@ -79,7 +79,7 @@ const unsigned char msg2_part2[] = { 0x15, 0x16, 0x17 };
 const unsigned char key_bytes[32] = { 0x2a };
 
 /* Print the contents of a buffer in hex */
-void print_buf(const char *title, unsigned char *buf, size_t len)
+static void print_buf(const char *title, unsigned char *buf, size_t len)
 {
     printf("%s:", title);
     for (size_t i = 0; i < len; i++) {

--- a/programs/cipher/cipher_aead_demo.c
+++ b/programs/cipher/cipher_aead_demo.c
@@ -35,6 +35,8 @@
 
 #include "mbedtls/cipher.h"
 
+#include <test/helpers.h>
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -77,16 +79,6 @@ const unsigned char msg2_part2[] = { 0x15, 0x16, 0x17 };
 /* Dummy key material - never do this in production!
  * 32-byte is enough to all the key size supported by this program. */
 const unsigned char key_bytes[32] = { 0x2a };
-
-/* Print the contents of a buffer in hex */
-void print_buf(const char *title, unsigned char *buf, size_t len)
-{
-    printf("%s:", title);
-    for (size_t i = 0; i < len; i++) {
-        printf(" %02x", buf[i]);
-    }
-    printf("\n");
-}
 
 /* Run an Mbed TLS function and bail out if it fails.
  * A string description of the error code can be recovered with:
@@ -198,7 +190,7 @@ static int aead_encrypt(mbedtls_cipher_context_t *ctx, size_t tag_len,
     p += tag_len;
 
     olen = p - out;
-    print_buf("out", out, olen);
+    mbedtls_test_print_buf("out", out, olen);
 
 exit:
     return ret;

--- a/programs/cipher/cipher_aead_demo.c
+++ b/programs/cipher/cipher_aead_demo.c
@@ -35,8 +35,6 @@
 
 #include "mbedtls/cipher.h"
 
-#include <test/helpers.h>
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -79,6 +77,16 @@ const unsigned char msg2_part2[] = { 0x15, 0x16, 0x17 };
 /* Dummy key material - never do this in production!
  * 32-byte is enough to all the key size supported by this program. */
 const unsigned char key_bytes[32] = { 0x2a };
+
+/* Print the contents of a buffer in hex */
+void print_buf(const char *title, unsigned char *buf, size_t len)
+{
+    printf("%s:", title);
+    for (size_t i = 0; i < len; i++) {
+        printf(" %02x", buf[i]);
+    }
+    printf("\n");
+}
 
 /* Run an Mbed TLS function and bail out if it fails.
  * A string description of the error code can be recovered with:
@@ -190,7 +198,7 @@ static int aead_encrypt(mbedtls_cipher_context_t *ctx, size_t tag_len,
     p += tag_len;
 
     olen = p - out;
-    mbedtls_test_print_buf("out", out, olen);
+    print_buf("out", out, olen);
 
 exit:
     return ret;

--- a/programs/fuzz/common.h
+++ b/programs/fuzz/common.h
@@ -23,3 +23,6 @@ int dummy_random(void *p_rng, unsigned char *output, size_t output_len);
 int dummy_entropy(void *data, unsigned char *output, size_t len);
 int fuzz_recv_timeout(void *ctx, unsigned char *buf, size_t len,
                       uint32_t timeout);
+
+/* Implemented in the fuzz_*.c sources and required by onefile.c */
+int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size);

--- a/programs/fuzz/fuzz_pkcs7.c
+++ b/programs/fuzz/fuzz_pkcs7.c
@@ -1,5 +1,6 @@
 #include <stdint.h>
 #include "mbedtls/pkcs7.h"
+#include "common.h"
 
 int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 {

--- a/programs/fuzz/fuzz_pubkey.c
+++ b/programs/fuzz/fuzz_pubkey.c
@@ -1,6 +1,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include "mbedtls/pk.h"
+#include "common.h"
 
 int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 {

--- a/programs/fuzz/fuzz_x509crl.c
+++ b/programs/fuzz/fuzz_x509crl.c
@@ -1,5 +1,6 @@
 #include <stdint.h>
 #include "mbedtls/x509_crl.h"
+#include "common.h"
 
 int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 {

--- a/programs/fuzz/fuzz_x509crt.c
+++ b/programs/fuzz/fuzz_x509crt.c
@@ -1,5 +1,6 @@
 #include <stdint.h>
 #include "mbedtls/x509_crt.h"
+#include "common.h"
 
 int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 {

--- a/programs/fuzz/fuzz_x509csr.c
+++ b/programs/fuzz/fuzz_x509csr.c
@@ -1,5 +1,6 @@
 #include <stdint.h>
 #include "mbedtls/x509_csr.h"
+#include "common.h"
 
 int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 {

--- a/programs/fuzz/onefile.c
+++ b/programs/fuzz/onefile.c
@@ -1,13 +1,12 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include "common.h"
 
 /* This file doesn't use any Mbed TLS function, but grab mbedtls_config.h anyway
  * in case it contains platform-specific #defines related to malloc or
  * stdio functions. */
 #include "mbedtls/build_info.h"
-
-int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size);
 
 int main(int argc, char **argv)
 {

--- a/programs/hash/md_hmac_demo.c
+++ b/programs/hash/md_hmac_demo.c
@@ -57,7 +57,7 @@ const unsigned char msg2_part2[] = { 0x06, 0x06 };
 const unsigned char key_bytes[32] = { 0 };
 
 /* Print the contents of a buffer in hex */
-void print_buf(const char *title, unsigned char *buf, size_t len)
+static void print_buf(const char *title, unsigned char *buf, size_t len)
 {
     printf("%s:", title);
     for (size_t i = 0; i < len; i++) {

--- a/programs/hash/md_hmac_demo.c
+++ b/programs/hash/md_hmac_demo.c
@@ -32,8 +32,6 @@
 
 #include "mbedtls/platform_util.h" // for mbedtls_platform_zeroize
 
-#include <test/helpers.h>
-
 #include <stdlib.h>
 #include <stdio.h>
 
@@ -57,6 +55,16 @@ const unsigned char msg2_part2[] = { 0x06, 0x06 };
 /* Dummy key material - never do this in production!
  * This example program uses SHA-256, so a 32-byte key makes sense. */
 const unsigned char key_bytes[32] = { 0 };
+
+/* Print the contents of a buffer in hex */
+void print_buf(const char *title, unsigned char *buf, size_t len)
+{
+    printf("%s:", title);
+    for (size_t i = 0; i < len; i++) {
+        printf(" %02x", buf[i]);
+    }
+    printf("\n");
+}
 
 /* Run an Mbed TLS function and bail out if it fails.
  * A string description of the error code can be recovered with:
@@ -99,14 +107,14 @@ static int hmac_demo(void)
     CHK(mbedtls_md_hmac_update(&ctx, msg1_part1, sizeof(msg1_part1)));
     CHK(mbedtls_md_hmac_update(&ctx, msg1_part2, sizeof(msg1_part2)));
     CHK(mbedtls_md_hmac_finish(&ctx, out));
-    mbedtls_test_print_buf("msg1", out, mbedtls_md_get_size(info));
+    print_buf("msg1", out, mbedtls_md_get_size(info));
 
     /* compute HMAC(key, msg2_part1 | msg2_part2) */
     CHK(mbedtls_md_hmac_reset(&ctx));     // prepare for new operation
     CHK(mbedtls_md_hmac_update(&ctx, msg2_part1, sizeof(msg2_part1)));
     CHK(mbedtls_md_hmac_update(&ctx, msg2_part2, sizeof(msg2_part2)));
     CHK(mbedtls_md_hmac_finish(&ctx, out));
-    mbedtls_test_print_buf("msg2", out, mbedtls_md_get_size(info));
+    print_buf("msg2", out, mbedtls_md_get_size(info));
 
 exit:
     mbedtls_md_free(&ctx);

--- a/programs/hash/md_hmac_demo.c
+++ b/programs/hash/md_hmac_demo.c
@@ -79,7 +79,7 @@ const unsigned char key_bytes[32] = { 0 };
  * This function demonstrates computation of the HMAC of two messages using
  * the multipart API.
  */
-int hmac_demo(void)
+static int hmac_demo(void)
 {
     int ret;
     const mbedtls_md_type_t alg = MBEDTLS_MD_SHA256;

--- a/programs/hash/md_hmac_demo.c
+++ b/programs/hash/md_hmac_demo.c
@@ -32,6 +32,8 @@
 
 #include "mbedtls/platform_util.h" // for mbedtls_platform_zeroize
 
+#include <test/helpers.h>
+
 #include <stdlib.h>
 #include <stdio.h>
 
@@ -55,16 +57,6 @@ const unsigned char msg2_part2[] = { 0x06, 0x06 };
 /* Dummy key material - never do this in production!
  * This example program uses SHA-256, so a 32-byte key makes sense. */
 const unsigned char key_bytes[32] = { 0 };
-
-/* Print the contents of a buffer in hex */
-void print_buf(const char *title, unsigned char *buf, size_t len)
-{
-    printf("%s:", title);
-    for (size_t i = 0; i < len; i++) {
-        printf(" %02x", buf[i]);
-    }
-    printf("\n");
-}
 
 /* Run an Mbed TLS function and bail out if it fails.
  * A string description of the error code can be recovered with:
@@ -107,14 +99,14 @@ int hmac_demo(void)
     CHK(mbedtls_md_hmac_update(&ctx, msg1_part1, sizeof(msg1_part1)));
     CHK(mbedtls_md_hmac_update(&ctx, msg1_part2, sizeof(msg1_part2)));
     CHK(mbedtls_md_hmac_finish(&ctx, out));
-    print_buf("msg1", out, mbedtls_md_get_size(info));
+    mbedtls_test_print_buf("msg1", out, mbedtls_md_get_size(info));
 
     /* compute HMAC(key, msg2_part1 | msg2_part2) */
     CHK(mbedtls_md_hmac_reset(&ctx));     // prepare for new operation
     CHK(mbedtls_md_hmac_update(&ctx, msg2_part1, sizeof(msg2_part1)));
     CHK(mbedtls_md_hmac_update(&ctx, msg2_part2, sizeof(msg2_part2)));
     CHK(mbedtls_md_hmac_finish(&ctx, out));
-    print_buf("msg2", out, mbedtls_md_get_size(info));
+    mbedtls_test_print_buf("msg2", out, mbedtls_md_get_size(info));
 
 exit:
     mbedtls_md_free(&ctx);

--- a/programs/pkey/gen_key.c
+++ b/programs/pkey/gen_key.c
@@ -40,7 +40,7 @@ int main(void)
 #define DEV_RANDOM_THRESHOLD        32
 
 static int dev_random_entropy_poll(void *data, unsigned char *output,
-                            size_t len, size_t *olen)
+                                   size_t len, size_t *olen)
 {
     FILE *file;
     size_t ret, left = len;

--- a/programs/pkey/gen_key.c
+++ b/programs/pkey/gen_key.c
@@ -39,7 +39,7 @@ int main(void)
 
 #define DEV_RANDOM_THRESHOLD        32
 
-int dev_random_entropy_poll(void *data, unsigned char *output,
+static int dev_random_entropy_poll(void *data, unsigned char *output,
                             size_t len, size_t *olen)
 {
     FILE *file;

--- a/programs/psa/aead_demo.c
+++ b/programs/psa/aead_demo.c
@@ -82,7 +82,7 @@ const unsigned char msg2_part2[] = { 0x15, 0x16, 0x17 };
 const unsigned char key_bytes[32] = { 0x2a };
 
 /* Print the contents of a buffer in hex */
-void print_buf(const char *title, uint8_t *buf, size_t len)
+static void print_buf(const char *title, uint8_t *buf, size_t len)
 {
     printf("%s:", title);
     for (size_t i = 0; i < len; i++) {

--- a/programs/psa/aead_demo.c
+++ b/programs/psa/aead_demo.c
@@ -36,8 +36,6 @@
 
 #include "psa/crypto.h"
 
-#include <test/helpers.h>
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -82,6 +80,16 @@ const unsigned char msg2_part2[] = { 0x15, 0x16, 0x17 };
 /* Dummy key material - never do this in production!
  * 32-byte is enough to all the key size supported by this program. */
 const unsigned char key_bytes[32] = { 0x2a };
+
+/* Print the contents of a buffer in hex */
+void print_buf(const char *title, uint8_t *buf, size_t len)
+{
+    printf("%s:", title);
+    for (size_t i = 0; i < len; i++) {
+        printf(" %02x", buf[i]);
+    }
+    printf("\n");
+}
 
 /* Run a PSA function and bail out if it fails.
  * The symbolic name of the error code can be recovered using:
@@ -208,7 +216,7 @@ static int aead_encrypt(psa_key_id_t key, psa_algorithm_t alg,
     p += olen_tag;
 
     olen = p - out;
-    mbedtls_test_print_buf("out", out, olen);
+    print_buf("out", out, olen);
 
 exit:
     psa_aead_abort(&op);   // required on errors, harmless on success

--- a/programs/psa/aead_demo.c
+++ b/programs/psa/aead_demo.c
@@ -36,6 +36,8 @@
 
 #include "psa/crypto.h"
 
+#include <test/helpers.h>
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -80,16 +82,6 @@ const unsigned char msg2_part2[] = { 0x15, 0x16, 0x17 };
 /* Dummy key material - never do this in production!
  * 32-byte is enough to all the key size supported by this program. */
 const unsigned char key_bytes[32] = { 0x2a };
-
-/* Print the contents of a buffer in hex */
-void print_buf(const char *title, uint8_t *buf, size_t len)
-{
-    printf("%s:", title);
-    for (size_t i = 0; i < len; i++) {
-        printf(" %02x", buf[i]);
-    }
-    printf("\n");
-}
 
 /* Run a PSA function and bail out if it fails.
  * The symbolic name of the error code can be recovered using:
@@ -216,7 +208,7 @@ static int aead_encrypt(psa_key_id_t key, psa_algorithm_t alg,
     p += olen_tag;
 
     olen = p - out;
-    print_buf("out", out, olen);
+    mbedtls_test_print_buf("out", out, olen);
 
 exit:
     psa_aead_abort(&op);   // required on errors, harmless on success

--- a/programs/psa/hmac_demo.c
+++ b/programs/psa/hmac_demo.c
@@ -59,7 +59,7 @@ const unsigned char msg2_part2[] = { 0x06, 0x06 };
 const unsigned char key_bytes[32] = { 0 };
 
 /* Print the contents of a buffer in hex */
-void print_buf(const char *title, uint8_t *buf, size_t len)
+static void print_buf(const char *title, uint8_t *buf, size_t len)
 {
     printf("%s:", title);
     for (size_t i = 0; i < len; i++) {

--- a/programs/psa/hmac_demo.c
+++ b/programs/psa/hmac_demo.c
@@ -32,8 +32,6 @@
 
 #include "mbedtls/platform_util.h" // for mbedtls_platform_zeroize
 
-#include <test/helpers.h>
-
 #include <stdlib.h>
 #include <stdio.h>
 
@@ -59,6 +57,16 @@ const unsigned char msg2_part2[] = { 0x06, 0x06 };
 /* Dummy key material - never do this in production!
  * This example program uses SHA-256, so a 32-byte key makes sense. */
 const unsigned char key_bytes[32] = { 0 };
+
+/* Print the contents of a buffer in hex */
+void print_buf(const char *title, uint8_t *buf, size_t len)
+{
+    printf("%s:", title);
+    for (size_t i = 0; i < len; i++) {
+        printf(" %02x", buf[i]);
+    }
+    printf("\n");
+}
 
 /* Run a PSA function and bail out if it fails.
  * The symbolic name of the error code can be recovered using:
@@ -114,14 +122,14 @@ static psa_status_t hmac_demo(void)
     PSA_CHECK(psa_mac_update(&op, msg1_part1, sizeof(msg1_part1)));
     PSA_CHECK(psa_mac_update(&op, msg1_part2, sizeof(msg1_part2)));
     PSA_CHECK(psa_mac_sign_finish(&op, out, sizeof(out), &out_len));
-    mbedtls_test_print_buf("msg1", out, out_len);
+    print_buf("msg1", out, out_len);
 
     /* compute HMAC(key, msg2_part1 | msg2_part2) */
     PSA_CHECK(psa_mac_sign_setup(&op, key, alg));
     PSA_CHECK(psa_mac_update(&op, msg2_part1, sizeof(msg2_part1)));
     PSA_CHECK(psa_mac_update(&op, msg2_part2, sizeof(msg2_part2)));
     PSA_CHECK(psa_mac_sign_finish(&op, out, sizeof(out), &out_len));
-    mbedtls_test_print_buf("msg2", out, out_len);
+    print_buf("msg2", out, out_len);
 
 exit:
     psa_mac_abort(&op);   // needed on error, harmless on success

--- a/programs/psa/hmac_demo.c
+++ b/programs/psa/hmac_demo.c
@@ -82,7 +82,7 @@ const unsigned char key_bytes[32] = { 0 };
  * This function demonstrates computation of the HMAC of two messages using
  * the multipart API.
  */
-psa_status_t hmac_demo(void)
+static psa_status_t hmac_demo(void)
 {
     psa_status_t status;
     const psa_algorithm_t alg = PSA_ALG_HMAC(PSA_ALG_SHA_256);

--- a/programs/psa/hmac_demo.c
+++ b/programs/psa/hmac_demo.c
@@ -32,6 +32,8 @@
 
 #include "mbedtls/platform_util.h" // for mbedtls_platform_zeroize
 
+#include <test/helpers.h>
+
 #include <stdlib.h>
 #include <stdio.h>
 
@@ -57,16 +59,6 @@ const unsigned char msg2_part2[] = { 0x06, 0x06 };
 /* Dummy key material - never do this in production!
  * This example program uses SHA-256, so a 32-byte key makes sense. */
 const unsigned char key_bytes[32] = { 0 };
-
-/* Print the contents of a buffer in hex */
-void print_buf(const char *title, uint8_t *buf, size_t len)
-{
-    printf("%s:", title);
-    for (size_t i = 0; i < len; i++) {
-        printf(" %02x", buf[i]);
-    }
-    printf("\n");
-}
 
 /* Run a PSA function and bail out if it fails.
  * The symbolic name of the error code can be recovered using:
@@ -122,14 +114,14 @@ psa_status_t hmac_demo(void)
     PSA_CHECK(psa_mac_update(&op, msg1_part1, sizeof(msg1_part1)));
     PSA_CHECK(psa_mac_update(&op, msg1_part2, sizeof(msg1_part2)));
     PSA_CHECK(psa_mac_sign_finish(&op, out, sizeof(out), &out_len));
-    print_buf("msg1", out, out_len);
+    mbedtls_test_print_buf("msg1", out, out_len);
 
     /* compute HMAC(key, msg2_part1 | msg2_part2) */
     PSA_CHECK(psa_mac_sign_setup(&op, key, alg));
     PSA_CHECK(psa_mac_update(&op, msg2_part1, sizeof(msg2_part1)));
     PSA_CHECK(psa_mac_update(&op, msg2_part2, sizeof(msg2_part2)));
     PSA_CHECK(psa_mac_sign_finish(&op, out, sizeof(out), &out_len));
-    print_buf("msg2", out, out_len);
+    mbedtls_test_print_buf("msg2", out, out_len);
 
 exit:
     psa_mac_abort(&op);   // needed on error, harmless on success

--- a/programs/psa/psa_constant_names.c
+++ b/programs/psa/psa_constant_names.c
@@ -192,7 +192,7 @@ typedef enum {
     TYPE_STATUS,
 } signed_value_type;
 
-int process_signed(signed_value_type type, long min, long max, char **argp)
+static int process_signed(signed_value_type type, long min, long max, char **argp)
 {
     for (; *argp != NULL; argp++) {
         char buffer[200];
@@ -231,7 +231,7 @@ typedef enum {
     TYPE_KEY_USAGE,
 } unsigned_value_type;
 
-int process_unsigned(unsigned_value_type type, unsigned long max, char **argp)
+static int process_unsigned(unsigned_value_type type, unsigned long max, char **argp)
 {
     for (; *argp != NULL; argp++) {
         char buffer[200];

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -597,7 +597,7 @@ static int my_verify(void *data, mbedtls_x509_crt *crt,
 #endif /* MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED */
 
 #if defined(MBEDTLS_SSL_DTLS_CONNECTION_ID)
-int report_cid_usage(mbedtls_ssl_context *ssl,
+static int report_cid_usage(mbedtls_ssl_context *ssl,
                      const char *additional_description)
 {
     int ret;

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -598,7 +598,7 @@ static int my_verify(void *data, mbedtls_x509_crt *crt,
 
 #if defined(MBEDTLS_SSL_DTLS_CONNECTION_ID)
 static int report_cid_usage(mbedtls_ssl_context *ssl,
-                     const char *additional_description)
+                            const char *additional_description)
 {
     int ret;
     unsigned char peer_cid[MBEDTLS_SSL_CID_OUT_LEN_MAX];

--- a/programs/ssl/ssl_context_info.c
+++ b/programs/ssl/ssl_context_info.c
@@ -248,7 +248,7 @@ static void print_b64(const uint8_t *b, size_t len)
  * /p prefix    prefix for the new lines
  */
 static void print_hex(const uint8_t *b, size_t len,
-               const size_t in_line, const char *prefix)
+                      const size_t in_line, const char *prefix)
 {
     size_t i = 0;
     const uint8_t *end = b + len;
@@ -510,7 +510,7 @@ static void print_deserialized_ssl_cert(const uint8_t *ssl, uint32_t len)
  * /p session_cfg_flag  session configuration flags
  */
 static void print_deserialized_ssl_session(const uint8_t *ssl, uint32_t len,
-                                    int session_cfg_flag)
+                                           int session_cfg_flag)
 {
     const struct mbedtls_ssl_ciphersuite_t *ciphersuite_info;
     int ciphersuite_id;

--- a/programs/ssl/ssl_context_info.c
+++ b/programs/ssl/ssl_context_info.c
@@ -111,12 +111,12 @@ const char buf_ln_err[] = "Buffer does not have enough data to complete the pars
 /*
  * Basic printing functions
  */
-void print_version(void)
+static void print_version(void)
 {
     printf("%s v%d.%d\n", PROG_NAME, VER_MAJOR, VER_MINOR);
 }
 
-void print_usage(void)
+static void print_usage(void)
 {
     print_version();
     printf("\nThis program is used to deserialize an Mbed TLS SSL session from the base64 code provided\n"
@@ -138,7 +138,7 @@ void print_usage(void)
         );
 }
 
-void printf_dbg(const char *str, ...)
+static void printf_dbg(const char *str, ...)
 {
     if (debug) {
         va_list args;
@@ -151,7 +151,7 @@ void printf_dbg(const char *str, ...)
 }
 
 MBEDTLS_PRINTF_ATTRIBUTE(1, 2)
-void printf_err(const char *str, ...)
+static void printf_err(const char *str, ...)
 {
     va_list args;
     va_start(args, str);
@@ -165,7 +165,7 @@ void printf_err(const char *str, ...)
 /*
  * Exit from the program in case of error
  */
-void error_exit(void)
+static void error_exit(void)
 {
     if (NULL != b64_file) {
         fclose(b64_file);
@@ -176,7 +176,7 @@ void error_exit(void)
 /*
  * This function takes the input arguments of this program
  */
-void parse_arguments(int argc, char *argv[])
+static void parse_arguments(int argc, char *argv[])
 {
     int i = 1;
 
@@ -223,7 +223,7 @@ void parse_arguments(int argc, char *argv[])
 /*
  * This function prints base64 code to the stdout
  */
-void print_b64(const uint8_t *b, size_t len)
+static void print_b64(const uint8_t *b, size_t len)
 {
     size_t i = 0;
     const uint8_t *end = b + len;
@@ -247,7 +247,7 @@ void print_b64(const uint8_t *b, size_t len)
  * /p in_line   number of bytes in one line
  * /p prefix    prefix for the new lines
  */
-void print_hex(const uint8_t *b, size_t len,
+static void print_hex(const uint8_t *b, size_t len,
                const size_t in_line, const char *prefix)
 {
     size_t i = 0;
@@ -271,7 +271,7 @@ void print_hex(const uint8_t *b, size_t len,
 /*
  *  Print the value of time_t in format e.g. 2020-01-23 13:05:59
  */
-void print_time(const uint64_t *time)
+static void print_time(const uint64_t *time)
 {
 #if defined(MBEDTLS_HAVE_TIME)
     char buf[20];
@@ -292,7 +292,7 @@ void print_time(const uint64_t *time)
 /*
  * Print the input string if the bit is set in the value
  */
-void print_if_bit(const char *str, int bit, int val)
+static void print_if_bit(const char *str, int bit, int val)
 {
     if (bit & val) {
         printf("\t%s\n", str);
@@ -302,7 +302,7 @@ void print_if_bit(const char *str, int bit, int val)
 /*
  * Return pointer to hardcoded "enabled" or "disabled" depending on the input value
  */
-const char *get_enabled_str(int is_en)
+static const char *get_enabled_str(int is_en)
 {
     return (is_en) ? "enabled" : "disabled";
 }
@@ -310,7 +310,7 @@ const char *get_enabled_str(int is_en)
 /*
  * Return pointer to hardcoded MFL string value depending on the MFL code at the input
  */
-const char *get_mfl_str(int mfl_code)
+static const char *get_mfl_str(int mfl_code)
 {
     switch (mfl_code) {
         case MBEDTLS_SSL_MAX_FRAG_LEN_NONE:
@@ -343,7 +343,7 @@ const char *get_mfl_str(int mfl_code)
  * \retval      number of bytes written in to the b64 buffer or 0 in case no more
  *              data was found
  */
-size_t read_next_b64_code(uint8_t **b64, size_t *max_len)
+static size_t read_next_b64_code(uint8_t **b64, size_t *max_len)
 {
     int valid_balance = 0;  /* balance between valid and invalid characters */
     size_t len = 0;
@@ -443,7 +443,7 @@ size_t read_next_b64_code(uint8_t **b64, size_t *max_len)
  * /p ssl   pointer to serialized certificate
  * /p len   number of bytes in the buffer
  */
-void print_deserialized_ssl_cert(const uint8_t *ssl, uint32_t len)
+static void print_deserialized_ssl_cert(const uint8_t *ssl, uint32_t len)
 {
     enum { STRLEN = 4096 };
     mbedtls_x509_crt crt;
@@ -509,7 +509,7 @@ void print_deserialized_ssl_cert(const uint8_t *ssl, uint32_t len)
  * /p len               number of bytes in the buffer
  * /p session_cfg_flag  session configuration flags
  */
-void print_deserialized_ssl_session(const uint8_t *ssl, uint32_t len,
+static void print_deserialized_ssl_session(const uint8_t *ssl, uint32_t len,
                                     int session_cfg_flag)
 {
     const struct mbedtls_ssl_ciphersuite_t *ciphersuite_info;
@@ -746,7 +746,7 @@ void print_deserialized_ssl_session(const uint8_t *ssl, uint32_t len,
  * /p ssl   pointer to serialized session
  * /p len   number of bytes in the buffer
  */
-void print_deserialized_ssl_context(const uint8_t *ssl, size_t len)
+static void print_deserialized_ssl_context(const uint8_t *ssl, size_t len)
 {
     const uint8_t *end = ssl + len;
     uint32_t session_len;

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -756,7 +756,7 @@ struct _sni_entry {
     sni_entry *next;
 };
 
-void sni_free(sni_entry *head)
+static void sni_free(sni_entry *head)
 {
     sni_entry *cur = head, *next;
 
@@ -786,7 +786,7 @@ void sni_free(sni_entry *head)
  *
  * Modifies the input string! This is not production quality!
  */
-sni_entry *sni_parse(char *sni_string)
+static sni_entry *sni_parse(char *sni_string)
 {
     sni_entry *cur = NULL, *new = NULL;
     char *p = sni_string;
@@ -878,7 +878,7 @@ error:
 /*
  * SNI callback.
  */
-int sni_callback(void *p_info, mbedtls_ssl_context *ssl,
+static int sni_callback(void *p_info, mbedtls_ssl_context *ssl,
                  const unsigned char *name, size_t name_len)
 {
     const sni_entry *cur = (const sni_entry *) p_info;
@@ -909,7 +909,7 @@ int sni_callback(void *p_info, mbedtls_ssl_context *ssl,
 /*
  * server certificate selection callback.
  */
-int cert_callback(mbedtls_ssl_context *ssl)
+static int cert_callback(mbedtls_ssl_context *ssl)
 {
     const sni_entry *cur = (sni_entry *) mbedtls_ssl_get_user_data_p(ssl);
     if (cur != NULL) {
@@ -954,7 +954,7 @@ struct _psk_entry {
 /*
  * Free a list of psk_entry's
  */
-int psk_free(psk_entry *head)
+static int psk_free(psk_entry *head)
 {
     psk_entry *next;
 
@@ -985,7 +985,7 @@ int psk_free(psk_entry *head)
  *
  * Modifies the input string! This is not production quality!
  */
-psk_entry *psk_parse(char *psk_string)
+static psk_entry *psk_parse(char *psk_string)
 {
     psk_entry *cur = NULL, *new = NULL;
     char *p = psk_string;
@@ -1027,7 +1027,7 @@ error:
 /*
  * PSK callback
  */
-int psk_callback(void *p_info, mbedtls_ssl_context *ssl,
+static int psk_callback(void *p_info, mbedtls_ssl_context *ssl,
                  const unsigned char *name, size_t name_len)
 {
     psk_entry *cur = (psk_entry *) p_info;
@@ -1055,7 +1055,7 @@ static mbedtls_net_context listen_fd, client_fd;
 /* Interruption handler to ensure clean exit (for valgrind testing) */
 #if !defined(_WIN32)
 static int received_sigterm = 0;
-void term_handler(int sig)
+static void term_handler(int sig)
 {
     ((void) sig);
     received_sigterm = 1;
@@ -1105,7 +1105,7 @@ typedef struct {
     void *p_rng;
 } ssl_async_key_context_t;
 
-int ssl_async_set_key(ssl_async_key_context_t *ctx,
+static int ssl_async_set_key(ssl_async_key_context_t *ctx,
                       mbedtls_x509_crt *cert,
                       mbedtls_pk_context *pk,
                       int pk_take_ownership,
@@ -1332,7 +1332,7 @@ static psa_status_t psa_setup_psk_key_slot(mbedtls_svc_key_id_t *slot,
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 #if defined(MBEDTLS_SSL_DTLS_CONNECTION_ID)
-int report_cid_usage(mbedtls_ssl_context *ssl,
+static int report_cid_usage(mbedtls_ssl_context *ssl,
                      const char *additional_description)
 {
     int ret;
@@ -1383,7 +1383,7 @@ static inline void put_unaligned_uint32(void *p, uint32_t x)
 }
 
 /* Functions for session ticket tests */
-int dummy_ticket_write(void *p_ticket, const mbedtls_ssl_session *session,
+static int dummy_ticket_write(void *p_ticket, const mbedtls_ssl_session *session,
                        unsigned char *start, const unsigned char *end,
                        size_t *tlen, uint32_t *ticket_lifetime)
 {
@@ -1410,7 +1410,7 @@ int dummy_ticket_write(void *p_ticket, const mbedtls_ssl_session *session,
     return 0;
 }
 
-int dummy_ticket_parse(void *p_ticket, mbedtls_ssl_session *session,
+static int dummy_ticket_parse(void *p_ticket, mbedtls_ssl_session *session,
                        unsigned char *buf, size_t len)
 {
     int ret;
@@ -1469,7 +1469,7 @@ int dummy_ticket_parse(void *p_ticket, mbedtls_ssl_session *session,
 }
 #endif /* MBEDTLS_SSL_SESSION_TICKETS && MBEDTLS_HAVE_TIME */
 
-int parse_cipher(char *buf)
+static int parse_cipher(char *buf)
 {
     if (strcmp(buf, "AES-128-CCM")) {
         return MBEDTLS_CIPHER_AES_128_CCM;

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -879,7 +879,7 @@ error:
  * SNI callback.
  */
 static int sni_callback(void *p_info, mbedtls_ssl_context *ssl,
-                 const unsigned char *name, size_t name_len)
+                        const unsigned char *name, size_t name_len)
 {
     const sni_entry *cur = (const sni_entry *) p_info;
 
@@ -1028,7 +1028,7 @@ error:
  * PSK callback
  */
 static int psk_callback(void *p_info, mbedtls_ssl_context *ssl,
-                 const unsigned char *name, size_t name_len)
+                        const unsigned char *name, size_t name_len)
 {
     psk_entry *cur = (psk_entry *) p_info;
 
@@ -1106,10 +1106,10 @@ typedef struct {
 } ssl_async_key_context_t;
 
 static int ssl_async_set_key(ssl_async_key_context_t *ctx,
-                      mbedtls_x509_crt *cert,
-                      mbedtls_pk_context *pk,
-                      int pk_take_ownership,
-                      unsigned delay)
+                             mbedtls_x509_crt *cert,
+                             mbedtls_pk_context *pk,
+                             int pk_take_ownership,
+                             unsigned delay)
 {
     if (ctx->slots_used >= sizeof(ctx->slots) / sizeof(*ctx->slots)) {
         return -1;
@@ -1333,7 +1333,7 @@ static psa_status_t psa_setup_psk_key_slot(mbedtls_svc_key_id_t *slot,
 
 #if defined(MBEDTLS_SSL_DTLS_CONNECTION_ID)
 static int report_cid_usage(mbedtls_ssl_context *ssl,
-                     const char *additional_description)
+                            const char *additional_description)
 {
     int ret;
     unsigned char peer_cid[MBEDTLS_SSL_CID_OUT_LEN_MAX];
@@ -1384,8 +1384,8 @@ static inline void put_unaligned_uint32(void *p, uint32_t x)
 
 /* Functions for session ticket tests */
 static int dummy_ticket_write(void *p_ticket, const mbedtls_ssl_session *session,
-                       unsigned char *start, const unsigned char *end,
-                       size_t *tlen, uint32_t *ticket_lifetime)
+                              unsigned char *start, const unsigned char *end,
+                              size_t *tlen, uint32_t *ticket_lifetime)
 {
     int ret;
     unsigned char *p = start;
@@ -1411,7 +1411,7 @@ static int dummy_ticket_write(void *p_ticket, const mbedtls_ssl_session *session
 }
 
 static int dummy_ticket_parse(void *p_ticket, mbedtls_ssl_session *session,
-                       unsigned char *buf, size_t len)
+                              unsigned char *buf, size_t len)
 {
     int ret;
     ((void) p_ticket);

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -1376,7 +1376,8 @@ static int report_cid_usage(mbedtls_ssl_context *ssl,
 }
 #endif /* MBEDTLS_SSL_DTLS_CONNECTION_ID */
 
-#if defined(MBEDTLS_SSL_SESSION_TICKETS) && defined(MBEDTLS_HAVE_TIME)
+#if defined(MBEDTLS_SSL_SESSION_TICKETS) && defined(MBEDTLS_SSL_TICKET_C) && \
+    defined(MBEDTLS_HAVE_TIME)
 static inline void put_unaligned_uint32(void *p, uint32_t x)
 {
     memcpy(p, &x, sizeof(x));
@@ -1467,7 +1468,7 @@ static int dummy_ticket_parse(void *p_ticket, mbedtls_ssl_session *session,
 
     return ret;
 }
-#endif /* MBEDTLS_SSL_SESSION_TICKETS && MBEDTLS_HAVE_TIME */
+#endif /* MBEDTLS_SSL_SESSION_TICKETS && MBEDTLS_SSL_TICKET_C && MBEDTLS_HAVE_TIME */
 
 static int parse_cipher(char *buf)
 {

--- a/programs/ssl/ssl_test_common_source.c
+++ b/programs/ssl/ssl_test_common_source.c
@@ -12,7 +12,7 @@
  *  SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
  */
 
-void eap_tls_key_derivation(void *p_expkey,
+static void eap_tls_key_derivation(void *p_expkey,
                             mbedtls_ssl_key_export_type secret_type,
                             const unsigned char *secret,
                             size_t secret_len,
@@ -36,7 +36,7 @@ void eap_tls_key_derivation(void *p_expkey,
     keys->tls_prf_type = tls_prf_type;
 }
 
-void nss_keylog_export(void *p_expkey,
+static void nss_keylog_export(void *p_expkey,
                        mbedtls_ssl_key_export_type secret_type,
                        const unsigned char *secret,
                        size_t secret_len,
@@ -106,7 +106,7 @@ exit:
 }
 
 #if defined(MBEDTLS_SSL_DTLS_SRTP)
-void dtls_srtp_key_derivation(void *p_expkey,
+static void dtls_srtp_key_derivation(void *p_expkey,
                               mbedtls_ssl_key_export_type secret_type,
                               const unsigned char *secret,
                               size_t secret_len,
@@ -131,7 +131,7 @@ void dtls_srtp_key_derivation(void *p_expkey,
 }
 #endif /* MBEDTLS_SSL_DTLS_SRTP */
 
-int ssl_check_record(mbedtls_ssl_context const *ssl,
+static int ssl_check_record(mbedtls_ssl_context const *ssl,
                      unsigned char const *buf, size_t len)
 {
     int my_ret = 0, ret_cr1, ret_cr2;
@@ -195,7 +195,7 @@ cleanup:
     return my_ret;
 }
 
-int recv_cb(void *ctx, unsigned char *buf, size_t len)
+static int recv_cb(void *ctx, unsigned char *buf, size_t len)
 {
     io_ctx_t *io_ctx = (io_ctx_t *) ctx;
     size_t recv_len;
@@ -223,7 +223,7 @@ int recv_cb(void *ctx, unsigned char *buf, size_t len)
     return (int) recv_len;
 }
 
-int recv_timeout_cb(void *ctx, unsigned char *buf, size_t len,
+static int recv_timeout_cb(void *ctx, unsigned char *buf, size_t len,
                     uint32_t timeout)
 {
     io_ctx_t *io_ctx = (io_ctx_t *) ctx;
@@ -248,7 +248,7 @@ int recv_timeout_cb(void *ctx, unsigned char *buf, size_t len,
     return (int) recv_len;
 }
 
-int send_cb(void *ctx, unsigned char const *buf, size_t len)
+static int send_cb(void *ctx, unsigned char const *buf, size_t len)
 {
     io_ctx_t *io_ctx = (io_ctx_t *) ctx;
 
@@ -319,7 +319,7 @@ uint16_t ssl_sig_algs_for_test[] = {
 /** Functionally equivalent to mbedtls_x509_crt_verify_info, see that function
  *  for more info.
  */
-int x509_crt_verify_info(char *buf, size_t size, const char *prefix,
+static int x509_crt_verify_info(char *buf, size_t size, const char *prefix,
                          uint32_t flags)
 {
 #if !defined(MBEDTLS_X509_REMOVE_INFO)
@@ -352,7 +352,7 @@ int x509_crt_verify_info(char *buf, size_t size, const char *prefix,
 }
 #endif /* MBEDTLS_X509_CRT_PARSE_C */
 
-void mbedtls_print_supported_sig_algs(void)
+static void mbedtls_print_supported_sig_algs(void)
 {
     mbedtls_printf("supported signature algorithms:\n");
     mbedtls_printf("\trsa_pkcs1_sha256 ");

--- a/programs/ssl/ssl_test_common_source.c
+++ b/programs/ssl/ssl_test_common_source.c
@@ -352,6 +352,7 @@ static int x509_crt_verify_info(char *buf, size_t size, const char *prefix,
 }
 #endif /* MBEDTLS_X509_CRT_PARSE_C */
 
+#if defined(MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED)
 static void mbedtls_print_supported_sig_algs(void)
 {
     mbedtls_printf("supported signature algorithms:\n");
@@ -373,3 +374,4 @@ static void mbedtls_print_supported_sig_algs(void)
     mbedtls_printf("ecdsa_sha1\n");
     mbedtls_printf("\n");
 }
+#endif /* MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED */

--- a/programs/ssl/ssl_test_common_source.c
+++ b/programs/ssl/ssl_test_common_source.c
@@ -13,12 +13,12 @@
  */
 
 static void eap_tls_key_derivation(void *p_expkey,
-                            mbedtls_ssl_key_export_type secret_type,
-                            const unsigned char *secret,
-                            size_t secret_len,
-                            const unsigned char client_random[32],
-                            const unsigned char server_random[32],
-                            mbedtls_tls_prf_types tls_prf_type)
+                                   mbedtls_ssl_key_export_type secret_type,
+                                   const unsigned char *secret,
+                                   size_t secret_len,
+                                   const unsigned char client_random[32],
+                                   const unsigned char server_random[32],
+                                   mbedtls_tls_prf_types tls_prf_type)
 {
     eap_tls_keys *keys = (eap_tls_keys *) p_expkey;
 
@@ -37,12 +37,12 @@ static void eap_tls_key_derivation(void *p_expkey,
 }
 
 static void nss_keylog_export(void *p_expkey,
-                       mbedtls_ssl_key_export_type secret_type,
-                       const unsigned char *secret,
-                       size_t secret_len,
-                       const unsigned char client_random[32],
-                       const unsigned char server_random[32],
-                       mbedtls_tls_prf_types tls_prf_type)
+                              mbedtls_ssl_key_export_type secret_type,
+                              const unsigned char *secret,
+                              size_t secret_len,
+                              const unsigned char client_random[32],
+                              const unsigned char server_random[32],
+                              mbedtls_tls_prf_types tls_prf_type)
 {
     char nss_keylog_line[200];
     size_t const client_random_len = 32;
@@ -107,12 +107,12 @@ exit:
 
 #if defined(MBEDTLS_SSL_DTLS_SRTP)
 static void dtls_srtp_key_derivation(void *p_expkey,
-                              mbedtls_ssl_key_export_type secret_type,
-                              const unsigned char *secret,
-                              size_t secret_len,
-                              const unsigned char client_random[32],
-                              const unsigned char server_random[32],
-                              mbedtls_tls_prf_types tls_prf_type)
+                                     mbedtls_ssl_key_export_type secret_type,
+                                     const unsigned char *secret,
+                                     size_t secret_len,
+                                     const unsigned char client_random[32],
+                                     const unsigned char server_random[32],
+                                     mbedtls_tls_prf_types tls_prf_type)
 {
     dtls_srtp_keys *keys = (dtls_srtp_keys *) p_expkey;
 
@@ -132,7 +132,7 @@ static void dtls_srtp_key_derivation(void *p_expkey,
 #endif /* MBEDTLS_SSL_DTLS_SRTP */
 
 static int ssl_check_record(mbedtls_ssl_context const *ssl,
-                     unsigned char const *buf, size_t len)
+                            unsigned char const *buf, size_t len)
 {
     int my_ret = 0, ret_cr1, ret_cr2;
     unsigned char *tmp_buf;
@@ -224,7 +224,7 @@ static int recv_cb(void *ctx, unsigned char *buf, size_t len)
 }
 
 static int recv_timeout_cb(void *ctx, unsigned char *buf, size_t len,
-                    uint32_t timeout)
+                           uint32_t timeout)
 {
     io_ctx_t *io_ctx = (io_ctx_t *) ctx;
     int ret;
@@ -320,7 +320,7 @@ uint16_t ssl_sig_algs_for_test[] = {
  *  for more info.
  */
 static int x509_crt_verify_info(char *buf, size_t size, const char *prefix,
-                         uint32_t flags)
+                                uint32_t flags)
 {
 #if !defined(MBEDTLS_X509_REMOVE_INFO)
     return mbedtls_x509_crt_verify_info(buf, size, prefix, flags);

--- a/programs/test/metatest.c
+++ b/programs/test/metatest.c
@@ -128,7 +128,7 @@ static void null_pointer_dereference(const char *name)
     volatile char *volatile p;
     set_to_zero_but_the_compiler_does_not_know(&p, sizeof(p));
     /* Undefined behavior (read from null data pointer) */
-    mbedtls_printf("%p -> %u\n", p, (unsigned) *p);
+    mbedtls_printf("%p -> %u\n", (void *) p, (unsigned) *p);
 }
 
 static void null_pointer_call(const char *name)

--- a/programs/test/metatest.c
+++ b/programs/test/metatest.c
@@ -76,13 +76,13 @@ void(*volatile do_nothing_with_object_but_the_compiler_does_not_know)(void *) =
 /* Test framework features */
 /****************************************************************/
 
-void meta_test_fail(const char *name)
+static void meta_test_fail(const char *name)
 {
     (void) name;
     mbedtls_test_fail("Forced test failure", __LINE__, __FILE__);
 }
 
-void meta_test_not_equal(const char *name)
+static void meta_test_not_equal(const char *name)
 {
     int left = 20;
     int right = 10;
@@ -94,7 +94,7 @@ exit:
     ;
 }
 
-void meta_test_not_le_s(const char *name)
+static void meta_test_not_le_s(const char *name)
 {
     int left = 20;
     int right = 10;
@@ -106,7 +106,7 @@ exit:
     ;
 }
 
-void meta_test_not_le_u(const char *name)
+static void meta_test_not_le_u(const char *name)
 {
     size_t left = 20;
     size_t right = 10;
@@ -122,7 +122,7 @@ exit:
 /* Platform features */
 /****************************************************************/
 
-void null_pointer_dereference(const char *name)
+static void null_pointer_dereference(const char *name)
 {
     (void) name;
     volatile char *volatile p;
@@ -131,7 +131,7 @@ void null_pointer_dereference(const char *name)
     mbedtls_printf("%p -> %u\n", p, (unsigned) *p);
 }
 
-void null_pointer_call(const char *name)
+static void null_pointer_call(const char *name)
 {
     (void) name;
     unsigned(*volatile p)(void);
@@ -148,7 +148,7 @@ void null_pointer_call(const char *name)
 /* Memory */
 /****************************************************************/
 
-void read_after_free(const char *name)
+static void read_after_free(const char *name)
 {
     (void) name;
     volatile char *p = calloc_but_the_compiler_does_not_know(1, 1);
@@ -158,7 +158,7 @@ void read_after_free(const char *name)
     mbedtls_printf("%u\n", (unsigned) *p);
 }
 
-void double_free(const char *name)
+static void double_free(const char *name)
 {
     (void) name;
     volatile char *p = calloc_but_the_compiler_does_not_know(1, 1);
@@ -168,7 +168,7 @@ void double_free(const char *name)
     free_but_the_compiler_does_not_know((void *) p);
 }
 
-void read_uninitialized_stack(const char *name)
+static void read_uninitialized_stack(const char *name)
 {
     (void) name;
     char buf[1];
@@ -182,7 +182,7 @@ void read_uninitialized_stack(const char *name)
     }
 }
 
-void memory_leak(const char *name)
+static void memory_leak(const char *name)
 {
     (void) name;
     volatile char *p = calloc_but_the_compiler_does_not_know(1, 1);
@@ -196,7 +196,7 @@ void memory_leak(const char *name)
  * %(start), %(offset) and %(count) are decimal integers.
  * %(direction) is either the character 'r' for read or 'w' for write.
  */
-void test_memory_poison(const char *name)
+static void test_memory_poison(const char *name)
 {
     size_t start = 0, offset = 0, count = 0;
     char direction = 'r';
@@ -254,7 +254,7 @@ void test_memory_poison(const char *name)
 /* Threading */
 /****************************************************************/
 
-void mutex_lock_not_initialized(const char *name)
+static void mutex_lock_not_initialized(const char *name)
 {
     (void) name;
 #if defined(MBEDTLS_THREADING_C)
@@ -270,7 +270,7 @@ exit:
 #endif
 }
 
-void mutex_unlock_not_initialized(const char *name)
+static void mutex_unlock_not_initialized(const char *name)
 {
     (void) name;
 #if defined(MBEDTLS_THREADING_C)
@@ -286,7 +286,7 @@ exit:
 #endif
 }
 
-void mutex_free_not_initialized(const char *name)
+static void mutex_free_not_initialized(const char *name)
 {
     (void) name;
 #if defined(MBEDTLS_THREADING_C)
@@ -300,7 +300,7 @@ void mutex_free_not_initialized(const char *name)
 #endif
 }
 
-void mutex_double_init(const char *name)
+static void mutex_double_init(const char *name)
 {
     (void) name;
 #if defined(MBEDTLS_THREADING_C)
@@ -315,7 +315,7 @@ void mutex_double_init(const char *name)
 #endif
 }
 
-void mutex_double_free(const char *name)
+static void mutex_double_free(const char *name)
 {
     (void) name;
 #if defined(MBEDTLS_THREADING_C)
@@ -330,7 +330,7 @@ void mutex_double_free(const char *name)
 #endif
 }
 
-void mutex_leak(const char *name)
+static void mutex_leak(const char *name)
 {
     (void) name;
 #if defined(MBEDTLS_THREADING_C)

--- a/programs/test/selftest.c
+++ b/programs/test/selftest.c
@@ -241,7 +241,7 @@ static void create_entropy_seed_file(void)
 }
 #endif
 
-int mbedtls_entropy_self_test_wrapper(int verbose)
+static int mbedtls_entropy_self_test_wrapper(int verbose)
 {
 #if defined(MBEDTLS_ENTROPY_NV_SEED) && !defined(MBEDTLS_NO_PLATFORM_ENTROPY)
     create_entropy_seed_file();
@@ -252,7 +252,7 @@ int mbedtls_entropy_self_test_wrapper(int verbose)
 
 #if defined(MBEDTLS_SELF_TEST)
 #if defined(MBEDTLS_MEMORY_BUFFER_ALLOC_C)
-int mbedtls_memory_buffer_alloc_free_and_self_test(int verbose)
+static int mbedtls_memory_buffer_alloc_free_and_self_test(int verbose)
 {
     if (verbose != 0) {
 #if defined(MBEDTLS_MEMORY_DEBUG)

--- a/programs/test/udp_proxy.c
+++ b/programs/test/udp_proxy.c
@@ -483,7 +483,7 @@ typedef struct {
 } packet;
 
 /* Print packet. Outgoing packets come with a reason (forward, dupl, etc.) */
-void print_packet(const packet *p, const char *why)
+static void print_packet(const packet *p, const char *why)
 {
 #if defined(MBEDTLS_TIMING_C)
     if (why == NULL) {
@@ -527,7 +527,7 @@ typedef enum {
 static inject_clihlo_state_t inject_clihlo_state;
 static packet initial_clihlo;
 
-int send_packet(const packet *p, const char *why)
+static int send_packet(const packet *p, const char *why)
 {
     int ret;
     mbedtls_net_context *dst = p->dst;
@@ -616,13 +616,13 @@ int send_packet(const packet *p, const char *why)
 static size_t prev_len;
 static packet prev[MAX_DELAYED_MSG];
 
-void clear_pending(void)
+static void clear_pending(void)
 {
     memset(&prev, 0, sizeof(prev));
     prev_len = 0;
 }
 
-void delay_packet(packet *delay)
+static void delay_packet(packet *delay)
 {
     if (prev_len == MAX_DELAYED_MSG) {
         return;
@@ -631,7 +631,7 @@ void delay_packet(packet *delay)
     memcpy(&prev[prev_len++], delay, sizeof(packet));
 }
 
-int send_delayed(void)
+static int send_delayed(void)
 {
     uint8_t offset;
     int ret;
@@ -663,7 +663,7 @@ int send_delayed(void)
 static unsigned char held[2048] = { 0 };
 #define HOLD_MAX 2
 
-int handle_message(const char *way,
+static int handle_message(const char *way,
                    mbedtls_net_context *dst,
                    mbedtls_net_context *src)
 {

--- a/programs/test/udp_proxy.c
+++ b/programs/test/udp_proxy.c
@@ -664,8 +664,8 @@ static unsigned char held[2048] = { 0 };
 #define HOLD_MAX 2
 
 static int handle_message(const char *way,
-                   mbedtls_net_context *dst,
-                   mbedtls_net_context *src)
+                          mbedtls_net_context *dst,
+                          mbedtls_net_context *src)
 {
     int ret;
     packet cur;

--- a/programs/test/zeroize.c
+++ b/programs/test/zeroize.c
@@ -23,7 +23,7 @@
 
 #define BUFFER_LEN 1024
 
-void usage(void)
+static void usage(void)
 {
     mbedtls_printf("Zeroize is a simple program to assist with testing\n");
     mbedtls_printf("the mbedtls_platform_zeroize() function by using the\n");

--- a/programs/util/pem2der.c
+++ b/programs/util/pem2der.c
@@ -46,7 +46,7 @@ struct options {
 } opt;
 
 static int convert_pem_to_der(const unsigned char *input, size_t ilen,
-                       unsigned char *output, size_t *olen)
+                              unsigned char *output, size_t *olen)
 {
     int ret;
     const unsigned char *s1, *s2, *end = input + ilen;

--- a/programs/util/pem2der.c
+++ b/programs/util/pem2der.c
@@ -45,7 +45,7 @@ struct options {
     const char *output_file;    /* where to store the output              */
 } opt;
 
-int convert_pem_to_der(const unsigned char *input, size_t ilen,
+static int convert_pem_to_der(const unsigned char *input, size_t ilen,
                        unsigned char *output, size_t *olen)
 {
     int ret;

--- a/programs/x509/cert_req.c
+++ b/programs/x509/cert_req.c
@@ -94,22 +94,22 @@ int main(void)
  * global options
  */
 struct options {
-    const char *filename;             /* filename of the key file             */
-    const char *password;             /* password for the key file            */
-    int debug_level;                  /* level of debugging                   */
+    const char *filename;             /* filename of the key file                 */
+    const char *password;             /* password for the key file                */
+    int debug_level;                  /* level of debugging                       */
     const char *output_file;          /* where to store the constructed key file  */
-    const char *subject_name;         /* subject name for certificate request   */
-    mbedtls_x509_san_list *san_list;  /* subjectAltName for certificate request */
-    unsigned char key_usage;          /* key usage flags                      */
-    int force_key_usage;              /* Force adding the KeyUsage extension  */
-    unsigned char ns_cert_type;       /* NS cert type                         */
-    int force_ns_cert_type;           /* Force adding NsCertType extension    */
-    mbedtls_md_type_t md_alg;         /* Hash algorithm used for signature.   */
+    const char *subject_name;         /* subject name for certificate request     */
+    mbedtls_x509_san_list *san_list;  /* subjectAltName for certificate request   */
+    unsigned char key_usage;          /* key usage flags                          */
+    int force_key_usage;              /* Force adding the KeyUsage extension      */
+    unsigned char ns_cert_type;       /* NS cert type                             */
+    int force_ns_cert_type;           /* Force adding NsCertType extension        */
+    mbedtls_md_type_t md_alg;         /* Hash algorithm used for signature.       */
 } opt;
 
 static int write_certificate_request(mbedtls_x509write_csr *req, const char *output_file,
-                              int (*f_rng)(void *, unsigned char *, size_t),
-                              void *p_rng)
+                                     int (*f_rng)(void *, unsigned char *, size_t),
+                                     void *p_rng)
 {
     int ret;
     FILE *f;

--- a/programs/x509/cert_req.c
+++ b/programs/x509/cert_req.c
@@ -107,7 +107,7 @@ struct options {
     mbedtls_md_type_t md_alg;         /* Hash algorithm used for signature.   */
 } opt;
 
-int write_certificate_request(mbedtls_x509write_csr *req, const char *output_file,
+static int write_certificate_request(mbedtls_x509write_csr *req, const char *output_file,
                               int (*f_rng)(void *, unsigned char *, size_t),
                               void *p_rng)
 {

--- a/programs/x509/cert_write.c
+++ b/programs/x509/cert_write.c
@@ -204,7 +204,7 @@ struct options {
     int format;                 /* format                               */
 } opt;
 
-int write_certificate(mbedtls_x509write_cert *crt, const char *output_file,
+static int write_certificate(mbedtls_x509write_cert *crt, const char *output_file,
                       int (*f_rng)(void *, unsigned char *, size_t),
                       void *p_rng)
 {
@@ -249,7 +249,7 @@ int write_certificate(mbedtls_x509write_cert *crt, const char *output_file,
     return 0;
 }
 
-int parse_serial_decimal_format(unsigned char *obuf, size_t obufmax,
+static int parse_serial_decimal_format(unsigned char *obuf, size_t obufmax,
                                 const char *ibuf, size_t *len)
 {
     unsigned long long int dec;

--- a/programs/x509/cert_write.c
+++ b/programs/x509/cert_write.c
@@ -205,8 +205,8 @@ struct options {
 } opt;
 
 static int write_certificate(mbedtls_x509write_cert *crt, const char *output_file,
-                      int (*f_rng)(void *, unsigned char *, size_t),
-                      void *p_rng)
+                             int (*f_rng)(void *, unsigned char *, size_t),
+                             void *p_rng)
 {
     int ret;
     FILE *f;
@@ -250,7 +250,7 @@ static int write_certificate(mbedtls_x509write_cert *crt, const char *output_fil
 }
 
 static int parse_serial_decimal_format(unsigned char *obuf, size_t obufmax,
-                                const char *ibuf, size_t *len)
+                                       const char *ibuf, size_t *len)
 {
     unsigned long long int dec;
     unsigned int remaining_bytes = sizeof(dec);

--- a/programs/x509/load_roots.c
+++ b/programs/x509/load_roots.c
@@ -48,7 +48,7 @@ struct options {
 } opt;
 
 
-int read_certificates(const char *const *filenames)
+static int read_certificates(const char *const *filenames)
 {
     mbedtls_x509_crt cas;
     int ret = 0;

--- a/tests/include/test/helpers.h
+++ b/tests/include/test/helpers.h
@@ -381,6 +381,9 @@ unsigned char *mbedtls_test_unhexify_alloc(const char *ibuf, size_t *olen);
 int mbedtls_test_hexcmp(uint8_t *a, uint8_t *b,
                         uint32_t a_len, uint32_t b_len);
 
+/* Print the contents of a buffer in hex */
+void mbedtls_test_print_buf(const char *title, unsigned char *buf, size_t len);
+
 #if defined(MBEDTLS_PSA_CRYPTO_C) && defined(MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG)
 #include "test/fake_external_rng_for_test.h"
 #endif

--- a/tests/include/test/helpers.h
+++ b/tests/include/test/helpers.h
@@ -381,9 +381,6 @@ unsigned char *mbedtls_test_unhexify_alloc(const char *ibuf, size_t *olen);
 int mbedtls_test_hexcmp(uint8_t *a, uint8_t *b,
                         uint32_t a_len, uint32_t b_len);
 
-/* Print the contents of a buffer in hex */
-void mbedtls_test_print_buf(const char *title, unsigned char *buf, size_t len);
-
 #if defined(MBEDTLS_PSA_CRYPTO_C) && defined(MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG)
 #include "test/fake_external_rng_for_test.h"
 #endif

--- a/tests/scripts/components-configuration-tls.sh
+++ b/tests/scripts/components-configuration-tls.sh
@@ -244,14 +244,14 @@ component_build_no_ssl_srv () {
     msg "build: full config except SSL server, make, gcc" # ~ 30s
     scripts/config.py full
     scripts/config.py unset MBEDTLS_SSL_SRV_C
-    make CC=gcc CFLAGS='-Werror -Wall -Wextra -O1'
+    make CC=gcc CFLAGS='-Werror -Wall -Wextra -O1 -Wmissing-prototypes'
 }
 
 component_build_no_ssl_cli () {
     msg "build: full config except SSL client, make, gcc" # ~ 30s
     scripts/config.py full
     scripts/config.py unset MBEDTLS_SSL_CLI_C
-    make CC=gcc CFLAGS='-Werror -Wall -Wextra -O1'
+    make CC=gcc CFLAGS='-Werror -Wall -Wextra -O1 -Wmissing-prototypes'
 }
 
 component_test_no_max_fragment_length () {

--- a/tests/src/asn1_helpers.c
+++ b/tests/src/asn1_helpers.c
@@ -15,6 +15,8 @@
 
 #include <mbedtls/asn1.h>
 
+#include <test/asn1_helpers.h>
+
 int mbedtls_test_asn1_skip_integer(unsigned char **p, const unsigned char *end,
                                    size_t min_bits, size_t max_bits,
                                    int must_be_odd)

--- a/tests/src/drivers/platform_builtin_keys.c
+++ b/tests/src/drivers/platform_builtin_keys.c
@@ -10,6 +10,8 @@
 
 #include <test/helpers.h>
 
+#if defined(MBEDTLS_PSA_CRYPTO_BUILTIN_KEYS)
+
 #include <psa/crypto.h>
 #include <psa/crypto_extra.h>
 
@@ -76,3 +78,5 @@ psa_status_t mbedtls_psa_platform_get_builtin_key(
 
     return PSA_ERROR_DOES_NOT_EXIST;
 }
+
+#endif /* MBEDTLS_PSA_CRYPTO_BUILTIN_KEYS */

--- a/tests/src/helpers.c
+++ b/tests/src/helpers.c
@@ -660,15 +660,6 @@ int mbedtls_test_hexcmp(uint8_t *a, uint8_t *b,
     return ret;
 }
 
-void mbedtls_test_print_buf(const char *title, unsigned char *buf, size_t len)
-{
-    printf("%s:", title);
-    for (size_t i = 0; i < len; i++) {
-        printf(" %02x", buf[i]);
-    }
-    printf("\n");
-}
-
 #if defined(MBEDTLS_TEST_HOOKS)
 void mbedtls_test_err_add_check(int high, int low,
                                 const char *file, int line)

--- a/tests/src/helpers.c
+++ b/tests/src/helpers.c
@@ -660,6 +660,15 @@ int mbedtls_test_hexcmp(uint8_t *a, uint8_t *b,
     return ret;
 }
 
+void mbedtls_test_print_buf(const char *title, unsigned char *buf, size_t len)
+{
+    printf("%s:", title);
+    for (size_t i = 0; i < len; i++) {
+        printf(" %02x", buf[i]);
+    }
+    printf("\n");
+}
+
 #if defined(MBEDTLS_TEST_HOOKS)
 void mbedtls_test_err_add_check(int high, int low,
                                 const char *file, int line)

--- a/tests/src/psa_memory_poisoning_wrappers.c
+++ b/tests/src/psa_memory_poisoning_wrappers.c
@@ -4,7 +4,8 @@
  *  Copyright The Mbed TLS Contributors
  *  SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
  */
-#include "test/memory.h"
+#include <test/memory.h>
+#include <test/psa_memory_poisoning_wrappers.h>
 
 #include "psa_crypto_invasive.h"
 

--- a/tests/src/test_helpers/ssl_helpers.c
+++ b/tests/src/test_helpers/ssl_helpers.c
@@ -950,7 +950,7 @@ int mbedtls_test_move_handshake_to_state(mbedtls_ssl_context *ssl,
 /*
  * Write application data. Increase write counter if necessary.
  */
-int mbedtls_ssl_write_fragment(mbedtls_ssl_context *ssl,
+static int mbedtls_ssl_write_fragment(mbedtls_ssl_context *ssl,
                                unsigned char *buf, int buf_len,
                                int *written,
                                const int expected_fragments)
@@ -997,7 +997,7 @@ exit:
  * Read application data and increase read counter and fragments counter
  * if necessary.
  */
-int mbedtls_ssl_read_fragment(mbedtls_ssl_context *ssl,
+static int mbedtls_ssl_read_fragment(mbedtls_ssl_context *ssl,
                               unsigned char *buf, int buf_len,
                               int *read, int *fragments,
                               const int expected_fragments)

--- a/tests/src/test_helpers/ssl_helpers.c
+++ b/tests/src/test_helpers/ssl_helpers.c
@@ -951,9 +951,9 @@ int mbedtls_test_move_handshake_to_state(mbedtls_ssl_context *ssl,
  * Write application data. Increase write counter if necessary.
  */
 static int mbedtls_ssl_write_fragment(mbedtls_ssl_context *ssl,
-                               unsigned char *buf, int buf_len,
-                               int *written,
-                               const int expected_fragments)
+                                      unsigned char *buf, int buf_len,
+                                      int *written,
+                                      const int expected_fragments)
 {
     int ret;
     /* Verify that calling mbedtls_ssl_write with a NULL buffer and zero length is
@@ -998,9 +998,9 @@ exit:
  * if necessary.
  */
 static int mbedtls_ssl_read_fragment(mbedtls_ssl_context *ssl,
-                              unsigned char *buf, int buf_len,
-                              int *read, int *fragments,
-                              const int expected_fragments)
+                                     unsigned char *buf, int buf_len,
+                                     int *read, int *fragments,
+                                     const int expected_fragments)
 {
     int ret;
     /* Verify that calling mbedtls_ssl_write with a NULL buffer and zero length is

--- a/tests/suites/test_suite_debug.function
+++ b/tests/suites/test_suite_debug.function
@@ -9,7 +9,7 @@ struct buffer_data {
     char *ptr;
 };
 
-void string_debug(void *data, int level, const char *file, int line, const char *str)
+static void string_debug(void *data, int level, const char *file, int line, const char *str)
 {
     struct buffer_data *buffer = (struct buffer_data *) data;
     char *p = buffer->ptr;

--- a/tests/suites/test_suite_pkcs7.function
+++ b/tests/suites/test_suite_pkcs7.function
@@ -17,7 +17,7 @@
  * END_DEPENDENCIES
  */
 /* BEGIN_SUITE_HELPERS */
-int pkcs7_parse_buffer(unsigned char *pkcs7_buf, int buflen)
+static int pkcs7_parse_buffer(unsigned char *pkcs7_buf, int buflen)
 {
     int res;
     mbedtls_pkcs7 pkcs7;

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -1623,11 +1623,11 @@ void ssl_tls13_derive_secret(int hash_alg,
 
     unsigned char const *lbl = NULL;
     size_t lbl_len;
-#define MBEDTLS_SSL_TLS1_3_LABEL(name, string)                       \
-    if (label_idx == (int) tls13_label_ ## name)                      \
+#define MBEDTLS_SSL_TLS1_3_LABEL(name, string)                         \
+    if (label_idx == (int) tls13_label_ ## name)                       \
     {                                                                  \
         lbl = mbedtls_ssl_tls13_labels.name;                           \
-        lbl_len = sizeof(mbedtls_ssl_tls13_labels.name);             \
+        lbl_len = sizeof(mbedtls_ssl_tls13_labels.name);               \
     }
     MBEDTLS_SSL_TLS1_3_LABEL_LIST
 #undef MBEDTLS_SSL_TLS1_3_LABEL
@@ -1667,7 +1667,7 @@ void ssl_tls13_derive_early_secrets(int hash_alg,
     /* Double-check that we've passed sane parameters. */
     psa_algorithm_t alg = (psa_algorithm_t) hash_alg;
     size_t const hash_len = PSA_HASH_LENGTH(alg);
-    TEST_ASSERT(PSA_ALG_IS_HASH(alg)             &&
+    TEST_ASSERT(PSA_ALG_IS_HASH(alg)               &&
                 secret->len == hash_len            &&
                 transcript->len == hash_len        &&
                 traffic_expected->len == hash_len  &&
@@ -1701,7 +1701,7 @@ void ssl_tls13_derive_handshake_secrets(int hash_alg,
     /* Double-check that we've passed sane parameters. */
     psa_algorithm_t alg = (psa_algorithm_t) hash_alg;
     size_t const hash_len = PSA_HASH_LENGTH(alg);
-    TEST_ASSERT(PSA_ALG_IS_HASH(alg)            &&
+    TEST_ASSERT(PSA_ALG_IS_HASH(alg)              &&
                 secret->len == hash_len           &&
                 transcript->len == hash_len       &&
                 client_expected->len == hash_len  &&
@@ -1736,7 +1736,7 @@ void ssl_tls13_derive_application_secrets(int hash_alg,
     /* Double-check that we've passed sane parameters. */
     psa_algorithm_t alg = (psa_algorithm_t) hash_alg;
     size_t const hash_len = PSA_HASH_LENGTH(alg);
-    TEST_ASSERT(PSA_ALG_IS_HASH(alg)            &&
+    TEST_ASSERT(PSA_ALG_IS_HASH(alg)              &&
                 secret->len == hash_len           &&
                 transcript->len == hash_len       &&
                 client_expected->len == hash_len  &&
@@ -1772,7 +1772,7 @@ void ssl_tls13_derive_resumption_secrets(int hash_alg,
     /* Double-check that we've passed sane parameters. */
     psa_algorithm_t alg = (psa_algorithm_t) hash_alg;
     size_t const hash_len = PSA_HASH_LENGTH(alg);
-    TEST_ASSERT(PSA_ALG_IS_HASH(alg)              &&
+    TEST_ASSERT(PSA_ALG_IS_HASH(alg)                &&
                 secret->len == hash_len             &&
                 transcript->len == hash_len         &&
                 resumption_expected->len == hash_len);
@@ -1803,7 +1803,7 @@ void ssl_tls13_create_psk_binder(int hash_alg,
     /* Double-check that we've passed sane parameters. */
     psa_algorithm_t alg = (psa_algorithm_t) hash_alg;
     size_t const hash_len = PSA_HASH_LENGTH(alg);
-    TEST_ASSERT(PSA_ALG_IS_HASH(alg)          &&
+    TEST_ASSERT(PSA_ALG_IS_HASH(alg)            &&
                 transcript->len == hash_len     &&
                 binder_expected->len == hash_len);
 

--- a/tests/suites/test_suite_x509parse.function
+++ b/tests/suites/test_suite_x509parse.function
@@ -91,7 +91,7 @@ static int ca_callback_fail(void *data, mbedtls_x509_crt const *child, mbedtls_x
 }
 #if defined(MBEDTLS_X509_CRT_PARSE_C)
 static int ca_callback(void *data, mbedtls_x509_crt const *child,
-                mbedtls_x509_crt **candidates)
+                       mbedtls_x509_crt **candidates)
 {
     int ret = 0;
     mbedtls_x509_crt *ca = (mbedtls_x509_crt *) data;
@@ -227,7 +227,7 @@ static int verify_print(void *data, mbedtls_x509_crt *crt, int certificate_depth
 }
 
 static int verify_parse_san(mbedtls_x509_subject_alternative_name *san,
-                     char **buf, size_t *size)
+                            char **buf, size_t *size)
 {
     int ret;
     size_t i;
@@ -318,7 +318,7 @@ static int verify_parse_san(mbedtls_x509_subject_alternative_name *san,
 }
 
 static int parse_crt_ext_cb(void *p_ctx, mbedtls_x509_crt const *crt, mbedtls_x509_buf const *oid,
-                     int critical, const unsigned char *cp, const unsigned char *end)
+                            int critical, const unsigned char *cp, const unsigned char *end)
 {
     (void) crt;
     (void) critical;
@@ -418,7 +418,7 @@ static int parse_crt_ext_cb(void *p_ctx, mbedtls_x509_crt const *crt, mbedtls_x5
 
 #if defined(MBEDTLS_X509_CSR_PARSE_C)
 static int parse_csr_ext_accept_cb(void *p_ctx, mbedtls_x509_csr const *csr, mbedtls_x509_buf const *oid,
-                            int critical, const unsigned char *cp, const unsigned char *end)
+                                   int critical, const unsigned char *cp, const unsigned char *end)
 {
     (void) p_ctx;
     (void) csr;
@@ -431,7 +431,7 @@ static int parse_csr_ext_accept_cb(void *p_ctx, mbedtls_x509_csr const *csr, mbe
 }
 
 static int parse_csr_ext_reject_cb(void *p_ctx, mbedtls_x509_csr const *csr, mbedtls_x509_buf const *oid,
-                            int critical, const unsigned char *cp, const unsigned char *end)
+                                   int critical, const unsigned char *cp, const unsigned char *end)
 {
     (void) p_ctx;
     (void) csr;

--- a/tests/suites/test_suite_x509parse.function
+++ b/tests/suites/test_suite_x509parse.function
@@ -85,7 +85,8 @@ static int verify_all(void *data, mbedtls_x509_crt *crt, int certificate_depth, 
 
 #if defined(MBEDTLS_X509_CRL_PARSE_C) && \
     defined(MBEDTLS_X509_TRUSTED_CERTIFICATE_CALLBACK)
-static int ca_callback_fail(void *data, mbedtls_x509_crt const *child, mbedtls_x509_crt **candidates)
+static int ca_callback_fail(void *data, mbedtls_x509_crt const *child,
+                            mbedtls_x509_crt **candidates)
 {
     ((void) data);
     ((void) child);
@@ -421,8 +422,12 @@ static int parse_crt_ext_cb(void *p_ctx, mbedtls_x509_crt const *crt, mbedtls_x5
 
 #if defined(MBEDTLS_X509_CSR_PARSE_C) && \
     !defined(MBEDTLS_X509_REMOVE_INFO)
-static int parse_csr_ext_accept_cb(void *p_ctx, mbedtls_x509_csr const *csr, mbedtls_x509_buf const *oid,
-                                   int critical, const unsigned char *cp, const unsigned char *end)
+static int parse_csr_ext_accept_cb(void *p_ctx,
+                                   mbedtls_x509_csr const *csr,
+                                   mbedtls_x509_buf const *oid,
+                                   int critical,
+                                   const unsigned char *cp,
+                                   const unsigned char *end)
 {
     (void) p_ctx;
     (void) csr;
@@ -434,8 +439,12 @@ static int parse_csr_ext_accept_cb(void *p_ctx, mbedtls_x509_csr const *csr, mbe
     return 0;
 }
 
-static int parse_csr_ext_reject_cb(void *p_ctx, mbedtls_x509_csr const *csr, mbedtls_x509_buf const *oid,
-                                   int critical, const unsigned char *cp, const unsigned char *end)
+static int parse_csr_ext_reject_cb(void *p_ctx,
+                                   mbedtls_x509_csr const *csr,
+                                   mbedtls_x509_buf const *oid,
+                                   int critical,
+                                   const unsigned char *cp,
+                                   const unsigned char *end)
 {
     (void) p_ctx;
     (void) csr;

--- a/tests/suites/test_suite_x509parse.function
+++ b/tests/suites/test_suite_x509parse.function
@@ -60,6 +60,9 @@ const mbedtls_x509_crt_profile profile_sha512 =
     1024,
 };
 
+#if defined(MBEDTLS_X509_CRT_PARSE_C)
+
+#if defined(MBEDTLS_FS_IO)
 static int verify_none(void *data, mbedtls_x509_crt *crt, int certificate_depth, uint32_t *flags)
 {
     ((void) data);
@@ -80,7 +83,8 @@ static int verify_all(void *data, mbedtls_x509_crt *crt, int certificate_depth, 
     return 0;
 }
 
-#if defined(MBEDTLS_X509_TRUSTED_CERTIFICATE_CALLBACK)
+#if defined(MBEDTLS_X509_CRL_PARSE_C) && \
+    defined(MBEDTLS_X509_TRUSTED_CERTIFICATE_CALLBACK)
 static int ca_callback_fail(void *data, mbedtls_x509_crt const *child, mbedtls_x509_crt **candidates)
 {
     ((void) data);
@@ -89,7 +93,7 @@ static int ca_callback_fail(void *data, mbedtls_x509_crt const *child, mbedtls_x
 
     return -1;
 }
-#if defined(MBEDTLS_X509_CRT_PARSE_C)
+
 static int ca_callback(void *data, mbedtls_x509_crt const *child,
                        mbedtls_x509_crt **candidates)
 {
@@ -138,8 +142,7 @@ exit:
     *candidates = first;
     return ret;
 }
-#endif /* MBEDTLS_X509_CRT_PARSE_C */
-#endif /* MBEDTLS_X509_TRUSTED_CERTIFICATE_CALLBACK */
+#endif /* MBEDTLS_X509_CRL_PARSE_C && MBEDTLS_X509_TRUSTED_CERTIFICATE_CALLBACK */
 
 static int verify_fatal(void *data, mbedtls_x509_crt *crt, int certificate_depth, uint32_t *flags)
 {
@@ -186,7 +189,6 @@ done:
     return ret;
 }
 
-#if defined(MBEDTLS_X509_CRT_PARSE_C)
 typedef struct {
     char buf[512];
     char *p;
@@ -316,6 +318,7 @@ static int verify_parse_san(mbedtls_x509_subject_alternative_name *san,
 
     return 0;
 }
+#endif /* MBEDTLS_FS_IO */
 
 static int parse_crt_ext_cb(void *p_ctx, mbedtls_x509_crt const *crt, mbedtls_x509_buf const *oid,
                             int critical, const unsigned char *cp, const unsigned char *end)
@@ -416,7 +419,8 @@ static int parse_crt_ext_cb(void *p_ctx, mbedtls_x509_crt const *crt, mbedtls_x5
 }
 #endif /* MBEDTLS_X509_CRT_PARSE_C */
 
-#if defined(MBEDTLS_X509_CSR_PARSE_C)
+#if defined(MBEDTLS_X509_CSR_PARSE_C) && \
+    !defined(MBEDTLS_X509_REMOVE_INFO)
 static int parse_csr_ext_accept_cb(void *p_ctx, mbedtls_x509_csr const *csr, mbedtls_x509_buf const *oid,
                                    int critical, const unsigned char *cp, const unsigned char *end)
 {
@@ -443,7 +447,7 @@ static int parse_csr_ext_reject_cb(void *p_ctx, mbedtls_x509_csr const *csr, mbe
     return MBEDTLS_ERROR_ADD(MBEDTLS_ERR_X509_INVALID_EXTENSIONS,
                              MBEDTLS_ERR_ASN1_UNEXPECTED_TAG);
 }
-#endif /* MBEDTLS_X509_CSR_PARSE_C */
+#endif /* MBEDTLS_X509_CSR_PARSE_C && !MBEDTLS_X509_REMOVE_INFO */
 /* END_HEADER */
 
 /* BEGIN_CASE depends_on:MBEDTLS_X509_CRT_PARSE_C */

--- a/tests/suites/test_suite_x509parse.function
+++ b/tests/suites/test_suite_x509parse.function
@@ -60,7 +60,7 @@ const mbedtls_x509_crt_profile profile_sha512 =
     1024,
 };
 
-int verify_none(void *data, mbedtls_x509_crt *crt, int certificate_depth, uint32_t *flags)
+static int verify_none(void *data, mbedtls_x509_crt *crt, int certificate_depth, uint32_t *flags)
 {
     ((void) data);
     ((void) crt);
@@ -70,7 +70,7 @@ int verify_none(void *data, mbedtls_x509_crt *crt, int certificate_depth, uint32
     return 0;
 }
 
-int verify_all(void *data, mbedtls_x509_crt *crt, int certificate_depth, uint32_t *flags)
+static int verify_all(void *data, mbedtls_x509_crt *crt, int certificate_depth, uint32_t *flags)
 {
     ((void) data);
     ((void) crt);
@@ -81,7 +81,7 @@ int verify_all(void *data, mbedtls_x509_crt *crt, int certificate_depth, uint32_
 }
 
 #if defined(MBEDTLS_X509_TRUSTED_CERTIFICATE_CALLBACK)
-int ca_callback_fail(void *data, mbedtls_x509_crt const *child, mbedtls_x509_crt **candidates)
+static int ca_callback_fail(void *data, mbedtls_x509_crt const *child, mbedtls_x509_crt **candidates)
 {
     ((void) data);
     ((void) child);
@@ -90,7 +90,7 @@ int ca_callback_fail(void *data, mbedtls_x509_crt const *child, mbedtls_x509_crt
     return -1;
 }
 #if defined(MBEDTLS_X509_CRT_PARSE_C)
-int ca_callback(void *data, mbedtls_x509_crt const *child,
+static int ca_callback(void *data, mbedtls_x509_crt const *child,
                 mbedtls_x509_crt **candidates)
 {
     int ret = 0;
@@ -141,7 +141,7 @@ exit:
 #endif /* MBEDTLS_X509_CRT_PARSE_C */
 #endif /* MBEDTLS_X509_TRUSTED_CERTIFICATE_CALLBACK */
 
-int verify_fatal(void *data, mbedtls_x509_crt *crt, int certificate_depth, uint32_t *flags)
+static int verify_fatal(void *data, mbedtls_x509_crt *crt, int certificate_depth, uint32_t *flags)
 {
     int *levels = (int *) data;
 
@@ -158,7 +158,7 @@ int verify_fatal(void *data, mbedtls_x509_crt *crt, int certificate_depth, uint3
 }
 
 /* strsep() not available on Windows */
-char *mystrsep(char **stringp, const char *delim)
+static char *mystrsep(char **stringp, const char *delim)
 {
     const char *p;
     char *ret = *stringp;
@@ -192,13 +192,13 @@ typedef struct {
     char *p;
 } verify_print_context;
 
-void verify_print_init(verify_print_context *ctx)
+static void verify_print_init(verify_print_context *ctx)
 {
     memset(ctx, 0, sizeof(verify_print_context));
     ctx->p = ctx->buf;
 }
 
-int verify_print(void *data, mbedtls_x509_crt *crt, int certificate_depth, uint32_t *flags)
+static int verify_print(void *data, mbedtls_x509_crt *crt, int certificate_depth, uint32_t *flags)
 {
     int ret;
     verify_print_context *ctx = (verify_print_context *) data;
@@ -226,7 +226,7 @@ int verify_print(void *data, mbedtls_x509_crt *crt, int certificate_depth, uint3
     return 0;
 }
 
-int verify_parse_san(mbedtls_x509_subject_alternative_name *san,
+static int verify_parse_san(mbedtls_x509_subject_alternative_name *san,
                      char **buf, size_t *size)
 {
     int ret;
@@ -317,7 +317,7 @@ int verify_parse_san(mbedtls_x509_subject_alternative_name *san,
     return 0;
 }
 
-int parse_crt_ext_cb(void *p_ctx, mbedtls_x509_crt const *crt, mbedtls_x509_buf const *oid,
+static int parse_crt_ext_cb(void *p_ctx, mbedtls_x509_crt const *crt, mbedtls_x509_buf const *oid,
                      int critical, const unsigned char *cp, const unsigned char *end)
 {
     (void) crt;
@@ -417,7 +417,7 @@ int parse_crt_ext_cb(void *p_ctx, mbedtls_x509_crt const *crt, mbedtls_x509_buf 
 #endif /* MBEDTLS_X509_CRT_PARSE_C */
 
 #if defined(MBEDTLS_X509_CSR_PARSE_C)
-int parse_csr_ext_accept_cb(void *p_ctx, mbedtls_x509_csr const *csr, mbedtls_x509_buf const *oid,
+static int parse_csr_ext_accept_cb(void *p_ctx, mbedtls_x509_csr const *csr, mbedtls_x509_buf const *oid,
                             int critical, const unsigned char *cp, const unsigned char *end)
 {
     (void) p_ctx;
@@ -430,7 +430,7 @@ int parse_csr_ext_accept_cb(void *p_ctx, mbedtls_x509_csr const *csr, mbedtls_x5
     return 0;
 }
 
-int parse_csr_ext_reject_cb(void *p_ctx, mbedtls_x509_csr const *csr, mbedtls_x509_buf const *oid,
+static int parse_csr_ext_reject_cb(void *p_ctx, mbedtls_x509_csr const *csr, mbedtls_x509_buf const *oid,
                             int critical, const unsigned char *cp, const unsigned char *end)
 {
     (void) p_ctx;

--- a/tests/suites/test_suite_x509write.function
+++ b/tests/suites/test_suite_x509write.function
@@ -11,14 +11,14 @@
 #include "mbedtls/psa_util.h"
 
 #if defined(MBEDTLS_RSA_C)
-int mbedtls_rsa_decrypt_func(void *ctx, size_t *olen,
+static int mbedtls_rsa_decrypt_func(void *ctx, size_t *olen,
                              const unsigned char *input, unsigned char *output,
                              size_t output_max_len)
 {
     return mbedtls_rsa_pkcs1_decrypt((mbedtls_rsa_context *) ctx, NULL, NULL,
                                      olen, input, output, output_max_len);
 }
-int mbedtls_rsa_sign_func(void *ctx,
+static int mbedtls_rsa_sign_func(void *ctx,
                           int (*f_rng)(void *, unsigned char *, size_t), void *p_rng,
                           mbedtls_md_type_t md_alg, unsigned int hashlen,
                           const unsigned char *hash, unsigned char *sig)
@@ -26,7 +26,7 @@ int mbedtls_rsa_sign_func(void *ctx,
     return mbedtls_rsa_pkcs1_sign((mbedtls_rsa_context *) ctx, f_rng, p_rng,
                                   md_alg, hashlen, hash, sig);
 }
-size_t mbedtls_rsa_key_len_func(void *ctx)
+static size_t mbedtls_rsa_key_len_func(void *ctx)
 {
     return ((const mbedtls_rsa_context *) ctx)->len;
 }

--- a/tests/suites/test_suite_x509write.function
+++ b/tests/suites/test_suite_x509write.function
@@ -12,16 +12,16 @@
 
 #if defined(MBEDTLS_RSA_C)
 static int mbedtls_rsa_decrypt_func(void *ctx, size_t *olen,
-                             const unsigned char *input, unsigned char *output,
-                             size_t output_max_len)
+                                    const unsigned char *input, unsigned char *output,
+                                    size_t output_max_len)
 {
     return mbedtls_rsa_pkcs1_decrypt((mbedtls_rsa_context *) ctx, NULL, NULL,
                                      olen, input, output, output_max_len);
 }
 static int mbedtls_rsa_sign_func(void *ctx,
-                          int (*f_rng)(void *, unsigned char *, size_t), void *p_rng,
-                          mbedtls_md_type_t md_alg, unsigned int hashlen,
-                          const unsigned char *hash, unsigned char *sig)
+                                 int (*f_rng)(void *, unsigned char *, size_t), void *p_rng,
+                                 mbedtls_md_type_t md_alg, unsigned int hashlen,
+                                 const unsigned char *hash, unsigned char *sig)
 {
     return mbedtls_rsa_pkcs1_sign((mbedtls_rsa_context *) ctx, f_rng, p_rng,
                                   md_alg, hashlen, hash, sig);

--- a/tests/suites/test_suite_x509write.function
+++ b/tests/suites/test_suite_x509write.function
@@ -10,7 +10,11 @@
 #include "mbedtls/pk.h"
 #include "mbedtls/psa_util.h"
 
-#if defined(MBEDTLS_RSA_C)
+#if defined(MBEDTLS_PEM_WRITE_C) && \
+    defined(MBEDTLS_X509_CRT_WRITE_C) && \
+    defined(MBEDTLS_X509_CRT_PARSE_C) && \
+    defined(MBEDTLS_MD_CAN_SHA1) && \
+    defined(MBEDTLS_RSA_C) && defined(MBEDTLS_PK_RSA_ALT_SUPPORT)
 static int mbedtls_rsa_decrypt_func(void *ctx, size_t *olen,
                                     const unsigned char *input, unsigned char *output,
                                     size_t output_max_len)
@@ -30,7 +34,7 @@ static size_t mbedtls_rsa_key_len_func(void *ctx)
 {
     return ((const mbedtls_rsa_context *) ctx)->len;
 }
-#endif /* MBEDTLS_RSA_C */
+#endif
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO) && \
     defined(MBEDTLS_PEM_WRITE_C) && defined(MBEDTLS_X509_CSR_WRITE_C)

--- a/tf-psa-crypto/tests/suites/helpers.function
+++ b/tf-psa-crypto/tests/suites/helpers.function
@@ -55,8 +55,8 @@
 /* Indicates whether we expect mbedtls_entropy_init
  * to initialize some strong entropy source. */
 #if !defined(MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES) && \
-    (!defined(MBEDTLS_NO_PLATFORM_ENTROPY) ||      \
-    defined(MBEDTLS_ENTROPY_HARDWARE_ALT) ||    \
+    (!defined(MBEDTLS_NO_PLATFORM_ENTROPY) ||       \
+    defined(MBEDTLS_ENTROPY_HARDWARE_ALT) ||        \
     defined(ENTROPY_NV_SEED))
 #define ENTROPY_HAVE_STRONG
 #endif

--- a/tf-psa-crypto/tests/suites/host_test.function
+++ b/tf-psa-crypto/tests/suites/host_test.function
@@ -8,7 +8,7 @@
  *
  * \return      0 if success else 1
  */
-int verify_string(char **str)
+static int verify_string(char **str)
 {
     if ((*str)[0] != '"' ||
         (*str)[strlen(*str) - 1] != '"') {
@@ -32,7 +32,7 @@ int verify_string(char **str)
  *
  * \return      0 if success else 1
  */
-int verify_int(char *str, intmax_t *p_value)
+static int verify_int(char *str, intmax_t *p_value)
 {
     char *end = NULL;
     errno = 0;
@@ -80,7 +80,7 @@ int verify_int(char *str, intmax_t *p_value)
  *
  * \return      0 if success else -1
  */
-int get_line(FILE *f, char *buf, size_t len)
+static int get_line(FILE *f, char *buf, size_t len)
 {
     char *ret;
     int i = 0, str_len = 0, has_string = 0;
@@ -485,7 +485,7 @@ static void try_chdir_if_supported(const char *argv0)
  *
  * \return      Program exit status.
  */
-int execute_tests(int argc, const char **argv)
+static int execute_tests(int argc, const char **argv)
 {
     /* Local Configurations and options */
     const char *default_filename = "DATA_FILE";

--- a/tf-psa-crypto/tests/suites/main_test.function
+++ b/tf-psa-crypto/tests/suites/main_test.function
@@ -69,7 +69,7 @@ __MBEDTLS_TEST_TEMPLATE__FUNCTIONS_CODE
  *
  * \return       0 if exp_id is found. 1 otherwise.
  */
-int get_expression(int32_t exp_id, intmax_t *out_value)
+static int get_expression(int32_t exp_id, intmax_t *out_value)
 {
     int ret = KEY_VALUE_MAPPING_FOUND;
 
@@ -100,7 +100,7 @@ int get_expression(int32_t exp_id, intmax_t *out_value)
  *
  * \return       DEPENDENCY_SUPPORTED if set else DEPENDENCY_NOT_SUPPORTED
  */
-int dep_check(int dep_id)
+static int dep_check(int dep_id)
 {
     int ret = DEPENDENCY_NOT_SUPPORTED;
 
@@ -155,7 +155,7 @@ TestWrapper_t test_funcs[] =
  *               DISPATCH_TEST_FN_NOT_FOUND if not found
  *               DISPATCH_UNSUPPORTED_SUITE if not compile time enabled.
  */
-int dispatch_test(size_t func_idx, void **params)
+static int dispatch_test(size_t func_idx, void **params)
 {
     int ret = DISPATCH_TEST_SUCCESS;
     TestWrapper_t fp = NULL;
@@ -193,7 +193,7 @@ int dispatch_test(size_t func_idx, void **params)
  *               DISPATCH_TEST_FN_NOT_FOUND if not found
  *               DISPATCH_UNSUPPORTED_SUITE if not compile time enabled.
  */
-int check_test(size_t func_idx)
+static int check_test(size_t func_idx)
 {
     int ret = DISPATCH_TEST_SUCCESS;
     TestWrapper_t fp = NULL;

--- a/tf-psa-crypto/tests/suites/test_suite_alignment.function
+++ b/tf-psa-crypto/tests/suites/test_suite_alignment.function
@@ -10,7 +10,7 @@
 /*
  * Convert a string of the form "abcd" (case-insensitive) to a uint64_t.
  */
-int parse_hex_string(char *hex_string, uint64_t *result)
+static int parse_hex_string(char *hex_string, uint64_t *result)
 {
     uint8_t raw[8] = { 0 };
     size_t olen;

--- a/tf-psa-crypto/tests/suites/test_suite_asn1parse.function
+++ b/tf-psa-crypto/tests/suites/test_suite_asn1parse.function
@@ -122,7 +122,7 @@ exit:
     return ERR_PARSE_INCONSISTENCY;
 }
 
-int get_len_step(const data_t *input, size_t buffer_size,
+static int get_len_step(const data_t *input, size_t buffer_size,
                  size_t actual_length)
 {
     unsigned char *buf = NULL;

--- a/tf-psa-crypto/tests/suites/test_suite_asn1parse.function
+++ b/tf-psa-crypto/tests/suites/test_suite_asn1parse.function
@@ -123,7 +123,7 @@ exit:
 }
 
 static int get_len_step(const data_t *input, size_t buffer_size,
-                 size_t actual_length)
+                        size_t actual_length)
 {
     unsigned char *buf = NULL;
     unsigned char *p = NULL;

--- a/tf-psa-crypto/tests/suites/test_suite_asn1write.function
+++ b/tf-psa-crypto/tests/suites/test_suite_asn1write.function
@@ -27,7 +27,7 @@ exit:
 }
 
 static int generic_write_finish_step(generic_write_data_t *data,
-                              const data_t *expected, int ret)
+                                     const data_t *expected, int ret)
 {
     int ok = 0;
 

--- a/tf-psa-crypto/tests/suites/test_suite_asn1write.function
+++ b/tf-psa-crypto/tests/suites/test_suite_asn1write.function
@@ -12,7 +12,7 @@ typedef struct {
     size_t size;
 } generic_write_data_t;
 
-int generic_write_start_step(generic_write_data_t *data)
+static int generic_write_start_step(generic_write_data_t *data)
 {
     mbedtls_test_set_step(data->size);
     mbedtls_free(data->output);
@@ -26,7 +26,7 @@ exit:
     return 0;
 }
 
-int generic_write_finish_step(generic_write_data_t *data,
+static int generic_write_finish_step(generic_write_data_t *data,
                               const data_t *expected, int ret)
 {
     int ok = 0;

--- a/tf-psa-crypto/tests/suites/test_suite_bignum.function
+++ b/tf-psa-crypto/tests/suites/test_suite_bignum.function
@@ -32,6 +32,7 @@ static int sign_is_valid(const mbedtls_mpi *X)
     return 1;
 }
 
+#if defined(MBEDTLS_GENPRIME)
 typedef struct mbedtls_test_mpi_random {
     data_t *data;
     size_t  pos;
@@ -73,6 +74,7 @@ static int mbedtls_test_mpi_miller_rabin_determinizer(void *state,
 
     return 0;
 }
+#endif /* MBEDTLS_GENPRIME */
 
 /* Random generator that is told how many bytes to return. */
 static int f_rng_bytes_left(void *state, unsigned char *buf, size_t len)

--- a/tf-psa-crypto/tests/suites/test_suite_bignum.function
+++ b/tf-psa-crypto/tests/suites/test_suite_bignum.function
@@ -44,7 +44,7 @@ typedef struct mbedtls_test_mpi_random {
  * test) are stored in the data member of the state structure. Each number is in
  * the format that mbedtls_mpi_read_string understands and is chunk_len long.
  */
-int mbedtls_test_mpi_miller_rabin_determinizer(void *state,
+static int mbedtls_test_mpi_miller_rabin_determinizer(void *state,
                                                unsigned char *buf,
                                                size_t len)
 {

--- a/tf-psa-crypto/tests/suites/test_suite_bignum.function
+++ b/tf-psa-crypto/tests/suites/test_suite_bignum.function
@@ -45,8 +45,8 @@ typedef struct mbedtls_test_mpi_random {
  * the format that mbedtls_mpi_read_string understands and is chunk_len long.
  */
 static int mbedtls_test_mpi_miller_rabin_determinizer(void *state,
-                                               unsigned char *buf,
-                                               size_t len)
+                                                      unsigned char *buf,
+                                                      size_t len)
 {
     mbedtls_test_mpi_random *random = (mbedtls_test_mpi_random *) state;
 

--- a/tf-psa-crypto/tests/suites/test_suite_cipher.function
+++ b/tf-psa-crypto/tests/suites/test_suite_cipher.function
@@ -129,7 +129,7 @@ exit:
  * return   1 if it is,
  *          0 if it isn't.
  */
-int buffer_is_all_zero(const uint8_t *buf, size_t size)
+static int buffer_is_all_zero(const uint8_t *buf, size_t size)
 {
     for (size_t i = 0; i < size; i++) {
         if (buf[i] != 0) {

--- a/tf-psa-crypto/tests/suites/test_suite_common.function
+++ b/tf-psa-crypto/tests/suites/test_suite_common.function
@@ -1,7 +1,11 @@
 /* BEGIN_HEADER */
 #include "common.h"
 
-static void fill_arrays(unsigned char *a, unsigned char *b, unsigned char *r1, unsigned char *r2, size_t n)
+static void fill_arrays(unsigned char *a,
+                        unsigned char *b,
+                        unsigned char *r1,
+                        unsigned char *r2,
+                        size_t n)
 {
     for (size_t i = 0; i < n; i++) {
         a[i]  = (unsigned char) i * 3;

--- a/tf-psa-crypto/tests/suites/test_suite_common.function
+++ b/tf-psa-crypto/tests/suites/test_suite_common.function
@@ -1,7 +1,7 @@
 /* BEGIN_HEADER */
 #include "common.h"
 
-void fill_arrays(unsigned char *a, unsigned char *b, unsigned char *r1, unsigned char *r2, size_t n)
+static void fill_arrays(unsigned char *a, unsigned char *b, unsigned char *r1, unsigned char *r2, size_t n)
 {
     for (size_t i = 0; i < n; i++) {
         a[i]  = (unsigned char) i * 3;

--- a/tf-psa-crypto/tests/suites/test_suite_ctr_drbg.function
+++ b/tf-psa-crypto/tests/suites/test_suite_ctr_drbg.function
@@ -96,6 +96,7 @@ exit:
 }
 
 static const int thread_random_reps = 10;
+void *thread_random_function(void *ctx); /* only used conditionally in ctr_drbg_threads */
 void *thread_random_function(void *ctx)
 {
     unsigned char out[16];

--- a/tf-psa-crypto/tests/suites/test_suite_dhm.function
+++ b/tf-psa-crypto/tests/suites/test_suite_dhm.function
@@ -2,8 +2,8 @@
 #include "mbedtls/dhm.h"
 
 static int check_get_value(const mbedtls_dhm_context *ctx,
-                    mbedtls_dhm_parameter param,
-                    const mbedtls_mpi *expected)
+                           mbedtls_dhm_parameter param,
+                           const mbedtls_mpi *expected)
 {
     mbedtls_mpi actual;
     int ok = 0;

--- a/tf-psa-crypto/tests/suites/test_suite_dhm.function
+++ b/tf-psa-crypto/tests/suites/test_suite_dhm.function
@@ -1,7 +1,7 @@
 /* BEGIN_HEADER */
 #include "mbedtls/dhm.h"
 
-int check_get_value(const mbedtls_dhm_context *ctx,
+static int check_get_value(const mbedtls_dhm_context *ctx,
                     mbedtls_dhm_parameter param,
                     const mbedtls_mpi *expected)
 {

--- a/tf-psa-crypto/tests/suites/test_suite_entropy.function
+++ b/tf-psa-crypto/tests/suites/test_suite_entropy.function
@@ -60,6 +60,8 @@ static void entropy_clear_sources(mbedtls_entropy_context *ctx)
 }
 
 #if defined(MBEDTLS_ENTROPY_NV_SEED)
+
+#if defined(MBEDTLS_MD_LIGHT) && defined(MBEDTLS_PLATFORM_NV_SEED_ALT)
 /*
  * NV seed read/write functions that use a buffer instead of a file
  */
@@ -84,7 +86,9 @@ static int buffer_nv_seed_write(unsigned char *buf, size_t buf_len)
     memcpy(buffer_seed, buf, MBEDTLS_ENTROPY_BLOCK_SIZE);
     return 0;
 }
+#endif /* MBEDTLS_MD_LIGHT && MBEDTLS_PLATFORM_NV_SEED_ALT */
 
+#if defined(MBEDTLS_FS_IO)
 /*
  * NV seed read/write helpers that fill the base seedfile
  */
@@ -111,6 +115,7 @@ static int write_nv_seed(unsigned char *buf, size_t buf_len)
     return 0;
 }
 
+#if defined(MBEDTLS_PLATFORM_NV_SEED_ALT)
 static int read_nv_seed(unsigned char *buf, size_t buf_len)
 {
     FILE *f;
@@ -133,6 +138,8 @@ static int read_nv_seed(unsigned char *buf, size_t buf_len)
 
     return 0;
 }
+#endif /* MBEDTLS_PLATFORM_NV_SEED_ALT */
+#endif /* MBEDTLS_FS_IO */
 #endif /* MBEDTLS_ENTROPY_NV_SEED */
 /* END_HEADER */
 

--- a/tf-psa-crypto/tests/suites/test_suite_entropy.function
+++ b/tf-psa-crypto/tests/suites/test_suite_entropy.function
@@ -65,7 +65,7 @@ static void entropy_clear_sources(mbedtls_entropy_context *ctx)
  */
 static unsigned char buffer_seed[MBEDTLS_ENTROPY_BLOCK_SIZE];
 
-int buffer_nv_seed_read(unsigned char *buf, size_t buf_len)
+static int buffer_nv_seed_read(unsigned char *buf, size_t buf_len)
 {
     if (buf_len != MBEDTLS_ENTROPY_BLOCK_SIZE) {
         return -1;
@@ -75,7 +75,7 @@ int buffer_nv_seed_read(unsigned char *buf, size_t buf_len)
     return 0;
 }
 
-int buffer_nv_seed_write(unsigned char *buf, size_t buf_len)
+static int buffer_nv_seed_write(unsigned char *buf, size_t buf_len)
 {
     if (buf_len != MBEDTLS_ENTROPY_BLOCK_SIZE) {
         return -1;
@@ -111,7 +111,7 @@ static int write_nv_seed(unsigned char *buf, size_t buf_len)
     return 0;
 }
 
-int read_nv_seed(unsigned char *buf, size_t buf_len)
+static int read_nv_seed(unsigned char *buf, size_t buf_len)
 {
     FILE *f;
 

--- a/tf-psa-crypto/tests/suites/test_suite_lmots.function
+++ b/tf-psa-crypto/tests/suites/test_suite_lmots.function
@@ -3,7 +3,7 @@
 #include "mbedtls/lms.h"
 
 #if defined(MBEDTLS_TEST_HOOKS)
-int check_lmots_private_key_for_leak(unsigned char *sig)
+static int check_lmots_private_key_for_leak(unsigned char *sig)
 {
     size_t idx;
 

--- a/tf-psa-crypto/tests/suites/test_suite_lmots.function
+++ b/tf-psa-crypto/tests/suites/test_suite_lmots.function
@@ -2,7 +2,7 @@
 #include "lmots.h"
 #include "mbedtls/lms.h"
 
-#if defined(MBEDTLS_TEST_HOOKS)
+#if defined(MBEDTLS_TEST_HOOKS) && defined(MBEDTLS_LMS_PRIVATE)
 static int check_lmots_private_key_for_leak(unsigned char *sig)
 {
     size_t idx;
@@ -18,7 +18,7 @@ static int check_lmots_private_key_for_leak(unsigned char *sig)
 exit:
     return -1;
 }
-#endif /* defined(MBEDTLS_TEST_HOOKS) */
+#endif /* MBEDTLS_TEST_HOOKS && MBEDTLS_LMS_PRIVATE */
 
 /* END_HEADER */
 

--- a/tf-psa-crypto/tests/suites/test_suite_pk.function
+++ b/tf-psa-crypto/tests/suites/test_suite_pk.function
@@ -221,7 +221,7 @@ exit:
 }
 
 #if defined(MBEDTLS_PSA_CRYPTO_CLIENT)
-psa_status_t pk_psa_import_key(const unsigned char *key_data, size_t key_len,
+static psa_status_t pk_psa_import_key(const unsigned char *key_data, size_t key_len,
                                psa_key_type_t type, psa_key_usage_t usage,
                                psa_algorithm_t alg, mbedtls_svc_key_id_t *key)
 {
@@ -320,7 +320,7 @@ exit:
  *                              for volatile keys.
  * \param[out] key              Identifier of the "generated" (actually imported) PSA key.
  */
-psa_status_t pk_psa_setup(psa_key_type_t type, size_t bits,
+static psa_status_t pk_psa_setup(psa_key_type_t type, size_t bits,
                           psa_key_usage_t usage, psa_algorithm_t alg,
                           psa_algorithm_t enrollment_alg,
                           mbedtls_svc_key_id_t persistent_key_id,
@@ -468,7 +468,7 @@ exit:
 #endif /* MBEDTLS_PSA_CRYPTO_CLIENT */
 
 #if defined(MBEDTLS_RSA_C)
-int mbedtls_rsa_decrypt_func(void *ctx, size_t *olen,
+static int mbedtls_rsa_decrypt_func(void *ctx, size_t *olen,
                              const unsigned char *input, unsigned char *output,
                              size_t output_max_len)
 {
@@ -476,7 +476,7 @@ int mbedtls_rsa_decrypt_func(void *ctx, size_t *olen,
                                      mbedtls_test_rnd_std_rand, NULL,
                                      olen, input, output, output_max_len);
 }
-int mbedtls_rsa_sign_func(void *ctx,
+static int mbedtls_rsa_sign_func(void *ctx,
                           int (*f_rng)(void *, unsigned char *, size_t), void *p_rng,
                           mbedtls_md_type_t md_alg, unsigned int hashlen,
                           const unsigned char *hash, unsigned char *sig)
@@ -487,7 +487,7 @@ int mbedtls_rsa_sign_func(void *ctx,
                                   mbedtls_test_rnd_std_rand, NULL,
                                   md_alg, hashlen, hash, sig);
 }
-size_t mbedtls_rsa_key_len_func(void *ctx)
+static size_t mbedtls_rsa_key_len_func(void *ctx)
 {
     return ((const mbedtls_rsa_context *) ctx)->len;
 }
@@ -618,7 +618,7 @@ exit:
 
 /* Create a copy of a PSA key with same usage and algorithm policy and destroy
  * the original one. */
-mbedtls_svc_key_id_t psa_copy_and_destroy(mbedtls_svc_key_id_t orig_key_id)
+static mbedtls_svc_key_id_t psa_copy_and_destroy(mbedtls_svc_key_id_t orig_key_id)
 {
     psa_key_attributes_t orig_attr = PSA_KEY_ATTRIBUTES_INIT;
     psa_key_attributes_t new_attr = PSA_KEY_ATTRIBUTES_INIT;

--- a/tf-psa-crypto/tests/suites/test_suite_pk.function
+++ b/tf-psa-crypto/tests/suites/test_suite_pk.function
@@ -222,8 +222,8 @@ exit:
 
 #if defined(MBEDTLS_PSA_CRYPTO_CLIENT)
 static psa_status_t pk_psa_import_key(const unsigned char *key_data, size_t key_len,
-                               psa_key_type_t type, psa_key_usage_t usage,
-                               psa_algorithm_t alg, mbedtls_svc_key_id_t *key)
+                                      psa_key_type_t type, psa_key_usage_t usage,
+                                      psa_algorithm_t alg, mbedtls_svc_key_id_t *key)
 {
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     psa_status_t status;
@@ -321,10 +321,10 @@ exit:
  * \param[out] key              Identifier of the "generated" (actually imported) PSA key.
  */
 static psa_status_t pk_psa_setup(psa_key_type_t type, size_t bits,
-                          psa_key_usage_t usage, psa_algorithm_t alg,
-                          psa_algorithm_t enrollment_alg,
-                          mbedtls_svc_key_id_t persistent_key_id,
-                          mbedtls_svc_key_id_t *key)
+                                 psa_key_usage_t usage, psa_algorithm_t alg,
+                                 psa_algorithm_t enrollment_alg,
+                                 mbedtls_svc_key_id_t persistent_key_id,
+                                 mbedtls_svc_key_id_t *key)
 {
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     psa_status_t status = PSA_ERROR_GENERIC_ERROR;
@@ -469,17 +469,17 @@ exit:
 
 #if defined(MBEDTLS_RSA_C)
 static int mbedtls_rsa_decrypt_func(void *ctx, size_t *olen,
-                             const unsigned char *input, unsigned char *output,
-                             size_t output_max_len)
+                                    const unsigned char *input, unsigned char *output,
+                                    size_t output_max_len)
 {
     return mbedtls_rsa_pkcs1_decrypt((mbedtls_rsa_context *) ctx,
                                      mbedtls_test_rnd_std_rand, NULL,
                                      olen, input, output, output_max_len);
 }
 static int mbedtls_rsa_sign_func(void *ctx,
-                          int (*f_rng)(void *, unsigned char *, size_t), void *p_rng,
-                          mbedtls_md_type_t md_alg, unsigned int hashlen,
-                          const unsigned char *hash, unsigned char *sig)
+                                 int (*f_rng)(void *, unsigned char *, size_t), void *p_rng,
+                                 mbedtls_md_type_t md_alg, unsigned int hashlen,
+                                 const unsigned char *hash, unsigned char *sig)
 {
     ((void) f_rng);
     ((void) p_rng);

--- a/tf-psa-crypto/tests/suites/test_suite_pk.function
+++ b/tf-psa-crypto/tests/suites/test_suite_pk.function
@@ -467,7 +467,7 @@ exit:
 }
 #endif /* MBEDTLS_PSA_CRYPTO_CLIENT */
 
-#if defined(MBEDTLS_RSA_C)
+#if defined(MBEDTLS_RSA_C) && defined(MBEDTLS_PK_RSA_ALT_SUPPORT)
 static int mbedtls_rsa_decrypt_func(void *ctx, size_t *olen,
                                     const unsigned char *input, unsigned char *output,
                                     size_t output_max_len)
@@ -491,7 +491,7 @@ static size_t mbedtls_rsa_key_len_func(void *ctx)
 {
     return ((const mbedtls_rsa_context *) ctx)->len;
 }
-#endif /* MBEDTLS_RSA_C */
+#endif /* MBEDTLS_RSA_C && MBEDTLS_PK_RSA_ALT_SUPPORT */
 
 typedef enum {
     /* The values are compatible with thinking of "from pair" as a boolean. */

--- a/tf-psa-crypto/tests/suites/test_suite_platform.function
+++ b/tf-psa-crypto/tests/suites/test_suite_platform.function
@@ -18,7 +18,7 @@
 #else
 #include <unistd.h>
 #endif
-void sleep_ms(int milliseconds)
+static void sleep_ms(int milliseconds)
 {
 #if defined(_WIN32) || defined(WIN32) || defined(__CYGWIN__) || \
     defined(__MINGW32__) || defined(_WIN64)

--- a/tf-psa-crypto/tests/suites/test_suite_psa_crypto.function
+++ b/tf-psa-crypto/tests/suites/test_suite_psa_crypto.function
@@ -153,7 +153,7 @@ static int construct_fake_rsa_key(unsigned char *buffer,
 }
 #endif /* MBEDTLS_ASN1_WRITE_C */
 
-int exercise_mac_setup(psa_key_type_t key_type,
+static int exercise_mac_setup(psa_key_type_t key_type,
                        const unsigned char *key_bytes,
                        size_t key_length,
                        psa_algorithm_t alg,
@@ -185,7 +185,7 @@ exit:
     return 0;
 }
 
-int exercise_cipher_setup(psa_key_type_t key_type,
+static int exercise_cipher_setup(psa_key_type_t key_type,
                           const unsigned char *key_bytes,
                           size_t key_length,
                           psa_algorithm_t alg,
@@ -1308,7 +1308,7 @@ same_key_context;
 /* Attempt to import the key in ctx. This handles any valid error codes
  * and reports an error for any invalid codes. This function also insures
  * that once imported by some thread, all threads can use the key. */
-void *thread_import_key(void *ctx)
+static void *thread_import_key(void *ctx)
 {
     mbedtls_svc_key_id_t returned_key_id;
     same_key_context *skc = (struct same_key_context *) ctx;
@@ -1382,7 +1382,7 @@ exit:
     return NULL;
 }
 
-void *thread_use_and_destroy_key(void *ctx)
+static void *thread_use_and_destroy_key(void *ctx)
 {
     same_key_context *skc = (struct same_key_context *) ctx;
 
@@ -1422,7 +1422,7 @@ typedef struct generate_key_context {
     int reps;
 }
 generate_key_context;
-void *thread_generate_key(void *ctx)
+static void *thread_generate_key(void *ctx)
 {
     mbedtls_svc_key_id_t key = MBEDTLS_SVC_KEY_ID_INIT;
     psa_key_attributes_t got_attributes = PSA_KEY_ATTRIBUTES_INIT;

--- a/tf-psa-crypto/tests/suites/test_suite_psa_crypto.function
+++ b/tf-psa-crypto/tests/suites/test_suite_psa_crypto.function
@@ -154,11 +154,11 @@ static int construct_fake_rsa_key(unsigned char *buffer,
 #endif /* MBEDTLS_ASN1_WRITE_C */
 
 static int exercise_mac_setup(psa_key_type_t key_type,
-                       const unsigned char *key_bytes,
-                       size_t key_length,
-                       psa_algorithm_t alg,
-                       psa_mac_operation_t *operation,
-                       psa_status_t *status)
+                              const unsigned char *key_bytes,
+                              size_t key_length,
+                              psa_algorithm_t alg,
+                              psa_mac_operation_t *operation,
+                              psa_status_t *status)
 {
     mbedtls_svc_key_id_t key = MBEDTLS_SVC_KEY_ID_INIT;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
@@ -186,11 +186,11 @@ exit:
 }
 
 static int exercise_cipher_setup(psa_key_type_t key_type,
-                          const unsigned char *key_bytes,
-                          size_t key_length,
-                          psa_algorithm_t alg,
-                          psa_cipher_operation_t *operation,
-                          psa_status_t *status)
+                                 const unsigned char *key_bytes,
+                                 size_t key_length,
+                                 psa_algorithm_t alg,
+                                 psa_cipher_operation_t *operation,
+                                 psa_status_t *status)
 {
     mbedtls_svc_key_id_t key = MBEDTLS_SVC_KEY_ID_INIT;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
@@ -263,14 +263,14 @@ exit:
 /* Assert that a key isn't reported as having a slot number. */
 #if defined(MBEDTLS_PSA_CRYPTO_SE_C)
 #define ASSERT_NO_SLOT_NUMBER(attributes)                             \
-    do                                                                  \
-    {                                                                   \
-        psa_key_slot_number_t ASSERT_NO_SLOT_NUMBER_slot_number;        \
-        TEST_EQUAL(psa_get_key_slot_number(                            \
-                       attributes,                                     \
+    do                                                                \
+    {                                                                 \
+        psa_key_slot_number_t ASSERT_NO_SLOT_NUMBER_slot_number;      \
+        TEST_EQUAL(psa_get_key_slot_number(                           \
+                       attributes,                                    \
                        &ASSERT_NO_SLOT_NUMBER_slot_number),           \
                    PSA_ERROR_INVALID_ARGUMENT);                       \
-    }                                                                   \
+    }                                                                 \
     while (0)
 #else /* MBEDTLS_PSA_CRYPTO_SE_C */
 #define ASSERT_NO_SLOT_NUMBER(attributes)     \

--- a/tf-psa-crypto/tests/suites/test_suite_psa_crypto.function
+++ b/tf-psa-crypto/tests/suites/test_suite_psa_crypto.function
@@ -39,28 +39,6 @@
 #define ASSERT_OPERATION_IS_ACTIVE(operation) TEST_ASSERT(operation.id != 0)
 #define ASSERT_OPERATION_IS_INACTIVE(operation) TEST_ASSERT(operation.id == 0)
 
-#if defined(PSA_WANT_ALG_JPAKE)
-int ecjpake_operation_setup(psa_pake_operation_t *operation,
-                            psa_pake_cipher_suite_t *cipher_suite,
-                            psa_pake_role_t role,
-                            mbedtls_svc_key_id_t key,
-                            size_t key_available)
-{
-    PSA_ASSERT(psa_pake_abort(operation));
-
-    PSA_ASSERT(psa_pake_setup(operation, cipher_suite));
-
-    PSA_ASSERT(psa_pake_set_role(operation, role));
-
-    if (key_available) {
-        PSA_ASSERT(psa_pake_set_password_key(operation, key));
-    }
-    return 0;
-exit:
-    return 1;
-}
-#endif
-
 /** An invalid export length that will never be set by psa_export_key(). */
 static const size_t INVALID_EXPORT_LENGTH = ~0U;
 

--- a/tf-psa-crypto/tests/suites/test_suite_psa_crypto.function
+++ b/tf-psa-crypto/tests/suites/test_suite_psa_crypto.function
@@ -1292,6 +1292,7 @@ exit:
 
 #if defined(MBEDTLS_THREADING_PTHREAD)
 
+#if defined(MBEDTLS_PSA_CRYPTO_STORAGE_C)
 typedef struct same_key_context {
     data_t *data;
     mbedtls_svc_key_id_t key;
@@ -1410,6 +1411,7 @@ static void *thread_use_and_destroy_key(void *ctx)
 exit:
     return NULL;
 }
+#endif /* MBEDTLS_PSA_CRYPTO_STORAGE_C */
 
 typedef struct generate_key_context {
     psa_key_type_t type;

--- a/tf-psa-crypto/tests/suites/test_suite_psa_crypto_metadata.function
+++ b/tf-psa-crypto/tests/suites/test_suite_psa_crypto_metadata.function
@@ -80,17 +80,17 @@
  * Unconditionally mask flag into the ambient variable
  * classification_flags_tested.
  */
-#define TEST_CLASSIFICATION_MACRO(cond, flag, alg, flags)     \
+#define TEST_CLASSIFICATION_MACRO(cond, flag, alg, flags)       \
     do                                                          \
     {                                                           \
-        if (cond)                                              \
+        if (cond)                                               \
         {                                                       \
-            if ((flags) & (flag))                          \
-            TEST_ASSERT(PSA_##flag(alg));               \
+            if ((flags) & (flag))                               \
+            TEST_ASSERT(PSA_##flag(alg));                       \
             else                                                \
-            TEST_ASSERT(!PSA_##flag(alg));             \
+            TEST_ASSERT(!PSA_##flag(alg));                      \
         }                                                       \
-        classification_flags_tested |= (flag);                \
+        classification_flags_tested |= (flag);                  \
     }                                                           \
     while (0)
 
@@ -193,8 +193,8 @@ exit:;
 }
 
 static void mac_algorithm_core(psa_algorithm_t alg, int classification_flags,
-                        psa_key_type_t key_type, size_t key_bits,
-                        size_t length)
+                               psa_key_type_t key_type, size_t key_bits,
+                               size_t length)
 {
     /* Algorithm classification */
     TEST_ASSERT(!PSA_ALG_IS_HASH(alg));
@@ -219,8 +219,8 @@ exit:;
 }
 
 static void aead_algorithm_core(psa_algorithm_t alg, int classification_flags,
-                         psa_key_type_t key_type, size_t key_bits,
-                         size_t tag_length)
+                                psa_key_type_t key_type, size_t key_bits,
+                                size_t tag_length)
 {
     /* Algorithm classification */
     TEST_ASSERT(!PSA_ALG_IS_HASH(alg));

--- a/tf-psa-crypto/tests/suites/test_suite_psa_crypto_metadata.function
+++ b/tf-psa-crypto/tests/suites/test_suite_psa_crypto_metadata.function
@@ -106,7 +106,7 @@
  * The expected parity is even so that 0 is considered a valid encoding.
  *
  * Return a nonzero value if value has even parity and 0 otherwise. */
-int has_even_parity(uint32_t value)
+static int has_even_parity(uint32_t value)
 {
     value ^= value >> 16;
     value ^= value >> 8;
@@ -116,7 +116,7 @@ int has_even_parity(uint32_t value)
 #define TEST_PARITY(value)                    \
     TEST_ASSERT(has_even_parity(value))
 
-void algorithm_classification(psa_algorithm_t alg, unsigned flags)
+static void algorithm_classification(psa_algorithm_t alg, unsigned flags)
 {
     unsigned classification_flags_tested = 0;
     TEST_CLASSIFICATION_MACRO(1, ALG_IS_VENDOR_DEFINED, alg, flags);
@@ -155,7 +155,7 @@ void algorithm_classification(psa_algorithm_t alg, unsigned flags)
 exit:;
 }
 
-void key_type_classification(psa_key_type_t type, unsigned flags)
+static void key_type_classification(psa_key_type_t type, unsigned flags)
 {
     unsigned classification_flags_tested = 0;
 
@@ -192,7 +192,7 @@ void key_type_classification(psa_key_type_t type, unsigned flags)
 exit:;
 }
 
-void mac_algorithm_core(psa_algorithm_t alg, int classification_flags,
+static void mac_algorithm_core(psa_algorithm_t alg, int classification_flags,
                         psa_key_type_t key_type, size_t key_bits,
                         size_t length)
 {
@@ -218,7 +218,7 @@ void mac_algorithm_core(psa_algorithm_t alg, int classification_flags,
 exit:;
 }
 
-void aead_algorithm_core(psa_algorithm_t alg, int classification_flags,
+static void aead_algorithm_core(psa_algorithm_t alg, int classification_flags,
                          psa_key_type_t key_type, size_t key_bits,
                          size_t tag_length)
 {

--- a/tf-psa-crypto/tests/suites/test_suite_psa_crypto_op_fail.function
+++ b/tf-psa-crypto/tests/suites/test_suite_psa_crypto_op_fail.function
@@ -27,11 +27,11 @@ static int test_equal_status(const char *test,
  * run, it would be better to clarify the expectations and reconcile the
  * library and the test case generator.
  */
-#define TEST_STATUS(expr1, expr2)                                     \
-    do {                                                                \
+#define TEST_STATUS(expr1, expr2)                                         \
+    do {                                                                  \
         if (!test_equal_status( #expr1 " == " #expr2, __LINE__, __FILE__, \
-                                expr1, expr2))                       \
-        goto exit;                                                  \
+                                expr1, expr2))                            \
+        goto exit;                                                        \
     } while (0)
 
 /* END_HEADER */

--- a/tf-psa-crypto/tests/suites/test_suite_psa_crypto_pake.function
+++ b/tf-psa-crypto/tests/suites/test_suite_psa_crypto_pake.function
@@ -71,9 +71,9 @@ static const uint8_t jpake_client_id[] = { 'c', 'l', 'i', 'e', 'n', 't' };
  * we're corrupting.
  */
 #define DO_ROUND_CONDITIONAL_INJECT(this_stage, buf) \
-    if (this_stage == err_stage)                  \
-    {                                               \
-        *(buf + 7) ^= 1;                           \
+    if (this_stage == err_stage)                     \
+    {                                                \
+        *(buf + 7) ^= 1;                             \
     }
 
 #define DO_ROUND_CONDITIONAL_CHECK_FAILURE(this_stage, function) \
@@ -84,20 +84,20 @@ static const uint8_t jpake_client_id[] = { 'c', 'l', 'i', 'e', 'n', 't' };
     }
 
 #define DO_ROUND_UPDATE_OFFSETS(main_buf_offset, step_offset, step_size) \
-    {                                       \
-        step_offset = main_buf_offset;      \
-        main_buf_offset += step_size;        \
+    {                                                                    \
+        step_offset = main_buf_offset;                                   \
+        main_buf_offset += step_size;                                    \
     }
 
-#define DO_ROUND_CHECK_FAILURE()                                  \
-    if (err_stage != ERR_NONE && status != PSA_SUCCESS)            \
+#define DO_ROUND_CHECK_FAILURE()                                    \
+    if (err_stage != ERR_NONE && status != PSA_SUCCESS)             \
     {                                                               \
-        TEST_EQUAL(status, expected_error_arg);                   \
+        TEST_EQUAL(status, expected_error_arg);                     \
         break;                                                      \
     }                                                               \
     else                                                            \
     {                                                               \
-        TEST_EQUAL(status, PSA_SUCCESS);                          \
+        TEST_EQUAL(status, PSA_SUCCESS);                            \
     }
 
 #if defined(PSA_WANT_ALG_JPAKE)
@@ -550,15 +550,15 @@ exit:
  *     - terminated with failure otherwise (either no error was expected at this
  *       stage or a different error code was expected)
  */
-#define SETUP_ALWAYS_CHECK_STEP(test_function, this_check_err_stage)      \
+#define SETUP_ALWAYS_CHECK_STEP(test_function, this_check_err_stage)        \
     status = test_function;                                                 \
-    if (err_stage != this_check_err_stage)                                 \
+    if (err_stage != this_check_err_stage)                                  \
     {                                                                       \
-        PSA_ASSERT(status);                                               \
+        PSA_ASSERT(status);                                                 \
     }                                                                       \
     else                                                                    \
     {                                                                       \
-        TEST_EQUAL(status, expected_error);                               \
+        TEST_EQUAL(status, expected_error);                                 \
         goto exit;                                                          \
     }
 
@@ -572,10 +572,10 @@ exit:
  * The test succeeds if the returned error is exactly the expected one,
  * otherwise it fails.
  */
-#define SETUP_CONDITIONAL_CHECK_STEP(test_function, this_check_err_stage) \
-    if (err_stage == this_check_err_stage)                                 \
+#define SETUP_CONDITIONAL_CHECK_STEP(test_function, this_check_err_stage)   \
+    if (err_stage == this_check_err_stage)                                  \
     {                                                                       \
-        TEST_EQUAL(test_function, expected_error);                        \
+        TEST_EQUAL(test_function, expected_error);                          \
         goto exit;                                                          \
     }
 /* END_HEADER */

--- a/tf-psa-crypto/tests/suites/test_suite_psa_crypto_se_driver_hal.function
+++ b/tf-psa-crypto/tests/suites/test_suite_psa_crypto_se_driver_hal.function
@@ -599,7 +599,7 @@ exit:
  * If this changes, the storage format version must change.
  * See psa_get_se_driver_its_file_uid() in psa_crypto_se.c.
  */
-psa_storage_uid_t file_uid_for_location(psa_key_location_t location)
+static psa_storage_uid_t file_uid_for_location(psa_key_location_t location)
 {
     if (location > PSA_MAX_SE_LOCATION) {
         return 0;

--- a/tf-psa-crypto/tests/suites/test_suite_psa_crypto_se_driver_hal.function
+++ b/tf-psa-crypto/tests/suites/test_suite_psa_crypto_se_driver_hal.function
@@ -14,8 +14,8 @@
 #endif
 
 /* Same in library/psa_crypto.c */
-#if defined(MBEDTLS_PSA_BUILTIN_ALG_HKDF) ||          \
-    defined(MBEDTLS_PSA_BUILTIN_ALG_HKDF_EXTRACT) ||  \
+#if defined(MBEDTLS_PSA_BUILTIN_ALG_HKDF) || \
+    defined(MBEDTLS_PSA_BUILTIN_ALG_HKDF_EXTRACT) || \
     defined(MBEDTLS_PSA_BUILTIN_ALG_HKDF_EXPAND)
 #define BUILTIN_ALG_ANY_HKDF 1
 #endif
@@ -36,11 +36,11 @@
 
 /** The location and lifetime used for tests that use a single driver. */
 #define TEST_DRIVER_LOCATION 1
-#define TEST_SE_PERSISTENT_LIFETIME                             \
+#define TEST_SE_PERSISTENT_LIFETIME                            \
     (PSA_KEY_LIFETIME_FROM_PERSISTENCE_AND_LOCATION(           \
          PSA_KEY_PERSISTENCE_DEFAULT, TEST_DRIVER_LOCATION))
 
-#define TEST_SE_VOLATILE_LIFETIME                               \
+#define TEST_SE_VOLATILE_LIFETIME                              \
     (PSA_KEY_LIFETIME_FROM_PERSISTENCE_AND_LOCATION(           \
          PSA_KEY_PERSISTENCE_VOLATILE, TEST_DRIVER_LOCATION))
 
@@ -54,13 +54,13 @@
  *
  * Use this macro to assert on guarantees provided by the core.
  */
-#define DRIVER_ASSERT_RETURN(TEST)                        \
-    do {                                                    \
-        if (!(TEST))                                       \
-        {                                                    \
-            mbedtls_test_fail( #TEST, __LINE__, __FILE__);   \
-            return PSA_ERROR_DETECTED_BY_DRIVER;           \
-        }                                                    \
+#define DRIVER_ASSERT_RETURN(TEST)                            \
+    do {                                                      \
+        if (!(TEST))                                          \
+        {                                                     \
+            mbedtls_test_fail( #TEST, __LINE__, __FILE__);    \
+            return PSA_ERROR_DETECTED_BY_DRIVER;              \
+        }                                                     \
     } while (0)
 
 /** Like #TEST_ASSERT for use in a driver method, with cleanup.
@@ -70,14 +70,14 @@
  *
  * Use this macro to assert on guarantees provided by the core.
  */
-#define DRIVER_ASSERT(TEST)                               \
-    do {                                                    \
-        if (!(TEST))                                       \
-        {                                                    \
-            mbedtls_test_fail( #TEST, __LINE__, __FILE__);   \
+#define DRIVER_ASSERT(TEST)                                   \
+    do {                                                      \
+        if (!(TEST))                                          \
+        {                                                     \
+            mbedtls_test_fail( #TEST, __LINE__, __FILE__);    \
             status = PSA_ERROR_DETECTED_BY_DRIVER;            \
             goto exit;                                        \
-        }                                                    \
+        }                                                     \
     } while (0)
 
 /** Like #PSA_ASSERT for a PSA API call that calls a driver underneath.
@@ -91,16 +91,16 @@
  * case, the test driver code is expected to have called mbedtls_test_fail()
  * already, so we make sure not to overwrite the failure information.
  */
-#define PSA_ASSERT_VIA_DRIVER(expr, expected_status)                  \
-    do {                                                                \
-        psa_status_t PSA_ASSERT_VIA_DRIVER_status = (expr);           \
-        if (PSA_ASSERT_VIA_DRIVER_status == PSA_ERROR_DETECTED_BY_DRIVER) \
-        goto exit;                                                  \
-        if (PSA_ASSERT_VIA_DRIVER_status != (expected_status))       \
-        {                                                               \
+#define PSA_ASSERT_VIA_DRIVER(expr, expected_status)                           \
+    do {                                                                       \
+        psa_status_t PSA_ASSERT_VIA_DRIVER_status = (expr);                    \
+        if (PSA_ASSERT_VIA_DRIVER_status == PSA_ERROR_DETECTED_BY_DRIVER)      \
+        goto exit;                                                             \
+        if (PSA_ASSERT_VIA_DRIVER_status != (expected_status))                 \
+        {                                                                      \
             mbedtls_test_fail( #expr, __LINE__, __FILE__);                     \
-            goto exit;                                                  \
-        }                                                               \
+            goto exit;                                                         \
+        }                                                                      \
     } while (0)
 
 

--- a/tf-psa-crypto/tests/suites/test_suite_psa_crypto_se_driver_hal_mocks.function
+++ b/tf-psa-crypto/tests/suites/test_suite_psa_crypto_se_driver_hal_mocks.function
@@ -6,7 +6,7 @@
 
 /** The location and lifetime used for tests that use a single driver. */
 #define TEST_DRIVER_LOCATION 1
-#define TEST_SE_PERSISTENT_LIFETIME                             \
+#define TEST_SE_PERSISTENT_LIFETIME                            \
     (PSA_KEY_LIFETIME_FROM_PERSISTENCE_AND_LOCATION(           \
          PSA_KEY_PERSISTENCE_DEFAULT, TEST_DRIVER_LOCATION))
 
@@ -163,10 +163,10 @@ static psa_status_t mock_import(psa_drv_se_context_t *drv_context,
 }
 
 static psa_status_t mock_export(psa_drv_se_context_t *context,
-                         psa_key_slot_number_t slot_number,
-                         uint8_t *p_data,
-                         size_t data_size,
-                         size_t *p_data_length)
+                                psa_key_slot_number_t slot_number,
+                                uint8_t *p_data,
+                                size_t data_size,
+                                size_t *p_data_length)
 {
     (void) context;
     (void) p_data;
@@ -180,10 +180,10 @@ static psa_status_t mock_export(psa_drv_se_context_t *context,
 }
 
 static psa_status_t mock_export_public(psa_drv_se_context_t *context,
-                                psa_key_slot_number_t slot_number,
-                                uint8_t *p_data,
-                                size_t data_size,
-                                size_t *p_data_length)
+                                       psa_key_slot_number_t slot_number,
+                                       uint8_t *p_data,
+                                       size_t data_size,
+                                       size_t *p_data_length)
 {
     (void) context;
     (void) p_data;
@@ -197,13 +197,13 @@ static psa_status_t mock_export_public(psa_drv_se_context_t *context,
 }
 
 static psa_status_t mock_sign(psa_drv_se_context_t *context,
-                       psa_key_slot_number_t key_slot,
-                       psa_algorithm_t alg,
-                       const uint8_t *p_hash,
-                       size_t hash_length,
-                       uint8_t *p_signature,
-                       size_t signature_size,
-                       size_t *p_signature_length)
+                              psa_key_slot_number_t key_slot,
+                              psa_algorithm_t alg,
+                              const uint8_t *p_hash,
+                              size_t hash_length,
+                              uint8_t *p_signature,
+                              size_t signature_size,
+                              size_t *p_signature_length)
 {
     (void) context;
     (void) p_hash;
@@ -220,12 +220,12 @@ static psa_status_t mock_sign(psa_drv_se_context_t *context,
 }
 
 static psa_status_t mock_verify(psa_drv_se_context_t *context,
-                         psa_key_slot_number_t key_slot,
-                         psa_algorithm_t alg,
-                         const uint8_t *p_hash,
-                         size_t hash_length,
-                         const uint8_t *p_signature,
-                         size_t signature_length)
+                                psa_key_slot_number_t key_slot,
+                                psa_algorithm_t alg,
+                                const uint8_t *p_hash,
+                                size_t hash_length,
+                                const uint8_t *p_signature,
+                                size_t signature_length)
 {
     (void) context;
     (void) p_hash;
@@ -241,10 +241,10 @@ static psa_status_t mock_verify(psa_drv_se_context_t *context,
 }
 
 static psa_status_t mock_allocate(psa_drv_se_context_t *drv_context,
-                           void *persistent_data,
-                           const psa_key_attributes_t *attributes,
-                           psa_key_creation_method_t method,
-                           psa_key_slot_number_t *key_slot)
+                                  void *persistent_data,
+                                  const psa_key_attributes_t *attributes,
+                                  psa_key_creation_method_t method,
+                                  psa_key_slot_number_t *key_slot)
 {
     (void) drv_context;
     (void) persistent_data;
@@ -259,8 +259,8 @@ static psa_status_t mock_allocate(psa_drv_se_context_t *drv_context,
 }
 
 static psa_status_t mock_destroy(psa_drv_se_context_t *context,
-                          void *persistent_data,
-                          psa_key_slot_number_t slot_number)
+                                 void *persistent_data,
+                                 psa_key_slot_number_t slot_number)
 {
     (void) context;
     (void) persistent_data;

--- a/tf-psa-crypto/tests/suites/test_suite_psa_crypto_se_driver_hal_mocks.function
+++ b/tf-psa-crypto/tests/suites/test_suite_psa_crypto_se_driver_hal_mocks.function
@@ -162,7 +162,7 @@ static psa_status_t mock_import(psa_drv_se_context_t *drv_context,
     return mock_import_data.return_value;
 }
 
-psa_status_t mock_export(psa_drv_se_context_t *context,
+static psa_status_t mock_export(psa_drv_se_context_t *context,
                          psa_key_slot_number_t slot_number,
                          uint8_t *p_data,
                          size_t data_size,
@@ -179,7 +179,7 @@ psa_status_t mock_export(psa_drv_se_context_t *context,
     return mock_export_data.return_value;
 }
 
-psa_status_t mock_export_public(psa_drv_se_context_t *context,
+static psa_status_t mock_export_public(psa_drv_se_context_t *context,
                                 psa_key_slot_number_t slot_number,
                                 uint8_t *p_data,
                                 size_t data_size,
@@ -196,7 +196,7 @@ psa_status_t mock_export_public(psa_drv_se_context_t *context,
     return mock_export_public_data.return_value;
 }
 
-psa_status_t mock_sign(psa_drv_se_context_t *context,
+static psa_status_t mock_sign(psa_drv_se_context_t *context,
                        psa_key_slot_number_t key_slot,
                        psa_algorithm_t alg,
                        const uint8_t *p_hash,
@@ -219,7 +219,7 @@ psa_status_t mock_sign(psa_drv_se_context_t *context,
     return mock_sign_data.return_value;
 }
 
-psa_status_t mock_verify(psa_drv_se_context_t *context,
+static psa_status_t mock_verify(psa_drv_se_context_t *context,
                          psa_key_slot_number_t key_slot,
                          psa_algorithm_t alg,
                          const uint8_t *p_hash,
@@ -240,7 +240,7 @@ psa_status_t mock_verify(psa_drv_se_context_t *context,
     return mock_verify_data.return_value;
 }
 
-psa_status_t mock_allocate(psa_drv_se_context_t *drv_context,
+static psa_status_t mock_allocate(psa_drv_se_context_t *drv_context,
                            void *persistent_data,
                            const psa_key_attributes_t *attributes,
                            psa_key_creation_method_t method,
@@ -258,7 +258,7 @@ psa_status_t mock_allocate(psa_drv_se_context_t *drv_context,
     return mock_allocate_data.return_value;
 }
 
-psa_status_t mock_destroy(psa_drv_se_context_t *context,
+static psa_status_t mock_destroy(psa_drv_se_context_t *context,
                           void *persistent_data,
                           psa_key_slot_number_t slot_number)
 {

--- a/tf-psa-crypto/tests/suites/test_suite_psa_its.function
+++ b/tf-psa-crypto/tests/suites/test_suite_psa_its.function
@@ -19,11 +19,11 @@
 #define PSA_ITS_STORAGE_PREFIX ""
 #define PSA_ITS_STORAGE_FILENAME_PATTERN "%08lx%08lx"
 #define PSA_ITS_STORAGE_SUFFIX ".psa_its"
-#define PSA_ITS_STORAGE_FILENAME_LENGTH         \
-    (sizeof(PSA_ITS_STORAGE_PREFIX) - 1 +    /*prefix without terminating 0*/ \
-     16 +  /*UID (64-bit number in hex)*/                               \
-     16 +  /*UID (64-bit number in hex)*/                               \
-     sizeof(PSA_ITS_STORAGE_SUFFIX) - 1 +    /*suffix without terminating 0*/ \
+#define PSA_ITS_STORAGE_FILENAME_LENGTH                                         \
+    (sizeof(PSA_ITS_STORAGE_PREFIX) - 1 +    /*prefix without terminating 0*/   \
+     16 +  /*UID (64-bit number in hex)*/                                       \
+     16 +  /*UID (64-bit number in hex)*/                                       \
+     sizeof(PSA_ITS_STORAGE_SUFFIX) - 1 +    /*suffix without terminating 0*/   \
      1 /*terminating null byte*/)
 #define PSA_ITS_STORAGE_TEMP \
     PSA_ITS_STORAGE_PREFIX "tempfile" PSA_ITS_STORAGE_SUFFIX


### PR DESCRIPTION
## Description

Fix two build issues related to custom configs:
- Fix #9186
- Fix #9188

Also fix additional build issues with sample programs and test suites caused by introducing `-Wmissing-prototypes`

See also https://github.com/Mbed-TLS/mbedtls-framework/pull/23

## PR checklist

- [x] **changelog** provided
- [x] **development PR** provided
- [x] **framework PR** provided https://github.com/Mbed-TLS/mbedtls-framework/pull/23
- [x] **3.6 PR** provided #9451
- [x] **2.28 PR**  not required because: neither issue is present in 2.28 (#9186: no build failure in the given configuration and compilers; #9188: moot since PSA did not support DHM yet)
- **tests**  provided. Some more CI coverage required, added `-Wmissing-prototypes` to `all.sh`