### PR TITLE
Make local functions and objects static

### DIFF
--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -597,7 +597,7 @@ static int my_verify(void *data, mbedtls_x509_crt *crt,
 #endif /* MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED */
 
 #if defined(MBEDTLS_SSL_DTLS_CONNECTION_ID)
-int report_cid_usage(mbedtls_ssl_context *ssl,
+static int report_cid_usage(mbedtls_ssl_context *ssl,
                      const char *additional_description)
 {
     int ret;

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -603,7 +603,7 @@ rng_context_t rng;
 /*
  * global options
  */
-struct options {
+static struct options {
     const char *server_addr;    /* address on which the ssl service runs    */
     const char *server_port;    /* port on which the ssl service runs       */
     int debug_level;            /* level of debugging                       */
@@ -1332,7 +1332,7 @@ static psa_status_t psa_setup_psk_key_slot(mbedtls_svc_key_id_t *slot,
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 #if defined(MBEDTLS_SSL_DTLS_CONNECTION_ID)
-int report_cid_usage(mbedtls_ssl_context *ssl,
+static int report_cid_usage(mbedtls_ssl_context *ssl,
                      const char *additional_description)
 {
     int ret;

--- a/programs/ssl/ssl_test_common_source.c
+++ b/programs/ssl/ssl_test_common_source.c
@@ -12,7 +12,7 @@
  *  SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
  */
 
-void eap_tls_key_derivation(void *p_expkey,
+static void eap_tls_key_derivation(void *p_expkey,
                             mbedtls_ssl_key_export_type secret_type,
                             const unsigned char *secret,
                             size_t secret_len,
@@ -36,7 +36,7 @@ void eap_tls_key_derivation(void *p_expkey,
     keys->tls_prf_type = tls_prf_type;
 }
 
-void nss_keylog_export(void *p_expkey,
+static void nss_keylog_export(void *p_expkey,
                        mbedtls_ssl_key_export_type secret_type,
                        const unsigned char *secret,
                        size_t secret_len,
@@ -131,7 +131,7 @@ void dtls_srtp_key_derivation(void *p_expkey,
 }
 #endif /* MBEDTLS_SSL_DTLS_SRTP */
 
-int ssl_check_record(mbedtls_ssl_context const *ssl,
+static int ssl_check_record(mbedtls_ssl_context const *ssl,
                      unsigned char const *buf, size_t len)
 {
     int my_ret = 0, ret_cr1, ret_cr2;
@@ -195,7 +195,7 @@ cleanup:
     return my_ret;
 }
 
-int recv_cb(void *ctx, unsigned char *buf, size_t len)
+static int recv_cb(void *ctx, unsigned char *buf, size_t len)
 {
     io_ctx_t *io_ctx = (io_ctx_t *) ctx;
     size_t recv_len;
@@ -223,7 +223,7 @@ int recv_cb(void *ctx, unsigned char *buf, size_t len)
     return (int) recv_len;
 }
 
-int recv_timeout_cb(void *ctx, unsigned char *buf, size_t len,
+static int recv_timeout_cb(void *ctx, unsigned char *buf, size_t len,
                     uint32_t timeout)
 {
     io_ctx_t *io_ctx = (io_ctx_t *) ctx;
@@ -248,7 +248,7 @@ int recv_timeout_cb(void *ctx, unsigned char *buf, size_t len,
     return (int) recv_len;
 }
 
-int send_cb(void *ctx, unsigned char const *buf, size_t len)
+static int send_cb(void *ctx, unsigned char const *buf, size_t len)
 {
     io_ctx_t *io_ctx = (io_ctx_t *) ctx;
 
@@ -291,7 +291,7 @@ int send_cb(void *ctx, unsigned char const *buf, size_t len)
 #define MBEDTLS_SSL_SIG_ALG(hash)
 #endif
 
-uint16_t ssl_sig_algs_for_test[] = {
+static uint16_t ssl_sig_algs_for_test[] = {
 #if defined(MBEDTLS_MD_CAN_SHA512)
     MBEDTLS_SSL_SIG_ALG(MBEDTLS_SSL_HASH_SHA512)
 #endif
@@ -319,7 +319,7 @@ uint16_t ssl_sig_algs_for_test[] = {
 /** Functionally equivalent to mbedtls_x509_crt_verify_info, see that function
  *  for more info.
  */
-int x509_crt_verify_info(char *buf, size_t size, const char *prefix,
+static int x509_crt_verify_info(char *buf, size_t size, const char *prefix,
                          uint32_t flags)
 {
 #if !defined(MBEDTLS_X509_REMOVE_INFO)
@@ -352,7 +352,7 @@ int x509_crt_verify_info(char *buf, size_t size, const char *prefix,
 }
 #endif /* MBEDTLS_X509_CRT_PARSE_C */
 
-void mbedtls_print_supported_sig_algs(void)
+static void mbedtls_print_supported_sig_algs(void)
 {
     mbedtls_printf("supported signature algorithms:\n");
     mbedtls_printf("\trsa_pkcs1_sha256 ");


### PR DESCRIPTION
Trying to build the programs in NuttX
which has a flat build.

These functions should be static,
so that we can link all these
objects together.

This should not hurt the current use cases.

## Description

In NuttX flat build, all objects are linked together, so that they end up in a flat namespace.

If `ssl_server2` and `ssl_client2` are linked together, we get some multiple definitions of these functions.

It should not hurt the current use cases if set these to `static`.

Please accept this PR as part of a (hopefully short) series to make mbedtls more cleanly integrated in NuttX.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** provided, or not required
- [x] **3.6 backport** done, or not required
- [x] **2.28 backport** done, or not required
- [x] **tests** provided, or not required



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
