### PR TITLE
[3.6] Fix a build failure that occurs in environments using Code Page 950

### DIFF
--- a/include/mbedtls/ecdh.h
+++ b/include/mbedtls/ecdh.h
@@ -6,7 +6,7 @@
  * The Elliptic Curve Diffie-Hellman (ECDH) protocol is an anonymous
  * key agreement protocol allowing two parties to establish a shared
  * secret over an insecure channel. Each party must have an
- * elliptic-curve public–private key pair.
+ * elliptic-curve public private key pair.
  *
  * For more information, see <em>NIST SP 800-56A Rev. 2: Recommendation for
  * Pair-Wise Key Establishment Schemes Using Discrete Logarithm


### PR DESCRIPTION
Replace a non-ASCII character with a space

## Description

A build error message was found:
**_ecdh.h(1): error C2220: the following warning is treated as an error
ecdh.h(1): warning C4819: The file contains a character that cannot be represented in the current code page (950). Save the file in Unicode format to prevent data loss_**



## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [X] **changelog** provided | not required because: no change in functionality
- [X] **development PR** provided # | not required because: file doesn't exist
- [X] **TF-PSA-Crypto PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/411
- [X] **framework PR** provided Mbed-TLS/mbedtls-framework# | not required
- [X] **3.6 PR** provided here
- **tests**  provided | not required because: no change in functionality



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
