### PR TITLE
Backport 3.6: Document the limitations of TLS handshake message defragmentation

### DIFF
--- a/ChangeLog.d/tls-hs-defrag-in.txt
+++ b/ChangeLog.d/tls-hs-defrag-in.txt
@@ -4,4 +4,4 @@ Bugfix
      some servers, especially with TLS 1.3 in practice. There are a few
      limitations, notably a fragmented ClientHello is only supported when
      TLS 1.3 support is enabled. See the documentation of
-     mbedtls_ssl_conf_max_frag_len() for details.
+     mbedtls_ssl_handshake() for details.

--- a/ChangeLog.d/tls-hs-defrag-in.txt
+++ b/ChangeLog.d/tls-hs-defrag-in.txt
@@ -1,12 +1,7 @@
 Bugfix
-   * Support re-assembly of fragmented handshake messages in TLS, as mandated
-     by the spec. Lack of support was causing handshake failures with some
-     servers, especially with TLS 1.3 in practice (though both protocol
-     version could be affected in principle, and both are fixed now).
-     The initial fragment for each handshake message must be at least 4 bytes.
-
-     Server-side, defragmentation of the ClientHello message is only
-     supported if the server accepts TLS 1.3 (regardless of whether the
-     ClientHello is 1.3 or 1.2). That is, servers configured (either
-     at compile time or at runtime) to only accept TLS 1.2 will
-     still fail the handshake if the ClientHello message is fragmented.
+   * Support re-assembly of fragmented handshake messages in TLS (both
+     1.2 and 1.3). The lack of support was causing handshake failures with
+     some servers, especially with TLS 1.3 in practice. There are a few
+     limitations, notably a fragmented ClientHello is only supported when
+     TLS 1.3 support is enabled. See the documentation of
+     mbedtls_ssl_conf_max_frag_len() for details.

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -4449,23 +4449,9 @@ void mbedtls_ssl_conf_cert_req_ca_list(mbedtls_ssl_config *conf,
  *                 with \c mbedtls_ssl_read()), not handshake messages.
  *                 With DTLS, this affects both ApplicationData and handshake.
  *
- * \note           Defragmentation of incoming handshake messages in TLS
- *                 (excluding DTLS) is supported with some limitations:
- *                 - On an Mbed TLS server that only accepts TLS 1.2,
- *                   the initial ClientHello message must not be fragmented.
- *                   A TLS 1.2 ClientHello may be fragmented if the server
- *                   also accepts TLS 1.3 connections (meaning
- *                   that #MBEDTLS_SSL_PROTO_TLS1_3 enabled, and the
- *                   accepted versions have not been restricted with
- *                   mbedtls_ssl_conf_max_tls_version() or the like).
- *                 - A ClientHello message that initiates a renegotiation
- *                   must not be fragmented.
- *                 - The first fragment of a handshake message must be
- *                   at least 4 bytes long.
- *                 - Non-handshake records must not be interleaved between
- *                   the fragments of a handshake message. (This is permitted
- *                   in TLS 1.2 but not in TLS 1.3, but Mbed TLS rejects it
- *                   even in TLS 1.2.)
+ * \note           Defragmentation of TLS handshake messages is supported
+ *                 with some limitations. See the documentation of
+ *                 mbedtls_ssl_handshake() for details.
  *
  * \note           This sets the maximum length for a record's payload,
  *                 excluding record overhead that will be added to it, see
@@ -4997,6 +4983,24 @@ int mbedtls_ssl_get_session(const mbedtls_ssl_context *ssl,
  *                 if a negotiation involving TLS 1.3 takes place (this may
  *                 be the case even if TLS 1.3 is offered but eventually
  *                 not selected).
+ *
+ * \note           Defragmentation of incoming handshake messages in TLS
+ *                 (excluding DTLS) is supported with some limitations:
+ *                 - On an Mbed TLS server that only accepts TLS 1.2,
+ *                   the initial ClientHello message must not be fragmented.
+ *                   A TLS 1.2 ClientHello may be fragmented if the server
+ *                   also accepts TLS 1.3 connections (meaning
+ *                   that #MBEDTLS_SSL_PROTO_TLS1_3 enabled, and the
+ *                   accepted versions have not been restricted with
+ *                   mbedtls_ssl_conf_max_tls_version() or the like).
+ *                 - A ClientHello message that initiates a renegotiation
+ *                   must not be fragmented.
+ *                 - The first fragment of a handshake message must be
+ *                   at least 4 bytes long.
+ *                 - Non-handshake records must not be interleaved between
+ *                   the fragments of a handshake message. (This is permitted
+ *                   in TLS 1.2 but not in TLS 1.3, but Mbed TLS rejects it
+ *                   even in TLS 1.2.)
  */
 int mbedtls_ssl_handshake(mbedtls_ssl_context *ssl);
 

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -4985,7 +4985,7 @@ int mbedtls_ssl_get_session(const mbedtls_ssl_context *ssl,
  *                 not selected).
  *
  * \note           Defragmentation of incoming handshake messages in TLS
- *                 (excluding DTLS) is supported with some limitations:
+ *                 is supported with some limitations:
  *                 - On an Mbed TLS server that only accepts TLS 1.2,
  *                   the initial ClientHello message must not be fragmented.
  *                   A TLS 1.2 ClientHello may be fragmented if the server
@@ -4993,6 +4993,7 @@ int mbedtls_ssl_get_session(const mbedtls_ssl_context *ssl,
  *                   that #MBEDTLS_SSL_PROTO_TLS1_3 enabled, and the
  *                   accepted versions have not been restricted with
  *                   mbedtls_ssl_conf_max_tls_version() or the like).
+ *                   This limitation does not apply to DTLS.
  *                 - The first fragment of a handshake message must be
  *                   at least 4 bytes long.
  *                 - Non-handshake records must not be interleaved between

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -4993,8 +4993,6 @@ int mbedtls_ssl_get_session(const mbedtls_ssl_context *ssl,
  *                   that #MBEDTLS_SSL_PROTO_TLS1_3 enabled, and the
  *                   accepted versions have not been restricted with
  *                   mbedtls_ssl_conf_max_tls_version() or the like).
- *                 - A ClientHello message that initiates a renegotiation
- *                   must not be fragmented.
  *                 - The first fragment of a handshake message must be
  *                   at least 4 bytes long.
  *                 - Non-handshake records must not be interleaved between

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -4984,8 +4984,10 @@ int mbedtls_ssl_get_session(const mbedtls_ssl_context *ssl,
  *                 be the case even if TLS 1.3 is offered but eventually
  *                 not selected).
  *
- * \note           Defragmentation of incoming handshake messages in TLS
- *                 is supported with some limitations:
+ * \note           In TLS, reception of fragmented handshake messages is
+ *                 supported with some limitations (those limitations do
+ *                 not apply to DTLS, where defragmentation is fully
+ *                 supported):
  *                 - On an Mbed TLS server that only accepts TLS 1.2,
  *                   the initial ClientHello message must not be fragmented.
  *                   A TLS 1.2 ClientHello may be fragmented if the server
@@ -4993,7 +4995,6 @@ int mbedtls_ssl_get_session(const mbedtls_ssl_context *ssl,
  *                   that #MBEDTLS_SSL_PROTO_TLS1_3 enabled, and the
  *                   accepted versions have not been restricted with
  *                   mbedtls_ssl_conf_max_tls_version() or the like).
- *                   This limitation does not apply to DTLS.
  *                 - The first fragment of a handshake message must be
  *                   at least 4 bytes long.
  *                 - Non-handshake records must not be interleaved between

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -4449,6 +4449,24 @@ void mbedtls_ssl_conf_cert_req_ca_list(mbedtls_ssl_config *conf,
  *                 with \c mbedtls_ssl_read()), not handshake messages.
  *                 With DTLS, this affects both ApplicationData and handshake.
  *
+ * \note           Defragmentation of incoming handshake messages in TLS
+ *                 (excluding DTLS) is supported with some limitations:
+ *                 - On an Mbed TLS server that only accepts TLS 1.2,
+ *                   the initial ClientHello message must not be fragmented.
+ *                   A TLS 1.2 ClientHello may be fragmented if the server
+ *                   also accepts TLS 1.3 connections (meaning
+ *                   that #MBEDTLS_SSL_PROTO_TLS1_3 enabled, and the
+ *                   accepted versions have not been restricted with
+ *                   mbedtls_ssl_conf_max_tls_version() or the like).
+ *                 - A ClientHello message that initiates a renegotiation
+ *                   must not be fragmented.
+ *                 - The first fragment of a handshake message must be
+ *                   at least 4 bytes long.
+ *                 - Non-handshake records must not be interleaved between
+ *                   the fragments of a handshake message. (This is permitted
+ *                   in TLS 1.2 but not in TLS 1.3, but Mbed TLS rejects it
+ *                   even in TLS 1.2.)
+ *
  * \note           This sets the maximum length for a record's payload,
  *                 excluding record overhead that will be added to it, see
  *                 \c mbedtls_ssl_get_record_expansion().


### PR DESCRIPTION
Direct backport of https://github.com/Mbed-TLS/mbedtls/pull/10040 (with some trivial conflicts due to changes to the previous `\note`).

## PR checklist

- [x] **changelog** provided
- [x] **development PR** https://github.com/Mbed-TLS/mbedtls/pull/10040
- [x] **TF-PSA-Crypto PR** not required because: TLS only
- [x] **framework PR** not required
- [x] **3.6 PR** here
- [x] **2.28 PR** not required because: ≥3.6 only
- **tests**  provided
