### PR TITLE
Remove DES from error generation

### DIFF
--- a/scripts/generate_errors.pl
+++ b/scripts/generate_errors.pl
@@ -36,7 +36,7 @@ if( @ARGV ) {
 my $error_format_file = $data_dir.'/error.fmt';
 
 my @low_level_modules = qw( AES ARIA ASN1 BASE64 BIGNUM
-                            CAMELLIA CCM CHACHA20 CHACHAPOLY CMAC CTR_DRBG DES
+                            CAMELLIA CCM CHACHA20 CHACHAPOLY CMAC CTR_DRBG
                             ENTROPY ERROR GCM HKDF HMAC_DRBG LMS MD5
                             NET PBKDF2 PLATFORM POLY1305 RIPEMD160
                             SHA1 SHA256 SHA512 SHA3 THREADING );


### PR DESCRIPTION
## Description

- Remove DES from `generate_errors.pl`
- Confirm successful build completion with DES removed

The goal is to fully remove DES support from the error infrastructure as part of the broader DES removal effort (see Mbed-TLS/mbedtls/issues/9164).  


## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [ ] **changelog** not required because: internal cleanup, no functional change or API removal
- [X] **development PR** here
- [ ] **TF-PSA-Crypto PR** not required because: this change is not in the submodule
- [ ] **framework PR** not required
- [ ] **3.6 PR** not required because: DES is still supported in 3.6
- **tests**  not required because: no runtime behavior changed, only error string generation logic



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
