### PR TITLE
Remove discussions of MBEDTLS_USE_PSA_CRYPTO in API documentation

### DIFF
--- a/configs/ext/README.md
+++ b/configs/ext/README.md
@@ -21,5 +21,6 @@ In TF-M, they are distributed under a 3-Clause BSD license, as noted at the top 
 
 In Mbed TLS, with permission from the TF-M project, they are distributed under a dual [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) OR [GPL-2.0-or-later](https://spdx.org/licenses/GPL-2.0-or-later.html) license, with copyright assigned to The Mbed TLS Contributors.
 
-We only retain the note at the top of the files because we are taking the files verbatim, for ease of
-maintenance.
+We only retain the note at the top of the files because the intent is to take these files verbatim,
+for ease of maintenance. Currently however, they contain changes, showing how these configurations
+will need to be adapted for 4.0.

--- a/configs/ext/tfm_mbedcrypto_config_profile_medium.h
+++ b/configs/ext/tfm_mbedcrypto_config_profile_medium.h
@@ -520,8 +520,7 @@
  * Compared to the default implementation:
  *
  * - p256-m has a much smaller code size and RAM footprint.
- * - p256-m is only available via the PSA API. This includes the pk module
- *   when #MBEDTLS_USE_PSA_CRYPTO is enabled.
+ * - p256-m is only available via the PSA API. This includes the pk module.
  * - p256-m does not support deterministic ECDSA, EC-JPAKE, custom protocols
  *   over the core arithmetic, or deterministic derivation of keys.
  *
@@ -534,7 +533,6 @@
  * cryptographic mechanisms through the PSA API:
  * - #MBEDTLS_PSA_CRYPTO_C and #MBEDTLS_PSA_CRYPTO_CONFIG for PSA-based
  *   configuration;
- * - #MBEDTLS_USE_PSA_CRYPTO if you want to use p256-m from PK, X.509 or TLS;
  * - #PSA_WANT_ECC_SECP_R1_256;
  * - #PSA_WANT_ALG_ECDH and/or #PSA_WANT_ALG_ECDSA as needed;
  * - #PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY, #PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_BASIC,

--- a/include/mbedtls/config_adjust_legacy_crypto.h
+++ b/include/mbedtls/config_adjust_legacy_crypto.h
@@ -271,8 +271,6 @@
  *     case there is no associated issue to track it yet.
  * - PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE because Weierstrass key derivation
  *   still depends on ECP_LIGHT.
- * - PK_C + USE_PSA + PSA_WANT_ALG_ECDSA is a temporary dependency which will
- *   be fixed by #7453.
  */
 #if defined(MBEDTLS_ECP_C) || \
     defined(MBEDTLS_PK_PARSE_EC_EXTENDED) || \

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -1556,8 +1556,6 @@
  *
  * Requires: PSA_WANT_ALG_SHA_256 or PSA_WANT_ALG_SHA_384
  *
- * \warning You must call psa_crypto_init() before doing any TLS operations.
- *
  * Comment this macro to disable support for TLS 1.2 / DTLS 1.2
  */
 #define MBEDTLS_SSL_PROTO_TLS1_2
@@ -1572,8 +1570,6 @@
  *
  * Requires: MBEDTLS_SSL_KEEP_PEER_CERTIFICATE
  * Requires: MBEDTLS_PSA_CRYPTO_C
- *
- * \warning You must call psa_crypto_init() before doing any TLS operations.
  *
  * Uncomment this macro to enable the support for TLS 1.3.
  */
@@ -3265,6 +3261,8 @@
  *
  * Requires: MBEDTLS_SSL_TLS_C
  *
+ * \warning You must call psa_crypto_init() before doing any TLS operations.
+ *
  * This module is required for SSL/TLS client support.
  */
 #define MBEDTLS_SSL_CLI_C
@@ -3278,6 +3276,8 @@
  * Caller:
  *
  * Requires: MBEDTLS_SSL_TLS_C
+ *
+ * \warning You must call psa_crypto_init() before doing any TLS operations.
  *
  * This module is required for SSL/TLS server support.
  */

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -642,7 +642,9 @@
  * \note  When this option is enabled, restartable operations in PK, X.509
  *        and TLS (see above) are not using PSA. On the other hand, ECDH
  *        computations in TLS are using PSA, and are not restartable. These
- *        are temporary limitations that should be lifted in the future.
+ *        are temporary limitations that should be lifted in the future. (See
+ *        https://github.com/Mbed-TLS/mbedtls/issues/9784 and
+ *        https://github.com/Mbed-TLS/mbedtls/issues/9817)
  *
  * Requires: MBEDTLS_ECP_C
  *

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -630,8 +630,6 @@
  * - Changes the behaviour of TLS 1.2 clients (not servers) when using the
  *   ECDHE-ECDSA key exchange (not other key exchanges) to make all ECC
  *   computations restartable:
- *   - ECDH operations from the key exchange, only for Short Weierstrass
- *     curves, only when MBEDTLS_USE_PSA_CRYPTO is not enabled.
  *   - verification of the server's key exchange signature;
  *   - verification of the server's certificate chain;
  *   - generation of the client's signature if client authentication is used,
@@ -641,11 +639,10 @@
  *        mbedtls_ssl_handshake(), can now return
  *        MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS.
  *
- * \note  When this option and MBEDTLS_USE_PSA_CRYPTO are both enabled,
- *        restartable operations in PK, X.509 and TLS (see above) are not
- *        using PSA. On the other hand, ECDH computations in TLS are using
- *        PSA, and are not restartable. These are temporary limitations that
- *        should be lifted in the future.
+ * \note  When this option is enabled, restartable operations in PK, X.509
+ *        and TLS (see above) are not using PSA. On the other hand, ECDH
+ *        computations in TLS are using PSA, and are not restartable. These
+ *        are temporary limitations that should be lifted in the future.
  *
  * Requires: MBEDTLS_ECP_C
  *
@@ -729,7 +726,7 @@
  *
  * Enable the ECDHE-PSK based ciphersuite modes in SSL / TLS.
  *
- * Requires: MBEDTLS_ECDH_C or (MBEDTLS_USE_PSA_CRYPTO and PSA_WANT_ALG_ECDH)
+ * Requires: MBEDTLS_ECDH_C or PSA_WANT_ALG_ECDH
  *
  * This enables the following ciphersuites (if other requisites are
  * enabled as well):
@@ -804,7 +801,7 @@
  *
  * Enable the ECDHE-RSA based ciphersuite modes in SSL / TLS.
  *
- * Requires: MBEDTLS_ECDH_C or (MBEDTLS_USE_PSA_CRYPTO and PSA_WANT_ALG_ECDH)
+ * Requires: MBEDTLS_ECDH_C or PSA_WANT_ALG_ECDH
  *           MBEDTLS_RSA_C
  *           MBEDTLS_PKCS1_V15
  *           MBEDTLS_X509_CRT_PARSE_C
@@ -829,8 +826,8 @@
  *
  * Enable the ECDHE-ECDSA based ciphersuite modes in SSL / TLS.
  *
- * Requires: MBEDTLS_ECDH_C or (MBEDTLS_USE_PSA_CRYPTO and PSA_WANT_ALG_ECDH)
- *           MBEDTLS_ECDSA_C or (MBEDTLS_USE_PSA_CRYPTO and PSA_WANT_ALG_ECDSA)
+ * Requires: MBEDTLS_ECDH_C or PSA_WANT_ALG_ECDH
+ *           MBEDTLS_ECDSA_C or PSA_WANT_ALG_ECDSA
  *           MBEDTLS_X509_CRT_PARSE_C
  *
  * This enables the following ciphersuites (if other requisites are
@@ -853,8 +850,8 @@
  *
  * Enable the ECDH-ECDSA based ciphersuite modes in SSL / TLS.
  *
- * Requires: MBEDTLS_ECDH_C or (MBEDTLS_USE_PSA_CRYPTO and PSA_WANT_ALG_ECDH)
- *           MBEDTLS_ECDSA_C or (MBEDTLS_USE_PSA_CRYPTO and PSA_WANT_ALG_ECDSA)
+ * Requires: MBEDTLS_ECDH_C or PSA_WANT_ALG_ECDH
+ *           MBEDTLS_ECDSA_C or PSA_WANT_ALG_ECDSA
  *           MBEDTLS_X509_CRT_PARSE_C
  *
  * This enables the following ciphersuites (if other requisites are
@@ -877,7 +874,7 @@
  *
  * Enable the ECDH-RSA based ciphersuite modes in SSL / TLS.
  *
- * Requires: MBEDTLS_ECDH_C or (MBEDTLS_USE_PSA_CRYPTO and PSA_WANT_ALG_ECDH)
+ * Requires: MBEDTLS_ECDH_C or PSA_WANT_ALG_ECDH
  *           MBEDTLS_RSA_C
  *           MBEDTLS_X509_CRT_PARSE_C
  *
@@ -905,13 +902,9 @@
  * Thread v1.0.0 specification; incompatible changes to the specification
  * might still happen. For this reason, this is disabled by default.
  *
- * Requires: MBEDTLS_ECJPAKE_C or (MBEDTLS_USE_PSA_CRYPTO and PSA_WANT_ALG_JPAKE)
+ * Requires: MBEDTLS_ECJPAKE_C or PSA_WANT_ALG_JPAKE
  *           SHA-256 (via MBEDTLS_SHA256_C or a PSA driver)
  *           MBEDTLS_ECP_DP_SECP256R1_ENABLED
- *
- * \warning If SHA-256 is provided only by a PSA driver, you must call
- * psa_crypto_init() before the first handshake (even if
- * MBEDTLS_USE_PSA_CRYPTO is disabled).
  *
  * This enables the following ciphersuites (if other requisites are
  * enabled as well):
@@ -1229,8 +1222,7 @@
  * Compared to the default implementation:
  *
  * - p256-m has a much smaller code size and RAM footprint.
- * - p256-m is only available via the PSA API. This includes the pk module
- *   when #MBEDTLS_USE_PSA_CRYPTO is enabled.
+ * - p256-m is only available via the PSA API. This includes the pk module.
  * - p256-m does not support deterministic ECDSA, EC-JPAKE, custom protocols
  *   over the core arithmetic, or deterministic derivation of keys.
  *
@@ -1242,7 +1234,6 @@
  * MBEDTLS_xxx option. You do need to separately request support for the
  * cryptographic mechanisms through the PSA API:
  * - #MBEDTLS_PSA_CRYPTO_C for PSA-based configuration;
- * - #MBEDTLS_USE_PSA_CRYPTO if you want to use p256-m from PK, X.509 or TLS;
  * - #PSA_WANT_ECC_SECP_R1_256;
  * - #PSA_WANT_ALG_ECDH and/or #PSA_WANT_ALG_ECDSA as needed;
  * - #PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY, #PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_BASIC,
@@ -1563,15 +1554,9 @@
  *
  * Enable support for TLS 1.2 (and DTLS 1.2 if DTLS is enabled).
  *
- * Requires: Without MBEDTLS_USE_PSA_CRYPTO: MBEDTLS_MD_C and
- *              (MBEDTLS_SHA256_C or MBEDTLS_SHA384_C or
- *               SHA-256 or SHA-512 provided by a PSA driver)
- *           With MBEDTLS_USE_PSA_CRYPTO:
- *              PSA_WANT_ALG_SHA_256 or PSA_WANT_ALG_SHA_384
+ * Requires: PSA_WANT_ALG_SHA_256 or PSA_WANT_ALG_SHA_384
  *
- * \warning If building with MBEDTLS_USE_PSA_CRYPTO, or if the hash(es) used
- * are only provided by PSA drivers, you must call psa_crypto_init() before
- * doing any TLS operations.
+ * \warning You must call psa_crypto_init() before doing any TLS operations.
  *
  * Comment this macro to disable support for TLS 1.2 / DTLS 1.2
  */
@@ -1588,14 +1573,7 @@
  * Requires: MBEDTLS_SSL_KEEP_PEER_CERTIFICATE
  * Requires: MBEDTLS_PSA_CRYPTO_C
  *
- * \note TLS 1.3 uses PSA crypto for cryptographic operations that are
- *       directly performed by TLS 1.3 code. As a consequence, you must
- *       call psa_crypto_init() before the first TLS 1.3 handshake.
- *
- * \note Cryptographic operations performed indirectly via another module
- *       (X.509, PK) or by code shared with TLS 1.2 (record protection,
- *       running handshake hash) only use PSA crypto if
- *       #MBEDTLS_USE_PSA_CRYPTO is enabled.
+ * \warning You must call psa_crypto_init() before doing any TLS operations.
  *
  * Uncomment this macro to enable the support for TLS 1.3.
  */
@@ -1643,7 +1621,7 @@
  * Requires: PSA_WANT_ALG_ECDH or PSA_WANT_ALG_FFDH
  *           MBEDTLS_X509_CRT_PARSE_C
  *           and at least one of:
- *               MBEDTLS_ECDSA_C or (MBEDTLS_USE_PSA_CRYPTO and PSA_WANT_ALG_ECDSA)
+ *               MBEDTLS_ECDSA_C or PSA_WANT_ALG_ECDSA
  *               MBEDTLS_PKCS1_V21
  *
  * Comment to disable support for the ephemeral key exchange mode in TLS 1.3.
@@ -2324,7 +2302,6 @@
  *          library/psa_crypto_mac.c
  *          library/ssl_ciphersuites.c
  *          library/ssl_msg.c
- *          library/ssl_ticket.c (unless MBEDTLS_USE_PSA_CRYPTO is enabled)
  * Auto-enabled by: MBEDTLS_PSA_CRYPTO_C depending on which ciphers are enabled
  *                  (see the documentation of that option for details).
  *
@@ -3389,11 +3366,9 @@
  *          library/x509_crt.c
  *          library/x509_csr.c
  *
- * Requires: MBEDTLS_ASN1_PARSE_C, MBEDTLS_BIGNUM_C, MBEDTLS_OID_C, MBEDTLS_PK_PARSE_C,
- *           (MBEDTLS_MD_C or MBEDTLS_USE_PSA_CRYPTO)
+ * Requires: MBEDTLS_ASN1_PARSE_C, MBEDTLS_BIGNUM_C, MBEDTLS_OID_C, MBEDTLS_PK_PARSE_C
  *
- * \warning If building with MBEDTLS_USE_PSA_CRYPTO, you must call
- * psa_crypto_init() before doing any X.509 operation.
+ * \warning You must call psa_crypto_init() before doing any X.509 operation.
  *
  * This module is required for the X.509 parsing modules.
  */
@@ -3451,10 +3426,8 @@
  * Module:  library/x509_create.c
  *
  * Requires: MBEDTLS_BIGNUM_C, MBEDTLS_OID_C, MBEDTLS_PK_PARSE_C,
- *           (MBEDTLS_MD_C or MBEDTLS_USE_PSA_CRYPTO)
  *
- * \warning If building with MBEDTLS_USE_PSA_CRYPTO, you must call
- * psa_crypto_init() before doing any X.509 create operation.
+ * \warning You must call psa_crypto_init() before doing any X.509 operation.
  *
  * This module is the basis for creating X.509 certificates and CSRs.
  */

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1984,9 +1984,8 @@ void mbedtls_ssl_init(mbedtls_ssl_context *ssl);
  *                 Calling mbedtls_ssl_setup again is not supported, even
  *                 if no session is active.
  *
- * \note           If #MBEDTLS_USE_PSA_CRYPTO is enabled, the PSA crypto
- *                 subsystem must have been initialized by calling
- *                 psa_crypto_init() before calling this function.
+ * \note           The PSA crypto subsystem must have been initialized by
+ *                 calling psa_crypto_init() before calling this function.
  *
  * \param ssl      SSL context
  * \param conf     SSL configuration to use
@@ -4920,10 +4919,8 @@ int mbedtls_ssl_get_session(const mbedtls_ssl_context *ssl,
  *                 currently being processed might or might not contain further
  *                 DTLS records.
  *
- * \note           If the context is configured to allow TLS 1.3, or if
- *                 #MBEDTLS_USE_PSA_CRYPTO is enabled, the PSA crypto
- *                 subsystem must have been initialized by calling
- *                 psa_crypto_init() before calling this function.
+ * \note           The PSA crypto subsystem must have been initialized by
+ *                 calling psa_crypto_init() before calling this function.
  */
 int mbedtls_ssl_handshake(mbedtls_ssl_context *ssl);
 

--- a/include/mbedtls/ssl_ciphersuites.h
+++ b/include/mbedtls/ssl_ciphersuites.h
@@ -389,7 +389,7 @@ typedef enum {
 #endif
 
 /* The handshake params structure has a set of fields called xxdh_psa which are used:
- * - by TLS 1.2 with `USE_PSA` to do ECDH or ECDHE;
+ * - by TLS 1.2 to do ECDH or ECDHE;
  * - by TLS 1.3 to do ECDHE or FFDHE.
  * The following macros can be used to guard their declaration and use.
  */

--- a/include/mbedtls/x509_crl.h
+++ b/include/mbedtls/x509_crl.h
@@ -95,9 +95,8 @@ mbedtls_x509_crl;
 /**
  * \brief          Parse a DER-encoded CRL and append it to the chained list
  *
- * \note           If #MBEDTLS_USE_PSA_CRYPTO is enabled, the PSA crypto
- *                 subsystem must have been initialized by calling
- *                 psa_crypto_init() before calling this function.
+ * \note           The PSA crypto subsystem must have been initialized by
+ *                 calling psa_crypto_init() before calling this function.
  *
  * \param chain    points to the start of the chain
  * \param buf      buffer holding the CRL data in DER format
@@ -113,9 +112,8 @@ int mbedtls_x509_crl_parse_der(mbedtls_x509_crl *chain,
  *
  * \note           Multiple CRLs are accepted only if using PEM format
  *
- * \note           If #MBEDTLS_USE_PSA_CRYPTO is enabled, the PSA crypto
- *                 subsystem must have been initialized by calling
- *                 psa_crypto_init() before calling this function.
+ * \note           The PSA crypto subsystem must have been initialized by
+ *                 calling psa_crypto_init() before calling this function.
  *
  * \param chain    points to the start of the chain
  * \param buf      buffer holding the CRL data in PEM or DER format
@@ -132,9 +130,8 @@ int mbedtls_x509_crl_parse(mbedtls_x509_crl *chain, const unsigned char *buf, si
  *
  * \note           Multiple CRLs are accepted only if using PEM format
  *
- * \note           If #MBEDTLS_USE_PSA_CRYPTO is enabled, the PSA crypto
- *                 subsystem must have been initialized by calling
- *                 psa_crypto_init() before calling this function.
+ * \note           The PSA crypto subsystem must have been initialized by
+ *                 calling psa_crypto_init() before calling this function.
  *
  * \param chain    points to the start of the chain
  * \param path     filename to read the CRLs from (in PEM or DER encoding)

--- a/include/mbedtls/x509_crt.h
+++ b/include/mbedtls/x509_crt.h
@@ -345,9 +345,8 @@ extern const mbedtls_x509_crt_profile mbedtls_x509_crt_profile_none;
  * \brief          Parse a single DER formatted certificate and add it
  *                 to the end of the provided chained list.
  *
- * \note           If #MBEDTLS_USE_PSA_CRYPTO is enabled, the PSA crypto
- *                 subsystem must have been initialized by calling
- *                 psa_crypto_init() before calling this function.
+ * \note           The PSA crypto subsystem must have been initialized by
+ *                 calling psa_crypto_init() before calling this function.
  *
  * \param chain    The pointer to the start of the CRT chain to attach to.
  *                 When parsing the first CRT in a chain, this should point
@@ -410,9 +409,8 @@ typedef int (*mbedtls_x509_crt_ext_cb_t)(void *p_ctx,
  * \brief            Parse a single DER formatted certificate and add it
  *                   to the end of the provided chained list.
  *
- * \note             If #MBEDTLS_USE_PSA_CRYPTO is enabled, the PSA crypto
- *                   subsystem must have been initialized by calling
- *                   psa_crypto_init() before calling this function.
+ * \note             The PSA crypto subsystem must have been initialized by
+ *                   calling psa_crypto_init() before calling this function.
  *
  * \param chain      The pointer to the start of the CRT chain to attach to.
  *                   When parsing the first CRT in a chain, this should point
@@ -464,9 +462,8 @@ int mbedtls_x509_crt_parse_der_with_ext_cb(mbedtls_x509_crt *chain,
  *                 temporary ownership of the CRT buffer until the CRT
  *                 is destroyed.
  *
- * \note           If #MBEDTLS_USE_PSA_CRYPTO is enabled, the PSA crypto
- *                 subsystem must have been initialized by calling
- *                 psa_crypto_init() before calling this function.
+ * \note           The PSA crypto subsystem must have been initialized by
+ *                 calling psa_crypto_init() before calling this function.
  *
  * \param chain    The pointer to the start of the CRT chain to attach to.
  *                 When parsing the first CRT in a chain, this should point
@@ -508,9 +505,8 @@ int mbedtls_x509_crt_parse_der_nocopy(mbedtls_x509_crt *chain,
  *                 long as the certificates are enclosed in the PEM specific
  *                 '-----{BEGIN/END} CERTIFICATE-----' delimiters.
  *
- * \note           If #MBEDTLS_USE_PSA_CRYPTO is enabled, the PSA crypto
- *                 subsystem must have been initialized by calling
- *                 psa_crypto_init() before calling this function.
+ * \note           The PSA crypto subsystem must have been initialized by
+ *                 calling psa_crypto_init() before calling this function.
  *
  * \param chain    The chain to which to add the parsed certificates.
  * \param buf      The buffer holding the certificate data in PEM or DER format.
@@ -536,9 +532,8 @@ int mbedtls_x509_crt_parse(mbedtls_x509_crt *chain, const unsigned char *buf, si
  *                 of failed certificates it encountered. If none complete
  *                 correctly, the first error is returned.
  *
- * \note           If #MBEDTLS_USE_PSA_CRYPTO is enabled, the PSA crypto
- *                 subsystem must have been initialized by calling
- *                 psa_crypto_init() before calling this function.
+ * \note           The PSA crypto subsystem must have been initialized by
+ *                 calling psa_crypto_init() before calling this function.
  *
  * \param chain    points to the start of the chain
  * \param path     filename to read the certificates from

--- a/include/mbedtls/x509_csr.h
+++ b/include/mbedtls/x509_csr.h
@@ -79,9 +79,8 @@ mbedtls_x509write_csr;
  *                 ignored, unless the critical flag is set, in which case
  *                 the CSR is rejected.
  *
- * \note           If #MBEDTLS_USE_PSA_CRYPTO is enabled, the PSA crypto
- *                 subsystem must have been initialized by calling
- *                 psa_crypto_init() before calling this function.
+ * \note           The PSA crypto subsystem must have been initialized by
+ *                 calling psa_crypto_init() before calling this function.
  *
  * \param csr      CSR context to fill
  * \param buf      buffer holding the CRL data
@@ -135,9 +134,8 @@ typedef int (*mbedtls_x509_csr_ext_cb_t)(void *p_ctx,
  *                 the result of the callback function decides whether
  *                 CSR is rejected.
  *
- * \note           If #MBEDTLS_USE_PSA_CRYPTO is enabled, the PSA crypto
- *                 subsystem must have been initialized by calling
- *                 psa_crypto_init() before calling this function.
+ * \note           The PSA crypto subsystem must have been initialized by
+ *                 calling psa_crypto_init() before calling this function.
  *
  * \param csr      CSR context to fill
  * \param buf      buffer holding the CRL data
@@ -158,9 +156,8 @@ int mbedtls_x509_csr_parse_der_with_ext_cb(mbedtls_x509_csr *csr,
  *
  * \note           See notes for \c mbedtls_x509_csr_parse_der()
  *
- * \note           If #MBEDTLS_USE_PSA_CRYPTO is enabled, the PSA crypto
- *                 subsystem must have been initialized by calling
- *                 psa_crypto_init() before calling this function.
+ * \note           The PSA crypto subsystem must have been initialized by
+ *                 calling psa_crypto_init() before calling this function.
  *
  * \param csr      CSR context to fill
  * \param buf      buffer holding the CRL data

--- a/tf-psa-crypto/drivers/builtin/include/mbedtls/cipher.h
+++ b/tf-psa-crypto/drivers/builtin/include/mbedtls/cipher.h
@@ -642,8 +642,6 @@ int mbedtls_cipher_setup(mbedtls_cipher_context_t *ctx,
  *                      Please use psa_aead_xxx() / psa_cipher_xxx() directly
  *                      instead.
  *
- * \note                See #MBEDTLS_USE_PSA_CRYPTO for information on PSA.
- *
  * \param ctx           The context to initialize. May not be \c NULL.
  * \param cipher_info   The cipher to use.
  * \param taglen        For AEAD ciphers, the length in bytes of the

--- a/tf-psa-crypto/drivers/builtin/include/mbedtls/pk.h
+++ b/tf-psa-crypto/drivers/builtin/include/mbedtls/pk.h
@@ -88,20 +88,17 @@ typedef enum {
 typedef struct mbedtls_pk_rsassa_pss_options {
     /** The digest to use for MGF1 in PSS.
      *
-     * \note When #MBEDTLS_USE_PSA_CRYPTO is enabled and #MBEDTLS_RSA_C is
-     *       disabled, this must be equal to the \c md_alg argument passed
-     *       to mbedtls_pk_verify_ext(). In a future version of the library,
-     *       this constraint may apply whenever #MBEDTLS_USE_PSA_CRYPTO is
-     *       enabled regardless of the status of #MBEDTLS_RSA_C.
+     * \note When #MBEDTLS_RSA_C is disabled, this must be equal to the \c md_alg argument passed
+     *       to mbedtls_pk_verify_ext(). In a future version of the library, this constraint may
+     *       apply regardless of the status of #MBEDTLS_RSA_C.
      */
     mbedtls_md_type_t mgf1_hash_id;
 
     /** The expected length of the salt, in bytes. This may be
      * #MBEDTLS_RSA_SALT_LEN_ANY to accept any salt length.
      *
-     * \note When #MBEDTLS_USE_PSA_CRYPTO is enabled, only
-     *       #MBEDTLS_RSA_SALT_LEN_ANY is valid. Any other value may be
-     *       ignored (allowing any salt length).
+     * \note Only #MBEDTLS_RSA_SALT_LEN_ANY is valid. Any other value may be ignored (allowing any
+     *       salt length).
      */
     int expected_salt_len;
 
@@ -165,7 +162,8 @@ typedef struct mbedtls_pk_rsassa_pss_options {
  * which functions are used for various operations. The overall picture looks
  * like this:
  * - if USE_PSA is not defined and ECP_C is defined then use ecp_keypair data
- *   structure and legacy functions
+ *   structure and legacy functions. (MBEDTLS_USE_PSA_CRYPTO is always on and
+ *   although this codepath remains present, it never will be taken.)
  * - if USE_PSA is defined and
  *     - if ECP_C then use ecp_keypair structure, convert data to a PSA friendly
  *       format and use PSA functions
@@ -222,7 +220,7 @@ typedef struct mbedtls_pk_context {
     void *MBEDTLS_PRIVATE(pk_ctx);                        /**< Underlying public key context  */
     /* The following field is used to store the ID of a private key in the
      * following cases:
-     * - opaque key when MBEDTLS_USE_PSA_CRYPTO is defined
+     * - opaque key
      * - normal key when MBEDTLS_PK_USE_PSA_EC_DATA is defined. In this case:
      *    - the pk_ctx above is not not used to store the private key anymore.
      *      Actually that field not populated at all in this case because also
@@ -805,9 +803,9 @@ int mbedtls_pk_verify_restartable(mbedtls_pk_context *ctx,
  *
  * \note            If type is MBEDTLS_PK_RSASSA_PSS, then options must point
  *                  to a mbedtls_pk_rsassa_pss_options structure,
- *                  otherwise it must be NULL. Note that if
- *                  #MBEDTLS_USE_PSA_CRYPTO is defined, the salt length is not
- *                  verified as PSA_ALG_RSA_PSS_ANY_SALT is used.
+ *                  otherwise it must be NULL. Note that the salt length is not
+ *                  verified as contexes have PSA_ALG_RSA_PSS_ANY_SALT as default
+ *                  and that is the only valid value.
  */
 int mbedtls_pk_verify_ext(mbedtls_pk_type_t type, const void *options,
                           mbedtls_pk_context *ctx, mbedtls_md_type_t md_alg,
@@ -1075,9 +1073,8 @@ static inline mbedtls_ecp_keypair *mbedtls_pk_ec(const mbedtls_pk_context pk)
 /**
  * \brief           Parse a private key in PEM or DER format
  *
- * \note            If #MBEDTLS_USE_PSA_CRYPTO is enabled, the PSA crypto
- *                  subsystem must have been initialized by calling
- *                  psa_crypto_init() before calling this function.
+ * \note            The PSA crypto subsystem must have been initialized by
+ *                  calling psa_crypto_init() before calling this function.
  *
  * \param ctx       The PK context to fill. It must have been initialized
  *                  but not set up.
@@ -1115,9 +1112,8 @@ int mbedtls_pk_parse_key(mbedtls_pk_context *ctx,
 /**
  * \brief           Parse a public key in PEM or DER format
  *
- * \note            If #MBEDTLS_USE_PSA_CRYPTO is enabled, the PSA crypto
- *                  subsystem must have been initialized by calling
- *                  psa_crypto_init() before calling this function.
+ * \note            The PSA crypto subsystem must have been initialized by
+ *                  calling psa_crypto_init() before calling this function.
  *
  * \param ctx       The PK context to fill. It must have been initialized
  *                  but not set up.
@@ -1148,9 +1144,8 @@ int mbedtls_pk_parse_public_key(mbedtls_pk_context *ctx,
 /**
  * \brief           Load and parse a private key
  *
- * \note            If #MBEDTLS_USE_PSA_CRYPTO is enabled, the PSA crypto
- *                  subsystem must have been initialized by calling
- *                  psa_crypto_init() before calling this function.
+ * \note            The PSA crypto subsystem must have been initialized by
+ *                  calling psa_crypto_init() before calling this function.
  *
  * \param ctx       The PK context to fill. It must have been initialized
  *                  but not set up.


### PR DESCRIPTION
## Description

Remove discussions of MBEDTLS_USE_PSA_CRYPTO in API documentation. Resolves partially #9632.

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** not required because: documentation only
- [x] **development PR** this 
- [x] **framework PR** not required
- [x] **3.6 PR** not required because: 4.0 only
- [x] **2.28 PR** not required because: 4.0 only
- **tests**  not required because: documentation only
