### PR TITLE
Backport 3.6: make_generated_files.bat: document C compiler requirement

### DIFF
--- a/scripts/make_generated_files.bat
+++ b/scripts/make_generated_files.bat
@@ -1,6 +1,10 @@
 @rem Generate automatically-generated configuration-independent source files
 @rem and build scripts.
-@rem Perl and Python 3 must be on the PATH.
+@rem Requirements:
+@rem * Perl must be on the PATH ("perl" command).
+@rem * Python 3.8 or above must be on the PATH ("python" command).
+
+@rem @@@@ library\** @@@@
 @rem psa_crypto_driver_wrappers.h needs to be generated prior to
 @rem generate_visualc_files.pl being invoked.
 python scripts\generate_driver_wrappers.py || exit /b 1
@@ -8,8 +12,14 @@ perl scripts\generate_errors.pl || exit /b 1
 perl scripts\generate_query_config.pl || exit /b 1
 perl scripts\generate_features.pl || exit /b 1
 python scripts\generate_ssl_debug_helpers.py || exit /b 1
+
+@rem @@@@ Build @@@@
 perl scripts\generate_visualc_files.pl || exit /b 1
+
+@rem @@@@ programs\** @@@@
 python scripts\generate_psa_constants.py || exit /b 1
+
+@rem @@@@ tests\** @@@@
 python framework\scripts\generate_bignum_tests.py || exit /b 1
 python framework\scripts\generate_config_tests.py || exit /b 1
 python framework\scripts\generate_ecp_tests.py || exit /b 1

--- a/scripts/make_generated_files.bat
+++ b/scripts/make_generated_files.bat
@@ -3,6 +3,8 @@
 @rem Requirements:
 @rem * Perl must be on the PATH ("perl" command).
 @rem * Python 3.8 or above must be on the PATH ("python" command).
+@rem * Either a C compiler called "cc" must be on the PATH, or
+@rem   the "CC" environment variable must point to a C compiler.
 
 @rem @@@@ library\** @@@@
 @rem psa_crypto_driver_wrappers.h needs to be generated prior to


### PR DESCRIPTION
Document that `make_generated_files.bat` needs a C compiler as `%CC%` or `cc` (for `c_build_helper` users: `generate_psa_tests.py`).

## PR checklist

- [x] **changelog** not required because: doc only
- [x] **development PR** https://github.com/Mbed-TLS/mbedtls/pull/9128
- [x] **framework PR** not required
- [x] **3.6 PR** here
- [x] **2.28 PR** not required because: file not in 2.28
- **tests**  provided | not required because: 
