### PR TITLE
mbedtls prerequisite: Return int from platform mutex_init

### DIFF
--- a/programs/Makefile
+++ b/programs/Makefile
@@ -233,7 +233,7 @@ endif
 
 test/metatest$(EXEXT): $(FRAMEWORK)/tests/programs/metatest.c $(DEP)
 	echo "  CC    $(FRAMEWORK)/tests/programs/metatest.c"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) -I../library -I../tf-psa-crypto/core $(FRAMEWORK)/tests/programs/metatest.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) -I../library -I../tf-psa-crypto/core -I../tf-psa-crypto/drivers/builtin/include -I../tf-psa-crypto/drivers/builtin/src $(FRAMEWORK)/tests/programs/metatest.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test/query_config.o: test/query_config.c $(FRAMEWORK)/tests/programs/query_config.h $(DEP)
 	echo "  CC    test/query_config.c"

--- a/programs/test/CMakeLists.txt
+++ b/programs/test/CMakeLists.txt
@@ -102,6 +102,10 @@ foreach(exe IN LISTS executables)
     target_link_libraries(${exe} ${libs} ${CMAKE_THREAD_LIBS_INIT})
 endforeach()
 
+target_include_directories(metatest
+        PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../tf-psa-crypto/drivers/builtin/include
+                ${CMAKE_CURRENT_SOURCE_DIR}/../../tf-psa-crypto/drivers/builtin/src)
+
 install(TARGETS ${executables}
         DESTINATION "bin"
         PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)


### PR DESCRIPTION
Prerequisite for https://github.com/Mbed-TLS/mbedtls-framework/pull/205 and https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/439.

* Allow metatest.c to use crypto internal headers

## PR checklist

- [x] **changelog** provided | not required because: internal only
- [x] **development PR** here
- [x] **TF-PSA-Crypto PR** not required because: file not built in crypto yet
- [x] **framework PR** provided https://github.com/Mbed-TLS/mbedtls-framework/pull/205 (unblocked by this)
- [x] **3.6 PR** not required because: 3.6 already works
- **tests**  provided
