### PR TITLE
Neon impl of ChaCha20 (better size & perf)

### DIFF
--- a/ChangeLog.d/chacha20-neon.txt
+++ b/ChangeLog.d/chacha20-neon.txt
@@ -1,3 +1,4 @@
+Features
    * ChaCha20 size and performance: add a Neon implementation of ChaCha20 for
      Thumb2 and 32 and 64-bit Arm, for Armv7 onwards. At default settings,
      this improves performance by around 2x to 2.3x on Aarch64.

--- a/ChangeLog.d/chacha20-neon.txt
+++ b/ChangeLog.d/chacha20-neon.txt
@@ -1,0 +1,3 @@
+   * ChaCha20 size and performance: add a Neon implementation of ChaCha20 for
+     Thumb2 and 32 and 64-bit Arm, for Armv7 onwards. At default settings,
+     this improves performance by around 2x to 2.3x on Aarch64.

--- a/include/mbedtls/build_info.h
+++ b/include/mbedtls/build_info.h
@@ -50,6 +50,11 @@
 #define MBEDTLS_ARCH_IS_ARM32
 #endif
 
+#if !defined(MBEDTLS_ARCH_IS_THUMB) && \
+    defined(_M_ARMT) || defined(__thumb__) || defined(__thumb2__)
+#define MBEDTLS_ARCH_IS_THUMB
+#endif
+
 #if !defined(MBEDTLS_ARCH_IS_X64) && \
     (defined(__amd64__) || defined(__x86_64__) || \
     ((defined(_M_X64) || defined(_M_AMD64)) && !defined(_M_ARM64EC)))

--- a/tests/scripts/components-configuration-crypto.sh
+++ b/tests/scripts/components-configuration-crypto.sh
@@ -2368,6 +2368,42 @@ END
     ./tf-psa-crypto/tests/test_suite_shax
 }
 
+
+support_test_chacha20_variations () {
+    case $(uname -m) in
+        aarch64) true;;
+        *) false;;
+    esac
+}
+
+component_test_chacha20_neon_variations () {
+    msg "ChaCha20 Neon scalar and multiblock variations"
+
+    # define minimal config sufficient to test ChaCha20
+     cat > include/mbedtls/mbedtls_config.h << END
+         #define MBEDTLS_AES_C
+         #define MBEDTLS_CHACHA20_C
+         #define MBEDTLS_ENTROPY_C
+         #define MBEDTLS_CTR_DRBG_C
+         #define MBEDTLS_PSA_CRYPTO_C
+         #define MBEDTLS_PSA_CRYPTO_CONFIG
+         #define MBEDTLS_SELF_TEST
+END
+
+    cat > tf-psa-crypto/include/psa/crypto_config.h << END
+        #define PSA_WANT_ALG_SHA_256   1
+END
+
+    make clean
+    for x in 0 1 2 3 4 5 6; do
+        msg "multiblock = $x"
+        make clean
+        make -C tests ../tf-psa-crypto/tests/test_suite_chacha20 CFLAGS="-DMBEDTLS_CHACHA20_NEON_MULTIBLOCK=$x"
+        ./tf-psa-crypto/tests/test_suite_chacha20
+    done
+}
+
+
 support_build_aes_aesce_armcc () {
     support_build_armcc
 }

--- a/tf-psa-crypto/drivers/builtin/include/mbedtls/chacha20.h
+++ b/tf-psa-crypto/drivers/builtin/include/mbedtls/chacha20.h
@@ -34,9 +34,9 @@ extern "C" {
 #endif
 
 typedef struct mbedtls_chacha20_context {
-    uint32_t MBEDTLS_PRIVATE(state)[16];          /*! The state (before round operations). */
-    uint8_t  MBEDTLS_PRIVATE(keystream8)[64];     /*! Leftover keystream bytes. */
-    size_t MBEDTLS_PRIVATE(keystream_bytes_used); /*! Number of keystream bytes already used. */
+    uint32_t MBEDTLS_PRIVATE(state)[16];               /*! The state (before round operations). */
+    uint8_t  MBEDTLS_PRIVATE(keystream8)[64];          /*! Leftover keystream bytes. */
+    size_t MBEDTLS_PRIVATE(keystream_bytes_remaining); /*! Number of not-used keystream bytes */
 }
 mbedtls_chacha20_context;
 

--- a/tf-psa-crypto/drivers/builtin/include/mbedtls/chacha20.h
+++ b/tf-psa-crypto/drivers/builtin/include/mbedtls/chacha20.h
@@ -34,9 +34,9 @@ extern "C" {
 #endif
 
 typedef struct mbedtls_chacha20_context {
-    uint32_t MBEDTLS_PRIVATE(state)[16];               /*! The state (before round operations). */
-    uint8_t  MBEDTLS_PRIVATE(keystream8)[64];          /*! Leftover keystream bytes. */
-    size_t MBEDTLS_PRIVATE(keystream_bytes_remaining); /*! Number of not-used keystream bytes */
+    uint32_t MBEDTLS_PRIVATE(state)[16];          /*! The state (before round operations). */
+    uint8_t  MBEDTLS_PRIVATE(keystream8)[64];     /*! Leftover keystream bytes. */
+    size_t MBEDTLS_PRIVATE(keystream_bytes_used); /*! Number of keystream bytes already used. */
 }
 mbedtls_chacha20_context;
 

--- a/tf-psa-crypto/drivers/builtin/src/chacha20.c
+++ b/tf-psa-crypto/drivers/builtin/src/chacha20.c
@@ -115,47 +115,35 @@ typedef struct {
 
 static inline chacha20_neon_regs_t chacha20_neon_singlepass(chacha20_neon_regs_t r)
 {
-    r.a = vaddq_u32(r.a, r.b);                    // r.a += b
-    r.d = veorq_u32(r.d, r.a);                    // r.d ^= a
-    r.d = chacha20_neon_vrotlq_16_u32(r.d);       // r.d <<<= 16
+    for (unsigned i = 0; i < 2; i++) {
+        r.a = vaddq_u32(r.a, r.b);                    // r.a += b
+        r.d = veorq_u32(r.d, r.a);                    // r.d ^= a
+        r.d = chacha20_neon_vrotlq_16_u32(r.d);       // r.d <<<= 16
 
-    r.c = vaddq_u32(r.c, r.d);                    // r.c += d
-    r.b = veorq_u32(r.b, r.c);                    // r.b ^= c
-    r.b = chacha20_neon_vrotlq_12_u32(r.b);       // r.b <<<= 12
+        r.c = vaddq_u32(r.c, r.d);                    // r.c += d
+        r.b = veorq_u32(r.b, r.c);                    // r.b ^= c
+        r.b = chacha20_neon_vrotlq_12_u32(r.b);       // r.b <<<= 12
 
-    r.a = vaddq_u32(r.a, r.b);                    // r.a += b
-    r.d = veorq_u32(r.d, r.a);                    // r.d ^= a
-    r.d = chacha20_neon_vrotlq_8_u32(r.d);        // r.d <<<= 8
+        r.a = vaddq_u32(r.a, r.b);                    // r.a += b
+        r.d = veorq_u32(r.d, r.a);                    // r.d ^= a
+        r.d = chacha20_neon_vrotlq_8_u32(r.d);        // r.d <<<= 8
 
-    r.c = vaddq_u32(r.c, r.d);                    // r.c += d
-    r.b = veorq_u32(r.b, r.c);                    // r.b ^= c
-    r.b = chacha20_neon_vrotlq_7_u32(r.b);        // r.b <<<= 7
+        r.c = vaddq_u32(r.c, r.d);                    // r.c += d
+        r.b = veorq_u32(r.b, r.c);                    // r.b ^= c
+        r.b = chacha20_neon_vrotlq_7_u32(r.b);        // r.b <<<= 7
 
-    // re-order b, c and d for the diagonal rounds
-    r.b = vextq_u32(r.b, r.b, 1);                 // r.b now holds positions 5,6,7,4
-    r.c = vextq_u32(r.c, r.c, 2);                 // 10, 11, 8, 9
-    r.d = vextq_u32(r.d, r.d, 3);                 // 15, 12, 13, 14
-
-    r.a = vaddq_u32(r.a, r.b);                    // r.a += b
-    r.d = veorq_u32(r.d, r.a);                    // r.d ^= a
-    r.d = chacha20_neon_vrotlq_16_u32(r.d);       // r.d <<<= 16
-
-    r.c = vaddq_u32(r.c, r.d);                    // r.c += d
-    r.b = veorq_u32(r.b, r.c);                    // r.b ^= c
-    r.b = chacha20_neon_vrotlq_12_u32(r.b);       // r.b <<<= 12
-
-    r.a = vaddq_u32(r.a, r.b);                    // r.a += b
-    r.d = veorq_u32(r.d, r.a);                    // r.d ^= a
-    r.d = chacha20_neon_vrotlq_8_u32(r.d);        // r.d <<<= 8
-
-    r.c = vaddq_u32(r.c, r.d);                    // r.c += d
-    r.b = veorq_u32(r.b, r.c);                    // r.b ^= c
-    r.b = chacha20_neon_vrotlq_7_u32(r.b);        // r.b <<<= 7
-
-    // restore element order in b, c, d
-    r.b = vextq_u32(r.b, r.b, 3);
-    r.c = vextq_u32(r.c, r.c, 2);
-    r.d = vextq_u32(r.d, r.d, 1);
+        if (i == 0) {
+            // re-order b, c and d for the diagonal rounds
+            r.b = vextq_u32(r.b, r.b, 1);                 // r.b now holds positions 5,6,7,4
+            r.c = vextq_u32(r.c, r.c, 2);                 // 10, 11, 8, 9
+            r.d = vextq_u32(r.d, r.d, 3);                 // 15, 12, 13, 14
+        } else {
+            // restore element order in b, c, d
+            r.b = vextq_u32(r.b, r.b, 3);
+            r.c = vextq_u32(r.c, r.c, 2);
+            r.d = vextq_u32(r.d, r.d, 1);
+        }
+    }
 
     return r;
 }

--- a/tf-psa-crypto/drivers/builtin/src/chacha20.c
+++ b/tf-psa-crypto/drivers/builtin/src/chacha20.c
@@ -140,8 +140,7 @@ static void chacha20_block(const uint32_t initial_state[16],
 
 void mbedtls_chacha20_init(mbedtls_chacha20_context *ctx)
 {
-    mbedtls_platform_zeroize(ctx->state, sizeof(ctx->state));
-    mbedtls_platform_zeroize(ctx->keystream8, sizeof(ctx->keystream8));
+    mbedtls_platform_zeroize(ctx, sizeof(mbedtls_chacha20_context));
 
     /* Initially, there's no keystream bytes available */
     ctx->keystream_bytes_used = CHACHA20_BLOCK_SIZE_BYTES;
@@ -164,14 +163,18 @@ int mbedtls_chacha20_setkey(mbedtls_chacha20_context *ctx,
     ctx->state[3] = 0x6b206574;
 
     /* Set key */
-    ctx->state[4]  = MBEDTLS_GET_UINT32_LE(key, 0);
-    ctx->state[5]  = MBEDTLS_GET_UINT32_LE(key, 4);
-    ctx->state[6]  = MBEDTLS_GET_UINT32_LE(key, 8);
-    ctx->state[7]  = MBEDTLS_GET_UINT32_LE(key, 12);
-    ctx->state[8]  = MBEDTLS_GET_UINT32_LE(key, 16);
-    ctx->state[9]  = MBEDTLS_GET_UINT32_LE(key, 20);
-    ctx->state[10] = MBEDTLS_GET_UINT32_LE(key, 24);
-    ctx->state[11] = MBEDTLS_GET_UINT32_LE(key, 28);
+    if (MBEDTLS_IS_BIG_ENDIAN) {
+        ctx->state[4]  = MBEDTLS_GET_UINT32_LE(key, 0);
+        ctx->state[5]  = MBEDTLS_GET_UINT32_LE(key, 4);
+        ctx->state[6]  = MBEDTLS_GET_UINT32_LE(key, 8);
+        ctx->state[7]  = MBEDTLS_GET_UINT32_LE(key, 12);
+        ctx->state[8]  = MBEDTLS_GET_UINT32_LE(key, 16);
+        ctx->state[9]  = MBEDTLS_GET_UINT32_LE(key, 20);
+        ctx->state[10] = MBEDTLS_GET_UINT32_LE(key, 24);
+        ctx->state[11] = MBEDTLS_GET_UINT32_LE(key, 28);
+    } else {
+        memcpy(&ctx->state[4], key, 32);
+    }
 
     return 0;
 }
@@ -184,9 +187,13 @@ int mbedtls_chacha20_starts(mbedtls_chacha20_context *ctx,
     ctx->state[12] = counter;
 
     /* Nonce */
-    ctx->state[13] = MBEDTLS_GET_UINT32_LE(nonce, 0);
-    ctx->state[14] = MBEDTLS_GET_UINT32_LE(nonce, 4);
-    ctx->state[15] = MBEDTLS_GET_UINT32_LE(nonce, 8);
+    if (MBEDTLS_IS_BIG_ENDIAN) {
+        ctx->state[13] = MBEDTLS_GET_UINT32_LE(nonce, 0);
+        ctx->state[14] = MBEDTLS_GET_UINT32_LE(nonce, 4);
+        ctx->state[15] = MBEDTLS_GET_UINT32_LE(nonce, 8);
+    } else {
+        memcpy(&ctx->state[13], nonce, 12);
+    }
 
     mbedtls_platform_zeroize(ctx->keystream8, sizeof(ctx->keystream8));
 

--- a/tf-psa-crypto/drivers/builtin/src/chacha20.c
+++ b/tf-psa-crypto/drivers/builtin/src/chacha20.c
@@ -104,9 +104,12 @@ static inline uint32x4_t chacha20_neon_vrotlq_7_u32(uint32x4_t v)
 // Increment the 32-bit element within v that corresponds to the ChaCha20 counter
 static inline uint32x4_t chacha20_neon_inc_counter(uint32x4_t v)
 {
-    const uint32_t inc_const_scalar[4] = { 1, 0, 0, 0 };
-    const uint32x4_t inc_const = vld1q_u32(inc_const_scalar);
-    return vaddq_u32(v, inc_const);
+    if (MBEDTLS_IS_BIG_ENDIAN) {
+        v[3]++;
+    } else {
+        v[0]++;
+    }
+    return v;
 }
 
 typedef struct {

--- a/tf-psa-crypto/drivers/builtin/src/chacha20.c
+++ b/tf-psa-crypto/drivers/builtin/src/chacha20.c
@@ -56,11 +56,20 @@
     #define MBEDTLS_CHACHA20_NEON_MULTIBLOCK 0
 #elif !defined(MBEDTLS_CHACHA20_NEON_MULTIBLOCK)
 // By default, select the best performing option that is smaller than the scalar implementation.
+#if defined(MBEDTLS_ARCH_IS_THUMB)
+// For Thumb, we need a smaller multiblock settting to be smaller than the scalar implementation
+    #if defined(MBEDTLS_COMPILER_IS_GCC)
+        #define MBEDTLS_CHACHA20_NEON_MULTIBLOCK 1
+    #else
+        #define MBEDTLS_CHACHA20_NEON_MULTIBLOCK 2
+    #endif
+#else // arm or aarch64
     #if defined(MBEDTLS_COMPILER_IS_GCC)
         #define MBEDTLS_CHACHA20_NEON_MULTIBLOCK 2
     #else
         #define MBEDTLS_CHACHA20_NEON_MULTIBLOCK 3
     #endif
+#endif
 #endif
 
 #if MBEDTLS_CHACHA20_NEON_MULTIBLOCK != 0

--- a/tf-psa-crypto/drivers/builtin/src/chacha20.c
+++ b/tf-psa-crypto/drivers/builtin/src/chacha20.c
@@ -141,9 +141,6 @@ static void chacha20_block(const uint32_t initial_state[16],
 void mbedtls_chacha20_init(mbedtls_chacha20_context *ctx)
 {
     mbedtls_platform_zeroize(ctx, sizeof(mbedtls_chacha20_context));
-
-    /* Initially, there's no keystream bytes available */
-    ctx->keystream_bytes_used = CHACHA20_BLOCK_SIZE_BYTES;
 }
 
 void mbedtls_chacha20_free(mbedtls_chacha20_context *ctx)
@@ -195,10 +192,8 @@ int mbedtls_chacha20_starts(mbedtls_chacha20_context *ctx,
         memcpy(&ctx->state[13], nonce, 12);
     }
 
-    mbedtls_platform_zeroize(ctx->keystream8, sizeof(ctx->keystream8));
-
     /* Initially, there's no keystream bytes available */
-    ctx->keystream_bytes_used = CHACHA20_BLOCK_SIZE_BYTES;
+    ctx->keystream_bytes_remaining = 0U;
 
     return 0;
 }
@@ -211,11 +206,12 @@ int mbedtls_chacha20_update(mbedtls_chacha20_context *ctx,
     size_t offset = 0U;
 
     /* Use leftover keystream bytes, if available */
-    while (size > 0U && ctx->keystream_bytes_used < CHACHA20_BLOCK_SIZE_BYTES) {
+    while (size > 0U && ctx->keystream_bytes_remaining > 0U) {
         output[offset] = input[offset]
-                         ^ ctx->keystream8[ctx->keystream_bytes_used];
+                         ^ ctx->keystream8[CHACHA20_BLOCK_SIZE_BYTES -
+                                           ctx->keystream_bytes_remaining];
 
-        ctx->keystream_bytes_used++;
+        ctx->keystream_bytes_remaining--;
         offset++;
         size--;
     }
@@ -240,7 +236,7 @@ int mbedtls_chacha20_update(mbedtls_chacha20_context *ctx,
 
         mbedtls_xor(output + offset, input + offset, ctx->keystream8, size);
 
-        ctx->keystream_bytes_used = size;
+        ctx->keystream_bytes_remaining = CHACHA20_BLOCK_SIZE_BYTES - size;
 
     }
 


### PR DESCRIPTION
## Description

Neon implementation of ChaCha20 which, depending on how it's configured, is ~500b smaller than the scalar impl, or up to 4.6x faster. In its default setting it has slightly better code size than the scalar impl, and is 2-2.3x faster.

Tested on all combinations of Armv7 arm/thumb2; Armv8 arm/thumb2/aarch64 on clang 14, gcc 11, and some more recent versions, plus Armv8 aarch64_be on gcc 7.5.

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** provided | not required because: 
- [ ] **development PR** provided # | not required because: 
- [ ] **framework PR** provided Mbed-TLS/mbedtls-framework# | not required
- [x] **3.6 PR** not required because: non-functional change
- [x] **2.28 PR** not required because: non-functional change
- **tests**  provided

| | multiblock setting | size delta c.f. main | perf delta c.f. main |
| --- | --- | --- | --- |
| clang | 0 | -180 | 0% |
| | 1 | -624 | 14% |
|  | 2 | -416 | 64% |
|  | 3 | -216 | 98% |
|  | 4 | 12 | 172% |
|  | 5 | 288 | 161% |
|  | 6 | 520 | 224% |
|  |  |  |  |
| gcc | 0 | -128 | 0% |
| | 1 | -576 | 57% |
|  | 2 | -332 | 129% |
|  | 3 | -56 | 177% |
|  | 4 | 252 | 280% |
|  | 5 | 608 | 273% |
|  | 6 | 744 | 355% |
