### PR TITLE
[Backport 3.6] All.sh changes to support tf-psa-crypto components

### DIFF
--- a/tests/scripts/all-core.sh
+++ b/tests/scripts/all-core.sh
@@ -156,8 +156,8 @@ pre_check_environment () {
 # Must be called before pre_initialize_variables which sets ALL_COMPONENTS.
 pre_load_components () {
     # Include the components from components.sh
-    test_script_dir="${0%/*}"
-    for file in "$test_script_dir"/components-*.sh; do
+    # Use a path relative to the current directory, aka project's root.
+    for file in tests/scripts/components-*.sh; do
         source $file
     done
 }
@@ -866,7 +866,8 @@ pre_check_tools () {
             set "$@" ARMC6_CC="$ARMC6_CC" RUN_ARMCC=1;;
         *) set "$@" RUN_ARMCC=0;;
     esac
-    "$@" scripts/output_env.sh
+    # Use a path relative to the currently-sourced file.
+    "$@" "${BASH_SOURCE%/*}"/../../scripts/output_env.sh
 }
 
 pre_generate_files() {
@@ -881,8 +882,8 @@ pre_generate_files() {
 }
 
 pre_load_helpers () {
-    # The path is going to change when this is moved to the framework
-    test_script_dir="${0%/*}"
+    # Use a path relative to the currently-sourced file.
+    test_script_dir="${BASH_SOURCE%/*}"
     source "$test_script_dir"/all-helpers.sh
 }
 

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -8,8 +8,9 @@
 # This file is executable; it is the entry point for users and the CI.
 # See "Files structure" in all-core.sh for other files used.
 
+# This script must be invoked from the project's root.
+
 # The path is going to change when this is moved to the framework
-test_script_dir="${0%/*}"
-source "$test_script_dir"/all-core.sh
+source tests/scripts/all-core.sh
 
 main "$@"


### PR DESCRIPTION
## Description

This is the 3.6 partial backport of 9720 - here we don't want support for tf-psa-crypto components, so I'm just backporting changes to `all-core.sh` in order to preserver alignment between branches (before this is moved to the framework in the next PR).

## PR checklist

- [x] **changelog** not required because: internal changes, tests only
- [x] **development PR** provided #9720
- [x] **framework PR** not required
- [x] **3.6 PR** provided here
- [x] **2.28 PR** not required because: 2.28 is too old for that
- **tests**  not required because: manual testing, see below
