### PR TITLE
Fix X.509 certificate profiles to honor MBEDTLS_PK_SIGALG_ECDSA

### DIFF
--- a/ChangeLog.d/fix-x509-profile-pk-sigalg.txt
+++ b/ChangeLog.d/fix-x509-profile-pk-sigalg.txt
@@ -1,0 +1,5 @@
+Bugfix
+   * Fix X.509 certificate profile checks to correctly map internal PK types
+     to public signature algorithm identifiers. Previously, ECKEY certificates
+     were incorrectly rejected when MBEDTLS_PK_SIGALG_ECDSA was allowed in a
+     custom profile. Fixes #10849 and #10747.

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -181,6 +181,24 @@ int mbedtls_x509_profile_check_md_alg(const mbedtls_x509_crt_profile *profile,
     return -1;
 }
 
+/*
+ * Map an internal pk_type to the public pk_sigalg_t used in profiles.
+ *
+ * This is needed because mbedtls_pk_type_t and mbedtls_pk_sigalg_t have
+ * different numerical values for the same logical algorithms.
+ */
+static mbedtls_pk_sigalg_t x509_pk_type_to_sigalg(mbedtls_pk_type_t pk_type)
+{
+    switch (pk_type) {
+        case MBEDTLS_PK_RSA:        return MBEDTLS_PK_SIGALG_RSA_PKCS1V15;
+        case MBEDTLS_PK_RSASSA_PSS: return MBEDTLS_PK_SIGALG_RSA_PSS;
+        case MBEDTLS_PK_ECKEY:
+        case MBEDTLS_PK_ECKEY_DH:
+        case MBEDTLS_PK_ECDSA:      return MBEDTLS_PK_SIGALG_ECDSA;
+        default:                    return MBEDTLS_PK_SIGALG_NONE;
+    }
+}
+
 int mbedtls_x509_profile_check_pk_alg(const mbedtls_x509_crt_profile *profile,
                                       mbedtls_pk_sigalg_t pk_alg)
 {
@@ -3067,7 +3085,7 @@ static int x509_crt_verify_restartable_ca_cb(mbedtls_x509_crt *crt,
     /* Check the type and size of the key */
     pk_type = mbedtls_pk_get_type(&crt->pk);
 
-    if (mbedtls_x509_profile_check_pk_alg(profile, (mbedtls_pk_sigalg_t) pk_type) != 0) {
+    if (mbedtls_x509_profile_check_pk_alg(profile, x509_pk_type_to_sigalg(pk_type)) != 0) {
         ee_flags |= MBEDTLS_X509_BADCERT_BAD_PK;
     }
 

--- a/tests/suites/test_suite_x509parse.data
+++ b/tests/suites/test_suite_x509parse.data
@@ -2752,6 +2752,10 @@ X509 CRT verify chain #25 (len=3, vrfy fatal on depth 3, untrusted)
 depends_on:PSA_WANT_ALG_SHA_256:PSA_HAVE_ALG_ECDSA_VERIFY:PSA_WANT_ECC_SECP_R1_256:PSA_HAVE_ALG_SOME_RSA_VERIFY:PSA_WANT_ALG_SHA_1:PSA_WANT_ECC_SECP_R1_384
 mbedtls_x509_crt_verify_chain:"../framework/data_files/server10_int3_int-ca2_ca.crt":"../framework/data_files/test-ca2.crt":-1:-4:"":8
 
+X509 CRT verify chain #26 (ECDSA-only profile, EC self-signed cert)
+depends_on:PSA_WANT_ALG_SHA_256:PSA_HAVE_ALG_ECDSA_VERIFY:PSA_WANT_ECC_SECP_R1_256
+mbedtls_x509_crt_verify_chain:"../framework/data_files/server5-selfsigned.crt":"../framework/data_files/server5-selfsigned.crt":0:0:"ecdsa_only":0
+
 X509 OID description #1
 x509_oid_desc:"2b06010505070301":"TLS Web Server Authentication"
 
@@ -3519,3 +3523,7 @@ oid_get_numeric_string:"8001":MBEDTLS_ERR_ASN1_INVALID_DATA:""
 
 OID get numeric string - overlong encoding, second subidentifier
 oid_get_numeric_string:"2B8001":MBEDTLS_ERR_ASN1_INVALID_DATA:""
+
+X509 CRT verify chain #18 (ECDSA-only profile, EC self-signed cert)
+depends_on:PSA_WANT_ALG_SHA_256:PSA_HAVE_ALG_ECDSA_VERIFY:PSA_WANT_ECC_SECP_R1_256
+mbedtls_x509_crt_verify_chain:"../framework/data_files/server5-selfsigned.crt":"../framework/data_files/server5-selfsigned.crt":0:0:"ecdsa_only":0

--- a/tests/suites/test_suite_x509parse.function
+++ b/tests/suites/test_suite_x509parse.function
@@ -58,6 +58,14 @@ const mbedtls_x509_crt_profile profile_rsa3072 =
     3072,
 };
 
+const mbedtls_x509_crt_profile profile_ecdsa_only =
+{
+    0xFFFFFFFF, /* Any MD        */
+    MBEDTLS_X509_ID_FLAG(MBEDTLS_PK_SIGALG_ECDSA),
+    0xFFFFFFFF, /* Any curve     */
+    1024,
+};
+
 const mbedtls_x509_crt_profile profile_sha512 =
 {
     MBEDTLS_X509_ID_FLAG(MBEDTLS_MD_SHA512),
@@ -1511,6 +1519,8 @@ void mbedtls_x509_crt_verify_chain(char *chain_paths, char *trusted_ca,
         profile = &profile_rsa3072;
     } else if (strcmp(profile_name, "sha512") == 0) {
         profile = &profile_sha512;
+    } else if (strcmp(profile_name, "ecdsa_only") == 0) {
+        profile = &profile_ecdsa_only;
     }
 
     res = mbedtls_x509_crt_verify_with_profile(&chain, &trusted, NULL, profile,


### PR DESCRIPTION
## Description

When verifying a certificate against a custom mbedtls_x509_crt_profile, the profile check for allowed PK algorithms used a direct cast from mbedtls_pk_type_t to mbedtls_pk_sigalg_t. These two enums have different numerical values, so an ECKEY certificate (pk_type=2) was incorrectly matched against MBEDTLS_PK_SIGALG_RSA_PSS (sigalg=2) instead of MBEDTLS_PK_SIGALG_ECDSA (sigalg=3).

Add a translation helper x509_pk_type_to_sigalg() that maps internal pk_type values to the public sigalg values used in profiles.

Fixes #10849
Fixes #10747

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** provided
- [] **framework PR** not required
- [] **TF-PSA-Crypto development PR** not required because: change is in mbedtls library only
- [] **TF-PSA-Crypto 1.1 PR** not required because: change is in mbedtls library only
- [x] **mbedtls development PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10936
- [ ] **mbedtls 4.1 PR** TODO
- [] **mbedtls 3.6 PR** not required because: different code structure in 3.6
- [ x] **tests** provided 