### PR TITLE
Fix memory errors in sample programs

### DIFF
--- a/programs/ssl/ssl_context_info.c
+++ b/programs/ssl/ssl_context_info.c
@@ -882,8 +882,8 @@ static void print_deserialized_ssl_context(const uint8_t *ssl, size_t len)
         printf("\tALPN negotiation                   : ");
         CHECK_SSL_END(alpn_len);
         if (alpn_len > 0) {
-            if (strlen((const char *) ssl) == alpn_len) {
-                printf("%s\n", ssl);
+            if (memchr(ssl, '\0', alpn_len) == NULL) {
+                printf("%.*s\n", alpn_len, ssl);
             } else {
                 printf("\n");
                 printf_err("\tALPN negotiation is incorrect\n");

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -1385,6 +1385,10 @@ static int dummy_ticket_parse(void *p_ticket, mbedtls_ssl_session *session,
     int ret;
     ((void) p_ticket);
 
+    if (len < 4) {
+        return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
+    }
+
     if ((ret = mbedtls_ssl_session_load(session, buf + 4, len - 4)) != 0) {
         return ret;
     }


### PR DESCRIPTION
## Description

Fix two memory safety issues in sample programs as described in #10803.

### Changes

**1. `ssl_server2.c` — `dummy_ticket_parse()` underflow**

When `len < 4`, the expression `len - 4` underflows (`size_t` is unsigned), causing `mbedtls_ssl_session_load` to read past the ticket buffer. Added a length check at the start of the function returning `MBEDTLS_ERR_SSL_BAD_INPUT_DATA`.

**2. `ssl_context_info.c` — ALPN `strlen()` unbounded read**

`strlen((const char *) ssl)` could read past the `alpn_len` boundary since the decoded buffer may not be null-terminated. Replaced with `memchr(ssl, '\0', alpn_len)` which is bounded, and use `printf("%.*s", alpn_len, ssl)` for safe output.

Both issues were in sample programs, not the library itself, so no security implications — but should be fixed to prevent confusion in future investigations.

Fixes #10803

## PR checklist

- [x] **changelog** not required because: no user-visable change
- [x] **framework PR** not provided
- [x] **TF-PSA-Crypto development PR** not required because: mbedtls only
- [x] **TF-PSA-Crypto 1.1 PR** not required because: mbedtls only
- [x] **mbedtls development PR** provided HERE
- [ ] **mbedtls 4.1 PR** provided TODO
- [ ] **mbedtls 3.6 PR** provided: TODO
- **tests**  not provided: bug fix only
