### PR TITLE
fix MBEDTLS_CONFIG_FILE not installing properly

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,8 +1,30 @@
 option(INSTALL_MBEDTLS_HEADERS "Install Mbed TLS headers." ON)
 
+# Check the MBEDTLS_CONFIG_FILE is valid if it is set
+if(MBEDTLS_CONFIG_FILE)
+    # we need to make sure our file paths are absolute to avoid any issues with the list command later
+    if(NOT IS_ABSOLUTE "${MBEDTLS_CONFIG_FILE}")
+        set(MBEDTLS_CONFIG_FILE "${CMAKE_CURRENT_SOURCE_DIR}/${MBEDTLS_CONFIG_FILE}")
+        message(WARNING "**** WARNING : ${PROJECT_NAME} : Converted relative path to: ${MBEDTLS_CONFIG_FILE}")
+    endif()
+
+    if(EXISTS "${MBEDTLS_CONFIG_FILE}" AND NOT IS_DIRECTORY "${MBEDTLS_CONFIG_FILE}")
+        message(STATUS "${PROJECT_NAME} : MBEDTLS_CONFIG_FILE override set to : ${MBEDTLS_CONFIG_FILE}")
+    else ()
+        message(FATAL_ERROR "${PROJECT_NAME} : MBEDTLS_CONFIG_FILE override invalid or inaccessible : ${MBEDTLS_CONFIG_FILE}")
+    endif ()
+endif ()
+
+
 if(INSTALL_MBEDTLS_HEADERS)
 
     file(GLOB headers "mbedtls/*.h")
+
+    # if the override is defined remove the default mbedtls_config.h, validity checks for the override are conducted above
+    if(MBEDTLS_CONFIG_FILE)
+        list(REMOVE_ITEM headers "${CMAKE_CURRENT_SOURCE_DIR}/mbedtls/mbedtls_config.h")
+        list(APPEND headers ${MBEDTLS_CONFIG_FILE})
+    endif ()
 
     install(FILES ${headers}
         DESTINATION include/mbedtls


### PR DESCRIPTION
fixes #9947

## Description

this is a fix for https://github.com/Mbed-TLS/mbedtls/issues/9947


## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [ ] **changelog** provided | not required because: 
- [x] **development PR** provided 
- [ ] **TF-PSA-Crypto PR** provided # | not required because: 
- [ ] **framework PR** provided Mbed-TLS/mbedtls-framework# | not required
- [ ] **3.6 PR** provided # | not required because: 
- [x] **2.28 PR** not required because: too outdated 
- [x] **tests**  provided

https://github.com/jurassicLizard/mbed-tls-cmake-build-test/tree/mbedtls/development-9947

## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
