### PR TITLE
All.sh add support for tf-psa-crypto components

### DIFF
--- a/tests/scripts/all-core.sh
+++ b/tests/scripts/all-core.sh
@@ -156,8 +156,8 @@ pre_check_environment () {
 # Must be called before pre_initialize_variables which sets ALL_COMPONENTS.
 pre_load_components () {
     # Include the components from components.sh
-    test_script_dir="${0%/*}"
-    for file in "$test_script_dir"/components-*.sh; do
+    # Use a path relative to the current directory, aka project's root.
+    for file in tests/scripts/components-*.sh; do
         source $file
     done
 }
@@ -864,7 +864,8 @@ pre_check_tools () {
             set "$@" ARMC5_CC="$ARMC5_CC" ARMC6_CC="$ARMC6_CC" RUN_ARMCC=1;;
         *) set "$@" RUN_ARMCC=0;;
     esac
-    "$@" scripts/output_env.sh
+    # Use a path relative to the currently-sourced file.
+    "$@" "${BASH_SOURCE%/*}"/../../scripts/output_env.sh
 }
 
 pre_generate_files() {
@@ -879,8 +880,8 @@ pre_generate_files() {
 }
 
 pre_load_helpers () {
-    # The path is going to change when this is moved to the framework
-    test_script_dir="${0%/*}"
+    # Use a path relative to the currently-sourced file.
+    test_script_dir="${BASH_SOURCE%/*}"
     source "$test_script_dir"/all-helpers.sh
 }
 

--- a/tests/scripts/all-core.sh
+++ b/tests/scripts/all-core.sh
@@ -109,11 +109,12 @@
 # means that components can assume that the working directory is in a
 # cleaned-up state, and don't need to perform the cleanup themselves.
 # * Run `make clean`.
-# * Restore `include/mbedtls/mbedtls_config.h` from a backup made before running
-#   the component.
-# * Check out `Makefile`, `library/Makefile`, `programs/Makefile`,
-#   `tests/Makefile` and `programs/fuzz/Makefile` from git.
-#   This cleans up after an in-tree use of CMake.
+# * Restore the various config files (potentially modified by config.py) from
+#   a backup made when starting the script.
+# * If in Mbed TLS, restore the various `Makefile`s (potentially modified by
+#   in-tree use of CMake) from a backup made when starting the script. (Note:
+#   if the files look generated when starting the script, they will be
+#   restored from the git index before making the backup.)
 
 
 ################################################################
@@ -165,6 +166,7 @@ pre_load_components () {
 pre_initialize_variables () {
     if in_mbedtls_repo; then
         CONFIG_H='include/mbedtls/mbedtls_config.h'
+        CONFIG_TEST_DRIVER_H='tests/include/test/drivers/config_test_driver.h'
         if [ -d tf-psa-crypto ]; then
             CRYPTO_CONFIG_H='tf-psa-crypto/include/psa/crypto_config.h'
             PSA_CORE_PATH='tf-psa-crypto/core'
@@ -176,20 +178,21 @@ pre_initialize_variables () {
             PSA_CORE_PATH=''
             BUILTIN_SRC_PATH=''
         fi
+        config_files="$CONFIG_H $CRYPTO_CONFIG_H $CONFIG_TEST_DRIVER_H"
     else
-        CONFIG_H='drivers/builtin/include/mbedtls/mbedtls_config.h'
         CRYPTO_CONFIG_H='include/psa/crypto_config.h'
         PSA_CORE_PATH='core'
         BUILTIN_SRC_PATH='drivers/builtin/src'
+
+        config_files="$CRYPTO_CONFIG_H"
     fi
-    CONFIG_TEST_DRIVER_H='tests/include/test/drivers/config_test_driver.h'
 
     # Files that are clobbered by some jobs will be backed up. Use a different
     # suffix from auxiliary scripts so that all.sh and auxiliary scripts can
     # independently decide when to remove the backup file.
     backup_suffix='.all.bak'
     # Files clobbered by config.py
-    files_to_back_up="$CONFIG_H $CRYPTO_CONFIG_H $CONFIG_TEST_DRIVER_H"
+    files_to_back_up="$config_files"
     if in_mbedtls_repo; then
         # Files clobbered by in-tree cmake
         files_to_back_up="$files_to_back_up Makefile library/Makefile programs/Makefile tests/Makefile programs/fuzz/Makefile"
@@ -616,7 +619,7 @@ pre_parse_command_line () {
 pre_check_git () {
     if [ $FORCE -eq 1 ]; then
         rm -rf "$OUT_OF_SOURCE_DIR"
-        git checkout-index -f -q $CONFIG_H
+        git checkout-index -f -q $config_files
         cleanup
     else
 
@@ -627,12 +630,14 @@ pre_check_git () {
             exit 1
         fi
 
-        if ! git diff --quiet "$CONFIG_H"; then
-            err_msg "Warning - the configuration file '$CONFIG_H' has been edited. "
-            echo "You can either delete or preserve your work, or force the test by rerunning the"
-            echo "script as: $0 --force"
-            exit 1
-        fi
+        for config in $config_files; do
+            if ! git diff --quiet "$config"; then
+                err_msg "Warning - the configuration file '$config' has been edited. "
+                echo "You can either delete or preserve your work, or force the test by rerunning the"
+                echo "script as: $0 --force"
+                exit 1
+            fi
+        done
     fi
 }
 

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1,16 +1,96 @@
 #! /usr/bin/env bash
 
-# all.sh
+# all.sh (transitional wrapper)
 #
 # Copyright The Mbed TLS Contributors
 # SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 
-# This file is executable; it is the entry point for users and the CI.
-# See "Files structure" in all-core.sh for other files used.
+# During the transition of CI associated with the repo split,
+# we want all.sh from the mbedtls repo to transparently run both
+# mbedtls and tf-psa-crypto components.
+# This is what this wrapper is about.
+# Once the transition is over, this wrapper can be removed,
+# and mbedtls-all.sh renamed again to all.sh.
+#
+# This wrapper is mostly for the CI's benefit. Developers probably want to
+# directly invoke one or two of the following commands:
+# - tests/scripts/mbedtls-all.sh ...
+# - (cd tf-psa-crypto && tests/scripts/all.sh ...)
 
 # This script must be invoked from the project's root.
 
-# The path is going to change when this is moved to the framework
-source tests/scripts/all-core.sh
+set -eu
 
-main "$@"
+# Get the list of components available on each side.
+COMP_MBEDTLS=$(tests/scripts/mbedtls-all.sh --list-all-components | sort)
+COMP_CRYPTO=$(cd tf-psa-crypto && tests/scripts/all.sh --list-all-components | sort)
+
+# Error out if any component is available on both sides
+COMMON=$(comm -12 <(echo "$COMP_MBEDTLS") <(echo "$COMP_CRYPTO") | tr '\n' ' ')
+if [ -n "$COMMON" ]; then
+    echo "The following components are duplicated: $COMMON" >&2
+    exit 2
+fi
+
+# all.sh complains when a component is requested explicitly but is not
+# available. However, here we actually run two instances of all.sh, so when
+# requesting one component epxlicitly, at least one instance is not going to
+# know about it. So, when invoking each side, remove the other side's
+# components from its command line. This is safe because we know from above
+# that no component is on both sides.
+
+# mbedtls args are global args without the crypto components
+COMP_CRYPTO=$(echo $COMP_CRYPTO | tr '\n' ' ')
+for arg in "$@"; do
+    case " $COMP_CRYPTO " in
+        *" $arg "*) ;;
+        *) mbedtls_args+=( $arg ) ;;
+    esac
+done
+
+# crypto args are global args without the mbedtls components
+COMP_MBEDTLS=$(echo $COMP_MBEDTLS | tr '\n' ' ')
+for arg in "$@"; do
+    case " $COMP_MBEDTLS " in
+        *" $arg "*) ;;
+        *) crypto_args+=( $arg ) ;;
+    esac
+done
+
+# Note: don't print debug info on what commands are being run, because we
+# don't want to pollute the output especially when --list-components is used.
+
+# call mbedtls's all.sh
+set +e
+tests/scripts/mbedtls-all.sh "${mbedtls_args[@]}"
+mbedtls_exit=$?
+set -e
+if [ $mbedtls_exit -ne 0 ]; then
+    echo "mbedtls-all.sh exited $mbedtls_exit" >&2
+fi
+
+# if it returned non-zero, should we keep going?
+if [ $mbedtls_exit -ne 0 ]; then
+     case " $@ " in
+         *" --keep-going "*) ;; # fall through and run tf-psa-crypto's all.sh
+         *) exit $mbedtls_exit;;
+     esac
+fi
+
+# call tf-psa-crypto's all.sh
+set +e
+(cd tf-psa-crypto && tests/scripts/all.sh "${crypto_args[@]}")
+crypto_exit=$?
+set -e
+if [ $crypto_exit -ne 0 ]; then
+    echo "tf-psa-crypto's all.sh exited $crypto_exit" >&2
+fi
+
+# return an appropriate exit code
+if [ $mbedtls_exit -ne 0 ]; then
+    echo "mbedtls-all.sh exited $mbedtls_exit" >&2
+    echo "Please scroll up for a summary of errors in mbedtls-all.sh" >&2
+    exit $mbedtls_exit
+else
+    exit $crypto_exit
+fi

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -55,7 +55,7 @@ if [ "$#" -eq 1 ]; then
     fi
 fi
 
-if [ "$#" -ne 4 -o "$1" != '--seed' -o "$3" != '--keep-going' ]; then
+if [ "$#" -ne 4 -o "${1:-unset}" != '--seed' -o "${3:-unset}" != '--keep-going' ]; then
     echo "This invocation is not supported by the transitional wrapper." >&2
     echo "See the comments at the top of $0." >&2
     exit 1

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -5,92 +5,98 @@
 # Copyright The Mbed TLS Contributors
 # SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 
-# During the transition of CI associated with the repo split,
-# we want all.sh from the mbedtls repo to transparently run both
-# mbedtls and tf-psa-crypto components.
-# This is what this wrapper is about.
-# Once the transition is over, this wrapper can be removed,
-# and mbedtls-all.sh renamed again to all.sh.
-#
-# This wrapper is mostly for the CI's benefit. Developers probably want to
-# directly invoke one or two of the following commands:
+# This is a transitional wrapper that's only meant for the CI.
+# Developers should directly invoke on or two of:
 # - tests/scripts/mbedtls-all.sh ...
 # - (cd tf-psa-crypto && tests/scripts/all.sh ...)
+#
+# During the transition, it's illegal for a tf-psa-crypto component to have
+# the same name as an mbedtls components; since this wrapper handles both
+# sides at once, component names need to be globally unique. Once the
+# transition period is over, unicity on each side will be enough.
+#
+# For context, here are the steps of the transition:
+# 1. We have an all.sh in tf-psa-crypto but for now we don't invoke it directly
+# on the CI, only through this transitional wrapper in mbedtls. (tf-psa-crypto
+# doesn't have its own CI initially and runs Mbed TLS's instead.)
+# 2. We move all relevant components to tf-psa-crypto so that it gets the level of
+# coverage we want. We need to make sure the new names are unique.
+# 3. We change the CI job on tf-psa-crypto to stop checking out mbedtls and running
+# its all.sh - instead we do the normal thing of checking out tf-psa-crypto and
+# running its all.sh. (In two steps: (a) add the new job, (b) remove the old
+# one.)
+# 4. We remove the transitional wrapper in mbedtls and we're now free to rename
+# tf-psa-crypto components as we want. If we followed a consistent naming
+# pattern, this can be as simple as s/_tf_psa_crypto// in components-*.sh.
 
 # This script must be invoked from the project's root.
 
+# There are exactly 4 ways this is invoked in the CI:
+# 1. tests/scripts/all.sh --help
+# 2. tests/scripts/all.sh --list-all-components
+# 3. tests/scripts/all.sh --list-components
+# 4. tests/scripts/all.sh --seed 4 --keep-going single_component_name
+# This wrapper does not support other invocations.
+
 set -eu
 
+# Cases 1-3
+if [ "$#" -eq 1 ]; then
+    if [ "$1" = '--help' ]; then
+        # It doesn't matter which one we use, they're the same
+        tests/scripts/mbedtls-all.sh "$1"
+        exit 0
+    fi
+    if [ "$1" = '--list-all-components' -o "$1" = '--list-components' ]; then
+        # Invoke both
+        tests/scripts/mbedtls-all.sh "$1"
+        (cd tf-psa-crypto && tests/scripts/all.sh "$1")
+        exit 0
+    fi
+fi
+
+if [ "$#" -ne 4 -o "$1" != '--seed' -o "$3" != '--keep-going' ]; then
+    echo "This invocation is not supported by the transitional wrapper." >&2
+    echo "See the comments at the top of $0." >&2
+    exit 1
+fi
+
+# Case 4: invoke the right all.sh for this component
+comp_name=$4
+
 # Get the list of components available on each side.
-COMP_MBEDTLS=$(tests/scripts/mbedtls-all.sh --list-all-components | sort)
-COMP_CRYPTO=$(cd tf-psa-crypto && tests/scripts/all.sh --list-all-components | sort)
+COMP_MBEDTLS=$(tests/scripts/mbedtls-all.sh --list-all-components | tr '\n' ' ')
+COMP_CRYPTO=$(cd tf-psa-crypto && tests/scripts/all.sh --list-all-components | tr '\n' ' ')
 
-# Error out if any component is available on both sides
-COMMON=$(comm -12 <(echo "$COMP_MBEDTLS") <(echo "$COMP_CRYPTO") | tr '\n' ' ')
-if [ -n "$COMMON" ]; then
-    echo "The following components are duplicated: $COMMON" >&2
-    exit 2
-fi
-
-# all.sh complains when a component is requested explicitly but is not
-# available. However, here we actually run two instances of all.sh, so when
-# requesting one component epxlicitly, at least one instance is not going to
-# know about it. So, when invoking each side, remove the other side's
-# components from its command line. This is safe because we know from above
-# that no component is on both sides.
-
-# mbedtls args are global args without the crypto components
-COMP_CRYPTO=$(echo $COMP_CRYPTO | tr '\n' ' ')
-for arg in "$@"; do
-    case " $COMP_CRYPTO " in
-        *" $arg "*) ;;
-        *) mbedtls_args+=( $arg ) ;;
+# tell if $1 is in space-separated list $2
+is_in() {
+    needle=$1
+    haystack=$2
+    case " $haystack " in
+        *" $needle "*) echo 1;;
+        *) echo 0;;
     esac
-done
+}
 
-# crypto args are global args without the mbedtls components
-COMP_MBEDTLS=$(echo $COMP_MBEDTLS | tr '\n' ' ')
-for arg in "$@"; do
-    case " $COMP_MBEDTLS " in
-        *" $arg "*) ;;
-        *) crypto_args+=( $arg ) ;;
-    esac
-done
+is_crypto=$(is_in "$comp_name" "$COMP_CRYPTO")
+is_mbedtls=$(is_in "$comp_name" "$COMP_MBEDTLS")
 
-# Note: don't print debug info on what commands are being run, because we
-# don't want to pollute the output especially when --list-components is used.
-
-# call mbedtls's all.sh
-set +e
-tests/scripts/mbedtls-all.sh "${mbedtls_args[@]}"
-mbedtls_exit=$?
-set -e
-if [ $mbedtls_exit -ne 0 ]; then
-    echo "mbedtls-all.sh exited $mbedtls_exit" >&2
+# Component should be on exactly one side (see comment near the top).
+if [ "$is_crypto" -eq 1 -a "$is_mbedtls" -eq 1 ]; then
+    echo "Component '$comp_name' is both in crypto and Mbed TLS". >&2
+    echo "See the comments at the top of $0." >&2
+    exit 1
+fi
+if [ "$is_crypto" -eq 0 -a "$is_mbedtls" -eq 0 ]; then
+    echo "Component '$comp_name' is neither in crypto nor in Mbed TLS". >&2
+    echo "See the comments at the top of $0." >&2
+    exit 1
 fi
 
-# if it returned non-zero, should we keep going?
-if [ $mbedtls_exit -ne 0 ]; then
-     case " $@ " in
-         *" --keep-going "*) ;; # fall through and run tf-psa-crypto's all.sh
-         *) exit $mbedtls_exit;;
-     esac
-fi
-
-# call tf-psa-crypto's all.sh
-set +e
-(cd tf-psa-crypto && tests/scripts/all.sh "${crypto_args[@]}")
-crypto_exit=$?
-set -e
-if [ $crypto_exit -ne 0 ]; then
-    echo "tf-psa-crypto's all.sh exited $crypto_exit" >&2
-fi
-
-# return an appropriate exit code
-if [ $mbedtls_exit -ne 0 ]; then
-    echo "mbedtls-all.sh exited $mbedtls_exit" >&2
-    echo "Please scroll up for a summary of errors in mbedtls-all.sh" >&2
-    exit $mbedtls_exit
+# Invoke the real thing
+if [ "$is_crypto" -eq 1 ]; then
+    cd tf-psa-crypto
+    exec tests/scripts/all.sh "$@"
 else
-    exit $crypto_exit
+    exec tests/scripts/mbedtls-all.sh "$@"
 fi

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -93,8 +93,18 @@ if [ "$is_crypto" -eq 0 -a "$is_mbedtls" -eq 0 ]; then
     exit 1
 fi
 
+
 # Invoke the real thing
 if [ "$is_crypto" -eq 1 ]; then
+    # Make sure the path to the outcomes file is absolute. This is done by
+    # pre_prepare_outcome_file() however by the time it runs we've already
+    # changed the working directory, so do it now.
+    if [ -n "${MBEDTLS_TEST_OUTCOME_FILE+set}" ]; then
+        case "$MBEDTLS_TEST_OUTCOME_FILE" in
+          [!/]*) MBEDTLS_TEST_OUTCOME_FILE="$PWD/$MBEDTLS_TEST_OUTCOME_FILE";;
+        esac
+        export MBEDTLS_TEST_OUTCOME_FILE
+    fi
     cd tf-psa-crypto
     exec tests/scripts/all.sh "$@"
 else

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -8,8 +8,9 @@
 # This file is executable; it is the entry point for users and the CI.
 # See "Files structure" in all-core.sh for other files used.
 
+# This script must be invoked from the project's root.
+
 # The path is going to change when this is moved to the framework
-test_script_dir="${0%/*}"
-source "$test_script_dir"/all-core.sh
+source tests/scripts/all-core.sh
 
 main "$@"

--- a/tests/scripts/components-build-system.sh
+++ b/tests/scripts/components-build-system.sh
@@ -85,26 +85,6 @@ component_test_cmake_out_of_source () {
     rm -rf "$OUT_OF_SOURCE_DIR"
 }
 
-component_test_cmake_tf_psa_crypto_out_of_source () {
-    # Remove existing generated files so that we use the ones cmake
-    # generates
-    make neat
-    msg "build: cmake tf-psa-crypto 'out-of-source' build"
-    MBEDTLS_ROOT_DIR="$PWD"
-    cd tf-psa-crypto
-    TF_PSA_CRYPTO_ROOT_DIR="$PWD"
-    mkdir "$OUT_OF_SOURCE_DIR"
-    cd "$OUT_OF_SOURCE_DIR"
-    # Note: Explicitly generate files as these are turned off in releases
-    cmake -D CMAKE_BUILD_TYPE:String=Check -D GEN_FILES=ON "$TF_PSA_CRYPTO_ROOT_DIR"
-    make
-    msg "test: cmake tf-psa-crypto 'out-of-source' build"
-    make test
-    cd "$TF_PSA_CRYPTO_ROOT_DIR"
-    rm -rf "$OUT_OF_SOURCE_DIR"
-    cd "$MBEDTLS_ROOT_DIR"
-}
-
 component_test_cmake_as_subdirectory () {
     # Remove existing generated files so that we use the ones CMake
     # generates

--- a/tests/scripts/mbedtls-all.sh
+++ b/tests/scripts/mbedtls-all.sh
@@ -1,0 +1,16 @@
+#! /usr/bin/env bash
+
+# all.sh (mbedtls part)
+#
+# Copyright The Mbed TLS Contributors
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+
+# This file is executable; it is the entry point for users and the CI.
+# See "Files structure" in all-core.sh for other files used.
+
+# This script must be invoked from the project's root.
+
+# The path is going to change when this is moved to the framework
+source tests/scripts/all-core.sh
+
+main "$@"

--- a/tf-psa-crypto/tests/scripts/all.sh
+++ b/tf-psa-crypto/tests/scripts/all.sh
@@ -1,0 +1,16 @@
+#! /usr/bin/env bash
+
+# all.sh
+#
+# Copyright The Mbed TLS Contributors
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+
+# This file is executable; it is the entry point for users and the CI.
+# See "Files structure" in all-core.sh for other files used.
+
+# This script must be invoked from the project's root.
+
+# The path is going to change when this is moved to the framework
+source ../tests/scripts/all-core.sh
+
+main "$@"

--- a/tf-psa-crypto/tests/scripts/all.sh
+++ b/tf-psa-crypto/tests/scripts/all.sh
@@ -10,6 +10,13 @@
 
 # This script must be invoked from the project's root.
 
+# Prevent silly mistakes when people would invoke this from mbedtls
+if [ -d tf-psa-crypto -a -d library ]; then
+    echo "When invoking this script from an mbedtls checkout," >&2
+    echo "you must change the working directory to tf-psa-crypto." >&2
+    exit 255
+fi
+
 # The path is going to change when this is moved to the framework
 source ../tests/scripts/all-core.sh
 

--- a/tf-psa-crypto/tests/scripts/components-build-system.sh
+++ b/tf-psa-crypto/tests/scripts/components-build-system.sh
@@ -1,0 +1,24 @@
+# components-build-system.sh
+#
+# Copyright The Mbed TLS Contributors
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+
+# This file contains test components that are executed by all.sh
+
+################################################################
+#### Build System Testing
+################################################################
+
+component_test_cmake_tf_psa_crypto_out_of_source () {
+    msg "build: cmake tf-psa-crypto 'out-of-source' build"
+    TF_PSA_CRYPTO_ROOT_DIR="$PWD"
+    mkdir "$OUT_OF_SOURCE_DIR"
+    cd "$OUT_OF_SOURCE_DIR"
+    # Note: Explicitly generate files as these are turned off in releases
+    cmake -D CMAKE_BUILD_TYPE:String=Check -D GEN_FILES=ON "$TF_PSA_CRYPTO_ROOT_DIR"
+    make
+    msg "test: cmake tf-psa-crypto 'out-of-source' build"
+    make test
+    cd "$TF_PSA_CRYPTO_ROOT_DIR"
+    rm -rf "$OUT_OF_SOURCE_DIR"
+}


### PR DESCRIPTION
## Description

- Add `tf-psa-crypto/tests/scripts/all.sh` that can be invoked independently and will source components from `tf-psa-crypto/tests/scripts/component-*.sh`. Ultimately this is going to be the main entry point for tf-psa-crypto's CI when all relevant components have been migrated.
- Turn `tests/scripts/all.sh` into a wrapper that handles both mbedtls and tf-psa-crypto. This is a transitional wapper so that the CI can just keep calling the same single entry point, and still get all components, while we move relevant components to tf-psa-crypto, and until tf-psa-crypto gets its own autonomous CI.

## PR checklist

- [x] **changelog** not required because: internal changes, tests only
- [x] **development PR** here
- [x] **framework PR** not required
- [x] **3.6 PR** provided #9754
- [x] **2.28 PR** not required because: 2.28 is too old for that
- **tests**  not required because: manual testing, see below

## Manual testing

- Once the CI is passing, check the outcome file to confirm we're still running the same number of components.
- Anything else reviewers can think of - time to be creative :)
