### PR TITLE
Mechanism to error out on removed configuration options: mbedtls prerequisite for crypto

### DIFF
--- a/library/Makefile
+++ b/library/Makefile
@@ -356,6 +356,8 @@ $(TF_PSA_CRYPTO_GENERATED_CONFIG_CHECK_FILES):
 	echo "  Gen   $(TF_PSA_CRYPTO_GENERATED_CONFIG_CHECK_FILES)"
 	$(PYTHON) $(TF_PSA_CRYPTO_CORE_PATH)/../scripts/generate_config_checks.py
 
+$(TF_PSA_CRYPTO_CORE_PATH)/tf_psa_crypto_config.o: $(TF_PSA_CRYPTO_GENERATED_CONFIG_CHECK_FILES)
+
 clean:
 ifndef WINDOWS
 	rm -f *.o *.s libmbed*

--- a/tests/scripts/components-configuration-crypto.sh
+++ b/tests/scripts/components-configuration-crypto.sh
@@ -2436,7 +2436,10 @@ component_test_xts () {
     # supported through the PSA API.
     msg "build: Default + MBEDTLS_CIPHER_MODE_XTS"
 
-    echo "#define MBEDTLS_CIPHER_MODE_XTS" > psa_user_config.h
+    cat <<'EOF' >psa_user_config.h
+#define MBEDTLS_CIPHER_MODE_XTS
+#define TF_PSA_CRYPTO_CONFIG_CHECK_BYPASS
+EOF
     cmake -DTF_PSA_CRYPTO_USER_CONFIG_FILE="psa_user_config.h"
     make
 


### PR DESCRIPTION
Additional patches needed to pass the CI on https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/269.

## PR checklist

- [x] **changelog** not required because: build/test stuff only
- [x] **development PR** here
- [x] **TF-PSA-Crypto PR** https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/269
- [x] **framework PR** not required
- [x] **3.6 PR** not required because: new stuff
- **tests**  provided
