### PR TITLE
Move ssl_ticket to the PSA API

### DIFF
--- a/ChangeLog.d/9874.txt
+++ b/ChangeLog.d/9874.txt
@@ -1,5 +1,5 @@
 API changes
    * Align the mbedtls_ssl_ticket_setup() function with the PSA Crypto API.
-     Instead of taking a mbedtls_cipher_type_t as an argument, this function now takes 3
-     new arguments: a PSA algorithm, key type and key size, to specify the AEAD for ticket
-     protection.
+     Instead of taking a mbedtls_cipher_type_t as an argument, this function 
+     now takes 3 new arguments: a PSA algorithm, key type and key size, to 
+     specify the AEAD for ticket protection.

--- a/ChangeLog.d/9874.txt
+++ b/ChangeLog.d/9874.txt
@@ -1,2 +1,5 @@
 API changes
-   * Convert the mbedtl_ssl_ticket_setup function to use the TF_PSA_Crypto API.
+   * Align the mbedtls_ssl_ticket_setup() function with the PSA Crypto API.
+     Instead of taking a mbedtls_cipher_type_t as an argument, this function now takes 3
+     new arguments: a PSA algorithm, key type and key size, to specify the AEAD for ticket
+     protection.

--- a/ChangeLog.d/9874.txt
+++ b/ChangeLog.d/9874.txt
@@ -1,0 +1,2 @@
+API changes
+   * Convert the mbedtl_ssl_ticket_setup function to use the TF_PSA_Crypto API.

--- a/ChangeLog.d/9874.txt
+++ b/ChangeLog.d/9874.txt
@@ -1,5 +1,5 @@
 API changes
    * Align the mbedtls_ssl_ticket_setup() function with the PSA Crypto API.
-     Instead of taking a mbedtls_cipher_type_t as an argument, this function 
-     now takes 3 new arguments: a PSA algorithm, key type and key size, to 
+     Instead of taking a mbedtls_cipher_type_t as an argument, this function
+     now takes 3 new arguments: a PSA algorithm, key type and key size, to
      specify the AEAD for ticket protection.

--- a/include/mbedtls/ssl_ticket.h
+++ b/include/mbedtls/ssl_ticket.h
@@ -20,7 +20,6 @@
  */
 
 #include "mbedtls/ssl.h"
-#include "mbedtls/cipher.h"
 
 #if defined(MBEDTLS_HAVE_TIME)
 #include "mbedtls/platform_time.h"
@@ -93,8 +92,12 @@ void mbedtls_ssl_ticket_init(mbedtls_ssl_ticket_context *ctx);
  * \param ctx       Context to be set up
  * \param f_rng     RNG callback function (mandatory)
  * \param p_rng     RNG callback context
- * \param cipher    AEAD cipher to use for ticket protection.
- *                  Recommended value: MBEDTLS_CIPHER_AES_256_GCM.
+ * \param alg       Cryptographic algorithm to use recomended value
+ *                  PSA_ALG_GCM from include/psa/crypto_values.h.
+ * \param key_type  Cryptographic key type to use recomended value
+ *                  PSA_KEY_TYPE_AES from include/psa/crypto_values.h.
+ * \param key_bits  Cryptographic key type to use recomended value
+ *                  PSA_KEY_TYPE_AES from include/psa/crypto_values.h.
  * \param lifetime  Tickets lifetime in seconds
  *                  Recommended value: 86400 (one day).
  *
@@ -117,7 +120,7 @@ void mbedtls_ssl_ticket_init(mbedtls_ssl_ticket_context *ctx);
  */
 int mbedtls_ssl_ticket_setup(mbedtls_ssl_ticket_context *ctx,
                              int (*f_rng)(void *, unsigned char *, size_t), void *p_rng,
-                             mbedtls_cipher_type_t cipher,
+                             psa_algorithm_t alg, psa_key_type_t key_type, psa_key_bits_t key_bits,
                              uint32_t lifetime);
 
 /**

--- a/include/mbedtls/ssl_ticket.h
+++ b/include/mbedtls/ssl_ticket.h
@@ -92,12 +92,9 @@ void mbedtls_ssl_ticket_init(mbedtls_ssl_ticket_context *ctx);
  * \param ctx       Context to be set up
  * \param f_rng     RNG callback function (mandatory)
  * \param p_rng     RNG callback context
- * \param alg       Cryptographic algorithm to use recomended value
- *                  PSA_ALG_GCM from include/psa/crypto_values.h.
- * \param key_type  Cryptographic key type to use recomended value
- *                  PSA_KEY_TYPE_AES from include/psa/crypto_values.h.
- * \param key_bits  Cryptographic key type to use recomended value
- *                  PSA_KEY_TYPE_AES from include/psa/crypto_values.h.
+ * \param alg       AEAD cipher to use for ticket protection.
+ * \param key_type  Cryptographic key type to use.
+ * \param key_bits  Cryptographic key size to use in bits.
  * \param lifetime  Tickets lifetime in seconds
  *                  Recommended value: 86400 (one day).
  *

--- a/library/ssl_ticket.c
+++ b/library/ssl_ticket.c
@@ -186,19 +186,10 @@ int mbedtls_ssl_ticket_rotate(mbedtls_ssl_ticket_context *ctx,
  */
 int mbedtls_ssl_ticket_setup(mbedtls_ssl_ticket_context *ctx,
                              int (*f_rng)(void *, unsigned char *, size_t), void *p_rng,
-                             mbedtls_cipher_type_t cipher,
+                             psa_algorithm_t alg, psa_key_type_t key_type, psa_key_bits_t key_bits,
                              uint32_t lifetime)
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
-    size_t key_bits;
-
-    psa_algorithm_t alg;
-    psa_key_type_t key_type;
-
-    if (mbedtls_ssl_cipher_to_psa(cipher, TICKET_AUTH_TAG_BYTES,
-                                  &alg, &key_type, &key_bits) != PSA_SUCCESS) {
-        return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
-    }
 
     if (PSA_ALG_IS_AEAD(alg) == 0) {
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;

--- a/programs/fuzz/fuzz_server.c
+++ b/programs/fuzz/fuzz_server.c
@@ -131,10 +131,13 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 #endif
 #if defined(MBEDTLS_SSL_SESSION_TICKETS) && defined(MBEDTLS_SSL_TICKET_C)
     if (options & 0x4) {
-        if (mbedtls_ssl_ticket_setup(&ticket_ctx,
-                                     dummy_random, &ctr_drbg,
-                                     MBEDTLS_CIPHER_AES_256_GCM,
-                                     86400) != 0) {
+        if (mbedtls_ssl_ticket_setup(&ticket_ctx, //context
+                                     dummy_random, //f_rng
+                                     &ctr_drbg, //p_rng
+                                     PSA_ALG_GCM, //alg
+                                     PSA_KEY_TYPE_AES, //key_type
+                                     256, //key_bits
+                                     86400) != 0) { //lifetime
             goto exit;
         }
 

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -1476,7 +1476,7 @@ static int dummy_ticket_parse(void *p_ticket, mbedtls_ssl_session *session,
 
 static int parse_cipher(char *buf)
 {
-    int rc = 0;
+    int ret = 0;
     if (strcmp(buf, "AES-128-CCM")) {
         opt.ticket_alg = PSA_ALG_CCM;
         opt.ticket_key_type = PSA_KEY_TYPE_AES;
@@ -1490,13 +1490,13 @@ static int parse_cipher(char *buf)
         opt.ticket_key_type = PSA_KEY_TYPE_AES;
         opt.ticket_key_bits = 192;
     } else if (strcmp(buf, "AES-192-GCM")) {
-        opt.ticket_alg = PSA_ALG_CCM;
+        opt.ticket_alg = PSA_ALG_GCM;
         opt.ticket_key_type = PSA_KEY_TYPE_AES;
         opt.ticket_key_bits = 192;
     } else if (strcmp(buf, "AES-256-CCM")) {
         opt.ticket_alg = PSA_ALG_CCM;
         opt.ticket_key_type = PSA_KEY_TYPE_AES;
-        opt.ticket_key_bits = 128;
+        opt.ticket_key_bits = 256;
     } else if (strcmp(buf, "ARIA-128-CCM")) {
         opt.ticket_alg = PSA_ALG_CCM;
         opt.ticket_key_type = PSA_KEY_TYPE_ARIA;
@@ -1510,7 +1510,7 @@ static int parse_cipher(char *buf)
         opt.ticket_key_type = PSA_KEY_TYPE_ARIA;
         opt.ticket_key_bits = 192;
     } else if (strcmp(buf, "ARIA-192-GCM")) {
-        opt.ticket_alg = PSA_ALG_CCM;
+        opt.ticket_alg = PSA_ALG_GCM;
         opt.ticket_key_type = PSA_KEY_TYPE_ARIA;
         opt.ticket_key_bits = 192;
     } else if (strcmp(buf, "ARIA-256-CCM")) {
@@ -1538,9 +1538,9 @@ static int parse_cipher(char *buf)
         opt.ticket_key_type = PSA_KEY_TYPE_CHACHA20;
         opt.ticket_key_bits = 256;
     } else {
-        rc = -1;
+        ret = -1;
     }
-    return rc;
+    return ret;
 }
 
 int main(int argc, char *argv[])


### PR DESCRIPTION
## Description

Convert the mbedtl_ssl_ticket_setup function to use the TF_PSA_Crypto API. Depends on the merge of #9923 resolves #9874

## PR checklist

- [x] **changelog** provided
- [x] **development PR** provided #HERE
- [x] **framework PR** not required
- [x] **3.6 PR** not required because: this is an API break.
- [x] **2.28 PR** not required because: this is an API break.
- **tests**  not required because: covered by existing tests.