### PR TITLE
[Backport 3.6] Fix issue in handling legacy_compression_methods in ssl_tls13_parse_client_hello()

### DIFF
--- a/ChangeLog.d/fix-legacy-compression-issue.txt
+++ b/ChangeLog.d/fix-legacy-compression-issue.txt
@@ -2,5 +2,5 @@ Bugfix
    * Fixes an issue where some TLS 1.2 clients could not connect to an
      Mbed TLS 3.6.0 server, due to incorrect handling of
      legacy_compression_methods in the ClientHello.
-     fixes #8995, #9243.
+     Fixes #8995, #9243.
 

--- a/ChangeLog.d/fix-legacy-compression-issue.txt
+++ b/ChangeLog.d/fix-legacy-compression-issue.txt
@@ -1,7 +1,6 @@
 Bugfix
-   * Fix an issue where TLS 1.2 clients who send a ClientHello message with
-     legacy_compression_methods get a failure in connection because TLS 1.3
-     is enabled by default and the server rejects the ClientHello packet as
-     malformed for TLS 1.3 in a way that stops the fallback to TLS 1.2.
+   * Fixes an issue where some TLS 1.2 clients could not connect to an
+     Mbed TLS 3.6.0 server, due to incorrect handling of
+     legacy_compression_methods in the ClientHello.
      fixes #8995, #9243.
 

--- a/ChangeLog.d/fix-legacy-compression-issue.txt
+++ b/ChangeLog.d/fix-legacy-compression-issue.txt
@@ -1,7 +1,7 @@
 Bugfix
-   * Fix an issue where ssl_tls13_parse_client_hello() assumed legacy_compression_methods
-     length would always be zero, which is true for TLS 1.3. However, with TLS 1.3 enabled
-     by default, all ClientHello requests (including TLS 1.2 requests) are initially
-     processed by ssl_tls13_parse_client_hello() before being passed to the TLS 1.2
-     parsing function. This caused an issue where legacy_compression_methods
-     might not be zero for TLS 1.2 requests, as it is processed earlier.
+   * Fix an issue where TLS 1.2 clients who send a ClientHello message with
+     legacy_compression_methods get a failure in connection because TLS 1.3
+     is enabled by default and the server rejects the ClientHello packet as
+     malformed for TLS 1.3 in a way that stops the fallback to TLS 1.2.
+     fixes #8995, #9243.
+

--- a/ChangeLog.d/fix-legacy-compression-issue.txt
+++ b/ChangeLog.d/fix-legacy-compression-issue.txt
@@ -1,0 +1,7 @@
+Bugfix
+   * Fix an issue where ssl_tls13_parse_client_hello() assumed legacy_compression_methods
+     length would always be zero, which is true for TLS 1.3. However, with TLS 1.3 enabled
+     by default, all ClientHello requests (including TLS 1.2 requests) are initially
+     processed by ssl_tls13_parse_client_hello() before being passed to the TLS 1.2
+     parsing function. This caused an issue where legacy_compression_methods
+     might not be zero for TLS 1.2 requests, as it is processed earlier.

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1265,6 +1265,8 @@ static int ssl_tls13_parse_client_hello(mbedtls_ssl_context *ssl,
     mbedtls_ssl_handshake_params *handshake = ssl->handshake;
     int hrr_required = 0;
     int no_usable_share_for_key_agreement = 0;
+    unsigned char legacy_compression_methods_len;
+    unsigned char legacy_compression_methods;
 
 #if defined(MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_SOME_PSK_ENABLED)
     int got_psk = 0;
@@ -1361,6 +1363,13 @@ static int ssl_tls13_parse_client_hello(mbedtls_ssl_context *ssl,
     MBEDTLS_SSL_CHK_BUF_READ_PTR(p, end, cipher_suites_len + 2 + 2);
     p += cipher_suites_len;
     cipher_suites_end = p;
+
+    legacy_compression_methods_len = *p;
+    legacy_compression_methods = *(p+1);
+
+    if (legacy_compression_methods_len != 1 || legacy_compression_methods != 0) {
+        return SSL_CLIENT_HELLO_TLS1_2;
+    }
 
     /*
      * Search for the supported versions extension and parse it to determine

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1265,8 +1265,6 @@ static int ssl_tls13_parse_client_hello(mbedtls_ssl_context *ssl,
     mbedtls_ssl_handshake_params *handshake = ssl->handshake;
     int hrr_required = 0;
     int no_usable_share_for_key_agreement = 0;
-    unsigned char legacy_compression_methods_len;
-    unsigned char legacy_compression_methods;
 
 #if defined(MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_SOME_PSK_ENABLED)
     int got_psk = 0;
@@ -1364,19 +1362,17 @@ static int ssl_tls13_parse_client_hello(mbedtls_ssl_context *ssl,
     p += cipher_suites_len;
     cipher_suites_end = p;
 
-    legacy_compression_methods_len = *p;
-    legacy_compression_methods = *(p+1);
-
-    if (legacy_compression_methods_len != 1 || legacy_compression_methods != 0) {
-        return SSL_CLIENT_HELLO_TLS1_2;
-    }
+    /* Check if we have enough data to for legacy_compression_methods
+     * and a length byte.
+     */
+    MBEDTLS_SSL_CHK_BUF_READ_PTR(p, end, 1 + p[0]);
 
     /*
      * Search for the supported versions extension and parse it to determine
      * if the client supports TLS 1.3.
      */
     ret = mbedtls_ssl_tls13_is_supported_versions_ext_present_in_exts(
-        ssl, p + 2, end,
+        ssl, p + 1 + p[0], end,
         &supported_versions_data, &supported_versions_data_end);
     if (ret < 0) {
         MBEDTLS_SSL_DEBUG_RET(1,

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1362,7 +1362,7 @@ static int ssl_tls13_parse_client_hello(mbedtls_ssl_context *ssl,
     p += cipher_suites_len;
     cipher_suites_end = p;
 
-    /* Check if we have enough data to for legacy_compression_methods
+    /* Check if we have enough data for legacy_compression_methods
      * and a length byte.
      */
     MBEDTLS_SSL_CHK_BUF_READ_PTR(p, end, 1 + p[0]);

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1355,17 +1355,16 @@ static int ssl_tls13_parse_client_hello(mbedtls_ssl_context *ssl,
      * compression methods and the length of the extensions.
      *
      * cipher_suites                cipher_suites_len bytes
-     * legacy_compression_methods                   2 bytes
-     * extensions_len                               2 bytes
+     * legacy_compression_methods length            1 byte
      */
-    MBEDTLS_SSL_CHK_BUF_READ_PTR(p, end, cipher_suites_len + 2 + 2);
+    MBEDTLS_SSL_CHK_BUF_READ_PTR(p, end, cipher_suites_len + 1);
     p += cipher_suites_len;
     cipher_suites_end = p;
 
     /* Check if we have enough data for legacy_compression_methods
-     * and a length byte.
+     * and the length of the extensions (2 bytes).
      */
-    MBEDTLS_SSL_CHK_BUF_READ_PTR(p, end, 1 + p[0]);
+    MBEDTLS_SSL_CHK_BUF_READ_PTR(p + 1, end, p[0] + 2);
 
     /*
      * Search for the supported versions extension and parse it to determine

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14145,13 +14145,25 @@ run_test    "TLS 1.3: no HRR in case of PSK key exchange mode" \
 # Legacy_compression_methods testing
 
 requires_gnutls
+requires_config_enabled MBEDTLS_SSL_SRV_C
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
-run_test    "ClientHello parse handle Legacy_compression_methods" \
+run_test    "TLS 1.2 ClientHello indicating support for deflate compression method (fallback from TLS 1.3)" \
             "$P_SRV debug_level=3" \
             "$G_CLI  --priority=NORMAL:-VERS-ALL:+VERS-TLS1.2:+COMP-DEFLATE localhost" \
             0 \
-            -c "Handshake was completed"
+            -c "Handshake was completed" \
+            -s "dumping .client hello, compression. (2 bytes)"
+
+requires_gnutls
+requires_config_enabled MBEDTLS_SSL_SRV_C
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test    "TLS 1.2 ClientHello indicating support for deflate compression method" \
+            "$P_SRV debug_level=3" \
+            "$G_CLI  --priority=NORMAL:-VERS-ALL:+VERS-TLS1.2:+COMP-DEFLATE localhost" \
+            0 \
+            -c "Handshake was completed" \
+            -s "dumping .client hello, compression. (2 bytes)"
 
 # Test heap memory usage after handshake
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14147,17 +14147,6 @@ run_test    "TLS 1.3: no HRR in case of PSK key exchange mode" \
 requires_gnutls
 requires_config_enabled MBEDTLS_SSL_SRV_C
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
-run_test    "TLS 1.2 ClientHello indicating support for deflate compression method (fallback from TLS 1.3)" \
-            "$P_SRV debug_level=3" \
-            "$G_CLI  --priority=NORMAL:-VERS-ALL:+VERS-TLS1.2:+COMP-DEFLATE localhost" \
-            0 \
-            -c "Handshake was completed" \
-            -s "dumping .client hello, compression. (2 bytes)"
-
-requires_gnutls
-requires_config_enabled MBEDTLS_SSL_SRV_C
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 run_test    "TLS 1.2 ClientHello indicating support for deflate compression method" \
             "$P_SRV debug_level=3" \
             "$G_CLI  --priority=NORMAL:-VERS-ALL:+VERS-TLS1.2:+COMP-DEFLATE localhost" \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14142,6 +14142,17 @@ run_test    "TLS 1.3: no HRR in case of PSK key exchange mode" \
             -c "Selected key exchange mode: psk$" \
             -c "HTTP/1.0 200 OK"
 
+# Legacy_compression_methods testing
+
+requires_gnutls
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
+run_test    "ClientHello parse handle Legacy_compression_methods" \
+            "$P_SRV debug_level=3" \
+            "$G_CLI  --priority=NORMAL:-VERS-ALL:+VERS-TLS1.2:+COMP-DEFLATE localhost" \
+            0 \
+            -c "Handshake was completed"
+
 # Test heap memory usage after handshake
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_MEMORY_DEBUG


### PR DESCRIPTION
## Description

Please write a few sentences describing the overall goals of the pull request's commits.
backports #9244 


## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [X] **changelog** provided | not required because: 
- [X] **development PR** provided #9244 
- [X] **framework PR** not required
- [X] **3.6 PR** not required because: This is it
- [X] **2.28 PR** not required because: (feature not in 2.28)
- [X] **tests**  provided



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
