### PR TITLE
[Backport 3.6] psa: fix parameters' names of psa_key_derivation_verify_bytes()

### DIFF
--- a/include/psa/crypto.h
+++ b/include/psa/crypto.h
@@ -3865,8 +3865,8 @@ psa_status_t psa_key_derivation_output_key_ext(
  * psa_key_derivation_abort().
  *
  * \param[in,out] operation The key derivation operation object to read from.
- * \param[in] expected_output Buffer containing the expected derivation output.
- * \param output_length     Length of the expected output; this is also the
+ * \param[in] expected      Buffer containing the expected derivation output.
+ * \param expected_length   Length of the expected output; this is also the
  *                          number of bytes that will be read.
  *
  * \retval #PSA_SUCCESS \emptydescription
@@ -3896,8 +3896,8 @@ psa_status_t psa_key_derivation_output_key_ext(
  */
 psa_status_t psa_key_derivation_verify_bytes(
     psa_key_derivation_operation_t *operation,
-    const uint8_t *expected_output,
-    size_t output_length);
+    const uint8_t *expected,
+    size_t expected_length);
 
 /** Compare output data from a key derivation operation to an expected value
  * stored in a key object.


### PR DESCRIPTION
## Description

This is the backport of #9308

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [ ] **changelog** not required because: this is only a documentation update
- [ ] **development PR** provided: https://github.com/Mbed-TLS/mbedtls/pull/9308 
- [ ] **framework PR** not required
- [ ] **3.6 PR** not required because: this is the 3.6 backport
- [ ] **2.28 PR** not required
- **tests** not required because: this is only a documentation update