### PR TITLE
Simplify crypto config default path setting

### DIFF
--- a/scripts/config.py
+++ b/scripts/config.py
@@ -286,11 +286,7 @@ class CryptoConfigFile(config_common.ConfigFile):
     # Temporary, while Mbed TLS does not just rely on the TF-PSA-Crypto
     # build system to build its crypto library. When it does, the
     # condition can just be removed.
-    _path_in_tree = ('include/psa/crypto_config.h'
-                     if not os.path.isdir(os.path.join(os.path.dirname(__file__),
-                                                       os.pardir,
-                                                       'tf-psa-crypto')) else
-                     'tf-psa-crypto/include/psa/crypto_config.h')
+    _path_in_tree = 'include/psa/crypto_config.h'
     default_path = [_path_in_tree,
                     os.path.join(os.path.dirname(__file__),
                                  os.pardir,


### PR DESCRIPTION
## Description
Fix mbedtls-framework CI for mbedtls-3.6 and simply config.py code anyway.

## PR checklist
- [x] **changelog** not required because: python code improvement
- [x] **development PR** not required because: 3.6 only code 
- [x] **framework PR** not required
- [x] **3.6 PR** here 
- [x] **2.28 PR** not required because: 3.6 only code 
- **tests**  not required because: python code improvement