### PR TITLE
Fix preprocessor guards for C99 format size specifiers

### DIFF
--- a/ChangeLog.d/fix-msvc-version-guard-format-zu.txt
+++ b/ChangeLog.d/fix-msvc-version-guard-format-zu.txt
@@ -1,5 +1,5 @@
 Bugfix
    * Fix definition of MBEDTLS_PRINTF_SIZET to prevent runtime crashes that
      occurred whenever SSL debugging was enabled on a copy of Mbed TLS built
-     with Visual Studio 2013.
+     with Visual Studio 2013 or MinGW.
      Fixes #10017.

--- a/ChangeLog.d/fix-msvc-version-guard-format-zu.txt
+++ b/ChangeLog.d/fix-msvc-version-guard-format-zu.txt
@@ -1,0 +1,5 @@
+Bugfix
+   * Fix definition of MBEDTLS_PRINTF_SIZET to prevent runtime crashes that
+     occurred whenever SSL debugging was enabled on a copy of Mbed TLS built
+     with Visual Studio 2013.
+     Fixes #10017.

--- a/include/mbedtls/debug.h
+++ b/include/mbedtls/debug.h
@@ -108,7 +108,7 @@
  *
  * This module provides debugging functions.
  */
-#if (defined(__MINGW32__) && __USE_MINGW_ANSI_STDIO == 0) || (defined(_MSC_VER) && _MSC_VER < 1900)
+#if defined(__MINGW32__) || (defined(_MSC_VER) && _MSC_VER < 1900)
    #include <inttypes.h>
    #define MBEDTLS_PRINTF_SIZET     PRIuPTR
    #define MBEDTLS_PRINTF_LONGLONG  "I64d"

--- a/include/mbedtls/debug.h
+++ b/include/mbedtls/debug.h
@@ -108,16 +108,16 @@
  *
  * This module provides debugging functions.
  */
-#if (defined(__MINGW32__) && __USE_MINGW_ANSI_STDIO == 0) || (defined(_MSC_VER) && _MSC_VER < 1800)
+#if (defined(__MINGW32__) && __USE_MINGW_ANSI_STDIO == 0) || (defined(_MSC_VER) && _MSC_VER < 1900)
    #include <inttypes.h>
    #define MBEDTLS_PRINTF_SIZET     PRIuPTR
    #define MBEDTLS_PRINTF_LONGLONG  "I64d"
 #else \
-    /* (defined(__MINGW32__)  && __USE_MINGW_ANSI_STDIO == 0) || (defined(_MSC_VER) && _MSC_VER < 1800) */
+    /* (defined(__MINGW32__)  && __USE_MINGW_ANSI_STDIO == 0) || (defined(_MSC_VER) && _MSC_VER < 1900) */
    #define MBEDTLS_PRINTF_SIZET     "zu"
    #define MBEDTLS_PRINTF_LONGLONG  "lld"
 #endif \
-    /* (defined(__MINGW32__)  && __USE_MINGW_ANSI_STDIO == 0) || (defined(_MSC_VER) && _MSC_VER < 1800) */
+    /* (defined(__MINGW32__)  && __USE_MINGW_ANSI_STDIO == 0) || (defined(_MSC_VER) && _MSC_VER < 1900) */
 
 #if !defined(MBEDTLS_PRINTF_MS_TIME)
 #include <inttypes.h>

--- a/include/mbedtls/debug.h
+++ b/include/mbedtls/debug.h
@@ -113,11 +113,11 @@
    #define MBEDTLS_PRINTF_SIZET     PRIuPTR
    #define MBEDTLS_PRINTF_LONGLONG  "I64d"
 #else \
-    /* (defined(__MINGW32__)  && __USE_MINGW_ANSI_STDIO == 0) || (defined(_MSC_VER) && _MSC_VER < 1900) */
+    /* defined(__MINGW32__) || (defined(_MSC_VER) && _MSC_VER < 1900) */
    #define MBEDTLS_PRINTF_SIZET     "zu"
    #define MBEDTLS_PRINTF_LONGLONG  "lld"
 #endif \
-    /* (defined(__MINGW32__)  && __USE_MINGW_ANSI_STDIO == 0) || (defined(_MSC_VER) && _MSC_VER < 1900) */
+    /* defined(__MINGW32__) || (defined(_MSC_VER) && _MSC_VER < 1900) */
 
 #if !defined(MBEDTLS_PRINTF_MS_TIME)
 #include <inttypes.h>

--- a/tests/suites/test_suite_debug.data
+++ b/tests/suites/test_suite_debug.data
@@ -5,6 +5,9 @@ printf_int_expr:(uintptr_t) "%" MBEDTLS_PRINTF_SIZET:sizeof(size_t):0:"0"
 printf "%" MBEDTLS_PRINTF_LONGLONG, 0
 printf_int_expr:(uintptr_t) "%" MBEDTLS_PRINTF_LONGLONG:sizeof(long long):0:"0"
 
+printf "%" MBEDTLS_PRINTF_MS_TIME, 0
+printf_int_expr:(uintptr_t) "%" MBEDTLS_PRINTF_MS_TIME:MBEDTLS_MS_TIME_SIZE:0:"0"
+
 Debug print msg (threshold 1, level 0)
 debug_print_msg_threshold:1:0:"MyFile":999:"MyFile(0999)\: Text message, 2 == 2\n"
 

--- a/tests/suites/test_suite_debug.data
+++ b/tests/suites/test_suite_debug.data
@@ -6,7 +6,7 @@ printf "%" MBEDTLS_PRINTF_LONGLONG, 0
 printf_int_expr:(uintptr_t) "%" MBEDTLS_PRINTF_LONGLONG:sizeof(long long):0:"0"
 
 printf "%" MBEDTLS_PRINTF_MS_TIME, 0
-printf_int_expr:(uintptr_t) "%" MBEDTLS_PRINTF_MS_TIME:MBEDTLS_MS_TIME_SIZE:0:"0"
+printf_int_expr:(uintptr_t) "%" MBEDTLS_PRINTF_MS_TIME:sizeof(mbedtls_ms_time_t):0:"0"
 
 Debug print msg (threshold 1, level 0)
 debug_print_msg_threshold:1:0:"MyFile":999:"MyFile(0999)\: Text message, 2 == 2\n"

--- a/tests/suites/test_suite_debug.data
+++ b/tests/suites/test_suite_debug.data
@@ -1,3 +1,10 @@
+# printf_int_expr expects a smuggled string expression as its first parameter
+printf "%" MBEDTLS_PRINTF_SIZET, 0
+printf_int_expr:(uintptr_t) "%" MBEDTLS_PRINTF_SIZET:sizeof(size_t):0:"0"
+
+printf "%" MBEDTLS_PRINTF_LONGLONG, 0
+printf_int_expr:(uintptr_t) "%" MBEDTLS_PRINTF_LONGLONG:sizeof(long long):0:"0"
+
 Debug print msg (threshold 1, level 0)
 debug_print_msg_threshold:1:0:"MyFile":999:"MyFile(0999)\: Text message, 2 == 2\n"
 

--- a/tests/suites/test_suite_debug.data
+++ b/tests/suites/test_suite_debug.data
@@ -1,12 +1,11 @@
-# printf_int_expr expects a smuggled string expression as its first parameter
 printf "%" MBEDTLS_PRINTF_SIZET, 0
-printf_int_expr:(uintptr_t) "%" MBEDTLS_PRINTF_SIZET:sizeof(size_t):0:"0"
+printf_int_expr:PRINTF_SIZET:sizeof(size_t):0:"0"
 
 printf "%" MBEDTLS_PRINTF_LONGLONG, 0
-printf_int_expr:(uintptr_t) "%" MBEDTLS_PRINTF_LONGLONG:sizeof(long long):0:"0"
+printf_int_expr:PRINTF_LONGLONG:sizeof(long long):0:"0"
 
 printf "%" MBEDTLS_PRINTF_MS_TIME, 0
-printf_int_expr:(uintptr_t) "%" MBEDTLS_PRINTF_MS_TIME:sizeof(mbedtls_ms_time_t):0:"0"
+printf_int_expr:PRINTF_MS_TIME:sizeof(mbedtls_ms_time_t):0:"0"
 
 Debug print msg (threshold 1, level 0)
 debug_print_msg_threshold:1:0:"MyFile":999:"MyFile(0999)\: Text message, 2 == 2\n"

--- a/tests/suites/test_suite_debug.function
+++ b/tests/suites/test_suite_debug.function
@@ -4,6 +4,11 @@
 #include "mbedtls/pk.h"
 #include <test/ssl_helpers.h>
 
+#if defined(_WIN32)
+#   include <stdlib.h>
+#   include <crtdbg.h>
+#endif
+
 // Use a macro instead of sizeof(mbedtls_ms_time_t) because the expression store
 // doesn't exclude entries based on depends_on headers, which would cause failures
 // in builds without MBEDTLS_HAVE_TIME
@@ -55,6 +60,23 @@ static void string_debug(void *data, int level, const char *file, int line, cons
     buffer->ptr = p;
 }
 #endif /* MBEDTLS_SSL_TLS_C */
+
+#if defined(_WIN32)
+static void noop_invalid_parameter_handler(
+    const wchar_t *expression,
+    const wchar_t *function,
+    const wchar_t *file,
+    unsigned int line,
+    uintptr_t pReserved)
+{
+    (void) expression;
+    (void) function;
+    (void) file;
+    (void) line;
+    (void) pReserved;
+}
+#endif /* _WIN32 */
+
 /* END_HEADER */
 
 /* BEGIN_DEPENDENCIES
@@ -66,6 +88,17 @@ static void string_debug(void *data, int level, const char *file, int line, cons
 void printf_int_expr(intmax_t smuggle_format_expr, /* TODO: teach test framework about string expressions */
                      intmax_t sizeof_x, intmax_t x, char *result)
 {
+#if defined(_WIN32)
+    /* Windows treats any invalid format specifiers passsed to the CRT as fatal assertion failures.
+       Disable this behaviour temporarily, so the rest of the test cases can complete. */
+    _invalid_parameter_handler saved_handler =
+        _set_invalid_parameter_handler(noop_invalid_parameter_handler);
+
+    // Disable assertion pop-up window in Debug builds
+    int saved_report_mode = _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_REPORT_MODE);
+    _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_DEBUG);
+#endif
+
     const char *format = (char *) ((uintptr_t) smuggle_format_expr);
     char *output = NULL;
     const size_t n = strlen(result);
@@ -87,6 +120,13 @@ void printf_int_expr(intmax_t smuggle_format_expr, /* TODO: teach test framework
 exit:
     mbedtls_free(output);
     output = NULL;
+
+#if defined(_WIN32)
+    // Restore default Windows behaviour
+    _set_invalid_parameter_handler(saved_handler);
+    _CrtSetReportMode(_CRT_ASSERT, saved_report_mode);
+    (void) saved_report_mode;
+#endif
 }
 /* END_CASE */
 

--- a/tests/suites/test_suite_debug.function
+++ b/tests/suites/test_suite_debug.function
@@ -9,6 +9,7 @@ struct buffer_data {
     char *ptr;
 };
 
+#if defined(MBEDTLS_SSL_TLS_C)
 static void string_debug(void *data, int level, const char *file, int line, const char *str)
 {
     struct buffer_data *buffer = (struct buffer_data *) data;
@@ -44,14 +45,15 @@ static void string_debug(void *data, int level, const char *file, int line, cons
 
     buffer->ptr = p;
 }
+#endif /* MBEDTLS_SSL_TLS_C */
 /* END_HEADER */
 
 /* BEGIN_DEPENDENCIES
- * depends_on:MBEDTLS_DEBUG_C:MBEDTLS_SSL_TLS_C
+ * depends_on:MBEDTLS_DEBUG_C
  * END_DEPENDENCIES
  */
 
-/* BEGIN_CASE */
+/* BEGIN_CASE depends_on:MBEDTLS_SSL_TLS_C */
 void debug_print_msg_threshold(int threshold, int level, char *file,
                                int line, char *result_str)
 {
@@ -89,7 +91,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE */
+/* BEGIN_CASE depends_on:MBEDTLS_SSL_TLS_C */
 void mbedtls_debug_print_ret(char *file, int line, char *text, int value,
                              char *result_str)
 {
@@ -124,7 +126,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE */
+/* BEGIN_CASE depends_on:MBEDTLS_SSL_TLS_C */
 void mbedtls_debug_print_buf(char *file, int line, char *text,
                              data_t *data, char *result_str)
 {
@@ -159,7 +161,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_FS_IO:MBEDTLS_X509_CRT_PARSE_C:!MBEDTLS_X509_REMOVE_INFO */
+/* BEGIN_CASE depends_on:MBEDTLS_SSL_TLS_C:MBEDTLS_FS_IO:MBEDTLS_X509_CRT_PARSE_C:!MBEDTLS_X509_REMOVE_INFO */
 void mbedtls_debug_print_crt(char *crt_file, char *file, int line,
                              char *prefix, char *result_str)
 {
@@ -199,7 +201,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_BIGNUM_C */
+/* BEGIN_CASE depends_on:MBEDTLS_SSL_TLS_C:MBEDTLS_BIGNUM_C */
 void mbedtls_debug_print_mpi(char *value, char *file, int line,
                              char *prefix, char *result_str)
 {

--- a/tests/suites/test_suite_debug.function
+++ b/tests/suites/test_suite_debug.function
@@ -53,6 +53,34 @@ static void string_debug(void *data, int level, const char *file, int line, cons
  * END_DEPENDENCIES
  */
 
+/* BEGIN_CASE */
+void printf_int_expr(intmax_t smuggle_format_expr, /* TODO: teach test framework about string expressions */
+                     intmax_t sizeof_x, intmax_t x, char *result)
+{
+    const char *format = (char *) ((uintptr_t) smuggle_format_expr);
+    char *output = NULL;
+    const size_t n = strlen(result);
+
+    /* Nominal case: buffer just large enough */
+    TEST_CALLOC(output, n + 1);
+    if ((size_t) sizeof_x <= sizeof(int)) { // Any smaller integers would be promoted to an int due to calling a vararg function
+        TEST_EQUAL(n, mbedtls_snprintf(output, n + 1, format, (int) x));
+    } else if (sizeof_x == sizeof(long)) {
+        TEST_EQUAL(n, mbedtls_snprintf(output, n + 1, format, (long) x));
+    } else if (sizeof_x == sizeof(long long)) {
+        TEST_EQUAL(n, mbedtls_snprintf(output, n + 1, format, (long long) x));
+    } else {
+        TEST_FAIL(
+            "sizeof_x <= sizeof(int) || sizeof_x == sizeof(long) || sizeof_x == sizeof(long long)");
+    }
+    TEST_MEMORY_COMPARE(result, n + 1, output, n + 1);
+
+exit:
+    mbedtls_free(output);
+    output = NULL;
+}
+/* END_CASE */
+
 /* BEGIN_CASE depends_on:MBEDTLS_SSL_TLS_C */
 void debug_print_msg_threshold(int threshold, int level, char *file,
                                int line, char *result_str)

--- a/tests/suites/test_suite_debug.function
+++ b/tests/suites/test_suite_debug.function
@@ -9,13 +9,9 @@
 #   include <crtdbg.h>
 #endif
 
-// Use a macro instead of sizeof(mbedtls_ms_time_t) because the expression store
-// doesn't exclude entries based on depends_on headers, which would cause failures
-// in builds without MBEDTLS_HAVE_TIME
-#if defined(MBEDTLS_PLATFORM_MS_TIME_TYPE_MACRO)
-#   define MBEDTLS_MS_TIME_SIZE sizeof(MBEDTLS_PLATFORM_MS_TIME_TYPE_MACRO)
-#else
-#   define MBEDTLS_MS_TIME_SIZE sizeof(int64_t)
+// Dummy type for builds without MBEDTLS_HAVE_TIME
+#if !defined(MBEDTLS_HAVE_TIME)
+typedef int64_t mbedtls_ms_time_t;
 #endif
 
 struct buffer_data {

--- a/tests/suites/test_suite_debug.function
+++ b/tests/suites/test_suite_debug.function
@@ -4,6 +4,15 @@
 #include "mbedtls/pk.h"
 #include <test/ssl_helpers.h>
 
+// Use a macro instead of sizeof(mbedtls_ms_time_t) because the expression store
+// doesn't exclude entries based on depends_on headers, which would cause failures
+// in builds without MBEDTLS_HAVE_TIME
+#if defined(MBEDTLS_PLATFORM_MS_TIME_TYPE_MACRO)
+#   define MBEDTLS_MS_TIME_SIZE sizeof(MBEDTLS_PLATFORM_MS_TIME_TYPE_MACRO)
+#else
+#   define MBEDTLS_MS_TIME_SIZE sizeof(int64_t)
+#endif
+
 struct buffer_data {
     char buf[2000];
     char *ptr;

--- a/tests/suites/test_suite_debug.function
+++ b/tests/suites/test_suite_debug.function
@@ -14,6 +14,18 @@
 typedef int64_t mbedtls_ms_time_t;
 #endif
 
+typedef enum {
+    PRINTF_SIZET,
+    PRINTF_LONGLONG,
+    PRINTF_MS_TIME,
+} printf_format_indicator_t;
+
+const char *const printf_formats[] = {
+    [PRINTF_SIZET]    = "%" MBEDTLS_PRINTF_SIZET,
+    [PRINTF_LONGLONG] = "%" MBEDTLS_PRINTF_LONGLONG,
+    [PRINTF_MS_TIME]  = "%" MBEDTLS_PRINTF_MS_TIME,
+};
+
 struct buffer_data {
     char buf[2000];
     char *ptr;
@@ -81,8 +93,7 @@ static void noop_invalid_parameter_handler(
  */
 
 /* BEGIN_CASE */
-void printf_int_expr(intmax_t smuggle_format_expr, /* TODO: teach test framework about string expressions */
-                     intmax_t sizeof_x, intmax_t x, char *result)
+void printf_int_expr(int format_indicator, intmax_t sizeof_x, intmax_t x, char *result)
 {
 #if defined(_WIN32)
     /* Windows treats any invalid format specifiers passsed to the CRT as fatal assertion failures.
@@ -95,7 +106,7 @@ void printf_int_expr(intmax_t smuggle_format_expr, /* TODO: teach test framework
     _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_DEBUG);
 #endif
 
-    const char *format = (char *) ((uintptr_t) smuggle_format_expr);
+    const char *format = printf_formats[format_indicator];
     char *output = NULL;
     const size_t n = strlen(result);
 


### PR DESCRIPTION
## Description

This PR fixes the preprocessor guards protecting the use of `%zu` in `MBEDTLS_PRINTF_SIZET`
It also adds a non-regression test to `test_suite_debug`.

Fixes #10017
Unblocks #9976

## PR checklist

- [ ] **changelog** provided
- [ ] **TF-PSA-Crypto PR** Mbed-TLS/TF-PSA-Crypto#192
- [ ] **framework PR** not required
- [ ] **3.6 PR** #10043
- [ ] **2.28 PR** #10044 
- [ ]  **tests**  provided