### PR TITLE
Fix -Wundef warnings for MBEDTLS_GCC_VERSION in alignment.h

### DIFF
--- a/library/alignment.h
+++ b/library/alignment.h
@@ -281,10 +281,10 @@ static inline void mbedtls_put_unaligned_uint64(void *p, uint64_t x)
  * Detect GCC built-in byteswap routines
  */
 #if defined(__GNUC__)
-#if MBEDTLS_GCC_VERSION >= 40800
+#if defined(MBEDTLS_COMPILER_IS_GCC) && MBEDTLS_GCC_VERSION >= 40800
 #define MBEDTLS_BSWAP16 __builtin_bswap16
 #endif
-#if MBEDTLS_GCC_VERSION >= 40300
+#if defined(MBEDTLS_COMPILER_IS_GCC) && MBEDTLS_GCC_VERSION >= 40300
 #define MBEDTLS_BSWAP32 __builtin_bswap32
 #define MBEDTLS_BSWAP64 __builtin_bswap64
 #endif


### PR DESCRIPTION
## Description

`MBEDTLS_GCC_VERSION` is only defined for GCC in `build_info.h` (excluded for clang via `!defined(__clang__)`). Lines 284 and 287 of `alignment.h` used it in bare `#if` directives without a `defined()` guard. When compiling with clang and `-Wundef`, the undefined macro triggers warnings through the include chain `common.h` → `build_info.h` → `alignment.h`.

Add `defined(MBEDTLS_COMPILER_IS_GCC)` guard to both lines.

### Reproduce

```
clang -fsyntax-only -Wundef -Werror \
    -I include -I library \
    library/common.h
```

### Testing

Build and SSL test suites pass.

A corresponding fix for the development branch has been submitted as Mbed-TLS/TF-PSA-Crypto#([add PR number](https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/782)).

## PR checklist

- [ ] **changelog** not required because: trivial warning fix, no behavior change
- [ ] **framework PR** not required
- [ ] **TF-PSA-Crypto development PR** provided Mbed-TLS/TF-PSA-Crypto#(add PR number)
- [ ] **TF-PSA-Crypto 1.1 PR** not required because: can backport after merge
- [ ] **mbedtls development PR** not required because: file is in tf-psa-crypto submodule on development
- [ ] **mbedtls 4.1 PR** not required because: file is in tf-psa-crypto submodule
- [x] **mbedtls 3.6 PR** provided (this PR)
- **tests** not required because: compile-time warning fix only, no runtime behavior change