### PR TITLE
basic-build-test.sh: Restore make only command

### DIFF
--- a/tests/scripts/basic-build-test.sh
+++ b/tests/scripts/basic-build-test.sh
@@ -76,7 +76,7 @@ export LDFLAGS=' --coverage'
 make clean
 cp "$CONFIG_H" "$CONFIG_BAK"
 scripts/config.py full
-make -j
+make
 
 
 # Step 2 - Execute the tests


### PR DESCRIPTION
## Description

Fix local testing leftover when working on #9394 . This was causing basic-build-test.sh to fail on the Open CI (not the internal one though).

Change tested successfully [here](https://mbedtls.trustedfirmware.org/job/mbed-tls-nightly-tests/812/).

## PR checklist

- [x] **changelog** not required because: fix in a test script 
- [x] **development PR** provided #9431 
- [x] **framework PR** not required
- [x] **3.6 PR** not required because: development only issue 
- [x] **2.28 PR** not required because: development only issue 
- **tests**  not required because:  fix in a test script