### PR TITLE
Set psk to NULL in ssl_psk_remove

### DIFF
--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -2243,6 +2243,7 @@ static void ssl_remove_psk(mbedtls_ssl_context *ssl)
         mbedtls_zeroize_and_free(ssl->handshake->psk,
                                  ssl->handshake->psk_len);
         ssl->handshake->psk_len = 0;
+        ssl->handshake->psk = NULL;
     }
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 }


### PR DESCRIPTION
Summary:
set the psk to NULL after it is released. `ssl_remove_psk` will free`ssl->handshake->psk`. If we don't set it to `NULL`. It may be [used](https://github.com/Mbed-TLS/mbedtls/blob/development/library/ssl_tls13_keys.c#L1875-L1879) or [free](https://github.com/Mbed-TLS/mbedtls/blob/development/library/ssl_tls.c#L4861-L4863) again in other conditions.

Test Plan:

Reviewers: 

Subscribers: ronald.cron@arm.com

Tasks:

Tags:

## Description

Address an issue that `psk` is not set to NULL after it is released.



## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required (robustness improvement)
- [x] **3.6 backport** #9245
- [x] **2.28 backport** #9246
- [x] **tests** not required (robustness improvement)



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
