### PR TITLE
Allow builds with no RNG but entropy in an NV seed: prepare Mbed TLS

### DIFF
--- a/configs/crypto-config-ccm-psk-tls1_2.h
+++ b/configs/crypto-config-ccm-psk-tls1_2.h
@@ -31,15 +31,9 @@
 
 #define MBEDTLS_CTR_DRBG_C
 #define MBEDTLS_ENTROPY_C
+#define MBEDTLS_PSA_BUILTIN_GET_ENTROPY
 
 /* Save RAM at the expense of ROM */
 #define MBEDTLS_AES_ROM_TABLES
-
-/*
- * You should adjust this to the exact number of sources you're using: default
- * is the "platform_entropy_poll" source, but you may want to add other ones
- * Minimum is 2 for the entropy test suite.
- */
-#define MBEDTLS_ENTROPY_MAX_SOURCES 2
 
 #endif /* PSA_CRYPTO_CONFIG_H */

--- a/configs/crypto-config-suite-b.h
+++ b/configs/crypto-config-suite-b.h
@@ -51,6 +51,7 @@
 #define MBEDTLS_ENTROPY_C
 #define MBEDTLS_PK_C
 #define MBEDTLS_PK_PARSE_C
+#define MBEDTLS_PSA_BUILTIN_GET_ENTROPY
 
 /* For test certificates */
 #define MBEDTLS_BASE64_C
@@ -69,10 +70,4 @@
 /* Significant speed benefit at the expense of some ROM */
 #define MBEDTLS_ECP_NIST_OPTIM
 
-/*
- * You should adjust this to the exact number of sources you're using: default
- * is the "mbedtls_platform_entropy_poll" source, but you may want to add other ones.
- * Minimum is 2 for the entropy test suite.
- */
-#define MBEDTLS_ENTROPY_MAX_SOURCES 2
 #endif /* PSA_CRYPTO_CONFIG_H */

--- a/configs/crypto-config-thread.h
+++ b/configs/crypto-config-thread.h
@@ -60,6 +60,7 @@
 #define MBEDTLS_MD_C
 #define MBEDTLS_PK_C
 #define MBEDTLS_PK_PARSE_C
+#define MBEDTLS_PSA_BUILTIN_GET_ENTROPY
 
 /* Save RAM at the expense of ROM */
 #define MBEDTLS_AES_ROM_TABLES

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -89,6 +89,7 @@ EXCLUDE_FROM_FULL = frozenset([
     'MBEDTLS_NO_64BIT_MULTIPLICATION', # influences anything that uses bignum
     'MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES', # removes a feature
     'MBEDTLS_NO_UDBL_DIVISION', # influences anything that uses bignum
+    'MBEDTLS_PSA_DRIVER_GET_ENTROPY', # incompatible with MBEDTLS_PSA_BUILTIN_GET_ENTROPY
     'MBEDTLS_PSA_P256M_DRIVER_ENABLED', # influences SECP256R1 KeyGen/ECDH/ECDSA
     'MBEDTLS_PLATFORM_NO_STD_FUNCTIONS', # removes a feature
     'MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS', # removes a feature

--- a/tests/scripts/analyze_outcomes.py
+++ b/tests/scripts/analyze_outcomes.py
@@ -62,6 +62,12 @@ class CoverageTask(outcome_analysis.CoverageTask):
             # https://github.com/Mbed-TLS/mbedtls/issues/9586
             'Config: !MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_ENABLED',
         ],
+        'test_suite_config.crypto_combinations': [
+            # New thing in crypto. Not intended to be tested separately
+            # in mbedtls.
+            # https://github.com/Mbed-TLS/mbedtls/issues/10300
+            'Config: entropy: NV seed only',
+        ],
         'test_suite_config.psa_boolean': [
             # We don't test with HMAC disabled.
             # https://github.com/Mbed-TLS/mbedtls/issues/9591


### PR DESCRIPTION
Just what it takes to make https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/369 work. Contributes to https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/307

First in a chain. See https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/369 for the merge order.

## PR checklist

- [x] **changelog** not required because: happening in crypto
- [x] **development PR** here
- [x] **TF-PSA-Crypto PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/369
- [x] **framework PR** provided https://github.com/Mbed-TLS/mbedtls-framework#178
- [x] **3.6 PR** not required because: new stuff
- **tests**  provided
