### PR TITLE
[Backport 3.6] Move `config.py` functionalities to the framework

### DIFF
--- a/scripts/config.py
+++ b/scripts/config.py
@@ -103,9 +103,6 @@ EXCLUDE_FROM_FULL = frozenset([
     'MBEDTLS_TEST_CONSTANT_FLOW_MEMSAN', # build dependency (clang+memsan)
     'MBEDTLS_TEST_CONSTANT_FLOW_VALGRIND', # build dependency (valgrind headers)
     'MBEDTLS_X509_REMOVE_INFO', # removes a feature
-    *PSA_UNSUPPORTED_FEATURE,
-    *PSA_DEPRECATED_FEATURE,
-    *PSA_UNSTABLE_FEATURE
 ])
 
 def is_seamless_alt(name):
@@ -212,8 +209,6 @@ def include_in_crypto(name):
             'MBEDTLS_PKCS7_C', # part of libmbedx509
     ]:
         return False
-    if name in EXCLUDE_FROM_CRYPTO:
-        return False
     return True
 
 def crypto_adapter(adapter):
@@ -232,7 +227,6 @@ def crypto_adapter(adapter):
 
 DEPRECATED = frozenset([
     'MBEDTLS_PSA_CRYPTO_SE_C',
-    *PSA_DEPRECATED_FEATURE
 ])
 def no_deprecated_adapter(adapter):
     """Modify an adapter to disable deprecated symbols.

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -423,13 +423,16 @@ class CombinedConfig(config_common.Config):
 
         If mbedtls_file or crypto_file is specified, write the specific configuration
         to the corresponding file instead.
+
+        The parameter name is differ from the definition of the super class to handle
+        two different config files.
         """
 
         self.mbedtls_configfile.write(self.settings, mbedtls_file)
         self.crypto_configfile.write(self.settings, crypto_file)
 
     def filename(self, name=None):
-        """Get the names of the config files.
+        """Get the name of the config files.
 
         If 'name' is specified return the name of the config file where it is defined.
         """

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -424,8 +424,8 @@ class CombinedConfig(config_common.Config):
         If mbedtls_file or crypto_file is specified, write the specific configuration
         to the corresponding file instead.
 
-        The parameter name is differ from the definition of the super class to handle
-        two different config files.
+        Two file name parameters and not only one as in the super class as we handle
+        two configuration files in this class.
         """
 
         self.mbedtls_configfile.write(self.settings, mbedtls_file)

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -447,7 +447,7 @@ class MbedTLSConfigTool(config_common.ConfigTool):
     """Command line mbedtls_config.h and crypto_config.h manipulation tool."""
 
     def __init__(self):
-        super().__init__(MbedTLSConfigFile)
+        super().__init__(MbedTLSConfigFile.default_path)
         self.config = CombinedConfig(MbedTLSConfigFile(self.args.file),
                                      CryptoConfigFile(self.args.cryptofile))
 

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -3,7 +3,7 @@
 """Mbed TLS and PSA configuration file manipulation library and tool
 
 Basic usage, to read the Mbed TLS configuration:
-    config = CombinedConfigFile()
+    config = MbedTLSConfig()
     if 'MBEDTLS_RSA_C' in config: print('RSA is enabled')
 """
 
@@ -448,8 +448,7 @@ class MbedTLSConfigTool(config_common.ConfigTool):
 
     def __init__(self):
         super().__init__(MbedTLSConfigFile.default_path)
-        self.config = CombinedConfig(MbedTLSConfigFile(self.args.file),
-                                     CryptoConfigFile(self.args.cryptofile))
+        self.config = MbedTLSConfig(self.args.file)
 
     def custom_parser_options(self):
         """Adds MbedTLS specific options for the parser."""

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -448,8 +448,8 @@ class MbedTLSConfigTool(config_common.ConfigTool):
 
     def __init__(self):
         super().__init__(MbedTLSConfigFile)
-        self.config = CombinedConfig(MbedTLSConfigFile(self.parser_args.file),
-                                     CryptoConfigFile(self.parser_args.cryptofile))
+        self.config = CombinedConfig(MbedTLSConfigFile(self.args.file),
+                                     CryptoConfigFile(self.args.cryptofile))
 
     def custom_parser_options(self):
         """Adds MbedTLS specific options for the parser."""

--- a/tests/scripts/depends.py
+++ b/tests/scripts/depends.py
@@ -537,7 +537,7 @@ def main():
                             default=True)
         options = parser.parse_args()
         os.chdir(options.directory)
-        conf = config.ConfigFile(options.config)
+        conf = config.MbedTLSConfig(options.config)
         domain_data = DomainData(options, conf)
 
         if options.tasks is True:


### PR DESCRIPTION
## Description

Move the part of the `config.py` which is common in the TF-PSA_Crypto and the MbedTLS repo to the framework repo.

Trivial backport of #9470 except to use MbedTLSConfig as default config handler.

Resolve #9325

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** provided | not required because: script change
- [x] **development PR** provided #9470 
- [x] **framework PR** provided Mbed-TLS/mbedtls-framework#41
- [x] **3.6 PR** provided: this is
- [x] **2.28 PR** provided # | not required because: not related change
- **tests**  provided 
