### PR TITLE
Fix a build error in the full config on some C23 platforms

### DIFF
--- a/tests/suites/test_suite_base64.function
+++ b/tests/suites/test_suite_base64.function
@@ -33,7 +33,7 @@ void enc_chars()
 /* BEGIN_CASE depends_on:MBEDTLS_TEST_HOOKS */
 void dec_chars()
 {
-    char *p;
+    const char *p;
     signed char expected;
 
     for (unsigned c = 0; c <= 0xff; c++) {


### PR DESCRIPTION
Fix https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/876

## PR checklist

- [x] **changelog** no because this only affects configurations with `MBEDTLS_TEST_HOOKS` enabled
- [x] **framework PR** not required
- [ ] **TF-PSA-Crypto development PR** TODO
- [ ] **TF-PSA-Crypto 1.1 PR** TODO
- [x] **mbedtls development PR** not required because: crypto only
- [x] **mbedtls 4.1 PR** not required because: crypto only
- [ ] **mbedtls 3.6 PR** provided here
- **tests**  test manually under Ubuntu 26.04 in a build with `-O -std=c23`
