### PR TITLE
Fix buffer overreads on malformed inputs in sample programs

### DIFF
--- a/ChangeLog.d/fix-sample-program-memory-errors.txt
+++ b/ChangeLog.d/fix-sample-program-memory-errors.txt
@@ -1,0 +1,6 @@
+Bugfix
+   * Fix potential buffer overreads on malformed inputs in sample programs:
+     ssl_server2 could read past the end of a session ticket shorter than
+     4 bytes when the dummy_ticket option is enabled, and ssl_context_info
+     could call strlen() on non-null-terminated ALPN data from the input
+     file, reading past the end of the decoded buffer. Fixes #10803.

--- a/programs/ssl/ssl_context_info.c
+++ b/programs/ssl/ssl_context_info.c
@@ -882,8 +882,13 @@ static void print_deserialized_ssl_context(const uint8_t *ssl, size_t len)
         printf("\tALPN negotiation                   : ");
         CHECK_SSL_END(alpn_len);
         if (alpn_len > 0) {
-            if (strlen((const char *) ssl) == alpn_len) {
-                printf("%s\n", ssl);
+            /* The ALPN protocol name in the serialized data is not
+             * null-terminated, so do not use strlen() on it: with a
+             * malformed input file it could read past the end of the
+             * decoded buffer. Read exactly alpn_len bytes instead, and
+             * treat an embedded null byte as incorrect data. */
+            if (memchr(ssl, '\0', alpn_len) == NULL) {
+                printf("%.*s\n", (int) alpn_len, ssl);
             } else {
                 printf("\n");
                 printf_err("\tALPN negotiation is incorrect\n");

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -1385,6 +1385,14 @@ static int dummy_ticket_parse(void *p_ticket, mbedtls_ssl_session *session,
     int ret;
     ((void) p_ticket);
 
+    /* Tickets are written by dummy_ticket_write() and start with a 4-byte
+     * lifetime header. Reject shorter tickets (which a misbehaving client
+     * could send) to avoid an underflow of len - 4 below resulting in a
+     * read past the end of the ticket buffer. */
+    if (len < 4) {
+        return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
+    }
+
     if ((ret = mbedtls_ssl_session_load(session, buf + 4, len - 4)) != 0) {
         return ret;
     }


### PR DESCRIPTION
Fixes #10803.

## Description

This fixes the two memory errors reported in #10803, both in sample programs (not in the library).

**ssl_server2.c — `dummy_ticket_parse()` length underflow.** Tickets written by `dummy_ticket_write()` start with a 4-byte lifetime header, so the parser called `mbedtls_ssl_session_load(session, buf + 4, len - 4)` unconditionally. A remote client can send a ticket shorter than 4 bytes; `len` is a `size_t`, so `len - 4` underflows and the loader reads past the end of the ticket buffer. The fix rejects tickets shorter than 4 bytes with `MBEDTLS_ERR_SSL_BAD_INPUT_DATA` before the subtraction.

**ssl_context_info.c — `strlen()` on non-null-terminated ALPN data.** The tool called `strlen()` on the serialized ALPN name, which is stored as exactly `alpn_len` bytes with no terminator, so a crafted input file made it read past the decoded buffer. The fix reads exactly `alpn_len` bytes, using `memchr()` to detect an embedded null (still reported as "ALPN negotiation is incorrect") and printing with `"%.*s"`.

Verified with Valgrind before and after each fix: the ALPN "uninitialised value ... strlen" error and the ticket "Invalid read of size 4 ... 3 bytes after a block of size 1" both disappear after the change. Both sample programs rebuild with no new warnings.

## PR checklist

- [x] **changelog** provided
- [x] **framework PR** not required
- [x] **TF-PSA-Crypto development PR** not required because this change only touches Mbed TLS sample programs
- [x] **TF-PSA-Crypto 1.1 PR** not required because this change only touches Mbed TLS sample programs
- [x] **mbedtls development PR** provided
- [x] **mbedtls 4.1 PR** not required because this is a sample-program fix with no API/ABI change; a backport can follow if maintainers want one
- [x] **mbedtls 3.6 PR** not required because this is a sample-program fix with no API/ABI change; a backport can follow if maintainers want one
- **tests** not required because the change is in sample programs, which are not covered by the project's automated test suites; the fixes were verified manually with Valgrind