### PR TITLE
Remove guards for tf-psa-crypto/include/mbedtls conditionals

### DIFF
--- a/programs/test/generate_cpp_dummy_build.sh
+++ b/programs/test/generate_cpp_dummy_build.sh
@@ -52,11 +52,9 @@ EOF
         esac
     done
 
-    if [ -d "tf-psa-crypto/include/mbedtls" ]; then
-        for header in tf-psa-crypto/include/mbedtls/*.h; do
-            echo "#include \"${header#tf-psa-crypto/include/}\""
-        done
-    fi
+    for header in tf-psa-crypto/include/mbedtls/*.h; do
+        echo "#include \"${header#tf-psa-crypto/include/}\""
+    done
 
     for header in tf-psa-crypto/include/psa/*.h; do
         case ${header#tf-psa-crypto/include/} in

--- a/tests/scripts/libtestdriver1_rewrite.pl
+++ b/tests/scripts/libtestdriver1_rewrite.pl
@@ -25,9 +25,8 @@ while (<>) {
     # included in files via #include mbedtls/<file>.h, so when expanding to the
     # full path make sure that files in include/mbedtls are not expanded
     # to driver/builtin/include/mbedtls.
-    if ( $public_files_regex ) {
-        s!^(\s*#\s*include\s*[\"<])mbedtls/($public_files_regex)!${1}libtestdriver1/tf-psa-crypto/include/mbedtls/${2}!;
-    }
+    s!^(\s*#\s*include\s*[\"<])mbedtls/($public_files_regex)!${1}libtestdriver1/tf-psa-crypto/include/mbedtls/${2}!;
+
     s!^(\s*#\s*include\s*[\"<])mbedtls/!${1}libtestdriver1/tf-psa-crypto/drivers/builtin/include/mbedtls/!;
     s!^(\s*#\s*include\s*[\"<])psa/!${1}libtestdriver1/tf-psa-crypto/include/psa/!;
     s!^(\s*#\s*include\s*[\"<])tf-psa-crypto/!${1}libtestdriver1/tf-psa-crypto/include/tf-psa-crypto/!;


### PR DESCRIPTION
Now that https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/247 is merged, the conditionals added in https://github.com/Mbed-TLS/mbedtls/pull/10122 to account for both scenarios (i.e. when `tf-psa-crypto/include/mbedtls` exists with files and when it doesn't exist) can be removed.

n.b. Once this is merged, patches in `TF-PSA-Crypto` will need to be rebased on top of https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/247 to pass the CI. Perhaps it makes sense to wait a bit before merging this patch as it's not an important change and will save extra rebases for PRs that are not based on top of https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/247.

## PR checklist

- [ ] **changelog** not required because: minor internal change
- [ ] **development PR** provided: HERE 
- [ ] **TF-PSA-Crypto PR** not required because: mbedtls minor change only
- [ ] **framework PR** not required
- [ ] **3.6 PR** not required because: 4.0/1.0 work
- **tests** not required because: minor non-functional change