### PR TITLE
Remove call to pk_decrypt() in ssl_server2

### DIFF
--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -1140,7 +1140,6 @@ static int ssl_async_set_key(ssl_async_key_context_t *ctx,
 
 typedef enum {
     ASYNC_OP_SIGN,
-    ASYNC_OP_DECRYPT,
 } ssl_async_operation_type_t;
 
 typedef struct {
@@ -1160,7 +1159,6 @@ typedef struct {
 static const char *const ssl_async_operation_names[] =
 {
     "sign",
-    "decrypt",
 };
 
 static int ssl_async_start(mbedtls_ssl_context *ssl,
@@ -1261,11 +1259,6 @@ static int ssl_async_resume(mbedtls_ssl_context *ssl,
     }
 
     switch (ctx->operation_type) {
-        case ASYNC_OP_DECRYPT:
-            ret = mbedtls_pk_decrypt(key_slot->pk,
-                                     ctx->input, ctx->input_len,
-                                     output, output_len, output_size);
-            break;
         case ASYNC_OP_SIGN:
             ret = mbedtls_pk_sign(key_slot->pk,
                                   ctx->md_alg,


### PR DESCRIPTION
## Description

We no longer use decrypt TLS 1.2 (never did in 1.3) so we no longer need this path. Further simplifications could probably be made (we currently have an enum type with only one possible value...) but for now I'm trying to keep changes minimal.

This is to support https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/297 which in turns paves the way for https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/298

## PR checklist

- [x] **changelog** not required because: sample program only
- [x] **development PR** provided HERE
- [x] **TF-PSA-Crypto PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/297
- [x] **framework PR** not required
- [x] **3.6 PR** not required because: 4.0-only removal
- **tests** not required because: removal