### PR TITLE
[Backport 2.28] Specify previously missed register clobbers in AES-NI asm blocks

### DIFF
--- a/ChangeLog.d/fix-aesni-asm-clobbers.txt
+++ b/ChangeLog.d/fix-aesni-asm-clobbers.txt
@@ -1,0 +1,5 @@
+Bugfix
+   * Fix missing constraints on the AES-NI inline assembly which is used on
+     GCC-like compilers when building AES for generic x86_64 targets. This
+     may have resulted in incorrect code with some compilers, depending on
+     optimizations. Fixes #9819.

--- a/library/aesni.c
+++ b/library/aesni.c
@@ -460,7 +460,7 @@ int mbedtls_aesni_crypt_ecb(mbedtls_aes_context *ctx,
          "movdqu    %%xmm0, (%4)    \n\t" // export output
          :
          : "r" (ctx->nr), "r" (ctx->rk), "r" (mode), "r" (input), "r" (output)
-         : "memory", "cc", "xmm0", "xmm1");
+         : "memory", "cc", "xmm0", "xmm1", "0", "1");
 
 
     return 0;

--- a/library/aesni.c
+++ b/library/aesni.c
@@ -648,7 +648,7 @@ static void aesni_setkey_enc_128(unsigned char *rk,
          AESKEYGENA(xmm0_xmm1, "0x36")      "call 1b \n\t"
          :
          : "r" (rk), "r" (key)
-         : "memory", "cc", "0");
+         : "memory", "cc", "xmm0", "xmm1", "0");
 }
 
 /*
@@ -705,7 +705,7 @@ static void aesni_setkey_enc_192(unsigned char *rk,
 
          :
          : "r" (rk), "r" (key)
-         : "memory", "cc", "0");
+         : "memory", "cc", "xmm0", "xmm1", "xmm2", "0");
 }
 
 /*
@@ -771,7 +771,7 @@ static void aesni_setkey_enc_256(unsigned char *rk,
          AESKEYGENA(xmm1_xmm2, "0x40")      "call 1b \n\t"
          :
          : "r" (rk), "r" (key)
-         : "memory", "cc", "0");
+         : "memory", "cc", "xmm0", "xmm1", "xmm2", "0");
 }
 
 #endif  /* MBEDTLS_AESNI_HAVE_CODE */


### PR DESCRIPTION
## Description

Backport of #9809 for #9819.

## PR checklist

- [x] **changelog** provided
- [x] **development PR** #9809
- [x] **framework PR** not needed
- [x] **3.6 PR** #9848
- [x] **2.28 PR** this one
- **tests** not required because: no functionality is added, and the bug isn't normally reproducible in testing