### PR TITLE
Reject overflowing numeric OID components

### DIFF
--- a/ChangeLog.d/numeric-oid-overflow.txt
+++ b/ChangeLog.d/numeric-oid-overflow.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Reject numeric OID components that exceed the range of unsigned int
+     instead of silently encoding a different value. Fixes #10910.

--- a/library/x509_create.c
+++ b/library/x509_create.c
@@ -287,7 +287,7 @@ static int oid_parse_number(unsigned int *num, const char **p, const char *bound
 
     while (*p < bound && **p >= '0' && **p <= '9') {
         ret = 0;
-        if (*num > (UINT_MAX / 10)) {
+        if (*num > (UINT_MAX - (unsigned int) (**p - '0')) / 10) {
             return MBEDTLS_ERR_ASN1_INVALID_DATA;
         }
         *num *= 10;

--- a/tests/suites/test_suite_x509write.data
+++ b/tests/suites/test_suite_x509write.data
@@ -337,3 +337,12 @@ oid_from_numeric_string:"2.4294967215":0:"8FFFFFFF7F"
 
 OID from numeric string - OID with overflowing subidentifier
 oid_from_numeric_string:"2.4294967216":MBEDTLS_ERR_ASN1_INVALID_DATA:""
+
+OID from numeric string - numeric component overflows on final digit
+oid_from_numeric_string:"2.4294967296":MBEDTLS_ERR_ASN1_INVALID_DATA:""
+
+OID from numeric string - numeric component overflows to nonzero value
+oid_from_numeric_string:"2.4294967299":MBEDTLS_ERR_ASN1_INVALID_DATA:""
+
+OID from numeric string - numeric component continues after overflow
+oid_from_numeric_string:"2.42949672966":MBEDTLS_ERR_ASN1_INVALID_DATA:""


### PR DESCRIPTION

## Description

  `oid_parse_number()` checked the accumulated value before multiplying by 10,
  but did not account for the pending digit. Numeric components such as
  `4294967296` could therefore wrap and be accepted as a different OID value.

  Validate the complete multiply-add before updating the accumulator, and add
  regression cases for overflow to zero, overflow to a nonzero value, and
  continued parsing after a wrap.

  Fixes #10910

  ## PR checklist

  - [x] **changelog** provided
  - [x] **framework PR** not required because: no framework changes
  - [x] **TF-PSA-Crypto development PR** not required because: no TF-PSA-Crypto changes
  - [x] **TF-PSA-Crypto 1.1 PR** not required because: no TF-PSA-Crypto changes
  - [x] **mbedtls development PR** this PR
  - [ ] **mbedtls 4.1 PR** to be provided after the development fix is accepted
  - [ ] **mbedtls 3.6 PR** to be provided after the development fix is accepted
  - **tests** provided