### PR TITLE
Backport 2.28: mbedtls_net_send API description typo fix

### DIFF
--- a/include/mbedtls/net_sockets.h
+++ b/include/mbedtls/net_sockets.h
@@ -226,7 +226,7 @@ int mbedtls_net_recv(void *ctx, unsigned char *buf, size_t len);
 
 /**
  * \brief          Write at most 'len' characters. If no error occurs,
- *                 the actual amount read is returned.
+ *                 the actual amount written is returned.
  *
  * \param ctx      Socket
  * \param buf      The buffer to read from


### PR DESCRIPTION
Trivial backport of https://github.com/Mbed-TLS/mbedtls/pull/9096

## PR checklist

- [x] **changelog** not required
- [x] **crypto** not required: TLS only
- [x] **development** https://github.com/Mbed-TLS/mbedtls/pull/9096
- [x] **3.6 backport** https://github.com/Mbed-TLS/mbedtls/pull/10058
- [x] **2.28 backport** here
- [x] **tests** not required
