### PR TITLE
[3.6] Block-cipher: allow PSA dispatching also when CRYPTO_CLIENT && !CRYPTO_C

### DIFF
--- a/include/mbedtls/config_adjust_legacy_crypto.h
+++ b/include/mbedtls/config_adjust_legacy_crypto.h
@@ -200,8 +200,12 @@
 #endif /* MBEDTLS_MD_LIGHT */
 
 /* BLOCK_CIPHER module can dispatch to PSA when:
- * - PSA is enabled and drivers have been initialized
- * - desired key type is supported on the PSA side
+ * - MBEDTLS_PSA_CRYPTO_C is enabled and any of the block cipher key types are
+ *   accelerated (MBEDTLS_PSA_ACCEL_KEY_TYPE_xxx), or
+ * - MBEDTLS_PSA_CRYPTO_CLIENT is enabled and any of the block cipher key types
+ *   are supported by the PSA Crypto provider (PSA_WANT_KEY_TYPE_xxx).
+ * In both cases PSA needs to be initialized through psa_crypto_init() before
+ * trying to use block_cipher module.
  * If the above conditions are not met, but the legacy support is enabled, then
  * BLOCK_CIPHER will dynamically fallback to it.
  *
@@ -215,6 +219,7 @@
  *   a legacy module (i.e. MBEDTLS_xxx_C)
  */
 #if defined(MBEDTLS_PSA_CRYPTO_C)
+
 #if defined(MBEDTLS_PSA_ACCEL_KEY_TYPE_AES)
 #define MBEDTLS_BLOCK_CIPHER_AES_VIA_PSA
 #define MBEDTLS_BLOCK_CIPHER_SOME_PSA
@@ -227,7 +232,23 @@
 #define MBEDTLS_BLOCK_CIPHER_CAMELLIA_VIA_PSA
 #define MBEDTLS_BLOCK_CIPHER_SOME_PSA
 #endif
-#endif /* MBEDTLS_PSA_CRYPTO_C */
+
+#elif defined(MBEDTLS_PSA_CRYPTO_CLIENT)
+
+#if defined(PSA_WANT_KEY_TYPE_AES)
+#define MBEDTLS_BLOCK_CIPHER_AES_VIA_PSA
+#define MBEDTLS_BLOCK_CIPHER_SOME_PSA
+#endif
+#if defined(PSA_WANT_KEY_TYPE_ARIA)
+#define MBEDTLS_BLOCK_CIPHER_ARIA_VIA_PSA
+#define MBEDTLS_BLOCK_CIPHER_SOME_PSA
+#endif
+#if defined(PSA_WANT_KEY_TYPE_CAMELLIA)
+#define MBEDTLS_BLOCK_CIPHER_CAMELLIA_VIA_PSA
+#define MBEDTLS_BLOCK_CIPHER_SOME_PSA
+#endif
+
+#endif /* !MBEDTLS_PSA_CRYPTO_C && !MBEDTLS_PSA_CRYPTO_CLIENT */
 
 #if defined(MBEDTLS_AES_C)
 #define MBEDTLS_BLOCK_CIPHER_AES_VIA_LEGACY

--- a/tests/suites/test_suite_block_cipher.function
+++ b/tests/suites/test_suite_block_cipher.function
@@ -106,10 +106,12 @@ void block_cipher_psa_dynamic_dispatch(int cipher_type, int pre_psa_ret, int pos
     /* Before PSA crypto init */
     TEST_EQUAL(pre_psa_ret, mbedtls_block_cipher_setup(&ctx, cipher_type));
 
-#if defined(MBEDTLS_BLOCK_CIPHER_SOME_PSA)
+#if defined(MBEDTLS_BLOCK_CIPHER_SOME_LEGACY)
     TEST_EQUAL(ctx.engine, MBEDTLS_BLOCK_CIPHER_ENGINE_LEGACY);
 #endif
 
+    /* PSA dispatching can only be tested when CRYPTO_C is enabled. */
+#if defined(MBEDTLS_PSA_CRYPTO_C)
     mbedtls_block_cipher_free(&ctx);
 
     /* Now initilize PSA Crypto */
@@ -120,7 +122,8 @@ void block_cipher_psa_dynamic_dispatch(int cipher_type, int pre_psa_ret, int pos
     TEST_EQUAL(0, mbedtls_block_cipher_setup(&ctx, cipher_type));
 #if defined(MBEDTLS_BLOCK_CIPHER_SOME_PSA)
     TEST_EQUAL(ctx.engine, post_psa_engine);
-#endif
+#endif /* MBEDTLS_BLOCK_CIPHER_SOME_PSA */
+#endif /* MBEDTLS_PSA_CRYPTO_C */
 
 exit:
     mbedtls_block_cipher_free(&ctx);


### PR DESCRIPTION
## Description

Allow block-cipher to dispatch to PSA in pure crypto client configuration, i.e. `CRYPTO_CLIENT && !CRYPTO_C`.

This fix is very similar to the one which is worked in parallel for MD in https://github.com/Mbed-TLS/mbedtls/pull/9562. 

## PR checklist

- [ ] **changelog** TODO
- [ ] **development PR** provided # TODO
- [ ] **TF-PSA-Crypto PR** not required
- [ ] **framework PR** provided https://github.com/Mbed-TLS/mbedtls-framework/pull/139
- [ ] **3.6 PR** not required because: it's this one
- [ ] **2.28 PR** not required because: there's no block-cipher there
- **tests**  provided