### PR TITLE
Have the definition of MBEDTLS_CONFIG_VERSION uncommented by default

### DIFF
--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -19,7 +19,7 @@
  * It is equal to the #MBEDTLS_VERSION_NUMBER of the Mbed TLS version that
  * introduced the config format we want to be compatible with.
  */
-//#define MBEDTLS_CONFIG_VERSION 0x04000000
+#define MBEDTLS_CONFIG_VERSION 0x04000000
 
 /**
  * \name SECTION: Platform abstraction layer


### PR DESCRIPTION
Checking through the history in https://github.com/Mbed-TLS/mbedtls/pull/4589, this seems to have been what we intended from the start. But we couldn't do it yet because the library version was still 2.x while the config version was already 3.0, so we temporarily commented out the definition in 1cafe5ce20c54e68a4de0f85bd4bc844e3798198. But then we forgot to uncomment it during the release since it wasn't part of any process.

Thinking about it independently of the history, I think it makes more sense to have it uncommented by default. That way, if someone copies the config from a given version and then keeps it around, they'll get the compatibility mode for that version.

## PR checklist

- [x] **changelog** not required because: not an interface commitment
- [x] **development PR** here
- [x] **TF-PSA-Crypto PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/463
- [x] **framework PR** not required
- [x] **3.6 PR** not required because: I don't see a reason to act in the LTS
- **tests**  provided
