### PR TITLE
Backport 3.6: ssl_client1 and ssl_server demo scripts

### DIFF
--- a/programs/ssl/ssl_client1.c
+++ b/programs/ssl/ssl_client1.c
@@ -240,6 +240,9 @@ int main(void)
         }
 
         if (ret == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY) {
+            mbedtls_printf("The return value %d from mbedtls_ssl_read() means that the server\n"
+                           "closed the connection first. We're ok with that.\n",
+                           MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY);
             break;
         }
 
@@ -259,7 +262,9 @@ int main(void)
 
     mbedtls_ssl_close_notify(&ssl);
 
-    exit_code = MBEDTLS_EXIT_SUCCESS;
+    if (ret == 0 || ret == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY) {
+        exit_code = MBEDTLS_EXIT_SUCCESS;
+    }
 
 exit:
 

--- a/programs/ssl/tls12_client_demo.sh
+++ b/programs/ssl/tls12_client_demo.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+#
+# Copyright The Mbed TLS Contributors
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+
+program="${0%/*}"/ssl_client1
+protocol='TLS 1.2'
+
+. "${0%/*}/tls_client_demo_common.sh"
+
+depends_on MBEDTLS_SSL_PROTO_TLS1_2
+if ! { config_has MBEDTLS_KEY_EXCHANGE_ECDH_ECDSA_ENABLED ||
+       config_has MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED ||
+       config_has MBEDTLS_KEY_EXCHANGE_ECDH_RSA_ENABLED ||
+       config_has MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED ||
+       config_has MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED ||
+       config_has MBEDTLS_KEY_EXCHANGE_RSA_ENABLED; }; then
+    depends_on 'MBEDTLS_KEY_EXCHANGE_<any-non-PSK>_ENABLED'
+fi
+
+run_one_connection -www -tls1_2
+
+cleanup

--- a/programs/ssl/tls12_client_demo.sh
+++ b/programs/ssl/tls12_client_demo.sh
@@ -18,6 +18,6 @@ if ! { config_has MBEDTLS_KEY_EXCHANGE_ECDH_ECDSA_ENABLED ||
     depends_on 'MBEDTLS_KEY_EXCHANGE_<any-non-PSK>_ENABLED'
 fi
 
-run_one_connection -www -tls1_2
+run_one_connection -tls1_2
 
 cleanup

--- a/programs/ssl/tls12_server_demo.sh
+++ b/programs/ssl/tls12_server_demo.sh
@@ -20,4 +20,10 @@ fi
 
 run_one_connection -tls1_2
 
+if config_has MBEDTLS_SSL_PROTO_DTLS; then
+    program="${0%/*}"/dtls_server
+    protocol='DTLS 1.2'
+    run_one_connection -dtls1_2
+fi
+
 cleanup

--- a/programs/ssl/tls12_server_demo.sh
+++ b/programs/ssl/tls12_server_demo.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+#
+# Copyright The Mbed TLS Contributors
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+
+program="${0%/*}"/ssl_server
+protocol='TLS 1.2'
+
+. "${0%/*}/tls_server_demo_common.sh"
+
+depends_on MBEDTLS_SSL_PROTO_TLS1_2
+if ! { config_has MBEDTLS_KEY_EXCHANGE_ECDH_ECDSA_ENABLED ||
+       config_has MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED ||
+       config_has MBEDTLS_KEY_EXCHANGE_ECDH_RSA_ENABLED ||
+       config_has MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED ||
+       config_has MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED ||
+       config_has MBEDTLS_KEY_EXCHANGE_RSA_ENABLED; }; then
+    depends_on 'MBEDTLS_KEY_EXCHANGE_<any-non-PSK>_ENABLED'
+fi
+
+run_one_connection -tls1_2
+
+cleanup

--- a/programs/ssl/tls12_server_demo.sh
+++ b/programs/ssl/tls12_server_demo.sh
@@ -20,6 +20,11 @@ fi
 
 run_one_connection -tls1_2
 
+if config_has MBEDTLS_THREADING_PTHREAD; then
+    program="${0%/*}"/ssl_pthread_server
+    run_one_connection -tls1_2
+fi
+
 if config_has MBEDTLS_SSL_PROTO_DTLS; then
     program="${0%/*}"/dtls_server
     protocol='DTLS 1.2'

--- a/programs/ssl/tls13_client_demo.sh
+++ b/programs/ssl/tls13_client_demo.sh
@@ -10,6 +10,6 @@ protocol='TLS 1.3'
 
 depends_on MBEDTLS_SSL_PROTO_TLS1_3 MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
 
-run_one_connection -www -tls1_3
+run_one_connection -tls1_3
 
 cleanup

--- a/programs/ssl/tls13_client_demo.sh
+++ b/programs/ssl/tls13_client_demo.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+#
+# Copyright The Mbed TLS Contributors
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+
+program="${0%/*}"/ssl_client1
+protocol='TLS 1.3'
+
+. "${0%/*}/tls_client_demo_common.sh"
+
+depends_on MBEDTLS_SSL_PROTO_TLS1_3 MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
+
+run_one_connection -www -tls1_3
+
+cleanup

--- a/programs/ssl/tls13_server_demo.sh
+++ b/programs/ssl/tls13_server_demo.sh
@@ -12,4 +12,9 @@ depends_on MBEDTLS_SSL_PROTO_TLS1_3 MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMER
 
 run_one_connection -tls1_3
 
+if config_has MBEDTLS_THREADING_PTHREAD; then
+    program="${0%/*}"/ssl_pthread_server
+    run_one_connection -tls1_3
+fi
+
 cleanup

--- a/programs/ssl/tls13_server_demo.sh
+++ b/programs/ssl/tls13_server_demo.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+#
+# Copyright The Mbed TLS Contributors
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+
+program="${0%/*}"/ssl_server
+protocol='TLS 1.3'
+
+. "${0%/*}/tls_server_demo_common.sh"
+
+depends_on MBEDTLS_SSL_PROTO_TLS1_3 MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
+
+run_one_connection -tls1_3
+
+cleanup

--- a/programs/ssl/tls_client_demo_common.sh
+++ b/programs/ssl/tls_client_demo_common.sh
@@ -59,7 +59,8 @@ run_one_connection () {
     kill "$server_pid" 2>/dev/null || true # The server may exit first
     # Check and display the presence of a few connection parameters
     grep '^ *client_version=' "$server_log"
-    grep '^ *KeyExchangeAlgorithm=' "$server_log"
+    grep '^ *KeyExchangeAlgorithm=' "$server_log" || # TLS 1.2
+        grep -A1 '^ *extension_type=key_share' "$server_log" # TLS 1.3
     grep '^ *cipher_suite ' "$server_log"
     grep 'ApplicationData' "$server_log"
     if [ "$ret" -ne 0 ]; then

--- a/programs/ssl/tls_client_demo_common.sh
+++ b/programs/ssl/tls_client_demo_common.sh
@@ -26,6 +26,18 @@ depends_on MBEDTLS_SSL_TLS_C MBEDTLS_SSL_CLI_C
 server_log="openssl-s_server-$$.log"
 files_to_clean="$server_log"
 
+unique_string="Response in demo $$."
+
+response () {
+    # Sleep until the client is likely to be connected.
+    sleep 2
+    printf '%s\r\n' \
+           'HTTP/1.0 200 OK' \
+           'Content-Type: text/plain' \
+           '' \
+           "$unique_string"
+}
+
 run_one_connection () {
     echo
     echo "#### Local connection: $protocol ####"
@@ -35,9 +47,9 @@ run_one_connection () {
         -key "$root_dir/framework/data_files/server5.key" \
         -cert "$root_dir/framework/data_files/server5.crt" \
         "$@"
-    set openssl s_server -accept 4433 "$@"
+    set openssl s_server -accept 4433 -trace "$@"
     printf '+ %s &\n' "$*"
-    "$@" >"$server_log" 2>&1 &
+    response | "$@" >"$server_log" 2>&1 &
     server_pid=$!
     # Give the server a reasonable amount of time to start
     sleep 1
@@ -45,6 +57,11 @@ run_one_connection () {
     printf '+ %s\n' "$program"
     "$program" || ret=$?
     kill "$server_pid" 2>/dev/null || true # The server may exit first
+    # Check and display the presence of a few connection parameters
+    grep '^ *client_version=' "$server_log"
+    grep '^ *KeyExchangeAlgorithm=' "$server_log"
+    grep '^ *cipher_suite ' "$server_log"
+    grep 'ApplicationData' "$server_log"
     if [ "$ret" -ne 0 ]; then
         echo "FAIL: $program returned $ret"
         echo "BEGIN server output"

--- a/programs/ssl/tls_client_demo_common.sh
+++ b/programs/ssl/tls_client_demo_common.sh
@@ -1,0 +1,56 @@
+## Common parts for an interoperability demo between an Mbed TLS client
+## and an OpenSSL server.
+
+# Required named parameters:
+# * $protocol: human-readable protocol version.
+# * $program: client program to run.
+
+# Copyright The Mbed TLS Contributors
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+
+. "${0%/*}/../demo_common.sh"
+
+msg <<'EOF'
+This script demonstrates the interoperability between a very simple
+$protocol client using Mbed TLS and an OpenSSL server.
+
+EOF
+
+if ! openssl version >/dev/null; then
+    echo >&2 "This demo script requires the 'openssl' command line program."
+    exit 100
+fi
+
+depends_on MBEDTLS_SSL_TLS_C MBEDTLS_SSL_CLI_C
+
+server_log="openssl-s_server-$$.log"
+files_to_clean="$server_log"
+
+run_one_connection () {
+    echo
+    echo "#### Local connection: $protocol ####"
+    # Pass a key and certificate. The ssl_client1 program doesn't actually
+    # check the certificates, so it doesn't matter what we pass here.
+    set -- \
+        -key "$root_dir/framework/data_files/server5.key" \
+        -cert "$root_dir/framework/data_files/server5.crt" \
+        "$@"
+    set openssl s_server -accept 4433 "$@"
+    printf '+ %s &\n' "$*"
+    "$@" >"$server_log" 2>&1 &
+    server_pid=$!
+    # Give the server a reasonable amount of time to start
+    sleep 1
+    ret=0
+    printf '+ %s\n' "$program"
+    "$program" || ret=$?
+    kill "$server_pid" 2>/dev/null || true # The server may exit first
+    if [ "$ret" -ne 0 ]; then
+        echo "FAIL: $program returned $ret"
+        echo "BEGIN server output"
+        cat "$server_log"
+        echo "END server output"
+        rm "$server_log"
+    fi
+    return "$ret"
+}

--- a/programs/ssl/tls_server_demo_common.sh
+++ b/programs/ssl/tls_server_demo_common.sh
@@ -40,6 +40,7 @@ run_one_connection () {
     set openssl s_client -connect localhost:4433 "$@"
     printf '\n+ %s\n' "$*"
     echo "This is some content." | "$@" >"$client_log" 2>&1
+    echo
 
     ret=0
     kill "$server_pid" || wait "$server_pid" || ret=$?

--- a/programs/ssl/tls_server_demo_common.sh
+++ b/programs/ssl/tls_server_demo_common.sh
@@ -1,0 +1,54 @@
+## Common parts for an interoperability demo between an Mbed TLS server
+## and an OpenSSL client.
+
+# Required named parameters:
+# * $protocol: human-readable protocol version.
+# * $program: server program to run.
+
+# Copyright The Mbed TLS Contributors
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+
+. "${0%/*}/../demo_common.sh"
+
+msg <<'EOF'
+This script demonstrates the interoperability between a very simple
+$protocol server using Mbed TLS and an OpenSSL client.
+
+EOF
+
+if ! openssl version >/dev/null; then
+    echo >&2 "This demo script requires the 'openssl' command line program."
+    exit 100
+fi
+
+depends_on MBEDTLS_SSL_TLS_C MBEDTLS_SSL_SRV_C
+
+client_log="openssl-s_client-$$.log"
+files_to_clean="$client_log"
+
+run_one_connection () {
+    echo
+    echo "#### Local connection: $protocol ####"
+
+    # Start the server in the background
+    printf '+ %s &\n' "$program"
+    "$program" &
+    server_pid=$!
+
+    # Give the server a reasonable amount of time to start
+    sleep 1
+    set openssl s_client -connect localhost:4433 "$@"
+    printf '\n+ %s\n' "$*"
+    echo "This is some content." | "$@" >"$client_log" 2>&1
+
+    ret=0
+    kill "$server_pid" || wait "$server_pid" || ret=$?
+    if [ "$ret" -ne 0 ]; then
+        echo "FAIL: $* returned $ret"
+        echo "BEGIN client output"
+        cat "$client_log"
+        echo "END client output"
+        rm "$client_log"
+    fi
+    return "$ret"
+}


### PR DESCRIPTION
Add demo scripts for `ssl_client1`, `ssl_server`, `ssl_pthread_server` and `dtls_server`. This way we have CI coverage for:

* These sample programs.
* A no-frills, out-of-box TLS connection.

The TLS 1.3 demo reveals https://github.com/Mbed-TLS/mbedtls/issues/9072 and https://github.com/Mbed-TLS/mbedtls/issues/8749.

Fixes #9072 in the sense that when this pull request passes the CI, it means the issue is fixed. (The actual fixes are in previous PR: #9501 and #9507.)

The sample programs hard-code port 4433, so the demos can't run concurrently. This may be a problem for CI reliability (although in principle it shouldn't be since each test run runs alone in a Docker instance).

Omitted:

* `mini_client` — would require different interactions with `openssl s_server`.
* `dtls_client` — would require different interactions with `openssl s_server`.
* `ssl_fork_server` — would require fancier process handling.

Priority: high because it is a non-regression test for https://github.com/Mbed-TLS/mbedtls/issues/9072 and https://github.com/Mbed-TLS/mbedtls/issues/8749. Not very-high because I don't propose to rush this into 3.6.1. We can do manual testing for 3.6.1, and have the automated testing before 3.6.2.

Status: I expect a CI failure until https://github.com/Mbed-TLS/mbedtls/issues/8749 is fixed.

## PR checklist

- [x] **changelog** not required because: only tests
- [ ] **development PR** TODO
- [x] **framework PR** not required
- [x] **3.6 PR** here
- [ ] **2.28 PR** TODO
- **tests**  provided
