### PR TITLE
Pylint: Complain about a missing comma in multiline lists of strings

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -70,6 +70,17 @@ disable=locally-disabled,locally-enabled,logging-format-interpolation,no-else-re
 # Don't diplay statistics. Just the facts.
 reports=no
 
+[STRING]
+# Complain about
+# ```
+# list_of_strings = [
+#    'foo' # <-- missing comma
+#    'bar',
+#    'corge',
+# ]
+# ```
+check-str-concat-over-line-jumps=yes
+
 [VARIABLES]
 # Allow unused variables if their name starts with an underscore.
 # [unused-argument]


### PR DESCRIPTION
Have Pylint complain about a likely missing comma in e.g.
```
mylist = [
    "foo"
    "bar",
    "corge",
]
```

(Patch made because I spotted this in a review and I feel Pylint should have spotted it before me.)

## PR checklist

- [x] **changelog** not required because: test only
- [x] **development PR** here
- [x] **TF-PSA-Crypto PR** https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/268
- [x] **framework PR** https://github.com/Mbed-TLS/mbedtls-framework/pull/163
- [x] **3.6 PR** https://github.com/Mbed-TLS/mbedtls/pull/10150
- **tests**  provided
