### PR TITLE
Switch generate_psa_test.py to automatic dependencies for positive test cases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,8 @@ endif
 .SILENT:
 
 .PHONY: all no_test programs lib tests install uninstall clean test check lcov apidoc apidoc_clean
+.PHONY: FORCE
+FORCE:
 
 all: programs tests
 	$(MAKE) post_build
@@ -49,11 +51,11 @@ tests: mbedtls_test
 mbedtls_test:
 	$(MAKE) -C tests mbedtls_test
 
-library/%:
+library/%: FORCE
 	$(MAKE) -C library $*
-programs/%:
+programs/%: FORCE
 	$(MAKE) -C programs $*
-tests/%:
+tests/%: FORCE
 	$(MAKE) -C tests $*
 
 .PHONY: generated_files

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -125,6 +125,7 @@ generated_psa_test_data: ../framework/scripts/mbedtls_framework/crypto_knowledge
 generated_psa_test_data: ../framework/scripts/mbedtls_framework/macro_collector.py
 generated_psa_test_data: ../framework/scripts/mbedtls_framework/psa_information.py
 generated_psa_test_data: ../framework/scripts/mbedtls_framework/psa_storage.py
+generated_psa_test_data: ../framework/scripts/mbedtls_framework/psa_test_case.py
 generated_psa_test_data: ../framework/scripts/mbedtls_framework/test_case.py
 generated_psa_test_data: ../framework/scripts/mbedtls_framework/test_data_generation.py
 ## The generated file only depends on the options that are present in

--- a/tf-psa-crypto/tests/CMakeLists.txt
+++ b/tf-psa-crypto/tests/CMakeLists.txt
@@ -157,6 +157,7 @@ if(GEN_FILES)
             ${TF_PSA_CRYPTO_FRAMEWORK_DIR}/scripts/mbedtls_framework/macro_collector.py
             ${TF_PSA_CRYPTO_FRAMEWORK_DIR}/scripts/mbedtls_framework/psa_information.py
             ${TF_PSA_CRYPTO_FRAMEWORK_DIR}/scripts/mbedtls_framework/psa_storage.py
+            ${TF_PSA_CRYPTO_FRAMEWORK_DIR}/scripts/mbedtls_framework/psa_test_case.py
             ${TF_PSA_CRYPTO_FRAMEWORK_DIR}/scripts/mbedtls_framework/test_case.py
             ${TF_PSA_CRYPTO_FRAMEWORK_DIR}/scripts/mbedtls_framework/test_data_generation.py
             ${CMAKE_CURRENT_SOURCE_DIR}/../include/psa/crypto_config.h


### PR DESCRIPTION
Mostly happening in the framework, see Mbed-TLS/mbedtls-framework#83.

## PR checklist

- [x] **changelog** not required because: mostly test stuff, also undocumented  makefile usage
- [x] **development PR** here
- [x] **framework PR** provided Mbed-TLS/mbedtls-framework#83
- [x] **3.6 PR** https://github.com/Mbed-TLS/mbedtls/pull/9796
- [x] **2.28 PR** partial forward port from https://github.com/Mbed-TLS/mbedtls/pull/9025, nothing new now
- **tests**  provided
