### PR TITLE
benchmark.c: Add a mbedtls_timing_hardclock variation with xtensa CCOUNT

### DIFF
--- a/programs/test/benchmark.c
+++ b/programs/test/benchmark.c
@@ -363,6 +363,20 @@ static unsigned long mbedtls_timing_hardclock(void)
 #endif /* !HAVE_HARDCLOCK && MBEDTLS_HAVE_ASM &&
           __GNUC__ && __ia64__ */
 
+#if !defined(HAVE_HARDCLOCK) && defined(MBEDTLS_HAVE_ASM) &&      \
+    defined(__GNUC__) && defined(__xtensa__)
+
+#define HAVE_HARDCLOCK
+
+static unsigned long mbedtls_timing_hardclock(void)
+{
+    unsigned int ccount;
+    asm volatile ("rsr %0, ccount" : "=r" (ccount));
+    return ccount;
+}
+#endif /* !HAVE_HARDCLOCK && MBEDTLS_HAVE_ASM &&
+          __GNUC__ && __xtensa__ */
+
 #if !defined(HAVE_HARDCLOCK) && defined(_WIN32) && \
     !defined(EFIX64) && !defined(EFI32)
 


### PR DESCRIPTION
## Description

benchmark.c: Add a mbedtls_timing_hardclock variation with xtensa CCOUNT

backport of https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/390

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [ ] **changelog** provided | not required because: 
- [ ] **development PR** not required because: moved to tf-psa-crypto
- [ ] **TF-PSA-Crypto PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/390
- [ ] **framework PR** provided Mbed-TLS/mbedtls-framework# | not required
- [ ] **3.6 PR** provided
- **tests**  provided | not required because: 



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
