### PR TITLE
Backport 4.1: ssl_fork_server RNG testing

### DIFF
--- a/library/ssl_tls12_client.c
+++ b/library/ssl_tls12_client.c
@@ -1645,17 +1645,27 @@ static int ssl_parse_server_ecdh_params(mbedtls_ssl_context *ssl,
      *  5+      ECPoint contents
      */
     if (end - *p < 4) {
+        MBEDTLS_SSL_DEBUG_MSG(2,
+                              ("bad server key exchange message: too short (%u)",
+                               (unsigned) (end - *p)));
         return MBEDTLS_ERR_SSL_DECODE_ERROR;
     }
 
     /* First byte is curve_type; only named_curve is handled */
     if (*(*p)++ != MBEDTLS_ECP_TLS_NAMED_CURVE) {
+        MBEDTLS_SSL_DEBUG_MSG(2,
+                              ("bad server key exchange message: not named_curve (%u != %u)",
+                               (unsigned) (*p)[-1],
+                               (unsigned) MBEDTLS_ECP_TLS_NAMED_CURVE));
         return MBEDTLS_ERR_SSL_HANDSHAKE_FAILURE;
     }
 
     /* Next two bytes are the namedcurve value */
     tls_id = MBEDTLS_GET_UINT16_BE(*p, 0);
     *p += 2;
+    MBEDTLS_SSL_DEBUG_MSG(3,
+                          ("server key exchange message: server picked ECDHE curve 0x%04x",
+                           (unsigned) tls_id));
 
     /* Check it's a curve we offered */
     if (mbedtls_ssl_check_curve_tls_id(ssl, tls_id) != 0) {
@@ -1676,13 +1686,23 @@ static int ssl_parse_server_ecdh_params(mbedtls_ssl_context *ssl,
     /* Keep a copy of the peer's public key */
     ecpoint_len = *(*p)++;
     if ((size_t) (end - *p) < ecpoint_len) {
+        MBEDTLS_SSL_DEBUG_MSG(2,
+                              ("bad server key exchange message: too short for point (%u < %u)",
+                               (unsigned) (end - *p),
+                               (unsigned) ecpoint_len));
         return MBEDTLS_ERR_SSL_DECODE_ERROR;
     }
 
     if (ecpoint_len > sizeof(handshake->xxdh_psa_peerkey)) {
+        MBEDTLS_SSL_DEBUG_MSG(2,
+                              ("bad server key exchange message: ecpoint_len too long "
+                               "(%" MBEDTLS_PRINTF_SIZET " > %" MBEDTLS_PRINTF_SIZET ")",
+                               ecpoint_len,
+                               sizeof(handshake->xxdh_psa_peerkey)));
         return MBEDTLS_ERR_SSL_HANDSHAKE_FAILURE;
     }
 
+    MBEDTLS_SSL_DEBUG_BUF(3, "server ephemeral public key", *p, ecpoint_len);
     memcpy(handshake->xxdh_psa_peerkey, *p, ecpoint_len);
     handshake->xxdh_psa_peerkey_len = ecpoint_len;
     *p += ecpoint_len;

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -1505,6 +1505,10 @@ int mbedtls_ssl_tls13_read_public_xxdhe_share(mbedtls_ssl_context *ssl,
                                   sizeof(handshake->xxdh_psa_peerkey)));
         return MBEDTLS_ERR_SSL_HANDSHAKE_FAILURE;
     }
+    MBEDTLS_SSL_DEBUG_BUF(3, (mbedtls_ssl_conf_get_endpoint(ssl->conf) == MBEDTLS_SSL_IS_CLIENT ?
+                              "server ephemeral public key" :
+                              "client ephemeral public key"),
+                          p, peerkey_len);
     memcpy(handshake->xxdh_psa_peerkey, p, peerkey_len);
     handshake->xxdh_psa_peerkey_len = peerkey_len;
 

--- a/tests/opt-testcases/sample.sh
+++ b/tests/opt-testcases/sample.sh
@@ -248,6 +248,9 @@ run_test    "Sample: ssl_fork_server, 2 successive clients with same seed, TLS 1
             -C "error" \
             -v 'distinct_server_random'
 
+requires_config_enabled MBEDTLS_ENTROPY_NO_SOURCES_OK
+requires_config_disabled MBEDTLS_PSA_BUILTIN_GET_ENTROPY
+requires_config_disabled MBEDTLS_PSA_DRIVER_GET_ENTROPY
 run_test    "Sample: ssl_fork_server, 2 successive clients with same seed, TLS 1.3: unique random" \
             -P 4433 \
             "server_with_own_seedfile $PROGRAMS_DIR/ssl_fork_server" \

--- a/tests/opt-testcases/sample.sh
+++ b/tests/opt-testcases/sample.sh
@@ -211,7 +211,7 @@ two_clients () (
     "$PROGRAMS_DIR/ssl_client2" "$@"
 )
 
-run_test    "Sample: ssl_fork_server, 2 successive clients, TLS 1.2" \
+run_test    "Sample: ssl_fork_server, 2 successive clients, TLS 1.2: unique random" \
             -P 4433 \
             "server_with_own_seedfile $PROGRAMS_DIR/ssl_fork_server" \
             "two_clients force_version=tls12 debug_level=3" \
@@ -220,7 +220,7 @@ run_test    "Sample: ssl_fork_server, 2 successive clients, TLS 1.2" \
             -C "error" \
             -v 'distinct_server_random'
 
-run_test    "Sample: ssl_fork_server, 2 successive clients, TLS 1.3" \
+run_test    "Sample: ssl_fork_server, 2 successive clients, TLS 1.3: unique random" \
             -P 4433 \
             "server_with_own_seedfile $PROGRAMS_DIR/ssl_fork_server" \
             "two_clients force_version=tls13 debug_level=3" \
@@ -228,6 +228,27 @@ run_test    "Sample: ssl_fork_server, 2 successive clients, TLS 1.3" \
             -S "error" \
             -C "error" \
             -v 'distinct_server_random'
+
+# Pick ECDHE-RSA, not ECDHE-ECDSA, because ssl_fork_server only loads one key,
+# and it uses an RSA key if both RSA and ECDSA are available.
+run_test    "Sample: ssl_fork_server, 2 successive clients, TLS 1.2: unique ephemeral ECDHE" \
+            -P 4433 \
+            "server_with_own_seedfile $PROGRAMS_DIR/ssl_fork_server" \
+            "two_clients force_version=tls12 force_ciphersuite=TLS-ECDHE-RSA-WITH-AES-128-GCM-SHA256 debug_level=3" \
+            0 \
+            -S "error" \
+            -C "error" \
+            -v 'distinct_server_ephemeral'
+
+requires_config_enabled MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
+run_test    "Sample: ssl_fork_server, 2 successive clients, TLS 1.3: unique ephemeral" \
+            -P 4433 \
+            "server_with_own_seedfile $PROGRAMS_DIR/ssl_fork_server" \
+            "two_clients force_version=tls13 tls13_kex_modes=ephemeral debug_level=3" \
+            0 \
+            -S "error" \
+            -C "error" \
+            -v 'distinct_server_ephemeral'
 
 run_test    "Sample: ssl_client1 with ssl_fork_server" \
             -P 4433 \

--- a/tests/opt-testcases/sample.sh
+++ b/tests/opt-testcases/sample.sh
@@ -206,6 +206,29 @@ run_test    "Sample: ssl_fork_server, ssl_client2" \
             -S "error" \
             -C "error"
 
+two_clients () (
+    "$PROGRAMS_DIR/ssl_client2" "$@" &&
+    "$PROGRAMS_DIR/ssl_client2" "$@"
+)
+
+run_test    "Sample: ssl_fork_server, 2 successive clients, TLS 1.2" \
+            -P 4433 \
+            "server_with_own_seedfile $PROGRAMS_DIR/ssl_fork_server" \
+            "two_clients force_version=tls12 debug_level=3" \
+            0 \
+            -S "error" \
+            -C "error" \
+            -v 'distinct_server_random'
+
+run_test    "Sample: ssl_fork_server, 2 successive clients, TLS 1.3" \
+            -P 4433 \
+            "server_with_own_seedfile $PROGRAMS_DIR/ssl_fork_server" \
+            "two_clients force_version=tls13 debug_level=3" \
+            0 \
+            -S "error" \
+            -C "error" \
+            -v 'distinct_server_random'
+
 run_test    "Sample: ssl_client1 with ssl_fork_server" \
             -P 4433 \
             "server_with_own_seedfile $PROGRAMS_DIR/ssl_fork_server" \

--- a/tests/opt-testcases/sample.sh
+++ b/tests/opt-testcases/sample.sh
@@ -196,7 +196,7 @@ run_test    "Sample: ssl_server, gnutls client, TLS 1.3" \
 
 run_test    "Sample: ssl_fork_server, ssl_client2" \
             -P 4433 \
-            "$PROGRAMS_DIR/ssl_fork_server" \
+            "server_with_own_seedfile $PROGRAMS_DIR/ssl_fork_server" \
             "$PROGRAMS_DIR/ssl_client2" \
             0 \
             -s "[1-9][0-9]* bytes read" \
@@ -208,7 +208,7 @@ run_test    "Sample: ssl_fork_server, ssl_client2" \
 
 run_test    "Sample: ssl_client1 with ssl_fork_server" \
             -P 4433 \
-            "$PROGRAMS_DIR/ssl_fork_server" \
+            "server_with_own_seedfile $PROGRAMS_DIR/ssl_fork_server" \
             "$PROGRAMS_DIR/ssl_client1" \
             0 \
             -s "[1-9][0-9]* bytes read" \

--- a/tests/opt-testcases/sample.sh
+++ b/tests/opt-testcases/sample.sh
@@ -229,6 +229,34 @@ run_test    "Sample: ssl_fork_server, 2 successive clients, TLS 1.3: unique rand
             -C "error" \
             -v 'distinct_server_random'
 
+two_clients_same_seed () (
+    cp seedfile seedfile1 &&
+    "$PROGRAMS_DIR/ssl_client2" "$@" &&
+    mv seedfile1 seedfile &&
+    "$PROGRAMS_DIR/ssl_client2" "$@"
+)
+
+requires_config_enabled MBEDTLS_ENTROPY_NO_SOURCES_OK
+requires_config_disabled MBEDTLS_PSA_BUILTIN_GET_ENTROPY
+requires_config_disabled MBEDTLS_PSA_DRIVER_GET_ENTROPY
+run_test    "Sample: ssl_fork_server, 2 successive clients with same seed, TLS 1.2: unique random" \
+            -P 4433 \
+            "server_with_own_seedfile $PROGRAMS_DIR/ssl_fork_server" \
+            "two_clients_same_seed force_version=tls12 debug_level=3" \
+            0 \
+            -S "error" \
+            -C "error" \
+            -v 'distinct_server_random'
+
+run_test    "Sample: ssl_fork_server, 2 successive clients with same seed, TLS 1.3: unique random" \
+            -P 4433 \
+            "server_with_own_seedfile $PROGRAMS_DIR/ssl_fork_server" \
+            "two_clients_same_seed force_version=tls13 debug_level=3" \
+            0 \
+            -S "error" \
+            -C "error" \
+            -v 'distinct_server_random'
+
 # Pick ECDHE-RSA, not ECDHE-ECDSA, because ssl_fork_server only loads one key,
 # and it uses an RSA key if both RSA and ECDSA are available.
 run_test    "Sample: ssl_fork_server, 2 successive clients, TLS 1.2: unique ephemeral ECDHE" \

--- a/tests/scripts/components-configuration-platform.sh
+++ b/tests/scripts/components-configuration-platform.sh
@@ -35,6 +35,30 @@ component_test_psa_driver_get_entropy()
     $MAKE_COMMAND test
 }
 
+component_test_entropy_nv_seed_only () {
+    msg "build: NV seed only (NV seed only)"
+    scripts/config.py full
+    scripts/config.py unset MBEDTLS_PSA_BUILTIN_GET_ENTROPY
+    scripts/config.py set MBEDTLS_ENTROPY_NO_SOURCES_OK
+
+    cmake -D CMAKE_BUILD_TYPE:String=Check .
+    make
+
+    # Check that the library seems to refer to the seedfile, but not to
+    # platform entropy sources.
+    grep seedfile tf-psa-crypto/platform/CMakeFiles/platform.dir/platform.c.o
+    not grep getrandom tf-psa-crypto/drivers/builtin/CMakeFiles/builtin.dir/src/entropy*.o platform/CMakeFiles/platform.dir/platform*.o
+    not grep /dev/random tf-psa-crypto/drivers/builtin/CMakeFiles/builtin.dir/src/entropy*.o platform/CMakeFiles/platform.dir/platform*.o
+    not grep /dev/.random tf-psa-crypto/drivers/builtin/CMakeFiles/builtin.dir/src/entropy*.o platform/CMakeFiles/platform.dir/platform*.o
+    not grep mbedtls_platform_get_entropy tf-psa-crypto/drivers/builtin/CMakeFiles/builtin.dir/src/entropy*.o platform/CMakeFiles/platform.dir/platform*.o
+
+    msg "test: NV seed only"
+    make test
+
+    msg "test: NV seed only - ssl-opt on sample programs"
+    tests/ssl-opt.sh -f 'Default\|Sample'
+}
+
 component_build_no_sockets () {
     # Note, C99 compliance can also be tested with the sockets support disabled,
     # as that requires a POSIX platform (which isn't the same as C99).

--- a/tests/scripts/components-configuration-platform.sh
+++ b/tests/scripts/components-configuration-platform.sh
@@ -47,10 +47,10 @@ component_test_entropy_nv_seed_only () {
     # Check that the library seems to refer to the seedfile, but not to
     # platform entropy sources.
     grep seedfile tf-psa-crypto/platform/CMakeFiles/platform.dir/platform.c.o
-    not grep getrandom tf-psa-crypto/drivers/builtin/CMakeFiles/builtin.dir/src/entropy*.o platform/CMakeFiles/platform.dir/platform*.o
-    not grep /dev/random tf-psa-crypto/drivers/builtin/CMakeFiles/builtin.dir/src/entropy*.o platform/CMakeFiles/platform.dir/platform*.o
-    not grep /dev/.random tf-psa-crypto/drivers/builtin/CMakeFiles/builtin.dir/src/entropy*.o platform/CMakeFiles/platform.dir/platform*.o
-    not grep mbedtls_platform_get_entropy tf-psa-crypto/drivers/builtin/CMakeFiles/builtin.dir/src/entropy*.o platform/CMakeFiles/platform.dir/platform*.o
+    not grep getrandom tf-psa-crypto/drivers/builtin/CMakeFiles/builtin.dir/src/entropy*.o tf-psa-crypto/platform/CMakeFiles/platform.dir/platform*.o
+    not grep /dev/random tf-psa-crypto/drivers/builtin/CMakeFiles/builtin.dir/src/entropy*.o tf-psa-crypto/platform/CMakeFiles/platform.dir/platform*.o
+    not grep /dev/.random tf-psa-crypto/drivers/builtin/CMakeFiles/builtin.dir/src/entropy*.o tf-psa-crypto/platform/CMakeFiles/platform.dir/platform*.o
+    not grep mbedtls_platform_get_entropy tf-psa-crypto/drivers/builtin/CMakeFiles/builtin.dir/src/entropy*.o tf-psa-crypto/platform/CMakeFiles/platform.dir/platform*.o
 
     msg "test: NV seed only"
     make test

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -14605,6 +14605,8 @@ EOF
     fi
 fi
 
+cleanup
+
 if [ $FAILS -gt 255 ]; then
     # Clamp at 255 as caller gets exit code & 0xFF
     # (so 256 would be 0, or success, etc)

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -1637,6 +1637,35 @@ do_run_test_once() {
     fi
 }
 
+# In builds with an NV seed, and especially with _only_ an NV seed,
+# the fact that the client and the server use the same seedfile may be
+# disruptive. In particular, it could cause a buggy server to pass just
+# because the client has rewritten the seed file between connections.
+#
+# So when we're specificially testing randomness, make the server use
+# its own seedfile. The seedfile name is hardcoded as "seedfile", but
+# we can change the current directory. This is easy for the sample
+# programs that don't use external files (it would be harder for those that
+# are called with arguments referencing files under data_files/).
+server_with_own_seedfile () {
+    set -eu
+    test -d "$subdirectory_for_server_seedfile" || mkdir "$subdirectory_for_server_seedfile"
+    test -s "$subdirectory_for_server_seedfile/seedfile" || cp seedfile "$subdirectory_for_server_seedfile"
+    cd "$subdirectory_for_server_seedfile"
+    # Assume that the path to the program is a relative path, and
+    # that the directory is a simple subdirectory.
+    server="../$1"
+    shift
+    # This process must become the server process, otherwise
+    # wait_server_start won't notice when the server starts listening.
+    exec "$server" "$@"
+}
+
+# Directory for running a server with its own seedfile (see above).
+# Define the variable here so that it's always available, in particular
+# in cleanup(). But only create and populate the directory on demand.
+subdirectory_for_server_seedfile="tmp-ssl-opt-wd-$$"
+
 # Detect if the current test is going to use TLS 1.3 or TLS 1.2.
 # $1 and $2 contain the server and client command lines, respectively.
 #
@@ -1954,6 +1983,10 @@ cleanup() {
     rm -f $CLI_OUT $SRV_OUT $PXY_OUT $SESSION
     rm -f context_srv.txt
     rm -f context_cli.txt
+    if [ -d "$subdirectory_for_server_seedfile" ]; then
+        rm -f "$subdirectory_for_server_seedfile/seedfile"
+        rmdir "$subdirectory_for_server_seedfile"
+    fi
     test -n "${SRV_PID:-}" && kill $SRV_PID >/dev/null 2>&1
     test -n "${PXY_PID:-}" && kill $PXY_PID >/dev/null 2>&1
     test -n "${CLI_PID:-}" && kill $CLI_PID >/dev/null 2>&1

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -1564,6 +1564,12 @@ check_test_failure() {
                     return
                 fi
                 ;;
+            "-v")
+                if ! ${PYTHON:-} ../framework/scripts/validate_ssl_logs.py "$CLI_OUT" "$SRV_OUT" $2; then
+                    fail "Validation failed on client and server output"
+                    return
+                fi
+                ;;
 
             *)
                 echo "Unknown test: $1" >&2

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -2183,8 +2183,8 @@ SESSION="session.$$"
 SKIP_NEXT="NO"
 
 trap 'cleanup; trap - HUP; kill -HUP $$' HUP
-trap 'cleanup; trap - HUP; kill -INT $$' INT
-trap 'cleanup; trap - HUP; kill -TERM $$' TERM
+trap 'cleanup; trap - INT; kill -INT $$' INT
+trap 'cleanup; trap - TERM; kill -TERM $$' TERM
 
 # Basic test
 

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -1654,6 +1654,9 @@ do_run_test_once() {
 # programs that don't use external files (it would be harder for those that
 # are called with arguments referencing files under data_files/).
 server_with_own_seedfile () {
+    if ! [ -e seedfile ]; then
+        exec "$@"
+    fi
     set -eu
     test -d "$subdirectory_for_server_seedfile" || mkdir "$subdirectory_for_server_seedfile"
     test -s "$subdirectory_for_server_seedfile/seedfile" || cp seedfile "$subdirectory_for_server_seedfile"

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -1997,7 +1997,6 @@ cleanup() {
     test -n "${PXY_PID:-}" && kill $PXY_PID >/dev/null 2>&1
     test -n "${CLI_PID:-}" && kill $CLI_PID >/dev/null 2>&1
     test -n "${DOG_PID:-}" && kill $DOG_PID >/dev/null 2>&1
-    exit 1
 }
 
 #
@@ -2183,7 +2182,9 @@ SESSION="session.$$"
 
 SKIP_NEXT="NO"
 
-trap cleanup INT TERM HUP
+trap 'cleanup; trap - HUP; kill -HUP $$' HUP
+trap 'cleanup; trap - HUP; kill -INT $$' INT
+trap 'cleanup; trap - HUP; kill -TERM $$' TERM
 
 # Basic test
 
@@ -14607,9 +14608,10 @@ fi
 
 cleanup
 
-if [ $FAILS -gt 255 ]; then
-    # Clamp at 255 as caller gets exit code & 0xFF
-    # (so 256 would be 0, or success, etc)
-    FAILS=255
+if [ $FAILS -gt 125 ]; then
+    # Clamp at 125 as caller gets exit code & 0xFF
+    # (so 256 would be 0, or success, etc), and 126 and above have
+    # conventional meanings (fork/exec failure, signal).
+    FAILS=125
 fi
 exit $FAILS


### PR DESCRIPTION
Test that `ssl_fork_server` has a different RNG state in each client. Fixes https://github.com/Mbed-TLS/mbedtls/issues/10664.

Forward port of https://github.com/Mbed-TLS/mbedtls/pull/10666. Differences:

* "SSL debug: dump the server ephemeral public key on the client": a chunk of code that's specific to legacy ECDH is omitted in 4.x.
* "Test for distinct server ephemeral public keys in ssl_fork_server": Remove TLS 1.2 DHE test case since DHE was removed in 4.0.
* "More testing of NV-seed only builds: run some ssl-opt, do legacy crypto": very different structure. In 4.x, `component_test_entropy_nv_seed_only` already exists in crypto but we now add it to mbedtls so that we can run `ssl-opt.sh`. Also, in 4.x, there's only one variant because `MBEDTLS_USE_PSA_CRYPTO` is always enabled.
* "ssl_fork_server: Assert unique server random values with identical client random values": adapt test case dependencies for an NV-seed-only build.

## PR checklist

- [x] **changelog** not required because: test only
- [x] **development PR** https://github.com/Mbed-TLS/mbedtls/pull/10861
- [x] **4.1 PR** https://github.com/Mbed-TLS/mbedtls/pull/10858
- [x] **TF-PSA-Crypto PR** not required because: TLS only
- [x] **framework PR** provided https://github.com/Mbed-TLS/mbedtls-framework/pull/296
- [x] **3.6 PR** https://github.com/Mbed-TLS/mbedtls/pull/10666
- **tests**  provided
