### PR TITLE
[Backport 3.6]  Extend ssl-opt testing for TLS HS defragmentation 

### DIFF
--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -76,6 +76,7 @@ int main(void)
 #define DFL_RECO_SERVER_NAME    NULL
 #define DFL_RECO_DELAY          0
 #define DFL_RECO_MODE           1
+#define DFL_RENEGO_DELAY        -2
 #define DFL_CID_ENABLED         0
 #define DFL_CID_VALUE           ""
 #define DFL_CID_ENABLED_RENEGO  -1
@@ -308,7 +309,8 @@ int main(void)
 #if defined(MBEDTLS_SSL_RENEGOTIATION)
 #define USAGE_RENEGO \
     "    renegotiation=%%d    default: 0 (disabled)\n"      \
-    "    renegotiate=%%d      default: 0 (disabled)\n"
+    "    renegotiate=%%d      default: 0 (disabled)\n"      \
+    "    renego_delay=%%d     default: -2 (library default)\n"
 #else
 #define USAGE_RENEGO ""
 #endif
@@ -957,6 +959,7 @@ int main(int argc, char *argv[])
     opt.renegotiation       = DFL_RENEGOTIATION;
     opt.allow_legacy        = DFL_ALLOW_LEGACY;
     opt.renegotiate         = DFL_RENEGOTIATE;
+    opt.renego_delay        = DFL_RENEGO_DELAY;
     opt.exchanges           = DFL_EXCHANGES;
     opt.min_version         = DFL_MIN_VERSION;
     opt.max_version         = DFL_MAX_VERSION;
@@ -1193,6 +1196,8 @@ usage:
                     break;
                 default: goto usage;
             }
+        } else if (strcmp(p, "renego_delay") == 0) {
+            opt.renego_delay = (atoi(q));
         } else if (strcmp(p, "renegotiate") == 0) {
             opt.renegotiate = atoi(q);
             if (opt.renegotiate < 0 || opt.renegotiate > 1) {
@@ -1966,6 +1971,9 @@ usage:
     }
 #if defined(MBEDTLS_SSL_RENEGOTIATION)
     mbedtls_ssl_conf_renegotiation(&conf, opt.renegotiation);
+    if (opt.renego_delay != DFL_RENEGO_DELAY) {
+        mbedtls_ssl_conf_renegotiation_enforced(&conf, opt.renego_delay);
+    }
 #endif
 
 #if defined(MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED)
@@ -2510,6 +2518,8 @@ usage:
         }
         mbedtls_printf(" ok\n");
     }
+
+
 #endif /* MBEDTLS_SSL_RENEGOTIATION */
 
 #if defined(MBEDTLS_SSL_DTLS_CONNECTION_ID)

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14473,7 +14473,7 @@ run_test    "Handshake defragmentation on server: len=32, TLS 1.2 ClientHello (u
             -s "bad client hello message" \
             -s "SSL - A message could not be parsed due to a syntactic error"
 
-# Test Server Buffer resizing with fragmented handshake on TLS1.2
+# Test server-side buffer resizing with fragmented handshake on TLS1.2
 requires_openssl_3_x
 requires_protocol_version tls12
 requires_certificate_authentication
@@ -14491,7 +14491,7 @@ run_test    "Handshake defragmentation on server with buffer resizing: len=256, 
             -s "Prepare: waiting for more handshake fragments 256/[0-9]\\+" \
             -s "Consume: waiting for more handshake fragments 256/[0-9]\\+"
 
-# Test Client initiated renegotiation with fragmented handshake on TLS1.2
+# Test client-initiated renegotiation with fragmented handshake on TLS1.2
 requires_openssl_3_x
 requires_protocol_version tls12
 requires_certificate_authentication
@@ -14528,7 +14528,13 @@ run_test    "Handshake defragmentation with client-initiated renegotiation: len=
             -s "Prepare: waiting for more handshake fragments 512/[0-9]\\+" \
             -s "Consume: waiting for more handshake fragments 512/[0-9]\\+" \
 
-# Test Server initiated renegotiation with fragmented handshake on TLS1.2
+# Test server-initiated renegotiation with fragmented handshake on TLS1.2
+# Note: The /reneg endpoint serves as a directive for OpenSSL's s_server
+# to initiate a handshake renegotiation.
+# Note: Adjusting the renegotiation delay beyond the library's default value
+# of 16 is necessary, as it sets the maximum record depth to match it.
+# Splitting messages during the renegotiation process requires a deeper
+# stack to accommodate the increased processing complexity.
 requires_openssl_3_x
 requires_protocol_version tls12
 requires_certificate_authentication

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14480,7 +14480,7 @@ requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_MAX_FRAGMENT_LENGTH
 requires_config_enabled MBEDTLS_SSL_VARIABLE_BUFFER_LENGTH
 requires_max_content_len 1025
-run_test    "Handshake defragmentation on server with buffer resizing: len=256, MFL=1024" \
+run_test    "Handshake defragmentation on server: len=256, buffer resizing with MFL=1024" \
             "$P_SRV debug_level=4 auth_mode=required" \
             "$O_NEXT_CLI -tls1_2 -split_send_frag 256 -maxfraglen 1024 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             0 \
@@ -14496,7 +14496,7 @@ requires_openssl_3_x
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_RENEGOTIATION
-run_test    "Handshake defragmentation with client-initiated renegotiation: len=512" \
+run_test    "Handshake defragmentation on server: len=512, client-initiated renegotation" \
             "$P_SRV debug_level=4 exchanges=2 renegotiation=1 auth_mode=required" \
             "$O_NEXT_CLI_RENEGOTIATE -tls1_2 -split_send_frag 512 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key -connect 127.0.0.1:+$SRV_PORT" \
             0 \
@@ -14514,7 +14514,7 @@ requires_openssl_3_x
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_RENEGOTIATION
-run_test    "Handshake defragmentation with client-initiated renegotiation: len=256" \
+run_test    "Handshake defragmentation on server: len=256, client-initiated renegotation" \
             "$P_SRV debug_level=4 exchanges=2 renegotiation=1 auth_mode=required" \
             "$O_NEXT_CLI_RENEGOTIATE -tls1_2 -split_send_frag 256 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key -connect 127.0.0.1:+$SRV_PORT" \
             0 \
@@ -14533,7 +14533,7 @@ requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_RENEGOTIATION
-run_test    "Handshake defragmentation with client-initiated renegotiation: len=128" \
+run_test    "Handshake defragmentation on server: len=128, client-initiated renegotation" \
             "$P_SRV debug_level=4 exchanges=2 renegotiation=1 auth_mode=required" \
             "$O_NEXT_CLI_RENEGOTIATE -tls1_2 -split_send_frag 128 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key -connect 127.0.0.1:+$SRV_PORT" \
             0 \
@@ -14551,7 +14551,7 @@ requires_openssl_3_x
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_config_enabled MBEDTLS_SSL_RENEGOTIATION
-run_test    "Handshake defragmentation with client-initiated renegotiation: len=4" \
+run_test    "Handshake defragmentation on server: len=4, client-initiated renegotation" \
             "$P_SRV debug_level=4 exchanges=2 renegotiation=1 auth_mode=required" \
             "$O_NEXT_CLI_RENEGOTIATE -tls1_2 -split_send_frag 4 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key -connect 127.0.0.1:+$SRV_PORT" \
             0 \
@@ -14570,7 +14570,7 @@ requires_openssl_3_x
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_RENEGOTIATION
-run_test    "Handshake defragmentation with server-initiated renegotiation: len=512" \
+run_test    "Handshake defragmentation on client: len=512, server-initiated renegotation" \
             "$O_NEXT_SRV -tls1_2 -split_send_frag 512 -legacy_renegotiation -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             "$P_CLI debug_level=3 renegotiation=1 request_page=/reneg" \
             0 \
@@ -14592,7 +14592,7 @@ requires_openssl_3_x
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_RENEGOTIATION
-run_test    "Handshake defragmentation with server-initiated renegotiation: len=256" \
+run_test    "Handshake defragmentation on client: len=256, server-initiated renegotation" \
             "$O_NEXT_SRV -tls1_2 -split_send_frag 256 -legacy_renegotiation -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             "$P_CLI debug_level=3 renegotiation=1 renego_delay=32 request_page=/reneg" \
             0 \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14556,6 +14556,20 @@ run_test    "Handshake defragmentation on server: len=4, client-initiated renego
             -s "Prepare: waiting for more handshake fragments 4/" \
             -s "Consume: waiting for more handshake fragments 4/" \
 
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
+requires_config_enabled MBEDTLS_SSL_RENEGOTIATION
+run_test    "Handshake defragmentation on server: len=4, client-initiated server-rejected renegotation" \
+            "$P_SRV debug_level=4 exchanges=2 renegotiation=0 auth_mode=required" \
+            "$O_NEXT_CLI_RENEGOTIATE -tls1_2 -split_send_frag 4 -connect 127.0.0.1:+$SRV_PORT" \
+            1 \
+            -s "received TLS_EMPTY_RENEGOTIATION_INFO" \
+            -s "refusing renegotiation, sending alert" \
+            -s "server hello, secure renegotiation extension" \
+            -s "initial handshake fragment: 4, 0\\.\\.4 of [0-9]\\+" \
+            -s "Prepare: waiting for more handshake fragments 4/" \
+            -s "Consume: waiting for more handshake fragments 4/" \
+
 # Test server-initiated renegotiation with fragmented handshake on TLS1.2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_RENEGOTIATION

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14475,7 +14475,7 @@ run_test    "Handshake defragmentation on server: len=32, TLS 1.2 ClientHello (u
 
 # Test server-side buffer resizing with fragmented handshake on TLS1.2
 requires_openssl_3_x
-requires_protocol_version tls12
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_MAX_FRAGMENT_LENGTH
 requires_config_enabled MBEDTLS_SSL_VARIABLE_BUFFER_LENGTH
@@ -14493,25 +14493,7 @@ run_test    "Handshake defragmentation on server with buffer resizing: len=256, 
 
 # Test client-initiated renegotiation with fragmented handshake on TLS1.2
 requires_openssl_3_x
-requires_protocol_version tls12
-requires_certificate_authentication
-requires_config_enabled MBEDTLS_SSL_RENEGOTIATION
-run_test    "Handshake defragmentation with client-initiated renegotiation: len=256" \
-            "$P_SRV debug_level=4 exchanges=2 renegotiation=1 auth_mode=required" \
-            "$O_NEXT_CLI_RENEGOTIATE -tls1_2 -split_send_frag 256 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key -connect 127.0.0.1:+$SRV_PORT" \
-            0 \
-            -s "received TLS_EMPTY_RENEGOTIATION_INFO" \
-            -s "found renegotiation extension" \
-            -s "server hello, secure renegotiation extension" \
-            -s "=> renegotiate" \
-            -S "write hello request" \
-            -s "reassembled record" \
-            -s "initial handshake fragment: 256, 0..256 of [0-9]\\+" \
-            -s "Prepare: waiting for more handshake fragments 256/[0-9]\\+" \
-            -s "Consume: waiting for more handshake fragments 256/[0-9]\\+" \
-
-requires_openssl_3_x
-requires_protocol_version tls12
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_RENEGOTIATION
 run_test    "Handshake defragmentation with client-initiated renegotiation: len=512" \
@@ -14528,30 +14510,27 @@ run_test    "Handshake defragmentation with client-initiated renegotiation: len=
             -s "Prepare: waiting for more handshake fragments 512/[0-9]\\+" \
             -s "Consume: waiting for more handshake fragments 512/[0-9]\\+" \
 
-# Test server-initiated renegotiation with fragmented handshake on TLS1.2
-# Note: The /reneg endpoint serves as a directive for OpenSSL's s_server
-# to initiate a handshake renegotiation.
-# Note: Adjusting the renegotiation delay beyond the library's default value
-# of 16 is necessary, as it sets the maximum record depth to match it.
-# Splitting messages during the renegotiation process requires a deeper
-# stack to accommodate the increased processing complexity.
 requires_openssl_3_x
-requires_protocol_version tls12
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_RENEGOTIATION
-run_test    "Handshake defragmentation with server-initiated renegotiation: len=256" \
-            "$O_NEXT_SRV -tls1_2 -split_send_frag 256 -legacy_renegotiation -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
-            "$P_CLI debug_level=3 renegotiation=1 renego_delay=32 request_page=/reneg" \
+run_test    "Handshake defragmentation with client-initiated renegotiation: len=256" \
+            "$P_SRV debug_level=4 exchanges=2 renegotiation=1 auth_mode=required" \
+            "$O_NEXT_CLI_RENEGOTIATE -tls1_2 -split_send_frag 256 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key -connect 127.0.0.1:+$SRV_PORT" \
             0 \
-            -c "initial handshake fragment: 256, 0..256 of [0-9]\\+" \
-            -c "Prepare: waiting for more handshake fragments 256/[0-9]\\+" \
-            -c "Consume: waiting for more handshake fragments 256/[0-9]\\+" \
-            -c "client hello, adding renegotiation extension" \
-            -c "found renegotiation extension" \
-            -c "=> renegotiate"
+            -s "received TLS_EMPTY_RENEGOTIATION_INFO" \
+            -s "found renegotiation extension" \
+            -s "server hello, secure renegotiation extension" \
+            -s "=> renegotiate" \
+            -S "write hello request" \
+            -s "reassembled record" \
+            -s "initial handshake fragment: 256, 0..256 of [0-9]\\+" \
+            -s "Prepare: waiting for more handshake fragments 256/[0-9]\\+" \
+            -s "Consume: waiting for more handshake fragments 256/[0-9]\\+" \
 
+# Test server-initiated renegotiation with fragmented handshake on TLS1.2
 requires_openssl_3_x
-requires_protocol_version tls12
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_RENEGOTIATION
 run_test    "Handshake defragmentation with server-initiated renegotiation: len=512" \
@@ -14561,6 +14540,28 @@ run_test    "Handshake defragmentation with server-initiated renegotiation: len=
             -c "initial handshake fragment: 512, 0..512 of [0-9]\\+" \
             -c "Prepare: waiting for more handshake fragments 512/[0-9]\\+" \
             -c "Consume: waiting for more handshake fragments 512/[0-9]\\+" \
+            -c "client hello, adding renegotiation extension" \
+            -c "found renegotiation extension" \
+            -c "=> renegotiate"
+
+
+# Note: The /reneg endpoint serves as a directive for OpenSSL's s_server
+# to initiate a handshake renegotiation.
+# Note: Adjusting the renegotiation delay beyond the library's default value
+# of 16 is necessary, as it sets the maximum record depth to match it.
+# Splitting messages during the renegotiation process requires a deeper
+# stack to accommodate the increased processing complexity.
+requires_openssl_3_x
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_RENEGOTIATION
+run_test    "Handshake defragmentation with server-initiated renegotiation: len=256" \
+            "$O_NEXT_SRV -tls1_2 -split_send_frag 256 -legacy_renegotiation -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$P_CLI debug_level=3 renegotiation=1 renego_delay=32 request_page=/reneg" \
+            0 \
+            -c "initial handshake fragment: 256, 0..256 of [0-9]\\+" \
+            -c "Prepare: waiting for more handshake fragments 256/[0-9]\\+" \
+            -c "Consume: waiting for more handshake fragments 256/[0-9]\\+" \
             -c "client hello, adding renegotiation extension" \
             -c "found renegotiation extension" \
             -c "=> renegotiate"

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14587,10 +14587,11 @@ run_test    "Handshake defragmentation on client: len=512, server-initiated rene
 
 # Note: The /reneg endpoint serves as a directive for OpenSSL's s_server
 # to initiate a handshake renegotiation.
-# Note: Adjusting the renegotiation delay beyond the library's default value
-# of 16 is necessary, as it sets the maximum record depth to match it.
-# Splitting messages during the renegotiation process requires a deeper
-# stack to accommodate the increased processing complexity.
+# Note: Adjusting the renegotiation delay beyond the library's default
+# value of 16 is necessary. This parameter defines the maximum
+# number of records received before renegotiation is completed.
+# By fragmenting records and thereby increasing their quantity,
+# the default threshold can be reached more quickly.
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_RENEGOTIATION
 run_test    "Handshake defragmentation on client: len=256, server-initiated renegotation" \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14528,6 +14528,43 @@ run_test    "Handshake defragmentation with client-initiated renegotiation: len=
             -s "Prepare: waiting for more handshake fragments 256/[0-9]\\+" \
             -s "Consume: waiting for more handshake fragments 256/[0-9]\\+" \
 
+requires_openssl_3_x
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
+requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_RENEGOTIATION
+run_test    "Handshake defragmentation with client-initiated renegotiation: len=128" \
+            "$P_SRV debug_level=4 exchanges=2 renegotiation=1 auth_mode=required" \
+            "$O_NEXT_CLI_RENEGOTIATE -tls1_2 -split_send_frag 128 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key -connect 127.0.0.1:+$SRV_PORT" \
+            0 \
+            -s "received TLS_EMPTY_RENEGOTIATION_INFO" \
+            -s "found renegotiation extension" \
+            -s "server hello, secure renegotiation extension" \
+            -s "=> renegotiate" \
+            -S "write hello request" \
+            -s "reassembled record" \
+            -s "initial handshake fragment: 128, 0..128 of [0-9]\\+" \
+            -s "Prepare: waiting for more handshake fragments 128/[0-9]\\+" \
+            -s "Consume: waiting for more handshake fragments 128/[0-9]\\+" \
+
+requires_openssl_3_x
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
+requires_config_enabled MBEDTLS_SSL_RENEGOTIATION
+run_test    "Handshake defragmentation with client-initiated renegotiation: len=4" \
+            "$P_SRV debug_level=4 exchanges=2 renegotiation=1 auth_mode=required" \
+            "$O_NEXT_CLI_RENEGOTIATE -tls1_2 -split_send_frag 4 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key -connect 127.0.0.1:+$SRV_PORT" \
+            0 \
+            -s "received TLS_EMPTY_RENEGOTIATION_INFO" \
+            -s "found renegotiation extension" \
+            -s "server hello, secure renegotiation extension" \
+            -s "=> renegotiate" \
+            -S "write hello request" \
+            -s "reassembled record" \
+            -s "initial handshake fragment: 4, 0..4 of [0-9]\\+" \
+            -s "Prepare: waiting for more handshake fragments 4/[0-9]\\+" \
+            -s "Consume: waiting for more handshake fragments 4/[0-9]\\+" \
+
 # Test server-initiated renegotiation with fragmented handshake on TLS1.2
 requires_openssl_3_x
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14492,7 +14492,7 @@ run_test    "Handshake defragmentation on server: len=256, buffer resizing with 
 # Test client-initiated renegotiation with fragmented handshake on TLS1.2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_RENEGOTIATION
-run_test    "Handshake defragmentation on server: len=512, client-initiated renegotation" \
+run_test    "Handshake defragmentation on server: len=512, client-initiated renegotiation" \
             "$P_SRV debug_level=4 exchanges=2 renegotiation=1 auth_mode=required" \
             "$O_NEXT_CLI_RENEGOTIATE -tls1_2 -split_send_frag 512 -connect 127.0.0.1:+$SRV_PORT" \
             0 \
@@ -14508,7 +14508,7 @@ run_test    "Handshake defragmentation on server: len=512, client-initiated rene
 
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_RENEGOTIATION
-run_test    "Handshake defragmentation on server: len=256, client-initiated renegotation" \
+run_test    "Handshake defragmentation on server: len=256, client-initiated renegotiation" \
             "$P_SRV debug_level=4 exchanges=2 renegotiation=1 auth_mode=required" \
             "$O_NEXT_CLI_RENEGOTIATE -tls1_2 -split_send_frag 256 -connect 127.0.0.1:+$SRV_PORT" \
             0 \
@@ -14525,7 +14525,7 @@ run_test    "Handshake defragmentation on server: len=256, client-initiated rene
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_config_enabled MBEDTLS_SSL_RENEGOTIATION
-run_test    "Handshake defragmentation on server: len=128, client-initiated renegotation" \
+run_test    "Handshake defragmentation on server: len=128, client-initiated renegotiation" \
             "$P_SRV debug_level=4 exchanges=2 renegotiation=1 auth_mode=required" \
             "$O_NEXT_CLI_RENEGOTIATE -tls1_2 -split_send_frag 128 -connect 127.0.0.1:+$SRV_PORT" \
             0 \
@@ -14542,7 +14542,7 @@ run_test    "Handshake defragmentation on server: len=128, client-initiated rene
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_config_enabled MBEDTLS_SSL_RENEGOTIATION
-run_test    "Handshake defragmentation on server: len=4, client-initiated renegotation" \
+run_test    "Handshake defragmentation on server: len=4, client-initiated renegotiation" \
             "$P_SRV debug_level=4 exchanges=2 renegotiation=1 auth_mode=required" \
             "$O_NEXT_CLI_RENEGOTIATE -tls1_2 -split_send_frag 4 -connect 127.0.0.1:+$SRV_PORT" \
             0 \
@@ -14559,7 +14559,7 @@ run_test    "Handshake defragmentation on server: len=4, client-initiated renego
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_config_enabled MBEDTLS_SSL_RENEGOTIATION
-run_test    "Handshake defragmentation on server: len=4, client-initiated server-rejected renegotation" \
+run_test    "Handshake defragmentation on server: len=4, client-initiated server-rejected renegotiation" \
             "$P_SRV debug_level=4 exchanges=2 renegotiation=0 auth_mode=required" \
             "$O_NEXT_CLI_RENEGOTIATE -tls1_2 -split_send_frag 4 -connect 127.0.0.1:+$SRV_PORT" \
             1 \
@@ -14573,7 +14573,7 @@ run_test    "Handshake defragmentation on server: len=4, client-initiated server
 # Test server-initiated renegotiation with fragmented handshake on TLS1.2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_RENEGOTIATION
-run_test    "Handshake defragmentation on client: len=512, server-initiated renegotation" \
+run_test    "Handshake defragmentation on client: len=512, server-initiated renegotiation" \
             "$O_NEXT_SRV -tls1_2 -split_send_frag 512 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             "$P_CLI debug_level=3 renegotiation=1 request_page=/reneg" \
             0 \
@@ -14595,7 +14595,7 @@ run_test    "Handshake defragmentation on client: len=512, server-initiated rene
 # Setting it to -1 disables that policy's enforment.
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_RENEGOTIATION
-run_test    "Handshake defragmentation on client: len=256, server-initiated renegotation" \
+run_test    "Handshake defragmentation on client: len=256, server-initiated renegotiation" \
             "$O_NEXT_SRV -tls1_2 -split_send_frag 256 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             "$P_CLI debug_level=3 renegotiation=1 renego_delay=-1 request_page=/reneg" \
             0 \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -103,7 +103,7 @@ if [ -n "${OPENSSL_NEXT:-}" ]; then
     O_NEXT_SRV_NO_CERT="$OPENSSL_NEXT s_server -www "
     O_NEXT_CLI="echo 'GET / HTTP/1.0' | $OPENSSL_NEXT s_client -CAfile $DATA_FILES_PATH/test-ca_cat12.crt"
     O_NEXT_CLI_NO_CERT="echo 'GET / HTTP/1.0' | $OPENSSL_NEXT s_client"
-    O_NEXT_CLI_RENEGOTIATE="echo 'R' | $OPENSSL_NEXT s_client"
+    O_NEXT_CLI_RENEGOTIATE="echo 'R' | $OPENSSL_NEXT s_client -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key"
 else
     O_NEXT_SRV=false
     O_NEXT_SRV_NO_CERT=false
@@ -14494,7 +14494,7 @@ requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_RENEGOTIATION
 run_test    "Handshake defragmentation on server: len=512, client-initiated renegotation" \
             "$P_SRV debug_level=4 exchanges=2 renegotiation=1 auth_mode=required" \
-            "$O_NEXT_CLI_RENEGOTIATE -tls1_2 -split_send_frag 512 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key -connect 127.0.0.1:+$SRV_PORT" \
+            "$O_NEXT_CLI_RENEGOTIATE -tls1_2 -split_send_frag 512 -connect 127.0.0.1:+$SRV_PORT" \
             0 \
             -s "received TLS_EMPTY_RENEGOTIATION_INFO" \
             -s "found renegotiation extension" \
@@ -14510,7 +14510,7 @@ requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_RENEGOTIATION
 run_test    "Handshake defragmentation on server: len=256, client-initiated renegotation" \
             "$P_SRV debug_level=4 exchanges=2 renegotiation=1 auth_mode=required" \
-            "$O_NEXT_CLI_RENEGOTIATE -tls1_2 -split_send_frag 256 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key -connect 127.0.0.1:+$SRV_PORT" \
+            "$O_NEXT_CLI_RENEGOTIATE -tls1_2 -split_send_frag 256 -connect 127.0.0.1:+$SRV_PORT" \
             0 \
             -s "received TLS_EMPTY_RENEGOTIATION_INFO" \
             -s "found renegotiation extension" \
@@ -14527,7 +14527,7 @@ requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_config_enabled MBEDTLS_SSL_RENEGOTIATION
 run_test    "Handshake defragmentation on server: len=128, client-initiated renegotation" \
             "$P_SRV debug_level=4 exchanges=2 renegotiation=1 auth_mode=required" \
-            "$O_NEXT_CLI_RENEGOTIATE -tls1_2 -split_send_frag 128 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key -connect 127.0.0.1:+$SRV_PORT" \
+            "$O_NEXT_CLI_RENEGOTIATE -tls1_2 -split_send_frag 128 -connect 127.0.0.1:+$SRV_PORT" \
             0 \
             -s "received TLS_EMPTY_RENEGOTIATION_INFO" \
             -s "found renegotiation extension" \
@@ -14544,7 +14544,7 @@ requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_config_enabled MBEDTLS_SSL_RENEGOTIATION
 run_test    "Handshake defragmentation on server: len=4, client-initiated renegotation" \
             "$P_SRV debug_level=4 exchanges=2 renegotiation=1 auth_mode=required" \
-            "$O_NEXT_CLI_RENEGOTIATE -tls1_2 -split_send_frag 4 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key -connect 127.0.0.1:+$SRV_PORT" \
+            "$O_NEXT_CLI_RENEGOTIATE -tls1_2 -split_send_frag 4 -connect 127.0.0.1:+$SRV_PORT" \
             0 \
             -s "received TLS_EMPTY_RENEGOTIATION_INFO" \
             -s "found renegotiation extension" \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14474,7 +14474,6 @@ run_test    "Handshake defragmentation on server: len=32, TLS 1.2 ClientHello (u
             -s "SSL - A message could not be parsed due to a syntactic error"
 
 # Test server-side buffer resizing with fragmented handshake on TLS1.2
-requires_openssl_3_x
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_MAX_FRAGMENT_LENGTH
@@ -14492,7 +14491,6 @@ run_test    "Handshake defragmentation on server: len=256, buffer resizing with 
             -s "Consume: waiting for more handshake fragments 256/"
 
 # Test client-initiated renegotiation with fragmented handshake on TLS1.2
-requires_openssl_3_x
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_RENEGOTIATION
@@ -14510,7 +14508,6 @@ run_test    "Handshake defragmentation on server: len=512, client-initiated rene
             -s "Prepare: waiting for more handshake fragments 512/" \
             -s "Consume: waiting for more handshake fragments 512/" \
 
-requires_openssl_3_x
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_RENEGOTIATION
@@ -14528,7 +14525,6 @@ run_test    "Handshake defragmentation on server: len=256, client-initiated rene
             -s "Prepare: waiting for more handshake fragments 256/" \
             -s "Consume: waiting for more handshake fragments 256/" \
 
-requires_openssl_3_x
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_certificate_authentication
@@ -14547,7 +14543,6 @@ run_test    "Handshake defragmentation on server: len=128, client-initiated rene
             -s "Prepare: waiting for more handshake fragments 128/" \
             -s "Consume: waiting for more handshake fragments 128/" \
 
-requires_openssl_3_x
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_config_enabled MBEDTLS_SSL_RENEGOTIATION
@@ -14566,7 +14561,6 @@ run_test    "Handshake defragmentation on server: len=4, client-initiated renego
             -s "Consume: waiting for more handshake fragments 4/" \
 
 # Test server-initiated renegotiation with fragmented handshake on TLS1.2
-requires_openssl_3_x
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_RENEGOTIATION
@@ -14588,7 +14582,6 @@ run_test    "Handshake defragmentation on client: len=512, server-initiated rene
 # of 16 is necessary, as it sets the maximum record depth to match it.
 # Splitting messages during the renegotiation process requires a deeper
 # stack to accommodate the increased processing complexity.
-requires_openssl_3_x
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_RENEGOTIATION

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14463,13 +14463,31 @@ run_test    "TLS 1.2 ClientHello indicating support for deflate compression meth
 
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_certificate_authentication
-run_test    "Handshake defragmentation on server: len=32, TLS 1.2 ClientHello" \
+run_test    "Handshake defragmentation on server: len=32, TLS 1.2 ClientHello (unsupported)" \
             "$P_SRV debug_level=4 force_version=tls12 auth_mode=required" \
             "$O_NEXT_CLI -tls1_2 -split_send_frag 32 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             1 \
             -s "The SSL configuration is tls12 only" \
             -s "bad client hello message" \
             -s "SSL - A message could not be parsed due to a syntactic error"
+
+# Test Server Buffer resizing with fragmented handshake on TLS1.2
+requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_MAX_FRAGMENT_LENGTH
+requires_config_enabled MBEDTLS_SSL_VARIABLE_BUFFER_LENGTH
+requires_max_content_len 1025
+run_test    "Handshake defragmentation on server with buffer resizing: len=256, MFL=1024" \
+            "$P_SRV debug_level=4 auth_mode=required" \
+            "$O_NEXT_CLI -tls1_2 -split_send_frag 256 -maxfraglen 1024 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            0 \
+            -s "Reallocating in_buf" \
+            -s "Reallocating out_buf" \
+            -s "reassembled record" \
+            -s "initial handshake fragment: 256, 0..256 of [0-9]\\+" \
+            -s "Prepare: waiting for more handshake fragments 256/[0-9]\\+" \
+            -s "Consume: waiting for more handshake fragments 256/[0-9]\\+"
 
 # Test heap memory usage after handshake
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14559,6 +14559,22 @@ run_test    "Handshake defragmentation with server-initiated renegotiation: len=
             -c "found renegotiation extension" \
             -c "=> renegotiate"
 
+# Mock negative test to demonstrate the failure with n-bit sized fragments, where ClientHello < n.
+requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_RENEGOTIATION
+run_test    "Handshake defragmentation mock with server-initiated renegotation: len=256 renego_delay=default(16)" \
+            "$O_NEXT_SRV -tls1_2 -split_send_frag 256 -legacy_renegotiation -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$P_CLI debug_level=3 renegotiation=1 request_page=/reneg" \
+            1 \
+            -c "initial handshake fragment: 256, 0..256 of [0-9]\\+" \
+            -c "Prepare: waiting for more handshake fragments 256/[0-9]\\+" \
+            -c "Consume: waiting for more handshake fragments 256/[0-9]\\+" \
+            -c "client hello, adding renegotiation extension" \
+            -c "found renegotiation extension" \
+            -c "renegotiation requested, but not honored by server"
+
 # Test heap memory usage after handshake
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_MEMORY_DEBUG

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14571,6 +14571,15 @@ run_test    "Handshake defragmentation on server: len=4, client-initiated server
             -s "Consume: waiting for more handshake fragments 4/" \
 
 # Test server-initiated renegotiation with fragmented handshake on TLS1.2
+
+# Note: The /reneg endpoint serves as a directive for OpenSSL's s_server
+# to initiate a handshake renegotiation.
+# Note: Adjusting the renegotiation delay beyond the library's default
+# value of 16 is necessary. This parameter defines the maximum
+# number of records received before renegotiation is completed.
+# By fragmenting records and thereby increasing their quantity,
+# the default threshold can be reached more quickly.
+# Setting it to -1 disables that policy's enforment.
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_RENEGOTIATION
 run_test    "Handshake defragmentation on client: len=512, server-initiated renegotiation" \
@@ -14584,15 +14593,6 @@ run_test    "Handshake defragmentation on client: len=512, server-initiated rene
             -c "found renegotiation extension" \
             -c "=> renegotiate"
 
-
-# Note: The /reneg endpoint serves as a directive for OpenSSL's s_server
-# to initiate a handshake renegotiation.
-# Note: Adjusting the renegotiation delay beyond the library's default
-# value of 16 is necessary. This parameter defines the maximum
-# number of records received before renegotiation is completed.
-# By fragmenting records and thereby increasing their quantity,
-# the default threshold can be reached more quickly.
-# Setting it to -1 disables that policy's enforment.
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_RENEGOTIATION
 run_test    "Handshake defragmentation on client: len=256, server-initiated renegotiation" \
@@ -14602,6 +14602,32 @@ run_test    "Handshake defragmentation on client: len=256, server-initiated rene
             -c "initial handshake fragment: 256, 0\\.\\.256 of [0-9]\\+" \
             -c "Prepare: waiting for more handshake fragments 256/" \
             -c "Consume: waiting for more handshake fragments 256/" \
+            -c "client hello, adding renegotiation extension" \
+            -c "found renegotiation extension" \
+            -c "=> renegotiate"
+
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+requires_config_enabled MBEDTLS_SSL_RENEGOTIATION
+run_test    "Handshake defragmentation on client: len=128, server-initiated renegotiation" \
+            "$O_NEXT_SRV -tls1_2 -split_send_frag 128 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$P_CLI debug_level=3 renegotiation=1 renego_delay=-1 request_page=/reneg" \
+            0 \
+            -c "initial handshake fragment: 128, 0\\.\\.128 of [0-9]\\+" \
+            -c "Prepare: waiting for more handshake fragments 128/" \
+            -c "Consume: waiting for more handshake fragments 128/" \
+            -c "client hello, adding renegotiation extension" \
+            -c "found renegotiation extension" \
+            -c "=> renegotiate"
+
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+requires_config_enabled MBEDTLS_SSL_RENEGOTIATION
+run_test    "Handshake defragmentation on client: len=4, server-initiated renegotiation" \
+            "$O_NEXT_SRV -tls1_2 -split_send_frag 4 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$P_CLI debug_level=3 renegotiation=1 renego_delay=-1 request_page=/reneg" \
+            0 \
+            -c "initial handshake fragment: 4, 0\\.\\.4 of [0-9]\\+" \
+            -c "Prepare: waiting for more handshake fragments 4/" \
+            -c "Consume: waiting for more handshake fragments 4/" \
             -c "client hello, adding renegotiation extension" \
             -c "found renegotiation extension" \
             -c "=> renegotiate"

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14575,6 +14575,22 @@ run_test    "Handshake defragmentation mock with server-initiated renegotation: 
             -c "found renegotiation extension" \
             -c "renegotiation requested, but not honored by server"
 
+# Fixing the above mock negative using the new renego_delay parameter
+requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_RENEGOTIATION
+run_test    "Handshake defragmentation mock with server-initiated renegotiation: len=256  renego_delay=32" \
+            "$O_NEXT_SRV -tls1_2 -split_send_frag 256 -legacy_renegotiation -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$P_CLI debug_level=3 allow_legacy=1 renegotiation=1 renego_delay=32 request_page=/reneg" \
+            0 \
+            -c "initial handshake fragment: 200, 0..200 of [0-9]\\+" \
+            -c "Prepare: waiting for more handshake fragments 200/[0-9]\\+" \
+            -c "Consume: waiting for more handshake fragments 200/[0-9]\\+" \
+            -c "client hello, adding renegotiation extension" \
+            -c "found renegotiation extension" \
+            -c "=> renegotiate"
+
 # Test heap memory usage after handshake
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_MEMORY_DEBUG

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14533,13 +14533,13 @@ requires_openssl_3_x
 requires_protocol_version tls12
 requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_RENEGOTIATION
-run_test    "Handshake defragmentation with server-initiated renegotiation: len=300" \
-            "$O_NEXT_SRV -tls1_2 -split_send_frag 300 -legacy_renegotiation -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
-            "$P_CLI debug_level=3 renegotiation=1 request_page=/reneg" \
+run_test    "Handshake defragmentation with server-initiated renegotiation: len=256" \
+            "$O_NEXT_SRV -tls1_2 -split_send_frag 256 -legacy_renegotiation -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$P_CLI debug_level=3 renegotiation=1 renego_delay=32 request_page=/reneg" \
             0 \
-            -c "initial handshake fragment: 300, 0..300 of [0-9]\\+" \
-            -c "Prepare: waiting for more handshake fragments 300/[0-9]\\+" \
-            -c "Consume: waiting for more handshake fragments 300/[0-9]\\+" \
+            -c "initial handshake fragment: 256, 0..256 of [0-9]\\+" \
+            -c "Prepare: waiting for more handshake fragments 256/[0-9]\\+" \
+            -c "Consume: waiting for more handshake fragments 256/[0-9]\\+" \
             -c "client hello, adding renegotiation extension" \
             -c "found renegotiation extension" \
             -c "=> renegotiate"
@@ -14555,38 +14555,6 @@ run_test    "Handshake defragmentation with server-initiated renegotiation: len=
             -c "initial handshake fragment: 512, 0..512 of [0-9]\\+" \
             -c "Prepare: waiting for more handshake fragments 512/[0-9]\\+" \
             -c "Consume: waiting for more handshake fragments 512/[0-9]\\+" \
-            -c "client hello, adding renegotiation extension" \
-            -c "found renegotiation extension" \
-            -c "=> renegotiate"
-
-# Mock negative test to demonstrate the failure with n-bit sized fragments, where ClientHello < n.
-requires_openssl_3_x
-requires_protocol_version tls12
-requires_certificate_authentication
-requires_config_enabled MBEDTLS_SSL_RENEGOTIATION
-run_test    "Handshake defragmentation mock with server-initiated renegotation: len=256 renego_delay=default(16)" \
-            "$O_NEXT_SRV -tls1_2 -split_send_frag 256 -legacy_renegotiation -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
-            "$P_CLI debug_level=3 renegotiation=1 request_page=/reneg" \
-            1 \
-            -c "initial handshake fragment: 256, 0..256 of [0-9]\\+" \
-            -c "Prepare: waiting for more handshake fragments 256/[0-9]\\+" \
-            -c "Consume: waiting for more handshake fragments 256/[0-9]\\+" \
-            -c "client hello, adding renegotiation extension" \
-            -c "found renegotiation extension" \
-            -c "renegotiation requested, but not honored by server"
-
-# Fixing the above mock negative using the new renego_delay parameter
-requires_openssl_3_x
-requires_protocol_version tls12
-requires_certificate_authentication
-requires_config_enabled MBEDTLS_SSL_RENEGOTIATION
-run_test    "Handshake defragmentation mock with server-initiated renegotiation: len=256  renego_delay=32" \
-            "$O_NEXT_SRV -tls1_2 -split_send_frag 256 -legacy_renegotiation -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
-            "$P_CLI debug_level=3 allow_legacy=1 renegotiation=1 renego_delay=32 request_page=/reneg" \
-            0 \
-            -c "initial handshake fragment: 200, 0..200 of [0-9]\\+" \
-            -c "Prepare: waiting for more handshake fragments 200/[0-9]\\+" \
-            -c "Consume: waiting for more handshake fragments 200/[0-9]\\+" \
             -c "client hello, adding renegotiation extension" \
             -c "found renegotiation extension" \
             -c "=> renegotiate"

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14487,9 +14487,9 @@ run_test    "Handshake defragmentation on server with buffer resizing: len=256, 
             -s "Reallocating in_buf" \
             -s "Reallocating out_buf" \
             -s "reassembled record" \
-            -s "initial handshake fragment: 256, 0..256 of [0-9]\\+" \
-            -s "Prepare: waiting for more handshake fragments 256/[0-9]\\+" \
-            -s "Consume: waiting for more handshake fragments 256/[0-9]\\+"
+            -s "initial handshake fragment: 256, 0\\.\\.256 of [0-9]\\+" \
+            -s "Prepare: waiting for more handshake fragments 256/" \
+            -s "Consume: waiting for more handshake fragments 256/"
 
 # Test client-initiated renegotiation with fragmented handshake on TLS1.2
 requires_openssl_3_x
@@ -14506,9 +14506,9 @@ run_test    "Handshake defragmentation with client-initiated renegotiation: len=
             -s "=> renegotiate" \
             -S "write hello request" \
             -s "reassembled record" \
-            -s "initial handshake fragment: 512, 0..512 of [0-9]\\+" \
-            -s "Prepare: waiting for more handshake fragments 512/[0-9]\\+" \
-            -s "Consume: waiting for more handshake fragments 512/[0-9]\\+" \
+            -s "initial handshake fragment: 512, 0\\.\\.512 of [0-9]\\+" \
+            -s "Prepare: waiting for more handshake fragments 512/" \
+            -s "Consume: waiting for more handshake fragments 512/" \
 
 requires_openssl_3_x
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
@@ -14524,9 +14524,9 @@ run_test    "Handshake defragmentation with client-initiated renegotiation: len=
             -s "=> renegotiate" \
             -S "write hello request" \
             -s "reassembled record" \
-            -s "initial handshake fragment: 256, 0..256 of [0-9]\\+" \
-            -s "Prepare: waiting for more handshake fragments 256/[0-9]\\+" \
-            -s "Consume: waiting for more handshake fragments 256/[0-9]\\+" \
+            -s "initial handshake fragment: 256, 0\\.\\.256 of [0-9]\\+" \
+            -s "Prepare: waiting for more handshake fragments 256/" \
+            -s "Consume: waiting for more handshake fragments 256/" \
 
 requires_openssl_3_x
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
@@ -14543,9 +14543,9 @@ run_test    "Handshake defragmentation with client-initiated renegotiation: len=
             -s "=> renegotiate" \
             -S "write hello request" \
             -s "reassembled record" \
-            -s "initial handshake fragment: 128, 0..128 of [0-9]\\+" \
-            -s "Prepare: waiting for more handshake fragments 128/[0-9]\\+" \
-            -s "Consume: waiting for more handshake fragments 128/[0-9]\\+" \
+            -s "initial handshake fragment: 128, 0\\.\\.128 of [0-9]\\+" \
+            -s "Prepare: waiting for more handshake fragments 128/" \
+            -s "Consume: waiting for more handshake fragments 128/" \
 
 requires_openssl_3_x
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
@@ -14561,9 +14561,9 @@ run_test    "Handshake defragmentation with client-initiated renegotiation: len=
             -s "=> renegotiate" \
             -S "write hello request" \
             -s "reassembled record" \
-            -s "initial handshake fragment: 4, 0..4 of [0-9]\\+" \
-            -s "Prepare: waiting for more handshake fragments 4/[0-9]\\+" \
-            -s "Consume: waiting for more handshake fragments 4/[0-9]\\+" \
+            -s "initial handshake fragment: 4, 0\\.\\.4 of [0-9]\\+" \
+            -s "Prepare: waiting for more handshake fragments 4/" \
+            -s "Consume: waiting for more handshake fragments 4/" \
 
 # Test server-initiated renegotiation with fragmented handshake on TLS1.2
 requires_openssl_3_x
@@ -14574,9 +14574,9 @@ run_test    "Handshake defragmentation with server-initiated renegotiation: len=
             "$O_NEXT_SRV -tls1_2 -split_send_frag 512 -legacy_renegotiation -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             "$P_CLI debug_level=3 renegotiation=1 request_page=/reneg" \
             0 \
-            -c "initial handshake fragment: 512, 0..512 of [0-9]\\+" \
-            -c "Prepare: waiting for more handshake fragments 512/[0-9]\\+" \
-            -c "Consume: waiting for more handshake fragments 512/[0-9]\\+" \
+            -c "initial handshake fragment: 512, 0\\.\\.512 of [0-9]\\+" \
+            -c "Prepare: waiting for more handshake fragments 512/" \
+            -c "Consume: waiting for more handshake fragments 512/" \
             -c "client hello, adding renegotiation extension" \
             -c "found renegotiation extension" \
             -c "=> renegotiate"
@@ -14596,9 +14596,9 @@ run_test    "Handshake defragmentation with server-initiated renegotiation: len=
             "$O_NEXT_SRV -tls1_2 -split_send_frag 256 -legacy_renegotiation -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             "$P_CLI debug_level=3 renegotiation=1 renego_delay=32 request_page=/reneg" \
             0 \
-            -c "initial handshake fragment: 256, 0..256 of [0-9]\\+" \
-            -c "Prepare: waiting for more handshake fragments 256/[0-9]\\+" \
-            -c "Consume: waiting for more handshake fragments 256/[0-9]\\+" \
+            -c "initial handshake fragment: 256, 0\\.\\.256 of [0-9]\\+" \
+            -c "Prepare: waiting for more handshake fragments 256/" \
+            -c "Consume: waiting for more handshake fragments 256/" \
             -c "client hello, adding renegotiation extension" \
             -c "found renegotiation extension" \
             -c "=> renegotiate"

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14475,7 +14475,6 @@ run_test    "Handshake defragmentation on server: len=32, TLS 1.2 ClientHello (u
 
 # Test server-side buffer resizing with fragmented handshake on TLS1.2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_MAX_FRAGMENT_LENGTH
 requires_config_enabled MBEDTLS_SSL_VARIABLE_BUFFER_LENGTH
 requires_max_content_len 1025
@@ -14492,7 +14491,6 @@ run_test    "Handshake defragmentation on server: len=256, buffer resizing with 
 
 # Test client-initiated renegotiation with fragmented handshake on TLS1.2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_RENEGOTIATION
 run_test    "Handshake defragmentation on server: len=512, client-initiated renegotation" \
             "$P_SRV debug_level=4 exchanges=2 renegotiation=1 auth_mode=required" \
@@ -14509,7 +14507,6 @@ run_test    "Handshake defragmentation on server: len=512, client-initiated rene
             -s "Consume: waiting for more handshake fragments 512/" \
 
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_RENEGOTIATION
 run_test    "Handshake defragmentation on server: len=256, client-initiated renegotation" \
             "$P_SRV debug_level=4 exchanges=2 renegotiation=1 auth_mode=required" \
@@ -14527,7 +14524,6 @@ run_test    "Handshake defragmentation on server: len=256, client-initiated rene
 
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
-requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_RENEGOTIATION
 run_test    "Handshake defragmentation on server: len=128, client-initiated renegotation" \
             "$P_SRV debug_level=4 exchanges=2 renegotiation=1 auth_mode=required" \
@@ -14562,7 +14558,6 @@ run_test    "Handshake defragmentation on server: len=4, client-initiated renego
 
 # Test server-initiated renegotiation with fragmented handshake on TLS1.2
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_RENEGOTIATION
 run_test    "Handshake defragmentation on client: len=512, server-initiated renegotation" \
             "$O_NEXT_SRV -tls1_2 -split_send_frag 512 -legacy_renegotiation -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
@@ -14583,7 +14578,6 @@ run_test    "Handshake defragmentation on client: len=512, server-initiated rene
 # Splitting messages during the renegotiation process requires a deeper
 # stack to accommodate the increased processing complexity.
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-requires_certificate_authentication
 requires_config_enabled MBEDTLS_SSL_RENEGOTIATION
 run_test    "Handshake defragmentation on client: len=256, server-initiated renegotation" \
             "$O_NEXT_SRV -tls1_2 -split_send_frag 256 -legacy_renegotiation -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14528,6 +14528,37 @@ run_test    "Handshake defragmentation with client-initiated renegotiation: len=
             -s "Prepare: waiting for more handshake fragments 512/[0-9]\\+" \
             -s "Consume: waiting for more handshake fragments 512/[0-9]\\+" \
 
+# Test Server initiated renegotiation with fragmented handshake on TLS1.2
+requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_RENEGOTIATION
+run_test    "Handshake defragmentation with server-initiated renegotiation: len=300" \
+            "$O_NEXT_SRV -tls1_2 -split_send_frag 300 -legacy_renegotiation -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$P_CLI debug_level=3 renegotiation=1 request_page=/reneg" \
+            0 \
+            -c "initial handshake fragment: 300, 0..300 of [0-9]\\+" \
+            -c "Prepare: waiting for more handshake fragments 300/[0-9]\\+" \
+            -c "Consume: waiting for more handshake fragments 300/[0-9]\\+" \
+            -c "client hello, adding renegotiation extension" \
+            -c "found renegotiation extension" \
+            -c "=> renegotiate"
+
+requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_RENEGOTIATION
+run_test    "Handshake defragmentation with server-initiated renegotiation: len=512" \
+            "$O_NEXT_SRV -tls1_2 -split_send_frag 512 -legacy_renegotiation -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$P_CLI debug_level=3 renegotiation=1 request_page=/reneg" \
+            0 \
+            -c "initial handshake fragment: 512, 0..512 of [0-9]\\+" \
+            -c "Prepare: waiting for more handshake fragments 512/[0-9]\\+" \
+            -c "Consume: waiting for more handshake fragments 512/[0-9]\\+" \
+            -c "client hello, adding renegotiation extension" \
+            -c "found renegotiation extension" \
+            -c "=> renegotiate"
+
 # Test heap memory usage after handshake
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_MEMORY_DEBUG

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -103,12 +103,14 @@ if [ -n "${OPENSSL_NEXT:-}" ]; then
     O_NEXT_SRV_NO_CERT="$OPENSSL_NEXT s_server -www "
     O_NEXT_CLI="echo 'GET / HTTP/1.0' | $OPENSSL_NEXT s_client -CAfile $DATA_FILES_PATH/test-ca_cat12.crt"
     O_NEXT_CLI_NO_CERT="echo 'GET / HTTP/1.0' | $OPENSSL_NEXT s_client"
+    O_NEXT_CLI_RENEGOTIATE="echo 'R' | $OPENSSL_NEXT s_client"
 else
     O_NEXT_SRV=false
     O_NEXT_SRV_NO_CERT=false
     O_NEXT_SRV_EARLY_DATA=false
     O_NEXT_CLI_NO_CERT=false
     O_NEXT_CLI=false
+    O_NEXT_CLI_RENEGOTIATE=false
 fi
 
 if [ -n "${GNUTLS_NEXT_SERV:-}" ]; then
@@ -14488,6 +14490,43 @@ run_test    "Handshake defragmentation on server with buffer resizing: len=256, 
             -s "initial handshake fragment: 256, 0..256 of [0-9]\\+" \
             -s "Prepare: waiting for more handshake fragments 256/[0-9]\\+" \
             -s "Consume: waiting for more handshake fragments 256/[0-9]\\+"
+
+# Test Client initiated renegotiation with fragmented handshake on TLS1.2
+requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_RENEGOTIATION
+run_test    "Handshake defragmentation with client-initiated renegotiation: len=256" \
+            "$P_SRV debug_level=4 exchanges=2 renegotiation=1 auth_mode=required" \
+            "$O_NEXT_CLI_RENEGOTIATE -tls1_2 -split_send_frag 256 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key -connect 127.0.0.1:+$SRV_PORT" \
+            0 \
+            -s "received TLS_EMPTY_RENEGOTIATION_INFO" \
+            -s "found renegotiation extension" \
+            -s "server hello, secure renegotiation extension" \
+            -s "=> renegotiate" \
+            -S "write hello request" \
+            -s "reassembled record" \
+            -s "initial handshake fragment: 256, 0..256 of [0-9]\\+" \
+            -s "Prepare: waiting for more handshake fragments 256/[0-9]\\+" \
+            -s "Consume: waiting for more handshake fragments 256/[0-9]\\+" \
+
+requires_openssl_3_x
+requires_protocol_version tls12
+requires_certificate_authentication
+requires_config_enabled MBEDTLS_SSL_RENEGOTIATION
+run_test    "Handshake defragmentation with client-initiated renegotiation: len=512" \
+            "$P_SRV debug_level=4 exchanges=2 renegotiation=1 auth_mode=required" \
+            "$O_NEXT_CLI_RENEGOTIATE -tls1_2 -split_send_frag 512 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key -connect 127.0.0.1:+$SRV_PORT" \
+            0 \
+            -s "received TLS_EMPTY_RENEGOTIATION_INFO" \
+            -s "found renegotiation extension" \
+            -s "server hello, secure renegotiation extension" \
+            -s "=> renegotiate" \
+            -S "write hello request" \
+            -s "reassembled record" \
+            -s "initial handshake fragment: 512, 0..512 of [0-9]\\+" \
+            -s "Prepare: waiting for more handshake fragments 512/[0-9]\\+" \
+            -s "Consume: waiting for more handshake fragments 512/[0-9]\\+" \
 
 # Test heap memory usage after handshake
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14560,7 +14560,7 @@ run_test    "Handshake defragmentation on server: len=4, client-initiated renego
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_RENEGOTIATION
 run_test    "Handshake defragmentation on client: len=512, server-initiated renegotation" \
-            "$O_NEXT_SRV -tls1_2 -split_send_frag 512 -legacy_renegotiation -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_SRV -tls1_2 -split_send_frag 512 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             "$P_CLI debug_level=3 renegotiation=1 request_page=/reneg" \
             0 \
             -c "initial handshake fragment: 512, 0\\.\\.512 of [0-9]\\+" \
@@ -14580,7 +14580,7 @@ run_test    "Handshake defragmentation on client: len=512, server-initiated rene
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_RENEGOTIATION
 run_test    "Handshake defragmentation on client: len=256, server-initiated renegotation" \
-            "$O_NEXT_SRV -tls1_2 -split_send_frag 256 -legacy_renegotiation -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
+            "$O_NEXT_SRV -tls1_2 -split_send_frag 256 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
             "$P_CLI debug_level=3 renegotiation=1 renego_delay=32 request_page=/reneg" \
             0 \
             -c "initial handshake fragment: 256, 0\\.\\.256 of [0-9]\\+" \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14592,11 +14592,12 @@ run_test    "Handshake defragmentation on client: len=512, server-initiated rene
 # number of records received before renegotiation is completed.
 # By fragmenting records and thereby increasing their quantity,
 # the default threshold can be reached more quickly.
+# Setting it to -1 disables that policy's enforment.
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 requires_config_enabled MBEDTLS_SSL_RENEGOTIATION
 run_test    "Handshake defragmentation on client: len=256, server-initiated renegotation" \
             "$O_NEXT_SRV -tls1_2 -split_send_frag 256 -cert $DATA_FILES_PATH/server5.crt -key $DATA_FILES_PATH/server5.key" \
-            "$P_CLI debug_level=3 renegotiation=1 renego_delay=32 request_page=/reneg" \
+            "$P_CLI debug_level=3 renegotiation=1 renego_delay=-1 request_page=/reneg" \
             0 \
             -c "initial handshake fragment: 256, 0\\.\\.256 of [0-9]\\+" \
             -c "Prepare: waiting for more handshake fragments 256/" \


### PR DESCRIPTION
## Description

This is a backport of #10007


## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** not required because:  Testing changes
- [x] **development PR** provided #10007 
- [x] **TF-PSA-Crypto PR** not required because:  No changes to crypto
- [x] **framework PR** not required: No changes to framework
- [x] **3.6 PR** provided #here
- [x] **2.28 PR** not required because: Feature we are testing has not been backported to 2.28
- **tests**  provided