### PR TITLE
Backport 3.6: Fix driver schema json default type requirements

### DIFF
--- a/ChangeLog.d/fix-driver-schema-check.txt
+++ b/ChangeLog.d/fix-driver-schema-check.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix invalid JSON schemas for driver descriptions used by
+     generate_driver_wrappers.py.

--- a/scripts/data_files/driver_jsons/driver_opaque_schema.json
+++ b/scripts/data_files/driver_jsons/driver_opaque_schema.json
@@ -11,7 +11,7 @@
     },
     "type": {
       "type": "string",
-      "const": ["opaque"]
+      "const": "opaque"
     },
     "location": {
       "type": ["integer","string"],

--- a/scripts/data_files/driver_jsons/driver_transparent_schema.json
+++ b/scripts/data_files/driver_jsons/driver_transparent_schema.json
@@ -11,7 +11,7 @@
     },
     "type": {
       "type": "string",
-      "const": ["transparent"]
+      "const": "transparent"
     },
     "mbedtls/h_condition": {
       "type": "string"


### PR DESCRIPTION
## Description

Fix the const default value for the driver schema jsons.




## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** provided
- [x] **development PR** https://github.com/Mbed-TLS/mbedtls/pull/9674
- [x] **framework PR** not required
- [x] **3.6 PR** here
- [x] **2.28 PR** not required because: feature not in 2.28
- **tests**  not required because: no infrastructure to test driver JSON parsing
