### PR TITLE
[3.6] Add `MBEDTLS_CONFIG_NAME` option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,15 @@ endif()
 # Make MBEDTLS_CONFIG_FILE and MBEDTLS_USER_CONFIG_FILE into PATHs
 set(MBEDTLS_CONFIG_FILE "" CACHE FILEPATH "Mbed TLS config file (overrides default).")
 set(MBEDTLS_USER_CONFIG_FILE "" CACHE FILEPATH "Mbed TLS user config file (appended to default).")
+set(MBEDTLS_CONFIG_NAME "" CACHE STRING "Mbed TLS config name")
+
+if(MBEDTLS_CONFIG_NAME)
+    configure_file(include/mbedtls/mbedtls_config.h ${CMAKE_CURRENT_BINARY_DIR}/named_config.h)
+    if (NOT (${MBEDTLS_CONFIG_NAME} MATCHES "default"))
+        execute_process(COMMAND ${PYTHON} scripts/config.py -f ${CMAKE_CURRENT_BINARY_DIR}/named_config.h ${MBEDTLS_CONFIG_NAME})
+    endif()
+    set(MBEDTLS_CONFIG_FILE ${CMAKE_CURRENT_BINARY_DIR}/named_config.h)
+endif()
 
 # Create a symbolic link from ${base_name} in the binary directory
 # to the corresponding path in the source directory.


### PR DESCRIPTION
This allows a named config (e.g. "full") to be specified in CMake. scripts/config.py will be called to setup the relevant config.


## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [ ] **changelog** provided | not required because: 
- [ ] **development PR** provided # | not required because: 
- [ ] **TF-PSA-Crypto PR** provided # | not required because: 
- [ ] **framework PR** provided Mbed-TLS/mbedtls-framework# | not required
- [ ] **3.6 PR** provided # | not required because: 
- [ ] **2.28 PR** provided # | not required because: 
- **tests**  provided | not required because: 
