### PR TITLE
Backport 3.6: Fix MD_PSA_INIT called before initializing some data structures

### DIFF
--- a/tests/suites/test_suite_ecdsa.function
+++ b/tests/suites/test_suite_ecdsa.function
@@ -196,12 +196,11 @@ void ecdsa_det_test_vectors(int id, char *d_str, int md_alg, data_t *hash,
 {
     mbedtls_ecp_group grp;
     mbedtls_mpi d, r, s, r_check, s_check;
-
-    MD_PSA_INIT();
-
     mbedtls_ecp_group_init(&grp);
     mbedtls_mpi_init(&d); mbedtls_mpi_init(&r); mbedtls_mpi_init(&s);
     mbedtls_mpi_init(&r_check); mbedtls_mpi_init(&s_check);
+
+    MD_PSA_INIT();
 
     TEST_ASSERT(mbedtls_ecp_group_load(&grp, id) == 0);
     TEST_ASSERT(mbedtls_test_read_mpi(&d, d_str) == 0);
@@ -235,12 +234,12 @@ void ecdsa_write_read_zero(int id)
     unsigned char sig[200];
     size_t sig_len, i;
 
-    MD_PSA_INIT();
-
     mbedtls_ecdsa_init(&ctx);
     memset(&rnd_info, 0x00, sizeof(mbedtls_test_rnd_pseudo_info));
     memset(hash, 0, sizeof(hash));
     memset(sig, 0x2a, sizeof(sig));
+
+    MD_PSA_INIT();
 
     /* generate signing key */
     TEST_ASSERT(mbedtls_ecdsa_genkey(&ctx, id,
@@ -300,12 +299,12 @@ void ecdsa_write_read_random(int id)
     unsigned char sig[200];
     size_t sig_len, i;
 
-    MD_PSA_INIT();
-
     mbedtls_ecdsa_init(&ctx);
     memset(&rnd_info, 0x00, sizeof(mbedtls_test_rnd_pseudo_info));
     memset(hash, 0, sizeof(hash));
     memset(sig, 0x2a, sizeof(sig));
+
+    MD_PSA_INIT();
 
     /* prepare material for signature */
     TEST_ASSERT(mbedtls_test_rnd_pseudo_rand(&rnd_info,
@@ -436,11 +435,11 @@ void ecdsa_write_restart(int id, char *d_str, int md_alg,
     unsigned char sig[MBEDTLS_ECDSA_MAX_LEN];
     size_t slen;
 
-    MD_PSA_INIT();
-
     mbedtls_ecdsa_restart_init(&rs_ctx);
     mbedtls_ecdsa_init(&ctx);
     memset(sig, 0, sizeof(sig));
+
+    MD_PSA_INIT();
 
     TEST_ASSERT(mbedtls_ecp_group_load(&ctx.grp, id) == 0);
     TEST_ASSERT(mbedtls_test_read_mpi(&ctx.d, d_str) == 0);

--- a/tests/suites/test_suite_ecjpake.function
+++ b/tests/suites/test_suite_ecjpake.function
@@ -102,6 +102,7 @@ cleanup:
 void ecjpake_invalid_param()
 {
     mbedtls_ecjpake_context ctx;
+    mbedtls_ecjpake_init(&ctx);
     unsigned char buf[42] = { 0 };
     size_t const len = sizeof(buf);
     mbedtls_ecjpake_role invalid_role = (mbedtls_ecjpake_role) 42;
@@ -109,8 +110,6 @@ void ecjpake_invalid_param()
     mbedtls_ecp_group_id valid_group = MBEDTLS_ECP_DP_SECP256R1;
 
     MD_PSA_INIT();
-
-    mbedtls_ecjpake_init(&ctx);
 
     TEST_EQUAL(MBEDTLS_ERR_ECP_BAD_INPUT_DATA,
                mbedtls_ecjpake_setup(&ctx,
@@ -139,13 +138,13 @@ exit:
 void read_bad_md(data_t *msg)
 {
     mbedtls_ecjpake_context corrupt_ctx;
+    mbedtls_ecjpake_init(&corrupt_ctx);
     const unsigned char *pw = NULL;
     const size_t pw_len = 0;
     int any_role = MBEDTLS_ECJPAKE_CLIENT;
 
     MD_PSA_INIT();
 
-    mbedtls_ecjpake_init(&corrupt_ctx);
     TEST_ASSERT(mbedtls_ecjpake_setup(&corrupt_ctx, any_role,
                                       MBEDTLS_MD_SHA256, MBEDTLS_ECP_DP_SECP256R1, pw,
                                       pw_len) == 0);
@@ -164,12 +163,11 @@ exit:
 void read_round_one(int role, data_t *msg, int ref_ret)
 {
     mbedtls_ecjpake_context ctx;
+    mbedtls_ecjpake_init(&ctx);
     const unsigned char *pw = NULL;
     const size_t pw_len = 0;
 
     MD_PSA_INIT();
-
-    mbedtls_ecjpake_init(&ctx);
 
     TEST_ASSERT(mbedtls_ecjpake_setup(&ctx, role,
                                       MBEDTLS_MD_SHA256, MBEDTLS_ECP_DP_SECP256R1, pw,
@@ -187,12 +185,11 @@ exit:
 void read_round_two_cli(data_t *msg, int ref_ret)
 {
     mbedtls_ecjpake_context ctx;
+    mbedtls_ecjpake_init(&ctx);
     const unsigned char *pw = NULL;
     const size_t pw_len = 0;
 
     MD_PSA_INIT();
-
-    mbedtls_ecjpake_init(&ctx);
 
     TEST_ASSERT(mbedtls_ecjpake_setup(&ctx, MBEDTLS_ECJPAKE_CLIENT,
                                       MBEDTLS_MD_SHA256, MBEDTLS_ECP_DP_SECP256R1, pw,
@@ -216,12 +213,11 @@ exit:
 void read_round_two_srv(data_t *msg, int ref_ret)
 {
     mbedtls_ecjpake_context ctx;
+    mbedtls_ecjpake_init(&ctx);
     const unsigned char *pw = NULL;
     const size_t pw_len = 0;
 
     MD_PSA_INIT();
-
-    mbedtls_ecjpake_init(&ctx);
 
     TEST_ASSERT(mbedtls_ecjpake_setup(&ctx, MBEDTLS_ECJPAKE_SERVER,
                                       MBEDTLS_MD_SHA256, MBEDTLS_ECP_DP_SECP256R1, pw,

--- a/tests/suites/test_suite_hmac_drbg.function
+++ b/tests/suites/test_suite_hmac_drbg.function
@@ -41,14 +41,14 @@ void hmac_drbg_entropy_usage(int md_alg)
     size_t default_entropy_len;
     size_t expected_consumed_entropy = 0;
 
-    MD_PSA_INIT();
-
     mbedtls_hmac_drbg_init(&ctx);
     memset(buf, 0, sizeof(buf));
     memset(out, 0, sizeof(out));
 
     entropy.len = sizeof(buf);
     entropy.p = buf;
+
+    MD_PSA_INIT();
 
     md_info = mbedtls_md_info_from_type(md_alg);
     TEST_ASSERT(md_info != NULL);
@@ -129,10 +129,9 @@ void hmac_drbg_seed_file(int md_alg, char *path, int ret)
 {
     const mbedtls_md_info_t *md_info;
     mbedtls_hmac_drbg_context ctx;
+    mbedtls_hmac_drbg_init(&ctx);
 
     MD_PSA_INIT();
-
-    mbedtls_hmac_drbg_init(&ctx);
 
     md_info = mbedtls_md_info_from_type(md_alg);
     TEST_ASSERT(md_info != NULL);
@@ -159,11 +158,11 @@ void hmac_drbg_buf(int md_alg)
     mbedtls_hmac_drbg_context ctx;
     size_t i;
 
-    MD_PSA_INIT();
-
     mbedtls_hmac_drbg_init(&ctx);
     memset(buf, 0, sizeof(buf));
     memset(out, 0, sizeof(out));
+
+    MD_PSA_INIT();
 
     md_info = mbedtls_md_info_from_type(md_alg);
     TEST_ASSERT(md_info != NULL);
@@ -194,12 +193,12 @@ void hmac_drbg_no_reseed(int md_alg, data_t *entropy,
     const mbedtls_md_info_t *md_info;
     mbedtls_hmac_drbg_context ctx;
 
-    MD_PSA_INIT();
-
     mbedtls_hmac_drbg_init(&ctx);
 
     p_entropy.p = entropy->x;
     p_entropy.len = entropy->len;
+
+    MD_PSA_INIT();
 
     md_info = mbedtls_md_info_from_type(md_alg);
     TEST_ASSERT(md_info != NULL);
@@ -244,12 +243,12 @@ void hmac_drbg_nopr(int md_alg, data_t *entropy, data_t *custom,
     const mbedtls_md_info_t *md_info;
     mbedtls_hmac_drbg_context ctx;
 
-    MD_PSA_INIT();
-
     mbedtls_hmac_drbg_init(&ctx);
 
     p_entropy.p = entropy->x;
     p_entropy.len = entropy->len;
+
+    MD_PSA_INIT();
 
     md_info = mbedtls_md_info_from_type(md_alg);
     TEST_ASSERT(md_info != NULL);
@@ -279,12 +278,12 @@ void hmac_drbg_pr(int md_alg, data_t *entropy, data_t *custom,
     const mbedtls_md_info_t *md_info;
     mbedtls_hmac_drbg_context ctx;
 
-    MD_PSA_INIT();
-
     mbedtls_hmac_drbg_init(&ctx);
 
     p_entropy.p = entropy->x;
     p_entropy.len = entropy->len;
+
+    MD_PSA_INIT();
 
     md_info = mbedtls_md_info_from_type(md_alg);
     TEST_ASSERT(md_info != NULL);

--- a/tests/suites/test_suite_md.function
+++ b/tests/suites/test_suite_md.function
@@ -21,10 +21,10 @@ void mbedtls_md_list()
     const int *md_type_ptr;
     const mbedtls_md_info_t *info;
     mbedtls_md_context_t ctx;
+    mbedtls_md_init(&ctx);
     unsigned char out[MBEDTLS_MD_MAX_SIZE] = { 0 };
 
     MD_PSA_INIT();
-    mbedtls_md_init(&ctx);
 
     /*
      * Test that mbedtls_md_list() only returns valid MDs.
@@ -87,13 +87,13 @@ void md_to_from_psa()
 void md_null_args()
 {
     mbedtls_md_context_t ctx;
+    mbedtls_md_init(&ctx);
 #if defined(MBEDTLS_MD_C)
     const mbedtls_md_info_t *info = mbedtls_md_info_from_type(*(mbedtls_md_list()));
 #endif
     unsigned char buf[1] = { 0 };
 
     MD_PSA_INIT();
-    mbedtls_md_init(&ctx);
 
     TEST_EQUAL(0, mbedtls_md_get_size(NULL));
 #if defined(MBEDTLS_MD_C)
@@ -245,11 +245,10 @@ void md_text_multi(int md_type, char *text_src_string,
 
     const mbedtls_md_info_t *md_info = NULL;
     mbedtls_md_context_t ctx, ctx_copy;
-
-    MD_PSA_INIT();
-
     mbedtls_md_init(&ctx);
     mbedtls_md_init(&ctx_copy);
+
+    MD_PSA_INIT();
 
     halfway = src_len / 2;
 
@@ -291,12 +290,11 @@ void md_hex_multi(int md_type, data_t *src_str, data_t *hash)
     unsigned char output[MBEDTLS_MD_MAX_SIZE] = { 0 };
     const mbedtls_md_info_t *md_info = NULL;
     mbedtls_md_context_t ctx, ctx_copy;
+    mbedtls_md_init(&ctx);
+    mbedtls_md_init(&ctx_copy);
     int halfway;
 
     MD_PSA_INIT();
-
-    mbedtls_md_init(&ctx);
-    mbedtls_md_init(&ctx_copy);
 
     md_info = mbedtls_md_info_from_type(md_type);
     TEST_ASSERT(md_info != NULL);
@@ -363,11 +361,10 @@ void md_hmac_multi(int md_type, int trunc_size, data_t *key_str,
     unsigned char output[MBEDTLS_MD_MAX_SIZE] = { 0 };
     const mbedtls_md_info_t *md_info = NULL;
     mbedtls_md_context_t ctx;
+    mbedtls_md_init(&ctx);
     int halfway;
 
     MD_PSA_INIT();
-
-    mbedtls_md_init(&ctx);
 
     md_info = mbedtls_md_info_from_type(md_type);
     TEST_ASSERT(md_info != NULL);

--- a/tests/suites/test_suite_pem.function
+++ b/tests/suites/test_suite_pem.function
@@ -66,14 +66,13 @@ void mbedtls_pem_read_buffer(char *header, char *footer, char *data,
                              char *pwd, int res, data_t *out)
 {
     mbedtls_pem_context ctx;
+    mbedtls_pem_init(&ctx);
     int ret;
     size_t use_len = 0;
     size_t pwd_len = strlen(pwd);
     const unsigned char *buf;
 
     MD_PSA_INIT();
-
-    mbedtls_pem_init(&ctx);
 
     ret = mbedtls_pem_read_buffer(&ctx, header, footer, (unsigned char *) data,
                                   (unsigned char *) pwd, pwd_len, &use_len);

--- a/tests/suites/test_suite_pkcs1_v21.function
+++ b/tests/suites/test_suite_pkcs1_v21.function
@@ -14,18 +14,18 @@ void pkcs1_rsaes_oaep_encrypt(int mod, data_t *input_N, data_t *input_E,
 {
     unsigned char output[256];
     mbedtls_rsa_context ctx;
+    mbedtls_rsa_init(&ctx);
     mbedtls_test_rnd_buf_info info;
     mbedtls_mpi N, E;
-
-    MD_PSA_INIT();
+    mbedtls_mpi_init(&N); mbedtls_mpi_init(&E);
 
     info.fallback_f_rng = mbedtls_test_rnd_std_rand;
     info.fallback_p_rng = NULL;
     info.buf = rnd_buf->x;
     info.length = rnd_buf->len;
 
-    mbedtls_mpi_init(&N); mbedtls_mpi_init(&E);
-    mbedtls_rsa_init(&ctx);
+    MD_PSA_INIT();
+
     TEST_ASSERT(mbedtls_rsa_set_padding(&ctx,
                                         MBEDTLS_RSA_PKCS_V21, hash) == 0);
     memset(output, 0x00, sizeof(output));
@@ -66,17 +66,16 @@ void pkcs1_rsaes_oaep_decrypt(int mod, data_t *input_P, data_t *input_Q,
 {
     unsigned char output[64];
     mbedtls_rsa_context ctx;
+    mbedtls_rsa_init(&ctx);
     size_t output_len;
     mbedtls_test_rnd_pseudo_info rnd_info;
     mbedtls_mpi N, P, Q, E;
+    mbedtls_mpi_init(&N); mbedtls_mpi_init(&P);
+    mbedtls_mpi_init(&Q); mbedtls_mpi_init(&E);
     ((void) seed);
 
     MD_PSA_INIT();
 
-    mbedtls_mpi_init(&N); mbedtls_mpi_init(&P);
-    mbedtls_mpi_init(&Q); mbedtls_mpi_init(&E);
-
-    mbedtls_rsa_init(&ctx);
     TEST_ASSERT(mbedtls_rsa_set_padding(&ctx,
                                         MBEDTLS_RSA_PKCS_V21, hash) == 0);
 
@@ -131,19 +130,19 @@ void pkcs1_rsassa_pss_sign(int mod, data_t *input_P, data_t *input_Q,
 {
     unsigned char output[512];
     mbedtls_rsa_context ctx;
+    mbedtls_rsa_init(&ctx);
     mbedtls_test_rnd_buf_info info;
     mbedtls_mpi N, P, Q, E;
-
-    MD_PSA_INIT();
+    mbedtls_mpi_init(&N); mbedtls_mpi_init(&P);
+    mbedtls_mpi_init(&Q); mbedtls_mpi_init(&E);
 
     info.fallback_f_rng = mbedtls_test_rnd_std_rand;
     info.fallback_p_rng = NULL;
     info.buf = rnd_buf->x;
     info.length = rnd_buf->len;
 
-    mbedtls_mpi_init(&N); mbedtls_mpi_init(&P);
-    mbedtls_mpi_init(&Q); mbedtls_mpi_init(&E);
-    mbedtls_rsa_init(&ctx);
+    MD_PSA_INIT();
+
     TEST_ASSERT(mbedtls_rsa_set_padding(&ctx,
                                         MBEDTLS_RSA_PKCS_V21, hash) == 0);
 
@@ -196,13 +195,13 @@ void pkcs1_rsassa_pss_verify(int mod, data_t *input_N, data_t *input_E,
                              char *salt, data_t *result_str, int result)
 {
     mbedtls_rsa_context ctx;
+    mbedtls_rsa_init(&ctx);
     mbedtls_mpi N, E;
+    mbedtls_mpi_init(&N); mbedtls_mpi_init(&E);
     ((void) salt);
 
     MD_PSA_INIT();
 
-    mbedtls_mpi_init(&N); mbedtls_mpi_init(&E);
-    mbedtls_rsa_init(&ctx);
     TEST_ASSERT(mbedtls_rsa_set_padding(&ctx,
                                         MBEDTLS_RSA_PKCS_V21, hash) == 0);
 
@@ -236,12 +235,12 @@ void pkcs1_rsassa_pss_verify_ext(int mod, data_t *input_N, data_t *input_E,
                                  int result_full)
 {
     mbedtls_rsa_context ctx;
+    mbedtls_rsa_init(&ctx);
     mbedtls_mpi N, E;
+    mbedtls_mpi_init(&N); mbedtls_mpi_init(&E);
 
     MD_PSA_INIT();
 
-    mbedtls_mpi_init(&N); mbedtls_mpi_init(&E);
-    mbedtls_rsa_init(&ctx);
     TEST_ASSERT(mbedtls_rsa_set_padding(&ctx,
                                         MBEDTLS_RSA_PKCS_V21, ctx_hash) == 0);
 

--- a/tests/suites/test_suite_pkparse.function
+++ b/tests/suites/test_suite_pkparse.function
@@ -114,10 +114,10 @@ static int pk_can_ecdsa(const mbedtls_pk_context *ctx)
 void pk_parse_keyfile_rsa(char *key_file, char *password, int result)
 {
     mbedtls_pk_context ctx;
+    mbedtls_pk_init(&ctx);
     int res;
     char *pwd = password;
 
-    mbedtls_pk_init(&ctx);
     MD_PSA_INIT();
 
     if (strcmp(pwd, "NULL") == 0) {
@@ -161,9 +161,9 @@ exit:
 void pk_parse_public_keyfile_rsa(char *key_file, int result)
 {
     mbedtls_pk_context ctx;
+    mbedtls_pk_init(&ctx);
     int res;
 
-    mbedtls_pk_init(&ctx);
     MD_PSA_INIT();
 
     res = mbedtls_pk_parse_public_keyfile(&ctx, key_file);

--- a/tests/suites/test_suite_random.function
+++ b/tests/suites/test_suite_random.function
@@ -22,7 +22,9 @@
 void random_twice_with_ctr_drbg()
 {
     mbedtls_entropy_context entropy;
+    mbedtls_entropy_init(&entropy);
     mbedtls_ctr_drbg_context drbg;
+    mbedtls_ctr_drbg_init(&drbg);
     unsigned char output1[OUTPUT_SIZE];
     unsigned char output2[OUTPUT_SIZE];
 
@@ -34,8 +36,6 @@ void random_twice_with_ctr_drbg()
 
 
     /* First round */
-    mbedtls_entropy_init(&entropy);
-    mbedtls_ctr_drbg_init(&drbg);
     TEST_EQUAL(0, mbedtls_ctr_drbg_seed(&drbg,
                                         mbedtls_entropy_func, &entropy,
                                         NULL, 0));
@@ -73,7 +73,9 @@ exit:
 void random_twice_with_hmac_drbg(int md_type)
 {
     mbedtls_entropy_context entropy;
+    mbedtls_entropy_init(&entropy);
     mbedtls_hmac_drbg_context drbg;
+    mbedtls_hmac_drbg_init(&drbg);
     unsigned char output1[OUTPUT_SIZE];
     unsigned char output2[OUTPUT_SIZE];
     const mbedtls_md_info_t *md_info = mbedtls_md_info_from_type(md_type);
@@ -81,8 +83,6 @@ void random_twice_with_hmac_drbg(int md_type)
     MD_PSA_INIT();
 
     /* First round */
-    mbedtls_entropy_init(&entropy);
-    mbedtls_hmac_drbg_init(&drbg);
     TEST_EQUAL(0, mbedtls_hmac_drbg_seed(&drbg, md_info,
                                          mbedtls_entropy_func, &entropy,
                                          NULL, 0));


### PR DESCRIPTION
Trivial backport of https://github.com/Mbed-TLS/mbedtls/pull/9752. Given that this is fixing issues only in tests, only in circumstances that are very unusual in 3.6, I didn't bother to see if 3.6 might have other similar bits of code, i.e. I made even less effort at completeness than in development.

## PR checklist

- [x] **changelog** not required because: test stuff only
- [x] **development PR** https://github.com/Mbed-TLS/mbedtls/pull/9752
- [x] **framework PR** not required
- [x] **3.6 PR** here
- [x] **2.28 PR** not required because: `MD_PSA_INIT` didn't exist
- **tests**  statu quo



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
