### PR TITLE
Removed use of mbedtls_cipher_info from ssl_context_info.c

### DIFF
--- a/programs/ssl/ssl_context_info.c
+++ b/programs/ssl/ssl_context_info.c
@@ -553,18 +553,7 @@ static void print_deserialized_ssl_session(const uint8_t *ssl, uint32_t len,
 
         printf("\tciphersuite    : %s\n", mbedtls_ssl_ciphersuite_get_name(ciphersuite_info));
         printf("\tcipher flags   : 0x%02X\n", ciphersuite_info->MBEDTLS_PRIVATE(flags));
-
-#if defined(MBEDTLS_CIPHER_C)
-        const mbedtls_cipher_info_t *cipher_info;
-        cipher_info = mbedtls_cipher_info_from_type(ciphersuite_info->MBEDTLS_PRIVATE(cipher));
-        if (cipher_info == NULL) {
-            printf_err("Cannot find cipher info\n");
-        } else {
-            printf("\tcipher         : %s\n", mbedtls_cipher_info_get_name(cipher_info));
-        }
-#else /* MBEDTLS_CIPHER_C */
         printf("\tcipher type     : %d\n", ciphersuite_info->MBEDTLS_PRIVATE(cipher));
-#endif /* MBEDTLS_CIPHER_C */
 
 #if defined(MBEDTLS_MD_C)
         md_info = mbedtls_md_info_from_type(ciphersuite_info->MBEDTLS_PRIVATE(mac));


### PR DESCRIPTION
## Description

Implements changes described in #9977 



## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog**  not required because:  This doesn't fix anything relevant
- [x] **development PR** not required because:  This is going to be refactored
- [x] **TF-PSA-Crypto PR** not required because: It doesn't apply
- [x] **framework PR** not required
- [x] **3.6 PR** not required because: 
- [x] **tests**  not required because: 
