### PR TITLE
Allow `code_style.py` to work from a git hook

### DIFF
--- a/scripts/code_style.py
+++ b/scripts/code_style.py
@@ -85,9 +85,8 @@ def get_src_files(since: Optional[str]) -> List[str]:
     # Get a list of environment vars that git sets
     git_env_vars = subprocess.check_output(["git", "rev-parse", "--local-env-vars"],
                                            universal_newlines=True)
-    git_env_vars = git_env_vars.split()
     # Remove the vars from the environment
-    for var in git_env_vars:
+    for var in git_env_vars.split():
         framework_env.pop(var, None)
 
     output = subprocess.check_output(["git", "-C", "framework", "ls-files"]


### PR DESCRIPTION
When running a git hook, git sets certain environment variables (such as `GIT_INDEX_FILE`) which force git to look at the main repository, overriding other options. This trips up code_style.py whenever it tries to run a git command on the framework submodule.

Fix this by explicitly clearing git-related environment-variables before running git commands on the framework. This is recommended by [git's documentation](https://git-scm.com/docs/githooks):

> Environment variables, such as GIT_DIR, GIT_WORK_TREE, etc., are
> exported so that Git commands run by the hook can correctly locate
> the repository. If your hook needs to invoke Git commands in a
> foreign repository or in a different working tree of the same
> repository, then it should clear these environment variables so
> they do not interfere with Git operations at the foreign location.


## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required - contributor-facing only
- [x] **3.6 backport** #9234 
- [x] **2.28 backport** not required - no framework submodule in 2.28
- [x] **tests** not required - script change only
