### PR TITLE
Doxygen doxyfile public only

### DIFF
--- a/doxygen/mbedtls.doxyfile
+++ b/doxygen/mbedtls.doxyfile
@@ -6,10 +6,7 @@ EXTRACT_ALL            = YES
 EXTRACT_PRIVATE        = YES
 EXTRACT_STATIC         = YES
 CASE_SENSE_NAMES       = NO
-INPUT                  = ../include ../tf-psa-crypto/include input ../tf-psa-crypto/drivers/builtin/include ../tests/include/alt-dummy
-EXCLUDE                = \
-  ../tf-psa-crypto/drivers/builtin/include/mbedtls/build_info.h \
-  ../tf-psa-crypto/drivers/builtin/include/mbedtls/oid.h
+INPUT                  = ../include ../tf-psa-crypto/include ../tests/include/alt-dummy
 FILE_PATTERNS          = *.h
 RECURSIVE              = YES
 EXCLUDE_SYMLINKS       = YES

--- a/include/mbedtls/x509_crt.h
+++ b/include/mbedtls/x509_crt.h
@@ -733,7 +733,7 @@ int mbedtls_x509_crt_verify_with_profile(mbedtls_x509_crt *crt,
  *                 to disable restartable ECC.
  *
  * \return         See \c mbedtls_crt_verify_with_profile(), or
- * \return         #MBEDTLS_ERR_ECP_IN_PROGRESS if maximum number of
+ * \return         #PSA_OPERATION_INCOMPLETE if maximum number of
  *                 operations was reached: see \c mbedtls_ecp_set_max_ops().
  */
 int mbedtls_x509_crt_verify_restartable(mbedtls_x509_crt *crt,


### PR DESCRIPTION
mbedtls part of and resolves https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/281

Changes doxygen so that only files in ./include, ./tf-psa-crypto/include, and ./tests/include/alt-dummy are rendered (i.e. only public files).

You may notice that ./drivers/builtin/include is still present in INCLUDE_PATH in the doxyfile. According to [doxygen documentation](https://www.doxygen.nl/manual/config.html#cfg_include_path): "The INCLUDE_PATH tag can be used to specify one or more directories that contain include files that are not input files but should be processed by the preprocessor."

In practice, removing this gave weird results, e.g. some macros like MBEDTLS_PSA_HMAC_OPERATION_INIT from crypto_builtin_composites.h were not available in the documentation, and it thought that MBEDTLS_PRIVATE was a function with a few different signatures, so it seems to be correct to leave it.

As the mbedtls CI has a readthedocs build, the resulting changes should be viewable there.

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [ ] **changelog** not required because: Documentation change, covered under overall documentation about public/private headers
- [ ] **development PR** provided: HERE 
- [ ] **TF-PSA-Crypto PR** provided: https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/305 
- [ ] **framework PR** not required
- [ ] **3.6 PR** not required because: 4.0/1.0 change only
- **tests**  not required because: documentation change