### PR TITLE
ssl: size _pms_ecdh against PSA_RAW_KEY_AGREEMENT_OUTPUT_MAX_SIZE

### DIFF
--- a/ChangeLog.d/fix-pms-ecdh-psa-client-size.txt
+++ b/ChangeLog.d/fix-pms-ecdh-psa-client-size.txt
@@ -1,0 +1,8 @@
+Bugfix
+   * Fix TLS 1.2 ECDHE handshakes failing in PSA-client-only
+     builds (MBEDTLS_PSA_CRYPTO_C disabled) where
+     MBEDTLS_ECP_MAX_BYTES collapses to 1 and the
+     premaster-secret union sized below
+     PSA_RAW_KEY_AGREEMENT_OUTPUT_MAX_SIZE caused
+     psa_raw_key_agreement() to return PSA_ERROR_BUFFER_TOO_SMALL.
+     Fixes #10757.

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -648,18 +648,32 @@
 #endif
 #endif /* !MBEDTLS_PSK_MAX_LEN */
 
+/**
+ * In PSA-client-only builds (MBEDTLS_PSA_CRYPTO_C off, e.g. NS-side
+ * mbedtls dispatching to a secure PSA service like TF-M) the local
+ * ECP_LIGHT cascade does not run and MBEDTLS_ECP_MAX_BYTES collapses
+ * to 1. Take the larger of that and PSA_RAW_KEY_AGREEMENT_OUTPUT_MAX_SIZE,
+ * which is sized by the enabled PSA_WANT_ECC_* curves and is always
+ * defined, so psa_raw_key_agreement() has a real output buffer to
+ * write the ECDH shared secret into.
+ */
+#define MBEDTLS_SSL_PMS_ECDH_SIZE                                       \
+    (PSA_RAW_KEY_AGREEMENT_OUTPUT_MAX_SIZE > MBEDTLS_ECP_MAX_BYTES      \
+         ? PSA_RAW_KEY_AGREEMENT_OUTPUT_MAX_SIZE                        \
+         : MBEDTLS_ECP_MAX_BYTES)
+
 /* Dummy type used only for its size */
 union mbedtls_ssl_premaster_secret {
     unsigned char dummy; /* Make the union non-empty even with SSL disabled */
 #if defined(MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED)    || \
     defined(MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED)
-    unsigned char _pms_ecdh[MBEDTLS_ECP_MAX_BYTES];    /* RFC 4492 5.10 */
+    unsigned char _pms_ecdh[MBEDTLS_SSL_PMS_ECDH_SIZE];    /* RFC 4492 5.10 */
 #endif
 #if defined(MBEDTLS_KEY_EXCHANGE_PSK_ENABLED)
     unsigned char _pms_psk[4 + 2 * MBEDTLS_PSK_MAX_LEN];       /* RFC 4279 2 */
 #endif
 #if defined(MBEDTLS_KEY_EXCHANGE_ECDHE_PSK_ENABLED)
-    unsigned char _pms_ecdhe_psk[4 + MBEDTLS_ECP_MAX_BYTES
+    unsigned char _pms_ecdhe_psk[4 + MBEDTLS_SSL_PMS_ECDH_SIZE
                                  + MBEDTLS_PSK_MAX_LEN];       /* RFC 5489 2 */
 #endif
 #if defined(MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED)


### PR DESCRIPTION
In PSA-client-only builds (MBEDTLS_PSA_CRYPTO_C disabled, e.g. NS-side mbedtls dispatching to a secure PSA service like TF-M), the local ECP_LIGHT cascade does not run and MBEDTLS_ECP_MAX_BYTES collapses to 1. The `_pms_ecdh` and `_pms_ecdhe_psk` members of `union mbedtls_ssl_premaster_secret` then declare 1-byte arrays. In builds where only ECDHE-RSA / ECDHE-ECDSA is enabled (no PSK, no ECJPAKE), the whole union ends up that small, and psa_raw_key_agreement() returns PSA_ERROR_BUFFER_TOO_SMALL during the TLS 1.2 ECDHE handshake. The handshake aborts as MBEDTLS_ERR_SSL_HW_ACCEL_FAILED with no path to success in this configuration.

Introduce MBEDTLS_SSL_PMS_ECDH_SIZE as max(PSA_RAW_KEY_AGREEMENT_OUTPUT_MAX_SIZE, MBEDTLS_ECP_MAX_BYTES) so both legacy ECP and PSA-client builds get a sufficient buffer. PSA_RAW_KEY_AGREEMENT_OUTPUT_MAX_SIZE is always defined, sized by the enabled PSA_WANT_ECC_* curves.

Fixes #10757.

## Description

Fixes TLS 1.2 ECDHE handshakes silently failing on PSA-client-only Mbed TLS builds (NS-side dispatching to a secure PSA provider such as TF-M). In that configuration `MBEDTLS_ECP_MAX_BYTES` collapses to 1, sizing the premaster-secret union below `PSA_RAW_KEY_AGREEMENT_OUTPUT_MAX_SIZE`, so `psa_raw_key_agreement()` returns `PSA_ERROR_BUFFER_TOO_SMALL` during the key-exchange step. The fix introduces `MBEDTLS_SSL_PMS_ECDH_SIZE` taking the max of the legacy and PSA sizing macros, so both legacy ECP and PSA-client builds get a sufficient buffer with no behaviour change on configurations that already worked.

Tests deliberately omitted because the failing configuration (`MBEDTLS_PSA_CRYPTO_C` disabled, ECDHE-only key exchange) is not currently exercised in CI, so a meaningful runtime regression test would require new CI matrix coverage. The change is structurally inspectable: it widens a compile-time buffer to the documented PSA constant that already bounds psa_raw_key_agreement()` output. Happy to add a `MBEDTLS_STATIC_ASSERT` in `include/mbedtls/ssl.h` along the lines of `MBEDTLS_STATIC_ASSERT(MBEDTLS_SSL_PMS_ECDH_SIZE >= PSA_RAW_KEY_AGREEMENT_OUTPUT_MAX_SIZE, ...)` if reviewers prefer a compile-time guard.

## PR checklist

- [x] **changelog** provided: `ChangeLog.d/fix-pms-ecdh-psa-client-size.txt`
- [x] **framework PR** not required
- [x] **TF-PSA-Crypto development PR** not required because: the fix is contained in `include/mbedtls/ssl.h` and does not touch TF-PSA-Crypto.
- [x] **TF-PSA-Crypto 1.1 PR** not required because: same as above.
- [x] **mbedtls development PR** provided
- [ ] **mbedtls 4.1 PR** not required because: backport will be evaluated as a follow-up after this lands on development. The fix introduces a new macro `MBEDTLS_SSL_PMS_ECDH_SIZE` in a public header, so the LTS backport may need to inline the expression instead.
- [ ] **mbedtls 3.6 PR** not required because: same as above.
- [ ] **tests** not required because: configuration not in current CI matrix (see Description); offering a static assertion if preferred.