### PR TITLE
Fix obsolete comment about MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER

### DIFF
--- a/scripts/config.py
+++ b/scripts/config.py
@@ -200,7 +200,7 @@ EXCLUDE_FROM_FULL = frozenset([
     'MBEDTLS_PLATFORM_NO_STD_FUNCTIONS', # removes a feature
     'MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS', # removes a feature
     'MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG', # behavior change + build dependency
-    'MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER', # incompatible with USE_PSA_CRYPTO
+    'MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER', # interface and behavior change
     'MBEDTLS_PSA_CRYPTO_SPM', # platform dependency (PSA SPM)
     'MBEDTLS_PSA_INJECT_ENTROPY', # conflicts with platform entropy sources
     'MBEDTLS_RSA_NO_CRT', # influences the use of RSA in X.509 and TLS


### PR DESCRIPTION
MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER has been compatible with MBEDTLS_USE_PSA_CRYPTO since https://github.com/Mbed-TLS/mbedtls/pull/5380. We still don't want to enable it in the full config because it's a behavior change, even an interface change.

## PR checklist

- [x] **changelog** not required because: comment only
- [x] **development PR** #9600
- [x] **framework PR** not required
- [x] **3.6 PR** here
- [x] **2.28 PR** not required because: only applicable since 3.2.0
- **tests**  provided
