### PR TITLE
[Backport 3.6] PR 9394 backport of fixes and framework submodule update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,10 @@ cmake_minimum_required(VERSION 3.5.1)
 
 include(CMakePackageConfigHelpers)
 
+# Include convenience functions for printing properties and variables, like
+# cmake_print_properties(), cmake_print_variables().
+include(CMakePrintHelpers)
+
 # https://cmake.org/cmake/help/latest/policy/CMP0011.html
 # Setting this policy is required in CMake >= 3.18.0, otherwise a warning is generated. The OLD
 # policy setting is deprecated, and will be removed in future versions.

--- a/programs/fuzz/Makefile
+++ b/programs/fuzz/Makefile
@@ -9,9 +9,7 @@ ifdef FUZZINGENGINE
 LOCAL_LDFLAGS += -lFuzzingEngine
 endif
 
-# A test application is built for each suites/test_suite_*.data file.
-# Application name is same as .data file's base name and can be
-# constructed by stripping path 'suites/' and extension .data.
+# A test application is built for each fuzz_*.c file.
 APPS = $(basename $(wildcard fuzz_*.c))
 
 # Construct executable name by adding OS specific suffix $(EXEXT).

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -69,7 +69,8 @@ string(REGEX REPLACE "[^;]*/" ""
 # Derive generated file paths in the build directory. The generated data
 # files go into the suites/ subdirectory.
 set(base_generated_data_files
-    ${base_bignum_generated_data_files} ${base_ecp_generated_data_files} ${base_psa_generated_data_files})
+    ${base_bignum_generated_data_files} ${base_config_generated_data_files}
+    ${base_ecp_generated_data_files} ${base_psa_generated_data_files})
 string(REGEX REPLACE "([^;]+)" "suites/\\1"
        all_generated_data_files "${base_generated_data_files}")
 set(bignum_generated_data_files "")
@@ -197,6 +198,7 @@ function(add_test_suite suite_name)
     # Get the test names of the tests with generated .data files
     # from the generated_data_files list in parent scope.
     set(bignum_generated_data_names "")
+    set(config_generated_data_names "")
     set(ecp_generated_data_names "")
     set(psa_generated_data_names "")
     foreach(generated_data_file ${bignum_generated_data_files})
@@ -207,6 +209,15 @@ function(add_test_suite suite_name)
         # Remove leading "test_suite_"
         string(SUBSTRING ${generated_data_name} 11 -1 generated_data_name)
         list(APPEND bignum_generated_data_names ${generated_data_name})
+    endforeach()
+    foreach(generated_data_file ${config_generated_data_files})
+        # Get the plain filename
+        get_filename_component(generated_data_name ${generated_data_file} NAME)
+        # Remove the ".data" extension
+        get_name_without_last_ext(generated_data_name ${generated_data_name})
+        # Remove leading "test_suite_"
+        string(SUBSTRING ${generated_data_name} 11 -1 generated_data_name)
+        list(APPEND config_generated_data_names ${generated_data_name})
     endforeach()
     foreach(generated_data_file ${ecp_generated_data_files})
         # Get the plain filename
@@ -234,7 +245,7 @@ function(add_test_suite suite_name)
     elseif(";${config_generated_data_names};" MATCHES ";${data_name};")
         set(data_file
             ${CMAKE_CURRENT_BINARY_DIR}/suites/test_suite_${data_name}.data)
-        set(dependency test_suite_bignum_generated_data)
+        set(dependency test_suite_config_generated_data)
     elseif(";${ecp_generated_data_names};" MATCHES ";${data_name};")
         set(data_file
             ${CMAKE_CURRENT_BINARY_DIR}/suites/test_suite_${data_name}.data)

--- a/tests/include/test/psa_test_wrappers.h
+++ b/tests/include/test/psa_test_wrappers.h
@@ -17,7 +17,6 @@ extern "C" {
     !defined(RECORD_PSA_STATUS_COVERAGE_LOG)
 
 #include <psa/crypto.h>
-
 #include <test/memory.h>
 #include <test/psa_crypto_helpers.h>
 #include <test/psa_test_wrappers.h>

--- a/tests/src/psa_test_wrappers.c
+++ b/tests/src/psa_test_wrappers.c
@@ -10,7 +10,6 @@
     !defined(RECORD_PSA_STATUS_COVERAGE_LOG)
 
 #include <psa/crypto.h>
-
 #include <test/memory.h>
 #include <test/psa_crypto_helpers.h>
 #include <test/psa_test_wrappers.h>


### PR DESCRIPTION
## Description
In 3.6, backport some improvements/fixes and the framework update done in PR 9394. 

## PR checklist
- [x] **changelog** not required because: we will have one change log for the whole repo split work
- [x] **development PR** provided #9394
- [x] **framework PR** provided Mbed-TLS/mbedtls-framework#36
- [x] **3.6 PR** not required because: n/a
- [x] **2.28 PR** not required because: n/a
- **tests**  not required because: no additional tests required