### PR TITLE
psasim: some improvements to the core

### DIFF
--- a/tests/psa-client-server/psasim/src/psa_ff_server.c
+++ b/tests/psa-client-server/psasim/src/psa_ff_server.c
@@ -26,8 +26,6 @@
 #define MAX_CLIENTS 128
 #define MAX_MESSAGES 32
 
-#define SLEEP_US        1
-
 struct connection {
     uint32_t client;
     void *rhandle;
@@ -104,9 +102,6 @@ psa_signal_t psa_wait(psa_signal_t signal_mask, uint32_t timeout)
     uint32_t requested_version;
     ssize_t len;
     int idx;
-#if !defined(PSASIM_USE_USLEEP)
-    const struct timespec ts_delay = { .tv_sec = 0, .tv_nsec = SLEEP_US * 1000 };
-#endif
 
     if (timeout == PSA_POLL) {
         INFO("psa_wait: Called in polling mode");
@@ -261,11 +256,6 @@ psa_signal_t psa_wait(psa_signal_t signal_mask, uint32_t timeout)
             break;
         } else {
             /* There is no 'select' function in SysV to block on multiple queues, so busy-wait :( */
-#if defined(PSASIM_USE_USLEEP)
-            usleep(SLEEP_US);
-#else /* PSASIM_USE_USLEEP */
-            nanosleep(&ts_delay, NULL);
-#endif /* PSASIM_USE_USLEEP */
         }
     } while (timeout == PSA_BLOCK);
 

--- a/tests/psa-client-server/psasim/src/psa_ff_server.c
+++ b/tests/psa-client-server/psasim/src/psa_ff_server.c
@@ -474,7 +474,7 @@ void psa_write(psa_handle_t msg_handle, uint32_t outvec_idx,
 
     while (sofar < num_bytes) {
         size_t sending = (num_bytes - sofar);
-        if (sending >= MAX_FRAGMENT_SIZE) {
+        if (sending > (MAX_FRAGMENT_SIZE - (sizeof(size_t) * 2))) {
             sending = MAX_FRAGMENT_SIZE - (sizeof(size_t) * 2);
         }
 

--- a/tests/psa-client-server/psasim/src/psa_sim_crypto_client.c
+++ b/tests/psa-client-server/psasim/src/psa_sim_crypto_client.c
@@ -44,7 +44,7 @@ int psa_crypto_call(int function,
     invec.base = in_params;
     invec.len = in_params_len;
 
-    size_t max_receive = 8192;
+    size_t max_receive = 24576;
     uint8_t *receive = malloc(max_receive);
     if (receive == NULL) {
         fprintf(stderr, "FAILED to allocate %u bytes\n", (unsigned) max_receive);
@@ -119,6 +119,11 @@ fail:
 
 void mbedtls_psa_crypto_free(void)
 {
+    /* Do not try to close a connection that was never started.*/
+    if (handle == -1) {
+        return;
+    }
+
     CLIENT_PRINT("Closing handle");
     psa_close(handle);
     handle = -1;

--- a/tests/psa-client-server/psasim/src/psa_sim_crypto_server.c
+++ b/tests/psa-client-server/psasim/src/psa_sim_crypto_server.c
@@ -131,7 +131,7 @@ int psa_aead_abort_wrapper(
 
     ok = psasim_server_serialise_psa_aead_operation_t(
         &rpos, &rremain,
-        operation);
+        operation, 1);
     if (!ok) {
         goto fail;
     }
@@ -375,7 +375,7 @@ int psa_aead_decrypt_setup_wrapper(
 
     ok = psasim_server_serialise_psa_aead_operation_t(
         &rpos, &rremain,
-        operation);
+        operation, 0);
     if (!ok) {
         goto fail;
     }
@@ -619,7 +619,7 @@ int psa_aead_encrypt_setup_wrapper(
 
     ok = psasim_server_serialise_psa_aead_operation_t(
         &rpos, &rremain,
-        operation);
+        operation, 0);
     if (!ok) {
         goto fail;
     }
@@ -736,7 +736,7 @@ int psa_aead_finish_wrapper(
 
     ok = psasim_server_serialise_psa_aead_operation_t(
         &rpos, &rremain,
-        operation);
+        operation, 1);
     if (!ok) {
         goto fail;
     }
@@ -866,7 +866,7 @@ int psa_aead_generate_nonce_wrapper(
 
     ok = psasim_server_serialise_psa_aead_operation_t(
         &rpos, &rremain,
-        operation);
+        operation, 0);
     if (!ok) {
         goto fail;
     }
@@ -977,7 +977,7 @@ int psa_aead_set_lengths_wrapper(
 
     ok = psasim_server_serialise_psa_aead_operation_t(
         &rpos, &rremain,
-        operation);
+        operation, 0);
     if (!ok) {
         goto fail;
     }
@@ -1062,7 +1062,7 @@ int psa_aead_set_nonce_wrapper(
 
     ok = psasim_server_serialise_psa_aead_operation_t(
         &rpos, &rremain,
-        operation);
+        operation, 0);
     if (!ok) {
         goto fail;
     }
@@ -1172,7 +1172,7 @@ int psa_aead_update_wrapper(
 
     ok = psasim_server_serialise_psa_aead_operation_t(
         &rpos, &rremain,
-        operation);
+        operation, 0);
     if (!ok) {
         goto fail;
     }
@@ -1277,7 +1277,7 @@ int psa_aead_update_ad_wrapper(
 
     ok = psasim_server_serialise_psa_aead_operation_t(
         &rpos, &rremain,
-        operation);
+        operation, 0);
     if (!ok) {
         goto fail;
     }
@@ -1387,7 +1387,7 @@ int psa_aead_verify_wrapper(
 
     ok = psasim_server_serialise_psa_aead_operation_t(
         &rpos, &rremain,
-        operation);
+        operation, 0);
     if (!ok) {
         goto fail;
     }
@@ -1760,7 +1760,7 @@ int psa_cipher_abort_wrapper(
 
     ok = psasim_server_serialise_psa_cipher_operation_t(
         &rpos, &rremain,
-        operation);
+        operation, 1);
     if (!ok) {
         goto fail;
     }
@@ -1980,7 +1980,7 @@ int psa_cipher_decrypt_setup_wrapper(
 
     ok = psasim_server_serialise_psa_cipher_operation_t(
         &rpos, &rremain,
-        operation);
+        operation, 0);
     if (!ok) {
         goto fail;
     }
@@ -2200,7 +2200,7 @@ int psa_cipher_encrypt_setup_wrapper(
 
     ok = psasim_server_serialise_psa_cipher_operation_t(
         &rpos, &rremain,
-        operation);
+        operation, 0);
     if (!ok) {
         goto fail;
     }
@@ -2296,7 +2296,7 @@ int psa_cipher_finish_wrapper(
 
     ok = psasim_server_serialise_psa_cipher_operation_t(
         &rpos, &rremain,
-        operation);
+        operation, 1);
     if (!ok) {
         goto fail;
     }
@@ -2410,7 +2410,7 @@ int psa_cipher_generate_iv_wrapper(
 
     ok = psasim_server_serialise_psa_cipher_operation_t(
         &rpos, &rremain,
-        operation);
+        operation, 0);
     if (!ok) {
         goto fail;
     }
@@ -2513,7 +2513,7 @@ int psa_cipher_set_iv_wrapper(
 
     ok = psasim_server_serialise_psa_cipher_operation_t(
         &rpos, &rremain,
-        operation);
+        operation, 0);
     if (!ok) {
         goto fail;
     }
@@ -2623,7 +2623,7 @@ int psa_cipher_update_wrapper(
 
     ok = psasim_server_serialise_psa_cipher_operation_t(
         &rpos, &rremain,
-        operation);
+        operation, 0);
     if (!ok) {
         goto fail;
     }
@@ -3436,7 +3436,7 @@ int psa_hash_abort_wrapper(
 
     ok = psasim_server_serialise_psa_hash_operation_t(
         &rpos, &rremain,
-        operation);
+        operation, 1);
     if (!ok) {
         goto fail;
     }
@@ -3520,7 +3520,7 @@ int psa_hash_clone_wrapper(
 
     ok = psasim_server_serialise_psa_hash_operation_t(
         &rpos, &rremain,
-        target_operation);
+        target_operation, 0);
     if (!ok) {
         goto fail;
     }
@@ -3827,7 +3827,7 @@ int psa_hash_finish_wrapper(
 
     ok = psasim_server_serialise_psa_hash_operation_t(
         &rpos, &rremain,
-        operation);
+        operation, 1);
     if (!ok) {
         goto fail;
     }
@@ -3929,7 +3929,7 @@ int psa_hash_setup_wrapper(
 
     ok = psasim_server_serialise_psa_hash_operation_t(
         &rpos, &rremain,
-        operation);
+        operation, 0);
     if (!ok) {
         goto fail;
     }
@@ -4014,7 +4014,7 @@ int psa_hash_update_wrapper(
 
     ok = psasim_server_serialise_psa_hash_operation_t(
         &rpos, &rremain,
-        operation);
+        operation, 0);
     if (!ok) {
         goto fail;
     }
@@ -4103,7 +4103,7 @@ int psa_hash_verify_wrapper(
 
     ok = psasim_server_serialise_psa_hash_operation_t(
         &rpos, &rremain,
-        operation);
+        operation, 1);
     if (!ok) {
         goto fail;
     }
@@ -4389,7 +4389,7 @@ int psa_key_derivation_abort_wrapper(
 
     ok = psasim_server_serialise_psa_key_derivation_operation_t(
         &rpos, &rremain,
-        operation);
+        operation, 1);
     if (!ok) {
         goto fail;
     }
@@ -4567,7 +4567,7 @@ int psa_key_derivation_input_bytes_wrapper(
 
     ok = psasim_server_serialise_psa_key_derivation_operation_t(
         &rpos, &rremain,
-        operation);
+        operation, 0);
     if (!ok) {
         goto fail;
     }
@@ -4664,7 +4664,7 @@ int psa_key_derivation_input_integer_wrapper(
 
     ok = psasim_server_serialise_psa_key_derivation_operation_t(
         &rpos, &rremain,
-        operation);
+        operation, 0);
     if (!ok) {
         goto fail;
     }
@@ -4757,7 +4757,7 @@ int psa_key_derivation_input_key_wrapper(
 
     ok = psasim_server_serialise_psa_key_derivation_operation_t(
         &rpos, &rremain,
-        operation);
+        operation, 0);
     if (!ok) {
         goto fail;
     }
@@ -4860,7 +4860,7 @@ int psa_key_derivation_key_agreement_wrapper(
 
     ok = psasim_server_serialise_psa_key_derivation_operation_t(
         &rpos, &rremain,
-        operation);
+        operation, 0);
     if (!ok) {
         goto fail;
     }
@@ -4950,7 +4950,7 @@ int psa_key_derivation_output_bytes_wrapper(
 
     ok = psasim_server_serialise_psa_key_derivation_operation_t(
         &rpos, &rremain,
-        operation);
+        operation, 0);
     if (!ok) {
         goto fail;
     }
@@ -5055,7 +5055,7 @@ int psa_key_derivation_output_key_wrapper(
 
     ok = psasim_server_serialise_psa_key_derivation_operation_t(
         &rpos, &rremain,
-        operation);
+        operation, 0);
     if (!ok) {
         goto fail;
     }
@@ -5166,7 +5166,7 @@ int psa_key_derivation_output_key_ext_wrapper(
 
     ok = psasim_server_serialise_psa_key_derivation_operation_t(
         &rpos, &rremain,
-        operation);
+        operation, 0);
     if (!ok) {
         goto fail;
     }
@@ -5261,7 +5261,7 @@ int psa_key_derivation_set_capacity_wrapper(
 
     ok = psasim_server_serialise_psa_key_derivation_operation_t(
         &rpos, &rremain,
-        operation);
+        operation, 0);
     if (!ok) {
         goto fail;
     }
@@ -5345,7 +5345,7 @@ int psa_key_derivation_setup_wrapper(
 
     ok = psasim_server_serialise_psa_key_derivation_operation_t(
         &rpos, &rremain,
-        operation);
+        operation, 0);
     if (!ok) {
         goto fail;
     }
@@ -5420,7 +5420,7 @@ int psa_mac_abort_wrapper(
 
     ok = psasim_server_serialise_psa_mac_operation_t(
         &rpos, &rremain,
-        operation);
+        operation, 1);
     if (!ok) {
         goto fail;
     }
@@ -5643,7 +5643,7 @@ int psa_mac_sign_finish_wrapper(
 
     ok = psasim_server_serialise_psa_mac_operation_t(
         &rpos, &rremain,
-        operation);
+        operation, 1);
     if (!ok) {
         goto fail;
     }
@@ -5754,7 +5754,7 @@ int psa_mac_sign_setup_wrapper(
 
     ok = psasim_server_serialise_psa_mac_operation_t(
         &rpos, &rremain,
-        operation);
+        operation, 0);
     if (!ok) {
         goto fail;
     }
@@ -5839,7 +5839,7 @@ int psa_mac_update_wrapper(
 
     ok = psasim_server_serialise_psa_mac_operation_t(
         &rpos, &rremain,
-        operation);
+        operation, 0);
     if (!ok) {
         goto fail;
     }
@@ -6030,7 +6030,7 @@ int psa_mac_verify_finish_wrapper(
 
     ok = psasim_server_serialise_psa_mac_operation_t(
         &rpos, &rremain,
-        operation);
+        operation, 1);
     if (!ok) {
         goto fail;
     }
@@ -6127,7 +6127,7 @@ int psa_mac_verify_setup_wrapper(
 
     ok = psasim_server_serialise_psa_mac_operation_t(
         &rpos, &rremain,
-        operation);
+        operation, 0);
     if (!ok) {
         goto fail;
     }
@@ -6589,7 +6589,7 @@ int psa_sign_hash_abort_wrapper(
 
     ok = psasim_server_serialise_psa_sign_hash_interruptible_operation_t(
         &rpos, &rremain,
-        operation);
+        operation, 1);
     if (!ok) {
         goto fail;
     }
@@ -6685,7 +6685,7 @@ int psa_sign_hash_complete_wrapper(
 
     ok = psasim_server_serialise_psa_sign_hash_interruptible_operation_t(
         &rpos, &rremain,
-        operation);
+        operation, 0);
     if (!ok) {
         goto fail;
     }
@@ -6873,7 +6873,7 @@ int psa_sign_hash_start_wrapper(
 
     ok = psasim_server_serialise_psa_sign_hash_interruptible_operation_t(
         &rpos, &rremain,
-        operation);
+        operation, 0);
     if (!ok) {
         goto fail;
     }
@@ -7181,7 +7181,7 @@ int psa_verify_hash_abort_wrapper(
 
     ok = psasim_server_serialise_psa_verify_hash_interruptible_operation_t(
         &rpos, &rremain,
-        operation);
+        operation, 1);
     if (!ok) {
         goto fail;
     }
@@ -7256,7 +7256,7 @@ int psa_verify_hash_complete_wrapper(
 
     ok = psasim_server_serialise_psa_verify_hash_interruptible_operation_t(
         &rpos, &rremain,
-        operation);
+        operation, 0);
     if (!ok) {
         goto fail;
     }
@@ -7436,7 +7436,7 @@ int psa_verify_hash_start_wrapper(
 
     ok = psasim_server_serialise_psa_verify_hash_interruptible_operation_t(
         &rpos, &rremain,
-        operation);
+        operation, 0);
     if (!ok) {
         goto fail;
     }

--- a/tests/psa-client-server/psasim/src/psa_sim_generate.pl
+++ b/tests/psa-client-server/psasim/src/psa_sim_generate.pl
@@ -349,7 +349,7 @@ int psa_crypto_call(int function,
     invec.base = in_params;
     invec.len = in_params_len;
 
-    size_t max_receive = 8192;
+    size_t max_receive = 24576;
     uint8_t *receive = malloc(max_receive);
     if (receive == NULL) {
         fprintf(stderr, "FAILED to allocate %u bytes\n", (unsigned) max_receive);
@@ -424,6 +424,11 @@ fail:
 
 void mbedtls_psa_crypto_free(void)
 {
+    /* Do not try to close a connection that was never started.*/
+    if (handle == -1) {
+        return;
+    }
+
     CLIENT_PRINT("Closing handle");
     psa_close(handle);
     handle = -1;

--- a/tests/psa-client-server/psasim/src/psa_sim_generate.pl
+++ b/tests/psa-client-server/psasim/src/psa_sim_generate.pl
@@ -750,11 +750,19 @@ EOF
 
             my $server_specific = ($argtype =~ /^psa_\w+_operation_t/) ? "server_" : "";
 
+            my $completed = ""; # Only needed on server serialise calls
+            if (length($server_specific)) {
+                # On server serialisation, which is only for operation types,
+                # we need to mark the operation as completed (variously called
+                # terminated or inactive in psa/crypto.h) on certain calls.
+                $completed = ($name =~ /_(abort|finish|hash_verify)$/) ? ", 1" : ", 0";
+            }
+
             print $fh <<EOF;
 
     ok = psasim_${server_specific}serialise_${argtype}(
         &rpos, &rremain,
-        $argname);
+        $argname$completed);
     if (!ok) {
         goto fail;
     }

--- a/tests/psa-client-server/psasim/src/psa_sim_serialise.c
+++ b/tests/psa-client-server/psasim/src/psa_sim_serialise.c
@@ -936,7 +936,8 @@ size_t psasim_server_serialise_psa_hash_operation_t_needs(
 
 int psasim_server_serialise_psa_hash_operation_t(uint8_t **pos,
                                                  size_t *remaining,
-                                                 psa_hash_operation_t *operation)
+                                                 psa_hash_operation_t *operation,
+                                                 int completed)
 {
     psasim_operation_t client_operation;
 
@@ -945,6 +946,13 @@ int psasim_server_serialise_psa_hash_operation_t(uint8_t **pos,
     }
 
     ssize_t slot = operation - hash_operations;
+
+    if (completed) {
+        memset(&hash_operations[slot],
+               0,
+               sizeof(psa_hash_operation_t));
+        hash_operation_handles[slot] = 0;
+    }
 
     client_operation.handle = hash_operation_handles[slot];
 
@@ -1031,7 +1039,8 @@ size_t psasim_server_serialise_psa_aead_operation_t_needs(
 
 int psasim_server_serialise_psa_aead_operation_t(uint8_t **pos,
                                                  size_t *remaining,
-                                                 psa_aead_operation_t *operation)
+                                                 psa_aead_operation_t *operation,
+                                                 int completed)
 {
     psasim_operation_t client_operation;
 
@@ -1040,6 +1049,13 @@ int psasim_server_serialise_psa_aead_operation_t(uint8_t **pos,
     }
 
     ssize_t slot = operation - aead_operations;
+
+    if (completed) {
+        memset(&aead_operations[slot],
+               0,
+               sizeof(psa_aead_operation_t));
+        aead_operation_handles[slot] = 0;
+    }
 
     client_operation.handle = aead_operation_handles[slot];
 
@@ -1162,7 +1178,8 @@ size_t psasim_server_serialise_psa_mac_operation_t_needs(
 
 int psasim_server_serialise_psa_mac_operation_t(uint8_t **pos,
                                                 size_t *remaining,
-                                                psa_mac_operation_t *operation)
+                                                psa_mac_operation_t *operation,
+                                                int completed)
 {
     psasim_operation_t client_operation;
 
@@ -1171,6 +1188,13 @@ int psasim_server_serialise_psa_mac_operation_t(uint8_t **pos,
     }
 
     ssize_t slot = operation - mac_operations;
+
+    if (completed) {
+        memset(&mac_operations[slot],
+               0,
+               sizeof(psa_mac_operation_t));
+        mac_operation_handles[slot] = 0;
+    }
 
     client_operation.handle = mac_operation_handles[slot];
 
@@ -1257,7 +1281,8 @@ size_t psasim_server_serialise_psa_cipher_operation_t_needs(
 
 int psasim_server_serialise_psa_cipher_operation_t(uint8_t **pos,
                                                    size_t *remaining,
-                                                   psa_cipher_operation_t *operation)
+                                                   psa_cipher_operation_t *operation,
+                                                   int completed)
 {
     psasim_operation_t client_operation;
 
@@ -1266,6 +1291,13 @@ int psasim_server_serialise_psa_cipher_operation_t(uint8_t **pos,
     }
 
     ssize_t slot = operation - cipher_operations;
+
+    if (completed) {
+        memset(&cipher_operations[slot],
+               0,
+               sizeof(psa_cipher_operation_t));
+        cipher_operation_handles[slot] = 0;
+    }
 
     client_operation.handle = cipher_operation_handles[slot];
 
@@ -1352,7 +1384,8 @@ size_t psasim_server_serialise_psa_key_derivation_operation_t_needs(
 
 int psasim_server_serialise_psa_key_derivation_operation_t(uint8_t **pos,
                                                            size_t *remaining,
-                                                           psa_key_derivation_operation_t *operation)
+                                                           psa_key_derivation_operation_t *operation,
+                                                           int completed)
 {
     psasim_operation_t client_operation;
 
@@ -1361,6 +1394,13 @@ int psasim_server_serialise_psa_key_derivation_operation_t(uint8_t **pos,
     }
 
     ssize_t slot = operation - key_derivation_operations;
+
+    if (completed) {
+        memset(&key_derivation_operations[slot],
+               0,
+               sizeof(psa_key_derivation_operation_t));
+        key_derivation_operation_handles[slot] = 0;
+    }
 
     client_operation.handle = key_derivation_operation_handles[slot];
 
@@ -1447,7 +1487,8 @@ size_t psasim_server_serialise_psa_sign_hash_interruptible_operation_t_needs(
 
 int psasim_server_serialise_psa_sign_hash_interruptible_operation_t(uint8_t **pos,
                                                                     size_t *remaining,
-                                                                    psa_sign_hash_interruptible_operation_t *operation)
+                                                                    psa_sign_hash_interruptible_operation_t *operation,
+                                                                    int completed)
 {
     psasim_operation_t client_operation;
 
@@ -1456,6 +1497,13 @@ int psasim_server_serialise_psa_sign_hash_interruptible_operation_t(uint8_t **po
     }
 
     ssize_t slot = operation - sign_hash_interruptible_operations;
+
+    if (completed) {
+        memset(&sign_hash_interruptible_operations[slot],
+               0,
+               sizeof(psa_sign_hash_interruptible_operation_t));
+        sign_hash_interruptible_operation_handles[slot] = 0;
+    }
 
     client_operation.handle = sign_hash_interruptible_operation_handles[slot];
 
@@ -1542,7 +1590,8 @@ size_t psasim_server_serialise_psa_verify_hash_interruptible_operation_t_needs(
 
 int psasim_server_serialise_psa_verify_hash_interruptible_operation_t(uint8_t **pos,
                                                                       size_t *remaining,
-                                                                      psa_verify_hash_interruptible_operation_t *operation)
+                                                                      psa_verify_hash_interruptible_operation_t *operation,
+                                                                      int completed)
 {
     psasim_operation_t client_operation;
 
@@ -1551,6 +1600,13 @@ int psasim_server_serialise_psa_verify_hash_interruptible_operation_t(uint8_t **
     }
 
     ssize_t slot = operation - verify_hash_interruptible_operations;
+
+    if (completed) {
+        memset(&verify_hash_interruptible_operations[slot],
+               0,
+               sizeof(psa_verify_hash_interruptible_operation_t));
+        verify_hash_interruptible_operation_handles[slot] = 0;
+    }
 
     client_operation.handle = verify_hash_interruptible_operation_handles[slot];
 

--- a/tests/psa-client-server/psasim/src/psa_sim_serialise.h
+++ b/tests/psa-client-server/psasim/src/psa_sim_serialise.h
@@ -664,12 +664,15 @@ size_t psasim_server_serialise_psa_hash_operation_t_needs(
  * \param remaining[in,out]  Pointer to a `size_t` holding number of bytes
  *                           remaining in the buffer.
  * \param value              The value to serialise into the buffer.
+ * \param completed          Non-zero if the operation is now completed (set by
+ *                           finish and abort calls).
  *
  * \return                   \c 1 on success ("okay"), \c 0 on error.
  */
 int psasim_server_serialise_psa_hash_operation_t(uint8_t **pos,
                                                  size_t *remaining,
-                                                 psa_hash_operation_t *value);
+                                                 psa_hash_operation_t *value,
+                                                 int completed);
 
 /** Deserialise a `psa_hash_operation_t` from a buffer on the server side.
  *
@@ -750,12 +753,15 @@ size_t psasim_server_serialise_psa_aead_operation_t_needs(
  * \param remaining[in,out]  Pointer to a `size_t` holding number of bytes
  *                           remaining in the buffer.
  * \param value              The value to serialise into the buffer.
+ * \param completed          Non-zero if the operation is now completed (set by
+ *                           finish and abort calls).
  *
  * \return                   \c 1 on success ("okay"), \c 0 on error.
  */
 int psasim_server_serialise_psa_aead_operation_t(uint8_t **pos,
                                                  size_t *remaining,
-                                                 psa_aead_operation_t *value);
+                                                 psa_aead_operation_t *value,
+                                                 int completed);
 
 /** Deserialise a `psa_aead_operation_t` from a buffer on the server side.
  *
@@ -879,12 +885,15 @@ size_t psasim_server_serialise_psa_mac_operation_t_needs(
  * \param remaining[in,out]  Pointer to a `size_t` holding number of bytes
  *                           remaining in the buffer.
  * \param value              The value to serialise into the buffer.
+ * \param completed          Non-zero if the operation is now completed (set by
+ *                           finish and abort calls).
  *
  * \return                   \c 1 on success ("okay"), \c 0 on error.
  */
 int psasim_server_serialise_psa_mac_operation_t(uint8_t **pos,
                                                 size_t *remaining,
-                                                psa_mac_operation_t *value);
+                                                psa_mac_operation_t *value,
+                                                int completed);
 
 /** Deserialise a `psa_mac_operation_t` from a buffer on the server side.
  *
@@ -965,12 +974,15 @@ size_t psasim_server_serialise_psa_cipher_operation_t_needs(
  * \param remaining[in,out]  Pointer to a `size_t` holding number of bytes
  *                           remaining in the buffer.
  * \param value              The value to serialise into the buffer.
+ * \param completed          Non-zero if the operation is now completed (set by
+ *                           finish and abort calls).
  *
  * \return                   \c 1 on success ("okay"), \c 0 on error.
  */
 int psasim_server_serialise_psa_cipher_operation_t(uint8_t **pos,
                                                    size_t *remaining,
-                                                   psa_cipher_operation_t *value);
+                                                   psa_cipher_operation_t *value,
+                                                   int completed);
 
 /** Deserialise a `psa_cipher_operation_t` from a buffer on the server side.
  *
@@ -1051,12 +1063,15 @@ size_t psasim_server_serialise_psa_key_derivation_operation_t_needs(
  * \param remaining[in,out]  Pointer to a `size_t` holding number of bytes
  *                           remaining in the buffer.
  * \param value              The value to serialise into the buffer.
+ * \param completed          Non-zero if the operation is now completed (set by
+ *                           finish and abort calls).
  *
  * \return                   \c 1 on success ("okay"), \c 0 on error.
  */
 int psasim_server_serialise_psa_key_derivation_operation_t(uint8_t **pos,
                                                            size_t *remaining,
-                                                           psa_key_derivation_operation_t *value);
+                                                           psa_key_derivation_operation_t *value,
+                                                           int completed);
 
 /** Deserialise a `psa_key_derivation_operation_t` from a buffer on the server side.
  *
@@ -1137,12 +1152,15 @@ size_t psasim_server_serialise_psa_sign_hash_interruptible_operation_t_needs(
  * \param remaining[in,out]  Pointer to a `size_t` holding number of bytes
  *                           remaining in the buffer.
  * \param value              The value to serialise into the buffer.
+ * \param completed          Non-zero if the operation is now completed (set by
+ *                           finish and abort calls).
  *
  * \return                   \c 1 on success ("okay"), \c 0 on error.
  */
 int psasim_server_serialise_psa_sign_hash_interruptible_operation_t(uint8_t **pos,
                                                                     size_t *remaining,
-                                                                    psa_sign_hash_interruptible_operation_t *value);
+                                                                    psa_sign_hash_interruptible_operation_t *value,
+                                                                    int completed);
 
 /** Deserialise a `psa_sign_hash_interruptible_operation_t` from a buffer on the server side.
  *
@@ -1223,12 +1241,15 @@ size_t psasim_server_serialise_psa_verify_hash_interruptible_operation_t_needs(
  * \param remaining[in,out]  Pointer to a `size_t` holding number of bytes
  *                           remaining in the buffer.
  * \param value              The value to serialise into the buffer.
+ * \param completed          Non-zero if the operation is now completed (set by
+ *                           finish and abort calls).
  *
  * \return                   \c 1 on success ("okay"), \c 0 on error.
  */
 int psasim_server_serialise_psa_verify_hash_interruptible_operation_t(uint8_t **pos,
                                                                       size_t *remaining,
-                                                                      psa_verify_hash_interruptible_operation_t *value);
+                                                                      psa_verify_hash_interruptible_operation_t *value,
+                                                                      int completed);
 
 /** Deserialise a `psa_verify_hash_interruptible_operation_t` from a buffer on the server side.
  *


### PR DESCRIPTION
## Description

This PR contains some commits which were originally part of #9237. The goal is to separate commits which simply improve `psasim` from those which make `psasim` interacting with test suites.

## PR checklist

- [ ] **changelog** not required
- [ ] **3.6 backport** not required
- [ ] **2.28 backport** not required
- [ ] **tests** not required
