### PR TITLE
psa_util.c included in builds without PSA, which can break the build

### DIFF
--- a/ChangeLog.d/psa_util_in_builds_without_psa.txt
+++ b/ChangeLog.d/psa_util_in_builds_without_psa.txt
@@ -1,0 +1,5 @@
+Bugfix
+   * When MBEDTLS_PSA_CRYPTO_C was disabled and MBEDTLS_ECDSA_C enabled,
+     some code was defining 0-size arrays, resulting in compilation errors.
+     Fixed by disabling the offending code in configurations without PSA
+     Crypto, where it never worked. Fixes #9311.


### PR DESCRIPTION
Introduced max size/bytes macros in psa_util.c. Prevents 0-size array compiler warning in psa-util.c when MBEDTLS_ECDSA_C is enabled but MBEDTLS_PSA_CRYPTO_C is disabled. Fixes #9311 

## PR checklist

- [x] **changelog** provided
- [x] **3.6 backport** provided, see #9463
- [x] **2.28 backport** not required, feature doesn't exist
- [x] **tests** not required because we removed buggy functions in configurations that made them buggy. See also #9317