### PR TITLE
[Backport 3.6] adjust_legacy_from_psa: Add XTS algorithm support

### DIFF
--- a/include/mbedtls/config_adjust_legacy_from_psa.h
+++ b/include/mbedtls/config_adjust_legacy_from_psa.h
@@ -859,6 +859,12 @@
 #endif
 #endif /* PSA_WANT_ALG_GCM */
 
+#if defined(PSA_WANT_ALG_XTS)
+#if !defined(MBEDTLS_PSA_ACCEL_ALG_XTS)
+#define MBEDTLS_PSA_BUILTIN_ALG_XTS 1
+#endif
+#endif /* PSA_WANT_ALG_XTS */
+
 #if defined(PSA_WANT_ALG_CHACHA20_POLY1305)
 #if !defined(MBEDTLS_PSA_ACCEL_ALG_CHACHA20_POLY1305)
 #if defined(PSA_WANT_KEY_TYPE_CHACHA20)

--- a/include/psa/crypto_config.h
+++ b/include/psa/crypto_config.h
@@ -79,6 +79,7 @@
 #define PSA_WANT_ALG_TLS12_PRF                  1
 #define PSA_WANT_ALG_TLS12_PSK_TO_MS            1
 #define PSA_WANT_ALG_TLS12_ECJPAKE_TO_PMS       1
+#define PSA_WANT_ALG_XTS                        1
 
 #define PSA_WANT_ECC_BRAINPOOL_P_R1_256         1
 #define PSA_WANT_ECC_BRAINPOOL_P_R1_384         1

--- a/library/psa_crypto_cipher.c
+++ b/library/psa_crypto_cipher.c
@@ -174,6 +174,11 @@ psa_status_t mbedtls_cipher_values_from_psa(
                 *mode = MBEDTLS_MODE_CBC;
                 break;
 #endif
+#if defined(MBEDTLS_PSA_BUILTIN_ALG_XTS)
+            case PSA_ALG_XTS:
+                *mode = MBEDTLS_MODE_XTS;
+                break;
+#endif
 #if defined(MBEDTLS_PSA_BUILTIN_ALG_CCM_STAR_NO_TAG)
             case PSA_ALG_CCM_STAR_NO_TAG:
                 *mode = MBEDTLS_MODE_CCM_STAR_NO_TAG;


### PR DESCRIPTION
## Description

Fix https://github.com/Mbed-TLS/mbedtls/issues/6384 in mbedtls 3.6

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [ ] **changelog** provided | not required because: 
- [ ] **development PR** not required because: mbedtls 3.6
- [ ] **TF-PSA-Crypto PR** not required because:  mbedtls 3.6
- [ ] **framework PR** not required
- [ ] **3.6 PR** provided
- **tests** no
