### PR TITLE
tests_suite_debug: fix psa initialization

### DIFF
--- a/tests/suites/test_suite_debug.function
+++ b/tests/suites/test_suite_debug.function
@@ -59,10 +59,9 @@ void debug_print_msg_threshold(int threshold, int level, char *file,
     mbedtls_ssl_config conf;
     struct buffer_data buffer;
 
-    MD_OR_USE_PSA_INIT();
-
     mbedtls_ssl_init(&ssl);
     mbedtls_ssl_config_init(&conf);
+    MD_OR_USE_PSA_INIT();
     memset(buffer.buf, 0, 2000);
     buffer.ptr = buffer.buf;
 
@@ -98,10 +97,9 @@ void mbedtls_debug_print_ret(char *file, int line, char *text, int value,
     mbedtls_ssl_config conf;
     struct buffer_data buffer;
 
-    MD_OR_USE_PSA_INIT();
-
     mbedtls_ssl_init(&ssl);
     mbedtls_ssl_config_init(&conf);
+    MD_OR_USE_PSA_INIT();
     memset(buffer.buf, 0, 2000);
     buffer.ptr = buffer.buf;
 
@@ -134,10 +132,9 @@ void mbedtls_debug_print_buf(char *file, int line, char *text,
     mbedtls_ssl_config conf;
     struct buffer_data buffer;
 
-    MD_OR_USE_PSA_INIT();
-
     mbedtls_ssl_init(&ssl);
     mbedtls_ssl_config_init(&conf);
+    MD_OR_USE_PSA_INIT();
     memset(buffer.buf, 0, 2000);
     buffer.ptr = buffer.buf;
 
@@ -211,11 +208,10 @@ void mbedtls_debug_print_mpi(char *value, char *file, int line,
     struct buffer_data buffer;
     mbedtls_mpi val;
 
-    MD_OR_USE_PSA_INIT();
-
     mbedtls_ssl_init(&ssl);
     mbedtls_ssl_config_init(&conf);
     mbedtls_mpi_init(&val);
+    MD_OR_USE_PSA_INIT();
     memset(buffer.buf, 0, 2000);
     buffer.ptr = buffer.buf;
 


### PR DESCRIPTION
## Description

Since MD_OR_USE_PSA_INIT() can fail and jump to the "exit" label it should be placed after all initializations has been done. This issue was discovered by Coverity testing.

## PR checklist

- [ ] **changelog** not required
- [ ] **3.6 backport**  not required
- [ ] **2.28 backport**  not required
- [ ] **tests**  not required

