### PR TITLE
[3.6] Add missing credit for `set_hostname` issue

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -35,6 +35,7 @@ Security
      The library will now prevent the handshake and return
      MBEDTLS_ERR_SSL_CERTIFICATE_VERIFICATION_WITHOUT_HOSTNAME
      if mbedtls_ssl_set_hostname() has not been called.
+     Reported by Daniel Stenberg.
      CVE-2025-27809
    * Zeroize a temporary heap buffer used in psa_key_derivation_output_key()
      when deriving an ECC key pair.


### PR DESCRIPTION
Correctly credit Daniel Stenberg for reporting the problem with `mbedtls_ssl_set_hostname()`, which we had forgotten to do previously.

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** not required because: ChangeLog change itself
- [x] **development PR** not required because: No published ChangeLog in development yet.
- [x] **TF-PSA-Crypto PR** not required because: update is ssl-related.
- [x] **framework PR** not required
- [x] **3.6 PR** here
- [x] **2.28 PR** not required because: 2.28 is end-of-life
- **tests**  not required because: ChangeLog update only