### PR TITLE
query_config.fmt: only include necessary headers

### DIFF
--- a/programs/test/CMakeLists.txt
+++ b/programs/test/CMakeLists.txt
@@ -56,6 +56,7 @@ if(GEN_FILES)
                 ${CMAKE_CURRENT_SOURCE_DIR}/../../tf-psa-crypto/include/psa/crypto_config.h
                 ${CMAKE_CURRENT_SOURCE_DIR}/../../scripts/data_files/query_config.fmt
                 ${CMAKE_CURRENT_BINARY_DIR}/query_config.c
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../..
         DEPENDS
             ${CMAKE_CURRENT_SOURCE_DIR}/../../scripts/generate_query_config.pl
             ${CMAKE_CURRENT_SOURCE_DIR}/../../include/mbedtls/mbedtls_config.h

--- a/scripts/data_files/query_config.fmt
+++ b/scripts/data_files/query_config.fmt
@@ -1,81 +1,42 @@
-/*
+/* -*-c-*-
  *  Query Mbed TLS compile time configurations from mbedtls_config.h
  *
  *  Copyright The Mbed TLS Contributors
  *  SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
  */
 
+#include "tf-psa-crypto/build_info.h"
 #include "mbedtls/build_info.h"
 
 #include "query_config.h"
 
+#include <string.h>
 #include "mbedtls/platform.h"
 
 /*
- * Include all the headers with public APIs in case they define a macro to its
- * default value when that configuration is not set in mbedtls_config.h, or
- * for PSA_WANT macros, in case they're auto-defined based on mbedtls_config.h
- * rather than defined directly in crypto_config.h.
+ * Include some with public APIs in case they define a macro to its
+ * default value when that configuration is not set in mbedtls_config.h.
+ * generate_query_config.pl checks whether all necessary headers are
+ * included.
  */
 #include "psa/crypto.h"
-
-#include "mbedtls/aes.h"
-#include "mbedtls/aria.h"
-#include "mbedtls/asn1.h"
-#include "mbedtls/asn1write.h"
-#include "mbedtls/base64.h"
+#include "psa/crypto_extra.h"
+#include "psa/crypto_legacy.h"
 #include "mbedtls/bignum.h"
-#include "mbedtls/camellia.h"
-#include "mbedtls/ccm.h"
-#include "mbedtls/chacha20.h"
-#include "mbedtls/chachapoly.h"
-#include "mbedtls/cipher.h"
-#include "mbedtls/cmac.h"
 #include "mbedtls/ctr_drbg.h"
-#include "mbedtls/debug.h"
-#include "mbedtls/des.h"
-#include "mbedtls/ecdh.h"
-#include "mbedtls/ecdsa.h"
-#include "mbedtls/ecjpake.h"
 #include "mbedtls/ecp.h"
 #include "mbedtls/entropy.h"
-#include "mbedtls/error.h"
-#include "mbedtls/gcm.h"
 #include "mbedtls/hmac_drbg.h"
-#include "mbedtls/md.h"
-#include "mbedtls/md5.h"
 #include "mbedtls/memory_buffer_alloc.h"
-#include "mbedtls/net_sockets.h"
-#include "mbedtls/nist_kw.h"
-#include "mbedtls/oid.h"
-#include "mbedtls/pem.h"
-#include "mbedtls/pk.h"
-#include "mbedtls/pkcs12.h"
-#include "mbedtls/pkcs5.h"
-#if defined(MBEDTLS_HAVE_TIME)
-#include "mbedtls/platform_time.h"
-#endif
 #include "mbedtls/platform_util.h"
-#include "mbedtls/poly1305.h"
-#include "mbedtls/ripemd160.h"
 #include "mbedtls/rsa.h"
-#include "mbedtls/sha1.h"
-#include "mbedtls/sha256.h"
-#include "mbedtls/sha512.h"
+
+#include "mbedtls/debug.h"
 #include "mbedtls/ssl.h"
 #include "mbedtls/ssl_cache.h"
-#include "mbedtls/ssl_ciphersuites.h"
 #include "mbedtls/ssl_cookie.h"
-#include "mbedtls/ssl_ticket.h"
-#include "mbedtls/threading.h"
-#include "mbedtls/timing.h"
-#include "mbedtls/version.h"
 #include "mbedtls/x509.h"
-#include "mbedtls/x509_crl.h"
 #include "mbedtls/x509_crt.h"
-#include "mbedtls/x509_csr.h"
-
-#include <string.h>
 
 /*
  * Helper macros to convert a macro or its expansion into a string

--- a/scripts/generate_query_config.pl
+++ b/scripts/generate_query_config.pl
@@ -49,8 +49,6 @@ if( @ARGV ) {
           or die "No arguments supplied, must be run from project root or a first-level subdirectory\n";
     }
 }
--f 'include/mbedtls/build_info.h'
-  or die "$0: must be run from project root or a first-level subdirectory\n";
 
 # Excluded macros from the generated query_config.c. For example, macros that
 # have commas or function-like macros cannot be transformed into strings easily

--- a/scripts/generate_query_config.pl
+++ b/scripts/generate_query_config.pl
@@ -49,6 +49,8 @@ if( @ARGV ) {
           or die "No arguments supplied, must be run from project root or a first-level subdirectory\n";
     }
 }
+ -f 'include/mbedtls/build_info.h'
+  or die "$0: must be run from project root, or from a first-level subdirectory with no arguments\n";
 
 # Excluded macros from the generated query_config.c. For example, macros that
 # have commas or function-like macros cannot be transformed into strings easily


### PR DESCRIPTION
This lets us remove or rename any other headers without hassle, and means we don't risk forgetting to add a new header.

Fix #10323. Helps with https://github.com/Mbed-TLS/mbedtls/issues/9164, https://github.com/Mbed-TLS/mbedtls/issues/10087 and possibly other 1.0/4.0 tasks because it lets us fiddle with crypto headers without needing to prepare the mbedtls repository first.

Alternative to https://github.com/Mbed-TLS/mbedtls/pull/10324

## PR checklist

- [x] **changelog** provided | not required because: internal change
- [x] **development PR** here
- [x] **TF-PSA-Crypto PR** not required because: feature not in crypto
- [x] **framework PR** not required
- [x] **3.6 PR** provided # | not required because: we aren't going to add or remove headers in 3.6
- **tests**  provided; you can check that this doesn't change the output of `programs/test/query_compile_time_config -l`
