### PR TITLE
[3.6] Make demo_common.sh usable on its own

### DIFF
--- a/programs/psa/key_ladder_demo.sh
+++ b/programs/psa/key_ladder_demo.sh
@@ -3,7 +3,6 @@
 # Copyright The Mbed TLS Contributors
 # SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 
-. "${0%/*}/../../framework/scripts/project_detection.sh"
 . "${0%/*}/../../framework/scripts/demo_common.sh"
 
 msg <<'EOF'

--- a/programs/psa/psa_hash_demo.sh
+++ b/programs/psa/psa_hash_demo.sh
@@ -3,7 +3,6 @@
 # Copyright The Mbed TLS Contributors
 # SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 
-. "${0%/*}/../../framework/scripts/project_detection.sh"
 . "${0%/*}/../../framework/scripts/demo_common.sh"
 
 msg <<'EOF'


### PR DESCRIPTION
## Description

Resolves https://github.com/Mbed-TLS/mbedtls-framework/issues/157 for `mbedtls-3.6`

## PR checklist

- [ ] **changelog** no
- [ ] **development PR** no
- [ ] **TF-PSA-Crypto PR** https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/255
- [ ] **framework PR** https://github.com/Mbed-TLS/mbedtls-framework/pull/159
- [ ] **3.6 PR** this one
- [ ] **tests**  no