### PR TITLE
Clean up ci.requirements.txt

### DIFF
--- a/scripts/ci.requirements.txt
+++ b/scripts/ci.requirements.txt
@@ -17,7 +17,10 @@ mypy == 0.942
 
 # At the time of writing, only needed for tests/scripts/audit-validity-dates.py.
 # It needs >=35.0.0 for correct operation, and that requires Python >=3.6.
-cryptography >= 35.0.0
+# >=35.0.0 also requires Rust to build from source, which we are forced to do on
+# FreeBSD, since PyPI doesn't carry binary wheels for the BSDs.
+# Disable on FreeBSD until we get a Rust toolchain up and running on the CI.
+cryptography >= 35.0.0; platform_system != 'FreeBSD'
 
 # For building `framework/data_files/server9-bad-saltlen.crt` and check python
 # files.

--- a/scripts/ci.requirements.txt
+++ b/scripts/ci.requirements.txt
@@ -2,10 +2,12 @@
 
 -r driver.requirements.txt
 
+# The dependencies below are only used in scripts that we run on the Linux CI.
+
 # Use a known version of Pylint, because new versions tend to add warnings
 # that could start rejecting our code.
 # 2.4.4 is the version in Ubuntu 20.04. It supports Python >=3.5.
-pylint == 2.4.4
+pylint == 2.4.4; platform_system == 'Linux'
 
 # Use a version of mypy that is compatible with our code base.
 # mypy <0.940 is known not to work: see commit
@@ -13,15 +15,14 @@ pylint == 2.4.4
 # mypy >=0.960 is known not to work:
 #   https://github.com/Mbed-TLS/mbedtls-framework/issues/50
 # mypy 0.942 is the version in Ubuntu 22.04.
-mypy == 0.942
+mypy == 0.942; platform_system == 'Linux'
 
 # At the time of writing, only needed for tests/scripts/audit-validity-dates.py.
 # It needs >=35.0.0 for correct operation, and that requires Python >=3.6.
 # >=35.0.0 also requires Rust to build from source, which we are forced to do on
 # FreeBSD, since PyPI doesn't carry binary wheels for the BSDs.
-# Disable on FreeBSD until we get a Rust toolchain up and running on the CI.
-cryptography >= 35.0.0; platform_system != 'FreeBSD'
+cryptography >= 35.0.0; platform_system == 'Linux'
 
 # For building `framework/data_files/server9-bad-saltlen.crt` and check python
 # files.
-asn1crypto
+asn1crypto; platform_system == 'Linux'

--- a/scripts/ci.requirements.txt
+++ b/scripts/ci.requirements.txt
@@ -16,12 +16,8 @@ pylint == 2.4.4
 mypy == 0.942
 
 # At the time of writing, only needed for tests/scripts/audit-validity-dates.py.
-# It needs >=35.0.0 for correct operation, and that requires Python >=3.6,
-# but our CI has Python 3.5. So let pip install the newest version that's
-# compatible with the running Python: this way we get something good enough
-# for mypy and pylint under Python 3.5, and we also get something good enough
-# to run audit-validity-dates.py on Python >=3.6.
-cryptography # >= 35.0.0
+# It needs >=35.0.0 for correct operation, and that requires Python >=3.6.
+cryptography >= 35.0.0
 
 # For building `framework/data_files/server9-bad-saltlen.crt` and check python
 # files.


### PR DESCRIPTION
## Description

Workaround for Mbed-TLS/mbedtls-test#214

The dependency on cryptography was declared without a version constraint due to us using Python 3.5 on the CI in certain places.
We no longer have a dependency on 3.5, so re-introduce the version constraint.

Cryptography is also causing us issues on the FreeBSD CI due to it needing a Rust toolchain.
Since it is unused on FreeBSD, disable it until we get a toolchain up and running.

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [ ] **changelog** not required: Not a user-facing change
- [ ] **TF-PSA-Crypto PR** https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/378
- [ ] **framework PR** provided not required
- [ ] **3.6 PR** #10303
- **tests**  not required 