### PR TITLE
[dev] Remove deprecated function mbedtls_ssl_conf_curves()

### DIFF
--- a/ChangeLog.d/rm-ssl-conf-curves.txt
+++ b/ChangeLog.d/rm-ssl-conf-curves.txt
@@ -1,0 +1,4 @@
+Removals
+   * Remove the function mbedtls_ssl_conf_curves() which had been deprecated
+     in favour of mbedtls_ssl_conf_groups() since Mbed TLS 3.1.
+

--- a/docs/3.0-migration-guide.md
+++ b/docs/3.0-migration-guide.md
@@ -748,7 +748,7 @@ for both DTLS-CID and TLS 1.3.
 
 The default preference order for curves in TLS now favors resource usage (performance and memory consumption) over size. The exact order is unspecified and may change, but generally you can expect 256-bit curves to be preferred over larger curves.
 
-If you prefer a different order, call `mbedtls_ssl_conf_curves()` when configuring a TLS connection.
+If you prefer a different order, call `mbedtls_ssl_conf_groups()` when configuring a TLS connection.
 
 ### SSL key export interface change
 
@@ -1025,7 +1025,7 @@ mbedtls_x509_crt_profile my_profile = mbedtls_x509_crt_profile_default;
 my_profile.allowed_mds |= MBEDTLS_X509_ID_FLAG( MBEDTLS_MD_SHA224 );
 ```
 
-If you still need to allow hashes and curves in TLS that have been removed from the default configuration, call `mbedtls_ssl_conf_sig_hashes()` and `mbedtls_ssl_conf_curves()` with the desired lists.
+If you still need to allow hashes and curves in TLS that have been removed from the default configuration, call `mbedtls_ssl_conf_sig_hashes()` and `mbedtls_ssl_conf_groups()` with the desired lists.
 
 ### Remove 3DES ciphersuites
 

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1567,10 +1567,6 @@ struct mbedtls_ssl_config {
     const uint16_t *MBEDTLS_PRIVATE(sig_algs);      /*!< allowed signature algorithms       */
 #endif /* MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED */
 
-#if defined(MBEDTLS_ECP_C) && !defined(MBEDTLS_DEPRECATED_REMOVED)
-    const mbedtls_ecp_group_id *MBEDTLS_PRIVATE(curve_list); /*!< allowed curves             */
-#endif
-
     const uint16_t *MBEDTLS_PRIVATE(group_list);     /*!< allowed IANA NamedGroups */
 
 #if defined(MBEDTLS_DHM_C)

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -3813,54 +3813,6 @@ void mbedtls_ssl_conf_dhm_min_bitlen(mbedtls_ssl_config *conf,
                                      unsigned int bitlen);
 #endif /* MBEDTLS_DHM_C && MBEDTLS_SSL_CLI_C */
 
-#if defined(MBEDTLS_ECP_C)
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-/**
- * \brief          Set the allowed curves in order of preference.
- *
- *                 On server: this only affects selection of the ECDHE curve;
- *                 the curves used for ECDH and ECDSA are determined by the
- *                 list of available certificates instead.
- *
- *                 On client: this affects the list of curves offered for any
- *                 use. The server can override our preference order.
- *
- *                 Both sides: limits the set of curves accepted for use in
- *                 ECDHE and in the peer's end-entity certificate.
- *
- * \deprecated     Superseded by mbedtls_ssl_conf_groups().
- *
- * \note           This has no influence on which curves are allowed inside the
- *                 certificate chains, see \c mbedtls_ssl_conf_cert_profile()
- *                 for that. For the end-entity certificate however, the key
- *                 will be accepted only if it is allowed both by this list
- *                 and by the cert profile.
- *
- * \note           This list should be ordered by decreasing preference
- *                 (preferred curve first).
- *
- * \note           The default list is the same set of curves that
- *                 #mbedtls_x509_crt_profile_default allows, plus
- *                 ECDHE-only curves selected according to the same criteria.
- *                 The order favors curves with the lowest resource usage.
- *
- * \note           New minor versions of Mbed TLS may extend this list,
- *                 for example if new curves are added to the library.
- *                 New minor versions of Mbed TLS will not remove items
- *                 from this list unless serious security concerns require it.
- *                 New minor versions of Mbed TLS may change the order in
- *                 keeping with the general principle of favoring the lowest
- *                 resource usage.
- *
- * \param conf     SSL configuration
- * \param curves   Ordered list of allowed curves,
- *                 terminated by MBEDTLS_ECP_DP_NONE.
- */
-void MBEDTLS_DEPRECATED mbedtls_ssl_conf_curves(mbedtls_ssl_config *conf,
-                                                const mbedtls_ecp_group_id *curves);
-#endif /* MBEDTLS_DEPRECATED_REMOVED */
-#endif /* MBEDTLS_ECP_C */
-
 /**
  * \brief          Set the allowed groups in order of preference.
  *
@@ -3871,13 +3823,6 @@ void MBEDTLS_DEPRECATED mbedtls_ssl_conf_curves(mbedtls_ssl_config *conf,
  *
  *                 Both sides: limits the set of groups accepted for use in
  *                 key sharing.
- *
- * \note           This function replaces the deprecated mbedtls_ssl_conf_curves(),
- *                 which only allows ECP curves to be configured.
- *
- * \note           The most recent invocation of either mbedtls_ssl_conf_curves()
- *                 or mbedtls_ssl_conf_groups() nullifies all previous invocations
- *                 of both.
  *
  * \note           This list should be ordered by decreasing preference
  *                 (preferred group first).

--- a/library/ssl_client.c
+++ b/library/ssl_client.c
@@ -222,7 +222,7 @@ static int ssl_write_supported_groups_ext(mbedtls_ssl_context *ssl,
     unsigned char *p = buf;
     unsigned char *named_group_list; /* Start of named_group_list */
     size_t named_group_list_len;     /* Length of named_group_list */
-    const uint16_t *group_list = mbedtls_ssl_get_groups(ssl);
+    const uint16_t *group_list = ssl->conf->group_list;
 
     *out_len = 0;
 

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -2268,16 +2268,6 @@ int mbedtls_ssl_get_handshake_transcript(mbedtls_ssl_context *ssl,
                                          size_t *olen);
 
 /*
- * Return supported groups.
- *
- * In future, invocations can be changed to ssl->conf->group_list.
- */
-static inline const void *mbedtls_ssl_get_groups(const mbedtls_ssl_context *ssl)
-{
-    return ssl->conf->group_list;
-}
-
-/*
  * Helper functions for NamedGroup.
  */
 static inline int mbedtls_ssl_tls12_named_group_is_ecdhe(uint16_t named_group)
@@ -2319,7 +2309,7 @@ static inline int mbedtls_ssl_tls13_named_group_is_ffdh(uint16_t named_group)
 static inline int mbedtls_ssl_named_group_is_offered(
     const mbedtls_ssl_context *ssl, uint16_t named_group)
 {
-    const uint16_t *group_list = mbedtls_ssl_get_groups(ssl);
+    const uint16_t *group_list = ssl->conf->group_list;
 
     if (group_list == NULL) {
         return 0;

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -2270,25 +2270,11 @@ int mbedtls_ssl_get_handshake_transcript(mbedtls_ssl_context *ssl,
 /*
  * Return supported groups.
  *
- * In future, invocations can be changed to ssl->conf->group_list
- * when mbedtls_ssl_conf_curves() is deleted.
- *
- * ssl->handshake->group_list is either a translation of curve_list to IANA TLS group
- * identifiers when mbedtls_ssl_conf_curves() has been used, or a pointer to
- * ssl->conf->group_list when mbedtls_ssl_conf_groups() has been more recently invoked.
- *
+ * In future, invocations can be changed to ssl->conf->group_list.
  */
 static inline const void *mbedtls_ssl_get_groups(const mbedtls_ssl_context *ssl)
 {
-    #if defined(MBEDTLS_DEPRECATED_REMOVED) || !defined(MBEDTLS_ECP_C)
     return ssl->conf->group_list;
-    #else
-    if ((ssl->handshake != NULL) && (ssl->handshake->group_list != NULL)) {
-        return ssl->handshake->group_list;
-    } else {
-        return ssl->conf->group_list;
-    }
-    #endif
 }
 
 /*

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1154,48 +1154,6 @@ static int ssl_handshake_init(mbedtls_ssl_context *ssl)
     }
 #endif
 
-/*
- * curve_list is translated to IANA TLS group identifiers here because
- * mbedtls_ssl_conf_curves returns void and so can't return
- * any error codes.
- */
-#if defined(MBEDTLS_ECP_C)
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-    /* Heap allocate and translate curve_list from internal to IANA group ids */
-    if (ssl->conf->curve_list != NULL) {
-        size_t length;
-        const mbedtls_ecp_group_id *curve_list = ssl->conf->curve_list;
-
-        for (length = 0;  (curve_list[length] != MBEDTLS_ECP_DP_NONE); length++) {
-        }
-
-        /* Leave room for zero termination */
-        uint16_t *group_list = mbedtls_calloc(length + 1, sizeof(uint16_t));
-        if (group_list == NULL) {
-            return MBEDTLS_ERR_SSL_ALLOC_FAILED;
-        }
-
-        for (size_t i = 0; i < length; i++) {
-            uint16_t tls_id = mbedtls_ssl_get_tls_id_from_ecp_group_id(
-                curve_list[i]);
-            if (tls_id == 0) {
-                mbedtls_free(group_list);
-                return MBEDTLS_ERR_SSL_BAD_CONFIG;
-            }
-            group_list[i] = tls_id;
-        }
-
-        group_list[length] = 0;
-
-        ssl->handshake->group_list = group_list;
-        ssl->handshake->group_list_heap_allocated = 1;
-    } else {
-        ssl->handshake->group_list = ssl->conf->group_list;
-        ssl->handshake->group_list_heap_allocated = 0;
-    }
-#endif /* MBEDTLS_DEPRECATED_REMOVED */
-#endif /* MBEDTLS_ECP_C */
-
 #if defined(MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED)
 #if !defined(MBEDTLS_DEPRECATED_REMOVED)
 #if defined(MBEDTLS_SSL_PROTO_TLS1_2)
@@ -2741,9 +2699,6 @@ void mbedtls_ssl_conf_sig_algs(mbedtls_ssl_config *conf,
 void mbedtls_ssl_conf_groups(mbedtls_ssl_config *conf,
                              const uint16_t *group_list)
 {
-#if defined(MBEDTLS_ECP_C) && !defined(MBEDTLS_DEPRECATED_REMOVED)
-    conf->curve_list = NULL;
-#endif
     conf->group_list = group_list;
 }
 
@@ -5964,9 +5919,6 @@ int mbedtls_ssl_config_defaults(mbedtls_ssl_config *conf,
             conf->sig_algs = ssl_preset_suiteb_sig_algs;
 #endif /* MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED */
 
-#if defined(MBEDTLS_ECP_C) && !defined(MBEDTLS_DEPRECATED_REMOVED)
-            conf->curve_list = NULL;
-#endif
             conf->group_list = ssl_preset_suiteb_groups;
             break;
 
@@ -5990,9 +5942,6 @@ int mbedtls_ssl_config_defaults(mbedtls_ssl_config *conf,
             conf->sig_algs = ssl_preset_default_sig_algs;
 #endif /* MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED */
 
-#if defined(MBEDTLS_ECP_C) && !defined(MBEDTLS_DEPRECATED_REMOVED)
-            conf->curve_list = NULL;
-#endif
             conf->group_list = ssl_preset_default_groups;
 
 #if defined(MBEDTLS_DHM_C) && defined(MBEDTLS_SSL_CLI_C)

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -2735,25 +2735,6 @@ void mbedtls_ssl_conf_sig_algs(mbedtls_ssl_config *conf,
 }
 #endif /* MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED */
 
-#if defined(MBEDTLS_ECP_C)
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-/*
- * Set the allowed elliptic curves
- *
- * mbedtls_ssl_setup() takes the provided list
- * and translates it to a list of IANA TLS group identifiers,
- * stored in ssl->handshake->group_list.
- *
- */
-void mbedtls_ssl_conf_curves(mbedtls_ssl_config *conf,
-                             const mbedtls_ecp_group_id *curve_list)
-{
-    conf->curve_list = curve_list;
-    conf->group_list = NULL;
-}
-#endif /* MBEDTLS_DEPRECATED_REMOVED */
-#endif /* MBEDTLS_ECP_C */
-
 /*
  * Set the allowed groups
  */
@@ -5594,7 +5575,7 @@ void mbedtls_ssl_config_init(mbedtls_ssl_config *conf)
 /* The selection should be the same as mbedtls_x509_crt_profile_default in
  * x509_crt.c, plus Montgomery curves for ECDHE. Here, the order matters:
  * curves with a lower resource usage come first.
- * See the documentation of mbedtls_ssl_conf_curves() for what we promise
+ * See the documentation of mbedtls_ssl_conf_groups() for what we promise
  * about this list.
  */
 static const uint16_t ssl_preset_default_groups[] = {

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -6119,7 +6119,7 @@ unsigned char mbedtls_ssl_hash_from_md_alg(int md)
  */
 int mbedtls_ssl_check_curve_tls_id(const mbedtls_ssl_context *ssl, uint16_t tls_id)
 {
-    const uint16_t *group_list = mbedtls_ssl_get_groups(ssl);
+    const uint16_t *group_list = ssl->conf->group_list;
 
     if (group_list == NULL) {
         return -1;

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -2966,7 +2966,7 @@ static int ssl_prepare_server_key_exchange(mbedtls_ssl_context *ssl,
          * } ServerECDHParams;
          */
         uint16_t *curr_tls_id = ssl->handshake->curves_tls_id;
-        const uint16_t *group_list = mbedtls_ssl_get_groups(ssl);
+        const uint16_t *group_list = ssl->conf->group_list;
         int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
         size_t len = 0;
 

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -216,7 +216,7 @@ static int ssl_tls13_get_default_group_id(mbedtls_ssl_context *ssl,
 
 
 #if defined(PSA_WANT_ALG_ECDH) || defined(PSA_WANT_ALG_FFDH)
-    const uint16_t *group_list = mbedtls_ssl_get_groups(ssl);
+    const uint16_t *group_list = ssl->conf->group_list;
     /* Pick first available ECDHE group compatible with TLS 1.3 */
     if (group_list == NULL) {
         return MBEDTLS_ERR_SSL_BAD_CONFIG;
@@ -382,7 +382,7 @@ static int ssl_tls13_parse_hrr_key_share_ext(mbedtls_ssl_context *ssl,
     int selected_group;
     int found = 0;
 
-    const uint16_t *group_list = mbedtls_ssl_get_groups(ssl);
+    const uint16_t *group_list = ssl->conf->group_list;
     if (group_list == NULL) {
         return MBEDTLS_ERR_SSL_BAD_CONFIG;
     }

--- a/tests/scripts/analyze_outcomes.py
+++ b/tests/scripts/analyze_outcomes.py
@@ -429,10 +429,6 @@ class DriverVSReference_ecp_light_only(outcome_analysis.DriverVSReference):
             re.compile(r'ECP point multiplication .*'),
             re.compile(r'ECP test vectors .*'),
         ],
-        'test_suite_ssl': [
-            # This deprecated function is only present when ECP_C is On.
-            'Test configuration of groups for DHE through mbedtls_ssl_conf_curves()',
-        ],
     }
 
 class DriverVSReference_no_ecp_at_all(outcome_analysis.DriverVSReference):
@@ -468,10 +464,6 @@ class DriverVSReference_no_ecp_at_all(outcome_analysis.DriverVSReference):
             # while checking driver's coverage.
             re.compile(r'Parse EC Key .*compressed\)'),
             re.compile(r'Parse Public EC Key .*compressed\)'),
-        ],
-        # See ecp_light_only
-        'test_suite_ssl': [
-            'Test configuration of groups for DHE through mbedtls_ssl_conf_curves()',
         ],
     }
 
@@ -515,10 +507,6 @@ class DriverVSReference_ecc_no_bignum(outcome_analysis.DriverVSReference):
         ],
         'test_suite_debug': [
             re.compile(r'Debug print mbedtls_mpi.*'),
-        ],
-        # See ecp_light_only
-        'test_suite_ssl': [
-            'Test configuration of groups for DHE through mbedtls_ssl_conf_curves()',
         ],
     }
 
@@ -570,10 +558,6 @@ class DriverVSReference_ecc_ffdh_no_bignum(outcome_analysis.DriverVSReference):
         ],
         'test_suite_debug': [
             re.compile(r'Debug print mbedtls_mpi.*'),
-        ],
-        # See ecp_light_only
-        'test_suite_ssl': [
-            'Test configuration of groups for DHE through mbedtls_ssl_conf_curves()',
         ],
     }
 

--- a/tests/suites/test_suite_ssl.data
+++ b/tests/suites/test_suite_ssl.data
@@ -3086,9 +3086,6 @@ TLS 1.3: SRV: Session serialization, load buffer size
 depends_on:MBEDTLS_SSL_PROTO_TLS1_3:MBEDTLS_SSL_SESSION_TICKETS:MBEDTLS_SSL_SRV_C
 ssl_serialize_session_load_buf_size:0:"":MBEDTLS_SSL_IS_SERVER:MBEDTLS_SSL_VERSION_TLS1_3
 
-Test configuration of groups for DHE through mbedtls_ssl_conf_curves()
-conf_curve:
-
 Test configuration of groups for DHE through mbedtls_ssl_conf_groups()
 conf_group:
 

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -3009,56 +3009,6 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_ECP_C:!MBEDTLS_DEPRECATED_REMOVED:!MBEDTLS_DEPRECATED_WARNING:PSA_WANT_ECC_SECP_R1_192:PSA_WANT_ECC_SECP_R1_224:PSA_WANT_ECC_SECP_R1_256 */
-void conf_curve()
-{
-
-    mbedtls_ecp_group_id curve_list[] = { MBEDTLS_ECP_DP_SECP192R1,
-                                          MBEDTLS_ECP_DP_SECP224R1,
-                                          MBEDTLS_ECP_DP_SECP256R1,
-                                          MBEDTLS_ECP_DP_NONE };
-    uint16_t iana_tls_group_list[] = { MBEDTLS_SSL_IANA_TLS_GROUP_SECP192R1,
-                                       MBEDTLS_SSL_IANA_TLS_GROUP_SECP224R1,
-                                       MBEDTLS_SSL_IANA_TLS_GROUP_SECP256R1,
-                                       MBEDTLS_SSL_IANA_TLS_GROUP_NONE };
-
-    mbedtls_ssl_config conf;
-    mbedtls_ssl_config_init(&conf);
-#if defined(MBEDTLS_SSL_PROTO_TLS1_2)
-    mbedtls_ssl_conf_max_tls_version(&conf, MBEDTLS_SSL_VERSION_TLS1_2);
-    mbedtls_ssl_conf_min_tls_version(&conf, MBEDTLS_SSL_VERSION_TLS1_2);
-#else
-    mbedtls_ssl_conf_max_tls_version(&conf, MBEDTLS_SSL_VERSION_TLS1_3);
-    mbedtls_ssl_conf_min_tls_version(&conf, MBEDTLS_SSL_VERSION_TLS1_3);
-#endif
-    mbedtls_ssl_conf_curves(&conf, curve_list);
-
-    mbedtls_ssl_context ssl;
-    mbedtls_ssl_init(&ssl);
-    MD_OR_USE_PSA_INIT();
-
-    mbedtls_ssl_conf_rng(&conf, mbedtls_test_random, NULL);
-
-    TEST_ASSERT(mbedtls_ssl_setup(&ssl, &conf) == 0);
-
-    TEST_ASSERT(ssl.handshake != NULL && ssl.handshake->group_list != NULL);
-    TEST_ASSERT(ssl.conf != NULL && ssl.conf->group_list == NULL);
-
-    TEST_EQUAL(ssl.handshake->
-               group_list[ARRAY_LENGTH(iana_tls_group_list) - 1],
-               MBEDTLS_SSL_IANA_TLS_GROUP_NONE);
-
-    for (size_t i = 0; i < ARRAY_LENGTH(iana_tls_group_list); i++) {
-        TEST_EQUAL(iana_tls_group_list[i], ssl.handshake->group_list[i]);
-    }
-
-exit:
-    mbedtls_ssl_free(&ssl);
-    mbedtls_ssl_config_free(&conf);
-    MD_OR_USE_PSA_DONE();
-}
-/* END_CASE */
-
 /* BEGIN_CASE depends_on:MBEDTLS_DEPRECATED_REMOVED */
 void conf_group()
 {

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -3009,7 +3009,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_DEPRECATED_REMOVED */
+/* BEGIN_CASE */
 void conf_group()
 {
     uint16_t iana_tls_group_list[] = { MBEDTLS_SSL_IANA_TLS_GROUP_SECP192R1,

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -3021,8 +3021,9 @@ void conf_group()
     mbedtls_ssl_config_init(&conf);
 
     mbedtls_ssl_conf_rng(&conf, mbedtls_test_random, NULL);
-    mbedtls_ssl_conf_max_tls_version(&conf, MBEDTLS_SSL_VERSION_TLS1_2);
-    mbedtls_ssl_conf_min_tls_version(&conf, MBEDTLS_SSL_VERSION_TLS1_2);
+    mbedtls_ssl_config_defaults(&conf, MBEDTLS_SSL_IS_CLIENT,
+                                MBEDTLS_SSL_TRANSPORT_STREAM,
+                                MBEDTLS_SSL_PRESET_DEFAULT);
 
     mbedtls_ssl_conf_groups(&conf, iana_tls_group_list);
 


### PR DESCRIPTION
## Description

Resolve #9891

## PR checklist

- [x] **changelog** provided
- [x] **development PR** provided HERE
- [x] **framework PR** not required
- [x] **3.6 PR** provided #9907
- [x] **2.28 PR** not required because: 2.28 not affected
- **tests**  not required because: covered by existing tests
