### PR TITLE
Backport 3.6: config.py: don't rely on section names

### DIFF
--- a/scripts/config.py
+++ b/scripts/config.py
@@ -26,7 +26,7 @@ def is_full_section(section):
     """
     return section is None or section.endswith('support') or section.endswith('modules')
 
-def realfull_adapter(_name, active, section):
+def realfull_adapter(_name, _value, active, section):
     """Activate all symbols found in the global and boolean feature sections.
 
     This is intended for building the documentation, including the
@@ -135,7 +135,7 @@ def include_in_full(name):
         return is_seamless_alt(name)
     return True
 
-def full_adapter(name, active, section):
+def full_adapter(name, _value, active, section):
     """Config adapter for "full"."""
     if not is_full_section(section):
         return active
@@ -173,7 +173,7 @@ def keep_in_baremetal(name):
         return False
     return True
 
-def baremetal_adapter(name, active, section):
+def baremetal_adapter(name, _value, active, section):
     """Config adapter for "baremetal"."""
     if not is_full_section(section):
         return active
@@ -192,10 +192,10 @@ EXCLUDE_FOR_SIZE = frozenset([
     'MBEDTLS_TEST_HOOKS', # only useful with the hosted test framework, increases code size
 ])
 
-def baremetal_size_adapter(name, active, section):
+def baremetal_size_adapter(name, value, active, section):
     if name in EXCLUDE_FOR_SIZE:
         return False
-    return baremetal_adapter(name, active, section)
+    return baremetal_adapter(name, value, active, section)
 
 def include_in_crypto(name):
     """Rules for symbols in a crypto configuration."""
@@ -214,15 +214,15 @@ def include_in_crypto(name):
 def crypto_adapter(adapter):
     """Modify an adapter to disable non-crypto symbols.
 
-    ``crypto_adapter(adapter)(name, active, section)`` is like
-    ``adapter(name, active, section)``, but unsets all X.509 and TLS symbols.
+    ``crypto_adapter(adapter)(name, value, active, section)`` is like
+    ``adapter(name, value, active, section)``, but unsets all X.509 and TLS symbols.
     """
-    def continuation(name, active, section):
+    def continuation(name, value, active, section):
         if not include_in_crypto(name):
             return False
         if adapter is None:
             return active
-        return adapter(name, active, section)
+        return adapter(name, value, active, section)
     return continuation
 
 DEPRECATED = frozenset([
@@ -231,34 +231,34 @@ DEPRECATED = frozenset([
 def no_deprecated_adapter(adapter):
     """Modify an adapter to disable deprecated symbols.
 
-    ``no_deprecated_adapter(adapter)(name, active, section)`` is like
-    ``adapter(name, active, section)``, but unsets all deprecated symbols
+    ``no_deprecated_adapter(adapter)(name, value, active, section)`` is like
+    ``adapter(name, value, active, section)``, but unsets all deprecated symbols
     and sets ``MBEDTLS_DEPRECATED_REMOVED``.
     """
-    def continuation(name, active, section):
+    def continuation(name, value, active, section):
         if name == 'MBEDTLS_DEPRECATED_REMOVED':
             return True
         if name in DEPRECATED:
             return False
         if adapter is None:
             return active
-        return adapter(name, active, section)
+        return adapter(name, value, active, section)
     return continuation
 
 def no_platform_adapter(adapter):
     """Modify an adapter to disable platform symbols.
 
-    ``no_platform_adapter(adapter)(name, active, section)`` is like
-    ``adapter(name, active, section)``, but unsets all platform symbols other
+    ``no_platform_adapter(adapter)(name, value, active, section)`` is like
+    ``adapter(name, value, active, section)``, but unsets all platform symbols other
     ``than MBEDTLS_PLATFORM_C.
     """
-    def continuation(name, active, section):
+    def continuation(name, value, active, section):
         # Allow MBEDTLS_PLATFORM_C but remove all other platform symbols.
         if name.startswith('MBEDTLS_PLATFORM_') and name != 'MBEDTLS_PLATFORM_C':
             return False
         if adapter is None:
             return active
-        return adapter(name, active, section)
+        return adapter(name, value, active, section)
     return continuation
 
 

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -37,18 +37,14 @@ def is_boolean_setting(name, value):
         return True
     return False
 
-def realfull_adapter(_name, _value, active, section):
-    """Activate all symbols found in the global and boolean feature sections.
+def realfull_adapter(_name, _value, _active, _section):
+    """Activate all symbols.
 
     This is intended for building the documentation, including the
     documentation of settings that are activated by defining an optional
-    preprocessor macro.
-
-    Do not activate definitions in the section containing symbols that are
-    supposed to be defined and documented in their own module.
+    preprocessor macro. There is no expectation that the resulting
+    configuration can be built.
     """
-    if section == 'Module configuration options':
-        return active
     return True
 
 PSA_UNSUPPORTED_FEATURE = frozenset([

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -37,7 +37,7 @@ def is_boolean_setting(name, value):
         return True
     return False
 
-def realfull_adapter(_name, _value, _active, _section):
+def realfull_adapter(_name, _value, _active):
     """Activate all symbols.
 
     This is intended for building the documentation, including the
@@ -142,7 +142,7 @@ def include_in_full(name):
         return is_seamless_alt(name)
     return True
 
-def full_adapter(name, value, active, _section):
+def full_adapter(name, value, active):
     """Config adapter for "full"."""
     if not is_boolean_setting(name, value):
         return active
@@ -180,7 +180,7 @@ def keep_in_baremetal(name):
         return False
     return True
 
-def baremetal_adapter(name, value, active, _section):
+def baremetal_adapter(name, value, active):
     """Config adapter for "baremetal"."""
     if not is_boolean_setting(name, value):
         return active
@@ -199,10 +199,10 @@ EXCLUDE_FOR_SIZE = frozenset([
     'MBEDTLS_TEST_HOOKS', # only useful with the hosted test framework, increases code size
 ])
 
-def baremetal_size_adapter(name, value, active, section):
+def baremetal_size_adapter(name, value, active):
     if name in EXCLUDE_FOR_SIZE:
         return False
-    return baremetal_adapter(name, value, active, section)
+    return baremetal_adapter(name, value, active)
 
 def include_in_crypto(name):
     """Rules for symbols in a crypto configuration."""
@@ -221,15 +221,15 @@ def include_in_crypto(name):
 def crypto_adapter(adapter):
     """Modify an adapter to disable non-crypto symbols.
 
-    ``crypto_adapter(adapter)(name, value, active, section)`` is like
-    ``adapter(name, value, active, section)``, but unsets all X.509 and TLS symbols.
+    ``crypto_adapter(adapter)(name, value, active)`` is like
+    ``adapter(name, value, active)``, but unsets all X.509 and TLS symbols.
     """
-    def continuation(name, value, active, section):
+    def continuation(name, value, active):
         if not include_in_crypto(name):
             return False
         if adapter is None:
             return active
-        return adapter(name, value, active, section)
+        return adapter(name, value, active)
     return continuation
 
 DEPRECATED = frozenset([
@@ -238,34 +238,34 @@ DEPRECATED = frozenset([
 def no_deprecated_adapter(adapter):
     """Modify an adapter to disable deprecated symbols.
 
-    ``no_deprecated_adapter(adapter)(name, value, active, section)`` is like
-    ``adapter(name, value, active, section)``, but unsets all deprecated symbols
+    ``no_deprecated_adapter(adapter)(name, value, active)`` is like
+    ``adapter(name, value, active)``, but unsets all deprecated symbols
     and sets ``MBEDTLS_DEPRECATED_REMOVED``.
     """
-    def continuation(name, value, active, section):
+    def continuation(name, value, active):
         if name == 'MBEDTLS_DEPRECATED_REMOVED':
             return True
         if name in DEPRECATED:
             return False
         if adapter is None:
             return active
-        return adapter(name, value, active, section)
+        return adapter(name, value, active)
     return continuation
 
 def no_platform_adapter(adapter):
     """Modify an adapter to disable platform symbols.
 
-    ``no_platform_adapter(adapter)(name, value, active, section)`` is like
-    ``adapter(name, value, active, section)``, but unsets all platform symbols other
+    ``no_platform_adapter(adapter)(name, value, active)`` is like
+    ``adapter(name, value, active)``, but unsets all platform symbols other
     ``than MBEDTLS_PLATFORM_C.
     """
-    def continuation(name, value, active, section):
+    def continuation(name, value, active):
         # Allow MBEDTLS_PLATFORM_C but remove all other platform symbols.
         if name.startswith('MBEDTLS_PLATFORM_') and name != 'MBEDTLS_PLATFORM_C':
             return False
         if adapter is None:
             return active
-        return adapter(name, value, active, section)
+        return adapter(name, value, active)
     return continuation
 
 

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -18,13 +18,24 @@ import framework_scripts_path # pylint: disable=unused-import
 from mbedtls_framework import config_common
 
 
-def is_full_section(section):
-    """Is this section affected by "config.py full" and friends?
+def is_boolean_setting(name, value):
+    """Is this a boolean setting?
 
-    In a config file where the sections are not used the whole config file
-    is an empty section (with value None) and the whole file is affected.
+    Mbed TLS boolean settings are enabled if the preprocessor macro is
+    defined, and disabled if the preprocessor macro is not defined. The
+    macro definition line in the configuration file has an empty expansion.
+
+    PSA_WANT_xxx settings are also boolean, but when they are enabled,
+    they expand to a nonzero value. We leave them undefined when they
+    are disabled. (Setting them to 0 currently means to enable them, but
+    this might change to mean disabling them. Currently we just never set
+    them to 0.)
     """
-    return section is None or section.endswith('support') or section.endswith('modules')
+    if name.startswith('PSA_WANT_'):
+        return True
+    if not value:
+        return True
+    return False
 
 def realfull_adapter(_name, _value, active, section):
     """Activate all symbols found in the global and boolean feature sections.
@@ -135,9 +146,9 @@ def include_in_full(name):
         return is_seamless_alt(name)
     return True
 
-def full_adapter(name, _value, active, section):
+def full_adapter(name, value, active, _section):
     """Config adapter for "full"."""
-    if not is_full_section(section):
+    if not is_boolean_setting(name, value):
         return active
     return include_in_full(name)
 
@@ -173,9 +184,9 @@ def keep_in_baremetal(name):
         return False
     return True
 
-def baremetal_adapter(name, _value, active, section):
+def baremetal_adapter(name, value, active, _section):
     """Config adapter for "baremetal"."""
-    if not is_full_section(section):
+    if not is_boolean_setting(name, value):
         return active
     if name == 'MBEDTLS_NO_PLATFORM_ENTROPY':
         # No OS-provided entropy source


### PR DESCRIPTION
Straightforward backport of https://github.com/Mbed-TLS/mbedtls/pull/9604.

## PR checklist

- [x] **changelog** not required because: refactoring only
- [x] **development PR** #9604
- [x] **framework PR** https://github.com/Mbed-TLS/mbedtls-framework/pull/49
- [x] **3.6 PR** here
- [x] **2.28 PR** not required because: we won't change `config.py` in 2.28
- **tests**  manual (see #9604)
