### PR TITLE
Test with GCC 15 with sloppy union initialization

### DIFF
--- a/tests/scripts/components-compiler.sh
+++ b/tests/scripts/components-compiler.sh
@@ -93,10 +93,7 @@ component_test_gcc15_drivers_opt () {
     scripts/config.py full
     loc_cflags="$ASAN_CFLAGS -DPSA_CRYPTO_DRIVER_TEST -DMBEDTLS_CONFIG_ADJUST_TEST_ACCELERATORS"
     loc_cflags="${loc_cflags} -I../framework/tests/include -O2"
-    # Until https://github.com/Mbed-TLS/mbedtls/issues/9814 is fixed,
-    # disable the new problematic optimization.
-    loc_cflags="${loc_cflags} -fzero-init-padding-bits=unions"
-    # Also allow a warning that we don't yet comply to.
+    # Allow a warning that we don't yet comply to.
     # https://github.com/Mbed-TLS/mbedtls/issues/9944
     loc_cflags="${loc_cflags} -Wno-error=unterminated-string-initialization"
 


### PR DESCRIPTION
Update the GCC 15 testing to have basic non-regression testing for https://github.com/Mbed-TLS/mbedtls/issues/9814 and https://github.com/Mbed-TLS/mbedtls/issues/9975. See https://github.com/Mbed-TLS/mbedtls/pull/10168 for more explanations.

Needs preceding PR: update crypto with https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/295.

## PR checklist

- [x] **changelog** provided
- [x] **development PR** here
- [x] **TF-PSA-Crypto PR** https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/295
- [x] **framework PR** not required
- [x] **3.6 PR** https://github.com/Mbed-TLS/mbedtls/pull/10168
- **tests**  provided with GCC 15; more to follow in https://github.com/Mbed-TLS/mbedtls-framework/pull/168 and https://github.com/Mbed-TLS/mbedtls/pull/10178
