### PR TITLE
Mbedtls 2.28: Fix compilation on MS-DOS DJGPP

### DIFF
--- a/ChangeLog.d/fix-compilation-with-djgpp.txt
+++ b/ChangeLog.d/fix-compilation-with-djgpp.txt
@@ -1,5 +1,2 @@
-Bugfix:
-  * DJGPP does not provide `suseconds_t`, but defines `__unix__`
-  * `net_sockets.c` uses it for `mbedtls_net_usleep()`
-  * This fix makes use of the alternate codepath w/o `suseconds_t` if `__DJGPP__` is defined
-
+Bugfix
+   * Fix compilation on MS-DOS DJGPP. Fixes #9813.

--- a/ChangeLog.d/fix-compilation-with-djgpp.txt
+++ b/ChangeLog.d/fix-compilation-with-djgpp.txt
@@ -1,0 +1,5 @@
+Bugfix:
+  * DJGPP does not provide `suseconds_t`, but defines `__unix__`
+  * `net_sockets.c` uses it for `mbedtls_net_usleep()`
+  * This fix makes use of the alternate codepath w/o `suseconds_t` if `__DJGPP__` is defined
+

--- a/library/net_sockets.c
+++ b/library/net_sockets.c
@@ -529,8 +529,8 @@ void mbedtls_net_usleep(unsigned long usec)
 #else
     struct timeval tv;
     tv.tv_sec  = usec / 1000000;
-#if defined(__unix__) || defined(__unix) || \
-    (defined(__APPLE__) && defined(__MACH__))
+#if (defined(__unix__) || defined(__unix) || \
+    (defined(__APPLE__) && defined(__MACH__))) && !defined(__DJGPP__)
     tv.tv_usec = (suseconds_t) usec % 1000000;
 #else
     tv.tv_usec = usec % 1000000;


### PR DESCRIPTION
## Description
mbedTLS does not compile on MS-DOS DJGPP because the toolchain does define `__unix__`, but does not provide `suseconds_t`.
Excluding the code path with modifying the `#if` to be false when `__DJGPP__` is defined makes it compile fine.


## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** provided
- [x] **development PR** provided #9810
- [x] **framework PR** not required
- [x] **3.6 PR** provided #9812
- [x] **2.28 PR** provided
- **tests**  not required because: no functional change. Existing ifdef is activated for another platform
