### PR TITLE
Backport 3.6: Check union initialization portably

### DIFF
--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -2917,13 +2917,15 @@ void hash_operation_init()
      * Clang 5 complains when `-Wmissing-field-initializers` is used, even
      * though it's OK by the C standard. We could test for this, but we'd need
      * to suppress the Clang warning for the test. */
-    psa_hash_operation_t func = psa_hash_operation_init_short();
-    psa_hash_operation_t init = psa_hash_operation_init_short();
+    psa_hash_operation_t short_wrapper = psa_hash_operation_init_short();
+    psa_hash_operation_t func = psa_hash_operation_init();
+    psa_hash_operation_t init = PSA_HASH_OPERATION_INIT;
     psa_hash_operation_t zero;
-
     memset(&zero, 0, sizeof(zero));
 
     /* A freshly-initialized hash operation should not be usable. */
+    TEST_EQUAL(psa_hash_update(&short_wrapper, input, sizeof(input)),
+               PSA_ERROR_BAD_STATE);
     TEST_EQUAL(psa_hash_update(&func, input, sizeof(input)),
                PSA_ERROR_BAD_STATE);
     TEST_EQUAL(psa_hash_update(&init, input, sizeof(input)),
@@ -2932,6 +2934,7 @@ void hash_operation_init()
                PSA_ERROR_BAD_STATE);
 
     /* A default hash operation should be abortable without error. */
+    PSA_ASSERT(psa_hash_abort(&short_wrapper));
     PSA_ASSERT(psa_hash_abort(&func));
     PSA_ASSERT(psa_hash_abort(&init));
     PSA_ASSERT(psa_hash_abort(&zero));
@@ -3437,13 +3440,16 @@ void mac_operation_init()
      * Clang 5 complains when `-Wmissing-field-initializers` is used, even
      * though it's OK by the C standard. We could test for this, but we'd need
      * to suppress the Clang warning for the test. */
-    psa_mac_operation_t func = psa_mac_operation_init_short();
-    psa_mac_operation_t init = psa_mac_operation_init_short();
+    psa_mac_operation_t short_wrapper = psa_mac_operation_init_short();
+    psa_mac_operation_t func = psa_mac_operation_init();
+    psa_mac_operation_t init = PSA_MAC_OPERATION_INIT;
     psa_mac_operation_t zero;
-
     memset(&zero, 0, sizeof(zero));
 
     /* A freshly-initialized MAC operation should not be usable. */
+    TEST_EQUAL(psa_mac_update(&short_wrapper,
+                              input, sizeof(input)),
+               PSA_ERROR_BAD_STATE);
     TEST_EQUAL(psa_mac_update(&func,
                               input, sizeof(input)),
                PSA_ERROR_BAD_STATE);
@@ -3455,6 +3461,7 @@ void mac_operation_init()
                PSA_ERROR_BAD_STATE);
 
     /* A default MAC operation should be abortable without error. */
+    PSA_ASSERT(psa_mac_abort(&short_wrapper));
     PSA_ASSERT(psa_mac_abort(&func));
     PSA_ASSERT(psa_mac_abort(&init));
     PSA_ASSERT(psa_mac_abort(&zero));
@@ -3862,13 +3869,18 @@ void cipher_operation_init()
      * Clang 5 complains when `-Wmissing-field-initializers` is used, even
      * though it's OK by the C standard. We could test for this, but we'd need
      * to suppress the Clang warning for the test. */
-    psa_cipher_operation_t func = psa_cipher_operation_init_short();
-    psa_cipher_operation_t init = psa_cipher_operation_init_short();
+    psa_cipher_operation_t short_wrapper = psa_cipher_operation_init_short();
+    psa_cipher_operation_t func = psa_cipher_operation_init();
+    psa_cipher_operation_t init = PSA_CIPHER_OPERATION_INIT;
     psa_cipher_operation_t zero;
-
     memset(&zero, 0, sizeof(zero));
 
     /* A freshly-initialized cipher operation should not be usable. */
+    TEST_EQUAL(psa_cipher_update(&short_wrapper,
+                                 input, sizeof(input),
+                                 output, sizeof(output),
+                                 &output_length),
+               PSA_ERROR_BAD_STATE);
     TEST_EQUAL(psa_cipher_update(&func,
                                  input, sizeof(input),
                                  output, sizeof(output),
@@ -3886,6 +3898,7 @@ void cipher_operation_init()
                PSA_ERROR_BAD_STATE);
 
     /* A default cipher operation should be abortable without error. */
+    PSA_ASSERT(psa_cipher_abort(&short_wrapper));
     PSA_ASSERT(psa_cipher_abort(&func));
     PSA_ASSERT(psa_cipher_abort(&init));
     PSA_ASSERT(psa_cipher_abort(&zero));
@@ -8736,13 +8749,15 @@ void key_derivation_init()
      * though it's OK by the C standard. We could test for this, but we'd need
      * to suppress the Clang warning for the test. */
     size_t capacity;
-    psa_key_derivation_operation_t func = psa_key_derivation_operation_init_short();
-    psa_key_derivation_operation_t init = psa_key_derivation_operation_init_short();
+    psa_key_derivation_operation_t short_wrapper = psa_key_derivation_operation_init_short();
+    psa_key_derivation_operation_t func = psa_key_derivation_operation_init();
+    psa_key_derivation_operation_t init = PSA_KEY_DERIVATION_OPERATION_INIT;
     psa_key_derivation_operation_t zero;
-
     memset(&zero, 0, sizeof(zero));
 
     /* A default operation should not be able to report its capacity. */
+    TEST_EQUAL(psa_key_derivation_get_capacity(&short_wrapper, &capacity),
+               PSA_ERROR_BAD_STATE);
     TEST_EQUAL(psa_key_derivation_get_capacity(&func, &capacity),
                PSA_ERROR_BAD_STATE);
     TEST_EQUAL(psa_key_derivation_get_capacity(&init, &capacity),
@@ -8751,6 +8766,7 @@ void key_derivation_init()
                PSA_ERROR_BAD_STATE);
 
     /* A default operation should be abortable without error. */
+    PSA_ASSERT(psa_key_derivation_abort(&short_wrapper));
     PSA_ASSERT(psa_key_derivation_abort(&func));
     PSA_ASSERT(psa_key_derivation_abort(&init));
     PSA_ASSERT(psa_key_derivation_abort(&zero));

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -343,7 +343,7 @@ static int aead_multipart_internal_func(int key_type_arg, data_t *key_data,
     mbedtls_svc_key_id_t key = MBEDTLS_SVC_KEY_ID_INIT;
     psa_key_type_t key_type = key_type_arg;
     psa_algorithm_t alg = alg_arg;
-    psa_aead_operation_t operation = PSA_AEAD_OPERATION_INIT;
+    psa_aead_operation_t operation = psa_aead_operation_init_short();
     unsigned char *output_data = NULL;
     unsigned char *part_data = NULL;
     unsigned char *final_data = NULL;
@@ -598,7 +598,7 @@ static int mac_multipart_internal_func(int key_type_arg, data_t *key_data,
     mbedtls_svc_key_id_t key = MBEDTLS_SVC_KEY_ID_INIT;
     psa_key_type_t key_type = key_type_arg;
     psa_algorithm_t alg = alg_arg;
-    psa_mac_operation_t operation = PSA_MAC_OPERATION_INIT;
+    psa_mac_operation_t operation = psa_mac_operation_init_short();
     unsigned char mac[PSA_MAC_MAX_SIZE];
     size_t part_offset = 0;
     size_t part_length = 0;
@@ -2147,7 +2147,7 @@ void mac_key_policy(int policy_usage_arg,
 {
     mbedtls_svc_key_id_t key = MBEDTLS_SVC_KEY_ID_INIT;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
-    psa_mac_operation_t operation = PSA_MAC_OPERATION_INIT;
+    psa_mac_operation_t operation = psa_mac_operation_init_short();
     psa_key_type_t key_type = key_type_arg;
     psa_algorithm_t policy_alg = policy_alg_arg;
     psa_algorithm_t exercise_alg = exercise_alg_arg;
@@ -2247,7 +2247,7 @@ void cipher_key_policy(int policy_usage_arg,
 {
     mbedtls_svc_key_id_t key = MBEDTLS_SVC_KEY_ID_INIT;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
-    psa_cipher_operation_t operation = PSA_CIPHER_OPERATION_INIT;
+    psa_cipher_operation_t operation = psa_cipher_operation_init_short();
     psa_key_usage_t policy_usage = policy_usage_arg;
     size_t output_buffer_size = 0;
     size_t input_buffer_size = 0;
@@ -2338,7 +2338,7 @@ void aead_key_policy(int policy_usage_arg,
 {
     mbedtls_svc_key_id_t key = MBEDTLS_SVC_KEY_ID_INIT;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
-    psa_aead_operation_t operation = PSA_AEAD_OPERATION_INIT;
+    psa_aead_operation_t operation = psa_aead_operation_init_short();
     psa_key_usage_t policy_usage = policy_usage_arg;
     psa_status_t status;
     psa_status_t expected_status = expected_status_arg;
@@ -2596,7 +2596,7 @@ void derive_key_policy(int policy_usage,
 {
     mbedtls_svc_key_id_t key = MBEDTLS_SVC_KEY_ID_INIT;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
-    psa_key_derivation_operation_t operation = PSA_KEY_DERIVATION_OPERATION_INIT;
+    psa_key_derivation_operation_t operation = psa_key_derivation_operation_init_short();
     psa_status_t status;
 
     PSA_ASSERT(psa_crypto_init());
@@ -2647,7 +2647,7 @@ void agreement_key_policy(int policy_usage,
     mbedtls_svc_key_id_t key = MBEDTLS_SVC_KEY_ID_INIT;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     psa_key_type_t key_type = key_type_arg;
-    psa_key_derivation_operation_t operation = PSA_KEY_DERIVATION_OPERATION_INIT;
+    psa_key_derivation_operation_t operation = psa_key_derivation_operation_init_short();
     psa_status_t status;
     psa_status_t expected_status = expected_status_arg;
 
@@ -2730,7 +2730,7 @@ void raw_agreement_key_policy(int policy_usage,
     mbedtls_svc_key_id_t key = MBEDTLS_SVC_KEY_ID_INIT;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     psa_key_type_t key_type = key_type_arg;
-    psa_key_derivation_operation_t operation = PSA_KEY_DERIVATION_OPERATION_INIT;
+    psa_key_derivation_operation_t operation = psa_key_derivation_operation_init_short();
     psa_status_t status;
     psa_status_t expected_status = expected_status_arg;
 
@@ -2917,8 +2917,8 @@ void hash_operation_init()
      * Clang 5 complains when `-Wmissing-field-initializers` is used, even
      * though it's OK by the C standard. We could test for this, but we'd need
      * to suppress the Clang warning for the test. */
-    psa_hash_operation_t func = psa_hash_operation_init();
-    psa_hash_operation_t init = PSA_HASH_OPERATION_INIT;
+    psa_hash_operation_t func = psa_hash_operation_init_short();
+    psa_hash_operation_t init = psa_hash_operation_init_short();
     psa_hash_operation_t zero;
 
     memset(&zero, 0, sizeof(zero));
@@ -2947,7 +2947,7 @@ void hash_setup(int alg_arg,
     size_t output_size = 0;
     size_t output_length = 0;
     psa_status_t expected_status = expected_status_arg;
-    psa_hash_operation_t operation = PSA_HASH_OPERATION_INIT;
+    psa_hash_operation_t operation = psa_hash_operation_init_short();
     psa_status_t status;
 
     PSA_ASSERT(psa_crypto_init());
@@ -2993,7 +2993,7 @@ void hash_compute_fail(int alg_arg, data_t *input,
     uint8_t *output = NULL;
     size_t output_size = output_size_arg;
     size_t output_length = INVALID_EXPORT_LENGTH;
-    psa_hash_operation_t operation = PSA_HASH_OPERATION_INIT;
+    psa_hash_operation_t operation = psa_hash_operation_init_short();
     psa_status_t expected_status = expected_status_arg;
     psa_status_t status;
 
@@ -3040,7 +3040,7 @@ void hash_compare_fail(int alg_arg, data_t *input,
 {
     psa_algorithm_t alg = alg_arg;
     psa_status_t expected_status = expected_status_arg;
-    psa_hash_operation_t operation = PSA_HASH_OPERATION_INIT;
+    psa_hash_operation_t operation = psa_hash_operation_init_short();
     psa_status_t status;
 
     PSA_ASSERT(psa_crypto_init());
@@ -3078,7 +3078,7 @@ void hash_compute_compare(int alg_arg, data_t *input,
     psa_algorithm_t alg = alg_arg;
     uint8_t output[PSA_HASH_MAX_SIZE + 1];
     size_t output_length = INVALID_EXPORT_LENGTH;
-    psa_hash_operation_t operation = PSA_HASH_OPERATION_INIT;
+    psa_hash_operation_t operation = psa_hash_operation_init_short();
     size_t i;
 
     PSA_ASSERT(psa_crypto_init());
@@ -3188,7 +3188,7 @@ void hash_bad_order()
     };
     unsigned char hash[sizeof(valid_hash)] = { 0 };
     size_t hash_len;
-    psa_hash_operation_t operation = PSA_HASH_OPERATION_INIT;
+    psa_hash_operation_t operation = psa_hash_operation_init_short();
 
     PSA_ASSERT(psa_crypto_init());
 
@@ -3292,7 +3292,7 @@ void hash_verify_bad_args()
         0xa4, 0x95, 0x99, 0x1b, 0x78, 0x52, 0xb8, 0x55, 0xaa, 0xbb
     };
     size_t expected_size = PSA_HASH_LENGTH(alg);
-    psa_hash_operation_t operation = PSA_HASH_OPERATION_INIT;
+    psa_hash_operation_t operation = psa_hash_operation_init_short();
 
     PSA_ASSERT(psa_crypto_init());
 
@@ -3326,7 +3326,7 @@ void hash_finish_bad_args()
     psa_algorithm_t alg = PSA_ALG_SHA_256;
     unsigned char hash[PSA_HASH_MAX_SIZE];
     size_t expected_size = PSA_HASH_LENGTH(alg);
-    psa_hash_operation_t operation = PSA_HASH_OPERATION_INIT;
+    psa_hash_operation_t operation = psa_hash_operation_init_short();
     size_t hash_len;
 
     PSA_ASSERT(psa_crypto_init());
@@ -3347,11 +3347,11 @@ void hash_clone_source_state()
 {
     psa_algorithm_t alg = PSA_ALG_SHA_256;
     unsigned char hash[PSA_HASH_MAX_SIZE];
-    psa_hash_operation_t op_source = PSA_HASH_OPERATION_INIT;
-    psa_hash_operation_t op_init = PSA_HASH_OPERATION_INIT;
-    psa_hash_operation_t op_setup = PSA_HASH_OPERATION_INIT;
-    psa_hash_operation_t op_finished = PSA_HASH_OPERATION_INIT;
-    psa_hash_operation_t op_aborted = PSA_HASH_OPERATION_INIT;
+    psa_hash_operation_t op_source = psa_hash_operation_init_short();
+    psa_hash_operation_t op_init = psa_hash_operation_init_short();
+    psa_hash_operation_t op_setup = psa_hash_operation_init_short();
+    psa_hash_operation_t op_finished = psa_hash_operation_init_short();
+    psa_hash_operation_t op_aborted = psa_hash_operation_init_short();
     size_t hash_len;
 
     PSA_ASSERT(psa_crypto_init());
@@ -3392,11 +3392,11 @@ void hash_clone_target_state()
 {
     psa_algorithm_t alg = PSA_ALG_SHA_256;
     unsigned char hash[PSA_HASH_MAX_SIZE];
-    psa_hash_operation_t op_init = PSA_HASH_OPERATION_INIT;
-    psa_hash_operation_t op_setup = PSA_HASH_OPERATION_INIT;
-    psa_hash_operation_t op_finished = PSA_HASH_OPERATION_INIT;
-    psa_hash_operation_t op_aborted = PSA_HASH_OPERATION_INIT;
-    psa_hash_operation_t op_target = PSA_HASH_OPERATION_INIT;
+    psa_hash_operation_t op_init = psa_hash_operation_init_short();
+    psa_hash_operation_t op_setup = psa_hash_operation_init_short();
+    psa_hash_operation_t op_finished = psa_hash_operation_init_short();
+    psa_hash_operation_t op_aborted = psa_hash_operation_init_short();
+    psa_hash_operation_t op_target = psa_hash_operation_init_short();
     size_t hash_len;
 
     PSA_ASSERT(psa_crypto_init());
@@ -3437,8 +3437,8 @@ void mac_operation_init()
      * Clang 5 complains when `-Wmissing-field-initializers` is used, even
      * though it's OK by the C standard. We could test for this, but we'd need
      * to suppress the Clang warning for the test. */
-    psa_mac_operation_t func = psa_mac_operation_init();
-    psa_mac_operation_t init = PSA_MAC_OPERATION_INIT;
+    psa_mac_operation_t func = psa_mac_operation_init_short();
+    psa_mac_operation_t init = psa_mac_operation_init_short();
     psa_mac_operation_t zero;
 
     memset(&zero, 0, sizeof(zero));
@@ -3470,7 +3470,7 @@ void mac_setup(int key_type_arg,
     psa_key_type_t key_type = key_type_arg;
     psa_algorithm_t alg = alg_arg;
     psa_status_t expected_status = expected_status_arg;
-    psa_mac_operation_t operation = PSA_MAC_OPERATION_INIT;
+    psa_mac_operation_t operation = psa_mac_operation_init_short();
     psa_status_t status = PSA_ERROR_GENERIC_ERROR;
 #if defined(KNOWN_SUPPORTED_MAC_ALG)
     const uint8_t smoke_test_key_data[16] = "kkkkkkkkkkkkkkkk";
@@ -3513,7 +3513,7 @@ void mac_bad_order()
         0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa
     };
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
-    psa_mac_operation_t operation = PSA_MAC_OPERATION_INIT;
+    psa_mac_operation_t operation = psa_mac_operation_init_short();
     uint8_t sign_mac[PSA_MAC_MAX_SIZE + 10] = { 0 };
     size_t sign_mac_length = 0;
     const uint8_t input[] = { 0xbb, 0xbb, 0xbb, 0xbb };
@@ -3678,7 +3678,7 @@ void mac_sign(int key_type_arg,
     mbedtls_svc_key_id_t key = MBEDTLS_SVC_KEY_ID_INIT;
     psa_key_type_t key_type = key_type_arg;
     psa_algorithm_t alg = alg_arg;
-    psa_mac_operation_t operation = PSA_MAC_OPERATION_INIT;
+    psa_mac_operation_t operation = psa_mac_operation_init_short();
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     uint8_t *actual_mac = NULL;
     size_t mac_buffer_size =
@@ -3764,7 +3764,7 @@ void mac_verify(int key_type_arg,
     mbedtls_svc_key_id_t key = MBEDTLS_SVC_KEY_ID_INIT;
     psa_key_type_t key_type = key_type_arg;
     psa_algorithm_t alg = alg_arg;
-    psa_mac_operation_t operation = PSA_MAC_OPERATION_INIT;
+    psa_mac_operation_t operation = psa_mac_operation_init_short();
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     uint8_t *perturbed_mac = NULL;
 
@@ -3862,8 +3862,8 @@ void cipher_operation_init()
      * Clang 5 complains when `-Wmissing-field-initializers` is used, even
      * though it's OK by the C standard. We could test for this, but we'd need
      * to suppress the Clang warning for the test. */
-    psa_cipher_operation_t func = psa_cipher_operation_init();
-    psa_cipher_operation_t init = PSA_CIPHER_OPERATION_INIT;
+    psa_cipher_operation_t func = psa_cipher_operation_init_short();
+    psa_cipher_operation_t init = psa_cipher_operation_init_short();
     psa_cipher_operation_t zero;
 
     memset(&zero, 0, sizeof(zero));
@@ -3901,7 +3901,7 @@ void cipher_setup(int key_type_arg,
     psa_key_type_t key_type = key_type_arg;
     psa_algorithm_t alg = alg_arg;
     psa_status_t expected_status = expected_status_arg;
-    psa_cipher_operation_t operation = PSA_CIPHER_OPERATION_INIT;
+    psa_cipher_operation_t operation = psa_cipher_operation_init_short();
     psa_status_t status;
 #if defined(KNOWN_SUPPORTED_CIPHER_ALG)
     const uint8_t smoke_test_key_data[16] = "kkkkkkkkkkkkkkkk";
@@ -3940,7 +3940,7 @@ void cipher_bad_order()
     psa_key_type_t key_type = PSA_KEY_TYPE_AES;
     psa_algorithm_t alg = PSA_ALG_CBC_PKCS7;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
-    psa_cipher_operation_t operation = PSA_CIPHER_OPERATION_INIT;
+    psa_cipher_operation_t operation = psa_cipher_operation_init_short();
     unsigned char iv[PSA_BLOCK_CIPHER_BLOCK_LENGTH(PSA_KEY_TYPE_AES)] = { 0 };
     const uint8_t key_data[] = {
         0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
@@ -4126,7 +4126,7 @@ void cipher_encrypt_fail(int alg_arg,
     size_t output_buffer_size = 0;
     size_t output_length = 0;
     size_t function_output_length;
-    psa_cipher_operation_t operation = PSA_CIPHER_OPERATION_INIT;
+    psa_cipher_operation_t operation = psa_cipher_operation_init_short();
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
 
     if (PSA_ERROR_BAD_STATE != expected_status) {
@@ -4191,7 +4191,7 @@ void cipher_encrypt_validate_iv_length(int alg, int key_type, data_t *key_data,
                                        int expected_result)
 {
     mbedtls_svc_key_id_t key = MBEDTLS_SVC_KEY_ID_INIT;
-    psa_cipher_operation_t operation = PSA_CIPHER_OPERATION_INIT;
+    psa_cipher_operation_t operation = psa_cipher_operation_init_short();
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     size_t output_buffer_size = 0;
     unsigned char *output = NULL;
@@ -4226,7 +4226,7 @@ void cipher_alg_without_iv(int alg_arg, int key_type_arg, data_t *key_data,
     mbedtls_svc_key_id_t key = MBEDTLS_SVC_KEY_ID_INIT;
     psa_key_type_t key_type = key_type_arg;
     psa_algorithm_t alg = alg_arg;
-    psa_cipher_operation_t operation = PSA_CIPHER_OPERATION_INIT;
+    psa_cipher_operation_t operation = psa_cipher_operation_init_short();
     uint8_t iv[1] = { 0x5a };
     unsigned char *output = NULL;
     size_t output_buffer_size = 0;
@@ -4343,7 +4343,7 @@ void cipher_bad_key(int alg_arg, int key_type_arg, data_t *key_data)
     psa_algorithm_t alg = alg_arg;
     psa_key_type_t key_type = key_type_arg;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
-    psa_cipher_operation_t operation = PSA_CIPHER_OPERATION_INIT;
+    psa_cipher_operation_t operation = psa_cipher_operation_init_short();
     psa_status_t status;
 
     PSA_ASSERT(psa_crypto_init());
@@ -4393,7 +4393,7 @@ void cipher_encrypt_validation(int alg_arg,
     size_t output2_buffer_size = 0;
     size_t output2_length = 0;
     size_t function_output_length = 0;
-    psa_cipher_operation_t operation = PSA_CIPHER_OPERATION_INIT;
+    psa_cipher_operation_t operation = psa_cipher_operation_init_short();
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
 
     PSA_ASSERT(psa_crypto_init());
@@ -4477,7 +4477,7 @@ void cipher_encrypt_multipart(int alg_arg, int key_type_arg,
     size_t output_buffer_size = 0;
     size_t function_output_length = 0;
     size_t total_output_length = 0;
-    psa_cipher_operation_t operation = PSA_CIPHER_OPERATION_INIT;
+    psa_cipher_operation_t operation = psa_cipher_operation_init_short();
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
 
     PSA_ASSERT(psa_crypto_init());
@@ -4576,7 +4576,7 @@ void cipher_decrypt_multipart(int alg_arg, int key_type_arg,
     size_t output_buffer_size = 0;
     size_t function_output_length = 0;
     size_t total_output_length = 0;
-    psa_cipher_operation_t operation = PSA_CIPHER_OPERATION_INIT;
+    psa_cipher_operation_t operation = psa_cipher_operation_init_short();
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
 
     PSA_ASSERT(psa_crypto_init());
@@ -4675,7 +4675,7 @@ void cipher_decrypt_fail(int alg_arg,
     size_t output_buffer_size = 0;
     size_t output_length = 0;
     size_t function_output_length;
-    psa_cipher_operation_t operation = PSA_CIPHER_OPERATION_INIT;
+    psa_cipher_operation_t operation = psa_cipher_operation_init_short();
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
 
     if (PSA_ERROR_BAD_STATE != expected_status) {
@@ -4888,8 +4888,8 @@ void cipher_verify_output_multipart(int alg_arg,
     size_t output2_buffer_size = 0;
     size_t output2_length = 0;
     size_t function_output_length;
-    psa_cipher_operation_t operation1 = PSA_CIPHER_OPERATION_INIT;
-    psa_cipher_operation_t operation2 = PSA_CIPHER_OPERATION_INIT;
+    psa_cipher_operation_t operation1 = psa_cipher_operation_init_short();
+    psa_cipher_operation_t operation2 = psa_cipher_operation_init_short();
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
 
     PSA_ASSERT(psa_crypto_init());
@@ -5444,7 +5444,7 @@ void aead_multipart_generate_nonce(int key_type_arg, data_t *key_data,
     mbedtls_svc_key_id_t key = MBEDTLS_SVC_KEY_ID_INIT;
     psa_key_type_t key_type = key_type_arg;
     psa_algorithm_t alg = alg_arg;
-    psa_aead_operation_t operation = PSA_AEAD_OPERATION_INIT;
+    psa_aead_operation_t operation = psa_aead_operation_init_short();
     /* Some tests try to get more than the maximum nonce length,
      * so allocate double. */
     uint8_t nonce_buffer[PSA_AEAD_NONCE_MAX_SIZE * 2];
@@ -5548,7 +5548,7 @@ void aead_multipart_set_nonce(int key_type_arg, data_t *key_data,
     mbedtls_svc_key_id_t key = MBEDTLS_SVC_KEY_ID_INIT;
     psa_key_type_t key_type = key_type_arg;
     psa_algorithm_t alg = alg_arg;
-    psa_aead_operation_t operation = PSA_AEAD_OPERATION_INIT;
+    psa_aead_operation_t operation = psa_aead_operation_init_short();
     uint8_t *nonce_buffer = NULL;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     psa_status_t status = PSA_ERROR_GENERIC_ERROR;
@@ -5671,7 +5671,7 @@ void aead_multipart_update_buffer_test(int key_type_arg, data_t *key_data,
     mbedtls_svc_key_id_t key = MBEDTLS_SVC_KEY_ID_INIT;
     psa_key_type_t key_type = key_type_arg;
     psa_algorithm_t alg = alg_arg;
-    psa_aead_operation_t operation = PSA_AEAD_OPERATION_INIT;
+    psa_aead_operation_t operation = psa_aead_operation_init_short();
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     psa_status_t status = PSA_ERROR_GENERIC_ERROR;
     psa_status_t expected_status = expected_status_arg;
@@ -5755,7 +5755,7 @@ void aead_multipart_finish_buffer_test(int key_type_arg, data_t *key_data,
     mbedtls_svc_key_id_t key = MBEDTLS_SVC_KEY_ID_INIT;
     psa_key_type_t key_type = key_type_arg;
     psa_algorithm_t alg = alg_arg;
-    psa_aead_operation_t operation = PSA_AEAD_OPERATION_INIT;
+    psa_aead_operation_t operation = psa_aead_operation_init_short();
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     psa_status_t status = PSA_ERROR_GENERIC_ERROR;
     psa_status_t expected_status = expected_status_arg;
@@ -5842,7 +5842,7 @@ void aead_multipart_verify(int key_type_arg, data_t *key_data,
     mbedtls_svc_key_id_t key = MBEDTLS_SVC_KEY_ID_INIT;
     psa_key_type_t key_type = key_type_arg;
     psa_algorithm_t alg = alg_arg;
-    psa_aead_operation_t operation = PSA_AEAD_OPERATION_INIT;
+    psa_aead_operation_t operation = psa_aead_operation_init_short();
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     psa_status_t status = PSA_ERROR_GENERIC_ERROR;
     psa_status_t expected_status = expected_status_arg;
@@ -5935,7 +5935,7 @@ void aead_multipart_setup(int key_type_arg, data_t *key_data,
     mbedtls_svc_key_id_t key = MBEDTLS_SVC_KEY_ID_INIT;
     psa_key_type_t key_type = key_type_arg;
     psa_algorithm_t alg = alg_arg;
-    psa_aead_operation_t operation = PSA_AEAD_OPERATION_INIT;
+    psa_aead_operation_t operation = psa_aead_operation_init_short();
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     psa_status_t status = PSA_ERROR_GENERIC_ERROR;
     psa_status_t expected_status = expected_status_arg;
@@ -5977,7 +5977,7 @@ void aead_multipart_state_test(int key_type_arg, data_t *key_data,
     mbedtls_svc_key_id_t key = MBEDTLS_SVC_KEY_ID_INIT;
     psa_key_type_t key_type = key_type_arg;
     psa_algorithm_t alg = alg_arg;
-    psa_aead_operation_t operation = PSA_AEAD_OPERATION_INIT;
+    psa_aead_operation_t operation = psa_aead_operation_init_short();
     unsigned char *output_data = NULL;
     unsigned char *final_data = NULL;
     size_t output_size = 0;
@@ -6879,7 +6879,7 @@ void sign_hash_interruptible(int key_type_arg, data_t *key_data,
     size_t max_completes = 0;
 
     psa_sign_hash_interruptible_operation_t operation =
-        psa_sign_hash_interruptible_operation_init();
+        psa_sign_hash_interruptible_operation_init_short();
 
     PSA_ASSERT(psa_crypto_init());
 
@@ -7061,7 +7061,7 @@ void sign_hash_fail_interruptible(int key_type_arg, data_t *key_data,
 
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     psa_sign_hash_interruptible_operation_t operation =
-        psa_sign_hash_interruptible_operation_init();
+        psa_sign_hash_interruptible_operation_init_short();
 
     TEST_CALLOC(signature, signature_size);
 
@@ -7272,9 +7272,9 @@ void sign_verify_hash_interruptible(int key_type_arg, data_t *key_data,
     size_t max_completes = 0;
 
     psa_sign_hash_interruptible_operation_t sign_operation =
-        psa_sign_hash_interruptible_operation_init();
+        psa_sign_hash_interruptible_operation_init_short();
     psa_verify_hash_interruptible_operation_t verify_operation =
-        psa_verify_hash_interruptible_operation_init();
+        psa_verify_hash_interruptible_operation_init_short();
 
     PSA_ASSERT(psa_crypto_init());
 
@@ -7367,7 +7367,7 @@ void sign_verify_hash_interruptible(int key_type_arg, data_t *key_data,
 
     PSA_ASSERT(psa_verify_hash_abort(&verify_operation));
 
-    verify_operation = psa_verify_hash_interruptible_operation_init();
+    verify_operation = psa_verify_hash_interruptible_operation_init_short();
 
     if (input_data->len != 0) {
         /* Flip a bit in the input and verify that the signature is now
@@ -7475,7 +7475,7 @@ void verify_hash_interruptible(int key_type_arg, data_t *key_data,
     size_t max_completes = 0;
 
     psa_verify_hash_interruptible_operation_t operation =
-        psa_verify_hash_interruptible_operation_init();
+        psa_verify_hash_interruptible_operation_init_short();
 
     TEST_LE_U(signature_data->len, PSA_SIGNATURE_MAX_SIZE);
 
@@ -7645,7 +7645,7 @@ void verify_hash_fail_interruptible(int key_type_arg, data_t *key_data,
     size_t min_completes = 0;
     size_t max_completes = 0;
     psa_verify_hash_interruptible_operation_t operation =
-        psa_verify_hash_interruptible_operation_init();
+        psa_verify_hash_interruptible_operation_init_short();
 
     PSA_ASSERT(psa_crypto_init());
 
@@ -7754,9 +7754,9 @@ void interruptible_signverify_hash_state_test(int key_type_arg,
     size_t signature_length = 0xdeadbeef;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     psa_sign_hash_interruptible_operation_t sign_operation =
-        psa_sign_hash_interruptible_operation_init();
+        psa_sign_hash_interruptible_operation_init_short();
     psa_verify_hash_interruptible_operation_t verify_operation =
-        psa_verify_hash_interruptible_operation_init();
+        psa_verify_hash_interruptible_operation_init_short();
 
     PSA_ASSERT(psa_crypto_init());
 
@@ -7910,9 +7910,9 @@ void interruptible_signverify_hash_edgecase_tests(int key_type_arg,
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     uint8_t *input_buffer = NULL;
     psa_sign_hash_interruptible_operation_t sign_operation =
-        psa_sign_hash_interruptible_operation_init();
+        psa_sign_hash_interruptible_operation_init_short();
     psa_verify_hash_interruptible_operation_t verify_operation =
-        psa_verify_hash_interruptible_operation_init();
+        psa_verify_hash_interruptible_operation_init_short();
 
     PSA_ASSERT(psa_crypto_init());
 
@@ -8041,9 +8041,9 @@ void interruptible_signverify_hash_ops_tests(int key_type_arg,
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
 
     psa_sign_hash_interruptible_operation_t sign_operation =
-        psa_sign_hash_interruptible_operation_init();
+        psa_sign_hash_interruptible_operation_init_short();
     psa_verify_hash_interruptible_operation_t verify_operation =
-        psa_verify_hash_interruptible_operation_init();
+        psa_verify_hash_interruptible_operation_init_short();
 
     PSA_ASSERT(psa_crypto_init());
 
@@ -8736,8 +8736,8 @@ void key_derivation_init()
      * though it's OK by the C standard. We could test for this, but we'd need
      * to suppress the Clang warning for the test. */
     size_t capacity;
-    psa_key_derivation_operation_t func = psa_key_derivation_operation_init();
-    psa_key_derivation_operation_t init = PSA_KEY_DERIVATION_OPERATION_INIT;
+    psa_key_derivation_operation_t func = psa_key_derivation_operation_init_short();
+    psa_key_derivation_operation_t init = psa_key_derivation_operation_init_short();
     psa_key_derivation_operation_t zero;
 
     memset(&zero, 0, sizeof(zero));
@@ -8762,7 +8762,7 @@ void derive_setup(int alg_arg, int expected_status_arg)
 {
     psa_algorithm_t alg = alg_arg;
     psa_status_t expected_status = expected_status_arg;
-    psa_key_derivation_operation_t operation = PSA_KEY_DERIVATION_OPERATION_INIT;
+    psa_key_derivation_operation_t operation = psa_key_derivation_operation_init_short();
 
     PSA_ASSERT(psa_crypto_init());
 
@@ -8782,7 +8782,7 @@ void derive_set_capacity(int alg_arg, int64_t capacity_arg,
     psa_algorithm_t alg = alg_arg;
     size_t capacity = capacity_arg;
     psa_status_t expected_status = expected_status_arg;
-    psa_key_derivation_operation_t operation = PSA_KEY_DERIVATION_OPERATION_INIT;
+    psa_key_derivation_operation_t operation = psa_key_derivation_operation_init_short();
 
     PSA_ASSERT(psa_crypto_init());
 
@@ -8826,7 +8826,7 @@ void derive_input(int alg_arg,
     mbedtls_svc_key_id_t keys[] = { MBEDTLS_SVC_KEY_ID_INIT,
                                     MBEDTLS_SVC_KEY_ID_INIT,
                                     MBEDTLS_SVC_KEY_ID_INIT };
-    psa_key_derivation_operation_t operation = PSA_KEY_DERIVATION_OPERATION_INIT;
+    psa_key_derivation_operation_t operation = psa_key_derivation_operation_init_short();
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     size_t i;
     psa_key_type_t output_key_type = output_key_type_arg;
@@ -8909,7 +8909,7 @@ exit:
 void derive_input_invalid_cost(int alg_arg, int64_t cost)
 {
     psa_algorithm_t alg = alg_arg;
-    psa_key_derivation_operation_t operation = PSA_KEY_DERIVATION_OPERATION_INIT;
+    psa_key_derivation_operation_t operation = psa_key_derivation_operation_init_short();
 
     PSA_ASSERT(psa_crypto_init());
     PSA_ASSERT(psa_key_derivation_setup(&operation, alg));
@@ -8931,7 +8931,7 @@ void derive_over_capacity(int alg_arg)
     psa_algorithm_t alg = alg_arg;
     mbedtls_svc_key_id_t key = MBEDTLS_SVC_KEY_ID_INIT;
     size_t key_type = PSA_KEY_TYPE_DERIVE;
-    psa_key_derivation_operation_t operation = PSA_KEY_DERIVATION_OPERATION_INIT;
+    psa_key_derivation_operation_t operation = psa_key_derivation_operation_init_short();
     unsigned char input1[] = "Input 1";
     size_t input1_length = sizeof(input1);
     unsigned char input2[] = "Input 2";
@@ -8983,7 +8983,7 @@ void derive_actions_without_setup()
     uint8_t output_buffer[16];
     size_t buffer_size = 16;
     size_t capacity = 0;
-    psa_key_derivation_operation_t operation = PSA_KEY_DERIVATION_OPERATION_INIT;
+    psa_key_derivation_operation_t operation = psa_key_derivation_operation_init_short();
 
     TEST_ASSERT(psa_key_derivation_output_bytes(&operation,
                                                 output_buffer, buffer_size)
@@ -9030,7 +9030,7 @@ void derive_output(int alg_arg,
     psa_status_t statuses[] = { expected_status_arg1, expected_status_arg2,
                                 expected_status_arg3, expected_status_arg4 };
     size_t requested_capacity = requested_capacity_arg;
-    psa_key_derivation_operation_t operation = PSA_KEY_DERIVATION_OPERATION_INIT;
+    psa_key_derivation_operation_t operation = psa_key_derivation_operation_init_short();
     uint8_t *expected_outputs[2] =
     { expected_output1->x, expected_output2->x };
     size_t output_sizes[2] =
@@ -9258,7 +9258,7 @@ void derive_full(int alg_arg,
     mbedtls_svc_key_id_t key = MBEDTLS_SVC_KEY_ID_INIT;
     psa_algorithm_t alg = alg_arg;
     size_t requested_capacity = requested_capacity_arg;
-    psa_key_derivation_operation_t operation = PSA_KEY_DERIVATION_OPERATION_INIT;
+    psa_key_derivation_operation_t operation = psa_key_derivation_operation_init_short();
     unsigned char output_buffer[32];
     size_t expected_capacity = requested_capacity;
     size_t current_capacity;
@@ -9320,7 +9320,7 @@ void derive_ecjpake_to_pms(data_t *input, int expected_input_status_arg,
                            int expected_output_status_arg)
 {
     psa_algorithm_t alg = PSA_ALG_TLS12_ECJPAKE_TO_PMS;
-    psa_key_derivation_operation_t operation = PSA_KEY_DERIVATION_OPERATION_INIT;
+    psa_key_derivation_operation_t operation = psa_key_derivation_operation_init_short();
     psa_key_derivation_step_t step = (psa_key_derivation_step_t) derivation_step;
     uint8_t *output_buffer = NULL;
     psa_status_t status;
@@ -9377,7 +9377,7 @@ void derive_key_exercise(int alg_arg,
     psa_key_usage_t derived_usage = derived_usage_arg;
     psa_algorithm_t derived_alg = derived_alg_arg;
     size_t capacity = PSA_BITS_TO_BYTES(derived_bits);
-    psa_key_derivation_operation_t operation = PSA_KEY_DERIVATION_OPERATION_INIT;
+    psa_key_derivation_operation_t operation = psa_key_derivation_operation_init_short();
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     psa_key_attributes_t got_attributes = PSA_KEY_ATTRIBUTES_INIT;
 
@@ -9442,7 +9442,7 @@ void derive_key_export(int alg_arg,
     size_t bytes1 = bytes1_arg;
     size_t bytes2 = bytes2_arg;
     size_t capacity = bytes1 + bytes2;
-    psa_key_derivation_operation_t operation = PSA_KEY_DERIVATION_OPERATION_INIT;
+    psa_key_derivation_operation_t operation = psa_key_derivation_operation_init_short();
     uint8_t *output_buffer = NULL;
     uint8_t *export_buffer = NULL;
     psa_key_attributes_t base_attributes = PSA_KEY_ATTRIBUTES_INIT;
@@ -9526,7 +9526,7 @@ void derive_key_type(int alg_arg,
     const psa_algorithm_t alg = alg_arg;
     const psa_key_type_t key_type = key_type_arg;
     const size_t bits = bits_arg;
-    psa_key_derivation_operation_t operation = PSA_KEY_DERIVATION_OPERATION_INIT;
+    psa_key_derivation_operation_t operation = psa_key_derivation_operation_init_short();
     const size_t export_buffer_size =
         PSA_EXPORT_KEY_OUTPUT_SIZE(key_type, bits);
     uint8_t *export_buffer = NULL;
@@ -9591,7 +9591,7 @@ void derive_key_custom(int alg_arg,
     const size_t bits = bits_arg;
     psa_custom_key_parameters_t custom = PSA_CUSTOM_KEY_PARAMETERS_INIT;
     custom.flags = flags_arg;
-    psa_key_derivation_operation_t operation = PSA_KEY_DERIVATION_OPERATION_INIT;
+    psa_key_derivation_operation_t operation = psa_key_derivation_operation_init_short();
     const size_t export_buffer_size =
         PSA_EXPORT_KEY_OUTPUT_SIZE(key_type, bits);
     uint8_t *export_buffer = NULL;
@@ -9662,7 +9662,7 @@ void derive_key_ext(int alg_arg,
     const size_t bits = bits_arg;
     psa_key_production_parameters_t *params = NULL;
     size_t params_data_length = 0;
-    psa_key_derivation_operation_t operation = PSA_KEY_DERIVATION_OPERATION_INIT;
+    psa_key_derivation_operation_t operation = psa_key_derivation_operation_init_short();
     const size_t export_buffer_size =
         PSA_EXPORT_KEY_OUTPUT_SIZE(key_type, bits);
     uint8_t *export_buffer = NULL;
@@ -9732,7 +9732,7 @@ void derive_key(int alg_arg,
     psa_key_type_t type = type_arg;
     size_t bits = bits_arg;
     psa_status_t expected_status = expected_status_arg;
-    psa_key_derivation_operation_t operation = PSA_KEY_DERIVATION_OPERATION_INIT;
+    psa_key_derivation_operation_t operation = psa_key_derivation_operation_init_short();
     psa_key_attributes_t base_attributes = PSA_KEY_ATTRIBUTES_INIT;
     psa_key_attributes_t derived_attributes = PSA_KEY_ATTRIBUTES_INIT;
 
@@ -9783,7 +9783,7 @@ void key_agreement_setup(int alg_arg,
     psa_algorithm_t alg = alg_arg;
     psa_algorithm_t our_key_alg = our_key_alg_arg;
     psa_key_type_t our_key_type = our_key_type_arg;
-    psa_key_derivation_operation_t operation = PSA_KEY_DERIVATION_OPERATION_INIT;
+    psa_key_derivation_operation_t operation = psa_key_derivation_operation_init_short();
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     psa_status_t expected_status = expected_status_arg;
     psa_status_t status;
@@ -9903,7 +9903,7 @@ void key_agreement_capacity(int alg_arg,
     mbedtls_svc_key_id_t our_key = MBEDTLS_SVC_KEY_ID_INIT;
     psa_algorithm_t alg = alg_arg;
     psa_key_type_t our_key_type = our_key_type_arg;
-    psa_key_derivation_operation_t operation = PSA_KEY_DERIVATION_OPERATION_INIT;
+    psa_key_derivation_operation_t operation = psa_key_derivation_operation_init_short();
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     size_t actual_capacity;
     unsigned char output[16];
@@ -10000,7 +10000,7 @@ void key_agreement_output(int alg_arg,
     mbedtls_svc_key_id_t our_key = MBEDTLS_SVC_KEY_ID_INIT;
     psa_algorithm_t alg = alg_arg;
     psa_key_type_t our_key_type = our_key_type_arg;
-    psa_key_derivation_operation_t operation = PSA_KEY_DERIVATION_OPERATION_INIT;
+    psa_key_derivation_operation_t operation = psa_key_derivation_operation_init_short();
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     uint8_t *actual_output = NULL;
 
@@ -10366,7 +10366,7 @@ void persistent_key_load_key_from_storage(data_t *data,
     size_t bits = bits_arg;
     psa_key_usage_t usage_flags = usage_flags_arg;
     psa_algorithm_t alg = alg_arg;
-    psa_key_derivation_operation_t operation = PSA_KEY_DERIVATION_OPERATION_INIT;
+    psa_key_derivation_operation_t operation = psa_key_derivation_operation_init_short();
     unsigned char *first_export = NULL;
     unsigned char *second_export = NULL;
     size_t export_size = PSA_EXPORT_KEY_OUTPUT_SIZE(type, bits);
@@ -10503,7 +10503,7 @@ void ecjpake_setup(int alg_arg, int key_type_pw_arg, int key_usage_pw_arg,
                    int expected_error_arg)
 {
     psa_pake_cipher_suite_t cipher_suite = psa_pake_cipher_suite_init();
-    psa_pake_operation_t operation = psa_pake_operation_init();
+    psa_pake_operation_t operation = psa_pake_operation_init_short();
     psa_algorithm_t alg = alg_arg;
     psa_pake_primitive_t primitive = primitive_arg;
     psa_key_type_t key_type_pw = key_type_pw_arg;
@@ -10727,8 +10727,8 @@ void ecjpake_rounds_inject(int alg_arg, int primitive_arg, int hash_arg,
                            data_t *pw_data)
 {
     psa_pake_cipher_suite_t cipher_suite = psa_pake_cipher_suite_init();
-    psa_pake_operation_t server = psa_pake_operation_init();
-    psa_pake_operation_t client = psa_pake_operation_init();
+    psa_pake_operation_t server = psa_pake_operation_init_short();
+    psa_pake_operation_t client = psa_pake_operation_init_short();
     psa_algorithm_t alg = alg_arg;
     psa_algorithm_t hash_alg = hash_arg;
     mbedtls_svc_key_id_t key = MBEDTLS_SVC_KEY_ID_INIT;
@@ -10780,17 +10780,17 @@ void ecjpake_rounds(int alg_arg, int primitive_arg, int hash_arg,
                     int client_input_first, int inj_err_type_arg)
 {
     psa_pake_cipher_suite_t cipher_suite = psa_pake_cipher_suite_init();
-    psa_pake_operation_t server = psa_pake_operation_init();
-    psa_pake_operation_t client = psa_pake_operation_init();
+    psa_pake_operation_t server = psa_pake_operation_init_short();
+    psa_pake_operation_t client = psa_pake_operation_init_short();
     psa_algorithm_t alg = alg_arg;
     psa_algorithm_t hash_alg = hash_arg;
     psa_algorithm_t derive_alg = derive_alg_arg;
     mbedtls_svc_key_id_t key = MBEDTLS_SVC_KEY_ID_INIT;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     psa_key_derivation_operation_t server_derive =
-        PSA_KEY_DERIVATION_OPERATION_INIT;
+        psa_key_derivation_operation_init_short();
     psa_key_derivation_operation_t client_derive =
-        PSA_KEY_DERIVATION_OPERATION_INIT;
+        psa_key_derivation_operation_init_short();
     ecjpake_injected_failure_t inj_err_type = inj_err_type_arg;
 
     PSA_INIT();

--- a/tests/suites/test_suite_psa_crypto_driver_wrappers.function
+++ b/tests/suites/test_suite_psa_crypto_driver_wrappers.function
@@ -1063,7 +1063,7 @@ void cipher_encrypt_validation(int alg_arg,
     size_t output2_buffer_size = 0;
     size_t output2_length = 0;
     size_t function_output_length = 0;
-    psa_cipher_operation_t operation = PSA_CIPHER_OPERATION_INIT;
+    psa_cipher_operation_t operation = psa_cipher_operation_init_short();
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     mbedtls_test_driver_cipher_hooks = mbedtls_test_driver_cipher_hooks_init();
 
@@ -1158,7 +1158,7 @@ void cipher_encrypt_multipart(int alg_arg,
     size_t output_buffer_size = 0;
     size_t function_output_length = 0;
     size_t total_output_length = 0;
-    psa_cipher_operation_t operation = PSA_CIPHER_OPERATION_INIT;
+    psa_cipher_operation_t operation = psa_cipher_operation_init_short();
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     mbedtls_test_driver_cipher_hooks = mbedtls_test_driver_cipher_hooks_init();
     mbedtls_test_driver_cipher_hooks.forced_status = force_status;
@@ -1287,7 +1287,7 @@ void cipher_decrypt_multipart(int alg_arg,
     size_t output_buffer_size = 0;
     size_t function_output_length = 0;
     size_t total_output_length = 0;
-    psa_cipher_operation_t operation = PSA_CIPHER_OPERATION_INIT;
+    psa_cipher_operation_t operation = psa_cipher_operation_init_short();
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     mbedtls_test_driver_cipher_hooks = mbedtls_test_driver_cipher_hooks_init();
     mbedtls_test_driver_cipher_hooks.forced_status = force_status;
@@ -1475,7 +1475,7 @@ void cipher_entry_points(int alg_arg, int key_type_arg,
     unsigned char *output = NULL;
     size_t output_buffer_size = 0;
     size_t function_output_length = 0;
-    psa_cipher_operation_t operation = PSA_CIPHER_OPERATION_INIT;
+    psa_cipher_operation_t operation = psa_cipher_operation_init_short();
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     mbedtls_test_driver_cipher_hooks = mbedtls_test_driver_cipher_hooks_init();
 
@@ -1810,7 +1810,7 @@ void mac_sign(int key_type_arg,
     mbedtls_svc_key_id_t key = MBEDTLS_SVC_KEY_ID_INIT;
     psa_key_type_t key_type = key_type_arg;
     psa_algorithm_t alg = alg_arg;
-    psa_mac_operation_t operation = PSA_MAC_OPERATION_INIT;
+    psa_mac_operation_t operation = psa_mac_operation_init_short();
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     uint8_t *actual_mac = NULL;
     size_t mac_buffer_size =
@@ -1884,7 +1884,7 @@ void mac_sign_multipart(int key_type_arg,
     mbedtls_svc_key_id_t key = MBEDTLS_SVC_KEY_ID_INIT;
     psa_key_type_t key_type = key_type_arg;
     psa_algorithm_t alg = alg_arg;
-    psa_mac_operation_t operation = PSA_MAC_OPERATION_INIT;
+    psa_mac_operation_t operation = psa_mac_operation_init_short();
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     uint8_t *actual_mac = NULL;
     size_t mac_buffer_size =
@@ -2001,7 +2001,7 @@ void mac_verify(int key_type_arg,
     mbedtls_svc_key_id_t key = MBEDTLS_SVC_KEY_ID_INIT;
     psa_key_type_t key_type = key_type_arg;
     psa_algorithm_t alg = alg_arg;
-    psa_mac_operation_t operation = PSA_MAC_OPERATION_INIT;
+    psa_mac_operation_t operation = psa_mac_operation_init_short();
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     psa_status_t status = PSA_ERROR_GENERIC_ERROR;
     psa_status_t forced_status = forced_status_arg;
@@ -2056,7 +2056,7 @@ void mac_verify_multipart(int key_type_arg,
     mbedtls_svc_key_id_t key = MBEDTLS_SVC_KEY_ID_INIT;
     psa_key_type_t key_type = key_type_arg;
     psa_algorithm_t alg = alg_arg;
-    psa_mac_operation_t operation = PSA_MAC_OPERATION_INIT;
+    psa_mac_operation_t operation = psa_mac_operation_init_short();
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     psa_status_t status = PSA_ERROR_GENERIC_ERROR;
     psa_status_t forced_status = forced_status_arg;
@@ -2294,7 +2294,7 @@ void hash_multipart_setup(int alg_arg,
     psa_status_t forced_status = forced_status_arg;
     psa_status_t expected_status = expected_status_arg;
     unsigned char *output = NULL;
-    psa_hash_operation_t operation = PSA_HASH_OPERATION_INIT;
+    psa_hash_operation_t operation = psa_hash_operation_init_short();
     size_t output_length;
 
 
@@ -2341,7 +2341,7 @@ void hash_multipart_update(int alg_arg,
     psa_algorithm_t alg = alg_arg;
     psa_status_t forced_status = forced_status_arg;
     unsigned char *output = NULL;
-    psa_hash_operation_t operation = PSA_HASH_OPERATION_INIT;
+    psa_hash_operation_t operation = psa_hash_operation_init_short();
     size_t output_length;
 
 
@@ -2398,7 +2398,7 @@ void hash_multipart_finish(int alg_arg,
     psa_algorithm_t alg = alg_arg;
     psa_status_t forced_status = forced_status_arg;
     unsigned char *output = NULL;
-    psa_hash_operation_t operation = PSA_HASH_OPERATION_INIT;
+    psa_hash_operation_t operation = psa_hash_operation_init_short();
     size_t output_length;
 
     PSA_ASSERT(psa_crypto_init());
@@ -2452,8 +2452,8 @@ void hash_clone(int alg_arg,
     psa_algorithm_t alg = alg_arg;
     psa_status_t forced_status = forced_status_arg;
     unsigned char *output = NULL;
-    psa_hash_operation_t source_operation = PSA_HASH_OPERATION_INIT;
-    psa_hash_operation_t target_operation = PSA_HASH_OPERATION_INIT;
+    psa_hash_operation_t source_operation = psa_hash_operation_init_short();
+    psa_hash_operation_t target_operation = psa_hash_operation_init_short();
     size_t output_length;
 
     PSA_ASSERT(psa_crypto_init());
@@ -3019,7 +3019,7 @@ void pake_operations(data_t *pw_data, int forced_status_setup_arg, int forced_st
     psa_pake_operation_t operation = psa_pake_operation_init();
     psa_pake_cipher_suite_t cipher_suite = psa_pake_cipher_suite_init();
     psa_key_derivation_operation_t implicit_key =
-        PSA_KEY_DERIVATION_OPERATION_INIT;
+        psa_key_derivation_operation_init_short();
     psa_pake_primitive_t primitive = PSA_PAKE_PRIMITIVE(
         PSA_PAKE_PRIMITIVE_TYPE_ECC,
         PSA_ECC_FAMILY_SECP_R1, 256);
@@ -3214,9 +3214,9 @@ void ecjpake_rounds(int alg_arg, int primitive_arg, int hash_arg,
     mbedtls_svc_key_id_t key = MBEDTLS_SVC_KEY_ID_INIT;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     psa_key_derivation_operation_t server_derive =
-        PSA_KEY_DERIVATION_OPERATION_INIT;
+        psa_key_derivation_operation_init_short();
     psa_key_derivation_operation_t client_derive =
-        PSA_KEY_DERIVATION_OPERATION_INIT;
+        psa_key_derivation_operation_init_short();
     pake_in_driver = in_driver;
     /* driver setup is called indirectly through pake_output/pake_input */
     if (pake_in_driver) {


### PR DESCRIPTION
Improved testing for https://github.com/Mbed-TLS/mbedtls/issues/9814 and https://github.com/Mbed-TLS/mbedtls/issues/9975:

* In unit tests for PSA crypto API multipart operations, use a not-all-bits-zero initializer, simulating what happens with GCC 15. This validates the fix for https://github.com/Mbed-TLS/mbedtls/issues/9814.
* (framework) In test drivers, check that the context is zero on entry to setup. This validates the fix for https://github.com/Mbed-TLS/mbedtls/issues/9975, and also validates that the frontend is robust against https://github.com/Mbed-TLS/mbedtls/issues/9814.

Needs preceding PR:

- [x] framework https://github.com/Mbed-TLS/mbedtls-framework/pull/168
- [x] Continues from https://github.com/Mbed-TLS/mbedtls/pull/10168. The first new commit is "Use short initializers for multipart operation structures".

## PR checklist

- [x] **changelog** not required because: just additional testing (changelog entry in https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/295)
- [x] **framework PR** provided https://github.com/Mbed-TLS/mbedtls-framework/pull/168
- [x] **crypto PR** https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/296
- [x] **mbedtls development PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10178
- [x] **mbedtls 3.6 PR** here
- **tests**  provided
