### PR TITLE
[Backport 2.28] Fix some typo for include folder

### DIFF
--- a/include/mbedtls/ecdh.h
+++ b/include/mbedtls/ecdh.h
@@ -299,7 +299,7 @@ int mbedtls_ecdh_read_params(mbedtls_ecdh_context *ctx,
  * \brief           This function sets up an ECDH context from an EC key.
  *
  *                  It is used by clients and servers in place of the
- *                  ServerKeyEchange for static ECDH, and imports ECDH
+ *                  ServerKeyExchange for static ECDH, and imports ECDH
  *                  parameters from the EC key information of a certificate.
  *
  * \see             ecp.h

--- a/include/mbedtls/ecp.h
+++ b/include/mbedtls/ecp.h
@@ -259,7 +259,7 @@ mbedtls_ecp_point;
  * range of <code>0..2^(2*pbits)-1</code>, and transforms it in-place to an integer
  * which is congruent mod \p P to the given MPI, and is close enough to \p pbits
  * in size, so that it may be efficiently brought in the 0..P-1 range by a few
- * additions or subtractions. Therefore, it is only an approximative modular
+ * additions or subtractions. Therefore, it is only an approximate modular
  * reduction. It must return 0 on success and non-zero on failure.
  *
  * \note        Alternative implementations must keep the group IDs distinct. If

--- a/programs/test/metatest.c
+++ b/programs/test/metatest.c
@@ -385,7 +385,7 @@ typedef struct {
     void (*entry_point)(const char *name);
 } metatest_t;
 
-/* The list of availble meta-tests. Remember to register new functions here!
+/* The list of available meta-tests. Remember to register new functions here!
  *
  * Note that we always compile all the functions, so that `metatest --list`
  * will always list all the available meta-tests.

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -1351,7 +1351,7 @@ run_test_psa_force_curve() {
 # a maximum fragment length.
 #  first argument ($1) is MFL for SSL client
 #  second argument ($2) is memory usage for SSL client with default MFL (16k)
-run_test_memory_after_hanshake_with_mfl()
+run_test_memory_after_handshake_with_mfl()
 {
     # The test passes if the difference is around 2*(16k-MFL)
     MEMORY_USAGE_LIMIT="$(( $2 - ( 2 * ( 16384 - $1 )) ))"
@@ -1371,7 +1371,7 @@ run_test_memory_after_hanshake_with_mfl()
 
 # Test that the server's memory usage after a handshake is reduced when a client specifies
 # different values of Maximum Fragment Length: default (16k), 4k, 2k, 1k and 512 bytes
-run_tests_memory_after_hanshake()
+run_tests_memory_after_handshake()
 {
     # all tests in this sequence requires the same configuration (see requires_config_enabled())
     SKIP_THIS_TESTS="$SKIP_NEXT"
@@ -1387,16 +1387,16 @@ run_tests_memory_after_hanshake()
                 -F "handshake_memory_get MEMORY_USAGE_MFL_16K"
 
     SKIP_NEXT="$SKIP_THIS_TESTS"
-    run_test_memory_after_hanshake_with_mfl 4096 "$MEMORY_USAGE_MFL_16K"
+    run_test_memory_after_handshake_with_mfl 4096 "$MEMORY_USAGE_MFL_16K"
 
     SKIP_NEXT="$SKIP_THIS_TESTS"
-    run_test_memory_after_hanshake_with_mfl 2048 "$MEMORY_USAGE_MFL_16K"
+    run_test_memory_after_handshake_with_mfl 2048 "$MEMORY_USAGE_MFL_16K"
 
     SKIP_NEXT="$SKIP_THIS_TESTS"
-    run_test_memory_after_hanshake_with_mfl 1024 "$MEMORY_USAGE_MFL_16K"
+    run_test_memory_after_handshake_with_mfl 1024 "$MEMORY_USAGE_MFL_16K"
 
     SKIP_NEXT="$SKIP_THIS_TESTS"
-    run_test_memory_after_hanshake_with_mfl 512 "$MEMORY_USAGE_MFL_16K"
+    run_test_memory_after_handshake_with_mfl 512 "$MEMORY_USAGE_MFL_16K"
 }
 
 cleanup() {
@@ -4372,7 +4372,7 @@ run_test    "Renegotiation: openssl server, client-initiated" \
             -c "client hello, adding renegotiation extension" \
             -c "found renegotiation extension" \
             -c "=> renegotiate" \
-            -C "ssl_hanshake() returned" \
+            -C "ssl_handshake() returned" \
             -C "error" \
             -c "HTTP/1.0 200 [Oo][Kk]"
 
@@ -4385,7 +4385,7 @@ run_test    "Renegotiation: gnutls server strict, client-initiated" \
             -c "client hello, adding renegotiation extension" \
             -c "found renegotiation extension" \
             -c "=> renegotiate" \
-            -C "ssl_hanshake() returned" \
+            -C "ssl_handshake() returned" \
             -C "error" \
             -c "HTTP/1.0 200 [Oo][Kk]"
 
@@ -4426,7 +4426,7 @@ run_test    "Renegotiation: gnutls server unsafe, client-inititated legacy" \
             -c "client hello, adding renegotiation extension" \
             -C "found renegotiation extension" \
             -c "=> renegotiate" \
-            -C "ssl_hanshake() returned" \
+            -C "ssl_handshake() returned" \
             -C "error" \
             -c "HTTP/1.0 200 [Oo][Kk]"
 
@@ -10608,7 +10608,7 @@ requires_config_enabled MBEDTLS_MEMORY_DEBUG
 requires_config_enabled MBEDTLS_MEMORY_BUFFER_ALLOC_C
 requires_config_enabled MBEDTLS_SSL_MAX_FRAGMENT_LENGTH
 requires_max_content_len 16384
-run_tests_memory_after_hanshake
+run_tests_memory_after_handshake
 
 if [ "$LIST_TESTS" -eq 0 ]; then
     # Final report


### PR DESCRIPTION
## Description

Partial backport of #9287 (some files do not exist in 2.28)



## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required
- [x] **3.6 backport** done -> #9386 
- [x] **2.28 backport** done
- [x] **tests** not required



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
