### PR TITLE
Backport 4.1: Cmake custom compile-time config support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,13 +139,24 @@ set(MBEDTLS_CONFIG_SET "" CACHE STRING "Options to set, separated by semicolons 
 set(MBEDTLS_CONFIG_UNSET "" CACHE STRING "Options to unset, separated by semicolons.")
 
 if(MBEDTLS_CONFIG_NAME OR MBEDTLS_CONFIG_SET OR MBEDTLS_CONFIG_UNSET)
-    if(MBEDTLS_CONFIG_FILE)
-        message(FATAL_ERROR
-            "MBEDTLS_CONFIG_FILE cannot be combined with MBEDTLS_CONFIG_NAME, "
-            "MBEDTLS_CONFIG_SET or MBEDTLS_CONFIG_UNSET.")
-    endif()
     if(NOT MBEDTLS_PYTHON_EXECUTABLE)
         message(FATAL_ERROR "Python 3 is required to generate an Mbed TLS configuration file.")
+    endif()
+
+    if(MBEDTLS_CONFIG_FILE)
+        set(MBEDTLS_BASE_CONFIG_FILE "${MBEDTLS_CONFIG_FILE}")
+        if(NOT EXISTS "${MBEDTLS_BASE_CONFIG_FILE}")
+            file(RELATIVE_PATH MBEDTLS_CONFIG_FILE_RELATIVE
+                 "${CMAKE_CURRENT_BINARY_DIR}" "${MBEDTLS_CONFIG_FILE}")
+            set(MBEDTLS_BASE_CONFIG_FILE
+                "${CMAKE_CURRENT_SOURCE_DIR}/${MBEDTLS_CONFIG_FILE_RELATIVE}")
+        endif()
+    else()
+        set(MBEDTLS_BASE_CONFIG_FILE
+            "${CMAKE_CURRENT_SOURCE_DIR}/include/mbedtls/mbedtls_config.h")
+    endif()
+    if(NOT EXISTS "${MBEDTLS_BASE_CONFIG_FILE}")
+        message(FATAL_ERROR "Mbed TLS configuration file not found: ${MBEDTLS_BASE_CONFIG_FILE}")
     endif()
 
     set(MBEDTLS_GENERATED_CONFIG_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated/include")
@@ -153,8 +164,8 @@ if(MBEDTLS_CONFIG_NAME OR MBEDTLS_CONFIG_SET OR MBEDTLS_CONFIG_UNSET)
     set(MBEDTLS_GENERATED_CRYPTO_CONFIG_FILE "${MBEDTLS_GENERATED_CONFIG_DIR}/psa/crypto_config.h")
     file(MAKE_DIRECTORY "${MBEDTLS_GENERATED_CONFIG_DIR}/mbedtls")
     file(MAKE_DIRECTORY "${MBEDTLS_GENERATED_CONFIG_DIR}/psa")
-    file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/include/mbedtls/mbedtls_config.h"
-         DESTINATION "${MBEDTLS_GENERATED_CONFIG_DIR}/mbedtls")
+    configure_file("${MBEDTLS_BASE_CONFIG_FILE}"
+                   "${MBEDTLS_GENERATED_CONFIG_FILE}" COPYONLY)
     # config.py handles the Mbed TLS and PSA configurations together. Give it
     # a build-tree PSA configuration so that it never modifies the source tree.
     file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/tf-psa-crypto/include/psa/crypto_config.h"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,6 +134,71 @@ endif()
 # Make MBEDTLS_CONFIG_FILE and MBEDTLS_USER_CONFIG_FILE into PATHs
 set(MBEDTLS_CONFIG_FILE "" CACHE FILEPATH "Mbed TLS config file (overrides default).")
 set(MBEDTLS_USER_CONFIG_FILE "" CACHE FILEPATH "Mbed TLS user config file (appended to default).")
+set(MBEDTLS_CONFIG_NAME "" CACHE STRING "Named Mbed TLS configuration (see config.py).")
+set(MBEDTLS_CONFIG_SET "" CACHE STRING "Options to set, separated by semicolons (OPTION or OPTION=VALUE).")
+set(MBEDTLS_CONFIG_UNSET "" CACHE STRING "Options to unset, separated by semicolons.")
+
+if(MBEDTLS_CONFIG_NAME OR MBEDTLS_CONFIG_SET OR MBEDTLS_CONFIG_UNSET)
+    if(MBEDTLS_CONFIG_FILE)
+        message(FATAL_ERROR
+            "MBEDTLS_CONFIG_FILE cannot be combined with MBEDTLS_CONFIG_NAME, "
+            "MBEDTLS_CONFIG_SET or MBEDTLS_CONFIG_UNSET.")
+    endif()
+    if(NOT MBEDTLS_PYTHON_EXECUTABLE)
+        message(FATAL_ERROR "Python 3 is required to generate an Mbed TLS configuration file.")
+    endif()
+
+    set(MBEDTLS_GENERATED_CONFIG_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated/include")
+    set(MBEDTLS_GENERATED_CONFIG_FILE "${MBEDTLS_GENERATED_CONFIG_DIR}/mbedtls/mbedtls_config.h")
+    set(MBEDTLS_GENERATED_CRYPTO_CONFIG_FILE "${MBEDTLS_GENERATED_CONFIG_DIR}/psa/crypto_config.h")
+    file(MAKE_DIRECTORY "${MBEDTLS_GENERATED_CONFIG_DIR}/mbedtls")
+    file(MAKE_DIRECTORY "${MBEDTLS_GENERATED_CONFIG_DIR}/psa")
+    file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/include/mbedtls/mbedtls_config.h"
+         DESTINATION "${MBEDTLS_GENERATED_CONFIG_DIR}/mbedtls")
+    # config.py handles the Mbed TLS and PSA configurations together. Give it
+    # a build-tree PSA configuration so that it never modifies the source tree.
+    file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/tf-psa-crypto/include/psa/crypto_config.h"
+         DESTINATION "${MBEDTLS_GENERATED_CONFIG_DIR}/psa")
+
+    function(mbedtls_configure_generated_file)
+        execute_process(
+            COMMAND
+                ${MBEDTLS_PYTHON_EXECUTABLE}
+                "${CMAKE_CURRENT_SOURCE_DIR}/scripts/config.py"
+                --file "${MBEDTLS_GENERATED_CONFIG_FILE}"
+                --cryptofile "${MBEDTLS_GENERATED_CRYPTO_CONFIG_FILE}"
+                ${ARGN}
+            RESULT_VARIABLE result
+        )
+        if(result)
+            message(FATAL_ERROR "Failed to configure the generated Mbed TLS configuration file")
+        endif()
+    endfunction(mbedtls_configure_generated_file)
+
+    if(MBEDTLS_CONFIG_NAME)
+        mbedtls_configure_generated_file("${MBEDTLS_CONFIG_NAME}")
+    endif()
+    foreach(option IN LISTS MBEDTLS_CONFIG_UNSET)
+        mbedtls_configure_generated_file(unset "${option}")
+    endforeach(option)
+    foreach(option IN LISTS MBEDTLS_CONFIG_SET)
+        string(FIND "${option}" "=" separator)
+        if(separator EQUAL -1)
+            mbedtls_configure_generated_file(--force set "${option}")
+        else()
+            string(SUBSTRING "${option}" 0 ${separator} name)
+            math(EXPR value_start "${separator} + 1")
+            string(SUBSTRING "${option}" ${value_start} -1 value)
+            mbedtls_configure_generated_file(--force set "${name}" "${value}")
+        endif()
+    endforeach(option)
+
+    set(MBEDTLS_CONFIG_FILE "${MBEDTLS_GENERATED_CONFIG_FILE}")
+    if(NOT TF_PSA_CRYPTO_CONFIG_FILE AND NOT TF_PSA_CRYPTO_CONFIG_NAME)
+        # Named configurations can adjust both configuration files.
+        set(TF_PSA_CRYPTO_CONFIG_FILE "${MBEDTLS_GENERATED_CRYPTO_CONFIG_FILE}")
+    endif()
+endif()
 
 # Create a symbolic link from ${base_name} in the binary directory
 # to the corresponding path in the source directory.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,10 +134,11 @@ endif()
 # Make configuration file options into PATHs
 set(MBEDTLS_CONFIG_FILE "" CACHE FILEPATH "Mbed TLS config file (overrides default).")
 set(MBEDTLS_USER_CONFIG_FILE "" CACHE FILEPATH "Mbed TLS user config file (appended to default).")
-set(MBEDTLS_CONFIG_BASE_FILE "" CACHE STRING "Mbed TLS config to copy and optionally transform.")
+set(MBEDTLS_CONFIG_BASE_FILE "" CACHE FILEPATH "Mbed TLS config to copy and optionally transform.")
 set(MBEDTLS_CONFIG_NAME "" CACHE STRING "Named Mbed TLS configuration (see config.py).")
 set(MBEDTLS_CONFIG_SET "" CACHE STRING "Options to set, separated by semicolons (OPTION or OPTION=VALUE).")
 set(MBEDTLS_CONFIG_UNSET "" CACHE STRING "Options to unset, separated by semicolons.")
+set(TF_PSA_CRYPTO_CONFIG_BASE_FILE "" CACHE FILEPATH "TF-PSA-Crypto config to copy and optionally transform.")
 
 set(MBEDTLS_CONFIG_TRANSFORMED FALSE)
 if(NOT "${MBEDTLS_CONFIG_NAME}" STREQUAL "" OR
@@ -182,9 +183,13 @@ if(NOT "${MBEDTLS_CONFIG_BASE_FILE}" STREQUAL "" OR
     endif()
 
     if(NOT "${MBEDTLS_CONFIG_BASE_FILE}" STREQUAL "")
-        get_filename_component(MBEDTLS_BASE_CONFIG_FILE
-            "${MBEDTLS_CONFIG_BASE_FILE}" ABSOLUTE
-            BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+        set(MBEDTLS_BASE_CONFIG_FILE "${MBEDTLS_CONFIG_BASE_FILE}")
+        if(NOT EXISTS "${MBEDTLS_BASE_CONFIG_FILE}")
+            file(RELATIVE_PATH MBEDTLS_CONFIG_BASE_FILE_RELATIVE
+                 "${CMAKE_CURRENT_BINARY_DIR}" "${MBEDTLS_CONFIG_BASE_FILE}")
+            set(MBEDTLS_BASE_CONFIG_FILE
+                "${CMAKE_CURRENT_SOURCE_DIR}/${MBEDTLS_CONFIG_BASE_FILE_RELATIVE}")
+        endif()
     else()
         set(MBEDTLS_BASE_CONFIG_FILE
             "${CMAKE_CURRENT_SOURCE_DIR}/include/mbedtls/mbedtls_config.h")
@@ -201,9 +206,15 @@ if(NOT "${MBEDTLS_CONFIG_BASE_FILE}" STREQUAL "" OR
 
     if(MBEDTLS_CONFIG_TRANSFORMED)
         if(NOT "${TF_PSA_CRYPTO_CONFIG_BASE_FILE}" STREQUAL "")
-            get_filename_component(MBEDTLS_BASE_CRYPTO_CONFIG_FILE
-                "${TF_PSA_CRYPTO_CONFIG_BASE_FILE}" ABSOLUTE
-                BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+            set(MBEDTLS_BASE_CRYPTO_CONFIG_FILE
+                "${TF_PSA_CRYPTO_CONFIG_BASE_FILE}")
+            if(NOT EXISTS "${MBEDTLS_BASE_CRYPTO_CONFIG_FILE}")
+                file(RELATIVE_PATH TF_PSA_CRYPTO_CONFIG_BASE_FILE_RELATIVE
+                     "${CMAKE_CURRENT_BINARY_DIR}"
+                     "${TF_PSA_CRYPTO_CONFIG_BASE_FILE}")
+                set(MBEDTLS_BASE_CRYPTO_CONFIG_FILE
+                    "${CMAKE_CURRENT_SOURCE_DIR}/${TF_PSA_CRYPTO_CONFIG_BASE_FILE_RELATIVE}")
+            endif()
         else()
             set(MBEDTLS_BASE_CRYPTO_CONFIG_FILE
                 "${CMAKE_CURRENT_SOURCE_DIR}/tf-psa-crypto/include/psa/crypto_config.h")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,7 +134,7 @@ endif()
 # Make configuration file options into PATHs
 set(MBEDTLS_CONFIG_FILE "" CACHE FILEPATH "Mbed TLS config file (overrides default).")
 set(MBEDTLS_USER_CONFIG_FILE "" CACHE FILEPATH "Mbed TLS user config file (appended to default).")
-set(MBEDTLS_CONFIG_BASE_FILE "" CACHE FILEPATH "Mbed TLS config to copy and optionally transform.")
+set(MBEDTLS_CONFIG_BASE_FILE "" CACHE STRING "Mbed TLS config to copy and optionally transform.")
 set(MBEDTLS_CONFIG_NAME "" CACHE STRING "Named Mbed TLS configuration (see config.py).")
 set(MBEDTLS_CONFIG_SET "" CACHE STRING "Options to set, separated by semicolons (OPTION or OPTION=VALUE).")
 set(MBEDTLS_CONFIG_UNSET "" CACHE STRING "Options to unset, separated by semicolons.")
@@ -157,15 +157,9 @@ if(NOT "${MBEDTLS_CONFIG_FILE}" STREQUAL "" AND
 endif()
 
 if(MBEDTLS_CONFIG_TRANSFORMED AND
-   (NOT "${TF_PSA_CRYPTO_CONFIG_FILE}" STREQUAL "" OR
-    NOT "${TF_PSA_CRYPTO_CONFIG_BASE_FILE}" STREQUAL "" OR
-    NOT "${TF_PSA_CRYPTO_CONFIG_NAME}" STREQUAL "" OR
-    NOT "${TF_PSA_CRYPTO_CONFIG_SET}" STREQUAL "" OR
-    NOT "${TF_PSA_CRYPTO_CONFIG_UNSET}" STREQUAL ""))
+   NOT "${TF_PSA_CRYPTO_CONFIG_FILE}" STREQUAL "")
     message(FATAL_ERROR
-        "TF_PSA_CRYPTO_CONFIG_FILE, TF_PSA_CRYPTO_CONFIG_BASE_FILE, "
-        "TF_PSA_CRYPTO_CONFIG_NAME, TF_PSA_CRYPTO_CONFIG_SET and "
-        "TF_PSA_CRYPTO_CONFIG_UNSET cannot be combined with "
+        "TF_PSA_CRYPTO_CONFIG_FILE cannot be combined with "
         "MBEDTLS_CONFIG_NAME, MBEDTLS_CONFIG_SET or MBEDTLS_CONFIG_UNSET.")
 endif()
 
@@ -188,13 +182,9 @@ if(NOT "${MBEDTLS_CONFIG_BASE_FILE}" STREQUAL "" OR
     endif()
 
     if(NOT "${MBEDTLS_CONFIG_BASE_FILE}" STREQUAL "")
-        set(MBEDTLS_BASE_CONFIG_FILE "${MBEDTLS_CONFIG_BASE_FILE}")
-        if(NOT EXISTS "${MBEDTLS_BASE_CONFIG_FILE}")
-            file(RELATIVE_PATH MBEDTLS_CONFIG_BASE_FILE_RELATIVE
-                 "${CMAKE_CURRENT_BINARY_DIR}" "${MBEDTLS_CONFIG_BASE_FILE}")
-            set(MBEDTLS_BASE_CONFIG_FILE
-                "${CMAKE_CURRENT_SOURCE_DIR}/${MBEDTLS_CONFIG_BASE_FILE_RELATIVE}")
-        endif()
+        get_filename_component(MBEDTLS_BASE_CONFIG_FILE
+            "${MBEDTLS_CONFIG_BASE_FILE}" ABSOLUTE
+            BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
     else()
         set(MBEDTLS_BASE_CONFIG_FILE
             "${CMAKE_CURRENT_SOURCE_DIR}/include/mbedtls/mbedtls_config.h")
@@ -210,15 +200,25 @@ if(NOT "${MBEDTLS_CONFIG_BASE_FILE}" STREQUAL "" OR
                    "${MBEDTLS_GENERATED_CONFIG_FILE}" COPYONLY)
 
     if(MBEDTLS_CONFIG_TRANSFORMED)
+        if(NOT "${TF_PSA_CRYPTO_CONFIG_BASE_FILE}" STREQUAL "")
+            get_filename_component(MBEDTLS_BASE_CRYPTO_CONFIG_FILE
+                "${TF_PSA_CRYPTO_CONFIG_BASE_FILE}" ABSOLUTE
+                BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+        else()
+            set(MBEDTLS_BASE_CRYPTO_CONFIG_FILE
+                "${CMAKE_CURRENT_SOURCE_DIR}/tf-psa-crypto/include/psa/crypto_config.h")
+        endif()
+        if(NOT EXISTS "${MBEDTLS_BASE_CRYPTO_CONFIG_FILE}")
+            message(FATAL_ERROR
+                "TF-PSA-Crypto configuration file not found: "
+                "${MBEDTLS_BASE_CRYPTO_CONFIG_FILE}")
+        endif()
+
         set(MBEDTLS_GENERATED_CRYPTO_CONFIG_FILE
             "${MBEDTLS_GENERATED_CONFIG_DIR}/psa/crypto_config.h")
         file(MAKE_DIRECTORY "${MBEDTLS_GENERATED_CONFIG_DIR}/psa")
-        # config.py handles the Mbed TLS and PSA configurations together. Give
-        # it a build-tree PSA configuration so that it never modifies the
-        # source tree.
-        configure_file(
-            "${CMAKE_CURRENT_SOURCE_DIR}/tf-psa-crypto/include/psa/crypto_config.h"
-            "${MBEDTLS_GENERATED_CRYPTO_CONFIG_FILE}" COPYONLY)
+        configure_file("${MBEDTLS_BASE_CRYPTO_CONFIG_FILE}"
+                       "${MBEDTLS_GENERATED_CRYPTO_CONFIG_FILE}" COPYONLY)
     endif()
 
     function(mbedtls_configure_generated_file)
@@ -257,8 +257,10 @@ if(NOT "${MBEDTLS_CONFIG_BASE_FILE}" STREQUAL "" OR
     set(MBEDTLS_CONFIG_FILE
         "$<BUILD_INTERFACE:${MBEDTLS_GENERATED_CONFIG_FILE}>$<INSTALL_INTERFACE:mbedtls/mbedtls_config.h>")
     if(MBEDTLS_CONFIG_TRANSFORMED)
-        set(TF_PSA_CRYPTO_CONFIG_FILE
-            "$<BUILD_INTERFACE:${MBEDTLS_GENERATED_CRYPTO_CONFIG_FILE}>$<INSTALL_INTERFACE:psa/crypto_config_mbedtls.h>")
+        # TF-PSA-Crypto applies its own transformations after the PSA changes
+        # made by the Mbed TLS configuration tool.
+        set(TF_PSA_CRYPTO_CONFIG_BASE_FILE_OVERRIDE
+            "${MBEDTLS_GENERATED_CRYPTO_CONFIG_FILE}")
     endif()
 endif()
 
@@ -477,15 +479,6 @@ set(TF_PSA_CRYPTO_FATAL_WARNINGS ${MBEDTLS_FATAL_WARNINGS} CACHE BOOL "")
 set(USE_STATIC_TF_PSA_CRYPTO_LIBRARY ${USE_STATIC_MBEDTLS_LIBRARY} CACHE BOOL "")
 set(USE_SHARED_TF_PSA_CRYPTO_LIBRARY ${USE_SHARED_MBEDTLS_LIBRARY} CACHE BOOL "")
 add_subdirectory(tf-psa-crypto)
-
-# Keep the generated configuration distinct from TF-PSA-Crypto's default
-# configuration header, which is installed by the subproject.
-if(NOT "${MBEDTLS_GENERATED_CRYPTO_CONFIG_FILE}" STREQUAL "" AND
-   INSTALL_TF_PSA_CRYPTO_HEADERS)
-    install(FILES "${MBEDTLS_GENERATED_CRYPTO_CONFIG_FILE}"
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/psa
-        RENAME crypto_config_mbedtls.h)
-endif()
 
 set(tfpsacrypto_target "${TF_PSA_CRYPTO_TARGET_PREFIX}tfpsacrypto")
 if (USE_STATIC_MBEDTLS_LIBRARY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,12 +229,14 @@ if(NOT "${MBEDTLS_CONFIG_BASE_FILE}" STREQUAL "" OR
         endif()
     endforeach(option)
 
-    set(MBEDTLS_CONFIG_FILE "${MBEDTLS_GENERATED_CONFIG_FILE}")
+    set(MBEDTLS_CONFIG_FILE
+        "$<BUILD_INTERFACE:${MBEDTLS_GENERATED_CONFIG_FILE}>$<INSTALL_INTERFACE:mbedtls/mbedtls_config.h>")
     if("${TF_PSA_CRYPTO_CONFIG_FILE}" STREQUAL "" AND
        "${TF_PSA_CRYPTO_CONFIG_NAME}" STREQUAL "")
         # Named configurations can adjust both configuration files.
-        set(TF_PSA_CRYPTO_CONFIG_FILE "${MBEDTLS_GENERATED_CRYPTO_CONFIG_FILE}"
-            CACHE FILEPATH "TF-PSA-Crypto config file (overrides default)." FORCE)
+        set(TF_PSA_CRYPTO_CONFIG_FILE
+            "$<BUILD_INTERFACE:${MBEDTLS_GENERATED_CRYPTO_CONFIG_FILE}>$<INSTALL_INTERFACE:psa/crypto_config_mbedtls.h>"
+            CACHE STRING "TF-PSA-Crypto config file (overrides default)." FORCE)
     endif()
 endif()
 
@@ -453,6 +455,15 @@ set(TF_PSA_CRYPTO_FATAL_WARNINGS ${MBEDTLS_FATAL_WARNINGS} CACHE BOOL "")
 set(USE_STATIC_TF_PSA_CRYPTO_LIBRARY ${USE_STATIC_MBEDTLS_LIBRARY} CACHE BOOL "")
 set(USE_SHARED_TF_PSA_CRYPTO_LIBRARY ${USE_SHARED_MBEDTLS_LIBRARY} CACHE BOOL "")
 add_subdirectory(tf-psa-crypto)
+
+# Keep the generated configuration distinct from TF-PSA-Crypto's default
+# configuration header, which is installed by the subproject.
+if(NOT "${MBEDTLS_GENERATED_CRYPTO_CONFIG_FILE}" STREQUAL "" AND
+   INSTALL_TF_PSA_CRYPTO_HEADERS)
+    install(FILES "${MBEDTLS_GENERATED_CRYPTO_CONFIG_FILE}"
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/psa
+        RENAME crypto_config_mbedtls.h)
+endif()
 
 set(tfpsacrypto_target "${TF_PSA_CRYPTO_TARGET_PREFIX}tfpsacrypto")
 if (USE_STATIC_MBEDTLS_LIBRARY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,25 +131,49 @@ if(NOT MBEDTLS_AS_SUBPROJECT)
         FORCE)
 endif()
 
-# Make MBEDTLS_CONFIG_FILE and MBEDTLS_USER_CONFIG_FILE into PATHs
+# Make configuration file options into PATHs
 set(MBEDTLS_CONFIG_FILE "" CACHE FILEPATH "Mbed TLS config file (overrides default).")
 set(MBEDTLS_USER_CONFIG_FILE "" CACHE FILEPATH "Mbed TLS user config file (appended to default).")
+set(MBEDTLS_CONFIG_BASE_FILE "" CACHE FILEPATH "Mbed TLS config to copy and optionally transform.")
 set(MBEDTLS_CONFIG_NAME "" CACHE STRING "Named Mbed TLS configuration (see config.py).")
 set(MBEDTLS_CONFIG_SET "" CACHE STRING "Options to set, separated by semicolons (OPTION or OPTION=VALUE).")
 set(MBEDTLS_CONFIG_UNSET "" CACHE STRING "Options to unset, separated by semicolons.")
 
-if(MBEDTLS_CONFIG_NAME OR MBEDTLS_CONFIG_SET OR MBEDTLS_CONFIG_UNSET)
-    if(NOT MBEDTLS_PYTHON_EXECUTABLE)
+if(NOT "${MBEDTLS_CONFIG_FILE}" STREQUAL "" AND
+   (NOT "${MBEDTLS_CONFIG_BASE_FILE}" STREQUAL "" OR
+    NOT "${MBEDTLS_CONFIG_NAME}" STREQUAL "" OR
+    NOT "${MBEDTLS_CONFIG_SET}" STREQUAL "" OR
+    NOT "${MBEDTLS_CONFIG_UNSET}" STREQUAL ""))
+    message(FATAL_ERROR
+        "MBEDTLS_CONFIG_FILE cannot be combined with MBEDTLS_CONFIG_BASE_FILE, "
+        "MBEDTLS_CONFIG_NAME, MBEDTLS_CONFIG_SET or MBEDTLS_CONFIG_UNSET.")
+endif()
+
+if(NOT "${MBEDTLS_CONFIG_BASE_FILE}" STREQUAL "" OR
+   NOT "${MBEDTLS_CONFIG_NAME}" STREQUAL "" OR
+   NOT "${MBEDTLS_CONFIG_SET}" STREQUAL "" OR
+   NOT "${MBEDTLS_CONFIG_UNSET}" STREQUAL "")
+    if("${CMAKE_CURRENT_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_BINARY_DIR}")
+        message(FATAL_ERROR
+            "MBEDTLS_CONFIG_BASE_FILE, MBEDTLS_CONFIG_NAME, "
+            "MBEDTLS_CONFIG_SET and MBEDTLS_CONFIG_UNSET are not supported "
+            "in an in-tree build.")
+    endif()
+
+    if((NOT "${MBEDTLS_CONFIG_NAME}" STREQUAL "" OR
+        NOT "${MBEDTLS_CONFIG_SET}" STREQUAL "" OR
+        NOT "${MBEDTLS_CONFIG_UNSET}" STREQUAL "") AND
+       "${MBEDTLS_PYTHON_EXECUTABLE}" STREQUAL "")
         message(FATAL_ERROR "Python 3 is required to generate an Mbed TLS configuration file.")
     endif()
 
-    if(MBEDTLS_CONFIG_FILE)
-        set(MBEDTLS_BASE_CONFIG_FILE "${MBEDTLS_CONFIG_FILE}")
+    if(NOT "${MBEDTLS_CONFIG_BASE_FILE}" STREQUAL "")
+        set(MBEDTLS_BASE_CONFIG_FILE "${MBEDTLS_CONFIG_BASE_FILE}")
         if(NOT EXISTS "${MBEDTLS_BASE_CONFIG_FILE}")
-            file(RELATIVE_PATH MBEDTLS_CONFIG_FILE_RELATIVE
-                 "${CMAKE_CURRENT_BINARY_DIR}" "${MBEDTLS_CONFIG_FILE}")
+            file(RELATIVE_PATH MBEDTLS_CONFIG_BASE_FILE_RELATIVE
+                 "${CMAKE_CURRENT_BINARY_DIR}" "${MBEDTLS_CONFIG_BASE_FILE}")
             set(MBEDTLS_BASE_CONFIG_FILE
-                "${CMAKE_CURRENT_SOURCE_DIR}/${MBEDTLS_CONFIG_FILE_RELATIVE}")
+                "${CMAKE_CURRENT_SOURCE_DIR}/${MBEDTLS_CONFIG_BASE_FILE_RELATIVE}")
         endif()
     else()
         set(MBEDTLS_BASE_CONFIG_FILE
@@ -168,8 +192,9 @@ if(MBEDTLS_CONFIG_NAME OR MBEDTLS_CONFIG_SET OR MBEDTLS_CONFIG_UNSET)
                    "${MBEDTLS_GENERATED_CONFIG_FILE}" COPYONLY)
     # config.py handles the Mbed TLS and PSA configurations together. Give it
     # a build-tree PSA configuration so that it never modifies the source tree.
-    file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/tf-psa-crypto/include/psa/crypto_config.h"
-         DESTINATION "${MBEDTLS_GENERATED_CONFIG_DIR}/psa")
+    configure_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/tf-psa-crypto/include/psa/crypto_config.h"
+        "${MBEDTLS_GENERATED_CRYPTO_CONFIG_FILE}" COPYONLY)
 
     function(mbedtls_configure_generated_file)
         execute_process(
@@ -186,7 +211,7 @@ if(MBEDTLS_CONFIG_NAME OR MBEDTLS_CONFIG_SET OR MBEDTLS_CONFIG_UNSET)
         endif()
     endfunction(mbedtls_configure_generated_file)
 
-    if(MBEDTLS_CONFIG_NAME)
+    if(NOT "${MBEDTLS_CONFIG_NAME}" STREQUAL "")
         mbedtls_configure_generated_file("${MBEDTLS_CONFIG_NAME}")
     endif()
     foreach(option IN LISTS MBEDTLS_CONFIG_UNSET)
@@ -205,9 +230,11 @@ if(MBEDTLS_CONFIG_NAME OR MBEDTLS_CONFIG_SET OR MBEDTLS_CONFIG_UNSET)
     endforeach(option)
 
     set(MBEDTLS_CONFIG_FILE "${MBEDTLS_GENERATED_CONFIG_FILE}")
-    if(NOT TF_PSA_CRYPTO_CONFIG_FILE AND NOT TF_PSA_CRYPTO_CONFIG_NAME)
+    if("${TF_PSA_CRYPTO_CONFIG_FILE}" STREQUAL "" AND
+       "${TF_PSA_CRYPTO_CONFIG_NAME}" STREQUAL "")
         # Named configurations can adjust both configuration files.
-        set(TF_PSA_CRYPTO_CONFIG_FILE "${MBEDTLS_GENERATED_CRYPTO_CONFIG_FILE}")
+        set(TF_PSA_CRYPTO_CONFIG_FILE "${MBEDTLS_GENERATED_CRYPTO_CONFIG_FILE}"
+            CACHE FILEPATH "TF-PSA-Crypto config file (overrides default)." FORCE)
     endif()
 endif()
 
@@ -383,19 +410,19 @@ endfunction(set_msvc_base_compile_options)
 function(set_config_files_compile_definitions target)
     # Pass-through MBEDTLS_CONFIG_FILE, MBEDTLS_USER_CONFIG_FILE,
     # TF_PSA_CRYPTO_CONFIG_FILE and TF_PSA_CRYPTO_USER_CONFIG_FILE
-    if(MBEDTLS_CONFIG_FILE)
+    if(NOT "${MBEDTLS_CONFIG_FILE}" STREQUAL "")
         target_compile_definitions(${target}
             PUBLIC MBEDTLS_CONFIG_FILE="${MBEDTLS_CONFIG_FILE}")
     endif()
-    if(MBEDTLS_USER_CONFIG_FILE)
+    if(NOT "${MBEDTLS_USER_CONFIG_FILE}" STREQUAL "")
         target_compile_definitions(${target}
             PUBLIC MBEDTLS_USER_CONFIG_FILE="${MBEDTLS_USER_CONFIG_FILE}")
     endif()
-    if(TF_PSA_CRYPTO_CONFIG_FILE)
+    if(NOT "${TF_PSA_CRYPTO_CONFIG_FILE}" STREQUAL "")
         target_compile_definitions(${target}
             PUBLIC TF_PSA_CRYPTO_CONFIG_FILE="${TF_PSA_CRYPTO_CONFIG_FILE}")
     endif()
-    if(TF_PSA_CRYPTO_USER_CONFIG_FILE)
+    if(NOT "${TF_PSA_CRYPTO_USER_CONFIG_FILE}" STREQUAL "")
         target_compile_definitions(${target}
             PUBLIC TF_PSA_CRYPTO_USER_CONFIG_FILE="${TF_PSA_CRYPTO_USER_CONFIG_FILE}")
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,6 +139,13 @@ set(MBEDTLS_CONFIG_NAME "" CACHE STRING "Named Mbed TLS configuration (see confi
 set(MBEDTLS_CONFIG_SET "" CACHE STRING "Options to set, separated by semicolons (OPTION or OPTION=VALUE).")
 set(MBEDTLS_CONFIG_UNSET "" CACHE STRING "Options to unset, separated by semicolons.")
 
+set(MBEDTLS_CONFIG_TRANSFORMED FALSE)
+if(NOT "${MBEDTLS_CONFIG_NAME}" STREQUAL "" OR
+   NOT "${MBEDTLS_CONFIG_SET}" STREQUAL "" OR
+   NOT "${MBEDTLS_CONFIG_UNSET}" STREQUAL "")
+    set(MBEDTLS_CONFIG_TRANSFORMED TRUE)
+endif()
+
 if(NOT "${MBEDTLS_CONFIG_FILE}" STREQUAL "" AND
    (NOT "${MBEDTLS_CONFIG_BASE_FILE}" STREQUAL "" OR
     NOT "${MBEDTLS_CONFIG_NAME}" STREQUAL "" OR
@@ -146,6 +153,19 @@ if(NOT "${MBEDTLS_CONFIG_FILE}" STREQUAL "" AND
     NOT "${MBEDTLS_CONFIG_UNSET}" STREQUAL ""))
     message(FATAL_ERROR
         "MBEDTLS_CONFIG_FILE cannot be combined with MBEDTLS_CONFIG_BASE_FILE, "
+        "MBEDTLS_CONFIG_NAME, MBEDTLS_CONFIG_SET or MBEDTLS_CONFIG_UNSET.")
+endif()
+
+if(MBEDTLS_CONFIG_TRANSFORMED AND
+   (NOT "${TF_PSA_CRYPTO_CONFIG_FILE}" STREQUAL "" OR
+    NOT "${TF_PSA_CRYPTO_CONFIG_BASE_FILE}" STREQUAL "" OR
+    NOT "${TF_PSA_CRYPTO_CONFIG_NAME}" STREQUAL "" OR
+    NOT "${TF_PSA_CRYPTO_CONFIG_SET}" STREQUAL "" OR
+    NOT "${TF_PSA_CRYPTO_CONFIG_UNSET}" STREQUAL ""))
+    message(FATAL_ERROR
+        "TF_PSA_CRYPTO_CONFIG_FILE, TF_PSA_CRYPTO_CONFIG_BASE_FILE, "
+        "TF_PSA_CRYPTO_CONFIG_NAME, TF_PSA_CRYPTO_CONFIG_SET and "
+        "TF_PSA_CRYPTO_CONFIG_UNSET cannot be combined with "
         "MBEDTLS_CONFIG_NAME, MBEDTLS_CONFIG_SET or MBEDTLS_CONFIG_UNSET.")
 endif()
 
@@ -185,16 +205,21 @@ if(NOT "${MBEDTLS_CONFIG_BASE_FILE}" STREQUAL "" OR
 
     set(MBEDTLS_GENERATED_CONFIG_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated/include")
     set(MBEDTLS_GENERATED_CONFIG_FILE "${MBEDTLS_GENERATED_CONFIG_DIR}/mbedtls/mbedtls_config.h")
-    set(MBEDTLS_GENERATED_CRYPTO_CONFIG_FILE "${MBEDTLS_GENERATED_CONFIG_DIR}/psa/crypto_config.h")
     file(MAKE_DIRECTORY "${MBEDTLS_GENERATED_CONFIG_DIR}/mbedtls")
-    file(MAKE_DIRECTORY "${MBEDTLS_GENERATED_CONFIG_DIR}/psa")
     configure_file("${MBEDTLS_BASE_CONFIG_FILE}"
                    "${MBEDTLS_GENERATED_CONFIG_FILE}" COPYONLY)
-    # config.py handles the Mbed TLS and PSA configurations together. Give it
-    # a build-tree PSA configuration so that it never modifies the source tree.
-    configure_file(
-        "${CMAKE_CURRENT_SOURCE_DIR}/tf-psa-crypto/include/psa/crypto_config.h"
-        "${MBEDTLS_GENERATED_CRYPTO_CONFIG_FILE}" COPYONLY)
+
+    if(MBEDTLS_CONFIG_TRANSFORMED)
+        set(MBEDTLS_GENERATED_CRYPTO_CONFIG_FILE
+            "${MBEDTLS_GENERATED_CONFIG_DIR}/psa/crypto_config.h")
+        file(MAKE_DIRECTORY "${MBEDTLS_GENERATED_CONFIG_DIR}/psa")
+        # config.py handles the Mbed TLS and PSA configurations together. Give
+        # it a build-tree PSA configuration so that it never modifies the
+        # source tree.
+        configure_file(
+            "${CMAKE_CURRENT_SOURCE_DIR}/tf-psa-crypto/include/psa/crypto_config.h"
+            "${MBEDTLS_GENERATED_CRYPTO_CONFIG_FILE}" COPYONLY)
+    endif()
 
     function(mbedtls_configure_generated_file)
         execute_process(
@@ -231,12 +256,9 @@ if(NOT "${MBEDTLS_CONFIG_BASE_FILE}" STREQUAL "" OR
 
     set(MBEDTLS_CONFIG_FILE
         "$<BUILD_INTERFACE:${MBEDTLS_GENERATED_CONFIG_FILE}>$<INSTALL_INTERFACE:mbedtls/mbedtls_config.h>")
-    if("${TF_PSA_CRYPTO_CONFIG_FILE}" STREQUAL "" AND
-       "${TF_PSA_CRYPTO_CONFIG_NAME}" STREQUAL "")
-        # Named configurations can adjust both configuration files.
+    if(MBEDTLS_CONFIG_TRANSFORMED)
         set(TF_PSA_CRYPTO_CONFIG_FILE
-            "$<BUILD_INTERFACE:${MBEDTLS_GENERATED_CRYPTO_CONFIG_FILE}>$<INSTALL_INTERFACE:psa/crypto_config_mbedtls.h>"
-            CACHE STRING "TF-PSA-Crypto config file (overrides default)." FORCE)
+            "$<BUILD_INTERFACE:${MBEDTLS_GENERATED_CRYPTO_CONFIG_FILE}>$<INSTALL_INTERFACE:psa/crypto_config_mbedtls.h>")
     endif()
 endif()
 

--- a/ChangeLog.d/cmake-config.txt
+++ b/ChangeLog.d/cmake-config.txt
@@ -1,0 +1,4 @@
+Features
+   * Add the `MBEDTLS_CONFIG_NAME`, `MBEDTLS_CONFIG_SET` and
+     `MBEDTLS_CONFIG_UNSET` CMake options for selecting and customizing
+     compile-time configurations. Fixes #10838.

--- a/ChangeLog.d/cmake-config.txt
+++ b/ChangeLog.d/cmake-config.txt
@@ -1,4 +1,5 @@
 Features
    * Add the `MBEDTLS_CONFIG_NAME`, `MBEDTLS_CONFIG_SET` and
      `MBEDTLS_CONFIG_UNSET` CMake options for selecting and customizing
-     compile-time configurations. Fixes #10838.
+     compile-time configurations, including configurations based on a custom
+     `MBEDTLS_CONFIG_FILE`. Fixes #10838.

--- a/ChangeLog.d/cmake-config.txt
+++ b/ChangeLog.d/cmake-config.txt
@@ -1,5 +1,4 @@
 Features
-   * Add the `MBEDTLS_CONFIG_NAME`, `MBEDTLS_CONFIG_SET` and
-     `MBEDTLS_CONFIG_UNSET` CMake options for selecting and customizing
-     compile-time configurations, including configurations based on a custom
-     `MBEDTLS_CONFIG_FILE`. Fixes #10838.
+   * Add the `MBEDTLS_CONFIG_BASE_FILE`, `MBEDTLS_CONFIG_NAME`,
+     `MBEDTLS_CONFIG_SET` and `MBEDTLS_CONFIG_UNSET` CMake options for
+     selecting and customizing compile-time configurations. Fixes #10838.

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -4,9 +4,20 @@ if(INSTALL_MBEDTLS_HEADERS)
 
     file(GLOB headers "mbedtls/*.h")
 
+    if(NOT "${MBEDTLS_GENERATED_CONFIG_FILE}" STREQUAL "")
+        list(REMOVE_ITEM headers
+            "${CMAKE_CURRENT_SOURCE_DIR}/mbedtls/mbedtls_config.h")
+    endif()
+
     install(FILES ${headers}
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/mbedtls
         PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)
+
+    if(NOT "${MBEDTLS_GENERATED_CONFIG_FILE}" STREQUAL "")
+        install(FILES "${MBEDTLS_GENERATED_CONFIG_FILE}"
+            DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/mbedtls
+            PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)
+    endif()
 
     file(GLOB private_headers "mbedtls/private/*.h")
 

--- a/programs/test/cmake_package_install/cmake_package_config.c
+++ b/programs/test/cmake_package_install/cmake_package_config.c
@@ -1,0 +1,13 @@
+/*
+ *  Simple program to test an installed Mbed TLS configuration.
+ *
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+ */
+
+#include "mbedtls/build_info.h"
+
+int main(void)
+{
+    return 0;
+}

--- a/tests/scripts/components-build-system.sh
+++ b/tests/scripts/components-build-system.sh
@@ -290,9 +290,48 @@ component_build_cmake_config_options () {
     cd "$OUT_OF_SOURCE_DIR"
 
     msg "configure: cmake with MBEDTLS_CONFIG_NAME"
-    cmake -DMBEDTLS_CONFIG_NAME=full "$MBEDTLS_ROOT_DIR"
-    grep '^#define MBEDTLS_SSL_PROTO_TLS1_3$' \
-         generated/include/mbedtls/mbedtls_config.h
+    cmake -DMBEDTLS_CONFIG_NAME=crypto "$MBEDTLS_ROOT_DIR"
+    make query_compile_time_config
+    not programs/test/query_compile_time_config MBEDTLS_SSL_TLS_C
+    programs/test/query_compile_time_config PSA_WANT_ALG_CMAC
+
+    cd "$MBEDTLS_ROOT_DIR"
+    rm -rf "$OUT_OF_SOURCE_DIR"
+    mkdir "$OUT_OF_SOURCE_DIR"
+    cd "$OUT_OF_SOURCE_DIR"
+
+    msg "configure: cmake with a false-like option name"
+    cmake -DMBEDTLS_CONFIG_SET=NO "$MBEDTLS_ROOT_DIR"
+    grep '^#define NO$' generated/include/mbedtls/mbedtls_config.h
+
+    cd "$MBEDTLS_ROOT_DIR"
+    rm -rf "$OUT_OF_SOURCE_DIR"
+    mkdir "$OUT_OF_SOURCE_DIR"
+    cd "$OUT_OF_SOURCE_DIR"
+
+    msg "configure: cmake with MBEDTLS_CONFIG_BASE_FILE only"
+    cmake -DMBEDTLS_CONFIG_BASE_FILE=configs/config-ccm-psk-tls1_2.h \
+          "$MBEDTLS_ROOT_DIR"
+    cmp "$MBEDTLS_ROOT_DIR/configs/config-ccm-psk-tls1_2.h" \
+        generated/include/mbedtls/mbedtls_config.h
+
+    cd "$MBEDTLS_ROOT_DIR"
+    rm -rf "$OUT_OF_SOURCE_DIR"
+    mkdir "$OUT_OF_SOURCE_DIR"
+    cd "$OUT_OF_SOURCE_DIR"
+
+    msg "configure: reject MBEDTLS_CONFIG_FILE with transformations"
+    not cmake -DMBEDTLS_CONFIG_FILE=configs/config-ccm-psk-tls1_2.h \
+              -DMBEDTLS_CONFIG_SET=MBEDTLS_DEBUG_C "$MBEDTLS_ROOT_DIR"
+
+    cd "$MBEDTLS_ROOT_DIR"
+    rm -rf "$OUT_OF_SOURCE_DIR"
+    mkdir "$OUT_OF_SOURCE_DIR"
+    cd "$OUT_OF_SOURCE_DIR"
+
+    msg "configure: reject a missing base configuration"
+    not cmake -DMBEDTLS_CONFIG_BASE_FILE=configs/does-not-exist.h \
+              "$MBEDTLS_ROOT_DIR"
 
     cd "$MBEDTLS_ROOT_DIR"
     rm -rf "$OUT_OF_SOURCE_DIR"
@@ -300,8 +339,9 @@ component_build_cmake_config_options () {
     cd "$OUT_OF_SOURCE_DIR"
 
     msg "build: cmake with a base config, MBEDTLS_CONFIG_SET and MBEDTLS_CONFIG_UNSET"
-    cmake -DMBEDTLS_CONFIG_FILE=configs/config-ccm-psk-tls1_2.h \
-          -DMBEDTLS_CONFIG_UNSET=MBEDTLS_SSL_SRV_C \
+    cp "$MBEDTLS_ROOT_DIR/configs/config-ccm-psk-tls1_2.h" base_config.before
+    cmake -DMBEDTLS_CONFIG_BASE_FILE=configs/config-ccm-psk-tls1_2.h \
+          '-DMBEDTLS_CONFIG_UNSET=MBEDTLS_SSL_SRV_C;PSA_WANT_ALG_CMAC;PSA_WANT_ALG_PBKDF2_AES_CMAC_PRF_128' \
           '-DMBEDTLS_CONFIG_SET=MBEDTLS_SSL_RENEGOTIATION;MBEDTLS_DEBUG_C;MBEDTLS_ERROR_C;MBEDTLS_SSL_IN_CONTENT_LEN=12000' \
           "$MBEDTLS_ROOT_DIR"
     make query_compile_time_config
@@ -311,11 +351,18 @@ component_build_cmake_config_options () {
     programs/test/query_compile_time_config MBEDTLS_DEBUG_C
     programs/test/query_compile_time_config MBEDTLS_ERROR_C
     not programs/test/query_compile_time_config MBEDTLS_SSL_SRV_C
+    not programs/test/query_compile_time_config PSA_WANT_ALG_CMAC
     [ "$(programs/test/query_compile_time_config MBEDTLS_SSL_IN_CONTENT_LEN)" = \
       "12000" ]
+    cmp base_config.before \
+        "$MBEDTLS_ROOT_DIR/configs/config-ccm-psk-tls1_2.h"
 
     cd "$MBEDTLS_ROOT_DIR"
     rm -rf "$OUT_OF_SOURCE_DIR"
+
+    msg "configure: reject transformations in an in-tree build"
+    not cmake -DMBEDTLS_CONFIG_SET=NO .
+    rm -rf CMakeCache.txt CMakeFiles
 }
 
 support_build_cmake_config_options () {

--- a/tests/scripts/components-build-system.sh
+++ b/tests/scripts/components-build-system.sh
@@ -284,6 +284,41 @@ support_build_cmake_custom_config_file () {
     support_test_cmake_out_of_source
 }
 
+component_build_cmake_config_options () {
+    MBEDTLS_ROOT_DIR="$PWD"
+    mkdir "$OUT_OF_SOURCE_DIR"
+    cd "$OUT_OF_SOURCE_DIR"
+
+    msg "configure: cmake with MBEDTLS_CONFIG_NAME"
+    cmake -DMBEDTLS_CONFIG_NAME=full "$MBEDTLS_ROOT_DIR"
+    grep '^#define MBEDTLS_SSL_PROTO_TLS1_3$' \
+         generated/include/mbedtls/mbedtls_config.h
+
+    cd "$MBEDTLS_ROOT_DIR"
+    rm -rf "$OUT_OF_SOURCE_DIR"
+    mkdir "$OUT_OF_SOURCE_DIR"
+    cd "$OUT_OF_SOURCE_DIR"
+
+    msg "build: cmake with MBEDTLS_CONFIG_SET and MBEDTLS_CONFIG_UNSET"
+    cmake '-DMBEDTLS_CONFIG_UNSET=MBEDTLS_SSL_ALL_ALERT_MESSAGES;MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE' \
+          '-DMBEDTLS_CONFIG_SET=MBEDTLS_SSL_PROTO_TLS1_3;MBEDTLS_SSL_ALL_ALERT_MESSAGES;MBEDTLS_SSL_IN_CONTENT_LEN=12000' \
+          "$MBEDTLS_ROOT_DIR"
+    make query_compile_time_config
+
+    programs/test/query_compile_time_config MBEDTLS_SSL_PROTO_TLS1_3
+    programs/test/query_compile_time_config MBEDTLS_SSL_ALL_ALERT_MESSAGES
+    not programs/test/query_compile_time_config MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
+    [ "$(programs/test/query_compile_time_config MBEDTLS_SSL_IN_CONTENT_LEN)" = \
+      "12000" ]
+
+    cd "$MBEDTLS_ROOT_DIR"
+    rm -rf "$OUT_OF_SOURCE_DIR"
+}
+
+support_build_cmake_config_options () {
+    support_test_cmake_out_of_source
+}
+
 component_build_cmake_programs_no_testing () {
     # Verify that the type of builds performed by oss-fuzz don't get accidentally broken
     msg "build: cmake with -DENABLE_PROGRAMS=ON and -DENABLE_TESTING=OFF"

--- a/tests/scripts/components-build-system.sh
+++ b/tests/scripts/components-build-system.sh
@@ -303,6 +303,8 @@ component_build_cmake_config_options () {
     msg "configure: cmake with a false-like option name"
     cmake -DMBEDTLS_CONFIG_SET=NO "$MBEDTLS_ROOT_DIR"
     grep '^#define NO$' generated/include/mbedtls/mbedtls_config.h
+    cmake -DMBEDTLS_CONFIG_SET= .
+    grep '^TF_PSA_CRYPTO_CONFIG_FILE:FILEPATH=$' CMakeCache.txt
 
     cd "$MBEDTLS_ROOT_DIR"
     rm -rf "$OUT_OF_SOURCE_DIR"
@@ -314,6 +316,7 @@ component_build_cmake_config_options () {
           "$MBEDTLS_ROOT_DIR"
     cmp "$MBEDTLS_ROOT_DIR/configs/config-ccm-psk-tls1_2.h" \
         generated/include/mbedtls/mbedtls_config.h
+    not test -e generated/include/psa/crypto_config.h
 
     cd "$MBEDTLS_ROOT_DIR"
     rm -rf "$OUT_OF_SOURCE_DIR"
@@ -325,6 +328,24 @@ component_build_cmake_config_options () {
               -DMBEDTLS_CONFIG_SET=MBEDTLS_DEBUG_C "$MBEDTLS_ROOT_DIR"
 
     cd "$MBEDTLS_ROOT_DIR"
+    for option in \
+        "TF_PSA_CRYPTO_CONFIG_FILE=$MBEDTLS_ROOT_DIR/tf-psa-crypto/include/psa/crypto_config.h" \
+        "TF_PSA_CRYPTO_CONFIG_BASE_FILE=$MBEDTLS_ROOT_DIR/tf-psa-crypto/include/psa/crypto_config.h" \
+        "TF_PSA_CRYPTO_CONFIG_NAME=full" \
+        "TF_PSA_CRYPTO_CONFIG_SET=PSA_WANT_ALG_SHA_256" \
+        "TF_PSA_CRYPTO_CONFIG_UNSET=PSA_WANT_ALG_CMAC"
+    do
+        rm -rf "$OUT_OF_SOURCE_DIR"
+        mkdir "$OUT_OF_SOURCE_DIR"
+        cd "$OUT_OF_SOURCE_DIR"
+
+        msg "configure: reject $option with Mbed TLS transformations"
+        not cmake "-D$option" -DMBEDTLS_CONFIG_SET=MBEDTLS_DEBUG_C \
+                  "$MBEDTLS_ROOT_DIR"
+
+        cd "$MBEDTLS_ROOT_DIR"
+    done
+
     rm -rf "$OUT_OF_SOURCE_DIR"
     mkdir "$OUT_OF_SOURCE_DIR"
     cd "$OUT_OF_SOURCE_DIR"
@@ -358,7 +379,7 @@ component_build_cmake_config_options () {
         "$MBEDTLS_ROOT_DIR/configs/config-ccm-psk-tls1_2.h"
 
     msg "install: generated configurations are relocatable"
-    install_dir="$OUT_OF_SOURCE_DIR/install"
+    install_dir="$OUT_OF_SOURCE_DIR.install"
     cmake -DCMAKE_INSTALL_PREFIX="$install_dir" .
     cmake --build . --target install
     cmp generated/include/mbedtls/mbedtls_config.h \
@@ -366,9 +387,11 @@ component_build_cmake_config_options () {
     cmp generated/include/psa/crypto_config.h \
         "$install_dir/include/psa/crypto_config_mbedtls.h"
 
-    # The installed targets must not refer to configuration headers in the
-    # build tree.
-    mv generated generated.moved
+    # The installed targets must not refer to the build tree.
+    cd "$MBEDTLS_ROOT_DIR"
+    mv "$OUT_OF_SOURCE_DIR" "$OUT_OF_SOURCE_DIR.moved"
+    mkdir "$OUT_OF_SOURCE_DIR"
+    cd "$OUT_OF_SOURCE_DIR"
     mkdir consumer
     cat >consumer/CMakeLists.txt <<EOF
 cmake_minimum_required(VERSION 3.10)
@@ -386,7 +409,7 @@ EOF
     cd ..
 
     cd "$MBEDTLS_ROOT_DIR"
-    rm -rf "$OUT_OF_SOURCE_DIR"
+    rm -rf "$OUT_OF_SOURCE_DIR" "$OUT_OF_SOURCE_DIR.moved" "$install_dir"
 
     msg "configure: reject transformations in an in-tree build"
     not cmake -DMBEDTLS_CONFIG_SET=NO .

--- a/tests/scripts/components-build-system.sh
+++ b/tests/scripts/components-build-system.sh
@@ -320,6 +320,19 @@ component_build_cmake_config_options () {
 
     cd "$MBEDTLS_ROOT_DIR"
     rm -rf "$OUT_OF_SOURCE_DIR"
+    launch_dir="$OUT_OF_SOURCE_DIR.launch"
+    mkdir "$launch_dir"
+    cd "$launch_dir"
+
+    msg "configure: resolve a relative base config from the source tree"
+    cmake -H"$MBEDTLS_ROOT_DIR" -B"$OUT_OF_SOURCE_DIR" \
+        -DMBEDTLS_CONFIG_BASE_FILE=configs/config-ccm-psk-tls1_2.h \
+        -DMBEDTLS_CONFIG_SET=MBEDTLS_DEBUG_C
+    grep '^#define MBEDTLS_DEBUG_C' \
+        "$OUT_OF_SOURCE_DIR/generated/include/mbedtls/mbedtls_config.h"
+
+    cd "$MBEDTLS_ROOT_DIR"
+    rm -rf "$OUT_OF_SOURCE_DIR" "$launch_dir"
     mkdir "$OUT_OF_SOURCE_DIR"
     cd "$OUT_OF_SOURCE_DIR"
 
@@ -328,24 +341,36 @@ component_build_cmake_config_options () {
               -DMBEDTLS_CONFIG_SET=MBEDTLS_DEBUG_C "$MBEDTLS_ROOT_DIR"
 
     cd "$MBEDTLS_ROOT_DIR"
-    for option in \
-        "TF_PSA_CRYPTO_CONFIG_FILE=$MBEDTLS_ROOT_DIR/tf-psa-crypto/include/psa/crypto_config.h" \
-        "TF_PSA_CRYPTO_CONFIG_BASE_FILE=$MBEDTLS_ROOT_DIR/tf-psa-crypto/include/psa/crypto_config.h" \
-        "TF_PSA_CRYPTO_CONFIG_NAME=full" \
-        "TF_PSA_CRYPTO_CONFIG_SET=PSA_WANT_ALG_SHA_256" \
-        "TF_PSA_CRYPTO_CONFIG_UNSET=PSA_WANT_ALG_CMAC"
-    do
-        rm -rf "$OUT_OF_SOURCE_DIR"
-        mkdir "$OUT_OF_SOURCE_DIR"
-        cd "$OUT_OF_SOURCE_DIR"
+    rm -rf "$OUT_OF_SOURCE_DIR"
+    mkdir "$OUT_OF_SOURCE_DIR"
+    cd "$OUT_OF_SOURCE_DIR"
 
-        msg "configure: reject $option with Mbed TLS transformations"
-        not cmake "-D$option" -DMBEDTLS_CONFIG_SET=MBEDTLS_DEBUG_C \
-                  "$MBEDTLS_ROOT_DIR"
+    msg "configure: reject TF_PSA_CRYPTO_CONFIG_FILE with Mbed TLS transformations"
+    not cmake \
+        -DTF_PSA_CRYPTO_CONFIG_FILE="$MBEDTLS_ROOT_DIR/tf-psa-crypto/include/psa/crypto_config.h" \
+        -DMBEDTLS_CONFIG_SET=MBEDTLS_DEBUG_C "$MBEDTLS_ROOT_DIR"
 
-        cd "$MBEDTLS_ROOT_DIR"
-    done
+    cd "$MBEDTLS_ROOT_DIR"
+    rm -rf "$OUT_OF_SOURCE_DIR"
+    mkdir "$OUT_OF_SOURCE_DIR"
+    cd "$OUT_OF_SOURCE_DIR"
 
+    msg "build: combine Mbed TLS and TF-PSA-Crypto transformations"
+    cmake \
+        -DMBEDTLS_CONFIG_BASE_FILE=configs/config-ccm-psk-tls1_2.h \
+        '-DMBEDTLS_CONFIG_SET=MBEDTLS_DEBUG_C;PSA_WANT_ALG_RIPEMD160' \
+        -DTF_PSA_CRYPTO_CONFIG_BASE_FILE="$MBEDTLS_ROOT_DIR/tf-psa-crypto/configs/crypto-config-symmetric-only.h" \
+        -DTF_PSA_CRYPTO_CONFIG_UNSET=PSA_WANT_ALG_RIPEMD160 \
+        "$MBEDTLS_ROOT_DIR"
+    make query_compile_time_config
+    programs/test/query_compile_time_config MBEDTLS_DEBUG_C
+    grep '^#define PSA_WANT_ALG_RIPEMD160' \
+        generated/include/psa/crypto_config.h
+    not programs/test/query_compile_time_config PSA_WANT_ALG_RIPEMD160
+    not programs/test/query_compile_time_config \
+        PSA_WANT_KEY_TYPE_DH_KEY_PAIR_BASIC
+
+    cd "$MBEDTLS_ROOT_DIR"
     rm -rf "$OUT_OF_SOURCE_DIR"
     mkdir "$OUT_OF_SOURCE_DIR"
     cd "$OUT_OF_SOURCE_DIR"
@@ -384,8 +409,8 @@ component_build_cmake_config_options () {
     cmake --build . --target install
     cmp generated/include/mbedtls/mbedtls_config.h \
         "$install_dir/include/mbedtls/mbedtls_config.h"
-    cmp generated/include/psa/crypto_config.h \
-        "$install_dir/include/psa/crypto_config_mbedtls.h"
+    cmp tf-psa-crypto/include/psa/crypto_config.h \
+        "$install_dir/include/psa/crypto_config.h"
 
     # The installed targets must not refer to the build tree.
     cd "$MBEDTLS_ROOT_DIR"

--- a/tests/scripts/components-build-system.sh
+++ b/tests/scripts/components-build-system.sh
@@ -384,6 +384,8 @@ component_build_cmake_config_options () {
 
     msg "build: cmake with a base config, MBEDTLS_CONFIG_SET and MBEDTLS_CONFIG_UNSET"
     cp "$MBEDTLS_ROOT_DIR/configs/config-ccm-psk-tls1_2.h" base_config.before
+    cp "$MBEDTLS_ROOT_DIR/tf-psa-crypto/include/psa/crypto_config.h" \
+       crypto_config.before
     cmake -DMBEDTLS_CONFIG_BASE_FILE=configs/config-ccm-psk-tls1_2.h \
           '-DMBEDTLS_CONFIG_UNSET=MBEDTLS_SSL_SRV_C;PSA_WANT_ALG_CMAC;PSA_WANT_ALG_PBKDF2_AES_CMAC_PRF_128' \
           '-DMBEDTLS_CONFIG_SET=MBEDTLS_SSL_RENEGOTIATION;MBEDTLS_DEBUG_C;MBEDTLS_ERROR_C;MBEDTLS_SSL_IN_CONTENT_LEN=12000' \
@@ -400,6 +402,8 @@ component_build_cmake_config_options () {
       "12000" ]
     cmp base_config.before \
         "$MBEDTLS_ROOT_DIR/configs/config-ccm-psk-tls1_2.h"
+    cmp crypto_config.before \
+        "$MBEDTLS_ROOT_DIR/tf-psa-crypto/include/psa/crypto_config.h"
 
     msg "install: generated configurations are relocatable"
     install_dir="$OUT_OF_SOURCE_DIR.install"

--- a/tests/scripts/components-build-system.sh
+++ b/tests/scripts/components-build-system.sh
@@ -320,13 +320,13 @@ component_build_cmake_config_options () {
 
     cd "$MBEDTLS_ROOT_DIR"
     rm -rf "$OUT_OF_SOURCE_DIR"
-    launch_dir="$OUT_OF_SOURCE_DIR.launch"
+    launch_dir="$MBEDTLS_ROOT_DIR/cmake-config-launch"
     mkdir "$launch_dir"
     cd "$launch_dir"
 
-    msg "configure: resolve a relative base config from the source tree"
+    msg "configure: resolve a base config relative to the launch directory"
     cmake -H"$MBEDTLS_ROOT_DIR" -B"$OUT_OF_SOURCE_DIR" \
-        -DMBEDTLS_CONFIG_BASE_FILE=configs/config-ccm-psk-tls1_2.h \
+        -DMBEDTLS_CONFIG_BASE_FILE=../configs/config-ccm-psk-tls1_2.h \
         -DMBEDTLS_CONFIG_SET=MBEDTLS_DEBUG_C
     grep '^#define MBEDTLS_DEBUG_C' \
         "$OUT_OF_SOURCE_DIR/generated/include/mbedtls/mbedtls_config.h"
@@ -358,17 +358,15 @@ component_build_cmake_config_options () {
     msg "build: combine Mbed TLS and TF-PSA-Crypto transformations"
     cmake \
         -DMBEDTLS_CONFIG_BASE_FILE=configs/config-ccm-psk-tls1_2.h \
-        '-DMBEDTLS_CONFIG_SET=MBEDTLS_DEBUG_C;PSA_WANT_ALG_RIPEMD160' \
-        -DTF_PSA_CRYPTO_CONFIG_BASE_FILE="$MBEDTLS_ROOT_DIR/tf-psa-crypto/configs/crypto-config-symmetric-only.h" \
-        -DTF_PSA_CRYPTO_CONFIG_UNSET=PSA_WANT_ALG_RIPEMD160 \
+        -DMBEDTLS_CONFIG_SET=MBEDTLS_DEBUG_C \
+        -DTF_PSA_CRYPTO_CONFIG_BASE_FILE="$MBEDTLS_ROOT_DIR/configs/crypto-config-ccm-psk-tls1_2.h" \
+        -DTF_PSA_CRYPTO_CONFIG_UNSET=MBEDTLS_HAVE_TIME \
         "$MBEDTLS_ROOT_DIR"
     make query_compile_time_config
     programs/test/query_compile_time_config MBEDTLS_DEBUG_C
-    grep '^#define PSA_WANT_ALG_RIPEMD160' \
+    grep '^#define MBEDTLS_HAVE_TIME' \
         generated/include/psa/crypto_config.h
-    not programs/test/query_compile_time_config PSA_WANT_ALG_RIPEMD160
-    not programs/test/query_compile_time_config \
-        PSA_WANT_KEY_TYPE_DH_KEY_PAIR_BASIC
+    not programs/test/query_compile_time_config MBEDTLS_HAVE_TIME
 
     cd "$MBEDTLS_ROOT_DIR"
     rm -rf "$OUT_OF_SOURCE_DIR"

--- a/tests/scripts/components-build-system.sh
+++ b/tests/scripts/components-build-system.sh
@@ -357,6 +357,32 @@ component_build_cmake_config_options () {
     cmp base_config.before \
         "$MBEDTLS_ROOT_DIR/configs/config-ccm-psk-tls1_2.h"
 
+    msg "install: generated configurations are relocatable"
+    install_dir="$OUT_OF_SOURCE_DIR/install"
+    cmake -DCMAKE_INSTALL_PREFIX="$install_dir" .
+    cmake --build . --target install
+    cmp generated/include/mbedtls/mbedtls_config.h \
+        "$install_dir/include/mbedtls/mbedtls_config.h"
+    cmp generated/include/psa/crypto_config.h \
+        "$install_dir/include/psa/crypto_config_mbedtls.h"
+
+    # The installed targets must not refer to configuration headers in the
+    # build tree.
+    mv generated generated.moved
+    mkdir consumer
+    cat >consumer/CMakeLists.txt <<EOF
+cmake_minimum_required(VERSION 3.10)
+project(consumer C)
+find_package(MbedTLS REQUIRED CONFIG)
+add_executable(consumer
+    "$MBEDTLS_ROOT_DIR/programs/test/cmake_package_install/cmake_package_config.c")
+target_link_libraries(consumer PRIVATE
+    MbedTLS::mbedtls MbedTLS::mbedx509 MbedTLS::tfpsacrypto)
+EOF
+    cmake -S consumer -B consumer-build \
+          -DCMAKE_PREFIX_PATH="$install_dir"
+    cmake --build consumer-build
+
     cd "$MBEDTLS_ROOT_DIR"
     rm -rf "$OUT_OF_SOURCE_DIR"
 

--- a/tests/scripts/components-build-system.sh
+++ b/tests/scripts/components-build-system.sh
@@ -379,9 +379,11 @@ add_executable(consumer
 target_link_libraries(consumer PRIVATE
     MbedTLS::mbedtls MbedTLS::mbedx509 MbedTLS::tfpsacrypto)
 EOF
-    cmake -S consumer -B consumer-build \
-          -DCMAKE_PREFIX_PATH="$install_dir"
-    cmake --build consumer-build
+    mkdir consumer-build
+    cd consumer-build
+    cmake -DCMAKE_PREFIX_PATH="$install_dir" ../consumer
+    cmake --build .
+    cd ..
 
     cd "$MBEDTLS_ROOT_DIR"
     rm -rf "$OUT_OF_SOURCE_DIR"

--- a/tests/scripts/components-build-system.sh
+++ b/tests/scripts/components-build-system.sh
@@ -299,15 +299,18 @@ component_build_cmake_config_options () {
     mkdir "$OUT_OF_SOURCE_DIR"
     cd "$OUT_OF_SOURCE_DIR"
 
-    msg "build: cmake with MBEDTLS_CONFIG_SET and MBEDTLS_CONFIG_UNSET"
-    cmake '-DMBEDTLS_CONFIG_UNSET=MBEDTLS_SSL_ALL_ALERT_MESSAGES;MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE' \
-          '-DMBEDTLS_CONFIG_SET=MBEDTLS_SSL_PROTO_TLS1_3;MBEDTLS_SSL_ALL_ALERT_MESSAGES;MBEDTLS_SSL_IN_CONTENT_LEN=12000' \
+    msg "build: cmake with a base config, MBEDTLS_CONFIG_SET and MBEDTLS_CONFIG_UNSET"
+    cmake -DMBEDTLS_CONFIG_FILE=configs/config-ccm-psk-tls1_2.h \
+          -DMBEDTLS_CONFIG_UNSET=MBEDTLS_SSL_SRV_C \
+          '-DMBEDTLS_CONFIG_SET=MBEDTLS_SSL_RENEGOTIATION;MBEDTLS_DEBUG_C;MBEDTLS_ERROR_C;MBEDTLS_SSL_IN_CONTENT_LEN=12000' \
           "$MBEDTLS_ROOT_DIR"
     make query_compile_time_config
 
-    programs/test/query_compile_time_config MBEDTLS_SSL_PROTO_TLS1_3
-    programs/test/query_compile_time_config MBEDTLS_SSL_ALL_ALERT_MESSAGES
-    not programs/test/query_compile_time_config MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
+    programs/test/query_compile_time_config MBEDTLS_SSL_PROTO_TLS1_2
+    programs/test/query_compile_time_config MBEDTLS_SSL_RENEGOTIATION
+    programs/test/query_compile_time_config MBEDTLS_DEBUG_C
+    programs/test/query_compile_time_config MBEDTLS_ERROR_C
+    not programs/test/query_compile_time_config MBEDTLS_SSL_SRV_C
     [ "$(programs/test/query_compile_time_config MBEDTLS_SSL_IN_CONTENT_LEN)" = \
       "12000" ]
 


### PR DESCRIPTION
Trivial backport of https://github.com/Mbed-TLS/mbedtls/pull/10860

## PR checklist

- [x] **changelog** provided 
- [x] **framework PR** not required
- [x] **TF-PSA-Crypto development PR** provided: https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/868
- [x] **TF-PSA-Crypto 1.1 PR** provided: Mbed-TLS/TF-PSA-Crypto#882
- [x] **mbedtls development PR** provided: https://github.com/Mbed-TLS/mbedtls/pull/10860
- [x] **mbedtls 4.1 PR** provided: https://github.com/Mbed-TLS/mbedtls/pull/10935
- [x] **mbedtls 3.6 PR** provided: https://github.com/Mbed-TLS/mbedtls/pull/10912
- **tests**  provided:
