### PR TITLE
[Backport 2.28] Fix new coverity issues

### DIFF
--- a/tests/suites/test_suite_psa_crypto_memory.function
+++ b/tests/suites/test_suite_psa_crypto_memory.function
@@ -243,7 +243,7 @@ void local_output_round_trip()
     TEST_CALLOC(buffer_copy_for_comparison, local_output.length);
     memcpy(buffer_copy_for_comparison, local_output.buffer, local_output.length);
 
-    psa_crypto_local_output_free(&local_output);
+    TEST_EQUAL(psa_crypto_local_output_free(&local_output), PSA_SUCCESS);
     TEST_ASSERT(local_output.buffer == NULL);
     TEST_EQUAL(local_output.length, 0);
 

--- a/tests/suites/test_suite_psa_crypto_memory.function
+++ b/tests/suites/test_suite_psa_crypto_memory.function
@@ -107,7 +107,10 @@ void local_input_alloc(int input_len, psa_status_t exp_status)
 
 exit:
     mbedtls_free(local_input.buffer);
-    mbedtls_free(input);
+
+    if (local_input.buffer != input) {
+        mbedtls_free(input);
+    }
 }
 /* END_CASE */
 

--- a/tests/suites/test_suite_x509write.function
+++ b/tests/suites/test_suite_x509write.function
@@ -219,13 +219,13 @@ void x509_csr_check_opaque(char *key_file, int md_type, int key_usage,
     memset(&rnd_info, 0x2a, sizeof(mbedtls_test_rnd_pseudo_info));
 
     mbedtls_x509write_csr_init(&req);
+    mbedtls_pk_init(&key);
 
     USE_PSA_INIT();
 
     md_alg_psa = mbedtls_psa_translate_md((mbedtls_md_type_t) md_type);
     TEST_ASSERT(md_alg_psa != MBEDTLS_MD_NONE);
 
-    mbedtls_pk_init(&key);
     TEST_ASSERT(mbedtls_pk_parse_keyfile(&key, key_file, NULL) == 0);
     TEST_ASSERT(mbedtls_pk_wrap_as_opaque(&key, &key_id, md_alg_psa) == 0);
 

--- a/tests/suites/test_suite_x509write.function
+++ b/tests/suites/test_suite_x509write.function
@@ -207,19 +207,21 @@ void x509_csr_check_opaque(char *key_file, int md_type, int key_usage,
                            int cert_type)
 {
     mbedtls_pk_context key;
+    mbedtls_pk_init(&key);
+
     mbedtls_svc_key_id_t key_id = MBEDTLS_SVC_KEY_ID_INIT;
     psa_algorithm_t md_alg_psa;
+
     mbedtls_x509write_csr req;
+    mbedtls_x509write_csr_init(&req);
+
     unsigned char buf[4096];
     int ret;
     size_t pem_len = 0;
     const char *subject_name = "C=NL,O=PolarSSL,CN=PolarSSL Server 1";
     mbedtls_test_rnd_pseudo_info rnd_info;
-
     memset(&rnd_info, 0x2a, sizeof(mbedtls_test_rnd_pseudo_info));
 
-    mbedtls_x509write_csr_init(&req);
-    mbedtls_pk_init(&key);
 
     USE_PSA_INIT();
 


### PR DESCRIPTION
## Description

Backport of the relevant parts of #9721 (Some tests did not exist / bignum codepath tests did not exist)

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** ~~provided |~~ not required because: No serious issues fixed
- [x] **development PR** provided #9721 ~~| not required because: ~~
- [x] **framework PR** ~~provided Mbed-TLS/mbedtls-framework#~~ | not required : No framework component
- [x] **3.6 PR** provided #9723 ~~| not required because: ~~
- [x] **2.28 PR** ~~provided # |~~ not required because: This is the 2.28 backport 
- **tests**  ~~provided |~~ not required because: Existing tests suffice 
