### PR TITLE
Fix bug in bump_version.sh

### DIFF
--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -124,8 +124,8 @@ cat include/mbedtls/build_info.h |                                    \
 mv tmp include/mbedtls/build_info.h
 
 [ $VERBOSE ] && echo "Bumping version in tests/suites/test_suite_version.data"
-sed -e "s/version:\".\{1,\}/version:\"$VERSION\"/g" < tf-psa-crypto/tests/suites/test_suite_version.data > tmp
-mv tmp tf-psa-crypto/tests/suites/test_suite_version.data
+sed -e "s/version:\".\{1,\}/version:\"$VERSION\"/g" < tests/suites/test_suite_version.data > tmp
+mv tmp tests/suites/test_suite_version.data
 
 [ $VERBOSE ] && echo "Bumping PROJECT_NAME in doxygen/mbedtls.doxyfile and doxygen/input/doc_mainpage.h"
 for i in doxygen/mbedtls.doxyfile doxygen/input/doc_mainpage.h;


### PR DESCRIPTION
This had not been updated after test_suite_version was moved back to mbedtls from TF-PSA-Crypto.

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** not required because: Minor internal fix
- [x] **development PR** here 
- [x] **TF-PSA-Crypto PR** not required because: Issue not in crypto
- [x] **framework PR** not required
- [x] **3.6 PR** not required because: Issue not in 3.6
- **tests**  not required because: Script fix only