### PR TITLE
[3.6] Fix demo programs' bash scripts

### DIFF
--- a/programs/psa/key_ladder_demo.sh
+++ b/programs/psa/key_ladder_demo.sh
@@ -3,6 +3,7 @@
 # Copyright The Mbed TLS Contributors
 # SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 
+. "${0%/*}/../../framework/scripts/project_detection.sh"
 . "${0%/*}/../../framework/scripts/demo_common.sh"
 
 msg <<'EOF'

--- a/programs/psa/psa_hash_demo.sh
+++ b/programs/psa/psa_hash_demo.sh
@@ -3,6 +3,7 @@
 # Copyright The Mbed TLS Contributors
 # SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 
+. "${0%/*}/../../framework/scripts/project_detection.sh"
 . "${0%/*}/../../framework/scripts/demo_common.sh"
 
 msg <<'EOF'


### PR DESCRIPTION
## Description

Recently https://github.com/Mbed-TLS/mbedtls-framework/pull/141 was merged in the framework and this requires updates in the demo programs launching scripts. This [was done](https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/181/files) in `development`, but not on the 3.6 branch. This commit solves the problem.

## PR checklist

- [ ] **changelog** not required
- [ ] **development PR** not required
- [ ] **TF-PSA-Crypto PR** not required
- [ ] **framework PR** not required
- [ ] **3.6 PR** not required
- **tests**  not required
