### PR TITLE
Pk rsa alt removal

### DIFF
--- a/tests/suites/test_suite_x509write.function
+++ b/tests/suites/test_suite_x509write.function
@@ -11,37 +11,6 @@
 #include "mbedtls/pk.h"
 #include "mbedtls/psa_util.h"
 
-#if defined(MBEDTLS_PEM_WRITE_C) && \
-    defined(MBEDTLS_X509_CRT_WRITE_C) && \
-    defined(MBEDTLS_X509_CRT_PARSE_C) && \
-    defined(PSA_WANT_ALG_SHA_1) && \
-    defined(MBEDTLS_RSA_C) && defined(MBEDTLS_PK_RSA_ALT_SUPPORT)
-static int mbedtls_rsa_decrypt_func(void *ctx, size_t *olen,
-                                    const unsigned char *input, unsigned char *output,
-                                    size_t output_max_len)
-{
-    return mbedtls_rsa_pkcs1_decrypt((mbedtls_rsa_context *) ctx, NULL, NULL,
-                                     olen, input, output, output_max_len);
-}
-
-static int mbedtls_rsa_sign_func(void *ctx,
-                                 mbedtls_md_type_t md_alg, unsigned int hashlen,
-                                 const unsigned char *hash, unsigned char *sig)
-{
-    return mbedtls_rsa_pkcs1_sign((mbedtls_rsa_context *) ctx,
-                                  mbedtls_psa_get_random,
-                                  MBEDTLS_PSA_RANDOM_STATE,
-                                  md_alg,
-                                  hashlen,
-                                  hash,
-                                  sig);
-}
-static size_t mbedtls_rsa_key_len_func(void *ctx)
-{
-    return ((const mbedtls_rsa_context *) ctx)->len;
-}
-#endif
-
 #if defined(MBEDTLS_USE_PSA_CRYPTO) && \
     defined(MBEDTLS_PEM_WRITE_C) && defined(MBEDTLS_X509_CSR_WRITE_C)
 static int x509_crt_verifycsr(const unsigned char *buf, size_t buflen)
@@ -435,19 +404,6 @@ void x509_crt_check(char *subject_key_file, char *subject_pwd,
                                          issuer_pwd) == 0);
 
     issuer_key_type = mbedtls_pk_get_type(&issuer_key);
-
-#if defined(MBEDTLS_RSA_C) && defined(MBEDTLS_PK_RSA_ALT_SUPPORT)
-    /* For RSA PK contexts, create a copy as an alternative RSA context. */
-    if (pk_wrap == 1 && issuer_key_type == MBEDTLS_PK_RSA) {
-        TEST_ASSERT(mbedtls_pk_setup_rsa_alt(&issuer_key_alt,
-                                             mbedtls_pk_rsa(issuer_key),
-                                             mbedtls_rsa_decrypt_func,
-                                             mbedtls_rsa_sign_func,
-                                             mbedtls_rsa_key_len_func) == 0);
-
-        key = &issuer_key_alt;
-    }
-#endif
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     /* Turn the issuer PK context into an opaque one. */


### PR DESCRIPTION
## Description

Remove MBEDTLS_PK_RSA_ALT resolves https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/208 ~depends https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/218~ (actually the other way round)

## PR checklist

- [x] **changelog** not required because: will be on the crypto side (test only changes here)
- [x] **development PR** provided #HERE 
- [x] **TF-PSA-Crypto PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/218
- [x] **framework PR** not required
- [x] **3.6 PR** not required because: No backports
- [x] **2.28 PR** not required because: No backports
- **tests**  provided
