### PR TITLE
Support Unicode in .function files

### DIFF
--- a/tests/suites/test_suite_psa_crypto_ecp.function
+++ b/tests/suites/test_suite_psa_crypto_ecp.function
@@ -53,7 +53,7 @@ static int check_ecc_private_key(psa_ecc_family_t family, size_t bits,
     }
 
     /* Check masked bits on Curve25519 and Curve448 scalars.
-     * See RFC 7748 \S4.1 (we expect the "decoded" form here). */
+     * See RFC 7748 §4.1 (we expect the "decoded" form here). */
 #if defined(MBEDTLS_PSA_BUILTIN_ECC_MONTGOMERY_255)
     if (family == PSA_ECC_FAMILY_MONTGOMERY && bits == 255) {
         TEST_EQUAL(key[0] & 0xf8, key[0]);

--- a/tf-psa-crypto/tests/suites/test_suite_dhm.function
+++ b/tf-psa-crypto/tests/suites/test_suite_dhm.function
@@ -38,7 +38,7 @@ static int check_dhm_param_output(const mbedtls_mpi *expected,
     n = (buffer[*offset] << 8) | buffer[*offset + 1];
     *offset += 2;
     /* The DHM param output from Mbed TLS has leading zeros stripped, as
-     * permitted but not required by RFC 5246 \S4.4. */
+     * permitted but not required by RFC 5246 §4.4. */
     TEST_EQUAL(n, mbedtls_mpi_size(expected));
     TEST_ASSERT(size >= *offset + n);
     TEST_EQUAL(0, mbedtls_mpi_read_binary(&actual, buffer + *offset, n));


### PR DESCRIPTION
Bring in https://github.com/Mbed-TLS/mbedtls-framework/pull/66 and take advantage of it. Fixes a gotcha I encountered in https://github.com/Mbed-TLS/mbedtls/pull/9739.

## PR checklist

- [x] **changelog** not required because: test stuff only
- [x] **development PR** here
- [x] **framework PR** provided Mbed-TLS/mbedtls-framework#66
- [ ] **3.6 PR** TODO
- [ ] **2.28 PR** TODO
- **tests**  provided
