### PR TITLE
psa_sim: make server ping time much faster

### DIFF
--- a/tests/psa-client-server/psasim/src/psa_ff_server.c
+++ b/tests/psa-client-server/psasim/src/psa_ff_server.c
@@ -26,7 +26,7 @@
 #define MAX_CLIENTS 128
 #define MAX_MESSAGES 32
 
-#define SLEEP_MS        50
+#define SLEEP_US        1
 
 struct connection {
     uint32_t client;
@@ -105,7 +105,7 @@ psa_signal_t psa_wait(psa_signal_t signal_mask, uint32_t timeout)
     ssize_t len;
     int idx;
 #if !defined(PSASIM_USE_USLEEP)
-    const struct timespec ts_delay = { .tv_sec = 0, .tv_nsec = SLEEP_MS * 1000000 };
+    const struct timespec ts_delay = { .tv_sec = 0, .tv_nsec = SLEEP_US * 1000 };
 #endif
 
     if (timeout == PSA_POLL) {
@@ -262,7 +262,7 @@ psa_signal_t psa_wait(psa_signal_t signal_mask, uint32_t timeout)
         } else {
             /* There is no 'select' function in SysV to block on multiple queues, so busy-wait :( */
 #if defined(PSASIM_USE_USLEEP)
-            usleep(SLEEP_MS * 1000);
+            usleep(SLEEP_US);
 #else /* PSASIM_USE_USLEEP */
             nanosleep(&ts_delay, NULL);
 #endif /* PSASIM_USE_USLEEP */


### PR DESCRIPTION
## Description

This PR is an extract from https://github.com/Mbed-TLS/mbedtls/pull/9237 in order to split different topics in different PRs. Here's what this one addresses:

- Reduce server's ping time for messages from 50ms to 1us because otherwise tests suites will take forever to execute.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [ ] **changelog** not required
- [ ] **3.6 backport** not required
- [ ] **2.28 backport** not required
- [ ] **tests** not required
