### PR TITLE
Add header and documentation for interruptible ECC export public-key

### DIFF
--- a/tests/include/test/psa_test_wrappers.h
+++ b/tests/include/test/psa_test_wrappers.h
@@ -348,6 +348,25 @@ psa_status_t mbedtls_test_wrap_psa_export_public_key(
 #define psa_export_public_key(arg0_key, arg1_data, arg2_data_size, arg3_data_length) \
     mbedtls_test_wrap_psa_export_public_key(arg0_key, arg1_data, arg2_data_size, arg3_data_length)
 
+psa_status_t mbedtls_test_wrap_psa_export_public_key_iop_abort(
+    psa_export_public_key_iop_t *arg0_operation);
+#define psa_export_public_key_iop_abort(arg0_operation) \
+    mbedtls_test_wrap_psa_export_public_key_iop_abort(arg0_operation)
+
+psa_status_t mbedtls_test_wrap_psa_export_public_key_iop_complete(
+    psa_export_public_key_iop_t *arg0_operation,
+    uint8_t *arg1_data,
+    size_t arg2_data_size,
+    size_t *arg3_data_length);
+#define psa_export_public_key_iop_complete(arg0_operation, arg1_data, arg2_data_size, arg3_data_length) \
+    mbedtls_test_wrap_psa_export_public_key_iop_complete(arg0_operation, arg1_data, arg2_data_size, arg3_data_length)
+
+psa_status_t mbedtls_test_wrap_psa_export_public_key_iop_setup(
+    psa_export_public_key_iop_t *arg0_operation,
+    psa_key_id_t arg1_key);
+#define psa_export_public_key_iop_setup(arg0_operation, arg1_key) \
+    mbedtls_test_wrap_psa_export_public_key_iop_setup(arg0_operation, arg1_key)
+
 psa_status_t mbedtls_test_wrap_psa_generate_key(
     const psa_key_attributes_t *arg0_attributes,
     mbedtls_svc_key_id_t *arg1_key);

--- a/tests/src/psa_test_wrappers.c
+++ b/tests/src/psa_test_wrappers.c
@@ -595,6 +595,40 @@ psa_status_t mbedtls_test_wrap_psa_export_public_key(
     return status;
 }
 
+/* Wrapper for psa_export_public_key_iop_abort */
+psa_status_t mbedtls_test_wrap_psa_export_public_key_iop_abort(
+    psa_export_public_key_iop_t *arg0_operation)
+{
+    psa_status_t status = (psa_export_public_key_iop_abort)(arg0_operation);
+    return status;
+}
+
+/* Wrapper for psa_export_public_key_iop_complete */
+psa_status_t mbedtls_test_wrap_psa_export_public_key_iop_complete(
+    psa_export_public_key_iop_t *arg0_operation,
+    uint8_t *arg1_data,
+    size_t arg2_data_size,
+    size_t *arg3_data_length)
+{
+#if !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS)
+    MBEDTLS_TEST_MEMORY_POISON(arg1_data, arg2_data_size);
+#endif /* !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS) */
+    psa_status_t status = (psa_export_public_key_iop_complete)(arg0_operation, arg1_data, arg2_data_size, arg3_data_length);
+#if !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS)
+    MBEDTLS_TEST_MEMORY_UNPOISON(arg1_data, arg2_data_size);
+#endif /* !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS) */
+    return status;
+}
+
+/* Wrapper for psa_export_public_key_iop_setup */
+psa_status_t mbedtls_test_wrap_psa_export_public_key_iop_setup(
+    psa_export_public_key_iop_t *arg0_operation,
+    psa_key_id_t arg1_key)
+{
+    psa_status_t status = (psa_export_public_key_iop_setup)(arg0_operation, arg1_key);
+    return status;
+}
+
 /* Wrapper for psa_generate_key */
 psa_status_t mbedtls_test_wrap_psa_generate_key(
     const psa_key_attributes_t *arg0_attributes,

--- a/tf-psa-crypto/core/psa_crypto.c
+++ b/tf-psa-crypto/core/psa_crypto.c
@@ -1664,6 +1664,45 @@ exit:
     return (status == PSA_SUCCESS) ? unlock_status : status;
 }
 
+/****************************************************************/
+/* Interruptible ECC Export Public-key */
+/****************************************************************/
+
+uint32_t psa_export_public_key_iop_get_num_ops(psa_export_public_key_iop_t *operation)
+{
+    (void) operation;
+    return 0;
+}
+
+psa_status_t psa_export_public_key_iop_setup(psa_export_public_key_iop_t *operation,
+                                             psa_key_id_t key)
+{
+    (void) operation;
+    (void) key;
+
+    return PSA_ERROR_NOT_SUPPORTED;
+}
+
+psa_status_t psa_export_public_key_iop_complete(psa_export_public_key_iop_t *operation,
+                                                uint8_t *data,
+                                                size_t data_size,
+                                                size_t *data_length)
+{
+    (void) operation;
+    (void) data;
+    (void) data_size;
+    (void) data_length;
+
+    return PSA_ERROR_NOT_SUPPORTED;
+}
+
+psa_status_t psa_export_public_key_iop_abort(psa_export_public_key_iop_t *operation)
+{
+    (void) operation;
+
+    return PSA_ERROR_NOT_SUPPORTED;
+}
+
 /** Validate that a key policy is internally well-formed.
  *
  * This function only rejects invalid policies. It does not validate the

--- a/tf-psa-crypto/include/psa/crypto.h
+++ b/tf-psa-crypto/include/psa/crypto.h
@@ -5241,8 +5241,6 @@ psa_status_t psa_key_agreement_iop_complete(
  *
  * \retval #PSA_SUCCESS
  *          The operation was aborted successfully.
- *
- * \retval #PSA_ERROR_NOT_SUPPORTED \emptydescription
  * \retval #PSA_ERROR_BAD_STATE
  *          The library has not been previously initialized by
  *          \c psa_crypto_init().
@@ -5533,8 +5531,6 @@ psa_status_t psa_generate_key_iop_complete(
  *
  * \retval #PSA_SUCCESS
  *          The operation was aborted successfully.
- *
- * \retval #PSA_ERROR_NOT_SUPPORTED \emptydescription
  * \retval #PSA_ERROR_BAD_STATE
  *          The library has not been previously initialized by
  *          \c psa_crypto_init().
@@ -5793,8 +5789,6 @@ psa_status_t psa_export_public_key_iop_complete(psa_export_public_key_iop_t *ope
  *
  * \retval #PSA_SUCCESS
  *          The operation was aborted successfully.
- *
- * \retval #PSA_ERROR_NOT_SUPPORTED \emptydescription
  * \retval #PSA_ERROR_BAD_STATE
  *          The library has not been previously initialized by
  *          \c psa_crypto_init().

--- a/tf-psa-crypto/include/psa/crypto.h
+++ b/tf-psa-crypto/include/psa/crypto.h
@@ -5274,7 +5274,7 @@ psa_status_t psa_key_agreement_iop_abort(
  *   \endcode
  * - Initialize the structure to the initializer #PSA_GENERATE_KEY_IOP_INIT,
  *   for example:
- * - \code
+ *   \code
  *   psa_generate_key_iop_t operation = PSA_GENERATE_KEY_IOP_INIT;
  *   \endcode
  * - Assign the result of the function psa_generate_key_iop_init() to the
@@ -5302,7 +5302,6 @@ typedef struct psa_generate_key_iop_s psa_generate_key_iop_t;
  * \warning                     This is a beta API, and thus subject to change
  *                              at any point. It is not bound by the usual
  *                              interface stability promises.
- *
  *                              This is a helper provided to help you tune the
  *                              value passed to \c
  *                              psa_interruptible_set_max_ops().
@@ -5497,7 +5496,7 @@ psa_status_t psa_generate_key_iop_setup(
  *         The following conditions can result in this error:
  *         * The library has not been previously initialized by
  *           \c psa_crypto_init().
- *         * The operation state is not valid: it must be inactive.
+ *         * The operation state is not valid: it must be active.
  */
 psa_status_t psa_generate_key_iop_complete(
     psa_generate_key_iop_t *operation,
@@ -5528,7 +5527,7 @@ psa_status_t psa_generate_key_iop_complete(
  *                              psa_generate_key_iop_abort() after the
  *                              operation has already been terminated by a call
  *                              to \c psa_generate_key_iop_abort() or
- *                              psa_generate_key_iop_complete() is safe.
+ *                              \c psa_generate_key_iop_complete() is safe.
  *
  * \param[in,out] operation     The \c psa_key_agreement_iop_t to use
  *

--- a/tf-psa-crypto/include/psa/crypto.h
+++ b/tf-psa-crypto/include/psa/crypto.h
@@ -5550,10 +5550,10 @@ psa_status_t psa_generate_key_iop_abort(
  */
 
 /**
- *  The type of the state data structure for interruptible key generation
+ *  The type of the state data structure for interruptible public-key export
  *  operations.
  *
- *  Before calling any function on an interruptible key generation object, the
+ *  Before calling any function on an interruptible export public-key object, the
  *  application must initialize it by any of the following means:
  * - Set the structure to all-bits-zero, for example:
  * \code
@@ -5569,7 +5569,7 @@ psa_status_t psa_generate_key_iop_abort(
  * \code
  * psa_export_public_key_iop_t operation = PSA_EXPORT_PUBLIC_KEY_IOP_INIT;
  * \endcode
- * - Assign the result of the function psa_generate_key_iop_init() to the
+ * - Assign the result of the function psa_export_public_key_iop_init() to the
  *   structure, for example:
  * \code
  * psa_export_public_key_iop_t operation;
@@ -5583,7 +5583,7 @@ psa_status_t psa_generate_key_iop_abort(
 typedef struct psa_export_public_key_iop_s psa_export_public_key_iop_t;
 
 /**
- * \brief                       Get the number of ops that a key generation
+ * \brief                       Get the number of ops that an export public-key
  *                              operation has taken so far. If the operation has
  *                              completed, then this will represent the number
  *                              of ops required for the entire operation. After

--- a/tf-psa-crypto/include/psa/crypto.h
+++ b/tf-psa-crypto/include/psa/crypto.h
@@ -5731,9 +5731,6 @@ psa_status_t psa_export_public_key_iop_setup(psa_export_public_key_iop_t *operat
  *                               * \c PSA_EXPORT_PUBLIC_KEY_MAX_SIZE evaluates to the maximum
  *                                 output size of any supported public key or public part
  *                                 of a key pair.
- *                               * \c PSA_EXPORT_ASYMMETRIC_KEY_MAX_SIZE evaluates
- *                                 to the maximum output size of any supported public
- *                                 key or key pair.
  *
  * \param[out] data_length      On success, the number of bytes that make up the key data.
  *
@@ -5748,9 +5745,7 @@ psa_status_t psa_export_public_key_iop_setup(psa_export_public_key_iop_t *operat
  * \retval #PSA_ERROR_BUFFER_TOO_SMALL
  *          The size of the data buffer is too small.
  *          \c PSA_EXPORT_PUBLIC_KEY_OUTPUT_SIZE(),
- *          \c PSA_EXPORT_PUBLIC_KEY_MAX_SIZE, or
- *          \c PSA_EXPORT_ASYMMETRIC_KEY_MAX_SIZE can be used to determine a
- *          sufficient buffer size.
+ *          \c PSA_EXPORT_PUBLIC_KEY_MAX_SIZE.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY \emptydescription
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE \emptydescription
  * \retval #PSA_ERROR_CORRUPTION_DETECTED \emptydescription

--- a/tf-psa-crypto/include/psa/crypto.h
+++ b/tf-psa-crypto/include/psa/crypto.h
@@ -5545,6 +5545,44 @@ psa_status_t psa_generate_key_iop_abort(
 
 /**@}*/
 
+/**
+ *  \defgroup interruptible_export_public_key Interruptible public-key export
+ * @{
+ */
+
+/**
+ *  The type of the state data structure for interruptible key generation
+ *  operations.
+ *
+ *  Before calling any function on an interruptible key generation object, the
+ *  application must initialize it by any of the following means:
+ * - Set the structure to all-bits-zero, for example:
+ * \code
+ * psa_export_public_key_iop_t operation;
+ * memset(&operation, 0, sizeof(operation));
+ * \endcode
+ * - Initialize the structure to logical zero values, for example:
+ * \code
+ * static psa_export_public_key_iop_t operation;
+ * \endcode
+ * - Initialize the structure to the initializer #PSA_EXPORT_PUBLIC_KEY_IOP_INIT,
+ *   for example:
+ * \code
+ * psa_export_public_key_iop_t operation = PSA_EXPORT_PUBLIC_KEY_IOP_INIT;
+ * \endcode
+ * - Assign the result of the function psa_generate_key_iop_init() to the
+ *   structure, for example:
+ * \code
+ * psa_export_public_key_iop_t operation;
+ * operation = psa_export_public_key_iop_init();
+ * \endcode
+ *
+ * This is an implementation-defined \c struct. Applications should not
+ * make any assumptions about the content of this structure.
+ * Implementation details can change in future versions without notice.
+ */
+typedef struct psa_export_public_key_iop_s psa_export_public_key_iop_t;
+
 #ifdef __cplusplus
 }
 #endif

--- a/tf-psa-crypto/include/psa/crypto.h
+++ b/tf-psa-crypto/include/psa/crypto.h
@@ -5583,6 +5583,30 @@ psa_status_t psa_generate_key_iop_abort(
  */
 typedef struct psa_export_public_key_iop_s psa_export_public_key_iop_t;
 
+/**
+ * \brief                       Get the number of ops that a key generation
+ *                              operation has taken so far. If the operation has
+ *                              completed, then this will represent the number
+ *                              of ops required for the entire operation. After
+ *                              initialization or calling
+ *                              \c psa_export_public_key_iop_abort() on the operation,
+ *                              a value of 0 will be returned.
+ *
+ * \warning                     This is a beta API, and thus subject to change
+ *                              at any point. It is not bound by the usual
+ *                              interface stability promises.
+ *                              This is a helper provided to help you tune the
+ *                              value passed to
+ *                              \c psa_interruptible_set_max_ops().
+ *
+ * \param operation             The \c psa_export_public_key_iop_t to use. This must
+ *                              be initialized first.
+ *
+ * \return                      Number of ops that the operation has taken so
+ *                              far.
+ */
+uint32_t psa_export_public_key_iop_get_num_ops(psa_export_public_key_iop_t *operation);
+
 #ifdef __cplusplus
 }
 #endif

--- a/tf-psa-crypto/include/psa/crypto.h
+++ b/tf-psa-crypto/include/psa/crypto.h
@@ -5768,6 +5768,49 @@ psa_status_t psa_export_public_key_iop_complete(psa_export_public_key_iop_t *ope
                                                 size_t data_size,
                                                 size_t *data_length);
 
+/**
+ * \brief                       Abort an interruptible public-key export operation.
+ *
+ * \warning                     This is a beta API, and thus subject to change
+ *                              at any point. It is not bound by the usual
+ *                              interface stability promises.
+ *
+ * \note                        This function clears the number of ops completed
+ *                              as part of the operation. Please ensure you copy
+ *                              this value via
+ *                              \c psa_export_public_key_iop_get_num_ops() if
+ *                              required before calling.
+ *
+ * \note                        Aborting an operation frees all
+ *                              associated resources except for the operation
+ *                              structure itself. Once aborted, the operation
+ *                              object can be reused for another operation by
+ *                              calling \c psa_export_public_key_iop_setup() again.
+ *
+ * \note                        You may call this function any time after the
+ *                              operation object has been initialized.
+ *                              In particular, calling
+ *                              \c psa_export_public_key_iop_abort() after the
+ *                              operation has already been terminated by a call
+ *                              to \c psa_export_public_key_iop_abort() or
+ *                              \c psa_export_public_key_iop_complete() is safe.
+ *
+ * \param[in,out] operation     The \c psa_export_public_key_iop_t to use
+ *
+ * \retval #PSA_SUCCESS
+ *          The operation was aborted successfully.
+ *
+ * \retval #PSA_ERROR_NOT_SUPPORTED \emptydescription
+ * \retval #PSA_ERROR_BAD_STATE
+ *          The library has not been previously initialized by
+ *          \c psa_crypto_init().
+ * \retval #PSA_ERROR_CORRUPTION_DETECTED \emptydescription
+ *
+ */
+psa_status_t psa_export_public_key_iop_abort(psa_export_public_key_iop_t *operation);
+
+/**@}*/
+
 #ifdef __cplusplus
 }
 #endif

--- a/tf-psa-crypto/include/psa/crypto.h
+++ b/tf-psa-crypto/include/psa/crypto.h
@@ -5558,7 +5558,7 @@ psa_status_t psa_generate_key_iop_abort(
  * \endcode
  * - Initialize the structure to logical zero values, for example:
  * \code
- * static psa_export_public_key_iop_t operation;
+ * psa_export_public_key_iop_t operation = {0};
  * \endcode
  * - Initialize the structure to the initializer #PSA_EXPORT_PUBLIC_KEY_IOP_INIT,
  *   for example:

--- a/tf-psa-crypto/include/psa/crypto.h
+++ b/tf-psa-crypto/include/psa/crypto.h
@@ -5684,6 +5684,90 @@ uint32_t psa_export_public_key_iop_get_num_ops(psa_export_public_key_iop_t *oper
 psa_status_t psa_export_public_key_iop_setup(psa_export_public_key_iop_t *operation,
                                              psa_key_id_t key);
 
+/**
+ * \brief                       Continue and eventually complete the action of
+ *                              exporting a public key, in an interruptible
+ *                              manner.
+ * \see                         \c psa_export_public_key_iop_setup()
+ *
+ * \warning                     This is a beta API, and thus subject to change
+ *                              at any point. It is not bound by the usual
+ *                              interface stability promises.
+ *
+ * \note                        This function combined with
+ *                              \c psa_export_public_key_iop_setup() is equivalent to
+ *                              \c psa_export_public_key() but this
+ *                              function can return early and resume according
+ *                              to the limit set with
+ *                              \c psa_interruptible_set_max_ops() to reduce the
+ *                              maximum time spent in a function call.
+ *
+ * \note                        Users should call this function on the same
+ *                              operation object repeatedly whilst it returns
+ *                              #PSA_OPERATION_INCOMPLETE, stopping when it
+ *                              returns either #PSA_SUCCESS or an error.
+ *                              Alternatively users can call
+ *                              \c psa_export_public_key_iop_abort() at any
+ *                              point if they no longer want the result.
+ *
+ * \note                        When this function returns successfully, the
+ *                              operation becomes inactive. If this function
+ *                              returns an error status, the operation enters an
+ *                              error state and must be aborted by calling
+ *                              \c psa_export_public_key_iop_abort().
+ *
+ * \param[in, out] operation    The \c psa_export_public_key_iop_t to use.
+ *                              This must be initialized first, and have had
+ *                              \c psa_export_public_key_iop_setup() called
+ *                              with it first.
+ *
+ * \param[out] data             Buffer where the key data is to be written.
+ *
+ * \param[in] data_size         Size of the \c data buffer in bytes.
+ *                              This must be appropriate for the key:
+ *                               * The required output size is
+ *                                 \c PSA_EXPORT_PUBLIC_KEY_OUTPUT_SIZE(type, bits)
+ *                                 where type is the key type and bits is the key
+ *                                 size in bits.
+ *                               * \c PSA_EXPORT_PUBLIC_KEY_MAX_SIZE evaluates to the maximum
+ *                                 output size of any supported public key or public part
+ *                                 of a key pair.
+ *                               * \c PSA_EXPORT_ASYMMETRIC_KEY_MAX_SIZE evaluates
+ *                                 to the maximum output size of any supported public
+ *                                 key or key pair.
+ *
+ * \param[out] data_length      On success, the number of bytes that make up the key data.
+ *
+ * \retval #PSA_SUCCESS
+ *         Success. The first (*\c data_length) bytes of data contain the exported
+           public key.
+ * \retval #PSA_ERROR_BAD_STATE
+ *         The following conditions can result in this error:
+ *         * The library has not been previously initialized by
+ *           \c psa_crypto_init().
+ *         * The operation state is not valid: it must be active.
+ * \retval #PSA_ERROR_BUFFER_TOO_SMALL
+ *          The size of the data buffer is too small.
+ *          \c PSA_EXPORT_PUBLIC_KEY_OUTPUT_SIZE(),
+ *          \c PSA_EXPORT_PUBLIC_KEY_MAX_SIZE, or
+ *          \c PSA_EXPORT_ASYMMETRIC_KEY_MAX_SIZE can be used to determine a
+ *          sufficient buffer size.
+ * \retval #PSA_ERROR_INSUFFICIENT_MEMORY \emptydescription
+ * \retval #PSA_ERROR_COMMUNICATION_FAILURE \emptydescription
+ * \retval #PSA_ERROR_CORRUPTION_DETECTED \emptydescription
+ * \retval #PSA_ERROR_STORAGE_FAILURE \emptydescription
+ * \retval #PSA_ERROR_DATA_CORRUPT \emptydescription
+ * \retval #PSA_ERROR_DATA_INVALID \emptydescription
+ * \retval #PSA_OPERATION_INCOMPLETE
+ *         Operation was interrupted due to the setting of
+ *         \c psa_interruptible_set_max_ops(). There is still work to be done.
+ *         Call this function again with the same operation object.
+ */
+psa_status_t psa_export_public_key_iop_complete(psa_export_public_key_iop_t *operation,
+                                                uint8_t *data,
+                                                size_t data_size,
+                                                size_t *data_length);
+
 #ifdef __cplusplus
 }
 #endif

--- a/tf-psa-crypto/include/psa/crypto.h
+++ b/tf-psa-crypto/include/psa/crypto.h
@@ -5607,6 +5607,83 @@ typedef struct psa_export_public_key_iop_s psa_export_public_key_iop_t;
  */
 uint32_t psa_export_public_key_iop_get_num_ops(psa_export_public_key_iop_t *operation);
 
+/**
+ * \brief                       Start an interruptible operation to export a
+ *                              public key or the public part of a key pair in
+ *                              binary format.
+
+ *
+ * \see                         \c psa_export_public_key_iop_complete()
+ *
+ * \warning                     This is a beta API, and thus subject to change
+ *                              at any point. It is not bound by the usual
+ *                              interface stability promises.
+ *
+ * \note                        This function combined with
+ *                              \c psa_export_public_key_iop_complete() is equivalent
+ *                              to \c psa_export_public_key() but
+ *                               \c psa_export_public_key_iop_complete() can return
+ *                              early and resume according to the limit set with
+ *                              \c psa_interruptible_set_max_ops() to reduce the
+ *                              maximum time spent in a function.
+ *
+ * \note                        Users should call
+ *                              \c psa_export_public_key_iop_complete() repeatedly
+ *                              on the same operation object after a successful
+ *                              call to this function until
+ *                              \c psa_export_public_key_iop_complete() either returns
+ *                              #PSA_SUCCESS or an error.
+ *                              \c psa_export_public_key_iop_complete() will return
+ *                              #PSA_OPERATION_INCOMPLETE if there is more work
+ *                              to do. Alternatively users can call
+ *                              \c psa_export_public_key_iop_abort() at any point
+ *                              if they no longer want the result.
+ *
+ *  \note                       This function clears the number of ops completed
+ *                              as part of the operation. Please ensure you copy
+ *                              this value via
+ *                              \c psa_export_public_key_iop_get_num_ops() if
+ *                              required before calling.
+ *
+ * \note                        If this function returns an error status, the
+ *                              operation enters an error state and must be
+ *                              aborted by calling
+ *                              \c psa_export_public_key_iop_abort().
+ *
+ * \param[in, out] operation    The \c psa_export_public_key_iop_t to use.
+ *                              This must be initialized as per the
+ *                              documentation for
+ *                              \c psa_export_public_key_iop_t, and be inactive.
+ *
+ * \param[in]      key          Identifier of the key to export.
+ *
+ * \retval #PSA_SUCCESS
+ *          The operation started successfully.
+ *          Call \c psa_export_public_key_iop_complete() with the same context to
+ *          complete the operation.
+ * \retval #PSA_ERROR_INVALID_HANDLE
+ *          \c key is not a valid key identifier.
+ * \retval #PSA_ERROR_INVALID_ARGUMENT
+ *         The key is neither a public key nor a key pair.
+ * \retval #PSA_ERROR_NOT_SUPPORTED
+ *         The following conditions can result in this error:
+ *          * The key's storage location does not support export of the key.
+ *          * The implementation does not support export of keys with this key type.
+ * \retval #PSA_ERROR_BAD_STATE
+ *         The following conditions can result in this error:
+ *         * The library has not been previously initialized by
+ *           \c psa_crypto_init().
+ *         * The operation state is not valid: it must be inactive.
+ * \retval #PSA_ERROR_COMMUNICATION_FAILURE \emptydescription
+ * \retval #PSA_ERROR_CORRUPTION_DETECTED \emptydescription
+ * \retval #PSA_ERROR_STORAGE_FAILURE \emptydescription
+ * \retval #PSA_ERROR_DATA_CORRUPT \emptydescription
+ * \retval #PSA_ERROR_DATA_INVALID \emptydescription
+ * \retval #PSA_ERROR_INSUFFICIENT_MEMORY \emptydescription
+ */
+psa_status_t psa_export_public_key_iop_setup(psa_export_public_key_iop_t *operation,
+                                             psa_key_id_t key);
+
 #ifdef __cplusplus
 }
 #endif

--- a/tf-psa-crypto/include/psa/crypto_struct.h
+++ b/tf-psa-crypto/include/psa/crypto_struct.h
@@ -568,6 +568,37 @@ psa_generate_key_iop_init(void)
     return v;
 }
 
+/**
+ * \brief The context for PSA interruptible export public-key.
+ */
+struct psa_export_public_key_iop_s {
+#if defined(MBEDTLS_PSA_CRYPTO_CLIENT) && !defined(MBEDTLS_PSA_CRYPTO_C)
+    mbedtls_psa_client_handle_t handle;
+#else
+    /**
+     *  Unique ID indicating which driver got assigned to do the
+     * operation. Since driver contexts are driver-specific, swapping
+     * drivers halfway through the operation is not supported.
+     * ID values are auto-generated in psa_crypto_driver_wrappers.h
+     * ID value zero means the context is not valid or not assigned to
+     * any driver (i.e. none of the driver contexts are active).
+     */
+    unsigned int MBEDTLS_PRIVATE(id);
+#endif
+};
+#if defined(MBEDTLS_PSA_CRYPTO_CLIENT) && !defined(MBEDTLS_PSA_CRYPTO_C)
+#define PSA_EXPORT_PUBLIC_KEY_IOP_INIT { 0 }
+#else
+#define PSA_EXPORT_PUBLIC_KEY_IOP_INIT { 0 }
+#endif
+
+static inline struct psa_export_public_key_iop_s psa_export_public_key_iop_init(void)
+{
+    const struct psa_export_public_key_iop_s v = PSA_EXPORT_PUBLIC_KEY_IOP_INIT;
+
+    return v;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/tf-psa-crypto/include/psa/crypto_struct.h
+++ b/tf-psa-crypto/include/psa/crypto_struct.h
@@ -531,7 +531,7 @@ psa_key_agreement_iop_init(void)
 }
 
 /**
- * \brief The context for PSA interruptible key agreement.
+ * \brief The context for PSA interruptible key generation.
  */
 struct psa_generate_key_iop_s {
 #if defined(MBEDTLS_PSA_CRYPTO_CLIENT) && !defined(MBEDTLS_PSA_CRYPTO_C)


### PR DESCRIPTION
## Description

Add the PSA interface headers and documentation for interruptible ECC export public-key


## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [X] **changelog** not required because: 
- [X] **development PR** not required because: 
- [X] **framework PR**  not required
- [X] **3.6 PR** not required because: 
- [X] **2.28 PR** not required because: 
- [X] **tests**  not required because: 

