### PR TITLE
Add missing include of `stdio.h` in PSASIM

### DIFF
--- a/tests/psa-client-server/psasim/include/util.h
+++ b/tests/psa-client-server/psasim/include/util.h
@@ -7,6 +7,8 @@
 
 #include "service.h"
 
+#include <stdio.h>
+
 #define PRINT(fmt, ...) \
     fprintf(stdout, fmt "\n", ##__VA_ARGS__)
 


### PR DESCRIPTION
This is required in util.h in PSASIM as it uses fprintf. Previously stdio was inadvertantly included via psa/crypto_struct.h (of all places).


## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** not required because: No user-facing change
- [x] **development PR** here
- [x] **TF-PSA-Crypto PR** not required because: Mbed TLS change only
- [x] **framework PR** not required
- [ ] **3.6 PR** provided # TODO
- **tests**  not required because: Trivial fix to tests themselves
