### PR TITLE
Remove deprecated function mbedtls_x509write_crt_set_serial()

### DIFF
--- a/ChangeLog.d/9892.txt
+++ b/ChangeLog.d/9892.txt
@@ -1,0 +1,4 @@
+Removals
+   * Remove deprecated mbedtls_x509write_crt_set_serial(). The function was
+     already deprecated and superseeded by
+     mbedtls_x509write_crt_set_serial_raw().

--- a/include/mbedtls/x509_crt.h
+++ b/include/mbedtls/x509_crt.h
@@ -943,28 +943,6 @@ void mbedtls_x509write_crt_init(mbedtls_x509write_cert *ctx);
  */
 void mbedtls_x509write_crt_set_version(mbedtls_x509write_cert *ctx, int version);
 
-#if defined(MBEDTLS_BIGNUM_C) && !defined(MBEDTLS_DEPRECATED_REMOVED)
-/**
- * \brief           Set the serial number for a Certificate.
- *
- * \deprecated      This function is deprecated and will be removed in a
- *                  future version of the library. Please use
- *                  mbedtls_x509write_crt_set_serial_raw() instead.
- *
- * \note            Even though the MBEDTLS_BIGNUM_C guard looks redundant since
- *                  X509 depends on PK and PK depends on BIGNUM, this emphasizes
- *                  a direct dependency between X509 and BIGNUM which is going
- *                  to be deprecated in the future.
- *
- * \param ctx       CRT context to use
- * \param serial    serial number to set
- *
- * \return          0 if successful
- */
-int MBEDTLS_DEPRECATED mbedtls_x509write_crt_set_serial(
-    mbedtls_x509write_cert *ctx, const mbedtls_mpi *serial);
-#endif // MBEDTLS_BIGNUM_C && !MBEDTLS_DEPRECATED_REMOVED
-
 /**
  * \brief           Set the serial number for a Certificate.
  *

--- a/library/x509write_crt.c
+++ b/library/x509write_crt.c
@@ -92,30 +92,6 @@ int mbedtls_x509write_crt_set_issuer_name(mbedtls_x509write_cert *ctx,
     return mbedtls_x509_string_to_names(&ctx->issuer, issuer_name);
 }
 
-#if defined(MBEDTLS_BIGNUM_C) && !defined(MBEDTLS_DEPRECATED_REMOVED)
-int mbedtls_x509write_crt_set_serial(mbedtls_x509write_cert *ctx,
-                                     const mbedtls_mpi *serial)
-{
-    int ret;
-    size_t tmp_len;
-
-    /* Ensure that the MPI value fits into the buffer */
-    tmp_len = mbedtls_mpi_size(serial);
-    if (tmp_len > MBEDTLS_X509_RFC5280_MAX_SERIAL_LEN) {
-        return MBEDTLS_ERR_X509_BAD_INPUT_DATA;
-    }
-
-    ctx->serial_len = tmp_len;
-
-    ret = mbedtls_mpi_write_binary(serial, ctx->serial, tmp_len);
-    if (ret < 0) {
-        return ret;
-    }
-
-    return 0;
-}
-#endif // MBEDTLS_BIGNUM_C && !MBEDTLS_DEPRECATED_REMOVED
-
 int mbedtls_x509write_crt_set_serial_raw(mbedtls_x509write_cert *ctx,
                                          unsigned char *serial, size_t serial_len)
 {

--- a/tests/suites/test_suite_x509write.function
+++ b/tests/suites/test_suite_x509write.function
@@ -471,14 +471,8 @@ void x509_crt_check(char *subject_key_file, char *subject_pwd,
         mbedtls_x509write_crt_set_version(&crt, ver);
     }
 
-#if defined(MBEDTLS_TEST_DEPRECATED) && defined(MBEDTLS_BIGNUM_C)
-    TEST_ASSERT(mbedtls_mpi_read_binary(&serial_mpi, serial_arg->x,
-                                        serial_arg->len) == 0);
-    TEST_ASSERT(mbedtls_x509write_crt_set_serial(&crt, &serial_mpi) == 0);
-#else
     TEST_ASSERT(mbedtls_x509write_crt_set_serial_raw(&crt, serial_arg->x,
                                                      serial_arg->len) == 0);
-#endif
     TEST_ASSERT(mbedtls_x509write_crt_set_validity(&crt, not_before,
                                                    not_after) == 0);
     mbedtls_x509write_crt_set_md_alg(&crt, md_type);
@@ -664,13 +658,6 @@ void x509_set_serial_check()
 
     USE_PSA_INIT();
     memset(invalid_serial, 0x01, sizeof(invalid_serial));
-
-#if defined(MBEDTLS_TEST_DEPRECATED) && defined(MBEDTLS_BIGNUM_C)
-    TEST_EQUAL(mbedtls_mpi_read_binary(&serial_mpi, invalid_serial,
-                                       sizeof(invalid_serial)), 0);
-    TEST_EQUAL(mbedtls_x509write_crt_set_serial(&ctx, &serial_mpi),
-               MBEDTLS_ERR_X509_BAD_INPUT_DATA);
-#endif
 
     TEST_EQUAL(mbedtls_x509write_crt_set_serial_raw(&ctx, invalid_serial,
                                                     sizeof(invalid_serial)),


### PR DESCRIPTION
## Description

Resolves #9892

## PR checklist

- [ ] **changelog** provided
- [ ] **development PR** not required: it's this one
- [ ] **framework PR** not required: no change
- [ ] **3.6 PR** not required because: only `development` change
- [ ] **2.28 PR** not required because: only `development` change
- **tests** not required because: this is a removal