### PR TITLE
Backport 2.28: Fix broken config autodetection in ssl-opt.sh on Ubuntu 24.04

### DIFF
--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -836,11 +836,13 @@ wait_client_done() {
     ( sleep $CLI_DELAY; echo "===CLIENT_TIMEOUT===" >> $CLI_OUT; kill $CLI_PID ) &
     DOG_PID=$!
 
-    wait $CLI_PID
+    # For Ubuntu 22.04, `Terminated` message is outputed by wait command.
+    # To remove it from stdout, redirect stdout/stderr to CLI_OUT
+    wait $CLI_PID >> $CLI_OUT 2>&1
     CLI_EXIT=$?
 
     kill $DOG_PID >/dev/null 2>&1
-    wait $DOG_PID
+    wait $DOG_PID >> $CLI_OUT 2>&1
 
     echo "EXIT: $CLI_EXIT" >> $CLI_OUT
 
@@ -1181,7 +1183,9 @@ do_run_test_once() {
 
     # terminate the server (and the proxy)
     kill $SRV_PID
-    wait $SRV_PID
+    # For Ubuntu 22.04, `Terminated` message is outputed by wait command.
+    # To remove it from stdout, redirect stdout/stderr to CLI_OUT
+    wait $SRV_PID >> $SRV_OUT 2>&1
     SRV_RET=$?
 
     if [ -n "$PXY_CMD" ]; then

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -9551,7 +9551,7 @@ run_test  "DTLS-SRTP all profiles supported" \
           -c "found srtp profile" \
           -c "selected srtp profile" \
           -c "DTLS-SRTP key material is"\
-          -g "find_in_both '^ *Keying material: [0-9A-F]*$'"\
+          -g "find_in_both '^ *Keying material: [0-9A-F]*\$'"\
           -C "error"
 
 
@@ -9570,7 +9570,7 @@ run_test  "DTLS-SRTP server supports all profiles. Client supports one profile."
           -c "found srtp profile: MBEDTLS_TLS_SRTP_NULL_HMAC_SHA1_80" \
           -c "selected srtp profile" \
           -c "DTLS-SRTP key material is"\
-          -g "find_in_both '^ *Keying material: [0-9A-F]*$'"\
+          -g "find_in_both '^ *Keying material: [0-9A-F]*\$'"\
           -C "error"
 
 requires_config_enabled MBEDTLS_SSL_DTLS_SRTP
@@ -9588,7 +9588,7 @@ run_test  "DTLS-SRTP server supports one profile. Client supports all profiles."
           -c "found srtp profile: MBEDTLS_TLS_SRTP_NULL_HMAC_SHA1_32" \
           -c "selected srtp profile" \
           -c "DTLS-SRTP key material is"\
-          -g "find_in_both '^ *Keying material: [0-9A-F]*$'"\
+          -g "find_in_both '^ *Keying material: [0-9A-F]*\$'"\
           -C "error"
 
 requires_config_enabled MBEDTLS_SSL_DTLS_SRTP
@@ -9606,7 +9606,7 @@ run_test  "DTLS-SRTP server and Client support only one matching profile." \
           -c "found srtp profile: MBEDTLS_TLS_SRTP_AES128_CM_HMAC_SHA1_32" \
           -c "selected srtp profile" \
           -c "DTLS-SRTP key material is"\
-          -g "find_in_both '^ *Keying material: [0-9A-F]*$'"\
+          -g "find_in_both '^ *Keying material: [0-9A-F]*\$'"\
           -C "error"
 
 requires_config_enabled MBEDTLS_SSL_DTLS_SRTP
@@ -9659,8 +9659,8 @@ run_test  "DTLS-SRTP all profiles supported. mki used" \
           -c "dumping 'sending mki' (8 bytes)" \
           -c "dumping 'received mki' (8 bytes)" \
           -c "DTLS-SRTP key material is"\
-          -g "find_in_both '^ *Keying material: [0-9A-F]*$'"\
-          -g "find_in_both '^ *DTLS-SRTP mki value: [0-9A-F]*$'"\
+          -g "find_in_both '^ *Keying material: [0-9A-F]*\$'"\
+          -g "find_in_both '^ *DTLS-SRTP mki value: [0-9A-F]*\$'"\
           -C "error"
 
 requires_config_enabled MBEDTLS_SSL_DTLS_SRTP
@@ -9681,7 +9681,7 @@ run_test  "DTLS-SRTP all profiles supported. server doesn't support mki." \
           -c "selected srtp profile" \
           -c "DTLS-SRTP key material is"\
           -c "DTLS-SRTP no mki value negotiated"\
-          -g "find_in_both '^ *Keying material: [0-9A-F]*$'"\
+          -g "find_in_both '^ *Keying material: [0-9A-F]*\$'"\
           -c "dumping 'sending mki' (8 bytes)" \
           -C "dumping 'received mki' (8 bytes)" \
           -C "error"
@@ -9696,7 +9696,7 @@ run_test  "DTLS-SRTP all profiles supported. openssl client." \
           -s "selected srtp profile" \
           -s "server hello, adding use_srtp extension" \
           -s "DTLS-SRTP key material is"\
-          -g "find_in_both '^ *Keying material: [0-9A-F]*$'"\
+          -g "find_in_both '^ *Keying material: [0-9A-F]*\$'"\
           -c "SRTP Extension negotiated, profile=SRTP_AES128_CM_SHA1_80"
 
 requires_config_enabled MBEDTLS_SSL_DTLS_SRTP
@@ -9709,7 +9709,7 @@ run_test  "DTLS-SRTP server supports all profiles. Client supports all profiles,
           -s "selected srtp profile" \
           -s "server hello, adding use_srtp extension" \
           -s "DTLS-SRTP key material is"\
-          -g "find_in_both '^ *Keying material: [0-9A-F]*$'"\
+          -g "find_in_both '^ *Keying material: [0-9A-F]*\$'"\
           -c "SRTP Extension negotiated, profile=SRTP_AES128_CM_SHA1_32"
 
 requires_config_enabled MBEDTLS_SSL_DTLS_SRTP
@@ -9722,7 +9722,7 @@ run_test  "DTLS-SRTP server supports all profiles. Client supports one profile. 
           -s "selected srtp profile" \
           -s "server hello, adding use_srtp extension" \
           -s "DTLS-SRTP key material is"\
-          -g "find_in_both '^ *Keying material: [0-9A-F]*$'"\
+          -g "find_in_both '^ *Keying material: [0-9A-F]*\$'"\
           -c "SRTP Extension negotiated, profile=SRTP_AES128_CM_SHA1_32"
 
 requires_config_enabled MBEDTLS_SSL_DTLS_SRTP
@@ -9735,7 +9735,7 @@ run_test  "DTLS-SRTP server supports one profile. Client supports all profiles. 
           -s "selected srtp profile" \
           -s "server hello, adding use_srtp extension" \
           -s "DTLS-SRTP key material is"\
-          -g "find_in_both '^ *Keying material: [0-9A-F]*$'"\
+          -g "find_in_both '^ *Keying material: [0-9A-F]*\$'"\
           -c "SRTP Extension negotiated, profile=SRTP_AES128_CM_SHA1_32"
 
 requires_config_enabled MBEDTLS_SSL_DTLS_SRTP
@@ -9748,7 +9748,7 @@ run_test  "DTLS-SRTP server and Client support only one matching profile. openss
           -s "selected srtp profile" \
           -s "server hello, adding use_srtp extension" \
           -s "DTLS-SRTP key material is"\
-          -g "find_in_both '^ *Keying material: [0-9A-F]*$'"\
+          -g "find_in_both '^ *Keying material: [0-9A-F]*\$'"\
           -c "SRTP Extension negotiated, profile=SRTP_AES128_CM_SHA1_32"
 
 requires_config_enabled MBEDTLS_SSL_DTLS_SRTP

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -1184,7 +1184,7 @@ do_run_test_once() {
     # terminate the server (and the proxy)
     kill $SRV_PID
     # For Ubuntu 22.04, `Terminated` message is outputed by wait command.
-    # To remove it from stdout, redirect stdout/stderr to CLI_OUT
+    # To remove it from stdout, redirect stdout/stderr to SRV_OUT
     wait $SRV_PID >> $SRV_OUT 2>&1
     SRV_RET=$?
 

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -354,7 +354,7 @@ detect_required_features() {
     esac
 
     case " $1 " in
-        *[-_\ =]tickets=[^0]*)
+        *[-_\ =]tickets=[!0]*)
             requires_config_enabled MBEDTLS_SSL_TICKET_C;;
     esac
     case " $1 " in
@@ -437,10 +437,10 @@ maybe_adapt_for_psk() {
 }
 
 case " $CONFIGS_ENABLED " in
-    *\ MBEDTLS_KEY_EXCHANGE_[^P]*) PSK_ONLY="NO";;
-    *\ MBEDTLS_KEY_EXCHANGE_P[^S]*) PSK_ONLY="NO";;
-    *\ MBEDTLS_KEY_EXCHANGE_PS[^K]*) PSK_ONLY="NO";;
-    *\ MBEDTLS_KEY_EXCHANGE_PSK[^_]*) PSK_ONLY="NO";;
+    *\ MBEDTLS_KEY_EXCHANGE_[!P]*) PSK_ONLY="NO";;
+    *\ MBEDTLS_KEY_EXCHANGE_P[!S]*) PSK_ONLY="NO";;
+    *\ MBEDTLS_KEY_EXCHANGE_PS[!K]*) PSK_ONLY="NO";;
+    *\ MBEDTLS_KEY_EXCHANGE_PSK[!_]*) PSK_ONLY="NO";;
     *\ MBEDTLS_KEY_EXCHANGE_PSK_ENABLED\ *) PSK_ONLY="YES";;
     *) PSK_ONLY="NO";;
 esac


### PR DESCRIPTION
Fix https://github.com/Mbed-TLS/mbedtls/issues/9999

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** not required because: test code only
- [x] **development PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10001
- [x] **TF-PSA-Crypto not required because: SSL only
- [x] **framework PR** not required
- [x] **3.6 PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10002
- [x] **2.28 PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10003
- **tests**  provided
