### PR TITLE
Msancf clang16 dev

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,7 +143,7 @@ find_package(Threads)
 # If this is the root project add longer list of available CMAKE_BUILD_TYPE values
 if(NOT MBEDTLS_AS_SUBPROJECT)
     set(CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE}
-        CACHE STRING "Choose the type of build: None Debug Release Coverage ASan ASanDbg MemSan MemSanDbg Check CheckFull TSan TSanDbg"
+        CACHE STRING "Choose the type of build: None Debug Release Coverage ASan ASanDbg CFMemSan CFMemSanDbg MemSan MemSanDbg Check CheckFull TSan TSanDbg"
         FORCE)
 endif()
 
@@ -286,10 +286,23 @@ function(set_clang_base_compile_options target)
     set_target_properties(${target} PROPERTIES LINK_FLAGS_ASAN "-fsanitize=address -fsanitize=undefined")
     target_compile_options(${target} PRIVATE $<$<CONFIG:ASanDbg>:-fsanitize=address -fno-common -fsanitize=undefined -fno-sanitize-recover=all -O1 -g3 -fno-omit-frame-pointer -fno-optimize-sibling-calls>)
     set_target_properties(${target} PROPERTIES LINK_FLAGS_ASANDBG "-fsanitize=address -fsanitize=undefined")
+
+    set(sanitize_memory_debug_flags "-O1 -g3 -fno-omit-frame-pointer -fno-optimize-sibling-calls -fsanitize-memory-track-origins=2")
     target_compile_options(${target} PRIVATE $<$<CONFIG:MemSan>:-fsanitize=memory>)
     set_target_properties(${target} PROPERTIES LINK_FLAGS_MEMSAN "-fsanitize=memory")
-    target_compile_options(${target} PRIVATE $<$<CONFIG:MemSanDbg>:-fsanitize=memory -O1 -g3 -fno-omit-frame-pointer -fno-optimize-sibling-calls -fsanitize-memory-track-origins=2>)
+    target_compile_options(${target} PRIVATE $<$<CONFIG:MemSanDbg>:-fsanitize=memory ${sanitize_memory_debug_flags}>)
     set_target_properties(${target} PROPERTIES LINK_FLAGS_MEMSANDBG "-fsanitize=memory")
+
+    set(cf_sanitize_memory_flags -fsanitize=memory -DMBEDTLS_TEST_CONSTANT_FLOW_MEMSAN)
+    if(CMAKE_C_COMPILER_VERSION VERSION_GREATER 16.0.0)
+        set(cf_sanitize_memory_flags ${cf_sanitize_memory_flags} -fno-sanitize-memory-param-retval)
+    endif()
+    string(REPLACE ";" " " cf_sanitize_memory_flags_joined "${cf_sanitize_memory_flags}")
+    target_compile_options(${target} PRIVATE $<$<CONFIG:CFMemSan>:${cf_sanitize_memory_flags}>)
+    set_target_properties(${target} PROPERTIES LINK_FLAGS_CFMEMSAN "${cf_sanitize_memory_flags_joined}")
+    target_compile_options(${target} PRIVATE $<$<CONFIG:CFMemSanDbg>:${cf_sanitize_memory_flags} ${sanitize_memory_debug_flags}>)
+    set_target_properties(${target} PROPERTIES LINK_FLAGS_CFMEMSANDBG "${cf_sanitize_memory_flags_joined}")
+
     target_compile_options(${target} PRIVATE $<$<CONFIG:TSan>:-fsanitize=thread -O3>)
     set_target_properties(${target} PROPERTIES LINK_FLAGS_TSAN "-fsanitize=thread")
     target_compile_options(${target} PRIVATE $<$<CONFIG:TSanDbg>:-fsanitize=thread -O1 -g3 -fno-omit-frame-pointer -fno-optimize-sibling-calls>)

--- a/tests/scripts/components-sanitizers.sh
+++ b/tests/scripts/components-sanitizers.sh
@@ -40,16 +40,15 @@ skip_all_except_given_suite () {
 component_test_memsan_constant_flow_psa () {
     # This tests both (1) accesses to undefined memory, and (2) branches or
     # memory access depending on secret values. To distinguish between those:
-    # - unset MBEDTLS_TEST_CONSTANT_FLOW_MEMSAN - does the failure persist?
-    # - or alternatively, change the build type to MemSanDbg, which enables
+    # - change the build type to MemSan - does the failure persist?
+    # - or alternatively, change the build type to CFMemSanDbg, which enables
     # origin tracking and nicer stack traces (which are useful for debugging
     # anyway), and check if the origin was TEST_CF_SECRET() or something else.
     msg "build: cmake MSan (clang), full config with constant flow testing"
     scripts/config.py full
-    scripts/config.py set MBEDTLS_TEST_CONSTANT_FLOW_MEMSAN
     scripts/config.py unset MBEDTLS_AESNI_C # memsan doesn't grok asm
     scripts/config.py unset MBEDTLS_HAVE_ASM
-    CC=clang cmake -D GEN_FILES=Off -D CMAKE_BUILD_TYPE:String=MemSan .
+    CC=clang cmake -D GEN_FILES=Off -D CMAKE_BUILD_TYPE:String=CFMemSan .
     make
 
     msg "test: main suites (Msan + constant flow)"


### PR DESCRIPTION
Fix false positives of constant-flow testing when using `MBEDTLS_TEST_CONSTANT_FLOW_MEMSAN` on Clang 16 and above. Fixes #9921.

This isn't needed for the CI (in the short to medium term) because still we do this testing on an old platform with an old Clang, but is needed on typical developer machines nowadays.

## PR checklist

- [x] **changelog** not required because: test only
- [x] **development PR** here
- [x] **crypto PR** https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/170
- [x] **framework PR** not required
- [x] **3.6 PR** https://github.com/Mbed-TLS/mbedtls/pull/9922
- [ ] **2.28 PR** TODO if 2.28 is still around when we merge this
- **tests**  provided for non-regression; requires local testing with Clang ≥16 to validate that #9921 is fixed.
