### PR TITLE
Fix Mbed-TLS build when WIN32_LEAN_AND_MEAN macro is defined globally

### DIFF
--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -48,7 +48,9 @@
 
 #if defined(MBEDTLS_HAVE_TIME)
 #if defined(_WIN32) && !defined(EFIX64) && !defined(EFI32)
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
 #include <windows.h>
 #else
 #include <time.h>

--- a/tf-psa-crypto/drivers/builtin/src/sha256.c
+++ b/tf-psa-crypto/drivers/builtin/src/sha256.c
@@ -152,7 +152,9 @@ static int mbedtls_a64_crypto_sha256_determine_support(void)
     return 1;
 }
 #elif defined(MBEDTLS_PLATFORM_IS_WINDOWS_ON_ARM64)
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
 #include <Windows.h>
 #include <processthreadsapi.h>
 


### PR DESCRIPTION
## Description

See how MS does it: [include/mimalloc/atomic.h:13](https://github.com/microsoft/mimalloc/blob/5eb8c752f7dc2aaef5080831b1f8ff8092bc25af/include/mimalloc/atomic.h#L13)

## PR checklist

- [x] **changelog** not required because: minor build fix
- [x] **framework PR** not required
- [x] **3.6 PR** provided #9486
- [x] **2.28 PR** not required because: does not use `WIN32_LEAN_AND_MEAN`
- [x] **tests**  not required because: minor build fix not changing anything
