### PR TITLE
Fix -Wundef warnings for PSA macros in pk_internal.h

### DIFF
--- a/ChangeLog.d/pk_internal_wundef.txt
+++ b/ChangeLog.d/pk_internal_wundef.txt
@@ -1,0 +1,4 @@
+Bugfix
+   * library/pk_internal.h: Fix 'MBEDTLS_PSA_MAX_EC_PUBKEY_LENGTH' and
+     'MBEDTLS_PSA_MAX_EC_KEY_PAIR_LENGTH' are not defined errors when
+     building in a configuration that does not enable PSA.

--- a/library/pk_internal.h
+++ b/library/pk_internal.h
@@ -61,13 +61,17 @@
 #endif
 
 #if defined(PK_EXPORT_KEYS_ON_THE_STACK)
-/* We know for ECC, pubkey are longer than privkeys, but double check.
- * Also, take the maximum size of legacy and PSA, as PSA might be disabled. */
+/* Take the maximum size of legacy ECP and PSA EC sizes.
+ * PSA might be disabled, so guard the PSA-specific macros. */
+#if defined(MBEDTLS_PSA_CRYPTO_CLIENT)
 #define PK_EXPORT_KEY_STACK_BUFFER_SIZE  MBEDTLS_PSA_MAX_EC_PUBKEY_LENGTH
 #if PK_EXPORT_KEY_STACK_BUFFER_SIZE < MBEDTLS_PSA_MAX_EC_KEY_PAIR_LENGTH
 #undef PK_EXPORT_KEY_STACK_BUFFER_SIZE
 #define PK_EXPORT_KEY_STACK_BUFFER_SIZE  MBEDTLS_PSA_MAX_EC_KEY_PAIR_LENGTH
 #endif
+#else
+#define PK_EXPORT_KEY_STACK_BUFFER_SIZE  0
+#endif /* MBEDTLS_PSA_CRYPTO_CLIENT */
 #if PK_EXPORT_KEY_STACK_BUFFER_SIZE < MBEDTLS_ECP_MAX_BYTES
 #undef PK_EXPORT_KEY_STACK_BUFFER_SIZE
 #define PK_EXPORT_KEY_STACK_BUFFER_SIZE  MBEDTLS_ECP_MAX_BYTES


### PR DESCRIPTION
## Description

`MBEDTLS_PSA_MAX_EC_PUBKEY_LENGTH` and `MBEDTLS_PSA_MAX_EC_KEY_PAIR_LENGTH` are only defined when `MBEDTLS_PSA_CRYPTO_CLIENT` is enabled (via `psa_util_internal.h`). However, the `PK_EXPORT_KEYS_ON_THE_STACK` block in `pk_internal.h` used them unconditionally, triggering `-Wundef` warnings when compiling with a config that does not enable PSA.

Guard the PSA-specific size macros with `#if defined(MBEDTLS_PSA_CRYPTO_CLIENT)`, falling back to 0 when PSA is disabled. The subsequent `MBEDTLS_ECP_MAX_BYTES` and `MBEDTLS_ECP_MAX_PT_LEN` comparisons then set the proper buffer size.

This issue does not affect the development branch, where `psa_util_internal.h` is included unconditionally.

### Reproduce

Create a minimal config without PSA (e.g., AES + SHA256 only):


```
cat  /tmp/minimal_config.h

#define MBEDTLS_AES_C
#define MBEDTLS_SHA256_C
#define MBEDTLS_CIPHER_C
```

```
gcc -fsyntax-only -Wundef -Werror \
    -DMBEDTLS_CONFIG_FILE='"/tmp/minimal_config.h"' \
    -I include -I library \
    library/pk_ecc.c
```

### Testing

Build and SSL test suites pass with default config.

## PR checklist

- [ ] **changelog** not required because: trivial warning fix, no behavior change
- [ ] **framework PR** not required
- [ ] **TF-PSA-Crypto development PR** not required because: not affected (psa_util_internal.h included unconditionally)
- [ ] **TF-PSA-Crypto 1.1 PR** not required because: not affected
- [ ] **mbedtls development PR** not required because: not affected
- [ ] **mbedtls 4.1 PR** not required because: not affected
- [x] **mbedtls 3.6 PR** provided (this PR)
- **tests** not required because: compile-time warning fix only, no runtime behavior change