### PR TITLE
Rsa remove redundant public 3.6

### DIFF
--- a/library/rsa.c
+++ b/library/rsa.c
@@ -1554,6 +1554,7 @@ int mbedtls_rsa_private(mbedtls_rsa_context *ctx,
     MBEDTLS_MPI_CHK(mbedtls_mpi_add_mpi(&T, &TQ, &TP));
 #endif /* MBEDTLS_RSA_NO_CRT */
 
+#if !defined(MBEDTLS_RSA_NO_CRT)
     /* Verify the result to prevent a glitching attack: Arjen Lenstra,
      * Memo on RSA signature generation in the presence of faults, 1996.
      * https://infoscience.epfl.ch/record/164524/files/nscan20.PDF
@@ -1574,6 +1575,7 @@ int mbedtls_rsa_private(mbedtls_rsa_context *ctx,
         ret = MBEDTLS_ERR_RSA_VERIFY_FAILED;
         goto cleanup;
     }
+#endif
 
     /*
      * Unblind

--- a/library/rsa.c
+++ b/library/rsa.c
@@ -2470,12 +2470,6 @@ int mbedtls_rsa_rsassa_pkcs1_v15_sign(mbedtls_rsa_context *ctx,
     }
 
     MBEDTLS_MPI_CHK(mbedtls_rsa_private(ctx, f_rng, p_rng, sig, sig_try));
-    MBEDTLS_MPI_CHK(mbedtls_rsa_public(ctx, sig_try, verif));
-
-    if (mbedtls_ct_memcmp(verif, sig, ctx->len) != 0) {
-        ret = MBEDTLS_ERR_RSA_PRIVATE_FAILED;
-        goto cleanup;
-    }
 
     memcpy(sig, sig_try, ctx->len);
 

--- a/library/rsa.c
+++ b/library/rsa.c
@@ -1564,9 +1564,12 @@ int mbedtls_rsa_private(mbedtls_rsa_context *ctx,
      * of it, possibly through a side channel in padding verification.
      * We do the verification before unblinding, to reduce the risk of
      * leaking information about the input.
+     * We use the "unsafe" version of exponentiation, which leaks the
+     * public exponent, for a slight performance improvement.
      */
-    MBEDTLS_MPI_CHK(mbedtls_mpi_exp_mod(&check_result_blinded, &T, &ctx->E,
-                                        &ctx->N, &ctx->RN));
+    MBEDTLS_MPI_CHK(mbedtls_mpi_exp_mod_unsafe(&check_result_blinded,
+                                               &T, &ctx->E,
+                                               &ctx->N, &ctx->RN));
     if (mbedtls_mpi_cmp_mpi(&check_result_blinded, &input_blinded) != 0) {
         ret = MBEDTLS_ERR_RSA_VERIFY_FAILED;
         goto cleanup;


### PR DESCRIPTION
Minor improvements to the protection against Lenstra's glitch attack in RSA:

* This was done twice for PKCS#1v1.5 signatures. Keep only one instance.
* Make it clear when looking at the code what is done and why. (We were temporarily worried that it wasn't done for PSS signatures, until we found the code that does it.)
* Use the “unsafe” exponentiation function that leaks the public exponent, but is faster.
* Don't do it when `MBEDTLS_RSA_NO_CRT` is enabled: it's pointless.

Note: I did 3.6 first out of habit, but do we actually want all of these changes in the LTS? Or just add a comment?

## PR checklist

- [x] **changelog** not required because: just a maintainability and performance improvement
- [x] **development PR** not required because: crypto only
- [ ] **TF-PSA-Crypto PR** TODO
- [x] **framework PR** not required
- [x] **3.6 PR** here
- **tests**  provided
