### PR TITLE
Improve detection of CMake library installation problems

### DIFF
--- a/programs/test/cmake_package_install/CMakeLists.txt
+++ b/programs/test/cmake_package_install/CMakeLists.txt
@@ -37,5 +37,11 @@ find_package(MbedTLS REQUIRED)
 #
 
 add_executable(cmake_package_install cmake_package_install.c)
+
+string(REGEX MATCH "GNU" CMAKE_COMPILER_IS_GNU "${CMAKE_C_COMPILER_ID}")
+if(CMAKE_COMPILER_IS_GNU)
+    target_compile_options(cmake_package_install PRIVATE -Wall -Werror)
+endif()
+
 target_link_libraries(cmake_package_install
     MbedTLS::mbedtls MbedTLS::mbedx509 MbedTLS::tfpsacrypto)


### PR DESCRIPTION
## Description
When building cmake_package_install, fail in case of warnings with GNU GCC. This would have caught the issue reported in #10022.

## PR checklist
- [x] **changelog** not required because: bug not released
- [x] **development PR** here
- [x] **TF-PSA-Crypto PR** provided Mbed-TLS/TF-PSA-Crypto#322
- [x] **framework PR** not required
- [x] **3.6 PR** not required because: development only issue 
- **tests**  provided