### PR TITLE
ecp.c: Refactored a minor check in ecp check privkey

### DIFF
--- a/tf-psa-crypto/drivers/builtin/src/ecp.c
+++ b/tf-psa-crypto/drivers/builtin/src/ecp.c
@@ -2913,7 +2913,7 @@ int mbedtls_ecp_check_privkey(const mbedtls_ecp_group *grp,
         /* see RFC 7748 sec. 5 para. 5 */
         if (mbedtls_mpi_get_bit(d, 0) != 0 ||
             mbedtls_mpi_get_bit(d, 1) != 0 ||
-            mbedtls_mpi_bitlen(d) - 1 != grp->nbits) {  /* mbedtls_mpi_bitlen is one-based! */
+            mbedtls_mpi_bitlen(d) != grp->nbits + 1) {  /* mbedtls_mpi_bitlen is one-based! */
             return MBEDTLS_ERR_ECP_INVALID_KEY;
         }
 


### PR DESCRIPTION
## Description

Added a comment based on an investigation we did at the functional behaviour of a check.  

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** not required because: is a minor non functional change.
- [x] **development PR** provided
- [x] **framework PR** not required
- [x] **3.6 PR** provided #9495
- [x] **2.28 PR** provided #9496
- **tests**  not required because:  is a minor non functional change.



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
