### PR TITLE
Restore testing of all reference configs

### DIFF
--- a/tests/scripts/components-configuration.sh
+++ b/tests/scripts/components-configuration.sh
@@ -141,7 +141,7 @@ component_test_ref_configs () {
     # dependency resolution for generated files and just rely on them being
     # present (thanks to pre_generate_files) by turning GEN_FILES off.
     CC=$ASAN_CC cmake -D GEN_FILES=Off -D CMAKE_BUILD_TYPE:String=Asan .
-    tests/scripts/test-ref-configs.pl config-tfm.h
+    tests/scripts/test-ref-configs.pl
 }
 
 component_test_full_cmake_clang () {


### PR DESCRIPTION
## Description
Following commit [635a2beb](https://github.com/Mbed-TLS/mbedtls/commit/635a2beb74dc92173790a9e3c58d9009d2fd1904) in #9394 only the TF-M reference config was tested.

## PR checklist
- [x] **changelog** not required because: testing regression fix 
- [x] **development PR** provided , this one
- [x] **framework PR** not required
- [x] **3.6 PR** not required because: fixing development only issue
- [x] **2.28 PR** not required because: fixing development only issue 
- **tests**  not required because: testing regression fix