### PR TITLE
Backport 3.6: Fix discussions of MBEDTLS_USE_PSA_CRYPTO in standalone documentation

### DIFF
--- a/docs/architecture/psa-migration/strategy.md
+++ b/docs/architecture/psa-migration/strategy.md
@@ -36,7 +36,9 @@ Compile-time options
 We currently have a few compile-time options that are relevant to the migration:
 
 - `MBEDTLS_PSA_CRYPTO_C` - enabled by default, controls the presence of the PSA
-  Crypto APIs.
+  Crypto APIs with their implementations. (Builds with only
+  `MBEDTLS_PSA_CRYPTO_CLIENT`, where PSA crypto APIs are present but
+  implemented via third-party code, are out of scope of this document.)
 - `MBEDTLS_USE_PSA_CRYPTO` - disabled by default (enabled in "full" config),
   controls usage of PSA Crypto APIs to perform operations in X.509 and TLS
 (G1 above), as well as the availability of some new APIs (G2 above).

--- a/docs/driver-only-builds.md
+++ b/docs/driver-only-builds.md
@@ -278,9 +278,11 @@ The same holds for the associated algorithm:
 removing builtin support (i.e. `MBEDTLS_DHM_C`).
 
 Note that the PSA API only supports FFDH with RFC 7919 groups, whereas the
-Mbed TLS legacy API supports custom groups. As a consequence, the TLS layer
-of Mbed TLS only supports DHE cipher suites if built-in FFDH
+Mbed TLS legacy API supports custom groups. As a consequence, the TLS 1.2
+layer of Mbed TLS only supports DHE cipher suites if built-in FFDH
 (`MBEDTLS_DHM_C`) is present, even when `MBEDTLS_USE_PSA_CRYPTO` is enabled.
+(The TLS 1.3 layer uses PSA, and this is not a limitation because the
+protocol does not allow custom FFDH groups.)
 
 RSA
 ---


### PR DESCRIPTION
Minor corrections found while rewiewing https://github.com/Mbed-TLS/mbedtls/pull/9818.

## PR checklist

- [x] **changelog** not required because: docs only
- [x] **development PR** provided #9818
- [x] **framework PR** not required
- [x] **3.6 PR** here
- [x] **2.28 PR** not required because: the affected documents didn't exist yet
- **tests**  provided | not required because: 
