### PR TITLE
[Backport 3.6] Defragment incoming TLS handshake messages (context extension pointer)

### DIFF
--- a/ChangeLog.d/tls-hs-defrag-in.txt
+++ b/ChangeLog.d/tls-hs-defrag-in.txt
@@ -1,0 +1,2 @@
+Change
+   * Defragment incoming TLS handshake messages.

--- a/ChangeLog.d/tls-hs-defrag-in.txt
+++ b/ChangeLog.d/tls-hs-defrag-in.txt
@@ -1,2 +1,2 @@
-Change
+Changes
    * Defragment incoming TLS handshake messages.

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1827,8 +1827,6 @@ struct mbedtls_ssl_context {
 
     size_t MBEDTLS_PRIVATE(in_hslen);            /*!< current handshake message length,
                                                     including the handshake header   */
-    unsigned char *MBEDTLS_PRIVATE(in_hshdr);    /*!< original handshake header start  */
-    size_t MBEDTLS_PRIVATE(in_hsfraglen);        /*!< accumulated hs fragments length  */
     int MBEDTLS_PRIVATE(nb_zero);                /*!< # of 0-length encrypted messages */
 
     int MBEDTLS_PRIVATE(keep_current_message);   /*!< drop or reuse current message

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1805,7 +1805,7 @@ struct mbedtls_ssl_context {
                                                   *   (the end is marked by in_len).   */
 #endif /* MBEDTLS_SSL_DTLS_CONNECTION_ID */
     unsigned char *MBEDTLS_PRIVATE(in_len);      /*!< two-bytes message length field   */
-    mbedtls_ssl_context_in_ext *MBEDTLS_PRIVATE(in_ext); /*!< extension structure      */
+    unsigned char *MBEDTLS_PRIVATE(in_ext);      /*!< extension structure (ABI compat) */
     unsigned char *MBEDTLS_PRIVATE(in_msg);      /*!< message contents (in_iv+ivlen)   */
     unsigned char *MBEDTLS_PRIVATE(in_offt);     /*!< read offset in application data  */
 

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1817,6 +1817,8 @@ struct mbedtls_ssl_context {
 
     size_t MBEDTLS_PRIVATE(in_hslen);            /*!< current handshake message length,
                                                     including the handshake header   */
+    unsigned char *MBEDTLS_PRIVATE(in_hshdr);    /*!< original handshake header start  */
+    size_t MBEDTLS_PRIVATE(in_hsfraglen);        /*!< accumulated hs fragments length  */
     int MBEDTLS_PRIVATE(nb_zero);                /*!< # of 0-length encrypted messages */
 
     int MBEDTLS_PRIVATE(keep_current_message);   /*!< drop or reuse current message

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1806,7 +1806,6 @@ struct mbedtls_ssl_context {
 #endif /* MBEDTLS_SSL_DTLS_CONNECTION_ID */
     unsigned char *MBEDTLS_PRIVATE(in_len);      /*!< two-bytes message length field   */
     mbedtls_ssl_context_in_ext *MBEDTLS_PRIVATE(in_ext); /*!< extension structure      */
-    unsigned char *MBEDTLS_PRIVATE(in_iv);       /*!< ivlen-byte IV                    */
     unsigned char *MBEDTLS_PRIVATE(in_msg);      /*!< message contents (in_iv+ivlen)   */
     unsigned char *MBEDTLS_PRIVATE(in_offt);     /*!< read offset in application data  */
 

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1684,6 +1684,16 @@ struct mbedtls_ssl_config {
 #endif
 };
 
+/* We need to add more fields to ssl_context, but can't in this branch (3.6)
+ * since we're not allowed to change the ABI. So, put a pointer to this struct
+ * in place of on of the existing pointers in ssl_context - picked in_iv
+ * because it's one of the least used, so that minimizes the disruption. */
+typedef struct {
+    unsigned char *MBEDTLS_PRIVATE(in_iv);       /*!< ivlen-byte IV                    */
+    unsigned char *MBEDTLS_PRIVATE(in_hshdr);    /*!< original handshake header start  */
+    size_t MBEDTLS_PRIVATE(in_hsfraglen);        /*!< accumulated hs fragments length  */
+} mbedtls_ssl_context_in_ext;
+
 struct mbedtls_ssl_context {
     const mbedtls_ssl_config *MBEDTLS_PRIVATE(conf); /*!< configuration information          */
 
@@ -1795,6 +1805,7 @@ struct mbedtls_ssl_context {
                                                   *   (the end is marked by in_len).   */
 #endif /* MBEDTLS_SSL_DTLS_CONNECTION_ID */
     unsigned char *MBEDTLS_PRIVATE(in_len);      /*!< two-bytes message length field   */
+    mbedtls_ssl_context_in_ext *MBEDTLS_PRIVATE(in_ext); /*!< extension structure      */
     unsigned char *MBEDTLS_PRIVATE(in_iv);       /*!< ivlen-byte IV                    */
     unsigned char *MBEDTLS_PRIVATE(in_msg);      /*!< message contents (in_iv+ivlen)   */
     unsigned char *MBEDTLS_PRIVATE(in_offt);     /*!< read offset in application data  */

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -409,6 +409,11 @@ uint32_t mbedtls_ssl_get_extension_mask(unsigned int extension_type);
 #define MBEDTLS_CLIENT_HELLO_RANDOM_LEN 32
 #define MBEDTLS_SERVER_HELLO_RANDOM_LEN 32
 
+static inline mbedtls_ssl_context_in_ext *mbedtls_ssl_get_in_ext(const mbedtls_ssl_context *ssl)
+{
+    return (mbedtls_ssl_context_in_ext *) ssl->in_ext;
+}
+
 #if defined(MBEDTLS_SSL_MAX_FRAGMENT_LENGTH)
 /**
  * \brief          Return the maximum fragment length (payload, in bytes) for

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -1831,15 +1831,10 @@ MBEDTLS_CHECK_RETURN_CRITICAL
 int mbedtls_ssl_check_timer(mbedtls_ssl_context *ssl);
 
 void mbedtls_ssl_reset_in_pointers(mbedtls_ssl_context *ssl);
+void mbedtls_ssl_update_in_pointers(mbedtls_ssl_context *ssl);
 void mbedtls_ssl_reset_out_pointers(mbedtls_ssl_context *ssl);
-static inline void mbedtls_ssl_reset_in_out_pointers(mbedtls_ssl_context *ssl)
-{
-    mbedtls_ssl_reset_in_pointers(ssl);
-    mbedtls_ssl_reset_out_pointers(ssl);
-}
 void mbedtls_ssl_update_out_pointers(mbedtls_ssl_context *ssl,
                                      mbedtls_ssl_transform *transform);
-void mbedtls_ssl_update_in_pointers(mbedtls_ssl_context *ssl);
 
 MBEDTLS_CHECK_RETURN_CRITICAL
 int mbedtls_ssl_session_reset_int(mbedtls_ssl_context *ssl, int partial);

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -1830,7 +1830,13 @@ void mbedtls_ssl_set_timer(mbedtls_ssl_context *ssl, uint32_t millisecs);
 MBEDTLS_CHECK_RETURN_CRITICAL
 int mbedtls_ssl_check_timer(mbedtls_ssl_context *ssl);
 
-void mbedtls_ssl_reset_in_out_pointers(mbedtls_ssl_context *ssl);
+void mbedtls_ssl_reset_in_pointers(mbedtls_ssl_context *ssl);
+void mbedtls_ssl_reset_out_pointers(mbedtls_ssl_context *ssl);
+static inline void mbedtls_ssl_reset_in_out_pointers(mbedtls_ssl_context *ssl)
+{
+    mbedtls_ssl_reset_in_pointers(ssl);
+    mbedtls_ssl_reset_out_pointers(ssl);
+}
 void mbedtls_ssl_update_out_pointers(mbedtls_ssl_context *ssl,
                                      mbedtls_ssl_transform *transform);
 void mbedtls_ssl_update_in_pointers(mbedtls_ssl_context *ssl);

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -3226,7 +3226,11 @@ int mbedtls_ssl_prepare_handshake_record(mbedtls_ssl_context *ssl)
         return MBEDTLS_ERR_SSL_INVALID_RECORD;
     }
 
-    ssl->in_hslen = mbedtls_ssl_hs_hdr_len(ssl) + ssl_get_hs_total_len(ssl);
+    if (ssl->in_hslen == 0) {
+        ssl->in_hslen = mbedtls_ssl_hs_hdr_len(ssl) + ssl_get_hs_total_len(ssl);
+        ssl->in_hsfraglen = 0;
+        ssl->in_hshdr = ssl->in_hdr;
+    }
 
     MBEDTLS_SSL_DEBUG_MSG(3, ("handshake message: msglen ="
                               " %" MBEDTLS_PRINTF_SIZET ", type = %u, hslen = %"
@@ -3292,10 +3296,59 @@ int mbedtls_ssl_prepare_handshake_record(mbedtls_ssl_context *ssl)
         }
     } else
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
-    /* With TLS we don't handle fragmentation (for now) */
-    if (ssl->in_msglen < ssl->in_hslen) {
-        MBEDTLS_SSL_DEBUG_MSG(1, ("TLS handshake fragmentation not supported"));
-        return MBEDTLS_ERR_SSL_FEATURE_UNAVAILABLE;
+    {
+        int ret;
+        const size_t hs_remain = ssl->in_hslen - ssl->in_hsfraglen;
+        const size_t msg_hslen = (hs_remain <= ssl->in_msglen ? hs_remain : ssl->in_msglen);
+
+        MBEDTLS_SSL_DEBUG_MSG(3,
+                              ("handshake fragment: %" MBEDTLS_PRINTF_SIZET " .. %"
+                               MBEDTLS_PRINTF_SIZET " of %"
+                               MBEDTLS_PRINTF_SIZET " msglen %" MBEDTLS_PRINTF_SIZET,
+                               ssl->in_hsfraglen, ssl->in_hsfraglen + msg_hslen,
+                               ssl->in_hslen, ssl->in_msglen));
+        (void) msg_hslen;
+        if (ssl->in_msglen < hs_remain) {
+            ssl->in_hsfraglen += ssl->in_msglen;
+            ssl->in_hdr = ssl->in_msg + ssl->in_msglen;
+            ssl->in_msglen = 0;
+            mbedtls_ssl_update_in_pointers(ssl);
+            return MBEDTLS_ERR_SSL_CONTINUE_PROCESSING;
+        }
+        if (ssl->in_hshdr != ssl->in_hdr) {
+            /*
+             * At ssl->in_hshdr we have a sequence of records that cover the next handshake
+             * record, each with its own record header that we need to remove.
+             * Note that the reassembled record size may not equal the size of the message,
+             * there maybe bytes from the next message following it.
+             */
+            size_t merged_rec_len = 0;
+            unsigned char *p = ssl->in_hshdr, *q = NULL;
+            do {
+                mbedtls_record rec;
+                ret = ssl_parse_record_header(ssl, p, mbedtls_ssl_in_hdr_len(ssl), &rec);
+                if (ret != 0) {
+                    return ret;
+                }
+                merged_rec_len += rec.data_len;
+                p = rec.buf + rec.buf_len;
+                if (q != NULL) {
+                    memmove(q, rec.buf + rec.data_offset, rec.data_len);
+                    q += rec.data_len;
+                } else {
+                    q = p;
+                }
+            } while (merged_rec_len < ssl->in_hslen);
+            ssl->in_hdr = ssl->in_hshdr;
+            mbedtls_ssl_update_in_pointers(ssl);
+            ssl->in_msglen = merged_rec_len;
+            /* Adjust message length. */
+            MBEDTLS_PUT_UINT16_BE(merged_rec_len, ssl->in_len, 0);
+            ssl->in_hsfraglen = 0;
+            ssl->in_hshdr = NULL;
+            MBEDTLS_SSL_DEBUG_BUF(4, "reassembled record",
+                                  ssl->in_hdr, mbedtls_ssl_in_hdr_len(ssl) + merged_rec_len);
+        }
     }
 
     return 0;
@@ -4640,6 +4693,16 @@ static int ssl_consume_current_message(mbedtls_ssl_context *ssl)
             return MBEDTLS_ERR_SSL_INTERNAL_ERROR;
         }
 
+        if (ssl->in_hsfraglen != 0) {
+            /* Not all handshake fragments have arrived, do not consume. */
+            MBEDTLS_SSL_DEBUG_MSG(3,
+                                  ("waiting for more fragments (%" MBEDTLS_PRINTF_SIZET " of %"
+                                   MBEDTLS_PRINTF_SIZET ", %" MBEDTLS_PRINTF_SIZET " left)",
+                                   ssl->in_hsfraglen, ssl->in_hslen,
+                                   ssl->in_hslen - ssl->in_hsfraglen));
+            return 0;
+        }
+
         /*
          * Get next Handshake message in the current record
          */
@@ -4665,6 +4728,7 @@ static int ssl_consume_current_message(mbedtls_ssl_context *ssl)
             ssl->in_msglen -= ssl->in_hslen;
             memmove(ssl->in_msg, ssl->in_msg + ssl->in_hslen,
                     ssl->in_msglen);
+            MBEDTLS_PUT_UINT16_BE(ssl->in_msglen, ssl->in_len, 0);
 
             MBEDTLS_SSL_DEBUG_BUF(4, "remaining content in record",
                                   ssl->in_msg, ssl->in_msglen);
@@ -5339,7 +5403,7 @@ void mbedtls_ssl_update_in_pointers(mbedtls_ssl_context *ssl)
     } else
 #endif
     {
-        ssl->in_ctr = ssl->in_hdr - MBEDTLS_SSL_SEQUENCE_NUMBER_LEN;
+        ssl->in_ctr = ssl->in_buf;
         ssl->in_len = ssl->in_hdr + 3;
 #if defined(MBEDTLS_SSL_DTLS_CONNECTION_ID)
         ssl->in_cid = ssl->in_len;
@@ -5355,24 +5419,35 @@ void mbedtls_ssl_update_in_pointers(mbedtls_ssl_context *ssl)
  * Setup an SSL context
  */
 
-void mbedtls_ssl_reset_in_out_pointers(mbedtls_ssl_context *ssl)
+void mbedtls_ssl_reset_in_pointers(mbedtls_ssl_context *ssl)
+{
+#if defined(MBEDTLS_SSL_PROTO_DTLS)
+    if (ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM) {
+        ssl->in_hdr = ssl->in_buf;
+    } else
+#endif
+    {
+        ssl->in_hdr = ssl->in_buf + MBEDTLS_SSL_SEQUENCE_NUMBER_LEN;
+    }
+
+    /* Derive other internal pointers. */
+    mbedtls_ssl_update_in_pointers(ssl);
+}
+
+void mbedtls_ssl_reset_out_pointers(mbedtls_ssl_context *ssl)
 {
     /* Set the incoming and outgoing record pointers. */
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
     if (ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM) {
         ssl->out_hdr = ssl->out_buf;
-        ssl->in_hdr  = ssl->in_buf;
     } else
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
     {
         ssl->out_ctr = ssl->out_buf;
-        ssl->out_hdr = ssl->out_buf + 8;
-        ssl->in_hdr  = ssl->in_buf  + 8;
+        ssl->out_hdr = ssl->out_buf + MBEDTLS_SSL_SEQUENCE_NUMBER_LEN;
     }
-
     /* Derive other internal pointers. */
     mbedtls_ssl_update_out_pointers(ssl, NULL /* no transform enabled */);
-    mbedtls_ssl_update_in_pointers(ssl);
 }
 
 /*

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -3229,8 +3229,8 @@ int mbedtls_ssl_prepare_handshake_record(mbedtls_ssl_context *ssl)
 
     if (ssl->in_hslen == 0) {
         ssl->in_hslen = mbedtls_ssl_hs_hdr_len(ssl) + ssl_get_hs_total_len(ssl);
-        ssl->in_ext->in_hsfraglen = 0;
-        ssl->in_ext->in_hshdr = ssl->in_hdr;
+        mbedtls_ssl_get_in_ext(ssl)->in_hsfraglen = 0;
+        mbedtls_ssl_get_in_ext(ssl)->in_hshdr = ssl->in_hdr;
     }
 
     MBEDTLS_SSL_DEBUG_MSG(3, ("handshake message: msglen ="
@@ -3298,35 +3298,35 @@ int mbedtls_ssl_prepare_handshake_record(mbedtls_ssl_context *ssl)
     } else
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
     {
-        if (ssl->in_ext->in_hsfraglen > ssl->in_hslen) {
+        if (mbedtls_ssl_get_in_ext(ssl)->in_hsfraglen > ssl->in_hslen) {
             return MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
         }
         int ret;
-        const size_t hs_remain = ssl->in_hslen - ssl->in_ext->in_hsfraglen;
+        const size_t hs_remain = ssl->in_hslen - mbedtls_ssl_get_in_ext(ssl)->in_hsfraglen;
         MBEDTLS_SSL_DEBUG_MSG(3,
                               ("handshake fragment: %" MBEDTLS_PRINTF_SIZET " .. %"
                                MBEDTLS_PRINTF_SIZET " of %"
                                MBEDTLS_PRINTF_SIZET " msglen %" MBEDTLS_PRINTF_SIZET,
-                               ssl->in_ext->in_hsfraglen,
-                               ssl->in_ext->in_hsfraglen +
+                               mbedtls_ssl_get_in_ext(ssl)->in_hsfraglen,
+                               mbedtls_ssl_get_in_ext(ssl)->in_hsfraglen +
                                (hs_remain <= ssl->in_msglen ? hs_remain : ssl->in_msglen),
                                ssl->in_hslen, ssl->in_msglen));
         if (ssl->in_msglen < hs_remain) {
-            ssl->in_ext->in_hsfraglen += ssl->in_msglen;
+            mbedtls_ssl_get_in_ext(ssl)->in_hsfraglen += ssl->in_msglen;
             ssl->in_hdr = ssl->in_msg + ssl->in_msglen;
             ssl->in_msglen = 0;
             mbedtls_ssl_update_in_pointers(ssl);
             return MBEDTLS_ERR_SSL_CONTINUE_PROCESSING;
         }
-        if (ssl->in_ext->in_hshdr != ssl->in_hdr) {
+        if (mbedtls_ssl_get_in_ext(ssl)->in_hshdr != ssl->in_hdr) {
             /*
-             * At ssl->in_ext->in_hshdr we have a sequence of records that cover the next handshake
+             * At mbedtls_ssl_get_in_ext(ssl)->in_hshdr we have a sequence of records that cover the next handshake
              * record, each with its own record header that we need to remove.
              * Note that the reassembled record size may not equal the size of the message,
              * there maybe bytes from the next message following it.
              */
             size_t merged_rec_len = 0;
-            unsigned char *p = ssl->in_ext->in_hshdr, *q = NULL;
+            unsigned char *p = mbedtls_ssl_get_in_ext(ssl)->in_hshdr, *q = NULL;
             do {
                 mbedtls_record rec;
                 ret = ssl_parse_record_header(ssl, p, mbedtls_ssl_in_hdr_len(ssl), &rec);
@@ -3342,13 +3342,13 @@ int mbedtls_ssl_prepare_handshake_record(mbedtls_ssl_context *ssl)
                     q = p;
                 }
             } while (merged_rec_len < ssl->in_hslen);
-            ssl->in_hdr = ssl->in_ext->in_hshdr;
+            ssl->in_hdr = mbedtls_ssl_get_in_ext(ssl)->in_hshdr;
             mbedtls_ssl_update_in_pointers(ssl);
             ssl->in_msglen = merged_rec_len;
             /* Adjust message length. */
             MBEDTLS_PUT_UINT16_BE(merged_rec_len, ssl->in_len, 0);
-            ssl->in_ext->in_hsfraglen = 0;
-            ssl->in_ext->in_hshdr = NULL;
+            mbedtls_ssl_get_in_ext(ssl)->in_hsfraglen = 0;
+            mbedtls_ssl_get_in_ext(ssl)->in_hshdr = NULL;
             MBEDTLS_SSL_DEBUG_BUF(4, "reassembled record",
                                   ssl->in_hdr, mbedtls_ssl_in_hdr_len(ssl) + merged_rec_len);
         }
@@ -4696,13 +4696,13 @@ static int ssl_consume_current_message(mbedtls_ssl_context *ssl)
             return MBEDTLS_ERR_SSL_INTERNAL_ERROR;
         }
 
-        if (ssl->in_ext->in_hsfraglen != 0) {
+        if (mbedtls_ssl_get_in_ext(ssl)->in_hsfraglen != 0) {
             /* Not all handshake fragments have arrived, do not consume. */
             MBEDTLS_SSL_DEBUG_MSG(3,
                                   ("waiting for more fragments (%" MBEDTLS_PRINTF_SIZET " of %"
                                    MBEDTLS_PRINTF_SIZET ", %" MBEDTLS_PRINTF_SIZET " left)",
-                                   ssl->in_ext->in_hsfraglen, ssl->in_hslen,
-                                   ssl->in_hslen - ssl->in_ext->in_hsfraglen));
+                                   mbedtls_ssl_get_in_ext(ssl)->in_hsfraglen, ssl->in_hslen,
+                                   ssl->in_hslen - mbedtls_ssl_get_in_ext(ssl)->in_hsfraglen));
             return 0;
         }
 
@@ -4955,7 +4955,7 @@ static int ssl_get_next_record(mbedtls_ssl_context *ssl)
 #if defined(MBEDTLS_SSL_DTLS_CONNECTION_ID)
                 ssl->in_len = ssl->in_cid + rec.cid_len;
 #endif /* MBEDTLS_SSL_DTLS_CONNECTION_ID */
-                ssl->in_ext->in_iv  = ssl->in_msg = ssl->in_len + 2;
+                mbedtls_ssl_get_in_ext(ssl)->in_iv  = ssl->in_msg = ssl->in_len + 2;
                 ssl->in_msglen = rec.data_len;
 
                 ret = ssl_check_client_reconnect(ssl);
@@ -5074,7 +5074,7 @@ static int ssl_get_next_record(mbedtls_ssl_context *ssl)
 #if defined(MBEDTLS_SSL_DTLS_CONNECTION_ID)
     ssl->in_len = ssl->in_cid + rec.cid_len;
 #endif /* MBEDTLS_SSL_DTLS_CONNECTION_ID */
-    ssl->in_ext->in_iv  = ssl->in_len + 2;
+    mbedtls_ssl_get_in_ext(ssl)->in_iv  = ssl->in_len + 2;
 
     /* The record content type may change during decryption,
      * so re-read it. */
@@ -5380,7 +5380,7 @@ void mbedtls_ssl_update_out_pointers(mbedtls_ssl_context *ssl,
 void mbedtls_ssl_update_in_pointers(mbedtls_ssl_context *ssl)
 {
     /* This function sets the pointers to match the case
-     * of unprotected TLS/DTLS records, with both  ssl->in_ext->in_iv
+     * of unprotected TLS/DTLS records, with both  mbedtls_ssl_get_in_ext(ssl)->in_iv
      * and ssl->in_msg pointing to the beginning of the record
      * content.
      *
@@ -5402,7 +5402,7 @@ void mbedtls_ssl_update_in_pointers(mbedtls_ssl_context *ssl)
 #else /* MBEDTLS_SSL_DTLS_CONNECTION_ID */
         ssl->in_len = ssl->in_ctr + MBEDTLS_SSL_SEQUENCE_NUMBER_LEN;
 #endif /* MBEDTLS_SSL_DTLS_CONNECTION_ID */
-        ssl->in_ext->in_iv  = ssl->in_len + 2;
+        mbedtls_ssl_get_in_ext(ssl)->in_iv  = ssl->in_len + 2;
     } else
 #endif
     {
@@ -5411,11 +5411,11 @@ void mbedtls_ssl_update_in_pointers(mbedtls_ssl_context *ssl)
 #if defined(MBEDTLS_SSL_DTLS_CONNECTION_ID)
         ssl->in_cid = ssl->in_len;
 #endif
-        ssl->in_ext->in_iv  = ssl->in_hdr + 5;
+        mbedtls_ssl_get_in_ext(ssl)->in_iv  = ssl->in_hdr + 5;
     }
 
     /* This will be adjusted at record decryption time. */
-    ssl->in_msg = ssl->in_ext->in_iv;
+    ssl->in_msg = mbedtls_ssl_get_in_ext(ssl)->in_iv;
 }
 
 /*

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -3220,7 +3220,8 @@ static uint32_t ssl_get_hs_total_len(mbedtls_ssl_context const *ssl)
 
 int mbedtls_ssl_prepare_handshake_record(mbedtls_ssl_context *ssl)
 {
-    if (ssl->in_msglen < mbedtls_ssl_hs_hdr_len(ssl)) {
+    /* First handshake fragment must at least include the header. */
+    if (ssl->in_msglen < mbedtls_ssl_hs_hdr_len(ssl) && ssl->in_hslen == 0) {
         MBEDTLS_SSL_DEBUG_MSG(1, ("handshake message too short: %" MBEDTLS_PRINTF_SIZET,
                                   ssl->in_msglen));
         return MBEDTLS_ERR_SSL_INVALID_RECORD;

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -3299,15 +3299,14 @@ int mbedtls_ssl_prepare_handshake_record(mbedtls_ssl_context *ssl)
     {
         int ret;
         const size_t hs_remain = ssl->in_hslen - ssl->in_hsfraglen;
-        const size_t msg_hslen = (hs_remain <= ssl->in_msglen ? hs_remain : ssl->in_msglen);
-
         MBEDTLS_SSL_DEBUG_MSG(3,
                               ("handshake fragment: %" MBEDTLS_PRINTF_SIZET " .. %"
                                MBEDTLS_PRINTF_SIZET " of %"
                                MBEDTLS_PRINTF_SIZET " msglen %" MBEDTLS_PRINTF_SIZET,
-                               ssl->in_hsfraglen, ssl->in_hsfraglen + msg_hslen,
+                               ssl->in_hsfraglen,
+                               ssl->in_hsfraglen +
+                               (hs_remain <= ssl->in_msglen ? hs_remain : ssl->in_msglen),
                                ssl->in_hslen, ssl->in_msglen));
-        (void) msg_hslen;
         if (ssl->in_msglen < hs_remain) {
             ssl->in_hsfraglen += ssl->in_msglen;
             ssl->in_hdr = ssl->in_msg + ssl->in_msglen;
@@ -5425,7 +5424,7 @@ void mbedtls_ssl_reset_in_pointers(mbedtls_ssl_context *ssl)
     if (ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM) {
         ssl->in_hdr = ssl->in_buf;
     } else
-#endif
+#endif  /* MBEDTLS_SSL_PROTO_DTLS */
     {
         ssl->in_hdr = ssl->in_buf + MBEDTLS_SSL_SEQUENCE_NUMBER_LEN;
     }

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -4955,7 +4955,7 @@ static int ssl_get_next_record(mbedtls_ssl_context *ssl)
 #if defined(MBEDTLS_SSL_DTLS_CONNECTION_ID)
                 ssl->in_len = ssl->in_cid + rec.cid_len;
 #endif /* MBEDTLS_SSL_DTLS_CONNECTION_ID */
-                ssl->in_iv  = ssl->in_msg = ssl->in_len + 2;
+                ssl->in_ext->in_iv  = ssl->in_msg = ssl->in_len + 2;
                 ssl->in_msglen = rec.data_len;
 
                 ret = ssl_check_client_reconnect(ssl);
@@ -5074,7 +5074,7 @@ static int ssl_get_next_record(mbedtls_ssl_context *ssl)
 #if defined(MBEDTLS_SSL_DTLS_CONNECTION_ID)
     ssl->in_len = ssl->in_cid + rec.cid_len;
 #endif /* MBEDTLS_SSL_DTLS_CONNECTION_ID */
-    ssl->in_iv  = ssl->in_len + 2;
+    ssl->in_ext->in_iv  = ssl->in_len + 2;
 
     /* The record content type may change during decryption,
      * so re-read it. */
@@ -5380,7 +5380,7 @@ void mbedtls_ssl_update_out_pointers(mbedtls_ssl_context *ssl,
 void mbedtls_ssl_update_in_pointers(mbedtls_ssl_context *ssl)
 {
     /* This function sets the pointers to match the case
-     * of unprotected TLS/DTLS records, with both  ssl->in_iv
+     * of unprotected TLS/DTLS records, with both  ssl->in_ext->in_iv
      * and ssl->in_msg pointing to the beginning of the record
      * content.
      *
@@ -5402,7 +5402,7 @@ void mbedtls_ssl_update_in_pointers(mbedtls_ssl_context *ssl)
 #else /* MBEDTLS_SSL_DTLS_CONNECTION_ID */
         ssl->in_len = ssl->in_ctr + MBEDTLS_SSL_SEQUENCE_NUMBER_LEN;
 #endif /* MBEDTLS_SSL_DTLS_CONNECTION_ID */
-        ssl->in_iv  = ssl->in_len + 2;
+        ssl->in_ext->in_iv  = ssl->in_len + 2;
     } else
 #endif
     {
@@ -5411,11 +5411,11 @@ void mbedtls_ssl_update_in_pointers(mbedtls_ssl_context *ssl)
 #if defined(MBEDTLS_SSL_DTLS_CONNECTION_ID)
         ssl->in_cid = ssl->in_len;
 #endif
-        ssl->in_iv  = ssl->in_hdr + 5;
+        ssl->in_ext->in_iv  = ssl->in_hdr + 5;
     }
 
     /* This will be adjusted at record decryption time. */
-    ssl->in_msg = ssl->in_iv;
+    ssl->in_msg = ssl->in_ext->in_iv;
 }
 
 /*

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -3298,6 +3298,9 @@ int mbedtls_ssl_prepare_handshake_record(mbedtls_ssl_context *ssl)
     } else
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
     {
+        if (ssl->in_hsfraglen > ssl->in_hslen) {
+            return MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
+        }
         int ret;
         const size_t hs_remain = ssl->in_hslen - ssl->in_hsfraglen;
         MBEDTLS_SSL_DEBUG_MSG(3,

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -352,8 +352,8 @@ static void handle_buffer_resizing(mbedtls_ssl_context *ssl, int downsizing,
         iv_offset_in = ssl->in_ext->in_iv - ssl->in_buf;
         len_offset_in = ssl->in_len - ssl->in_buf;
         hdr_in = ssl->in_hdr - ssl->in_buf;
-        if (ssl->in_hshdr != NULL) {
-            hshdr_in = ssl->in_hshdr - ssl->in_buf;
+        if (ssl->in_ext->in_hshdr != NULL) {
+            hshdr_in = ssl->in_ext->in_hshdr - ssl->in_buf;
         }
         if (downsizing ?
             ssl->in_buf_len > in_buf_new_len && ssl->in_left < in_buf_new_len :
@@ -399,8 +399,8 @@ static void handle_buffer_resizing(mbedtls_ssl_context *ssl, int downsizing,
         ssl->in_msg = ssl->in_buf + written_in;
         ssl->in_len = ssl->in_buf + len_offset_in;
         ssl->in_ext->in_iv = ssl->in_buf + iv_offset_in;
-        if (ssl->in_hshdr != NULL) {
-            ssl->in_hshdr = ssl->in_buf + hshdr_in;
+        if (ssl->in_ext->in_hshdr != NULL) {
+            ssl->in_ext->in_hshdr = ssl->in_buf + hshdr_in;
         }
     }
 }
@@ -1507,8 +1507,8 @@ void mbedtls_ssl_session_reset_msg_layer(mbedtls_ssl_context *ssl,
     ssl->in_hslen   = 0;
     ssl->keep_current_message = 0;
     ssl->transform_in  = NULL;
-    ssl->in_hshdr = NULL;
-    ssl->in_hsfraglen = 0;
+    ssl->in_ext->in_hshdr = NULL;
+    ssl->in_ext->in_hsfraglen = 0;
 
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
     ssl->next_record_offset = 0;

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1409,6 +1409,14 @@ int mbedtls_ssl_setup(mbedtls_ssl_context *ssl,
         ret = MBEDTLS_ERR_SSL_ALLOC_FAILED;
         goto error;
     }
+    ssl->in_ext = mbedtls_calloc(1, sizeof(mbedtls_ssl_context_in_ext));
+    if (ssl->in_ext == NULL) {
+        MBEDTLS_SSL_DEBUG_MSG(1,
+                              ("alloc(%" MBEDTLS_PRINTF_SIZET " bytes) failed",
+                               sizeof(mbedtls_ssl_context_in_ext)));
+        ret = MBEDTLS_ERR_SSL_ALLOC_FAILED;
+        goto error;
+    }
 
 #if defined(MBEDTLS_SSL_VARIABLE_BUFFER_LENGTH)
     ssl->out_buf_len = out_buf_len;
@@ -1435,6 +1443,7 @@ int mbedtls_ssl_setup(mbedtls_ssl_context *ssl,
 
 error:
     mbedtls_free(ssl->in_buf);
+    mbedtls_free(ssl->in_ext);
     mbedtls_free(ssl->out_buf);
 
     ssl->conf = NULL;
@@ -1444,6 +1453,7 @@ error:
     ssl->out_buf_len = 0;
 #endif
     ssl->in_buf = NULL;
+    ssl->in_ext = NULL;
     ssl->out_buf = NULL;
 
     ssl->in_hdr = NULL;
@@ -5555,6 +5565,11 @@ void mbedtls_ssl_free(mbedtls_ssl_context *ssl)
 
         mbedtls_zeroize_and_free(ssl->in_buf, in_buf_len);
         ssl->in_buf = NULL;
+    }
+
+    if (ssl->in_ext != NULL) {
+        mbedtls_free(ssl->in_ext);
+        ssl->in_ext = NULL;
     }
 
     if (ssl->transform) {

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -349,7 +349,7 @@ static void handle_buffer_resizing(mbedtls_ssl_context *ssl, int downsizing,
     size_t hshdr_in = 0;
     if (ssl->in_buf != NULL) {
         written_in = ssl->in_msg - ssl->in_buf;
-        iv_offset_in = ssl->in_iv - ssl->in_buf;
+        iv_offset_in = ssl->in_ext->in_iv - ssl->in_buf;
         len_offset_in = ssl->in_len - ssl->in_buf;
         hdr_in = ssl->in_hdr - ssl->in_buf;
         if (ssl->in_hshdr != NULL) {
@@ -398,7 +398,7 @@ static void handle_buffer_resizing(mbedtls_ssl_context *ssl, int downsizing,
 
         ssl->in_msg = ssl->in_buf + written_in;
         ssl->in_len = ssl->in_buf + len_offset_in;
-        ssl->in_iv = ssl->in_buf + iv_offset_in;
+        ssl->in_ext->in_iv = ssl->in_buf + iv_offset_in;
         if (ssl->in_hshdr != NULL) {
             ssl->in_hshdr = ssl->in_buf + hshdr_in;
         }
@@ -1459,7 +1459,7 @@ error:
     ssl->in_hdr = NULL;
     ssl->in_ctr = NULL;
     ssl->in_len = NULL;
-    ssl->in_iv = NULL;
+    ssl->in_ext->in_iv = NULL;
     ssl->in_msg = NULL;
 
     ssl->out_hdr = NULL;

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -344,12 +344,17 @@ static void handle_buffer_resizing(mbedtls_ssl_context *ssl, int downsizing,
                                    size_t out_buf_new_len)
 {
     int modified = 0;
-    size_t written_in = 0, iv_offset_in = 0, len_offset_in = 0;
+    size_t written_in = 0, iv_offset_in = 0, len_offset_in = 0, hdr_in = 0;
     size_t written_out = 0, iv_offset_out = 0, len_offset_out = 0;
+    size_t hshdr_in = 0;
     if (ssl->in_buf != NULL) {
         written_in = ssl->in_msg - ssl->in_buf;
         iv_offset_in = ssl->in_iv - ssl->in_buf;
         len_offset_in = ssl->in_len - ssl->in_buf;
+        hdr_in = ssl->in_hdr - ssl->in_buf;
+        if (ssl->in_hshdr != NULL) {
+            hshdr_in = ssl->in_hshdr - ssl->in_buf;
+        }
         if (downsizing ?
             ssl->in_buf_len > in_buf_new_len && ssl->in_left < in_buf_new_len :
             ssl->in_buf_len < in_buf_new_len) {
@@ -381,7 +386,10 @@ static void handle_buffer_resizing(mbedtls_ssl_context *ssl, int downsizing,
     }
     if (modified) {
         /* Update pointers here to avoid doing it twice. */
-        mbedtls_ssl_reset_in_out_pointers(ssl);
+        ssl->in_hdr = ssl->in_buf + hdr_in;
+        mbedtls_ssl_update_in_pointers(ssl);
+        mbedtls_ssl_reset_out_pointers(ssl);
+
         /* Fields below might not be properly updated with record
          * splitting or with CID, so they are manually updated here. */
         ssl->out_msg = ssl->out_buf + written_out;
@@ -391,6 +399,9 @@ static void handle_buffer_resizing(mbedtls_ssl_context *ssl, int downsizing,
         ssl->in_msg = ssl->in_buf + written_in;
         ssl->in_len = ssl->in_buf + len_offset_in;
         ssl->in_iv = ssl->in_buf + iv_offset_in;
+        if (ssl->in_hshdr != NULL) {
+            ssl->in_hshdr = ssl->in_buf + hshdr_in;
+        }
     }
 }
 #endif /* MBEDTLS_SSL_VARIABLE_BUFFER_LENGTH */
@@ -1484,6 +1495,8 @@ void mbedtls_ssl_session_reset_msg_layer(mbedtls_ssl_context *ssl,
     ssl->in_hslen   = 0;
     ssl->keep_current_message = 0;
     ssl->transform_in  = NULL;
+    ssl->in_hshdr = NULL;
+    ssl->in_hsfraglen = 0;
 
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
     ssl->next_record_offset = 0;

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -349,11 +349,11 @@ static void handle_buffer_resizing(mbedtls_ssl_context *ssl, int downsizing,
     size_t hshdr_in = 0;
     if (ssl->in_buf != NULL) {
         written_in = ssl->in_msg - ssl->in_buf;
-        iv_offset_in = ssl->in_ext->in_iv - ssl->in_buf;
+        iv_offset_in = mbedtls_ssl_get_in_ext(ssl)->in_iv - ssl->in_buf;
         len_offset_in = ssl->in_len - ssl->in_buf;
         hdr_in = ssl->in_hdr - ssl->in_buf;
-        if (ssl->in_ext->in_hshdr != NULL) {
-            hshdr_in = ssl->in_ext->in_hshdr - ssl->in_buf;
+        if (mbedtls_ssl_get_in_ext(ssl)->in_hshdr != NULL) {
+            hshdr_in = mbedtls_ssl_get_in_ext(ssl)->in_hshdr - ssl->in_buf;
         }
         if (downsizing ?
             ssl->in_buf_len > in_buf_new_len && ssl->in_left < in_buf_new_len :
@@ -398,9 +398,9 @@ static void handle_buffer_resizing(mbedtls_ssl_context *ssl, int downsizing,
 
         ssl->in_msg = ssl->in_buf + written_in;
         ssl->in_len = ssl->in_buf + len_offset_in;
-        ssl->in_ext->in_iv = ssl->in_buf + iv_offset_in;
-        if (ssl->in_ext->in_hshdr != NULL) {
-            ssl->in_ext->in_hshdr = ssl->in_buf + hshdr_in;
+        mbedtls_ssl_get_in_ext(ssl)->in_iv = ssl->in_buf + iv_offset_in;
+        if (mbedtls_ssl_get_in_ext(ssl)->in_hshdr != NULL) {
+            mbedtls_ssl_get_in_ext(ssl)->in_hshdr = ssl->in_buf + hshdr_in;
         }
     }
 }
@@ -1459,7 +1459,7 @@ error:
     ssl->in_hdr = NULL;
     ssl->in_ctr = NULL;
     ssl->in_len = NULL;
-    ssl->in_ext->in_iv = NULL;
+    mbedtls_ssl_get_in_ext(ssl)->in_iv = NULL;
     ssl->in_msg = NULL;
 
     ssl->out_hdr = NULL;
@@ -1507,8 +1507,8 @@ void mbedtls_ssl_session_reset_msg_layer(mbedtls_ssl_context *ssl,
     ssl->in_hslen   = 0;
     ssl->keep_current_message = 0;
     ssl->transform_in  = NULL;
-    ssl->in_ext->in_hshdr = NULL;
-    ssl->in_ext->in_hsfraglen = 0;
+    mbedtls_ssl_get_in_ext(ssl)->in_hshdr = NULL;
+    mbedtls_ssl_get_in_ext(ssl)->in_hsfraglen = 0;
 
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
     ssl->next_record_offset = 0;

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1420,7 +1420,8 @@ int mbedtls_ssl_setup(mbedtls_ssl_context *ssl,
         goto error;
     }
 
-    mbedtls_ssl_reset_in_out_pointers(ssl);
+    mbedtls_ssl_reset_in_pointers(ssl);
+    mbedtls_ssl_reset_out_pointers(ssl);
 
 #if defined(MBEDTLS_SSL_DTLS_SRTP)
     memset(&ssl->dtls_srtp_info, 0, sizeof(ssl->dtls_srtp_info));
@@ -1485,7 +1486,8 @@ void mbedtls_ssl_session_reset_msg_layer(mbedtls_ssl_context *ssl,
     /* Cancel any possibly running timer */
     mbedtls_ssl_set_timer(ssl, 0);
 
-    mbedtls_ssl_reset_in_out_pointers(ssl);
+    mbedtls_ssl_reset_in_pointers(ssl);
+    mbedtls_ssl_reset_out_pointers(ssl);
 
     /* Reset incoming message parsing */
     ssl->in_offt    = NULL;

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -1057,11 +1057,6 @@ read_record_header:
         MBEDTLS_SSL_DEBUG_MSG(1, ("bad client hello message"));
         return MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE;
     }
-    {
-        size_t handshake_len = MBEDTLS_GET_UINT24_BE(buf, 1);
-        MBEDTLS_SSL_DEBUG_MSG(3, ("client hello v3, handshake len.: %u",
-                                  (unsigned) handshake_len));
-    }
 
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
     if (ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM) {

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -1061,23 +1061,6 @@ read_record_header:
         size_t handshake_len = MBEDTLS_GET_UINT24_BE(buf, 1);
         MBEDTLS_SSL_DEBUG_MSG(3, ("client hello v3, handshake len.: %u",
                                   (unsigned) handshake_len));
-
-        /* The record layer has a record size limit of 2^14 - 1 and
-         * fragmentation is not supported, so buf[1] should be zero. */
-        if (buf[1] != 0) {
-            MBEDTLS_SSL_DEBUG_MSG(1, ("bad client hello message: %u != 0",
-                                      (unsigned) buf[1]));
-            return MBEDTLS_ERR_SSL_DECODE_ERROR;
-        }
-
-        /* We don't support fragmentation of ClientHello (yet?) */
-        if (msg_len != mbedtls_ssl_hs_hdr_len(ssl) + handshake_len) {
-            MBEDTLS_SSL_DEBUG_MSG(1, ("bad client hello message: %u != %u + %u",
-                                      (unsigned) msg_len,
-                                      (unsigned) mbedtls_ssl_hs_hdr_len(ssl),
-                                      (unsigned) handshake_len));
-            return MBEDTLS_ERR_SSL_DECODE_ERROR;
-        }
     }
 
 #if defined(MBEDTLS_SSL_PROTO_DTLS)

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14475,6 +14475,9 @@ run_test    "Client Handshake defragmentation (513)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
+# OpenSSL does not allow max_send_frag to be less than 512
+# so we use split_send_frag instead for tests lower than 512 below.
+
 requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (256)" \
             "$O_NEXT_SRV -split_send_frag 256 " \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14479,6 +14479,7 @@ run_test    "Client Handshake defragmentation (513)" \
 # so we use split_send_frag instead for tests lower than 512 below.
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Client Handshake defragmentation (256)" \
             "$O_NEXT_SRV -split_send_frag 256 " \
             "$P_CLI debug_level=4 " \
@@ -14487,6 +14488,7 @@ run_test    "Client Handshake defragmentation (256)" \
             -c "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Client Handshake defragmentation (128)" \
             "$O_NEXT_SRV -split_send_frag 128 " \
             "$P_CLI debug_level=4 " \
@@ -14495,6 +14497,7 @@ run_test    "Client Handshake defragmentation (128)" \
             -c "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Client Handshake defragmentation (64)" \
             "$O_NEXT_SRV -split_send_frag 64 " \
             "$P_CLI debug_level=4 " \
@@ -14503,6 +14506,7 @@ run_test    "Client Handshake defragmentation (64)" \
             -c "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Client Handshake defragmentation (36)" \
             "$O_NEXT_SRV -split_send_frag 36 " \
             "$P_CLI debug_level=4 " \
@@ -14511,6 +14515,7 @@ run_test    "Client Handshake defragmentation (36)" \
             -c "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Client Handshake defragmentation (32)" \
             "$O_NEXT_SRV -split_send_frag 32 " \
             "$P_CLI debug_level=4 " \
@@ -14519,6 +14524,7 @@ run_test    "Client Handshake defragmentation (32)" \
             -c "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Client Handshake defragmentation (16)" \
             "$O_NEXT_SRV -split_send_frag 16 " \
             "$P_CLI debug_level=4 " \
@@ -14527,6 +14533,7 @@ run_test    "Client Handshake defragmentation (16)" \
             -c "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Client Handshake defragmentation (13)" \
             "$O_NEXT_SRV -split_send_frag 13 " \
             "$P_CLI debug_level=4 " \
@@ -14535,6 +14542,7 @@ run_test    "Client Handshake defragmentation (13)" \
             -c "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Client Handshake defragmentation (5)" \
             "$O_NEXT_SRV -split_send_frag 5 " \
             "$P_CLI debug_level=4 " \
@@ -14543,6 +14551,7 @@ run_test    "Client Handshake defragmentation (5)" \
             -c "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Server Handshake defragmentation (512)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -max_send_frag 512 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14551,6 +14560,7 @@ run_test    "Server Handshake defragmentation (512)" \
             -s "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Server Handshake defragmentation (513)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -max_send_frag 513 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14559,6 +14569,7 @@ run_test    "Server Handshake defragmentation (513)" \
             -s "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Server Handshake defragmentation (256)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 256 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14567,6 +14578,7 @@ run_test    "Server Handshake defragmentation (256)" \
             -s "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Server Handshake defragmentation (128)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 128 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14575,6 +14587,7 @@ run_test    "Server Handshake defragmentation (128)" \
             -s "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Server Handshake defragmentation (64)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 64 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14583,6 +14596,7 @@ run_test    "Server Handshake defragmentation (64)" \
             -s "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Server Handshake defragmentation (36)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 36 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14591,6 +14605,7 @@ run_test    "Server Handshake defragmentation (36)" \
             -s "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Server Handshake defragmentation (32)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 32 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14599,6 +14614,7 @@ run_test    "Server Handshake defragmentation (32)" \
             -s "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Server Handshake defragmentation (16)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 16 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14607,6 +14623,7 @@ run_test    "Server Handshake defragmentation (16)" \
             -s "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Server Handshake defragmentation (13)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 13 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14615,6 +14632,7 @@ run_test    "Server Handshake defragmentation (13)" \
             -s "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Server Handshake defragmentation (5)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 5 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14459,6 +14459,7 @@ run_test    "TLS 1.2 ClientHello indicating support for deflate compression meth
 
 # Handshake defragmentation testing
 
+requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (512)" \
             "$O_NEXT_SRV -max_send_frag 512 " \
             "$P_CLI debug_level=4 " \
@@ -14466,6 +14467,7 @@ run_test    "Client Handshake defragmentation (512)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (513)" \
             "$O_NEXT_SRV -max_send_frag 513 " \
             "$P_CLI debug_level=4 " \
@@ -14473,6 +14475,7 @@ run_test    "Client Handshake defragmentation (513)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (256)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 256 " \
             "$P_CLI debug_level=4 " \
@@ -14480,6 +14483,7 @@ run_test    "Client Handshake defragmentation (256)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (128)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 128 " \
             "$P_CLI debug_level=4 " \
@@ -14487,6 +14491,7 @@ run_test    "Client Handshake defragmentation (128)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (64)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 64 " \
             "$P_CLI debug_level=4 " \
@@ -14494,6 +14499,7 @@ run_test    "Client Handshake defragmentation (64)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (36)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 36 " \
             "$P_CLI debug_level=4 " \
@@ -14501,6 +14507,7 @@ run_test    "Client Handshake defragmentation (36)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (32)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 32 " \
             "$P_CLI debug_level=4 " \
@@ -14508,6 +14515,7 @@ run_test    "Client Handshake defragmentation (32)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (16)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 16 " \
             "$P_CLI debug_level=4 " \
@@ -14515,7 +14523,7 @@ run_test    "Client Handshake defragmentation (16)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
-
+requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (13)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 13 " \
             "$P_CLI debug_level=4 " \
@@ -14523,6 +14531,7 @@ run_test    "Client Handshake defragmentation (13)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (5)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 5 " \
             "$P_CLI debug_level=4 " \
@@ -14530,6 +14539,7 @@ run_test    "Client Handshake defragmentation (5)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (512)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -max_send_frag 512 " \
@@ -14537,6 +14547,7 @@ run_test    "Server Handshake defragmentation (512)" \
             -s "<= handshake" \
             -s "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (513)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -max_send_frag 513 " \
@@ -14544,6 +14555,7 @@ run_test    "Server Handshake defragmentation (513)" \
             -s "<= handshake" \
             -s "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (256)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 256 " \
@@ -14551,6 +14563,7 @@ run_test    "Server Handshake defragmentation (256)" \
             -s "<= handshake" \
             -s "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (128)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 128 " \
@@ -14558,6 +14571,7 @@ run_test    "Server Handshake defragmentation (128)" \
             -s "<= handshake" \
             -s "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (64)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 64 " \
@@ -14565,6 +14579,7 @@ run_test    "Server Handshake defragmentation (64)" \
             -s "<= handshake" \
             -s "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (36)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 36 " \
@@ -14572,6 +14587,7 @@ run_test    "Server Handshake defragmentation (36)" \
             -s "<= handshake" \
             -s "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (32)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 32 " \
@@ -14579,6 +14595,7 @@ run_test    "Server Handshake defragmentation (32)" \
             -s "<= handshake" \
             -s "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (16)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 16 " \
@@ -14586,6 +14603,7 @@ run_test    "Server Handshake defragmentation (16)" \
             -s "<= handshake" \
             -s "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (13)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 13 " \
@@ -14593,6 +14611,7 @@ run_test    "Server Handshake defragmentation (13)" \
             -s "<= handshake" \
             -s "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (5)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 5 " \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14477,7 +14477,7 @@ run_test    "Client Handshake defragmentation (513)" \
 
 requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (256)" \
-            "$O_NEXT_SRV -mtu 32 -split_send_frag 256 " \
+            "$O_NEXT_SRV -split_send_frag 256 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "<= handshake" \
@@ -14485,7 +14485,7 @@ run_test    "Client Handshake defragmentation (256)" \
 
 requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (128)" \
-            "$O_NEXT_SRV -mtu 32 -split_send_frag 128 " \
+            "$O_NEXT_SRV -split_send_frag 128 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "<= handshake" \
@@ -14493,7 +14493,7 @@ run_test    "Client Handshake defragmentation (128)" \
 
 requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (64)" \
-            "$O_NEXT_SRV -mtu 32 -split_send_frag 64 " \
+            "$O_NEXT_SRV -split_send_frag 64 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "<= handshake" \
@@ -14501,7 +14501,7 @@ run_test    "Client Handshake defragmentation (64)" \
 
 requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (36)" \
-            "$O_NEXT_SRV -mtu 32 -split_send_frag 36 " \
+            "$O_NEXT_SRV -split_send_frag 36 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "<= handshake" \
@@ -14509,7 +14509,7 @@ run_test    "Client Handshake defragmentation (36)" \
 
 requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (32)" \
-            "$O_NEXT_SRV -mtu 32 -split_send_frag 32 " \
+            "$O_NEXT_SRV -split_send_frag 32 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "<= handshake" \
@@ -14517,7 +14517,7 @@ run_test    "Client Handshake defragmentation (32)" \
 
 requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (16)" \
-            "$O_NEXT_SRV -mtu 32 -split_send_frag 16 " \
+            "$O_NEXT_SRV -split_send_frag 16 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "<= handshake" \
@@ -14525,7 +14525,7 @@ run_test    "Client Handshake defragmentation (16)" \
 
 requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (13)" \
-            "$O_NEXT_SRV -mtu 32 -split_send_frag 13 " \
+            "$O_NEXT_SRV -split_send_frag 13 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "<= handshake" \
@@ -14533,7 +14533,7 @@ run_test    "Client Handshake defragmentation (13)" \
 
 requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (5)" \
-            "$O_NEXT_SRV -mtu 32 -split_send_frag 5 " \
+            "$O_NEXT_SRV -split_send_frag 5 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "<= handshake" \
@@ -14558,7 +14558,7 @@ run_test    "Server Handshake defragmentation (513)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (256)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 256 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -split_send_frag 256 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -14566,7 +14566,7 @@ run_test    "Server Handshake defragmentation (256)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (128)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 128 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -split_send_frag 128 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -14574,7 +14574,7 @@ run_test    "Server Handshake defragmentation (128)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (64)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 64 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -split_send_frag 64 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -14582,7 +14582,7 @@ run_test    "Server Handshake defragmentation (64)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (36)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 36 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -split_send_frag 36 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -14590,7 +14590,7 @@ run_test    "Server Handshake defragmentation (36)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (32)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 32 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -split_send_frag 32 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -14598,7 +14598,7 @@ run_test    "Server Handshake defragmentation (32)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (16)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 16 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -split_send_frag 16 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -14606,7 +14606,7 @@ run_test    "Server Handshake defragmentation (16)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (13)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 13 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -split_send_frag 13 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -14614,7 +14614,7 @@ run_test    "Server Handshake defragmentation (13)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (5)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 5 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -split_send_frag 5 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14460,6 +14460,7 @@ run_test    "TLS 1.2 ClientHello indicating support for deflate compression meth
 # Handshake defragmentation testing
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Client Handshake defragmentation (512)" \
             "$O_NEXT_SRV -max_send_frag 512 " \
             "$P_CLI debug_level=4 " \
@@ -14468,6 +14469,7 @@ run_test    "Client Handshake defragmentation (512)" \
             -c "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Client Handshake defragmentation (513)" \
             "$O_NEXT_SRV -max_send_frag 513 " \
             "$P_CLI debug_level=4 " \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14542,7 +14542,7 @@ run_test    "Client Handshake defragmentation (5)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (512)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -max_send_frag 512 " \
+            "$O_NEXT_CLI -max_send_frag 512 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -14550,7 +14550,7 @@ run_test    "Server Handshake defragmentation (512)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (513)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -max_send_frag 513 " \
+            "$O_NEXT_CLI -max_send_frag 513 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -14558,7 +14558,7 @@ run_test    "Server Handshake defragmentation (513)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (256)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 256 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 256 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -14566,7 +14566,7 @@ run_test    "Server Handshake defragmentation (256)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (128)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 128 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 128 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -14574,7 +14574,7 @@ run_test    "Server Handshake defragmentation (128)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (64)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 64 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 64 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -14582,7 +14582,7 @@ run_test    "Server Handshake defragmentation (64)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (36)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 36 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 36 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -14590,7 +14590,7 @@ run_test    "Server Handshake defragmentation (36)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (32)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 32 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 32 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -14598,7 +14598,7 @@ run_test    "Server Handshake defragmentation (32)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (16)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 16 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 16 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -14606,7 +14606,7 @@ run_test    "Server Handshake defragmentation (16)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (13)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 13 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 13 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -14614,7 +14614,7 @@ run_test    "Server Handshake defragmentation (13)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (5)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 5 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 5 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14541,7 +14541,7 @@ run_test    "Client Handshake defragmentation (5)" \
 
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (512)" \
-            "$P_SRV debug_level=4 " \
+            "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -max_send_frag 512 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
@@ -14549,7 +14549,7 @@ run_test    "Server Handshake defragmentation (512)" \
 
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (513)" \
-            "$P_SRV debug_level=4 " \
+            "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -max_send_frag 513 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
@@ -14557,7 +14557,7 @@ run_test    "Server Handshake defragmentation (513)" \
 
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (256)" \
-            "$P_SRV debug_level=4 " \
+            "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 256 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
@@ -14565,7 +14565,7 @@ run_test    "Server Handshake defragmentation (256)" \
 
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (128)" \
-            "$P_SRV debug_level=4 " \
+            "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 128 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
@@ -14573,7 +14573,7 @@ run_test    "Server Handshake defragmentation (128)" \
 
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (64)" \
-            "$P_SRV debug_level=4 " \
+            "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 64 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
@@ -14581,7 +14581,7 @@ run_test    "Server Handshake defragmentation (64)" \
 
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (36)" \
-            "$P_SRV debug_level=4 " \
+            "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 36 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
@@ -14589,7 +14589,7 @@ run_test    "Server Handshake defragmentation (36)" \
 
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (32)" \
-            "$P_SRV debug_level=4 " \
+            "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 32 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
@@ -14597,7 +14597,7 @@ run_test    "Server Handshake defragmentation (32)" \
 
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (16)" \
-            "$P_SRV debug_level=4 " \
+            "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 16 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
@@ -14605,7 +14605,7 @@ run_test    "Server Handshake defragmentation (16)" \
 
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (13)" \
-            "$P_SRV debug_level=4 " \
+            "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 13 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
@@ -14613,7 +14613,7 @@ run_test    "Server Handshake defragmentation (13)" \
 
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (5)" \
-            "$P_SRV debug_level=4 " \
+            "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 5 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14459,7 +14459,7 @@ run_test    "TLS 1.2 ClientHello indicating support for deflate compression meth
 
 # Handshake defragmentation testing
 
-run_test    "Client Hanshake defragmentation (512)" \
+run_test    "Client Handshake defragmentation (512)" \
             "$O_NEXT_SRV -max_send_frag 512 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -14467,7 +14467,7 @@ run_test    "Client Hanshake defragmentation (512)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
-run_test    "Client Hanshake defragmentation (513)" \
+run_test    "Client Handshake defragmentation (513)" \
             "$O_NEXT_SRV -max_send_frag 513 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -14475,7 +14475,7 @@ run_test    "Client Hanshake defragmentation (513)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
-run_test    "Client Hanshake defragmentation (256)" \
+run_test    "Client Handshake defragmentation (256)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 256 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -14483,7 +14483,7 @@ run_test    "Client Hanshake defragmentation (256)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
-run_test    "Client Hanshake defragmentation (128)" \
+run_test    "Client Handshake defragmentation (128)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 128 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -14491,7 +14491,7 @@ run_test    "Client Hanshake defragmentation (128)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
-run_test    "Client Hanshake defragmentation (64)" \
+run_test    "Client Handshake defragmentation (64)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 64 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -14499,7 +14499,7 @@ run_test    "Client Hanshake defragmentation (64)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
-run_test    "Client Hanshake defragmentation (36)" \
+run_test    "Client Handshake defragmentation (36)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 36 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -14507,7 +14507,7 @@ run_test    "Client Hanshake defragmentation (36)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
-run_test    "Client Hanshake defragmentation (32)" \
+run_test    "Client Handshake defragmentation (32)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 32 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -14515,7 +14515,7 @@ run_test    "Client Hanshake defragmentation (32)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
-run_test    "Client Hanshake defragmentation (16)" \
+run_test    "Client Handshake defragmentation (16)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 16 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -14524,7 +14524,7 @@ run_test    "Client Hanshake defragmentation (16)" \
             -c "handshake fragment: "
 
 
-run_test    "Client Hanshake defragmentation (13)" \
+run_test    "Client Handshake defragmentation (13)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 13 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -14532,7 +14532,7 @@ run_test    "Client Hanshake defragmentation (13)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
-run_test    "Client Hanshake defragmentation (5)" \
+run_test    "Client Handshake defragmentation (5)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 5 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -14540,70 +14540,70 @@ run_test    "Client Hanshake defragmentation (5)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
-run_test    "Server Hanshake defragmentation (512)" \
+run_test    "Server Handshake defragmentation (512)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -max_send_frag 512 " \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
 
-run_test    "Server Hanshake defragmentation (513)" \
+run_test    "Server Handshake defragmentation (513)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -max_send_frag 513 " \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
 
-run_test    "Server Hanshake defragmentation (256)" \
+run_test    "Server Handshake defragmentation (256)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 256 " \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
 
-run_test    "Server Hanshake defragmentation (128)" \
+run_test    "Server Handshake defragmentation (128)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 128 " \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
 
-run_test    "Server Hanshake defragmentation (64)" \
+run_test    "Server Handshake defragmentation (64)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 64 " \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
 
-run_test    "Server Hanshake defragmentation (36)" \
+run_test    "Server Handshake defragmentation (36)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 36 " \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
 
-run_test    "Server Hanshake defragmentation (32)" \
+run_test    "Server Handshake defragmentation (32)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 32 " \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
 
-run_test    "Server Hanshake defragmentation (16)" \
+run_test    "Server Handshake defragmentation (16)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 16 " \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
 
-run_test    "Server Hanshake defragmentation (13)" \
+run_test    "Server Handshake defragmentation (13)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 13 " \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
 
-run_test    "Server Hanshake defragmentation (5)" \
+run_test    "Server Handshake defragmentation (5)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 5 " \
             0 \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14463,7 +14463,6 @@ run_test    "Client Handshake defragmentation (512)" \
             "$O_NEXT_SRV -max_send_frag 512 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "received ServerHello message" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
@@ -14471,7 +14470,6 @@ run_test    "Client Handshake defragmentation (513)" \
             "$O_NEXT_SRV -max_send_frag 513 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "received ServerHello message" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
@@ -14479,7 +14477,6 @@ run_test    "Client Handshake defragmentation (256)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 256 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "received ServerHello message" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
@@ -14487,7 +14484,6 @@ run_test    "Client Handshake defragmentation (128)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 128 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "received ServerHello message" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
@@ -14495,7 +14491,6 @@ run_test    "Client Handshake defragmentation (64)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 64 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "received ServerHello message" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
@@ -14503,7 +14498,6 @@ run_test    "Client Handshake defragmentation (36)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 36 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "received ServerHello message" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
@@ -14511,7 +14505,6 @@ run_test    "Client Handshake defragmentation (32)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 32 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "received ServerHello message" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
@@ -14519,7 +14512,6 @@ run_test    "Client Handshake defragmentation (16)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 16 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "received ServerHello message" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
@@ -14528,7 +14520,6 @@ run_test    "Client Handshake defragmentation (13)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 13 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "received ServerHello message" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
@@ -14536,7 +14527,6 @@ run_test    "Client Handshake defragmentation (5)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 5 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "received ServerHello message" \
             -c "<= handshake" \
             -c "handshake fragment: "
 

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14459,87 +14459,156 @@ run_test    "TLS 1.2 ClientHello indicating support for deflate compression meth
 
 # Handshake defragmentation testing
 
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-run_test    "Hanshake defragmentation (512)" \
-            "$O_SRV -max_send_frag 512 " \
+run_test    "Client Hanshake defragmentation (512)" \
+            "$O_NEXT_SRV -max_send_frag 512 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "received ServerHello message" \
             -c "<= handshake" \
+            -c "handshake fragment: "
 
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-run_test    "Hanshake defragmentation (513)" \
-            "$O_SRV -max_send_frag 513 " \
+run_test    "Client Hanshake defragmentation (513)" \
+            "$O_NEXT_SRV -max_send_frag 513 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "received ServerHello message" \
             -c "<= handshake" \
+            -c "handshake fragment: "
 
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-run_test    "Hanshake defragmentation (256)" \
-            "$O_SRV -mtu 32 -split_send_frag 256 " \
+run_test    "Client Hanshake defragmentation (256)" \
+            "$O_NEXT_SRV -mtu 32 -split_send_frag 256 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "received ServerHello message" \
             -c "<= handshake" \
+            -c "handshake fragment: "
 
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-run_test    "Hanshake defragmentation (128)" \
-            "$O_SRV -mtu 32 -split_send_frag 128 " \
+run_test    "Client Hanshake defragmentation (128)" \
+            "$O_NEXT_SRV -mtu 32 -split_send_frag 128 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "received ServerHello message" \
             -c "<= handshake" \
+            -c "handshake fragment: "
 
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-run_test    "Hanshake defragmentation (64)" \
-            "$O_SRV -mtu 32 -split_send_frag 64 " \
+run_test    "Client Hanshake defragmentation (64)" \
+            "$O_NEXT_SRV -mtu 32 -split_send_frag 64 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "received ServerHello message" \
             -c "<= handshake" \
+            -c "handshake fragment: "
 
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-run_test    "Hanshake defragmentation (36)" \
-            "$O_SRV -mtu 32 -split_send_frag 36 " \
+run_test    "Client Hanshake defragmentation (36)" \
+            "$O_NEXT_SRV -mtu 32 -split_send_frag 36 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "received ServerHello message" \
             -c "<= handshake" \
+            -c "handshake fragment: "
 
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-run_test    "Hanshake defragmentation (32)" \
-            "$O_SRV -mtu 32 -split_send_frag 32 " \
+run_test    "Client Hanshake defragmentation (32)" \
+            "$O_NEXT_SRV -mtu 32 -split_send_frag 32 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "received ServerHello message" \
             -c "<= handshake" \
+            -c "handshake fragment: "
 
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-run_test    "Hanshake defragmentation (16)" \
-            "$O_SRV -mtu 32 -split_send_frag 16 " \
+run_test    "Client Hanshake defragmentation (16)" \
+            "$O_NEXT_SRV -mtu 32 -split_send_frag 16 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "received ServerHello message" \
             -c "<= handshake" \
+            -c "handshake fragment: "
 
 
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-run_test    "Hanshake defragmentation (13)" \
-            "$O_SRV -mtu 32 -split_send_frag 13 " \
+run_test    "Client Hanshake defragmentation (13)" \
+            "$O_NEXT_SRV -mtu 32 -split_send_frag 13 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "received ServerHello message" \
             -c "<= handshake" \
+            -c "handshake fragment: "
 
-
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-run_test    "Hanshake defragmentation (5)" \
-            "$O_SRV -mtu 32 -split_send_frag 5 " \
+run_test    "Client Hanshake defragmentation (5)" \
+            "$O_NEXT_SRV -mtu 32 -split_send_frag 5 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "received ServerHello message" \
             -c "<= handshake" \
+            -c "handshake fragment: "
+
+run_test    "Server Hanshake defragmentation (512)" \
+            "$P_SRV debug_level=4 " \
+            "$O_NEXT_CLI -max_send_frag 512 " \
+            0 \
+            -s "<= handshake" \
+            -s "handshake fragment: "
+
+run_test    "Server Hanshake defragmentation (513)" \
+            "$P_SRV debug_level=4 " \
+            "$O_NEXT_CLI -max_send_frag 513 " \
+            0 \
+            -s "<= handshake" \
+            -s "handshake fragment: "
+
+run_test    "Server Hanshake defragmentation (256)" \
+            "$P_SRV debug_level=4 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 256 " \
+            0 \
+            -s "<= handshake" \
+            -s "handshake fragment: "
+
+run_test    "Server Hanshake defragmentation (128)" \
+            "$P_SRV debug_level=4 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 128 " \
+            0 \
+            -s "<= handshake" \
+            -s "handshake fragment: "
+
+run_test    "Server Hanshake defragmentation (64)" \
+            "$P_SRV debug_level=4 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 64 " \
+            0 \
+            -s "<= handshake" \
+            -s "handshake fragment: "
+
+run_test    "Server Hanshake defragmentation (36)" \
+            "$P_SRV debug_level=4 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 36 " \
+            0 \
+            -s "<= handshake" \
+            -s "handshake fragment: "
+
+run_test    "Server Hanshake defragmentation (32)" \
+            "$P_SRV debug_level=4 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 32 " \
+            0 \
+            -s "<= handshake" \
+            -s "handshake fragment: "
+
+run_test    "Server Hanshake defragmentation (16)" \
+            "$P_SRV debug_level=4 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 16 " \
+            0 \
+            -s "<= handshake" \
+            -s "handshake fragment: "
+
+run_test    "Server Hanshake defragmentation (13)" \
+            "$P_SRV debug_level=4 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 13 " \
+            0 \
+            -s "<= handshake" \
+            -s "handshake fragment: "
+
+run_test    "Server Hanshake defragmentation (5)" \
+            "$P_SRV debug_level=4 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 5 " \
+            0 \
+            -s "<= handshake" \
+            -s "handshake fragment: "
 
 # Test heap memory usage after handshake
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14478,8 +14478,12 @@ run_test    "Client Handshake defragmentation (513)" \
 # OpenSSL does not allow max_send_frag to be less than 512
 # so we use split_send_frag instead for tests lower than 512 below.
 
+# There is an issue with OpenSSL when fragmenting with values less
+# than 512 bytes in TLS 1.2 so we require TLS 1.3 with these values.
+
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Client Handshake defragmentation (256)" \
             "$O_NEXT_SRV -split_send_frag 256 " \
             "$P_CLI debug_level=4 " \
@@ -14489,6 +14493,7 @@ run_test    "Client Handshake defragmentation (256)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Client Handshake defragmentation (128)" \
             "$O_NEXT_SRV -split_send_frag 128 " \
             "$P_CLI debug_level=4 " \
@@ -14498,6 +14503,7 @@ run_test    "Client Handshake defragmentation (128)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Client Handshake defragmentation (64)" \
             "$O_NEXT_SRV -split_send_frag 64 " \
             "$P_CLI debug_level=4 " \
@@ -14507,6 +14513,7 @@ run_test    "Client Handshake defragmentation (64)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Client Handshake defragmentation (36)" \
             "$O_NEXT_SRV -split_send_frag 36 " \
             "$P_CLI debug_level=4 " \
@@ -14516,6 +14523,7 @@ run_test    "Client Handshake defragmentation (36)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Client Handshake defragmentation (32)" \
             "$O_NEXT_SRV -split_send_frag 32 " \
             "$P_CLI debug_level=4 " \
@@ -14525,6 +14533,7 @@ run_test    "Client Handshake defragmentation (32)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Client Handshake defragmentation (16)" \
             "$O_NEXT_SRV -split_send_frag 16 " \
             "$P_CLI debug_level=4 " \
@@ -14534,6 +14543,7 @@ run_test    "Client Handshake defragmentation (16)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Client Handshake defragmentation (13)" \
             "$O_NEXT_SRV -split_send_frag 13 " \
             "$P_CLI debug_level=4 " \
@@ -14543,6 +14553,7 @@ run_test    "Client Handshake defragmentation (13)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Client Handshake defragmentation (5)" \
             "$O_NEXT_SRV -split_send_frag 5 " \
             "$P_CLI debug_level=4 " \
@@ -14570,6 +14581,7 @@ run_test    "Server Handshake defragmentation (513)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Server Handshake defragmentation (256)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 256 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14579,6 +14591,7 @@ run_test    "Server Handshake defragmentation (256)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Server Handshake defragmentation (128)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 128 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14588,6 +14601,7 @@ run_test    "Server Handshake defragmentation (128)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Server Handshake defragmentation (64)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 64 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14597,6 +14611,7 @@ run_test    "Server Handshake defragmentation (64)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Server Handshake defragmentation (36)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 36 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14606,6 +14621,7 @@ run_test    "Server Handshake defragmentation (36)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Server Handshake defragmentation (32)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 32 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14615,6 +14631,7 @@ run_test    "Server Handshake defragmentation (32)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Server Handshake defragmentation (16)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 16 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14624,6 +14641,7 @@ run_test    "Server Handshake defragmentation (16)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Server Handshake defragmentation (13)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 13 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14633,6 +14651,7 @@ run_test    "Server Handshake defragmentation (13)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Server Handshake defragmentation (5)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 5 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14457,6 +14457,90 @@ run_test    "TLS 1.2 ClientHello indicating support for deflate compression meth
             -c "Handshake was completed" \
             -s "dumping .client hello, compression. (2 bytes)"
 
+# Handshake defragmentation testing
+
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test    "Hanshake defragmentation (512)" \
+            "$O_SRV -max_send_frag 512 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "received ServerHello message" \
+            -c "<= handshake" \
+
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test    "Hanshake defragmentation (513)" \
+            "$O_SRV -max_send_frag 513 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "received ServerHello message" \
+            -c "<= handshake" \
+
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test    "Hanshake defragmentation (256)" \
+            "$O_SRV -mtu 32 -split_send_frag 256 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "received ServerHello message" \
+            -c "<= handshake" \
+
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test    "Hanshake defragmentation (128)" \
+            "$O_SRV -mtu 32 -split_send_frag 128 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "received ServerHello message" \
+            -c "<= handshake" \
+
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test    "Hanshake defragmentation (64)" \
+            "$O_SRV -mtu 32 -split_send_frag 64 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "received ServerHello message" \
+            -c "<= handshake" \
+
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test    "Hanshake defragmentation (36)" \
+            "$O_SRV -mtu 32 -split_send_frag 36 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "received ServerHello message" \
+            -c "<= handshake" \
+
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test    "Hanshake defragmentation (32)" \
+            "$O_SRV -mtu 32 -split_send_frag 32 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "received ServerHello message" \
+            -c "<= handshake" \
+
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test    "Hanshake defragmentation (16)" \
+            "$O_SRV -mtu 32 -split_send_frag 16 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "received ServerHello message" \
+            -c "<= handshake" \
+
+
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test    "Hanshake defragmentation (13)" \
+            "$O_SRV -mtu 32 -split_send_frag 13 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "received ServerHello message" \
+            -c "<= handshake" \
+
+
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test    "Hanshake defragmentation (5)" \
+            "$O_SRV -mtu 32 -split_send_frag 5 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "received ServerHello message" \
+            -c "<= handshake" \
+
 # Test heap memory usage after handshake
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_MEMORY_DEBUG


### PR DESCRIPTION
## Description

This is the 3.6 backport of https://github.com/Mbed-TLS/mbedtls/pull/9872 and https://github.com/Mbed-TLS/mbedtls/pull/9928, with a few extra commits to try and preserve ABI compatibility in 3.6.

Status: work in progress pushed for CI feedback and early design review. **Outdated** see https://github.com/Mbed-TLS/mbedtls/pull/9981

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [ ] **changelog** provided | not required because: 
- [ ] **development PR** provided # | not required because: 
- [ ] **TF-PSA-Crypto PR** provided # | not required because: 
- [ ] **framework PR** provided Mbed-TLS/mbedtls-framework# | not required
- [ ] **3.6 PR** provided # | not required because: 
- [ ] **2.28 PR** provided # | not required because: 
- **tests**  provided | not required because: 



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
