### PR TITLE
Fix defrag interleave 3.6

### DIFF
--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -5148,6 +5148,18 @@ int mbedtls_ssl_handle_message_type(mbedtls_ssl_context *ssl)
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
 
+    /* If we're in the middle of a fragmented TLS handshake message,
+     * we don't accept any other message type. For TLS 1.3, the spec forbids
+     * interleaving other message types between handshake fragments. For TLS
+     * 1.2, the spec does not forbid it but we do. */
+    if (ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_STREAM &&
+        ssl->badmac_seen_or_in_hsfraglen != 0 &&
+        ssl->in_msgtype != MBEDTLS_SSL_MSG_HANDSHAKE) {
+        MBEDTLS_SSL_DEBUG_MSG(1, ("non-handshake message in the middle"
+                                  " of a fragmented handshake message"));
+        return MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE;
+    }
+
     /*
      * Handle particular types of records
      */


### PR DESCRIPTION
## Description

This is the subset of https://github.com/Mbed-TLS/mbedtls/pull/9976 that's the most urgently needed.

## PR checklist


- [x] **changelog** not required because: fixing a bug that was never released
- [x] **development PR** provided #10047
- [x] **TF-PSA-Crypto PR** not required because: TLS only
- [x] **framework PR** not required
- [x] **3.6 PR** provided HERE
- [x] **2.28 PR** not required because: not affected
- **tests**  not required because: deferred to #9976 
