### PR TITLE
Disable allow_abbrev from Python scripts using argparse

### DIFF
--- a/scripts/abi_check.py
+++ b/scripts/abi_check.py
@@ -549,7 +549,8 @@ class AbiChecker:
 def run_main():
     try:
         parser = argparse.ArgumentParser(
-            description=__doc__
+            description=__doc__,
+            allow_abbrev=False
         )
         parser.add_argument(
             "-v", "--verbose", action="store_true",

--- a/scripts/assemble_changelog.py
+++ b/scripts/assemble_changelog.py
@@ -499,7 +499,8 @@ def set_defaults(options):
 
 def main():
     """Command line entry point."""
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     allow_abbrev=False)
     parser.add_argument('--dir', '-d', metavar='DIR',
                         default='ChangeLog.d',
                         help='Directory to read entries from'

--- a/scripts/code_size_compare.py
+++ b/scripts/code_size_compare.py
@@ -857,7 +857,8 @@ class CodeSizeComparison:
         self.gen_code_size_comparison()
 
 def main():
-    parser = argparse.ArgumentParser(description=(__doc__))
+    parser = argparse.ArgumentParser(description=(__doc__),
+                                     allow_abbrev=False)
     group_required = parser.add_argument_group(
         'required arguments',
         'required arguments to parse for running ' + os.path.basename(__file__))

--- a/scripts/code_style.py
+++ b/scripts/code_style.py
@@ -224,7 +224,7 @@ def main() -> int:
         print("Note: The only supported version is " +
               UNCRUSTIFY_SUPPORTED_VERSION)
 
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(allow_abbrev=False)
     parser.add_argument('-f', '--fix', action='store_true',
                         help=('modify source files to fix the code style '
                               '(default: print diff, do not modify files)'))

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -485,8 +485,9 @@ if __name__ == '__main__':
     def main():
         """Command line mbedtls_config.h manipulation tool."""
         parser = argparse.ArgumentParser(description="""
-        Mbed TLS configuration file manipulation tool.
-        """)
+                                        Mbed TLS configuration file manipulation tool.
+                                        """,
+                                        allow_abbrev=False)
         parser.add_argument('--file', '-f',
                             help="""File to read (and modify if requested).
                             Default: {}.

--- a/scripts/generate_driver_wrappers.py
+++ b/scripts/generate_driver_wrappers.py
@@ -167,7 +167,7 @@ def main() -> int:
     """
     def_arg_project_root = build_tree.guess_project_root()
 
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(allow_abbrev=False)
     parser.add_argument('--project-root', default=def_arg_project_root,
                         help='root directory of repo source code')
     parser.add_argument('--template-dir',

--- a/scripts/generate_ssl_debug_helpers.py
+++ b/scripts/generate_ssl_debug_helpers.py
@@ -400,7 +400,7 @@ def main():
     """
     Command line entry
     """
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(allow_abbrev=False)
     parser.add_argument('--mbedtls-root', nargs='?', default=None,
                         help='root directory of mbedtls source code')
     parser.add_argument('output_directory', nargs='?',

--- a/scripts/min_requirements.py
+++ b/scripts/min_requirements.py
@@ -94,7 +94,8 @@ DEFAULT_REQUIREMENTS_FILE = 'ci.requirements.txt'
 
 def main() -> None:
     """Command line entry point."""
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     allow_abbrev=False)
     parser.add_argument('--no-act', '-n',
                         action='store_true',
                         help="Don't act, just print what will be done")

--- a/tests/scripts/analyze_outcomes.py
+++ b/tests/scripts/analyze_outcomes.py
@@ -664,7 +664,8 @@ def main():
     main_results = Results()
 
     try:
-        parser = argparse.ArgumentParser(description=__doc__)
+        parser = argparse.ArgumentParser(description=__doc__,
+                                         allow_abbrev=False)
         parser.add_argument('outcomes', metavar='OUTCOMES.CSV',
                             help='Outcome file to analyze')
         parser.add_argument('specified_tasks', default='all', nargs='?',

--- a/tests/scripts/audit-validity-dates.py
+++ b/tests/scripts/audit-validity-dates.py
@@ -385,7 +385,8 @@ def main():
     """
     Perform argument parsing.
     """
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     allow_abbrev=False)
 
     parser.add_argument('-a', '--all',
                         action='store_true',

--- a/tests/scripts/check_files.py
+++ b/tests/scripts/check_files.py
@@ -531,7 +531,8 @@ class IntegrityChecker:
 
 
 def run_main():
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     allow_abbrev=False)
     parser.add_argument(
         "-l", "--log_file", type=str, help="path to optional output log",
     )

--- a/tests/scripts/check_names.py
+++ b/tests/scripts/check_names.py
@@ -933,7 +933,8 @@ def main():
             "This script confirms that the naming of all symbols and identifiers "
             "in Mbed TLS are consistent with the house style and are also "
             "self-consistent.\n\n"
-            "Expected to be run from the Mbed TLS root directory.")
+            "Expected to be run from the Mbed TLS root directory."),
+        allow_abbrev=False
     )
     parser.add_argument(
         "-v", "--verbose",

--- a/tests/scripts/check_test_cases.py
+++ b/tests/scripts/check_test_cases.py
@@ -209,7 +209,8 @@ class DescriptionChecker(TestDescriptionExplorer):
         seen[description] = line_number
 
 def main():
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     allow_abbrev=False)
     parser.add_argument('--list-all',
                         action='store_true',
                         help='List all test cases, without doing checks')

--- a/tests/scripts/depends.py
+++ b/tests/scripts/depends.py
@@ -504,7 +504,8 @@ def main():
             "Example usage:\n"
             r"./tests/scripts/depends.py \!MBEDTLS_SHA1_C MBEDTLS_SHA256_C""\n"
             "./tests/scripts/depends.py MBEDTLS_AES_C hashes\n"
-            "./tests/scripts/depends.py cipher_id cipher_chaining\n")
+            "./tests/scripts/depends.py cipher_id cipher_chaining\n",
+            allow_abbrev=False)
         parser.add_argument('--color', metavar='WHEN',
                             help='Colorize the output (always/auto/never)',
                             choices=['always', 'auto', 'never'], default='auto')

--- a/tests/scripts/generate_server9_bad_saltlen.py
+++ b/tests/scripts/generate_server9_bad_saltlen.py
@@ -47,7 +47,7 @@ def build_argparser(parser):
 
 
 def main():
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(allow_abbrev=False)
     build_argparser(parser)
     args = parser.parse_args()
 

--- a/tests/scripts/generate_tls13_compat_tests.py
+++ b/tests/scripts/generate_tls13_compat_tests.py
@@ -554,7 +554,7 @@ def main():
     """
     Main function of this program
     """
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(allow_abbrev=False)
 
     parser.add_argument('-o', '--output', nargs='?',
                         default=None, help='Output file path if `-a` was set')

--- a/tests/scripts/list_internal_identifiers.py
+++ b/tests/scripts/list_internal_identifiers.py
@@ -26,7 +26,8 @@ def main():
         description=(
             "This script writes a list of parsed identifiers in internal "
             "headers to \"identifiers\". This is useful for generating a list "
-            "of names to exclude from API/ABI compatibility checking. "))
+            "of names to exclude from API/ABI compatibility checking. "),
+        allow_abbrev=False)
 
     parser.parse_args()
 

--- a/tests/scripts/psa_collect_statuses.py
+++ b/tests/scripts/psa_collect_statuses.py
@@ -100,7 +100,8 @@ def collect_status_logs(options):
     return data
 
 def main():
-    parser = argparse.ArgumentParser(description=globals()['__doc__'])
+    parser = argparse.ArgumentParser(description=globals()['__doc__'],
+                                     allow_abbrev=False)
     parser.add_argument('--clean-after',
                         action='store_true',
                         help='Run "make clean" after rebuilding')

--- a/tests/scripts/run_demos.py
+++ b/tests/scripts/run_demos.py
@@ -51,7 +51,8 @@ def run_all_demos(quiet=False):
     return run_demos(all_demos, quiet=quiet)
 
 def main():
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     allow_abbrev=False)
     parser.add_argument('--quiet', '-q',
                         action='store_true',
                         help="suppress the output of demos")

--- a/tests/scripts/test_config_script.py
+++ b/tests/scripts/test_config_script.py
@@ -154,7 +154,8 @@ def run_all(options):
 def main():
     """Command line entry point."""
     parser = argparse.ArgumentParser(description=__doc__,
-                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+                                     formatter_class=argparse.RawDescriptionHelpFormatter,
+                                     allow_abbrev=False)
     parser.add_argument('-d', metavar='DIR',
                         dest='output_directory', required=True,
                         help="""Output directory.""")

--- a/tests/scripts/test_psa_compliance.py
+++ b/tests/scripts/test_psa_compliance.py
@@ -149,7 +149,7 @@ if __name__ == '__main__':
     BUILD_DIR = 'out_of_source_build'
 
     # pylint: disable=invalid-name
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(allow_abbrev=False)
     parser.add_argument('--build-dir', nargs=1,
                         help='path to Mbed TLS / TF-PSA-Crypto build directory')
     args = parser.parse_args()

--- a/tests/scripts/test_psa_constant_names.py
+++ b/tests/scripts/test_psa_constant_names.py
@@ -159,7 +159,8 @@ HEADERS = ['psa/crypto.h', 'psa/crypto_extra.h', 'psa/crypto_values.h']
 TEST_SUITES = ['tests/suites/test_suite_psa_crypto_metadata.data']
 
 def main():
-    parser = argparse.ArgumentParser(description=globals()['__doc__'])
+    parser = argparse.ArgumentParser(description=globals()['__doc__'],
+                                     allow_abbrev=False)
     parser.add_argument('--include', '-I',
                         action='append', default=['tf-psa-crypto/include', 'include'],
                         help='Directory for header files')

--- a/tests/scripts/translate_ciphers.py
+++ b/tests/scripts/translate_ciphers.py
@@ -173,7 +173,7 @@ def main(target, names):
     print(format_ciphersuite_names(target, names))
 
 if __name__ == "__main__":
-    PARSER = argparse.ArgumentParser()
+    PARSER = argparse.ArgumentParser(allow_abbrev=False)
     PARSER.add_argument('target', metavar='TARGET', choices=['o', 'g', 'm'])
     PARSER.add_argument('names', metavar='NAMES', nargs='+')
     ARGS = PARSER.parse_args()


### PR DESCRIPTION
## Description

Python's argparse library, by default, allows shortening of command line arguments. This can introduce silent failures when shortened commands are used and another command is added to the script which uses that name.

This change sets ArgumentParser parameter allow_abbrev to False.

## PR checklist

- [x] **changelog** not required
- [x] **3.6 backport** required
- [x] **2.28 backport** required
- [x] **tests** not required

