### PR TITLE
Fix some typo for include folder

### DIFF
--- a/include/mbedtls/config_adjust_legacy_crypto.h
+++ b/include/mbedtls/config_adjust_legacy_crypto.h
@@ -4,7 +4,7 @@
  *
  * This is an internal header. Do not include it directly.
  *
- * Automatically enable certain dependencies. Generally, MBEDLTS_xxx
+ * Automatically enable certain dependencies. Generally, MBEDTLS_xxx
  * configurations need to be explicitly enabled by the user: enabling
  * MBEDTLS_xxx_A but not MBEDTLS_xxx_B when A requires B results in a
  * compilation error. However, we do automatically enable certain options
@@ -433,7 +433,7 @@
 #define MBEDTLS_PSA_UTIL_HAVE_ECDSA
 #endif
 
-/* Some internal helpers to determine which keys are availble. */
+/* Some internal helpers to determine which keys are available. */
 #if (!defined(MBEDTLS_USE_PSA_CRYPTO) && defined(MBEDTLS_AES_C)) || \
     (defined(MBEDTLS_USE_PSA_CRYPTO) && defined(PSA_WANT_KEY_TYPE_AES))
 #define MBEDTLS_SSL_HAVE_AES
@@ -447,7 +447,7 @@
 #define MBEDTLS_SSL_HAVE_CAMELLIA
 #endif
 
-/* Some internal helpers to determine which operation modes are availble. */
+/* Some internal helpers to determine which operation modes are available. */
 #if (!defined(MBEDTLS_USE_PSA_CRYPTO) && defined(MBEDTLS_CIPHER_MODE_CBC)) || \
     (defined(MBEDTLS_USE_PSA_CRYPTO) && defined(PSA_WANT_ALG_CBC_NO_PADDING))
 #define MBEDTLS_SSL_HAVE_CBC

--- a/include/mbedtls/config_adjust_ssl.h
+++ b/include/mbedtls/config_adjust_ssl.h
@@ -4,7 +4,7 @@
  *
  * This is an internal header. Do not include it directly.
  *
- * Automatically enable certain dependencies. Generally, MBEDLTS_xxx
+ * Automatically enable certain dependencies. Generally, MBEDTLS_xxx
  * configurations need to be explicitly enabled by the user: enabling
  * MBEDTLS_xxx_A but not MBEDTLS_xxx_B when A requires B results in a
  * compilation error. However, we do automatically enable certain options

--- a/include/mbedtls/config_adjust_x509.h
+++ b/include/mbedtls/config_adjust_x509.h
@@ -4,7 +4,7 @@
  *
  * This is an internal header. Do not include it directly.
  *
- * Automatically enable certain dependencies. Generally, MBEDLTS_xxx
+ * Automatically enable certain dependencies. Generally, MBEDTLS_xxx
  * configurations need to be explicitly enabled by the user: enabling
  * MBEDTLS_xxx_A but not MBEDTLS_xxx_B when A requires B results in a
  * compilation error. However, we do automatically enable certain options

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -1037,7 +1037,7 @@
  *           MBEDTLS_ECP_DP_SECP256R1_ENABLED
  *
  * \warning If SHA-256 is provided only by a PSA driver, you must call
- * psa_crypto_init() before the first hanshake (even if
+ * psa_crypto_init() before the first handshake (even if
  * MBEDTLS_USE_PSA_CRYPTO is disabled).
  *
  * This enables the following ciphersuites (if other requisites are
@@ -2544,7 +2544,7 @@
  * The CTR_DRBG generator uses AES-256 by default.
  * To use AES-128 instead, enable \c MBEDTLS_CTR_DRBG_USE_128_BIT_KEY above.
  *
- * AES support can either be achived through builtin (MBEDTLS_AES_C) or PSA.
+ * AES support can either be achieved through builtin (MBEDTLS_AES_C) or PSA.
  * Builtin is the default option when MBEDTLS_AES_C is defined otherwise PSA
  * is used.
  *

--- a/programs/test/metatest.c
+++ b/programs/test/metatest.c
@@ -381,7 +381,7 @@ typedef struct {
     void (*entry_point)(const char *name);
 } metatest_t;
 
-/* The list of availble meta-tests. Remember to register new functions here!
+/* The list of available meta-tests. Remember to register new functions here!
  *
  * Note that we always compile all the functions, so that `metatest --list`
  * will always list all the available meta-tests.

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -1814,7 +1814,7 @@ run_test_psa_force_curve() {
 # a maximum fragment length.
 #  first argument ($1) is MFL for SSL client
 #  second argument ($2) is memory usage for SSL client with default MFL (16k)
-run_test_memory_after_hanshake_with_mfl()
+run_test_memory_after_handshake_with_mfl()
 {
     # The test passes if the difference is around 2*(16k-MFL)
     MEMORY_USAGE_LIMIT="$(( $2 - ( 2 * ( 16384 - $1 )) ))"
@@ -1834,7 +1834,7 @@ run_test_memory_after_hanshake_with_mfl()
 
 # Test that the server's memory usage after a handshake is reduced when a client specifies
 # different values of Maximum Fragment Length: default (16k), 4k, 2k, 1k and 512 bytes
-run_tests_memory_after_hanshake()
+run_tests_memory_after_handshake()
 {
     # all tests in this sequence requires the same configuration (see requires_config_enabled())
     SKIP_THIS_TESTS="$SKIP_NEXT"
@@ -1850,16 +1850,16 @@ run_tests_memory_after_hanshake()
                 -F "handshake_memory_get MEMORY_USAGE_MFL_16K"
 
     SKIP_NEXT="$SKIP_THIS_TESTS"
-    run_test_memory_after_hanshake_with_mfl 4096 "$MEMORY_USAGE_MFL_16K"
+    run_test_memory_after_handshake_with_mfl 4096 "$MEMORY_USAGE_MFL_16K"
 
     SKIP_NEXT="$SKIP_THIS_TESTS"
-    run_test_memory_after_hanshake_with_mfl 2048 "$MEMORY_USAGE_MFL_16K"
+    run_test_memory_after_handshake_with_mfl 2048 "$MEMORY_USAGE_MFL_16K"
 
     SKIP_NEXT="$SKIP_THIS_TESTS"
-    run_test_memory_after_hanshake_with_mfl 1024 "$MEMORY_USAGE_MFL_16K"
+    run_test_memory_after_handshake_with_mfl 1024 "$MEMORY_USAGE_MFL_16K"
 
     SKIP_NEXT="$SKIP_THIS_TESTS"
-    run_test_memory_after_hanshake_with_mfl 512 "$MEMORY_USAGE_MFL_16K"
+    run_test_memory_after_handshake_with_mfl 512 "$MEMORY_USAGE_MFL_16K"
 }
 
 cleanup() {
@@ -5549,7 +5549,7 @@ run_test    "Renegotiation: openssl server, client-initiated" \
             -c "client hello, adding renegotiation extension" \
             -c "found renegotiation extension" \
             -c "=> renegotiate" \
-            -C "ssl_hanshake() returned" \
+            -C "ssl_handshake() returned" \
             -C "error" \
             -c "HTTP/1.0 200 [Oo][Kk]"
 
@@ -5563,7 +5563,7 @@ run_test    "Renegotiation: gnutls server strict, client-initiated" \
             -c "client hello, adding renegotiation extension" \
             -c "found renegotiation extension" \
             -c "=> renegotiate" \
-            -C "ssl_hanshake() returned" \
+            -C "ssl_handshake() returned" \
             -C "error" \
             -c "HTTP/1.0 200 [Oo][Kk]"
 
@@ -5607,7 +5607,7 @@ run_test    "Renegotiation: gnutls server unsafe, client-inititated legacy" \
             -c "client hello, adding renegotiation extension" \
             -C "found renegotiation extension" \
             -c "=> renegotiate" \
-            -C "ssl_hanshake() returned" \
+            -C "ssl_handshake() returned" \
             -C "error" \
             -c "HTTP/1.0 200 [Oo][Kk]"
 
@@ -14143,7 +14143,7 @@ requires_config_enabled MBEDTLS_MEMORY_DEBUG
 requires_config_enabled MBEDTLS_MEMORY_BUFFER_ALLOC_C
 requires_config_enabled MBEDTLS_SSL_MAX_FRAGMENT_LENGTH
 requires_max_content_len 16384
-run_tests_memory_after_hanshake
+run_tests_memory_after_handshake
 
 if [ "$LIST_TESTS" -eq 0 ]; then
 

--- a/tf-psa-crypto/drivers/builtin/include/mbedtls/ecdh.h
+++ b/tf-psa-crypto/drivers/builtin/include/mbedtls/ecdh.h
@@ -325,7 +325,7 @@ int mbedtls_ecdh_read_params(mbedtls_ecdh_context *ctx,
  * \brief           This function sets up an ECDH context from an EC key.
  *
  *                  It is used by clients and servers in place of the
- *                  ServerKeyEchange for static ECDH, and imports ECDH
+ *                  ServerKeyExchange for static ECDH, and imports ECDH
  *                  parameters from the EC key information of a certificate.
  *
  * \see             ecp.h

--- a/tf-psa-crypto/drivers/builtin/include/mbedtls/ecp.h
+++ b/tf-psa-crypto/drivers/builtin/include/mbedtls/ecp.h
@@ -207,7 +207,7 @@ mbedtls_ecp_point;
  * range of <code>0..2^(2*pbits)-1</code>, and transforms it in-place to an integer
  * which is congruent mod \p P to the given MPI, and is close enough to \p pbits
  * in size, so that it may be efficiently brought in the 0..P-1 range by a few
- * additions or subtractions. Therefore, it is only an approximative modular
+ * additions or subtractions. Therefore, it is only an approximate modular
  * reduction. It must return 0 on success and non-zero on failure.
  *
  * \note        Alternative implementations of the ECP module must obey the


### PR DESCRIPTION
## Description

Fix some typo in Include folder. 
Because the user will refer to the function description in Include folder,
it's better to fix the typo.



## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required
- [x] **3.6 backport** done -> #9386
- [x] **2.28 backport** done -> #9387 
- [x] **tests** not required
