### PR TITLE
Add basic handshake defragmentation tests in ssl-opt

### DIFF
--- a/ChangeLog.d/tls-hs-defrag-in.txt
+++ b/ChangeLog.d/tls-hs-defrag-in.txt
@@ -3,3 +3,10 @@ Bugfix
      by the spec. Lack of support was causing handshake failures with some
      servers, especially with TLS 1.3 in practice (though both protocol
      version could be affected in principle, and both are fixed now).
+     The initial fragment for each handshake message must be at least 4 bytes.
+
+     Server-side, defragmentation of the ClientHello message is only
+     supported if the server accepts TLS 1.3 (regardless of whether the
+     ClientHello is 1.3 or 1.2). That is, servers configured (either
+     at compile time or at runtime) to only accept TLS 1.2 will
+     still fail the handshake if the ClientHello message is fragmented.

--- a/tests/scripts/analyze_outcomes.py
+++ b/tests/scripts/analyze_outcomes.py
@@ -50,6 +50,11 @@ class CoverageTask(outcome_analysis.CoverageTask):
             # TLS doesn't use restartable ECDH yet.
             # https://github.com/Mbed-TLS/mbedtls/issues/7294
             re.compile(r'EC restart:.*no USE_PSA.*'),
+            # Temporary disable Handshake defragmentation tests until mbedtls
+            # pr #10011 has been merged.
+            'Handshake defragmentation on client: len=4, TLS 1.2',
+            'Handshake defragmentation on client: len=5, TLS 1.2',
+            'Handshake defragmentation on client: len=13, TLS 1.2'
         ],
         'test_suite_config.mbedtls_boolean': [
             # Missing coverage of test configurations.

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -13874,10 +13874,9 @@ run_test    "TLS 1.2 ClientHello indicating support for deflate compression meth
 
 # Handshake defragmentation testing
 
-# To warrant that the handhake messages are large enough and need to be split
+# To guarantee that the handhake messages are large enough and need to be split
 # into fragments, the tests require certificate authentication. The party in control
-# of the fragmentation operations is OpenSSL and will always use server5.crt (548 Bytes)
-# either from O_NEXT_SRV or test data.
+# of the fragmentation operations is OpenSSL and will always use server5.crt (548 Bytes).
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client (no fragmentation, for reference)" \
@@ -13897,9 +13896,7 @@ run_test    "Handshake defragmentation on client: len=512, TLS 1.3" \
             -c "handshake fragment: 0 \\.\\. 512 of [0-9]\\+ msglen 512" \
             -c "waiting for more fragments (512 of [0-9]\\+"
 
-# Since the removal of the DHE-RSA key exchange, the default openssl server
-# certificate does not match what is provided by the testing client. Those
-# use-cases are out of scope for defregmentation testing, and should be skipped.
+#The server uses an ECDSA cert, so make sure we have a compatible key exchange
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
@@ -14220,12 +14217,12 @@ run_test    "Handshake defragmentation on server: len=128, TLS 1.3" \
             -s "handshake fragment: 0 \\.\\. 128 of [0-9]\\+ msglen 128" \
             -s "waiting for more fragments (128"
 
-# Server-side ClientHello degfragmentation is only supported for MBEDTLS_SSL_PROTO_TLS1_3. For TLS 1.2 testing
+# Server-side ClientHello defragmentationis only supported for MBEDTLS_SSL_PROTO_TLS1_3. For TLS 1.2 testing
 # the server should suport both protocols and downgrade to client-requested TL1.2 after proccessing the ClientHello.
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
-run_test    "Handshake defragmentation on server: len=128, TLS 1.2  TLS 1.3 Client-Hallo -> 1.2 Handhsake" \
+run_test    "Handshake defragmentation on server: len=128, TLS 1.2  TLS 1.3 ClientHello -> 1.2 Handshake" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_2 -split_send_frag 128 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14246,7 +14243,7 @@ run_test    "Handshake defragmentation on server: len=64, TLS 1.3" \
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
-run_test    "Handshake defragmentation on server: len=64, TLS 1.2  TLS 1.3 Client-Hallo -> 1.2 Handhsake" \
+run_test    "Handshake defragmentation on server: len=64, TLS 1.2  TLS 1.3 ClientHello -> 1.2 Handshake" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_2 -split_send_frag 64 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14267,7 +14264,7 @@ run_test    "Handshake defragmentation on server: len=36, TLS 1.3" \
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
-run_test    "Handshake defragmentation on server: len=36, TLS 1.2  TLS 1.3 Client-Hallo -> 1.2 Handhsake" \
+run_test    "Handshake defragmentation on server: len=36, TLS 1.2  TLS 1.3 ClientHello -> 1.2 Handshake" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_2 -split_send_frag 36 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14288,7 +14285,7 @@ run_test    "Handshake defragmentation on server: len=32, TLS 1.3" \
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
-run_test    "Handshake defragmentation on server: len=32, TLS 1.2  TLS 1.3 Client-Hallo -> 1.2 Handhsake" \
+run_test    "Handshake defragmentation on server: len=32, TLS 1.2  TLS 1.3 ClientHello -> 1.2 Handshake" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_2 -split_send_frag 32 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14309,7 +14306,7 @@ run_test    "Handshake defragmentation on server: len=16, TLS 1.3" \
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
-run_test    "Handshake defragmentation on server: len=16, TLS 1.2  TLS 1.3 Client-Hallo -> 1.2 Handhsake" \
+run_test    "Handshake defragmentation on server: len=16, TLS 1.2  TLS 1.3 ClientHello -> 1.2 Handshake" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_2 -split_send_frag 16 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14330,7 +14327,7 @@ run_test    "Handshake defragmentation on server: len=13, TLS 1.3" \
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
-run_test    "Handshake defragmentation on server: len=13, TLS 1.2  TLS 1.3 Client-Hallo -> 1.2 Handhsake" \
+run_test    "Handshake defragmentation on server: len=13, TLS 1.2  TLS 1.3 ClientHello -> 1.2 Handshake" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_2 -split_send_frag 13 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14351,7 +14348,7 @@ run_test    "Handshake defragmentation on server: len=5, TLS 1.3" \
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
-run_test    "Handshake defragmentation on server: len=5, TLS 1.2  TLS 1.3 Client-Hallo -> 1.2 Handhsake" \
+run_test    "Handshake defragmentation on server: len=5, TLS 1.2  TLS 1.3 ClientHello -> 1.2 Handshake" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_2 -split_send_frag 5 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14372,7 +14369,7 @@ run_test    "Handshake defragmentation on server: len=4, TLS 1.3" \
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
-run_test    "Handshake defragmentation on server: len=4, TLS 1.2  TLS 1.3 Client-Hallo -> 1.2 Handhsake" \
+run_test    "Handshake defragmentation on server: len=4, TLS 1.2  TLS 1.3 ClientHello -> 1.2 Handshake" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_2 -split_send_frag 4 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14393,7 +14390,7 @@ run_test    "Handshake defragmentation on server: len=3, TLS 1.3" \
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
-run_test    "Handshake defragmentation on server: len=3, TLS 1.3 Client-Hallo -> 1.2 Handhsake" \
+run_test    "Handshake defragmentation on server: len=3, TLS 1.3 ClientHello -> 1.2 Handshake" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_2 -split_send_frag 3 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             1 \
@@ -14404,7 +14401,7 @@ run_test    "Handshake defragmentation on server: len=3, TLS 1.3 Client-Hallo ->
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
-run_test    "Handshake defragmentation on server: len=32, TLS 1.3 Client-Hallo -> 1.2 Handhsake" \
+run_test    "Handshake defragmentation on server: len=32, TLS 1.2 ClientHello" \
             "$P_SRV debug_level=4 force_version=tls12 auth_mode=required" \
             "$O_NEXT_CLI -tls1_2 -split_send_frag 32 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             1 \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -13874,7 +13874,7 @@ run_test    "TLS 1.2 ClientHello indicating support for deflate compression meth
 
 # Handshake defragmentation testing
 
-run_test    "Client Hanshake defragmentation (512)" \
+run_test    "Client Handshake defragmentation (512)" \
             "$O_NEXT_SRV -max_send_frag 512 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -13882,7 +13882,7 @@ run_test    "Client Hanshake defragmentation (512)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
-run_test    "Client Hanshake defragmentation (513)" \
+run_test    "Client Handshake defragmentation (513)" \
             "$O_NEXT_SRV -max_send_frag 513 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -13890,7 +13890,7 @@ run_test    "Client Hanshake defragmentation (513)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
-run_test    "Client Hanshake defragmentation (256)" \
+run_test    "Client Handshake defragmentation (256)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 256 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -13898,7 +13898,7 @@ run_test    "Client Hanshake defragmentation (256)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
-run_test    "Client Hanshake defragmentation (128)" \
+run_test    "Client Handshake defragmentation (128)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 128 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -13906,7 +13906,7 @@ run_test    "Client Hanshake defragmentation (128)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
-run_test    "Client Hanshake defragmentation (64)" \
+run_test    "Client Handshake defragmentation (64)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 64 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -13914,7 +13914,7 @@ run_test    "Client Hanshake defragmentation (64)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
-run_test    "Client Hanshake defragmentation (36)" \
+run_test    "Client Handshake defragmentation (36)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 36 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -13922,7 +13922,7 @@ run_test    "Client Hanshake defragmentation (36)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
-run_test    "Client Hanshake defragmentation (32)" \
+run_test    "Client Handshake defragmentation (32)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 32 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -13930,7 +13930,7 @@ run_test    "Client Hanshake defragmentation (32)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
-run_test    "Client Hanshake defragmentation (16)" \
+run_test    "Client Handshake defragmentation (16)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 16 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -13939,7 +13939,7 @@ run_test    "Client Hanshake defragmentation (16)" \
             -c "handshake fragment: "
 
 
-run_test    "Client Hanshake defragmentation (13)" \
+run_test    "Client Handshake defragmentation (13)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 13 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -13947,7 +13947,7 @@ run_test    "Client Hanshake defragmentation (13)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
-run_test    "Client Hanshake defragmentation (5)" \
+run_test    "Client Handshake defragmentation (5)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 5 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -13955,70 +13955,70 @@ run_test    "Client Hanshake defragmentation (5)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
-run_test    "Server Hanshake defragmentation (512)" \
+run_test    "Server Handshake defragmentation (512)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -max_send_frag 512 " \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
 
-run_test    "Server Hanshake defragmentation (513)" \
+run_test    "Server Handshake defragmentation (513)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -max_send_frag 513 " \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
 
-run_test    "Server Hanshake defragmentation (256)" \
+run_test    "Server Handshake defragmentation (256)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 256 " \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
 
-run_test    "Server Hanshake defragmentation (128)" \
+run_test    "Server Handshake defragmentation (128)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 128 " \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
 
-run_test    "Server Hanshake defragmentation (64)" \
+run_test    "Server Handshake defragmentation (64)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 64 " \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
 
-run_test    "Server Hanshake defragmentation (36)" \
+run_test    "Server Handshake defragmentation (36)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 36 " \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
 
-run_test    "Server Hanshake defragmentation (32)" \
+run_test    "Server Handshake defragmentation (32)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 32 " \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
 
-run_test    "Server Hanshake defragmentation (16)" \
+run_test    "Server Handshake defragmentation (16)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 16 " \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
 
-run_test    "Server Hanshake defragmentation (13)" \
+run_test    "Server Handshake defragmentation (13)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 13 " \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
 
-run_test    "Server Hanshake defragmentation (5)" \
+run_test    "Server Handshake defragmentation (5)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 5 " \
             0 \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -13892,7 +13892,7 @@ run_test    "Client Handshake defragmentation (513)" \
 
 requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (256)" \
-            "$O_NEXT_SRV -mtu 32 -split_send_frag 256 " \
+            "$O_NEXT_SRV -split_send_frag 256 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "<= handshake" \
@@ -13900,7 +13900,7 @@ run_test    "Client Handshake defragmentation (256)" \
 
 requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (128)" \
-            "$O_NEXT_SRV -mtu 32 -split_send_frag 128 " \
+            "$O_NEXT_SRV -split_send_frag 128 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "<= handshake" \
@@ -13908,7 +13908,7 @@ run_test    "Client Handshake defragmentation (128)" \
 
 requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (64)" \
-            "$O_NEXT_SRV -mtu 32 -split_send_frag 64 " \
+            "$O_NEXT_SRV -split_send_frag 64 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "<= handshake" \
@@ -13916,7 +13916,7 @@ run_test    "Client Handshake defragmentation (64)" \
 
 requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (36)" \
-            "$O_NEXT_SRV -mtu 32 -split_send_frag 36 " \
+            "$O_NEXT_SRV -split_send_frag 36 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "<= handshake" \
@@ -13924,7 +13924,7 @@ run_test    "Client Handshake defragmentation (36)" \
 
 requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (32)" \
-            "$O_NEXT_SRV -mtu 32 -split_send_frag 32 " \
+            "$O_NEXT_SRV -split_send_frag 32 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "<= handshake" \
@@ -13932,7 +13932,7 @@ run_test    "Client Handshake defragmentation (32)" \
 
 requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (16)" \
-            "$O_NEXT_SRV -mtu 32 -split_send_frag 16 " \
+            "$O_NEXT_SRV -split_send_frag 16 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "<= handshake" \
@@ -13940,7 +13940,7 @@ run_test    "Client Handshake defragmentation (16)" \
 
 requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (13)" \
-            "$O_NEXT_SRV -mtu 32 -split_send_frag 13 " \
+            "$O_NEXT_SRV -split_send_frag 13 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "<= handshake" \
@@ -13948,7 +13948,7 @@ run_test    "Client Handshake defragmentation (13)" \
 
 requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (5)" \
-            "$O_NEXT_SRV -mtu 32 -split_send_frag 5 " \
+            "$O_NEXT_SRV -split_send_frag 5 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "<= handshake" \
@@ -13973,7 +13973,7 @@ run_test    "Server Handshake defragmentation (513)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (256)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 256 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -split_send_frag 256 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -13981,7 +13981,7 @@ run_test    "Server Handshake defragmentation (256)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (128)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 128 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -split_send_frag 128 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -13989,7 +13989,7 @@ run_test    "Server Handshake defragmentation (128)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (64)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 64 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -split_send_frag 64 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -13997,7 +13997,7 @@ run_test    "Server Handshake defragmentation (64)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (36)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 36 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -split_send_frag 36 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -14005,7 +14005,7 @@ run_test    "Server Handshake defragmentation (36)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (32)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 32 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -split_send_frag 32 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -14013,7 +14013,7 @@ run_test    "Server Handshake defragmentation (32)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (16)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 16 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -split_send_frag 16 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -14021,7 +14021,7 @@ run_test    "Server Handshake defragmentation (16)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (13)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 13 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -split_send_frag 13 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -14029,7 +14029,7 @@ run_test    "Server Handshake defragmentation (13)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (5)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 5 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -split_send_frag 5 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -13875,6 +13875,7 @@ run_test    "TLS 1.2 ClientHello indicating support for deflate compression meth
 # Handshake defragmentation testing
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Client Handshake defragmentation (512)" \
             "$O_NEXT_SRV -max_send_frag 512 " \
             "$P_CLI debug_level=4 " \
@@ -13883,6 +13884,7 @@ run_test    "Client Handshake defragmentation (512)" \
             -c "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Client Handshake defragmentation (513)" \
             "$O_NEXT_SRV -max_send_frag 513 " \
             "$P_CLI debug_level=4 " \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14225,7 +14225,7 @@ run_test    "Handshake defragmentation on server: len=128, TLS 1.3" \
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
-run_test    "Handshake defragmentation on server: len=128, TLS 1.2" \
+run_test    "Handshake defragmentation on server: len=128, TLS 1.2  TLS 1.3 Client-Hallo -> 1.2 Handhsake" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_2 -split_send_frag 128 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14246,7 +14246,7 @@ run_test    "Handshake defragmentation on server: len=64, TLS 1.3" \
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
-run_test    "Handshake defragmentation on server: len=64, TLS 1.2" \
+run_test    "Handshake defragmentation on server: len=64, TLS 1.2  TLS 1.3 Client-Hallo -> 1.2 Handhsake" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_2 -split_send_frag 64 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14267,7 +14267,7 @@ run_test    "Handshake defragmentation on server: len=36, TLS 1.3" \
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
-run_test    "Handshake defragmentation on server: len=36, TLS 1.2" \
+run_test    "Handshake defragmentation on server: len=36, TLS 1.2  TLS 1.3 Client-Hallo -> 1.2 Handhsake" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_2 -split_send_frag 36 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14288,7 +14288,7 @@ run_test    "Handshake defragmentation on server: len=32, TLS 1.3" \
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
-run_test    "Handshake defragmentation on server: len=32, TLS 1.2" \
+run_test    "Handshake defragmentation on server: len=32, TLS 1.2  TLS 1.3 Client-Hallo -> 1.2 Handhsake" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_2 -split_send_frag 32 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14309,7 +14309,7 @@ run_test    "Handshake defragmentation on server: len=16, TLS 1.3" \
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
-run_test    "Handshake defragmentation on server: len=16, TLS 1.2" \
+run_test    "Handshake defragmentation on server: len=16, TLS 1.2  TLS 1.3 Client-Hallo -> 1.2 Handhsake" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_2 -split_send_frag 16 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14330,7 +14330,7 @@ run_test    "Handshake defragmentation on server: len=13, TLS 1.3" \
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
-run_test    "Handshake defragmentation on server: len=13, TLS 1.2" \
+run_test    "Handshake defragmentation on server: len=13, TLS 1.2  TLS 1.3 Client-Hallo -> 1.2 Handhsake" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_2 -split_send_frag 13 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14351,7 +14351,7 @@ run_test    "Handshake defragmentation on server: len=5, TLS 1.3" \
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
-run_test    "Handshake defragmentation on server: len=5, TLS 1.2" \
+run_test    "Handshake defragmentation on server: len=5, TLS 1.2  TLS 1.3 Client-Hallo -> 1.2 Handhsake" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_2 -split_send_frag 5 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14372,7 +14372,7 @@ run_test    "Handshake defragmentation on server: len=4, TLS 1.3" \
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
-run_test    "Handshake defragmentation on server: len=4, TLS 1.2" \
+run_test    "Handshake defragmentation on server: len=4, TLS 1.2  TLS 1.3 Client-Hallo -> 1.2 Handhsake" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_2 -split_send_frag 4 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14393,7 +14393,7 @@ run_test    "Handshake defragmentation on server: len=3, TLS 1.3" \
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
-run_test    "Handshake defragmentation on server: len=3, TLS 1.3 -> 1.2" \
+run_test    "Handshake defragmentation on server: len=3, TLS 1.3 Client-Hallo -> 1.2 Handhsake" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_2 -split_send_frag 3 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             1 \
@@ -14404,7 +14404,7 @@ run_test    "Handshake defragmentation on server: len=3, TLS 1.3 -> 1.2" \
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
-run_test    "Handshake defragmentation on server: len=32, TLS 1.2 -> 1.2" \
+run_test    "Handshake defragmentation on server: len=32, TLS 1.3 Client-Hallo -> 1.2 Handhsake" \
             "$P_SRV debug_level=4 force_version=tls12 auth_mode=required" \
             "$O_NEXT_CLI -tls1_2 -split_send_frag 32 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             1 \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -13872,6 +13872,90 @@ run_test    "TLS 1.2 ClientHello indicating support for deflate compression meth
             -c "Handshake was completed" \
             -s "dumping .client hello, compression. (2 bytes)"
 
+# Handshake defragmentation testing
+
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test    "Hanshake defragmentation (512)" \
+            "$O_SRV -max_send_frag 512 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "received ServerHello message" \
+            -c "<= handshake" \
+
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test    "Hanshake defragmentation (513)" \
+            "$O_SRV -max_send_frag 513 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "received ServerHello message" \
+            -c "<= handshake" \
+
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test    "Hanshake defragmentation (256)" \
+            "$O_SRV -mtu 32 -split_send_frag 256 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "received ServerHello message" \
+            -c "<= handshake" \
+
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test    "Hanshake defragmentation (128)" \
+            "$O_SRV -mtu 32 -split_send_frag 128 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "received ServerHello message" \
+            -c "<= handshake" \
+
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test    "Hanshake defragmentation (64)" \
+            "$O_SRV -mtu 32 -split_send_frag 64 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "received ServerHello message" \
+            -c "<= handshake" \
+
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test    "Hanshake defragmentation (36)" \
+            "$O_SRV -mtu 32 -split_send_frag 36 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "received ServerHello message" \
+            -c "<= handshake" \
+
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test    "Hanshake defragmentation (32)" \
+            "$O_SRV -mtu 32 -split_send_frag 32 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "received ServerHello message" \
+            -c "<= handshake" \
+
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test    "Hanshake defragmentation (16)" \
+            "$O_SRV -mtu 32 -split_send_frag 16 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "received ServerHello message" \
+            -c "<= handshake" \
+
+
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test    "Hanshake defragmentation (13)" \
+            "$O_SRV -mtu 32 -split_send_frag 13 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "received ServerHello message" \
+            -c "<= handshake" \
+
+
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test    "Hanshake defragmentation (5)" \
+            "$O_SRV -mtu 32 -split_send_frag 5 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "received ServerHello message" \
+            -c "<= handshake" \
+
 # Test heap memory usage after handshake
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_MEMORY_DEBUG

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -13894,6 +13894,7 @@ run_test    "Client Handshake defragmentation (513)" \
 # so we use split_send_frag instead for tests lower than 512 below.
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Client Handshake defragmentation (256)" \
             "$O_NEXT_SRV -split_send_frag 256 " \
             "$P_CLI debug_level=4 " \
@@ -13902,6 +13903,7 @@ run_test    "Client Handshake defragmentation (256)" \
             -c "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Client Handshake defragmentation (128)" \
             "$O_NEXT_SRV -split_send_frag 128 " \
             "$P_CLI debug_level=4 " \
@@ -13910,6 +13912,7 @@ run_test    "Client Handshake defragmentation (128)" \
             -c "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Client Handshake defragmentation (64)" \
             "$O_NEXT_SRV -split_send_frag 64 " \
             "$P_CLI debug_level=4 " \
@@ -13918,6 +13921,7 @@ run_test    "Client Handshake defragmentation (64)" \
             -c "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Client Handshake defragmentation (36)" \
             "$O_NEXT_SRV -split_send_frag 36 " \
             "$P_CLI debug_level=4 " \
@@ -13926,6 +13930,7 @@ run_test    "Client Handshake defragmentation (36)" \
             -c "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Client Handshake defragmentation (32)" \
             "$O_NEXT_SRV -split_send_frag 32 " \
             "$P_CLI debug_level=4 " \
@@ -13934,6 +13939,7 @@ run_test    "Client Handshake defragmentation (32)" \
             -c "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Client Handshake defragmentation (16)" \
             "$O_NEXT_SRV -split_send_frag 16 " \
             "$P_CLI debug_level=4 " \
@@ -13942,6 +13948,7 @@ run_test    "Client Handshake defragmentation (16)" \
             -c "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Client Handshake defragmentation (13)" \
             "$O_NEXT_SRV -split_send_frag 13 " \
             "$P_CLI debug_level=4 " \
@@ -13950,6 +13957,7 @@ run_test    "Client Handshake defragmentation (13)" \
             -c "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Client Handshake defragmentation (5)" \
             "$O_NEXT_SRV -split_send_frag 5 " \
             "$P_CLI debug_level=4 " \
@@ -13958,6 +13966,7 @@ run_test    "Client Handshake defragmentation (5)" \
             -c "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Server Handshake defragmentation (512)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -max_send_frag 512 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -13966,6 +13975,7 @@ run_test    "Server Handshake defragmentation (512)" \
             -s "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Server Handshake defragmentation (513)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -max_send_frag 513 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -13974,6 +13984,7 @@ run_test    "Server Handshake defragmentation (513)" \
             -s "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Server Handshake defragmentation (256)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 256 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -13982,6 +13993,7 @@ run_test    "Server Handshake defragmentation (256)" \
             -s "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Server Handshake defragmentation (128)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 128 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -13990,6 +14002,7 @@ run_test    "Server Handshake defragmentation (128)" \
             -s "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Server Handshake defragmentation (64)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 64 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -13998,6 +14011,7 @@ run_test    "Server Handshake defragmentation (64)" \
             -s "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Server Handshake defragmentation (36)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 36 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14006,6 +14020,7 @@ run_test    "Server Handshake defragmentation (36)" \
             -s "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Server Handshake defragmentation (32)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 32 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14014,6 +14029,7 @@ run_test    "Server Handshake defragmentation (32)" \
             -s "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Server Handshake defragmentation (16)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 16 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14022,6 +14038,7 @@ run_test    "Server Handshake defragmentation (16)" \
             -s "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Server Handshake defragmentation (13)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 13 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14030,6 +14047,7 @@ run_test    "Server Handshake defragmentation (13)" \
             -s "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Server Handshake defragmentation (5)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 5 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -13874,6 +13874,7 @@ run_test    "TLS 1.2 ClientHello indicating support for deflate compression meth
 
 # Handshake defragmentation testing
 
+requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (512)" \
             "$O_NEXT_SRV -max_send_frag 512 " \
             "$P_CLI debug_level=4 " \
@@ -13881,6 +13882,7 @@ run_test    "Client Handshake defragmentation (512)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (513)" \
             "$O_NEXT_SRV -max_send_frag 513 " \
             "$P_CLI debug_level=4 " \
@@ -13888,6 +13890,7 @@ run_test    "Client Handshake defragmentation (513)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (256)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 256 " \
             "$P_CLI debug_level=4 " \
@@ -13895,6 +13898,7 @@ run_test    "Client Handshake defragmentation (256)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (128)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 128 " \
             "$P_CLI debug_level=4 " \
@@ -13902,6 +13906,7 @@ run_test    "Client Handshake defragmentation (128)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (64)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 64 " \
             "$P_CLI debug_level=4 " \
@@ -13909,6 +13914,7 @@ run_test    "Client Handshake defragmentation (64)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (36)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 36 " \
             "$P_CLI debug_level=4 " \
@@ -13916,6 +13922,7 @@ run_test    "Client Handshake defragmentation (36)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (32)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 32 " \
             "$P_CLI debug_level=4 " \
@@ -13923,6 +13930,7 @@ run_test    "Client Handshake defragmentation (32)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (16)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 16 " \
             "$P_CLI debug_level=4 " \
@@ -13930,7 +13938,7 @@ run_test    "Client Handshake defragmentation (16)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
-
+requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (13)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 13 " \
             "$P_CLI debug_level=4 " \
@@ -13938,6 +13946,7 @@ run_test    "Client Handshake defragmentation (13)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (5)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 5 " \
             "$P_CLI debug_level=4 " \
@@ -13945,6 +13954,7 @@ run_test    "Client Handshake defragmentation (5)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (512)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -max_send_frag 512 " \
@@ -13952,6 +13962,7 @@ run_test    "Server Handshake defragmentation (512)" \
             -s "<= handshake" \
             -s "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (513)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -max_send_frag 513 " \
@@ -13959,6 +13970,7 @@ run_test    "Server Handshake defragmentation (513)" \
             -s "<= handshake" \
             -s "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (256)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 256 " \
@@ -13966,6 +13978,7 @@ run_test    "Server Handshake defragmentation (256)" \
             -s "<= handshake" \
             -s "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (128)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 128 " \
@@ -13973,6 +13986,7 @@ run_test    "Server Handshake defragmentation (128)" \
             -s "<= handshake" \
             -s "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (64)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 64 " \
@@ -13980,6 +13994,7 @@ run_test    "Server Handshake defragmentation (64)" \
             -s "<= handshake" \
             -s "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (36)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 36 " \
@@ -13987,6 +14002,7 @@ run_test    "Server Handshake defragmentation (36)" \
             -s "<= handshake" \
             -s "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (32)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 32 " \
@@ -13994,6 +14010,7 @@ run_test    "Server Handshake defragmentation (32)" \
             -s "<= handshake" \
             -s "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (16)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 16 " \
@@ -14001,6 +14018,7 @@ run_test    "Server Handshake defragmentation (16)" \
             -s "<= handshake" \
             -s "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (13)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 13 " \
@@ -14008,6 +14026,7 @@ run_test    "Server Handshake defragmentation (13)" \
             -s "<= handshake" \
             -s "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (5)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 5 " \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -13878,7 +13878,6 @@ run_test    "Client Handshake defragmentation (512)" \
             "$O_NEXT_SRV -max_send_frag 512 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "received ServerHello message" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
@@ -13886,7 +13885,6 @@ run_test    "Client Handshake defragmentation (513)" \
             "$O_NEXT_SRV -max_send_frag 513 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "received ServerHello message" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
@@ -13894,7 +13892,6 @@ run_test    "Client Handshake defragmentation (256)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 256 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "received ServerHello message" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
@@ -13902,7 +13899,6 @@ run_test    "Client Handshake defragmentation (128)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 128 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "received ServerHello message" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
@@ -13910,7 +13906,6 @@ run_test    "Client Handshake defragmentation (64)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 64 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "received ServerHello message" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
@@ -13918,7 +13913,6 @@ run_test    "Client Handshake defragmentation (36)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 36 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "received ServerHello message" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
@@ -13926,7 +13920,6 @@ run_test    "Client Handshake defragmentation (32)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 32 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "received ServerHello message" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
@@ -13934,7 +13927,6 @@ run_test    "Client Handshake defragmentation (16)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 16 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "received ServerHello message" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
@@ -13943,7 +13935,6 @@ run_test    "Client Handshake defragmentation (13)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 13 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "received ServerHello message" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
@@ -13951,7 +13942,6 @@ run_test    "Client Handshake defragmentation (5)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 5 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "received ServerHello message" \
             -c "<= handshake" \
             -c "handshake fragment: "
 

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -13877,7 +13877,6 @@ run_test    "TLS 1.2 ClientHello indicating support for deflate compression meth
 # To guarantee that the handhake messages are large enough and need to be split
 # into fragments, the tests require certificate authentication. The party in control
 # of the fragmentation operations is OpenSSL and will always use server5.crt (548 Bytes).
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client (no fragmentation, for reference)" \
             "$O_NEXT_SRV" \
@@ -14138,14 +14137,13 @@ run_test    "Handshake defragmentation on client: len=3, TLS 1.2" \
             -c "handshake message too short: 3" \
             -c "SSL - An invalid SSL record was received"
 
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server (no fragmentation, for reference)." \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
-            -C "reassembled record" \
-            -C "waiting for more fragments"
+            -S "reassembled record" \
+            -S "waiting for more fragments"
 
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14055,7 +14055,7 @@ run_test    "Handshake defragmentation on client: len=32, TLS 1.2" \
 requires_openssl_3_x
 requires_protocol_version tls13
 requires_certificate_authentication
-run_test    "Handshake defragmentation on client: len=14, TLS 1.3" \
+run_test    "Handshake defragmentation on client: len=16, TLS 1.3" \
             "$O_NEXT_SRV -tls1_3 -split_send_frag 16 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -14067,7 +14067,7 @@ requires_openssl_3_x
 requires_protocol_version tls12
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
-run_test    "Handshake defragmentation on client: len=14, TLS 1.2" \
+run_test    "Handshake defragmentation on client: len=16, TLS 1.2" \
             "$O_NEXT_SRV -tls1_2 -split_send_frag 16 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -14118,6 +14118,28 @@ run_test    "Handshake defragmentation on client: len=5, TLS 1.2" \
             -c "reassembled record" \
             -c "handshake fragment: 0 \\.\\. 5 of [0-9]\\+ msglen 5" \
             -c "waiting for more fragments (5"
+
+requires_openssl_3_x
+requires_protocol_version tls13
+requires_certificate_authentication
+run_test    "Handshake defragmentation on client: len=4, TLS 1.3" \
+            "$O_NEXT_SRV -tls1_3 -split_send_frag 4 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "reassembled record" \
+            -c "handshake fragment: 0 \\.\\. 4 of [0-9]\\+ msglen 4" \
+            -c "waiting for more fragments (4"
+
+requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on client: len=4, TLS 1.2" \
+            "$O_NEXT_SRV -tls1_2 -split_send_frag 4 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "reassembled record" \
+            -c "handshake fragment: 0 \\.\\. 4 of [0-9]\\+ msglen 4" \
+            -c "waiting for more fragments (4"
 
 requires_openssl_3_x
 requires_protocol_version tls13
@@ -14210,12 +14232,11 @@ requires_protocol_version tls12
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=256, TLS 1.2" \
             "$P_SRV debug_level=4 auth_mode=required" \
-            "$O_NEXT_CLI -tls1_3 -split_send_frag 256 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -tls1_2 -split_send_frag 256 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 256 of [0-9]\\+ msglen 256" \
             -s "waiting for more fragments (256"
-
 
 requires_openssl_3_x
 requires_protocol_version tls13
@@ -14228,8 +14249,11 @@ run_test    "Handshake defragmentation on server: len=128, TLS 1.3" \
             -s "handshake fragment: 0 \\.\\. 128 of [0-9]\\+ msglen 128" \
             -s "waiting for more fragments (128"
 
+# Server-side ClientHello degfragmentation is only supported for MBEDTLS_SSL_PROTO_TLS1_3. For TLS 1.2 testing
+# the server should suport both protocols and downgrade to client-requested TL1.2 after proccessing the ClientHello.
 requires_openssl_3_x
-requires_protocol_version tls12
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=128, TLS 1.2" \
             "$P_SRV debug_level=4 auth_mode=required" \
@@ -14251,7 +14275,8 @@ run_test    "Handshake defragmentation on server: len=64, TLS 1.3" \
             -s "waiting for more fragments (64"
 
 requires_openssl_3_x
-requires_protocol_version tls12
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=64, TLS 1.2" \
             "$P_SRV debug_level=4 auth_mode=required" \
@@ -14273,7 +14298,8 @@ run_test    "Handshake defragmentation on server: len=36, TLS 1.3" \
             -s "waiting for more fragments (36"
 
 requires_openssl_3_x
-requires_protocol_version tls12
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=36, TLS 1.2" \
             "$P_SRV debug_level=4 auth_mode=required" \
@@ -14295,7 +14321,8 @@ run_test    "Handshake defragmentation on server: len=32, TLS 1.3" \
             -s "waiting for more fragments (32"
 
 requires_openssl_3_x
-requires_protocol_version tls12
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=32, TLS 1.2" \
             "$P_SRV debug_level=4 auth_mode=required" \
@@ -14317,7 +14344,8 @@ run_test    "Handshake defragmentation on server: len=16, TLS 1.3" \
             -s "waiting for more fragments (16"
 
 requires_openssl_3_x
-requires_protocol_version tls12
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=16, TLS 1.2" \
             "$P_SRV debug_level=4 auth_mode=required" \
@@ -14339,7 +14367,8 @@ run_test    "Handshake defragmentation on server: len=13, TLS 1.3" \
             -s "waiting for more fragments (13"
 
 requires_openssl_3_x
-requires_protocol_version tls12
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=13, TLS 1.2" \
             "$P_SRV debug_level=4 auth_mode=required" \
@@ -14361,7 +14390,8 @@ run_test    "Handshake defragmentation on server: len=5, TLS 1.3" \
             -s "waiting for more fragments (5"
 
 requires_openssl_3_x
-requires_protocol_version tls12
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=5, TLS 1.2" \
             "$P_SRV debug_level=4 auth_mode=required" \
@@ -14371,6 +14401,7 @@ run_test    "Handshake defragmentation on server: len=5, TLS 1.2" \
             -s "handshake fragment: 0 \\.\\. 5 of [0-9]\\+ msglen 5" \
             -s "waiting for more fragments (5"
 
+requires_openssl_3_x
 requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=4, TLS 1.3" \
@@ -14404,8 +14435,6 @@ run_test    "Handshake defragmentation on server: len=3, TLS 1.3" \
             -s "handshake message too short: 3" \
             -s "SSL - An invalid SSL record was received"
 
-# Server-side ClientHello degfragmentation is only supported for MBEDTLS_SSL_PROTO_TLS1_3. For TLS 1.2 testing
-# the server should suport both protocols and downgrade to client-requested TL1.2 after proccessing the ClientHello.
 requires_openssl_3_x
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -14422,7 +14451,7 @@ requires_openssl_3_x
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
-run_test    "Handshake defragmentation on server: len=32, TLS 1.2" \
+run_test    "Handshake defragmentation on server: len=32, TLS 1.2 -> 1.2" \
             "$P_SRV debug_level=4 force_version=tls12 auth_mode=required" \
             "$O_NEXT_CLI -tls1_2 -split_send_frag 32 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             1 \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -13957,7 +13957,7 @@ run_test    "Client Handshake defragmentation (5)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (512)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -max_send_frag 512 " \
+            "$O_NEXT_CLI -max_send_frag 512 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -13965,7 +13965,7 @@ run_test    "Server Handshake defragmentation (512)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (513)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -max_send_frag 513 " \
+            "$O_NEXT_CLI -max_send_frag 513 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -13973,7 +13973,7 @@ run_test    "Server Handshake defragmentation (513)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (256)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 256 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 256 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -13981,7 +13981,7 @@ run_test    "Server Handshake defragmentation (256)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (128)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 128 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 128 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -13989,7 +13989,7 @@ run_test    "Server Handshake defragmentation (128)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (64)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 64 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 64 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -13997,7 +13997,7 @@ run_test    "Server Handshake defragmentation (64)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (36)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 36 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 36 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -14005,7 +14005,7 @@ run_test    "Server Handshake defragmentation (36)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (32)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 32 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 32 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -14013,7 +14013,7 @@ run_test    "Server Handshake defragmentation (32)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (16)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 16 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 16 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -14021,7 +14021,7 @@ run_test    "Server Handshake defragmentation (16)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (13)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 13 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 13 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -14029,7 +14029,7 @@ run_test    "Server Handshake defragmentation (13)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (5)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 5 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 5 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14118,6 +14118,7 @@ run_test    "Handshake defragmentation on client: len=4, TLS 1.2" \
             -c "waiting for more fragments (4"
 
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
+requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=3, TLS 1.3" \
             "$O_NEXT_SRV -tls1_3 -split_send_frag 3 " \
             "$P_CLI debug_level=4 " \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -13956,7 +13956,7 @@ run_test    "Client Handshake defragmentation (5)" \
 
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (512)" \
-            "$P_SRV debug_level=4 " \
+            "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -max_send_frag 512 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
@@ -13964,7 +13964,7 @@ run_test    "Server Handshake defragmentation (512)" \
 
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (513)" \
-            "$P_SRV debug_level=4 " \
+            "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -max_send_frag 513 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
@@ -13972,7 +13972,7 @@ run_test    "Server Handshake defragmentation (513)" \
 
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (256)" \
-            "$P_SRV debug_level=4 " \
+            "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 256 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
@@ -13980,7 +13980,7 @@ run_test    "Server Handshake defragmentation (256)" \
 
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (128)" \
-            "$P_SRV debug_level=4 " \
+            "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 128 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
@@ -13988,7 +13988,7 @@ run_test    "Server Handshake defragmentation (128)" \
 
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (64)" \
-            "$P_SRV debug_level=4 " \
+            "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 64 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
@@ -13996,7 +13996,7 @@ run_test    "Server Handshake defragmentation (64)" \
 
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (36)" \
-            "$P_SRV debug_level=4 " \
+            "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 36 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
@@ -14004,7 +14004,7 @@ run_test    "Server Handshake defragmentation (36)" \
 
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (32)" \
-            "$P_SRV debug_level=4 " \
+            "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 32 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
@@ -14012,7 +14012,7 @@ run_test    "Server Handshake defragmentation (32)" \
 
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (16)" \
-            "$P_SRV debug_level=4 " \
+            "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 16 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
@@ -14020,7 +14020,7 @@ run_test    "Server Handshake defragmentation (16)" \
 
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (13)" \
-            "$P_SRV debug_level=4 " \
+            "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 13 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
@@ -14028,7 +14028,7 @@ run_test    "Server Handshake defragmentation (13)" \
 
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (5)" \
-            "$P_SRV debug_level=4 " \
+            "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 5 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -13874,6 +13874,7 @@ run_test    "TLS 1.2 ClientHello indicating support for deflate compression meth
 
 # Handshake defragmentation testing
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 run_test    "Client Handshake defragmentation (512)" \
@@ -13881,8 +13882,10 @@ run_test    "Client Handshake defragmentation (512)" \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
-            -c "waiting for more fragments (512 [0-9]\\+, [0-9]\\+ left)"
+            -c "handshake fragment: 0 \\.\\. 512 of [0-9]\\+ msglen 512" \
+            -c "waiting for more fragments (512 of [0-9]\\+"
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 run_test    "Client Handshake defragmentation (513)" \
@@ -13890,7 +13893,8 @@ run_test    "Client Handshake defragmentation (513)" \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
-            -c "waiting for more fragments (513 [0-9]\\+, [0-9]\\+ left)"
+            -c "handshake fragment: 0 \\.\\. 513 of [0-9]\\+ msglen 513" \
+            -c "waiting for more fragments (513 of [0-9]\\+"
 
 # OpenSSL does not allow max_send_frag to be less than 512
 # so we use split_send_frag instead for tests lower than 512 below.
@@ -13898,6 +13902,7 @@ run_test    "Client Handshake defragmentation (513)" \
 # There is an issue with OpenSSL when fragmenting with values less
 # than 512 bytes in TLS 1.2 so we require TLS 1.3 with these values.
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -13906,8 +13911,10 @@ run_test    "Client Handshake defragmentation (256)" \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
-            -c "waiting for more fragments (256 of [0-9]\\+, [0-9]\\+ left)"
+            -c "handshake fragment: 0 \\.\\. 256 of [0-9]\\+ msglen 256" \
+            -c "waiting for more fragments (256 of [0-9]\\+"
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -13916,8 +13923,10 @@ run_test    "Client Handshake defragmentation (128)" \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
-            -c "waiting for more fragments (128 [0-9]\\+, [0-9]\\+ left)"
+            -c "handshake fragment: 0 \\.\\. 128 of [0-9]\\+ msglen 128" \
+            -c "waiting for more fragments (128"
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -13926,8 +13935,10 @@ run_test    "Client Handshake defragmentation (64)" \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
-            -c "waiting for more fragments (64 [0-9]\\+, [0-9]\\+ left)"
+            -c "handshake fragment: 0 \\.\\. 64 of [0-9]\\+ msglen 64" \
+            -c "waiting for more fragments (64"
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -13936,8 +13947,10 @@ run_test    "Client Handshake defragmentation (36)" \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
-            -c "waiting for more fragments (36 [0-9]\\+, [0-9]\\+ left)"
+            -c "handshake fragment: 0 \\.\\. 36 of [0-9]\\+ msglen 36" \
+            -c "waiting for more fragments (36"
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -13946,8 +13959,10 @@ run_test    "Client Handshake defragmentation (32)" \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
-            -c "waiting for more fragments (32 [0-9]\\+, [0-9]\\+ left)"
+            -c "handshake fragment: 0 \\.\\. 32 of [0-9]\\+ msglen 32" \
+            -c "waiting for more fragments (32"
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -13956,8 +13971,10 @@ run_test    "Client Handshake defragmentation (16)" \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
-            -c "waiting for more fragments (16 [0-9]\\+, [0-9]\\+ left)"
+            -c "handshake fragment: 0 \\.\\. 16 of [0-9]\\+ msglen 16" \
+            -c "waiting for more fragments (16"
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -13966,8 +13983,10 @@ run_test    "Client Handshake defragmentation (13)" \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
-            -c "waiting for more fragments (13 [0-9]\\+, [0-9]\\+ left)"
+            -c "handshake fragment: 0 \\.\\. 13 of [0-9]\\+ msglen 13" \
+            -c "waiting for more fragments (13"
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -13976,8 +13995,10 @@ run_test    "Client Handshake defragmentation (5)" \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
-            -c "waiting for more fragments (5 [0-9]\\+, [0-9]\\+ left)"
+            -c "handshake fragment: 0 \\.\\. 5 of [0-9]\\+ msglen 5" \
+            -c "waiting for more fragments (5"
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 run_test    "Server Handshake defragmentation (512)" \
@@ -13985,8 +14006,10 @@ run_test    "Server Handshake defragmentation (512)" \
             "$O_NEXT_CLI -max_send_frag 512 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
-            -s "waiting for more fragments (512 [0-9]\\+, [0-9]\\+ left)"
+            -s "handshake fragment: 0 \\.\\. 512 of [0-9]\\+ msglen 512" \
+            -s "waiting for more fragments (512"
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 run_test    "Server Handshake defragmentation (513)" \
@@ -13994,8 +14017,10 @@ run_test    "Server Handshake defragmentation (513)" \
             "$O_NEXT_CLI -max_send_frag 513 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
-            -s "waiting for more fragments (513 [0-9]\\+, [0-9]\\+ left)"
+            -s "handshake fragment: 0 \\.\\. 513 of [0-9]\\+ msglen 513" \
+            -s "waiting for more fragments (513"
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -14004,8 +14029,10 @@ run_test    "Server Handshake defragmentation (256)" \
             "$O_NEXT_CLI -split_send_frag 256 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
-            -s "waiting for more fragments (256 [0-9]\\+, [0-9]\\+ left)"
+            -s "handshake fragment: 0 \\.\\. 256 of [0-9]\\+ msglen 256" \
+            -s "waiting for more fragments (256"
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -14014,8 +14041,10 @@ run_test    "Server Handshake defragmentation (128)" \
             "$O_NEXT_CLI -split_send_frag 128 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
-            -s "waiting for more fragments (128 [0-9]\\+, [0-9]\\+ left)"
+            -s "handshake fragment: 0 \\.\\. 128 of [0-9]\\+ msglen 128" \
+            -s "waiting for more fragments (128"
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -14024,8 +14053,10 @@ run_test    "Server Handshake defragmentation (64)" \
             "$O_NEXT_CLI -split_send_frag 64 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
-            -s "waiting for more fragments (64 [0-9]\\+, [0-9]\\+ left)"
+            -s "handshake fragment: 0 \\.\\. 64 of [0-9]\\+ msglen 64" \
+            -s "waiting for more fragments (64"
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -14034,8 +14065,10 @@ run_test    "Server Handshake defragmentation (36)" \
             "$O_NEXT_CLI -split_send_frag 36 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
-            -s "waiting for more fragments (36 [0-9]\\+, [0-9]\\+ left)"
+            -s "handshake fragment: 0 \\.\\. 36 of [0-9]\\+ msglen 36" \
+            -s "waiting for more fragments (36"
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -14044,8 +14077,10 @@ run_test    "Server Handshake defragmentation (32)" \
             "$O_NEXT_CLI -split_send_frag 32 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
-            -s "waiting for more fragments (32 [0-9]\\+, [0-9]\\+ left)"
+            -s "handshake fragment: 0 \\.\\. 32 of [0-9]\\+ msglen 32" \
+            -s "waiting for more fragments (32"
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -14054,8 +14089,10 @@ run_test    "Server Handshake defragmentation (16)" \
             "$O_NEXT_CLI -split_send_frag 16 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
-            -s "waiting for more fragments (16 [0-9]\\+, [0-9]\\+ left)"
+            -s "handshake fragment: 0 \\.\\. 16 of [0-9]\\+ msglen 16" \
+            -s "waiting for more fragments (16"
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -14064,8 +14101,10 @@ run_test    "Server Handshake defragmentation (13)" \
             "$O_NEXT_CLI -split_send_frag 13 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
-            -s "waiting for more fragments (12 [0-9]\\+, [0-9]\\+ left)"
+            -s "handshake fragment: 0 \\.\\. 13 of [0-9]\\+ msglen 13" \
+            -s "waiting for more fragments (13"
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -14074,7 +14113,8 @@ run_test    "Server Handshake defragmentation (5)" \
             "$O_NEXT_CLI -split_send_frag 5 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
-            -s "waiting for more fragments (5 [0-9]\\+, [0-9]\\+ left)"
+            -s "handshake fragment: 0 \\.\\. 5 of [0-9]\\+ msglen 5" \
+            -s "waiting for more fragments (5"
 
 # Test heap memory usage after handshake
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -13877,7 +13877,7 @@ run_test    "TLS 1.2 ClientHello indicating support for deflate compression meth
 requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
-run_test    "Client Handshake defragmentation (512)" \
+run_test    "Handshake defragmentation on client: len=512, TLS 1.3" \
             "$O_NEXT_SRV -max_send_frag 512 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -13888,7 +13888,7 @@ run_test    "Client Handshake defragmentation (512)" \
 requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
-run_test    "Client Handshake defragmentation (513)" \
+run_test    "Handshake defragmentation on client: len=513, TLS 1.3" \
             "$O_NEXT_SRV -max_send_frag 513 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -13906,7 +13906,7 @@ requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
-run_test    "Client Handshake defragmentation (256)" \
+run_test    "Handshake defragmentation on client: len=256, TLS 1.3" \
             "$O_NEXT_SRV -split_send_frag 256 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -13918,7 +13918,7 @@ requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
-run_test    "Client Handshake defragmentation (128)" \
+run_test    "Handshake defragmentation on client: len=128, TLS 1.3" \
             "$O_NEXT_SRV -split_send_frag 128 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -13930,7 +13930,7 @@ requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
-run_test    "Client Handshake defragmentation (64)" \
+run_test    "Handshake defragmentation on client: len=64, TLS 1.3" \
             "$O_NEXT_SRV -split_send_frag 64 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -13942,7 +13942,7 @@ requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
-run_test    "Client Handshake defragmentation (36)" \
+run_test    "Handshake defragmentation on client: len=36, TLS 1.3" \
             "$O_NEXT_SRV -split_send_frag 36 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -13954,7 +13954,7 @@ requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
-run_test    "Client Handshake defragmentation (32)" \
+run_test    "Handshake defragmentation on client: len=32, TLS 1.3" \
             "$O_NEXT_SRV -split_send_frag 32 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -13966,7 +13966,7 @@ requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
-run_test    "Client Handshake defragmentation (16)" \
+run_test    "Handshake defragmentation on client: len=14, TLS 1.3" \
             "$O_NEXT_SRV -split_send_frag 16 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -13978,7 +13978,7 @@ requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
-run_test    "Client Handshake defragmentation (13)" \
+run_test    "Handshake defragmentation on client: len=13, TLS 1.3" \
             "$O_NEXT_SRV -split_send_frag 13 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -13990,7 +13990,7 @@ requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
-run_test    "Client Handshake defragmentation (5)" \
+run_test    "Handshake defragmentation on client: len=5, TLS 1.3" \
             "$O_NEXT_SRV -split_send_frag 5 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -14001,7 +14001,7 @@ run_test    "Client Handshake defragmentation (5)" \
 requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
-run_test    "Server Handshake defragmentation (512)" \
+run_test    "Handshake defragmentation on server: len=512, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -max_send_frag 512 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14012,7 +14012,7 @@ run_test    "Server Handshake defragmentation (512)" \
 requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
-run_test    "Server Handshake defragmentation (513)" \
+run_test    "Handshake defragmentation on server: len=513, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -max_send_frag 513 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14024,7 +14024,7 @@ requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
-run_test    "Server Handshake defragmentation (256)" \
+run_test    "Handshake defragmentation on server: len=256, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 256 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14036,7 +14036,7 @@ requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
-run_test    "Server Handshake defragmentation (128)" \
+run_test    "Handshake defragmentation on server: len=128, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 128 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14048,7 +14048,7 @@ requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
-run_test    "Server Handshake defragmentation (64)" \
+run_test    "Handshake defragmentation on server: len=64, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 64 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14060,7 +14060,7 @@ requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
-run_test    "Server Handshake defragmentation (36)" \
+run_test    "Handshake defragmentation on server: len=36, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 36 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14072,7 +14072,7 @@ requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
-run_test    "Server Handshake defragmentation (32)" \
+run_test    "Handshake defragmentation on server: len=32, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 32 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14084,7 +14084,7 @@ requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
-run_test    "Server Handshake defragmentation (16)" \
+run_test    "Handshake defragmentation on server: len=16, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 16 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14096,7 +14096,7 @@ requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
-run_test    "Server Handshake defragmentation (13)" \
+run_test    "Handshake defragmentation on server: len=13, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 13 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14108,7 +14108,7 @@ requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
-run_test    "Server Handshake defragmentation (5)" \
+run_test    "Handshake defragmentation on server: len=5, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 5 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -13894,9 +13894,13 @@ run_test    "Handshake defragmentation on client: len=512, TLS 1.3" \
             -c "handshake fragment: 0 \\.\\. 512 of [0-9]\\+ msglen 512" \
             -c "waiting for more fragments (512 of [0-9]\\+"
 
+# Since the removal of the DHE-RSA key exchange, the default openssl server
+# certificate does not match what is provided by the testing client. Those
+# use-cases are out of scope for defregmentation testing, and should be skipped.
 requires_openssl_3_x
 requires_protocol_version tls12
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
 run_test    "Handshake defragmentation on client: len=512, TLS 1.2" \
             "$O_NEXT_SRV -tls1_2 -max_send_frag 512 " \
             "$P_CLI debug_level=4 " \
@@ -13919,6 +13923,7 @@ run_test    "Handshake defragmentation on client: len=513, TLS 1.3" \
 requires_openssl_3_x
 requires_protocol_version tls12
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
 run_test    "Handshake defragmentation on client: len=513, TLS 1.2" \
             "$O_NEXT_SRV -tls1_2 -max_send_frag 513 " \
             "$P_CLI debug_level=4 " \
@@ -13947,6 +13952,7 @@ run_test    "Handshake defragmentation on client: len=256, TLS 1.3" \
 requires_openssl_3_x
 requires_protocol_version tls12
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
 run_test    "Handshake defragmentation on client: len=256, TLS 1.2" \
             "$O_NEXT_SRV -tls1_2 -split_send_frag 256 " \
             "$P_CLI debug_level=4 " \
@@ -13969,6 +13975,7 @@ run_test    "Handshake defragmentation on client: len=128, TLS 1.3" \
 requires_openssl_3_x
 requires_protocol_version tls12
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
 run_test    "Handshake defragmentation on client: len=128, TLS 1.2" \
             "$O_NEXT_SRV -tls1_2 -split_send_frag 128 " \
             "$P_CLI debug_level=4 " \
@@ -13991,6 +13998,7 @@ run_test    "Handshake defragmentation on client: len=64, TLS 1.3" \
 requires_openssl_3_x
 requires_protocol_version tls12
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
 run_test    "Handshake defragmentation on client: len=64, TLS 1.2" \
             "$O_NEXT_SRV -tls1_2 -split_send_frag 64 " \
             "$P_CLI debug_level=4 " \
@@ -14013,6 +14021,7 @@ run_test    "Handshake defragmentation on client: len=36, TLS 1.3" \
 requires_openssl_3_x
 requires_protocol_version tls12
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
 run_test    "Handshake defragmentation on client: len=36, TLS 1.2" \
             "$O_NEXT_SRV -tls1_2 -split_send_frag 36 " \
             "$P_CLI debug_level=4 " \
@@ -14035,6 +14044,7 @@ run_test    "Handshake defragmentation on client: len=32, TLS 1.3" \
 requires_openssl_3_x
 requires_protocol_version tls12
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
 run_test    "Handshake defragmentation on client: len=32, TLS 1.2" \
             "$O_NEXT_SRV -tls1_2 -split_send_frag 32 " \
             "$P_CLI debug_level=4 " \
@@ -14057,6 +14067,7 @@ run_test    "Handshake defragmentation on client: len=14, TLS 1.3" \
 requires_openssl_3_x
 requires_protocol_version tls12
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
 run_test    "Handshake defragmentation on client: len=14, TLS 1.2" \
             "$O_NEXT_SRV -tls1_2 -split_send_frag 16 " \
             "$P_CLI debug_level=4 " \
@@ -14123,6 +14134,7 @@ run_test    "Handshake defragmentation on client: len=3, TLS 1.3" \
 requires_openssl_3_x
 requires_protocol_version tls12
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
 run_test    "Handshake defragmentation on client: len=3, TLS 1.2" \
             "$O_NEXT_SRV -tls1_2 -split_send_frag 3 " \
             "$P_CLI debug_level=4 " \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -13880,8 +13880,8 @@ run_test    "Client Handshake defragmentation (512)" \
             "$O_NEXT_SRV -max_send_frag 512 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "<= handshake" \
-            -c "handshake fragment: "
+            -c "reassembled record" \
+            -c "waiting for more fragments (512 [0-9]\\+, [0-9]\\+ left)"
 
 requires_openssl_tls1_3
 requires_certificate_authentication
@@ -13889,8 +13889,8 @@ run_test    "Client Handshake defragmentation (513)" \
             "$O_NEXT_SRV -max_send_frag 513 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "<= handshake" \
-            -c "handshake fragment: "
+            -c "reassembled record" \
+            -c "waiting for more fragments (513 [0-9]\\+, [0-9]\\+ left)"
 
 # OpenSSL does not allow max_send_frag to be less than 512
 # so we use split_send_frag instead for tests lower than 512 below.
@@ -13905,8 +13905,8 @@ run_test    "Client Handshake defragmentation (256)" \
             "$O_NEXT_SRV -split_send_frag 256 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "<= handshake" \
-            -c "handshake fragment: "
+            -c "reassembled record" \
+            -c "waiting for more fragments (256 of [0-9]\\+, [0-9]\\+ left)"
 
 requires_openssl_tls1_3
 requires_certificate_authentication
@@ -13915,8 +13915,8 @@ run_test    "Client Handshake defragmentation (128)" \
             "$O_NEXT_SRV -split_send_frag 128 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "<= handshake" \
-            -c "handshake fragment: "
+            -c "reassembled record" \
+            -c "waiting for more fragments (128 [0-9]\\+, [0-9]\\+ left)"
 
 requires_openssl_tls1_3
 requires_certificate_authentication
@@ -13925,8 +13925,8 @@ run_test    "Client Handshake defragmentation (64)" \
             "$O_NEXT_SRV -split_send_frag 64 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "<= handshake" \
-            -c "handshake fragment: "
+            -c "reassembled record" \
+            -c "waiting for more fragments (64 [0-9]\\+, [0-9]\\+ left)"
 
 requires_openssl_tls1_3
 requires_certificate_authentication
@@ -13935,8 +13935,8 @@ run_test    "Client Handshake defragmentation (36)" \
             "$O_NEXT_SRV -split_send_frag 36 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "<= handshake" \
-            -c "handshake fragment: "
+            -c "reassembled record" \
+            -c "waiting for more fragments (36 [0-9]\\+, [0-9]\\+ left)"
 
 requires_openssl_tls1_3
 requires_certificate_authentication
@@ -13945,8 +13945,8 @@ run_test    "Client Handshake defragmentation (32)" \
             "$O_NEXT_SRV -split_send_frag 32 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "<= handshake" \
-            -c "handshake fragment: "
+            -c "reassembled record" \
+            -c "waiting for more fragments (32 [0-9]\\+, [0-9]\\+ left)"
 
 requires_openssl_tls1_3
 requires_certificate_authentication
@@ -13955,8 +13955,8 @@ run_test    "Client Handshake defragmentation (16)" \
             "$O_NEXT_SRV -split_send_frag 16 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "<= handshake" \
-            -c "handshake fragment: "
+            -c "reassembled record" \
+            -c "waiting for more fragments (16 [0-9]\\+, [0-9]\\+ left)"
 
 requires_openssl_tls1_3
 requires_certificate_authentication
@@ -13965,8 +13965,8 @@ run_test    "Client Handshake defragmentation (13)" \
             "$O_NEXT_SRV -split_send_frag 13 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "<= handshake" \
-            -c "handshake fragment: "
+            -c "reassembled record" \
+            -c "waiting for more fragments (13 [0-9]\\+, [0-9]\\+ left)"
 
 requires_openssl_tls1_3
 requires_certificate_authentication
@@ -13975,8 +13975,8 @@ run_test    "Client Handshake defragmentation (5)" \
             "$O_NEXT_SRV -split_send_frag 5 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "<= handshake" \
-            -c "handshake fragment: "
+            -c "reassembled record" \
+            -c "waiting for more fragments (5 [0-9]\\+, [0-9]\\+ left)"
 
 requires_openssl_tls1_3
 requires_certificate_authentication
@@ -13984,8 +13984,8 @@ run_test    "Server Handshake defragmentation (512)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -max_send_frag 512 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
-            -s "<= handshake" \
-            -s "handshake fragment: "
+            -s "reassembled record" \
+            -s "waiting for more fragments (512 [0-9]\\+, [0-9]\\+ left)"
 
 requires_openssl_tls1_3
 requires_certificate_authentication
@@ -13993,8 +13993,8 @@ run_test    "Server Handshake defragmentation (513)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -max_send_frag 513 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
-            -s "<= handshake" \
-            -s "handshake fragment: "
+            -s "reassembled record" \
+            -s "waiting for more fragments (513 [0-9]\\+, [0-9]\\+ left)"
 
 requires_openssl_tls1_3
 requires_certificate_authentication
@@ -14003,8 +14003,8 @@ run_test    "Server Handshake defragmentation (256)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 256 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
-            -s "<= handshake" \
-            -s "handshake fragment: "
+            -s "reassembled record" \
+            -s "waiting for more fragments (256 [0-9]\\+, [0-9]\\+ left)"
 
 requires_openssl_tls1_3
 requires_certificate_authentication
@@ -14013,8 +14013,8 @@ run_test    "Server Handshake defragmentation (128)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 128 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
-            -s "<= handshake" \
-            -s "handshake fragment: "
+            -s "reassembled record" \
+            -s "waiting for more fragments (128 [0-9]\\+, [0-9]\\+ left)"
 
 requires_openssl_tls1_3
 requires_certificate_authentication
@@ -14023,8 +14023,8 @@ run_test    "Server Handshake defragmentation (64)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 64 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
-            -s "<= handshake" \
-            -s "handshake fragment: "
+            -s "reassembled record" \
+            -s "waiting for more fragments (64 [0-9]\\+, [0-9]\\+ left)"
 
 requires_openssl_tls1_3
 requires_certificate_authentication
@@ -14033,8 +14033,8 @@ run_test    "Server Handshake defragmentation (36)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 36 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
-            -s "<= handshake" \
-            -s "handshake fragment: "
+            -s "reassembled record" \
+            -s "waiting for more fragments (36 [0-9]\\+, [0-9]\\+ left)"
 
 requires_openssl_tls1_3
 requires_certificate_authentication
@@ -14043,8 +14043,8 @@ run_test    "Server Handshake defragmentation (32)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 32 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
-            -s "<= handshake" \
-            -s "handshake fragment: "
+            -s "reassembled record" \
+            -s "waiting for more fragments (32 [0-9]\\+, [0-9]\\+ left)"
 
 requires_openssl_tls1_3
 requires_certificate_authentication
@@ -14053,8 +14053,8 @@ run_test    "Server Handshake defragmentation (16)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 16 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
-            -s "<= handshake" \
-            -s "handshake fragment: "
+            -s "reassembled record" \
+            -s "waiting for more fragments (16 [0-9]\\+, [0-9]\\+ left)"
 
 requires_openssl_tls1_3
 requires_certificate_authentication
@@ -14063,8 +14063,8 @@ run_test    "Server Handshake defragmentation (13)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 13 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
-            -s "<= handshake" \
-            -s "handshake fragment: "
+            -s "reassembled record" \
+            -s "waiting for more fragments (12 [0-9]\\+, [0-9]\\+ left)"
 
 requires_openssl_tls1_3
 requires_certificate_authentication
@@ -14073,8 +14073,8 @@ run_test    "Server Handshake defragmentation (5)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 5 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
-            -s "<= handshake" \
-            -s "handshake fragment: "
+            -s "reassembled record" \
+            -s "waiting for more fragments (5 [0-9]\\+, [0-9]\\+ left)"
 
 # Test heap memory usage after handshake
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -13875,10 +13875,10 @@ run_test    "TLS 1.2 ClientHello indicating support for deflate compression meth
 # Handshake defragmentation testing
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=512, TLS 1.3" \
-            "$O_NEXT_SRV -max_send_frag 512 " \
+            "$O_NEXT_SRV -tls1_3 -max_send_frag 512 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
@@ -13886,10 +13886,10 @@ run_test    "Handshake defragmentation on client: len=512, TLS 1.3" \
             -c "waiting for more fragments (512 of [0-9]\\+"
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=513, TLS 1.3" \
-            "$O_NEXT_SRV -max_send_frag 513 " \
+            "$O_NEXT_SRV -tls1_3 -max_send_frag 513 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
@@ -13903,11 +13903,10 @@ run_test    "Handshake defragmentation on client: len=513, TLS 1.3" \
 # than 512 bytes in TLS 1.2 so we require TLS 1.3 with these values.
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Handshake defragmentation on client: len=256, TLS 1.3" \
-            "$O_NEXT_SRV -split_send_frag 256 " \
+            "$O_NEXT_SRV -tls1_3 -split_send_frag 256 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
@@ -13915,11 +13914,10 @@ run_test    "Handshake defragmentation on client: len=256, TLS 1.3" \
             -c "waiting for more fragments (256 of [0-9]\\+"
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Handshake defragmentation on client: len=128, TLS 1.3" \
-            "$O_NEXT_SRV -split_send_frag 128 " \
+            "$O_NEXT_SRV -tls1_3 -split_send_frag 128 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
@@ -13927,11 +13925,10 @@ run_test    "Handshake defragmentation on client: len=128, TLS 1.3" \
             -c "waiting for more fragments (128"
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Handshake defragmentation on client: len=64, TLS 1.3" \
-            "$O_NEXT_SRV -split_send_frag 64 " \
+            "$O_NEXT_SRV -tls1_3 -split_send_frag 64 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
@@ -13939,11 +13936,10 @@ run_test    "Handshake defragmentation on client: len=64, TLS 1.3" \
             -c "waiting for more fragments (64"
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Handshake defragmentation on client: len=36, TLS 1.3" \
-            "$O_NEXT_SRV -split_send_frag 36 " \
+            "$O_NEXT_SRV -tls1_3 -split_send_frag 36 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
@@ -13951,11 +13947,10 @@ run_test    "Handshake defragmentation on client: len=36, TLS 1.3" \
             -c "waiting for more fragments (36"
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Handshake defragmentation on client: len=32, TLS 1.3" \
-            "$O_NEXT_SRV -split_send_frag 32 " \
+            "$O_NEXT_SRV -tls1_3 -split_send_frag 32 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
@@ -13963,11 +13958,10 @@ run_test    "Handshake defragmentation on client: len=32, TLS 1.3" \
             -c "waiting for more fragments (32"
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Handshake defragmentation on client: len=14, TLS 1.3" \
-            "$O_NEXT_SRV -split_send_frag 16 " \
+            "$O_NEXT_SRV -tls1_3 -split_send_frag 16 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
@@ -13975,11 +13969,10 @@ run_test    "Handshake defragmentation on client: len=14, TLS 1.3" \
             -c "waiting for more fragments (16"
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Handshake defragmentation on client: len=13, TLS 1.3" \
-            "$O_NEXT_SRV -split_send_frag 13 " \
+            "$O_NEXT_SRV -tls1_3 -split_send_frag 13 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
@@ -13987,11 +13980,10 @@ run_test    "Handshake defragmentation on client: len=13, TLS 1.3" \
             -c "waiting for more fragments (13"
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Handshake defragmentation on client: len=5, TLS 1.3" \
-            "$O_NEXT_SRV -split_send_frag 5 " \
+            "$O_NEXT_SRV -tls1_3 -split_send_frag 5 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
@@ -13999,118 +13991,110 @@ run_test    "Handshake defragmentation on client: len=5, TLS 1.3" \
             -c "waiting for more fragments (5"
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=512, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
-            "$O_NEXT_CLI -max_send_frag 512 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -tls1_3 -max_send_frag 512 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 512 of [0-9]\\+ msglen 512" \
             -s "waiting for more fragments (512"
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=513, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
-            "$O_NEXT_CLI -max_send_frag 513 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -tls1_3 -max_send_frag 513 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 513 of [0-9]\\+ msglen 513" \
             -s "waiting for more fragments (513"
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Handshake defragmentation on server: len=256, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
-            "$O_NEXT_CLI -split_send_frag 256 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -tls1_3 -split_send_frag 256 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 256 of [0-9]\\+ msglen 256" \
             -s "waiting for more fragments (256"
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Handshake defragmentation on server: len=128, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
-            "$O_NEXT_CLI -split_send_frag 128 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -tls1_3 -split_send_frag 128 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 128 of [0-9]\\+ msglen 128" \
             -s "waiting for more fragments (128"
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Handshake defragmentation on server: len=64, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
-            "$O_NEXT_CLI -split_send_frag 64 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -tls1_3 -split_send_frag 64 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 64 of [0-9]\\+ msglen 64" \
             -s "waiting for more fragments (64"
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Handshake defragmentation on server: len=36, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
-            "$O_NEXT_CLI -split_send_frag 36 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -tls1_3 -split_send_frag 36 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 36 of [0-9]\\+ msglen 36" \
             -s "waiting for more fragments (36"
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Handshake defragmentation on server: len=32, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
-            "$O_NEXT_CLI -split_send_frag 32 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -tls1_3 -split_send_frag 32 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 32 of [0-9]\\+ msglen 32" \
             -s "waiting for more fragments (32"
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Handshake defragmentation on server: len=16, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
-            "$O_NEXT_CLI -split_send_frag 16 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -tls1_3 -split_send_frag 16 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 16 of [0-9]\\+ msglen 16" \
             -s "waiting for more fragments (16"
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Handshake defragmentation on server: len=13, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
-            "$O_NEXT_CLI -split_send_frag 13 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -tls1_3 -split_send_frag 13 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 13 of [0-9]\\+ msglen 13" \
             -s "waiting for more fragments (13"
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Handshake defragmentation on server: len=5, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
-            "$O_NEXT_CLI -split_send_frag 5 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -tls1_3 -split_send_frag 5 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 5 of [0-9]\\+ msglen 5" \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -13873,6 +13873,11 @@ run_test    "TLS 1.2 ClientHello indicating support for deflate compression meth
             -s "dumping .client hello, compression. (2 bytes)"
 
 # Handshake defragmentation testing
+
+# To warrant that the handhake messages are large enough and need to be split
+# into fragments, the tests require certificate authentication. The party in control
+# of the fragmentation operations is OpenSSL and will always use server5.crt (548 Bytes)
+# either from O_NEXT_SRV or test data.
 requires_openssl_3_x
 requires_protocol_version tls13
 requires_certificate_authentication
@@ -13931,12 +13936,6 @@ run_test    "Handshake defragmentation on client: len=513, TLS 1.2" \
             -c "reassembled record" \
             -c "handshake fragment: 0 \\.\\. 513 of [0-9]\\+ msglen 513" \
             -c "waiting for more fragments (513 of [0-9]\\+"
-
-# OpenSSL does not allow max_send_frag to be less than 512
-# so we use split_send_frag instead for tests lower than 512 below.
-
-# There is an issue with OpenSSL when fragmenting with values less
-# than 512 bytes in TLS 1.2 so we require TLS 1.3 with these values.
 
 requires_openssl_3_x
 requires_protocol_version tls13
@@ -14405,11 +14404,13 @@ run_test    "Handshake defragmentation on server: len=3, TLS 1.3" \
             -s "handshake message too short: 3" \
             -s "SSL - An invalid SSL record was received"
 
+# Server-side ClientHello degfragmentation is only supported for MBEDTLS_SSL_PROTO_TLS1_3. For TLS 1.2 testing
+# the server should suport both protocols and downgrade to client-requested TL1.2 after proccessing the ClientHello.
 requires_openssl_3_x
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
-run_test    "Handshake defragmentation on server: len=3, TLS 1.3" \
+run_test    "Handshake defragmentation on server: len=3, TLS 1.3 -> 1.2" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_2 -split_send_frag 3 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             1 \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -13878,8 +13878,7 @@ run_test    "TLS 1.2 ClientHello indicating support for deflate compression meth
 # into fragments, the tests require certificate authentication. The party in control
 # of the fragmentation operations is OpenSSL and will always use server5.crt (548 Bytes)
 # either from O_NEXT_SRV or test data.
-requires_openssl_3_x
-requires_protocol_version tls13
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client (no fragmentation, for reference)" \
             "$O_NEXT_SRV" \
@@ -13888,8 +13887,7 @@ run_test    "Handshake defragmentation on client (no fragmentation, for referenc
             -C "reassembled record" \
             -C "waiting for more fragments"
 
-requires_openssl_3_x
-requires_protocol_version tls13
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=512, TLS 1.3" \
             "$O_NEXT_SRV -tls1_3 -split_send_frag 512 " \
@@ -13902,8 +13900,7 @@ run_test    "Handshake defragmentation on client: len=512, TLS 1.3" \
 # Since the removal of the DHE-RSA key exchange, the default openssl server
 # certificate does not match what is provided by the testing client. Those
 # use-cases are out of scope for defregmentation testing, and should be skipped.
-requires_openssl_3_x
-requires_protocol_version tls12
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
 run_test    "Handshake defragmentation on client: len=512, TLS 1.2" \
@@ -13914,8 +13911,7 @@ run_test    "Handshake defragmentation on client: len=512, TLS 1.2" \
             -c "handshake fragment: 0 \\.\\. 512 of [0-9]\\+ msglen 512" \
             -c "waiting for more fragments (512 of [0-9]\\+"
 
-requires_openssl_3_x
-requires_protocol_version tls13
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=513, TLS 1.3" \
             "$O_NEXT_SRV -tls1_3 -split_send_frag 513 " \
@@ -13925,8 +13921,7 @@ run_test    "Handshake defragmentation on client: len=513, TLS 1.3" \
             -c "handshake fragment: 0 \\.\\. 513 of [0-9]\\+ msglen 513" \
             -c "waiting for more fragments (513 of [0-9]\\+"
 
-requires_openssl_3_x
-requires_protocol_version tls12
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
 run_test    "Handshake defragmentation on client: len=513, TLS 1.2" \
@@ -13937,8 +13932,7 @@ run_test    "Handshake defragmentation on client: len=513, TLS 1.2" \
             -c "handshake fragment: 0 \\.\\. 513 of [0-9]\\+ msglen 513" \
             -c "waiting for more fragments (513 of [0-9]\\+"
 
-requires_openssl_3_x
-requires_protocol_version tls13
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=256, TLS 1.3" \
             "$O_NEXT_SRV -tls1_3 -split_send_frag 256 " \
@@ -13948,8 +13942,7 @@ run_test    "Handshake defragmentation on client: len=256, TLS 1.3" \
             -c "handshake fragment: 0 \\.\\. 256 of [0-9]\\+ msglen 256" \
             -c "waiting for more fragments (256 of [0-9]\\+"
 
-requires_openssl_3_x
-requires_protocol_version tls12
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
 run_test    "Handshake defragmentation on client: len=256, TLS 1.2" \
@@ -13960,8 +13953,7 @@ run_test    "Handshake defragmentation on client: len=256, TLS 1.2" \
             -c "handshake fragment: 0 \\.\\. 256 of [0-9]\\+ msglen 256" \
             -c "waiting for more fragments (256 of [0-9]\\+"
 
-requires_openssl_3_x
-requires_protocol_version tls13
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=128, TLS 1.3" \
             "$O_NEXT_SRV -tls1_3 -split_send_frag 128 " \
@@ -13971,8 +13963,7 @@ run_test    "Handshake defragmentation on client: len=128, TLS 1.3" \
             -c "handshake fragment: 0 \\.\\. 128 of [0-9]\\+ msglen 128" \
             -c "waiting for more fragments (128"
 
-requires_openssl_3_x
-requires_protocol_version tls12
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
 run_test    "Handshake defragmentation on client: len=128, TLS 1.2" \
@@ -13983,8 +13974,7 @@ run_test    "Handshake defragmentation on client: len=128, TLS 1.2" \
             -c "handshake fragment: 0 \\.\\. 128 of [0-9]\\+ msglen 128" \
             -c "waiting for more fragments (128"
 
-requires_openssl_3_x
-requires_protocol_version tls13
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=64, TLS 1.3" \
             "$O_NEXT_SRV -tls1_3 -split_send_frag 64 " \
@@ -13994,8 +13984,7 @@ run_test    "Handshake defragmentation on client: len=64, TLS 1.3" \
             -c "handshake fragment: 0 \\.\\. 64 of [0-9]\\+ msglen 64" \
             -c "waiting for more fragments (64"
 
-requires_openssl_3_x
-requires_protocol_version tls12
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
 run_test    "Handshake defragmentation on client: len=64, TLS 1.2" \
@@ -14006,8 +13995,7 @@ run_test    "Handshake defragmentation on client: len=64, TLS 1.2" \
             -c "handshake fragment: 0 \\.\\. 64 of [0-9]\\+ msglen 64" \
             -c "waiting for more fragments (64"
 
-requires_openssl_3_x
-requires_protocol_version tls13
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=36, TLS 1.3" \
             "$O_NEXT_SRV -tls1_3 -split_send_frag 36 " \
@@ -14017,8 +14005,7 @@ run_test    "Handshake defragmentation on client: len=36, TLS 1.3" \
             -c "handshake fragment: 0 \\.\\. 36 of [0-9]\\+ msglen 36" \
             -c "waiting for more fragments (36"
 
-requires_openssl_3_x
-requires_protocol_version tls12
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
 run_test    "Handshake defragmentation on client: len=36, TLS 1.2" \
@@ -14029,8 +14016,7 @@ run_test    "Handshake defragmentation on client: len=36, TLS 1.2" \
             -c "handshake fragment: 0 \\.\\. 36 of [0-9]\\+ msglen 36" \
             -c "waiting for more fragments (36"
 
-requires_openssl_3_x
-requires_protocol_version tls13
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=32, TLS 1.3" \
             "$O_NEXT_SRV -tls1_3 -split_send_frag 32 " \
@@ -14040,8 +14026,7 @@ run_test    "Handshake defragmentation on client: len=32, TLS 1.3" \
             -c "handshake fragment: 0 \\.\\. 32 of [0-9]\\+ msglen 32" \
             -c "waiting for more fragments (32"
 
-requires_openssl_3_x
-requires_protocol_version tls12
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
 run_test    "Handshake defragmentation on client: len=32, TLS 1.2" \
@@ -14052,8 +14037,7 @@ run_test    "Handshake defragmentation on client: len=32, TLS 1.2" \
             -c "handshake fragment: 0 \\.\\. 32 of [0-9]\\+ msglen 32" \
             -c "waiting for more fragments (32"
 
-requires_openssl_3_x
-requires_protocol_version tls13
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=16, TLS 1.3" \
             "$O_NEXT_SRV -tls1_3 -split_send_frag 16 " \
@@ -14063,8 +14047,7 @@ run_test    "Handshake defragmentation on client: len=16, TLS 1.3" \
             -c "handshake fragment: 0 \\.\\. 16 of [0-9]\\+ msglen 16" \
             -c "waiting for more fragments (16"
 
-requires_openssl_3_x
-requires_protocol_version tls12
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
 run_test    "Handshake defragmentation on client: len=16, TLS 1.2" \
@@ -14075,8 +14058,7 @@ run_test    "Handshake defragmentation on client: len=16, TLS 1.2" \
             -c "handshake fragment: 0 \\.\\. 16 of [0-9]\\+ msglen 16" \
             -c "waiting for more fragments (16"
 
-requires_openssl_3_x
-requires_protocol_version tls13
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=13, TLS 1.3" \
             "$O_NEXT_SRV -tls1_3 -split_send_frag 13 " \
@@ -14087,8 +14069,7 @@ run_test    "Handshake defragmentation on client: len=13, TLS 1.3" \
             -c "waiting for more fragments (13"
 
 skip_next_test
-requires_openssl_3_x
-requires_protocol_version tls12
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=13, TLS 1.2" \
             "$O_NEXT_SRV -tls1_2 -split_send_frag 13 " \
@@ -14098,8 +14079,7 @@ run_test    "Handshake defragmentation on client: len=13, TLS 1.2" \
             -c "handshake fragment: 0 \\.\\. 13 of [0-9]\\+ msglen 13" \
             -c "waiting for more fragments (13"
 
-requires_openssl_3_x
-requires_protocol_version tls13
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=5, TLS 1.3" \
             "$O_NEXT_SRV -tls1_3 -split_send_frag 5 " \
@@ -14110,8 +14090,7 @@ run_test    "Handshake defragmentation on client: len=5, TLS 1.3" \
             -c "waiting for more fragments (5"
 
 skip_next_test
-requires_openssl_3_x
-requires_protocol_version tls12
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=5, TLS 1.2" \
             "$O_NEXT_SRV -tls1_2 -split_send_frag 5 " \
@@ -14121,8 +14100,7 @@ run_test    "Handshake defragmentation on client: len=5, TLS 1.2" \
             -c "handshake fragment: 0 \\.\\. 5 of [0-9]\\+ msglen 5" \
             -c "waiting for more fragments (5"
 
-requires_openssl_3_x
-requires_protocol_version tls13
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=4, TLS 1.3" \
             "$O_NEXT_SRV -tls1_3 -split_send_frag 4 " \
@@ -14133,8 +14111,7 @@ run_test    "Handshake defragmentation on client: len=4, TLS 1.3" \
             -c "waiting for more fragments (4"
 
 skip_next_test
-requires_openssl_3_x
-requires_protocol_version tls12
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=4, TLS 1.2" \
             "$O_NEXT_SRV -tls1_2 -split_send_frag 4 " \
@@ -14144,8 +14121,7 @@ run_test    "Handshake defragmentation on client: len=4, TLS 1.2" \
             -c "handshake fragment: 0 \\.\\. 4 of [0-9]\\+ msglen 4" \
             -c "waiting for more fragments (4"
 
-requires_openssl_3_x
-requires_protocol_version tls13
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=3, TLS 1.3" \
             "$O_NEXT_SRV -tls1_3 -split_send_frag 3 " \
@@ -14155,8 +14131,7 @@ run_test    "Handshake defragmentation on client: len=3, TLS 1.3" \
             -c "handshake message too short: 3" \
             -c "SSL - An invalid SSL record was received"
 
-requires_openssl_3_x
-requires_protocol_version tls12
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
 run_test    "Handshake defragmentation on client: len=3, TLS 1.2" \
@@ -14166,7 +14141,7 @@ run_test    "Handshake defragmentation on client: len=3, TLS 1.2" \
             -c "handshake message too short: 3" \
             -c "SSL - An invalid SSL record was received"
 
-requires_protocol_version tls13
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server (no fragmentation, for reference)." \
             "$P_SRV debug_level=4 auth_mode=required" \
@@ -14175,8 +14150,7 @@ run_test    "Handshake defragmentation on server (no fragmentation, for referenc
             -C "reassembled record" \
             -C "waiting for more fragments"
 
-requires_openssl_3_x
-requires_protocol_version tls13
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=512, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
@@ -14186,8 +14160,7 @@ run_test    "Handshake defragmentation on server: len=512, TLS 1.3" \
             -s "handshake fragment: 0 \\.\\. 512 of [0-9]\\+ msglen 512" \
             -s "waiting for more fragments (512"
 
-requires_openssl_3_x
-requires_protocol_version tls12
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=512, TLS 1.2" \
             "$P_SRV debug_level=4 auth_mode=required" \
@@ -14197,8 +14170,7 @@ run_test    "Handshake defragmentation on server: len=512, TLS 1.2" \
             -s "handshake fragment: 0 \\.\\. 512 of [0-9]\\+ msglen 512" \
             -s "waiting for more fragments (512"
 
-requires_openssl_3_x
-requires_protocol_version tls13
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=513, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
@@ -14208,8 +14180,7 @@ run_test    "Handshake defragmentation on server: len=513, TLS 1.3" \
             -s "handshake fragment: 0 \\.\\. 513 of [0-9]\\+ msglen 513" \
             -s "waiting for more fragments (513"
 
-requires_openssl_3_x
-requires_protocol_version tls12
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=513, TLS 1.2" \
             "$P_SRV debug_level=4 auth_mode=required" \
@@ -14219,8 +14190,7 @@ run_test    "Handshake defragmentation on server: len=513, TLS 1.2" \
             -s "handshake fragment: 0 \\.\\. 513 of [0-9]\\+ msglen 513" \
             -s "waiting for more fragments (513"
 
-requires_openssl_3_x
-requires_protocol_version tls13
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=256, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
@@ -14230,8 +14200,7 @@ run_test    "Handshake defragmentation on server: len=256, TLS 1.3" \
             -s "handshake fragment: 0 \\.\\. 256 of [0-9]\\+ msglen 256" \
             -s "waiting for more fragments (256"
 
-requires_openssl_3_x
-requires_protocol_version tls12
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=256, TLS 1.2" \
             "$P_SRV debug_level=4 auth_mode=required" \
@@ -14241,8 +14210,7 @@ run_test    "Handshake defragmentation on server: len=256, TLS 1.2" \
             -s "handshake fragment: 0 \\.\\. 256 of [0-9]\\+ msglen 256" \
             -s "waiting for more fragments (256"
 
-requires_openssl_3_x
-requires_protocol_version tls13
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=128, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
@@ -14254,7 +14222,6 @@ run_test    "Handshake defragmentation on server: len=128, TLS 1.3" \
 
 # Server-side ClientHello degfragmentation is only supported for MBEDTLS_SSL_PROTO_TLS1_3. For TLS 1.2 testing
 # the server should suport both protocols and downgrade to client-requested TL1.2 after proccessing the ClientHello.
-requires_openssl_3_x
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
@@ -14266,8 +14233,7 @@ run_test    "Handshake defragmentation on server: len=128, TLS 1.2" \
             -s "handshake fragment: 0 \\.\\. 128 of [0-9]\\+ msglen 128" \
             -s "waiting for more fragments (128"
 
-requires_openssl_3_x
-requires_protocol_version tls13
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=64, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
@@ -14277,7 +14243,6 @@ run_test    "Handshake defragmentation on server: len=64, TLS 1.3" \
             -s "handshake fragment: 0 \\.\\. 64 of [0-9]\\+ msglen 64" \
             -s "waiting for more fragments (64"
 
-requires_openssl_3_x
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
@@ -14289,8 +14254,7 @@ run_test    "Handshake defragmentation on server: len=64, TLS 1.2" \
             -s "handshake fragment: 0 \\.\\. 64 of [0-9]\\+ msglen 64" \
             -s "waiting for more fragments (64"
 
-requires_openssl_3_x
-requires_protocol_version tls13
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=36, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
@@ -14300,7 +14264,6 @@ run_test    "Handshake defragmentation on server: len=36, TLS 1.3" \
             -s "handshake fragment: 0 \\.\\. 36 of [0-9]\\+ msglen 36" \
             -s "waiting for more fragments (36"
 
-requires_openssl_3_x
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
@@ -14312,8 +14275,7 @@ run_test    "Handshake defragmentation on server: len=36, TLS 1.2" \
             -s "handshake fragment: 0 \\.\\. 36 of [0-9]\\+ msglen 36" \
             -s "waiting for more fragments (36"
 
-requires_openssl_3_x
-requires_protocol_version tls13
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=32, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
@@ -14323,7 +14285,6 @@ run_test    "Handshake defragmentation on server: len=32, TLS 1.3" \
             -s "handshake fragment: 0 \\.\\. 32 of [0-9]\\+ msglen 32" \
             -s "waiting for more fragments (32"
 
-requires_openssl_3_x
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
@@ -14335,8 +14296,7 @@ run_test    "Handshake defragmentation on server: len=32, TLS 1.2" \
             -s "handshake fragment: 0 \\.\\. 32 of [0-9]\\+ msglen 32" \
             -s "waiting for more fragments (32"
 
-requires_openssl_3_x
-requires_protocol_version tls13
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=16, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
@@ -14346,7 +14306,6 @@ run_test    "Handshake defragmentation on server: len=16, TLS 1.3" \
             -s "handshake fragment: 0 \\.\\. 16 of [0-9]\\+ msglen 16" \
             -s "waiting for more fragments (16"
 
-requires_openssl_3_x
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
@@ -14358,8 +14317,7 @@ run_test    "Handshake defragmentation on server: len=16, TLS 1.2" \
             -s "handshake fragment: 0 \\.\\. 16 of [0-9]\\+ msglen 16" \
             -s "waiting for more fragments (16"
 
-requires_openssl_3_x
-requires_protocol_version tls13
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=13, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
@@ -14369,7 +14327,6 @@ run_test    "Handshake defragmentation on server: len=13, TLS 1.3" \
             -s "handshake fragment: 0 \\.\\. 13 of [0-9]\\+ msglen 13" \
             -s "waiting for more fragments (13"
 
-requires_openssl_3_x
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
@@ -14381,8 +14338,7 @@ run_test    "Handshake defragmentation on server: len=13, TLS 1.2" \
             -s "handshake fragment: 0 \\.\\. 13 of [0-9]\\+ msglen 13" \
             -s "waiting for more fragments (13"
 
-requires_openssl_3_x
-requires_protocol_version tls13
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=5, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
@@ -14392,7 +14348,6 @@ run_test    "Handshake defragmentation on server: len=5, TLS 1.3" \
             -s "handshake fragment: 0 \\.\\. 5 of [0-9]\\+ msglen 5" \
             -s "waiting for more fragments (5"
 
-requires_openssl_3_x
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
@@ -14404,8 +14359,7 @@ run_test    "Handshake defragmentation on server: len=5, TLS 1.2" \
             -s "handshake fragment: 0 \\.\\. 5 of [0-9]\\+ msglen 5" \
             -s "waiting for more fragments (5"
 
-requires_openssl_3_x
-requires_protocol_version tls13
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=4, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
@@ -14415,7 +14369,6 @@ run_test    "Handshake defragmentation on server: len=4, TLS 1.3" \
             -s "handshake fragment: 0 \\.\\. 4 of [0-9]\\+ msglen 4" \
             -s "waiting for more fragments (4"
 
-requires_openssl_3_x
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
@@ -14427,8 +14380,7 @@ run_test    "Handshake defragmentation on server: len=4, TLS 1.2" \
             -s "handshake fragment: 0 \\.\\. 4 of [0-9]\\+ msglen 4" \
             -s "waiting for more fragments (4"
 
-requires_openssl_3_x
-requires_protocol_version tls13
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=3, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
@@ -14438,7 +14390,6 @@ run_test    "Handshake defragmentation on server: len=3, TLS 1.3" \
             -s "handshake message too short: 3" \
             -s "SSL - An invalid SSL record was received"
 
-requires_openssl_3_x
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
@@ -14450,7 +14401,6 @@ run_test    "Handshake defragmentation on server: len=3, TLS 1.3 -> 1.2" \
             -s "handshake message too short: 3" \
             -s "SSL - An invalid SSL record was received"
 
-requires_openssl_3_x
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -13873,6 +13873,15 @@ run_test    "TLS 1.2 ClientHello indicating support for deflate compression meth
             -s "dumping .client hello, compression. (2 bytes)"
 
 # Handshake defragmentation testing
+requires_openssl_3_x
+requires_protocol_version tls13
+requires_certificate_authentication
+run_test    "Handshake defragmentation on client (no fragmentation, for reference)" \
+            "$O_NEXT_SRV" \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -C "reassembled record" \
+            -C "waiting for more fragments"
 
 requires_openssl_3_x
 requires_protocol_version tls13
@@ -14099,6 +14108,16 @@ run_test    "Handshake defragmentation on client: len=5, TLS 1.2" \
             -c "reassembled record" \
             -c "handshake fragment: 0 \\.\\. 5 of [0-9]\\+ msglen 5" \
             -c "waiting for more fragments (5"
+
+requires_openssl_3_x
+requires_protocol_version tls13
+requires_certificate_authentication
+run_test    "Handshake defragmentation on server (no fragmentation, for reference)." \
+            "$P_SRV debug_level=4 auth_mode=required" \
+            "$O_NEXT_CLI -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            0 \
+            -C "reassembled record" \
+            -C "waiting for more fragments"
 
 requires_openssl_3_x
 requires_protocol_version tls13

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14118,7 +14118,6 @@ run_test    "Handshake defragmentation on client: len=4, TLS 1.2" \
             -c "waiting for more fragments (4"
 
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
-requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=3, TLS 1.3" \
             "$O_NEXT_SRV -tls1_3 -split_send_frag 3 " \
             "$P_CLI debug_level=4 " \
@@ -14128,8 +14127,6 @@ run_test    "Handshake defragmentation on client: len=3, TLS 1.3" \
             -c "SSL - An invalid SSL record was received"
 
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-requires_certificate_authentication
-requires_config_enabled MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
 run_test    "Handshake defragmentation on client: len=3, TLS 1.2" \
             "$O_NEXT_SRV -tls1_2 -split_send_frag 3 " \
             "$P_CLI debug_level=4 " \
@@ -14397,7 +14394,6 @@ run_test    "Handshake defragmentation on server: len=3, TLS 1.3 ClientHello -> 
             -s "SSL - An invalid SSL record was received"
 
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=32, TLS 1.2 ClientHello" \
             "$P_SRV debug_level=4 force_version=tls12 auth_mode=required" \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14109,7 +14109,6 @@ run_test    "Handshake defragmentation on client: len=5, TLS 1.2" \
             -c "handshake fragment: 0 \\.\\. 5 of [0-9]\\+ msglen 5" \
             -c "waiting for more fragments (5"
 
-requires_openssl_3_x
 requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server (no fragmentation, for reference)." \
@@ -14339,6 +14338,28 @@ run_test    "Handshake defragmentation on server: len=5, TLS 1.2" \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 5 of [0-9]\\+ msglen 5" \
             -s "waiting for more fragments (5"
+
+requires_protocol_version tls13
+requires_certificate_authentication
+run_test    "Handshake defragmentation on server: len=4, TLS 1.3" \
+            "$P_SRV debug_level=4 auth_mode=required" \
+            "$O_NEXT_CLI -tls1_3 -split_send_frag 4 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            0 \
+            -s "reassembled record" \
+            -s "handshake fragment: 0 \\.\\. 4 of [0-9]\\+ msglen 4" \
+            -s "waiting for more fragments (4"
+
+requires_openssl_3_x
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
+requires_certificate_authentication
+run_test    "Handshake defragmentation on server: len=4, TLS 1.2" \
+            "$P_SRV debug_level=4 auth_mode=required" \
+            "$O_NEXT_CLI -tls1_2 -split_send_frag 4 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            0 \
+            -s "reassembled record" \
+            -s "handshake fragment: 0 \\.\\. 4 of [0-9]\\+ msglen 4" \
+            -s "waiting for more fragments (4"
 
 # Test heap memory usage after handshake
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -13890,6 +13890,9 @@ run_test    "Client Handshake defragmentation (513)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
+# OpenSSL does not allow max_send_frag to be less than 512
+# so we use split_send_frag instead for tests lower than 512 below.
+
 requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (256)" \
             "$O_NEXT_SRV -split_send_frag 256 " \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -13892,7 +13892,7 @@ requires_openssl_3_x
 requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=512, TLS 1.3" \
-            "$O_NEXT_SRV -tls1_3 -max_send_frag 512 " \
+            "$O_NEXT_SRV -tls1_3 -split_send_frag 512 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
@@ -13907,7 +13907,7 @@ requires_protocol_version tls12
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
 run_test    "Handshake defragmentation on client: len=512, TLS 1.2" \
-            "$O_NEXT_SRV -tls1_2 -max_send_frag 512 " \
+            "$O_NEXT_SRV -tls1_2 -split_send_frag 512 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
@@ -13918,7 +13918,7 @@ requires_openssl_3_x
 requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=513, TLS 1.3" \
-            "$O_NEXT_SRV -tls1_3 -max_send_frag 513 " \
+            "$O_NEXT_SRV -tls1_3 -split_send_frag 513 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
@@ -13930,7 +13930,7 @@ requires_protocol_version tls12
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
 run_test    "Handshake defragmentation on client: len=513, TLS 1.2" \
-            "$O_NEXT_SRV -tls1_2 -max_send_frag 513 " \
+            "$O_NEXT_SRV -tls1_2 -split_send_frag 513 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
@@ -14177,7 +14177,7 @@ requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=512, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
-            "$O_NEXT_CLI -tls1_3 -max_send_frag 512 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -tls1_3 -split_send_frag 512 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 512 of [0-9]\\+ msglen 512" \
@@ -14188,7 +14188,7 @@ requires_protocol_version tls12
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=512, TLS 1.2" \
             "$P_SRV debug_level=4 auth_mode=required" \
-            "$O_NEXT_CLI -tls1_2 -max_send_frag 512 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -tls1_2 -split_send_frag 512 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 512 of [0-9]\\+ msglen 512" \
@@ -14199,7 +14199,7 @@ requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=513, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
-            "$O_NEXT_CLI -tls1_3 -max_send_frag 513 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -tls1_3 -split_send_frag 513 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 513 of [0-9]\\+ msglen 513" \
@@ -14210,7 +14210,7 @@ requires_protocol_version tls12
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=513, TLS 1.2" \
             "$P_SRV debug_level=4 auth_mode=required" \
-            "$O_NEXT_CLI -tls1_2 -max_send_frag 513 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -tls1_2 -split_send_frag 513 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 513 of [0-9]\\+ msglen 513" \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -13874,87 +13874,156 @@ run_test    "TLS 1.2 ClientHello indicating support for deflate compression meth
 
 # Handshake defragmentation testing
 
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-run_test    "Hanshake defragmentation (512)" \
-            "$O_SRV -max_send_frag 512 " \
+run_test    "Client Hanshake defragmentation (512)" \
+            "$O_NEXT_SRV -max_send_frag 512 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "received ServerHello message" \
             -c "<= handshake" \
+            -c "handshake fragment: "
 
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-run_test    "Hanshake defragmentation (513)" \
-            "$O_SRV -max_send_frag 513 " \
+run_test    "Client Hanshake defragmentation (513)" \
+            "$O_NEXT_SRV -max_send_frag 513 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "received ServerHello message" \
             -c "<= handshake" \
+            -c "handshake fragment: "
 
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-run_test    "Hanshake defragmentation (256)" \
-            "$O_SRV -mtu 32 -split_send_frag 256 " \
+run_test    "Client Hanshake defragmentation (256)" \
+            "$O_NEXT_SRV -mtu 32 -split_send_frag 256 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "received ServerHello message" \
             -c "<= handshake" \
+            -c "handshake fragment: "
 
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-run_test    "Hanshake defragmentation (128)" \
-            "$O_SRV -mtu 32 -split_send_frag 128 " \
+run_test    "Client Hanshake defragmentation (128)" \
+            "$O_NEXT_SRV -mtu 32 -split_send_frag 128 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "received ServerHello message" \
             -c "<= handshake" \
+            -c "handshake fragment: "
 
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-run_test    "Hanshake defragmentation (64)" \
-            "$O_SRV -mtu 32 -split_send_frag 64 " \
+run_test    "Client Hanshake defragmentation (64)" \
+            "$O_NEXT_SRV -mtu 32 -split_send_frag 64 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "received ServerHello message" \
             -c "<= handshake" \
+            -c "handshake fragment: "
 
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-run_test    "Hanshake defragmentation (36)" \
-            "$O_SRV -mtu 32 -split_send_frag 36 " \
+run_test    "Client Hanshake defragmentation (36)" \
+            "$O_NEXT_SRV -mtu 32 -split_send_frag 36 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "received ServerHello message" \
             -c "<= handshake" \
+            -c "handshake fragment: "
 
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-run_test    "Hanshake defragmentation (32)" \
-            "$O_SRV -mtu 32 -split_send_frag 32 " \
+run_test    "Client Hanshake defragmentation (32)" \
+            "$O_NEXT_SRV -mtu 32 -split_send_frag 32 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "received ServerHello message" \
             -c "<= handshake" \
+            -c "handshake fragment: "
 
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-run_test    "Hanshake defragmentation (16)" \
-            "$O_SRV -mtu 32 -split_send_frag 16 " \
+run_test    "Client Hanshake defragmentation (16)" \
+            "$O_NEXT_SRV -mtu 32 -split_send_frag 16 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "received ServerHello message" \
             -c "<= handshake" \
+            -c "handshake fragment: "
 
 
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-run_test    "Hanshake defragmentation (13)" \
-            "$O_SRV -mtu 32 -split_send_frag 13 " \
+run_test    "Client Hanshake defragmentation (13)" \
+            "$O_NEXT_SRV -mtu 32 -split_send_frag 13 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "received ServerHello message" \
             -c "<= handshake" \
+            -c "handshake fragment: "
 
-
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-run_test    "Hanshake defragmentation (5)" \
-            "$O_SRV -mtu 32 -split_send_frag 5 " \
+run_test    "Client Hanshake defragmentation (5)" \
+            "$O_NEXT_SRV -mtu 32 -split_send_frag 5 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "received ServerHello message" \
             -c "<= handshake" \
+            -c "handshake fragment: "
+
+run_test    "Server Hanshake defragmentation (512)" \
+            "$P_SRV debug_level=4 " \
+            "$O_NEXT_CLI -max_send_frag 512 " \
+            0 \
+            -s "<= handshake" \
+            -s "handshake fragment: "
+
+run_test    "Server Hanshake defragmentation (513)" \
+            "$P_SRV debug_level=4 " \
+            "$O_NEXT_CLI -max_send_frag 513 " \
+            0 \
+            -s "<= handshake" \
+            -s "handshake fragment: "
+
+run_test    "Server Hanshake defragmentation (256)" \
+            "$P_SRV debug_level=4 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 256 " \
+            0 \
+            -s "<= handshake" \
+            -s "handshake fragment: "
+
+run_test    "Server Hanshake defragmentation (128)" \
+            "$P_SRV debug_level=4 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 128 " \
+            0 \
+            -s "<= handshake" \
+            -s "handshake fragment: "
+
+run_test    "Server Hanshake defragmentation (64)" \
+            "$P_SRV debug_level=4 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 64 " \
+            0 \
+            -s "<= handshake" \
+            -s "handshake fragment: "
+
+run_test    "Server Hanshake defragmentation (36)" \
+            "$P_SRV debug_level=4 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 36 " \
+            0 \
+            -s "<= handshake" \
+            -s "handshake fragment: "
+
+run_test    "Server Hanshake defragmentation (32)" \
+            "$P_SRV debug_level=4 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 32 " \
+            0 \
+            -s "<= handshake" \
+            -s "handshake fragment: "
+
+run_test    "Server Hanshake defragmentation (16)" \
+            "$P_SRV debug_level=4 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 16 " \
+            0 \
+            -s "<= handshake" \
+            -s "handshake fragment: "
+
+run_test    "Server Hanshake defragmentation (13)" \
+            "$P_SRV debug_level=4 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 13 " \
+            0 \
+            -s "<= handshake" \
+            -s "handshake fragment: "
+
+run_test    "Server Hanshake defragmentation (5)" \
+            "$P_SRV debug_level=4 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 5 " \
+            0 \
+            -s "<= handshake" \
+            -s "handshake fragment: "
 
 # Test heap memory usage after handshake
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14086,6 +14086,7 @@ run_test    "Handshake defragmentation on client: len=13, TLS 1.3" \
             -c "handshake fragment: 0 \\.\\. 13 of [0-9]\\+ msglen 13" \
             -c "waiting for more fragments (13"
 
+skip_next_test
 requires_openssl_3_x
 requires_protocol_version tls12
 requires_certificate_authentication
@@ -14108,6 +14109,7 @@ run_test    "Handshake defragmentation on client: len=5, TLS 1.3" \
             -c "handshake fragment: 0 \\.\\. 5 of [0-9]\\+ msglen 5" \
             -c "waiting for more fragments (5"
 
+skip_next_test
 requires_openssl_3_x
 requires_protocol_version tls12
 requires_certificate_authentication
@@ -14130,6 +14132,7 @@ run_test    "Handshake defragmentation on client: len=4, TLS 1.3" \
             -c "handshake fragment: 0 \\.\\. 4 of [0-9]\\+ msglen 4" \
             -c "waiting for more fragments (4"
 
+skip_next_test
 requires_openssl_3_x
 requires_protocol_version tls12
 requires_certificate_authentication

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -13886,10 +13886,32 @@ run_test    "Handshake defragmentation on client: len=512, TLS 1.3" \
             -c "waiting for more fragments (512 of [0-9]\\+"
 
 requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on client: len=512, TLS 1.2" \
+            "$O_NEXT_SRV -tls1_2 -max_send_frag 512 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "reassembled record" \
+            -c "handshake fragment: 0 \\.\\. 512 of [0-9]\\+ msglen 512" \
+            -c "waiting for more fragments (512 of [0-9]\\+"
+
+requires_openssl_3_x
 requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=513, TLS 1.3" \
             "$O_NEXT_SRV -tls1_3 -max_send_frag 513 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "reassembled record" \
+            -c "handshake fragment: 0 \\.\\. 513 of [0-9]\\+ msglen 513" \
+            -c "waiting for more fragments (513 of [0-9]\\+"
+
+requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on client: len=513, TLS 1.2" \
+            "$O_NEXT_SRV -tls1_2 -max_send_frag 513 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
@@ -13914,10 +13936,32 @@ run_test    "Handshake defragmentation on client: len=256, TLS 1.3" \
             -c "waiting for more fragments (256 of [0-9]\\+"
 
 requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on client: len=256, TLS 1.2" \
+            "$O_NEXT_SRV -tls1_2 -split_send_frag 256 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "reassembled record" \
+            -c "handshake fragment: 0 \\.\\. 256 of [0-9]\\+ msglen 256" \
+            -c "waiting for more fragments (256 of [0-9]\\+"
+
+requires_openssl_3_x
 requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=128, TLS 1.3" \
             "$O_NEXT_SRV -tls1_3 -split_send_frag 128 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "reassembled record" \
+            -c "handshake fragment: 0 \\.\\. 128 of [0-9]\\+ msglen 128" \
+            -c "waiting for more fragments (128"
+
+requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on client: len=128, TLS 1.2" \
+            "$O_NEXT_SRV -tls1_2 -split_send_frag 128 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
@@ -13936,10 +13980,32 @@ run_test    "Handshake defragmentation on client: len=64, TLS 1.3" \
             -c "waiting for more fragments (64"
 
 requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on client: len=64, TLS 1.2" \
+            "$O_NEXT_SRV -tls1_2 -split_send_frag 64 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "reassembled record" \
+            -c "handshake fragment: 0 \\.\\. 64 of [0-9]\\+ msglen 64" \
+            -c "waiting for more fragments (64"
+
+requires_openssl_3_x
 requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=36, TLS 1.3" \
             "$O_NEXT_SRV -tls1_3 -split_send_frag 36 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "reassembled record" \
+            -c "handshake fragment: 0 \\.\\. 36 of [0-9]\\+ msglen 36" \
+            -c "waiting for more fragments (36"
+
+requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on client: len=36, TLS 1.2" \
+            "$O_NEXT_SRV -tls1_2 -split_send_frag 36 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
@@ -13958,10 +14024,32 @@ run_test    "Handshake defragmentation on client: len=32, TLS 1.3" \
             -c "waiting for more fragments (32"
 
 requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on client: len=32, TLS 1.2" \
+            "$O_NEXT_SRV -tls1_2 -split_send_frag 32 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "reassembled record" \
+            -c "handshake fragment: 0 \\.\\. 32 of [0-9]\\+ msglen 32" \
+            -c "waiting for more fragments (32"
+
+requires_openssl_3_x
 requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=14, TLS 1.3" \
             "$O_NEXT_SRV -tls1_3 -split_send_frag 16 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "reassembled record" \
+            -c "handshake fragment: 0 \\.\\. 16 of [0-9]\\+ msglen 16" \
+            -c "waiting for more fragments (16"
+
+requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on client: len=14, TLS 1.2" \
+            "$O_NEXT_SRV -tls1_2 -split_send_frag 16 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
@@ -13980,10 +14068,32 @@ run_test    "Handshake defragmentation on client: len=13, TLS 1.3" \
             -c "waiting for more fragments (13"
 
 requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on client: len=13, TLS 1.2" \
+            "$O_NEXT_SRV -tls1_2 -split_send_frag 13 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "reassembled record" \
+            -c "handshake fragment: 0 \\.\\. 13 of [0-9]\\+ msglen 13" \
+            -c "waiting for more fragments (13"
+
+requires_openssl_3_x
 requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=5, TLS 1.3" \
             "$O_NEXT_SRV -tls1_3 -split_send_frag 5 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "reassembled record" \
+            -c "handshake fragment: 0 \\.\\. 5 of [0-9]\\+ msglen 5" \
+            -c "waiting for more fragments (5"
+
+requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on client: len=5, TLS 1.2" \
+            "$O_NEXT_SRV -tls1_2 -split_send_frag 5 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
@@ -14002,11 +14112,33 @@ run_test    "Handshake defragmentation on server: len=512, TLS 1.3" \
             -s "waiting for more fragments (512"
 
 requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on server: len=512, TLS 1.2" \
+            "$P_SRV debug_level=4 auth_mode=required" \
+            "$O_NEXT_CLI -tls1_2 -max_send_frag 512 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            0 \
+            -s "reassembled record" \
+            -s "handshake fragment: 0 \\.\\. 512 of [0-9]\\+ msglen 512" \
+            -s "waiting for more fragments (512"
+
+requires_openssl_3_x
 requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=513, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_3 -max_send_frag 513 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            0 \
+            -s "reassembled record" \
+            -s "handshake fragment: 0 \\.\\. 513 of [0-9]\\+ msglen 513" \
+            -s "waiting for more fragments (513"
+
+requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on server: len=513, TLS 1.2" \
+            "$P_SRV debug_level=4 auth_mode=required" \
+            "$O_NEXT_CLI -tls1_2 -max_send_frag 513 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 513 of [0-9]\\+ msglen 513" \
@@ -14024,11 +14156,34 @@ run_test    "Handshake defragmentation on server: len=256, TLS 1.3" \
             -s "waiting for more fragments (256"
 
 requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on server: len=256, TLS 1.2" \
+            "$P_SRV debug_level=4 auth_mode=required" \
+            "$O_NEXT_CLI -tls1_3 -split_send_frag 256 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            0 \
+            -s "reassembled record" \
+            -s "handshake fragment: 0 \\.\\. 256 of [0-9]\\+ msglen 256" \
+            -s "waiting for more fragments (256"
+
+
+requires_openssl_3_x
 requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=128, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_3 -split_send_frag 128 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            0 \
+            -s "reassembled record" \
+            -s "handshake fragment: 0 \\.\\. 128 of [0-9]\\+ msglen 128" \
+            -s "waiting for more fragments (128"
+
+requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on server: len=128, TLS 1.2" \
+            "$P_SRV debug_level=4 auth_mode=required" \
+            "$O_NEXT_CLI -tls1_2 -split_send_frag 128 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 128 of [0-9]\\+ msglen 128" \
@@ -14046,11 +14201,33 @@ run_test    "Handshake defragmentation on server: len=64, TLS 1.3" \
             -s "waiting for more fragments (64"
 
 requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on server: len=64, TLS 1.2" \
+            "$P_SRV debug_level=4 auth_mode=required" \
+            "$O_NEXT_CLI -tls1_2 -split_send_frag 64 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            0 \
+            -s "reassembled record" \
+            -s "handshake fragment: 0 \\.\\. 64 of [0-9]\\+ msglen 64" \
+            -s "waiting for more fragments (64"
+
+requires_openssl_3_x
 requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=36, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_3 -split_send_frag 36 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            0 \
+            -s "reassembled record" \
+            -s "handshake fragment: 0 \\.\\. 36 of [0-9]\\+ msglen 36" \
+            -s "waiting for more fragments (36"
+
+requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on server: len=36, TLS 1.2" \
+            "$P_SRV debug_level=4 auth_mode=required" \
+            "$O_NEXT_CLI -tls1_2 -split_send_frag 36 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 36 of [0-9]\\+ msglen 36" \
@@ -14068,11 +14245,33 @@ run_test    "Handshake defragmentation on server: len=32, TLS 1.3" \
             -s "waiting for more fragments (32"
 
 requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on server: len=32, TLS 1.2" \
+            "$P_SRV debug_level=4 auth_mode=required" \
+            "$O_NEXT_CLI -tls1_2 -split_send_frag 32 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            0 \
+            -s "reassembled record" \
+            -s "handshake fragment: 0 \\.\\. 32 of [0-9]\\+ msglen 32" \
+            -s "waiting for more fragments (32"
+
+requires_openssl_3_x
 requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=16, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_3 -split_send_frag 16 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            0 \
+            -s "reassembled record" \
+            -s "handshake fragment: 0 \\.\\. 16 of [0-9]\\+ msglen 16" \
+            -s "waiting for more fragments (16"
+
+requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on server: len=16, TLS 1.2" \
+            "$P_SRV debug_level=4 auth_mode=required" \
+            "$O_NEXT_CLI -tls1_2 -split_send_frag 16 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 16 of [0-9]\\+ msglen 16" \
@@ -14090,11 +14289,33 @@ run_test    "Handshake defragmentation on server: len=13, TLS 1.3" \
             -s "waiting for more fragments (13"
 
 requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on server: len=13, TLS 1.2" \
+            "$P_SRV debug_level=4 auth_mode=required" \
+            "$O_NEXT_CLI -tls1_2 -split_send_frag 13 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            0 \
+            -s "reassembled record" \
+            -s "handshake fragment: 0 \\.\\. 13 of [0-9]\\+ msglen 13" \
+            -s "waiting for more fragments (13"
+
+requires_openssl_3_x
 requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=5, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_3 -split_send_frag 5 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            0 \
+            -s "reassembled record" \
+            -s "handshake fragment: 0 \\.\\. 5 of [0-9]\\+ msglen 5" \
+            -s "waiting for more fragments (5"
+
+requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on server: len=5, TLS 1.2" \
+            "$P_SRV debug_level=4 auth_mode=required" \
+            "$O_NEXT_CLI -tls1_2 -split_send_frag 5 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 5 of [0-9]\\+ msglen 5" \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -13893,8 +13893,12 @@ run_test    "Client Handshake defragmentation (513)" \
 # OpenSSL does not allow max_send_frag to be less than 512
 # so we use split_send_frag instead for tests lower than 512 below.
 
+# There is an issue with OpenSSL when fragmenting with values less
+# than 512 bytes in TLS 1.2 so we require TLS 1.3 with these values.
+
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Client Handshake defragmentation (256)" \
             "$O_NEXT_SRV -split_send_frag 256 " \
             "$P_CLI debug_level=4 " \
@@ -13904,6 +13908,7 @@ run_test    "Client Handshake defragmentation (256)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Client Handshake defragmentation (128)" \
             "$O_NEXT_SRV -split_send_frag 128 " \
             "$P_CLI debug_level=4 " \
@@ -13913,6 +13918,7 @@ run_test    "Client Handshake defragmentation (128)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Client Handshake defragmentation (64)" \
             "$O_NEXT_SRV -split_send_frag 64 " \
             "$P_CLI debug_level=4 " \
@@ -13922,6 +13928,7 @@ run_test    "Client Handshake defragmentation (64)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Client Handshake defragmentation (36)" \
             "$O_NEXT_SRV -split_send_frag 36 " \
             "$P_CLI debug_level=4 " \
@@ -13931,6 +13938,7 @@ run_test    "Client Handshake defragmentation (36)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Client Handshake defragmentation (32)" \
             "$O_NEXT_SRV -split_send_frag 32 " \
             "$P_CLI debug_level=4 " \
@@ -13940,6 +13948,7 @@ run_test    "Client Handshake defragmentation (32)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Client Handshake defragmentation (16)" \
             "$O_NEXT_SRV -split_send_frag 16 " \
             "$P_CLI debug_level=4 " \
@@ -13949,6 +13958,7 @@ run_test    "Client Handshake defragmentation (16)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Client Handshake defragmentation (13)" \
             "$O_NEXT_SRV -split_send_frag 13 " \
             "$P_CLI debug_level=4 " \
@@ -13958,6 +13968,7 @@ run_test    "Client Handshake defragmentation (13)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Client Handshake defragmentation (5)" \
             "$O_NEXT_SRV -split_send_frag 5 " \
             "$P_CLI debug_level=4 " \
@@ -13985,6 +13996,7 @@ run_test    "Server Handshake defragmentation (513)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Server Handshake defragmentation (256)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 256 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -13994,6 +14006,7 @@ run_test    "Server Handshake defragmentation (256)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Server Handshake defragmentation (128)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 128 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14003,6 +14016,7 @@ run_test    "Server Handshake defragmentation (128)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Server Handshake defragmentation (64)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 64 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14012,6 +14026,7 @@ run_test    "Server Handshake defragmentation (64)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Server Handshake defragmentation (36)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 36 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14021,6 +14036,7 @@ run_test    "Server Handshake defragmentation (36)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Server Handshake defragmentation (32)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 32 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14030,6 +14046,7 @@ run_test    "Server Handshake defragmentation (32)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Server Handshake defragmentation (16)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 16 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14039,6 +14056,7 @@ run_test    "Server Handshake defragmentation (16)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Server Handshake defragmentation (13)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 13 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14048,6 +14066,7 @@ run_test    "Server Handshake defragmentation (13)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Server Handshake defragmentation (5)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 5 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \


### PR DESCRIPTION
## Description
Implements a portion of the testing needed for #9872. This pr extends #9928 and resolves #9887



## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** provided.
- [x] **development PR** provided
- [x] **TF-PSA-Crypto PR** not required because:  ssl-opt testing changes only
- [x] **framework PR** not required
- [x] **3.6 PR** provided #10016
- [x] **2.28 PR** not required because:  Not backported to 2.28
- **tests**  provided
