### PR TITLE
Align development 3.6 test helpers with ssl helpers and `certs.c`

### DIFF
--- a/tests/include/test/psa_crypto_helpers.h
+++ b/tests/include/test/psa_crypto_helpers.h
@@ -11,7 +11,10 @@
 
 #include "test/helpers.h"
 
-#if defined(MBEDTLS_PSA_CRYPTO_CLIENT)
+#if ((MBEDTLS_VERSION_MAJOR < 4) \
+    && defined(MBEDTLS_PSA_CRYPTO_C)) \
+    || (MBEDTLS_VERSION_MAJOR >= 4 \
+        && defined(MBEDTLS_PSA_CRYPTO_CLIENT))
 #include "test/psa_helpers.h"
 #include <psa/crypto.h>
 #endif
@@ -40,7 +43,8 @@
         mbedtls_psa_crypto_free();                                      \
     }                                                                   \
     while (0)
-#elif defined(MBEDTLS_PSA_CRYPTO_CLIENT) /* MBEDTLS_PSA_CRYPTO_CLIENT && !MBEDTLS_PSA_CRYPTO_C */
+#elif MBEDTLS_VERSION_MAJOR >= 4 && \
+    defined(MBEDTLS_PSA_CRYPTO_CLIENT)   /* MBEDTLS_PSA_CRYPTO_CLIENT && !MBEDTLS_PSA_CRYPTO_C */
 #define PSA_INIT() PSA_ASSERT(psa_crypto_init())
 #define PSA_DONE() mbedtls_psa_crypto_free();
 #else  /* MBEDTLS_PSA_CRYPTO_CLIENT && !MBEDTLS_PSA_CRYPTO_C */
@@ -48,7 +52,10 @@
 #define PSA_DONE() ((void) 0)
 #endif /* MBEDTLS_PSA_CRYPTO_C */
 
-#if defined(MBEDTLS_PSA_CRYPTO_CLIENT)
+#if ((MBEDTLS_VERSION_MAJOR < 4) \
+    && defined(MBEDTLS_PSA_CRYPTO_C)) \
+    || (MBEDTLS_VERSION_MAJOR >= 4 \
+        && defined(MBEDTLS_PSA_CRYPTO_CLIENT))
 
 #if defined(MBEDTLS_PSA_CRYPTO_STORAGE_C)
 
@@ -319,7 +326,7 @@ uint64_t mbedtls_test_parse_binary_string(data_t *bin_string);
     }                                                                      \
     while (0)
 
-#endif /* MBEDTLS_PSA_CRYPTO_CLIENT */
+#endif /* MBEDTLS_PSA_CRYPTO_CLIENT || MBEDTLS_PSA_CRYPTO_C */
 
 /** \def USE_PSA_INIT
  *

--- a/tests/include/test/psa_crypto_helpers.h
+++ b/tests/include/test/psa_crypto_helpers.h
@@ -253,7 +253,9 @@ uint64_t mbedtls_test_parse_binary_string(data_t *bin_string);
  *  \param key_type  Key type
  *  \param key_bits  Key length in number of bits.
  */
-#if defined(MBEDTLS_PSA_ACCEL_KEY_TYPE_AES)
+#if defined(MBEDTLS_AES_ALT) || \
+    defined(MBEDTLS_AES_SETKEY_ENC_ALT) || \
+    defined(MBEDTLS_PSA_ACCEL_KEY_TYPE_AES)
 #define MBEDTLS_TEST_HAVE_ALT_AES 1
 #else
 #define MBEDTLS_TEST_HAVE_ALT_AES 0
@@ -295,7 +297,8 @@ uint64_t mbedtls_test_parse_binary_string(data_t *bin_string);
  *  \param  nonce_length    The nonce length in number of bytes.
  */
 
-#if defined(MBEDTLS_PSA_ACCEL_ALG_GCM)
+#if defined(MBEDTLS_GCM_ALT) || \
+    defined(MBEDTLS_PSA_ACCEL_ALG_GCM)
 #define MBEDTLS_TEST_HAVE_ACCEL_GCM  1
 #else
 #define MBEDTLS_TEST_HAVE_ACCEL_GCM  0

--- a/tests/include/test/ssl_helpers.h
+++ b/tests/include/test/ssl_helpers.h
@@ -38,21 +38,24 @@
 #endif
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
-#if defined(PSA_WANT_KEY_TYPE_AES)
-#if defined(PSA_WANT_ALG_GCM)
-#if defined(PSA_WANT_ALG_SHA_384)
+#if defined(MBEDTLS_SSL_HAVE_AES) || defined(PSA_WANT_KEY_TYPE_AES)
+#if defined(MBEDTLS_SSL_HAVE_GCM) || defined(PSA_WANT_ALG_GCM)
+#if defined(MBEDTLS_MD_CAN_SHA384) || defined(PSA_WANT_ALG_SHA384)
 #define MBEDTLS_TEST_HAS_TLS1_3_AES_256_GCM_SHA384
 #endif
-#if defined(PSA_WANT_ALG_SHA_256)
+#if defined(MBEDTLS_MD_CAN_SHA256) \
+    || defined(PSA_WANT_ALG_SHA_256)
 #define MBEDTLS_TEST_HAS_TLS1_3_AES_128_GCM_SHA256
 #endif
-#endif /* PSA_WANT_ALG_GCM */
-#if defined(PSA_WANT_ALG_CCM) && defined(PSA_WANT_ALG_SHA_256)
+#endif /* MBEDTLS_SSL_HAVE_GCM || PSA_WANT_ALG_GCM */
+#if (defined(MBEDTLS_SSL_HAVE_CCM) && defined(MBEDTLS_MD_CAN_SHA256)) \
+    || (defined(PSA_WANT_ALG_CCM) && defined(PSA_WANT_ALG_SHA_256))
 #define MBEDTLS_TEST_HAS_TLS1_3_AES_128_CCM_SHA256
 #define MBEDTLS_TEST_HAS_TLS1_3_AES_128_CCM_8_SHA256
 #endif
-#endif /* PSA_WANT_KEY_TYPE_AES */
-#if defined(PSA_WANT_ALG_CHACHA20_POLY1305) && defined(PSA_WANT_ALG_SHA_256)
+#endif /* MBEDTLS_SSL_HAVE_AES || PSA_WANT_KEY_TYPE_AES */
+#if (defined(MBEDTLS_SSL_HAVE_CHACHAPOLY) && defined(MBEDTLS_MD_CAN_SHA256)) \
+    || (defined(PSA_WANT_ALG_CHACHA20_POLY1305) && defined(PSA_WANT_ALG_SHA_256))
 #define MBEDTLS_TEST_HAS_TLS1_3_CHACHA20_POLY1305_SHA256
 #endif
 
@@ -501,7 +504,8 @@ int mbedtls_test_move_handshake_to_state(mbedtls_ssl_context *ssl,
 #endif
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_2) && \
-    defined(PSA_WANT_ALG_CBC_NO_PADDING) && defined(PSA_WANT_KEY_TYPE_AES)
+    ((defined(MBEDTLS_SSL_HAVE_CBC) && defined(MBEDTLS_SSL_HAVE_AES)) \
+    || (defined(PSA_WANT_ALG_CBC_NO_PADDING) && defined(PSA_WANT_KEY_TYPE_AES)))
 int mbedtls_test_psa_cipher_encrypt_helper(mbedtls_ssl_transform *transform,
                                            const unsigned char *iv,
                                            size_t iv_len,
@@ -509,8 +513,9 @@ int mbedtls_test_psa_cipher_encrypt_helper(mbedtls_ssl_transform *transform,
                                            size_t ilen,
                                            unsigned char *output,
                                            size_t *olen);
-#endif /* MBEDTLS_SSL_PROTO_TLS1_2 && PSA_WANT_ALG_CBC_NO_PADDING &&
-          PSA_WANT_KEY_TYPE_AES */
+#endif /* MBEDTLS_SSL_PROTO_TLS1_2 &&
+          (MBEDTLS_SSL_HAVE_CBC && MBEDTLS_SSL_HAVE_AES)
+        || (PSA_WANT_ALG_CBC_NO_PADDING && PSA_WANT_KEY_TYPE_AES) */
 
 int mbedtls_test_ssl_build_transforms(mbedtls_ssl_transform *t_in,
                                       mbedtls_ssl_transform *t_out,

--- a/tests/src/certs.c
+++ b/tests/src/certs.c
@@ -301,13 +301,13 @@ const size_t mbedtls_test_cli_crt_ec_len =
  * Dispatch between SHA-1 and SHA-256
  */
 
-#if defined(PSA_WANT_ALG_SHA_256)
+#if defined(MBEDTLS_MD_CAN_SHA256) || defined(PSA_WANT_ALG_SHA_256)
 #define TEST_CA_CRT_RSA  TEST_CA_CRT_RSA_SHA256
 #define TEST_SRV_CRT_RSA TEST_SRV_CRT_RSA_SHA256
 #else
 #define TEST_CA_CRT_RSA  TEST_CA_CRT_RSA_SHA1
 #define TEST_SRV_CRT_RSA TEST_SRV_CRT_RSA_SHA1
-#endif /* PSA_WANT_ALG_SHA_256 */
+#endif /* MBEDTLS_MD_CAN_SHA256 || PSA_WANT_ALG_SHA_256 */
 
 const char mbedtls_test_ca_crt_rsa[]  = TEST_CA_CRT_RSA;
 const char mbedtls_test_srv_crt_rsa[] = TEST_SRV_CRT_RSA;
@@ -406,25 +406,33 @@ const size_t mbedtls_test_cli_crt_len =
 
 /* List of CAs in PEM or DER, depending on config */
 const char *mbedtls_test_cas[] = {
-#if defined(MBEDTLS_RSA_C) && defined(PSA_WANT_ALG_SHA_1)
+#if defined(MBEDTLS_RSA_C) && \
+    (defined(MBEDTLS_MD_CAN_SHA1) \
+    || defined(PSA_WANT_ALG_SHA_1))
     mbedtls_test_ca_crt_rsa_sha1,
 #endif
-#if defined(MBEDTLS_RSA_C) && defined(PSA_WANT_ALG_SHA_256)
+#if defined(MBEDTLS_RSA_C) && \
+    (defined(MBEDTLS_MD_CAN_SHA256) \
+    || defined(PSA_WANT_ALG_SHA_256))
     mbedtls_test_ca_crt_rsa_sha256,
 #endif
-#if defined(PSA_HAVE_ALG_SOME_ECDSA)
+#if defined(MBEDTLS_PK_CAN_ECDSA_SOME) || defined(PSA_HAVE_ALG_SOME_ECDSA)
     mbedtls_test_ca_crt_ec,
 #endif
     NULL
 };
 const size_t mbedtls_test_cas_len[] = {
-#if defined(MBEDTLS_RSA_C) && defined(PSA_WANT_ALG_SHA_1)
+#if defined(MBEDTLS_RSA_C) && \
+    (defined(MBEDTLS_MD_CAN_SHA1) \
+    || defined(PSA_WANT_ALG_SHA_1))
     sizeof(mbedtls_test_ca_crt_rsa_sha1),
 #endif
-#if defined(MBEDTLS_RSA_C) && defined(PSA_WANT_ALG_SHA_256)
+#if defined(MBEDTLS_RSA_C) && \
+    (defined(MBEDTLS_MD_CAN_SHA256) \
+    || defined(PSA_WANT_ALG_SHA_256))
     sizeof(mbedtls_test_ca_crt_rsa_sha256),
 #endif
-#if defined(PSA_HAVE_ALG_SOME_ECDSA)
+#if defined(MBEDTLS_PK_CAN_ECDSA_SOME) || defined(PSA_HAVE_ALG_SOME_ECDSA)
     sizeof(mbedtls_test_ca_crt_ec),
 #endif
     0
@@ -433,31 +441,33 @@ const size_t mbedtls_test_cas_len[] = {
 /* List of all available CA certificates in DER format */
 const unsigned char *mbedtls_test_cas_der[] = {
 #if defined(MBEDTLS_RSA_C)
-#if defined(PSA_WANT_ALG_SHA_256)
+#if (defined(MBEDTLS_MD_CAN_SHA256) \
+    || defined(PSA_WANT_ALG_SHA_256))
     mbedtls_test_ca_crt_rsa_sha256_der,
-#endif /* PSA_WANT_ALG_SHA_256 */
-#if defined(PSA_WANT_ALG_SHA_1)
+#endif /* MBEDTLS_MD_CAN_SHA256 || PSA_WANT_ALG_SHA_256 */
+#if defined(MBEDTLS_MD_CAN_SHA1) || defined(PSA_WANT_ALG_SHA_1)
     mbedtls_test_ca_crt_rsa_sha1_der,
-#endif /* PSA_WANT_ALG_SHA_1 */
+#endif /* MBEDTLS_MD_CAN_SHA1 || PSA_WANT_ALG_SHA_1 */
 #endif /* MBEDTLS_RSA_C */
-#if defined(PSA_HAVE_ALG_SOME_ECDSA)
+#if defined(MBEDTLS_PK_CAN_ECDSA_SOME) || defined(PSA_HAVE_ALG_SOME_ECDSA)
     mbedtls_test_ca_crt_ec_der,
-#endif /* PSA_HAVE_ALG_SOME_ECDSA */
+#endif /* MBEDTLS_PK_CAN_ECDSA_SOME || PSA_HAVE_ALG_SOME_ECDSA */
     NULL
 };
 
 const size_t mbedtls_test_cas_der_len[] = {
 #if defined(MBEDTLS_RSA_C)
-#if defined(PSA_WANT_ALG_SHA_256)
+#if defined(MBEDTLS_MD_CAN_SHA256) \
+    || defined(PSA_WANT_ALG_SHA_256)
     sizeof(mbedtls_test_ca_crt_rsa_sha256_der),
-#endif /* PSA_WANT_ALG_SHA_256 */
-#if defined(PSA_WANT_ALG_SHA_1)
+#endif /* MBEDTLS_MD_CAN_SHA256 || PSA_WANT_ALG_SHA_256 */
+#if defined(MBEDTLS_MD_CAN_SHA1) || defined(PSA_WANT_ALG_SHA_1)
     sizeof(mbedtls_test_ca_crt_rsa_sha1_der),
-#endif /* PSA_WANT_ALG_SHA_1 */
+#endif /* MBEDTLS_MD_CAN_SHA1 || PSA_WANT_ALG_SHA_1 */
 #endif /* MBEDTLS_RSA_C */
-#if defined(PSA_HAVE_ALG_SOME_ECDSA)
+#if defined(MBEDTLS_PK_CAN_ECDSA_SOME) || defined(PSA_HAVE_ALG_SOME_ECDSA)
     sizeof(mbedtls_test_ca_crt_ec_der),
-#endif /* PSA_HAVE_ALG_SOME_ECDSA */
+#endif /* MBEDTLS_PK_CAN_ECDSA_SOME || PSA_HAVE_ALG_SOME_ECDSA */
     0
 };
 
@@ -465,16 +475,17 @@ const size_t mbedtls_test_cas_der_len[] = {
 #if defined(MBEDTLS_PEM_PARSE_C)
 const char mbedtls_test_cas_pem[] =
 #if defined(MBEDTLS_RSA_C)
-#if defined(PSA_WANT_ALG_SHA_256)
+#if defined(MBEDTLS_MD_CAN_SHA256) \
+    || defined(PSA_WANT_ALG_SHA_256)
     TEST_CA_CRT_RSA_SHA256_PEM
-#endif /* PSA_WANT_ALG_SHA_256 */
-#if defined(PSA_WANT_ALG_SHA_1)
+#endif /* MBEDTLS_MD_CAN_SHA256 || PSA_WANT_ALG_SHA_256 */
+#if defined(MBEDTLS_MD_CAN_SHA1) || defined(PSA_WANT_ALG_SHA_1)
     TEST_CA_CRT_RSA_SHA1_PEM
-#endif /* PSA_WANT_ALG_SHA_1 */
+#endif /* MBEDTLS_MD_CAN_SHA1 || PSA_WANT_ALG_SHA_1 */
 #endif /* MBEDTLS_RSA_C */
-#if defined(PSA_HAVE_ALG_SOME_ECDSA)
+#if defined(MBEDTLS_PK_CAN_ECDSA_SOME) || defined(PSA_HAVE_ALG_SOME_ECDSA)
     TEST_CA_CRT_EC_PEM
-#endif /* PSA_HAVE_ALG_SOME_ECDSA */
+#endif /* MBEDTLS_PK_CAN_ECDSA_SOME || PSA_HAVE_ALG_SOME_ECDSA */
     "";
 const size_t mbedtls_test_cas_pem_len = sizeof(mbedtls_test_cas_pem);
 #endif /* MBEDTLS_PEM_PARSE_C */

--- a/tests/src/drivers/hash.c
+++ b/tests/src/drivers/hash.c
@@ -13,7 +13,11 @@
 #include "test/drivers/hash.h"
 
 #if defined(MBEDTLS_TEST_LIBTESTDRIVER1)
+#if MBEDTLS_VERSION_MAJOR < 4
+#include "libtestdriver1/library/psa_crypto_hash.h"
+#else
 #include "libtestdriver1/tf-psa-crypto/drivers/builtin/src/psa_crypto_hash.h"
+#endif
 #endif
 
 mbedtls_test_driver_hash_hooks_t

--- a/tests/src/drivers/test_driver_aead.c
+++ b/tests/src/drivers/test_driver_aead.c
@@ -16,7 +16,11 @@
 #include "mbedtls/constant_time.h"
 
 #if defined(MBEDTLS_TEST_LIBTESTDRIVER1)
+#if MBEDTLS_VERSION_MAJOR < 4
+#include "libtestdriver1/library/psa_crypto_aead.h"
+#else
 #include "libtestdriver1/tf-psa-crypto/drivers/builtin/src/psa_crypto_aead.h"
+#endif
 #endif
 
 mbedtls_test_driver_aead_hooks_t

--- a/tests/src/drivers/test_driver_asymmetric_encryption.c
+++ b/tests/src/drivers/test_driver_asymmetric_encryption.c
@@ -16,7 +16,11 @@
 #include "test/drivers/key_management.h"
 
 #if defined(MBEDTLS_TEST_LIBTESTDRIVER1)
+#if MBEDTLS_VERSION_MAJOR < 4
+#include "libtestdriver1/library/psa_crypto_rsa.h"
+#else
 #include "libtestdriver1/tf-psa-crypto/drivers/builtin/src/psa_crypto_rsa.h"
+#endif
 #endif
 
 #define PSA_RSA_KEY_PAIR_MAX_SIZE \

--- a/tests/src/drivers/test_driver_cipher.c
+++ b/tests/src/drivers/test_driver_cipher.c
@@ -19,7 +19,11 @@
 #include "test/random.h"
 
 #if defined(MBEDTLS_TEST_LIBTESTDRIVER1)
+#if MBEDTLS_VERSION_MAJOR < 4
+#include "libtestdriver1/library/psa_crypto_cipher.h"
+#else
 #include "libtestdriver1/tf-psa-crypto/drivers/builtin/src/psa_crypto_cipher.h"
+#endif
 #endif
 
 #include <string.h>

--- a/tests/src/drivers/test_driver_key_agreement.c
+++ b/tests/src/drivers/test_driver_key_agreement.c
@@ -20,9 +20,15 @@
 #include <string.h>
 
 #if defined(MBEDTLS_TEST_LIBTESTDRIVER1)
+#if MBEDTLS_VERSION_MAJOR < 4
+#include "libtestdriver1/include/psa/crypto.h"
+#include "libtestdriver1/library/psa_crypto_ecp.h"
+#include "libtestdriver1/library/psa_crypto_ffdh.h"
+#else
 #include "libtestdriver1/tf-psa-crypto/include/psa/crypto.h"
 #include "libtestdriver1/tf-psa-crypto/drivers/builtin/src/psa_crypto_ecp.h"
 #include "libtestdriver1/tf-psa-crypto/drivers/builtin/src/psa_crypto_ffdh.h"
+#endif
 #endif
 
 mbedtls_test_driver_key_agreement_hooks_t

--- a/tests/src/drivers/test_driver_key_management.c
+++ b/tests/src/drivers/test_driver_key_management.c
@@ -23,9 +23,15 @@
 #include "test/random.h"
 
 #if defined(MBEDTLS_TEST_LIBTESTDRIVER1)
+#if MBEDTLS_VERSION_MAJOR < 4
+#include "libtestdriver1/library/psa_crypto_ecp.h"
+#include "libtestdriver1/library/psa_crypto_rsa.h"
+#include "libtestdriver1/library/psa_crypto_ffdh.h"
+#else
 #include "libtestdriver1/tf-psa-crypto/drivers/builtin/src/psa_crypto_ecp.h"
 #include "libtestdriver1/tf-psa-crypto/drivers/builtin/src/psa_crypto_rsa.h"
 #include "libtestdriver1/tf-psa-crypto/drivers/builtin/src/psa_crypto_ffdh.h"
+#endif
 #endif
 
 #include <string.h>

--- a/tests/src/drivers/test_driver_mac.c
+++ b/tests/src/drivers/test_driver_mac.c
@@ -13,7 +13,11 @@
 #include "test/drivers/mac.h"
 
 #if defined(MBEDTLS_TEST_LIBTESTDRIVER1)
+#if MBEDTLS_VERSION_MAJOR < 4
+#include "libtestdriver1/library/psa_crypto_mac.h"
+#else
 #include "libtestdriver1/tf-psa-crypto/drivers/builtin/src/psa_crypto_mac.h"
+#endif
 #endif
 
 mbedtls_test_driver_mac_hooks_t mbedtls_test_driver_mac_hooks =

--- a/tests/src/drivers/test_driver_pake.c
+++ b/tests/src/drivers/test_driver_pake.c
@@ -14,7 +14,11 @@
 #include "string.h"
 
 #if defined(MBEDTLS_TEST_LIBTESTDRIVER1)
+#if MBEDTLS_VERSION_MAJOR < 4
+#include "libtestdriver1/library/psa_crypto_pake.h"
+#else
 #include "libtestdriver1/tf-psa-crypto/drivers/builtin/src/psa_crypto_pake.h"
+#endif
 #endif
 
 mbedtls_test_driver_pake_hooks_t mbedtls_test_driver_pake_hooks =

--- a/tests/src/drivers/test_driver_signature.c
+++ b/tests/src/drivers/test_driver_signature.c
@@ -26,9 +26,15 @@
 #include "test/random.h"
 
 #if defined(MBEDTLS_TEST_LIBTESTDRIVER1)
+#if MBEDTLS_VERSION_MAJOR < 4
+#include "libtestdriver1/library/psa_crypto_ecp.h"
+#include "libtestdriver1/library/psa_crypto_hash.h"
+#include "libtestdriver1/library/psa_crypto_rsa.h"
+#else
 #include "libtestdriver1/tf-psa-crypto/drivers/builtin/src/psa_crypto_ecp.h"
 #include "libtestdriver1/tf-psa-crypto/drivers/builtin/src/psa_crypto_hash.h"
 #include "libtestdriver1/tf-psa-crypto/drivers/builtin/src/psa_crypto_rsa.h"
+#endif
 #endif
 
 #include <string.h>

--- a/tests/src/psa_exercise_key.c
+++ b/tests/src/psa_exercise_key.c
@@ -11,7 +11,9 @@
 #include <test/macros.h>
 #include <test/psa_exercise_key.h>
 
-#if defined(MBEDTLS_PSA_CRYPTO_CLIENT)
+#if ((MBEDTLS_VERSION_MAJOR < 4) \
+    && defined(MBEDTLS_PSA_CRYPTO_C)) \
+    || defined(MBEDTLS_PSA_CRYPTO_CLIENT)
 
 #include <mbedtls/asn1.h>
 #include <psa/crypto.h>
@@ -1332,4 +1334,4 @@ exit:
 }
 #endif /* MBEDTLS_PK_C */
 
-#endif /* MBEDTLS_PSA_CRYPTO_CLIENT */
+#endif /* MBEDTLS_PSA_CRYPTO_C || MBEDTLS_PSA_CRYPTO_CLIENT */

--- a/tests/src/psa_exercise_key.c
+++ b/tests/src/psa_exercise_key.c
@@ -13,7 +13,8 @@
 
 #if ((MBEDTLS_VERSION_MAJOR < 4) \
     && defined(MBEDTLS_PSA_CRYPTO_C)) \
-    || defined(MBEDTLS_PSA_CRYPTO_CLIENT)
+    || (MBEDTLS_VERSION_MAJOR >= 4 \
+        && defined(MBEDTLS_PSA_CRYPTO_CLIENT))
 
 #include <mbedtls/asn1.h>
 #include <psa/crypto.h>

--- a/tests/src/test_helpers/ssl_helpers.c
+++ b/tests/src/test_helpers/ssl_helpers.c
@@ -2543,6 +2543,11 @@ int mbedtls_test_get_tls13_ticket(
                                          server_options, NULL, NULL, NULL);
     TEST_EQUAL(ret, 0);
 
+#if MBEDTLS_VERSION_MAJOR < 4
+    mbedtls_ssl_conf_tls13_enable_signal_new_session_tickets(
+        &client_ep.conf, MBEDTLS_SSL_TLS1_3_SIGNAL_NEW_SESSION_TICKETS_ENABLED);
+#endif
+
     mbedtls_ssl_conf_session_tickets_cb(&server_ep.conf,
                                         mbedtls_test_ticket_write,
                                         mbedtls_test_ticket_parse,

--- a/tests/src/test_helpers/ssl_helpers.c
+++ b/tests/src/test_helpers/ssl_helpers.c
@@ -1082,7 +1082,8 @@ static int psk_dummy_callback(void *p_info, mbedtls_ssl_context *ssl,
           MBEDTLS_SSL_SRV_C */
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_2) && \
-    defined(PSA_WANT_ALG_CBC_NO_PADDING) && defined(PSA_WANT_KEY_TYPE_AES)
+    ((defined(MBEDTLS_SSL_HAVE_CBC) && defined(MBEDTLS_SSL_HAVE_AES)) \
+    || (defined(PSA_WANT_ALG_CBC_NO_PADDING) && defined(PSA_WANT_KEY_TYPE_AES)))
 int mbedtls_test_psa_cipher_encrypt_helper(mbedtls_ssl_transform *transform,
                                            const unsigned char *iv,
                                            size_t iv_len,
@@ -1130,8 +1131,9 @@ int mbedtls_test_psa_cipher_encrypt_helper(mbedtls_ssl_transform *transform,
                                 iv, iv_len, input, ilen, output, olen);
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 }
-#endif /* MBEDTLS_SSL_PROTO_TLS1_2 && PSA_WANT_ALG_CBC_NO_PADDING &&
-          PSA_WANT_KEY_TYPE_AES */
+#endif /* MBEDTLS_SSL_PROTO_TLS1_2 &&
+          ((MBEDTLS_SSL_HAVE_CBC && MBEDTLS_SSL_HAVE_AES)
+        || (PSA_WANT_ALG_CBC_NO_PADDING && PSA_WANT_KEY_TYPE_AES)) */
 
 static void mbedtls_test_ssl_cipher_info_from_type(mbedtls_cipher_type_t cipher_type,
                                                    mbedtls_cipher_mode_t *cipher_mode,


### PR DESCRIPTION
Previous state of #9430 with the full scope (in case we need to harmonize the ssl helpers and `certs.c` later).

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [ ] **changelog** provided | not required because: 
- [ ] **development PR** provided # | not required because: 
- [ ] **framework PR** provided Mbed-TLS/mbedtls-framework# | not required
- [ ] **3.6 PR** provided # | not required because: 
- [ ] **2.28 PR** provided # | not required because: 
- **tests**  provided | not required because: 
