### PR TITLE
[Backport 3.6] Adapt test_keys.h and test_cert.h generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -355,35 +355,37 @@ if(ENABLE_TESTING OR ENABLE_PROGRAMS)
     if(GEN_FILES)
         add_custom_command(
             OUTPUT
-                ${CMAKE_CURRENT_SOURCE_DIR}/framework/tests/include/test/test_keys.h
-            WORKING_DIRECTORY
-                ${CMAKE_CURRENT_SOURCE_DIR}/tests
+                ${CMAKE_CURRENT_BINARY_DIR}/tests/include/test/test_keys.h
+            COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/tests/include/test
             COMMAND
                 "${MBEDTLS_PYTHON_EXECUTABLE}"
                 "${CMAKE_CURRENT_SOURCE_DIR}/framework/scripts/generate_test_keys.py"
                 "--output"
-                "${CMAKE_CURRENT_SOURCE_DIR}/framework/tests/include/test/test_keys.h"
+                "${CMAKE_CURRENT_BINARY_DIR}/tests/include/test/test_keys.h"
             DEPENDS
                 ${CMAKE_CURRENT_SOURCE_DIR}/framework/scripts/generate_test_keys.py
         )
-        add_custom_target(test_keys_header DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/framework/tests/include/test/test_keys.h)
+        add_custom_target(test_keys_header
+            DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/tests/include/test/test_keys.h)
         add_custom_command(
             OUTPUT
-                ${CMAKE_CURRENT_SOURCE_DIR}/tests/src/test_certs.h
+                ${CMAKE_CURRENT_BINARY_DIR}/tests/include/test/test_certs.h
+            COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/tests/include/test
             WORKING_DIRECTORY
                 ${CMAKE_CURRENT_SOURCE_DIR}/tests
             COMMAND
                 "${MBEDTLS_PYTHON_EXECUTABLE}"
                 "${CMAKE_CURRENT_SOURCE_DIR}/framework/scripts/generate_test_cert_macros.py"
                 "--output"
-                "${CMAKE_CURRENT_SOURCE_DIR}/tests/src/test_certs.h"
+                "${CMAKE_CURRENT_BINARY_DIR}/tests/include/test/test_certs.h"
             DEPENDS
                 ${CMAKE_CURRENT_SOURCE_DIR}/framework/scripts/generate_test_cert_macros.py
         )
-        add_custom_target(test_certs_header DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/tests/src/test_certs.h)
+        add_custom_target(test_certs_header DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/tests/include/test/test_certs.h)
         add_dependencies(mbedtls_test test_keys_header test_certs_header)
     endif()
     target_include_directories(mbedtls_test
+        PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/tests/include
         PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/framework/tests/include
         PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tests/include
         PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include

--- a/scripts/make_generated_files.bat
+++ b/scripts/make_generated_files.bat
@@ -15,9 +15,6 @@ perl scripts\generate_query_config.pl || exit /b 1
 perl scripts\generate_features.pl || exit /b 1
 python framework\scripts\generate_ssl_debug_helpers.py || exit /b 1
 
-@rem @@@@ Build @@@@
-perl scripts\generate_visualc_files.pl || exit /b 1
-
 @rem @@@@ programs\** @@@@
 python scripts\generate_psa_constants.py || exit /b 1
 
@@ -26,7 +23,12 @@ python framework\scripts\generate_bignum_tests.py || exit /b 1
 python framework\scripts\generate_config_tests.py || exit /b 1
 python framework\scripts\generate_ecp_tests.py || exit /b 1
 python framework\scripts\generate_psa_tests.py || exit /b 1
-python framework\scripts\generate_test_keys.py --output framework\tests\include\test\test_keys.h || exit /b 1
-python framework\scripts\generate_test_cert_macros.py --output tests\src\test_certs.h || exit /b 1
+python framework\scripts\generate_test_keys.py --output tests\include\test\test_keys.h || exit /b 1
+python framework\scripts\generate_test_cert_macros.py --output tests\include\test\test_certs.h || exit /b 1
 python framework\scripts\generate_tls_handshake_tests.py || exit /b 1
 python framework\scripts\generate_tls13_compat_tests.py || exit /b 1
+
+@rem @@@@ Build @@@@
+@rem Call generate_visualc_files.pl last to be sure everything else has been
+@rem generated before.
+perl scripts\generate_visualc_files.pl || exit /b 1

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -25,6 +25,6 @@
 /suites/test_suite_config.psa_boolean.data
 /suites/test_suite_psa_crypto_storage_format.v[0-9]*.data
 /suites/test_suite_psa_crypto_storage_format.current.data
-/src/test_keys.h
-/src/test_certs.h
+/include/test/test_keys.h
+/include/test/test_certs.h
 ###END_GENERATED_FILES###

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -336,6 +336,7 @@ function(add_test_suite suite_name)
     # files are automatically included because the library targets declare
     # them as PUBLIC.
     target_include_directories(test_suite_${data_name}
+        PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/include
         PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
         PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../framework/tests/include
         PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../library)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -53,7 +53,7 @@ endif
 GENERATED_DATA_FILES += $(GENERATED_PSA_DATA_FILES)
 
 GENERATED_FILES = $(GENERATED_DATA_FILES)
-GENERATED_FILES += ../framework/tests/include/test/test_keys.h src/test_certs.h
+GENERATED_FILES += include/test/test_keys.h include/test/test_certs.h
 
 # Generated files needed to (fully) run ssl-opt.sh
 .PHONY: ssl-opt
@@ -164,12 +164,12 @@ all: $(BINARIES)
 
 mbedtls_test: $(MBEDTLS_TEST_OBJS)
 
-src/test_certs.h: ../framework/scripts/generate_test_cert_macros.py \
+include/test/test_certs.h: ../framework/scripts/generate_test_cert_macros.py \
 				  $($(PYTHON) ../framework/scripts/generate_test_cert_macros.py --list-dependencies)
 	echo "  Gen   $@"
 	$(PYTHON) ../framework/scripts/generate_test_cert_macros.py --output $@
 
-../framework/tests/include/test/test_keys.h: ../framework/scripts/generate_test_keys.py
+include/test/test_keys.h: ../framework/scripts/generate_test_keys.py
 	echo "  Gen   $@"
 	$(PYTHON) ../framework/scripts/generate_test_keys.py --output $@
 
@@ -180,7 +180,7 @@ ifdef RECORD_PSA_STATUS_COVERAGE_LOG
 # therefore the wildcard enumeration above doesn't include it.
 TEST_OBJS_DEPS += ../framework/tests/include/test/instrument_record_status.h
 endif
-TEST_OBJS_DEPS += src/test_certs.h ../framework/tests/include/test/test_keys.h
+TEST_OBJS_DEPS += include/test/test_certs.h include/test/test_keys.h
 
 # Rule to compile common test C files in framework
 ../framework/tests/src/%.o : ../framework/tests/src/%.c $(TEST_OBJS_DEPS)

--- a/tests/scripts/check-generated-files.sh
+++ b/tests/scripts/check-generated-files.sh
@@ -126,7 +126,7 @@ check framework/scripts/generate_bignum_tests.py $(framework/scripts/generate_bi
 check framework/scripts/generate_config_tests.py $(framework/scripts/generate_config_tests.py --list)
 check framework/scripts/generate_ecp_tests.py $(framework/scripts/generate_ecp_tests.py --list)
 check framework/scripts/generate_psa_tests.py $(framework/scripts/generate_psa_tests.py --list)
-check framework/scripts/generate_test_keys.py framework/tests/include/test/test_keys.h
+check framework/scripts/generate_test_keys.py tests/include/test/test_keys.h
 check scripts/generate_driver_wrappers.py $library_dir/psa_crypto_driver_wrappers.h $library_dir/psa_crypto_driver_wrappers_no_static.c
 
 # Additional checks for Mbed TLS only
@@ -137,7 +137,7 @@ if in_mbedtls_repo; then
     check framework/scripts/generate_ssl_debug_helpers.py library/ssl_debug_helpers_generated.c
     check framework/scripts/generate_tls_handshake_tests.py tests/opt-testcases/handshake-generated.sh
     check framework/scripts/generate_tls13_compat_tests.py tests/opt-testcases/tls13-compat.sh
-    check framework/scripts/generate_test_cert_macros.py tests/src/test_certs.h
+    check framework/scripts/generate_test_cert_macros.py tests/include/test/test_certs.h
     # generate_visualc_files enumerates source files (library/*.c). It doesn't
     # care about their content, but the files must exist. So it must run after
     # the step that creates or updates these files.

--- a/tests/src/certs.c
+++ b/tests/src/certs.c
@@ -13,7 +13,7 @@
 
 #include "mbedtls/pk.h"
 
-#include "test_certs.h"
+#include "test/test_certs.h"
 
 /*
  *


### PR DESCRIPTION
## Description
Adapt test_keys.h and test_cert.h generation to the changes done in https://github.com/Mbed-TLS/mbedtls-framework/pull/149 for the sake of https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/201.
Fixes the component check_generated_files failing in the CI of https://github.com/Mbed-TLS/mbedtls-framework/pull/149 against 3.6.

## PR checklist
- [x] **changelog** not required because: just changing the location of test headers 
- [x] **development PR** provided #10062 
- [x] **TF-PSA-Crypto PR** provided Mbed-TLS/TF-PSA-Crypto#201
- [x] **framework PR** provided Mbed-TLS/mbedtls-framework#149
- [x] **3.6 PR** provided here
- [x] **2.28 PR** not required because: no impact on 2.28
- **tests**  not required because: only test internal changes.