### PR TITLE
Fix issue causing IAR compilation failure in ssl_ticket.c

### DIFF
--- a/library/ssl_ticket.c
+++ b/library/ssl_ticket.c
@@ -502,21 +502,23 @@ int mbedtls_ssl_ticket_parse(void *p_ticket,
     }
 
 #if defined(MBEDTLS_HAVE_TIME)
-    mbedtls_ms_time_t ticket_creation_time, ticket_age;
-    mbedtls_ms_time_t ticket_lifetime =
-        (mbedtls_ms_time_t) key->lifetime * 1000;
+    {
+        mbedtls_ms_time_t ticket_creation_time, ticket_age;
+        mbedtls_ms_time_t ticket_lifetime =
+            (mbedtls_ms_time_t) key->lifetime * 1000;
 
-    ret = mbedtls_ssl_session_get_ticket_creation_time(session,
-                                                       &ticket_creation_time);
-    if (ret != 0) {
-        goto cleanup;
-    }
+        ret = mbedtls_ssl_session_get_ticket_creation_time(session,
+                                                           &ticket_creation_time);
+        if (ret != 0) {
+            goto cleanup;
+        }
 
-    ticket_age = mbedtls_ms_time() - ticket_creation_time;
-    if (ticket_age < 0 || ticket_age > ticket_lifetime) {
-        ret = MBEDTLS_ERR_SSL_SESSION_TICKET_EXPIRED;
-        goto cleanup;
-    }
+        ticket_age = mbedtls_ms_time() - ticket_creation_time;
+        if (ticket_age < 0 || ticket_age > ticket_lifetime) {
+            ret = MBEDTLS_ERR_SSL_SESSION_TICKET_EXPIRED;
+            goto cleanup;
+        }
+	}
 #endif
 
 cleanup:


### PR DESCRIPTION
## Description

When attempting to upgrade to v3.6.0 our compiler (IAR for ARM 9.20.2) gave the following error:

```
[build]           goto cleanup;
[build]           ^
[build] "C:\Path\to\submodules\mbedtls-morningstar\library\ssl_ticket.c",451  Error[Pe546]: 
[build]           transfer of control bypasses initialization of:
[build]             variable "ticket_lifetime" (declared at line 506
```

Limiting the scope of the variable in question solved the issue.

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [ ] **changelog** provided | not required because: 
- [ ] **development PR** provided # | not required because: 
- [ ] **framework PR** provided Mbed-TLS/mbedtls-framework# | not required
- [ ] **3.6 PR** provided # | not required because: 
- [ ] **2.28 PR** provided # | not required because: 
- **tests**  provided | not required because: 



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
