### PR TITLE
ecp.h: Fix documentation of nbits for Montgomery keys

### DIFF
--- a/tf-psa-crypto/drivers/builtin/include/mbedtls/ecp.h
+++ b/tf-psa-crypto/drivers/builtin/include/mbedtls/ecp.h
@@ -200,7 +200,8 @@ mbedtls_ecp_point;
  *
  * For Montgomery curves, we do not store \p A, but <code>(A + 2) / 4</code>,
  * which is the quantity used in the formulas. Additionally, \p nbits is
- * not the size of \p N but the required size for private keys.
+ * not the size of \p N but the position of the highest bit for private keys,
+ * i.e. the private key bit-size minus 1.
  *
  * If \p modp is NULL, reduction modulo \p P is done using a generic algorithm.
  * Otherwise, \p modp must point to a function that takes an \p mbedtls_mpi in the
@@ -235,8 +236,8 @@ typedef struct mbedtls_ecp_group {
     mbedtls_mpi N;              /*!< The order of \p G. */
     size_t pbits;               /*!< The number of bits in \p P.*/
     size_t nbits;               /*!< For Short Weierstrass: The number of bits in \p P.
-                                     For Montgomery curves: the number of bits in the
-                                     private keys. */
+                                     For Montgomery curves: one less than the
+                                     number of bits in private keys. */
     /* End of public fields */
 
     unsigned int MBEDTLS_PRIVATE(h);             /*!< \internal 1 if the constants are static. */


### PR DESCRIPTION
Fixes #9393.

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** not required because: documentation only
- [x] **development PR** here
- [x] **framework PR** not required
- [ ] **3.6 PR** TODO
- [ ] **2.28 PR** TODO
- **tests**  not required because: documentation only
