### PR TITLE
Break down mbedtls_test_ssl_perform_handshake

### DIFF
--- a/ChangeLog.d/mbedtls_ssl_conf_alpn_protocols.txt
+++ b/ChangeLog.d/mbedtls_ssl_conf_alpn_protocols.txt
@@ -1,0 +1,4 @@
+API changes
+   * The list passed to mbedtls_ssl_conf_alpn_protocols() is now declared
+     as having const elements, reflecting the fact that the library will
+     not modify it

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1569,7 +1569,7 @@ struct mbedtls_ssl_config {
 #endif /* MBEDTLS_SSL_EARLY_DATA */
 
 #if defined(MBEDTLS_SSL_ALPN)
-    const char **MBEDTLS_PRIVATE(alpn_list);         /*!< ordered list of protocols          */
+    const char *const *MBEDTLS_PRIVATE(alpn_list); /*!< ordered list of protocols */
 #endif
 
 #if defined(MBEDTLS_SSL_DTLS_SRTP)
@@ -4011,7 +4011,8 @@ int mbedtls_ssl_set_hs_ecjpake_password_opaque(mbedtls_ssl_context *ssl,
  *
  * \return         0 on success, or MBEDTLS_ERR_SSL_BAD_INPUT_DATA.
  */
-int mbedtls_ssl_conf_alpn_protocols(mbedtls_ssl_config *conf, const char **protos);
+int mbedtls_ssl_conf_alpn_protocols(mbedtls_ssl_config *conf,
+                                    const char *const *protos);
 
 /**
  * \brief          Get the name of the negotiated Application Layer Protocol.

--- a/library/ssl_client.c
+++ b/library/ssl_client.c
@@ -141,7 +141,7 @@ static int ssl_write_alpn_ext(mbedtls_ssl_context *ssl,
      *     ProtocolName protocol_name_list<2..2^16-1>
      * } ProtocolNameList;
      */
-    for (const char **cur = ssl->conf->alpn_list; *cur != NULL; cur++) {
+    for (const char *const *cur = ssl->conf->alpn_list; *cur != NULL; cur++) {
         /*
          * mbedtls_ssl_conf_set_alpn_protocols() checked that the length of
          * protocol names is less than 255.

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -2534,10 +2534,11 @@ void mbedtls_ssl_conf_sni(mbedtls_ssl_config *conf,
 #endif /* MBEDTLS_SSL_SERVER_NAME_INDICATION */
 
 #if defined(MBEDTLS_SSL_ALPN)
-int mbedtls_ssl_conf_alpn_protocols(mbedtls_ssl_config *conf, const char **protos)
+int mbedtls_ssl_conf_alpn_protocols(mbedtls_ssl_config *conf,
+                                    const char *const *protos)
 {
     size_t cur_len, tot_len;
-    const char **p;
+    const char *const *p;
 
     /*
      * RFC 7301 3.1: "Empty strings MUST NOT be included and byte strings
@@ -5111,7 +5112,7 @@ static int ssl_context_load(mbedtls_ssl_context *ssl,
 #if defined(MBEDTLS_SSL_ALPN)
     {
         uint8_t alpn_len;
-        const char **cur;
+        const char *const *cur;
 
         if ((size_t) (end - p) < 1) {
             return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
@@ -8547,7 +8548,7 @@ int mbedtls_ssl_parse_alpn_ext(mbedtls_ssl_context *ssl,
     }
 
     /* Use our order of preference */
-    for (const char **alpn = ssl->conf->alpn_list; *alpn != NULL; alpn++) {
+    for (const char *const *alpn = ssl->conf->alpn_list; *alpn != NULL; alpn++) {
         size_t const alpn_len = strlen(*alpn);
         p = protocol_name_list;
         while (p < protocol_name_list_end) {

--- a/library/ssl_tls12_client.c
+++ b/library/ssl_tls12_client.c
@@ -869,7 +869,7 @@ static int ssl_parse_alpn_ext(mbedtls_ssl_context *ssl,
                               const unsigned char *buf, size_t len)
 {
     size_t list_len, name_len;
-    const char **p;
+    const char *const *p;
 
     /* If we didn't send it, the server shouldn't send it */
     if (ssl->conf->alpn_list == NULL) {

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -158,7 +158,7 @@ static int ssl_tls13_parse_alpn_ext(mbedtls_ssl_context *ssl,
 
     /* Check that the server chosen protocol was in our list and save it */
     MBEDTLS_SSL_CHK_BUF_READ_PTR(p, protocol_name_list_end, protocol_name_len);
-    for (const char **alpn = ssl->conf->alpn_list; *alpn != NULL; alpn++) {
+    for (const char *const *alpn = ssl->conf->alpn_list; *alpn != NULL; alpn++) {
         if (protocol_name_len == strlen(*alpn) &&
             memcmp(p, *alpn, protocol_name_len) == 0) {
             ssl->alpn_chosen = *alpn;

--- a/tests/include/test/ssl_helpers.h
+++ b/tests/include/test/ssl_helpers.h
@@ -187,15 +187,6 @@ typedef struct mbedtls_test_message_socket_context {
 #if defined(MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED)
 
 /*
- * Structure with endpoint's certificates for SSL communication tests.
- */
-typedef struct mbedtls_test_ssl_endpoint_certificate {
-    mbedtls_x509_crt *ca_cert;
-    mbedtls_x509_crt *cert;
-    mbedtls_pk_context *pkey;
-} mbedtls_test_ssl_endpoint_certificate;
-
-/*
  * Endpoint structure for SSL communication tests.
  */
 typedef struct mbedtls_test_ssl_endpoint {
@@ -203,7 +194,11 @@ typedef struct mbedtls_test_ssl_endpoint {
     mbedtls_ssl_context ssl;
     mbedtls_ssl_config conf;
     mbedtls_test_mock_socket socket;
-    mbedtls_test_ssl_endpoint_certificate cert;
+
+    /* Objects owned by the endpoint */
+    mbedtls_x509_crt *ca_chain;
+    mbedtls_x509_crt *cert;
+    mbedtls_pk_context *pkey;
 } mbedtls_test_ssl_endpoint;
 
 #endif /* MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED */
@@ -432,8 +427,7 @@ int mbedtls_test_mock_tcp_recv_msg(void *ctx,
 #if defined(MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED)
 
 /*
- * Initializes \p ep_cert structure and assigns it to endpoint
- * represented by \p ep.
+ * Load default CA certificates and endpoint keys into \p ep.
  *
  * \retval  0 on success, otherwise error code.
  */

--- a/tests/include/test/ssl_helpers.h
+++ b/tests/include/test/ssl_helpers.h
@@ -199,6 +199,7 @@ typedef struct mbedtls_test_ssl_endpoint {
 #endif
 
     /* Objects owned by the endpoint */
+    int *ciphersuites;
     mbedtls_x509_crt *ca_chain;
     mbedtls_x509_crt *cert;
     mbedtls_pk_context *pkey;

--- a/tests/include/test/ssl_helpers.h
+++ b/tests/include/test/ssl_helpers.h
@@ -458,25 +458,17 @@ int mbedtls_test_ssl_endpoint_certificate_init(mbedtls_test_ssl_endpoint *ep,
  * MBEDTLS_SSL_IS_CLIENT.
  * \p pk_alg the algorithm to use, currently only MBEDTLS_PK_RSA and
  * MBEDTLS_PK_ECDSA are supported.
- * \p dtls_context - in case of DTLS - this is the context handling metadata.
- * \p input_queue - used only in case of DTLS.
- * \p output_queue - used only in case of DTLS.
  *
  * \retval  0 on success, otherwise error code.
  */
 int mbedtls_test_ssl_endpoint_init(
     mbedtls_test_ssl_endpoint *ep, int endpoint_type,
-    const mbedtls_test_handshake_test_options *options,
-    mbedtls_test_message_socket_context *dtls_context,
-    mbedtls_test_ssl_message_queue *input_queue,
-    mbedtls_test_ssl_message_queue *output_queue);
+    const mbedtls_test_handshake_test_options *options);
 
 /*
  * Deinitializes endpoint represented by \p ep.
  */
-void mbedtls_test_ssl_endpoint_free(
-    mbedtls_test_ssl_endpoint *ep,
-    mbedtls_test_message_socket_context *context);
+void mbedtls_test_ssl_endpoint_free(mbedtls_test_ssl_endpoint *ep);
 
 /* Join a DTLS client with a DTLS server.
  *

--- a/tests/include/test/ssl_helpers.h
+++ b/tests/include/test/ssl_helpers.h
@@ -450,6 +450,9 @@ int mbedtls_test_ssl_endpoint_certificate_init(mbedtls_test_ssl_endpoint *ep,
  * `mbedtls_test_ssl_endpoint_free()` after calling this function
  * even if it fails.
  *
+ * \note For DTLS, after calling this function on both endpoints,
+ *       call mbedtls_test_ssl_dtls_join_endpoints().
+ *
  * \p endpoint_type must be set as MBEDTLS_SSL_IS_SERVER or
  * MBEDTLS_SSL_IS_CLIENT.
  * \p pk_alg the algorithm to use, currently only MBEDTLS_PK_RSA and
@@ -473,6 +476,21 @@ int mbedtls_test_ssl_endpoint_init(
 void mbedtls_test_ssl_endpoint_free(
     mbedtls_test_ssl_endpoint *ep,
     mbedtls_test_message_socket_context *context);
+
+/* Join a DTLS client with a DTLS server.
+ *
+ * You must call this function after setting up the endpoint objects
+ * and before starting a DTLS handshake.
+ *
+ * \param client    The client. It must have been set up with
+ *                  mbedtls_test_ssl_endpoint_init().
+ * \param server    The server. It must have been set up with
+ *                  mbedtls_test_ssl_endpoint_init().
+ *
+ * \retval  0 on success, otherwise error code.
+ */
+int mbedtls_test_ssl_dtls_join_endpoints(mbedtls_test_ssl_endpoint *client,
+                                         mbedtls_test_ssl_endpoint *server);
 
 /*
  * This function moves ssl handshake from \p ssl to prescribed \p state.

--- a/tests/include/test/ssl_helpers.h
+++ b/tests/include/test/ssl_helpers.h
@@ -205,6 +205,7 @@ typedef struct mbedtls_test_ssl_endpoint {
 
     /* Objects owned by the endpoint */
     int *ciphersuites;
+    mbedtls_test_ssl_message_queue queue_input;
     mbedtls_x509_crt *ca_chain;
     mbedtls_x509_crt *cert;
     mbedtls_pk_context *pkey;

--- a/tests/include/test/ssl_helpers.h
+++ b/tests/include/test/ssl_helpers.h
@@ -457,7 +457,7 @@ int mbedtls_test_ssl_endpoint_certificate_init(mbedtls_test_ssl_endpoint *ep,
  */
 int mbedtls_test_ssl_endpoint_init(
     mbedtls_test_ssl_endpoint *ep, int endpoint_type,
-    mbedtls_test_handshake_test_options *options,
+    const mbedtls_test_handshake_test_options *options,
     mbedtls_test_message_socket_context *dtls_context,
     mbedtls_test_ssl_message_queue *input_queue,
     mbedtls_test_ssl_message_queue *output_queue);
@@ -609,7 +609,7 @@ int mbedtls_test_ssl_do_handshake_with_endpoints(
 
 #if defined(MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED)
 void mbedtls_test_ssl_perform_handshake(
-    mbedtls_test_handshake_test_options *options);
+    const mbedtls_test_handshake_test_options *options);
 #endif /* MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED */
 
 #if defined(MBEDTLS_TEST_HOOKS)

--- a/tests/include/test/ssl_helpers.h
+++ b/tests/include/test/ssl_helpers.h
@@ -194,6 +194,11 @@ typedef struct mbedtls_test_ssl_endpoint {
     mbedtls_ssl_context ssl;
     mbedtls_ssl_config conf;
     mbedtls_test_mock_socket socket;
+
+    /* Objects only used by DTLS.
+     * They should be guarded by MBEDTLS_SSL_PROTO_DTLS, but
+     * currently aren't because some code accesses them without guards. */
+    mbedtls_test_message_socket_context dtls_context;
 #if defined(MBEDTLS_TIMING_C)
     mbedtls_timing_delay_context timer;
 #endif

--- a/tests/include/test/ssl_helpers.h
+++ b/tests/include/test/ssl_helpers.h
@@ -447,18 +447,59 @@ int mbedtls_test_ssl_endpoint_certificate_init(mbedtls_test_ssl_endpoint *ep,
                                                int opaque_alg, int opaque_alg2,
                                                int opaque_usage);
 
-/*
- * Initializes \p ep structure. It is important to call
- * `mbedtls_test_ssl_endpoint_free()` after calling this function
- * even if it fails.
+/** Initialize the configuration in an SSL endpoint structure.
  *
- * \note For DTLS, after calling this function on both endpoints,
- *       call mbedtls_test_ssl_dtls_join_endpoints().
+ * \note You must call `mbedtls_test_ssl_endpoint_free()` after
+ * calling this function, even if it fails. This is necessary to
+ * free data that may have been stored in the endpoint structure.
  *
- * \p endpoint_type must be set as MBEDTLS_SSL_IS_SERVER or
- * MBEDTLS_SSL_IS_CLIENT.
- * \p pk_alg the algorithm to use, currently only MBEDTLS_PK_RSA and
- * MBEDTLS_PK_ECDSA are supported.
+ * \param[out] ep       The endpoint structure to configure.
+ * \param endpoint_type #MBEDTLS_SSL_IS_SERVER or #MBEDTLS_SSL_IS_CLIENT.
+ * \param[in] options   The options to use for configuring the endpoint
+ *                      structure.
+ *
+ * \retval  0 on success, otherwise error code.
+ */
+int mbedtls_test_ssl_endpoint_init_conf(
+    mbedtls_test_ssl_endpoint *ep, int endpoint_type,
+    const mbedtls_test_handshake_test_options *options);
+
+/** Initialize the session context in an endpoint structure.
+ *
+ * \note The endpoint structure must have been set up with
+ *       mbedtls_test_ssl_endpoint_init_conf() with the same \p options.
+ *       Between calling mbedtls_test_ssl_endpoint_init_conf() and
+ *       mbedtls_test_ssl_endpoint_init_ssl(), you may configure `ep->ssl`
+ *       further if you know what you're doing.
+ *
+ * \note You must call `mbedtls_test_ssl_endpoint_free()` after
+ * calling this function, even if it fails. This is necessary to
+ * free data that may have been stored in the endpoint structure.
+ *
+ * \param[out] ep       The endpoint structure to set up.
+ * \param[in] options   The options used for configuring the endpoint
+ *                      structure.
+ *
+ * \retval  0 on success, otherwise error code.
+ */
+int mbedtls_test_ssl_endpoint_init_ssl(
+    mbedtls_test_ssl_endpoint *ep,
+    const mbedtls_test_handshake_test_options *options);
+
+/** Initialize the configuration and a context in an SSL endpoint structure.
+ *
+ * This function is equivalent to calling
+ * mbedtls_test_ssl_endpoint_init_conf() followed by
+ * mbedtls_test_ssl_endpoint_init_ssl().
+ *
+ * \note You must call `mbedtls_test_ssl_endpoint_free()` after
+ * calling this function, even if it fails. This is necessary to
+ * free data that may have been stored in the endpoint structure.
+ *
+ * \param[out] ep       The endpoint structure to configure.
+ * \param endpoint_type #MBEDTLS_SSL_IS_SERVER or #MBEDTLS_SSL_IS_CLIENT.
+ * \param[in] options   The options to use for configuring the endpoint
+ *                      structure.
  *
  * \retval  0 on success, otherwise error code.
  */

--- a/tests/include/test/ssl_helpers.h
+++ b/tests/include/test/ssl_helpers.h
@@ -194,6 +194,7 @@ typedef struct mbedtls_test_ssl_endpoint {
     mbedtls_ssl_context ssl;
     mbedtls_ssl_config conf;
     mbedtls_test_mock_socket socket;
+    uintptr_t user_data_cookie; /* A unique value associated with this endpoint */
 
     /* Objects only used by DTLS.
      * They should be guarded by MBEDTLS_SSL_PROTO_DTLS, but

--- a/tests/include/test/ssl_helpers.h
+++ b/tests/include/test/ssl_helpers.h
@@ -624,6 +624,49 @@ int mbedtls_test_ssl_do_handshake_with_endpoints(
 #endif /* defined(MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED) */
 
 #if defined(MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED)
+/** Perform an SSL handshake and exchange data over the connection.
+ *
+ * This function also handles cases where the handshake is expected to fail.
+ *
+ * If the handshake succeeds as expected, this function validates that
+ * connection parameters are as expected, exchanges data over the
+ * connection, and exercises some optional protocol features if they
+ * are enabled. See the code to see what features are validated and exercised.
+ *
+ * The handshake is expected to fail in the following cases:
+ * - If `options->expected_handshake_result != 0`.
+ * - If `options->expected_negotiated_version == MBEDTLS_SSL_VERSION_UNKNOWN`.
+ *
+ * \param[in] options   Options for the connection.
+ * \param client        The client endpoint. It must have been set up with
+ *                      mbedtls_test_ssl_endpoint_init() with \p options
+ *                      and #MBEDTLS_SSL_IS_CLIENT.
+ * \param server        The server endpoint. It must have been set up with
+ *                      mbedtls_test_ssl_endpoint_init() with \p options
+ *                      and #MBEDTLS_SSL_IS_CLIENT.
+ *
+ * \return              1 on success, 0 on failure. On failure, this function
+ *                      calls mbedtls_test_fail(), indicating the failure
+ *                      reason and location. The causes of failure are:
+ *                      - Inconsistent options or bad endpoint state.
+ *                      - Operational problem during the handshake.
+ *                      - The handshake was expected to pass, but failed.
+ *                      - The handshake was expected to fail, but passed or
+ *                        failed with a different result.
+ *                      - The handshake passed as expected, but some connection
+ *                        parameter (e.g. protocol version, cipher suite, ...)
+ *                        is not as expected.
+ *                      - The handshake passed as expected, but something
+ *                        went wrong when attempting to exchange data.
+ *                      - The handshake passed as expected, but something
+ *                        went wrong when exercising other features
+ *                        (e.g. renegotiation, serialization, ...).
+ */
+int mbedtls_test_ssl_perform_connection(
+    const mbedtls_test_handshake_test_options *options,
+    mbedtls_test_ssl_endpoint *client,
+    mbedtls_test_ssl_endpoint *server);
+
 void mbedtls_test_ssl_perform_handshake(
     const mbedtls_test_handshake_test_options *options);
 #endif /* MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED */

--- a/tests/include/test/ssl_helpers.h
+++ b/tests/include/test/ssl_helpers.h
@@ -194,6 +194,9 @@ typedef struct mbedtls_test_ssl_endpoint {
     mbedtls_ssl_context ssl;
     mbedtls_ssl_config conf;
     mbedtls_test_mock_socket socket;
+#if defined(MBEDTLS_TIMING_C)
+    mbedtls_timing_delay_context timer;
+#endif
 
     /* Objects owned by the endpoint */
     mbedtls_x509_crt *ca_chain;

--- a/tests/src/test_helpers/ssl_helpers.c
+++ b/tests/src/test_helpers/ssl_helpers.c
@@ -2136,29 +2136,15 @@ void mbedtls_test_ssl_perform_handshake(
 #endif
 
     /* Client side */
-    if (options->dtls != 0) {
-        TEST_EQUAL(mbedtls_test_ssl_endpoint_init(&client,
-                                                  MBEDTLS_SSL_IS_CLIENT,
-                                                  options), 0);
-    } else {
-        TEST_EQUAL(mbedtls_test_ssl_endpoint_init(&client,
-                                                  MBEDTLS_SSL_IS_CLIENT,
-                                                  options), 0);
-    }
-
+    TEST_EQUAL(mbedtls_test_ssl_endpoint_init(&client,
+                                              MBEDTLS_SSL_IS_CLIENT,
+                                              options), 0);
     TEST_ASSERT(set_ciphersuite(&client, options->cipher));
 
     /* Server side */
-    if (options->dtls != 0) {
-        TEST_EQUAL(mbedtls_test_ssl_endpoint_init(&server,
-                                                  MBEDTLS_SSL_IS_SERVER,
-                                                  options), 0);
-    } else {
-        TEST_EQUAL(mbedtls_test_ssl_endpoint_init(&server,
-                                                  MBEDTLS_SSL_IS_SERVER,
-                                                  options), 0);
-    }
-
+    TEST_EQUAL(mbedtls_test_ssl_endpoint_init(&server,
+                                              MBEDTLS_SSL_IS_SERVER,
+                                              options), 0);
     mbedtls_ssl_conf_authmode(&server.conf, options->srv_auth_mode);
 
     if (options->dtls) {

--- a/tests/src/test_helpers/ssl_helpers.c
+++ b/tests/src/test_helpers/ssl_helpers.c
@@ -719,15 +719,6 @@ int mbedtls_test_ssl_endpoint_certificate_init(mbedtls_test_ssl_endpoint *ep,
     ret = mbedtls_ssl_conf_own_cert(&(ep->conf), ep->cert,
                                     ep->pkey);
     TEST_EQUAL(ret, 0);
-    TEST_ASSERT(ep->conf.key_cert != NULL);
-
-    ret = mbedtls_ssl_conf_own_cert(&(ep->conf), NULL, NULL);
-    TEST_EQUAL(ret, 0);
-    TEST_ASSERT(ep->conf.key_cert == NULL);
-
-    ret = mbedtls_ssl_conf_own_cert(&(ep->conf), ep->cert,
-                                    ep->pkey);
-    TEST_EQUAL(ret, 0);
 
     ok = 1;
 

--- a/tests/src/test_helpers/ssl_helpers.c
+++ b/tests/src/test_helpers/ssl_helpers.c
@@ -71,7 +71,7 @@ void mbedtls_test_init_handshake_options(
     opts->server_max_version = MBEDTLS_SSL_VERSION_UNKNOWN;
     opts->expected_negotiated_version = MBEDTLS_SSL_VERSION_TLS1_3;
     opts->pk_alg = MBEDTLS_PK_RSA;
-    opts->srv_auth_mode = MBEDTLS_SSL_VERIFY_NONE;
+    opts->srv_auth_mode = MBEDTLS_SSL_VERIFY_REQUIRED;
     opts->mfl = MBEDTLS_SSL_MAX_FRAG_LEN_NONE;
     opts->cli_msg_len = 100;
     opts->srv_msg_len = 100;
@@ -876,7 +876,11 @@ int mbedtls_test_ssl_endpoint_init(
         mbedtls_ssl_conf_groups(&(ep->conf), options->group_list);
     }
 
-    mbedtls_ssl_conf_authmode(&(ep->conf), MBEDTLS_SSL_VERIFY_REQUIRED);
+    if (MBEDTLS_SSL_IS_SERVER == endpoint_type) {
+        mbedtls_ssl_conf_authmode(&(ep->conf), options->srv_auth_mode);
+    } else {
+        mbedtls_ssl_conf_authmode(&(ep->conf), MBEDTLS_SSL_VERIFY_REQUIRED);
+    }
 
 #if defined(MBEDTLS_SSL_EARLY_DATA)
     mbedtls_ssl_conf_early_data(&(ep->conf), options->early_data);
@@ -2440,7 +2444,6 @@ void mbedtls_test_ssl_perform_handshake(
     TEST_EQUAL(mbedtls_test_ssl_endpoint_init(server,
                                               MBEDTLS_SSL_IS_SERVER,
                                               options), 0);
-    mbedtls_ssl_conf_authmode(&server->conf, options->srv_auth_mode);
 
     if (options->dtls) {
         TEST_EQUAL(mbedtls_test_ssl_dtls_join_endpoints(client, server), 0);

--- a/tests/src/test_helpers/ssl_helpers.c
+++ b/tests/src/test_helpers/ssl_helpers.c
@@ -933,6 +933,19 @@ void mbedtls_test_ssl_endpoint_free(
     }
 }
 
+int mbedtls_test_ssl_dtls_join_endpoints(mbedtls_test_ssl_endpoint *client,
+                                         mbedtls_test_ssl_endpoint *server)
+{
+    int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
+
+    /* Nothing to do yet. */
+    (void) client;
+    (void) server;
+    ret = 0;
+
+    return ret;
+}
+
 int mbedtls_test_move_handshake_to_state(mbedtls_ssl_context *ssl,
                                          mbedtls_ssl_context *second_ssl,
                                          int state)
@@ -2168,6 +2181,10 @@ void mbedtls_test_ssl_perform_handshake(
     }
 
     mbedtls_ssl_conf_authmode(&server.conf, options->srv_auth_mode);
+
+    if (options->dtls) {
+        TEST_EQUAL(mbedtls_test_ssl_dtls_join_endpoints(&client, &server), 0);
+    }
 
 #if defined(MBEDTLS_SSL_MAX_FRAGMENT_LENGTH)
     TEST_EQUAL(mbedtls_ssl_conf_max_frag_len(&(server.conf),

--- a/tests/src/test_helpers/ssl_helpers.c
+++ b/tests/src/test_helpers/ssl_helpers.c
@@ -800,7 +800,7 @@ exit:
     return ret;
 }
 
-int mbedtls_test_ssl_endpoint_init(
+int mbedtls_test_ssl_endpoint_init_conf(
     mbedtls_test_ssl_endpoint *ep, int endpoint_type,
     const mbedtls_test_handshake_test_options *options)
 {
@@ -968,7 +968,22 @@ int mbedtls_test_ssl_endpoint_init(
                ep->user_data_cookie);
     mbedtls_ssl_conf_set_user_data_p(&ep->conf, ep);
 
-    /* We've finished the configuration. Now set up a context. */
+    return 0;
+
+exit:
+    if (ret == 0) {
+        /* Exiting due to a test assertion that isn't ret == 0 */
+        ret = -1;
+    }
+    return ret;
+}
+
+int mbedtls_test_ssl_endpoint_init_ssl(
+    mbedtls_test_ssl_endpoint *ep,
+    const mbedtls_test_handshake_test_options *options)
+{
+    int endpoint_type = mbedtls_ssl_conf_get_endpoint(&ep->conf);
+    int ret = -1;
 
     ret = mbedtls_ssl_setup(&(ep->ssl), &(ep->conf));
     TEST_EQUAL(ret, 0);
@@ -1006,6 +1021,18 @@ exit:
         /* Exiting due to a test assertion that isn't ret == 0 */
         ret = -1;
     }
+    return ret;
+}
+
+int mbedtls_test_ssl_endpoint_init(
+    mbedtls_test_ssl_endpoint *ep, int endpoint_type,
+    const mbedtls_test_handshake_test_options *options)
+{
+    int ret = mbedtls_test_ssl_endpoint_init_conf(ep, endpoint_type, options);
+    if (ret != 0) {
+        return ret;
+    }
+    ret = mbedtls_test_ssl_endpoint_init_ssl(ep, options);
     return ret;
 }
 

--- a/tests/src/test_helpers/ssl_helpers.c
+++ b/tests/src/test_helpers/ssl_helpers.c
@@ -786,6 +786,11 @@ int mbedtls_test_ssl_endpoint_init(
                             mbedtls_test_mock_tcp_send_msg,
                             mbedtls_test_mock_tcp_recv_msg,
                             NULL);
+#if defined(MBEDTLS_TIMING_C)
+        mbedtls_ssl_set_timer_cb(&ep->ssl, &ep->timer,
+                                 mbedtls_timing_set_delay,
+                                 mbedtls_timing_get_delay);
+#endif
     } else {
         mbedtls_ssl_set_bio(&(ep->ssl), &(ep->socket),
                             mbedtls_test_mock_tcp_send_nb,
@@ -2100,9 +2105,6 @@ void mbedtls_test_ssl_perform_handshake(
 #if defined(MBEDTLS_SSL_HANDSHAKE_WITH_PSK_ENABLED)
     const char *psk_identity = "foo";
 #endif
-#if defined(MBEDTLS_TIMING_C)
-    mbedtls_timing_delay_context timer_client, timer_server;
-#endif
 #if defined(MBEDTLS_SSL_CONTEXT_SERIALIZATION)
     unsigned char *context_buf = NULL;
     size_t context_buf_len;
@@ -2133,11 +2135,6 @@ void mbedtls_test_ssl_perform_handshake(
                                                   options, &client_context,
                                                   &client_queue,
                                                   &server_queue), 0);
-#if defined(MBEDTLS_TIMING_C)
-        mbedtls_ssl_set_timer_cb(&client.ssl, &timer_client,
-                                 mbedtls_timing_set_delay,
-                                 mbedtls_timing_get_delay);
-#endif
     } else {
         TEST_EQUAL(mbedtls_test_ssl_endpoint_init(&client,
                                                   MBEDTLS_SSL_IS_CLIENT,
@@ -2156,11 +2153,6 @@ void mbedtls_test_ssl_perform_handshake(
                                                   options, &server_context,
                                                   &server_queue,
                                                   &client_queue), 0);
-#if defined(MBEDTLS_TIMING_C)
-        mbedtls_ssl_set_timer_cb(&server.ssl, &timer_server,
-                                 mbedtls_timing_set_delay,
-                                 mbedtls_timing_get_delay);
-#endif
     } else {
         TEST_EQUAL(mbedtls_test_ssl_endpoint_init(&server,
                                                   MBEDTLS_SSL_IS_SERVER,
@@ -2323,7 +2315,7 @@ void mbedtls_test_ssl_perform_handshake(
         mbedtls_ssl_set_user_data_p(&server.ssl, &server);
 
 #if defined(MBEDTLS_TIMING_C)
-        mbedtls_ssl_set_timer_cb(&server.ssl, &timer_server,
+        mbedtls_ssl_set_timer_cb(&server.ssl, &server.timer,
                                  mbedtls_timing_set_delay,
                                  mbedtls_timing_get_delay);
 #endif

--- a/tests/src/test_helpers/ssl_helpers.c
+++ b/tests/src/test_helpers/ssl_helpers.c
@@ -637,7 +637,7 @@ int mbedtls_test_ssl_endpoint_certificate_init(mbedtls_test_ssl_endpoint *ep,
             cert->ca_cert,
             (const unsigned char *) mbedtls_test_cas_der[i],
             mbedtls_test_cas_der_len[i]);
-        TEST_ASSERT(ret == 0);
+        TEST_EQUAL(ret, 0);
     }
 
     /* Load own certificate and private key */
@@ -648,25 +648,25 @@ int mbedtls_test_ssl_endpoint_certificate_init(mbedtls_test_ssl_endpoint *ep,
                 cert->cert,
                 (const unsigned char *) mbedtls_test_srv_crt_rsa_sha256_der,
                 mbedtls_test_srv_crt_rsa_sha256_der_len);
-            TEST_ASSERT(ret == 0);
+            TEST_EQUAL(ret, 0);
 
             ret = mbedtls_pk_parse_key(
                 cert->pkey,
                 (const unsigned char *) mbedtls_test_srv_key_rsa_der,
                 mbedtls_test_srv_key_rsa_der_len, NULL, 0);
-            TEST_ASSERT(ret == 0);
+            TEST_EQUAL(ret, 0);
         } else {
             ret = mbedtls_x509_crt_parse(
                 cert->cert,
                 (const unsigned char *) mbedtls_test_srv_crt_ec_der,
                 mbedtls_test_srv_crt_ec_der_len);
-            TEST_ASSERT(ret == 0);
+            TEST_EQUAL(ret, 0);
 
             ret = mbedtls_pk_parse_key(
                 cert->pkey,
                 (const unsigned char *) mbedtls_test_srv_key_ec_der,
                 mbedtls_test_srv_key_ec_der_len, NULL, 0);
-            TEST_ASSERT(ret == 0);
+            TEST_EQUAL(ret, 0);
         }
     } else {
         if (pk_alg == MBEDTLS_PK_RSA) {
@@ -674,25 +674,25 @@ int mbedtls_test_ssl_endpoint_certificate_init(mbedtls_test_ssl_endpoint *ep,
                 cert->cert,
                 (const unsigned char *) mbedtls_test_cli_crt_rsa_der,
                 mbedtls_test_cli_crt_rsa_der_len);
-            TEST_ASSERT(ret == 0);
+            TEST_EQUAL(ret, 0);
 
             ret = mbedtls_pk_parse_key(
                 cert->pkey,
                 (const unsigned char *) mbedtls_test_cli_key_rsa_der,
                 mbedtls_test_cli_key_rsa_der_len, NULL, 0);
-            TEST_ASSERT(ret == 0);
+            TEST_EQUAL(ret, 0);
         } else {
             ret = mbedtls_x509_crt_parse(
                 cert->cert,
                 (const unsigned char *) mbedtls_test_cli_crt_ec_der,
                 mbedtls_test_cli_crt_ec_len);
-            TEST_ASSERT(ret == 0);
+            TEST_EQUAL(ret, 0);
 
             ret = mbedtls_pk_parse_key(
                 cert->pkey,
                 (const unsigned char *) mbedtls_test_cli_key_ec_der,
                 mbedtls_test_cli_key_ec_der_len, NULL, 0);
-            TEST_ASSERT(ret == 0);
+            TEST_EQUAL(ret, 0);
         }
     }
 
@@ -723,16 +723,16 @@ int mbedtls_test_ssl_endpoint_certificate_init(mbedtls_test_ssl_endpoint *ep,
 
     ret = mbedtls_ssl_conf_own_cert(&(ep->conf), cert->cert,
                                     cert->pkey);
-    TEST_ASSERT(ret == 0);
+    TEST_EQUAL(ret, 0);
     TEST_ASSERT(ep->conf.key_cert != NULL);
 
     ret = mbedtls_ssl_conf_own_cert(&(ep->conf), NULL, NULL);
-    TEST_ASSERT(ret == 0);
+    TEST_EQUAL(ret, 0);
     TEST_ASSERT(ep->conf.key_cert == NULL);
 
     ret = mbedtls_ssl_conf_own_cert(&(ep->conf), cert->cert,
                                     cert->pkey);
-    TEST_ASSERT(ret == 0);
+    TEST_EQUAL(ret, 0);
 
     ok = 1;
 
@@ -787,9 +787,9 @@ int mbedtls_test_ssl_endpoint_init(
     mbedtls_ssl_set_user_data_n(&ep->ssl, user_data_n);
 
     if (dtls_context != NULL) {
-        TEST_ASSERT(mbedtls_test_message_socket_setup(input_queue, output_queue,
-                                                      100, &(ep->socket),
-                                                      dtls_context) == 0);
+        TEST_EQUAL(mbedtls_test_message_socket_setup(input_queue, output_queue,
+                                                     100, &(ep->socket),
+                                                     dtls_context), 0);
     } else {
         mbedtls_test_mock_socket_init(&(ep->socket));
     }
@@ -812,7 +812,7 @@ int mbedtls_test_ssl_endpoint_init(
                                       MBEDTLS_SSL_TRANSPORT_DATAGRAM :
                                       MBEDTLS_SSL_TRANSPORT_STREAM,
                                       MBEDTLS_SSL_PRESET_DEFAULT);
-    TEST_ASSERT(ret == 0);
+    TEST_EQUAL(ret, 0);
 
     if (MBEDTLS_SSL_IS_CLIENT == endpoint_type) {
         if (options->client_min_version != MBEDTLS_SSL_VERSION_UNKNOWN) {
@@ -868,7 +868,7 @@ int mbedtls_test_ssl_endpoint_init(
 #endif
 
     ret = mbedtls_ssl_setup(&(ep->ssl), &(ep->conf));
-    TEST_ASSERT(ret == 0);
+    TEST_EQUAL(ret, 0);
 
     if (MBEDTLS_SSL_IS_CLIENT == endpoint_type) {
         ret = mbedtls_ssl_set_hostname(&(ep->ssl), "localhost");
@@ -902,7 +902,7 @@ int mbedtls_test_ssl_endpoint_init(
                                                      options->opaque_alg,
                                                      options->opaque_alg2,
                                                      options->opaque_usage);
-    TEST_ASSERT(ret == 0);
+    TEST_EQUAL(ret, 0);
 
     TEST_EQUAL(mbedtls_ssl_conf_get_user_data_n(&ep->conf), user_data_n);
     mbedtls_ssl_conf_set_user_data_p(&ep->conf, ep);
@@ -985,7 +985,7 @@ static int mbedtls_ssl_write_fragment(mbedtls_ssl_context *ssl,
     /* Verify that calling mbedtls_ssl_write with a NULL buffer and zero length is
      * a valid no-op for TLS connections. */
     if (ssl->conf->transport != MBEDTLS_SSL_TRANSPORT_DATAGRAM) {
-        TEST_ASSERT(mbedtls_ssl_write(ssl, NULL, 0) == 0);
+        TEST_EQUAL(mbedtls_ssl_write(ssl, NULL, 0), 0);
     }
 
     ret = mbedtls_ssl_write(ssl, buf + *written, buf_len - *written);
@@ -1032,7 +1032,7 @@ static int mbedtls_ssl_read_fragment(mbedtls_ssl_context *ssl,
     /* Verify that calling mbedtls_ssl_write with a NULL buffer and zero length is
      * a valid no-op for TLS connections. */
     if (ssl->conf->transport != MBEDTLS_SSL_TRANSPORT_DATAGRAM) {
-        TEST_ASSERT(mbedtls_ssl_read(ssl, NULL, 0) == 0);
+        TEST_EQUAL(mbedtls_ssl_read(ssl, NULL, 0), 0);
     }
 
     ret = mbedtls_ssl_read(ssl, buf + *read, buf_len - *read);
@@ -1042,7 +1042,7 @@ static int mbedtls_ssl_read_fragment(mbedtls_ssl_context *ssl,
     }
 
     if (expected_fragments == 0) {
-        TEST_ASSERT(ret == 0);
+        TEST_EQUAL(ret, 0);
     } else if (expected_fragments == 1) {
         TEST_ASSERT(ret == buf_len ||
                     ret == MBEDTLS_ERR_SSL_WANT_READ ||
@@ -1929,10 +1929,10 @@ int mbedtls_test_ssl_exchange_data(
                 if (expected_fragments_1 == 0) {
                     /* This error is expected when the message is too large and
                      * cannot be fragmented */
-                    TEST_ASSERT(ret == MBEDTLS_ERR_SSL_BAD_INPUT_DATA);
+                    TEST_EQUAL(ret, MBEDTLS_ERR_SSL_BAD_INPUT_DATA);
                     msg_len_1 = 0;
                 } else {
-                    TEST_ASSERT(ret == 0);
+                    TEST_EQUAL(ret, 0);
                 }
             }
 
@@ -1944,10 +1944,10 @@ int mbedtls_test_ssl_exchange_data(
                 if (expected_fragments_2 == 0) {
                     /* This error is expected when the message is too large and
                      * cannot be fragmented */
-                    TEST_ASSERT(ret == MBEDTLS_ERR_SSL_BAD_INPUT_DATA);
+                    TEST_EQUAL(ret, MBEDTLS_ERR_SSL_BAD_INPUT_DATA);
                     msg_len_2 = 0;
                 } else {
-                    TEST_ASSERT(ret == 0);
+                    TEST_EQUAL(ret, 0);
                 }
             }
 
@@ -1957,7 +1957,7 @@ int mbedtls_test_ssl_exchange_data(
                                                 msg_len_2, &read_1,
                                                 &fragments_2,
                                                 expected_fragments_2);
-                TEST_ASSERT(ret == 0);
+                TEST_EQUAL(ret, 0);
             }
 
             /* ssl_2 reading */
@@ -1966,15 +1966,15 @@ int mbedtls_test_ssl_exchange_data(
                                                 msg_len_1, &read_2,
                                                 &fragments_1,
                                                 expected_fragments_1);
-                TEST_ASSERT(ret == 0);
+                TEST_EQUAL(ret, 0);
             }
         }
 
         ret = -1;
-        TEST_ASSERT(0 == memcmp(msg_buf_1, in_buf_2, msg_len_1));
-        TEST_ASSERT(0 == memcmp(msg_buf_2, in_buf_1, msg_len_2));
-        TEST_ASSERT(fragments_1 == expected_fragments_1);
-        TEST_ASSERT(fragments_2 == expected_fragments_2);
+        TEST_EQUAL(0, memcmp(msg_buf_1, in_buf_2, msg_len_1));
+        TEST_EQUAL(0, memcmp(msg_buf_2, in_buf_1, msg_len_2));
+        TEST_EQUAL(fragments_1, expected_fragments_1);
+        TEST_EQUAL(fragments_2, expected_fragments_2);
     }
 
     ret = 0;
@@ -2026,12 +2026,12 @@ static int check_ssl_version(
     switch (expected_negotiated_version) {
         case MBEDTLS_SSL_VERSION_TLS1_2:
             TEST_EQUAL(version_number, MBEDTLS_SSL_VERSION_TLS1_2);
-            TEST_ASSERT(strcmp(version_string, "TLSv1.2") == 0);
+            TEST_EQUAL(strcmp(version_string, "TLSv1.2"), 0);
             break;
 
         case MBEDTLS_SSL_VERSION_TLS1_3:
             TEST_EQUAL(version_number, MBEDTLS_SSL_VERSION_TLS1_3);
-            TEST_ASSERT(strcmp(version_string, "TLSv1.3") == 0);
+            TEST_EQUAL(strcmp(version_string, "TLSv1.3"), 0);
             break;
 
         default:
@@ -2142,21 +2142,21 @@ void mbedtls_test_ssl_perform_handshake(
 
     /* Client side */
     if (options->dtls != 0) {
-        TEST_ASSERT(mbedtls_test_ssl_endpoint_init(&client,
-                                                   MBEDTLS_SSL_IS_CLIENT,
-                                                   options, &client_context,
-                                                   &client_queue,
-                                                   &server_queue) == 0);
+        TEST_EQUAL(mbedtls_test_ssl_endpoint_init(&client,
+                                                  MBEDTLS_SSL_IS_CLIENT,
+                                                  options, &client_context,
+                                                  &client_queue,
+                                                  &server_queue), 0);
 #if defined(MBEDTLS_TIMING_C)
         mbedtls_ssl_set_timer_cb(&client.ssl, &timer_client,
                                  mbedtls_timing_set_delay,
                                  mbedtls_timing_get_delay);
 #endif
     } else {
-        TEST_ASSERT(mbedtls_test_ssl_endpoint_init(&client,
-                                                   MBEDTLS_SSL_IS_CLIENT,
-                                                   options, NULL, NULL,
-                                                   NULL) == 0);
+        TEST_EQUAL(mbedtls_test_ssl_endpoint_init(&client,
+                                                  MBEDTLS_SSL_IS_CLIENT,
+                                                  options, NULL, NULL,
+                                                  NULL), 0);
     }
 
     if (strlen(options->cipher) > 0) {
@@ -2165,49 +2165,49 @@ void mbedtls_test_ssl_perform_handshake(
 
     /* Server side */
     if (options->dtls != 0) {
-        TEST_ASSERT(mbedtls_test_ssl_endpoint_init(&server,
-                                                   MBEDTLS_SSL_IS_SERVER,
-                                                   options, &server_context,
-                                                   &server_queue,
-                                                   &client_queue) == 0);
+        TEST_EQUAL(mbedtls_test_ssl_endpoint_init(&server,
+                                                  MBEDTLS_SSL_IS_SERVER,
+                                                  options, &server_context,
+                                                  &server_queue,
+                                                  &client_queue), 0);
 #if defined(MBEDTLS_TIMING_C)
         mbedtls_ssl_set_timer_cb(&server.ssl, &timer_server,
                                  mbedtls_timing_set_delay,
                                  mbedtls_timing_get_delay);
 #endif
     } else {
-        TEST_ASSERT(mbedtls_test_ssl_endpoint_init(&server,
-                                                   MBEDTLS_SSL_IS_SERVER,
-                                                   options, NULL, NULL,
-                                                   NULL) == 0);
+        TEST_EQUAL(mbedtls_test_ssl_endpoint_init(&server,
+                                                  MBEDTLS_SSL_IS_SERVER,
+                                                  options, NULL, NULL,
+                                                  NULL), 0);
     }
 
     mbedtls_ssl_conf_authmode(&server.conf, options->srv_auth_mode);
 
 #if defined(MBEDTLS_SSL_MAX_FRAGMENT_LENGTH)
-    TEST_ASSERT(mbedtls_ssl_conf_max_frag_len(&(server.conf),
-                                              (unsigned char) options->mfl)
-                == 0);
-    TEST_ASSERT(mbedtls_ssl_conf_max_frag_len(&(client.conf),
-                                              (unsigned char) options->mfl)
-                == 0);
+    TEST_EQUAL(mbedtls_ssl_conf_max_frag_len(&(server.conf),
+                                             (unsigned char) options->mfl),
+               0);
+    TEST_EQUAL(mbedtls_ssl_conf_max_frag_len(&(client.conf),
+                                             (unsigned char) options->mfl),
+               0);
 #else
-    TEST_ASSERT(MBEDTLS_SSL_MAX_FRAG_LEN_NONE == options->mfl);
+    TEST_EQUAL(MBEDTLS_SSL_MAX_FRAG_LEN_NONE, options->mfl);
 #endif /* MBEDTLS_SSL_MAX_FRAGMENT_LENGTH */
 
 #if defined(MBEDTLS_SSL_HANDSHAKE_WITH_PSK_ENABLED)
     if (options->psk_str != NULL && options->psk_str->len > 0) {
-        TEST_ASSERT(mbedtls_ssl_conf_psk(
-                        &client.conf, options->psk_str->x,
-                        options->psk_str->len,
-                        (const unsigned char *) psk_identity,
-                        strlen(psk_identity)) == 0);
+        TEST_EQUAL(mbedtls_ssl_conf_psk(
+                       &client.conf, options->psk_str->x,
+                       options->psk_str->len,
+                       (const unsigned char *) psk_identity,
+                       strlen(psk_identity)), 0);
 
-        TEST_ASSERT(mbedtls_ssl_conf_psk(
-                        &server.conf, options->psk_str->x,
-                        options->psk_str->len,
-                        (const unsigned char *) psk_identity,
-                        strlen(psk_identity)) == 0);
+        TEST_EQUAL(mbedtls_ssl_conf_psk(
+                       &server.conf, options->psk_str->x,
+                       options->psk_str->len,
+                       (const unsigned char *) psk_identity,
+                       strlen(psk_identity)), 0);
 #if defined(MBEDTLS_SSL_SRV_C)
         mbedtls_ssl_conf_psk_cb(&server.conf, psk_dummy_callback, NULL);
 #endif
@@ -2227,17 +2227,17 @@ void mbedtls_test_ssl_perform_handshake(
     }
 #endif /* MBEDTLS_SSL_RENEGOTIATION */
 
-    TEST_ASSERT(mbedtls_test_mock_socket_connect(&(client.socket),
-                                                 &(server.socket),
-                                                 BUFFSIZE) == 0);
+    TEST_EQUAL(mbedtls_test_mock_socket_connect(&(client.socket),
+                                                &(server.socket),
+                                                BUFFSIZE), 0);
 
 #if defined(MBEDTLS_SSL_VARIABLE_BUFFER_LENGTH)
     if (options->resize_buffers != 0) {
         /* Ensure that the buffer sizes are appropriate before resizes */
-        TEST_ASSERT(client.ssl.out_buf_len == MBEDTLS_SSL_OUT_BUFFER_LEN);
-        TEST_ASSERT(client.ssl.in_buf_len == MBEDTLS_SSL_IN_BUFFER_LEN);
-        TEST_ASSERT(server.ssl.out_buf_len == MBEDTLS_SSL_OUT_BUFFER_LEN);
-        TEST_ASSERT(server.ssl.in_buf_len == MBEDTLS_SSL_IN_BUFFER_LEN);
+        TEST_EQUAL(client.ssl.out_buf_len, MBEDTLS_SSL_OUT_BUFFER_LEN);
+        TEST_EQUAL(client.ssl.in_buf_len, MBEDTLS_SSL_IN_BUFFER_LEN);
+        TEST_EQUAL(server.ssl.out_buf_len, MBEDTLS_SSL_OUT_BUFFER_LEN);
+        TEST_EQUAL(server.ssl.in_buf_len, MBEDTLS_SSL_IN_BUFFER_LEN);
     }
 #endif
 
@@ -2245,17 +2245,17 @@ void mbedtls_test_ssl_perform_handshake(
         expected_handshake_result = MBEDTLS_ERR_SSL_BAD_PROTOCOL_VERSION;
     }
 
-    TEST_ASSERT(mbedtls_test_move_handshake_to_state(&(client.ssl),
-                                                     &(server.ssl),
-                                                     MBEDTLS_SSL_HANDSHAKE_OVER)
-                ==  expected_handshake_result);
+    TEST_EQUAL(mbedtls_test_move_handshake_to_state(&(client.ssl),
+                                                    &(server.ssl),
+                                                    MBEDTLS_SSL_HANDSHAKE_OVER),
+               expected_handshake_result);
 
     if (expected_handshake_result != 0) {
         /* Connection will have failed by this point, skip to cleanup */
         goto exit;
     }
 
-    TEST_ASSERT(mbedtls_ssl_is_handshake_over(&client.ssl) == 1);
+    TEST_EQUAL(mbedtls_ssl_is_handshake_over(&client.ssl), 1);
 
     /* Make sure server state is moved to HANDSHAKE_OVER also. */
     TEST_EQUAL(mbedtls_test_move_handshake_to_state(&(server.ssl),
@@ -2263,7 +2263,7 @@ void mbedtls_test_ssl_perform_handshake(
                                                     MBEDTLS_SSL_HANDSHAKE_OVER),
                0);
 
-    TEST_ASSERT(mbedtls_ssl_is_handshake_over(&server.ssl) == 1);
+    TEST_EQUAL(mbedtls_ssl_is_handshake_over(&server.ssl), 1);
     /* Check that both sides have negotiated the expected version. */
     mbedtls_test_set_step(0);
     if (!check_ssl_version(options->expected_negotiated_version,
@@ -2286,48 +2286,48 @@ void mbedtls_test_ssl_perform_handshake(
     if (options->resize_buffers != 0) {
         /* A server, when using DTLS, might delay a buffer resize to happen
          * after it receives a message, so we force it. */
-        TEST_ASSERT(exchange_data(&(client.ssl), &(server.ssl)) == 0);
+        TEST_EQUAL(exchange_data(&(client.ssl), &(server.ssl)), 0);
 
-        TEST_ASSERT(client.ssl.out_buf_len ==
-                    mbedtls_ssl_get_output_buflen(&client.ssl));
-        TEST_ASSERT(client.ssl.in_buf_len ==
-                    mbedtls_ssl_get_input_buflen(&client.ssl));
-        TEST_ASSERT(server.ssl.out_buf_len ==
-                    mbedtls_ssl_get_output_buflen(&server.ssl));
-        TEST_ASSERT(server.ssl.in_buf_len ==
-                    mbedtls_ssl_get_input_buflen(&server.ssl));
+        TEST_EQUAL(client.ssl.out_buf_len,
+                   mbedtls_ssl_get_output_buflen(&client.ssl));
+        TEST_EQUAL(client.ssl.in_buf_len,
+                   mbedtls_ssl_get_input_buflen(&client.ssl));
+        TEST_EQUAL(server.ssl.out_buf_len,
+                   mbedtls_ssl_get_output_buflen(&server.ssl));
+        TEST_EQUAL(server.ssl.in_buf_len,
+                   mbedtls_ssl_get_input_buflen(&server.ssl));
     }
 #endif
 
     if (options->cli_msg_len != 0 || options->srv_msg_len != 0) {
         /* Start data exchanging test */
-        TEST_ASSERT(mbedtls_test_ssl_exchange_data(
-                        &(client.ssl), options->cli_msg_len,
-                        options->expected_cli_fragments,
-                        &(server.ssl), options->srv_msg_len,
-                        options->expected_srv_fragments)
-                    == 0);
+        TEST_EQUAL(mbedtls_test_ssl_exchange_data(
+                       &(client.ssl), options->cli_msg_len,
+                       options->expected_cli_fragments,
+                       &(server.ssl), options->srv_msg_len,
+                       options->expected_srv_fragments),
+                   0);
     }
 #if defined(MBEDTLS_SSL_CONTEXT_SERIALIZATION)
     if (options->serialize == 1) {
-        TEST_ASSERT(options->dtls == 1);
+        TEST_EQUAL(options->dtls, 1);
 
-        TEST_ASSERT(mbedtls_ssl_context_save(&(server.ssl), NULL,
-                                             0, &context_buf_len)
-                    == MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL);
+        TEST_EQUAL(mbedtls_ssl_context_save(&(server.ssl), NULL,
+                                            0, &context_buf_len),
+                   MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL);
 
         context_buf = mbedtls_calloc(1, context_buf_len);
         TEST_ASSERT(context_buf != NULL);
 
-        TEST_ASSERT(mbedtls_ssl_context_save(&(server.ssl), context_buf,
-                                             context_buf_len,
-                                             &context_buf_len)
-                    == 0);
+        TEST_EQUAL(mbedtls_ssl_context_save(&(server.ssl), context_buf,
+                                            context_buf_len,
+                                            &context_buf_len),
+                   0);
 
         mbedtls_ssl_free(&(server.ssl));
         mbedtls_ssl_init(&(server.ssl));
 
-        TEST_ASSERT(mbedtls_ssl_setup(&(server.ssl), &(server.conf)) == 0);
+        TEST_EQUAL(mbedtls_ssl_setup(&(server.ssl), &(server.conf)), 0);
 
         mbedtls_ssl_set_bio(&(server.ssl), &server_context,
                             mbedtls_test_mock_tcp_send_msg,
@@ -2344,30 +2344,30 @@ void mbedtls_test_ssl_perform_handshake(
 #if defined(MBEDTLS_SSL_VARIABLE_BUFFER_LENGTH)
         if (options->resize_buffers != 0) {
             /* Ensure that the buffer sizes are appropriate before resizes */
-            TEST_ASSERT(server.ssl.out_buf_len == MBEDTLS_SSL_OUT_BUFFER_LEN);
-            TEST_ASSERT(server.ssl.in_buf_len == MBEDTLS_SSL_IN_BUFFER_LEN);
+            TEST_EQUAL(server.ssl.out_buf_len, MBEDTLS_SSL_OUT_BUFFER_LEN);
+            TEST_EQUAL(server.ssl.in_buf_len, MBEDTLS_SSL_IN_BUFFER_LEN);
         }
 #endif
-        TEST_ASSERT(mbedtls_ssl_context_load(&(server.ssl), context_buf,
-                                             context_buf_len) == 0);
+        TEST_EQUAL(mbedtls_ssl_context_load(&(server.ssl), context_buf,
+                                            context_buf_len), 0);
 
 #if defined(MBEDTLS_SSL_VARIABLE_BUFFER_LENGTH)
         /* Validate buffer sizes after context deserialization */
         if (options->resize_buffers != 0) {
-            TEST_ASSERT(server.ssl.out_buf_len ==
-                        mbedtls_ssl_get_output_buflen(&server.ssl));
-            TEST_ASSERT(server.ssl.in_buf_len ==
-                        mbedtls_ssl_get_input_buflen(&server.ssl));
+            TEST_EQUAL(server.ssl.out_buf_len,
+                       mbedtls_ssl_get_output_buflen(&server.ssl));
+            TEST_EQUAL(server.ssl.in_buf_len,
+                       mbedtls_ssl_get_input_buflen(&server.ssl));
         }
 #endif
         /* Retest writing/reading */
         if (options->cli_msg_len != 0 || options->srv_msg_len != 0) {
-            TEST_ASSERT(mbedtls_test_ssl_exchange_data(
-                            &(client.ssl), options->cli_msg_len,
-                            options->expected_cli_fragments,
-                            &(server.ssl), options->srv_msg_len,
-                            options->expected_srv_fragments)
-                        == 0);
+            TEST_EQUAL(mbedtls_test_ssl_exchange_data(
+                           &(client.ssl), options->cli_msg_len,
+                           options->expected_cli_fragments,
+                           &(server.ssl), options->srv_msg_len,
+                           options->expected_srv_fragments),
+                       0);
         }
     }
 #endif /* MBEDTLS_SSL_CONTEXT_SERIALIZATION */
@@ -2375,24 +2375,24 @@ void mbedtls_test_ssl_perform_handshake(
 #if defined(MBEDTLS_SSL_RENEGOTIATION)
     if (options->renegotiate) {
         /* Start test with renegotiation */
-        TEST_ASSERT(server.ssl.renego_status ==
-                    MBEDTLS_SSL_INITIAL_HANDSHAKE);
-        TEST_ASSERT(client.ssl.renego_status ==
-                    MBEDTLS_SSL_INITIAL_HANDSHAKE);
+        TEST_EQUAL(server.ssl.renego_status,
+                   MBEDTLS_SSL_INITIAL_HANDSHAKE);
+        TEST_EQUAL(client.ssl.renego_status,
+                   MBEDTLS_SSL_INITIAL_HANDSHAKE);
 
         /* After calling this function for the server, it only sends a handshake
          * request. All renegotiation should happen during data exchanging */
-        TEST_ASSERT(mbedtls_ssl_renegotiate(&(server.ssl)) == 0);
-        TEST_ASSERT(server.ssl.renego_status ==
-                    MBEDTLS_SSL_RENEGOTIATION_PENDING);
-        TEST_ASSERT(client.ssl.renego_status ==
-                    MBEDTLS_SSL_INITIAL_HANDSHAKE);
+        TEST_EQUAL(mbedtls_ssl_renegotiate(&(server.ssl)), 0);
+        TEST_EQUAL(server.ssl.renego_status,
+                   MBEDTLS_SSL_RENEGOTIATION_PENDING);
+        TEST_EQUAL(client.ssl.renego_status,
+                   MBEDTLS_SSL_INITIAL_HANDSHAKE);
 
-        TEST_ASSERT(exchange_data(&(client.ssl), &(server.ssl)) == 0);
-        TEST_ASSERT(server.ssl.renego_status ==
-                    MBEDTLS_SSL_RENEGOTIATION_DONE);
-        TEST_ASSERT(client.ssl.renego_status ==
-                    MBEDTLS_SSL_RENEGOTIATION_DONE);
+        TEST_EQUAL(exchange_data(&(client.ssl), &(server.ssl)), 0);
+        TEST_EQUAL(server.ssl.renego_status,
+                   MBEDTLS_SSL_RENEGOTIATION_DONE);
+        TEST_EQUAL(client.ssl.renego_status,
+                   MBEDTLS_SSL_RENEGOTIATION_DONE);
 
         /* After calling mbedtls_ssl_renegotiate for the client,
          * all renegotiation should happen inside this function.
@@ -2404,34 +2404,34 @@ void mbedtls_test_ssl_perform_handshake(
 #if defined(MBEDTLS_SSL_VARIABLE_BUFFER_LENGTH)
         if (options->resize_buffers != 0) {
             /* Ensure that the buffer sizes are appropriate before resizes */
-            TEST_ASSERT(client.ssl.out_buf_len == MBEDTLS_SSL_OUT_BUFFER_LEN);
-            TEST_ASSERT(client.ssl.in_buf_len == MBEDTLS_SSL_IN_BUFFER_LEN);
+            TEST_EQUAL(client.ssl.out_buf_len, MBEDTLS_SSL_OUT_BUFFER_LEN);
+            TEST_EQUAL(client.ssl.in_buf_len, MBEDTLS_SSL_IN_BUFFER_LEN);
         }
 #endif
         TEST_ASSERT(ret == 0 ||
                     ret == MBEDTLS_ERR_SSL_WANT_READ ||
                     ret == MBEDTLS_ERR_SSL_WANT_WRITE);
-        TEST_ASSERT(server.ssl.renego_status ==
-                    MBEDTLS_SSL_RENEGOTIATION_DONE);
-        TEST_ASSERT(client.ssl.renego_status ==
-                    MBEDTLS_SSL_RENEGOTIATION_IN_PROGRESS);
+        TEST_EQUAL(server.ssl.renego_status,
+                   MBEDTLS_SSL_RENEGOTIATION_DONE);
+        TEST_EQUAL(client.ssl.renego_status,
+                   MBEDTLS_SSL_RENEGOTIATION_IN_PROGRESS);
 
-        TEST_ASSERT(exchange_data(&(client.ssl), &(server.ssl)) == 0);
-        TEST_ASSERT(server.ssl.renego_status ==
-                    MBEDTLS_SSL_RENEGOTIATION_DONE);
-        TEST_ASSERT(client.ssl.renego_status ==
-                    MBEDTLS_SSL_RENEGOTIATION_DONE);
+        TEST_EQUAL(exchange_data(&(client.ssl), &(server.ssl)), 0);
+        TEST_EQUAL(server.ssl.renego_status,
+                   MBEDTLS_SSL_RENEGOTIATION_DONE);
+        TEST_EQUAL(client.ssl.renego_status,
+                   MBEDTLS_SSL_RENEGOTIATION_DONE);
 #if defined(MBEDTLS_SSL_VARIABLE_BUFFER_LENGTH)
         /* Validate buffer sizes after renegotiation */
         if (options->resize_buffers != 0) {
-            TEST_ASSERT(client.ssl.out_buf_len ==
-                        mbedtls_ssl_get_output_buflen(&client.ssl));
-            TEST_ASSERT(client.ssl.in_buf_len ==
-                        mbedtls_ssl_get_input_buflen(&client.ssl));
-            TEST_ASSERT(server.ssl.out_buf_len ==
-                        mbedtls_ssl_get_output_buflen(&server.ssl));
-            TEST_ASSERT(server.ssl.in_buf_len ==
-                        mbedtls_ssl_get_input_buflen(&server.ssl));
+            TEST_EQUAL(client.ssl.out_buf_len,
+                       mbedtls_ssl_get_output_buflen(&client.ssl));
+            TEST_EQUAL(client.ssl.in_buf_len,
+                       mbedtls_ssl_get_input_buflen(&client.ssl));
+            TEST_EQUAL(server.ssl.out_buf_len,
+                       mbedtls_ssl_get_output_buflen(&server.ssl));
+            TEST_EQUAL(server.ssl.in_buf_len,
+                       mbedtls_ssl_get_input_buflen(&server.ssl));
         }
 #endif /* MBEDTLS_SSL_VARIABLE_BUFFER_LENGTH */
     }

--- a/tests/src/test_helpers/ssl_helpers.c
+++ b/tests/src/test_helpers/ssl_helpers.c
@@ -736,15 +736,8 @@ exit:
 
 int mbedtls_test_ssl_endpoint_init(
     mbedtls_test_ssl_endpoint *ep, int endpoint_type,
-    const mbedtls_test_handshake_test_options *options,
-    mbedtls_test_message_socket_context *dtls_context,
-    mbedtls_test_ssl_message_queue *input_queue,
-    mbedtls_test_ssl_message_queue *output_queue)
+    const mbedtls_test_handshake_test_options *options)
 {
-    (void) dtls_context; // no longer used
-    (void) input_queue; // no longer used
-    (void) output_queue; // no longer used
-
     int ret = -1;
     uintptr_t user_data_n;
 
@@ -904,11 +897,8 @@ exit:
 }
 
 void mbedtls_test_ssl_endpoint_free(
-    mbedtls_test_ssl_endpoint *ep,
-    mbedtls_test_message_socket_context *context)
+    mbedtls_test_ssl_endpoint *ep)
 {
-    (void) context; // no longer used
-
     mbedtls_ssl_free(&(ep->ssl));
     mbedtls_ssl_config_free(&(ep->conf));
 
@@ -2082,13 +2072,11 @@ int mbedtls_test_ssl_do_handshake_with_endpoints(
     options->server_max_version = proto;
     options->client_max_version = proto;
 
-    ret = mbedtls_test_ssl_endpoint_init(client_ep, MBEDTLS_SSL_IS_CLIENT, options,
-                                         NULL, NULL, NULL);
+    ret = mbedtls_test_ssl_endpoint_init(client_ep, MBEDTLS_SSL_IS_CLIENT, options);
     if (ret != 0) {
         return ret;
     }
-    ret = mbedtls_test_ssl_endpoint_init(server_ep, MBEDTLS_SSL_IS_SERVER, options,
-                                         NULL, NULL, NULL);
+    ret = mbedtls_test_ssl_endpoint_init(server_ep, MBEDTLS_SSL_IS_SERVER, options);
     if (ret != 0) {
         return ret;
     }
@@ -2151,13 +2139,11 @@ void mbedtls_test_ssl_perform_handshake(
     if (options->dtls != 0) {
         TEST_EQUAL(mbedtls_test_ssl_endpoint_init(&client,
                                                   MBEDTLS_SSL_IS_CLIENT,
-                                                  options, NULL, NULL,
-                                                  NULL), 0);
+                                                  options), 0);
     } else {
         TEST_EQUAL(mbedtls_test_ssl_endpoint_init(&client,
                                                   MBEDTLS_SSL_IS_CLIENT,
-                                                  options, NULL, NULL,
-                                                  NULL), 0);
+                                                  options), 0);
     }
 
     TEST_ASSERT(set_ciphersuite(&client, options->cipher));
@@ -2166,13 +2152,11 @@ void mbedtls_test_ssl_perform_handshake(
     if (options->dtls != 0) {
         TEST_EQUAL(mbedtls_test_ssl_endpoint_init(&server,
                                                   MBEDTLS_SSL_IS_SERVER,
-                                                  options, NULL, NULL,
-                                                  NULL), 0);
+                                                  options), 0);
     } else {
         TEST_EQUAL(mbedtls_test_ssl_endpoint_init(&server,
                                                   MBEDTLS_SSL_IS_SERVER,
-                                                  options, NULL, NULL,
-                                                  NULL), 0);
+                                                  options), 0);
     }
 
     mbedtls_ssl_conf_authmode(&server.conf, options->srv_auth_mode);
@@ -2440,8 +2424,8 @@ void mbedtls_test_ssl_perform_handshake(
     TEST_ASSERT(mbedtls_ssl_get_user_data_p(&server.ssl) == &server);
 
 exit:
-    mbedtls_test_ssl_endpoint_free(&client, NULL);
-    mbedtls_test_ssl_endpoint_free(&server, NULL);
+    mbedtls_test_ssl_endpoint_free(&client);
+    mbedtls_test_ssl_endpoint_free(&server);
 #if defined(MBEDTLS_DEBUG_C)
     if (options->cli_log_fun || options->srv_log_fun) {
         mbedtls_debug_set_threshold(0);
@@ -2615,11 +2599,11 @@ int mbedtls_test_get_tls13_ticket(
     mbedtls_platform_zeroize(&server_ep, sizeof(server_ep));
 
     ret = mbedtls_test_ssl_endpoint_init(&client_ep, MBEDTLS_SSL_IS_CLIENT,
-                                         client_options, NULL, NULL, NULL);
+                                         client_options);
     TEST_EQUAL(ret, 0);
 
     ret = mbedtls_test_ssl_endpoint_init(&server_ep, MBEDTLS_SSL_IS_SERVER,
-                                         server_options, NULL, NULL, NULL);
+                                         server_options);
     TEST_EQUAL(ret, 0);
 
     mbedtls_ssl_conf_session_tickets_cb(&server_ep.conf,
@@ -2647,8 +2631,8 @@ int mbedtls_test_get_tls13_ticket(
     ok = 1;
 
 exit:
-    mbedtls_test_ssl_endpoint_free(&client_ep, NULL);
-    mbedtls_test_ssl_endpoint_free(&server_ep, NULL);
+    mbedtls_test_ssl_endpoint_free(&client_ep);
+    mbedtls_test_ssl_endpoint_free(&server_ep);
 
     if (ret == 0 && !ok) {
         /* Exiting due to a test assertion that isn't ret == 0 */

--- a/tests/src/test_helpers/ssl_helpers.c
+++ b/tests/src/test_helpers/ssl_helpers.c
@@ -805,7 +805,6 @@ int mbedtls_test_ssl_endpoint_init(
     const mbedtls_test_handshake_test_options *options)
 {
     int ret = -1;
-    uintptr_t user_data_n;
 #if defined(MBEDTLS_SSL_HANDSHAKE_WITH_PSK_ENABLED)
     const char *psk_identity = "foo";
 #endif
@@ -828,10 +827,10 @@ int mbedtls_test_ssl_endpoint_init(
     TEST_EQUAL(mbedtls_ssl_get_user_data_n(&ep->ssl), 0);
 
     (void) mbedtls_test_rnd_std_rand(NULL,
-                                     (void *) &user_data_n,
-                                     sizeof(user_data_n));
-    mbedtls_ssl_conf_set_user_data_n(&ep->conf, user_data_n);
-    mbedtls_ssl_set_user_data_n(&ep->ssl, user_data_n);
+                                     (void *) &ep->user_data_cookie,
+                                     sizeof(ep->user_data_cookie));
+    mbedtls_ssl_conf_set_user_data_n(&ep->conf, ep->user_data_cookie);
+    mbedtls_ssl_set_user_data_n(&ep->ssl, ep->user_data_cookie);
 
     mbedtls_test_mock_socket_init(&(ep->socket));
 
@@ -965,7 +964,8 @@ int mbedtls_test_ssl_endpoint_init(
     }
 #endif
 
-    TEST_EQUAL(mbedtls_ssl_conf_get_user_data_n(&ep->conf), user_data_n);
+    TEST_EQUAL(mbedtls_ssl_conf_get_user_data_n(&ep->conf),
+               ep->user_data_cookie);
     mbedtls_ssl_conf_set_user_data_p(&ep->conf, ep);
 
     /* We've finished the configuration. Now set up a context. */
@@ -996,7 +996,7 @@ int mbedtls_test_ssl_endpoint_init(
                             NULL);
     }
 
-    TEST_EQUAL(mbedtls_ssl_get_user_data_n(&ep->ssl), user_data_n);
+    TEST_EQUAL(mbedtls_ssl_get_user_data_n(&ep->ssl), ep->user_data_cookie);
     mbedtls_ssl_set_user_data_p(&ep->ssl, ep);
 
     return 0;

--- a/tests/src/test_helpers/ssl_helpers.c
+++ b/tests/src/test_helpers/ssl_helpers.c
@@ -653,6 +653,68 @@ static void test_ssl_endpoint_certificate_free(mbedtls_test_ssl_endpoint *ep)
     }
 }
 
+static int load_endpoint_rsa(mbedtls_test_ssl_endpoint *ep)
+{
+    int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
+    if (ep->conf.endpoint == MBEDTLS_SSL_IS_SERVER) {
+        ret = mbedtls_x509_crt_parse(
+            ep->cert,
+            (const unsigned char *) mbedtls_test_srv_crt_rsa_sha256_der,
+            mbedtls_test_srv_crt_rsa_sha256_der_len);
+        TEST_EQUAL(ret, 0);
+        ret = mbedtls_pk_parse_key(
+            ep->pkey,
+            (const unsigned char *) mbedtls_test_srv_key_rsa_der,
+            mbedtls_test_srv_key_rsa_der_len, NULL, 0);
+        TEST_EQUAL(ret, 0);
+    } else {
+        ret = mbedtls_x509_crt_parse(
+            ep->cert,
+            (const unsigned char *) mbedtls_test_cli_crt_rsa_der,
+            mbedtls_test_cli_crt_rsa_der_len);
+        TEST_EQUAL(ret, 0);
+        ret = mbedtls_pk_parse_key(
+            ep->pkey,
+            (const unsigned char *) mbedtls_test_cli_key_rsa_der,
+            mbedtls_test_cli_key_rsa_der_len, NULL, 0);
+        TEST_EQUAL(ret, 0);
+    }
+
+exit:
+    return ret;
+}
+
+static int load_endpoint_ecc(mbedtls_test_ssl_endpoint *ep)
+{
+    int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
+    if (ep->conf.endpoint == MBEDTLS_SSL_IS_SERVER) {
+        ret = mbedtls_x509_crt_parse(
+            ep->cert,
+            (const unsigned char *) mbedtls_test_srv_crt_ec_der,
+            mbedtls_test_srv_crt_ec_der_len);
+        TEST_EQUAL(ret, 0);
+        ret = mbedtls_pk_parse_key(
+            ep->pkey,
+            (const unsigned char *) mbedtls_test_srv_key_ec_der,
+            mbedtls_test_srv_key_ec_der_len, NULL, 0);
+        TEST_EQUAL(ret, 0);
+    } else {
+        ret = mbedtls_x509_crt_parse(
+            ep->cert,
+            (const unsigned char *) mbedtls_test_cli_crt_ec_der,
+            mbedtls_test_cli_crt_ec_len);
+        TEST_EQUAL(ret, 0);
+        ret = mbedtls_pk_parse_key(
+            ep->pkey,
+            (const unsigned char *) mbedtls_test_cli_key_ec_der,
+            mbedtls_test_cli_key_ec_der_len, NULL, 0);
+        TEST_EQUAL(ret, 0);
+    }
+
+exit:
+    return ret;
+}
+
 int mbedtls_test_ssl_endpoint_certificate_init(mbedtls_test_ssl_endpoint *ep,
                                                int pk_alg,
                                                int opaque_alg, int opaque_alg2,
@@ -689,58 +751,10 @@ int mbedtls_test_ssl_endpoint_certificate_init(mbedtls_test_ssl_endpoint *ep,
 
     /* Load own certificate and private key */
 
-    if (ep->conf.endpoint == MBEDTLS_SSL_IS_SERVER) {
-        if (pk_alg == MBEDTLS_PK_RSA) {
-            ret = mbedtls_x509_crt_parse(
-                ep->cert,
-                (const unsigned char *) mbedtls_test_srv_crt_rsa_sha256_der,
-                mbedtls_test_srv_crt_rsa_sha256_der_len);
-            TEST_EQUAL(ret, 0);
-
-            ret = mbedtls_pk_parse_key(
-                ep->pkey,
-                (const unsigned char *) mbedtls_test_srv_key_rsa_der,
-                mbedtls_test_srv_key_rsa_der_len, NULL, 0);
-            TEST_EQUAL(ret, 0);
-        } else {
-            ret = mbedtls_x509_crt_parse(
-                ep->cert,
-                (const unsigned char *) mbedtls_test_srv_crt_ec_der,
-                mbedtls_test_srv_crt_ec_der_len);
-            TEST_EQUAL(ret, 0);
-
-            ret = mbedtls_pk_parse_key(
-                ep->pkey,
-                (const unsigned char *) mbedtls_test_srv_key_ec_der,
-                mbedtls_test_srv_key_ec_der_len, NULL, 0);
-            TEST_EQUAL(ret, 0);
-        }
+    if (pk_alg == MBEDTLS_PK_RSA) {
+        TEST_EQUAL(load_endpoint_rsa(ep), 0);
     } else {
-        if (pk_alg == MBEDTLS_PK_RSA) {
-            ret = mbedtls_x509_crt_parse(
-                ep->cert,
-                (const unsigned char *) mbedtls_test_cli_crt_rsa_der,
-                mbedtls_test_cli_crt_rsa_der_len);
-            TEST_EQUAL(ret, 0);
-
-            ret = mbedtls_pk_parse_key(
-                ep->pkey,
-                (const unsigned char *) mbedtls_test_cli_key_rsa_der,
-                mbedtls_test_cli_key_rsa_der_len, NULL, 0);
-            TEST_EQUAL(ret, 0);
-        } else {
-            ret = mbedtls_x509_crt_parse(
-                ep->cert,
-                (const unsigned char *) mbedtls_test_cli_crt_ec_der,
-                mbedtls_test_cli_crt_ec_len);
-            TEST_EQUAL(ret, 0);
-
-            ret = mbedtls_pk_parse_key(
-                ep->pkey,
-                (const unsigned char *) mbedtls_test_cli_key_ec_der,
-                mbedtls_test_cli_key_ec_der_len, NULL, 0);
-            TEST_EQUAL(ret, 0);
-        }
+        TEST_EQUAL(load_endpoint_ecc(ep), 0);
     }
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)

--- a/tests/src/test_helpers/ssl_helpers.c
+++ b/tests/src/test_helpers/ssl_helpers.c
@@ -736,7 +736,7 @@ exit:
 
 int mbedtls_test_ssl_endpoint_init(
     mbedtls_test_ssl_endpoint *ep, int endpoint_type,
-    mbedtls_test_handshake_test_options *options,
+    const mbedtls_test_handshake_test_options *options,
     mbedtls_test_message_socket_context *dtls_context,
     mbedtls_test_ssl_message_queue *input_queue,
     mbedtls_test_ssl_message_queue *output_queue)
@@ -2105,7 +2105,7 @@ int mbedtls_test_ssl_do_handshake_with_endpoints(
 
 #if defined(MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED)
 void mbedtls_test_ssl_perform_handshake(
-    mbedtls_test_handshake_test_options *options)
+    const mbedtls_test_handshake_test_options *options)
 {
     enum { BUFFSIZE = 17000 };
     mbedtls_test_ssl_endpoint client, server;

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -3043,6 +3043,7 @@ void handshake_ciphersuite_select(char *cipher, int pk_alg, data_t *psk_str,
     options.opaque_alg = psa_alg;
     options.opaque_alg2 = psa_alg2;
     options.opaque_usage = psa_usage;
+    options.srv_auth_mode = MBEDTLS_SSL_VERIFY_NONE;
     options.expected_handshake_result = expected_handshake_result;
     options.expected_ciphersuite = expected_ciphersuite;
 

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -2879,20 +2879,18 @@ void mbedtls_endpoint_sanity(int endpoint_type)
 
     MD_OR_USE_PSA_INIT();
 
-    ret = mbedtls_test_ssl_endpoint_init(NULL, endpoint_type, &options,
-                                         NULL, NULL, NULL);
+    ret = mbedtls_test_ssl_endpoint_init(NULL, endpoint_type, &options);
     TEST_EQUAL(MBEDTLS_ERR_SSL_BAD_INPUT_DATA,  ret);
 
     ret = mbedtls_test_ssl_endpoint_certificate_init(NULL, options.pk_alg,
                                                      0, 0, 0);
     TEST_EQUAL(MBEDTLS_ERR_SSL_BAD_INPUT_DATA,  ret);
 
-    ret = mbedtls_test_ssl_endpoint_init(&ep, endpoint_type, &options,
-                                         NULL, NULL, NULL);
+    ret = mbedtls_test_ssl_endpoint_init(&ep, endpoint_type, &options);
     TEST_EQUAL(ret,  0);
 
 exit:
-    mbedtls_test_ssl_endpoint_free(&ep, NULL);
+    mbedtls_test_ssl_endpoint_free(&ep);
     mbedtls_test_free_handshake_options(&options);
     MD_OR_USE_PSA_DONE();
 }
@@ -2931,15 +2929,14 @@ void move_handshake_to_state(int endpoint_type, int tls_version, int state, int 
     mbedtls_platform_zeroize(&base_ep, sizeof(base_ep));
     mbedtls_platform_zeroize(&second_ep, sizeof(second_ep));
 
-    ret = mbedtls_test_ssl_endpoint_init(&base_ep, endpoint_type, &options,
-                                         NULL, NULL, NULL);
+    ret = mbedtls_test_ssl_endpoint_init(&base_ep, endpoint_type, &options);
     TEST_EQUAL(ret,  0);
 
     ret = mbedtls_test_ssl_endpoint_init(
         &second_ep,
         (endpoint_type == MBEDTLS_SSL_IS_SERVER) ?
         MBEDTLS_SSL_IS_CLIENT : MBEDTLS_SSL_IS_SERVER,
-        &options, NULL, NULL, NULL);
+        &options);
 
     TEST_EQUAL(ret,  0);
 
@@ -2965,8 +2962,8 @@ void move_handshake_to_state(int endpoint_type, int tls_version, int state, int 
 
 exit:
     mbedtls_test_free_handshake_options(&options);
-    mbedtls_test_ssl_endpoint_free(&base_ep, NULL);
-    mbedtls_test_ssl_endpoint_free(&second_ep, NULL);
+    mbedtls_test_ssl_endpoint_free(&base_ep);
+    mbedtls_test_ssl_endpoint_free(&second_ep);
     MD_OR_USE_PSA_DONE();
 }
 /* END_CASE */
@@ -3225,8 +3222,7 @@ void recombine_server_first_flight(int version,
     client_options.cli_log_fun = mbedtls_test_ssl_log_analyzer;
 #endif
     TEST_EQUAL(mbedtls_test_ssl_endpoint_init(&client, MBEDTLS_SSL_IS_CLIENT,
-                                              &client_options, NULL, NULL,
-                                              NULL), 0);
+                                              &client_options), 0);
 
     server_options.server_min_version = version;
     server_options.server_max_version = version;
@@ -3235,8 +3231,7 @@ void recombine_server_first_flight(int version,
     server_options.srv_log_fun = mbedtls_test_ssl_log_analyzer;
 #endif
     TEST_EQUAL(mbedtls_test_ssl_endpoint_init(&server, MBEDTLS_SSL_IS_SERVER,
-                                              &server_options, NULL, NULL,
-                                              NULL), 0);
+                                              &server_options), 0);
 
     TEST_EQUAL(mbedtls_test_mock_socket_connect(&client.socket,
                                                 &server.socket,
@@ -3321,8 +3316,8 @@ goal_reached:
 #endif
 
 exit:
-    mbedtls_test_ssl_endpoint_free(&client, NULL);
-    mbedtls_test_ssl_endpoint_free(&server, NULL);
+    mbedtls_test_ssl_endpoint_free(&client);
+    mbedtls_test_ssl_endpoint_free(&server);
     mbedtls_test_free_handshake_options(&client_options);
     mbedtls_test_free_handshake_options(&server_options);
     MD_OR_USE_PSA_DONE();
@@ -3598,11 +3593,10 @@ void force_bad_session_id_len()
     MD_OR_USE_PSA_INIT();
 
     TEST_EQUAL(mbedtls_test_ssl_endpoint_init(&client, MBEDTLS_SSL_IS_CLIENT,
-                                              &options, NULL, NULL,
-                                              NULL), 0);
+                                              &options), 0);
 
     TEST_EQUAL(mbedtls_test_ssl_endpoint_init(&server, MBEDTLS_SSL_IS_SERVER,
-                                              &options, NULL, NULL, NULL), 0);
+                                              &options), 0);
 
     mbedtls_debug_set_threshold(1);
     mbedtls_ssl_conf_dbg(&server.conf, options.srv_log_fun,
@@ -3631,8 +3625,8 @@ void force_bad_session_id_len()
     /* Make sure that the cache did not store the session */
     TEST_EQUAL(srv_pattern.counter, 1);
 exit:
-    mbedtls_test_ssl_endpoint_free(&client, NULL);
-    mbedtls_test_ssl_endpoint_free(&server, NULL);
+    mbedtls_test_ssl_endpoint_free(&client);
+    mbedtls_test_ssl_endpoint_free(&server);
     mbedtls_test_free_handshake_options(&options);
     mbedtls_debug_set_threshold(0);
     MD_OR_USE_PSA_DONE();
@@ -3793,16 +3787,14 @@ void raw_key_agreement_fail(int bad_server_ecdhe_key)
     client_options.pk_alg = MBEDTLS_PK_ECDSA;
     client_options.group_list = iana_tls_group_list;
     TEST_EQUAL(mbedtls_test_ssl_endpoint_init(&client, MBEDTLS_SSL_IS_CLIENT,
-                                              &client_options, NULL, NULL,
-                                              NULL), 0);
+                                              &client_options), 0);
 
     /* Server side */
     server_options.pk_alg = MBEDTLS_PK_ECDSA;
     server_options.server_min_version = MBEDTLS_SSL_VERSION_TLS1_2;
     server_options.server_max_version = MBEDTLS_SSL_VERSION_TLS1_2;
     TEST_EQUAL(mbedtls_test_ssl_endpoint_init(&server, MBEDTLS_SSL_IS_SERVER,
-                                              &server_options, NULL, NULL,
-                                              NULL), 0);
+                                              &server_options), 0);
 
     TEST_EQUAL(mbedtls_test_mock_socket_connect(&(client.socket),
                                                 &(server.socket),
@@ -3836,8 +3828,8 @@ void raw_key_agreement_fail(int bad_server_ecdhe_key)
     }
 
 exit:
-    mbedtls_test_ssl_endpoint_free(&client, NULL);
-    mbedtls_test_ssl_endpoint_free(&server, NULL);
+    mbedtls_test_ssl_endpoint_free(&client);
+    mbedtls_test_ssl_endpoint_free(&server);
     mbedtls_test_free_handshake_options(&client_options);
     mbedtls_test_free_handshake_options(&server_options);
 
@@ -3868,13 +3860,13 @@ void tls13_server_certificate_msg_invalid_vector_len()
 
     client_options.pk_alg = MBEDTLS_PK_ECDSA;
     ret = mbedtls_test_ssl_endpoint_init(&client_ep, MBEDTLS_SSL_IS_CLIENT,
-                                         &client_options, NULL, NULL, NULL);
+                                         &client_options);
     TEST_EQUAL(ret, 0);
 
     mbedtls_test_init_handshake_options(&server_options);
     server_options.pk_alg = MBEDTLS_PK_ECDSA;
     ret = mbedtls_test_ssl_endpoint_init(&server_ep, MBEDTLS_SSL_IS_SERVER,
-                                         &server_options, NULL, NULL, NULL);
+                                         &server_options);
     TEST_EQUAL(ret, 0);
 
     ret = mbedtls_test_mock_socket_connect(&(client_ep.socket),
@@ -3932,8 +3924,8 @@ void tls13_server_certificate_msg_invalid_vector_len()
 
 exit:
     mbedtls_ssl_reset_chk_buf_ptr_fail_args();
-    mbedtls_test_ssl_endpoint_free(&client_ep, NULL);
-    mbedtls_test_ssl_endpoint_free(&server_ep, NULL);
+    mbedtls_test_ssl_endpoint_free(&client_ep);
+    mbedtls_test_ssl_endpoint_free(&server_ep);
     mbedtls_test_free_handshake_options(&client_options);
     mbedtls_test_free_handshake_options(&server_options);
     MD_OR_USE_PSA_DONE();
@@ -4124,11 +4116,11 @@ void tls13_resume_session_with_ticket()
      * Prepare for handshake with the ticket.
      */
     ret = mbedtls_test_ssl_endpoint_init(&client_ep, MBEDTLS_SSL_IS_CLIENT,
-                                         &client_options, NULL, NULL, NULL);
+                                         &client_options);
     TEST_EQUAL(ret, 0);
 
     ret = mbedtls_test_ssl_endpoint_init(&server_ep, MBEDTLS_SSL_IS_SERVER,
-                                         &server_options, NULL, NULL, NULL);
+                                         &server_options);
     TEST_EQUAL(ret, 0);
 
     mbedtls_ssl_conf_session_tickets_cb(&server_ep.conf,
@@ -4161,8 +4153,8 @@ void tls13_resume_session_with_ticket()
                MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL);
 
 exit:
-    mbedtls_test_ssl_endpoint_free(&client_ep, NULL);
-    mbedtls_test_ssl_endpoint_free(&server_ep, NULL);
+    mbedtls_test_ssl_endpoint_free(&client_ep);
+    mbedtls_test_ssl_endpoint_free(&server_ep);
     mbedtls_test_free_handshake_options(&client_options);
     mbedtls_test_free_handshake_options(&server_options);
     mbedtls_ssl_session_free(&saved_session);
@@ -4286,13 +4278,13 @@ void tls13_read_early_data(int scenario)
     }
 
     ret = mbedtls_test_ssl_endpoint_init(&client_ep, MBEDTLS_SSL_IS_CLIENT,
-                                         &client_options, NULL, NULL, NULL);
+                                         &client_options);
     TEST_EQUAL(ret, 0);
 
     server_options.srv_log_fun = mbedtls_test_ssl_log_analyzer;
     server_options.srv_log_obj = &server_pattern;
     ret = mbedtls_test_ssl_endpoint_init(&server_ep, MBEDTLS_SSL_IS_SERVER,
-                                         &server_options, NULL, NULL, NULL);
+                                         &server_options);
     TEST_EQUAL(ret, 0);
 
     mbedtls_ssl_conf_session_tickets_cb(&server_ep.conf,
@@ -4367,8 +4359,8 @@ void tls13_read_early_data(int scenario)
                    MBEDTLS_SSL_HANDSHAKE_OVER), 0);
 
 exit:
-    mbedtls_test_ssl_endpoint_free(&client_ep, NULL);
-    mbedtls_test_ssl_endpoint_free(&server_ep, NULL);
+    mbedtls_test_ssl_endpoint_free(&client_ep);
+    mbedtls_test_ssl_endpoint_free(&server_ep);
     mbedtls_test_free_handshake_options(&client_options);
     mbedtls_test_free_handshake_options(&server_options);
     mbedtls_ssl_session_free(&saved_session);
@@ -4440,11 +4432,11 @@ void tls13_cli_early_data_state(int scenario)
     }
 
     ret = mbedtls_test_ssl_endpoint_init(&client_ep, MBEDTLS_SSL_IS_CLIENT,
-                                         &client_options, NULL, NULL, NULL);
+                                         &client_options);
     TEST_EQUAL(ret, 0);
 
     ret = mbedtls_test_ssl_endpoint_init(&server_ep, MBEDTLS_SSL_IS_SERVER,
-                                         &server_options, NULL, NULL, NULL);
+                                         &server_options);
     TEST_EQUAL(ret, 0);
 
     mbedtls_ssl_conf_session_tickets_cb(&server_ep.conf,
@@ -4741,8 +4733,8 @@ void tls13_cli_early_data_state(int scenario)
 #endif
 
 exit:
-    mbedtls_test_ssl_endpoint_free(&client_ep, NULL);
-    mbedtls_test_ssl_endpoint_free(&server_ep, NULL);
+    mbedtls_test_ssl_endpoint_free(&client_ep);
+    mbedtls_test_ssl_endpoint_free(&server_ep);
     mbedtls_test_free_handshake_options(&client_options);
     mbedtls_test_free_handshake_options(&server_options);
     mbedtls_ssl_session_free(&saved_session);
@@ -4817,11 +4809,11 @@ void tls13_write_early_data(int scenario)
     }
 
     ret = mbedtls_test_ssl_endpoint_init(&client_ep, MBEDTLS_SSL_IS_CLIENT,
-                                         &client_options, NULL, NULL, NULL);
+                                         &client_options);
     TEST_EQUAL(ret, 0);
 
     ret = mbedtls_test_ssl_endpoint_init(&server_ep, MBEDTLS_SSL_IS_SERVER,
-                                         &server_options, NULL, NULL, NULL);
+                                         &server_options);
     TEST_EQUAL(ret, 0);
 
     mbedtls_ssl_conf_session_tickets_cb(&server_ep.conf,
@@ -5090,8 +5082,8 @@ complete_handshake:
     } while (1);
 
 exit:
-    mbedtls_test_ssl_endpoint_free(&client_ep, NULL);
-    mbedtls_test_ssl_endpoint_free(&server_ep, NULL);
+    mbedtls_test_ssl_endpoint_free(&client_ep);
+    mbedtls_test_ssl_endpoint_free(&server_ep);
     mbedtls_test_free_handshake_options(&client_options);
     mbedtls_test_free_handshake_options(&server_options);
     mbedtls_ssl_session_free(&saved_session);
@@ -5140,11 +5132,11 @@ void tls13_cli_max_early_data_size(int max_early_data_size_arg)
      * Prepare for handshake with the ticket.
      */
     ret = mbedtls_test_ssl_endpoint_init(&client_ep, MBEDTLS_SSL_IS_CLIENT,
-                                         &client_options, NULL, NULL, NULL);
+                                         &client_options);
     TEST_EQUAL(ret, 0);
 
     ret = mbedtls_test_ssl_endpoint_init(&server_ep, MBEDTLS_SSL_IS_SERVER,
-                                         &server_options, NULL, NULL, NULL);
+                                         &server_options);
     TEST_EQUAL(ret, 0);
 
     mbedtls_ssl_conf_session_tickets_cb(&server_ep.conf,
@@ -5237,8 +5229,8 @@ void tls13_cli_max_early_data_size(int max_early_data_size_arg)
                0);
 
 exit:
-    mbedtls_test_ssl_endpoint_free(&client_ep, NULL);
-    mbedtls_test_ssl_endpoint_free(&server_ep, NULL);
+    mbedtls_test_ssl_endpoint_free(&client_ep);
+    mbedtls_test_ssl_endpoint_free(&server_ep);
     mbedtls_test_free_handshake_options(&client_options);
     mbedtls_test_free_handshake_options(&server_options);
     mbedtls_ssl_session_free(&saved_session);
@@ -5344,11 +5336,11 @@ void tls13_srv_max_early_data_size(int scenario, int max_early_data_size_arg, in
     }
 
     ret = mbedtls_test_ssl_endpoint_init(&client_ep, MBEDTLS_SSL_IS_CLIENT,
-                                         &client_options, NULL, NULL, NULL);
+                                         &client_options);
     TEST_EQUAL(ret, 0);
 
     ret = mbedtls_test_ssl_endpoint_init(&server_ep, MBEDTLS_SSL_IS_SERVER,
-                                         &server_options, NULL, NULL, NULL);
+                                         &server_options);
     TEST_EQUAL(ret, 0);
 
     mbedtls_ssl_conf_session_tickets_cb(&server_ep.conf,
@@ -5491,8 +5483,8 @@ void tls13_srv_max_early_data_size(int scenario, int max_early_data_size_arg, in
     TEST_EQUAL(server_pattern.counter, 1);
 
 exit:
-    mbedtls_test_ssl_endpoint_free(&client_ep, NULL);
-    mbedtls_test_ssl_endpoint_free(&server_ep, NULL);
+    mbedtls_test_ssl_endpoint_free(&client_ep);
+    mbedtls_test_ssl_endpoint_free(&server_ep);
     mbedtls_test_free_handshake_options(&client_options);
     mbedtls_test_free_handshake_options(&server_options);
     mbedtls_ssl_session_free(&saved_session);
@@ -5540,11 +5532,11 @@ void inject_client_content_on_the_wire(int pk_alg,
     options.pk_alg = pk_alg;
 
     ret = mbedtls_test_ssl_endpoint_init(&server, MBEDTLS_SSL_IS_SERVER,
-                                         &options, NULL, NULL, NULL);
+                                         &options);
     TEST_EQUAL(ret, 0);
 
     ret = mbedtls_test_ssl_endpoint_init(&client, MBEDTLS_SSL_IS_CLIENT,
-                                         &options, NULL, NULL, NULL);
+                                         &options);
     TEST_EQUAL(ret, 0);
 
     ret = mbedtls_test_mock_socket_connect(&server.socket, &client.socket,
@@ -5571,8 +5563,8 @@ void inject_client_content_on_the_wire(int pk_alg,
 
 exit:
     mbedtls_test_free_handshake_options(&options);
-    mbedtls_test_ssl_endpoint_free(&server, NULL);
-    mbedtls_test_ssl_endpoint_free(&client, NULL);
+    mbedtls_test_ssl_endpoint_free(&server);
+    mbedtls_test_ssl_endpoint_free(&client);
     mbedtls_debug_set_threshold(0);
     PSA_DONE();
 }
@@ -5618,11 +5610,11 @@ void send_large_fragmented_hello(int hs_len_int, int first_frag_content_len_int,
     options.pk_alg = MBEDTLS_PK_ECDSA;
 
     ret = mbedtls_test_ssl_endpoint_init(&server, MBEDTLS_SSL_IS_SERVER,
-                                         &options, NULL, NULL, NULL);
+                                         &options);
     TEST_EQUAL(ret, 0);
 
     ret = mbedtls_test_ssl_endpoint_init(&client, MBEDTLS_SSL_IS_CLIENT,
-                                         &options, NULL, NULL, NULL);
+                                         &options);
     TEST_EQUAL(ret, 0);
 
     ret = mbedtls_test_mock_socket_connect(&server.socket, &client.socket,
@@ -5685,8 +5677,8 @@ void send_large_fragmented_hello(int hs_len_int, int first_frag_content_len_int,
 
 exit:
     mbedtls_test_free_handshake_options(&options);
-    mbedtls_test_ssl_endpoint_free(&server, NULL);
-    mbedtls_test_ssl_endpoint_free(&client, NULL);
+    mbedtls_test_ssl_endpoint_free(&server);
+    mbedtls_test_ssl_endpoint_free(&client);
     mbedtls_debug_set_threshold(0);
     mbedtls_free(first_frag);
     PSA_DONE();
@@ -5731,8 +5723,8 @@ void ssl_tls_exporter_consistent_result(int proto, int exported_key_length, int 
     TEST_EQUAL(memcmp(key_buffer_server, key_buffer_client, (size_t) exported_key_length), 0);
 
 exit:
-    mbedtls_test_ssl_endpoint_free(&server_ep, NULL);
-    mbedtls_test_ssl_endpoint_free(&client_ep, NULL);
+    mbedtls_test_ssl_endpoint_free(&server_ep);
+    mbedtls_test_ssl_endpoint_free(&client_ep);
     mbedtls_test_free_handshake_options(&options);
     mbedtls_free(key_buffer_server);
     mbedtls_free(key_buffer_client);
@@ -5772,8 +5764,8 @@ void ssl_tls_exporter_uses_label(int proto)
     TEST_ASSERT(memcmp(key_buffer_server, key_buffer_client, sizeof(key_buffer_server)) != 0);
 
 exit:
-    mbedtls_test_ssl_endpoint_free(&server_ep, NULL);
-    mbedtls_test_ssl_endpoint_free(&client_ep, NULL);
+    mbedtls_test_ssl_endpoint_free(&server_ep);
+    mbedtls_test_ssl_endpoint_free(&client_ep);
     mbedtls_test_free_handshake_options(&options);
     MD_OR_USE_PSA_DONE();
 }
@@ -5811,8 +5803,8 @@ void ssl_tls_exporter_uses_context(int proto)
     TEST_ASSERT(memcmp(key_buffer_server, key_buffer_client, sizeof(key_buffer_server)) != 0);
 
 exit:
-    mbedtls_test_ssl_endpoint_free(&server_ep, NULL);
-    mbedtls_test_ssl_endpoint_free(&client_ep, NULL);
+    mbedtls_test_ssl_endpoint_free(&server_ep);
+    mbedtls_test_ssl_endpoint_free(&client_ep);
     mbedtls_test_free_handshake_options(&options);
     MD_OR_USE_PSA_DONE();
 }
@@ -5853,8 +5845,8 @@ void ssl_tls13_exporter_uses_length(void)
     TEST_ASSERT(memcmp(key_buffer_server, key_buffer_client, sizeof(key_buffer_server)) != 0);
 
 exit:
-    mbedtls_test_ssl_endpoint_free(&server_ep, NULL);
-    mbedtls_test_ssl_endpoint_free(&client_ep, NULL);
+    mbedtls_test_ssl_endpoint_free(&server_ep);
+    mbedtls_test_ssl_endpoint_free(&client_ep);
     mbedtls_test_free_handshake_options(&options);
     MD_OR_USE_PSA_DONE();
 }
@@ -5890,8 +5882,8 @@ void ssl_tls_exporter_rejects_bad_parameters(
     TEST_EQUAL(ret, MBEDTLS_ERR_SSL_BAD_INPUT_DATA);
 
 exit:
-    mbedtls_test_ssl_endpoint_free(&server_ep, NULL);
-    mbedtls_test_ssl_endpoint_free(&client_ep, NULL);
+    mbedtls_test_ssl_endpoint_free(&server_ep);
+    mbedtls_test_ssl_endpoint_free(&client_ep);
     mbedtls_test_free_handshake_options(&options);
     mbedtls_free(key_buffer);
     mbedtls_free(label);
@@ -5917,11 +5909,9 @@ void ssl_tls_exporter_too_early(int proto, int check_server, int state)
 
     MD_OR_USE_PSA_INIT();
 
-    ret = mbedtls_test_ssl_endpoint_init(&server_ep, MBEDTLS_SSL_IS_SERVER, &options,
-                                         NULL, NULL, NULL);
+    ret = mbedtls_test_ssl_endpoint_init(&server_ep, MBEDTLS_SSL_IS_SERVER, &options);
     TEST_EQUAL(ret, 0);
-    ret = mbedtls_test_ssl_endpoint_init(&client_ep, MBEDTLS_SSL_IS_CLIENT, &options,
-                                         NULL, NULL, NULL);
+    ret = mbedtls_test_ssl_endpoint_init(&client_ep, MBEDTLS_SSL_IS_CLIENT, &options);
     TEST_EQUAL(ret, 0);
 
     ret = mbedtls_test_mock_socket_connect(&client_ep.socket, &server_ep.socket, BUFFSIZE);
@@ -5945,8 +5935,8 @@ void ssl_tls_exporter_too_early(int proto, int check_server, int state)
     TEST_EQUAL(ret, MBEDTLS_ERR_SSL_BAD_INPUT_DATA);
 
 exit:
-    mbedtls_test_ssl_endpoint_free(&server_ep, NULL);
-    mbedtls_test_ssl_endpoint_free(&client_ep, NULL);
+    mbedtls_test_ssl_endpoint_free(&server_ep);
+    mbedtls_test_ssl_endpoint_free(&client_ep);
     mbedtls_test_free_handshake_options(&options);
     MD_OR_USE_PSA_DONE();
 }

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -435,50 +435,41 @@ void test_callback_buffer_sanity()
     memset(input, 0, sizeof(input));
 
     /* Make sure calling put and get on NULL buffer results in error. */
-    TEST_ASSERT(mbedtls_test_ssl_buffer_put(NULL, input, sizeof(input))
-                == -1);
-    TEST_ASSERT(mbedtls_test_ssl_buffer_get(NULL, output, sizeof(output))
-                == -1);
-    TEST_ASSERT(mbedtls_test_ssl_buffer_put(NULL, NULL, sizeof(input))
-                == -1);
+    TEST_EQUAL(mbedtls_test_ssl_buffer_put(NULL, input, sizeof(input)), -1);
+    TEST_EQUAL(mbedtls_test_ssl_buffer_get(NULL, output, sizeof(output)), -1);
+    TEST_EQUAL(mbedtls_test_ssl_buffer_put(NULL, NULL, sizeof(input)), -1);
 
-    TEST_ASSERT(mbedtls_test_ssl_buffer_put(NULL, NULL, 0) == -1);
-    TEST_ASSERT(mbedtls_test_ssl_buffer_get(NULL, NULL, 0) == -1);
+    TEST_EQUAL(mbedtls_test_ssl_buffer_put(NULL, NULL, 0), -1);
+    TEST_EQUAL(mbedtls_test_ssl_buffer_get(NULL, NULL, 0), -1);
 
     /* Make sure calling put and get on a buffer that hasn't been set up results
      * in error. */
-    TEST_ASSERT(mbedtls_test_ssl_buffer_put(&buf, input, sizeof(input))
-                == -1);
-    TEST_ASSERT(mbedtls_test_ssl_buffer_get(&buf, output, sizeof(output))
-                == -1);
-    TEST_ASSERT(mbedtls_test_ssl_buffer_put(&buf, NULL, sizeof(input))
-                == -1);
+    TEST_EQUAL(mbedtls_test_ssl_buffer_put(&buf, input, sizeof(input)), -1);
+    TEST_EQUAL(mbedtls_test_ssl_buffer_get(&buf, output, sizeof(output)), -1);
+    TEST_EQUAL(mbedtls_test_ssl_buffer_put(&buf, NULL, sizeof(input)), -1);
 
-    TEST_ASSERT(mbedtls_test_ssl_buffer_put(&buf, NULL, 0) == -1);
-    TEST_ASSERT(mbedtls_test_ssl_buffer_get(&buf, NULL, 0) == -1);
+    TEST_EQUAL(mbedtls_test_ssl_buffer_put(&buf, NULL, 0), -1);
+    TEST_EQUAL(mbedtls_test_ssl_buffer_get(&buf, NULL, 0), -1);
 
     /* Make sure calling put and get on NULL input only results in
      * error if the length is not zero, and that a NULL output is valid for data
      * dropping.
      */
 
-    TEST_ASSERT(mbedtls_test_ssl_buffer_setup(&buf, sizeof(input)) == 0);
+    TEST_EQUAL(mbedtls_test_ssl_buffer_setup(&buf, sizeof(input)),  0);
 
-    TEST_ASSERT(mbedtls_test_ssl_buffer_put(&buf, NULL, sizeof(input))
-                == -1);
-    TEST_ASSERT(mbedtls_test_ssl_buffer_get(&buf, NULL, sizeof(output))
-                == 0);
-    TEST_ASSERT(mbedtls_test_ssl_buffer_put(&buf, NULL, 0) == 0);
-    TEST_ASSERT(mbedtls_test_ssl_buffer_get(&buf, NULL, 0) == 0);
+    TEST_EQUAL(mbedtls_test_ssl_buffer_put(&buf, NULL, sizeof(input)), -1);
+    TEST_EQUAL(mbedtls_test_ssl_buffer_get(&buf, NULL, sizeof(output)), 0);
+    TEST_EQUAL(mbedtls_test_ssl_buffer_put(&buf, NULL, 0), 0);
+    TEST_EQUAL(mbedtls_test_ssl_buffer_get(&buf, NULL, 0), 0);
 
     /* Make sure calling put several times in the row is safe */
 
-    TEST_ASSERT(mbedtls_test_ssl_buffer_put(&buf, input, sizeof(input))
-                == sizeof(input));
-    TEST_ASSERT(mbedtls_test_ssl_buffer_get(&buf, output, 2) == 2);
-    TEST_ASSERT(mbedtls_test_ssl_buffer_put(&buf, input, 1) == 1);
-    TEST_ASSERT(mbedtls_test_ssl_buffer_put(&buf, input, 2) == 1);
-    TEST_ASSERT(mbedtls_test_ssl_buffer_put(&buf, input, 2) == 0);
+    TEST_EQUAL(mbedtls_test_ssl_buffer_put(&buf, input, sizeof(input)), sizeof(input));
+    TEST_EQUAL(mbedtls_test_ssl_buffer_get(&buf, output, 2), 2);
+    TEST_EQUAL(mbedtls_test_ssl_buffer_put(&buf, input, 1), 1);
+    TEST_EQUAL(mbedtls_test_ssl_buffer_put(&buf, input, 2), 1);
+    TEST_EQUAL(mbedtls_test_ssl_buffer_put(&buf, input, 2), 0);
 
 
 exit:
@@ -519,7 +510,7 @@ void test_callback_buffer(int size, int put1, int put1_ret,
 
     mbedtls_test_ssl_buffer_init(&buf);
     USE_PSA_INIT();
-    TEST_ASSERT(mbedtls_test_ssl_buffer_setup(&buf, size) == 0);
+    TEST_EQUAL(mbedtls_test_ssl_buffer_setup(&buf, size),  0);
 
     /* Check the sanity of input parameters and initialise local variables. That
      * is, ensure that the amount of data is not negative and that we are not
@@ -578,17 +569,16 @@ void test_callback_buffer(int size, int put1, int put1_ret,
 
     written = read = 0;
     for (j = 0; j < ROUNDS; j++) {
-        TEST_ASSERT(put_ret[j] == mbedtls_test_ssl_buffer_put(&buf,
-                                                              input + written, put[j]));
+        TEST_EQUAL(put_ret[j],  mbedtls_test_ssl_buffer_put(&buf,
+                                                            input + written, put[j]));
         written += put_ret[j];
-        TEST_ASSERT(get_ret[j] == mbedtls_test_ssl_buffer_get(&buf,
-                                                              output + read, get[j]));
+        TEST_EQUAL(get_ret[j],  mbedtls_test_ssl_buffer_get(&buf,
+                                                            output + read, get[j]));
         read += get_ret[j];
         TEST_ASSERT(read <= written);
         if (get_ret[j] > 0) {
-            TEST_ASSERT(memcmp(output + read - get_ret[j],
-                               input + read - get_ret[j], get_ret[j])
-                        == 0);
+            TEST_EQUAL(memcmp(output + read - get_ret[j],
+                              input + read - get_ret[j], get_ret[j]),  0);
         }
     }
 
@@ -673,8 +663,8 @@ void ssl_mock_tcp(int blocking)
     }
 
     /* Make sure that sending a message takes a few  iterations. */
-    TEST_ASSERT(0 == mbedtls_test_mock_socket_connect(&client, &server,
-                                                      BUFLEN));
+    TEST_EQUAL(0,  mbedtls_test_mock_socket_connect(&client, &server,
+                                                    BUFLEN));
 
     /* Send the message to the server */
     send_ret = recv_ret = 1;
@@ -690,9 +680,9 @@ void ssl_mock_tcp(int blocking)
         if (send_ret == BUFLEN) {
             int blocking_ret = send(&client, message, 1);
             if (blocking) {
-                TEST_ASSERT(blocking_ret == 0);
+                TEST_EQUAL(blocking_ret,  0);
             } else {
-                TEST_ASSERT(blocking_ret == MBEDTLS_ERR_SSL_WANT_WRITE);
+                TEST_EQUAL(blocking_ret,  MBEDTLS_ERR_SSL_WANT_WRITE);
             }
         }
 
@@ -704,9 +694,9 @@ void ssl_mock_tcp(int blocking)
             TEST_ASSERT(recv_ret <= BUFLEN);
             read += recv_ret;
         } else if (blocking) {
-            TEST_ASSERT(recv_ret == 0);
+            TEST_EQUAL(recv_ret,  0);
         } else {
-            TEST_ASSERT(recv_ret == MBEDTLS_ERR_SSL_WANT_READ);
+            TEST_EQUAL(recv_ret,  MBEDTLS_ERR_SSL_WANT_READ);
             recv_ret = 0;
         }
 
@@ -714,13 +704,13 @@ void ssl_mock_tcp(int blocking)
         if (recv_ret == BUFLEN) {
             int blocking_ret = recv(&server, received, 1);
             if (blocking) {
-                TEST_ASSERT(blocking_ret == 0);
+                TEST_EQUAL(blocking_ret,  0);
             } else {
-                TEST_ASSERT(blocking_ret == MBEDTLS_ERR_SSL_WANT_READ);
+                TEST_EQUAL(blocking_ret,  MBEDTLS_ERR_SSL_WANT_READ);
             }
         }
     }
-    TEST_ASSERT(memcmp(message, received, MSGLEN) == 0);
+    TEST_EQUAL(memcmp(message, received, MSGLEN),  0);
 
 exit:
     mbedtls_test_mock_socket_close(&client);
@@ -774,8 +764,8 @@ void ssl_mock_tcp_interleaving(int blocking)
     }
 
     /* Make sure that sending a message takes a few  iterations. */
-    TEST_ASSERT(0 == mbedtls_test_mock_socket_connect(&client, &server,
-                                                      BUFLEN));
+    TEST_EQUAL(0,  mbedtls_test_mock_socket_connect(&client, &server,
+                                                    BUFLEN));
 
     /* Send the message from both sides, interleaving. */
     progress = 1;
@@ -803,9 +793,9 @@ void ssl_mock_tcp_interleaving(int blocking)
             if (send_ret[i] == BUFLEN) {
                 int blocking_ret = send(socket, message[i], 1);
                 if (blocking) {
-                    TEST_ASSERT(blocking_ret == 0);
+                    TEST_EQUAL(blocking_ret,  0);
                 } else {
-                    TEST_ASSERT(blocking_ret == MBEDTLS_ERR_SSL_WANT_WRITE);
+                    TEST_EQUAL(blocking_ret,  MBEDTLS_ERR_SSL_WANT_WRITE);
                 }
             }
         }
@@ -823,9 +813,9 @@ void ssl_mock_tcp_interleaving(int blocking)
                 TEST_ASSERT(recv_ret[i] <= BUFLEN);
                 read[i] += recv_ret[i];
             } else if (blocking) {
-                TEST_ASSERT(recv_ret[i] == 0);
+                TEST_EQUAL(recv_ret[i],  0);
             } else {
-                TEST_ASSERT(recv_ret[i] == MBEDTLS_ERR_SSL_WANT_READ);
+                TEST_EQUAL(recv_ret[i],  MBEDTLS_ERR_SSL_WANT_READ);
                 recv_ret[i] = 0;
             }
 
@@ -834,9 +824,9 @@ void ssl_mock_tcp_interleaving(int blocking)
             if (recv_ret[i] == BUFLEN) {
                 int blocking_ret = recv(socket, received[i], 1);
                 if (blocking) {
-                    TEST_ASSERT(blocking_ret == 0);
+                    TEST_EQUAL(blocking_ret,  0);
                 } else {
-                    TEST_ASSERT(blocking_ret == MBEDTLS_ERR_SSL_WANT_READ);
+                    TEST_EQUAL(blocking_ret,  MBEDTLS_ERR_SSL_WANT_READ);
                 }
             }
         }
@@ -848,7 +838,7 @@ void ssl_mock_tcp_interleaving(int blocking)
     }
 
     for (i = 0; i < ROUNDS; i++) {
-        TEST_ASSERT(memcmp(message[i], received[i], MSGLEN) == 0);
+        TEST_EQUAL(memcmp(message[i], received[i], MSGLEN),  0);
     }
 
 exit:
@@ -865,14 +855,14 @@ void ssl_message_queue_sanity()
 
     USE_PSA_INIT();
     /* Trying to push/pull to an empty queue */
-    TEST_ASSERT(mbedtls_test_ssl_message_queue_push_info(NULL, 1)
-                == MBEDTLS_TEST_ERROR_ARG_NULL);
-    TEST_ASSERT(mbedtls_test_ssl_message_queue_pop_info(NULL, 1)
-                == MBEDTLS_TEST_ERROR_ARG_NULL);
+    TEST_EQUAL(mbedtls_test_ssl_message_queue_push_info(NULL, 1),
+               MBEDTLS_TEST_ERROR_ARG_NULL);
+    TEST_EQUAL(mbedtls_test_ssl_message_queue_pop_info(NULL, 1),
+               MBEDTLS_TEST_ERROR_ARG_NULL);
 
-    TEST_ASSERT(mbedtls_test_ssl_message_queue_setup(&queue, 3) == 0);
-    TEST_ASSERT(queue.capacity == 3);
-    TEST_ASSERT(queue.num == 0);
+    TEST_EQUAL(mbedtls_test_ssl_message_queue_setup(&queue, 3),  0);
+    TEST_EQUAL(queue.capacity,  3);
+    TEST_EQUAL(queue.num,  0);
 
 exit:
     mbedtls_test_ssl_message_queue_free(&queue);
@@ -886,22 +876,22 @@ void ssl_message_queue_basic()
     mbedtls_test_ssl_message_queue queue = SSL_MESSAGE_QUEUE_INIT;
 
     USE_PSA_INIT();
-    TEST_ASSERT(mbedtls_test_ssl_message_queue_setup(&queue, 3) == 0);
+    TEST_EQUAL(mbedtls_test_ssl_message_queue_setup(&queue, 3),  0);
 
     /* Sanity test - 3 pushes and 3 pops with sufficient space */
-    TEST_ASSERT(mbedtls_test_ssl_message_queue_push_info(&queue, 1) == 1);
-    TEST_ASSERT(queue.capacity == 3);
-    TEST_ASSERT(queue.num == 1);
-    TEST_ASSERT(mbedtls_test_ssl_message_queue_push_info(&queue, 1) == 1);
-    TEST_ASSERT(queue.capacity == 3);
-    TEST_ASSERT(queue.num == 2);
-    TEST_ASSERT(mbedtls_test_ssl_message_queue_push_info(&queue, 2) == 2);
-    TEST_ASSERT(queue.capacity == 3);
-    TEST_ASSERT(queue.num == 3);
+    TEST_EQUAL(mbedtls_test_ssl_message_queue_push_info(&queue, 1),  1);
+    TEST_EQUAL(queue.capacity,  3);
+    TEST_EQUAL(queue.num,  1);
+    TEST_EQUAL(mbedtls_test_ssl_message_queue_push_info(&queue, 1),  1);
+    TEST_EQUAL(queue.capacity,  3);
+    TEST_EQUAL(queue.num,  2);
+    TEST_EQUAL(mbedtls_test_ssl_message_queue_push_info(&queue, 2),  2);
+    TEST_EQUAL(queue.capacity,  3);
+    TEST_EQUAL(queue.num,  3);
 
-    TEST_ASSERT(mbedtls_test_ssl_message_queue_pop_info(&queue, 1) == 1);
-    TEST_ASSERT(mbedtls_test_ssl_message_queue_pop_info(&queue, 1) == 1);
-    TEST_ASSERT(mbedtls_test_ssl_message_queue_pop_info(&queue, 2) == 2);
+    TEST_EQUAL(mbedtls_test_ssl_message_queue_pop_info(&queue, 1),  1);
+    TEST_EQUAL(mbedtls_test_ssl_message_queue_pop_info(&queue, 1),  1);
+    TEST_EQUAL(mbedtls_test_ssl_message_queue_pop_info(&queue, 2),  2);
 
 exit:
     mbedtls_test_ssl_message_queue_free(&queue);
@@ -915,21 +905,21 @@ void ssl_message_queue_overflow_underflow()
     mbedtls_test_ssl_message_queue queue = SSL_MESSAGE_QUEUE_INIT;
 
     USE_PSA_INIT();
-    TEST_ASSERT(mbedtls_test_ssl_message_queue_setup(&queue, 3) == 0);
+    TEST_EQUAL(mbedtls_test_ssl_message_queue_setup(&queue, 3),  0);
 
     /* 4 pushes (last one with an error), 4 pops (last one with an error) */
-    TEST_ASSERT(mbedtls_test_ssl_message_queue_push_info(&queue, 1) == 1);
-    TEST_ASSERT(mbedtls_test_ssl_message_queue_push_info(&queue, 1) == 1);
-    TEST_ASSERT(mbedtls_test_ssl_message_queue_push_info(&queue, 2) == 2);
-    TEST_ASSERT(mbedtls_test_ssl_message_queue_push_info(&queue, 3)
-                == MBEDTLS_ERR_SSL_WANT_WRITE);
+    TEST_EQUAL(mbedtls_test_ssl_message_queue_push_info(&queue, 1),  1);
+    TEST_EQUAL(mbedtls_test_ssl_message_queue_push_info(&queue, 1),  1);
+    TEST_EQUAL(mbedtls_test_ssl_message_queue_push_info(&queue, 2),  2);
+    TEST_EQUAL(mbedtls_test_ssl_message_queue_push_info(&queue, 3),
+               MBEDTLS_ERR_SSL_WANT_WRITE);
 
-    TEST_ASSERT(mbedtls_test_ssl_message_queue_pop_info(&queue, 1) == 1);
-    TEST_ASSERT(mbedtls_test_ssl_message_queue_pop_info(&queue, 1) == 1);
-    TEST_ASSERT(mbedtls_test_ssl_message_queue_pop_info(&queue, 2) == 2);
+    TEST_EQUAL(mbedtls_test_ssl_message_queue_pop_info(&queue, 1),  1);
+    TEST_EQUAL(mbedtls_test_ssl_message_queue_pop_info(&queue, 1),  1);
+    TEST_EQUAL(mbedtls_test_ssl_message_queue_pop_info(&queue, 2),  2);
 
-    TEST_ASSERT(mbedtls_test_ssl_message_queue_pop_info(&queue, 1)
-                == MBEDTLS_ERR_SSL_WANT_READ);
+    TEST_EQUAL(mbedtls_test_ssl_message_queue_pop_info(&queue, 1),
+               MBEDTLS_ERR_SSL_WANT_READ);
 
 exit:
     mbedtls_test_ssl_message_queue_free(&queue);
@@ -943,29 +933,29 @@ void ssl_message_queue_interleaved()
     mbedtls_test_ssl_message_queue queue = SSL_MESSAGE_QUEUE_INIT;
 
     USE_PSA_INIT();
-    TEST_ASSERT(mbedtls_test_ssl_message_queue_setup(&queue, 3) == 0);
+    TEST_EQUAL(mbedtls_test_ssl_message_queue_setup(&queue, 3),  0);
 
     /* Interleaved test - [2 pushes, 1 pop] twice, and then two pops
      * (to wrap around the buffer) */
-    TEST_ASSERT(mbedtls_test_ssl_message_queue_push_info(&queue, 1) == 1);
-    TEST_ASSERT(mbedtls_test_ssl_message_queue_push_info(&queue, 1) == 1);
+    TEST_EQUAL(mbedtls_test_ssl_message_queue_push_info(&queue, 1),  1);
+    TEST_EQUAL(mbedtls_test_ssl_message_queue_push_info(&queue, 1),  1);
 
-    TEST_ASSERT(mbedtls_test_ssl_message_queue_pop_info(&queue, 1) == 1);
+    TEST_EQUAL(mbedtls_test_ssl_message_queue_pop_info(&queue, 1),  1);
 
-    TEST_ASSERT(mbedtls_test_ssl_message_queue_push_info(&queue, 2) == 2);
-    TEST_ASSERT(mbedtls_test_ssl_message_queue_push_info(&queue, 3) == 3);
+    TEST_EQUAL(mbedtls_test_ssl_message_queue_push_info(&queue, 2),  2);
+    TEST_EQUAL(mbedtls_test_ssl_message_queue_push_info(&queue, 3),  3);
 
-    TEST_ASSERT(mbedtls_test_ssl_message_queue_pop_info(&queue, 1) == 1);
-    TEST_ASSERT(mbedtls_test_ssl_message_queue_pop_info(&queue, 2) == 2);
+    TEST_EQUAL(mbedtls_test_ssl_message_queue_pop_info(&queue, 1),  1);
+    TEST_EQUAL(mbedtls_test_ssl_message_queue_pop_info(&queue, 2),  2);
 
-    TEST_ASSERT(mbedtls_test_ssl_message_queue_push_info(&queue, 5) == 5);
-    TEST_ASSERT(mbedtls_test_ssl_message_queue_push_info(&queue, 8) == 8);
+    TEST_EQUAL(mbedtls_test_ssl_message_queue_push_info(&queue, 5),  5);
+    TEST_EQUAL(mbedtls_test_ssl_message_queue_push_info(&queue, 8),  8);
 
-    TEST_ASSERT(mbedtls_test_ssl_message_queue_pop_info(&queue, 3) == 3);
+    TEST_EQUAL(mbedtls_test_ssl_message_queue_pop_info(&queue, 3),  3);
 
-    TEST_ASSERT(mbedtls_test_ssl_message_queue_pop_info(&queue, 5) == 5);
+    TEST_EQUAL(mbedtls_test_ssl_message_queue_pop_info(&queue, 5),  5);
 
-    TEST_ASSERT(mbedtls_test_ssl_message_queue_pop_info(&queue, 8) == 8);
+    TEST_EQUAL(mbedtls_test_ssl_message_queue_pop_info(&queue, 8),  8);
 
 exit:
     mbedtls_test_ssl_message_queue_free(&queue);
@@ -981,13 +971,13 @@ void ssl_message_queue_insufficient_buffer()
     size_t buffer_len = 5;
 
     USE_PSA_INIT();
-    TEST_ASSERT(mbedtls_test_ssl_message_queue_setup(&queue, 1) == 0);
+    TEST_EQUAL(mbedtls_test_ssl_message_queue_setup(&queue, 1),  0);
 
     /* Popping without a sufficient buffer */
-    TEST_ASSERT(mbedtls_test_ssl_message_queue_push_info(&queue, message_len)
-                == (int) message_len);
-    TEST_ASSERT(mbedtls_test_ssl_message_queue_pop_info(&queue, buffer_len)
-                == (int) buffer_len);
+    TEST_EQUAL(mbedtls_test_ssl_message_queue_push_info(&queue, message_len),
+               (int) message_len);
+    TEST_EQUAL(mbedtls_test_ssl_message_queue_pop_info(&queue, buffer_len),
+               (int) buffer_len);
 exit:
     mbedtls_test_ssl_message_queue_free(&queue);
     USE_PSA_DONE();
@@ -1007,40 +997,40 @@ void ssl_message_mock_uninitialized()
 
     USE_PSA_INIT();
     /* Send with a NULL context */
-    TEST_ASSERT(mbedtls_test_mock_tcp_send_msg(NULL, message, MSGLEN)
-                == MBEDTLS_TEST_ERROR_CONTEXT_ERROR);
+    TEST_EQUAL(mbedtls_test_mock_tcp_send_msg(NULL, message, MSGLEN),
+               MBEDTLS_TEST_ERROR_CONTEXT_ERROR);
 
-    TEST_ASSERT(mbedtls_test_mock_tcp_recv_msg(NULL, message, MSGLEN)
-                == MBEDTLS_TEST_ERROR_CONTEXT_ERROR);
+    TEST_EQUAL(mbedtls_test_mock_tcp_recv_msg(NULL, message, MSGLEN),
+               MBEDTLS_TEST_ERROR_CONTEXT_ERROR);
 
-    TEST_ASSERT(mbedtls_test_message_socket_setup(&server_queue,
-                                                  &client_queue, 1,
-                                                  &server,
-                                                  &server_context) == 0);
+    TEST_EQUAL(mbedtls_test_message_socket_setup(&server_queue,
+                                                 &client_queue, 1,
+                                                 &server,
+                                                 &server_context),  0);
 
-    TEST_ASSERT(mbedtls_test_message_socket_setup(&client_queue,
-                                                  &server_queue, 1,
-                                                  &client,
-                                                  &client_context) == 0);
+    TEST_EQUAL(mbedtls_test_message_socket_setup(&client_queue,
+                                                 &server_queue, 1,
+                                                 &client,
+                                                 &client_context),  0);
 
-    TEST_ASSERT(mbedtls_test_mock_tcp_send_msg(&client_context, message,
-                                               MSGLEN)
-                == MBEDTLS_TEST_ERROR_SEND_FAILED);
+    TEST_EQUAL(mbedtls_test_mock_tcp_send_msg(&client_context, message,
+                                              MSGLEN),
+               MBEDTLS_TEST_ERROR_SEND_FAILED);
 
-    TEST_ASSERT(mbedtls_test_mock_tcp_recv_msg(&server_context, received,
-                                               MSGLEN)
-                == MBEDTLS_ERR_SSL_WANT_READ);
+    TEST_EQUAL(mbedtls_test_mock_tcp_recv_msg(&server_context, received,
+                                              MSGLEN),
+               MBEDTLS_ERR_SSL_WANT_READ);
 
     /* Push directly to a queue to later simulate a disconnected behavior */
-    TEST_ASSERT(mbedtls_test_ssl_message_queue_push_info(&server_queue,
-                                                         MSGLEN)
-                == MSGLEN);
+    TEST_EQUAL(mbedtls_test_ssl_message_queue_push_info(&server_queue,
+                                                        MSGLEN),
+               MSGLEN);
 
     /* Test if there's an error when trying to read from a disconnected
      * socket */
-    TEST_ASSERT(mbedtls_test_mock_tcp_recv_msg(&server_context, received,
-                                               MSGLEN)
-                == MBEDTLS_TEST_ERROR_RECV_FAILED);
+    TEST_EQUAL(mbedtls_test_mock_tcp_recv_msg(&server_context, received,
+                                              MSGLEN),
+               MBEDTLS_TEST_ERROR_RECV_FAILED);
 exit:
     mbedtls_test_message_socket_close(&server_context);
     mbedtls_test_message_socket_close(&client_context);
@@ -1062,46 +1052,46 @@ void ssl_message_mock_basic()
     mbedtls_test_message_socket_init(&client_context);
     USE_PSA_INIT();
 
-    TEST_ASSERT(mbedtls_test_message_socket_setup(&server_queue,
-                                                  &client_queue, 1,
-                                                  &server,
-                                                  &server_context) == 0);
+    TEST_EQUAL(mbedtls_test_message_socket_setup(&server_queue,
+                                                 &client_queue, 1,
+                                                 &server,
+                                                 &server_context),  0);
 
-    TEST_ASSERT(mbedtls_test_message_socket_setup(&client_queue,
-                                                  &server_queue, 1,
-                                                  &client,
-                                                  &client_context) == 0);
+    TEST_EQUAL(mbedtls_test_message_socket_setup(&client_queue,
+                                                 &server_queue, 1,
+                                                 &client,
+                                                 &client_context),  0);
 
     /* Fill up the buffer with structured data so that unwanted changes
      * can be detected */
     for (i = 0; i < MSGLEN; i++) {
         message[i] = i & 0xFF;
     }
-    TEST_ASSERT(0 == mbedtls_test_mock_socket_connect(&client, &server,
-                                                      MSGLEN));
+    TEST_EQUAL(0,  mbedtls_test_mock_socket_connect(&client, &server,
+                                                    MSGLEN));
 
     /* Send the message to the server */
-    TEST_ASSERT(mbedtls_test_mock_tcp_send_msg(&client_context, message,
-                                               MSGLEN) == MSGLEN);
+    TEST_EQUAL(mbedtls_test_mock_tcp_send_msg(&client_context, message,
+                                              MSGLEN),  MSGLEN);
 
     /* Read from the server */
-    TEST_ASSERT(mbedtls_test_mock_tcp_recv_msg(&server_context, received,
-                                               MSGLEN)
-                == MSGLEN);
+    TEST_EQUAL(mbedtls_test_mock_tcp_recv_msg(&server_context, received,
+                                              MSGLEN),
+               MSGLEN);
 
-    TEST_ASSERT(memcmp(message, received, MSGLEN) == 0);
+    TEST_EQUAL(memcmp(message, received, MSGLEN),  0);
     memset(received, 0, MSGLEN);
 
     /* Send the message to the client */
-    TEST_ASSERT(mbedtls_test_mock_tcp_send_msg(&server_context, message,
-                                               MSGLEN)
-                == MSGLEN);
+    TEST_EQUAL(mbedtls_test_mock_tcp_send_msg(&server_context, message,
+                                              MSGLEN),
+               MSGLEN);
 
     /* Read from the client */
-    TEST_ASSERT(mbedtls_test_mock_tcp_recv_msg(&client_context, received,
-                                               MSGLEN)
-                == MSGLEN);
-    TEST_ASSERT(memcmp(message, received, MSGLEN) == 0);
+    TEST_EQUAL(mbedtls_test_mock_tcp_recv_msg(&client_context, received,
+                                              MSGLEN),
+               MSGLEN);
+    TEST_EQUAL(memcmp(message, received, MSGLEN),  0);
 
 exit:
     mbedtls_test_message_socket_close(&server_context);
@@ -1124,51 +1114,51 @@ void ssl_message_mock_queue_overflow_underflow()
     mbedtls_test_message_socket_init(&client_context);
     USE_PSA_INIT();
 
-    TEST_ASSERT(mbedtls_test_message_socket_setup(&server_queue,
-                                                  &client_queue, 2,
-                                                  &server,
-                                                  &server_context) == 0);
+    TEST_EQUAL(mbedtls_test_message_socket_setup(&server_queue,
+                                                 &client_queue, 2,
+                                                 &server,
+                                                 &server_context),  0);
 
-    TEST_ASSERT(mbedtls_test_message_socket_setup(&client_queue,
-                                                  &server_queue, 2,
-                                                  &client,
-                                                  &client_context) == 0);
+    TEST_EQUAL(mbedtls_test_message_socket_setup(&client_queue,
+                                                 &server_queue, 2,
+                                                 &client,
+                                                 &client_context),  0);
 
     /* Fill up the buffer with structured data so that unwanted changes
      * can be detected */
     for (i = 0; i < MSGLEN; i++) {
         message[i] = i & 0xFF;
     }
-    TEST_ASSERT(0 == mbedtls_test_mock_socket_connect(&client, &server,
-                                                      MSGLEN*2));
+    TEST_EQUAL(0,  mbedtls_test_mock_socket_connect(&client, &server,
+                                                    MSGLEN*2));
 
     /* Send three message to the server, last one with an error */
-    TEST_ASSERT(mbedtls_test_mock_tcp_send_msg(&client_context, message,
-                                               MSGLEN - 1)
-                == MSGLEN - 1);
+    TEST_EQUAL(mbedtls_test_mock_tcp_send_msg(&client_context, message,
+                                              MSGLEN - 1),
+               MSGLEN - 1);
 
-    TEST_ASSERT(mbedtls_test_mock_tcp_send_msg(&client_context, message,
-                                               MSGLEN)
-                == MSGLEN);
+    TEST_EQUAL(mbedtls_test_mock_tcp_send_msg(&client_context, message,
+                                              MSGLEN),
+               MSGLEN);
 
-    TEST_ASSERT(mbedtls_test_mock_tcp_send_msg(&client_context, message,
-                                               MSGLEN)
-                == MBEDTLS_ERR_SSL_WANT_WRITE);
+    TEST_EQUAL(mbedtls_test_mock_tcp_send_msg(&client_context, message,
+                                              MSGLEN),
+               MBEDTLS_ERR_SSL_WANT_WRITE);
 
     /* Read three messages from the server, last one with an error */
-    TEST_ASSERT(mbedtls_test_mock_tcp_recv_msg(&server_context, received,
-                                               MSGLEN - 1)
-                == MSGLEN - 1);
+    TEST_EQUAL(mbedtls_test_mock_tcp_recv_msg(&server_context, received,
+                                              MSGLEN - 1),
+               MSGLEN - 1);
 
-    TEST_ASSERT(mbedtls_test_mock_tcp_recv_msg(&server_context, received,
-                                               MSGLEN)
-                == MSGLEN);
+    TEST_EQUAL(mbedtls_test_mock_tcp_recv_msg(&server_context, received,
+                                              MSGLEN),
+               MSGLEN);
 
-    TEST_ASSERT(memcmp(message, received, MSGLEN) == 0);
+    TEST_EQUAL(memcmp(message, received, MSGLEN),  0);
 
-    TEST_ASSERT(mbedtls_test_mock_tcp_recv_msg(&server_context, received,
-                                               MSGLEN)
-                == MBEDTLS_ERR_SSL_WANT_READ);
+    TEST_EQUAL(mbedtls_test_mock_tcp_recv_msg(&server_context, received,
+                                              MSGLEN),
+               MBEDTLS_ERR_SSL_WANT_READ);
 
 exit:
     mbedtls_test_message_socket_close(&server_context);
@@ -1191,39 +1181,39 @@ void ssl_message_mock_socket_overflow()
     mbedtls_test_message_socket_init(&client_context);
     USE_PSA_INIT();
 
-    TEST_ASSERT(mbedtls_test_message_socket_setup(&server_queue,
-                                                  &client_queue, 2,
-                                                  &server,
-                                                  &server_context) == 0);
+    TEST_EQUAL(mbedtls_test_message_socket_setup(&server_queue,
+                                                 &client_queue, 2,
+                                                 &server,
+                                                 &server_context),  0);
 
-    TEST_ASSERT(mbedtls_test_message_socket_setup(&client_queue,
-                                                  &server_queue, 2,
-                                                  &client,
-                                                  &client_context) == 0);
+    TEST_EQUAL(mbedtls_test_message_socket_setup(&client_queue,
+                                                 &server_queue, 2,
+                                                 &client,
+                                                 &client_context),  0);
 
     /* Fill up the buffer with structured data so that unwanted changes
      * can be detected */
     for (i = 0; i < MSGLEN; i++) {
         message[i] = i & 0xFF;
     }
-    TEST_ASSERT(0 == mbedtls_test_mock_socket_connect(&client, &server,
-                                                      MSGLEN));
+    TEST_EQUAL(0,  mbedtls_test_mock_socket_connect(&client, &server,
+                                                    MSGLEN));
 
     /* Send two message to the server, second one with an error */
-    TEST_ASSERT(mbedtls_test_mock_tcp_send_msg(&client_context, message,
-                                               MSGLEN)
-                == MSGLEN);
+    TEST_EQUAL(mbedtls_test_mock_tcp_send_msg(&client_context, message,
+                                              MSGLEN),
+               MSGLEN);
 
-    TEST_ASSERT(mbedtls_test_mock_tcp_send_msg(&client_context, message,
-                                               MSGLEN)
-                == MBEDTLS_TEST_ERROR_SEND_FAILED);
+    TEST_EQUAL(mbedtls_test_mock_tcp_send_msg(&client_context, message,
+                                              MSGLEN),
+               MBEDTLS_TEST_ERROR_SEND_FAILED);
 
     /* Read the only message from the server */
-    TEST_ASSERT(mbedtls_test_mock_tcp_recv_msg(&server_context, received,
-                                               MSGLEN)
-                == MSGLEN);
+    TEST_EQUAL(mbedtls_test_mock_tcp_recv_msg(&server_context, received,
+                                              MSGLEN),
+               MSGLEN);
 
-    TEST_ASSERT(memcmp(message, received, MSGLEN) == 0);
+    TEST_EQUAL(memcmp(message, received, MSGLEN),  0);
 
 exit:
     mbedtls_test_message_socket_close(&server_context);
@@ -1246,15 +1236,15 @@ void ssl_message_mock_truncated()
     mbedtls_test_message_socket_init(&client_context);
     USE_PSA_INIT();
 
-    TEST_ASSERT(mbedtls_test_message_socket_setup(&server_queue,
-                                                  &client_queue, 2,
-                                                  &server,
-                                                  &server_context) == 0);
+    TEST_EQUAL(mbedtls_test_message_socket_setup(&server_queue,
+                                                 &client_queue, 2,
+                                                 &server,
+                                                 &server_context),  0);
 
-    TEST_ASSERT(mbedtls_test_message_socket_setup(&client_queue,
-                                                  &server_queue, 2,
-                                                  &client,
-                                                  &client_context) == 0);
+    TEST_EQUAL(mbedtls_test_message_socket_setup(&client_queue,
+                                                 &server_queue, 2,
+                                                 &client,
+                                                 &client_context),  0);
 
     memset(received, 0, MSGLEN);
     /* Fill up the buffer with structured data so that unwanted changes
@@ -1262,35 +1252,35 @@ void ssl_message_mock_truncated()
     for (i = 0; i < MSGLEN; i++) {
         message[i] = i & 0xFF;
     }
-    TEST_ASSERT(0 == mbedtls_test_mock_socket_connect(&client, &server,
-                                                      2 * MSGLEN));
+    TEST_EQUAL(0,  mbedtls_test_mock_socket_connect(&client, &server,
+                                                    2 * MSGLEN));
 
     /* Send two messages to the server, the second one small enough to fit in the
      * receiver's buffer. */
-    TEST_ASSERT(mbedtls_test_mock_tcp_send_msg(&client_context, message,
-                                               MSGLEN)
-                == MSGLEN);
-    TEST_ASSERT(mbedtls_test_mock_tcp_send_msg(&client_context, message,
-                                               MSGLEN / 2)
-                == MSGLEN / 2);
+    TEST_EQUAL(mbedtls_test_mock_tcp_send_msg(&client_context, message,
+                                              MSGLEN),
+               MSGLEN);
+    TEST_EQUAL(mbedtls_test_mock_tcp_send_msg(&client_context, message,
+                                              MSGLEN / 2),
+               MSGLEN / 2);
     /* Read a truncated message from the server */
-    TEST_ASSERT(mbedtls_test_mock_tcp_recv_msg(&server_context, received,
-                                               MSGLEN/2)
-                == MSGLEN/2);
+    TEST_EQUAL(mbedtls_test_mock_tcp_recv_msg(&server_context, received,
+                                              MSGLEN/2),
+               MSGLEN/2);
 
     /* Test that the first half of the message is valid, and second one isn't */
-    TEST_ASSERT(memcmp(message, received, MSGLEN/2) == 0);
+    TEST_EQUAL(memcmp(message, received, MSGLEN/2),  0);
     TEST_ASSERT(memcmp(message + MSGLEN/2, received + MSGLEN/2, MSGLEN/2)
                 != 0);
     memset(received, 0, MSGLEN);
 
     /* Read a full message from the server */
-    TEST_ASSERT(mbedtls_test_mock_tcp_recv_msg(&server_context, received,
-                                               MSGLEN/2)
-                == MSGLEN / 2);
+    TEST_EQUAL(mbedtls_test_mock_tcp_recv_msg(&server_context, received,
+                                              MSGLEN/2),
+               MSGLEN / 2);
 
     /* Test that the first half of the message is valid */
-    TEST_ASSERT(memcmp(message, received, MSGLEN/2) == 0);
+    TEST_EQUAL(memcmp(message, received, MSGLEN/2),  0);
 
 exit:
     mbedtls_test_message_socket_close(&server_context);
@@ -1313,33 +1303,33 @@ void ssl_message_mock_socket_read_error()
     mbedtls_test_message_socket_init(&client_context);
     USE_PSA_INIT();
 
-    TEST_ASSERT(mbedtls_test_message_socket_setup(&server_queue,
-                                                  &client_queue, 1,
-                                                  &server,
-                                                  &server_context) == 0);
+    TEST_EQUAL(mbedtls_test_message_socket_setup(&server_queue,
+                                                 &client_queue, 1,
+                                                 &server,
+                                                 &server_context),  0);
 
-    TEST_ASSERT(mbedtls_test_message_socket_setup(&client_queue,
-                                                  &server_queue, 1,
-                                                  &client,
-                                                  &client_context) == 0);
+    TEST_EQUAL(mbedtls_test_message_socket_setup(&client_queue,
+                                                 &server_queue, 1,
+                                                 &client,
+                                                 &client_context),  0);
 
     /* Fill up the buffer with structured data so that unwanted changes
      * can be detected */
     for (i = 0; i < MSGLEN; i++) {
         message[i] = i & 0xFF;
     }
-    TEST_ASSERT(0 == mbedtls_test_mock_socket_connect(&client, &server,
-                                                      MSGLEN));
+    TEST_EQUAL(0,  mbedtls_test_mock_socket_connect(&client, &server,
+                                                    MSGLEN));
 
-    TEST_ASSERT(mbedtls_test_mock_tcp_send_msg(&client_context, message,
-                                               MSGLEN)
-                == MSGLEN);
+    TEST_EQUAL(mbedtls_test_mock_tcp_send_msg(&client_context, message,
+                                              MSGLEN),
+               MSGLEN);
 
     /* Force a read error by disconnecting the socket by hand */
     server.status = 0;
-    TEST_ASSERT(mbedtls_test_mock_tcp_recv_msg(&server_context, received,
-                                               MSGLEN)
-                == MBEDTLS_TEST_ERROR_RECV_FAILED);
+    TEST_EQUAL(mbedtls_test_mock_tcp_recv_msg(&server_context, received,
+                                              MSGLEN),
+               MBEDTLS_TEST_ERROR_RECV_FAILED);
     /* Return to a valid state */
     server.status = MBEDTLS_MOCK_SOCKET_CONNECTED;
 
@@ -1347,11 +1337,11 @@ void ssl_message_mock_socket_read_error()
 
     /* Test that even though the server tried to read once disconnected, the
      * continuity is preserved */
-    TEST_ASSERT(mbedtls_test_mock_tcp_recv_msg(&server_context, received,
-                                               MSGLEN)
-                == MSGLEN);
+    TEST_EQUAL(mbedtls_test_mock_tcp_recv_msg(&server_context, received,
+                                              MSGLEN),
+               MSGLEN);
 
-    TEST_ASSERT(memcmp(message, received, MSGLEN) == 0);
+    TEST_EQUAL(memcmp(message, received, MSGLEN),  0);
 
 exit:
     mbedtls_test_message_socket_close(&server_context);
@@ -1374,48 +1364,48 @@ void ssl_message_mock_interleaved_one_way()
     mbedtls_test_message_socket_init(&client_context);
     USE_PSA_INIT();
 
-    TEST_ASSERT(mbedtls_test_message_socket_setup(&server_queue,
-                                                  &client_queue, 3,
-                                                  &server,
-                                                  &server_context) == 0);
+    TEST_EQUAL(mbedtls_test_message_socket_setup(&server_queue,
+                                                 &client_queue, 3,
+                                                 &server,
+                                                 &server_context),  0);
 
-    TEST_ASSERT(mbedtls_test_message_socket_setup(&client_queue,
-                                                  &server_queue, 3,
-                                                  &client,
-                                                  &client_context) == 0);
+    TEST_EQUAL(mbedtls_test_message_socket_setup(&client_queue,
+                                                 &server_queue, 3,
+                                                 &client,
+                                                 &client_context),  0);
 
     /* Fill up the buffer with structured data so that unwanted changes
      * can be detected */
     for (i = 0; i < MSGLEN; i++) {
         message[i] = i & 0xFF;
     }
-    TEST_ASSERT(0 == mbedtls_test_mock_socket_connect(&client, &server,
-                                                      MSGLEN*3));
+    TEST_EQUAL(0,  mbedtls_test_mock_socket_connect(&client, &server,
+                                                    MSGLEN*3));
 
     /* Interleaved test - [2 sends, 1 read] twice, and then two reads
      * (to wrap around the buffer) */
     for (i = 0; i < 2; i++) {
-        TEST_ASSERT(mbedtls_test_mock_tcp_send_msg(&client_context, message,
-                                                   MSGLEN) == MSGLEN);
+        TEST_EQUAL(mbedtls_test_mock_tcp_send_msg(&client_context, message,
+                                                  MSGLEN),  MSGLEN);
 
-        TEST_ASSERT(mbedtls_test_mock_tcp_send_msg(&client_context, message,
-                                                   MSGLEN) == MSGLEN);
+        TEST_EQUAL(mbedtls_test_mock_tcp_send_msg(&client_context, message,
+                                                  MSGLEN),  MSGLEN);
 
-        TEST_ASSERT(mbedtls_test_mock_tcp_recv_msg(&server_context, received,
-                                                   MSGLEN) == MSGLEN);
-        TEST_ASSERT(memcmp(message, received, MSGLEN) == 0);
+        TEST_EQUAL(mbedtls_test_mock_tcp_recv_msg(&server_context, received,
+                                                  MSGLEN),  MSGLEN);
+        TEST_EQUAL(memcmp(message, received, MSGLEN),  0);
         memset(received, 0, sizeof(received));
     }
 
     for (i = 0; i < 2; i++) {
-        TEST_ASSERT(mbedtls_test_mock_tcp_recv_msg(&server_context, received,
-                                                   MSGLEN) == MSGLEN);
+        TEST_EQUAL(mbedtls_test_mock_tcp_recv_msg(&server_context, received,
+                                                  MSGLEN),  MSGLEN);
 
-        TEST_ASSERT(memcmp(message, received, MSGLEN) == 0);
+        TEST_EQUAL(memcmp(message, received, MSGLEN),  0);
     }
-    TEST_ASSERT(mbedtls_test_mock_tcp_recv_msg(&server_context, received,
-                                               MSGLEN)
-                == MBEDTLS_ERR_SSL_WANT_READ);
+    TEST_EQUAL(mbedtls_test_mock_tcp_recv_msg(&server_context, received,
+                                              MSGLEN),
+               MBEDTLS_ERR_SSL_WANT_READ);
 exit:
     mbedtls_test_message_socket_close(&server_context);
     mbedtls_test_message_socket_close(&client_context);
@@ -1437,75 +1427,75 @@ void ssl_message_mock_interleaved_two_ways()
     mbedtls_test_message_socket_init(&client_context);
     USE_PSA_INIT();
 
-    TEST_ASSERT(mbedtls_test_message_socket_setup(&server_queue,
-                                                  &client_queue, 3,
-                                                  &server,
-                                                  &server_context) == 0);
+    TEST_EQUAL(mbedtls_test_message_socket_setup(&server_queue,
+                                                 &client_queue, 3,
+                                                 &server,
+                                                 &server_context),  0);
 
-    TEST_ASSERT(mbedtls_test_message_socket_setup(&client_queue,
-                                                  &server_queue, 3,
-                                                  &client,
-                                                  &client_context) == 0);
+    TEST_EQUAL(mbedtls_test_message_socket_setup(&client_queue,
+                                                 &server_queue, 3,
+                                                 &client,
+                                                 &client_context),  0);
 
     /* Fill up the buffer with structured data so that unwanted changes
      * can be detected */
     for (i = 0; i < MSGLEN; i++) {
         message[i] = i & 0xFF;
     }
-    TEST_ASSERT(0 == mbedtls_test_mock_socket_connect(&client, &server,
-                                                      MSGLEN*3));
+    TEST_EQUAL(0,  mbedtls_test_mock_socket_connect(&client, &server,
+                                                    MSGLEN*3));
 
     /* Interleaved test - [2 sends, 1 read] twice, both ways, and then two reads
      * (to wrap around the buffer) both ways. */
     for (i = 0; i < 2; i++) {
-        TEST_ASSERT(mbedtls_test_mock_tcp_send_msg(&client_context, message,
-                                                   MSGLEN) == MSGLEN);
+        TEST_EQUAL(mbedtls_test_mock_tcp_send_msg(&client_context, message,
+                                                  MSGLEN),  MSGLEN);
 
-        TEST_ASSERT(mbedtls_test_mock_tcp_send_msg(&client_context, message,
-                                                   MSGLEN) == MSGLEN);
+        TEST_EQUAL(mbedtls_test_mock_tcp_send_msg(&client_context, message,
+                                                  MSGLEN),  MSGLEN);
 
-        TEST_ASSERT(mbedtls_test_mock_tcp_send_msg(&server_context, message,
-                                                   MSGLEN) == MSGLEN);
+        TEST_EQUAL(mbedtls_test_mock_tcp_send_msg(&server_context, message,
+                                                  MSGLEN),  MSGLEN);
 
-        TEST_ASSERT(mbedtls_test_mock_tcp_send_msg(&server_context, message,
-                                                   MSGLEN) == MSGLEN);
+        TEST_EQUAL(mbedtls_test_mock_tcp_send_msg(&server_context, message,
+                                                  MSGLEN),  MSGLEN);
 
-        TEST_ASSERT(mbedtls_test_mock_tcp_recv_msg(&server_context, received,
-                                                   MSGLEN) == MSGLEN);
+        TEST_EQUAL(mbedtls_test_mock_tcp_recv_msg(&server_context, received,
+                                                  MSGLEN),  MSGLEN);
 
-        TEST_ASSERT(memcmp(message, received, MSGLEN) == 0);
+        TEST_EQUAL(memcmp(message, received, MSGLEN),  0);
 
         memset(received, 0, sizeof(received));
 
-        TEST_ASSERT(mbedtls_test_mock_tcp_recv_msg(&client_context, received,
-                                                   MSGLEN) == MSGLEN);
+        TEST_EQUAL(mbedtls_test_mock_tcp_recv_msg(&client_context, received,
+                                                  MSGLEN),  MSGLEN);
 
-        TEST_ASSERT(memcmp(message, received, MSGLEN) == 0);
+        TEST_EQUAL(memcmp(message, received, MSGLEN),  0);
 
         memset(received, 0, sizeof(received));
     }
 
     for (i = 0; i < 2; i++) {
-        TEST_ASSERT(mbedtls_test_mock_tcp_recv_msg(&server_context, received,
-                                                   MSGLEN) == MSGLEN);
+        TEST_EQUAL(mbedtls_test_mock_tcp_recv_msg(&server_context, received,
+                                                  MSGLEN),  MSGLEN);
 
-        TEST_ASSERT(memcmp(message, received, MSGLEN) == 0);
+        TEST_EQUAL(memcmp(message, received, MSGLEN),  0);
         memset(received, 0, sizeof(received));
 
-        TEST_ASSERT(mbedtls_test_mock_tcp_recv_msg(&client_context, received,
-                                                   MSGLEN) == MSGLEN);
+        TEST_EQUAL(mbedtls_test_mock_tcp_recv_msg(&client_context, received,
+                                                  MSGLEN),  MSGLEN);
 
-        TEST_ASSERT(memcmp(message, received, MSGLEN) == 0);
+        TEST_EQUAL(memcmp(message, received, MSGLEN),  0);
         memset(received, 0, sizeof(received));
     }
 
-    TEST_ASSERT(mbedtls_test_mock_tcp_recv_msg(&server_context, received,
-                                               MSGLEN)
-                == MBEDTLS_ERR_SSL_WANT_READ);
+    TEST_EQUAL(mbedtls_test_mock_tcp_recv_msg(&server_context, received,
+                                              MSGLEN),
+               MBEDTLS_ERR_SSL_WANT_READ);
 
-    TEST_ASSERT(mbedtls_test_mock_tcp_recv_msg(&client_context, received,
-                                               MSGLEN)
-                == MBEDTLS_ERR_SSL_WANT_READ);
+    TEST_EQUAL(mbedtls_test_mock_tcp_recv_msg(&client_context, received,
+                                              MSGLEN),
+               MBEDTLS_ERR_SSL_WANT_READ);
 exit:
     mbedtls_test_message_socket_close(&server_context);
     mbedtls_test_message_socket_close(&client_context);
@@ -1524,12 +1514,12 @@ void ssl_dtls_replay(data_t *prevs, data_t *new, int ret)
     mbedtls_ssl_config_init(&conf);
     MD_OR_USE_PSA_INIT();
 
-    TEST_ASSERT(mbedtls_ssl_config_defaults(&conf,
-                                            MBEDTLS_SSL_IS_CLIENT,
-                                            MBEDTLS_SSL_TRANSPORT_DATAGRAM,
-                                            MBEDTLS_SSL_PRESET_DEFAULT) == 0);
+    TEST_EQUAL(mbedtls_ssl_config_defaults(&conf,
+                                           MBEDTLS_SSL_IS_CLIENT,
+                                           MBEDTLS_SSL_TRANSPORT_DATAGRAM,
+                                           MBEDTLS_SSL_PRESET_DEFAULT),  0);
 
-    TEST_ASSERT(mbedtls_ssl_setup(&ssl, &conf) == 0);
+    TEST_EQUAL(mbedtls_ssl_setup(&ssl, &conf),  0);
 
     /* Read previous record numbers */
     for (len = 0; len < prevs->len; len += 6) {
@@ -1539,7 +1529,7 @@ void ssl_dtls_replay(data_t *prevs, data_t *new, int ret)
 
     /* Check new number */
     memcpy(ssl.in_ctr + 2, new->x, 6);
-    TEST_ASSERT(mbedtls_ssl_dtls_replay_check(&ssl) == ret);
+    TEST_EQUAL(mbedtls_ssl_dtls_replay_check(&ssl),  ret);
 
 exit:
     mbedtls_ssl_free(&ssl);
@@ -1557,13 +1547,13 @@ void ssl_set_hostname_twice(char *input_hostname0, char *input_hostname1)
     mbedtls_ssl_init(&ssl);
     USE_PSA_INIT();
 
-    TEST_ASSERT(mbedtls_ssl_set_hostname(&ssl, input_hostname0) == 0);
+    TEST_EQUAL(mbedtls_ssl_set_hostname(&ssl, input_hostname0),  0);
     output_hostname = mbedtls_ssl_get_hostname(&ssl);
-    TEST_ASSERT(strcmp(input_hostname0, output_hostname) == 0);
+    TEST_EQUAL(strcmp(input_hostname0, output_hostname),  0);
 
-    TEST_ASSERT(mbedtls_ssl_set_hostname(&ssl, input_hostname1) == 0);
+    TEST_EQUAL(mbedtls_ssl_set_hostname(&ssl, input_hostname1),  0);
     output_hostname = mbedtls_ssl_get_hostname(&ssl);
-    TEST_ASSERT(strcmp(input_hostname1, output_hostname) == 0);
+    TEST_EQUAL(strcmp(input_hostname1, output_hostname),  0);
 
 exit:
     mbedtls_ssl_free(&ssl);
@@ -1601,7 +1591,7 @@ void ssl_crypt_record(int cipher_type, int hash_id,
                                             (size_t) cid0_len,
                                             (size_t) cid1_len);
 
-    TEST_ASSERT(ret == 0);
+    TEST_EQUAL(ret,  0);
 
     TEST_CALLOC(buf, buflen);
 
@@ -1660,7 +1650,7 @@ void ssl_crypt_record(int cipher_type, int hash_id,
             /* DTLS 1.2 + CID hides the real content type and
              * uses a special CID content type in the protected
              * record. Double-check this. */
-            TEST_ASSERT(rec.type == MBEDTLS_SSL_MSG_CID);
+            TEST_EQUAL(rec.type,  MBEDTLS_SSL_MSG_CID);
         }
 #endif /* MBEDTLS_SSL_DTLS_CONNECTION_ID */
 
@@ -1669,24 +1659,24 @@ void ssl_crypt_record(int cipher_type, int hash_id,
             /* TLS 1.3 hides the real content type and
              * always uses Application Data as the content type
              * for protected records. Double-check this. */
-            TEST_ASSERT(rec.type == MBEDTLS_SSL_MSG_APPLICATION_DATA);
+            TEST_EQUAL(rec.type,  MBEDTLS_SSL_MSG_APPLICATION_DATA);
         }
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3 */
 
         /* Decrypt record with t_dec */
         ret = mbedtls_ssl_decrypt_buf(&ssl, t_dec, &rec);
-        TEST_ASSERT(ret == 0);
+        TEST_EQUAL(ret,  0);
 
         /* Compare results */
-        TEST_ASSERT(rec.type == rec_backup.type);
-        TEST_ASSERT(memcmp(rec.ctr, rec_backup.ctr, 8) == 0);
-        TEST_ASSERT(rec.ver[0] == rec_backup.ver[0]);
-        TEST_ASSERT(rec.ver[1] == rec_backup.ver[1]);
-        TEST_ASSERT(rec.data_len == rec_backup.data_len);
-        TEST_ASSERT(rec.data_offset == rec_backup.data_offset);
-        TEST_ASSERT(memcmp(rec.buf + rec.data_offset,
-                           rec_backup.buf + rec_backup.data_offset,
-                           rec.data_len) == 0);
+        TEST_EQUAL(rec.type,  rec_backup.type);
+        TEST_EQUAL(memcmp(rec.ctr, rec_backup.ctr, 8),  0);
+        TEST_EQUAL(rec.ver[0],  rec_backup.ver[0]);
+        TEST_EQUAL(rec.ver[1],  rec_backup.ver[1]);
+        TEST_EQUAL(rec.data_len,  rec_backup.data_len);
+        TEST_EQUAL(rec.data_offset,  rec_backup.data_offset);
+        TEST_EQUAL(memcmp(rec.buf + rec.data_offset,
+                          rec_backup.buf + rec_backup.data_offset,
+                          rec.data_len),  0);
     }
 
 exit:
@@ -1754,7 +1744,7 @@ void ssl_crypt_record_small(int cipher_type, int hash_id,
                                             (size_t) cid0_len,
                                             (size_t) cid1_len);
 
-    TEST_ASSERT(ret == 0);
+    TEST_EQUAL(ret,  0);
 
     TEST_CALLOC(buf, buflen);
 
@@ -1819,7 +1809,7 @@ void ssl_crypt_record_small(int cipher_type, int hash_id,
                 /* DTLS 1.2 + CID hides the real content type and
                  * uses a special CID content type in the protected
                  * record. Double-check this. */
-                TEST_ASSERT(rec.type == MBEDTLS_SSL_MSG_CID);
+                TEST_EQUAL(rec.type,  MBEDTLS_SSL_MSG_CID);
             }
 #endif /* MBEDTLS_SSL_DTLS_CONNECTION_ID */
 
@@ -1828,26 +1818,26 @@ void ssl_crypt_record_small(int cipher_type, int hash_id,
                 /* TLS 1.3 hides the real content type and
                  * always uses Application Data as the content type
                  * for protected records. Double-check this. */
-                TEST_ASSERT(rec.type == MBEDTLS_SSL_MSG_APPLICATION_DATA);
+                TEST_EQUAL(rec.type,  MBEDTLS_SSL_MSG_APPLICATION_DATA);
             }
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3 */
 
             /* Decrypt record with t_dec */
-            TEST_ASSERT(mbedtls_ssl_decrypt_buf(&ssl, t_dec, &rec) == 0);
+            TEST_EQUAL(mbedtls_ssl_decrypt_buf(&ssl, t_dec, &rec),  0);
 
             /* Compare results */
-            TEST_ASSERT(rec.type == rec_backup.type);
-            TEST_ASSERT(memcmp(rec.ctr, rec_backup.ctr, 8) == 0);
-            TEST_ASSERT(rec.ver[0] == rec_backup.ver[0]);
-            TEST_ASSERT(rec.ver[1] == rec_backup.ver[1]);
-            TEST_ASSERT(rec.data_len == rec_backup.data_len);
-            TEST_ASSERT(rec.data_offset == rec_backup.data_offset);
-            TEST_ASSERT(memcmp(rec.buf + rec.data_offset,
-                               rec_backup.buf + rec_backup.data_offset,
-                               rec.data_len) == 0);
+            TEST_EQUAL(rec.type,  rec_backup.type);
+            TEST_EQUAL(memcmp(rec.ctr, rec_backup.ctr, 8),  0);
+            TEST_EQUAL(rec.ver[0],  rec_backup.ver[0]);
+            TEST_EQUAL(rec.ver[1],  rec_backup.ver[1]);
+            TEST_EQUAL(rec.data_len,  rec_backup.data_len);
+            TEST_EQUAL(rec.data_offset,  rec_backup.data_offset);
+            TEST_EQUAL(memcmp(rec.buf + rec.data_offset,
+                              rec_backup.buf + rec_backup.data_offset,
+                              rec.data_len),  0);
         }
 
-        TEST_ASSERT(seen_success == 1);
+        TEST_EQUAL(seen_success,  1);
     }
 
 exit:
@@ -1886,16 +1876,16 @@ void ssl_tls13_hkdf_expand_label(int hash_alg,
 
     /* Check sanity of test parameters. */
     TEST_ASSERT((size_t) desired_length <= sizeof(dst));
-    TEST_ASSERT((size_t) desired_length == expected->len);
+    TEST_EQUAL((size_t) desired_length,  expected->len);
 
     PSA_INIT();
 
-    TEST_ASSERT(mbedtls_ssl_tls13_hkdf_expand_label(
-                    (psa_algorithm_t) hash_alg,
-                    secret->x, secret->len,
-                    lbl, lbl_len,
-                    ctx->x, ctx->len,
-                    dst, desired_length) == 0);
+    TEST_EQUAL(mbedtls_ssl_tls13_hkdf_expand_label(
+                   (psa_algorithm_t) hash_alg,
+                   secret->x, secret->len,
+                   lbl, lbl_len,
+                   ctx->x, ctx->len,
+                   dst, desired_length),  0);
 
     TEST_MEMORY_COMPARE(dst, (size_t) desired_length,
                         expected->x, (size_t) expected->len);
@@ -1919,7 +1909,7 @@ void ssl_tls13_traffic_key_generation(int hash_alg,
     mbedtls_ssl_key_set keys;
 
     /* Check sanity of test parameters. */
-    TEST_ASSERT(client_secret->len == server_secret->len);
+    TEST_EQUAL(client_secret->len,  server_secret->len);
     TEST_ASSERT(
         expected_client_write_iv->len == expected_server_write_iv->len &&
         expected_client_write_iv->len == (size_t) desired_iv_len);
@@ -1984,17 +1974,17 @@ void ssl_tls13_derive_secret(int hash_alg,
 
     /* Check sanity of test parameters. */
     TEST_ASSERT((size_t) desired_length <= sizeof(dst));
-    TEST_ASSERT((size_t) desired_length == expected->len);
+    TEST_EQUAL((size_t) desired_length,  expected->len);
 
     PSA_INIT();
 
-    TEST_ASSERT(mbedtls_ssl_tls13_derive_secret(
-                    (psa_algorithm_t) hash_alg,
-                    secret->x, secret->len,
-                    lbl, lbl_len,
-                    ctx->x, ctx->len,
-                    already_hashed,
-                    dst, desired_length) == 0);
+    TEST_EQUAL(mbedtls_ssl_tls13_derive_secret(
+                   (psa_algorithm_t) hash_alg,
+                   secret->x, secret->len,
+                   lbl, lbl_len,
+                   ctx->x, ctx->len,
+                   already_hashed,
+                   dst, desired_length),  0);
 
     TEST_MEMORY_COMPARE(dst, desired_length,
                         expected->x, desired_length);
@@ -2016,16 +2006,16 @@ void ssl_tls13_exporter(int hash_alg,
 
     /* Check sanity of test parameters. */
     TEST_ASSERT((size_t) desired_length <= sizeof(dst));
-    TEST_ASSERT((size_t) desired_length == expected->len);
+    TEST_EQUAL((size_t) desired_length,  expected->len);
 
     PSA_INIT();
 
-    TEST_ASSERT(mbedtls_ssl_tls13_exporter(
-                    (psa_algorithm_t) hash_alg,
-                    secret->x, secret->len,
-                    (unsigned char *) label, strlen(label),
-                    (unsigned char *) context_value, strlen(context_value),
-                    dst, desired_length) == 0);
+    TEST_EQUAL(mbedtls_ssl_tls13_exporter(
+                   (psa_algorithm_t) hash_alg,
+                   secret->x, secret->len,
+                   (unsigned char *) label, strlen(label),
+                   (unsigned char *) context_value, strlen(context_value),
+                   dst, desired_length),  0);
 
     TEST_MEMORY_COMPARE(dst, desired_length,
                         expected->x, desired_length);
@@ -2055,9 +2045,9 @@ void ssl_tls13_derive_early_secrets(int hash_alg,
 
     PSA_INIT();
 
-    TEST_ASSERT(mbedtls_ssl_tls13_derive_early_secrets(
-                    alg, secret->x, transcript->x, transcript->len,
-                    &secrets) == 0);
+    TEST_EQUAL(mbedtls_ssl_tls13_derive_early_secrets(
+                   alg, secret->x, transcript->x, transcript->len,
+                   &secrets),  0);
 
     TEST_MEMORY_COMPARE(secrets.client_early_traffic_secret, hash_len,
                         traffic_expected->x, traffic_expected->len);
@@ -2089,9 +2079,9 @@ void ssl_tls13_derive_handshake_secrets(int hash_alg,
 
     PSA_INIT();
 
-    TEST_ASSERT(mbedtls_ssl_tls13_derive_handshake_secrets(
-                    alg, secret->x, transcript->x, transcript->len,
-                    &secrets) == 0);
+    TEST_EQUAL(mbedtls_ssl_tls13_derive_handshake_secrets(
+                   alg, secret->x, transcript->x, transcript->len,
+                   &secrets),  0);
 
     TEST_MEMORY_COMPARE(secrets.client_handshake_traffic_secret, hash_len,
                         client_expected->x, client_expected->len);
@@ -2125,9 +2115,9 @@ void ssl_tls13_derive_application_secrets(int hash_alg,
 
     PSA_INIT();
 
-    TEST_ASSERT(mbedtls_ssl_tls13_derive_application_secrets(
-                    alg, secret->x, transcript->x, transcript->len,
-                    &secrets) == 0);
+    TEST_EQUAL(mbedtls_ssl_tls13_derive_application_secrets(
+                   alg, secret->x, transcript->x, transcript->len,
+                   &secrets),  0);
 
     TEST_MEMORY_COMPARE(secrets.client_application_traffic_secret_N, hash_len,
                         client_expected->x, client_expected->len);
@@ -2159,9 +2149,9 @@ void ssl_tls13_derive_resumption_secrets(int hash_alg,
 
     PSA_INIT();
 
-    TEST_ASSERT(mbedtls_ssl_tls13_derive_resumption_master_secret(
-                    alg, secret->x, transcript->x, transcript->len,
-                    &secrets) == 0);
+    TEST_EQUAL(mbedtls_ssl_tls13_derive_resumption_master_secret(
+                   alg, secret->x, transcript->x, transcript->len,
+                   &secrets),  0);
 
     TEST_MEMORY_COMPARE(secrets.resumption_master_secret, hash_len,
                         resumption_expected->x, resumption_expected->len);
@@ -2189,13 +2179,13 @@ void ssl_tls13_create_psk_binder(int hash_alg,
 
     PSA_INIT();
 
-    TEST_ASSERT(mbedtls_ssl_tls13_create_psk_binder(
-                    NULL,  /* SSL context for debugging only */
-                    alg,
-                    psk->x, psk->len,
-                    psk_type,
-                    transcript->x,
-                    binder) == 0);
+    TEST_EQUAL(mbedtls_ssl_tls13_create_psk_binder(
+                   NULL,   /* SSL context for debugging only */
+                   alg,
+                   psk->x, psk->len,
+                   psk_type,
+                   transcript->x,
+                   binder),  0);
 
     TEST_MEMORY_COMPARE(binder, hash_len,
                         binder_expected->x, binder_expected->len);
@@ -2237,8 +2227,8 @@ void ssl_tls13_record_protection(int ciphersuite,
         other_endpoint = MBEDTLS_SSL_IS_SERVER;
     }
 
-    TEST_ASSERT(server_write_key->len == client_write_key->len);
-    TEST_ASSERT(server_write_iv->len  == client_write_iv->len);
+    TEST_EQUAL(server_write_key->len,  client_write_key->len);
+    TEST_EQUAL(server_write_iv->len,  client_write_iv->len);
 
     memcpy(keys.client_write_key,
            client_write_key->x, client_write_key->len);
@@ -2254,12 +2244,12 @@ void ssl_tls13_record_protection(int ciphersuite,
 
     MD_OR_USE_PSA_INIT();
 
-    TEST_ASSERT(mbedtls_ssl_tls13_populate_transform(
-                    &transform_send, endpoint,
-                    ciphersuite, &keys, NULL) == 0);
-    TEST_ASSERT(mbedtls_ssl_tls13_populate_transform(
-                    &transform_recv, other_endpoint,
-                    ciphersuite, &keys, NULL) == 0);
+    TEST_EQUAL(mbedtls_ssl_tls13_populate_transform(
+                   &transform_send, endpoint,
+                   ciphersuite, &keys, NULL),  0);
+    TEST_EQUAL(mbedtls_ssl_tls13_populate_transform(
+                   &transform_recv, other_endpoint,
+                   ciphersuite, &keys, NULL),  0);
 
     /* Make sure we have enough space in the buffer even if
      * we use more padding than the KAT. */
@@ -2286,14 +2276,14 @@ void ssl_tls13_record_protection(int ciphersuite,
     memset(&rec.ctr[0], 0, 8);
     rec.ctr[7] = ctr;
 
-    TEST_ASSERT(mbedtls_ssl_encrypt_buf(NULL, &transform_send, &rec) == 0);
+    TEST_EQUAL(mbedtls_ssl_encrypt_buf(NULL, &transform_send, &rec),  0);
 
     if (padding_used == MBEDTLS_SSL_CID_TLS1_3_PADDING_GRANULARITY) {
         TEST_MEMORY_COMPARE(rec.buf + rec.data_offset, rec.data_len,
                             ciphertext->x, ciphertext->len);
     }
 
-    TEST_ASSERT(mbedtls_ssl_decrypt_buf(NULL, &transform_recv, &rec) == 0);
+    TEST_EQUAL(mbedtls_ssl_decrypt_buf(NULL, &transform_recv, &rec),  0);
     TEST_MEMORY_COMPARE(rec.buf + rec.data_offset, rec.data_len,
                         plaintext->x, plaintext->len);
 
@@ -2315,11 +2305,11 @@ void ssl_tls13_key_evolution(int hash_alg,
 
     PSA_INIT();
 
-    TEST_ASSERT(mbedtls_ssl_tls13_evolve_secret(
-                    (psa_algorithm_t) hash_alg,
-                    secret->len ? secret->x : NULL,
-                    input->len ? input->x : NULL, input->len,
-                    secret_new) == 0);
+    TEST_EQUAL(mbedtls_ssl_tls13_evolve_secret(
+                   (psa_algorithm_t) hash_alg,
+                   secret->len ? secret->x : NULL,
+                   input->len ? input->x : NULL, input->len,
+                   secret_new),  0);
 
     TEST_MEMORY_COMPARE(secret_new, (size_t) expected->len,
                         expected->x, (size_t) expected->len);
@@ -2342,13 +2332,13 @@ void ssl_tls_prf(int type, data_t *secret, data_t *random,
 
     MD_OR_USE_PSA_INIT();
 
-    TEST_ASSERT(mbedtls_ssl_tls_prf(type, secret->x, secret->len,
-                                    label, random->x, random->len,
-                                    output, result_str->len) == exp_ret);
+    TEST_EQUAL(mbedtls_ssl_tls_prf(type, secret->x, secret->len,
+                                   label, random->x, random->len,
+                                   output, result_str->len),  exp_ret);
 
     if (exp_ret == 0) {
-        TEST_ASSERT(mbedtls_test_hexcmp(output, result_str->x,
-                                        result_str->len, result_str->len) == 0);
+        TEST_EQUAL(mbedtls_test_hexcmp(output, result_str->x,
+                                       result_str->len, result_str->len),  0);
     }
 exit:
 
@@ -2378,94 +2368,94 @@ void ssl_serialize_session_save_load(int ticket_len, char *crt_file,
     ((void) crt_file);
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
     if (tls_version == MBEDTLS_SSL_VERSION_TLS1_3) {
-        TEST_ASSERT(mbedtls_test_ssl_tls13_populate_session(
-                        &original, 0, endpoint_type) == 0);
+        TEST_EQUAL(mbedtls_test_ssl_tls13_populate_session(
+                       &original, 0, endpoint_type),  0);
     }
 #endif
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_2)
     if (tls_version == MBEDTLS_SSL_VERSION_TLS1_2) {
-        TEST_ASSERT(mbedtls_test_ssl_tls12_populate_session(
-                        &original, ticket_len, endpoint_type, crt_file) == 0);
+        TEST_EQUAL(mbedtls_test_ssl_tls12_populate_session(
+                       &original, ticket_len, endpoint_type, crt_file),  0);
     }
 #endif
 
     /* Serialize it */
-    TEST_ASSERT(mbedtls_ssl_session_save(&original, NULL, 0, &len)
-                == MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL);
+    TEST_EQUAL(mbedtls_ssl_session_save(&original, NULL, 0, &len),
+               MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL);
     TEST_CALLOC(buf, len);
-    TEST_ASSERT(mbedtls_ssl_session_save(&original, buf, len, &len)
-                == 0);
+    TEST_EQUAL(mbedtls_ssl_session_save(&original, buf, len, &len),
+               0);
 
     /* Restore session from serialized data */
-    TEST_ASSERT(mbedtls_ssl_session_load(&restored, buf, len) == 0);
+    TEST_EQUAL(mbedtls_ssl_session_load(&restored, buf, len),  0);
 
     /*
      * Make sure both session structures are identical
      */
 #if defined(MBEDTLS_HAVE_TIME)
     if (tls_version == MBEDTLS_SSL_VERSION_TLS1_2) {
-        TEST_ASSERT(original.start == restored.start);
+        TEST_EQUAL(original.start,  restored.start);
     }
 #if defined(MBEDTLS_SSL_SESSION_TICKETS) && defined(MBEDTLS_SSL_SRV_C)
-    TEST_ASSERT(original.ticket_creation_time == restored.ticket_creation_time);
+    TEST_EQUAL(original.ticket_creation_time,  restored.ticket_creation_time);
 #endif
 #endif /* MBEDTLS_HAVE_TIME */
 
-    TEST_ASSERT(original.tls_version == restored.tls_version);
-    TEST_ASSERT(original.endpoint == restored.endpoint);
-    TEST_ASSERT(original.ciphersuite == restored.ciphersuite);
+    TEST_EQUAL(original.tls_version,  restored.tls_version);
+    TEST_EQUAL(original.endpoint,  restored.endpoint);
+    TEST_EQUAL(original.ciphersuite,  restored.ciphersuite);
 #if defined(MBEDTLS_SSL_PROTO_TLS1_2)
     if (tls_version == MBEDTLS_SSL_VERSION_TLS1_2) {
-        TEST_ASSERT(original.id_len == restored.id_len);
-        TEST_ASSERT(memcmp(original.id,
-                           restored.id, sizeof(original.id)) == 0);
-        TEST_ASSERT(memcmp(original.master,
-                           restored.master, sizeof(original.master)) == 0);
+        TEST_EQUAL(original.id_len,  restored.id_len);
+        TEST_EQUAL(memcmp(original.id,
+                          restored.id, sizeof(original.id)),  0);
+        TEST_EQUAL(memcmp(original.master,
+                          restored.master, sizeof(original.master)),  0);
 
 #if defined(MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED)
 #if defined(MBEDTLS_SSL_KEEP_PEER_CERTIFICATE)
         TEST_ASSERT((original.peer_cert == NULL) ==
                     (restored.peer_cert == NULL));
         if (original.peer_cert != NULL) {
-            TEST_ASSERT(original.peer_cert->raw.len ==
-                        restored.peer_cert->raw.len);
-            TEST_ASSERT(memcmp(original.peer_cert->raw.p,
-                               restored.peer_cert->raw.p,
-                               original.peer_cert->raw.len) == 0);
+            TEST_EQUAL(original.peer_cert->raw.len,
+                       restored.peer_cert->raw.len);
+            TEST_EQUAL(memcmp(original.peer_cert->raw.p,
+                              restored.peer_cert->raw.p,
+                              original.peer_cert->raw.len),  0);
         }
 #else /* MBEDTLS_SSL_KEEP_PEER_CERTIFICATE */
-        TEST_ASSERT(original.peer_cert_digest_type ==
-                    restored.peer_cert_digest_type);
-        TEST_ASSERT(original.peer_cert_digest_len ==
-                    restored.peer_cert_digest_len);
+        TEST_EQUAL(original.peer_cert_digest_type,
+                   restored.peer_cert_digest_type);
+        TEST_EQUAL(original.peer_cert_digest_len,
+                   restored.peer_cert_digest_len);
         TEST_ASSERT((original.peer_cert_digest == NULL) ==
                     (restored.peer_cert_digest == NULL));
         if (original.peer_cert_digest != NULL) {
-            TEST_ASSERT(memcmp(original.peer_cert_digest,
-                               restored.peer_cert_digest,
-                               original.peer_cert_digest_len) == 0);
+            TEST_EQUAL(memcmp(original.peer_cert_digest,
+                              restored.peer_cert_digest,
+                              original.peer_cert_digest_len),  0);
         }
 #endif /* MBEDTLS_SSL_KEEP_PEER_CERTIFICATE */
 #endif /* MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED */
-        TEST_ASSERT(original.verify_result == restored.verify_result);
+        TEST_EQUAL(original.verify_result,  restored.verify_result);
 
 #if defined(MBEDTLS_SSL_MAX_FRAGMENT_LENGTH)
-        TEST_ASSERT(original.mfl_code == restored.mfl_code);
+        TEST_EQUAL(original.mfl_code,  restored.mfl_code);
 #endif
 
 #if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC)
-        TEST_ASSERT(original.encrypt_then_mac == restored.encrypt_then_mac);
+        TEST_EQUAL(original.encrypt_then_mac,  restored.encrypt_then_mac);
 #endif
 #if defined(MBEDTLS_SSL_SESSION_TICKETS) && defined(MBEDTLS_SSL_CLI_C)
-        TEST_ASSERT(original.ticket_len == restored.ticket_len);
+        TEST_EQUAL(original.ticket_len,  restored.ticket_len);
         if (original.ticket_len != 0) {
             TEST_ASSERT(original.ticket != NULL);
             TEST_ASSERT(restored.ticket != NULL);
-            TEST_ASSERT(memcmp(original.ticket,
-                               restored.ticket, original.ticket_len) == 0);
+            TEST_EQUAL(memcmp(original.ticket,
+                              restored.ticket, original.ticket_len),  0);
         }
-        TEST_ASSERT(original.ticket_lifetime == restored.ticket_lifetime);
+        TEST_EQUAL(original.ticket_lifetime,  restored.ticket_lifetime);
 #endif
     }
 #endif /* MBEDTLS_SSL_PROTO_TLS1_2 */
@@ -2473,15 +2463,15 @@ void ssl_serialize_session_save_load(int ticket_len, char *crt_file,
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
     if (tls_version == MBEDTLS_SSL_VERSION_TLS1_3) {
 #if defined(MBEDTLS_SSL_SESSION_TICKETS)
-        TEST_ASSERT(original.ticket_age_add == restored.ticket_age_add);
-        TEST_ASSERT(original.ticket_flags == restored.ticket_flags);
-        TEST_ASSERT(original.resumption_key_len == restored.resumption_key_len);
+        TEST_EQUAL(original.ticket_age_add,  restored.ticket_age_add);
+        TEST_EQUAL(original.ticket_flags,  restored.ticket_flags);
+        TEST_EQUAL(original.resumption_key_len,  restored.resumption_key_len);
         if (original.resumption_key_len != 0) {
             TEST_ASSERT(original.resumption_key != NULL);
             TEST_ASSERT(restored.resumption_key != NULL);
-            TEST_ASSERT(memcmp(original.resumption_key,
-                               restored.resumption_key,
-                               original.resumption_key_len) == 0);
+            TEST_EQUAL(memcmp(original.resumption_key,
+                              restored.resumption_key,
+                              original.resumption_key_len),  0);
         }
 #endif /* MBEDTLS_SSL_SESSION_TICKETS */
 
@@ -2502,16 +2492,16 @@ void ssl_serialize_session_save_load(int ticket_len, char *crt_file,
         if (endpoint_type == MBEDTLS_SSL_IS_CLIENT) {
 #if defined(MBEDTLS_SSL_SESSION_TICKETS)
 #if defined(MBEDTLS_HAVE_TIME)
-            TEST_ASSERT(original.ticket_reception_time == restored.ticket_reception_time);
+            TEST_EQUAL(original.ticket_reception_time,  restored.ticket_reception_time);
 #endif
-            TEST_ASSERT(original.ticket_lifetime == restored.ticket_lifetime);
-            TEST_ASSERT(original.ticket_len == restored.ticket_len);
+            TEST_EQUAL(original.ticket_lifetime,  restored.ticket_lifetime);
+            TEST_EQUAL(original.ticket_len,  restored.ticket_len);
             if (original.ticket_len != 0) {
                 TEST_ASSERT(original.ticket != NULL);
                 TEST_ASSERT(restored.ticket != NULL);
-                TEST_ASSERT(memcmp(original.ticket,
-                                   restored.ticket,
-                                   original.ticket_len) == 0);
+                TEST_EQUAL(memcmp(original.ticket,
+                                  restored.ticket,
+                                  original.ticket_len),  0);
             }
 #if defined(MBEDTLS_SSL_SERVER_NAME_INDICATION)
             TEST_ASSERT(original.hostname != NULL);
@@ -2526,12 +2516,12 @@ void ssl_serialize_session_save_load(int ticket_len, char *crt_file,
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3 */
 
 #if defined(MBEDTLS_SSL_EARLY_DATA)
-    TEST_ASSERT(
-        original.max_early_data_size == restored.max_early_data_size);
+    TEST_EQUAL(
+        original.max_early_data_size,  restored.max_early_data_size);
 #endif
 
 #if defined(MBEDTLS_SSL_RECORD_SIZE_LIMIT)
-    TEST_ASSERT(original.record_size_limit == restored.record_size_limit);
+    TEST_EQUAL(original.record_size_limit,  restored.record_size_limit);
 #endif
 
 exit:
@@ -2563,15 +2553,15 @@ void ssl_serialize_session_load_save(int ticket_len, char *crt_file,
     switch (tls_version) {
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
         case MBEDTLS_SSL_VERSION_TLS1_3:
-            TEST_ASSERT(mbedtls_test_ssl_tls13_populate_session(
-                            &session, 0, endpoint_type) == 0);
+            TEST_EQUAL(mbedtls_test_ssl_tls13_populate_session(
+                           &session, 0, endpoint_type),  0);
             break;
 #endif
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_2)
         case MBEDTLS_SSL_VERSION_TLS1_2:
-            TEST_ASSERT(mbedtls_test_ssl_tls12_populate_session(
-                            &session, ticket_len, endpoint_type, crt_file) == 0);
+            TEST_EQUAL(mbedtls_test_ssl_tls12_populate_session(
+                           &session, ticket_len, endpoint_type, crt_file),  0);
             break;
 #endif
         default:
@@ -2581,31 +2571,31 @@ void ssl_serialize_session_load_save(int ticket_len, char *crt_file,
     }
 
     /* Get desired buffer size for serializing */
-    TEST_ASSERT(mbedtls_ssl_session_save(&session, NULL, 0, &len0)
-                == MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL);
+    TEST_EQUAL(mbedtls_ssl_session_save(&session, NULL, 0, &len0),
+               MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL);
 
     /* Allocate first buffer */
     buf1 = mbedtls_calloc(1, len0);
     TEST_ASSERT(buf1 != NULL);
 
     /* Serialize to buffer and free live session */
-    TEST_ASSERT(mbedtls_ssl_session_save(&session, buf1, len0, &len1)
-                == 0);
-    TEST_ASSERT(len0 == len1);
+    TEST_EQUAL(mbedtls_ssl_session_save(&session, buf1, len0, &len1),
+               0);
+    TEST_EQUAL(len0,  len1);
     mbedtls_ssl_session_free(&session);
 
     /* Restore session from serialized data */
-    TEST_ASSERT(mbedtls_ssl_session_load(&session, buf1, len1) == 0);
+    TEST_EQUAL(mbedtls_ssl_session_load(&session, buf1, len1),  0);
 
     /* Allocate second buffer and serialize to it */
     buf2 = mbedtls_calloc(1, len0);
     TEST_ASSERT(buf2 != NULL);
-    TEST_ASSERT(mbedtls_ssl_session_save(&session, buf2, len0, &len2)
-                == 0);
+    TEST_EQUAL(mbedtls_ssl_session_save(&session, buf2, len0, &len2),
+               0);
 
     /* Make sure both serialized versions are identical */
-    TEST_ASSERT(len1 == len2);
-    TEST_ASSERT(memcmp(buf1, buf2, len1) == 0);
+    TEST_EQUAL(len1,  len2);
+    TEST_EQUAL(memcmp(buf1, buf2, len1),  0);
 
 exit:
     mbedtls_ssl_session_free(&session);
@@ -2636,14 +2626,14 @@ void ssl_serialize_session_save_buf_size(int ticket_len, char *crt_file,
     switch (tls_version) {
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
         case MBEDTLS_SSL_VERSION_TLS1_3:
-            TEST_ASSERT(mbedtls_test_ssl_tls13_populate_session(
-                            &session, 0, endpoint_type) == 0);
+            TEST_EQUAL(mbedtls_test_ssl_tls13_populate_session(
+                           &session, 0, endpoint_type),  0);
             break;
 #endif
 #if defined(MBEDTLS_SSL_PROTO_TLS1_2)
         case MBEDTLS_SSL_VERSION_TLS1_2:
-            TEST_ASSERT(mbedtls_test_ssl_tls12_populate_session(
-                            &session, ticket_len, endpoint_type, crt_file) == 0);
+            TEST_EQUAL(mbedtls_test_ssl_tls12_populate_session(
+                           &session, ticket_len, endpoint_type, crt_file),  0);
             break;
 #endif
         default:
@@ -2652,8 +2642,8 @@ void ssl_serialize_session_save_buf_size(int ticket_len, char *crt_file,
             break;
     }
 
-    TEST_ASSERT(mbedtls_ssl_session_save(&session, NULL, 0, &good_len)
-                == MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL);
+    TEST_EQUAL(mbedtls_ssl_session_save(&session, NULL, 0, &good_len),
+               MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL);
 
     /* Try all possible bad lengths */
     for (bad_len = 1; bad_len < good_len; bad_len++) {
@@ -2661,10 +2651,10 @@ void ssl_serialize_session_save_buf_size(int ticket_len, char *crt_file,
         mbedtls_free(buf);
         buf = NULL;
         TEST_CALLOC(buf, bad_len);
-        TEST_ASSERT(mbedtls_ssl_session_save(&session, buf, bad_len,
-                                             &test_len)
-                    == MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL);
-        TEST_ASSERT(test_len == good_len);
+        TEST_EQUAL(mbedtls_ssl_session_save(&session, buf, bad_len,
+                                            &test_len),
+                   MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL);
+        TEST_EQUAL(test_len,  good_len);
     }
 
 exit:
@@ -2695,15 +2685,15 @@ void ssl_serialize_session_load_buf_size(int ticket_len, char *crt_file,
     switch (tls_version) {
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
         case MBEDTLS_SSL_VERSION_TLS1_3:
-            TEST_ASSERT(mbedtls_test_ssl_tls13_populate_session(
-                            &session, 0, endpoint_type) == 0);
+            TEST_EQUAL(mbedtls_test_ssl_tls13_populate_session(
+                           &session, 0, endpoint_type),  0);
             break;
 #endif
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_2)
         case MBEDTLS_SSL_VERSION_TLS1_2:
-            TEST_ASSERT(mbedtls_test_ssl_tls12_populate_session(
-                            &session, ticket_len, endpoint_type, crt_file) == 0);
+            TEST_EQUAL(mbedtls_test_ssl_tls12_populate_session(
+                           &session, ticket_len, endpoint_type, crt_file),  0);
             break;
 #endif
 
@@ -2713,11 +2703,11 @@ void ssl_serialize_session_load_buf_size(int ticket_len, char *crt_file,
             break;
     }
 
-    TEST_ASSERT(mbedtls_ssl_session_save(&session, NULL, 0, &good_len)
-                == MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL);
+    TEST_EQUAL(mbedtls_ssl_session_save(&session, NULL, 0, &good_len),
+               MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL);
     TEST_CALLOC(good_buf, good_len);
-    TEST_ASSERT(mbedtls_ssl_session_save(&session, good_buf, good_len,
-                                         &good_len) == 0);
+    TEST_EQUAL(mbedtls_ssl_session_save(&session, good_buf, good_len,
+                                        &good_len),  0);
     mbedtls_ssl_session_free(&session);
 
     /* Try all possible bad lengths */
@@ -2728,8 +2718,8 @@ void ssl_serialize_session_load_buf_size(int ticket_len, char *crt_file,
         TEST_CALLOC_NONNULL(bad_buf, bad_len);
         memcpy(bad_buf, good_buf, bad_len);
 
-        TEST_ASSERT(mbedtls_ssl_session_load(&session, bad_buf, bad_len)
-                    == MBEDTLS_ERR_SSL_BAD_INPUT_DATA);
+        TEST_EQUAL(mbedtls_ssl_session_load(&session, bad_buf, bad_len),
+                   MBEDTLS_ERR_SSL_BAD_INPUT_DATA);
     }
 
 exit:
@@ -2764,14 +2754,14 @@ void ssl_session_serialize_version_check(int corrupt_major,
     switch (tls_version) {
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
         case MBEDTLS_SSL_VERSION_TLS1_3:
-            TEST_ASSERT(mbedtls_test_ssl_tls13_populate_session(
-                            &session, 0, endpoint_type) == 0);
+            TEST_EQUAL(mbedtls_test_ssl_tls13_populate_session(
+                           &session, 0, endpoint_type),  0);
             break;
 #endif
 #if defined(MBEDTLS_SSL_PROTO_TLS1_2)
         case MBEDTLS_SSL_VERSION_TLS1_2:
-            TEST_ASSERT(mbedtls_test_ssl_tls12_populate_session(
-                            &session, 0, endpoint_type, NULL) == 0);
+            TEST_EQUAL(mbedtls_test_ssl_tls12_populate_session(
+                           &session, 0, endpoint_type, NULL),  0);
 
             break;
 #endif
@@ -2782,18 +2772,18 @@ void ssl_session_serialize_version_check(int corrupt_major,
     }
 
     /* Infer length of serialized session. */
-    TEST_ASSERT(mbedtls_ssl_session_save(&session,
-                                         serialized_session,
-                                         sizeof(serialized_session),
-                                         &serialized_session_len) == 0);
+    TEST_EQUAL(mbedtls_ssl_session_save(&session,
+                                        serialized_session,
+                                        sizeof(serialized_session),
+                                        &serialized_session_len),  0);
 
     mbedtls_ssl_session_free(&session);
 
     /* Without any modification, we should be able to successfully
      * de-serialize the session - double-check that. */
-    TEST_ASSERT(mbedtls_ssl_session_load(&session,
-                                         serialized_session,
-                                         serialized_session_len) == 0);
+    TEST_EQUAL(mbedtls_ssl_session_load(&session,
+                                        serialized_session,
+                                        serialized_session_len),  0);
     mbedtls_ssl_session_free(&session);
 
     /* Go through the bytes in the serialized session header and
@@ -2812,10 +2802,10 @@ void ssl_session_serialize_version_check(int corrupt_major,
             *byte ^= corrupted_bit;
 
             /* Attempt to deserialize */
-            TEST_ASSERT(mbedtls_ssl_session_load(&session,
-                                                 serialized_session,
-                                                 serialized_session_len) ==
-                        MBEDTLS_ERR_SSL_VERSION_MISMATCH);
+            TEST_EQUAL(mbedtls_ssl_session_load(&session,
+                                                serialized_session,
+                                                serialized_session_len),
+                       MBEDTLS_ERR_SSL_VERSION_MISMATCH);
 
             /* Undo the change */
             *byte ^= corrupted_bit;
@@ -2840,15 +2830,15 @@ void ssl_session_id_accessors_check(int tls_version)
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
         case MBEDTLS_SSL_VERSION_TLS1_3:
             ciphersuite_id = MBEDTLS_TLS1_3_AES_128_GCM_SHA256;
-            TEST_ASSERT(mbedtls_test_ssl_tls13_populate_session(
-                            &session, 0, MBEDTLS_SSL_IS_SERVER) == 0);
+            TEST_EQUAL(mbedtls_test_ssl_tls13_populate_session(
+                           &session, 0, MBEDTLS_SSL_IS_SERVER),  0);
             break;
 #endif
 #if defined(MBEDTLS_SSL_PROTO_TLS1_2)
         case MBEDTLS_SSL_VERSION_TLS1_2:
             ciphersuite_id = MBEDTLS_TLS_PSK_WITH_AES_128_GCM_SHA256;
-            TEST_ASSERT(mbedtls_test_ssl_tls12_populate_session(
-                            &session, 0, MBEDTLS_SSL_IS_SERVER, NULL) == 0);
+            TEST_EQUAL(mbedtls_test_ssl_tls12_populate_session(
+                           &session, 0, MBEDTLS_SSL_IS_SERVER, NULL),  0);
 
             break;
 #endif
@@ -2857,15 +2847,18 @@ void ssl_session_id_accessors_check(int tls_version)
             TEST_ASSERT(0);
             break;
     }
+
+    /* We expect pointers to the same strings, not just strings with
+     * the same content. */
     TEST_ASSERT(*mbedtls_ssl_session_get_id(&session) == session.id);
-    TEST_ASSERT(mbedtls_ssl_session_get_id_len(&session) == session.id_len);
+    TEST_EQUAL(mbedtls_ssl_session_get_id_len(&session),  session.id_len);
     /* mbedtls_test_ssl_tls1x_populate_session sets a mock suite-id of 0xabcd */
-    TEST_ASSERT(mbedtls_ssl_session_get_ciphersuite_id(&session) == 0xabcd);
+    TEST_EQUAL(mbedtls_ssl_session_get_ciphersuite_id(&session),  0xabcd);
 
     /* Test setting a reference id for tls1.3 and tls1.2 */
     ciphersuite_info = mbedtls_ssl_ciphersuite_from_id(ciphersuite_id);
     if (ciphersuite_info != NULL) {
-        TEST_ASSERT(mbedtls_ssl_ciphersuite_get_id(ciphersuite_info) == ciphersuite_id);
+        TEST_EQUAL(mbedtls_ssl_ciphersuite_get_id(ciphersuite_info),  ciphersuite_id);
     }
 
 exit:
@@ -2888,15 +2881,15 @@ void mbedtls_endpoint_sanity(int endpoint_type)
 
     ret = mbedtls_test_ssl_endpoint_init(NULL, endpoint_type, &options,
                                          NULL, NULL, NULL);
-    TEST_ASSERT(MBEDTLS_ERR_SSL_BAD_INPUT_DATA == ret);
+    TEST_EQUAL(MBEDTLS_ERR_SSL_BAD_INPUT_DATA,  ret);
 
     ret = mbedtls_test_ssl_endpoint_certificate_init(NULL, options.pk_alg,
                                                      0, 0, 0);
-    TEST_ASSERT(MBEDTLS_ERR_SSL_BAD_INPUT_DATA == ret);
+    TEST_EQUAL(MBEDTLS_ERR_SSL_BAD_INPUT_DATA,  ret);
 
     ret = mbedtls_test_ssl_endpoint_init(&ep, endpoint_type, &options,
                                          NULL, NULL, NULL);
-    TEST_ASSERT(ret == 0);
+    TEST_EQUAL(ret,  0);
 
 exit:
     mbedtls_test_ssl_endpoint_free(&ep, NULL);
@@ -2940,7 +2933,7 @@ void move_handshake_to_state(int endpoint_type, int tls_version, int state, int 
 
     ret = mbedtls_test_ssl_endpoint_init(&base_ep, endpoint_type, &options,
                                          NULL, NULL, NULL);
-    TEST_ASSERT(ret == 0);
+    TEST_EQUAL(ret,  0);
 
     ret = mbedtls_test_ssl_endpoint_init(
         &second_ep,
@@ -2948,12 +2941,12 @@ void move_handshake_to_state(int endpoint_type, int tls_version, int state, int 
         MBEDTLS_SSL_IS_CLIENT : MBEDTLS_SSL_IS_SERVER,
         &options, NULL, NULL, NULL);
 
-    TEST_ASSERT(ret == 0);
+    TEST_EQUAL(ret,  0);
 
     ret = mbedtls_test_mock_socket_connect(&(base_ep.socket),
                                            &(second_ep.socket),
                                            BUFFSIZE);
-    TEST_ASSERT(ret == 0);
+    TEST_EQUAL(ret,  0);
 
     ret = mbedtls_test_move_handshake_to_state(&(base_ep.ssl),
                                                &(second_ep.ssl),
@@ -2962,7 +2955,7 @@ void move_handshake_to_state(int endpoint_type, int tls_version, int state, int 
         TEST_ASSERT(ret == 0 ||
                     ret == MBEDTLS_ERR_SSL_WANT_READ ||
                     ret == MBEDTLS_ERR_SSL_WANT_WRITE);
-        TEST_ASSERT(base_ep.ssl.state == state);
+        TEST_EQUAL(base_ep.ssl.state,  state);
     } else {
         TEST_ASSERT(ret != 0 &&
                     ret != MBEDTLS_ERR_SSL_WANT_READ &&
@@ -3415,13 +3408,13 @@ void test_multiple_psks()
     mbedtls_ssl_config_init(&conf);
     MD_OR_USE_PSA_INIT();
 
-    TEST_ASSERT(mbedtls_ssl_conf_psk(&conf,
-                                     psk0, sizeof(psk0),
-                                     psk0_identity, sizeof(psk0_identity)) == 0);
-    TEST_ASSERT(mbedtls_ssl_conf_psk(&conf,
-                                     psk1, sizeof(psk1),
-                                     psk1_identity, sizeof(psk1_identity)) ==
-                MBEDTLS_ERR_SSL_FEATURE_UNAVAILABLE);
+    TEST_EQUAL(mbedtls_ssl_conf_psk(&conf,
+                                    psk0, sizeof(psk0),
+                                    psk0_identity, sizeof(psk0_identity)), 0);
+    TEST_EQUAL(mbedtls_ssl_conf_psk(&conf,
+                                    psk1, sizeof(psk1),
+                                    psk1_identity, sizeof(psk1_identity)),
+               MBEDTLS_ERR_SSL_FEATURE_UNAVAILABLE);
 
 exit:
     mbedtls_ssl_config_free(&conf);
@@ -3460,43 +3453,43 @@ void test_multiple_psks_opaque(int mode)
     switch (mode) {
         case 0:
 
-            TEST_ASSERT(mbedtls_ssl_conf_psk(&conf,
-                                             psk0_raw, sizeof(psk0_raw),
-                                             psk0_raw_identity, sizeof(psk0_raw_identity))
-                        == 0);
-            TEST_ASSERT(mbedtls_ssl_conf_psk_opaque(&conf,
-                                                    psk1_opaque,
-                                                    psk1_opaque_identity,
-                                                    sizeof(psk1_opaque_identity))
-                        == MBEDTLS_ERR_SSL_FEATURE_UNAVAILABLE);
+            TEST_EQUAL(mbedtls_ssl_conf_psk(&conf,
+                                            psk0_raw, sizeof(psk0_raw),
+                                            psk0_raw_identity, sizeof(psk0_raw_identity)),
+                       0);
+            TEST_EQUAL(mbedtls_ssl_conf_psk_opaque(&conf,
+                                                   psk1_opaque,
+                                                   psk1_opaque_identity,
+                                                   sizeof(psk1_opaque_identity)),
+                       MBEDTLS_ERR_SSL_FEATURE_UNAVAILABLE);
             break;
 
         case 1:
 
-            TEST_ASSERT(mbedtls_ssl_conf_psk_opaque(&conf,
-                                                    psk0_opaque,
-                                                    psk0_opaque_identity,
-                                                    sizeof(psk0_opaque_identity))
-                        == 0);
-            TEST_ASSERT(mbedtls_ssl_conf_psk(&conf,
-                                             psk1_raw, sizeof(psk1_raw),
-                                             psk1_raw_identity, sizeof(psk1_raw_identity))
-                        == MBEDTLS_ERR_SSL_FEATURE_UNAVAILABLE);
+            TEST_EQUAL(mbedtls_ssl_conf_psk_opaque(&conf,
+                                                   psk0_opaque,
+                                                   psk0_opaque_identity,
+                                                   sizeof(psk0_opaque_identity)),
+                       0);
+            TEST_EQUAL(mbedtls_ssl_conf_psk(&conf,
+                                            psk1_raw, sizeof(psk1_raw),
+                                            psk1_raw_identity, sizeof(psk1_raw_identity)),
+                       MBEDTLS_ERR_SSL_FEATURE_UNAVAILABLE);
 
             break;
 
         case 2:
 
-            TEST_ASSERT(mbedtls_ssl_conf_psk_opaque(&conf,
-                                                    psk0_opaque,
-                                                    psk0_opaque_identity,
-                                                    sizeof(psk0_opaque_identity))
-                        == 0);
-            TEST_ASSERT(mbedtls_ssl_conf_psk_opaque(&conf,
-                                                    psk1_opaque,
-                                                    psk1_opaque_identity,
-                                                    sizeof(psk1_opaque_identity))
-                        == MBEDTLS_ERR_SSL_FEATURE_UNAVAILABLE);
+            TEST_EQUAL(mbedtls_ssl_conf_psk_opaque(&conf,
+                                                   psk0_opaque,
+                                                   psk0_opaque_identity,
+                                                   sizeof(psk0_opaque_identity)),
+                       0);
+            TEST_EQUAL(mbedtls_ssl_conf_psk_opaque(&conf,
+                                                   psk1_opaque,
+                                                   psk1_opaque_identity,
+                                                   sizeof(psk1_opaque_identity)),
+                       MBEDTLS_ERR_SSL_FEATURE_UNAVAILABLE);
 
             break;
 
@@ -3529,7 +3522,7 @@ void conf_version(int endpoint, int transport,
     mbedtls_ssl_conf_min_tls_version(&conf, min_tls_version);
     mbedtls_ssl_conf_max_tls_version(&conf, max_tls_version);
 
-    TEST_ASSERT(mbedtls_ssl_setup(&ssl, &conf) == expected_ssl_setup_result);
+    TEST_EQUAL(mbedtls_ssl_setup(&ssl, &conf), expected_ssl_setup_result);
     TEST_EQUAL(mbedtls_ssl_conf_get_endpoint(
                    mbedtls_ssl_context_get_config(&ssl)), endpoint);
 
@@ -3562,7 +3555,7 @@ void conf_group()
     mbedtls_ssl_init(&ssl);
     MD_OR_USE_PSA_INIT();
 
-    TEST_ASSERT(mbedtls_ssl_setup(&ssl, &conf) == 0);
+    TEST_EQUAL(mbedtls_ssl_setup(&ssl, &conf), 0);
 
     TEST_ASSERT(ssl.conf != NULL && ssl.conf->group_list != NULL);
 
@@ -3604,35 +3597,35 @@ void force_bad_session_id_len()
     mbedtls_test_message_socket_init(&client_context);
     MD_OR_USE_PSA_INIT();
 
-    TEST_ASSERT(mbedtls_test_ssl_endpoint_init(&client, MBEDTLS_SSL_IS_CLIENT,
-                                               &options, NULL, NULL,
-                                               NULL) == 0);
+    TEST_EQUAL(mbedtls_test_ssl_endpoint_init(&client, MBEDTLS_SSL_IS_CLIENT,
+                                              &options, NULL, NULL,
+                                              NULL), 0);
 
-    TEST_ASSERT(mbedtls_test_ssl_endpoint_init(&server, MBEDTLS_SSL_IS_SERVER,
-                                               &options, NULL, NULL, NULL) == 0);
+    TEST_EQUAL(mbedtls_test_ssl_endpoint_init(&server, MBEDTLS_SSL_IS_SERVER,
+                                              &options, NULL, NULL, NULL), 0);
 
     mbedtls_debug_set_threshold(1);
     mbedtls_ssl_conf_dbg(&server.conf, options.srv_log_fun,
                          options.srv_log_obj);
 
-    TEST_ASSERT(mbedtls_test_mock_socket_connect(&(client.socket),
-                                                 &(server.socket),
-                                                 BUFFSIZE) == 0);
+    TEST_EQUAL(mbedtls_test_mock_socket_connect(&(client.socket),
+                                                &(server.socket),
+                                                BUFFSIZE), 0);
 
-    TEST_ASSERT(mbedtls_test_move_handshake_to_state(
-                    &(client.ssl), &(server.ssl), MBEDTLS_SSL_HANDSHAKE_WRAPUP)
-                ==  0);
+    TEST_EQUAL(mbedtls_test_move_handshake_to_state(
+                   &(client.ssl), &(server.ssl), MBEDTLS_SSL_HANDSHAKE_WRAPUP),
+               0);
     /* Force a bad session_id_len that will be read by the server in
      * mbedtls_ssl_cache_set. */
     server.ssl.session_negotiate->id_len = 33;
     if (options.cli_msg_len != 0 || options.srv_msg_len != 0) {
         /* Start data exchanging test */
-        TEST_ASSERT(mbedtls_test_ssl_exchange_data(
-                        &(client.ssl), options.cli_msg_len,
-                        options.expected_cli_fragments,
-                        &(server.ssl), options.srv_msg_len,
-                        options.expected_srv_fragments)
-                    == 0);
+        TEST_EQUAL(mbedtls_test_ssl_exchange_data(
+                       &(client.ssl), options.cli_msg_len,
+                       options.expected_cli_fragments,
+                       &(server.ssl), options.srv_msg_len,
+                       options.expected_srv_fragments),
+                   0);
     }
 
     /* Make sure that the cache did not store the session */
@@ -3686,7 +3679,7 @@ void timing_final_delay_accessor()
     USE_PSA_INIT();
     mbedtls_timing_set_delay(&delay_context, 50, 100);
 
-    TEST_ASSERT(mbedtls_timing_get_final_delay(&delay_context) == 100);
+    TEST_EQUAL(mbedtls_timing_get_final_delay(&delay_context), 100);
 
 exit:
     USE_PSA_DONE();
@@ -3710,63 +3703,63 @@ void cid_sanity()
     mbedtls_ssl_config_init(&conf);
     MD_OR_USE_PSA_INIT();
 
-    TEST_ASSERT(mbedtls_ssl_config_defaults(&conf,
-                                            MBEDTLS_SSL_IS_CLIENT,
-                                            MBEDTLS_SSL_TRANSPORT_STREAM,
-                                            MBEDTLS_SSL_PRESET_DEFAULT)
-                == 0);
+    TEST_EQUAL(mbedtls_ssl_config_defaults(&conf,
+                                           MBEDTLS_SSL_IS_CLIENT,
+                                           MBEDTLS_SSL_TRANSPORT_STREAM,
+                                           MBEDTLS_SSL_PRESET_DEFAULT),
+               0);
 
-    TEST_ASSERT(mbedtls_ssl_setup(&ssl, &conf) == 0);
+    TEST_EQUAL(mbedtls_ssl_setup(&ssl, &conf), 0);
 
     /* Can't use CID functions with stream transport. */
-    TEST_ASSERT(mbedtls_ssl_set_cid(&ssl, MBEDTLS_SSL_CID_ENABLED, own_cid,
-                                    sizeof(own_cid))
-                == MBEDTLS_ERR_SSL_BAD_INPUT_DATA);
+    TEST_EQUAL(mbedtls_ssl_set_cid(&ssl, MBEDTLS_SSL_CID_ENABLED, own_cid,
+                                   sizeof(own_cid)),
+               MBEDTLS_ERR_SSL_BAD_INPUT_DATA);
 
-    TEST_ASSERT(mbedtls_ssl_get_own_cid(&ssl, &cid_enabled, test_cid,
-                                        &own_cid_len)
-                == MBEDTLS_ERR_SSL_BAD_INPUT_DATA);
+    TEST_EQUAL(mbedtls_ssl_get_own_cid(&ssl, &cid_enabled, test_cid,
+                                       &own_cid_len),
+               MBEDTLS_ERR_SSL_BAD_INPUT_DATA);
 
-    TEST_ASSERT(mbedtls_ssl_config_defaults(&conf,
-                                            MBEDTLS_SSL_IS_CLIENT,
-                                            MBEDTLS_SSL_TRANSPORT_DATAGRAM,
-                                            MBEDTLS_SSL_PRESET_DEFAULT)
-                == 0);
+    TEST_EQUAL(mbedtls_ssl_config_defaults(&conf,
+                                           MBEDTLS_SSL_IS_CLIENT,
+                                           MBEDTLS_SSL_TRANSPORT_DATAGRAM,
+                                           MBEDTLS_SSL_PRESET_DEFAULT),
+               0);
 
     /* Attempt to set config cid size too big. */
-    TEST_ASSERT(mbedtls_ssl_conf_cid(&conf, MBEDTLS_SSL_CID_IN_LEN_MAX + 1,
-                                     MBEDTLS_SSL_UNEXPECTED_CID_IGNORE)
-                == MBEDTLS_ERR_SSL_BAD_INPUT_DATA);
+    TEST_EQUAL(mbedtls_ssl_conf_cid(&conf, MBEDTLS_SSL_CID_IN_LEN_MAX + 1,
+                                    MBEDTLS_SSL_UNEXPECTED_CID_IGNORE),
+               MBEDTLS_ERR_SSL_BAD_INPUT_DATA);
 
-    TEST_ASSERT(mbedtls_ssl_conf_cid(&conf, sizeof(own_cid),
-                                     MBEDTLS_SSL_UNEXPECTED_CID_IGNORE)
-                == 0);
+    TEST_EQUAL(mbedtls_ssl_conf_cid(&conf, sizeof(own_cid),
+                                    MBEDTLS_SSL_UNEXPECTED_CID_IGNORE),
+               0);
 
     /* Attempt to set CID length not matching config. */
-    TEST_ASSERT(mbedtls_ssl_set_cid(&ssl, MBEDTLS_SSL_CID_ENABLED, own_cid,
-                                    MBEDTLS_SSL_CID_IN_LEN_MAX - 1)
-                == MBEDTLS_ERR_SSL_BAD_INPUT_DATA);
+    TEST_EQUAL(mbedtls_ssl_set_cid(&ssl, MBEDTLS_SSL_CID_ENABLED, own_cid,
+                                   MBEDTLS_SSL_CID_IN_LEN_MAX - 1),
+               MBEDTLS_ERR_SSL_BAD_INPUT_DATA);
 
-    TEST_ASSERT(mbedtls_ssl_set_cid(&ssl, MBEDTLS_SSL_CID_ENABLED, own_cid,
-                                    sizeof(own_cid))
-                == 0);
+    TEST_EQUAL(mbedtls_ssl_set_cid(&ssl, MBEDTLS_SSL_CID_ENABLED, own_cid,
+                                   sizeof(own_cid)),
+               0);
 
     /* Test we get back what we put in. */
-    TEST_ASSERT(mbedtls_ssl_get_own_cid(&ssl, &cid_enabled, test_cid,
-                                        &own_cid_len)
-                == 0);
+    TEST_EQUAL(mbedtls_ssl_get_own_cid(&ssl, &cid_enabled, test_cid,
+                                       &own_cid_len),
+               0);
 
     TEST_EQUAL(cid_enabled, MBEDTLS_SSL_CID_ENABLED);
     TEST_MEMORY_COMPARE(own_cid, own_cid_len, test_cid, own_cid_len);
 
     /* Test disabling works. */
-    TEST_ASSERT(mbedtls_ssl_set_cid(&ssl, MBEDTLS_SSL_CID_DISABLED, NULL,
-                                    0)
-                == 0);
+    TEST_EQUAL(mbedtls_ssl_set_cid(&ssl, MBEDTLS_SSL_CID_DISABLED, NULL,
+                                   0),
+               0);
 
-    TEST_ASSERT(mbedtls_ssl_get_own_cid(&ssl, &cid_enabled, test_cid,
-                                        &own_cid_len)
-                == 0);
+    TEST_EQUAL(mbedtls_ssl_get_own_cid(&ssl, &cid_enabled, test_cid,
+                                       &own_cid_len),
+               0);
 
     TEST_EQUAL(cid_enabled, MBEDTLS_SSL_CID_DISABLED);
 
@@ -3925,8 +3918,8 @@ void tls13_server_certificate_msg_invalid_vector_len()
         ret = mbedtls_ssl_tls13_parse_certificate(&(client_ep.ssl), buf, end);
         TEST_EQUAL(ret, expected_result);
 
-        TEST_ASSERT(mbedtls_ssl_cmp_chk_buf_ptr_fail_args(
-                        &expected_chk_buf_ptr_args) == 0);
+        TEST_EQUAL(mbedtls_ssl_cmp_chk_buf_ptr_fail_args(
+                       &expected_chk_buf_ptr_args), 0);
 
         mbedtls_ssl_reset_chk_buf_ptr_fail_args();
 
@@ -4667,7 +4660,7 @@ void tls13_cli_early_data_state(int scenario)
                 break;
 
             case MBEDTLS_SSL_CLIENT_CCS_BEFORE_2ND_CLIENT_HELLO:
-                TEST_ASSERT(scenario == TEST_EARLY_DATA_HRR);
+                TEST_EQUAL(scenario, TEST_EARLY_DATA_HRR);
                 TEST_EQUAL(client_ep.ssl.early_data_state,
                            MBEDTLS_SSL_EARLY_DATA_STATE_REJECTED);
                 break;
@@ -5068,12 +5061,12 @@ complete_handshake:
          * this first part of the handshake with HRR.
          */
         if ((scenario == TEST_EARLY_DATA_HRR) && (beyond_first_hello)) {
-            TEST_ASSERT(mbedtls_test_move_handshake_to_state(
-                            &(client_ep.ssl), &(server_ep.ssl),
-                            MBEDTLS_SSL_SERVER_HELLO) == 0);
-            TEST_ASSERT(mbedtls_test_move_handshake_to_state(
-                            &(client_ep.ssl), &(server_ep.ssl),
-                            MBEDTLS_SSL_CLIENT_HELLO) == 0);
+            TEST_EQUAL(mbedtls_test_move_handshake_to_state(
+                           &(client_ep.ssl), &(server_ep.ssl),
+                           MBEDTLS_SSL_SERVER_HELLO), 0);
+            TEST_EQUAL(mbedtls_test_move_handshake_to_state(
+                           &(client_ep.ssl), &(server_ep.ssl),
+                           MBEDTLS_SSL_CLIENT_HELLO), 0);
         }
 
         TEST_EQUAL(mbedtls_test_move_handshake_to_state(
@@ -5239,9 +5232,9 @@ void tls13_cli_max_early_data_size(int max_early_data_size_arg)
     ret = mbedtls_ssl_handshake(&(server_ep.ssl));
     TEST_EQUAL(ret, MBEDTLS_ERR_SSL_WANT_READ);
 
-    TEST_ASSERT(mbedtls_test_move_handshake_to_state(
-                    &(client_ep.ssl), &(server_ep.ssl), MBEDTLS_SSL_HANDSHAKE_OVER)
-                ==  0);
+    TEST_EQUAL(mbedtls_test_move_handshake_to_state(
+                   &(client_ep.ssl), &(server_ep.ssl), MBEDTLS_SSL_HANDSHAKE_OVER),
+               0);
 
 exit:
     mbedtls_test_ssl_endpoint_free(&client_ep, NULL);
@@ -5473,7 +5466,7 @@ void tls13_srv_max_early_data_size(int scenario, int max_early_data_size_arg, in
                     goto exit;
                 }
 
-                TEST_ASSERT(ret == MBEDTLS_ERR_SSL_WANT_READ);
+                TEST_EQUAL(ret, MBEDTLS_ERR_SSL_WANT_READ);
 
                 TEST_EQUAL(server_pattern.counter, 1);
                 server_pattern.counter = 0;
@@ -5548,15 +5541,15 @@ void inject_client_content_on_the_wire(int pk_alg,
 
     ret = mbedtls_test_ssl_endpoint_init(&server, MBEDTLS_SSL_IS_SERVER,
                                          &options, NULL, NULL, NULL);
-    TEST_EQUAL(ret,  0);
+    TEST_EQUAL(ret, 0);
 
     ret = mbedtls_test_ssl_endpoint_init(&client, MBEDTLS_SSL_IS_CLIENT,
                                          &options, NULL, NULL, NULL);
-    TEST_EQUAL(ret,  0);
+    TEST_EQUAL(ret, 0);
 
     ret = mbedtls_test_mock_socket_connect(&server.socket, &client.socket,
                                            BUFFSIZE);
-    TEST_EQUAL(ret,  0);
+    TEST_EQUAL(ret, 0);
 
     /* Make the server move to the required state */
     ret = mbedtls_test_move_handshake_to_state(&client.ssl, &server.ssl, state);
@@ -5573,7 +5566,7 @@ void inject_client_content_on_the_wire(int pk_alg,
     do {
         ret = mbedtls_ssl_handshake_step(&server.ssl);
     } while (ret == 0 && server.ssl.state == state);
-    TEST_EQUAL(ret,  expected_ret);
+    TEST_EQUAL(ret, expected_ret);
     TEST_ASSERT(srv_pattern.counter >= 1);
 
 exit:
@@ -5626,15 +5619,15 @@ void send_large_fragmented_hello(int hs_len_int, int first_frag_content_len_int,
 
     ret = mbedtls_test_ssl_endpoint_init(&server, MBEDTLS_SSL_IS_SERVER,
                                          &options, NULL, NULL, NULL);
-    TEST_EQUAL(ret,  0);
+    TEST_EQUAL(ret, 0);
 
     ret = mbedtls_test_ssl_endpoint_init(&client, MBEDTLS_SSL_IS_CLIENT,
                                          &options, NULL, NULL, NULL);
-    TEST_EQUAL(ret,  0);
+    TEST_EQUAL(ret, 0);
 
     ret = mbedtls_test_mock_socket_connect(&server.socket, &client.socket,
                                            BUFFSIZE);
-    TEST_EQUAL(ret,  0);
+    TEST_EQUAL(ret, 0);
 
     /* Make the server move past the initial dummy state */
     ret = mbedtls_test_move_handshake_to_state(&client.ssl, &server.ssl,
@@ -5714,7 +5707,7 @@ void ssl_tls_exporter_consistent_result(int proto, int exported_key_length, int 
     MD_OR_USE_PSA_INIT();
 
     ret = mbedtls_test_ssl_do_handshake_with_endpoints(&server_ep, &client_ep, &options, proto);
-    TEST_ASSERT(ret == 0);
+    TEST_EQUAL(ret, 0);
 
     TEST_ASSERT(exported_key_length > 0);
     TEST_CALLOC(key_buffer_server, exported_key_length);
@@ -5729,13 +5722,13 @@ void ssl_tls_exporter_consistent_result(int proto, int exported_key_length, int 
                                              key_buffer_server, (size_t) exported_key_length,
                                              label, sizeof(label),
                                              context, sizeof(context), use_context);
-    TEST_ASSERT(ret == 0);
+    TEST_EQUAL(ret, 0);
     ret = mbedtls_ssl_export_keying_material(&client_ep.ssl,
                                              key_buffer_client, (size_t) exported_key_length,
                                              label, sizeof(label),
                                              context, sizeof(context), use_context);
-    TEST_ASSERT(ret == 0);
-    TEST_ASSERT(memcmp(key_buffer_server, key_buffer_client, (size_t) exported_key_length) == 0);
+    TEST_EQUAL(ret, 0);
+    TEST_EQUAL(memcmp(key_buffer_server, key_buffer_client, (size_t) exported_key_length), 0);
 
 exit:
     mbedtls_test_ssl_endpoint_free(&server_ep, NULL);
@@ -5759,7 +5752,7 @@ void ssl_tls_exporter_uses_label(int proto)
     MD_OR_USE_PSA_INIT();
 
     ret = mbedtls_test_ssl_do_handshake_with_endpoints(&server_ep, &client_ep, &options, proto);
-    TEST_ASSERT(ret == 0);
+    TEST_EQUAL(ret, 0);
 
     char label_server[] = "test-label-server";
     char label_client[] = "test-label-client";
@@ -5770,12 +5763,12 @@ void ssl_tls_exporter_uses_label(int proto)
                                              key_buffer_server, sizeof(key_buffer_server),
                                              label_server, sizeof(label_server),
                                              context, sizeof(context), 1);
-    TEST_ASSERT(ret == 0);
+    TEST_EQUAL(ret, 0);
     ret = mbedtls_ssl_export_keying_material(&client_ep.ssl,
                                              key_buffer_client, sizeof(key_buffer_client),
                                              label_client, sizeof(label_client),
                                              context, sizeof(context), 1);
-    TEST_ASSERT(ret == 0);
+    TEST_EQUAL(ret, 0);
     TEST_ASSERT(memcmp(key_buffer_server, key_buffer_client, sizeof(key_buffer_server)) != 0);
 
 exit:
@@ -5798,7 +5791,7 @@ void ssl_tls_exporter_uses_context(int proto)
     MD_OR_USE_PSA_INIT();
 
     ret = mbedtls_test_ssl_do_handshake_with_endpoints(&server_ep, &client_ep, &options, proto);
-    TEST_ASSERT(ret == 0);
+    TEST_EQUAL(ret, 0);
 
     char label[] = "test-label";
     uint8_t key_buffer_server[24] = { 0 };
@@ -5809,12 +5802,12 @@ void ssl_tls_exporter_uses_context(int proto)
                                              key_buffer_server, sizeof(key_buffer_server),
                                              label, sizeof(label),
                                              context_server, sizeof(context_server), 1);
-    TEST_ASSERT(ret == 0);
+    TEST_EQUAL(ret, 0);
     ret = mbedtls_ssl_export_keying_material(&client_ep.ssl,
                                              key_buffer_client, sizeof(key_buffer_client),
                                              label, sizeof(label),
                                              context_client, sizeof(context_client), 1);
-    TEST_ASSERT(ret == 0);
+    TEST_EQUAL(ret, 0);
     TEST_ASSERT(memcmp(key_buffer_server, key_buffer_client, sizeof(key_buffer_server)) != 0);
 
 exit:
@@ -5841,7 +5834,7 @@ void ssl_tls13_exporter_uses_length(void)
                                                        &client_ep,
                                                        &options,
                                                        MBEDTLS_SSL_VERSION_TLS1_3);
-    TEST_ASSERT(ret == 0);
+    TEST_EQUAL(ret, 0);
 
     char label[] = "test-label";
     uint8_t key_buffer_server[16] = { 0 };
@@ -5851,12 +5844,12 @@ void ssl_tls13_exporter_uses_length(void)
                                              key_buffer_server, sizeof(key_buffer_server),
                                              label, sizeof(label),
                                              context, sizeof(context), 1);
-    TEST_ASSERT(ret == 0);
+    TEST_EQUAL(ret, 0);
     ret = mbedtls_ssl_export_keying_material(&client_ep.ssl,
                                              key_buffer_client, sizeof(key_buffer_client),
                                              label, sizeof(label),
                                              context, sizeof(context), 1);
-    TEST_ASSERT(ret == 0);
+    TEST_EQUAL(ret, 0);
     TEST_ASSERT(memcmp(key_buffer_server, key_buffer_client, sizeof(key_buffer_server)) != 0);
 
 exit:
@@ -5888,13 +5881,13 @@ void ssl_tls_exporter_rejects_bad_parameters(
     MD_OR_USE_PSA_INIT();
 
     ret = mbedtls_test_ssl_do_handshake_with_endpoints(&server_ep, &client_ep, &options, proto);
-    TEST_ASSERT(ret == 0);
+    TEST_EQUAL(ret, 0);
 
     ret = mbedtls_ssl_export_keying_material(&client_ep.ssl,
                                              key_buffer, exported_key_length,
                                              label, label_length,
                                              context, context_length, 1);
-    TEST_ASSERT(ret == MBEDTLS_ERR_SSL_BAD_INPUT_DATA);
+    TEST_EQUAL(ret, MBEDTLS_ERR_SSL_BAD_INPUT_DATA);
 
 exit:
     mbedtls_test_ssl_endpoint_free(&server_ep, NULL);
@@ -5926,13 +5919,13 @@ void ssl_tls_exporter_too_early(int proto, int check_server, int state)
 
     ret = mbedtls_test_ssl_endpoint_init(&server_ep, MBEDTLS_SSL_IS_SERVER, &options,
                                          NULL, NULL, NULL);
-    TEST_ASSERT(ret == 0);
+    TEST_EQUAL(ret, 0);
     ret = mbedtls_test_ssl_endpoint_init(&client_ep, MBEDTLS_SSL_IS_CLIENT, &options,
                                          NULL, NULL, NULL);
-    TEST_ASSERT(ret == 0);
+    TEST_EQUAL(ret, 0);
 
     ret = mbedtls_test_mock_socket_connect(&client_ep.socket, &server_ep.socket, BUFFSIZE);
-    TEST_ASSERT(ret == 0);
+    TEST_EQUAL(ret, 0);
 
     if (check_server) {
         ret = mbedtls_test_move_handshake_to_state(&server_ep.ssl, &client_ep.ssl, state);
@@ -5949,7 +5942,7 @@ void ssl_tls_exporter_too_early(int proto, int check_server, int state)
                                              NULL, 0, 0);
 
     /* FIXME: A more appropriate error code should be created for this case. */
-    TEST_ASSERT(ret == MBEDTLS_ERR_SSL_BAD_INPUT_DATA);
+    TEST_EQUAL(ret, MBEDTLS_ERR_SSL_BAD_INPUT_DATA);
 
 exit:
     mbedtls_test_ssl_endpoint_free(&server_ep, NULL);


### PR DESCRIPTION
Break down `mbedtls_test_ssl_perform_handshake()` and make `mbedtls_test_ssl_endpoint_init()` more consistent with it.

This is a preliminary for https://github.com/Mbed-TLS/mbedtls/issues/10160. I struggled a lot with the SSL helper code, and which function does what. In particular, I want to be able to customize what is passed to `mbedtls_ssl_conf_own_cert()`, and that was difficult when it was buried very deep down into the call stack.

There is a lot of further refactoring that should ideally be done, but are out of scope here, including:

* Better documentation for the existing functions.
* Break down `mbedtls_test_ssl_perform_connection()` further, to allow several test functions to start a handshake, do weird stuff, and finally let the common function finish the handshake, verifying that it reaches the expected state and that the resulting connection is usable.

Regarding backports: This pull request mostly touches `ssl_helpers.c`, which it changes considerably. This file had already diverged from 3.6 a little, but now backports to this file will be very hard. However, I don't propose to backport this pull request, because `ssl_helpers.c` should be in the framework. Instead, at this point, I think we're better off moving the file from `development` to the framework, and restoring the things that are needed in 3.6 (I think mostly changing back `PSA_WANT_xxx` guards to `MBEDTLS_SSL_HAVE_xxx`).

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** provided (I made one library function const)
- [x] **development PR** here
- [x] **TF-PSA-Crypto PR** not required because: TLS only
- [x] **framework PR** not required
- [x] **3.6 PR** not required because: better move the file to the framework than replay all the patches in 3.6
- **tests**  provided | not required because: 
