### PR TITLE
[Backport 3.6] PSA its function uid0 errorcode fix

### DIFF
--- a/library/psa_crypto_its.h
+++ b/library/psa_crypto_its.h
@@ -59,8 +59,9 @@ struct psa_storage_info_t {
  * \retval      #PSA_ERROR_NOT_SUPPORTED         The operation failed because one or more of the flags provided in `create_flags` is not supported or is not valid
  * \retval      #PSA_ERROR_INSUFFICIENT_STORAGE  The operation failed because there was insufficient space on the storage medium
  * \retval      #PSA_ERROR_STORAGE_FAILURE       The operation failed because the physical storage has failed (Fatal error)
- * \retval      #PSA_ERROR_INVALID_ARGUMENT      The operation failed because one of the provided pointers(`p_data`)
- *                                               is invalid, for example is `NULL` or references memory the caller cannot access
+ * \retval      #PSA_ERROR_INVALID_ARGUMENT      The operation failed because \p uid is 0,
+ *                                               or one of the provided pointers (`p_data`) is invalid,
+ *                                               for example is `NULL` or references memory the caller cannot access.
  */
 psa_status_t psa_its_set(psa_storage_uid_t uid,
                          uint32_t data_length,
@@ -83,8 +84,9 @@ psa_status_t psa_its_set(psa_storage_uid_t uid,
  * \retval      #PSA_ERROR_DOES_NOT_EXIST    The operation failed because the provided `uid` value was not found in the storage
  * \retval      #PSA_ERROR_STORAGE_FAILURE   The operation failed because the physical storage has failed (Fatal error)
  * \retval      #PSA_ERROR_DATA_CORRUPT      The operation failed because stored data has been corrupted
- * \retval      #PSA_ERROR_INVALID_ARGUMENT  The operation failed because one of the provided pointers(`p_data`, `p_data_length`)
- *                                           is invalid. For example is `NULL` or references memory the caller cannot access.
+ * \retval      #PSA_ERROR_INVALID_ARGUMENT  The operation failed because \p uid is 0,
+ *                                           or one of the provided pointers (`p_data`) is invalid,
+ *                                           for example is `NULL` or references memory the caller cannot access.
  *                                           In addition, this can also happen if an invalid offset was provided.
  */
 psa_status_t psa_its_get(psa_storage_uid_t uid,
@@ -104,8 +106,9 @@ psa_status_t psa_its_get(psa_storage_uid_t uid,
  * \retval      #PSA_SUCCESS                 The operation completed successfully
  * \retval      #PSA_ERROR_DOES_NOT_EXIST    The operation failed because the provided uid value was not found in the storage
  * \retval      #PSA_ERROR_DATA_CORRUPT      The operation failed because stored data has been corrupted
- * \retval      #PSA_ERROR_INVALID_ARGUMENT  The operation failed because one of the provided pointers(`p_info`)
- *                                           is invalid, for example is `NULL` or references memory the caller cannot access
+ * \retval      #PSA_ERROR_INVALID_ARGUMENT  The operation failed because \p uid is 0,
+ *                                           or the provided pointer (`p_info`) is invalid,
+ *                                           for example is `NULL` or references memory the caller cannot access.
  */
 psa_status_t psa_its_get_info(psa_storage_uid_t uid,
                               struct psa_storage_info_t *p_info);
@@ -121,6 +124,7 @@ psa_status_t psa_its_get_info(psa_storage_uid_t uid,
  * \retval      #PSA_ERROR_DOES_NOT_EXIST     The operation failed because the provided key value was not found in the storage
  * \retval      #PSA_ERROR_NOT_PERMITTED      The operation failed because the provided key value was created with PSA_STORAGE_FLAG_WRITE_ONCE
  * \retval      #PSA_ERROR_STORAGE_FAILURE    The operation failed because the physical storage has failed (Fatal error)
+ * \retval      #PSA_ERROR_INVALID_ARGUMENT   The operation failed because \p uid is 0.
  */
 psa_status_t psa_its_remove(psa_storage_uid_t uid);
 

--- a/library/psa_its_file.c
+++ b/library/psa_its_file.c
@@ -79,6 +79,10 @@ static psa_status_t psa_its_read_file(psa_storage_uid_t uid,
     psa_its_file_header_t header;
     size_t n;
 
+    if (uid == 0) {
+        return PSA_ERROR_INVALID_ARGUMENT;
+    }
+
     *p_stream = NULL;
     psa_its_fill_filename(uid, filename);
     *p_stream = fopen(filename, "rb");
@@ -178,7 +182,7 @@ psa_status_t psa_its_set(psa_storage_uid_t uid,
                          psa_storage_create_flags_t create_flags)
 {
     if (uid == 0) {
-        return PSA_ERROR_INVALID_HANDLE;
+        return PSA_ERROR_INVALID_ARGUMENT;
     }
 
     psa_status_t status = PSA_ERROR_STORAGE_FAILURE;
@@ -239,6 +243,11 @@ psa_status_t psa_its_remove(psa_storage_uid_t uid)
 {
     char filename[PSA_ITS_STORAGE_FILENAME_LENGTH];
     FILE *stream;
+
+    if (uid == 0) {
+        return PSA_ERROR_INVALID_ARGUMENT;
+    }
+
     psa_its_fill_filename(uid, filename);
     stream = fopen(filename, "rb");
     if (stream == NULL) {

--- a/tests/suites/test_suite_psa_its.data
+++ b/tests/suites/test_suite_psa_its.data
@@ -29,7 +29,10 @@ Multiple files
 set_multiple:1:5
 
 Set UID 0
-set_fail:0:"40414243444546474849":PSA_ERROR_INVALID_HANDLE
+set_fail:0:"40414243444546474849":PSA_ERROR_INVALID_ARGUMENT
+
+All functions reject UID 0
+invalid_uid0
 
 Non-existent file
 nonexistent:1:0

--- a/tests/suites/test_suite_psa_its.function
+++ b/tests/suites/test_suite_psa_its.function
@@ -307,14 +307,14 @@ void invalid_uid0()
 {
     struct psa_storage_info_t info;
 
-    TEST_ASSERT(psa_its_set_wrap(0, 0, NULL, 0) ==
-                PSA_ERROR_INVALID_ARGUMENT);
-    TEST_ASSERT(psa_its_get(0, 0, 0, NULL, NULL) ==
-                PSA_ERROR_INVALID_ARGUMENT);
-    TEST_ASSERT(psa_its_get_info(0, &info) ==
-                PSA_ERROR_INVALID_ARGUMENT);
-    TEST_ASSERT(psa_its_remove(0) ==
-                PSA_ERROR_INVALID_ARGUMENT);
+    TEST_EQUAL(psa_its_set_wrap(0, 0, NULL, 0),
+               PSA_ERROR_INVALID_ARGUMENT);
+    TEST_EQUAL(psa_its_get(0, 0, 0, NULL, NULL),
+               PSA_ERROR_INVALID_ARGUMENT);
+    TEST_EQUAL(psa_its_get_info(0, &info),
+               PSA_ERROR_INVALID_ARGUMENT);
+    TEST_EQUAL(psa_its_remove(0),
+               PSA_ERROR_INVALID_ARGUMENT);
 
 exit:
     cleanup();

--- a/tests/suites/test_suite_psa_its.function
+++ b/tests/suites/test_suite_psa_its.function
@@ -301,3 +301,22 @@ exit:
     cleanup();
 }
 /* END_CASE */
+
+/* BEGIN_CASE */
+void invalid_uid0()
+{
+    struct psa_storage_info_t info;
+
+    TEST_ASSERT(psa_its_set_wrap(0, 0, NULL, 0) ==
+                PSA_ERROR_INVALID_ARGUMENT);
+    TEST_ASSERT(psa_its_get(0, 0, 0, NULL, NULL) ==
+                PSA_ERROR_INVALID_ARGUMENT);
+    TEST_ASSERT(psa_its_get_info(0, &info) ==
+                PSA_ERROR_INVALID_ARGUMENT);
+    TEST_ASSERT(psa_its_remove(0) ==
+                PSA_ERROR_INVALID_ARGUMENT);
+
+exit:
+    cleanup();
+}
+/* END_CASE */


### PR DESCRIPTION
## Description

Fixes: https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/826
Backport of: https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/835

Fix `psa_its_set()`, `psa_its_get()`, `psa_its_get_info()`, `psa_its_remove()`to return `PSA_ERROR_INVALID_ARGUMENT` when called with UID 0, to match the PSA Storage API requirement.

Update the test and function description.

## PR checklist

- [x] **changelog** no user-visible change
- [x] **framework PR** not required
- [x] **TF-PSA-Crypto development PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/835
- [x] **TF-PSA-Crypto 1.1 PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/870
- [x] **mbedtls development PR** not required because: tf-crypto only
- [x] **mbedtls 4.1 PR** not required because: tf-crypto only
- [x] **mbedtls 3.6 PR** provided: https://github.com/Mbed-TLS/mbedtls/pull/10920
- **tests**  provided