### PR TITLE
Mark TLS 1.2 algo suite definitons const

### DIFF
--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -5826,7 +5826,7 @@ static const uint16_t ssl_preset_suiteb_sig_algs[] = {
 
 /* NOTICE: see above */
 #if defined(MBEDTLS_SSL_PROTO_TLS1_2)
-static uint16_t ssl_tls12_preset_suiteb_sig_algs[] = {
+static const uint16_t ssl_tls12_preset_suiteb_sig_algs[] = {
 
 #if defined(MBEDTLS_MD_CAN_SHA256)
 #if defined(MBEDTLS_KEY_EXCHANGE_ECDSA_CERT_REQ_ALLOWED_ENABLED)

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -5762,7 +5762,7 @@ static const uint16_t ssl_preset_default_sig_algs[] = {
 
 /* NOTICE: see above */
 #if defined(MBEDTLS_SSL_PROTO_TLS1_2)
-static uint16_t ssl_tls12_preset_default_sig_algs[] = {
+static const uint16_t ssl_tls12_preset_default_sig_algs[] = {
 
 #if defined(MBEDTLS_MD_CAN_SHA512)
 #if defined(MBEDTLS_KEY_EXCHANGE_ECDSA_CERT_REQ_ALLOWED_ENABLED)


### PR DESCRIPTION
## Description

Backport of https://github.com/Mbed-TLS/mbedtls/pull/8947 to 3.6

cc @mpg

## PR checklist

- [x] **changelog** not required because: no user-visible change (except a small memory optimisation)
- [x] **development PR** provided #8947
- [x] **TF-PSA-Crypto PR** not required because: TLS only
- [x] **framework PR** not required
- [x] **3.6 PR** provided HERE
- **tests** not required because: nothing new to cover