### PR TITLE
Fix incorrect array length in function prototype

### DIFF
--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -2364,7 +2364,7 @@ int mbedtls_ssl_set_cid(mbedtls_ssl_context *ssl,
  */
 int mbedtls_ssl_get_own_cid(mbedtls_ssl_context *ssl,
                             int *enabled,
-                            unsigned char own_cid[MBEDTLS_SSL_CID_OUT_LEN_MAX],
+                            unsigned char own_cid[MBEDTLS_SSL_CID_IN_LEN_MAX],
                             size_t *own_cid_len);
 
 /**

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -132,7 +132,7 @@ int mbedtls_ssl_set_cid(mbedtls_ssl_context *ssl,
 
 int mbedtls_ssl_get_own_cid(mbedtls_ssl_context *ssl,
                             int *enabled,
-                            unsigned char own_cid[MBEDTLS_SSL_CID_OUT_LEN_MAX],
+                            unsigned char own_cid[MBEDTLS_SSL_CID_IN_LEN_MAX],
                             size_t *own_cid_len)
 {
     *enabled = MBEDTLS_SSL_CID_DISABLED;


### PR DESCRIPTION
Fixes #9179
(MBEDTLS_SSL_CID_OUT_LEN_MAX changed to MBEDTLS_SSL_CID_IN_LEN_MAX in library\ssl.h and library\ssl_tls.c)

## PR checklist

- [x] **changelog** not required - not really a user-facing fix
- [x] **3.6 backport** #9248 
- [x] **2.28 backport** not required
- [x] **tests** not required