### PR TITLE
Move private pk interfaces to mbedtls/private/pk.h

### DIFF
--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -6,6 +6,9 @@
  */
 
 #define MBEDTLS_ALLOW_PRIVATE_ACCESS
+#define MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS
+
+#include "mbedtls/private/pk_private.h"
 
 #include "ssl_test_lib.h"
 

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -6,7 +6,6 @@
  */
 
 #define MBEDTLS_ALLOW_PRIVATE_ACCESS
-#define MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS
 
 #include "mbedtls/private/pk_private.h"
 

--- a/programs/ssl/ssl_test_lib.h
+++ b/programs/ssl/ssl_test_lib.h
@@ -7,6 +7,9 @@
 
 #ifndef MBEDTLS_PROGRAMS_SSL_SSL_TEST_LIB_H
 #define MBEDTLS_PROGRAMS_SSL_SSL_TEST_LIB_H
+#define MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS
+
+#include "mbedtls/private/pk_private.h"
 
 #include "mbedtls/build_info.h"
 

--- a/programs/ssl/ssl_test_lib.h
+++ b/programs/ssl/ssl_test_lib.h
@@ -7,7 +7,6 @@
 
 #ifndef MBEDTLS_PROGRAMS_SSL_SSL_TEST_LIB_H
 #define MBEDTLS_PROGRAMS_SSL_SSL_TEST_LIB_H
-#define MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS
 
 #include "mbedtls/private/pk_private.h"
 


### PR DESCRIPTION
## Description

Move private pk interfaces to mbedtls/private/pk.h. Contributes to https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/344

This PR is part of a chain which needs to be merged in the following order:

1.  https://github.com/Mbed-TLS/mbedtls/pull/10351
2. https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/413

## PR checklist

- [x] **changelog** not required because: will be on the crypto side
- [x] **development PR** provided #HERE
- [x] **TF-PSA-Crypto PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/413
- [x] **framework PR** not required
- [x] **3.6 PR** not required because: No backports
- **tests**  not required because: No changes
