### PR TITLE
[Backport 2.28] tests: fix calloc() argument list (gcc-14 fix)

### DIFF
--- a/tests/include/test/macros.h
+++ b/tests/include/test/macros.h
@@ -135,8 +135,8 @@
     do {                                                    \
         TEST_ASSERT((pointer) == NULL);                     \
         if ((item_count) != 0) {                            \
-            (pointer) = mbedtls_calloc(sizeof(*(pointer)),  \
-                                       (item_count));       \
+            (pointer) = mbedtls_calloc((item_count),        \
+                                       sizeof(*(pointer))); \
             TEST_ASSERT((pointer) != NULL);                 \
         }                                                   \
     } while (0)
@@ -165,8 +165,8 @@
 #define TEST_CALLOC_NONNULL(pointer, item_count)            \
     do {                                                    \
         TEST_ASSERT((pointer) == NULL);                     \
-        (pointer) = mbedtls_calloc(sizeof(*(pointer)),      \
-                                   (item_count));           \
+        (pointer) = mbedtls_calloc((item_count),            \
+                                   sizeof(*(pointer)));     \
         if (((pointer) == NULL) && ((item_count) == 0)) {   \
             (pointer) = mbedtls_calloc(1, 1);               \
         }                                                   \
@@ -185,8 +185,8 @@
     do {                                                    \
         TEST_ASSERT((pointer) == NULL);                     \
         if ((item_count) != 0) {                            \
-            (pointer) = mbedtls_calloc(sizeof(*(pointer)),  \
-                                       (item_count));       \
+            (pointer) = mbedtls_calloc((item_count),        \
+                                       sizeof(*(pointer))); \
             TEST_ASSUME((pointer) != NULL);                 \
         }                                                   \
     } while (0)


### PR DESCRIPTION
## Description

Backport https://github.com/Mbed-TLS/mbedtls/pull/8751

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** ~~provided~~ | not required because: minor change
- [x] **development PR** ~~provided #~~ | not required because: it is a backport
- [x] **framework PR** ~~provided Mbed-TLS/mbedtls-framework#~~ | not required (no framework interaction)
- **tests**  ~~provided~~ | not required because: Not testable (compiler fix)



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
