### PR TITLE
[1.1] tests: scripts: remove _reference test components

### DIFF
--- a/tests/scripts/components-configuration-crypto.sh
+++ b/tests/scripts/components-configuration-crypto.sh
@@ -1416,9 +1416,6 @@ component_test_psa_crypto_config_accel_hash_use_psa () {
     msg "test: full with accelerated hashes"
     $MAKE_COMMAND test
 
-    # This is mostly useful so that we can later compare outcome files with
-    # the reference config in analyze_outcomes.py, to check that the
-    # dependency declarations in ssl-opt.sh and in TLS code are correct.
     msg "test: ssl-opt.sh, full with accelerated hashes"
     tests/ssl-opt.sh
 
@@ -1443,8 +1440,7 @@ config_psa_crypto_hmac_use_psa () {
         scripts/config.py unset-all MBEDTLS_SHA
     fi
 
-    # Direct dependencies of MD_C. We disable them also in the reference
-    # component to work with the same set of features.
+    # Direct dependencies of MD_C.
     scripts/config.py unset MBEDTLS_PKCS7_C
     scripts/config.py unset MBEDTLS_PKCS5_C
     scripts/config.py unset MBEDTLS_HMAC_DRBG_C

--- a/tests/scripts/components-configuration-crypto.sh
+++ b/tests/scripts/components-configuration-crypto.sh
@@ -1306,53 +1306,6 @@ component_test_new_psa_want_key_pair_symbol () {
 }
 
 component_test_psa_crypto_config_accel_hash () {
-    msg "test: accelerated hash"
-
-    loc_accel_list="ALG_MD5 ALG_RIPEMD160 ALG_SHA_1 \
-                    ALG_SHA_224 ALG_SHA_256 ALG_SHA_384 ALG_SHA_512 \
-                    ALG_SHA3_224 ALG_SHA3_256 ALG_SHA3_384 ALG_SHA3_512"
-
-    # Configure
-    # ---------
-
-    # Start from default config (no USE_PSA)
-    helper_libtestdriver1_adjust_config "default"
-
-    # Build
-    # -----
-
-    helper_libtestdriver1_make_drivers "$loc_accel_list"
-
-    helper_libtestdriver1_make_main "$loc_accel_list"
-
-    # There's a risk of something getting re-enabled via config_psa.h;
-    # make sure it did not happen. Note: it's OK for MD_C to be enabled.
-    not grep mbedtls_md5 ${BUILTIN_SRC_PATH}/md5.o
-    not grep mbedtls_sha1 ${BUILTIN_SRC_PATH}/sha1.o
-    not grep mbedtls_sha256 ${BUILTIN_SRC_PATH}/sha256.o
-    not grep mbedtls_sha512 ${BUILTIN_SRC_PATH}/sha512.o
-    not grep mbedtls_ripemd160 ${BUILTIN_SRC_PATH}/ripemd160.o
-
-    # Run the tests
-    # -------------
-
-    msg "test: accelerated hash"
-    $MAKE_COMMAND test
-}
-
-# Auxiliary function to build config for hashes with and without drivers
-config_psa_crypto_hash () {
-    driver_only="$1"
-    # start with config full for maximum coverage (also enables USE_PSA)
-    helper_libtestdriver1_adjust_config "full"
-    if [ "$driver_only" -eq 1 ]; then
-        # disable the built-in implementation of hashes
-        scripts/config.py unset MBEDTLS_SHA256_USE_ARMV8_A_CRYPTO_IF_PRESENT
-        scripts/config.py unset MBEDTLS_SHA512_USE_A64_CRYPTO_IF_PRESENT
-    fi
-}
-
-component_test_psa_crypto_config_accel_hash () {
     msg "test: full with accelerated hashes"
 
     loc_accel_list="ALG_MD5 ALG_RIPEMD160 ALG_SHA_1 \
@@ -1362,7 +1315,11 @@ component_test_psa_crypto_config_accel_hash () {
     # Configure
     # ---------
 
-    config_psa_crypto_hash 1
+    helper_libtestdriver1_adjust_config "full"
+
+    # disable the built-in implementation of hashes
+    scripts/config.py unset MBEDTLS_SHA256_USE_ARMV8_A_CRYPTO_IF_PRESENT
+    scripts/config.py unset MBEDTLS_SHA512_USE_A64_CRYPTO_IF_PRESENT
 
     # Build
     # -----

--- a/tests/scripts/components-configuration-crypto.sh
+++ b/tests/scripts/components-configuration-crypto.sh
@@ -174,15 +174,6 @@ component_test_rsa_no_crt () {
 
     msg "test: RSA_NO_CRT - main suites (inc. selftests) (ASan build)" # ~ 50s
     make test
-
-    msg "test: RSA_NO_CRT - RSA-related part of ssl-opt.sh (ASan build)" # ~ 5s
-    tests/ssl-opt.sh -f RSA
-
-    msg "test: RSA_NO_CRT - RSA-related part of compat.sh (ASan build)" # ~ 3 min
-    tests/compat.sh -t RSA
-
-    msg "test: RSA_NO_CRT - RSA-related part of context-info.sh (ASan build)" # ~ 15 sec
-    tests/context-info.sh
 }
 
 component_test_no_ctr_drbg () {
@@ -460,13 +451,6 @@ component_test_everest () {
 
     msg "test: metatests (clang, ASan)"
     framework/scripts/run-metatests.sh any asan poison
-
-    msg "test: Everest ECDH context - ECDH-related part of ssl-opt.sh (ASan build)" # ~ 5s
-    tests/ssl-opt.sh -f ECDH
-
-    msg "test: Everest ECDH context - compat.sh with some ECDH ciphersuites (ASan build)" # ~ 3 min
-    # Exclude some symmetric ciphers that are redundant here to gain time.
-    tests/compat.sh -f ECDH -V NO -e 'ARIA\|CAMELLIA\|CHACHA'
 }
 
 component_test_everest_curve25519_only () {
@@ -691,9 +675,6 @@ component_test_psa_crypto_config_accel_ffdh () {
 
     msg "test: full with accelerated FFDH"
     $MAKE_COMMAND test
-
-    msg "ssl-opt: full with accelerated FFDH alg"
-    tests/ssl-opt.sh -f "ffdh"
 }
 
 component_test_psa_crypto_config_accel_pake () {
@@ -943,9 +924,6 @@ component_test_psa_crypto_config_accel_ecc_ecp_light_only () {
 
     msg "test suites: full with accelerated EC algs"
     $MAKE_COMMAND test
-
-    msg "ssl-opt: full with accelerated EC algs"
-    tests/ssl-opt.sh
 }
 
 # Build and test a configuration where driver accelerates all EC algs while
@@ -1004,9 +982,6 @@ component_test_psa_crypto_config_accel_ecc_no_ecp_at_all () {
 
     msg "test: full + accelerated EC algs - ECP"
     $MAKE_COMMAND test
-
-    msg "ssl-opt: full + accelerated EC algs - ECP"
-    tests/ssl-opt.sh
 }
 
 # Common helper used by:
@@ -1106,9 +1081,6 @@ common_test_psa_crypto_config_accel_ecc_ffdh_no_bignum () {
     msg "test suites: full + accelerated $accel_text algs + USE_PSA - $removed_text - BIGNUM"
 
     $MAKE_COMMAND test
-
-    msg "ssl-opt: full + accelerated $accel_text algs + USE_PSA - $removed_text - BIGNUM"
-    tests/ssl-opt.sh
 }
 
 component_test_psa_crypto_config_accel_ecc_no_bignum () {
@@ -1412,14 +1384,6 @@ component_test_psa_crypto_config_accel_hash () {
 
     msg "test: full with accelerated hashes"
     $MAKE_COMMAND test
-
-    msg "test: ssl-opt.sh, full with accelerated hashes"
-    tests/ssl-opt.sh
-
-    # This is to make sure all ciphersuites are exercised, but we don't need
-    # interop testing (besides, we already got some from ssl-opt.sh).
-    msg "test: compat.sh, full with accelerated hashes"
-    tests/compat.sh -p mbedTLS -V YES
 }
 
 # Auxiliary function to build config for hashes with and without drivers
@@ -1553,13 +1517,6 @@ component_test_psa_crypto_config_accel_cipher_aead_cmac () {
 
     msg "test: full config with accelerated cipher inc. AEAD and CMAC"
     $MAKE_COMMAND test
-
-    msg "ssl-opt: full config with accelerated cipher inc. AEAD and CMAC"
-    # Exclude password-protected key tests — they require built-in CBC and AES.
-    tests/ssl-opt.sh -e "TLS: password protected"
-
-    msg "compat.sh: full config with accelerated cipher inc. AEAD and CMAC"
-    tests/compat.sh -V NO -p mbedTLS
 }
 
 common_block_cipher_dispatch () {

--- a/tests/scripts/components-configuration-crypto.sh
+++ b/tests/scripts/components-configuration-crypto.sh
@@ -699,21 +699,6 @@ component_test_psa_crypto_config_accel_ffdh () {
     tests/ssl-opt.sh -f "ffdh"
 }
 
-component_test_psa_crypto_config_reference_ffdh () {
-    msg "build: full with non-accelerated FFDH"
-
-    # Start with full (USE_PSA and TLS 1.3)
-    helper_libtestdriver1_adjust_config "full"
-
-    $MAKE_COMMAND
-
-    msg "test suites: full with non-accelerated FFDH alg"
-    $MAKE_COMMAND test
-
-    msg "ssl-opt: full with non-accelerated FFDH alg"
-    tests/ssl-opt.sh -f "ffdh"
-}
-
 component_test_psa_crypto_config_accel_pake () {
     msg "build: full with accelerated PAKE"
 
@@ -915,19 +900,12 @@ component_test_psa_crypto_config_accel_ecc_non_weierstrass_curves () {
     common_test_psa_crypto_config_accel_ecc_some_curves 0
 }
 
-# Auxiliary function to build config for all EC based algorithms (EC-JPAKE,
-# ECDH, ECDSA) with and without drivers.
-# The input parameter is a boolean value which indicates:
-# - 0 keep built-in EC algs,
-# - 1 exclude built-in EC algs (driver only).
-#
-# This is used by the two following components to ensure they always use the
-# same config, except for the use of driver or built-in EC algorithms:
-# - component_test_psa_crypto_config_accel_ecc_ecp_light_only;
-# - component_test_psa_crypto_config_reference_ecc_ecp_light_only.
-# This supports comparing their test coverage with analyze_outcomes.py.
-config_psa_crypto_config_ecp_light_only () {
-    driver_only="$1"
+component_test_psa_crypto_config_accel_ecc_ecp_light_only () {
+    msg "build: full with accelerated EC algs"
+
+    # Configure
+    # ---------
+
     # start with config full for maximum coverage (also enables USE_PSA)
     helper_libtestdriver1_adjust_config "full"
 
@@ -935,17 +913,6 @@ config_psa_crypto_config_ecp_light_only () {
     # the future, the following line could be removed (see issues
     # 6061, 6332 and following ones)
     scripts/config.py unset MBEDTLS_ECP_RESTARTABLE
-}
-
-# Keep in sync with component_test_psa_crypto_config_reference_ecc_ecp_light_only
-component_test_psa_crypto_config_accel_ecc_ecp_light_only () {
-    msg "build: full with accelerated EC algs"
-
-    # Configure
-    # ---------
-
-    # Use the same config as reference, only without built-in EC algs
-    config_psa_crypto_config_ecp_light_only 1
 
     # Algorithms and key types to accelerate
     loc_accel_list="ALG_ECDSA ALG_DETERMINISTIC_ECDSA \
@@ -984,37 +951,15 @@ component_test_psa_crypto_config_accel_ecc_ecp_light_only () {
     tests/ssl-opt.sh
 }
 
-# Keep in sync with component_test_psa_crypto_config_accel_ecc_ecp_light_only
-component_test_psa_crypto_config_reference_ecc_ecp_light_only () {
-    msg "build: non-accelerated EC algs"
+# Build and test a configuration where driver accelerates all EC algs while
+# all support and dependencies from ECP and ECP_LIGHT are removed on the library
+# side.
+component_test_psa_crypto_config_accel_ecc_no_ecp_at_all () {
+    msg "build: full + accelerated EC algs - ECP"
 
-    config_psa_crypto_config_ecp_light_only 0
+    # Configure
+    # ---------
 
-    cmake -D CMAKE_BUILD_TYPE:String=Release .
-    cmake --build .
-
-    msg "test suites: full with non-accelerated EC algs"
-    ctest
-
-    msg "ssl-opt: full with non-accelerated EC algs"
-    tests/ssl-opt.sh
-}
-
-# This helper function is used by:
-# - component_test_psa_crypto_config_accel_ecc_no_ecp_at_all()
-# - component_test_psa_crypto_config_reference_ecc_no_ecp_at_all()
-# to ensure that both tests use the same underlying configuration when testing
-# driver's coverage with analyze_outcomes.py.
-#
-# This functions accepts 1 boolean parameter as follows:
-# - 1: building with accelerated EC algorithms (ECDSA, ECDH, ECJPAKE), therefore
-#      excluding their built-in implementation as well as ECP_C & ECP_LIGHT
-# - 0: include built-in implementation of EC algorithms.
-#
-# PK_C and RSA_C are always disabled to ensure there is no remaining dependency
-# on the ECP module.
-config_psa_crypto_no_ecp_at_all () {
-    driver_only="$1"
     # start with full config for maximum coverage (also enables USE_PSA)
     helper_libtestdriver1_adjust_config "full"
 
@@ -1027,21 +972,7 @@ config_psa_crypto_no_ecp_at_all () {
     # the future, the following line could be removed (see issues
     # 6061, 6332 and following ones)
     scripts/config.py unset MBEDTLS_ECP_RESTARTABLE
-}
 
-# Build and test a configuration where driver accelerates all EC algs while
-# all support and dependencies from ECP and ECP_LIGHT are removed on the library
-# side.
-#
-# Keep in sync with component_test_psa_crypto_config_reference_ecc_no_ecp_at_all()
-component_test_psa_crypto_config_accel_ecc_no_ecp_at_all () {
-    msg "build: full + accelerated EC algs - ECP"
-
-    # Configure
-    # ---------
-
-    # Set common configurations between library's and driver's builds
-    config_psa_crypto_no_ecp_at_all 1
     # Disable all the builtin curves. All the required algs are accelerated.
     helper_disable_builtin_curves
 
@@ -1081,47 +1012,30 @@ component_test_psa_crypto_config_accel_ecc_no_ecp_at_all () {
     tests/ssl-opt.sh
 }
 
-# Reference function used for driver's coverage analysis in analyze_outcomes.py
-# in conjunction with component_test_psa_crypto_config_accel_ecc_no_ecp_at_all().
-# Keep in sync with its accelerated counterpart.
-component_test_psa_crypto_config_reference_ecc_no_ecp_at_all () {
-    msg "build: full + non accelerated EC algs"
-
-    config_psa_crypto_no_ecp_at_all 0
-
-    cmake -D CMAKE_BUILD_TYPE:String=Release .
-    cmake --build .
-
-    msg "test: full + non accelerated EC algs"
-    ctest
-
-    msg "ssl-opt: full + non accelerated EC algs"
-    tests/ssl-opt.sh
-}
-
-# This is a common configuration helper used directly from:
-# - common_test_psa_crypto_config_accel_ecc_ffdh_no_bignum
-# - common_test_psa_crypto_config_reference_ecc_ffdh_no_bignum
-# and indirectly from:
+# Common helper used by:
 # - component_test_psa_crypto_config_accel_ecc_no_bignum
-#       - accelerate all EC algs, disable RSA and FFDH
-# - component_test_psa_crypto_config_reference_ecc_no_bignum
-#       - this is the reference component of the above
-#       - it still disables RSA and FFDH, but it uses builtin EC algs
 # - component_test_psa_crypto_config_accel_ecc_ffdh_no_bignum
-#       - accelerate all EC and FFDH algs, disable only RSA
-# - component_test_psa_crypto_config_reference_ecc_ffdh_no_bignum
-#       - this is the reference component of the above
-#       - it still disables RSA, but it uses builtin EC and FFDH algs
 #
-# This function accepts 2 parameters:
-# $1: a boolean value which states if we are testing an accelerated scenario
-#     or not.
-# $2: a string value which states which components are tested. Allowed values
-#     are "ECC" or "ECC_DH".
-config_psa_crypto_config_accel_ecc_ffdh_no_bignum () {
-    driver_only="$1"
-    test_target="$2"
+# The goal is to build and test accelerating either:
+# - ECC only or
+# - both ECC and FFDH
+common_test_psa_crypto_config_accel_ecc_ffdh_no_bignum () {
+    test_target="$1"
+
+    # This is an internal helper to simplify text message handling
+    if [ "$test_target" = "ECC_DH" ]; then
+        accel_text="ECC/FFDH"
+        removed_text="ECP - DH"
+    else
+        accel_text="ECC"
+        removed_text="ECP"
+    fi
+
+    msg "build: full + accelerated $accel_text algs + USE_PSA - $removed_text - BIGNUM"
+
+    # Configure
+    # ---------
+
     # start with full config for maximum coverage (also enables USE_PSA)
     helper_libtestdriver1_adjust_config "full"
 
@@ -1150,38 +1064,7 @@ config_psa_crypto_config_accel_ecc_ffdh_no_bignum () {
     # the future, the following line could be removed (see issues
     # 6061, 6332 and following ones)
     scripts/config.py unset MBEDTLS_ECP_RESTARTABLE
-}
 
-# Common helper used by:
-# - component_test_psa_crypto_config_accel_ecc_no_bignum
-# - component_test_psa_crypto_config_accel_ecc_ffdh_no_bignum
-#
-# The goal is to build and test accelerating either:
-# - ECC only or
-# - both ECC and FFDH
-#
-# It is meant to be used in conjunction with
-# common_test_psa_crypto_config_reference_ecc_ffdh_no_bignum() for drivers
-# coverage analysis in the "analyze_outcomes.py" script.
-common_test_psa_crypto_config_accel_ecc_ffdh_no_bignum () {
-    test_target="$1"
-
-    # This is an internal helper to simplify text message handling
-    if [ "$test_target" = "ECC_DH" ]; then
-        accel_text="ECC/FFDH"
-        removed_text="ECP - DH"
-    else
-        accel_text="ECC"
-        removed_text="ECP"
-    fi
-
-    msg "build: full + accelerated $accel_text algs + USE_PSA - $removed_text - BIGNUM"
-
-    # Configure
-    # ---------
-
-    # Set common configurations between library's and driver's builds
-    config_psa_crypto_config_accel_ecc_ffdh_no_bignum 1 "$test_target"
     # Disable all the builtin curves. All the required algs are accelerated.
     helper_disable_builtin_curves
 
@@ -1231,55 +1114,12 @@ common_test_psa_crypto_config_accel_ecc_ffdh_no_bignum () {
     tests/ssl-opt.sh
 }
 
-# Common helper used by:
-# - component_test_psa_crypto_config_reference_ecc_no_bignum
-# - component_test_psa_crypto_config_reference_ecc_ffdh_no_bignum
-#
-# The goal is to build and test a reference scenario (i.e. with builtin
-# components) compared to the ones used in
-# common_test_psa_crypto_config_accel_ecc_ffdh_no_bignum() above.
-#
-# It is meant to be used in conjunction with
-# common_test_psa_crypto_config_accel_ecc_ffdh_no_bignum() for drivers'
-# coverage analysis in "analyze_outcomes.py" script.
-common_test_psa_crypto_config_reference_ecc_ffdh_no_bignum () {
-    test_target="$1"
-
-    # This is an internal helper to simplify text message handling
-    if [ "$test_target" = "ECC_DH" ]; then
-        accel_text="ECC/FFDH"
-    else
-        accel_text="ECC"
-    fi
-
-    msg "build: full + non accelerated $accel_text algs + USE_PSA"
-
-    config_psa_crypto_config_accel_ecc_ffdh_no_bignum 0 "$test_target"
-
-    cmake -D CMAKE_BUILD_TYPE:String=Release .
-    cmake --build .
-
-    msg "test suites: full + non accelerated EC algs + USE_PSA"
-    ctest
-
-    msg "ssl-opt: full + non accelerated $accel_text algs + USE_PSA"
-    tests/ssl-opt.sh
-}
-
 component_test_psa_crypto_config_accel_ecc_no_bignum () {
     common_test_psa_crypto_config_accel_ecc_ffdh_no_bignum "ECC"
 }
 
-component_test_psa_crypto_config_reference_ecc_no_bignum () {
-    common_test_psa_crypto_config_reference_ecc_ffdh_no_bignum "ECC"
-}
-
 component_test_psa_crypto_config_accel_ecc_ffdh_no_bignum () {
     common_test_psa_crypto_config_accel_ecc_ffdh_no_bignum "ECC_DH"
-}
-
-component_test_psa_crypto_config_reference_ecc_ffdh_no_bignum () {
-    common_test_psa_crypto_config_reference_ecc_ffdh_no_bignum "ECC_DH"
 }
 
 component_test_tfm_config_as_is () {
@@ -1453,24 +1293,6 @@ component_test_psa_crypto_config_accel_rsa_crypto () {
     $MAKE_COMMAND test
 }
 
-component_test_psa_crypto_config_reference_rsa_crypto () {
-    msg "build: crypto_full with non-accelerated RSA"
-
-    # Configure
-    # ---------
-    config_psa_crypto_accel_rsa 0
-
-    # Build
-    # -----
-    cmake -D CMAKE_BUILD_TYPE:String=Release .
-    cmake --build .
-
-    # Run the tests
-    # -------------
-    msg "test: crypto_full with non-accelerated RSA"
-    ctest
-}
-
 # This is a temporary test to verify that full RSA support is present even when
 # only one single new symbols (PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_BASIC) is defined.
 component_test_new_psa_want_key_pair_symbol () {
@@ -1561,9 +1383,6 @@ config_psa_crypto_hash_use_psa () {
     fi
 }
 
-# Note that component_test_psa_crypto_config_reference_hash_use_psa
-# is related to this component and both components need to be kept in sync.
-# For details please see comments for component_test_psa_crypto_config_reference_hash_use_psa.
 component_test_psa_crypto_config_accel_hash_use_psa () {
     msg "test: full with accelerated hashes"
 
@@ -1607,25 +1426,6 @@ component_test_psa_crypto_config_accel_hash_use_psa () {
     # interop testing (besides, we already got some from ssl-opt.sh).
     msg "test: compat.sh, full with accelerated hashes"
     tests/compat.sh -p mbedTLS -V YES
-}
-
-# This component provides reference configuration for test_psa_crypto_config_accel_hash_use_psa
-# without accelerated hash. The outcome from both components are used by the analyze_outcomes.py
-# script to find regression in test coverage when accelerated hash is used (tests and ssl-opt).
-# Both components need to be kept in sync.
-component_test_psa_crypto_config_reference_hash_use_psa () {
-    msg "test: full without accelerated hashes"
-
-    config_psa_crypto_hash_use_psa 0
-
-    cmake -D CMAKE_BUILD_TYPE:String=Release .
-    cmake --build .
-
-    msg "test: full without accelerated hashes"
-    ctest
-
-    msg "test: ssl-opt.sh, full without accelerated hashes"
-    tests/ssl-opt.sh
 }
 
 # Auxiliary function to build config for hashes with and without drivers
@@ -1687,18 +1487,6 @@ component_test_psa_crypto_config_accel_hmac () {
     $MAKE_COMMAND test
 }
 
-component_test_psa_crypto_config_reference_hmac () {
-    msg "test: full without accelerated hmac"
-
-    config_psa_crypto_hmac_use_psa 0
-
-    cmake -D CMAKE_BUILD_TYPE:String=Release .
-    cmake --build .
-
-    msg "test: full without accelerated hmac"
-    ctest
-}
-
 component_test_psa_crypto_config_accel_aead () {
     msg "test: accelerated AEAD"
 
@@ -1733,21 +1521,6 @@ component_test_psa_crypto_config_accel_aead () {
     $MAKE_COMMAND test
 }
 
-# This is a common configuration function used in:
-# - component_test_psa_crypto_config_accel_cipher_aead_cmac
-# - component_test_psa_crypto_config_reference_cipher_aead_cmac
-common_psa_crypto_config_accel_cipher_aead_cmac () {
-    # Start from the full config
-    helper_libtestdriver1_adjust_config "full"
-
-    scripts/config.py unset MBEDTLS_NIST_KW_C
-}
-
-# The 2 following test components, i.e.
-# - component_test_psa_crypto_config_accel_cipher_aead_cmac
-# - component_test_psa_crypto_config_reference_cipher_aead_cmac
-# are meant to be used together in analyze_outcomes.py script in order to test
-# driver's coverage for ciphers and AEADs.
 component_test_psa_crypto_config_accel_cipher_aead_cmac () {
     msg "build: full config with accelerated cipher inc. AEAD and CMAC"
 
@@ -1759,7 +1532,10 @@ component_test_psa_crypto_config_accel_cipher_aead_cmac () {
     # Configure
     # ---------
 
-    common_psa_crypto_config_accel_cipher_aead_cmac
+    # Start from the full config
+    helper_libtestdriver1_adjust_config "full"
+
+    scripts/config.py unset MBEDTLS_NIST_KW_C
 
     # Build
     # -----
@@ -1790,24 +1566,6 @@ component_test_psa_crypto_config_accel_cipher_aead_cmac () {
     tests/ssl-opt.sh -e "TLS: password protected"
 
     msg "compat.sh: full config with accelerated cipher inc. AEAD and CMAC"
-    tests/compat.sh -V NO -p mbedTLS
-}
-
-component_test_psa_crypto_config_reference_cipher_aead_cmac () {
-    msg "build: full config with non-accelerated cipher inc. AEAD and CMAC"
-    common_psa_crypto_config_accel_cipher_aead_cmac
-
-    cmake -D CMAKE_BUILD_TYPE:String=Release .
-    cmake --build .
-
-    msg "test: full config with non-accelerated cipher inc. AEAD and CMAC"
-    ctest
-
-    msg "ssl-opt: full config with non-accelerated cipher inc. AEAD and CMAC"
-    # Exclude password-protected key tests as in test_psa_crypto_config_accel_cipher_aead_cmac.
-    tests/ssl-opt.sh -e "TLS: password protected"
-
-    msg "compat.sh: full config with non-accelerated cipher inc. AEAD and CMAC"
     tests/compat.sh -V NO -p mbedTLS
 }
 

--- a/tests/scripts/components-configuration-crypto.sh
+++ b/tests/scripts/components-configuration-crypto.sh
@@ -19,7 +19,7 @@ component_test_psa_crypto_key_id_encodes_owner () {
     CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
     make
 
-    msg "test: full config - USE_PSA_CRYPTO + PSA_CRYPTO_KEY_ID_ENCODES_OWNER, cmake, gcc, ASan"
+    msg "test: full config + PSA_CRYPTO_KEY_ID_ENCODES_OWNER, cmake, gcc, ASan"
     make test
 }
 
@@ -185,29 +185,29 @@ component_test_rsa_no_crt () {
     tests/context-info.sh
 }
 
-component_test_no_ctr_drbg_use_psa () {
-    msg "build: Full minus CTR_DRBG, PSA crypto in TLS"
+component_test_no_ctr_drbg () {
+    msg "build: Full minus CTR_DRBG"
     scripts/config.py full
     scripts/config.py unset MBEDTLS_CTR_DRBG_C
 
     CC=$ASAN_CC cmake -D CMAKE_BUILD_TYPE:String=Asan .
     make
 
-    msg "test: Full minus CTR_DRBG, USE_PSA_CRYPTO - main suites"
+    msg "test: Full minus CTR_DRBG - main suites"
     make test
 
     # In this configuration, the TLS test programs use HMAC_DRBG.
     # The SSL tests are slow, so run a small subset, just enough to get
     # confidence that the SSL code copes with HMAC_DRBG.
-    msg "test: Full minus CTR_DRBG, USE_PSA_CRYPTO - ssl-opt.sh (subset)"
+    msg "test: Full minus CTR_DRBG - ssl-opt.sh (subset)"
     tests/ssl-opt.sh -f 'Default\|SSL async private.*delay=\|tickets enabled on server'
 
-    msg "test: Full minus CTR_DRBG, USE_PSA_CRYPTO - compat.sh (subset)"
+    msg "test: Full minus CTR_DRBG - compat.sh (subset)"
     tests/compat.sh -m tls12 -t 'ECDSA PSK' -V NO -p OpenSSL
 }
 
-component_test_no_hmac_drbg_use_psa () {
-    msg "build: Full minus HMAC_DRBG, PSA crypto in TLS"
+component_test_no_hmac_drbg () {
+    msg "build: Full minus HMAC_DRBG"
     scripts/config.py full
     scripts/config.py unset MBEDTLS_HMAC_DRBG_C
     scripts/config.py unset PSA_WANT_ALG_DETERMINISTIC_ECDSA # requires HMAC_DRBG
@@ -215,7 +215,7 @@ component_test_no_hmac_drbg_use_psa () {
     CC=$ASAN_CC cmake -D CMAKE_BUILD_TYPE:String=Asan .
     make
 
-    msg "test: Full minus HMAC_DRBG, USE_PSA_CRYPTO - main suites"
+    msg "test: Full minus HMAC_DRBG - main suites"
     make test
 
     # Normally our ECDSA implementation uses deterministic ECDSA. But since
@@ -223,17 +223,17 @@ component_test_no_hmac_drbg_use_psa () {
     # instead.
     # Test SSL with non-deterministic ECDSA. Only test features that
     # might be affected by how ECDSA signature is performed.
-    msg "test: Full minus HMAC_DRBG, USE_PSA_CRYPTO - ssl-opt.sh (subset)"
+    msg "test: Full minus HMAC_DRBG - ssl-opt.sh (subset)"
     tests/ssl-opt.sh -f 'Default\|SSL async private: sign'
 
     # To save time, only test one protocol version, since this part of
     # the protocol is identical in (D)TLS up to 1.2.
-    msg "test: Full minus HMAC_DRBG, USE_PSA_CRYPTO - compat.sh (ECDSA)"
+    msg "test: Full minus HMAC_DRBG - compat.sh (ECDSA)"
     tests/compat.sh -m tls12 -t 'ECDSA'
 }
 
-component_test_psa_external_rng_no_drbg_use_psa () {
-    msg "build: PSA_CRYPTO_EXTERNAL_RNG minus *_DRBG, PSA crypto in TLS"
+component_test_psa_external_rng_no_drbg () {
+    msg "build: PSA_CRYPTO_EXTERNAL_RNG minus *_DRBG"
     scripts/config.py full
     scripts/config.py set MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG
     scripts/config.py unset MBEDTLS_ENTROPY_NV_SEED
@@ -245,15 +245,15 @@ component_test_psa_external_rng_no_drbg_use_psa () {
     CC=$ASAN_CC cmake -D CMAKE_BUILD_TYPE:String=Asan .
     cmake --build .
 
-    msg "test: PSA_CRYPTO_EXTERNAL_RNG minus *_DRBG, PSA crypto - main suites"
+    msg "test: PSA_CRYPTO_EXTERNAL_RNG minus *_DRBG - main suites"
     ctest
 
-    msg "test: PSA_CRYPTO_EXTERNAL_RNG minus *_DRBG, PSA crypto - ssl-opt.sh (subset)"
+    msg "test: PSA_CRYPTO_EXTERNAL_RNG minus *_DRBG - ssl-opt.sh (subset)"
     tests/ssl-opt.sh -f 'Default\|opaque'
 }
 
-component_test_psa_external_rng_use_psa_crypto () {
-    msg "build: full + PSA_CRYPTO_EXTERNAL_RNG + USE_PSA_CRYPTO minus CTR_DRBG/NV_SEED"
+component_test_psa_external_rng () {
+    msg "build: full + PSA_CRYPTO_EXTERNAL_RNG minus CTR_DRBG/NV_SEED"
     scripts/config.py full
     scripts/config.py set MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG
     scripts/config.py unset MBEDTLS_CTR_DRBG_C
@@ -263,10 +263,10 @@ component_test_psa_external_rng_use_psa_crypto () {
     CC=$ASAN_CC cmake -D CMAKE_BUILD_TYPE:String=Asan .
     cmake --build .
 
-    msg "test: full + PSA_CRYPTO_EXTERNAL_RNG + USE_PSA_CRYPTO minus CTR_DRBG/NV_SEED"
+    msg "test: full + PSA_CRYPTO_EXTERNAL_RNG minus CTR_DRBG/NV_SEED"
     ctest
 
-    msg "test: full + PSA_CRYPTO_EXTERNAL_RNG + USE_PSA_CRYPTO minus CTR_DRBG/NV_SEED"
+    msg "test: full + PSA_CRYPTO_EXTERNAL_RNG minus CTR_DRBG/NV_SEED"
     tests/ssl-opt.sh -f 'Default\|opaque'
 }
 
@@ -386,9 +386,6 @@ component_test_full_no_cipher () {
 component_test_full_no_ccm () {
     msg "build: full no PSA_WANT_ALG_CCM"
 
-    # Full config enables:
-    # - USE_PSA_CRYPTO so that TLS code dispatches cipher/AEAD to PSA
-    # - CRYPTO_CONFIG so that PSA_WANT config symbols are evaluated
     scripts/config.py full
 
     # Disable PSA_WANT_ALG_CCM so that CCM is not supported in PSA. CCM_C is still
@@ -1372,7 +1369,7 @@ component_test_psa_crypto_config_accel_hash () {
 }
 
 # Auxiliary function to build config for hashes with and without drivers
-config_psa_crypto_hash_use_psa () {
+config_psa_crypto_hash () {
     driver_only="$1"
     # start with config full for maximum coverage (also enables USE_PSA)
     helper_libtestdriver1_adjust_config "full"
@@ -1383,7 +1380,7 @@ config_psa_crypto_hash_use_psa () {
     fi
 }
 
-component_test_psa_crypto_config_accel_hash_use_psa () {
+component_test_psa_crypto_config_accel_hash () {
     msg "test: full with accelerated hashes"
 
     loc_accel_list="ALG_MD5 ALG_RIPEMD160 ALG_SHA_1 \
@@ -1393,7 +1390,7 @@ component_test_psa_crypto_config_accel_hash_use_psa () {
     # Configure
     # ---------
 
-    config_psa_crypto_hash_use_psa 1
+    config_psa_crypto_hash 1
 
     # Build
     # -----
@@ -1426,7 +1423,7 @@ component_test_psa_crypto_config_accel_hash_use_psa () {
 }
 
 # Auxiliary function to build config for hashes with and without drivers
-config_psa_crypto_hmac_use_psa () {
+config_psa_crypto_hmac () {
     driver_only="$1"
     # start with config full for maximum coverage (also enables USE_PSA)
     helper_libtestdriver1_adjust_config "full"
@@ -1460,7 +1457,7 @@ component_test_psa_crypto_config_accel_hmac () {
     # Configure
     # ---------
 
-    config_psa_crypto_hmac_use_psa 1
+    config_psa_crypto_hmac 1
 
     # Build
     # -----


### PR DESCRIPTION
## Description

Backport of https://github.com/Mbed-TLS/mbedtls/pull/10848

I just cherry-picked all the commits from the main PR. No other change applied.

## PR checklist

- [x] **changelog** not required because: same as in main PR
- [x] **framework PR** not required
- [x] **TF-PSA-Crypto development PR** not required because: same as in main PR
- [x] **TF-PSA-Crypto 1.1 PR** not required because: same as in main PR
- [x] **mbedtls development PR** provided: https://github.com/Mbed-TLS/mbedtls/pull/10848
- [x] **mbedtls 4.1 PR** provided: this one 
- [x] **mbedtls 3.6 PR** not required because: same as in main PR
- **tests**  not required because:  same as in main PR