### PR TITLE
Backport 3.6: Added debug print in tls13 ssl_tls13_write_key_share_ext

### DIFF
--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -319,6 +319,7 @@ static int ssl_tls13_write_key_share_ext(mbedtls_ssl_context *ssl,
             ssl, group_id, p, end, &key_exchange_len);
         p += key_exchange_len;
         if (ret != 0) {
+            MBEDTLS_SSL_DEBUG_MSG(1, ("client hello: failed generating xxdh key exchange"));
             return ret;
         }
 


### PR DESCRIPTION
Trivial backport of #9798

## PR checklist

- [x] **changelog** not required because: minor improvement
- [x] **development PR** https://github.com/Mbed-TLS/mbedtls/pull/9798
- [x] **framework PR** not required
- [x] **3.6 PR** here
- [x] **2.28 PR** not required because: feature not present
- **tests**  provided
