### PR TITLE
Fix PSA initialisation in client fuzzers

### DIFF
--- a/ChangeLog.d/fix-client-fuzzing.txt
+++ b/ChangeLog.d/fix-client-fuzzing.txt
@@ -1,0 +1,3 @@
+Bugfix
+	* Call to `psa_crypto_init()` before parsing the test CA certificate in the
+	  fuzzing programs for TLS and DTLS clients.

--- a/programs/fuzz/fuzz_client.c
+++ b/programs/fuzz/fuzz_client.c
@@ -37,6 +37,11 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
     fuzzBufferOffset_t biomemfuzz;
     uint16_t options;
 
+    psa_status_t status = psa_crypto_init();
+    if (status != PSA_SUCCESS) {
+        goto exit;
+    }
+
     if (initialized == 0) {
 #if defined(MBEDTLS_X509_CRT_PARSE_C) && defined(MBEDTLS_PEM_PARSE_C)
         mbedtls_x509_crt_init(&cacert);
@@ -65,11 +70,6 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 
     mbedtls_ssl_init(&ssl);
     mbedtls_ssl_config_init(&conf);
-
-    psa_status_t status = psa_crypto_init();
-    if (status != PSA_SUCCESS) {
-        goto exit;
-    }
 
     if (mbedtls_ssl_config_defaults(&conf,
                                     MBEDTLS_SSL_IS_CLIENT,

--- a/programs/fuzz/fuzz_dtlsclient.c
+++ b/programs/fuzz/fuzz_dtlsclient.c
@@ -33,6 +33,11 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
     unsigned char buf[4096];
     fuzzBufferOffset_t biomemfuzz;
 
+    psa_status_t status = psa_crypto_init();
+    if (status != PSA_SUCCESS) {
+        goto exit;
+    }
+
     if (initialized == 0) {
 #if defined(MBEDTLS_X509_CRT_PARSE_C) && defined(MBEDTLS_PEM_PARSE_C)
         mbedtls_x509_crt_init(&cacert);
@@ -48,11 +53,6 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 
     mbedtls_ssl_init(&ssl);
     mbedtls_ssl_config_init(&conf);
-
-    psa_status_t status = psa_crypto_init();
-    if (status != PSA_SUCCESS) {
-        goto exit;
-    }
 
     if (mbedtls_ssl_config_defaults(&conf,
                                     MBEDTLS_SSL_IS_CLIENT,


### PR DESCRIPTION
## Description

The fuzzer programs for TLS and DTLS incorrectly initialised the PSA subsystem later than required, leading to a failure that broke the fuzzer. On the first call to the program, an initialisation clause parses a CA certificate. This initialisation happens _before_ the call to `psa_crypto_init()`. This PR moves the call to `psa_crypto_init()` before the certificate parsing.

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [ ] **changelog** provided | not required because:
- [x] **framework PR** not required because: this only affects the fuzzer programs.
- [x] **TF-PSA-Crypto development PR** not required because: this only affects the fuzzer programs.
- [x] **TF-PSA-Crypto 1.1 PR** not required because: this only affects the fuzzer programs.
- [x] **mbedtls development PR** provided: this PR.
- [ ] **mbedtls 4.1 PR** provided # | not required because:
- [ ] **mbedtls 3.6 PR** provided # | not required because:
- **tests** not required because:


## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
