### PR TITLE
psasim-server: add function to reset operations slots

### DIFF
--- a/tests/psa-client-server/psasim/src/psa_sim_crypto_server.c
+++ b/tests/psa-client-server/psasim/src/psa_sim_crypto_server.c
@@ -2314,3 +2314,8 @@ psa_status_t psa_crypto_call(psa_msg_t msg)
 
     return ok ? PSA_SUCCESS : PSA_ERROR_GENERIC_ERROR;
 }
+
+void psa_crypto_close(void)
+{
+    psa_sim_serialize_reset();
+}

--- a/tests/psa-client-server/psasim/src/psa_sim_generate.pl
+++ b/tests/psa-client-server/psasim/src/psa_sim_generate.pl
@@ -244,6 +244,16 @@ EOF
 }
 EOF
 
+    # Finally, add psa_crypto_close()
+
+    print $fh <<EOF;
+
+void psa_crypto_close(void)
+{
+    psa_sim_serialize_reset();
+}
+EOF
+
     close($fh);
 }
 

--- a/tests/psa-client-server/psasim/src/psa_sim_serialise.c
+++ b/tests/psa-client-server/psasim/src/psa_sim_serialise.c
@@ -711,4 +711,6 @@ void psa_sim_serialize_reset(void)
 {
     memset(hash_operation_handles, 0, sizeof(hash_operation_handles));
     memset(hash_operations, 0, sizeof(hash_operations));
+    memset(aead_operation_handles, 0, sizeof(aead_operation_handles));
+    memset(aead_operations, 0, sizeof(aead_operations));
 }

--- a/tests/psa-client-server/psasim/src/psa_sim_serialise.c
+++ b/tests/psa-client-server/psasim/src/psa_sim_serialise.c
@@ -706,3 +706,9 @@ int psasim_deserialise_mbedtls_svc_key_id_t(uint8_t **pos,
 
     return 1;
 }
+
+void psa_sim_serialize_reset(void)
+{
+    memset(hash_operation_handles, 0, sizeof(hash_operation_handles));
+    memset(hash_operations, 0, sizeof(hash_operations));
+}

--- a/tests/psa-client-server/psasim/src/psa_sim_serialise.h
+++ b/tests/psa-client-server/psasim/src/psa_sim_serialise.h
@@ -54,6 +54,10 @@
  * don't contain pointers.
  */
 
+/** Reset all operation slots.
+ *
+ * Should be called when all clients have disconnected.
+ */
 void psa_sim_serialize_reset(void);
 
 /** Return how much buffer space is needed by \c psasim_serialise_begin().

--- a/tests/psa-client-server/psasim/src/psa_sim_serialise.h
+++ b/tests/psa-client-server/psasim/src/psa_sim_serialise.h
@@ -54,6 +54,8 @@
  * don't contain pointers.
  */
 
+void psa_sim_serialize_reset(void);
+
 /** Return how much buffer space is needed by \c psasim_serialise_begin().
  *
  * \return                   The number of bytes needed in the buffer for

--- a/tests/psa-client-server/psasim/src/server.c
+++ b/tests/psa-client-server/psasim/src/server.c
@@ -54,6 +54,7 @@ int psa_server_main(int argc, char *argv[])
     int client_disconnected = 0;
     char mbedtls_version[18];
     extern psa_status_t psa_crypto_call(psa_msg_t msg);
+    extern psa_status_t psa_crypto_close(void);
 
     mbedtls_version_get_string_full(mbedtls_version);
     SERVER_PRINT("%s", mbedtls_version);
@@ -81,6 +82,7 @@ int psa_server_main(int argc, char *argv[])
                         SERVER_PRINT("Got a disconnection message");
                         ret = PSA_SUCCESS;
                         client_disconnected = 1;
+                        psa_crypto_close();
                         break;
                     default:
                         SERVER_PRINT("Got an IPC call of type %d", msg.type);


### PR DESCRIPTION
## Description

This PR is an extract from https://github.com/Mbed-TLS/mbedtls/pull/9237 in order to split different topics in different PRs.

When the client disconnects the server can clean operations slots so that upcoming clients will not hit the maximum slot limit (at least it's very unlikely to happen for normal clients).

## PR checklist

- [ ] **changelog** not required
- [ ] **3.6 backport**  not required
- [ ] **2.28 backport**  not required
- [ ] **tests**  required
