### PR TITLE
Enable independent TF-PSA-Crypto file checks

### DIFF
--- a/tests/scripts/check_files.py
+++ b/tests/scripts/check_files.py
@@ -367,9 +367,13 @@ class LicenseIssueTracker(LineIssueTracker):
 
     heading = "License issue:"
 
+    TF_PSA_CRYPTO_PATH = "tf-psa-crypto/"
+    if build_tree.looks_like_tf_psa_crypto_root(os.getcwd()):
+        TF_PSA_CRYPTO_PATH = ""
+
     LICENSE_EXEMPTION_RE_LIST = [
         # Exempt third-party drivers which may be under a different license
-        r'tf-psa-crypto/drivers/(?=(everest)/.*)',
+        TF_PSA_CRYPTO_PATH + r'drivers/(?=(everest)/.*)',
         # Documentation explaining the license may have accidental
         # false positives.
         r'(ChangeLog|LICENSE|framework\/LICENSE|[-0-9A-Z_a-z]+\.md)\Z',
@@ -472,7 +476,8 @@ class IntegrityChecker:
         """Instantiate the sanity checker.
         Check files under the current directory.
         Write a report of issues to log_file."""
-        build_tree.check_repo_path()
+        if (not build_tree.looks_like_root(os.getcwd())):
+            raise Exception("This script must be run from Mbed TLS or TF-PSA-Crypto root")
         self.logger = None
         self.setup_logger(log_file)
         self.issues_to_check = [

--- a/tests/scripts/check_files.py
+++ b/tests/scripts/check_files.py
@@ -367,13 +367,9 @@ class LicenseIssueTracker(LineIssueTracker):
 
     heading = "License issue:"
 
-    TF_PSA_CRYPTO_PATH = "tf-psa-crypto/"
-    if build_tree.looks_like_tf_psa_crypto_root(os.getcwd()):
-        TF_PSA_CRYPTO_PATH = ""
-
     LICENSE_EXEMPTION_RE_LIST = [
         # Exempt third-party drivers which may be under a different license
-        TF_PSA_CRYPTO_PATH + r'drivers/(?=(everest)/.*)',
+        r'(tf-psa-crypto/)?drivers/(?=(everest)/.*)',
         # Documentation explaining the license may have accidental
         # false positives.
         r'(ChangeLog|LICENSE|framework\/LICENSE|[-0-9A-Z_a-z]+\.md)\Z',
@@ -476,7 +472,7 @@ class IntegrityChecker:
         """Instantiate the sanity checker.
         Check files under the current directory.
         Write a report of issues to log_file."""
-        if (not build_tree.looks_like_root(os.getcwd())):
+        if not build_tree.looks_like_root(os.getcwd()):
             raise Exception("This script must be run from Mbed TLS or TF-PSA-Crypto root")
         self.logger = None
         self.setup_logger(log_file)

--- a/tf-psa-crypto/tests/scripts/components-basic-checks.sh 
+++ b/tf-psa-crypto/tests/scripts/components-basic-checks.sh 
@@ -1,0 +1,15 @@
+# components-basic-checks.sh
+#
+# Copyright The Mbed TLS Contributors
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+
+# This file contains test components that are executed by all.sh
+
+################################################################
+#### Basic checks
+################################################################
+
+component_tf_psa_crypto_check_files () {
+    msg "Check: file sanity checks (permissions, encodings)" # < 1s
+    ../tests/scripts/check_files.py
+}


### PR DESCRIPTION
## Description

Cloes [#51](https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/51).

This could potentially be further refactored in two ways;
- Seperate the script into two, one for MbedTLS and another for TF-PSA-Crypto
- Seperate TF-PSA-Crypto from MbedTLS inside of the script.

This has a dependency on: #9767.

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** not required because: Non-API change.
- [x] **development PR** provided.
- [x] **framework PR** not required.
- [x] **3.6 PR** not required because: for repo split.
- [x] **2.28 PR** not required because: for repo split.
- **tests**  not required.

## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
