### PR TITLE
Switch all.sh components from selftest to which_aes

### DIFF
--- a/programs/Makefile
+++ b/programs/Makefile
@@ -47,6 +47,7 @@ APPS = \
 	../tf-psa-crypto/programs/psa/key_ladder_demo \
 	../tf-psa-crypto/programs/psa/psa_constant_names \
 	../tf-psa-crypto/programs/psa/psa_hash \
+	../tf-psa-crypto/programs/test/which_aes \
 	ssl/dtls_client \
 	ssl/dtls_server \
 	ssl/mini_client \
@@ -178,6 +179,10 @@ pkey/rsa_verify_pss$(EXEXT): pkey/rsa_verify_pss.c $(DEP)
 ../tf-psa-crypto/programs/psa/psa_hash$(EXEXT): ../tf-psa-crypto/programs/psa/psa_hash.c $(DEP)
 	echo "  CC    psa/psa_hash.c"
 	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) ../tf-psa-crypto/programs/psa/psa_hash.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+
+../tf-psa-crypto/programs/test/which_aes$(EXEXT): ../tf-psa-crypto/programs/test/which_aes.c $(DEP)
+	echo "  CC    test/which_aes.c"
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) ../tf-psa-crypto/programs/test/which_aes.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 ssl/dtls_client$(EXEXT): ssl/dtls_client.c $(DEP)
 	echo "  CC    ssl/dtls_client.c"

--- a/tests/scripts/components-platform.sh
+++ b/tests/scripts/components-platform.sh
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 # components-platform.sh
 #
 # Copyright The Mbed TLS Contributors

--- a/tests/scripts/components-platform.sh
+++ b/tests/scripts/components-platform.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # components-platform.sh
 #
 # Copyright The Mbed TLS Contributors

--- a/tests/scripts/components-platform.sh
+++ b/tests/scripts/components-platform.sh
@@ -120,15 +120,17 @@ component_test_aesni () { # ~ 60s
     msg "AES tests, test intrinsics"
     make clean
     make CC=gcc CFLAGS='-Werror -Wall -Wextra -mpclmul -msse2 -maes'
-    # check that we built intrinsics - this should be used by default when supported by the compiler
-    ./programs/test/selftest aes | grep "AESNI code" | grep -q "intrinsics"
+    # check that the intrinsics implementation is in use - this should be used by default when
+    # supported by the compiler
+    ./tf-psa-crypto/programs/test/which_aes | grep -q "AESNI INTRINSICS"
 
     # test the asm implementation
     msg "AES tests, test assembly"
     make clean
     make CC=gcc CFLAGS='-Werror -Wall -Wextra -mno-pclmul -mno-sse2 -mno-aes'
-    # check that we built assembly - this should be built if the compiler does not support intrinsics
-    ./programs/test/selftest aes | grep "AESNI code" | grep -q "assembly"
+    # check that the assembly implementation is in use - this should be used if the compiler
+    # does not support intrinsics
+    ./tf-psa-crypto/programs/test/which_aes | grep -q "AESNI ASSEMBLY"
 
     # test the plain C implementation
     scripts/config.py unset MBEDTLS_AESNI_C
@@ -137,20 +139,17 @@ component_test_aesni () { # ~ 60s
     make clean
     make CC=gcc CFLAGS='-O2 -Werror'
     # check that there is no AESNI code present
-    ./programs/test/selftest aes | not grep -q "AESNI code"
-    not grep -q "AES note: using AESNI" ./programs/test/selftest
-    grep -q "AES note: built-in implementation." ./programs/test/selftest
+    not grep -q mbedtls_aesni_has_support ./tf-psa-crypto/programs/test/which_aes
+    # check that the built-in software implementation is in use
+    ./tf-psa-crypto/programs/test/which_aes | grep -q "SOFTWARE"
 
-    # test the intrinsics implementation
+    # test the AESNI implementation
     scripts/config.py set MBEDTLS_AESNI_C
     scripts/config.py set MBEDTLS_AES_USE_HARDWARE_ONLY
     msg "AES tests, test AESNI only"
     make clean
     make CC=gcc CFLAGS='-Werror -Wall -Wextra -mpclmul -msse2 -maes'
-    ./programs/test/selftest aes | grep -q "AES note: using AESNI"
-    ./programs/test/selftest aes | not grep -q "AES note: built-in implementation."
-    grep -q "AES note: using AESNI" ./programs/test/selftest
-    not grep -q "AES note: built-in implementation." ./programs/test/selftest
+    ./tf-psa-crypto/programs/test/which_aes | grep -q "AESNI"
 }
 
 support_test_aesni_m32 () {
@@ -172,21 +171,15 @@ component_test_aesni_m32 () { # ~ 60s
     make clean
     make CC=gcc CFLAGS='-m32 -Werror -Wall -Wextra' LDFLAGS='-m32'
     # check that we built intrinsics - this should be used by default when supported by the compiler
-    ./programs/test/selftest aes | grep "AESNI code" | grep -q "intrinsics"
-    grep -q "AES note: using AESNI" ./programs/test/selftest
-    grep -q "AES note: built-in implementation." ./programs/test/selftest
-    grep -q mbedtls_aesni_has_support ./programs/test/selftest
+    ./tf-psa-crypto/programs/test/which_aes | grep -q "AESNI INTRINSICS"
+    grep -q mbedtls_aesni_has_support ./tf-psa-crypto/programs/test/which_aes
 
     scripts/config.py set MBEDTLS_AESNI_C
     scripts/config.py set MBEDTLS_AES_USE_HARDWARE_ONLY
     msg "AES tests, test AESNI only"
     make clean
     make CC=gcc CFLAGS='-m32 -Werror -Wall -Wextra -mpclmul -msse2 -maes' LDFLAGS='-m32'
-    ./programs/test/selftest aes | grep -q "AES note: using AESNI"
-    ./programs/test/selftest aes | not grep -q "AES note: built-in implementation."
-    grep -q "AES note: using AESNI" ./programs/test/selftest
-    not grep -q "AES note: built-in implementation." ./programs/test/selftest
-    not grep -q mbedtls_aesni_has_support ./programs/test/selftest
+    ./tf-psa-crypto/programs/test/which_aes | grep -q "AESNI"
 }
 
 support_test_aesni_m32_clang () {
@@ -205,10 +198,8 @@ component_test_aesni_m32_clang () {
     make clean
     make CC=clang CFLAGS='-m32 -Werror -Wall -Wextra' LDFLAGS='-m32'
     # check that we built intrinsics - this should be used by default when supported by the compiler
-    ./programs/test/selftest aes | grep "AESNI code" | grep -q "intrinsics"
-    grep -q "AES note: using AESNI" ./programs/test/selftest
-    grep -q "AES note: built-in implementation." ./programs/test/selftest
-    grep -q mbedtls_aesni_has_support ./programs/test/selftest
+    ./tf-psa-crypto/programs/test/which_aes | grep -q "AESNI INTRINSICS"
+    grep -q mbedtls_aesni_has_support ./tf-psa-crypto/programs/test/which_aes
 }
 
 support_build_aes_armce () {

--- a/tests/scripts/components-platform.sh
+++ b/tests/scripts/components-platform.sh
@@ -138,8 +138,9 @@ component_test_aesni () { # ~ 60s
     msg "AES tests, plain C"
     make clean
     make CC=gcc CFLAGS='-O2 -Werror'
-    # check that there is no AESNI code present
-    not grep -q mbedtls_aesni_has_support ./tf-psa-crypto/programs/test/which_aes
+    # check that the plain C implementation is present and the AESNI one is not
+    grep -q mbedtls_internal_aes_encrypt ./tf-psa-crypto/drivers/builtin/src/aes.o
+    not grep -q mbedtls_aesni_crypt_ecb ./tf-psa-crypto/drivers/builtin/src/aesni.o
     # check that the built-in software implementation is in use
     ./tf-psa-crypto/programs/test/which_aes | grep -q "SOFTWARE"
 
@@ -149,6 +150,9 @@ component_test_aesni () { # ~ 60s
     msg "AES tests, test AESNI only"
     make clean
     make CC=gcc CFLAGS='-Werror -Wall -Wextra -mpclmul -msse2 -maes'
+    # check that the AESNI implementation is present and the plain C one is not
+    grep -q mbedtls_aesni_crypt_ecb ./tf-psa-crypto/drivers/builtin/src/aesni.o
+    not grep -q mbedtls_internal_aes_encrypt ./tf-psa-crypto/drivers/builtin/src/aes.o
     ./tf-psa-crypto/programs/test/which_aes | grep -q "AESNI"
 }
 
@@ -172,6 +176,9 @@ component_test_aesni_m32 () { # ~ 60s
     make CC=gcc CFLAGS='-m32 -Werror -Wall -Wextra' LDFLAGS='-m32'
     # check that we built intrinsics - this should be used by default when supported by the compiler
     ./tf-psa-crypto/programs/test/which_aes | grep -q "AESNI INTRINSICS"
+    # check that both the AESNI and plain C implementations are present
+    grep -q mbedtls_aesni_crypt_ecb ./tf-psa-crypto/drivers/builtin/src/aesni.o
+    grep -q mbedtls_internal_aes_encrypt ./tf-psa-crypto/drivers/builtin/src/aes.o
     grep -q mbedtls_aesni_has_support ./tf-psa-crypto/programs/test/which_aes
 
     scripts/config.py set MBEDTLS_AESNI_C
@@ -180,6 +187,10 @@ component_test_aesni_m32 () { # ~ 60s
     make clean
     make CC=gcc CFLAGS='-m32 -Werror -Wall -Wextra -mpclmul -msse2 -maes' LDFLAGS='-m32'
     ./tf-psa-crypto/programs/test/which_aes | grep -q "AESNI"
+    # check that the AESNI implementation is present and the plain C one is not
+    grep -q mbedtls_aesni_crypt_ecb ./tf-psa-crypto/drivers/builtin/src/aesni.o
+    not grep -q mbedtls_internal_aes_encrypt ./tf-psa-crypto/drivers/builtin/src/aes.o
+    not grep -q mbedtls_aesni_has_support ./tf-psa-crypto/programs/test/which_aes
 }
 
 support_test_aesni_m32_clang () {
@@ -199,6 +210,9 @@ component_test_aesni_m32_clang () {
     make CC=clang CFLAGS='-m32 -Werror -Wall -Wextra' LDFLAGS='-m32'
     # check that we built intrinsics - this should be used by default when supported by the compiler
     ./tf-psa-crypto/programs/test/which_aes | grep -q "AESNI INTRINSICS"
+    # check that both the AESNI and plain C implementations are present
+    grep -q mbedtls_aesni_crypt_ecb ./tf-psa-crypto/drivers/builtin/src/aesni.o
+    grep -q mbedtls_internal_aes_encrypt ./tf-psa-crypto/drivers/builtin/src/aes.o
     grep -q mbedtls_aesni_has_support ./tf-psa-crypto/programs/test/which_aes
 }
 


### PR DESCRIPTION
Changes components in the CI that check the AES implementation so that they no longer use `selftest`, and instead use the new program introduced in https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/199 (`which_aes`) to discover the AES implementation.

Note - due to the way `which_aes` was implemented, there is some difference in test coverage. Namely, with this new program we cannot grep the compiled file to check the result of conditional compilation (as much).
e.g. in the final test of `component_test_aesni`, the test checks the compiled `selftest` to ensure that there is no built-in/software AES implementation, however with `which_aes`, this is not possible (with the current implementation). `which_aes` _can_ check if `AESNI` code is present/absent, but not `AESCE` or software implementations. The old code does not run for `AESCE` so the main missing functionality is the ability to check if the software implementation is present or absent in the compiled code. 

So either we lose some coverage that checks which implementations are compiled (even if they are not used), or we rework `which_aes` to be more similar to `selftest` and restore this ability.

resolves https://github.com/Mbed-TLS/mbedtls/issues/10111


## PR checklist

- [x] **changelog** not required because: internal testing change
- [x] **development PR** provided: here 
- [x] **TF-PSA-Crypto PR** provided: https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/199
- [x] **framework PR** not required
- [x] **3.6 PR** not required because: 4.0/1.0 only change 
- **tests**  not required because: making changes to tests.
