### PR TITLE
[3.6 Backport] Add basic handshake defragmentation tests in ssl-opt

### DIFF
--- a/ChangeLog.d/tls-hs-defrag-in.txt
+++ b/ChangeLog.d/tls-hs-defrag-in.txt
@@ -3,3 +3,10 @@ Bugfix
      by the spec. Lack of support was causing handshake failures with some
      servers, especially with TLS 1.3 in practice (though both protocol
      version could be affected in principle, and both are fixed now).
+     The initial fragment for each handshake message must be at least 4 bytes.
+
+     Server-side, defragmentation of the ClientHello message is only
+     supported if the server accepts TLS 1.3 (regardless of whether the
+     ClientHello is 1.3 or 1.2). That is, servers configured (either
+     at compile time or at runtime) to only accept TLS 1.2 will
+     still fail the handshake if the ClientHello message is fragmented.

--- a/tests/scripts/analyze_outcomes.py
+++ b/tests/scripts/analyze_outcomes.py
@@ -53,6 +53,11 @@ class CoverageTask(outcome_analysis.CoverageTask):
             # https://github.com/Mbed-TLS/mbedtls/issues/9581
             'Opaque key for server authentication: invalid key: decrypt with ECC key, no async',
             'Opaque key for server authentication: invalid key: ecdh with RSA key, no async',
+            # Temporary disable Handshake defragmentation tests until mbedtls
+            # pr #10011 has been merged.
+            'Handshake defragmentation on client: len=4, TLS 1.2',
+            'Handshake defragmentation on client: len=5, TLS 1.2',
+            'Handshake defragmentation on client: len=13, TLS 1.2'
         ],
         'test_suite_config.mbedtls_boolean': [
             # We never test with CBC/PKCS5/PKCS12 enabled but

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14459,10 +14459,9 @@ run_test    "TLS 1.2 ClientHello indicating support for deflate compression meth
 
 # Handshake defragmentation testing
 
-# To warrant that the handhake messages are large enough and need to be split
+# To guarantee that the handhake messages are large enough and need to be split
 # into fragments, the tests require certificate authentication. The party in control
-# of the fragmentation operations is OpenSSL and will always use server5.crt (548 Bytes)
-# either from O_NEXT_SRV or test data.
+# of the fragmentation operations is OpenSSL and will always use server5.crt (548 Bytes).
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client (no fragmentation, for reference)" \
@@ -14793,12 +14792,12 @@ run_test    "Handshake defragmentation on server: len=128, TLS 1.3" \
             -s "handshake fragment: 0 \\.\\. 128 of [0-9]\\+ msglen 128" \
             -s "waiting for more fragments (128"
 
-# Server-side ClientHello degfragmentation is only supported for MBEDTLS_SSL_PROTO_TLS1_3. For TLS 1.2 testing
+# Server-side ClientHello defragmentationis only supported for MBEDTLS_SSL_PROTO_TLS1_3. For TLS 1.2 testing
 # the server should suport both protocols and downgrade to client-requested TL1.2 after proccessing the ClientHello.
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
-run_test    "Handshake defragmentation on server: len=128, TLS 1.2  TLS 1.3 Client-Hallo -> 1.2 Handhsake" \
+run_test    "Handshake defragmentation on server: len=128, TLS 1.2  TLS 1.3 ClientHello -> 1.2 Handshake" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_2 -split_send_frag 128 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14819,7 +14818,7 @@ run_test    "Handshake defragmentation on server: len=64, TLS 1.3" \
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
-run_test    "Handshake defragmentation on server: len=64, TLS 1.2  TLS 1.3 Client-Hallo -> 1.2 Handhsake" \
+run_test    "Handshake defragmentation on server: len=64, TLS 1.2  TLS 1.3 ClientHello -> 1.2 Handshake" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_2 -split_send_frag 64 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14840,7 +14839,7 @@ run_test    "Handshake defragmentation on server: len=36, TLS 1.3" \
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
-run_test    "Handshake defragmentation on server: len=36, TLS 1.2  TLS 1.3 Client-Hallo -> 1.2 Handhsake" \
+run_test    "Handshake defragmentation on server: len=36, TLS 1.2  TLS 1.3 ClientHello -> 1.2 Handshake" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_2 -split_send_frag 36 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14861,7 +14860,7 @@ run_test    "Handshake defragmentation on server: len=32, TLS 1.3" \
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
-run_test    "Handshake defragmentation on server: len=32, TLS 1.2  TLS 1.3 Client-Hallo -> 1.2 Handhsake" \
+run_test    "Handshake defragmentation on server: len=32, TLS 1.2  TLS 1.3 ClientHello -> 1.2 Handshake" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_2 -split_send_frag 32 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14882,7 +14881,7 @@ run_test    "Handshake defragmentation on server: len=16, TLS 1.3" \
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
-run_test    "Handshake defragmentation on server: len=16, TLS 1.2  TLS 1.3 Client-Hallo -> 1.2 Handhsake" \
+run_test    "Handshake defragmentation on server: len=16, TLS 1.2  TLS 1.3 ClientHello -> 1.2 Handshake" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_2 -split_send_frag 16 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14903,7 +14902,7 @@ run_test    "Handshake defragmentation on server: len=13, TLS 1.3" \
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
-run_test    "Handshake defragmentation on server: len=13, TLS 1.2  TLS 1.3 Client-Hallo -> 1.2 Handhsake" \
+run_test    "Handshake defragmentation on server: len=13, TLS 1.2  TLS 1.3 ClientHello -> 1.2 Handshake" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_2 -split_send_frag 13 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14924,7 +14923,7 @@ run_test    "Handshake defragmentation on server: len=5, TLS 1.3" \
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
-run_test    "Handshake defragmentation on server: len=5, TLS 1.2  TLS 1.3 Client-Hallo -> 1.2 Handhsake" \
+run_test    "Handshake defragmentation on server: len=5, TLS 1.2  TLS 1.3 ClientHello -> 1.2 Handshake" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_2 -split_send_frag 5 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14945,7 +14944,7 @@ run_test    "Handshake defragmentation on server: len=4, TLS 1.3" \
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
-run_test    "Handshake defragmentation on server: len=4, TLS 1.2  TLS 1.3 Client-Hallo -> 1.2 Handhsake" \
+run_test    "Handshake defragmentation on server: len=4, TLS 1.2  TLS 1.3 ClientHello -> 1.2 Handshake" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_2 -split_send_frag 4 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14966,7 +14965,7 @@ run_test    "Handshake defragmentation on server: len=3, TLS 1.3" \
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
-run_test    "Handshake defragmentation on server: len=3, TLS 1.3 Client-Hallo -> 1.2 Handhsake" \
+run_test    "Handshake defragmentation on server: len=3, TLS 1.3 ClientHello -> 1.2 Handshake" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_2 -split_send_frag 3 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             1 \
@@ -14977,7 +14976,7 @@ run_test    "Handshake defragmentation on server: len=3, TLS 1.3 Client-Hallo ->
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
-run_test    "Handshake defragmentation on server: len=32, TLS 1.3 Client-Hallo -> 1.2 Handhsake" \
+run_test    "Handshake defragmentation on server: len=32, TLS 1.2 ClientHello" \
             "$P_SRV debug_level=4 force_version=tls12 auth_mode=required" \
             "$O_NEXT_CLI -tls1_2 -split_send_frag 32 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             1 \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14475,6 +14475,9 @@ run_test    "Client Handshake defragmentation (513)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
+# OpenSSL does not allow max_send_frag to be less than 512
+# so we use split_send_frag instead for tests lower than 512 below.
+
 requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (256)" \
             "$O_NEXT_SRV -split_send_frag 256 " \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14694,7 +14694,6 @@ run_test    "Handshake defragmentation on client: len=5, TLS 1.2" \
             -c "handshake fragment: 0 \\.\\. 5 of [0-9]\\+ msglen 5" \
             -c "waiting for more fragments (5"
 
-requires_openssl_3_x
 requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server (no fragmentation, for reference)." \
@@ -14924,6 +14923,28 @@ run_test    "Handshake defragmentation on server: len=5, TLS 1.2" \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 5 of [0-9]\\+ msglen 5" \
             -s "waiting for more fragments (5"
+
+requires_protocol_version tls13
+requires_certificate_authentication
+run_test    "Handshake defragmentation on server: len=4, TLS 1.3" \
+            "$P_SRV debug_level=4 auth_mode=required" \
+            "$O_NEXT_CLI -tls1_3 -split_send_frag 4 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            0 \
+            -s "reassembled record" \
+            -s "handshake fragment: 0 \\.\\. 4 of [0-9]\\+ msglen 4" \
+            -s "waiting for more fragments (4"
+
+requires_openssl_3_x
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
+requires_certificate_authentication
+run_test    "Handshake defragmentation on server: len=4, TLS 1.2" \
+            "$P_SRV debug_level=4 auth_mode=required" \
+            "$O_NEXT_CLI -tls1_2 -split_send_frag 4 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            0 \
+            -s "reassembled record" \
+            -s "handshake fragment: 0 \\.\\. 4 of [0-9]\\+ msglen 4" \
+            -s "waiting for more fragments (4"
 
 # Test heap memory usage after handshake
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14479,6 +14479,7 @@ run_test    "Client Handshake defragmentation (513)" \
 # so we use split_send_frag instead for tests lower than 512 below.
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Client Handshake defragmentation (256)" \
             "$O_NEXT_SRV -split_send_frag 256 " \
             "$P_CLI debug_level=4 " \
@@ -14487,6 +14488,7 @@ run_test    "Client Handshake defragmentation (256)" \
             -c "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Client Handshake defragmentation (128)" \
             "$O_NEXT_SRV -split_send_frag 128 " \
             "$P_CLI debug_level=4 " \
@@ -14495,6 +14497,7 @@ run_test    "Client Handshake defragmentation (128)" \
             -c "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Client Handshake defragmentation (64)" \
             "$O_NEXT_SRV -split_send_frag 64 " \
             "$P_CLI debug_level=4 " \
@@ -14503,6 +14506,7 @@ run_test    "Client Handshake defragmentation (64)" \
             -c "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Client Handshake defragmentation (36)" \
             "$O_NEXT_SRV -split_send_frag 36 " \
             "$P_CLI debug_level=4 " \
@@ -14511,6 +14515,7 @@ run_test    "Client Handshake defragmentation (36)" \
             -c "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Client Handshake defragmentation (32)" \
             "$O_NEXT_SRV -split_send_frag 32 " \
             "$P_CLI debug_level=4 " \
@@ -14519,6 +14524,7 @@ run_test    "Client Handshake defragmentation (32)" \
             -c "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Client Handshake defragmentation (16)" \
             "$O_NEXT_SRV -split_send_frag 16 " \
             "$P_CLI debug_level=4 " \
@@ -14527,6 +14533,7 @@ run_test    "Client Handshake defragmentation (16)" \
             -c "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Client Handshake defragmentation (13)" \
             "$O_NEXT_SRV -split_send_frag 13 " \
             "$P_CLI debug_level=4 " \
@@ -14535,6 +14542,7 @@ run_test    "Client Handshake defragmentation (13)" \
             -c "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Client Handshake defragmentation (5)" \
             "$O_NEXT_SRV -split_send_frag 5 " \
             "$P_CLI debug_level=4 " \
@@ -14543,6 +14551,7 @@ run_test    "Client Handshake defragmentation (5)" \
             -c "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Server Handshake defragmentation (512)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -max_send_frag 512 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14551,6 +14560,7 @@ run_test    "Server Handshake defragmentation (512)" \
             -s "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Server Handshake defragmentation (513)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -max_send_frag 513 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14559,6 +14569,7 @@ run_test    "Server Handshake defragmentation (513)" \
             -s "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Server Handshake defragmentation (256)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 256 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14567,6 +14578,7 @@ run_test    "Server Handshake defragmentation (256)" \
             -s "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Server Handshake defragmentation (128)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 128 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14575,6 +14587,7 @@ run_test    "Server Handshake defragmentation (128)" \
             -s "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Server Handshake defragmentation (64)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 64 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14583,6 +14596,7 @@ run_test    "Server Handshake defragmentation (64)" \
             -s "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Server Handshake defragmentation (36)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 36 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14591,6 +14605,7 @@ run_test    "Server Handshake defragmentation (36)" \
             -s "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Server Handshake defragmentation (32)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 32 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14599,6 +14614,7 @@ run_test    "Server Handshake defragmentation (32)" \
             -s "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Server Handshake defragmentation (16)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 16 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14607,6 +14623,7 @@ run_test    "Server Handshake defragmentation (16)" \
             -s "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Server Handshake defragmentation (13)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 13 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14615,6 +14632,7 @@ run_test    "Server Handshake defragmentation (13)" \
             -s "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Server Handshake defragmentation (5)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 5 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14459,6 +14459,7 @@ run_test    "TLS 1.2 ClientHello indicating support for deflate compression meth
 
 # Handshake defragmentation testing
 
+requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (512)" \
             "$O_NEXT_SRV -max_send_frag 512 " \
             "$P_CLI debug_level=4 " \
@@ -14466,6 +14467,7 @@ run_test    "Client Handshake defragmentation (512)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (513)" \
             "$O_NEXT_SRV -max_send_frag 513 " \
             "$P_CLI debug_level=4 " \
@@ -14473,6 +14475,7 @@ run_test    "Client Handshake defragmentation (513)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (256)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 256 " \
             "$P_CLI debug_level=4 " \
@@ -14480,6 +14483,7 @@ run_test    "Client Handshake defragmentation (256)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (128)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 128 " \
             "$P_CLI debug_level=4 " \
@@ -14487,6 +14491,7 @@ run_test    "Client Handshake defragmentation (128)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (64)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 64 " \
             "$P_CLI debug_level=4 " \
@@ -14494,6 +14499,7 @@ run_test    "Client Handshake defragmentation (64)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (36)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 36 " \
             "$P_CLI debug_level=4 " \
@@ -14501,6 +14507,7 @@ run_test    "Client Handshake defragmentation (36)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (32)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 32 " \
             "$P_CLI debug_level=4 " \
@@ -14508,6 +14515,7 @@ run_test    "Client Handshake defragmentation (32)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (16)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 16 " \
             "$P_CLI debug_level=4 " \
@@ -14515,7 +14523,7 @@ run_test    "Client Handshake defragmentation (16)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
-
+requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (13)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 13 " \
             "$P_CLI debug_level=4 " \
@@ -14523,6 +14531,7 @@ run_test    "Client Handshake defragmentation (13)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (5)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 5 " \
             "$P_CLI debug_level=4 " \
@@ -14530,6 +14539,7 @@ run_test    "Client Handshake defragmentation (5)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (512)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -max_send_frag 512 " \
@@ -14537,6 +14547,7 @@ run_test    "Server Handshake defragmentation (512)" \
             -s "<= handshake" \
             -s "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (513)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -max_send_frag 513 " \
@@ -14544,6 +14555,7 @@ run_test    "Server Handshake defragmentation (513)" \
             -s "<= handshake" \
             -s "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (256)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 256 " \
@@ -14551,6 +14563,7 @@ run_test    "Server Handshake defragmentation (256)" \
             -s "<= handshake" \
             -s "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (128)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 128 " \
@@ -14558,6 +14571,7 @@ run_test    "Server Handshake defragmentation (128)" \
             -s "<= handshake" \
             -s "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (64)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 64 " \
@@ -14565,6 +14579,7 @@ run_test    "Server Handshake defragmentation (64)" \
             -s "<= handshake" \
             -s "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (36)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 36 " \
@@ -14572,6 +14587,7 @@ run_test    "Server Handshake defragmentation (36)" \
             -s "<= handshake" \
             -s "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (32)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 32 " \
@@ -14579,6 +14595,7 @@ run_test    "Server Handshake defragmentation (32)" \
             -s "<= handshake" \
             -s "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (16)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 16 " \
@@ -14586,6 +14603,7 @@ run_test    "Server Handshake defragmentation (16)" \
             -s "<= handshake" \
             -s "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (13)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 13 " \
@@ -14593,6 +14611,7 @@ run_test    "Server Handshake defragmentation (13)" \
             -s "<= handshake" \
             -s "handshake fragment: "
 
+requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (5)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 5 " \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14463,8 +14463,7 @@ run_test    "TLS 1.2 ClientHello indicating support for deflate compression meth
 # into fragments, the tests require certificate authentication. The party in control
 # of the fragmentation operations is OpenSSL and will always use server5.crt (548 Bytes)
 # either from O_NEXT_SRV or test data.
-requires_openssl_3_x
-requires_protocol_version tls13
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client (no fragmentation, for reference)" \
             "$O_NEXT_SRV" \
@@ -14473,8 +14472,7 @@ run_test    "Handshake defragmentation on client (no fragmentation, for referenc
             -C "reassembled record" \
             -C "waiting for more fragments"
 
-requires_openssl_3_x
-requires_protocol_version tls13
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=512, TLS 1.3" \
             "$O_NEXT_SRV -tls1_3 -split_send_frag 512 " \
@@ -14484,8 +14482,7 @@ run_test    "Handshake defragmentation on client: len=512, TLS 1.3" \
             -c "handshake fragment: 0 \\.\\. 512 of [0-9]\\+ msglen 512" \
             -c "waiting for more fragments (512 of [0-9]\\+"
 
-requires_openssl_3_x
-requires_protocol_version tls12
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=512, TLS 1.2" \
             "$O_NEXT_SRV -tls1_2 -split_send_frag 512 " \
@@ -14495,8 +14492,7 @@ run_test    "Handshake defragmentation on client: len=512, TLS 1.2" \
             -c "handshake fragment: 0 \\.\\. 512 of [0-9]\\+ msglen 512" \
             -c "waiting for more fragments (512 of [0-9]\\+"
 
-requires_openssl_3_x
-requires_protocol_version tls13
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=513, TLS 1.3" \
             "$O_NEXT_SRV -tls1_3 -split_send_frag 513 " \
@@ -14506,8 +14502,7 @@ run_test    "Handshake defragmentation on client: len=513, TLS 1.3" \
             -c "handshake fragment: 0 \\.\\. 513 of [0-9]\\+ msglen 513" \
             -c "waiting for more fragments (513 of [0-9]\\+"
 
-requires_openssl_3_x
-requires_protocol_version tls12
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=513, TLS 1.2" \
             "$O_NEXT_SRV -tls1_2 -split_send_frag 513 " \
@@ -14517,8 +14512,7 @@ run_test    "Handshake defragmentation on client: len=513, TLS 1.2" \
             -c "handshake fragment: 0 \\.\\. 513 of [0-9]\\+ msglen 513" \
             -c "waiting for more fragments (513 of [0-9]\\+"
 
-requires_openssl_3_x
-requires_protocol_version tls13
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=256, TLS 1.3" \
             "$O_NEXT_SRV -tls1_3 -split_send_frag 256 " \
@@ -14528,8 +14522,7 @@ run_test    "Handshake defragmentation on client: len=256, TLS 1.3" \
             -c "handshake fragment: 0 \\.\\. 256 of [0-9]\\+ msglen 256" \
             -c "waiting for more fragments (256 of [0-9]\\+"
 
-requires_openssl_3_x
-requires_protocol_version tls12
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=256, TLS 1.2" \
             "$O_NEXT_SRV -tls1_2 -split_send_frag 256 " \
@@ -14539,8 +14532,7 @@ run_test    "Handshake defragmentation on client: len=256, TLS 1.2" \
             -c "handshake fragment: 0 \\.\\. 256 of [0-9]\\+ msglen 256" \
             -c "waiting for more fragments (256 of [0-9]\\+"
 
-requires_openssl_3_x
-requires_protocol_version tls13
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=128, TLS 1.3" \
             "$O_NEXT_SRV -tls1_3 -split_send_frag 128 " \
@@ -14550,8 +14542,7 @@ run_test    "Handshake defragmentation on client: len=128, TLS 1.3" \
             -c "handshake fragment: 0 \\.\\. 128 of [0-9]\\+ msglen 128" \
             -c "waiting for more fragments (128"
 
-requires_openssl_3_x
-requires_protocol_version tls12
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=128, TLS 1.2" \
             "$O_NEXT_SRV -tls1_2 -split_send_frag 128 " \
@@ -14561,8 +14552,7 @@ run_test    "Handshake defragmentation on client: len=128, TLS 1.2" \
             -c "handshake fragment: 0 \\.\\. 128 of [0-9]\\+ msglen 128" \
             -c "waiting for more fragments (128"
 
-requires_openssl_3_x
-requires_protocol_version tls13
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=64, TLS 1.3" \
             "$O_NEXT_SRV -tls1_3 -split_send_frag 64 " \
@@ -14572,8 +14562,7 @@ run_test    "Handshake defragmentation on client: len=64, TLS 1.3" \
             -c "handshake fragment: 0 \\.\\. 64 of [0-9]\\+ msglen 64" \
             -c "waiting for more fragments (64"
 
-requires_openssl_3_x
-requires_protocol_version tls12
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=64, TLS 1.2" \
             "$O_NEXT_SRV -tls1_2 -split_send_frag 64 " \
@@ -14583,8 +14572,7 @@ run_test    "Handshake defragmentation on client: len=64, TLS 1.2" \
             -c "handshake fragment: 0 \\.\\. 64 of [0-9]\\+ msglen 64" \
             -c "waiting for more fragments (64"
 
-requires_openssl_3_x
-requires_protocol_version tls13
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=36, TLS 1.3" \
             "$O_NEXT_SRV -tls1_3 -split_send_frag 36 " \
@@ -14594,8 +14582,7 @@ run_test    "Handshake defragmentation on client: len=36, TLS 1.3" \
             -c "handshake fragment: 0 \\.\\. 36 of [0-9]\\+ msglen 36" \
             -c "waiting for more fragments (36"
 
-requires_openssl_3_x
-requires_protocol_version tls12
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=36, TLS 1.2" \
             "$O_NEXT_SRV -tls1_2 -split_send_frag 36 " \
@@ -14605,8 +14592,7 @@ run_test    "Handshake defragmentation on client: len=36, TLS 1.2" \
             -c "handshake fragment: 0 \\.\\. 36 of [0-9]\\+ msglen 36" \
             -c "waiting for more fragments (36"
 
-requires_openssl_3_x
-requires_protocol_version tls13
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=32, TLS 1.3" \
             "$O_NEXT_SRV -tls1_3 -split_send_frag 32 " \
@@ -14616,8 +14602,7 @@ run_test    "Handshake defragmentation on client: len=32, TLS 1.3" \
             -c "handshake fragment: 0 \\.\\. 32 of [0-9]\\+ msglen 32" \
             -c "waiting for more fragments (32"
 
-requires_openssl_3_x
-requires_protocol_version tls12
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=32, TLS 1.2" \
             "$O_NEXT_SRV -tls1_2 -split_send_frag 32 " \
@@ -14627,8 +14612,7 @@ run_test    "Handshake defragmentation on client: len=32, TLS 1.2" \
             -c "handshake fragment: 0 \\.\\. 32 of [0-9]\\+ msglen 32" \
             -c "waiting for more fragments (32"
 
-requires_openssl_3_x
-requires_protocol_version tls13
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=16, TLS 1.3" \
             "$O_NEXT_SRV -tls1_3 -split_send_frag 16 " \
@@ -14638,8 +14622,7 @@ run_test    "Handshake defragmentation on client: len=16, TLS 1.3" \
             -c "handshake fragment: 0 \\.\\. 16 of [0-9]\\+ msglen 16" \
             -c "waiting for more fragments (16"
 
-requires_openssl_3_x
-requires_protocol_version tls12
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=16, TLS 1.2" \
             "$O_NEXT_SRV -tls1_2 -split_send_frag 16 " \
@@ -14649,8 +14632,7 @@ run_test    "Handshake defragmentation on client: len=16, TLS 1.2" \
             -c "handshake fragment: 0 \\.\\. 16 of [0-9]\\+ msglen 16" \
             -c "waiting for more fragments (16"
 
-requires_openssl_3_x
-requires_protocol_version tls13
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=13, TLS 1.3" \
             "$O_NEXT_SRV -tls1_3 -split_send_frag 13 " \
@@ -14661,8 +14643,7 @@ run_test    "Handshake defragmentation on client: len=13, TLS 1.3" \
             -c "waiting for more fragments (13"
 
 skip_next_test
-requires_openssl_3_x
-requires_protocol_version tls12
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=13, TLS 1.2" \
             "$O_NEXT_SRV -tls1_2 -split_send_frag 13 " \
@@ -14672,8 +14653,7 @@ run_test    "Handshake defragmentation on client: len=13, TLS 1.2" \
             -c "handshake fragment: 0 \\.\\. 13 of [0-9]\\+ msglen 13" \
             -c "waiting for more fragments (13"
 
-requires_openssl_3_x
-requires_protocol_version tls13
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=5, TLS 1.3" \
             "$O_NEXT_SRV -tls1_3 -split_send_frag 5 " \
@@ -14684,8 +14664,7 @@ run_test    "Handshake defragmentation on client: len=5, TLS 1.3" \
             -c "waiting for more fragments (5"
 
 skip_next_test
-requires_openssl_3_x
-requires_protocol_version tls12
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=5, TLS 1.2" \
             "$O_NEXT_SRV -tls1_2 -split_send_frag 5 " \
@@ -14695,8 +14674,7 @@ run_test    "Handshake defragmentation on client: len=5, TLS 1.2" \
             -c "handshake fragment: 0 \\.\\. 5 of [0-9]\\+ msglen 5" \
             -c "waiting for more fragments (5"
 
-requires_openssl_3_x
-requires_protocol_version tls13
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=4, TLS 1.3" \
             "$O_NEXT_SRV -tls1_3 -split_send_frag 4 " \
@@ -14707,8 +14685,7 @@ run_test    "Handshake defragmentation on client: len=4, TLS 1.3" \
             -c "waiting for more fragments (4"
 
 skip_next_test
-requires_openssl_3_x
-requires_protocol_version tls12
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=4, TLS 1.2" \
             "$O_NEXT_SRV -tls1_2 -split_send_frag 4 " \
@@ -14718,8 +14695,7 @@ run_test    "Handshake defragmentation on client: len=4, TLS 1.2" \
             -c "handshake fragment: 0 \\.\\. 4 of [0-9]\\+ msglen 4" \
             -c "waiting for more fragments (4"
 
-requires_openssl_3_x
-requires_protocol_version tls13
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=3, TLS 1.3" \
             "$O_NEXT_SRV -tls1_3 -split_send_frag 3 " \
@@ -14729,8 +14705,7 @@ run_test    "Handshake defragmentation on client: len=3, TLS 1.3" \
             -c "handshake message too short: 3" \
             -c "SSL - An invalid SSL record was received"
 
-requires_openssl_3_x
-requires_protocol_version tls12
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=3, TLS 1.2" \
             "$O_NEXT_SRV -tls1_2 -split_send_frag 3 " \
@@ -14739,7 +14714,7 @@ run_test    "Handshake defragmentation on client: len=3, TLS 1.2" \
             -c "handshake message too short: 3" \
             -c "SSL - An invalid SSL record was received"
 
-requires_protocol_version tls13
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server (no fragmentation, for reference)." \
             "$P_SRV debug_level=4 auth_mode=required" \
@@ -14748,8 +14723,7 @@ run_test    "Handshake defragmentation on server (no fragmentation, for referenc
             -C "reassembled record" \
             -C "waiting for more fragments"
 
-requires_openssl_3_x
-requires_protocol_version tls13
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=512, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
@@ -14759,8 +14733,7 @@ run_test    "Handshake defragmentation on server: len=512, TLS 1.3" \
             -s "handshake fragment: 0 \\.\\. 512 of [0-9]\\+ msglen 512" \
             -s "waiting for more fragments (512"
 
-requires_openssl_3_x
-requires_protocol_version tls12
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=512, TLS 1.2" \
             "$P_SRV debug_level=4 auth_mode=required" \
@@ -14770,8 +14743,7 @@ run_test    "Handshake defragmentation on server: len=512, TLS 1.2" \
             -s "handshake fragment: 0 \\.\\. 512 of [0-9]\\+ msglen 512" \
             -s "waiting for more fragments (512"
 
-requires_openssl_3_x
-requires_protocol_version tls13
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=513, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
@@ -14781,8 +14753,7 @@ run_test    "Handshake defragmentation on server: len=513, TLS 1.3" \
             -s "handshake fragment: 0 \\.\\. 513 of [0-9]\\+ msglen 513" \
             -s "waiting for more fragments (513"
 
-requires_openssl_3_x
-requires_protocol_version tls12
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=513, TLS 1.2" \
             "$P_SRV debug_level=4 auth_mode=required" \
@@ -14792,8 +14763,7 @@ run_test    "Handshake defragmentation on server: len=513, TLS 1.2" \
             -s "handshake fragment: 0 \\.\\. 513 of [0-9]\\+ msglen 513" \
             -s "waiting for more fragments (513"
 
-requires_openssl_3_x
-requires_protocol_version tls13
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=256, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
@@ -14803,8 +14773,7 @@ run_test    "Handshake defragmentation on server: len=256, TLS 1.3" \
             -s "handshake fragment: 0 \\.\\. 256 of [0-9]\\+ msglen 256" \
             -s "waiting for more fragments (256"
 
-requires_openssl_3_x
-requires_protocol_version tls12
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=256, TLS 1.2" \
             "$P_SRV debug_level=4 auth_mode=required" \
@@ -14814,8 +14783,7 @@ run_test    "Handshake defragmentation on server: len=256, TLS 1.2" \
             -s "handshake fragment: 0 \\.\\. 256 of [0-9]\\+ msglen 256" \
             -s "waiting for more fragments (256"
 
-requires_openssl_3_x
-requires_protocol_version tls13
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=128, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
@@ -14827,7 +14795,6 @@ run_test    "Handshake defragmentation on server: len=128, TLS 1.3" \
 
 # Server-side ClientHello degfragmentation is only supported for MBEDTLS_SSL_PROTO_TLS1_3. For TLS 1.2 testing
 # the server should suport both protocols and downgrade to client-requested TL1.2 after proccessing the ClientHello.
-requires_openssl_3_x
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
@@ -14839,8 +14806,7 @@ run_test    "Handshake defragmentation on server: len=128, TLS 1.2" \
             -s "handshake fragment: 0 \\.\\. 128 of [0-9]\\+ msglen 128" \
             -s "waiting for more fragments (128"
 
-requires_openssl_3_x
-requires_protocol_version tls13
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=64, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
@@ -14850,7 +14816,6 @@ run_test    "Handshake defragmentation on server: len=64, TLS 1.3" \
             -s "handshake fragment: 0 \\.\\. 64 of [0-9]\\+ msglen 64" \
             -s "waiting for more fragments (64"
 
-requires_openssl_3_x
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
@@ -14862,8 +14827,7 @@ run_test    "Handshake defragmentation on server: len=64, TLS 1.2" \
             -s "handshake fragment: 0 \\.\\. 64 of [0-9]\\+ msglen 64" \
             -s "waiting for more fragments (64"
 
-requires_openssl_3_x
-requires_protocol_version tls13
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=36, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
@@ -14873,7 +14837,6 @@ run_test    "Handshake defragmentation on server: len=36, TLS 1.3" \
             -s "handshake fragment: 0 \\.\\. 36 of [0-9]\\+ msglen 36" \
             -s "waiting for more fragments (36"
 
-requires_openssl_3_x
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
@@ -14885,8 +14848,7 @@ run_test    "Handshake defragmentation on server: len=36, TLS 1.2" \
             -s "handshake fragment: 0 \\.\\. 36 of [0-9]\\+ msglen 36" \
             -s "waiting for more fragments (36"
 
-requires_openssl_3_x
-requires_protocol_version tls13
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=32, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
@@ -14896,7 +14858,6 @@ run_test    "Handshake defragmentation on server: len=32, TLS 1.3" \
             -s "handshake fragment: 0 \\.\\. 32 of [0-9]\\+ msglen 32" \
             -s "waiting for more fragments (32"
 
-requires_openssl_3_x
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
@@ -14908,8 +14869,7 @@ run_test    "Handshake defragmentation on server: len=32, TLS 1.2" \
             -s "handshake fragment: 0 \\.\\. 32 of [0-9]\\+ msglen 32" \
             -s "waiting for more fragments (32"
 
-requires_openssl_3_x
-requires_protocol_version tls13
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=16, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
@@ -14919,7 +14879,6 @@ run_test    "Handshake defragmentation on server: len=16, TLS 1.3" \
             -s "handshake fragment: 0 \\.\\. 16 of [0-9]\\+ msglen 16" \
             -s "waiting for more fragments (16"
 
-requires_openssl_3_x
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
@@ -14931,8 +14890,7 @@ run_test    "Handshake defragmentation on server: len=16, TLS 1.2" \
             -s "handshake fragment: 0 \\.\\. 16 of [0-9]\\+ msglen 16" \
             -s "waiting for more fragments (16"
 
-requires_openssl_3_x
-requires_protocol_version tls13
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=13, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
@@ -14942,7 +14900,6 @@ run_test    "Handshake defragmentation on server: len=13, TLS 1.3" \
             -s "handshake fragment: 0 \\.\\. 13 of [0-9]\\+ msglen 13" \
             -s "waiting for more fragments (13"
 
-requires_openssl_3_x
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
@@ -14954,8 +14911,7 @@ run_test    "Handshake defragmentation on server: len=13, TLS 1.2" \
             -s "handshake fragment: 0 \\.\\. 13 of [0-9]\\+ msglen 13" \
             -s "waiting for more fragments (13"
 
-requires_openssl_3_x
-requires_protocol_version tls13
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=5, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
@@ -14965,7 +14921,6 @@ run_test    "Handshake defragmentation on server: len=5, TLS 1.3" \
             -s "handshake fragment: 0 \\.\\. 5 of [0-9]\\+ msglen 5" \
             -s "waiting for more fragments (5"
 
-requires_openssl_3_x
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
@@ -14977,8 +14932,7 @@ run_test    "Handshake defragmentation on server: len=5, TLS 1.2" \
             -s "handshake fragment: 0 \\.\\. 5 of [0-9]\\+ msglen 5" \
             -s "waiting for more fragments (5"
 
-requires_openssl_3_x
-requires_protocol_version tls13
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=4, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
@@ -14988,7 +14942,6 @@ run_test    "Handshake defragmentation on server: len=4, TLS 1.3" \
             -s "handshake fragment: 0 \\.\\. 4 of [0-9]\\+ msglen 4" \
             -s "waiting for more fragments (4"
 
-requires_openssl_3_x
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
@@ -15000,8 +14953,7 @@ run_test    "Handshake defragmentation on server: len=4, TLS 1.2" \
             -s "handshake fragment: 0 \\.\\. 4 of [0-9]\\+ msglen 4" \
             -s "waiting for more fragments (4"
 
-requires_openssl_3_x
-requires_protocol_version tls13
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=3, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
@@ -15011,7 +14963,6 @@ run_test    "Handshake defragmentation on server: len=3, TLS 1.3" \
             -s "handshake message too short: 3" \
             -s "SSL - An invalid SSL record was received"
 
-requires_openssl_3_x
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
@@ -15023,7 +14974,6 @@ run_test    "Handshake defragmentation on server: len=3, TLS 1.3 -> 1.2" \
             -s "handshake message too short: 3" \
             -s "SSL - An invalid SSL record was received"
 
-requires_openssl_3_x
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14477,7 +14477,7 @@ run_test    "Client Handshake defragmentation (513)" \
 
 requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (256)" \
-            "$O_NEXT_SRV -mtu 32 -split_send_frag 256 " \
+            "$O_NEXT_SRV -split_send_frag 256 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "<= handshake" \
@@ -14485,7 +14485,7 @@ run_test    "Client Handshake defragmentation (256)" \
 
 requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (128)" \
-            "$O_NEXT_SRV -mtu 32 -split_send_frag 128 " \
+            "$O_NEXT_SRV -split_send_frag 128 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "<= handshake" \
@@ -14493,7 +14493,7 @@ run_test    "Client Handshake defragmentation (128)" \
 
 requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (64)" \
-            "$O_NEXT_SRV -mtu 32 -split_send_frag 64 " \
+            "$O_NEXT_SRV -split_send_frag 64 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "<= handshake" \
@@ -14501,7 +14501,7 @@ run_test    "Client Handshake defragmentation (64)" \
 
 requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (36)" \
-            "$O_NEXT_SRV -mtu 32 -split_send_frag 36 " \
+            "$O_NEXT_SRV -split_send_frag 36 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "<= handshake" \
@@ -14509,7 +14509,7 @@ run_test    "Client Handshake defragmentation (36)" \
 
 requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (32)" \
-            "$O_NEXT_SRV -mtu 32 -split_send_frag 32 " \
+            "$O_NEXT_SRV -split_send_frag 32 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "<= handshake" \
@@ -14517,7 +14517,7 @@ run_test    "Client Handshake defragmentation (32)" \
 
 requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (16)" \
-            "$O_NEXT_SRV -mtu 32 -split_send_frag 16 " \
+            "$O_NEXT_SRV -split_send_frag 16 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "<= handshake" \
@@ -14525,7 +14525,7 @@ run_test    "Client Handshake defragmentation (16)" \
 
 requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (13)" \
-            "$O_NEXT_SRV -mtu 32 -split_send_frag 13 " \
+            "$O_NEXT_SRV -split_send_frag 13 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "<= handshake" \
@@ -14533,7 +14533,7 @@ run_test    "Client Handshake defragmentation (13)" \
 
 requires_openssl_tls1_3
 run_test    "Client Handshake defragmentation (5)" \
-            "$O_NEXT_SRV -mtu 32 -split_send_frag 5 " \
+            "$O_NEXT_SRV -split_send_frag 5 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "<= handshake" \
@@ -14558,7 +14558,7 @@ run_test    "Server Handshake defragmentation (513)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (256)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 256 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -split_send_frag 256 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -14566,7 +14566,7 @@ run_test    "Server Handshake defragmentation (256)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (128)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 128 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -split_send_frag 128 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -14574,7 +14574,7 @@ run_test    "Server Handshake defragmentation (128)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (64)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 64 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -split_send_frag 64 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -14582,7 +14582,7 @@ run_test    "Server Handshake defragmentation (64)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (36)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 36 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -split_send_frag 36 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -14590,7 +14590,7 @@ run_test    "Server Handshake defragmentation (36)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (32)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 32 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -split_send_frag 32 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -14598,7 +14598,7 @@ run_test    "Server Handshake defragmentation (32)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (16)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 16 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -split_send_frag 16 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -14606,7 +14606,7 @@ run_test    "Server Handshake defragmentation (16)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (13)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 13 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -split_send_frag 13 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -14614,7 +14614,7 @@ run_test    "Server Handshake defragmentation (13)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (5)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 5 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -split_send_frag 5 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14460,6 +14460,7 @@ run_test    "TLS 1.2 ClientHello indicating support for deflate compression meth
 # Handshake defragmentation testing
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Client Handshake defragmentation (512)" \
             "$O_NEXT_SRV -max_send_frag 512 " \
             "$P_CLI debug_level=4 " \
@@ -14468,6 +14469,7 @@ run_test    "Client Handshake defragmentation (512)" \
             -c "handshake fragment: "
 
 requires_openssl_tls1_3
+requires_certificate_authentication
 run_test    "Client Handshake defragmentation (513)" \
             "$O_NEXT_SRV -max_send_frag 513 " \
             "$P_CLI debug_level=4 " \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14458,6 +14458,15 @@ run_test    "TLS 1.2 ClientHello indicating support for deflate compression meth
             -s "dumping .client hello, compression. (2 bytes)"
 
 # Handshake defragmentation testing
+requires_openssl_3_x
+requires_protocol_version tls13
+requires_certificate_authentication
+run_test    "Handshake defragmentation on client (no fragmentation, for reference)" \
+            "$O_NEXT_SRV" \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -C "reassembled record" \
+            -C "waiting for more fragments"
 
 requires_openssl_3_x
 requires_protocol_version tls13
@@ -14684,6 +14693,16 @@ run_test    "Handshake defragmentation on client: len=5, TLS 1.2" \
             -c "reassembled record" \
             -c "handshake fragment: 0 \\.\\. 5 of [0-9]\\+ msglen 5" \
             -c "waiting for more fragments (5"
+
+requires_openssl_3_x
+requires_protocol_version tls13
+requires_certificate_authentication
+run_test    "Handshake defragmentation on server (no fragmentation, for reference)." \
+            "$P_SRV debug_level=4 auth_mode=required" \
+            "$O_NEXT_CLI -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            0 \
+            -C "reassembled record" \
+            -C "waiting for more fragments"
 
 requires_openssl_3_x
 requires_protocol_version tls13

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14459,6 +14459,7 @@ run_test    "TLS 1.2 ClientHello indicating support for deflate compression meth
 
 # Handshake defragmentation testing
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 run_test    "Client Handshake defragmentation (512)" \
@@ -14466,8 +14467,10 @@ run_test    "Client Handshake defragmentation (512)" \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
-            -c "waiting for more fragments (512 [0-9]\\+, [0-9]\\+ left)"
+            -c "handshake fragment: 0 \\.\\. 512 of [0-9]\\+ msglen 512" \
+            -c "waiting for more fragments (512 of [0-9]\\+"
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 run_test    "Client Handshake defragmentation (513)" \
@@ -14475,7 +14478,8 @@ run_test    "Client Handshake defragmentation (513)" \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
-            -c "waiting for more fragments (513 [0-9]\\+, [0-9]\\+ left)"
+            -c "handshake fragment: 0 \\.\\. 513 of [0-9]\\+ msglen 513" \
+            -c "waiting for more fragments (513 of [0-9]\\+"
 
 # OpenSSL does not allow max_send_frag to be less than 512
 # so we use split_send_frag instead for tests lower than 512 below.
@@ -14483,6 +14487,7 @@ run_test    "Client Handshake defragmentation (513)" \
 # There is an issue with OpenSSL when fragmenting with values less
 # than 512 bytes in TLS 1.2 so we require TLS 1.3 with these values.
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -14491,8 +14496,10 @@ run_test    "Client Handshake defragmentation (256)" \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
-            -c "waiting for more fragments (256 of [0-9]\\+, [0-9]\\+ left)"
+            -c "handshake fragment: 0 \\.\\. 256 of [0-9]\\+ msglen 256" \
+            -c "waiting for more fragments (256 of [0-9]\\+"
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -14501,8 +14508,10 @@ run_test    "Client Handshake defragmentation (128)" \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
-            -c "waiting for more fragments (128 [0-9]\\+, [0-9]\\+ left)"
+            -c "handshake fragment: 0 \\.\\. 128 of [0-9]\\+ msglen 128" \
+            -c "waiting for more fragments (128"
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -14511,8 +14520,10 @@ run_test    "Client Handshake defragmentation (64)" \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
-            -c "waiting for more fragments (64 [0-9]\\+, [0-9]\\+ left)"
+            -c "handshake fragment: 0 \\.\\. 64 of [0-9]\\+ msglen 64" \
+            -c "waiting for more fragments (64"
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -14521,8 +14532,10 @@ run_test    "Client Handshake defragmentation (36)" \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
-            -c "waiting for more fragments (36 [0-9]\\+, [0-9]\\+ left)"
+            -c "handshake fragment: 0 \\.\\. 36 of [0-9]\\+ msglen 36" \
+            -c "waiting for more fragments (36"
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -14531,8 +14544,10 @@ run_test    "Client Handshake defragmentation (32)" \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
-            -c "waiting for more fragments (32 [0-9]\\+, [0-9]\\+ left)"
+            -c "handshake fragment: 0 \\.\\. 32 of [0-9]\\+ msglen 32" \
+            -c "waiting for more fragments (32"
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -14541,8 +14556,10 @@ run_test    "Client Handshake defragmentation (16)" \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
-            -c "waiting for more fragments (16 [0-9]\\+, [0-9]\\+ left)"
+            -c "handshake fragment: 0 \\.\\. 16 of [0-9]\\+ msglen 16" \
+            -c "waiting for more fragments (16"
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -14551,8 +14568,10 @@ run_test    "Client Handshake defragmentation (13)" \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
-            -c "waiting for more fragments (13 [0-9]\\+, [0-9]\\+ left)"
+            -c "handshake fragment: 0 \\.\\. 13 of [0-9]\\+ msglen 13" \
+            -c "waiting for more fragments (13"
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -14561,8 +14580,10 @@ run_test    "Client Handshake defragmentation (5)" \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
-            -c "waiting for more fragments (5 [0-9]\\+, [0-9]\\+ left)"
+            -c "handshake fragment: 0 \\.\\. 5 of [0-9]\\+ msglen 5" \
+            -c "waiting for more fragments (5"
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 run_test    "Server Handshake defragmentation (512)" \
@@ -14570,8 +14591,10 @@ run_test    "Server Handshake defragmentation (512)" \
             "$O_NEXT_CLI -max_send_frag 512 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
-            -s "waiting for more fragments (512 [0-9]\\+, [0-9]\\+ left)"
+            -s "handshake fragment: 0 \\.\\. 512 of [0-9]\\+ msglen 512" \
+            -s "waiting for more fragments (512"
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 run_test    "Server Handshake defragmentation (513)" \
@@ -14579,8 +14602,10 @@ run_test    "Server Handshake defragmentation (513)" \
             "$O_NEXT_CLI -max_send_frag 513 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
-            -s "waiting for more fragments (513 [0-9]\\+, [0-9]\\+ left)"
+            -s "handshake fragment: 0 \\.\\. 513 of [0-9]\\+ msglen 513" \
+            -s "waiting for more fragments (513"
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -14589,8 +14614,10 @@ run_test    "Server Handshake defragmentation (256)" \
             "$O_NEXT_CLI -split_send_frag 256 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
-            -s "waiting for more fragments (256 [0-9]\\+, [0-9]\\+ left)"
+            -s "handshake fragment: 0 \\.\\. 256 of [0-9]\\+ msglen 256" \
+            -s "waiting for more fragments (256"
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -14599,8 +14626,10 @@ run_test    "Server Handshake defragmentation (128)" \
             "$O_NEXT_CLI -split_send_frag 128 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
-            -s "waiting for more fragments (128 [0-9]\\+, [0-9]\\+ left)"
+            -s "handshake fragment: 0 \\.\\. 128 of [0-9]\\+ msglen 128" \
+            -s "waiting for more fragments (128"
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -14609,8 +14638,10 @@ run_test    "Server Handshake defragmentation (64)" \
             "$O_NEXT_CLI -split_send_frag 64 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
-            -s "waiting for more fragments (64 [0-9]\\+, [0-9]\\+ left)"
+            -s "handshake fragment: 0 \\.\\. 64 of [0-9]\\+ msglen 64" \
+            -s "waiting for more fragments (64"
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -14619,8 +14650,10 @@ run_test    "Server Handshake defragmentation (36)" \
             "$O_NEXT_CLI -split_send_frag 36 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
-            -s "waiting for more fragments (36 [0-9]\\+, [0-9]\\+ left)"
+            -s "handshake fragment: 0 \\.\\. 36 of [0-9]\\+ msglen 36" \
+            -s "waiting for more fragments (36"
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -14629,8 +14662,10 @@ run_test    "Server Handshake defragmentation (32)" \
             "$O_NEXT_CLI -split_send_frag 32 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
-            -s "waiting for more fragments (32 [0-9]\\+, [0-9]\\+ left)"
+            -s "handshake fragment: 0 \\.\\. 32 of [0-9]\\+ msglen 32" \
+            -s "waiting for more fragments (32"
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -14639,8 +14674,10 @@ run_test    "Server Handshake defragmentation (16)" \
             "$O_NEXT_CLI -split_send_frag 16 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
-            -s "waiting for more fragments (16 [0-9]\\+, [0-9]\\+ left)"
+            -s "handshake fragment: 0 \\.\\. 16 of [0-9]\\+ msglen 16" \
+            -s "waiting for more fragments (16"
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -14649,8 +14686,10 @@ run_test    "Server Handshake defragmentation (13)" \
             "$O_NEXT_CLI -split_send_frag 13 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
-            -s "waiting for more fragments (12 [0-9]\\+, [0-9]\\+ left)"
+            -s "handshake fragment: 0 \\.\\. 13 of [0-9]\\+ msglen 13" \
+            -s "waiting for more fragments (13"
 
+requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -14659,7 +14698,8 @@ run_test    "Server Handshake defragmentation (5)" \
             "$O_NEXT_CLI -split_send_frag 5 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
-            -s "waiting for more fragments (5 [0-9]\\+, [0-9]\\+ left)"
+            -s "handshake fragment: 0 \\.\\. 5 of [0-9]\\+ msglen 5" \
+            -s "waiting for more fragments (5"
 
 # Test heap memory usage after handshake
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14542,7 +14542,7 @@ run_test    "Client Handshake defragmentation (5)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (512)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -max_send_frag 512 " \
+            "$O_NEXT_CLI -max_send_frag 512 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -14550,7 +14550,7 @@ run_test    "Server Handshake defragmentation (512)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (513)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -max_send_frag 513 " \
+            "$O_NEXT_CLI -max_send_frag 513 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -14558,7 +14558,7 @@ run_test    "Server Handshake defragmentation (513)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (256)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 256 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 256 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -14566,7 +14566,7 @@ run_test    "Server Handshake defragmentation (256)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (128)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 128 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 128 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -14574,7 +14574,7 @@ run_test    "Server Handshake defragmentation (128)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (64)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 64 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 64 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -14582,7 +14582,7 @@ run_test    "Server Handshake defragmentation (64)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (36)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 36 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 36 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -14590,7 +14590,7 @@ run_test    "Server Handshake defragmentation (36)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (32)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 32 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 32 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -14598,7 +14598,7 @@ run_test    "Server Handshake defragmentation (32)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (16)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 16 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 16 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -14606,7 +14606,7 @@ run_test    "Server Handshake defragmentation (16)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (13)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 13 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 13 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
@@ -14614,7 +14614,7 @@ run_test    "Server Handshake defragmentation (13)" \
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (5)" \
             "$P_SRV debug_level=4 " \
-            "$O_NEXT_CLI -mtu 32 -split_send_frag 5 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 5 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14541,7 +14541,7 @@ run_test    "Client Handshake defragmentation (5)" \
 
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (512)" \
-            "$P_SRV debug_level=4 " \
+            "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -max_send_frag 512 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
@@ -14549,7 +14549,7 @@ run_test    "Server Handshake defragmentation (512)" \
 
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (513)" \
-            "$P_SRV debug_level=4 " \
+            "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -max_send_frag 513 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
@@ -14557,7 +14557,7 @@ run_test    "Server Handshake defragmentation (513)" \
 
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (256)" \
-            "$P_SRV debug_level=4 " \
+            "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 256 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
@@ -14565,7 +14565,7 @@ run_test    "Server Handshake defragmentation (256)" \
 
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (128)" \
-            "$P_SRV debug_level=4 " \
+            "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 128 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
@@ -14573,7 +14573,7 @@ run_test    "Server Handshake defragmentation (128)" \
 
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (64)" \
-            "$P_SRV debug_level=4 " \
+            "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 64 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
@@ -14581,7 +14581,7 @@ run_test    "Server Handshake defragmentation (64)" \
 
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (36)" \
-            "$P_SRV debug_level=4 " \
+            "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 36 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
@@ -14589,7 +14589,7 @@ run_test    "Server Handshake defragmentation (36)" \
 
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (32)" \
-            "$P_SRV debug_level=4 " \
+            "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 32 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
@@ -14597,7 +14597,7 @@ run_test    "Server Handshake defragmentation (32)" \
 
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (16)" \
-            "$P_SRV debug_level=4 " \
+            "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 16 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
@@ -14605,7 +14605,7 @@ run_test    "Server Handshake defragmentation (16)" \
 
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (13)" \
-            "$P_SRV debug_level=4 " \
+            "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 13 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \
@@ -14613,7 +14613,7 @@ run_test    "Server Handshake defragmentation (13)" \
 
 requires_openssl_tls1_3
 run_test    "Server Handshake defragmentation (5)" \
-            "$P_SRV debug_level=4 " \
+            "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 5 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "<= handshake" \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14462,7 +14462,7 @@ run_test    "TLS 1.2 ClientHello indicating support for deflate compression meth
 requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
-run_test    "Client Handshake defragmentation (512)" \
+run_test    "Handshake defragmentation on client: len=512, TLS 1.3" \
             "$O_NEXT_SRV -max_send_frag 512 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -14473,7 +14473,7 @@ run_test    "Client Handshake defragmentation (512)" \
 requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
-run_test    "Client Handshake defragmentation (513)" \
+run_test    "Handshake defragmentation on client: len=513, TLS 1.3" \
             "$O_NEXT_SRV -max_send_frag 513 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -14491,7 +14491,7 @@ requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
-run_test    "Client Handshake defragmentation (256)" \
+run_test    "Handshake defragmentation on client: len=256, TLS 1.3" \
             "$O_NEXT_SRV -split_send_frag 256 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -14503,7 +14503,7 @@ requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
-run_test    "Client Handshake defragmentation (128)" \
+run_test    "Handshake defragmentation on client: len=128, TLS 1.3" \
             "$O_NEXT_SRV -split_send_frag 128 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -14515,7 +14515,7 @@ requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
-run_test    "Client Handshake defragmentation (64)" \
+run_test    "Handshake defragmentation on client: len=64, TLS 1.3" \
             "$O_NEXT_SRV -split_send_frag 64 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -14527,7 +14527,7 @@ requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
-run_test    "Client Handshake defragmentation (36)" \
+run_test    "Handshake defragmentation on client: len=36, TLS 1.3" \
             "$O_NEXT_SRV -split_send_frag 36 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -14539,7 +14539,7 @@ requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
-run_test    "Client Handshake defragmentation (32)" \
+run_test    "Handshake defragmentation on client: len=32, TLS 1.3" \
             "$O_NEXT_SRV -split_send_frag 32 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -14551,7 +14551,7 @@ requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
-run_test    "Client Handshake defragmentation (16)" \
+run_test    "Handshake defragmentation on client: len=14, TLS 1.3" \
             "$O_NEXT_SRV -split_send_frag 16 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -14563,7 +14563,7 @@ requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
-run_test    "Client Handshake defragmentation (13)" \
+run_test    "Handshake defragmentation on client: len=13, TLS 1.3" \
             "$O_NEXT_SRV -split_send_frag 13 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -14575,7 +14575,7 @@ requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
-run_test    "Client Handshake defragmentation (5)" \
+run_test    "Handshake defragmentation on client: len=5, TLS 1.3" \
             "$O_NEXT_SRV -split_send_frag 5 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -14586,7 +14586,7 @@ run_test    "Client Handshake defragmentation (5)" \
 requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
-run_test    "Server Handshake defragmentation (512)" \
+run_test    "Handshake defragmentation on server: len=512, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -max_send_frag 512 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14597,7 +14597,7 @@ run_test    "Server Handshake defragmentation (512)" \
 requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
-run_test    "Server Handshake defragmentation (513)" \
+run_test    "Handshake defragmentation on server: len=513, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -max_send_frag 513 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14609,7 +14609,7 @@ requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
-run_test    "Server Handshake defragmentation (256)" \
+run_test    "Handshake defragmentation on server: len=256, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 256 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14621,7 +14621,7 @@ requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
-run_test    "Server Handshake defragmentation (128)" \
+run_test    "Handshake defragmentation on server: len=128, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 128 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14633,7 +14633,7 @@ requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
-run_test    "Server Handshake defragmentation (64)" \
+run_test    "Handshake defragmentation on server: len=64, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 64 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14645,7 +14645,7 @@ requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
-run_test    "Server Handshake defragmentation (36)" \
+run_test    "Handshake defragmentation on server: len=36, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 36 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14657,7 +14657,7 @@ requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
-run_test    "Server Handshake defragmentation (32)" \
+run_test    "Handshake defragmentation on server: len=32, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 32 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14669,7 +14669,7 @@ requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
-run_test    "Server Handshake defragmentation (16)" \
+run_test    "Handshake defragmentation on server: len=16, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 16 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14681,7 +14681,7 @@ requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
-run_test    "Server Handshake defragmentation (13)" \
+run_test    "Handshake defragmentation on server: len=13, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 13 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14693,7 +14693,7 @@ requires_openssl_3_x
 requires_openssl_tls1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
-run_test    "Server Handshake defragmentation (5)" \
+run_test    "Handshake defragmentation on server: len=5, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 5 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14459,7 +14459,7 @@ run_test    "TLS 1.2 ClientHello indicating support for deflate compression meth
 
 # Handshake defragmentation testing
 
-run_test    "Client Hanshake defragmentation (512)" \
+run_test    "Client Handshake defragmentation (512)" \
             "$O_NEXT_SRV -max_send_frag 512 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -14467,7 +14467,7 @@ run_test    "Client Hanshake defragmentation (512)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
-run_test    "Client Hanshake defragmentation (513)" \
+run_test    "Client Handshake defragmentation (513)" \
             "$O_NEXT_SRV -max_send_frag 513 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -14475,7 +14475,7 @@ run_test    "Client Hanshake defragmentation (513)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
-run_test    "Client Hanshake defragmentation (256)" \
+run_test    "Client Handshake defragmentation (256)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 256 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -14483,7 +14483,7 @@ run_test    "Client Hanshake defragmentation (256)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
-run_test    "Client Hanshake defragmentation (128)" \
+run_test    "Client Handshake defragmentation (128)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 128 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -14491,7 +14491,7 @@ run_test    "Client Hanshake defragmentation (128)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
-run_test    "Client Hanshake defragmentation (64)" \
+run_test    "Client Handshake defragmentation (64)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 64 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -14499,7 +14499,7 @@ run_test    "Client Hanshake defragmentation (64)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
-run_test    "Client Hanshake defragmentation (36)" \
+run_test    "Client Handshake defragmentation (36)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 36 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -14507,7 +14507,7 @@ run_test    "Client Hanshake defragmentation (36)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
-run_test    "Client Hanshake defragmentation (32)" \
+run_test    "Client Handshake defragmentation (32)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 32 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -14515,7 +14515,7 @@ run_test    "Client Hanshake defragmentation (32)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
-run_test    "Client Hanshake defragmentation (16)" \
+run_test    "Client Handshake defragmentation (16)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 16 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -14524,7 +14524,7 @@ run_test    "Client Hanshake defragmentation (16)" \
             -c "handshake fragment: "
 
 
-run_test    "Client Hanshake defragmentation (13)" \
+run_test    "Client Handshake defragmentation (13)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 13 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -14532,7 +14532,7 @@ run_test    "Client Hanshake defragmentation (13)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
-run_test    "Client Hanshake defragmentation (5)" \
+run_test    "Client Handshake defragmentation (5)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 5 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -14540,70 +14540,70 @@ run_test    "Client Hanshake defragmentation (5)" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
-run_test    "Server Hanshake defragmentation (512)" \
+run_test    "Server Handshake defragmentation (512)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -max_send_frag 512 " \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
 
-run_test    "Server Hanshake defragmentation (513)" \
+run_test    "Server Handshake defragmentation (513)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -max_send_frag 513 " \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
 
-run_test    "Server Hanshake defragmentation (256)" \
+run_test    "Server Handshake defragmentation (256)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 256 " \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
 
-run_test    "Server Hanshake defragmentation (128)" \
+run_test    "Server Handshake defragmentation (128)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 128 " \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
 
-run_test    "Server Hanshake defragmentation (64)" \
+run_test    "Server Handshake defragmentation (64)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 64 " \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
 
-run_test    "Server Hanshake defragmentation (36)" \
+run_test    "Server Handshake defragmentation (36)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 36 " \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
 
-run_test    "Server Hanshake defragmentation (32)" \
+run_test    "Server Handshake defragmentation (32)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 32 " \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
 
-run_test    "Server Hanshake defragmentation (16)" \
+run_test    "Server Handshake defragmentation (16)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 16 " \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
 
-run_test    "Server Hanshake defragmentation (13)" \
+run_test    "Server Handshake defragmentation (13)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 13 " \
             0 \
             -s "<= handshake" \
             -s "handshake fragment: "
 
-run_test    "Server Hanshake defragmentation (5)" \
+run_test    "Server Handshake defragmentation (5)" \
             "$P_SRV debug_level=4 " \
             "$O_NEXT_CLI -mtu 32 -split_send_frag 5 " \
             0 \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14462,7 +14462,6 @@ run_test    "TLS 1.2 ClientHello indicating support for deflate compression meth
 # To guarantee that the handhake messages are large enough and need to be split
 # into fragments, the tests require certificate authentication. The party in control
 # of the fragmentation operations is OpenSSL and will always use server5.crt (548 Bytes).
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client (no fragmentation, for reference)" \
             "$O_NEXT_SRV" \
@@ -14713,14 +14712,13 @@ run_test    "Handshake defragmentation on client: len=3, TLS 1.2" \
             -c "handshake message too short: 3" \
             -c "SSL - An invalid SSL record was received"
 
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server (no fragmentation, for reference)." \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
-            -C "reassembled record" \
-            -C "waiting for more fragments"
+            -S "reassembled record" \
+            -S "waiting for more fragments"
 
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14463,7 +14463,6 @@ run_test    "Client Handshake defragmentation (512)" \
             "$O_NEXT_SRV -max_send_frag 512 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "received ServerHello message" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
@@ -14471,7 +14470,6 @@ run_test    "Client Handshake defragmentation (513)" \
             "$O_NEXT_SRV -max_send_frag 513 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "received ServerHello message" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
@@ -14479,7 +14477,6 @@ run_test    "Client Handshake defragmentation (256)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 256 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "received ServerHello message" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
@@ -14487,7 +14484,6 @@ run_test    "Client Handshake defragmentation (128)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 128 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "received ServerHello message" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
@@ -14495,7 +14491,6 @@ run_test    "Client Handshake defragmentation (64)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 64 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "received ServerHello message" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
@@ -14503,7 +14498,6 @@ run_test    "Client Handshake defragmentation (36)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 36 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "received ServerHello message" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
@@ -14511,7 +14505,6 @@ run_test    "Client Handshake defragmentation (32)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 32 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "received ServerHello message" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
@@ -14519,7 +14512,6 @@ run_test    "Client Handshake defragmentation (16)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 16 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "received ServerHello message" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
@@ -14528,7 +14520,6 @@ run_test    "Client Handshake defragmentation (13)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 13 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "received ServerHello message" \
             -c "<= handshake" \
             -c "handshake fragment: "
 
@@ -14536,7 +14527,6 @@ run_test    "Client Handshake defragmentation (5)" \
             "$O_NEXT_SRV -mtu 32 -split_send_frag 5 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "received ServerHello message" \
             -c "<= handshake" \
             -c "handshake fragment: "
 

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14471,10 +14471,32 @@ run_test    "Handshake defragmentation on client: len=512, TLS 1.3" \
             -c "waiting for more fragments (512 of [0-9]\\+"
 
 requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on client: len=512, TLS 1.2" \
+            "$O_NEXT_SRV -tls1_2 -max_send_frag 512 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "reassembled record" \
+            -c "handshake fragment: 0 \\.\\. 512 of [0-9]\\+ msglen 512" \
+            -c "waiting for more fragments (512 of [0-9]\\+"
+
+requires_openssl_3_x
 requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=513, TLS 1.3" \
             "$O_NEXT_SRV -tls1_3 -max_send_frag 513 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "reassembled record" \
+            -c "handshake fragment: 0 \\.\\. 513 of [0-9]\\+ msglen 513" \
+            -c "waiting for more fragments (513 of [0-9]\\+"
+
+requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on client: len=513, TLS 1.2" \
+            "$O_NEXT_SRV -tls1_2 -max_send_frag 513 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
@@ -14499,10 +14521,32 @@ run_test    "Handshake defragmentation on client: len=256, TLS 1.3" \
             -c "waiting for more fragments (256 of [0-9]\\+"
 
 requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on client: len=256, TLS 1.2" \
+            "$O_NEXT_SRV -tls1_2 -split_send_frag 256 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "reassembled record" \
+            -c "handshake fragment: 0 \\.\\. 256 of [0-9]\\+ msglen 256" \
+            -c "waiting for more fragments (256 of [0-9]\\+"
+
+requires_openssl_3_x
 requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=128, TLS 1.3" \
             "$O_NEXT_SRV -tls1_3 -split_send_frag 128 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "reassembled record" \
+            -c "handshake fragment: 0 \\.\\. 128 of [0-9]\\+ msglen 128" \
+            -c "waiting for more fragments (128"
+
+requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on client: len=128, TLS 1.2" \
+            "$O_NEXT_SRV -tls1_2 -split_send_frag 128 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
@@ -14521,10 +14565,32 @@ run_test    "Handshake defragmentation on client: len=64, TLS 1.3" \
             -c "waiting for more fragments (64"
 
 requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on client: len=64, TLS 1.2" \
+            "$O_NEXT_SRV -tls1_2 -split_send_frag 64 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "reassembled record" \
+            -c "handshake fragment: 0 \\.\\. 64 of [0-9]\\+ msglen 64" \
+            -c "waiting for more fragments (64"
+
+requires_openssl_3_x
 requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=36, TLS 1.3" \
             "$O_NEXT_SRV -tls1_3 -split_send_frag 36 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "reassembled record" \
+            -c "handshake fragment: 0 \\.\\. 36 of [0-9]\\+ msglen 36" \
+            -c "waiting for more fragments (36"
+
+requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on client: len=36, TLS 1.2" \
+            "$O_NEXT_SRV -tls1_2 -split_send_frag 36 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
@@ -14543,10 +14609,32 @@ run_test    "Handshake defragmentation on client: len=32, TLS 1.3" \
             -c "waiting for more fragments (32"
 
 requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on client: len=32, TLS 1.2" \
+            "$O_NEXT_SRV -tls1_2 -split_send_frag 32 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "reassembled record" \
+            -c "handshake fragment: 0 \\.\\. 32 of [0-9]\\+ msglen 32" \
+            -c "waiting for more fragments (32"
+
+requires_openssl_3_x
 requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=14, TLS 1.3" \
             "$O_NEXT_SRV -tls1_3 -split_send_frag 16 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "reassembled record" \
+            -c "handshake fragment: 0 \\.\\. 16 of [0-9]\\+ msglen 16" \
+            -c "waiting for more fragments (16"
+
+requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on client: len=14, TLS 1.2" \
+            "$O_NEXT_SRV -tls1_2 -split_send_frag 16 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
@@ -14565,10 +14653,32 @@ run_test    "Handshake defragmentation on client: len=13, TLS 1.3" \
             -c "waiting for more fragments (13"
 
 requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on client: len=13, TLS 1.2" \
+            "$O_NEXT_SRV -tls1_2 -split_send_frag 13 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "reassembled record" \
+            -c "handshake fragment: 0 \\.\\. 13 of [0-9]\\+ msglen 13" \
+            -c "waiting for more fragments (13"
+
+requires_openssl_3_x
 requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=5, TLS 1.3" \
             "$O_NEXT_SRV -tls1_3 -split_send_frag 5 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "reassembled record" \
+            -c "handshake fragment: 0 \\.\\. 5 of [0-9]\\+ msglen 5" \
+            -c "waiting for more fragments (5"
+
+requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on client: len=5, TLS 1.2" \
+            "$O_NEXT_SRV -tls1_2 -split_send_frag 5 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
@@ -14587,11 +14697,33 @@ run_test    "Handshake defragmentation on server: len=512, TLS 1.3" \
             -s "waiting for more fragments (512"
 
 requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on server: len=512, TLS 1.2" \
+            "$P_SRV debug_level=4 auth_mode=required" \
+            "$O_NEXT_CLI -tls1_2 -max_send_frag 512 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            0 \
+            -s "reassembled record" \
+            -s "handshake fragment: 0 \\.\\. 512 of [0-9]\\+ msglen 512" \
+            -s "waiting for more fragments (512"
+
+requires_openssl_3_x
 requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=513, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_3 -max_send_frag 513 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            0 \
+            -s "reassembled record" \
+            -s "handshake fragment: 0 \\.\\. 513 of [0-9]\\+ msglen 513" \
+            -s "waiting for more fragments (513"
+
+requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on server: len=513, TLS 1.2" \
+            "$P_SRV debug_level=4 auth_mode=required" \
+            "$O_NEXT_CLI -tls1_2 -max_send_frag 513 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 513 of [0-9]\\+ msglen 513" \
@@ -14609,11 +14741,34 @@ run_test    "Handshake defragmentation on server: len=256, TLS 1.3" \
             -s "waiting for more fragments (256"
 
 requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on server: len=256, TLS 1.2" \
+            "$P_SRV debug_level=4 auth_mode=required" \
+            "$O_NEXT_CLI -tls1_3 -split_send_frag 256 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            0 \
+            -s "reassembled record" \
+            -s "handshake fragment: 0 \\.\\. 256 of [0-9]\\+ msglen 256" \
+            -s "waiting for more fragments (256"
+
+
+requires_openssl_3_x
 requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=128, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_3 -split_send_frag 128 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            0 \
+            -s "reassembled record" \
+            -s "handshake fragment: 0 \\.\\. 128 of [0-9]\\+ msglen 128" \
+            -s "waiting for more fragments (128"
+
+requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on server: len=128, TLS 1.2" \
+            "$P_SRV debug_level=4 auth_mode=required" \
+            "$O_NEXT_CLI -tls1_2 -split_send_frag 128 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 128 of [0-9]\\+ msglen 128" \
@@ -14631,11 +14786,33 @@ run_test    "Handshake defragmentation on server: len=64, TLS 1.3" \
             -s "waiting for more fragments (64"
 
 requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on server: len=64, TLS 1.2" \
+            "$P_SRV debug_level=4 auth_mode=required" \
+            "$O_NEXT_CLI -tls1_2 -split_send_frag 64 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            0 \
+            -s "reassembled record" \
+            -s "handshake fragment: 0 \\.\\. 64 of [0-9]\\+ msglen 64" \
+            -s "waiting for more fragments (64"
+
+requires_openssl_3_x
 requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=36, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_3 -split_send_frag 36 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            0 \
+            -s "reassembled record" \
+            -s "handshake fragment: 0 \\.\\. 36 of [0-9]\\+ msglen 36" \
+            -s "waiting for more fragments (36"
+
+requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on server: len=36, TLS 1.2" \
+            "$P_SRV debug_level=4 auth_mode=required" \
+            "$O_NEXT_CLI -tls1_2 -split_send_frag 36 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 36 of [0-9]\\+ msglen 36" \
@@ -14653,11 +14830,33 @@ run_test    "Handshake defragmentation on server: len=32, TLS 1.3" \
             -s "waiting for more fragments (32"
 
 requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on server: len=32, TLS 1.2" \
+            "$P_SRV debug_level=4 auth_mode=required" \
+            "$O_NEXT_CLI -tls1_2 -split_send_frag 32 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            0 \
+            -s "reassembled record" \
+            -s "handshake fragment: 0 \\.\\. 32 of [0-9]\\+ msglen 32" \
+            -s "waiting for more fragments (32"
+
+requires_openssl_3_x
 requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=16, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_3 -split_send_frag 16 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            0 \
+            -s "reassembled record" \
+            -s "handshake fragment: 0 \\.\\. 16 of [0-9]\\+ msglen 16" \
+            -s "waiting for more fragments (16"
+
+requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on server: len=16, TLS 1.2" \
+            "$P_SRV debug_level=4 auth_mode=required" \
+            "$O_NEXT_CLI -tls1_2 -split_send_frag 16 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 16 of [0-9]\\+ msglen 16" \
@@ -14675,11 +14874,33 @@ run_test    "Handshake defragmentation on server: len=13, TLS 1.3" \
             -s "waiting for more fragments (13"
 
 requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on server: len=13, TLS 1.2" \
+            "$P_SRV debug_level=4 auth_mode=required" \
+            "$O_NEXT_CLI -tls1_2 -split_send_frag 13 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            0 \
+            -s "reassembled record" \
+            -s "handshake fragment: 0 \\.\\. 13 of [0-9]\\+ msglen 13" \
+            -s "waiting for more fragments (13"
+
+requires_openssl_3_x
 requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=5, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_3 -split_send_frag 5 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            0 \
+            -s "reassembled record" \
+            -s "handshake fragment: 0 \\.\\. 5 of [0-9]\\+ msglen 5" \
+            -s "waiting for more fragments (5"
+
+requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on server: len=5, TLS 1.2" \
+            "$P_SRV debug_level=4 auth_mode=required" \
+            "$O_NEXT_CLI -tls1_2 -split_send_frag 5 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 5 of [0-9]\\+ msglen 5" \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14459,87 +14459,156 @@ run_test    "TLS 1.2 ClientHello indicating support for deflate compression meth
 
 # Handshake defragmentation testing
 
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-run_test    "Hanshake defragmentation (512)" \
-            "$O_SRV -max_send_frag 512 " \
+run_test    "Client Hanshake defragmentation (512)" \
+            "$O_NEXT_SRV -max_send_frag 512 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "received ServerHello message" \
             -c "<= handshake" \
+            -c "handshake fragment: "
 
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-run_test    "Hanshake defragmentation (513)" \
-            "$O_SRV -max_send_frag 513 " \
+run_test    "Client Hanshake defragmentation (513)" \
+            "$O_NEXT_SRV -max_send_frag 513 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "received ServerHello message" \
             -c "<= handshake" \
+            -c "handshake fragment: "
 
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-run_test    "Hanshake defragmentation (256)" \
-            "$O_SRV -mtu 32 -split_send_frag 256 " \
+run_test    "Client Hanshake defragmentation (256)" \
+            "$O_NEXT_SRV -mtu 32 -split_send_frag 256 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "received ServerHello message" \
             -c "<= handshake" \
+            -c "handshake fragment: "
 
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-run_test    "Hanshake defragmentation (128)" \
-            "$O_SRV -mtu 32 -split_send_frag 128 " \
+run_test    "Client Hanshake defragmentation (128)" \
+            "$O_NEXT_SRV -mtu 32 -split_send_frag 128 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "received ServerHello message" \
             -c "<= handshake" \
+            -c "handshake fragment: "
 
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-run_test    "Hanshake defragmentation (64)" \
-            "$O_SRV -mtu 32 -split_send_frag 64 " \
+run_test    "Client Hanshake defragmentation (64)" \
+            "$O_NEXT_SRV -mtu 32 -split_send_frag 64 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "received ServerHello message" \
             -c "<= handshake" \
+            -c "handshake fragment: "
 
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-run_test    "Hanshake defragmentation (36)" \
-            "$O_SRV -mtu 32 -split_send_frag 36 " \
+run_test    "Client Hanshake defragmentation (36)" \
+            "$O_NEXT_SRV -mtu 32 -split_send_frag 36 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "received ServerHello message" \
             -c "<= handshake" \
+            -c "handshake fragment: "
 
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-run_test    "Hanshake defragmentation (32)" \
-            "$O_SRV -mtu 32 -split_send_frag 32 " \
+run_test    "Client Hanshake defragmentation (32)" \
+            "$O_NEXT_SRV -mtu 32 -split_send_frag 32 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "received ServerHello message" \
             -c "<= handshake" \
+            -c "handshake fragment: "
 
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-run_test    "Hanshake defragmentation (16)" \
-            "$O_SRV -mtu 32 -split_send_frag 16 " \
+run_test    "Client Hanshake defragmentation (16)" \
+            "$O_NEXT_SRV -mtu 32 -split_send_frag 16 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "received ServerHello message" \
             -c "<= handshake" \
+            -c "handshake fragment: "
 
 
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-run_test    "Hanshake defragmentation (13)" \
-            "$O_SRV -mtu 32 -split_send_frag 13 " \
+run_test    "Client Hanshake defragmentation (13)" \
+            "$O_NEXT_SRV -mtu 32 -split_send_frag 13 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "received ServerHello message" \
             -c "<= handshake" \
+            -c "handshake fragment: "
 
-
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-run_test    "Hanshake defragmentation (5)" \
-            "$O_SRV -mtu 32 -split_send_frag 5 " \
+run_test    "Client Hanshake defragmentation (5)" \
+            "$O_NEXT_SRV -mtu 32 -split_send_frag 5 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "received ServerHello message" \
             -c "<= handshake" \
+            -c "handshake fragment: "
+
+run_test    "Server Hanshake defragmentation (512)" \
+            "$P_SRV debug_level=4 " \
+            "$O_NEXT_CLI -max_send_frag 512 " \
+            0 \
+            -s "<= handshake" \
+            -s "handshake fragment: "
+
+run_test    "Server Hanshake defragmentation (513)" \
+            "$P_SRV debug_level=4 " \
+            "$O_NEXT_CLI -max_send_frag 513 " \
+            0 \
+            -s "<= handshake" \
+            -s "handshake fragment: "
+
+run_test    "Server Hanshake defragmentation (256)" \
+            "$P_SRV debug_level=4 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 256 " \
+            0 \
+            -s "<= handshake" \
+            -s "handshake fragment: "
+
+run_test    "Server Hanshake defragmentation (128)" \
+            "$P_SRV debug_level=4 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 128 " \
+            0 \
+            -s "<= handshake" \
+            -s "handshake fragment: "
+
+run_test    "Server Hanshake defragmentation (64)" \
+            "$P_SRV debug_level=4 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 64 " \
+            0 \
+            -s "<= handshake" \
+            -s "handshake fragment: "
+
+run_test    "Server Hanshake defragmentation (36)" \
+            "$P_SRV debug_level=4 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 36 " \
+            0 \
+            -s "<= handshake" \
+            -s "handshake fragment: "
+
+run_test    "Server Hanshake defragmentation (32)" \
+            "$P_SRV debug_level=4 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 32 " \
+            0 \
+            -s "<= handshake" \
+            -s "handshake fragment: "
+
+run_test    "Server Hanshake defragmentation (16)" \
+            "$P_SRV debug_level=4 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 16 " \
+            0 \
+            -s "<= handshake" \
+            -s "handshake fragment: "
+
+run_test    "Server Hanshake defragmentation (13)" \
+            "$P_SRV debug_level=4 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 13 " \
+            0 \
+            -s "<= handshake" \
+            -s "handshake fragment: "
+
+run_test    "Server Hanshake defragmentation (5)" \
+            "$P_SRV debug_level=4 " \
+            "$O_NEXT_CLI -mtu 32 -split_send_frag 5 " \
+            0 \
+            -s "<= handshake" \
+            -s "handshake fragment: "
 
 # Test heap memory usage after handshake
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14478,8 +14478,12 @@ run_test    "Client Handshake defragmentation (513)" \
 # OpenSSL does not allow max_send_frag to be less than 512
 # so we use split_send_frag instead for tests lower than 512 below.
 
+# There is an issue with OpenSSL when fragmenting with values less
+# than 512 bytes in TLS 1.2 so we require TLS 1.3 with these values.
+
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Client Handshake defragmentation (256)" \
             "$O_NEXT_SRV -split_send_frag 256 " \
             "$P_CLI debug_level=4 " \
@@ -14489,6 +14493,7 @@ run_test    "Client Handshake defragmentation (256)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Client Handshake defragmentation (128)" \
             "$O_NEXT_SRV -split_send_frag 128 " \
             "$P_CLI debug_level=4 " \
@@ -14498,6 +14503,7 @@ run_test    "Client Handshake defragmentation (128)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Client Handshake defragmentation (64)" \
             "$O_NEXT_SRV -split_send_frag 64 " \
             "$P_CLI debug_level=4 " \
@@ -14507,6 +14513,7 @@ run_test    "Client Handshake defragmentation (64)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Client Handshake defragmentation (36)" \
             "$O_NEXT_SRV -split_send_frag 36 " \
             "$P_CLI debug_level=4 " \
@@ -14516,6 +14523,7 @@ run_test    "Client Handshake defragmentation (36)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Client Handshake defragmentation (32)" \
             "$O_NEXT_SRV -split_send_frag 32 " \
             "$P_CLI debug_level=4 " \
@@ -14525,6 +14533,7 @@ run_test    "Client Handshake defragmentation (32)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Client Handshake defragmentation (16)" \
             "$O_NEXT_SRV -split_send_frag 16 " \
             "$P_CLI debug_level=4 " \
@@ -14534,6 +14543,7 @@ run_test    "Client Handshake defragmentation (16)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Client Handshake defragmentation (13)" \
             "$O_NEXT_SRV -split_send_frag 13 " \
             "$P_CLI debug_level=4 " \
@@ -14543,6 +14553,7 @@ run_test    "Client Handshake defragmentation (13)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Client Handshake defragmentation (5)" \
             "$O_NEXT_SRV -split_send_frag 5 " \
             "$P_CLI debug_level=4 " \
@@ -14570,6 +14581,7 @@ run_test    "Server Handshake defragmentation (513)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Server Handshake defragmentation (256)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 256 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14579,6 +14591,7 @@ run_test    "Server Handshake defragmentation (256)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Server Handshake defragmentation (128)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 128 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14588,6 +14601,7 @@ run_test    "Server Handshake defragmentation (128)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Server Handshake defragmentation (64)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 64 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14597,6 +14611,7 @@ run_test    "Server Handshake defragmentation (64)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Server Handshake defragmentation (36)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 36 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14606,6 +14621,7 @@ run_test    "Server Handshake defragmentation (36)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Server Handshake defragmentation (32)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 32 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14615,6 +14631,7 @@ run_test    "Server Handshake defragmentation (32)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Server Handshake defragmentation (16)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 16 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14624,6 +14641,7 @@ run_test    "Server Handshake defragmentation (16)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Server Handshake defragmentation (13)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 13 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14633,6 +14651,7 @@ run_test    "Server Handshake defragmentation (13)" \
 
 requires_openssl_tls1_3
 requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Server Handshake defragmentation (5)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 5 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14660,6 +14660,7 @@ run_test    "Handshake defragmentation on client: len=13, TLS 1.3" \
             -c "handshake fragment: 0 \\.\\. 13 of [0-9]\\+ msglen 13" \
             -c "waiting for more fragments (13"
 
+skip_next_test
 requires_openssl_3_x
 requires_protocol_version tls12
 requires_certificate_authentication
@@ -14682,6 +14683,7 @@ run_test    "Handshake defragmentation on client: len=5, TLS 1.3" \
             -c "handshake fragment: 0 \\.\\. 5 of [0-9]\\+ msglen 5" \
             -c "waiting for more fragments (5"
 
+skip_next_test
 requires_openssl_3_x
 requires_protocol_version tls12
 requires_certificate_authentication
@@ -14704,6 +14706,7 @@ run_test    "Handshake defragmentation on client: len=4, TLS 1.3" \
             -c "handshake fragment: 0 \\.\\. 4 of [0-9]\\+ msglen 4" \
             -c "waiting for more fragments (4"
 
+skip_next_test
 requires_openssl_3_x
 requires_protocol_version tls12
 requires_certificate_authentication

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14798,7 +14798,7 @@ run_test    "Handshake defragmentation on server: len=128, TLS 1.3" \
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
-run_test    "Handshake defragmentation on server: len=128, TLS 1.2" \
+run_test    "Handshake defragmentation on server: len=128, TLS 1.2  TLS 1.3 Client-Hallo -> 1.2 Handhsake" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_2 -split_send_frag 128 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14819,7 +14819,7 @@ run_test    "Handshake defragmentation on server: len=64, TLS 1.3" \
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
-run_test    "Handshake defragmentation on server: len=64, TLS 1.2" \
+run_test    "Handshake defragmentation on server: len=64, TLS 1.2  TLS 1.3 Client-Hallo -> 1.2 Handhsake" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_2 -split_send_frag 64 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14840,7 +14840,7 @@ run_test    "Handshake defragmentation on server: len=36, TLS 1.3" \
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
-run_test    "Handshake defragmentation on server: len=36, TLS 1.2" \
+run_test    "Handshake defragmentation on server: len=36, TLS 1.2  TLS 1.3 Client-Hallo -> 1.2 Handhsake" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_2 -split_send_frag 36 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14861,7 +14861,7 @@ run_test    "Handshake defragmentation on server: len=32, TLS 1.3" \
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
-run_test    "Handshake defragmentation on server: len=32, TLS 1.2" \
+run_test    "Handshake defragmentation on server: len=32, TLS 1.2  TLS 1.3 Client-Hallo -> 1.2 Handhsake" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_2 -split_send_frag 32 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14882,7 +14882,7 @@ run_test    "Handshake defragmentation on server: len=16, TLS 1.3" \
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
-run_test    "Handshake defragmentation on server: len=16, TLS 1.2" \
+run_test    "Handshake defragmentation on server: len=16, TLS 1.2  TLS 1.3 Client-Hallo -> 1.2 Handhsake" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_2 -split_send_frag 16 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14903,7 +14903,7 @@ run_test    "Handshake defragmentation on server: len=13, TLS 1.3" \
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
-run_test    "Handshake defragmentation on server: len=13, TLS 1.2" \
+run_test    "Handshake defragmentation on server: len=13, TLS 1.2  TLS 1.3 Client-Hallo -> 1.2 Handhsake" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_2 -split_send_frag 13 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14924,7 +14924,7 @@ run_test    "Handshake defragmentation on server: len=5, TLS 1.3" \
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
-run_test    "Handshake defragmentation on server: len=5, TLS 1.2" \
+run_test    "Handshake defragmentation on server: len=5, TLS 1.2  TLS 1.3 Client-Hallo -> 1.2 Handhsake" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_2 -split_send_frag 5 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14945,7 +14945,7 @@ run_test    "Handshake defragmentation on server: len=4, TLS 1.3" \
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
-run_test    "Handshake defragmentation on server: len=4, TLS 1.2" \
+run_test    "Handshake defragmentation on server: len=4, TLS 1.2  TLS 1.3 Client-Hallo -> 1.2 Handhsake" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_2 -split_send_frag 4 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14966,7 +14966,7 @@ run_test    "Handshake defragmentation on server: len=3, TLS 1.3" \
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
-run_test    "Handshake defragmentation on server: len=3, TLS 1.3 -> 1.2" \
+run_test    "Handshake defragmentation on server: len=3, TLS 1.3 Client-Hallo -> 1.2 Handhsake" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_2 -split_send_frag 3 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             1 \
@@ -14977,7 +14977,7 @@ run_test    "Handshake defragmentation on server: len=3, TLS 1.3 -> 1.2" \
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
-run_test    "Handshake defragmentation on server: len=32, TLS 1.2 -> 1.2" \
+run_test    "Handshake defragmentation on server: len=32, TLS 1.3 Client-Hallo -> 1.2 Handhsake" \
             "$P_SRV debug_level=4 force_version=tls12 auth_mode=required" \
             "$O_NEXT_CLI -tls1_2 -split_send_frag 32 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             1 \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14477,7 +14477,7 @@ requires_openssl_3_x
 requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=512, TLS 1.3" \
-            "$O_NEXT_SRV -tls1_3 -max_send_frag 512 " \
+            "$O_NEXT_SRV -tls1_3 -split_send_frag 512 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
@@ -14488,7 +14488,7 @@ requires_openssl_3_x
 requires_protocol_version tls12
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=512, TLS 1.2" \
-            "$O_NEXT_SRV -tls1_2 -max_send_frag 512 " \
+            "$O_NEXT_SRV -tls1_2 -split_send_frag 512 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
@@ -14499,7 +14499,7 @@ requires_openssl_3_x
 requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=513, TLS 1.3" \
-            "$O_NEXT_SRV -tls1_3 -max_send_frag 513 " \
+            "$O_NEXT_SRV -tls1_3 -split_send_frag 513 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
@@ -14510,7 +14510,7 @@ requires_openssl_3_x
 requires_protocol_version tls12
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=513, TLS 1.2" \
-            "$O_NEXT_SRV -tls1_2 -max_send_frag 513 " \
+            "$O_NEXT_SRV -tls1_2 -split_send_frag 513 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
@@ -14750,7 +14750,7 @@ requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=512, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
-            "$O_NEXT_CLI -tls1_3 -max_send_frag 512 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -tls1_3 -split_send_frag 512 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 512 of [0-9]\\+ msglen 512" \
@@ -14761,7 +14761,7 @@ requires_protocol_version tls12
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=512, TLS 1.2" \
             "$P_SRV debug_level=4 auth_mode=required" \
-            "$O_NEXT_CLI -tls1_2 -max_send_frag 512 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -tls1_2 -split_send_frag 512 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 512 of [0-9]\\+ msglen 512" \
@@ -14772,7 +14772,7 @@ requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=513, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
-            "$O_NEXT_CLI -tls1_3 -max_send_frag 513 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -tls1_3 -split_send_frag 513 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 513 of [0-9]\\+ msglen 513" \
@@ -14783,7 +14783,7 @@ requires_protocol_version tls12
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=513, TLS 1.2" \
             "$P_SRV debug_level=4 auth_mode=required" \
-            "$O_NEXT_CLI -tls1_2 -max_send_frag 513 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -tls1_2 -split_send_frag 513 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 513 of [0-9]\\+ msglen 513" \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14465,8 +14465,8 @@ run_test    "Client Handshake defragmentation (512)" \
             "$O_NEXT_SRV -max_send_frag 512 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "<= handshake" \
-            -c "handshake fragment: "
+            -c "reassembled record" \
+            -c "waiting for more fragments (512 [0-9]\\+, [0-9]\\+ left)"
 
 requires_openssl_tls1_3
 requires_certificate_authentication
@@ -14474,8 +14474,8 @@ run_test    "Client Handshake defragmentation (513)" \
             "$O_NEXT_SRV -max_send_frag 513 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "<= handshake" \
-            -c "handshake fragment: "
+            -c "reassembled record" \
+            -c "waiting for more fragments (513 [0-9]\\+, [0-9]\\+ left)"
 
 # OpenSSL does not allow max_send_frag to be less than 512
 # so we use split_send_frag instead for tests lower than 512 below.
@@ -14490,8 +14490,8 @@ run_test    "Client Handshake defragmentation (256)" \
             "$O_NEXT_SRV -split_send_frag 256 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "<= handshake" \
-            -c "handshake fragment: "
+            -c "reassembled record" \
+            -c "waiting for more fragments (256 of [0-9]\\+, [0-9]\\+ left)"
 
 requires_openssl_tls1_3
 requires_certificate_authentication
@@ -14500,8 +14500,8 @@ run_test    "Client Handshake defragmentation (128)" \
             "$O_NEXT_SRV -split_send_frag 128 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "<= handshake" \
-            -c "handshake fragment: "
+            -c "reassembled record" \
+            -c "waiting for more fragments (128 [0-9]\\+, [0-9]\\+ left)"
 
 requires_openssl_tls1_3
 requires_certificate_authentication
@@ -14510,8 +14510,8 @@ run_test    "Client Handshake defragmentation (64)" \
             "$O_NEXT_SRV -split_send_frag 64 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "<= handshake" \
-            -c "handshake fragment: "
+            -c "reassembled record" \
+            -c "waiting for more fragments (64 [0-9]\\+, [0-9]\\+ left)"
 
 requires_openssl_tls1_3
 requires_certificate_authentication
@@ -14520,8 +14520,8 @@ run_test    "Client Handshake defragmentation (36)" \
             "$O_NEXT_SRV -split_send_frag 36 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "<= handshake" \
-            -c "handshake fragment: "
+            -c "reassembled record" \
+            -c "waiting for more fragments (36 [0-9]\\+, [0-9]\\+ left)"
 
 requires_openssl_tls1_3
 requires_certificate_authentication
@@ -14530,8 +14530,8 @@ run_test    "Client Handshake defragmentation (32)" \
             "$O_NEXT_SRV -split_send_frag 32 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "<= handshake" \
-            -c "handshake fragment: "
+            -c "reassembled record" \
+            -c "waiting for more fragments (32 [0-9]\\+, [0-9]\\+ left)"
 
 requires_openssl_tls1_3
 requires_certificate_authentication
@@ -14540,8 +14540,8 @@ run_test    "Client Handshake defragmentation (16)" \
             "$O_NEXT_SRV -split_send_frag 16 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "<= handshake" \
-            -c "handshake fragment: "
+            -c "reassembled record" \
+            -c "waiting for more fragments (16 [0-9]\\+, [0-9]\\+ left)"
 
 requires_openssl_tls1_3
 requires_certificate_authentication
@@ -14550,8 +14550,8 @@ run_test    "Client Handshake defragmentation (13)" \
             "$O_NEXT_SRV -split_send_frag 13 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "<= handshake" \
-            -c "handshake fragment: "
+            -c "reassembled record" \
+            -c "waiting for more fragments (13 [0-9]\\+, [0-9]\\+ left)"
 
 requires_openssl_tls1_3
 requires_certificate_authentication
@@ -14560,8 +14560,8 @@ run_test    "Client Handshake defragmentation (5)" \
             "$O_NEXT_SRV -split_send_frag 5 " \
             "$P_CLI debug_level=4 " \
             0 \
-            -c "<= handshake" \
-            -c "handshake fragment: "
+            -c "reassembled record" \
+            -c "waiting for more fragments (5 [0-9]\\+, [0-9]\\+ left)"
 
 requires_openssl_tls1_3
 requires_certificate_authentication
@@ -14569,8 +14569,8 @@ run_test    "Server Handshake defragmentation (512)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -max_send_frag 512 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
-            -s "<= handshake" \
-            -s "handshake fragment: "
+            -s "reassembled record" \
+            -s "waiting for more fragments (512 [0-9]\\+, [0-9]\\+ left)"
 
 requires_openssl_tls1_3
 requires_certificate_authentication
@@ -14578,8 +14578,8 @@ run_test    "Server Handshake defragmentation (513)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -max_send_frag 513 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
-            -s "<= handshake" \
-            -s "handshake fragment: "
+            -s "reassembled record" \
+            -s "waiting for more fragments (513 [0-9]\\+, [0-9]\\+ left)"
 
 requires_openssl_tls1_3
 requires_certificate_authentication
@@ -14588,8 +14588,8 @@ run_test    "Server Handshake defragmentation (256)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 256 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
-            -s "<= handshake" \
-            -s "handshake fragment: "
+            -s "reassembled record" \
+            -s "waiting for more fragments (256 [0-9]\\+, [0-9]\\+ left)"
 
 requires_openssl_tls1_3
 requires_certificate_authentication
@@ -14598,8 +14598,8 @@ run_test    "Server Handshake defragmentation (128)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 128 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
-            -s "<= handshake" \
-            -s "handshake fragment: "
+            -s "reassembled record" \
+            -s "waiting for more fragments (128 [0-9]\\+, [0-9]\\+ left)"
 
 requires_openssl_tls1_3
 requires_certificate_authentication
@@ -14608,8 +14608,8 @@ run_test    "Server Handshake defragmentation (64)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 64 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
-            -s "<= handshake" \
-            -s "handshake fragment: "
+            -s "reassembled record" \
+            -s "waiting for more fragments (64 [0-9]\\+, [0-9]\\+ left)"
 
 requires_openssl_tls1_3
 requires_certificate_authentication
@@ -14618,8 +14618,8 @@ run_test    "Server Handshake defragmentation (36)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 36 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
-            -s "<= handshake" \
-            -s "handshake fragment: "
+            -s "reassembled record" \
+            -s "waiting for more fragments (36 [0-9]\\+, [0-9]\\+ left)"
 
 requires_openssl_tls1_3
 requires_certificate_authentication
@@ -14628,8 +14628,8 @@ run_test    "Server Handshake defragmentation (32)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 32 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
-            -s "<= handshake" \
-            -s "handshake fragment: "
+            -s "reassembled record" \
+            -s "waiting for more fragments (32 [0-9]\\+, [0-9]\\+ left)"
 
 requires_openssl_tls1_3
 requires_certificate_authentication
@@ -14638,8 +14638,8 @@ run_test    "Server Handshake defragmentation (16)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 16 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
-            -s "<= handshake" \
-            -s "handshake fragment: "
+            -s "reassembled record" \
+            -s "waiting for more fragments (16 [0-9]\\+, [0-9]\\+ left)"
 
 requires_openssl_tls1_3
 requires_certificate_authentication
@@ -14648,8 +14648,8 @@ run_test    "Server Handshake defragmentation (13)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 13 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
-            -s "<= handshake" \
-            -s "handshake fragment: "
+            -s "reassembled record" \
+            -s "waiting for more fragments (12 [0-9]\\+, [0-9]\\+ left)"
 
 requires_openssl_tls1_3
 requires_certificate_authentication
@@ -14658,8 +14658,8 @@ run_test    "Server Handshake defragmentation (5)" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -split_send_frag 5 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
-            -s "<= handshake" \
-            -s "handshake fragment: "
+            -s "reassembled record" \
+            -s "waiting for more fragments (5 [0-9]\\+, [0-9]\\+ left)"
 
 # Test heap memory usage after handshake
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14694,6 +14694,27 @@ run_test    "Handshake defragmentation on client: len=5, TLS 1.2" \
             -c "handshake fragment: 0 \\.\\. 5 of [0-9]\\+ msglen 5" \
             -c "waiting for more fragments (5"
 
+requires_openssl_3_x
+requires_protocol_version tls13
+requires_certificate_authentication
+run_test    "Handshake defragmentation on client: len=3, TLS 1.3" \
+            "$O_NEXT_SRV -tls1_3 -split_send_frag 3 " \
+            "$P_CLI debug_level=4 " \
+            1 \
+            -c "=> ssl_tls13_process_server_hello" \
+            -c "handshake message too short: 3" \
+            -c "SSL - An invalid SSL record was received"
+
+requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on client: len=3, TLS 1.2" \
+            "$O_NEXT_SRV -tls1_2 -split_send_frag 3 " \
+            "$P_CLI debug_level=4 " \
+            1 \
+            -c "handshake message too short: 3" \
+            -c "SSL - An invalid SSL record was received"
+
 requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server (no fragmentation, for reference)." \
@@ -14945,6 +14966,41 @@ run_test    "Handshake defragmentation on server: len=4, TLS 1.2" \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 4 of [0-9]\\+ msglen 4" \
             -s "waiting for more fragments (4"
+
+requires_openssl_3_x
+requires_protocol_version tls13
+requires_certificate_authentication
+run_test    "Handshake defragmentation on server: len=3, TLS 1.3" \
+            "$P_SRV debug_level=4 auth_mode=required" \
+            "$O_NEXT_CLI -tls1_3 -split_send_frag 3 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            1 \
+            -s "<= parse client hello" \
+            -s "handshake message too short: 3" \
+            -s "SSL - An invalid SSL record was received"
+
+requires_openssl_3_x
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
+requires_certificate_authentication
+run_test    "Handshake defragmentation on server: len=3, TLS 1.3" \
+            "$P_SRV debug_level=4 auth_mode=required" \
+            "$O_NEXT_CLI -tls1_2 -split_send_frag 3 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            1 \
+            -s "<= parse client hello" \
+            -s "handshake message too short: 3" \
+            -s "SSL - An invalid SSL record was received"
+
+requires_openssl_3_x
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
+requires_certificate_authentication
+run_test    "Handshake defragmentation on server: len=32, TLS 1.2" \
+            "$P_SRV debug_level=4 force_version=tls12 auth_mode=required" \
+            "$O_NEXT_CLI -tls1_2 -split_send_frag 32 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            1 \
+            -s "The SSL configuration is tls12 only" \
+            -s "bad client hello message" \
+            -s "SSL - A message could not be parsed due to a syntactic error"
 
 # Test heap memory usage after handshake
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14630,7 +14630,7 @@ run_test    "Handshake defragmentation on client: len=32, TLS 1.2" \
 requires_openssl_3_x
 requires_protocol_version tls13
 requires_certificate_authentication
-run_test    "Handshake defragmentation on client: len=14, TLS 1.3" \
+run_test    "Handshake defragmentation on client: len=16, TLS 1.3" \
             "$O_NEXT_SRV -tls1_3 -split_send_frag 16 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -14641,7 +14641,7 @@ run_test    "Handshake defragmentation on client: len=14, TLS 1.3" \
 requires_openssl_3_x
 requires_protocol_version tls12
 requires_certificate_authentication
-run_test    "Handshake defragmentation on client: len=14, TLS 1.2" \
+run_test    "Handshake defragmentation on client: len=16, TLS 1.2" \
             "$O_NEXT_SRV -tls1_2 -split_send_frag 16 " \
             "$P_CLI debug_level=4 " \
             0 \
@@ -14692,6 +14692,28 @@ run_test    "Handshake defragmentation on client: len=5, TLS 1.2" \
             -c "reassembled record" \
             -c "handshake fragment: 0 \\.\\. 5 of [0-9]\\+ msglen 5" \
             -c "waiting for more fragments (5"
+
+requires_openssl_3_x
+requires_protocol_version tls13
+requires_certificate_authentication
+run_test    "Handshake defragmentation on client: len=4, TLS 1.3" \
+            "$O_NEXT_SRV -tls1_3 -split_send_frag 4 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "reassembled record" \
+            -c "handshake fragment: 0 \\.\\. 4 of [0-9]\\+ msglen 4" \
+            -c "waiting for more fragments (4"
+
+requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+run_test    "Handshake defragmentation on client: len=4, TLS 1.2" \
+            "$O_NEXT_SRV -tls1_2 -split_send_frag 4 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "reassembled record" \
+            -c "handshake fragment: 0 \\.\\. 4 of [0-9]\\+ msglen 4" \
+            -c "waiting for more fragments (4"
 
 requires_openssl_3_x
 requires_protocol_version tls13
@@ -14783,12 +14805,11 @@ requires_protocol_version tls12
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=256, TLS 1.2" \
             "$P_SRV debug_level=4 auth_mode=required" \
-            "$O_NEXT_CLI -tls1_3 -split_send_frag 256 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -tls1_2 -split_send_frag 256 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 256 of [0-9]\\+ msglen 256" \
             -s "waiting for more fragments (256"
-
 
 requires_openssl_3_x
 requires_protocol_version tls13
@@ -14801,8 +14822,11 @@ run_test    "Handshake defragmentation on server: len=128, TLS 1.3" \
             -s "handshake fragment: 0 \\.\\. 128 of [0-9]\\+ msglen 128" \
             -s "waiting for more fragments (128"
 
+# Server-side ClientHello degfragmentation is only supported for MBEDTLS_SSL_PROTO_TLS1_3. For TLS 1.2 testing
+# the server should suport both protocols and downgrade to client-requested TL1.2 after proccessing the ClientHello.
 requires_openssl_3_x
-requires_protocol_version tls12
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=128, TLS 1.2" \
             "$P_SRV debug_level=4 auth_mode=required" \
@@ -14824,7 +14848,8 @@ run_test    "Handshake defragmentation on server: len=64, TLS 1.3" \
             -s "waiting for more fragments (64"
 
 requires_openssl_3_x
-requires_protocol_version tls12
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=64, TLS 1.2" \
             "$P_SRV debug_level=4 auth_mode=required" \
@@ -14846,7 +14871,8 @@ run_test    "Handshake defragmentation on server: len=36, TLS 1.3" \
             -s "waiting for more fragments (36"
 
 requires_openssl_3_x
-requires_protocol_version tls12
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=36, TLS 1.2" \
             "$P_SRV debug_level=4 auth_mode=required" \
@@ -14868,7 +14894,8 @@ run_test    "Handshake defragmentation on server: len=32, TLS 1.3" \
             -s "waiting for more fragments (32"
 
 requires_openssl_3_x
-requires_protocol_version tls12
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=32, TLS 1.2" \
             "$P_SRV debug_level=4 auth_mode=required" \
@@ -14890,7 +14917,8 @@ run_test    "Handshake defragmentation on server: len=16, TLS 1.3" \
             -s "waiting for more fragments (16"
 
 requires_openssl_3_x
-requires_protocol_version tls12
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=16, TLS 1.2" \
             "$P_SRV debug_level=4 auth_mode=required" \
@@ -14912,7 +14940,8 @@ run_test    "Handshake defragmentation on server: len=13, TLS 1.3" \
             -s "waiting for more fragments (13"
 
 requires_openssl_3_x
-requires_protocol_version tls12
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=13, TLS 1.2" \
             "$P_SRV debug_level=4 auth_mode=required" \
@@ -14934,7 +14963,8 @@ run_test    "Handshake defragmentation on server: len=5, TLS 1.3" \
             -s "waiting for more fragments (5"
 
 requires_openssl_3_x
-requires_protocol_version tls12
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=5, TLS 1.2" \
             "$P_SRV debug_level=4 auth_mode=required" \
@@ -14944,6 +14974,7 @@ run_test    "Handshake defragmentation on server: len=5, TLS 1.2" \
             -s "handshake fragment: 0 \\.\\. 5 of [0-9]\\+ msglen 5" \
             -s "waiting for more fragments (5"
 
+requires_openssl_3_x
 requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=4, TLS 1.3" \
@@ -14977,8 +15008,6 @@ run_test    "Handshake defragmentation on server: len=3, TLS 1.3" \
             -s "handshake message too short: 3" \
             -s "SSL - An invalid SSL record was received"
 
-# Server-side ClientHello degfragmentation is only supported for MBEDTLS_SSL_PROTO_TLS1_3. For TLS 1.2 testing
-# the server should suport both protocols and downgrade to client-requested TL1.2 after proccessing the ClientHello.
 requires_openssl_3_x
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -14995,7 +15024,7 @@ requires_openssl_3_x
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
-run_test    "Handshake defragmentation on server: len=32, TLS 1.2" \
+run_test    "Handshake defragmentation on server: len=32, TLS 1.2 -> 1.2" \
             "$P_SRV debug_level=4 force_version=tls12 auth_mode=required" \
             "$O_NEXT_CLI -tls1_2 -split_send_frag 32 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             1 \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14694,6 +14694,7 @@ run_test    "Handshake defragmentation on client: len=4, TLS 1.2" \
             -c "waiting for more fragments (4"
 
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
+requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=3, TLS 1.3" \
             "$O_NEXT_SRV -tls1_3 -split_send_frag 3 " \
             "$P_CLI debug_level=4 " \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14460,10 +14460,10 @@ run_test    "TLS 1.2 ClientHello indicating support for deflate compression meth
 # Handshake defragmentation testing
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=512, TLS 1.3" \
-            "$O_NEXT_SRV -max_send_frag 512 " \
+            "$O_NEXT_SRV -tls1_3 -max_send_frag 512 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
@@ -14471,10 +14471,10 @@ run_test    "Handshake defragmentation on client: len=512, TLS 1.3" \
             -c "waiting for more fragments (512 of [0-9]\\+"
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=513, TLS 1.3" \
-            "$O_NEXT_SRV -max_send_frag 513 " \
+            "$O_NEXT_SRV -tls1_3 -max_send_frag 513 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
@@ -14488,11 +14488,10 @@ run_test    "Handshake defragmentation on client: len=513, TLS 1.3" \
 # than 512 bytes in TLS 1.2 so we require TLS 1.3 with these values.
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Handshake defragmentation on client: len=256, TLS 1.3" \
-            "$O_NEXT_SRV -split_send_frag 256 " \
+            "$O_NEXT_SRV -tls1_3 -split_send_frag 256 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
@@ -14500,11 +14499,10 @@ run_test    "Handshake defragmentation on client: len=256, TLS 1.3" \
             -c "waiting for more fragments (256 of [0-9]\\+"
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Handshake defragmentation on client: len=128, TLS 1.3" \
-            "$O_NEXT_SRV -split_send_frag 128 " \
+            "$O_NEXT_SRV -tls1_3 -split_send_frag 128 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
@@ -14512,11 +14510,10 @@ run_test    "Handshake defragmentation on client: len=128, TLS 1.3" \
             -c "waiting for more fragments (128"
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Handshake defragmentation on client: len=64, TLS 1.3" \
-            "$O_NEXT_SRV -split_send_frag 64 " \
+            "$O_NEXT_SRV -tls1_3 -split_send_frag 64 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
@@ -14524,11 +14521,10 @@ run_test    "Handshake defragmentation on client: len=64, TLS 1.3" \
             -c "waiting for more fragments (64"
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Handshake defragmentation on client: len=36, TLS 1.3" \
-            "$O_NEXT_SRV -split_send_frag 36 " \
+            "$O_NEXT_SRV -tls1_3 -split_send_frag 36 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
@@ -14536,11 +14532,10 @@ run_test    "Handshake defragmentation on client: len=36, TLS 1.3" \
             -c "waiting for more fragments (36"
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Handshake defragmentation on client: len=32, TLS 1.3" \
-            "$O_NEXT_SRV -split_send_frag 32 " \
+            "$O_NEXT_SRV -tls1_3 -split_send_frag 32 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
@@ -14548,11 +14543,10 @@ run_test    "Handshake defragmentation on client: len=32, TLS 1.3" \
             -c "waiting for more fragments (32"
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Handshake defragmentation on client: len=14, TLS 1.3" \
-            "$O_NEXT_SRV -split_send_frag 16 " \
+            "$O_NEXT_SRV -tls1_3 -split_send_frag 16 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
@@ -14560,11 +14554,10 @@ run_test    "Handshake defragmentation on client: len=14, TLS 1.3" \
             -c "waiting for more fragments (16"
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Handshake defragmentation on client: len=13, TLS 1.3" \
-            "$O_NEXT_SRV -split_send_frag 13 " \
+            "$O_NEXT_SRV -tls1_3 -split_send_frag 13 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
@@ -14572,11 +14565,10 @@ run_test    "Handshake defragmentation on client: len=13, TLS 1.3" \
             -c "waiting for more fragments (13"
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Handshake defragmentation on client: len=5, TLS 1.3" \
-            "$O_NEXT_SRV -split_send_frag 5 " \
+            "$O_NEXT_SRV -tls1_3 -split_send_frag 5 " \
             "$P_CLI debug_level=4 " \
             0 \
             -c "reassembled record" \
@@ -14584,118 +14576,110 @@ run_test    "Handshake defragmentation on client: len=5, TLS 1.3" \
             -c "waiting for more fragments (5"
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=512, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
-            "$O_NEXT_CLI -max_send_frag 512 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -tls1_3 -max_send_frag 512 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 512 of [0-9]\\+ msglen 512" \
             -s "waiting for more fragments (512"
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=513, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
-            "$O_NEXT_CLI -max_send_frag 513 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -tls1_3 -max_send_frag 513 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 513 of [0-9]\\+ msglen 513" \
             -s "waiting for more fragments (513"
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Handshake defragmentation on server: len=256, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
-            "$O_NEXT_CLI -split_send_frag 256 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -tls1_3 -split_send_frag 256 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 256 of [0-9]\\+ msglen 256" \
             -s "waiting for more fragments (256"
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Handshake defragmentation on server: len=128, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
-            "$O_NEXT_CLI -split_send_frag 128 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -tls1_3 -split_send_frag 128 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 128 of [0-9]\\+ msglen 128" \
             -s "waiting for more fragments (128"
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Handshake defragmentation on server: len=64, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
-            "$O_NEXT_CLI -split_send_frag 64 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -tls1_3 -split_send_frag 64 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 64 of [0-9]\\+ msglen 64" \
             -s "waiting for more fragments (64"
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Handshake defragmentation on server: len=36, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
-            "$O_NEXT_CLI -split_send_frag 36 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -tls1_3 -split_send_frag 36 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 36 of [0-9]\\+ msglen 36" \
             -s "waiting for more fragments (36"
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Handshake defragmentation on server: len=32, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
-            "$O_NEXT_CLI -split_send_frag 32 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -tls1_3 -split_send_frag 32 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 32 of [0-9]\\+ msglen 32" \
             -s "waiting for more fragments (32"
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Handshake defragmentation on server: len=16, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
-            "$O_NEXT_CLI -split_send_frag 16 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -tls1_3 -split_send_frag 16 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 16 of [0-9]\\+ msglen 16" \
             -s "waiting for more fragments (16"
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Handshake defragmentation on server: len=13, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
-            "$O_NEXT_CLI -split_send_frag 13 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -tls1_3 -split_send_frag 13 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 13 of [0-9]\\+ msglen 13" \
             -s "waiting for more fragments (13"
 
 requires_openssl_3_x
-requires_openssl_tls1_3
+requires_protocol_version tls13
 requires_certificate_authentication
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 run_test    "Handshake defragmentation on server: len=5, TLS 1.3" \
             "$P_SRV debug_level=4 auth_mode=required" \
-            "$O_NEXT_CLI -split_send_frag 5 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_CLI -tls1_3 -split_send_frag 5 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
             -s "reassembled record" \
             -s "handshake fragment: 0 \\.\\. 5 of [0-9]\\+ msglen 5" \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14694,7 +14694,6 @@ run_test    "Handshake defragmentation on client: len=4, TLS 1.2" \
             -c "waiting for more fragments (4"
 
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
-requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=3, TLS 1.3" \
             "$O_NEXT_SRV -tls1_3 -split_send_frag 3 " \
             "$P_CLI debug_level=4 " \
@@ -14704,7 +14703,6 @@ run_test    "Handshake defragmentation on client: len=3, TLS 1.3" \
             -c "SSL - An invalid SSL record was received"
 
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-requires_certificate_authentication
 run_test    "Handshake defragmentation on client: len=3, TLS 1.2" \
             "$O_NEXT_SRV -tls1_2 -split_send_frag 3 " \
             "$P_CLI debug_level=4 " \
@@ -14972,7 +14970,6 @@ run_test    "Handshake defragmentation on server: len=3, TLS 1.3 ClientHello -> 
             -s "SSL - An invalid SSL record was received"
 
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 run_test    "Handshake defragmentation on server: len=32, TLS 1.2 ClientHello" \
             "$P_SRV debug_level=4 force_version=tls12 auth_mode=required" \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14457,6 +14457,90 @@ run_test    "TLS 1.2 ClientHello indicating support for deflate compression meth
             -c "Handshake was completed" \
             -s "dumping .client hello, compression. (2 bytes)"
 
+# Handshake defragmentation testing
+
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test    "Hanshake defragmentation (512)" \
+            "$O_SRV -max_send_frag 512 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "received ServerHello message" \
+            -c "<= handshake" \
+
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test    "Hanshake defragmentation (513)" \
+            "$O_SRV -max_send_frag 513 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "received ServerHello message" \
+            -c "<= handshake" \
+
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test    "Hanshake defragmentation (256)" \
+            "$O_SRV -mtu 32 -split_send_frag 256 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "received ServerHello message" \
+            -c "<= handshake" \
+
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test    "Hanshake defragmentation (128)" \
+            "$O_SRV -mtu 32 -split_send_frag 128 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "received ServerHello message" \
+            -c "<= handshake" \
+
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test    "Hanshake defragmentation (64)" \
+            "$O_SRV -mtu 32 -split_send_frag 64 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "received ServerHello message" \
+            -c "<= handshake" \
+
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test    "Hanshake defragmentation (36)" \
+            "$O_SRV -mtu 32 -split_send_frag 36 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "received ServerHello message" \
+            -c "<= handshake" \
+
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test    "Hanshake defragmentation (32)" \
+            "$O_SRV -mtu 32 -split_send_frag 32 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "received ServerHello message" \
+            -c "<= handshake" \
+
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test    "Hanshake defragmentation (16)" \
+            "$O_SRV -mtu 32 -split_send_frag 16 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "received ServerHello message" \
+            -c "<= handshake" \
+
+
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test    "Hanshake defragmentation (13)" \
+            "$O_SRV -mtu 32 -split_send_frag 13 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "received ServerHello message" \
+            -c "<= handshake" \
+
+
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test    "Hanshake defragmentation (5)" \
+            "$O_SRV -mtu 32 -split_send_frag 5 " \
+            "$P_CLI debug_level=4 " \
+            0 \
+            -c "received ServerHello message" \
+            -c "<= handshake" \
+
 # Test heap memory usage after handshake
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_MEMORY_DEBUG


### PR DESCRIPTION
## Description

Backport of #9989


## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [ ] **changelog** provided.
- [ ] **development PR** provided #9989
- [ ] **TF-PSA-Crypto PR** not required because:  ssl-opt testing changes only
- [ ] **framework PR** not required
- [ ] **3.6 PR** provided.
- [ ] **2.28 PR** not required because:  Not backported to 2.28
- **tests**  provided
