### PR TITLE
Add missing dependencies in library CMakeLists.txt

### DIFF
--- a/ChangeLog.d/fix-dependency-on-generated-files.txt
+++ b/ChangeLog.d/fix-dependency-on-generated-files.txt
@@ -1,0 +1,4 @@
+Bugfix
+    * Fix potential CMake parallel build failure due to missing dependencies.
+      The `mbedcrypto` and `mbedtls` libraries were missing dependencies on
+      generated files.

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -187,6 +187,19 @@ if(GEN_FILES)
             ${CMAKE_CURRENT_SOURCE_DIR}/../scripts/data_files/driver_templates/psa_crypto_driver_wrappers.h.jinja
             ${CMAKE_CURRENT_SOURCE_DIR}/../scripts/data_files/driver_templates/psa_crypto_driver_wrappers_no_static.c.jinja
     )
+
+    add_custom_target(${MBEDTLS_TARGET_PREFIX}mbedcrypto_generated_files_target
+        DEPENDS
+            ${CMAKE_CURRENT_BINARY_DIR}/error.c
+            ${CMAKE_CURRENT_BINARY_DIR}/version_features.c
+            ${CMAKE_CURRENT_BINARY_DIR}/psa_crypto_driver_wrappers.h
+            ${CMAKE_CURRENT_BINARY_DIR}/psa_crypto_driver_wrappers_no_static.c
+    )
+
+    add_custom_target(${MBEDTLS_TARGET_PREFIX}mbedtls_generated_files_target
+        DEPENDS
+            ${CMAKE_CURRENT_BINARY_DIR}/ssl_debug_helpers_generated.c
+    )
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCC)
@@ -288,6 +301,13 @@ if(USE_STATIC_MBEDTLS_LIBRARY)
     add_library(${mbedtls_static_target} STATIC ${src_tls})
     set_target_properties(${mbedtls_static_target} PROPERTIES OUTPUT_NAME mbedtls)
     target_link_libraries(${mbedtls_static_target} PUBLIC ${libs} ${mbedx509_static_target})
+
+    if(GEN_FILES)
+        add_dependencies(${mbedcrypto_static_target}
+            ${MBEDTLS_TARGET_PREFIX}mbedcrypto_generated_files_target)
+        add_dependencies(${mbedtls_static_target}
+            ${MBEDTLS_TARGET_PREFIX}mbedtls_generated_files_target)
+    endif()
 endif(USE_STATIC_MBEDTLS_LIBRARY)
 
 if(USE_SHARED_MBEDTLS_LIBRARY)
@@ -311,6 +331,13 @@ if(USE_SHARED_MBEDTLS_LIBRARY)
     add_library(${mbedtls_target} SHARED ${src_tls})
     set_target_properties(${mbedtls_target} PROPERTIES VERSION 3.6.3 SOVERSION 21)
     target_link_libraries(${mbedtls_target} PUBLIC ${libs} ${mbedx509_target})
+
+    if(GEN_FILES)
+        add_dependencies(${mbedcrypto_target}
+            ${MBEDTLS_TARGET_PREFIX}mbedcrypto_generated_files_target)
+        add_dependencies(${mbedtls_target}
+            ${MBEDTLS_TARGET_PREFIX}mbedtls_generated_files_target)
+    endif()
 endif(USE_SHARED_MBEDTLS_LIBRARY)
 
 foreach(target IN LISTS target_libraries)

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -187,13 +187,6 @@ if(GEN_FILES)
             ${CMAKE_CURRENT_SOURCE_DIR}/../scripts/data_files/driver_templates/psa_crypto_driver_wrappers.h.jinja
             ${CMAKE_CURRENT_SOURCE_DIR}/../scripts/data_files/driver_templates/psa_crypto_driver_wrappers_no_static.c.jinja
     )
-
-
-else()
-    link_to_source(error.c)
-    link_to_source(version_features.c)
-    link_to_source(ssl_debug_helpers_generated.c)
-    link_to_source(psa_crypto_driver_wrappers_no_static.c)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCC)


### PR DESCRIPTION
## Description
Fix potential CMake parallel build failure due to missing dependencies
See https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/286

## PR checklist
- [x] **changelog** present
- [x] **development PR** #10176 
- [x] **TF-PSA-Crypto PR** #Mbed-TLS/tf-psa-crypto#292
- [x] **3.6 PR** here
- **tests**  not required because: CI multi-processor CMake builds (j2) exercise this 