### PR TITLE
Backport 3.6: Added OID of Ed448 ECDSA signature algorithm

### DIFF
--- a/library/oid.c
+++ b/library/oid.c
@@ -457,6 +457,12 @@ static const oid_sig_alg_t oid_sig_alg[] =
         MBEDTLS_MD_SHA512,   MBEDTLS_PK_ECDSA,
     },
 #endif /* MBEDTLS_MD_CAN_SHA512 */
+#if defined(MBEDTLS_MD_CAN_SHA3_256)
+    {
+        OID_DESCRIPTOR(MBEDTLS_OID_ED448,            "Ed448",                "Ed448 with SHA3-256"),
+        MBEDTLS_MD_SHA3_256, MBEDTLS_PK_ECDSA
+    },
+#endif /* MBEDTLS_MD_CAN_SHA3_256 */
 #endif /* MBEDTLS_PK_CAN_ECDSA_SOME */
 #if defined(MBEDTLS_RSA_C)
     {


### PR DESCRIPTION
Trust roots are more and more frequently signed with Ed448. Adding the related algorithm identifiers (see RFC 9481) is needed to be able to load certificates signed with Ed448.

## Description

One of my customers signs the trust roots for his embedded appliances with Ed448 signature algorithm. This results in an unknown OID error when loading such certificates. Adding the related algorithm identifier to the OID database fixes that issue.


## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [ ] **changelog** not required because: minimal 4-line change
- [ ] **development PR** not required because: change is in submodule
- [ ] **TF-PSA-Crypto PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/240
- [ ] **framework PR** not required
- **tests**  not required because: not new logic introduced
