### PR TITLE
Improve order of test suites with make test

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -269,8 +269,8 @@ endif
 
 # Test suites caught by SKIP_TEST_SUITES are built but not executed.
 check: $(BINARIES) $(CRYPTO_BINARIES)
-	perl scripts/run-test-suites.pl $(TEST_FLAGS) --skip=$(SKIP_TEST_SUITES)
 	cd ../tf-psa-crypto/tests && perl ../../tests/scripts/run-test-suites.pl $(TEST_FLAGS) --skip=$(SKIP_TEST_SUITES)
+	perl scripts/run-test-suites.pl $(TEST_FLAGS) --skip=$(SKIP_TEST_SUITES)
 
 test: check
 


### PR DESCRIPTION
## Description

Before this commit we were running (1) X.509 and TLS suites, then (2) crypto suites. Except if there was a failure in (1) we were not running (2) at all.

This tripped me up when debugging a failure in some all.sh component: I thought the only failure was in test_suite_x509write, and since I saw no other failure I assumed test_suite_pk was passing and lost hair trying to figure out why pk_sign was only failing in the x509 test suite but not in the pk test suite - only to discover that test_suite_pk would have been failing if it was only run...

Overall it makes more sense to test the lower part of the stack first - if it doesn't work, then we don't really expect the upper part of the stack to work anyway.

## PR checklist

- [ ] **changelog** not required because: small change to tests
- [ ] **development PR** here
- [ ] **framework PR** not required
- [ ] **3.6 PR** not required because: not affected (no `tf-psa-crypto` split)
- [ ] **2.28 PR** not required because: not affected (no `tf-psa-crypto` split)
- **tests**  not required because: already covered by outcome analysis

