### PR TITLE
Increased MBEDTLS_BEFORE_COLON (size of temporary buffer) to 32

### DIFF
--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -1744,7 +1744,7 @@ static int x509_info_cert_policies(char **buf, size_t *size,
 /*
  * Return an informational string about the certificate.
  */
-#define MBEDTLS_BEFORE_COLON        18
+#define MBEDTLS_BEFORE_COLON        32
 #define MBEDTLS_BEFORE_COLON_STR    "18"
 int mbedtls_x509_crt_info(char *buf, size_t size, const char *prefix,
                           const mbedtls_x509_crt *crt)
@@ -1807,6 +1807,7 @@ int mbedtls_x509_crt_info(char *buf, size_t size, const char *prefix,
     /* Key size */
     if ((ret = mbedtls_x509_key_size_helper(key_size_str, MBEDTLS_BEFORE_COLON,
                                             mbedtls_pk_get_name(&crt->pk))) != 0) {
+        assert(ret != MBEDTLS_ERR_X509_BUFFER_TOO_SMALL);
         return ret;
     }
 

--- a/library/x509_csr.c
+++ b/library/x509_csr.c
@@ -519,7 +519,7 @@ int mbedtls_x509_csr_parse_file(mbedtls_x509_csr *csr, const char *path)
 #endif /* MBEDTLS_FS_IO */
 
 #if !defined(MBEDTLS_X509_REMOVE_INFO)
-#define MBEDTLS_BEFORE_COLON       14
+#define MBEDTLS_BEFORE_COLON       32
 #define MBEDTLS_BEFORE_COLON_STR   "14"
 /*
  * Return an informational string about the CSR.
@@ -552,6 +552,7 @@ int mbedtls_x509_csr_info(char *buf, size_t size, const char *prefix,
 
     if ((ret = mbedtls_x509_key_size_helper(key_size_str, MBEDTLS_BEFORE_COLON,
                                             mbedtls_pk_get_name(&csr->pk))) != 0) {
+        assert(ret != MBEDTLS_ERR_X509_BUFFER_TOO_SMALL);
         return ret;
     }
 


### PR DESCRIPTION
## Description

Fix for Ticket #4894:
* The buffer size is increased to 32
* An asseretion is added to check for buffer to small in development builds


## PR checklist

- [ ] **changelog** not required because: I have no idea, what to write
- **tests**  provided (as comment in #4894)

