### PR TITLE
Replace legacy macros with PSA_WANT counterparts

### DIFF
--- a/library/asn1parse.c
+++ b/library/asn1parse.c
@@ -8,7 +8,7 @@
 #include "common.h"
 
 #if defined(MBEDTLS_ASN1_PARSE_C) || defined(MBEDTLS_X509_CREATE_C) || \
-    defined(MBEDTLS_PSA_UTIL_HAVE_ECDSA)
+    defined(PSA_WANT_ALG_ECDSA) || defined(PSA_WANT_ALG_DETERMINISTIC_ECDSA)
 
 #include "mbedtls/asn1.h"
 #include "mbedtls/platform_util.h"
@@ -74,7 +74,7 @@ int mbedtls_asn1_get_tag(unsigned char **p,
 
     return mbedtls_asn1_get_len(p, end, len);
 }
-#endif /* MBEDTLS_ASN1_PARSE_C || MBEDTLS_X509_CREATE_C || MBEDTLS_PSA_UTIL_HAVE_ECDSA */
+#endif /* MBEDTLS_ASN1_PARSE_C || MBEDTLS_X509_CREATE_C || PSA_WANT_ALG_ECDSA || PSA_WANT_ALG_DETERMINISTIC_ECDSA*/
 
 #if defined(MBEDTLS_ASN1_PARSE_C)
 int mbedtls_asn1_get_bool(unsigned char **p,

--- a/library/asn1parse.c
+++ b/library/asn1parse.c
@@ -8,7 +8,7 @@
 #include "common.h"
 
 #if defined(MBEDTLS_ASN1_PARSE_C) || defined(MBEDTLS_X509_CREATE_C) || \
-    defined(PSA_WANT_ALG_ECDSA) || defined(PSA_WANT_ALG_DETERMINISTIC_ECDSA)
+    defined(PSA_HAVE_ALG_SOME_ECDSA)
 
 #include "mbedtls/asn1.h"
 #include "mbedtls/platform_util.h"
@@ -74,7 +74,7 @@ int mbedtls_asn1_get_tag(unsigned char **p,
 
     return mbedtls_asn1_get_len(p, end, len);
 }
-#endif /* MBEDTLS_ASN1_PARSE_C || MBEDTLS_X509_CREATE_C || PSA_WANT_ALG_ECDSA || PSA_WANT_ALG_DETERMINISTIC_ECDSA*/
+#endif /* MBEDTLS_ASN1_PARSE_C || PSA_HAVE_ALG_SOME_ECDSA */
 
 #if defined(MBEDTLS_ASN1_PARSE_C)
 int mbedtls_asn1_get_bool(unsigned char **p,

--- a/library/asn1write.c
+++ b/library/asn1write.c
@@ -8,7 +8,7 @@
 #include "common.h"
 
 #if defined(MBEDTLS_ASN1_WRITE_C) || defined(MBEDTLS_X509_USE_C) || \
-    defined(PSA_WANT_ALG_ECDSA) || defined(PSA_WANT_ALG_DETERMINISTIC_ECDSA)
+    defined(PSA_HAVE_ALG_SOME_ECDSA)
 
 #include "mbedtls/asn1write.h"
 #include "mbedtls/error.h"
@@ -63,7 +63,7 @@ int mbedtls_asn1_write_tag(unsigned char **p, const unsigned char *start, unsign
 
     return 1;
 }
-#endif /* MBEDTLS_ASN1_WRITE_C || MBEDTLS_X509_USE_C || PSA_WANT_ALG_ECDSA || PSA_WANT_ALG_DETERMINISTIC_ECDSA */
+#endif /* MBEDTLS_ASN1_WRITE_C || MBEDTLS_X509_USE_C || PSA_HAVE_ALG_SOME_ECDSA */
 
 #if defined(MBEDTLS_ASN1_WRITE_C)
 static int mbedtls_asn1_write_len_and_tag(unsigned char **p,

--- a/library/asn1write.c
+++ b/library/asn1write.c
@@ -8,7 +8,7 @@
 #include "common.h"
 
 #if defined(MBEDTLS_ASN1_WRITE_C) || defined(MBEDTLS_X509_USE_C) || \
-    defined(MBEDTLS_PSA_UTIL_HAVE_ECDSA)
+    defined(PSA_WANT_ALG_ECDSA) || defined(PSA_WANT_ALG_DETERMINISTIC_ECDSA)
 
 #include "mbedtls/asn1write.h"
 #include "mbedtls/error.h"
@@ -63,7 +63,7 @@ int mbedtls_asn1_write_tag(unsigned char **p, const unsigned char *start, unsign
 
     return 1;
 }
-#endif /* MBEDTLS_ASN1_WRITE_C || MBEDTLS_X509_USE_C || MBEDTLS_PSA_UTIL_HAVE_ECDSA */
+#endif /* MBEDTLS_ASN1_WRITE_C || MBEDTLS_X509_USE_C || PSA_WANT_ALG_ECDSA || PSA_WANT_ALG_DETERMINISTIC_ECDSA */
 
 #if defined(MBEDTLS_ASN1_WRITE_C)
 static int mbedtls_asn1_write_len_and_tag(unsigned char **p,

--- a/library/psa_util.c
+++ b/library/psa_util.c
@@ -365,7 +365,7 @@ int mbedtls_psa_get_random(void *p_rng,
 
 #endif /* MBEDTLS_PSA_CRYPTO_CLIENT */
 
-#if defined(MBEDTLS_PSA_UTIL_HAVE_ECDSA)
+#if defined(PSA_WANT_ALG_ECDSA) || defined(PSA_WANT_ALG_DETERMINISTIC_ECDSA)
 
 /**
  * \brief  Convert a single raw coordinate to DER ASN.1 format. The output der
@@ -599,4 +599,4 @@ int mbedtls_ecdsa_der_to_raw(size_t bits, const unsigned char *der, size_t der_l
     return 0;
 }
 
-#endif /* MBEDTLS_PSA_UTIL_HAVE_ECDSA */
+#endif /* PSA_WANT_ALG_ECDSA || PSA_WANT_ALG_DETERMINISTIC_ECDSA */

--- a/library/psa_util.c
+++ b/library/psa_util.c
@@ -365,7 +365,7 @@ int mbedtls_psa_get_random(void *p_rng,
 
 #endif /* MBEDTLS_PSA_CRYPTO_CLIENT */
 
-#if defined(PSA_WANT_ALG_ECDSA) || defined(PSA_WANT_ALG_DETERMINISTIC_ECDSA)
+#if defined(PSA_HAVE_ALG_SOME_ECDSA)
 
 /**
  * \brief  Convert a single raw coordinate to DER ASN.1 format. The output der
@@ -599,4 +599,4 @@ int mbedtls_ecdsa_der_to_raw(size_t bits, const unsigned char *der, size_t der_l
     return 0;
 }
 
-#endif /* PSA_WANT_ALG_ECDSA || PSA_WANT_ALG_DETERMINISTIC_ECDSA */
+#endif /* PSA_HAVE_ALG_SOME_ECDSA */

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -267,6 +267,13 @@ uint32_t mbedtls_ssl_get_extension_mask(unsigned int extension_type);
 #define MBEDTLS_SSL_SOME_SUITES_USE_STREAM
 #endif
 
+/* This macro determines whether AEAD is supported */
+#if defined(PSA_WANT_ALG_CCM) ||                                  \
+    defined(PSA_WANT_ALG_GCM) ||                                  \
+    defined(PSA_WANT_ALG_CHACHA20_POLY1305)
+#define MBEDTLS_SSL_SOME_SUITES_USE_AEAD
+#endif
+
 /* This macro determines whether the CBC construct used in TLS 1.2 is supported. */
 #if defined(MBEDTLS_SSL_SOME_SUITES_USE_CBC) && \
     defined(MBEDTLS_SSL_PROTO_TLS1_2)

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -851,7 +851,7 @@ static void ssl_extract_add_data_from_record(unsigned char *add_data,
     *add_data_len = (size_t) (cur - add_data);
 }
 
-#if defined(PSA_WANT_ALG_CCM) || defined(PSA_WANT_ALG_GCM) || defined(PSA_WANT_ALG_CHACHA20_POLY1305)
+#if defined(MBEDTLS_SSL_SOME_SUITES_USE_AEAD)
 MBEDTLS_CHECK_RETURN_CRITICAL
 static int ssl_transform_aead_dynamic_iv_is_explicit(
     mbedtls_ssl_transform const *transform)
@@ -896,7 +896,7 @@ static void ssl_build_record_nonce(unsigned char *dst_iv,
     dst_iv += dst_iv_len - dynamic_iv_len;
     mbedtls_xor(dst_iv, dst_iv, dynamic_iv, dynamic_iv_len);
 }
-#endif /* PSA_WANT_ALG_CCM || PSA_WANT_ALG_GCM || PSA_WANT_ALG_CHACHA20_POLY1305 */
+#endif /* MBEDTLS_SSL_SOME_SUITES_USE_AEAD */
 
 int mbedtls_ssl_encrypt_buf(mbedtls_ssl_context *ssl,
                             mbedtls_ssl_transform *transform,
@@ -1132,7 +1132,7 @@ hmac_failed_etm_disabled:
     } else
 #endif /* MBEDTLS_SSL_SOME_SUITES_USE_STREAM */
 
-#if defined(PSA_WANT_ALG_CCM) || defined(PSA_WANT_ALG_GCM) || defined(PSA_WANT_ALG_CHACHA20_POLY1305)
+#if defined(MBEDTLS_SSL_SOME_SUITES_USE_AEAD)
     if (ssl_mode == MBEDTLS_SSL_MODE_AEAD) {
         unsigned char iv[12];
         unsigned char *dynamic_iv;
@@ -1242,7 +1242,7 @@ hmac_failed_etm_disabled:
 
         auth_done++;
     } else
-#endif /* PSA_WANT_ALG_CCM || PSA_WANT_ALG_GCM || PSA_WANT_ALG_CHACHA20_POLY1305 */
+#endif /* MBEDTLS_SSL_SOME_SUITES_USE_AEAD */
 #if defined(MBEDTLS_SSL_SOME_SUITES_USE_CBC)
     if (ssl_mode == MBEDTLS_SSL_MODE_CBC ||
         ssl_mode == MBEDTLS_SSL_MODE_CBC_ETM) {
@@ -1480,9 +1480,9 @@ int mbedtls_ssl_decrypt_buf(mbedtls_ssl_context const *ssl,
                             mbedtls_ssl_transform *transform,
                             mbedtls_record *rec)
 {
-#if defined(MBEDTLS_SSL_SOME_SUITES_USE_CBC) || defined(PSA_WANT_ALG_CCM) || defined(PSA_WANT_ALG_GCM) || defined(PSA_WANT_ALG_CHACHA20_POLY1305)
+#if defined(MBEDTLS_SSL_SOME_SUITES_USE_CBC) || defined(MBEDTLS_SSL_SOME_SUITES_USE_AEAD)
     size_t olen;
-#endif /* MBEDTLS_SSL_SOME_SUITES_USE_CBC || PSA_WANT_ALG_CCM || PSA_WANT_ALG_GCM || PSA_WANT_ALG_CHACHA20_POLY1305 */
+#endif /* MBEDTLS_SSL_SOME_SUITES_USE_CBC || MBEDTLS_SSL_SOME_SUITES_USE_AEAD */
     mbedtls_ssl_mode_t ssl_mode;
     int ret;
 
@@ -1543,7 +1543,7 @@ int mbedtls_ssl_decrypt_buf(mbedtls_ssl_context const *ssl,
          * so there's no encryption to do here.*/
     } else
 #endif /* MBEDTLS_SSL_SOME_SUITES_USE_STREAM */
-#if defined(PSA_WANT_ALG_CCM) || defined(PSA_WANT_ALG_GCM) || defined(PSA_WANT_ALG_CHACHA20_POLY1305)
+#if defined(MBEDTLS_SSL_SOME_SUITES_USE_AEAD)
     if (ssl_mode == MBEDTLS_SSL_MODE_AEAD) {
         unsigned char iv[12];
         unsigned char *dynamic_iv;
@@ -1660,7 +1660,7 @@ int mbedtls_ssl_decrypt_buf(mbedtls_ssl_context const *ssl,
             return MBEDTLS_ERR_SSL_INTERNAL_ERROR;
         }
     } else
-#endif /* PSA_WANT_ALG_CCM || PSA_WANT_ALG_GCM || PSA_WANT_ALG_CHACHA20_POLY1305 */
+#endif /* MBEDTLS_SSL_SOME_SUITES_USE_AEAD */
 #if defined(MBEDTLS_SSL_SOME_SUITES_USE_CBC)
     if (ssl_mode == MBEDTLS_SSL_MODE_CBC ||
         ssl_mode == MBEDTLS_SSL_MODE_CBC_ETM) {

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -851,7 +851,7 @@ static void ssl_extract_add_data_from_record(unsigned char *add_data,
     *add_data_len = (size_t) (cur - add_data);
 }
 
-#if defined(MBEDTLS_SSL_HAVE_AEAD)
+#if defined(PSA_WANT_ALG_CCM) || defined(PSA_WANT_ALG_GCM) || defined(PSA_WANT_ALG_CHACHA20_POLY1305)
 MBEDTLS_CHECK_RETURN_CRITICAL
 static int ssl_transform_aead_dynamic_iv_is_explicit(
     mbedtls_ssl_transform const *transform)
@@ -896,7 +896,7 @@ static void ssl_build_record_nonce(unsigned char *dst_iv,
     dst_iv += dst_iv_len - dynamic_iv_len;
     mbedtls_xor(dst_iv, dst_iv, dynamic_iv, dynamic_iv_len);
 }
-#endif /* MBEDTLS_SSL_HAVE_AEAD */
+#endif /* PSA_WANT_ALG_CCM || PSA_WANT_ALG_GCM || PSA_WANT_ALG_CHACHA20_POLY1305 */
 
 int mbedtls_ssl_encrypt_buf(mbedtls_ssl_context *ssl,
                             mbedtls_ssl_transform *transform,
@@ -1132,7 +1132,7 @@ hmac_failed_etm_disabled:
     } else
 #endif /* MBEDTLS_SSL_SOME_SUITES_USE_STREAM */
 
-#if defined(MBEDTLS_SSL_HAVE_AEAD)
+#if defined(PSA_WANT_ALG_CCM) || defined(PSA_WANT_ALG_GCM) || defined(PSA_WANT_ALG_CHACHA20_POLY1305)
     if (ssl_mode == MBEDTLS_SSL_MODE_AEAD) {
         unsigned char iv[12];
         unsigned char *dynamic_iv;
@@ -1242,7 +1242,7 @@ hmac_failed_etm_disabled:
 
         auth_done++;
     } else
-#endif /* MBEDTLS_SSL_HAVE_AEAD */
+#endif /* PSA_WANT_ALG_CCM || PSA_WANT_ALG_GCM || PSA_WANT_ALG_CHACHA20_POLY1305 */
 #if defined(MBEDTLS_SSL_SOME_SUITES_USE_CBC)
     if (ssl_mode == MBEDTLS_SSL_MODE_CBC ||
         ssl_mode == MBEDTLS_SSL_MODE_CBC_ETM) {
@@ -1480,9 +1480,9 @@ int mbedtls_ssl_decrypt_buf(mbedtls_ssl_context const *ssl,
                             mbedtls_ssl_transform *transform,
                             mbedtls_record *rec)
 {
-#if defined(MBEDTLS_SSL_SOME_SUITES_USE_CBC) || defined(MBEDTLS_SSL_HAVE_AEAD)
+#if defined(MBEDTLS_SSL_SOME_SUITES_USE_CBC) || defined(PSA_WANT_ALG_CCM) || defined(PSA_WANT_ALG_GCM) || defined(PSA_WANT_ALG_CHACHA20_POLY1305)
     size_t olen;
-#endif /* MBEDTLS_SSL_SOME_SUITES_USE_CBC || MBEDTLS_SSL_HAVE_AEAD */
+#endif /* MBEDTLS_SSL_SOME_SUITES_USE_CBC || PSA_WANT_ALG_CCM || PSA_WANT_ALG_GCM || PSA_WANT_ALG_CHACHA20_POLY1305 */
     mbedtls_ssl_mode_t ssl_mode;
     int ret;
 
@@ -1543,7 +1543,7 @@ int mbedtls_ssl_decrypt_buf(mbedtls_ssl_context const *ssl,
          * so there's no encryption to do here.*/
     } else
 #endif /* MBEDTLS_SSL_SOME_SUITES_USE_STREAM */
-#if defined(MBEDTLS_SSL_HAVE_AEAD)
+#if defined(PSA_WANT_ALG_CCM) || defined(PSA_WANT_ALG_GCM) || defined(PSA_WANT_ALG_CHACHA20_POLY1305)
     if (ssl_mode == MBEDTLS_SSL_MODE_AEAD) {
         unsigned char iv[12];
         unsigned char *dynamic_iv;
@@ -1660,7 +1660,7 @@ int mbedtls_ssl_decrypt_buf(mbedtls_ssl_context const *ssl,
             return MBEDTLS_ERR_SSL_INTERNAL_ERROR;
         }
     } else
-#endif /* MBEDTLS_SSL_HAVE_AEAD */
+#endif /* PSA_WANT_ALG_CCM || PSA_WANT_ALG_GCM || PSA_WANT_ALG_CHACHA20_POLY1305 */
 #if defined(MBEDTLS_SSL_SOME_SUITES_USE_CBC)
     if (ssl_mode == MBEDTLS_SSL_MODE_CBC ||
         ssl_mode == MBEDTLS_SSL_MODE_CBC_ETM) {

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -8957,7 +8957,7 @@ static int ssl_tls12_populate_transform(mbedtls_ssl_transform *transform,
     keylen = mbedtls_cipher_info_get_key_bitlen(cipher_info) / 8;
 #endif
 
-#if defined(MBEDTLS_SSL_HAVE_AEAD)
+#if defined(PSA_WANT_ALG_CCM) || defined(PSA_WANT_ALG_GCM) || defined(PSA_WANT_ALG_CHACHA20_POLY1305)
     if (ssl_mode == MBEDTLS_SSL_MODE_AEAD) {
         size_t explicit_ivlen;
 
@@ -8992,7 +8992,7 @@ static int ssl_tls12_populate_transform(mbedtls_ssl_transform *transform,
         explicit_ivlen = transform->ivlen - transform->fixed_ivlen;
         transform->minlen = explicit_ivlen + transform->taglen;
     } else
-#endif /* MBEDTLS_SSL_HAVE_AEAD */
+#endif /* PSA_WANT_ALG_CCM || PSA_WANT_ALG_GCM || PSA_WANT_ALG_CHACHA20_POLY1305 */
 #if defined(MBEDTLS_SSL_SOME_SUITES_USE_MAC)
     if (ssl_mode == MBEDTLS_SSL_MODE_STREAM ||
         ssl_mode == MBEDTLS_SSL_MODE_CBC ||

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -8957,7 +8957,7 @@ static int ssl_tls12_populate_transform(mbedtls_ssl_transform *transform,
     keylen = mbedtls_cipher_info_get_key_bitlen(cipher_info) / 8;
 #endif
 
-#if defined(PSA_WANT_ALG_CCM) || defined(PSA_WANT_ALG_GCM) || defined(PSA_WANT_ALG_CHACHA20_POLY1305)
+#if defined(MBEDTLS_SSL_SOME_SUITES_USE_AEAD)
     if (ssl_mode == MBEDTLS_SSL_MODE_AEAD) {
         size_t explicit_ivlen;
 
@@ -8992,7 +8992,7 @@ static int ssl_tls12_populate_transform(mbedtls_ssl_transform *transform,
         explicit_ivlen = transform->ivlen - transform->fixed_ivlen;
         transform->minlen = explicit_ivlen + transform->taglen;
     } else
-#endif /* PSA_WANT_ALG_CCM || PSA_WANT_ALG_GCM || PSA_WANT_ALG_CHACHA20_POLY1305 */
+#endif /* MBEDTLS_SSL_SOME_SUITES_USE_AEAD */
 #if defined(MBEDTLS_SSL_SOME_SUITES_USE_MAC)
     if (ssl_mode == MBEDTLS_SSL_MODE_STREAM ||
         ssl_mode == MBEDTLS_SSL_MODE_CBC ||

--- a/tests/suites/test_suite_psa_crypto_util.function
+++ b/tests/suites/test_suite_psa_crypto_util.function
@@ -3,7 +3,7 @@
 #include <mbedtls/psa_util.h>
 /* END_HEADER */
 
-/* BEGIN_CASE depends_on:MBEDTLS_PSA_UTIL_HAVE_ECDSA */
+/* BEGIN_CASE depends_on:PSA_WANT_ALG_ECDSA || PSA_WANT_ALG_DETERMINISTIC_ECDSA */
 void ecdsa_raw_to_der(int key_bits, data_t *input, data_t *exp_result, int exp_ret)
 {
     unsigned char *tmp_buf = NULL;
@@ -24,7 +24,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_PSA_UTIL_HAVE_ECDSA */
+/* BEGIN_CASE depends_on:PSA_WANT_ALG_ECDSA || PSA_WANT_ALG_DETERMINISTIC_ECDSA */
 void ecdsa_raw_to_der_incremental(int key_bits, data_t *input, data_t *exp_result)
 {
     unsigned char *tmp_buf = NULL;
@@ -54,7 +54,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_PSA_UTIL_HAVE_ECDSA */
+/* BEGIN_CASE depends_on:PSA_WANT_ALG_ECDSA || PSA_WANT_ALG_DETERMINISTIC_ECDSA */
 void ecdsa_der_to_raw(int key_bits, data_t *input, data_t *exp_result, int exp_ret)
 {
     unsigned char *in_buf = NULL;

--- a/tests/suites/test_suite_psa_crypto_util.function
+++ b/tests/suites/test_suite_psa_crypto_util.function
@@ -3,7 +3,7 @@
 #include <mbedtls/psa_util.h>
 /* END_HEADER */
 
-/* BEGIN_CASE depends_on:PSA_WANT_ALG_ECDSA || PSA_WANT_ALG_DETERMINISTIC_ECDSA */
+/* BEGIN_CASE depends_on:PSA_HAVE_ALG_SOME_ECDSA */
 void ecdsa_raw_to_der(int key_bits, data_t *input, data_t *exp_result, int exp_ret)
 {
     unsigned char *tmp_buf = NULL;
@@ -24,7 +24,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:PSA_WANT_ALG_ECDSA || PSA_WANT_ALG_DETERMINISTIC_ECDSA */
+/* BEGIN_CASE depends_on:PSA_HAVE_ALG_SOME_ECDSA */
 void ecdsa_raw_to_der_incremental(int key_bits, data_t *input, data_t *exp_result)
 {
     unsigned char *tmp_buf = NULL;
@@ -54,7 +54,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:PSA_WANT_ALG_ECDSA || PSA_WANT_ALG_DETERMINISTIC_ECDSA */
+/* BEGIN_CASE depends_on:PSA_HAVE_ALG_SOME_ECDSA */
 void ecdsa_der_to_raw(int key_bits, data_t *input, data_t *exp_result, int exp_ret)
 {
     unsigned char *in_buf = NULL;

--- a/tf-psa-crypto/drivers/builtin/include/mbedtls/asn1.h
+++ b/tf-psa-crypto/drivers/builtin/include/mbedtls/asn1.h
@@ -198,7 +198,7 @@ typedef struct mbedtls_asn1_named_data {
 mbedtls_asn1_named_data;
 
 #if defined(MBEDTLS_ASN1_PARSE_C) || defined(MBEDTLS_X509_CREATE_C) || \
-    defined(MBEDTLS_PSA_UTIL_HAVE_ECDSA)
+    defined(PSA_WANT_ALG_ECDSA) || defined(PSA_WANT_ALG_DETERMINISTIC_ECDSA)
 /**
  * \brief       Get the length of an ASN.1 element.
  *              Updates the pointer to immediately behind the length.
@@ -245,7 +245,7 @@ int mbedtls_asn1_get_len(unsigned char **p,
 int mbedtls_asn1_get_tag(unsigned char **p,
                          const unsigned char *end,
                          size_t *len, int tag);
-#endif /* MBEDTLS_ASN1_PARSE_C || MBEDTLS_X509_CREATE_C || MBEDTLS_PSA_UTIL_HAVE_ECDSA */
+#endif /* MBEDTLS_ASN1_PARSE_C || MBEDTLS_X509_CREATE_C || PSA_WANT_ALG_ECDSA || PSA_WANT_ALG_DETERMINISTIC_ECDSA */
 
 #if defined(MBEDTLS_ASN1_PARSE_C)
 /**

--- a/tf-psa-crypto/drivers/builtin/include/mbedtls/asn1.h
+++ b/tf-psa-crypto/drivers/builtin/include/mbedtls/asn1.h
@@ -198,7 +198,7 @@ typedef struct mbedtls_asn1_named_data {
 mbedtls_asn1_named_data;
 
 #if defined(MBEDTLS_ASN1_PARSE_C) || defined(MBEDTLS_X509_CREATE_C) || \
-    defined(PSA_WANT_ALG_ECDSA) || defined(PSA_WANT_ALG_DETERMINISTIC_ECDSA)
+    defined(PSA_HAVE_ALG_SOME_ECDSA)
 /**
  * \brief       Get the length of an ASN.1 element.
  *              Updates the pointer to immediately behind the length.
@@ -245,7 +245,7 @@ int mbedtls_asn1_get_len(unsigned char **p,
 int mbedtls_asn1_get_tag(unsigned char **p,
                          const unsigned char *end,
                          size_t *len, int tag);
-#endif /* MBEDTLS_ASN1_PARSE_C || MBEDTLS_X509_CREATE_C || PSA_WANT_ALG_ECDSA || PSA_WANT_ALG_DETERMINISTIC_ECDSA */
+#endif /* MBEDTLS_ASN1_PARSE_C || MBEDTLS_X509_CREATE_C || PSA_HAVE_ALG_SOME_ECDSA */
 
 #if defined(MBEDTLS_ASN1_PARSE_C)
 /**

--- a/tf-psa-crypto/drivers/builtin/include/mbedtls/asn1write.h
+++ b/tf-psa-crypto/drivers/builtin/include/mbedtls/asn1write.h
@@ -37,7 +37,7 @@ extern "C" {
 #endif
 
 #if defined(MBEDTLS_ASN1_WRITE_C) || defined(MBEDTLS_X509_USE_C) || \
-    defined(MBEDTLS_PSA_UTIL_HAVE_ECDSA)
+    defined(PSA_WANT_ALG_ECDSA) || defined(PSA_WANT_ALG_DETERMINISTIC_ECDSA)
 /**
  * \brief           Write a length field in ASN.1 format.
  *
@@ -66,7 +66,7 @@ int mbedtls_asn1_write_len(unsigned char **p, const unsigned char *start,
  */
 int mbedtls_asn1_write_tag(unsigned char **p, const unsigned char *start,
                            unsigned char tag);
-#endif /* MBEDTLS_ASN1_WRITE_C || MBEDTLS_X509_USE_C || MBEDTLS_PSA_UTIL_HAVE_ECDSA*/
+#endif /* MBEDTLS_ASN1_WRITE_C || MBEDTLS_X509_USE_C || PSA_WANT_ALG_ECDSA || PSA_WANT_ALG_DETERMINISTIC_ECDSA*/
 
 #if defined(MBEDTLS_ASN1_WRITE_C)
 /**

--- a/tf-psa-crypto/drivers/builtin/include/mbedtls/asn1write.h
+++ b/tf-psa-crypto/drivers/builtin/include/mbedtls/asn1write.h
@@ -37,7 +37,7 @@ extern "C" {
 #endif
 
 #if defined(MBEDTLS_ASN1_WRITE_C) || defined(MBEDTLS_X509_USE_C) || \
-    defined(PSA_WANT_ALG_ECDSA) || defined(PSA_WANT_ALG_DETERMINISTIC_ECDSA)
+    defined(PSA_HAVE_ALG_SOME_ECDSA)
 /**
  * \brief           Write a length field in ASN.1 format.
  *
@@ -66,7 +66,7 @@ int mbedtls_asn1_write_len(unsigned char **p, const unsigned char *start,
  */
 int mbedtls_asn1_write_tag(unsigned char **p, const unsigned char *start,
                            unsigned char tag);
-#endif /* MBEDTLS_ASN1_WRITE_C || MBEDTLS_X509_USE_C || PSA_WANT_ALG_ECDSA || PSA_WANT_ALG_DETERMINISTIC_ECDSA*/
+#endif /* MBEDTLS_ASN1_WRITE_C || MBEDTLS_X509_USE_C || PSA_HAVE_ALG_SOME_ECDSA */
 
 #if defined(MBEDTLS_ASN1_WRITE_C)
 /**

--- a/tf-psa-crypto/drivers/builtin/include/mbedtls/config_psa.h
+++ b/tf-psa-crypto/drivers/builtin/include/mbedtls/config_psa.h
@@ -52,9 +52,7 @@
 
 #endif /* MBEDTLS_PSA_CRYPTO_CONFIG */
 
-#if defined(PSA_WANT_ALG_JPAKE)
-#define PSA_WANT_ALG_SOME_PAKE 1
-#endif
+#include "psa/crypto_adjust_config_derived.h"
 
 #include "psa/crypto_adjust_auto_enabled.h"
 

--- a/tf-psa-crypto/drivers/builtin/include/mbedtls/psa_util.h
+++ b/tf-psa-crypto/drivers/builtin/include/mbedtls/psa_util.h
@@ -141,7 +141,7 @@ static inline mbedtls_md_type_t mbedtls_md_type_from_psa_alg(psa_algorithm_t psa
 }
 #endif /* MBEDTLS_PSA_CRYPTO_CLIENT */
 
-#if defined(PSA_WANT_ALG_ECDSA) || defined(PSA_WANT_ALG_DETERMINISTIC_ECDSA)
+#if defined(PSA_HAVE_ALG_SOME_ECDSA)
 
 /** Convert an ECDSA signature from raw format to DER ASN.1 format.
  *
@@ -181,7 +181,7 @@ int mbedtls_ecdsa_raw_to_der(size_t bits, const unsigned char *raw, size_t raw_l
 int mbedtls_ecdsa_der_to_raw(size_t bits, const unsigned char *der, size_t der_len,
                              unsigned char *raw, size_t raw_size, size_t *raw_len);
 
-#endif /* PSA_WANT_ALG_ECDSA || PSA_WANT_ALG_DETERMINISTIC_ECDSA */
+#endif /* PSA_HAVE_ALG_SOME_ECDSA */
 
 /**@}*/
 

--- a/tf-psa-crypto/drivers/builtin/include/mbedtls/psa_util.h
+++ b/tf-psa-crypto/drivers/builtin/include/mbedtls/psa_util.h
@@ -141,7 +141,7 @@ static inline mbedtls_md_type_t mbedtls_md_type_from_psa_alg(psa_algorithm_t psa
 }
 #endif /* MBEDTLS_PSA_CRYPTO_CLIENT */
 
-#if defined(MBEDTLS_PSA_UTIL_HAVE_ECDSA)
+#if defined(PSA_WANT_ALG_ECDSA) || defined(PSA_WANT_ALG_DETERMINISTIC_ECDSA)
 
 /** Convert an ECDSA signature from raw format to DER ASN.1 format.
  *
@@ -181,7 +181,7 @@ int mbedtls_ecdsa_raw_to_der(size_t bits, const unsigned char *raw, size_t raw_l
 int mbedtls_ecdsa_der_to_raw(size_t bits, const unsigned char *der, size_t der_len,
                              unsigned char *raw, size_t raw_size, size_t *raw_len);
 
-#endif /* MBEDTLS_PSA_UTIL_HAVE_ECDSA */
+#endif /* PSA_WANT_ALG_ECDSA || PSA_WANT_ALG_DETERMINISTIC_ECDSA */
 
 /**@}*/
 

--- a/tf-psa-crypto/include/psa/crypto_adjust_config_derived.h
+++ b/tf-psa-crypto/include/psa/crypto_adjust_config_derived.h
@@ -1,0 +1,31 @@
+/**
+ * \file psa/crypto_adjust_config_derived.h
+ * \brief Adjust PSA configuration by defining internal symbols
+ *
+ * This is an internal header. Do not include it directly.
+ */
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+ */
+
+#ifndef PSA_CRYPTO_ADJUST_CONFIG_DERIVED_H
+#define PSA_CRYPTO_ADJUST_CONFIG_DERIVED_H
+
+#if !defined(MBEDTLS_CONFIG_FILES_READ)
+#error "Do not include psa/crypto_adjust_*.h manually! This can lead to problems, " \
+    "up to and including runtime errors such as buffer overflows. " \
+    "If you're trying to fix a complaint from check_config.h, just remove " \
+    "it from your configuration file: since Mbed TLS 3.0, it is included " \
+    "automatically at the right point."
+#endif /* */
+
+#if defined(PSA_WANT_ALG_ECDSA) || defined(PSA_WANT_ALG_DETERMINISTIC_ECDSA)
+#define PSA_HAVE_ALG_SOME_ECDSA
+#endif
+
+#if defined(PSA_WANT_ALG_JPAKE)
+#define PSA_WANT_ALG_SOME_PAKE 1
+#endif
+
+#endif /* PSA_CRYPTO_ADJUST_CONFIG_DERIVED_H */


### PR DESCRIPTION
## Description

Replace `MBEDTLS_PSA_UTIL_HAVE_ECDSA` with `PSA_WANT_ALG_ECDSA || PSA_WANT_ALG_DETERMINISTIC_ECDSA` and
`MBEDTLS_SSL_HAVE_AEAD` with `PSA_WANT_ALG_CCM || PSA_WANT_ALG_GCM || PSA_WANT_ALG_CHACHA20_POLY1305`

Resolves #9336 



## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required, internal changes
- [x] **3.6 backport** not required, needed for 4.0
- [x] **2.28 backport** not required, needed for 4.0
- [x] **tests** not required



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
