### PR TITLE
crypto_adjust_config_dependencies: auto-enable ECB when using builtin CCM/GCM

### DIFF
--- a/include/psa/crypto_adjust_config_dependencies.h
+++ b/include/psa/crypto_adjust_config_dependencies.h
@@ -48,4 +48,18 @@
 #define PSA_WANT_ALG_CMAC 1
 #endif
 
+/* When at least one block cipher (AES, ARIA, Camellia) is accelerated, the
+ * builtin implementation of GCM/CCM calls into legacy gcm/ccm modules first
+ * and then into block_cipher module. The latter will
+ * then dispatch to PSA again to encypt data using block ciphers in ECB mode,
+ * which means we need PSA_WANT_ALG_ECB_NO_PADDING to allow this.
+ */
+#if ((defined(PSA_WANT_ALG_GCM) && !defined(MBEDTLS_PSA_ACCEL_ALG_GCM)) || \
+     (defined(PSA_WANT_ALG_CCM) && !defined(MBEDTLS_PSA_ACCEL_ALG_CCM))) && \
+    (defined(MBEDTLS_PSA_ACCEL_KEY_TYPE_AES) || \
+     defined(MBEDTLS_PSA_ACCEL_KEY_TYPE_ARIA) || \
+     defined(MBEDTLS_PSA_ACCEL_KEY_TYPE_CAMELLIA))
+#define PSA_WANT_ALG_ECB_NO_PADDING 1
+#endif
+
 #endif /* PSA_CRYPTO_ADJUST_CONFIG_DEPENDENCIES_H */


### PR DESCRIPTION
## Description

Builtin implementation of CCM/GCM use block cipher modes in ECB mode, but this is not enforced/checked. This PR auto-enables it when required.

Depends on: https://github.com/Mbed-TLS/mbedtls/pull/9979

## PR checklist

- [ ] **changelog** not required because: for the end user there's no change
- [ ] **development PR** not required because: no change
- [ ] **TF-PSA-Crypto PR** not required because: no change
- [ ] **framework PR** not required: no change
- [ ] **3.6 PR** not required because: it's this one
- [ ] **2.28 PR** not required because: no backport
- **tests** not required because: TBH I'm not sure. It might be, but I would like to ask for reviewers' opinion on this