### PR TITLE
Enable independent TF-PSA-Crypto doxygen checks

### DIFF
--- a/tests/scripts/check-doxy-blocks.pl
+++ b/tests/scripts/check-doxy-blocks.pl
@@ -16,7 +16,8 @@ use strict;
 use File::Basename;
 
 # C/header files in the following directories will be checked
-my @directories = qw(include/mbedtls library doxygen/input);
+my @mbedtls_directories = qw(include/mbedtls library doxygen/input);
+my @tf_psa_crypto_directories = qw(include/psa drivers core doxygen/input);
 
 # very naive pattern to find directives:
 # everything with a backslach except '\0' and backslash at EOL
@@ -53,13 +54,18 @@ sub check_dir {
     }
 }
 
+open my $project_file, "scripts/project_name.txt" or die "This script must be run from Mbed TLS or TF-PSA-Crypto root directory";
+my $project = <$project_file>;
+my @directories;
+
+if ($project eq "TF-PSA-Crypto") {
+    @directories = @tf_psa_crypto_directories
+} elsif ($project eq "Mbed TLS") {
+    @directories = @mbedtls_directories
+}
 # Check that the script is being run from the project's root directory.
 for my $dir (@directories) {
-    if (! -d $dir) {
-        die "This script must be run from the Mbed TLS root directory";
-    } else {
-        check_dir($dir)
-    }
+    check_dir($dir)
 }
 
 exit $exit_code;

--- a/tests/scripts/doxygen.sh
+++ b/tests/scripts/doxygen.sh
@@ -7,9 +7,10 @@
 
 # Abort on errors (and uninitialised variables)
 set -eu
+. $MBEDTLS_FRAMEWORK_DIR/scripts/project_detection.sh
 
-if [ -d library -a -d include -a -d tests ]; then :; else
-    echo "Must be run from Mbed TLS root" >&2
+if in_mbedtls_repo | in_tf_psa_crypto_repo then :; else
+    echo "Must be run from Mbed TLS root or TF-PSA-Crypto root" >&2
     exit 1
 fi
 

--- a/tf-psa-crypto/tests/scripts/components-basic-checks.sh
+++ b/tf-psa-crypto/tests/scripts/components-basic-checks.sh
@@ -1,0 +1,20 @@
+# components-basic-checks.sh
+#
+# Copyright The Mbed TLS Contributors
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+
+# This file contains test components that are executed by all.sh
+
+################################################################
+#### Basic checks
+################################################################
+
+component_check_doxy_blocks () {
+    msg "Check: doxygen markup outside doxygen blocks" # < 1s
+    $MBEDTLS_FRAMEWORK_ROOT_DIR/scripts/check-doxy-blocks.pl
+}
+
+component_check_doxygen_warnings () {
+    msg "Check: doxygen warnings (builds the documentation)" # ~ 3s
+    $MBEDTLS_FRAMEWORK_ROOT_DIR/scripts/doxygen.sh
+}


### PR DESCRIPTION
## Description
This pull request enables independent TF-PSA-Crypto doxygen checks and closes issue:https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/49 .

Depends on: https://github.com/Mbed-TLS/mbedtls-framework/issues/69

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** not required: testing change.
- [x] **development PR** provided.
- [x] **framework PR** provided Mbed-TLS/mbedtls-framework# | not required
- [x] **3.6 PR** not required because: 4.0 repo slit.
- [x] **2.28 PR** not required because: TF-PSA-Crypto did not exist. 
- **tests**  provided | not required because: 

## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
