### PR TITLE
Use native socket type on Windows

### DIFF
--- a/ChangeLog.d/fix-windows-socket-type.txt
+++ b/ChangeLog.d/fix-windows-socket-type.txt
@@ -1,0 +1,4 @@
+Bugfix
+   * Fix bugs related to incorrectly using Unix-like file
+     descriptors as socket handles on Windows.
+     Resolves #10097

--- a/include/mbedtls/net_sockets.h
+++ b/include/mbedtls/net_sockets.h
@@ -76,18 +76,22 @@ extern "C" {
 /**
  * Wrapper type for sockets.
  *
- * Currently backed by just a file descriptor, but might be more in the future
+ * Currently backed by just a file descriptor or a socket handle, but might be more in the future
  * (eg two file descriptors for combined IPv4 + IPv6 support, or additional
  * structures for hand-made UDP demultiplexing).
  */
 typedef struct mbedtls_net_context {
-    /** The underlying file descriptor.
+    /** The underlying file descriptor or socket handle.
      *
      * This field is only guaranteed to be present on POSIX/Unix-like platforms.
      * On other platforms, it may have a different type, have a different
      * meaning, or be absent altogether.
      */
+#ifdef _MSC_VER
+    SOCKET fd;
+#else
     int fd;
+#endif
 }
 mbedtls_net_context;
 


### PR DESCRIPTION
## Description

Define properly socket type on Windows, and adjust checks for invalid socket.
Resolves #10097.


## PR checklist

- [x] **changelog** provided 
- [x] **TF-PSA-Crypto PR** provided [TF-PSA-Crypto/#262](https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/262)
- [x] **framework PR** not required
- [x] **3.6 PR** not required because: not planned
- **tests**  not required because: no additional tests needed