### PR TITLE
Run test suites on subproject

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -270,7 +270,6 @@ endif
 # Test suites caught by SKIP_TEST_SUITES are built but not executed.
 check: $(BINARIES) $(CRYPTO_BINARIES)
 	perl scripts/run-test-suites.pl $(TEST_FLAGS) --skip=$(SKIP_TEST_SUITES)
-	cd ../tf-psa-crypto/tests && perl ../../tests/scripts/run-test-suites.pl $(TEST_FLAGS) --skip=$(SKIP_TEST_SUITES)
 
 test: check
 

--- a/tests/scripts/basic-build-test.sh
+++ b/tests/scripts/basic-build-test.sh
@@ -35,8 +35,6 @@ if [ -d library -a -d include -a -d tests ]; then :; else
     exit 1
 fi
 
-MBEDTLS_ROOT_DIR="$PWD"
-
 : ${OPENSSL:="openssl"}
 : ${GNUTLS_CLI:="gnutls-cli"}
 : ${GNUTLS_SERV:="gnutls-serv"}
@@ -81,11 +79,7 @@ make
 
 # Step 2 - Execute the tests
 TEST_OUTPUT=out_${PPID}
-cd $MBEDTLS_ROOT_DIR/tests
-if [ ! -f "seedfile" ]; then
-    dd if=/dev/urandom of="seedfile" bs=64 count=1
-fi
-cd $MBEDTLS_ROOT_DIR/tf-psa-crypto/tests
+cd tests
 if [ ! -f "seedfile" ]; then
     dd if=/dev/urandom of="seedfile" bs=64 count=1
 fi
@@ -93,14 +87,10 @@ echo
 
 # Step 2a - Unit Tests (keep going even if some tests fail)
 echo '################ Unit tests ################'
-cd $MBEDTLS_ROOT_DIR/tests
-perl scripts/run-test-suites.pl -v 2 |tee tls-x509-unit-test-$TEST_OUTPUT
-cd $MBEDTLS_ROOT_DIR/tf-psa-crypto/tests
-perl $MBEDTLS_ROOT_DIR/tests/scripts/run-test-suites.pl -v 2 |tee ../../tests/crypto-unit-test-$TEST_OUTPUT
+perl scripts/run-test-suites.pl -v 2 |tee unit-test-$TEST_OUTPUT
 echo '^^^^^^^^^^^^^^^^ Unit tests ^^^^^^^^^^^^^^^^'
 echo
 
-cd $MBEDTLS_ROOT_DIR/tests
 # Step 2b - System Tests (keep going even if some tests fail)
 echo
 echo '################ ssl-opt.sh ################'
@@ -151,13 +141,13 @@ rm -f "tests/basic-build-test-$$.ok"
 
     cd tests
 
-    # Step 4a - TLS and x509 unit tests
-    echo "TLS and x509 unit tests - tests/scripts/run-test-suites.pl"
+    # Step 4a - Unit tests
+    echo "Unit tests - tests/scripts/run-test-suites.pl"
 
-    PASSED_TESTS=$(tail -n6 tls-x509-unit-test-$TEST_OUTPUT|sed -n -e 's/test cases passed :[\t]*\([0-9]*\)/\1/p'| tr -d ' ')
-    SKIPPED_TESTS=$(tail -n6 tls-x509-unit-test-$TEST_OUTPUT|sed -n -e 's/skipped :[ \t]*\([0-9]*\)/\1/p'| tr -d ' ')
-    TOTAL_SUITES=$(tail -n6 tls-x509-unit-test-$TEST_OUTPUT|sed -n -e 's/.* (\([0-9]*\) .*, [0-9]* tests run)/\1/p'| tr -d ' ')
-    FAILED_TESTS=$(tail -n6 tls-x509-unit-test-$TEST_OUTPUT|sed -n -e 's/failed :[\t]*\([0-9]*\)/\1/p' |tr -d ' ')
+    PASSED_TESTS=$(tail -n6 unit-test-$TEST_OUTPUT|sed -n -e 's/test cases passed :[\t]*\([0-9]*\)/\1/p'| tr -d ' ')
+    SKIPPED_TESTS=$(tail -n6 unit-test-$TEST_OUTPUT|sed -n -e 's/skipped :[ \t]*\([0-9]*\)/\1/p'| tr -d ' ')
+    TOTAL_SUITES=$(tail -n6 unit-test-$TEST_OUTPUT|sed -n -e 's/.* (\([0-9]*\) .*, [0-9]* tests run)/\1/p'| tr -d ' ')
+    FAILED_TESTS=$(tail -n6 unit-test-$TEST_OUTPUT|sed -n -e 's/failed :[\t]*\([0-9]*\)/\1/p' |tr -d ' ')
 
     echo "No test suites     : $TOTAL_SUITES"
     echo "Passed             : $PASSED_TESTS"
@@ -173,29 +163,7 @@ rm -f "tests/basic-build-test-$$.ok"
     TOTAL_AVAIL=$(($PASSED_TESTS + $FAILED_TESTS + $SKIPPED_TESTS))
     TOTAL_EXED=$(($PASSED_TESTS + $FAILED_TESTS))
 
-    # Step 4b - Crypto unit tests
-    echo "Crypto unit tests - tests/scripts/run-test-suites.pl"
-
-    PASSED_TESTS=$(tail -n6 crypto-unit-test-$TEST_OUTPUT|sed -n -e 's/test cases passed :[\t]*\([0-9]*\)/\1/p'| tr -d ' ')
-    SKIPPED_TESTS=$(tail -n6 crypto-unit-test-$TEST_OUTPUT|sed -n -e 's/skipped :[ \t]*\([0-9]*\)/\1/p'| tr -d ' ')
-    TOTAL_SUITES=$(tail -n6 crypto-unit-test-$TEST_OUTPUT|sed -n -e 's/.* (\([0-9]*\) .*, [0-9]* tests run)/\1/p'| tr -d ' ')
-    FAILED_TESTS=$(tail -n6 crypto-unit-test-$TEST_OUTPUT|sed -n -e 's/failed :[\t]*\([0-9]*\)/\1/p' |tr -d ' ')
-
-    echo "No test suites     : $TOTAL_SUITES"
-    echo "Passed             : $PASSED_TESTS"
-    echo "Failed             : $FAILED_TESTS"
-    echo "Skipped            : $SKIPPED_TESTS"
-    echo "Total exec'd tests : $(($PASSED_TESTS + $FAILED_TESTS))"
-    echo "Total avail tests  : $(($PASSED_TESTS + $FAILED_TESTS + $SKIPPED_TESTS))"
-    echo
-
-    TOTAL_PASS=$(($TOTAL_PASS+$PASSED_TESTS))
-    TOTAL_FAIL=$(($TOTAL_FAIL+$FAILED_TESTS))
-    TOTAL_SKIP=$(($TOTAL_SKIP+$SKIPPED_TESTS))
-    TOTAL_AVAIL=$(($TOTAL_AVAIL + $PASSED_TESTS + $FAILED_TESTS + $SKIPPED_TESTS))
-    TOTAL_EXED=$(($TOTAL_EXED + $PASSED_TESTS + $FAILED_TESTS))
-
-    # Step 4c - TLS Options tests
+    # Step 4b - TLS Options tests
     echo "TLS Options tests - tests/ssl-opt.sh"
 
     PASSED_TESTS=$(tail -n5 sys-test-$TEST_OUTPUT|sed -n -e 's/.* (\([0-9]*\) \/ [0-9]* tests ([0-9]* skipped))$/\1/p')
@@ -217,7 +185,7 @@ rm -f "tests/basic-build-test-$$.ok"
     TOTAL_EXED=$(($TOTAL_EXED + $TOTAL_TESTS))
 
 
-    # Step 4d - System Compatibility tests
+    # Step 4c - System Compatibility tests
     echo "System/Compatibility tests - tests/compat.sh"
 
     PASSED_TESTS=$(cat compat-test-$TEST_OUTPUT | sed -n -e 's/.* (\([0-9]*\) \/ [0-9]* tests ([0-9]* skipped))$/\1/p' | awk 'BEGIN{ s = 0 } { s += $1 } END{ print s }')
@@ -239,7 +207,7 @@ rm -f "tests/basic-build-test-$$.ok"
     TOTAL_EXED=$(($TOTAL_EXED + $EXED_TESTS))
 
 
-    # Step 4e - Grand totals
+    # Step 4d - Grand totals
     echo "-------------------------------------------------------------------------"
     echo "Total tests"
 
@@ -251,13 +219,12 @@ rm -f "tests/basic-build-test-$$.ok"
     echo
 
 
-    # Step 4f - Coverage report
+    # Step 4e - Coverage report
     echo "Coverage statistics:"
     sed -n '1,/^Overall coverage/d; /%/p' cov-$TEST_OUTPUT
     echo
 
-    rm tls-x509-unit-test-$TEST_OUTPUT
-    rm crypto-unit-test-$TEST_OUTPUT
+    rm unit-test-$TEST_OUTPUT
     rm sys-test-$TEST_OUTPUT
     rm compat-test-$TEST_OUTPUT
     rm cov-$TEST_OUTPUT

--- a/tests/scripts/basic-build-test.sh
+++ b/tests/scripts/basic-build-test.sh
@@ -83,6 +83,9 @@ cd tests
 if [ ! -f "seedfile" ]; then
     dd if=/dev/urandom of="seedfile" bs=64 count=1
 fi
+if [ ! -f "../tf-psa-crypto/tests/seedfile" ]; then
+    cp "seedfile" "../tf-psa-crypto/tests/seedfile"
+fi
 echo
 
 # Step 2a - Unit Tests (keep going even if some tests fail)

--- a/tests/scripts/run-test-suites.pl
+++ b/tests/scripts/run-test-suites.pl
@@ -28,6 +28,7 @@ use strict;
 use utf8;
 use open qw(:std utf8);
 
+use Cwd qw(getcwd);
 use Getopt::Long qw(:config auto_help gnu_compat);
 use Pod::Usage;
 
@@ -60,15 +61,8 @@ my $skip_re =
       ')(\z|\.)' );
 
 # in case test suites are linked dynamically
-if (-d '../../tf-psa-crypto') {
-    $ENV{'LD_LIBRARY_PATH'} = '../../library';
-    $ENV{'DYLD_LIBRARY_PATH'} = '../../library';
-}
-else
-{
-    $ENV{'LD_LIBRARY_PATH'} = '../library';
-    $ENV{'DYLD_LIBRARY_PATH'} = '../library';
-}
+$ENV{'LD_LIBRARY_PATH'} = getcwd() . "/../library";
+$ENV{'DYLD_LIBRARY_PATH'} = $ENV{'LD_LIBRARY_PATH'}; # For macOS
 
 my $prefix = $^O eq "MSWin32" ? '' : './';
 

--- a/tests/scripts/run-test-suites.pl
+++ b/tests/scripts/run-test-suites.pl
@@ -85,8 +85,11 @@ sub pad_print_center {
 
 for my $suite_path (@suites)
 {
-    my $suite = $suite_path;
-    $suite =~ s!.*/!!;
+    my ($dir, $suite) = ('.', $suite_path);
+    if ($suite =~ m!(.*)/([^/]*)!) {
+        $dir = $1;
+        $suite = $2;
+    }
     print "$suite ", "." x ( 72 - length($suite) - 2 - 4 ), " ";
     if( $suite =~ /$skip_re/o ) {
         print "SKIP\n";
@@ -94,7 +97,7 @@ for my $suite_path (@suites)
         next;
     }
 
-    my $command = "$prefix$suite_path";
+    my $command = "cd $dir && $prefix$suite";
     if( $verbose ) {
         $command .= ' -v';
     }

--- a/tests/scripts/run-test-suites.pl
+++ b/tests/scripts/run-test-suites.pl
@@ -40,7 +40,8 @@ GetOptions(
 
 # All test suites = executable files with a .datax file.
 my @suites = ();
-for my $data_file (glob 'test_suite_*.datax') {
+my @test_dirs = qw(../tf-psa-crypto/tests .);
+for my $data_file (map {glob "$_/test_suite_*.datax"} @test_dirs) {
     (my $base = $data_file) =~ s/\.datax$//;
     push @suites, $base if -x $base;
     push @suites, "$base.exe" if -e "$base.exe";
@@ -82,8 +83,10 @@ sub pad_print_center {
     print $padchar x( $padlen ), " $string ", $padchar x( $padlen ), "\n";
 }
 
-for my $suite (@suites)
+for my $suite_path (@suites)
 {
+    my $suite = $suite_path;
+    $suite =~ s!.*/!!;
     print "$suite ", "." x ( 72 - length($suite) - 2 - 4 ), " ";
     if( $suite =~ /$skip_re/o ) {
         print "SKIP\n";
@@ -91,7 +94,7 @@ for my $suite (@suites)
         next;
     }
 
-    my $command = "$prefix$suite";
+    my $command = "$prefix$suite_path";
     if( $verbose ) {
         $command .= ' -v';
     }


### PR DESCRIPTION
Fix `make test` not running the crypto tests if a TLS test fails. Ensure that the reporting is correct.

## PR checklist

- [x] **changelog** not required because: maintainer facing only
- [x] **development PR** here
- [x] **framework PR** not required
- [x] **3.6 PR** not required because: bug introduced in development
- [x] **2.28 PR** not required because: bug introduced in development
- **tests**  provided + run `basic-build-test.sh`: https://mbedtls.trustedfirmware.org/job/mbedtls-restricted-release-new/33/
