### PR TITLE
query_config.fmt: glob headers instead of listing them explicitly

### DIFF
--- a/include/mbedtls/oid.h
+++ b/include/mbedtls/oid.h
@@ -11,6 +11,7 @@
 #define MBEDTLS_OID_H
 
 #include "mbedtls/build_info.h"
+#include "mbedtls/asn1.h"
 
 /*
  * Top level OID tuples

--- a/programs/test/CMakeLists.txt
+++ b/programs/test/CMakeLists.txt
@@ -56,6 +56,7 @@ if(GEN_FILES)
                 ${CMAKE_CURRENT_SOURCE_DIR}/../../tf-psa-crypto/include/psa/crypto_config.h
                 ${CMAKE_CURRENT_SOURCE_DIR}/../../scripts/data_files/query_config.fmt
                 ${CMAKE_CURRENT_BINARY_DIR}/query_config.c
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../..
         DEPENDS
             ${CMAKE_CURRENT_SOURCE_DIR}/../../scripts/generate_query_config.pl
             ${CMAKE_CURRENT_SOURCE_DIR}/../../include/mbedtls/mbedtls_config.h

--- a/scripts/data_files/query_config.fmt
+++ b/scripts/data_files/query_config.fmt
@@ -17,7 +17,9 @@
 #include <mbedtls/platform_time.h>
 #endif
 
+/* *INDENT-OFF* */
 INCLUDE_HEADERS
+/* *INDENT-ON* */
 
 /*
  * Helper macros to convert a macro or its expansion into a string

--- a/scripts/data_files/query_config.fmt
+++ b/scripts/data_files/query_config.fmt
@@ -1,4 +1,4 @@
-/*
+/* -*-c-*-
  *  Query Mbed TLS compile time configurations from mbedtls_config.h
  *
  *  Copyright The Mbed TLS Contributors
@@ -10,72 +10,9 @@
 #include "query_config.h"
 
 #include "mbedtls/platform.h"
-
-/*
- * Include all the headers with public APIs in case they define a macro to its
- * default value when that configuration is not set in mbedtls_config.h, or
- * for PSA_WANT macros, in case they're auto-defined based on mbedtls_config.h
- * rather than defined directly in crypto_config.h.
- */
-#include "psa/crypto.h"
-
-#include "mbedtls/aes.h"
-#include "mbedtls/aria.h"
-#include "mbedtls/asn1.h"
-#include "mbedtls/asn1write.h"
-#include "mbedtls/base64.h"
-#include "mbedtls/bignum.h"
-#include "mbedtls/camellia.h"
-#include "mbedtls/ccm.h"
-#include "mbedtls/chacha20.h"
-#include "mbedtls/chachapoly.h"
-#include "mbedtls/cipher.h"
-#include "mbedtls/cmac.h"
-#include "mbedtls/ctr_drbg.h"
-#include "mbedtls/debug.h"
-#include "mbedtls/des.h"
-#include "mbedtls/ecdh.h"
-#include "mbedtls/ecdsa.h"
-#include "mbedtls/ecjpake.h"
-#include "mbedtls/ecp.h"
-#include "mbedtls/entropy.h"
-#include "mbedtls/error.h"
-#include "mbedtls/gcm.h"
-#include "mbedtls/hmac_drbg.h"
-#include "mbedtls/md.h"
-#include "mbedtls/md5.h"
-#include "mbedtls/memory_buffer_alloc.h"
-#include "mbedtls/net_sockets.h"
-#include "mbedtls/nist_kw.h"
-#include "mbedtls/oid.h"
-#include "mbedtls/pem.h"
-#include "mbedtls/pk.h"
-#include "mbedtls/pkcs12.h"
-#include "mbedtls/pkcs5.h"
-#if defined(MBEDTLS_HAVE_TIME)
-#include "mbedtls/platform_time.h"
-#endif
-#include "mbedtls/platform_util.h"
-#include "mbedtls/poly1305.h"
-#include "mbedtls/ripemd160.h"
-#include "mbedtls/rsa.h"
-#include "mbedtls/sha1.h"
-#include "mbedtls/sha256.h"
-#include "mbedtls/sha512.h"
-#include "mbedtls/ssl.h"
-#include "mbedtls/ssl_cache.h"
-#include "mbedtls/ssl_ciphersuites.h"
-#include "mbedtls/ssl_cookie.h"
-#include "mbedtls/ssl_ticket.h"
-#include "mbedtls/threading.h"
-#include "mbedtls/timing.h"
-#include "mbedtls/version.h"
-#include "mbedtls/x509.h"
-#include "mbedtls/x509_crl.h"
-#include "mbedtls/x509_crt.h"
-#include "mbedtls/x509_csr.h"
-
 #include <string.h>
+
+INCLUDE_HEADERS
 
 /*
  * Helper macros to convert a macro or its expansion into a string

--- a/scripts/data_files/query_config.fmt
+++ b/scripts/data_files/query_config.fmt
@@ -12,6 +12,11 @@
 #include "mbedtls/platform.h"
 #include <string.h>
 
+/* Work around https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/393 */
+#if defined(MBEDTLS_HAVE_TIME)
+#include <mbedtls/platform_time.h>
+#endif
+
 INCLUDE_HEADERS
 
 /*

--- a/scripts/generate_query_config.pl
+++ b/scripts/generate_query_config.pl
@@ -100,6 +100,29 @@ EOT
     close(CONFIG_FILE);
 }
 
+# We need to include all the headers with public APIs in case they
+# define a macro to its default value when that configuration is not
+# set in a header included by build_info.h (crypto_config.h,
+# mbedtls_config.h, *adjust*.h). Some module-specific macros are set
+# in that module's header. For simplicity, include all headers, with
+# some ad hoc knowledge of headers that are included by other headers
+# and should not be included directly. We don't include internal headers
+# because those should not define configurable macros.
+my @header_files = ();
+my @header_roots = qw(
+                         include
+                         tf-psa-crypto/include
+                         tf-psa-crypto/drivers/builtin/include
+                    );
+for my $root (@header_roots) {
+    my @paths = glob "$root/*/*.h $root/*/*/*.h";
+    map {s!^\Q$root/!!} @paths;
+    # Exclude some headers that are included by build_info.h and cannot
+    # be included directly.
+    push @header_files, grep {!m!_config\.h|[/_]adjust[/_]!} @paths;
+}
+my $include_headers = join('', map {"#include <$_>\n"} @header_files);
+
 # Read the full format file into a string
 local $/;
 open(FORMAT_FILE, "<", $query_config_format_file) or die "Opening query config format file '$query_config_format_file': $!";
@@ -107,6 +130,7 @@ my $query_config_format = <FORMAT_FILE>;
 close(FORMAT_FILE);
 
 # Replace the body of the query_config() function with the code we just wrote
+$query_config_format =~ s/INCLUDE_HEADERS/$include_headers/g;
 $query_config_format =~ s/CHECK_CONFIG/$config_check/g;
 $query_config_format =~ s/LIST_CONFIG/$list_config/g;
 

--- a/scripts/generate_query_config.pl
+++ b/scripts/generate_query_config.pl
@@ -49,6 +49,8 @@ if( @ARGV ) {
           or die "No arguments supplied, must be run from project root or a first-level subdirectory\n";
     }
 }
+-f 'include/mbedtls/build_info.h'
+  or die "$0: must be run from project root, or from a first-level subdirectory with no arguments\n";
 
 # Excluded macros from the generated query_config.c. For example, macros that
 # have commas or function-like macros cannot be transformed into strings easily

--- a/scripts/generate_query_config.pl
+++ b/scripts/generate_query_config.pl
@@ -122,6 +122,7 @@ for my $root (@header_roots) {
     # Exclude some headers that are included by build_info.h and cannot
     # be included directly.
     push @header_files, grep {!m[
+            ^psa/crypto_(platform|struct)\.h$ | # have alt versions, included by psa/crypto.h anyway
             ^mbedtls/platform_time\.h$ | # errors without time.h
             _config\.h |
             [/_]adjust[/_]

--- a/scripts/generate_query_config.pl
+++ b/scripts/generate_query_config.pl
@@ -121,7 +121,11 @@ for my $root (@header_roots) {
     map {s!^\Q$root/!!} @paths;
     # Exclude some headers that are included by build_info.h and cannot
     # be included directly.
-    push @header_files, grep {!m!_config\.h|[/_]adjust[/_]!} @paths;
+    push @header_files, grep {!m[
+            ^mbedtls/platform_time\.h$ | # errors without time.h
+            _config\.h |
+            [/_]adjust[/_]
+        ]x} @paths;
 }
 my $include_headers = join('', map {"#include <$_>\n"} @header_files);
 


### PR DESCRIPTION
This lets us remove or rename crypto headers without hassle, and means we don't risk forgetting to add a new header.

Fix #10323. Helps with https://github.com/Mbed-TLS/mbedtls/issues/9164, https://github.com/Mbed-TLS/mbedtls/issues/10087 and possibly other 1.0/4.0 tasks because it lets us fiddle with crypto headers without needing to prepare the mbedtls repository first.

Alternative to https://github.com/Mbed-TLS/mbedtls/pull/10325

## PR checklist

- [x] **changelog** provided | not required because: internal change
- [x] **development PR** here
- [x] **TF-PSA-Crypto PR** not required because: feature not in crypto
- [x] **framework PR** not required
- [x] **3.6 PR** provided # | not required because: we aren't going to add or remove headers in 3.6
- **tests**  provided; you can check that this doesn't change the output of `programs/test/query_compile_time_config -l`
