### PR TITLE
3.6 only: Fix possible miscompilation of ssl_hostname_skip_cn_verification hack

### DIFF
--- a/ChangeLog.d/mbedtls_ssl_set_hostname.txt
+++ b/ChangeLog.d/mbedtls_ssl_set_hostname.txt
@@ -1,0 +1,7 @@
+Bugfix
+   * Fix mbedtls_ssl_set_hostname(ssl, NULL) causing the connection to
+     fail when compiled with some versions of IAR in configurations
+     with MBEDTLS_SSL_SERVER_NAME_INDICATION disabled. Also fix
+     mbedtls_ssl_set_hostname(ssl, "") which could disable hostname
+     verification instead of requiring an empty hostname when compiled
+     with some optimizing compilers. Fixes #10842.

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -2789,7 +2789,7 @@ void mbedtls_ssl_conf_groups(mbedtls_ssl_config *conf,
  * mbedtls_ssl_set_hostname() has been called with `NULL`.
  * If mbedtls_ssl_set_hostname() has never been called on `ssl`, then
  * `ssl->hostname == NULL`. */
-static const char *const ssl_hostname_skip_cn_verification = "";
+static const char *const ssl_hostname_skip_cn_verification[] = { 0 };
 
 #if defined(MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED)
 /** Whether mbedtls_ssl_set_hostname() has been called.
@@ -2820,7 +2820,7 @@ static
 #endif
 const char *mbedtls_ssl_get_hostname_pointer(const mbedtls_ssl_context *ssl)
 {
-    if (ssl->hostname == ssl_hostname_skip_cn_verification) {
+    if (ssl->hostname == (char *) ssl_hostname_skip_cn_verification) {
         return NULL;
     }
     return ssl->hostname;
@@ -2830,7 +2830,7 @@ const char *mbedtls_ssl_get_hostname_pointer(const mbedtls_ssl_context *ssl)
 static void mbedtls_ssl_free_hostname(mbedtls_ssl_context *ssl)
 {
     if (ssl->hostname != NULL &&
-        ssl->hostname != ssl_hostname_skip_cn_verification) {
+        ssl->hostname != (char *) ssl_hostname_skip_cn_verification) {
         mbedtls_zeroize_and_free(ssl->hostname, strlen(ssl->hostname));
     }
     ssl->hostname = NULL;


### PR DESCRIPTION
Fix #10842

## PR checklist

- [x] **changelog** provided
- [x] **framework PR** not required
- [x] **TF-PSA-Crypto development PR** not required because: TLS only
- [x] **TF-PSA-Crypto 1.1 PR** not required because: TLS only
- [x] **mbedtls development PR** not required because: the bug is only present in LTS branches up to 3.6 where we needed a hack to preserve the ABI
- [x] **mbedtls 4.1 PR** not required because: the bug is only present in LTS branches up to 3.6 where we needed a hack to preserve the ABI
- [x] **mbedtls 3.6 PR** provided here
- **tests**  not required because: the only consequence is possible miscompilation on some compilers that we don't have on our CI
