### PR TITLE
Mechanism to error out on removed configuration options

### DIFF
--- a/include/mbedtls/build_info.h
+++ b/include/mbedtls/build_info.h
@@ -68,6 +68,11 @@
 #include MBEDTLS_USER_CONFIG_FILE
 #endif
 
+/* For the sake of consistency checks in mbedtls_config.c */
+#if defined(MBEDTLS_INCLUDE_AFTER_RAW_CONFIG)
+#include MBEDTLS_INCLUDE_AFTER_RAW_CONFIG
+#endif
+
 /* Indicate that all configuration files have been read.
  * It is now time to adjust the configuration (follow through on dependencies,
  * make PSA and legacy crypto consistent, etc.).

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -118,6 +118,13 @@ if(GEN_FILES)
             ${CMAKE_CURRENT_BINARY_DIR}/ssl_debug_helpers_generated.c
             ${CMAKE_CURRENT_BINARY_DIR}/version_features.c
     )
+
+    # List generated headers as sources explicitly. Normally CMake finds
+    # headers by tracing include directives, but if that happens before the
+    # generated headers are generated, this process doesn't find them.
+    list(APPEND src_x509
+        ${MBEDTLS_GENERATED_CONFIG_CHECKS_HEADERS}
+    )
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCC)
@@ -237,7 +244,9 @@ foreach(target IN LISTS target_libraries)
                $<INSTALL_INTERFACE:include/>
         PRIVATE ${MBEDTLS_DIR}/library/
                 ${MBEDTLS_DIR}/tf-psa-crypto/core
-                ${MBEDTLS_DIR}/tf-psa-crypto/drivers/builtin/src)
+                ${MBEDTLS_DIR}/tf-psa-crypto/drivers/builtin/src
+                # needed for generated headers
+                ${CMAKE_CURRENT_BINARY_DIR})
     set_config_files_compile_definitions(${target})
     install(
         TARGETS ${target}

--- a/library/Makefile
+++ b/library/Makefile
@@ -346,6 +346,8 @@ $(GENERATED_CONFIG_CHECK_FILES):
 	echo "  Gen   $(GENERATED_CONFIG_CHECK_FILES)"
 	$(PYTHON) ../scripts/generate_config_checks.py
 
+mbedtls_config.o: $(GENERATED_CONFIG_CHECK_FILES)
+
 TF_PSA_CRYPTO_GENERATED_CONFIG_CHECK_FILES = $(shell $(PYTHON) \
 	$(TF_PSA_CRYPTO_CORE_PATH)/../scripts/generate_config_checks.py \
 	--list $(TF_PSA_CRYPTO_CORE_PATH))

--- a/library/mbedtls_config.c
+++ b/library/mbedtls_config.c
@@ -6,8 +6,29 @@
  *  SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
  */
 
+/* Apply the TF-PSA-Crypto configuration first. We need to do this
+ * before <mbedtls/build_info.h>, because "mbedtls_config_check_before.h"
+ * needs to run after the crypto config (including derived macros) is
+ * finalized, but before the user's mbedtls config is applied. This way
+ * it is possible to differentiate macros set by the user's mbedtls config
+ * from macros set or derived by the crypto config. */
+#include <tf-psa-crypto/build_info.h>
+
+/* Consistency checks on the user's configuration.
+ * Check that it doesn't define macros that we assume are under full
+ * control of the library, or options from past major versions that
+ * no longer have any effect.
+ * These headers are automatically generated. See
+ * framework/scripts/mbedtls_framework/config_checks_generator.py
+ */
+#include "mbedtls_config_check_before.h"
+#define MBEDTLS_INCLUDE_AFTER_RAW_CONFIG "mbedtls_config_check_user.h"
+
 #include <mbedtls/build_info.h>
 
 /* Consistency checks in the configuration: check for incompatible options,
  * missing options when at least one of a set needs to be enabled, etc. */
+/* Manually written checks */
 #include "mbedtls_check_config.h"
+/* Automatically generated checks */
+#include "mbedtls_config_check_final.h"

--- a/scripts/generate_config_checks.py
+++ b/scripts/generate_config_checks.py
@@ -16,6 +16,11 @@ class CryptoInternal(SubprojectInternal):
 class CryptoOption(SubprojectOption):
     SUBPROJECT = 'psa/crypto_config.h'
 
+ALWAYS_ENABLED_SINCE_4_0 = frozenset([
+    'MBEDTLS_PSA_CRYPTO_CONFIG',
+    'MBEDTLS_USE_PSA_CRYPTO',
+])
+
 def checkers_for_removed_options() -> Iterator[Checker]:
     """Discover removed options. Yield corresponding checkers."""
     history = config_history.ConfigHistory()
@@ -24,6 +29,8 @@ def checkers_for_removed_options() -> Iterator[Checker]:
     crypto_public = history.options('tfpsacrypto', '1.0')
     crypto_internal = history.internal('tfpsacrypto', '1.0')
     for option in sorted(old_public - new_public):
+        if option in ALWAYS_ENABLED_SINCE_4_0:
+            continue
         if option in crypto_public:
             yield CryptoOption(option)
         elif option in crypto_internal:

--- a/scripts/generate_config_checks.py
+++ b/scripts/generate_config_checks.py
@@ -7,11 +7,19 @@ import framework_scripts_path # pylint: disable=unused-import
 from mbedtls_framework.config_checks_generator import * \
     #pylint: disable=wildcard-import,unused-wildcard-import
 
+class CryptoInternal(SubprojectInternal):
+    SUBPROJECT = 'TF-PSA-Crypto'
+
+class CryptoOption(SubprojectOption):
+    SUBPROJECT = 'psa/crypto_config.h'
+
 MBEDTLS_CHECKS = BranchData(
     header_directory='library',
     header_prefix='mbedtls_',
     project_cpp_prefix='MBEDTLS',
     checkers=[
+        CryptoInternal('MBEDTLS_MD5_C', 'PSA_WANT_ALG_MD5 in psa/crypto_config.h'),
+        CryptoOption('MBEDTLS_BASE64_C'),
         Removed('MBEDTLS_KEY_EXCHANGE_RSA_ENABLED', 'Mbed TLS 4.0'),
         Removed('MBEDTLS_PADLOCK_C', 'Mbed TLS 4.0'),
     ],

--- a/tests/scripts/test_config_checks.py
+++ b/tests/scripts/test_config_checks.py
@@ -55,5 +55,43 @@ class MbedtlsTestConfigChecks(unittest_config_checks.TestConfigChecks):
                       error=('MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED'))
 
 
+    def test_define_MBEDTLS_MD5_C_redundant(self) -> None:
+        """Error when redundantly setting a subproject internal option."""
+        self.bad_case('#define PSA_WANT_ALG_MD5 1',
+                      '#define MBEDTLS_MD5_C',
+                      error=r'MBEDTLS_MD5_C.* PSA_WANT_ALG_MD5 in psa/crypto_config\.h')
+
+    def test_define_MBEDTLS_MD5_C_added(self) -> None:
+        """Error when setting a subproject internal option that was disabled."""
+        self.bad_case('''
+                      #undef PSA_WANT_ALG_MD5
+                      #undef MBEDTLS_MD5_C
+                      ''',
+                      '#define MBEDTLS_MD5_C',
+                      error=r'MBEDTLS_MD5_C.* PSA_WANT_ALG_MD5 in psa/crypto_config\.h')
+
+    def test_define_MBEDTLS_BASE64_C_redundant(self) -> None:
+        """Ok to redundantly set a subproject option."""
+        self.good_case(None,
+                       '#define MBEDTLS_BASE64_C')
+
+    def test_define_MBEDTLS_BASE64_C_added(self) -> None:
+        """Error when setting a subproject option that was disabled."""
+        self.bad_case('''
+                      #undef MBEDTLS_BASE64_C
+                      #undef MBEDTLS_PEM_PARSE_C
+                      #undef MBEDTLS_PEM_WRITE_C
+                      ''',
+                      '#define MBEDTLS_BASE64_C',
+                      error=r'MBEDTLS_BASE64_C .*psa/crypto_config\.h')
+
+    @unittest.skip("Checks for #undef are not implemented yet.")
+    def test_define_MBEDTLS_BASE64_C_unset(self) -> None:
+        """Error when unsetting a subproject option that was enabled."""
+        self.bad_case(None,
+                      '#undef MBEDTLS_BASE64_C',
+                      error=r'MBEDTLS_BASE64_C .*psa/crypto_config\.h')
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/test_config_checks.py
+++ b/tests/scripts/test_config_checks.py
@@ -59,7 +59,7 @@ class MbedtlsTestConfigChecks(unittest_config_checks.TestConfigChecks):
         """Error when redundantly setting a subproject internal option."""
         self.bad_case('#define PSA_WANT_ALG_MD5 1',
                       '#define MBEDTLS_MD5_C',
-                      error=r'MBEDTLS_MD5_C.* PSA_WANT_ALG_MD5 in psa/crypto_config\.h')
+                      error=r'MBEDTLS_MD5_C is an internal macro')
 
     def test_define_MBEDTLS_MD5_C_added(self) -> None:
         """Error when setting a subproject internal option that was disabled."""
@@ -68,7 +68,7 @@ class MbedtlsTestConfigChecks(unittest_config_checks.TestConfigChecks):
                       #undef MBEDTLS_MD5_C
                       ''',
                       '#define MBEDTLS_MD5_C',
-                      error=r'MBEDTLS_MD5_C.* PSA_WANT_ALG_MD5 in psa/crypto_config\.h')
+                      error=r'MBEDTLS_MD5_C is an internal macro')
 
     def test_define_MBEDTLS_BASE64_C_redundant(self) -> None:
         """Ok to redundantly set a subproject option."""

--- a/tests/scripts/test_config_checks.py
+++ b/tests/scripts/test_config_checks.py
@@ -23,13 +23,13 @@ class MbedtlsTestConfigChecks(unittest_config_checks.TestConfigChecks):
     ]
 
     def test_crypto_config_read(self) -> None:
-        """Check that crypto_config.h is read in crypto."""
+        """Check that crypto_config.h is read in mbedtls."""
         self.bad_case('#error witness',
                       None,
                       error='witness')
 
     def test_mbedtls_config_read(self) -> None:
-        """Check that mbedtls_config.h is read in crypto."""
+        """Check that mbedtls_config.h is read in mbedtls."""
         self.bad_case(''
                       '#error witness',
                       error='witness')

--- a/tests/scripts/test_config_checks.py
+++ b/tests/scripts/test_config_checks.py
@@ -112,6 +112,15 @@ class MbedtlsTestConfigChecks(unittest_config_checks.TestConfigChecks):
                       '#undef MBEDTLS_BASE64_C',
                       error=r'MBEDTLS_BASE64_C .*psa/crypto_config\.h')
 
+    def test_crypto_define_MBEDTLS_USE_PSA_CRYPTO(self) -> None:
+        """It's ok to set MBEDTLS_USE_PSA_CRYPTO (now effectively always on)."""
+        self.good_case('#define MBEDTLS_USE_PSA_CRYPTO')
+
+    def test_crypto_define_MBEDTLS_USE_PSA_CRYPTO(self) -> None:
+        """It's ok to set MBEDTLS_USE_PSA_CRYPTO (now effectively always on)."""
+        self.good_case(None,
+                       '#define MBEDTLS_USE_PSA_CRYPTO')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Set up a mechanism for erroring out if users try to use removed options in their configuration file. Resolves https://github.com/Mbed-TLS/mbedtls/issues/10147.

Specification in https://github.com/Mbed-TLS/mbedtls-framework/pull/184.

Status: ready.

Needed preceding PR: framework https://github.com/Mbed-TLS/mbedtls-framework/pull/164

## PR checklist

- [x] **TF-PSA-Crypto PR** https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/269 (not needed as a prerequisite, just doing the same thing in the other project)
- [x] **development PR** here
- [x] **3.6 PR** not required because: new code for use in 1.0/4.0 only
- [x] **framework PR** https://github.com/Mbed-TLS/mbedtls-framework/pull/164
- [x] **tests** provided
