### PR TITLE
[Backport 3.6] Revert & fix #9690 workarounds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,9 +235,15 @@ if(CMAKE_COMPILER_IS_GNU)
     # test_suite_pkwrite taking >3h on the CI. Observed with GCC 5.4 on
     # Ubuntu 16.04 x86_64 and GCC 6.5 on Ubuntu 18.04 x86_64.
     # GCC 7.5 and above on Ubuntu 18.04 appear fine.
-    # To avoid the performance problem, we use -O2 here. It doesn't slow
-    # down much even with modern compiler versions.
-    set(CMAKE_C_FLAGS_ASAN        "-fsanitize=address -fno-common -fsanitize=undefined -fno-sanitize-recover=all -O2")
+    # To avoid the performance problem, we use -O2 when GCC version is lower than 7.0.
+    # It doesn't slow down much even with modern compiler versions.
+    if (GCC_VERSION VERSION_LESS 7.0)
+        message(STATUS "USING O2")
+        set(CMAKE_C_FLAGS_ASAN        "-fsanitize=address -fno-common -fsanitize=undefined -fno-sanitize-recover=all -O2")
+    else()
+        message(STATUS "USING O3")
+        set(CMAKE_C_FLAGS_ASAN        "-fsanitize=address -fno-common -fsanitize=undefined -fno-sanitize-recover=all -O3")
+    endif()
     set(CMAKE_C_FLAGS_ASANDBG     "-fsanitize=address -fno-common -fsanitize=undefined -fno-sanitize-recover=all -O1 -g3 -fno-omit-frame-pointer -fno-optimize-sibling-calls")
     set(CMAKE_C_FLAGS_TSAN        "-fsanitize=thread -O3")
     set(CMAKE_C_FLAGS_TSANDBG     "-fsanitize=thread -O1 -g3 -fno-omit-frame-pointer -fno-optimize-sibling-calls")

--- a/tests/suites/test_suite_pkwrite.data
+++ b/tests/suites/test_suite_pkwrite.data
@@ -30,16 +30,13 @@ Public key write check EC 521 bits (DER)
 depends_on:MBEDTLS_PK_HAVE_ECC_KEYS:MBEDTLS_ECP_HAVE_SECP521R1
 pk_write_pubkey_check:"../framework/data_files/ec_521_pub.der":TEST_DER
 
-## The pk_write_pubkey_check sometimes take ~3 hours to run with
-## GCC+Asan on the CI in the full config. Comment out the slowest
-## ones while we investigate and release 3.6.2.
-# Public key write check EC Brainpool 512 bits
-# depends_on:MBEDTLS_PK_HAVE_ECC_KEYS:MBEDTLS_PEM_PARSE_C:MBEDTLS_PEM_WRITE_C:MBEDTLS_ECP_HAVE_BP512R1
-# pk_write_pubkey_check:"../framework/data_files/ec_bp512_pub.pem":TEST_PEM
+Public key write check EC Brainpool 512 bits
+depends_on:MBEDTLS_PK_HAVE_ECC_KEYS:MBEDTLS_PEM_PARSE_C:MBEDTLS_PEM_WRITE_C:MBEDTLS_ECP_HAVE_BP512R1
+pk_write_pubkey_check:"../framework/data_files/ec_bp512_pub.pem":TEST_PEM
 
-# Public key write check EC Brainpool 512 bits (DER)
-# depends_on:MBEDTLS_PK_HAVE_ECC_KEYS:MBEDTLS_ECP_HAVE_BP512R1
-# pk_write_pubkey_check:"../framework/data_files/ec_bp512_pub.der":TEST_DER
+Public key write check EC Brainpool 512 bits (DER)
+depends_on:MBEDTLS_PK_HAVE_ECC_KEYS:MBEDTLS_ECP_HAVE_BP512R1
+pk_write_pubkey_check:"../framework/data_files/ec_bp512_pub.der":TEST_DER
 
 Public key write check EC X25519
 depends_on:MBEDTLS_PK_HAVE_ECC_KEYS:MBEDTLS_PEM_PARSE_C:MBEDTLS_PEM_WRITE_C:MBEDTLS_ECP_HAVE_CURVE25519


### PR DESCRIPTION
## Description

This is the backport of #9703.
Since this is targetting the `mbedtls-3.6` branch I think the more appropriate title would be "Revert & fix #9698 workarounds".

## PR checklist

- [x] **changelog** not required
- [x] **development PR** provided #9703
- [x] **framework PR** not required
- [x] **3.6 PR** not required because: it's this one
- [ ] **2.28 PR** not required because: it's not affected by #9698
- **tests**  not required