### PR TITLE
[Backport 3.6] Implement TLS-Exporter

### DIFF
--- a/ChangeLog.d/add-tls-exporter.txt
+++ b/ChangeLog.d/add-tls-exporter.txt
@@ -1,0 +1,4 @@
+Features:
+   * Add the function mbedtls_ssl_export_keying_material() which allows the
+     client and server to extract additional shared symmetric keys from an SSL
+     session, according to the TLS-Exporter specification in RFC 8446 and 5705.

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -5591,6 +5591,30 @@ int  mbedtls_ssl_tls_prf(const mbedtls_tls_prf_types prf,
                          const unsigned char *random, size_t rlen,
                          unsigned char *dstbuf, size_t dlen);
 
+ /**
+  * \brief             TLS-Exporter to derive shared symmetric keys between server and client.
+  *
+  * \param ctx         SSL context from which to export keys. Must have finished the handshake.
+  * \param out         Output buffer of length at least key_len bytes.
+  * \param key_len     Length of the key to generate in bytes. Must be < 2^16 in TLS 1.3.
+  * \param label       Label for which to generate the key of length label_len.
+  * \param label_len   Length of label in bytes. Must be < 251 in TLS 1.3.
+  * \param context     Context of the key. Can be NULL if context_len or use_context is 0.
+  * \param context_len Length of context. Must be < 2^16 in TLS1.2.
+  * \param use_context Indicates if a context should be used in deriving the key.
+  *
+  * \note TLS 1.2 makes a distinction between a 0-length context and no context.
+  *       This is why the use_context argument exists. TLS 1.3 does not make
+  *       this distinction. If use_context is 0 and TLS 1.3 is used, context and
+  *       context_len are ignored and a 0-length context is used.
+  *
+  * \return            0 on success. An SSL specific error on failure.
+  */
+ int mbedtls_ssl_export_keying_material(mbedtls_ssl_context *ssl,
+                                        uint8_t *out, size_t key_len,
+                                        const char *label, size_t label_len,
+                                        const unsigned char *context, size_t context_len,
+                                        int use_context);
 #ifdef __cplusplus
 }
 #endif

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -19,6 +19,7 @@
 #include "ssl_client.h"
 #include "ssl_debug_helpers.h"
 #include "ssl_misc.h"
+#include "ssl_tls13_keys.h"
 
 #include "debug_internal.h"
 #include "mbedtls/error.h"
@@ -9933,4 +9934,99 @@ int mbedtls_ssl_session_set_ticket_alpn(mbedtls_ssl_session *session,
     return 0;
 }
 #endif /* MBEDTLS_SSL_SRV_C && MBEDTLS_SSL_EARLY_DATA && MBEDTLS_SSL_ALPN */
+
+static int mbedtls_ssl_tls12_export_keying_material(const mbedtls_ssl_context *ssl,
+                                                    const mbedtls_md_type_t hash_alg,
+                                                    uint8_t *out, const size_t key_len,
+                                                    const char *label, const size_t label_len,
+                                                    const unsigned char *context, const size_t context_len,
+                                                    const int use_context)
+{
+    int ret = 0;
+    size_t prf_input_len = use_context ? 64 + 2 + context_len : 64;
+    unsigned char *prf_input = NULL;
+    char *label_str = NULL;
+
+    if (use_context && context_len >= (1 << 16)) {
+        ret = MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
+        goto exit;
+    }
+
+    prf_input = mbedtls_calloc(prf_input_len, sizeof(unsigned char));
+    label_str = mbedtls_calloc(label_len + 1, sizeof(char));
+    if (prf_input == NULL || label_str == NULL) {
+        ret = MBEDTLS_ERR_SSL_ALLOC_FAILED;
+        goto exit;
+    }
+
+    memcpy(label_str, label, label_len);
+    label_str[label_len] = '\0';
+
+    /* The input to the PRF is client_random, then server_random.
+     * If a context is provided, this is then followed by the context length
+     * as a 16-bit big-endian integer, and then the context itself. */
+    memcpy(prf_input, ssl->transform->randbytes + 32, 32);
+    memcpy(prf_input + 32, ssl->transform->randbytes, 32);
+    if (use_context) {
+        prf_input[64] = (unsigned char)((context_len >> 8) & 0xff);
+        prf_input[65] = (unsigned char)(context_len & 0xff);
+        memcpy(prf_input + 66, context, context_len);
+    }
+    ret = tls_prf_generic(hash_alg, ssl->session->master, 48, label_str,
+                          prf_input, prf_input_len,
+                          out, key_len);
+
+exit:
+    mbedtls_free(prf_input);
+    mbedtls_free(label_str);
+    return ret;
+}
+
+static int mbedtls_ssl_tls13_export_keying_material(mbedtls_ssl_context *ssl,
+                                                    const mbedtls_md_type_t hash_alg,
+                                                    uint8_t *out, const size_t key_len,
+                                                    const char *label, const size_t label_len,
+                                                    const unsigned char *context, const size_t context_len)
+{
+    const psa_algorithm_t psa_hash_alg = mbedtls_md_psa_alg_from_type(hash_alg);
+    const size_t hash_len = PSA_HASH_LENGTH(hash_alg);
+    const unsigned char *secret = ssl->session->app_secrets.exporter_master_secret;
+
+    if (key_len > 0xff || label_len > 250) {
+        return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
+    }
+
+    return mbedtls_ssl_tls13_exporter(psa_hash_alg, secret, hash_len,
+                                      (const unsigned char *)label, label_len,
+                                      context, context_len, out, key_len);
+}
+
+int mbedtls_ssl_export_keying_material(mbedtls_ssl_context *ssl,
+                                        uint8_t *out, const size_t key_len,
+                                        const char *label, const size_t label_len,
+                                        const unsigned char *context, const size_t context_len,
+                                        const int use_context)
+{
+    if (!mbedtls_ssl_is_handshake_over(ssl)) {
+        return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
+    }
+
+    int ciphersuite_id = mbedtls_ssl_get_ciphersuite_id_from_ssl(ssl);
+    const mbedtls_ssl_ciphersuite_t *ciphersuite = mbedtls_ssl_ciphersuite_from_id(ciphersuite_id);
+    const mbedtls_md_type_t hash_alg = ciphersuite->mac;
+
+    switch (mbedtls_ssl_get_version_number(ssl)) {
+        case MBEDTLS_SSL_VERSION_TLS1_2:
+            return mbedtls_ssl_tls12_export_keying_material(ssl, hash_alg, out, key_len,
+                                                            label, label_len,
+                                                            context, context_len, use_context);
+        case MBEDTLS_SSL_VERSION_TLS1_3:
+            return mbedtls_ssl_tls13_export_keying_material(ssl, hash_alg, out, key_len, label, label_len,
+                                                            use_context ? context : NULL,
+                                                            use_context ? context_len : 0);
+        default:
+            return MBEDTLS_ERR_SSL_BAD_PROTOCOL_VERSION;
+    }
+}
+
 #endif /* MBEDTLS_SSL_TLS_C */

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -1890,26 +1890,17 @@ int mbedtls_ssl_tls13_exporter(const psa_algorithm_t hash_alg,
 {
     size_t hash_len = PSA_HASH_LENGTH(hash_alg);
     unsigned char hkdf_secret[MBEDTLS_TLS1_3_MD_MAX_SIZE];
-    unsigned char hashed_context[PSA_HASH_MAX_SIZE];
-    size_t hashed_context_len = 0;
     int ret = 0;
-    psa_status_t status = 0;
 
     ret = mbedtls_ssl_tls13_derive_secret(hash_alg, secret, secret_len, label, label_len, NULL, 0,
                                           MBEDTLS_SSL_TLS1_3_CONTEXT_UNHASHED, hkdf_secret, hash_len);
     if (ret != 0) {
         goto exit;
     }
-
-    status = psa_hash_compute(hash_alg, context_value, context_len, hashed_context, hash_len, &hashed_context_len);
-    if (status != PSA_SUCCESS) {
-        ret = PSA_TO_MBEDTLS_ERR(status);
-        goto exit;
-    }
-    ret = mbedtls_ssl_tls13_hkdf_expand_label(hash_alg, hkdf_secret, hash_len,
-                                              MBEDTLS_SSL_TLS1_3_LBL_WITH_LEN(exporter),
-                                              hashed_context, hashed_context_len,
-                                              out, out_len);
+    ret = mbedtls_ssl_tls13_derive_secret(hash_alg, hkdf_secret, hash_len,
+                                          MBEDTLS_SSL_TLS1_3_LBL_WITH_LEN(exporter),
+                                          context_value, context_len, MBEDTLS_SSL_TLS1_3_CONTEXT_UNHASHED,
+                                          out, out_len);
 
 exit:
     mbedtls_platform_zeroize(hkdf_secret, sizeof(hkdf_secret));

--- a/library/ssl_tls13_keys.h
+++ b/library/ssl_tls13_keys.h
@@ -646,6 +646,22 @@ int mbedtls_ssl_tls13_export_handshake_psk(mbedtls_ssl_context *ssl,
                                            size_t *psk_len);
 #endif
 
+/**
+ * \brief Calculate TLS-Exporter function as defined in RFC 8446, Section 7.5.
+ *
+ * \param[in]   hash_alg  The hash algorithm.
+ * \param[in]   secret  The secret to use. (Should be the exporter master secret.)
+ * \param[in]   secret_len  Length of secret.
+ * \param[in]   label  The label of the exported key.
+ * \param[in]   label_len  The length of label.
+ * \param[out]  out  The output buffer for the exported key. Must have room for at least out_len bytes.
+ * \param[in]   out_len  Length of the key to generate.
+int mbedtls_ssl_tls13_exporter(psa_algorithm_t hash_alg,
+                               const unsigned char *secret, size_t secret_len,
+                               const unsigned char *label, size_t label_len,
+                               const unsigned char *context_value, size_t context_len,
+                               unsigned char *out, size_t out_len);
+
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3 */
 
 #endif /* MBEDTLS_SSL_TLS1_3_KEYS_H */

--- a/library/ssl_tls13_keys.h
+++ b/library/ssl_tls13_keys.h
@@ -656,6 +656,7 @@ int mbedtls_ssl_tls13_export_handshake_psk(mbedtls_ssl_context *ssl,
  * \param[in]   label_len  The length of label.
  * \param[out]  out  The output buffer for the exported key. Must have room for at least out_len bytes.
  * \param[in]   out_len  Length of the key to generate.
+ */
 int mbedtls_ssl_tls13_exporter(psa_algorithm_t hash_alg,
                                const unsigned char *secret, size_t secret_len,
                                const unsigned char *label, size_t label_len,

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -102,6 +102,8 @@ int main(void)
 #define DFL_NSS_KEYLOG          0
 #define DFL_NSS_KEYLOG_FILE     NULL
 #define DFL_SKIP_CLOSE_NOTIFY   0
+#define DFL_EXP_LABEL           NULL
+#define DFL_EXP_LEN             20
 #define DFL_QUERY_CONFIG_MODE   0
 #define DFL_USE_SRTP            0
 #define DFL_SRTP_FORCE_PROFILE  0
@@ -395,6 +397,10 @@ int main(void)
                                                                       "    read_timeout=%%d     default: 0 ms (no timeout)\n"        \
                                                                       "    max_resend=%%d       default: 0 (no resend on timeout)\n" \
                                                                       "    skip_close_notify=%%d default: 0 (send close_notify)\n" \
+                                                                      "    exp_label=%%s       Label to input into TLS-Exporter\n" \
+                                                                      "                         default: None (don't try to export a key)\n" \
+                                                                      "    exp_len=%%d         Length of key to extract from TLS-Exporter \n" \
+                                                                      "                         default: 20\n" \
                                                                       "\n"                                                    \
     USAGE_DTLS                                              \
     USAGE_CID                                               \
@@ -542,6 +548,8 @@ struct options {
                                  * after renegotiation                      */
     int reproducible;           /* make communication reproducible          */
     int skip_close_notify;      /* skip sending the close_notify alert      */
+    const char *exp_label;      /* label to input into mbedtls_ssl_export_keying_material() */
+    int exp_len;                /* Lenght of key to export using mbedtls_ssl_export_keying_material() */
 #if defined(MBEDTLS_SSL_EARLY_DATA)
     int early_data;             /* early data enablement flag               */
 #endif
@@ -1423,6 +1431,10 @@ usage:
             if (opt.skip_close_notify < 0 || opt.skip_close_notify > 1) {
                 goto usage;
             }
+        } else if (strcmp(p, "exp_label") == 0) {
+            opt.exp_label = q;
+        } else if (strcmp(p, "exp_len") == 0) {
+            opt.exp_len = atoi(q);
         } else if (strcmp(p, "use_srtp") == 0) {
             opt.use_srtp = atoi(q);
         } else if (strcmp(p, "srtp_force_profile") == 0) {
@@ -2489,6 +2501,27 @@ usage:
         goto exit;
     }
 #endif /* MBEDTLS_SSL_DTLS_CONNECTION_ID */
+
+    if (opt.exp_label != NULL && opt.exp_len > 0) {
+        unsigned char *exported_key = calloc((size_t)opt.exp_len, sizeof(unsigned int));
+        if (exported_key == NULL) {
+            mbedtls_printf("Could not allocate %d bytes\n", opt.exp_len);
+            ret = 3;
+            goto exit;
+        }
+        ret = mbedtls_ssl_export_keying_material(&ssl, exported_key, (size_t)opt.exp_len,
+                                                 opt.exp_label, strlen(opt.exp_label),
+                                                 NULL, 0, 0);
+        if (ret != 0) {
+            goto exit;
+        }
+        mbedtls_printf("Exporting key of length %d with label \"%s\": 0x", opt.exp_len, opt.exp_label);
+        for (i = 0; i < opt.exp_len; i++) {
+            mbedtls_printf("%02X", exported_key[i]);
+        }
+        mbedtls_printf("\n\n");
+        fflush(stdout);
+    }
 
     /*
      * 6. Write the GET request

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -992,6 +992,8 @@ int main(int argc, char *argv[])
     opt.nss_keylog          = DFL_NSS_KEYLOG;
     opt.nss_keylog_file     = DFL_NSS_KEYLOG_FILE;
     opt.skip_close_notify   = DFL_SKIP_CLOSE_NOTIFY;
+    opt.exp_label           = DFL_EXP_LABEL;
+    opt.exp_len             = DFL_EXP_LEN;
     opt.query_config_mode   = DFL_QUERY_CONFIG_MODE;
     opt.use_srtp            = DFL_USE_SRTP;
     opt.force_srtp_profile  = DFL_SRTP_FORCE_PROFILE;

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -71,6 +71,8 @@ int main(void)
 #define DFL_NBIO                0
 #define DFL_EVENT               0
 #define DFL_READ_TIMEOUT        0
+#define DFL_EXP_LABEL           NULL
+#define DFL_EXP_LEN             20
 #define DFL_CA_FILE             ""
 #define DFL_CA_PATH             ""
 #define DFL_CRT_FILE            ""
@@ -519,6 +521,10 @@ int main(void)
     "    event=%%d            default: 0 (loop)\n"                            \
     "                        options: 1 (level-triggered, implies nbio=1),\n" \
     "    read_timeout=%%d     default: 0 ms (no timeout)\n"    \
+    "    exp_label=%%s       Label to input into TLS-Exporter\n" \
+    "                         default: None (don't try to export a key)\n" \
+    "    exp_len=%%d         Length of key to extract from TLS-Exporter \n" \
+    "                         default: 20\n" \
     "\n"                                                    \
     USAGE_DTLS                                              \
     USAGE_SRTP                                              \
@@ -610,6 +616,8 @@ struct options {
     int nbio;                   /* should I/O be blocking?                  */
     int event;                  /* loop or event-driven IO? level or edge triggered? */
     uint32_t read_timeout;      /* timeout on mbedtls_ssl_read() in milliseconds    */
+    const char *exp_label;      /* label to input into mbedtls_ssl_export_keying_material() */
+    int exp_len;                /* Lenght of key to export using mbedtls_ssl_export_keying_material() */
     int response_size;          /* pad response with header to requested size */
     uint16_t buffer_size;       /* IO buffer size */
     const char *ca_file;        /* the file with the CA certificate(s)      */
@@ -1690,6 +1698,8 @@ int main(int argc, char *argv[])
     opt.cid_val             = DFL_CID_VALUE;
     opt.cid_val_renego      = DFL_CID_VALUE_RENEGO;
     opt.read_timeout        = DFL_READ_TIMEOUT;
+    opt.exp_label           = DFL_EXP_LABEL;
+    opt.exp_len             = DFL_EXP_LEN;
     opt.ca_file             = DFL_CA_FILE;
     opt.ca_path             = DFL_CA_PATH;
     opt.crt_file            = DFL_CRT_FILE;
@@ -1868,6 +1878,10 @@ usage:
             }
         } else if (strcmp(p, "read_timeout") == 0) {
             opt.read_timeout = atoi(q);
+        } else if (strcmp(p, "exp_label") == 0) {
+            opt.exp_label = q;
+        } else if (strcmp(p, "exp_len") == 0) {
+            opt.exp_len = atoi(q);
         } else if (strcmp(p, "buffer_size") == 0) {
             opt.buffer_size = atoi(q);
             if (opt.buffer_size < 1) {
@@ -3630,6 +3644,27 @@ handshake:
             mbedtls_printf("%02x ", eap_tls_iv[j]);
         }
         mbedtls_printf("\n");
+    }
+
+    if (opt.exp_label != NULL && opt.exp_len > 0) {
+        unsigned char *exported_key = calloc((size_t)opt.exp_len, sizeof(unsigned int));
+        if (exported_key == NULL) {
+            mbedtls_printf("Could not allocate %d bytes\n", opt.exp_len);
+            ret = 3;
+            goto exit;
+        }
+        ret = mbedtls_ssl_export_keying_material(&ssl, exported_key, (size_t)opt.exp_len,
+                                                 opt.exp_label, strlen(opt.exp_label),
+                                                 NULL, 0, 0);
+        if (ret != 0) {
+            goto exit;
+        }
+        mbedtls_printf("Exporting key of length %d with label \"%s\": 0x", opt.exp_len, opt.exp_label);
+        for (i = 0; i < opt.exp_len; i++) {
+            mbedtls_printf("%02X", exported_key[i]);
+        }
+        mbedtls_printf("\n\n");
+        fflush(stdout);
     }
 
 #if defined(MBEDTLS_SSL_DTLS_SRTP)

--- a/tests/suites/test_suite_ssl.data
+++ b/tests/suites/test_suite_ssl.data
@@ -2840,6 +2840,11 @@ SSL TLS 1.3 Key schedule: Derive-Secret( ., "res master", hash)
 depends_on:PSA_WANT_ALG_SHA_256
 ssl_tls13_derive_secret:PSA_ALG_SHA_256:"e2d32d4ed66dd37897a0e80c84107503ce58bf8aad4cb55a5002d77ecb890ece":tls13_label_res_master:"c3c122e0bd907a4a3ff6112d8fd53dbf89c773d9552e8b6b9d56d361b3a97bf6":32:MBEDTLS_SSL_TLS1_3_CONTEXT_HASHED:"5e95bdf1f89005ea2e9aa0ba85e728e3c19c5fe0c699e3f5bee59faebd0b5406"
 
+SSL TLS 1.3 Exporter
+# Based on the "exp master" key from RFC 8448, expected result calculated with a HMAC-SHA256 calculator.
+depends_on:PSA_WANT_ALG_SHA_256
+ssl_tls13_exporter:PSA_ALG_SHA_256:"3fd93d4ffddc98e64b14dd107aedf8ee4add23f4510f58a4592d0b201bee56b4":"test":"context value":32:"83d0fac39f87c1b4fbcd261369f31149c535391a9199bd4c5daf89fe259c2e94"
+
 SSL TLS 1.3 Key schedule: Early secrets derivation helper
 # Vector from RFC 8448
 depends_on:PSA_WANT_ALG_SHA_256

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -1656,6 +1656,37 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_SSL_PROTO_TLS1_3 */
+void ssl_tls13_exporter(int hash_alg,
+                        data_t *secret,
+                        char *label,
+                        char *context_value,
+                        int desired_length,
+                        data_t *expected)
+{
+    unsigned char dst[100];
+
+    /* Check sanity of test parameters. */
+    TEST_ASSERT((size_t) desired_length <= sizeof(dst));
+    TEST_ASSERT((size_t) desired_length == expected->len);
+
+    PSA_INIT();
+
+    TEST_ASSERT(mbedtls_ssl_tls13_exporter(
+                    (psa_algorithm_t) hash_alg,
+                    secret->x, secret->len,
+                    (unsigned char *)label, strlen(label),
+                    (unsigned char *)context_value, strlen(context_value),
+                    dst, desired_length) == 0);
+
+    TEST_MEMORY_COMPARE(dst, desired_length,
+                        expected->x, desired_length);
+
+exit:
+    PSA_DONE();
+}
+/* END_CASE */
+
+/* BEGIN_CASE depends_on:MBEDTLS_SSL_PROTO_TLS1_3 */
 void ssl_tls13_derive_early_secrets(int hash_alg,
                                     data_t *secret,
                                     data_t *transcript,


### PR DESCRIPTION
## Description

Backport of #9421

This pull request implements the TLS-Exporter feature as defined in RFC 8446, Section 7.5 and RFC 5705.

TLS-Exporter allows the client and server to extract additional shared symmetric keys from the SSL context by inputting a label and a desired length for the key.

Currently, it is possible for library users to implement TLS-Exporter in TLS 1.2 by using `mbedtls_ssl_set_export_keys_cb()` to obtain the master secret and then calculate `mbedtls_ssl_tls_prf()`. It is not currently possible to do this for TLS 1.3. This pull request adds the function `mbedtls_ssl_export_keying_material()` to implement TLS-Exporter in the library for both TLS 1.2 and 1.3.

I have added a test for the TLS 1.3 Exporter. I could not find test vectors online, so I have taken the "exp master" key from RFC 8448 and used an online HMAC-SHA256 calculator to calculate the expected result. Additionally, I have added options to `ssl_client2` and `ssl_server2` to print out the derived symmetric keys on the command line. I have checked that when connecting `openssl s_client` (with the `-keymatexport` option) to `ssl_server2`, they both export the same key.

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** provided
- [x] **development PR** provided #9421
- [x] **framework PR** not required
- [ ] **3.6 PR** provided # (I would like to get a review before making a 3.6 backport)
- [x] **2.28 PR** not required because: TLS 1.3 is only experimental in this version, and the user can implement TLS-Exporter in TLS 1.2
- [x] **tests**  provided
