### PR TITLE
Backport 3.6:  Fix inconsistent ordering of driver vs reference in analyze_outcomes

### DIFF
--- a/tests/scripts/analyze_outcomes.py
+++ b/tests/scripts/analyze_outcomes.py
@@ -129,8 +129,8 @@ def name_matches_pattern(name: str, str_or_re) -> bool:
 def analyze_driver_vs_reference(results: Results, outcomes: Outcomes,
                                 component_ref: str, component_driver: str,
                                 ignored_suites: typing.List[str], ignored_tests=None) -> None:
-    """Check that all tests passing in the reference component are also
-    passing in the corresponding driver component.
+    """Check that all tests passing in the driver component are also
+    passing in the corresponding reference component.
     Skip:
     - full test suites provided in ignored_suites list
     - only some specific test inside a test suite, for which the corresponding

--- a/tests/scripts/analyze_outcomes.py
+++ b/tests/scripts/analyze_outcomes.py
@@ -166,7 +166,7 @@ def analyze_driver_vs_reference(results: Results, outcomes: Outcomes,
                     ignored = True
 
         if not ignored and not suite_case in driver_outcomes.successes:
-            results.error("PASS -> SKIP/FAIL: {}", suite_case)
+            results.error("SKIP/FAIL -> PASS: {}", suite_case)
         if ignored and suite_case in driver_outcomes.successes:
             results.error("uselessly ignored: {}", suite_case)
 


### PR DESCRIPTION
Trivial backport of #9304

## PR checklist

- [x] **changelog** not required - internal test script change only
- [x] **3.6 backport** of #9304 
- [x] **2.28 backport** not required
- [x] **tests** not required