### PR TITLE
Fix incorrect handling of T61 and other strings

### DIFF
--- a/library/x509.c
+++ b/library/x509.c
@@ -840,9 +840,7 @@ int mbedtls_x509_dn_gets(char *buf, size_t size, const mbedtls_x509_name *dn)
             MBEDTLS_X509_SAFE_SNPRINTF;
         }
 
-        print_hexstring = (name->val.tag != MBEDTLS_ASN1_UTF8_STRING) &&
-                          (name->val.tag != MBEDTLS_ASN1_PRINTABLE_STRING) &&
-                          (name->val.tag != MBEDTLS_ASN1_IA5_STRING);
+        print_hexstring = !MBEDTLS_ASN1_IS_STRING_TAG(name->val.tag);
 
         if ((ret = mbedtls_oid_get_attr_short_name(&name->oid, &short_name)) == 0) {
             ret = mbedtls_snprintf(p, n, "%s=", short_name);


### PR DESCRIPTION
These should be returned as strings by `mbedtls_x509_dn_gets()` rather than being returned in hexstring form.



## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [ ] **changelog** provided, or not required
- [ ] **3.6 backport** done, or not required
- [x] **2.28 backport** not required - problem doesn't exist in 2.28
- [ ] **tests** provided, or not required