### PR TITLE
Add TLS Handshake defragmentation tests

### DIFF
--- a/ChangeLog.d/tls-hs-defrag-in.txt
+++ b/ChangeLog.d/tls-hs-defrag-in.txt
@@ -1,0 +1,2 @@
+Change
+   * Defragment incoming TLS handshake messages.

--- a/ChangeLog.d/tls-hs-defrag-in.txt
+++ b/ChangeLog.d/tls-hs-defrag-in.txt
@@ -1,2 +1,2 @@
-Change
+Changes
    * Defragment incoming TLS handshake messages.

--- a/ChangeLog.d/tls-hs-defrag-in.txt
+++ b/ChangeLog.d/tls-hs-defrag-in.txt
@@ -1,2 +1,5 @@
-Changes
-   * Defragment incoming TLS handshake messages.
+Bugfix
+   * Support re-assembly of fragmented handshake messages in TLS, as mandated
+     by the spec. Lack of support was causing handshake failures with some
+     servers, especially with TLS 1.3 in practice (though both protocol
+     version could be affected in principle, and both are fixed now).

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1808,6 +1808,8 @@ struct mbedtls_ssl_context {
 
     size_t MBEDTLS_PRIVATE(in_hslen);            /*!< current handshake message length,
                                                     including the handshake header   */
+    unsigned char *MBEDTLS_PRIVATE(in_hshdr);    /*!< original handshake header start  */
+    size_t MBEDTLS_PRIVATE(in_hsfraglen);        /*!< accumulated hs fragments length  */
     int MBEDTLS_PRIVATE(nb_zero);                /*!< # of 0-length encrypted messages */
 
     int MBEDTLS_PRIVATE(keep_current_message);   /*!< drop or reuse current message

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1808,8 +1808,8 @@ struct mbedtls_ssl_context {
 
     size_t MBEDTLS_PRIVATE(in_hslen);            /*!< current handshake message length,
                                                     including the handshake header   */
-    unsigned char *MBEDTLS_PRIVATE(in_hshdr);    /*!< original handshake header start  */
-    size_t MBEDTLS_PRIVATE(in_hsfraglen);        /*!< accumulated hs fragments length  */
+    size_t MBEDTLS_PRIVATE(in_hsfraglen);        /*!< accumulated length of hs fragments
+                                                    (up to in_hslen) */
     int MBEDTLS_PRIVATE(nb_zero);                /*!< # of 0-length encrypted messages */
 
     int MBEDTLS_PRIVATE(keep_current_message);   /*!< drop or reuse current message

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -1829,7 +1829,13 @@ void mbedtls_ssl_set_timer(mbedtls_ssl_context *ssl, uint32_t millisecs);
 MBEDTLS_CHECK_RETURN_CRITICAL
 int mbedtls_ssl_check_timer(mbedtls_ssl_context *ssl);
 
-void mbedtls_ssl_reset_in_out_pointers(mbedtls_ssl_context *ssl);
+void mbedtls_ssl_reset_in_pointers(mbedtls_ssl_context *ssl);
+void mbedtls_ssl_reset_out_pointers(mbedtls_ssl_context *ssl);
+static inline void mbedtls_ssl_reset_in_out_pointers(mbedtls_ssl_context *ssl)
+{
+    mbedtls_ssl_reset_in_pointers(ssl);
+    mbedtls_ssl_reset_out_pointers(ssl);
+}
 void mbedtls_ssl_update_out_pointers(mbedtls_ssl_context *ssl,
                                      mbedtls_ssl_transform *transform);
 void mbedtls_ssl_update_in_pointers(mbedtls_ssl_context *ssl);

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -1830,15 +1830,10 @@ MBEDTLS_CHECK_RETURN_CRITICAL
 int mbedtls_ssl_check_timer(mbedtls_ssl_context *ssl);
 
 void mbedtls_ssl_reset_in_pointers(mbedtls_ssl_context *ssl);
+void mbedtls_ssl_update_in_pointers(mbedtls_ssl_context *ssl);
 void mbedtls_ssl_reset_out_pointers(mbedtls_ssl_context *ssl);
-static inline void mbedtls_ssl_reset_in_out_pointers(mbedtls_ssl_context *ssl)
-{
-    mbedtls_ssl_reset_in_pointers(ssl);
-    mbedtls_ssl_reset_out_pointers(ssl);
-}
 void mbedtls_ssl_update_out_pointers(mbedtls_ssl_context *ssl,
                                      mbedtls_ssl_transform *transform);
-void mbedtls_ssl_update_in_pointers(mbedtls_ssl_context *ssl);
 
 MBEDTLS_CHECK_RETURN_CRITICAL
 int mbedtls_ssl_session_reset_int(mbedtls_ssl_context *ssl, int partial);

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -3225,7 +3225,11 @@ int mbedtls_ssl_prepare_handshake_record(mbedtls_ssl_context *ssl)
         return MBEDTLS_ERR_SSL_INVALID_RECORD;
     }
 
-    ssl->in_hslen = mbedtls_ssl_hs_hdr_len(ssl) + ssl_get_hs_total_len(ssl);
+    if (ssl->in_hslen == 0) {
+        ssl->in_hslen = mbedtls_ssl_hs_hdr_len(ssl) + ssl_get_hs_total_len(ssl);
+        ssl->in_hsfraglen = 0;
+        ssl->in_hshdr = ssl->in_hdr;
+    }
 
     MBEDTLS_SSL_DEBUG_MSG(3, ("handshake message: msglen ="
                               " %" MBEDTLS_PRINTF_SIZET ", type = %u, hslen = %"
@@ -3291,10 +3295,59 @@ int mbedtls_ssl_prepare_handshake_record(mbedtls_ssl_context *ssl)
         }
     } else
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
-    /* With TLS we don't handle fragmentation (for now) */
-    if (ssl->in_msglen < ssl->in_hslen) {
-        MBEDTLS_SSL_DEBUG_MSG(1, ("TLS handshake fragmentation not supported"));
-        return MBEDTLS_ERR_SSL_FEATURE_UNAVAILABLE;
+    {
+        int ret;
+        const size_t hs_remain = ssl->in_hslen - ssl->in_hsfraglen;
+        const size_t msg_hslen = (hs_remain <= ssl->in_msglen ? hs_remain : ssl->in_msglen);
+
+        MBEDTLS_SSL_DEBUG_MSG(3,
+                              ("handshake fragment: %" MBEDTLS_PRINTF_SIZET " .. %"
+                               MBEDTLS_PRINTF_SIZET " of %"
+                               MBEDTLS_PRINTF_SIZET " msglen %" MBEDTLS_PRINTF_SIZET,
+                               ssl->in_hsfraglen, ssl->in_hsfraglen + msg_hslen,
+                               ssl->in_hslen, ssl->in_msglen));
+        (void) msg_hslen;
+        if (ssl->in_msglen < hs_remain) {
+            ssl->in_hsfraglen += ssl->in_msglen;
+            ssl->in_hdr = ssl->in_msg + ssl->in_msglen;
+            ssl->in_msglen = 0;
+            mbedtls_ssl_update_in_pointers(ssl);
+            return MBEDTLS_ERR_SSL_CONTINUE_PROCESSING;
+        }
+        if (ssl->in_hshdr != ssl->in_hdr) {
+            /*
+             * At ssl->in_hshdr we have a sequence of records that cover the next handshake
+             * record, each with its own record header that we need to remove.
+             * Note that the reassembled record size may not equal the size of the message,
+             * there maybe bytes from the next message following it.
+             */
+            size_t merged_rec_len = 0;
+            unsigned char *p = ssl->in_hshdr, *q = NULL;
+            do {
+                mbedtls_record rec;
+                ret = ssl_parse_record_header(ssl, p, mbedtls_ssl_in_hdr_len(ssl), &rec);
+                if (ret != 0) {
+                    return ret;
+                }
+                merged_rec_len += rec.data_len;
+                p = rec.buf + rec.buf_len;
+                if (q != NULL) {
+                    memmove(q, rec.buf + rec.data_offset, rec.data_len);
+                    q += rec.data_len;
+                } else {
+                    q = p;
+                }
+            } while (merged_rec_len < ssl->in_hslen);
+            ssl->in_hdr = ssl->in_hshdr;
+            mbedtls_ssl_update_in_pointers(ssl);
+            ssl->in_msglen = merged_rec_len;
+            /* Adjust message length. */
+            MBEDTLS_PUT_UINT16_BE(merged_rec_len, ssl->in_len, 0);
+            ssl->in_hsfraglen = 0;
+            ssl->in_hshdr = NULL;
+            MBEDTLS_SSL_DEBUG_BUF(4, "reassembled record",
+                                  ssl->in_hdr, mbedtls_ssl_in_hdr_len(ssl) + merged_rec_len);
+        }
     }
 
     return 0;
@@ -4639,6 +4692,16 @@ static int ssl_consume_current_message(mbedtls_ssl_context *ssl)
             return MBEDTLS_ERR_SSL_INTERNAL_ERROR;
         }
 
+        if (ssl->in_hsfraglen != 0) {
+            /* Not all handshake fragments have arrived, do not consume. */
+            MBEDTLS_SSL_DEBUG_MSG(3,
+                                  ("waiting for more fragments (%" MBEDTLS_PRINTF_SIZET " of %"
+                                   MBEDTLS_PRINTF_SIZET ", %" MBEDTLS_PRINTF_SIZET " left)",
+                                   ssl->in_hsfraglen, ssl->in_hslen,
+                                   ssl->in_hslen - ssl->in_hsfraglen));
+            return 0;
+        }
+
         /*
          * Get next Handshake message in the current record
          */
@@ -4664,6 +4727,7 @@ static int ssl_consume_current_message(mbedtls_ssl_context *ssl)
             ssl->in_msglen -= ssl->in_hslen;
             memmove(ssl->in_msg, ssl->in_msg + ssl->in_hslen,
                     ssl->in_msglen);
+            MBEDTLS_PUT_UINT16_BE(ssl->in_msglen, ssl->in_len, 0);
 
             MBEDTLS_SSL_DEBUG_BUF(4, "remaining content in record",
                                   ssl->in_msg, ssl->in_msglen);
@@ -5338,7 +5402,7 @@ void mbedtls_ssl_update_in_pointers(mbedtls_ssl_context *ssl)
     } else
 #endif
     {
-        ssl->in_ctr = ssl->in_hdr - MBEDTLS_SSL_SEQUENCE_NUMBER_LEN;
+        ssl->in_ctr = ssl->in_buf;
         ssl->in_len = ssl->in_hdr + 3;
 #if defined(MBEDTLS_SSL_DTLS_CONNECTION_ID)
         ssl->in_cid = ssl->in_len;
@@ -5354,24 +5418,35 @@ void mbedtls_ssl_update_in_pointers(mbedtls_ssl_context *ssl)
  * Setup an SSL context
  */
 
-void mbedtls_ssl_reset_in_out_pointers(mbedtls_ssl_context *ssl)
+void mbedtls_ssl_reset_in_pointers(mbedtls_ssl_context *ssl)
+{
+#if defined(MBEDTLS_SSL_PROTO_DTLS)
+    if (ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM) {
+        ssl->in_hdr = ssl->in_buf;
+    } else
+#endif
+    {
+        ssl->in_hdr = ssl->in_buf + MBEDTLS_SSL_SEQUENCE_NUMBER_LEN;
+    }
+
+    /* Derive other internal pointers. */
+    mbedtls_ssl_update_in_pointers(ssl);
+}
+
+void mbedtls_ssl_reset_out_pointers(mbedtls_ssl_context *ssl)
 {
     /* Set the incoming and outgoing record pointers. */
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
     if (ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM) {
         ssl->out_hdr = ssl->out_buf;
-        ssl->in_hdr  = ssl->in_buf;
     } else
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
     {
         ssl->out_ctr = ssl->out_buf;
-        ssl->out_hdr = ssl->out_buf + 8;
-        ssl->in_hdr  = ssl->in_buf  + 8;
+        ssl->out_hdr = ssl->out_buf + MBEDTLS_SSL_SEQUENCE_NUMBER_LEN;
     }
-
     /* Derive other internal pointers. */
     mbedtls_ssl_update_out_pointers(ssl, NULL /* no transform enabled */);
-    mbedtls_ssl_update_in_pointers(ssl);
 }
 
 /*

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -3219,7 +3219,8 @@ static uint32_t ssl_get_hs_total_len(mbedtls_ssl_context const *ssl)
 
 int mbedtls_ssl_prepare_handshake_record(mbedtls_ssl_context *ssl)
 {
-    if (ssl->in_msglen < mbedtls_ssl_hs_hdr_len(ssl)) {
+    /* First handshake fragment must at least include the header. */
+    if (ssl->in_msglen < mbedtls_ssl_hs_hdr_len(ssl) && ssl->in_hslen == 0) {
         MBEDTLS_SSL_DEBUG_MSG(1, ("handshake message too short: %" MBEDTLS_PRINTF_SIZET,
                                   ssl->in_msglen));
         return MBEDTLS_ERR_SSL_INVALID_RECORD;

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -3298,15 +3298,14 @@ int mbedtls_ssl_prepare_handshake_record(mbedtls_ssl_context *ssl)
     {
         int ret;
         const size_t hs_remain = ssl->in_hslen - ssl->in_hsfraglen;
-        const size_t msg_hslen = (hs_remain <= ssl->in_msglen ? hs_remain : ssl->in_msglen);
-
         MBEDTLS_SSL_DEBUG_MSG(3,
                               ("handshake fragment: %" MBEDTLS_PRINTF_SIZET " .. %"
                                MBEDTLS_PRINTF_SIZET " of %"
                                MBEDTLS_PRINTF_SIZET " msglen %" MBEDTLS_PRINTF_SIZET,
-                               ssl->in_hsfraglen, ssl->in_hsfraglen + msg_hslen,
+                               ssl->in_hsfraglen,
+                               ssl->in_hsfraglen +
+                               (hs_remain <= ssl->in_msglen ? hs_remain : ssl->in_msglen),
                                ssl->in_hslen, ssl->in_msglen));
-        (void) msg_hslen;
         if (ssl->in_msglen < hs_remain) {
             ssl->in_hsfraglen += ssl->in_msglen;
             ssl->in_hdr = ssl->in_msg + ssl->in_msglen;
@@ -5424,7 +5423,7 @@ void mbedtls_ssl_reset_in_pointers(mbedtls_ssl_context *ssl)
     if (ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM) {
         ssl->in_hdr = ssl->in_buf;
     } else
-#endif
+#endif  /* MBEDTLS_SSL_PROTO_DTLS */
     {
         ssl->in_hdr = ssl->in_buf + MBEDTLS_SSL_SEQUENCE_NUMBER_LEN;
     }

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -3297,6 +3297,9 @@ int mbedtls_ssl_prepare_handshake_record(mbedtls_ssl_context *ssl)
     } else
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
     {
+        if (ssl->in_hsfraglen > ssl->in_hslen) {
+            return MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
+        }
         int ret;
         const size_t hs_remain = ssl->in_hslen - ssl->in_hsfraglen;
         MBEDTLS_SSL_DEBUG_MSG(3,

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -3229,7 +3229,6 @@ int mbedtls_ssl_prepare_handshake_record(mbedtls_ssl_context *ssl)
     if (ssl->in_hslen == 0) {
         ssl->in_hslen = mbedtls_ssl_hs_hdr_len(ssl) + ssl_get_hs_total_len(ssl);
         ssl->in_hsfraglen = 0;
-        ssl->in_hshdr = ssl->in_hdr;
     }
 
     MBEDTLS_SSL_DEBUG_MSG(3, ("handshake message: msglen ="
@@ -3296,10 +3295,7 @@ int mbedtls_ssl_prepare_handshake_record(mbedtls_ssl_context *ssl)
         }
     } else
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
-    {
-        if (ssl->in_hsfraglen > ssl->in_hslen) {
-            return MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
-        }
+    if (ssl->in_hsfraglen <= ssl->in_hslen) {
         int ret;
         const size_t hs_remain = ssl->in_hslen - ssl->in_hsfraglen;
         MBEDTLS_SSL_DEBUG_MSG(3,
@@ -3317,15 +3313,16 @@ int mbedtls_ssl_prepare_handshake_record(mbedtls_ssl_context *ssl)
             mbedtls_ssl_update_in_pointers(ssl);
             return MBEDTLS_ERR_SSL_CONTINUE_PROCESSING;
         }
-        if (ssl->in_hshdr != ssl->in_hdr) {
+        if (ssl->in_hsfraglen > 0) {
             /*
-             * At ssl->in_hshdr we have a sequence of records that cover the next handshake
+             * At in_first_hdr we have a sequence of records that cover the next handshake
              * record, each with its own record header that we need to remove.
              * Note that the reassembled record size may not equal the size of the message,
-             * there maybe bytes from the next message following it.
+             * there may be more messages after it, complete or partial.
              */
+            unsigned char *in_first_hdr = ssl->in_buf + MBEDTLS_SSL_SEQUENCE_NUMBER_LEN;
+            unsigned char *p = in_first_hdr, *q = NULL;
             size_t merged_rec_len = 0;
-            unsigned char *p = ssl->in_hshdr, *q = NULL;
             do {
                 mbedtls_record rec;
                 ret = ssl_parse_record_header(ssl, p, mbedtls_ssl_in_hdr_len(ssl), &rec);
@@ -3341,16 +3338,17 @@ int mbedtls_ssl_prepare_handshake_record(mbedtls_ssl_context *ssl)
                     q = p;
                 }
             } while (merged_rec_len < ssl->in_hslen);
-            ssl->in_hdr = ssl->in_hshdr;
+            ssl->in_hdr = in_first_hdr;
             mbedtls_ssl_update_in_pointers(ssl);
             ssl->in_msglen = merged_rec_len;
             /* Adjust message length. */
             MBEDTLS_PUT_UINT16_BE(merged_rec_len, ssl->in_len, 0);
             ssl->in_hsfraglen = 0;
-            ssl->in_hshdr = NULL;
             MBEDTLS_SSL_DEBUG_BUF(4, "reassembled record",
                                   ssl->in_hdr, mbedtls_ssl_in_hdr_len(ssl) + merged_rec_len);
         }
+    } else {
+        return MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     }
 
     return 0;

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -343,12 +343,17 @@ static void handle_buffer_resizing(mbedtls_ssl_context *ssl, int downsizing,
                                    size_t out_buf_new_len)
 {
     int modified = 0;
-    size_t written_in = 0, iv_offset_in = 0, len_offset_in = 0;
+    size_t written_in = 0, iv_offset_in = 0, len_offset_in = 0, hdr_in = 0;
     size_t written_out = 0, iv_offset_out = 0, len_offset_out = 0;
+    size_t hshdr_in = 0;
     if (ssl->in_buf != NULL) {
         written_in = ssl->in_msg - ssl->in_buf;
         iv_offset_in = ssl->in_iv - ssl->in_buf;
         len_offset_in = ssl->in_len - ssl->in_buf;
+        hdr_in = ssl->in_hdr - ssl->in_buf;
+        if (ssl->in_hshdr != NULL) {
+            hshdr_in = ssl->in_hshdr - ssl->in_buf;
+        }
         if (downsizing ?
             ssl->in_buf_len > in_buf_new_len && ssl->in_left < in_buf_new_len :
             ssl->in_buf_len < in_buf_new_len) {
@@ -380,7 +385,10 @@ static void handle_buffer_resizing(mbedtls_ssl_context *ssl, int downsizing,
     }
     if (modified) {
         /* Update pointers here to avoid doing it twice. */
-        mbedtls_ssl_reset_in_out_pointers(ssl);
+        ssl->in_hdr = ssl->in_buf + hdr_in;
+        mbedtls_ssl_update_in_pointers(ssl);
+        mbedtls_ssl_reset_out_pointers(ssl);
+
         /* Fields below might not be properly updated with record
          * splitting or with CID, so they are manually updated here. */
         ssl->out_msg = ssl->out_buf + written_out;
@@ -390,6 +398,9 @@ static void handle_buffer_resizing(mbedtls_ssl_context *ssl, int downsizing,
         ssl->in_msg = ssl->in_buf + written_in;
         ssl->in_len = ssl->in_buf + len_offset_in;
         ssl->in_iv = ssl->in_buf + iv_offset_in;
+        if (ssl->in_hshdr != NULL) {
+            ssl->in_hshdr = ssl->in_buf + hshdr_in;
+        }
     }
 }
 #endif /* MBEDTLS_SSL_VARIABLE_BUFFER_LENGTH */
@@ -1483,6 +1494,8 @@ void mbedtls_ssl_session_reset_msg_layer(mbedtls_ssl_context *ssl,
     ssl->in_hslen   = 0;
     ssl->keep_current_message = 0;
     ssl->transform_in  = NULL;
+    ssl->in_hshdr = NULL;
+    ssl->in_hsfraglen = 0;
 
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
     ssl->next_record_offset = 0;

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1419,7 +1419,8 @@ int mbedtls_ssl_setup(mbedtls_ssl_context *ssl,
         goto error;
     }
 
-    mbedtls_ssl_reset_in_out_pointers(ssl);
+    mbedtls_ssl_reset_in_pointers(ssl);
+    mbedtls_ssl_reset_out_pointers(ssl);
 
 #if defined(MBEDTLS_SSL_DTLS_SRTP)
     memset(&ssl->dtls_srtp_info, 0, sizeof(ssl->dtls_srtp_info));
@@ -1484,7 +1485,8 @@ void mbedtls_ssl_session_reset_msg_layer(mbedtls_ssl_context *ssl,
     /* Cancel any possibly running timer */
     mbedtls_ssl_set_timer(ssl, 0);
 
-    mbedtls_ssl_reset_in_out_pointers(ssl);
+    mbedtls_ssl_reset_in_pointers(ssl);
+    mbedtls_ssl_reset_out_pointers(ssl);
 
     /* Reset incoming message parsing */
     ssl->in_offt    = NULL;

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -345,15 +345,11 @@ static void handle_buffer_resizing(mbedtls_ssl_context *ssl, int downsizing,
     int modified = 0;
     size_t written_in = 0, iv_offset_in = 0, len_offset_in = 0, hdr_in = 0;
     size_t written_out = 0, iv_offset_out = 0, len_offset_out = 0;
-    size_t hshdr_in = 0;
     if (ssl->in_buf != NULL) {
         written_in = ssl->in_msg - ssl->in_buf;
         iv_offset_in = ssl->in_iv - ssl->in_buf;
         len_offset_in = ssl->in_len - ssl->in_buf;
         hdr_in = ssl->in_hdr - ssl->in_buf;
-        if (ssl->in_hshdr != NULL) {
-            hshdr_in = ssl->in_hshdr - ssl->in_buf;
-        }
         if (downsizing ?
             ssl->in_buf_len > in_buf_new_len && ssl->in_left < in_buf_new_len :
             ssl->in_buf_len < in_buf_new_len) {
@@ -398,9 +394,6 @@ static void handle_buffer_resizing(mbedtls_ssl_context *ssl, int downsizing,
         ssl->in_msg = ssl->in_buf + written_in;
         ssl->in_len = ssl->in_buf + len_offset_in;
         ssl->in_iv = ssl->in_buf + iv_offset_in;
-        if (ssl->in_hshdr != NULL) {
-            ssl->in_hshdr = ssl->in_buf + hshdr_in;
-        }
     }
 }
 #endif /* MBEDTLS_SSL_VARIABLE_BUFFER_LENGTH */
@@ -1494,10 +1487,9 @@ void mbedtls_ssl_session_reset_msg_layer(mbedtls_ssl_context *ssl,
     ssl->in_msgtype = 0;
     ssl->in_msglen  = 0;
     ssl->in_hslen   = 0;
+    ssl->in_hsfraglen = 0;
     ssl->keep_current_message = 0;
     ssl->transform_in  = NULL;
-    ssl->in_hshdr = NULL;
-    ssl->in_hsfraglen = 0;
 
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
     ssl->next_record_offset = 0;

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -1060,23 +1060,6 @@ read_record_header:
         size_t handshake_len = MBEDTLS_GET_UINT24_BE(buf, 1);
         MBEDTLS_SSL_DEBUG_MSG(3, ("client hello v3, handshake len.: %u",
                                   (unsigned) handshake_len));
-
-        /* The record layer has a record size limit of 2^14 - 1 and
-         * fragmentation is not supported, so buf[1] should be zero. */
-        if (buf[1] != 0) {
-            MBEDTLS_SSL_DEBUG_MSG(1, ("bad client hello message: %u != 0",
-                                      (unsigned) buf[1]));
-            return MBEDTLS_ERR_SSL_DECODE_ERROR;
-        }
-
-        /* We don't support fragmentation of ClientHello (yet?) */
-        if (msg_len != mbedtls_ssl_hs_hdr_len(ssl) + handshake_len) {
-            MBEDTLS_SSL_DEBUG_MSG(1, ("bad client hello message: %u != %u + %u",
-                                      (unsigned) msg_len,
-                                      (unsigned) mbedtls_ssl_hs_hdr_len(ssl),
-                                      (unsigned) handshake_len));
-            return MBEDTLS_ERR_SSL_DECODE_ERROR;
-        }
     }
 
 #if defined(MBEDTLS_SSL_PROTO_DTLS)

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -1056,11 +1056,6 @@ read_record_header:
         MBEDTLS_SSL_DEBUG_MSG(1, ("bad client hello message"));
         return MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE;
     }
-    {
-        size_t handshake_len = MBEDTLS_GET_UINT24_BE(buf, 1);
-        MBEDTLS_SSL_DEBUG_MSG(3, ("client hello v3, handshake len.: %u",
-                                  (unsigned) handshake_len));
-    }
 
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
     if (ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM) {

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14165,8 +14165,8 @@ run_test    "Client Handshake defragmentation (512)" \
             "$O_NEXT_SRV -max_send_frag 512 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "<= handshake" \
-            -c "handshake fragment: "
+            -c "reassembled record" \
+            -c "waiting for more fragments (512 [0-9]\\+, [0-9]\\+ left)"
 
 requires_openssl_tls1_3
 requires_certificate_authentication
@@ -14174,8 +14174,8 @@ run_test    "Client Handshake defragmentation (513)" \
             "$O_NEXT_SRV -max_send_frag 513 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "<= handshake" \
-            -c "handshake fragment: "
+            -c "reassembled record" \
+            -c "waiting for more fragments (513 [0-9]\\+, [0-9]\\+ left)"
 
 # OpenSSL does not allow max_send_frag to be less than 512
 # so we use split_send_frag instead for tests lower than 512 below.
@@ -14190,8 +14190,8 @@ run_test    "Client Handshake defragmentation (256)" \
             "$O_NEXT_SRV -split_send_frag 256 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "<= handshake" \
-            -c "handshake fragment: "
+            -c "reassembled record" \
+            -c "waiting for more fragments (256 of [0-9]\\+, [0-9]\\+ left)"
 
 requires_openssl_tls1_3
 requires_certificate_authentication
@@ -14200,8 +14200,8 @@ run_test    "Client Handshake defragmentation (128)" \
             "$O_NEXT_SRV -split_send_frag 128 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "<= handshake" \
-            -c "handshake fragment: "
+            -c "reassembled record" \
+            -c "waiting for more fragments (128 [0-9]\\+, [0-9]\\+ left)"
 
 requires_openssl_tls1_3
 requires_certificate_authentication
@@ -14210,8 +14210,8 @@ run_test    "Client Handshake defragmentation (64)" \
             "$O_NEXT_SRV -split_send_frag 64 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "<= handshake" \
-            -c "handshake fragment: "
+            -c "reassembled record" \
+            -c "waiting for more fragments (64 [0-9]\\+, [0-9]\\+ left)"
 
 requires_openssl_tls1_3
 requires_certificate_authentication
@@ -14220,8 +14220,8 @@ run_test    "Client Handshake defragmentation (36)" \
             "$O_NEXT_SRV -split_send_frag 36 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "<= handshake" \
-            -c "handshake fragment: "
+            -c "reassembled record" \
+            -c "waiting for more fragments (36 [0-9]\\+, [0-9]\\+ left)"
 
 requires_openssl_tls1_3
 requires_certificate_authentication
@@ -14230,8 +14230,8 @@ run_test    "Client Handshake defragmentation (32)" \
             "$O_NEXT_SRV -split_send_frag 32 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "<= handshake" \
-            -c "handshake fragment: "
+            -c "reassembled record" \
+            -c "waiting for more fragments (32 [0-9]\\+, [0-9]\\+ left)"
 
 requires_openssl_tls1_3
 requires_certificate_authentication
@@ -14240,8 +14240,8 @@ run_test    "Client Handshake defragmentation (16)" \
             "$O_NEXT_SRV -split_send_frag 16 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "<= handshake" \
-            -c "handshake fragment: "
+            -c "reassembled record" \
+            -c "waiting for more fragments (16 [0-9]\\+, [0-9]\\+ left)"
 
 requires_openssl_tls1_3
 requires_certificate_authentication
@@ -14250,8 +14250,8 @@ run_test    "Client Handshake defragmentation (13)" \
             "$O_NEXT_SRV -split_send_frag 13 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "<= handshake" \
-            -c "handshake fragment: "
+            -c "reassembled record" \
+            -c "waiting for more fragments (13 [0-9]\\+, [0-9]\\+ left)"
 
 requires_openssl_tls1_3
 requires_certificate_authentication
@@ -14260,8 +14260,8 @@ run_test    "Client Handshake defragmentation (5)" \
             "$O_NEXT_SRV -split_send_frag 5 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "<= handshake" \
-            -c "handshake fragment: "
+            -c "reassembled record" \
+            -c "waiting for more fragments (5 [0-9]\\+, [0-9]\\+ left)"
 
 requires_openssl_tls1_3
 requires_certificate_authentication
@@ -14269,8 +14269,8 @@ run_test    "Server Handshake defragmentation (512)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -max_send_frag 512 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
-            -s "<= handshake" \
-            -s "handshake fragment: "
+            -s "reassembled record" \
+            -s "waiting for more fragments (512 [0-9]\\+, [0-9]\\+ left)"
 
 requires_openssl_tls1_3
 requires_certificate_authentication
@@ -14278,8 +14278,8 @@ run_test    "Server Handshake defragmentation (513)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -max_send_frag 513 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
-            -s "<= handshake" \
-            -s "handshake fragment: "
+            -s "reassembled record" \
+            -s "waiting for more fragments (513 [0-9]\\+, [0-9]\\+ left)"
 
 requires_openssl_tls1_3
 requires_certificate_authentication
@@ -14288,8 +14288,8 @@ run_test    "Server Handshake defragmentation (256)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 256 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
-            -s "<= handshake" \
-            -s "handshake fragment: "
+            -s "reassembled record" \
+            -s "waiting for more fragments (256 [0-9]\\+, [0-9]\\+ left)"
 
 requires_openssl_tls1_3
 requires_certificate_authentication
@@ -14298,8 +14298,8 @@ run_test    "Server Handshake defragmentation (128)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 128 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
-            -s "<= handshake" \
-            -s "handshake fragment: "
+            -s "reassembled record" \
+            -s "waiting for more fragments (128 [0-9]\\+, [0-9]\\+ left)"
 
 requires_openssl_tls1_3
 requires_certificate_authentication
@@ -14308,8 +14308,8 @@ run_test    "Server Handshake defragmentation (64)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 64 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
-            -s "<= handshake" \
-            -s "handshake fragment: "
+            -s "reassembled record" \
+            -s "waiting for more fragments (64 [0-9]\\+, [0-9]\\+ left)"
 
 requires_openssl_tls1_3
 requires_certificate_authentication
@@ -14318,8 +14318,8 @@ run_test    "Server Handshake defragmentation (36)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 36 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
-            -s "<= handshake" \
-            -s "handshake fragment: "
+            -s "reassembled record" \
+            -s "waiting for more fragments (36 [0-9]\\+, [0-9]\\+ left)"
 
 requires_openssl_tls1_3
 requires_certificate_authentication
@@ -14328,8 +14328,8 @@ run_test    "Server Handshake defragmentation (32)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 32 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
-            -s "<= handshake" \
-            -s "handshake fragment: "
+            -s "reassembled record" \
+            -s "waiting for more fragments (32 [0-9]\\+, [0-9]\\+ left)"
 
 requires_openssl_tls1_3
 requires_certificate_authentication
@@ -14338,8 +14338,8 @@ run_test    "Server Handshake defragmentation (16)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 16 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
-            -s "<= handshake" \
-            -s "handshake fragment: "
+            -s "reassembled record" \
+            -s "waiting for more fragments (16 [0-9]\\+, [0-9]\\+ left)"
 
 requires_openssl_tls1_3
 requires_certificate_authentication
@@ -14348,8 +14348,8 @@ run_test    "Server Handshake defragmentation (13)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 13 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
-            -s "<= handshake" \
-            -s "handshake fragment: "
+            -s "reassembled record" \
+            -s "waiting for more fragments (12 [0-9]\\+, [0-9]\\+ left)"
 
 requires_openssl_tls1_3
 requires_certificate_authentication
@@ -14358,8 +14358,8 @@ run_test    "Server Handshake defragmentation (5)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 5 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
-            -s "<= handshake" \
-            -s "handshake fragment: "
+            -s "reassembled record" \
+            -s "waiting for more fragments (5 [0-9]\\+, [0-9]\\+ left)"
 
 # Test heap memory usage after handshake
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14175,6 +14175,9 @@ run_test    "Client Handshake defragmentation (513)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
+# OpenSSL does not allow max_send_frag to be less than 512
+# so we use split_send_frag instead for tests lower than 512 below.
+
 requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (256)" \
             "$O_NEXT_SRV -split_send_frag 256 " \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14157,6 +14157,90 @@ run_test    "TLS 1.2 ClientHello indicating support for deflate compression meth
             -c "Handshake was completed" \
             -s "dumping .client hello, compression. (2 bytes)"
 
+# Handshake defragmentation testing
+
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test    "Hanshake defragmentation (512)" \
+            "$O_SRV -max_send_frag 512 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "received ServerHello message" \
+            -c "<= handshake" \
+
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test    "Hanshake defragmentation (513)" \
+            "$O_SRV -max_send_frag 513 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "received ServerHello message" \
+            -c "<= handshake" \
+
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test    "Hanshake defragmentation (256)" \
+            "$O_SRV -mtu 32 -split_send_frag 256 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "received ServerHello message" \
+            -c "<= handshake" \
+
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test    "Hanshake defragmentation (128)" \
+            "$O_SRV -mtu 32 -split_send_frag 128 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "received ServerHello message" \
+            -c "<= handshake" \
+
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test    "Hanshake defragmentation (64)" \
+            "$O_SRV -mtu 32 -split_send_frag 64 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "received ServerHello message" \
+            -c "<= handshake" \
+
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test    "Hanshake defragmentation (36)" \
+            "$O_SRV -mtu 32 -split_send_frag 36 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "received ServerHello message" \
+            -c "<= handshake" \
+
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test    "Hanshake defragmentation (32)" \
+            "$O_SRV -mtu 32 -split_send_frag 32 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "received ServerHello message" \
+            -c "<= handshake" \
+
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test    "Hanshake defragmentation (16)" \
+            "$O_SRV -mtu 32 -split_send_frag 16 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "received ServerHello message" \
+            -c "<= handshake" \
+
+
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test    "Hanshake defragmentation (13)" \
+            "$O_SRV -mtu 32 -split_send_frag 13 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "received ServerHello message" \
+            -c "<= handshake" \
+
+
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test    "Hanshake defragmentation (5)" \
+            "$O_SRV -mtu 32 -split_send_frag 5 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "received ServerHello message" \
+            -c "<= handshake" \
+
 # Test heap memory usage after handshake
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_MEMORY_DEBUG

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14495,6 +14495,24 @@ run_test    "Handshake defragmentation on server: len=5, TLS 1.3" \
             -s "handshake fragment: 0 \\.\\. 5 of [0-9]\\+ msglen 5" \
             -s "waiting for more fragments (5"
 
+# Test Server Buffer resizing with fragmented handshake on TLS1.2
+# TODO investigate a a GNUTLS version for  -maxfraglen 512
+requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_MAX_FRAGMENT_LENGTH
+requires_config_enabled MBEDTLS_SSL_VARIABLE_BUFFER_LENGTH
+requires_max_content_len 1025
+run_test    "Handshake defragmentation on Server with buffer resizing: len=256, MFL=1024" \
+            "$P_SRV debug_level=4 auth_mode=required" \
+            "$O_NEXT_CLI -tls1_2 -split_send_frag 256 -split_send_frag 256 -maxfraglen 1024 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            0 \
+            -s "Reallocating in_buf" \
+            -s "Reallocating out_buf" \
+            -s "reassembled record" \
+            -s "handshake fragment: 0 \\.\\. 256 of [0-9]\\+ msglen 256" \
+            -s "waiting for more fragments (256"
+
 # Test heap memory usage after handshake
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_MEMORY_DEBUG

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14353,32 +14353,10 @@ run_test    "Handshake defragmentation on client: len=13, TLS 1.3" \
             -c "waiting for more fragments (13"
 
 requires_openssl_3_x
-requires_protocol_version tls12
-requires_certificate_authentication
-run_test    "Handshake defragmentation on client: len=13, TLS 1.2" \
-            "$O_NEXT_SRV -tls1_2 -split_send_frag 13 " \
-            "$P_CLI debug_level=4 " \
-            0 \
-            -c "reassembled record" \
-            -c "handshake fragment: 0 \\.\\. 13 of [0-9]\\+ msglen 13" \
-            -c "waiting for more fragments (13"
-
-requires_openssl_3_x
 requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=5, TLS 1.3" \
             "$O_NEXT_SRV -tls1_3 -split_send_frag 5 " \
-            "$P_CLI debug_level=4 " \
-            0 \
-            -c "reassembled record" \
-            -c "handshake fragment: 0 \\.\\. 5 of [0-9]\\+ msglen 5" \
-            -c "waiting for more fragments (5"
-
-requires_openssl_3_x
-requires_protocol_version tls12
-requires_certificate_authentication
-run_test    "Handshake defragmentation on client: len=5, TLS 1.2" \
-            "$O_NEXT_SRV -tls1_2 -split_send_frag 5 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
@@ -14441,34 +14419,11 @@ run_test    "Handshake defragmentation on server: len=256, TLS 1.3" \
             -s "waiting for more fragments (256"
 
 requires_openssl_3_x
-requires_protocol_version tls12
-requires_certificate_authentication
-run_test    "Handshake defragmentation on server: len=256, TLS 1.2" \
-            "$P_SRV debug_level=4 auth_mode=required" \
-            "$O_NEXT_CLI -tls1_3 -split_send_frag 256 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
-            0 \
-            -s "reassembled record" \
-            -s "handshake fragment: 0 \\.\\. 256 of [0-9]\\+ msglen 256" \
-            -s "waiting for more fragments (256"
-
-
-requires_openssl_3_x
 requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=128, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_3 -split_send_frag 128 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
-            0 \
-            -s "reassembled record" \
-            -s "handshake fragment: 0 \\.\\. 128 of [0-9]\\+ msglen 128" \
-            -s "waiting for more fragments (128"
-
-requires_openssl_3_x
-requires_protocol_version tls12
-requires_certificate_authentication
-run_test    "Handshake defragmentation on server: len=128, TLS 1.2" \
-            "$P_SRV debug_level=4 auth_mode=required" \
-            "$O_NEXT_CLI -tls1_2 -split_send_frag 128 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 128 of [0-9]\\+ msglen 128" \
@@ -14486,33 +14441,11 @@ run_test    "Handshake defragmentation on server: len=64, TLS 1.3" \
             -s "waiting for more fragments (64"
 
 requires_openssl_3_x
-requires_protocol_version tls12
-requires_certificate_authentication
-run_test    "Handshake defragmentation on server: len=64, TLS 1.2" \
-            "$P_SRV debug_level=4 auth_mode=required" \
-            "$O_NEXT_CLI -tls1_2 -split_send_frag 64 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
-            0 \
-            -s "reassembled record" \
-            -s "handshake fragment: 0 \\.\\. 64 of [0-9]\\+ msglen 64" \
-            -s "waiting for more fragments (64"
-
-requires_openssl_3_x
 requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=36, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_3 -split_send_frag 36 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
-            0 \
-            -s "reassembled record" \
-            -s "handshake fragment: 0 \\.\\. 36 of [0-9]\\+ msglen 36" \
-            -s "waiting for more fragments (36"
-
-requires_openssl_3_x
-requires_protocol_version tls12
-requires_certificate_authentication
-run_test    "Handshake defragmentation on server: len=36, TLS 1.2" \
-            "$P_SRV debug_level=4 auth_mode=required" \
-            "$O_NEXT_CLI -tls1_2 -split_send_frag 36 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 36 of [0-9]\\+ msglen 36" \
@@ -14530,33 +14463,11 @@ run_test    "Handshake defragmentation on server: len=32, TLS 1.3" \
             -s "waiting for more fragments (32"
 
 requires_openssl_3_x
-requires_protocol_version tls12
-requires_certificate_authentication
-run_test    "Handshake defragmentation on server: len=32, TLS 1.2" \
-            "$P_SRV debug_level=4 auth_mode=required" \
-            "$O_NEXT_CLI -tls1_2 -split_send_frag 32 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
-            0 \
-            -s "reassembled record" \
-            -s "handshake fragment: 0 \\.\\. 32 of [0-9]\\+ msglen 32" \
-            -s "waiting for more fragments (32"
-
-requires_openssl_3_x
 requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=16, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_3 -split_send_frag 16 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
-            0 \
-            -s "reassembled record" \
-            -s "handshake fragment: 0 \\.\\. 16 of [0-9]\\+ msglen 16" \
-            -s "waiting for more fragments (16"
-
-requires_openssl_3_x
-requires_protocol_version tls12
-requires_certificate_authentication
-run_test    "Handshake defragmentation on server: len=16, TLS 1.2" \
-            "$P_SRV debug_level=4 auth_mode=required" \
-            "$O_NEXT_CLI -tls1_2 -split_send_frag 16 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 16 of [0-9]\\+ msglen 16" \
@@ -14574,33 +14485,11 @@ run_test    "Handshake defragmentation on server: len=13, TLS 1.3" \
             -s "waiting for more fragments (13"
 
 requires_openssl_3_x
-requires_protocol_version tls12
-requires_certificate_authentication
-run_test    "Handshake defragmentation on server: len=13, TLS 1.2" \
-            "$P_SRV debug_level=4 auth_mode=required" \
-            "$O_NEXT_CLI -tls1_2 -split_send_frag 13 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
-            0 \
-            -s "reassembled record" \
-            -s "handshake fragment: 0 \\.\\. 13 of [0-9]\\+ msglen 13" \
-            -s "waiting for more fragments (13"
-
-requires_openssl_3_x
 requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=5, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_3 -split_send_frag 5 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
-            0 \
-            -s "reassembled record" \
-            -s "handshake fragment: 0 \\.\\. 5 of [0-9]\\+ msglen 5" \
-            -s "waiting for more fragments (5"
-
-requires_openssl_3_x
-requires_protocol_version tls12
-requires_certificate_authentication
-run_test    "Handshake defragmentation on server: len=5, TLS 1.2" \
-            "$P_SRV debug_level=4 auth_mode=required" \
-            "$O_NEXT_CLI -tls1_2 -split_send_frag 5 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 5 of [0-9]\\+ msglen 5" \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14159,6 +14159,7 @@ run_test    "TLS 1.2 ClientHello indicating support for deflate compression meth
 
 # Handshake defragmentation testing
 
+requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (512)" \
             "$O_NEXT_SRV -max_send_frag 512 " \
             "$P_CLI debug_level=4 " \
@@ -14166,6 +14167,7 @@ run_test    "Client Handshake defragmentation (512)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (513)" \
             "$O_NEXT_SRV -max_send_frag 513 " \
             "$P_CLI debug_level=4 " \
@@ -14173,6 +14175,7 @@ run_test    "Client Handshake defragmentation (513)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (256)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 256 " \
             "$P_CLI debug_level=4 " \
@@ -14180,6 +14183,7 @@ run_test    "Client Handshake defragmentation (256)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (128)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 128 " \
             "$P_CLI debug_level=4 " \
@@ -14187,6 +14191,7 @@ run_test    "Client Handshake defragmentation (128)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (64)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 64 " \
             "$P_CLI debug_level=4 " \
@@ -14194,6 +14199,7 @@ run_test    "Client Handshake defragmentation (64)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (36)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 36 " \
             "$P_CLI debug_level=4 " \
@@ -14201,6 +14207,7 @@ run_test    "Client Handshake defragmentation (36)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (32)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 32 " \
             "$P_CLI debug_level=4 " \
@@ -14208,6 +14215,7 @@ run_test    "Client Handshake defragmentation (32)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (16)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 16 " \
             "$P_CLI debug_level=4 " \
@@ -14215,7 +14223,7 @@ run_test    "Client Handshake defragmentation (16)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
-
+requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (13)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 13 " \
             "$P_CLI debug_level=4 " \
@@ -14223,6 +14231,7 @@ run_test    "Client Handshake defragmentation (13)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (5)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 5 " \
             "$P_CLI debug_level=4 " \
@@ -14230,6 +14239,7 @@ run_test    "Client Handshake defragmentation (5)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (512)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -max_send_frag 512 " \
@@ -14237,6 +14247,7 @@ run_test    "Server Handshake defragmentation (512)" \
             -s "<= handshake" \
             -s "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (513)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -max_send_frag 513 " \
@@ -14244,6 +14255,7 @@ run_test    "Server Handshake defragmentation (513)" \
             -s "<= handshake" \
             -s "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (256)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 256 " \
@@ -14251,6 +14263,7 @@ run_test    "Server Handshake defragmentation (256)" \
             -s "<= handshake" \
             -s "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (128)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 128 " \
@@ -14258,6 +14271,7 @@ run_test    "Server Handshake defragmentation (128)" \
             -s "<= handshake" \
             -s "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (64)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 64 " \
@@ -14265,6 +14279,7 @@ run_test    "Server Handshake defragmentation (64)" \
             -s "<= handshake" \
             -s "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (36)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 36 " \
@@ -14272,6 +14287,7 @@ run_test    "Server Handshake defragmentation (36)" \
             -s "<= handshake" \
             -s "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (32)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 32 " \
@@ -14279,6 +14295,7 @@ run_test    "Server Handshake defragmentation (32)" \
             -s "<= handshake" \
             -s "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (16)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 16 " \
@@ -14286,6 +14303,7 @@ run_test    "Server Handshake defragmentation (16)" \
             -s "<= handshake" \
             -s "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (13)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 13 " \
@@ -14293,6 +14311,7 @@ run_test    "Server Handshake defragmentation (13)" \
             -s "<= handshake" \
             -s "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (5)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 5 " \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14160,10 +14160,10 @@ run_test    "TLS 1.2 ClientHello indicating support for deflate compression meth
 # Handshake defragmentation testing
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=512, TLS 1.3" \
-            "$O_NEXT_SRV -max_send_frag 512 " \
+            "$O_NEXT_SRV -tls1_3 -max_send_frag 512 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
@@ -14171,10 +14171,10 @@ run_test    "Handshake defragmentation on client: len=512, TLS 1.3" \
             -c "waiting for more fragments (512 of [0-9]\\+"
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=513, TLS 1.3" \
-            "$O_NEXT_SRV -max_send_frag 513 " \
+            "$O_NEXT_SRV -tls1_3 -max_send_frag 513 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
@@ -14188,11 +14188,10 @@ run_test    "Handshake defragmentation on client: len=513, TLS 1.3" \
 # than 512 bytes in TLS 1.2 so we require TLS 1.3 with these values.
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Handshake defragmentation on client: len=256, TLS 1.3" \
-            "$O_NEXT_SRV -split_send_frag 256 " \
+            "$O_NEXT_SRV -tls1_3 -split_send_frag 256 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
@@ -14200,11 +14199,10 @@ run_test    "Handshake defragmentation on client: len=256, TLS 1.3" \
             -c "waiting for more fragments (256 of [0-9]\\+"
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Handshake defragmentation on client: len=128, TLS 1.3" \
-            "$O_NEXT_SRV -split_send_frag 128 " \
+            "$O_NEXT_SRV -tls1_3 -split_send_frag 128 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
@@ -14212,11 +14210,10 @@ run_test    "Handshake defragmentation on client: len=128, TLS 1.3" \
             -c "waiting for more fragments (128"
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Handshake defragmentation on client: len=64, TLS 1.3" \
-            "$O_NEXT_SRV -split_send_frag 64 " \
+            "$O_NEXT_SRV -tls1_3 -split_send_frag 64 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
@@ -14224,11 +14221,10 @@ run_test    "Handshake defragmentation on client: len=64, TLS 1.3" \
             -c "waiting for more fragments (64"
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Handshake defragmentation on client: len=36, TLS 1.3" \
-            "$O_NEXT_SRV -split_send_frag 36 " \
+            "$O_NEXT_SRV -tls1_3 -split_send_frag 36 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
@@ -14236,11 +14232,10 @@ run_test    "Handshake defragmentation on client: len=36, TLS 1.3" \
             -c "waiting for more fragments (36"
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Handshake defragmentation on client: len=32, TLS 1.3" \
-            "$O_NEXT_SRV -split_send_frag 32 " \
+            "$O_NEXT_SRV -tls1_3 -split_send_frag 32 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
@@ -14248,11 +14243,10 @@ run_test    "Handshake defragmentation on client: len=32, TLS 1.3" \
             -c "waiting for more fragments (32"
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Handshake defragmentation on client: len=14, TLS 1.3" \
-            "$O_NEXT_SRV -split_send_frag 16 " \
+            "$O_NEXT_SRV -tls1_3 -split_send_frag 16 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
@@ -14260,11 +14254,10 @@ run_test    "Handshake defragmentation on client: len=14, TLS 1.3" \
             -c "waiting for more fragments (16"
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Handshake defragmentation on client: len=13, TLS 1.3" \
-            "$O_NEXT_SRV -split_send_frag 13 " \
+            "$O_NEXT_SRV -tls1_3 -split_send_frag 13 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
@@ -14272,11 +14265,10 @@ run_test    "Handshake defragmentation on client: len=13, TLS 1.3" \
             -c "waiting for more fragments (13"
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Handshake defragmentation on client: len=5, TLS 1.3" \
-            "$O_NEXT_SRV -split_send_frag 5 " \
+            "$O_NEXT_SRV -tls1_3 -split_send_frag 5 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
@@ -14284,118 +14276,110 @@ run_test    "Handshake defragmentation on client: len=5, TLS 1.3" \
             -c "waiting for more fragments (5"
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=512, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
-            "$O_NEXT_CLI -max_send_frag 512 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -tls1_3 -max_send_frag 512 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 512 of [0-9]\\+ msglen 512" \
             -s "waiting for more fragments (512"
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=513, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
-            "$O_NEXT_CLI -max_send_frag 513 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -tls1_3 -max_send_frag 513 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 513 of [0-9]\\+ msglen 513" \
             -s "waiting for more fragments (513"
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Handshake defragmentation on server: len=256, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
-            "$O_NEXT_CLI -split_send_frag 256 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -tls1_3 -split_send_frag 256 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 256 of [0-9]\\+ msglen 256" \
             -s "waiting for more fragments (256"
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Handshake defragmentation on server: len=128, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
-            "$O_NEXT_CLI -split_send_frag 128 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -tls1_3 -split_send_frag 128 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 128 of [0-9]\\+ msglen 128" \
             -s "waiting for more fragments (128"
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Handshake defragmentation on server: len=64, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
-            "$O_NEXT_CLI -split_send_frag 64 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -tls1_3 -split_send_frag 64 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 64 of [0-9]\\+ msglen 64" \
             -s "waiting for more fragments (64"
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Handshake defragmentation on server: len=36, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
-            "$O_NEXT_CLI -split_send_frag 36 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -tls1_3 -split_send_frag 36 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 36 of [0-9]\\+ msglen 36" \
             -s "waiting for more fragments (36"
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Handshake defragmentation on server: len=32, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
-            "$O_NEXT_CLI -split_send_frag 32 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -tls1_3 -split_send_frag 32 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 32 of [0-9]\\+ msglen 32" \
             -s "waiting for more fragments (32"
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Handshake defragmentation on server: len=16, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
-            "$O_NEXT_CLI -split_send_frag 16 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -tls1_3 -split_send_frag 16 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 16 of [0-9]\\+ msglen 16" \
             -s "waiting for more fragments (16"
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Handshake defragmentation on server: len=13, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
-            "$O_NEXT_CLI -split_send_frag 13 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -tls1_3 -split_send_frag 13 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 13 of [0-9]\\+ msglen 13" \
             -s "waiting for more fragments (13"
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Handshake defragmentation on server: len=5, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
-            "$O_NEXT_CLI -split_send_frag 5 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -tls1_3 -split_send_frag 5 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 5 of [0-9]\\+ msglen 5" \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14177,7 +14177,7 @@ run_test    "Client Handshake defragmentation (513)" \
 
 requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (256)" \
-            "$O_NEXT_SRV -mtu 32 -split_send_frag 256 " \
+            "$O_NEXT_SRV -split_send_frag 256 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "<= handshake" \
@@ -14185,7 +14185,7 @@ run_test    "Client Handshake defragmentation (256)" \
 
 requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (128)" \
-            "$O_NEXT_SRV -mtu 32 -split_send_frag 128 " \
+            "$O_NEXT_SRV -split_send_frag 128 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "<= handshake" \
@@ -14193,7 +14193,7 @@ run_test    "Client Handshake defragmentation (128)" \
 
 requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (64)" \
-            "$O_NEXT_SRV -mtu 32 -split_send_frag 64 " \
+            "$O_NEXT_SRV -split_send_frag 64 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "<= handshake" \
@@ -14201,7 +14201,7 @@ run_test    "Client Handshake defragmentation (64)" \
 
 requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (36)" \
-            "$O_NEXT_SRV -mtu 32 -split_send_frag 36 " \
+            "$O_NEXT_SRV -split_send_frag 36 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "<= handshake" \
@@ -14209,7 +14209,7 @@ run_test    "Client Handshake defragmentation (36)" \
 
 requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (32)" \
-            "$O_NEXT_SRV -mtu 32 -split_send_frag 32 " \
+            "$O_NEXT_SRV -split_send_frag 32 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "<= handshake" \
@@ -14217,7 +14217,7 @@ run_test    "Client Handshake defragmentation (32)" \
 
 requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (16)" \
-            "$O_NEXT_SRV -mtu 32 -split_send_frag 16 " \
+            "$O_NEXT_SRV -split_send_frag 16 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "<= handshake" \
@@ -14225,7 +14225,7 @@ run_test    "Client Handshake defragmentation (16)" \
 
 requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (13)" \
-            "$O_NEXT_SRV -mtu 32 -split_send_frag 13 " \
+            "$O_NEXT_SRV -split_send_frag 13 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "<= handshake" \
@@ -14233,7 +14233,7 @@ run_test    "Client Handshake defragmentation (13)" \
 
 requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (5)" \
-            "$O_NEXT_SRV -mtu 32 -split_send_frag 5 " \
+            "$O_NEXT_SRV -split_send_frag 5 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "<= handshake" \
@@ -14258,7 +14258,7 @@ run_test    "Server Handshake defragmentation (513)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (256)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 256 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -split_send_frag 256 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -14266,7 +14266,7 @@ run_test    "Server Handshake defragmentation (256)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (128)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 128 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -split_send_frag 128 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -14274,7 +14274,7 @@ run_test    "Server Handshake defragmentation (128)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (64)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 64 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -split_send_frag 64 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -14282,7 +14282,7 @@ run_test    "Server Handshake defragmentation (64)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (36)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 36 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -split_send_frag 36 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -14290,7 +14290,7 @@ run_test    "Server Handshake defragmentation (36)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (32)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 32 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -split_send_frag 32 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -14298,7 +14298,7 @@ run_test    "Server Handshake defragmentation (32)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (16)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 16 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -split_send_frag 16 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -14306,7 +14306,7 @@ run_test    "Server Handshake defragmentation (16)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (13)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 13 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -split_send_frag 13 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -14314,7 +14314,7 @@ run_test    "Server Handshake defragmentation (13)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (5)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 5 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -split_send_frag 5 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14178,8 +14178,12 @@ run_test    "Client Handshake defragmentation (513)" \
 # OpenSSL does not allow max_send_frag to be less than 512
 # so we use split_send_frag instead for tests lower than 512 below.
 
+# There is an issue with OpenSSL when fragmenting with values less
+# than 512 bytes in TLS 1.2 so we require TLS 1.3 with these values.
+
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Client Handshake defragmentation (256)" \
             "$O_NEXT_SRV -split_send_frag 256 " \
             "$P_CLI debug_level=4 " \
@@ -14189,6 +14193,7 @@ run_test    "Client Handshake defragmentation (256)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Client Handshake defragmentation (128)" \
             "$O_NEXT_SRV -split_send_frag 128 " \
             "$P_CLI debug_level=4 " \
@@ -14198,6 +14203,7 @@ run_test    "Client Handshake defragmentation (128)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Client Handshake defragmentation (64)" \
             "$O_NEXT_SRV -split_send_frag 64 " \
             "$P_CLI debug_level=4 " \
@@ -14207,6 +14213,7 @@ run_test    "Client Handshake defragmentation (64)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Client Handshake defragmentation (36)" \
             "$O_NEXT_SRV -split_send_frag 36 " \
             "$P_CLI debug_level=4 " \
@@ -14216,6 +14223,7 @@ run_test    "Client Handshake defragmentation (36)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Client Handshake defragmentation (32)" \
             "$O_NEXT_SRV -split_send_frag 32 " \
             "$P_CLI debug_level=4 " \
@@ -14225,6 +14233,7 @@ run_test    "Client Handshake defragmentation (32)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Client Handshake defragmentation (16)" \
             "$O_NEXT_SRV -split_send_frag 16 " \
             "$P_CLI debug_level=4 " \
@@ -14234,6 +14243,7 @@ run_test    "Client Handshake defragmentation (16)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Client Handshake defragmentation (13)" \
             "$O_NEXT_SRV -split_send_frag 13 " \
             "$P_CLI debug_level=4 " \
@@ -14243,6 +14253,7 @@ run_test    "Client Handshake defragmentation (13)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Client Handshake defragmentation (5)" \
             "$O_NEXT_SRV -split_send_frag 5 " \
             "$P_CLI debug_level=4 " \
@@ -14270,6 +14281,7 @@ run_test    "Server Handshake defragmentation (513)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Server Handshake defragmentation (256)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 256 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14279,6 +14291,7 @@ run_test    "Server Handshake defragmentation (256)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Server Handshake defragmentation (128)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 128 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14288,6 +14301,7 @@ run_test    "Server Handshake defragmentation (128)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Server Handshake defragmentation (64)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 64 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14297,6 +14311,7 @@ run_test    "Server Handshake defragmentation (64)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Server Handshake defragmentation (36)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 36 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14306,6 +14321,7 @@ run_test    "Server Handshake defragmentation (36)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Server Handshake defragmentation (32)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 32 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14315,6 +14331,7 @@ run_test    "Server Handshake defragmentation (32)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Server Handshake defragmentation (16)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 16 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14324,6 +14341,7 @@ run_test    "Server Handshake defragmentation (16)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Server Handshake defragmentation (13)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 13 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14333,6 +14351,7 @@ run_test    "Server Handshake defragmentation (13)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Server Handshake defragmentation (5)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 5 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14160,6 +14160,7 @@ run_test    "TLS 1.2 ClientHello indicating support for deflate compression meth
 # Handshake defragmentation testing
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Client Handshake defragmentation (512)" \
             "$O_NEXT_SRV -max_send_frag 512 " \
             "$P_CLI debug_level=4 " \
@@ -14168,6 +14169,7 @@ run_test    "Client Handshake defragmentation (512)" \
             -c "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Client Handshake defragmentation (513)" \
             "$O_NEXT_SRV -max_send_frag 513 " \
             "$P_CLI debug_level=4 " \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14179,6 +14179,7 @@ run_test    "Client Handshake defragmentation (513)" \
 # so we use split_send_frag instead for tests lower than 512 below.
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Client Handshake defragmentation (256)" \
             "$O_NEXT_SRV -split_send_frag 256 " \
             "$P_CLI debug_level=4 " \
@@ -14187,6 +14188,7 @@ run_test    "Client Handshake defragmentation (256)" \
             -c "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Client Handshake defragmentation (128)" \
             "$O_NEXT_SRV -split_send_frag 128 " \
             "$P_CLI debug_level=4 " \
@@ -14195,6 +14197,7 @@ run_test    "Client Handshake defragmentation (128)" \
             -c "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Client Handshake defragmentation (64)" \
             "$O_NEXT_SRV -split_send_frag 64 " \
             "$P_CLI debug_level=4 " \
@@ -14203,6 +14206,7 @@ run_test    "Client Handshake defragmentation (64)" \
             -c "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Client Handshake defragmentation (36)" \
             "$O_NEXT_SRV -split_send_frag 36 " \
             "$P_CLI debug_level=4 " \
@@ -14211,6 +14215,7 @@ run_test    "Client Handshake defragmentation (36)" \
             -c "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Client Handshake defragmentation (32)" \
             "$O_NEXT_SRV -split_send_frag 32 " \
             "$P_CLI debug_level=4 " \
@@ -14219,6 +14224,7 @@ run_test    "Client Handshake defragmentation (32)" \
             -c "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Client Handshake defragmentation (16)" \
             "$O_NEXT_SRV -split_send_frag 16 " \
             "$P_CLI debug_level=4 " \
@@ -14227,6 +14233,7 @@ run_test    "Client Handshake defragmentation (16)" \
             -c "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Client Handshake defragmentation (13)" \
             "$O_NEXT_SRV -split_send_frag 13 " \
             "$P_CLI debug_level=4 " \
@@ -14235,6 +14242,7 @@ run_test    "Client Handshake defragmentation (13)" \
             -c "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Client Handshake defragmentation (5)" \
             "$O_NEXT_SRV -split_send_frag 5 " \
             "$P_CLI debug_level=4 " \
@@ -14243,6 +14251,7 @@ run_test    "Client Handshake defragmentation (5)" \
             -c "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Server Handshake defragmentation (512)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -max_send_frag 512 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14251,6 +14260,7 @@ run_test    "Server Handshake defragmentation (512)" \
             -s "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Server Handshake defragmentation (513)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -max_send_frag 513 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14259,6 +14269,7 @@ run_test    "Server Handshake defragmentation (513)" \
             -s "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Server Handshake defragmentation (256)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 256 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14267,6 +14278,7 @@ run_test    "Server Handshake defragmentation (256)" \
             -s "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Server Handshake defragmentation (128)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 128 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14275,6 +14287,7 @@ run_test    "Server Handshake defragmentation (128)" \
             -s "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Server Handshake defragmentation (64)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 64 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14283,6 +14296,7 @@ run_test    "Server Handshake defragmentation (64)" \
             -s "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Server Handshake defragmentation (36)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 36 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14291,6 +14305,7 @@ run_test    "Server Handshake defragmentation (36)" \
             -s "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Server Handshake defragmentation (32)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 32 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14299,6 +14314,7 @@ run_test    "Server Handshake defragmentation (32)" \
             -s "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Server Handshake defragmentation (16)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 16 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14307,6 +14323,7 @@ run_test    "Server Handshake defragmentation (16)" \
             -s "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Server Handshake defragmentation (13)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 13 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14315,6 +14332,7 @@ run_test    "Server Handshake defragmentation (13)" \
             -s "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Server Handshake defragmentation (5)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 5 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14513,6 +14513,24 @@ run_test    "Handshake defragmentation on Server with buffer resizing: len=256, 
             -s "handshake fragment: 0 \\.\\. 256 of [0-9]\\+ msglen 256" \
             -s "waiting for more fragments (256"
 
+# Test Client initialised renegotiation with fragmented handshake on TLS1.2
+requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_RENEGOTIATION
+run_test    "Handshake defragmentation with client-initiated renegotation: len=256" \
+            "$P_SRV debug_level=4 exchanges=2 renegotiation=1 auth_mode=required" \
+            "echo 'R' | $OPENSSL_NEXT s_client -tls1_2 -split_send_frag 256 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key -connect 127.0.0.1:+$SRV_PORT" \
+            0 \
+            -s "received TLS_EMPTY_RENEGOTIATION_INFO" \
+            -s "found renegotiation extension" \
+            -s "server hello, secure renegotiation extension" \
+            -s "=> renegotiate" \
+            -S "write hello request" \
+            -s "reassembled record" \
+            -s "handshake fragment: 0 \\.\\. 256 of [0-9]\\+ msglen 256" \
+            -s "waiting for more fragments (256"
+
 # Test heap memory usage after handshake
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_MEMORY_DEBUG

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14163,7 +14163,6 @@ run_test    "Client Handshake defragmentation (512)" \
             "$O_NEXT_SRV -max_send_frag 512 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "received ServerHello message" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
@@ -14171,7 +14170,6 @@ run_test    "Client Handshake defragmentation (513)" \
             "$O_NEXT_SRV -max_send_frag 513 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "received ServerHello message" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
@@ -14179,7 +14177,6 @@ run_test    "Client Handshake defragmentation (256)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 256 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "received ServerHello message" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
@@ -14187,7 +14184,6 @@ run_test    "Client Handshake defragmentation (128)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 128 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "received ServerHello message" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
@@ -14195,7 +14191,6 @@ run_test    "Client Handshake defragmentation (64)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 64 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "received ServerHello message" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
@@ -14203,7 +14198,6 @@ run_test    "Client Handshake defragmentation (36)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 36 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "received ServerHello message" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
@@ -14211,7 +14205,6 @@ run_test    "Client Handshake defragmentation (32)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 32 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "received ServerHello message" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
@@ -14219,7 +14212,6 @@ run_test    "Client Handshake defragmentation (16)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 16 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "received ServerHello message" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
@@ -14228,7 +14220,6 @@ run_test    "Client Handshake defragmentation (13)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 13 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "received ServerHello message" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
@@ -14236,7 +14227,6 @@ run_test    "Client Handshake defragmentation (5)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 5 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "received ServerHello message" \
             -c "<= handshake" \
             -c "handshake fragment: "
 

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14159,7 +14159,7 @@ run_test    "TLS 1.2 ClientHello indicating support for deflate compression meth
 
 # Handshake defragmentation testing
 
-run_test    "Client Hanshake defragmentation (512)" \
+run_test    "Client Handshake defragmentation (512)" \
             "$O_NEXT_SRV -max_send_frag 512 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -14167,7 +14167,7 @@ run_test    "Client Hanshake defragmentation (512)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
-run_test    "Client Hanshake defragmentation (513)" \
+run_test    "Client Handshake defragmentation (513)" \
             "$O_NEXT_SRV -max_send_frag 513 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -14175,7 +14175,7 @@ run_test    "Client Hanshake defragmentation (513)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
-run_test    "Client Hanshake defragmentation (256)" \
+run_test    "Client Handshake defragmentation (256)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 256 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -14183,7 +14183,7 @@ run_test    "Client Hanshake defragmentation (256)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
-run_test    "Client Hanshake defragmentation (128)" \
+run_test    "Client Handshake defragmentation (128)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 128 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -14191,7 +14191,7 @@ run_test    "Client Hanshake defragmentation (128)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
-run_test    "Client Hanshake defragmentation (64)" \
+run_test    "Client Handshake defragmentation (64)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 64 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -14199,7 +14199,7 @@ run_test    "Client Hanshake defragmentation (64)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
-run_test    "Client Hanshake defragmentation (36)" \
+run_test    "Client Handshake defragmentation (36)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 36 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -14207,7 +14207,7 @@ run_test    "Client Hanshake defragmentation (36)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
-run_test    "Client Hanshake defragmentation (32)" \
+run_test    "Client Handshake defragmentation (32)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 32 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -14215,7 +14215,7 @@ run_test    "Client Hanshake defragmentation (32)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
-run_test    "Client Hanshake defragmentation (16)" \
+run_test    "Client Handshake defragmentation (16)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 16 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -14224,7 +14224,7 @@ run_test    "Client Hanshake defragmentation (16)" \
             -c "handshake fragment: "
 
 
-run_test    "Client Hanshake defragmentation (13)" \
+run_test    "Client Handshake defragmentation (13)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 13 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -14232,7 +14232,7 @@ run_test    "Client Hanshake defragmentation (13)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
-run_test    "Client Hanshake defragmentation (5)" \
+run_test    "Client Handshake defragmentation (5)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 5 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -14240,70 +14240,70 @@ run_test    "Client Hanshake defragmentation (5)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
-run_test    "Server Hanshake defragmentation (512)" \
+run_test    "Server Handshake defragmentation (512)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -max_send_frag 512 " \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
 
-run_test    "Server Hanshake defragmentation (513)" \
+run_test    "Server Handshake defragmentation (513)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -max_send_frag 513 " \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
 
-run_test    "Server Hanshake defragmentation (256)" \
+run_test    "Server Handshake defragmentation (256)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 256 " \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
 
-run_test    "Server Hanshake defragmentation (128)" \
+run_test    "Server Handshake defragmentation (128)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 128 " \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
 
-run_test    "Server Hanshake defragmentation (64)" \
+run_test    "Server Handshake defragmentation (64)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 64 " \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
 
-run_test    "Server Hanshake defragmentation (36)" \
+run_test    "Server Handshake defragmentation (36)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 36 " \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
 
-run_test    "Server Hanshake defragmentation (32)" \
+run_test    "Server Handshake defragmentation (32)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 32 " \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
 
-run_test    "Server Hanshake defragmentation (16)" \
+run_test    "Server Handshake defragmentation (16)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 16 " \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
 
-run_test    "Server Hanshake defragmentation (13)" \
+run_test    "Server Handshake defragmentation (13)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 13 " \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
 
-run_test    "Server Hanshake defragmentation (5)" \
+run_test    "Server Handshake defragmentation (5)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 5 " \
             0 \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14241,7 +14241,7 @@ run_test    "Client Handshake defragmentation (5)" \
 
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (512)" \
-            "$P_SRV debug_level=4 " \
+            "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -max_send_frag 512 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
@@ -14249,7 +14249,7 @@ run_test    "Server Handshake defragmentation (512)" \
 
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (513)" \
-            "$P_SRV debug_level=4 " \
+            "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -max_send_frag 513 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
@@ -14257,7 +14257,7 @@ run_test    "Server Handshake defragmentation (513)" \
 
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (256)" \
-            "$P_SRV debug_level=4 " \
+            "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 256 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
@@ -14265,7 +14265,7 @@ run_test    "Server Handshake defragmentation (256)" \
 
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (128)" \
-            "$P_SRV debug_level=4 " \
+            "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 128 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
@@ -14273,7 +14273,7 @@ run_test    "Server Handshake defragmentation (128)" \
 
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (64)" \
-            "$P_SRV debug_level=4 " \
+            "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 64 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
@@ -14281,7 +14281,7 @@ run_test    "Server Handshake defragmentation (64)" \
 
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (36)" \
-            "$P_SRV debug_level=4 " \
+            "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 36 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
@@ -14289,7 +14289,7 @@ run_test    "Server Handshake defragmentation (36)" \
 
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (32)" \
-            "$P_SRV debug_level=4 " \
+            "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 32 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
@@ -14297,7 +14297,7 @@ run_test    "Server Handshake defragmentation (32)" \
 
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (16)" \
-            "$P_SRV debug_level=4 " \
+            "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 16 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
@@ -14305,7 +14305,7 @@ run_test    "Server Handshake defragmentation (16)" \
 
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (13)" \
-            "$P_SRV debug_level=4 " \
+            "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 13 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
@@ -14313,7 +14313,7 @@ run_test    "Server Handshake defragmentation (13)" \
 
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (5)" \
-            "$P_SRV debug_level=4 " \
+            "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 5 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14159,87 +14159,156 @@ run_test    "TLS 1.2 ClientHello indicating support for deflate compression meth
 
 # Handshake defragmentation testing
 
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-run_test    "Hanshake defragmentation (512)" \
-            "$O_SRV -max_send_frag 512 " \
+run_test    "Client Hanshake defragmentation (512)" \
+            "$O_NEXT_SRV -max_send_frag 512 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "received ServerHello message" \
             -c "<= handshake" \
+            -c "handshake fragment: "
 
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-run_test    "Hanshake defragmentation (513)" \
-            "$O_SRV -max_send_frag 513 " \
+run_test    "Client Hanshake defragmentation (513)" \
+            "$O_NEXT_SRV -max_send_frag 513 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "received ServerHello message" \
             -c "<= handshake" \
+            -c "handshake fragment: "
 
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-run_test    "Hanshake defragmentation (256)" \
-            "$O_SRV -mtu 32 -split_send_frag 256 " \
+run_test    "Client Hanshake defragmentation (256)" \
+            "$O_NEXT_SRV -mtu 32 -split_send_frag 256 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "received ServerHello message" \
             -c "<= handshake" \
+            -c "handshake fragment: "
 
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-run_test    "Hanshake defragmentation (128)" \
-            "$O_SRV -mtu 32 -split_send_frag 128 " \
+run_test    "Client Hanshake defragmentation (128)" \
+            "$O_NEXT_SRV -mtu 32 -split_send_frag 128 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "received ServerHello message" \
             -c "<= handshake" \
+            -c "handshake fragment: "
 
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-run_test    "Hanshake defragmentation (64)" \
-            "$O_SRV -mtu 32 -split_send_frag 64 " \
+run_test    "Client Hanshake defragmentation (64)" \
+            "$O_NEXT_SRV -mtu 32 -split_send_frag 64 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "received ServerHello message" \
             -c "<= handshake" \
+            -c "handshake fragment: "
 
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-run_test    "Hanshake defragmentation (36)" \
-            "$O_SRV -mtu 32 -split_send_frag 36 " \
+run_test    "Client Hanshake defragmentation (36)" \
+            "$O_NEXT_SRV -mtu 32 -split_send_frag 36 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "received ServerHello message" \
             -c "<= handshake" \
+            -c "handshake fragment: "
 
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-run_test    "Hanshake defragmentation (32)" \
-            "$O_SRV -mtu 32 -split_send_frag 32 " \
+run_test    "Client Hanshake defragmentation (32)" \
+            "$O_NEXT_SRV -mtu 32 -split_send_frag 32 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "received ServerHello message" \
             -c "<= handshake" \
+            -c "handshake fragment: "
 
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-run_test    "Hanshake defragmentation (16)" \
-            "$O_SRV -mtu 32 -split_send_frag 16 " \
+run_test    "Client Hanshake defragmentation (16)" \
+            "$O_NEXT_SRV -mtu 32 -split_send_frag 16 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "received ServerHello message" \
             -c "<= handshake" \
+            -c "handshake fragment: "
 
 
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-run_test    "Hanshake defragmentation (13)" \
-            "$O_SRV -mtu 32 -split_send_frag 13 " \
+run_test    "Client Hanshake defragmentation (13)" \
+            "$O_NEXT_SRV -mtu 32 -split_send_frag 13 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "received ServerHello message" \
             -c "<= handshake" \
+            -c "handshake fragment: "
 
-
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-run_test    "Hanshake defragmentation (5)" \
-            "$O_SRV -mtu 32 -split_send_frag 5 " \
+run_test    "Client Hanshake defragmentation (5)" \
+            "$O_NEXT_SRV -mtu 32 -split_send_frag 5 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "received ServerHello message" \
             -c "<= handshake" \
+            -c "handshake fragment: "
+
+run_test    "Server Hanshake defragmentation (512)" \
+            "$P_SRV debug_level=4 " \
+            "$O_NEXT_CLI -max_send_frag 512 " \
+            0 \
+            -s "<= handshake" \
+            -s "handshake fragment: "
+
+run_test    "Server Hanshake defragmentation (513)" \
+            "$P_SRV debug_level=4 " \
+            "$O_NEXT_CLI -max_send_frag 513 " \
+            0 \
+            -s "<= handshake" \
+            -s "handshake fragment: "
+
+run_test    "Server Hanshake defragmentation (256)" \
+            "$P_SRV debug_level=4 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 256 " \
+            0 \
+            -s "<= handshake" \
+            -s "handshake fragment: "
+
+run_test    "Server Hanshake defragmentation (128)" \
+            "$P_SRV debug_level=4 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 128 " \
+            0 \
+            -s "<= handshake" \
+            -s "handshake fragment: "
+
+run_test    "Server Hanshake defragmentation (64)" \
+            "$P_SRV debug_level=4 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 64 " \
+            0 \
+            -s "<= handshake" \
+            -s "handshake fragment: "
+
+run_test    "Server Hanshake defragmentation (36)" \
+            "$P_SRV debug_level=4 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 36 " \
+            0 \
+            -s "<= handshake" \
+            -s "handshake fragment: "
+
+run_test    "Server Hanshake defragmentation (32)" \
+            "$P_SRV debug_level=4 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 32 " \
+            0 \
+            -s "<= handshake" \
+            -s "handshake fragment: "
+
+run_test    "Server Hanshake defragmentation (16)" \
+            "$P_SRV debug_level=4 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 16 " \
+            0 \
+            -s "<= handshake" \
+            -s "handshake fragment: "
+
+run_test    "Server Hanshake defragmentation (13)" \
+            "$P_SRV debug_level=4 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 13 " \
+            0 \
+            -s "<= handshake" \
+            -s "handshake fragment: "
+
+run_test    "Server Hanshake defragmentation (5)" \
+            "$P_SRV debug_level=4 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 5 " \
+            0 \
+            -s "<= handshake" \
+            -s "handshake fragment: "
 
 # Test heap memory usage after handshake
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14159,6 +14159,7 @@ run_test    "TLS 1.2 ClientHello indicating support for deflate compression meth
 
 # Handshake defragmentation testing
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 run_test    "Client Handshake defragmentation (512)" \
@@ -14166,8 +14167,10 @@ run_test    "Client Handshake defragmentation (512)" \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
-            -c "waiting for more fragments (512 [0-9]\\+, [0-9]\\+ left)"
+            -c "handshake fragment: 0 \\.\\. 512 of [0-9]\\+ msglen 512" \
+            -c "waiting for more fragments (512 of [0-9]\\+"
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 run_test    "Client Handshake defragmentation (513)" \
@@ -14175,7 +14178,8 @@ run_test    "Client Handshake defragmentation (513)" \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
-            -c "waiting for more fragments (513 [0-9]\\+, [0-9]\\+ left)"
+            -c "handshake fragment: 0 \\.\\. 513 of [0-9]\\+ msglen 513" \
+            -c "waiting for more fragments (513 of [0-9]\\+"
 
 # OpenSSL does not allow max_send_frag to be less than 512
 # so we use split_send_frag instead for tests lower than 512 below.
@@ -14183,6 +14187,7 @@ run_test    "Client Handshake defragmentation (513)" \
 # There is an issue with OpenSSL when fragmenting with values less
 # than 512 bytes in TLS 1.2 so we require TLS 1.3 with these values.
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -14191,8 +14196,10 @@ run_test    "Client Handshake defragmentation (256)" \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
-            -c "waiting for more fragments (256 of [0-9]\\+, [0-9]\\+ left)"
+            -c "handshake fragment: 0 \\.\\. 256 of [0-9]\\+ msglen 256" \
+            -c "waiting for more fragments (256 of [0-9]\\+"
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -14201,8 +14208,10 @@ run_test    "Client Handshake defragmentation (128)" \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
-            -c "waiting for more fragments (128 [0-9]\\+, [0-9]\\+ left)"
+            -c "handshake fragment: 0 \\.\\. 128 of [0-9]\\+ msglen 128" \
+            -c "waiting for more fragments (128"
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -14211,8 +14220,10 @@ run_test    "Client Handshake defragmentation (64)" \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
-            -c "waiting for more fragments (64 [0-9]\\+, [0-9]\\+ left)"
+            -c "handshake fragment: 0 \\.\\. 64 of [0-9]\\+ msglen 64" \
+            -c "waiting for more fragments (64"
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -14221,8 +14232,10 @@ run_test    "Client Handshake defragmentation (36)" \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
-            -c "waiting for more fragments (36 [0-9]\\+, [0-9]\\+ left)"
+            -c "handshake fragment: 0 \\.\\. 36 of [0-9]\\+ msglen 36" \
+            -c "waiting for more fragments (36"
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -14231,8 +14244,10 @@ run_test    "Client Handshake defragmentation (32)" \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
-            -c "waiting for more fragments (32 [0-9]\\+, [0-9]\\+ left)"
+            -c "handshake fragment: 0 \\.\\. 32 of [0-9]\\+ msglen 32" \
+            -c "waiting for more fragments (32"
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -14241,8 +14256,10 @@ run_test    "Client Handshake defragmentation (16)" \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
-            -c "waiting for more fragments (16 [0-9]\\+, [0-9]\\+ left)"
+            -c "handshake fragment: 0 \\.\\. 16 of [0-9]\\+ msglen 16" \
+            -c "waiting for more fragments (16"
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -14251,8 +14268,10 @@ run_test    "Client Handshake defragmentation (13)" \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
-            -c "waiting for more fragments (13 [0-9]\\+, [0-9]\\+ left)"
+            -c "handshake fragment: 0 \\.\\. 13 of [0-9]\\+ msglen 13" \
+            -c "waiting for more fragments (13"
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -14261,8 +14280,10 @@ run_test    "Client Handshake defragmentation (5)" \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
-            -c "waiting for more fragments (5 [0-9]\\+, [0-9]\\+ left)"
+            -c "handshake fragment: 0 \\.\\. 5 of [0-9]\\+ msglen 5" \
+            -c "waiting for more fragments (5"
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 run_test    "Server Handshake defragmentation (512)" \
@@ -14270,8 +14291,10 @@ run_test    "Server Handshake defragmentation (512)" \
             "$O_NEXT_CLI -max_send_frag 512 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
-            -s "waiting for more fragments (512 [0-9]\\+, [0-9]\\+ left)"
+            -s "handshake fragment: 0 \\.\\. 512 of [0-9]\\+ msglen 512" \
+            -s "waiting for more fragments (512"
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 run_test    "Server Handshake defragmentation (513)" \
@@ -14279,8 +14302,10 @@ run_test    "Server Handshake defragmentation (513)" \
             "$O_NEXT_CLI -max_send_frag 513 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
-            -s "waiting for more fragments (513 [0-9]\\+, [0-9]\\+ left)"
+            -s "handshake fragment: 0 \\.\\. 513 of [0-9]\\+ msglen 513" \
+            -s "waiting for more fragments (513"
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -14289,8 +14314,10 @@ run_test    "Server Handshake defragmentation (256)" \
             "$O_NEXT_CLI -split_send_frag 256 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
-            -s "waiting for more fragments (256 [0-9]\\+, [0-9]\\+ left)"
+            -s "handshake fragment: 0 \\.\\. 256 of [0-9]\\+ msglen 256" \
+            -s "waiting for more fragments (256"
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -14299,8 +14326,10 @@ run_test    "Server Handshake defragmentation (128)" \
             "$O_NEXT_CLI -split_send_frag 128 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
-            -s "waiting for more fragments (128 [0-9]\\+, [0-9]\\+ left)"
+            -s "handshake fragment: 0 \\.\\. 128 of [0-9]\\+ msglen 128" \
+            -s "waiting for more fragments (128"
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -14309,8 +14338,10 @@ run_test    "Server Handshake defragmentation (64)" \
             "$O_NEXT_CLI -split_send_frag 64 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
-            -s "waiting for more fragments (64 [0-9]\\+, [0-9]\\+ left)"
+            -s "handshake fragment: 0 \\.\\. 64 of [0-9]\\+ msglen 64" \
+            -s "waiting for more fragments (64"
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -14319,8 +14350,10 @@ run_test    "Server Handshake defragmentation (36)" \
             "$O_NEXT_CLI -split_send_frag 36 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
-            -s "waiting for more fragments (36 [0-9]\\+, [0-9]\\+ left)"
+            -s "handshake fragment: 0 \\.\\. 36 of [0-9]\\+ msglen 36" \
+            -s "waiting for more fragments (36"
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -14329,8 +14362,10 @@ run_test    "Server Handshake defragmentation (32)" \
             "$O_NEXT_CLI -split_send_frag 32 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
-            -s "waiting for more fragments (32 [0-9]\\+, [0-9]\\+ left)"
+            -s "handshake fragment: 0 \\.\\. 32 of [0-9]\\+ msglen 32" \
+            -s "waiting for more fragments (32"
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -14339,8 +14374,10 @@ run_test    "Server Handshake defragmentation (16)" \
             "$O_NEXT_CLI -split_send_frag 16 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
-            -s "waiting for more fragments (16 [0-9]\\+, [0-9]\\+ left)"
+            -s "handshake fragment: 0 \\.\\. 16 of [0-9]\\+ msglen 16" \
+            -s "waiting for more fragments (16"
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -14349,8 +14386,10 @@ run_test    "Server Handshake defragmentation (13)" \
             "$O_NEXT_CLI -split_send_frag 13 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
-            -s "waiting for more fragments (12 [0-9]\\+, [0-9]\\+ left)"
+            -s "handshake fragment: 0 \\.\\. 13 of [0-9]\\+ msglen 13" \
+            -s "waiting for more fragments (13"
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -14359,7 +14398,8 @@ run_test    "Server Handshake defragmentation (5)" \
             "$O_NEXT_CLI -split_send_frag 5 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
-            -s "waiting for more fragments (5 [0-9]\\+, [0-9]\\+ left)"
+            -s "handshake fragment: 0 \\.\\. 5 of [0-9]\\+ msglen 5" \
+            -s "waiting for more fragments (5"
 
 # Test heap memory usage after handshake
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14242,7 +14242,7 @@ run_test    "Client Handshake defragmentation (5)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (512)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -max_send_frag 512 " \
+            "$O_NEXT_CLI -max_send_frag 512 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -14250,7 +14250,7 @@ run_test    "Server Handshake defragmentation (512)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (513)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -max_send_frag 513 " \
+            "$O_NEXT_CLI -max_send_frag 513 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -14258,7 +14258,7 @@ run_test    "Server Handshake defragmentation (513)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (256)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 256 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 256 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -14266,7 +14266,7 @@ run_test    "Server Handshake defragmentation (256)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (128)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 128 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 128 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -14274,7 +14274,7 @@ run_test    "Server Handshake defragmentation (128)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (64)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 64 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 64 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -14282,7 +14282,7 @@ run_test    "Server Handshake defragmentation (64)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (36)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 36 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 36 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -14290,7 +14290,7 @@ run_test    "Server Handshake defragmentation (36)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (32)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 32 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 32 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -14298,7 +14298,7 @@ run_test    "Server Handshake defragmentation (32)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (16)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 16 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 16 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -14306,7 +14306,7 @@ run_test    "Server Handshake defragmentation (16)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (13)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 13 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 13 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -14314,7 +14314,7 @@ run_test    "Server Handshake defragmentation (13)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (5)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 5 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 5 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14171,10 +14171,32 @@ run_test    "Handshake defragmentation on client: len=512, TLS 1.3" \
             -c "waiting for more fragments (512 of [0-9]\\+"
 
 requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on client: len=512, TLS 1.2" \
+            "$O_NEXT_SRV -tls1_2 -max_send_frag 512 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "reassembled record" \
+            -c "handshake fragment: 0 \\.\\. 512 of [0-9]\\+ msglen 512" \
+            -c "waiting for more fragments (512 of [0-9]\\+"
+
+requires_openssl_3_x
 requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=513, TLS 1.3" \
             "$O_NEXT_SRV -tls1_3 -max_send_frag 513 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "reassembled record" \
+            -c "handshake fragment: 0 \\.\\. 513 of [0-9]\\+ msglen 513" \
+            -c "waiting for more fragments (513 of [0-9]\\+"
+
+requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on client: len=513, TLS 1.2" \
+            "$O_NEXT_SRV -tls1_2 -max_send_frag 513 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
@@ -14199,10 +14221,32 @@ run_test    "Handshake defragmentation on client: len=256, TLS 1.3" \
             -c "waiting for more fragments (256 of [0-9]\\+"
 
 requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on client: len=256, TLS 1.2" \
+            "$O_NEXT_SRV -tls1_2 -split_send_frag 256 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "reassembled record" \
+            -c "handshake fragment: 0 \\.\\. 256 of [0-9]\\+ msglen 256" \
+            -c "waiting for more fragments (256 of [0-9]\\+"
+
+requires_openssl_3_x
 requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=128, TLS 1.3" \
             "$O_NEXT_SRV -tls1_3 -split_send_frag 128 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "reassembled record" \
+            -c "handshake fragment: 0 \\.\\. 128 of [0-9]\\+ msglen 128" \
+            -c "waiting for more fragments (128"
+
+requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on client: len=128, TLS 1.2" \
+            "$O_NEXT_SRV -tls1_2 -split_send_frag 128 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
@@ -14221,10 +14265,32 @@ run_test    "Handshake defragmentation on client: len=64, TLS 1.3" \
             -c "waiting for more fragments (64"
 
 requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on client: len=64, TLS 1.2" \
+            "$O_NEXT_SRV -tls1_2 -split_send_frag 64 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "reassembled record" \
+            -c "handshake fragment: 0 \\.\\. 64 of [0-9]\\+ msglen 64" \
+            -c "waiting for more fragments (64"
+
+requires_openssl_3_x
 requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=36, TLS 1.3" \
             "$O_NEXT_SRV -tls1_3 -split_send_frag 36 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "reassembled record" \
+            -c "handshake fragment: 0 \\.\\. 36 of [0-9]\\+ msglen 36" \
+            -c "waiting for more fragments (36"
+
+requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on client: len=36, TLS 1.2" \
+            "$O_NEXT_SRV -tls1_2 -split_send_frag 36 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
@@ -14243,10 +14309,32 @@ run_test    "Handshake defragmentation on client: len=32, TLS 1.3" \
             -c "waiting for more fragments (32"
 
 requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on client: len=32, TLS 1.2" \
+            "$O_NEXT_SRV -tls1_2 -split_send_frag 32 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "reassembled record" \
+            -c "handshake fragment: 0 \\.\\. 32 of [0-9]\\+ msglen 32" \
+            -c "waiting for more fragments (32"
+
+requires_openssl_3_x
 requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=14, TLS 1.3" \
             "$O_NEXT_SRV -tls1_3 -split_send_frag 16 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "reassembled record" \
+            -c "handshake fragment: 0 \\.\\. 16 of [0-9]\\+ msglen 16" \
+            -c "waiting for more fragments (16"
+
+requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on client: len=14, TLS 1.2" \
+            "$O_NEXT_SRV -tls1_2 -split_send_frag 16 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
@@ -14265,10 +14353,32 @@ run_test    "Handshake defragmentation on client: len=13, TLS 1.3" \
             -c "waiting for more fragments (13"
 
 requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on client: len=13, TLS 1.2" \
+            "$O_NEXT_SRV -tls1_2 -split_send_frag 13 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "reassembled record" \
+            -c "handshake fragment: 0 \\.\\. 13 of [0-9]\\+ msglen 13" \
+            -c "waiting for more fragments (13"
+
+requires_openssl_3_x
 requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=5, TLS 1.3" \
             "$O_NEXT_SRV -tls1_3 -split_send_frag 5 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "reassembled record" \
+            -c "handshake fragment: 0 \\.\\. 5 of [0-9]\\+ msglen 5" \
+            -c "waiting for more fragments (5"
+
+requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on client: len=5, TLS 1.2" \
+            "$O_NEXT_SRV -tls1_2 -split_send_frag 5 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
@@ -14287,11 +14397,33 @@ run_test    "Handshake defragmentation on server: len=512, TLS 1.3" \
             -s "waiting for more fragments (512"
 
 requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on server: len=512, TLS 1.2" \
+            "$P_SRV debug_level=4 auth_mode=required" \
+            "$O_NEXT_CLI -tls1_2 -max_send_frag 512 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            0 \
+            -s "reassembled record" \
+            -s "handshake fragment: 0 \\.\\. 512 of [0-9]\\+ msglen 512" \
+            -s "waiting for more fragments (512"
+
+requires_openssl_3_x
 requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=513, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_3 -max_send_frag 513 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            0 \
+            -s "reassembled record" \
+            -s "handshake fragment: 0 \\.\\. 513 of [0-9]\\+ msglen 513" \
+            -s "waiting for more fragments (513"
+
+requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on server: len=513, TLS 1.2" \
+            "$P_SRV debug_level=4 auth_mode=required" \
+            "$O_NEXT_CLI -tls1_2 -max_send_frag 513 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 513 of [0-9]\\+ msglen 513" \
@@ -14309,11 +14441,34 @@ run_test    "Handshake defragmentation on server: len=256, TLS 1.3" \
             -s "waiting for more fragments (256"
 
 requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on server: len=256, TLS 1.2" \
+            "$P_SRV debug_level=4 auth_mode=required" \
+            "$O_NEXT_CLI -tls1_3 -split_send_frag 256 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            0 \
+            -s "reassembled record" \
+            -s "handshake fragment: 0 \\.\\. 256 of [0-9]\\+ msglen 256" \
+            -s "waiting for more fragments (256"
+
+
+requires_openssl_3_x
 requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=128, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_3 -split_send_frag 128 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            0 \
+            -s "reassembled record" \
+            -s "handshake fragment: 0 \\.\\. 128 of [0-9]\\+ msglen 128" \
+            -s "waiting for more fragments (128"
+
+requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on server: len=128, TLS 1.2" \
+            "$P_SRV debug_level=4 auth_mode=required" \
+            "$O_NEXT_CLI -tls1_2 -split_send_frag 128 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 128 of [0-9]\\+ msglen 128" \
@@ -14331,11 +14486,33 @@ run_test    "Handshake defragmentation on server: len=64, TLS 1.3" \
             -s "waiting for more fragments (64"
 
 requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on server: len=64, TLS 1.2" \
+            "$P_SRV debug_level=4 auth_mode=required" \
+            "$O_NEXT_CLI -tls1_2 -split_send_frag 64 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            0 \
+            -s "reassembled record" \
+            -s "handshake fragment: 0 \\.\\. 64 of [0-9]\\+ msglen 64" \
+            -s "waiting for more fragments (64"
+
+requires_openssl_3_x
 requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=36, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_3 -split_send_frag 36 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            0 \
+            -s "reassembled record" \
+            -s "handshake fragment: 0 \\.\\. 36 of [0-9]\\+ msglen 36" \
+            -s "waiting for more fragments (36"
+
+requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on server: len=36, TLS 1.2" \
+            "$P_SRV debug_level=4 auth_mode=required" \
+            "$O_NEXT_CLI -tls1_2 -split_send_frag 36 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 36 of [0-9]\\+ msglen 36" \
@@ -14353,11 +14530,33 @@ run_test    "Handshake defragmentation on server: len=32, TLS 1.3" \
             -s "waiting for more fragments (32"
 
 requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on server: len=32, TLS 1.2" \
+            "$P_SRV debug_level=4 auth_mode=required" \
+            "$O_NEXT_CLI -tls1_2 -split_send_frag 32 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            0 \
+            -s "reassembled record" \
+            -s "handshake fragment: 0 \\.\\. 32 of [0-9]\\+ msglen 32" \
+            -s "waiting for more fragments (32"
+
+requires_openssl_3_x
 requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=16, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_3 -split_send_frag 16 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            0 \
+            -s "reassembled record" \
+            -s "handshake fragment: 0 \\.\\. 16 of [0-9]\\+ msglen 16" \
+            -s "waiting for more fragments (16"
+
+requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on server: len=16, TLS 1.2" \
+            "$P_SRV debug_level=4 auth_mode=required" \
+            "$O_NEXT_CLI -tls1_2 -split_send_frag 16 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 16 of [0-9]\\+ msglen 16" \
@@ -14375,11 +14574,33 @@ run_test    "Handshake defragmentation on server: len=13, TLS 1.3" \
             -s "waiting for more fragments (13"
 
 requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on server: len=13, TLS 1.2" \
+            "$P_SRV debug_level=4 auth_mode=required" \
+            "$O_NEXT_CLI -tls1_2 -split_send_frag 13 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            0 \
+            -s "reassembled record" \
+            -s "handshake fragment: 0 \\.\\. 13 of [0-9]\\+ msglen 13" \
+            -s "waiting for more fragments (13"
+
+requires_openssl_3_x
 requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=5, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_3 -split_send_frag 5 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            0 \
+            -s "reassembled record" \
+            -s "handshake fragment: 0 \\.\\. 5 of [0-9]\\+ msglen 5" \
+            -s "waiting for more fragments (5"
+
+requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on server: len=5, TLS 1.2" \
+            "$P_SRV debug_level=4 auth_mode=required" \
+            "$O_NEXT_CLI -tls1_2 -split_send_frag 5 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 5 of [0-9]\\+ msglen 5" \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14162,7 +14162,7 @@ run_test    "TLS 1.2 ClientHello indicating support for deflate compression meth
 requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
-run_test    "Client Handshake defragmentation (512)" \
+run_test    "Handshake defragmentation on client: len=512, TLS 1.3" \
             "$O_NEXT_SRV -max_send_frag 512 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -14173,7 +14173,7 @@ run_test    "Client Handshake defragmentation (512)" \
 requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
-run_test    "Client Handshake defragmentation (513)" \
+run_test    "Handshake defragmentation on client: len=513, TLS 1.3" \
             "$O_NEXT_SRV -max_send_frag 513 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -14191,7 +14191,7 @@ requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
-run_test    "Client Handshake defragmentation (256)" \
+run_test    "Handshake defragmentation on client: len=256, TLS 1.3" \
             "$O_NEXT_SRV -split_send_frag 256 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -14203,7 +14203,7 @@ requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
-run_test    "Client Handshake defragmentation (128)" \
+run_test    "Handshake defragmentation on client: len=128, TLS 1.3" \
             "$O_NEXT_SRV -split_send_frag 128 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -14215,7 +14215,7 @@ requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
-run_test    "Client Handshake defragmentation (64)" \
+run_test    "Handshake defragmentation on client: len=64, TLS 1.3" \
             "$O_NEXT_SRV -split_send_frag 64 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -14227,7 +14227,7 @@ requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
-run_test    "Client Handshake defragmentation (36)" \
+run_test    "Handshake defragmentation on client: len=36, TLS 1.3" \
             "$O_NEXT_SRV -split_send_frag 36 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -14239,7 +14239,7 @@ requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
-run_test    "Client Handshake defragmentation (32)" \
+run_test    "Handshake defragmentation on client: len=32, TLS 1.3" \
             "$O_NEXT_SRV -split_send_frag 32 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -14251,7 +14251,7 @@ requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
-run_test    "Client Handshake defragmentation (16)" \
+run_test    "Handshake defragmentation on client: len=14, TLS 1.3" \
             "$O_NEXT_SRV -split_send_frag 16 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -14263,7 +14263,7 @@ requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
-run_test    "Client Handshake defragmentation (13)" \
+run_test    "Handshake defragmentation on client: len=13, TLS 1.3" \
             "$O_NEXT_SRV -split_send_frag 13 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -14275,7 +14275,7 @@ requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
-run_test    "Client Handshake defragmentation (5)" \
+run_test    "Handshake defragmentation on client: len=5, TLS 1.3" \
             "$O_NEXT_SRV -split_send_frag 5 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -14286,7 +14286,7 @@ run_test    "Client Handshake defragmentation (5)" \
 requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
-run_test    "Server Handshake defragmentation (512)" \
+run_test    "Handshake defragmentation on server: len=512, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -max_send_frag 512 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14297,7 +14297,7 @@ run_test    "Server Handshake defragmentation (512)" \
 requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
-run_test    "Server Handshake defragmentation (513)" \
+run_test    "Handshake defragmentation on server: len=513, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -max_send_frag 513 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14309,7 +14309,7 @@ requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
-run_test    "Server Handshake defragmentation (256)" \
+run_test    "Handshake defragmentation on server: len=256, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 256 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14321,7 +14321,7 @@ requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
-run_test    "Server Handshake defragmentation (128)" \
+run_test    "Handshake defragmentation on server: len=128, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 128 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14333,7 +14333,7 @@ requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
-run_test    "Server Handshake defragmentation (64)" \
+run_test    "Handshake defragmentation on server: len=64, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 64 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14345,7 +14345,7 @@ requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
-run_test    "Server Handshake defragmentation (36)" \
+run_test    "Handshake defragmentation on server: len=36, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 36 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14357,7 +14357,7 @@ requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
-run_test    "Server Handshake defragmentation (32)" \
+run_test    "Handshake defragmentation on server: len=32, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 32 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14369,7 +14369,7 @@ requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
-run_test    "Server Handshake defragmentation (16)" \
+run_test    "Handshake defragmentation on server: len=16, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 16 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14381,7 +14381,7 @@ requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
-run_test    "Server Handshake defragmentation (13)" \
+run_test    "Handshake defragmentation on server: len=13, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 13 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14393,7 +14393,7 @@ requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
-run_test    "Server Handshake defragmentation (5)" \
+run_test    "Handshake defragmentation on server: len=5, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 5 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \


### PR DESCRIPTION
## Description

Fixes #9887 
Add TLS Handshake defragmentation tests based on implementation done in #9872 .


## PR checklist

- [x] **changelog** provided
- [x] **development PR** provided
- [x] **framework PR** not required
- [ ] **3.6 PR** provided #TODO
- [x] **2.28 PR** not required because: New feature
- [x] **tests**  provided
