### PR TITLE
Backport 3.6: test sample programs in ssl-opt.sh

### DIFF
--- a/programs/ssl/dtls_client.c
+++ b/programs/ssl/dtls_client.c
@@ -44,7 +44,7 @@ int main(void)
 #ifdef FORCE_IPV4
 #define SERVER_ADDR "127.0.0.1"     /* Forces IPv4 */
 #else
-#define SERVER_ADDR "::1"
+#define SERVER_ADDR SERVER_NAME
 #endif
 
 #define MESSAGE     "Echo this"

--- a/programs/ssl/dtls_client.c
+++ b/programs/ssl/dtls_client.c
@@ -9,18 +9,17 @@
 
 #include "mbedtls/platform.h"
 
-#if !defined(MBEDTLS_SSL_CLI_C) || !defined(MBEDTLS_SSL_PROTO_DTLS) ||    \
-    !defined(MBEDTLS_NET_C)  || !defined(MBEDTLS_TIMING_C) ||             \
-    !defined(MBEDTLS_ENTROPY_C) || !defined(MBEDTLS_CTR_DRBG_C) ||        \
-    !defined(MBEDTLS_X509_CRT_PARSE_C) || !defined(MBEDTLS_RSA_C) ||      \
-    !defined(MBEDTLS_PEM_PARSE_C)
+#if !defined(MBEDTLS_ENTROPY_C) || !defined(MBEDTLS_CTR_DRBG_C) ||      \
+    !defined(MBEDTLS_NET_C) || !defined(MBEDTLS_SSL_CLI_C) ||           \
+    !defined(MBEDTLS_TIMING_C) || !defined(MBEDTLS_SSL_PROTO_DTLS) ||   \
+    !defined(MBEDTLS_PEM_PARSE_C) || !defined(MBEDTLS_X509_CRT_PARSE_C)
 int main(void)
 {
-    mbedtls_printf("MBEDTLS_SSL_CLI_C and/or MBEDTLS_SSL_PROTO_DTLS and/or "
-                   "MBEDTLS_NET_C and/or MBEDTLS_TIMING_C and/or "
-                   "MBEDTLS_ENTROPY_C and/or MBEDTLS_CTR_DRBG_C and/or "
-                   "MBEDTLS_X509_CRT_PARSE_C and/or MBEDTLS_RSA_C and/or "
-                   "MBEDTLS_PEM_PARSE_C not defined.\n");
+    mbedtls_printf("MBEDTLS_ENTROPY_C and/or MBEDTLS_CTR_DRBG_C and/or "
+                   "MBEDTLS_NET_C and/or MBEDTLS_SSL_CLI_C and/or "
+                   "MBEDTLS_TIMING_C and/or MBEDTLS_SSL_PROTO_DTLS and/or "
+                   "MBEDTLS_PEM_PARSE_C and/or MBEDTLS_X509_CRT_PARSE_C "
+                   "not defined.\n");
     mbedtls_exit(0);
 }
 #else
@@ -337,6 +336,5 @@ exit:
 
     mbedtls_exit(ret);
 }
-#endif /* MBEDTLS_SSL_CLI_C && MBEDTLS_SSL_PROTO_DTLS && MBEDTLS_NET_C &&
-          MBEDTLS_TIMING_C && MBEDTLS_ENTROPY_C && MBEDTLS_CTR_DRBG_C &&
-          MBEDTLS_X509_CRT_PARSE_C && MBEDTLS_RSA_C && MBEDTLS_PEM_PARSE_C */
+
+#endif /* configuration allows running this program */

--- a/programs/ssl/dtls_server.c
+++ b/programs/ssl/dtls_server.c
@@ -18,19 +18,19 @@
 #define BIND_IP     "::"
 #endif
 
-#if !defined(MBEDTLS_SSL_SRV_C) || !defined(MBEDTLS_SSL_PROTO_DTLS) ||    \
-    !defined(MBEDTLS_SSL_COOKIE_C) || !defined(MBEDTLS_NET_C) ||          \
-    !defined(MBEDTLS_ENTROPY_C) || !defined(MBEDTLS_CTR_DRBG_C) ||        \
-    !defined(MBEDTLS_X509_CRT_PARSE_C) || !defined(MBEDTLS_RSA_C) ||      \
-    !defined(MBEDTLS_PEM_PARSE_C) || !defined(MBEDTLS_TIMING_C)
-
+#if !defined(MBEDTLS_ENTROPY_C) || !defined(MBEDTLS_CTR_DRBG_C) ||      \
+    !defined(MBEDTLS_NET_C) || !defined(MBEDTLS_SSL_SRV_C) ||           \
+    !defined(MBEDTLS_TIMING_C) || !defined(MBEDTLS_SSL_PROTO_DTLS) ||   \
+    !defined(MBEDTLS_SSL_COOKIE_C) ||                                   \
+    !defined(MBEDTLS_PEM_PARSE_C) || !defined(MBEDTLS_X509_CRT_PARSE_C)
 int main(void)
 {
-    printf("MBEDTLS_SSL_SRV_C and/or MBEDTLS_SSL_PROTO_DTLS and/or "
-           "MBEDTLS_SSL_COOKIE_C and/or MBEDTLS_NET_C and/or "
-           "MBEDTLS_ENTROPY_C and/or MBEDTLS_CTR_DRBG_C and/or "
-           "MBEDTLS_X509_CRT_PARSE_C and/or MBEDTLS_RSA_C and/or "
-           "MBEDTLS_PEM_PARSE_C and/or MBEDTLS_TIMING_C not defined.\n");
+    mbedtls_printf("MBEDTLS_ENTROPY_C and/or MBEDTLS_CTR_DRBG_C and/or "
+                   "MBEDTLS_NET_C and/or MBEDTLS_SSL_SRV_C and/or "
+                   "MBEDTLS_TIMING_C and/or MBEDTLS_SSL_PROTO_DTLS and/or "
+                   "MBEDTLS_SSL_COOKIE_C and/or "
+                   "MBEDTLS_PEM_PARSE_C and/or MBEDTLS_X509_CRT_PARSE_C "
+                   "not defined.\n");
     mbedtls_exit(0);
 }
 #else
@@ -402,7 +402,5 @@ exit:
 
     mbedtls_exit(ret);
 }
-#endif /* MBEDTLS_SSL_SRV_C && MBEDTLS_SSL_PROTO_DTLS &&
-          MBEDTLS_SSL_COOKIE_C && MBEDTLS_NET_C && MBEDTLS_ENTROPY_C &&
-          MBEDTLS_CTR_DRBG_C && MBEDTLS_X509_CRT_PARSE_C && MBEDTLS_RSA_C
-          && MBEDTLS_PEM_PARSE_C && MBEDTLS_TIMING_C */
+
+#endif /* configuration allows running this program */

--- a/programs/ssl/ssl_client1.c
+++ b/programs/ssl/ssl_client1.c
@@ -240,6 +240,9 @@ int main(void)
         }
 
         if (ret == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY) {
+            mbedtls_printf("The return value %d from mbedtls_ssl_read() means that the server\n"
+                           "closed the connection first. We're ok with that.\n",
+                           MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY);
             break;
         }
 
@@ -259,7 +262,9 @@ int main(void)
 
     mbedtls_ssl_close_notify(&ssl);
 
-    exit_code = MBEDTLS_EXIT_SUCCESS;
+    if (ret == 0 || ret == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY) {
+        exit_code = MBEDTLS_EXIT_SUCCESS;
+    }
 
 exit:
 

--- a/programs/ssl/ssl_client1.c
+++ b/programs/ssl/ssl_client1.c
@@ -9,17 +9,14 @@
 
 #include "mbedtls/platform.h"
 
-#if !defined(MBEDTLS_BIGNUM_C) || !defined(MBEDTLS_ENTROPY_C) ||     \
-    !defined(MBEDTLS_SSL_TLS_C) || !defined(MBEDTLS_SSL_CLI_C) ||    \
-    !defined(MBEDTLS_NET_C) || !defined(MBEDTLS_RSA_C) ||            \
-    !defined(MBEDTLS_PEM_PARSE_C) || !defined(MBEDTLS_CTR_DRBG_C) || \
-    !defined(MBEDTLS_X509_CRT_PARSE_C)
+#if !defined(MBEDTLS_ENTROPY_C) || !defined(MBEDTLS_CTR_DRBG_C) ||      \
+    !defined(MBEDTLS_NET_C) || !defined(MBEDTLS_SSL_CLI_C) ||           \
+    !defined(MBEDTLS_PEM_PARSE_C) || !defined(MBEDTLS_X509_CRT_PARSE_C)
 int main(void)
 {
-    mbedtls_printf("MBEDTLS_BIGNUM_C and/or MBEDTLS_ENTROPY_C and/or "
-                   "MBEDTLS_SSL_TLS_C and/or MBEDTLS_SSL_CLI_C and/or "
-                   "MBEDTLS_NET_C and/or MBEDTLS_RSA_C and/or "
-                   "MBEDTLS_CTR_DRBG_C and/or MBEDTLS_X509_CRT_PARSE_C "
+    mbedtls_printf("MBEDTLS_ENTROPY_C and/or MBEDTLS_CTR_DRBG_C and/or "
+                   "MBEDTLS_NET_C and/or MBEDTLS_SSL_CLI_C and/or "
+                   "MBEDTLS_PEM_PARSE_C and/or MBEDTLS_X509_CRT_PARSE_C "
                    "not defined.\n");
     mbedtls_exit(0);
 }
@@ -288,6 +285,5 @@ exit:
 
     mbedtls_exit(exit_code);
 }
-#endif /* MBEDTLS_BIGNUM_C && MBEDTLS_ENTROPY_C && MBEDTLS_SSL_TLS_C &&
-          MBEDTLS_SSL_CLI_C && MBEDTLS_NET_C && MBEDTLS_RSA_C &&
-          MBEDTLS_PEM_PARSE_C && MBEDTLS_CTR_DRBG_C && MBEDTLS_X509_CRT_PARSE_C */
+
+#endif /* configuration allows running this program */

--- a/programs/ssl/ssl_fork_server.c
+++ b/programs/ssl/ssl_fork_server.c
@@ -9,22 +9,15 @@
 
 #include "mbedtls/platform.h"
 
-#if !defined(MBEDTLS_BIGNUM_C) || !defined(MBEDTLS_ENTROPY_C) ||          \
-    !defined(MBEDTLS_SSL_TLS_C) || !defined(MBEDTLS_SSL_SRV_C) ||         \
-    !defined(MBEDTLS_NET_C) || !defined(MBEDTLS_RSA_C) ||                 \
-    !defined(MBEDTLS_CTR_DRBG_C) || !defined(MBEDTLS_X509_CRT_PARSE_C) || \
-    !defined(MBEDTLS_TIMING_C) || !defined(MBEDTLS_FS_IO) ||              \
-    !defined(MBEDTLS_PEM_PARSE_C)
-int main(int argc, char *argv[])
+#if !defined(MBEDTLS_ENTROPY_C) || !defined(MBEDTLS_CTR_DRBG_C) ||      \
+    !defined(MBEDTLS_NET_C) || !defined(MBEDTLS_SSL_SRV_C) ||           \
+    !defined(MBEDTLS_PEM_PARSE_C) || !defined(MBEDTLS_X509_CRT_PARSE_C)
+int main(void)
 {
-    ((void) argc);
-    ((void) argv);
-
-    mbedtls_printf("MBEDTLS_BIGNUM_C and/or MBEDTLS_ENTROPY_C "
-                   "and/or MBEDTLS_SSL_TLS_C and/or MBEDTLS_SSL_SRV_C and/or "
-                   "MBEDTLS_NET_C and/or MBEDTLS_RSA_C and/or "
-                   "MBEDTLS_CTR_DRBG_C and/or MBEDTLS_X509_CRT_PARSE_C and/or "
-                   "MBEDTLS_TIMING_C and/or MBEDTLS_PEM_PARSE_C not defined.\n");
+    mbedtls_printf("MBEDTLS_ENTROPY_C and/or MBEDTLS_CTR_DRBG_C and/or "
+                   "MBEDTLS_NET_C and/or MBEDTLS_SSL_SRV_C and/or "
+                   "MBEDTLS_PEM_PARSE_C and/or MBEDTLS_X509_CRT_PARSE_C "
+                   "not defined.\n");
     mbedtls_exit(0);
 }
 #elif defined(_WIN32)
@@ -225,6 +218,7 @@ int main(void)
         if (pid != 0) {
             mbedtls_printf(" ok\n");
             mbedtls_net_close(&client_fd);
+            fflush(stdout);
 
             if ((ret = mbedtls_ctr_drbg_reseed(&ctr_drbg,
                                                (const unsigned char *) "parent",
@@ -282,6 +276,7 @@ int main(void)
         }
 
         mbedtls_printf("pid %d: SSL handshake ok\n", pid);
+        fflush(stdout);
 
         /*
          * 6. Read the HTTP Request
@@ -312,12 +307,14 @@ int main(void)
                         mbedtls_printf("pid %d: mbedtls_ssl_read returned %d\n", pid, ret);
                         break;
                 }
+                fflush(stdout);
 
                 break;
             }
 
             len = ret;
             mbedtls_printf("pid %d: %d bytes read\n\n%s", pid, len, (char *) buf);
+            fflush(stdout);
 
             if (ret > 0) {
                 break;
@@ -333,7 +330,7 @@ int main(void)
         len = sprintf((char *) buf, HTTP_RESPONSE,
                       mbedtls_ssl_get_ciphersuite(&ssl));
 
-        while (cnt++ < 100) {
+        while (cnt++ < 10) {
             while ((ret = mbedtls_ssl_write(&ssl, buf, len)) <= 0) {
                 if (ret == MBEDTLS_ERR_NET_CONN_RESET) {
                     mbedtls_printf(
@@ -349,12 +346,16 @@ int main(void)
                 }
             }
             len = ret;
-            mbedtls_printf("pid %d: %d bytes written\n\n%s\n", pid, len, (char *) buf);
+            mbedtls_printf("pid %d: %d bytes written (cnt=%d)\n\n%s\n",
+                           pid, len, cnt, (char *) buf);
+            fflush(stdout);
 
             mbedtls_net_usleep(1000000);
         }
 
         mbedtls_ssl_close_notify(&ssl);
+        mbedtls_printf("pid %d: shutting down\n", pid);
+        fflush(stdout);
         goto exit;
     }
 

--- a/programs/ssl/ssl_pthread_server.c
+++ b/programs/ssl/ssl_pthread_server.c
@@ -10,20 +10,21 @@
 
 #include "mbedtls/platform.h"
 
-#if !defined(MBEDTLS_BIGNUM_C)  || !defined(MBEDTLS_ENTROPY_C) ||         \
-    !defined(MBEDTLS_SSL_TLS_C) || !defined(MBEDTLS_SSL_SRV_C) ||         \
-    !defined(MBEDTLS_NET_C) || !defined(MBEDTLS_RSA_C) ||                 \
-    !defined(MBEDTLS_CTR_DRBG_C) || !defined(MBEDTLS_X509_CRT_PARSE_C) || \
-    !defined(MBEDTLS_FS_IO) || !defined(MBEDTLS_THREADING_C) ||           \
-    !defined(MBEDTLS_THREADING_PTHREAD) || !defined(MBEDTLS_PEM_PARSE_C)
+#if !defined(MBEDTLS_ENTROPY_C) || !defined(MBEDTLS_CTR_DRBG_C) ||      \
+    !defined(MBEDTLS_NET_C) || !defined(MBEDTLS_SSL_SRV_C) ||           \
+    !defined(MBEDTLS_PEM_PARSE_C) || !defined(MBEDTLS_X509_CRT_PARSE_C)
 int main(void)
 {
-    mbedtls_printf("MBEDTLS_BIGNUM_C and/or MBEDTLS_ENTROPY_C "
-                   "and/or MBEDTLS_SSL_TLS_C and/or MBEDTLS_SSL_SRV_C and/or "
-                   "MBEDTLS_NET_C and/or MBEDTLS_RSA_C and/or "
-                   "MBEDTLS_CTR_DRBG_C and/or MBEDTLS_X509_CRT_PARSE_C and/or "
-                   "MBEDTLS_THREADING_C and/or MBEDTLS_THREADING_PTHREAD "
-                   "and/or MBEDTLS_PEM_PARSE_C not defined.\n");
+    mbedtls_printf("MBEDTLS_ENTROPY_C and/or MBEDTLS_CTR_DRBG_C and/or "
+                   "MBEDTLS_NET_C and/or MBEDTLS_SSL_SRV_C and/or "
+                   "MBEDTLS_PEM_PARSE_C and/or MBEDTLS_X509_CRT_PARSE_C "
+                   "not defined.\n");
+    mbedtls_exit(0);
+}
+#elif !defined(MBEDTLS_THREADING_C) || !defined(MBEDTLS_THREADING_PTHREAD)
+int main(void)
+{
+    mbedtls_printf("MBEDTLS_THREADING_PTHREAD not defined.\n");
     mbedtls_exit(0);
 }
 #else
@@ -123,6 +124,7 @@ static void *handle_ssl_connection(void *data)
      * 5. Handshake
      */
     mbedtls_printf("  [ #%ld ]  Performing the SSL/TLS handshake\n", thread_id);
+    fflush(stdout);
 
     while ((ret = mbedtls_ssl_handshake(&ssl)) != 0) {
         if (ret != MBEDTLS_ERR_SSL_WANT_READ && ret != MBEDTLS_ERR_SSL_WANT_WRITE) {
@@ -138,6 +140,7 @@ static void *handle_ssl_connection(void *data)
      * 6. Read the HTTP Request
      */
     mbedtls_printf("  [ #%ld ]  < Read from client\n", thread_id);
+    fflush(stdout);
 
     do {
         len = sizeof(buf) - 1;
@@ -170,6 +173,7 @@ static void *handle_ssl_connection(void *data)
         len = ret;
         mbedtls_printf("  [ #%ld ]  %d bytes read\n=====\n%s\n=====\n",
                        thread_id, len, (char *) buf);
+        fflush(stdout);
 
         if (ret > 0) {
             break;
@@ -180,6 +184,7 @@ static void *handle_ssl_connection(void *data)
      * 7. Write the 200 Response
      */
     mbedtls_printf("  [ #%ld ]  > Write to client:\n", thread_id);
+    fflush(stdout);
 
     len = sprintf((char *) buf, HTTP_RESPONSE,
                   mbedtls_ssl_get_ciphersuite(&ssl));
@@ -201,6 +206,7 @@ static void *handle_ssl_connection(void *data)
     len = ret;
     mbedtls_printf("  [ #%ld ]  %d bytes written\n=====\n%s\n=====\n",
                    thread_id, len, (char *) buf);
+    fflush(stdout);
 
     mbedtls_printf("  [ #%ld ]  . Closing the connection...", thread_id);
 
@@ -214,6 +220,7 @@ static void *handle_ssl_connection(void *data)
     }
 
     mbedtls_printf(" ok\n");
+    fflush(stdout);
 
     ret = 0;
 
@@ -442,6 +449,7 @@ reset:
      * 3. Wait until a client connects
      */
     mbedtls_printf("  [ main ]  Waiting for a remote connection\n");
+    fflush(stdout);
 
     if ((ret = mbedtls_net_accept(&listen_fd, &client_fd,
                                   NULL, 0, NULL)) != 0) {
@@ -483,7 +491,4 @@ exit:
     mbedtls_exit(ret);
 }
 
-#endif /* MBEDTLS_BIGNUM_C && MBEDTLS_ENTROPY_C &&
-          MBEDTLS_SSL_TLS_C && MBEDTLS_SSL_SRV_C && MBEDTLS_NET_C &&
-          MBEDTLS_RSA_C && MBEDTLS_CTR_DRBG_C && MBEDTLS_THREADING_C &&
-          MBEDTLS_THREADING_PTHREAD && MBEDTLS_PEM_PARSE_C */
+#endif /* configuration allows running this program */

--- a/programs/ssl/ssl_server.c
+++ b/programs/ssl/ssl_server.c
@@ -312,16 +312,19 @@ reset:
     mbedtls_printf(" %d bytes written\n\n%s\n", len, (char *) buf);
 
     mbedtls_printf("  . Closing the connection...");
+    fflush(stdout);
 
     while ((ret = mbedtls_ssl_close_notify(&ssl)) < 0) {
         if (ret != MBEDTLS_ERR_SSL_WANT_READ &&
-            ret != MBEDTLS_ERR_SSL_WANT_WRITE) {
+            ret != MBEDTLS_ERR_SSL_WANT_WRITE &&
+            ret != MBEDTLS_ERR_NET_CONN_RESET) {
             mbedtls_printf(" failed\n  ! mbedtls_ssl_close_notify returned %d\n\n", ret);
             goto reset;
         }
     }
 
     mbedtls_printf(" ok\n");
+    fflush(stdout);
 
     ret = 0;
     goto reset;

--- a/programs/ssl/ssl_server.c
+++ b/programs/ssl/ssl_server.c
@@ -9,18 +9,15 @@
 
 #include "mbedtls/platform.h"
 
-#if !defined(MBEDTLS_BIGNUM_C) || !defined(MBEDTLS_PEM_PARSE_C) || \
-    !defined(MBEDTLS_ENTROPY_C) || !defined(MBEDTLS_SSL_TLS_C) ||  \
-    !defined(MBEDTLS_SSL_SRV_C) || !defined(MBEDTLS_NET_C) ||      \
-    !defined(MBEDTLS_RSA_C) || !defined(MBEDTLS_CTR_DRBG_C) ||     \
-    !defined(MBEDTLS_X509_CRT_PARSE_C) || !defined(MBEDTLS_FS_IO)
+#if !defined(MBEDTLS_ENTROPY_C) || !defined(MBEDTLS_CTR_DRBG_C) ||      \
+    !defined(MBEDTLS_NET_C) || !defined(MBEDTLS_SSL_SRV_C) ||           \
+    !defined(MBEDTLS_PEM_PARSE_C) || !defined(MBEDTLS_X509_CRT_PARSE_C)
 int main(void)
 {
-    mbedtls_printf("MBEDTLS_BIGNUM_C and/or MBEDTLS_ENTROPY_C "
-                   "and/or MBEDTLS_SSL_TLS_C and/or MBEDTLS_SSL_SRV_C and/or "
-                   "MBEDTLS_NET_C and/or MBEDTLS_RSA_C and/or "
-                   "MBEDTLS_CTR_DRBG_C and/or MBEDTLS_X509_CRT_PARSE_C "
-                   "and/or MBEDTLS_PEM_PARSE_C not defined.\n");
+    mbedtls_printf("MBEDTLS_ENTROPY_C and/or MBEDTLS_CTR_DRBG_C and/or "
+                   "MBEDTLS_NET_C and/or MBEDTLS_SSL_SRV_C and/or "
+                   "MBEDTLS_PEM_PARSE_C and/or MBEDTLS_X509_CRT_PARSE_C "
+                   "not defined.\n");
     mbedtls_exit(0);
 }
 #else
@@ -356,7 +353,5 @@ exit:
 
     mbedtls_exit(ret);
 }
-#endif /* MBEDTLS_BIGNUM_C && MBEDTLS_ENTROPY_C &&
-          MBEDTLS_SSL_TLS_C && MBEDTLS_SSL_SRV_C && MBEDTLS_NET_C &&
-          MBEDTLS_RSA_C && MBEDTLS_CTR_DRBG_C && MBEDTLS_X509_CRT_PARSE_C
-          && MBEDTLS_FS_IO && MBEDTLS_PEM_PARSE_C */
+
+#endif /* configuration allows running this program */

--- a/tests/opt-testcases/sample.sh
+++ b/tests/opt-testcases/sample.sh
@@ -4,3 +4,45 @@
 # SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 
 : ${PROGRAMS_DIR:=../programs/ssl}
+
+requires_protocol_version tls12
+run_test    "Sample: ssl_client1, openssl server, TLS 1.2" \
+            -P 4433 \
+            "$O_SRV -tls1_2" \
+            "$PROGRAMS_DIR/ssl_client1" \
+            0 \
+            -c "New, TLSv1.2, Cipher is" \
+            -S "ERROR" \
+            -C "error"
+
+requires_protocol_version tls12
+run_test    "Sample: ssl_client1, gnutls server, TLS 1.2" \
+            -P 4433 \
+            "$G_SRV --priority=NORMAL:-VERS-TLS-ALL:+VERS-TLS1.2" \
+            "$PROGRAMS_DIR/ssl_client1" \
+            0 \
+            -s "Version: TLS1.2" \
+            -c "<TD>Protocol version:</TD><TD>TLS1.2</TD>" \
+            -S "Error" \
+            -C "error"
+
+requires_protocol_version tls13
+run_test    "Sample: ssl_client1, openssl server, TLS 1.3" \
+            -P 4433 \
+            "$O_SRV -tls1_3" \
+            "$PROGRAMS_DIR/ssl_client1" \
+            0 \
+            -c "New, TLSv1.3, Cipher is" \
+            -S "ERROR" \
+            -C "error"
+
+requires_protocol_version tls13
+run_test    "Sample: ssl_client1, gnutls server, TLS 1.3" \
+            -P 4433 \
+            "$G_SRV --priority=NORMAL:-VERS-TLS-ALL:+VERS-TLS1.3" \
+            "$PROGRAMS_DIR/ssl_client1" \
+            0 \
+            -s "Version: TLS1.3" \
+            -c "<TD>Protocol version:</TD><TD>TLS1.3</TD>" \
+            -S "Error" \
+            -C "error"

--- a/tests/opt-testcases/sample.sh
+++ b/tests/opt-testcases/sample.sh
@@ -118,3 +118,47 @@ run_test    "Sample: ssl_server, gnutls client, TLS 1.3" \
             -c "Description:.*TLS1.3" \
             -S "error" \
             -C "ERROR"
+
+requires_protocol_version tls12
+run_test    "Sample: ssl_pthread_server, openssl client, TLS 1.2" \
+            -P 4433 \
+            "$PROGRAMS_DIR/ssl_pthread_server" \
+            "$O_CLI -tls1_2" \
+            0 \
+            -s "Successful connection using: TLS-" \
+            -c "New, TLSv1.2, Cipher is" \
+            -S "error" \
+            -C "ERROR"
+
+requires_protocol_version tls12
+run_test    "Sample: ssl_pthread_server, gnutls client, TLS 1.2" \
+            -P 4433 \
+            "$PROGRAMS_DIR/ssl_pthread_server" \
+            "$G_CLI --priority=NORMAL:-VERS-TLS-ALL:+VERS-TLS1.2 localhost" \
+            0 \
+            -s "Successful connection using: TLS-" \
+            -c "Description:.*TLS1.2" \
+            -S "error" \
+            -C "ERROR"
+
+requires_protocol_version tls13
+run_test    "Sample: ssl_pthread_server, openssl client, TLS 1.3" \
+            -P 4433 \
+            "$PROGRAMS_DIR/ssl_pthread_server" \
+            "$O_CLI -tls1_3" \
+            0 \
+            -s "Successful connection using: TLS1-3-" \
+            -c "New, TLSv1.3, Cipher is" \
+            -S "error" \
+            -C "ERROR"
+
+requires_protocol_version tls13
+run_test    "Sample: ssl_pthread_server, gnutls client, TLS 1.3" \
+            -P 4433 \
+            "$PROGRAMS_DIR/ssl_pthread_server" \
+            "$G_CLI --priority=NORMAL:-VERS-TLS-ALL:+VERS-TLS1.3 localhost" \
+            0 \
+            -s "Successful connection using: TLS1-3-" \
+            -c "Description:.*TLS1.3" \
+            -S "error" \
+            -C "ERROR"

--- a/tests/opt-testcases/sample.sh
+++ b/tests/opt-testcases/sample.sh
@@ -74,3 +74,47 @@ run_test    "Sample: dtls_client, gnutls server, DTLS 1.2" \
             -c "[1-9][0-9]* bytes read" \
             -S "Error" \
             -C "error"
+
+requires_protocol_version tls12
+run_test    "Sample: ssl_server, openssl client, TLS 1.2" \
+            -P 4433 \
+            "$PROGRAMS_DIR/ssl_server" \
+            "$O_CLI -tls1_2" \
+            0 \
+            -s "Successful connection using: TLS-" \
+            -c "New, TLSv1.2, Cipher is" \
+            -S "error" \
+            -C "ERROR"
+
+requires_protocol_version tls12
+run_test    "Sample: ssl_server, gnutls client, TLS 1.2" \
+            -P 4433 \
+            "$PROGRAMS_DIR/ssl_server" \
+            "$G_CLI --priority=NORMAL:-VERS-TLS-ALL:+VERS-TLS1.2 localhost" \
+            0 \
+            -s "Successful connection using: TLS-" \
+            -c "Description:.*TLS1.2" \
+            -S "error" \
+            -C "ERROR"
+
+requires_protocol_version tls13
+run_test    "Sample: ssl_server, openssl client, TLS 1.3" \
+            -P 4433 \
+            "$PROGRAMS_DIR/ssl_server" \
+            "$O_CLI -tls1_3" \
+            0 \
+            -s "Successful connection using: TLS1-3-" \
+            -c "New, TLSv1.3, Cipher is" \
+            -S "error" \
+            -C "ERROR"
+
+requires_protocol_version tls13
+run_test    "Sample: ssl_server, gnutls client, TLS 1.3" \
+            -P 4433 \
+            "$PROGRAMS_DIR/ssl_server" \
+            "$G_CLI --priority=NORMAL:-VERS-TLS-ALL:+VERS-TLS1.3 localhost" \
+            0 \
+            -s "Successful connection using: TLS1-3-" \
+            -c "Description:.*TLS1.3" \
+            -S "error" \
+            -C "ERROR"

--- a/tests/opt-testcases/sample.sh
+++ b/tests/opt-testcases/sample.sh
@@ -120,6 +120,50 @@ run_test    "Sample: ssl_server, gnutls client, TLS 1.3" \
             -C "ERROR"
 
 requires_protocol_version tls12
+run_test    "Sample: ssl_fork_server, openssl client, TLS 1.2" \
+            -P 4433 \
+            "$PROGRAMS_DIR/ssl_fork_server" \
+            "$O_CLI -tls1_2" \
+            0 \
+            -s "Successful connection using: TLS-" \
+            -c "New, TLSv1.2, Cipher is" \
+            -S "error" \
+            -C "ERROR"
+
+requires_protocol_version tls12
+run_test    "Sample: ssl_fork_server, gnutls client, TLS 1.2" \
+            -P 4433 \
+            "$PROGRAMS_DIR/ssl_fork_server" \
+            "$G_CLI --priority=NORMAL:-VERS-TLS-ALL:+VERS-TLS1.2 localhost" \
+            0 \
+            -s "Successful connection using: TLS-" \
+            -c "Description:.*TLS1.2" \
+            -S "error" \
+            -C "ERROR"
+
+requires_protocol_version tls13
+run_test    "Sample: ssl_fork_server, openssl client, TLS 1.3" \
+            -P 4433 \
+            "$PROGRAMS_DIR/ssl_fork_server" \
+            "$O_CLI -tls1_3" \
+            0 \
+            -s "Successful connection using: TLS1-3-" \
+            -c "New, TLSv1.3, Cipher is" \
+            -S "error" \
+            -C "ERROR"
+
+requires_protocol_version tls13
+run_test    "Sample: ssl_fork_server, gnutls client, TLS 1.3" \
+            -P 4433 \
+            "$PROGRAMS_DIR/ssl_fork_server" \
+            "$G_CLI --priority=NORMAL:-VERS-TLS-ALL:+VERS-TLS1.3 localhost" \
+            0 \
+            -s "Successful connection using: TLS1-3-" \
+            -c "Description:.*TLS1.3" \
+            -S "error" \
+            -C "ERROR"
+
+requires_protocol_version tls12
 run_test    "Sample: ssl_pthread_server, openssl client, TLS 1.2" \
             -P 4433 \
             "$PROGRAMS_DIR/ssl_pthread_server" \

--- a/tests/opt-testcases/sample.sh
+++ b/tests/opt-testcases/sample.sh
@@ -1,0 +1,6 @@
+# Test that SSL sample programs can interoperate with OpenSSL and GnuTLS.
+
+# Copyright The Mbed TLS Contributors
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+
+: ${PROGRAMS_DIR:=../programs/ssl}

--- a/tests/opt-testcases/sample.sh
+++ b/tests/opt-testcases/sample.sh
@@ -27,9 +27,10 @@ run_test    "Sample: ssl_client1, gnutls server, TLS 1.2" \
             -C "error"
 
 requires_protocol_version tls13
+requires_openssl_tls1_3
 run_test    "Sample: ssl_client1, openssl server, TLS 1.3" \
             -P 4433 \
-            "$O_SRV -tls1_3" \
+            "$O_NEXT_SRV -tls1_3" \
             "$PROGRAMS_DIR/ssl_client1" \
             0 \
             -c "New, TLSv1.3, Cipher is" \
@@ -98,10 +99,11 @@ run_test    "Sample: ssl_server, gnutls client, TLS 1.2" \
             -C "ERROR"
 
 requires_protocol_version tls13
+requires_openssl_tls1_3
 run_test    "Sample: ssl_server, openssl client, TLS 1.3" \
             -P 4433 \
             "$PROGRAMS_DIR/ssl_server" \
-            "$O_CLI -tls1_3" \
+            "$O_NEXT_CLI -tls1_3" \
             0 \
             -s "Successful connection using: TLS1-3-" \
             -c "New, TLSv1.3, Cipher is" \
@@ -142,10 +144,11 @@ run_test    "Sample: ssl_fork_server, gnutls client, TLS 1.2" \
             -C "ERROR"
 
 requires_protocol_version tls13
+requires_openssl_tls1_3
 run_test    "Sample: ssl_fork_server, openssl client, TLS 1.3" \
             -P 4433 \
             "$PROGRAMS_DIR/ssl_fork_server" \
-            "$O_CLI -tls1_3" \
+            "$O_NEXT_CLI -tls1_3" \
             0 \
             -s "Successful connection using: TLS1-3-" \
             -c "New, TLSv1.3, Cipher is" \
@@ -186,10 +189,11 @@ run_test    "Sample: ssl_pthread_server, gnutls client, TLS 1.2" \
             -C "ERROR"
 
 requires_protocol_version tls13
+requires_openssl_tls1_3
 run_test    "Sample: ssl_pthread_server, openssl client, TLS 1.3" \
             -P 4433 \
             "$PROGRAMS_DIR/ssl_pthread_server" \
-            "$O_CLI -tls1_3" \
+            "$O_NEXT_CLI -tls1_3" \
             0 \
             -s "Successful connection using: TLS1-3-" \
             -c "New, TLSv1.3, Cipher is" \

--- a/tests/opt-testcases/sample.sh
+++ b/tests/opt-testcases/sample.sh
@@ -1,9 +1,22 @@
-# Test that SSL sample programs can interoperate with OpenSSL and GnuTLS.
+# Test that SSL sample programs can interoperate with each other
+# and with OpenSSL and GnuTLS.
 
 # Copyright The Mbed TLS Contributors
 # SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 
 : ${PROGRAMS_DIR:=../programs/ssl}
+
+run_test    "Sample: ssl_client1, ssl_server2" \
+            -P 4433 \
+            "$PROGRAMS_DIR/ssl_server2" \
+            "$PROGRAMS_DIR/ssl_client1" \
+            0 \
+            -s "[1-9][0-9]* bytes read" \
+            -s "[1-9][0-9]* bytes written" \
+            -c "[1-9][0-9]* bytes read" \
+            -c "[1-9][0-9]* bytes written" \
+            -S "error" \
+            -C "error"
 
 requires_protocol_version tls12
 run_test    "Sample: ssl_client1, openssl server, TLS 1.2" \
@@ -49,6 +62,22 @@ run_test    "Sample: ssl_client1, gnutls server, TLS 1.3" \
             -S "Error" \
             -C "error"
 
+# The server complains of extra data after it closes the connection
+# because the client keeps sending data, so the server receives
+# more application data when it expects a new handshake. We consider
+# the test a success if both sides have sent and received application
+# data, no matter what happens afterwards.
+run_test    "Sample: dtls_client, ssl_server2" \
+            -P 4433 \
+            "$PROGRAMS_DIR/ssl_server2 dtls=1 server_addr=localhost" \
+            "$PROGRAMS_DIR/dtls_client" \
+            0 \
+            -s "[1-9][0-9]* bytes read" \
+            -s "[1-9][0-9]* bytes written" \
+            -c "[1-9][0-9]* bytes read" \
+            -c "[1-9][0-9]* bytes written" \
+            -C "error"
+
 requires_protocol_version dtls12
 run_test    "Sample: dtls_client, openssl server, DTLS 1.2" \
             -P 4433 \
@@ -74,6 +103,30 @@ run_test    "Sample: dtls_client, gnutls server, DTLS 1.2" \
             -c "[1-9][0-9]* bytes written" \
             -c "[1-9][0-9]* bytes read" \
             -S "Error" \
+            -C "error"
+
+run_test    "Sample: ssl_server, ssl_client2" \
+            -P 4433 \
+            "$PROGRAMS_DIR/ssl_server" \
+            "$PROGRAMS_DIR/ssl_client2" \
+            0 \
+            -s "[1-9][0-9]* bytes read" \
+            -s "[1-9][0-9]* bytes written" \
+            -c "[1-9][0-9]* bytes read" \
+            -c "[1-9][0-9]* bytes written" \
+            -S "error" \
+            -C "error"
+
+run_test    "Sample: ssl_client1 with ssl_server" \
+            -P 4433 \
+            "$PROGRAMS_DIR/ssl_server" \
+            "$PROGRAMS_DIR/ssl_client1" \
+            0 \
+            -s "[1-9][0-9]* bytes read" \
+            -s "[1-9][0-9]* bytes written" \
+            -c "[1-9][0-9]* bytes read" \
+            -c "[1-9][0-9]* bytes written" \
+            -S "error" \
             -C "error"
 
 requires_protocol_version tls12
@@ -122,6 +175,30 @@ run_test    "Sample: ssl_server, gnutls client, TLS 1.3" \
             -S "error" \
             -C "ERROR"
 
+run_test    "Sample: ssl_fork_server, ssl_client2" \
+            -P 4433 \
+            "$PROGRAMS_DIR/ssl_fork_server" \
+            "$PROGRAMS_DIR/ssl_client2" \
+            0 \
+            -s "[1-9][0-9]* bytes read" \
+            -s "[1-9][0-9]* bytes written" \
+            -c "[1-9][0-9]* bytes read" \
+            -c "[1-9][0-9]* bytes written" \
+            -S "error" \
+            -C "error"
+
+run_test    "Sample: ssl_client1 with ssl_fork_server" \
+            -P 4433 \
+            "$PROGRAMS_DIR/ssl_fork_server" \
+            "$PROGRAMS_DIR/ssl_client1" \
+            0 \
+            -s "[1-9][0-9]* bytes read" \
+            -s "[1-9][0-9]* bytes written" \
+            -c "[1-9][0-9]* bytes read" \
+            -c "[1-9][0-9]* bytes written" \
+            -S "error" \
+            -C "error"
+
 requires_protocol_version tls12
 run_test    "Sample: ssl_fork_server, openssl client, TLS 1.2" \
             -P 4433 \
@@ -168,6 +245,30 @@ run_test    "Sample: ssl_fork_server, gnutls client, TLS 1.3" \
             -S "error" \
             -C "ERROR"
 
+run_test    "Sample: ssl_pthread_server, ssl_client2" \
+            -P 4433 \
+            "$PROGRAMS_DIR/ssl_pthread_server" \
+            "$PROGRAMS_DIR/ssl_client2" \
+            0 \
+            -s "[1-9][0-9]* bytes read" \
+            -s "[1-9][0-9]* bytes written" \
+            -c "[1-9][0-9]* bytes read" \
+            -c "[1-9][0-9]* bytes written" \
+            -S "error" \
+            -C "error"
+
+run_test    "Sample: ssl_client1 with ssl_pthread_server" \
+            -P 4433 \
+            "$PROGRAMS_DIR/ssl_pthread_server" \
+            "$PROGRAMS_DIR/ssl_client1" \
+            0 \
+            -s "[1-9][0-9]* bytes read" \
+            -s "[1-9][0-9]* bytes written" \
+            -c "[1-9][0-9]* bytes read" \
+            -c "[1-9][0-9]* bytes written" \
+            -S "error" \
+            -C "error"
+
 requires_protocol_version tls12
 run_test    "Sample: ssl_pthread_server, openssl client, TLS 1.2" \
             -P 4433 \
@@ -213,6 +314,38 @@ run_test    "Sample: ssl_pthread_server, gnutls client, TLS 1.3" \
             -c "Description:.*TLS1.3" \
             -S "error" \
             -C "ERROR"
+
+# The server complains of extra data after it closes the connection
+# because the client keeps sending data, so the server receives
+# more application data when it expects a new handshake. We consider
+# the test a success if both sides have sent and received application
+# data, no matter what happens afterwards.
+run_test    "Sample: dtls_client with dtls_server" \
+            -P 4433 \
+            "$PROGRAMS_DIR/dtls_server" \
+            "$PROGRAMS_DIR/dtls_client" \
+            0 \
+            -s "[1-9][0-9]* bytes read" \
+            -s "[1-9][0-9]* bytes written" \
+            -c "[1-9][0-9]* bytes read" \
+            -c "[1-9][0-9]* bytes written" \
+            -C "error"
+
+# The server complains of extra data after it closes the connection
+# because the client keeps sending data, so the server receives
+# more application data when it expects a new handshake. We consider
+# the test a success if both sides have sent and received application
+# data, no matter what happens afterwards.
+run_test    "Sample: ssl_client2, dtls_server" \
+            -P 4433 \
+            "$PROGRAMS_DIR/dtls_server" \
+            "$PROGRAMS_DIR/ssl_client2 dtls=1" \
+            0 \
+            -s "[1-9][0-9]* bytes read" \
+            -s "[1-9][0-9]* bytes written" \
+            -c "[1-9][0-9]* bytes read" \
+            -c "[1-9][0-9]* bytes written" \
+            -C "error"
 
 requires_protocol_version dtls12
 run_test    "Sample: dtls_server, openssl client, DTLS 1.2" \

--- a/tests/opt-testcases/sample.sh
+++ b/tests/opt-testcases/sample.sh
@@ -206,3 +206,27 @@ run_test    "Sample: ssl_pthread_server, gnutls client, TLS 1.3" \
             -c "Description:.*TLS1.3" \
             -S "error" \
             -C "ERROR"
+
+requires_protocol_version dtls12
+run_test    "Sample: dtls_server, openssl client, DTLS 1.2" \
+            -P 4433 \
+            "$PROGRAMS_DIR/dtls_server" \
+            "$O_CLI -dtls1_2" \
+            0 \
+            -s "[1-9][0-9]* bytes read" \
+            -s "[1-9][0-9]* bytes written" \
+            -c "New, TLSv1.2, Cipher is" \
+            -S "error" \
+            -C "ERROR"
+
+requires_protocol_version dtls12
+run_test    "Sample: dtls_server, gnutls client, DTLS 1.2" \
+            -P 4433 \
+            "$PROGRAMS_DIR/dtls_server" \
+            "$G_CLI -u --priority=NORMAL:-VERS-TLS-ALL:+VERS-TLS1.2 localhost" \
+            0 \
+            -s "[1-9][0-9]* bytes read" \
+            -s "[1-9][0-9]* bytes written" \
+            -c "Description:.*DTLS1.2" \
+            -S "error" \
+            -C "ERROR"

--- a/tests/opt-testcases/sample.sh
+++ b/tests/opt-testcases/sample.sh
@@ -11,7 +11,7 @@ run_test    "Sample: ssl_client1, openssl server, TLS 1.2" \
             "$O_SRV -tls1_2" \
             "$PROGRAMS_DIR/ssl_client1" \
             0 \
-            -c "New, TLSv1.2, Cipher is" \
+            -c "Protocol.*TLSv1.2" \
             -S "ERROR" \
             -C "error"
 
@@ -56,7 +56,6 @@ run_test    "Sample: dtls_client, openssl server, DTLS 1.2" \
             "$PROGRAMS_DIR/dtls_client" \
             0 \
             -s "Echo this" \
-            -s "DONE" \
             -c "Echo this" \
             -c "[1-9][0-9]* bytes written" \
             -c "[1-9][0-9]* bytes read" \
@@ -84,7 +83,7 @@ run_test    "Sample: ssl_server, openssl client, TLS 1.2" \
             "$O_CLI -tls1_2" \
             0 \
             -s "Successful connection using: TLS-" \
-            -c "New, TLSv1.2, Cipher is" \
+            -c "Protocol.*TLSv1.2" \
             -S "error" \
             -C "ERROR"
 
@@ -130,7 +129,7 @@ run_test    "Sample: ssl_fork_server, openssl client, TLS 1.2" \
             "$O_CLI -tls1_2" \
             0 \
             -s "Successful connection using: TLS-" \
-            -c "New, TLSv1.2, Cipher is" \
+            -c "Protocol.*TLSv1.2" \
             -S "error" \
             -C "ERROR"
 
@@ -176,7 +175,7 @@ run_test    "Sample: ssl_pthread_server, openssl client, TLS 1.2" \
             "$O_CLI -tls1_2" \
             0 \
             -s "Successful connection using: TLS-" \
-            -c "New, TLSv1.2, Cipher is" \
+            -c "Protocol.*TLSv1.2" \
             -S "error" \
             -C "ERROR"
 
@@ -223,7 +222,7 @@ run_test    "Sample: dtls_server, openssl client, DTLS 1.2" \
             0 \
             -s "[1-9][0-9]* bytes read" \
             -s "[1-9][0-9]* bytes written" \
-            -c "New, TLSv1.2, Cipher is" \
+            -c "Protocol.*TLSv1.2" \
             -S "error" \
             -C "ERROR"
 

--- a/tests/opt-testcases/sample.sh
+++ b/tests/opt-testcases/sample.sh
@@ -46,3 +46,31 @@ run_test    "Sample: ssl_client1, gnutls server, TLS 1.3" \
             -c "<TD>Protocol version:</TD><TD>TLS1.3</TD>" \
             -S "Error" \
             -C "error"
+
+requires_protocol_version dtls12
+run_test    "Sample: dtls_client, openssl server, DTLS 1.2" \
+            -P 4433 \
+            "$O_SRV -dtls1_2" \
+            "$PROGRAMS_DIR/dtls_client" \
+            0 \
+            -s "Echo this" \
+            -s "DONE" \
+            -c "Echo this" \
+            -c "[1-9][0-9]* bytes written" \
+            -c "[1-9][0-9]* bytes read" \
+            -S "ERROR" \
+            -C "error"
+
+requires_protocol_version dtls12
+run_test    "Sample: dtls_client, gnutls server, DTLS 1.2" \
+            -P 4433 \
+            "$G_SRV -u --echo --priority=NORMAL:-VERS-TLS-ALL:+VERS-TLS1.2" \
+            "$PROGRAMS_DIR/dtls_client" \
+            0 \
+            -s "Server listening" \
+            -s "[1-9][0-9]* bytes command:" \
+            -c "Echo this" \
+            -c "[1-9][0-9]* bytes written" \
+            -c "[1-9][0-9]* bytes read" \
+            -S "Error" \
+            -C "error"

--- a/tests/opt-testcases/sample.sh
+++ b/tests/opt-testcases/sample.sh
@@ -78,10 +78,20 @@ run_test    "Sample: dtls_client, ssl_server2" \
             -c "[1-9][0-9]* bytes written" \
             -C "error"
 
+# The dtls_client program connects to localhost. This test case fails on
+# systems where the name "localhost" resolves to an IPv6 address, but
+# the IPv6 connection is not possible. Possible reasons include:
+# * OpenSSL is too old (IPv6 support was added in 1.1.0).
+# * OpenSSL was built without IPv6 support.
+# * A firewall blocks IPv6.
+#
+# To facilitate working with this test case, have it run with $OPENSSL_NEXT
+# which is at least 1.1.1a. At the time it was introduced, this test case
+# passed with OpenSSL 1.0.2g on an environment where IPv6 is disabled.
 requires_protocol_version dtls12
 run_test    "Sample: dtls_client, openssl server, DTLS 1.2" \
             -P 4433 \
-            "$O_SRV -dtls1_2" \
+            "$O_NEXT_SRV -dtls1_2" \
             "$PROGRAMS_DIR/dtls_client" \
             0 \
             -s "Echo this" \

--- a/tests/opt-testcases/sample.sh
+++ b/tests/opt-testcases/sample.sh
@@ -38,9 +38,10 @@ run_test    "Sample: ssl_client1, openssl server, TLS 1.3" \
             -C "error"
 
 requires_protocol_version tls13
+requires_gnutls_tls1_3
 run_test    "Sample: ssl_client1, gnutls server, TLS 1.3" \
             -P 4433 \
-            "$G_SRV --priority=NORMAL:-VERS-TLS-ALL:+VERS-TLS1.3" \
+            "$G_NEXT_SRV --priority=NORMAL:-VERS-TLS-ALL:+VERS-TLS1.3" \
             "$PROGRAMS_DIR/ssl_client1" \
             0 \
             -s "Version: TLS1.3" \
@@ -111,10 +112,11 @@ run_test    "Sample: ssl_server, openssl client, TLS 1.3" \
             -C "ERROR"
 
 requires_protocol_version tls13
+requires_gnutls_tls1_3
 run_test    "Sample: ssl_server, gnutls client, TLS 1.3" \
             -P 4433 \
             "$PROGRAMS_DIR/ssl_server" \
-            "$G_CLI --priority=NORMAL:-VERS-TLS-ALL:+VERS-TLS1.3 localhost" \
+            "$G_NEXT_CLI --priority=NORMAL:-VERS-TLS-ALL:+VERS-TLS1.3 localhost" \
             0 \
             -s "Successful connection using: TLS1-3-" \
             -c "Description:.*TLS1.3" \
@@ -156,10 +158,11 @@ run_test    "Sample: ssl_fork_server, openssl client, TLS 1.3" \
             -C "ERROR"
 
 requires_protocol_version tls13
+requires_gnutls_tls1_3
 run_test    "Sample: ssl_fork_server, gnutls client, TLS 1.3" \
             -P 4433 \
             "$PROGRAMS_DIR/ssl_fork_server" \
-            "$G_CLI --priority=NORMAL:-VERS-TLS-ALL:+VERS-TLS1.3 localhost" \
+            "$G_NEXT_CLI --priority=NORMAL:-VERS-TLS-ALL:+VERS-TLS1.3 localhost" \
             0 \
             -s "Successful connection using: TLS1-3-" \
             -c "Description:.*TLS1.3" \
@@ -201,10 +204,11 @@ run_test    "Sample: ssl_pthread_server, openssl client, TLS 1.3" \
             -C "ERROR"
 
 requires_protocol_version tls13
+requires_gnutls_tls1_3
 run_test    "Sample: ssl_pthread_server, gnutls client, TLS 1.3" \
             -P 4433 \
             "$PROGRAMS_DIR/ssl_pthread_server" \
-            "$G_CLI --priority=NORMAL:-VERS-TLS-ALL:+VERS-TLS1.3 localhost" \
+            "$G_NEXT_CLI --priority=NORMAL:-VERS-TLS-ALL:+VERS-TLS1.3 localhost" \
             0 \
             -s "Successful connection using: TLS1-3-" \
             -c "Description:.*TLS1.3" \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -500,6 +500,7 @@ detect_required_features() {
             requires_config_enabled MBEDTLS_SSL_CLI_C
             requires_certificate_authentication
             ;;
+        *"programs/ssl/ssl_pthread_server "*|\
         *"programs/ssl/ssl_server "*)
             requires_config_enabled MBEDTLS_CTR_DRBG_C
             requires_config_enabled MBEDTLS_ENTROPY_C
@@ -507,6 +508,11 @@ detect_required_features() {
             requires_config_enabled MBEDTLS_SSL_SRV_C
             requires_certificate_authentication
             ;;
+    esac
+
+    case " $CMD_LINE " in
+        *"programs/ssl/ssl_pthread_server "*)
+            requires_config_enabled MBEDTLS_THREADING_PTHREAD;;
     esac
 
     case "$CMD_LINE" in

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -500,6 +500,13 @@ detect_required_features() {
             requires_config_enabled MBEDTLS_SSL_CLI_C
             requires_certificate_authentication
             ;;
+        *"programs/ssl/ssl_server "*)
+            requires_config_enabled MBEDTLS_CTR_DRBG_C
+            requires_config_enabled MBEDTLS_ENTROPY_C
+            requires_config_enabled MBEDTLS_PEM_PARSE_C
+            requires_config_enabled MBEDTLS_SSL_SRV_C
+            requires_certificate_authentication
+            ;;
     esac
 
     case "$CMD_LINE" in

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -509,6 +509,11 @@ detect_required_features() {
             requires_config_enabled MBEDTLS_PEM_PARSE_C
             requires_config_enabled MBEDTLS_SSL_SRV_C
             requires_certificate_authentication
+            # The actual minimum depends on the configuration since it's
+            # mostly about the certificate size.
+            # In config-suite-b.h, for the test certificates (server5.crt),
+            # 1024 is not enough.
+            requires_config_value_at_least MBEDTLS_SSL_OUT_CONTENT_LEN 2000
             ;;
     esac
 

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -1447,7 +1447,11 @@ analyze_test_commands() {
     # GnuTLS, override its port specification.
     if [ "$THIS_SRV_PORT" != "$SRV_PORT" ]; then
         case "$SRV_CMD" in
-            "$G_SRV"*|"$G_NEXT_SRV"*) SRV_CMD="$SRV_CMD -p $THIS_SRV_PORT";;
+            "$G_SRV"*|"$G_NEXT_SRV"*)
+                SRV_CMD=$(
+                    printf %s "$SRV_CMD " |
+                    sed -e "s/ -p $SRV_PORT / -p $THIS_SRV_PORT /"
+                );;
             "$O_SRV"*|"$O_NEXT_SRV"*) SRV_CMD="$SRV_CMD -accept $THIS_SRV_PORT";;
         esac
     fi

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -492,6 +492,7 @@ detect_required_features() {
     esac
 
     case " $CMD_LINE " in
+        *"programs/ssl/dtls_client "*|\
         *"programs/ssl/ssl_client1 "*)
             requires_config_enabled MBEDTLS_CTR_DRBG_C
             requires_config_enabled MBEDTLS_ENTROPY_C
@@ -1382,9 +1383,13 @@ skip_handshake_stage_check() {
 # Outputs:
 # * $CLI_CMD, $PXY_CMD, $SRV_CMD: may be tweaked.
 analyze_test_commands() {
-    # if the test uses DTLS but no custom proxy, add a simple proxy
-    # as it provides timing info that's useful to debug failures
-    if [ -z "$PXY_CMD" ] && [ "$DTLS" -eq 1 ]; then
+    # If the test uses DTLS, does not force a specific port, and does not
+    # specify a custom proxy, add a simple proxy.
+    # It provides timing info that's useful to debug failures.
+    if [ "$DTLS" -eq 1 ] &&
+       [ "$THIS_SRV_PORT" = "$SRV_PORT" ] &&
+       [ -z "$PXY_CMD" ]
+    then
         PXY_CMD="$P_PXY"
         case " $SRV_CMD " in
             *' server_addr=::1 '*)
@@ -1751,7 +1756,7 @@ run_test() {
         esac
     fi
 
-    # does this test use a proxy?
+    # Does this test specify a proxy?
     if [ "X$1" = "X-p" ]; then
         PXY_CMD="$2"
         shift 2

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -1812,7 +1812,10 @@ run_test() {
     # Check if we are trying to use an external tool which does not support ECDH
     EXT_WO_ECDH=$(use_ext_tool_without_ecdh_support "$SRV_CMD" "$CLI_CMD")
 
-    # Guess the TLS version which is going to be used
+    # Guess the TLS version which is going to be used.
+    # Note that this detection is wrong in some cases, which causes unduly
+    # skipped test cases in builds with TLS 1.3 but not TLS 1.2.
+    # https://github.com/Mbed-TLS/mbedtls/issues/9560
     if [ "$EXT_WO_ECDH" = "no" ]; then
         TLS_VERSION=$(get_tls_version "$SRV_CMD" "$CLI_CMD")
     else

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -500,6 +500,7 @@ detect_required_features() {
             requires_config_enabled MBEDTLS_SSL_CLI_C
             requires_certificate_authentication
             ;;
+        *"programs/ssl/dtls_server "*|\
         *"programs/ssl/ssl_fork_server "*|\
         *"programs/ssl/ssl_pthread_server "*|\
         *"programs/ssl/ssl_server "*)
@@ -1277,7 +1278,7 @@ wait_client_done() {
 # check if the given command uses dtls and sets global variable DTLS
 detect_dtls() {
     case "$1" in
-        *dtls=1*|*-dtls*|*-u*) DTLS=1;;
+        *dtls=1*|*-dtls*|*-u*|*/dtls_*) DTLS=1;;
         *) DTLS=0;;
     esac
 }

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -500,6 +500,7 @@ detect_required_features() {
             requires_config_enabled MBEDTLS_SSL_CLI_C
             requires_certificate_authentication
             ;;
+        *"programs/ssl/ssl_fork_server "*|\
         *"programs/ssl/ssl_pthread_server "*|\
         *"programs/ssl/ssl_server "*)
             requires_config_enabled MBEDTLS_CTR_DRBG_C

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -491,6 +491,16 @@ detect_required_features() {
             requires_certificate_authentication;;
     esac
 
+    case " $CMD_LINE " in
+        *"programs/ssl/ssl_client1 "*)
+            requires_config_enabled MBEDTLS_CTR_DRBG_C
+            requires_config_enabled MBEDTLS_ENTROPY_C
+            requires_config_enabled MBEDTLS_PEM_PARSE_C
+            requires_config_enabled MBEDTLS_SSL_CLI_C
+            requires_certificate_authentication
+            ;;
+    esac
+
     case "$CMD_LINE" in
         *[-_\ =]psk*|*[-_\ =]PSK*) :;; # No certificate requirement with PSK
         */server5*|\


### PR DESCRIPTION
Test the SSL sample programs (`ssl_client1`, `dtls_client`, `ssl_server`, `ssl_fork_server`, `ssl_pthread_server`, `dtls_server`) in `ssl-opt.sh`. Test against both GnuTLS and OpenSSL. Test with all relevant protocol versions (TLS 1.2/1.3; DTLS 1.2 only).

`mini_client` is excluded because it's complicated, see [this comment](https://github.com/Mbed-TLS/mbedtls/pull/9541#issuecomment-2344479846). It's also not part of the deliverable we want, which is primarily `ssl_client1` and `ssl_server` interoperabiliy with TLS 1.3, and secondarily (because that part is not much more effort) those programs and `dtls_client` and `dtls_server` with (D)TLS 1.2. (I'm still throwing in `ssl_pthread_server` and `ssl_fork_server` because they're really easy.)

The TLS 1.3 test cases are non-regression tests for https://github.com/Mbed-TLS/mbedtls/issues/9072 and https://github.com/Mbed-TLS/mbedtls/issues/8749.

Fixes #9072 in the sense that when this pull request passes the CI, it means the issue is fixed. (The actual fixes are in previous PR: #9501 and #9507.)

The sample programs hard-code port 4433, so these tests can't run concurrently. This may be a problem for CI reliability (although in principle it shouldn't be since each test run runs alone in a Docker instance). If it's a problem, the obvious solution is to make the port configurable in each program (and remove the forced-port hacks in `ssl-opt.sh`).

Prerequisites:

* [x] https://github.com/Mbed-TLS/mbedtls/pull/9546 — Sorting out the failures when some key exchanges are excluded got me into a nasty bag of worms around dependency calculations in `ssl-opt.sh` that warrants its own pull request.
* [x] https://github.com/Mbed-TLS/mbedtls/pull/9563 — fix middlebox compatibility mode, rather than figure out what depends on it and write alternative test cases when it's disabled.

## PR checklist

- [x] **changelog** not required because: test only. (I don't think the improvements in compile-time dependencies in sample programs warrant a changelog entry.)
- [x] **development PR** #9638 
- [x] **framework PR** not required
- [x] **3.6 PR** here
- [x] **2.28 PR** let's not bother given that there's likely going to be only one more 2.28.x release
- **tests**  provided
