### PR TITLE
Backport 3.6: Add MD5 support for requires_hash_alg

### DIFF
--- a/tests/scripts/analyze_outcomes.py
+++ b/tests/scripts/analyze_outcomes.py
@@ -344,6 +344,12 @@ KNOWN_TASKS = {
                     'Key ASN1 (Encrypted key PKCS5, trailing garbage data)',
                     re.compile(r'Parse (RSA|EC) Key .*\(.* ([Ee]ncrypted|password).*\)'),
                 ],
+                # Encrypted keys are not supported so far.
+                'ssl-opt': [
+                    'TLS: password protected server key',
+                    'TLS: password protected client key',
+                    'TLS: password protected server key, two certificates',
+                ],
             }
         }
     },

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -2115,7 +2115,7 @@ requires_config_enabled MBEDTLS_X509_CRT_PARSE_C
 # server5.key.enc is in PEM format and AES-256-CBC crypted. Unfortunately PEM
 # module does not support PSA dispatching so we need builtin support.
 requires_config_enabled MBEDTLS_CIPHER_MODE_CBC
-requires_config_enabled MBEDTLS_AES_C
+requires_cipher_enabled AES
 requires_hash_alg MD5
 requires_hash_alg SHA_256
 run_test    "TLS: password protected client key" \
@@ -2127,7 +2127,7 @@ requires_config_enabled MBEDTLS_X509_CRT_PARSE_C
 # server5.key.enc is in PEM format and AES-256-CBC crypted. Unfortunately PEM
 # module does not support PSA dispatching so we need builtin support.
 requires_config_enabled MBEDTLS_CIPHER_MODE_CBC
-requires_config_enabled MBEDTLS_AES_C
+requires_cipher_enabled AES
 requires_hash_alg MD5
 requires_hash_alg SHA_256
 run_test    "TLS: password protected server key" \
@@ -2140,7 +2140,7 @@ requires_config_enabled MBEDTLS_RSA_C
 # server5.key.enc is in PEM format and AES-256-CBC crypted. Unfortunately PEM
 # module does not support PSA dispatching so we need builtin support.
 requires_config_enabled MBEDTLS_CIPHER_MODE_CBC
-requires_config_enabled MBEDTLS_AES_C
+requires_cipher_enabled AES
 requires_hash_alg MD5
 requires_hash_alg SHA_256
 run_test    "TLS: password protected server key, two certificates" \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -593,6 +593,7 @@ case " $CONFIGS_ENABLED " in
     *) PSK_ONLY="NO";;
 esac
 
+HAS_ALG_MD5="NO"
 HAS_ALG_SHA_1="NO"
 HAS_ALG_SHA_224="NO"
 HAS_ALG_SHA_256="NO"
@@ -611,7 +612,10 @@ check_for_hash_alg()
     else
         CURR_ALG=MBEDTLS_${1}_C
         # Remove the second underscore to match MBEDTLS_* naming convention
-        CURR_ALG=$(echo "$CURR_ALG" | sed 's/_//2')
+        # MD5 is an exception to this convention
+        if [ "${1}" != "MD5" ]; then
+            CURR_ALG=$(echo "$CURR_ALG" | sed 's/_//2')
+        fi
     fi
 
     case $CONFIGS_ENABLED in
@@ -625,7 +629,7 @@ check_for_hash_alg()
 
 populate_enabled_hash_algs()
 {
-    for hash_alg in SHA_1 SHA_224 SHA_256 SHA_384 SHA_512; do
+    for hash_alg in SHA_1 SHA_224 SHA_256 SHA_384 SHA_512 MD5; do
         if check_for_hash_alg "$hash_alg"; then
             hash_alg_variable=HAS_ALG_${hash_alg}
             eval ${hash_alg_variable}=YES
@@ -638,6 +642,7 @@ requires_hash_alg() {
     HASH_DEFINE="Invalid"
     HAS_HASH_ALG="NO"
     case $1 in
+        MD5):;;
         SHA_1):;;
         SHA_224):;;
         SHA_256):;;
@@ -2107,11 +2112,11 @@ run_test    "key size: TLS-ECDHE-ECDSA-WITH-AES-128-CCM-8" \
             -c "Key size is 128"
 
 requires_config_enabled MBEDTLS_X509_CRT_PARSE_C
-requires_config_enabled MBEDTLS_MD_CAN_MD5
 # server5.key.enc is in PEM format and AES-256-CBC crypted. Unfortunately PEM
 # module does not support PSA dispatching so we need builtin support.
 requires_config_enabled MBEDTLS_CIPHER_MODE_CBC
 requires_config_enabled MBEDTLS_AES_C
+requires_hash_alg MD5
 requires_hash_alg SHA_256
 run_test    "TLS: password protected client key" \
             "$P_SRV force_version=tls12 auth_mode=required" \
@@ -2119,11 +2124,11 @@ run_test    "TLS: password protected client key" \
             0
 
 requires_config_enabled MBEDTLS_X509_CRT_PARSE_C
-requires_config_enabled MBEDTLS_MD_CAN_MD5
 # server5.key.enc is in PEM format and AES-256-CBC crypted. Unfortunately PEM
 # module does not support PSA dispatching so we need builtin support.
 requires_config_enabled MBEDTLS_CIPHER_MODE_CBC
 requires_config_enabled MBEDTLS_AES_C
+requires_hash_alg MD5
 requires_hash_alg SHA_256
 run_test    "TLS: password protected server key" \
             "$P_SRV crt_file=data_files/server5.crt key_file=data_files/server5.key.enc key_pwd=PolarSSLTest" \
@@ -2132,11 +2137,11 @@ run_test    "TLS: password protected server key" \
 
 requires_config_enabled MBEDTLS_X509_CRT_PARSE_C
 requires_config_enabled MBEDTLS_RSA_C
-requires_config_enabled MBEDTLS_MD_CAN_MD5
 # server5.key.enc is in PEM format and AES-256-CBC crypted. Unfortunately PEM
 # module does not support PSA dispatching so we need builtin support.
 requires_config_enabled MBEDTLS_CIPHER_MODE_CBC
 requires_config_enabled MBEDTLS_AES_C
+requires_hash_alg MD5
 requires_hash_alg SHA_256
 run_test    "TLS: password protected server key, two certificates" \
             "$P_SRV force_version=tls12\

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -2115,7 +2115,7 @@ requires_config_enabled MBEDTLS_X509_CRT_PARSE_C
 # server5.key.enc is in PEM format and AES-256-CBC crypted. Unfortunately PEM
 # module does not support PSA dispatching so we need builtin support.
 requires_config_enabled MBEDTLS_CIPHER_MODE_CBC
-requires_cipher_enabled AES
+requires_config_enabled MBEDTLS_AES_C
 requires_hash_alg MD5
 requires_hash_alg SHA_256
 run_test    "TLS: password protected client key" \
@@ -2127,7 +2127,7 @@ requires_config_enabled MBEDTLS_X509_CRT_PARSE_C
 # server5.key.enc is in PEM format and AES-256-CBC crypted. Unfortunately PEM
 # module does not support PSA dispatching so we need builtin support.
 requires_config_enabled MBEDTLS_CIPHER_MODE_CBC
-requires_cipher_enabled AES
+requires_config_enabled MBEDTLS_AES_C
 requires_hash_alg MD5
 requires_hash_alg SHA_256
 run_test    "TLS: password protected server key" \
@@ -2140,7 +2140,7 @@ requires_config_enabled MBEDTLS_RSA_C
 # server5.key.enc is in PEM format and AES-256-CBC crypted. Unfortunately PEM
 # module does not support PSA dispatching so we need builtin support.
 requires_config_enabled MBEDTLS_CIPHER_MODE_CBC
-requires_cipher_enabled AES
+requires_config_enabled MBEDTLS_AES_C
 requires_hash_alg MD5
 requires_hash_alg SHA_256
 run_test    "TLS: password protected server key, two certificates" \


### PR DESCRIPTION
Trivial backport of #9290 

## PR checklist

- [x] **changelog** not required
- [x] **3.6 backport** of #9290 
- [x] **2.28 backport** not required
- [x] **tests** not required
