### PR TITLE
Backport 3.6: Fix some all.sh components with sub-components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ massif-*
 
 # Unix-like build artifacts:
 *.o
+*.s
 
 # MSVC build artifacts:
 *.exe

--- a/library/Makefile
+++ b/library/Makefile
@@ -337,6 +337,10 @@ libmbedcrypto.dll: $(OBJS_CRYPTO)
 	echo "  CC    $<"
 	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) -o $@ -c $<
 
+.c.s:
+	echo "  CC    $<"
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) -S -o $@ -c $<
+
 .PHONY: generated_files
 generated_files: $(GENERATED_FILES)
 

--- a/library/Makefile
+++ b/library/Makefile
@@ -391,12 +391,13 @@ psa_crypto.o:psa_crypto_driver_wrappers.h
 
 clean:
 ifndef WINDOWS
-	rm -f *.o libmbed*
-	rm -f $(THIRDPARTY_CRYPTO_OBJECTS)
+	rm -f *.o *.s libmbed*
+	rm -f $(THIRDPARTY_CRYPTO_OBJECTS) $(THIRDPARTY_CRYPTO_OBJECTS:.o=.s)
 else
 	if exist *.o del /Q /F *.o
+	if exist *.s del /Q /F *.s
 	if exist libmbed* del /Q /F libmbed*
-	del /Q /F del_errors_out_if_the_file_list_is_empty_but_not_if_a_file_does_not_exist $(subst /,\,$(THIRDPARTY_CRYPTO_OBJECTS))
+	del /Q /F del_errors_out_if_the_file_list_is_empty_but_not_if_a_file_does_not_exist $(subst /,\,$(THIRDPARTY_CRYPTO_OBJECTS) $(THIRDPARTY_CRYPTO_OBJECTS:.o=.s))
 endif
 
 neat: clean

--- a/tests/scripts/components-compiler.sh
+++ b/tests/scripts/components-compiler.sh
@@ -83,20 +83,20 @@ support_test_gcc_earliest_opt () {
 
 component_build_mingw () {
     msg "build: Windows cross build - mingw64, make (Link Library)" # ~ 30s
-    make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -Wall -Wextra -maes -msse2 -mpclmul' WINDOWS_BUILD=1 lib programs
+    make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar CFLAGS='-Werror -Wall -Wextra -maes -msse2 -mpclmul' WINDOWS_BUILD=1 lib programs
 
     # note Make tests only builds the tests, but doesn't run them
-    make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -maes -msse2 -mpclmul' WINDOWS_BUILD=1 tests
+    make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar CFLAGS='-Werror -maes -msse2 -mpclmul' WINDOWS_BUILD=1 tests
     make WINDOWS_BUILD=1 clean
 
     msg "build: Windows cross build - mingw64, make (DLL)" # ~ 30s
-    make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -Wall -Wextra -maes -msse2 -mpclmul' WINDOWS_BUILD=1 SHARED=1 lib programs
-    make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -Wall -Wextra -maes -msse2 -mpclmul' WINDOWS_BUILD=1 SHARED=1 tests
+    make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar CFLAGS='-Werror -Wall -Wextra -maes -msse2 -mpclmul' WINDOWS_BUILD=1 SHARED=1 lib programs
+    make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar CFLAGS='-Werror -Wall -Wextra -maes -msse2 -mpclmul' WINDOWS_BUILD=1 SHARED=1 tests
     make WINDOWS_BUILD=1 clean
 
     msg "build: Windows cross build - mingw64, make (Library only, default config without MBEDTLS_AESNI_C)" # ~ 30s
     ./scripts/config.py unset MBEDTLS_AESNI_C #
-    make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -Wall -Wextra' WINDOWS_BUILD=1 lib
+    make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar CFLAGS='-Werror -Wall -Wextra' WINDOWS_BUILD=1 lib
     make WINDOWS_BUILD=1 clean
 }
 

--- a/tests/scripts/components-compiler.sh
+++ b/tests/scripts/components-compiler.sh
@@ -56,7 +56,7 @@ support_test_clang_latest_opt () {
 
 component_test_clang_earliest_opt () {
     scripts/config.py full
-    test_build_opt 'full config' "$CLANG_EARLIEST" -O0
+    test_build_opt 'full config' "$CLANG_EARLIEST" -O2
 }
 
 support_test_clang_earliest_opt () {
@@ -74,7 +74,7 @@ support_test_gcc_latest_opt () {
 
 component_test_gcc_earliest_opt () {
     scripts/config.py full
-    test_build_opt 'full config' "$GCC_EARLIEST" -O0
+    test_build_opt 'full config' "$GCC_EARLIEST" -O2
 }
 
 support_test_gcc_earliest_opt () {

--- a/tests/scripts/components-configuration-crypto.sh
+++ b/tests/scripts/components-configuration-crypto.sh
@@ -2322,7 +2322,7 @@ component_test_psa_crypto_config_accel_des () {
     helper_libtestdriver1_make_main "$loc_accel_list"
 
     # Make sure this was not re-enabled by accident (additive config)
-    not grep mbedtls_des* library/des.o
+    not grep mbedtls_des library/des.o
 
     # Run the tests
     # -------------

--- a/tests/scripts/components-platform.sh
+++ b/tests/scripts/components-platform.sh
@@ -171,27 +171,27 @@ component_build_aes_armce () {
     # test for presence of AES instructions
     scripts/config.py set MBEDTLS_AES_USE_HARDWARE_ONLY
     msg "clang, test A32 crypto instructions built"
-    make -B library/aesce.o CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a72+crypto -marm -S"
-    grep -E 'aes[0-9a-z]+.[0-9]\s*[qv]' library/aesce.o
+    make -B library/aesce.s CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a72+crypto -marm"
+    grep -E 'aes[0-9a-z]+.[0-9]\s*[qv]' library/aesce.s
     msg "clang, test T32 crypto instructions built"
-    make -B library/aesce.o CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a32+crypto -mthumb -S"
-    grep -E 'aes[0-9a-z]+.[0-9]\s*[qv]' library/aesce.o
+    make -B library/aesce.s CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a32+crypto -mthumb"
+    grep -E 'aes[0-9a-z]+.[0-9]\s*[qv]' library/aesce.s
     msg "clang, test aarch64 crypto instructions built"
-    make -B library/aesce.o CC=clang CFLAGS="--target=aarch64-linux-gnu -march=armv8-a -S"
-    grep -E 'aes[a-z]+\s*[qv]' library/aesce.o
+    make -B library/aesce.s CC=clang CFLAGS="--target=aarch64-linux-gnu -march=armv8-a"
+    grep -E 'aes[a-z]+\s*[qv]' library/aesce.s
 
     # test for absence of AES instructions
     scripts/config.py unset MBEDTLS_AES_USE_HARDWARE_ONLY
     scripts/config.py unset MBEDTLS_AESCE_C
     msg "clang, test A32 crypto instructions not built"
-    make -B library/aesce.o CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a72+crypto -marm -S"
-    not grep -E 'aes[0-9a-z]+.[0-9]\s*[qv]' library/aesce.o
+    make -B library/aesce.s CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a72+crypto -marm"
+    not grep -E 'aes[0-9a-z]+.[0-9]\s*[qv]' library/aesce.s
     msg "clang, test T32 crypto instructions not built"
-    make -B library/aesce.o CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a32+crypto -mthumb -S"
-    not grep -E 'aes[0-9a-z]+.[0-9]\s*[qv]' library/aesce.o
+    make -B library/aesce.s CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a32+crypto -mthumb"
+    not grep -E 'aes[0-9a-z]+.[0-9]\s*[qv]' library/aesce.s
     msg "clang, test aarch64 crypto instructions not built"
-    make -B library/aesce.o CC=clang CFLAGS="--target=aarch64-linux-gnu -march=armv8-a -S"
-    not grep -E 'aes[a-z]+\s*[qv]' library/aesce.o
+    make -B library/aesce.s CC=clang CFLAGS="--target=aarch64-linux-gnu -march=armv8-a"
+    not grep -E 'aes[a-z]+\s*[qv]' library/aesce.s
 }
 
 support_build_sha_armce () {
@@ -237,32 +237,32 @@ component_build_sha_armce () {
     for opt in MBEDTLS_SHA256_USE_ARMV8_A_CRYPTO_ONLY MBEDTLS_SHA256_USE_ARMV8_A_CRYPTO_IF_PRESENT; do
         scripts/config.py set ${opt}
             msg "${opt} clang, test A32 crypto instructions built"
-            make -B library/sha256.o CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a72+crypto -marm -S"
-            grep -E 'sha256[a-z0-9]+.32\s+[qv]' library/sha256.o
+            make -B library/sha256.s CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a72+crypto -marm"
+            grep -E 'sha256[a-z0-9]+.32\s+[qv]' library/sha256.s
 
             msg "${opt} clang, test T32 crypto instructions built"
-            make -B library/sha256.o CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a32+crypto -mthumb -S"
-            grep -E 'sha256[a-z0-9]+.32\s+[qv]' library/sha256.o
+            make -B library/sha256.s CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a32+crypto -mthumb"
+            grep -E 'sha256[a-z0-9]+.32\s+[qv]' library/sha256.s
 
             msg "${opt} clang, test aarch64 crypto instructions built"
-            make -B library/sha256.o CC=clang CFLAGS="--target=aarch64-linux-gnu -march=armv8-a -S"
-            grep -E 'sha256[a-z0-9]+\s+[qv]' library/sha256.o
+            make -B library/sha256.s CC=clang CFLAGS="--target=aarch64-linux-gnu -march=armv8-a"
+            grep -E 'sha256[a-z0-9]+\s+[qv]' library/sha256.s
         scripts/config.py unset ${opt}
     done
 
 
     # examine the disassembly for absence of SHA instructions
     msg "clang, test A32 crypto instructions not built"
-    make -B library/sha256.o CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a72+crypto -marm -S"
-    not grep -E 'sha256[a-z0-9]+.32\s+[qv]' library/sha256.o
+    make -B library/sha256.s CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a72+crypto -marm"
+    not grep -E 'sha256[a-z0-9]+.32\s+[qv]' library/sha256.s
 
     msg "clang, test T32 crypto instructions not built"
-    make -B library/sha256.o CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a32+crypto -mthumb -S"
-    not grep -E 'sha256[a-z0-9]+.32\s+[qv]' library/sha256.o
+    make -B library/sha256.s CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a32+crypto -mthumb"
+    not grep -E 'sha256[a-z0-9]+.32\s+[qv]' library/sha256.s
 
     msg "clang, test aarch64 crypto instructions not built"
-    make -B library/sha256.o CC=clang CFLAGS="--target=aarch64-linux-gnu -march=armv8-a -S"
-    not grep -E 'sha256[a-z0-9]+\s+[qv]' library/sha256.o
+    make -B library/sha256.s CC=clang CFLAGS="--target=aarch64-linux-gnu -march=armv8-a"
+    not grep -E 'sha256[a-z0-9]+\s+[qv]' library/sha256.s
 }
 
 component_test_m32_no_asm () {

--- a/tests/scripts/components-platform.sh
+++ b/tests/scripts/components-platform.sh
@@ -149,49 +149,53 @@ component_build_aes_armce () {
     scripts/config.py set MBEDTLS_AES_USE_HARDWARE_ONLY
 
     msg "MBEDTLS_AES_USE_HARDWARE_ONLY, clang, aarch64"
-    make -B library/aesce.o CC=clang CFLAGS="--target=aarch64-linux-gnu -march=armv8-a+crypto"
-
-    msg "MBEDTLS_AES_USE_HARDWARE_ONLY, clang, arm"
-    make -B library/aesce.o CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a72+crypto -marm"
-
-    msg "MBEDTLS_AES_USE_HARDWARE_ONLY, clang, thumb"
-    make -B library/aesce.o CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a32+crypto -mthumb"
-
-    scripts/config.py unset MBEDTLS_AES_USE_HARDWARE_ONLY
-
-    msg "no MBEDTLS_AES_USE_HARDWARE_ONLY, clang, aarch64"
-    make -B library/aesce.o CC=clang CFLAGS="--target=aarch64-linux-gnu -march=armv8-a+crypto"
-
-    msg "no MBEDTLS_AES_USE_HARDWARE_ONLY, clang, arm"
-    make -B library/aesce.o CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a72+crypto -marm"
-
-    msg "no MBEDTLS_AES_USE_HARDWARE_ONLY, clang, thumb"
-    make -B library/aesce.o CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a32+crypto -mthumb"
-
-    # test for presence of AES instructions
-    scripts/config.py set MBEDTLS_AES_USE_HARDWARE_ONLY
-    msg "clang, test A32 crypto instructions built"
-    make -B library/aesce.s CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a72+crypto -marm"
-    grep -E 'aes[0-9a-z]+.[0-9]\s*[qv]' library/aesce.s
-    msg "clang, test T32 crypto instructions built"
-    make -B library/aesce.s CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a32+crypto -mthumb"
-    grep -E 'aes[0-9a-z]+.[0-9]\s*[qv]' library/aesce.s
+    make -B library/aesce.o library/aesce.s CC=clang CFLAGS="--target=aarch64-linux-gnu -march=armv8-a+crypto"
     msg "clang, test aarch64 crypto instructions built"
-    make -B library/aesce.s CC=clang CFLAGS="--target=aarch64-linux-gnu -march=armv8-a"
     grep -E 'aes[a-z]+\s*[qv]' library/aesce.s
 
-    # test for absence of AES instructions
+    msg "MBEDTLS_AES_USE_HARDWARE_ONLY, clang, arm"
+    make -B library/aesce.o library/aesce.s CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a72+crypto -marm"
+    msg "clang, test A32 crypto instructions built"
+    grep -E 'aes[0-9a-z]+.[0-9]\s*[qv]' library/aesce.s
+
+    msg "MBEDTLS_AES_USE_HARDWARE_ONLY, clang, thumb"
+    make -B library/aesce.o library/aesce.s CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a32+crypto -mthumb"
+    msg "clang, test T32 crypto instructions built"
+    grep -E 'aes[0-9a-z]+.[0-9]\s*[qv]' library/aesce.s
+
     scripts/config.py unset MBEDTLS_AES_USE_HARDWARE_ONLY
+
+    msg "MBEDTLS_AES_USE_both, clang, aarch64"
+    make -B library/aesce.o library/aesce.s CC=clang CFLAGS="--target=aarch64-linux-gnu -march=armv8-a+crypto"
+    msg "clang, test aarch64 crypto instructions built"
+    grep -E 'aes[a-z]+\s*[qv]' library/aesce.s
+
+    msg "MBEDTLS_AES_USE_both, clang, arm"
+    make -B library/aesce.o library/aesce.s CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a72+crypto -marm"
+    msg "clang, test A32 crypto instructions built"
+    grep -E 'aes[0-9a-z]+.[0-9]\s*[qv]' library/aesce.s
+
+    msg "MBEDTLS_AES_USE_both, clang, thumb"
+    make -B library/aesce.o library/aesce.s CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a32+crypto -mthumb"
+    msg "clang, test T32 crypto instructions built"
+    grep -E 'aes[0-9a-z]+.[0-9]\s*[qv]' library/aesce.s
+
     scripts/config.py unset MBEDTLS_AESCE_C
-    msg "clang, test A32 crypto instructions not built"
-    make -B library/aesce.s CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a72+crypto -marm"
-    not grep -E 'aes[0-9a-z]+.[0-9]\s*[qv]' library/aesce.s
-    msg "clang, test T32 crypto instructions not built"
-    make -B library/aesce.s CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a32+crypto -mthumb"
-    not grep -E 'aes[0-9a-z]+.[0-9]\s*[qv]' library/aesce.s
+
+    msg "no MBEDTLS_AESCE_C, clang, aarch64"
+    make -B library/aesce.o library/aesce.s CC=clang CFLAGS="--target=aarch64-linux-gnu -march=armv8-a"
     msg "clang, test aarch64 crypto instructions not built"
-    make -B library/aesce.s CC=clang CFLAGS="--target=aarch64-linux-gnu -march=armv8-a"
     not grep -E 'aes[a-z]+\s*[qv]' library/aesce.s
+
+    msg "no MBEDTLS_AESCE_C, clang, arm"
+    make -B library/aesce.o library/aesce.s CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a72 -marm"
+    msg "clang, test A32 crypto instructions not built"
+    not grep -E 'aes[0-9a-z]+.[0-9]\s*[qv]' library/aesce.s
+
+    msg "no MBEDTLS_AESCE_C, clang, thumb"
+    make -B library/aesce.o library/aesce.s CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a32 -mthumb"
+    msg "clang, test T32 crypto instructions not built"
+    not grep -E 'aes[0-9a-z]+.[0-9]\s*[qv]' library/aesce.s
 }
 
 support_build_sha_armce () {
@@ -202,62 +206,54 @@ support_build_sha_armce () {
 component_build_sha_armce () {
     scripts/config.py unset MBEDTLS_SHA256_USE_ARMV8_A_CRYPTO_IF_PRESENT
 
-
     # Test variations of SHA256 Armv8 crypto extensions
     scripts/config.py set MBEDTLS_SHA256_USE_ARMV8_A_CRYPTO_ONLY
         msg "MBEDTLS_SHA256_USE_ARMV8_A_CRYPTO_ONLY clang, aarch64"
-        make -B library/sha256.o CC=clang CFLAGS="--target=aarch64-linux-gnu -march=armv8-a"
+        make -B library/sha256.o library/sha256.s CC=clang CFLAGS="--target=aarch64-linux-gnu -march=armv8-a+crypto"
+        msg "MBEDTLS_SHA256_USE_ARMV8_A_CRYPTO_ONLY clang, test aarch64 crypto instructions built"
+        grep -E 'sha256[a-z0-9]+\s+[qv]' library/sha256.s
+
         msg "MBEDTLS_SHA256_USE_ARMV8_A_CRYPTO_ONLY clang, arm"
-        make -B library/sha256.o CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a72+crypto -marm"
+        make -B library/sha256.o library/sha256.s CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a72+crypto -marm"
+        msg "MBEDTLS_SHA256_USE_ARMV8_A_CRYPTO_ONLY clang, test A32 crypto instructions built"
+        grep -E 'sha256[a-z0-9]+.32\s+[qv]' library/sha256.s
     scripts/config.py unset MBEDTLS_SHA256_USE_ARMV8_A_CRYPTO_ONLY
 
 
     # test the deprecated form of the config option
     scripts/config.py set MBEDTLS_SHA256_USE_A64_CRYPTO_ONLY
         msg "MBEDTLS_SHA256_USE_A64_CRYPTO_ONLY clang, thumb"
-        make -B library/sha256.o CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a32+crypto -mthumb"
+        make -B library/sha256.o library/sha256.s CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a32+crypto -mthumb"
+        msg "MBEDTLS_SHA256_USE_A64_CRYPTO_ONLY clang, test T32 crypto instructions built"
+        grep -E 'sha256[a-z0-9]+.32\s+[qv]' library/sha256.s
     scripts/config.py unset MBEDTLS_SHA256_USE_A64_CRYPTO_ONLY
 
     scripts/config.py set MBEDTLS_SHA256_USE_ARMV8_A_CRYPTO_IF_PRESENT
         msg "MBEDTLS_SHA256_USE_ARMV8_A_CRYPTO_IF_PRESENT clang, aarch64"
-        make -B library/sha256.o CC=clang CFLAGS="--target=aarch64-linux-gnu -march=armv8-a"
+        make -B library/sha256.o library/sha256.s CC=clang CFLAGS="--target=aarch64-linux-gnu -march=armv8-a+crypto"
+        msg "MBEDTLS_SHA256_USE_ARMV8_A_CRYPTO_IF_PRESENT clang, test aarch64 crypto instructions built"
+        grep -E 'sha256[a-z0-9]+\s+[qv]' library/sha256.s
     scripts/config.py unset MBEDTLS_SHA256_USE_ARMV8_A_CRYPTO_IF_PRESENT
 
 
     # test the deprecated form of the config option
     scripts/config.py set MBEDTLS_SHA256_USE_A64_CRYPTO_IF_PRESENT
         msg "MBEDTLS_SHA256_USE_A64_CRYPTO_IF_PRESENT clang, arm"
-        make -B library/sha256.o CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a72+crypto -marm -std=c99"
+        make -B library/sha256.o library/sha256.s CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a72+crypto -marm -std=c99"
+
         msg "MBEDTLS_SHA256_USE_A64_CRYPTO_IF_PRESENT clang, thumb"
-        make -B library/sha256.o CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a32+crypto -mthumb"
+        make -B library/sha256.o library/sha256.s CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a32+crypto -mthumb"
+        msg "MBEDTLS_SHA256_USE_A64_CRYPTO_IF_PRESENT clang, test T32 crypto instructions built"
+        grep -E 'sha256[a-z0-9]+.32\s+[qv]' library/sha256.s
     scripts/config.py unset MBEDTLS_SHA256_USE_A64_CRYPTO_IF_PRESENT
-
-
-    # examine the disassembly for presence of SHA instructions
-    for opt in MBEDTLS_SHA256_USE_ARMV8_A_CRYPTO_ONLY MBEDTLS_SHA256_USE_ARMV8_A_CRYPTO_IF_PRESENT; do
-        scripts/config.py set ${opt}
-            msg "${opt} clang, test A32 crypto instructions built"
-            make -B library/sha256.s CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a72+crypto -marm"
-            grep -E 'sha256[a-z0-9]+.32\s+[qv]' library/sha256.s
-
-            msg "${opt} clang, test T32 crypto instructions built"
-            make -B library/sha256.s CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a32+crypto -mthumb"
-            grep -E 'sha256[a-z0-9]+.32\s+[qv]' library/sha256.s
-
-            msg "${opt} clang, test aarch64 crypto instructions built"
-            make -B library/sha256.s CC=clang CFLAGS="--target=aarch64-linux-gnu -march=armv8-a"
-            grep -E 'sha256[a-z0-9]+\s+[qv]' library/sha256.s
-        scripts/config.py unset ${opt}
-    done
-
 
     # examine the disassembly for absence of SHA instructions
     msg "clang, test A32 crypto instructions not built"
-    make -B library/sha256.s CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a72+crypto -marm"
+    make -B library/sha256.s CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a72 -marm"
     not grep -E 'sha256[a-z0-9]+.32\s+[qv]' library/sha256.s
 
     msg "clang, test T32 crypto instructions not built"
-    make -B library/sha256.s CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a32+crypto -mthumb"
+    make -B library/sha256.s CC=clang CFLAGS="--target=arm-linux-gnueabihf -mcpu=cortex-a32 -mthumb"
     not grep -E 'sha256[a-z0-9]+.32\s+[qv]' library/sha256.s
 
     msg "clang, test aarch64 crypto instructions not built"


### PR DESCRIPTION
Some issues I discovered while working on https://github.com/Mbed-TLS/mbedtls/pull/9286. Backport of https://github.com/Mbed-TLS/mbedtls/pull/9293, conceptually identical, but with a lot of merge conflicts due to changes on the same line: we have lines that refer to `${BUILTIN_SRC_PATH}` in `development`, but that's just `library` in 3.6.

## PR checklist

- [x] **changelog** not required because: test only
- [x] **development PR** provided https://github.com/Mbed-TLS/mbedtls/pull/9293
- [x] **framework PR** not required
- [x] **3.6 PR** here
- [x] **2.28 PR** https://github.com/Mbed-TLS/mbedtls/pull/9609
- **tests**  provided
