### PR TITLE
Backport 3.6: Fix uint32_t printed as unsigned int

### DIFF
--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -1484,9 +1484,12 @@ int mbedtls_ssl_tls13_check_early_data_len(mbedtls_ssl_context *ssl,
          ssl->total_early_data_size)) {
 
         MBEDTLS_SSL_DEBUG_MSG(
-            2, ("EarlyData: Too much early data received, %u + %" MBEDTLS_PRINTF_SIZET " > %u",
-                ssl->total_early_data_size, early_data_len,
-                ssl->session_negotiate->max_early_data_size));
+            2, ("EarlyData: Too much early data received, "
+                "%" MBEDTLS_PRINTF_SIZET " + %" MBEDTLS_PRINTF_SIZET
+                " > %" MBEDTLS_PRINTF_SIZET,
+                (size_t) ssl->total_early_data_size,
+                early_data_len,
+                (size_t) ssl->session_negotiate->max_early_data_size));
 
         MBEDTLS_SSL_PEND_FATAL_ALERT(
             MBEDTLS_SSL_ALERT_MSG_UNEXPECTED_MESSAGE,

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -1485,11 +1485,10 @@ int mbedtls_ssl_tls13_check_early_data_len(mbedtls_ssl_context *ssl,
 
         MBEDTLS_SSL_DEBUG_MSG(
             2, ("EarlyData: Too much early data received, "
-                "%" MBEDTLS_PRINTF_SIZET " + %" MBEDTLS_PRINTF_SIZET
-                " > %" MBEDTLS_PRINTF_SIZET,
-                (size_t) ssl->total_early_data_size,
+                "%lu + %" MBEDTLS_PRINTF_SIZET " > %lu",
+                (unsigned long) ssl->total_early_data_size,
                 early_data_len,
-                (size_t) ssl->session_negotiate->max_early_data_size));
+                (unsigned long) ssl->session_negotiate->max_early_data_size));
 
         MBEDTLS_SSL_PEND_FATAL_ALERT(
             MBEDTLS_SSL_ALERT_MSG_UNEXPECTED_MESSAGE,

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -92,8 +92,9 @@ static void ssl_tls13_select_ciphersuite(
         return;
     }
 
-    MBEDTLS_SSL_DEBUG_MSG(2, ("No matched ciphersuite, psk_ciphersuite_id=%x, psk_hash_alg=%x",
-                              (unsigned) psk_ciphersuite_id, psk_hash_alg));
+    MBEDTLS_SSL_DEBUG_MSG(2, ("No matched ciphersuite, psk_ciphersuite_id=%x, psk_hash_alg=%lx",
+                              (unsigned) psk_ciphersuite_id,
+                              (unsigned long) psk_hash_alg));
 }
 
 #if defined(MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_SOME_PSK_ENABLED)


### PR DESCRIPTION
Trivial backport of https://github.com/Mbed-TLS/mbedtls/pull/9225

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required
- [x] **3.6 backport** of https://github.com/Mbed-TLS/mbedtls/pull/9225
- [x] **2.28 backport** not required
- [x] **tests** locally
