### PR TITLE
config.py: don't rely on section names

### DIFF
--- a/scripts/config.py
+++ b/scripts/config.py
@@ -27,7 +27,7 @@ def is_full_section(section):
     """
     return section is None or section.endswith('support') or section.endswith('modules')
 
-def realfull_adapter(_name, active, section):
+def realfull_adapter(_name, _value, active, section):
     """Activate all symbols found in the global and boolean feature sections.
 
     This is intended for building the documentation, including the
@@ -138,7 +138,7 @@ def include_in_full(name):
         return is_seamless_alt(name)
     return True
 
-def full_adapter(name, active, section):
+def full_adapter(name, _value, active, section):
     """Config adapter for "full"."""
     if not is_full_section(section):
         return active
@@ -176,7 +176,7 @@ def keep_in_baremetal(name):
         return False
     return True
 
-def baremetal_adapter(name, active, section):
+def baremetal_adapter(name, _value, active, section):
     """Config adapter for "baremetal"."""
     if not is_full_section(section):
         return active
@@ -195,10 +195,10 @@ EXCLUDE_FOR_SIZE = frozenset([
     'MBEDTLS_TEST_HOOKS', # only useful with the hosted test framework, increases code size
 ])
 
-def baremetal_size_adapter(name, active, section):
+def baremetal_size_adapter(name, value, active, section):
     if name in EXCLUDE_FOR_SIZE:
         return False
-    return baremetal_adapter(name, active, section)
+    return baremetal_adapter(name, value, active, section)
 
 def include_in_crypto(name):
     """Rules for symbols in a crypto configuration."""
@@ -219,15 +219,15 @@ def include_in_crypto(name):
 def crypto_adapter(adapter):
     """Modify an adapter to disable non-crypto symbols.
 
-    ``crypto_adapter(adapter)(name, active, section)`` is like
-    ``adapter(name, active, section)``, but unsets all X.509 and TLS symbols.
+    ``crypto_adapter(adapter)(name, value, active, section)`` is like
+    ``adapter(name, value, active, section)``, but unsets all X.509 and TLS symbols.
     """
-    def continuation(name, active, section):
+    def continuation(name, value, active, section):
         if not include_in_crypto(name):
             return False
         if adapter is None:
             return active
-        return adapter(name, active, section)
+        return adapter(name, value, active, section)
     return continuation
 
 DEPRECATED = frozenset([
@@ -237,34 +237,34 @@ DEPRECATED = frozenset([
 def no_deprecated_adapter(adapter):
     """Modify an adapter to disable deprecated symbols.
 
-    ``no_deprecated_adapter(adapter)(name, active, section)`` is like
-    ``adapter(name, active, section)``, but unsets all deprecated symbols
+    ``no_deprecated_adapter(adapter)(name, value, active, section)`` is like
+    ``adapter(name, value, active, section)``, but unsets all deprecated symbols
     and sets ``MBEDTLS_DEPRECATED_REMOVED``.
     """
-    def continuation(name, active, section):
+    def continuation(name, value, active, section):
         if name == 'MBEDTLS_DEPRECATED_REMOVED':
             return True
         if name in DEPRECATED:
             return False
         if adapter is None:
             return active
-        return adapter(name, active, section)
+        return adapter(name, value, active, section)
     return continuation
 
 def no_platform_adapter(adapter):
     """Modify an adapter to disable platform symbols.
 
-    ``no_platform_adapter(adapter)(name, active, section)`` is like
-    ``adapter(name, active, section)``, but unsets all platform symbols other
+    ``no_platform_adapter(adapter)(name, value, active, section)`` is like
+    ``adapter(name, value, active, section)``, but unsets all platform symbols other
     ``than MBEDTLS_PLATFORM_C.
     """
-    def continuation(name, active, section):
+    def continuation(name, value, active, section):
         # Allow MBEDTLS_PLATFORM_C but remove all other platform symbols.
         if name.startswith('MBEDTLS_PLATFORM_') and name != 'MBEDTLS_PLATFORM_C':
             return False
         if adapter is None:
             return active
-        return adapter(name, active, section)
+        return adapter(name, value, active, section)
     return continuation
 
 

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -19,13 +19,24 @@ import framework_scripts_path # pylint: disable=unused-import
 from mbedtls_framework import config_common
 
 
-def is_full_section(section):
-    """Is this section affected by "config.py full" and friends?
+def is_boolean_setting(name, value):
+    """Is this a boolean setting?
 
-    In a config file where the sections are not used the whole config file
-    is an empty section (with value None) and the whole file is affected.
+    Mbed TLS boolean settings are enabled if the preprocessor macro is
+    defined, and disabled if the preprocessor macro is not defined. The
+    macro definition line in the configuration file has an empty expansion.
+
+    PSA_WANT_xxx settings are also boolean, but when they are enabled,
+    they expand to a nonzero value. We leave them undefined when they
+    are disabled. (Setting them to 0 currently means to enable them, but
+    this might change to mean disabling them. Currently we just never set
+    them to 0.)
     """
-    return section is None or section.endswith('support') or section.endswith('modules')
+    if name.startswith('PSA_WANT_'):
+        return True
+    if not value:
+        return True
+    return False
 
 def realfull_adapter(_name, _value, active, section):
     """Activate all symbols found in the global and boolean feature sections.
@@ -138,9 +149,9 @@ def include_in_full(name):
         return is_seamless_alt(name)
     return True
 
-def full_adapter(name, _value, active, section):
+def full_adapter(name, value, active, _section):
     """Config adapter for "full"."""
-    if not is_full_section(section):
+    if not is_boolean_setting(name, value):
         return active
     return include_in_full(name)
 
@@ -176,9 +187,9 @@ def keep_in_baremetal(name):
         return False
     return True
 
-def baremetal_adapter(name, _value, active, section):
+def baremetal_adapter(name, value, active, _section):
     """Config adapter for "baremetal"."""
-    if not is_full_section(section):
+    if not is_boolean_setting(name, value):
         return active
     if name == 'MBEDTLS_NO_PLATFORM_ENTROPY':
         # No OS-provided entropy source

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -38,7 +38,7 @@ def is_boolean_setting(name, value):
         return True
     return False
 
-def realfull_adapter(_name, _value, _active, _section):
+def realfull_adapter(_name, _value, _active):
     """Activate all symbols.
 
     This is intended for building the documentation, including the
@@ -145,7 +145,7 @@ def include_in_full(name):
         return is_seamless_alt(name)
     return True
 
-def full_adapter(name, value, active, _section):
+def full_adapter(name, value, active):
     """Config adapter for "full"."""
     if not is_boolean_setting(name, value):
         return active
@@ -183,7 +183,7 @@ def keep_in_baremetal(name):
         return False
     return True
 
-def baremetal_adapter(name, value, active, _section):
+def baremetal_adapter(name, value, active):
     """Config adapter for "baremetal"."""
     if not is_boolean_setting(name, value):
         return active
@@ -202,10 +202,10 @@ EXCLUDE_FOR_SIZE = frozenset([
     'MBEDTLS_TEST_HOOKS', # only useful with the hosted test framework, increases code size
 ])
 
-def baremetal_size_adapter(name, value, active, section):
+def baremetal_size_adapter(name, value, active):
     if name in EXCLUDE_FOR_SIZE:
         return False
-    return baremetal_adapter(name, value, active, section)
+    return baremetal_adapter(name, value, active)
 
 def include_in_crypto(name):
     """Rules for symbols in a crypto configuration."""
@@ -226,15 +226,15 @@ def include_in_crypto(name):
 def crypto_adapter(adapter):
     """Modify an adapter to disable non-crypto symbols.
 
-    ``crypto_adapter(adapter)(name, value, active, section)`` is like
-    ``adapter(name, value, active, section)``, but unsets all X.509 and TLS symbols.
+    ``crypto_adapter(adapter)(name, value, active)`` is like
+    ``adapter(name, value, active)``, but unsets all X.509 and TLS symbols.
     """
-    def continuation(name, value, active, section):
+    def continuation(name, value, active):
         if not include_in_crypto(name):
             return False
         if adapter is None:
             return active
-        return adapter(name, value, active, section)
+        return adapter(name, value, active)
     return continuation
 
 DEPRECATED = frozenset([
@@ -244,34 +244,34 @@ DEPRECATED = frozenset([
 def no_deprecated_adapter(adapter):
     """Modify an adapter to disable deprecated symbols.
 
-    ``no_deprecated_adapter(adapter)(name, value, active, section)`` is like
-    ``adapter(name, value, active, section)``, but unsets all deprecated symbols
+    ``no_deprecated_adapter(adapter)(name, value, active)`` is like
+    ``adapter(name, value, active)``, but unsets all deprecated symbols
     and sets ``MBEDTLS_DEPRECATED_REMOVED``.
     """
-    def continuation(name, value, active, section):
+    def continuation(name, value, active):
         if name == 'MBEDTLS_DEPRECATED_REMOVED':
             return True
         if name in DEPRECATED:
             return False
         if adapter is None:
             return active
-        return adapter(name, value, active, section)
+        return adapter(name, value, active)
     return continuation
 
 def no_platform_adapter(adapter):
     """Modify an adapter to disable platform symbols.
 
-    ``no_platform_adapter(adapter)(name, value, active, section)`` is like
-    ``adapter(name, value, active, section)``, but unsets all platform symbols other
+    ``no_platform_adapter(adapter)(name, value, active)`` is like
+    ``adapter(name, value, active)``, but unsets all platform symbols other
     ``than MBEDTLS_PLATFORM_C.
     """
-    def continuation(name, value, active, section):
+    def continuation(name, value, active):
         # Allow MBEDTLS_PLATFORM_C but remove all other platform symbols.
         if name.startswith('MBEDTLS_PLATFORM_') and name != 'MBEDTLS_PLATFORM_C':
             return False
         if adapter is None:
             return active
-        return adapter(name, value, active, section)
+        return adapter(name, value, active)
     return continuation
 
 

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -38,18 +38,14 @@ def is_boolean_setting(name, value):
         return True
     return False
 
-def realfull_adapter(_name, _value, active, section):
-    """Activate all symbols found in the global and boolean feature sections.
+def realfull_adapter(_name, _value, _active, _section):
+    """Activate all symbols.
 
     This is intended for building the documentation, including the
     documentation of settings that are activated by defining an optional
-    preprocessor macro.
-
-    Do not activate definitions in the section containing symbols that are
-    supposed to be defined and documented in their own module.
+    preprocessor macro. There is no expectation that the resulting
+    configuration can be built.
     """
-    if section == 'Module configuration options':
-        return active
     return True
 
 PSA_UNSUPPORTED_FEATURE = frozenset([


### PR DESCRIPTION
In `config.py`, stop relying on section names for `config.py full`, `config.py realfull`, etc. This way we can move configuration settings around as described in https://github.com/Mbed-TLS/mbedtls/pull/9236 without having to worry about messing up the tooling.

Specifically:

* `full` and friends no longer rely on the section to determine which settings are booleans that should be activated.
* `realfull` is now really full. The goal is to document everything, and it turns out that uncommenting everything does work.

## Testing

The script `tests/scripts/test_config_script.py` runs some tests on `config.py` and places the output in the given directory. Run it on the version of `config.py` from two commits to compare its effects.

```
$ git checkout --recurse-submodules upstream/pull/9604~4
$ tests/scripts/test_config_script.py -d 0
$ git checkout --recurse-submodules upstream/pull/9604~3
$ tests/scripts/test_config_script.py -d 1
$ git checkout --recurse-submodules upstream/pull/9604~2
$ tests/scripts/test_config_script.py -d 2
$ git checkout --recurse-submodules upstream/pull/9604~1
$ tests/scripts/test_config_script.py -d 3
$ git checkout --recurse-submodules upstream/pull/9604
$ tests/scripts/test_config_script.py -d 4
$ diff -ru 0 1
$ diff -ru 1 2
$ diff -ru 2 3 | less
$ diff -ru 3 4
```

2→3 has an expected difference in the behavior of `realfull`.

## PR checklist

- [x] **changelog** not required because: refactoring only
- [x] **development PR** provided # | not required because: 
- [x] **framework PR** https://github.com/Mbed-TLS/mbedtls-framework/pull/49
- [x] **3.6 PR** https://github.com/Mbed-TLS/mbedtls/pull/9637
- [x] **2.28 PR** not required because: we won't change `config.py` in 2.28
- **tests**  manual (see above)
