### PR TITLE
Backport 3.6: Fix inconsistent docs for mbedtls_sha3_finish and mbedtls_sha3 olen

### DIFF
--- a/include/mbedtls/sha3.h
+++ b/include/mbedtls/sha3.h
@@ -118,7 +118,7 @@ int mbedtls_sha3_update(mbedtls_sha3_context *ctx,
  * \param output   The SHA-3 checksum result.
  *                 This must be a writable buffer of length \c olen bytes.
  * \param olen     Defines the length of output buffer (in bytes). For SHA-3 224, SHA-3 256,
- *                 SHA-3 384 and SHA-3 512 \c olen must equal to 28, 32, 48 and 64,
+ *                 SHA-3 384 and SHA-3 512 \c olen must be at least 28, 32, 48 and 64,
  *                 respectively.
  *
  * \return         \c 0 on success.
@@ -144,7 +144,7 @@ int mbedtls_sha3_finish(mbedtls_sha3_context *ctx,
  * \param output   The SHA-3 checksum result.
  *                 This must be a writable buffer of length \c olen bytes.
  * \param olen     Defines the length of output buffer (in bytes). For SHA-3 224, SHA-3 256,
- *                 SHA-3 384 and SHA-3 512 \c olen must equal to 28, 32, 48 and 64,
+ *                 SHA-3 384 and SHA-3 512 \c olen must be at least 28, 32, 48 and 64,
  *                 respectively.
  *
  * \return         \c 0 on success.


### PR DESCRIPTION
## Summary

The documentation of `mbedtls_sha3_finish()` and `mbedtls_sha3()` states that `olen` must equal 28/32/48/64 for SHA3-224/256/384/512, implying an error if `olen` is larger. However, the implementation silently accepts `olen` larger than the digest size and writes only the digest, ignoring the excess buffer.

This has been confirmed by the maintainer ([#10844](https://github.com/Mbed-TLS/mbedtls/issues/10844)): the intent is that `olen` is the output buffer size, and it must be at least the digest size, not exactly equal.

## Change

```diff
- *                 SHA-3 384 and SHA-3 512 \c olen must equal to 28, 32, 48 and 64,
+ *                 SHA-3 384 and SHA-3 512 \c olen must be at least 28, 32, 48 and 64,
```

Applied to both `mbedtls_sha3_finish` and `mbedtls_sha3` function docs.

## Test

A unit test verifying `olen > digest_size` does not return an error would ideally accompany this change. The maintainer noted this would be welcome in a follow-up.

Fixes #10844