### PR TITLE
Use submodule work trees during ABI check

### DIFF
--- a/scripts/abi_check.py
+++ b/scripts/abi_check.py
@@ -207,7 +207,8 @@ class AbiChecker:
 
         try:
             # Try to update the submodules using local commits
-            # (Git will sometimes insist on fetching the remote without --no-fetch if the submodules are shallow clones)
+            # (Git will sometimes insist on fetching the remote without --no-fetch
+            # if the submodules are shallow clones)
             update_output = subprocess.check_output(
                 [self.git_command, "submodule", "update", "--init", '--recursive', '--no-fetch'],
                 cwd=git_worktree_path,

--- a/scripts/abi_check.py
+++ b/scripts/abi_check.py
@@ -398,13 +398,14 @@ class AbiChecker:
         """Remove the specified git worktree."""
         shutil.rmtree(git_worktree_path)
         submodule_output = subprocess.check_output(
-            [self.git_command, "submodule", "foreach", "--recursive", "git worktree prune"],
+            [self.git_command, "submodule", "foreach", "--recursive",
+             f'git worktree remove "{git_worktree_path}/$displaypath"'],
             cwd=self.repo_path,
             stderr=subprocess.STDOUT
         )
         self.log.debug(submodule_output.decode("utf-8"))
         worktree_output = subprocess.check_output(
-            [self.git_command, "worktree", "prune"],
+            [self.git_command, "worktree", "remove", git_worktree_path],
             cwd=self.repo_path,
             stderr=subprocess.STDOUT
         )

--- a/scripts/abi_check.py
+++ b/scripts/abi_check.py
@@ -199,7 +199,7 @@ class AbiChecker:
         otherwise update it to the default revision"""
         submodule_output = subprocess.check_output(
             [self.git_command, "submodule", "foreach", "--recursive",
-             'git worktree add --detach "{}/$displaypath" HEAD'.format(git_worktree_path)],
+             f'git worktree add --detach "{git_worktree_path}/$displaypath" HEAD'],
             cwd=self.repo_path,
             stderr=subprocess.STDOUT
         )

--- a/scripts/abi_check.py
+++ b/scripts/abi_check.py
@@ -197,6 +197,13 @@ class AbiChecker:
         """If the crypto submodule is present, initialize it.
         if version.crypto_revision exists, update it to that revision,
         otherwise update it to the default revision"""
+        submodule_output = subprocess.check_output(
+            [self.git_command, "submodule", "foreach", "--recursive",
+             'git worktree add --detach "{}/$displaypath" HEAD'.format(git_worktree_path)],
+            cwd=self.repo_path,
+            stderr=subprocess.STDOUT
+        )
+        self.log.debug(submodule_output.decode("utf-8"))
         update_output = subprocess.check_output(
             [self.git_command, "submodule", "update", "--init", '--recursive'],
             cwd=git_worktree_path,
@@ -390,6 +397,12 @@ class AbiChecker:
     def _cleanup_worktree(self, git_worktree_path):
         """Remove the specified git worktree."""
         shutil.rmtree(git_worktree_path)
+        submodule_output = subprocess.check_output(
+            [self.git_command, "submodule", "foreach", "--recursive", "git worktree prune"],
+            cwd=self.repo_path,
+            stderr=subprocess.STDOUT
+        )
+        self.log.debug(submodule_output.decode("utf-8"))
         worktree_output = subprocess.check_output(
             [self.git_command, "worktree", "prune"],
             cwd=self.repo_path,


### PR DESCRIPTION
## Description

This fixes our ABI checking in PR-merge jobs.
For parametrihzed jobs, this PR when used in conjuction with https://github.com/Mbed-TLS/mbedtls-test/pull/220 fixes the issue.

Conceptually, this is a port of https://github.com/Mbed-TLS/mbedtls-test/commit/62d05693659a18ad5a1c50e2b94502185c6c7e82 to `abi_check.py`

## PR checklist
- [x] **changelog**  not required
- [x] **development PR** #10416
- [x] **TF-PSA-Crypto PR** not required 
- [x] **framework PR** not required
- [x] **3.6 PR**: #10417
- **tests** not required 