### PR TITLE
[Backport 3.6] net/mbedtls_net_connect: Preventing double close problem

### DIFF
--- a/ChangeLog.d/replace-close-with-mbedtls_net_close.txt
+++ b/ChangeLog.d/replace-close-with-mbedtls_net_close.txt
@@ -1,0 +1,4 @@
+Bugfix
+   * Use 'mbedtls_net_close' instead of 'close' in 'mbedtls_net_bind'
+     and 'mbedtls_net_connect' to prevent possible double close fd
+     problems. Fixes #9711.

--- a/library/net_sockets.c
+++ b/library/net_sockets.c
@@ -190,7 +190,7 @@ int mbedtls_net_connect(mbedtls_net_context *ctx, const char *host,
             break;
         }
 
-        close(ctx->fd);
+        mbedtls_net_close(ctx);
         ret = MBEDTLS_ERR_NET_CONNECT_FAILED;
     }
 
@@ -237,13 +237,13 @@ int mbedtls_net_bind(mbedtls_net_context *ctx, const char *bind_ip, const char *
         n = 1;
         if (setsockopt(ctx->fd, SOL_SOCKET, SO_REUSEADDR,
                        (const char *) &n, sizeof(n)) != 0) {
-            close(ctx->fd);
+            mbedtls_net_close(ctx);
             ret = MBEDTLS_ERR_NET_SOCKET_FAILED;
             continue;
         }
 
         if (bind(ctx->fd, cur->ai_addr, MSVC_INT_CAST cur->ai_addrlen) != 0) {
-            close(ctx->fd);
+            mbedtls_net_close(ctx);
             ret = MBEDTLS_ERR_NET_BIND_FAILED;
             continue;
         }
@@ -251,7 +251,7 @@ int mbedtls_net_bind(mbedtls_net_context *ctx, const char *bind_ip, const char *
         /* Listen only makes sense for TCP */
         if (proto == MBEDTLS_NET_PROTO_TCP) {
             if (listen(ctx->fd, MBEDTLS_NET_LISTEN_BACKLOG) != 0) {
-                close(ctx->fd);
+                mbedtls_net_close(ctx);
                 ret = MBEDTLS_ERR_NET_LISTEN_FAILED;
                 continue;
             }


### PR DESCRIPTION
In the test examples and real usage scenarios, 'mbedtls_net_free' is called after 'mbedtls_net_connect' fails, which will cause the problem of double close the same fd. It is possible to close this closed fd which has been applied by other link.

## Description

hi all. We found that in the scenario of sudden network disconnection, ‘mbedtls_net_connect’ will close fd after the connection fails, and then call ‘mbedtls_net_free’ to close it again. There is a risk of double close here. At first, we suspected that it was used incorrectly, but after referring to the implementation and case in the programs directory, we did not find that it was a usage error. Therefore, we suggest to mark fd as unavailable after closing it to prevent fd from being used by other programs during the interval between 'mbedtls_net_connect' and 'mbedtls_net_free'.



## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** provided
- [x] **development PR** provided #9711 
- [x] **framework PR** not required
- [x] **3.6 PR** here
- [x] **2.28 PR** provided #9715 
- **tests**  not required because: minor change, testing would require help from the OS

## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
