### PR TITLE
Remove definitions of legacy symbols

### DIFF
--- a/docs/driver-only-builds.md
+++ b/docs/driver-only-builds.md
@@ -100,12 +100,8 @@ considerations](#general-considerations) above.
 
 If you want to check at compile-time whether a certain hash algorithm is
 available in the present build of Mbed TLS, regardless of whether it's
-provided by a driver or built-in, you should use the following macros:
-
-- for code that uses only the PSA Crypto API: `PSA_WANT_ALG_xxx` from
-  `psa/crypto.h`;
-- for code that uses non-PSA crypto APIs: `MBEDTLS_MD_CAN_xxx` from
-  `mbedtls/config_adjust_legacy_crypto.h`.
+provided by a driver or built-in, you should use `PSA_WANT_ALG_xxx` from
+`psa/crypto.h`.
 
 ### HMAC
 
@@ -186,13 +182,8 @@ enabled, with the following exceptions:
 
 If you want to check at compile-time whether a certain curve is available in
 the present build of Mbed TLS, regardless of whether ECC is provided by a
-driver or built-in, you should use the following macros:
-
-- for code that uses only the PSA Crypto API: `PSA_WANT_ECC_xxx` from
-  `psa/crypto.h`;
-- for code that may also use non-PSA crypto APIs: `MBEDTLS_ECP_HAVE_xxx` from
-  `mbedtls/build_info.h` where xxx can take the same values as for
-`MBEDTLS_ECP_DP_xxx` macros.
+driver or built-in, you should use `PSA_WANT_ECC_xxx` from
+  `psa/crypto.h`.
 
 Note that for externally-provided drivers, the integrator is responsible for
 ensuring the appropriate `MBEDTLS_PSA_ACCEL_xxx` macros are defined. However,

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -211,7 +211,7 @@
 #endif
 
 #if defined(MBEDTLS_ENTROPY_C) && \
-    !(defined(MBEDTLS_MD_CAN_SHA512) || defined(MBEDTLS_MD_CAN_SHA256))
+    !(defined(MBEDTLS_MD_CAN_SHA512) || defined(PSA_WANT_ALG_SHA_256))
 #error "MBEDTLS_ENTROPY_C defined, but not all prerequisites"
 #endif
 #if defined(MBEDTLS_ENTROPY_C) && \
@@ -224,7 +224,7 @@
 #error "MBEDTLS_CTR_DRBG_ENTROPY_LEN value too high"
 #endif
 #if defined(MBEDTLS_ENTROPY_C) && \
-    defined(MBEDTLS_ENTROPY_FORCE_SHA256) && !defined(MBEDTLS_MD_CAN_SHA256)
+    defined(MBEDTLS_ENTROPY_FORCE_SHA256) && !defined(PSA_WANT_ALG_SHA_256)
 #error "MBEDTLS_ENTROPY_FORCE_SHA256 defined, but not all prerequisites"
 #endif
 
@@ -339,30 +339,30 @@
 
 /* Use of EC J-PAKE in TLS requires SHA-256. */
 #if defined(MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED) &&                    \
-    !defined(MBEDTLS_MD_CAN_SHA256)
+    !defined(PSA_WANT_ALG_SHA_256)
 #error "MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED defined, but not all prerequisites"
 #endif
 
 #if defined(MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED) &&        \
     !defined(MBEDTLS_SSL_KEEP_PEER_CERTIFICATE) &&            \
-    !defined(MBEDTLS_MD_CAN_SHA256) &&                        \
+    !defined(PSA_WANT_ALG_SHA_256) &&                        \
     !defined(MBEDTLS_MD_CAN_SHA512) &&                        \
     !defined(PSA_WANT_ALG_SHA_1)
 #error "!MBEDTLS_SSL_KEEP_PEER_CERTIFICATE requires SHA-512, SHA-256 or SHA-1".
 #endif
 
 #if defined(MBEDTLS_MD_C) && \
-    !defined(MBEDTLS_MD_CAN_MD5) && \
-    !defined(MBEDTLS_MD_CAN_RIPEMD160) && \
+    !defined(PSA_WANT_ALG_MD5) && \
+    !defined(PSA_WANT_ALG_RIPEMD160) && \
     !defined(PSA_WANT_ALG_SHA_1) && \
-    !defined(MBEDTLS_MD_CAN_SHA224) && \
-    !defined(MBEDTLS_MD_CAN_SHA256) && \
-    !defined(MBEDTLS_MD_CAN_SHA384) && \
+    !defined(PSA_WANT_ALG_SHA_224) && \
+    !defined(PSA_WANT_ALG_SHA_256) && \
+    !defined(PSA_WANT_ALG_SHA_384) && \
     !defined(MBEDTLS_MD_CAN_SHA512) && \
-    !defined(MBEDTLS_MD_CAN_SHA3_224) && \
-    !defined(MBEDTLS_MD_CAN_SHA3_256) && \
-    !defined(MBEDTLS_MD_CAN_SHA3_384) && \
-    !defined(MBEDTLS_MD_CAN_SHA3_512)
+    !defined(PSA_WANT_ALG_SHA3_224) && \
+    !defined(PSA_WANT_ALG_SHA3_256) && \
+    !defined(PSA_WANT_ALG_SHA3_384) && \
+    !defined(PSA_WANT_ALG_SHA3_512)
 #error "MBEDTLS_MD_C defined, but no hash algorithm"
 #endif
 
@@ -398,7 +398,7 @@
 #endif
 
 #if defined(MBEDTLS_PK_C) && \
-    !defined(MBEDTLS_RSA_C) && !defined(MBEDTLS_PK_HAVE_ECC_KEYS)
+    !defined(MBEDTLS_RSA_C) && !defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY)
 #error "MBEDTLS_PK_C defined, but not all prerequisites"
 #endif
 
@@ -839,7 +839,7 @@
 #endif
 #else /* MBEDTLS_USE_PSA_CRYPTO */
 #if !defined(MBEDTLS_MD_C) || \
-    !(defined(MBEDTLS_MD_CAN_SHA256) || defined(MBEDTLS_MD_CAN_SHA384))
+    !(defined(PSA_WANT_ALG_SHA_256) || defined(PSA_WANT_ALG_SHA_384))
 #error "MBEDTLS_SSL_TLS_C defined, but not all prerequisites"
 #endif
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
@@ -919,8 +919,8 @@
 #endif
 
 #if defined(MBEDTLS_SSL_TICKET_C) && \
-    !( defined(MBEDTLS_SSL_HAVE_CCM) || defined(MBEDTLS_SSL_HAVE_GCM) || \
-    defined(MBEDTLS_SSL_HAVE_CHACHAPOLY) )
+    !( defined(PSA_WANT_ALG_CCM) || defined(PSA_WANT_ALG_GCM) || \
+    defined(PSA_WANT_ALG_CHACHA20_POLY1305) )
 #error "MBEDTLS_SSL_TICKET_C defined, but not all prerequisites"
 #endif
 
@@ -1020,8 +1020,8 @@
 #endif
 
 #if defined(MBEDTLS_SSL_CONTEXT_SERIALIZATION) && \
-    !( defined(MBEDTLS_SSL_HAVE_CCM) || defined(MBEDTLS_SSL_HAVE_GCM) || \
-    defined(MBEDTLS_SSL_HAVE_CHACHAPOLY) )
+    !( defined(PSA_WANT_ALG_CCM) || defined(PSA_WANT_ALG_GCM) || \
+    defined(PSA_WANT_ALG_CHACHA20_POLY1305) )
 #error "MBEDTLS_SSL_CONTEXT_SERIALIZATION defined, but not all prerequisites"
 #endif
 

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -211,7 +211,7 @@
 #endif
 
 #if defined(MBEDTLS_ENTROPY_C) && \
-    !(defined(MBEDTLS_MD_CAN_SHA512) || defined(PSA_WANT_ALG_SHA_256))
+    !(defined(PSA_WANT_ALG_SHA_512) || defined(PSA_WANT_ALG_SHA_256))
 #error "MBEDTLS_ENTROPY_C defined, but not all prerequisites"
 #endif
 #if defined(MBEDTLS_ENTROPY_C) && \
@@ -219,7 +219,7 @@
 #error "MBEDTLS_CTR_DRBG_ENTROPY_LEN value too high"
 #endif
 #if defined(MBEDTLS_ENTROPY_C) &&                                            \
-    (defined(MBEDTLS_ENTROPY_FORCE_SHA256) || !defined(MBEDTLS_MD_CAN_SHA512)) \
+    (defined(MBEDTLS_ENTROPY_FORCE_SHA256) || !defined(PSA_WANT_ALG_SHA_512)) \
     && defined(MBEDTLS_CTR_DRBG_ENTROPY_LEN) && (MBEDTLS_CTR_DRBG_ENTROPY_LEN > 32)
 #error "MBEDTLS_CTR_DRBG_ENTROPY_LEN value too high"
 #endif
@@ -346,7 +346,7 @@
 #if defined(MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED) &&        \
     !defined(MBEDTLS_SSL_KEEP_PEER_CERTIFICATE) &&            \
     !defined(PSA_WANT_ALG_SHA_256) &&                        \
-    !defined(MBEDTLS_MD_CAN_SHA512) &&                        \
+    !defined(PSA_WANT_ALG_SHA_512) &&                        \
     !defined(PSA_WANT_ALG_SHA_1)
 #error "!MBEDTLS_SSL_KEEP_PEER_CERTIFICATE requires SHA-512, SHA-256 or SHA-1".
 #endif
@@ -358,7 +358,7 @@
     !defined(PSA_WANT_ALG_SHA_224) && \
     !defined(PSA_WANT_ALG_SHA_256) && \
     !defined(PSA_WANT_ALG_SHA_384) && \
-    !defined(MBEDTLS_MD_CAN_SHA512) && \
+    !defined(PSA_WANT_ALG_SHA_512) && \
     !defined(PSA_WANT_ALG_SHA3_224) && \
     !defined(PSA_WANT_ALG_SHA3_256) && \
     !defined(PSA_WANT_ALG_SHA3_384) && \

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -832,18 +832,10 @@
 #endif
 
 /* TLS 1.2 and 1.3 require SHA-256 or SHA-384 (running handshake hash) */
-#if defined(MBEDTLS_SSL_TLS_C)
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
-#if !(defined(PSA_WANT_ALG_SHA_256) || defined(PSA_WANT_ALG_SHA_384))
-#error "MBEDTLS_SSL_TLS_C defined, but not all prerequisites"
-#endif
-#else /* MBEDTLS_USE_PSA_CRYPTO */
-#if !defined(MBEDTLS_MD_C) || \
+#if defined(MBEDTLS_SSL_TLS_C) && \
     !(defined(PSA_WANT_ALG_SHA_256) || defined(PSA_WANT_ALG_SHA_384))
 #error "MBEDTLS_SSL_TLS_C defined, but not all prerequisites"
 #endif
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
-#endif /* MBEDTLS_SSL_TLS_C */
 
 #if defined(MBEDTLS_SSL_SRV_C) && !defined(MBEDTLS_SSL_TLS_C)
 #error "MBEDTLS_SSL_SRV_C defined, but not all prerequisites"

--- a/include/mbedtls/config_adjust_legacy_crypto.h
+++ b/include/mbedtls/config_adjust_legacy_crypto.h
@@ -124,7 +124,6 @@
 #define MBEDTLS_MD_SOME_PSA
 #endif
 #if defined(MBEDTLS_PSA_ACCEL_ALG_SHA_512)
-#define MBEDTLS_MD_CAN_SHA512
 #define MBEDTLS_MD_SHA512_VIA_PSA
 #define MBEDTLS_MD_SOME_PSA
 #endif
@@ -167,7 +166,6 @@
 #define MBEDTLS_MD_SOME_LEGACY
 #endif
 #if defined(MBEDTLS_SHA512_C)
-#define MBEDTLS_MD_CAN_SHA512
 #define MBEDTLS_MD_SOME_LEGACY
 #endif
 #if defined(MBEDTLS_SHA3_C)

--- a/include/mbedtls/config_adjust_legacy_crypto.h
+++ b/include/mbedtls/config_adjust_legacy_crypto.h
@@ -376,8 +376,8 @@
 #define MBEDTLS_SSL_HAVE_CHACHAPOLY
 #endif
 
-#if defined(MBEDTLS_SSL_HAVE_GCM) || defined(MBEDTLS_SSL_HAVE_CCM) || \
-    defined(MBEDTLS_SSL_HAVE_CHACHAPOLY)
+#if defined(PSA_WANT_ALG_GCM) || defined(PSA_WANT_ALG_CCM) || \
+    defined(PSA_WANT_ALG_CHACHA20_POLY1305)
 #define MBEDTLS_SSL_HAVE_AEAD
 #endif
 

--- a/include/mbedtls/config_adjust_legacy_crypto.h
+++ b/include/mbedtls/config_adjust_legacy_crypto.h
@@ -150,28 +150,14 @@
 #endif /* MBEDTLS_PSA_CRYPTO_C */
 
 /* Built-in implementations */
-#if defined(MBEDTLS_MD5_C)
-#define MBEDTLS_MD_SOME_LEGACY
-#endif
-#if defined(MBEDTLS_SHA1_C)
-#define MBEDTLS_MD_SOME_LEGACY
-#endif
-#if defined(MBEDTLS_SHA224_C)
-#define MBEDTLS_MD_SOME_LEGACY
-#endif
-#if defined(MBEDTLS_SHA256_C)
-#define MBEDTLS_MD_SOME_LEGACY
-#endif
-#if defined(MBEDTLS_SHA384_C)
-#define MBEDTLS_MD_SOME_LEGACY
-#endif
-#if defined(MBEDTLS_SHA512_C)
-#define MBEDTLS_MD_SOME_LEGACY
-#endif
-#if defined(MBEDTLS_SHA3_C)
-#define MBEDTLS_MD_SOME_LEGACY
-#endif
-#if defined(MBEDTLS_RIPEMD160_C)
+#if defined(MBEDTLS_MD5_C) || \
+    defined(MBEDTLS_SHA1_C) || \
+    defined(MBEDTLS_SHA224_C) || \
+    defined(MBEDTLS_SHA256_C) || \
+    defined(MBEDTLS_SHA384_C) || \
+    defined(MBEDTLS_SHA512_C) || \
+    defined(MBEDTLS_SHA3_C) || \
+    defined(MBEDTLS_RIPEMD160_C)
 #define MBEDTLS_MD_SOME_LEGACY
 #endif
 

--- a/include/mbedtls/config_adjust_legacy_crypto.h
+++ b/include/mbedtls/config_adjust_legacy_crypto.h
@@ -104,7 +104,6 @@
 #if defined(MBEDTLS_PSA_CRYPTO_C)
 
 #if defined(MBEDTLS_PSA_ACCEL_ALG_MD5)
-#define MBEDTLS_MD_CAN_MD5
 #define MBEDTLS_MD_MD5_VIA_PSA
 #define MBEDTLS_MD_SOME_PSA
 #endif
@@ -113,17 +112,14 @@
 #define MBEDTLS_MD_SOME_PSA
 #endif
 #if defined(MBEDTLS_PSA_ACCEL_ALG_SHA_224)
-#define MBEDTLS_MD_CAN_SHA224
 #define MBEDTLS_MD_SHA224_VIA_PSA
 #define MBEDTLS_MD_SOME_PSA
 #endif
 #if defined(MBEDTLS_PSA_ACCEL_ALG_SHA_256)
-#define MBEDTLS_MD_CAN_SHA256
 #define MBEDTLS_MD_SHA256_VIA_PSA
 #define MBEDTLS_MD_SOME_PSA
 #endif
 #if defined(MBEDTLS_PSA_ACCEL_ALG_SHA_384)
-#define MBEDTLS_MD_CAN_SHA384
 #define MBEDTLS_MD_SHA384_VIA_PSA
 #define MBEDTLS_MD_SOME_PSA
 #endif
@@ -133,27 +129,22 @@
 #define MBEDTLS_MD_SOME_PSA
 #endif
 #if defined(MBEDTLS_PSA_ACCEL_ALG_RIPEMD160)
-#define MBEDTLS_MD_CAN_RIPEMD160
 #define MBEDTLS_MD_RIPEMD160_VIA_PSA
 #define MBEDTLS_MD_SOME_PSA
 #endif
 #if defined(MBEDTLS_PSA_ACCEL_ALG_SHA3_224)
-#define MBEDTLS_MD_CAN_SHA3_224
 #define MBEDTLS_MD_SHA3_224_VIA_PSA
 #define MBEDTLS_MD_SOME_PSA
 #endif
 #if defined(MBEDTLS_PSA_ACCEL_ALG_SHA3_256)
-#define MBEDTLS_MD_CAN_SHA3_256
 #define MBEDTLS_MD_SHA3_256_VIA_PSA
 #define MBEDTLS_MD_SOME_PSA
 #endif
 #if defined(MBEDTLS_PSA_ACCEL_ALG_SHA3_384)
-#define MBEDTLS_MD_CAN_SHA3_384
 #define MBEDTLS_MD_SHA3_384_VIA_PSA
 #define MBEDTLS_MD_SOME_PSA
 #endif
 #if defined(MBEDTLS_PSA_ACCEL_ALG_SHA3_512)
-#define MBEDTLS_MD_CAN_SHA3_512
 #define MBEDTLS_MD_SHA3_512_VIA_PSA
 #define MBEDTLS_MD_SOME_PSA
 #endif
@@ -161,22 +152,18 @@
 
 /* Built-in implementations */
 #if defined(MBEDTLS_MD5_C)
-#define MBEDTLS_MD_CAN_MD5
 #define MBEDTLS_MD_SOME_LEGACY
 #endif
 #if defined(MBEDTLS_SHA1_C)
 #define MBEDTLS_MD_SOME_LEGACY
 #endif
 #if defined(MBEDTLS_SHA224_C)
-#define MBEDTLS_MD_CAN_SHA224
 #define MBEDTLS_MD_SOME_LEGACY
 #endif
 #if defined(MBEDTLS_SHA256_C)
-#define MBEDTLS_MD_CAN_SHA256
 #define MBEDTLS_MD_SOME_LEGACY
 #endif
 #if defined(MBEDTLS_SHA384_C)
-#define MBEDTLS_MD_CAN_SHA384
 #define MBEDTLS_MD_SOME_LEGACY
 #endif
 #if defined(MBEDTLS_SHA512_C)
@@ -184,14 +171,9 @@
 #define MBEDTLS_MD_SOME_LEGACY
 #endif
 #if defined(MBEDTLS_SHA3_C)
-#define MBEDTLS_MD_CAN_SHA3_224
-#define MBEDTLS_MD_CAN_SHA3_256
-#define MBEDTLS_MD_CAN_SHA3_384
-#define MBEDTLS_MD_CAN_SHA3_512
 #define MBEDTLS_MD_SOME_LEGACY
 #endif
 #if defined(MBEDTLS_RIPEMD160_C)
-#define MBEDTLS_MD_CAN_RIPEMD160
 #define MBEDTLS_MD_SOME_LEGACY
 #endif
 
@@ -333,14 +315,6 @@
 #define MBEDTLS_PSA_CRYPTO_CLIENT
 #endif /* MBEDTLS_PSA_CRYPTO_C */
 
-/* Helper symbol to state that the PK module has support for EC keys. This
- * can either be provided through the legacy ECP solution or through the
- * PSA friendly MBEDTLS_PK_USE_PSA_EC_DATA (see pk.h for its description). */
-#if defined(MBEDTLS_ECP_C) || \
-    (defined(MBEDTLS_USE_PSA_CRYPTO) && defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY))
-#define MBEDTLS_PK_HAVE_ECC_KEYS
-#endif /* MBEDTLS_PK_USE_PSA_EC_DATA || MBEDTLS_ECP_C */
-
 /* Historically pkparse did not check the CBC padding when decrypting
  * a key. This was a bug, which is now fixed. As a consequence, pkparse
  * now needs PKCS7 padding support, but existing configurations might not
@@ -360,21 +334,6 @@
 #endif
 
 /* Some internal helpers to determine which operation modes are available. */
-
-#if (!defined(MBEDTLS_USE_PSA_CRYPTO) && defined(MBEDTLS_GCM_C)) || \
-    (defined(MBEDTLS_USE_PSA_CRYPTO) && defined(PSA_WANT_ALG_GCM))
-#define MBEDTLS_SSL_HAVE_GCM
-#endif
-
-#if (!defined(MBEDTLS_USE_PSA_CRYPTO) && defined(MBEDTLS_CCM_C)) || \
-    (defined(MBEDTLS_USE_PSA_CRYPTO) && defined(PSA_WANT_ALG_CCM))
-#define MBEDTLS_SSL_HAVE_CCM
-#endif
-
-#if (!defined(MBEDTLS_USE_PSA_CRYPTO) && defined(MBEDTLS_CHACHAPOLY_C)) || \
-    (defined(MBEDTLS_USE_PSA_CRYPTO) && defined(PSA_WANT_ALG_CHACHA20_POLY1305))
-#define MBEDTLS_SSL_HAVE_CHACHAPOLY
-#endif
 
 #if defined(PSA_WANT_ALG_GCM) || defined(PSA_WANT_ALG_CCM) || \
     defined(PSA_WANT_ALG_CHACHA20_POLY1305)

--- a/include/mbedtls/config_adjust_legacy_crypto.h
+++ b/include/mbedtls/config_adjust_legacy_crypto.h
@@ -333,44 +333,6 @@
 #define MBEDTLS_PSA_CRYPTO_CLIENT
 #endif /* MBEDTLS_PSA_CRYPTO_C */
 
-/* Helpers to state that each key is supported either on the builtin or PSA side. */
-#if defined(MBEDTLS_ECP_DP_SECP521R1_ENABLED) || defined(PSA_WANT_ECC_SECP_R1_521)
-#define MBEDTLS_ECP_HAVE_SECP521R1
-#endif
-#if defined(MBEDTLS_ECP_DP_BP512R1_ENABLED) || defined(PSA_WANT_ECC_BRAINPOOL_P_R1_512)
-#define MBEDTLS_ECP_HAVE_BP512R1
-#endif
-#if defined(MBEDTLS_ECP_DP_CURVE448_ENABLED) || defined(PSA_WANT_ECC_MONTGOMERY_448)
-#define MBEDTLS_ECP_HAVE_CURVE448
-#endif
-#if defined(MBEDTLS_ECP_DP_BP384R1_ENABLED) || defined(PSA_WANT_ECC_BRAINPOOL_P_R1_384)
-#define MBEDTLS_ECP_HAVE_BP384R1
-#endif
-#if defined(MBEDTLS_ECP_DP_SECP384R1_ENABLED) || defined(PSA_WANT_ECC_SECP_R1_384)
-#define MBEDTLS_ECP_HAVE_SECP384R1
-#endif
-#if defined(MBEDTLS_ECP_DP_BP256R1_ENABLED) || defined(PSA_WANT_ECC_BRAINPOOL_P_R1_256)
-#define MBEDTLS_ECP_HAVE_BP256R1
-#endif
-#if defined(MBEDTLS_ECP_DP_SECP256K1_ENABLED) || defined(PSA_WANT_ECC_SECP_K1_256)
-#define MBEDTLS_ECP_HAVE_SECP256K1
-#endif
-#if defined(MBEDTLS_ECP_DP_SECP256R1_ENABLED) || defined(PSA_WANT_ECC_SECP_R1_256)
-#define MBEDTLS_ECP_HAVE_SECP256R1
-#endif
-#if defined(MBEDTLS_ECP_DP_CURVE25519_ENABLED) || defined(PSA_WANT_ECC_MONTGOMERY_255)
-#define MBEDTLS_ECP_HAVE_CURVE25519
-#endif
-#if defined(MBEDTLS_ECP_DP_SECP224R1_ENABLED) || defined(PSA_WANT_ECC_SECP_R1_224)
-#define MBEDTLS_ECP_HAVE_SECP224R1
-#endif
-#if defined(MBEDTLS_ECP_DP_SECP192K1_ENABLED) || defined(PSA_WANT_ECC_SECP_K1_192)
-#define MBEDTLS_ECP_HAVE_SECP192K1
-#endif
-#if defined(MBEDTLS_ECP_DP_SECP192R1_ENABLED) || defined(PSA_WANT_ECC_SECP_R1_192)
-#define MBEDTLS_ECP_HAVE_SECP192R1
-#endif
-
 /* Helper symbol to state that the PK module has support for EC keys. This
  * can either be provided through the legacy ECP solution or through the
  * PSA friendly MBEDTLS_PK_USE_PSA_EC_DATA (see pk.h for its description). */
@@ -397,32 +359,7 @@
 #define MBEDTLS_SHA256_USE_ARMV8_A_CRYPTO_ONLY
 #endif
 
-/* psa_util file features some ECDSA conversion functions, to convert between
- * legacy's ASN.1 DER format and PSA's raw one. */
-#if defined(MBEDTLS_ECDSA_C) || (defined(MBEDTLS_PSA_CRYPTO_C) && \
-    (defined(PSA_WANT_ALG_ECDSA) || defined(PSA_WANT_ALG_DETERMINISTIC_ECDSA)))
-#define MBEDTLS_PSA_UTIL_HAVE_ECDSA
-#endif
-
-/* Some internal helpers to determine which keys are available. */
-#if (!defined(MBEDTLS_USE_PSA_CRYPTO) && defined(MBEDTLS_AES_C)) || \
-    (defined(MBEDTLS_USE_PSA_CRYPTO) && defined(PSA_WANT_KEY_TYPE_AES))
-#define MBEDTLS_SSL_HAVE_AES
-#endif
-#if (!defined(MBEDTLS_USE_PSA_CRYPTO) && defined(MBEDTLS_ARIA_C)) || \
-    (defined(MBEDTLS_USE_PSA_CRYPTO) && defined(PSA_WANT_KEY_TYPE_ARIA))
-#define MBEDTLS_SSL_HAVE_ARIA
-#endif
-#if (!defined(MBEDTLS_USE_PSA_CRYPTO) && defined(MBEDTLS_CAMELLIA_C)) || \
-    (defined(MBEDTLS_USE_PSA_CRYPTO) && defined(PSA_WANT_KEY_TYPE_CAMELLIA))
-#define MBEDTLS_SSL_HAVE_CAMELLIA
-#endif
-
 /* Some internal helpers to determine which operation modes are available. */
-#if (!defined(MBEDTLS_USE_PSA_CRYPTO) && defined(MBEDTLS_CIPHER_MODE_CBC)) || \
-    (defined(MBEDTLS_USE_PSA_CRYPTO) && defined(PSA_WANT_ALG_CBC_NO_PADDING))
-#define MBEDTLS_SSL_HAVE_CBC
-#endif
 
 #if (!defined(MBEDTLS_USE_PSA_CRYPTO) && defined(MBEDTLS_GCM_C)) || \
     (defined(MBEDTLS_USE_PSA_CRYPTO) && defined(PSA_WANT_ALG_GCM))

--- a/include/mbedtls/config_adjust_legacy_crypto.h
+++ b/include/mbedtls/config_adjust_legacy_crypto.h
@@ -87,7 +87,6 @@
 
 #if defined(MBEDTLS_MD_LIGHT)
 /*
- * - MBEDTLS_MD_CAN_xxx is defined if the md module can perform xxx.
  * - MBEDTLS_MD_xxx_VIA_PSA is defined if the md module may perform xxx via PSA
  *   (see below).
  * - MBEDTLS_MD_SOME_PSA is defined if at least one algorithm may be performed

--- a/tf-psa-crypto/tests/suites/test_suite_pkwrite.data
+++ b/tf-psa-crypto/tests/suites/test_suite_pkwrite.data
@@ -79,11 +79,11 @@ depends_on:PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY:PSA_WANT_ECC_SECP_R1_192
 pk_write_key_check:"../../framework/data_files/ec_prv.sec1.der":TEST_DER
 
 Private key write check EC 256 bits (top bit set)
-depends_on:PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY:MBEDTLS_PEM_PARSE_C:MBEDTLS_PEM_WRITE_C:MBEDTLS_ECP_HAVE_SECP256R1
+depends_on:PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY:MBEDTLS_PEM_PARSE_C:MBEDTLS_PEM_WRITE_C:PSA_WANT_ECC_SECP_R1_256
 pk_write_key_check:"../../framework/data_files/ec_256_long_prv.pem":TEST_PEM
 
 Private key write check EC 256 bits (top bit set) (DER)
-depends_on:PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY:MBEDTLS_ECP_HAVE_SECP256R1
+depends_on:PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY:PSA_WANT_ECC_SECP_R1_256
 pk_write_key_check:"../../framework/data_files/ec_256_long_prv.der":TEST_DER
 
 Private key write check EC 521 bits


### PR DESCRIPTION
## Description

Resolves #9396

Removal of symbols from #9385, #9540, and #9544 to be included in their respective PRs.


## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** not required, internal changes
- [x] **development PR** provided
- [x] **framework PR** https://github.com/Mbed-TLS/mbedtls-framework/pull/34
- [x] **3.6 PR** #9640 
- [x] **2.28 PR** not required, needed for 4.0
- [x] **tests** not required



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
