### PR TITLE
[Backport 4.1] Check test dependencies against crypto internal macros

### DIFF
--- a/tests/scripts/analyze_outcomes.py
+++ b/tests/scripts/analyze_outcomes.py
@@ -48,9 +48,6 @@ class CoverageTask(outcome_analysis.CoverageTask):
             # We don't run ssl-opt.sh with Valgrind on the CI because
             # it's extremely slow. We don't intend to change this.
             'DTLS fragmenting: proxy MTU: auto-reduction (with valgrind)',
-            # TLS doesn't use restartable ECDH yet.
-            # https://github.com/Mbed-TLS/mbedtls/issues/7294
-            re.compile(r'EC restart:.*no USE_PSA.*'),
             # The following test fails intermittently on the CI with a frequency
             # that significantly impacts CI throughput. They are thus disabled
             # for the time being. See

--- a/tests/scripts/components-basic-checks.sh
+++ b/tests/scripts/components-basic-checks.sh
@@ -134,11 +134,6 @@ component_check_test_dependencies () {
 
     # Expected ones with justification - keep in sorted order!
     rm -f $expected
-    # Temporary, see https://github.com/Mbed-TLS/mbedtls/issues/10618
-    echo "MBEDTLS_PKCS1_V15" >> $expected
-    echo "MBEDTLS_PKCS1_V21" >> $expected
-    # Temporary, see https://github.com/Mbed-TLS/mbedtls/issues/10619
-    echo "MBEDTLS_RSA_C" >> $expected
     # Acceptable: these are light wrappers around official PSA_WANT macros,
     # to hide the fact that ECDSA could be randomized or deterministic.
     echo "PSA_HAVE_ALG_ECDSA_SIGN" >> $expected

--- a/tests/scripts/components-basic-checks.sh
+++ b/tests/scripts/components-basic-checks.sh
@@ -100,6 +100,66 @@ component_check_test_cases () {
     unset opt
 }
 
+component_check_test_dependencies () {
+    msg "Check: test cases dependencies: no crypto internals"
+    # The purpose of this component is to catch unjustified dependencies from
+    # mbedtls test on crypto internal feature macros.
+    #
+    # Most of the time, use of crypto internal feature macros are mistakes,
+    # which this component is maeant to catch. However a few of them are
+    # justified, or known issues yet to be resolved, so this component includes
+    # a list of expected exceptions.
+
+    crypto="check-test-deps-crypto-$$"
+    used="check-test-deps-used-$$"
+    found="check-test-deps-found-$$"
+    expected="check-test-deps-expected-$$"
+
+    (
+        cd tf-psa-crypto
+        PYTHONPATH=framework/scripts python \
+            -c 'from mbedtls_framework import config_macros; \
+                print("\n".join(config_macros.Current().internal()))'
+    ) | sort -u > $crypto
+
+    (
+        grep depends_on tests/suites/test_suite_* |
+            sed -e 's/.*depends_on:\([^ ]*\).*/\1/' -e's/!//g' |
+            tr ':' '\n'
+        egrep -oh '(PSA|MBEDTLS)_[A-Z0-9_]*' tests/ssl-opt.sh tests/opt-testcases/*.sh
+    ) | sort -u > $used
+
+    # Find macros that are both used in mbedtls tests and crypto-internal.
+    comm -12 $crypto $used > $found
+
+    # Expected ones with justification - keep in sorted order!
+    rm -f $expected
+    # Temporary, see https://github.com/Mbed-TLS/mbedtls/issues/10618
+    echo "MBEDTLS_PKCS1_V15" >> $expected
+    echo "MBEDTLS_PKCS1_V21" >> $expected
+    # Temporary, see https://github.com/Mbed-TLS/mbedtls/issues/10619
+    echo "MBEDTLS_RSA_C" >> $expected
+    # Acceptable: these are light wrappers around official PSA_WANT macros,
+    # to hide the fact that ECDSA could be randomized or deterministic.
+    echo "PSA_HAVE_ALG_ECDSA_SIGN" >> $expected
+    echo "PSA_HAVE_ALG_ECDSA_VERIFY" >> $expected
+    echo "PSA_HAVE_ALG_SOME_ECDSA" >> $expected
+    echo "PSA_WANT_ALG_ECDSA_ANY" >> $expected
+
+    # Compare reality with expectation.
+    # We want an exact match, to ensure the above list remains up-to-date.
+    #
+    # The output should be empty. When it's not:
+    # - Each '+' line is a macro that was found but not expected. You want to
+    # find where that macro occurs, and either replace it with PSA macros, or
+    # add it to the exceptions list above with a justification.
+    # - Each '-' line is a macro that was expected but not found; it means the
+    # exceptions list above should be updated by removing that macro.
+    diff -U0 $expected $found
+
+    rm $found $expected $crypto $used
+}
+
 component_check_doxygen_warnings () {
     msg "Check: doxygen warnings (builds the documentation)" # ~ 3s
     ./framework/scripts/doxygen.sh

--- a/tests/scripts/components-basic-checks.sh
+++ b/tests/scripts/components-basic-checks.sh
@@ -123,7 +123,9 @@ component_check_test_dependencies () {
     ) | sort -u > $crypto
 
     (
-        grep depends_on tests/suites/test_suite_* |
+          grep depends_on \
+            tests/suites/test_suite_*.data \
+            tests/suites/test_suite_*.function |
             sed -e 's/.*depends_on:\([^ ]*\).*/\1/' -e's/!//g' |
             tr ':' '\n'
         egrep -oh '(PSA|MBEDTLS)_[A-Z0-9_]*' tests/ssl-opt.sh tests/opt-testcases/*.sh

--- a/tests/scripts/components-basic-checks.sh
+++ b/tests/scripts/components-basic-checks.sh
@@ -135,10 +135,14 @@ component_check_test_dependencies () {
     # Expected ones with justification - keep in sorted order!
     rm -f $expected
     # Acceptable: these are light wrappers around official PSA_WANT macros,
-    # to hide the fact that ECDSA could be randomized or deterministic.
+    # to hide the fact that ECDSA and RSA could be randomized or deterministic.
     echo "PSA_HAVE_ALG_ECDSA_SIGN" >> $expected
     echo "PSA_HAVE_ALG_ECDSA_VERIFY" >> $expected
     echo "PSA_HAVE_ALG_SOME_ECDSA" >> $expected
+    echo "PSA_HAVE_ALG_RSA_PKCS1V15_SIGN" >> $expected
+    echo "PSA_HAVE_ALG_RSA_PKCS1V15_VERIFY" >> $expected
+    echo "PSA_HAVE_ALG_SOME_RSA_SIGN" >> $expected
+    echo "PSA_HAVE_ALG_SOME_RSA_VERIFY" >> $expected
     echo "PSA_WANT_ALG_ECDSA_ANY" >> $expected
 
     # Compare reality with expectation.

--- a/tests/scripts/components-basic-checks.sh
+++ b/tests/scripts/components-basic-checks.sh
@@ -106,7 +106,7 @@ component_check_test_dependencies () {
     # mbedtls test on crypto internal feature macros.
     #
     # Most of the time, use of crypto internal feature macros are mistakes,
-    # which this component is maeant to catch. However a few of them are
+    # which this component is meant to catch. However a few of them are
     # justified, or known issues yet to be resolved, so this component includes
     # a list of expected exceptions.
 

--- a/tests/scripts/components-basic-checks.sh
+++ b/tests/scripts/components-basic-checks.sh
@@ -138,9 +138,9 @@ component_check_test_dependencies () {
     # to hide the fact that ECDSA and RSA could be randomized or deterministic.
     echo "PSA_HAVE_ALG_ECDSA_SIGN" >> $expected
     echo "PSA_HAVE_ALG_ECDSA_VERIFY" >> $expected
-    echo "PSA_HAVE_ALG_SOME_ECDSA" >> $expected
     echo "PSA_HAVE_ALG_RSA_PKCS1V15_SIGN" >> $expected
     echo "PSA_HAVE_ALG_RSA_PKCS1V15_VERIFY" >> $expected
+    echo "PSA_HAVE_ALG_SOME_ECDSA" >> $expected
     echo "PSA_HAVE_ALG_SOME_RSA_SIGN" >> $expected
     echo "PSA_HAVE_ALG_SOME_RSA_VERIFY" >> $expected
     echo "PSA_WANT_ALG_ECDSA_ANY" >> $expected

--- a/tests/scripts/components-basic-checks.sh
+++ b/tests/scripts/components-basic-checks.sh
@@ -110,10 +110,12 @@ component_check_test_dependencies () {
     # justified, or known issues yet to be resolved, so this component includes
     # a list of expected exceptions.
 
-    crypto="check-test-deps-crypto-$$"
-    used="check-test-deps-used-$$"
-    found="check-test-deps-found-$$"
-    expected="check-test-deps-expected-$$"
+    out_of_source_dir="$OUT_OF_SOURCE_DIR/check-test-deps-$$"
+    mkdir -p "$out_of_source_dir"
+    crypto="$out_of_source_dir/crypto"
+    used="$out_of_source_dir/used"
+    found="$out_of_source_dir/found"
+    expected="$out_of_source_dir/expected"
 
     (
         cd tf-psa-crypto
@@ -123,7 +125,7 @@ component_check_test_dependencies () {
     ) | sort -u > $crypto
 
     (
-          grep depends_on \
+        grep depends_on \
             tests/suites/test_suite_*.data \
             tests/suites/test_suite_*.function |
             sed -e 's/.*depends_on:\([^ ]*\).*/\1/' -e's/!//g' |
@@ -156,9 +158,9 @@ component_check_test_dependencies () {
     # add it to the exceptions list above with a justification.
     # - Each '-' line is a macro that was expected but not found; it means the
     # exceptions list above should be updated by removing that macro.
-    diff -U0 $expected $found
+    diff -U0 "$expected" "$found"
 
-    rm $found $expected $crypto $used
+    rm -rf "$out_of_source_dir"
 }
 
 component_check_doxygen_warnings () {

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -9338,7 +9338,7 @@ run_test    "EC restart: TLS, max_ops=1000" \
             -C "mbedtls_ecdh_make_public.*\(4b00\|-248\)" \
             -c "mbedtls_pk_sign.*\(4b00\|-248\)"
 
-# Note: wen never get to ECDH: abort as soon as we determined the cert is bad.
+# Note: we never get to ECDH: abort as soon as we determined the cert is bad.
 requires_config_enabled MBEDTLS_ECP_RESTARTABLE
 requires_config_enabled PSA_WANT_ECC_SECP_R1_256
 run_test    "EC restart: TLS, max_ops=1000, badsign" \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -9316,39 +9316,18 @@ run_test    "EC restart: TLS, max_ops=65535" \
             -C "mbedtls_ecdh_make_public.*\(4b00\|-248\)" \
             -C "mbedtls_pk_sign.*\(4b00\|-248\)"
 
-# The following test cases for restartable ECDH come in two variants:
-# * The "(USE_PSA)" variant expects the current behavior, which is the behavior
-#   from Mbed TLS 3.x when MBEDTLS_USE_PSA_CRYPTO is enabled. This tests
-#   the partial implementation where ECDH in TLS is not actually restartable.
-# * The "(no USE_PSA)" variant expects the desired behavior. These test
-#   cases cannot currently pass because the implementation of restartable ECC
-#   in TLS is partial: ECDH is not actually restartable. This is the behavior
-#   from Mbed TLS 3.x when MBEDTLS_USE_PSA_CRYPTO is disabled.
+# The following test cases for restartable ECC are currently partial: we expect
+# signature generation and verification to be restartable, but no ECDH.
 #
-# As part of resolving https://github.com/Mbed-TLS/mbedtls/issues/7294,
-# we will remove the "(USE_PSA)" test cases and run the "(no USE_PSA)" test
-# cases.
+# This is because TLS hasn't been updated yet to use the new interruptible ECDH
+# interface from PSA: https://github.com/Mbed-TLS/mbedtls/issues/7294.
+# Once this has been done, the lines -C "mbedtls_ecdh_make_public.*\(4b00\|-248\)"
+# below can be updated to positive assertions about interruptible key
+# generation, public export and key agreement.
 
-# With USE_PSA disabled we expect full restartable behaviour.
 requires_config_enabled MBEDTLS_ECP_RESTARTABLE
 requires_config_enabled PSA_WANT_ECC_SECP_R1_256
-skip_next_test
-run_test    "EC restart: TLS, max_ops=1000 (no USE_PSA)" \
-            "$P_SRV groups=secp256r1 auth_mode=required" \
-            "$P_CLI force_ciphersuite=TLS-ECDHE-ECDSA-WITH-AES-128-GCM-SHA256 \
-             key_file=$DATA_FILES_PATH/server5.key crt_file=$DATA_FILES_PATH/server5.crt  \
-             debug_level=1 ec_max_ops=1000" \
-            0 \
-            -c "x509_verify_cert.*\(4b00\|-248\)" \
-            -c "mbedtls_pk_verify.*\(4b00\|-248\)" \
-            -c "mbedtls_ecdh_make_public.*\(4b00\|-248\)" \
-            -c "mbedtls_pk_sign.*\(4b00\|-248\)"
-
-# With USE_PSA enabled we expect only partial restartable behaviour:
-# everything except ECDH (where TLS calls PSA directly).
-requires_config_enabled MBEDTLS_ECP_RESTARTABLE
-requires_config_enabled PSA_WANT_ECC_SECP_R1_256
-run_test    "EC restart: TLS, max_ops=1000 (USE_PSA)" \
+run_test    "EC restart: TLS, max_ops=1000" \
             "$P_SRV groups=secp256r1 auth_mode=required" \
             "$P_CLI force_ciphersuite=TLS-ECDHE-ECDSA-WITH-AES-128-GCM-SHA256 \
              key_file=$DATA_FILES_PATH/server5.key crt_file=$DATA_FILES_PATH/server5.crt  \
@@ -9359,8 +9338,7 @@ run_test    "EC restart: TLS, max_ops=1000 (USE_PSA)" \
             -C "mbedtls_ecdh_make_public.*\(4b00\|-248\)" \
             -c "mbedtls_pk_sign.*\(4b00\|-248\)"
 
-# This works the same with & without USE_PSA as we never get to ECDH:
-# we abort as soon as we determined the cert is bad.
+# Note: wen never get to ECDH: abort as soon as we determined the cert is bad.
 requires_config_enabled MBEDTLS_ECP_RESTARTABLE
 requires_config_enabled PSA_WANT_ECC_SECP_R1_256
 run_test    "EC restart: TLS, max_ops=1000, badsign" \
@@ -9379,31 +9357,9 @@ run_test    "EC restart: TLS, max_ops=1000, badsign" \
             -c "! mbedtls_ssl_handshake returned" \
             -c "X509 - Certificate verification failed"
 
-# With USE_PSA disabled we expect full restartable behaviour.
 requires_config_enabled MBEDTLS_ECP_RESTARTABLE
 requires_config_enabled PSA_WANT_ECC_SECP_R1_256
-skip_next_test
-run_test    "EC restart: TLS, max_ops=1000, auth_mode=optional badsign (no USE_PSA)" \
-            "$P_SRV groups=secp256r1 auth_mode=required \
-             crt_file=$DATA_FILES_PATH/server5-badsign.crt \
-             key_file=$DATA_FILES_PATH/server5.key" \
-            "$P_CLI force_ciphersuite=TLS-ECDHE-ECDSA-WITH-AES-128-GCM-SHA256 \
-             key_file=$DATA_FILES_PATH/server5.key crt_file=$DATA_FILES_PATH/server5.crt  \
-             debug_level=1 ec_max_ops=1000 auth_mode=optional" \
-            0 \
-            -c "x509_verify_cert.*\(4b00\|-248\)" \
-            -c "mbedtls_pk_verify.*\(4b00\|-248\)" \
-            -c "mbedtls_ecdh_make_public.*\(4b00\|-248\)" \
-            -c "mbedtls_pk_sign.*\(4b00\|-248\)" \
-            -c "! The certificate is not correctly signed by the trusted CA" \
-            -C "! mbedtls_ssl_handshake returned" \
-            -C "X509 - Certificate verification failed"
-
-# With USE_PSA enabled we expect only partial restartable behaviour:
-# everything except ECDH (where TLS calls PSA directly).
-requires_config_enabled MBEDTLS_ECP_RESTARTABLE
-requires_config_enabled PSA_WANT_ECC_SECP_R1_256
-run_test    "EC restart: TLS, max_ops=1000, auth_mode=optional badsign (USE_PSA)" \
+run_test    "EC restart: TLS, max_ops=1000, auth_mode=optional badsign" \
             "$P_SRV groups=secp256r1 auth_mode=required \
              crt_file=$DATA_FILES_PATH/server5-badsign.crt \
              key_file=$DATA_FILES_PATH/server5.key" \
@@ -9419,31 +9375,9 @@ run_test    "EC restart: TLS, max_ops=1000, auth_mode=optional badsign (USE_PSA)
             -C "! mbedtls_ssl_handshake returned" \
             -C "X509 - Certificate verification failed"
 
-# With USE_PSA disabled we expect full restartable behaviour.
 requires_config_enabled MBEDTLS_ECP_RESTARTABLE
 requires_config_enabled PSA_WANT_ECC_SECP_R1_256
-skip_next_test
-run_test    "EC restart: TLS, max_ops=1000, auth_mode=none badsign (no USE_PSA)" \
-            "$P_SRV groups=secp256r1 auth_mode=required \
-             crt_file=$DATA_FILES_PATH/server5-badsign.crt \
-             key_file=$DATA_FILES_PATH/server5.key" \
-            "$P_CLI force_ciphersuite=TLS-ECDHE-ECDSA-WITH-AES-128-GCM-SHA256 \
-             key_file=$DATA_FILES_PATH/server5.key crt_file=$DATA_FILES_PATH/server5.crt  \
-             debug_level=1 ec_max_ops=1000 auth_mode=none" \
-            0 \
-            -C "x509_verify_cert.*\(4b00\|-248\)" \
-            -c "mbedtls_pk_verify.*\(4b00\|-248\)" \
-            -c "mbedtls_ecdh_make_public.*\(4b00\|-248\)" \
-            -c "mbedtls_pk_sign.*\(4b00\|-248\)" \
-            -C "! The certificate is not correctly signed by the trusted CA" \
-            -C "! mbedtls_ssl_handshake returned" \
-            -C "X509 - Certificate verification failed"
-
-# With USE_PSA enabled we expect only partial restartable behaviour:
-# everything except ECDH (where TLS calls PSA directly).
-requires_config_enabled MBEDTLS_ECP_RESTARTABLE
-requires_config_enabled PSA_WANT_ECC_SECP_R1_256
-run_test    "EC restart: TLS, max_ops=1000, auth_mode=none badsign (USE_PSA)" \
+run_test    "EC restart: TLS, max_ops=1000, auth_mode=none badsign" \
             "$P_SRV groups=secp256r1 auth_mode=required \
              crt_file=$DATA_FILES_PATH/server5-badsign.crt \
              key_file=$DATA_FILES_PATH/server5.key" \
@@ -9459,26 +9393,9 @@ run_test    "EC restart: TLS, max_ops=1000, auth_mode=none badsign (USE_PSA)" \
             -C "! mbedtls_ssl_handshake returned" \
             -C "X509 - Certificate verification failed"
 
-# With USE_PSA disabled we expect full restartable behaviour.
 requires_config_enabled MBEDTLS_ECP_RESTARTABLE
 requires_config_enabled PSA_WANT_ECC_SECP_R1_256
-skip_next_test
-run_test    "EC restart: DTLS, max_ops=1000 (no USE_PSA)" \
-            "$P_SRV groups=secp256r1 auth_mode=required dtls=1" \
-            "$P_CLI force_ciphersuite=TLS-ECDHE-ECDSA-WITH-AES-128-GCM-SHA256 \
-             key_file=$DATA_FILES_PATH/server5.key crt_file=$DATA_FILES_PATH/server5.crt  \
-             dtls=1 debug_level=1 ec_max_ops=1000" \
-            0 \
-            -c "x509_verify_cert.*\(4b00\|-248\)" \
-            -c "mbedtls_pk_verify.*\(4b00\|-248\)" \
-            -c "mbedtls_ecdh_make_public.*\(4b00\|-248\)" \
-            -c "mbedtls_pk_sign.*\(4b00\|-248\)"
-
-# With USE_PSA enabled we expect only partial restartable behaviour:
-# everything except ECDH (where TLS calls PSA directly).
-requires_config_enabled MBEDTLS_ECP_RESTARTABLE
-requires_config_enabled PSA_WANT_ECC_SECP_R1_256
-run_test    "EC restart: DTLS, max_ops=1000 (USE_PSA)" \
+run_test    "EC restart: DTLS, max_ops=1000" \
             "$P_SRV groups=secp256r1 auth_mode=required dtls=1" \
             "$P_CLI force_ciphersuite=TLS-ECDHE-ECDSA-WITH-AES-128-GCM-SHA256 \
              key_file=$DATA_FILES_PATH/server5.key crt_file=$DATA_FILES_PATH/server5.crt  \
@@ -9489,26 +9406,9 @@ run_test    "EC restart: DTLS, max_ops=1000 (USE_PSA)" \
             -C "mbedtls_ecdh_make_public.*\(4b00\|-248\)" \
             -c "mbedtls_pk_sign.*\(4b00\|-248\)"
 
-# With USE_PSA disabled we expect full restartable behaviour.
 requires_config_enabled MBEDTLS_ECP_RESTARTABLE
 requires_config_enabled PSA_WANT_ECC_SECP_R1_256
-skip_next_test
-run_test    "EC restart: TLS, max_ops=1000 no client auth (no USE_PSA)" \
-            "$P_SRV groups=secp256r1" \
-            "$P_CLI force_ciphersuite=TLS-ECDHE-ECDSA-WITH-AES-128-GCM-SHA256 \
-             debug_level=1 ec_max_ops=1000" \
-            0 \
-            -c "x509_verify_cert.*\(4b00\|-248\)" \
-            -c "mbedtls_pk_verify.*\(4b00\|-248\)" \
-            -c "mbedtls_ecdh_make_public.*\(4b00\|-248\)" \
-            -C "mbedtls_pk_sign.*\(4b00\|-248\)"
-
-
-# With USE_PSA enabled we expect only partial restartable behaviour:
-# everything except ECDH (where TLS calls PSA directly).
-requires_config_enabled MBEDTLS_ECP_RESTARTABLE
-requires_config_enabled PSA_WANT_ECC_SECP_R1_256
-run_test    "EC restart: TLS, max_ops=1000 no client auth (USE_PSA)" \
+run_test    "EC restart: TLS, max_ops=1000 no client auth" \
             "$P_SRV groups=secp256r1" \
             "$P_CLI force_ciphersuite=TLS-ECDHE-ECDSA-WITH-AES-128-GCM-SHA256 \
              debug_level=1 ec_max_ops=1000" \

--- a/tests/suites/test_suite_error.data
+++ b/tests/suites/test_suite_error.data
@@ -1,9 +1,9 @@
 Single low error
-depends_on:MBEDTLS_AES_C
-error_strerror:-0x0020:"AES - Invalid key length"
+depends_on:MBEDTLS_NET_C
+error_strerror:-0x0042:"NET - Failed to open a socket"
 
 Single high error
-depends_on:PSA_WANT_ALG_SHA_256:PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY:MBEDTLS_X509_CRT_PARSE_C
+depends_on:MBEDTLS_X509_CRT_PARSE_C
 error_strerror:-0x2280:"X509 - The serial tag or value is invalid"
 
 Non existing high error


### PR DESCRIPTION
## Description

Backport of https://github.com/Mbed-TLS/mbedtls/pull/10620
This is a folllow-up to https://github.com/Mbed-TLS/mbedtls/pull/10608

## PR checklist

- [x] **changelog** not required because: tests only
- [x] **framework PR** not provided
- [x] **TF-PSA-Crypto development PR** not required because: mbedtls only
- [x] **TF-PSA-Crypto 1.1 PR** not required because: mbedtls only
- [x] **mbedtls development PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10620
- [x] **mbedtls 4.1 PR** provided HERE
- [x] **mbedtls 3.6 PR** not provided: library didn't split
- **tests**  provided