### PR TITLE
Backport 3.6: Use a null pointer for empty data

### DIFF
--- a/tests/suites/test_suite_aes.function
+++ b/tests/suites/test_suite_aes.function
@@ -306,7 +306,7 @@ void aes_encrypt_xts(char *hex_key_string, char *hex_data_unit_string,
     dst = mbedtls_test_unhexify_alloc(hex_dst_string, &dst_len);
     TEST_ASSERT(src_len == dst_len);
 
-    output = mbedtls_test_zero_alloc(dst_len);
+    TEST_CALLOC(output, dst_len);
 
     TEST_ASSERT(mbedtls_aes_xts_setkey_enc(&ctx, key, key_len * 8) == 0);
     TEST_ASSERT(mbedtls_aes_crypt_xts(&ctx, MBEDTLS_AES_ENCRYPT, src_len,
@@ -350,7 +350,7 @@ void aes_decrypt_xts(char *hex_key_string, char *hex_data_unit_string,
     dst = mbedtls_test_unhexify_alloc(hex_dst_string, &dst_len);
     TEST_ASSERT(src_len == dst_len);
 
-    output = mbedtls_test_zero_alloc(dst_len);
+    TEST_CALLOC(output, dst_len);
 
     TEST_ASSERT(mbedtls_aes_xts_setkey_dec(&ctx, key, key_len * 8) == 0);
     TEST_ASSERT(mbedtls_aes_crypt_xts(&ctx, MBEDTLS_AES_DECRYPT, src_len,

--- a/tests/suites/test_suite_base64.function
+++ b/tests/suites/test_suite_base64.function
@@ -109,7 +109,7 @@ void base64_encode_hex(data_t *src, char *dst, int dst_buf_size,
     unsigned char *res = NULL;
     size_t len;
 
-    res = mbedtls_test_zero_alloc(dst_buf_size);
+    TEST_CALLOC(res, dst_buf_size);
 
     TEST_CF_SECRET(src->x, src->len);
     TEST_ASSERT(mbedtls_base64_encode(res, dst_buf_size, &len, src->x, src->len) == result);
@@ -136,7 +136,7 @@ void base64_decode_hex(char *src, data_t *dst, int dst_buf_size,
     unsigned char *res = NULL;
     size_t len;
 
-    res = mbedtls_test_zero_alloc(dst_buf_size);
+    TEST_CALLOC(res, dst_buf_size);
 
     TEST_ASSERT(mbedtls_base64_decode(res, dst_buf_size, &len, (unsigned char *) src,
                                       strlen(src)) == result);


### PR DESCRIPTION
In binary arguments to test functions, don't allocate an extra byte when a binary input is empty. This could hide bugs where the library tries to access one byte in an empty buffer.

## PR checklist

- [x] **changelog** provided | not required because: 
- [ ] **development PR** TODO (or not required?)
- [ ] **TF-PSA-Crypto PR** TODO
- [x] **framework PR** https://github.com/Mbed-TLS/mbedtls-framework/pull/177 (needs to be merged after 3.6 and crypto are updated)
- [x] **3.6 PR** here
- **tests**  provided | not required because: 
