### PR TITLE
[3.6] Fix GCC 15 warning 'Wunterminated-string-initialization'

### DIFF
--- a/ChangeLog.d/unterminated-string-initialization.txt
+++ b/ChangeLog.d/unterminated-string-initialization.txt
@@ -1,0 +1,5 @@
+Bugfix
+   * GCC 15 introduced the warning 'unterminated-string-initialization', which
+     complains if you initialize a string into an array without space for a
+     terminating null character. This is intentional in many parts of the
+     code, so suppress the warning in these places. Fixes #9944.

--- a/ChangeLog.d/unterminated-string-initialization.txt
+++ b/ChangeLog.d/unterminated-string-initialization.txt
@@ -1,5 +1,3 @@
 Bugfix
-   * GCC 15 introduced the warning 'unterminated-string-initialization', which
-     complains if you initialize a string into an array without space for a
-     terminating null character. This is intentional in many parts of the
-     code, so suppress the warning in these places. Fixes #9944.
+   * Silence spurious -Wunterminated-string-initialization warnings introduced
+     by GCC 15. Fixes #9944.

--- a/library/common.h
+++ b/library/common.h
@@ -434,4 +434,20 @@ static inline void mbedtls_xor_no_simd(unsigned char *r,
 #    define MBEDTLS_MAYBE_UNUSED
 #endif
 
+/* GCC >= 15 has a warning 'unterminated-string-initialization' which complains if you initialize
+ * a string into an array without space for a terminating NULL character. In some places in the
+ * codebase this behaviour is intended, so we add the macro MBEDTLS_ATTRIBUTE_UNTERMINATED_STRING
+ * to suppress the warning in these places.
+ */
+#if defined(__has_attribute)
+#if __has_attribute(nonstring)
+#define MBEDTLS_HAS_ATTRIBUTE_NONSTRING
+#endif /* __has_attribute(nonstring) */
+#endif /* __has_attribute */
+#if defined(MBEDTLS_HAS_ATTRIBUTE_NONSTRING)
+#define MBEDTLS_ATTRIBUTE_UNTERMINATED_STRING __attribute__((nonstring))
+#else
+#define MBEDTLS_ATTRIBUTE_UNTERMINATED_STRING
+#endif /* MBEDTLS_HAS_ATTRIBUTE_NONSTRING */
+
 #endif /* MBEDTLS_LIBRARY_COMMON_H */

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -83,7 +83,7 @@ struct mbedtls_ssl_tls13_labels_struct const mbedtls_ssl_tls13_labels =
  */
 
 /* We need to tell the compiler that we meant to leave out the null character. */
-static const char tls13_label_prefix[6] __attribute__ ((nonstring)) = "tls13 ";
+static const char tls13_label_prefix[6] MBEDTLS_ATTRIBUTE_UNTERMINATED_STRING = "tls13 ";
 
 #define SSL_TLS1_3_KEY_SCHEDULE_HKDF_LABEL_LEN(label_len, context_len) \
     (2                     /* expansion length           */ \

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -82,7 +82,8 @@ struct mbedtls_ssl_tls13_labels_struct const mbedtls_ssl_tls13_labels =
  *            the HkdfLabel structure on success.
  */
 
-static const char tls13_label_prefix[6] = "tls13 ";
+/* We need to tell the compiler that we meant to leave out the null character. */
+static const char tls13_label_prefix[6] __attribute__ ((nonstring)) = "tls13 ";
 
 #define SSL_TLS1_3_KEY_SCHEDULE_HKDF_LABEL_LEN(label_len, context_len) \
     (2                     /* expansion length           */ \

--- a/library/ssl_tls13_keys.h
+++ b/library/ssl_tls13_keys.h
@@ -42,7 +42,7 @@
 
 /* We need to tell the compiler that we meant to leave out the null character. */
 #define MBEDTLS_SSL_TLS1_3_LABEL(name, string)       \
-    const unsigned char name    [sizeof(string) - 1] __attribute__ ((nonstring));
+    const unsigned char name    [sizeof(string) - 1] MBEDTLS_ATTRIBUTE_UNTERMINATED_STRING;
 
 union mbedtls_ssl_tls13_labels_union {
     MBEDTLS_SSL_TLS1_3_LABEL_LIST

--- a/library/ssl_tls13_keys.h
+++ b/library/ssl_tls13_keys.h
@@ -40,8 +40,9 @@
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
 
+/* We need to tell the compiler that we meant to leave out the null character. */
 #define MBEDTLS_SSL_TLS1_3_LABEL(name, string)       \
-    const unsigned char name    [sizeof(string) - 1];
+    const unsigned char name    [sizeof(string) - 1] __attribute__ ((nonstring));
 
 union mbedtls_ssl_tls13_labels_union {
     MBEDTLS_SSL_TLS1_3_LABEL_LIST

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -3480,7 +3480,8 @@ void mac_setup(int key_type_arg,
     psa_mac_operation_t operation = psa_mac_operation_init_short();
     psa_status_t status = PSA_ERROR_GENERIC_ERROR;
 #if defined(KNOWN_SUPPORTED_MAC_ALG)
-    const uint8_t smoke_test_key_data[16] = "kkkkkkkkkkkkkkkk";
+    /* We need to tell the compiler that we meant to leave out the null character. */
+    const uint8_t smoke_test_key_data[16] __attribute__ ((nonstring)) = "kkkkkkkkkkkkkkkk";
 #endif
 
     PSA_ASSERT(psa_crypto_init());
@@ -3917,7 +3918,8 @@ void cipher_setup(int key_type_arg,
     psa_cipher_operation_t operation = psa_cipher_operation_init_short();
     psa_status_t status;
 #if defined(KNOWN_SUPPORTED_CIPHER_ALG)
-    const uint8_t smoke_test_key_data[16] = "kkkkkkkkkkkkkkkk";
+    /* We need to tell the compiler that we meant to leave out the null character. */
+    const uint8_t smoke_test_key_data[16] __attribute__ ((nonstring)) = "kkkkkkkkkkkkkkkk";
 #endif
 
     PSA_ASSERT(psa_crypto_init());

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -3481,7 +3481,8 @@ void mac_setup(int key_type_arg,
     psa_status_t status = PSA_ERROR_GENERIC_ERROR;
 #if defined(KNOWN_SUPPORTED_MAC_ALG)
     /* We need to tell the compiler that we meant to leave out the null character. */
-    const uint8_t smoke_test_key_data[16] __attribute__ ((nonstring)) = "kkkkkkkkkkkkkkkk";
+    const uint8_t smoke_test_key_data[16] MBEDTLS_ATTRIBUTE_UNTERMINATED_STRING =
+        "kkkkkkkkkkkkkkkk";
 #endif
 
     PSA_ASSERT(psa_crypto_init());
@@ -3919,7 +3920,8 @@ void cipher_setup(int key_type_arg,
     psa_status_t status;
 #if defined(KNOWN_SUPPORTED_CIPHER_ALG)
     /* We need to tell the compiler that we meant to leave out the null character. */
-    const uint8_t smoke_test_key_data[16] __attribute__ ((nonstring)) = "kkkkkkkkkkkkkkkk";
+    const uint8_t smoke_test_key_data[16] MBEDTLS_ATTRIBUTE_UNTERMINATED_STRING =
+        "kkkkkkkkkkkkkkkk";
 #endif
 
     PSA_ASSERT(psa_crypto_init());

--- a/tests/suites/test_suite_psa_crypto_slot_management.function
+++ b/tests/suites/test_suite_psa_crypto_slot_management.function
@@ -377,8 +377,9 @@ void create_existent(int lifetime_arg, int owner_id_arg, int id_arg,
     mbedtls_svc_key_id_t returned_id = MBEDTLS_SVC_KEY_ID_INIT;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     psa_key_type_t type1 = PSA_KEY_TYPE_RAW_DATA;
-    const uint8_t material1[5] = "a key";
-    const uint8_t material2[5] = "b key";
+    /* We need to tell the compiler that we meant to leave out the null character. */
+    const uint8_t material1[5] __attribute__ ((nonstring)) = "a key";
+    const uint8_t material2[5] __attribute__ ((nonstring)) = "b key";
     size_t bits1 = PSA_BYTES_TO_BITS(sizeof(material1));
     uint8_t reexported[sizeof(material1)];
     size_t reexported_length;
@@ -747,7 +748,7 @@ void invalid_handle(int handle_construction,
     psa_key_id_t key_id;
     psa_status_t close_status = close_status_arg;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
-    uint8_t material[1] = "a";
+    uint8_t material[1] = { 'a' };
 
     PSA_ASSERT(psa_crypto_init());
 

--- a/tests/suites/test_suite_psa_crypto_slot_management.function
+++ b/tests/suites/test_suite_psa_crypto_slot_management.function
@@ -378,8 +378,8 @@ void create_existent(int lifetime_arg, int owner_id_arg, int id_arg,
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     psa_key_type_t type1 = PSA_KEY_TYPE_RAW_DATA;
     /* We need to tell the compiler that we meant to leave out the null character. */
-    const uint8_t material1[5] __attribute__ ((nonstring)) = "a key";
-    const uint8_t material2[5] __attribute__ ((nonstring)) = "b key";
+    const uint8_t material1[5] MBEDTLS_ATTRIBUTE_UNTERMINATED_STRING = "a key";
+    const uint8_t material2[5] MBEDTLS_ATTRIBUTE_UNTERMINATED_STRING = "b key";
     size_t bits1 = PSA_BYTES_TO_BITS(sizeof(material1));
     uint8_t reexported[sizeof(material1)];
     size_t reexported_length;

--- a/tests/suites/test_suite_ssl_decrypt.function
+++ b/tests/suites/test_suite_ssl_decrypt.function
@@ -38,7 +38,7 @@ void ssl_decrypt_null(int hash_id)
                               MBEDTLS_SSL_TRANSPORT_STREAM,
                               version);
     /* We need to tell the compiler that we meant to leave out the null character. */
-    const char sample_plaintext[3] __attribute__ ((nonstring)) = "ABC";
+    const char sample_plaintext[3] MBEDTLS_ATTRIBUTE_UNTERMINATED_STRING = "ABC";
     mbedtls_ssl_context ssl;
     mbedtls_ssl_init(&ssl);
     uint8_t *buf = NULL;

--- a/tests/suites/test_suite_ssl_decrypt.function
+++ b/tests/suites/test_suite_ssl_decrypt.function
@@ -37,7 +37,8 @@ void ssl_decrypt_null(int hash_id)
     mbedtls_ssl_write_version(rec_good.ver,
                               MBEDTLS_SSL_TRANSPORT_STREAM,
                               version);
-    const char sample_plaintext[3] = "ABC";
+    /* We need to tell the compiler that we meant to leave out the null character. */
+    const char sample_plaintext[3] __attribute__ ((nonstring)) = "ABC";
     mbedtls_ssl_context ssl;
     mbedtls_ssl_init(&ssl);
     uint8_t *buf = NULL;


### PR DESCRIPTION
mbedtls-3.6 part of https://github.com/Mbed-TLS/mbedtls/issues/9944

Merge order (for 3.6):
Merge this PR

Once this PR + the `mbedtls` development (https://github.com/Mbed-TLS/mbedtls/pull/10216) and `TF-PSA-Crypto` (https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/313) PRs have been merged, then merge the framework PR (https://github.com/Mbed-TLS/mbedtls-framework/pull/173)

This PR does not depend on the framework PR https://github.com/Mbed-TLS/mbedtls-framework/pull/173 in terms of submodule updates, but will require it to be merged to fix the issue completely. AIUI during the release process the framework pointer is updated, ~~so I haven't done it here on the assumption that it will be done later, but I can change this to ensure the framework change gets pulled in when this is merged.~~ so if we want the issue to be resolved before the release process starts, then there will need to be an extra commit updating the framework pointer once the framework PR is merged.

## PR checklist

- [x] **changelog** provided
- [x] **development PR** provided: https://github.com/Mbed-TLS/mbedtls/pull/10216
- [x] **TF-PSA-Crypto PR** provided: https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/313
- [x] **framework PR** provided: https://github.com/Mbed-TLS/mbedtls-framework/pull/173
- [x] **3.6 PR** provided: HERE
- **tests**  not required because: build only change 