### PR TITLE
[BACKPORT] Fixed some minor typos in comments.

### DIFF
--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -4461,7 +4461,7 @@ static int ssl_load_buffered_message(mbedtls_ssl_context *ssl)
         ret = 0;
         goto exit;
     } else {
-        MBEDTLS_SSL_DEBUG_MSG(2, ("Next handshake message %u not or only partially bufffered",
+        MBEDTLS_SSL_DEBUG_MSG(2, ("Next handshake message %u not or only partially buffered",
                                   hs->in_msg_seq));
     }
 
@@ -6275,7 +6275,7 @@ int mbedtls_ssl_write_early_data(mbedtls_ssl_context *ssl,
     } else {
         /*
          * If we are past the point where we can send early data or we have
-         * already reached the maximum early data size, return immediatly.
+         * already reached the maximum early data size, return immediately.
          * Otherwise, progress the handshake as much as possible to not delay
          * it too much. If we reach a point where we can still send early data,
          * then we will send some.

--- a/library/ssl_tls12_client.c
+++ b/library/ssl_tls12_client.c
@@ -2024,7 +2024,7 @@ static int ssl_get_ecdh_params_from_cert(mbedtls_ssl_context *ssl)
 
     tls_id = mbedtls_ssl_get_tls_id_from_ecp_group_id(grp_id);
     if (tls_id == 0) {
-        MBEDTLS_SSL_DEBUG_MSG(1, ("ECC group %u not suported",
+        MBEDTLS_SSL_DEBUG_MSG(1, ("ECC group %u not supported",
                                   grp_id));
         return MBEDTLS_ERR_SSL_ILLEGAL_PARAMETER;
     }

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -12526,7 +12526,7 @@ run_test    "DTLS reordering: Buffer out-of-order handshake message fragment on 
             0 \
             -c "Buffering HS message" \
             -c "found fragmented DTLS handshake message"\
-            -c "Next handshake message 1 not or only partially bufffered" \
+            -c "Next handshake message 1 not or only partially buffered" \
             -c "Next handshake message has been buffered - load"\
             -S "Buffering HS message" \
             -S "Next handshake message has been buffered - load"\


### PR DESCRIPTION
## Description

Cherry-picked from commit [67aa959ea1](https://github.com/Mbed-TLS/mbedtls/commit/67aa959ea1)

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** not required because this change only fixes typos in comments and does not affect any public API or behaviour.
- [x] **development PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10214
- [x] **TF-PSA-Crypto PR** not required because this change does not touch the PSA-Crypto component.
- [x] **framework PR** not required because this change does not affect the framework submodule.
- [x] **3.6 PR** provided here
- **tests** not required because there is no executable code change - just typo fixes in comments.

