### PR TITLE
[dev] Fix format specifiers for ANSI stdio

### DIFF
--- a/include/mbedtls/debug.h
+++ b/include/mbedtls/debug.h
@@ -111,7 +111,7 @@
 #if defined(__MINGW32__) || (defined(_MSC_VER) && _MSC_VER < 1900)
    #include <inttypes.h>
    #define MBEDTLS_PRINTF_SIZET     PRIuPTR
-   #define MBEDTLS_PRINTF_LONGLONG  "I64d"
+   #define MBEDTLS_PRINTF_LONGLONG  PRId64
 #else \
     /* defined(__MINGW32__) || (defined(_MSC_VER) && _MSC_VER < 1900) */
    #define MBEDTLS_PRINTF_SIZET     "zu"


### PR DESCRIPTION
Trivial forward-port of #10165 

Instead of using the windows-specific `"I64d"` format specifier, use the friendly MinGW abstraction `PRId64`, which works both when `__USE_MINGW_ANSI_STDIO` is enabled and when it is disabled.

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [ ] **changelog** provided | not required because: 
- [x] **development PR** here 
- [x] **TF-PSA-Crypto PR** not required because: Issue is in mbedtls only
- [x] **framework PR** not required
- [x] **3.6 PR** provided #10165 
- **tests**  not required because: Platform build fix only

