### PR TITLE
Remove component uses of MBEDTLS_ECDSA_DETERMINISTIC

### DIFF
--- a/tests/scripts/components-configuration-crypto.sh
+++ b/tests/scripts/components-configuration-crypto.sh
@@ -210,7 +210,7 @@ component_test_no_hmac_drbg_use_psa () {
     msg "build: Full minus HMAC_DRBG, PSA crypto in TLS"
     scripts/config.py full
     scripts/config.py unset MBEDTLS_HMAC_DRBG_C
-    scripts/config.py unset MBEDTLS_ECDSA_DETERMINISTIC # requires HMAC_DRBG
+    scripts/config.py -c $CRYPTO_CONFIG_H unset PSA_WANT_ALG_DETERMINISTIC_ECDSA # requires HMAC_DRBG
 
     CC=$ASAN_CC cmake -D CMAKE_BUILD_TYPE:String=Asan .
     make
@@ -241,7 +241,7 @@ component_test_psa_external_rng_no_drbg_use_psa () {
     scripts/config.py unset MBEDTLS_PLATFORM_NV_SEED_ALT
     scripts/config.py unset MBEDTLS_CTR_DRBG_C
     scripts/config.py unset MBEDTLS_HMAC_DRBG_C
-    scripts/config.py unset MBEDTLS_ECDSA_DETERMINISTIC # requires HMAC_DRBG
+    scripts/config.py -c $CRYPTO_CONFIG_H unset PSA_WANT_ALG_DETERMINISTIC_ECDSA # Requires HMAC_DRBG
     make CC=$ASAN_CC CFLAGS="$ASAN_CFLAGS" LDFLAGS="$ASAN_CFLAGS"
 
     msg "test: PSA_CRYPTO_EXTERNAL_RNG minus *_DRBG, PSA crypto - main suites"
@@ -293,7 +293,6 @@ component_test_crypto_full_md_light_only () {
     scripts/config.py unset MBEDTLS_HMAC_DRBG_C
     scripts/config.py unset MBEDTLS_PKCS7_C
     # Disable indirect dependencies of MD_C
-    scripts/config.py unset MBEDTLS_ECDSA_DETERMINISTIC # needs HMAC_DRBG
     scripts/config.py -c $CRYPTO_CONFIG_H unset PSA_WANT_ALG_DETERMINISTIC_ECDSA
     # Disable things that would auto-enable MD_C
     scripts/config.py unset MBEDTLS_PKCS5_C
@@ -1656,7 +1655,6 @@ config_psa_crypto_hmac_use_psa () {
     scripts/config.py unset MBEDTLS_HMAC_DRBG_C
     scripts/config.py unset MBEDTLS_HKDF_C
     # Dependencies of HMAC_DRBG
-    scripts/config.py unset MBEDTLS_ECDSA_DETERMINISTIC
     scripts/config.py -f "$CRYPTO_CONFIG_H" unset PSA_WANT_ALG_DETERMINISTIC_ECDSA
 }
 


### PR DESCRIPTION
Remove all references to MBEDTLS_ECDSA_DETERMINISTIC from components-configuration-crypto.sh. Replace them with PSA_WANT_ALG_DETERMINISTIC_ECDSA.

This is safe because:
* MBEDTLS_ECDSA_DETERMINISTIC is only ever unset in components in order to avoid errors from disabling its dependency MBEDTLS_HMAC_DRBG_C.
* MBEDTLS_ECDSA_DETERMINISTIC is only ever defined in config_adjust_legacy_from_psa.h, and only if PSA_WANT_ALG_DETERMINISTIC_ECDSA is defined.

Therefore PSA_WANT_ALG_DETERMINISTIC_ECDSA's dependencies are a superset of MBEDTLS_ECDSA_DETERMINISTIC's dependencies and must include MBEDTLS_HMAC_DRBG_C, so disabling PSA_WANT_ALG_DETERMINISTIC_ECDSA is a sufficient substitute for disabling MBEDTLS_ECDSA_DETERMINISTIC.

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** not required because: Internal changes only
- [x] **development PR** here
- [x] **TF-PSA-Crypto PR** not required because: Mbed TLS testing change only
- [x] **framework PR** not required
- [x] **3.6 PR** not required because: Removal of legacy options is 4.0-only
- **tests**  not required because: Changes to testing itself
