### PR TITLE
4.1: Add CVE-2026-73096 ID in ChangeLog

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -30,7 +30,7 @@ Security
      unauthenticated plaintext data to be processed across a key change. In
      servers with MBEDTLS_SSL_EARLY_DATA enabled, this could be exploited by a
      man-in-the-middle attacker to cause loss of 0-RTT early data.
-     Reported by Ben Smyth.
+     Reported by Ben Smyth. CVE-2026-73096
    * Fix a remote buffer overflow in (D)TLS with ECDHE-PSK cipher suites when
      CBC is disabled. Reported by Karnakar Reddy. CVE-ID-50580
    * Fix a potential information disclosure in TLS 1.2 servers using session


### PR DESCRIPTION
## Description
backport of #10942

## PR checklist
- [x] **changelog** not required because: ChangeLog update
- [x] **framework PR** not required
- [x] **TF-PSA-Crypto development PR** not required because: TLS only
- [x] **TF-PSA-Crypto 1.1 PR** not required because: TLS only
- [x] **mbedtls development PR** provided #10942 
- [x] **mbedtls 4.1 PR** provided here
- [x] **mbedtls 3.6 PR** provided provide #10943
- **tests**  not required because: ChangeLog update
