### PR TITLE
allow negotiation of all use_srtp profile values currently listed by IANA

### DIFF
--- a/ChangeLog.d/new-dtls-use_srtp-modes.txt
+++ b/ChangeLog.d/new-dtls-use_srtp-modes.txt
@@ -1,0 +1,2 @@
+API changes
+   * allow negotiation of all use_srtp profile values currently listed by IANA

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1101,7 +1101,7 @@ typedef struct {
 #if defined(MBEDTLS_SSL_DTLS_SRTP)
 
 #define MBEDTLS_TLS_SRTP_MAX_MKI_LENGTH             255
-#define MBEDTLS_TLS_SRTP_MAX_PROFILE_LIST_LENGTH    4
+#define MBEDTLS_TLS_SRTP_MAX_PROFILE_LIST_LENGTH    14
 /*
  * For code readability use a typedef for DTLS-SRTP profiles
  *
@@ -1111,12 +1111,23 @@ typedef struct {
  * Reminder: if this list is expanded mbedtls_ssl_check_srtp_profile_value
  * must be updated too.
  */
-#define MBEDTLS_TLS_SRTP_AES128_CM_HMAC_SHA1_80     ((uint16_t) 0x0001)
-#define MBEDTLS_TLS_SRTP_AES128_CM_HMAC_SHA1_32     ((uint16_t) 0x0002)
-#define MBEDTLS_TLS_SRTP_NULL_HMAC_SHA1_80          ((uint16_t) 0x0005)
-#define MBEDTLS_TLS_SRTP_NULL_HMAC_SHA1_32          ((uint16_t) 0x0006)
+#define MBEDTLS_TLS_SRTP_AES128_CM_HMAC_SHA1_80               ((uint16_t) 0x0001)       /* RFC5764 foundation for DTLS+SRTP */
+#define MBEDTLS_TLS_SRTP_AES128_CM_HMAC_SHA1_32               ((uint16_t) 0x0002)       /* RFC5764 foundation for DTLS+SRTP */
+/* 0x0003-0x0004 are listed as "Unassigned" */
+#define MBEDTLS_TLS_SRTP_NULL_HMAC_SHA1_80                    ((uint16_t) 0x0005)       /* RFC5764 foundation for DTLS+SRTP */
+#define MBEDTLS_TLS_SRTP_NULL_HMAC_SHA1_32                    ((uint16_t) 0x0006)       /* RFC5764 foundation for DTLS+SRTP */
+#define MBEDTLS_TLS_SRTP_AEAD_AES_128_GCM                     ((uint16_t) 0x0007)       /* RFC7714 AES-GCM for SRTP */
+#define MBEDTLS_TLS_SRTP_AEAD_AES_256_GCM                     ((uint16_t) 0x0008)       /* RFC7714 AES-GCM for SRTP */
+#define MBEDTLS_TLS_DOUBLE_AEAD_AES_128_GCM_AEAD_AES_128_GCM  ((uint16_t) 0x0009)       /* RFC8723 double encryption for SRTP */
+#define MBEDTLS_TLS_DOUBLE_AEAD_AES_256_GCM_AEAD_AES_256_GCM  ((uint16_t) 0x000A)       /* RFC8723 double encryption for SRTP */
+#define MBEDTLS_TLS_SRTP_ARIA_128_CTR_HMAC_SHA1_80            ((uint16_t) 0x000B)       /* RFC8269 ARIA+SRTP */
+#define MBEDTLS_TLS_SRTP_ARIA_128_CTR_HMAC_SHA1_32            ((uint16_t) 0x000C)       /* RFC8269 ARIA+SRTP */
+#define MBEDTLS_TLS_SRTP_ARIA_256_CTR_HMAC_SHA1_80            ((uint16_t) 0x000D)       /* RFC8269 ARIA+SRTP */
+#define MBEDTLS_TLS_SRTP_ARIA_256_CTR_HMAC_SHA1_32            ((uint16_t) 0x000E)       /* RFC8269 ARIA+SRTP */
+#define MBEDTLS_TLS_SRTP_AEAD_ARIA_128_GCM                    ((uint16_t) 0x000F)       /* RFC8269 ARIA+SRTP */
+#define MBEDTLS_TLS_SRTP_AEAD_ARIA_256_GCM                    ((uint16_t) 0x0010)       /* RFC8269 ARIA+SRTP */
 /* This one is not iana defined, but for code readability. */
-#define MBEDTLS_TLS_SRTP_UNSET                      ((uint16_t) 0x0000)
+#define MBEDTLS_TLS_SRTP_UNSET                                ((uint16_t) 0x0000)       /* end of list marker */
 
 typedef uint16_t mbedtls_ssl_srtp_profile;
 
@@ -3964,6 +3975,26 @@ static inline const char *mbedtls_ssl_get_srtp_profile_as_string(mbedtls_ssl_srt
             return "MBEDTLS_TLS_SRTP_NULL_HMAC_SHA1_80";
         case MBEDTLS_TLS_SRTP_NULL_HMAC_SHA1_32:
             return "MBEDTLS_TLS_SRTP_NULL_HMAC_SHA1_32";
+        case MBEDTLS_TLS_SRTP_AEAD_AES_128_GCM:
+            return "MBEDTLS_TLS_SRTP_AEAD_AES_128_GCM";
+        case MBEDTLS_TLS_SRTP_AEAD_AES_256_GCM:
+            return "MBEDTLS_TLS_SRTP_AEAD_AES_256_GCM";
+        case MBEDTLS_TLS_DOUBLE_AEAD_AES_128_GCM_AEAD_AES_128_GCM:
+            return "MBEDTLS_TLS_DOUBLE_AEAD_AES_128_GCM_AEAD_AES_128_GCM";
+        case MBEDTLS_TLS_DOUBLE_AEAD_AES_256_GCM_AEAD_AES_256_GCM:
+            return "MBEDTLS_TLS_DOUBLE_AEAD_AES_256_GCM_AEAD_AES_256_GCM";
+        case MBEDTLS_TLS_SRTP_ARIA_128_CTR_HMAC_SHA1_80:
+            return "MBEDTLS_TLS_SRTP_ARIA_128_CTR_HMAC_SHA1_80";
+        case MBEDTLS_TLS_SRTP_ARIA_128_CTR_HMAC_SHA1_32:
+            return "MBEDTLS_TLS_SRTP_ARIA_128_CTR_HMAC_SHA1_32";
+        case MBEDTLS_TLS_SRTP_ARIA_256_CTR_HMAC_SHA1_80:
+            return "MBEDTLS_TLS_SRTP_ARIA_256_CTR_HMAC_SHA1_80";
+        case MBEDTLS_TLS_SRTP_ARIA_256_CTR_HMAC_SHA1_32:
+            return "MBEDTLS_TLS_SRTP_ARIA_256_CTR_HMAC_SHA1_32";
+        case MBEDTLS_TLS_SRTP_AEAD_ARIA_128_GCM:
+            return "MBEDTLS_TLS_SRTP_AEAD_ARIA_128_GCM";
+        case MBEDTLS_TLS_SRTP_AEAD_ARIA_256_GCM:
+            return "MBEDTLS_TLS_SRTP_AEAD_ARIA_256_GCM";
         default: break;
     }
     return "";

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -1597,6 +1597,16 @@ static inline mbedtls_ssl_srtp_profile mbedtls_ssl_check_srtp_profile_value
         case MBEDTLS_TLS_SRTP_AES128_CM_HMAC_SHA1_32:
         case MBEDTLS_TLS_SRTP_NULL_HMAC_SHA1_80:
         case MBEDTLS_TLS_SRTP_NULL_HMAC_SHA1_32:
+        case MBEDTLS_TLS_SRTP_AEAD_AES_128_GCM:
+        case MBEDTLS_TLS_SRTP_AEAD_AES_256_GCM:
+        case MBEDTLS_TLS_DOUBLE_AEAD_AES_128_GCM_AEAD_AES_128_GCM:
+        case MBEDTLS_TLS_DOUBLE_AEAD_AES_256_GCM_AEAD_AES_256_GCM:
+        case MBEDTLS_TLS_SRTP_ARIA_128_CTR_HMAC_SHA1_80:
+        case MBEDTLS_TLS_SRTP_ARIA_128_CTR_HMAC_SHA1_32:
+        case MBEDTLS_TLS_SRTP_ARIA_256_CTR_HMAC_SHA1_80:
+        case MBEDTLS_TLS_SRTP_ARIA_256_CTR_HMAC_SHA1_32:
+        case MBEDTLS_TLS_SRTP_AEAD_ARIA_128_GCM:
+        case MBEDTLS_TLS_SRTP_AEAD_ARIA_256_GCM:
             return srtp_profile_value;
         default: break;
     }

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -212,12 +212,22 @@ int main(void)
     "    use_srtp=%%d         default: 0 (disabled)\n" \
     "                          This cannot be used with eap_tls=1 or " \
     "                          nss_keylog=1\n"             \
-    "    srtp_force_profile=%%d  default: 0 (all enabled)\n"   \
+    "    srtp_force_profile=%%d  default: 0 (all RFC5764+RFC7714 modes enabled)\n"   \
     "                        available profiles:\n"       \
-    "                        1 - SRTP_AES128_CM_HMAC_SHA1_80\n"  \
-    "                        2 - SRTP_AES128_CM_HMAC_SHA1_32\n"  \
-    "                        3 - SRTP_NULL_HMAC_SHA1_80\n"       \
-    "                        4 - SRTP_NULL_HMAC_SHA1_32\n"       \
+    "                        1  - SRTP_AES128_CM_HMAC_SHA1_80\n"  \
+    "                        2  - SRTP_AES128_CM_HMAC_SHA1_32\n"  \
+    "                        5  - SRTP_NULL_HMAC_SHA1_80\n"       \
+    "                        6  - SRTP_NULL_HMAC_SHA1_32\n"       \
+    "                        7  - SRTP_AEAD_AES_128_GCM\n"        \
+    "                        8  - SRTP_AEAD_AES_256_GCM\n"        \
+    "                        9  - DOUBLE_AEAD_AES_128_GCM_AEAD_AES_128_GCM\n"       \
+    "                        10 - DOUBLE_AEAD_AES_256_GCM_AEAD_AES_256_GCM\n"       \
+    "                        11 - SRTP_ARIA_128_CTR_HMAC_SHA1_80\n"                 \
+    "                        12 - SRTP_ARIA_128_CTR_HMAC_SHA1_32\n"                 \
+    "                        13 - SRTP_ARIA_256_CTR_HMAC_SHA1_80\n"                 \
+    "                        14 - SRTP_ARIA_256_CTR_HMAC_SHA1_32\n"                 \
+    "                        15 - SRTP_AEAD_ARIA_128_GCM\n"       \
+    "                        16 - SRTP_AEAD_ARIA_256_GCM\n"       \
     "    mki=%%s              default: \"\" (in hex, without 0x)\n"
 #else /* MBEDTLS_SSL_DTLS_SRTP */
 #define USAGE_SRTP ""
@@ -853,6 +863,8 @@ int main(int argc, char *argv[])
         MBEDTLS_TLS_SRTP_AES128_CM_HMAC_SHA1_32,
         MBEDTLS_TLS_SRTP_NULL_HMAC_SHA1_80,
         MBEDTLS_TLS_SRTP_NULL_HMAC_SHA1_32,
+        MBEDTLS_TLS_SRTP_AEAD_AES_128_GCM,
+        MBEDTLS_TLS_SRTP_AEAD_AES_256_GCM,
         MBEDTLS_TLS_SRTP_UNSET
     };
 #endif /* MBEDTLS_SSL_DTLS_SRTP */

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -298,12 +298,22 @@ int main(void)
 #if defined(MBEDTLS_SSL_DTLS_SRTP)
 #define USAGE_SRTP \
     "    use_srtp=%%d         default: 0 (disabled)\n" \
-    "    srtp_force_profile=%%d  default: 0 (all enabled)\n"   \
+    "    srtp_force_profile=%%d  default: 0 (all RFC5764+RFC7714 modes enabled)\n"   \
     "                        available profiles:\n"       \
-    "                        1 - SRTP_AES128_CM_HMAC_SHA1_80\n"  \
-    "                        2 - SRTP_AES128_CM_HMAC_SHA1_32\n"  \
-    "                        3 - SRTP_NULL_HMAC_SHA1_80\n"       \
-    "                        4 - SRTP_NULL_HMAC_SHA1_32\n"       \
+    "                        1  - SRTP_AES128_CM_HMAC_SHA1_80\n"  \
+    "                        2  - SRTP_AES128_CM_HMAC_SHA1_32\n"  \
+    "                        5  - SRTP_NULL_HMAC_SHA1_80\n"       \
+    "                        6  - SRTP_NULL_HMAC_SHA1_32\n"       \
+    "                        7  - SRTP_AEAD_AES_128_GCM\n"        \
+    "                        8  - SRTP_AEAD_AES_256_GCM\n"        \
+    "                        9  - DOUBLE_AEAD_AES_128_GCM_AEAD_AES_128_GCM\n"       \
+    "                        10 - DOUBLE_AEAD_AES_256_GCM_AEAD_AES_256_GCM\n"       \
+    "                        11 - SRTP_ARIA_128_CTR_HMAC_SHA1_80\n"                 \
+    "                        12 - SRTP_ARIA_128_CTR_HMAC_SHA1_32\n"                 \
+    "                        13 - SRTP_ARIA_256_CTR_HMAC_SHA1_80\n"                 \
+    "                        14 - SRTP_ARIA_256_CTR_HMAC_SHA1_32\n"                 \
+    "                        15 - SRTP_AEAD_ARIA_128_GCM\n"       \
+    "                        16 - SRTP_AEAD_ARIA_256_GCM\n"       \
     "    support_mki=%%d     default: 0 (not supported)\n"
 #else /* MBEDTLS_SSL_DTLS_SRTP */
 #define USAGE_SRTP ""
@@ -1609,6 +1619,8 @@ int main(int argc, char *argv[])
         MBEDTLS_TLS_SRTP_AES128_CM_HMAC_SHA1_32,
         MBEDTLS_TLS_SRTP_NULL_HMAC_SHA1_80,
         MBEDTLS_TLS_SRTP_NULL_HMAC_SHA1_32,
+        MBEDTLS_TLS_SRTP_AEAD_AES_128_GCM,
+        MBEDTLS_TLS_SRTP_AEAD_AES_256_GCM,
         MBEDTLS_TLS_SRTP_UNSET
     };
 #endif /* MBEDTLS_SSL_DTLS_SRTP */

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -10995,6 +10995,44 @@ run_test  "DTLS-SRTP server supports all profiles. Client supports one profile."
 
 requires_config_enabled MBEDTLS_SSL_DTLS_SRTP
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test  "DTLS-SRTP server supports all profiles. Client supports only SRTP_AEAD_AES_128_GCM." \
+          "$P_SRV dtls=1 use_srtp=1 debug_level=3" \
+          "$P_CLI dtls=1 use_srtp=1 srtp_force_profile=7 debug_level=3" \
+          0 \
+          -s "found use_srtp extension" \
+          -s "found srtp profile: MBEDTLS_TLS_SRTP_AEAD_AES_128_GCM" \
+          -s "selected srtp profile: MBEDTLS_TLS_SRTP_AEAD_AES_128_GCM" \
+          -s "server hello, adding use_srtp extension" \
+          -s "DTLS-SRTP key material is"\
+          -c "client hello, adding use_srtp extension" \
+          -c "found use_srtp extension" \
+          -c "found srtp profile: MBEDTLS_TLS_SRTP_AEAD_AES_128_GCM" \
+          -c "selected srtp profile" \
+          -c "DTLS-SRTP key material is"\
+          -g "find_in_both '^ *Keying material: [0-9A-F]*$'"\
+          -C "error"
+
+requires_config_enabled MBEDTLS_SSL_DTLS_SRTP
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test  "DTLS-SRTP server supports all profiles. Client supports only SRTP_AEAD_AES_256_GCM." \
+          "$P_SRV dtls=1 use_srtp=1 debug_level=3" \
+          "$P_CLI dtls=1 use_srtp=1 srtp_force_profile=8 debug_level=3" \
+          0 \
+          -s "found use_srtp extension" \
+          -s "found srtp profile: MBEDTLS_TLS_SRTP_AEAD_AES_256_GCM" \
+          -s "selected srtp profile: MBEDTLS_TLS_SRTP_AEAD_AES_256_GCM" \
+          -s "server hello, adding use_srtp extension" \
+          -s "DTLS-SRTP key material is"\
+          -c "client hello, adding use_srtp extension" \
+          -c "found use_srtp extension" \
+          -c "found srtp profile: MBEDTLS_TLS_SRTP_AEAD_AES_256_GCM" \
+          -c "selected srtp profile" \
+          -c "DTLS-SRTP key material is"\
+          -g "find_in_both '^ *Keying material: [0-9A-F]*$'"\
+          -C "error"
+
+requires_config_enabled MBEDTLS_SSL_DTLS_SRTP
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 run_test  "DTLS-SRTP server supports one profile. Client supports all profiles." \
           "$P_SRV dtls=1 use_srtp=1 srtp_force_profile=6 debug_level=3" \
           "$P_CLI dtls=1 use_srtp=1 debug_level=3" \
@@ -11014,6 +11052,44 @@ run_test  "DTLS-SRTP server supports one profile. Client supports all profiles."
 
 requires_config_enabled MBEDTLS_SSL_DTLS_SRTP
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test  "DTLS-SRTP server supports only SRTP_AEAD_AES_128_GCM. Client supports all profiles." \
+          "$P_SRV dtls=1 use_srtp=1 srtp_force_profile=7 debug_level=3" \
+          "$P_CLI dtls=1 use_srtp=1 debug_level=3" \
+          0 \
+          -s "found use_srtp extension" \
+          -s "found srtp profile" \
+          -s "selected srtp profile: MBEDTLS_TLS_SRTP_AEAD_AES_128_GCM" \
+          -s "server hello, adding use_srtp extension" \
+          -s "DTLS-SRTP key material is"\
+          -c "client hello, adding use_srtp extension" \
+          -c "found use_srtp extension" \
+          -c "found srtp profile: MBEDTLS_TLS_SRTP_SRTP_AEAD_AES_128_GCM" \
+          -c "selected srtp profile" \
+          -c "DTLS-SRTP key material is"\
+          -g "find_in_both '^ *Keying material: [0-9A-F]*$'"\
+          -C "error"
+
+requires_config_enabled MBEDTLS_SSL_DTLS_SRTP
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test  "DTLS-SRTP server supports only SRTP_AEAD_AES_256_GCM. Client supports all profiles." \
+          "$P_SRV dtls=1 use_srtp=1 srtp_force_profile=8 debug_level=3" \
+          "$P_CLI dtls=1 use_srtp=1 debug_level=3" \
+          0 \
+          -s "found use_srtp extension" \
+          -s "found srtp profile" \
+          -s "selected srtp profile: MBEDTLS_TLS_SRTP_AEAD_AES_256_GCM" \
+          -s "server hello, adding use_srtp extension" \
+          -s "DTLS-SRTP key material is"\
+          -c "client hello, adding use_srtp extension" \
+          -c "found use_srtp extension" \
+          -c "found srtp profile: MBEDTLS_TLS_SRTP_AEAD_AES_256_GCM" \
+          -c "selected srtp profile" \
+          -c "DTLS-SRTP key material is"\
+          -g "find_in_both '^ *Keying material: [0-9A-F]*$'"\
+          -C "error"
+
+requires_config_enabled MBEDTLS_SSL_DTLS_SRTP
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 run_test  "DTLS-SRTP server and Client support only one matching profile." \
           "$P_SRV dtls=1 use_srtp=1 srtp_force_profile=2 debug_level=3" \
           "$P_CLI dtls=1 use_srtp=1 srtp_force_profile=2 debug_level=3" \
@@ -11026,6 +11102,44 @@ run_test  "DTLS-SRTP server and Client support only one matching profile." \
           -c "client hello, adding use_srtp extension" \
           -c "found use_srtp extension" \
           -c "found srtp profile: MBEDTLS_TLS_SRTP_AES128_CM_HMAC_SHA1_32" \
+          -c "selected srtp profile" \
+          -c "DTLS-SRTP key material is"\
+          -g "find_in_both '^ *Keying material: [0-9A-F]*$'"\
+          -C "error"
+
+requires_config_enabled MBEDTLS_SSL_DTLS_SRTP
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test  "DTLS-SRTP server and Client support can agree to only matching profile SRTP_AEAD_AES_128_GCM." \
+          "$P_SRV dtls=1 use_srtp=1 srtp_force_profile=7 debug_level=3" \
+          "$P_CLI dtls=1 use_srtp=1 srtp_force_profile=7 debug_level=3" \
+          0 \
+          -s "found use_srtp extension" \
+          -s "found srtp profile: MBEDTLS_TLS_SRTP_AEAD_AES_128_GCM" \
+          -s "selected srtp profile: MBEDTLS_TLS_SRTP_AEAD_AES_128_GCM" \
+          -s "server hello, adding use_srtp extension" \
+          -s "DTLS-SRTP key material is"\
+          -c "client hello, adding use_srtp extension" \
+          -c "found use_srtp extension" \
+          -c "found srtp profile: MBEDTLS_TLS_MBEDTLS_TLS_SRTP_AEAD_AES_128_GCM" \
+          -c "selected srtp profile" \
+          -c "DTLS-SRTP key material is"\
+          -g "find_in_both '^ *Keying material: [0-9A-F]*$'"\
+          -C "error"
+
+requires_config_enabled MBEDTLS_SSL_DTLS_SRTP
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test  "DTLS-SRTP server and Client support can agree to only matching profile SRTP_AEAD_AES_256_GCM." \
+          "$P_SRV dtls=1 use_srtp=1 srtp_force_profile=8 debug_level=3" \
+          "$P_CLI dtls=1 use_srtp=1 srtp_force_profile=8 debug_level=3" \
+          0 \
+          -s "found use_srtp extension" \
+          -s "found srtp profile: MBEDTLS_TLS_SRTP_AEAD_AES_256_GCM" \
+          -s "selected srtp profile: MBEDTLS_TLS_SRTP_AEAD_AES_256_GCM" \
+          -s "server hello, adding use_srtp extension" \
+          -s "DTLS-SRTP key material is"\
+          -c "client hello, adding use_srtp extension" \
+          -c "found use_srtp extension" \
+          -c "found srtp profile: MBEDTLS_TLS_MBEDTLS_TLS_SRTP_AEAD_AES_256_GCM" \
           -c "selected srtp profile" \
           -c "DTLS-SRTP key material is"\
           -g "find_in_both '^ *Keying material: [0-9A-F]*$'"\
@@ -11116,7 +11230,7 @@ requires_config_enabled MBEDTLS_SSL_DTLS_SRTP
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 run_test  "DTLS-SRTP all profiles supported. openssl client." \
           "$P_SRV dtls=1 use_srtp=1 debug_level=3" \
-          "$O_CLI -dtls -use_srtp SRTP_AES128_CM_SHA1_80:SRTP_AES128_CM_SHA1_32 -keymatexport 'EXTRACTOR-dtls_srtp' -keymatexportlen 60" \
+          "$O_CLI -dtls -use_srtp SRTP_AES128_CM_SHA1_80:SRTP_AES128_CM_SHA1_32:SRTP_AEAD_AES_128_GCM:SRTP_AEAD_AES_256_GCM -keymatexport 'EXTRACTOR-dtls_srtp' -keymatexportlen 88" \
           0 \
           -s "found use_srtp extension" \
           -s "found srtp profile" \
@@ -11130,7 +11244,7 @@ requires_config_enabled MBEDTLS_SSL_DTLS_SRTP
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 run_test  "DTLS-SRTP server supports all profiles. Client supports all profiles, in different order. openssl client." \
           "$P_SRV dtls=1 use_srtp=1 debug_level=3" \
-          "$O_CLI -dtls -use_srtp SRTP_AES128_CM_SHA1_32:SRTP_AES128_CM_SHA1_80 -keymatexport 'EXTRACTOR-dtls_srtp' -keymatexportlen 60" \
+          "$O_CLI -dtls -use_srtp SRTP_AES128_CM_SHA1_32:SRTP_AES128_CM_SHA1_80:SRTP_AEAD_AES_128_GCM:SRTP_AEAD_AES_256_GCM -keymatexport 'EXTRACTOR-dtls_srtp' -keymatexportlen 88" \
           0 \
           -s "found use_srtp extension" \
           -s "found srtp profile" \
@@ -11144,7 +11258,7 @@ requires_config_enabled MBEDTLS_SSL_DTLS_SRTP
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 run_test  "DTLS-SRTP server supports all profiles. Client supports one profile. openssl client." \
           "$P_SRV dtls=1 use_srtp=1 debug_level=3" \
-          "$O_CLI -dtls -use_srtp SRTP_AES128_CM_SHA1_32 -keymatexport 'EXTRACTOR-dtls_srtp' -keymatexportlen 60" \
+          "$O_CLI -dtls -use_srtp SRTP_AES128_CM_SHA1_32 -keymatexport 'EXTRACTOR-dtls_srtp' -keymatexportlen 88" \
           0 \
           -s "found use_srtp extension" \
           -s "found srtp profile" \
@@ -11158,7 +11272,7 @@ requires_config_enabled MBEDTLS_SSL_DTLS_SRTP
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 run_test  "DTLS-SRTP server supports one profile. Client supports all profiles. openssl client." \
           "$P_SRV dtls=1 use_srtp=1 srtp_force_profile=2 debug_level=3" \
-          "$O_CLI -dtls -use_srtp SRTP_AES128_CM_SHA1_80:SRTP_AES128_CM_SHA1_32 -keymatexport 'EXTRACTOR-dtls_srtp' -keymatexportlen 60" \
+          "$O_CLI -dtls -use_srtp SRTP_AES128_CM_SHA1_80:SRTP_AES128_CM_SHA1_32:SRTP_AEAD_AES_128_GCM:SRTP_AEAD_AES_256_GCM -keymatexport 'EXTRACTOR-dtls_srtp' -keymatexportlen 88" \
           0 \
           -s "found use_srtp extension" \
           -s "found srtp profile" \
@@ -11172,7 +11286,7 @@ requires_config_enabled MBEDTLS_SSL_DTLS_SRTP
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 run_test  "DTLS-SRTP server and Client support only one matching profile. openssl client." \
           "$P_SRV dtls=1 use_srtp=1 srtp_force_profile=2 debug_level=3" \
-          "$O_CLI -dtls -use_srtp SRTP_AES128_CM_SHA1_32 -keymatexport 'EXTRACTOR-dtls_srtp' -keymatexportlen 60" \
+          "$O_CLI -dtls -use_srtp SRTP_AES128_CM_SHA1_32 -keymatexport 'EXTRACTOR-dtls_srtp' -keymatexportlen 88" \
           0 \
           -s "found use_srtp extension" \
           -s "found srtp profile" \
@@ -11184,9 +11298,37 @@ run_test  "DTLS-SRTP server and Client support only one matching profile. openss
 
 requires_config_enabled MBEDTLS_SSL_DTLS_SRTP
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test  "DTLS-SRTP server and Client support can agree to only matching profile SRTP_AEAD_AES_128_GCM. openssl client." \
+          "$P_SRV dtls=1 use_srtp=1 srtp_force_profile=7 debug_level=3" \
+          "$O_CLI -dtls -use_srtp SRTP_AEAD_AES_128_GCM -keymatexport 'EXTRACTOR-dtls_srtp' -keymatexportlen 88" \
+          0 \
+          -s "found use_srtp extension" \
+          -s "found srtp profile" \
+          -s "selected srtp profile" \
+          -s "server hello, adding use_srtp extension" \
+          -s "DTLS-SRTP key material is"\
+          -g "find_in_both '^ *Keying material: [0-9A-F]*$'"\
+          -c "SRTP Extension negotiated, profile=SRTP_AEAD_AES_128_GCM"
+
+requires_config_enabled MBEDTLS_SSL_DTLS_SRTP
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test  "DTLS-SRTP server and Client support can agree to only matching profile SRTP_AEAD_AES_256_GCM. openssl client." \
+          "$P_SRV dtls=1 use_srtp=1 srtp_force_profile=8 debug_level=3" \
+          "$O_CLI -dtls -use_srtp SRTP_AEAD_AES_256_GCM -keymatexport 'EXTRACTOR-dtls_srtp' -keymatexportlen 88" \
+          0 \
+          -s "found use_srtp extension" \
+          -s "found srtp profile" \
+          -s "selected srtp profile" \
+          -s "server hello, adding use_srtp extension" \
+          -s "DTLS-SRTP key material is"\
+          -g "find_in_both '^ *Keying material: [0-9A-F]*$'"\
+          -c "SRTP Extension negotiated, profile=SRTP_AEAD_AES_128_GCM"
+
+requires_config_enabled MBEDTLS_SSL_DTLS_SRTP
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 run_test  "DTLS-SRTP server and Client support only one different profile. openssl client." \
           "$P_SRV dtls=1 use_srtp=1 srtp_force_profile=1 debug_level=3" \
-          "$O_CLI -dtls -use_srtp SRTP_AES128_CM_SHA1_32 -keymatexport 'EXTRACTOR-dtls_srtp' -keymatexportlen 60" \
+          "$O_CLI -dtls -use_srtp SRTP_AES128_CM_SHA1_32 -keymatexport 'EXTRACTOR-dtls_srtp' -keymatexportlen 88" \
           0 \
           -s "found use_srtp extension" \
           -s "found srtp profile" \
@@ -11199,7 +11341,7 @@ requires_config_enabled MBEDTLS_SSL_DTLS_SRTP
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 run_test  "DTLS-SRTP server doesn't support use_srtp extension. openssl client" \
           "$P_SRV dtls=1 debug_level=3" \
-          "$O_CLI -dtls -use_srtp SRTP_AES128_CM_SHA1_80:SRTP_AES128_CM_SHA1_32 -keymatexport 'EXTRACTOR-dtls_srtp' -keymatexportlen 60" \
+          "$O_CLI -dtls -use_srtp SRTP_AES128_CM_SHA1_80:SRTP_AES128_CM_SHA1_32 -keymatexport 'EXTRACTOR-dtls_srtp' -keymatexportlen 88" \
           0 \
           -s "found use_srtp extension" \
           -S "server hello, adding use_srtp extension" \
@@ -11209,7 +11351,7 @@ run_test  "DTLS-SRTP server doesn't support use_srtp extension. openssl client" 
 requires_config_enabled MBEDTLS_SSL_DTLS_SRTP
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 run_test  "DTLS-SRTP all profiles supported. openssl server" \
-          "$O_SRV -dtls -verify 0 -use_srtp SRTP_AES128_CM_SHA1_80:SRTP_AES128_CM_SHA1_32 -keymatexport 'EXTRACTOR-dtls_srtp' -keymatexportlen 60" \
+          "$O_SRV -dtls -verify 0 -use_srtp SRTP_AES128_CM_SHA1_80:SRTP_AES128_CM_SHA1_32:SRTP_AEAD_AES_128_GCM:SRTP_AEAD_AES_256_GCM -keymatexport 'EXTRACTOR-dtls_srtp' -keymatexportlen 88" \
           "$P_CLI dtls=1 use_srtp=1 debug_level=3" \
           0 \
           -c "client hello, adding use_srtp extension" \
@@ -11222,7 +11364,7 @@ run_test  "DTLS-SRTP all profiles supported. openssl server" \
 requires_config_enabled MBEDTLS_SSL_DTLS_SRTP
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 run_test  "DTLS-SRTP server supports all profiles. Client supports all profiles, in different order. openssl server." \
-          "$O_SRV -dtls -verify 0 -use_srtp SRTP_AES128_CM_SHA1_32:SRTP_AES128_CM_SHA1_80 -keymatexport 'EXTRACTOR-dtls_srtp' -keymatexportlen 60" \
+          "$O_SRV -dtls -verify 0 -use_srtp SRTP_AES128_CM_SHA1_32:SRTP_AES128_CM_SHA1_80:SRTP_AEAD_AES_128_GCM:SRTP_AEAD_AES_256_GCM -keymatexport 'EXTRACTOR-dtls_srtp' -keymatexportlen 88" \
           "$P_CLI dtls=1 use_srtp=1 debug_level=3" \
           0 \
           -c "client hello, adding use_srtp extension" \
@@ -11235,7 +11377,7 @@ run_test  "DTLS-SRTP server supports all profiles. Client supports all profiles,
 requires_config_enabled MBEDTLS_SSL_DTLS_SRTP
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 run_test  "DTLS-SRTP server supports all profiles. Client supports one profile. openssl server." \
-          "$O_SRV -dtls -verify 0 -use_srtp SRTP_AES128_CM_SHA1_80:SRTP_AES128_CM_SHA1_32 -keymatexport 'EXTRACTOR-dtls_srtp' -keymatexportlen 60" \
+          "$O_SRV -dtls -verify 0 -use_srtp SRTP_AES128_CM_SHA1_80:SRTP_AES128_CM_SHA1_32:SRTP_AEAD_AES_128_GCM:SRTP_AEAD_AES_256_GCM -keymatexport 'EXTRACTOR-dtls_srtp' -keymatexportlen 88" \
           "$P_CLI dtls=1 use_srtp=1 srtp_force_profile=2 debug_level=3" \
           0 \
           -c "client hello, adding use_srtp extension" \
@@ -11247,8 +11389,34 @@ run_test  "DTLS-SRTP server supports all profiles. Client supports one profile. 
 
 requires_config_enabled MBEDTLS_SSL_DTLS_SRTP
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test  "DTLS-SRTP server supports all profiles. Client supports only SRTP_AEAD_AES_128_GCM. openssl server." \
+          "$O_SRV -dtls -verify 0 -use_srtp SRTP_AES128_CM_SHA1_80:SRTP_AES128_CM_SHA1_32:SRTP_AEAD_AES_128_GCM:SRTP_AEAD_AES_256_GCM -keymatexport 'EXTRACTOR-dtls_srtp' -keymatexportlen 88" \
+          "$P_CLI dtls=1 use_srtp=1 srtp_force_profile=7 debug_level=3" \
+          0 \
+          -c "client hello, adding use_srtp extension" \
+          -c "found use_srtp extension" \
+          -c "found srtp profile: MBEDTLS_TLS_SRTP_AEAD_AES_128_GCM" \
+          -c "selected srtp profile" \
+          -c "DTLS-SRTP key material is"\
+          -C "error"
+
+requires_config_enabled MBEDTLS_SSL_DTLS_SRTP
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test  "DTLS-SRTP server supports all profiles. Client supports only SRTP_AEAD_AES_256_GCM. openssl server." \
+          "$O_SRV -dtls -verify 0 -use_srtp SRTP_AES128_CM_SHA1_80:SRTP_AES128_CM_SHA1_32:SRTP_AEAD_AES_128_GCM:SRTP_AEAD_AES_256_GCM -keymatexport 'EXTRACTOR-dtls_srtp' -keymatexportlen 88" \
+          "$P_CLI dtls=1 use_srtp=1 srtp_force_profile=8 debug_level=3" \
+          0 \
+          -c "client hello, adding use_srtp extension" \
+          -c "found use_srtp extension" \
+          -c "found srtp profile: MBEDTLS_TLS_SRTP_AEAD_AES_256_GCM" \
+          -c "selected srtp profile" \
+          -c "DTLS-SRTP key material is"\
+          -C "error"
+
+requires_config_enabled MBEDTLS_SSL_DTLS_SRTP
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 run_test  "DTLS-SRTP server supports one profile. Client supports all profiles. openssl server." \
-          "$O_SRV -dtls -verify 0 -use_srtp SRTP_AES128_CM_SHA1_32 -keymatexport 'EXTRACTOR-dtls_srtp' -keymatexportlen 60" \
+          "$O_SRV -dtls -verify 0 -use_srtp SRTP_AES128_CM_SHA1_32 -keymatexport 'EXTRACTOR-dtls_srtp' -keymatexportlen 88" \
           "$P_CLI dtls=1 use_srtp=1 debug_level=3" \
           0 \
           -c "client hello, adding use_srtp extension" \
@@ -11261,7 +11429,7 @@ run_test  "DTLS-SRTP server supports one profile. Client supports all profiles. 
 requires_config_enabled MBEDTLS_SSL_DTLS_SRTP
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 run_test  "DTLS-SRTP server and Client support only one matching profile. openssl server." \
-          "$O_SRV -dtls -verify 0 -use_srtp SRTP_AES128_CM_SHA1_32 -keymatexport 'EXTRACTOR-dtls_srtp' -keymatexportlen 60" \
+          "$O_SRV -dtls -verify 0 -use_srtp SRTP_AES128_CM_SHA1_32 -keymatexport 'EXTRACTOR-dtls_srtp' -keymatexportlen 88" \
           "$P_CLI dtls=1 use_srtp=1 srtp_force_profile=2 debug_level=3" \
           0 \
           -c "client hello, adding use_srtp extension" \
@@ -11274,7 +11442,7 @@ run_test  "DTLS-SRTP server and Client support only one matching profile. openss
 requires_config_enabled MBEDTLS_SSL_DTLS_SRTP
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 run_test  "DTLS-SRTP server and Client support only one different profile. openssl server." \
-          "$O_SRV -dtls -verify 0 -use_srtp SRTP_AES128_CM_SHA1_32 -keymatexport 'EXTRACTOR-dtls_srtp' -keymatexportlen 60" \
+          "$O_SRV -dtls -verify 0 -use_srtp SRTP_AES128_CM_SHA1_32 -keymatexport 'EXTRACTOR-dtls_srtp' -keymatexportlen 88" \
           "$P_CLI dtls=1 use_srtp=1 srtp_force_profile=6 debug_level=3" \
           0 \
           -c "client hello, adding use_srtp extension" \
@@ -11300,7 +11468,7 @@ run_test  "DTLS-SRTP server doesn't support use_srtp extension. openssl server" 
 requires_config_enabled MBEDTLS_SSL_DTLS_SRTP
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 run_test  "DTLS-SRTP all profiles supported. server doesn't support mki. openssl server." \
-          "$O_SRV -dtls -verify 0 -use_srtp SRTP_AES128_CM_SHA1_80:SRTP_AES128_CM_SHA1_32 -keymatexport 'EXTRACTOR-dtls_srtp' -keymatexportlen 60" \
+          "$O_SRV -dtls -verify 0 -use_srtp SRTP_AES128_CM_SHA1_80:SRTP_AES128_CM_SHA1_32 -keymatexport 'EXTRACTOR-dtls_srtp' -keymatexportlen 88" \
           "$P_CLI dtls=1 use_srtp=1 mki=542310ab34290481 debug_level=3" \
           0 \
           -c "client hello, adding use_srtp extension" \
@@ -11318,7 +11486,7 @@ requires_gnutls
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 run_test  "DTLS-SRTP all profiles supported. gnutls client." \
           "$P_SRV dtls=1 use_srtp=1 debug_level=3" \
-          "$G_CLI -u --srtp-profiles=SRTP_AES128_CM_HMAC_SHA1_80:SRTP_AES128_CM_HMAC_SHA1_32:SRTP_NULL_HMAC_SHA1_80:SRTP_NULL_SHA1_32 --insecure 127.0.0.1" \
+          "$G_CLI -u --srtp-profiles=SRTP_AES128_CM_HMAC_SHA1_80:SRTP_AES128_CM_HMAC_SHA1_32:SRTP_NULL_HMAC_SHA1_80:SRTP_NULL_SHA1_32:SRTP_AEAD_AES_128_GCM:SRTP_AEAD_AES_256_GCM --insecure 127.0.0.1" \
           0 \
           -s "found use_srtp extension" \
           -s "found srtp profile" \
@@ -11332,7 +11500,7 @@ requires_gnutls
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 run_test  "DTLS-SRTP server supports all profiles. Client supports all profiles, in different order. gnutls client." \
           "$P_SRV dtls=1 use_srtp=1 debug_level=3" \
-          "$G_CLI -u --srtp-profiles=SRTP_NULL_HMAC_SHA1_80:SRTP_AES128_CM_HMAC_SHA1_80:SRTP_NULL_SHA1_32:SRTP_AES128_CM_HMAC_SHA1_32 --insecure 127.0.0.1" \
+          "$G_CLI -u --srtp-profiles=SRTP_NULL_HMAC_SHA1_80:SRTP_AES128_CM_HMAC_SHA1_80:SRTP_NULL_SHA1_32:SRTP_AES128_CM_HMAC_SHA1_32:SRTP_AEAD_AES_128_GCM:SRTP_AEAD_AES_256_GCM --insecure 127.0.0.1" \
           0 \
           -s "found use_srtp extension" \
           -s "found srtp profile" \
@@ -11360,7 +11528,7 @@ requires_gnutls
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 run_test  "DTLS-SRTP server supports one profile. Client supports all profiles. gnutls client." \
           "$P_SRV dtls=1 use_srtp=1 srtp_force_profile=6 debug_level=3" \
-          "$G_CLI -u --srtp-profiles=SRTP_AES128_CM_HMAC_SHA1_80:SRTP_AES128_CM_HMAC_SHA1_32:SRTP_NULL_HMAC_SHA1_80:SRTP_NULL_SHA1_32 --insecure 127.0.0.1" \
+          "$G_CLI -u --srtp-profiles=SRTP_AES128_CM_HMAC_SHA1_80:SRTP_AES128_CM_HMAC_SHA1_32:SRTP_NULL_HMAC_SHA1_80:SRTP_NULL_SHA1_32:SRTP_AEAD_AES_128_GCM:SRTP_AEAD_AES_256_GCM --insecure 127.0.0.1" \
           0 \
           -s "found use_srtp extension" \
           -s "found srtp profile" \
@@ -11368,6 +11536,34 @@ run_test  "DTLS-SRTP server supports one profile. Client supports all profiles. 
           -s "server hello, adding use_srtp extension" \
           -s "DTLS-SRTP key material is"\
           -c "SRTP profile: SRTP_NULL_SHA1_32"
+
+requires_config_enabled MBEDTLS_SSL_DTLS_SRTP
+requires_gnutls
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test  "DTLS-SRTP server supports only SRTP_AEAD_AES_128_GCM profile. Client supports all profiles. gnutls client." \
+          "$P_SRV dtls=1 use_srtp=1 srtp_force_profile=7 debug_level=3" \
+          "$G_CLI -u --srtp-profiles=SRTP_AES128_CM_HMAC_SHA1_80:SRTP_AES128_CM_HMAC_SHA1_32:SRTP_NULL_HMAC_SHA1_80:SRTP_NULL_SHA1_32:SRTP_AEAD_AES_128_GCM:SRTP_AEAD_AES_256_GCM --insecure 127.0.0.1" \
+          0 \
+          -s "found use_srtp extension" \
+          -s "found srtp profile" \
+          -s "selected srtp profile: MBEDTLS_TLS_SRTP_AEAD_AES_128_GCM" \
+          -s "server hello, adding use_srtp extension" \
+          -s "DTLS-SRTP key material is"\
+          -c "SRTP profile: SRTP_AEAD_AES_128_GCM"
+
+requires_config_enabled MBEDTLS_SSL_DTLS_SRTP
+requires_gnutls
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test  "DTLS-SRTP server supports only SRTP_AEAD_AES_256_GCM profile. Client supports all profiles. gnutls client." \
+          "$P_SRV dtls=1 use_srtp=1 srtp_force_profile=8 debug_level=3" \
+          "$G_CLI -u --srtp-profiles=SRTP_AES128_CM_HMAC_SHA1_80:SRTP_AES128_CM_HMAC_SHA1_32:SRTP_NULL_HMAC_SHA1_80:SRTP_NULL_SHA1_32:SRTP_AEAD_AES_128_GCM:SRTP_AEAD_AES_256_GCM --insecure 127.0.0.1" \
+          0 \
+          -s "found use_srtp extension" \
+          -s "found srtp profile" \
+          -s "selected srtp profile: MBEDTLS_TLS_SRTP_AEAD_AES_256_GCM" \
+          -s "server hello, adding use_srtp extension" \
+          -s "DTLS-SRTP key material is"\
+          -c "SRTP profile: SRTP_AEAD_AES_256_GCM"
 
 requires_config_enabled MBEDTLS_SSL_DTLS_SRTP
 requires_gnutls
@@ -11402,7 +11598,7 @@ requires_gnutls
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 run_test  "DTLS-SRTP server doesn't support use_srtp extension. gnutls client" \
           "$P_SRV dtls=1 debug_level=3" \
-          "$G_CLI -u --srtp-profiles=SRTP_AES128_CM_HMAC_SHA1_80:SRTP_AES128_CM_HMAC_SHA1_32:SRTP_NULL_HMAC_SHA1_80:SRTP_NULL_SHA1_32 --insecure 127.0.0.1" \
+          "$G_CLI -u --srtp-profiles=SRTP_AES128_CM_HMAC_SHA1_80:SRTP_AES128_CM_HMAC_SHA1_32:SRTP_NULL_HMAC_SHA1_80:SRTP_NULL_SHA1_32:SRTP_AEAD_AES_128_GCM:SRTP_AEAD_AES_256_GCM --insecure 127.0.0.1" \
           0 \
           -s "found use_srtp extension" \
           -S "server hello, adding use_srtp extension" \
@@ -11413,7 +11609,7 @@ requires_config_enabled MBEDTLS_SSL_DTLS_SRTP
 requires_gnutls
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 run_test  "DTLS-SRTP all profiles supported. gnutls server" \
-          "$G_SRV -u --srtp-profiles=SRTP_AES128_CM_HMAC_SHA1_80:SRTP_AES128_CM_HMAC_SHA1_32:SRTP_NULL_HMAC_SHA1_80:SRTP_NULL_SHA1_32" \
+          "$G_SRV -u --srtp-profiles=SRTP_AES128_CM_HMAC_SHA1_80:SRTP_AES128_CM_HMAC_SHA1_32:SRTP_NULL_HMAC_SHA1_80:SRTP_NULL_SHA1_32:SRTP_AEAD_AES_128_GCM:SRTP_AEAD_AES_256_GCM" \
           "$P_CLI dtls=1 use_srtp=1 debug_level=3" \
           0 \
           -c "client hello, adding use_srtp extension" \
@@ -11427,7 +11623,7 @@ requires_config_enabled MBEDTLS_SSL_DTLS_SRTP
 requires_gnutls
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 run_test  "DTLS-SRTP server supports all profiles. Client supports all profiles, in different order. gnutls server." \
-          "$G_SRV -u --srtp-profiles=SRTP_NULL_SHA1_32:SRTP_AES128_CM_HMAC_SHA1_32:SRTP_AES128_CM_HMAC_SHA1_80:SRTP_NULL_HMAC_SHA1_80:SRTP_NULL_SHA1_32" \
+          "$G_SRV -u --srtp-profiles=SRTP_NULL_SHA1_32:SRTP_AES128_CM_HMAC_SHA1_32:SRTP_AES128_CM_HMAC_SHA1_80:SRTP_NULL_HMAC_SHA1_80:SRTP_NULL_SHA1_32:SRTP_AEAD_AES_128_GCM:SRTP_AEAD_AES_256_GCM" \
           "$P_CLI dtls=1 use_srtp=1 debug_level=3" \
           0 \
           -c "client hello, adding use_srtp extension" \
@@ -11441,7 +11637,7 @@ requires_config_enabled MBEDTLS_SSL_DTLS_SRTP
 requires_gnutls
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 run_test  "DTLS-SRTP server supports all profiles. Client supports one profile. gnutls server." \
-          "$G_SRV -u --srtp-profiles=SRTP_NULL_SHA1_32:SRTP_AES128_CM_HMAC_SHA1_32:SRTP_AES128_CM_HMAC_SHA1_80:SRTP_NULL_HMAC_SHA1_80:SRTP_NULL_SHA1_32" \
+          "$G_SRV -u --srtp-profiles=SRTP_NULL_SHA1_32:SRTP_AES128_CM_HMAC_SHA1_32:SRTP_AES128_CM_HMAC_SHA1_80:SRTP_NULL_HMAC_SHA1_80:SRTP_NULL_SHA1_32:SRTP_AEAD_AES_128_GCM:SRTP_AEAD_AES_256_GCM" \
           "$P_CLI dtls=1 use_srtp=1 srtp_force_profile=2 debug_level=3" \
           0 \
           -c "client hello, adding use_srtp extension" \
@@ -11511,7 +11707,7 @@ requires_config_enabled MBEDTLS_SSL_DTLS_SRTP
 requires_gnutls
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
 run_test  "DTLS-SRTP all profiles supported. mki used. gnutls server." \
-          "$G_SRV -u --srtp-profiles=SRTP_AES128_CM_HMAC_SHA1_80:SRTP_AES128_CM_HMAC_SHA1_32:SRTP_NULL_HMAC_SHA1_80:SRTP_NULL_SHA1_32" \
+          "$G_SRV -u --srtp-profiles=SRTP_AES128_CM_HMAC_SHA1_80:SRTP_AES128_CM_HMAC_SHA1_32:SRTP_NULL_HMAC_SHA1_80:SRTP_NULL_SHA1_32:SRTP_AEAD_AES_128_GCM:SRTP_AEAD_AES_256_GCM" \
           "$P_CLI dtls=1 use_srtp=1 mki=542310ab34290481 debug_level=3" \
           0 \
           -c "client hello, adding use_srtp extension" \


### PR DESCRIPTION
## Description

allow negotiation of all use_srtp profile values currently listed by IANA, especially the AEAD modes from RFC7714(which all browsers already support for WebRTC)

## PR checklist

- [ ] **changelog** provided
- [ ] **development PR** provided
- [ ] **TF-PSA-Crypto PR** not required because: No changes
- [ ] **framework PR** not required
- [ ] **3.6 PR** not required because: Not breaking any APIs
- **tests**  provided (but these are completely blind changes matching existing test patterns, unable to run/execute any of these due to local build-system limitations/changes)

