### PR TITLE
[dev] Drop building with armcc5 in all.sh

### DIFF
--- a/scripts/output_env.sh
+++ b/scripts/output_env.sh
@@ -78,10 +78,6 @@ print_version "cmake" "--version" "" "head -n 1"
 echo
 
 if [ "${RUN_ARMCC:-1}" -ne 0 ]; then
-    : "${ARMC5_CC:=armcc}"
-    print_version "$ARMC5_CC" "--vsn" "" "head -n 2"
-    echo
-
     : "${ARMC6_CC:=armclang}"
     print_version "$ARMC6_CC" "--vsn" "" "head -n 2"
     echo

--- a/tests/scripts/all-core.sh
+++ b/tests/scripts/all-core.sh
@@ -51,7 +51,7 @@
 #   * GCC and Clang (recent enough for using ASan with gcc and MemSan with clang, or valgrind)
 #   * G++
 #   * arm-gcc and mingw-gcc
-#   * ArmCC 5 and ArmCC 6, unless invoked with --no-armcc
+#   * ArmCC 6 (aka armclang), unless invoked with --no-armcc
 #   * OpenSSL and GnuTLS command line tools, in suitable versions for the
 #     interoperability tests. The following are the official versions at the
 #     time of writing:
@@ -223,7 +223,6 @@ pre_initialize_variables () {
     : ${GNUTLS_CLI:="gnutls-cli"}
     : ${GNUTLS_SERV:="gnutls-serv"}
     : ${OUT_OF_SOURCE_DIR:=./mbedtls_out_of_source_build}
-    : ${ARMC5_BIN_DIR:=/usr/bin}
     : ${ARMC6_BIN_DIR:=/usr/bin}
     : ${ARM_NONE_EABI_GCC_PREFIX:=arm-none-eabi-}
     : ${ARM_LINUX_GNUEABI_GCC_PREFIX:=arm-linux-gnueabi-}
@@ -345,7 +344,6 @@ General options:
   -s|--seed             Integer seed value to use for this test run.
 
 Tool path options:
-     --armc5-bin-dir=<ARMC5_bin_dir_path>       ARM Compiler 5 bin directory.
      --armc6-bin-dir=<ARMC6_bin_dir_path>       ARM Compiler 6 bin directory.
      --clang-earliest=<Clang_earliest_path>     Earliest version of clang available
      --clang-latest=<Clang_latest_path>         Latest version of clang available
@@ -506,7 +504,6 @@ pre_parse_command_line () {
             --arm-none-eabi-gcc-prefix) shift; ARM_NONE_EABI_GCC_PREFIX="$1";;
             --arm-linux-gnueabi-gcc-prefix) shift; ARM_LINUX_GNUEABI_GCC_PREFIX="$1";;
             --armcc) no_armcc=;;
-            --armc5-bin-dir) shift; ARMC5_BIN_DIR="$1";;
             --armc6-bin-dir) shift; ARMC6_BIN_DIR="$1";;
             --clang-earliest) shift; CLANG_EARLIEST="$1";;
             --clang-latest) shift; CLANG_LATEST="$1";;
@@ -795,7 +792,6 @@ pre_print_configuration () {
     echo "OPENSSL_NEXT: $OPENSSL_NEXT"
     echo "GNUTLS_CLI: $GNUTLS_CLI"
     echo "GNUTLS_SERV: $GNUTLS_SERV"
-    echo "ARMC5_BIN_DIR: $ARMC5_BIN_DIR"
     echo "ARMC6_BIN_DIR: $ARMC6_BIN_DIR"
 }
 
@@ -843,14 +839,10 @@ pre_check_tools () {
 
     case " $RUN_COMPONENTS " in
         *_armcc*)
-            ARMC5_CC="$ARMC5_BIN_DIR/armcc"
-            ARMC5_AR="$ARMC5_BIN_DIR/armar"
-            ARMC5_FROMELF="$ARMC5_BIN_DIR/fromelf"
             ARMC6_CC="$ARMC6_BIN_DIR/armclang"
             ARMC6_AR="$ARMC6_BIN_DIR/armar"
             ARMC6_FROMELF="$ARMC6_BIN_DIR/fromelf"
-            check_tools "$ARMC5_CC" "$ARMC5_AR" "$ARMC5_FROMELF" \
-                        "$ARMC6_CC" "$ARMC6_AR" "$ARMC6_FROMELF";;
+            check_tools "$ARMC6_CC" "$ARMC6_AR" "$ARMC6_FROMELF";;
     esac
 
     # past this point, no call to check_tool, only printing output
@@ -861,7 +853,7 @@ pre_check_tools () {
     msg "info: output_env.sh"
     case $RUN_COMPONENTS in
         *_armcc*)
-            set "$@" ARMC5_CC="$ARMC5_CC" ARMC6_CC="$ARMC6_CC" RUN_ARMCC=1;;
+            set "$@" ARMC6_CC="$ARMC6_CC" RUN_ARMCC=1;;
         *) set "$@" RUN_ARMCC=0;;
     esac
     "$@" scripts/output_env.sh

--- a/tests/scripts/components-platform.sh
+++ b/tests/scripts/components-platform.sh
@@ -488,5 +488,5 @@ component_build_armcc () {
 
 support_build_armcc () {
     armc6_cc="$ARMC6_BIN_DIR/armclang"
-    (check_tools "$armc5_cc" "$armc6_cc" > /dev/null 2>&1)
+    (check_tools "$armc6_cc" > /dev/null 2>&1)
 }

--- a/tests/scripts/components-platform.sh
+++ b/tests/scripts/components-platform.sh
@@ -436,8 +436,9 @@ component_build_arm_clang_thumb () {
 }
 
 component_build_armcc () {
-    msg "build: ARM Compiler 5"
+    # Common configuration for all the builds below
     scripts/config.py baremetal
+
     # armc[56] don't support SHA-512 intrinsics
     scripts/config.py unset MBEDTLS_SHA512_USE_A64_CRYPTO_IF_PRESENT
 
@@ -453,13 +454,6 @@ component_build_armcc () {
     scripts/config.py unset MBEDTLS_SHA256_USE_ARMV8_A_CRYPTO_IF_PRESENT
 
     scripts/config.py set MBEDTLS_HAVE_ASM
-
-    make CC="$ARMC5_CC" AR="$ARMC5_AR" WARNING_CFLAGS='--strict --c99' lib
-
-    msg "size: ARM Compiler 5"
-    "$ARMC5_FROMELF" -z library/*.o
-    "$ARMC5_FROMELF" -z ${PSA_CORE_PATH}/*.o
-    "$ARMC5_FROMELF" -z ${BUILTIN_SRC_PATH}/*.o
 
     # Compile mostly with -O1 since some Arm inline assembly is disabled for -O0.
 
@@ -493,7 +487,6 @@ component_build_armcc () {
 }
 
 support_build_armcc () {
-    armc5_cc="$ARMC5_BIN_DIR/armcc"
     armc6_cc="$ARMC6_BIN_DIR/armclang"
     (check_tools "$armc5_cc" "$armc6_cc" > /dev/null 2>&1)
 }


### PR DESCRIPTION
## Description

It is my understanding that with the migration to a new license scheme in the CI, we are loosing support for armcc5. Since this is a legacy version, we can just stop testing with it.



## PR checklist

- [x] **changelog** not required because: internal (testing)
- [x] **development PR** provided here
- [x] **framework PR** not required
- [x] **3.6 PR** provided #9737
- [x] **2.28 PR** provided: #9736
- **tests** not required because: n/a
