### PR TITLE
Add temporary test component for SHA3 testing

### DIFF
--- a/tests/scripts/components-configuration.sh
+++ b/tests/scripts/components-configuration.sh
@@ -353,11 +353,12 @@ component_test_memory_buffer_allocator () {
 }
 
 # Temporary component for SHA3 config option removal
-# Must be removed when SHA3 removal is merged
+# Will be removed according to this issue:
+# https://github.com/Mbed-TLS/mbedtls/issues/10203
 component_test_full_no_sha3 () {
     msg "build: full config without SHA3"
     scripts/config.py full
-    scripts/config.py unset-all PSA_WANT_ALG_SHA3_*
+    scripts/config.py unset-all 'PSA_WANT_ALG_SHA3_*'
     make
 
     msg "test: full - PSA_WANT_ALG_SHA3_*"

--- a/tests/scripts/components-configuration.sh
+++ b/tests/scripts/components-configuration.sh
@@ -351,3 +351,15 @@ component_test_memory_buffer_allocator () {
     # MBEDTLS_MEMORY_BUFFER_ALLOC is slow. Skip tests that tend to time out.
     tests/ssl-opt.sh -e '^DTLS proxy'
 }
+
+# Temporary component for SHA3 config option removal
+# Must be removed when SHA3 removal is merged
+component_test_full_no_sha3 () {
+    msg "build: full config without SHA3"
+    scripts/config.py full
+    scripts/config.py unset-all PSA_WANT_ALG_SHA3_*
+    make
+
+    msg "test: full - PSA_WANT_ALG_SHA3_*"
+    make test
+}


### PR DESCRIPTION
With the removal of MBEDTLS_SHA3_C the test cases with disabled SHA3 dependency are never executed. Adding a temporary `all.sh` component which disabling the `PSA_WANT_ALG_SHA3_*` macros to cover these test cases.

Prerequisite for Mbed-TLS/TF-PSA-Crypto#266

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** not required because: only testing changes
- [x] **development PR** provided: this is
- [x] **TF-PSA-Crypto PR** not required because: testing only for repo
- [x] **framework PR** not required
- [x] **3.6 PR** not required because: 4.0/1.0 related changes
- **tests**  provided 
