### PR TITLE
[Backport 3.6] Allow `code_style.py` to work from a git hook

### DIFF
--- a/scripts/code_style.py
+++ b/scripts/code_style.py
@@ -85,9 +85,8 @@ def get_src_files(since: Optional[str]) -> List[str]:
     # Get a list of environment vars that git sets
     git_env_vars = subprocess.check_output(["git", "rev-parse", "--local-env-vars"],
                                            universal_newlines=True)
-    git_env_vars = git_env_vars.split()
     # Remove the vars from the environment
-    for var in git_env_vars:
+    for var in git_env_vars.split():
         framework_env.pop(var, None)
 
     output = subprocess.check_output(["git", "-C", "framework", "ls-files"]


### PR DESCRIPTION
Trivial backport of #9233 


## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required - contributor-facing only
- [x] **3.6 backport** of #9233 
- [x] **2.28 backport** not required - no framework submodule in 2.28
- [x] **tests** not required - checker script changes only