### PR TITLE
Remove `MBEDTLS_SHA3_C` config option

### DIFF
--- a/programs/test/selftest.c
+++ b/programs/test/selftest.c
@@ -294,7 +294,10 @@ const selftest_t selftests[] =
 #if defined(MBEDTLS_SHA512_C)
     { "sha512", mbedtls_sha512_self_test },
 #endif
-#if defined(MBEDTLS_SHA3_C)
+#if defined(PSA_WANT_ALG_SHA3_224) || \
+    defined(PSA_WANT_ALG_SHA3_256) || \
+    defined(PSA_WANT_ALG_SHA3_384) || \
+    defined(PSA_WANT_ALG_SHA3_512)
     { "sha3", mbedtls_sha3_self_test },
 #endif
 #if defined(MBEDTLS_DES_C)

--- a/tests/scripts/components-configuration-crypto.sh
+++ b/tests/scripts/components-configuration-crypto.sh
@@ -1554,7 +1554,7 @@ component_test_psa_crypto_config_accel_hash () {
     scripts/config.py unset MBEDTLS_SHA256_C
     scripts/config.py unset MBEDTLS_SHA384_C
     scripts/config.py unset MBEDTLS_SHA512_C
-    scripts/config.py unset MBEDTLS_SHA3_C
+    scripts/config.py unset-all PSA_WANT_ALG_SHA3_*
 
     # Build
     # -----
@@ -1594,7 +1594,7 @@ config_psa_crypto_hash_use_psa () {
         scripts/config.py unset MBEDTLS_SHA384_C
         scripts/config.py unset MBEDTLS_SHA512_C
         scripts/config.py unset MBEDTLS_SHA512_USE_A64_CRYPTO_IF_PRESENT
-        scripts/config.py unset MBEDTLS_SHA3_C
+        scripts/config.py unset-all PSA_WANT_ALG_SHA3_*
     fi
 }
 

--- a/tests/scripts/depends.py
+++ b/tests/scripts/depends.py
@@ -346,10 +346,6 @@ REVERSE_DEPENDENCIES = {
     'MBEDTLS_SHA512_C': ['MBEDTLS_SHA512_USE_A64_CRYPTO_IF_PRESENT',
                          'MBEDTLS_SHA512_USE_A64_CRYPTO_ONLY',
                          'PSA_WANT_ALG_SHA_512'],
-    'MBEDTLS_SHA3_C' : ['PSA_WANT_ALG_SHA3_224',
-                        'PSA_WANT_ALG_SHA3_256',
-                        'PSA_WANT_ALG_SHA3_384',
-                        'PSA_WANT_ALG_SHA3_512'],
 }
 
 # If an option is tested in an exclusive test, alter the following defines.


### PR DESCRIPTION
## Description

Replace uses of MBEDTLS_SHA3_C config option with PSA_WANT macros.

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [ ] **changelog** provided | not required because: 
- [x] **development PR** not required because: this is
- [x] **TF-PSA-Crypto PR** provided Mbed-TLS/TF-PSA-Crypto#266
- [x] **framework PR** not required
- [x] **3.6 PR** not required because: 4.0 changes
- **tests**  provided
