### PR TITLE
3.6: Add CVE-2026-73096 ID in ChangeLog

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -41,7 +41,7 @@ Security
      unauthenticated plaintext data to be processed across a key change. In
      servers with MBEDTLS_SSL_EARLY_DATA enabled, this could be exploited by a
      man-in-the-middle attacker to cause loss of 0-RTT early data.
-     Reported by Ben Smyth.
+     Reported by Ben Smyth. CVE-2026-73096
    * Fix a possible buffer overflow in mbedtls_ecdh_calc_secret(): when the
      provided output buffer is too small, sometimes (depending on the value of
      the computed shared secret), the function would not return an error as it


### PR DESCRIPTION
## Description
backport of #10942

## PR checklist
- [x] **changelog** not required because: ChangeLog update
- [x] **framework PR** not required
- [x] **TF-PSA-Crypto development PR** not required because: TLS only
- [x] **TF-PSA-Crypto 1.1 PR** not required because: TLS only
- [x] **mbedtls development PR** provided #10942 
- [x] **mbedtls 4.1 PR** provided #10944 
- [x] **mbedtls 3.6 PR** provided here
- **tests**  not required because: ChangeLog update