### PR TITLE
Prerequisite for adding support for Blake2 in TF-PSA-Crypto

### DIFF
--- a/tests/scripts/components-configuration-crypto.sh
+++ b/tests/scripts/components-configuration-crypto.sh
@@ -594,7 +594,8 @@ component_test_psa_crypto_config_accel_ecdsa () {
 
     # These hashes are needed for some ECDSA signature tests.
     loc_extra_list="ALG_SHA_1 ALG_SHA_224 ALG_SHA_256 ALG_SHA_384 ALG_SHA_512 \
-                    ALG_SHA3_224 ALG_SHA3_256 ALG_SHA3_384 ALG_SHA3_512"
+                    ALG_SHA3_224 ALG_SHA3_256 ALG_SHA3_384 ALG_SHA3_512 \
+                    ALG_BLAKE2S_HASH256 ALG_BLAKE2B_HASH512"
 
     helper_libtestdriver1_make_drivers "$loc_accel_list" "$loc_extra_list"
 
@@ -745,7 +746,8 @@ component_test_psa_crypto_config_accel_ecc_some_key_types () {
 
     # These hashes are needed for some ECDSA signature tests.
     loc_extra_list="ALG_SHA_1 ALG_SHA_224 ALG_SHA_256 ALG_SHA_384 ALG_SHA_512 \
-                    ALG_SHA3_224 ALG_SHA3_256 ALG_SHA3_384 ALG_SHA3_512"
+                    ALG_SHA3_224 ALG_SHA3_256 ALG_SHA3_384 ALG_SHA3_512 \
+                    ALG_BLAKE2S_HASH256 ALG_BLAKE2B_HASH512"
     helper_libtestdriver1_make_drivers "$loc_accel_list" "$loc_extra_list"
 
     helper_libtestdriver1_make_main "$loc_accel_list"
@@ -833,7 +835,8 @@ common_test_psa_crypto_config_accel_ecc_some_curves () {
 
     # These hashes are needed for some ECDSA signature tests.
     loc_extra_list="ALG_SHA_1 ALG_SHA_224 ALG_SHA_256 ALG_SHA_384 ALG_SHA_512 \
-                    ALG_SHA3_224 ALG_SHA3_256 ALG_SHA3_384 ALG_SHA3_512"
+                    ALG_SHA3_224 ALG_SHA3_256 ALG_SHA3_384 ALG_SHA3_512 \
+                    ALG_BLAKE2S_HASH256 ALG_BLAKE2B_HASH512"
     helper_libtestdriver1_make_drivers "$loc_accel_list" "$loc_extra_list"
 
     # For grep to work below we need less inlining in ecp.c
@@ -908,7 +911,8 @@ component_test_psa_crypto_config_accel_ecc_ecp_light_only () {
 
     # These hashes are needed for some ECDSA signature tests.
     loc_extra_list="ALG_SHA_1 ALG_SHA_224 ALG_SHA_256 ALG_SHA_384 ALG_SHA_512 \
-                    ALG_SHA3_224 ALG_SHA3_256 ALG_SHA3_384 ALG_SHA3_512"
+                    ALG_SHA3_224 ALG_SHA3_256 ALG_SHA3_384 ALG_SHA3_512 \
+                    ALG_BLAKE2S_HASH256 ALG_BLAKE2B_HASH512"
     helper_libtestdriver1_make_drivers "$loc_accel_list" "$loc_extra_list"
 
     helper_libtestdriver1_make_main "$loc_accel_list"
@@ -964,7 +968,8 @@ component_test_psa_crypto_config_accel_ecc_no_ecp_at_all () {
     # Things we wanted supported in libtestdriver1, but not accelerated in the main library:
     # SHA-1 and all SHA-2/3 variants, as they are used by ECDSA deterministic.
     loc_extra_list="ALG_SHA_1 ALG_SHA_224 ALG_SHA_256 ALG_SHA_384 ALG_SHA_512 \
-                    ALG_SHA3_224 ALG_SHA3_256 ALG_SHA3_384 ALG_SHA3_512"
+                    ALG_SHA3_224 ALG_SHA3_256 ALG_SHA3_384 ALG_SHA3_512 \
+                    ALG_BLAKE2S_HASH256 ALG_BLAKE2B_HASH512"
 
     helper_libtestdriver1_make_drivers "$loc_accel_list" "$loc_extra_list"
 
@@ -1060,7 +1065,8 @@ common_test_psa_crypto_config_accel_ecc_ffdh_no_bignum () {
     # Things we wanted supported in libtestdriver1, but not accelerated in the main library:
     # SHA-1 and all SHA-2/3 variants, as they are used by ECDSA deterministic.
     loc_extra_list="ALG_SHA_1 ALG_SHA_224 ALG_SHA_256 ALG_SHA_384 ALG_SHA_512 \
-                    ALG_SHA3_224 ALG_SHA3_256 ALG_SHA3_384 ALG_SHA3_512"
+                    ALG_SHA3_224 ALG_SHA3_256 ALG_SHA3_384 ALG_SHA3_512 \
+                    ALG_BLAKE2S_HASH256 ALG_BLAKE2B_HASH512"
 
     helper_libtestdriver1_make_drivers "$loc_accel_list" "$loc_extra_list"
 
@@ -1247,7 +1253,8 @@ component_test_psa_crypto_config_accel_rsa_crypto () {
 
     # These hashes are needed for unit tests.
     loc_extra_list="ALG_SHA_1 ALG_SHA_224 ALG_SHA_256 ALG_SHA_384 ALG_SHA_512 \
-                    ALG_SHA3_224 ALG_SHA3_256 ALG_SHA3_384 ALG_SHA3_512 ALG_MD5"
+                    ALG_SHA3_224 ALG_SHA3_256 ALG_SHA3_384 ALG_SHA3_512 ALG_MD5 \
+                    ALG_BLAKE2S_HASH256 ALG_BLAKE2B_HASH512"
     helper_libtestdriver1_make_drivers "$loc_accel_list" "$loc_extra_list"
 
     helper_libtestdriver1_make_main "$loc_accel_list"
@@ -1310,7 +1317,8 @@ component_test_psa_crypto_config_accel_hash () {
 
     loc_accel_list="ALG_MD5 ALG_RIPEMD160 ALG_SHA_1 \
                     ALG_SHA_224 ALG_SHA_256 ALG_SHA_384 ALG_SHA_512 \
-                    ALG_SHA3_224 ALG_SHA3_256 ALG_SHA3_384 ALG_SHA3_512"
+                    ALG_SHA3_224 ALG_SHA3_256 ALG_SHA3_384 ALG_SHA3_512 \
+                    ALG_BLAKE2S_HASH256 ALG_BLAKE2B_HASH512"
 
     # Configure
     # ---------
@@ -1373,7 +1381,8 @@ component_test_psa_crypto_config_accel_hmac () {
     loc_accel_list="ALG_HMAC KEY_TYPE_HMAC \
                     ALG_MD5 ALG_RIPEMD160 ALG_SHA_1 \
                     ALG_SHA_224 ALG_SHA_256 ALG_SHA_384 ALG_SHA_512 \
-                    ALG_SHA3_224 ALG_SHA3_256 ALG_SHA3_384 ALG_SHA3_512"
+                    ALG_SHA3_224 ALG_SHA3_256 ALG_SHA3_384 ALG_SHA3_512 \
+                    ALG_BLAKE2S_HASH256 ALG_BLAKE2B_HASH512"
 
     # Configure
     # ---------

--- a/tests/scripts/components-configuration-crypto.sh
+++ b/tests/scripts/components-configuration-crypto.sh
@@ -595,7 +595,7 @@ component_test_psa_crypto_config_accel_ecdsa () {
     # These hashes are needed for some ECDSA signature tests.
     loc_extra_list="ALG_SHA_1 ALG_SHA_224 ALG_SHA_256 ALG_SHA_384 ALG_SHA_512 \
                     ALG_SHA3_224 ALG_SHA3_256 ALG_SHA3_384 ALG_SHA3_512 \
-                    ALG_BLAKE2S_HASH256 ALG_BLAKE2B_HASH512"
+                    ALG_BLAKE2S_HASH256 ALG_BLAKE2B_HASH512 ALG_SM3"
 
     helper_libtestdriver1_make_drivers "$loc_accel_list" "$loc_extra_list"
 
@@ -747,7 +747,7 @@ component_test_psa_crypto_config_accel_ecc_some_key_types () {
     # These hashes are needed for some ECDSA signature tests.
     loc_extra_list="ALG_SHA_1 ALG_SHA_224 ALG_SHA_256 ALG_SHA_384 ALG_SHA_512 \
                     ALG_SHA3_224 ALG_SHA3_256 ALG_SHA3_384 ALG_SHA3_512 \
-                    ALG_BLAKE2S_HASH256 ALG_BLAKE2B_HASH512"
+                    ALG_BLAKE2S_HASH256 ALG_BLAKE2B_HASH512 ALG_SM3"
     helper_libtestdriver1_make_drivers "$loc_accel_list" "$loc_extra_list"
 
     helper_libtestdriver1_make_main "$loc_accel_list"
@@ -836,7 +836,7 @@ common_test_psa_crypto_config_accel_ecc_some_curves () {
     # These hashes are needed for some ECDSA signature tests.
     loc_extra_list="ALG_SHA_1 ALG_SHA_224 ALG_SHA_256 ALG_SHA_384 ALG_SHA_512 \
                     ALG_SHA3_224 ALG_SHA3_256 ALG_SHA3_384 ALG_SHA3_512 \
-                    ALG_BLAKE2S_HASH256 ALG_BLAKE2B_HASH512"
+                    ALG_BLAKE2S_HASH256 ALG_BLAKE2B_HASH512 ALG_SM3"
     helper_libtestdriver1_make_drivers "$loc_accel_list" "$loc_extra_list"
 
     # For grep to work below we need less inlining in ecp.c
@@ -912,7 +912,7 @@ component_test_psa_crypto_config_accel_ecc_ecp_light_only () {
     # These hashes are needed for some ECDSA signature tests.
     loc_extra_list="ALG_SHA_1 ALG_SHA_224 ALG_SHA_256 ALG_SHA_384 ALG_SHA_512 \
                     ALG_SHA3_224 ALG_SHA3_256 ALG_SHA3_384 ALG_SHA3_512 \
-                    ALG_BLAKE2S_HASH256 ALG_BLAKE2B_HASH512"
+                    ALG_BLAKE2S_HASH256 ALG_BLAKE2B_HASH512 ALG_SM3"
     helper_libtestdriver1_make_drivers "$loc_accel_list" "$loc_extra_list"
 
     helper_libtestdriver1_make_main "$loc_accel_list"
@@ -969,7 +969,7 @@ component_test_psa_crypto_config_accel_ecc_no_ecp_at_all () {
     # SHA-1 and all SHA-2/3 variants, as they are used by ECDSA deterministic.
     loc_extra_list="ALG_SHA_1 ALG_SHA_224 ALG_SHA_256 ALG_SHA_384 ALG_SHA_512 \
                     ALG_SHA3_224 ALG_SHA3_256 ALG_SHA3_384 ALG_SHA3_512 \
-                    ALG_BLAKE2S_HASH256 ALG_BLAKE2B_HASH512"
+                    ALG_BLAKE2S_HASH256 ALG_BLAKE2B_HASH512 ALG_SM3"
 
     helper_libtestdriver1_make_drivers "$loc_accel_list" "$loc_extra_list"
 
@@ -1066,7 +1066,7 @@ common_test_psa_crypto_config_accel_ecc_ffdh_no_bignum () {
     # SHA-1 and all SHA-2/3 variants, as they are used by ECDSA deterministic.
     loc_extra_list="ALG_SHA_1 ALG_SHA_224 ALG_SHA_256 ALG_SHA_384 ALG_SHA_512 \
                     ALG_SHA3_224 ALG_SHA3_256 ALG_SHA3_384 ALG_SHA3_512 \
-                    ALG_BLAKE2S_HASH256 ALG_BLAKE2B_HASH512"
+                    ALG_BLAKE2S_HASH256 ALG_BLAKE2B_HASH512 ALG_SM3"
 
     helper_libtestdriver1_make_drivers "$loc_accel_list" "$loc_extra_list"
 
@@ -1254,7 +1254,7 @@ component_test_psa_crypto_config_accel_rsa_crypto () {
     # These hashes are needed for unit tests.
     loc_extra_list="ALG_SHA_1 ALG_SHA_224 ALG_SHA_256 ALG_SHA_384 ALG_SHA_512 \
                     ALG_SHA3_224 ALG_SHA3_256 ALG_SHA3_384 ALG_SHA3_512 ALG_MD5 \
-                    ALG_BLAKE2S_HASH256 ALG_BLAKE2B_HASH512"
+                    ALG_BLAKE2S_HASH256 ALG_BLAKE2B_HASH512 ALG_SM3"
     helper_libtestdriver1_make_drivers "$loc_accel_list" "$loc_extra_list"
 
     helper_libtestdriver1_make_main "$loc_accel_list"
@@ -1318,7 +1318,7 @@ component_test_psa_crypto_config_accel_hash () {
     loc_accel_list="ALG_MD5 ALG_RIPEMD160 ALG_SHA_1 \
                     ALG_SHA_224 ALG_SHA_256 ALG_SHA_384 ALG_SHA_512 \
                     ALG_SHA3_224 ALG_SHA3_256 ALG_SHA3_384 ALG_SHA3_512 \
-                    ALG_BLAKE2S_HASH256 ALG_BLAKE2B_HASH512"
+                    ALG_BLAKE2S_HASH256 ALG_BLAKE2B_HASH512 ALG_SM3"
 
     # Configure
     # ---------
@@ -1382,7 +1382,7 @@ component_test_psa_crypto_config_accel_hmac () {
                     ALG_MD5 ALG_RIPEMD160 ALG_SHA_1 \
                     ALG_SHA_224 ALG_SHA_256 ALG_SHA_384 ALG_SHA_512 \
                     ALG_SHA3_224 ALG_SHA3_256 ALG_SHA3_384 ALG_SHA3_512 \
-                    ALG_BLAKE2S_HASH256 ALG_BLAKE2B_HASH512"
+                    ALG_BLAKE2S_HASH256 ALG_BLAKE2B_HASH512 ALG_SM3"
 
     # Configure
     # ---------

--- a/tests/scripts/libtestdriver1_rewrite.pl
+++ b/tests/scripts/libtestdriver1_rewrite.pl
@@ -19,6 +19,10 @@ my @private_files = map { basename($_) } glob("../tf-psa-crypto/include/mbedtls/
 
 my $private_files_regex = join('|', map { quotemeta($_) } @private_files);
 
+my @private_builtin_tf_psa_crypto_files = map { basename($_) } glob("../tf-psa-crypto/drivers/builtin/include/tf-psa-crypto/private/*.h");
+
+my $private_builtin_tf_psa_crypto_files_regex = join('|', map { quotemeta($_) } @private_builtin_tf_psa_crypto_files);
+
 while (<>) {
     s!^(\s*#\s*include\s*[\"<])mbedtls/build_info.h!${1}libtestdriver1/include/mbedtls/build_info.h!;
     s!^(\s*#\s*include\s*[\"<])mbedtls/mbedtls_config.h!${1}libtestdriver1/include/mbedtls/mbedtls_config.h!;
@@ -37,6 +41,13 @@ while (<>) {
     }
     s!^(\s*#\s*include\s*[\"<])mbedtls/!${1}libtestdriver1/tf-psa-crypto/drivers/builtin/include/mbedtls/!;
     s!^(\s*#\s*include\s*[\"<])psa/!${1}libtestdriver1/tf-psa-crypto/include/psa/!;
+    # Files in tf-psa-crypto/include/tf-psa-crypto/private and
+    # drivers/builtin/include/tf-psa-crypto/private are both included via
+    # #include tf-psa-crypto/private/<file>.h, so make sure builtin driver
+    # headers (e.g. blake2.h) are not expanded to the public include path.
+    if ( $private_builtin_tf_psa_crypto_files_regex ) {
+        s!^(\s*#\s*include\s*[\"<])tf-psa-crypto/private/($private_builtin_tf_psa_crypto_files_regex)!${1}libtestdriver1/tf-psa-crypto/drivers/builtin/include/tf-psa-crypto/private/${2}!;
+    }
     s!^(\s*#\s*include\s*[\"<])tf-psa-crypto/!${1}libtestdriver1/tf-psa-crypto/include/tf-psa-crypto/!;
     if (/^\s*#\s*include/) {
         print;


### PR DESCRIPTION
## Description

The main goals of this PR are:
- update 'libtestdriver1_rewrite.pl' in order to properly set the path of tf-psa-crypto private include files;
- update the framework reference in order to allow tests of https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/867 with 'development' branch of `mbedtls` to pass.

Prerequisite for https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/867.

## PR checklist

- [x] **changelog** not required because: no user facing change
- [x] **framework PR** provided: https://github.com/Mbed-TLS/mbedtls-framework/pull/316
- [x] **TF-PSA-Crypto development PR** provided: https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/867
- [x] **TF-PSA-Crypto 1.1 PR** not required because: https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/867 is not planned to be backported
- [x] **mbedtls development PR** provided: this one
- [x] **mbedtls 4.1 PR** provided: only Perl script fix can ideally be backported, but libtestdriver1 should be removed sooner or later, so it's not worth it.
- [x] **mbedtls 3.6 PR** not required because: tf-psa-crypto doesn't exist there and blake2 won't be ported there.
- **tests**  not required because: no code change