### PR TITLE
Added a fix for the CI failure due to private access error

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -370,6 +370,7 @@ libtestdriver1.a:
 	perl -i ./scripts/libtestdriver1_rewrite.pl ./libtestdriver1/tf-psa-crypto/core/*.[ch]
 	perl -i ./scripts/libtestdriver1_rewrite.pl ./libtestdriver1/tf-psa-crypto/include/*/*.h
 	perl -i ./scripts/libtestdriver1_rewrite.pl ./libtestdriver1/tf-psa-crypto/drivers/builtin/include/*/*.h
+	perl -i ./scripts/libtestdriver1_rewrite.pl ./libtestdriver1/tf-psa-crypto/drivers/builtin/include/*/*/*.h
 	perl -i ./scripts/libtestdriver1_rewrite.pl ./libtestdriver1/tf-psa-crypto/drivers/builtin/src/*.[ch]
 
 	$(MAKE) -C ./libtestdriver1/library CFLAGS="-I../../ $(CFLAGS)" LDFLAGS="$(LDFLAGS)" libmbedcrypto.a


### PR DESCRIPTION
## Description

A oneliner to fix the private access CI failure for the mbed-tls/tf-psa-crypto#318 PR



## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [X] **changelog** not required because: internal change
- [X] **development PR** provided 
- [X] **TF-PSA-Crypto PR** not required because: irrelevant
- [X] **framework PR** not required
- [X] **3.6 PR** not required because: no backport required 
- **tests**  not required because: tested by the CI
