### PR TITLE
Backport 3.6: Test coalesced or split handshake messages

### DIFF
--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -1333,10 +1333,16 @@ int mbedtls_ssl_handshake_client_step(mbedtls_ssl_context *ssl);
 MBEDTLS_CHECK_RETURN_CRITICAL
 int mbedtls_ssl_handshake_server_step(mbedtls_ssl_context *ssl);
 void mbedtls_ssl_handshake_wrapup(mbedtls_ssl_context *ssl);
+
 static inline void mbedtls_ssl_handshake_set_state(mbedtls_ssl_context *ssl,
                                                    mbedtls_ssl_states state)
 {
     ssl->state = (int) state;
+}
+
+static inline void mbedtls_ssl_handshake_increment_state(mbedtls_ssl_context *ssl)
+{
+    mbedtls_ssl_handshake_set_state(ssl, ssl->state + 1);
 }
 
 MBEDTLS_CHECK_RETURN_CRITICAL

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -1351,7 +1351,7 @@ static inline void mbedtls_ssl_handshake_set_state(mbedtls_ssl_context *ssl,
 {
     MBEDTLS_SSL_DEBUG_MSG(3, ("handshake state: %d (%s) -> %d (%s)",
                               ssl->state, mbedtls_ssl_states_str(ssl->state),
-                              state, mbedtls_ssl_states_str(state)));
+                              (int) state, mbedtls_ssl_states_str(state)));
     ssl->state = (int) state;
 }
 

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -16,6 +16,9 @@
 #include "mbedtls/error.h"
 
 #include "mbedtls/ssl.h"
+#include "mbedtls/debug.h"
+#include "debug_internal.h"
+
 #include "mbedtls/cipher.h"
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO) || defined(MBEDTLS_SSL_PROTO_TLS1_3)
@@ -1334,9 +1337,21 @@ MBEDTLS_CHECK_RETURN_CRITICAL
 int mbedtls_ssl_handshake_server_step(mbedtls_ssl_context *ssl);
 void mbedtls_ssl_handshake_wrapup(mbedtls_ssl_context *ssl);
 
+#if defined(MBEDTLS_DEBUG_C)
+/* Declared in "ssl_debug_helpers.h". We can't include this file from
+ * "ssl_misc.h" because it includes "ssl_misc.h" because it needs some
+ * type definitions. TODO: split the type definitions and the helper
+ * functions into different headers.
+ */
+const char *mbedtls_ssl_states_str(mbedtls_ssl_states state);
+#endif
+
 static inline void mbedtls_ssl_handshake_set_state(mbedtls_ssl_context *ssl,
                                                    mbedtls_ssl_states state)
 {
+    MBEDTLS_SSL_DEBUG_MSG(3, ("handshake state: %d (%s) -> %d (%s)",
+                              ssl->state, mbedtls_ssl_states_str(ssl->state),
+                              state, mbedtls_ssl_states_str(state)));
     ssl->state = (int) state;
 }
 

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -5318,7 +5318,7 @@ int mbedtls_ssl_write_change_cipher_spec(mbedtls_ssl_context *ssl)
     ssl->out_msglen  = 1;
     ssl->out_msg[0]  = 1;
 
-    ssl->state++;
+    mbedtls_ssl_handshake_increment_state(ssl);
 
     if ((ret = mbedtls_ssl_write_handshake_msg(ssl)) != 0) {
         MBEDTLS_SSL_DEBUG_RET(1, "mbedtls_ssl_write_handshake_msg", ret);
@@ -5380,7 +5380,7 @@ int mbedtls_ssl_parse_change_cipher_spec(mbedtls_ssl_context *ssl)
 
     mbedtls_ssl_update_in_pointers(ssl);
 
-    ssl->state++;
+    mbedtls_ssl_handshake_increment_state(ssl);
 
     MBEDTLS_SSL_DEBUG_MSG(2, ("<= parse change cipher spec"));
 

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -3971,6 +3971,7 @@ static int ssl_parse_record_header(mbedtls_ssl_context const *ssl,
     rec->buf_len = rec->data_offset + rec->data_len;
 
     if (rec->data_len == 0) {
+        MBEDTLS_SSL_DEBUG_MSG(1, ("rejecting empty record"));
         return MBEDTLS_ERR_SSL_INVALID_RECORD;
     }
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1554,7 +1554,7 @@ int mbedtls_ssl_session_reset_int(mbedtls_ssl_context *ssl, int partial)
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
 
-    ssl->state = MBEDTLS_SSL_HELLO_REQUEST;
+    mbedtls_ssl_handshake_set_state(ssl, MBEDTLS_SSL_HELLO_REQUEST);
     ssl->tls_version = ssl->conf->max_tls_version;
 
     mbedtls_ssl_session_reset_msg_layer(ssl, partial);
@@ -4539,7 +4539,7 @@ int mbedtls_ssl_handshake_step(mbedtls_ssl_context *ssl)
 
         switch (ssl->state) {
             case MBEDTLS_SSL_HELLO_REQUEST:
-                ssl->state = MBEDTLS_SSL_CLIENT_HELLO;
+                mbedtls_ssl_handshake_set_state(ssl, MBEDTLS_SSL_CLIENT_HELLO);
                 ret = 0;
                 break;
 
@@ -4690,7 +4690,7 @@ int mbedtls_ssl_start_renegotiation(mbedtls_ssl_context *ssl)
     }
 #endif
 
-    ssl->state = MBEDTLS_SSL_HELLO_REQUEST;
+    mbedtls_ssl_handshake_set_state(ssl, MBEDTLS_SSL_HELLO_REQUEST);
     ssl->renego_status = MBEDTLS_SSL_RENEGOTIATION_IN_PROGRESS;
 
     if ((ret = mbedtls_ssl_handshake(ssl)) != 0) {
@@ -5473,7 +5473,7 @@ static int ssl_context_load(mbedtls_ssl_context *ssl,
      * Most of them already set to the correct value by mbedtls_ssl_init() and
      * mbedtls_ssl_reset(), so we only need to set the remaining ones.
      */
-    ssl->state = MBEDTLS_SSL_HANDSHAKE_OVER;
+    mbedtls_ssl_handshake_set_state(ssl, MBEDTLS_SSL_HANDSHAKE_OVER);
     ssl->tls_version = MBEDTLS_SSL_VERSION_TLS1_2;
 
     /* Adjust pointers for header fields of outgoing records to
@@ -7530,7 +7530,7 @@ int mbedtls_ssl_write_certificate(mbedtls_ssl_context *ssl)
 
     if (!mbedtls_ssl_ciphersuite_uses_srv_cert(ciphersuite_info)) {
         MBEDTLS_SSL_DEBUG_MSG(2, ("<= skip write certificate"));
-        ssl->state++;
+        mbedtls_ssl_handshake_increment_state(ssl);
         return 0;
     }
 
@@ -7547,7 +7547,7 @@ int mbedtls_ssl_parse_certificate(mbedtls_ssl_context *ssl)
 
     if (!mbedtls_ssl_ciphersuite_uses_srv_cert(ciphersuite_info)) {
         MBEDTLS_SSL_DEBUG_MSG(2, ("<= skip parse certificate"));
-        ssl->state++;
+        mbedtls_ssl_handshake_increment_state(ssl);
         return 0;
     }
 
@@ -7570,7 +7570,7 @@ int mbedtls_ssl_write_certificate(mbedtls_ssl_context *ssl)
 
     if (!mbedtls_ssl_ciphersuite_uses_srv_cert(ciphersuite_info)) {
         MBEDTLS_SSL_DEBUG_MSG(2, ("<= skip write certificate"));
-        ssl->state++;
+        mbedtls_ssl_handshake_increment_state(ssl);
         return 0;
     }
 
@@ -7578,7 +7578,7 @@ int mbedtls_ssl_write_certificate(mbedtls_ssl_context *ssl)
     if (ssl->conf->endpoint == MBEDTLS_SSL_IS_CLIENT) {
         if (ssl->handshake->client_auth == 0) {
             MBEDTLS_SSL_DEBUG_MSG(2, ("<= skip write certificate"));
-            ssl->state++;
+            mbedtls_ssl_handshake_increment_state(ssl);
             return 0;
         }
     }
@@ -7632,7 +7632,7 @@ int mbedtls_ssl_write_certificate(mbedtls_ssl_context *ssl)
     ssl->out_msgtype = MBEDTLS_SSL_MSG_HANDSHAKE;
     ssl->out_msg[0]  = MBEDTLS_SSL_HS_CERTIFICATE;
 
-    ssl->state++;
+    mbedtls_ssl_handshake_increment_state(ssl);
 
     if ((ret = mbedtls_ssl_write_handshake_msg(ssl)) != 0) {
         MBEDTLS_SSL_DEBUG_RET(1, "mbedtls_ssl_write_handshake_msg", ret);
@@ -8090,7 +8090,7 @@ crt_verify:
 exit:
 
     if (ret == 0) {
-        ssl->state++;
+        mbedtls_ssl_handshake_increment_state(ssl);
     }
 
 #if defined(MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED)
@@ -8306,7 +8306,7 @@ void mbedtls_ssl_handshake_wrapup(mbedtls_ssl_context *ssl)
 #endif
     mbedtls_ssl_handshake_wrapup_free_hs_transform(ssl);
 
-    ssl->state = MBEDTLS_SSL_HANDSHAKE_OVER;
+    mbedtls_ssl_handshake_set_state(ssl, MBEDTLS_SSL_HANDSHAKE_OVER);
 
     MBEDTLS_SSL_DEBUG_MSG(3, ("<= handshake wrapup"));
 }
@@ -8349,16 +8349,16 @@ int mbedtls_ssl_write_finished(mbedtls_ssl_context *ssl)
     if (ssl->handshake->resume != 0) {
 #if defined(MBEDTLS_SSL_CLI_C)
         if (ssl->conf->endpoint == MBEDTLS_SSL_IS_CLIENT) {
-            ssl->state = MBEDTLS_SSL_HANDSHAKE_WRAPUP;
+            mbedtls_ssl_handshake_set_state(ssl, MBEDTLS_SSL_HANDSHAKE_WRAPUP);
         }
 #endif
 #if defined(MBEDTLS_SSL_SRV_C)
         if (ssl->conf->endpoint == MBEDTLS_SSL_IS_SERVER) {
-            ssl->state = MBEDTLS_SSL_CLIENT_CHANGE_CIPHER_SPEC;
+            mbedtls_ssl_handshake_set_state(ssl, MBEDTLS_SSL_CLIENT_CHANGE_CIPHER_SPEC);
         }
 #endif
     } else {
-        ssl->state++;
+        mbedtls_ssl_handshake_increment_state(ssl);
     }
 
     /*
@@ -8483,16 +8483,16 @@ int mbedtls_ssl_parse_finished(mbedtls_ssl_context *ssl)
     if (ssl->handshake->resume != 0) {
 #if defined(MBEDTLS_SSL_CLI_C)
         if (ssl->conf->endpoint == MBEDTLS_SSL_IS_CLIENT) {
-            ssl->state = MBEDTLS_SSL_CLIENT_CHANGE_CIPHER_SPEC;
+            mbedtls_ssl_handshake_set_state(ssl, MBEDTLS_SSL_CLIENT_CHANGE_CIPHER_SPEC);
         }
 #endif
 #if defined(MBEDTLS_SSL_SRV_C)
         if (ssl->conf->endpoint == MBEDTLS_SSL_IS_SERVER) {
-            ssl->state = MBEDTLS_SSL_HANDSHAKE_WRAPUP;
+            mbedtls_ssl_handshake_set_state(ssl, MBEDTLS_SSL_HANDSHAKE_WRAPUP);
         }
 #endif
     } else {
-        ssl->state++;
+        mbedtls_ssl_handshake_increment_state(ssl);
     }
 
 #if defined(MBEDTLS_SSL_PROTO_DTLS)

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -1636,7 +1636,7 @@ have_ciphersuite:
     ssl->session_negotiate->ciphersuite = ciphersuites[i];
     ssl->handshake->ciphersuite_info = ciphersuite_info;
 
-    ssl->state++;
+    mbedtls_ssl_handshake_increment_state(ssl);
 
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
     if (ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM) {
@@ -2064,7 +2064,7 @@ static int ssl_write_hello_verify_request(mbedtls_ssl_context *ssl)
     ssl->out_msgtype = MBEDTLS_SSL_MSG_HANDSHAKE;
     ssl->out_msg[0]  = MBEDTLS_SSL_HS_HELLO_VERIFY_REQUEST;
 
-    ssl->state = MBEDTLS_SSL_SERVER_HELLO_VERIFY_REQUEST_SENT;
+    mbedtls_ssl_handshake_set_state(ssl, MBEDTLS_SSL_SERVER_HELLO_VERIFY_REQUEST_SENT);
 
     if ((ret = mbedtls_ssl_write_handshake_msg(ssl)) != 0) {
         MBEDTLS_SSL_DEBUG_RET(1, "mbedtls_ssl_write_handshake_msg", ret);
@@ -2232,7 +2232,7 @@ static int ssl_write_server_hello(mbedtls_ssl_context *ssl)
          * New session, create a new session id,
          * unless we're about to issue a session ticket
          */
-        ssl->state++;
+        mbedtls_ssl_handshake_increment_state(ssl);
 
 #if defined(MBEDTLS_HAVE_TIME)
         ssl->session_negotiate->start = mbedtls_time(NULL);
@@ -2256,7 +2256,7 @@ static int ssl_write_server_hello(mbedtls_ssl_context *ssl)
          * Resuming a session
          */
         n = ssl->session_negotiate->id_len;
-        ssl->state = MBEDTLS_SSL_SERVER_CHANGE_CIPHER_SPEC;
+        mbedtls_ssl_handshake_set_state(ssl, MBEDTLS_SSL_SERVER_CHANGE_CIPHER_SPEC);
 
         if ((ret = mbedtls_ssl_derive_keys(ssl)) != 0) {
             MBEDTLS_SSL_DEBUG_RET(1, "mbedtls_ssl_derive_keys", ret);
@@ -2382,7 +2382,7 @@ static int ssl_write_certificate_request(mbedtls_ssl_context *ssl)
 
     if (!mbedtls_ssl_ciphersuite_cert_req_allowed(ciphersuite_info)) {
         MBEDTLS_SSL_DEBUG_MSG(2, ("<= skip write certificate request"));
-        ssl->state++;
+        mbedtls_ssl_handshake_increment_state(ssl);
         return 0;
     }
 
@@ -2405,7 +2405,7 @@ static int ssl_write_certificate_request(mbedtls_ssl_context *ssl)
 
     MBEDTLS_SSL_DEBUG_MSG(2, ("=> write certificate request"));
 
-    ssl->state++;
+    mbedtls_ssl_handshake_increment_state(ssl);
 
 #if defined(MBEDTLS_SSL_SERVER_NAME_INDICATION)
     if (ssl->handshake->sni_authmode != MBEDTLS_SSL_VERIFY_UNSET) {
@@ -3252,7 +3252,7 @@ static int ssl_write_server_key_exchange(mbedtls_ssl_context *ssl)
         /* Key exchanges not involving ephemeral keys don't use
          * ServerKeyExchange, so end here. */
         MBEDTLS_SSL_DEBUG_MSG(2, ("<= skip write server key exchange"));
-        ssl->state++;
+        mbedtls_ssl_handshake_increment_state(ssl);
         return 0;
     }
 #endif /* MBEDTLS_KEY_EXCHANGE_SOME_NON_PFS_ENABLED */
@@ -3306,7 +3306,7 @@ static int ssl_write_server_key_exchange(mbedtls_ssl_context *ssl)
     ssl->out_msgtype = MBEDTLS_SSL_MSG_HANDSHAKE;
     ssl->out_msg[0]  = MBEDTLS_SSL_HS_SERVER_KEY_EXCHANGE;
 
-    ssl->state++;
+    mbedtls_ssl_handshake_increment_state(ssl);
 
     if ((ret = mbedtls_ssl_write_handshake_msg(ssl)) != 0) {
         MBEDTLS_SSL_DEBUG_RET(1, "mbedtls_ssl_write_handshake_msg", ret);
@@ -3328,7 +3328,7 @@ static int ssl_write_server_hello_done(mbedtls_ssl_context *ssl)
     ssl->out_msgtype = MBEDTLS_SSL_MSG_HANDSHAKE;
     ssl->out_msg[0]  = MBEDTLS_SSL_HS_SERVER_HELLO_DONE;
 
-    ssl->state++;
+    mbedtls_ssl_handshake_increment_state(ssl);
 
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
     if (ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM) {
@@ -4052,7 +4052,7 @@ static int ssl_parse_client_key_exchange(mbedtls_ssl_context *ssl)
         return ret;
     }
 
-    ssl->state++;
+    mbedtls_ssl_handshake_increment_state(ssl);
 
     MBEDTLS_SSL_DEBUG_MSG(2, ("<= parse client key exchange"));
 
@@ -4070,7 +4070,7 @@ static int ssl_parse_certificate_verify(mbedtls_ssl_context *ssl)
 
     if (!mbedtls_ssl_ciphersuite_cert_req_allowed(ciphersuite_info)) {
         MBEDTLS_SSL_DEBUG_MSG(2, ("<= skip parse certificate verify"));
-        ssl->state++;
+        mbedtls_ssl_handshake_increment_state(ssl);
         return 0;
     }
 
@@ -4096,20 +4096,20 @@ static int ssl_parse_certificate_verify(mbedtls_ssl_context *ssl)
 
     if (!mbedtls_ssl_ciphersuite_cert_req_allowed(ciphersuite_info)) {
         MBEDTLS_SSL_DEBUG_MSG(2, ("<= skip parse certificate verify"));
-        ssl->state++;
+        mbedtls_ssl_handshake_increment_state(ssl);
         return 0;
     }
 
 #if defined(MBEDTLS_SSL_KEEP_PEER_CERTIFICATE)
     if (ssl->session_negotiate->peer_cert == NULL) {
         MBEDTLS_SSL_DEBUG_MSG(2, ("<= skip parse certificate verify"));
-        ssl->state++;
+        mbedtls_ssl_handshake_increment_state(ssl);
         return 0;
     }
 #else /* MBEDTLS_SSL_KEEP_PEER_CERTIFICATE */
     if (ssl->session_negotiate->peer_cert_digest == NULL) {
         MBEDTLS_SSL_DEBUG_MSG(2, ("<= skip parse certificate verify"));
-        ssl->state++;
+        mbedtls_ssl_handshake_increment_state(ssl);
         return 0;
     }
 #endif /* !MBEDTLS_SSL_KEEP_PEER_CERTIFICATE */
@@ -4121,7 +4121,7 @@ static int ssl_parse_certificate_verify(mbedtls_ssl_context *ssl)
         return ret;
     }
 
-    ssl->state++;
+    mbedtls_ssl_handshake_increment_state(ssl);
 
     /* Process the message contents */
     if (ssl->in_msgtype != MBEDTLS_SSL_MSG_HANDSHAKE ||
@@ -4305,7 +4305,7 @@ int mbedtls_ssl_handshake_server_step(mbedtls_ssl_context *ssl)
 
     switch (ssl->state) {
         case MBEDTLS_SSL_HELLO_REQUEST:
-            ssl->state = MBEDTLS_SSL_CLIENT_HELLO;
+            mbedtls_ssl_handshake_set_state(ssl, MBEDTLS_SSL_CLIENT_HELLO);
             break;
 
         /*
@@ -4394,7 +4394,7 @@ int mbedtls_ssl_handshake_server_step(mbedtls_ssl_context *ssl)
 
         case MBEDTLS_SSL_FLUSH_BUFFERS:
             MBEDTLS_SSL_DEBUG_MSG(2, ("handshake: done"));
-            ssl->state = MBEDTLS_SSL_HANDSHAKE_WRAPUP;
+            mbedtls_ssl_handshake_set_state(ssl, MBEDTLS_SSL_HANDSHAKE_WRAPUP);
             break;
 
         case MBEDTLS_SSL_HANDSHAKE_WRAPUP:

--- a/tests/include/test/ssl_helpers.h
+++ b/tests/include/test/ssl_helpers.h
@@ -182,17 +182,6 @@ typedef struct mbedtls_test_message_socket_context {
 
 
 
-/* The mbedtls_test_ssl_endpoint_xxx tooling currently compiles in PSK-only
- * builds, but does not reach the end of the handshake.
- *
- * https://github.com/Mbed-TLS/mbedtls/issues/10048
- */
-#if defined(MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED)
-#define MBEDTLS_TEST_SSL_ENDPOINT
-#endif
-
-#if defined(MBEDTLS_TEST_SSL_ENDPOINT)
-
 #if defined(MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED)
 /*
  * Structure with endpoint's certificates for SSL communication tests.
@@ -216,8 +205,6 @@ typedef struct mbedtls_test_ssl_endpoint {
     mbedtls_test_ssl_endpoint_certificate cert;
 #endif
 } mbedtls_test_ssl_endpoint;
-
-#endif /* MBEDTLS_TEST_SSL_ENDPOINT */
 
 
 
@@ -442,7 +429,7 @@ int mbedtls_test_mock_tcp_send_msg(void *ctx,
 int mbedtls_test_mock_tcp_recv_msg(void *ctx,
                                    unsigned char *buf, size_t buf_len);
 
-#if defined(MBEDTLS_TEST_SSL_ENDPOINT)
+
 
 #if defined(MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED)
 /*
@@ -508,8 +495,6 @@ void mbedtls_test_ssl_endpoint_free(
 int mbedtls_test_move_handshake_to_state(mbedtls_ssl_context *ssl,
                                          mbedtls_ssl_context *second_ssl,
                                          int state);
-
-#endif /* MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED */
 
 /*
  * Helper function setting up inverse record transformations

--- a/tests/include/test/ssl_helpers.h
+++ b/tests/include/test/ssl_helpers.h
@@ -179,8 +179,21 @@ typedef struct mbedtls_test_message_socket_context {
     mbedtls_test_mock_socket *socket;
 } mbedtls_test_message_socket_context;
 
-#if defined(MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED)
 
+
+
+/* The mbedtls_test_ssl_endpoint_xxx tooling currently compiles in PSK-only
+ * builds, but does not reach the end of the handshake.
+ *
+ * https://github.com/Mbed-TLS/mbedtls/issues/10048
+ */
+#if defined(MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED)
+#define MBEDTLS_TEST_SSL_ENDPOINT
+#endif
+
+#if defined(MBEDTLS_TEST_SSL_ENDPOINT)
+
+#if defined(MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED)
 /*
  * Structure with endpoint's certificates for SSL communication tests.
  */
@@ -189,6 +202,7 @@ typedef struct mbedtls_test_ssl_endpoint_certificate {
     mbedtls_x509_crt *cert;
     mbedtls_pk_context *pkey;
 } mbedtls_test_ssl_endpoint_certificate;
+#endif /* MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED */
 
 /*
  * Endpoint structure for SSL communication tests.
@@ -198,10 +212,14 @@ typedef struct mbedtls_test_ssl_endpoint {
     mbedtls_ssl_context ssl;
     mbedtls_ssl_config conf;
     mbedtls_test_mock_socket socket;
+#if defined(MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED)
     mbedtls_test_ssl_endpoint_certificate cert;
+#endif
 } mbedtls_test_ssl_endpoint;
 
-#endif /* MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED */
+#endif /* MBEDTLS_TEST_SSL_ENDPOINT */
+
+
 
 /*
  * Random number generator aimed for TLS unitary tests. Its main purpose is to
@@ -424,8 +442,9 @@ int mbedtls_test_mock_tcp_send_msg(void *ctx,
 int mbedtls_test_mock_tcp_recv_msg(void *ctx,
                                    unsigned char *buf, size_t buf_len);
 
-#if defined(MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED)
+#if defined(MBEDTLS_TEST_SSL_ENDPOINT)
 
+#if defined(MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED)
 /*
  * Initializes \p ep_cert structure and assigns it to endpoint
  * represented by \p ep.
@@ -436,6 +455,7 @@ int mbedtls_test_ssl_endpoint_certificate_init(mbedtls_test_ssl_endpoint *ep,
                                                int pk_alg,
                                                int opaque_alg, int opaque_alg2,
                                                int opaque_usage);
+#endif /* MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED */
 
 /*
  * Initializes \p ep structure. It is important to call

--- a/tests/include/test/ssl_helpers.h
+++ b/tests/include/test/ssl_helpers.h
@@ -477,7 +477,7 @@ void mbedtls_test_ssl_endpoint_free(
  *                       &server.ssl, &client.ssl,
  *                       MBEDTLS_SSL_HANDSHAKE_OVER);
  * mbedtls_test_move_handshake_to_state(
- *                       &client.ssl, &client.ssl,
+ *                       &client.ssl, &server.ssl,
  *                       MBEDTLS_SSL_HANDSHAKE_OVER);
  * ```
  * Note that you need both calls to reach the handshake-over state on

--- a/tests/include/test/ssl_helpers.h
+++ b/tests/include/test/ssl_helpers.h
@@ -471,6 +471,18 @@ void mbedtls_test_ssl_endpoint_free(
  * /p second_ssl is used as second endpoint and their sockets have to be
  * connected before calling this function.
  *
+ * For example, to perform a full handshake:
+ * ```
+ * mbedtls_test_move_handshake_to_state(
+ *                       &server.ssl, &client.ssl,
+ *                       MBEDTLS_SSL_HANDSHAKE_OVER);
+ * mbedtls_test_move_handshake_to_state(
+ *                       &client.ssl, &client.ssl,
+ *                       MBEDTLS_SSL_HANDSHAKE_OVER);
+ * ```
+ * Note that you need both calls to reach the handshake-over state on
+ * both sides.
+ *
  * \retval  0 on success, otherwise error code.
  */
 int mbedtls_test_move_handshake_to_state(mbedtls_ssl_context *ssl,

--- a/tests/include/test/ssl_helpers.h
+++ b/tests/include/test/ssl_helpers.h
@@ -180,6 +180,22 @@ typedef struct mbedtls_test_message_socket_context {
 } mbedtls_test_message_socket_context;
 
 
+/* Does it work when mbedtls_test_ssl_endpoint_init() loads its default
+ * certificates? */
+#if defined(MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED)
+#  if defined(MBEDTLS_RSA_C) && defined(MBEDTLS_MD_CAN_SHA256)
+#    define MBEDTLS_TEST_SSL_ENDPOINT_DEFAULT_CERT_RSA
+#    define MBEDTLS_TEST_SSL_ENDPOINT_DEFAULT_CERTS
+#  endif
+
+/* The ECDSA certificate has a secp256r1 key, and is signed with a
+ * secp384r1 keys, so both curves are needed. */
+#  if defined(MBEDTLS_PK_CAN_ECDSA_SIGN) && defined(MBEDTLS_MD_CAN_SHA256) && \
+    defined(MBEDTLS_ECP_HAVE_SECP384R1) && defined(MBEDTLS_ECP_HAVE_SECP256R1)
+#    define MBEDTLS_TEST_SSL_ENDPOINT_DEFAULT_CERT_ECDSA
+#    define MBEDTLS_TEST_SSL_ENDPOINT_DEFAULT_CERTS
+#  endif
+#endif
 
 
 #if defined(MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED)

--- a/tests/src/certs.c
+++ b/tests/src/certs.c
@@ -412,7 +412,9 @@ const char *mbedtls_test_cas[] = {
 #if defined(MBEDTLS_RSA_C) && defined(MBEDTLS_MD_CAN_SHA256)
     mbedtls_test_ca_crt_rsa_sha256,
 #endif
-#if defined(MBEDTLS_PK_CAN_ECDSA_SOME)
+#if defined(MBEDTLS_PK_CAN_ECDSA_SOME) && \
+    defined(MBEDTLS_ECP_HAVE_SECP384R1) && \
+    defined(MBEDTLS_MD_CAN_SHA256)
     mbedtls_test_ca_crt_ec,
 #endif
     NULL
@@ -424,7 +426,9 @@ const size_t mbedtls_test_cas_len[] = {
 #if defined(MBEDTLS_RSA_C) && defined(MBEDTLS_MD_CAN_SHA256)
     sizeof(mbedtls_test_ca_crt_rsa_sha256),
 #endif
-#if defined(MBEDTLS_PK_CAN_ECDSA_SOME)
+#if defined(MBEDTLS_PK_CAN_ECDSA_SOME) && \
+    defined(MBEDTLS_ECP_HAVE_SECP384R1) && \
+    defined(MBEDTLS_MD_CAN_SHA256)
     sizeof(mbedtls_test_ca_crt_ec),
 #endif
     0
@@ -440,7 +444,9 @@ const unsigned char *mbedtls_test_cas_der[] = {
     mbedtls_test_ca_crt_rsa_sha1_der,
 #endif /* MBEDTLS_MD_CAN_SHA1 */
 #endif /* MBEDTLS_RSA_C */
-#if defined(MBEDTLS_PK_CAN_ECDSA_SOME)
+#if defined(MBEDTLS_PK_CAN_ECDSA_SOME) && \
+    defined(MBEDTLS_ECP_HAVE_SECP384R1) && \
+    defined(MBEDTLS_MD_CAN_SHA256)
     mbedtls_test_ca_crt_ec_der,
 #endif /* MBEDTLS_PK_CAN_ECDSA_SOME */
     NULL
@@ -455,7 +461,9 @@ const size_t mbedtls_test_cas_der_len[] = {
     sizeof(mbedtls_test_ca_crt_rsa_sha1_der),
 #endif /* MBEDTLS_MD_CAN_SHA1 */
 #endif /* MBEDTLS_RSA_C */
-#if defined(MBEDTLS_PK_CAN_ECDSA_SOME)
+#if defined(MBEDTLS_PK_CAN_ECDSA_SOME) && \
+    defined(MBEDTLS_ECP_HAVE_SECP384R1) && \
+    defined(MBEDTLS_MD_CAN_SHA256)
     sizeof(mbedtls_test_ca_crt_ec_der),
 #endif /* MBEDTLS_PK_CAN_ECDSA_SOME */
     0

--- a/tests/src/test_helpers/ssl_helpers.c
+++ b/tests/src/test_helpers/ssl_helpers.c
@@ -70,7 +70,7 @@ void mbedtls_test_init_handshake_options(
     opts->server_min_version = MBEDTLS_SSL_VERSION_UNKNOWN;
     opts->server_max_version = MBEDTLS_SSL_VERSION_UNKNOWN;
     opts->expected_negotiated_version = MBEDTLS_SSL_VERSION_TLS1_3;
-    opts->pk_alg = MBEDTLS_PK_RSA;
+    opts->pk_alg = MBEDTLS_PK_NONE;
     opts->srv_auth_mode = MBEDTLS_SSL_VERIFY_NONE;
     opts->mfl = MBEDTLS_SSL_MAX_FRAG_LEN_NONE;
     opts->cli_msg_len = 100;
@@ -894,11 +894,21 @@ int mbedtls_test_ssl_endpoint_init(
 #endif /* MBEDTLS_DEBUG_C */
 
 #if defined(MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED)
-    ret = mbedtls_test_ssl_endpoint_certificate_init(ep, options->pk_alg,
-                                                     options->opaque_alg,
-                                                     options->opaque_alg2,
-                                                     options->opaque_usage);
-    TEST_EQUAL(ret, 0);
+    if (options->pk_alg == MBEDTLS_PK_NONE) {
+#if defined(MBEDTLS_TEST_SSL_ENDPOINT_DEFAULT_CERT_ECDSA)
+        options->pk_alg = MBEDTLS_PK_ECDSA;
+#elif defined(MBEDTLS_TEST_SSL_ENDPOINT_DEFAULT_CERT_RSA)
+        options->pk_alg = MBEDTLS_PK_RSA;
+#endif
+    }
+    if (options->pk_alg != MBEDTLS_PK_NONE) {
+        ret = mbedtls_test_ssl_endpoint_certificate_init(ep, options->pk_alg,
+                                                         options->opaque_alg,
+                                                         options->opaque_alg2,
+                                                         options->opaque_usage);
+        TEST_EQUAL(ret, 0);
+    }
+#endif
 
 #if defined(MBEDTLS_SSL_HANDSHAKE_WITH_PSK_ENABLED)
     const char *const psk_identity = "Client_identity";

--- a/tests/src/test_helpers/ssl_helpers.c
+++ b/tests/src/test_helpers/ssl_helpers.c
@@ -745,6 +745,10 @@ exit:
     return ret;
 }
 
+#endif  /* MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED */
+
+#if defined(MBEDTLS_TEST_SSL_ENDPOINT)
+
 int mbedtls_test_ssl_endpoint_init(
     mbedtls_test_ssl_endpoint *ep, int endpoint_type,
     mbedtls_test_handshake_test_options *options,
@@ -891,11 +895,13 @@ int mbedtls_test_ssl_endpoint_init(
 #endif
 #endif /* MBEDTLS_DEBUG_C */
 
+#if defined(MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED)
     ret = mbedtls_test_ssl_endpoint_certificate_init(ep, options->pk_alg,
                                                      options->opaque_alg,
                                                      options->opaque_alg2,
                                                      options->opaque_usage);
     TEST_ASSERT(ret == 0);
+#endif
 
     TEST_EQUAL(mbedtls_ssl_conf_get_user_data_n(&ep->conf), user_data_n);
     mbedtls_ssl_conf_set_user_data_p(&ep->conf, ep);
@@ -910,7 +916,9 @@ void mbedtls_test_ssl_endpoint_free(
     mbedtls_test_ssl_endpoint *ep,
     mbedtls_test_message_socket_context *context)
 {
+#if defined(MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED)
     test_ssl_endpoint_certificate_free(ep);
+#endif
 
     mbedtls_ssl_free(&(ep->ssl));
     mbedtls_ssl_config_free(&(ep->conf));
@@ -958,7 +966,7 @@ int mbedtls_test_move_handshake_to_state(mbedtls_ssl_context *ssl,
     return (max_steps >= 0) ? ret : -1;
 }
 
-#endif /* MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED */
+#endif /* MBEDTLS_TEST_SSL_ENDPOINT */
 
 /*
  * Write application data. Increase write counter if necessary.

--- a/tests/src/test_helpers/ssl_helpers.c
+++ b/tests/src/test_helpers/ssl_helpers.c
@@ -747,8 +747,6 @@ exit:
 
 #endif  /* MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED */
 
-#if defined(MBEDTLS_TEST_SSL_ENDPOINT)
-
 int mbedtls_test_ssl_endpoint_init(
     mbedtls_test_ssl_endpoint *ep, int endpoint_type,
     mbedtls_test_handshake_test_options *options,
@@ -976,8 +974,6 @@ int mbedtls_test_move_handshake_to_state(mbedtls_ssl_context *ssl,
 
     return (max_steps >= 0) ? ret : -1;
 }
-
-#endif /* MBEDTLS_TEST_SSL_ENDPOINT */
 
 /*
  * Write application data. Increase write counter if necessary.

--- a/tests/src/test_helpers/ssl_helpers.c
+++ b/tests/src/test_helpers/ssl_helpers.c
@@ -636,7 +636,7 @@ int mbedtls_test_ssl_endpoint_certificate_init(mbedtls_test_ssl_endpoint *ep,
             cert->ca_cert,
             (const unsigned char *) mbedtls_test_cas_der[i],
             mbedtls_test_cas_der_len[i]);
-        TEST_ASSERT(ret == 0);
+        TEST_EQUAL(ret, 0);
     }
 
     /* Load own certificate and private key */
@@ -647,27 +647,27 @@ int mbedtls_test_ssl_endpoint_certificate_init(mbedtls_test_ssl_endpoint *ep,
                 cert->cert,
                 (const unsigned char *) mbedtls_test_srv_crt_rsa_sha256_der,
                 mbedtls_test_srv_crt_rsa_sha256_der_len);
-            TEST_ASSERT(ret == 0);
+            TEST_EQUAL(ret, 0);
 
             ret = mbedtls_pk_parse_key(
                 cert->pkey,
                 (const unsigned char *) mbedtls_test_srv_key_rsa_der,
                 mbedtls_test_srv_key_rsa_der_len, NULL, 0,
                 mbedtls_test_rnd_std_rand, NULL);
-            TEST_ASSERT(ret == 0);
+            TEST_EQUAL(ret, 0);
         } else {
             ret = mbedtls_x509_crt_parse(
                 cert->cert,
                 (const unsigned char *) mbedtls_test_srv_crt_ec_der,
                 mbedtls_test_srv_crt_ec_der_len);
-            TEST_ASSERT(ret == 0);
+            TEST_EQUAL(ret, 0);
 
             ret = mbedtls_pk_parse_key(
                 cert->pkey,
                 (const unsigned char *) mbedtls_test_srv_key_ec_der,
                 mbedtls_test_srv_key_ec_der_len, NULL, 0,
                 mbedtls_test_rnd_std_rand, NULL);
-            TEST_ASSERT(ret == 0);
+            TEST_EQUAL(ret, 0);
         }
     } else {
         if (pk_alg == MBEDTLS_PK_RSA) {
@@ -675,27 +675,27 @@ int mbedtls_test_ssl_endpoint_certificate_init(mbedtls_test_ssl_endpoint *ep,
                 cert->cert,
                 (const unsigned char *) mbedtls_test_cli_crt_rsa_der,
                 mbedtls_test_cli_crt_rsa_der_len);
-            TEST_ASSERT(ret == 0);
+            TEST_EQUAL(ret, 0);
 
             ret = mbedtls_pk_parse_key(
                 cert->pkey,
                 (const unsigned char *) mbedtls_test_cli_key_rsa_der,
                 mbedtls_test_cli_key_rsa_der_len, NULL, 0,
                 mbedtls_test_rnd_std_rand, NULL);
-            TEST_ASSERT(ret == 0);
+            TEST_EQUAL(ret, 0);
         } else {
             ret = mbedtls_x509_crt_parse(
                 cert->cert,
                 (const unsigned char *) mbedtls_test_cli_crt_ec_der,
                 mbedtls_test_cli_crt_ec_len);
-            TEST_ASSERT(ret == 0);
+            TEST_EQUAL(ret, 0);
 
             ret = mbedtls_pk_parse_key(
                 cert->pkey,
                 (const unsigned char *) mbedtls_test_cli_key_ec_der,
                 mbedtls_test_cli_key_ec_der_len, NULL, 0,
                 mbedtls_test_rnd_std_rand, NULL);
-            TEST_ASSERT(ret == 0);
+            TEST_EQUAL(ret, 0);
         }
     }
 
@@ -726,16 +726,16 @@ int mbedtls_test_ssl_endpoint_certificate_init(mbedtls_test_ssl_endpoint *ep,
 
     ret = mbedtls_ssl_conf_own_cert(&(ep->conf), cert->cert,
                                     cert->pkey);
-    TEST_ASSERT(ret == 0);
+    TEST_EQUAL(ret, 0);
     TEST_ASSERT(ep->conf.key_cert != NULL);
 
     ret = mbedtls_ssl_conf_own_cert(&(ep->conf), NULL, NULL);
-    TEST_ASSERT(ret == 0);
+    TEST_EQUAL(ret, 0);
     TEST_ASSERT(ep->conf.key_cert == NULL);
 
     ret = mbedtls_ssl_conf_own_cert(&(ep->conf), cert->cert,
                                     cert->pkey);
-    TEST_ASSERT(ret == 0);
+    TEST_EQUAL(ret, 0);
 
 exit:
     if (ret != 0) {
@@ -814,7 +814,7 @@ int mbedtls_test_ssl_endpoint_init(
                                       MBEDTLS_SSL_TRANSPORT_DATAGRAM :
                                       MBEDTLS_SSL_TRANSPORT_STREAM,
                                       MBEDTLS_SSL_PRESET_DEFAULT);
-    TEST_ASSERT(ret == 0);
+    TEST_EQUAL(ret, 0);
 
     if (MBEDTLS_SSL_IS_CLIENT == endpoint_type) {
         if (options->client_min_version != MBEDTLS_SSL_VERSION_UNKNOWN) {
@@ -870,7 +870,7 @@ int mbedtls_test_ssl_endpoint_init(
 #endif
 
     ret = mbedtls_ssl_setup(&(ep->ssl), &(ep->conf));
-    TEST_ASSERT(ret == 0);
+    TEST_EQUAL(ret, 0);
 
 #if defined(MBEDTLS_SSL_PROTO_DTLS) && defined(MBEDTLS_SSL_SRV_C)
     if (endpoint_type == MBEDTLS_SSL_IS_SERVER && dtls_context != NULL) {
@@ -900,7 +900,7 @@ int mbedtls_test_ssl_endpoint_init(
                                                      options->opaque_alg,
                                                      options->opaque_alg2,
                                                      options->opaque_usage);
-    TEST_ASSERT(ret == 0);
+    TEST_EQUAL(ret, 0);
 #endif
 
     TEST_EQUAL(mbedtls_ssl_conf_get_user_data_n(&ep->conf), user_data_n);
@@ -980,7 +980,7 @@ static int mbedtls_ssl_write_fragment(mbedtls_ssl_context *ssl,
     /* Verify that calling mbedtls_ssl_write with a NULL buffer and zero length is
      * a valid no-op for TLS connections. */
     if (ssl->conf->transport != MBEDTLS_SSL_TRANSPORT_DATAGRAM) {
-        TEST_ASSERT(mbedtls_ssl_write(ssl, NULL, 0) == 0);
+        TEST_EQUAL(mbedtls_ssl_write(ssl, NULL, 0), 0);
     }
 
     ret = mbedtls_ssl_write(ssl, buf + *written, buf_len - *written);
@@ -1027,7 +1027,7 @@ static int mbedtls_ssl_read_fragment(mbedtls_ssl_context *ssl,
     /* Verify that calling mbedtls_ssl_write with a NULL buffer and zero length is
      * a valid no-op for TLS connections. */
     if (ssl->conf->transport != MBEDTLS_SSL_TRANSPORT_DATAGRAM) {
-        TEST_ASSERT(mbedtls_ssl_read(ssl, NULL, 0) == 0);
+        TEST_EQUAL(mbedtls_ssl_read(ssl, NULL, 0), 0);
     }
 
     ret = mbedtls_ssl_read(ssl, buf + *read, buf_len - *read);
@@ -1037,7 +1037,7 @@ static int mbedtls_ssl_read_fragment(mbedtls_ssl_context *ssl,
     }
 
     if (expected_fragments == 0) {
-        TEST_ASSERT(ret == 0);
+        TEST_EQUAL(ret, 0);
     } else if (expected_fragments == 1) {
         TEST_ASSERT(ret == buf_len ||
                     ret == MBEDTLS_ERR_SSL_WANT_READ ||
@@ -1924,10 +1924,10 @@ int mbedtls_test_ssl_exchange_data(
                 if (expected_fragments_1 == 0) {
                     /* This error is expected when the message is too large and
                      * cannot be fragmented */
-                    TEST_ASSERT(ret == MBEDTLS_ERR_SSL_BAD_INPUT_DATA);
+                    TEST_EQUAL(ret, MBEDTLS_ERR_SSL_BAD_INPUT_DATA);
                     msg_len_1 = 0;
                 } else {
-                    TEST_ASSERT(ret == 0);
+                    TEST_EQUAL(ret, 0);
                 }
             }
 
@@ -1939,10 +1939,10 @@ int mbedtls_test_ssl_exchange_data(
                 if (expected_fragments_2 == 0) {
                     /* This error is expected when the message is too large and
                      * cannot be fragmented */
-                    TEST_ASSERT(ret == MBEDTLS_ERR_SSL_BAD_INPUT_DATA);
+                    TEST_EQUAL(ret, MBEDTLS_ERR_SSL_BAD_INPUT_DATA);
                     msg_len_2 = 0;
                 } else {
-                    TEST_ASSERT(ret == 0);
+                    TEST_EQUAL(ret, 0);
                 }
             }
 
@@ -1952,7 +1952,7 @@ int mbedtls_test_ssl_exchange_data(
                                                 msg_len_2, &read_1,
                                                 &fragments_2,
                                                 expected_fragments_2);
-                TEST_ASSERT(ret == 0);
+                TEST_EQUAL(ret, 0);
             }
 
             /* ssl_2 reading */
@@ -1961,15 +1961,15 @@ int mbedtls_test_ssl_exchange_data(
                                                 msg_len_1, &read_2,
                                                 &fragments_1,
                                                 expected_fragments_1);
-                TEST_ASSERT(ret == 0);
+                TEST_EQUAL(ret, 0);
             }
         }
 
         ret = -1;
         TEST_ASSERT(0 == memcmp(msg_buf_1, in_buf_2, msg_len_1));
         TEST_ASSERT(0 == memcmp(msg_buf_2, in_buf_1, msg_len_2));
-        TEST_ASSERT(fragments_1 == expected_fragments_1);
-        TEST_ASSERT(fragments_2 == expected_fragments_2);
+        TEST_EQUAL(fragments_1, expected_fragments_1);
+        TEST_EQUAL(fragments_2, expected_fragments_2);
     }
 
     ret = 0;
@@ -2021,12 +2021,12 @@ static int check_ssl_version(
     switch (expected_negotiated_version) {
         case MBEDTLS_SSL_VERSION_TLS1_2:
             TEST_EQUAL(version_number, MBEDTLS_SSL_VERSION_TLS1_2);
-            TEST_ASSERT(strcmp(version_string, "TLSv1.2") == 0);
+            TEST_EQUAL(strcmp(version_string, "TLSv1.2"), 0);
             break;
 
         case MBEDTLS_SSL_VERSION_TLS1_3:
             TEST_EQUAL(version_number, MBEDTLS_SSL_VERSION_TLS1_3);
-            TEST_ASSERT(strcmp(version_string, "TLSv1.3") == 0);
+            TEST_EQUAL(strcmp(version_string, "TLSv1.3"), 0);
             break;
 
         default:
@@ -2130,7 +2130,7 @@ void mbedtls_test_ssl_perform_handshake(
                                               (unsigned char) options->mfl)
                 == 0);
 #else
-    TEST_ASSERT(MBEDTLS_SSL_MAX_FRAG_LEN_NONE == options->mfl);
+    TEST_EQUAL(MBEDTLS_SSL_MAX_FRAG_LEN_NONE, options->mfl);
 #endif /* MBEDTLS_SSL_MAX_FRAGMENT_LENGTH */
 
 #if defined(MBEDTLS_SSL_HANDSHAKE_WITH_PSK_ENABLED)
@@ -2172,10 +2172,10 @@ void mbedtls_test_ssl_perform_handshake(
 #if defined(MBEDTLS_SSL_VARIABLE_BUFFER_LENGTH)
     if (options->resize_buffers != 0) {
         /* Ensure that the buffer sizes are appropriate before resizes */
-        TEST_ASSERT(client.ssl.out_buf_len == MBEDTLS_SSL_OUT_BUFFER_LEN);
-        TEST_ASSERT(client.ssl.in_buf_len == MBEDTLS_SSL_IN_BUFFER_LEN);
-        TEST_ASSERT(server.ssl.out_buf_len == MBEDTLS_SSL_OUT_BUFFER_LEN);
-        TEST_ASSERT(server.ssl.in_buf_len == MBEDTLS_SSL_IN_BUFFER_LEN);
+        TEST_EQUAL(client.ssl.out_buf_len, MBEDTLS_SSL_OUT_BUFFER_LEN);
+        TEST_EQUAL(client.ssl.in_buf_len, MBEDTLS_SSL_IN_BUFFER_LEN);
+        TEST_EQUAL(server.ssl.out_buf_len, MBEDTLS_SSL_OUT_BUFFER_LEN);
+        TEST_EQUAL(server.ssl.in_buf_len, MBEDTLS_SSL_IN_BUFFER_LEN);
     }
 #endif
 
@@ -2193,7 +2193,7 @@ void mbedtls_test_ssl_perform_handshake(
         goto exit;
     }
 
-    TEST_ASSERT(mbedtls_ssl_is_handshake_over(&client.ssl) == 1);
+    TEST_EQUAL(mbedtls_ssl_is_handshake_over(&client.ssl), 1);
 
     /* Make sure server state is moved to HANDSHAKE_OVER also. */
     TEST_EQUAL(mbedtls_test_move_handshake_to_state(&(server.ssl),
@@ -2201,7 +2201,7 @@ void mbedtls_test_ssl_perform_handshake(
                                                     MBEDTLS_SSL_HANDSHAKE_OVER),
                0);
 
-    TEST_ASSERT(mbedtls_ssl_is_handshake_over(&server.ssl) == 1);
+    TEST_EQUAL(mbedtls_ssl_is_handshake_over(&server.ssl), 1);
     /* Check that both sides have negotiated the expected version. */
     mbedtls_test_set_step(0);
     if (!check_ssl_version(options->expected_negotiated_version,
@@ -2224,16 +2224,16 @@ void mbedtls_test_ssl_perform_handshake(
     if (options->resize_buffers != 0) {
         /* A server, when using DTLS, might delay a buffer resize to happen
          * after it receives a message, so we force it. */
-        TEST_ASSERT(exchange_data(&(client.ssl), &(server.ssl)) == 0);
+        TEST_EQUAL(exchange_data(&(client.ssl), &(server.ssl)), 0);
 
-        TEST_ASSERT(client.ssl.out_buf_len ==
-                    mbedtls_ssl_get_output_buflen(&client.ssl));
-        TEST_ASSERT(client.ssl.in_buf_len ==
-                    mbedtls_ssl_get_input_buflen(&client.ssl));
-        TEST_ASSERT(server.ssl.out_buf_len ==
-                    mbedtls_ssl_get_output_buflen(&server.ssl));
-        TEST_ASSERT(server.ssl.in_buf_len ==
-                    mbedtls_ssl_get_input_buflen(&server.ssl));
+        TEST_EQUAL(client.ssl.out_buf_len,
+                   mbedtls_ssl_get_output_buflen(&client.ssl));
+        TEST_EQUAL(client.ssl.in_buf_len,
+                   mbedtls_ssl_get_input_buflen(&client.ssl));
+        TEST_EQUAL(server.ssl.out_buf_len,
+                   mbedtls_ssl_get_output_buflen(&server.ssl));
+        TEST_EQUAL(server.ssl.in_buf_len,
+                   mbedtls_ssl_get_input_buflen(&server.ssl));
     }
 #endif
 
@@ -2248,7 +2248,7 @@ void mbedtls_test_ssl_perform_handshake(
     }
 #if defined(MBEDTLS_SSL_CONTEXT_SERIALIZATION)
     if (options->serialize == 1) {
-        TEST_ASSERT(options->dtls == 1);
+        TEST_EQUAL(options->dtls, 1);
 
         TEST_ASSERT(mbedtls_ssl_context_save(&(server.ssl), NULL,
                                              0, &context_buf_len)
@@ -2265,7 +2265,7 @@ void mbedtls_test_ssl_perform_handshake(
         mbedtls_ssl_free(&(server.ssl));
         mbedtls_ssl_init(&(server.ssl));
 
-        TEST_ASSERT(mbedtls_ssl_setup(&(server.ssl), &(server.conf)) == 0);
+        TEST_EQUAL(mbedtls_ssl_setup(&(server.ssl), &(server.conf)), 0);
 
         mbedtls_ssl_set_bio(&(server.ssl), &server_context,
                             mbedtls_test_mock_tcp_send_msg,
@@ -2282,8 +2282,8 @@ void mbedtls_test_ssl_perform_handshake(
 #if defined(MBEDTLS_SSL_VARIABLE_BUFFER_LENGTH)
         if (options->resize_buffers != 0) {
             /* Ensure that the buffer sizes are appropriate before resizes */
-            TEST_ASSERT(server.ssl.out_buf_len == MBEDTLS_SSL_OUT_BUFFER_LEN);
-            TEST_ASSERT(server.ssl.in_buf_len == MBEDTLS_SSL_IN_BUFFER_LEN);
+            TEST_EQUAL(server.ssl.out_buf_len, MBEDTLS_SSL_OUT_BUFFER_LEN);
+            TEST_EQUAL(server.ssl.in_buf_len, MBEDTLS_SSL_IN_BUFFER_LEN);
         }
 #endif
         TEST_ASSERT(mbedtls_ssl_context_load(&(server.ssl), context_buf,
@@ -2292,10 +2292,10 @@ void mbedtls_test_ssl_perform_handshake(
 #if defined(MBEDTLS_SSL_VARIABLE_BUFFER_LENGTH)
         /* Validate buffer sizes after context deserialization */
         if (options->resize_buffers != 0) {
-            TEST_ASSERT(server.ssl.out_buf_len ==
-                        mbedtls_ssl_get_output_buflen(&server.ssl));
-            TEST_ASSERT(server.ssl.in_buf_len ==
-                        mbedtls_ssl_get_input_buflen(&server.ssl));
+            TEST_EQUAL(server.ssl.out_buf_len,
+                       mbedtls_ssl_get_output_buflen(&server.ssl));
+            TEST_EQUAL(server.ssl.in_buf_len,
+                       mbedtls_ssl_get_input_buflen(&server.ssl));
         }
 #endif
         /* Retest writing/reading */
@@ -2313,24 +2313,18 @@ void mbedtls_test_ssl_perform_handshake(
 #if defined(MBEDTLS_SSL_RENEGOTIATION)
     if (options->renegotiate) {
         /* Start test with renegotiation */
-        TEST_ASSERT(server.ssl.renego_status ==
-                    MBEDTLS_SSL_INITIAL_HANDSHAKE);
-        TEST_ASSERT(client.ssl.renego_status ==
-                    MBEDTLS_SSL_INITIAL_HANDSHAKE);
+        TEST_EQUAL(server.ssl.renego_status, MBEDTLS_SSL_INITIAL_HANDSHAKE);
+        TEST_EQUAL(client.ssl.renego_status, MBEDTLS_SSL_INITIAL_HANDSHAKE);
 
         /* After calling this function for the server, it only sends a handshake
          * request. All renegotiation should happen during data exchanging */
-        TEST_ASSERT(mbedtls_ssl_renegotiate(&(server.ssl)) == 0);
-        TEST_ASSERT(server.ssl.renego_status ==
-                    MBEDTLS_SSL_RENEGOTIATION_PENDING);
-        TEST_ASSERT(client.ssl.renego_status ==
-                    MBEDTLS_SSL_INITIAL_HANDSHAKE);
+        TEST_EQUAL(mbedtls_ssl_renegotiate(&(server.ssl)), 0);
+        TEST_EQUAL(server.ssl.renego_status, MBEDTLS_SSL_RENEGOTIATION_PENDING);
+        TEST_EQUAL(client.ssl.renego_status, MBEDTLS_SSL_INITIAL_HANDSHAKE);
 
-        TEST_ASSERT(exchange_data(&(client.ssl), &(server.ssl)) == 0);
-        TEST_ASSERT(server.ssl.renego_status ==
-                    MBEDTLS_SSL_RENEGOTIATION_DONE);
-        TEST_ASSERT(client.ssl.renego_status ==
-                    MBEDTLS_SSL_RENEGOTIATION_DONE);
+        TEST_EQUAL(exchange_data(&(client.ssl), &(server.ssl)), 0);
+        TEST_EQUAL(server.ssl.renego_status, MBEDTLS_SSL_RENEGOTIATION_DONE);
+        TEST_EQUAL(client.ssl.renego_status, MBEDTLS_SSL_RENEGOTIATION_DONE);
 
         /* After calling mbedtls_ssl_renegotiate for the client,
          * all renegotiation should happen inside this function.
@@ -2342,34 +2336,30 @@ void mbedtls_test_ssl_perform_handshake(
 #if defined(MBEDTLS_SSL_VARIABLE_BUFFER_LENGTH)
         if (options->resize_buffers != 0) {
             /* Ensure that the buffer sizes are appropriate before resizes */
-            TEST_ASSERT(client.ssl.out_buf_len == MBEDTLS_SSL_OUT_BUFFER_LEN);
-            TEST_ASSERT(client.ssl.in_buf_len == MBEDTLS_SSL_IN_BUFFER_LEN);
+            TEST_EQUAL(client.ssl.out_buf_len, MBEDTLS_SSL_OUT_BUFFER_LEN);
+            TEST_EQUAL(client.ssl.in_buf_len, MBEDTLS_SSL_IN_BUFFER_LEN);
         }
 #endif
         TEST_ASSERT(ret == 0 ||
                     ret == MBEDTLS_ERR_SSL_WANT_READ ||
                     ret == MBEDTLS_ERR_SSL_WANT_WRITE);
-        TEST_ASSERT(server.ssl.renego_status ==
-                    MBEDTLS_SSL_RENEGOTIATION_DONE);
-        TEST_ASSERT(client.ssl.renego_status ==
-                    MBEDTLS_SSL_RENEGOTIATION_IN_PROGRESS);
+        TEST_EQUAL(server.ssl.renego_status, MBEDTLS_SSL_RENEGOTIATION_DONE);
+        TEST_EQUAL(client.ssl.renego_status, MBEDTLS_SSL_RENEGOTIATION_IN_PROGRESS);
 
         TEST_ASSERT(exchange_data(&(client.ssl), &(server.ssl)) == 0);
-        TEST_ASSERT(server.ssl.renego_status ==
-                    MBEDTLS_SSL_RENEGOTIATION_DONE);
-        TEST_ASSERT(client.ssl.renego_status ==
-                    MBEDTLS_SSL_RENEGOTIATION_DONE);
+        TEST_EQUAL(server.ssl.renego_status, MBEDTLS_SSL_RENEGOTIATION_DONE);
+        TEST_EQUAL(client.ssl.renego_status, MBEDTLS_SSL_RENEGOTIATION_DONE);
 #if defined(MBEDTLS_SSL_VARIABLE_BUFFER_LENGTH)
         /* Validate buffer sizes after renegotiation */
         if (options->resize_buffers != 0) {
-            TEST_ASSERT(client.ssl.out_buf_len ==
-                        mbedtls_ssl_get_output_buflen(&client.ssl));
-            TEST_ASSERT(client.ssl.in_buf_len ==
-                        mbedtls_ssl_get_input_buflen(&client.ssl));
-            TEST_ASSERT(server.ssl.out_buf_len ==
-                        mbedtls_ssl_get_output_buflen(&server.ssl));
-            TEST_ASSERT(server.ssl.in_buf_len ==
-                        mbedtls_ssl_get_input_buflen(&server.ssl));
+            TEST_EQUAL(client.ssl.out_buf_len,
+                       mbedtls_ssl_get_output_buflen(&client.ssl));
+            TEST_EQUAL(client.ssl.in_buf_len,
+                       mbedtls_ssl_get_input_buflen(&client.ssl));
+            TEST_EQUAL(server.ssl.out_buf_len,
+                       mbedtls_ssl_get_output_buflen(&server.ssl));
+            TEST_EQUAL(server.ssl.in_buf_len,
+                       mbedtls_ssl_get_input_buflen(&server.ssl));
         }
 #endif /* MBEDTLS_SSL_VARIABLE_BUFFER_LENGTH */
     }

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -3135,6 +3135,27 @@ void recombine_server_first_flight(int version,
     mbedtls_debug_set_threshold(3);
 #endif
 
+#if defined(MBEDTLS_SSL_HANDSHAKE_WITH_PSK_ENABLED)
+    int want_psk = 0;
+    /* In TLS 1.2, we can set a PSK even if it isn't needed. */
+    if (version <= MBEDTLS_SSL_VERSION_TLS1_2) {
+        want_psk = 1;
+    }
+    /* In TLS 1.3, only set a PSK if needed.
+     * https://github.com/Mbed-TLS/mbedtls/issues/10071
+     */
+#if !defined(MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED)
+    if (version == MBEDTLS_SSL_VERSION_TLS1_3) {
+        want_psk = 1;
+    }
+#endif
+    data_t psk = {.x = (unsigned char *) "swordfish", .len = 9};
+    if (want_psk) {
+        client_options.psk_str = &psk;
+        server_options.psk_str = &psk;
+    }
+#endif
+
     client_options.client_min_version = version;
     client_options.client_max_version = version;
 #if defined(MBEDTLS_DEBUG_C)
@@ -3176,7 +3197,15 @@ void recombine_server_first_flight(int version,
     }
     TEST_EQUAL(ret, MBEDTLS_ERR_SSL_WANT_READ);
     ret = 0;
-    TEST_EQUAL(server.ssl.state, MBEDTLS_SSL_SERVER_HELLO_DONE + 1);
+#if defined(MBEDTLS_TEST_SSL_ENDPOINT_DEFAULT_CERTS)
+    TEST_EQUAL(server.ssl.state, MBEDTLS_SSL_CLIENT_CERTIFICATE);
+#else
+    if (version >= MBEDTLS_SSL_VERSION_TLS1_3) {
+        TEST_EQUAL(server.ssl.state, MBEDTLS_SSL_CLIENT_FINISHED);
+    } else {
+        TEST_EQUAL(server.ssl.state, MBEDTLS_SSL_CLIENT_KEY_EXCHANGE);
+    }
+#endif
 
     /* Recombine the first flight from the server */
     TEST_ASSERT(recombine_records(&server, instruction, param));

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -67,6 +67,7 @@ typedef enum {
     RECOMBINE_NOMINAL,          /* param: ignored */
     RECOMBINE_SPLIT_FIRST,      /* param: offset of split (<=0 means from end) */
     RECOMBINE_INSERT_EMPTY,     /* param: offset (<0 means from end) */
+    RECOMBINE_INSERT_RECORD,    /* param: record type */
     RECOMBINE_COALESCE,         /* param: min number of records */
     RECOMBINE_COALESCE_SPLIT_ONCE, /* param: offset of split (<=0 means from end) */
     RECOMBINE_COALESCE_SPLIT_ENDS, /* the hairiest one? param: offset, must be >0 */
@@ -118,8 +119,9 @@ exit:
 
 /* Insert an empty record at the given offset. If offset is negative,
  * count from the end of the first record. */
-static int recombine_insert_empty_record(mbedtls_test_ssl_buffer *buf,
-                                         int offset)
+static int recombine_insert_record(mbedtls_test_ssl_buffer *buf,
+                                   int offset,
+                                   uint8_t inserted_record_type)
 {
     const size_t header_length = 5;
     TEST_LE_U(header_length, buf->content_length);
@@ -132,22 +134,50 @@ static int recombine_insert_empty_record(mbedtls_test_ssl_buffer *buf,
         offset = record_length + offset;
     }
 
-    /* Check that we have room to insert two record headers */
-    TEST_LE_U(buf->content_length + 2 * header_length, buf->capacity);
+    uint8_t inserted_content[42] = { 0 };
+    size_t inserted_content_length = 0;
+    switch (inserted_record_type) {
+        case MBEDTLS_SSL_MSG_ALERT:
+            inserted_content[0] = MBEDTLS_SSL_ALERT_LEVEL_WARNING;
+            inserted_content[1] = MBEDTLS_SSL_ALERT_MSG_NO_RENEGOTIATION;
+            inserted_content_length = 2;
+            break;
+        case MBEDTLS_SSL_MSG_CHANGE_CIPHER_SPEC:
+            inserted_content[0] = 0x01;
+            inserted_content_length = 1;
+            break;
+        case MBEDTLS_SSL_MSG_APPLICATION_DATA:
+            inserted_content_length = sizeof(inserted_content);
+            break;
+        default:
+            /* Leave the content empty */
+            break;
+    }
+
+    /* Check that we have room to insert two record headers plus the new
+     * content. */
+    TEST_LE_U(buf->content_length + 2 * header_length + inserted_content_length,
+              buf->capacity);
 
     /* Make room for an empty record and a record header */
-    size_t empty_record_start = header_length + offset;
-    size_t empty_content_start = empty_record_start + header_length;
-    size_t tail_record_start = empty_content_start;
+    size_t inserted_record_start = header_length + offset;
+    size_t inserted_content_start = inserted_record_start + header_length;
+    size_t tail_record_start = inserted_content_start + inserted_content_length;
     size_t tail_content_start = tail_record_start + header_length;
     memmove(buf->buffer + tail_content_start,
             buf->buffer + tail_record_start,
             buf->content_length - tail_record_start);
     buf->content_length += 2 * header_length;
 
-    /* Construct headers for the new records based on the existing one */
-    memcpy(buf->buffer + empty_record_start, buf->buffer, header_length);
-    MBEDTLS_PUT_UINT16_BE(0, buf->buffer, empty_content_start - 2);
+    /* Construct the inserted record based on the existing one */
+    memcpy(buf->buffer + inserted_record_start, buf->buffer, header_length);
+    buf->buffer[inserted_record_start] = inserted_record_type;
+    MBEDTLS_PUT_UINT16_BE(inserted_content_length,
+                          buf->buffer, inserted_content_start - 2);
+    memcpy(buf->buffer + inserted_content_start,
+           inserted_content, inserted_content_length);
+
+    /* Construct header for the last fragment based on the existing one */
     memcpy(buf->buffer + tail_record_start, buf->buffer, header_length);
     MBEDTLS_PUT_UINT16_BE(record_length - offset,
                           buf->buffer, tail_content_start - 2);
@@ -235,7 +265,15 @@ static int recombine_records(mbedtls_test_ssl_endpoint *server,
             break;
 
         case RECOMBINE_INSERT_EMPTY:
-            ret = recombine_insert_empty_record(buf, param);
+            /* Insert an empty handshake record. */
+            ret = recombine_insert_record(buf, param, MBEDTLS_SSL_MSG_HANDSHAKE);
+            TEST_LE_S(0, ret);
+            break;
+
+        case RECOMBINE_INSERT_RECORD:
+            /* Insert an extra record at a position where splitting
+             * would be ok. */
+            ret = recombine_insert_record(buf, 5, param);
             TEST_LE_S(0, ret);
             break;
 

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -65,8 +65,99 @@ exit:
 
 typedef enum {
     RECOMBINE_NOMINAL,          /* param: ignored */
+    RECOMBINE_SPLIT_FIRST,      /* param: offset of split (<=0 means from end) */
+    RECOMBINE_INSERT_EMPTY,     /* param: offset (<0 means from end) */
     RECOMBINE_COALESCE,         /* param: min number of records */
+    RECOMBINE_COALESCE_SPLIT_ONCE, /* param: offset of split (<=0 means from end) */
+    RECOMBINE_COALESCE_SPLIT_ENDS, /* the hairiest one? param: offset, must be >0 */
 } recombine_records_instruction_t;
+
+/* Split the first record into two pieces of lengths offset and
+ * record_length-offset. If offset is zero or negative, count from the end of
+ * the record. */
+static int recombine_split_first_record(mbedtls_test_ssl_buffer *buf,
+                                        int offset)
+{
+    const size_t header_length = 5;
+    TEST_LE_U(header_length, buf->content_length);
+    size_t record_length = MBEDTLS_GET_UINT16_BE(buf->buffer, header_length - 2);
+
+    if (offset > 0) {
+        TEST_LE_S(offset, record_length);
+    } else {
+        TEST_LE_S(-offset, record_length);
+        offset = record_length + offset;
+    }
+
+    /* Check that we have room to insert a record header */
+    TEST_LE_U(buf->content_length + header_length, buf->capacity);
+
+    /* Make room for a record header */
+    size_t new_record_start = header_length + offset;
+    size_t new_content_start = new_record_start + header_length;
+    memmove(buf->buffer + new_content_start,
+            buf->buffer + new_record_start,
+            buf->content_length - new_record_start);
+    buf->content_length += header_length;
+
+    /* Construct a header for the new record based on the existing one */
+    memcpy(buf->buffer + new_record_start, buf->buffer, header_length);
+    MBEDTLS_PUT_UINT16_BE(record_length - offset,
+                          buf->buffer, new_content_start - 2);
+
+    /* Adjust the length of the first record */
+    MBEDTLS_PUT_UINT16_BE(offset, buf->buffer, header_length - 2);
+
+    return 0;
+
+exit:
+    return -1;
+}
+
+/* Insert an empty record at the given offset. If offset is negative,
+ * count from the end of the first record. */
+static int recombine_insert_empty_record(mbedtls_test_ssl_buffer *buf,
+                                         int offset)
+{
+    const size_t header_length = 5;
+    TEST_LE_U(header_length, buf->content_length);
+    size_t record_length = MBEDTLS_GET_UINT16_BE(buf->buffer, header_length - 2);
+
+    if (offset >= 0) {
+        TEST_LE_S(offset, record_length);
+    } else {
+        TEST_LE_S(-offset, record_length);
+        offset = record_length + offset;
+    }
+
+    /* Check that we have room to insert two record headers */
+    TEST_LE_U(buf->content_length + 2 * header_length, buf->capacity);
+
+    /* Make room for an empty record and a record header */
+    size_t empty_record_start = header_length + offset;
+    size_t empty_content_start = empty_record_start + header_length;
+    size_t tail_record_start = empty_content_start;
+    size_t tail_content_start = tail_record_start + header_length;
+    memmove(buf->buffer + tail_content_start,
+            buf->buffer + tail_record_start,
+            buf->content_length - tail_record_start);
+    buf->content_length += 2 * header_length;
+
+    /* Construct headers for the new records based on the existing one */
+    memcpy(buf->buffer + empty_record_start, buf->buffer, header_length);
+    MBEDTLS_PUT_UINT16_BE(0, buf->buffer, empty_content_start - 2);
+    memcpy(buf->buffer + tail_record_start, buf->buffer, header_length);
+    MBEDTLS_PUT_UINT16_BE(record_length - offset,
+                          buf->buffer, tail_content_start - 2);
+
+    /* Adjust the length of the first record */
+    MBEDTLS_PUT_UINT16_BE(offset, buf->buffer, header_length - 2);
+
+    return 0;
+
+exit:
+    return -1;
+}
 
 /* Coalesce TLS handshake records.
  * DTLS is not supported.
@@ -136,6 +227,16 @@ static int recombine_records(mbedtls_test_ssl_endpoint *server,
         case RECOMBINE_NOMINAL:
             break;
 
+        case RECOMBINE_SPLIT_FIRST:
+            ret = recombine_split_first_record(buf, param);
+            TEST_LE_S(0, ret);
+            break;
+
+        case RECOMBINE_INSERT_EMPTY:
+            ret = recombine_insert_empty_record(buf, param);
+            TEST_LE_S(0, ret);
+            break;
+
         case RECOMBINE_COALESCE:
             ret = recombine_coalesce_handshake_records(buf, param);
             if (param == INT_MAX) {
@@ -143,6 +244,27 @@ static int recombine_records(mbedtls_test_ssl_endpoint *server,
             } else {
                 TEST_EQUAL(ret, param);
             }
+            break;
+
+        case RECOMBINE_COALESCE_SPLIT_ONCE:
+            ret = recombine_coalesce_handshake_records(buf, INT_MAX);
+            /* Require at least two coalesced records, otherwise this
+             * doesn't lead to a meaningful test (use
+             * RECOMBINE_SPLIT_FIRST instead). */
+            TEST_LE_S(2, ret);
+            ret = recombine_split_first_record(buf, param);
+            TEST_LE_S(0, ret);
+            break;
+
+        case RECOMBINE_COALESCE_SPLIT_ENDS:
+            ret = recombine_coalesce_handshake_records(buf, INT_MAX);
+            /* Accept a single record, which will be split at both ends */
+            TEST_LE_S(1, ret);
+            TEST_LE_S(1, param);
+            ret = recombine_split_first_record(buf, -param);
+            TEST_LE_S(0, ret);
+            ret = recombine_split_first_record(buf, param);
+            TEST_LE_S(0, ret);
             break;
 
         default:

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -74,8 +74,6 @@ typedef enum {
     RECOMBINE_COALESCE_SPLIT_BOTH_ENDS, /* param: offset, must be >0 */
 } recombine_records_instruction_t;
 
-#if defined(MBEDTLS_TEST_SSL_ENDPOINT)
-
 /* Split the first record into two pieces of lengths offset and
  * record_length-offset. If offset is zero or negative, count from the end of
  * the record. */
@@ -362,8 +360,6 @@ static int recombine_records(mbedtls_test_ssl_endpoint *server,
 exit:
     return 0;
 }
-
-#endif /* MBEDTLS_TEST_SSL_ENDPOINT */
 
 /* END_HEADER */
 
@@ -3104,7 +3100,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_TEST_SSL_ENDPOINT */
+/* BEGIN_CASE */
 void recombine_server_first_flight(int version,
                                    int instruction, int param,
                                    char *client_log, char *server_log,

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -66,6 +66,7 @@ exit:
 typedef enum {
     RECOMBINE_NOMINAL,          /* param: ignored */
     RECOMBINE_SPLIT_FIRST,      /* param: offset of split (<=0 means from end) */
+    RECOMBINE_TRUNCATE_FIRST,   /* param: offset of truncation (<=0 means from end) */
     RECOMBINE_INSERT_EMPTY,     /* param: offset (<0 means from end) */
     RECOMBINE_INSERT_RECORD,    /* param: record type */
     RECOMBINE_COALESCE,         /* param: min number of records */
@@ -110,6 +111,39 @@ static int recombine_split_first_record(mbedtls_test_ssl_buffer *buf,
 
     /* Adjust the length of the first record */
     MBEDTLS_PUT_UINT16_BE(offset, buf->buffer, header_length - 2);
+
+    return 0;
+
+exit:
+    return -1;
+}
+
+/* Truncate the first record, keeping only the first offset bytes.
+ * If offset is zero or negative, count from the end of the record.
+ * Remove the subsequent records.
+ */
+static int recombine_truncate_first_record(mbedtls_test_ssl_buffer *buf,
+                                           int offset)
+{
+    const size_t header_length = 5;
+    TEST_LE_U(header_length, buf->content_length);
+    size_t record_length = MBEDTLS_GET_UINT16_BE(buf->buffer, header_length - 2);
+
+    if (offset > 0) {
+        TEST_LE_S(offset, record_length);
+    } else {
+        TEST_LE_S(-offset, record_length);
+        offset = record_length + offset;
+    }
+
+    /* Adjust the length of the first record */
+    MBEDTLS_PUT_UINT16_BE(offset, buf->buffer, header_length - 2);
+
+    /* Wipe the rest */
+    size_t truncated_end = header_length + offset;
+    memset(buf->buffer + truncated_end, '!',
+           buf->content_length - truncated_end);
+    buf->content_length = truncated_end;
 
     return 0;
 
@@ -261,6 +295,11 @@ static int recombine_records(mbedtls_test_ssl_endpoint *server,
 
         case RECOMBINE_SPLIT_FIRST:
             ret = recombine_split_first_record(buf, param);
+            TEST_LE_S(0, ret);
+            break;
+
+        case RECOMBINE_TRUNCATE_FIRST:
+            ret = recombine_truncate_first_record(buf, param);
             TEST_LE_S(0, ret);
             break;
 
@@ -3166,6 +3205,14 @@ void recombine_server_first_flight(int version,
 
     /* Server: parse the first flight from the client
      * and emit the second flight from the server */
+    if (instruction == RECOMBINE_TRUNCATE_FIRST) {
+        /* Close without a notification. The case of closing with a
+         * notification is tested via RECOMBINE_INSERT_RECORD to insert
+         * an alert record (which we reject, making the client SSL
+         * context become invalid). */
+        mbedtls_test_mock_socket_close(&server.socket);
+        goto goal_reached;
+    }
     while (ret == 0 && !mbedtls_ssl_is_handshake_over(&server.ssl)) {
         mbedtls_test_set_step(1000 + server.ssl.state);
         ret = mbedtls_ssl_handshake_step(&server.ssl);

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -74,7 +74,7 @@ typedef enum {
     RECOMBINE_COALESCE_SPLIT_BOTH_ENDS, /* param: offset, must be >0 */
 } recombine_records_instruction_t;
 
-#if defined(MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED)
+#if defined(MBEDTLS_TEST_SSL_ENDPOINT)
 
 /* Split the first record into two pieces of lengths offset and
  * record_length-offset. If offset is zero or negative, count from the end of
@@ -363,7 +363,7 @@ exit:
     return 0;
 }
 
-#endif /* MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED */
+#endif /* MBEDTLS_TEST_SSL_ENDPOINT */
 
 /* END_HEADER */
 
@@ -3104,9 +3104,7 @@ exit:
 }
 /* END_CASE */
 
-/* This test case doesn't actually depend on certificates,
- * but our helper code for mbedtls_test_ssl_endpoint does. */
-/* BEGIN_CASE depends_on:MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED */
+/* BEGIN_CASE depends_on:MBEDTLS_TEST_SSL_ENDPOINT */
 void recombine_server_first_flight(int version,
                                    int instruction, int param,
                                    char *client_log, char *server_log,

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -3023,8 +3023,10 @@ void recombine_server_first_flight(int version,
                                    int goal_state, int expected_ret)
 {
     enum { BUFFSIZE = 17000 };
-    mbedtls_test_ssl_endpoint client = { 0 };
-    mbedtls_test_ssl_endpoint server = { 0 };
+    mbedtls_test_ssl_endpoint client;
+    memset(&client, 0, sizeof(client));
+    mbedtls_test_ssl_endpoint server;
+    memset(&server, 0, sizeof(server));
     mbedtls_test_handshake_test_options client_options;
     mbedtls_test_init_handshake_options(&client_options);
     mbedtls_test_handshake_test_options server_options;

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -3137,10 +3137,6 @@ void recombine_server_first_flight(int version,
     TEST_EQUAL(mbedtls_test_ssl_endpoint_init(&client, MBEDTLS_SSL_IS_CLIENT,
                                               &client_options, NULL, NULL,
                                               NULL), 0);
-#if defined(MBEDTLS_DEBUG_C)
-    mbedtls_ssl_conf_dbg(&client.conf, client_options.cli_log_fun,
-                         client_options.cli_log_obj);
-#endif
 
     server_options.server_min_version = version;
     server_options.server_max_version = version;
@@ -3151,10 +3147,6 @@ void recombine_server_first_flight(int version,
     TEST_EQUAL(mbedtls_test_ssl_endpoint_init(&server, MBEDTLS_SSL_IS_SERVER,
                                               &server_options, NULL, NULL,
                                               NULL), 0);
-#if defined(MBEDTLS_DEBUG_C)
-    mbedtls_ssl_conf_dbg(&server.conf, server_options.srv_log_fun,
-                         server_options.srv_log_obj);
-#endif
 
     TEST_EQUAL(mbedtls_test_mock_socket_connect(&client.socket,
                                                 &server.socket,

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -69,9 +69,9 @@ typedef enum {
     RECOMBINE_TRUNCATE_FIRST,   /* param: offset of truncation (<=0 means from end) */
     RECOMBINE_INSERT_EMPTY,     /* param: offset (<0 means from end) */
     RECOMBINE_INSERT_RECORD,    /* param: record type */
-    RECOMBINE_COALESCE,         /* param: min number of records */
+    RECOMBINE_COALESCE,         /* param: number of records (INT_MAX=all) */
     RECOMBINE_COALESCE_SPLIT_ONCE, /* param: offset of split (<=0 means from end) */
-    RECOMBINE_COALESCE_SPLIT_ENDS, /* the hairiest one? param: offset, must be >0 */
+    RECOMBINE_COALESCE_SPLIT_BOTH_ENDS, /* param: offset, must be >0 */
 } recombine_records_instruction_t;
 
 #if defined(MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED)
@@ -229,6 +229,10 @@ exit:
  * DTLS is not supported.
  * Encrypted or authenticated handshake records are not supported.
  * Assume the buffer content is a valid sequence of records.
+ *
+ * Coalesce only the first max records, or all the records if there are
+ * fewer than max.
+ * Return the number of coalesced records, or -1 on error.
  */
 static int recombine_coalesce_handshake_records(mbedtls_test_ssl_buffer *buf,
                                                 int max)
@@ -318,6 +322,9 @@ static int recombine_records(mbedtls_test_ssl_endpoint *server,
 
         case RECOMBINE_COALESCE:
             ret = recombine_coalesce_handshake_records(buf, param);
+            /* If param != INT_MAX, enforce that there were that many
+             * records to coalesce. In particular, 1 < param < INT_MAX
+             * ensures that library will see some coalesced records. */
             if (param == INT_MAX) {
                 TEST_LE_S(1, ret);
             } else {
@@ -335,7 +342,7 @@ static int recombine_records(mbedtls_test_ssl_endpoint *server,
             TEST_LE_S(0, ret);
             break;
 
-        case RECOMBINE_COALESCE_SPLIT_ENDS:
+        case RECOMBINE_COALESCE_SPLIT_BOTH_ENDS:
             ret = recombine_coalesce_handshake_records(buf, INT_MAX);
             /* Accept a single record, which will be split at both ends */
             TEST_LE_S(1, ret);
@@ -3105,6 +3112,12 @@ void recombine_server_first_flight(int version,
                                    char *client_log, char *server_log,
                                    int goal_state, int expected_ret)
 {
+    /* Make sure we have a buffer that's large enough for the longest
+     * data that the library might ever send, plus a bit extra so that
+     * we can inject more content. The library won't ever send more than
+     * 2^14 bytes of handshake messages, so we round that up. In practice
+     * we could surely get away with a much smaller buffer. The main
+     * variable part is the server certificate. */
     enum { BUFFSIZE = 17000 };
     mbedtls_test_ssl_endpoint client;
     memset(&client, 0, sizeof(client));

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -72,6 +72,8 @@ typedef enum {
     RECOMBINE_COALESCE_SPLIT_ENDS, /* the hairiest one? param: offset, must be >0 */
 } recombine_records_instruction_t;
 
+#if defined(MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED)
+
 /* Split the first record into two pieces of lengths offset and
  * record_length-offset. If offset is zero or negative, count from the end of
  * the record. */
@@ -276,6 +278,8 @@ static int recombine_records(mbedtls_test_ssl_endpoint *server,
 exit:
     return 0;
 }
+
+#endif /* MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED */
 
 /* END_HEADER */
 
@@ -3016,7 +3020,9 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE */
+/* This test case doesn't actually depend on certificates,
+ * but our helper code for mbedtls_test_ssl_endpoint does. */
+/* BEGIN_CASE depends_on:MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED */
 void recombine_server_first_flight(int version,
                                    int instruction, int param,
                                    char *client_log, char *server_log,

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -3040,6 +3040,9 @@ void recombine_server_first_flight(int version,
 #if defined(MBEDTLS_DEBUG_C)
     mbedtls_test_ssl_log_pattern cli_pattern = { .pattern = client_log };
     mbedtls_test_ssl_log_pattern srv_pattern = { .pattern = server_log };
+#else
+    (void) client_log;
+    (void) server_log;
 #endif
     int ret = 0;
 
@@ -3053,8 +3056,6 @@ void recombine_server_first_flight(int version,
 #if defined(MBEDTLS_DEBUG_C)
     client_options.cli_log_obj = &cli_pattern;
     client_options.cli_log_fun = mbedtls_test_ssl_log_analyzer;
-#else
-    (void) cli_pattern;
 #endif
     TEST_EQUAL(mbedtls_test_ssl_endpoint_init(&client, MBEDTLS_SSL_IS_CLIENT,
                                               &client_options, NULL, NULL,
@@ -3069,8 +3070,6 @@ void recombine_server_first_flight(int version,
 #if defined(MBEDTLS_DEBUG_C)
     server_options.srv_log_obj = &srv_pattern;
     server_options.srv_log_fun = mbedtls_test_ssl_log_analyzer;
-#else
-    (void) srv_pattern;
 #endif
     TEST_EQUAL(mbedtls_test_ssl_endpoint_init(&server, MBEDTLS_SSL_IS_SERVER,
                                               &server_options, NULL, NULL,

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -63,6 +63,98 @@ exit:
 }
 #endif
 
+typedef enum {
+    RECOMBINE_NOMINAL,          /* param: ignored */
+    RECOMBINE_COALESCE,         /* param: min number of records */
+} recombine_records_instruction_t;
+
+/* Coalesce TLS handshake records.
+ * DTLS is not supported.
+ * Encrypted or authenticated handshake records are not supported.
+ * Assume the buffer content is a valid sequence of records.
+ */
+static int recombine_coalesce_handshake_records(mbedtls_test_ssl_buffer *buf,
+                                                int max)
+{
+    const size_t header_length = 5;
+    TEST_LE_U(header_length, buf->content_length);
+    if (buf->buffer[0] != MBEDTLS_SSL_MSG_HANDSHAKE) {
+        return 0;
+    }
+
+    size_t record_length = MBEDTLS_GET_UINT16_BE(buf->buffer, header_length - 2);
+    TEST_LE_U(header_length + record_length, buf->content_length);
+
+    int count;
+    for (count = 1; count < max; count++) {
+        size_t next_start = header_length + record_length;
+        if (next_start >= buf->content_length) {
+            /* We've already reached the last record. */
+            break;
+        }
+
+        TEST_LE_U(next_start + header_length, buf->content_length);
+        if (buf->buffer[next_start] != MBEDTLS_SSL_MSG_HANDSHAKE) {
+            /* There's another record, but it isn't a handshake record. */
+            break;
+        }
+        size_t next_length =
+            MBEDTLS_GET_UINT16_BE(buf->buffer, next_start + header_length - 2);
+        TEST_LE_U(next_start + header_length + next_length, buf->content_length);
+
+        /* Erase the next record header */
+        memmove(buf->buffer + next_start,
+                buf->buffer + next_start + header_length,
+                buf->content_length - next_start);
+        buf->content_length -= header_length;
+        /* Update the first record length */
+        record_length += next_length;
+        TEST_LE_U(record_length, 0xffff);
+        MBEDTLS_PUT_UINT16_BE(record_length, buf->buffer, header_length - 2);
+    }
+
+    return count;
+
+exit:
+    return -1;
+}
+
+static int recombine_records(mbedtls_test_ssl_endpoint *server,
+                             recombine_records_instruction_t instruction,
+                             int param)
+{
+    mbedtls_test_ssl_buffer *buf = server->socket.output;
+    int ret;
+
+    /* buf is a circular buffer. For simplicity, this code assumes that
+     * the data is located at the beginning. This should be ok since
+     * this function is only meant to be used on the first flight
+     * emitted by a server. */
+    TEST_EQUAL(buf->start, 0);
+
+    switch (instruction) {
+        case RECOMBINE_NOMINAL:
+            break;
+
+        case RECOMBINE_COALESCE:
+            ret = recombine_coalesce_handshake_records(buf, param);
+            if (param == INT_MAX) {
+                TEST_LE_S(1, ret);
+            } else {
+                TEST_EQUAL(ret, param);
+            }
+            break;
+
+        default:
+            TEST_FAIL("Instructions not understood");
+    }
+
+    return 1;
+
+exit:
+    return 0;
+}
+
 /* END_HEADER */
 
 /* BEGIN_DEPENDENCIES
@@ -2799,6 +2891,146 @@ void handshake_fragmentation(int mfl,
 
 exit:
     mbedtls_test_free_handshake_options(&options);
+}
+/* END_CASE */
+
+/* BEGIN_CASE */
+void recombine_server_first_flight(int version,
+                                   int instruction, int param,
+                                   char *client_log, char *server_log,
+                                   int goal_state, int expected_ret)
+{
+    enum { BUFFSIZE = 17000 };
+    mbedtls_test_ssl_endpoint client = { 0 };
+    mbedtls_test_ssl_endpoint server = { 0 };
+    mbedtls_test_handshake_test_options client_options;
+    mbedtls_test_init_handshake_options(&client_options);
+    mbedtls_test_handshake_test_options server_options;
+    mbedtls_test_init_handshake_options(&server_options);
+#if defined(MBEDTLS_DEBUG_C)
+    mbedtls_test_ssl_log_pattern cli_pattern = { .pattern = client_log };
+    mbedtls_test_ssl_log_pattern srv_pattern = { .pattern = server_log };
+#endif
+    int ret = 0;
+
+    MD_OR_USE_PSA_INIT();
+#if defined(MBEDTLS_DEBUG_C)
+    mbedtls_debug_set_threshold(3);
+#endif
+
+    client_options.client_min_version = version;
+    client_options.client_max_version = version;
+#if defined(MBEDTLS_DEBUG_C)
+    client_options.cli_log_obj = &cli_pattern;
+    client_options.cli_log_fun = mbedtls_test_ssl_log_analyzer;
+#else
+    (void) cli_pattern;
+#endif
+    TEST_EQUAL(mbedtls_test_ssl_endpoint_init(&client, MBEDTLS_SSL_IS_CLIENT,
+                                              &client_options, NULL, NULL,
+                                              NULL), 0);
+#if defined(MBEDTLS_DEBUG_C)
+    mbedtls_ssl_conf_dbg(&client.conf, client_options.cli_log_fun,
+                         client_options.cli_log_obj);
+#endif
+
+    server_options.server_min_version = version;
+    server_options.server_max_version = version;
+#if defined(MBEDTLS_DEBUG_C)
+    server_options.srv_log_obj = &srv_pattern;
+    server_options.srv_log_fun = mbedtls_test_ssl_log_analyzer;
+#else
+    (void) srv_pattern;
+#endif
+    TEST_EQUAL(mbedtls_test_ssl_endpoint_init(&server, MBEDTLS_SSL_IS_SERVER,
+                                              &server_options, NULL, NULL,
+                                              NULL), 0);
+#if defined(MBEDTLS_DEBUG_C)
+    mbedtls_ssl_conf_dbg(&server.conf, server_options.srv_log_fun,
+                         server_options.srv_log_obj);
+#endif
+
+    TEST_EQUAL(mbedtls_test_mock_socket_connect(&client.socket,
+                                                &server.socket,
+                                                BUFFSIZE), 0);
+
+    /* Client: emit the first flight from the client */
+    while (ret == 0) {
+        mbedtls_test_set_step(client.ssl.state);
+        ret = mbedtls_ssl_handshake_step(&client.ssl);
+    }
+    TEST_EQUAL(ret, MBEDTLS_ERR_SSL_WANT_READ);
+    ret = 0;
+    TEST_EQUAL(client.ssl.state, MBEDTLS_SSL_SERVER_HELLO);
+
+    /* Server: parse the first flight from the client
+     * and emit the first flight from the server */
+    while (ret == 0) {
+        mbedtls_test_set_step(1000 + server.ssl.state);
+        ret = mbedtls_ssl_handshake_step(&server.ssl);
+    }
+    TEST_EQUAL(ret, MBEDTLS_ERR_SSL_WANT_READ);
+    ret = 0;
+    TEST_EQUAL(server.ssl.state, MBEDTLS_SSL_SERVER_HELLO_DONE + 1);
+
+    /* Recombine the first flight from the server */
+    TEST_ASSERT(recombine_records(&server, instruction, param));
+
+    /* Client: parse the first flight from the server
+     * and emit the second flight from the client */
+    while (ret == 0 && !mbedtls_ssl_is_handshake_over(&client.ssl)) {
+        mbedtls_test_set_step(client.ssl.state);
+        ret = mbedtls_ssl_handshake_step(&client.ssl);
+        if (client.ssl.state == goal_state && ret != 0) {
+            TEST_EQUAL(ret, expected_ret);
+            goto goal_reached;
+        }
+    }
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3)
+    if (version >= MBEDTLS_SSL_VERSION_TLS1_3 &&
+        goal_state >= MBEDTLS_SSL_HANDSHAKE_OVER) {
+        TEST_EQUAL(ret, 0);
+    } else
+#endif
+    {
+        TEST_EQUAL(ret, MBEDTLS_ERR_SSL_WANT_READ);
+    }
+    ret = 0;
+
+    /* Server: parse the first flight from the client
+     * and emit the second flight from the server */
+    while (ret == 0 && !mbedtls_ssl_is_handshake_over(&server.ssl)) {
+        mbedtls_test_set_step(1000 + server.ssl.state);
+        ret = mbedtls_ssl_handshake_step(&server.ssl);
+    }
+    TEST_EQUAL(ret, 0);
+
+    /* Client: parse the second flight from the server */
+    while (ret == 0 && !mbedtls_ssl_is_handshake_over(&client.ssl)) {
+        mbedtls_test_set_step(client.ssl.state);
+        ret = mbedtls_ssl_handshake_step(&client.ssl);
+    }
+    if (client.ssl.state == goal_state) {
+        TEST_EQUAL(ret, expected_ret);
+    } else {
+        TEST_EQUAL(ret, 0);
+    }
+
+goal_reached:
+#if defined(MBEDTLS_DEBUG_C)
+    TEST_ASSERT(cli_pattern.counter >= 1);
+    TEST_ASSERT(srv_pattern.counter >= 1);
+#endif
+
+exit:
+    mbedtls_test_ssl_endpoint_free(&client, NULL);
+    mbedtls_test_ssl_endpoint_free(&server, NULL);
+    mbedtls_test_free_handshake_options(&client_options);
+    mbedtls_test_free_handshake_options(&server_options);
+    MD_OR_USE_PSA_DONE();
+#if defined(MBEDTLS_DEBUG_C)
+    mbedtls_debug_set_threshold(0);
+#endif
 }
 /* END_CASE */
 

--- a/tests/suites/test_suite_ssl.records.data
+++ b/tests/suites/test_suite_ssl.records.data
@@ -75,9 +75,13 @@ Recombine server flight 1: TLS 1.3, truncate at 4 (bad)
 depends_on:MBEDTLS_TEST_SSL_ENDPOINT_TLS1_3
 recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_3:RECOMBINE_TRUNCATE_FIRST:4:"initial handshake fragment\: 4, 0..4 of":"":MBEDTLS_SSL_SERVER_HELLO:MBEDTLS_ERR_SSL_WANT_READ
 
-Recombine server flight 1: TLS 1.2, insert empty record after first (bad)
-depends_on:MBEDTLS_SSL_PROTO_TLS1_2
+Recombine server flight 1: TLS 1.2 cert, insert empty record after first (bad)
+depends_on:MBEDTLS_SSL_PROTO_TLS1_2:MBEDTLS_TEST_SSL_ENDPOINT_DEFAULT_CERTS
 recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_2:RECOMBINE_SPLIT_FIRST:0:"rejecting empty record":"":MBEDTLS_SSL_SERVER_CERTIFICATE:MBEDTLS_ERR_SSL_INVALID_RECORD
+
+Recombine server flight 1: TLS 1.2 PSK, insert empty record after first (bad)
+depends_on:MBEDTLS_SSL_PROTO_TLS1_2:!MBEDTLS_TEST_SSL_ENDPOINT_DEFAULT_CERTS
+recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_2:RECOMBINE_SPLIT_FIRST:0:"rejecting empty record":"":MBEDTLS_SSL_SERVER_KEY_EXCHANGE:MBEDTLS_ERR_SSL_INVALID_RECORD
 
 Recombine server flight 1: TLS 1.3, insert empty record after first (bad)
 depends_on:MBEDTLS_TEST_SSL_ENDPOINT_TLS1_3

--- a/tests/suites/test_suite_ssl.records.data
+++ b/tests/suites/test_suite_ssl.records.data
@@ -159,4 +159,4 @@ recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_2:RECOMBINE_COALESCE_SPLI
 
 Recombine server flight 1: TLS 1.2, coalesce and split at both ends
 depends_on:MBEDTLS_SSL_PROTO_TLS1_2
-recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_2:RECOMBINE_COALESCE_SPLIT_ENDS:5:"subsequent handshake fragment\: 5,":"<= handshake wrapup":MBEDTLS_SSL_HANDSHAKE_OVER:0
+recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_2:RECOMBINE_COALESCE_SPLIT_BOTH_ENDS:5:"subsequent handshake fragment\: 5,":"<= handshake wrapup":MBEDTLS_SSL_HANDSHAKE_OVER:0

--- a/tests/suites/test_suite_ssl.records.data
+++ b/tests/suites/test_suite_ssl.records.data
@@ -67,6 +67,14 @@ Recombine server flight 1: TLS 1.3, split first at 1 (bad)
 depends_on:MBEDTLS_SSL_PROTO_TLS1_3
 recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_3:RECOMBINE_SPLIT_FIRST:1:"handshake message too short\: 1":"":MBEDTLS_SSL_SERVER_HELLO:MBEDTLS_ERR_SSL_INVALID_RECORD
 
+Recombine server flight 1: TLS 1.2, truncate at 4 (bad)
+depends_on:MBEDTLS_SSL_PROTO_TLS1_2
+recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_2:RECOMBINE_TRUNCATE_FIRST:4:"initial handshake fragment\: 4, 0..4 of":"":MBEDTLS_SSL_SERVER_HELLO:MBEDTLS_ERR_SSL_WANT_READ
+
+Recombine server flight 1: TLS 1.3, truncate at 4 (bad)
+depends_on:MBEDTLS_SSL_PROTO_TLS1_3
+recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_3:RECOMBINE_TRUNCATE_FIRST:4:"initial handshake fragment\: 4, 0..4 of":"":MBEDTLS_SSL_SERVER_HELLO:MBEDTLS_ERR_SSL_WANT_READ
+
 Recombine server flight 1: TLS 1.2, insert empty record after first (bad)
 depends_on:MBEDTLS_SSL_PROTO_TLS1_2
 recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_2:RECOMBINE_SPLIT_FIRST:0:"rejecting empty record":"":MBEDTLS_SSL_SERVER_CERTIFICATE:MBEDTLS_ERR_SSL_INVALID_RECORD

--- a/tests/suites/test_suite_ssl.records.data
+++ b/tests/suites/test_suite_ssl.records.data
@@ -91,6 +91,46 @@ Recombine server flight 1: TLS 1.3, insert empty record at 42 (bad)
 depends_on:MBEDTLS_SSL_PROTO_TLS1_3
 recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_3:RECOMBINE_INSERT_EMPTY:42:"rejecting empty record":"":MBEDTLS_SSL_SERVER_HELLO:MBEDTLS_ERR_SSL_INVALID_RECORD
 
+Recombine server flight 1: TLS 1.2, insert ChangeCipherSpec record at 5 (bad)
+depends_on:MBEDTLS_SSL_PROTO_TLS1_2
+recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_2:RECOMBINE_INSERT_RECORD:MBEDTLS_SSL_MSG_CHANGE_CIPHER_SPEC:"non-handshake message in the middle of a fragmented handshake message":"":MBEDTLS_SSL_SERVER_HELLO:MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE
+
+Recombine server flight 1: TLS 1.3, insert ChangeCipherSpec record at 5 (bad)
+depends_on:MBEDTLS_SSL_PROTO_TLS1_3
+recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_3:RECOMBINE_INSERT_RECORD:MBEDTLS_SSL_MSG_CHANGE_CIPHER_SPEC:"non-handshake message in the middle of a fragmented handshake message":"":MBEDTLS_SSL_SERVER_HELLO:MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE
+
+Recombine server flight 1: TLS 1.2, insert alert record at 5 (bad)
+depends_on:MBEDTLS_SSL_PROTO_TLS1_2
+recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_2:RECOMBINE_INSERT_RECORD:MBEDTLS_SSL_MSG_ALERT:"non-handshake message in the middle of a fragmented handshake message":"":MBEDTLS_SSL_SERVER_HELLO:MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE
+
+Recombine server flight 1: TLS 1.3, insert alert record at 5 (bad)
+depends_on:MBEDTLS_SSL_PROTO_TLS1_3
+recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_3:RECOMBINE_INSERT_RECORD:MBEDTLS_SSL_MSG_ALERT:"non-handshake message in the middle of a fragmented handshake message":"":MBEDTLS_SSL_SERVER_HELLO:MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE
+
+Recombine server flight 1: TLS 1.2, insert data record at 5 (bad)
+depends_on:MBEDTLS_SSL_PROTO_TLS1_2
+recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_2:RECOMBINE_INSERT_RECORD:MBEDTLS_SSL_MSG_APPLICATION_DATA:"non-handshake message in the middle of a fragmented handshake message":"":MBEDTLS_SSL_SERVER_HELLO:MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE
+
+Recombine server flight 1: TLS 1.3, insert data record at 5 (bad)
+depends_on:MBEDTLS_SSL_PROTO_TLS1_3
+recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_3:RECOMBINE_INSERT_RECORD:MBEDTLS_SSL_MSG_APPLICATION_DATA:"non-handshake message in the middle of a fragmented handshake message":"":MBEDTLS_SSL_SERVER_HELLO:MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE
+
+Recombine server flight 1: TLS 1.2, insert CID record at 5 (bad)
+depends_on:MBEDTLS_SSL_PROTO_TLS1_2
+recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_2:RECOMBINE_INSERT_RECORD:MBEDTLS_SSL_MSG_CID:"unknown record type":"":MBEDTLS_SSL_SERVER_HELLO:MBEDTLS_ERR_SSL_INVALID_RECORD
+
+Recombine server flight 1: TLS 1.3, insert CID record at 5 (bad)
+depends_on:MBEDTLS_SSL_PROTO_TLS1_3
+recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_3:RECOMBINE_INSERT_RECORD:MBEDTLS_SSL_MSG_CID:"unknown record type":"":MBEDTLS_SSL_SERVER_HELLO:MBEDTLS_ERR_SSL_INVALID_RECORD
+
+Recombine server flight 1: TLS 1.2, insert unknown record at 5 (bad)
+depends_on:MBEDTLS_SSL_PROTO_TLS1_2
+recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_2:RECOMBINE_INSERT_RECORD:255:"unknown record type 255":"":MBEDTLS_SSL_SERVER_HELLO:MBEDTLS_ERR_SSL_INVALID_RECORD
+
+Recombine server flight 1: TLS 1.3, insert unknown record at 5 (bad)
+depends_on:MBEDTLS_SSL_PROTO_TLS1_3
+recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_3:RECOMBINE_INSERT_RECORD:255:"unknown record type 255":"":MBEDTLS_SSL_SERVER_HELLO:MBEDTLS_ERR_SSL_INVALID_RECORD
+
 # Since there is a single unencrypted handshake message in the first flight
 # from the server, and the test code that recombines handshake records can only
 # handle plaintext records, we can't have TLS 1.3 tests with coalesced

--- a/tests/suites/test_suite_ssl.records.data
+++ b/tests/suites/test_suite_ssl.records.data
@@ -3,7 +3,7 @@ depends_on:MBEDTLS_SSL_PROTO_TLS1_2
 recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_2:RECOMBINE_NOMINAL:0:"<= handshake wrapup":"<= handshake wrapup":MBEDTLS_SSL_HANDSHAKE_OVER:0
 
 Recombine server flight 1: TLS 1.3, nominal
-depends_on:MBEDTLS_SSL_PROTO_TLS1_3
+depends_on:MBEDTLS_TEST_SSL_ENDPOINT_TLS1_3
 recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_3:RECOMBINE_NOMINAL:0:"<= handshake wrapup":"<= handshake wrapup":MBEDTLS_SSL_TLS1_3_NEW_SESSION_TICKET_FLUSH:0
 
 Recombine server flight 1: TLS 1.2, coalesce 2
@@ -11,7 +11,7 @@ depends_on:MBEDTLS_SSL_PROTO_TLS1_2
 recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_2:RECOMBINE_COALESCE:2:"<= handshake wrapup":"<= handshake wrapup":MBEDTLS_SSL_HANDSHAKE_OVER:0
 
 Recombine server flight 1: TLS 1.2, coalesce 3
-depends_on:MBEDTLS_SSL_PROTO_TLS1_2
+depends_on:MBEDTLS_SSL_PROTO_TLS1_2:MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED
 recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_2:RECOMBINE_COALESCE:3:"<= handshake wrapup":"<= handshake wrapup":MBEDTLS_SSL_HANDSHAKE_OVER:0
 
 Recombine server flight 1: TLS 1.2, coalesce all
@@ -22,7 +22,7 @@ recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_2:RECOMBINE_COALESCE:INT_
 # actually perform any coalescing. Run the test case anyway, but this does
 # very little beyond exercising the test code itself a little.
 Recombine server flight 1: TLS 1.3, coalesce all
-depends_on:MBEDTLS_SSL_PROTO_TLS1_3
+depends_on:MBEDTLS_TEST_SSL_ENDPOINT_TLS1_3
 recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_3:RECOMBINE_COALESCE:INT_MAX:"<= handshake wrapup":"<= handshake wrapup":MBEDTLS_SSL_TLS1_3_NEW_SESSION_TICKET_FLUSH:0
 
 Recombine server flight 1: TLS 1.2, split first at 4
@@ -30,7 +30,7 @@ depends_on:MBEDTLS_SSL_PROTO_TLS1_2
 recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_2:RECOMBINE_SPLIT_FIRST:4:"initial handshake fragment\: 4, 0..4 of":"<= handshake wrapup":MBEDTLS_SSL_HANDSHAKE_OVER:0
 
 Recombine server flight 1: TLS 1.3, split first at 4
-depends_on:MBEDTLS_SSL_PROTO_TLS1_3
+depends_on:MBEDTLS_TEST_SSL_ENDPOINT_TLS1_3
 recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_3:RECOMBINE_SPLIT_FIRST:4:"initial handshake fragment\: 4, 0..4 of":"<= handshake wrapup":MBEDTLS_SSL_TLS1_3_NEW_SESSION_TICKET_FLUSH:0
 
 Recombine server flight 1: TLS 1.2, split first at end-1
@@ -38,7 +38,7 @@ depends_on:MBEDTLS_SSL_PROTO_TLS1_2
 recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_2:RECOMBINE_SPLIT_FIRST:-1:"subsequent handshake fragment\: 1,":"<= handshake wrapup":MBEDTLS_SSL_HANDSHAKE_OVER:0
 
 Recombine server flight 1: TLS 1.3, split first at end-1
-depends_on:MBEDTLS_SSL_PROTO_TLS1_3
+depends_on:MBEDTLS_TEST_SSL_ENDPOINT_TLS1_3
 recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_3:RECOMBINE_SPLIT_FIRST:-1:"subsequent handshake fragment\: 1,":"<= handshake wrapup":MBEDTLS_SSL_TLS1_3_NEW_SESSION_TICKET_FLUSH:0
 
 # The library doesn't support an initial handshake fragment that doesn't
@@ -48,7 +48,7 @@ depends_on:MBEDTLS_SSL_PROTO_TLS1_2
 recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_2:RECOMBINE_SPLIT_FIRST:3:"handshake message too short\: 3":"":MBEDTLS_SSL_SERVER_HELLO:MBEDTLS_ERR_SSL_INVALID_RECORD
 
 Recombine server flight 1: TLS 1.3, split first at 3 (bad)
-depends_on:MBEDTLS_SSL_PROTO_TLS1_3
+depends_on:MBEDTLS_TEST_SSL_ENDPOINT_TLS1_3
 recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_3:RECOMBINE_SPLIT_FIRST:3:"handshake message too short\: 3":"":MBEDTLS_SSL_SERVER_HELLO:MBEDTLS_ERR_SSL_INVALID_RECORD
 
 Recombine server flight 1: TLS 1.2, split first at 2 (bad)
@@ -56,7 +56,7 @@ depends_on:MBEDTLS_SSL_PROTO_TLS1_2
 recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_2:RECOMBINE_SPLIT_FIRST:2:"handshake message too short\: 2":"":MBEDTLS_SSL_SERVER_HELLO:MBEDTLS_ERR_SSL_INVALID_RECORD
 
 Recombine server flight 1: TLS 1.3, split first at 2 (bad)
-depends_on:MBEDTLS_SSL_PROTO_TLS1_3
+depends_on:MBEDTLS_TEST_SSL_ENDPOINT_TLS1_3
 recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_3:RECOMBINE_SPLIT_FIRST:2:"handshake message too short\: 2":"":MBEDTLS_SSL_SERVER_HELLO:MBEDTLS_ERR_SSL_INVALID_RECORD
 
 Recombine server flight 1: TLS 1.2, split first at 1 (bad)
@@ -64,7 +64,7 @@ depends_on:MBEDTLS_SSL_PROTO_TLS1_2
 recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_2:RECOMBINE_SPLIT_FIRST:1:"handshake message too short\: 1":"":MBEDTLS_SSL_SERVER_HELLO:MBEDTLS_ERR_SSL_INVALID_RECORD
 
 Recombine server flight 1: TLS 1.3, split first at 1 (bad)
-depends_on:MBEDTLS_SSL_PROTO_TLS1_3
+depends_on:MBEDTLS_TEST_SSL_ENDPOINT_TLS1_3
 recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_3:RECOMBINE_SPLIT_FIRST:1:"handshake message too short\: 1":"":MBEDTLS_SSL_SERVER_HELLO:MBEDTLS_ERR_SSL_INVALID_RECORD
 
 Recombine server flight 1: TLS 1.2, truncate at 4 (bad)
@@ -72,7 +72,7 @@ depends_on:MBEDTLS_SSL_PROTO_TLS1_2
 recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_2:RECOMBINE_TRUNCATE_FIRST:4:"initial handshake fragment\: 4, 0..4 of":"":MBEDTLS_SSL_SERVER_HELLO:MBEDTLS_ERR_SSL_WANT_READ
 
 Recombine server flight 1: TLS 1.3, truncate at 4 (bad)
-depends_on:MBEDTLS_SSL_PROTO_TLS1_3
+depends_on:MBEDTLS_TEST_SSL_ENDPOINT_TLS1_3
 recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_3:RECOMBINE_TRUNCATE_FIRST:4:"initial handshake fragment\: 4, 0..4 of":"":MBEDTLS_SSL_SERVER_HELLO:MBEDTLS_ERR_SSL_WANT_READ
 
 Recombine server flight 1: TLS 1.2, insert empty record after first (bad)
@@ -80,7 +80,7 @@ depends_on:MBEDTLS_SSL_PROTO_TLS1_2
 recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_2:RECOMBINE_SPLIT_FIRST:0:"rejecting empty record":"":MBEDTLS_SSL_SERVER_CERTIFICATE:MBEDTLS_ERR_SSL_INVALID_RECORD
 
 Recombine server flight 1: TLS 1.3, insert empty record after first (bad)
-depends_on:MBEDTLS_SSL_PROTO_TLS1_3
+depends_on:MBEDTLS_TEST_SSL_ENDPOINT_TLS1_3
 recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_3:RECOMBINE_SPLIT_FIRST:0:"rejecting empty record":"":MBEDTLS_SSL_ENCRYPTED_EXTENSIONS:MBEDTLS_ERR_SSL_INVALID_RECORD
 
 Recombine server flight 1: TLS 1.2, insert empty record at start (bad)
@@ -88,7 +88,7 @@ depends_on:MBEDTLS_SSL_PROTO_TLS1_2
 recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_2:RECOMBINE_INSERT_EMPTY:0:"rejecting empty record":"":MBEDTLS_SSL_SERVER_HELLO:MBEDTLS_ERR_SSL_INVALID_RECORD
 
 Recombine server flight 1: TLS 1.3, insert empty record at start (bad)
-depends_on:MBEDTLS_SSL_PROTO_TLS1_3
+depends_on:MBEDTLS_TEST_SSL_ENDPOINT_TLS1_3
 recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_3:RECOMBINE_INSERT_EMPTY:0:"rejecting empty record":"":MBEDTLS_SSL_SERVER_HELLO:MBEDTLS_ERR_SSL_INVALID_RECORD
 
 Recombine server flight 1: TLS 1.2, insert empty record at 42 (bad)
@@ -96,7 +96,7 @@ depends_on:MBEDTLS_SSL_PROTO_TLS1_2
 recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_2:RECOMBINE_INSERT_EMPTY:42:"rejecting empty record":"":MBEDTLS_SSL_SERVER_HELLO:MBEDTLS_ERR_SSL_INVALID_RECORD
 
 Recombine server flight 1: TLS 1.3, insert empty record at 42 (bad)
-depends_on:MBEDTLS_SSL_PROTO_TLS1_3
+depends_on:MBEDTLS_TEST_SSL_ENDPOINT_TLS1_3
 recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_3:RECOMBINE_INSERT_EMPTY:42:"rejecting empty record":"":MBEDTLS_SSL_SERVER_HELLO:MBEDTLS_ERR_SSL_INVALID_RECORD
 
 Recombine server flight 1: TLS 1.2, insert ChangeCipherSpec record at 5 (bad)
@@ -104,7 +104,7 @@ depends_on:MBEDTLS_SSL_PROTO_TLS1_2
 recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_2:RECOMBINE_INSERT_RECORD:MBEDTLS_SSL_MSG_CHANGE_CIPHER_SPEC:"non-handshake message in the middle of a fragmented handshake message":"":MBEDTLS_SSL_SERVER_HELLO:MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE
 
 Recombine server flight 1: TLS 1.3, insert ChangeCipherSpec record at 5 (bad)
-depends_on:MBEDTLS_SSL_PROTO_TLS1_3
+depends_on:MBEDTLS_TEST_SSL_ENDPOINT_TLS1_3
 recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_3:RECOMBINE_INSERT_RECORD:MBEDTLS_SSL_MSG_CHANGE_CIPHER_SPEC:"non-handshake message in the middle of a fragmented handshake message":"":MBEDTLS_SSL_SERVER_HELLO:MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE
 
 Recombine server flight 1: TLS 1.2, insert alert record at 5 (bad)
@@ -112,7 +112,7 @@ depends_on:MBEDTLS_SSL_PROTO_TLS1_2
 recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_2:RECOMBINE_INSERT_RECORD:MBEDTLS_SSL_MSG_ALERT:"non-handshake message in the middle of a fragmented handshake message":"":MBEDTLS_SSL_SERVER_HELLO:MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE
 
 Recombine server flight 1: TLS 1.3, insert alert record at 5 (bad)
-depends_on:MBEDTLS_SSL_PROTO_TLS1_3
+depends_on:MBEDTLS_TEST_SSL_ENDPOINT_TLS1_3
 recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_3:RECOMBINE_INSERT_RECORD:MBEDTLS_SSL_MSG_ALERT:"non-handshake message in the middle of a fragmented handshake message":"":MBEDTLS_SSL_SERVER_HELLO:MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE
 
 Recombine server flight 1: TLS 1.2, insert data record at 5 (bad)
@@ -120,7 +120,7 @@ depends_on:MBEDTLS_SSL_PROTO_TLS1_2
 recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_2:RECOMBINE_INSERT_RECORD:MBEDTLS_SSL_MSG_APPLICATION_DATA:"non-handshake message in the middle of a fragmented handshake message":"":MBEDTLS_SSL_SERVER_HELLO:MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE
 
 Recombine server flight 1: TLS 1.3, insert data record at 5 (bad)
-depends_on:MBEDTLS_SSL_PROTO_TLS1_3
+depends_on:MBEDTLS_TEST_SSL_ENDPOINT_TLS1_3
 recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_3:RECOMBINE_INSERT_RECORD:MBEDTLS_SSL_MSG_APPLICATION_DATA:"non-handshake message in the middle of a fragmented handshake message":"":MBEDTLS_SSL_SERVER_HELLO:MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE
 
 Recombine server flight 1: TLS 1.2, insert CID record at 5 (bad)
@@ -128,7 +128,7 @@ depends_on:MBEDTLS_SSL_PROTO_TLS1_2
 recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_2:RECOMBINE_INSERT_RECORD:MBEDTLS_SSL_MSG_CID:"unknown record type":"":MBEDTLS_SSL_SERVER_HELLO:MBEDTLS_ERR_SSL_INVALID_RECORD
 
 Recombine server flight 1: TLS 1.3, insert CID record at 5 (bad)
-depends_on:MBEDTLS_SSL_PROTO_TLS1_3
+depends_on:MBEDTLS_TEST_SSL_ENDPOINT_TLS1_3
 recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_3:RECOMBINE_INSERT_RECORD:MBEDTLS_SSL_MSG_CID:"unknown record type":"":MBEDTLS_SSL_SERVER_HELLO:MBEDTLS_ERR_SSL_INVALID_RECORD
 
 Recombine server flight 1: TLS 1.2, insert unknown record at 5 (bad)
@@ -136,7 +136,7 @@ depends_on:MBEDTLS_SSL_PROTO_TLS1_2
 recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_2:RECOMBINE_INSERT_RECORD:255:"unknown record type 255":"":MBEDTLS_SSL_SERVER_HELLO:MBEDTLS_ERR_SSL_INVALID_RECORD
 
 Recombine server flight 1: TLS 1.3, insert unknown record at 5 (bad)
-depends_on:MBEDTLS_SSL_PROTO_TLS1_3
+depends_on:MBEDTLS_TEST_SSL_ENDPOINT_TLS1_3
 recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_3:RECOMBINE_INSERT_RECORD:255:"unknown record type 255":"":MBEDTLS_SSL_SERVER_HELLO:MBEDTLS_ERR_SSL_INVALID_RECORD
 
 # Since there is a single unencrypted handshake message in the first flight

--- a/tests/suites/test_suite_ssl.records.data
+++ b/tests/suites/test_suite_ssl.records.data
@@ -24,3 +24,91 @@ recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_2:RECOMBINE_COALESCE:INT_
 Recombine server flight 1: TLS 1.3, coalesce all
 depends_on:MBEDTLS_SSL_PROTO_TLS1_3
 recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_3:RECOMBINE_COALESCE:INT_MAX:"<= handshake wrapup":"<= handshake wrapup":MBEDTLS_SSL_TLS1_3_NEW_SESSION_TICKET_FLUSH:0
+
+Recombine server flight 1: TLS 1.2, split first at 4
+depends_on:MBEDTLS_SSL_PROTO_TLS1_2
+recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_2:RECOMBINE_SPLIT_FIRST:4:"initial handshake fragment\: 4, 0..4 of":"<= handshake wrapup":MBEDTLS_SSL_HANDSHAKE_OVER:0
+
+Recombine server flight 1: TLS 1.3, split first at 4
+depends_on:MBEDTLS_SSL_PROTO_TLS1_3
+recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_3:RECOMBINE_SPLIT_FIRST:4:"initial handshake fragment\: 4, 0..4 of":"<= handshake wrapup":MBEDTLS_SSL_TLS1_3_NEW_SESSION_TICKET_FLUSH:0
+
+Recombine server flight 1: TLS 1.2, split first at end-1
+depends_on:MBEDTLS_SSL_PROTO_TLS1_2
+recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_2:RECOMBINE_SPLIT_FIRST:-1:"subsequent handshake fragment\: 1,":"<= handshake wrapup":MBEDTLS_SSL_HANDSHAKE_OVER:0
+
+Recombine server flight 1: TLS 1.3, split first at end-1
+depends_on:MBEDTLS_SSL_PROTO_TLS1_3
+recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_3:RECOMBINE_SPLIT_FIRST:-1:"subsequent handshake fragment\: 1,":"<= handshake wrapup":MBEDTLS_SSL_TLS1_3_NEW_SESSION_TICKET_FLUSH:0
+
+# The library doesn't support an initial handshake fragment that doesn't
+# contain the full 4-byte handshake header.
+Recombine server flight 1: TLS 1.2, split first at 3 (bad)
+depends_on:MBEDTLS_SSL_PROTO_TLS1_2
+recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_2:RECOMBINE_SPLIT_FIRST:3:"handshake message too short\: 3":"":MBEDTLS_SSL_SERVER_HELLO:MBEDTLS_ERR_SSL_INVALID_RECORD
+
+Recombine server flight 1: TLS 1.3, split first at 3 (bad)
+depends_on:MBEDTLS_SSL_PROTO_TLS1_3
+recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_3:RECOMBINE_SPLIT_FIRST:3:"handshake message too short\: 3":"":MBEDTLS_SSL_SERVER_HELLO:MBEDTLS_ERR_SSL_INVALID_RECORD
+
+Recombine server flight 1: TLS 1.2, split first at 2 (bad)
+depends_on:MBEDTLS_SSL_PROTO_TLS1_2
+recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_2:RECOMBINE_SPLIT_FIRST:2:"handshake message too short\: 2":"":MBEDTLS_SSL_SERVER_HELLO:MBEDTLS_ERR_SSL_INVALID_RECORD
+
+Recombine server flight 1: TLS 1.3, split first at 2 (bad)
+depends_on:MBEDTLS_SSL_PROTO_TLS1_3
+recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_3:RECOMBINE_SPLIT_FIRST:2:"handshake message too short\: 2":"":MBEDTLS_SSL_SERVER_HELLO:MBEDTLS_ERR_SSL_INVALID_RECORD
+
+Recombine server flight 1: TLS 1.2, split first at 1 (bad)
+depends_on:MBEDTLS_SSL_PROTO_TLS1_2
+recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_2:RECOMBINE_SPLIT_FIRST:1:"handshake message too short\: 1":"":MBEDTLS_SSL_SERVER_HELLO:MBEDTLS_ERR_SSL_INVALID_RECORD
+
+Recombine server flight 1: TLS 1.3, split first at 1 (bad)
+depends_on:MBEDTLS_SSL_PROTO_TLS1_3
+recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_3:RECOMBINE_SPLIT_FIRST:1:"handshake message too short\: 1":"":MBEDTLS_SSL_SERVER_HELLO:MBEDTLS_ERR_SSL_INVALID_RECORD
+
+Recombine server flight 1: TLS 1.2, insert empty record after first (bad)
+depends_on:MBEDTLS_SSL_PROTO_TLS1_2
+recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_2:RECOMBINE_SPLIT_FIRST:0:"rejecting empty record":"":MBEDTLS_SSL_SERVER_CERTIFICATE:MBEDTLS_ERR_SSL_INVALID_RECORD
+
+Recombine server flight 1: TLS 1.3, insert empty record after first (bad)
+depends_on:MBEDTLS_SSL_PROTO_TLS1_3
+recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_3:RECOMBINE_SPLIT_FIRST:0:"rejecting empty record":"":MBEDTLS_SSL_ENCRYPTED_EXTENSIONS:MBEDTLS_ERR_SSL_INVALID_RECORD
+
+Recombine server flight 1: TLS 1.2, insert empty record at start (bad)
+depends_on:MBEDTLS_SSL_PROTO_TLS1_2
+recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_2:RECOMBINE_INSERT_EMPTY:0:"rejecting empty record":"":MBEDTLS_SSL_SERVER_HELLO:MBEDTLS_ERR_SSL_INVALID_RECORD
+
+Recombine server flight 1: TLS 1.3, insert empty record at start (bad)
+depends_on:MBEDTLS_SSL_PROTO_TLS1_3
+recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_3:RECOMBINE_INSERT_EMPTY:0:"rejecting empty record":"":MBEDTLS_SSL_SERVER_HELLO:MBEDTLS_ERR_SSL_INVALID_RECORD
+
+Recombine server flight 1: TLS 1.2, insert empty record at 42 (bad)
+depends_on:MBEDTLS_SSL_PROTO_TLS1_2
+recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_2:RECOMBINE_INSERT_EMPTY:42:"rejecting empty record":"":MBEDTLS_SSL_SERVER_HELLO:MBEDTLS_ERR_SSL_INVALID_RECORD
+
+Recombine server flight 1: TLS 1.3, insert empty record at 42 (bad)
+depends_on:MBEDTLS_SSL_PROTO_TLS1_3
+recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_3:RECOMBINE_INSERT_EMPTY:42:"rejecting empty record":"":MBEDTLS_SSL_SERVER_HELLO:MBEDTLS_ERR_SSL_INVALID_RECORD
+
+# Since there is a single unencrypted handshake message in the first flight
+# from the server, and the test code that recombines handshake records can only
+# handle plaintext records, we can't have TLS 1.3 tests with coalesced
+# handshake messages. Hence most coalesce-and-split test cases are 1.2-only.
+
+Recombine server flight 1: TLS 1.2, coalesce and split at 4
+depends_on:MBEDTLS_SSL_PROTO_TLS1_2
+recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_2:RECOMBINE_COALESCE_SPLIT_ONCE:4:"initial handshake fragment\: 4, 0..4 of":"<= handshake wrapup":MBEDTLS_SSL_HANDSHAKE_OVER:0
+
+# The last message of the first flight from the server is ServerHelloDone,
+# which is an empty handshake message, i.e. of length 4. The library doesn't
+# support fragmentation of a handshake message, so the last place where we
+# can split the flight is 4+1 = 5 bytes before it ends, with 1 byte in the
+# previous handshake message and 4 bytes of ServerHelloDone including header.
+Recombine server flight 1: TLS 1.2, coalesce and split at end-5
+depends_on:MBEDTLS_SSL_PROTO_TLS1_2
+recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_2:RECOMBINE_COALESCE_SPLIT_ONCE:-5:"subsequent handshake fragment\: 5,":"<= handshake wrapup":MBEDTLS_SSL_HANDSHAKE_OVER:0
+
+Recombine server flight 1: TLS 1.2, coalesce and split at both ends
+depends_on:MBEDTLS_SSL_PROTO_TLS1_2
+recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_2:RECOMBINE_COALESCE_SPLIT_ENDS:5:"subsequent handshake fragment\: 5,":"<= handshake wrapup":MBEDTLS_SSL_HANDSHAKE_OVER:0

--- a/tests/suites/test_suite_ssl.records.data
+++ b/tests/suites/test_suite_ssl.records.data
@@ -1,0 +1,26 @@
+Recombine server flight 1: TLS 1.2, nominal
+depends_on:MBEDTLS_SSL_PROTO_TLS1_2
+recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_2:RECOMBINE_NOMINAL:0:"<= handshake wrapup":"<= handshake wrapup":MBEDTLS_SSL_HANDSHAKE_OVER:0
+
+Recombine server flight 1: TLS 1.3, nominal
+depends_on:MBEDTLS_SSL_PROTO_TLS1_3
+recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_3:RECOMBINE_NOMINAL:0:"<= handshake wrapup":"<= handshake wrapup":MBEDTLS_SSL_TLS1_3_NEW_SESSION_TICKET_FLUSH:0
+
+Recombine server flight 1: TLS 1.2, coalesce 2
+depends_on:MBEDTLS_SSL_PROTO_TLS1_2
+recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_2:RECOMBINE_COALESCE:2:"<= handshake wrapup":"<= handshake wrapup":MBEDTLS_SSL_HANDSHAKE_OVER:0
+
+Recombine server flight 1: TLS 1.2, coalesce 3
+depends_on:MBEDTLS_SSL_PROTO_TLS1_2
+recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_2:RECOMBINE_COALESCE:3:"<= handshake wrapup":"<= handshake wrapup":MBEDTLS_SSL_HANDSHAKE_OVER:0
+
+Recombine server flight 1: TLS 1.2, coalesce all
+depends_on:MBEDTLS_SSL_PROTO_TLS1_2
+recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_2:RECOMBINE_COALESCE:INT_MAX:"<= handshake wrapup":"<= handshake wrapup":MBEDTLS_SSL_HANDSHAKE_OVER:0
+
+# TLS 1.3 has a single non-encrypted handshake record, so this doesn't
+# actually perform any coalescing. Run the test case anyway, but this does
+# very little beyond exercising the test code itself a little.
+Recombine server flight 1: TLS 1.3, coalesce all
+depends_on:MBEDTLS_SSL_PROTO_TLS1_3
+recombine_server_first_flight:MBEDTLS_SSL_VERSION_TLS1_3:RECOMBINE_COALESCE:INT_MAX:"<= handshake wrapup":"<= handshake wrapup":MBEDTLS_SSL_TLS1_3_NEW_SESSION_TICKET_FLUSH:0


### PR DESCRIPTION
Straightforward backport of https://github.com/Mbed-TLS/mbedtls/pull/10045

Status: for CI feedback. Includes additional fixes on top of #10045 which I'll forward port once they stabilize. I may still rewrite the history a little.

## PR checklist

- [x] **changelog** not required because: test only
- [x] **development PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10045
- [x] **TF-PSA-Crypto PR** not required because: TLS only
- [x] **framework PR** not required
- [x] **3.6 PR** here
- [x] **2.28 PR** not required because: 2.28 is near its end of life and we aren't adding any record-related complexity to it
- **tests**  provided
