### PR TITLE
Backport 3.6: Add pragma for bcrypt.lib - Fix win build with cmake

### DIFF
--- a/ChangeLog.d/windows_pragma_lib_bcrypt
+++ b/ChangeLog.d/windows_pragma_lib_bcrypt
@@ -1,0 +1,2 @@
+Changes
+   * Add pragma bcrypt.lib to entropy_poll.c for msvc builds

--- a/library/entropy_poll.c
+++ b/library/entropy_poll.c
@@ -42,6 +42,10 @@
 #include <bcrypt.h>
 #include <intsafe.h>
 
+#if defined(_MSC_VER)
+#pragma comment( lib, "bcrypt.lib" )
+#endif /* _MSC_VER */
+
 int mbedtls_platform_entropy_poll(void *data, unsigned char *output, size_t len,
                                   size_t *olen)
 {


### PR DESCRIPTION
## Description

Backport of #9055 for mbedtls 3.6

## PR checklist

- [x] **changelog** provided
- [x] **development PR** provided #9055 
- [x] **framework PR** not required
- [x] **3.6 PR** provided
- [x] **2.28 PR** not required because: 2.28 did not use bcrypt
- **tests**  not required because: build related