### PR TITLE
Backport 4.1: Restore __cplusplus guard absent from oid.h

### DIFF
--- a/include/mbedtls/oid.h
+++ b/include/mbedtls/oid.h
@@ -265,6 +265,10 @@
  *   ecdsa-with-SHA2(3) 4 } */
 #define MBEDTLS_OID_ECDSA_SHA512            MBEDTLS_OID_ANSI_X9_62_SIG_SHA2 "\x04"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if defined(MBEDTLS_X509_USE_C)
 /**
  * \brief           Translate an ASN.1 OID into its numeric representation
@@ -300,5 +304,9 @@ int mbedtls_oid_get_numeric_string(char *buf, size_t size, const mbedtls_asn1_bu
  */
 int mbedtls_oid_from_numeric_string(mbedtls_asn1_buf *oid, const char *oid_str, size_t size);
 #endif /* MBEDTLS_X509_CREATE_C */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* oid.h */


### PR DESCRIPTION
## Description

See #10927 

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** not required because of the fix being overly trivial to mention
- [x] **framework PR** - not applicable
- [x] **TF-PSA-Crypto development PR** - not applicable
- [x] **TF-PSA-Crypto 1.1 PR** - not applicable
- [x] **mbedtls development PR** provided in #10927 
- [x] **mbedtls 4.1 PR** provided **here**
- [x] **mbedtls 3.6 PR** not required because this issue did not exist in 3.x
- **tests**  not required because this is a preprocessor guard, not a feature
