### PR TITLE
Silence support failures in all.sh

### DIFF
--- a/tests/scripts/components-basic-checks.sh
+++ b/tests/scripts/components-basic-checks.sh
@@ -97,7 +97,7 @@ component_check_code_style () {
 }
 
 support_check_code_style () {
-    case $(uncrustify --version) in
+    case $(uncrustify --version 2>/dev/null) in
         *0.75.1*) true;;
         *) false;;
     esac

--- a/tests/scripts/components-configuration.sh
+++ b/tests/scripts/components-configuration.sh
@@ -227,7 +227,7 @@ support_build_baremetal () {
     # Older Glibc versions include time.h from other headers such as stdlib.h,
     # which makes the no-time.h-in-baremetal check fail. Ubuntu 16.04 has this
     # problem, Ubuntu 18.04 is ok.
-    ! grep -q -F time.h /usr/include/x86_64-linux-gnu/sys/types.h
+    ! grep -s -q -F time.h /usr/include/x86_64-linux-gnu/sys/types.h
 }
 
 component_build_tfm () {

--- a/tests/scripts/components-platform.sh
+++ b/tests/scripts/components-platform.sh
@@ -98,7 +98,7 @@ support_test_aesni () {
     # in component_test_aesni_m32.
     (gcc -v 2>&1 | grep Target | grep -q x86_64) &&
     [[ "$HOSTTYPE" == "x86_64" && "$OSTYPE" == "linux-gnu" ]] &&
-    (lscpu | grep -qw aes)
+    (lscpu | grep -qw aes) 2>/dev/null
 }
 
 component_test_aesni () { # ~ 60s
@@ -155,7 +155,7 @@ component_test_aesni () { # ~ 60s
 }
 
 support_test_aesni_m32 () {
-    support_test_m32_no_asm && (lscpu | grep -qw aes)
+    support_test_m32_no_asm && (lscpu | grep -qw aes) 2>/dev/null
 }
 
 component_test_aesni_m32 () { # ~ 60s

--- a/tests/scripts/components-platform.sh
+++ b/tests/scripts/components-platform.sh
@@ -94,13 +94,11 @@ support_test_aesni () {
     #
     # The name of this function is possibly slightly misleading, but needs to align
     # with the name of the corresponding test, component_test_aesni.
-    #
-    # In principle 32-bit x86 can support AESNI, but our implementation does not
-    # support 32-bit x86, so we check for x86-64.
-    # We can only grep /proc/cpuinfo on Linux, so this also checks for Linux
+    # We check only for 64-bit x86 here: 32-bit AESNI is tested separately
+    # in component_test_aesni_m32.
     (gcc -v 2>&1 | grep Target | grep -q x86_64) &&
-        [[ "$HOSTTYPE" == "x86_64" && "$OSTYPE" == "linux-gnu" ]] &&
-        (lscpu | grep -qw aes)
+    [[ "$HOSTTYPE" == "x86_64" && "$OSTYPE" == "linux-gnu" ]] &&
+    (lscpu | grep -qw aes)
 }
 
 component_test_aesni () { # ~ 60s


### PR DESCRIPTION
Suppress output that's expected on stderr when a `support_xxx` function returns a negative result.

## PR checklist

- [x] **changelog** not required because: test only
- [x] **development PR** https://github.com/Mbed-TLS/mbedtls/pull/10493
- [x] **mbedtls 4.1 PR** https://github.com/Mbed-TLS/mbedtls/pull/10681
- [x] **TF-PSA-Crypto PR** https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/681
- [x] **TF-PSA-Crypto 1.1 PR** https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/747
- [x] **framework PR** not required
- [x] **3.6 PR** https://github.com/Mbed-TLS/mbedtls/pull/10586
- **tests**  provided (if the CI keeps passing, it's not wrong)
