### PR TITLE
Replace mbedtls_md_info_from_string() with strcmp()

### DIFF
--- a/programs/x509/cert_req.c
+++ b/programs/x509/cert_req.c
@@ -305,8 +305,47 @@ usage:
                 q = r;
             }
         } else if (strcmp(p, "md") == 0) {
-            const mbedtls_md_info_t *md_info =
-                mbedtls_md_info_from_string(q);
+            const mbedtls_md_info_t *md_info = NULL;
+
+#if defined(PSA_WANT_ALG_MD5)
+            if (strcmp(q, "MD5") == 0) {
+                md_info = mbedtls_md_info_from_type(MBEDTLS_MD_MD5);
+            } else
+#endif
+#if defined(PSA_WANT_ALG_RIPEMD160)
+            if (strcmp(q, "RIPEMD160") == 0) {
+                md_info = mbedtls_md_info_from_type(MBEDTLS_MD_RIPEMD160);
+            } else
+#endif
+#if defined(PSA_WANT_ALG_SHA_1)
+            if (strcmp(q, "SHA1") == 0) {
+                md_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA1);
+            } else
+#endif
+#if defined(PSA_WANT_ALG_SHA_224) || defined(MBEDTLS_PSA_ACCEL_ALG_SHA3_224)
+            if (strcmp(q, "SHA224") == 0) {
+                md_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA224);
+            } else
+#endif
+#if defined(PSA_WANT_ALG_SHA_256) || defined(MBEDTLS_PSA_ACCEL_ALG_SHA3_256)
+            if (strcmp(q, "SHA256") == 0) {
+                md_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
+            } else
+#endif
+#if defined(PSA_WANT_ALG_SHA_384) || defined(MBEDTLS_PSA_ACCEL_ALG_SHA3_384)
+            if (strcmp(q, "SHA384") == 0) {
+                md_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA384);
+            } else
+#endif
+#if defined(PSA_WANT_ALG_SHA_512) || defined(MBEDTLS_PSA_ACCEL_ALG_SHA3_512)
+            if (strcmp(q, "SHA512") == 0) {
+                md_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA512);
+            } else
+#endif
+            {
+                md_info = NULL;
+            }
+
             if (md_info == NULL) {
                 mbedtls_printf("Invalid argument for option %s\n", p);
                 goto usage;

--- a/programs/x509/cert_req.c
+++ b/programs/x509/cert_req.c
@@ -314,8 +314,47 @@ usage:
                 q = r;
             }
         } else if (strcmp(p, "md") == 0) {
-            const mbedtls_md_info_t *md_info =
-                mbedtls_md_info_from_string(q);
+            const mbedtls_md_info_t *md_info = NULL;
+
+#if defined(PSA_WANT_ALG_MD5)
+            if (strcmp(q, "MD5") == 0) {
+                md_info = mbedtls_md_info_from_type(MBEDTLS_MD_MD5);
+            } else
+#endif
+#if defined(PSA_WANT_ALG_RIPEMD160)
+            if (strcmp(q, "RIPEMD160") == 0) {
+                md_info = mbedtls_md_info_from_type(MBEDTLS_MD_RIPEMD160);
+            } else
+#endif
+#if defined(PSA_WANT_ALG_SHA_1)
+            if (strcmp(q, "SHA1") == 0) {
+                md_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA1);
+            } else
+#endif
+#if defined(PSA_WANT_ALG_SHA_224) || defined(MBEDTLS_PSA_ACCEL_ALG_SHA3_224)
+            if (strcmp(q, "SHA224") == 0) {
+                md_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA224);
+            } else
+#endif
+#if defined(PSA_WANT_ALG_SHA_256) || defined(MBEDTLS_PSA_ACCEL_ALG_SHA3_256)
+            if (strcmp(q, "SHA256") == 0) {
+                md_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
+            } else
+#endif
+#if defined(PSA_WANT_ALG_SHA_384) || defined(MBEDTLS_PSA_ACCEL_ALG_SHA3_384)
+            if (strcmp(q, "SHA384") == 0) {
+                md_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA384);
+            } else
+#endif
+#if defined(PSA_WANT_ALG_SHA_512) || defined(MBEDTLS_PSA_ACCEL_ALG_SHA3_512)
+            if (strcmp(q, "SHA512") == 0) {
+                md_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA512);
+            } else
+#endif
+            {
+                md_info = NULL;
+            }
+
             if (md_info == NULL) {
                 mbedtls_printf("Invalid argument for option %s\n", p);
                 goto usage;

--- a/programs/x509/cert_req.c
+++ b/programs/x509/cert_req.c
@@ -327,28 +327,48 @@ usage:
             } else
 #endif
 #if defined(PSA_WANT_ALG_SHA_1)
-            if (strcmp(q, "SHA1") == 0) {
+            if (strcmp(q, "SHA1") == 0 || strcmp(q, "SHA") == 0) {
                 md_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA1);
             } else
 #endif
-#if defined(PSA_WANT_ALG_SHA_224) || defined(MBEDTLS_PSA_ACCEL_ALG_SHA3_224)
+#if defined(PSA_WANT_ALG_SHA_224)
             if (strcmp(q, "SHA224") == 0) {
                 md_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA224);
             } else
 #endif
-#if defined(PSA_WANT_ALG_SHA_256) || defined(MBEDTLS_PSA_ACCEL_ALG_SHA3_256)
+#if defined(PSA_WANT_ALG_SHA_256)
             if (strcmp(q, "SHA256") == 0) {
                 md_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
             } else
 #endif
-#if defined(PSA_WANT_ALG_SHA_384) || defined(MBEDTLS_PSA_ACCEL_ALG_SHA3_384)
+#if defined(PSA_WANT_ALG_SHA_384)
             if (strcmp(q, "SHA384") == 0) {
                 md_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA384);
             } else
 #endif
-#if defined(PSA_WANT_ALG_SHA_512) || defined(MBEDTLS_PSA_ACCEL_ALG_SHA3_512)
+#if defined(PSA_WANT_ALG_SHA_512)
             if (strcmp(q, "SHA512") == 0) {
                 md_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA512);
+            } else
+#endif
+#if defined(PSA_WANT_ALG_SHA3_224)
+            if (strcmp(q, "SHA3-224") == 0) {
+                md_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA3_224);
+            } else
+#endif
+#if defined(PSA_WANT_ALG_SHA3_256)
+            if (strcmp(q, "SHA3-256") == 0) {
+                md_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA3_256);
+            } else
+#endif
+#if defined(PSA_WANT_ALG_SHA3_384)
+            if (strcmp(q, "SHA3-384") == 0) {
+                md_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA3_384);
+            } else
+#endif
+#if defined(PSA_WANT_ALG_SHA3_512)
+            if (strcmp(q, "SHA3-512") == 0) {
+                md_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA3_512);
             } else
 #endif
             {

--- a/programs/x509/cert_write.c
+++ b/programs/x509/cert_write.c
@@ -432,8 +432,47 @@ usage:
                 goto usage;
             }
         } else if (strcmp(p, "md") == 0) {
-            const mbedtls_md_info_t *md_info =
-                mbedtls_md_info_from_string(q);
+            const mbedtls_md_info_t *md_info = NULL;
+
+#if defined(PSA_WANT_ALG_MD5)
+            if (strcmp(q, "MD5") == 0) {
+                md_info = mbedtls_md_info_from_type(MBEDTLS_MD_MD5);
+            } else
+#endif
+#if defined(PSA_WANT_ALG_RIPEMD160)
+            if (strcmp(q, "RIPEMD160") == 0) {
+                md_info = mbedtls_md_info_from_type(MBEDTLS_MD_RIPEMD160);
+            } else
+#endif
+#if defined(PSA_WANT_ALG_SHA_1)
+            if (strcmp(q, "SHA1") == 0) {
+                md_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA1);
+            } else
+#endif
+#if defined(PSA_WANT_ALG_SHA_224) || defined(MBEDTLS_PSA_ACCEL_ALG_SHA3_224)
+            if (strcmp(q, "SHA224") == 0) {
+                md_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA224);
+            } else
+#endif
+#if defined(PSA_WANT_ALG_SHA_256) || defined(MBEDTLS_PSA_ACCEL_ALG_SHA3_256)
+            if (strcmp(q, "SHA256") == 0) {
+                md_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
+            } else
+#endif
+#if defined(PSA_WANT_ALG_SHA_384) || defined(MBEDTLS_PSA_ACCEL_ALG_SHA3_384)
+            if (strcmp(q, "SHA384") == 0) {
+                md_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA384);
+            } else
+#endif
+#if defined(PSA_WANT_ALG_SHA_512) || defined(MBEDTLS_PSA_ACCEL_ALG_SHA3_512)
+            if (strcmp(q, "SHA512") == 0) {
+                md_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA512);
+            } else
+#endif
+            {
+                md_info = NULL;
+            }
+
             if (md_info == NULL) {
                 mbedtls_printf("Invalid argument for option %s\n", p);
                 goto usage;

--- a/programs/x509/cert_write.c
+++ b/programs/x509/cert_write.c
@@ -423,8 +423,47 @@ usage:
                 goto usage;
             }
         } else if (strcmp(p, "md") == 0) {
-            const mbedtls_md_info_t *md_info =
-                mbedtls_md_info_from_string(q);
+            const mbedtls_md_info_t *md_info = NULL;
+
+#if defined(PSA_WANT_ALG_MD5)
+            if (strcmp(q, "MD5") == 0) {
+                md_info = mbedtls_md_info_from_type(MBEDTLS_MD_MD5);
+            } else
+#endif
+#if defined(PSA_WANT_ALG_RIPEMD160)
+            if (strcmp(q, "RIPEMD160") == 0) {
+                md_info = mbedtls_md_info_from_type(MBEDTLS_MD_RIPEMD160);
+            } else
+#endif
+#if defined(PSA_WANT_ALG_SHA_1)
+            if (strcmp(q, "SHA1") == 0) {
+                md_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA1);
+            } else
+#endif
+#if defined(PSA_WANT_ALG_SHA_224) || defined(MBEDTLS_PSA_ACCEL_ALG_SHA3_224)
+            if (strcmp(q, "SHA224") == 0) {
+                md_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA224);
+            } else
+#endif
+#if defined(PSA_WANT_ALG_SHA_256) || defined(MBEDTLS_PSA_ACCEL_ALG_SHA3_256)
+            if (strcmp(q, "SHA256") == 0) {
+                md_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
+            } else
+#endif
+#if defined(PSA_WANT_ALG_SHA_384) || defined(MBEDTLS_PSA_ACCEL_ALG_SHA3_384)
+            if (strcmp(q, "SHA384") == 0) {
+                md_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA384);
+            } else
+#endif
+#if defined(PSA_WANT_ALG_SHA_512) || defined(MBEDTLS_PSA_ACCEL_ALG_SHA3_512)
+            if (strcmp(q, "SHA512") == 0) {
+                md_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA512);
+            } else
+#endif
+            {
+                md_info = NULL;
+            }
+
             if (md_info == NULL) {
                 mbedtls_printf("Invalid argument for option %s\n", p);
                 goto usage;

--- a/programs/x509/cert_write.c
+++ b/programs/x509/cert_write.c
@@ -445,28 +445,48 @@ usage:
             } else
 #endif
 #if defined(PSA_WANT_ALG_SHA_1)
-            if (strcmp(q, "SHA1") == 0) {
+            if (strcmp(q, "SHA1") == 0 || strcmp(q, "SHA") == 0) {
                 md_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA1);
             } else
 #endif
-#if defined(PSA_WANT_ALG_SHA_224) || defined(MBEDTLS_PSA_ACCEL_ALG_SHA3_224)
+#if defined(PSA_WANT_ALG_SHA_224)
             if (strcmp(q, "SHA224") == 0) {
                 md_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA224);
             } else
 #endif
-#if defined(PSA_WANT_ALG_SHA_256) || defined(MBEDTLS_PSA_ACCEL_ALG_SHA3_256)
+#if defined(PSA_WANT_ALG_SHA_256)
             if (strcmp(q, "SHA256") == 0) {
                 md_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
             } else
 #endif
-#if defined(PSA_WANT_ALG_SHA_384) || defined(MBEDTLS_PSA_ACCEL_ALG_SHA3_384)
+#if defined(PSA_WANT_ALG_SHA_384)
             if (strcmp(q, "SHA384") == 0) {
                 md_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA384);
             } else
 #endif
-#if defined(PSA_WANT_ALG_SHA_512) || defined(MBEDTLS_PSA_ACCEL_ALG_SHA3_512)
+#if defined(PSA_WANT_ALG_SHA_512)
             if (strcmp(q, "SHA512") == 0) {
                 md_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA512);
+            } else
+#endif
+#if defined(PSA_WANT_ALG_SHA3_224)
+            if (strcmp(q, "SHA3-224") == 0) {
+                md_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA3_224);
+            } else
+#endif
+#if defined(PSA_WANT_ALG_SHA3_256)
+            if (strcmp(q, "SHA3-256") == 0) {
+                md_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA3_256);
+            } else
+#endif
+#if defined(PSA_WANT_ALG_SHA3_384)
+            if (strcmp(q, "SHA3-384") == 0) {
+                md_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA3_384);
+            } else
+#endif
+#if defined(PSA_WANT_ALG_SHA3_512)
+            if (strcmp(q, "SHA3-512") == 0) {
+                md_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA3_512);
             } else
 #endif
             {


### PR DESCRIPTION
## Description

Replace `mbedtls_md_info_from_string()` to `strcmp()`: `mbedtls_md_info_from_string()` is going away in 4.0

Behavior is unchanged for invalid/unsupported values.

Issue: https://github.com/Mbed-TLS/mbedtls/issues/10156

## PR checklist

- [x] **changelog** not required because: no user visible change
- [x] **framework PR** not required
- [x] **TF-PSA-Crypto development PR** not required because: no change
- [x] **TF-PSA-Crypto 1.1 PR** not required because: no change
- [x] **mbedtls development PR** provided: https://github.com/Mbed-TLS/mbedtls/pull/10628
- [x] **mbedtls 4.1 PR** provided: https://github.com/Mbed-TLS/mbedtls/pull/10923
- [x] **mbedtls 3.6 PR**  not required because: targeted function stays in 3.6, no need for replacement
- **tests**  not required because: code refactor, no behaviour change