### PR TITLE
Remove DES from Mbed TLS core (except references blocked by TF PSA Crypto)

### DIFF
--- a/programs/test/selftest.c
+++ b/programs/test/selftest.c
@@ -21,7 +21,6 @@
 #include "mbedtls/sha256.h"
 #include "mbedtls/sha512.h"
 #include "mbedtls/sha3.h"
-#include "mbedtls/des.h"
 #include "mbedtls/aes.h"
 #include "mbedtls/camellia.h"
 #include "mbedtls/aria.h"
@@ -296,9 +295,6 @@ const selftest_t selftests[] =
     defined(PSA_WANT_ALG_SHA3_512)
     { "sha3", mbedtls_sha3_self_test },
 #endif
-#if defined(MBEDTLS_DES_C)
-    { "des", mbedtls_des_self_test },
-#endif
 #if defined(MBEDTLS_AES_C)
     { "aes", mbedtls_aes_self_test },
 #endif
@@ -448,7 +444,8 @@ int main(int argc, char *argv[])
             }                                                           \
         } else {                                                        \
             mbedtls_printf("Padding checks only implemented for types of size 2, 4 or 8" \
-                           " - cannot check type '" #TYPE "' of size %" MBEDTLS_PRINTF_SIZET "\n",       \
+                           " - cannot check type '" #TYPE "' of size %" MBEDTLS_PRINTF_SIZET \
+                           "\n",       \
                            sizeof(TYPE));                                       \
             mbedtls_exit(MBEDTLS_EXIT_FAILURE);                       \
         }                                                               \

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -75,7 +75,7 @@ EXCLUDE_FROM_FULL = frozenset([
     #pylint: disable=line-too-long
     'MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH', # interacts with CTR_DRBG_128_BIT_KEY
     'MBEDTLS_AES_USE_HARDWARE_ONLY', # hardware dependency
-    'MBEDTLS_BLOCK_CIPHER_NO_DECRYPT', # incompatible with ECB in PSA, CBC/XTS/NIST_KW/DES
+    'MBEDTLS_BLOCK_CIPHER_NO_DECRYPT', # incompatible with ECB in PSA, CBC/XTS/NIST_KW
     'MBEDTLS_CTR_DRBG_USE_128_BIT_KEY', # interacts with ENTROPY_FORCE_SHA256
     'MBEDTLS_DEPRECATED_REMOVED', # conflicts with deprecated options
     'MBEDTLS_DEPRECATED_WARNING', # conflicts with deprecated options

--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -599,11 +599,6 @@ setup_arguments()
         *) O_SUPPORT_STATIC_ECDH="NO";;
     esac
 
-    case $($OPENSSL ciphers ALL) in
-        *DES-CBC-*) O_SUPPORT_SINGLE_DES="YES";;
-        *) O_SUPPORT_SINGLE_DES="NO";;
-    esac
-
     # OpenSSL <1.0.2 doesn't support DTLS 1.2. Check if OpenSSL
     # supports -dtls1_2 from the s_server help. (The s_client
     # help isn't accurate as of 1.0.2g: it supports DTLS 1.2

--- a/tests/scripts/components-configuration-crypto.sh
+++ b/tests/scripts/components-configuration-crypto.sh
@@ -1734,53 +1734,6 @@ component_test_psa_crypto_config_reference_hmac () {
     make test
 }
 
-component_test_psa_crypto_config_accel_des () {
-    msg "test: accelerated DES"
-
-    # Albeit this components aims at accelerating DES which should only support
-    # CBC and ECB modes, we need to accelerate more than that otherwise DES_C
-    # would automatically be re-enabled by "config_adjust_legacy_from_psa.c"
-    loc_accel_list="ALG_ECB_NO_PADDING ALG_CBC_NO_PADDING ALG_CBC_PKCS7 \
-                    ALG_CTR ALG_CFB ALG_OFB ALG_XTS ALG_CMAC \
-                    KEY_TYPE_DES"
-
-    # Note: we cannot accelerate all ciphers' key types otherwise we would also
-    # have to either disable CCM/GCM or accelerate them, but that's out of scope
-    # of this component. This limitation will be addressed by #8598.
-
-    # Configure
-    # ---------
-
-    # Start from the full config
-    helper_libtestdriver1_adjust_config "full"
-
-    # Disable the things that are being accelerated
-    scripts/config.py unset MBEDTLS_CIPHER_MODE_CBC
-    scripts/config.py unset MBEDTLS_CIPHER_PADDING_PKCS7
-    scripts/config.py unset MBEDTLS_CIPHER_MODE_CTR
-    scripts/config.py unset MBEDTLS_CIPHER_MODE_CFB
-    scripts/config.py unset MBEDTLS_CIPHER_MODE_OFB
-    scripts/config.py unset MBEDTLS_CIPHER_MODE_XTS
-    scripts/config.py unset MBEDTLS_DES_C
-    scripts/config.py unset MBEDTLS_CMAC_C
-
-    # Build
-    # -----
-
-    helper_libtestdriver1_make_drivers "$loc_accel_list"
-
-    helper_libtestdriver1_make_main "$loc_accel_list"
-
-    # Make sure this was not re-enabled by accident (additive config)
-    not grep mbedtls_des ${BUILTIN_SRC_PATH}/des.o
-
-    # Run the tests
-    # -------------
-
-    msg "test: accelerated DES"
-    make test
-}
-
 component_test_psa_crypto_config_accel_aead () {
     msg "test: accelerated AEAD"
 
@@ -1841,7 +1794,7 @@ component_test_psa_crypto_config_accel_cipher_aead_cmac () {
     loc_accel_list="ALG_ECB_NO_PADDING ALG_CBC_NO_PADDING ALG_CBC_PKCS7 ALG_CTR ALG_CFB \
                     ALG_OFB ALG_XTS ALG_STREAM_CIPHER ALG_CCM_STAR_NO_TAG \
                     ALG_GCM ALG_CCM ALG_CHACHA20_POLY1305 ALG_CMAC \
-                    KEY_TYPE_DES KEY_TYPE_AES KEY_TYPE_ARIA KEY_TYPE_CHACHA20 KEY_TYPE_CAMELLIA"
+                    KEY_TYPE_AES KEY_TYPE_ARIA KEY_TYPE_CHACHA20 KEY_TYPE_CAMELLIA"
 
     # Configure
     # ---------
@@ -1878,7 +1831,6 @@ component_test_psa_crypto_config_accel_cipher_aead_cmac () {
 
     # Make sure this was not re-enabled by accident (additive config)
     not grep mbedtls_cipher ${BUILTIN_SRC_PATH}/cipher.o
-    not grep mbedtls_des ${BUILTIN_SRC_PATH}/des.o
     not grep mbedtls_aes ${BUILTIN_SRC_PATH}/aes.o
     not grep mbedtls_aria ${BUILTIN_SRC_PATH}/aria.o
     not grep mbedtls_camellia ${BUILTIN_SRC_PATH}/camellia.o
@@ -2168,7 +2120,7 @@ component_build_aes_variations () {
     cd "$MBEDTLS_ROOT_DIR"
     msg "build: aes.o for all combinations of relevant config options + BLOCK_CIPHER_NO_DECRYPT"
 
-    # MBEDTLS_BLOCK_CIPHER_NO_DECRYPT is incompatible with ECB in PSA, CBC/XTS/NIST_KW/DES,
+    # MBEDTLS_BLOCK_CIPHER_NO_DECRYPT is incompatible with ECB in PSA, CBC/XTS/NIST_KW,
     # manually set or unset those configurations to check
     # MBEDTLS_BLOCK_CIPHER_NO_DECRYPT with various combinations in aes.o.
     scripts/config.py set MBEDTLS_BLOCK_CIPHER_NO_DECRYPT

--- a/tests/scripts/components-configuration-crypto.sh
+++ b/tests/scripts/components-configuration-crypto.sh
@@ -1818,6 +1818,10 @@ component_test_psa_crypto_config_accel_cipher_aead_cmac () {
     scripts/config.py unset MBEDTLS_CHACHA20_C
     scripts/config.py unset MBEDTLS_CAMELLIA_C
 
+    # Disable DES, if it still exists.
+    # This can be removed once we remove DES from the library.
+    scripts/config.py unset PSA_WANT_KEY_TYPE_DES
+
     # Disable CIPHER_C entirely as all ciphers/AEADs are accelerated and PSA
     # does not depend on it.
     scripts/config.py unset MBEDTLS_CIPHER_C
@@ -1855,6 +1859,10 @@ component_test_psa_crypto_config_accel_cipher_aead_cmac () {
 component_test_psa_crypto_config_reference_cipher_aead_cmac () {
     msg "build: full config with non-accelerated cipher inc. AEAD and CMAC"
     common_psa_crypto_config_accel_cipher_aead_cmac
+
+    # Disable DES, if it still exists.
+    # This can be removed once we remove DES from the library.
+    scripts/config.py unset PSA_WANT_KEY_TYPE_DES
 
     make
 

--- a/tests/scripts/components-configuration-tls.sh
+++ b/tests/scripts/components-configuration-tls.sh
@@ -63,7 +63,7 @@ component_test_tls1_2_default_stream_cipher_only () {
     # Disable CBC. Note: When implemented, PSA_WANT_ALG_CBC_MAC will also need to be unset here to fully disable CBC
     scripts/config.py -c $CRYPTO_CONFIG_H unset PSA_WANT_ALG_CBC_NO_PADDING
     scripts/config.py -c $CRYPTO_CONFIG_H unset PSA_WANT_ALG_CBC_PKCS7
-    # Disable CBC-legacy (controlled by MBEDTLS_CIPHER_MODE_CBC plus at least one block cipher (AES, ARIA, Camellia, DES))
+    # Disable CBC-legacy (controlled by MBEDTLS_CIPHER_MODE_CBC plus at least one block cipher (AES, ARIA, Camellia))
     # Note: The unset below is to be removed for 4.0
     scripts/config.py unset MBEDTLS_CIPHER_MODE_CBC
     # Disable CBC-EtM (controlled by the same as CBC-legacy plus MBEDTLS_SSL_ENCRYPT_THEN_MAC)
@@ -96,7 +96,7 @@ component_test_tls1_2_default_cbc_legacy_cipher_only () {
     scripts/config.py unset MBEDTLS_CHACHAPOLY_C
     #Disable TLS 1.3 (as no AEAD)
     scripts/config.py unset MBEDTLS_SSL_PROTO_TLS1_3
-    # Enable CBC-legacy (controlled by MBEDTLS_CIPHER_MODE_CBC plus at least one block cipher (AES, ARIA, Camellia, DES))
+    # Enable CBC-legacy (controlled by MBEDTLS_CIPHER_MODE_CBC plus at least one block cipher (AES, ARIA, Camellia))
     scripts/config.py -c $CRYPTO_CONFIG_H set PSA_WANT_ALG_CBC_NO_PADDING
     # Disable CBC-EtM (controlled by the same as CBC-legacy plus MBEDTLS_SSL_ENCRYPT_THEN_MAC)
     scripts/config.py unset MBEDTLS_SSL_ENCRYPT_THEN_MAC
@@ -129,7 +129,7 @@ component_test_tls1_2_default_cbc_legacy_cbc_etm_cipher_only () {
     scripts/config.py unset MBEDTLS_CHACHAPOLY_C
     #Disable TLS 1.3 (as no AEAD)
     scripts/config.py unset MBEDTLS_SSL_PROTO_TLS1_3
-    # Enable CBC-legacy (controlled by MBEDTLS_CIPHER_MODE_CBC plus at least one block cipher (AES, ARIA, Camellia, DES))
+    # Enable CBC-legacy (controlled by MBEDTLS_CIPHER_MODE_CBC plus at least one block cipher (AES, ARIA, Camellia))
     scripts/config.py -c $CRYPTO_CONFIG_H set PSA_WANT_ALG_CBC_NO_PADDING
     # Enable CBC-EtM (controlled by the same as CBC-legacy plus MBEDTLS_SSL_ENCRYPT_THEN_MAC)
     scripts/config.py set MBEDTLS_SSL_ENCRYPT_THEN_MAC


### PR DESCRIPTION
## Description

This PR removes remaining DES-related code and references from the Mbed TLS core that do not depend on TF-PSA-Crypto as part of the larger DES removal tracked in [#9164](https://github.com/Mbed-TLS/mbedtls/issues/9164).

Specifically:
- Removed DES self-test from `programs/test/selftest.c`
- Removed DES detection logic from `tests/compat.sh` (dead code)
- Removed `component_test_psa_crypto_config_accel_des` from `tests/scripts/components-configuration-crypto.sh`
- Removed DES comments from:
  - `scripts/config.py`
  - `tests/scripts/components-configuration-tls.sh`

This PR does not update changelogs or documentation files. Those will be addressed separately after the full DES removal is complete.

Generated build artifacts (under `build/`) were not modified or committed.
All tests pass locally.

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [ ] **changelog** not required because that will be provided in a follow-up commit after final DES cleanup.
- [X] **development PR** provided here
- [ ] **TF-PSA-Crypto PR** not required because this PR does not touch TF-PSA-Crypto.
- [ ] **framework PR** not required
- [ ] **3.6 PR** not required because DES removal is only applicable to Mbed TLS 4.0 and later.
- **tests**  not required because no new tests were added; existing tests confirm a clean build.



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.