### PR TITLE
Update the 3.0 migration guide and fix broken README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ However, it does not aim to implement the whole specification; in particular it 
 
 Mbed TLS supports drivers for cryptographic accelerators, secure elements and random generators. This is work in progress. Please note that the driver interfaces are not fully stable yet and may change without notice. We intend to preserve backward compatibility for application code (using the PSA Crypto API), but the code of the drivers may have to change in future minor releases of Mbed TLS.
 
-Please see the [PSA driver example and guide](docs/psa-driver-example-and-guide.md) for information on writing a driver.
+Please see the [PSA driver example and guide](https://github.com/Mbed-TLS/TF-PSA-Crypto/blob/development/docs/psa-driver-example-and-guide.md) for information on writing a driver.
 
 License
 -------

--- a/docs/3.0-migration-guide.md
+++ b/docs/3.0-migration-guide.md
@@ -71,7 +71,7 @@ If you were accessing structure fields directly, and these fields are not docume
 
 If no accessor function exists, please open an [enhancement request against Mbed TLS](https://github.com/Mbed-TLS/mbedtls/issues/new?template=feature_request.md) and describe your use case. The Mbed TLS development team is aware that some useful accessor functions are missing in the 3.0 release, and we expect to add them to the first minor release(s) (3.1, etc.).
 
-As a last resort, you can access the field `foo` of a structure `bar` by writing `bar.MBEDTLS_PRIVATE(foo)`. Note that you do so at your own risk, since such code is likely to break in a future minor version of Mbed TLS. However, in the Mbed TLS 3.6 LTS this is generally a safe way to access struct members because LTS versions try to maintain ABI stability.
+As a last resort, you can access the field `foo` of a structure `bar` by writing `bar.MBEDTLS_PRIVATE(foo)`. Note that you do so at your own risk, since such code is likely to break in a future minor version of Mbed TLS. In the Mbed TLS 3.6 LTS this will tend to be safer than in a normal minor release because LTS versions try to maintain ABI stability.
 
 ### Move part of timing module out of the library
 

--- a/docs/3.0-migration-guide.md
+++ b/docs/3.0-migration-guide.md
@@ -349,7 +349,7 @@ original names of those functions. The renamed functions are:
 | `mbedtls_sha512_finish_ret`    | `mbedtls_sha512_finish`    |
 | `mbedtls_sha512_ret`           | `mbedtls_sha512`           |
 
-To migrate to the this change the user can keep the `*_ret` names in their code
+To migrate to this change the user can keep the `*_ret` names in their code
 and include the `compat_2.x.h` header file which holds macros with proper
 renaming or to rename those functions in their code according to the list from
 mentioned header file.
@@ -409,7 +409,7 @@ using the multi-part API.
 Previously, the documentation didn't state explicitly if it was OK to call
 `mbedtls_cipher_check_tag()` or `mbedtls_cipher_write_tag()` directly after
 the last call to `mbedtls_cipher_update()` — that is, without calling
-`mbedtls_cipher_finish()` in-between. If you code was missing that call,
+`mbedtls_cipher_finish()` in-between. If your code was missing that call,
 please add it and be prepared to get as much as 15 bytes of output.
 
 Currently the output is always 0 bytes, but it may be more when alternative
@@ -422,7 +422,7 @@ This change affects users of the MD2, MD4, RC4, Blowfish and XTEA algorithms.
 
 They are already niche or obsolete and most of them are weak or broken. For
 those reasons possible users should consider switching to modern and safe
-alternatives to be found in literature.
+alternatives to be found in the literature.
 
 ### Deprecated functions were removed from cipher
 
@@ -806,11 +806,11 @@ multiple times on the same SSL configuration.
 In Mbed TLS 2.x, users would observe later calls overwriting
 the effect of earlier calls, with the prevailing PSK being
 the one that has been configured last. In Mbed TLS 3.0,
-calling `mbedtls_ssl_conf_[opaque_]psk()` multiple times
+calling `mbedtls_ssl_conf_psk[_opaque]()` multiple times
 will return an error, leaving the first PSK intact.
 
 To achieve equivalent functionality when migrating to Mbed TLS 3.0,
-users calling `mbedtls_ssl_conf_[opaque_]psk()` multiple times should
+users calling `mbedtls_ssl_conf_psk[_opaque]()` multiple times should
 remove all but the last call, so that only one call to _either_
 `mbedtls_ssl_conf_psk()` _or_ `mbedtls_ssl_conf_psk_opaque()`
 remains.

--- a/docs/3.0-migration-guide.md
+++ b/docs/3.0-migration-guide.md
@@ -71,7 +71,7 @@ If you were accessing structure fields directly, and these fields are not docume
 
 If no accessor function exists, please open an [enhancement request against Mbed TLS](https://github.com/Mbed-TLS/mbedtls/issues/new?template=feature_request.md) and describe your use case. The Mbed TLS development team is aware that some useful accessor functions are missing in the 3.0 release, and we expect to add them to the first minor release(s) (3.1, etc.).
 
-As a last resort, you can access the field `foo` of a structure `bar` by writing `bar.MBEDTLS_PRIVATE(foo)`. Note that you do so at your own risk, since such code is likely to break in a future minor version of Mbed TLS.
+As a last resort, you can access the field `foo` of a structure `bar` by writing `bar.MBEDTLS_PRIVATE(foo)`. Note that you do so at your own risk, since such code is likely to break in a future minor version of Mbed TLS. However, in the Mbed TLS 3.6 LTS this is generally a safe way to access struct members because LTS versions try to maintain ABI stability.
 
 ### Move part of timing module out of the library
 


### PR DESCRIPTION
Do the following things:
* Fix some typos in the 3.0 migration guide
* Add a note in the migration guide about `MBEDTLS_PRIVATE()` (specifically that it may be used more safely in the 3.6 LTS)
* Fix a broken link to PSA crypto driver examples in `README.md`

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** not required because: Docs only
- [x] **development PR** here
- [x] **TF-PSA-Crypto PR** not required because: Only mbedtls docs
- [x] **framework PR** not required
- [x] **3.6 PR** provided #10064 
- [x] **2.28 PR** not required because: No migration guide in 2.28
- **tests** not required because: Docs changes only
