### PR TITLE
psa_sim: improve log prints

### DIFF
--- a/tests/psa-client-server/psasim/include/util.h
+++ b/tests/psa-client-server/psasim/include/util.h
@@ -13,20 +13,18 @@
 #if defined(DEBUG)
 #define INFO(fmt, ...) \
     fprintf(stdout, "Info (%s - %d): " fmt "\n", __FILE__, __LINE__, ##__VA_ARGS__)
+#else /* !DEBUG */
+#define INFO(...)
+#endif /* DEBUG*/
 
 #define ERROR(fmt, ...) \
-    fprintf(stdout, "Error (%s - %d): " fmt "\n", __FILE__, __LINE__, ##__VA_ARGS__)
+    fprintf(stderr, "Error (%s - %d): " fmt "\n", __FILE__, __LINE__, ##__VA_ARGS__)
 
 #define FATAL(fmt, ...) \
     { \
-        fprintf(stdout, "Fatal (%s - %d): " fmt "\n", __FILE__, __LINE__, ##__VA_ARGS__); \
+        fprintf(stderr, "Fatal (%s - %d): " fmt "\n", __FILE__, __LINE__, ##__VA_ARGS__); \
         abort(); \
     }
-#else /* DEBUG */
-#define INFO(...)
-#define ERROR(...)
-#define FATAL(...)
-#endif /* DEBUG*/
 
 #define PROJECT_ID              'M'
 #define PATHNAMESIZE            256

--- a/tests/psa-client-server/psasim/src/client.c
+++ b/tests/psa-client-server/psasim/src/client.c
@@ -7,12 +7,14 @@
 
 /* Includes from mbedtls */
 #include "psa/crypto.h"
+#include "util.h"
 
 int main()
 {
     /* psa_crypto_init() connects to the server */
     psa_status_t status = psa_crypto_init();
     if (status != PSA_SUCCESS) {
+        ERROR("psa_crypto_init returned %d", status);
         return 1;
     }
 

--- a/tests/psa-client-server/psasim/src/psa_ff_client.c
+++ b/tests/psa-client-server/psasim/src/psa_ff_client.c
@@ -199,7 +199,6 @@ static psa_status_t process_response(int rx_qid, vectors_t *vecs, int type,
             default:
                 FATAL("   ERROR: unknown internal message type: %ld",
                       response.message_type);
-                return ret;
         }
     }
 }
@@ -301,10 +300,10 @@ psa_handle_t psa_connect(uint32_t sid, uint32_t minor_version)
                 handles[idx].valid = 1;
                 return idx;
             } else {
-                INFO("Server didn't like you");
+                ERROR("Server didn't like you");
             }
         } else {
-            INFO("Couldn't contact RoT service. Does it exist?");
+            ERROR("Couldn't contact RoT service. Does it exist?");
 
             if (__psa_ff_client_security_state == 0) {
                 ERROR("Invalid SID");
@@ -339,7 +338,7 @@ uint32_t psa_version(uint32_t sid)
             }
         }
     }
-    INFO("psa_version failed: does the service exist?");
+    ERROR("psa_version failed: does the service exist?");
     return PSA_VERSION_NONE;
 }
 

--- a/tests/psa-client-server/psasim/src/psa_sim_crypto_client.c
+++ b/tests/psa-client-server/psasim/src/psa_sim_crypto_client.c
@@ -22,7 +22,7 @@
 #include "psa/crypto.h"
 
 #define CLIENT_PRINT(fmt, ...) \
-    PRINT("Client: " fmt, ##__VA_ARGS__)
+    INFO("Client: " fmt, ##__VA_ARGS__)
 
 static psa_handle_t handle = -1;
 

--- a/tests/psa-client-server/psasim/src/psa_sim_generate.pl
+++ b/tests/psa-client-server/psasim/src/psa_sim_generate.pl
@@ -302,7 +302,7 @@ sub client_calls_header
 #include "psa/crypto.h"
 
 #define CLIENT_PRINT(fmt, ...) \
-    PRINT("Client: " fmt, ##__VA_ARGS__)
+    INFO("Client: " fmt, ##__VA_ARGS__)
 
 static psa_handle_t handle = -1;
 

--- a/tests/psa-client-server/psasim/src/psa_sim_serialise.c
+++ b/tests/psa-client-server/psasim/src/psa_sim_serialise.c
@@ -10,6 +10,7 @@
  */
 
 #include "psa_sim_serialise.h"
+#include "util.h"
 #include <stdlib.h>
 #include <string.h>
 
@@ -71,8 +72,7 @@ static ssize_t allocate_hash_operation_slot(void)
 {
     psasim_client_handle_t handle = next_hash_operation_handle++;
     if (next_hash_operation_handle == 0) {      /* wrapped around */
-        fprintf(stderr, "MAX HASH HANDLES REACHED\n");
-        exit(1);
+        FATAL("Hash operation handle wrapped");
     }
 
     for (ssize_t i = 0; i < MAX_LIVE_HANDLES_PER_CLASS; i++) {
@@ -81,6 +81,8 @@ static ssize_t allocate_hash_operation_slot(void)
             return i;
         }
     }
+
+    ERROR("All slots are currently used. Unable to allocate a new one.");
 
     return -1;  /* all in use */
 }
@@ -94,7 +96,9 @@ static ssize_t find_hash_slot_by_handle(psasim_client_handle_t handle)
         }
     }
 
-    return -1;  /* all in use */
+    ERROR("Unable to find slot by handle %u", handle);
+
+    return -1;  /* not found */
 }
 
 static psa_aead_operation_t aead_operations[MAX_LIVE_HANDLES_PER_CLASS];
@@ -705,4 +709,10 @@ int psasim_deserialise_mbedtls_svc_key_id_t(uint8_t **pos,
     *remaining -= sizeof(*value);
 
     return 1;
+}
+
+void psa_sim_serialize_reset(void)
+{
+    memset(hash_operation_handles, 0, sizeof(hash_operation_handles));
+    memset(hash_operations, 0, sizeof(hash_operations));
 }

--- a/tests/psa-client-server/psasim/src/psa_sim_serialise.c
+++ b/tests/psa-client-server/psasim/src/psa_sim_serialise.c
@@ -110,8 +110,7 @@ static ssize_t allocate_aead_operation_slot(void)
 {
     psasim_client_handle_t handle = next_aead_operation_handle++;
     if (next_aead_operation_handle == 0) {      /* wrapped around */
-        fprintf(stderr, "MAX HASH HANDLES REACHED\n");
-        exit(1);
+        FATAL("Aead operation handle wrapped");
     }
 
     for (ssize_t i = 0; i < MAX_LIVE_HANDLES_PER_CLASS; i++) {
@@ -120,6 +119,8 @@ static ssize_t allocate_aead_operation_slot(void)
             return i;
         }
     }
+
+    ERROR("All slots are currently used. Unable to allocate a new one.");
 
     return -1;  /* all in use */
 }
@@ -133,7 +134,9 @@ static ssize_t find_aead_slot_by_handle(psasim_client_handle_t handle)
         }
     }
 
-    return -1;  /* all in use */
+    ERROR("Unable to find slot by handle %u", handle);
+
+    return -1;  /* not found */
 }
 
 size_t psasim_serialise_begin_needs(void)
@@ -709,10 +712,4 @@ int psasim_deserialise_mbedtls_svc_key_id_t(uint8_t **pos,
     *remaining -= sizeof(*value);
 
     return 1;
-}
-
-void psa_sim_serialize_reset(void)
-{
-    memset(hash_operation_handles, 0, sizeof(hash_operation_handles));
-    memset(hash_operations, 0, sizeof(hash_operations));
 }


### PR DESCRIPTION
## Description

This PR is an extract from #9237 in order to split different topics in different PRs. Here's what this one addresses:

- always print ERROR and FATAL messages because they should never occur, but when they do it's important to see them immediately;
- keep INFO prints under DEBUG guard;
- set client's PRINT as INFO message because otherwise it will mess test_suites's output;
- change some error messages from INFO to ERROR because that's what they are.

## PR checklist

- [ ] **changelog** not required
- [ ] **3.6 backport** not required
- [ ] **2.28 backport** not required
- [ ] **tests** not required