### PR TITLE
Specify previously missed register clobbers in AES-NI asm blocks

### DIFF
--- a/ChangeLog.d/fix-aesni-asm-clobbers.txt
+++ b/ChangeLog.d/fix-aesni-asm-clobbers.txt
@@ -1,0 +1,5 @@
+Bugfix
+   * Fix missing constraints on the AES-NI inline assembly which is used on
+     GCC-like compilers when building AES for generic x86_64 targets. This
+     may have resulted in incorrect code with some compilers, depending on
+     optimizations. Fixes #9819.

--- a/tf-psa-crypto/drivers/builtin/src/aesni.c
+++ b/tf-psa-crypto/drivers/builtin/src/aesni.c
@@ -489,7 +489,7 @@ int mbedtls_aesni_crypt_ecb(mbedtls_aes_context *ctx,
          "movdqu    %%xmm0, (%4)    \n\t" // export output
          :
          : "r" (ctx->nr), "r" (ctx->buf + ctx->rk_offset), "r" (mode), "r" (input), "r" (output)
-         : "memory", "cc", "xmm0", "xmm1");
+         : "memory", "cc", "xmm0", "xmm1", "0", "1");
 
 
     return 0;

--- a/tf-psa-crypto/drivers/builtin/src/aesni.c
+++ b/tf-psa-crypto/drivers/builtin/src/aesni.c
@@ -679,7 +679,7 @@ static void aesni_setkey_enc_128(unsigned char *rk,
          AESKEYGENA(xmm0_xmm1, "0x36")      "call 1b \n\t"
          :
          : "r" (rk), "r" (key)
-         : "memory", "cc", "0");
+         : "memory", "cc", "xmm0", "xmm1", "0");
 }
 
 /*
@@ -737,7 +737,7 @@ static void aesni_setkey_enc_192(unsigned char *rk,
 
          :
          : "r" (rk), "r" (key)
-         : "memory", "cc", "0");
+         : "memory", "cc", "xmm0", "xmm1", "xmm2", "0");
 }
 #endif /* !MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH */
 
@@ -805,7 +805,7 @@ static void aesni_setkey_enc_256(unsigned char *rk,
          AESKEYGENA(xmm1_xmm2, "0x40")      "call 1b \n\t"
          :
          : "r" (rk), "r" (key)
-         : "memory", "cc", "0");
+         : "memory", "cc", "xmm0", "xmm1", "xmm2", "0");
 }
 #endif /* !MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH */
 


### PR DESCRIPTION
## Description

We have just integrated mbedTLS AES code into John the Ripper via https://github.com/openwall/john/pull/5591 and I've been reviewing our changes as well as looking at mbedTLS original code. One of our concerns was how good or bad the inline asm blocks are compared to the intrinsics, and whether we should possibly get rid of the inline asm. I found you also have an issue open for that (#8231), which is great. Meanwhile, I noticed a number of performance issues with the inline asm code and what I think is one bug. This PR is to fix the bug:

While most of the inline asm blocks specify what they clobber (memory, condition flags, other registers), the one in `mbedtls_aesni_crypt_ecb` clobbers a couple of input registers without specifying so. This PR fixes that in the same fashion as further asm blocks in the same source file use.

The risk from this bug was a potential miscompile that could result in incorrect computation/behavior, including potentially a security vulnerability. However, in practice this is unlikely because the entire non-inline function consists solely of this asm block. Issues could arise with link-time optimization and aggressive function inlining into an application using mbedTLS.

Fix https://github.com/Mbed-TLS/mbedtls/issues/9819

## PR checklist

- [x] **changelog** provided
- [x] **development PR** provided (this one)
- [x] **framework PR** not needed
- [x] **3.6 PR** #9848
- [x] **2.28 PR** #9849
- **tests** not required because: no functionality is added, and the bug isn't normally reproducible in testing