### PR TITLE
[3.6 backport]: mbedtls_conf_curves()

### DIFF
--- a/docs/3.0-migration-guide.md
+++ b/docs/3.0-migration-guide.md
@@ -748,7 +748,7 @@ for both DTLS-CID and TLS 1.3.
 
 The default preference order for curves in TLS now favors resource usage (performance and memory consumption) over size. The exact order is unspecified and may change, but generally you can expect 256-bit curves to be preferred over larger curves.
 
-If you prefer a different order, call `mbedtls_ssl_conf_curves()` when configuring a TLS connection.
+If you prefer a different order, call `mbedtls_ssl_conf_groups()` when configuring a TLS connection.
 
 ### SSL key export interface change
 
@@ -1025,7 +1025,7 @@ mbedtls_x509_crt_profile my_profile = mbedtls_x509_crt_profile_default;
 my_profile.allowed_mds |= MBEDTLS_X509_ID_FLAG( MBEDTLS_MD_SHA224 );
 ```
 
-If you still need to allow hashes and curves in TLS that have been removed from the default configuration, call `mbedtls_ssl_conf_sig_hashes()` and `mbedtls_ssl_conf_curves()` with the desired lists.
+If you still need to allow hashes and curves in TLS that have been removed from the default configuration, call `mbedtls_ssl_conf_sig_hashes()` and `mbedtls_ssl_conf_groups()` with the desired lists.
 
 ### Remove 3DES ciphersuites
 

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -3059,7 +3059,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_DEPRECATED_REMOVED */
+/* BEGIN_CASE */
 void conf_group()
 {
     uint16_t iana_tls_group_list[] = { MBEDTLS_SSL_IANA_TLS_GROUP_SECP192R1,

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -3071,8 +3071,9 @@ void conf_group()
     mbedtls_ssl_config_init(&conf);
 
     mbedtls_ssl_conf_rng(&conf, mbedtls_test_random, NULL);
-    mbedtls_ssl_conf_max_tls_version(&conf, MBEDTLS_SSL_VERSION_TLS1_2);
-    mbedtls_ssl_conf_min_tls_version(&conf, MBEDTLS_SSL_VERSION_TLS1_2);
+    mbedtls_ssl_config_defaults(&conf, MBEDTLS_SSL_IS_CLIENT,
+                                MBEDTLS_SSL_TRANSPORT_STREAM,
+                                MBEDTLS_SSL_PRESET_DEFAULT);
 
     mbedtls_ssl_conf_groups(&conf, iana_tls_group_list);
 


### PR DESCRIPTION
## Description

This is the very partial 3.6 backport of #9906: don't remove the function but recommend its replacement in the migration guide. Also cherry-pick a commit fixing a test dependency that was always wrong, and then another one fixing a problem in the test that was previously hidden by the wrong dependency.

## PR checklist

- [x] **changelog** not required because: doc/test only
- [x] **development PR** provided #9906
- [x] **framework PR** not required
- [x] **3.6 PR** provided HERE
- [x] **2.28 PR** not required because: 2.28 not affected
- **tests**  not required because: covered by existing tests