### PR TITLE
Do not add error codes

### DIFF
--- a/ChangeLog.d/error-unification.txt
+++ b/ChangeLog.d/error-unification.txt
@@ -1,10 +1,10 @@
 API changes
-   * The PSA and Mbed TLS error space are now unified. This means that
-     mbedtls_xxx() functions can return PSA_ERROR_xxx values.
+   * The PSA and Mbed TLS error spaces are now unified. mbedtls_xxx()
+     functions can now return PSA_ERROR_xxx values.
      There is no longer a distinction between "low-level" and "high-level"
-     Mbed TLS error codes..
-     This will not affect most applications since in both cases, the
-     error values are between -32767 and -1 as before.
+     Mbed TLS error codes.
+     This will not affect most applications since the error values are
+     between -32767 and -1 as before.
 
 Removals
    * Remove mbedtls_low_level_sterr() and mbedtls_high_level_strerr(),

--- a/ChangeLog.d/error-unification.txt
+++ b/ChangeLog.d/error-unification.txt
@@ -5,3 +5,7 @@ API changes
      Mbed TLS error codes..
      This will not affect most applications since in both cases, the
      error values are between -32767 and -1 as before.
+
+Removals
+   * Remove mbedtls_low_level_sterr() and mbedtls_high_level_strerr(),
+     since these concepts no longer exists. There is just mbedtls_strerror().

--- a/ChangeLog.d/error-unification.txt
+++ b/ChangeLog.d/error-unification.txt
@@ -1,0 +1,7 @@
+API changes
+   * The PSA and Mbed TLS error space are now unified. This means that
+     mbedtls_xxx() functions can return PSA_ERROR_xxx values.
+     There is no longer a distinction between "low-level" and "high-level"
+     Mbed TLS error codes..
+     This will not affect most applications since in both cases, the
+     error values are between -32767 and -1 as before.

--- a/include/mbedtls/error.h
+++ b/include/mbedtls/error.h
@@ -30,36 +30,6 @@ extern "C" {
  */
 void mbedtls_strerror(int errnum, char *buffer, size_t buflen);
 
-/**
- * \brief Translate the high-level part of an Mbed TLS error code into a string
- *        representation.
- *
- * This function returns a const pointer to an un-modifiable string. The caller
- * must not try to modify the string. It is intended to be used mostly for
- * logging purposes.
- *
- * \param error_code    error code
- *
- * \return The string representation of the error code, or \c NULL if the error
- *         code is unknown.
- */
-const char *mbedtls_high_level_strerr(int error_code);
-
-/**
- * \brief Translate the low-level part of an Mbed TLS error code into a string
- *        representation.
- *
- * This function returns a const pointer to an un-modifiable string. The caller
- * must not try to modify the string. It is intended to be used mostly for
- * logging purposes.
- *
- * \param error_code    error code
- *
- * \return The string representation of the error code, or \c NULL if the error
- *         code is unknown.
- */
-const char *mbedtls_low_level_strerr(int error_code);
-
 #ifdef __cplusplus
 }
 #endif

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -7004,7 +7004,7 @@ static int ssl_parse_certificate_chain(mbedtls_ssl_context *ssl,
 #endif /* MBEDTLS_SSL_KEEP_PEER_CERTIFICATE */
         switch (ret) {
             case 0: /*ok*/
-            case MBEDTLS_ERR_X509_UNKNOWN_SIG_ALG + MBEDTLS_ERR_OID_NOT_FOUND:
+            case MBEDTLS_ERR_OID_NOT_FOUND:
                 /* Ignore certificate with an unknown algorithm: maybe a
                    prior certificate was already trusted. */
                 break;

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -518,7 +518,7 @@ int mbedtls_ssl_tls13_parse_certificate(mbedtls_ssl_context *ssl,
         switch (ret) {
             case 0: /*ok*/
                 break;
-            case MBEDTLS_ERR_X509_UNKNOWN_SIG_ALG + MBEDTLS_ERR_OID_NOT_FOUND:
+            case MBEDTLS_ERR_OID_NOT_FOUND:
                 /* Ignore certificate with an unknown algorithm: maybe a
                    prior certificate was already trusted. */
                 break;

--- a/scripts/data_files/error.fmt
+++ b/scripts/data_files/error.fmt
@@ -20,7 +20,7 @@
 
 HEADER_INCLUDED
 
-const char *mbedtls_high_level_strerr(int error_code)
+static const char *mbedtls_high_level_strerr(int error_code)
 {
     int high_level_error_code;
 
@@ -43,7 +43,7 @@ const char *mbedtls_high_level_strerr(int error_code)
     return NULL;
 }
 
-const char *mbedtls_low_level_strerr(int error_code)
+static const char *mbedtls_low_level_strerr(int error_code)
 {
     int low_level_error_code;
 


### PR DESCRIPTION
Never add a low-level error code to a high-level error code. Just use the low-level error code. Resolves https://github.com/Mbed-TLS/mbedtls/issues/9619, a step towards [having unified PSA and mbedtls error codes](https://github.com/Mbed-TLS/mbedtls/issues/8501).

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** provided
- [x] **development PR** here
- [x] **crypto PR** https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/167
- [x] **framework PR** not required
- [x] **3.6 PR** not required because: API break
- [x] **2.28 PR** not required because: API break
- **tests**  provided | not required because: 
