### PR TITLE
Fix typo that caused cpp_dummy_build not to be built with CMake

### DIFF
--- a/tests/scripts/components-build-system.sh
+++ b/tests/scripts/components-build-system.sh
@@ -65,7 +65,7 @@ component_test_cmake_out_of_source () {
     mkdir "$OUT_OF_SOURCE_DIR"
     cd "$OUT_OF_SOURCE_DIR"
     # Note: Explicitly generate files as these are turned off in releases
-    cmake -D CMAKE_BUILD_TYPE:String=Check -D GEN_FILES=ON _D TEST_CPP=1 "$MBEDTLS_ROOT_DIR"
+    cmake -D CMAKE_BUILD_TYPE:String=Check -D GEN_FILES=ON -D TEST_CPP=1 "$MBEDTLS_ROOT_DIR"
     make
 
     msg "test: cmake 'out-of-source' build"


### PR DESCRIPTION
[Found by Tom](https://github.com/Mbed-TLS/mbedtls/pull/9446#discussion_r1754922190).

## PR checklist

- [x] **changelog** not required because: test only
- [x] **development PR** here
- [x] **framework PR** not required
- [x] **3.6 PR** not required (typo not present in 3.6)
- [x] **2.28 PR** not required because: code added in 3.6
- **tests**  provided
