### PR TITLE
[Backport 3.6] tests/ssl_helpers: Check that message queue is popped

### DIFF
--- a/tests/src/test_helpers/ssl_helpers.c
+++ b/tests/src/test_helpers/ssl_helpers.c
@@ -551,7 +551,10 @@ int mbedtls_test_mock_tcp_recv_msg(void *ctx,
              * happen in test environment, unless forced manually. */
         }
     }
-    mbedtls_test_ssl_message_queue_pop_info(queue, buf_len);
+    ret = mbedtls_test_ssl_message_queue_pop_info(queue, buf_len);
+    if (ret < 0) {
+        return ret;
+    }
 
     return (msg_len > INT_MAX) ? INT_MAX : (int) msg_len;
 }


### PR DESCRIPTION
Trivial backport of #8775 

## PR checklist

- [x] **changelog** not required
- [x] **backport 3.6** this is the backport
- [x] **backport 2.28** done -> #9440 
- [x] **tests** : This a small change in testing
