### PR TITLE
[Backport 3.6] psa_util.c included in builds without PSA, which can break the build

### DIFF
--- a/ChangeLog.d/psa_util_in_builds_without_psa.txt
+++ b/ChangeLog.d/psa_util_in_builds_without_psa.txt
@@ -1,0 +1,5 @@
+Bugfix
+   * When MBEDTLS_PSA_CRYPTO_C was disabled and MBEDTLS_ECDSA_C enabled,
+     some code was defining 0-size arrays, resulting in compilation errors.
+     Fixed by disabling the offending code in configurations without PSA
+     Crypto, where it never worked. Fixes #9311.

--- a/include/mbedtls/config_adjust_legacy_crypto.h
+++ b/include/mbedtls/config_adjust_legacy_crypto.h
@@ -428,7 +428,7 @@
 
 /* psa_util file features some ECDSA conversion functions, to convert between
  * legacy's ASN.1 DER format and PSA's raw one. */
-#if defined(MBEDTLS_ECDSA_C) || (defined(MBEDTLS_PSA_CRYPTO_C) && \
+#if (defined(MBEDTLS_PSA_CRYPTO_CLIENT) && \
     (defined(PSA_WANT_ALG_ECDSA) || defined(PSA_WANT_ALG_DETERMINISTIC_ECDSA)))
 #define MBEDTLS_PSA_UTIL_HAVE_ECDSA
 #endif


### PR DESCRIPTION
Backport of #9313 

## PR checklist

- [x] **changelog** provided
- [x] **3.6 backport** provided - this is the backport.
- [x] **2.28 backport** not required, feature doesn't exist
- [x] **tests** not required because we removed buggy functions in configurations that made them buggy. See also #9317