### PR TITLE
3.6 only: make list_generated_files

### DIFF
--- a/library/Makefile
+++ b/library/Makefile
@@ -341,8 +341,10 @@ libmbedcrypto.dll: $(OBJS_CRYPTO)
 	echo "  CC    $<"
 	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) -S -o $@ -c $<
 
-.PHONY: generated_files
+.PHONY: generated_files list_generated_files
 generated_files: $(GENERATED_FILES)
+list_generated_files:
+	@for x in $(GENERATED_FILES); do echo "$$x"; done
 
 # See root Makefile
 GEN_FILES ?= yes

--- a/programs/Makefile
+++ b/programs/Makefile
@@ -131,9 +131,11 @@ fuzz: ${MBEDTLS_TEST_OBJS}
 ${MBEDTLS_TEST_OBJS}:
 	$(MAKE) -C ../tests mbedtls_test
 
-.PHONY: generated_files
 GENERATED_FILES = psa/psa_constant_names_generated.c test/query_config.c
+.PHONY: generated_files list_generated_files
 generated_files: $(GENERATED_FILES)
+list_generated_files:
+	@for x in $(GENERATED_FILES); do echo "$$x"; done
 
 psa/psa_constant_names_generated.c: $(gen_file_dep) ../scripts/generate_psa_constants.py
 psa/psa_constant_names_generated.c: $(gen_file_dep) ../include/psa/crypto_values.h

--- a/scripts/generate_visualc_files.pl
+++ b/scripts/generate_visualc_files.pl
@@ -13,6 +13,12 @@ use warnings;
 use strict;
 use Digest::MD5 'md5_hex';
 
+my $help = <<EOF;
+Usage: $0 [--help|--list]
+Generate Visual Studio solutions and project files from templates.
+Must be run from the Mbed TLS root or the scripts directory.
+EOF
+
 my $vsx_dir = "visualc/VS2017";
 my $vsx_ext = "vcxproj";
 my $vsx_app_tpl_file = "scripts/data_files/vs2017-app-template.$vsx_ext";
@@ -263,6 +269,25 @@ sub main {
     if( ! check_dirs() ) {
         chdir '..' or die;
         check_dirs or die "Must be run from Mbed TLS root or scripts dir\n";
+    }
+
+    if (@ARGV == 0) {
+        # normal operation, code below
+    } elsif (@ARGV == 1 && $ARGV[0] eq '--help') {
+        print $help;
+        exit;
+    } elsif (@ARGV == 1 && $ARGV[0] eq '--list') {
+        my @app_list = get_app_list();
+        my @project_list = map {s!.*/!!; "$_.$vsx_ext"} @app_list;
+        foreach (@project_list) {
+            print "$vsx_dir/$_\n";
+        }
+        print "$vsx_main_file\n";
+        print "$vsx_sln_file\n";
+        exit;
+    } else {
+        print STDERR $help;
+        exit 120;
     }
 
     # Remove old files to ensure that, for example, project files from deleted

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -71,8 +71,10 @@ opt-testcases/tls13-compat.sh: ../framework/scripts/generate_tls13_compat_tests.
 GENERATED_FILES += opt-testcases/tls13-compat.sh
 ssl-opt: opt-testcases/tls13-compat.sh
 
-.PHONY: generated_files
+.PHONY: generated_files list_generated_files
 generated_files: $(GENERATED_FILES)
+list_generated_files:
+	@for x in $(GENERATED_FILES); do echo "$$x"; done
 
 # generate_bignum_tests.py and generate_psa_tests.py spend more time analyzing
 # inputs than generating outputs. Its inputs are the same no matter which files


### PR DESCRIPTION
Implement `make list_generated_files`. Only needed for 3.6: in development the information is stored in the framework, in `scripts/make_generated_files.py`.

## PR checklist

- [x] **changelog** not required because: maintainer stuff
- [x] **development PR** not required because: use `framework/scripts/make_generated_files.py --list`
- [x] **TF-PSA-Crypto PR** not required because: use `framework/scripts/make_generated_files.py --list`
- [x] **framework PR** provided Mbed-TLS/mbedtls-framework#195 (not a prerequisite; both PR are needed to make `framework/scripts/make_generated_files.py --list` work in 3.6)
- [x] **3.6 PR** here
- **tests**  not required because: maintainer stuff
