### PR TITLE
dtls_server: allow unexpected message on second handshake

### DIFF
--- a/programs/ssl/dtls_server.c
+++ b/programs/ssl/dtls_server.c
@@ -289,7 +289,14 @@ reset:
         ret = 0;
         goto reset;
     } else if (ret != 0) {
-        printf(" failed\n  ! mbedtls_ssl_handshake returned -0x%x\n\n", (unsigned int) -ret);
+        printf(" failed\n  ! mbedtls_ssl_handshake returned -0x%x\n", (unsigned int) -ret);
+        if (ret == MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE) {
+            printf("    An unexpected message was received from our peer. If this happened at\n");
+            printf("    the beginning of the handshake, this is likely a duplicated packet or\n");
+            printf("    a close_notify alert from the previous connection, which is harmless.\n");
+            ret = 0;
+        }
+        printf("\n");
         goto reset;
     }
 

--- a/tests/opt-testcases/sample.sh
+++ b/tests/opt-testcases/sample.sh
@@ -334,11 +334,6 @@ run_test    "Sample: ssl_pthread_server, gnutls client, TLS 1.3" \
             -S "error" \
             -C "ERROR"
 
-# The server complains of extra data after it closes the connection
-# because the client keeps sending data, so the server receives
-# more application data when it expects a new handshake. We consider
-# the test a success if both sides have sent and received application
-# data, no matter what happens afterwards.
 run_test    "Sample: dtls_client with dtls_server" \
             -P 4433 \
             "$PROGRAMS_DIR/dtls_server" \
@@ -348,13 +343,9 @@ run_test    "Sample: dtls_client with dtls_server" \
             -s "[1-9][0-9]* bytes written" \
             -c "[1-9][0-9]* bytes read" \
             -c "[1-9][0-9]* bytes written" \
+            -S "error" \
             -C "error"
 
-# The server complains of extra data after it closes the connection
-# because the client keeps sending data, so the server receives
-# more application data when it expects a new handshake. We consider
-# the test a success if both sides have sent and received application
-# data, no matter what happens afterwards.
 run_test    "Sample: ssl_client2, dtls_server" \
             -P 4433 \
             "$PROGRAMS_DIR/dtls_server" \
@@ -364,6 +355,7 @@ run_test    "Sample: ssl_client2, dtls_server" \
             -s "[1-9][0-9]* bytes written" \
             -c "[1-9][0-9]* bytes read" \
             -c "[1-9][0-9]* bytes written" \
+            -S "error" \
             -C "error"
 
 requires_protocol_version dtls12


### PR DESCRIPTION
In `dtls_server`, don't treat `MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE` as a real error if it happens during a handshake. This error can happen if the client sends a `close_notify` alert after the server has decided to close the connection, or if there's a duplicated packet from the first connection.

In testing, this error happens reliably when the client is `dtls_client` or `ssl_client2 dtls=1`. It also happens reliably when the client is `openssl s_client -dtls_12` and I type into it interactively. When the client is `echo stuff | openssl s_client -dtls_12`, I don't see the error locally, but [it's happening with low frequency on the CI](https://github.com/Mbed-TLS/mbedtls/issues/9652).

Fixes https://github.com/Mbed-TLS/mbedtls/issues/9652. Improvement filed as #9666.

## PR checklist

- [x] **changelog** not required because: test only
- [x] **development PR** here
- [x] **framework PR** not required
- [x] **3.6 PR** https://github.com/Mbed-TLS/mbedtls/pull/9655
- [x] **2.28 PR** not required because: we don't test `dtls_server` in 2.28
- **tests**  provided
