### PR TITLE
Backport 3.6: Fix getrandom detection with musl libc

### DIFF
--- a/ChangeLog.d/musl_getrandom.txt
+++ b/ChangeLog.d/musl_getrandom.txt
@@ -1,0 +1,5 @@
+Features
+   * Use the getrandom() system call for PSA crypto initialization on Linux
+     when supported by the C library, including musl, uClibc and Android
+     bionic, avoiding unnecessary reliance on /dev/random on Linux 5.6 and
+     earlier.

--- a/library/entropy_poll.c
+++ b/library/entropy_poll.c
@@ -72,10 +72,16 @@ int mbedtls_platform_entropy_poll(void *data, unsigned char *output, size_t len,
 
 /*
  * Test for Linux getrandom() support.
- * Since there is no wrapper in the libc yet, use the generic syscall wrapper
- * available in GNU libc and compatible libc's (eg uClibc).
+ * Use the generic syscall wrapper when sys/syscall.h is available.
  */
-#if ((defined(__linux__) && defined(__GLIBC__)) || defined(__midipix__))
+#if defined(__linux__) && defined(__has_include)
+#if __has_include(<sys/syscall.h>)
+#define MBEDTLS_PLATFORM_HAS_SYS_SYSCALL_H
+#endif
+#endif
+
+#if defined(MBEDTLS_PLATFORM_HAS_SYS_SYSCALL_H) || \
+    (defined(__linux__) && defined(__GLIBC__)) || defined(__midipix__)
 #include <unistd.h>
 #include <sys/syscall.h>
 #if defined(SYS_getrandom)
@@ -93,7 +99,9 @@ static int getrandom_wrapper(void *buf, size_t buflen, unsigned int flags)
     return (int) syscall(SYS_getrandom, buf, buflen, flags);
 }
 #endif /* SYS_getrandom */
-#endif /* __linux__ || __midipix__ */
+#endif /* sys/syscall.h or a known generic syscall wrapper */
+
+#undef MBEDTLS_PLATFORM_HAS_SYS_SYSCALL_H
 
 #if defined(__FreeBSD__) || defined(__DragonFly__)
 #include <sys/param.h>


### PR DESCRIPTION
This is the 3.6 backport of Mbed-TLS/TF-PSA-Crypto#843.

This backport is presented as one commit containing the final approved
change. The code change is applied to
`library/entropy_poll.c`, where Mbed TLS 3.6 implements platform entropy
polling, instead of TF-PSA-Crypto's `platform/platform_util.c`. Only the
source path and surrounding patch context differ; the final detection
block and changelog entry match the approved development PR.

On Linux, this enables the existing getrandom syscall path when
`<sys/syscall.h>` is available and defines `SYS_getrandom`, including on
musl. The existing glibc/Midipix detection and runtime `ENOSYS` fallback
are preserved.

## Validation

- Linux x86_64 on workstation (Fedora 44, kernel 7.1.10, glibc 2.43,
  GCC 16.2.1): Debug build passed; CTest 140/140 passed.
- ARM EABI5 musl / GCC 12.4.0: full static Debug library build passed.
  Under qemu-arm 10.2.2, two consecutive processes completed PSA crypto
  initialization and generated 32 random bytes. Two further runs passed
  with the random-device fallback path set to a nonexistent file;
  syscall traces confirmed successful getrandom calls.
- The same four initialization/random-generation checks also passed
  natively with glibc, including the unavailable-device checks.
- dietlibc 0.34 / GCC 13.3.0 / Ubuntu 24.04: the modified source file
  compiled with `-std=c99 -Wall -Wextra -Werror`; preprocessing confirmed
  dietlibc headers and the existing fallback path, with no HAVE_GETRANDOM.
  This is source-compilation coverage, not a full dietlibc build or run.
- macOS arm64 / AppleClang 21.0.0: Debug build and 140/140 CTest passed.
- Additional Zig 0.16.0 cross-compilation and detection checks passed for
  ARM musl, AArch64 musl and x86_64 glibc.
- ChangeLog assembly and `git diff --check` passed.

Linux runtime tests above used kernel 7.1.10; the original blocking symptom
on older kernels was not reproduced here. uClibc-ng and Android bionic
were not retested on this backport; the original PR's earlier validation
is recorded in [the original validation comment](https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/843#issuecomment-5167057072).

## PR checklist

- [x] **changelog** provided in `ChangeLog.d/musl_getrandom.txt`.
- [x] **3.6 backport** this PR.
- [x] **TF-PSA-Crypto development PR** Mbed-TLS/TF-PSA-Crypto#843.
- [x] **TF-PSA-Crypto 1.1 PR** Mbed-TLS/TF-PSA-Crypto#893.
- **tests** existing test suites passed; no new committed test cases. Manual
  libc testing was accepted for the original PR.
