### PR TITLE
Update the `hashes` domain to use PSA macros in `depends.py`

### DIFF
--- a/tests/scripts/components-configuration.sh
+++ b/tests/scripts/components-configuration.sh
@@ -351,16 +351,3 @@ component_test_memory_buffer_allocator () {
     # MBEDTLS_MEMORY_BUFFER_ALLOC is slow. Skip tests that tend to time out.
     tests/ssl-opt.sh -e '^DTLS proxy'
 }
-
-# Temporary component for SHA3 config option removal
-# Will be removed according to this issue:
-# https://github.com/Mbed-TLS/mbedtls/issues/10203
-component_test_full_no_sha3 () {
-    msg "build: full config without SHA3"
-    scripts/config.py full
-    scripts/config.py unset-all 'PSA_WANT_ALG_SHA3_*'
-    make
-
-    msg "test: full - PSA_WANT_ALG_SHA3_*"
-    make test
-}


### PR DESCRIPTION
## Description

In `depends.py` use PSA macros for the `hashes` domain.

Resolve #9144 #10203
~Depends on #10145 #9292~ (merged)

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** not required because: test related changes
- [x] **development PR** provided this is
- [x] **framework PR** not required
- [x] **3.6 PR** not required because: 4.0 related changes
- [x] **2.28 PR** not required because: 4.0 related changes
- **tests**  provided
