### PR TITLE
[Backport 3.6] Add default config tests for the A64, A32, Thumb 1 and Thumb 2 instruction sets

### DIFF
--- a/tests/scripts/all-core.sh
+++ b/tests/scripts/all-core.sh
@@ -228,6 +228,7 @@ pre_initialize_variables () {
     : ${ARM_NONE_EABI_GCC_PREFIX:=arm-none-eabi-}
     : ${ARM_LINUX_GNUEABI_GCC_PREFIX:=arm-linux-gnueabi-}
     : ${ARM_LINUX_GNUEABIHF_GCC_PREFIX:=arm-linux-gnueabihf-}
+    : ${AARCH64_LINUX_GNU_GCC_PREFIX:=aarch64-linux-gnu-}
     : ${CLANG_LATEST:="clang-latest"}
     : ${CLANG_EARLIEST:="clang-earliest"}
     : ${GCC_LATEST:="gcc-latest"}

--- a/tests/scripts/all-core.sh
+++ b/tests/scripts/all-core.sh
@@ -227,6 +227,7 @@ pre_initialize_variables () {
     : ${ARMC6_BIN_DIR:=/usr/bin}
     : ${ARM_NONE_EABI_GCC_PREFIX:=arm-none-eabi-}
     : ${ARM_LINUX_GNUEABI_GCC_PREFIX:=arm-linux-gnueabi-}
+    : ${ARM_LINUX_GNUEABIHF_GCC_PREFIX:=arm-linux-gnueabihf-}
     : ${CLANG_LATEST:="clang-latest"}
     : ${CLANG_EARLIEST:="clang-earliest"}
     : ${GCC_LATEST:="gcc-latest"}

--- a/tests/scripts/all-core.sh
+++ b/tests/scripts/all-core.sh
@@ -325,6 +325,12 @@ General options:
      --arm-linux-gnueabi-gcc-prefix=<string>
                         Prefix for a cross-compiler for arm-linux-gnueabi
                         (default: "${ARM_LINUX_GNUEABI_GCC_PREFIX}")
+     --arm-linux-gnueabihf-gcc-prefix=<string>
+                        Prefix for a cross-compiler for arm-linux-gnueabihf
+                        (default: "${ARM_LINUX_GNUEABIHF_GCC_PREFIX}")
+     --aarch64-linux-gnu-gcc-prefix=<string>
+                        Prefix for a cross-compiler for aarch64-linux-gnu
+                        (default: "${AARCH64_LINUX_GNU_GCC_PREFIX}")
      --armcc            Run ARM Compiler builds (on by default).
      --restore          First clean up the build tree, restoring backed up
                         files. Do not run any components unless they are
@@ -507,6 +513,8 @@ pre_parse_command_line () {
             --append-outcome) append_outcome=1;;
             --arm-none-eabi-gcc-prefix) shift; ARM_NONE_EABI_GCC_PREFIX="$1";;
             --arm-linux-gnueabi-gcc-prefix) shift; ARM_LINUX_GNUEABI_GCC_PREFIX="$1";;
+            --arm-linux-gnueabihf-gcc-prefix) shift; ARM_LINUX_GNUEABIHF_GCC_PREFIX="$1";;
+            --aarch64-linux-gnu-gcc-prefix) shift; AARCH64_LINUX_GNU_GCC_PREFIX="$1";;
             --armcc) no_armcc=;;
             --armc5-bin-dir) shift; ARMC5_BIN_DIR="$1";;
             --armc6-bin-dir) shift; ARMC6_BIN_DIR="$1";;

--- a/tests/scripts/all-helpers.sh
+++ b/tests/scripts/all-helpers.sh
@@ -266,6 +266,15 @@ clang_version() {
     fi
 }
 
+gcc_version() {
+    cc="$1"
+    if command -v clang > /dev/null ; then
+        "$cc" --version | sed -En '1s/^[^ ]* \([^)]*\) ([0-9]+).*/\1/p'
+    else
+        echo 0  # report version 0 for "no clang"
+    fi
+}
+
 can_run_cc_output() {
     cc="$1"
     result=1
@@ -301,4 +310,15 @@ can_run_arm_linux_gnueabihf () {
         fi
     fi
     return $((! can_run_arm_linux_gnueabihf))
+}
+
+can_run_aarch64_linux_gnu () {
+    if [ -z "${can_run_aarch64_linux_gnu:-}" ]; then
+        if can_run_cc_output "${AARCH64_LINUX_GNU_GCC_PREFIX}gcc"; then
+            can_run_aarch64_linux_gnu=1
+        else
+            can_run_aarch64_linux_gnu=0
+        fi
+    fi
+    return $((! can_run_aarch64_linux_gnu))
 }

--- a/tests/scripts/all-helpers.sh
+++ b/tests/scripts/all-helpers.sh
@@ -290,8 +290,9 @@ can_run_cc_output() {
     $result
 }
 
+can_run_arm_linux_gnueabi=
 can_run_arm_linux_gnueabi () {
-    if [ -z "${can_run_arm_linux_gnueabi:-}" ]; then
+    if [ -z "$can_run_arm_linux_gnueabi" ]; then
         if can_run_cc_output "${ARM_LINUX_GNUEABI_GCC_PREFIX}gcc"; then
             can_run_arm_linux_gnueabi=true
         else
@@ -301,8 +302,9 @@ can_run_arm_linux_gnueabi () {
     $can_run_arm_linux_gnueabi
 }
 
+can_run_arm_linux_gnueabihf=
 can_run_arm_linux_gnueabihf () {
-    if [ -z "${can_run_arm_linux_gnueabihf:-}" ]; then
+    if [ -z "$can_run_arm_linux_gnueabihf" ]; then
         if can_run_cc_output "${ARM_LINUX_GNUEABIHF_GCC_PREFIX}gcc"; then
             can_run_arm_linux_gnueabihf=true
         else
@@ -312,8 +314,9 @@ can_run_arm_linux_gnueabihf () {
     $can_run_arm_linux_gnueabihf
 }
 
+can_run_aarch64_linux_gnu=
 can_run_aarch64_linux_gnu () {
-    if [ -z "${can_run_aarch64_linux_gnu:-}" ]; then
+    if [ -z "$can_run_aarch64_linux_gnu" ]; then
         if can_run_cc_output "${AARCH64_LINUX_GNU_GCC_PREFIX}gcc"; then
             can_run_aarch64_linux_gnu=true
         else

--- a/tests/scripts/all-helpers.sh
+++ b/tests/scripts/all-helpers.sh
@@ -267,11 +267,11 @@ clang_version() {
 }
 
 gcc_version() {
-    cc="$1"
-    if command -v clang > /dev/null ; then
-        "$cc" --version | sed -En '1s/^[^ ]* \([^)]*\) ([0-9]+).*/\1/p'
+    gcc="$1"
+    if command -v "$gcc" > /dev/null ; then
+        "$gcc" --version | sed -En '1s/^[^ ]* \([^)]*\) ([0-9]+).*/\1/p'
     else
-        echo 0  # report version 0 for "no clang"
+        echo 0  # report version 0 for "no gcc"
     fi
 }
 

--- a/tests/scripts/all-helpers.sh
+++ b/tests/scripts/all-helpers.sh
@@ -285,7 +285,7 @@ can_run_cc_output() {
                 result=0
             fi
         fi
-        rm "$testbin"
+        rm -f "$testbin"
     fi
     return $result
 }

--- a/tests/scripts/all-helpers.sh
+++ b/tests/scripts/all-helpers.sh
@@ -265,3 +265,40 @@ clang_version() {
         echo 0  # report version 0 for "no clang"
     fi
 }
+
+can_run_cc_output() {
+    cc="$1"
+    result=1
+    if type "$cc" >/dev/null 2>&1; then
+        testbin=$(mktemp)
+        if echo 'int main(void){return 0;}' | "$cc" -o "$testbin" -x c -; then
+            if "$testbin" 2>/dev/null; then
+                result=0
+            fi
+        fi
+        rm "$testbin"
+    fi
+    return $result
+}
+
+can_run_arm_linux_gnueabi () {
+    if [ -z "${can_run_arm_linux_gnueabi:-}" ]; then
+        if can_run_cc_output "${ARM_LINUX_GNUEABI_GCC_PREFIX}gcc"; then
+            can_run_arm_linux_gnueabi=1
+        else
+            can_run_arm_linux_gnueabi=0
+        fi
+    fi
+    return $((! can_run_arm_linux_gnueabi))
+}
+
+can_run_arm_linux_gnueabihf () {
+    if [ -z "${can_run_arm_linux_gnueabihf:-}" ]; then
+        if can_run_cc_output "${ARM_LINUX_GNUEABIHF_GCC_PREFIX}gcc"; then
+            can_run_arm_linux_gnueabihf=1
+        else
+            can_run_arm_linux_gnueabihf=0
+        fi
+    fi
+    return $((! can_run_arm_linux_gnueabihf))
+}

--- a/tests/scripts/all-helpers.sh
+++ b/tests/scripts/all-helpers.sh
@@ -277,48 +277,48 @@ gcc_version() {
 
 can_run_cc_output() {
     cc="$1"
-    result=1
+    result=false
     if type "$cc" >/dev/null 2>&1; then
         testbin=$(mktemp)
         if echo 'int main(void){return 0;}' | "$cc" -o "$testbin" -x c -; then
             if "$testbin" 2>/dev/null; then
-                result=0
+                result=true
             fi
         fi
         rm -f "$testbin"
     fi
-    return $result
+    $result
 }
 
 can_run_arm_linux_gnueabi () {
     if [ -z "${can_run_arm_linux_gnueabi:-}" ]; then
         if can_run_cc_output "${ARM_LINUX_GNUEABI_GCC_PREFIX}gcc"; then
-            can_run_arm_linux_gnueabi=1
+            can_run_arm_linux_gnueabi=true
         else
-            can_run_arm_linux_gnueabi=0
+            can_run_arm_linux_gnueabi=false
         fi
     fi
-    return $((! can_run_arm_linux_gnueabi))
+    $can_run_arm_linux_gnueabi
 }
 
 can_run_arm_linux_gnueabihf () {
     if [ -z "${can_run_arm_linux_gnueabihf:-}" ]; then
         if can_run_cc_output "${ARM_LINUX_GNUEABIHF_GCC_PREFIX}gcc"; then
-            can_run_arm_linux_gnueabihf=1
+            can_run_arm_linux_gnueabihf=true
         else
-            can_run_arm_linux_gnueabihf=0
+            can_run_arm_linux_gnueabihf=false
         fi
     fi
-    return $((! can_run_arm_linux_gnueabihf))
+    $can_run_arm_linux_gnueabihf
 }
 
 can_run_aarch64_linux_gnu () {
     if [ -z "${can_run_aarch64_linux_gnu:-}" ]; then
         if can_run_cc_output "${AARCH64_LINUX_GNU_GCC_PREFIX}gcc"; then
-            can_run_aarch64_linux_gnu=1
+            can_run_aarch64_linux_gnu=true
         else
-            can_run_aarch64_linux_gnu=0
+            can_run_aarch64_linux_gnu=false
         fi
     fi
-    return $((! can_run_aarch64_linux_gnu))
+    $can_run_aarch64_linux_gnu
 }

--- a/tests/scripts/components-platform.sh
+++ b/tests/scripts/components-platform.sh
@@ -360,9 +360,9 @@ support_test_arm_linux_gnueabi_gcc_arm5vte () {
     can_run_arm_linux_gnueabi
 }
 
-component_test_arm_linux_gnueabi_gcc_thumb_1 () {
-    # The hard float ABI is not implemented for Thumb 1, so use gnueabi
-    # Some Thumb 1 asm is sensitive to optimisation level, so test both -O0 and -Os
+# The hard float ABI is not implemented for Thumb 1, so use gnueabi
+# Some Thumb 1 asm is sensitive to optimisation level, so test both -O0 and -Os
+component_test_arm_linux_gnueabi_gcc_thumb_1_opt_0 () {
     msg "test: ${ARM_LINUX_GNUEABI_GCC_PREFIX}gcc -O0, thumb 1, default config" # ~2m 10s
     make CC="${ARM_LINUX_GNUEABI_GCC_PREFIX}gcc" CFLAGS='-std=c99 -Werror -Wextra -O0 -mcpu=arm1136j-s -mthumb'
 
@@ -374,9 +374,14 @@ component_test_arm_linux_gnueabi_gcc_thumb_1 () {
 
     msg "program demos: make, default config (out-of-box)" # ~0s
     tests/scripts/run_demos.py
+}
 
+support_test_arm_linux_gnueabi_gcc_thumb_1_opt_0 () {
+    can_run_arm_linux_gnueabi
+}
+
+component_test_arm_linux_gnueabi_gcc_thumb_1_opt_s () {
     msg "test: ${ARM_LINUX_GNUEABI_GCC_PREFIX}gcc -Os, thumb 1, default config" # ~3m 10s
-    make clean
     make CC="${ARM_LINUX_GNUEABI_GCC_PREFIX}gcc" CFLAGS='-std=c99 -Werror -Wextra -Os -mcpu=arm1136j-s -mthumb'
 
     msg "test: main suites make, default config (out-of-box)" # ~21m 10s
@@ -389,7 +394,7 @@ component_test_arm_linux_gnueabi_gcc_thumb_1 () {
     tests/scripts/run_demos.py
 }
 
-support_test_arm_linux_gnueabi_gcc_thumb_1 () {
+support_test_arm_linux_gnueabi_gcc_thumb_1_opt_s () {
     can_run_arm_linux_gnueabi
 }
 

--- a/tests/scripts/components-platform.sh
+++ b/tests/scripts/components-platform.sh
@@ -343,16 +343,16 @@ support_test_mx32 () {
 
 component_test_arm_linux_gnueabi_gcc_arm5vte () {
     # Mimic Debian armel port
-    msg "test: ${ARM_LINUX_GNUEABI_GCC_PREFIX}gcc -march=arm5vte, default config"
+    msg "test: ${ARM_LINUX_GNUEABI_GCC_PREFIX}gcc -march=arm5vte, default config" # ~4m
     make CC="${ARM_LINUX_GNUEABI_GCC_PREFIX}gcc" AR="${ARM_LINUX_GNUEABI_GCC_PREFIX}ar" CFLAGS='-Werror -Wall -Wextra -march=armv5te -O1'
 
-    msg "test: main suites make, default config (out-of-box)" # ~10s
+    msg "test: main suites make, default config (out-of-box)" # ~7m 40s
     make test
 
-    msg "selftest: make, default config (out-of-box)" # ~10s
+    msg "selftest: make, default config (out-of-box)" # ~0s
     programs/test/selftest
 
-    msg "program demos: make, default config (out-of-box)" # ~10s
+    msg "program demos: make, default config (out-of-box)" # ~0s
     tests/scripts/run_demos.py
 }
 
@@ -363,30 +363,30 @@ support_test_arm_linux_gnueabi_gcc_arm5vte () {
 component_test_arm_linux_gnueabi_gcc_thumb_1 () {
     # The hard float ABI is not implemented for Thumb 1, so use gnueabi
     # Some Thumb 1 asm is sensitive to optimisation level, so test both -O0 and -Os
-    msg "test: ${ARM_LINUX_GNUEABI_GCC_PREFIX}gcc -O0, thumb 1, default config"
+    msg "test: ${ARM_LINUX_GNUEABI_GCC_PREFIX}gcc -O0, thumb 1, default config" # ~2m 10s
     make clean
     make CC="${ARM_LINUX_GNUEABI_GCC_PREFIX}gcc" CFLAGS='-std=c99 -Werror -Wextra -O0 -mcpu=arm1136j-s -mthumb'
 
-    msg "test: main suites make, default config (out-of-box)" # ~10s
+    msg "test: main suites make, default config (out-of-box)" # ~36m
     make test
 
     msg "selftest: make, default config (out-of-box)" # ~10s
     programs/test/selftest
 
-    msg "program demos: make, default config (out-of-box)" # ~10s
+    msg "program demos: make, default config (out-of-box)" # ~0s
     tests/scripts/run_demos.py
 
-    msg "test: ${ARM_LINUX_GNUEABI_GCC_PREFIX}gcc -Os, thumb 1, default config"
+    msg "test: ${ARM_LINUX_GNUEABI_GCC_PREFIX}gcc -Os, thumb 1, default config" # ~3m 10s
     make clean
     make CC="${ARM_LINUX_GNUEABI_GCC_PREFIX}gcc" CFLAGS='-std=c99 -Werror -Wextra -Os -mcpu=arm1136j-s -mthumb'
 
-    msg "test: main suites make, default config (out-of-box)" # ~10s
+    msg "test: main suites make, default config (out-of-box)" # ~21m 10s
     make test
 
-    msg "selftest: make, default config (out-of-box)" # ~10s
+    msg "selftest: make, default config (out-of-box)" # ~2s
     programs/test/selftest
 
-    msg "program demos: make, default config (out-of-box)" # ~10s
+    msg "program demos: make, default config (out-of-box)" # ~0s
     tests/scripts/run_demos.py
 }
 
@@ -395,17 +395,17 @@ support_test_arm_linux_gnueabi_gcc_thumb_1 () {
 }
 
 component_test_arm_linux_gnueabihf_gcc_armv7 () {
-    msg "test: ${ARM_LINUX_GNUEABIHF_GCC_PREFIX}gcc -O2, A32, default config"
+    msg "test: ${ARM_LINUX_GNUEABIHF_GCC_PREFIX}gcc -O2, A32, default config" # ~4m 30s
     make clean
     make CC="${ARM_LINUX_GNUEABIHF_GCC_PREFIX}gcc" CFLAGS='-std=c99 -Werror -Wextra -O2 -march=armv7-a -marm'
 
-    msg "test: main suites make, default config (out-of-box)" # ~10s
+    msg "test: main suites make, default config (out-of-box)" # ~3m 30s
     make test
 
-    msg "selftest: make, default config (out-of-box)" # ~10s
+    msg "selftest: make, default config (out-of-box)" # ~0s
     programs/test/selftest
 
-    msg "program demos: make, default config (out-of-box)" # ~10s
+    msg "program demos: make, default config (out-of-box)" # ~0s
     tests/scripts/run_demos.py
 }
 
@@ -414,17 +414,17 @@ support_test_arm_linux_gnueabihf_gcc_armv7 () {
 }
 
 component_test_arm_linux_gnueabihf_gcc_thumb_2 () {
-    msg "test: ${ARM_LINUX_GNUEABIHF_GCC_PREFIX}gcc -Os, thumb 2, default config"
+    msg "test: ${ARM_LINUX_GNUEABIHF_GCC_PREFIX}gcc -Os, thumb 2, default config" # ~4m
     make clean
     make CC="${ARM_LINUX_GNUEABIHF_GCC_PREFIX}gcc" CFLAGS='-std=c99 -Werror -Wextra -Os -march=armv7-a -mthumb'
 
-    msg "test: main suites make, default config (out-of-box)" # ~10s
+    msg "test: main suites make, default config (out-of-box)" # ~3m 40s
     make test
 
-    msg "selftest: make, default config (out-of-box)" # ~10s
+    msg "selftest: make, default config (out-of-box)" # ~0s
     programs/test/selftest
 
-    msg "program demos: make, default config (out-of-box)" # ~10s
+    msg "program demos: make, default config (out-of-box)" # ~0s
     tests/scripts/run_demos.py
 }
 
@@ -433,17 +433,17 @@ support_test_arm_linux_gnueabihf_gcc_thumb_2 () {
 }
 
 component_test_aarch64_linux_gnu_gcc () {
-    msg "test: ${AARCH64_LINUX_GNU_GCC_PREFIX}gcc -O2, default config"
+    msg "test: ${AARCH64_LINUX_GNU_GCC_PREFIX}gcc -O2, default config" # ~3m 50s
     make clean
     make CC="${AARCH64_LINUX_GNU_GCC_PREFIX}gcc" CFLAGS='-std=c99 -Werror -Wextra -O2'
 
-    msg "test: main suites make, default config (out-of-box)" # ~10s
+    msg "test: main suites make, default config (out-of-box)" # ~1m 50s
     make test
 
-    msg "selftest: make, default config (out-of-box)" # ~10s
+    msg "selftest: make, default config (out-of-box)" # ~0s
     programs/test/selftest
 
-    msg "program demos: make, default config (out-of-box)" # ~10s
+    msg "program demos: make, default config (out-of-box)" # ~0s
     tests/scripts/run_demos.py
 }
 

--- a/tests/scripts/components-platform.sh
+++ b/tests/scripts/components-platform.sh
@@ -364,7 +364,6 @@ component_test_arm_linux_gnueabi_gcc_thumb_1 () {
     # The hard float ABI is not implemented for Thumb 1, so use gnueabi
     # Some Thumb 1 asm is sensitive to optimisation level, so test both -O0 and -Os
     msg "test: ${ARM_LINUX_GNUEABI_GCC_PREFIX}gcc -O0, thumb 1, default config" # ~2m 10s
-    make clean
     make CC="${ARM_LINUX_GNUEABI_GCC_PREFIX}gcc" CFLAGS='-std=c99 -Werror -Wextra -O0 -mcpu=arm1136j-s -mthumb'
 
     msg "test: main suites make, default config (out-of-box)" # ~36m
@@ -396,7 +395,6 @@ support_test_arm_linux_gnueabi_gcc_thumb_1 () {
 
 component_test_arm_linux_gnueabihf_gcc_armv7 () {
     msg "test: ${ARM_LINUX_GNUEABIHF_GCC_PREFIX}gcc -O2, A32, default config" # ~4m 30s
-    make clean
     make CC="${ARM_LINUX_GNUEABIHF_GCC_PREFIX}gcc" CFLAGS='-std=c99 -Werror -Wextra -O2 -march=armv7-a -marm'
 
     msg "test: main suites make, default config (out-of-box)" # ~3m 30s
@@ -415,7 +413,6 @@ support_test_arm_linux_gnueabihf_gcc_armv7 () {
 
 component_test_arm_linux_gnueabihf_gcc_thumb_2 () {
     msg "test: ${ARM_LINUX_GNUEABIHF_GCC_PREFIX}gcc -Os, thumb 2, default config" # ~4m
-    make clean
     make CC="${ARM_LINUX_GNUEABIHF_GCC_PREFIX}gcc" CFLAGS='-std=c99 -Werror -Wextra -Os -march=armv7-a -mthumb'
 
     msg "test: main suites make, default config (out-of-box)" # ~3m 40s
@@ -434,7 +431,6 @@ support_test_arm_linux_gnueabihf_gcc_thumb_2 () {
 
 component_test_aarch64_linux_gnu_gcc () {
     msg "test: ${AARCH64_LINUX_GNU_GCC_PREFIX}gcc -O2, default config" # ~3m 50s
-    make clean
     make CC="${AARCH64_LINUX_GNU_GCC_PREFIX}gcc" CFLAGS='-std=c99 -Werror -Wextra -O2'
 
     msg "test: main suites make, default config (out-of-box)" # ~1m 50s

--- a/tests/scripts/components-platform.sh
+++ b/tests/scripts/components-platform.sh
@@ -341,6 +341,97 @@ support_test_mx32 () {
     esac
 }
 
+component_test_arm_linux_gnueabi_gcc_arm5vte () {
+    # Mimic Debian armel port
+    msg "test: ${ARM_LINUX_GNUEABI_GCC_PREFIX}gcc -march=arm5vte, default config"
+    make CC="${ARM_LINUX_GNUEABI_GCC_PREFIX}gcc" AR="${ARM_LINUX_GNUEABI_GCC_PREFIX}ar" CFLAGS='-Werror -Wall -Wextra -march=armv5te -O1'
+
+    msg "test: main suites make, default config (out-of-box)" # ~10s
+    make test
+
+    msg "selftest: make, default config (out-of-box)" # ~10s
+    programs/test/selftest
+
+    msg "program demos: make, default config (out-of-box)" # ~10s
+    tests/scripts/run_demos.py
+}
+
+support_test_arm_linux_gnueabi_gcc_arm5vte () {
+    can_run_arm_linux_gnueabi
+}
+
+component_test_arm_linux_gnueabi_gcc_thumb_1 () {
+    # The hard float ABI is not implemented for Thumb 1, so use gnueabi
+    # Some Thumb 1 asm is sensitive to optimisation level, so test both -O0 and -Os
+    msg "test: ${ARM_LINUX_GNUEABI_GCC_PREFIX}gcc -O0, thumb 1, default config"
+    make clean
+    make CC="${ARM_LINUX_GNUEABI_GCC_PREFIX}gcc" CFLAGS='-std=c99 -Werror -Wextra -O0 -mcpu=arm1136j-s -mthumb'
+
+    msg "test: main suites make, default config (out-of-box)" # ~10s
+    make test
+
+    msg "selftest: make, default config (out-of-box)" # ~10s
+    programs/test/selftest
+
+    msg "program demos: make, default config (out-of-box)" # ~10s
+    tests/scripts/run_demos.py
+
+    msg "test: ${ARM_LINUX_GNUEABI_GCC_PREFIX}gcc -Os, thumb 1, default config"
+    make clean
+    make CC="${ARM_LINUX_GNUEABI_GCC_PREFIX}gcc" CFLAGS='-std=c99 -Werror -Wextra -Os -mcpu=arm1136j-s -mthumb'
+
+    msg "test: main suites make, default config (out-of-box)" # ~10s
+    make test
+
+    msg "selftest: make, default config (out-of-box)" # ~10s
+    programs/test/selftest
+
+    msg "program demos: make, default config (out-of-box)" # ~10s
+    tests/scripts/run_demos.py
+}
+
+support_test_arm_linux_gnueabi_gcc_thumb_1 () {
+    can_run_arm_linux_gnueabi
+}
+
+component_test_arm_linux_gnueabihf_gcc_armv7 () {
+    msg "test: ${ARM_LINUX_GNUEABIHF_GCC_PREFIX}gcc -O2, A32, default config"
+    make clean
+    make CC="${ARM_LINUX_GNUEABIHF_GCC_PREFIX}gcc" CFLAGS='-std=c99 -Werror -Wextra -O2 -march=armv7-a -marm'
+
+    msg "test: main suites make, default config (out-of-box)" # ~10s
+    make test
+
+    msg "selftest: make, default config (out-of-box)" # ~10s
+    programs/test/selftest
+
+    msg "program demos: make, default config (out-of-box)" # ~10s
+    tests/scripts/run_demos.py
+}
+
+support_test_arm_linux_gnueabihf_gcc_armv7 () {
+    can_run_arm_linux_gnueabihf
+}
+
+component_test_arm_linux_gnueabihf_gcc_thumb_2 () {
+    msg "test: ${ARM_LINUX_GNUEABIHF_GCC_PREFIX}gcc -Os, thumb 2, default config"
+    make clean
+    make CC="${ARM_LINUX_GNUEABIHF_GCC_PREFIX}gcc" CFLAGS='-std=c99 -Werror -Wextra -Os -march=armv7-a -mthumb'
+
+    msg "test: main suites make, default config (out-of-box)" # ~10s
+    make test
+
+    msg "selftest: make, default config (out-of-box)" # ~10s
+    programs/test/selftest
+
+    msg "program demos: make, default config (out-of-box)" # ~10s
+    tests/scripts/run_demos.py
+}
+
+support_test_arm_linux_gnueabihf_gcc_thumb_2 () {
+    can_run_arm_linux_gnueabihf
+}
+
 component_build_arm_none_eabi_gcc () {
     msg "build: ${ARM_NONE_EABI_GCC_PREFIX}gcc -O1, baremetal+debug" # ~ 10s
     scripts/config.py baremetal

--- a/tests/scripts/components-platform.sh
+++ b/tests/scripts/components-platform.sh
@@ -449,6 +449,7 @@ component_test_aarch64_linux_gnu_gcc () {
 }
 
 support_test_aarch64_linux_gnu_gcc () {
+    # Minimum version of GCC for MBEDTLS_AESCE_C is 6.0
     [ "$(gcc_version "${AARCH64_LINUX_GNU_GCC_PREFIX}gcc")" -ge 6 ] && can_run_aarch64_linux_gnu
 }
 

--- a/tests/scripts/components-platform.sh
+++ b/tests/scripts/components-platform.sh
@@ -432,6 +432,25 @@ support_test_arm_linux_gnueabihf_gcc_thumb_2 () {
     can_run_arm_linux_gnueabihf
 }
 
+component_test_aarch64_linux_gnu_gcc () {
+    msg "test: ${AARCH64_LINUX_GNU_GCC_PREFIX}gcc -O2, default config"
+    make clean
+    make CC="${AARCH64_LINUX_GNU_GCC_PREFIX}gcc" CFLAGS='-std=c99 -Werror -Wextra -O2'
+
+    msg "test: main suites make, default config (out-of-box)" # ~10s
+    make test
+
+    msg "selftest: make, default config (out-of-box)" # ~10s
+    programs/test/selftest
+
+    msg "program demos: make, default config (out-of-box)" # ~10s
+    tests/scripts/run_demos.py
+}
+
+support_test_aarch64_linux_gnu_gcc () {
+    [ "$(gcc_version "${AARCH64_LINUX_GNU_GCC_PREFIX}gcc")" -ge 6 ] && can_run_aarch64_linux_gnu
+}
+
 component_build_arm_none_eabi_gcc () {
     msg "build: ${ARM_NONE_EABI_GCC_PREFIX}gcc -O1, baremetal+debug" # ~ 10s
     scripts/config.py baremetal


### PR DESCRIPTION
This PR is the 3.6 backport of #9389
