### PR TITLE
Improve debug log enablement in unit tests

### DIFF
--- a/programs/Makefile
+++ b/programs/Makefile
@@ -62,6 +62,7 @@ APPS = \
 	test/query_compile_time_config \
 	test/query_included_headers \
 	test/selftest \
+	test/ssl_unit_test_debug \
 	test/udp_proxy \
 	test/zeroize \
 	util/pem2der \
@@ -271,6 +272,10 @@ test/query_included_headers$(EXEXT): $(FRAMEWORK)/tests/programs/query_included_
 test/selftest$(EXEXT): test/selftest.c $(DEP)
 	echo "  CC    test/selftest.c"
 	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) test/selftest.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+
+test/ssl_unit_test_debug$(EXEXT): test/ssl_unit_test_debug.c $(DEP)
+	echo "  CC    test/selftest.c"
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) -I../library -I../tf-psa-crypto/core -I../tf-psa-crypto/drivers/builtin/src test/ssl_unit_test_debug.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test/udp_proxy$(EXEXT): test/udp_proxy.c $(DEP)
 	echo "  CC    test/udp_proxy.c"

--- a/programs/test/CMakeLists.txt
+++ b/programs/test/CMakeLists.txt
@@ -7,6 +7,7 @@ set(executables
     query_compile_time_config
     query_included_headers
     selftest
+    ssl_unit_test_debug
     udp_proxy
     zeroize
 )
@@ -83,6 +84,9 @@ foreach(exe IN LISTS executables)
             ${MBEDTLS_FRAMEWORK_DIR}/tests/programs/query_config.h
             ${CMAKE_CURRENT_BINARY_DIR}/query_config.c)
     endif()
+    if(exe STREQUAL "ssl_unit_test_debug")
+        list(APPEND extra_sources $<TARGET_OBJECTS:mbedtls_test_helpers>)
+    endif()
     add_executable(${exe} ${source} $<TARGET_OBJECTS:mbedtls_test>
         ${extra_sources})
     set_base_compile_options(${exe})
@@ -100,6 +104,12 @@ foreach(exe IN LISTS executables)
     set_target_properties(${exe} PROPERTIES C_STANDARD 11)
     target_link_libraries(${exe} ${libs} ${CMAKE_THREAD_LIBS_INIT})
 endforeach()
+
+target_include_directories(ssl_unit_test_debug
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../framework/tests/include
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../tests/include
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../tf-psa-crypto/include
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../tf-psa-crypto/drivers/builtin/include)
 
 install(TARGETS ${executables}
         DESTINATION "bin"

--- a/programs/test/ssl_unit_test_debug.c
+++ b/programs/test/ssl_unit_test_debug.c
@@ -1,0 +1,60 @@
+/*
+ *  Test the debug facility in SSL unit tests.
+ *
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+ */
+
+/* Not needed directly by this program, but needed by internal headers
+ * included by test helper headers. */
+#define MBEDTLS_ALLOW_PRIVATE_ACCESS
+
+#include <mbedtls/build_info.h>
+#include <mbedtls/platform.h>
+
+#if !defined(MBEDTLS_DEBUG_C) ||                         \
+    !defined(MBEDTLS_SSL_CLI_C) ||                       \
+    !defined(MBEDTLS_SSL_SRV_C) ||                       \
+    !defined(MBEDTLS_SSL_PROTO_TLS1_2) ||                \
+    !defined(PSA_WANT_ALG_ECDSA) ||                      \
+    !defined(PSA_WANT_ALG_ECDH) ||                       \
+    !defined(PSA_WANT_ECC_SECP_R1_256) ||                \
+    !defined(PSA_WANT_ALG_SHA_256) ||                    \
+    !defined(PSA_WANT_ALG_CHACHA20_POLY1305) ||          \
+    !defined(MBEDTLS_PSA_CRYPTO_C)
+int main(void)
+{
+    mbedtls_printf("This program is unusable in this configuration.\n");
+    mbedtls_exit(0);
+}
+#else
+
+#include <stdlib.h>
+#include <mbedtls/debug.h>
+#include <test/ssl_helpers.h>
+
+int main(int argc, char *argv[])
+{
+    if (argc < 2) {
+        mbedtls_printf("Usage: ssl_unit_test_debug THRESHOLD\n");
+        mbedtls_exit(2);
+    }
+    int threshold = atoi(argv[1]);
+
+    mbedtls_test_handshake_test_options options;
+    mbedtls_test_init_handshake_options(&options);
+    options.client_min_version = MBEDTLS_SSL_VERSION_TLS1_2;
+    options.client_max_version = MBEDTLS_SSL_VERSION_TLS1_2;
+    options.expected_negotiated_version = MBEDTLS_SSL_VERSION_TLS1_2;
+
+    if (threshold >= 0) {
+        mbedtls_test_ssl_debug_stdout_threshold = threshold;
+    }
+
+    mbedtls_test_ssl_perform_handshake(&options);
+
+    mbedtls_test_free_handshake_options(&options);
+    mbedtls_exit(0);
+}
+
+#endif /* configuration allows running this program */

--- a/programs/test/ssl_unit_test_debug_demo.sh
+++ b/programs/test/ssl_unit_test_debug_demo.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+#
+# Copyright The Mbed TLS Contributors
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+
+. "${0%/*}/../../framework/scripts/demo_common.sh"
+
+msg <<'EOF'
+This script tests that SSL debugging logs are working in unit tests.
+EOF
+
+# Expected dependencies
+depends_on MBEDTLS_DEBUG_C MBEDTLS_SSL_CLI_C MBEDTLS_SSL_SRV_C MBEDTLS_SSL_PROTO_TLS1_2
+# Dependencies due to test helper limitations (could be partly relaxed with
+# some work)
+depends_on PSA_WANT_ALG_ECDSA PSA_WANT_ALG_ECDH PSA_WANT_ECC_SECP_R1_256
+depends_on PSA_WANT_ALG_SHA_256 PSA_WANT_ALG_CHACHA20_POLY1305
+
+program="${0%/*}"/ssl_unit_test_debug
+tmp_out="$program.out"
+files_to_clean="$tmp_out"
+
+go () {
+    "$program" "$@" >"$tmp_out"
+}
+
+check_log () {
+    run "Check for a level $1 $2 log" \
+        grep -q -E "^$2: [^ ]+: \\|$1\\| " "$tmp_out"
+}
+
+check_no_log () {
+    run "Check the absence of a level $1 log" \
+        grep -L ": \\|$1\\| " "$tmp_out"
+}
+
+run "Run with the default settings" go -1
+run "Check that stdout is empty" test ! -s "$tmp_out"
+
+run "Run with threshold=0" go 0
+run "Check that stdout is empty" test ! -s "$tmp_out"
+
+run "Run with threshold=1" go 1
+check_log 1 Client
+check_log 1 Server
+check_no_log 2
+
+run "Run with threshold=4" go 4
+check_log 1 Client
+check_log 4 Client
+check_log 1 Server
+check_log 4 Server
+
+cleanup

--- a/tests/include/test/ssl_helpers.h
+++ b/tests/include/test/ssl_helpers.h
@@ -241,6 +241,13 @@ int mbedtls_test_random(void *p_rng, unsigned char *output, size_t output_len);
 void mbedtls_test_ssl_debug_handler(void *ctx, int level,
                                     const char *file, int line,
                                     const char *msg);
+
+/** Debug messages up to this level are printed to stdout.
+ *
+ * \note In unit tests, you need to run the test suite with `-v`,
+ *       otherwise stdout is suppressed.
+ */
+extern int mbedtls_test_ssl_debug_stdout_threshold;
 #endif /* MBEDTLS_DEBUG_C */
 
 void mbedtls_test_init_handshake_options(

--- a/tests/src/test_helpers/ssl_helpers.c
+++ b/tests/src/test_helpers/ssl_helpers.c
@@ -22,11 +22,22 @@ int mbedtls_test_random(void *p_rng, unsigned char *output, size_t output_len)
     return 0;
 }
 
-void mbedtls_test_ssl_log_analyzer(void *ctx, int level,
-                                   const char *file, int line,
-                                   const char *str)
+#if defined(MBEDTLS_DEBUG_C)
+static void ssl_log_analyzer(mbedtls_test_ssl_log_pattern *p,
+                             const char *str)
 {
-    mbedtls_test_ssl_log_pattern *p = (mbedtls_test_ssl_log_pattern *) ctx;
+    if (NULL != p &&
+        NULL != p->pattern &&
+        NULL != strstr(str, p->pattern)) {
+        p->counter++;
+    }
+}
+
+void mbedtls_test_ssl_debug_handler(void *ctx, int level,
+                                    const char *file, int line,
+                                    const char *msg)
+{
+    mbedtls_test_ssl_endpoint *ep = ctx;
 
 /* Change 0 to 1 for debugging of test cases that use this function. */
 #if 0
@@ -45,12 +56,15 @@ void mbedtls_test_ssl_log_analyzer(void *ctx, int level,
     (void) file;
 #endif
 
-    if (NULL != p &&
-        NULL != p->pattern &&
-        NULL != strstr(str, p->pattern)) {
-        p->counter++;
+    /* Stop before doing anything else if the debug level is beyond this
+     * endpoint's threshold. */
+    if (level > ep->debug_threshold) {
+        return;
     }
+
+    ssl_log_analyzer(&ep->log_pattern, msg);
 }
+#endif /* MBEDTLS_DEBUG_C */
 
 void mbedtls_test_init_handshake_options(
     mbedtls_test_handshake_test_options *opts)
@@ -817,6 +831,14 @@ int mbedtls_test_ssl_endpoint_init_conf(
 
     ep->name = (endpoint_type == MBEDTLS_SSL_IS_SERVER) ? "Server" : "Client";
 
+#if defined(MBEDTLS_DEBUG_C)
+    ep->debug_threshold = options->debug_threshold;
+    ep->log_pattern.counter = 0;
+    ep->log_pattern.pattern = (endpoint_type == MBEDTLS_SSL_IS_SERVER ?
+                               options->srv_log_pattern :
+                               options->cli_log_pattern);
+#endif /* MBEDTLS_DEBUG_C */
+
     mbedtls_ssl_init(&(ep->ssl));
     mbedtls_ssl_config_init(&(ep->conf));
     mbedtls_test_message_socket_init(&ep->dtls_context);
@@ -927,20 +949,7 @@ int mbedtls_test_ssl_endpoint_init_conf(
 #endif
 
 #if defined(MBEDTLS_DEBUG_C)
-#if defined(MBEDTLS_SSL_SRV_C)
-    if (endpoint_type == MBEDTLS_SSL_IS_SERVER &&
-        options->srv_log_fun != NULL) {
-        mbedtls_ssl_conf_dbg(&(ep->conf), options->srv_log_fun,
-                             options->srv_log_obj);
-    }
-#endif
-#if defined(MBEDTLS_SSL_CLI_C)
-    if (endpoint_type == MBEDTLS_SSL_IS_CLIENT &&
-        options->cli_log_fun != NULL) {
-        mbedtls_ssl_conf_dbg(&(ep->conf), options->cli_log_fun,
-                             options->cli_log_obj);
-    }
-#endif
+    mbedtls_ssl_conf_dbg(&(ep->conf), mbedtls_test_ssl_debug_handler, ep);
 #endif /* MBEDTLS_DEBUG_C */
 
     ret = mbedtls_test_ssl_endpoint_certificate_init(ep, options->pk_alg,
@@ -1014,6 +1023,24 @@ int mbedtls_test_ssl_endpoint_init_ssl(
     TEST_EQUAL(mbedtls_ssl_get_user_data_n(&ep->ssl), ep->user_data_cookie);
     mbedtls_ssl_set_user_data_p(&ep->ssl, ep);
 
+#if defined(MBEDTLS_DEBUG_C)
+    /* Hack alert: we set the debug threshold to the highest meaningful level.
+     * We do it unconditionally so that it's easy to obtain debug logs for
+     * unit tests, even if the tests themselves don't care about logs.
+     * This way, mbedtls_test_ssl_debug_handler() is always called.
+     *
+     * In particular, this is independent of options->debug_threshold,
+     * which indicates how much the test case cares about logs.
+     * It's the job of mbedtls_test_ssl_debug_handler() to do any further
+     * filtering of the log level.
+     *
+     * This is a dirty hack because the debug threshold is a global state,
+     * and we won't be able to restore it correctly. See also
+     * mbedtls_test_ssl_endpoint_free().
+     */
+    mbedtls_debug_set_threshold(4);
+#endif /* MBEDTLS_DEBUG_C */
+
     return 0;
 
 exit:
@@ -1051,6 +1078,18 @@ void mbedtls_test_ssl_endpoint_free(
     } else {
         mbedtls_test_mock_socket_close(&(ep->socket));
     }
+
+#if defined(MBEDTLS_DEBUG_C)
+    /* Hack alert: the debug threshold is a global state.
+     * mbedtls_test_ssl_endpoint_init_ssl() sets it, and here we restore
+     * it to its default value. This is correct in the typical case where
+     * a test function calls mbedtls_test_ssl_endpoint_init_ssl() (often
+     * indirectly), then does stuff, and finally calls
+     * mbedtls_test_ssl_endpoint_free() as part of its cleanup. In more
+     * complex workflows, the debug threshold may not be restored correctly.
+     */
+    mbedtls_debug_set_threshold(0);
+#endif /* MBEDTLS_DEBUG_C */
 }
 
 int mbedtls_test_ssl_dtls_join_endpoints(mbedtls_test_ssl_endpoint *client,
@@ -2473,12 +2512,6 @@ void mbedtls_test_ssl_perform_handshake(
 
     MD_OR_USE_PSA_INIT();
 
-#if defined(MBEDTLS_DEBUG_C)
-    if (options->cli_log_fun || options->srv_log_fun) {
-        mbedtls_debug_set_threshold(4);
-    }
-#endif
-
     /* Client side */
     TEST_EQUAL(mbedtls_test_ssl_endpoint_init(client,
                                               MBEDTLS_SSL_IS_CLIENT,
@@ -2500,14 +2533,18 @@ void mbedtls_test_ssl_perform_handshake(
     TEST_ASSERT(mbedtls_ssl_conf_get_user_data_p(&server->conf) == server);
     TEST_ASSERT(mbedtls_ssl_get_user_data_p(&server->ssl) == server);
 
+#if defined(MBEDTLS_DEBUG_C)
+    if (options->cli_log_pattern != NULL) {
+        TEST_LE_U(1, client->log_pattern.counter);
+    }
+    if (options->srv_log_pattern != NULL) {
+        TEST_LE_U(1, server->log_pattern.counter);
+    }
+#endif /* MBEDTLS_DEBUG_C */
+
 exit:
     mbedtls_test_ssl_endpoint_free(client);
     mbedtls_test_ssl_endpoint_free(server);
-#if defined(MBEDTLS_DEBUG_C)
-    if (options->cli_log_fun || options->srv_log_fun) {
-        mbedtls_debug_set_threshold(0);
-    }
-#endif
     MD_OR_USE_PSA_DONE();
 }
 #endif /* MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED */

--- a/tests/src/test_helpers/ssl_helpers.c
+++ b/tests/src/test_helpers/ssl_helpers.c
@@ -33,28 +33,29 @@ static void ssl_log_analyzer(mbedtls_test_ssl_log_pattern *p,
     }
 }
 
+/* Change this value to see debug logs on stdout. Note that you need to
+ * run the test suite with -v, otherwise stdout is suppressed.
+ * Don't forget to NOT commit the change!
+ */
+int mbedtls_test_ssl_debug_stdout_threshold = 0;
+
 void mbedtls_test_ssl_debug_handler(void *ctx, int level,
                                     const char *file, int line,
                                     const char *msg)
 {
     mbedtls_test_ssl_endpoint *ep = ctx;
 
-/* Change 0 to 1 for debugging of test cases that use this function. */
-#if 0
-    const char *q, *basename;
-    /* Extract basename from file */
-    for (q = basename = file; *q != '\0'; q++) {
-        if (*q == '/' || *q == '\\') {
-            basename = q + 1;
+    if (level <= mbedtls_test_ssl_debug_stdout_threshold) {
+        const char *q, *basename;
+        /* Extract basename from file */
+        for (q = basename = file; *q != '\0'; q++) {
+            if (*q == '/' || *q == '\\') {
+                basename = q + 1;
+            }
         }
+        printf("%s:%04d: |%d| %s",
+               basename, line, level, msg);
     }
-    printf("%s:%04d: |%d| %s",
-           basename, line, level, str);
-#else
-    (void) level;
-    (void) line;
-    (void) file;
-#endif
 
     /* Stop before doing anything else if the debug level is beyond this
      * endpoint's threshold. */

--- a/tests/src/test_helpers/ssl_helpers.c
+++ b/tests/src/test_helpers/ssl_helpers.c
@@ -53,8 +53,8 @@ void mbedtls_test_ssl_debug_handler(void *ctx, int level,
                 basename = q + 1;
             }
         }
-        printf("%s:%04d: |%d| %s",
-               basename, line, level, msg);
+        printf("%s: %s:%04d: |%d| %s",
+               ep->name, basename, line, level, msg);
     }
 
     /* Stop before doing anything else if the debug level is beyond this

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -3138,11 +3138,14 @@ void handshake_fragmentation(int mfl,
                              int expected_cli_hs_fragmentation)
 {
     mbedtls_test_handshake_test_options options;
-    mbedtls_test_ssl_log_pattern srv_pattern, cli_pattern;
 
-    srv_pattern.pattern = cli_pattern.pattern = "found fragmented DTLS handshake";
-    srv_pattern.counter = 0;
-    cli_pattern.counter = 0;
+    options.debug_threshold = 2;
+    if (expected_cli_hs_fragmentation) {
+        options.cli_log_pattern = "found fragmented DTLS handshakeC";
+    }
+    if (expected_srv_hs_fragmentation) {
+        options.srv_log_pattern = "found fragmented DTLS handshakeS";
+    }
 
     mbedtls_test_init_handshake_options(&options);
     options.dtls = 1;
@@ -3151,21 +3154,10 @@ void handshake_fragmentation(int mfl,
     /* Set cipher to one using CBC so that record splitting can be tested */
     options.cipher = "TLS-ECDHE-RSA-WITH-AES-256-CBC-SHA384";
     options.srv_auth_mode = MBEDTLS_SSL_VERIFY_REQUIRED;
-    options.srv_log_obj = &srv_pattern;
-    options.cli_log_obj = &cli_pattern;
-    options.srv_log_fun = mbedtls_test_ssl_log_analyzer;
-    options.cli_log_fun = mbedtls_test_ssl_log_analyzer;
 
     mbedtls_test_ssl_perform_handshake(&options);
-
-    /* Test if the server received a fragmented handshake */
-    if (expected_srv_hs_fragmentation) {
-        TEST_ASSERT(srv_pattern.counter >= 1);
-    }
-    /* Test if the client received a fragmented handshake */
-    if (expected_cli_hs_fragmentation) {
-        TEST_ASSERT(cli_pattern.counter >= 1);
-    }
+    /* The goto below is used to avoid an "unused label" warning.*/
+    goto exit;
 
 exit:
     mbedtls_test_free_handshake_options(&options);
@@ -3199,19 +3191,9 @@ void recombine_server_first_flight(int version,
     mbedtls_test_init_handshake_options(&client_options);
     mbedtls_test_handshake_test_options server_options;
     mbedtls_test_init_handshake_options(&server_options);
-#if defined(MBEDTLS_DEBUG_C)
-    mbedtls_test_ssl_log_pattern cli_pattern = { .pattern = client_log };
-    mbedtls_test_ssl_log_pattern srv_pattern = { .pattern = server_log };
-#else
-    (void) client_log;
-    (void) server_log;
-#endif
     int ret = 0;
 
     MD_OR_USE_PSA_INIT();
-#if defined(MBEDTLS_DEBUG_C)
-    mbedtls_debug_set_threshold(3);
-#endif
 
     // Does't really matter but we want to know to declare dependencies.
     client_options.pk_alg = MBEDTLS_PK_ECDSA;
@@ -3220,8 +3202,10 @@ void recombine_server_first_flight(int version,
     client_options.client_min_version = version;
     client_options.client_max_version = version;
 #if defined(MBEDTLS_DEBUG_C)
-    client_options.cli_log_obj = &cli_pattern;
-    client_options.cli_log_fun = mbedtls_test_ssl_log_analyzer;
+    client_options.cli_log_pattern = client_log;
+    client_options.debug_threshold = 3;
+#else
+    (void) client_log;
 #endif
     TEST_EQUAL(mbedtls_test_ssl_endpoint_init(&client, MBEDTLS_SSL_IS_CLIENT,
                                               &client_options), 0);
@@ -3229,8 +3213,10 @@ void recombine_server_first_flight(int version,
     server_options.server_min_version = version;
     server_options.server_max_version = version;
 #if defined(MBEDTLS_DEBUG_C)
-    server_options.srv_log_obj = &srv_pattern;
-    server_options.srv_log_fun = mbedtls_test_ssl_log_analyzer;
+    server_options.srv_log_pattern = server_log;
+    server_options.debug_threshold = 3;
+#else
+    (void) server_log;
 #endif
     TEST_EQUAL(mbedtls_test_ssl_endpoint_init(&server, MBEDTLS_SSL_IS_SERVER,
                                               &server_options), 0);
@@ -3313,8 +3299,10 @@ void recombine_server_first_flight(int version,
 
 goal_reached:
 #if defined(MBEDTLS_DEBUG_C)
-    TEST_ASSERT(cli_pattern.counter >= 1);
-    TEST_ASSERT(srv_pattern.counter >= 1);
+    if (*client_log) {
+        TEST_LE_U(1, client.log_pattern.counter);
+    }
+    TEST_LE_U(1, server.log_pattern.counter);
 #endif
 
 exit:
@@ -3323,9 +3311,6 @@ exit:
     mbedtls_test_free_handshake_options(&client_options);
     mbedtls_test_free_handshake_options(&server_options);
     MD_OR_USE_PSA_DONE();
-#if defined(MBEDTLS_DEBUG_C)
-    mbedtls_debug_set_threshold(0);
-#endif
 }
 /* END_CASE */
 
@@ -3579,15 +3564,12 @@ void force_bad_session_id_len()
     mbedtls_test_ssl_endpoint client, server;
     memset(&client, 0, sizeof(client));
     memset(&server, 0, sizeof(server));
-    mbedtls_test_ssl_log_pattern srv_pattern, cli_pattern;
     mbedtls_test_message_socket_context server_context, client_context;
 
-    srv_pattern.pattern = cli_pattern.pattern = "cache did not store session";
-    srv_pattern.counter = 0;
     mbedtls_test_init_handshake_options(&options);
-
-    options.srv_log_obj = &srv_pattern;
-    options.srv_log_fun = mbedtls_test_ssl_log_analyzer;
+    options.debug_threshold = 1;
+    options.cli_log_pattern = "cache did not store session";
+    options.srv_log_pattern = "cache did not store session";
 
     mbedtls_test_message_socket_init(&server_context);
     mbedtls_test_message_socket_init(&client_context);
@@ -3598,10 +3580,6 @@ void force_bad_session_id_len()
 
     TEST_EQUAL(mbedtls_test_ssl_endpoint_init(&server, MBEDTLS_SSL_IS_SERVER,
                                               &options), 0);
-
-    mbedtls_debug_set_threshold(1);
-    mbedtls_ssl_conf_dbg(&server.conf, options.srv_log_fun,
-                         options.srv_log_obj);
 
     TEST_EQUAL(mbedtls_test_mock_socket_connect(&(client.socket),
                                                 &(server.socket),
@@ -3624,12 +3602,12 @@ void force_bad_session_id_len()
     }
 
     /* Make sure that the cache did not store the session */
-    TEST_EQUAL(srv_pattern.counter, 1);
+    TEST_EQUAL(1, server.log_pattern.counter);
+
 exit:
     mbedtls_test_ssl_endpoint_free(&client);
     mbedtls_test_ssl_endpoint_free(&server);
     mbedtls_test_free_handshake_options(&options);
-    mbedtls_debug_set_threshold(0);
     MD_OR_USE_PSA_DONE();
 }
 /* END_CASE */
@@ -4181,7 +4159,6 @@ void tls13_read_early_data(int scenario)
     mbedtls_test_handshake_test_options client_options;
     mbedtls_test_handshake_test_options server_options;
     mbedtls_ssl_session saved_session;
-    mbedtls_test_ssl_log_pattern server_pattern = { NULL, 0 };
     uint16_t group_list[3] = {
         MBEDTLS_SSL_IANA_TLS_GROUP_SECP256R1,
         MBEDTLS_SSL_IANA_TLS_GROUP_SECP384R1,
@@ -4234,15 +4211,15 @@ void tls13_read_early_data(int scenario)
             break;
 
         case TEST_EARLY_DATA_SERVER_REJECTS:
-            mbedtls_debug_set_threshold(3);
-            server_pattern.pattern =
+            server_options.debug_threshold = 3;
+            server_options.srv_log_pattern =
                 "EarlyData: deprotect and discard app data records.";
             server_options.early_data = MBEDTLS_SSL_EARLY_DATA_DISABLED;
             break;
 
         case TEST_EARLY_DATA_HRR:
-            mbedtls_debug_set_threshold(3);
-            server_pattern.pattern =
+            server_options.debug_threshold = 3;
+            server_options.srv_log_pattern =
                 "EarlyData: Ignore application message before 2nd ClientHello";
             server_options.group_list = group_list + 1;
             break;
@@ -4259,16 +4236,16 @@ void tls13_read_early_data(int scenario)
             client_options.alpn_list[1] = NULL;
             server_options.alpn_list[0] = "ALPNExample2";
             server_options.alpn_list[1] = NULL;
-            mbedtls_debug_set_threshold(3);
-            server_pattern.pattern =
+            server_options.debug_threshold = 3;
+            server_options.srv_log_pattern =
                 "EarlyData: rejected, the selected ALPN is different "
                 "from the one associated with the pre-shared key.";
             break;
         case TEST_EARLY_DATA_NO_LATER_ALPN:
             client_options.alpn_list[0] = NULL;
             server_options.alpn_list[0] = NULL;
-            mbedtls_debug_set_threshold(3);
-            server_pattern.pattern =
+            server_options.debug_threshold = 3;
+            server_options.srv_log_pattern =
                 "EarlyData: rejected, the selected ALPN is different "
                 "from the one associated with the pre-shared key.";
             break;
@@ -4282,8 +4259,6 @@ void tls13_read_early_data(int scenario)
                                          &client_options);
     TEST_EQUAL(ret, 0);
 
-    server_options.srv_log_fun = mbedtls_test_ssl_log_analyzer;
-    server_options.srv_log_obj = &server_pattern;
     ret = mbedtls_test_ssl_endpoint_init(&server_ep, MBEDTLS_SSL_IS_SERVER,
                                          &server_options);
     TEST_EQUAL(ret, 0);
@@ -4348,7 +4323,7 @@ void tls13_read_early_data(int scenario)
 #endif
             TEST_EQUAL(ret, 0);
             TEST_EQUAL(server_ep.ssl.handshake->early_data_accepted, 0);
-            TEST_EQUAL(server_pattern.counter, 1);
+            TEST_EQUAL(server_ep.log_pattern.counter, 1);
             break;
 
         default:
@@ -4365,7 +4340,6 @@ exit:
     mbedtls_test_free_handshake_options(&client_options);
     mbedtls_test_free_handshake_options(&server_options);
     mbedtls_ssl_session_free(&saved_session);
-    mbedtls_debug_set_threshold(0);
     PSA_DONE();
 }
 /* END_CASE */
@@ -5255,13 +5229,11 @@ void tls13_srv_max_early_data_size(int scenario, int max_early_data_size_arg, in
     mbedtls_test_handshake_test_options client_options;
     mbedtls_test_handshake_test_options server_options;
     mbedtls_ssl_session saved_session;
-    mbedtls_test_ssl_log_pattern server_pattern = { NULL, 0 };
     uint16_t group_list[3] = {
         MBEDTLS_SSL_IANA_TLS_GROUP_SECP256R1,
         MBEDTLS_SSL_IANA_TLS_GROUP_SECP384R1,
         MBEDTLS_SSL_IANA_TLS_GROUP_NONE
     };
-    char pattern[128];
     unsigned char *buf_write = NULL;
     uint32_t write_size = (uint32_t) write_size_arg;
     unsigned char *buf_read = NULL;
@@ -5303,20 +5275,15 @@ void tls13_srv_max_early_data_size(int scenario, int max_early_data_size_arg, in
     /*
      * Prepare for handshake with the ticket.
      */
-    server_options.srv_log_fun = mbedtls_test_ssl_log_analyzer;
-    server_options.srv_log_obj = &server_pattern;
-    server_pattern.pattern = pattern;
-
     switch (scenario) {
         case TEST_EARLY_DATA_ACCEPTED:
             break;
 
         case TEST_EARLY_DATA_SERVER_REJECTS:
             server_options.early_data = MBEDTLS_SSL_EARLY_DATA_DISABLED;
-            ret = mbedtls_snprintf(pattern, sizeof(pattern),
-                                   "EarlyData: deprotect and discard app data records.");
-            TEST_ASSERT(ret < (int) sizeof(pattern));
-            mbedtls_debug_set_threshold(3);
+            server_options.debug_threshold = 3;
+            server_options.srv_log_pattern =
+                "EarlyData: deprotect and discard app data records.";
             break;
 
         case TEST_EARLY_DATA_HRR:
@@ -5325,11 +5292,9 @@ void tls13_srv_max_early_data_size(int scenario, int max_early_data_size_arg, in
              * mbedtls_test_get_tls13_ticket() forcing an HelloRetryRequest.
              */
             server_options.group_list = group_list + 1;
-            ret = mbedtls_snprintf(
-                pattern, sizeof(pattern),
-                "EarlyData: Ignore application message before 2nd ClientHello");
-            TEST_ASSERT(ret < (int) sizeof(pattern));
-            mbedtls_debug_set_threshold(3);
+            server_options.debug_threshold = 3;
+            server_options.srv_log_pattern =
+                "EarlyData: Ignore application message before 2nd ClientHello";
             break;
 
         default:
@@ -5461,8 +5426,8 @@ void tls13_srv_max_early_data_size(int scenario, int max_early_data_size_arg, in
 
                 TEST_EQUAL(ret, MBEDTLS_ERR_SSL_WANT_READ);
 
-                TEST_EQUAL(server_pattern.counter, 1);
-                server_pattern.counter = 0;
+                TEST_EQUAL(server_ep.log_pattern.counter, 1);
+                server_ep.log_pattern.counter = 0;
                 if (expanded_early_data_chunk_size == 0) {
                     expanded_early_data_chunk_size = server_ep.ssl.total_early_data_size;
                 }
@@ -5471,17 +5436,15 @@ void tls13_srv_max_early_data_size(int scenario, int max_early_data_size_arg, in
         TEST_LE_U(server_ep.ssl.total_early_data_size, max_early_data_size);
     } while (1);
 
-    mbedtls_debug_set_threshold(3);
     ret = write_early_data(&(client_ep.ssl), buf_write, write_size);
     TEST_EQUAL(ret, write_size);
 
-    ret = mbedtls_snprintf(pattern, sizeof(pattern),
-                           "EarlyData: Too much early data received");
-    TEST_ASSERT(ret < (int) sizeof(pattern));
+    server_ep.debug_threshold = 3;
+    server_ep.log_pattern.pattern = "EarlyData: Too much early data received";
 
     ret = mbedtls_ssl_handshake(&(server_ep.ssl));
     TEST_EQUAL(ret, MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE);
-    TEST_EQUAL(server_pattern.counter, 1);
+    TEST_EQUAL(server_ep.log_pattern.counter, 1);
 
 exit:
     mbedtls_test_ssl_endpoint_free(&client_ep);
@@ -5491,7 +5454,6 @@ exit:
     mbedtls_ssl_session_free(&saved_session);
     mbedtls_free(buf_write);
     mbedtls_free(buf_read);
-    mbedtls_debug_set_threshold(0);
     PSA_DONE();
 }
 /* END_CASE */
@@ -5519,16 +5481,12 @@ void inject_client_content_on_the_wire(int pk_alg,
     mbedtls_platform_zeroize(&client, sizeof(client));
     mbedtls_test_handshake_test_options options;
     mbedtls_test_init_handshake_options(&options);
-    mbedtls_test_ssl_log_pattern srv_pattern;
-    memset(&srv_pattern, 0, sizeof(srv_pattern));
     int ret = -1;
 
     PSA_INIT();
 
-    srv_pattern.pattern = log_pattern;
-    options.srv_log_obj = &srv_pattern;
-    options.srv_log_fun = mbedtls_test_ssl_log_analyzer;
-    mbedtls_debug_set_threshold(3);
+    options.debug_threshold = 3;
+    options.srv_log_pattern = log_pattern;
 
     options.pk_alg = pk_alg;
 
@@ -5560,13 +5518,12 @@ void inject_client_content_on_the_wire(int pk_alg,
         ret = mbedtls_ssl_handshake_step(&server.ssl);
     } while (ret == 0 && server.ssl.state == state);
     TEST_EQUAL(ret, expected_ret);
-    TEST_ASSERT(srv_pattern.counter >= 1);
+    TEST_LE_U(1, server.log_pattern.counter);
 
 exit:
     mbedtls_test_free_handshake_options(&options);
     mbedtls_test_ssl_endpoint_free(&server);
     mbedtls_test_ssl_endpoint_free(&client);
-    mbedtls_debug_set_threshold(0);
     PSA_DONE();
 }
 /* END_CASE */
@@ -5591,9 +5548,6 @@ void send_large_fragmented_hello(int hs_len_int, int first_frag_content_len_int,
     mbedtls_test_handshake_test_options options;
     mbedtls_test_init_handshake_options(&options);
 
-    mbedtls_test_ssl_log_pattern srv_pattern;
-    memset(&srv_pattern, 0, sizeof(srv_pattern));
-
     unsigned char *first_frag = NULL;
     int ret = -1;
 
@@ -5602,10 +5556,10 @@ void send_large_fragmented_hello(int hs_len_int, int first_frag_content_len_int,
 
     PSA_INIT();
 
-    srv_pattern.pattern = log_pattern;
-    options.srv_log_obj = &srv_pattern;
-    options.srv_log_fun = mbedtls_test_ssl_log_analyzer;
-    mbedtls_debug_set_threshold(1);
+#if defined(MBEDTLS_DEBUG_C)
+    options.debug_threshold = 1;
+    options.srv_log_pattern = log_pattern;
+#endif
 
     // Does't really matter but we want to know to declare dependencies.
     options.pk_alg = MBEDTLS_PK_ECDSA;
@@ -5674,13 +5628,14 @@ void send_large_fragmented_hello(int hs_len_int, int first_frag_content_len_int,
         }
     }
     TEST_EQUAL(ret, expected_ret);
-    TEST_EQUAL(srv_pattern.counter, 1);
+#if defined(MBEDTLS_DEBUG_C)
+    TEST_LE_U(1, server.log_pattern.counter);
+#endif
 
 exit:
     mbedtls_test_free_handshake_options(&options);
     mbedtls_test_ssl_endpoint_free(&server);
     mbedtls_test_ssl_endpoint_free(&client);
-    mbedtls_debug_set_threshold(0);
     mbedtls_free(first_frag);
     PSA_DONE();
 }


### PR DESCRIPTION
Simplify the use of SSL debug logs (provided by `debug.c`) in unit tests.

1. Streamline log pattern searches in unit tests: now you just need to declare the pattern to search, and the test helpers will set things up.
2. Make it easier to get debug logs on stdout while debugging: set `mbedtls_test_ssl_debug_stdout_threshold = 4;` in the C code and run `tests/test_suite_ssl -v`.

Follow-up: I'd prefer to write debug logs to a file if `MBEDTLS_SSL_DEBUG=filename.log` is set in the environment. But I haven't coded this yet.

Code extracted from #10217.

Builds on https://github.com/Mbed-TLS/mbedtls/pull/10197. The same remarks apply regarding a 3.6 backport.

## PR checklist

- [x] **changelog** not required because: test only
- [x] **development PR** here
- [x] **TF-PSA-Crypto PR** not required because: SSL only
- [x] **framework PR** provided Mbed-TLS/mbedtls-framework# | not required
- [x] **3.6 PR** not required because: depends on https://github.com/Mbed-TLS/mbedtls/pull/10197
- **tests**  provided
