### PR TITLE
Document HOSTCC as the host compiler when cross-compiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ You need the following tools to build the library with the provided makefiles:
 
 * GNU Make 3.82 or a build tool that CMake supports.
 * A C99 toolchain (compiler, linker, archiver). We actively test with GCC 5.4, Clang 3.8, Arm Compiler 6, IAR 8 and Visual Studio 2017. More recent versions should work. Slightly older versions may work.
+* If cross-compiling, and not using an official release, a C compiler for the build platform. Set the `HOSTCC` environment variable to this compiler.
 * Python 3.8 to generate the test code. Python is also needed to integrate PSA drivers and to build the development branch (see next section).
 * Perl to run the tests, and to generate some source files in the development branch.
 * CMake 3.10.2 or later (if using CMake).
@@ -72,7 +73,7 @@ The following tools are required:
     Depending on your Python installation, you may need to invoke `python` instead of `python3`. To install the packages system-wide, omit the `--user` option.
 * A C compiler for the host platform, for some test data.
 
-If you are cross-compiling, you must set the `CC` environment variable to a C compiler for the host platform when generating the configuration-independent files.
+If you are cross-compiling, you must set the `HOSTCC` environment variable to a C compiler for the host platform when generating the configuration-independent files. If `HOSTCC` is unset, `CC` will be used instead.
 
 Any of the following methods are available to generate the configuration-independent files:
 


### PR DESCRIPTION
We don't document `HOSTCC`. This [came up on the mailing list](https://lists.trustedfirmware.org/archives/list/mbed-tls@lists.trustedfirmware.org/thread/XYW7ZRO6NQV7WIUEYIGCWG32FLOZIV5Y/).

## PR checklist

- [x] **changelog** not required because: doc only
- [x] **development PR** here
- [ ] **TF-PSA-Crypto PR** TODO
- [x] **framework PR** not required
- [ ] **3.6 PR** TODO
- [x] **2.28 PR** not required because: no generated files before 3.0
- **tests**  not required because: doc only
