### PR TITLE
The LTS branch 2.28 is now EOL

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,6 @@ If the provided content is part of the present PR remove the # symbol.
 - [ ] **TF-PSA-Crypto PR** provided # | not required because: 
 - [ ] **framework PR** provided Mbed-TLS/mbedtls-framework# | not required
 - [ ] **3.6 PR** provided # | not required because: 
-- [ ] **2.28 PR** provided # | not required because: 
 - **tests**  provided | not required because: 
 
 

--- a/BRANCHES.md
+++ b/BRANCHES.md
@@ -11,7 +11,6 @@ At any point in time, we have a number of maintained branches, currently consist
   as well as all the new features and bug fixes and security fixes.
 - One or more long-time support (LTS) branches: these only get bug fixes and
   security fixes. Currently, the supported LTS branches are:
-- [`mbedtls-2.28`](https://github.com/Mbed-TLS/mbedtls/tree/mbedtls-2.28).
 - [`mbedtls-3.6`](https://github.com/Mbed-TLS/mbedtls/tree/mbedtls-3.6).
 
 We retain a number of historical branches, whose names are prefixed by `archive/`,
@@ -108,8 +107,5 @@ The following branches are currently maintained:
 - [`mbedtls-3.6`](https://github.com/Mbed-TLS/mbedtls/tree/mbedtls-3.6)
  maintained until March 2027, see
   <https://github.com/Mbed-TLS/mbedtls/releases/tag/v3.6.0>.
-- [`mbedtls-2.28`](https://github.com/Mbed-TLS/mbedtls/tree/mbedtls-2.28)
- maintained until the end of 2024, see
-  <https://github.com/Mbed-TLS/mbedtls/releases/tag/v2.28.8>.
 
 Users are urged to always use the latest version of a maintained branch.


### PR DESCRIPTION
## Description

Update BRANCHES.md and the PR template.

## PR checklist

- [x] **changelog** not required because: doc only / already announced
- [x] **development PR** provided HERE
- [x] **TF-PSA-Crypto PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/237
- [x] **framework PR** not required
- [x] **3.6 PR** not required because: PR template irrelevant, and BRANCHES.md already updated as part of the release
- [x] **2.28 PR** not required because: well that's the point
- **tests**  not required because: doc only
