### PR TITLE
[Backport 2.28] Disable allow_abbrev from Python scripts using argparse

### DIFF
--- a/scripts/abi_check.py
+++ b/scripts/abi_check.py
@@ -536,7 +536,8 @@ class AbiChecker:
 def run_main():
     try:
         parser = argparse.ArgumentParser(
-            description=__doc__
+            description=__doc__,
+            allow_abbrev=False
         )
         parser.add_argument(
             "-v", "--verbose", action="store_true",

--- a/scripts/assemble_changelog.py
+++ b/scripts/assemble_changelog.py
@@ -498,7 +498,8 @@ def set_defaults(options):
 
 def main():
     """Command line entry point."""
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     allow_abbrev=False)
     parser.add_argument('--dir', '-d', metavar='DIR',
                         default='ChangeLog.d',
                         help='Directory to read entries from'

--- a/scripts/code_style.py
+++ b/scripts/code_style.py
@@ -177,7 +177,7 @@ def main() -> int:
         print("Note: The only supported version is " +
               UNCRUSTIFY_SUPPORTED_VERSION)
 
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(allow_abbrev=False)
     parser.add_argument('-f', '--fix', action='store_true',
                         help=('modify source files to fix the code style '
                               '(default: print diff, do not modify files)'))

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -478,8 +478,9 @@ if __name__ == '__main__':
     def main():
         """Command line config.h manipulation tool."""
         parser = argparse.ArgumentParser(description="""
-        Mbed TLS configuration file manipulation tool.
-        """)
+                                         Mbed TLS configuration file manipulation tool.
+                                         """,
+                                         allow_abbrev=False)
         parser.add_argument('--file', '-f',
                             help="""File to read (and modify if requested).
                             Default: {}.

--- a/scripts/mbedtls_dev/test_data_generation.py
+++ b/scripts/mbedtls_dev/test_data_generation.py
@@ -167,7 +167,8 @@ class TestGenerator:
 
 def main(args, description: str, generator_class: Type[TestGenerator] = TestGenerator):
     """Command line entry point."""
-    parser = argparse.ArgumentParser(description=description)
+    parser = argparse.ArgumentParser(description=description,
+                                     allow_abbrev=False)
     parser.add_argument('--list', action='store_true',
                         help='List available targets and exit')
     parser.add_argument('targets', nargs='*', metavar='TARGET',

--- a/scripts/min_requirements.py
+++ b/scripts/min_requirements.py
@@ -92,7 +92,8 @@ DEFAULT_REQUIREMENTS_FILE = 'ci.requirements.txt'
 
 def main() -> None:
     """Command line entry point."""
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     allow_abbrev=False)
     parser.add_argument('--no-act', '-n',
                         action='store_true',
                         help="Don't act, just print what will be done")

--- a/tests/scripts/analyze_outcomes.py
+++ b/tests/scripts/analyze_outcomes.py
@@ -133,7 +133,8 @@ TASKS = {
 
 def main():
     try:
-        parser = argparse.ArgumentParser(description=__doc__)
+        parser = argparse.ArgumentParser(description=__doc__,
+                                         allow_abbrev=False)
         parser.add_argument('outcomes', metavar='OUTCOMES.CSV',
                             help='Outcome file to analyze')
         parser.add_argument('task', default='all', nargs='?',

--- a/tests/scripts/check_files.py
+++ b/tests/scripts/check_files.py
@@ -502,7 +502,8 @@ class IntegrityChecker:
 
 
 def run_main():
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     allow_abbrev=False)
     parser.add_argument(
         "-l", "--log_file", type=str, help="path to optional output log",
     )

--- a/tests/scripts/check_names.py
+++ b/tests/scripts/check_names.py
@@ -918,7 +918,8 @@ def main():
             "This script confirms that the naming of all symbols and identifiers "
             "in Mbed TLS are consistent with the house style and are also "
             "self-consistent.\n\n"
-            "Expected to be run from the Mbed TLS root directory.")
+            "Expected to be run from the Mbed TLS root directory."),
+        allow_abbrev=False
     )
     parser.add_argument(
         "-v", "--verbose",

--- a/tests/scripts/check_test_cases.py
+++ b/tests/scripts/check_test_cases.py
@@ -185,7 +185,8 @@ class DescriptionChecker(TestDescriptionExplorer):
         seen[description] = line_number
 
 def main():
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     allow_abbrev=False)
     parser.add_argument('--list-all',
                         action='store_true',
                         help='List all test cases, without doing checks')

--- a/tests/scripts/depends.py
+++ b/tests/scripts/depends.py
@@ -510,7 +510,8 @@ def main():
             "Example usage:\n"
             r"./tests/scripts/depends.py \!MBEDTLS_SHA1_C MBEDTLS_SHA256_C""\n"
             "./tests/scripts/depends.py MBEDTLS_AES_C hashes\n"
-            "./tests/scripts/depends.py cipher_id cipher_chaining\n")
+            "./tests/scripts/depends.py cipher_id cipher_chaining\n",
+            allow_abbrev=False)
         parser.add_argument('--color', metavar='WHEN',
                             help='Colorize the output (always/auto/never)',
                             choices=['always', 'auto', 'never'], default='auto')

--- a/tests/scripts/generate_psa_wrappers.py
+++ b/tests/scripts/generate_psa_wrappers.py
@@ -232,7 +232,8 @@ DEFAULT_C_OUTPUT_FILE_NAME = 'tests/src/psa_test_wrappers.c'
 DEFAULT_H_OUTPUT_FILE_NAME = 'tests/include/test/psa_test_wrappers.h'
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description=globals()['__doc__'])
+    parser = argparse.ArgumentParser(description=globals()['__doc__'],
+                                     allow_abbrev=False)
     parser.add_argument('--log',
                         help='Stream to log to (default: no logging code)')
     parser.add_argument('--output-c',

--- a/tests/scripts/generate_server9_bad_saltlen.py
+++ b/tests/scripts/generate_server9_bad_saltlen.py
@@ -47,7 +47,7 @@ def build_argparser(parser):
 
 
 def main():
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(allow_abbrev=False)
     build_argparser(parser)
     args = parser.parse_args()
 

--- a/tests/scripts/generate_test_code.py
+++ b/tests/scripts/generate_test_code.py
@@ -1191,7 +1191,8 @@ def main():
     :return:
     """
     parser = argparse.ArgumentParser(
-        description='Dynamically generate test suite code.')
+        description='Dynamically generate test suite code.',
+        allow_abbrev=False)
 
     parser.add_argument("-f", "--functions-file",
                         dest="funcs_file",

--- a/tests/scripts/list_internal_identifiers.py
+++ b/tests/scripts/list_internal_identifiers.py
@@ -26,7 +26,8 @@ def main():
         description=(
             "This script writes a list of parsed identifiers in internal "
             "headers to \"identifiers\". This is useful for generating a list "
-            "of names to exclude from API/ABI compatibility checking. "))
+            "of names to exclude from API/ABI compatibility checking. "),
+        allow_abbrev=False)
 
     parser.parse_args()
 

--- a/tests/scripts/psa_collect_statuses.py
+++ b/tests/scripts/psa_collect_statuses.py
@@ -100,7 +100,8 @@ def collect_status_logs(options):
     return data
 
 def main():
-    parser = argparse.ArgumentParser(description=globals()['__doc__'])
+    parser = argparse.ArgumentParser(description=globals()['__doc__'],
+                                     allow_abbrev=False)
     parser.add_argument('--clean-after',
                         action='store_true',
                         help='Run "make clean" after rebuilding')

--- a/tests/scripts/run_demos.py
+++ b/tests/scripts/run_demos.py
@@ -51,7 +51,8 @@ def run_all_demos(quiet=False):
     return run_demos(all_demos, quiet=quiet)
 
 def main():
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     allow_abbrev=False)
     parser.add_argument('--quiet', '-q',
                         action='store_true',
                         help="suppress the output of demos")

--- a/tests/scripts/test_config_script.py
+++ b/tests/scripts/test_config_script.py
@@ -154,7 +154,8 @@ def run_all(options):
 def main():
     """Command line entry point."""
     parser = argparse.ArgumentParser(description=__doc__,
-                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+                                     formatter_class=argparse.RawDescriptionHelpFormatter,
+                                     allow_abbrev=False)
     parser.add_argument('-d', metavar='DIR',
                         dest='output_directory', required=True,
                         help="""Output directory.""")

--- a/tests/scripts/test_psa_constant_names.py
+++ b/tests/scripts/test_psa_constant_names.py
@@ -159,7 +159,8 @@ HEADERS = ['psa/crypto.h', 'psa/crypto_extra.h', 'psa/crypto_values.h']
 TEST_SUITES = ['tests/suites/test_suite_psa_crypto_metadata.data']
 
 def main():
-    parser = argparse.ArgumentParser(description=globals()['__doc__'])
+    parser = argparse.ArgumentParser(description=globals()['__doc__'],
+                                     allow_abbrev=False)
     parser.add_argument('--include', '-I',
                         action='append', default=['include'],
                         help='Directory for header files')


### PR DESCRIPTION
## Description

Backport of https://github.com/Mbed-TLS/mbedtls/pull/9294

## PR checklist

- [x] **changelog** not required
- [x] **3.6 backport** not required
- [x] **2.28 backport** not required
- [x] **tests** not required

