### PR TITLE
Make installable pqcp headers available to the libtestdriver1 build

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -243,6 +243,8 @@ libtestdriver1.a:
 	cp -Rf ../tf-psa-crypto/core ./libtestdriver1/tf-psa-crypto
 	cp -Rf ../tf-psa-crypto/include ./libtestdriver1/tf-psa-crypto
 	cp -Rf ../tf-psa-crypto/drivers/builtin ./libtestdriver1/tf-psa-crypto/drivers/builtin
+	# Make installable pqcp headers available to the libtestdriver1 build
+	cp -Rf ../tf-psa-crypto/drivers/pqcp/include ./libtestdriver1/tf-psa-crypto/
 	if [ -d ../tf-psa-crypto/dispatch ]; then \
 	    cp -Rf ../tf-psa-crypto/dispatch ./libtestdriver1/tf-psa-crypto/dispatch; \
 	fi


### PR DESCRIPTION
Needed for https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/871

## PR checklist

- [x] **changelog** not required because:internal stuff
- [x] **framework PR** not required
- [x] **TF-PSA-Crypto development PR** not required because: old-style libtestdriver1 only
- [x] **TF-PSA-Crypto 1.1 PR** not required because: development only
- [x] **mbedtls development PR** provided here
- [x] **mbedtls 4.1 PR** not required because: development only
- [x] **mbedtls 3.6 PR** not required because: development only
- **tests**  provided
