### PR TITLE
Test with GCC 15

### DIFF
--- a/programs/test/dlopen.c
+++ b/programs/test/dlopen.c
@@ -50,8 +50,15 @@ int main(void)
 #if defined(MBEDTLS_SSL_TLS_C)
     void *tls_so = dlopen(TLS_SO_FILENAME, RTLD_NOW);
     CHECK_DLERROR("dlopen", TLS_SO_FILENAME);
+#pragma GCC diagnostic push
+    /* dlsym() returns an object pointer which is meant to be used as a
+     * function pointer. This has undefined behavior in standard C, so
+     * "gcc -std=c99 -pedantic" complains about it, but it is perfectly
+     * fine on platforms that have dlsym(). */
+#pragma GCC diagnostic ignored "-Wpedantic"
     const int *(*ssl_list_ciphersuites)(void) =
         dlsym(tls_so, "mbedtls_ssl_list_ciphersuites");
+#pragma GCC diagnostic pop
     CHECK_DLERROR("dlsym", "mbedtls_ssl_list_ciphersuites");
     const int *ciphersuites = ssl_list_ciphersuites();
     for (n = 0; ciphersuites[n] != 0; n++) {/* nothing to do, we're just counting */
@@ -85,9 +92,15 @@ int main(void)
         CHECK_DLERROR("dlopen", TFPSACRYPTO_SO_FILENAME);
         crypto_so_filename = TFPSACRYPTO_SO_FILENAME;
     }
-
+#pragma GCC diagnostic push
+    /* dlsym() returns an object pointer which is meant to be used as a
+     * function pointer. This has undefined behavior in standard C, so
+     * "gcc -std=c99 -pedantic" complains about it, but it is perfectly
+     * fine on platforms that have dlsym(). */
+#pragma GCC diagnostic ignored "-Wpedantic"
     const int *(*md_list)(void) =
         dlsym(crypto_so, "mbedtls_md_list");
+#pragma GCC diagnostic pop
     CHECK_DLERROR("dlsym", "mbedtls_md_list");
     const int *mds = md_list();
     for (n = 0; mds[n] != 0; n++) {/* nothing to do, we're just counting */

--- a/tests/scripts/components-compiler.sh
+++ b/tests/scripts/components-compiler.sh
@@ -73,6 +73,23 @@ support_test_gcc_latest_opt () {
     type "$GCC_LATEST" >/dev/null 2>/dev/null
 }
 
+# Prepare for a non-regression for https://github.com/Mbed-TLS/mbedtls/issues/9814 :
+# test with GCC 15 (initially, a snapshot, since GCC 15 isn't released yet
+# at the time of writing).
+# Eventually, $GCC_LATEST will be GCC 15 or above, and we can remove this
+# separate component.
+# For the time being, we don't make $GCC_LATEST be GCC 15 on the CI
+# platform, because that would break branches where #9814 isn'f fixed yet.
+support_test_gcc15_opt () {
+    test -x /usr/local/gcc-15/bin/gcc-15
+}
+component_test_gcc15_opt () {
+    scripts/config.py full
+    # Until https://github.com/Mbed-TLS/mbedtls/issues/9814 is fixed,
+    # disable the new problematic optimization.
+    test_build_opt 'full config' "/usr/local/gcc-15/bin/gcc-15 -fzero-init-padding-bits=unions" -O2
+}
+
 component_test_gcc_earliest_opt () {
     scripts/config.py full
     test_build_opt 'full config' "$GCC_EARLIEST" -O2

--- a/tests/scripts/components-compiler.sh
+++ b/tests/scripts/components-compiler.sh
@@ -87,7 +87,9 @@ component_test_gcc15_opt () {
     scripts/config.py full
     # Until https://github.com/Mbed-TLS/mbedtls/issues/9814 is fixed,
     # disable the new problematic optimization.
-    test_build_opt 'full config' "/usr/local/gcc-15/bin/gcc-15 -fzero-init-padding-bits=unions" -O2
+    # Also disable a warning that we don't yet comply to.
+    make CC="/usr/local/gcc-15/bin/gcc-15" CFLAGS="-O2 -Wall -Wextra -Werror -fzero-init-padding-bits=unions -Wno-error=unterminated-string-initialization"
+    make test
 }
 
 component_test_gcc_earliest_opt () {

--- a/tests/scripts/components-compiler.sh
+++ b/tests/scripts/components-compiler.sh
@@ -80,15 +80,23 @@ support_test_gcc_latest_opt () {
 # separate component.
 # For the time being, we don't make $GCC_LATEST be GCC 15 on the CI
 # platform, because that would break branches where #9814 isn'f fixed yet.
-support_test_gcc15_opt () {
+support_test_gcc15_drivers_opt () {
     test -x /usr/local/gcc-15/bin/gcc-15
 }
-component_test_gcc15_opt () {
+component_test_gcc15_drivers_opt () {
+    msg "build: GCC 15: full + test drivers dispatching to builtins"
     scripts/config.py full
+    loc_cflags="$ASAN_CFLAGS -DPSA_CRYPTO_DRIVER_TEST -DMBEDTLS_CONFIG_ADJUST_TEST_ACCELERATORS"
+    loc_cflags="${loc_cflags} -I../framework/tests/include -O2"
     # Until https://github.com/Mbed-TLS/mbedtls/issues/9814 is fixed,
     # disable the new problematic optimization.
+    loc_cflags="${loc_cflags} -fzero-init-padding-bits=unions"
     # Also disable a warning that we don't yet comply to.
-    make CC="/usr/local/gcc-15/bin/gcc-15" CFLAGS="-O2 -Wall -Wextra -Werror -fzero-init-padding-bits=unions -Wno-error=unterminated-string-initialization"
+    loc_cflags="${loc_cflags} -Wno-error=unterminated-string-initialization"
+
+    make CC=/usr/local/gcc-15/bin/gcc-15 CFLAGS="${loc_cflags}" LDFLAGS="$ASAN_CFLAGS"
+
+    msg "test: GCC 15: full + test drivers dispatching to builtins"
     make test
 }
 

--- a/tests/scripts/components-compiler.sh
+++ b/tests/scripts/components-compiler.sh
@@ -81,7 +81,13 @@ support_test_gcc_latest_opt () {
 # For the time being, we don't make $GCC_LATEST be GCC 15 on the CI
 # platform, because that would break branches where #9814 isn'f fixed yet.
 support_test_gcc15_drivers_opt () {
-    test -x /usr/local/gcc-15/bin/gcc-15
+    if type gcc-15 >/dev/null 2>/dev/null; then
+        GCC_15=gcc-15
+    elif [ -x /usr/local/gcc-15/bin/gcc-15 ]; then
+        GCC_15=/usr/local/gcc-15/bin/gcc-15
+    else
+        return 1
+    fi
 }
 component_test_gcc15_drivers_opt () {
     msg "build: GCC 15: full + test drivers dispatching to builtins"
@@ -94,7 +100,7 @@ component_test_gcc15_drivers_opt () {
     # Also disable a warning that we don't yet comply to.
     loc_cflags="${loc_cflags} -Wno-error=unterminated-string-initialization"
 
-    make CC=/usr/local/gcc-15/bin/gcc-15 CFLAGS="${loc_cflags}" LDFLAGS="$ASAN_CFLAGS"
+    make CC=$GCC_15 CFLAGS="${loc_cflags}" LDFLAGS="$ASAN_CFLAGS"
 
     msg "test: GCC 15: full + test drivers dispatching to builtins"
     make test

--- a/tests/scripts/components-compiler.sh
+++ b/tests/scripts/components-compiler.sh
@@ -74,12 +74,11 @@ support_test_gcc_latest_opt () {
 }
 
 # Prepare for a non-regression for https://github.com/Mbed-TLS/mbedtls/issues/9814 :
-# test with GCC 15 (initially, a snapshot, since GCC 15 isn't released yet
-# at the time of writing).
+# test with GCC 15.
 # Eventually, $GCC_LATEST will be GCC 15 or above, and we can remove this
 # separate component.
 # For the time being, we don't make $GCC_LATEST be GCC 15 on the CI
-# platform, because that would break branches where #9814 isn'f fixed yet.
+# platform, because that would break branches where #9814 isn't fixed yet.
 support_test_gcc15_drivers_opt () {
     if type gcc-15 >/dev/null 2>/dev/null; then
         GCC_15=gcc-15
@@ -97,7 +96,8 @@ component_test_gcc15_drivers_opt () {
     # Until https://github.com/Mbed-TLS/mbedtls/issues/9814 is fixed,
     # disable the new problematic optimization.
     loc_cflags="${loc_cflags} -fzero-init-padding-bits=unions"
-    # Also disable a warning that we don't yet comply to.
+    # Also allow a warning that we don't yet comply to.
+    # https://github.com/Mbed-TLS/mbedtls/issues/9944
     loc_cflags="${loc_cflags} -Wno-error=unterminated-string-initialization"
 
     make CC=$GCC_15 CFLAGS="${loc_cflags}" LDFLAGS="$ASAN_CFLAGS"


### PR DESCRIPTION
Resolves https://github.com/Mbed-TLS/mbedtls/issues/9884. Preliminaries for the bug fix to https://github.com/Mbed-TLS/mbedtls/issues/9814. Start testing with GCC 15, but using the workaround `-fzero-init-padding-bits=unions` until we actually fix the bug. Also some miscellaneous things I found useful in https://github.com/Mbed-TLS/mbedtls/pull/9955. Also update the crypto submodule (the framework is already at the tip of main).

Forward-ported from 3.6. Differences:

* Some parts are in crypto now.
* "Enable drivers when testing with GCC 15": Different way to build with all drivers.

## PR checklist

- [x] **changelog** not required because: test and refactoring only
- [x] **development PR** here
- [x] **TF-PSA-Crypto PR** https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/272
- [x] **framework PR** not required
- [x] **3.6 PR** https://github.com/Mbed-TLS/mbedtls/pull/10151
- **tests**  provided | not required because: 
