### PR TITLE
Backport 3.6: Fix broken config autodetection in ssl-opt.sh on Ubuntu 24.04

### DIFF
--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -11614,7 +11614,7 @@ run_test  "DTLS-SRTP all profiles supported. server doesn't support mki." \
           -c "selected srtp profile" \
           -c "DTLS-SRTP key material is"\
           -c "DTLS-SRTP no mki value negotiated"\
-          -g "find_in_both '^ *Keying material: [0-9A-F]*$'"\
+          -g "find_in_both '^ *Keying material: [0-9A-F]*\$'"\
           -c "dumping 'sending mki' (8 bytes)" \
           -C "dumping 'received mki' (8 bytes)" \
           -C "error"
@@ -11630,7 +11630,7 @@ run_test  "DTLS-SRTP all profiles supported. openssl client." \
           -s "selected srtp profile" \
           -s "server hello, adding use_srtp extension" \
           -s "DTLS-SRTP key material is"\
-          -g "find_in_both '^ *Keying material: [0-9A-F]*$'"\
+          -g "find_in_both '^ *Keying material: [0-9A-F]*\$'"\
           -c "SRTP Extension negotiated, profile=SRTP_AES128_CM_SHA1_80"
 
 requires_config_enabled MBEDTLS_SSL_DTLS_SRTP

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -475,7 +475,7 @@ detect_required_features() {
     esac
 
     case " $CMD_LINE " in
-        *[-_\ =]tickets=[^0]*)
+        *[-_\ =]tickets=[!0]*)
             requires_config_enabled MBEDTLS_SSL_TICKET_C;;
     esac
     case " $CMD_LINE " in


### PR DESCRIPTION
Fix https://github.com/Mbed-TLS/mbedtls/issues/9999

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** not required because: test code only
- [x] **development PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10001
- [x] **TF-PSA-Crypto not required because: SSL only
- [x] **framework PR** not required
- [x] **3.6 PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10002
- [x] **2.28 PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10003
- **tests**  provided
