### PR TITLE
Backport 2.28: Set psk to NULL in ssl_psk_remove

### DIFF
--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -4452,6 +4452,7 @@ static void ssl_remove_psk(mbedtls_ssl_context *ssl)
                                  ssl->handshake->psk_len);
         mbedtls_free(ssl->handshake->psk);
         ssl->handshake->psk_len = 0;
+        ssl->handshake->psk = NULL;
     }
 }
 


### PR DESCRIPTION
Summary:
Back port [PR 9241](https://github.com/Mbed-TLS/mbedtls/pull/9241) to 2.28 branch

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags:

## Description

Please write a few sentences describing the overall goals of the pull request's commits.



## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [ ] **changelog** provided, or not required
- [ ] **3.6 backport** done, or not required
- [x] **2.28 backport** done, or not required
- [ ] **tests** provided, or not required



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
