### PR TITLE
ccm.c: Return early when ccm* is used without tag.

### DIFF
--- a/tf-psa-crypto/drivers/builtin/src/ccm.c
+++ b/tf-psa-crypto/drivers/builtin/src/ccm.c
@@ -167,11 +167,12 @@ static int ccm_calculate_first_block_if_ready(mbedtls_ccm_context *ctx)
     }
 
     /* CCM expects non-empty tag.
-     * CCM* allows empty tag. For CCM* without tag, ignore plaintext length.
+     * CCM* allows empty tag. For CCM* without tag, the tag calculation is skipped.
      */
     if (ctx->tag_len == 0) {
         if (ctx->mode == MBEDTLS_CCM_STAR_ENCRYPT || ctx->mode == MBEDTLS_CCM_STAR_DECRYPT) {
             ctx->plaintext_len = 0;
+            return 0;
         } else {
             return MBEDTLS_ERR_CCM_BAD_INPUT;
         }


### PR DESCRIPTION
## Description

Adjusts `ccm_calculate_first_block_if_ready` to return early before unnecessarily calculating  invalid context.


## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** not required because:   It does not change the functional flow of the code.
- [x] **development PR** provided
- [x] **framework PR** not required
- [x] **3.6 PR** provided #9498
- [x] **2.28 PR** not required because: Not present in 2.28
- **tests**  provided | not required because: It does not change the functional flow of the code.



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
