### PR TITLE
Replace MBEDTLS_PSA_UTIL_HAVE_ECDSA with PSA_HAVE_ALG_SOME_ECDSA

### DIFF
--- a/tf-psa-crypto/core/psa_util.c
+++ b/tf-psa-crypto/core/psa_util.c
@@ -365,7 +365,7 @@ int mbedtls_psa_get_random(void *p_rng,
 
 #endif /* MBEDTLS_PSA_CRYPTO_CLIENT */
 
-#if defined(MBEDTLS_PSA_UTIL_HAVE_ECDSA)
+#if defined(PSA_HAVE_ALG_SOME_ECDSA)
 
 /**
  * \brief  Convert a single raw coordinate to DER ASN.1 format. The output der
@@ -599,4 +599,4 @@ int mbedtls_ecdsa_der_to_raw(size_t bits, const unsigned char *der, size_t der_l
     return 0;
 }
 
-#endif /* MBEDTLS_PSA_UTIL_HAVE_ECDSA */
+#endif /* PSA_HAVE_ALG_SOME_ECDSA */

--- a/tf-psa-crypto/drivers/builtin/include/mbedtls/asn1.h
+++ b/tf-psa-crypto/drivers/builtin/include/mbedtls/asn1.h
@@ -198,7 +198,7 @@ typedef struct mbedtls_asn1_named_data {
 mbedtls_asn1_named_data;
 
 #if defined(MBEDTLS_ASN1_PARSE_C) || defined(MBEDTLS_X509_CREATE_C) || \
-    defined(MBEDTLS_PSA_UTIL_HAVE_ECDSA)
+    defined(PSA_HAVE_ALG_SOME_ECDSA)
 /**
  * \brief       Get the length of an ASN.1 element.
  *              Updates the pointer to immediately behind the length.
@@ -245,7 +245,7 @@ int mbedtls_asn1_get_len(unsigned char **p,
 int mbedtls_asn1_get_tag(unsigned char **p,
                          const unsigned char *end,
                          size_t *len, int tag);
-#endif /* MBEDTLS_ASN1_PARSE_C || MBEDTLS_X509_CREATE_C || MBEDTLS_PSA_UTIL_HAVE_ECDSA */
+#endif /* MBEDTLS_ASN1_PARSE_C || MBEDTLS_X509_CREATE_C || PSA_HAVE_ALG_SOME_ECDSA */
 
 #if defined(MBEDTLS_ASN1_PARSE_C)
 /**

--- a/tf-psa-crypto/drivers/builtin/include/mbedtls/asn1write.h
+++ b/tf-psa-crypto/drivers/builtin/include/mbedtls/asn1write.h
@@ -37,7 +37,7 @@ extern "C" {
 #endif
 
 #if defined(MBEDTLS_ASN1_WRITE_C) || defined(MBEDTLS_X509_USE_C) || \
-    defined(MBEDTLS_PSA_UTIL_HAVE_ECDSA)
+    defined(PSA_HAVE_ALG_SOME_ECDSA)
 /**
  * \brief           Write a length field in ASN.1 format.
  *
@@ -66,7 +66,7 @@ int mbedtls_asn1_write_len(unsigned char **p, const unsigned char *start,
  */
 int mbedtls_asn1_write_tag(unsigned char **p, const unsigned char *start,
                            unsigned char tag);
-#endif /* MBEDTLS_ASN1_WRITE_C || MBEDTLS_X509_USE_C || MBEDTLS_PSA_UTIL_HAVE_ECDSA*/
+#endif /* MBEDTLS_ASN1_WRITE_C || MBEDTLS_X509_USE_C || PSA_HAVE_ALG_SOME_ECDSA*/
 
 #if defined(MBEDTLS_ASN1_WRITE_C)
 /**

--- a/tf-psa-crypto/drivers/builtin/include/mbedtls/config_psa.h
+++ b/tf-psa-crypto/drivers/builtin/include/mbedtls/config_psa.h
@@ -52,9 +52,7 @@
 
 #endif /* MBEDTLS_PSA_CRYPTO_CONFIG */
 
-#if defined(PSA_WANT_ALG_JPAKE)
-#define PSA_WANT_ALG_SOME_PAKE 1
-#endif
+#include "psa/crypto_adjust_config_derived.h"
 
 #include "psa/crypto_adjust_auto_enabled.h"
 

--- a/tf-psa-crypto/drivers/builtin/include/mbedtls/psa_util.h
+++ b/tf-psa-crypto/drivers/builtin/include/mbedtls/psa_util.h
@@ -141,7 +141,7 @@ static inline mbedtls_md_type_t mbedtls_md_type_from_psa_alg(psa_algorithm_t psa
 }
 #endif /* MBEDTLS_PSA_CRYPTO_CLIENT */
 
-#if defined(MBEDTLS_PSA_UTIL_HAVE_ECDSA)
+#if defined(PSA_HAVE_ALG_SOME_ECDSA)
 
 /** Convert an ECDSA signature from raw format to DER ASN.1 format.
  *
@@ -181,7 +181,7 @@ int mbedtls_ecdsa_raw_to_der(size_t bits, const unsigned char *raw, size_t raw_l
 int mbedtls_ecdsa_der_to_raw(size_t bits, const unsigned char *der, size_t der_len,
                              unsigned char *raw, size_t raw_size, size_t *raw_len);
 
-#endif /* MBEDTLS_PSA_UTIL_HAVE_ECDSA */
+#endif /* PSA_HAVE_ALG_SOME_ECDSA */
 
 /**@}*/
 

--- a/tf-psa-crypto/drivers/builtin/src/asn1parse.c
+++ b/tf-psa-crypto/drivers/builtin/src/asn1parse.c
@@ -8,7 +8,7 @@
 #include "common.h"
 
 #if defined(MBEDTLS_ASN1_PARSE_C) || defined(MBEDTLS_X509_CREATE_C) || \
-    defined(MBEDTLS_PSA_UTIL_HAVE_ECDSA)
+    defined(PSA_HAVE_ALG_SOME_ECDSA)
 
 #include "mbedtls/asn1.h"
 #include "mbedtls/platform_util.h"
@@ -74,7 +74,7 @@ int mbedtls_asn1_get_tag(unsigned char **p,
 
     return mbedtls_asn1_get_len(p, end, len);
 }
-#endif /* MBEDTLS_ASN1_PARSE_C || MBEDTLS_X509_CREATE_C || MBEDTLS_PSA_UTIL_HAVE_ECDSA */
+#endif /* MBEDTLS_ASN1_PARSE_C || MBEDTLS_X509_CREATE_C || PSA_HAVE_ALG_SOME_ECDSA */
 
 #if defined(MBEDTLS_ASN1_PARSE_C)
 int mbedtls_asn1_get_bool(unsigned char **p,

--- a/tf-psa-crypto/drivers/builtin/src/asn1write.c
+++ b/tf-psa-crypto/drivers/builtin/src/asn1write.c
@@ -8,7 +8,7 @@
 #include "common.h"
 
 #if defined(MBEDTLS_ASN1_WRITE_C) || defined(MBEDTLS_X509_USE_C) || \
-    defined(MBEDTLS_PSA_UTIL_HAVE_ECDSA)
+    defined(PSA_HAVE_ALG_SOME_ECDSA)
 
 #include "mbedtls/asn1write.h"
 #include "mbedtls/error.h"
@@ -63,7 +63,7 @@ int mbedtls_asn1_write_tag(unsigned char **p, const unsigned char *start, unsign
 
     return 1;
 }
-#endif /* MBEDTLS_ASN1_WRITE_C || MBEDTLS_X509_USE_C || MBEDTLS_PSA_UTIL_HAVE_ECDSA */
+#endif /* MBEDTLS_ASN1_WRITE_C || MBEDTLS_X509_USE_C || PSA_HAVE_ALG_SOME_ECDSA */
 
 #if defined(MBEDTLS_ASN1_WRITE_C)
 static int mbedtls_asn1_write_len_and_tag(unsigned char **p,

--- a/tf-psa-crypto/include/psa/crypto_adjust_config_derived.h
+++ b/tf-psa-crypto/include/psa/crypto_adjust_config_derived.h
@@ -1,0 +1,31 @@
+/**
+ * \file psa/crypto_adjust_config_derived.h
+ * \brief Adjust PSA configuration by defining internal symbols
+ *
+ * This is an internal header. Do not include it directly.
+ */
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+ */
+
+#ifndef PSA_CRYPTO_ADJUST_CONFIG_DERIVED_H
+#define PSA_CRYPTO_ADJUST_CONFIG_DERIVED_H
+
+#if !defined(MBEDTLS_CONFIG_FILES_READ)
+#error "Do not include psa/crypto_adjust_*.h manually! This can lead to problems, " \
+    "up to and including runtime errors such as buffer overflows. " \
+    "If you're trying to fix a complaint from check_config.h, just remove " \
+    "it from your configuration file: since Mbed TLS 3.0, it is included " \
+    "automatically at the right point."
+#endif /* */
+
+#if defined(PSA_WANT_ALG_ECDSA) || defined(PSA_WANT_ALG_DETERMINISTIC_ECDSA)
+#define PSA_HAVE_ALG_SOME_ECDSA
+#endif
+
+#if defined(PSA_WANT_ALG_JPAKE)
+#define PSA_WANT_ALG_SOME_PAKE 1
+#endif
+
+#endif /* PSA_CRYPTO_ADJUST_CONFIG_DERIVED_H */

--- a/tf-psa-crypto/tests/suites/test_suite_psa_crypto_util.function
+++ b/tf-psa-crypto/tests/suites/test_suite_psa_crypto_util.function
@@ -3,7 +3,7 @@
 #include <mbedtls/psa_util.h>
 /* END_HEADER */
 
-/* BEGIN_CASE depends_on:MBEDTLS_PSA_UTIL_HAVE_ECDSA */
+/* BEGIN_CASE depends_on:PSA_HAVE_ALG_SOME_ECDSA */
 void ecdsa_raw_to_der(int key_bits, data_t *input, data_t *exp_result, int exp_ret)
 {
     unsigned char *tmp_buf = NULL;
@@ -24,7 +24,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_PSA_UTIL_HAVE_ECDSA */
+/* BEGIN_CASE depends_on:PSA_HAVE_ALG_SOME_ECDSA */
 void ecdsa_raw_to_der_incremental(int key_bits, data_t *input, data_t *exp_result)
 {
     unsigned char *tmp_buf = NULL;
@@ -54,7 +54,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_PSA_UTIL_HAVE_ECDSA */
+/* BEGIN_CASE depends_on:PSA_HAVE_ALG_SOME_ECDSA */
 void ecdsa_der_to_raw(int key_bits, data_t *input, data_t *exp_result, int exp_ret)
 {
     unsigned char *in_buf = NULL;


### PR DESCRIPTION
## Description

Replace `MBEDTLS_PSA_UTIL_HAVE_ECDSA` with `PSA_HAVE_ALG_SOME_ECDSA`

Resolves #9336 



## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required, internal changes
- [x] **3.6 backport** not required, needed for 4.0
- [x] **2.28 backport** not required, needed for 4.0
- [x] **tests** not required



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
