### PR TITLE
Constify cipher_wrap:mbedtls_cipher_base_lookup_table

### DIFF
--- a/library/cipher_wrap.c
+++ b/library/cipher_wrap.c
@@ -2425,7 +2425,7 @@ const mbedtls_cipher_definition_t mbedtls_cipher_definitions[] =
                      sizeof(mbedtls_cipher_definitions[0]))
 int mbedtls_cipher_supported[NUM_CIPHERS];
 
-const mbedtls_cipher_base_t *mbedtls_cipher_base_lookup_table[] = {
+const mbedtls_cipher_base_t * const mbedtls_cipher_base_lookup_table[] = {
 #if defined(MBEDTLS_AES_C)
     [MBEDTLS_CIPHER_BASE_INDEX_AES] = &aes_info,
 #endif

--- a/library/cipher_wrap.h
+++ b/library/cipher_wrap.h
@@ -169,7 +169,7 @@ extern const mbedtls_cipher_definition_t mbedtls_cipher_definitions[];
 
 extern int mbedtls_cipher_supported[];
 
-extern const mbedtls_cipher_base_t *mbedtls_cipher_base_lookup_table[];
+extern const mbedtls_cipher_base_t * const mbedtls_cipher_base_lookup_table[];
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Description

Constify cipher_wrap:mbedtls_cipher_base_lookup_table

This structure is initialized during the compilation and there is no reason it changes.
Making it const allows the compiler to put it in .rodata section instead of .data one.

## PR checklist

- [x] **changelog** not required because:  This doesn't fix anything relevant
- [x] **development PR** provided: https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/261
- [x] **TF-PSA-Crypto PR** not required because: It doesn't apply
- [x] **framework PR** not required
- [x] **3.6 PR** provided: This is the one. 
- [x] **tests**  not required because: 
