### PR TITLE
Fix submodule error messages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -351,7 +351,7 @@ if(CMAKE_BUILD_TYPE STREQUAL "Check" AND TEST_CPP)
 endif()
 
 if (NOT EXISTS "${MBEDTLS_FRAMEWORK_DIR}/CMakeLists.txt")
-    if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git/")
+    if (EXISTS "${MBEDTLS_DIR}/.git")
         message(FATAL_ERROR "${MBEDTLS_FRAMEWORK_DIR}/CMakeLists.txt not found (and does appear to be a git checkout). Run `git submodule update --init` from the source tree to fetch the submodule contents.")
     else ()
         message(FATAL_ERROR "${MBEDTLS_FRAMEWORK_DIR}/CMakeLists.txt not found (and does not appear to be a git checkout). Please ensure you have downloaded the right archive from the release page on GitHub.")

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ ifneq (,$(filter-out lib library/%,$(or $(MAKECMDGOALS),all)))
     ifeq (,$(wildcard framework/exported.make))
         # Use the define keyword to get a multi-line message.
         # GNU make appends ".  Stop.", so tweak the ending of our message accordingly.
-        ifeq (,$(wildcard .git))
+        ifneq (,$(wildcard .git))
             define error_message
 ${MBEDTLS_PATH}/framework/exported.make not found (and does appear to be a git checkout). Run `git submodule update --init` from the source tree to fetch the submodule contents.
 This is a fatal error


### PR DESCRIPTION
## PR checklist
Fix issue with make file submodule error message displaying incorrect message when inside git repository. 

If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** not required.
- [x] **development PR** provided.
- [x] **framework PR** not required.
- [x] **3.6 PR** provided: #9834
- [x] **2.28 PR** not required because: framework does not exist.
- **tests**  provided | not required because: 

## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
