### PR TITLE
Remove mbedtls_ssl_conf_rng() 

### DIFF
--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -2061,17 +2061,6 @@ void mbedtls_ssl_conf_verify(mbedtls_ssl_config *conf,
 #endif /* MBEDTLS_X509_CRT_PARSE_C */
 
 /**
- * \brief          Set the random number generator callback
- *
- * \param conf     SSL configuration
- * \param f_rng    RNG function (mandatory)
- * \param p_rng    RNG parameter
- */
-void mbedtls_ssl_conf_rng(mbedtls_ssl_config *conf,
-                          int (*f_rng)(void *, unsigned char *, size_t),
-                          void *p_rng);
-
-/**
  * \brief          Set the debug callback
  *
  *                 The callback has the following argument:

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1405,10 +1405,6 @@ struct mbedtls_ssl_config {
     void(*MBEDTLS_PRIVATE(f_dbg))(void *, int, const char *, int, const char *);
     void *MBEDTLS_PRIVATE(p_dbg);                    /*!< context for the debug function     */
 
-    /** Callback for getting (pseudo-)random numbers                        */
-    int(*MBEDTLS_PRIVATE(f_rng))(void *, unsigned char *, size_t);
-    void *MBEDTLS_PRIVATE(p_rng);                    /*!< context for the RNG function       */
-
     /** Callback to retrieve a session from the cache                       */
     mbedtls_ssl_cache_get_t *MBEDTLS_PRIVATE(f_get_cache);
     /** Callback to store a session into the cache                          */

--- a/library/ssl_client.c
+++ b/library/ssl_client.c
@@ -726,7 +726,7 @@ static int ssl_generate_random(mbedtls_ssl_context *ssl)
     }
 
     ret = psa_generate_random(randbytes + gmt_unix_time_len,
-                           MBEDTLS_CLIENT_HELLO_RANDOM_LEN - gmt_unix_time_len);
+                              MBEDTLS_CLIENT_HELLO_RANDOM_LEN - gmt_unix_time_len);
     return ret;
 }
 
@@ -868,7 +868,7 @@ static int ssl_prepare_client_hello(mbedtls_ssl_context *ssl)
         if (session_id_len > 0) {
 
             ret = psa_generate_random(session_negotiate->id,
-                                   session_id_len);
+                                      session_id_len);
             if (ret != 0) {
                 MBEDTLS_SSL_DEBUG_RET(1, "creating session id failed", ret);
                 return ret;

--- a/library/ssl_client.c
+++ b/library/ssl_client.c
@@ -725,8 +725,7 @@ static int ssl_generate_random(mbedtls_ssl_context *ssl)
 #endif /* MBEDTLS_HAVE_TIME */
     }
 
-    ret = ssl->conf->f_rng(ssl->conf->p_rng,
-                           randbytes + gmt_unix_time_len,
+    ret = psa_generate_random(randbytes + gmt_unix_time_len,
                            MBEDTLS_CLIENT_HELLO_RANDOM_LEN - gmt_unix_time_len);
     return ret;
 }
@@ -867,8 +866,8 @@ static int ssl_prepare_client_hello(mbedtls_ssl_context *ssl)
     if (session_id_len != session_negotiate->id_len) {
         session_negotiate->id_len = session_id_len;
         if (session_id_len > 0) {
-            ret = ssl->conf->f_rng(ssl->conf->p_rng,
-                                   session_negotiate->id,
+
+            ret = psa_generate_random(session_negotiate->id,
                                    session_id_len);
             if (ret != 0) {
                 MBEDTLS_SSL_DEBUG_RET(1, "creating session id failed", ret);

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -1721,9 +1721,7 @@ void mbedtls_ssl_transform_init(mbedtls_ssl_transform *transform);
 MBEDTLS_CHECK_RETURN_CRITICAL
 int mbedtls_ssl_encrypt_buf(mbedtls_ssl_context *ssl,
                             mbedtls_ssl_transform *transform,
-                            mbedtls_record *rec,
-                            int (*f_rng)(void *, unsigned char *, size_t),
-                            void *p_rng);
+                            mbedtls_record *rec);
 MBEDTLS_CHECK_RETURN_CRITICAL
 int mbedtls_ssl_decrypt_buf(mbedtls_ssl_context const *ssl,
                             mbedtls_ssl_transform *transform,

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -823,12 +823,6 @@ int mbedtls_ssl_encrypt_buf(mbedtls_ssl_context *ssl,
     ((void) ssl);
 #endif
 
-    /* The PRNG is used for dynamic IV generation that's used
-     * for CBC transformations in TLS 1.2. */
-#if !(defined(MBEDTLS_SSL_SOME_SUITES_USE_CBC) && \
-    defined(MBEDTLS_SSL_PROTO_TLS1_2))
-#endif
-
     MBEDTLS_SSL_DEBUG_MSG(2, ("=> encrypt buf"));
 
     if (transform == NULL) {

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -827,8 +827,6 @@ int mbedtls_ssl_encrypt_buf(mbedtls_ssl_context *ssl,
      * for CBC transformations in TLS 1.2. */
 #if !(defined(MBEDTLS_SSL_SOME_SUITES_USE_CBC) && \
     defined(MBEDTLS_SSL_PROTO_TLS1_2))
-    ((void) f_rng);
-    ((void) p_rng);
 #endif
 
     MBEDTLS_SSL_DEBUG_MSG(2, ("=> encrypt buf"));

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -4462,7 +4462,7 @@ void mbedtls_ssl_handshake_free(mbedtls_ssl_context *ssl)
 #endif /* MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED */
 
 #if defined(MBEDTLS_SSL_ASYNC_PRIVATE)
-    if (ssl->conf != NULL && ssl->conf->f_async_cancel != NULL && handshake->async_in_progress != 0) {
+    if(ssl->conf->f_async_cancel != NULL && handshake->async_in_progress != 0) {
         ssl->conf->f_async_cancel(ssl);
         handshake->async_in_progress = 0;
     }

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -4462,11 +4462,9 @@ void mbedtls_ssl_handshake_free(mbedtls_ssl_context *ssl)
 #endif /* MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED */
 
 #if defined(MBEDTLS_SSL_ASYNC_PRIVATE)
-    if (ssl->conf != NULL) {
-        if (ssl->conf->f_async_cancel != NULL && handshake->async_in_progress != 0) {
-            ssl->conf->f_async_cancel(ssl);
-            handshake->async_in_progress = 0;
-        }
+    if (ssl->conf != NULL && ssl->conf->f_async_cancel != NULL && handshake->async_in_progress != 0) {
+        ssl->conf->f_async_cancel(ssl);
+        handshake->async_in_progress = 0;
     }
 
 #endif /* MBEDTLS_SSL_ASYNC_PRIVATE */

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -4465,8 +4465,8 @@ void mbedtls_ssl_handshake_free(mbedtls_ssl_context *ssl)
 #if defined(MBEDTLS_SSL_ASYNC_PRIVATE)
     if (ssl->conf != NULL) {
         if (ssl->conf->f_async_cancel != NULL && handshake->async_in_progress != 0) {
-                ssl->conf->f_async_cancel(ssl);
-                handshake->async_in_progress = 0;
+            ssl->conf->f_async_cancel(ssl);
+            handshake->async_in_progress = 0;
         }
     }
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -4462,7 +4462,7 @@ void mbedtls_ssl_handshake_free(mbedtls_ssl_context *ssl)
 #endif /* MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED */
 
 #if defined(MBEDTLS_SSL_ASYNC_PRIVATE)
-    if(ssl->conf->f_async_cancel != NULL && handshake->async_in_progress != 0) {
+    if (ssl->conf->f_async_cancel != NULL && handshake->async_in_progress != 0) {
         ssl->conf->f_async_cancel(ssl);
         handshake->async_in_progress = 0;
     }

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -4464,11 +4464,9 @@ void mbedtls_ssl_handshake_free(mbedtls_ssl_context *ssl)
 
 #if defined(MBEDTLS_SSL_ASYNC_PRIVATE)
     if (ssl->conf != NULL) {
-        if (ssl->conf->f_async_cancel != NULL) {
-            if (handshake->async_in_progress != 0) {
+        if (ssl->conf->f_async_cancel != NULL && handshake->async_in_progress != 0) {
                 ssl->conf->f_async_cancel(ssl);
                 handshake->async_in_progress = 0;
-            }
         }
     }
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1223,11 +1223,6 @@ static int ssl_conf_check(const mbedtls_ssl_context *ssl)
         return ret;
     }
 
-    if (ssl->conf->f_rng == NULL) {
-        MBEDTLS_SSL_DEBUG_MSG(1, ("no RNG provided"));
-        return MBEDTLS_ERR_SSL_NO_RNG;
-    }
-
     /* Space for further checks */
 
     return 0;
@@ -1249,6 +1244,7 @@ int mbedtls_ssl_setup(mbedtls_ssl_context *ssl,
     if ((ret = ssl_conf_check(ssl)) != 0) {
         return ret;
     }
+
     ssl->tls_version = ssl->conf->max_tls_version;
 
     /*
@@ -1286,6 +1282,10 @@ int mbedtls_ssl_setup(mbedtls_ssl_context *ssl,
 #endif
 
     if ((ret = ssl_handshake_init(ssl)) != 0) {
+        goto error;
+    }
+
+    if((ret = psa_crypto_init()) != 0) {
         goto error;
     }
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1244,7 +1244,6 @@ int mbedtls_ssl_setup(mbedtls_ssl_context *ssl,
     if ((ret = ssl_conf_check(ssl)) != 0) {
         return ret;
     }
-
     ssl->tls_version = ssl->conf->max_tls_version;
 
     /*

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -4467,10 +4467,13 @@ void mbedtls_ssl_handshake_free(mbedtls_ssl_context *ssl)
 #endif /* MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED */
 
 #if defined(MBEDTLS_SSL_ASYNC_PRIVATE)
-    if (ssl->conf->f_async_cancel != NULL && handshake->async_in_progress != 0) {
+    if (ssl->conf != NULL) {
+    if (ssl->conf->f_async_cancel != NULL) {
+    if(handshake->async_in_progress != 0) {
         ssl->conf->f_async_cancel(ssl);
         handshake->async_in_progress = 0;
-    }
+    }}}
+
 #endif /* MBEDTLS_SSL_ASYNC_PRIVATE */
 
 #if defined(PSA_WANT_ALG_SHA_256)

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -4464,11 +4464,13 @@ void mbedtls_ssl_handshake_free(mbedtls_ssl_context *ssl)
 
 #if defined(MBEDTLS_SSL_ASYNC_PRIVATE)
     if (ssl->conf != NULL) {
-    if (ssl->conf->f_async_cancel != NULL) {
-    if(handshake->async_in_progress != 0) {
-        ssl->conf->f_async_cancel(ssl);
-        handshake->async_in_progress = 0;
-    }}}
+        if (ssl->conf->f_async_cancel != NULL) {
+            if (handshake->async_in_progress != 0) {
+                ssl->conf->f_async_cancel(ssl);
+                handshake->async_in_progress = 0;
+            }
+        }
+    }
 
 #endif /* MBEDTLS_SSL_ASYNC_PRIVATE */
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1285,10 +1285,6 @@ int mbedtls_ssl_setup(mbedtls_ssl_context *ssl,
         goto error;
     }
 
-    if((ret = psa_crypto_init()) != 0) {
-        goto error;
-    }
-
     return 0;
 
 error:

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1526,14 +1526,6 @@ void mbedtls_ssl_conf_verify(mbedtls_ssl_config *conf,
 }
 #endif /* MBEDTLS_X509_CRT_PARSE_C */
 
-void mbedtls_ssl_conf_rng(mbedtls_ssl_config *conf,
-                          int (*f_rng)(void *, unsigned char *, size_t),
-                          void *p_rng)
-{
-    conf->f_rng      = f_rng;
-    conf->p_rng      = p_rng;
-}
-
 void mbedtls_ssl_conf_dbg(mbedtls_ssl_config *conf,
                           void (*f_dbg)(void *, int, const char *, int, const char *),
                           void  *p_dbg)

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -2133,7 +2133,7 @@ static int ssl_write_server_hello(mbedtls_ssl_context *ssl)
     MBEDTLS_SSL_DEBUG_MSG(3, ("server hello, current time: %" MBEDTLS_PRINTF_LONGLONG,
                               (long long) t));
 #else
-    if ((ret = psa_generate_random(ssl->conf->p_rng, p, 4)) != 0) {
+    if ((ret = psa_generate_random(p, 4)) != 0) {
         return ret;
     }
 
@@ -2166,7 +2166,6 @@ static int ssl_write_server_hello(mbedtls_ssl_context *ssl)
     } else
 #endif
     {
-	    
         if ((ret = psa_generate_random(p, 8)) != 0) {
             return ret;
         }

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -2133,14 +2133,14 @@ static int ssl_write_server_hello(mbedtls_ssl_context *ssl)
     MBEDTLS_SSL_DEBUG_MSG(3, ("server hello, current time: %" MBEDTLS_PRINTF_LONGLONG,
                               (long long) t));
 #else
-    if ((ret = ssl->conf->f_rng(ssl->conf->p_rng, p, 4)) != 0) {
+    if ((ret = psa_generate_random(ssl->conf->p_rng, p, 4)) != 0) {
         return ret;
     }
 
     p += 4;
 #endif /* MBEDTLS_HAVE_TIME */
 
-    if ((ret = ssl->conf->f_rng(ssl->conf->p_rng, p, 20)) != 0) {
+    if ((ret = psa_generate_random(p, 20)) != 0) {
         return ret;
     }
     p += 20;
@@ -2166,7 +2166,8 @@ static int ssl_write_server_hello(mbedtls_ssl_context *ssl)
     } else
 #endif
     {
-        if ((ret = ssl->conf->f_rng(ssl->conf->p_rng, p, 8)) != 0) {
+	    
+        if ((ret = psa_generate_random(p, 8)) != 0) {
             return ret;
         }
     }
@@ -2197,7 +2198,7 @@ static int ssl_write_server_hello(mbedtls_ssl_context *ssl)
 #endif /* MBEDTLS_SSL_SESSION_TICKETS */
         {
             ssl->session_negotiate->id_len = n = 32;
-            if ((ret = ssl->conf->f_rng(ssl->conf->p_rng, ssl->session_negotiate->id,
+            if ((ret = psa_generate_random(ssl->session_negotiate->id,
                                         n)) != 0) {
                 return ret;
             }

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -2198,7 +2198,7 @@ static int ssl_write_server_hello(mbedtls_ssl_context *ssl)
         {
             ssl->session_negotiate->id_len = n = 32;
             if ((ret = psa_generate_random(ssl->session_negotiate->id,
-                                        n)) != 0) {
+                                           n)) != 0) {
                 return ret;
             }
         }

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1997,7 +1997,7 @@ static int ssl_tls13_prepare_server_hello(mbedtls_ssl_context *ssl)
         ssl->handshake->randbytes + MBEDTLS_CLIENT_HELLO_RANDOM_LEN;
 
     if ((ret = psa_generate_random(server_randbytes,
-                                MBEDTLS_SERVER_HELLO_RANDOM_LEN)) != 0) {
+                                   MBEDTLS_SERVER_HELLO_RANDOM_LEN)) != 0) {
         MBEDTLS_SSL_DEBUG_RET(1, "psa_generate_random", ret);
         return ret;
     }
@@ -3173,7 +3173,7 @@ static int ssl_tls13_prepare_new_session_ticket(mbedtls_ssl_context *ssl,
 
     /* Generate ticket_age_add */
     if ((ret = psa_generate_random((unsigned char *) &session->ticket_age_add,
-                                sizeof(session->ticket_age_add)) != 0)) {
+                                   sizeof(session->ticket_age_add)) != 0)) {
         MBEDTLS_SSL_DEBUG_RET(1, "generate_ticket_age_add", ret);
         return ret;
     }

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1996,7 +1996,7 @@ static int ssl_tls13_prepare_server_hello(mbedtls_ssl_context *ssl)
     unsigned char *server_randbytes =
         ssl->handshake->randbytes + MBEDTLS_CLIENT_HELLO_RANDOM_LEN;
 
-    if ((ret = ssl->conf->f_rng(ssl->conf->p_rng, server_randbytes,
+    if ((ret = psa_generate_random(server_randbytes,
                                 MBEDTLS_SERVER_HELLO_RANDOM_LEN)) != 0) {
         MBEDTLS_SSL_DEBUG_RET(1, "f_rng", ret);
         return ret;
@@ -3172,8 +3172,7 @@ static int ssl_tls13_prepare_new_session_ticket(mbedtls_ssl_context *ssl,
 #endif
 
     /* Generate ticket_age_add */
-    if ((ret = ssl->conf->f_rng(ssl->conf->p_rng,
-                                (unsigned char *) &session->ticket_age_add,
+    if ((ret = psa_generate_random((unsigned char *) &session->ticket_age_add,
                                 sizeof(session->ticket_age_add)) != 0)) {
         MBEDTLS_SSL_DEBUG_RET(1, "generate_ticket_age_add", ret);
         return ret;
@@ -3182,7 +3181,7 @@ static int ssl_tls13_prepare_new_session_ticket(mbedtls_ssl_context *ssl,
                               (unsigned int) session->ticket_age_add));
 
     /* Generate ticket_nonce */
-    ret = ssl->conf->f_rng(ssl->conf->p_rng, ticket_nonce, ticket_nonce_size);
+    ret = psa_generate_random(ticket_nonce, ticket_nonce_size);
     if (ret != 0) {
         MBEDTLS_SSL_DEBUG_RET(1, "generate_ticket_nonce", ret);
         return ret;

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1998,7 +1998,7 @@ static int ssl_tls13_prepare_server_hello(mbedtls_ssl_context *ssl)
 
     if ((ret = psa_generate_random(server_randbytes,
                                 MBEDTLS_SERVER_HELLO_RANDOM_LEN)) != 0) {
-        MBEDTLS_SSL_DEBUG_RET(1, "f_rng", ret);
+        MBEDTLS_SSL_DEBUG_RET(1, "psa_generate_random", ret);
         return ret;
     }
 

--- a/programs/fuzz/fuzz_client.c
+++ b/programs/fuzz/fuzz_client.c
@@ -142,7 +142,6 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
     // mbedtls_ssl_conf_cert_profile, mbedtls_ssl_conf_sig_hashes
 
     srand(1);
-    mbedtls_ssl_conf_rng(&conf, dummy_random, &ctr_drbg);
 
     if (mbedtls_ssl_setup(&ssl, &conf) != 0) {
         goto exit;

--- a/programs/fuzz/fuzz_client.c
+++ b/programs/fuzz/fuzz_client.c
@@ -141,8 +141,6 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
     //There may be other options to add :
     // mbedtls_ssl_conf_cert_profile, mbedtls_ssl_conf_sig_hashes
 
-    srand(1);
-
     if (mbedtls_ssl_setup(&ssl, &conf) != 0) {
         goto exit;
     }

--- a/programs/fuzz/fuzz_dtlsclient.c
+++ b/programs/fuzz/fuzz_dtlsclient.c
@@ -68,7 +68,6 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
     }
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
-    srand(1);
     if (mbedtls_ctr_drbg_seed(&ctr_drbg, dummy_entropy, &entropy,
                               (const unsigned char *) pers, strlen(pers)) != 0) {
         goto exit;

--- a/programs/fuzz/fuzz_dtlsclient.c
+++ b/programs/fuzz/fuzz_dtlsclient.c
@@ -85,7 +85,6 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
     mbedtls_ssl_conf_ca_chain(&conf, &cacert, NULL);
 #endif
     mbedtls_ssl_conf_authmode(&conf, MBEDTLS_SSL_VERIFY_NONE);
-    mbedtls_ssl_conf_rng(&conf, dummy_random, &ctr_drbg);
 
     if (mbedtls_ssl_setup(&ssl, &conf) != 0) {
         goto exit;

--- a/programs/fuzz/fuzz_dtlsserver.c
+++ b/programs/fuzz/fuzz_dtlsserver.c
@@ -98,9 +98,6 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
         goto exit;
     }
 
-
-    srand(1);
-
 #if defined(MBEDTLS_X509_CRT_PARSE_C) && defined(MBEDTLS_PEM_PARSE_C)
     mbedtls_ssl_conf_ca_chain(&conf, srvcert.next, NULL);
     if (mbedtls_ssl_conf_own_cert(&conf, &srvcert, &pkey) != 0) {

--- a/programs/fuzz/fuzz_dtlsserver.c
+++ b/programs/fuzz/fuzz_dtlsserver.c
@@ -100,7 +100,6 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 
 
     srand(1);
-    mbedtls_ssl_conf_rng(&conf, dummy_random, &ctr_drbg);
 
 #if defined(MBEDTLS_X509_CRT_PARSE_C) && defined(MBEDTLS_PEM_PARSE_C)
     mbedtls_ssl_conf_ca_chain(&conf, srvcert.next, NULL);

--- a/programs/fuzz/fuzz_server.c
+++ b/programs/fuzz/fuzz_server.c
@@ -112,8 +112,6 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
         goto exit;
     }
 
-    srand(1);
-
 #if defined(MBEDTLS_X509_CRT_PARSE_C) && defined(MBEDTLS_PEM_PARSE_C)
     mbedtls_ssl_conf_ca_chain(&conf, srvcert.next, NULL);
     if (mbedtls_ssl_conf_own_cert(&conf, &srvcert, &pkey) != 0) {

--- a/programs/fuzz/fuzz_server.c
+++ b/programs/fuzz/fuzz_server.c
@@ -113,7 +113,6 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
     }
 
     srand(1);
-    mbedtls_ssl_conf_rng(&conf, dummy_random, &ctr_drbg);
 
 #if defined(MBEDTLS_X509_CRT_PARSE_C) && defined(MBEDTLS_PEM_PARSE_C)
     mbedtls_ssl_conf_ca_chain(&conf, srvcert.next, NULL);

--- a/programs/ssl/dtls_client.c
+++ b/programs/ssl/dtls_client.c
@@ -169,7 +169,6 @@ int main(int argc, char *argv[])
      * Production code should set a proper ca chain and use REQUIRED. */
     mbedtls_ssl_conf_authmode(&conf, MBEDTLS_SSL_VERIFY_OPTIONAL);
     mbedtls_ssl_conf_ca_chain(&conf, &cacert, NULL);
-    mbedtls_ssl_conf_rng(&conf, mbedtls_ctr_drbg_random, &ctr_drbg);
     mbedtls_ssl_conf_dbg(&conf, my_debug, stdout);
     mbedtls_ssl_conf_read_timeout(&conf, READ_TIMEOUT_MS);
 

--- a/programs/ssl/dtls_server.c
+++ b/programs/ssl/dtls_server.c
@@ -200,7 +200,6 @@ int main(void)
         goto exit;
     }
 
-    mbedtls_ssl_conf_rng(&conf, mbedtls_ctr_drbg_random, &ctr_drbg);
     mbedtls_ssl_conf_dbg(&conf, my_debug, stdout);
     mbedtls_ssl_conf_read_timeout(&conf, READ_TIMEOUT_MS);
 

--- a/programs/ssl/mini_client.c
+++ b/programs/ssl/mini_client.c
@@ -187,8 +187,6 @@ int main(void)
         goto exit;
     }
 
-    mbedtls_ssl_conf_rng(&conf, mbedtls_ctr_drbg_random, &ctr_drbg);
-
 #if defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED)
     mbedtls_ssl_conf_psk(&conf, psk, sizeof(psk),
                          (const unsigned char *) psk_id, sizeof(psk_id) - 1);

--- a/programs/ssl/ssl_client1.c
+++ b/programs/ssl/ssl_client1.c
@@ -150,7 +150,6 @@ int main(void)
      * but makes interop easier in this simplified example */
     mbedtls_ssl_conf_authmode(&conf, MBEDTLS_SSL_VERIFY_OPTIONAL);
     mbedtls_ssl_conf_ca_chain(&conf, &cacert, NULL);
-    mbedtls_ssl_conf_rng(&conf, mbedtls_ctr_drbg_random, &ctr_drbg);
     mbedtls_ssl_conf_dbg(&conf, my_debug, stdout);
 
     if ((ret = mbedtls_ssl_setup(&ssl, &conf)) != 0) {

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -1906,7 +1906,6 @@ usage:
 #endif
 #endif  /* MBEDTLS_HAVE_TIME */
     }
-    mbedtls_ssl_conf_rng(&conf, rng_get, &rng);
     mbedtls_ssl_conf_dbg(&conf, my_debug, stdout);
 
     mbedtls_ssl_conf_read_timeout(&conf, opt.read_timeout);

--- a/programs/ssl/ssl_fork_server.c
+++ b/programs/ssl/ssl_fork_server.c
@@ -160,7 +160,6 @@ int main(void)
         goto exit;
     }
 
-    mbedtls_ssl_conf_rng(&conf, mbedtls_ctr_drbg_random, &ctr_drbg);
     mbedtls_ssl_conf_dbg(&conf, my_debug, stdout);
 
     mbedtls_ssl_conf_ca_chain(&conf, srvcert.next, NULL);

--- a/programs/ssl/ssl_mail_client.c
+++ b/programs/ssl/ssl_mail_client.c
@@ -571,7 +571,6 @@ usage:
      * but makes interop easier in this simplified example */
     mbedtls_ssl_conf_authmode(&conf, MBEDTLS_SSL_VERIFY_OPTIONAL);
 
-    mbedtls_ssl_conf_rng(&conf, mbedtls_ctr_drbg_random, &ctr_drbg);
     mbedtls_ssl_conf_dbg(&conf, my_debug, stdout);
 
     if (opt.force_ciphersuite[0] != DFL_FORCE_CIPHER) {

--- a/programs/ssl/ssl_pthread_server.c
+++ b/programs/ssl/ssl_pthread_server.c
@@ -401,7 +401,6 @@ int main(void)
         goto exit;
     }
 
-    mbedtls_ssl_conf_rng(&conf, mbedtls_ctr_drbg_random, &ctr_drbg);
     mbedtls_ssl_conf_dbg(&conf, my_mutexed_debug, stdout);
 
     /* mbedtls_ssl_cache_get() and mbedtls_ssl_cache_set() are thread-safe if

--- a/programs/ssl/ssl_server.c
+++ b/programs/ssl/ssl_server.c
@@ -179,7 +179,6 @@ int main(void)
         goto exit;
     }
 
-    mbedtls_ssl_conf_rng(&conf, mbedtls_ctr_drbg_random, &ctr_drbg);
     mbedtls_ssl_conf_dbg(&conf, my_debug, stdout);
 
 #if defined(MBEDTLS_SSL_CACHE_C)

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -2925,7 +2925,6 @@ usage:
 #endif
 #endif  /* MBEDTLS_HAVE_TIME */
     }
-    mbedtls_ssl_conf_rng(&conf, rng_get, &rng);
     mbedtls_ssl_conf_dbg(&conf, my_debug, stdout);
 
 #if defined(MBEDTLS_SSL_CACHE_C)

--- a/programs/x509/cert_app.c
+++ b/programs/x509/cert_app.c
@@ -383,7 +383,6 @@ usage:
             mbedtls_ssl_conf_authmode(&conf, MBEDTLS_SSL_VERIFY_NONE);
         }
 
-        mbedtls_ssl_conf_rng(&conf, mbedtls_ctr_drbg_random, &ctr_drbg);
         mbedtls_ssl_conf_dbg(&conf, my_debug, stdout);
 
         if ((ret = mbedtls_ssl_setup(&ssl, &conf)) != 0) {

--- a/tests/src/test_helpers/ssl_helpers.c
+++ b/tests/src/test_helpers/ssl_helpers.c
@@ -767,7 +767,6 @@ int mbedtls_test_ssl_endpoint_init(
 
     mbedtls_ssl_init(&(ep->ssl));
     mbedtls_ssl_config_init(&(ep->conf));
-    mbedtls_ssl_conf_rng(&(ep->conf), mbedtls_test_random, NULL);
 
     TEST_ASSERT(mbedtls_ssl_conf_get_user_data_p(&ep->conf) == NULL);
     TEST_EQUAL(mbedtls_ssl_conf_get_user_data_n(&ep->conf), 0);

--- a/tests/suites/test_suite_debug.function
+++ b/tests/suites/test_suite_debug.function
@@ -156,7 +156,6 @@ void debug_print_msg_threshold(int threshold, int level, char *file,
                                            MBEDTLS_SSL_TRANSPORT_STREAM,
                                            MBEDTLS_SSL_PRESET_DEFAULT),
                0);
-    mbedtls_ssl_conf_rng(&conf, mbedtls_test_random, NULL);
     mbedtls_ssl_conf_dbg(&conf, string_debug, &buffer);
 
     TEST_ASSERT(mbedtls_ssl_setup(&ssl, &conf) == 0);
@@ -194,7 +193,6 @@ void mbedtls_debug_print_ret(char *file, int line, char *text, int value,
                                            MBEDTLS_SSL_TRANSPORT_STREAM,
                                            MBEDTLS_SSL_PRESET_DEFAULT),
                0);
-    mbedtls_ssl_conf_rng(&conf, mbedtls_test_random, NULL);
     mbedtls_ssl_conf_dbg(&conf, string_debug, &buffer);
 
     TEST_ASSERT(mbedtls_ssl_setup(&ssl, &conf) == 0);
@@ -229,7 +227,6 @@ void mbedtls_debug_print_buf(char *file, int line, char *text,
                                            MBEDTLS_SSL_TRANSPORT_STREAM,
                                            MBEDTLS_SSL_PRESET_DEFAULT),
                0);
-    mbedtls_ssl_conf_rng(&conf, mbedtls_test_random, NULL);
     mbedtls_ssl_conf_dbg(&conf, string_debug, &buffer);
 
     TEST_ASSERT(mbedtls_ssl_setup(&ssl, &conf) == 0);
@@ -267,7 +264,6 @@ void mbedtls_debug_print_crt(char *crt_file, char *file, int line,
                                            MBEDTLS_SSL_TRANSPORT_STREAM,
                                            MBEDTLS_SSL_PRESET_DEFAULT),
                0);
-    mbedtls_ssl_conf_rng(&conf, mbedtls_test_random, NULL);
     mbedtls_ssl_conf_dbg(&conf, string_debug, &buffer);
 
     TEST_ASSERT(mbedtls_ssl_setup(&ssl, &conf) == 0);
@@ -306,7 +302,6 @@ void mbedtls_debug_print_mpi(char *value, char *file, int line,
                                            MBEDTLS_SSL_TRANSPORT_STREAM,
                                            MBEDTLS_SSL_PRESET_DEFAULT),
                0);
-    mbedtls_ssl_conf_rng(&conf, mbedtls_test_random, NULL);
     mbedtls_ssl_conf_dbg(&conf, string_debug, &buffer);
 
     TEST_ASSERT(mbedtls_ssl_setup(&ssl, &conf) == 0);

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -1219,7 +1219,6 @@ void ssl_dtls_replay(data_t *prevs, data_t *new, int ret)
                                             MBEDTLS_SSL_IS_CLIENT,
                                             MBEDTLS_SSL_TRANSPORT_DATAGRAM,
                                             MBEDTLS_SSL_PRESET_DEFAULT) == 0);
-    mbedtls_ssl_conf_rng(&conf, mbedtls_test_random, NULL);
 
     TEST_ASSERT(mbedtls_ssl_setup(&ssl, &conf) == 0);
 
@@ -3033,7 +3032,6 @@ void conf_version(int endpoint, int transport,
     mbedtls_ssl_conf_transport(&conf, transport);
     mbedtls_ssl_conf_min_tls_version(&conf, min_tls_version);
     mbedtls_ssl_conf_max_tls_version(&conf, max_tls_version);
-    mbedtls_ssl_conf_rng(&conf, mbedtls_test_random, NULL);
 
     TEST_ASSERT(mbedtls_ssl_setup(&ssl, &conf) == expected_ssl_setup_result);
     TEST_EQUAL(mbedtls_ssl_conf_get_endpoint(
@@ -3058,7 +3056,6 @@ void conf_group()
     mbedtls_ssl_config conf;
     mbedtls_ssl_config_init(&conf);
 
-    mbedtls_ssl_conf_rng(&conf, mbedtls_test_random, NULL);
     mbedtls_ssl_config_defaults(&conf, MBEDTLS_SSL_IS_CLIENT,
                                 MBEDTLS_SSL_TRANSPORT_STREAM,
                                 MBEDTLS_SSL_PRESET_DEFAULT);
@@ -3168,7 +3165,6 @@ void cookie_parsing(data_t *cookie, int exp_ret)
                                            MBEDTLS_SSL_TRANSPORT_DATAGRAM,
                                            MBEDTLS_SSL_PRESET_DEFAULT),
                0);
-    mbedtls_ssl_conf_rng(&conf, mbedtls_test_random, NULL);
 
     TEST_EQUAL(mbedtls_ssl_setup(&ssl, &conf), 0);
     TEST_EQUAL(mbedtls_ssl_check_dtls_clihlo_cookie(&ssl, ssl.cli_id,
@@ -3223,7 +3219,6 @@ void cid_sanity()
                                             MBEDTLS_SSL_TRANSPORT_STREAM,
                                             MBEDTLS_SSL_PRESET_DEFAULT)
                 == 0);
-    mbedtls_ssl_conf_rng(&conf, mbedtls_test_random, NULL);
 
     TEST_ASSERT(mbedtls_ssl_setup(&ssl, &conf) == 0);
 
@@ -3482,7 +3477,6 @@ void ssl_ecjpake_set_password(int use_opaque_arg)
                                            MBEDTLS_SSL_IS_CLIENT,
                                            MBEDTLS_SSL_TRANSPORT_STREAM,
                                            MBEDTLS_SSL_PRESET_DEFAULT), 0);
-    mbedtls_ssl_conf_rng(&conf, mbedtls_test_random, NULL);
 
     TEST_EQUAL(mbedtls_ssl_setup(&ssl, &conf), 0);
 

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -1340,8 +1340,7 @@ void ssl_crypt_record(int cipher_type, int hash_id,
         rec_backup = rec;
 
         /* Encrypt record */
-        ret = mbedtls_ssl_encrypt_buf(&ssl, t_enc, &rec,
-                                      mbedtls_test_rnd_std_rand, NULL);
+        ret = mbedtls_ssl_encrypt_buf(&ssl, t_enc, &rec);
         TEST_ASSERT(ret == 0 || ret == MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL);
         if (ret != 0) {
             continue;
@@ -1494,8 +1493,7 @@ void ssl_crypt_record_small(int cipher_type, int hash_id,
             rec_backup = rec;
 
             /* Encrypt record */
-            ret = mbedtls_ssl_encrypt_buf(&ssl, t_enc, &rec,
-                                          mbedtls_test_rnd_std_rand, NULL);
+            ret = mbedtls_ssl_encrypt_buf(&ssl, t_enc, &rec);
 
             if (ret == MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL) {
                 /* It's ok if the output buffer is too small. We do insist
@@ -1948,8 +1946,7 @@ void ssl_tls13_record_protection(int ciphersuite,
     memset(&rec.ctr[0], 0, 8);
     rec.ctr[7] = ctr;
 
-    TEST_ASSERT(mbedtls_ssl_encrypt_buf(NULL, &transform_send, &rec,
-                                        NULL, NULL) == 0);
+    TEST_ASSERT(mbedtls_ssl_encrypt_buf(NULL, &transform_send, &rec) == 0);
 
     if (padding_used == MBEDTLS_SSL_CID_TLS1_3_PADDING_GRANULARITY) {
         TEST_MEMORY_COMPARE(rec.buf + rec.data_offset, rec.data_len,


### PR DESCRIPTION
## Description

Remove mbedtls_ssl_conf_rng() resolves #9052 depends https://github.com/Mbed-TLS/mbedtls/pull/10039

## PR checklist

- [x] **changelog** not required because: it will be provided under a later issue
- [x] **development PR** provided #HERE
- [x] **TF-PSA-Crypto PR** not required because: No changes
- [x] **framework PR** not required
- [x] **3.6 PR** not required because: No backports
- [x] **2.28 PR** not required because: No backports
- **tests**  not required because: No updates.
