### PR TITLE
Backport 3.6: ssl_fork_server RNG testing

### DIFF
--- a/library/ssl_tls12_client.c
+++ b/library/ssl_tls12_client.c
@@ -1733,17 +1733,27 @@ static int ssl_parse_server_ecdh_params(mbedtls_ssl_context *ssl,
      *  5+      ECPoint contents
      */
     if (end - *p < 4) {
+        MBEDTLS_SSL_DEBUG_MSG(2,
+                              ("bad server key exchange message: too short (%u)",
+                               (unsigned) (end - *p)));
         return MBEDTLS_ERR_SSL_DECODE_ERROR;
     }
 
     /* First byte is curve_type; only named_curve is handled */
     if (*(*p)++ != MBEDTLS_ECP_TLS_NAMED_CURVE) {
+        MBEDTLS_SSL_DEBUG_MSG(2,
+                              ("bad server key exchange message: not named_curve (%u != %u)",
+                               (unsigned) (*p)[-1],
+                               (unsigned) MBEDTLS_ECP_TLS_NAMED_CURVE));
         return MBEDTLS_ERR_SSL_HANDSHAKE_FAILURE;
     }
 
     /* Next two bytes are the namedcurve value */
     tls_id = MBEDTLS_GET_UINT16_BE(*p, 0);
     *p += 2;
+    MBEDTLS_SSL_DEBUG_MSG(3,
+                          ("server key exchange message: server picked ECDHE curve 0x%04x",
+                           (unsigned) tls_id));
 
     /* Check it's a curve we offered */
     if (mbedtls_ssl_check_curve_tls_id(ssl, tls_id) != 0) {
@@ -1764,13 +1774,23 @@ static int ssl_parse_server_ecdh_params(mbedtls_ssl_context *ssl,
     /* Keep a copy of the peer's public key */
     ecpoint_len = *(*p)++;
     if ((size_t) (end - *p) < ecpoint_len) {
+        MBEDTLS_SSL_DEBUG_MSG(2,
+                              ("bad server key exchange message: too short for point (%u < %u)",
+                               (unsigned) (end - *p),
+                               (unsigned) ecpoint_len));
         return MBEDTLS_ERR_SSL_DECODE_ERROR;
     }
 
     if (ecpoint_len > sizeof(handshake->xxdh_psa_peerkey)) {
+        MBEDTLS_SSL_DEBUG_MSG(2,
+                              ("bad server key exchange message: ecpoint_len too long "
+                               "(%" MBEDTLS_PRINTF_SIZET " > %" MBEDTLS_PRINTF_SIZET ")",
+                               ecpoint_len,
+                               sizeof(handshake->xxdh_psa_peerkey)));
         return MBEDTLS_ERR_SSL_HANDSHAKE_FAILURE;
     }
 
+    MBEDTLS_SSL_DEBUG_BUF(3, "server ephemeral public key", *p, ecpoint_len);
     memcpy(handshake->xxdh_psa_peerkey, *p, ecpoint_len);
     handshake->xxdh_psa_peerkey_len = ecpoint_len;
     *p += ecpoint_len;
@@ -1856,6 +1876,44 @@ static int ssl_parse_server_ecdh_params(mbedtls_ssl_context *ssl,
                               ("bad server key exchange message (ECDHE curve)"));
         return MBEDTLS_ERR_SSL_HANDSHAKE_FAILURE;
     }
+
+#if defined(MBEDTLS_DEBUG_C)
+    {
+        uint8_t pub_buf[MBEDTLS_ECP_MAX_PT_LEN];
+        size_t pub_len;
+#if defined(MBEDTLS_ECDH_LEGACY_CONTEXT)
+        const mbedtls_ecdh_context *ecdh = &ssl->handshake->ecdh_ctx;
+#else
+        const mbedtls_ecdh_context_mbed *ecdh = &ssl->handshake->ecdh_ctx.ctx.mbed_ecdh;
+#endif
+#if defined(MBEDTLS_ECDH_VARIANT_EVEREST_ENABLED)
+        if (ssl->handshake->ecdh_ctx.var == MBEDTLS_ECDH_VARIANT_EVEREST) {
+            const mbedtls_x25519_context *x25519 =
+                &ssl->handshake->ecdh_ctx.ctx.everest_ecdh.ctx;
+            pub_len = MBEDTLS_X25519_KEY_SIZE_BYTES;
+            if (pub_len > sizeof(pub_buf)) {
+                MBEDTLS_SSL_DEBUG_MSG(1, ("Everest X25519 key too large: "
+                                          "%" MBEDTLS_PRINTF_SIZET " > %" MBEDTLS_PRINTF_SIZET,
+                                          pub_len, sizeof(pub_buf)));
+                return MBEDTLS_ERR_SSL_INTERNAL_ERROR;
+            }
+            memcpy(pub_buf, x25519->peer_point, pub_len);
+        } else
+#endif /* defined(MBEDTLS_ECDH_VARIANT_EVEREST_ENABLED) */
+        {
+            ret = mbedtls_ecp_point_write_binary(&ecdh->grp, &ecdh->Qp,
+                                                 MBEDTLS_ECP_PF_UNCOMPRESSED,
+                                                 &pub_len,
+                                                 pub_buf, sizeof(pub_buf));
+            if (ret != 0) {
+                MBEDTLS_SSL_DEBUG_RET(1, ("mbedtls_ecp_point_write_binary"), ret);
+                return MBEDTLS_ERR_SSL_INTERNAL_ERROR;
+            }
+        }
+        MBEDTLS_SSL_DEBUG_BUF(3, "server ephemeral public key",
+                              pub_buf, pub_len);
+    }
+#endif
 
     return ret;
 }

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -1525,6 +1525,10 @@ int mbedtls_ssl_tls13_read_public_xxdhe_share(mbedtls_ssl_context *ssl,
                                   sizeof(handshake->xxdh_psa_peerkey)));
         return MBEDTLS_ERR_SSL_HANDSHAKE_FAILURE;
     }
+    MBEDTLS_SSL_DEBUG_BUF(3, (mbedtls_ssl_conf_get_endpoint(ssl->conf) == MBEDTLS_SSL_IS_CLIENT ?
+                              "server ephemeral public key" :
+                              "client ephemeral public key"),
+                          p, peerkey_len);
     memcpy(handshake->xxdh_psa_peerkey, p, peerkey_len);
     handshake->xxdh_psa_peerkey_len = peerkey_len;
 

--- a/tests/opt-testcases/sample.sh
+++ b/tests/opt-testcases/sample.sh
@@ -187,7 +187,7 @@ run_test    "Sample: ssl_server, gnutls client, TLS 1.3" \
 
 run_test    "Sample: ssl_fork_server, ssl_client2" \
             -P 4433 \
-            "$PROGRAMS_DIR/ssl_fork_server" \
+            "server_with_own_seedfile $PROGRAMS_DIR/ssl_fork_server" \
             "$PROGRAMS_DIR/ssl_client2" \
             0 \
             -s "[1-9][0-9]* bytes read" \
@@ -199,7 +199,7 @@ run_test    "Sample: ssl_fork_server, ssl_client2" \
 
 run_test    "Sample: ssl_client1 with ssl_fork_server" \
             -P 4433 \
-            "$PROGRAMS_DIR/ssl_fork_server" \
+            "server_with_own_seedfile $PROGRAMS_DIR/ssl_fork_server" \
             "$PROGRAMS_DIR/ssl_client1" \
             0 \
             -s "[1-9][0-9]* bytes read" \

--- a/tests/opt-testcases/sample.sh
+++ b/tests/opt-testcases/sample.sh
@@ -202,7 +202,7 @@ two_clients () (
     "$PROGRAMS_DIR/ssl_client2" "$@"
 )
 
-run_test    "Sample: ssl_fork_server, 2 successive clients, TLS 1.2" \
+run_test    "Sample: ssl_fork_server, 2 successive clients, TLS 1.2: unique random" \
             -P 4433 \
             "server_with_own_seedfile $PROGRAMS_DIR/ssl_fork_server" \
             "two_clients force_version=tls12 debug_level=3" \
@@ -211,7 +211,7 @@ run_test    "Sample: ssl_fork_server, 2 successive clients, TLS 1.2" \
             -C "error" \
             -v 'distinct_server_random'
 
-run_test    "Sample: ssl_fork_server, 2 successive clients, TLS 1.3" \
+run_test    "Sample: ssl_fork_server, 2 successive clients, TLS 1.3: unique random" \
             -P 4433 \
             "server_with_own_seedfile $PROGRAMS_DIR/ssl_fork_server" \
             "two_clients force_version=tls13 debug_level=3" \
@@ -219,6 +219,36 @@ run_test    "Sample: ssl_fork_server, 2 successive clients, TLS 1.3" \
             -S "error" \
             -C "error" \
             -v 'distinct_server_random'
+
+# Pick ECDHE-RSA, not ECDHE-ECDSA, because ssl_fork_server only loads one key,
+# and it uses an RSA key if both RSA and ECDSA are available.
+run_test    "Sample: ssl_fork_server, 2 successive clients, TLS 1.2: unique ephemeral ECDHE" \
+            -P 4433 \
+            "server_with_own_seedfile $PROGRAMS_DIR/ssl_fork_server" \
+            "two_clients force_version=tls12 force_ciphersuite=TLS-ECDHE-RSA-WITH-AES-128-GCM-SHA256 debug_level=3" \
+            0 \
+            -S "error" \
+            -C "error" \
+            -v 'distinct_server_ephemeral'
+
+run_test    "Sample: ssl_fork_server, 2 successive clients, TLS 1.2: unique ephemeral DHE" \
+            -P 4433 \
+            "server_with_own_seedfile $PROGRAMS_DIR/ssl_fork_server" \
+            "two_clients force_version=tls12 force_ciphersuite=TLS-DHE-RSA-WITH-AES-128-CBC-SHA debug_level=3" \
+            0 \
+            -S "error" \
+            -C "error" \
+            -v 'distinct_server_ephemeral'
+
+requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
+run_test    "Sample: ssl_fork_server, 2 successive clients, TLS 1.3: unique ephemeral" \
+            -P 4433 \
+            "server_with_own_seedfile $PROGRAMS_DIR/ssl_fork_server" \
+            "two_clients force_version=tls13 tls13_kex_modes=ephemeral debug_level=3" \
+            0 \
+            -S "error" \
+            -C "error" \
+            -v 'distinct_server_ephemeral'
 
 run_test    "Sample: ssl_client1 with ssl_fork_server" \
             -P 4433 \

--- a/tests/opt-testcases/sample.sh
+++ b/tests/opt-testcases/sample.sh
@@ -197,6 +197,29 @@ run_test    "Sample: ssl_fork_server, ssl_client2" \
             -S "error" \
             -C "error"
 
+two_clients () (
+    "$PROGRAMS_DIR/ssl_client2" "$@" &&
+    "$PROGRAMS_DIR/ssl_client2" "$@"
+)
+
+run_test    "Sample: ssl_fork_server, 2 successive clients, TLS 1.2" \
+            -P 4433 \
+            "server_with_own_seedfile $PROGRAMS_DIR/ssl_fork_server" \
+            "two_clients force_version=tls12 debug_level=3" \
+            0 \
+            -S "error" \
+            -C "error" \
+            -v 'distinct_server_random'
+
+run_test    "Sample: ssl_fork_server, 2 successive clients, TLS 1.3" \
+            -P 4433 \
+            "server_with_own_seedfile $PROGRAMS_DIR/ssl_fork_server" \
+            "two_clients force_version=tls13 debug_level=3" \
+            0 \
+            -S "error" \
+            -C "error" \
+            -v 'distinct_server_random'
+
 run_test    "Sample: ssl_client1 with ssl_fork_server" \
             -P 4433 \
             "server_with_own_seedfile $PROGRAMS_DIR/ssl_fork_server" \

--- a/tests/opt-testcases/sample.sh
+++ b/tests/opt-testcases/sample.sh
@@ -220,6 +220,33 @@ run_test    "Sample: ssl_fork_server, 2 successive clients, TLS 1.3: unique rand
             -C "error" \
             -v 'distinct_server_random'
 
+two_clients_same_seed () (
+    cp seedfile seedfile1 &&
+    "$PROGRAMS_DIR/ssl_client2" "$@" &&
+    mv seedfile1 seedfile &&
+    "$PROGRAMS_DIR/ssl_client2" "$@"
+)
+
+requires_config_enabled MBEDTLS_NO_PLATFORM_ENTROPY
+requires_config_disabled MBEDTLS_ENTROPY_HARDWARE_ALT
+run_test    "Sample: ssl_fork_server, 2 successive clients with same seed, TLS 1.2: unique random" \
+            -P 4433 \
+            "server_with_own_seedfile $PROGRAMS_DIR/ssl_fork_server" \
+            "two_clients_same_seed force_version=tls12 debug_level=3" \
+            0 \
+            -S "error" \
+            -C "error" \
+            -v 'distinct_server_random'
+
+run_test    "Sample: ssl_fork_server, 2 successive clients with same seed, TLS 1.3: unique random" \
+            -P 4433 \
+            "server_with_own_seedfile $PROGRAMS_DIR/ssl_fork_server" \
+            "two_clients_same_seed force_version=tls13 debug_level=3" \
+            0 \
+            -S "error" \
+            -C "error" \
+            -v 'distinct_server_random'
+
 # Pick ECDHE-RSA, not ECDHE-ECDSA, because ssl_fork_server only loads one key,
 # and it uses an RSA key if both RSA and ECDSA are available.
 run_test    "Sample: ssl_fork_server, 2 successive clients, TLS 1.2: unique ephemeral ECDHE" \

--- a/tests/opt-testcases/sample.sh
+++ b/tests/opt-testcases/sample.sh
@@ -238,6 +238,8 @@ run_test    "Sample: ssl_fork_server, 2 successive clients with same seed, TLS 1
             -C "error" \
             -v 'distinct_server_random'
 
+requires_config_enabled MBEDTLS_NO_PLATFORM_ENTROPY
+requires_config_disabled MBEDTLS_ENTROPY_HARDWARE_ALT
 run_test    "Sample: ssl_fork_server, 2 successive clients with same seed, TLS 1.3: unique random" \
             -P 4433 \
             "server_with_own_seedfile $PROGRAMS_DIR/ssl_fork_server" \

--- a/tests/scripts/components-configuration-crypto.sh
+++ b/tests/scripts/components-configuration-crypto.sh
@@ -464,14 +464,11 @@ component_test_psa_external_rng_use_psa_crypto () {
     tests/ssl-opt.sh -f 'Default\|opaque'
 }
 
-component_test_entropy_nv_seed_only () {
-    msg "build: full minus platform entropy (NV seed only)"
+component_test_entropy_nv_seed_only_psa () {
+    msg "build: NV seed only, full (with USE_PSA_CRYPTO)"
     scripts/config.py full
     scripts/config.py set MBEDTLS_NO_PLATFORM_ENTROPY
     make CC=$ASAN_CC CFLAGS="$ASAN_CFLAGS" LDFLAGS="$ASAN_CFLAGS"
-
-    msg "build: full minus platform entropy (NV seed only)"
-    make test
 
     # Check that the library seems to refer to the seedfile, but not to
     # platform entropy sources.
@@ -479,6 +476,32 @@ component_test_entropy_nv_seed_only () {
     not grep getrandom library/entropy*.o
     not grep /dev/random library/entropy*.o
     not grep /dev/.random library/entropy*.o
+
+    msg "test: NV seed only, full (with USE_PSA_CRYPTO) - unit tests"
+    make test
+
+    msg "test: full minus platform entropy - ssl-opt on sample programs"
+    tests/ssl-opt.sh -f 'Default\|Sample'
+}
+
+component_test_entropy_nv_seed_only_legacy () {
+    msg "build: NV seed only (with legacy crypto)"
+    scripts/config.py set MBEDTLS_ENTROPY_NV_SEED
+    scripts/config.py set MBEDTLS_NO_PLATFORM_ENTROPY
+    make CC=$ASAN_CC CFLAGS="$ASAN_CFLAGS" LDFLAGS="$ASAN_CFLAGS"
+
+    # Check that the library seems to refer to the seedfile, but not to
+    # platform entropy sources.
+    grep seedfile library/platform.o
+    not grep getrandom library/entropy*.o
+    not grep /dev/random library/entropy*.o
+    not grep /dev/.random library/entropy*.o
+
+    msg "test: NV seed only (with legacy crypto) - unit tests"
+    make test
+
+    msg "test: NV seed only (with legacy crypto) - ssl-opt on sample programs"
+    tests/ssl-opt.sh -f 'Default\|Sample'
 }
 
 component_test_psa_inject_entropy () {

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -1716,6 +1716,35 @@ do_run_test_once() {
     fi
 }
 
+# In builds with an NV seed, and especially with _only_ an NV seed,
+# the fact that the client and the server use the same seedfile may be
+# disruptive. In particular, it could cause a buggy server to pass just
+# because the client has rewritten the seed file between connections.
+#
+# So when we're specificially testing randomness, make the server use
+# its own seedfile. The seedfile name is hardcoded as "seedfile", but
+# we can change the current directory. This is easy for the sample
+# programs that don't use external files (it would be harder for those that
+# are called with arguments referencing files under data_files/).
+server_with_own_seedfile () {
+    set -eu
+    test -d "$subdirectory_for_server_seedfile" || mkdir "$subdirectory_for_server_seedfile"
+    test -s "$subdirectory_for_server_seedfile/seedfile" || cp seedfile "$subdirectory_for_server_seedfile"
+    cd "$subdirectory_for_server_seedfile"
+    # Assume that the path to the program is a relative path, and
+    # that the directory is a simple subdirectory.
+    server="../$1"
+    shift
+    # This process must become the server process, otherwise
+    # wait_server_start won't notice when the server starts listening.
+    exec "$server" "$@"
+}
+
+# Directory for running a server with its own seedfile (see above).
+# Define the variable here so that it's always available, in particular
+# in cleanup(). But only create and populate the directory on demand.
+subdirectory_for_server_seedfile="tmp-ssl-opt-wd-$$"
+
 # Detect if the current test is going to use TLS 1.3 or TLS 1.2.
 # $1 and $2 contain the server and client command lines, respectively.
 #
@@ -2041,6 +2070,10 @@ cleanup() {
     rm -f $CLI_OUT $SRV_OUT $PXY_OUT $SESSION
     rm -f context_srv.txt
     rm -f context_cli.txt
+    if [ -d "$subdirectory_for_server_seedfile" ]; then
+        rm -f "$subdirectory_for_server_seedfile/seedfile"
+        rmdir "$subdirectory_for_server_seedfile"
+    fi
     test -n "${SRV_PID:-}" && kill $SRV_PID >/dev/null 2>&1
     test -n "${PXY_PID:-}" && kill $PXY_PID >/dev/null 2>&1
     test -n "${CLI_PID:-}" && kill $CLI_PID >/dev/null 2>&1

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -1643,6 +1643,12 @@ check_test_failure() {
                     return
                 fi
                 ;;
+            "-v")
+                if ! ${PYTHON:-} ../framework/scripts/validate_ssl_logs.py "$CLI_OUT" "$SRV_OUT" $2; then
+                    fail "Validation failed on client and server output"
+                    return
+                fi
+                ;;
 
             *)
                 echo "Unknown test: $1" >&2

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -2084,7 +2084,6 @@ cleanup() {
     test -n "${PXY_PID:-}" && kill $PXY_PID >/dev/null 2>&1
     test -n "${CLI_PID:-}" && kill $CLI_PID >/dev/null 2>&1
     test -n "${DOG_PID:-}" && kill $DOG_PID >/dev/null 2>&1
-    exit 1
 }
 
 #
@@ -2270,7 +2269,9 @@ SESSION="session.$$"
 
 SKIP_NEXT="NO"
 
-trap cleanup INT TERM HUP
+trap 'cleanup; trap - HUP; kill -HUP $$' HUP
+trap 'cleanup; trap - HUP; kill -INT $$' INT
+trap 'cleanup; trap - HUP; kill -TERM $$' TERM
 
 # Basic test
 
@@ -15616,9 +15617,10 @@ fi
 
 cleanup
 
-if [ $FAILS -gt 255 ]; then
-    # Clamp at 255 as caller gets exit code & 0xFF
-    # (so 256 would be 0, or success, etc)
-    FAILS=255
+if [ $FAILS -gt 125 ]; then
+    # Clamp at 125 as caller gets exit code & 0xFF
+    # (so 256 would be 0, or success, etc), and 126 and above have
+    # conventional meanings (fork/exec failure, signal).
+    FAILS=125
 fi
 exit $FAILS

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -2270,8 +2270,8 @@ SESSION="session.$$"
 SKIP_NEXT="NO"
 
 trap 'cleanup; trap - HUP; kill -HUP $$' HUP
-trap 'cleanup; trap - HUP; kill -INT $$' INT
-trap 'cleanup; trap - HUP; kill -TERM $$' TERM
+trap 'cleanup; trap - INT; kill -INT $$' INT
+trap 'cleanup; trap - TERM; kill -TERM $$' TERM
 
 # Basic test
 

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -15614,6 +15614,8 @@ EOF
     fi
 fi
 
+cleanup
+
 if [ $FAILS -gt 255 ]; then
     # Clamp at 255 as caller gets exit code & 0xFF
     # (so 256 would be 0, or success, etc)

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -1733,6 +1733,9 @@ do_run_test_once() {
 # programs that don't use external files (it would be harder for those that
 # are called with arguments referencing files under data_files/).
 server_with_own_seedfile () {
+    if ! [ -e seedfile ]; then
+        exec "$@"
+    fi
     set -eu
     test -d "$subdirectory_for_server_seedfile" || mkdir "$subdirectory_for_server_seedfile"
     test -s "$subdirectory_for_server_seedfile/seedfile" || cp seedfile "$subdirectory_for_server_seedfile"


### PR DESCRIPTION
Test that `ssl_fork_server` has a different RNG state in each client. Fixes https://github.com/Mbed-TLS/mbedtls/issues/10664.

Needs preceding PR: https://github.com/Mbed-TLS/mbedtls-framework/pull/296

## PR checklist

- [x] **changelog** not required because: test only
- [x] **development PR** https://github.com/Mbed-TLS/mbedtls/pull/10861
- [x] **4.1 PR** https://github.com/Mbed-TLS/mbedtls/pull/10858
- [x] **TF-PSA-Crypto PR** not required because: TLS only
- [x] **framework PR** provided https://github.com/Mbed-TLS/mbedtls-framework/pull/296
- [x] **3.6 PR** https://github.com/Mbed-TLS/mbedtls/pull/10666
- **tests**  provided
