### PR TITLE
Fix includes in udp_proxy.c

### DIFF
--- a/programs/test/udp_proxy.c
+++ b/programs/test/udp_proxy.c
@@ -14,11 +14,11 @@
 
 #include "mbedtls/build_info.h"
 
+#include <stdlib.h>
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"
 #else
 #include <stdio.h>
-#include <stdlib.h>
 #if defined(MBEDTLS_HAVE_TIME)
 #include <time.h>
 #define mbedtls_time            time


### PR DESCRIPTION
## Description

3.6 backport of https://github.com/Mbed-TLS/mbedtls/pull/10418

## PR checklist

- [x] **changelog** not required because: internal
- [x] **development PR** provided #10418
- [x] **TF-PSA-Crypto PR** not required because: TLS sample program
- [x] **framework PR** not required
- [x] **3.6 PR** provided HERE
- **tests** not required because: caught by existing tests