### PR TITLE
Misc small makefile fixes

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -247,8 +247,7 @@ ifndef WINDOWS
 	$(MAKE) -C psa-client-server/psasim clean
 	rm -rf $(BINARIES) *.c *.datax
 	rm -rf $(CRYPTO_BINARIES) ../tf-psa-crypto/tests/*.c ../tf-psa-crypto/tests/*.datax
-	rm -f src/*.o src/drivers/*.o src/test_helpers/*.o src/libmbed* src/test_keys.h src/test_certs.h
-	rm -f src/test_keys.h src/test_certs.h
+	rm -f src/*.o src/drivers/*.o src/test_helpers/*.o src/libmbed*
 	rm -f include/test/instrument_record_status.h
 	rm -f include/alt-extra/*/*_alt.h
 	rm -rf libtestdriver1
@@ -263,8 +262,6 @@ else
 	if exist ../tf-psa-crypto/tests/*.datax del /Q /F ../tf-psa-crypto/tests/*.datax
 	if exist src/*.o del /Q /F src/*.o
 	if exist src/drivers/*.o del /Q /F src/drivers/*.o
-	if exist src/test_keys.h del /Q /F src/test_keys.h
-	if exist src/test_certs.h del /Q /F src/test_certs.h
 	if exist src/test_helpers/*.o del /Q /F src/test_helpers/*.o
 	if exist src/libmbed* del /Q /F src/libmbed*
 	if exist include/test/instrument_record_status.h del /Q /F include/test/instrument_record_status.h

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -264,9 +264,9 @@ else
 	if exist src/*.o del /Q /F src/*.o
 	if exist src/drivers/*.o del /Q /F src/drivers/*.o
 	if exist src/test_keys.h del /Q /F src/test_keys.h
-	if exist src/test_certs.h del /Q /F src/test_cers.h
+	if exist src/test_certs.h del /Q /F src/test_certs.h
 	if exist src/test_helpers/*.o del /Q /F src/test_helpers/*.o
-	if exist src/libmbed* del /Q /F src/libmed*
+	if exist src/libmbed* del /Q /F src/libmbed*
 	if exist include/test/instrument_record_status.h del /Q /F include/test/instrument_record_status.h
 endif
 


### PR DESCRIPTION
## Description

Small fixes to the Makefiles:
- typos in the windows portion;
- some generated files were incorrectly removed by `clean` - they're supposed to be only removed by `neat`.

Forward-ported from the [3.6 release candidate PR](https://github.com/Mbed-TLS/mbedtls-restricted/pull/1286).

## PR checklist

- [x] **changelog** not required because: small fixes to the Makefiles
- [x] **development PR** here
- [x] **framework PR** not required
- [x] **3.6 PR** not required because: already done as part of the release (landed with mergeback of the release branch)
- [x] **2.28 PR** not required because: 2.28 not affected
- **tests** not required because: Makefiles
