### PR TITLE
Backport 3.6: fix `make lib GEN_FILES=` sometimes requiring python

### DIFF
--- a/library/Makefile
+++ b/library/Makefile
@@ -389,10 +389,12 @@ $(GENERATED_WRAPPER_FILES):
 
 psa_crypto.o:psa_crypto_driver_wrappers.h
 
+RM ?= rm
+
 clean:
 ifndef WINDOWS
-	rm -f *.o *.s libmbed*
-	rm -f $(THIRDPARTY_CRYPTO_OBJECTS) $(THIRDPARTY_CRYPTO_OBJECTS:.o=.s)
+	$(RM) -f *.o *.s libmbed*
+	$(RM) -f $(THIRDPARTY_CRYPTO_OBJECTS) $(THIRDPARTY_CRYPTO_OBJECTS:.o=.s)
 else
 	if exist *.o del /Q /F *.o
 	if exist *.s del /Q /F *.s
@@ -402,7 +404,7 @@ endif
 
 neat: clean
 ifndef WINDOWS
-	rm -f $(GENERATED_FILES)
+	$(RM) -f $(GENERATED_FILES)
 else
 	for %f in ($(subst /,\,$(GENERATED_FILES))) if exist %f del /Q /F %f
 endif

--- a/library/Makefile
+++ b/library/Makefile
@@ -380,9 +380,9 @@ version_features.c:
 GENERATED_WRAPPER_FILES = \
                     psa_crypto_driver_wrappers.h \
                     psa_crypto_driver_wrappers_no_static.c
-$(GENERATED_WRAPPER_FILES): ../scripts/generate_driver_wrappers.py
-$(GENERATED_WRAPPER_FILES): ../scripts/data_files/driver_templates/psa_crypto_driver_wrappers.h.jinja
-$(GENERATED_WRAPPER_FILES): ../scripts/data_files/driver_templates/psa_crypto_driver_wrappers_no_static.c.jinja
+$(GENERATED_WRAPPER_FILES): $(gen_file_dep) ../scripts/generate_driver_wrappers.py
+$(GENERATED_WRAPPER_FILES): $(gen_file_dep) ../scripts/data_files/driver_templates/psa_crypto_driver_wrappers.h.jinja
+$(GENERATED_WRAPPER_FILES): $(gen_file_dep) ../scripts/data_files/driver_templates/psa_crypto_driver_wrappers_no_static.c.jinja
 $(GENERATED_WRAPPER_FILES):
 	echo "  Gen   $(GENERATED_WRAPPER_FILES)"
 	$(PYTHON) ../scripts/generate_driver_wrappers.py

--- a/tests/scripts/components-build-system.sh
+++ b/tests/scripts/components-build-system.sh
@@ -59,6 +59,19 @@ component_build_make_no_gen_files () {
     # even if it isn't on $PATH.
     msg "build: make lib with GEN_FILES off in minimal environment"
     env PATH=/no/such/directory "$(command -v make)" GEN_FILES= AR="$AR" CC="$CC" lib
+
+    msg "build: make -C library clean with GEN_FILES off in minimal environment"
+    env PATH=/no/such/directory "$(command -v make)" GEN_FILES= RM="$RM" -C library clean
+
+    msg "build: make lib with GEN_FILES off with generated files missing"
+    make neat
+    # Check that a sample generated file is absent
+    not test -f library/error.c
+    PERL="$(command -v perl)"
+    PYTHON="$(command -v python3)"
+    # We take whatever Python environment we're in. For a future improvement,
+    # make a venv with just scripts/basic.requirements.txt.
+    env PATH=/no/such/directory "$(command -v make)" GEN_FILES= AR="$AR" CC="$CC" PERL="$PERL" PYTHON="$PYTHON" lib
 }
 
 support_test_cmake_out_of_source () {

--- a/tests/scripts/components-build-system.sh
+++ b/tests/scripts/components-build-system.sh
@@ -50,6 +50,8 @@ component_build_make_no_gen_files () {
     # GCC needs "as" in $PATH by default. To use GCC, we need to tell it where
     # to find the assembler. Or we can use clang which just works.
     CC="$(command -v clang)"
+    # For cleaning.
+    RM="$(command -v rm)"
 
     # Test the build with make.
     # Preferably we should also test with CMake. Note that a CMake test


### PR DESCRIPTION
Fix https://github.com/Mbed-TLS/mbedtls/issues/10335 and add a bit of testing.

Priority: high despite being unplanned because this is a bug that will affect every future release.

## PR checklist

- [x] **changelog** provided
- [x] **development PR** TODO? Not if [we abandon make](https://github.com/Mbed-TLS/mbedtls/issues/10316), but in the meantime we might as well forward-port at least the fix, if not the test.
- [x] **TF-PSA-Crypto PR** not required because: make is not supported in TF-PSA-Crypto
- [x] **framework PR** provided Mbed-TLS/mbedtls-framework# | not required
- [x] **3.6 PR** here
- **tests**  provided
