### PR TITLE
Modify dlopen.c and tfpsacrypto_dlopen.c so that they use PSA API-only dynamic loading

### DIFF
--- a/programs/test/dlopen.c
+++ b/programs/test/dlopen.c
@@ -105,8 +105,7 @@ int main(void)
         dlsym(crypto_so, "psa_hash_compute");
 
 #pragma GCC diagnostic pop
-    /* Use psa_hash_compute from PSA Crypto API instead of deprecated mbedtls_md_list()
-     * to demonstrate runtime linking of libmbedcrypto / libtfpsacrypto */
+    /* Demonstrate hashing a message with PSA Crypto */
 
     CHECK_DLERROR("dlsym", "psa_crypto_init");
     CHECK_DLERROR("dlsym", "psa_hash_compute");


### PR DESCRIPTION
## Description

- Replace soon-deprecated mbedtls_md_list() in dlopen.c with psa_hash_compute()
- Add tfpsacrypto_dlopen.c as a PSA-only shared-library loading test
- Enable -fPIC for tf-psa-crypto builtins to support shared linking
- Confirm clean builds and successful dlopen() test execution.



## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** not required because this change is only to test programs
- [x] **development PR** not required because this PR is targeting "development" directly
- [X] **TF-PSA-Crypto PR** provided Mbed-TLS/TF-PSA-Crypto#339
- [x] **framework PR** not required
- [x] **3.6 PR** not required because this only applies to Mbed TLS 4.0
- **tests** not required because this is itself a runtime test rather than an automated test suite.



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
