### PR TITLE
Restore __cplusplus guard absent from oid.h

### DIFF
--- a/include/mbedtls/oid.h
+++ b/include/mbedtls/oid.h
@@ -265,6 +265,10 @@
  *   ecdsa-with-SHA2(3) 4 } */
 #define MBEDTLS_OID_ECDSA_SHA512            MBEDTLS_OID_ANSI_X9_62_SIG_SHA2 "\x04"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if defined(MBEDTLS_X509_USE_C)
 /**
  * \brief           Translate an ASN.1 OID into its numeric representation
@@ -300,5 +304,9 @@ int mbedtls_oid_get_numeric_string(char *buf, size_t size, const mbedtls_asn1_bu
  */
 int mbedtls_oid_from_numeric_string(mbedtls_asn1_buf *oid, const char *oid_str, size_t size);
 #endif /* MBEDTLS_X509_CREATE_C */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* oid.h */


### PR DESCRIPTION
## Description

Since release 4.0.0, `mbedtls/oid.h` no longer includes an `extern "C"` guard for when the header is used from C++ code. This makes such C++ code fail to compile with an undefined reference error unless manually wrapped in `extern C`. I've had this happen in an ESP-IDF project.

This appears to be a regression, as the guard was present up until and including this commit:
https://github.com/Mbed-TLS/mbedtls/blob/791fc2e24c079a96f3149919747ebcc1f88f0bf3/include/mbedtls/oid.h#L469

Since this looked like a rather rudimentary bug to fix, I've created this PR to restore the appropriate preprocessor guards to the file. I apologize if this should have been an issue first, it did not appear necessary to me to create one for such a tiny little thing.

## PR checklist

- [x] **changelog** not required because of the fix being overly trivial to mention
- [x] **framework PR** - not applicable
- [x] **TF-PSA-Crypto development PR** - not applicable
- [x] **TF-PSA-Crypto 1.1 PR** - not applicable
- [x] **mbedtls development PR** provided **here**
- [x] **mbedtls 4.1 PR** provided in #10940 
- [x] **mbedtls 3.6 PR** not required because this issue did not exist in 3.x
- **tests**  not required because this is a preprocessor guard, not a feature
