### PR TITLE
Clean up after crypto hides its OID module

### DIFF
--- a/configs/crypto-config-suite-b.h
+++ b/configs/crypto-config-suite-b.h
@@ -49,7 +49,6 @@
 #define MBEDTLS_ASN1_WRITE_C
 #define MBEDTLS_CTR_DRBG_C
 #define MBEDTLS_ENTROPY_C
-#define MBEDTLS_OID_C
 #define MBEDTLS_PK_C
 #define MBEDTLS_PK_PARSE_C
 

--- a/configs/crypto-config-thread.h
+++ b/configs/crypto-config-thread.h
@@ -58,7 +58,6 @@
 #define MBEDTLS_ENTROPY_C
 #define MBEDTLS_HMAC_DRBG_C
 #define MBEDTLS_MD_C
-#define MBEDTLS_OID_C
 #define MBEDTLS_PK_C
 #define MBEDTLS_PK_PARSE_C
 

--- a/scripts/generate_errors.pl
+++ b/scripts/generate_errors.pl
@@ -38,7 +38,7 @@ my $error_format_file = $data_dir.'/error.fmt';
 my @low_level_modules = qw( AES ARIA ASN1 BASE64 BIGNUM
                             CAMELLIA CCM CHACHA20 CHACHAPOLY CMAC CTR_DRBG DES
                             ENTROPY ERROR GCM HKDF HMAC_DRBG LMS MD5
-                            NET OID PBKDF2 PLATFORM POLY1305 RIPEMD160
+                            NET PBKDF2 PLATFORM POLY1305 RIPEMD160
                             SHA1 SHA256 SHA512 SHA3 THREADING );
 my @high_level_modules = qw( CIPHER ECP MD
                              PEM PK PKCS12 PKCS5


### PR DESCRIPTION
## Description

Resolves https://github.com/Mbed-TLS/mbedtls/issues/10172

## PR checklist

- [x] **changelog** not required because: covered by earlier PRs
- [x] **development PR** provided HERE
- [x] **TF-PSA-Crypto PR** not required because: was already part of the previous issue
- [x] **framework PR** not required
- [x] **3.6 PR** not required because: 1.0/4.0 speficif
- **tests**  not required because: cleanup (can manually check the effect of the changes to `generate_errors.pl` though).