### PR TITLE
Fix new coverity issues

### DIFF
--- a/tests/src/bignum_codepath_check.c
+++ b/tests/src/bignum_codepath_check.c
@@ -11,14 +11,14 @@
 #if defined(MBEDTLS_TEST_HOOKS) && !defined(MBEDTLS_THREADING_C)
 int mbedtls_codepath_check = MBEDTLS_MPI_IS_TEST;
 
-void mbedtls_codepath_take_safe(void)
+static void mbedtls_codepath_take_safe(void)
 {
     if (mbedtls_codepath_check == MBEDTLS_MPI_IS_TEST) {
         mbedtls_codepath_check = MBEDTLS_MPI_IS_SECRET;
     }
 }
 
-void mbedtls_codepath_take_unsafe(void)
+static void mbedtls_codepath_take_unsafe(void)
 {
     mbedtls_codepath_check = MBEDTLS_MPI_IS_PUBLIC;
 }

--- a/tests/suites/test_suite_x509write.function
+++ b/tests/suites/test_suite_x509write.function
@@ -298,11 +298,12 @@ void x509_csr_check_opaque(char *key_file, int md_type, int key_usage,
     mbedtls_test_rnd_pseudo_info rnd_info;
 
     mbedtls_x509write_csr_init(&req);
+    mbedtls_pk_init(&key);
+
     MD_OR_USE_PSA_INIT();
 
     memset(&rnd_info, 0x2a, sizeof(mbedtls_test_rnd_pseudo_info));
 
-    mbedtls_pk_init(&key);
     TEST_ASSERT(mbedtls_pk_parse_keyfile(&key, key_file, NULL,
                                          mbedtls_test_rnd_std_rand, NULL) == 0);
 

--- a/tests/suites/test_suite_x509write.function
+++ b/tests/suites/test_suite_x509write.function
@@ -288,17 +288,19 @@ void x509_csr_check_opaque(char *key_file, int md_type, int key_usage,
                            int cert_type)
 {
     mbedtls_pk_context key;
+    mbedtls_pk_init(&key);
+
     mbedtls_svc_key_id_t key_id = MBEDTLS_SVC_KEY_ID_INIT;
     psa_key_attributes_t key_attr = PSA_KEY_ATTRIBUTES_INIT;
+
     mbedtls_x509write_csr req;
+    mbedtls_x509write_csr_init(&req);
+
     unsigned char buf[4096];
     int ret;
     size_t pem_len = 0;
     const char *subject_name = "C=NL,O=PolarSSL,CN=PolarSSL Server 1";
     mbedtls_test_rnd_pseudo_info rnd_info;
-
-    mbedtls_x509write_csr_init(&req);
-    mbedtls_pk_init(&key);
 
     MD_OR_USE_PSA_INIT();
 

--- a/tf-psa-crypto/tests/suites/test_suite_ctr_drbg.function
+++ b/tf-psa-crypto/tests/suites/test_suite_ctr_drbg.function
@@ -363,10 +363,10 @@ void ctr_drbg_threads(data_t *expected_result, int reseed, int arg_thread_count)
      * as this was the value used when the expected answers were calculated. */
     const size_t entropy_len = 48;
 
-    AES_PSA_INIT();
-
     mbedtls_ctr_drbg_context ctx;
     mbedtls_ctr_drbg_init(&ctx);
+
+    AES_PSA_INIT();
 
     TEST_CALLOC(threads, sizeof(mbedtls_test_thread_t) * thread_count);
     memset(out, 0, sizeof(out));

--- a/tf-psa-crypto/tests/suites/test_suite_ctr_drbg.function
+++ b/tf-psa-crypto/tests/suites/test_suite_ctr_drbg.function
@@ -365,11 +365,11 @@ void ctr_drbg_threads(data_t *expected_result, int reseed, int arg_thread_count)
 
     AES_PSA_INIT();
 
-    TEST_CALLOC(threads, sizeof(mbedtls_test_thread_t) * thread_count);
-    memset(out, 0, sizeof(out));
-
     mbedtls_ctr_drbg_context ctx;
     mbedtls_ctr_drbg_init(&ctx);
+
+    TEST_CALLOC(threads, sizeof(mbedtls_test_thread_t) * thread_count);
+    memset(out, 0, sizeof(out));
 
     test_offset_idx = 0;
 

--- a/tf-psa-crypto/tests/suites/test_suite_psa_crypto_memory.function
+++ b/tf-psa-crypto/tests/suites/test_suite_psa_crypto_memory.function
@@ -243,7 +243,7 @@ void local_output_round_trip()
     TEST_CALLOC(buffer_copy_for_comparison, local_output.length);
     memcpy(buffer_copy_for_comparison, local_output.buffer, local_output.length);
 
-    psa_crypto_local_output_free(&local_output);
+    TEST_EQUAL(psa_crypto_local_output_free(&local_output), PSA_SUCCESS);
     TEST_ASSERT(local_output.buffer == NULL);
     TEST_EQUAL(local_output.length, 0);
 

--- a/tf-psa-crypto/tests/suites/test_suite_psa_crypto_memory.function
+++ b/tf-psa-crypto/tests/suites/test_suite_psa_crypto_memory.function
@@ -107,7 +107,10 @@ void local_input_alloc(int input_len, psa_status_t exp_status)
 
 exit:
     mbedtls_free(local_input.buffer);
-    mbedtls_free(input);
+
+    if (local_input.buffer != input) {
+        mbedtls_free(input);
+    }
 }
 /* END_CASE */
 


### PR DESCRIPTION
## Description

Fix a number of issues detected by coverity in the most recent run.

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** ~~provided |~~ not required because: No major issues fixed
- [x] **development PR** ~~provided # |~~ not required because: This is the development PR
- [x] **framework PR** ~~provided Mbed-TLS/mbedtls-framework# |~~ not required : no framework changes
- [x] **3.6 PR** provided #9723 ~~| not required because:~~
- [x] **2.28 PR** provided #9729 ~~| not required because:~~
- **tests**  ~~provided |~~ not required because: Existing tests provide coverage.
