### PR TITLE
Remove RNG parameters from public SSL APIs

### DIFF
--- a/include/mbedtls/ssl_cookie.h
+++ b/include/mbedtls/ssl_cookie.h
@@ -55,9 +55,7 @@ void mbedtls_ssl_cookie_init(mbedtls_ssl_cookie_ctx *ctx);
 /**
  * \brief          Setup cookie context (generate keys)
  */
-int mbedtls_ssl_cookie_setup(mbedtls_ssl_cookie_ctx *ctx,
-                             int (*f_rng)(void *, unsigned char *, size_t),
-                             void *p_rng);
+int mbedtls_ssl_cookie_setup(mbedtls_ssl_cookie_ctx *ctx);
 
 /**
  * \brief          Set expiration delay for cookies

--- a/include/mbedtls/ssl_ticket.h
+++ b/include/mbedtls/ssl_ticket.h
@@ -68,8 +68,6 @@ typedef struct mbedtls_ssl_ticket_context {
     uint32_t MBEDTLS_PRIVATE(ticket_lifetime);       /*!< lifetime of tickets in seconds     */
 
     /** Callback for getting (pseudo-)random numbers                        */
-    int(*MBEDTLS_PRIVATE(f_rng))(void *, unsigned char *, size_t);
-    void *MBEDTLS_PRIVATE(p_rng);                    /*!< context for the RNG function       */
 
 #if defined(MBEDTLS_THREADING_C)
     mbedtls_threading_mutex_t MBEDTLS_PRIVATE(mutex);
@@ -90,8 +88,6 @@ void mbedtls_ssl_ticket_init(mbedtls_ssl_ticket_context *ctx);
  * \brief           Prepare context to be actually used
  *
  * \param ctx       Context to be set up
- * \param f_rng     RNG callback function (mandatory)
- * \param p_rng     RNG callback context
  * \param alg       AEAD cipher to use for ticket protection.
  * \param key_type  Cryptographic key type to use.
  * \param key_bits  Cryptographic key size to use in bits.
@@ -116,7 +112,6 @@ void mbedtls_ssl_ticket_init(mbedtls_ssl_ticket_context *ctx);
  *                  or a specific MBEDTLS_ERR_XXX error code
  */
 int mbedtls_ssl_ticket_setup(mbedtls_ssl_ticket_context *ctx,
-                             int (*f_rng)(void *, unsigned char *, size_t), void *p_rng,
                              psa_algorithm_t alg, psa_key_type_t key_type, psa_key_bits_t key_bits,
                              uint32_t lifetime);
 

--- a/library/ssl_cookie.c
+++ b/library/ssl_cookie.c
@@ -81,16 +81,12 @@ void mbedtls_ssl_cookie_free(mbedtls_ssl_cookie_ctx *ctx)
     mbedtls_platform_zeroize(ctx, sizeof(mbedtls_ssl_cookie_ctx));
 }
 
-int mbedtls_ssl_cookie_setup(mbedtls_ssl_cookie_ctx *ctx,
-                             int (*f_rng)(void *, unsigned char *, size_t),
-                             void *p_rng)
+int mbedtls_ssl_cookie_setup(mbedtls_ssl_cookie_ctx *ctx)
 {
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
     psa_algorithm_t alg;
 
-    (void) f_rng;
-    (void) p_rng;
 
     alg = mbedtls_md_psa_alg_from_type(COOKIE_MD);
     if (alg == 0) {

--- a/library/ssl_ticket.c
+++ b/library/ssl_ticket.c
@@ -75,10 +75,6 @@ static int ssl_ticket_gen_key(mbedtls_ssl_ticket_context *ctx,
      */
     key->lifetime = ctx->ticket_lifetime;
 
-    if ((ret = psa_crypto_init()) != 0) {
-        return ret;
-    }
-
     if ((ret = psa_generate_random(key->name, sizeof(key->name))) != 0) {
         return ret;
     }
@@ -277,10 +273,6 @@ int mbedtls_ssl_ticket_write(void *p_ticket,
     *ticket_lifetime = key->lifetime;
 
     memcpy(key_name, key->name, TICKET_KEY_NAME_BYTES);
-
-    if ((ret = psa_crypto_init()) != 0) {
-        goto cleanup;
-    }
 
     if ((ret = psa_generate_random(iv, TICKET_IV_BYTES)) != 0) {
         goto cleanup;

--- a/programs/fuzz/fuzz_dtlsserver.c
+++ b/programs/fuzz/fuzz_dtlsserver.c
@@ -108,7 +108,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
     }
 #endif
 
-    if (mbedtls_ssl_cookie_setup(&cookie_ctx, dummy_random, &ctr_drbg) != 0) {
+    if (mbedtls_ssl_cookie_setup(&cookie_ctx) != 0) {
         goto exit;
     }
 

--- a/programs/fuzz/fuzz_server.c
+++ b/programs/fuzz/fuzz_server.c
@@ -132,8 +132,6 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 #if defined(MBEDTLS_SSL_SESSION_TICKETS) && defined(MBEDTLS_SSL_TICKET_C)
     if (options & 0x4) {
         if (mbedtls_ssl_ticket_setup(&ticket_ctx, //context
-                                     dummy_random, //f_rng
-                                     &ctr_drbg, //p_rng
                                      PSA_ALG_GCM, //alg
                                      PSA_KEY_TYPE_AES, //key_type
                                      256, //key_bits

--- a/programs/ssl/dtls_server.c
+++ b/programs/ssl/dtls_server.c
@@ -216,8 +216,7 @@ int main(void)
         goto exit;
     }
 
-    if ((ret = mbedtls_ssl_cookie_setup(&cookie_ctx,
-                                        mbedtls_ctr_drbg_random, &ctr_drbg)) != 0) {
+    if ((ret = mbedtls_ssl_cookie_setup(&cookie_ctx)) != 0) {
         printf(" failed\n  ! mbedtls_ssl_cookie_setup returned %d\n\n", ret);
         goto exit;
     }

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -2971,8 +2971,6 @@ usage:
 #endif /* MBEDTLS_HAVE_TIME */
         {
             if ((ret = mbedtls_ssl_ticket_setup(&ticket_ctx,
-                                                rng_get,
-                                                &rng,
                                                 opt.ticket_alg,
                                                 opt.ticket_key_type,
                                                 opt.ticket_key_bits,
@@ -3014,8 +3012,7 @@ usage:
     if (opt.transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM) {
 #if defined(MBEDTLS_SSL_COOKIE_C)
         if (opt.cookies > 0) {
-            if ((ret = mbedtls_ssl_cookie_setup(&cookie_ctx,
-                                                rng_get, &rng)) != 0) {
+            if ((ret = mbedtls_ssl_cookie_setup(&cookie_ctx)) != 0) {
                 mbedtls_printf(" failed\n  ! mbedtls_ssl_cookie_setup returned %d\n\n", ret);
                 goto exit;
             }


### PR DESCRIPTION
## Description

Remove RNG parameters from public SSL APIs, resolves #9930 

## PR checklist

- [x] **changelog** not required because: it will be provided under a later issue
- [x] **development PR** provided #HERE
- [x] **TF-PSA-Crypto PR** not required because: No changes
- [x] **framework PR** not required
- [x] **3.6 PR** not required because: 4.0 work - API break
- [x] **2.28 PR** not required because: 4.0 work - API break
- **tests** not required because: No updates.
