### PR TITLE
Fix typo in platform_util.c

### DIFF
--- a/tf-psa-crypto/drivers/builtin/src/platform_util.c
+++ b/tf-psa-crypto/drivers/builtin/src/platform_util.c
@@ -149,7 +149,7 @@ void mbedtls_zeroize_and_free(void *buf, size_t len)
 #include <time.h>
 #if !defined(_WIN32) && (defined(unix) || \
     defined(__unix) || defined(__unix__) || (defined(__APPLE__) && \
-    defined(__MACH__)) || defined__midipix__)
+    defined(__MACH__)) || defined(__midipix__))
 #include <unistd.h>
 #endif /* !_WIN32 && (unix || __unix || __unix__ ||
         * (__APPLE__ && __MACH__) || __midipix__) */


### PR DESCRIPTION
## Description

There is a typo in the platform_util.c file where a parenthesis lack. This bug causes the build to fail when `MBEDTLS_HAVE_TIME_DATE` is defined and an non win32 platform is used.

## PR checklist

- [ ] **changelog** not required?
- [ ] **3.6 backport**  done -> #9388 
- [ ] **2.28 backport**  not required - issue not present
- [ ] **tests**  not required