### PR TITLE
3.6 only: Announce the main removals planned for 4.0

### DIFF
--- a/ChangeLog.d/announce-4.0-removals.txt
+++ b/ChangeLog.d/announce-4.0-removals.txt
@@ -1,0 +1,29 @@
+New deprecations
+   * The following cryptographic mechanisms are planned to be removed
+     in Mbed TLS 4.0:
+     - DES (including 3DES).
+     - PKCS#1v1.5 encryption (RSA-PKCS1-v1_5). (OAEP, PSS, and PKCS#1v1.5
+       signature are staying.)
+     - Finite-field Diffie-Hellman with custom groups. (RFC 7919 remain
+       supported.)
+     - Elliptic curves of size 225 bits or less.
+   * The following mechanisms are planned to be removed from (D)TLS 1.2
+     in Mbed TLS 4.0:
+     - RSA decryption (i.e. cipher suites using RSA without a key exchange:
+       cipher suites using an RSA signature and ECDHE are staying).
+     - Static ECDH (ephemeral ECDH, i.e. cipher suites using ECDHE, is staying).
+     - Finite-field Diffie-Hellman (i.e. DHE; ECDHE is staying)
+     - All cipher suites using CBC.
+   * The following low-level interfaces are planned to be removed from the
+     public API in Mbed TLS 4.0:
+     - Hashes: md5.h, ripemd160.h, sha1.h, sha3.h, sha256.h, sha512.h;
+     - Pseudorandom generation: ctr_drbg.h, hmac_drbg.h.
+     - Cipher primitives: aes.h, aria.h, camellia.h, chacha20.h,
+       chachapoly.h, poly1305.h;
+     - Cipher modes: ccm.h, cipher.h, cmac.h, gcm.h, hkdf.h;
+     - Private key encryption mechanisms: pkcs5.h, pkcs12.h.
+     - Asymmetric cryptography: bignum.h, dhm.h, ecdh.h, ecdsa.h, ecjpake.h,
+       ecp.h, rsa.h.
+     The cryptographic mechanisms remain present, but they will only be
+     accessible via the PSA API (psa_xxx functions introduced in
+     Mbed TLS 2.17.0) and, where relevant, PK.

--- a/ChangeLog.d/announce-4.0-removals.txt
+++ b/ChangeLog.d/announce-4.0-removals.txt
@@ -2,10 +2,10 @@ New deprecations
    * The following cryptographic mechanisms are planned to be removed
      in Mbed TLS 4.0:
      - DES (including 3DES).
-     - PKCS#1v1.5 encryption (RSA-PKCS1-v1_5). (OAEP, PSS, and PKCS#1v1.5
-       signature are staying.)
-     - Finite-field Diffie-Hellman with custom groups. (RFC 7919 remain
-       supported.)
+     - PKCS#1v1.5 encryption/decryption (RSAES-PKCS1-v1_5).
+       (OAEP, PSS, and PKCS#1v1.5 signature are staying.)
+     - Finite-field Diffie-Hellman with custom groups.
+       (RFC 7919 groups remain supported.)
      - Elliptic curves of size 225 bits or less.
    * The following mechanisms are planned to be removed from (D)TLS 1.2
      in Mbed TLS 4.0:

--- a/ChangeLog.d/announce-4.0-removals.txt
+++ b/ChangeLog.d/announce-4.0-removals.txt
@@ -17,8 +17,8 @@ New deprecations
      - TLS_DHE_*, i.e. cipher suites using finite-field Diffie-Hellman.
        (Ephemeral ECDH, i.e. TLS_ECDHE_*, is staying.)
      - TLS_*CBC*, i.e. all cipher suites using CBC.
-   * The following low-level interfaces are planned to be removed from the
-     public API in Mbed TLS 4.0:
+   * The following low-level application interfaces are planned to be removed
+     from the public API in Mbed TLS 4.0:
      - Hashes: hkdf.h, md5.h, ripemd160.h, sha1.h, sha3.h, sha256.h, sha512.h;
      - Pseudorandom generation: ctr_drbg.h, hmac_drbg.h;
      - Ciphers and modes: aes.h, aria.h, camellia.h, chacha20.h, chachapoly.h,
@@ -31,3 +31,9 @@ New deprecations
      Mbed TLS 2.28.0) and, where relevant, PK.
      For guidance on migrating application code to the PSA API, please consult
      the PSA transition guide (docs/psa-transition.md).
+   * The following integration interfaces are planned to be removed
+     in Mbed TLS 4.0:
+     - MBEDTLS_xxx_ALT replacement of cryptographic modules and functions.
+       Use PSA transparent drivers instead.
+     - MBEDTLS_PK_RSA_ALT and MBEDTLS_PSA_CRYPTO_SE_C.
+       Use PSA opaque drivers instead.

--- a/ChangeLog.d/announce-4.0-removals.txt
+++ b/ChangeLog.d/announce-4.0-removals.txt
@@ -16,11 +16,10 @@ New deprecations
      - All cipher suites using CBC.
    * The following low-level interfaces are planned to be removed from the
      public API in Mbed TLS 4.0:
-     - Hashes: md5.h, ripemd160.h, sha1.h, sha3.h, sha256.h, sha512.h;
-     - Pseudorandom generation: ctr_drbg.h, hmac_drbg.h.
-     - Cipher primitives: aes.h, aria.h, camellia.h, chacha20.h,
-       chachapoly.h, poly1305.h;
-     - Cipher modes: ccm.h, cipher.h, cmac.h, gcm.h, hkdf.h;
+     - Hashes: hkdf.h, md5.h, ripemd160.h, sha1.h, sha3.h, sha256.h, sha512.h;
+     - Pseudorandom generation: ctr_drbg.h, hmac_drbg.h;
+     - Ciphers and modes: aes.h, aria.h, camellia.h, chacha20.h, chachapoly.h,
+       cipher.h, cmac.h, gcm.h, poly1305.h;
      - Private key encryption mechanisms: pkcs5.h, pkcs12.h.
      - Asymmetric cryptography: bignum.h, dhm.h, ecdh.h, ecdsa.h, ecjpake.h,
        ecp.h, rsa.h.

--- a/ChangeLog.d/announce-4.0-removals.txt
+++ b/ChangeLog.d/announce-4.0-removals.txt
@@ -24,7 +24,7 @@ New deprecations
      - Asymmetric cryptography: bignum.h, dhm.h, ecdh.h, ecdsa.h, ecjpake.h,
        ecp.h, rsa.h.
      The cryptographic mechanisms remain present, but they will only be
-     accessible via the PSA API (psa_xxx functions introduced in
-     Mbed TLS 2.17.0) and, where relevant, PK.
+     accessible via the PSA API (psa_xxx functions introduced before
+     Mbed TLS 2.28.0) and, where relevant, PK.
      For guidance on migrating application code to the PSA API, please consult
      the PSA transition guide (docs/psa-transition.md).

--- a/ChangeLog.d/announce-4.0-removals.txt
+++ b/ChangeLog.d/announce-4.0-removals.txt
@@ -27,3 +27,5 @@ New deprecations
      The cryptographic mechanisms remain present, but they will only be
      accessible via the PSA API (psa_xxx functions introduced in
      Mbed TLS 2.17.0) and, where relevant, PK.
+     For guidance on migrating application code to the PSA API, please consult
+     the PSA transition guide (docs/psa-transition.md).

--- a/ChangeLog.d/announce-4.0-removals.txt
+++ b/ChangeLog.d/announce-4.0-removals.txt
@@ -20,7 +20,7 @@ New deprecations
    * The following low-level application interfaces are planned to be removed
      from the public API in Mbed TLS 4.0:
      - Hashes: hkdf.h, md5.h, ripemd160.h, sha1.h, sha3.h, sha256.h, sha512.h;
-     - Pseudorandom generation: ctr_drbg.h, hmac_drbg.h;
+     - Random generation: ctr_drbg.h, hmac_drbg.h, entropy.h;
      - Ciphers and modes: aes.h, aria.h, camellia.h, chacha20.h, chachapoly.h,
        cipher.h, cmac.h, gcm.h, poly1305.h;
      - Private key encryption mechanisms: pkcs5.h, pkcs12.h.

--- a/ChangeLog.d/announce-4.0-removals.txt
+++ b/ChangeLog.d/announce-4.0-removals.txt
@@ -7,13 +7,16 @@ New deprecations
      - Finite-field Diffie-Hellman with custom groups.
        (RFC 7919 groups remain supported.)
      - Elliptic curves of size 225 bits or less.
-   * The following mechanisms are planned to be removed from (D)TLS 1.2
+   * The following cipher suites are planned to be removed from (D)TLS 1.2
      in Mbed TLS 4.0:
-     - RSA decryption (i.e. cipher suites using RSA without a key exchange:
-       cipher suites using an RSA signature and ECDHE are staying).
-     - Static ECDH (ephemeral ECDH, i.e. cipher suites using ECDHE, is staying).
-     - Finite-field Diffie-Hellman (i.e. DHE; ECDHE is staying)
-     - All cipher suites using CBC.
+     - TLS_RSA_* (including TLS_RSA_PSK_*), i.e. cipher suites using
+       RSA decryption.
+       (RSA signatures, i.e. TLS_ECDHE_RSA_*, are staying.)
+     - TLS_ECDH_*, i.e. cipher suites using static ECDH.
+       (Ephemeral ECDH, i.e. TLS_ECDHE_*, is staying.)
+     - TLS_DHE_*, i.e. cipher suites using finite-field Diffie-Hellman.
+       (Ephemeral ECDH, i.e. TLS_ECDHE_*, is staying.)
+     - TLS_*CBC*, i.e. all cipher suites using CBC.
    * The following low-level interfaces are planned to be removed from the
      public API in Mbed TLS 4.0:
      - Hashes: hkdf.h, md5.h, ripemd160.h, sha1.h, sha3.h, sha256.h, sha512.h;

--- a/ChangeLog.d/announce-4.0-removals.txt
+++ b/ChangeLog.d/announce-4.0-removals.txt
@@ -27,8 +27,8 @@ New deprecations
      - Asymmetric cryptography: bignum.h, dhm.h, ecdh.h, ecdsa.h, ecjpake.h,
        ecp.h, rsa.h.
      The cryptographic mechanisms remain present, but they will only be
-     accessible via the PSA API (psa_xxx functions introduced before
-     Mbed TLS 2.28.0) and, where relevant, PK.
+     accessible via the PSA API (psa_xxx functions introduced gradually
+     starting with Mbed TLS 2.17) and, where relevant, `pk.h`.
      For guidance on migrating application code to the PSA API, please consult
      the PSA transition guide (docs/psa-transition.md).
    * The following integration interfaces are planned to be removed


### PR DESCRIPTION
Ideally we should officially deprecate features before removing them. But we don't add compiler warnings in an LTS release, so we aren't going to make anything deprecated in the warned-by-compiler sense. Still, I think it makes sense to use the changelog as a deprecation announcement channel.

I've only listed the main features we're planning to remove, not every little detail. I'm focusing on where a major feature is getting removed. I don't plan to make such an announcement of this type for individual functions, build system changes, etc.

## PR checklist

- [x] **changelog** provided
- [x] **development PR** not required because: we'll announce removals as we do them
- [x] **framework PR** not required
- [x] **3.6 PR** here
- [x] **2.28 PR** not required because: irrelevant
- **tests**  not required because: documentation only
