### PR TITLE
component_test_tfm_config_no_p256m: build programs

### DIFF
--- a/tests/scripts/components-configuration-crypto.sh
+++ b/tests/scripts/components-configuration-crypto.sh
@@ -1801,7 +1801,7 @@ component_test_tfm_config_no_p256m () {
     echo "#undef MBEDTLS_PSA_P256M_DRIVER_ENABLED" >> "$CONFIG_H"
 
     msg "build: TF-M config without p256m"
-    make CFLAGS='-Werror -Wall -Wextra -I../framework/tests/include/spe' tests
+    make CFLAGS='-Werror -Wall -Wextra -I../framework/tests/include/spe'
 
     # Check that p256m was not built
     not grep p256_ecdsa_ library/libmbedcrypto.a


### PR DESCRIPTION
Very minor, but needed for https://github.com/Mbed-TLS/mbedtls-framework/pull/129.

## PR checklist

- [x] **changelog** not required because: test stuff only
- [x] **development PR** provided #9932
- [x] **framework PR** not required
- [x] **3.6 PR** here
- [x] **2.28 PR** not required because: not applicable
- **tests**  provided
