### PR TITLE
[3.6] Fix pk write buffer overrun backport

### DIFF
--- a/tests/suites/test_suite_pkwrite.function
+++ b/tests/suites/test_suite_pkwrite.function
@@ -2,6 +2,7 @@
 #include "pk_internal.h"
 #include "mbedtls/pem.h"
 #include "mbedtls/oid.h"
+#include "mbedtls/base64.h"
 #include "psa/crypto_sizes.h"
 
 typedef enum {
@@ -72,7 +73,8 @@ static void pk_write_check_common(char *key_file, int is_public_key, int is_der)
     unsigned char *buf = NULL;
     unsigned char *check_buf = NULL;
     unsigned char *start_buf;
-    size_t buf_len, check_buf_len;
+    size_t buf_len, check_buf_len, wrong_buf_len = 1;
+    int expected_result;
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     mbedtls_svc_key_id_t opaque_id = MBEDTLS_SVC_KEY_ID_INIT;
     psa_key_attributes_t key_attr = PSA_KEY_ATTRIBUTES_INIT;
@@ -109,6 +111,17 @@ static void pk_write_check_common(char *key_file, int is_public_key, int is_der)
 
     start_buf = buf;
     buf_len = check_buf_len;
+    if (is_der) {
+        expected_result = MBEDTLS_ERR_ASN1_BUF_TOO_SMALL;
+    } else {
+        expected_result = MBEDTLS_ERR_BASE64_BUFFER_TOO_SMALL;
+    }
+    /* Intentionally pass a wrong size for the provided output buffer and check
+     * that the writing functions fails as expected. */
+    TEST_EQUAL(pk_write_any_key(&key, &start_buf, &wrong_buf_len, is_public_key,
+                                is_der), expected_result);
+    TEST_EQUAL(pk_write_any_key(&key, &start_buf, &buf_len, is_public_key,
+                                is_der), 0);
     TEST_EQUAL(pk_write_any_key(&key, &start_buf, &buf_len, is_public_key,
                                 is_der), 0);
 
@@ -127,6 +140,10 @@ static void pk_write_check_common(char *key_file, int is_public_key, int is_der)
         TEST_EQUAL(mbedtls_pk_setup_opaque(&key, opaque_id), 0);
         start_buf = buf;
         buf_len = check_buf_len;
+        /* Intentionally pass a wrong size for the provided output buffer and check
+         * that the writing functions fails as expected. */
+        TEST_EQUAL(pk_write_any_key(&key, &start_buf, &wrong_buf_len, is_public_key,
+                                    is_der), expected_result);
         TEST_EQUAL(pk_write_any_key(&key, &start_buf, &buf_len, is_public_key,
                                     is_der), 0);
 


### PR DESCRIPTION
Backport of #9690. The commit was simply cherry-picked from there.